### PR TITLE
refactor: move gcs logic from shared to mirror-schema

### DIFF
--- a/mirror/mirror-cli/src/upload.ts
+++ b/mirror/mirror-cli/src/upload.ts
@@ -15,7 +15,7 @@ import type {
 } from 'reflect-cli/src/yarg-types.js';
 import {SemVer} from 'semver';
 import {assert, assertObject, assertString} from 'shared/src/asserts.js';
-import {storeModule} from 'shared/src/mirror/store-module.js';
+import {storeModule} from 'mirror-schema/src/module.js';
 
 const require = createRequire(import.meta.url);
 

--- a/mirror/mirror-schema/package.json
+++ b/mirror/mirror-schema/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@badrap/valita": "^0.2.0",
     "@google-cloud/firestore": "^6.6.1",
+    "@google-cloud/storage": "^6.12.0",
     "firestore-jest-mock": "^0.21.0"
   },
   "devDependencies": {

--- a/mirror/mirror-schema/src/cloud-storage.test.ts
+++ b/mirror/mirror-schema/src/cloud-storage.test.ts
@@ -1,12 +1,20 @@
 import {expect, test} from '@jest/globals';
-import {parseCloudStorageURL} from './parse-cloud-storage-url.js';
+import {parseCloudStorageURL} from './cloud-storage.js';
 
 test('parseCloudStorageURL', () => {
   expect(parseCloudStorageURL('gs://bucket-name/filename')).toEqual({
     bucketName: 'bucket-name',
     filename: 'filename',
   });
+  expect(parseCloudStorageURL('gcs://bucket-name/filename')).toEqual({
+    bucketName: 'bucket-name',
+    filename: 'filename',
+  });
   expect(parseCloudStorageURL('gs://bucket-name/path/filename')).toEqual({
+    bucketName: 'bucket-name',
+    filename: 'path/filename',
+  });
+  expect(parseCloudStorageURL('gcs://bucket-name/path/filename')).toEqual({
     bucketName: 'bucket-name',
     filename: 'path/filename',
   });

--- a/mirror/mirror-schema/src/cloud-storage.ts
+++ b/mirror/mirror-schema/src/cloud-storage.ts
@@ -6,7 +6,7 @@ export function parseCloudStorageURL(url: string): {
 } {
   // Don't use the built in URL class, because Node.js implementation is not
   // standards compliant.
-  const m = url.match(/^gs:\/\/([^/]+)\/(.+)$/);
+  const m = url.match(/^gc?s:\/\/([^/]+)\/(.+)$/);
   assert(m);
   return {bucketName: m[1], filename: m[2]};
 }

--- a/mirror/mirror-schema/src/module.test.ts
+++ b/mirror/mirror-schema/src/module.test.ts
@@ -1,6 +1,6 @@
 import type {Bucket} from '@google-cloud/storage';
 import {expect, test} from '@jest/globals';
-import {sha256OfString, storeModule} from './store-module.js';
+import {sha256OfString, storeModule} from './module.js';
 
 test('basic', async () => {
   expect(await sha256OfString('foo')).toBe(

--- a/mirror/mirror-schema/src/module.ts
+++ b/mirror/mirror-schema/src/module.ts
@@ -1,5 +1,5 @@
 import type {Bucket} from '@google-cloud/storage';
-import * as crypto from './crypto.js';
+import * as crypto from 'shared/src/mirror/crypto.js';
 
 type Module = {
   name: string;

--- a/mirror/mirror-server/src/cloudflare/get-server-modules.ts
+++ b/mirror/mirror-server/src/cloudflare/get-server-modules.ts
@@ -3,7 +3,7 @@ import type {Storage} from 'firebase-admin/storage';
 import {HttpsError} from 'firebase-functions/v2/https';
 import * as schema from 'mirror-schema/src/server.js';
 import assert from 'node:assert';
-import {parseCloudStorageURL} from '../parse-cloud-storage-url.js';
+import {parseCloudStorageURL} from 'mirror-schema/src/cloud-storage.js';
 import type {CfModule} from './create-worker-upload-form.js';
 
 export async function getServerModules(

--- a/mirror/mirror-server/src/functions/app/publish.function.ts
+++ b/mirror/mirror-server/src/functions/app/publish.function.ts
@@ -11,7 +11,7 @@ import * as schema from 'mirror-schema/src/deployment.js';
 import * as semver from 'semver';
 import {newDeploymentID} from 'shared/src/mirror/ids.js';
 import {isSupportedSemverRange} from 'shared/src/mirror/is-supported-semver-range.js';
-import {storeModule} from 'shared/src/mirror/store-module.js';
+import {storeModule} from 'mirror-schema/src/module.js';
 import type {CfModule} from '../../cloudflare/create-worker-upload-form.js';
 import {getServerModuleMetadata} from '../../cloudflare/get-server-modules.js';
 import {publish as publishToCloudflare} from '../../cloudflare/publish.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1911,6 +1911,7 @@
       "dependencies": {
         "@badrap/valita": "^0.2.0",
         "@google-cloud/firestore": "^6.6.1",
+        "@google-cloud/storage": "^6.12.0",
         "firestore-jest-mock": "^0.21.0"
       },
       "devDependencies": {
@@ -7457,7 +7458,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-3.0.7.tgz",
       "integrity": "sha512-jJNutk0arIQhmpUUQJPJErsojqo834KcyB6X7a1mxuic8i1tKXxde8E69IZxNZawRIlZdIK2QY4WALvlK5MzYQ==",
-      "devOptional": true,
       "dependencies": {
         "arrify": "^2.0.0",
         "extend": "^3.0.2"
@@ -7470,7 +7470,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
       "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -7488,7 +7487,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-3.0.0.tgz",
       "integrity": "sha512-HRkZsNmjScY6Li8/kb70wjGlDDyLkVk3KvoEo9uIoxSjYLJasGiCch9+PqRVDOCGUFvEIqyogl+BeqILL4OJHA==",
-      "devOptional": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -7497,7 +7495,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-3.0.1.tgz",
       "integrity": "sha512-z1CjRjtQyBOYL+5Qr9DdYIfrdLBe746jRTYfaYU6MeXkqp7UfYs/jX16lFFVzZ7PGEJvqZNqYUEtb1mvDww4pA==",
-      "devOptional": true,
       "engines": {
         "node": ">=12"
       }
@@ -7564,7 +7561,6 @@
       "version": "6.12.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-6.12.0.tgz",
       "integrity": "sha512-78nNAY7iiZ4O/BouWMWTD/oSF2YtYgYB3GZirn0To6eBOugjXVoK+GXgUXOl+HlqbAOyHxAVXOlsj3snfbQ1dw==",
-      "devOptional": true,
       "dependencies": {
         "@google-cloud/paginator": "^3.0.7",
         "@google-cloud/projectify": "^3.0.0",
@@ -7593,7 +7589,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
       "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
-      "devOptional": true,
       "dependencies": {
         "end-of-stream": "^1.4.1",
         "inherits": "^2.0.3",
@@ -7605,7 +7600,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
       "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-      "devOptional": true,
       "bin": {
         "mime": "cli.js"
       },
@@ -7617,7 +7611,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "devOptional": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -16333,7 +16326,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
       "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
-      "devOptional": true,
       "dependencies": {
         "retry": "0.13.1"
       }
@@ -20484,8 +20476,7 @@
     "node_modules/ent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
-      "integrity": "sha512-GHrMyVZQWvTIdDtpiEXdHZnFQKzeO09apj8Cbl4pKWy4i0Oprcq17usfDt5aO63swf0JOeMWjWQE/LzgSRuWpA==",
-      "devOptional": true
+      "integrity": "sha512-GHrMyVZQWvTIdDtpiEXdHZnFQKzeO09apj8Cbl4pKWy4i0Oprcq17usfDt5aO63swf0JOeMWjWQE/LzgSRuWpA=="
     },
     "node_modules/entities": {
       "version": "2.1.0",
@@ -36694,7 +36685,6 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "devOptional": true,
       "engines": {
         "node": ">= 4"
       }
@@ -38238,7 +38228,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
       "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
-      "devOptional": true,
       "dependencies": {
         "stubs": "^3.0.0"
       }
@@ -38463,8 +38452,7 @@
     "node_modules/stubs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
-      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
-      "devOptional": true
+      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw=="
     },
     "node_modules/style-to-object": {
       "version": "0.4.1",
@@ -39144,7 +39132,6 @@
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-8.0.3.tgz",
       "integrity": "sha512-jJZpA5He2y52yUhA7pyAGZlgQpcB+xLjcN0eUFxr9c8hP/H7uOXbBNVo/O0C/xVfJLJs680jvkFgVJEEvk9+ww==",
-      "devOptional": true,
       "dependencies": {
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
@@ -39160,7 +39147,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-      "devOptional": true,
       "engines": {
         "node": ">= 10"
       }
@@ -39169,7 +39155,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-      "devOptional": true,
       "dependencies": {
         "@tootallnate/once": "2",
         "agent-base": "6",
@@ -39183,7 +39168,6 @@
       "version": "2.6.11",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
       "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
-      "devOptional": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -39202,14 +39186,12 @@
     "node_modules/teeny-request/node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "devOptional": true
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/teeny-request/node_modules/uuid": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
       "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "devOptional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -39217,14 +39199,12 @@
     "node_modules/teeny-request/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "devOptional": true
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/teeny-request/node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "devOptional": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -45919,7 +45899,6 @@
       "version": "0.0.0",
       "devDependencies": {
         "@badrap/valita": "^0.2.0",
-        "@google-cloud/storage": "^6.12.0",
         "@rocicorp/eslint-config": "^0.4.2",
         "@rocicorp/logger": "^5.2.0",
         "@rocicorp/prettier-config": "^0.1.1",
@@ -48984,7 +48963,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-3.0.7.tgz",
       "integrity": "sha512-jJNutk0arIQhmpUUQJPJErsojqo834KcyB6X7a1mxuic8i1tKXxde8E69IZxNZawRIlZdIK2QY4WALvlK5MzYQ==",
-      "devOptional": true,
       "requires": {
         "arrify": "^2.0.0",
         "extend": "^3.0.2"
@@ -48993,8 +48971,7 @@
         "arrify": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-          "devOptional": true
+          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
         }
       }
     },
@@ -49007,14 +48984,12 @@
     "@google-cloud/projectify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-3.0.0.tgz",
-      "integrity": "sha512-HRkZsNmjScY6Li8/kb70wjGlDDyLkVk3KvoEo9uIoxSjYLJasGiCch9+PqRVDOCGUFvEIqyogl+BeqILL4OJHA==",
-      "devOptional": true
+      "integrity": "sha512-HRkZsNmjScY6Li8/kb70wjGlDDyLkVk3KvoEo9uIoxSjYLJasGiCch9+PqRVDOCGUFvEIqyogl+BeqILL4OJHA=="
     },
     "@google-cloud/promisify": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-3.0.1.tgz",
-      "integrity": "sha512-z1CjRjtQyBOYL+5Qr9DdYIfrdLBe746jRTYfaYU6MeXkqp7UfYs/jX16lFFVzZ7PGEJvqZNqYUEtb1mvDww4pA==",
-      "devOptional": true
+      "integrity": "sha512-z1CjRjtQyBOYL+5Qr9DdYIfrdLBe746jRTYfaYU6MeXkqp7UfYs/jX16lFFVzZ7PGEJvqZNqYUEtb1mvDww4pA=="
     },
     "@google-cloud/pubsub": {
       "version": "3.7.0",
@@ -49068,7 +49043,6 @@
       "version": "6.12.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-6.12.0.tgz",
       "integrity": "sha512-78nNAY7iiZ4O/BouWMWTD/oSF2YtYgYB3GZirn0To6eBOugjXVoK+GXgUXOl+HlqbAOyHxAVXOlsj3snfbQ1dw==",
-      "devOptional": true,
       "requires": {
         "@google-cloud/paginator": "^3.0.7",
         "@google-cloud/projectify": "^3.0.0",
@@ -49094,7 +49068,6 @@
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
           "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
-          "devOptional": true,
           "requires": {
             "end-of-stream": "^1.4.1",
             "inherits": "^2.0.3",
@@ -49105,14 +49078,12 @@
         "mime": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-          "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-          "devOptional": true
+          "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="
         },
         "p-limit": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
           "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-          "devOptional": true,
           "requires": {
             "yocto-queue": "^0.1.0"
           }
@@ -56379,7 +56350,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
       "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
-      "devOptional": true,
       "requires": {
         "retry": "0.13.1"
       }
@@ -59529,8 +59499,7 @@
     "ent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
-      "integrity": "sha512-GHrMyVZQWvTIdDtpiEXdHZnFQKzeO09apj8Cbl4pKWy4i0Oprcq17usfDt5aO63swf0JOeMWjWQE/LzgSRuWpA==",
-      "devOptional": true
+      "integrity": "sha512-GHrMyVZQWvTIdDtpiEXdHZnFQKzeO09apj8Cbl4pKWy4i0Oprcq17usfDt5aO63swf0JOeMWjWQE/LzgSRuWpA=="
     },
     "entities": {
       "version": "2.1.0",
@@ -69513,6 +69482,7 @@
       "requires": {
         "@badrap/valita": "^0.2.0",
         "@google-cloud/firestore": "^6.6.1",
+        "@google-cloud/storage": "^6.12.0",
         "@rocicorp/eslint-config": "^0.4.2",
         "@rocicorp/prettier-config": "^0.1.1",
         "firebase-tools": "^12.3.0",
@@ -75131,8 +75101,7 @@
     "retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "devOptional": true
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
     },
     "retry-request": {
       "version": "5.0.2",
@@ -75551,7 +75520,6 @@
       "version": "file:packages/shared",
       "requires": {
         "@badrap/valita": "^0.2.0",
-        "@google-cloud/storage": "^6.12.0",
         "@rocicorp/eslint-config": "^0.4.2",
         "@rocicorp/logger": "^5.2.0",
         "@rocicorp/prettier-config": "^0.1.1",
@@ -76401,7 +76369,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
       "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
-      "devOptional": true,
       "requires": {
         "stubs": "^3.0.0"
       }
@@ -76578,8 +76545,7 @@
     "stubs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
-      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
-      "devOptional": true
+      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw=="
     },
     "style-to-object": {
       "version": "0.4.1",
@@ -77085,7 +77051,6 @@
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-8.0.3.tgz",
       "integrity": "sha512-jJZpA5He2y52yUhA7pyAGZlgQpcB+xLjcN0eUFxr9c8hP/H7uOXbBNVo/O0C/xVfJLJs680jvkFgVJEEvk9+ww==",
-      "devOptional": true,
       "requires": {
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
@@ -77097,14 +77062,12 @@
         "@tootallnate/once": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-          "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-          "devOptional": true
+          "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
         },
         "http-proxy-agent": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
           "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-          "devOptional": true,
           "requires": {
             "@tootallnate/once": "2",
             "agent-base": "6",
@@ -77115,7 +77078,6 @@
           "version": "2.6.11",
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
           "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
-          "devOptional": true,
           "requires": {
             "whatwg-url": "^5.0.0"
           }
@@ -77123,26 +77085,22 @@
         "tr46": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-          "devOptional": true
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
         },
         "uuid": {
           "version": "9.0.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-          "devOptional": true
+          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
         },
         "webidl-conversions": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-          "devOptional": true
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
         },
         "whatwg-url": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
           "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-          "devOptional": true,
           "requires": {
             "tr46": "~0.0.3",
             "webidl-conversions": "^3.0.0"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,7 +13,6 @@
   },
   "devDependencies": {
     "@badrap/valita": "^0.2.0",
-    "@google-cloud/storage": "^6.12.0",
     "@rocicorp/eslint-config": "^0.4.2",
     "@rocicorp/logger": "^5.2.0",
     "@rocicorp/prettier-config": "^0.1.1",


### PR DESCRIPTION
Nice to keep all of the google-cloud dependencies out of the reflect (i.e. packages) world.

Small change: recognize "gcs://..." urls, which are equivalent to "gs://..." urls.