### PR TITLE
fix: redundant deletes to be no-op (and return false)

### DIFF
--- a/packages/reflect-server/src/storage/replicache-transaction.test.ts
+++ b/packages/reflect-server/src/storage/replicache-transaction.test.ts
@@ -65,8 +65,11 @@ test('ReplicacheTransaction', async () => {
   expect(await storage.get('v/01/foo', userValueVersionInfoSchema)).toEqual({});
 
   // delete has special return value
-  expect(await writeTx3.del('foo'));
-  expect(!(await writeTx3.del('bar')));
+  expect(await writeTx3.del('foo')).toBe(true);
+  expect(await writeTx3.del('bar')).toBe(false);
+
+  // Redundant del should be a no-op
+  expect(await writeTx3.del('foo')).toBe(false);
 
   await entryCache.flush();
 

--- a/packages/reflect-server/src/storage/replicache-transaction.ts
+++ b/packages/reflect-server/src/storage/replicache-transaction.ts
@@ -59,7 +59,7 @@ export class ReplicacheTransaction implements WriteTransaction {
 
   async del(key: string): Promise<boolean> {
     const prev = await this._getUserValueEntry(key);
-    if (prev === undefined) {
+    if (prev === undefined || prev.deleted) {
       return false;
     }
 


### PR DESCRIPTION
#268 