### PR TITLE
feat(mirror): App creation in, or migration to WFP

### DIFF
--- a/mirror/mirror-cli/src/index.ts
+++ b/mirror/mirror-cli/src/index.ts
@@ -51,6 +51,7 @@ import {
   configureProviderHandler,
   configureProviderOptions,
 } from './configure-provider.js';
+import {migrateToWFPHandler, migrateToWFPOptions} from './migrate-to-wfp.js';
 import {certificatesHandler, certificatesOptions} from './certificates.js';
 
 async function main(argv: string[]): Promise<void> {
@@ -111,6 +112,14 @@ function createCLIParser(argv: string[]) {
     'Configures a provider for hosting Workers.',
     configureProviderOptions,
     configureProviderHandler,
+  );
+
+  // wfp
+  reflectCLI.command(
+    'wfp <appID>',
+    'Migrates an App to Workers for Platforms',
+    migrateToWFPOptions,
+    migrateToWFPHandler,
   );
 
   // publish-custom-domain

--- a/mirror/mirror-cli/src/migrate-to-wfp.ts
+++ b/mirror/mirror-cli/src/migrate-to-wfp.ts
@@ -1,0 +1,107 @@
+import {getProviderConfig} from './cf.js';
+import {GlobalScript} from 'cloudflare-api/src/scripts.js';
+import type {CommonYargsArgv, YargvToInterface} from './yarg-types.js';
+import {
+  DocumentReference,
+  Firestore,
+  Timestamp,
+  getFirestore,
+} from 'firebase-admin/firestore';
+import {appPath, appDataConverter} from 'mirror-schema/src/app.js';
+import {
+  deploymentsCollection,
+  deploymentDataConverter,
+  Deployment,
+} from 'mirror-schema/src/deployment.js';
+import {watch} from 'mirror-schema/src/watch.js';
+
+export function migrateToWFPOptions(yargs: CommonYargsArgv) {
+  return yargs.positional('appID', {
+    desc: 'The id of the app to migrate',
+    type: 'string',
+    demandOption: true,
+  });
+}
+
+type MigrateToWFPArgs = YargvToInterface<
+  ReturnType<typeof migrateToWFPOptions>
+>;
+
+export async function migrateToWFPHandler(
+  yargs: MigrateToWFPArgs,
+): Promise<void> {
+  const {stack, appID} = yargs;
+  const firestore = getFirestore();
+  const appDoc = firestore.doc(appPath(appID)).withConverter(appDataConverter);
+  const app = (await appDoc.get()).data();
+  if (!app) {
+    throw new Error(
+      `App ${appID} not found. Did you specify the correct --stack?`,
+    );
+  }
+  const {scriptRef, cfScriptName: name} = app;
+  if (scriptRef) {
+    throw new Error(`App is already migrated to ${scriptRef.namespace}`);
+  }
+
+  // The old script must first be deleted because:
+  // - There is a naming collision bug in Cloudflare that prevents same-named scripts
+  //   (even across namespaces) from being created.
+  // - The CNAME for Custom Hostnames cannot be created if a Custom Domain already exists
+  //   for that hostname.
+  console.log(`Deleting script ${name} and any custom domains`);
+  const config = await getProviderConfig(yargs);
+  await new GlobalScript(config, name).delete();
+
+  const newScriptRef = {
+    namespace: stack === 'prod' ? 'prod' : 'sand',
+    name,
+  };
+
+  console.log(`Setting ScriptRef`, newScriptRef);
+  const {writeTime} = await appDoc.update({
+    scriptRef: newScriptRef,
+    forceRedeployment: true, // Needed because the scriptRef does not affect the DeploymentSpec.
+  });
+
+  const deployment = await getNewDeployment(firestore, appID, writeTime);
+  let lastStatus;
+  for await (const doc of watch(deployment)) {
+    const state = doc.data();
+    if (state === undefined) {
+      throw new Error(`Deployment deleted?`);
+    }
+    const {status, statusMessage} = state;
+    if (status !== lastStatus) {
+      console.info(
+        `Status: ${status}${statusMessage ? ': ' + statusMessage : ''}`,
+      );
+      lastStatus = status;
+    }
+    switch (status) {
+      case 'RUNNING':
+      case 'STOPPED':
+      case 'FAILED':
+        return;
+    }
+  }
+}
+
+async function getNewDeployment(
+  firestore: Firestore,
+  appID: string,
+  since: Timestamp,
+): Promise<DocumentReference<Deployment>> {
+  const newDeployments = firestore
+    .collection(deploymentsCollection(appID))
+    .withConverter(deploymentDataConverter)
+    .where('requestTime', '>', since);
+
+  console.log(`Watching new deployments ...`);
+  for await (const deployments of watch(newDeployments)) {
+    if (deployments.docs.length) {
+      return deployments.docs[0].ref;
+    }
+  }
+  throw new Error('impossible');
+}


### PR DESCRIPTION
**Note**: This does not yet enable WFP in general, but prepares for enabling it by default, and for migrating existing apps to it.

### Creating an app in Workers for Platforms

This happens automatically if the requesting `reflect-cli` agent is of a minimum version value. The value is set to "0.37.0" to be safe, but can be moved earlier if appropriate.

### Migrating an existing app to Workers for Platforms

The `mirror wfp` command will migrate an existing App to Workers for Platforms. This involves:
* Deleting the existing Worker (and all of its data).
* Setting the namespaced `scriptRef` field on the App and forcing a redeployment.

<img width="870" alt="Screenshot 2023-09-29 at 4 53 11 PM" src="https://github.com/rocicorp/mono/assets/132324914/89351473-9d11-4dd2-99cd-6d7adb1149e0">
