### PR TITLE
feat(reflect-cli): report analytics errors as warnings

### DIFF
--- a/mirror/mirror-protocol/src/error.ts
+++ b/mirror/mirror-protocol/src/error.ts
@@ -23,12 +23,17 @@ const errorInfoSchema: v.ValitaType<ErrorInfo> = v.lazy<ErrorInfo>(() =>
 // reflect-cli sends its userParameters, but other agents (e.g. reflect-auth-ui) might send something different.
 const agentContextSchema = v.record(v.string());
 
+const severitySchema = v.union(v.literal('WARNING'), v.literal('ERROR'));
+
 export const errorReportingRequestSchema = v.object({
   ...baseRequestFields, // userID is empty if it is not known. Importantly, the userAgent is useful.
   action: v.string(), // e.g. "init", "create", "dev", "publish", etc.
   error: errorInfoSchema,
+  severity: severitySchema.default('ERROR'),
   agentContext: agentContextSchema,
 });
+
+export type Severity = v.Infer<typeof severitySchema>;
 
 export type ErrorReportingRequest = v.Infer<typeof errorReportingRequestSchema>;
 

--- a/mirror/mirror-server/src/functions/error/report.function.test.ts
+++ b/mirror/mirror-server/src/functions/error/report.function.test.ts
@@ -21,6 +21,7 @@ describe('error-report function', () => {
       message: 'error-reporting-test',
       stack: 'error-reporting-test',
     },
+    severity: 'ERROR',
     agentContext: {
       'up.reflect_os_architecture': 'x86_64',
       'up.reflect_os_name': 'Mac OS X',
@@ -40,6 +41,25 @@ describe('error-report function', () => {
     } catch (e) {
       expect(e).toBeInstanceOf(HttpsError);
       expect((e as HttpsError).code).toBe('unknown');
+      expect((e as HttpsError).message).toBe(
+        'action: error-reporting-test, description: error-reporting-test',
+      );
+    }
+  });
+
+  test('request push a warning', async () => {
+    try {
+      const resp = await errorReportingFunction.run({
+        data: {
+          ...request,
+          severity: 'WARNING',
+        },
+        rawRequest: null as unknown as Request,
+      });
+      console.log(resp);
+    } catch (e) {
+      expect(e).toBeInstanceOf(HttpsError);
+      expect((e as HttpsError).code).toBe('cancelled');
       expect((e as HttpsError).message).toBe(
         'action: error-reporting-test, description: error-reporting-test',
       );

--- a/mirror/mirror-server/src/functions/error/report.function.ts
+++ b/mirror/mirror-server/src/functions/error/report.function.ts
@@ -11,8 +11,16 @@ export const report = () =>
     errorReportingRequestSchema,
     errorReportingResponseSchema,
   ).handle((request, _context) => {
+    const {
+      severity,
+      action,
+      error: {desc},
+    } = request;
+
+    // 4xx and 5xx errors have different alerting thresholds.
+    // "cancelled" maps to 499 and "unknown" maps to 500
     throw new HttpsError(
-      'unknown',
-      `action: ${request.action}, description: ${request.error.desc}`,
+      severity === 'WARNING' ? 'cancelled' : 'unknown',
+      `action: ${action}, description: ${desc}`,
     );
   });


### PR DESCRIPTION
Allow classification of reported errors as "ERROR" or "WARNING", and report analytics errors as the latter.

On the server side, this will be classified as a `4xx` status and be subject to a higher alerting threshold.