### PR TITLE
fix: implicit room creation was using withRead instead of withWrite

### DIFF
--- a/packages/reflect-server/src/server/auth-do.ts
+++ b/packages/reflect-server/src/server/auth-do.ts
@@ -11,6 +11,7 @@ import {
   deleteRoomRecord,
   internalCreateRoom,
   objectIDByRoomID,
+  RoomRecord,
   roomRecordByRoomID,
   roomRecords,
   RoomStatus,
@@ -443,10 +444,11 @@ export class BaseAuthDO implements DurableObject {
       // writing the connection record, in case it doesn't exist or is
       // closed/deleted.
 
-      let roomRecord = await this._roomRecordLock.withRead(
-        // Check if room already exists.
-        () => roomRecordByRoomID(this._durableStorage, roomID),
-      );
+      let roomRecord: RoomRecord | undefined =
+        await this._roomRecordLock.withRead(
+          // Check if room already exists.
+          () => roomRecordByRoomID(this._durableStorage, roomID),
+        );
 
       if (!roomRecord) {
         roomRecord = await this._roomRecordLock.withWrite(async () => {


### PR DESCRIPTION
problem: implicit room creation was using withRead instead of withWrite allowing for multiple DO's being spun up during a website load with multiple reflect clients. 

fix: use withWrite lock

I spoke with @grgbkr about this and the test for this is a bit tricky and did not feel necessary to implement right now