### PR TITLE
feat(reflect-server): introduces maxMutationsPerTurn option

### DIFF
--- a/apps/reflect.net/demo/worker/index.ts
+++ b/apps/reflect.net/demo/worker/index.ts
@@ -92,6 +92,7 @@ const {
     console.log('deleting old client', tx.clientID);
     await deleteClient(tx, tx.clientID);
   },
+  maxMutationsPerTurn: 100,
 }));
 
 class RoomDO extends SuperRoomDO {

--- a/packages/reflect-server/src/process/process-pending.test.ts
+++ b/packages/reflect-server/src/process/process-pending.test.ts
@@ -95,6 +95,7 @@ describe('processPending', () => {
     pendingMutations: PendingMutation[];
     maxProcessedMutationTimestamp: number;
     bufferSizeMs?: number; // default 200
+    maxMutationsToProcess?: number; // default Number.MAX_SAFE_INTEGER
     expectedError?: string;
     expectedVersion: Version;
     expectedPokes?: Map<ClientID, PokeBody>;
@@ -500,6 +501,176 @@ describe('processPending', () => {
         ['c3', clientRecord('cg2', 4, 2, 4)],
       ]),
       expectedMaxProcessedMutationTimestamp: 740,
+      expectedMissableRecords: [
+        {
+          bufferNeededMs: 0,
+          missed: false,
+          now: START_TIME,
+        },
+      ],
+    },
+    {
+      name: 'three clients, two client groups, three mutations, only 2 processed due to maxMutationsToProcess',
+      version: 1,
+      clientRecords: new Map([
+        ['c1', clientRecord('cg1', 1)],
+        ['c2', clientRecord('cg1', 1)],
+        ['c3', clientRecord('cg2', 1)],
+      ]),
+      clients: new Map([
+        client('c1', 'u1', 'cg1', s1, 0),
+        client('c2', 'u2', 'cg1', s2, 0),
+        client('c3', 'u3', 'cg2', s3, 0),
+      ]),
+      storedConnectedClients: ['c1', 'c2', 'c3'],
+      pendingMutations: [
+        pendingMutation({
+          clientID: 'c1',
+          clientGroupID: 'cg1',
+          id: 2,
+          timestamps: 700,
+          name: 'inc',
+        }),
+        pendingMutation({
+          clientID: 'c2',
+          clientGroupID: 'cg1',
+          id: 2,
+          timestamps: 720,
+          name: 'inc',
+        }),
+        pendingMutation({
+          clientID: 'c3',
+          clientGroupID: 'cg2',
+          id: 2,
+          timestamps: 740,
+          name: 'inc',
+        }),
+      ],
+      maxProcessedMutationTimestamp: 700,
+      maxMutationsToProcess: 2,
+      expectedVersion: 3,
+      expectedPokes: new Map([
+        [
+          'c1',
+          {
+            pokes: [
+              {
+                baseCookie: 1,
+                cookie: 2,
+                lastMutationIDChanges: {c1: 2},
+                patch: [
+                  {
+                    op: 'put',
+                    key: 'count',
+                    value: 1,
+                  },
+                ],
+                timestamp: 700,
+              },
+              {
+                baseCookie: 2,
+                cookie: 3,
+                lastMutationIDChanges: {c2: 2},
+                patch: [
+                  {
+                    op: 'put',
+                    key: 'count',
+                    value: 2,
+                  },
+                ],
+                timestamp: 720,
+              },
+            ],
+            requestID: '4fxcm49g2j9',
+          },
+        ],
+        [
+          'c2',
+          {
+            pokes: [
+              {
+                baseCookie: 1,
+                cookie: 2,
+                lastMutationIDChanges: {c1: 2},
+                patch: [
+                  {
+                    op: 'put',
+                    key: 'count',
+                    value: 1,
+                  },
+                ],
+                timestamp: 700,
+              },
+              {
+                baseCookie: 2,
+                cookie: 3,
+                lastMutationIDChanges: {c2: 2},
+                patch: [
+                  {
+                    op: 'put',
+                    key: 'count',
+                    value: 2,
+                  },
+                ],
+                timestamp: 720,
+              },
+            ],
+            requestID: '4fxcm49g2j9',
+          },
+        ],
+        [
+          'c3',
+          {
+            pokes: [
+              {
+                baseCookie: 1,
+                cookie: 2,
+                lastMutationIDChanges: {},
+                patch: [
+                  {
+                    op: 'put',
+                    key: 'count',
+                    value: 1,
+                  },
+                ],
+                timestamp: 700,
+              },
+              {
+                baseCookie: 2,
+                cookie: 3,
+                lastMutationIDChanges: {},
+                patch: [
+                  {
+                    op: 'put',
+                    key: 'count',
+                    value: 2,
+                  },
+                ],
+                timestamp: 720,
+              },
+            ],
+            requestID: '4fxcm49g2j9',
+          },
+        ],
+      ]),
+      expectedUserValues: new Map([
+        ['count', {value: 2, version: 3, deleted: false}],
+      ]),
+      expectedClientRecords: new Map([
+        ['c1', clientRecord('cg1', 3, 2, 2)],
+        ['c2', clientRecord('cg1', 3, 2, 3)],
+        ['c3', clientRecord('cg2', 3, 1, 1)],
+      ]),
+      expectedPendingMutations: [
+        pendingMutation({
+          clientID: 'c3',
+          clientGroupID: 'cg2',
+          id: 2,
+          timestamps: 740,
+          name: 'inc',
+        }),
+      ],
+      expectedMaxProcessedMutationTimestamp: 720,
       expectedMissableRecords: [
         {
           bufferNeededMs: 0,
@@ -1152,6 +1323,7 @@ describe('processPending', () => {
         () => Promise.resolve(),
         c.maxProcessedMutationTimestamp,
         fakeBufferSizer,
+        c.maxMutationsToProcess ?? Number.MAX_SAFE_INTEGER,
       );
       if (c.expectedError) {
         let expectedE;

--- a/packages/reflect-server/src/server/reflect.ts
+++ b/packages/reflect-server/src/server/reflect.ts
@@ -44,6 +44,14 @@ export interface ReflectServerOptions<MD extends MutatorDefs> {
    * Default is `false`.
    */
   allowUnconfirmedWrites?: boolean | undefined;
+
+  /**
+   * If defined limits the number of mutations that will be processed per
+   * turn.
+   * Setting this limit can prevent busy rooms from experiencing "overloaded"
+   * exceptions at the cost of peer-to-peer latency.
+   */
+  maxMutationsPerTurn?: number | undefined;
 }
 
 /**
@@ -58,6 +66,7 @@ export type NormalizedOptions<MD extends MutatorDefs> = {
   logLevel: LogLevel;
   datadogMetricsOptions?: DatadogMetricsOptions | undefined;
   allowUnconfirmedWrites: boolean;
+  maxMutationsPerTurn: number;
 };
 
 function combineLogSinks(sinks: LogSink[]): LogSink {
@@ -129,6 +138,7 @@ function makeNormalizedOptionsGetter<
       logLevel = 'debug',
       allowUnconfirmedWrites = false,
       datadogMetricsOptions = undefined,
+      maxMutationsPerTurn = Number.MAX_SAFE_INTEGER,
     } = makeOptions(env);
     const logSink = logSinks ? combineLogSinks(logSinks) : consoleLogSink;
     return {
@@ -140,6 +150,7 @@ function makeNormalizedOptionsGetter<
       logLevel,
       allowUnconfirmedWrites,
       datadogMetricsOptions,
+      maxMutationsPerTurn,
     };
   };
 }
@@ -157,6 +168,7 @@ function createRoomDOClass<
         logSink,
         logLevel,
         allowUnconfirmedWrites,
+        maxMutationsPerTurn,
       } = getOptions(env);
       super({
         mutators,
@@ -167,6 +179,7 @@ function createRoomDOClass<
         logSink,
         logLevel,
         allowUnconfirmedWrites,
+        maxMutationsPerTurn,
       });
     }
   };

--- a/packages/reflect-server/src/server/room-do.test.ts
+++ b/packages/reflect-server/src/server/room-do.test.ts
@@ -29,6 +29,7 @@ test('sets roomID in createRoom', async () => {
     logSink: testLogSink,
     logLevel: 'info',
     allowUnconfirmedWrites: true,
+    maxMutationsPerTurn: Number.MAX_SAFE_INTEGER,
   });
   const createRoomRequest = newCreateRoomRequest(
     'http://example.com/',
@@ -57,6 +58,7 @@ test('inits storage schema', async () => {
     logSink: testLogSink,
     logLevel: 'info',
     allowUnconfirmedWrites: true,
+    maxMutationsPerTurn: Number.MAX_SAFE_INTEGER,
   });
 
   await state.concurrencyBlockingCallbacks();
@@ -91,6 +93,7 @@ test('runs roomStartHandler', async () => {
     logSink: testLogSink,
     logLevel: 'info',
     allowUnconfirmedWrites: true,
+    maxMutationsPerTurn: Number.MAX_SAFE_INTEGER,
   });
 
   await state.concurrencyBlockingCallbacks();
@@ -120,6 +123,7 @@ test('deleteAllData deletes all data', async () => {
     logSink: testLogSink,
     logLevel: 'info',
     allowUnconfirmedWrites: true,
+    maxMutationsPerTurn: Number.MAX_SAFE_INTEGER,
   });
   const createRoomRequest = newCreateRoomRequest(
     'http://example.com/',
@@ -155,6 +159,7 @@ test('after deleteAllData the roomDO just 410s', async () => {
     logSink: testLogSink,
     logLevel: 'info',
     allowUnconfirmedWrites: true,
+    maxMutationsPerTurn: Number.MAX_SAFE_INTEGER,
   });
   const createRoomRequest = newCreateRoomRequest(
     'http://example.com/',
@@ -237,6 +242,7 @@ test('401s if wrong auth api key', async () => {
       logSink: testLogSink,
       logLevel: 'info',
       allowUnconfirmedWrites: true,
+      maxMutationsPerTurn: Number.MAX_SAFE_INTEGER,
     });
 
     const response = await roomDO.fetch(testRequest);
@@ -255,6 +261,7 @@ test('Logs version during construction', async () => {
     logSink: testLogSink,
     logLevel: 'info',
     allowUnconfirmedWrites: true,
+    maxMutationsPerTurn: Number.MAX_SAFE_INTEGER,
   });
   expect(testLogSink.messages).toEqual(
     expect.arrayContaining([
@@ -280,6 +287,7 @@ test('Avoids queueing many intervals in the lock', async () => {
     logSink: testLogSink,
     logLevel: 'info',
     allowUnconfirmedWrites: true,
+    maxMutationsPerTurn: Number.MAX_SAFE_INTEGER,
   });
 
   const {promise: canFinishCallback, resolve: finishCallback} =
@@ -358,6 +366,7 @@ test('good, bad, invalid connect requests', async () => {
     logSink: testLogSink,
     logLevel: 'info',
     allowUnconfirmedWrites: true,
+    maxMutationsPerTurn: Number.MAX_SAFE_INTEGER,
   });
   for (const test of [goodTest, nonWebSocketTest, badRequestTest]) {
     const response = await roomDO.fetch(test.request);

--- a/packages/reflect-server/src/server/room-do.ts
+++ b/packages/reflect-server/src/server/room-do.ts
@@ -59,6 +59,7 @@ export interface RoomDOOptions<MD extends MutatorDefs> {
   logSink: LogSink;
   logLevel: LogLevel;
   allowUnconfirmedWrites: boolean;
+  maxMutationsPerTurn: number;
 }
 
 export const ROOM_ROUTES = {
@@ -87,6 +88,7 @@ export class BaseRoomDO<MD extends MutatorDefs> implements DurableObject {
   readonly #lock = new LoggingLock();
   readonly #mutators: MutatorMap;
   readonly #disconnectHandler: DisconnectHandler;
+  readonly #maxMutationsPerTurn: number;
   #lcHasRoomIdContext = false;
   #lc: LogContext;
   readonly #storage: DurableStorage;
@@ -105,10 +107,12 @@ export class BaseRoomDO<MD extends MutatorDefs> implements DurableObject {
       authApiKey,
       logSink,
       logLevel,
+      maxMutationsPerTurn,
     } = options;
 
     this.#mutators = new Map([...Object.entries(mutators)]) as MutatorMap;
     this.#disconnectHandler = disconnectHandler;
+    this.#maxMutationsPerTurn = maxMutationsPerTurn;
     this.#storage = new DurableStorage(
       state.storage,
       options.allowUnconfirmedWrites,
@@ -478,6 +482,7 @@ export class BaseRoomDO<MD extends MutatorDefs> implements DurableObject {
         this.#disconnectHandler,
         this.#maxProcessedMutationTimestamp,
         this.#bufferSizer,
+        this.#maxMutationsPerTurn,
       );
     this.#maxProcessedMutationTimestamp = maxProcessedMutationTimestamp;
     if (nothingToProcess && this.#turnTimerID) {


### PR DESCRIPTION
Sets the option to 100 for reflect.net for testing.

 If defined limits the number of mutations that will be processed per turn.
 
 Setting this limit can prevent busy rooms from experiencing "overloaded"
 exceptions at the cost of peer-to-peer latency and increased risk of running out of memory.
 
 This is a short term bandaid for Monday while we work on proper flow control.
 
