### PR TITLE
feat(mirror): Team subdomain schema and protocol

### DIFF
--- a/mirror/mirror-protocol/src/team.ts
+++ b/mirror/mirror-protocol/src/team.ts
@@ -1,0 +1,21 @@
+import * as v from 'shared/src/valita.js';
+import {baseRequestFields, baseResponseFields} from './base.js';
+import {createCall} from './call.js';
+
+export const ensureTeamRequestSchema = v.object({
+  ...baseRequestFields,
+  name: v.string(),
+});
+export type EnsureTeamRequest = v.Infer<typeof ensureTeamRequestSchema>;
+
+export const ensureTeamResponseSchema = v.object({
+  ...baseResponseFields,
+  teamID: v.string(),
+});
+export type EnsureTeamResponse = v.Infer<typeof ensureTeamResponseSchema>;
+
+export const ensureTeam = createCall(
+  'team-ensure',
+  ensureTeamRequestSchema,
+  ensureTeamResponseSchema,
+);

--- a/mirror/mirror-schema/src/team.test.ts
+++ b/mirror/mirror-schema/src/team.test.ts
@@ -1,0 +1,79 @@
+import {describe, expect, test} from '@jest/globals';
+import {isValidSubdomain, sanitizeForSubdomain} from './team.js';
+
+describe('team subdomain validation', () => {
+  type Case = {
+    desc: string;
+    name: string;
+    valid?: boolean;
+    sanitized?: string;
+  };
+  const cases: Case[] = [
+    {
+      desc: 'alphanumeric',
+      name: 'valid0name0',
+      valid: true,
+    },
+    {
+      desc: 'alphanumeric with hyphens',
+      name: 'this-is-1-valid-name0',
+      valid: true,
+    },
+    {
+      desc: 'cannot be uppercase',
+      name: 'NotAValidName',
+      sanitized: 'notavalidname',
+    },
+    {
+      desc: 'cannot start with digit',
+      name: '0is-not-allowed',
+      sanitized: 'is-not-allowed',
+    },
+    {
+      desc: 'dots not allowed',
+      name: 'foo.bar',
+      sanitized: 'foo-bar',
+    },
+    {
+      desc: 'starting and trailing illegal characters',
+      name: '.foo.bar.',
+      sanitized: 'foo-bar',
+    },
+    {
+      desc: 'consecutive illegal characters coalesced',
+      name: 'My Company, LLC.',
+      sanitized: 'my-company-llc',
+    },
+    {
+      desc: 'cannot end with hyphen',
+      name: 'cannot-end-with-hyphen-',
+      sanitized: 'cannot-end-with-hyphen',
+    },
+    {
+      desc: 'cannot have spaces',
+      name: 'name with spaces',
+      sanitized: 'name-with-spaces',
+    },
+    {
+      desc: 'space in the beginning',
+      name: ' name-starting-with-space',
+      sanitized: 'name-starting-with-space',
+    },
+    {
+      desc: 'space at the end',
+      name: 'name-ending-with-space ',
+      sanitized: 'name-ending-with-space',
+    },
+  ];
+
+  for (const c of cases) {
+    test(c.desc, () => {
+      expect(isValidSubdomain(c.name)).toBe(c.valid ?? false);
+      if (c.sanitized) {
+        expect(sanitizeForSubdomain(c.name)).toBe(c.sanitized);
+      } else {
+        expect(sanitizeForSubdomain(c.name)).toBe(c.name);
+      }
+    });
+  }
+});

--- a/mirror/mirror-schema/src/team.ts
+++ b/mirror/mirror-schema/src/team.ts
@@ -4,6 +4,13 @@ import * as path from './path.js';
 
 export const teamSchema = v.object({
   name: v.string(),
+
+  // Subdomain of reflect-server.net where apps are hosted, e.g.
+  // https://app-name.team-subdomain.reflect-server.net
+  //
+  // TODO: Denormalized to all of the Team's apps to simplify deployment logic.
+  subdomain: v.string().optional(), // Make required
+
   defaultCfID: v.string(),
 
   // Number of memberships of role 'admin'.
@@ -26,4 +33,34 @@ export const TEAM_COLLECTION = 'teams';
 
 export function teamPath(teamID: string): string {
   return path.join(TEAM_COLLECTION, teamID);
+}
+
+export const teamSubdomainIndexSchema = v.object({
+  teamID: v.string(),
+});
+
+export type TeamSubdomainIndex = v.Infer<typeof teamSubdomainIndexSchema>;
+
+export const teamSubdomainIndexDataConverter = firestoreDataConverter(
+  teamSubdomainIndexSchema,
+);
+
+export const TEAM_SUBDOMAIN_INDEX_COLLECTION = 'teamSubdomains';
+
+export function teamSubdomainIndexPath(subdomain: string): string {
+  return path.join(TEAM_SUBDOMAIN_INDEX_COLLECTION, subdomain);
+}
+
+const VALID_SUBDOMAIN = /^[a-z]([a-z0-9-])*[a-z0-9]$/;
+
+export function isValidSubdomain(name: string): boolean {
+  return VALID_SUBDOMAIN.test(name);
+}
+
+export function sanitizeForSubdomain(orig: string): string {
+  return orig
+    .toLocaleLowerCase()
+    .replaceAll(/[^a-z0-9-]+/g, '-') // Replace any sequences of illegal characters with a hyphens
+    .replaceAll(/^[0-9-]*/g, '') // Remove leading digits or hyphens
+    .replaceAll(/[-]*$/g, ''); // Remove trailing hyphens
 }

--- a/mirror/mirror-server/src/functions/team/ensure.function.test.ts
+++ b/mirror/mirror-server/src/functions/team/ensure.function.test.ts
@@ -1,0 +1,204 @@
+import {
+  describe,
+  expect,
+  test,
+  beforeAll,
+  beforeEach,
+  afterEach,
+} from '@jest/globals';
+import type {DecodedIdToken} from 'firebase-admin/auth';
+import {getFirestore, type Firestore} from 'firebase-admin/firestore';
+import {https} from 'firebase-functions/v2';
+import type {Request} from 'firebase-functions/v2/https';
+import {
+  TEAM_MEMBERSHIPS_COLLECTION_ID,
+  membershipDataConverter,
+  teamMembershipPath,
+} from 'mirror-schema/src/membership.js';
+import {
+  getMembership,
+  getTeam,
+  getUser,
+  setUser,
+} from 'mirror-schema/src/test-helpers.js';
+import {mockFunctionParamsAndSecrets} from '../../test-helpers.js';
+import {DEFAULT_MAX_APPS, ensure} from './ensure.function.js';
+import {initializeApp} from 'firebase-admin/app';
+import {userDataConverter, userPath} from 'mirror-schema/src/user.js';
+import {
+  teamPath,
+  teamSubdomainIndexDataConverter,
+  teamSubdomainIndexPath,
+} from 'mirror-schema/src/team.js';
+import {must} from 'shared/src/must.js';
+
+mockFunctionParamsAndSecrets();
+
+describe('team-ensure function', () => {
+  initializeApp({projectId: 'team-ensure-function-test'});
+  const firestore = getFirestore();
+  const USER_ID = 'team-ensure-test-user';
+  const USER_EMAIL = 'foo@bar.com';
+  const TEAM_ID = 'team-ensure-test-team';
+
+  function callEnsure(firestore: Firestore, name: string) {
+    const ensureFunction = https.onCall(ensure(firestore));
+
+    return ensureFunction.run({
+      data: {
+        requester: {
+          userID: USER_ID,
+          userAgent: {type: 'reflect-cli', version: '0.0.1'},
+        },
+        name,
+      },
+
+      auth: {
+        uid: USER_ID,
+        token: {email: USER_EMAIL} as DecodedIdToken,
+      },
+      rawRequest: null as unknown as Request,
+    });
+  }
+
+  async function deleteTeam(teamID: string, subdomain: string): Promise<void> {
+    const batch = firestore.batch();
+    batch.delete(firestore.doc(teamPath(teamID)));
+    batch.delete(firestore.doc(teamSubdomainIndexPath(subdomain)));
+    batch.delete(firestore.doc(teamMembershipPath(teamID, USER_ID)));
+    await batch.commit();
+  }
+
+  beforeAll(async () => {
+    const subs = await firestore
+      .collection('teamSubdomains')
+      .withConverter(teamSubdomainIndexDataConverter)
+      .get();
+    for (const doc of subs.docs) {
+      const team = await firestore.doc(teamPath(doc.data().teamID)).get();
+      console.warn(
+        `Existing subdomain: ${doc.ref.path}: ${doc.data().teamID}`,
+        team.data(),
+      );
+      const members = await firestore
+        .collection(TEAM_MEMBERSHIPS_COLLECTION_ID)
+        .withConverter(membershipDataConverter)
+        .get();
+      console.warn(`Members: [${members.docs.map(doc => doc.data())}]`);
+    }
+  });
+
+  beforeEach(async () => {
+    const batch = firestore.batch();
+    batch.create(
+      firestore.doc(userPath(USER_ID)).withConverter(userDataConverter),
+      {email: USER_EMAIL, roles: {}},
+    );
+    await batch.commit();
+  });
+
+  // Clean up test data from global emulator state.
+  afterEach(async () => {
+    const batch = firestore.batch();
+    batch.delete(firestore.doc(userPath(USER_ID)));
+    await batch.commit();
+  });
+
+  describe('ensure when user is already member of a team', () => {
+    for (const role of ['admin', 'member'] as const) {
+      test(`ensure with ${role} role`, async () => {
+        const name = 'Test User';
+
+        await setUser(firestore, USER_ID, USER_EMAIL, name, {
+          [TEAM_ID]: role,
+        });
+
+        const resp = await callEnsure(firestore, 'ignored');
+        expect(resp).toEqual({
+          success: true,
+          teamID: TEAM_ID,
+        });
+      });
+    }
+  });
+
+  test('ensure when no team', async () => {
+    const resp = await callEnsure(firestore, 'My Team, LLC.');
+    expect(resp).toMatchObject({
+      success: true,
+      teamID: expect.any(String),
+    });
+    const {teamID} = resp;
+    const user = await getUser(firestore, USER_ID);
+    expect(user.roles).toEqual({[teamID]: 'admin'});
+    const team = await getTeam(firestore, teamID);
+
+    expect(team).toEqual({
+      name: 'My Team, LLC.',
+      subdomain: 'my-team-llc',
+      defaultCfID: 'default-CLOUDFLARE_ACCOUNT_ID',
+      numAdmins: 1,
+      numMembers: 0,
+      numInvites: 0,
+      numApps: 0,
+      maxApps: DEFAULT_MAX_APPS,
+    });
+    const membership = await getMembership(firestore, teamID, USER_ID);
+    expect(membership).toEqual({
+      email: USER_EMAIL,
+      role: 'admin',
+    });
+    const subdomain = must(team.subdomain);
+    const subdomainIndex = await firestore
+      .doc(teamSubdomainIndexPath(subdomain))
+      .get();
+    expect(subdomainIndex.data()).toEqual({teamID});
+
+    // Cleanup
+    await deleteTeam(teamID, subdomain);
+  });
+
+  test('ensure team with colliding subdomain', async () => {
+    await firestore
+      .doc(teamSubdomainIndexPath('existing-team-name-llc'))
+      .withConverter(teamSubdomainIndexDataConverter)
+      .create({
+        teamID: TEAM_ID,
+      });
+
+    const resp = await callEnsure(firestore, 'Existing Team Name, LLC.');
+    expect(resp).toMatchObject({
+      success: true,
+      teamID: expect.any(String),
+    });
+    const {teamID} = resp;
+    const user = await getUser(firestore, USER_ID);
+    expect(user.roles).toEqual({[teamID]: 'admin'});
+    const team = await getTeam(firestore, teamID);
+
+    expect(team).toEqual({
+      name: 'Existing Team Name, LLC.',
+      subdomain: expect.stringMatching(/existing-team-name-llc-\d+/),
+      defaultCfID: 'default-CLOUDFLARE_ACCOUNT_ID',
+      numAdmins: 1,
+      numMembers: 0,
+      numInvites: 0,
+      numApps: 0,
+      maxApps: DEFAULT_MAX_APPS,
+    });
+    const membership = await getMembership(firestore, teamID, USER_ID);
+    expect(membership).toEqual({
+      email: USER_EMAIL,
+      role: 'admin',
+    });
+    const subdomain = must(team.subdomain);
+    const subdomainIndex = await firestore
+      .doc(teamSubdomainIndexPath(subdomain))
+      .get();
+    expect(subdomainIndex.data()).toEqual({teamID});
+
+    // Cleanup
+    await deleteTeam(teamID, subdomain);
+    await deleteTeam(TEAM_ID, 'existing-team-name-llc');
+  });
+});

--- a/mirror/mirror-server/src/functions/team/ensure.function.ts
+++ b/mirror/mirror-server/src/functions/team/ensure.function.ts
@@ -1,0 +1,130 @@
+import type {Firestore, Transaction} from 'firebase-admin/firestore';
+import {defineString} from 'firebase-functions/params';
+import {HttpsError} from 'firebase-functions/v2/https';
+import {
+  ensureTeamRequestSchema,
+  ensureTeamResponseSchema,
+} from 'mirror-protocol/src/team.js';
+import {userDataConverter, userPath} from 'mirror-schema/src/user.js';
+import {userAuthorization} from '../validators/auth.js';
+import {validateSchema} from '../validators/schema.js';
+import {newTeamID} from 'shared/src/mirror/ids.js';
+import {
+  membershipDataConverter,
+  teamMembershipPath,
+} from 'mirror-schema/src/membership.js';
+import {
+  teamDataConverter,
+  teamPath,
+  sanitizeForSubdomain,
+  teamSubdomainIndexPath,
+  teamSubdomainIndexDataConverter,
+} from 'mirror-schema/src/team.js';
+import {logger} from 'firebase-functions';
+import {must} from 'shared/src/must.js';
+import {randomInt} from 'crypto';
+
+const cloudflareAccountId = defineString('CLOUDFLARE_ACCOUNT_ID');
+
+export const DEFAULT_MAX_APPS = null;
+
+export const ensure = (firestore: Firestore) =>
+  validateSchema(ensureTeamRequestSchema, ensureTeamResponseSchema)
+    .validate(userAuthorization())
+    .handle(async (req, context) => {
+      const {userID} = context;
+      const {name} = req;
+
+      const userDocRef = firestore
+        .doc(userPath(userID))
+        .withConverter(userDataConverter);
+
+      const teamID = await firestore.runTransaction(async txn => {
+        try {
+          const userDoc = await txn.get(userDocRef);
+          if (!userDoc.exists) {
+            throw new HttpsError('not-found', `User ${userID} does not exist`);
+          }
+
+          const user = must(userDoc.data());
+          const {email} = user;
+
+          const teamIDs = Object.keys(user.roles);
+          if (teamIDs.length > 1) {
+            throw new HttpsError(
+              'internal',
+              'User is part of multiple teams, but only one team is supported at this time',
+            );
+          }
+          if (teamIDs.length === 1) {
+            return teamIDs[0];
+          }
+
+          const teamID = newTeamID();
+          const subdomain = await getSubdomain(firestore, txn, name);
+
+          logger.info(
+            `Creating team "${name}" (${teamID}) at ${subdomain}.reflect-server.net for user ${userID}`,
+          );
+          txn.create(
+            firestore.doc(teamPath(teamID)).withConverter(teamDataConverter),
+            {
+              name,
+              subdomain,
+              defaultCfID: cloudflareAccountId.value(),
+              numAdmins: 1,
+              numMembers: 0,
+              numInvites: 0,
+              numApps: 0,
+              maxApps: DEFAULT_MAX_APPS,
+            },
+          );
+          txn.create(
+            firestore
+              .doc(teamMembershipPath(teamID, userID))
+              .withConverter(membershipDataConverter),
+            {email, role: 'admin'},
+          );
+          txn.update(userDocRef, {roles: {[teamID]: 'admin'}});
+          txn.create(
+            firestore
+              .doc(teamSubdomainIndexPath(subdomain))
+              .withConverter(teamSubdomainIndexDataConverter),
+            {teamID},
+          );
+          return teamID;
+        } catch (e) {
+          console.error(String(e));
+          throw e;
+        }
+      });
+      return {teamID, success: true};
+    });
+
+async function getSubdomain(
+  firestore: Firestore,
+  txn: Transaction,
+  name: string,
+): Promise<string> {
+  // Try up to 5 times to add a random number fo the subdomain if it is taken.
+  for (let i = 0; i < 5; i++) {
+    const subdomain =
+      i === 0
+        ? sanitizeForSubdomain(name)
+        : `${sanitizeForSubdomain(name)}-${randomInt(10000)}`;
+    const entry = await txn.get(
+      firestore.doc(teamSubdomainIndexPath(subdomain)),
+    );
+    if (!entry.exists) {
+      return subdomain;
+    }
+    logger.info(
+      `Team with subdomain ${subdomain} (${entry.ref.path}) already exists. Adding a random suffix.`,
+      entry.data(),
+    );
+  }
+  throw new HttpsError(
+    'resource-exhausted',
+    `Failed to generate a random subdomain for ${name}`,
+  );
+}

--- a/mirror/mirror-server/src/functions/team/index.ts
+++ b/mirror/mirror-server/src/functions/team/index.ts
@@ -1,0 +1,1 @@
+export {ensure} from './ensure.function.js';

--- a/mirror/mirror-server/src/index.ts
+++ b/mirror/mirror-server/src/index.ts
@@ -12,6 +12,7 @@ import {
 import * as appFunctions from './functions/app/index.js';
 import {healthcheck as healthcheckHandler} from './functions/healthcheck.function.js';
 import * as serverFunctions from './functions/server/index.js';
+import * as teamFunctions from './functions/team/index.js';
 import * as userFunctions from './functions/user/index.js';
 import {DEPLOYMENT_SECRETS_NAMES} from './functions/app/secrets.js';
 
@@ -58,4 +59,8 @@ export const app = {
 
 export const server = {
   autoDeploy: serverFunctions.autoDeploy(getFirestore()),
+};
+
+export const team = {
+  ensure: https.onCall(baseHttpsOptions, teamFunctions.ensure(getFirestore())),
 };


### PR DESCRIPTION
Schema and protocol for supporting Team subdomains (e.g. `https://app-name.team-name.reflect-server.net`).

* Introduces a `subdomain` field is added to the `Team` doc, which defaults to a sanitized version of the team `name`. 
* Adds a `teamSubdomains/<subdomain>` Firestore collection to serve as a index for ensuring that subdomains are globally unique.
* Introduces a `team-ensure` cloud function that ensures that the user is part of exactly one team, initializing it with the supplied `name` if not. (This `name` will be the github username from the developer's oauth credentials). 

The implementation of `team-ensure` is largely taken from the current `app-create` function.

In the next step, the latter will be changed to expect that the `Team` is already ensured with creating the app, thereby splitting the original implementation. This will also facilitate creation of Apps in different teams when we add support for multiple teams.
