### PR TITLE
chore: Remove Whence

### DIFF
--- a/packages/replicache/src/dag/store.ts
+++ b/packages/replicache/src/dag/store.ts
@@ -1,6 +1,7 @@
-import type {Chunk} from './chunk.js';
+import {assert} from 'shared/asserts.js';
 import type {Hash} from '../hash.js';
 import type {Release} from '../with-transactions.js';
+import type {Chunk} from './chunk.js';
 
 export interface Store {
   read(): Promise<Read>;
@@ -49,4 +50,13 @@ export async function mustGetChunk(
     return chunk;
   }
   throw new ChunkNotFoundError(hash);
+}
+
+export async function mustGetHeadHash(
+  name: string,
+  store: Read,
+): Promise<Hash> {
+  const hash = await store.getHead(name);
+  assert(hash, `Missing head ${name}`);
+  return hash;
 }

--- a/packages/replicache/src/db/commit.test.ts
+++ b/packages/replicache/src/db/commit.test.ts
@@ -13,7 +13,7 @@ import {
   MetaType,
   baseSnapshotFromHash,
   chunkIndexDefinitionEqualIgnoreName,
-  chain as commitChain,
+  commitChain,
   newIndexChange as commitNewIndexChange,
   newLocalDD31 as commitNewLocalDD31,
   newLocalSDD as commitNewLocalSDD,

--- a/packages/replicache/src/db/mod.ts
+++ b/packages/replicache/src/db/mod.ts
@@ -6,9 +6,9 @@ export {
   baseSnapshotFromHash,
   baseSnapshotFromHead,
   baseSnapshotHashFromHash,
-  chain as commitChain,
-  fromHash as commitFromHash,
-  fromHead as commitFromHead,
+  commitChain,
+  commitFromHash,
+  commitFromHead,
   compareCookiesForSnapshots,
   fromChunk,
   isLocalMetaDD31,
@@ -38,16 +38,11 @@ export {decodeIndexKey, encodeIndexKey} from './index.js';
 export type {IndexKey} from './index.js';
 export {
   Read,
-  fromWhence,
-  readCommit,
-  readCommitForBTreeRead,
-  readCommitForBTreeWrite,
   readFromDefaultHead,
+  readFromHash,
+  readFromHead,
   readIndexesForRead,
-  whenceHash,
-  whenceHead,
 } from './read.js';
-export type {Whence} from './read.js';
 export {rebaseMutationAndCommit, rebaseMutationAndPutCommit} from './rebase.js';
 export {getRoot} from './root.js';
 export type {ScanOptions} from './scan.js';

--- a/packages/replicache/src/db/rebase.test.ts
+++ b/packages/replicache/src/db/rebase.test.ts
@@ -200,6 +200,16 @@ async function createMissingMutatorFixture() {
   return fixture;
 }
 
+async function commitAndBTree(
+  name = SYNC_HEAD_NAME,
+  read: dag.Read,
+  formatVersion: FormatVersion,
+): Promise<[db.Commit<db.Meta>, BTreeRead]> {
+  const commit = await db.commitFromHead(name, read);
+  const btreeRead = new BTreeRead(read, formatVersion, commit.valueHash);
+  return [commit, btreeRead];
+}
+
 suite('rebaseMutationAndCommit', () => {
   test('with sequence of mutations', async () => {
     const fixture = await createMutationSequenceFixture();
@@ -218,12 +228,11 @@ suite('rebaseMutationAndCommit', () => {
     expect(fixture.testMutator1CallCount).to.equal(1);
     expect(fixture.testMutator2CallCount).to.equal(0);
     await withRead(fixture.store, async read => {
-      const [, rebasedLocalCommit1, btreeRead] =
-        await db.readCommitForBTreeRead(
-          db.whenceHead(SYNC_HEAD_NAME),
-          read,
-          fixture.formatVersion,
-        );
+      const [rebasedLocalCommit1, btreeRead] = await commitAndBTree(
+        SYNC_HEAD_NAME,
+        read,
+        fixture.formatVersion,
+      );
       expect(hashOfRebasedLocalCommit1).to.equal(
         rebasedLocalCommit1.chunk.hash,
       );
@@ -244,12 +253,11 @@ suite('rebaseMutationAndCommit', () => {
     expect(fixture.testMutator1CallCount).to.equal(1);
     expect(fixture.testMutator2CallCount).to.equal(1);
     await withRead(fixture.store, async read => {
-      const [, rebasedLocalCommit2, btreeRead] =
-        await db.readCommitForBTreeRead(
-          db.whenceHead(SYNC_HEAD_NAME),
-          read,
-          fixture.formatVersion,
-        );
+      const [rebasedLocalCommit2, btreeRead] = await commitAndBTree(
+        SYNC_HEAD_NAME,
+        read,
+        fixture.formatVersion,
+      );
       expect(hashOfRebasedLocalCommit2).to.equal(
         rebasedLocalCommit2.chunk.hash,
       );
@@ -276,8 +284,8 @@ suite('rebaseMutationAndCommit', () => {
       ),
     );
     await withRead(fixture.store, async read => {
-      const [, rebasedLocalCommit, btreeRead] = await db.readCommitForBTreeRead(
-        db.whenceHead(SYNC_HEAD_NAME),
+      const [rebasedLocalCommit, btreeRead] = await commitAndBTree(
+        SYNC_HEAD_NAME,
         read,
         fixture.formatVersion,
       );
@@ -328,12 +336,11 @@ suite('rebaseMutationAndPutCommit', () => {
     expect(fixture.testMutator1CallCount).to.equal(1);
     expect(fixture.testMutator2CallCount).to.equal(0);
     await withRead(fixture.store, async read => {
-      const [, rebasedLocalCommit1, btreeRead] =
-        await db.readCommitForBTreeRead(
-          db.whenceHead(TEST_HEAD_NAME),
-          read,
-          fixture.formatVersion,
-        );
+      const [rebasedLocalCommit1, btreeRead] = await commitAndBTree(
+        TEST_HEAD_NAME,
+        read,
+        fixture.formatVersion,
+      );
       expect(hashOfRebasedLocalCommit1).to.equal(
         rebasedLocalCommit1.chunk.hash,
       );
@@ -364,12 +371,11 @@ suite('rebaseMutationAndPutCommit', () => {
     expect(fixture.testMutator1CallCount).to.equal(1);
     expect(fixture.testMutator2CallCount).to.equal(1);
     await withRead(fixture.store, async read => {
-      const [, rebasedLocalCommit2, btreeRead] =
-        await db.readCommitForBTreeRead(
-          db.whenceHead(TEST_HEAD_NAME),
-          read,
-          fixture.formatVersion,
-        );
+      const [rebasedLocalCommit2, btreeRead] = await commitAndBTree(
+        TEST_HEAD_NAME,
+        read,
+        fixture.formatVersion,
+      );
       expect(hashOfRebasedLocalCommit2).to.equal(
         rebasedLocalCommit2.chunk.hash,
       );
@@ -406,8 +412,8 @@ suite('rebaseMutationAndPutCommit', () => {
       },
     );
     await withRead(fixture.store, async read => {
-      const [, rebasedLocalCommit, btreeRead] = await db.readCommitForBTreeRead(
-        db.whenceHead(TEST_HEAD_NAME),
+      const [rebasedLocalCommit, btreeRead] = await commitAndBTree(
+        TEST_HEAD_NAME,
         read,
         fixture.formatVersion,
       );

--- a/packages/replicache/src/db/rebase.ts
+++ b/packages/replicache/src/db/rebase.ts
@@ -13,16 +13,15 @@ import {
   LocalMetaSDD,
   Meta,
   assertLocalMetaDD31,
-  fromHash,
+  commitFromHash,
   isLocalMetaDD31,
 } from './commit.js';
-import {whenceHash} from './read.js';
 import {Write, newWriteLocal} from './write.js';
 
 async function rebaseMutation(
   mutation: Commit<LocalMetaDD31 | LocalMetaSDD>,
   dagWrite: dag.Write,
-  basis: Hash,
+  basisHash: Hash,
   mutators: MutatorDefs,
   lc: LogContext,
   mutationClientID: ClientID,
@@ -56,7 +55,7 @@ async function rebaseMutation(
 
   const args = localMeta.mutatorArgsJSON;
 
-  const basisCommit = await fromHash(basis, dagWrite);
+  const basisCommit = await commitFromHash(basisHash, dagWrite);
   const nextMutationID = await basisCommit.getNextMutationID(
     mutationClientID,
     dagWrite,
@@ -72,7 +71,7 @@ async function rebaseMutation(
   }
 
   const dbWrite = await newWriteLocal(
-    whenceHash(basis),
+    basisHash,
     name,
     args,
     mutation.chunk.hash,

--- a/packages/replicache/src/persist/clients.test.ts
+++ b/packages/replicache/src/persist/clients.test.ts
@@ -8,9 +8,9 @@ import {
   Commit,
   SnapshotMetaDD31,
   SnapshotMetaSDD,
+  commitFromHash,
   commitIsSnapshot,
   fromChunk,
-  fromHash,
 } from '../db/commit.js';
 import {ChainBuilder} from '../db/test-helpers.js';
 import {FormatVersion} from '../format-version.js';
@@ -924,10 +924,10 @@ suite('initClientV6', () => {
     });
 
     await withRead(perdag, async read => {
-      const c1 = await fromHash(client1.headHash, read);
+      const c1 = await commitFromHash(client1.headHash, read);
       expect(c1.chunk.data.indexes).length(1);
 
-      const c2 = await fromHash(client2HeadHash, read);
+      const c2 = await commitFromHash(client2HeadHash, read);
       expect(c2.chunk.data.indexes).length(2);
 
       expect(c1.chunk.data.indexes[0].valueHash).to.equal(

--- a/packages/replicache/src/replicache.ts
+++ b/packages/replicache/src/replicache.ts
@@ -14,6 +14,7 @@ import {initBgIntervalProcess} from './bg-interval.js';
 import {PullDelegate, PushDelegate} from './connection-loop-delegates.js';
 import {ConnectionLoop, MAX_DELAY_MS, MIN_DELAY_MS} from './connection-loop.js';
 import * as dag from './dag/mod.js';
+import {mustGetHeadHash} from './dag/store.js';
 import {assertLocalCommitDD31} from './db/commit.js';
 import * as db from './db/mod.js';
 import {
@@ -1584,11 +1585,11 @@ export class Replicache<MD extends MutatorDefs = {}> {
     const clientID = await this._clientIDPromise;
     return withWrite(this._memdag, async dagWrite => {
       try {
-        const whence: db.Whence = db.whenceHead(db.DEFAULT_HEAD_NAME);
+        const headHash = await mustGetHeadHash(db.DEFAULT_HEAD_NAME, dagWrite);
         const originalHash = null;
 
         const dbWrite = await db.newWriteLocal(
-          whence,
+          headHash,
           name,
           frozenArgs,
           originalHash,

--- a/packages/replicache/src/sync/diff.ts
+++ b/packages/replicache/src/sync/diff.ts
@@ -3,7 +3,7 @@ import * as btree from '../btree/mod.js';
 import type {InternalDiff} from '../btree/node.js';
 import {allEntriesAsDiff, BTreeRead} from '../btree/read.js';
 import type * as dag from '../dag/mod.js';
-import {Commit, fromHash, Meta} from '../db/commit.js';
+import {Commit, commitFromHash, Meta} from '../db/commit.js';
 import {readIndexesForRead} from '../db/read.js';
 import type {FormatVersion} from '../format-version.js';
 import type {Hash} from '../hash.js';
@@ -41,8 +41,8 @@ export async function diff(
   formatVersion: FormatVersion,
 ): Promise<DiffsMap> {
   const [oldCommit, newCommit] = await Promise.all([
-    fromHash(oldHash, read),
-    fromHash(newHash, read),
+    commitFromHash(oldHash, read),
+    commitFromHash(newHash, read),
   ]);
 
   return diffCommits(oldCommit, newCommit, read, diffConfig, formatVersion);

--- a/packages/replicache/src/sync/patch.test.ts
+++ b/packages/replicache/src/sync/patch.test.ts
@@ -165,7 +165,7 @@ suite('patch', () => {
         let dbWrite;
         if (formatVersion >= FormatVersion.DD31) {
           dbWrite = await db.newWriteSnapshotDD31(
-            db.whenceHash(b.chain[0].chunk.hash),
+            b.chain[0].chunk.hash,
             {[clientID]: 1},
             'cookie',
             dagWrite,
@@ -174,7 +174,7 @@ suite('patch', () => {
           );
         } else {
           dbWrite = await db.newWriteSnapshotSDD(
-            db.whenceHash(b.chain[0].chunk.hash),
+            b.chain[0].chunk.hash,
             1,
             'cookie',
             dagWrite,

--- a/packages/replicache/src/sync/pull.test.ts
+++ b/packages/replicache/src/sync/pull.test.ts
@@ -1,10 +1,6 @@
 import {expect} from '@esm-bundle/chai';
 import {LogContext} from '@rocicorp/logger';
-import {
-  assertNotUndefined,
-  assertObject,
-  assertString,
-} from 'shared/asserts.js';
+import {assertObject, assertString} from 'shared/asserts.js';
 import {asyncIterableToArray} from '../async-iterable-to-array.js';
 import {BTreeRead} from '../btree/read.js';
 import type {Cookie, FrozenCookie} from '../cookies.js';
@@ -420,11 +416,7 @@ test('begin try pull SDD', async () => {
     // the index no longer returns values, demonstrating that it was rebuilt.
     if (c.numPendingMutations > 0) {
       await withRead(store, async dagRead => {
-        const read = await db.fromWhence(
-          db.whenceHead(DEFAULT_HEAD_NAME),
-          dagRead,
-          formatVersion,
-        );
+        const read = await db.readFromDefaultHead(dagRead, formatVersion);
         let got = false;
 
         const indexMap = read.getMapForIndex('2');
@@ -476,23 +468,19 @@ test('begin try pull SDD', async () => {
     await withRead(store, async read => {
       if (c.expNewSyncHead !== undefined) {
         const expSyncHead = c.expNewSyncHead;
-        const syncHeadHash = await read.getHead(SYNC_HEAD_NAME);
-        assertString(syncHeadHash);
-        const chunk = await read.getChunk(syncHeadHash);
-        assertNotUndefined(chunk);
-        const syncHead = db.fromChunk(chunk);
-        assertSnapshotCommitSDD(syncHead);
+        const syncHeadCommit = await db.commitFromHead(SYNC_HEAD_NAME, read);
+        assertSnapshotCommitSDD(syncHeadCommit);
         const [gotLastMutationID, gotCookie] = db.snapshotMetaParts(
-          syncHead,
+          syncHeadCommit,
           clientID,
         );
         expect(expSyncHead.lastMutationID).to.equal(gotLastMutationID);
         expect(expSyncHead.cookie).to.deep.equal(gotCookie);
         // Check the value is what's expected.
-        const [, , bTreeRead] = await db.readCommitForBTreeRead(
-          db.whenceHash(syncHead.chunk.hash),
+        const bTreeRead = new BTreeRead(
           read,
           formatVersion,
+          syncHeadCommit.valueHash,
         );
         const gotValueMap = await asyncIterableToArray(bTreeRead.entries());
         gotValueMap.sort((a, b) => stringCompare(a[0], b[0]));
@@ -501,7 +489,9 @@ test('begin try pull SDD', async () => {
         expect(expValueMap.length).to.equal(gotValueMap.length);
 
         // Check we have the expected index definitions.
-        const indexes: string[] = syncHead.indexes.map(i => i.definition.name);
+        const indexes: string[] = syncHeadCommit.indexes.map(
+          i => i.definition.name,
+        );
         expect(expSyncHead.indexes.length).to.equal(
           indexes.length,
           `${c.name}: expected indexes ${expSyncHead.indexes}, got ${indexes}`,
@@ -517,8 +507,8 @@ test('begin try pull SDD', async () => {
         // change's index ("2").
         if (expSyncHead.indexes.length > 1) {
           await withRead(store, async dagRead => {
-            const read = await db.fromWhence(
-              db.whenceHead(SYNC_HEAD_NAME),
+            const read = await db.readFromHead(
+              SYNC_HEAD_NAME,
               dagRead,
               formatVersion,
             );
@@ -530,7 +520,7 @@ test('begin try pull SDD', async () => {
           });
 
           assertObject(result);
-          expect(syncHeadHash).to.equal(result.syncHead);
+          expect(syncHeadCommit.chunk.hash).to.equal(result.syncHead);
         }
       } else {
         const gotHead = await read.getHead(SYNC_HEAD_NAME);
@@ -969,11 +959,7 @@ test('begin try pull DD31', async () => {
     // the index no longer returns values, demonstrating that it was rebuilt.
     if (c.numPendingMutations > 0) {
       await withRead(store, async dagRead => {
-        const read = await db.fromWhence(
-          db.whenceHead(DEFAULT_HEAD_NAME),
-          dagRead,
-          formatVersion,
-        );
+        const read = await db.readFromDefaultHead(dagRead, formatVersion);
         let got = false;
 
         const indexMap = read.getMapForIndex('2');
@@ -1027,23 +1013,19 @@ test('begin try pull DD31', async () => {
     await withRead(store, async read => {
       if (c.expNewSyncHead !== undefined) {
         const expSyncHead = c.expNewSyncHead;
-        const syncHeadHash = await read.getHead(SYNC_HEAD_NAME);
-        assertString(syncHeadHash);
-        const chunk = await read.getChunk(syncHeadHash);
-        assertNotUndefined(chunk);
-        const syncHead = db.fromChunk(chunk);
-        assertSnapshotCommitDD31(syncHead);
+        const syncHeadCommit = await db.commitFromHead(SYNC_HEAD_NAME, read);
+        assertSnapshotCommitDD31(syncHeadCommit);
         const [gotLastMutationID, gotCookie] = db.snapshotMetaParts(
-          syncHead,
+          syncHeadCommit,
           clientID,
         );
         expect(expSyncHead.lastMutationID).to.equal(gotLastMutationID);
         expect(expSyncHead.cookie).to.deep.equal(gotCookie);
         // Check the value is what's expected.
-        const [, , bTreeRead] = await db.readCommitForBTreeRead(
-          db.whenceHash(syncHead.chunk.hash),
+        const bTreeRead = new BTreeRead(
           read,
           formatVersion,
+          syncHeadCommit.valueHash,
         );
         const gotValueMap = (
           await asyncIterableToArray(bTreeRead.entries())
@@ -1054,7 +1036,9 @@ test('begin try pull DD31', async () => {
         expect(expValueMap).to.deep.equal(gotValueMap);
 
         // Check we have the expected index definitions.
-        const indexes: string[] = syncHead.indexes.map(i => i.definition.name);
+        const indexes: string[] = syncHeadCommit.indexes.map(
+          i => i.definition.name,
+        );
         expect(expSyncHead.indexes).to.deep.equal(indexes);
 
         // Check that we *don't* have old indexed values. The indexes should
@@ -1064,8 +1048,8 @@ test('begin try pull DD31', async () => {
         // change's index ("2").
         if (expSyncHead.indexes.length > 1) {
           await withRead(store, async dagRead => {
-            const read = await db.fromWhence(
-              db.whenceHead(SYNC_HEAD_NAME),
+            const read = await db.readFromHead(
+              SYNC_HEAD_NAME,
               dagRead,
               formatVersion,
             );
@@ -1077,7 +1061,7 @@ test('begin try pull DD31', async () => {
           });
 
           assertObject(result);
-          expect(syncHeadHash).to.equal(result.syncHead);
+          expect(syncHeadCommit.chunk.hash).to.equal(result.syncHead);
         }
       } else {
         const gotHead = await read.getHead(SYNC_HEAD_NAME);
@@ -1190,7 +1174,7 @@ suite('maybe end try pull', () => {
         const w =
           formatVersion >= FormatVersion.DD31
             ? await db.newWriteSnapshotDD31(
-                db.whenceHash(b.chain[0].chunk.hash),
+                b.chain[0].chunk.hash,
                 {[clientID]: 0},
                 'sync_cookie',
                 dagWrite,
@@ -1198,7 +1182,7 @@ suite('maybe end try pull', () => {
                 formatVersion,
               )
             : await db.newWriteSnapshotSDD(
-                db.whenceHash(b.chain[0].chunk.hash),
+                b.chain[0].chunk.hash,
                 0,
                 'sync_cookie',
                 dagWrite,
@@ -1228,7 +1212,7 @@ suite('maybe end try pull', () => {
         }
         basisHash = await withWrite(store, async dagWrite => {
           const w = await db.newWriteLocal(
-            db.whenceHash(basisHash),
+            basisHash,
             mutatorName,
             mutatorArgs,
             original.chunk.hash,

--- a/packages/replicache/src/sync/pull.ts
+++ b/packages/replicache/src/sync/pull.ts
@@ -374,7 +374,7 @@ export function handlePullResponseV0(
     }
 
     const dbWrite = await db.newWriteSnapshotSDD(
-      db.whenceHash(baseSnapshot.chunk.hash),
+      baseSnapshot.chunk.hash,
       response.lastMutationID,
       frozenCookie,
       dagWrite,
@@ -509,7 +509,7 @@ export function handlePullResponseV1(
     }
 
     const dbWrite = await db.newWriteSnapshotDD31(
-      db.whenceHash(baseSnapshot.chunk.hash),
+      baseSnapshot.chunk.hash,
       {...baseSnapshotMeta.lastMutationIDs, ...response.lastMutationIDChanges},
       frozenResponseCookie,
       dagWrite,

--- a/packages/replicache/src/sync/push.test.ts
+++ b/packages/replicache/src/sync/push.test.ts
@@ -2,7 +2,7 @@ import {expect} from '@esm-bundle/chai';
 import {LogContext} from '@rocicorp/logger';
 import * as dag from '../dag/mod.js';
 import {DEFAULT_HEAD_NAME} from '../db/commit.js';
-import {fromWhence, whenceHead} from '../db/read.js';
+import {readFromDefaultHead} from '../db/read.js';
 import {ChainBuilder} from '../db/test-helpers.js';
 import {FormatVersion} from '../format-version.js';
 import {deepFreeze} from '../json.js';
@@ -220,11 +220,7 @@ test('try push [SDD]', async () => {
     // rebuilt.
     if (c.numPendingMutations > 0) {
       await withRead(store, async dagRead => {
-        const read = await fromWhence(
-          whenceHead(DEFAULT_HEAD_NAME),
-          dagRead,
-          formatVersion,
-        );
+        const read = await readFromDefaultHead(dagRead, formatVersion);
         let got = false;
 
         const indexMap = read.getMapForIndex('2');
@@ -470,11 +466,7 @@ test('try push [DD31]', async () => {
     // rebuilt.
     if (c.numPendingMutations > 0) {
       await withRead(store, async dagRead => {
-        const read = await fromWhence(
-          whenceHead(DEFAULT_HEAD_NAME),
-          dagRead,
-          formatVersion,
-        );
+        const read = await readFromDefaultHead(dagRead, formatVersion);
         let got = false;
 
         const indexMap = read.getMapForIndex('2');

--- a/packages/replicache/src/sync/test-helpers.ts
+++ b/packages/replicache/src/sync/test-helpers.ts
@@ -44,7 +44,7 @@ export async function addSyncSnapshot(
   await withWrite(store, async dagWrite => {
     if (formatVersion >= FormatVersion.DD31) {
       const w = await db.newWriteSnapshotDD31(
-        db.whenceHash(baseSnapshot.chunk.hash),
+        baseSnapshot.chunk.hash,
         {[clientID]: await baseSnapshot.getMutationID(clientID, dagWrite)},
         cookie,
         dagWrite,
@@ -59,7 +59,7 @@ export async function addSyncSnapshot(
         formatVersion,
       );
       const w = await db.newWriteSnapshotSDD(
-        db.whenceHash(baseSnapshot.chunk.hash),
+        baseSnapshot.chunk.hash,
         await baseSnapshot.getMutationID(clientID, dagWrite),
         cookie,
         dagWrite,
@@ -70,8 +70,8 @@ export async function addSyncSnapshot(
       await w.commit(sync.SYNC_HEAD_NAME);
     }
   });
-  const [, commit] = await withRead(store, dagRead =>
-    db.readCommit(db.whenceHead(sync.SYNC_HEAD_NAME), dagRead),
+  const commit = await withRead(store, dagRead =>
+    db.commitFromHead(sync.SYNC_HEAD_NAME, dagRead),
   );
   syncChain.push(commit);
 


### PR DESCRIPTION
The whence was delaying the branching between head name and hash. This branching was often unnecessary and was causing extra microtasks.

Also, remove a bunch of helper functions that were not very helpful.