### PR TITLE
fix(reflect-cli): remove Reflect Channel from status command

### DIFF
--- a/mirror/mirror-schema/src/client-view/app.ts
+++ b/mirror/mirror-schema/src/client-view/app.ts
@@ -7,11 +7,9 @@ import {appSchema} from '../app.js';
 // Having the cli use a constrained schema makes it easier to
 // refactor/rewrite other parts of the schema.
 // Pick more fields as necessary.
-const appViewSchema = appSchema
-  .pick('name', 'serverReleaseChannel', 'runningDeployment')
-  .extend({
-    runningDeployment: deploymentViewSchema.optional(),
-  });
+const appViewSchema = appSchema.pick('name', 'runningDeployment').extend({
+  runningDeployment: deploymentViewSchema.optional(),
+});
 
 export type AppView = v.Infer<typeof appViewSchema>;
 

--- a/mirror/reflect-cli/src/status.ts
+++ b/mirror/reflect-cli/src/status.ts
@@ -49,7 +49,6 @@ function displayStatus(appID?: string, appView?: AppView): void {
         ['ID', appID],
         ['Status', getDeploymentStatus(appView?.runningDeployment)],
         ['Hostname', appView?.runningDeployment?.spec.hostname],
-        ['Reflect Channel', appView?.serverReleaseChannel],
         ['Server Version', appView?.runningDeployment?.spec.serverVersion],
       ]
     : [['App', undefined]];


### PR DESCRIPTION
No use showing `Reflect Channel` at this point when it has no meaning / dx.