### PR TITLE
feat(mirror-server): Encode app IDs in base36 to match the script name

### DIFF
--- a/packages/shared/src/mirror/ids.test.ts
+++ b/packages/shared/src/mirror/ids.test.ts
@@ -10,12 +10,12 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
-test('appID is timestamp base62 encoded', () => {
+test('appID is timestamp base36 encoded', () => {
   jest.setSystemTime(0);
   expect(newAppID()).toBe('0');
 
   jest.setSystemTime(1234567890);
-  expect(newAppID()).toBe('1LY7VK');
+  expect(newAppID()).toBe('kf12oi');
 });
 
 test('script name', () => {

--- a/packages/shared/src/mirror/ids.ts
+++ b/packages/shared/src/mirror/ids.ts
@@ -19,7 +19,7 @@ export function newAppIDAsNumber(): number {
 }
 
 export function newAppID(n = newAppIDAsNumber()): string {
-  return base62.encode(BigInt(n));
+  return n.toString(36);
 }
 
 /**


### PR DESCRIPTION
App IDs don't need to be so compact, and it's nice to be able to easily determine the appID from a script name (i.e. without converting between base62 and base36).