### PR TITLE
fix: Add missing commit in refresh

### DIFF
--- a/packages/replicache/src/persist/refresh.ts
+++ b/packages/replicache/src/persist/refresh.ts
@@ -8,8 +8,8 @@ import {sleep} from '../sleep.js';
 import * as sync from '../sync/mod.js';
 import {withRead, withWrite} from '../with-transactions.js';
 import {
-  assertClientV5,
   ClientStateNotFoundError,
+  assertClientV5,
   getClient,
   getClientGroupForClient,
   setClient,
@@ -210,6 +210,7 @@ export async function refresh(
 
         await memdagWrite.setHead(db.DEFAULT_HEAD_NAME, newMemdagHeadHash);
         await memdagWrite.commit();
+
         return [newMemdagHeadHash, diffs, perdagClientGroupHeadHash];
       });
     },
@@ -233,6 +234,8 @@ export async function refresh(
     // If this cleanup never happens, it's no big deal, some data will stay
     // alive longer but next refresh will fix it.
     await setClient(clientID, newClient, perdagWrite);
+
+    await perdagWrite.commit();
   });
 
   return result && [result[0], result[1]];


### PR DESCRIPTION
The missing commit was causing us to never clear the tempRefreshHash, which only leads to us keeping more data around than we need to.

It also was causing us to not set the headHash to the updated client head. This can cause our dag to be prematurely collected.