### PR TITLE
feat(mirror-server): wait for the cert activation after publish

### DIFF
--- a/mirror/README.md
+++ b/mirror/README.md
@@ -102,9 +102,10 @@ A Cloudflare account is needed to run workers and Durable Objects.
   on which the workers are served.
 - [Create an API key](https://dash.cloudflare.com/profile/api-tokens) for the Mirror Server
   (i.e. Cloud Functions) to make API calls. It should have the following permissions:
-  - `Workers Scripts`: Edit
-  - `Workers Routes`: Edit
-  - `Workers Tail`: Read
+  - `Account: Workers Scripts`: Edit
+  - `Account: Workers Tail`: Read
+  - `Zone: Workers Routes`: Edit
+  - `Zone: SSL and Certificates`: Read
 - In the Firestore console (https://console.firebase.google.com/project/reflect-mirror-{{stackname}}/firestore/data), create the document in a "cloudflares" collection:
 
 ```json

--- a/mirror/mirror-server/src/cloudflare/cf-fetch.ts
+++ b/mirror/mirror-server/src/cloudflare/cf-fetch.ts
@@ -32,7 +32,7 @@ export async function cfFetch<ResponseType = unknown>(
   resource: string,
   init: RequestInit = {},
   searchParams?: URLSearchParams,
-) {
+): Promise<ResponseType> {
   assert(resource.startsWith('/'), 'resource must start with /');
   const base = 'https://api.cloudflare.com/client/v4';
   const queryString = searchParams ? `?${searchParams.toString()}` : '';

--- a/mirror/mirror-server/src/cloudflare/config.ts
+++ b/mirror/mirror-server/src/cloudflare/config.ts
@@ -4,3 +4,8 @@ export type Config = {
   apiToken: string;
   env?: string;
 };
+
+export type ZoneConfig = {
+  zoneID: string;
+  apiToken: string;
+};

--- a/mirror/mirror-server/src/cloudflare/get-certificate-pack.ts
+++ b/mirror/mirror-server/src/cloudflare/get-certificate-pack.ts
@@ -1,0 +1,59 @@
+import {cfFetch} from './cf-fetch.js';
+import type {ZoneConfig} from './config.js';
+
+// Assumed from https://developers.cloudflare.com/api/operations/custom-hostname-for-a-zone-list-custom-hostnames
+export type CertificateStatus =
+  | 'initializing'
+  | 'pending_validation'
+  | 'deleted'
+  | 'pending_issuance'
+  | 'pending_deployment'
+  | 'pending_deletion'
+  | 'pending_expiration'
+  | 'expired'
+  | 'active'
+  | 'initializing_timed_out'
+  | 'validation_timed_out'
+  | 'issuance_timed_out'
+  | 'deployment_timed_out'
+  | 'deletion_timed_out'
+  | 'pending_cleanup'
+  | 'staging_deployment'
+  | 'staging_active'
+  | 'deactivating'
+  | 'inactive'
+  | 'backup_issued'
+  | 'holding_deployment';
+
+// API call is at https://developers.cloudflare.com/api/operations/certificate-packs-get-certificate-pack
+// but the return type is not at all documented.
+export type CertificatePack = {
+  id: string;
+  type: string;
+  hosts: string[];
+  status: CertificateStatus;
+
+  // These fields show up but we currently are not interested in.
+  // primary_certificate: '0';
+  // certificates: [];
+  // created_on: '2023-09-07T23:03:26.996316Z';
+  // validity_days: 90;
+  // validation_method: 'txt';
+  // validation_records: [[Object], [Object]];
+  // certificate_authority: 'lets_encrypt';
+};
+
+export function getCertificatePack(
+  {apiToken, zoneID}: ZoneConfig,
+  certID: string,
+): Promise<CertificatePack> {
+  return cfFetch<CertificatePack>(
+    apiToken,
+    `/zones/${zoneID}/ssl/certificate_packs/${certID}`,
+    {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    },
+  );
+}

--- a/mirror/mirror-server/src/cloudflare/publish-custom-domains.ts
+++ b/mirror/mirror-server/src/cloudflare/publish-custom-domains.ts
@@ -2,6 +2,20 @@ import {logger} from 'firebase-functions';
 import {cfFetch} from './cf-fetch.js';
 import type {Config} from './config.js';
 
+// Sort of documented at https://developers.cloudflare.com/api/operations/worker-domain-get-a-domain,
+// The field that we're interested in (`cert_id`) is undocumented, but appears in practice.
+/* eslint-disable @typescript-eslint/naming-convention */
+export type CustomDomain = {
+  id: string;
+  zone_id: string;
+  zone_name: string;
+  hostname: string;
+  service: string;
+  environment: string;
+  cert_id?: string;
+};
+/* eslint-enable @typescript-eslint/naming-convention */
+
 // Original file was here:
 // https://github.com/cloudflare/workers-sdk/blob/a728876e607635081cd1ed00d06b7af86e7efd49/packages/wrangler/src/deploy/deploy.ts#L170
 //
@@ -10,10 +24,10 @@ import type {Config} from './config.js';
 // mode. Therefore existing origins / dns records are not indicative of errors,
 // so we aggressively update rather than aggressively fail
 
-export async function publishCustomDomains(
+export function publishCustomDomains(
   {apiToken, scriptName, accountID}: Config,
   hostname: string,
-): Promise<void> {
+): Promise<CustomDomain[]> {
   /* eslint-disable @typescript-eslint/naming-convention */
   const body = {
     override_scope: true,
@@ -26,7 +40,7 @@ export async function publishCustomDomains(
   logger.log('Setting up custom domain:', hostname);
 
   // deploy to domains
-  await cfFetch(
+  return cfFetch<CustomDomain[]>(
     apiToken,
     `/accounts/${accountID}/workers/scripts/${scriptName}/domains/records`,
     {

--- a/mirror/mirror-server/src/cloudflare/publish.ts
+++ b/mirror/mirror-server/src/cloudflare/publish.ts
@@ -1,7 +1,7 @@
 import type {Storage} from 'firebase-admin/storage';
 import {nanoid} from 'nanoid';
 import {cfFetch} from './cf-fetch.js';
-import type {Config} from './config.js';
+import type {Config, ZoneConfig} from './config.js';
 import {
   CfModule,
   CfVars,
@@ -18,6 +18,9 @@ import type {
   DeploymentOptions,
   DeploymentSecrets,
 } from 'mirror-schema/src/deployment.js';
+import {getCertificatePack} from './get-certificate-pack.js';
+import {HttpsError} from 'firebase-functions/v2/https';
+import {sleep} from 'shared/src/sleep.js';
 
 export async function createScript(
   {accountID, scriptName, apiToken}: Config,
@@ -80,7 +83,9 @@ const migrations: Migration[] = [
   },
 ];
 
-export async function publish(
+const POLL_CERTIFICATE_STATUS_INTERVAL = 5000;
+
+export async function* publish(
   storage: Storage,
   config: Config,
   appName: string,
@@ -90,7 +95,7 @@ export async function publish(
   secrets: DeploymentSecrets,
   appModules: ModuleRef[],
   serverModules: ModuleRef[],
-): Promise<void> {
+): AsyncGenerator<string> {
   const assembler = new ModuleAssembler(
     appName,
     teamSubdomain,
@@ -110,11 +115,58 @@ export async function publish(
     reflectAuthApiKey = nanoid();
   }
 
-  await Promise.all([
+  const [customDomains] = await Promise.all([
     publishCustomDomains(config, hostname),
     submitTriggers(config, '*/5 * * * *'),
     ...Object.entries(secrets).map(([name, value]) =>
       submitSecret(config, name, value),
     ),
   ]);
+
+  const customDomainsWithHostname = customDomains.filter(
+    domain => domain.hostname === hostname,
+  );
+  if (customDomainsWithHostname.length !== 1) {
+    throw new HttpsError('internal', `No CustomDomain for ${hostname}`);
+  }
+  const customDomain = customDomainsWithHostname[0];
+  if (!customDomain.cert_id) {
+    logger.warn(
+      `Returned CustomDomain for ${hostname} does not have a cert_id`,
+      customDomain,
+    );
+    return;
+  }
+
+  const zoneConfig: ZoneConfig = {
+    apiToken: config.apiToken,
+    zoneID: customDomain.zone_id,
+  };
+  // Poll the status of the hostname certificate until it is 'active'.
+  for (let lastStatus = undefined; ; ) {
+    const cert = await getCertificatePack(zoneConfig, customDomain.cert_id);
+    if (cert.status === 'active') {
+      // Common case: certificate already exists.
+      logger.info(`Certificate for ${hostname} is active.`);
+      break;
+    }
+    if (cert.status === 'initializing' || cert.status.startsWith('pending_')) {
+      if (!lastStatus) {
+        // This gets written as a DEPLOYING message and is surfaced to users.
+        yield `Waiting for TLS to propagate.\n` +
+          `    This can take a few minutes the first time you publish a new app.\n` +
+          `    ☕ Go get yourself a coffee and it'll be done when you get back.`;
+      }
+      if (cert.status !== lastStatus) {
+        logger.info(`Certificate for ${hostname} is ${cert.status}`, cert);
+        lastStatus = cert.status;
+      }
+    } else {
+      throw new HttpsError(
+        'internal',
+        `Unexpected certificate status: ${cert.status}`,
+      );
+    }
+    await sleep(POLL_CERTIFICATE_STATUS_INTERVAL);
+  }
 }

--- a/mirror/mirror-server/src/functions/app/deploy.function.ts
+++ b/mirror/mirror-server/src/functions/app/deploy.function.ts
@@ -128,7 +128,7 @@ export async function runDeployment(
 
     const {secrets, hashes} = await getAppSecrets();
 
-    await publishToCloudflare(
+    for await (const deploymentUpdate of publishToCloudflare(
       storage,
       config,
       appName,
@@ -138,7 +138,15 @@ export async function runDeployment(
       secrets,
       appModules,
       serverModules,
-    );
+    )) {
+      await setDeploymentStatus(
+        firestore,
+        appID,
+        deploymentID,
+        'DEPLOYING',
+        deploymentUpdate,
+      );
+    }
     await setRunningDeployment(firestore, appID, deploymentID, hashes);
   } catch (e) {
     await setDeploymentStatus(


### PR DESCRIPTION
On the server side, `publishCustomDomains()` is followed by polling the Cloudflare [Get Certificate Pack](https://developers.cloudflare.com/api/operations/certificate-packs-get-certificate-pack) API until the certificate corresponding to the worker hostname is `active`.

The first time a hostname is published, the certificate goes through a number of deployment stages: `initializing` -> `pending_*` -> `active`. When this happens the server writes a `DEPLOYING` status message that gets surfaced to the reflect cli.

<img width="581" alt="Screenshot 2023-09-07 at 6 49 36 PM" src="https://github.com/rocicorp/mono/assets/132324914/f7b82f01-44e5-412a-ae09-6993d74213e5">
