### PR TITLE
chore: Use format version instead of dd31

### DIFF
--- a/packages/replicache/src/db/read.test.ts
+++ b/packages/replicache/src/db/read.test.ts
@@ -1,17 +1,28 @@
-import {LogContext} from '@rocicorp/logger';
 import {expect} from '@esm-bundle/chai';
+import {LogContext} from '@rocicorp/logger';
 import * as dag from '../dag/mod.js';
+import {
+  REPLICACHE_FORMAT_VERSION,
+  REPLICACHE_FORMAT_VERSION_SDD,
+  ReplicacheFormatVersion,
+} from '../format-version.js';
 import {DEFAULT_HEAD_NAME} from './commit.js';
 import {fromWhence, whenceHead} from './read.js';
-import {newWriteLocal} from './write.js';
 import {initDB} from './test-helpers.js';
+import {newWriteLocal} from './write.js';
 
 suite('basics', () => {
-  const t = async (dd31: boolean) => {
+  const t = async (replicacheFormatVersion: ReplicacheFormatVersion) => {
     const clientID = 'client-id';
     const ds = new dag.TestStore();
     const lc = new LogContext();
-    await initDB(await ds.write(), DEFAULT_HEAD_NAME, clientID, {}, dd31);
+    await initDB(
+      await ds.write(),
+      DEFAULT_HEAD_NAME,
+      clientID,
+      {},
+      replicacheFormatVersion,
+    );
     const w = await newWriteLocal(
       whenceHead(DEFAULT_HEAD_NAME),
       'mutator_name',
@@ -20,7 +31,7 @@ suite('basics', () => {
       await ds.write(),
       42,
       clientID,
-      dd31,
+      replicacheFormatVersion,
     );
     await w.put(lc, 'foo', 'bar');
     await w.commit(DEFAULT_HEAD_NAME);
@@ -30,6 +41,6 @@ suite('basics', () => {
     const val = await r.get('foo');
     expect(val).to.deep.equal('bar');
   };
-  test('dd31', () => t(true));
-  test('sdd', () => t(false));
+  test('dd31', () => t(REPLICACHE_FORMAT_VERSION));
+  test('sdd', () => t(REPLICACHE_FORMAT_VERSION_SDD));
 });

--- a/packages/replicache/src/db/rebase.ts
+++ b/packages/replicache/src/db/rebase.ts
@@ -1,21 +1,26 @@
 import type {LogContext} from '@rocicorp/logger';
 import {assert} from 'shared/asserts.js';
 import type * as dag from '../dag/mod.js';
+import {
+  REPLICACHE_FORMAT_VERSION_DD31,
+  ReplicacheFormatVersion,
+} from '../format-version.js';
 import type {Hash} from '../hash.js';
 import type {MutatorDefs} from '../replicache.js';
 import type {ClientID} from '../sync/ids.js';
 import {WriteTransactionImpl} from '../transactions.js';
 import {
   Commit,
-  fromHash,
-  isLocalMetaDD31,
   LocalMeta,
   LocalMetaDD31,
   LocalMetaSDD,
   Meta,
+  assertLocalMetaDD31,
+  fromHash,
+  isLocalMetaDD31,
 } from './commit.js';
 import {whenceHash} from './read.js';
-import {newWriteLocal, Write} from './write.js';
+import {Write, newWriteLocal} from './write.js';
 
 async function rebaseMutation(
   mutation: Commit<LocalMetaDD31 | LocalMetaSDD>,
@@ -24,11 +29,11 @@ async function rebaseMutation(
   mutators: MutatorDefs,
   lc: LogContext,
   mutationClientID: ClientID,
+  replicacheFormatVersion: ReplicacheFormatVersion,
 ): Promise<Write> {
   const localMeta = mutation.meta;
   const name = localMeta.mutatorName;
-  const dd31 = isLocalMetaDD31(localMeta);
-  if (dd31) {
+  if (isLocalMetaDD31(localMeta)) {
     assert(
       localMeta.clientID === mutationClientID,
       'mutationClientID must match clientID of LocalMeta',
@@ -65,6 +70,10 @@ async function rebaseMutation(
     );
   }
 
+  if (replicacheFormatVersion >= REPLICACHE_FORMAT_VERSION_DD31) {
+    assertLocalMetaDD31(localMeta);
+  }
+
   const dbWrite = await newWriteLocal(
     whenceHash(basis),
     name,
@@ -73,7 +82,7 @@ async function rebaseMutation(
     dagWrite,
     localMeta.timestamp,
     mutationClientID,
-    dd31,
+    replicacheFormatVersion,
   );
 
   const tx = new WriteTransactionImpl(
@@ -96,6 +105,7 @@ export async function rebaseMutationAndPutCommit(
   // TODO(greg): mutationClientID can be retrieved from mutation if LocalMeta
   // is a LocalMetaDD31.  As part of DD31 cleanup we can remove this arg.
   mutationClientID: ClientID,
+  replicacheFormatVersion: ReplicacheFormatVersion,
 ): Promise<Commit<Meta>> {
   const tx = await rebaseMutation(
     mutation,
@@ -104,6 +114,7 @@ export async function rebaseMutationAndPutCommit(
     mutators,
     lc,
     mutationClientID,
+    replicacheFormatVersion,
   );
   return tx.putCommit();
 }
@@ -118,6 +129,7 @@ export async function rebaseMutationAndCommit(
   // TODO(greg): mutationClientID can be retrieved from mutation if LocalMeta
   // is a LocalMetaDD31.  As part of DD31 cleanup we can remove this arg.
   mutationClientID: ClientID,
+  replicacheFormatVersion: ReplicacheFormatVersion,
 ): Promise<Hash> {
   const dbWrite = await rebaseMutation(
     mutation,
@@ -126,6 +138,7 @@ export async function rebaseMutationAndCommit(
     mutators,
     lc,
     mutationClientID,
+    replicacheFormatVersion,
   );
   return dbWrite.commit(headName);
 }

--- a/packages/replicache/src/db/test-helpers.ts
+++ b/packages/replicache/src/db/test-helpers.ts
@@ -6,6 +6,12 @@ import {BTreeWrite} from '../btree/mod.js';
 import type {Cookie} from '../cookies.js';
 import type * as dag from '../dag/mod.js';
 import {Visitor} from '../dag/visitor.js';
+import {
+  REPLICACHE_FORMAT_VERSION,
+  REPLICACHE_FORMAT_VERSION_DD31,
+  REPLICACHE_FORMAT_VERSION_SDD,
+  ReplicacheFormatVersion,
+} from '../format-version.js';
 import {Hash, emptyHash} from '../hash.js';
 import type {IndexDefinition, IndexDefinitions} from '../index-defs.js';
 import {JSONValue, deepFreeze} from '../json.js';
@@ -55,7 +61,7 @@ async function addGenesis(
   clientID: ClientID,
   headName = DEFAULT_HEAD_NAME,
   indexDefinitions: IndexDefinitions,
-  dd31: boolean,
+  replicacheFormatVersion: ReplicacheFormatVersion,
 ): Promise<Chain> {
   expect(chain).to.have.length(0);
   const commit = await createGenesis(
@@ -63,7 +69,7 @@ async function addGenesis(
     clientID,
     headName,
     indexDefinitions,
-    dd31,
+    replicacheFormatVersion,
   );
   chain.push(commit);
   return chain;
@@ -74,10 +80,16 @@ async function createGenesis(
   clientID: ClientID,
   headName: string,
   indexDefinitions: IndexDefinitions,
-  dd31: boolean,
+  replicacheFormatVersion: ReplicacheFormatVersion,
 ): Promise<Commit<Meta>> {
   await withWrite(store, async w => {
-    await initDB(w, headName, clientID, indexDefinitions, dd31);
+    await initDB(
+      w,
+      headName,
+      clientID,
+      indexDefinitions,
+      replicacheFormatVersion,
+    );
   });
   return withRead(store, async read => {
     const [, commit] = await readCommit(whenceHead(headName), read);
@@ -93,7 +105,7 @@ async function addLocal(
   clientID: ClientID,
   entries: [string, JSONValue][] | undefined,
   headName: string,
-  dd31: boolean,
+  replicacheFormatVersion: ReplicacheFormatVersion,
 ): Promise<Chain> {
   expect(chain).to.have.length.greaterThan(0);
   const i = chain.length;
@@ -103,7 +115,7 @@ async function addLocal(
     i,
     clientID,
     headName,
-    dd31,
+    replicacheFormatVersion,
   );
 
   chain.push(commit);
@@ -116,7 +128,7 @@ async function createLocal(
   i: number,
   clientID: ClientID,
   headName: string,
-  dd31: boolean,
+  replicacheFormatVersion: ReplicacheFormatVersion,
 ): Promise<Commit<Meta>> {
   const lc = new LogContext();
   await withWrite(store, async dagWrite => {
@@ -128,7 +140,7 @@ async function createLocal(
       dagWrite,
       42,
       clientID,
-      dd31,
+      replicacheFormatVersion,
     );
     for (const [key, val] of entries) {
       await w.put(lc, key, deepFreeze(val));
@@ -149,7 +161,9 @@ async function addIndexChange(
   indexName: string | undefined,
   indexDefinition: IndexDefinition | undefined,
   headName: string,
+  replicacheFormatVersion: ReplicacheFormatVersion,
 ): Promise<Chain> {
+  assert(replicacheFormatVersion <= REPLICACHE_FORMAT_VERSION_SDD);
   expect(chain).to.have.length.greaterThan(0);
   const i = chain.length;
   const name = indexName ?? `${i}`;
@@ -167,6 +181,7 @@ async function addIndexChange(
     jsonPointer,
     allowEmpty,
     headName,
+    replicacheFormatVersion,
   );
   chain.push(commit);
   return chain;
@@ -180,13 +195,16 @@ async function createIndex(
   jsonPointer: string,
   allowEmpty: boolean,
   headName: string,
+  replicacheFormatVersion: ReplicacheFormatVersion,
 ): Promise<Commit<Meta>> {
+  assert(replicacheFormatVersion <= REPLICACHE_FORMAT_VERSION_SDD);
   const lc = new LogContext();
   await withWrite(store, async dagWrite => {
     const w = await newWriteIndexChange(
       whenceHead(headName),
       dagWrite,
       clientID,
+      replicacheFormatVersion,
     );
     await createIndexForTesting(
       lc,
@@ -218,13 +236,13 @@ async function addSnapshot(
   cookie: Cookie = `cookie_${chain.length}`,
   lastMutationIDs: Record<ClientID, number> | undefined,
   headName: string,
-  dd31: boolean,
+  replicacheFormatVersion: ReplicacheFormatVersion,
 ): Promise<Chain> {
   expect(chain).to.have.length.greaterThan(0);
   const lc = new LogContext();
   await withWrite(store, async dagWrite => {
     let w;
-    if (dd31) {
+    if (replicacheFormatVersion >= REPLICACHE_FORMAT_VERSION_DD31) {
       w = await newWriteSnapshotDD31(
         whenceHead(headName),
         lastMutationIDs ?? {
@@ -236,6 +254,7 @@ async function addSnapshot(
         deepFreeze(cookie),
         dagWrite,
         clientID,
+        replicacheFormatVersion,
       );
     } else {
       w = await newWriteSnapshotSDD(
@@ -245,6 +264,7 @@ async function addSnapshot(
         dagWrite,
         readIndexesForWrite(chain[chain.length - 1], dagWrite),
         clientID,
+        replicacheFormatVersion,
       );
     }
 
@@ -266,13 +286,17 @@ export class ChainBuilder {
   readonly store: dag.Store;
   readonly headName: string;
   chain: Chain;
-  readonly dd31: boolean;
+  readonly replicacheFormatVersion: ReplicacheFormatVersion;
 
-  constructor(store: dag.Store, headName = DEFAULT_HEAD_NAME, dd31 = true) {
+  constructor(
+    store: dag.Store,
+    headName = DEFAULT_HEAD_NAME,
+    replicacheFormatVersion: ReplicacheFormatVersion = REPLICACHE_FORMAT_VERSION,
+  ) {
     this.store = store;
     this.headName = headName;
     this.chain = [];
-    this.dd31 = dd31;
+    this.replicacheFormatVersion = replicacheFormatVersion;
   }
 
   async addGenesis(
@@ -285,11 +309,11 @@ export class ChainBuilder {
       clientID,
       this.headName,
       indexDefinitions,
-      this.dd31,
+      this.replicacheFormatVersion,
     );
     const commit = this.chain.at(-1);
     assertNotUndefined(commit);
-    if (this.dd31) {
+    if (this.replicacheFormatVersion >= REPLICACHE_FORMAT_VERSION_DD31) {
       assertSnapshotCommitDD31(commit);
     } else {
       assertSnapshotCommitSDD(commit);
@@ -307,11 +331,11 @@ export class ChainBuilder {
       clientID,
       entries,
       this.headName,
-      this.dd31,
+      this.replicacheFormatVersion,
     );
     const commit = this.chain.at(-1);
     assertNotUndefined(commit);
-    if (this.dd31) {
+    if (this.replicacheFormatVersion >= REPLICACHE_FORMAT_VERSION_DD31) {
       assertLocalCommitDD31(commit);
     } else {
       assertLocalCommitSDD(commit);
@@ -333,11 +357,11 @@ export class ChainBuilder {
       cookie,
       lastMutationIDs,
       this.headName,
-      this.dd31,
+      this.replicacheFormatVersion,
     );
     const commit = this.chain.at(-1);
     assertNotUndefined(commit);
-    if (this.dd31) {
+    if (this.replicacheFormatVersion >= REPLICACHE_FORMAT_VERSION_DD31) {
       assertSnapshotCommitDD31(commit);
     } else {
       assertSnapshotCommitSDD(commit);
@@ -350,7 +374,7 @@ export class ChainBuilder {
     indexName?: string,
     indexDefinition?: IndexDefinition,
   ): Promise<Commit<Meta>> {
-    assert(!this.dd31);
+    assert(this.replicacheFormatVersion <= REPLICACHE_FORMAT_VERSION_SDD);
     await addIndexChange(
       this.chain,
       this.store,
@@ -358,6 +382,7 @@ export class ChainBuilder {
       indexName,
       indexDefinition,
       this.headName,
+      this.replicacheFormatVersion,
     );
     const commit = this.chain.at(-1);
     assertNotUndefined(commit);
@@ -371,7 +396,7 @@ export class ChainBuilder {
       this.store,
       takeIndexesFrom,
       clientID,
-      this.dd31,
+      this.replicacheFormatVersion,
     );
   }
 
@@ -394,23 +419,24 @@ export async function initDB(
   headName: string,
   clientID: ClientID,
   indexDefinitions: IndexDefinitions,
-  dd31: boolean,
+  replicacheFormatVersion: ReplicacheFormatVersion,
 ): Promise<Hash> {
   const basisHash = emptyHash;
   const indexes = await createEmptyIndexMaps(indexDefinitions, dagWrite);
-  const meta = dd31
-    ? ({
-        basisHash,
-        type: MetaType.SnapshotDD31,
-        lastMutationIDs: {},
-        cookieJSON: null,
-      } as const)
-    : ({
-        basisHash,
-        type: MetaType.SnapshotSDD,
-        lastMutationID: 0,
-        cookieJSON: null,
-      } as const);
+  const meta =
+    replicacheFormatVersion >= REPLICACHE_FORMAT_VERSION_DD31
+      ? ({
+          basisHash,
+          type: MetaType.SnapshotDD31,
+          lastMutationIDs: {},
+          cookieJSON: null,
+        } as const)
+      : ({
+          basisHash,
+          type: MetaType.SnapshotSDD,
+          lastMutationID: 0,
+          cookieJSON: null,
+        } as const);
 
   const w = new Write(
     dagWrite,
@@ -419,7 +445,8 @@ export async function initDB(
     meta,
     indexes,
     clientID,
-    dd31,
+    // TODO(arv): Pass format here too
+    replicacheFormatVersion,
   );
   return w.commit(headName);
 }
@@ -473,7 +500,9 @@ async function newWriteIndexChange(
   whence: Whence,
   dagWrite: dag.Write,
   clientID: ClientID,
+  replicacheFormatVersion: ReplicacheFormatVersion,
 ): Promise<Write> {
+  assert(replicacheFormatVersion <= REPLICACHE_FORMAT_VERSION_SDD);
   const [basisHash, basis, bTreeWrite] = await readCommitForBTreeWrite(
     whence,
     dagWrite,
@@ -487,7 +516,7 @@ async function newWriteIndexChange(
     {basisHash, type: MetaType.IndexChangeSDD, lastMutationID},
     indexes,
     clientID,
-    false,
+    replicacheFormatVersion,
   );
 }
 

--- a/packages/replicache/src/db/write.test.ts
+++ b/packages/replicache/src/db/write.test.ts
@@ -1,7 +1,14 @@
-import {LogContext} from '@rocicorp/logger';
 import {expect} from '@esm-bundle/chai';
+import {LogContext} from '@rocicorp/logger';
 import {assertNotUndefined} from 'shared/asserts.js';
+import {asyncIterableToArray} from '../async-iterable-to-array.js';
 import * as dag from '../dag/mod.js';
+import {
+  REPLICACHE_FORMAT_VERSION,
+  REPLICACHE_FORMAT_VERSION_SDD,
+  ReplicacheFormatVersion,
+} from '../format-version.js';
+import {withRead, withWrite} from '../with-transactions.js';
 import {DEFAULT_HEAD_NAME} from './commit.js';
 import {
   readCommitForBTreeRead,
@@ -9,17 +16,21 @@ import {
   whenceHash,
   whenceHead,
 } from './read.js';
-import {newWriteLocal} from './write.js';
-import {asyncIterableToArray} from '../async-iterable-to-array.js';
 import {initDB} from './test-helpers.js';
-import {withRead, withWrite} from '../with-transactions.js';
+import {newWriteLocal} from './write.js';
 
 suite('basics w/ commit', () => {
-  const t = async (dd31: boolean) => {
+  const t = async (replicacheFormatVersion: ReplicacheFormatVersion) => {
     const clientID = 'client-id';
     const ds = new dag.TestStore();
     const lc = new LogContext();
-    await initDB(await ds.write(), DEFAULT_HEAD_NAME, clientID, {}, dd31);
+    await initDB(
+      await ds.write(),
+      DEFAULT_HEAD_NAME,
+      clientID,
+      {},
+      replicacheFormatVersion,
+    );
 
     // Put.
     await withWrite(ds, async dagWrite => {
@@ -31,7 +42,7 @@ suite('basics w/ commit', () => {
         dagWrite,
         42,
         clientID,
-        dd31,
+        replicacheFormatVersion,
       );
       await w.put(lc, 'foo', 'bar');
       // Assert we can read the same value from within this transaction.;
@@ -50,7 +61,7 @@ suite('basics w/ commit', () => {
         dagWrite,
         42,
         clientID,
-        dd31,
+        replicacheFormatVersion,
       );
       const val = await w.get('foo');
       expect(val).to.deep.equal('bar');
@@ -66,7 +77,7 @@ suite('basics w/ commit', () => {
         dagWrite,
         42,
         clientID,
-        dd31,
+        replicacheFormatVersion,
       );
       await w.del(lc, 'foo');
       // Assert it is gone while still within this transaction.
@@ -85,23 +96,29 @@ suite('basics w/ commit', () => {
         dagWrite,
         42,
         clientID,
-        dd31,
+        replicacheFormatVersion,
       );
       const val = await w.get(`foo`);
       expect(val).to.be.undefined;
     });
   };
 
-  test('dd31', () => t(true));
-  test('sdd', () => t(false));
+  test('dd31', () => t(REPLICACHE_FORMAT_VERSION));
+  test('sdd', () => t(REPLICACHE_FORMAT_VERSION_SDD));
 });
 
 suite('basics w/ putCommit', () => {
-  const t = async (dd31: boolean) => {
+  const t = async (replicacheFormatVersion: ReplicacheFormatVersion) => {
     const clientID = 'client-id';
     const ds = new dag.TestStore();
     const lc = new LogContext();
-    await initDB(await ds.write(), DEFAULT_HEAD_NAME, clientID, {}, dd31);
+    await initDB(
+      await ds.write(),
+      DEFAULT_HEAD_NAME,
+      clientID,
+      {},
+      replicacheFormatVersion,
+    );
 
     // Put.
     const commit1 = await withWrite(ds, async dagWrite => {
@@ -113,7 +130,7 @@ suite('basics w/ putCommit', () => {
         dagWrite,
         42,
         clientID,
-        dd31,
+        replicacheFormatVersion,
       );
       await w.put(lc, 'foo', 'bar');
       // Assert we can read the same value from within this transaction.;
@@ -135,7 +152,7 @@ suite('basics w/ putCommit', () => {
         dagWrite,
         42,
         clientID,
-        dd31,
+        replicacheFormatVersion,
       );
       const val = await w.get('foo');
       expect(val).to.deep.equal('bar');
@@ -151,7 +168,7 @@ suite('basics w/ putCommit', () => {
         dagWrite,
         42,
         clientID,
-        dd31,
+        replicacheFormatVersion,
       );
       await w.del(lc, 'foo');
       // Assert it is gone while still within this transaction.
@@ -173,14 +190,14 @@ suite('basics w/ putCommit', () => {
         dagWrite,
         42,
         clientID,
-        dd31,
+        replicacheFormatVersion,
       );
       const val = await w.get(`foo`);
       expect(val).to.be.undefined;
     });
   };
-  test('dd31', () => t(true));
-  test('sdd', () => t(false));
+  test('dd31', () => t(REPLICACHE_FORMAT_VERSION));
+  test('sdd', () => t(REPLICACHE_FORMAT_VERSION_SDD));
 });
 
 test('clear', async () => {
@@ -196,7 +213,7 @@ test('clear', async () => {
       {
         idx: {prefix: '', jsonPointer: '', allowEmpty: false},
       },
-      true,
+      REPLICACHE_FORMAT_VERSION,
     ),
   );
   await withWrite(ds, async dagWrite => {
@@ -208,7 +225,7 @@ test('clear', async () => {
       dagWrite,
       42,
       clientID,
-      true,
+      REPLICACHE_FORMAT_VERSION,
     );
     await w.put(lc, 'foo', 'bar');
     await w.commit(DEFAULT_HEAD_NAME);
@@ -223,7 +240,7 @@ test('clear', async () => {
       dagWrite,
       42,
       clientID,
-      true,
+      REPLICACHE_FORMAT_VERSION,
     );
     await w.put(lc, 'hot', 'dog');
 
@@ -279,7 +296,7 @@ test('mutationID on newWriteLocal', async () => {
       {
         idx: {prefix: '', jsonPointer: '', allowEmpty: false},
       },
-      true,
+      REPLICACHE_FORMAT_VERSION,
     ),
   );
   await withWrite(ds, async dagWrite => {
@@ -291,7 +308,7 @@ test('mutationID on newWriteLocal', async () => {
       dagWrite,
       42,
       clientID,
-      true,
+      REPLICACHE_FORMAT_VERSION,
     );
     await w.put(lc, 'foo', 'bar');
     await w.commit(DEFAULT_HEAD_NAME);
@@ -307,7 +324,7 @@ test('mutationID on newWriteLocal', async () => {
       dagWrite,
       42,
       clientID,
-      true,
+      REPLICACHE_FORMAT_VERSION,
     );
     await w.put(lc, 'hot', 'dog');
     await w.commit(DEFAULT_HEAD_NAME);

--- a/packages/replicache/src/format-version.ts
+++ b/packages/replicache/src/format-version.ts
@@ -15,8 +15,11 @@ export type ReplicacheFormatVersion =
 export function parseReplicacheFormatVersion(
   v: number,
 ): ReplicacheFormatVersion {
-  v = v | 0;
-  if (v < REPLICACHE_FORMAT_VERSION_SDD || v > REPLICACHE_FORMAT_VERSION) {
+  if (
+    v !== (v | 0) ||
+    v < REPLICACHE_FORMAT_VERSION_SDD ||
+    v > REPLICACHE_FORMAT_VERSION
+  ) {
     throw new Error(`Unsupported format version: ${v}`);
   }
   return v as ReplicacheFormatVersion;

--- a/packages/replicache/src/mutation-recovery.ts
+++ b/packages/replicache/src/mutation-recovery.ts
@@ -10,6 +10,8 @@ import {
   REPLICACHE_FORMAT_VERSION_DD31,
   REPLICACHE_FORMAT_VERSION_SDD,
   REPLICACHE_FORMAT_VERSION_V6,
+  ReplicacheFormatVersion,
+  parseReplicacheFormatVersion,
 } from './format-version.js';
 import {assertHash} from './hash.js';
 import type {HTTPRequestInfo} from './http-request-info.js';
@@ -168,6 +170,7 @@ async function recoverMutationsOfClientV4(
   perdag: dag.Store,
   database: persist.IndexedDBDatabase,
   options: MutationRecoveryOptions,
+  replicacheFormatVersion: ReplicacheFormatVersion,
 ): Promise<persist.ClientMap | undefined> {
   assert(database.replicacheFormatVersion === REPLICACHE_FORMAT_VERSION_SDD);
   assertClientV4(client);
@@ -266,6 +269,7 @@ async function recoverMutationsOfClientV4(
             puller,
             requestID,
             dagForOtherClient,
+            replicacheFormatVersion,
             requestLc,
             false,
           );
@@ -409,6 +413,9 @@ async function recoverMutationsFromPerdagSDD(
   const stepDescription = `Recovering mutations from db ${database.name}.`;
   lc.debug?.('Start:', stepDescription);
   try {
+    const replicacheFormatVersion = parseReplicacheFormatVersion(
+      database.replicacheFormatVersion,
+    );
     let clientMap: persist.ClientMap | undefined =
       preReadClientMap ||
       (await withRead(perdag, read => persist.getClients(read)));
@@ -428,6 +435,7 @@ async function recoverMutationsFromPerdagSDD(
             perdag,
             database,
             options,
+            replicacheFormatVersion,
           );
           if (newClientMap) {
             break;
@@ -451,6 +459,9 @@ async function recoverMutationsFromPerdagDD31(
   const stepDescription = `Recovering mutations from db ${database.name}.`;
   lc.debug?.('Start:', stepDescription);
   try {
+    const replicacheFormatVersion = parseReplicacheFormatVersion(
+      database.replicacheFormatVersion,
+    );
     let clientGroups: persist.ClientGroupMap | undefined = await withRead(
       perdag,
       read => persist.getClientGroups(read),
@@ -471,6 +482,7 @@ async function recoverMutationsFromPerdagDD31(
             perdag,
             database,
             options,
+            replicacheFormatVersion,
           );
           if (newClientGroups) {
             break;
@@ -496,6 +508,7 @@ async function recoverMutationsOfClientGroupDD31(
   perdag: dag.Store,
   database: persist.IndexedDBDatabase,
   options: MutationRecoveryOptions,
+  replicacheFormatVersion: ReplicacheFormatVersion,
 ): Promise<persist.ClientGroupMap | undefined> {
   assert(database.replicacheFormatVersion >= REPLICACHE_FORMAT_VERSION_DD31);
 
@@ -636,6 +649,7 @@ async function recoverMutationsOfClientGroupDD31(
             puller,
             requestID,
             dagForOtherClientGroup,
+            replicacheFormatVersion,
             requestLc,
             false,
           );

--- a/packages/replicache/src/persist/clients-test-helpers.ts
+++ b/packages/replicache/src/persist/clients-test-helpers.ts
@@ -4,6 +4,10 @@ import * as btree from '../btree/mod.js';
 import * as dag from '../dag/mod.js';
 import {getRefs, newSnapshotCommitDataSDD} from '../db/commit.js';
 import * as db from '../db/mod.js';
+import {
+  REPLICACHE_FORMAT_VERSION_DD31,
+  ReplicacheFormatVersion,
+} from '../format-version.js';
 import {newUUIDHash} from '../hash.js';
 import type {IndexDefinitions} from '../index-defs.js';
 import type {ClientID} from '../sync/ids.js';
@@ -95,10 +99,10 @@ export async function initClientWithClientID(
   dagStore: dag.Store,
   mutatorNames: string[],
   indexes: IndexDefinitions,
-  dd31: boolean,
+  replicacheFormatVersion: ReplicacheFormatVersion,
 ): Promise<void> {
   let generatedClientID, client, clientMap;
-  if (dd31) {
+  if (replicacheFormatVersion >= REPLICACHE_FORMAT_VERSION_DD31) {
     [generatedClientID, client, , clientMap] = await initClientV6(
       new LogContext(),
       dagStore,

--- a/packages/replicache/src/persist/gather-mem-only-visitor.test.ts
+++ b/packages/replicache/src/persist/gather-mem-only-visitor.test.ts
@@ -4,12 +4,18 @@ import {TestLazyStore} from '../dag/test-lazy-store.js';
 import {MetaType} from '../db/commit.js';
 import * as db from '../db/mod.js';
 import {ChainBuilder} from '../db/test-helpers.js';
+import {
+  REPLICACHE_FORMAT_VERSION,
+  REPLICACHE_FORMAT_VERSION_DD31,
+  REPLICACHE_FORMAT_VERSION_SDD,
+  ReplicacheFormatVersion,
+} from '../format-version.js';
 import {assertHash, makeNewFakeHashFunction} from '../hash.js';
 import {withRead, withWrite} from '../with-transactions.js';
 import {GatherMemoryOnlyVisitor} from './gather-mem-only-visitor.js';
 
 suite('dag with no memory-only hashes gathers nothing', () => {
-  const t = async (dd31: boolean) => {
+  const t = async (replicacheFormatVersion: ReplicacheFormatVersion) => {
     const clientID = 'client-id';
     const hashFunction = makeNewFakeHashFunction();
     const perdag = new dag.TestStore(undefined, hashFunction);
@@ -20,10 +26,10 @@ suite('dag with no memory-only hashes gathers nothing', () => {
       assertHash,
     );
 
-    const pb = new ChainBuilder(perdag, undefined, dd31);
+    const pb = new ChainBuilder(perdag, undefined, replicacheFormatVersion);
     await pb.addGenesis(clientID);
     await pb.addLocal(clientID);
-    if (!dd31) {
+    if (replicacheFormatVersion <= REPLICACHE_FORMAT_VERSION_SDD) {
       await pb.addIndexChange(clientID);
     }
     await pb.addLocal(clientID);
@@ -45,12 +51,12 @@ suite('dag with no memory-only hashes gathers nothing', () => {
     });
   };
 
-  test('dd31', () => t(true));
-  test('sdd', () => t(false));
+  test('dd31', () => t(REPLICACHE_FORMAT_VERSION));
+  test('sdd', () => t(REPLICACHE_FORMAT_VERSION_SDD));
 });
 
 suite('dag with only memory-only hashes gathers everything', () => {
-  const t = async (dd31: boolean) => {
+  const t = async (replicacheFormatVersion: ReplicacheFormatVersion) => {
     const clientID = 'client-id';
     const hashFunction = makeNewFakeHashFunction();
     const perdag = new dag.TestStore(undefined, hashFunction);
@@ -61,7 +67,7 @@ suite('dag with only memory-only hashes gathers everything', () => {
       assertHash,
     );
 
-    const mb = new ChainBuilder(memdag, undefined, dd31);
+    const mb = new ChainBuilder(memdag, undefined, replicacheFormatVersion);
 
     const testGatheredChunks = async () => {
       await withRead(memdag, async dagRead => {
@@ -79,7 +85,7 @@ suite('dag with only memory-only hashes gathers everything', () => {
 
     await mb.addLocal(clientID);
     await testGatheredChunks();
-    if (!dd31) {
+    if (replicacheFormatVersion <= REPLICACHE_FORMAT_VERSION_SDD) {
       await mb.addIndexChange(clientID);
     }
 
@@ -87,14 +93,14 @@ suite('dag with only memory-only hashes gathers everything', () => {
     await testGatheredChunks();
   };
 
-  test('dd31', () => t(true));
-  test('sdd', () => t(false));
+  test('dd31', () => t(REPLICACHE_FORMAT_VERSION));
+  test('sdd', () => t(REPLICACHE_FORMAT_VERSION_SDD));
 });
 
 suite(
   'dag with some persisted hashes and some memory-only hashes on top',
   () => {
-    const t = async (dd31: boolean) => {
+    const t = async (replicacheFormatVersion: ReplicacheFormatVersion) => {
       const clientID = 'client-id';
       const hashFunction = makeNewFakeHashFunction();
       const perdag = new dag.TestStore(undefined, hashFunction);
@@ -105,8 +111,8 @@ suite(
         assertHash,
       );
 
-      const pb = new ChainBuilder(perdag, undefined, dd31);
-      const mb = new ChainBuilder(memdag, undefined, dd31);
+      const pb = new ChainBuilder(perdag, undefined, replicacheFormatVersion);
+      const mb = new ChainBuilder(memdag, undefined, replicacheFormatVersion);
 
       await pb.addGenesis(clientID);
       await pb.addLocal(clientID);
@@ -129,15 +135,16 @@ suite(
           originalHash: null,
           timestamp: 42,
         };
-        const meta = dd31
-          ? {
-              type: MetaType.LocalDD31,
-              ...metaBase,
-              baseSnapshotHash:
-                'face0000000040008000000000000000' + '' + '000000000001',
-              clientID,
-            }
-          : {type: MetaType.LocalSDD, ...metaBase};
+        const meta =
+          replicacheFormatVersion >= REPLICACHE_FORMAT_VERSION_DD31
+            ? {
+                type: MetaType.LocalDD31,
+                ...metaBase,
+                baseSnapshotHash:
+                  'face0000000040008000000000000000' + '' + '000000000001',
+                clientID,
+              }
+            : {type: MetaType.LocalSDD, ...metaBase};
         expect(Object.fromEntries(visitor.gatheredChunks)).to.deep.equal({
           ['face0000000040008000000000000000' + '' + '000000000004']: {
             data: [0, [['local', '2']]],
@@ -160,15 +167,15 @@ suite(
         });
       });
     };
-    test('dd31', () => t(true));
-    test('sdd', () => t(false));
+    test('dd31', () => t(REPLICACHE_FORMAT_VERSION));
+    test('sdd', () => t(REPLICACHE_FORMAT_VERSION_SDD));
   },
 );
 
 suite(
   'dag with some permanent hashes and some memory-only hashes on top w index',
   () => {
-    const t = async (dd31: boolean) => {
+    const t = async (replicacheFormatVersion: ReplicacheFormatVersion) => {
       const clientID = 'client-id';
       const hashFunction = makeNewFakeHashFunction();
       const perdag = new dag.TestStore(undefined, hashFunction);
@@ -179,8 +186,8 @@ suite(
         assertHash,
       );
 
-      const mb = new ChainBuilder(memdag, undefined, dd31);
-      const pb = new ChainBuilder(perdag, undefined, dd31);
+      const mb = new ChainBuilder(memdag, undefined, replicacheFormatVersion);
+      const pb = new ChainBuilder(perdag, undefined, replicacheFormatVersion);
 
       await pb.addGenesis(clientID, {
         testIndex: {prefix: '', jsonPointer: '/name', allowEmpty: true},
@@ -201,7 +208,7 @@ suite(
       });
 
       mb.chain = pb.chain.slice();
-      if (!dd31) {
+      if (replicacheFormatVersion <= REPLICACHE_FORMAT_VERSION_SDD) {
         await mb.addIndexChange(clientID, 'testIndex', {
           prefix: '',
           jsonPointer: '/name',
@@ -214,7 +221,7 @@ suite(
         const visitor = new GatherMemoryOnlyVisitor(dagRead);
         await visitor.visit(mb.headHash);
         expect(Object.fromEntries(visitor.gatheredChunks)).to.deep.equal(
-          dd31
+          replicacheFormatVersion >= REPLICACHE_FORMAT_VERSION_DD31
             ? {
                 ['face0000000040008000000000000000' + '' + '000000000008']: {
                   hash:
@@ -434,7 +441,7 @@ suite(
       });
     };
 
-    test('dd31', () => t(true));
-    test('sdd', () => t(false));
+    test('dd31', () => t(REPLICACHE_FORMAT_VERSION));
+    test('sdd', () => t(REPLICACHE_FORMAT_VERSION_SDD));
   },
 );

--- a/packages/replicache/src/persist/persist.test.ts
+++ b/packages/replicache/src/persist/persist.test.ts
@@ -10,6 +10,7 @@ import {
   createMutatorName,
   getChunkSnapshot,
 } from '../db/test-helpers.js';
+import {REPLICACHE_FORMAT_VERSION} from '../format-version.js';
 import {Hash, assertHash, makeNewFakeHashFunction} from '../hash.js';
 import type {JSONValue} from '../json.js';
 import type {MutatorDefs} from '../replicache.js';
@@ -909,6 +910,7 @@ async function setupPersistTest() {
       perdag,
       mutators,
       () => false,
+      REPLICACHE_FORMAT_VERSION,
       onGatherMemOnlyChunksForTest,
     );
     const persistedChunkHashes: Hash[] = [];

--- a/packages/replicache/src/persist/persist.ts
+++ b/packages/replicache/src/persist/persist.ts
@@ -3,6 +3,7 @@ import {assert} from 'shared/asserts.js';
 import type * as dag from '../dag/mod.js';
 import {assertSnapshotCommitDD31} from '../db/commit.js';
 import * as db from '../db/mod.js';
+import type {ReplicacheFormatVersion} from '../format-version.js';
 import type {Hash} from '../hash.js';
 import type {MutatorDefs} from '../replicache.js';
 import type {ClientGroupID, ClientID} from '../sync/ids.js';
@@ -42,6 +43,7 @@ export async function persistDD31(
   perdag: dag.Store,
   mutators: MutatorDefs,
   closed: () => boolean,
+  replicacheFormatVersion: ReplicacheFormatVersion,
   onGatherMemOnlyChunksForTest = () => Promise.resolve(),
 ): Promise<void> {
   if (closed()) {
@@ -186,6 +188,7 @@ export async function persistDD31(
           mutators,
           mutationIDs,
           lc,
+          replicacheFormatVersion,
         );
       }
     }
@@ -197,6 +200,7 @@ export async function persistDD31(
       mutators,
       mutationIDs,
       lc,
+      replicacheFormatVersion,
     );
 
     const newMainClientGroup = {
@@ -237,6 +241,7 @@ async function rebase(
   mutators: MutatorDefs,
   mutationIDs: Record<ClientID, number>,
   lc: LogContext,
+  replicacheFormatVersion: ReplicacheFormatVersion,
 ): Promise<Hash> {
   for (let i = mutations.length - 1; i >= 0; i--) {
     const mutationCommit = mutations[i];
@@ -255,6 +260,7 @@ async function rebase(
           mutators,
           lc,
           meta.clientID,
+          replicacheFormatVersion,
         )
       ).chunk.hash;
     }

--- a/packages/replicache/src/persist/refresh.test.ts
+++ b/packages/replicache/src/persist/refresh.test.ts
@@ -6,6 +6,7 @@ import type {Cookie} from '../cookies.js';
 import * as dag from '../dag/mod.js';
 import * as db from '../db/mod.js';
 import {ChainBuilder} from '../db/test-helpers.js';
+import {REPLICACHE_FORMAT_VERSION} from '../format-version.js';
 import {Hash, assertHash, fakeHash, makeNewFakeHashFunction} from '../hash.js';
 import {JSONValue, ReadonlyJSONValue, deepFreeze} from '../json.js';
 import {
@@ -152,6 +153,7 @@ function assertRefreshHashes(
 }
 
 suite('refresh', () => {
+  const replicacheFormatVersion = REPLICACHE_FORMAT_VERSION;
   test('identical dags', async () => {
     // If the dags are the same then refresh is a no op.
     const {perdag, memdag} = makeStores();
@@ -169,6 +171,7 @@ suite('refresh', () => {
       mutators,
       testSubscriptionsManagerOptions,
       () => false,
+      replicacheFormatVersion,
     );
     assert(result);
     expect(result[0]).to.deep.equal(
@@ -218,6 +221,7 @@ suite('refresh', () => {
       mutators,
       testSubscriptionsManagerOptions,
       () => false,
+      replicacheFormatVersion,
     );
     assert(result);
     expect(result[0]).to.deep.equal(
@@ -252,6 +256,7 @@ suite('refresh', () => {
       mutators,
       testSubscriptionsManagerOptions,
       () => false,
+      replicacheFormatVersion,
     );
     assert(result);
     expect(result[0]).to.deep.equal(
@@ -300,6 +305,7 @@ suite('refresh', () => {
       mutators,
       testSubscriptionsManagerOptions,
       () => false,
+      replicacheFormatVersion,
     );
     expect(diffs).undefined;
     await assertRefreshHashes(perdag, clientID, client.refreshHashes);
@@ -329,6 +335,7 @@ suite('refresh', () => {
       mutators,
       testSubscriptionsManagerOptions,
       () => false,
+      replicacheFormatVersion,
     );
     expect(diffs).undefined;
     await assertRefreshHashes(perdag, clientID, client.refreshHashes);
@@ -359,6 +366,7 @@ suite('refresh', () => {
       mutators,
       testSubscriptionsManagerOptions,
       () => false,
+      replicacheFormatVersion,
     );
     assert(result);
     expect(result[0]).to.deep.equal(
@@ -424,6 +432,7 @@ suite('refresh', () => {
       mutators,
       testSubscriptionsManagerOptions,
       () => false,
+      replicacheFormatVersion,
     );
     assert(result);
     expect(result[0]).to.deep.equal(
@@ -491,6 +500,7 @@ suite('refresh', () => {
       mutators,
       testSubscriptionsManagerOptions,
       () => false,
+      replicacheFormatVersion,
     );
     expect(diffs).undefined;
     await assertRefreshHashes(perdag, clientID, client.refreshHashes);
@@ -540,6 +550,7 @@ suite('refresh', () => {
         mutators,
         testSubscriptionsManagerOptions,
         () => false,
+        replicacheFormatVersion,
       );
     } catch (e) {
       expectedE = e;
@@ -791,6 +802,7 @@ suite('refresh', () => {
       },
       testSubscriptionsManagerOptions,
       () => false,
+      replicacheFormatVersion,
     );
     assert(result);
     expect(result[0]).to.deep.equal(

--- a/packages/replicache/src/persist/refresh.ts
+++ b/packages/replicache/src/persist/refresh.ts
@@ -3,6 +3,7 @@ import {sleep} from 'shared/sleep.js';
 import type * as dag from '../dag/mod.js';
 import {assertSnapshotCommitDD31} from '../db/commit.js';
 import * as db from '../db/mod.js';
+import type {ReplicacheFormatVersion} from '../format-version.js';
 import type {Hash} from '../hash.js';
 import type {MutatorDefs} from '../replicache.js';
 import type {ClientID} from '../sync/ids.js';
@@ -48,6 +49,7 @@ export async function refresh(
   mutators: MutatorDefs,
   diffConfig: sync.DiffComputationConfig,
   closed: () => boolean,
+  replicacheFormatVersion: ReplicacheFormatVersion,
 ): Promise<[Hash, sync.DiffsMap] | undefined> {
   if (closed()) {
     return;
@@ -219,6 +221,7 @@ export async function refresh(
               mutators,
               lc,
               newMemdagMutations[i].meta.clientID,
+              replicacheFormatVersion,
             )
           ).chunk.hash;
         }

--- a/packages/replicache/src/replicache-mutation-recovery.test.ts
+++ b/packages/replicache/src/replicache-mutation-recovery.test.ts
@@ -73,17 +73,24 @@ export async function createAndPersistClientWithPendingLocalSDD(
   perdag: dag.Store,
   numLocal: number,
 ): Promise<db.LocalMetaSDD[]> {
+  const replicacheFormatVersion = REPLICACHE_FORMAT_VERSION_SDD;
   const testMemdag = new dag.LazyStore(
     perdag,
     100 * 2 ** 20, // 100 MB,
     dag.uuidChunkHasher,
     assertHash,
   );
-  const b = new ChainBuilder(testMemdag, undefined, false);
+  const b = new ChainBuilder(testMemdag, undefined, replicacheFormatVersion);
   await b.addGenesis(clientID);
   await b.addSnapshot([['unique', uuid()]], clientID);
 
-  await initClientWithClientID(clientID, perdag, [], {}, false);
+  await initClientWithClientID(
+    clientID,
+    perdag,
+    [],
+    {},
+    replicacheFormatVersion,
+  );
 
   const localMetas: db.LocalMetaSDD[] = [];
   for (let i = 0; i < numLocal; i++) {

--- a/packages/replicache/src/replicache.ts
+++ b/packages/replicache/src/replicache.ts
@@ -944,6 +944,7 @@ export class Replicache<MD extends MutatorDefs = {}> {
             this._mutatorRegistry,
             lc,
             db.isLocalMetaDD31(meta) ? meta.clientID : clientID,
+            REPLICACHE_FORMAT_VERSION,
           ),
         );
       }
@@ -1233,6 +1234,7 @@ export class Replicache<MD extends MutatorDefs = {}> {
       deepFreeze(poke.baseCookie),
       pullResponse,
       clientID,
+      REPLICACHE_FORMAT_VERSION,
     );
 
     switch (result.type) {
@@ -1266,6 +1268,7 @@ export class Replicache<MD extends MutatorDefs = {}> {
           this.puller,
           requestID,
           this._memdag,
+          REPLICACHE_FORMAT_VERSION,
           requestLc,
         );
         return {
@@ -1307,6 +1310,7 @@ export class Replicache<MD extends MutatorDefs = {}> {
           this._perdag,
           this._mutatorRegistry,
           () => this.closed,
+          REPLICACHE_FORMAT_VERSION,
         );
       } catch (e) {
         if (e instanceof persist.ClientStateNotFoundError) {
@@ -1343,6 +1347,7 @@ export class Replicache<MD extends MutatorDefs = {}> {
         this._mutatorRegistry,
         this._subscriptions,
         () => this.closed,
+        REPLICACHE_FORMAT_VERSION,
       );
     } catch (e) {
       if (e instanceof persist.ClientStateNotFoundError) {
@@ -1585,7 +1590,7 @@ export class Replicache<MD extends MutatorDefs = {}> {
           dagWrite,
           timestamp,
           clientID,
-          true,
+          REPLICACHE_FORMAT_VERSION,
         );
 
         const tx = new WriteTransactionImpl(

--- a/packages/replicache/src/sync/diff.test.ts
+++ b/packages/replicache/src/sync/diff.test.ts
@@ -1,11 +1,12 @@
 import {expect} from '@esm-bundle/chai';
 import type {InternalDiff} from '../btree/node.js';
 import * as dag from '../dag/mod.js';
-import {diff} from './diff.js';
 import {ChainBuilder} from '../db/test-helpers.js';
-import {testSubscriptionsManagerOptions} from '../test-util.js';
+import {REPLICACHE_FORMAT_VERSION_SDD} from '../format-version.js';
 import type {IndexDefinitions} from '../index-defs.js';
+import {testSubscriptionsManagerOptions} from '../test-util.js';
 import {withRead} from '../with-transactions.js';
+import {diff} from './diff.js';
 
 type DiffsRecord = Record<string, InternalDiff>;
 
@@ -203,7 +204,7 @@ test('db diff dd31', async () => {
 
 test('db diff sdd', async () => {
   const clientID = 'client-id-1';
-  const dd31 = false;
+  const replicacheFormatVersion = REPLICACHE_FORMAT_VERSION_SDD;
 
   const t = async ({
     iOld,
@@ -217,7 +218,7 @@ test('db diff sdd', async () => {
     setupChain?: (b: ChainBuilder) => Promise<void>;
   }) => {
     const store = new dag.TestStore();
-    const b = new ChainBuilder(store, undefined, dd31);
+    const b = new ChainBuilder(store, undefined, replicacheFormatVersion);
     await b.addGenesis(clientID);
     await b.addLocal(clientID, [['a', 'a2']]);
     await b.addLocal(clientID, [['b', 'b1']]);

--- a/packages/replicache/src/sync/push.test.ts
+++ b/packages/replicache/src/sync/push.test.ts
@@ -1,22 +1,23 @@
-import {LogContext} from '@rocicorp/logger';
 import {expect} from '@esm-bundle/chai';
+import {LogContext} from '@rocicorp/logger';
 import * as dag from '../dag/mod.js';
 import {DEFAULT_HEAD_NAME} from '../db/commit.js';
 import {fromWhence, whenceHead} from '../db/read.js';
 import {ChainBuilder} from '../db/test-helpers.js';
-import {SYNC_HEAD_NAME} from './sync-head-name.js';
+import {REPLICACHE_FORMAT_VERSION_SDD} from '../format-version.js';
+import {deepFreeze} from '../json.js';
+import type {Pusher, PusherResult} from '../pusher.js';
+import {withRead, withWrite} from '../with-transactions.js';
+import type {ClientGroupID} from './ids.js';
 import {
-  push,
+  PUSH_VERSION_DD31,
+  PUSH_VERSION_SDD,
+  PushRequest,
   PushRequestV0,
   PushRequestV1,
-  PUSH_VERSION_SDD,
-  PUSH_VERSION_DD31,
-  PushRequest,
+  push,
 } from './push.js';
-import type {Pusher, PusherResult} from '../pusher.js';
-import type {ClientGroupID} from './ids.js';
-import {deepFreeze} from '../json.js';
-import {withRead, withWrite} from '../with-transactions.js';
+import {SYNC_HEAD_NAME} from './sync-head-name.js';
 
 type FakePusherArgs = {
   expPush: boolean;
@@ -70,7 +71,7 @@ test('try push [SDD]', async () => {
   const clientID = 'test_client_id';
   const store = new dag.TestStore();
   const lc = new LogContext();
-  const b = new ChainBuilder(store, undefined, false);
+  const b = new ChainBuilder(store, undefined, REPLICACHE_FORMAT_VERSION_SDD);
   await b.addGenesis(clientID);
   await b.addSnapshot([['foo', 'bar']], clientID);
   // chain[2] is an index change


### PR DESCRIPTION
For runtime behavior we used to pass a boolean for DD31. Instead pass a `ReplicacheFormatVersion`. This is in preparation for V7.