### PR TITLE
Bump version numbers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15252,14 +15252,14 @@
         "@types/jest": "^29.4.2",
         "@types/node-fetch": "^2.6.2",
         "cross-fetch": "^3.1.5",
-        "replicache": "12.0.1",
+        "replicache": "13.0.0-beta.0",
         "ts-jest": "^29.0.5",
         "typescript": "^4.9.5"
       }
     },
     "packages/reflect": {
       "name": "@rocicorp/reflect",
-      "version": "0.13.1",
+      "version": "0.14.0-beta.0",
       "license": "SEE LICENSE IN https://roci.dev/terms.html",
       "dependencies": {
         "@badrap/valita": "^0.2.0",
@@ -15281,7 +15281,7 @@
         "esbuild": "^0.17.11",
         "mocha": "^9.2.1",
         "reflect-protocol": "*",
-        "replicache": "12.0.1",
+        "replicache": "13.0.0-beta.0",
         "rollup": "^3.19.1",
         "rollup-plugin-dts": "^5.2.0",
         "shared": "*",
@@ -15304,7 +15304,7 @@
     },
     "packages/reflect-server": {
       "name": "@rocicorp/reflect-server",
-      "version": "0.22.0",
+      "version": "0.23.0-beta.0",
       "license": "SEE LICENSE IN https://roci.dev/terms.html",
       "dependencies": {
         "@badrap/valita": "^0.2.0",
@@ -15325,7 +15325,7 @@
         "jest-environment-miniflare": "^2.11.0",
         "miniflare": "^2.11.0",
         "reflect-protocol": "*",
-        "replicache": "12.0.1",
+        "replicache": "13.0.0-beta.0",
         "rollup": "^3.19.1",
         "rollup-plugin-dts": "^5.2.0",
         "shared": "*",
@@ -15570,7 +15570,7 @@
       }
     },
     "packages/replicache": {
-      "version": "12.0.1",
+      "version": "13.0.0-beta.0",
       "license": "https://roci.dev/terms.html",
       "dependencies": {
         "@rocicorp/lock": "^1.0.1",
@@ -17897,7 +17897,7 @@
         "esbuild": "^0.17.11",
         "mocha": "^9.2.1",
         "reflect-protocol": "*",
-        "replicache": "12.0.1",
+        "replicache": "13.0.0-beta.0",
         "rollup": "^3.19.1",
         "rollup-plugin-dts": "^5.2.0",
         "shared": "*",
@@ -17994,7 +17994,7 @@
         "jest-environment-miniflare": "^2.11.0",
         "miniflare": "^2.11.0",
         "reflect-protocol": "*",
-        "replicache": "12.0.1",
+        "replicache": "13.0.0-beta.0",
         "rollup": "^3.19.1",
         "rollup-plugin-dts": "^5.2.0",
         "shared": "*",
@@ -20135,7 +20135,7 @@
         "@types/jest": "^29.4.2",
         "@types/node-fetch": "^2.6.2",
         "cross-fetch": "^3.1.5",
-        "replicache": "12.0.1",
+        "replicache": "13.0.0-beta.0",
         "ts-jest": "^29.0.5",
         "typescript": "^4.9.5"
       }

--- a/packages/datadog/package.json
+++ b/packages/datadog/package.json
@@ -12,7 +12,7 @@
     "@types/jest": "^29.4.2",
     "@types/node-fetch": "^2.6.2",
     "cross-fetch": "^3.1.5",
-    "replicache": "12.0.1",
+    "replicache": "13.0.0-beta.0",
     "ts-jest": "^29.0.5",
     "typescript": "^4.9.5"
   },

--- a/packages/reflect-server/package.json
+++ b/packages/reflect-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rocicorp/reflect-server",
   "description": "Multiplayer server for Replicache",
-  "version": "0.22.0",
+  "version": "0.23.0-beta.0",
   "repository": "github:rocicorp/reflect-server",
   "license": "SEE LICENSE IN https://roci.dev/terms.html",
   "main": "out/reflect-server.js",
@@ -43,7 +43,7 @@
     "jest-environment-miniflare": "^2.11.0",
     "miniflare": "^2.11.0",
     "reflect-protocol": "*",
-    "replicache": "12.0.1",
+    "replicache": "13.0.0-beta.0",
     "rollup": "^3.19.1",
     "rollup-plugin-dts": "^5.2.0",
     "shared": "*",

--- a/packages/reflect/package.json
+++ b/packages/reflect/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rocicorp/reflect",
   "description": "",
-  "version": "0.13.1",
+  "version": "0.14.0-beta.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/rocicorp/reflect.git"
@@ -43,7 +43,7 @@
     "esbuild": "^0.17.11",
     "mocha": "^9.2.1",
     "reflect-protocol": "*",
-    "replicache": "12.0.1",
+    "replicache": "13.0.0-beta.0",
     "rollup": "^3.19.1",
     "rollup-plugin-dts": "^5.2.0",
     "shared": "*",

--- a/packages/replicache/package.json
+++ b/packages/replicache/package.json
@@ -1,7 +1,7 @@
 {
   "name": "replicache",
   "description": "Realtime sync for any backend stack",
-  "version": "12.0.1",
+  "version": "13.0.0-beta.0",
   "repository": "github:rocicorp/replicache",
   "license": "https://roci.dev/terms.html",
   "scripts": {


### PR DESCRIPTION
reflect 0.14.0-beta.0
reflect-server 0.23.0-beta.0
replicache 13.0.0-beta.0