### PR TITLE
feat(mirror): use DNS Record comments instead of tags for now

### DIFF
--- a/mirror/mirror-cli/src/configure-provider.ts
+++ b/mirror/mirror-cli/src/configure-provider.ts
@@ -134,7 +134,8 @@ async function checkCapabilities(
     name: 'test-mirror-record',
     content: 'test-mirror-content',
     comment: 'Temporarily created by mirror-cli. Delete me.',
-    tags: ['foo:bar'],
+    // TODO: Uncomment when Cloudflare enables tags for us.
+    // tags: ['foo:bar'],
   });
   await dnsRecords.delete(record.id);
 }

--- a/mirror/mirror-server/src/cloudflare/publish-custom-hostnames.test.ts
+++ b/mirror/mirror-server/src/cloudflare/publish-custom-hostnames.test.ts
@@ -50,7 +50,7 @@ describe('publish-custom-hostnames', () => {
     expect(fetch.requests()).toEqual([
       [
         'GET',
-        'https://api.cloudflare.com/client/v4/zones/1ab3d299c/dns_records?tag=script%3Aprod%2Ffoo-script',
+        'https://api.cloudflare.com/client/v4/zones/1ab3d299c/dns_records?tag=script%3Aprod%2Ffoo-script&comment.contains=%7Cscript%3Aprod%2Ffoo-script%7C&match=any',
       ],
     ]);
   });
@@ -69,7 +69,7 @@ describe('publish-custom-hostnames', () => {
     expect(fetch.requests()).toEqual([
       [
         'GET',
-        'https://api.cloudflare.com/client/v4/zones/1ab3d299c/dns_records?tag=script%3Aprod%2Ffoo-script',
+        'https://api.cloudflare.com/client/v4/zones/1ab3d299c/dns_records?tag=script%3Aprod%2Ffoo-script&comment.contains=%7Cscript%3Aprod%2Ffoo-script%7C&match=any',
       ],
       [
         'POST',
@@ -104,8 +104,9 @@ describe('publish-custom-hostnames', () => {
         type: 'CNAME',
         content: 'reflect-o-rama.net',
         proxied: true,
-        tags: ['script:prod/foo-script', 'ch:ch-id'],
-        comment: 'Managed by Rocicorp (reflect.net)',
+        // tags: ['script:prod/foo-script', 'ch:ch-id'],
+        // comment: 'Managed by Rocicorp (reflect.net)',
+        comment: '|script:prod/foo-script|ch:ch-id|',
       },
       ch,
     ]);
@@ -134,7 +135,7 @@ describe('publish-custom-hostnames', () => {
     expect(fetch.requests()).toEqual([
       [
         'GET',
-        'https://api.cloudflare.com/client/v4/zones/1ab3d299c/dns_records?tag=script%3Aprod%2Ffoo-script',
+        'https://api.cloudflare.com/client/v4/zones/1ab3d299c/dns_records?tag=script%3Aprod%2Ffoo-script&comment.contains=%7Cscript%3Aprod%2Ffoo-script%7C&match=any',
       ],
       [
         'POST',
@@ -178,8 +179,9 @@ describe('publish-custom-hostnames', () => {
       type: 'CNAME',
       content: 'reflect-o-rama.net',
       proxied: true,
-      tags: ['script:prod/foo-script', 'ch:existing-ch-id'],
-      comment: 'Managed by Rocicorp (reflect.net)',
+      // tags: ['script:prod/foo-script', 'ch:existing-ch-id'],
+      // comment: 'Managed by Rocicorp (reflect.net)',
+      comment: '|script:prod/foo-script|ch:existing-ch-id|',
     };
     expect(fetch.jsonPayloads()).toEqual([
       null, // DNSRecords.list()
@@ -219,7 +221,7 @@ describe('publish-custom-hostnames', () => {
     expect(fetch.requests()).toEqual([
       [
         'GET',
-        'https://api.cloudflare.com/client/v4/zones/1ab3d299c/dns_records?tag=script%3Aprod%2Ffoo-script',
+        'https://api.cloudflare.com/client/v4/zones/1ab3d299c/dns_records?tag=script%3Aprod%2Ffoo-script&comment.contains=%7Cscript%3Aprod%2Ffoo-script%7C&match=any',
       ],
       [
         'DELETE',
@@ -262,7 +264,7 @@ describe('publish-custom-hostnames', () => {
     expect(fetch.requests()).toEqual([
       [
         'GET',
-        'https://api.cloudflare.com/client/v4/zones/1ab3d299c/dns_records?tag=script%3Aprod%2Ffoo-script',
+        'https://api.cloudflare.com/client/v4/zones/1ab3d299c/dns_records?tag=script%3Aprod%2Ffoo-script&comment.contains=%7Cscript%3Aprod%2Ffoo-script%7C&match=any',
       ],
       [
         'DELETE',
@@ -297,7 +299,7 @@ describe('publish-custom-hostnames', () => {
       expect.arrayContaining([
         [
           'GET',
-          'https://api.cloudflare.com/client/v4/zones/1ab3d299c/dns_records?tag=script%3Aprod%2Ffoo-script',
+          'https://api.cloudflare.com/client/v4/zones/1ab3d299c/dns_records?tag=script%3Aprod%2Ffoo-script&comment.contains=%7Cscript%3Aprod%2Ffoo-script%7C&match=any',
         ],
         [
           'DELETE',
@@ -373,7 +375,7 @@ describe('publish-custom-hostnames', () => {
       expect.arrayContaining([
         [
           'GET',
-          'https://api.cloudflare.com/client/v4/zones/1ab3d299c/dns_records?tag=script%3Aprod%2Ffoo-script',
+          'https://api.cloudflare.com/client/v4/zones/1ab3d299c/dns_records?tag=script%3Aprod%2Ffoo-script&comment.contains=%7Cscript%3Aprod%2Ffoo-script%7C&match=any',
         ],
         [
           'DELETE',


### PR DESCRIPTION
The Cloudflare folks have been unresponsive with respect to enabling DNS Record tag support on our accounts.

For now, workaround this by encoding the tags in DNS Record comments instead, since we can achieve the same lookup with a `comment.includes=|script:<script-name>|` query. This unblocks progress on the migration to WFP.

> Note: Assuming our zones are on the `Free` tier, comments are [limited in length to 100 characters](https://developers.cloudflare.com/dns/manage-dns-records/reference/record-attributes/#record-comments). This should be sufficient since CustomHostname tags are ~40 characters in length, and script tags about the same.  🤞 

Once tag support is enabled, we can migrate to purely using tags.

#scrappy