### PR TITLE
refactor(mirror): Use the Script resource as the entry point into cloudflare libs

### DIFF
--- a/mirror/mirror-server/src/cloudflare/delete.ts
+++ b/mirror/mirror-server/src/cloudflare/delete.ts
@@ -1,13 +1,9 @@
-import type {Config} from './config.js';
 import {logger} from 'firebase-functions';
-import {GlobalScript} from 'cloudflare-api/src/scripts.js';
+import type {Script} from 'cloudflare-api/src/scripts.js';
 import {Errors, FetchResultError} from 'cloudflare-api/src/fetch.js';
 
 // https://github.com/cloudflare/workers-sdk/blob/e9fae5586c14eeae8bb44e0dcf940052635575b4/packages/wrangler/src/delete.ts#L93
-export async function deleteScript(config: Config): Promise<void> {
-  const {apiToken, accountID, scriptName} = config;
-  const script = new GlobalScript(apiToken, accountID, scriptName);
-
+export async function deleteScript(script: Script): Promise<void> {
   try {
     await script.delete(new URLSearchParams({force: 'true'}));
   } catch (e) {
@@ -17,5 +13,5 @@ export async function deleteScript(config: Config): Promise<void> {
       Errors.CouldNotRouteToScript,
     );
   }
-  logger.info(`Deleted script ${scriptName}`);
+  logger.info(`Deleted script ${script.id}`);
 }

--- a/mirror/mirror-server/src/cloudflare/tail/tail.ts
+++ b/mirror/mirror-server/src/cloudflare/tail/tail.ts
@@ -1,6 +1,6 @@
 import WebSocket from 'ws';
 import type {Outcome, TailFilterMessage} from './filters.js';
-import {GlobalScript} from 'cloudflare-api/src/scripts.js';
+import type {GlobalScript} from 'cloudflare-api/src/scripts.js';
 
 const TRACE_VERSION = 'trace-v1';
 
@@ -19,9 +19,7 @@ const TRACE_VERSION = 'trace-v1';
  * @returns a websocket connection, an expiration, and a function to call to delete the tail
  */
 export async function createTail(
-  apiToken: string,
-  accountID: string,
-  workerName: string,
+  script: GlobalScript,
   filters: TailFilterMessage,
   debug: boolean,
   packageVersion: string,
@@ -30,7 +28,6 @@ export async function createTail(
   expiration: Date;
   deleteTail: () => Promise<void>;
 }> {
-  const script = new GlobalScript(apiToken, accountID, workerName);
   const {
     id: tailId,
     url: websocketUrl,

--- a/mirror/mirror-server/src/functions/app/tail.handler.ts
+++ b/mirror/mirror-server/src/functions/app/tail.handler.ts
@@ -19,6 +19,7 @@ import {
 } from '../validators/auth.js';
 import {validateRequest} from '../validators/schema.js';
 import {defineSecretSafely} from './secrets.js';
+import {GlobalScript} from 'cloudflare-api/src/scripts.js';
 
 // This is the API token for reflect-server.net
 // https://dash.cloudflare.com/085f6d8eb08e5b23debfb08b21bda1eb/
@@ -52,9 +53,7 @@ export const tail = (
         let createTailResult;
         try {
           createTailResult = await createTail(
-            apiToken,
-            accountID,
-            cfWorkerName,
+            new GlobalScript(apiToken, accountID, cfWorkerName),
             filters,
             debug,
             packageVersion,


### PR DESCRIPTION
The cloudflare libs now take a base `Script` object that the cloud functions are responsible for instantiating, and disable unsupported features (like tail and cron) based on the type.

This is intended to be a pure refactoring and will facilitate forthcoming logic for handling NamespacedScripts.