### PR TITLE
fix: update the Team schema to track counts of the memberships and invites

### DIFF
--- a/mirror/mirror-schema/src/team.ts
+++ b/mirror/mirror-schema/src/team.ts
@@ -6,9 +6,12 @@ export const teamSchema = v.object({
   name: v.string(),
   defaultCfID: v.string(),
 
-  admins: v.array(v.string()),
-  members: v.array(v.string()),
-  invites: v.array(v.string()).optional(),
+  // Number of memberships of role 'admin'.
+  // A team must have at least one admin.
+  numAdmins: v.number(),
+  // Number of memberships of role 'member'.
+  numMembers: v.number(),
+  numInvites: v.number(),
 
   numApps: v.number(),
   // null means default max


### PR DESCRIPTION
The previous `admins`, `members`, and `invites` arrays have been replaced by the `memberships` and `invites` subcollections (to avoid document size limitations). Replace the array fields with numeric counts instead so that they can be displayed without querying the entire subcollection. 