### PR TITLE
fix(reflect-client): Disable persistance

### DIFF
--- a/apps/reflect.net/components/Demo/Demo.tsx
+++ b/apps/reflect.net/components/Demo/Demo.tsx
@@ -17,7 +17,7 @@ import styles from '@/styles/Home.module.css';
 import {getLocationString, Location} from '@/util/get-location-string';
 import {closeReflect} from '@/util/reflect';
 import {getWorkerHost} from '@/util/worker-host';
-import {ExperimentalMemKVStore, Reflect} from '@rocicorp/reflect/client';
+import {Reflect} from '@rocicorp/reflect/client';
 import classNames from 'classnames';
 import {event} from 'nextjs-google-analytics';
 import {useCallback, useEffect, useState} from 'react';
@@ -32,7 +32,6 @@ function usePuzzleRoomID() {
   useEffect(() => {
     const orchestratorClient = new Reflect<M>({
       socketOrigin: getWorkerHost(),
-      createKVStore: name => new ExperimentalMemKVStore(name),
       userID: 'anon',
       roomID: ORCHESTRATOR_ROOM,
       mutators,
@@ -112,7 +111,6 @@ function useReflect(
 
     const reflect = new Reflect<M>({
       socketOrigin: getWorkerHost(),
-      createKVStore: name => new ExperimentalMemKVStore(name),
       userID: 'anon',
       roomID: puzzleRoomID,
       mutators,

--- a/apps/reflect.net/demo/howto-frontend/index.ts
+++ b/apps/reflect.net/demo/howto-frontend/index.ts
@@ -1,5 +1,5 @@
 import {getWorkerHost} from '@/util/worker-host';
-import {ExperimentalMemKVStore, Reflect} from '@rocicorp/reflect/client';
+import {Reflect} from '@rocicorp/reflect/client';
 import {loggingOptions} from '../frontend/logging-options';
 import {M, mutators} from '../shared/mutators';
 
@@ -7,7 +7,6 @@ export const init = (roomID: string, userID: string): Reflect<M> => {
   // Set up our connection to reflect
   // Create a reflect client
   const reflectClient = new Reflect<M>({
-    createKVStore: name => new ExperimentalMemKVStore(name),
     socketOrigin: getWorkerHost(),
     onOnlineChange: online => {
       console.log(`${userID} online: ${online}`);

--- a/mirror/reflect-cli/template/src/index.tsx
+++ b/mirror/reflect-cli/template/src/index.tsx
@@ -1,11 +1,11 @@
+import {Reflect} from '@rocicorp/reflect/client';
+import {nanoid} from 'nanoid';
 import React, {useEffect} from 'react';
 import ReactDOM from 'react-dom/client';
-import {mutators} from './reflect/mutators';
-import {ExperimentalMemKVStore, Reflect} from '@rocicorp/reflect/client';
-import {nanoid} from 'nanoid';
-import {randUserInfo} from './reflect/client-state';
-import styles from './index.module.css';
 import CursorField from './cursor-field';
+import styles from './index.module.css';
+import {randUserInfo} from './reflect/client-state';
+import {mutators} from './reflect/mutators';
 import {useCount} from './subscriptions';
 
 const userID = nanoid();
@@ -23,11 +23,6 @@ const r = new Reflect({
   roomID,
   auth: userID,
   mutators,
-
-  // Turns off local persistence. This will go away soon.
-  createKVStore: (name: string) => {
-    return new ExperimentalMemKVStore(name);
-  },
 });
 
 const App = () => {

--- a/packages/reflect-client/src/client/options.ts
+++ b/packages/reflect-client/src/client/options.ts
@@ -172,12 +172,6 @@ export interface ReflectOptions<MD extends MutatorDefs> {
   hiddenTabDisconnectDelay?: number | undefined;
 
   /**
-   * Allows providing a custom implementation of the underlying storage layer.
-   * @deprecated Use [[kvStore]] instead.
-   */
-  createKVStore?: CreateKVStore | undefined;
-
-  /**
    * Determines what kind of storage implementation to use on the client.
    *
    * Defaults to `'mem'` which means that Reflect uses an in memory storage and

--- a/packages/reflect-client/src/client/reflect.test.ts
+++ b/packages/reflect-client/src/client/reflect.test.ts
@@ -28,7 +28,6 @@ import {
   MockSocket,
   TestLogSink,
   TestReflect,
-  idbExists,
   reflectForTest,
   tickAFewTimes,
   waitForUpstreamMessage,
@@ -1547,32 +1546,6 @@ test('kvStore option', async () => {
   const kvStore: CreateKVStore = name => new ExperimentalMemKVStore(name);
   await t(kvStore, 'kv-store-test-user-id-4', false, undefined);
   await t(kvStore, 'kv-store-test-user-id-4', false, 'bar');
-});
-
-test('experimentalKVStore', async () => {
-  const r1 = reflectForTest({
-    mutators: {
-      putFoo: async (tx, val: string) => {
-        await tx.put('foo', val);
-      },
-    },
-  });
-  await r1.mutate.putFoo('bar');
-  expect(await r1.query(tx => tx.get('foo'))).to.equal('bar');
-  // We currently disable persistence so there should be no IndexedDB.
-  expect(await idbExists(r1.idbName)).is.false;
-
-  const r2 = reflectForTest({
-    createKVStore: name => new ExperimentalMemKVStore(name),
-    mutators: {
-      putFoo: async (tx, val: string) => {
-        await tx.put('foo', val);
-      },
-    },
-  });
-  await r2.mutate.putFoo('bar');
-  expect(await r2.query(tx => tx.get('foo'))).to.equal('bar');
-  expect(await idbExists(r2.idbName)).is.false;
 });
 
 test('Close during connect should sleep', async () => {

--- a/packages/reflect-client/src/client/reflect.ts
+++ b/packages/reflect-client/src/client/reflect.ts
@@ -1432,10 +1432,8 @@ function getCreateKVStore<MD extends MutatorDefs>(
       return undefined;
 
     case 'mem':
-      return createMemStore;
-
     case undefined:
-      return options.createKVStore ?? createMemStore;
+      return createMemStore;
 
     default:
       return options.kvStore;

--- a/packages/reflect-client/src/client/test-utils.ts
+++ b/packages/reflect-client/src/client/test-utils.ts
@@ -221,18 +221,3 @@ export async function waitForUpstreamMessage(
     }
   }
 }
-
-export function idbExists(idbName: string): Promise<boolean> {
-  const req = indexedDB.open(idbName);
-  let existed = true;
-  const {promise, resolve} = resolver<boolean>();
-
-  req.onsuccess = function () {
-    req.result.close();
-    resolve(existed);
-  };
-  req.onupgradeneeded = function () {
-    existed = false;
-  };
-  return promise;
-}


### PR DESCRIPTION
Now we always use the in-memory store. This is a temporary fix until we have presence done.