### PR TITLE
feat: handle changes in user's email address

### DIFF
--- a/mirror/mirror-server/src/functions/user/ensure.function.test.ts
+++ b/mirror/mirror-server/src/functions/user/ensure.function.test.ts
@@ -19,7 +19,7 @@ function fakeFirestore(): Firestore {
   ).firestore() as unknown as Firestore;
 }
 
-function fakeAuth(email: string): Auth {
+function fakeAuth(email = 'foo@bar.com'): Auth {
   const auth = {
     getUser: () => Promise.resolve({email}),
     createCustomToken: () => Promise.resolve('custom-auth-token'),
@@ -74,7 +74,7 @@ describe('request validation', () => {
     test(c.name, async () => {
       const firestore = fakeFirestore();
       const ensureFunction = https.onCall(
-        ensure(firestore, c.auth ?? fakeAuth('foo@bar.com')),
+        ensure(firestore, c.auth ?? fakeAuth()),
       );
 
       let error: HttpsError | undefined = undefined;
@@ -98,9 +98,7 @@ describe('request validation', () => {
 
 test('creates user doc', async () => {
   const firestore = fakeFirestore();
-  const ensureFunction = https.onCall(
-    ensure(firestore, fakeAuth('foo@bar.com')),
-  );
+  const ensureFunction = https.onCall(ensure(firestore, fakeAuth()));
 
   const resp = await ensureFunction.run({
     data: {
@@ -123,9 +121,7 @@ test('creates user doc', async () => {
 
 test('does not overwrite existing user doc', async () => {
   const firestore = fakeFirestore();
-  const ensureFunction = https.onCall(
-    ensure(firestore, fakeAuth('foo@bar.com')),
-  );
+  const ensureFunction = https.onCall(ensure(firestore, fakeAuth()));
 
   await firestore.doc('users/foo').set({
     email: 'foo@bar.com',

--- a/mirror/mirror-server/src/functions/user/ensure.function.ts
+++ b/mirror/mirror-server/src/functions/user/ensure.function.ts
@@ -36,7 +36,7 @@ export function ensure(
           'User must have an email address',
         );
       }
-      const email = user.email;
+      const {email} = user;
       const userDocRef = firestore
         .doc(userPath(userID))
         .withConverter(userDataConverter);


### PR DESCRIPTION
The user's email address can change (e.g. if they change their main email address in github).

The `user-ensure` function is updated to detect this and update the email address stored in the user doc, and denormalized copies in team memberships.

Also, fix the logic to retrieve the email address for the `requester: { userID }` rather than the authenticated user, since the two may be different, as in the case with admin impersonation / delegation.