### PR TITLE
chore(mirror-server): add tool/process-deps.js

### DIFF
--- a/mirror/mirror-server/firebase.json
+++ b/mirror/mirror-server/firebase.json
@@ -1,8 +1,15 @@
 {
   "functions": {
-    "predeploy": ["npm run build"],
+    "predeploy": ["npm run build", "node tool/process-deps.js --remove"],
+    "postdeploy": ["node tool/process-deps.js --restore"],
     "source": "./",
-    "ignore": ["firebase.json", "**/node_modules/**", ".git"]
+    "ignore": [
+      "firebase.json",
+      "**/node_modules/**",
+      ".git",
+      "tsconfig.tsbuildinfo",
+      "ui-debug.log"
+    ]
   },
   "emulators": {
     "functions": {

--- a/mirror/mirror-server/package.json
+++ b/mirror/mirror-server/package.json
@@ -1,6 +1,7 @@
 {
   "name": "mirror-server",
   "version": "0.0.1",
+  "private": true,
   "scripts": {
     "build:watch": "node tool/build.js --watch",
     "build": "node tool/build.js",
@@ -19,11 +20,6 @@
     "postinstall": "node tool/fix-firestore-jest-mock.js"
   },
   "main": "out/index.js",
-  "// internalDependencies. Do not add these to dependencies, devDependencies or peerDependencies": {
-    "mirror-protocol": "0.0.0",
-    "mirror-schema": "0.0.0",
-    "shared": "0.0.0"
-  },
   "dependencies": {
     "@badrap/valita": "^0.2.0",
     "@google-cloud/firestore": "^6.6.1",
@@ -42,9 +38,16 @@
     "firebase-tools": "^12.3.0",
     "firestore-jest-mock": "^0.21.0",
     "ts-jest": "^29.1.0",
-    "typescript": "^5.1.3"
+    "typescript": "^5.1.3",
+    "mirror-protocol": "0.0.0",
+    "mirror-schema": "0.0.0",
+    "shared": "0.0.0"
   },
-  "private": true,
+  "bundleDependencies": [
+    "mirror-protocol",
+    "mirror-schema",
+    "shared"
+  ],
   "engines": {
     "node": "18"
   },

--- a/mirror/mirror-server/tool/build.js
+++ b/mirror/mirror-server/tool/build.js
@@ -1,17 +1,24 @@
 import * as esbuild from 'esbuild';
 import packageJSON from '../package.json' assert {type: 'json'};
 
-const {dependencies, devDependencies} = packageJSON;
-const external = Object.keys({
-  ...dependencies,
-  ...devDependencies,
-});
+const {dependencies, devDependencies, bundleDependencies} = packageJSON;
+const external = new Set(
+  Object.keys({
+    ...dependencies,
+    ...devDependencies,
+  }),
+);
+
+// See comment in tool/process-deps.js
+for (const dep of bundleDependencies) {
+  external.delete(dep);
+}
 
 const ctx = await esbuild.context({
   entryPoints: ['src/index.ts'],
   bundle: true,
   outfile: 'out/index.js',
-  external,
+  external: [...external],
   platform: 'node',
   target: 'esnext',
   format: 'esm',

--- a/mirror/mirror-server/tool/process-deps.js
+++ b/mirror/mirror-server/tool/process-deps.js
@@ -1,0 +1,51 @@
+// @ts-check
+import {readFileSync, writeFileSync} from 'fs';
+import {fileURLToPath} from 'url';
+
+// When deploying to Firebase, Firebase does an `npm install` which tries to
+// install our internal packages. That fails because these packages are not
+// published to npm. We therefore remove the internal packages from the
+// package.json before deploying to firebase.
+//
+// This is done using predeploy and postdeploy hooks in firebase.json.
+//
+// We store the list of internal packages in the `bundleDependencies` field of
+// package.json. Normally, bundleDependencies is used to specify packages that
+// should be bundled into the tarball created by `npm pack`. However, we don't
+// use `npm pack` and instead use esbuild to bundle our code. We therefore
+// repurpose bundleDependencies to specify packages that should be removed from
+// package.json before deploying to Firebase.
+//
+// Previously we used to not declare these packages as dependencies, but that
+// caused problems with turbo repo which failed to build things in the right
+// order.
+
+const filename = fileURLToPath(new URL('../package.json', import.meta.url));
+const packageJson = JSON.parse(readFileSync(filename, 'utf-8'));
+const {bundleDependencies, dependencies, devDependencies} = packageJson;
+
+function removeDeps() {
+  for (const dep of bundleDependencies) {
+    delete dependencies[dep];
+    delete devDependencies[dep];
+  }
+}
+
+function restoreDeps() {
+  for (const dep of bundleDependencies) {
+    devDependencies[dep] = '0.0.0';
+  }
+}
+
+if (process.argv.includes('--remove')) {
+  console.log('Removing dependencies from package.json');
+  removeDeps();
+} else if (process.argv.includes('--restore')) {
+  console.log('Restoring dependencies in package.json');
+  restoreDeps();
+} else {
+  console.error('Please specify --remove or --restore');
+  process.exit(1);
+}
+
+writeFileSync('./package.json', JSON.stringify(packageJson, null, 2) + '\n');


### PR DESCRIPTION
When deploying to Firebase, Firebase does an `npm install` which tries to install our internal packages. That fails because these packages are not published to npm. We therefore remove the internal packages from the package.json before deploying to firebase.

This is done using predeploy and postdeploy hooks in firebase.json.

We store the list of internal packages in the `bundleDependencies` field of package.json. Normally, bundleDependencies is used to specify packages that should be bundled into the tarball created by `npm pack`. However, we don't use `npm pack` and instead use esbuild to bundle our code. We therefore repurpose bundleDependencies to specify packages that should be removed from package.json before deploying to Firebase.

Previously we used to not declare these packages as dependencies, but that caused problems with turbo repo which failed to build things in the right order.