### PR TITLE
fix: avoid testing all routes in dispatch() by returning on the first match

### DIFF
--- a/packages/reflect-server/src/server/router.ts
+++ b/packages/reflect-server/src/server/router.ts
@@ -63,9 +63,8 @@ export class Router<InitialContext extends BaseContext = BaseContext> {
       const result = pattern.exec(request.url);
       if (result) {
         const {handler} = route;
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         return handler(
-          {...context, parsedURL: result!} as InitialContext,
+          {...context, parsedURL: result} as InitialContext,
           request,
         );
       }


### PR DESCRIPTION
Given that this is a pure refactoring with no new functionality, I didn't add any tests. However, I verified that the existing tests cover the functionality (by breaking it and confirming that tests fail), and that they pass after the refactoring.