### PR TITLE
feat(reflect-cli): reflect delete command for deleting apps

### DIFF
--- a/mirror/reflect-cli/src/delete.ts
+++ b/mirror/reflect-cli/src/delete.ts
@@ -1,0 +1,176 @@
+import {deleteApp} from 'mirror-protocol/src/app.js';
+import {authenticate} from './auth-config.js';
+import {makeRequester} from './requester.js';
+import {Firestore, getFirestore} from './firebase.js';
+import type {CommonYargsArgv, YargvToInterface} from './yarg-types.js';
+import {deploymentDataConverter} from 'mirror-schema/src/deployment.js';
+import {
+  APP_COLLECTION,
+  appPath,
+  appDataConverter,
+} from 'mirror-schema/src/app.js';
+import {userPath, userDataConverter} from 'mirror-schema/src/user.js';
+import {watch} from 'mirror-schema/src/watch.js';
+import {must} from 'shared/src/must.js';
+import {readAppConfig} from './app-config.js';
+import {confirm} from './inquirer.js';
+
+export function deleteOptions(yargs: CommonYargsArgv) {
+  return yargs
+    .option('name', {
+      describe: 'Name of the app to delete',
+      type: 'string',
+      conflicts: ['appID', 'all'],
+    })
+    .option('appID', {
+      describe: 'Internal ID of the app',
+      type: 'string',
+      conflicts: ['all', 'name'],
+      hidden: true,
+    })
+    .option('all', {
+      describe:
+        'Delete all of your apps, confirming for each one (unless --force is specified)',
+      type: 'boolean',
+      conflicts: ['name', 'appID'],
+    })
+    .option('force', {
+      describe: 'Suppress the confirmation prompt',
+      type: 'boolean',
+      alias: 'f',
+      default: false,
+    });
+}
+
+type DeleteHandlerArgs = YargvToInterface<ReturnType<typeof deleteOptions>>;
+
+export async function deleteHandler(yargs: DeleteHandlerArgs) {
+  const firestore = getFirestore();
+  const {user} = await authenticate(yargs);
+  const apps = await getAppsToDelete(firestore, user.uid, yargs);
+  for (const app of apps) {
+    const confirmed =
+      yargs.force ||
+      (await confirm({
+        message: `Delete "${app.name}" and all associated data?`,
+        default: false,
+      }));
+    if (!confirmed) {
+      continue;
+    }
+    console.info(`Requesting delete of "${app.name}"`);
+    const {deploymentPath} = await deleteApp({
+      requester: makeRequester(user.uid),
+      appID: app.id,
+    });
+
+    const deploymentDoc = firestore
+      .doc(deploymentPath)
+      .withConverter(deploymentDataConverter);
+
+    try {
+      for await (const snapshot of watch(deploymentDoc)) {
+        const deployment = snapshot.data();
+        if (!deployment) {
+          // Happens if requested by a superAdmin that has permission to read any doc.
+          console.info(`"${app.name}" successfully deleted`);
+          break;
+        }
+        const {status, statusMessage: msg} = deployment;
+        console.info(
+          `Status: ${status === 'DEPLOYING' ? 'DELETING' : status}${
+            msg ? ': ' + msg : ''
+          }`,
+        );
+        if (deployment.status === 'FAILED' || deployment.status === 'STOPPED') {
+          break;
+        }
+      }
+    } catch (e) {
+      // Once the App doc is deleted, security rules bar the user from accessing the
+      // deployment doc, which results in a 'permission-denied' error. Assume this to
+      // mean that the App was successfully deleted.
+      if ((e as unknown as {code?: unknown}).code === 'permission-denied') {
+        console.info(`"${app.name}" successfully deleted`);
+      } else {
+        throw e;
+      }
+    }
+  }
+}
+
+type AppInfo = {
+  id: string;
+  name: string;
+};
+
+async function getAppsToDelete(
+  firestore: Firestore,
+  userID: string,
+  yargs: DeleteHandlerArgs,
+): Promise<AppInfo[]> {
+  const {appID, name, all} = yargs;
+  if (appID) {
+    return getApp(firestore, appID);
+  }
+  if (all || name) {
+    const teamID = await getSingleAdminTeam(firestore, userID);
+    let query = firestore
+      .collection(APP_COLLECTION)
+      .withConverter(appDataConverter)
+      .where('teamID', '==', teamID);
+    if (name) {
+      query = query.where('name', '==', name);
+    }
+    const apps = await query.get();
+    return apps.docs.map(doc => ({id: doc.id, name: doc.data().name}));
+  }
+  const config = readAppConfig();
+  const defaultAppID = config?.apps?.default?.appID;
+  if (defaultAppID) {
+    return getApp(firestore, defaultAppID);
+  }
+  console.error(
+    'Missing reflect.config.json Could not determine App to delete.',
+  );
+  process.exit(1);
+}
+
+async function getApp(firestore: Firestore, id: string): Promise<AppInfo[]> {
+  const appDoc = await firestore
+    .doc(appPath(id))
+    .withConverter(appDataConverter)
+    .get();
+  if (!appDoc.exists) {
+    throw new Error(`App is already deleted`);
+  }
+  const {name} = must(appDoc.data());
+  return [{id, name}];
+}
+
+async function getSingleAdminTeam(
+  firestore: Firestore,
+  userID: string,
+): Promise<string> {
+  const userDoc = await firestore
+    .doc(userPath(userID))
+    .withConverter(userDataConverter)
+    .get();
+  if (!userDoc.exists) {
+    throw new Error('UserDoc does not exist.');
+  }
+  const user = must(userDoc.data());
+  const adminTeams = Object.entries(user.roles)
+    .filter(([_, role]) => role === 'admin')
+    .map(([teamID]) => teamID);
+  switch (adminTeams.length) {
+    case 0:
+      throw new Error('You are not an admin of any teams');
+    case 1:
+      return adminTeams[0];
+    default:
+      throw new Error(
+        'This version of @rocicorp/reflect does not support multiple teams. Please update to the latest version.',
+      );
+  }
+}

--- a/mirror/reflect-cli/src/index.ts
+++ b/mirror/reflect-cli/src/index.ts
@@ -13,6 +13,7 @@ import {publishHandler, publishOptions} from './publish.js';
 import {statusHandler} from './status.js';
 import {tailHandler, tailOptions} from './tail/index.js';
 import type {CommonYargsArgv, YargvToInterface} from './yarg-types.js';
+import {deleteHandler, deleteOptions} from './delete.js';
 
 async function main(argv: string[]): Promise<void> {
   const reflectCLI = createCLIParser(argv);
@@ -88,6 +89,14 @@ function createCLIParser(argv: string[]) {
     '🦚 Starts a log tailing session',
     tailOptions,
     handleWith(tailHandler).andCleanup(),
+  );
+
+  // delete
+  reflectCLI.command(
+    'delete',
+    '🗑️ Deletes one or more Apps and their associated data. If no flags are specified, defaults to the App of the current directory.',
+    deleteOptions,
+    handleWith(deleteHandler).andCleanup(),
   );
 
   reflectCLI.command(


### PR DESCRIPTION
`npx @rocicorp/reflect delete` allows a user to delete their apps.

### `reflect delete`

Deletes the app in the current directory, according to `reflect.config.json`.

<img width="686" alt="Screenshot 2023-09-01 at 10 46 34 PM" src="https://github.com/rocicorp/mono/assets/132324914/a36e613c-0808-473d-bb50-bf332efc7140">

### `reflect delete --name=app-name`

Deletes the app with the given name (for the user's Team).

<img width="694" alt="Screenshot 2023-09-01 at 11 04 22 PM" src="https://github.com/rocicorp/mono/assets/132324914/0a5df4f6-013b-49fe-8834-aceac5039e0f">

### `reflect delete --appID=app-id`

Deletes the app with the given internal app ID. This option is hidden from help since internal IDs are not part of the DX

<img width="687" alt="Screenshot 2023-09-01 at 11 05 37 PM" src="https://github.com/rocicorp/mono/assets/132324914/dc7825a4-9788-4ac7-b873-ed1ac7ea58e8">

### `reflect delete --all`

Deletes all of the Team's apps. The confirmation prompt allows the user to skip any app.

<img width="732" alt="Screenshot 2023-09-01 at 10 51 13 PM" src="https://github.com/rocicorp/mono/assets/132324914/93797b12-e066-4013-900f-744900a7a22f">

### `--force`

`--force` or `-f` suppress the confirmation prompt.

<img width="726" alt="Screenshot 2023-09-01 at 11 08 15 PM" src="https://github.com/rocicorp/mono/assets/132324914/2dec4b1b-3166-4709-83a0-954d63199ec1">

