### PR TITLE
feat(mirror-cli): add option to upload a server built from source

### DIFF
--- a/mirror/mirror-cli/src/upload-server.ts
+++ b/mirror/mirror-cli/src/upload-server.ts
@@ -33,7 +33,8 @@ export function uploadReflectServerOptions(yargs: CommonYargsArgv) {
     })
     .option('build-from-source-version', {
       describe:
-        'Build the server from source and give it the specified version string. This is only intended for testing in local development.',
+        'Build the server from source and give it the specified version string. ' +
+        'This is only intended for debugging and experiments, and requires that non-standard --channels be specified.',
       type: 'string',
     });
 }


### PR DESCRIPTION
The opposite of #833 , which is to force building the server from source and publish it with a temporary / fake version that can be used for debugging, experiments, etc. 

The `--build-from-source-version` option requires that only non-standard `--channels` are specified, so that we do not accidentally deploy unpublished code to "canary" or "stable".