### PR TITLE
perf(reflect-server): don't list all clients every turn

### DIFF
--- a/packages/reflect-server/src/storage/entry-cache.test.ts
+++ b/packages/reflect-server/src/storage/entry-cache.test.ts
@@ -5,18 +5,20 @@ import {EntryCache} from './entry-cache.js';
 import type {ListOptions} from './storage.js';
 import type {Patch} from 'reflect-protocol';
 
-describe('entry-cache', () => {
-  type Case = {
-    name: string;
-    pendingKeys: string[];
-    pendingKeysBatch: string[];
-    deletedKeys: string[];
-    deletedKeysBatch: string[];
+type Case = {
+  name: string;
+  pendingKeys: string[];
+  pendingKeysBatch: string[];
+  deletedKeys: string[];
+  deletedKeysBatch: string[];
+  listAndScanOpts?: {
+    opts: ListOptions;
     expected: [string, string][];
-    expectedPending: Patch;
-    opts?: ListOptions;
   };
-
+  expected: [string, string][];
+  expectedPending: Patch;
+};
+describe('entry-cache', () => {
   const durableEntryKeys: string[] = ['bar-1', 'baz-1', 'foo-1'];
 
   const cases: Case[] = [
@@ -39,8 +41,15 @@ describe('entry-cache', () => {
       pendingKeysBatch: [],
       deletedKeys: [],
       deletedKeysBatch: [],
-      opts: {prefix: 'foo'},
-      expected: [['foo-1', 'orig-foo-1']],
+      listAndScanOpts: {
+        opts: {prefix: 'foo'},
+        expected: [['foo-1', 'orig-foo-1']],
+      },
+      expected: [
+        ['bar-1', 'orig-bar-1'],
+        ['baz-1', 'orig-baz-1'],
+        ['foo-1', 'orig-foo-1'],
+      ],
       expectedPending: [],
     },
     {
@@ -49,10 +58,17 @@ describe('entry-cache', () => {
       pendingKeysBatch: [],
       deletedKeys: [],
       deletedKeysBatch: [],
-      opts: {limit: 2},
+      listAndScanOpts: {
+        opts: {limit: 2},
+        expected: [
+          ['bar-1', 'orig-bar-1'],
+          ['baz-1', 'orig-baz-1'],
+        ],
+      },
       expected: [
         ['bar-1', 'orig-bar-1'],
         ['baz-1', 'orig-baz-1'],
+        ['foo-1', 'orig-foo-1'],
       ],
       expectedPending: [],
     },
@@ -62,8 +78,15 @@ describe('entry-cache', () => {
       pendingKeysBatch: [],
       deletedKeys: [],
       deletedKeysBatch: [],
-      opts: {prefix: 'foo', limit: 2},
-      expected: [['foo-1', 'orig-foo-1']],
+      listAndScanOpts: {
+        opts: {prefix: 'foo', limit: 2},
+        expected: [['foo-1', 'orig-foo-1']],
+      },
+      expected: [
+        ['bar-1', 'orig-bar-1'],
+        ['baz-1', 'orig-baz-1'],
+        ['foo-1', 'orig-foo-1'],
+      ],
       expectedPending: [],
     },
     {
@@ -72,8 +95,15 @@ describe('entry-cache', () => {
       pendingKeysBatch: [],
       deletedKeys: [],
       deletedKeysBatch: [],
-      opts: {start: {key: 'baz-1'}},
+      listAndScanOpts: {
+        opts: {start: {key: 'baz-1'}},
+        expected: [
+          ['baz-1', 'orig-baz-1'],
+          ['foo-1', 'orig-foo-1'],
+        ],
+      },
       expected: [
+        ['bar-1', 'orig-bar-1'],
         ['baz-1', 'orig-baz-1'],
         ['foo-1', 'orig-foo-1'],
       ],
@@ -85,8 +115,15 @@ describe('entry-cache', () => {
       pendingKeysBatch: [],
       deletedKeys: [],
       deletedKeysBatch: [],
-      opts: {start: {key: 'baz-1', exclusive: true}},
-      expected: [['foo-1', 'orig-foo-1']],
+      listAndScanOpts: {
+        opts: {start: {key: 'baz-1', exclusive: true}},
+        expected: [['foo-1', 'orig-foo-1']],
+      },
+      expected: [
+        ['bar-1', 'orig-bar-1'],
+        ['baz-1', 'orig-baz-1'],
+        ['foo-1', 'orig-foo-1'],
+      ],
       expectedPending: [],
     },
     {
@@ -95,8 +132,19 @@ describe('entry-cache', () => {
       pendingKeysBatch: [],
       deletedKeys: [],
       deletedKeysBatch: [],
-      opts: {prefix: 'b', limit: 1, start: {key: 'bar-1', exclusive: true}},
-      expected: [['baz-1', 'orig-baz-1']],
+      listAndScanOpts: {
+        opts: {
+          prefix: 'b',
+          limit: 1,
+          start: {key: 'bar-1', exclusive: true},
+        },
+        expected: [['baz-1', 'orig-baz-1']],
+      },
+      expected: [
+        ['bar-1', 'orig-bar-1'],
+        ['baz-1', 'orig-baz-1'],
+        ['foo-1', 'orig-foo-1'],
+      ],
       expectedPending: [],
     },
 
@@ -125,13 +173,23 @@ describe('entry-cache', () => {
       pendingKeysBatch: ['baz-3', 'baz-4'],
       deletedKeys: [],
       deletedKeysBatch: [],
-      opts: {prefix: 'ba'},
+      listAndScanOpts: {
+        opts: {prefix: 'ba'},
+        expected: [
+          ['bar-1', 'orig-bar-1'],
+          ['baz-1', 'orig-baz-1'],
+          ['baz-2', 'new-baz-2'],
+          ['baz-3', 'new-baz-3'],
+          ['baz-4', 'new-baz-4'],
+        ],
+      },
       expected: [
         ['bar-1', 'orig-bar-1'],
         ['baz-1', 'orig-baz-1'],
         ['baz-2', 'new-baz-2'],
         ['baz-3', 'new-baz-3'],
         ['baz-4', 'new-baz-4'],
+        ['foo-1', 'orig-foo-1'],
       ],
       expectedPending: [
         {op: 'put', key: 'baz-2', value: 'new-baz-2'},
@@ -145,12 +203,22 @@ describe('entry-cache', () => {
       pendingKeysBatch: ['baz-3', 'baz-4'],
       deletedKeys: [],
       deletedKeysBatch: [],
-      opts: {limit: 4},
+      listAndScanOpts: {
+        opts: {limit: 4},
+        expected: [
+          ['bar-1', 'orig-bar-1'],
+          ['baz-1', 'orig-baz-1'],
+          ['baz-2', 'new-baz-2'],
+          ['baz-3', 'new-baz-3'],
+        ],
+      },
       expected: [
         ['bar-1', 'orig-bar-1'],
         ['baz-1', 'orig-baz-1'],
         ['baz-2', 'new-baz-2'],
         ['baz-3', 'new-baz-3'],
+        ['baz-4', 'new-baz-4'],
+        ['foo-1', 'orig-foo-1'],
       ],
       expectedPending: [
         {op: 'put', key: 'baz-2', value: 'new-baz-2'},
@@ -164,10 +232,20 @@ describe('entry-cache', () => {
       pendingKeysBatch: ['baz-3', 'baz-4'],
       deletedKeys: [],
       deletedKeysBatch: [],
-      opts: {prefix: 'baz', limit: 2},
+      listAndScanOpts: {
+        opts: {prefix: 'baz', limit: 2},
+        expected: [
+          ['baz-1', 'orig-baz-1'],
+          ['baz-2', 'new-baz-2'],
+        ],
+      },
       expected: [
+        ['bar-1', 'orig-bar-1'],
         ['baz-1', 'orig-baz-1'],
         ['baz-2', 'new-baz-2'],
+        ['baz-3', 'new-baz-3'],
+        ['baz-4', 'new-baz-4'],
+        ['foo-1', 'orig-foo-1'],
       ],
       expectedPending: [
         {op: 'put', key: 'baz-2', value: 'new-baz-2'},
@@ -181,8 +259,18 @@ describe('entry-cache', () => {
       pendingKeysBatch: ['baz-3', 'baz-4'],
       deletedKeys: [],
       deletedKeysBatch: [],
-      opts: {start: {key: 'baz-1'}},
+      listAndScanOpts: {
+        opts: {start: {key: 'baz-1'}},
+        expected: [
+          ['baz-1', 'orig-baz-1'],
+          ['baz-2', 'new-baz-2'],
+          ['baz-3', 'new-baz-3'],
+          ['baz-4', 'new-baz-4'],
+          ['foo-1', 'orig-foo-1'],
+        ],
+      },
       expected: [
+        ['bar-1', 'orig-bar-1'],
         ['baz-1', 'orig-baz-1'],
         ['baz-2', 'new-baz-2'],
         ['baz-3', 'new-baz-3'],
@@ -201,8 +289,18 @@ describe('entry-cache', () => {
       pendingKeysBatch: ['baz-3', 'baz-4'],
       deletedKeys: [],
       deletedKeysBatch: [],
-      opts: {start: {key: 'baz-1', exclusive: true}},
+      listAndScanOpts: {
+        opts: {start: {key: 'baz-1', exclusive: true}},
+        expected: [
+          ['baz-2', 'new-baz-2'],
+          ['baz-3', 'new-baz-3'],
+          ['baz-4', 'new-baz-4'],
+          ['foo-1', 'orig-foo-1'],
+        ],
+      },
       expected: [
+        ['bar-1', 'orig-bar-1'],
+        ['baz-1', 'orig-baz-1'],
         ['baz-2', 'new-baz-2'],
         ['baz-3', 'new-baz-3'],
         ['baz-4', 'new-baz-4'],
@@ -220,11 +318,25 @@ describe('entry-cache', () => {
       pendingKeysBatch: ['baz-3', 'baz-4'],
       deletedKeys: [],
       deletedKeysBatch: [],
-      opts: {prefix: 'b', limit: 3, start: {key: 'bar-1', exclusive: true}},
+      listAndScanOpts: {
+        opts: {
+          prefix: 'b',
+          limit: 3,
+          start: {key: 'bar-1', exclusive: true},
+        },
+        expected: [
+          ['baz-1', 'orig-baz-1'],
+          ['baz-2', 'new-baz-2'],
+          ['baz-3', 'new-baz-3'],
+        ],
+      },
       expected: [
+        ['bar-1', 'orig-bar-1'],
         ['baz-1', 'orig-baz-1'],
         ['baz-2', 'new-baz-2'],
         ['baz-3', 'new-baz-3'],
+        ['baz-4', 'new-baz-4'],
+        ['foo-1', 'orig-foo-1'],
       ],
       expectedPending: [
         {op: 'put', key: 'baz-2', value: 'new-baz-2'},
@@ -260,11 +372,19 @@ describe('entry-cache', () => {
       pendingKeysBatch: ['baz-4', 'baz-5'],
       deletedKeys: ['baz-1', 'baz-2'],
       deletedKeysBatch: ['baz-5', 'baz-6'],
-      opts: {prefix: 'ba'},
+      listAndScanOpts: {
+        opts: {prefix: 'ba'},
+        expected: [
+          ['bar-1', 'orig-bar-1'],
+          ['baz-3', 'new-baz-3'],
+          ['baz-4', 'new-baz-4'],
+        ],
+      },
       expected: [
         ['bar-1', 'orig-bar-1'],
         ['baz-3', 'new-baz-3'],
         ['baz-4', 'new-baz-4'],
+        ['foo-1', 'orig-foo-1'],
       ],
       expectedPending: [
         {op: 'del', key: 'baz-2'},
@@ -281,11 +401,20 @@ describe('entry-cache', () => {
       pendingKeysBatch: ['baz-4', 'baz-5', 'baz-6', 'baz-7'],
       deletedKeys: ['baz-1', 'baz-2'],
       deletedKeysBatch: ['baz-5', 'baz-7'],
-      opts: {limit: 3},
+      listAndScanOpts: {
+        opts: {limit: 3},
+        expected: [
+          ['bar-1', 'orig-bar-1'],
+          ['baz-3', 'new-baz-3'],
+          ['baz-4', 'new-baz-4'],
+        ],
+      },
       expected: [
         ['bar-1', 'orig-bar-1'],
         ['baz-3', 'new-baz-3'],
         ['baz-4', 'new-baz-4'],
+        ['baz-6', 'new-baz-6'],
+        ['foo-1', 'orig-foo-1'],
       ],
       expectedPending: [
         {op: 'del', key: 'baz-2'},
@@ -303,10 +432,19 @@ describe('entry-cache', () => {
       pendingKeysBatch: ['baz-4', 'baz-5', 'baz-6', 'baz-7'],
       deletedKeys: ['baz-1', 'baz-2'],
       deletedKeysBatch: ['baz-5', 'baz-7'],
-      opts: {prefix: 'baz', limit: 2},
+      listAndScanOpts: {
+        opts: {prefix: 'baz', limit: 2},
+        expected: [
+          ['baz-3', 'new-baz-3'],
+          ['baz-4', 'new-baz-4'],
+        ],
+      },
       expected: [
+        ['bar-1', 'orig-bar-1'],
         ['baz-3', 'new-baz-3'],
         ['baz-4', 'new-baz-4'],
+        ['baz-6', 'new-baz-6'],
+        ['foo-1', 'orig-foo-1'],
       ],
       expectedPending: [
         {op: 'del', key: 'baz-2'},
@@ -324,8 +462,16 @@ describe('entry-cache', () => {
       pendingKeysBatch: ['baz-4', 'baz-5'],
       deletedKeys: ['baz-1', 'baz-2'],
       deletedKeysBatch: ['baz-5', 'baz-6'],
-      opts: {start: {key: 'baz-3'}},
+      listAndScanOpts: {
+        opts: {start: {key: 'baz-3'}},
+        expected: [
+          ['baz-3', 'new-baz-3'],
+          ['baz-4', 'new-baz-4'],
+          ['foo-1', 'orig-foo-1'],
+        ],
+      },
       expected: [
+        ['bar-1', 'orig-bar-1'],
         ['baz-3', 'new-baz-3'],
         ['baz-4', 'new-baz-4'],
         ['foo-1', 'orig-foo-1'],
@@ -345,8 +491,16 @@ describe('entry-cache', () => {
       pendingKeysBatch: ['baz-4', 'baz-5'],
       deletedKeys: ['baz-1', 'baz-2'],
       deletedKeysBatch: ['baz-5', 'baz-6'],
-      opts: {start: {key: 'baz-3', exclusive: true}},
+      listAndScanOpts: {
+        opts: {start: {key: 'baz-3', exclusive: true}},
+        expected: [
+          ['baz-4', 'new-baz-4'],
+          ['foo-1', 'orig-foo-1'],
+        ],
+      },
       expected: [
+        ['bar-1', 'orig-bar-1'],
+        ['baz-3', 'new-baz-3'],
         ['baz-4', 'new-baz-4'],
         ['foo-1', 'orig-foo-1'],
       ],
@@ -365,10 +519,22 @@ describe('entry-cache', () => {
       pendingKeysBatch: ['baz-4', 'baz-5'],
       deletedKeys: ['baz-1', 'baz-2'],
       deletedKeysBatch: ['baz-5', 'baz-6'],
-      opts: {prefix: 'b', limit: 2, start: {key: 'bar-1', exclusive: true}},
+      listAndScanOpts: {
+        opts: {
+          prefix: 'b',
+          limit: 2,
+          start: {key: 'bar-1', exclusive: true},
+        },
+        expected: [
+          ['baz-3', 'new-baz-3'],
+          ['baz-4', 'new-baz-4'],
+        ],
+      },
       expected: [
+        ['bar-1', 'orig-bar-1'],
         ['baz-3', 'new-baz-3'],
         ['baz-4', 'new-baz-4'],
+        ['foo-1', 'orig-foo-1'],
       ],
       expectedPending: [
         {op: 'del', key: 'baz-2'},
@@ -420,21 +586,38 @@ describe('entry-cache', () => {
         c.pendingKeys.length + c.deletedKeys.length > 0,
       );
 
-      const entries = [...(await cache.list(c.opts || {}, valita.string()))];
+      const entries = [...(await cache.list({}, valita.string()))];
       expect(entries).toEqual(c.expected);
+      if (c.listAndScanOpts) {
+        const entries = [
+          ...(await cache.list(c.listAndScanOpts.opts, valita.string())),
+        ];
+        expect(entries).toEqual(c.listAndScanOpts.expected);
+      }
 
       // Test scan()
       const results: [string, string][] = [];
-      for await (const entry of cache.scan(c.opts || {}, valita.string())) {
+      for await (const entry of cache.scan({}, valita.string())) {
         results.push(entry);
       }
       expect(results).toEqual(c.expected);
+
+      if (c.listAndScanOpts) {
+        const results: [string, string][] = [];
+        for await (const entry of cache.scan(
+          c.listAndScanOpts.opts,
+          valita.string(),
+        )) {
+          results.push(entry);
+        }
+        expect(results).toEqual(c.listAndScanOpts.expected);
+      }
 
       // Test batchScan() with a variety of batch sizes.
       for (const batchSize of [1, 2, 3, 128]) {
         const results: [string, string][] = [];
         for await (const batch of cache.batchScan(
-          c.opts || {},
+          {},
           valita.string(),
           batchSize,
         )) {
@@ -442,6 +625,23 @@ describe('entry-cache', () => {
         }
         expect(results).toEqual(c.expected);
       }
+      if (c.listAndScanOpts) {
+        for (const batchSize of [1, 2, 3, 128]) {
+          const results: [string, string][] = [];
+          for await (const batch of cache.batchScan(
+            c.listAndScanOpts.opts,
+            valita.string(),
+            batchSize,
+          )) {
+            results.push(...batch);
+          }
+          expect(results).toEqual(c.listAndScanOpts.expected);
+        }
+      }
+
+      // Test getEntries
+      await testGetEntries(durableEntryKeys, cache, c);
+      await testGetEntries([...durableEntryKeys, ...c.pendingKeys], cache, c);
 
       const durableEntriesBeforeFlush = [
         ...(await durable.list({}, valita.string())),
@@ -469,10 +669,31 @@ describe('entry-cache', () => {
       expect(cache.isDirty()).toBe(false);
 
       const durableEntriesAfterFlush = [
-        ...(await durable.list(c.opts || {}, valita.string())),
+        ...(await durable.list({}, valita.string())),
       ];
 
       expect(durableEntriesAfterFlush).toEqual(c.expected);
     });
   }
 });
+
+async function testGetEntries(keys: string[], cache: EntryCache, c: Case) {
+  const compareEntries = (
+    [k1, _1]: [string, string],
+    [k2, _2]: [string, string],
+  ) => {
+    if (k1 === k2) {
+      return 0;
+    } else if (k1 < k2) {
+      return -1;
+    }
+    return 1;
+  };
+  const sortedResultEntries = [
+    ...(await cache.getEntries(keys, valita.string())).entries(),
+  ].sort(compareEntries);
+  const sortedExpectedEntries = c.expected
+    .filter(([k]) => keys.includes(k))
+    .sort(compareEntries);
+  expect(sortedResultEntries).toEqual(sortedExpectedEntries);
+}

--- a/packages/reflect-server/src/storage/storage.ts
+++ b/packages/reflect-server/src/storage/storage.ts
@@ -23,6 +23,10 @@ export interface Storage {
     key: string,
     schema: valita.Type<T>,
   ): Promise<T | undefined>;
+  getEntries<T extends ReadonlyJSONValue>(
+    keys: string[],
+    schema: valita.Type<T>,
+  ): Promise<Map<string, T>>;
 
   /**
    * Gets a contiguous sequence of keys and values based on the specified

--- a/packages/reflect-server/src/types/client-record.ts
+++ b/packages/reflect-server/src/types/client-record.ts
@@ -34,15 +34,22 @@ export function getClientRecord(
 export async function listClientRecords(
   storage: Storage,
 ): Promise<ClientRecordMap> {
-  const withPrefix = await storage.list(
+  const entries = await storage.list(
     {prefix: clientRecordPrefix},
     clientRecordSchema,
   );
-  const clientRecords = new Map();
-  for (const [key, record] of withPrefix) {
-    clientRecords.set(key.substring(clientRecordPrefix.length), record);
-  }
-  return clientRecords;
+  return toClientRecordMap(entries);
+}
+
+export async function getClientRecords(
+  clientIDs: ClientID[],
+  storage: Storage,
+): Promise<ClientRecordMap> {
+  const entries = await storage.getEntries(
+    clientIDs.map(clientRecordKey),
+    clientRecordSchema,
+  );
+  return toClientRecordMap(entries);
 }
 
 export function putClientRecord(
@@ -51,4 +58,14 @@ export function putClientRecord(
   storage: Storage,
 ): Promise<void> {
   return storage.put(clientRecordKey(clientID), record);
+}
+
+function toClientRecordMap(
+  entries: Map<string, ClientRecord>,
+): ClientRecordMap {
+  const clientRecords = new Map();
+  for (const [key, record] of entries) {
+    clientRecords.set(key.substring(clientRecordPrefix.length), record);
+  }
+  return clientRecords;
 }


### PR DESCRIPTION
Tackling this as it showed up at the top of time spent in profiles of reflect.net.
<img width="955" alt="Untitled (1)" src="https://github.com/rocicorp/mono/assets/19158916/0a4d6d78-888e-4063-a32c-e957a4df0a9b">

To enable this had to add getEntries to Storage interface and EntryCache impl.  

We still list all clients if a client needs to be fast forwarded in order to compute lastMutationIDChanges.   To avoid this we need more indexes (a long the lines of faster forward), which is too big of a change to tackle right now.