### PR TITLE
feat(reflect-cli): cli self deprecation and publish version check

### DIFF
--- a/mirror/reflect-cli/src/init.ts
+++ b/mirror/reflect-cli/src/init.ts
@@ -3,8 +3,9 @@ import {existsSync} from 'node:fs';
 import color from 'picocolors';
 import {configFileExists} from './app-config.js';
 import {logErrorAndExit, noFormat} from './log-error-and-exit.js';
-import {copyTemplate, findReflectVersion} from './scaffold.js';
+import {copyTemplate} from './scaffold.js';
 import type {CommonYargsArgv, YargvToInterface} from './yarg-types.js';
+import {findReflectVersion} from './version.js';
 
 export function initOptions(yargs: CommonYargsArgv) {
   return yargs;

--- a/mirror/reflect-cli/src/publish.ts
+++ b/mirror/reflect-cli/src/publish.ts
@@ -17,6 +17,7 @@ import {findServerVersionRange} from './find-reflect-server-version.js';
 import {Firestore, getFirestore} from './firebase.js';
 import {makeRequester} from './requester.js';
 import type {CommonYargsArgv, YargvToInterface} from './yarg-types.js';
+import {checkForServerDeprecation} from './version.js';
 
 export function publishOptions(yargs: CommonYargsArgv) {
   return yargs;
@@ -48,6 +49,7 @@ export async function publishHandler(
   }
 
   const range = await findServerVersionRange(absPath);
+  await checkForServerDeprecation(yargs, range);
   const serverVersionRange = range.raw;
 
   console.log(`Compiling ${script}`);

--- a/mirror/reflect-cli/src/scaffold.ts
+++ b/mirror/reflect-cli/src/scaffold.ts
@@ -1,11 +1,8 @@
 import fs, {existsSync} from 'node:fs';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
-import {readFile} from 'node:fs/promises';
-import {pkgUp} from 'pkg-up';
-import {assert, assertObject, assertString} from 'shared/src/asserts.js';
 import {writeTemplatedFilePlaceholders} from './app-config.js';
-import {execSync} from 'node:child_process';
+import {findReflectVersion} from './version.js';
 
 const templateDir = (templateName: string) =>
   path.resolve(
@@ -53,24 +50,4 @@ function copyDir(srcDir: string, destDir: string) {
     const destFile = path.resolve(destDir, file);
     copy(srcFile, destFile);
   }
-}
-
-export async function findReflectVersion(): Promise<string> {
-  const pkgDir = fileURLToPath(import.meta.url);
-  if (pkgDir.indexOf('/node_module') < 0) {
-    const version = execSync('npm view @rocicorp/reflect dist-tags.latest')
-      .toString()
-      .trim();
-    console.log(
-      `reflect-cli run from source. Using @rocicorp/reflect@latest version ${version}.`,
-    );
-    return version;
-  }
-  const pkg = await pkgUp({cwd: pkgDir});
-  assert(pkg);
-  const s = await readFile(pkg, 'utf-8');
-  const v = JSON.parse(s);
-  assertObject(v);
-  assertString(v.version);
-  return v.version;
 }

--- a/mirror/reflect-cli/src/version.ts
+++ b/mirror/reflect-cli/src/version.ts
@@ -1,5 +1,16 @@
 // TODO(arv): Use esbuild define instead.
 import packageJSON from '../package.json' assert {type: 'json'};
+import color from 'picocolors';
+import {exec} from 'node:child_process';
+import {resolver} from '@rocicorp/resolver';
+import {Range, SemVer, gt, gtr} from 'semver';
+import type {ArgumentsCamelCase} from 'yargs';
+import type {CommonYargsArgv, YargvToInterface} from './yarg-types.js';
+import {fileURLToPath} from 'node:url';
+import path from 'node:path';
+import {assert, assertObject, assertString} from 'shared/src/asserts.js';
+import {pkgUp} from 'pkg-up';
+import {readFile} from 'node:fs/promises';
 
 export const {version} = packageJSON;
 
@@ -9,3 +20,136 @@ export const userAgent = {
 } as const;
 
 export type UserAgent = typeof userAgent;
+
+const enum DistTag {
+  Latest = 'latest',
+  MinSupported = 'sup',
+  MinNonDeprecated = 'rec',
+}
+
+type DistTags = {[tag: string]: SemVer};
+
+// Run by yargs middleware. Stashes the DistTags in argv so that `npm view` is only run once.
+export async function tryDeprecationCheck(
+  argv: ArgumentsCamelCase,
+): Promise<void> {
+  try {
+    // Store the DistTags in argv so that it can be checked again if necessary.
+    argv._distTags = await checkForCliDeprecation();
+  } catch (e) {
+    console.warn(`Unable to check for deprecation. Proceeding anyway.`);
+  }
+}
+
+/**
+ * Extracts the DistTags stored in yargs during the deprecation check. In the case
+ * that the deprecation check failed, this will attempt to fetch the DistTags again
+ * and throw if still unsuccessful.
+ */
+function getOrRefetchDistTags(
+  yargs: YargvToInterface<CommonYargsArgv>,
+): Promise<DistTags> {
+  if (yargs._distTags) {
+    return Promise.resolve(yargs._distTags as DistTags);
+  }
+  // Use a longer, 30 second timeout when DistTags are needed to proceed.
+  return lookupDistTags(30000);
+}
+
+async function lookupDistTags(timeout: number): Promise<DistTags> {
+  const {promise: output, resolve, reject} = resolver<string>();
+  exec(
+    'npm view @rocicorp/reflect dist-tags --json',
+    {timeout},
+    (error, stdout) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve(stdout.toString().trim());
+      }
+    },
+  );
+  const distTags = JSON.parse(await output) as Record<string, string>;
+  return Object.fromEntries(
+    Object.entries(distTags).map(([tag, value]) => [tag, new SemVer(value)]),
+  );
+}
+
+export async function findReflectVersion(): Promise<string> {
+  const pkgDir = fileURLToPath(import.meta.url);
+  if (!pkgDir.includes('/node_module')) {
+    const reflectPkg = path.resolve(pkgDir, '../../../../', 'packages/reflect');
+    const pkg = await pkgUp({cwd: reflectPkg});
+    assert(pkg);
+    const s = await readFile(pkg, 'utf-8');
+    const v = JSON.parse(s);
+    assertObject(v);
+    assertString(v.version);
+    console.log(
+      `reflect-cli run from source. Using version from packages/reflect/package.json: ${v.version}.`,
+    );
+    return v.version;
+  }
+  return version;
+}
+
+async function checkForCliDeprecation(): Promise<DistTags> {
+  // Use a short, 3 second timeout to reduce delays if machine is offline (e.g. `reflect dev`).
+  const versions = await lookupDistTags(3000);
+  const minSupported = versions[DistTag.MinSupported];
+  const minNonDeprecated = versions[DistTag.MinNonDeprecated];
+  const latest = versions[DistTag.Latest];
+  const current = new SemVer(await findReflectVersion());
+  if (minSupported && gt(minSupported, current)) {
+    notifyUnsupported();
+  } else if (minNonDeprecated && gt(minNonDeprecated, current)) {
+    notifyDeprecated();
+  } else if (latest && gt(latest, current)) {
+    notifyLatest(latest, current.raw);
+  }
+  return versions;
+}
+
+export async function checkForServerDeprecation(
+  yargs: YargvToInterface<CommonYargsArgv>,
+  serverVersionRange: Range,
+): Promise<void> {
+  const versions = await getOrRefetchDistTags(yargs);
+  const minSupported = versions[DistTag.MinSupported];
+  const minNonDeprecated = versions[DistTag.MinNonDeprecated];
+  const latest = versions[DistTag.Latest];
+  if (minSupported && gtr(minSupported, serverVersionRange)) {
+    notifyUnsupported();
+  } else if (minNonDeprecated && gtr(minNonDeprecated, serverVersionRange)) {
+    notifyDeprecated();
+  } else if (latest && gtr(latest, serverVersionRange)) {
+    notifyLatest(latest, serverVersionRange.raw);
+  }
+}
+
+function notifyUnsupported() {
+  console.error(
+    `${color.red('This version of Reflect is no longer supported.')}\n` +
+      `Please update to ${color.bold('@rocicorp/reflect@latest')}.\n`,
+  );
+  process.exit(-1);
+}
+
+function notifyDeprecated() {
+  console.error(
+    `${color.yellow(
+      'Note: This version of Reflect is deprecated and will stop working soon.',
+    )}\n` + `Please update to ${color.bold('@rocicorp/reflect@latest')}.\n`,
+  );
+}
+
+function notifyLatest(latest: SemVer, current: string) {
+  console.error(
+    `${color.green(
+      `Tip: Reflect ${latest.version} is now available. Version ${current} is out of date.`,
+    )}\n` +
+      `For the latest features, update to ${color.bold(
+        '@rocicorp/reflect@latest',
+      )}.\n`,
+  );
+}


### PR DESCRIPTION
`reflect-cli` looks up dist-tags from `npm view @rocicorp/reflect` and checks its version against the following tags:
* `@latest`
* `@rec` (min non-deprecated)
* `@sup` (min-supported)

to notify the operator of opportunities to update.

<img width="677" alt="Screenshot 2023-09-28 at 1 10 37 PM" src="https://github.com/rocicorp/mono/assets/132324914/6f705b67-eddb-44f4-9a35-89d5ec8a0d2b">

In the case that the machine is offline, the deprecation check is skipped to allow the operator to perform offline actions like `reflect dev`.

An equivalent check is done on the `@rocicorp/reflect` dependency version range (e.g. `"^0.35.0"`) when the app is published. SemVer's version and range comparison API allows this logic to be essentially identical.

In practice, the cli and publish checks should be redundant, assuming that the user is running the cli from within the package, but it is not redundant in the case that the user is running `reflect` from a global instance, so both checks are warranted.

Slight change to `init` and `create`:
* When running from source, the version is retrieved from `packages/reflect/package.json` in the source tree rather than using @latest from `npm view`.

Fixes #1000