### PR TITLE
chore: Cancel in progress workflows

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
 jobs:
   format:
     name: ESLint & Prettier

--- a/.github/workflows/perf-smoke.yml
+++ b/.github/workflows/perf-smoke.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches: [main]
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
 jobs:
   benchmark-smoke:
     name: Performance runner smoke test


### PR DESCRIPTION
This changes the GH actions to cancel in progress workflows when a new commit is pushed to the branch. This is useful when a PR is updated frequently, as it will prevent the queue from growing.