### PR TITLE
Restore previous behavior of keeping pending writes after flush

### DIFF
--- a/packages/reflect-server/src/storage/entry-cache.test.ts
+++ b/packages/reflect-server/src/storage/entry-cache.test.ts
@@ -261,7 +261,7 @@ describe('entry-cache', () => {
       );
 
       await cache.flush();
-      expect(cache.isDirty()).toBe(false);
+      // expect(cache.isDirty()).toBe(false);
 
       const durableEntriesAfterFlush = [
         ...(await durable.list(c.opts || {}, valita.string())),

--- a/packages/reflect-server/src/storage/entry-cache.ts
+++ b/packages/reflect-server/src/storage/entry-cache.ts
@@ -88,7 +88,9 @@ export class EntryCache implements Storage {
         }),
     );
 
-    this._cache.clear();
+    // TODO: Add flushed(): Patch method to replace the current use of pending().
+    // Then the cache can be cleared here.
+    // this._cache.clear();
   }
 
   async list<T extends ReadonlyJSONValue>(


### PR DESCRIPTION
I was wrong about our existing uses of EntryCache.

Current code queries "pending()" after the cache has been flushed in order to determine the mutations that were flushed.

For now, I've restored the previous behavior to unbreak things.

Next, I'll add tests that would have caught the breakage in functionality, and then add a `flushed(): Patch` method to replace the current use of `pending()`.