### PR TITLE
feat(mirror): use DNSRecord tags now that they are enabled

### DIFF
--- a/mirror/mirror-cli/src/configure-provider.ts
+++ b/mirror/mirror-cli/src/configure-provider.ts
@@ -164,8 +164,7 @@ async function checkCapabilities(
     name: 'test-mirror-record',
     content: 'test-mirror-content',
     comment: 'Temporarily created by mirror-cli. Delete me.',
-    // TODO: Uncomment when Cloudflare enables tags for us.
-    // tags: ['foo:bar'],
+    tags: ['foo:bar'],
   });
   await dnsRecords.delete(record.id);
 }

--- a/mirror/mirror-cli/src/index.ts
+++ b/mirror/mirror-cli/src/index.ts
@@ -55,6 +55,10 @@ import {
 } from './configure-provider.js';
 import {migrateToWFPHandler, migrateToWFPOptions} from './migrate-to-wfp.js';
 import {certificatesHandler, certificatesOptions} from './certificates.js';
+import {
+  migrateDnsCommentsToTagsHandler,
+  migrateDnsCommentsToTagsOptions,
+} from './migrate-dns-comments-to-tags.js';
 
 async function main(argv: string[]): Promise<void> {
   const reflectCLI = createCLIParser(argv);
@@ -193,6 +197,13 @@ function createCLIParser(argv: string[]) {
     'Converts team subdomains to team labels. Triggers new deployments of those apps.',
     migrateTeamLabelsOptions,
     migrateTeamLabelsHandler,
+  );
+
+  reflectCLI.command(
+    'migrate-dns-comments-to-tags',
+    'Converts workaround-comments in DNSRecords to actual tags.',
+    migrateDnsCommentsToTagsOptions,
+    migrateDnsCommentsToTagsHandler,
   );
 
   reflectCLI.command(

--- a/mirror/mirror-cli/src/migrate-dns-comments-to-tags.ts
+++ b/mirror/mirror-cli/src/migrate-dns-comments-to-tags.ts
@@ -1,0 +1,46 @@
+import {getProviderConfig} from './cf.js';
+import type {CommonYargsArgv, YargvToInterface} from './yarg-types.js';
+import {DNSRecords, type DNSRecord} from 'cloudflare-api/src/dns-records.js';
+
+export function migrateDnsCommentsToTagsOptions(yargs: CommonYargsArgv) {
+  return yargs.option('dry-run', {
+    desc: 'Output actions to console instead of committing them',
+    type: 'boolean',
+    default: true,
+  });
+}
+
+type MigrateDnsCommentsToTagsHandlerArgs = YargvToInterface<
+  ReturnType<typeof migrateDnsCommentsToTagsOptions>
+>;
+
+export async function migrateDnsCommentsToTagsHandler(
+  yargs: MigrateDnsCommentsToTagsHandlerArgs,
+): Promise<void> {
+  const {dryRun} = yargs;
+  const {
+    apiToken,
+    defaultZone: {zoneID},
+  } = await getProviderConfig(yargs);
+  const resource = new DNSRecords({apiToken, zoneID});
+  const query = new URLSearchParams({['comment.startswith']: '|'});
+
+  for (const record of await resource.list(query)) {
+    const {id, name, comment} = record;
+    console.log(`Matched ${name}`, record);
+
+    const tags = comment.split('|').filter(val => val.length > 0);
+    tags.push('managed:rocicorp');
+
+    const patch: Partial<DNSRecord> = {
+      comment: 'Managed by Rocicorp (reflect.net)',
+      tags,
+    };
+
+    if (dryRun) {
+      console.info(`Would PATCH ${name}`, patch);
+    } else {
+      await resource.patch(id, patch);
+    }
+  }
+}

--- a/mirror/mirror-server/src/cloudflare/publish-custom-hostnames.test.ts
+++ b/mirror/mirror-server/src/cloudflare/publish-custom-hostnames.test.ts
@@ -52,7 +52,7 @@ describe('custom-hostnames', () => {
     expect(fetch.requests()).toEqual([
       [
         'GET',
-        'https://api.cloudflare.com/client/v4/zones/1ab3d299c/dns_records?tag=script%3Aprod%2Ffoo-script&comment.contains=%7Cscript%3Aprod%2Ffoo-script%7C&match=any',
+        'https://api.cloudflare.com/client/v4/zones/1ab3d299c/dns_records?tag=script%3Aprod%2Ffoo-script',
       ],
     ]);
   });
@@ -71,7 +71,7 @@ describe('custom-hostnames', () => {
     expect(fetch.requests()).toEqual([
       [
         'GET',
-        'https://api.cloudflare.com/client/v4/zones/1ab3d299c/dns_records?tag=script%3Aprod%2Ffoo-script&comment.contains=%7Cscript%3Aprod%2Ffoo-script%7C&match=any',
+        'https://api.cloudflare.com/client/v4/zones/1ab3d299c/dns_records?tag=script%3Aprod%2Ffoo-script',
       ],
       [
         'POST',
@@ -102,9 +102,8 @@ describe('custom-hostnames', () => {
         type: 'CNAME',
         content: 'reflect-o-rama.net',
         proxied: true,
-        // tags: ['script:prod/foo-script', 'ch:ch-id'],
-        // comment: 'Managed by Rocicorp (reflect.net)',
-        comment: '|script:prod/foo-script|ch:ch-id|',
+        tags: ['script:prod/foo-script', 'ch:ch-id', 'managed:rocicorp'],
+        comment: 'Managed by Rocicorp (reflect.net)',
       },
       ch,
     ]);
@@ -133,7 +132,7 @@ describe('custom-hostnames', () => {
     expect(fetch.requests()).toEqual([
       [
         'GET',
-        'https://api.cloudflare.com/client/v4/zones/1ab3d299c/dns_records?tag=script%3Aprod%2Ffoo-script&comment.contains=%7Cscript%3Aprod%2Ffoo-script%7C&match=any',
+        'https://api.cloudflare.com/client/v4/zones/1ab3d299c/dns_records?tag=script%3Aprod%2Ffoo-script',
       ],
       [
         'POST',
@@ -173,9 +172,8 @@ describe('custom-hostnames', () => {
       type: 'CNAME',
       content: 'reflect-o-rama.net',
       proxied: true,
-      // tags: ['script:prod/foo-script', 'ch:existing-ch-id'],
-      // comment: 'Managed by Rocicorp (reflect.net)',
-      comment: '|script:prod/foo-script|ch:existing-ch-id|',
+      tags: ['script:prod/foo-script', 'ch:existing-ch-id', 'managed:rocicorp'],
+      comment: 'Managed by Rocicorp (reflect.net)',
     };
     expect(fetch.jsonPayloads()).toEqual([
       null, // DNSRecords.list()
@@ -203,7 +201,7 @@ describe('custom-hostnames', () => {
     expect(fetch.requests()).toEqual([
       [
         'GET',
-        'https://api.cloudflare.com/client/v4/zones/1ab3d299c/dns_records?tag=script%3Aprod%2Ffoo-script&comment.contains=%7Cscript%3Aprod%2Ffoo-script%7C&match=any',
+        'https://api.cloudflare.com/client/v4/zones/1ab3d299c/dns_records?tag=script%3Aprod%2Ffoo-script',
       ],
       [
         'POST',
@@ -238,9 +236,8 @@ describe('custom-hostnames', () => {
         type: 'CNAME',
         content: 'reflect-o-rama.net',
         proxied: true,
-        // tags: ['script:prod/foo-script', 'ch:ch-id'],
-        // comment: 'Managed by Rocicorp (reflect.net)',
-        comment: '|script:prod/foo-script|ch:ch-id|',
+        tags: ['script:prod/foo-script', 'ch:ch-id', 'managed:rocicorp'],
+        comment: 'Managed by Rocicorp (reflect.net)',
       },
       ch,
     ]);
@@ -274,7 +271,7 @@ describe('custom-hostnames', () => {
     expect(fetch.requests()).toEqual([
       [
         'GET',
-        'https://api.cloudflare.com/client/v4/zones/1ab3d299c/dns_records?tag=script%3Aprod%2Ffoo-script&comment.contains=%7Cscript%3Aprod%2Ffoo-script%7C&match=any',
+        'https://api.cloudflare.com/client/v4/zones/1ab3d299c/dns_records?tag=script%3Aprod%2Ffoo-script',
       ],
       [
         'DELETE',
@@ -316,7 +313,7 @@ describe('custom-hostnames', () => {
       expect.arrayContaining([
         [
           'GET',
-          'https://api.cloudflare.com/client/v4/zones/1ab3d299c/dns_records?tag=script%3Aprod%2Ffoo-script&comment.contains=%7Cscript%3Aprod%2Ffoo-script%7C&match=any',
+          'https://api.cloudflare.com/client/v4/zones/1ab3d299c/dns_records?tag=script%3Aprod%2Ffoo-script',
         ],
         [
           'DELETE',
@@ -370,7 +367,7 @@ describe('custom-hostnames', () => {
     expect(fetch.requests()).toEqual([
       [
         'GET',
-        'https://api.cloudflare.com/client/v4/zones/1ab3d299c/dns_records?tag=script%3Aprod%2Ffoo-script&comment.contains=%7Cscript%3Aprod%2Ffoo-script%7C&match=any',
+        'https://api.cloudflare.com/client/v4/zones/1ab3d299c/dns_records?tag=script%3Aprod%2Ffoo-script',
       ],
       [
         'DELETE',
@@ -414,7 +411,7 @@ describe('custom-hostnames', () => {
       expect.arrayContaining([
         [
           'GET',
-          'https://api.cloudflare.com/client/v4/zones/1ab3d299c/dns_records?tag=script%3Aprod%2Ffoo-script&comment.contains=%7Cscript%3Aprod%2Ffoo-script%7C&match=any',
+          'https://api.cloudflare.com/client/v4/zones/1ab3d299c/dns_records?tag=script%3Aprod%2Ffoo-script',
         ],
         [
           'DELETE',
@@ -490,7 +487,7 @@ describe('custom-hostnames', () => {
       expect.arrayContaining([
         [
           'GET',
-          'https://api.cloudflare.com/client/v4/zones/1ab3d299c/dns_records?tag=script%3Aprod%2Ffoo-script&comment.contains=%7Cscript%3Aprod%2Ffoo-script%7C&match=any',
+          'https://api.cloudflare.com/client/v4/zones/1ab3d299c/dns_records?tag=script%3Aprod%2Ffoo-script',
         ],
         [
           'DELETE',


### PR DESCRIPTION
Reverts the DNSRecord comment workaround in #1007 and directly use tags now that both `reflect-server.net` and `reflect-server.dev` are Enterprise zones (which support tags). This eliminates the uneasiness of potentially being bitten by comment-length limits.

The `mirror migrate-dns-comments-to-tags` migration script was run on existing dns records. The `mirror-server` thus only performs handle the tag-based annotation and lookup.

<img width="1077" alt="Screenshot 2023-10-10 at 5 03 08 PM" src="https://github.com/rocicorp/mono/assets/132324914/5f641da4-a49a-416d-a54f-948b0087affc">
