### PR TITLE
feat(reflect-cli): support auth for multiple stacks by using separate auth files

### DIFF
--- a/mirror/reflect-cli/package.json
+++ b/mirror/reflect-cli/package.json
@@ -30,8 +30,8 @@
     "format": "prettier --write .",
     "check-format": "prettier --check .",
     "lint": "eslint --ext .ts,.tsx,.js,.jsx src/",
-    "start": "AUTH_URL=http://localhost:3000/auth node --no-warnings --loader ts-node/esm ./src/index.ts --stack staging",
-    "start-local": "AUTH_URL=http://localhost:3000/auth node --no-warnings --loader ts-node/esm ./src/index.ts --stack local",
+    "reflect": "node --no-warnings --loader ts-node/esm ./src/index.ts",
+    "reflect-local": "AUTH_URL=http://localhost:3000/auth node --no-warnings --loader ts-node/esm ./src/index.ts --stack local",
     "build": "node tool/build.js",
     "check-types": "tsc --noEmit"
   },

--- a/mirror/reflect-cli/src/login.test.ts
+++ b/mirror/reflect-cli/src/login.test.ts
@@ -27,7 +27,8 @@ describe('loginHandler', () => {
         );
         expect(serverResponse).toBeDefined();
       },
-      (config: UserAuthConfig) => {
+      (yargs, config: UserAuthConfig) => {
+        expect(yargs.stack).toBe('prod');
         expect(config).toBeDefined();
         expect(config.authCredential).toEqual({
           accessToken: 'valid-token',
@@ -66,7 +67,8 @@ describe('loginHandler', () => {
         );
         expect(serverResponse).toBeDefined();
       },
-      (config: UserAuthConfig) => {
+      (yargs, config: UserAuthConfig) => {
+        expect(yargs.stack).toBe('staging');
         expect(config).toBeDefined();
         expect(config.authCredential).toEqual({
           accessToken: 'valid-token',

--- a/mirror/reflect-cli/src/login.ts
+++ b/mirror/reflect-cli/src/login.ts
@@ -53,7 +53,7 @@ export async function loginHandler(
             ),
           };
 
-          writeAuthConfigFile(authConfig);
+          writeAuthConfigFile(yargs, authConfig);
         } catch (error) {
           res.end(() => {
             loginResolver.reject(


### PR DESCRIPTION
Allows us to be logged in to both the `prod` stack and the `staging` stack by storing and retrieving creds in separate auth files. `prod` creds remain in `~/.reflect/config/default.json`, while `staging` creds are stored in `~/.reflect/config/sandbox.json` (in preparation for migrating `staging` to a new `sandbox` stack).

Also renames the `npm run` script to `reflect` so that it is consistent with the `mirror-cli`'s `mirror` script.