### PR TITLE
fix(reflect-client): Connect timeout after close

### DIFF
--- a/packages/reflect-client/src/client/connect-checks.ts
+++ b/packages/reflect-client/src/client/connect-checks.ts
@@ -18,7 +18,8 @@ export async function checkConnectivity(
   reason: string,
   server: HTTPString,
   lc: LogContext,
-) {
+  signal: AbortSignal,
+): Promise<void> {
   const id = nanoid();
   lc = lc.withContext('connectCheckID', id).withContext('checkReason', reason);
   lc.info?.('Starting connectivity checks', {
@@ -26,14 +27,14 @@ export async function checkConnectivity(
   });
   const socketOrigin = toWSString(server);
   const checks: Checks = {
-    cfGet: _ => checkCfGet(id, server),
-    cfWebSocket: l => checkCfSocket(id, socketOrigin, false, l),
+    cfGet: _ => checkCfGet(id, server, signal),
+    cfWebSocket: l => checkCfSocket(id, socketOrigin, false, l, signal),
     cfWebSocketWSecWebSocketProtocolHeader: l =>
-      checkCfSocket(id, socketOrigin, true, l),
-    renderGet: _ => checkRenderGet(id),
-    renderWebSocket: l => checkRenderSocket(id, false, l),
+      checkCfSocket(id, socketOrigin, true, l, signal),
+    renderGet: _ => checkRenderGet(id, signal),
+    renderWebSocket: l => checkRenderSocket(id, false, l, signal),
     renderWebSocketWSecWebSocketProtocolHeader: l =>
-      checkRenderSocket(id, true, l),
+      checkRenderSocket(id, true, l, signal),
   };
 
   const resultPs: Promise<CheckResult>[] = [];
@@ -47,7 +48,7 @@ export async function checkConnectivity(
           result = await check(checkLc);
         } catch (e) {
           const detail = `Error: ${
-            e instanceof Error ? {name: e.name, message: e.message} : e
+            e instanceof Error ? `{name: ${e.name}, message: ${e.message}}` : e
           }`;
           result = {success: false, detail};
         }
@@ -58,6 +59,10 @@ export async function checkConnectivity(
   }
 
   const results = await Promise.all(resultPs);
+  if (signal.aborted) {
+    return;
+  }
+
   lc.info?.(
     'Connectivity checks summary\n',
     ...Object.keys(checks).map(
@@ -78,25 +83,25 @@ export async function checkConnectivity(
   );
 }
 
-function checkRenderGet(id: string) {
-  return checkGet(id, 'https://canary-render.onrender.com/canary/get');
+function checkRenderGet(id: string, signal: AbortSignal) {
+  return checkGet(id, 'https://canary-render.onrender.com/canary/get', signal);
 }
 
-function checkCfGet(id: string, server: HTTPString) {
+function checkCfGet(id: string, server: HTTPString, signal: AbortSignal) {
   const cfGetCheckBaseURL = new URL(server);
   cfGetCheckBaseURL.pathname = '/api/canary/v0/get';
   const url = cfGetCheckBaseURL.toString();
   assertHTTPString(url);
-  return checkGet(id, url);
+  return checkGet(id, url, signal);
 }
 
-function checkGet(id: string, baseURL: HTTPString) {
+function checkGet(id: string, baseURL: HTTPString, signal: AbortSignal) {
   const getCheckURL = new URL(baseURL);
   getCheckURL.searchParams.set('id', id);
   return Promise.race([
-    timeout(),
+    timeout(signal),
     (async () => {
-      const response = await fetch(getCheckURL);
+      const response = await fetch(getCheckURL, {signal});
       return {
         success: response.status === 200,
         detail: `Got response ${response.status} "${await response.text()}"`,
@@ -109,12 +114,14 @@ function checkRenderSocket(
   id: string,
   wSecWebSocketProtocolHeader: boolean,
   lc: LogContext,
+  signal: AbortSignal,
 ) {
   return checkSocket(
     id,
     'wss://canary-render.onrender.com/canary/websocket',
     wSecWebSocketProtocolHeader,
     lc,
+    signal,
   );
 }
 
@@ -123,12 +130,13 @@ function checkCfSocket(
   socketOrigin: WSString,
   wSecWebSocketProtocolHeader: boolean,
   lc: LogContext,
+  signal: AbortSignal,
 ) {
   const cfSocketCheckBaseURL = new URL(socketOrigin);
   cfSocketCheckBaseURL.pathname = '/api/canary/v0/websocket';
   const url = cfSocketCheckBaseURL.toString();
   assertWSString(url);
-  return checkSocket(id, url, wSecWebSocketProtocolHeader, lc);
+  return checkSocket(id, url, wSecWebSocketProtocolHeader, lc, signal);
 }
 
 async function checkSocket(
@@ -136,6 +144,7 @@ async function checkSocket(
   socketBaseURL: WSString,
   wSecWebSocketProtocolHeader: boolean,
   lc: LogContext,
+  signal: AbortSignal,
 ) {
   const socketCheckURL = new URL(socketBaseURL);
   socketCheckURL.searchParams.set('id', id);
@@ -176,7 +185,7 @@ async function checkSocket(
     cfWebSocket.addEventListener('message', onMessage);
     cfWebSocket.addEventListener('open', onOpen);
     cfWebSocket.addEventListener('close', onClose);
-    return await Promise.race([timeout(), promise]);
+    return await Promise.race([timeout(signal), promise]);
   } finally {
     cfWebSocket.removeEventListener('message', onMessage);
     cfWebSocket.removeEventListener('open', onOpen);
@@ -187,7 +196,7 @@ async function checkSocket(
 
 const TIMEOUT_MS = 10_000;
 
-async function timeout(): Promise<CheckResult> {
-  await sleep(TIMEOUT_MS);
+async function timeout(signal: AbortSignal): Promise<CheckResult> {
+  await sleep(TIMEOUT_MS, signal);
   return {success: false, detail: 'Timed out.'};
 }


### PR DESCRIPTION
When we close the Reflect instance we need to clear the connect timeout.

Also, abort all the connection checks when we close the Reflect instance.

Fixes #1062