### PR TITLE
fix(mirror-cli): allow specifying the stack.

### DIFF
--- a/mirror/mirror-cli/package.json
+++ b/mirror/mirror-cli/package.json
@@ -20,7 +20,7 @@
     "check-format": "prettier --check .",
     "lint": "eslint --ext .ts,.tsx,.js,.jsx src/",
     "build": "node tool/build.js",
-    "start": "node --no-warnings --loader ts-node/esm ./src/index.ts --stack staging",
+    "start": "node --no-warnings --loader ts-node/esm ./src/index.ts",
     "check-types": "tsc --noEmit"
   },
   "devDependencies": {


### PR DESCRIPTION
This was making it so that `npm run start ... --stack=foo` did nothing.