### PR TITLE
feat(mirror): attach mirror information to scripts using script tags

### DIFF
--- a/mirror/cloudflare-api/src/create-script-upload-form.ts
+++ b/mirror/cloudflare-api/src/create-script-upload-form.ts
@@ -293,6 +293,8 @@ export interface CfWorkerInit {
   logpush?: boolean | undefined;
   placement?: CfPlacement | undefined;
   tail_consumers?: CfTailConsumer[] | undefined;
+  // https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/platform/tags/
+  tags?: string[] | undefined;
 }
 
 // export interface CfWorkerContext {
@@ -404,6 +406,7 @@ export function createScriptUploadForm(worker: CfWorkerInit): FormData {
     logpush,
     placement,
     tail_consumers,
+    tags,
   } = worker;
 
   let {modules} = worker;
@@ -661,6 +664,7 @@ export function createScriptUploadForm(worker: CfWorkerInit): FormData {
     ...(logpush !== undefined && {logpush}),
     ...(placement && {placement}),
     ...(tail_consumers && {tail_consumers}),
+    ...(tags && {tags}),
   };
 
   if (bindings.unsafe?.metadata !== undefined) {

--- a/mirror/cloudflare-api/src/scripts.ts
+++ b/mirror/cloudflare-api/src/scripts.ts
@@ -132,6 +132,10 @@ export class NamespacedScript extends Script {
   readonly namespace: string;
   readonly productionEnvironment: GetOnlyFn<ScriptEnvironment>;
 
+  readonly getTags: GetOnlyFn<unknown>;
+  readonly putTag: SetOnlyFn<undefined>;
+  readonly deleteTag: DeleteFn<undefined>;
+
   constructor(
     {apiToken, accountID}: AccountAccess,
     {namespace, name}: NamespacedName,
@@ -147,6 +151,11 @@ export class NamespacedScript extends Script {
     this.id = `${namespace}/${name}`;
     this.namespace = namespace;
     this.productionEnvironment = this._script.get;
+
+    this.getTags = this._script.append('tags').get;
+    this.putTag = (tag, q) =>
+      this._script.append(`tags/${tag}`).put(undefined, q);
+    this.deleteTag = (tag, q) => this._script.append(`tags/${tag}`).delete(q);
   }
 }
 

--- a/mirror/mirror-server/src/cloudflare/publish.ts
+++ b/mirror/mirror-server/src/cloudflare/publish.ts
@@ -11,6 +11,7 @@ export async function uploadScript(
   mainModule: CfModule,
   modules: CfModule[],
   vars: CfVars,
+  tags: string[],
 ) {
   const cfMigrations = await getMigrationsToUpload(script, {
     config: {migrations},
@@ -33,6 +34,7 @@ export async function uploadScript(
     },
     modules,
     migrations: cfMigrations,
+    tags,
     // eslint-disable-next-line @typescript-eslint/naming-convention
     compatibility_date: '2023-05-18',
   });

--- a/mirror/mirror-server/src/functions/app/deploy.function.ts
+++ b/mirror/mirror-server/src/functions/app/deploy.function.ts
@@ -89,6 +89,7 @@ export async function runDeployment(
     cfScriptName,
     scriptRef,
     name: appName,
+    teamID,
     teamLabel,
   } = must(appDoc.data());
   const {
@@ -151,8 +152,8 @@ export async function runDeployment(
 
     for await (const deploymentUpdate of script.publish(
       storage,
-      appName,
-      teamLabel,
+      {id: appID, name: appName},
+      {id: teamID, label: teamLabel},
       hostname,
       options,
       secrets,


### PR DESCRIPTION
Adds `appID:...`, `appName:...`, `teamID:...`, and `teamLabel:...` tags to each script so that the information is available to script processes such as Tail Workers on [Event Bus](https://www.notion.so/replicache/Event-Bus-321e34570bda4f62a4bc3e47ce110e73#b3b87dfced33448684232b3388ab5163).

<img width="704" alt="Screenshot 2023-10-06 at 12 07 57 PM" src="https://github.com/rocicorp/mono/assets/132324914/6bd7e687-0ba3-421b-82ab-61dbb74db630">

<img width="974" alt="Screenshot 2023-10-06 at 12 10 29 PM" src="https://github.com/rocicorp/mono/assets/132324914/dcaad9fb-3529-4f1f-9731-b1344dc847ba">
