### PR TITLE
chore: Move config to shared

### DIFF
--- a/packages/reflect-protocol/src/json.ts
+++ b/packages/reflect-protocol/src/json.ts
@@ -1,4 +1,5 @@
 import * as valita from '@badrap/valita';
+import {skipAssertJSONValue} from 'shared/config.js';
 import type {ReadonlyJSONValue} from 'shared/json.js';
 import {isJSONValue} from 'shared/json.js';
 import * as v from 'shared/valita.js';
@@ -8,6 +9,9 @@ const path: (string | number)[] = [];
 export const jsonSchema: valita.Type<ReadonlyJSONValue> = v
   .unknown()
   .chain(v => {
+    if (skipAssertJSONValue) {
+      return valita.ok(v as ReadonlyJSONValue);
+    }
     const rv = isJSONValue(v, path)
       ? valita.ok(v)
       : valita.err({

--- a/packages/replicache/src/config.ts
+++ b/packages/replicache/src/config.ts
@@ -1,15 +1,7 @@
-declare const process: {
-  env: {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    NODE_ENV?: string;
-  };
-};
-
-const isProd = process.env.NODE_ENV === 'production';
+import {isProd} from 'shared/config.js';
 
 export {
   isProd as skipCommitDataAsserts,
-  isProd as skipAssertJSONValue,
   isProd as skipBTreeNodeAsserts,
   isProd as skipGCAsserts,
 

--- a/packages/replicache/src/json.ts
+++ b/packages/replicache/src/json.ts
@@ -1,19 +1,12 @@
-import type {JSONValue, ReadonlyJSONValue} from 'shared/json.js';
+import {skipAssertJSONValue} from 'shared/config.js';
+import type {ReadonlyJSONValue} from 'shared/json.js';
+import {skipFreeze, skipFrozenAsserts} from './config.js';
+import type {Cookie, FrozenCookie} from './cookies.js';
 import type {FrozenJSONValue} from './frozen-json.js';
-import * as json from 'shared/json.js';
 import * as frozenJSON from './frozen-json.js';
-import {skipAssertJSONValue, skipFreeze, skipFrozenAsserts} from './config.js';
-import type {FrozenCookie, Cookie} from './cookies.js';
 
 export * from 'shared/json.js';
 export * from './frozen-json.js';
-
-export function assertJSONValue(v: unknown): asserts v is JSONValue {
-  if (skipAssertJSONValue) {
-    return;
-  }
-  return json.assertJSONValue(v);
-}
 
 export function assertFrozenJSONValue(
   v: unknown,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -47,6 +47,10 @@
     "./deep-clone.js": {
       "import": "./src/deep-clone.ts",
       "types": "./src/deep-clone.ts"
+    },
+    "./config.js": {
+      "import": "./src/config.ts",
+      "types": "./src/config.ts"
     }
   },
   "eslintConfig": {

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -1,0 +1,10 @@
+declare const process: {
+  env: {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    NODE_ENV?: string;
+  };
+};
+
+export const isProd = process.env.NODE_ENV === 'production';
+
+export {isProd as skipAssertJSONValue};

--- a/packages/shared/src/json.ts
+++ b/packages/shared/src/json.ts
@@ -1,4 +1,5 @@
 import {assertObject, throwInvalidType} from './asserts.js';
+import {skipAssertJSONValue} from './config.js';
 import {hasOwn} from './has-own.js';
 
 /** The values that can be represented in JSON */
@@ -116,6 +117,9 @@ export function deepEqual(
 }
 
 export function assertJSONValue(v: unknown): asserts v is JSONValue {
+  if (skipAssertJSONValue) {
+    return;
+  }
   switch (typeof v) {
     case 'boolean':
     case 'number':


### PR DESCRIPTION
This allows skipping the "asserts" of JSON in reflect and reflect-server too.