### PR TITLE
Bump reflect version to 0.31.6

### DIFF
--- a/apps/reflect.net/package.json
+++ b/apps/reflect.net/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@rocicorp/logger": "^5.2.0",
-    "@rocicorp/reflect": "0.31.5",
+    "@rocicorp/reflect": "0.31.6",
     "firebase": "9.23.0",
     "firebaseui": "^6.0.2",
     "nanoid": "^4.0.2",

--- a/mirror/mirror-cli/package.json
+++ b/mirror/mirror-cli/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "dependencies": {
     "@badrap/valita": "^0.2.0",
-    "@rocicorp/reflect": "0.31.5",
+    "@rocicorp/reflect": "0.31.6",
     "esbuild": "^0.18.3",
     "firebase": "9.23.0",
     "firebase-admin": "^11.10.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@rocicorp/logger": "^5.2.0",
-        "@rocicorp/reflect": "0.31.5",
+        "@rocicorp/reflect": "0.31.6",
         "firebase": "9.23.0",
         "firebaseui": "^6.0.2",
         "nanoid": "^4.0.2",
@@ -879,7 +879,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@badrap/valita": "^0.2.0",
-        "@rocicorp/reflect": "0.31.5",
+        "@rocicorp/reflect": "0.31.6",
         "esbuild": "^0.18.3",
         "firebase": "9.23.0",
         "firebase-admin": "^11.10.1",
@@ -36293,7 +36293,7 @@
     },
     "packages/reflect": {
       "name": "@rocicorp/reflect",
-      "version": "0.31.5",
+      "version": "0.31.6",
       "license": "SEE LICENSE IN https://roci.dev/terms.html",
       "dependencies": {
         "@badrap/valita": "^0.2.0",
@@ -58009,7 +58009,7 @@
         "@badrap/valita": "^0.2.0",
         "@rocicorp/eslint-config": "^0.4.2",
         "@rocicorp/prettier-config": "^0.1.1",
-        "@rocicorp/reflect": "0.31.5",
+        "@rocicorp/reflect": "0.31.6",
         "@types/node": "^18.16.0",
         "@types/yargs": "^17.0.10",
         "esbuild": "^0.18.3",
@@ -62126,7 +62126,7 @@
         "@rocicorp/logger": "^5.2.0",
         "@rocicorp/prettier-config": "^0.1.1",
         "@rocicorp/rails": "^0.5.0-beta.0",
-        "@rocicorp/reflect": "0.31.5",
+        "@rocicorp/reflect": "0.31.6",
         "@rocicorp/resolver": "^1.0.0",
         "@types/react": "18.2.13",
         "@types/react-dom": "18.2.6",

--- a/packages/reflect/HACKING.md
+++ b/packages/reflect/HACKING.md
@@ -43,7 +43,18 @@ Make sure the `create` command still works as well as the app it generates.
 npx /path/to/rocicorp-reflect-<version>.tgz create my-app
 cd my-app
 npm install
+
+# Should run against remote server
 npm run dev
+
+# Should run against local server
+npx reflect dev src/reflect/index.ts
+VITE_WORKER_URL="ws://127.0.0.1:8080/" npm run dev
+
+# Should ask where to publish on vercel and run on vercel
+# Need to set VITE_WORKER_URL env var on deployment
+npx reflect publish src/reflect/index.ts
+npx vercel
 ```
 
 ### Replidraw-do
@@ -88,6 +99,7 @@ git push --tags
 
 ```
 # pull latest upstream
+git checkout main
 git pull
 
 git branch -D release

--- a/packages/reflect/package.json
+++ b/packages/reflect/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rocicorp/reflect",
   "description": "",
-  "version": "0.31.5",
+  "version": "0.31.6",
   "license": "SEE LICENSE IN https://roci.dev/terms.html",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
Had to roll a new release because the bundling of the template app includes files that are in the local directory but which aren't part of the source checkout (like .vercel). This creates a reflect package that doesn't work properly.

So even though there's no source change here, the actual built package is different.

The code that packages up the template has to be careful to only include the files it actually wants to include, not `*`. Can you please add this to your todo list @cesara.