### PR TITLE
fix(mirror): workaround valita constructor-less objects that break Firestore

### DIFF
--- a/mirror/mirror-schema/src/converter.test.ts
+++ b/mirror/mirror-schema/src/converter.test.ts
@@ -1,0 +1,73 @@
+import {expect, test} from '@jest/globals';
+import {DataConverter} from './converter.js';
+import {DeploymentSpec, deploymentSpecSchema} from './deployment.js';
+import type {
+  DocumentData,
+  QueryDocumentSnapshot,
+} from '@google-cloud/firestore';
+import {dummySecrets} from './test-helpers.js';
+
+// Replicates the internal validation performed in the Firestore libraries
+// that ensure that data confirms to certain expectations:
+// https://github.com/googleapis/nodejs-firestore/blob/d2b97c4e041ca6f3245b942540e793d429f8e5c5/dev/src/util.ts#L107
+function isObject(value: unknown): value is {[k: string]: unknown} {
+  return Object.prototype.toString.call(value) === '[object Object]';
+}
+
+function isPlainObject(input: unknown): input is object {
+  return (
+    isObject(input) &&
+    (Object.getPrototypeOf(input) === Object.prototype ||
+      Object.getPrototypeOf(input) === null ||
+      input.constructor.name === 'Object')
+  );
+}
+
+function isValidDocumentData(input: object): boolean {
+  for (const [name, value] of Object.entries(input)) {
+    console.info(`Checking ${name}`, value);
+    if (isPlainObject(value) && !isValidDocumentData(value)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+test('converter creates plain objects', () => {
+  const converter = new DataConverter(deploymentSpecSchema);
+
+  function convert(obj: DocumentData): DeploymentSpec {
+    const snapshot = {
+      data: () => obj,
+    } as QueryDocumentSnapshot<DocumentData>;
+    return converter.fromFirestore(snapshot);
+  }
+
+  const parsed = convert({
+    appModules: [],
+    serverVersionRange: 'foo',
+    serverVersion: 'bar',
+    hostname: 'baz',
+    hashesOfSecrets: dummySecrets(),
+    options: {vars: {}},
+  });
+
+  expect(isValidDocumentData(parsed));
+
+  /* eslint-disable @typescript-eslint/naming-convention */
+  expect(parsed).toEqual({
+    appModules: [],
+    serverVersionRange: 'foo',
+    serverVersion: 'bar',
+    hostname: 'baz',
+    hashesOfSecrets: dummySecrets(),
+    options: {
+      vars: {
+        DISABLE: 'false',
+        DISABLE_LOG_FILTERING: 'false',
+        LOG_LEVEL: 'info',
+      },
+    },
+  });
+  /* eslint-enable @typescript-eslint/naming-convention */
+});

--- a/mirror/mirror-schema/src/converter.ts
+++ b/mirror/mirror-schema/src/converter.ts
@@ -4,7 +4,8 @@ import type {
   QueryDocumentSnapshot,
 } from '@google-cloud/firestore';
 import type firebase from 'firebase/compat/app';
-import * as v from 'shared/src/valita.js';
+import type * as v from 'shared/src/valita.js';
+import {parse} from './parse.js';
 
 export function firestoreDataConverter<T extends DocumentData>(
   schema: v.Type<T>,
@@ -45,6 +46,6 @@ export class DataConverter<T extends DocumentData>
       | firebase.default.firestore.QueryDocumentSnapshot,
     _?: firebase.default.firestore.SnapshotOptions,
   ): T {
-    return v.parse(snapshot.data(), this.#schema, this.#mode);
+    return parse(snapshot.data(), this.#schema, this.#mode);
   }
 }

--- a/mirror/mirror-schema/src/deployment.ts
+++ b/mirror/mirror-schema/src/deployment.ts
@@ -3,6 +3,7 @@ import {firestoreDataConverter} from './converter.js';
 import * as path from './path.js';
 import {timestampSchema} from './timestamp.js';
 import {moduleRefSchema} from './module.js';
+import {parse} from './parse.js';
 
 export const logLevelSchema = v.union(
   v.literal('debug'),
@@ -33,10 +34,7 @@ export const varsSchema = v.object({
 export type DeploymentVars = v.Infer<typeof varsSchema>;
 
 function defaultVars(): DeploymentVars {
-  //shallow copy to ensure this will pass firestore isPlainObject check which requires objects to have a constructor with name 'Object'
-  //valita creates objects without a prototype and thus without a constructor
-  //https://github.com/badrap/valita/blob/5db630edb1397959f613b94b0f9e22ceb8ec78d4/src/index.ts#L568
-  return {...varsSchema.parse({})};
+  return parse({}, varsSchema);
 }
 
 export const deploymentOptionsSchema = v.object({

--- a/mirror/mirror-schema/src/parse.test.ts
+++ b/mirror/mirror-schema/src/parse.test.ts
@@ -1,0 +1,63 @@
+import {expect, test} from '@jest/globals';
+import {deploymentSpecSchema} from './deployment.js';
+import {dummySecrets} from './test-helpers.js';
+import {parse} from './parse.js';
+
+// Replicates the internal validation performed in the Firestore libraries
+// that ensure that data confirms to certain expectations:
+// https://github.com/googleapis/nodejs-firestore/blob/d2b97c4e041ca6f3245b942540e793d429f8e5c5/dev/src/util.ts#L107
+function isObject(value: unknown): value is {[k: string]: unknown} {
+  return Object.prototype.toString.call(value) === '[object Object]';
+}
+
+function isPlainObject(input: unknown): input is object {
+  return (
+    isObject(input) &&
+    (Object.getPrototypeOf(input) === Object.prototype ||
+      Object.getPrototypeOf(input) === null ||
+      input.constructor.name === 'Object')
+  );
+}
+
+function isValidDocumentData(input: object): boolean {
+  for (const [name, value] of Object.entries(input)) {
+    console.info(`Checking ${name}`, value);
+    if (isPlainObject(value) && !isValidDocumentData(value)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+test('parse creates plain objects', () => {
+  const parsed = parse(
+    {
+      appModules: [],
+      serverVersionRange: 'foo',
+      serverVersion: 'bar',
+      hostname: 'baz',
+      hashesOfSecrets: dummySecrets(),
+      options: {vars: {}},
+    },
+    deploymentSpecSchema,
+  );
+
+  expect(isValidDocumentData(parsed));
+
+  /* eslint-disable @typescript-eslint/naming-convention */
+  expect(parsed).toEqual({
+    appModules: [],
+    serverVersionRange: 'foo',
+    serverVersion: 'bar',
+    hostname: 'baz',
+    hashesOfSecrets: dummySecrets(),
+    options: {
+      vars: {
+        DISABLE: 'false',
+        DISABLE_LOG_FILTERING: 'false',
+        LOG_LEVEL: 'info',
+      },
+    },
+  });
+  /* eslint-enable @typescript-eslint/naming-convention */
+});

--- a/mirror/mirror-schema/src/parse.ts
+++ b/mirror/mirror-schema/src/parse.ts
@@ -1,0 +1,40 @@
+import * as v from 'shared/src/valita.js';
+
+// Firestore DocumentData-friendly version of valita.parse().
+export function parse<T extends Record<string, unknown>>(
+  value: unknown,
+  schema: v.Type<T>,
+  mode?: v.ParseOptionsMode,
+): T {
+  const parsed = v.parse(value, schema, mode);
+  return ensurePlainObject(parsed) as T;
+}
+
+// valita parsing for schemas with fields that have default values can result
+// in the creation of objects that violate assumptions of the Firestore libraries;
+// namely, that all Objects have constructors. This fixes it.
+function ensurePlainObject(
+  value: Record<string, unknown>,
+): Record<string, unknown> {
+  if (isMissingConstructor(value)) {
+    // Shallow copy to ensure this will pass firestore isPlainObject check, which requires objects to
+    // have a constructor with name 'Object'. valita creates objects without a prototype and thus
+    // without a constructor
+    // https://github.com/badrap/valita/blob/5db630edb1397959f613b94b0f9e22ceb8ec78d4/src/index.ts#L568
+    value = {...value};
+  }
+  for (const [name, val] of Object.entries(value)) {
+    if (isObject(val)) {
+      value[name] = ensurePlainObject(val);
+    }
+  }
+  return value;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return Object.prototype.toString.call(value) === '[object Object]';
+}
+
+function isMissingConstructor(input: unknown): boolean {
+  return isObject(input) && input.constructor === undefined;
+}


### PR DESCRIPTION
This replicate's @cesara 's fix in #851 to a common `parse()` method used in all `mirror-schema` logic, and employs that logic in the `DataConverter` class used to parse all objects from Firestore.

This ensures that objects with `DeploymentVars`, possibly deeply nested in the document, will always be parsed in a Firestore-friendly manner.

@grgbkr This should allow the new `DISABLE` var to be introduced properly.