### PR TITLE
chore(reflect.net): change reflect.net server log level to info

### DIFF
--- a/apps/reflect.net/wrangler.toml
+++ b/apps/reflect.net/wrangler.toml
@@ -9,7 +9,7 @@ durable_objects.bindings = [
   { name = "roomDO", class_name = "RoomDO" },
   { name = "authDO", class_name = "AuthDO" }
 ]
-vars = { DATADOG_SERVICE_LABEL = "reflect.net", LOG_LEVEL = "debug"}
+vars = { DATADOG_SERVICE_LABEL = "reflect.net", LOG_LEVEL = "info"}
 
 [[migrations]]
 tag = "v1"
@@ -43,4 +43,4 @@ durable_objects.bindings = [
   { name = "roomDO", class_name = "RoomDO" },
   { name = "authDO", class_name = "AuthDO" }
 ]
-vars = { DATADOG_SERVICE_LABEL = "staging.reflect.net", LOG_LEVEL = "debug" }
+vars = { DATADOG_SERVICE_LABEL = "staging.reflect.net", LOG_LEVEL = "info" }


### PR DESCRIPTION
https://github.com/rocicorp/mono/commit/41aba607266898753b6f37872e1b845ea7fab65c made info level logging more useful, and debug level logging is too expensive.  