### PR TITLE
fix(mirror): fix fallback origin AAAA record to be proxied

### DIFF
--- a/mirror/mirror-cli/src/publish-dispatcher.ts
+++ b/mirror/mirror-cli/src/publish-dispatcher.ts
@@ -140,6 +140,7 @@ export async function ensureFallbackOrigin(
       type: 'AAAA',
       name: hostname,
       content: '100::',
+      proxied: true,
     });
     console.log(dnsResult);
   } catch (e) {


### PR DESCRIPTION
The fallback origin needs to point to a proxied DNS record.

```
GET /zones/1b044253688b6ddb8e67738539a2b6d0/custom_hostnames/fallback_origin
Waiting for Fallback origin to become active:  {
  origin: 'apps.reflect-server.net',
  status: 'pending_deployment',
  created_at: '2023-10-09T18:26:19.30755Z',
  updated_at: '2023-10-09T18:26:20.268495Z',
  errors: [
    'DNS records are not setup correctly. Origin should be a proxied A/AAAA/CNAME dns record'
  ]
}
```