### PR TITLE
Revert "feat(reflect-cli): Use new tail backend (#1003)"

### DIFF
--- a/mirror/cloudflare-api/src/scripts.ts
+++ b/mirror/cloudflare-api/src/scripts.ts
@@ -1,11 +1,13 @@
 import {
   AccountAccess,
+  DeleteFn,
   DeleteOnlyFn,
   GetOnlyFn,
+  SetOnlyFn,
   RawSetOnlyFn,
   Resource,
-  SetOnlyFn,
 } from './resources.js';
+import type {TailCreationApiResponse, TailFilterMessage} from './tail.js';
 
 /* eslint-disable @typescript-eslint/naming-convention */
 export type Binding = {
@@ -147,6 +149,8 @@ export class NamespacedScript extends Script {
 export class GlobalScript extends Script {
   readonly id: string;
   readonly productionEnvironment: GetOnlyFn<ScriptEnvironment>;
+  readonly startTail: SetOnlyFn<TailFilterMessage, TailCreationApiResponse>;
+  readonly deleteTail: DeleteFn;
   readonly setSchedules: SetOnlyFn<ScriptSchedule[]>;
   readonly setCustomDomains: SetOnlyFn<CustomDomains>;
 
@@ -163,6 +167,9 @@ export class GlobalScript extends Script {
 
     this.id = name;
     this.productionEnvironment = service.append(`environments/production`).get;
+    this.startTail = this._script.append('tails').post;
+    this.deleteTail = (id, q) =>
+      this._script.append('tails').append(id).delete(q);
     this.setSchedules = this._script.append('schedules').put;
     this.setCustomDomains = this._script.append('domains/records').put;
   }

--- a/mirror/mirror-protocol/src/tail.ts
+++ b/mirror/mirror-protocol/src/tail.ts
@@ -3,10 +3,7 @@ import * as v from 'shared/src/valita.js';
 import {baseAppRequestFields} from './app.js';
 import {baseResponseFields} from './base.js';
 
-export const tailRequestSchema = v.object({
-  ...baseAppRequestFields,
-  roomID: v.string(),
-});
+export const tailRequestSchema = v.object(baseAppRequestFields);
 
 export type TailRequest = v.Infer<typeof tailRequestSchema>;
 

--- a/mirror/mirror-server/src/cloudflare/tail/filters.ts
+++ b/mirror/mirror-server/src/cloudflare/tail/filters.ts
@@ -1,0 +1,284 @@
+// Original filename at
+// https://github.com/cloudflare/workers-sdk/blob/6de3c5eced6f31a2a55f4c043e1025f4f4733ad0/packages/wrangler/src/tail/filters.ts#L138
+
+/**
+ * When tailing logs from a worker, oftentimes you don't want to see _every
+ * single event_. That's where filters come in. We can send a set of filters
+ * to the tail worker, and it will pre-filter any logs for us so that we
+ * only recieve the ones we care about.
+ */
+
+/**
+ * These are the filters we accept in the CLI. They
+ * were copied directly from Wrangler v1 in order to
+ * maintain compatability, so they aren't actually the exact
+ * filters we need to send up to the tail worker. They generally map 1:1,
+ * but often require some transformation or
+ * renaming to match what it expects.
+ *
+ * For a full description of each filter, either check the
+ * CLI description or see the documentation for `ApiFilter`.
+ */
+type TailCLIFilters = {
+  status?: ('ok' | 'error' | 'canceled')[];
+  header?: string;
+  method?: string[];
+  search?: string;
+  samplingRate?: number;
+  clientIp?: string[];
+};
+
+/**
+ * These are the filters we send to the tail worker. We
+ * actually send a list of filters (an array of objects),
+ * so rather than having a single TailAPIFilters type,
+ * each kind of filter gets its own type and we define
+ * TailAPIFilter to be the union of those types.
+ */
+type TailAPIFilter =
+  | SamplingRateFilter
+  | OutcomeFilter
+  | MethodFilter
+  | HeaderFilter
+  | ClientIPFilter
+  | QueryFilter;
+
+/**
+ * Filters logs based on a given sampling rate.
+ * For example, a `sampling_rate` of 0.25 will let one-quarter of the
+ * logs through.
+ */
+type SamplingRateFilter = {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  sampling_rate: number;
+};
+
+/**
+ * Filters logs based on the outcome of the worker's event handler.
+ */
+type OutcomeFilter = {
+  outcome: Outcome[];
+};
+
+/**
+ * There are five possible outcomes we can get, three of which
+ * (exception, exceededCpu, exceededMemory, and unknown) are considered errors
+ */
+export type Outcome =
+  | 'ok'
+  | 'canceled'
+  | 'exception'
+  | 'exceededCpu'
+  | 'exceededMemory'
+  | 'unknown';
+
+/**
+ * Filters logs based on the HTTP method used for the request
+ * that triggered the worker.
+ */
+type MethodFilter = {
+  method: string[];
+};
+
+/**
+ * Filters logs based on an HTTP header on the request that
+ * triggered the worker.
+ */
+type HeaderFilter = {
+  header: {
+    /**
+     * Filters on the header "key", e.g. "X-CLOUDFLARE-HEADER"
+     * or "X-CUSTOM-HEADER"
+     */
+    key: string;
+
+    /**
+     * Filters on the header "value", e.g. if this is set to
+     * "filter-for-me" and the "key" is "X-SHOULD-LOG", only
+     * events triggered by requests with the header
+     * "X-SHOULD-LOG:filter-for-me" will be logged.
+     */
+    query?: string;
+  };
+};
+
+/**
+ * Filters on the IP address the request came from that triggered
+ * the worker. A value of "self" will be replaced with the IP
+ * address that is running `wrangler tail`
+ */
+type ClientIPFilter = {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  client_ip: string[];
+};
+
+/**
+ * Filters logs by a query string. This means only logs that
+ * contain the given string will be sent to wrangler, and any
+ * that don't will be discarded by the tail worker.
+ */
+type QueryFilter = {
+  query: string;
+};
+
+/**
+ * The full message we send to the tail worker includes our
+ * filters and a debug flag.
+ */
+export type TailFilterMessage = {
+  filters: TailAPIFilter[];
+};
+
+/**
+ * Translate the flags passed in via a CLI invokation of wrangler
+ * into a message that we can send to the tail worker.
+ *
+ * @param cliFilters An object containing all the filters passed in from the CLI
+ * @returns A filter message ready to be sent to the tail worker
+ */
+export function translateCLICommandToFilterMessage(
+  cliFilters: TailCLIFilters,
+): TailFilterMessage {
+  const apiFilters: TailAPIFilter[] = [];
+
+  if (cliFilters.samplingRate) {
+    apiFilters.push(parseSamplingRate(cliFilters.samplingRate));
+  }
+
+  if (cliFilters.status) {
+    apiFilters.push(parseOutcome(cliFilters.status));
+  }
+
+  if (cliFilters.method) {
+    apiFilters.push(parseMethod(cliFilters.method));
+  }
+
+  if (cliFilters.header) {
+    apiFilters.push(parseHeader(cliFilters.header));
+  }
+
+  if (cliFilters.clientIp) {
+    apiFilters.push(parseIP(cliFilters.clientIp));
+  }
+
+  if (cliFilters.search) {
+    apiFilters.push(parseQuery(cliFilters.search));
+  }
+
+  return {
+    filters: apiFilters,
+  };
+}
+
+/**
+ * Parse the sampling rate passed in via command line
+ *
+ * @param samplingRate the sampling rate passed in via CLI
+ * @throws an Error if the rate doesn't make sense
+ * @returns a SamplingRateFilter for use with the API
+ */
+function parseSamplingRate(samplingRate: number): SamplingRateFilter {
+  if (samplingRate <= 0 || samplingRate >= 1) {
+    throw new Error(
+      'A sampling rate must be between 0 and 1 in order to have any effect.\nFor example, a sampling rate of 0.25 means 25% of events will be logged.',
+    );
+  }
+
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  return {sampling_rate: samplingRate};
+}
+
+/**
+ * Translate from CLI "status"es to API "outcome"s, including
+ * broadening "error" into "exception", "exceededCpu", and "unknown".
+ *
+ * @param statuses statuses passed in via CLI
+ * @returns an OutcomeFilter for use with the API
+ */
+function parseOutcome(
+  statuses: ('ok' | 'error' | 'canceled')[],
+): OutcomeFilter {
+  const outcomes = new Set<Outcome>();
+
+  for (const status of statuses) {
+    switch (status) {
+      case 'ok':
+        outcomes.add('ok');
+        break;
+
+      case 'canceled':
+        outcomes.add('canceled');
+        break;
+
+      case 'error':
+        outcomes.add('exception');
+        outcomes.add('exceededCpu');
+        outcomes.add('exceededMemory');
+        outcomes.add('unknown');
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  return {
+    outcome: Array.from(outcomes),
+  };
+}
+
+/**
+ * We just send silly methods through to the API anyway, since they don't
+ * cause any harm.
+ *
+ * @param method an array of HTTP request methods passed in via CLI
+ * @returns a MethodFilter for use with the API
+ */
+function parseMethod(method: string[]): MethodFilter {
+  return {method};
+}
+
+/**
+ * Header filters can contain either just a key ("X-HEADER-KEY") or both
+ * a key and a value ("X-HEADER-KEY:some-value"). This function parses
+ * a given string according to that pattern.
+ *
+ * @param header a header string, "X-HEADER-KEY" or "X-HEADER-KEY:some-value"
+ * @returns a HeaderFilter for use with the API
+ */
+function parseHeader(header: string): HeaderFilter {
+  const [headerKey, headerQuery] = header.split(':', 2);
+
+  return {
+    header: {
+      key: headerKey.trim(),
+      query: headerQuery?.trim(),
+    },
+  };
+}
+
+/**
+ * A list of IPs can be passed in to filter for messages that come from
+ * a worker triggered by a request originating from one of those IPs.
+ * You can also pass in the string "self" to filter for the IP of the
+ * machine running `wrangler tail`.
+ *
+ * @param clientIP an array of IP addresses to filter
+ * @returns a ClientIPFilter for use with the API
+ */
+function parseIP(clientIP: string[]): ClientIPFilter {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  return {client_ip: clientIP};
+}
+
+/**
+ * Users can filter for logs that contain a "search" or a "query string".
+ * For example, if `--search findme` is passed to then we will only
+ * receive logs that contain the string "findme".
+ *
+ * @param query a query string to search for
+ * @returns a QueryFilter for use with the API
+ */
+function parseQuery(query: string): QueryFilter {
+  return {query};
+}

--- a/mirror/mirror-server/src/cloudflare/tail/tail.ts
+++ b/mirror/mirror-server/src/cloudflare/tail/tail.ts
@@ -1,0 +1,280 @@
+import WebSocket from 'ws';
+import type {Outcome, TailFilterMessage} from './filters.js';
+import type {GlobalScript} from 'cloudflare-api/src/scripts.js';
+
+const TRACE_VERSION = 'trace-v1';
+
+/**
+ * Create and connect to a tail.
+ *
+ * Under the hood, this function
+ * - Registers a new Tail with the API
+ * - Connects to the tail worker
+ * - Sends any filters over the connection
+ *
+ * @param accountID the account ID associated with the worker to tail
+ * @param workerName the name of the worker to tail
+ * @param filters A list of `TailAPIFilters` given to the tail
+ * @param debug Flag to run tail in debug mode
+ * @returns a websocket connection, an expiration, and a function to call to delete the tail
+ */
+export async function createTail(
+  script: GlobalScript,
+  filters: TailFilterMessage,
+  debug: boolean,
+  packageVersion: string,
+): Promise<{
+  ws: WebSocket;
+  expiration: Date;
+  deleteTail: () => Promise<void>;
+}> {
+  const {
+    id: tailId,
+    url: websocketUrl,
+    expires_at: expiration,
+  } = await script.startTail(filters);
+
+  async function deleteTail() {
+    await script.deleteTail(tailId);
+  }
+
+  // connect to the tail
+  const ws = new WebSocket(websocketUrl, TRACE_VERSION, {
+    headers: {
+      'Sec-WebSocket-Protocol': TRACE_VERSION, // needs to be `trace-v1` to be accepted
+      'User-Agent': `reflect/${packageVersion}`,
+    },
+  });
+
+  // send filters when we open up
+  ws.on('open', () => {
+    ws.send(JSON.stringify({debug}));
+  });
+
+  return {ws, expiration, deleteTail};
+}
+
+/**
+ * Everything captured by the trace worker and sent to us via
+ * `wrangler tail` is structured JSON that deserializes to this type.
+ */
+export type TailEventMessage = {
+  /**
+   * Whether the execution of this worker succeeded or failed
+   */
+  outcome: Outcome;
+
+  /**
+   * The name of the script we're tailing
+   */
+  scriptName?: string;
+
+  /**
+   * Any exceptions raised by the worker
+   */
+  exceptions: {
+    /**
+     * The name of the exception.
+     */
+    name: string;
+
+    /**
+     * The error message
+     */
+    message: unknown;
+
+    /**
+     * When the exception was raised/thrown
+     */
+    timestamp: number;
+  }[];
+
+  /**
+   * Any logs sent out by the worker
+   */
+  logs: {
+    message: unknown[];
+    level: string; // TODO: make this a union of possible values
+    timestamp: number;
+  }[];
+
+  /**
+   * When the event was triggered
+   */
+  eventTimestamp: number;
+
+  /**
+   * The event that triggered the worker. In the case of an HTTP request,
+   * this will be a RequestEvent. If it's a cron trigger, it'll be a
+   * ScheduledEvent. If it's a durable object alarm, it's an AlarmEvent.
+   * If it's a email, it'a an EmailEvent
+   *
+   * Until workers-types exposes individual types for export, we'll have
+   * to just re-define these types ourselves.
+   */
+  event:
+    | RequestEvent
+    | ScheduledEvent
+    | AlarmEvent
+    | EmailEvent
+    | TailInfo
+    | undefined
+    | null;
+};
+
+/**
+ * A request that triggered worker execution
+ */
+
+type RequestEvent = {
+  request: Pick<Request, 'url' | 'method' | 'headers'> & {
+    /**
+     * Cloudflare-specific properties
+     * https://developers.cloudflare.com/workers/runtime-apis/request#incomingrequestcfproperties
+     */
+    cf: {
+      /**
+       * How long (in ms) it took for the client's TCP connection to make a
+       * round trip to the worker and back. For all my gamers out there,
+       * this is the request's ping
+       */
+      clientTcpRtt?: number;
+
+      /**
+       * Longitude and Latitude of where the request originated from
+       */
+      longitude?: string;
+      latitude?: string;
+
+      /**
+       * What cipher was used to establish the TLS connection
+       */
+      tlsCipher: string;
+
+      /**
+       * Which continent the request came from.
+       */
+      continent?: 'NA';
+
+      /**
+       * ASN of the incoming request
+       */
+      asn: number;
+
+      /**
+       * The country the incoming request is coming from
+       */
+      country?: string;
+
+      /**
+       * The TLS version the connection used
+       */
+      tlsVersion: string;
+
+      /**
+       * The colo that processed the request (i.e. the airport code
+       * of the closest city to the server that spun up the worker)
+       */
+      colo: string;
+
+      /**
+       * The timezone where the request came from
+       */
+      timezone?: string;
+
+      /**
+       * The city where the request came from
+       */
+      city?: string;
+
+      /**
+       * The browser-requested prioritization information in the request object
+       */
+      requestPriority?: string;
+
+      /**
+       * Which version of HTTP the request came over e.g. "HTTP/2"
+       */
+      httpProtocol: string;
+
+      /**
+       * The region where the request originated from
+       */
+      region?: string;
+      regionCode?: string;
+
+      /**
+       * The organization which owns the ASN of the incoming request, for example, Google Cloud.
+       */
+      asOrganization: string;
+
+      /**
+       * Metro code (DMA) of the incoming request, for example, "635".
+       */
+      metroCode?: string;
+
+      /**
+       * Postal code of the incoming request, for example, "78701".
+       */
+      postalCode?: string;
+    };
+  };
+};
+
+/**
+ * An event that was triggered at a certain time
+ */
+type ScheduledEvent = {
+  /**
+   * The cron pattern that matched when this event fired
+   */
+  cron: string;
+
+  /**
+   * The time this worker was scheduled to run.
+   * For some reason, this doesn't...work correctly when we
+   * do it directly as a Date. So parse it later on your own.
+   */
+  scheduledTime: number;
+};
+
+/**
+ * A event that was triggered from a durable object alarm
+ */
+type AlarmEvent = {
+  /**
+   * The datetime the alarm was scheduled for.
+   *
+   * This is sent as an ISO timestamp string (different than ScheduledEvent.scheduledTime),
+   * you should parse it later on on your own.
+   */
+  scheduledTime: string;
+};
+
+/**
+ * An event that was triggered from an email
+ */
+type EmailEvent = {
+  /**
+   * Who sent the email
+   */
+  mailFrom: string;
+
+  /**
+   * Who was the email sent to
+   */
+  rcptTo: string;
+
+  /**
+   * Size of the email in bytes
+   */
+  rawSize: number;
+};
+
+/**
+ * Message from tail with information about the tail itself
+ */
+type TailInfo = {
+  message: string;
+  type: string;
+};

--- a/mirror/mirror-server/src/functions/app/secrets.ts
+++ b/mirror/mirror-server/src/functions/app/secrets.ts
@@ -1,8 +1,8 @@
-import {SecretManagerServiceClient} from '@google-cloud/secret-manager';
 import {defineSecret} from 'firebase-functions/params';
 import type {DeploymentSecrets} from 'mirror-schema/src/deployment.js';
 import {assert} from 'shared/src/asserts.js';
 import {sha256OfString} from 'shared/src/sha256.js';
+import {SecretManagerServiceClient} from '@google-cloud/secret-manager';
 import {projectId} from '../../config/index.js';
 
 export function defineSecretSafely(name: string) {
@@ -31,9 +31,6 @@ export function defineSecretSafely(name: string) {
 const datadogLogsApiKey = defineSecretSafely('DATADOG_LOGS_API_KEY');
 const datadogMetricsApiKey = defineSecretSafely('DATADOG_METRICS_API_KEY');
 
-// TODO(darick): Replace with a stable per-app secret.
-export const REFLECT_AUTH_API_KEY = 'dummy-api-key';
-
 export const DEPLOYMENT_SECRETS_NAMES = [
   'DATADOG_LOGS_API_KEY',
   'DATADOG_METRICS_API_KEY',
@@ -41,18 +38,22 @@ export const DEPLOYMENT_SECRETS_NAMES = [
 
 export async function getAppSecrets() {
   const secrets: DeploymentSecrets = {
-    ['REFLECT_AUTH_API_KEY']: REFLECT_AUTH_API_KEY,
-    ['DATADOG_LOGS_API_KEY']: datadogLogsApiKey.value(),
-    ['DATADOG_METRICS_API_KEY']: datadogMetricsApiKey.value(),
+    /* eslint-disable @typescript-eslint/naming-convention */
+    REFLECT_AUTH_API_KEY: 'dummy-api-key', // TODO(darick): Replace with a stable per-app secret.
+    DATADOG_LOGS_API_KEY: datadogLogsApiKey.value(),
+    DATADOG_METRICS_API_KEY: datadogMetricsApiKey.value(),
+    /* eslint-enable @typescript-eslint/naming-convention */
   };
   const hashes = await hashSecrets(secrets);
   return {secrets, hashes};
 }
 
 export const NULL_SECRETS: DeploymentSecrets = {
-  ['REFLECT_AUTH_API_KEY']: '',
-  ['DATADOG_LOGS_API_KEY']: '',
-  ['DATADOG_METRICS_API_KEY']: '',
+  /* eslint-disable @typescript-eslint/naming-convention */
+  REFLECT_AUTH_API_KEY: '',
+  DATADOG_LOGS_API_KEY: '',
+  DATADOG_METRICS_API_KEY: '',
+  /* eslint-enable @typescript-eslint/naming-convention */
 } as const;
 
 export async function hashSecrets(

--- a/mirror/mirror-server/src/functions/app/tail.handler.test.ts
+++ b/mirror/mirror-server/src/functions/app/tail.handler.test.ts
@@ -1,19 +1,15 @@
-import type {Firestore} from '@google-cloud/firestore';
-import {getMockReq, getMockRes} from '@jest-mock/express';
-import {beforeEach, describe, expect, jest, test} from '@jest/globals';
+import {describe, test, jest, expect, beforeEach} from '@jest/globals';
 import type {Auth} from 'firebase-admin/auth';
 import type {https} from 'firebase-functions/v2';
-import {
-  fakeFirestore,
-  setApp,
-  setProvider,
-  setUser,
-} from 'mirror-schema/src/test-helpers.js';
-import {sleep} from 'shared/src/sleep.js';
-import type WebSocket from 'ws';
 import {mockFunctionParamsAndSecrets} from '../../test-helpers.js';
-import {mockApiTokenForProvider} from './secrets.js';
 import {tail} from './tail.handler.js';
+import {fakeFirestore} from 'mirror-schema/src/test-helpers.js';
+import {getMockReq, getMockRes} from '@jest-mock/express';
+import {setUser, setApp, setProvider} from 'mirror-schema/src/test-helpers.js';
+import type WebSocket from 'ws';
+import {sleep} from 'shared/src/sleep.js';
+import type {Firestore} from '@google-cloud/firestore';
+import {mockApiTokenForProvider} from './secrets.js';
 
 export class MockSocket {
   readonly url: string | URL;
@@ -64,8 +60,8 @@ describe('test tail', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     res: any,
   ) => void | Promise<void>;
-  let createTailMockPromise: Promise<void>;
-  let createTailResolver: () => void;
+  let createCloudflareTailMockPromise: Promise<void>;
+  let createCloudflareTailResolver: () => void;
 
   beforeEach(async () => {
     firestore = fakeFirestore();
@@ -77,16 +73,20 @@ describe('test tail', () => {
         .mockImplementation(() => Promise.resolve({uid: 'foo'})),
     } as unknown as Auth;
 
-    createTailMockPromise = new Promise<void>(resolve => {
-      createTailResolver = resolve;
+    createCloudflareTailMockPromise = new Promise<void>(resolve => {
+      createCloudflareTailResolver = resolve;
     });
 
-    const createTailMock = () => {
-      setTimeout(createTailResolver, 0);
-      return wsMock as unknown as WebSocket;
+    const createCloudflareTailMock = () => {
+      setTimeout(createCloudflareTailResolver, 0);
+      return Promise.resolve({
+        ws: wsMock as unknown as WebSocket,
+        expiration: new Date(),
+        deleteTail: () => Promise.resolve(),
+      });
     };
 
-    createTailFunction = tail(firestore, auth, createTailMock);
+    createTailFunction = tail(firestore, auth, createCloudflareTailMock);
     await setUser(firestore, 'foo', 'foo@bar.com', 'bob', {fooTeam: 'admin'});
     await setApp(firestore, 'myApp', {
       teamID: 'fooTeam',
@@ -105,7 +105,6 @@ describe('test tail', () => {
           userAgent: {type: 'reflect-cli', version: '0.0.1'},
         },
         appID: 'myApp',
-        roomID: 'myRoom',
       },
       headers: {
         // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -116,10 +115,11 @@ describe('test tail', () => {
   test('valid auth in header', async () => {
     const req = getRequestWithHeaders();
 
+    console.log('req', req.body);
     const {res} = getMockRes();
     req.res = res;
     const createTailPromise = createTailFunction(req, res);
-    await createTailMockPromise;
+    await createCloudflareTailMockPromise;
     wsMock.close();
     await createTailPromise;
     expect(auth.verifyIdToken).toBeCalledWith('this-is-the-encoded-token');
@@ -131,7 +131,7 @@ describe('test tail', () => {
     const {res} = getMockRes();
     req.res = res;
     const createTailPromise = createTailFunction(req, res);
-    await createTailMockPromise;
+    await createCloudflareTailMockPromise;
     wsMock.message(
       JSON.stringify({
         outcome: 'ok',

--- a/mirror/mirror-server/src/functions/app/tail.handler.ts
+++ b/mirror/mirror-server/src/functions/app/tail.handler.ts
@@ -1,23 +1,29 @@
 import type {Response} from 'express';
 import type {Auth} from 'firebase-admin/auth';
 import type {Firestore} from 'firebase-admin/firestore';
-import {logger} from 'firebase-functions';
+import {https, logger} from 'firebase-functions';
 import {HttpsError, onRequest} from 'firebase-functions/v2/https';
 import {tailRequestSchema} from 'mirror-protocol/src/tail.js';
-import type {App} from 'mirror-schema/src/app.js';
 import assert from 'node:assert';
 import {jsonSchema} from 'reflect-protocol';
-import {must} from 'shared/src/must.js';
 import {Queue} from 'shared/src/queue.js';
 import * as v from 'shared/src/valita.js';
-import WebSocket from 'ws';
+import type WebSocket from 'ws';
+import packageJson from '../../../package.json';
+import {createTail as createTailDefault} from '../../cloudflare/tail/tail.js';
 import {
   appAuthorization,
   tokenAuthentication,
   userAuthorization,
 } from '../validators/auth.js';
 import {validateRequest} from '../validators/schema.js';
-import {REFLECT_AUTH_API_KEY} from './secrets.js';
+import {getApiToken} from './secrets.js';
+import {GlobalScript} from 'cloudflare-api/src/scripts.js';
+import {
+  providerDataConverter,
+  providerPath,
+} from 'mirror-schema/src/provider.js';
+import {getDataOrFail} from '../validators/data.js';
 
 export const tail = (
   firestore: Firestore,
@@ -30,19 +36,37 @@ export const tail = (
       .validate(userAuthorization())
       .validate(appAuthorization(firestore))
       .handle(async (tailRequest, context) => {
-        const {response, app} = context;
-        const {
-          roomID,
-          requester: {userAgent},
-        } = tailRequest;
+        const {response} = context;
+        if (response === undefined) {
+          throw new https.HttpsError('not-found', 'response is undefined');
+        }
 
-        let ws: WebSocket;
+        const {appID} = tailRequest;
+        const {cfScriptName: cfWorkerName, provider} = context.app;
+        const apiToken = getApiToken(provider);
+        const {accountID} = getDataOrFail(
+          await firestore
+            .doc(providerPath(provider))
+            .withConverter(providerDataConverter)
+            .get(),
+          'internal',
+          `Unknown provider "${provider}" for App ${appID} `,
+        );
+
+        const filters = {filters: []};
+        const debug = true;
+        const packageVersion = packageJson.version || '0.0.0';
+
+        let createTailResult;
         try {
-          ws = createTail(
-            app,
-            roomID,
-            REFLECT_AUTH_API_KEY,
-            `${userAgent.type}/${userAgent.version}`,
+          createTailResult = await createTail(
+            new GlobalScript(
+              {apiToken: await apiToken, accountID},
+              cfWorkerName,
+            ),
+            filters,
+            debug,
+            packageVersion,
           );
         } catch (e) {
           throw new HttpsError('internal', `Failed to connect to backend`, e);
@@ -53,6 +77,10 @@ export const tail = (
           'Content-Type': 'text/event-stream',
         });
         response.flushHeaders();
+
+        const {ws, expiration, deleteTail} = createTailResult;
+        // TODO(arv): Do we need to deal with the expiration?
+        logger.log(`tail expiration: ${expiration}`);
 
         try {
           loop: for await (const item of wsQueue(ws, 10_000)) {
@@ -67,53 +95,29 @@ export const tail = (
                 break loop;
             }
           }
-        } catch (e) {
-          logger.info(
-            'Got exception from tail websocket',
-            e,
-            'forwarding error to SSE',
-          );
-          writeEvent(response, 'error', hasStringMessage(e) ? e.message : '');
         } finally {
-          ws.close();
+          await deleteTail();
         }
         response.end();
       }),
   );
-
-function hasStringMessage(v: unknown): v is {message: string} {
-  return (
-    typeof v === 'object' &&
-    v !== null &&
-    'message' in v &&
-    typeof v.message === 'string'
-  );
-}
 
 type QueueItem =
   | {type: 'data'; data: string}
   | {type: 'ping'}
   | {type: 'close'};
 
-function dataAsString(e: WebSocket.MessageEvent): string {
-  const {data} = e;
-  if (typeof data === 'string') {
-    return data;
-  }
-  assert(data instanceof Buffer);
-  return data.toString('utf-8');
-}
-
 function wsQueue(
   ws: WebSocket,
   pingInterval: number,
 ): AsyncIterable<QueueItem> {
   const q = new Queue<QueueItem>();
-  ws.onmessage = e => {
-    void q.enqueue({type: 'data', data: dataAsString(e)});
+  ws.onmessage = ({data}) => {
+    assert(data instanceof Buffer);
+    void q.enqueue({type: 'data', data: data.toString('utf-8')});
   };
 
-  ws.onerror = e => void q.enqueueRejection(e);
+  ws.onerror = event => void q.enqueueRejection(event);
   ws.onclose = () => {
     void q.enqueue({type: 'close'});
   };
@@ -143,33 +147,10 @@ const partialRecordSchema = v.object({
   ),
 });
 
-function writeData(response: Response, data: string) {
+export function writeData(response: Response, data: string) {
   const cfLogRecord = JSON.parse(data);
   const logRecords = v.parse(cfLogRecord, partialRecordSchema, 'strip');
   for (const rec of logRecords.logs) {
     response.write(`data: ${JSON.stringify(rec)}\n\n`);
   }
-}
-
-function writeEvent(response: Response, event: string, data: string) {
-  response.write(`event: ${event}\n`);
-  response.write(`data: ${data}\n\n`);
-}
-
-function createTailDefault(
-  app: App,
-  roomID: string,
-  reflectAPIToken: string,
-  packageVersion: string,
-): WebSocket {
-  const {hostname} = must(app.runningDeployment).spec;
-
-  const websocketUrl = `wss://${hostname}/api/debug/v0/tail?roomID=${encodeURIComponent(
-    roomID,
-  )}`;
-  return new WebSocket(websocketUrl, reflectAPIToken, {
-    headers: {
-      'User-Agent': `reflect/${packageVersion}`,
-    },
-  });
 }

--- a/mirror/reflect-cli/src/tail/index.ts
+++ b/mirror/reflect-cli/src/tail/index.ts
@@ -6,12 +6,7 @@ import type {CommonYargsArgv, YargvToInterface} from '../yarg-types.js';
 import {TailMessage, createTailEventSource} from './tail-event-source.js';
 
 export function tailOptions(yargs: CommonYargsArgv) {
-  return yargs.option('room-id', {
-    describe: 'The room ID of the room to tail',
-    type: 'string',
-    requiresArg: true,
-    demandOption: true,
-  });
+  return yargs;
 }
 
 type TailHandlerArgs = YargvToInterface<ReturnType<typeof tailOptions>>;
@@ -20,12 +15,10 @@ export async function tailHandler(yargs: TailHandlerArgs) {
   const {appID} = await ensureAppInstantiated(yargs);
   const {userID, getIdToken} = await authenticate(yargs);
   const idToken = await getIdToken();
-  const {roomId: roomID} = yargs;
 
   const data: TailRequest = {
     requester: makeRequester(userID),
     appID,
-    roomID,
   };
 
   const tailEventSource = createTailEventSource(
@@ -35,16 +28,8 @@ export async function tailHandler(yargs: TailHandlerArgs) {
     data,
   );
 
-  try {
-    console.log(`Connecting to room ${roomID} to tail log...`);
-    for await (const entry of tailEventSource) {
-      logTailMessage(entry);
-    }
-  } catch (e) {
-    if (e instanceof Error) {
-      console.error(e.message);
-      process.exit(1);
-    }
+  for await (const entry of tailEventSource) {
+    logTailMessage(entry);
   }
 }
 


### PR DESCRIPTION
This reverts commit e3e7513aaebfe4c0503419babad5910943512a0a.

We'll probably need to create a separate function/endpoint to run the new tail on while customers are still running old versions of reflect-cli that don't send the roomID.

https://rocicorp.slack.com/archives/C013XFG80JC/p1695774747406189