### PR TITLE
chore(reflect): Remove .prettierignore from template create

### DIFF
--- a/mirror/reflect-cli/templates/create/.prettierignore
+++ b/mirror/reflect-cli/templates/create/.prettierignore
@@ -1,4 +1,0 @@
-node_modules
-dist
-lib
-*.log


### PR DESCRIPTION
We were not installing prettier so there is no reason to have a .prettierignore file in the template create directory.