### PR TITLE
fix(reflect-client): Add missing replicache dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40926,7 +40926,7 @@
         "reflect-protocol": "0.0.0",
         "reflect-shared": "0.0.0",
         "reflect-types": "0.0.0",
-        "replicache": "13.0.0-beta.0",
+        "replicache": "13.0.0-beta.1",
         "rollup": "^3.24.0",
         "rollup-plugin-dts": "^5.3.0",
         "shared": "0.0.0",
@@ -41387,32 +41387,6 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
-    },
-    "packages/reflect-client/node_modules/replicache": {
-      "version": "13.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/replicache/-/replicache-13.0.0-beta.0.tgz",
-      "integrity": "sha512-vMf/xzDBY4Bz7svqZ7cI5BzsGbo5OL58LsC3uzkAq5kWuYnwh7Zt7FIq6/38E6BKSdPgmDzswNz+HgUU/PQZsg==",
-      "dev": true,
-      "dependencies": {
-        "@rocicorp/lock": "^1.0.1",
-        "@rocicorp/logger": "^4.1.0",
-        "@rocicorp/resolver": "^1.0.0"
-      },
-      "bin": {
-        "replicache": "out/cli.cjs"
-      },
-      "engines": {
-        "node": ">=14.8.0"
-      }
-    },
-    "packages/reflect-client/node_modules/replicache/node_modules/@rocicorp/logger": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@rocicorp/logger/-/logger-4.1.0.tgz",
-      "integrity": "sha512-RdXs1oowcSdgaYHIdROc0td0GIG5LnYMYZgK/forGfAu65ytDC59dz4VGe5+08Q8Ko3xg8KM7aDM5podnfFJ7w==",
-      "dev": true,
-      "engines": {
-        "node": "^14.13.1 || >=16.0.0"
-      }
     },
     "packages/reflect-client/node_modules/rollup": {
       "version": "3.25.1",
@@ -68642,7 +68616,7 @@
         "reflect-protocol": "0.0.0",
         "reflect-shared": "0.0.0",
         "reflect-types": "0.0.0",
-        "replicache": "13.0.0-beta.0",
+        "replicache": "13.0.0-beta.1",
         "rollup": "^3.24.0",
         "rollup-plugin-dts": "^5.3.0",
         "shared": "0.0.0",
@@ -68876,25 +68850,6 @@
           "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
           "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
           "dev": true
-        },
-        "replicache": {
-          "version": "13.0.0-beta.0",
-          "resolved": "https://registry.npmjs.org/replicache/-/replicache-13.0.0-beta.0.tgz",
-          "integrity": "sha512-vMf/xzDBY4Bz7svqZ7cI5BzsGbo5OL58LsC3uzkAq5kWuYnwh7Zt7FIq6/38E6BKSdPgmDzswNz+HgUU/PQZsg==",
-          "dev": true,
-          "requires": {
-            "@rocicorp/lock": "^1.0.1",
-            "@rocicorp/logger": "^4.1.0",
-            "@rocicorp/resolver": "^1.0.0"
-          },
-          "dependencies": {
-            "@rocicorp/logger": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/@rocicorp/logger/-/logger-4.1.0.tgz",
-              "integrity": "sha512-RdXs1oowcSdgaYHIdROc0td0GIG5LnYMYZgK/forGfAu65ytDC59dz4VGe5+08Q8Ko3xg8KM7aDM5podnfFJ7w==",
-              "dev": true
-            }
-          }
         },
         "rollup": {
           "version": "3.25.1",

--- a/packages/reflect-client/package.json
+++ b/packages/reflect-client/package.json
@@ -37,7 +37,7 @@
     "reflect-protocol": "0.0.0",
     "reflect-shared": "0.0.0",
     "reflect-types": "0.0.0",
-    "replicache": "13.0.0-beta.0",
+    "replicache": "13.0.0-beta.1",
     "rollup": "^3.24.0",
     "rollup-plugin-dts": "^5.3.0",
     "shared": "0.0.0",


### PR DESCRIPTION
I guess this was working before because other things were ensuring this was in the shared root node_modules already.  Still better to explicitly list it.  Verified this does not reintroduce the ambient initializer issue.  