### PR TITLE
feat(reflect-cli): hide implementation details from error messages

### DIFF
--- a/mirror/reflect-cli/src/firebase.ts
+++ b/mirror/reflect-cli/src/firebase.ts
@@ -11,6 +11,7 @@ import {
   sendAnalyticsEvent,
   getUserParameters,
 } from './metrics/send-ga-event.js';
+import color from 'picocolors';
 import type {ArgumentsCamelCase} from 'yargs';
 import {reportError, ErrorInfo} from 'mirror-protocol/src/error.js';
 import {version} from './version.js';
@@ -108,7 +109,9 @@ export function handleWith<T extends ArgumentsCamelCase<CommonYargsOptions>>(
         ]);
       } catch (e) {
         await reportE(args, eventName, e);
-        throw e;
+        const message = e instanceof Error ? e.message : String(e);
+        console.error(`\n${color.red(color.bold('Error'))}: ${message}`);
+        process.exit(-1);
       } finally {
         await getFirestore().terminate();
       }


### PR DESCRIPTION
Before:

<img width="874" alt="Screenshot 2023-10-10 at 9 45 45 AM" src="https://github.com/rocicorp/mono/assets/132324914/747c2f72-1e03-490a-a3ca-965d056b60a5">

After:

<img width="907" alt="Screenshot 2023-10-10 at 9 49 36 AM" src="https://github.com/rocicorp/mono/assets/132324914/be863ed4-287e-4ea7-a657-d817d36733ea">
