### PR TITLE
Store the JSON AuthCredential in the reflect-cli creds file

### DIFF
--- a/mirror/mirror-protocol/src/user.ts
+++ b/mirror/mirror-protocol/src/user.ts
@@ -7,7 +7,6 @@ export type EnsureUserRequest = v.Infer<typeof ensureUserRequestSchema>;
 
 export const ensureUserResponseSchema = v.object({
   ...baseResponseFields,
-  customToken: v.string(),
 });
 export type EnsureUserResponse = v.Infer<typeof ensureUserResponseSchema>;
 

--- a/mirror/mirror-server/src/functions/user/ensure.function.test.ts
+++ b/mirror/mirror-server/src/functions/user/ensure.function.test.ts
@@ -22,7 +22,6 @@ function fakeFirestore(): Firestore {
 function fakeAuth(email = 'foo@bar.com'): Auth {
   const auth = {
     getUser: () => Promise.resolve({email}),
-    createCustomToken: () => Promise.resolve('custom-auth-token'),
   };
   return auth as unknown as Auth;
 }
@@ -110,7 +109,7 @@ test('creates user doc', async () => {
     auth: {uid: 'foo'} as AuthData,
     rawRequest: null as unknown as Request,
   });
-  expect(resp).toEqual({customToken: 'custom-auth-token', success: true});
+  expect(resp).toEqual({success: true});
   const fooDoc = await firestore.doc('users/foo').get();
   expect(fooDoc.exists).toBe(true);
   expect(fooDoc.data()).toEqual({
@@ -139,7 +138,7 @@ test('does not overwrite existing user doc', async () => {
     auth: {uid: 'foo'} as AuthData,
     rawRequest: null as unknown as Request,
   });
-  expect(resp).toEqual({customToken: 'custom-auth-token', success: true});
+  expect(resp).toEqual({success: true});
   const fooDoc = await firestore.doc('users/foo').get();
   expect(fooDoc.exists).toBe(true);
   expect(fooDoc.data()).toEqual({
@@ -180,7 +179,7 @@ test('updates user doc if email is different', async () => {
     auth: {uid: 'foo'} as AuthData,
     rawRequest: null as unknown as Request,
   });
-  expect(resp).toEqual({customToken: 'custom-auth-token', success: true});
+  expect(resp).toEqual({success: true});
   const fooDoc = await firestore.doc('users/foo').get();
   expect(fooDoc.exists).toBe(true);
   expect(fooDoc.data()).toEqual({

--- a/mirror/mirror-server/src/functions/user/ensure.function.ts
+++ b/mirror/mirror-server/src/functions/user/ensure.function.ts
@@ -26,7 +26,7 @@ export function ensure(
   return withSchema(
     ensureUserRequestSchema,
     ensureUserResponseSchema,
-    withAuthorization(async (ensureUserRequest, context) => {
+    withAuthorization(async ensureUserRequest => {
       const {userID} = ensureUserRequest.requester;
 
       const user = await auth.getUser(userID);
@@ -72,11 +72,7 @@ export function ensure(
           }
         }
       });
-      const customToken = await auth.createCustomToken(context.auth.uid);
-      return {
-        customToken,
-        success: true,
-      };
+      return {success: true};
     }),
   );
 }

--- a/mirror/reflect-cli/src/login.test.ts
+++ b/mirror/reflect-cli/src/login.test.ts
@@ -9,7 +9,7 @@ const credentialReceiverServerFetch: (
 ) => Promise<http.ServerResponse<http.IncomingMessage>> = mockHttpServer();
 
 describe('loginHandler', () => {
-  test('should reject if customToken, refreshToken or expirationTime is missing', async () => {
+  test('should reject if authCredential is missing', async () => {
     const callbackUrl = new URL('http://localhost:8976/oauth/callback');
     let openInBrowserCalled = false;
     let writeAuthConfigFileCalled = false;
@@ -25,22 +25,29 @@ describe('loginHandler', () => {
       },
       (config: UserAuthConfig) => {
         expect(config).toBeDefined();
-        expect(config.customToken).toEqual('valid-token');
+        expect(config.authCredential).toEqual({
+          accessToken: 'valid-token',
+          signInMethod: 'github.com',
+          providerId: 'github.com',
+        });
         writeAuthConfigFileCalled = true;
       },
     );
 
     await expect(loginHandlerPromise).rejects.toThrow(
-      'Error saving credentials: Error: Missing customToken from the auth provider.',
+      'Error saving credentials: Error: Missing auth credential from the auth provider.',
     );
     expect(openInBrowserCalled).toEqual(true);
     expect(writeAuthConfigFileCalled).toEqual(false);
   });
 
-  test('should pass if customToken is valid', async () => {
+  test('should pass if authCredential is valid', async () => {
     // spyOn writeAuthConfigFile
     const callbackUrl = new URL('http://localhost:8976/oauth/callback');
-    callbackUrl.searchParams.set('customToken', 'valid-token');
+    callbackUrl.searchParams.set(
+      'authCredential',
+      '{"accessToken":"valid-token","providerId":"github.com","signInMethod":"github.com"}',
+    );
     let openInBrowserCalled = false;
     let writeAuthConfigFileCalled = false;
 
@@ -55,7 +62,11 @@ describe('loginHandler', () => {
       },
       (config: UserAuthConfig) => {
         expect(config).toBeDefined();
-        expect(config.customToken).toEqual('valid-token');
+        expect(config.authCredential).toEqual({
+          accessToken: 'valid-token',
+          signInMethod: 'github.com',
+          providerId: 'github.com',
+        });
         writeAuthConfigFileCalled = true;
       },
     );

--- a/mirror/reflect-cli/src/login.ts
+++ b/mirror/reflect-cli/src/login.ts
@@ -4,7 +4,9 @@ import http from 'node:http';
 import type {Socket} from 'node:net';
 import open from 'open';
 import {sleep} from 'shared/src/sleep.js';
+import {parse} from 'shared/src/valita.js';
 import {
+  authCredentialSchema,
   UserAuthConfig,
   writeAuthConfigFile as writeAuthConfigFileImpl,
 } from './auth-config.js';
@@ -27,12 +29,18 @@ export async function loginHandler(
 
     switch (pathname) {
       case '/oauth/callback': {
-        const customToken = searchParams.get('customToken');
+        const authCredential = searchParams.get('authCredential');
         try {
-          if (!customToken) {
-            throw new Error(`Missing customToken from the auth provider.`);
+          if (!authCredential) {
+            throw new Error(`Missing auth credential from the auth provider.`);
           }
-          const authConfig: UserAuthConfig = {customToken};
+          const authConfig: UserAuthConfig = {
+            authCredential: parse(
+              JSON.parse(authCredential),
+              authCredentialSchema,
+              'passthrough',
+            ),
+          };
 
           writeAuthConfigFile(authConfig);
         } catch (error) {

--- a/mirror/reflect-cli/src/test-helpers.ts
+++ b/mirror/reflect-cli/src/test-helpers.ts
@@ -3,7 +3,11 @@ import {setAuthConfigForTesting} from './auth-config.js';
 
 export function useFakeAuthConfig() {
   const newConfig = {
-    customToken: 'fake-custom-token',
+    authCredential: {
+      accessToken: 'valid-token',
+      providerId: 'github.com',
+      signInMethod: 'github.com',
+    },
   };
 
   beforeEach(() => {


### PR DESCRIPTION
The previous strategy of storing the a "custom token" was problematic in that custom tokens only last for one hour.

Instead, we store the `AuthCredential.toJSON()` object in `~/.reflect/config/default.json`, and then call the appropriate `FooAuthCredential.fromJSON(json)` method to `signInWithCredential()`. This should result in a longer lasting authentication scheme.

#684 