### PR TITLE
fix: Fixes issues with connection loop

### DIFF
--- a/packages/reflect/src/client/reflect.test.ts
+++ b/packages/reflect/src/client/reflect.test.ts
@@ -13,27 +13,28 @@ import {
 } from 'replicache';
 import * as valita from 'shared/valita.js';
 import * as sinon from 'sinon';
+import {REPORT_INTERVAL_MS} from './metrics.js';
 import {
-  ConnectionState,
   CONNECT_TIMEOUT_MS,
-  createSocket,
+  ConnectionState,
   HIDDEN_INTERVAL_MS,
   PING_INTERVAL_MS,
   PING_TIMEOUT_MS,
   PULL_TIMEOUT_MS,
   RUN_LOOP_INTERVAL_MS,
+  createSocket,
   serverAheadReloadReason,
 } from './reflect.js';
-import {
-  MockSocket,
-  reflectForTest,
-  TestLogSink,
-  TestReflect,
-  tickAFewTimes,
-} from './test-utils.js'; // Why use fakes when we can use the real thing!
-import {REPORT_INTERVAL_MS} from './metrics.js';
 import {RELOAD_REASON_STORAGE_KEY} from './reload-error-handler.js';
 import {ServerError} from './server-error.js';
+import {
+  MockSocket,
+  TestLogSink,
+  TestReflect,
+  reflectForTest,
+  tickAFewTimes,
+  waitForUpstreamMessage,
+} from './test-utils.js'; // Why use fakes when we can use the real thing!
 
 let clock: sinon.SinonFakeTimers;
 const startTime = 1678829450000;
@@ -1168,42 +1169,65 @@ test('server ahead', async () => {
   );
 });
 
-test('Disconnect on hide', async () => {
-  let visibilityState = 'visible';
-  sinon.stub(document, 'visibilityState').get(() => visibilityState);
+suite('Disconnect on hide', () => {
+  type Case = {
+    name: string;
+    duringPing: boolean;
+  };
 
-  const r = reflectForTest();
-  await r.triggerConnected();
-  expect(r.connectionState).to.equal(ConnectionState.Connected);
+  const cases: Case[] = [
+    {name: 'no ping', duringPing: false},
+    {name: 'during ping', duringPing: true},
+  ];
 
-  visibilityState = 'hidden';
-  document.dispatchEvent(new Event('visibilitychange'));
-  expect(r.connectionState).to.equal(ConnectionState.Connected);
+  for (const c of cases) {
+    test(c.name, async () => {
+      let visibilityState = 'visible';
+      sinon.stub(document, 'visibilityState').get(() => visibilityState);
 
-  let sleep = HIDDEN_INTERVAL_MS;
-  if (PING_INTERVAL_MS < HIDDEN_INTERVAL_MS) {
-    // We need a ping before PING_INTERVAL_MS to not get disconnected.
-    await clock.tickAsync(PING_INTERVAL_MS - 10);
-    await r.triggerPong();
-    sleep = HIDDEN_INTERVAL_MS - PING_INTERVAL_MS + 10;
+      const r = reflectForTest();
+      await r.triggerConnected();
+      expect(r.connectionState).to.equal(ConnectionState.Connected);
+
+      if (c.duringPing) {
+        await waitForUpstreamMessage(r, 'ping', clock);
+      }
+
+      visibilityState = 'hidden';
+      document.dispatchEvent(new Event('visibilitychange'));
+
+      if (c.duringPing) {
+        await r.triggerPong();
+      }
+
+      expect(r.connectionState).to.equal(ConnectionState.Connected);
+
+      let sleep = HIDDEN_INTERVAL_MS;
+      if (PING_INTERVAL_MS < HIDDEN_INTERVAL_MS) {
+        // We need a ping before PING_INTERVAL_MS to not get disconnected.
+        await clock.tickAsync(PING_INTERVAL_MS - 10);
+        await r.triggerPong();
+        sleep = HIDDEN_INTERVAL_MS - PING_INTERVAL_MS + 10;
+      }
+      await clock.tickAsync(sleep);
+
+      expect(r.connectionState).to.equal(ConnectionState.Disconnected);
+
+      // Stays disconnected as long as we are hidden.
+      while (Date.now() < 100_000) {
+        await clock.tickAsync(1_000);
+        expect(r.connectionState).to.equal(ConnectionState.Disconnected);
+        expect(document.visibilityState).to.equal('hidden');
+      }
+
+      visibilityState = 'visible';
+      document.dispatchEvent(new Event('visibilitychange'));
+
+      await r.waitForConnectionState(ConnectionState.Connecting);
+      await r.triggerConnected();
+      expect(r.connectionState).to.equal(ConnectionState.Connected);
+    });
   }
-  await clock.tickAsync(sleep);
-
-  expect(r.connectionState).to.equal(ConnectionState.Disconnected);
-
-  // Stays disconnected as long as we are hidden.
-  while (Date.now() < 100_000) {
-    await clock.tickAsync(1_000);
-    expect(r.connectionState).to.equal(ConnectionState.Disconnected);
-    expect(document.visibilityState).to.equal('hidden');
-  }
-
-  visibilityState = 'visible';
-  document.dispatchEvent(new Event('visibilitychange'));
-
-  await r.waitForConnectionState(ConnectionState.Connecting);
-  await r.triggerConnected();
-  expect(r.connectionState).to.equal(ConnectionState.Connected);
 });
 
 test('InvalidConnectionRequest', async () => {
@@ -1230,37 +1254,61 @@ test('InvalidConnectionRequest', async () => {
   });
 });
 
-test('Invalid Downstream message', async () => {
-  const testLogSink = new TestLogSink();
-  const r = reflectForTest({
-    logSinks: [testLogSink],
-    logLevel: 'debug',
-  });
-  await r.triggerConnected();
-  expect(r.connectionState).to.equal(ConnectionState.Connected);
+suite('Invalid Downstream message', () => {
+  type Case = {
+    name: string;
+    duringPing: boolean;
+  };
 
-  await r.triggerPoke({
-    pokes: [
-      {
-        baseCookie: null,
-        cookie: 1,
-        lastMutationIDChanges: {c1: 1},
-        // @ts-expect-error - invalid field
-        patch: [{op: 'put', key: 'k1', valueXXX: 'v1'}],
-        timestamp: 123456,
-      },
-    ],
-    requestID: 'test-request-id-poke',
-  });
+  const cases: Case[] = [
+    {name: 'no ping', duringPing: false},
+    {name: 'during ping', duringPing: true},
+  ];
 
-  await clock.tickAsync(0);
+  for (const c of cases) {
+    test(c.name, async () => {
+      const testLogSink = new TestLogSink();
+      const r = reflectForTest({
+        logSinks: [testLogSink],
+        logLevel: 'debug',
+      });
+      await r.triggerConnected();
+      expect(r.connectionState).to.equal(ConnectionState.Connected);
 
-  const found = testLogSink.messages.some(m =>
-    m.some(
-      v => v instanceof Error && v.message.includes('Invalid union value.'),
-    ),
-  );
-  expect(found).true;
+      if (c.duringPing) {
+        await waitForUpstreamMessage(r, 'ping', clock);
+      }
+
+      await r.triggerPoke({
+        pokes: [
+          {
+            baseCookie: null,
+            cookie: 1,
+            lastMutationIDChanges: {c1: 1},
+            // @ts-expect-error - invalid field
+            patch: [{op: 'put', key: 'k1', valueXXX: 'v1'}],
+            timestamp: 123456,
+          },
+        ],
+        requestID: 'test-request-id-poke',
+      });
+      await clock.tickAsync(0);
+
+      if (c.duringPing) {
+        await r.triggerPong();
+      }
+
+      expect(r.online).eq(true);
+      expect(r.connectionState).eq(ConnectionState.Connected);
+
+      const found = testLogSink.messages.some(m =>
+        m.some(
+          v => v instanceof Error && v.message.includes('Invalid union value.'),
+        ),
+      );
+      expect(found).true;
+    });
+  }
 });
 
 test('experimentalKVStore', async () => {

--- a/packages/reflect/src/client/reflect.ts
+++ b/packages/reflect/src/client/reflect.ts
@@ -36,7 +36,7 @@ import {
   UpdateNeededReason as ReplicacheUpdateNeededReason,
 } from 'replicache';
 import {assert} from 'shared/asserts.js';
-import {sleep} from 'shared/sleep.js';
+import {sleep, sleepWithAbort} from 'shared/sleep.js';
 import * as valita from 'shared/valita.js';
 import {nanoid} from '../util/nanoid.js';
 import {send} from '../util/socket.js';
@@ -50,7 +50,7 @@ import {
 import type {ReflectOptions} from './options.js';
 import {PokeHandler} from './poke-handler.js';
 import {reloadWithReason, reportReloadReason} from './reload-error-handler.js';
-import {isAuthError, ServerError} from './server-error.js';
+import {isAuthError, isServerError, ServerError} from './server-error.js';
 import {version} from './version.js';
 
 export const enum ConnectionState {
@@ -166,6 +166,10 @@ export class Reflect<MD extends MutatorDefs> {
   private _messageCount = 0;
   private _connectedAt = 0;
 
+  #abortPingTimeout = () => {
+    // intentionally empty
+  };
+
   /**
    * `onUpdateNeeded` is called when a code update is needed.
    *
@@ -207,7 +211,12 @@ export class Reflect<MD extends MutatorDefs> {
 
   #connectionStateChangeResolver = resolver<ConnectionState>();
 
-  #nextMessageResolver: Resolver<Downstream> | undefined = undefined;
+  /**
+   * This resolver is only used for rejections. It is awaited in the connected
+   * state (including when waiting for a pong). It is rejected when we get an
+   * invalid message or an 'error' message.
+   */
+  #rejectMessageError: Resolver<never> | undefined = undefined;
 
   #closeAbortController = new AbortController();
 
@@ -455,7 +464,7 @@ export class Reflect<MD extends MutatorDefs> {
     }
 
     const rejectInvalidMessage = (e?: unknown) =>
-      this.#nextMessageResolver?.reject(
+      this.#rejectMessageError?.reject(
         new Error(
           `Invalid message received from server: ${
             e instanceof Error ? e.message + '. ' : ''
@@ -538,7 +547,7 @@ export class Reflect<MD extends MutatorDefs> {
 
     lc.info?.(`${kind}: ${message}}`);
 
-    this.#nextMessageResolver?.reject(error);
+    this.#rejectMessageError?.reject(error);
     lc.debug?.('Rejecting connect resolver due to error', error);
     this._connectResolver.reject(error);
     await this._disconnect(lc, {server: kind});
@@ -611,7 +620,7 @@ export class Reflect<MD extends MutatorDefs> {
     // Reject connect after a timeout.
     const id = setTimeout(async () => {
       l.debug?.('Rejecting connect resolver due to timeout');
-      this._connectResolver.reject(new Error('Timed out connecting'));
+      this._connectResolver.reject(new TimedOutError('Connect'));
       await this._disconnect(l, {
         client: 'ConnectTimeout',
       });
@@ -698,7 +707,7 @@ export class Reflect<MD extends MutatorDefs> {
   }
 
   private async _handlePoke(_lc: LogContext, pokeMessage: PokeMessage) {
-    this.#nextMessageResolver?.resolve(pokeMessage);
+    this.#abortPingTimeout();
     const pokeBody = pokeMessage[1];
     const lastMutationIDChangeForSelf = await this._pokeHandler.handlePoke(
       pokeBody,
@@ -726,7 +735,7 @@ export class Reflect<MD extends MutatorDefs> {
     lc: LogContext,
     pullResponseMessage: PullResponseMessage,
   ) {
-    this.#nextMessageResolver?.resolve(pullResponseMessage);
+    this.#abortPingTimeout();
     const body = pullResponseMessage[1];
     lc = lc.addContext('requestID', body.requestID);
     lc.debug?.('Handling pull response', body);
@@ -887,33 +896,39 @@ export class Reflect<MD extends MutatorDefs> {
             // - After PING_INTERVAL_MS we send a ping
             // - We get disconnected
             // - We get a message
+            // - We get an error (rejectMessageError rejects)
             // - The tab becomes hidden (with a delay)
 
-            const pingTimeoutPromise = sleep(PING_INTERVAL_MS);
+            const controller = new AbortController();
+            this.#abortPingTimeout = () => controller.abort();
+            const [pingTimeoutPromise, pingTimeoutAborted] = sleepWithAbort(
+              PING_INTERVAL_MS,
+              controller.signal,
+            );
 
-            this.#nextMessageResolver = resolver();
+            this.#rejectMessageError = resolver();
 
             const enum RaceCases {
               Ping = 0,
-              Hidden = 1,
+              Hidden = 2,
             }
 
             const raceResult = await promiseRace([
               pingTimeoutPromise,
+              pingTimeoutAborted,
               this.#visibilityWatcher.waitForHidden(),
               this.#connectionStateChangeResolver.promise,
-              this.#nextMessageResolver.promise,
+              this.#rejectMessageError.promise,
             ]);
 
-            this.#nextMessageResolver = undefined;
-
             if (this.closed) {
+              this.#rejectMessageError = undefined;
               break;
             }
 
             switch (raceResult) {
               case RaceCases.Ping:
-                await this._ping(lc);
+                await this._ping(lc, this.#rejectMessageError.promise);
                 break;
               case RaceCases.Hidden:
                 await this._disconnect(lc, {
@@ -921,6 +936,8 @@ export class Reflect<MD extends MutatorDefs> {
                 });
                 break;
             }
+
+            this.#rejectMessageError = undefined;
           }
         }
       } catch (ex) {
@@ -948,7 +965,9 @@ export class Reflect<MD extends MutatorDefs> {
           needsReauth = true;
         }
 
-        errorCount++;
+        if (isServerError(ex) || ex instanceof TimedOutError) {
+          errorCount++;
+        }
       }
 
       // Only authentication errors are retried immediately the first time they
@@ -1082,7 +1101,10 @@ export class Reflect<MD extends MutatorDefs> {
   /**
    * Throws an error if the ping times out.
    */
-  private async _ping(l: LogContext): Promise<void> {
+  private async _ping(
+    l: LogContext,
+    messageErrorRejectionPromise: Promise<never>,
+  ): Promise<void> {
     l.debug?.('pinging');
     const {promise, resolve} = resolver();
     this._onPong = resolve;
@@ -1092,7 +1114,11 @@ export class Reflect<MD extends MutatorDefs> {
     send(this._socket, pingMessage);
 
     const connected =
-      (await promiseRace([promise, sleep(PING_TIMEOUT_MS)])) === 0;
+      (await promiseRace([
+        promise,
+        sleep(PING_TIMEOUT_MS),
+        messageErrorRejectionPromise,
+      ])) === 0;
     if (this._connectionState !== ConnectionState.Connected) {
       return;
     }
@@ -1105,7 +1131,7 @@ export class Reflect<MD extends MutatorDefs> {
       await this._disconnect(l, {
         client: 'PingTimeout',
       });
-      throw new Error('Ping timed out');
+      throw new TimedOutError('Ping');
     }
   }
 
@@ -1237,4 +1263,10 @@ function camelToSnake(s: string): string {
     .split(/\.?(?=[A-Z])/)
     .join('_')
     .toLowerCase();
+}
+
+class TimedOutError extends Error {
+  constructor(m: string) {
+    super(`${m} timed out`);
+  }
 }

--- a/packages/reflect/src/client/server-error.ts
+++ b/packages/reflect/src/client/server-error.ts
@@ -12,10 +12,14 @@ export class ServerError<K extends ErrorKind = ErrorKind> extends Error {
   }
 }
 
+export function isServerError(ex: unknown): ex is ServerError {
+  return ex instanceof ServerError;
+}
+
 export function isAuthError(
   ex: unknown,
 ): ex is ServerError<'AuthInvalidated'> | ServerError<'Unauthorized'> {
-  return ex instanceof ServerError && isAuthErrorKind(ex.kind);
+  return isServerError(ex) && isAuthErrorKind(ex.kind);
 }
 
 function isAuthErrorKind(


### PR DESCRIPTION
- If we get an invalid message we used to trigger
  `onOnlineChange(false)` but we didn't disconnect. Now we no longer
  trigger `onOnlineChange` for invalid messages and we stay connected.
- We used to incorrectly ignore errors when we were waiting for the
  response from a ping request. Now we handle these errors during ping
  and these gets captured by the main catch handler in the run loop.

Closes #452