### PR TITLE
Fix assertion error when `socketOrigin` is null.

### DIFF
--- a/packages/reflect-client/src/client/reflect.ts
+++ b/packages/reflect-client/src/client/reflect.ts
@@ -932,7 +932,12 @@ export class Reflect<MD extends MutatorDefs> {
   private async _runLoop() {
     (await this._l).info?.(`Starting Reflect version: ${this.version}`);
 
-    assert(this._socketOrigin);
+    if (this._socketOrigin === null) {
+      (await this._l).info?.(
+        'No socket origin provided, not starting connect loop.',
+      );
+      return;
+    }
 
     let runLoopCounter = 0;
     const bareLogContext = await this._l;


### PR DESCRIPTION
This accidentally regressed when responding to the original PR comment: https://github.com/rocicorp/mono/pull/710/commits/76c12b827d179b61e5e4d52c1744f916dd33da71#diff-717085d644c11744be5240ca70c3ee80cfbb93eabe9eef74a721b475eb685120L914

It causes an assertion failure in the tests, but this doesn't fail the test. Not sure why.