### PR TITLE
fix: deleteAllReplicacheData should default to IDB

### DIFF
--- a/packages/replicache/src/kv/mod.ts
+++ b/packages/replicache/src/kv/mod.ts
@@ -2,3 +2,4 @@ export type {Read, Store, Write, CreateStore} from './store.js';
 export {IDBStore, IDBNotFoundError} from './idb-store.js';
 export {dropStore as dropIDBStore} from './idb-util.js';
 export {MemStore} from './mem-store.js';
+export {newIDBStoreWithMemFallback} from './idb-store-with-mem-fallback.js';

--- a/packages/replicache/src/persist/collect-idb-databases.ts
+++ b/packages/replicache/src/persist/collect-idb-databases.ts
@@ -5,7 +5,7 @@ import {dropStore} from '../kv/idb-util.js';
 import {IDBDatabasesStore} from './idb-databases-store.js';
 import type {IndexedDBDatabase} from './idb-databases-store.js';
 import {initBgIntervalProcess} from '../bg-interval.js';
-import type {LogContext} from '@rocicorp/logger';
+import {LogContext} from '@rocicorp/logger';
 import {
   REPLICACHE_FORMAT_VERSION,
   REPLICACHE_FORMAT_VERSION_DD31,
@@ -194,7 +194,8 @@ function allClientsOlderThan(
  * and any errors encountered while dropping.
  */
 export async function deleteAllReplicacheData(
-  createKVStore: kv.CreateStore,
+  createKVStore: kv.CreateStore = name =>
+    kv.newIDBStoreWithMemFallback(new LogContext(), name),
 ): Promise<{
   dropped: string[];
   errors: unknown[];


### PR DESCRIPTION
v12.2.0 introduced a bug where deleteAllReplicacheData got a required argument for the createStore parameter. This is a breaking change and we should not have done it. This change makes the argument optional and defaults to IDB.

Fixes #357