### PR TITLE
feat(reflect-cli): "publish --reflect-channel=..." sets the server release channel

### DIFF
--- a/mirror/mirror-protocol/src/publish.ts
+++ b/mirror/mirror-protocol/src/publish.ts
@@ -13,6 +13,9 @@ export const publishRequestSchema = v.object({
   source: fileSchema,
   sourcemap: fileSchema,
   serverVersionRange: v.string(),
+
+  // Sets the App's server release channel when present.
+  serverReleaseChannel: v.string().optional(),
 });
 
 export type PublishRequest = v.Infer<typeof publishRequestSchema>;

--- a/mirror/mirror-schema/src/app.ts
+++ b/mirror/mirror-schema/src/app.ts
@@ -1,6 +1,10 @@
 import * as v from 'shared/src/valita.js';
 import {firestoreDataConverter} from './converter.js';
-import {deploymentOptionsSchema, deploymentSchema} from './deployment.js';
+import {
+  deploymentOptionsSchema,
+  deploymentSchema,
+  deploymentViewSchema,
+} from './deployment.js';
 import {DEFAULT_PROVIDER_ID} from './provider.js';
 
 const scriptRefSchema = v.object({
@@ -76,11 +80,15 @@ export type App = v.Infer<typeof appSchema>;
 
 export const appDataConverter = firestoreDataConverter(appSchema);
 
+// TODO: Move cli views to cli/... subdirectory.
+
 // The slice of App fields read by the cli.
 // Having the cli use a constrained schema makes it easier to
 // refactor/rewrite other parts of the schema.
 // Pick more fields as necessary.
-const appViewSchema = appSchema.pick('name');
+const appViewSchema = appSchema.pick('name', 'serverReleaseChannel').extend({
+  runningDeployment: deploymentViewSchema.optional(),
+});
 
 export type AppView = v.Infer<typeof appViewSchema>;
 

--- a/mirror/mirror-schema/src/deployment.ts
+++ b/mirror/mirror-schema/src/deployment.ts
@@ -130,13 +130,15 @@ export type Deployment = v.Infer<typeof deploymentSchema>;
 
 export const deploymentDataConverter = firestoreDataConverter(deploymentSchema);
 
+// TODO: Move cli views to cli/... subdirectory.
+
 // The slice of Deployment fields read by the cli.
 // Having the cli use a constrained schema makes it easier to
 // refactor/rewrite other parts of the schema.
 // Pick more fields as necessary.
-const deploymentViewSchema = deploymentSchema
+export const deploymentViewSchema = deploymentSchema
   .pick('status', 'statusMessage')
-  .extend({spec: deploymentSpecSchema.pick('hostname')});
+  .extend({spec: deploymentSpecSchema.pick('hostname', 'serverVersion')});
 
 export type DeploymentView = v.Infer<typeof deploymentViewSchema>;
 

--- a/mirror/mirror-schema/src/server.ts
+++ b/mirror/mirror-schema/src/server.ts
@@ -3,12 +3,17 @@ import {firestoreDataConverter} from './converter.js';
 import {moduleRefSchema} from './module.js';
 import * as path from './path.js';
 
-export const CANARY_RELEASE_CHANNEL = 'canary';
 export const STABLE_RELEASE_CHANNEL = 'stable';
+export const CANARY_RELEASE_CHANNEL = 'canary';
+
+export const STANDARD_RELEASE_CHANNELS: readonly string[] = [
+  STABLE_RELEASE_CHANNEL,
+  CANARY_RELEASE_CHANNEL,
+] as const;
 
 export const standardReleaseChannelSchema = v.union(
-  v.literal(CANARY_RELEASE_CHANNEL),
   v.literal(STABLE_RELEASE_CHANNEL),
+  v.literal(CANARY_RELEASE_CHANNEL),
 );
 
 // Defines the StandardReleaseChannels to which a newly created app should be limited

--- a/mirror/mirror-server/src/functions/app/auto-deploy.function.ts
+++ b/mirror/mirror-server/src/functions/app/auto-deploy.function.ts
@@ -92,6 +92,7 @@ export async function checkForAutoDeployment(
         ...desiredSpec,
       },
     },
+    undefined,
     lastAppUpdateTime,
   );
 }

--- a/mirror/mirror-server/src/functions/app/create.function.ts
+++ b/mirror/mirror-server/src/functions/app/create.function.ts
@@ -27,7 +27,11 @@ import {newAppID, newAppIDAsNumber, newAppScriptName} from '../../ids.js';
 import {userAuthorization} from '../validators/auth.js';
 import {getDataOrFail} from '../validators/data.js';
 import {validateSchema} from '../validators/schema.js';
-import {userAgentVersion, DistTags} from '../validators/version.js';
+import {
+  userAgentVersion,
+  DistTags,
+  checkStandardReleaseChannel,
+} from '../validators/version.js';
 import type {UserAgent} from 'mirror-protocol/src/user-agent.js';
 import {DistTag} from 'mirror-protocol/src/version.js';
 import {SemVer, gte, gt, coerce} from 'semver';
@@ -69,6 +73,8 @@ export const create = (firestore: Firestore, testDistTags?: DistTags) =>
           `Invalid App Name "${appName}". Names must be lowercased alphanumeric, starting with a letter and not ending with a hyphen.`,
         );
       }
+
+      checkStandardReleaseChannel(serverReleaseChannel);
 
       const userDocRef = firestore
         .doc(userPath(userID))

--- a/mirror/mirror-server/src/functions/validators/version.ts
+++ b/mirror/mirror-server/src/functions/validators/version.ts
@@ -8,6 +8,7 @@ import {
   DistTagMap,
   lookupDistTags,
 } from 'mirror-protocol/src/version.js';
+import {STANDARD_RELEASE_CHANNELS} from 'mirror-schema/src/server.js';
 
 export type DistTags = DistTagMap<SemVer>;
 
@@ -74,6 +75,15 @@ function checkAgent(
     throw new HttpsError(
       'unavailable',
       'This version of Reflect is no longer supported. Please update to @rocicorp/reflect@latest.',
+    );
+  }
+}
+
+export function checkStandardReleaseChannel(channel: string) {
+  if (!STANDARD_RELEASE_CHANNELS.includes(channel)) {
+    throw new HttpsError(
+      'invalid-argument',
+      `Reflect Channel must be one of [${STANDARD_RELEASE_CHANNELS}]`,
     );
   }
 }

--- a/mirror/reflect-cli/src/publish.ts
+++ b/mirror/reflect-cli/src/publish.ts
@@ -20,7 +20,10 @@ import type {CommonYargsArgv, YargvToInterface} from './yarg-types.js';
 import {checkForServerDeprecation} from './version.js';
 
 export function publishOptions(yargs: CommonYargsArgv) {
-  return yargs;
+  return yargs.option('reflect-channel', {
+    desc: 'Set the Reflect Channel for server updates',
+    type: 'string',
+  });
 }
 
 async function exists(path: string) {
@@ -41,6 +44,7 @@ export async function publishHandler(
   publish: PublishCaller = publishCaller, // Overridden in tests.
   firestore: Firestore = getFirestore(), // Overridden in tests.
 ) {
+  const {reflectChannel} = yargs;
   const {appID, server: script} = await ensureAppInstantiated(yargs);
 
   const absPath = path.resolve(script);
@@ -71,6 +75,9 @@ export async function publishHandler(
     serverVersionRange,
     appID,
   };
+  if (reflectChannel) {
+    data.serverReleaseChannel = reflectChannel;
+  }
 
   console.log('Requesting deployment');
   const {deploymentPath} = await publish(data);


### PR DESCRIPTION
Adds a `--reflect-channel` flag to `reflect publish` which results in setting the App's server release channel for choosing the server version (and future server auto-updates).

<img width="1034" alt="Screenshot 2023-10-09 at 4 06 58 PM" src="https://github.com/rocicorp/mono/assets/132324914/25a71a2e-1a59-49f2-86a4-6b012248066e">

The mirror-server requires that the channel be one of "stable" or "canary". This is a server-side control and can be changed without a cli update.

<img width="1034" alt="Screenshot 2023-10-09 at 4 04 31 PM" src="https://github.com/rocicorp/mono/assets/132324914/e90c280f-86da-4ca5-b2b3-47fd0ad8f65b">

Other minor changes:
* Check the `serverReleaseChannel` passed in to `app-create` as we do for publish. Because of create-on-demand-on-publish, there is currently no option to set this field to anything other than `stable`, but it is part of the protocol nonetheless.
* Replace the ad-hoc AppData interface with an extended AppView schema. Added a TODO to move these cli view schemas into a `cli/...` subdirectory. 
* Added padding to the labels outputted by `reflect status`
