### PR TITLE
chore: Use ClientID, ClientGroupID from sync/ids.ts

### DIFF
--- a/packages/replicache/src/db/rebase.ts
+++ b/packages/replicache/src/db/rebase.ts
@@ -1,10 +1,10 @@
+import type {LogContext} from '@rocicorp/logger';
+import {assert} from 'shared/asserts.js';
 import type * as dag from '../dag/mod.js';
 import type {Hash} from '../hash.js';
 import type {MutatorDefs} from '../replicache.js';
+import type {ClientID} from '../sync/ids.js';
 import {WriteTransactionImpl} from '../transactions.js';
-import type {LogContext} from '@rocicorp/logger';
-import type {ClientID} from '../sync/mod.js';
-import {assert} from 'shared/asserts.js';
 import {
   Commit,
   fromHash,
@@ -14,8 +14,8 @@ import {
   LocalMetaSDD,
   Meta,
 } from './commit.js';
-import {newWriteLocal, Write} from './write.js';
 import {whenceHash} from './read.js';
+import {newWriteLocal, Write} from './write.js';
 
 async function rebaseMutation(
   mutation: Commit<LocalMetaDD31 | LocalMetaSDD>,

--- a/packages/replicache/src/db/write.ts
+++ b/packages/replicache/src/db/write.ts
@@ -1,38 +1,38 @@
 import type {LogContext} from '@rocicorp/logger';
-import type * as dag from '../dag/mod.js';
+import {assert} from 'shared/asserts.js';
 import * as btree from '../btree/mod.js';
+import {BTreeRead, BTreeWrite} from '../btree/mod.js';
+import type {InternalDiff} from '../btree/node.js';
+import {allEntriesAsDiff} from '../btree/read.js';
+import type {FrozenCookie} from '../cookies.js';
+import type * as dag from '../dag/mod.js';
+import {Hash, emptyHash} from '../hash.js';
+import type {FrozenJSONValue} from '../json.js';
+import {lazy} from '../lazy.js';
+import type {DiffComputationConfig} from '../sync/diff.js';
+import type {ClientID} from '../sync/ids.js';
 import * as sync from '../sync/mod.js';
-import type {ClientID} from '../sync/mod.js';
 import {
   Commit,
   Meta as CommitMeta,
   IndexRecord,
-  newIndexChange as commitNewIndexChange,
-  newLocalSDD as commitNewLocalSDD,
-  newLocalDD31 as commitNewLocalDD31,
-  newSnapshotSDD as commitNewSnapshotSDD,
-  newSnapshotDD31 as commitNewSnapshotDD31,
-  MetaType,
   Meta,
+  MetaType,
   baseSnapshotHashFromHash,
+  newIndexChange as commitNewIndexChange,
+  newLocalDD31 as commitNewLocalDD31,
+  newLocalSDD as commitNewLocalSDD,
+  newSnapshotDD31 as commitNewSnapshotDD31,
+  newSnapshotSDD as commitNewSnapshotSDD,
   getMutationID,
 } from './commit.js';
+import {IndexOperation, IndexRead, IndexWrite, indexValue} from './index.js';
 import {
   Read,
+  Whence,
   readCommitForBTreeWrite,
   readIndexesForRead,
-  Whence,
 } from './read.js';
-import {IndexWrite, IndexOperation, indexValue, IndexRead} from './index.js';
-import {BTreeRead, BTreeWrite} from '../btree/mod.js';
-import {lazy} from '../lazy.js';
-import {emptyHash, Hash} from '../hash.js';
-import type {InternalDiff} from '../btree/node.js';
-import {allEntriesAsDiff} from '../btree/read.js';
-import {assert} from 'shared/asserts.js';
-import type {DiffComputationConfig} from '../sync/diff.js';
-import type {FrozenJSONValue} from '../json.js';
-import type {FrozenCookie} from '../cookies.js';
 
 export class Write extends Read {
   private readonly _dagWrite: dag.Write;

--- a/packages/replicache/src/mutation-recovery.ts
+++ b/packages/replicache/src/mutation-recovery.ts
@@ -164,7 +164,7 @@ function logMutationRecoveryError(
  */
 async function recoverMutationsOfClientV4(
   client: persist.Client,
-  clientID: sync.ClientID,
+  clientID: ClientID,
   perdag: dag.Store,
   database: persist.IndexedDBDatabase,
   options: MutationRecoveryOptions,
@@ -412,7 +412,7 @@ async function recoverMutationsFromPerdagSDD(
     let clientMap: persist.ClientMap | undefined =
       preReadClientMap ||
       (await withRead(perdag, read => persist.getClients(read)));
-    const clientIDsVisited = new Set<sync.ClientID>();
+    const clientIDsVisited = new Set<ClientID>();
     while (clientMap) {
       let newClientMap: persist.ClientMap | undefined;
       for (const [clientID, client] of clientMap) {
@@ -455,7 +455,7 @@ async function recoverMutationsFromPerdagDD31(
       perdag,
       read => persist.getClientGroups(read),
     );
-    const clientGroupIDsVisited = new Set<sync.ClientGroupID>();
+    const clientGroupIDsVisited = new Set<ClientGroupID>();
     while (clientGroups) {
       let newClientGroups: persist.ClientGroupMap | undefined;
       for (const [clientGroupID, clientGroup] of clientGroups) {
@@ -492,7 +492,7 @@ async function recoverMutationsFromPerdagDD31(
  */
 async function recoverMutationsOfClientGroupDD31(
   clientGroup: persist.ClientGroup,
-  clientGroupID: sync.ClientGroupID,
+  clientGroupID: ClientGroupID,
   perdag: dag.Store,
   database: persist.IndexedDBDatabase,
   options: MutationRecoveryOptions,
@@ -512,7 +512,7 @@ async function recoverMutationsOfClientGroupDD31(
     return;
   }
 
-  let clientID: sync.ClientID | undefined;
+  let clientID: ClientID | undefined;
 
   // If all local mutations have been applied then exit.
   let allAckd = true;

--- a/packages/replicache/src/persist/client-groups.test.ts
+++ b/packages/replicache/src/persist/client-groups.test.ts
@@ -1,7 +1,8 @@
 import {expect} from '@esm-bundle/chai';
 import * as dag from '../dag/mod.js';
-import type * as sync from '../sync/mod.js';
 import {assertHash, fakeHash, Hash} from '../hash.js';
+import type {ClientGroupID} from '../sync/ids.js';
+import {withRead, withWrite} from '../with-transactions.js';
 import {
   ClientGroup,
   clientGroupHasPendingMutations,
@@ -14,7 +15,6 @@ import {
   setClientGroup,
   setClientGroups,
 } from './client-groups.js';
-import {withRead, withWrite} from '../with-transactions.js';
 
 const headClientGroup1Hash = fakeHash('b1');
 const headClientGroup2Hash = fakeHash('b2');
@@ -23,7 +23,7 @@ const headClientGroup3Hash = fakeHash('b3');
 type PartialClientGroup = Partial<ClientGroup> & Pick<ClientGroup, 'headHash'>;
 
 export function makeClientGroupMap(
-  partialClientGroups: Record<sync.ClientGroupID, PartialClientGroup>,
+  partialClientGroups: Record<ClientGroupID, PartialClientGroup>,
 ): ClientGroupMap {
   const clientGroupMap = new Map();
   for (const [clientGroupID, partialClientGroup] of Object.entries(
@@ -56,7 +56,7 @@ test('getClientGroups with no existing ClientGroupMap in dag store', async () =>
 });
 
 async function testSetClientGroups(
-  partialClientGroupMap: Record<sync.ClientGroupID, PartialClientGroup>,
+  partialClientGroupMap: Record<ClientGroupID, PartialClientGroup>,
   dagStore: dag.Store,
 ) {
   const clientGroupMap = makeClientGroupMap(partialClientGroupMap);
@@ -93,8 +93,8 @@ test('setClientGroups and getClientGroups', async () => {
 });
 
 async function testSetClientGroupsSequence(
-  partialClientGroupMap1: Record<sync.ClientGroupID, PartialClientGroup>,
-  partialClientGroupMap2: Record<sync.ClientGroupID, PartialClientGroup>,
+  partialClientGroupMap1: Record<ClientGroupID, PartialClientGroup>,
+  partialClientGroupMap2: Record<ClientGroupID, PartialClientGroup>,
   dagStore: dag.Store,
 ) {
   await testSetClientGroups(partialClientGroupMap1, dagStore);
@@ -102,8 +102,8 @@ async function testSetClientGroupsSequence(
 }
 
 async function testSetClientGroupsSequenceThrowsError(
-  partialClientGroupMap1: Record<sync.ClientGroupID, PartialClientGroup>,
-  partialClientGroupMap2: Record<sync.ClientGroupID, PartialClientGroup>,
+  partialClientGroupMap1: Record<ClientGroupID, PartialClientGroup>,
+  partialClientGroupMap2: Record<ClientGroupID, PartialClientGroup>,
   expectedErrorMsg: string,
   dagStore: dag.Store,
 ) {
@@ -314,9 +314,9 @@ test('setClientGroups throws error if mutatorNames is not a set', async () => {
 });
 
 async function testSetClientGroup(
-  partialClientGroupMap1: Record<sync.ClientGroupID, PartialClientGroup>,
-  partialClientGroupEntryToSet: [sync.ClientGroupID, PartialClientGroup],
-  expectedPartialClientGroupMap: Record<sync.ClientGroupID, PartialClientGroup>,
+  partialClientGroupMap1: Record<ClientGroupID, PartialClientGroup>,
+  partialClientGroupEntryToSet: [ClientGroupID, PartialClientGroup],
+  expectedPartialClientGroupMap: Record<ClientGroupID, PartialClientGroup>,
   dagStore: dag.Store,
 ) {
   await testSetClientGroups(partialClientGroupMap1, dagStore);
@@ -343,8 +343,8 @@ async function testSetClientGroup(
 }
 
 async function testSetClientGroupThrowsError(
-  partialClientGroupMap1: Record<sync.ClientGroupID, PartialClientGroup>,
-  partialClientGroupEntryToSet: [sync.ClientGroupID, PartialClientGroup],
+  partialClientGroupMap1: Record<ClientGroupID, PartialClientGroup>,
+  partialClientGroupEntryToSet: [ClientGroupID, PartialClientGroup],
   expectedErrorMsg: string,
   dagStore: dag.Store,
 ) {

--- a/packages/replicache/src/persist/client-groups.ts
+++ b/packages/replicache/src/persist/client-groups.ts
@@ -13,9 +13,9 @@ import {
   indexDefinitionsEqual,
 } from '../index-defs.js';
 import {FrozenJSONValue, deepFreeze} from '../json.js';
-import type * as sync from '../sync/mod.js';
+import type {ClientGroupID, ClientID} from '../sync/ids.js';
 
-export type ClientGroupMap = ReadonlyMap<sync.ClientGroupID, ClientGroup>;
+export type ClientGroupMap = ReadonlyMap<ClientGroupID, ClientGroup>;
 
 export type ClientGroup = {
   /**
@@ -43,7 +43,7 @@ export type ClientGroup = {
    * are unacknowledged pending mutations without having to load the commit
    * graph.
    */
-  readonly mutationIDs: Readonly<Record<sync.ClientID, number>>;
+  readonly mutationIDs: Readonly<Record<ClientID, number>>;
 
   /**
    * The highest lastMutationID received from the server for every client
@@ -61,7 +61,7 @@ export type ClientGroup = {
    * it may be different because the other client does not update the commit
    * graph.
    */
-  readonly lastServerAckdMutationIDs: Readonly<Record<sync.ClientID, number>>;
+  readonly lastServerAckdMutationIDs: Readonly<Record<ClientID, number>>;
 
   /**
    * If the server deletes this client group it can signal that the client group
@@ -101,7 +101,7 @@ function assertClientGroup(value: unknown): asserts value is ClientGroup {
 
 function chunkDataToClientGroupMap(chunkData: unknown): ClientGroupMap {
   assertObject(chunkData);
-  const clientGroups = new Map<sync.ClientGroupID, ClientGroup>();
+  const clientGroups = new Map<ClientGroupID, ClientGroup>();
   for (const [key, value] of Object.entries(chunkData)) {
     if (value !== undefined) {
       assertClientGroup(value);
@@ -115,7 +115,7 @@ function clientGroupMapToChunkData(
   clientGroups: ClientGroupMap,
   dagWrite: dag.Write,
 ): FrozenJSONValue {
-  const chunkData: {[id: sync.ClientGroupID]: ClientGroup} = {};
+  const chunkData: {[id: ClientGroupID]: ClientGroup} = {};
   for (const [clientGroupID, clientGroup] of clientGroups.entries()) {
     dagWrite.assertValidHash(clientGroup.headHash);
     chunkData[clientGroupID] = {
@@ -157,7 +157,7 @@ export async function setClientGroups(
 }
 
 export async function setClientGroup(
-  clientGroupID: sync.ClientGroupID,
+  clientGroupID: ClientGroupID,
   clientGroup: ClientGroup,
   dagWrite: dag.Write,
 ): Promise<ClientGroupMap> {
@@ -170,7 +170,7 @@ export async function setClientGroup(
 }
 
 export async function deleteClientGroup(
-  clientGroupID: sync.ClientGroupID,
+  clientGroupID: ClientGroupID,
   dagWrite: dag.Write,
 ): Promise<ClientGroupMap> {
   const currClientGroups = await getClientGroups(dagWrite);
@@ -234,7 +234,7 @@ export function mutatorNamesEqual(
 }
 
 export async function getClientGroup(
-  id: sync.ClientGroupID,
+  id: ClientGroupID,
   dagRead: dag.Read,
 ): Promise<ClientGroup | undefined> {
   const clientGroups = await getClientGroups(dagRead);

--- a/packages/replicache/src/persist/clients-test-helpers.ts
+++ b/packages/replicache/src/persist/clients-test-helpers.ts
@@ -1,26 +1,26 @@
+import {LogContext} from '@rocicorp/logger';
+import {assert} from 'shared/asserts.js';
+import * as btree from '../btree/mod.js';
+import * as dag from '../dag/mod.js';
+import {getRefs, newSnapshotCommitDataSDD} from '../db/commit.js';
+import * as db from '../db/mod.js';
+import {newUUIDHash} from '../hash.js';
+import type {IndexDefinitions} from '../index-defs.js';
+import type {ClientID} from '../sync/ids.js';
+import {uuid as makeUuid} from '../uuid.js';
+import {withWrite} from '../with-transactions.js';
 import {
+  Client,
   ClientMap,
-  ClientV5,
+  ClientMapDD31,
   ClientV4,
-  setClients,
+  ClientV5,
+  ClientV6,
   getClients,
   initClientV6,
-  Client,
-  ClientMapDD31,
   isClientV4,
-  ClientV6,
+  setClients,
 } from './clients.js';
-import * as dag from '../dag/mod.js';
-import type * as sync from '../sync/mod.js';
-import {LogContext} from '@rocicorp/logger';
-import type {IndexDefinitions} from '../index-defs.js';
-import {newUUIDHash} from '../hash.js';
-import * as btree from '../btree/mod.js';
-import * as db from '../db/mod.js';
-import {uuid as makeUuid} from '../uuid.js';
-import {getRefs, newSnapshotCommitDataSDD} from '../db/commit.js';
-import {withWrite} from '../with-transactions.js';
-import {assert} from 'shared/asserts.js';
 
 export function setClientsForTesting(
   clients: ClientMap,
@@ -69,7 +69,7 @@ export function makeClientV6(partialClient: PartialClientV6): ClientV6 {
 }
 
 export function makeClientMapDD31(
-  obj: Record<sync.ClientID, PartialClientV5>,
+  obj: Record<ClientID, PartialClientV5>,
 ): ClientMapDD31 {
   return new Map(
     Object.entries(obj).map(
@@ -79,7 +79,7 @@ export function makeClientMapDD31(
 }
 
 export async function deleteClientForTesting(
-  clientID: sync.ClientID,
+  clientID: ClientID,
   dagStore: dag.Store,
 ): Promise<void> {
   await withWrite(dagStore, async dagWrite => {
@@ -91,7 +91,7 @@ export async function deleteClientForTesting(
 }
 
 export async function initClientWithClientID(
-  clientID: sync.ClientID,
+  clientID: ClientID,
   dagStore: dag.Store,
   mutatorNames: string[],
   indexes: IndexDefinitions,
@@ -119,7 +119,7 @@ function initClientV4(
   perdag: dag.Store,
 ): Promise<
   [
-    clientID: sync.ClientID,
+    clientID: ClientID,
     client: Client,
     clientMap: ClientMap,
     newClientGroup: boolean,

--- a/packages/replicache/src/persist/persist-test-helpers.ts
+++ b/packages/replicache/src/persist/persist-test-helpers.ts
@@ -3,7 +3,7 @@ import type * as dag from '../dag/mod.js';
 import {assertSnapshotMetaSDD} from '../db/commit.js';
 import * as db from '../db/mod.js';
 import type {Hash} from '../hash.js';
-import type * as sync from '../sync/mod.js';
+import type {ClientID} from '../sync/ids.js';
 import {withRead, withWrite} from '../with-transactions.js';
 import {assertHasClientState, setClient} from './clients.js';
 import {GatherMemoryOnlyVisitor} from './gather-mem-only-visitor.js';
@@ -19,7 +19,7 @@ import {GatherMemoryOnlyVisitor} from './gather-mem-only-visitor.js';
  * or is rejected if the persist fails.
  */
 export async function persistSDD(
-  clientID: sync.ClientID,
+  clientID: ClientID,
   memdag: dag.LazyStore,
   perdag: dag.Store,
   closed: () => boolean,
@@ -65,7 +65,7 @@ export async function persistSDD(
 
 function gatherMemOnlyChunks(
   memdag: dag.LazyStore,
-  clientID: sync.ClientID,
+  clientID: ClientID,
 ): Promise<
   [
     map: ReadonlyMap<Hash, dag.Chunk>,
@@ -99,7 +99,7 @@ async function writeChunks(
   perdag: dag.Store,
   chunks: ReadonlyMap<Hash, dag.Chunk>,
   mainHeadHash: Hash,
-  clientID: sync.ClientID,
+  clientID: ClientID,
   mutationID: number,
   lastMutationID: number,
 ): Promise<void> {

--- a/packages/replicache/src/persist/persist.test.ts
+++ b/packages/replicache/src/persist/persist.test.ts
@@ -12,9 +12,9 @@ import {
 } from '../db/test-helpers.js';
 import {Hash, assertHash, makeNewFakeHashFunction} from '../hash.js';
 import type {JSONValue} from '../json.js';
-import type {MutatorDefs} from '../mod.js';
+import type {MutatorDefs} from '../replicache.js';
 import {promiseVoid} from '../resolved-promises.js';
-import type * as sync from '../sync/mod.js';
+import type {ClientGroupID, ClientID} from '../sync/ids.js';
 import type {WriteTransaction} from '../transactions.js';
 import {withRead, withWrite} from '../with-transactions.js';
 import {
@@ -50,8 +50,8 @@ suite('persistDD31', () => {
     perdag: dag.TestStore,
     memdagChainBuilder: ChainBuilder,
     perdagClientGroupChainBuilder: ChainBuilder,
-    clients: {clientID: sync.ClientID; client: Client}[],
-    clientGroupID: sync.ClientGroupID,
+    clients: {clientID: ClientID; client: Client}[],
+    clientGroupID: ClientGroupID,
     testPersist: (
       persistedExpectation: PersistedExpectation,
       onGatherMemOnlyChunksForTest?: () => Promise<void>,
@@ -79,8 +79,8 @@ suite('persistDD31', () => {
     memdagCookie?: string;
     perdagClientGroupCookie?: string;
     memdagValueMap?: [string, JSONValue][];
-    memdagMutationIDs?: Record<sync.ClientID, number>;
-    perdagClientGroupMutationIDs?: Record<sync.ClientID, number>;
+    memdagMutationIDs?: Record<ClientID, number>;
+    perdagClientGroupMutationIDs?: Record<ClientID, number>;
   }) {
     const {
       memdagCookie = 'cookie1',
@@ -833,7 +833,7 @@ suite('persistDD31', () => {
 
 function expectUpdatedClientPersistHash(
   clientMap: ClientMap,
-  clients: {clientID: sync.ClientID; client: Client}[],
+  clients: {clientID: ClientID; client: Client}[],
   memdagSnapshotCommitHash: Hash,
   afterPersistClientMap: ClientMap,
 ) {
@@ -874,7 +874,7 @@ async function setupPersistTest() {
     };
   }
 
-  let clientGroupID: undefined | sync.ClientGroupID;
+  let clientGroupID: undefined | ClientGroupID;
   const createClient = async () => {
     const [cID, c] = await initClientV6(
       new LogContext(),
@@ -889,7 +889,7 @@ async function setupPersistTest() {
       client: c,
     };
   };
-  const clients: {clientID: sync.ClientID; client: ClientV6}[] = [];
+  const clients: {clientID: ClientID; client: ClientV6}[] = [];
   for (let i = 0; i < 3; i++) {
     clients.push(await createClient());
   }

--- a/packages/replicache/src/persist/persist.ts
+++ b/packages/replicache/src/persist/persist.ts
@@ -5,7 +5,7 @@ import {assertSnapshotCommitDD31} from '../db/commit.js';
 import * as db from '../db/mod.js';
 import type {Hash} from '../hash.js';
 import type {MutatorDefs} from '../replicache.js';
-import type * as sync from '../sync/mod.js';
+import type {ClientGroupID, ClientID} from '../sync/ids.js';
 import {withRead, withWrite} from '../with-transactions.js';
 import {ClientGroup, getClientGroup, setClientGroup} from './client-groups.js';
 import {
@@ -37,7 +37,7 @@ import {GatherMemoryOnlyVisitor} from './gather-mem-only-visitor.js';
  */
 export async function persistDD31(
   lc: LogContext,
-  clientID: sync.ClientID,
+  clientID: ClientID,
   memdag: dag.LazyStore,
   perdag: dag.Store,
   mutators: MutatorDefs,
@@ -130,7 +130,7 @@ export async function persistDD31(
     // these values are overwritten appropriately.
     let newMainClientGroupHeadHash: Hash =
       latestPerdagMainClientGroupHeadCommit.chunk.hash;
-    let mutationIDs: Record<sync.ClientID, number> = {
+    let mutationIDs: Record<ClientID, number> = {
       ...mainClientGroup.mutationIDs,
     };
     let {lastServerAckdMutationIDs} = mainClientGroup;
@@ -220,7 +220,7 @@ export async function persistDD31(
 
 async function getClientGroupInfo(
   perdagRead: dag.Read,
-  clientGroupID: sync.ClientGroupID,
+  clientGroupID: ClientGroupID,
 ): Promise<[ClientGroup, db.Commit<db.Meta>]> {
   const clientGroup = await getClientGroup(clientGroupID, perdagRead);
   assert(clientGroup, `No client group for clientGroupID: ${clientGroupID}`);
@@ -235,7 +235,7 @@ async function rebase(
   basis: Hash,
   write: dag.Write,
   mutators: MutatorDefs,
-  mutationIDs: Record<sync.ClientID, number>,
+  mutationIDs: Record<ClientID, number>,
   lc: LogContext,
 ): Promise<Hash> {
   for (let i = mutations.length - 1; i >= 0; i--) {

--- a/packages/replicache/src/persist/refresh.test.ts
+++ b/packages/replicache/src/persist/refresh.test.ts
@@ -20,7 +20,7 @@ import {
   setClient,
 } from '../persist/clients.js';
 import type {MutatorDefs} from '../replicache.js';
-import type * as sync from '../sync/mod.js';
+import type {ClientID} from '../sync/ids.js';
 import {addData, testSubscriptionsManagerOptions} from '../test-util.js';
 import type {WriteTransaction} from '../transactions.js';
 import {withRead, withWrite} from '../with-transactions.js';
@@ -28,7 +28,7 @@ import {refresh} from './refresh.js';
 
 async function makeChain(
   store: dag.Store,
-  clientID: sync.ClientID,
+  clientID: ClientID,
   cookie: number,
   headName: string,
   withLocal = true,
@@ -46,7 +46,7 @@ async function makeChain(
 
 function makeMemdagChain(
   memdag: dag.Store,
-  clientID: sync.ClientID,
+  clientID: ClientID,
   cookie: number,
 ): Promise<{headHash: Hash; chainBuilder: ChainBuilder}> {
   return makeChain(memdag, clientID, cookie, db.DEFAULT_HEAD_NAME);
@@ -55,7 +55,7 @@ function makeMemdagChain(
 const PERDAG_TEST_SETUP_HEAD_NAME = 'test-setup-head';
 async function makePerdagChainAndSetClientsAndClientGroup(
   perdag: dag.Store,
-  clientID: sync.ClientID,
+  clientID: ClientID,
   cookie: number,
   withLocal = true,
 ): Promise<{headHash: Hash; chainBuilder: ChainBuilder; client: ClientV6}> {
@@ -75,7 +75,7 @@ async function makePerdagChainAndSetClientsAndClientGroup(
 
 async function setClientsAndClientGroups(
   headHash: Hash,
-  clientID: sync.ClientID,
+  clientID: ClientID,
   perdag: dag.Store,
 ) {
   const clientGroupID = 'client-group-1';
@@ -597,7 +597,7 @@ suite('refresh', () => {
     }: {
       store: dag.Store;
       basisHash?: Hash | null;
-      lastMutationIDs: Record<sync.ClientID, number>;
+      lastMutationIDs: Record<ClientID, number>;
       cookieJSON: Cookie;
       valueHash?: Hash;
       indexes?: db.IndexRecord[];
@@ -640,7 +640,7 @@ suite('refresh', () => {
       entries = [],
     }: {
       store: dag.Store;
-      clientID: sync.ClientID;
+      clientID: ClientID;
       mutationID: number;
       basisHash: Hash;
       mutatorName: string;

--- a/packages/replicache/src/persist/refresh.ts
+++ b/packages/replicache/src/persist/refresh.ts
@@ -5,6 +5,7 @@ import {assertSnapshotCommitDD31} from '../db/commit.js';
 import * as db from '../db/mod.js';
 import type {Hash} from '../hash.js';
 import type {MutatorDefs} from '../replicache.js';
+import type {ClientID} from '../sync/ids.js';
 import * as sync from '../sync/mod.js';
 import {withRead, withWrite} from '../with-transactions.js';
 import {
@@ -43,7 +44,7 @@ export async function refresh(
   lc: LogContext,
   memdag: dag.LazyStore,
   perdag: dag.Store,
-  clientID: sync.ClientID,
+  clientID: ClientID,
   mutators: MutatorDefs,
   diffConfig: sync.DiffComputationConfig,
   closed: () => boolean,

--- a/packages/replicache/src/replicache-mutation-recovery-dd31.test.ts
+++ b/packages/replicache/src/replicache-mutation-recovery-dd31.test.ts
@@ -23,7 +23,6 @@ import {
   REPLICACHE_FORMAT_VERSION_V6,
 } from './replicache.js';
 import {stringCompare} from './string-compare.js';
-import type * as sync from './sync/mod.js';
 import {
   PULL_VERSION_DD31,
   PULL_VERSION_SDD,
@@ -51,14 +50,15 @@ import {withRead} from './with-transactions.js';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-expect-error
 import fetchMock from 'fetch-mock/esm/client';
+import type {ClientGroupID, ClientID} from './sync/ids.js';
 
 async function createAndPersistClientWithPendingLocalDD31(
-  clientID: sync.ClientID,
+  clientID: ClientID,
   perdag: dag.Store,
   numLocal: number,
   mutatorNames: string[],
   cookie: string | number,
-  snapshotLastMutationIDs?: Record<sync.ClientID, number> | undefined,
+  snapshotLastMutationIDs?: Record<ClientID, number> | undefined,
 ): Promise<db.LocalMetaDD31[]> {
   const testMemdag = new dag.LazyStore(
     perdag,
@@ -104,11 +104,11 @@ async function createAndPersistClientWithPendingLocalDD31(
 }
 
 async function persistSnapshotDD31(
-  clientID: sync.ClientID,
+  clientID: ClientID,
   perdag: dag.Store,
   cookie: string | number,
   mutatorNames: string[],
-  snapshotLastMutationIDs: Record<sync.ClientID, number>,
+  snapshotLastMutationIDs: Record<ClientID, number>,
 ): Promise<void> {
   const testMemdag = new dag.LazyStore(
     perdag,
@@ -147,8 +147,8 @@ suite('DD31', () => {
 
   function createPushRequestBodyDD31(
     profileID: string,
-    clientGroupID: sync.ClientGroupID,
-    clientID: sync.ClientID,
+    clientGroupID: ClientGroupID,
+    clientID: ClientID,
     localMetas: db.LocalMetaDD31[],
     schemaVersion: string,
   ): ReadonlyJSONObject {
@@ -170,14 +170,10 @@ suite('DD31', () => {
   async function testRecoveringMutationsOfClientV6(args: {
     schemaVersionOfClientWPendingMutations: string;
     schemaVersionOfClientRecoveringMutations: string;
-    snapshotLastMutationIDs?: Record<sync.ClientID, number> | undefined;
-    snapshotLastMutationIDsAfterPull?:
-      | Record<sync.ClientID, number>
-      | undefined;
-    pullLastMutationIDChanges?: Record<sync.ClientID, number> | undefined;
-    expectedLastServerAckdMutationIDs?:
-      | Record<sync.ClientID, number>
-      | undefined;
+    snapshotLastMutationIDs?: Record<ClientID, number> | undefined;
+    snapshotLastMutationIDsAfterPull?: Record<ClientID, number> | undefined;
+    pullLastMutationIDChanges?: Record<ClientID, number> | undefined;
+    expectedLastServerAckdMutationIDs?: Record<ClientID, number> | undefined;
     pullResponse?: PullResponseV1 | undefined;
     pushResponse?: PushResponse | undefined;
   }) {

--- a/packages/replicache/src/replicache-mutation-recovery.test.ts
+++ b/packages/replicache/src/replicache-mutation-recovery.test.ts
@@ -17,7 +17,6 @@ import {
   REPLICACHE_FORMAT_VERSION_V6,
   makeIDBNameForTesting,
 } from './replicache.js';
-import type * as sync from './sync/mod.js';
 import {PUSH_VERSION_SDD} from './sync/push.js';
 import {
   clock,
@@ -35,6 +34,7 @@ import {withRead} from './with-transactions.js';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-expect-error
 import fetchMock from 'fetch-mock/esm/client';
+import type {ClientID} from './sync/ids.js';
 
 initReplicacheTesting();
 
@@ -73,7 +73,7 @@ export async function createPerdag(args: {
 }
 
 export async function createAndPersistClientWithPendingLocalSDD(
-  clientID: sync.ClientID,
+  clientID: ClientID,
   perdag: dag.Store,
   numLocal: number,
 ): Promise<db.LocalMetaSDD[]> {
@@ -101,7 +101,7 @@ export async function createAndPersistClientWithPendingLocalSDD(
 
 export function createPushBodySDD(
   profileID: string,
-  clientID: sync.ClientID,
+  clientID: ClientID,
   localMetas: db.LocalMetaSDD[],
   schemaVersion: string,
 ): ReadonlyJSONObject {

--- a/packages/replicache/src/replicache.ts
+++ b/packages/replicache/src/replicache.ts
@@ -55,6 +55,7 @@ import {
   WatchNoIndexCallback,
   WatchOptions,
 } from './subscriptions.js';
+import type {ClientGroupID, ClientID} from './sync/ids.js';
 import * as sync from './sync/mod.js';
 import {PullError} from './sync/pull-error.js';
 import {HandlePullResponseResultType} from './sync/pull.js';
@@ -207,7 +208,7 @@ export type PendingMutation = {
   readonly name: string;
   readonly id: number;
   readonly args: ReadonlyJSONValue;
-  readonly clientID: sync.ClientID;
+  readonly clientID: ClientID;
 };
 
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -563,8 +564,8 @@ export class Replicache<MD extends MutatorDefs = {}> {
   private async _open(
     indexes: IndexDefinitions,
     profileIDResolver: (profileID: string) => void,
-    resolveClientGroupID: (clientGroupID: sync.ClientGroupID) => void,
-    resolveClientID: (clientID: sync.ClientID) => void,
+    resolveClientGroupID: (clientGroupID: ClientGroupID) => void,
+    resolveClientID: (clientID: ClientID) => void,
     resolveReady: () => void,
     resolveLicenseCheck: (valid: boolean) => void,
     resolveLicenseActive: (active: boolean) => void,
@@ -1362,12 +1363,12 @@ export class Replicache<MD extends MutatorDefs = {}> {
     }
   }
 
-  private _fireOnClientStateNotFound(clientID: sync.ClientID) {
+  private _fireOnClientStateNotFound(clientID: ClientID) {
     this._lc.error?.(`Client state not found, clientID: ${clientID}`);
     this.onClientStateNotFound?.();
   }
 
-  private _clientStateNotFoundOnClient(clientID: sync.ClientID) {
+  private _clientStateNotFoundOnClient(clientID: ClientID) {
     this._lc.error?.(`Client state not found, clientID: ${clientID}`);
     this._fireOnClientStateNotFound(clientID);
   }

--- a/packages/replicache/src/sync/mod.ts
+++ b/packages/replicache/src/sync/mod.ts
@@ -1,13 +1,12 @@
-export type {ClientID, ClientGroupID} from './ids.js';
+export {DiffsMap, addDiffsForIndexes, diff, diffCommits} from './diff.js';
+export type {DiffComputationConfig} from './diff.js';
 export {
-  maybeEndPull,
   beginPullV1 as beginPullDD31,
   beginPullV0 as beginPullSDD,
   handlePullResponseV1 as handlePullResponseDD31,
   handlePullResponseV0 as handlePullResponseSDD,
+  maybeEndPull,
 } from './pull.js';
 export {push} from './push.js';
 export {newRequestID} from './request-id.js';
 export {SYNC_HEAD_NAME} from './sync-head-name.js';
-export {DiffsMap, diff, diffCommits, addDiffsForIndexes} from './diff.js';
-export type {DiffComputationConfig} from './diff.js';

--- a/packages/replicache/src/sync/test-helpers.ts
+++ b/packages/replicache/src/sync/test-helpers.ts
@@ -1,10 +1,11 @@
 import {expect} from '@esm-bundle/chai';
-import type {Chain} from '../db/test-helpers.js';
 import type * as dag from '../dag/mod.js';
-import * as db from '../db/mod.js';
-import * as sync from '../sync/mod.js';
 import {commitIsSnapshot} from '../db/commit.js';
+import * as db from '../db/mod.js';
+import type {Chain} from '../db/test-helpers.js';
+import * as sync from '../sync/mod.js';
 import {withRead, withWrite} from '../with-transactions.js';
+import type {ClientID} from './ids.js';
 
 // See db.test_helpers for addLocal, addSnapshot, etc. We can't put addLocalRebase
 // there because sync depends on db, and addLocalRebase depends on sync.
@@ -18,7 +19,7 @@ export async function addSyncSnapshot(
   chain: Chain,
   store: dag.Store,
   takeIndexesFrom: number,
-  clientID: sync.ClientID,
+  clientID: ClientID,
   dd31: boolean,
 ): Promise<Chain> {
   expect(chain.length >= 2).to.be.true;


### PR DESCRIPTION
This is in preparation for another commit which caused import cycles due to mod.ts pulling in unrelated things.