### PR TITLE
feat(mirror): support dispatch to non-WFP workers

### DIFF
--- a/mirror/cloudflare-api/src/custom-hostnames.ts
+++ b/mirror/cloudflare-api/src/custom-hostnames.ts
@@ -35,7 +35,7 @@ export class CustomHostnames {
   readonly create: PostFn<CustomHostname>;
   readonly get: GetFn<CustomHostname>;
   readonly edit: PatchFn<CustomHostname>;
-  readonly delete: DeleteFn<{id: string}>;
+  readonly delete: DeleteFn;
 
   constructor(apiToken: string, zoneID: string) {
     const resource = new Resource(
@@ -45,7 +45,7 @@ export class CustomHostnames {
     this.list = resource.get;
     this.create = resource.post;
     this.get = id => resource.append(id).get();
-    this.edit = (id, ch) => resource.append(id).patch(ch);
+    this.edit = (id, val) => resource.append(id).patch(val);
     this.delete = id => resource.append(id).delete();
   }
 }

--- a/mirror/cloudflare-api/src/dispatch-namespaces.ts
+++ b/mirror/cloudflare-api/src/dispatch-namespaces.ts
@@ -1,0 +1,28 @@
+import {DeleteFn, GetFn, ListFn, PostFn, Resource} from './resources.js';
+
+/* eslint-disable @typescript-eslint/naming-convention */
+export type DispatchNamespace = {
+  namespace_id: string;
+  namespace_name: string;
+};
+/* eslint-enable @typescript-eslint/naming-convention */
+
+// https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/get-started/dynamic-dispatch/#dispatch-namespace-api-reference
+
+export class DispatchNamespaces {
+  readonly list: ListFn<DispatchNamespace>;
+  readonly create: PostFn<{name: string}, DispatchNamespace>;
+  readonly get: GetFn<DispatchNamespace>;
+  readonly delete: DeleteFn<null>;
+
+  constructor(apiToken: string, accountID: string) {
+    const resource = new Resource(
+      apiToken,
+      `/accounts/${accountID}/workers/dispatch/namespaces`,
+    );
+    this.list = resource.get;
+    this.create = resource.post;
+    this.get = id => resource.append(id).get();
+    this.delete = id => resource.append(id).delete();
+  }
+}

--- a/mirror/cloudflare-api/src/dns-records.ts
+++ b/mirror/cloudflare-api/src/dns-records.ts
@@ -30,15 +30,15 @@ export class DNSRecords {
   readonly get: GetFn<DNSRecord>;
   readonly patch: PatchFn<DNSRecord>;
   readonly update: PutFn<DNSRecord>;
-  readonly delete: DeleteFn<{id: string}>;
+  readonly delete: DeleteFn;
 
   constructor(apiToken: string, zoneID: string) {
     const resource = new Resource(apiToken, `/zones/${zoneID}/dns_records`);
     this.list = resource.get;
     this.create = resource.post;
     this.get = id => resource.append(id).get();
-    this.patch = (id, ch) => resource.append(id).patch(ch);
-    this.update = (id, ch) => resource.append(id).put(ch);
+    this.patch = (id, val) => resource.append(id).patch(val);
+    this.update = (id, val) => resource.append(id).put(val);
     this.delete = id => resource.append(id).delete();
   }
 }

--- a/mirror/cloudflare-api/src/fallback-origin.ts
+++ b/mirror/cloudflare-api/src/fallback-origin.ts
@@ -1,0 +1,25 @@
+import {DeleteFn, GetOnlyFn, PutOnlyFn, Resource} from './resources.js';
+
+export type FallbackOriginState = {
+  origin: string;
+  status: string;
+  errors: string[];
+};
+
+// https://developers.cloudflare.com/api/operations/custom-hostname-fallback-origin-for-a-zone-delete-fallback-origin-for-custom-hostnames
+
+export class FallbackOrigin {
+  readonly get: GetOnlyFn<FallbackOriginState>;
+  readonly update: PutOnlyFn<{origin: string}, FallbackOriginState>;
+  readonly delete: DeleteFn;
+
+  constructor(apiToken: string, zoneID: string) {
+    const resource = new Resource(
+      apiToken,
+      `/zones/${zoneID}/custom_hostnames/fallback_origin`,
+    );
+    this.get = resource.get;
+    this.update = resource.put;
+    this.delete = id => resource.append(id).delete();
+  }
+}

--- a/mirror/cloudflare-api/src/resources.ts
+++ b/mirror/cloudflare-api/src/resources.ts
@@ -3,11 +3,14 @@ import {cfFetch} from './fetch.js';
 import {assert} from 'shared/src/asserts.js';
 
 export type ListFn<T> = (query?: URLSearchParams) => Promise<T[]>;
+export type GetOnlyFn<T> = () => Promise<T>;
 export type GetFn<T> = (id: string) => Promise<T>;
 export type PostFn<I, O = I> = (val: PartialDeep<I>) => Promise<O>;
 export type PutFn<I, O = I> = (id: string, val: PartialDeep<I>) => Promise<O>;
+export type PutOnlyFn<I, O = I> = (val: PartialDeep<I>) => Promise<O>;
 export type PatchFn<I, O = I> = PutFn<I, O>;
-export type DeleteFn<T = unknown> = (id: string) => Promise<T>;
+export type PatchOnlyFn<I, O = I> = PutOnlyFn<I, O>;
+export type DeleteFn<T = {id: string}> = (id: string) => Promise<T>;
 
 const headers = {'Content-Type': 'application/json'};
 

--- a/mirror/cloudflare-api/src/worker-routes.ts
+++ b/mirror/cloudflare-api/src/worker-routes.ts
@@ -1,0 +1,26 @@
+import {DeleteFn, GetFn, ListFn, PostFn, PutFn, Resource} from './resources.js';
+
+export type WorkerRoute = {
+  id: string;
+  pattern: string;
+  script: string;
+};
+
+// https://developers.cloudflare.com/api/operations/worker-routes-list-routes
+
+export class WorkerRoutes {
+  readonly list: ListFn<WorkerRoute>;
+  readonly create: PostFn<WorkerRoute>;
+  readonly get: GetFn<WorkerRoute>;
+  readonly update: PutFn<WorkerRoute>;
+  readonly delete: DeleteFn;
+
+  constructor(apiToken: string, zoneID: string) {
+    const resource = new Resource(apiToken, `/zones/${zoneID}/workers/routes`);
+    this.list = resource.get;
+    this.create = resource.post;
+    this.get = id => resource.append(id).get();
+    this.update = (id, val) => resource.append(id).put(val);
+    this.delete = id => resource.append(id).delete();
+  }
+}

--- a/mirror/cloudflare-api/tsconfig.json
+++ b/mirror/cloudflare-api/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "types": ["node"],
-    "moduleResolution": "node"
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
   },
   "include": ["src/**/*.ts"]
 }

--- a/mirror/mirror-cli/dispatcher/index.ts
+++ b/mirror/mirror-cli/dispatcher/index.ts
@@ -13,15 +13,21 @@ interface Env {
 export default {
   async fetch(req: Request<CustomHostMetadata>, env: Env) {
     try {
+      // Namespaced (Workers for Platform) Workers are routed via Custom Hostname,
+      // for which the metadata contains the name of the script to dispatch to.
       const name = (req.cf?.hostMetadata as CustomHostMetadata)?.script_name;
-      if (!name) {
-        return new Response(`No metadata for ${req.headers.get('host')}`, {
-          status: 400,
-        });
+      if (name) {
+        console.log(`Dispatching ${req.url} to ${name}`);
+        const worker = env.workers.get(name);
+        return await worker.fetch(req);
       }
-      console.log(`Dispatching ${req.url} to ${name}`);
-      const worker = env.workers.get(name);
-      return await worker.fetch(req);
+      // Traditional Workers are routed via Custom Domain, for which Worker-to-Worker
+      // dispatch works within the same zone.
+      // https://developers.cloudflare.com/workers/configuration/routing/custom-domains/#interaction-with-routes
+      console.log(
+        `Dispatching ${req.url} via Custom Domain ${req.headers.get('host')}`,
+      );
+      return fetch(req);
     } catch (e) {
       if (!(e instanceof Error)) {
         return new Response(String(e), {status: 500});

--- a/mirror/mirror-cli/dispatcher/tsconfig.json
+++ b/mirror/mirror-cli/dispatcher/tsconfig.json
@@ -3,23 +3,8 @@
   "compilerOptions": {
     "lib": ["es2022"],
     "types": ["@cloudflare/workers-types"],
-
-    "moduleResolution": "node",
-    "esModuleInterop": true,
-    "resolveJsonModule": true,
-
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "forceConsistentCasingInFileNames": true,
+    "module": "Node16",
     "skipLibCheck": true,
-
-    "declaration": true,
-    "allowJs": true,
-
-    "incremental": true,
     "noEmit": true
   },
   "include": ["**/*.ts"],

--- a/mirror/mirror-cli/src/publish-dispatcher.ts
+++ b/mirror/mirror-cli/src/publish-dispatcher.ts
@@ -11,7 +11,10 @@ import {
   createScriptUploadForm,
   type CfModule,
 } from 'cloudflare-api/src/create-script-upload-form.js';
-import {publishCustomDomains} from './publish-custom-domains.js';
+import {DispatchNamespaces} from 'cloudflare-api/src/dispatch-namespaces.js';
+import {DNSRecords} from 'cloudflare-api/src/dns-records.js';
+import {FallbackOrigin} from 'cloudflare-api/src/fallback-origin.js';
+import {WorkerRoutes} from 'cloudflare-api/src/worker-routes.js';
 import {sleep} from 'shared/src/sleep.js';
 
 export function publishDispatcherOptions(yargs: CommonYargsArgv) {
@@ -21,18 +24,17 @@ export function publishDispatcherOptions(yargs: CommonYargsArgv) {
       type: 'string',
       default: 'mirror',
     })
-    .option('hostname', {
-      desc:
-        'The hostname (before the TLD) on which the dispatcher will run. This will be configured as the fallback origin for WfP Custom Hostnames. ' +
-        'If none is specified, defaults to `${namespace}-dispatcher`',
+    .option('fallback-hostname', {
+      desc: 'The hostname (before the TLD) to set the fallback origin to.',
       type: 'string',
+      default: 'apps',
     })
     .option('script-name', {
       desc: 'The script name of the dispatcher. If none is specified, defaults to `${namespace}-dispatcher`',
       type: 'string',
     })
-    .option('overwrite-fallback-origin', {
-      desc: 'Overwrites an existing fallback origin if it is different from ${hostname}.${tld}',
+    .option('overwrite-fallbacks', {
+      desc: 'Overwrites an existing fallback route and origin if it is different',
       type: 'boolean',
       default: false,
     });
@@ -46,109 +48,131 @@ export async function publishDispatcherHandler(
   yargs: PublishDispatcherHandlerArgs,
 ): Promise<void> {
   const config = await getCloudflareConfig(yargs);
-  const tld = await getZoneDomainName(config);
+  const zoneName = await getZoneDomainName(config);
 
-  const {namespace, overwriteFallbackOrigin} = yargs;
+  const {namespace, fallbackHostname, overwriteFallbacks} = yargs;
   const scriptName = yargs.scriptName ?? `${namespace}-dispatcher`;
-  const hostname = yargs.hostname ?? `${namespace}-dispatcher`;
-  const domainName = `${hostname}.${tld}`;
 
-  console.log(`Publishing ${scriptName} to ${domainName}`);
+  console.log(`Publishing ${scriptName}`);
 
   // These must be done serially:
   await ensureDispatchNamespace(config, namespace);
+
   // The namespace must have been created in order to setup bindings to it in the Worker.
-  await publishDispatcherScript(config, namespace, scriptName, domainName);
-  // The Worker must have been published in order to point the custom domain to it.
-  await publishCustomDomains(config, scriptName, domainName);
-  // The custom domain must have been created in order to use it as the Fallback origin.
-  await ensureFallbackOrigin(config, domainName, overwriteFallbackOrigin);
+  await publishDispatcherScript(config, namespace, scriptName);
+
+  // The worker must have been created in order to setup the fallback Worker Route.
+  await ensureFallbackRoute(config, zoneName, scriptName, overwriteFallbacks);
+
+  // This can technically be done in parallel with the rest but we keep it serial for readability.
+  await ensureFallbackOrigin(
+    config,
+    fallbackHostname,
+    zoneName,
+    overwriteFallbacks,
+  );
 }
 
 async function ensureDispatchNamespace(
   {apiKey, accountID}: CloudflareConfig,
   name: string,
 ): Promise<void> {
+  const namespaces = new DispatchNamespaces(apiKey, accountID);
   try {
-    const exists = await cfFetch(
-      apiKey,
-      `/accounts/${accountID}/workers/dispatch/namespaces/${name}`,
-    );
+    const exists = await namespaces.get(name);
     console.log(`"${name}" namespace exists: `, exists);
     return;
   } catch (e) {
-    if (e instanceof FetchResultError && e.codes().includes(100119)) {
-      // workers.api.error.dispatch_namespace_not_found
-      // Continue on to create the namespace.
-    } else {
-      throw e;
-    }
+    // 100119: workers.api.error.dispatch_namespace_not_found
+    FetchResultError.throwIfCodeIsNot(e, 100119);
   }
   console.log(`Creating "${name}" namespace`);
-  const result = await cfFetch(
-    apiKey,
-    `/accounts/${accountID}/workers/dispatch/namespaces`,
-    {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({name}),
-    },
-  );
+  const result = await namespaces.create({name});
   console.log(result);
 }
 
-type FallbackOrigin = {
-  origin: string;
-  status: string;
-  errors: string[];
-};
+export async function ensureFallbackRoute(
+  {apiKey, zoneID}: CloudflareConfig,
+  zoneName: string,
+  script: string,
+  overwriteExisting: boolean,
+) {
+  const pattern = `*.${zoneName}/*`;
+  const resource = new WorkerRoutes(apiKey, zoneID);
+  for (const route of await resource.list()) {
+    if (route.pattern === pattern) {
+      if (route.script === script) {
+        console.log(`Route already exists`, route);
+        return;
+      }
+      if (!overwriteExisting) {
+        throw new Error(
+          `Fallback route is currently set to ${route.script}. Use --overwrite-fallbacks to overwrite it.`,
+        );
+      }
+      console.warn(`Replacing old route to point to ${script}`, route);
+      const result = await resource.update(route.id, {pattern, script});
+      console.log(result);
+      return;
+    }
+  }
+  const result = await resource.create({pattern, script});
+  console.log(result);
+}
 
 export async function ensureFallbackOrigin(
   {apiKey, zoneID}: CloudflareConfig,
-  origin: string,
+  hostname: string,
+  zoneName: string,
   overwrite: boolean,
 ): Promise<void> {
-  const resource = `/zones/${zoneID}/custom_hostnames/fallback_origin`;
+  const origin = `${hostname}.${zoneName}`;
+  const current = new FallbackOrigin(apiKey, zoneID);
   try {
-    const existing = await cfFetch<FallbackOrigin>(apiKey, resource);
-    if (existing.origin !== origin) {
-      if (!overwrite) {
-        throw new Error(
-          `Fallback origin is currently set to ${existing.origin}. Use --overwrite-fallback-origin to overwrite it.`,
-        );
-      }
-      console.warn(`Overwriting existing fallback origin ${existing.origin}`);
+    const existing = await current.get();
+    if (existing.origin === origin) {
+      console.log(`Fallback Origin is already set to ${origin}`);
+      return;
     }
+    if (!overwrite) {
+      throw new Error(
+        `Fallback origin is currently set to ${existing.origin}. Use --overwrite-fallbacks to overwrite it.`,
+      );
+    }
+    console.warn(`Overwriting existing fallback origin ${existing.origin}`);
   } catch (e) {
-    if (e instanceof FetchResultError && e.codes().includes(1551)) {
-      // Resource not found.
-      // Continue on to set the fallback origin.
-    } else {
-      throw e;
-    }
+    // 1551: Resource not found.
+    FetchResultError.throwIfCodeIsNot(e, 1551);
   }
-  console.log(`Setting fallback origin: ${origin}`);
-  let fallbackOrigin = await cfFetch<FallbackOrigin>(apiKey, resource, {
-    method: 'PUT',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({origin}),
-  });
-  while (fallbackOrigin.status !== 'active') {
-    console.log(
-      `Waiting for Fallback origin to become active: `,
-      fallbackOrigin,
-    );
+  // https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/start/advanced-settings/worker-as-origin/
+  console.log(`Creating Fallback Origin DNS record for ${hostname}`);
+  try {
+    const dnsRecords = new DNSRecords(apiKey, zoneID);
+    const dnsResult = await dnsRecords.create({
+      type: 'AAAA',
+      name: hostname,
+      content: '100::',
+    });
+    console.log(dnsResult);
+  } catch (e) {
+    // 81057: Record already exists. Assume it is correct.
+    FetchResultError.throwIfCodeIsNot(e, 81057);
+  }
+
+  console.log(`Setting Fallback Origin to ${origin}`);
+  let state = await current.update({origin});
+  while (state.status !== 'active') {
+    console.log(`Waiting for Fallback origin to become active: `, state);
     await sleep(2000);
-    fallbackOrigin = await cfFetch<FallbackOrigin>(apiKey, resource);
+    state = await current.get();
   }
-  console.log(fallbackOrigin);
+  console.log(state);
 }
 
 async function publishDispatcherScript(
   {apiKey, accountID}: CloudflareConfig,
   namespace: string,
   name: string,
-  _2: string,
 ): Promise<void> {
   const dispatcherScript = await loadDispatcherScript();
   console.log(`Loaded ${name}`, dispatcherScript);
@@ -159,18 +183,20 @@ async function publishDispatcherScript(
     type: 'esm',
   };
 
+  /* eslint-disable @typescript-eslint/naming-convention */
   const form = createScriptUploadForm({
     name,
     main,
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     bindings: {dispatch_namespaces: [{binding: 'workers', namespace}]},
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     compatibility_date: '2023-09-04',
+    // no_minimal_subrequests is required to dispatch to non-namespaced workers by Custom Domain.
+    compatibility_flags: ['no_minimal_subrequests'],
   });
+  /* eslint-enable @typescript-eslint/naming-convention */
 
   const result = await cfFetch(
     apiKey,
-    `/accounts/${accountID}/workers/dispatch/namespaces/${namespace}/scripts/${name}`,
+    `/accounts/${accountID}/workers/scripts/${name}`,
     {
       method: 'PUT',
       body: form,

--- a/mirror/mirror-cli/src/query-analytics.ts
+++ b/mirror/mirror-cli/src/query-analytics.ts
@@ -23,5 +23,5 @@ export async function queryAnalyticsHandler(yargs: QueryAnalyticsHandlerArgs) {
     method: 'POST',
     body: query,
   });
-  console.log(`${query}:`, resp);
+  console.log(`${query}:`, await resp.text());
 }


### PR DESCRIPTION
Dispatch improvements to support coexistence of WFP and non-WFP workers.

* Dispatch worker dispatches to WFP workers vs Custom Hostname Metadata if it is present.
* Otherwise, it dispatches to the worker via its Custom Domain via [worker-to-worker routing](https://developers.cloudflare.com/workers/configuration/routing/custom-domains/#interaction-with-routes).

This means that we can continue supporting existing Workers with no changes while WFP is gradually built.

Also improved the `publish-dispatcher` command to:
* Create the `AAAA` DNS record for the fallback origin if necessary
* Create the fallback Workers Route to route all traffic to the publisher

Finally, added `cloudflare-api` objects for managing `DispatchNamespaces`, the `FallbackOrigin`, and  `WorkerRoutes`.