### PR TITLE
fix(replicache): Improve error logs for errors in subscription bodys

### DIFF
--- a/packages/replicache/src/replicache-subscribe.test.ts
+++ b/packages/replicache/src/replicache-subscribe.test.ts
@@ -1051,7 +1051,7 @@ test('Errors in subscriptions are logged if no onError', async () => {
       assert.deepEqual(testLogSink.messages[0], [
         'error',
         {name: rep.name},
-        [err],
+        ['Error in subscription body:', err],
       ]);
     }
 

--- a/packages/replicache/src/replicache.ts
+++ b/packages/replicache/src/replicache.ts
@@ -1010,7 +1010,7 @@ export class Replicache<MD extends MutatorDefs = {}> {
         online = false;
         this._lc.info?.(`${name} threw:\n`, e, '\nwith cause:\n', e.causedBy);
       } else if (e instanceof ReportError) {
-        this._lc.error?.(`${name} threw:\n`, e);
+        this._lc.error?.(e);
       } else {
         this._lc.info?.(`${name} threw:\n`, e);
       }


### PR DESCRIPTION
Problem
=======
When a subscription body throws an error we just log it and nothing else, making it hard to tell where the error occured.

Solution
======
Include `'Error in subscription body:'` in error log message.