### PR TITLE
feat(reflect-cli): go back to using the packaged reflect version in "reflect create"

### DIFF
--- a/mirror/reflect-cli/src/app-config.ts
+++ b/mirror/reflect-cli/src/app-config.ts
@@ -245,6 +245,7 @@ function getDefaultAppNameFromDir(dir: string): string {
 type TemplatePlaceholders = {
   appName: string;
   appHostname: string;
+  reflectVersion: string;
 };
 
 export function writeTemplatedFilePlaceholders(

--- a/mirror/reflect-cli/src/create.ts
+++ b/mirror/reflect-cli/src/create.ts
@@ -29,9 +29,9 @@ export async function createHandler(createYargs: CreatedHandlerArgs) {
   }
 
   await mkdir(name, {recursive: true});
-  scaffold(name, name);
+  await scaffold(name, name);
   console.log(`Installing @rocicorp/reflect`);
-  execSync(`npm add '@rocicorp/reflect'`, {
+  execSync(`npm install`, {
     cwd: name,
     stdio: ['ignore', 'inherit', 'inherit'],
   });

--- a/mirror/reflect-cli/src/scaffold.ts
+++ b/mirror/reflect-cli/src/scaffold.ts
@@ -1,6 +1,9 @@
 import fs, {existsSync} from 'node:fs';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
+import {readFile} from 'node:fs/promises';
+import {pkgUp} from 'pkg-up';
+import {assert, assertObject, assertString} from 'shared/src/asserts.js';
 import {writeTemplatedFilePlaceholders} from './app-config.js';
 
 const templateDir = (templateName: string) =>
@@ -27,9 +30,10 @@ export function copyTemplate(name: string, dest: string) {
   copyDir(sourceDir, dest);
 }
 
-export function scaffold(appName: string, dest: string) {
+export async function scaffold(appName: string, dest: string) {
+  const reflectVersion = await findReflectVersion();
   copyTemplate('create', dest);
-  writeTemplatedFilePlaceholders({appName}, dest, false);
+  writeTemplatedFilePlaceholders({appName, reflectVersion}, dest, false);
 }
 
 function copy(src: string, dest: string) {
@@ -48,4 +52,14 @@ function copyDir(srcDir: string, destDir: string) {
     const destFile = path.resolve(destDir, file);
     copy(srcFile, destFile);
   }
+}
+
+async function findReflectVersion(): Promise<string> {
+  const pkg = await pkgUp({cwd: fileURLToPath(import.meta.url)});
+  assert(pkg);
+  const s = await readFile(pkg, 'utf-8');
+  const v = JSON.parse(s);
+  assertObject(v);
+  assertString(v.version);
+  return v.version;
 }

--- a/mirror/reflect-cli/templates/create/package.json
+++ b/mirror/reflect-cli/templates/create/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "@rocicorp/eslint-config": "^0.1.2",
+    "@rocicorp/reflect": "^{{reflectVersion}}",
     "@types/react": "^18.0.17",
     "@types/react-dom": "^18.0.6",
     "@vitejs/plugin-react": "^2.0.1",


### PR DESCRIPTION
Restore the original behavior of `npx <some-reflect-package> create` using the version of that reflect package (instead of whatever is @latest).

The post `npm install` is preserved though.