### PR TITLE
fix(replicache): Update subscribe docs to match behavior

### DIFF
--- a/packages/replicache/src/replicache.ts
+++ b/packages/replicache/src/replicache.ts
@@ -1468,7 +1468,7 @@ export class Replicache<MD extends MutatorDefs = {}> {
    * {@link experimentalWatch}.
    *
    * If an error occurs in the `body` the `onError` function is called if
-   * present. Otherwise, the error is thrown.
+   * present. Otherwise, the error is logged at log level 'error'.
    *
    * To cancel the subscription, call the returned function.
    */


### PR DESCRIPTION
Docs currently say errors in body are thrown if no onError option is provided.  In fact they are just logged.