### PR TITLE
chore(reflect-cli): bump the package.json version to facilitate local testing

### DIFF
--- a/mirror/mirror-cli/package.json
+++ b/mirror/mirror-cli/package.json
@@ -8,7 +8,7 @@
     "esbuild": "^0.18.3",
     "firebase-admin": "^11.10.1",
     "pkg-up": "^4.0.0",
-    "reflect-cli": "0.31.0",
+    "reflect-cli": "0.33.0",
     "semver": "^7.5.3",
     "shared": "0.0.0",
     "yargs": "^17.4.1"

--- a/mirror/reflect-cli/package.json
+++ b/mirror/reflect-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reflect-cli",
   "private": true,
-  "version": "0.31.0",
+  "version": "0.33.0",
   "type": "module",
   "dependencies": {
     "@badrap/valita": "^0.2.10",

--- a/mirror/reflect-cli/src/publish.test.ts
+++ b/mirror/reflect-cli/src/publish.test.ts
@@ -13,6 +13,7 @@ import {Timestamp} from '@google-cloud/firestore';
 import {fakeFirestore} from 'mirror-schema/src/test-helpers.js';
 import {initFirebase} from './firebase.js';
 import {setAppConfigForTesting} from './app-config.js';
+import {version} from './version.js';
 
 type Args = Parameters<typeof publishHandler>[0];
 
@@ -101,7 +102,7 @@ test('it should compile typescript', async () => {
       requester: {
         userAgent: {
           type: 'reflect-cli',
-          version: '0.31.0',
+          version,
         },
         userID: 'fake-uid',
       },
@@ -133,7 +134,7 @@ test('it should compile typescript', async () => {
         appModules: [],
         hostname: 'app-name.reflect-server-net',
         serverVersion: '0.1.0',
-        serverVersionRange: '^0.31.0',
+        serverVersionRange: `^${version}`,
         options: defaultOptions(),
         hashesOfSecrets: {
           /* eslint-disable @typescript-eslint/naming-convention */

--- a/mirror/reflect-cli/src/version.test.ts
+++ b/mirror/reflect-cli/src/version.test.ts
@@ -4,14 +4,14 @@ import * as v from 'shared/src/valita.js';
 import {userAgent, version} from './version.js';
 
 test('version', () => {
-  expect(version).toBe('0.31.0');
+  expect(version).toBe('0.33.0');
 });
 
 test('userAgent', () => {
   expect(userAgent).toMatchInlineSnapshot(`
     {
       "type": "reflect-cli",
-      "version": "0.31.0",
+      "version": "0.33.0",
     }
   `);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -463,7 +463,7 @@
         "esbuild": "^0.18.3",
         "firebase-admin": "^11.10.1",
         "pkg-up": "^4.0.0",
-        "reflect-cli": "0.31.0",
+        "reflect-cli": "0.33.0",
         "semver": "^7.5.3",
         "shared": "0.0.0",
         "yargs": "^17.4.1"
@@ -1463,7 +1463,7 @@
       }
     },
     "mirror/reflect-cli": {
-      "version": "0.31.0",
+      "version": "0.33.0",
       "dependencies": {
         "@badrap/valita": "^0.2.10",
         "@inquirer/confirm": "^2.0.9",
@@ -35867,7 +35867,7 @@
         "@rocicorp/eslint-config": "^0.4.2",
         "@rocicorp/prettier-config": "^0.1.1",
         "@types/node": "^18.16.0",
-        "reflect-cli": "0.31.0",
+        "reflect-cli": "0.33.0",
         "reflect-client": "0.0.0",
         "reflect-server": "0.0.0",
         "reflect-shared": "0.0.0"
@@ -44034,7 +44034,7 @@
         "open": "^9.1.0",
         "picocolors": "^1.0.0",
         "pkg-up": "^4.0.0",
-        "reflect-cli": "0.31.0",
+        "reflect-cli": "0.33.0",
         "reflect-client": "0.0.0",
         "reflect-server": "0.0.0",
         "reflect-shared": "0.0.0",
@@ -57707,7 +57707,7 @@
         "esbuild": "^0.18.3",
         "firebase-admin": "^11.10.1",
         "pkg-up": "^4.0.0",
-        "reflect-cli": "0.31.0",
+        "reflect-cli": "0.33.0",
         "semver": "^7.5.3",
         "shared": "0.0.0",
         "typescript": "^5.1.3",

--- a/packages/reflect/package.json
+++ b/packages/reflect/package.json
@@ -47,7 +47,7 @@
     "@rocicorp/eslint-config": "^0.4.2",
     "@rocicorp/prettier-config": "^0.1.1",
     "@types/node": "^18.16.0",
-    "reflect-cli": "0.31.0",
+    "reflect-cli": "0.33.0",
     "reflect-client": "0.0.0",
     "reflect-server": "0.0.0",
     "reflect-shared": "0.0.0"


### PR DESCRIPTION
Locally running `npm run reflect create` will install the `@rocicorp/reflect` package at the local reflect-cli version. Bump it so that it behaves more like what happens with `npx @rocicorp/reflect create`.