### PR TITLE
fix(reflect): remove unneeded package.json dep on replicache

### DIFF
--- a/packages/reflect/package.json
+++ b/packages/reflect/package.json
@@ -18,8 +18,7 @@
     "@badrap/valita": "^0.2.0",
     "@rocicorp/lock": "^1.0.1",
     "@rocicorp/logger": "^5.2.0",
-    "@rocicorp/resolver": "^1.0.0",
-    "replicache": "13.0.0-beta.1"
+    "@rocicorp/resolver": "^1.0.0"
   },
   "devDependencies": {
     "reflect-client": "0.0.0",


### PR DESCRIPTION
This was introduced in https://github.com/rocicorp/mono/commit/1963c267bbeeb3569af3cec48ece0452589e08f1

This in combination with @rocicorp/rails peer dependencies led to incompatible version of replicache being installed in Monday's project and reflect-todo.  

Arv and I discussed and concluded this dependency is not needed.
https://rocicorp.slack.com/archives/C013XFG80JC/p1689625831730799?thread_ts=1689610469.724639&cid=C013XFG80JC 