### PR TITLE
feat(60fps): server buffering

### DIFF
--- a/packages/reflect-server/src/ff/fast-forward.test.ts
+++ b/packages/reflect-server/src/ff/fast-forward.test.ts
@@ -18,7 +18,6 @@ test('fastForward', async () => {
     state: Map<string, UserValue>;
     clientRecords: ClientRecordMap;
     clients: ClientID[];
-    timestamp: number;
     expectedError?: string;
     expectedPokes?: ClientPoke[];
   };
@@ -41,7 +40,6 @@ test('fastForward', async () => {
         ],
       ]),
       clients: [],
-      timestamp: 1,
       expectedPokes: [],
     },
     {
@@ -59,7 +57,6 @@ test('fastForward', async () => {
         ],
       ]),
       clients: ['c1'],
-      timestamp: 1,
       expectedPokes: [
         {
           clientID: 'c1',
@@ -68,7 +65,7 @@ test('fastForward', async () => {
             cookie: CURRENT_VERSION_FOR_TEST,
             lastMutationIDChanges: {c1: 1},
             patch: [],
-            timestamp: 1,
+            timestamp: undefined,
           },
         },
       ],
@@ -88,7 +85,6 @@ test('fastForward', async () => {
         ],
       ]),
       clients: ['c1'],
-      timestamp: 1,
       expectedPokes: [],
     },
     {
@@ -115,7 +111,6 @@ test('fastForward', async () => {
         ],
       ]),
       clients: ['c1'],
-      timestamp: 1,
       expectedPokes: [
         {
           clientID: 'c1',
@@ -134,7 +129,7 @@ test('fastForward', async () => {
                 key: 'hot',
               },
             ],
-            timestamp: 1,
+            timestamp: undefined,
           },
         },
       ],
@@ -169,7 +164,6 @@ test('fastForward', async () => {
         ],
       ]),
       clients: ['c1', 'c2'],
-      timestamp: 1,
       expectedPokes: [
         {
           clientID: 'c1',
@@ -188,7 +182,7 @@ test('fastForward', async () => {
                 key: 'hot',
               },
             ],
-            timestamp: 1,
+            timestamp: undefined,
           },
         },
         {
@@ -203,7 +197,7 @@ test('fastForward', async () => {
                 key: 'hot',
               },
             ],
-            timestamp: 1,
+            timestamp: undefined,
           },
         },
       ],
@@ -238,7 +232,6 @@ test('fastForward', async () => {
         ],
       ]),
       clients: ['c1'],
-      timestamp: 1,
       expectedPokes: [
         {
           clientID: 'c1',
@@ -257,7 +250,7 @@ test('fastForward', async () => {
                 key: 'hot',
               },
             ],
-            timestamp: 1,
+            timestamp: undefined,
           },
         },
       ],
@@ -313,7 +306,6 @@ test('fastForward', async () => {
         ],
       ]),
       clients: ['c1', 'c2', 'c3', 'c4', 'c5'],
-      timestamp: 1,
       expectedPokes: [
         {
           clientID: 'c1',
@@ -322,7 +314,7 @@ test('fastForward', async () => {
             cookie: CURRENT_VERSION_FOR_TEST,
             lastMutationIDChanges: {c1: 2, c2: 3, c3: 4},
             patch: [],
-            timestamp: 1,
+            timestamp: undefined,
           },
         },
         {
@@ -332,7 +324,7 @@ test('fastForward', async () => {
             cookie: CURRENT_VERSION_FOR_TEST,
             lastMutationIDChanges: {c1: 2, c2: 3, c3: 4},
             patch: [],
-            timestamp: 1,
+            timestamp: undefined,
           },
         },
         {
@@ -342,7 +334,7 @@ test('fastForward', async () => {
             cookie: CURRENT_VERSION_FOR_TEST,
             lastMutationIDChanges: {c1: 2},
             patch: [],
-            timestamp: 1,
+            timestamp: undefined,
           },
         },
         {
@@ -352,7 +344,7 @@ test('fastForward', async () => {
             cookie: CURRENT_VERSION_FOR_TEST,
             lastMutationIDChanges: {c4: 5, c5: 6},
             patch: [],
-            timestamp: 1,
+            timestamp: undefined,
           },
         },
         {
@@ -362,7 +354,7 @@ test('fastForward', async () => {
             cookie: CURRENT_VERSION_FOR_TEST,
             lastMutationIDChanges: {},
             patch: [],
-            timestamp: 1,
+            timestamp: undefined,
           },
         },
       ],
@@ -415,7 +407,6 @@ test('fastForward', async () => {
         ],
       ]),
       clients: ['c1', 'c2', 'c3', 'c4'],
-      timestamp: 1,
       expectedPokes: [
         {
           clientID: 'c1',
@@ -434,7 +425,7 @@ test('fastForward', async () => {
                 key: 'hot',
               },
             ],
-            timestamp: 1,
+            timestamp: undefined,
           },
         },
         {
@@ -449,7 +440,7 @@ test('fastForward', async () => {
                 key: 'hot',
               },
             ],
-            timestamp: 1,
+            timestamp: undefined,
           },
         },
         {
@@ -469,7 +460,7 @@ test('fastForward', async () => {
                 key: 'hot',
               },
             ],
-            timestamp: 1,
+            timestamp: undefined,
           },
         },
         {
@@ -484,7 +475,7 @@ test('fastForward', async () => {
                 key: 'hot',
               },
             ],
-            timestamp: 1,
+            timestamp: undefined,
           },
         },
       ],
@@ -503,7 +494,7 @@ test('fastForward', async () => {
       await putUserValue(key, value, storage);
     }
 
-    const pokes = await fastForwardRoom(c.clients, 42, storage, c.timestamp);
+    const pokes = await fastForwardRoom(c.clients, 42, storage);
 
     expect(pokes).toEqual(c.expectedPokes);
   }

--- a/packages/reflect-server/src/ff/fast-forward.ts
+++ b/packages/reflect-server/src/ff/fast-forward.ts
@@ -13,13 +13,11 @@ import {getPatch} from './get-patch.js';
  * @param clients clients active in room
  * @param currentVersion head version to fast-forward to
  * @param durable storage to read/write to
- * @param timestamp for resulting pokes
  */
 export async function fastForwardRoom(
   clients: ClientID[],
   currentVersion: Version,
   storage: DurableStorage,
-  timestamp: number,
 ): Promise<ClientPoke[]> {
   const clientRecords = await listClientRecords(storage);
   // Get all of the distinct base cookies. Typically almost all active clients
@@ -92,7 +90,8 @@ export async function fastForwardRoom(
           .get(clientGroupID)
           ?.get(record.baseCookie) ?? {},
       patch,
-      timestamp,
+      // apply immediately
+      timestamp: undefined,
     };
     const clientPoke: ClientPoke = {
       clientID,

--- a/packages/reflect-server/src/process/process-pending.ts
+++ b/packages/reflect-server/src/process/process-pending.ts
@@ -11,8 +11,12 @@ import {send} from '../util/socket.js';
 import type {PendingMutation} from '../types/mutation.js';
 import {randomID} from '../util/rand.js';
 
+// TODO: make buffer dynamic
+const PENDING_ORDER_BUFFER_MS = 200;
+
 /**
- * Processes all mutations in all rooms for a time range, and send relevant pokes.
+ * Processes all mutations in all rooms for a time range, and send relevant
+ * pokes.
  * @param clients Rooms to process mutations for
  * @param mutators All known mutators
  */
@@ -23,27 +27,58 @@ export async function processPending(
   pendingMutations: PendingMutation[],
   mutators: MutatorMap,
   disconnectHandler: DisconnectHandler,
-  timestamp: number,
-): Promise<void> {
+  maxProcessedMutationTimestamp: number,
+): Promise<number> {
   lc.debug?.('process pending');
 
   const t0 = Date.now();
+  const tooNewIndex = pendingMutations.findIndex(
+    pendingM =>
+      pendingM.timestamp !== undefined &&
+      pendingM.timestamp > t0 - PENDING_ORDER_BUFFER_MS,
+  );
+  const endIndex = tooNewIndex !== -1 ? tooNewIndex : pendingMutations.length;
+  const toProcess = pendingMutations.slice(0, endIndex);
+  const forcedMissCount =
+    maxProcessedMutationTimestamp === undefined
+      ? 0
+      : toProcess.reduce(
+          (sum, pendingM) =>
+            sum +
+            (pendingM.timestamp !== undefined &&
+            pendingM.timestamp < maxProcessedMutationTimestamp
+              ? 1
+              : 0),
+          0,
+        );
+  lc.debug?.(
+    'processing',
+    toProcess.length,
+    'of',
+    pendingMutations.length,
+    'pending mutations with',
+    forcedMissCount,
+    'forced misses',
+  );
   try {
     const pokes = await processRoom(
       lc,
       clients,
-      pendingMutations,
+      toProcess,
       mutators,
       disconnectHandler,
       storage,
-      timestamp,
     );
     sendPokes(lc, pokes, clients);
     lc.debug?.('clearing pending mutations');
-    pendingMutations.length = 0;
+    pendingMutations.splice(0, endIndex);
   } finally {
     lc.debug?.(`processPending took ${Date.now() - t0} ms`);
   }
+  return toProcess.reduce<number>(
+    (max, processed) => Math.max(max, processed.timestamp ?? max),
+    maxProcessedMutationTimestamp,
+  );
 }
 
 function sendPokes(

--- a/packages/reflect-server/src/process/process-room.test.ts
+++ b/packages/reflect-server/src/process/process-room.test.ts
@@ -334,8 +334,6 @@ describe('processRoom', () => {
     expectedVersion: Version;
   };
 
-  const startTime = 100;
-
   const cases: Case[] = [
     {
       name: 'no client record',
@@ -369,7 +367,7 @@ describe('processRoom', () => {
             cookie: 2,
             lastMutationIDChanges: {c1: 1, c2: 1},
             patch: [],
-            timestamp: 100,
+            timestamp: undefined,
           },
         },
         {
@@ -379,7 +377,7 @@ describe('processRoom', () => {
             cookie: 2,
             lastMutationIDChanges: {c1: 1, c2: 1},
             patch: [],
-            timestamp: 100,
+            timestamp: undefined,
           },
         },
         {
@@ -389,7 +387,7 @@ describe('processRoom', () => {
             cookie: 2,
             lastMutationIDChanges: {c3: 1},
             patch: [],
-            timestamp: 100,
+            timestamp: undefined,
           },
         },
       ],
@@ -423,7 +421,7 @@ describe('processRoom', () => {
             cookie: 2,
             lastMutationIDChanges: {c1: 1, c2: 1},
             patch: [],
-            timestamp: 100,
+            timestamp: undefined,
           },
         },
       ],
@@ -584,7 +582,7 @@ describe('processRoom', () => {
               c2: 1,
             },
             patch: [],
-            timestamp: 100,
+            timestamp: undefined,
           },
         },
         {
@@ -596,7 +594,7 @@ describe('processRoom', () => {
               c3: 4,
             },
             patch: [],
-            timestamp: 100,
+            timestamp: undefined,
           },
         },
         ...expectedPokesForPendingMutations1,
@@ -639,7 +637,6 @@ describe('processRoom', () => {
         mutators,
         () => Promise.resolve(),
         storage,
-        startTime,
       );
       if (c.expectedError) {
         try {

--- a/packages/reflect-server/src/process/process-room.ts
+++ b/packages/reflect-server/src/process/process-room.ts
@@ -31,7 +31,6 @@ export async function processRoom(
   mutators: MutatorMap,
   disconnectHandler: DisconnectHandler,
   storage: DurableStorage,
-  timestamp: number,
 ): Promise<ClientPoke[]> {
   const cache = new EntryCache(storage);
   const clientIDs = [...clients.keys()];
@@ -55,7 +54,6 @@ export async function processRoom(
     clientIDs,
     currentVersion,
     storage,
-    timestamp,
   );
   lc.debug?.('pokes from fastforward', JSON.stringify(clientPokes));
 

--- a/packages/reflect-server/src/server/room-do.ts
+++ b/packages/reflect-server/src/server/room-do.ts
@@ -73,6 +73,7 @@ export const ROOM_ROUTES = {
 export class BaseRoomDO<MD extends MutatorDefs> implements DurableObject {
   private readonly _clients: ClientMap = new Map();
   private readonly _pendingMutations: PendingMutation[] = [];
+  private _maxProcessedMutationTimestamp = 0;
   private readonly _lock = new Lock();
   private readonly _mutators: MutatorMap;
   private readonly _disconnectHandler: DisconnectHandler;
@@ -410,14 +411,14 @@ export class BaseRoomDO<MD extends MutatorDefs> implements DurableObject {
         return;
       }
 
-      await processPending(
+      this._maxProcessedMutationTimestamp = await processPending(
         lc,
         this._storage,
         this._clients,
         this._pendingMutations,
         this._mutators,
         this._disconnectHandler,
-        Date.now(),
+        this._maxProcessedMutationTimestamp,
       );
     });
   }


### PR DESCRIPTION
Currently a static buffer of 200ms, will make dynamic in a follow up.

The purpose of the server buffer is to avoid the server applying mutations from different clients in an order which prevents them from being played back with correct spacing.  

Towards https://github.com/rocicorp/mono/issues/243

See design at https://www.notion.so/replicache/60-FPS-Playback-with-Output-Gate-and-Better-Cloudflare-clocks-68765042bdad4995b61838e4cb80177b