### PR TITLE
feat(reflect-cli): hide "--stack" option from "reflect --help"

### DIFF
--- a/mirror/reflect-cli/src/create-cli-parser.ts
+++ b/mirror/reflect-cli/src/create-cli-parser.ts
@@ -35,6 +35,7 @@ export function createCLIParserBase(argv: string[]): Argv<{
       choices: ['prod', 'staging', 'local'],
       default: 'prod',
       requiresArg: true,
+      hidden: true,
     });
 
   reflectCLI.help().alias('h', 'help');


### PR DESCRIPTION
@aboodman

Sorry, this somehow dropped off of the list.  