### PR TITLE
feat: add some concurrency primitives

### DIFF
--- a/packages/shared/src/async.test.ts
+++ b/packages/shared/src/async.test.ts
@@ -1,6 +1,5 @@
 import {describe, expect, test} from '@jest/globals';
-import {CountDownLatch, Signal} from './async.js';
-import {sleep} from './sleep.js';
+import {CountDownLatch} from './async.js';
 
 describe('CountDownLatch', () => {
   test('countDown and zero', async () => {
@@ -39,30 +38,5 @@ describe('CountDownLatch', () => {
     expect(latch.value()).toBe(0);
     latch.countDown();
     expect(latch.value()).toBe(0);
-  });
-});
-
-describe('Signal', () => {
-  test('notify and notification', async () => {
-    const signal1 = new Signal();
-    const signal2 = new Signal();
-
-    let waiting = true;
-
-    const fn = new Promise<void>(async resolve => {
-      await signal2.notification();
-      waiting = false;
-      signal1.notify();
-      resolve();
-    });
-
-    await sleep(1);
-    expect(waiting).toBe(true);
-
-    signal2.notify();
-    await signal1.notification();
-    expect(waiting).toBe(false);
-
-    expect(fn).resolves;
   });
 });

--- a/packages/shared/src/async.ts
+++ b/packages/shared/src/async.ts
@@ -1,23 +1,19 @@
 import {assert} from './asserts.js';
-import {must} from './must.js';
+import {resolver} from '@rocicorp/resolver';
 
 /**
  * Primitive for synchronizing across concurrent logic.
  */
 export class CountDownLatch {
   readonly #promise: Promise<void>;
-  readonly #resolve: (value: void | PromiseLike<void>) => void;
+  readonly #resolve: (value: void) => void;
   #value: number;
 
   constructor(initialValue = 1) {
     assert(initialValue > 0);
-    let capturedResolve:
-      | ((value: void | PromiseLike<void>) => void)
-      | undefined;
-    this.#promise = new Promise(resolve => {
-      capturedResolve = resolve;
-    });
-    this.#resolve = must(capturedResolve);
+    const {promise, resolve} = resolver<void>();
+    this.#promise = promise;
+    this.#resolve = resolve;
     this.#value = initialValue;
   }
 
@@ -42,18 +38,5 @@ export class CountDownLatch {
     if (this.#value === 0) {
       this.#resolve();
     }
-  }
-}
-
-/** A one-time signal for coordinating a single event across concurrent logic. */
-export class Signal {
-  readonly #latch = new CountDownLatch(1);
-
-  notification(): Promise<void> {
-    return this.#latch.zero();
-  }
-
-  notify() {
-    this.#latch.countDown();
   }
 }


### PR DESCRIPTION
Mostly useful for testing concurrent logic in tests, but can be used more generally as well.

CountDownLatch is modeled after https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CountDownLatch.html