### PR TITLE
feat!(reflect-server): Fast(er) Forward: use version index to compute patches

### DIFF
--- a/packages/reflect-server/src/ff/fast-forward.test.ts
+++ b/packages/reflect-server/src/ff/fast-forward.test.ts
@@ -3,7 +3,11 @@ import {DurableStorage} from '../storage/durable-storage.js';
 import type {ClientPoke} from '../types/client-poke.js';
 import {ClientRecordMap, putClientRecord} from '../types/client-record.js';
 import type {ClientID} from '../types/client-state.js';
-import {putUserValue, UserValue} from '../types/user-value.js';
+import {
+  putUserValue,
+  UserValue,
+  userValueVersionEntry,
+} from '../types/user-value.js';
 import {fastForwardRoom} from '../ff/fast-forward.js';
 import {createSilentLogContext, mockMathRandom} from '../util/test-utils.js';
 
@@ -492,6 +496,8 @@ test('fastForward', async () => {
     }
     for (const [key, value] of c.state) {
       await putUserValue(key, value, storage);
+      const versionEntry = userValueVersionEntry(key, value);
+      await storage.put(versionEntry.key, versionEntry.value);
     }
 
     const pokes = await fastForwardRoom(

--- a/packages/reflect-server/src/ff/get-patch.test.ts
+++ b/packages/reflect-server/src/ff/get-patch.test.ts
@@ -1,143 +1,145 @@
 import {expect, describe, test} from '@jest/globals';
 import type {NullableVersion} from 'reflect-protocol';
 import type {PatchOperation} from 'replicache';
-import {getPatch} from '../../src/ff/get-patch.js';
+import {getPatches} from '../../src/ff/get-patch.js';
 import {DurableStorage} from '../../src/storage/durable-storage.js';
 import {ReplicacheTransaction} from '../../src/storage/replicache-transaction.js';
+import {createSilentLogContext} from '../util/test-utils.js';
 
 const {roomDO} = getMiniflareBindings();
 const id = roomDO.newUniqueId();
 
-describe('getPatch', () => {
+describe('getPatches', () => {
   type Case = {
     name: string;
     // undefined value means delete
-    muts?: {key: string; value?: string; mutationID: number; version: number}[];
-    fromCookie: NullableVersion;
-    expected: PatchOperation[];
+    muts: {key: string; value?: string; mutationID: number; version: number}[];
+    expected: [NullableVersion, PatchOperation[]][];
   };
 
   const cases: Case[] = [
     {
-      name: 'add a+b, diff from null',
+      name: 'add a+b',
       muts: [
         {key: 'a', mutationID: 1, value: 'a1', version: 2},
         {key: 'b', mutationID: 1, value: 'b1', version: 2},
       ],
-      fromCookie: null,
       expected: [
-        {
-          op: 'put',
-          key: 'a',
-          value: 'a1',
-        },
-        {
-          op: 'put',
-          key: 'b',
-          value: 'b1',
-        },
+        [2, []], // Nothing for a client that's up to date.
+        [
+          null,
+          [
+            {
+              op: 'put',
+              key: 'a',
+              value: 'a1',
+            },
+            {
+              op: 'put',
+              key: 'b',
+              value: 'b1',
+            },
+          ],
+        ],
       ],
     },
     {
       name: 'del b, diff from null',
       muts: [{key: 'b', mutationID: 2, version: 3}],
-      fromCookie: null,
       expected: [
-        {
-          op: 'put',
-          key: 'a',
-          value: 'a1',
-        },
-        // no delete for b because diff is from null
+        [
+          null,
+          [
+            {
+              op: 'put',
+              key: 'a',
+              value: 'a1',
+            },
+            // no delete for b because diff is from null
+          ],
+        ],
+        [
+          1, // diff from 1
+          [
+            {
+              op: 'put',
+              key: 'a',
+              value: 'a1',
+            },
+            {
+              op: 'del',
+              key: 'b',
+            },
+          ],
+        ],
+        [
+          2, // diff from 2
+          [
+            {
+              op: 'del',
+              key: 'b',
+            },
+          ],
+        ],
       ],
     },
     {
-      name: 'diff from 1',
-      fromCookie: 1,
-      expected: [
-        {
-          op: 'put',
-          key: 'a',
-          value: 'a1',
-        },
-        {
-          op: 'del',
-          key: 'b',
-        },
-      ],
-    },
-    {
-      name: 'diff from 2',
-      fromCookie: 2,
-      expected: [
-        {
-          op: 'del',
-          key: 'b',
-        },
-      ],
-    },
-    {
-      name: 'add b, diff from null',
+      name: 'add b',
       muts: [{key: 'b', mutationID: 3, value: 'b2', version: 4}],
-      fromCookie: 0,
       expected: [
-        {
-          op: 'put',
-          key: 'a',
-          value: 'a1',
-        },
-        {
-          op: 'put',
-          key: 'b',
-          value: 'b2',
-        },
+        [
+          0, // diff from 0
+          [
+            {
+              op: 'put',
+              key: 'a',
+              value: 'a1',
+            },
+            {
+              op: 'put',
+              key: 'b',
+              value: 'b2',
+            },
+          ],
+        ],
+        [
+          2, // diff from 2 after b re-added'
+          [
+            {
+              op: 'put',
+              key: 'b',
+              value: 'b2',
+            },
+          ],
+        ],
+        [
+          3, // diff from 3
+          [
+            {
+              op: 'put',
+              key: 'b',
+              value: 'b2',
+            },
+          ],
+        ],
+        [4, []], // diff from 4
       ],
     },
     {
-      name: 'diff from 2 after b re-added',
-      muts: [],
-      fromCookie: 2,
-      expected: [
-        {
-          op: 'put',
-          key: 'b',
-          value: 'b2',
-        },
-      ],
-    },
-    {
-      name: 'diff from 3',
-      muts: [],
-      fromCookie: 3,
-      expected: [
-        {
-          op: 'put',
-          key: 'b',
-          value: 'b2',
-        },
-      ],
-    },
-    {
-      name: 'diff from 4',
-      muts: [],
-      fromCookie: 4,
-      expected: [],
-    },
-    {
-      name: 'del a, diff from 4',
+      name: 'del a',
       muts: [{key: 'a', mutationID: 4, version: 5}],
-      fromCookie: 4,
       expected: [
-        {
-          op: 'del',
-          key: 'a',
-        },
+        [5, []], // diff from 5
+        [
+          4, // diff from 4
+          [
+            {
+              op: 'del',
+              key: 'a',
+            },
+          ],
+        ],
       ],
-    },
-    {
-      name: 'diff from 5',
-      fromCookie: 5,
-      expected: [],
     },
   ];
 
@@ -163,8 +165,13 @@ describe('getPatch', () => {
           await tx.del(p.key);
         }
       }
-      const patch = await getPatch(storage, c.fromCookie);
-      expect(patch).toEqual(c.expected);
+      const patches = await getPatches(
+        createSilentLogContext(),
+        storage,
+        new Set(c.expected.map(([version]) => version)),
+      );
+      console.log(patches);
+      expect(patches).toEqual(new Map(c.expected));
     });
   }
 });

--- a/packages/reflect-server/src/ff/get-patch.ts
+++ b/packages/reflect-server/src/ff/get-patch.ts
@@ -1,38 +1,91 @@
 import type {Patch, NullableVersion} from 'reflect-protocol';
 import type {DurableStorage} from '../storage/durable-storage.js';
-import {userValuePrefix, userValueSchema} from '../types/user-value.js';
+import {
+  decodeUserValueVersionKey,
+  userValueKey,
+  userValueSchema,
+  userValueVersionIndexPrefix,
+  userValueVersionInfoSchema,
+  userValueVersionKey,
+} from '../types/user-value.js';
+import {compareVersions} from '../types/version.js';
+import type {ListOptions} from '../storage/storage.js';
+import {MAX_ENTRIES_TO_GET} from '../db/data.js';
+import {must} from 'shared/src/must.js';
+import type {LogContext} from '@rocicorp/logger';
 
-export async function getPatch(
+export async function getPatches(
+  lc: LogContext,
   storage: DurableStorage,
-  fromCookie: NullableVersion,
-): Promise<Patch> {
-  const result = await storage.list({prefix: userValuePrefix}, userValueSchema);
+  versions: Set<NullableVersion>,
+): Promise<Map<NullableVersion, Patch>> {
+  if (versions.size === 0) {
+    return new Map();
+  }
+  const sortedVersions = [...versions].sort(compareVersions);
+  const earliestVersion = sortedVersions[0];
+  const scanOptions: ListOptions = {prefix: userValueVersionIndexPrefix};
+  if (earliestVersion !== null) {
+    scanOptions.start = {key: userValueVersionKey('', earliestVersion + 1)};
+  }
 
-  const patch: Patch = [];
-  for (const [key, value] of result) {
-    const validValue = value;
+  const superPatch: Patch = [];
+  const startingIndexes = new Map<NullableVersion, number>();
 
-    // TODO: More efficient way of finding changed values.
-    if (fromCookie !== null && validValue.version <= fromCookie) {
-      continue;
-    }
-
-    const unwrappedKey = key.substring(userValuePrefix.length);
-    const unwrappedValue = validValue.value;
-    if (validValue.deleted) {
-      if (fromCookie !== null) {
-        patch.push({
-          op: 'del',
-          key: unwrappedKey,
-        });
+  // Compute the superPatch (the Patch starting after the earliest Version)
+  // and starting indexes into the superPatch for each Version.
+  for await (const batch of storage.batchScan(
+    scanOptions,
+    userValueVersionInfoSchema,
+    MAX_ENTRIES_TO_GET,
+  )) {
+    // Fetch the values of all objects that were put().
+    const putValues = await storage.getEntries(
+      [...batch]
+        .filter(([_, value]) => !value.deleted)
+        .map(([key]) => userValueKey(decodeUserValueVersionKey(key).userKey)),
+      userValueSchema,
+    );
+    for (const [indexKey, value] of batch) {
+      const {userKey, version} = decodeUserValueVersionKey(indexKey);
+      while (
+        sortedVersions.length > 0 &&
+        compareVersions(sortedVersions[0], version) < 0
+      ) {
+        // Note: sortedVersions.shift() will not return undefined because length > 0
+        startingIndexes.set(sortedVersions.shift() ?? null, superPatch.length);
       }
-    } else {
-      patch.push({
-        op: 'put',
-        key: unwrappedKey,
-        value: unwrappedValue,
-      });
+      superPatch.push(
+        value.deleted
+          ? {
+              op: 'del',
+              key: userKey,
+            }
+          : {
+              op: 'put',
+              key: userKey,
+              value: must(putValues.get(userValueKey(userKey))).value,
+            },
+      );
     }
   }
-  return patch;
+  lc.info?.(
+    `Scanned ${superPatch.length} entries since version ${earliestVersion}`,
+  );
+  const patches = new Map(
+    [...startingIndexes].map(([key, index]) => [key, superPatch.slice(index)]),
+  );
+  // For the null Version (i.e. starting from scratch), remove any 'del' PatchOps.
+  const nullPatch = patches.get(null);
+  if (nullPatch) {
+    patches.set(
+      null,
+      nullPatch.filter(val => val.op === 'put'),
+    );
+  }
+  // For any remaining versions, there are no patch ops.
+  for (const v of sortedVersions) {
+    patches.set(v, []);
+  }
+  return patches;
 }


### PR DESCRIPTION
Previous strategy loads, in parallel, all of user storage for every client that is behind.

Fast(er) Forward: Use the version index to load all of the changed keys since the earliest version.
From that patch (the "superPatch"), the patches for all clients are constructed by starting at the appropriate version.

Fixes #268