### PR TITLE
refactor: advertise that the firestore jest mock implement both APIs

### DIFF
--- a/mirror/mirror-schema/src/test-helpers.ts
+++ b/mirror/mirror-schema/src/test-helpers.ts
@@ -1,4 +1,5 @@
 import type {Firestore} from '@google-cloud/firestore';
+import type firebase from 'firebase/compat/app';
 import {firebaseStub} from 'firestore-jest-mock/mocks/firebase.js';
 import {
   App,
@@ -26,11 +27,15 @@ import {
 } from 'mirror-schema/src/user.js';
 import {must} from 'shared/src/must.js';
 
-export function fakeFirestore(): Firestore {
+// The server and (v8) client Firestore interfaces are largely the same.
+// Have the jest mock implement both, which should largely work for our testing purposes.
+type AllTheFirestores = Firestore & firebase.default.firestore.Firestore;
+
+export function fakeFirestore(): AllTheFirestores {
   return firebaseStub(
     {database: {}},
     {mutable: true},
-  ).firestore() as unknown as Firestore;
+  ).firestore() as unknown as AllTheFirestores;
 }
 
 export async function setUser(

--- a/mirror/reflect-cli/src/get-existing-apps-for-user.test.ts
+++ b/mirror/reflect-cli/src/get-existing-apps-for-user.test.ts
@@ -5,7 +5,6 @@ import {
   setTeam,
   setUser,
 } from 'mirror-schema/src/test-helpers.js';
-import type {Firestore} from './firebase.js';
 import {getExistingAppsForUser} from './get-existing-apps-for-user.js';
 
 test('list when no team', async () => {
@@ -14,10 +13,7 @@ test('list when no team', async () => {
   const email = 'foo@bar.com';
   await setUser(firestore, userID, email, 'Foo Bar', {});
 
-  const apps = await getExistingAppsForUser(
-    firestore as unknown as Firestore,
-    userID,
-  );
+  const apps = await getExistingAppsForUser(firestore, userID);
 
   expect(apps).toEqual([]);
 });
@@ -29,10 +25,7 @@ test('list when missing team', async () => {
   const teamID = 'fooTeam';
   await setUser(firestore, userID, email, 'Foo Bar', {[teamID]: 'admin'});
 
-  const apps = await getExistingAppsForUser(
-    firestore as unknown as Firestore,
-    userID,
-  );
+  const apps = await getExistingAppsForUser(firestore, userID);
 
   expect(apps).toEqual([]);
 });
@@ -45,10 +38,7 @@ test('list with one team but no apps', async () => {
   await setUser(firestore, userID, email, 'Foo Bar', {[teamID]: 'admin'});
   await setTeam(firestore, teamID, {name: 'Foo Team'});
 
-  const apps = await getExistingAppsForUser(
-    firestore as unknown as Firestore,
-    userID,
-  );
+  const apps = await getExistingAppsForUser(firestore, userID);
 
   expect(apps).toEqual([]);
 });
@@ -66,10 +56,7 @@ test('list with multiple teams but no apps', async () => {
   await setTeam(firestore, teamID1, {name: 'Team 1'});
   await setTeam(firestore, teamID2, {name: 'Team 2'});
 
-  const apps = await getExistingAppsForUser(
-    firestore as unknown as Firestore,
-    userID,
-  );
+  const apps = await getExistingAppsForUser(firestore, userID);
 
   expect(apps).toEqual([]);
 });
@@ -86,10 +73,7 @@ test('list with one teams and one app', async () => {
   await setTeam(firestore, teamID, {name: 'Team Name'});
   await setApp(firestore, 'app-id', {teamID});
 
-  const apps = await getExistingAppsForUser(
-    firestore as unknown as Firestore,
-    userID,
-  );
+  const apps = await getExistingAppsForUser(firestore, userID);
 
   expect(apps).toEqual([
     {
@@ -116,10 +100,7 @@ test('list with one teams and two apps', async () => {
   await setApp(firestore, 'app-id-1', {teamID});
   await setApp(firestore, 'app-id-2', {teamID, serverReleaseChannel: 'canary'});
 
-  const apps = await getExistingAppsForUser(
-    firestore as unknown as Firestore,
-    userID,
-  );
+  const apps = await getExistingAppsForUser(firestore, userID);
 
   expect(apps).toEqual([
     {
@@ -160,10 +141,7 @@ test('list with two teams and two apps total', async () => {
     serverReleaseChannel: 'canary',
   });
 
-  const apps = await getExistingAppsForUser(
-    firestore as unknown as Firestore,
-    userID,
-  );
+  const apps = await getExistingAppsForUser(firestore, userID);
 
   expect(apps).toEqual([
     {
@@ -209,10 +187,7 @@ test('list with two teams and 4 apps total', async () => {
     serverReleaseChannel: 'canary',
   });
 
-  const apps = await getExistingAppsForUser(
-    firestore as unknown as Firestore,
-    userID,
-  );
+  const apps = await getExistingAppsForUser(firestore, userID);
 
   expect(apps).toEqual([
     {


### PR DESCRIPTION
Simplifies testing code.

#779 