### PR TITLE
chore: Pull wrangler dependency up to reflect level.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32501,6 +32501,9 @@
         "@rocicorp/reflect-client": "0.0.0",
         "@rocicorp/reflect-server": "0.0.0",
         "@types/node": "18"
+      },
+      "peerDependencies": {
+        "wrangler": "^2.13.0"
       }
     },
     "packages/reflect-client": {
@@ -32715,9 +32718,6 @@
       },
       "engines": {
         "node": ">=16.14.0 || >=17.1"
-      },
-      "peerDependencies": {
-        "wrangler": "^2.13.0"
       }
     },
     "packages/reflect-server/node_modules/@rollup/plugin-node-resolve": {

--- a/packages/reflect-server/package.json
+++ b/packages/reflect-server/package.json
@@ -54,9 +54,6 @@
     "typescript": "^5.1.3",
     "util": "^0.12.5"
   },
-  "peerDependencies": {
-    "wrangler": "^2.13.0"
-  },
   "files": [
     "out/reflect-server.d.ts",
     "out/reflect-server.js",

--- a/packages/reflect/package.json
+++ b/packages/reflect/package.json
@@ -25,6 +25,9 @@
     "@rocicorp/reflect-server": "0.0.0",
     "@types/node": "18"
   },
+  "peerDependencies": {
+    "wrangler": "^2.13.0"
+  },
   "files": [
     "client.d.ts",
     "client.js",


### PR DESCRIPTION
We don't actually need it in the server, it was only there to ensure user gets it and doesn't have to install manually.

But the server package.json doesn't get output in build anymore.