### PR TITLE
Allow the Datadog service label to be set by ENV

### DIFF
--- a/apps/reflect.net/demo/worker/index.ts
+++ b/apps/reflect.net/demo/worker/index.ts
@@ -19,6 +19,8 @@ type ReflectNetServerEnv = {
   DATADOG_METRICS_API_KEY?: string;
   // eslint-disable-next-line @typescript-eslint/naming-convention
   DATADOG_LOGS_API_KEY?: string;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  DATADOG_SERVICE_LABEL?: string;
 } & ReflectServerBaseEnv;
 
 function getDatadogMetricsOptions(env: ReflectNetServerEnv) {
@@ -30,7 +32,7 @@ function getDatadogMetricsOptions(env: ReflectNetServerEnv) {
   }
   return {
     apiKey: env.DATADOG_METRICS_API_KEY,
-    service: DATADOG_SERVICE_LABEL,
+    service: env.DATADOG_SERVICE_LABEL ?? DEFAULT_DATADOG_SERVICE_LABEL,
   };
 }
 
@@ -45,13 +47,13 @@ function getLogSinks(env: ReflectNetServerEnv) {
   return [
     createWorkerDatadogLogSink({
       apiKey: env.DATADOG_LOGS_API_KEY,
-      service: DATADOG_SERVICE_LABEL,
+      service: env.DATADOG_SERVICE_LABEL ?? DEFAULT_DATADOG_SERVICE_LABEL,
     }),
     consoleLogSink,
   ];
 }
 
-const DATADOG_SERVICE_LABEL = 'reflect.net';
+const DEFAULT_DATADOG_SERVICE_LABEL = 'reflect.net';
 const {
   worker,
   // eslint-disable-next-line @typescript-eslint/naming-convention


### PR DESCRIPTION
This will allow staging to output logs to DD with the service label `staging.reflect.net`. 

<img width="1043" alt="Screenshot 2023-07-28 at 12 26 21 PM" src="https://github.com/rocicorp/mono/assets/132324914/6ea9ff4e-9eec-44b5-933a-0cb7a950db39">
