### PR TITLE
refactor: use the server-sdk compatible version of onSnapshot()

### DIFF
--- a/mirror/reflect-cli/src/publish.ts
+++ b/mirror/reflect-cli/src/publish.ts
@@ -78,8 +78,8 @@ export async function publishHandler(
   const stopListener = (firestore ?? getFirestore())
     .doc(deploymentPath)
     .withConverter(deploymentDataConverter)
-    .onSnapshot({
-      next: snapshot => {
+    .onSnapshot(
+      snapshot => {
         const deployment = snapshot.data();
         if (!deployment) {
           console.error(`Deployment not found`);
@@ -102,11 +102,11 @@ export async function publishHandler(
           done();
         }
       },
-      error: e => {
-        console.error(e);
+      err => {
+        console.error(err);
         done();
       },
-    });
+    );
 
   await isDoneWatching;
   stopListener();


### PR DESCRIPTION
It turns out that the web sdk supports multiple versions of `DocumentReference.onSnapshot()`, one of which is compatible with that of the `@google-cloud/firestore` server sdk.

Switch to using that so that we can leverage the `firestore-jest-mocks` testing class.