### PR TITLE
fix(reflect-cli): call staging auth file staging.json instead of sandbox

### DIFF
--- a/mirror/reflect-cli/src/auth-config.ts
+++ b/mirror/reflect-cli/src/auth-config.ts
@@ -23,7 +23,7 @@ function getUserAuthConfigFile(
   yargs: YargvToInterface<CommonYargsArgv>,
 ): string {
   const {stack} = yargs;
-  const basename = stack === 'prod' ? 'default' : 'sandbox';
+  const basename = stack === 'prod' ? 'default' : stack;
   return path.join(getGlobalReflectConfigPath(), `config/${basename}.json`);
 }
 


### PR DESCRIPTION
I realize that the new sandbox stack will necessarily have different auth credentials, so the migration will be easier if staging has its own `staging.json` file while sandbox takes the new `sandbox.json`.