### PR TITLE
chore: use a cloud bucket named "modules" to better reflect its purpose

### DIFF
--- a/mirror/mirror-server/src/config/index.ts
+++ b/mirror/mirror-server/src/config/index.ts
@@ -13,7 +13,7 @@ function createAppOptions(): AppOptions {
 export const appOptions = createAppOptions();
 export const {projectId = ''} = appOptions;
 export const {serviceAccountId = ''} = appOptions;
-export const serversBucketName = `${projectId}-servers`;
+export const modulesBucketName = `${projectId}-modules`;
 
 export const baseHttpsOptions: HttpsOptions = {
   // TODO(darick): Convert to a limited list.

--- a/mirror/mirror-server/src/index.ts
+++ b/mirror/mirror-server/src/index.ts
@@ -6,7 +6,7 @@ import {https, setGlobalOptions} from 'firebase-functions/v2';
 import {
   appOptions,
   baseHttpsOptions,
-  serversBucketName,
+  modulesBucketName,
   serviceAccountId,
 } from './config/index.js';
 import * as appFunctions from './functions/app/index.js';
@@ -23,7 +23,7 @@ export const publish = https.onCall(
     ...baseHttpsOptions,
     secrets: ['CLOUDFLARE_API_TOKEN'],
   },
-  publishHandler(getFirestore(), getStorage(), serversBucketName),
+  publishHandler(getFirestore(), getStorage(), modulesBucketName),
 );
 
 export const healthcheck = https.onRequest(


### PR DESCRIPTION
I realize that we're storing both app and server modules in the same bucket. I like the simplicity of that, and created a new bucket with a better name.

New modules would be stored there. We can move the old files (and rename the links to them in Firestore) if we want, but that's not super important.