### PR TITLE
fix(reflect-cli): linux env -S node --no-warnings flag

### DIFF
--- a/packages/reflect/cli.js
+++ b/packages/reflect/cli.js
@@ -1,2 +1,2 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --no-warnings
 await import('./bin/cli.js');


### PR DESCRIPTION
problem running cli from linux
```
npx @rocicorp/reflect@canary create my-app
Need to install the following packages:
  @rocicorp/reflect@0.33.0-canary.2
Ok to proceed? (y) y
npm WARN deprecated rollup-plugin-inject@3.0.2: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.
npm WARN deprecated sourcemap-codec@1.4.8: Please use @jridgewell/sourcemap-codec instead
/usr/bin/env: 'node --no-warnings': No such file or directory
/usr/bin/env: use -[v]S to pass options in shebang lines
```