### PR TITLE
chore(mirror): remove internal Timestamp fields now that we default to passthrough

### DIFF
--- a/mirror/mirror-schema/src/deployment.test.ts
+++ b/mirror/mirror-schema/src/deployment.test.ts
@@ -69,25 +69,28 @@ describe('deployment', () => {
       deploymentOptions: {vars: {}},
     });
 
-    const parsedDeployment = deploymentSchema.parse({
-      deploymentID: 'boo',
-      requesterID: 'foo',
-      type: 'USER_UPLOAD',
-      spec: {
-        appModules: [],
-        hostname: 'bar',
-        serverVersionRange: 'baz',
-        serverVersion: 'boo',
-        options: {vars: {DISABLE_LOG_FILTERING: 'false'}},
-        hashesOfSecrets: {
-          REFLECT_AUTH_API_KEY: 'aaa',
-          DATADOG_LOGS_API_KEY: 'bbb',
-          DATADOG_METRICS_API_KEY: 'ccc',
+    const parsedDeployment = deploymentSchema.parse(
+      {
+        deploymentID: 'boo',
+        requesterID: 'foo',
+        type: 'USER_UPLOAD',
+        spec: {
+          appModules: [],
+          hostname: 'bar',
+          serverVersionRange: 'baz',
+          serverVersion: 'boo',
+          options: {vars: {DISABLE_LOG_FILTERING: 'false'}},
+          hashesOfSecrets: {
+            REFLECT_AUTH_API_KEY: 'aaa',
+            DATADOG_LOGS_API_KEY: 'bbb',
+            DATADOG_METRICS_API_KEY: 'ccc',
+          },
         },
+        requestTime: Timestamp.now(),
+        status: 'REQUESTED',
       },
-      requestTime: Timestamp.now(),
-      status: 'REQUESTED',
-    });
+      {mode: 'passthrough'},
+    );
 
     expect(parsedApp.deploymentOptions?.vars).toEqual(
       parsedDeployment.spec.options?.vars,

--- a/mirror/mirror-schema/src/timestamp.ts
+++ b/mirror/mirror-schema/src/timestamp.ts
@@ -4,12 +4,6 @@ import * as v from 'shared/src/valita.js';
 export const timestampSchema = v.object({
   nanoseconds: v.number(),
   seconds: v.number(),
-
-  // Undocumented fields from https://github.com/googleapis/nodejs-firestore/blob/ac35b372faf32f093d83af18d487f1b3f23ee673/dev/src/timestamp.ts#L60
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  _nanoseconds: v.number().optional(),
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  _seconds: v.number().optional(),
 });
 
 export type Timestamp = v.Infer<typeof timestampSchema>;


### PR DESCRIPTION
Since https://github.com/rocicorp/mono/commit/9b4fac73f3042a6de72c42b1f04f2248b6cc1aa3 our schema parsing uses `passthrough` by default so we no longer need to declare the internal fields in the firestore `Timestamp` class.

@arv 