### PR TITLE
feat(reflect-client): Add enableAnalytics option

### DIFF
--- a/packages/reflect-client/src/client/log-options.test.ts
+++ b/packages/reflect-client/src/client/log-options.test.ts
@@ -22,6 +22,22 @@ teardown(() => {
   sinon.restore();
 });
 
+function testEnableAnalyticsFalse(socketOrigin: string | null) {
+  test(`socketOrigin ${socketOrigin}, enableAnalytics false`, () => {
+    const {logLevel, logSink} = createLogOptions(
+      {
+        consoleLogLevel: 'info',
+        socketOrigin,
+        enableAnalytics: false,
+      },
+      fakeCreateDatadogLogSink,
+    );
+    expect(fakeCreateDatadogLogSink.callCount).to.equal(0);
+    expect(logLevel).to.equal('info');
+    expect(logSink).to.equal(consoleLogSink);
+  });
+}
+
 suite('when socketOrigin indicates testing or local dev', () => {
   const cases: (string | null)[] = [
     null,
@@ -37,6 +53,7 @@ suite('when socketOrigin indicates testing or local dev', () => {
         {
           consoleLogLevel: 'info',
           socketOrigin: c,
+          enableAnalytics: true,
         },
         fakeCreateDatadogLogSink,
       );
@@ -44,6 +61,7 @@ suite('when socketOrigin indicates testing or local dev', () => {
       expect(logLevel).to.equal('info');
       expect(logSink).to.equal(consoleLogSink);
     });
+    testEnableAnalyticsFalse(c);
   }
 });
 
@@ -61,6 +79,7 @@ function testLogLevels(
       {
         consoleLogLevel: 'debug',
         socketOrigin,
+        enableAnalytics: true,
       },
       fakeCreateDatadogLogSink,
     );
@@ -117,6 +136,7 @@ function testLogLevels(
       {
         consoleLogLevel: 'info',
         socketOrigin,
+        enableAnalytics: true,
       },
       fakeCreateDatadogLogSink,
     );
@@ -164,6 +184,7 @@ function testLogLevels(
       {
         consoleLogLevel: 'error',
         socketOrigin,
+        enableAnalytics: true,
       },
       fakeCreateDatadogLogSink,
     );
@@ -201,17 +222,21 @@ function testLogLevels(
 }
 
 suite('when socketOrigin is subdomain of .reflect-server.net', () => {
+  const socketOrigin = 'wss://testSubdomain.reflect-server.net';
   testLogLevels(
-    'wss://testSubdomain.reflect-server.net',
+    socketOrigin,
     'testsubdomain',
     'https://testsubdomain.reflect-server.net/api/logs/v0/log',
   );
+  testEnableAnalyticsFalse(socketOrigin);
 });
 
 suite('when socketOrigin is not a subdomain of .reflect-server.net', () => {
+  const socketOrigin = 'wss://fooBar.FuzzyWuzzy.com';
   testLogLevels(
-    'wss://fooBar.FuzzyWuzzy.com',
+    socketOrigin,
     'foobar.fuzzywuzzy.com',
     'https://foobar.fuzzywuzzy.com/api/logs/v0/log',
   );
+  testEnableAnalyticsFalse(socketOrigin);
 });

--- a/packages/reflect-client/src/client/log-options.ts
+++ b/packages/reflect-client/src/client/log-options.ts
@@ -55,12 +55,13 @@ export function createLogOptions(
   options: {
     consoleLogLevel: LogLevel;
     socketOrigin: string | null;
+    enableAnalytics: boolean;
   },
   createDatadogLogSink: (options: DatadogLogSinkOptions) => LogSink = (
     options: DatadogLogSinkOptions,
   ) => new DatadogLogSink(options),
 ): LogOptions {
-  const {consoleLogLevel, socketOrigin} = options;
+  const {consoleLogLevel, socketOrigin, enableAnalytics} = options;
   const socketOriginURL = socketOrigin === null ? null : new URL(socketOrigin);
   const socketHostname = socketOriginURL?.hostname;
 
@@ -71,7 +72,8 @@ export function createLogOptions(
     socketOrigin === null ||
     socketHostname === undefined ||
     socketHostname === 'localhost' ||
-    IP_ADDRESS_HOSTNAME_REGEX.test(socketHostname)
+    IP_ADDRESS_HOSTNAME_REGEX.test(socketHostname) ||
+    !enableAnalytics
   ) {
     return {
       logLevel: consoleLogLevel,

--- a/packages/reflect-client/src/client/options.ts
+++ b/packages/reflect-client/src/client/options.ts
@@ -161,6 +161,14 @@ export interface ReflectOptions<MD extends MutatorDefs> {
   hiddenTabDisconnectDelay?: number | undefined;
 
   /**
+   * Help Reflect improve its service by automatically sending diagnostic and
+   * usage data.
+   *
+   * Default is true.
+   */
+  enableAnalytics?: boolean | undefined;
+
+  /**
    * Determines what kind of storage implementation to use on the client.
    *
    * Defaults to `'mem'` which means that Reflect uses an in memory storage and

--- a/packages/reflect-client/src/client/reflect.test.ts
+++ b/packages/reflect-client/src/client/reflect.test.ts
@@ -811,11 +811,31 @@ test('Metrics', async () => {
     await r.triggerPong();
   }
 
-  fetchStub.calledOnceWithExactly('https://example.com/api/metrics/v0/report', {
-    method: 'POST',
-    body: '{"series":[{"metric":"time_to_connect_ms","points":[[120,[0]]]}]}',
-    keepalive: true,
-  });
+  expect(
+    fetchStub.calledWithMatch(
+      sinon.match(new RegExp('^https://example.com/api/metrics/v0/report?.*')),
+    ),
+  ).to.be.true;
+});
+
+test('Metrics not reported when enableAnalytics is false', async () => {
+  const fetchStub = sinon.stub(window, 'fetch');
+
+  const r = reflectForTest({enableAnalytics: false});
+  await r.waitForConnectionState(ConnectionState.Connecting);
+  await r.triggerConnected();
+  await r.waitForConnectionState(ConnectionState.Connected);
+
+  for (let t = 0; t < REPORT_INTERVAL_MS; t += PING_INTERVAL_MS) {
+    await clock.tickAsync(PING_INTERVAL_MS);
+    await r.triggerPong();
+  }
+
+  expect(
+    fetchStub.calledWithMatch(
+      sinon.match(new RegExp('^https://example.com/api/metrics/v0/report?.*')),
+    ),
+  ).to.be.false;
 });
 
 test('Authentication', async () => {

--- a/packages/reflect-client/src/client/reflect.ts
+++ b/packages/reflect-client/src/client/reflect.ts
@@ -297,6 +297,7 @@ export class Reflect<MD extends MutatorDefs> {
       onOnlineChange,
       jurisdiction,
       hiddenTabDisconnectDelay = DEFAULT_DISCONNECT_HIDDEN_DELAY_MS,
+      enableAnalytics = true,
     } = options;
     if (!userID) {
       throw new Error('ReflectOptions.userID must not be empty.');
@@ -326,6 +327,7 @@ export class Reflect<MD extends MutatorDefs> {
     this.#logOptions = this.#createLogOptions({
       consoleLogLevel: options.logLevel ?? 'error',
       socketOrigin,
+      enableAnalytics,
     });
     const logOptions = this.#logOptions;
 
@@ -373,7 +375,9 @@ export class Reflect<MD extends MutatorDefs> {
       reportIntervalMs: REPORT_INTERVAL_MS,
       host: location.host,
       source: 'client',
-      reporter: allSeries => this.#reportMetrics(allSeries),
+      reporter: enableAnalytics
+        ? allSeries => this.#reportMetrics(allSeries)
+        : () => Promise.resolve(),
       lc: this.#l,
     });
     this.#metrics.tags.push(`version:${this.version}`);
@@ -411,6 +415,7 @@ export class Reflect<MD extends MutatorDefs> {
   #createLogOptions(options: {
     consoleLogLevel: LogLevel;
     socketOrigin: string | null;
+    enableAnalytics: boolean;
   }): LogOptions {
     if (TESTING) {
       return forTesting(this)[createLogOptionsSymbol](options);


### PR DESCRIPTION
enableAnalytics defaults to true.

When set to false datadog logging and metrics are disabled.