### PR TITLE
chore(mirror): standardize naming and use objects as Resource parameters

### DIFF
--- a/mirror/cloudflare-api/src/custom-hostnames.test.ts
+++ b/mirror/cloudflare-api/src/custom-hostnames.test.ts
@@ -9,7 +9,10 @@ afterEach(() => {
 test('custom-hostnames', async () => {
   const fetch = mockFetch().default({});
 
-  const resource = new CustomHostnames('api-token', 'zone-id');
+  const resource = new CustomHostnames({
+    apiToken: 'api-token',
+    zoneID: 'zone-id',
+  });
   await resource.list();
   await resource.delete('hostname-id');
 

--- a/mirror/cloudflare-api/src/custom-hostnames.ts
+++ b/mirror/cloudflare-api/src/custom-hostnames.ts
@@ -5,6 +5,7 @@ import {
   SetOnlyFn,
   Resource,
   SetFn,
+  ZoneAccess,
 } from './resources.js';
 
 /* eslint-disable @typescript-eslint/naming-convention */
@@ -37,7 +38,7 @@ export class CustomHostnames {
   readonly edit: SetFn<CustomHostname>;
   readonly delete: DeleteFn;
 
-  constructor(apiToken: string, zoneID: string) {
+  constructor({apiToken, zoneID}: ZoneAccess) {
     const resource = new Resource(
       apiToken,
       `/zones/${zoneID}/custom_hostnames`,

--- a/mirror/cloudflare-api/src/dispatch-namespaces.ts
+++ b/mirror/cloudflare-api/src/dispatch-namespaces.ts
@@ -1,4 +1,11 @@
-import {DeleteFn, GetFn, ListFn, SetOnlyFn, Resource} from './resources.js';
+import {
+  DeleteFn,
+  GetFn,
+  ListFn,
+  SetOnlyFn,
+  Resource,
+  AccountAccess,
+} from './resources.js';
 
 /* eslint-disable @typescript-eslint/naming-convention */
 export type DispatchNamespace = {
@@ -15,7 +22,7 @@ export class DispatchNamespaces {
   readonly get: GetFn<DispatchNamespace>;
   readonly delete: DeleteFn<null>;
 
-  constructor(apiToken: string, accountID: string) {
+  constructor({apiToken, accountID}: AccountAccess) {
     const resource = new Resource(
       apiToken,
       `/accounts/${accountID}/workers/dispatch/namespaces`,

--- a/mirror/cloudflare-api/src/dns-records.test.ts
+++ b/mirror/cloudflare-api/src/dns-records.test.ts
@@ -9,7 +9,7 @@ afterEach(() => {
 test('dns-records', async () => {
   const fetch = mockFetch().default({});
 
-  const resource = new DNSRecords('api-token', 'zone-id');
+  const resource = new DNSRecords({apiToken: 'api-token', zoneID: 'zone-id'});
   await resource.list();
   await resource.delete('dns-record-id');
 

--- a/mirror/cloudflare-api/src/dns-records.ts
+++ b/mirror/cloudflare-api/src/dns-records.ts
@@ -5,6 +5,7 @@ import {
   SetOnlyFn,
   SetFn,
   Resource,
+  ZoneAccess,
 } from './resources.js';
 
 /* eslint-disable @typescript-eslint/naming-convention */
@@ -32,7 +33,7 @@ export class DNSRecords {
   readonly update: SetFn<DNSRecord>;
   readonly delete: DeleteFn;
 
-  constructor(apiToken: string, zoneID: string) {
+  constructor({apiToken, zoneID}: ZoneAccess) {
     const resource = new Resource(apiToken, `/zones/${zoneID}/dns_records`);
     this.list = resource.get;
     this.create = resource.post;

--- a/mirror/cloudflare-api/src/fallback-origin.ts
+++ b/mirror/cloudflare-api/src/fallback-origin.ts
@@ -1,4 +1,10 @@
-import {DeleteFn, GetOnlyFn, SetOnlyFn, Resource} from './resources.js';
+import {
+  DeleteFn,
+  GetOnlyFn,
+  SetOnlyFn,
+  Resource,
+  ZoneAccess,
+} from './resources.js';
 
 export type FallbackOriginState = {
   origin: string;
@@ -13,7 +19,7 @@ export class FallbackOrigin {
   readonly update: SetOnlyFn<{origin: string}, FallbackOriginState>;
   readonly delete: DeleteFn;
 
-  constructor(apiToken: string, zoneID: string) {
+  constructor({apiToken, zoneID}: ZoneAccess) {
     const resource = new Resource(
       apiToken,
       `/zones/${zoneID}/custom_hostnames/fallback_origin`,

--- a/mirror/cloudflare-api/src/resources.ts
+++ b/mirror/cloudflare-api/src/resources.ts
@@ -98,3 +98,13 @@ export class Resource {
   readonly delete = <T>(query?: URLSearchParams): Promise<T> =>
     this.#fetch('DELETE', undefined, query);
 }
+
+export type ZoneAccess = {
+  apiToken: string;
+  zoneID: string;
+};
+
+export type AccountAccess = {
+  apiToken: string;
+  accountID: string;
+};

--- a/mirror/cloudflare-api/src/scripts.ts
+++ b/mirror/cloudflare-api/src/scripts.ts
@@ -1,4 +1,5 @@
 import {
+  AccountAccess,
   DeleteOnlyFn,
   GetOnlyFn,
   RawSetOnlyFn,
@@ -125,8 +126,7 @@ export class NamespacedScript extends Script {
   readonly productionEnvironment: GetOnlyFn<ScriptEnvironment>;
 
   constructor(
-    apiToken: string,
-    accountID: string,
+    {apiToken, accountID}: AccountAccess,
     namespace: string,
     name: string,
   ) {
@@ -150,7 +150,7 @@ export class GlobalScript extends Script {
   readonly setSchedules: SetOnlyFn<ScriptSchedule[]>;
   readonly setCustomDomains: SetOnlyFn<CustomDomains>;
 
-  constructor(apiToken: string, accountID: string, name: string) {
+  constructor({apiToken, accountID}: AccountAccess, name: string) {
     super(
       new Resource(apiToken, `/accounts/${accountID}/workers/scripts`),
       name,

--- a/mirror/cloudflare-api/src/worker-routes.ts
+++ b/mirror/cloudflare-api/src/worker-routes.ts
@@ -5,6 +5,7 @@ import {
   SetOnlyFn,
   SetFn,
   Resource,
+  ZoneAccess,
 } from './resources.js';
 
 export type WorkerRoute = {
@@ -22,7 +23,7 @@ export class WorkerRoutes {
   readonly update: SetFn<WorkerRoute>;
   readonly delete: DeleteFn;
 
-  constructor(apiToken: string, zoneID: string) {
+  constructor({apiToken, zoneID}: ZoneAccess) {
     const resource = new Resource(apiToken, `/zones/${zoneID}/workers/routes`);
     this.list = resource.get;
     this.create = resource.post;

--- a/mirror/mirror-cli/src/cf.ts
+++ b/mirror/mirror-cli/src/cf.ts
@@ -8,7 +8,7 @@ import {
 } from 'mirror-schema/src/provider.js';
 
 export type ProviderConfig = Provider & {
-  apiKey: string;
+  apiToken: string;
 };
 
 export async function getProviderConfig(
@@ -25,6 +25,6 @@ export async function getProviderConfig(
     throw new Error(`No "${provider}" provider is setup for ${stack}`);
   }
 
-  const apiKey = await getSecret(stack, `${provider}_api_token`);
-  return {...providerData, apiKey};
+  const apiToken = await getSecret(stack, `${provider}_api_token`);
+  return {...providerData, apiToken};
 }

--- a/mirror/mirror-cli/src/configure-provider.ts
+++ b/mirror/mirror-cli/src/configure-provider.ts
@@ -52,12 +52,13 @@ export async function configureProviderHandler(
   const account = await selectOneOf('Cloudflare Account', accounts);
   const zones = await new Zones(apiToken).list();
   const zone = await selectOneOf('Zone', zones);
+  const {id: zoneID, name: zoneName} = zone;
 
   checkPermissions(zone);
   await checkCapabilities(
-    zone.name,
-    new CustomHostnames(apiToken, zone.id),
-    new DNSRecords(apiToken, zone.id),
+    zoneName,
+    new CustomHostnames({apiToken, zoneID}),
+    new DNSRecords({apiToken, zoneID}),
   );
 
   // TODO: Verify that the account can perform the necessary functions
@@ -69,10 +70,7 @@ export async function configureProviderHandler(
     accountID: account.id,
     dispatchNamespace: namespace,
     defaultMaxApps: maxApps,
-    defaultZone: {
-      id: zone.id,
-      name: zone.name,
-    },
+    defaultZone: {zoneID, zoneName},
   };
   console.log(`Configuring "${id}" provider`, provider);
   if (dryRun || !(await confirm({message: `Continue`, default: true}))) {

--- a/mirror/mirror-cli/src/custom-hostnames.ts
+++ b/mirror/mirror-cli/src/custom-hostnames.ts
@@ -36,11 +36,11 @@ export async function customHostnamesHandler(
   const {pattern = '', delete: deleteHostnames = false, create, get} = yargs;
   const config = await getProviderConfig(yargs);
   const {
-    apiKey,
-    defaultZone: {id: zoneID},
+    apiToken,
+    defaultZone: {zoneID},
   } = config;
 
-  const resource = new CustomHostnames(apiKey, zoneID);
+  const resource = new CustomHostnames({apiToken, zoneID});
 
   if (get) {
     const result = await resource.get(get);

--- a/mirror/mirror-cli/src/dns-records.ts
+++ b/mirror/mirror-cli/src/dns-records.ts
@@ -24,10 +24,10 @@ export async function dnsRecordsHandler(
 ): Promise<void> {
   const {search, delete: deleteRecords} = yargs;
   const {
-    apiKey,
-    defaultZone: {id: zoneID},
+    apiToken,
+    defaultZone: {zoneID},
   } = await getProviderConfig(yargs);
-  const resource = new DNSRecords(apiKey, zoneID);
+  const resource = new DNSRecords({apiToken, zoneID});
   const query = search ? new URLSearchParams({search}) : undefined;
 
   for (const record of await resource.list(query)) {

--- a/mirror/mirror-cli/src/get-worker.ts
+++ b/mirror/mirror-cli/src/get-worker.ts
@@ -33,7 +33,7 @@ export async function getWorkerHandler(
   yargs: GetWorkerHandlerArgs,
 ): Promise<void> {
   const config = await getProviderConfig(yargs);
-  const {apiKey, accountID} = config;
+  const {apiToken, accountID} = config;
   const {name, component, namespace, resource} = yargs;
 
   const base = namespace
@@ -42,6 +42,6 @@ export async function getWorkerHandler(
   const url = component ? `${base}/${component}` : base;
 
   console.log(`GET ${url}`);
-  const result = await cfCall(apiKey, url);
+  const result = await cfCall(apiToken, url);
   console.log(await result.text());
 }

--- a/mirror/mirror-cli/src/publish-custom-domains.ts
+++ b/mirror/mirror-cli/src/publish-custom-domains.ts
@@ -38,7 +38,7 @@ export async function publishCustomDomainsHandler(
 // so we aggressively update rather than aggressively fail
 
 export async function publishCustomDomains(
-  {apiKey, accountID}: ProviderConfig,
+  {apiToken, accountID}: ProviderConfig,
   scriptName: string,
   ...hostnames: string[]
 ): Promise<void> {
@@ -55,7 +55,7 @@ export async function publishCustomDomains(
 
   // deploy to domains
   const results = await cfFetch(
-    apiKey,
+    apiToken,
     `/accounts/${accountID}/workers/scripts/${scriptName}/domains/records`,
     {
       method: 'PUT',

--- a/mirror/mirror-cli/src/publish-dispatcher.ts
+++ b/mirror/mirror-cli/src/publish-dispatcher.ts
@@ -60,11 +60,11 @@ export async function publishDispatcherHandler(
 }
 
 async function ensureDispatchNamespace({
-  apiKey,
+  apiToken,
   accountID,
   dispatchNamespace: name,
 }: ProviderConfig): Promise<void> {
-  const namespaces = new DispatchNamespaces(apiKey, accountID);
+  const namespaces = new DispatchNamespaces({apiToken, accountID});
   await namespaces.delete('mirror');
   try {
     const exists = await namespaces.get(name);
@@ -79,12 +79,12 @@ async function ensureDispatchNamespace({
 }
 
 export async function ensureFallbackRoute(
-  {apiKey, defaultZone: {id: zoneID, name: zoneName}}: ProviderConfig,
+  {apiToken, defaultZone: {zoneID, zoneName}}: ProviderConfig,
   script: string,
   overwriteExisting: boolean,
 ) {
   const pattern = `*.${zoneName}/*`;
-  const resource = new WorkerRoutes(apiKey, zoneID);
+  const resource = new WorkerRoutes({apiToken, zoneID});
   for (const route of await resource.list()) {
     if (route.pattern === pattern) {
       if (route.script === script) {
@@ -107,12 +107,12 @@ export async function ensureFallbackRoute(
 }
 
 export async function ensureFallbackOrigin(
-  {apiKey, defaultZone: {id: zoneID, name: zoneName}}: ProviderConfig,
+  {apiToken, defaultZone: {zoneID, zoneName}}: ProviderConfig,
   hostname: string,
   overwrite: boolean,
 ): Promise<void> {
   const origin = `${hostname}.${zoneName}`;
-  const current = new FallbackOrigin(apiKey, zoneID);
+  const current = new FallbackOrigin({apiToken, zoneID});
   try {
     const existing = await current.get();
     if (existing.origin === origin) {
@@ -131,7 +131,7 @@ export async function ensureFallbackOrigin(
   // https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/start/advanced-settings/worker-as-origin/
   console.log(`Creating Fallback Origin DNS record for ${hostname}`);
   try {
-    const dnsRecords = new DNSRecords(apiKey, zoneID);
+    const dnsRecords = new DNSRecords({apiToken, zoneID});
     const dnsResult = await dnsRecords.create({
       type: 'AAAA',
       name: hostname,
@@ -153,7 +153,7 @@ export async function ensureFallbackOrigin(
 }
 
 async function publishDispatcherScript(
-  {apiKey, accountID, dispatchNamespace: namespace}: ProviderConfig,
+  {apiToken, accountID, dispatchNamespace: namespace}: ProviderConfig,
   name: string,
 ): Promise<void> {
   const dispatcherScript = await loadDispatcherScript();
@@ -177,7 +177,7 @@ async function publishDispatcherScript(
   /* eslint-enable @typescript-eslint/naming-convention */
 
   const result = await cfFetch(
-    apiKey,
+    apiToken,
     `/accounts/${accountID}/workers/scripts/${name}`,
     {
       method: 'PUT',

--- a/mirror/mirror-cli/src/query-analytics.ts
+++ b/mirror/mirror-cli/src/query-analytics.ts
@@ -16,10 +16,10 @@ type QueryAnalyticsHandlerArgs = YargvToInterface<
 
 // https://developers.cloudflare.com/analytics/analytics-engine/sql-api/
 export async function queryAnalyticsHandler(yargs: QueryAnalyticsHandlerArgs) {
-  const {apiKey, accountID} = await getProviderConfig(yargs);
+  const {apiToken, accountID} = await getProviderConfig(yargs);
   const resource = `/accounts/${accountID}/analytics_engine/sql`;
   const {query} = yargs;
-  const resp = await cfCall(apiKey, resource, {
+  const resp = await cfCall(apiToken, resource, {
     method: 'POST',
     body: query,
   });

--- a/mirror/mirror-schema/src/provider.ts
+++ b/mirror/mirror-schema/src/provider.ts
@@ -3,8 +3,8 @@ import {firestoreDataConverter} from './converter.js';
 import * as path from './path.js';
 
 export const zoneSchema = v.object({
-  id: v.string(),
-  name: v.string(), // e.g. 'reflect.net'
+  zoneID: v.string(),
+  zoneName: v.string(), // e.g. 'reflect.net'
 });
 
 /**

--- a/mirror/mirror-schema/src/test-helpers.ts
+++ b/mirror/mirror-schema/src/test-helpers.ts
@@ -155,8 +155,8 @@ export async function setProvider(
   const {
     accountID = `${providerID}-account-id`,
     defaultZone = {
-      id: `${providerID}-zone-id`,
-      name: `${providerID}-zone-name`,
+      zoneID: `${providerID}-zone-id`,
+      zoneName: `${providerID}-zone-name`,
     },
     defaultMaxApps = 3,
     dispatchNamespace = 'prod',

--- a/mirror/mirror-server/src/cloudflare/publish-custom-hostnames.test.ts
+++ b/mirror/mirror-server/src/cloudflare/publish-custom-hostnames.test.ts
@@ -21,8 +21,7 @@ describe('publish-custom-hostnames', () => {
   };
 
   const script = new NamespacedScript(
-    ZONE_CONFIG.apiToken,
-    ACCOUNT_ID,
+    {apiToken: ZONE_CONFIG.apiToken, accountID: ACCOUNT_ID},
     NAMESPACE,
     SCRIPT_NAME,
   );

--- a/mirror/mirror-server/src/cloudflare/publish-custom-hostnames.ts
+++ b/mirror/mirror-server/src/cloudflare/publish-custom-hostnames.ts
@@ -13,17 +13,17 @@ import type {PartialDeep} from 'type-fest';
 import {HttpsError} from 'firebase-functions/v2/https';
 
 export async function* publishCustomHostnames(
-  config: ZoneConfig,
+  zone: ZoneConfig,
   script: NamespacedScript,
   hostname: string,
 ): AsyncGenerator<string> {
-  const {apiToken, zoneID, zoneName} = config;
+  const {zoneName} = zone;
   assert(
     hostname.endsWith(`.${zoneName}`),
     `hostname must be in zone ${zoneName}`,
   );
 
-  const records = new DNSRecords(apiToken, zoneID);
+  const records = new DNSRecords(zone);
   const currentRecords = await records.list(
     new URLSearchParams({tag: `script:${script.id}`}),
   );
@@ -42,7 +42,7 @@ export async function* publishCustomHostnames(
     return;
   }
 
-  const hostnames = new CustomHostnames(apiToken, zoneID);
+  const hostnames = new CustomHostnames(zone);
   for (const name of create) {
     yield `Setting up hostname ${name}`;
   }

--- a/mirror/mirror-server/src/functions/app/auto-deploy.function.test.ts
+++ b/mirror/mirror-server/src/functions/app/auto-deploy.function.test.ts
@@ -73,8 +73,8 @@ describe('auto-deploy', () => {
         accountID: CLOUDFLARE_ACCOUNT_ID,
         defaultMaxApps: 3,
         defaultZone: {
-          id: 'zone-id',
-          name: 'reflect-o-rama.net',
+          zoneID: 'zone-id',
+          zoneName: 'reflect-o-rama.net',
         },
         dispatchNamespace: 'prod',
       },

--- a/mirror/mirror-server/src/functions/app/create.function.test.ts
+++ b/mirror/mirror-server/src/functions/app/create.function.test.ts
@@ -76,8 +76,8 @@ describe('app-create function', () => {
         accountID: CF_ID,
         defaultMaxApps: 3,
         defaultZone: {
-          id: 'zone-id',
-          name: 'reflect-o-rama.net',
+          zoneID: 'zone-id',
+          zoneName: 'reflect-o-rama.net',
         },
         dispatchNamespace: 'prod',
       });

--- a/mirror/mirror-server/src/functions/app/deploy.function.test.ts
+++ b/mirror/mirror-server/src/functions/app/deploy.function.test.ts
@@ -91,8 +91,8 @@ describe('deploy', () => {
         accountID: CLOUDFLARE_ACCOUNT_ID,
         defaultMaxApps: 3,
         defaultZone: {
-          id: 'zone-id',
-          name: 'reflect-o-rama.net',
+          zoneID: 'zone-id',
+          zoneName: 'reflect-o-rama.net',
         },
         dispatchNamespace: 'prod',
       },

--- a/mirror/mirror-server/src/functions/app/publish.function.test.ts
+++ b/mirror/mirror-server/src/functions/app/publish.function.test.ts
@@ -51,8 +51,8 @@ describe('publish', () => {
       {
         accountID: CF_ID,
         defaultZone: {
-          id: 'zone-id',
-          name: 'reflect-o-rama.net',
+          zoneID: 'zone-id',
+          zoneName: 'reflect-o-rama.net',
         },
         defaultMaxApps: 3,
         dispatchNamespace: 'prod',

--- a/mirror/mirror-server/src/functions/app/publish.function.ts
+++ b/mirror/mirror-server/src/functions/app/publish.function.ts
@@ -91,7 +91,7 @@ export async function computeDeploymentSpec(
     `Found matching version for ${serverVersionRange}: ${serverVersion}`,
   );
 
-  const {provider: providerID} = app;
+  const {provider: providerID, name: appName, teamLabel} = app;
   const provider = getDataOrFail(
     await firestore
       .doc(providerPath(providerID))
@@ -100,6 +100,9 @@ export async function computeDeploymentSpec(
     'internal',
     `Provider ${providerID} is not properly set up.`,
   );
+  const {
+    defaultZone: {zoneName},
+  } = provider;
 
   const {hashes: hashesOfSecrets} = await getAppSecrets();
 
@@ -107,7 +110,7 @@ export async function computeDeploymentSpec(
     serverVersionRange,
     serverVersion,
     // Note: Hyphens are not allowed in teamLabels.
-    hostname: `${app.name}-${app.teamLabel}.${provider.defaultZone.name}`,
+    hostname: `${appName}-${teamLabel}.${zoneName}`,
     options: app.deploymentOptions,
     hashesOfSecrets,
   };

--- a/mirror/mirror-server/src/functions/server/auto-deploy.function.test.ts
+++ b/mirror/mirror-server/src/functions/server/auto-deploy.function.test.ts
@@ -91,8 +91,8 @@ describe('server auto-deploy', () => {
         accountID: CLOUDFLARE_ACCOUNT_ID,
         defaultMaxApps: 3,
         defaultZone: {
-          id: 'zone-id',
-          name: 'reflect-o-rama.net',
+          zoneID: 'zone-id',
+          zoneName: 'reflect-o-rama.net',
         },
         dispatchNamespace: 'prod',
       },


### PR DESCRIPTION
Cleanup / standardize naming (`apiKey` -> `apiToken`) and replace sequences of string parameters with objects to reduce the possibility of wrong-parameter-order errors. This also makes it clearer how each resource is accessed.