### PR TITLE
feat(mirror): auto-migrate to WFP with publishing a supported version

### DIFF
--- a/mirror/mirror-server/src/functions/app/create.function.ts
+++ b/mirror/mirror-server/src/functions/app/create.function.ts
@@ -30,7 +30,7 @@ import {validateSchema} from '../validators/schema.js';
 import {userAgentVersion, DistTags} from '../validators/version.js';
 import type {UserAgent} from 'mirror-protocol/src/user-agent.js';
 import {DistTag} from 'mirror-protocol/src/version.js';
-import {SemVer, gte, gt} from 'semver';
+import {SemVer, gte, gt, coerce} from 'semver';
 
 export const create = (firestore: Firestore, testDistTags?: DistTags) =>
   validateSchema(createRequestSchema, createResponseSchema)
@@ -163,7 +163,8 @@ function supportsWorkersForPlatforms(userAgent: UserAgent): boolean {
       'Please use @rocicorp/reflect to create and publish apps.',
     );
   }
-  if (gte(new SemVer(version), MIN_WFP_VERSION)) {
+  // coerce to treat pre-releases equally.
+  if (gte(coerce(version) ?? version, MIN_WFP_VERSION)) {
     logger.info(`Creating WFP app for reflect-cli v${version}`);
     return true;
   }

--- a/mirror/mirror-server/src/functions/app/deploy.function.test.ts
+++ b/mirror/mirror-server/src/functions/app/deploy.function.test.ts
@@ -60,6 +60,7 @@ describe('deploy', () => {
   const TEAM_ID = 'my-team';
   const SERVER_VERSION = '0.35.0';
   const WFP_SERVER_VERSION = MIN_WFP_VERSION.raw;
+  const WFP_SERVER_VERSION_PRE_RELEASE_TAG = `${WFP_SERVER_VERSION}-canary.0`;
   const CLOUDFLARE_ACCOUNT_ID = 'foo-cloudflare-account';
   const NAMESPACE = 'prod';
   const SCRIPT_NAME = 'foo-bar-baz';
@@ -102,6 +103,18 @@ describe('deploy', () => {
     );
     batch.create(
       firestore
+        .doc(serverPath(WFP_SERVER_VERSION_PRE_RELEASE_TAG))
+        .withConverter(serverDataConverter),
+      {
+        major: MIN_WFP_VERSION.major,
+        minor: MIN_WFP_VERSION.minor,
+        patch: MIN_WFP_VERSION.patch,
+        modules: [],
+        channels: ['stable'],
+      },
+    );
+    batch.create(
+      firestore
         .doc(providerPath(DEFAULT_PROVIDER_ID))
         .withConverter(providerDataConverter),
       {
@@ -120,6 +133,8 @@ describe('deploy', () => {
   afterAll(async () => {
     const batch = firestore.batch();
     batch.delete(firestore.doc(serverPath(SERVER_VERSION)));
+    batch.delete(firestore.doc(serverPath(WFP_SERVER_VERSION)));
+    batch.delete(firestore.doc(serverPath(WFP_SERVER_VERSION_PRE_RELEASE_TAG)));
     batch.delete(firestore.doc(providerPath(DEFAULT_PROVIDER_ID)));
     await batch.commit();
   });
@@ -501,6 +516,11 @@ describe('deploy', () => {
       {
         name: 'supported version',
         serverVersion: WFP_SERVER_VERSION,
+        expectMigration: true,
+      },
+      {
+        name: 'supported version pre-release tag',
+        serverVersion: WFP_SERVER_VERSION_PRE_RELEASE_TAG,
         expectMigration: true,
       },
     ];

--- a/mirror/mirror-server/src/functions/app/deploy.function.ts
+++ b/mirror/mirror-server/src/functions/app/deploy.function.ts
@@ -42,7 +42,7 @@ import {
   ScriptHandler,
 } from '../../cloudflare/script-handler.js';
 import {MIN_WFP_VERSION} from './create.function.js';
-import {lt} from 'semver';
+import {lt, coerce} from 'semver';
 
 export const deploy = (firestore: Firestore, storage: Storage) =>
   onDocumentCreated(
@@ -435,7 +435,11 @@ async function migrateToWFP(
   script: ScriptHandler,
   serverVersion: string,
 ): Promise<boolean> {
-  if (scriptRef || lt(serverVersion, MIN_WFP_VERSION)) {
+  if (
+    scriptRef ||
+    // coerce to pre-releases equally.
+    lt(coerce(serverVersion) ?? serverVersion, MIN_WFP_VERSION)
+  ) {
     // Already on WFP or cannot migrate to WFP
     return false;
   }


### PR DESCRIPTION
Automatically migrates a non-WFP script to WFP the first time a WFP-supported server version is published. This involves:
* Deleting the old script (and its data) and custom domains
* After pushing a Namespaced version of script, updating the App with a namespaced `scriptRef` field.

This replaces the previous strategy of [migrating scripts manually](https://github.com/rocicorp/mono/pull/1024) and is accompanied by [release notes indicating that this will happen for SaaS customers](https://www.notion.so/replicache/reflect-0-36-0-25737134cf6249a2bc3567c7e043a4e1?pvs=4#25af16bde34b4599b17b855a8b8502a1).

The MIN_WFP_VERSION is now set to `0.36.0`.

<img width="965" alt="Screenshot 2023-10-06 at 6 03 03 PM" src="https://github.com/rocicorp/mono/assets/132324914/e0bfcedb-3617-4a91-b35b-52987be66f7c">

@aboodman 