### PR TITLE
feat(reflect-cli): export the new tail backend at the room-tail endpoint

### DIFF
--- a/mirror/mirror-protocol/src/tail.ts
+++ b/mirror/mirror-protocol/src/tail.ts
@@ -3,7 +3,20 @@ import * as v from 'shared/src/valita.js';
 import {baseAppRequestFields} from './app.js';
 import {baseResponseFields} from './base.js';
 
-export const tailRequestSchema = v.object(baseAppRequestFields);
+export const roomTailRequestSchema = v.object({
+  ...baseAppRequestFields,
+  roomID: v.string(),
+});
+
+export type RoomTailRequest = v.Infer<typeof roomTailRequestSchema>;
+
+export const roomTailResponseSchema = v.object(baseResponseFields);
+
+export type RoomTailResponse = v.Infer<typeof roomTailResponseSchema>;
+
+export const tailRequestSchema = v.object({
+  ...baseAppRequestFields,
+});
 
 export type TailRequest = v.Infer<typeof tailRequestSchema>;
 

--- a/mirror/mirror-server/src/functions/app/secrets.ts
+++ b/mirror/mirror-server/src/functions/app/secrets.ts
@@ -1,8 +1,8 @@
+import {SecretManagerServiceClient} from '@google-cloud/secret-manager';
 import {defineSecret} from 'firebase-functions/params';
 import type {DeploymentSecrets} from 'mirror-schema/src/deployment.js';
 import {assert} from 'shared/src/asserts.js';
 import {sha256OfString} from 'shared/src/sha256.js';
-import {SecretManagerServiceClient} from '@google-cloud/secret-manager';
 import {projectId} from '../../config/index.js';
 
 export function defineSecretSafely(name: string) {
@@ -31,6 +31,9 @@ export function defineSecretSafely(name: string) {
 const datadogLogsApiKey = defineSecretSafely('DATADOG_LOGS_API_KEY');
 const datadogMetricsApiKey = defineSecretSafely('DATADOG_METRICS_API_KEY');
 
+// TODO(darick): Replace with a stable per-app secret.
+export const REFLECT_AUTH_API_KEY = 'dummy-api-key';
+
 export const DEPLOYMENT_SECRETS_NAMES = [
   'DATADOG_LOGS_API_KEY',
   'DATADOG_METRICS_API_KEY',
@@ -38,22 +41,18 @@ export const DEPLOYMENT_SECRETS_NAMES = [
 
 export async function getAppSecrets() {
   const secrets: DeploymentSecrets = {
-    /* eslint-disable @typescript-eslint/naming-convention */
-    REFLECT_AUTH_API_KEY: 'dummy-api-key', // TODO(darick): Replace with a stable per-app secret.
-    DATADOG_LOGS_API_KEY: datadogLogsApiKey.value(),
-    DATADOG_METRICS_API_KEY: datadogMetricsApiKey.value(),
-    /* eslint-enable @typescript-eslint/naming-convention */
+    ['REFLECT_AUTH_API_KEY']: REFLECT_AUTH_API_KEY,
+    ['DATADOG_LOGS_API_KEY']: datadogLogsApiKey.value(),
+    ['DATADOG_METRICS_API_KEY']: datadogMetricsApiKey.value(),
   };
   const hashes = await hashSecrets(secrets);
   return {secrets, hashes};
 }
 
 export const NULL_SECRETS: DeploymentSecrets = {
-  /* eslint-disable @typescript-eslint/naming-convention */
-  REFLECT_AUTH_API_KEY: '',
-  DATADOG_LOGS_API_KEY: '',
-  DATADOG_METRICS_API_KEY: '',
-  /* eslint-enable @typescript-eslint/naming-convention */
+  ['REFLECT_AUTH_API_KEY']: '',
+  ['DATADOG_LOGS_API_KEY']: '',
+  ['DATADOG_METRICS_API_KEY']: '',
 } as const;
 
 export async function hashSecrets(

--- a/mirror/mirror-server/src/functions/room/index.ts
+++ b/mirror/mirror-server/src/functions/room/index.ts
@@ -1,0 +1,1 @@
+export {tail} from './tail.handler.js';

--- a/mirror/mirror-server/src/functions/room/tail.handler.test.ts
+++ b/mirror/mirror-server/src/functions/room/tail.handler.test.ts
@@ -1,0 +1,177 @@
+import type {Firestore} from '@google-cloud/firestore';
+import {getMockReq, getMockRes} from '@jest-mock/express';
+import {beforeEach, describe, expect, jest, test} from '@jest/globals';
+import type {Auth} from 'firebase-admin/auth';
+import type {https} from 'firebase-functions/v2';
+import {
+  fakeFirestore,
+  setApp,
+  setProvider,
+  setUser,
+} from 'mirror-schema/src/test-helpers.js';
+import {sleep} from 'shared/src/sleep.js';
+import type WebSocket from 'ws';
+import {mockFunctionParamsAndSecrets} from '../../test-helpers.js';
+import {mockApiTokenForProvider} from '../app/secrets.js';
+import {tail} from './tail.handler.js';
+
+export class MockSocket {
+  readonly url: string | URL;
+  protocol: string;
+  messages: string[] = [];
+  closed = false;
+  onUpstream?: (message: string) => void;
+  onclose?: (event: WebSocket.CloseEvent) => void;
+  onerror?: (event: WebSocket.ErrorEvent) => void;
+  onmessage?: (event: WebSocket.MessageEvent) => void;
+  constructor(url: string | URL, protocol = '') {
+    this.url = url;
+    this.protocol = protocol;
+  }
+  message(message: string) {
+    this.onmessage?.({
+      data: Buffer.from(message, 'utf8'),
+      type: 'message',
+      target: this as unknown as WebSocket,
+    });
+  }
+  send(message: string) {
+    this.messages.push(message);
+    this.onUpstream?.(message);
+  }
+
+  close() {
+    this.closed = true;
+    const closeEvent = {
+      code: 1000,
+      reason: 'mock close',
+      wasClean: true,
+      target: this as unknown as WebSocket,
+      type: 'close',
+    };
+    this.onclose?.(closeEvent);
+  }
+}
+
+mockFunctionParamsAndSecrets();
+
+describe('test tail', () => {
+  let firestore: Firestore & firebase.default.firestore.Firestore;
+  let auth: Auth;
+  let wsMock: MockSocket;
+  let createTailFunction: (
+    req: https.Request,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    res: any,
+  ) => void | Promise<void>;
+  let createTailMockPromise: Promise<void>;
+  let createTailResolver: () => void;
+
+  beforeEach(async () => {
+    firestore = fakeFirestore();
+    wsMock = new MockSocket('wss://example.com');
+
+    auth = {
+      verifyIdToken: jest
+        .fn()
+        .mockImplementation(() => Promise.resolve({uid: 'foo'})),
+    } as unknown as Auth;
+
+    createTailMockPromise = new Promise<void>(resolve => {
+      createTailResolver = resolve;
+    });
+
+    const createTailMock = () => {
+      setTimeout(createTailResolver, 0);
+      return wsMock as unknown as WebSocket;
+    };
+
+    createTailFunction = tail(firestore, auth, createTailMock);
+    await setUser(firestore, 'foo', 'foo@bar.com', 'bob', {fooTeam: 'admin'});
+    await setApp(firestore, 'myApp', {
+      teamID: 'fooTeam',
+      name: 'MyAppName',
+      provider: 'tail-test-provider',
+    });
+    await setProvider(firestore, 'tail-test-provider', {});
+    mockApiTokenForProvider('tail-test-provider');
+  });
+
+  const getRequestWithHeaders = (): https.Request =>
+    getMockReq({
+      body: {
+        requester: {
+          userID: 'foo',
+          userAgent: {type: 'reflect-cli', version: '0.0.1'},
+        },
+        appID: 'myApp',
+        roomID: 'myRoom',
+      },
+      headers: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        Authorization: 'Bearer this-is-the-encoded-token',
+      },
+    }) as unknown as https.Request;
+
+  test('valid auth in header', async () => {
+    const req = getRequestWithHeaders();
+
+    const {res} = getMockRes();
+    req.res = res;
+    const createTailPromise = createTailFunction(req, res);
+    await createTailMockPromise;
+    wsMock.close();
+    await createTailPromise;
+    expect(auth.verifyIdToken).toBeCalledWith('this-is-the-encoded-token');
+  });
+
+  test('handle message', async () => {
+    const req = getRequestWithHeaders();
+
+    const {res} = getMockRes();
+    req.res = res;
+    const createTailPromise = createTailFunction(req, res);
+    await createTailMockPromise;
+    wsMock.message(
+      JSON.stringify({
+        outcome: 'ok',
+        scriptName: 'arv-cli-test-1',
+        diagnosticsChannelEvents: [],
+        exceptions: [],
+        logs: [
+          {
+            message: [
+              'component=Worker',
+              'scheduled=ry5fw9fphyb',
+              'Handling scheduled event',
+            ],
+            level: 'info',
+            timestamp: 1691593226241,
+          },
+          {
+            message: [
+              'component=Worker',
+              'scheduled=ry5fw9fphyb',
+              'Returning early because REFLECT_AUTH_API_KEY is not defined in env.',
+            ],
+            level: 'debug',
+            timestamp: 1691593226241,
+          },
+        ],
+        eventTimestamp: 1691593226234,
+        event: {
+          cron: '* /5 * * * *',
+          scheduledTime: 1691593225000,
+        },
+      }),
+    );
+    await sleep(1);
+    expect(res.write).toBeCalledTimes(2);
+    expect(req.res.write).toBeCalledWith(
+      `data: {"message":["component=Worker","scheduled=ry5fw9fphyb","Returning early because REFLECT_AUTH_API_KEY is not defined in env."],"level":"debug","timestamp":1691593226241}\n\n`,
+    );
+    wsMock.close();
+    await createTailPromise;
+    expect(auth.verifyIdToken).toBeCalledWith('this-is-the-encoded-token');
+  });
+});

--- a/mirror/mirror-server/src/functions/room/tail.handler.ts
+++ b/mirror/mirror-server/src/functions/room/tail.handler.ts
@@ -1,0 +1,175 @@
+import type {Response} from 'express';
+import type {Auth} from 'firebase-admin/auth';
+import type {Firestore} from 'firebase-admin/firestore';
+import {logger} from 'firebase-functions';
+import {HttpsError, onRequest} from 'firebase-functions/v2/https';
+import {roomTailRequestSchema} from 'mirror-protocol/src/tail.js';
+import type {App} from 'mirror-schema/src/app.js';
+import assert from 'node:assert';
+import {jsonSchema} from 'reflect-protocol';
+import {must} from 'shared/src/must.js';
+import {Queue} from 'shared/src/queue.js';
+import * as v from 'shared/src/valita.js';
+import WebSocket from 'ws';
+import {
+  appAuthorization,
+  tokenAuthentication,
+  userAuthorization,
+} from '../validators/auth.js';
+import {validateRequest} from '../validators/schema.js';
+import {REFLECT_AUTH_API_KEY} from '../app/secrets.js';
+
+export const tail = (
+  firestore: Firestore,
+  auth: Auth,
+  createTail = createTailDefault,
+) =>
+  onRequest(
+    validateRequest(roomTailRequestSchema)
+      .validate(tokenAuthentication(auth))
+      .validate(userAuthorization())
+      .validate(appAuthorization(firestore))
+      .handle(async (tailRequest, context) => {
+        const {response, app} = context;
+        const {
+          roomID,
+          requester: {userAgent},
+        } = tailRequest;
+
+        let ws: WebSocket;
+        try {
+          ws = createTail(
+            app,
+            roomID,
+            REFLECT_AUTH_API_KEY,
+            `${userAgent.type}/${userAgent.version}`,
+          );
+        } catch (e) {
+          throw new HttpsError('internal', `Failed to connect to backend`, e);
+        }
+
+        response.writeHead(200, {
+          'Cache-Control': 'no-store',
+          'Content-Type': 'text/event-stream',
+        });
+        response.flushHeaders();
+
+        try {
+          loop: for await (const item of wsQueue(ws, 10_000)) {
+            switch (item.type) {
+              case 'data':
+                writeData(response, item.data);
+                break;
+              case 'ping':
+                response.write('\n\n');
+                break;
+              case 'close':
+                break loop;
+            }
+          }
+        } catch (e) {
+          logger.info(
+            'Got exception from tail websocket',
+            e,
+            'forwarding error to SSE',
+          );
+          writeEvent(response, 'error', hasStringMessage(e) ? e.message : '');
+        } finally {
+          ws.close();
+        }
+        response.end();
+      }),
+  );
+
+function hasStringMessage(v: unknown): v is {message: string} {
+  return (
+    typeof v === 'object' &&
+    v !== null &&
+    'message' in v &&
+    typeof v.message === 'string'
+  );
+}
+
+type QueueItem =
+  | {type: 'data'; data: string}
+  | {type: 'ping'}
+  | {type: 'close'};
+
+function dataAsString(e: WebSocket.MessageEvent): string {
+  const {data} = e;
+  if (typeof data === 'string') {
+    return data;
+  }
+  assert(data instanceof Buffer);
+  return data.toString('utf-8');
+}
+
+function wsQueue(
+  ws: WebSocket,
+  pingInterval: number,
+): AsyncIterable<QueueItem> {
+  const q = new Queue<QueueItem>();
+  ws.onmessage = e => {
+    void q.enqueue({type: 'data', data: dataAsString(e)});
+  };
+
+  ws.onerror = e => void q.enqueueRejection(e);
+  ws.onclose = () => {
+    void q.enqueue({type: 'close'});
+  };
+
+  const pingTimer = setInterval(
+    () => void q.enqueue({type: 'ping'}),
+    pingInterval,
+  );
+
+  function cleanup() {
+    clearInterval(pingTimer);
+    ws.close();
+  }
+
+  return {
+    [Symbol.asyncIterator]: () => q.asAsyncIterator(cleanup),
+  };
+}
+
+const partialRecordSchema = v.object({
+  logs: v.array(
+    v.object({
+      message: jsonSchema,
+      level: v.string(),
+      timestamp: v.number(),
+    }),
+  ),
+});
+
+function writeData(response: Response, data: string) {
+  const cfLogRecord = JSON.parse(data);
+  const logRecords = v.parse(cfLogRecord, partialRecordSchema, 'strip');
+  for (const rec of logRecords.logs) {
+    response.write(`data: ${JSON.stringify(rec)}\n\n`);
+  }
+}
+
+function writeEvent(response: Response, event: string, data: string) {
+  response.write(`event: ${event}\n`);
+  response.write(`data: ${data}\n\n`);
+}
+
+function createTailDefault(
+  app: App,
+  roomID: string,
+  reflectAPIToken: string,
+  packageVersion: string,
+): WebSocket {
+  const {hostname} = must(app.runningDeployment).spec;
+
+  const websocketUrl = `wss://${hostname}/api/debug/v0/tail?roomID=${encodeURIComponent(
+    roomID,
+  )}`;
+  return new WebSocket(websocketUrl, reflectAPIToken, {
+    headers: {
+      'User-Agent': `reflect/${packageVersion}`,
+    },
+  });
+}

--- a/mirror/mirror-server/src/index.ts
+++ b/mirror/mirror-server/src/index.ts
@@ -10,6 +10,7 @@ import {
   serviceAccountId,
 } from './config/index.js';
 import * as appFunctions from './functions/app/index.js';
+import * as roomFunctions from './functions/room/index.js';
 import * as serverFunctions from './functions/server/index.js';
 import * as teamFunctions from './functions/team/index.js';
 import * as userFunctions from './functions/user/index.js';
@@ -50,6 +51,17 @@ export const app = {
     appFunctions.tail(getFirestore(), getAuth()),
   ),
   delete: https.onCall(baseHttpsOptions, appFunctions.delete(getFirestore())),
+};
+
+export const room = {
+  tail: https.onRequest(
+    {
+      timeoutSeconds: 3600,
+      ...baseHttpsOptions,
+      secrets: [...DEPLOYMENT_SECRETS_NAMES],
+    },
+    roomFunctions.tail(getFirestore(), getAuth()),
+  ),
 };
 
 export const server = {

--- a/mirror/reflect-cli/src/tail/tail-event-source.ts
+++ b/mirror/reflect-cli/src/tail/tail-event-source.ts
@@ -65,27 +65,23 @@ async function* createIter<R extends BaseRequest>(
     throw new Error(`HTTP ${response.status} ${response.statusText}`);
   }
 
+  console.log('Connected.');
+
   assert(response.body);
   const reader = response.body
     .pipeThrough(new TextDecoderStream())
     .pipeThrough(lineByLineStream())
     .pipeThrough(eventSourceStream());
   try {
-    for await (const entry of messagesAsJSON(
-      reader as unknown as AsyncIterable<EventSourceEntry>,
-    )) {
-      yield entry;
+    for await (const entry of reader as unknown as AsyncIterable<EventSourceEntry>) {
+      if (entry.event === 'message') {
+        const v = JSON.parse(entry.data);
+        yield valita.parse(v, messageSchema, 'passthrough');
+      } else if (entry.event === 'error') {
+        throw new Error(entry.data);
+      }
     }
   } finally {
     abortController.abort();
-  }
-}
-
-async function* messagesAsJSON(eventSource: AsyncIterable<EventSourceEntry>) {
-  for await (const entry of eventSource) {
-    if (entry.event === 'message') {
-      const v = JSON.parse(entry.data);
-      yield valita.parse(v, messageSchema, 'passthrough');
-    }
   }
 }


### PR DESCRIPTION
Rolls forward @arv's new tail backend as a separate `room-tail` cloud function, keeping the old `app-tail` backend and behavior intact for now. The `reflect-cli` connects to the `room-tail` function.

Separately, we will figure out a strategy for migrating or deprecating old reflect-cli clients.