### PR TITLE
feat(mirror): app-delete function

### DIFF
--- a/mirror/mirror-protocol/src/app.ts
+++ b/mirror/mirror-protocol/src/app.ts
@@ -51,3 +51,22 @@ export const renameApp = createCall(
   renameAppRequestSchema,
   renameAppResponseSchema,
 );
+
+export const deleteAppRequestSchema = v.object({
+  ...baseAppRequestFields,
+});
+
+export type DeleteAppRequest = v.Infer<typeof deleteAppRequestSchema>;
+
+export const deleteAppResponseSchema = v.object({
+  ...baseResponseFields,
+  deploymentPath: v.string(),
+});
+
+export type DeleteAppResponse = v.Infer<typeof deleteAppResponseSchema>;
+
+export const deleteApp = createCall(
+  'app-delete',
+  deleteAppRequestSchema,
+  deleteAppResponseSchema,
+);

--- a/mirror/mirror-schema/src/deployment.ts
+++ b/mirror/mirror-schema/src/deployment.ts
@@ -63,6 +63,10 @@ export const deploymentTypeSchema = v.union(
   v.literal('OPTIONS_UPDATE'),
   v.literal('SECRETS_UPDATE'),
   v.literal('HOSTNAME_UPDATE'),
+  // Although DELETE is not technically a cloudflare "deployment", all cloudflare
+  // worker commands are serialized via the deployment queue to avoid race
+  // conditions that could otherwise arise from concurrent execution.
+  v.literal('DELETE'),
 );
 export type DeploymentType = v.Infer<typeof deploymentTypeSchema>;
 

--- a/mirror/mirror-server/src/cloudflare/delete.ts
+++ b/mirror/mirror-server/src/cloudflare/delete.ts
@@ -1,0 +1,32 @@
+import type {Config} from './config.js';
+import {cfFetch} from './cf-fetch.js';
+import {logger} from 'firebase-functions';
+
+// https://github.com/cloudflare/workers-sdk/blob/e9fae5586c14eeae8bb44e0dcf940052635575b4/packages/wrangler/src/delete.ts#L93
+export async function deleteScript(config: Config): Promise<void> {
+  const {apiToken, accountID, scriptName} = config;
+  const resource = `/accounts/${accountID}/workers/scripts/${scriptName}`;
+
+  try {
+    await cfFetch(
+      apiToken,
+      resource,
+      {method: 'DELETE'},
+      new URLSearchParams({force: 'true'}),
+    );
+  } catch (e) {
+    // Error returned by Cloudflare when the script is not found (already deleted)
+    // {
+    //   "code": 10007,
+    //   "message": "workers.api.error.script_not_found"
+    // }
+    // an attached to the ParseError in throwFetchError().
+    if ((e as unknown as {code?: number}).code === 10007) {
+      // Log a warning but otherwise consider it a success.
+      logger.warn(`Script ${scriptName} was not found in Cloudflare`, e);
+    } else {
+      throw e;
+    }
+  }
+  logger.info(`Deleted script ${scriptName}`);
+}

--- a/mirror/mirror-server/src/functions/app/delete.function.test.ts
+++ b/mirror/mirror-server/src/functions/app/delete.function.test.ts
@@ -1,0 +1,114 @@
+import {describe, expect, test, beforeEach, afterEach} from '@jest/globals';
+import {
+  setUser,
+  setApp,
+  setTeam,
+  setMembership,
+  getApp,
+} from 'mirror-schema/src/test-helpers.js';
+import {https} from 'firebase-functions/v2';
+import {HttpsError, type Request} from 'firebase-functions/v2/https';
+import type {AuthData} from 'firebase-functions/v2/tasks';
+import type {DeleteAppRequest} from 'mirror-protocol/src/app.js';
+import {teamPath} from 'mirror-schema/src/team.js';
+import {initializeApp} from 'firebase-admin/app';
+import {getFirestore} from 'firebase-admin/firestore';
+import {
+  appPath,
+  deploymentDataConverter,
+  deploymentsCollection,
+} from 'mirror-schema/src/deployment.js';
+import {deleteApp} from './delete.function.js';
+import {userDataConverter, userPath} from 'mirror-schema/src/user.js';
+import {teamMembershipPath} from 'mirror-schema/src/membership.js';
+import {fail} from 'assert';
+
+describe('app-delete function', () => {
+  initializeApp({projectId: 'delete-function-test'});
+  const firestore = getFirestore();
+  const APP_ID = 'app-delete-test-app';
+  const TEAM_ID = 'app-delete-test-team';
+  const USER_ID = 'app-delete-test-user';
+
+  const deleteFunction = https.onCall(deleteApp(firestore));
+
+  const request: DeleteAppRequest = {
+    requester: {
+      userAgent: {
+        type: 'reflect-cli',
+        version: '0.0.1',
+      },
+      userID: USER_ID,
+    },
+    appID: APP_ID,
+  } as const;
+
+  beforeEach(async () => {
+    await setUser(firestore, USER_ID, 'foo@bar.com', undefined, {
+      [TEAM_ID]: 'admin',
+    });
+    await setTeam(firestore, TEAM_ID, {});
+    await setMembership(firestore, TEAM_ID, USER_ID, 'foo@bar.com', 'admin');
+    await setApp(firestore, APP_ID, {teamID: TEAM_ID});
+  });
+
+  afterEach(async () => {
+    const batch = firestore.batch();
+    const deployments = await firestore
+      .collection(deploymentsCollection(APP_ID))
+      .listDocuments();
+    deployments.forEach(doc => batch.delete(doc));
+    batch.delete(firestore.doc(appPath(APP_ID)));
+    batch.delete(firestore.doc(userPath(USER_ID)));
+    batch.delete(firestore.doc(teamPath(TEAM_ID)));
+    batch.delete(firestore.doc(teamMembershipPath(TEAM_ID, USER_ID)));
+    await batch.commit();
+  });
+
+  test('requests delete deployment', async () => {
+    const resp = await deleteFunction.run({
+      auth: {uid: USER_ID} as AuthData,
+      data: request,
+      rawRequest: null as unknown as Request,
+    });
+
+    const {deploymentPath} = resp;
+    const deploymentDoc = await firestore
+      .doc(deploymentPath)
+      .withConverter(deploymentDataConverter);
+    const deployment = await deploymentDoc.get();
+    expect(deployment.exists).toBe(true);
+    expect(deployment.data()).toMatchObject({
+      type: 'DELETE',
+      requesterID: USER_ID,
+      status: 'REQUESTED',
+    });
+
+    const app = await getApp(firestore, APP_ID);
+    expect(app.queuedDeploymentIDs).toEqual([deployment.id]);
+  });
+
+  test('rejects non-admin', async () => {
+    await firestore
+      .doc(userPath(USER_ID))
+      .withConverter(userDataConverter)
+      .update({
+        roles: {[TEAM_ID]: 'member'},
+      });
+
+    try {
+      await deleteFunction.run({
+        auth: {uid: USER_ID} as AuthData,
+        data: request,
+        rawRequest: null as unknown as Request,
+      });
+      fail('app-delete should not succeed for non-admin');
+    } catch (e) {
+      expect(e).toBeInstanceOf(HttpsError);
+      expect((e as HttpsError).code).toBe('permission-denied');
+    }
+
+    const app = await getApp(firestore, APP_ID);
+    expect(app.queuedDeploymentIDs).toBeUndefined;
+  });
+});

--- a/mirror/mirror-server/src/functions/app/delete.function.ts
+++ b/mirror/mirror-server/src/functions/app/delete.function.ts
@@ -1,0 +1,88 @@
+import {FieldValue, type Firestore} from 'firebase-admin/firestore';
+import {
+  deleteAppRequestSchema,
+  deleteAppResponseSchema,
+} from 'mirror-protocol/src/app.js';
+import {appDataConverter, appPath} from 'mirror-schema/src/app.js';
+import {
+  teamDataConverter,
+  teamPath,
+  appNameIndexPath,
+} from 'mirror-schema/src/team.js';
+import {appAuthorization, userAuthorization} from '../validators/auth.js';
+import {validateSchema} from '../validators/schema.js';
+import {getDataOrFail} from '../validators/data.js';
+import {
+  DeploymentSpec,
+  defaultOptions,
+  deploymentsCollection,
+} from 'mirror-schema/src/deployment.js';
+import {NULL_SECRETS} from './secrets.js';
+import {requestDeployment} from './deploy.function.js';
+import {logger} from 'firebase-functions';
+
+const NULL_SPEC: DeploymentSpec = {
+  appModules: [],
+  serverVersion: '',
+  serverVersionRange: '',
+  hostname: '',
+  options: defaultOptions(),
+  hashesOfSecrets: NULL_SECRETS,
+};
+
+// Note: 'delete' is a reserved word, so we have to call the variable something else.
+export const deleteApp = (firestore: Firestore) =>
+  validateSchema(deleteAppRequestSchema, deleteAppResponseSchema)
+    .validate(userAuthorization())
+    .validate(appAuthorization(firestore, ['admin']))
+    .handle(async (request, context) => {
+      const {appID} = request;
+      const {userID} = context;
+
+      const deploymentPath = await requestDeployment(firestore, appID, {
+        requesterID: userID,
+        type: 'DELETE',
+        spec: NULL_SPEC,
+      });
+      logger.info(`Requested delete of app ${appID}`);
+      return {success: true, deploymentPath};
+    });
+
+// Called by the deployment executor when the worker in Cloudflare has been deleted.
+export async function deleteAppDocs(
+  firestore: Firestore,
+  appID: string,
+): Promise<void> {
+  const appDocRef = firestore
+    .doc(appPath(appID))
+    .withConverter(appDataConverter);
+  await firestore.runTransaction(async txn => {
+    const app = getDataOrFail(
+      await txn.get(appDocRef),
+      'internal',
+      `App ${appID} concurrently deleted?`,
+    );
+    const deployments = await txn.get(
+      firestore.collection(deploymentsCollection(appID)).select(),
+    );
+
+    const {teamID, name: appName} = app;
+
+    // Delete all documents associated with the App.
+    //
+    // 1. The App doc itself.
+    txn.delete(appDocRef);
+    // 2. All of its deployments.
+    //    TODO(darick): Clean up orphaned modules in GCS.
+    deployments.forEach(doc => txn.delete(doc.ref));
+    // 3. The app name index entry for the team.
+    txn.delete(firestore.doc(appNameIndexPath(teamID, appName)));
+    // 4. Finally, decrement the Team's `numApps` field.
+    //    Note that this is a "blind" update that doesn't require
+    //    reading/locking the Team doc in the Transaction.
+    txn.update(
+      firestore.doc(teamPath(teamID)).withConverter(teamDataConverter),
+      {numApps: FieldValue.increment(-1)},
+    );
+  });
+}

--- a/mirror/mirror-server/src/functions/app/index.ts
+++ b/mirror/mirror-server/src/functions/app/index.ts
@@ -4,3 +4,4 @@ export {deploy} from './deploy.function.js';
 export {autoDeploy} from './auto-deploy.function.js';
 export {rename} from './rename.function.js';
 export {tail} from './tail.handler.js';
+export {deleteApp as delete} from './delete.function.js';

--- a/mirror/mirror-server/src/functions/app/secrets.ts
+++ b/mirror/mirror-server/src/functions/app/secrets.ts
@@ -46,6 +46,14 @@ export async function getAppSecrets() {
   return {secrets, hashes};
 }
 
+export const NULL_SECRETS: DeploymentSecrets = {
+  /* eslint-disable @typescript-eslint/naming-convention */
+  REFLECT_AUTH_API_KEY: '',
+  DATADOG_LOGS_API_KEY: '',
+  DATADOG_METRICS_API_KEY: '',
+  /* eslint-enable @typescript-eslint/naming-convention */
+} as const;
+
 export async function hashSecrets(
   secrets: DeploymentSecrets,
 ): Promise<DeploymentSecrets> {

--- a/mirror/mirror-server/src/functions/healthcheck.function.ts
+++ b/mirror/mirror-server/src/functions/healthcheck.function.ts
@@ -1,8 +1,0 @@
-import type {Request, Response} from 'firebase-functions';
-
-/**
- * Healthcheck function.
- */
-export function healthcheck(_request: Request, response: Response): void {
-  response.json({message: 'ok'});
-}

--- a/mirror/mirror-server/src/index.ts
+++ b/mirror/mirror-server/src/index.ts
@@ -10,7 +10,6 @@ import {
   serviceAccountId,
 } from './config/index.js';
 import * as appFunctions from './functions/app/index.js';
-import {healthcheck as healthcheckHandler} from './functions/healthcheck.function.js';
 import * as serverFunctions from './functions/server/index.js';
 import * as teamFunctions from './functions/team/index.js';
 import * as userFunctions from './functions/user/index.js';
@@ -19,11 +18,6 @@ import {DEPLOYMENT_SECRETS_NAMES} from './functions/app/secrets.js';
 // Initializes firestore et al. (e.g. for subsequent calls to getFirestore())
 initializeApp(appOptions);
 setGlobalOptions({serviceAccount: serviceAccountId});
-
-export const healthcheck = https.onRequest(
-  baseHttpsOptions,
-  healthcheckHandler,
-);
 
 // Per https://firebase.google.com/docs/functions/manage-functions
 // functions should be deployed in groups of 10 or fewer
@@ -55,6 +49,7 @@ export const app = {
     },
     appFunctions.tail(getFirestore(), getAuth()),
   ),
+  delete: https.onCall(baseHttpsOptions, appFunctions.delete(getFirestore())),
 };
 
 export const server = {


### PR DESCRIPTION
Server-side logic for deleting an app and its associated Cloudflare worker.

The Cloudflare delete call is modeled as a special type of Deployment and enqueued / executed with the existing Deployment framework. This ensures that interactions with Cloudflare are serialized and it's not possible to have a publish executed concurrently with a delete, which could otherwise publish and orphan a script after we think we've deleted everything. By using the Deployment queue, if a publish is actually enqueued after the delete, that publish request will be deleted while it is waiting in the queue.

* `app-delete`: Requests a `DELETE` deployment
* `app-autoDeploy`: Executes the `DELETE` by first calling the Cloudflare delete API. If successful, all documents related to the App are deleted (including any remaining requested deployments), and the Team's `numApps` count is decremented.