### PR TITLE
feat: Disconnect on hide

### DIFF
--- a/packages/reflect/src/client/document-visible.test.ts
+++ b/packages/reflect/src/client/document-visible.test.ts
@@ -1,0 +1,122 @@
+import {expect} from '@esm-bundle/chai';
+import * as sinon from 'sinon';
+import {LogContext} from '@rocicorp/logger';
+import {waitForHidden, waitForVisible} from './document-visible.js';
+
+let clock: sinon.SinonFakeTimers;
+
+setup(() => {
+  clock = sinon.useFakeTimers();
+});
+
+teardown(() => {
+  sinon.restore();
+});
+
+class Document extends EventTarget {
+  #visibilityState: DocumentVisibilityState = 'visible';
+  set visibilityState(v) {
+    if (this.#visibilityState === v) {
+      return;
+    }
+    this.#visibilityState = v;
+    this.dispatchEvent(new Event('visibilitychange'));
+  }
+  get visibilityState() {
+    return this.#visibilityState;
+  }
+}
+
+test('waitForVisible', async () => {
+  const doc = new Document();
+  doc.visibilityState = 'hidden';
+
+  const p = waitForVisible(new LogContext(), doc);
+  doc.visibilityState = 'visible';
+  await p;
+});
+
+test('waitForHidden', async () => {
+  const doc = new Document();
+  doc.visibilityState = 'visible';
+
+  let resolved = false;
+  const p = waitForHidden(new LogContext(), doc, 1000).then(() => {
+    resolved = true;
+  });
+  doc.visibilityState = 'hidden';
+  expect(resolved).false;
+  await clock.tickAsync(1000);
+  expect(resolved).true;
+  await p;
+});
+
+test('waitForHidden flip back to visible', async () => {
+  const doc = new Document();
+  doc.visibilityState = 'visible';
+
+  let resolved = false;
+  void waitForHidden(new LogContext(), doc, 1000).then(() => {
+    resolved = true;
+  });
+
+  doc.visibilityState = 'hidden';
+  expect(resolved).false;
+  await clock.tickAsync(500);
+  expect(resolved).false;
+
+  // Flip back to visible.
+  doc.visibilityState = 'visible';
+  expect(resolved).false;
+
+  // And wait a bit more.
+  await clock.tickAsync(50_000);
+  expect(resolved).false;
+});
+
+test('waitForHidden flip back and forth', async () => {
+  const doc = new Document();
+  doc.visibilityState = 'visible';
+
+  let resolved = false;
+  const p = waitForHidden(new LogContext(), doc, 1000).then(() => {
+    resolved = true;
+  });
+
+  doc.visibilityState = 'hidden';
+  expect(resolved).false;
+  await clock.tickAsync(500);
+  expect(resolved).false;
+
+  // Flip back to visible.
+  doc.visibilityState = 'visible';
+  expect(resolved).false;
+  await clock.tickAsync(500);
+  expect(resolved).false;
+
+  doc.visibilityState = 'hidden';
+  await clock.tickAsync(500);
+  expect(resolved).false;
+  await clock.tickAsync(500);
+  expect(resolved).true;
+
+  await p;
+});
+
+test('waitForVisible no document', async () => {
+  await waitForVisible(new LogContext(), undefined);
+  // resolves "immediately"
+});
+
+test('waitForHidden no document', async () => {
+  let resolved = false;
+  void waitForHidden(new LogContext(), undefined, 1000).then(() => {
+    resolved = true;
+  });
+  expect(resolved).false;
+  await clock.tickAsync(1000);
+  expect(resolved).false;
+
+  await clock.tickAsync(100_000);
+  expect(resolved).false;
+});

--- a/packages/reflect/src/client/document-visible.ts
+++ b/packages/reflect/src/client/document-visible.ts
@@ -1,0 +1,73 @@
+import type {LogContext} from '@rocicorp/logger';
+
+type PartialDocument = Pick<
+  Document,
+  'visibilityState' | 'addEventListener' | 'removeEventListener'
+>;
+
+/**
+ * @returns A promise that resolves when the document becomes visible.
+ * If the document is already visible the promise resolves immediately.
+ */
+export function waitForVisible(
+  lc: LogContext,
+  doc: PartialDocument | undefined,
+): Promise<void> {
+  // No document in service worker etc. Treat context as always visible.
+  if (!doc || doc.visibilityState === 'visible') {
+    lc.debug?.(
+      doc
+        ? 'Context already visible'
+        : 'No document. Treating context as always visible',
+    );
+    return Promise.resolve();
+  }
+
+  lc.debug?.('Waiting for context to become visible');
+  return new Promise(resolve => {
+    const listener = () => {
+      if (doc.visibilityState === 'visible') {
+        doc.removeEventListener('visibilitychange', listener);
+        resolve();
+      }
+    };
+    doc.addEventListener('visibilitychange', listener);
+  });
+}
+
+/**
+ * @param lc The log context to use.
+ * @param ms The number of milliseconds to wait after the document becomes
+ * hidden before resolving the promise.
+ * @returns A promise that resolves when the document becomes hidden and stays hidden
+ * for at least `ms` milliseconds.
+ */
+export function waitForHidden(
+  lc: LogContext,
+  doc: PartialDocument | undefined,
+  ms: number,
+): Promise<void> {
+  if (!doc) {
+    lc.debug?.(
+      'No document. Treating context as always visible and never resolve this promise',
+    );
+    // This promise will never resolve.
+    return new Promise(() => undefined);
+  }
+
+  return new Promise(resolve => {
+    let id: ReturnType<typeof setTimeout> | undefined;
+    const listener = () => {
+      if (doc.visibilityState === 'hidden') {
+        id = setTimeout(() => {
+          doc.removeEventListener('visibilitychange', listener);
+          resolve();
+        }, ms);
+      } else {
+        clearTimeout(id);
+      }
+    };
+    doc.addEventListener('visibilitychange', listener);
+    listener();
+  });
+}

--- a/packages/reflect/src/client/reflect.ts
+++ b/packages/reflect/src/client/reflect.ts
@@ -35,6 +35,7 @@ import {send} from '../util/socket.js';
 import type {ConnectedMessage} from '../protocol/connected.js';
 import {ErrorKind, type ErrorMessage} from '../protocol/error.js';
 import {MessageError, isAuthError} from './connection-error.js';
+import {waitForVisible, waitForHidden} from './document-visible.js';
 
 export const enum ConnectionState {
   Disconnected,
@@ -52,7 +53,7 @@ export const enum CloseKind {
   Unknown = 'Unknown',
 }
 
-export type DisconnectReason = ErrorKind | CloseKind;
+export type DisconnectReason = ErrorKind | CloseKind | 'Hidden';
 
 /**
  * How frequently we should ping the server to keep the connection alive.
@@ -63,6 +64,11 @@ export const PING_INTERVAL_MS = 5_000;
  * The amount of time we wait for a pong before we consider the ping timed out.
  */
 export const PING_TIMEOUT_MS = 2_000;
+
+/**
+ * The amount of time to wait before we consider a tab hidden.
+ */
+export const HIDDEN_INTERVAL_MS = 5_000;
 
 /**
  * The amount of time we wait for a connection to be established before we
@@ -109,6 +115,8 @@ export class Reflect<MD extends MutatorDefs> {
   #connectionStateChangeResolver = resolver<ConnectionState>();
 
   #nextMessageResolver: Resolver<Downstream> | undefined = undefined;
+
+  #waitForHidden: Promise<void> | undefined = undefined;
 
   // We use an accessor pair to allow the subclass to override the setter.
   #connectionState: ConnectionState = ConnectionState.Disconnected;
@@ -656,6 +664,15 @@ export class Reflect<MD extends MutatorDefs> {
       try {
         switch (this._connectionState) {
           case ConnectionState.Disconnected: {
+            // If hidden, we wait for the tab to become visible before trying again.
+            await waitForVisible(lc, getDocument());
+            // Start listening to visibilityState hidden.
+            this.#waitForHidden = waitForHidden(
+              lc,
+              getDocument(),
+              HIDDEN_INTERVAL_MS,
+            );
+
             // If we got an auth error we try to get a new auth token before reconnecting.
             if (needsReauth) {
               await this.#updateAuthToken(lc);
@@ -689,17 +706,24 @@ export class Reflect<MD extends MutatorDefs> {
             // - After PING_INTERVAL_MS we send a ping
             // - We get disconnected
             // - We get a message
+            // - The tab becomes hidden (with a delay)
+
             const pingTimeoutPromise = sleep(PING_INTERVAL_MS);
 
             this.#nextMessageResolver = resolver();
 
-            let pingTimerFired = false;
-            await Promise.race([
-              pingTimeoutPromise.then(() => {
-                pingTimerFired = true;
-              }),
+            const enum RaceCases {
+              Ping = 0,
+              Hidden = 3,
+            }
+
+            assert(this.#waitForHidden);
+
+            const raceResult = await promiseRace([
+              pingTimeoutPromise,
               this.#connectionStateChangeResolver.promise,
               this.#nextMessageResolver.promise,
+              this.#waitForHidden,
             ]);
 
             this.#nextMessageResolver = undefined;
@@ -708,8 +732,13 @@ export class Reflect<MD extends MutatorDefs> {
               break;
             }
 
-            if (pingTimerFired) {
-              await this._ping(lc);
+            switch (raceResult) {
+              case RaceCases.Ping:
+                await this._ping(lc);
+                break;
+              case RaceCases.Hidden:
+                this._disconnect(lc, 'Hidden');
+                break;
             }
           }
         }
@@ -791,10 +820,8 @@ export class Reflect<MD extends MutatorDefs> {
     assert(this._socket);
     send(this._socket, pingMessage);
 
-    const connected = await Promise.race([
-      promise.then(() => true),
-      sleep(PING_TIMEOUT_MS).then(() => false),
-    ]);
+    const connected =
+      (await promiseRace([promise, sleep(PING_TIMEOUT_MS)])) === 0;
     if (this._connectionState !== ConnectionState.Connected) {
       return;
     }
@@ -888,4 +915,20 @@ class CloseError extends Error {
     super(`socket closed (${closeKind})`);
     this.kind = closeKind;
   }
+}
+
+/**
+ * Returns the document object. This is wrapped in a function because Reflect
+ * runs in environments that do not have a document (such as Web Workers, Deno
+ * etc)
+ */
+function getDocument(): Document | undefined {
+  return typeof document !== 'undefined' ? document : undefined;
+}
+
+/**
+ * Like Promise.race but returns the index of the first promise that resolved.
+ */
+function promiseRace(ps: Promise<unknown>[]): Promise<number> {
+  return Promise.race(ps.map((p, i) => p.then(() => i)));
 }


### PR DESCRIPTION
When the `visibilityState` of the document change to `hidden` and the document stays hidden for more than 5 seconds, the client will disconnect from the server.

Fixes https://github.com/rocicorp/mono/issues/180