### PR TITLE
Revert "feat: #438 canary request (#475)"

### DIFF
--- a/packages/reflect-server/src/server/paths.ts
+++ b/packages/reflect-server/src/server/paths.ts
@@ -1,5 +1,4 @@
 export const REPORT_METRICS_PATH = '/api/metrics/v0/report';
-export const CANARY_PATH = '/api/canary';
 
 export const CONNECT_URL_PATTERN = '/api/sync/:version/connect';
 export const LEGACY_CONNECT_PATH = '/connect';

--- a/packages/reflect-server/src/server/worker.test.ts
+++ b/packages/reflect-server/src/server/worker.test.ts
@@ -10,7 +10,7 @@ import {
   TestDurableObjectId,
   TestDurableObjectStub,
 } from './do-test-utils.js';
-import {CANARY_PATH, REPORT_METRICS_PATH} from './paths.js';
+import {REPORT_METRICS_PATH} from './paths.js';
 import {BaseWorkerEnv, createWorker} from './worker.js';
 
 const TEST_AUTH_API_KEY = 'TEST_REFLECT_AUTH_API_KEY_TEST';
@@ -578,58 +578,6 @@ test('reportMetrics', async () => {
     } else {
       expect(fetchSpy).not.toHaveBeenCalled();
     }
-
-    jest.resetAllMocks();
-  }
-});
-
-test('canary', async () => {
-  const canaryURL = new URL(CANARY_PATH, 'https://test.roci.dev/');
-  type TestCase = {
-    name: string;
-    method: string;
-    expectedStatus: number;
-  };
-  const testCases: TestCase[] = [
-    {
-      name: 'good request',
-      method: 'get',
-      expectedStatus: 200,
-    },
-    {
-      name: 'bad method',
-      method: 'post',
-      expectedStatus: 405,
-    },
-  ];
-  for (const tc of testCases) {
-    await testCanary(tc);
-  }
-
-  async function testCanary(tc: TestCase) {
-    const testEnv: BaseWorkerEnv = {
-      authDO: {
-        ...createTestDurableObjectNamespace(),
-      },
-    };
-
-    const worker = createWorker(() => ({
-      logSink: new TestLogSink(),
-      logLevel: 'error',
-    }));
-
-    const testRequest = new Request(canaryURL.toString(), {
-      method: tc.method,
-    });
-    if (worker.fetch === undefined) {
-      throw new Error('Expect fetch to be defined');
-    }
-    const response = await worker.fetch(
-      testRequest,
-      testEnv,
-      new TestExecutionContext(),
-    );
-    expect(response.status).toBe(tc.expectedStatus);
 
     jest.resetAllMocks();
   }

--- a/packages/reflect-server/src/server/worker.ts
+++ b/packages/reflect-server/src/server/worker.ts
@@ -7,11 +7,10 @@ import {
   AUTH_ROUTES_AUTHED_BY_API_KEY,
   AUTH_ROUTES_AUTHED_BY_AUTH_HANDLER,
 } from './auth-do.js';
-import {CANARY_PATH, REPORT_METRICS_PATH} from './paths.js';
+import {REPORT_METRICS_PATH} from './paths.js';
 import {
   BaseContext,
   checkAuthAPIKey,
-  get,
   Handler,
   post,
   Router,
@@ -103,8 +102,6 @@ const reportMetrics = post<WorkerContext, Response>(
     return new Response('ok');
   }),
 );
-
-const canary = get<WorkerContext, Response>(() => new Response('ok'));
 
 function requireAPIKeyMatchesEnv(next: Handler<WorkerContext, Response>) {
   return (ctx: WorkerContext, req: Request) => {
@@ -292,5 +289,4 @@ async function sendToAuthDO(
 
 export const WORKER_ROUTES = {
   [REPORT_METRICS_PATH]: reportMetrics,
-  [CANARY_PATH]: canary,
 } as const;

--- a/packages/reflect/src/client/metrics.test.ts
+++ b/packages/reflect/src/client/metrics.test.ts
@@ -19,7 +19,6 @@ test('Gauge', () => {
   type Case = {
     name: string;
     value: number | undefined;
-    tags: string[];
     time: number;
     expected: Point[];
   };
@@ -30,21 +29,18 @@ test('Gauge', () => {
       value: undefined,
       time: 100 * 1000,
       expected: [],
-      tags: [],
     },
     {
       name: 'val-10',
       value: 10,
       time: 200 * 1000,
       expected: [[200, [10]]],
-      tags: ['tag'],
     },
     {
       name: 'val-20',
       value: 20,
       time: 500 * 1000,
       expected: [[500, [20]]],
-      tags: ['tag1', 'tag2'],
     },
   ];
 
@@ -54,14 +50,10 @@ test('Gauge', () => {
   for (const c of cases) {
     clock.setSystemTime(c.time);
     if (c.value !== undefined) {
-      g.set(c.value, c.tags);
+      g.set(c.value);
     }
     const series = g.flush();
-    expect(series, c.name).deep.equal({
-      metric: 'mygauge',
-      points: c.expected,
-      tags: c.tags,
-    });
+    expect(series, c.name).deep.equal({metric: 'mygauge', points: c.expected});
   }
 });
 
@@ -87,7 +79,6 @@ test('State', () => {
       expected: {
         metric: 'mygauge_foo',
         points: [[200, [1]]],
-        tags: [],
       },
     },
     {
@@ -97,7 +88,6 @@ test('State', () => {
       expected: {
         metric: 'mygauge_bar',
         points: [[500, [1]]],
-        tags: [],
       },
     },
   ];

--- a/packages/reflect/src/client/reflect.ts
+++ b/packages/reflect/src/client/reflect.ts
@@ -61,11 +61,6 @@ export const enum ConnectionState {
 
 export const RUN_LOOP_INTERVAL_MS = 5_000;
 
-type CanaryResultTagType =
-  | 'canary:success'
-  | 'canary:failure'
-  | 'canary:timeout';
-
 type ClientDisconnectReason =
   | 'AbruptClose'
   | 'CleanClose'
@@ -589,47 +584,6 @@ export class Reflect<MD extends MutatorDefs> {
     this._connectResolver.resolve();
   }
 
-  private async _fetchCanary(l: LogContext): Promise<CanaryResultTagType> {
-    const canaryUrl = this._socketOrigin.replace(/^ws/, 'http') + 'api/canary';
-
-    function fetchTimeout(
-      url: string,
-      ms: number,
-    ): Promise<Response | 'canary:timeout'> {
-      const controller = new AbortController();
-      const {signal} = controller;
-      const fetchPromise = fetch(url, {method: 'GET', signal});
-
-      const timeoutPromise = (async (): Promise<'canary:timeout'> => {
-        await sleep(ms);
-        controller.abort();
-        return 'canary:timeout';
-      })();
-
-      return Promise.race([fetchPromise, timeoutPromise]);
-    }
-    try {
-      const result = await fetchTimeout(canaryUrl, CONNECT_TIMEOUT_MS);
-      if (result === 'canary:timeout') {
-        l.debug?.('timeout from canary');
-        return result;
-      }
-      const response = result;
-      if (response.ok) {
-        l.debug?.('200 response from canary');
-        return 'canary:success';
-      }
-      l.debug?.('non-200 response from canary', {
-        status: response.status,
-        statusText: response.statusText,
-      });
-      return 'canary:failure';
-    } catch (e) {
-      l.debug?.('error from canary', e);
-      return 'canary:failure';
-    }
-  }
-
   /**
    * Starts a new connection. This will create the WebSocket that does the HTTP
    * request to the server.
@@ -718,27 +672,11 @@ export class Reflect<MD extends MutatorDefs> {
           );
           // this._connectingStart reset below.
         }
+
         break;
       }
       case ConnectionState.Connecting: {
-        if (
-          'client' in reason &&
-          (reason.client === 'ConnectTimeout' ||
-            reason.client === 'AbruptClose' ||
-            reason.client === 'CleanClose')
-        ) {
-          l.debug?.(
-            'Failed to connect using websocket. Checking state of server using a canary request',
-          );
-          const tag = await this._fetchCanary(l);
-          l.debug?.('Canary result: ', tag);
-          this._metrics.lastConnectError.set(
-            getLastConnectMetricState(reason),
-            [tag],
-          );
-        } else {
-          this._metrics.lastConnectError.set(getLastConnectMetricState(reason));
-        }
+        this._metrics.lastConnectError.set(getLastConnectMetricState(reason));
         if (this._connectingStart === undefined) {
           l.error?.(
             'disconnect() called while connecting but connect start time is undefined. This should not happen.',


### PR DESCRIPTION
This reverts commit 9bc0e039ee8869adebbefe4ac39d3e0520228e39.

We don't need this anymore because the metrics ping serves same purpose.