### PR TITLE
fix(reflect-client): make TIME_TO_CONNECT_V2_SPECIAL_VALUES further apart

### DIFF
--- a/packages/reflect-client/src/client/metrics.ts
+++ b/packages/reflect-client/src/client/metrics.ts
@@ -19,8 +19,8 @@ export const REPORT_INTERVAL_MS = 5_000;
 
 export const TIME_TO_CONNECT_V2_SPECIAL_VALUES = {
   initialValue: 100_000,
-  connectError: 100_001,
-  disconnectedWaitingForVisible: 100_002,
+  connectError: 200_000,
+  disconnectedWaitingForVisible: 300_000,
 } as const;
 
 type ClientDisconnectReason =


### PR DESCRIPTION
Datadogs [Percentiles/threshold ](https://docs.datadoghq.com/metrics/distributions/#threshold-queries) queries don't seem to be able to discern them and so any of them get counted towards the initial, hidden and error queries.

<img width="1439" alt="image" src="https://github.com/rocicorp/mono/assets/19158916/cc49f5bd-0cdd-4a6e-ae36-34052e3378d1">

<img width="1177" alt="image" src="https://github.com/rocicorp/mono/assets/19158916/2b1c345d-4aea-4450-b22b-0367ef965dad">
