### PR TITLE
Add the milliscond time as the lockTiming log attribute

### DIFF
--- a/packages/reflect-server/src/util/lock.test.ts
+++ b/packages/reflect-server/src/util/lock.test.ts
@@ -62,15 +62,17 @@ describe('LoggingLock', () => {
     expect(sink.messages[0][0]).toBe('debug');
     expect(sink.messages[0][1]).toMatchObject({
       lockFn: 'logic',
-      lockTiming: 'acquired',
+      lockStage: 'acquired',
     });
     expect(sink.messages[0][1]).toHaveProperty('lockHoldID');
+    expect(sink.messages[0][1]).toHaveProperty('lockTiming');
     expect(sink.messages[1][0]).toBe('debug');
     expect(sink.messages[1][1]).toMatchObject({
       lockFn: 'logic',
-      lockTiming: 'held',
+      lockStage: 'held',
     });
     expect(sink.messages[1][1]).toHaveProperty('lockHoldID');
+    expect(sink.messages[1][1]).toHaveProperty('lockTiming');
   });
 
   test('logs at info level above threshold', async () => {
@@ -101,15 +103,17 @@ describe('LoggingLock', () => {
     expect(sink.messages[0][0]).toBe('debug');
     expect(sink.messages[0][1]).toMatchObject({
       lockFn: 'logic',
-      lockTiming: 'acquired',
+      lockStage: 'acquired',
     });
     expect(sink.messages[0][1]).toHaveProperty('lockHoldID');
+    expect(sink.messages[0][1]).toHaveProperty('lockTiming');
     expect(sink.messages[1][0]).toBe('info');
     expect(sink.messages[1][1]).toMatchObject({
       lockFn: 'logic',
-      lockTiming: 'held',
+      lockStage: 'held',
     });
     expect(sink.messages[1][1]).toHaveProperty('lockHoldID');
+    expect(sink.messages[1][1]).toHaveProperty('lockTiming');
   });
 
   test('logs multiple waiters without awaiting flush', async () => {

--- a/packages/reflect-server/src/util/lock.ts
+++ b/packages/reflect-server/src/util/lock.ts
@@ -59,9 +59,9 @@ export class LoggingLock {
 
       const elapsed = t1 - t0;
       if (elapsed >= this.#minThresholdMs) {
-        lc.withContext('lockTiming', 'acquired').debug?.(
-          `${name} acquired lock in ${elapsed} ms`,
-        );
+        lc.withContext('lockStage', 'acquired')
+          .withContext('lockTiming', elapsed)
+          .debug?.(`${name} acquired lock in ${elapsed} ms`);
       }
 
       try {
@@ -71,7 +71,9 @@ export class LoggingLock {
         const elapsed = t2 - t1;
         if (elapsed >= this.#minThresholdMs) {
           flushAfterLock = elapsed >= flushLogsIfLockHeldForMs;
-          const tlc = lc.withContext('lockTiming', 'held');
+          const tlc = lc
+            .withContext('lockStage', 'held')
+            .withContext('lockTiming', elapsed);
           (flushAfterLock ? tlc.info : tlc.debug)?.(
             `${name} held lock for ${elapsed} ms`,
           );


### PR DESCRIPTION
This will allow us to do range searches in Datadog.

Renames the previous `lockTiming` attribute (`acquired` or `held`) to `lockStage`.

#351 