### PR TITLE
chore(replicache): Make withWrite auto commit

### DIFF
--- a/packages/replicache/src/btree/node.test.ts
+++ b/packages/replicache/src/btree/node.test.ts
@@ -45,7 +45,6 @@ suite('btree node', () => {
     return withWrite(dagStore, async dagWrite => {
       const [h] = await makeTreeInner(node, dagWrite);
       await dagWrite.setHead('test', h);
-      await dagWrite.commit();
       return h;
     });
 
@@ -182,7 +181,6 @@ suite('btree node', () => {
       await fn(w);
       const h = await w.flush();
       await dagWrite.setHead('test', h);
-      await dagWrite.commit();
       return h;
     });
   }
@@ -260,7 +258,6 @@ suite('btree node', () => {
         await dagWrite.putChunk(c2);
         await dagWrite.putChunk(rootChunk);
         await dagWrite.setHead('test', rootHash);
-        await dagWrite.commit();
       });
 
       await withRead(dagStore, async dagRead => {
@@ -346,7 +343,6 @@ suite('btree node', () => {
         expect(h).to.not.equal(emptyHash);
         expect(h).to.not.equal(emptyTreeHash);
         await dagWrite.setHead('test', h);
-        await dagWrite.commit();
         return h;
       });
 
@@ -602,7 +598,6 @@ suite('btree node', () => {
           }
 
           await dagWrite.setHead('test', h);
-          await dagWrite.commit();
 
           for (const [k, v] of Object.entries(data)) {
             expect(await w.get(k)).to.equal(v);
@@ -1378,7 +1373,6 @@ suite('btree node', () => {
 
           await dagWrite.setHead('test/old', oldHash);
           await dagWrite.setHead('test/new', newHash);
-          await dagWrite.commit();
 
           return [oldHash, newHash];
         });

--- a/packages/replicache/src/db/root.test.ts
+++ b/packages/replicache/src/db/root.test.ts
@@ -11,7 +11,6 @@ test('getRoot', async () => {
     if (headHash !== undefined) {
       await withWrite(ds, async dw => {
         await dw.setHead(DEFAULT_HEAD_NAME, headHash);
-        await dw.commit();
       });
     }
     if (expected instanceof Error) {

--- a/packages/replicache/src/db/write.test.ts
+++ b/packages/replicache/src/db/write.test.ts
@@ -6,7 +6,7 @@ import {BTreeRead} from '../btree/read.js';
 import {mustGetHeadHash} from '../dag/store.js';
 import {TestStore} from '../dag/test-store.js';
 import {FormatVersion} from '../format-version.js';
-import {withRead, withWrite} from '../with-transactions.js';
+import {withRead, withWriteNoImplicitCommit} from '../with-transactions.js';
 import {DEFAULT_HEAD_NAME, commitFromHead} from './commit.js';
 import {readIndexesForRead} from './read.js';
 import {initDB} from './test-helpers.js';
@@ -26,7 +26,7 @@ suite('basics w/ commit', () => {
     );
 
     // Put.
-    await withWrite(ds, async dagWrite => {
+    await withWriteNoImplicitCommit(ds, async dagWrite => {
       const headHash = await mustGetHeadHash(DEFAULT_HEAD_NAME, dagWrite);
       const w = await newWriteLocal(
         headHash,
@@ -46,7 +46,7 @@ suite('basics w/ commit', () => {
     });
 
     // As well as after it has committed.
-    await withWrite(ds, async dagWrite => {
+    await withWriteNoImplicitCommit(ds, async dagWrite => {
       const w = await newWriteLocal(
         await mustGetHeadHash(DEFAULT_HEAD_NAME, dagWrite),
         'mutator_name',
@@ -62,7 +62,7 @@ suite('basics w/ commit', () => {
     });
 
     // Del.
-    await withWrite(ds, async dagWrite => {
+    await withWriteNoImplicitCommit(ds, async dagWrite => {
       const w = await newWriteLocal(
         await mustGetHeadHash(DEFAULT_HEAD_NAME, dagWrite),
         'mutator_name',
@@ -81,7 +81,7 @@ suite('basics w/ commit', () => {
     });
 
     // As well as after it has committed.
-    await withWrite(ds, async dagWrite => {
+    await withWriteNoImplicitCommit(ds, async dagWrite => {
       const w = await newWriteLocal(
         await mustGetHeadHash(DEFAULT_HEAD_NAME, dagWrite),
         'mutator_name',
@@ -115,7 +115,7 @@ suite('basics w/ putCommit', () => {
     );
 
     // Put.
-    const commit1 = await withWrite(ds, async dagWrite => {
+    const commit1 = await withWriteNoImplicitCommit(ds, async dagWrite => {
       const w = await newWriteLocal(
         await mustGetHeadHash(DEFAULT_HEAD_NAME, dagWrite),
         'mutator_name',
@@ -137,7 +137,7 @@ suite('basics w/ putCommit', () => {
     });
 
     // As well as from the Commit that was put.
-    await withWrite(ds, async dagWrite => {
+    await withWriteNoImplicitCommit(ds, async dagWrite => {
       const w = await newWriteLocal(
         commit1.chunk.hash,
         'mutator_name',
@@ -153,7 +153,7 @@ suite('basics w/ putCommit', () => {
     });
 
     // Del.
-    const commit2 = await withWrite(ds, async dagWrite => {
+    const commit2 = await withWriteNoImplicitCommit(ds, async dagWrite => {
       const w = await newWriteLocal(
         commit1.chunk.hash,
         'mutator_name',
@@ -175,7 +175,7 @@ suite('basics w/ putCommit', () => {
     });
 
     // As well as from the commit after it was put.
-    await withWrite(ds, async dagWrite => {
+    await withWriteNoImplicitCommit(ds, async dagWrite => {
       const w = await newWriteLocal(
         commit2.chunk.hash,
         'mutator_name',
@@ -199,7 +199,7 @@ test('clear', async () => {
   const clientID = 'client-id';
   const ds = new TestStore();
   const lc = new LogContext();
-  await withWrite(ds, dagWrite =>
+  await withWriteNoImplicitCommit(ds, dagWrite =>
     initDB(
       dagWrite,
       DEFAULT_HEAD_NAME,
@@ -211,7 +211,7 @@ test('clear', async () => {
       FormatVersion.Latest,
     ),
   );
-  await withWrite(ds, async dagWrite => {
+  await withWriteNoImplicitCommit(ds, async dagWrite => {
     const w = await newWriteLocal(
       await mustGetHeadHash(DEFAULT_HEAD_NAME, dagWrite),
       'mutator_name',
@@ -226,7 +226,7 @@ test('clear', async () => {
     await w.commit(DEFAULT_HEAD_NAME);
   });
 
-  await withWrite(ds, async dagWrite => {
+  await withWriteNoImplicitCommit(ds, async dagWrite => {
     const w = await newWriteLocal(
       await mustGetHeadHash(DEFAULT_HEAD_NAME, dagWrite),
       'mutator_name',
@@ -280,7 +280,7 @@ test('mutationID on newWriteLocal', async () => {
   const clientID = 'client-id';
   const ds = new TestStore();
   const lc = new LogContext();
-  await withWrite(ds, dagWrite =>
+  await withWriteNoImplicitCommit(ds, dagWrite =>
     initDB(
       dagWrite,
       DEFAULT_HEAD_NAME,
@@ -292,7 +292,7 @@ test('mutationID on newWriteLocal', async () => {
       FormatVersion.Latest,
     ),
   );
-  await withWrite(ds, async dagWrite => {
+  await withWriteNoImplicitCommit(ds, async dagWrite => {
     const headHash = await mustGetHeadHash(DEFAULT_HEAD_NAME, dagWrite);
     const w = await newWriteLocal(
       headHash,
@@ -309,7 +309,7 @@ test('mutationID on newWriteLocal', async () => {
     expect(await w.getMutationID()).equals(1);
   });
 
-  await withWrite(ds, async dagWrite => {
+  await withWriteNoImplicitCommit(ds, async dagWrite => {
     const headHash = await mustGetHeadHash(DEFAULT_HEAD_NAME, dagWrite);
     const w = await newWriteLocal(
       headHash,

--- a/packages/replicache/src/kv/idb-store-with-mem-fallback.test.ts
+++ b/packages/replicache/src/kv/idb-store-with-mem-fallback.test.ts
@@ -2,7 +2,11 @@ import {LogContext} from '@rocicorp/logger';
 import {expect} from 'chai';
 import {assert} from 'shared/src/asserts.js';
 import * as sinon from 'sinon';
-import {withRead, withWrite} from '../with-transactions.js';
+import {
+  withRead,
+  withWrite,
+  withWriteNoImplicitCommit,
+} from '../with-transactions.js';
 import {
   IDBStoreWithMemFallback,
   newIDBStoreWithMemFallback,
@@ -23,7 +27,6 @@ test('Firefox private browsing', async () => {
 
   await withWrite(store, async tx => {
     await tx.put('foo', 'bar');
-    await tx.commit();
   });
   await withRead(store, async tx => {
     expect(await tx.get('foo')).to.equal('bar');
@@ -49,8 +52,8 @@ test('race condition', async () => {
     name,
   );
 
-  const p1 = withWrite(store, () => undefined);
-  const p2 = withWrite(store, () => undefined);
+  const p1 = withWriteNoImplicitCommit(store, () => undefined);
+  const p2 = withWriteNoImplicitCommit(store, () => undefined);
   await p1;
   await p2;
 

--- a/packages/replicache/src/kv/idb-store.test.ts
+++ b/packages/replicache/src/kv/idb-store.test.ts
@@ -21,7 +21,6 @@ test('dropStore', async () => {
   // Write a value.
   await withWrite(store, async wt => {
     await wt.put('foo', 'bar');
-    await wt.commit();
   });
 
   // Verify it's there.
@@ -68,7 +67,6 @@ suite('reopening IDB', () => {
     // Write a value.
     await withWrite(store, async wt => {
       await wt.put('foo', 'bar');
-      await wt.commit();
     });
 
     // close the IDB from under the IDBStore
@@ -77,7 +75,6 @@ suite('reopening IDB', () => {
     // write again, without error
     await withWrite(store, async wt => {
       await wt.put('baz', 'qux');
-      await wt.commit();
     });
 
     await withRead(store, async rt => {
@@ -90,7 +87,6 @@ suite('reopening IDB', () => {
     // Write a value.
     await withWrite(store, async wt => {
       await wt.put('foo', 'bar');
-      await wt.commit();
     });
 
     await dropStore(name);

--- a/packages/replicache/src/kv/mem-store.test.ts
+++ b/packages/replicache/src/kv/mem-store.test.ts
@@ -1,7 +1,7 @@
 import {resolver} from '@rocicorp/resolver';
 import {expect} from 'chai';
 import {withRead, withWrite} from '../with-transactions.js';
-import {clearAllNamedMemStoresForTesting, MemStore} from './mem-store.js';
+import {MemStore, clearAllNamedMemStoresForTesting} from './mem-store.js';
 import {runAll} from './store-test-util.js';
 
 runAll('NamedMemStore', () => new MemStore('test'));
@@ -14,7 +14,6 @@ test('Creating multiple with same name shares data', async () => {
   const store = new MemStore('test');
   await withWrite(store, async wt => {
     await wt.put('foo', 'bar');
-    await wt.commit();
   });
 
   const store2 = new MemStore('test');
@@ -27,7 +26,6 @@ test('Creating multiple with different name gets unique data', async () => {
   const store = new MemStore('test');
   await withWrite(store, async wt => {
     await wt.put('foo', 'bar');
-    await wt.commit();
   });
 
   const store2 = new MemStore('test2');
@@ -40,7 +38,6 @@ test('Multiple reads at the same time', async () => {
   const store = new MemStore('test');
   await withWrite(store, async wt => {
     await wt.put('foo', 'bar');
-    await wt.commit();
   });
 
   const {promise, resolve} = resolver();
@@ -67,7 +64,6 @@ test('Single write at a time', async () => {
   const store = new MemStore('test');
   await withWrite(store, async wt => {
     await wt.put('foo', 'bar');
-    await wt.commit();
   });
 
   const {promise: promise1, resolve: resolve1} = resolver();

--- a/packages/replicache/src/kv/store-test-util.ts
+++ b/packages/replicache/src/kv/store-test-util.ts
@@ -1,6 +1,10 @@
 import {expect} from 'chai';
 import type {FrozenJSONValue, ReadonlyJSONValue} from '../json.js';
-import {withRead, withWrite} from '../with-transactions.js';
+import {
+  withRead,
+  withWrite,
+  withWriteNoImplicitCommit,
+} from '../with-transactions.js';
 import type {Read, Store, Write} from './store.js';
 
 class TestStore implements Store {
@@ -29,14 +33,12 @@ class TestStore implements Store {
   async put(key: string, value: FrozenJSONValue): Promise<void> {
     await withWrite(this, async write => {
       await write.put(key, value);
-      await write.commit();
     });
   }
 
   async del(key: string): Promise<void> {
     await withWrite(this, async write => {
       await write.del(key);
-      await write.commit();
     });
   }
 
@@ -81,7 +83,6 @@ async function simpleCommit(store: TestStore): Promise<void> {
     expect(await wt.get('bar')).to.deep.equal('baz');
     await wt.put('other', 'abc');
     expect(await wt.get('other')).to.deep.equal('abc');
-    await wt.commit();
   });
 
   // Verify that the write was effective.
@@ -99,7 +100,6 @@ async function del(store: TestStore): Promise<void> {
     expect(await wt.has('bar')).to.be.false;
     await wt.put('bar', 'baz');
     await wt.put('other', 'abc');
-    await wt.commit();
   });
 
   // Delete
@@ -109,7 +109,6 @@ async function del(store: TestStore): Promise<void> {
     expect(await wt.has('bar')).to.be.false;
     await wt.del('other');
     expect(await wt.has('other')).to.be.false;
-    await wt.commit();
   });
 
   // Verify that the delete was effective.
@@ -124,19 +123,18 @@ async function del(store: TestStore): Promise<void> {
 async function readOnlyCommit(store: TestStore): Promise<void> {
   await withWrite(store, async wt => {
     expect(await wt.has('bar')).to.be.false;
-    await wt.commit();
   });
 }
 
 async function readOnlyRollback(store: TestStore): Promise<void> {
-  await withWrite(store, async wt => {
+  await withWriteNoImplicitCommit(store, async wt => {
     expect(await wt.has('bar')).to.be.false;
   });
 }
 
 async function simpleRollback(store: TestStore): Promise<void> {
   // Start a write transaction and put a value, then abort.
-  await withWrite(store, async wt => {
+  await withWriteNoImplicitCommit(store, async wt => {
     await wt.put('bar', 'baz');
     await wt.put('other', 'abc');
     // no commit, implicit rollback
@@ -186,13 +184,12 @@ async function writeTransaction(store: TestStore): Promise<void> {
     expect(await wt.has('k1')).to.be.true;
     expect(await wt.has('k2')).to.be.true;
     await wt.put('k1', 'overwrite');
-    await wt.commit();
   });
   expect(await store.get('k1')).to.deep.equal('overwrite');
   expect(await store.get('k2')).to.deep.equal('v2');
 
   // Test put then rollback.
-  await withWrite(store, async wt => {
+  await withWriteNoImplicitCommit(store, async wt => {
     await wt.put('k1', 'should be rolled back');
   });
   expect(await store.get('k1')).to.deep.equal('overwrite');
@@ -201,13 +198,12 @@ async function writeTransaction(store: TestStore): Promise<void> {
   await withWrite(store, async wt => {
     await wt.del('k1');
     expect(await wt.has('k1')).to.be.false;
-    await wt.commit();
   });
   expect(await store.has('k1')).to.be.false;
 
   // Test del then rollback.
   expect(await store.has('k2')).to.be.true;
-  await withWrite(store, async wt => {
+  await withWriteNoImplicitCommit(store, async wt => {
     await wt.del('k2');
     expect(await wt.has('k2')).to.be.false;
   });
@@ -218,7 +214,6 @@ async function writeTransaction(store: TestStore): Promise<void> {
     await wt.put('k2', 'overwrite');
     await wt.del('k2');
     await wt.put('k2', 'final');
-    await wt.commit();
   });
   expect(await store.get('k2')).to.deep.equal('final');
 
@@ -227,7 +222,6 @@ async function writeTransaction(store: TestStore): Promise<void> {
     await wt.put('k2', 'new value');
     expect(await wt.has('k2')).to.be.true;
     expect(await wt.get('k2')).to.deep.equal('new value');
-    await wt.commit();
   });
 }
 

--- a/packages/replicache/src/mutation-recovery.ts
+++ b/packages/replicache/src/mutation-recovery.ts
@@ -223,10 +223,9 @@ async function recoverMutationsOfClientV4(
     assertHash,
   );
   try {
-    await withWrite(lazyDagForOtherClient, async write => {
-      await write.setHead(DEFAULT_HEAD_NAME, client.headHash);
-      await write.commit();
-    });
+    await withWrite(lazyDagForOtherClient, write =>
+      write.setHead(DEFAULT_HEAD_NAME, client.headHash),
+    );
 
     if (isPushDisabled()) {
       lc.debug?.(
@@ -352,7 +351,6 @@ async function recoverMutationsOfClientV4(
 
       const setNewClients = async (newClients: ClientMap) => {
         await setClients(newClients, dagWrite);
-        await dagWrite.commit();
         return newClients;
       };
 
@@ -544,10 +542,9 @@ async function disableClientGroup(
   // The client group is not the main client group so we do not need the
   // Replicache instance to update its internal _isClientGroupDisabled
   // property.
-  await withWrite(perdag, async perdagWrite => {
-    await persistDisableClientGroup(clientGroupID, perdagWrite);
-    await perdagWrite.commit();
-  });
+  await withWrite(perdag, perdagWrite =>
+    persistDisableClientGroup(clientGroupID, perdagWrite),
+  );
 }
 
 /**
@@ -615,10 +612,9 @@ async function recoverMutationsOfClientGroupDD31(
     assertHash,
   );
   try {
-    await withWrite(lazyDagForOtherClientGroup, async write => {
-      await write.setHead(DEFAULT_HEAD_NAME, clientGroup.headHash);
-      await write.commit();
-    });
+    await withWrite(lazyDagForOtherClientGroup, write =>
+      write.setHead(DEFAULT_HEAD_NAME, clientGroup.headHash),
+    );
 
     if (isPushDisabled()) {
       lc.debug?.(
@@ -785,7 +781,6 @@ async function recoverMutationsOfClientGroupDD31(
         },
       });
       await setClientGroups(newClientGroups, dagWrite);
-      await dagWrite.commit();
       return newClientGroups;
     });
   } catch (e) {

--- a/packages/replicache/src/new-client-channel.test.ts
+++ b/packages/replicache/src/new-client-channel.test.ts
@@ -10,7 +10,7 @@ import {
   makeChannelNameV1ForTesting,
 } from './new-client-channel.js';
 import {setClientGroup} from './persist/client-groups.js';
-import {withWrite} from './with-transactions.js';
+import {withWriteNoImplicitCommit} from './with-transactions.js';
 
 function getChannelMessagePromise(
   replicacheName: string,
@@ -323,7 +323,7 @@ suite('initNewClientChannel', () => {
 });
 
 async function putClientGroup(perdag: TestStore, clientGroupID1: string) {
-  await withWrite(perdag, async perdagWrite => {
+  await withWriteNoImplicitCommit(perdag, async perdagWrite => {
     await setClientGroup(
       clientGroupID1,
       {

--- a/packages/replicache/src/persist/client-gc.test.ts
+++ b/packages/replicache/src/persist/client-gc.test.ts
@@ -92,7 +92,6 @@ test('initClientGC starts 5 min interval that collects clients that have been in
 
   await withWrite(dagStore, async dagWrite => {
     await setClient('client4', client4WUpdatedHeartbeat, dagWrite);
-    await dagWrite.commit();
   });
 
   await clock.tickAsync(FIVE_MINS_IN_MS);

--- a/packages/replicache/src/persist/client-gc.ts
+++ b/packages/replicache/src/persist/client-gc.ts
@@ -45,7 +45,6 @@ function gcClients(clientID: ClientID, dagStore: Store): Promise<ClientMap> {
     }
     const newClients = new Map(clientsAfterGC);
     await setClients(newClients, dagWrite);
-    await dagWrite.commit();
     return newClients;
   });
 }

--- a/packages/replicache/src/persist/client-group-gc.ts
+++ b/packages/replicache/src/persist/client-group-gc.ts
@@ -52,7 +52,6 @@ export function gcClientGroups(dagStore: Store): Promise<ClientGroupMap> {
       }
     }
     await setClientGroups(clientGroups, tx);
-    await tx.commit();
     return clientGroups;
   });
 }

--- a/packages/replicache/src/persist/client-groups.test.ts
+++ b/packages/replicache/src/persist/client-groups.test.ts
@@ -3,7 +3,7 @@ import type {Read, Store, Write} from '../dag/store.js';
 import {TestStore} from '../dag/test-store.js';
 import {Hash, assertHash, fakeHash} from '../hash.js';
 import type {ClientGroupID} from '../sync/ids.js';
-import {withRead, withWrite} from '../with-transactions.js';
+import {withRead, withWriteNoImplicitCommit} from '../with-transactions.js';
 import {
   ClientGroup,
   ClientGroupMap,
@@ -61,7 +61,7 @@ async function testSetClientGroups(
   dagStore: Store,
 ) {
   const clientGroupMap = makeClientGroupMap(partialClientGroupMap);
-  await withWrite(dagStore, async (write: Write) => {
+  await withWriteNoImplicitCommit(dagStore, async (write: Write) => {
     const returnClientGroupMap = await setClientGroups(clientGroupMap, write);
     expect(returnClientGroupMap).to.deep.equal(clientGroupMap);
     const readClientGroupMap = await getClientGroups(write);
@@ -110,7 +110,7 @@ async function testSetClientGroupsSequenceThrowsError(
 ) {
   await testSetClientGroups(partialClientGroupMap1, dagStore);
   const clientGroupMap2 = makeClientGroupMap(partialClientGroupMap2);
-  await withWrite(dagStore, async (write: Write) => {
+  await withWriteNoImplicitCommit(dagStore, async (write: Write) => {
     let expectedE: unknown;
     try {
       await setClientGroups(clientGroupMap2, write);
@@ -324,7 +324,7 @@ async function testSetClientGroup(
   const expectedClientGroupMap = makeClientGroupMap(
     expectedPartialClientGroupMap,
   );
-  await withWrite(dagStore, async (write: Write) => {
+  await withWriteNoImplicitCommit(dagStore, async (write: Write) => {
     const [clientGroupID, partialClientGroup] = partialClientGroupEntryToSet;
     const returnClientGroupMap = await setClientGroup(
       clientGroupID,
@@ -350,7 +350,7 @@ async function testSetClientGroupThrowsError(
   dagStore: Store,
 ) {
   const clientGroupMap1 = makeClientGroupMap(partialClientGroupMap1);
-  await withWrite(dagStore, async (write: Write) => {
+  await withWriteNoImplicitCommit(dagStore, async (write: Write) => {
     const returnClientGroupMap1 = await setClientGroups(clientGroupMap1, write);
     expect(returnClientGroupMap1).to.deep.equal(clientGroupMap1);
     const readClientGroupMap1 = await getClientGroups(write);
@@ -362,7 +362,7 @@ async function testSetClientGroupThrowsError(
     expect(readClientGroupMap1).to.deep.equal(readClientGroupMap1);
   });
 
-  await withWrite(dagStore, async (write: Write) => {
+  await withWriteNoImplicitCommit(dagStore, async (write: Write) => {
     const [clientGroupID, partialClientGroup] = partialClientGroupEntryToSet;
     const clientGroup = makeClientGroup(partialClientGroup);
     let expectedE: unknown;
@@ -640,12 +640,12 @@ test('deleteClientGroup', async () => {
     'client-group-2': clientGroup2,
   });
 
-  await withWrite(dagStore, async (write: Write) => {
+  await withWriteNoImplicitCommit(dagStore, async (write: Write) => {
     await setClientGroups(clientGroupMap1, write);
     await write.commit();
   });
 
-  await withWrite(dagStore, async (write: Write) => {
+  await withWriteNoImplicitCommit(dagStore, async (write: Write) => {
     const returnClientGroupMap = await deleteClientGroup(
       'client-group-3',
       write,
@@ -664,7 +664,7 @@ test('deleteClientGroup', async () => {
   const expectedClientGroupAfterDeletingClientGroup1 = makeClientGroupMap({
     'client-group-2': clientGroup2,
   });
-  await withWrite(dagStore, async (write: Write) => {
+  await withWriteNoImplicitCommit(dagStore, async (write: Write) => {
     const returnClientGroupMap = await deleteClientGroup(
       'client-group-1',
       write,
@@ -717,13 +717,13 @@ test('setClientGroups properly manages refs to client group heads when client gr
     },
   });
 
-  await withWrite(dagStore, async (write: Write) => {
+  await withWriteNoImplicitCommit(dagStore, async (write: Write) => {
     await setClientGroups(clientGroupMap1, write);
     await write.commit();
   });
   await expectRefs([clientGroup1HeadHash, clientGroup2HeadHash], dagStore);
 
-  await withWrite(dagStore, async (write: Write) => {
+  await withWriteNoImplicitCommit(dagStore, async (write: Write) => {
     await setClientGroups(clientGroupMap2, write);
     await write.commit();
   });
@@ -756,13 +756,13 @@ test("setClientGroup properly manages refs to client group heads when a client g
     'client-group-2': clientGroup2,
   });
 
-  await withWrite(dagStore, async (write: Write) => {
+  await withWriteNoImplicitCommit(dagStore, async (write: Write) => {
     await setClientGroups(clientGroupMap1, write);
     await write.commit();
   });
   await expectRefs([clientGroup1V1HeadHash, clientGroup2HeadHash], dagStore);
 
-  await withWrite(dagStore, async (write: Write) => {
+  await withWriteNoImplicitCommit(dagStore, async (write: Write) => {
     await setClientGroups(clientGroupMap2, write);
     await write.commit();
   });
@@ -784,13 +784,13 @@ test('setClientGroup properly manages refs to client group heads when a client g
     },
   });
 
-  await withWrite(dagStore, async (write: Write) => {
+  await withWriteNoImplicitCommit(dagStore, async (write: Write) => {
     await setClientGroups(clientGroupMap1, write);
     await write.commit();
   });
   await expectRefs([clientGroup1HeadHash, clientGroup2HeadHash], dagStore);
 
-  await withWrite(dagStore, async (write: Write) => {
+  await withWriteNoImplicitCommit(dagStore, async (write: Write) => {
     await setClientGroup(
       'client-group-3',
       makeClientGroup({
@@ -822,13 +822,13 @@ test("setClientGroup properly manages refs to client group heads when a client g
     },
   });
 
-  await withWrite(dagStore, async (write: Write) => {
+  await withWriteNoImplicitCommit(dagStore, async (write: Write) => {
     await setClientGroups(clientGroupMap1, write);
     await write.commit();
   });
   await expectRefs([clientGroup1V1HeadHash, clientGroup2HeadHash], dagStore);
 
-  await withWrite(dagStore, async (write: Write) => {
+  await withWriteNoImplicitCommit(dagStore, async (write: Write) => {
     await setClientGroup(
       'client-group-1',
       makeClientGroup({
@@ -856,13 +856,13 @@ test('deleteClientGroup properly manages refs to client group heads', async () =
     },
   });
 
-  await withWrite(dagStore, async (write: Write) => {
+  await withWriteNoImplicitCommit(dagStore, async (write: Write) => {
     await setClientGroups(clientGroupMap1, write);
     await write.commit();
   });
   await expectRefs([clientGroup1HeadHash, clientGroup2HeadHash], dagStore);
 
-  await withWrite(dagStore, async (write: Write) => {
+  await withWriteNoImplicitCommit(dagStore, async (write: Write) => {
     await deleteClientGroup('client-group-1', write);
     await write.commit();
   });
@@ -881,7 +881,7 @@ test('getClientGroup', async () => {
       headHash: headClientGroup2Hash,
     },
   });
-  await withWrite(dagStore, async (write: Write) => {
+  await withWriteNoImplicitCommit(dagStore, async (write: Write) => {
     await setClientGroups(clientGroupMap, write);
     await write.commit();
   });
@@ -983,7 +983,7 @@ test('Disable Client Group', async () => {
     'client-group-2': clientGroup2,
   });
 
-  await withWrite(dagStore, async (write: Write) => {
+  await withWriteNoImplicitCommit(dagStore, async (write: Write) => {
     await setClientGroups(clientGroupMap1, write);
     await write.commit();
   });
@@ -999,7 +999,7 @@ test('Disable Client Group', async () => {
     expect(readClientGroupMap.get('client-group-2')?.disabled).false;
   }
 
-  await withWrite(dagStore, async (write: Write) => {
+  await withWriteNoImplicitCommit(dagStore, async (write: Write) => {
     await disableClientGroup('client-group-1', write);
     await testDisabledState(write);
     await write.commit();

--- a/packages/replicache/src/persist/clients-test-helpers.ts
+++ b/packages/replicache/src/persist/clients-test-helpers.ts
@@ -35,7 +35,6 @@ export function setClientsForTesting(
 ): Promise<ClientMap> {
   return withWrite(dagStore, async dagWrite => {
     await setClients(clients, dagWrite);
-    await dagWrite.commit();
     return clients;
   });
 }
@@ -93,7 +92,6 @@ export async function deleteClientForTesting(
     const clients = new Map(await getClients(dagWrite));
     clients.delete(clientID);
     await setClients(clients, dagWrite);
-    await dagWrite.commit();
   });
 }
 
@@ -197,8 +195,6 @@ function initClientV4(
     await setClients(updatedClients, dagWrite);
 
     await Promise.all(chunksToPut.map(c => dagWrite.putChunk(c)));
-
-    await dagWrite.commit();
 
     return [newClientID, newClient, updatedClients, false];
   });

--- a/packages/replicache/src/persist/clients.test.ts
+++ b/packages/replicache/src/persist/clients.test.ts
@@ -19,7 +19,7 @@ import {assertHash, fakeHash, newUUIDHash} from '../hash.js';
 import type {IndexDefinitions} from '../index-defs.js';
 import {deepFreeze} from '../json.js';
 import type {ClientGroupID, ClientID} from '../sync/ids.js';
-import {withRead, withWrite} from '../with-transactions.js';
+import {withRead, withWriteNoImplicitCommit} from '../with-transactions.js';
 import {ClientGroup, getClientGroup, setClientGroup} from './client-groups.js';
 import {makeClientV6, setClientsForTesting} from './clients-test-helpers.js';
 import {
@@ -291,7 +291,7 @@ test('getClient', async () => {
 
 test('updateClients throws errors if clients head exist but the chunk it references does not', async () => {
   const dagStore = new TestStore();
-  await withWrite(dagStore, async (write: Write) => {
+  await withWriteNoImplicitCommit(dagStore, async (write: Write) => {
     await write.setHead('clients', randomStuffHash);
     await write.commit();
   });
@@ -308,7 +308,7 @@ test('updateClients throws errors if clients head exist but the chunk it referen
 
 test('updateClients throws errors if chunk pointed to by clients head does not contain a valid ClientMap', async () => {
   const dagStore = new TestStore();
-  await withWrite(dagStore, async (write: Write) => {
+  await withWriteNoImplicitCommit(dagStore, async (write: Write) => {
     const headHash = headClient1Hash;
     const chunk = write.createChunk(
       deepFreeze({
@@ -386,7 +386,7 @@ test('setClient', async () => {
   const dagStore = new TestStore();
 
   const t = async (clientID: ClientID, client: ClientV5) => {
-    await withWrite(dagStore, async (write: Write) => {
+    await withWriteNoImplicitCommit(dagStore, async (write: Write) => {
       await setClient(clientID, client, write);
       await write.commit();
     });
@@ -432,7 +432,7 @@ test('getClientGroupID', async () => {
     expectedClientGroupID: ClientGroupID | undefined,
     expectedClientGroup: ClientGroup | undefined,
   ) => {
-    await withWrite(dagStore, async write => {
+    await withWriteNoImplicitCommit(dagStore, async write => {
       await setClient(clientID, client, write);
       await setClientGroup(clientGroupID, clientGroup, write);
       await write.commit();
@@ -537,7 +537,7 @@ suite('findMatchingClient', () => {
     await b.addGenesis(clientID);
     await b.addLocal(clientID, []);
 
-    await withWrite(perdag, async write => {
+    await withWriteNoImplicitCommit(perdag, async write => {
       const client: ClientV5 = {
         clientGroupID,
         headHash: b.chain[1].chunk.hash,
@@ -638,7 +638,7 @@ suite('findMatchingClient', () => {
       mutatorNames: initialMutatorNames,
       disabled: false,
     };
-    await withWrite(perdag, async write => {
+    await withWriteNoImplicitCommit(perdag, async write => {
       await setClientGroup(clientGroupID, clientGroup, write);
       await write.commit();
     });
@@ -717,7 +717,7 @@ suite('initClientV6', () => {
       disabled: false,
     };
 
-    await withWrite(perdag, async write => {
+    await withWriteNoImplicitCommit(perdag, async write => {
       await setClient(clientID1, client1, write);
       await setClientGroup(clientGroupID, clientGroup1, write);
       await write.commit();
@@ -787,7 +787,7 @@ suite('initClientV6', () => {
       disabled: false,
     };
 
-    await withWrite(perdag, async write => {
+    await withWriteNoImplicitCommit(perdag, async write => {
       await setClient(clientID1, client1, write);
       await setClientGroup(clientGroupID1, clientGroup1, write);
       await write.commit();
@@ -876,7 +876,7 @@ suite('initClientV6', () => {
       disabled: false,
     };
 
-    await withWrite(perdag, async write => {
+    await withWriteNoImplicitCommit(perdag, async write => {
       await setClient(clientID1, client1, write);
       await setClientGroup(clientGroupID1, clientGroup1, write);
       await write.commit();

--- a/packages/replicache/src/persist/clients.ts
+++ b/packages/replicache/src/persist/clients.ts
@@ -30,7 +30,7 @@ import {IndexDefinitions, indexDefinitionsEqual} from '../index-defs.js';
 import {FrozenJSONValue, deepFreeze} from '../json.js';
 import type {ClientGroupID, ClientID} from '../sync/ids.js';
 import {uuid as makeUuid} from '../uuid.js';
-import {withWrite} from '../with-transactions.js';
+import {withWriteNoImplicitCommit} from '../with-transactions.js';
 import {
   ClientGroup,
   getClientGroup,
@@ -317,7 +317,7 @@ export function initClientV6(
   indexes: IndexDefinitions,
   formatVersion: FormatVersion,
 ): Promise<InitClientV6Result> {
-  return withWrite(perdag, async dagWrite => {
+  return withWriteNoImplicitCommit(perdag, async dagWrite => {
     async function setClientsAndClientGroupAndCommit(
       basisHash: Hash | null,
       cookieJSON: FrozenCookie,

--- a/packages/replicache/src/persist/collect-idb-databases.test.ts
+++ b/packages/replicache/src/persist/collect-idb-databases.test.ts
@@ -7,7 +7,7 @@ import {FormatVersion} from '../format-version.js';
 import {fakeHash} from '../hash.js';
 import {IDBStore} from '../kv/idb-store.js';
 import {TestMemStore} from '../kv/test-mem-store.js';
-import {withWrite} from '../with-transactions.js';
+import {withWriteNoImplicitCommit} from '../with-transactions.js';
 import {ClientGroupMap, setClientGroups} from './client-groups.js';
 import {makeClientGroupMap} from './client-groups.test.js';
 import {
@@ -87,7 +87,7 @@ suite('collectIDBDatabases', () => {
 
           await setClientsForTesting(clients, dagStore);
           if (clientGroups) {
-            await withWrite(dagStore, async tx => {
+            await withWriteNoImplicitCommit(dagStore, async tx => {
               await setClientGroups(clientGroups, tx);
               await tx.commit();
             });

--- a/packages/replicache/src/persist/gather-mem-only-visitor.test.ts
+++ b/packages/replicache/src/persist/gather-mem-only-visitor.test.ts
@@ -6,7 +6,7 @@ import {DEFAULT_HEAD_NAME, MetaType} from '../db/commit.js';
 import {ChainBuilder} from '../db/test-helpers.js';
 import {FormatVersion} from '../format-version.js';
 import {assertHash, makeNewFakeHashFunction} from '../hash.js';
-import {withRead, withWrite} from '../with-transactions.js';
+import {withRead, withWriteNoImplicitCommit} from '../with-transactions.js';
 import {GatherMemoryOnlyVisitor} from './gather-mem-only-visitor.js';
 
 suite('dag with no memory-only hashes gathers nothing', () => {
@@ -112,7 +112,7 @@ suite(
       await pb.addGenesis(clientID);
       await pb.addLocal(clientID);
 
-      await withWrite(memdag, async memdagWrite => {
+      await withWriteNoImplicitCommit(memdag, async memdagWrite => {
         await memdagWrite.setHead(DEFAULT_HEAD_NAME, pb.headHash);
         await memdagWrite.commit();
       });
@@ -204,7 +204,7 @@ suite(
         undefined,
         undefined,
       );
-      await withWrite(memdag, async memdagWrite => {
+      await withWriteNoImplicitCommit(memdag, async memdagWrite => {
         await memdagWrite.setHead(DEFAULT_HEAD_NAME, pb.headHash);
         await memdagWrite.commit();
       });

--- a/packages/replicache/src/persist/gather-not-cached-visitor.test.ts
+++ b/packages/replicache/src/persist/gather-not-cached-visitor.test.ts
@@ -4,7 +4,7 @@ import {TestStore} from '../dag/test-store.js';
 import {MetaType} from '../db/commit.js';
 import {ChainBuilder} from '../db/test-helpers.js';
 import {assertHash, makeNewFakeHashFunction} from '../hash.js';
-import {withRead, withWrite} from '../with-transactions.js';
+import {withRead, withWriteNoImplicitCommit} from '../with-transactions.js';
 import {GatherNotCachedVisitor} from './gather-not-cached-visitor.js';
 
 suite('GatherNotCachedVisitor', () => {
@@ -25,7 +25,7 @@ suite('GatherNotCachedVisitor', () => {
       return visitor.gatheredChunks;
     });
 
-    await withWrite(memdag, async dagWrite => {
+    await withWriteNoImplicitCommit(memdag, async dagWrite => {
       for (const {chunk, size} of gatheredChunks.values()) {
         await dagWrite.putChunk(chunk, size);
         await dagWrite.setHead('test', pb.headHash);
@@ -88,7 +88,7 @@ suite('GatherNotCachedVisitor', () => {
       return visitor.gatheredChunks;
     });
 
-    await withWrite(memdag, async dagWrite => {
+    await withWriteNoImplicitCommit(memdag, async dagWrite => {
       for (const {chunk, size} of gatheredChunks.values()) {
         await dagWrite.putChunk(chunk, size);
         await dagWrite.setHead('test', pb.headHash);

--- a/packages/replicache/src/persist/heartbeat.ts
+++ b/packages/replicache/src/persist/heartbeat.ts
@@ -59,7 +59,6 @@ export function writeHeartbeat(
     const newClients = new Map(clients).set(clientID, newClient);
 
     await setClients(newClients, dagWrite);
-    await dagWrite.commit();
     return newClients;
   });
 }

--- a/packages/replicache/src/persist/idb-databases-store.ts
+++ b/packages/replicache/src/persist/idb-databases-store.ts
@@ -77,16 +77,12 @@ export class IDBDatabasesStore {
         [db.name]: db,
       };
       await write.put(DBS_KEY, dbRecord);
-      await write.commit();
       return dbRecord;
     });
   }
 
   clearDatabases(): Promise<void> {
-    return withWrite(this.#kvStore, async write => {
-      await write.del(DBS_KEY);
-      await write.commit();
-    });
+    return withWrite(this.#kvStore, write => write.del(DBS_KEY));
   }
 
   deleteDatabases(names: Iterable<IndexedDBName>): Promise<void> {
@@ -99,7 +95,6 @@ export class IDBDatabasesStore {
         delete dbRecord[name];
       }
       await write.put(DBS_KEY, dbRecord);
-      await write.commit();
     });
   }
 
@@ -118,7 +113,6 @@ export class IDBDatabasesStore {
         // Profile id is 'p' followed by the guid with no dashes.
         profileId = `p${uuid().replace(/-/g, '')}`;
         await write.put(PROFILE_ID_KEY, profileId);
-        await write.commit();
       }
       assertString(profileId);
       return profileId;

--- a/packages/replicache/src/persist/persist-test-helpers.ts
+++ b/packages/replicache/src/persist/persist-test-helpers.ts
@@ -130,7 +130,5 @@ async function writeChunks(
     }
 
     await Promise.all(ps);
-
-    await dagWrite.commit();
   });
 }

--- a/packages/replicache/src/persist/persist.test.ts
+++ b/packages/replicache/src/persist/persist.test.ts
@@ -26,7 +26,7 @@ import type {MutatorDefs} from '../replicache.js';
 import {promiseVoid} from '../resolved-promises.js';
 import type {ClientGroupID, ClientID} from '../sync/ids.js';
 import type {WriteTransaction} from '../transactions.js';
-import {withRead, withWrite} from '../with-transactions.js';
+import {withRead, withWriteNoImplicitCommit} from '../with-transactions.js';
 import {
   CLIENT_GROUPS_HEAD_NAME,
   ClientGroup,
@@ -225,7 +225,7 @@ suite('persistDD31', () => {
     perdagClientGroupHeadHash: Hash,
     clientGroupPartial?: Partial<ClientGroup>,
   ) {
-    await withWrite(perdag, async perdagWrite => {
+    await withWriteNoImplicitCommit(perdag, async perdagWrite => {
       const clientGroup = await getClientGroup(clientGroupID, perdagWrite);
       assertNotUndefined(clientGroup);
       await setClientGroup(
@@ -828,7 +828,7 @@ suite('persistDD31', () => {
   test('persist throws a ClientStateNotFoundError if client is missing', async () => {
     await setupSnapshots();
 
-    await withWrite(perdag, async perdagWrite => {
+    await withWriteNoImplicitCommit(perdag, async perdagWrite => {
       const clientMap = await getClients(perdagWrite);
       const newClientMap = new Map(clientMap);
       newClientMap.delete(clients[0].clientID);

--- a/packages/replicache/src/persist/persist.ts
+++ b/packages/replicache/src/persist/persist.ts
@@ -224,14 +224,12 @@ export async function persistDD31(
     };
 
     await setClientGroup(mainClientGroupID, newMainClientGroup, perdagWrite);
-    await perdagWrite.commit();
   });
 
   if (gatheredChunks && memdagBaseSnapshotPersisted) {
-    await withWrite(memdag, async memdagWrite => {
-      memdagWrite.chunksPersisted([...gatheredChunks.keys()]);
-      await memdagWrite.commit();
-    });
+    await withWrite(memdag, memdagWrite =>
+      memdagWrite.chunksPersisted([...gatheredChunks.keys()]),
+    );
   }
 }
 

--- a/packages/replicache/src/persist/refresh.ts
+++ b/packages/replicache/src/persist/refresh.ts
@@ -153,7 +153,6 @@ export async function refresh(
           };
 
           await setClient(clientID, newClient, perdagWrite);
-          await perdagWrite.commit();
           return [
             perdagClientGroupHeadHash,
             perdagClientGroupBaseSnapshot,
@@ -248,7 +247,6 @@ export async function refresh(
         );
 
         await memdagWrite.setHead(DEFAULT_HEAD_NAME, newMemdagHeadHash);
-        await memdagWrite.commit();
         return {
           type: 'complete',
           newMemdagHeadHash,
@@ -273,8 +271,6 @@ export async function refresh(
       // If this cleanup never happens, it's no big deal, some data will stay
       // alive longer but next refresh will fix it.
       await setClient(clientID, newClient, perdagWrite);
-
-      await perdagWrite.commit();
     });
 
   if (result.type === 'aborted') {

--- a/packages/replicache/src/replicache-mutation-recovery-dd31.test.ts
+++ b/packages/replicache/src/replicache-mutation-recovery-dd31.test.ts
@@ -48,7 +48,7 @@ import {
   tickAFewTimes,
 } from './test-util.js';
 import {uuid} from './uuid.js';
-import {withRead, withWrite} from './with-transactions.js';
+import {withRead, withWriteNoImplicitCommit} from './with-transactions.js';
 
 // fetch-mock has invalid d.ts file so we removed that on npm install.
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -2155,7 +2155,7 @@ suite('DD31', () => {
     );
     assertClientV6(client1);
     expect(client1.clientGroupID).to.not.equal(await rep.clientGroupID);
-    await withWrite(testPerdagDD31, async write => {
+    await withWriteNoImplicitCommit(testPerdagDD31, async write => {
       await disableClientGroup(client1.clientGroupID, write);
       await write.commit();
     });

--- a/packages/replicache/src/replicache-persist.test.ts
+++ b/packages/replicache/src/replicache-persist.test.ts
@@ -37,7 +37,7 @@ import {
 } from './persist/clients.js';
 import type {MutatorDefs} from './replicache.js';
 import type {WriteTransaction} from './transactions.js';
-import {withRead, withWrite} from './with-transactions.js';
+import {withRead, withWriteNoImplicitCommit} from './with-transactions.js';
 
 initReplicacheTesting();
 
@@ -52,7 +52,7 @@ async function deleteClientGroupForTesting<
 >(rep: ReplicacheTest<MD>) {
   const clientGroupID = await rep.clientGroupID;
   assert(clientGroupID);
-  await withWrite(rep.perdag, async tx => {
+  await withWriteNoImplicitCommit(rep.perdag, async tx => {
     await deleteClientGroup(clientGroupID, tx);
     await tx.commit();
   });

--- a/packages/replicache/src/sync/patch.test.ts
+++ b/packages/replicache/src/sync/patch.test.ts
@@ -10,7 +10,7 @@ import {
 import {FormatVersion} from '../format-version.js';
 import type {JSONValue} from '../json.js';
 import {assertPatchOperations} from '../patch-operation.js';
-import {withWrite} from '../with-transactions.js';
+import {withWriteNoImplicitCommit} from '../with-transactions.js';
 import {apply} from './patch.js';
 
 suite('patch', () => {
@@ -165,7 +165,7 @@ suite('patch', () => {
     for (const c of cases) {
       const b = new ChainBuilder(store, undefined, formatVersion);
       await b.addGenesis(clientID);
-      await withWrite(store, async dagWrite => {
+      await withWriteNoImplicitCommit(store, async dagWrite => {
         let dbWrite;
         if (formatVersion >= FormatVersion.DD31) {
           dbWrite = await newWriteSnapshotDD31(

--- a/packages/replicache/src/sync/pull.test.ts
+++ b/packages/replicache/src/sync/pull.test.ts
@@ -47,7 +47,11 @@ import type {
 } from '../puller.js';
 import {stringCompare} from '../string-compare.js';
 import {testSubscriptionsManagerOptions} from '../test-util.js';
-import {withRead, withWrite} from '../with-transactions.js';
+import {
+  withRead,
+  withWrite,
+  withWriteNoImplicitCommit,
+} from '../with-transactions.js';
 import type {DiffsMap} from './diff.js';
 import {
   BeginPullResponseV0,
@@ -413,7 +417,6 @@ test('begin try pull SDD', async () => {
         b.chain[b.chain.length - 1].chunk.hash,
       );
       await w.removeHead(SYNC_HEAD_NAME);
-      await w.commit();
     });
     for (let i = 0; i < c.numPendingMutations; i++) {
       await b.addLocal(clientID);
@@ -955,7 +958,6 @@ test('begin try pull DD31', async () => {
         b.chain[b.chain.length - 1].chunk.hash,
       );
       await w.removeHead(SYNC_HEAD_NAME);
-      await w.commit();
     });
     for (let i = 0; i < c.numPendingMutations; i++) {
       await b.addLocal(clientID);
@@ -1170,7 +1172,7 @@ suite('maybe end try pull', () => {
       for (let j = 0; j < c.numPending; j++) {
         await b.addLocal(clientID);
       }
-      let basisHash = await withWrite(store, async dagWrite => {
+      let basisHash = await withWriteNoImplicitCommit(store, async dagWrite => {
         await dagWrite.setHead(
           DEFAULT_HEAD_NAME,
           b.chain[b.chain.length - 1].chunk.hash,
@@ -1216,7 +1218,7 @@ suite('maybe end try pull', () => {
         } else {
           throw new Error('impossible');
         }
-        basisHash = await withWrite(store, async dagWrite => {
+        basisHash = await withWriteNoImplicitCommit(store, async dagWrite => {
           const w = await newWriteLocal(
             basisHash,
             mutatorName,

--- a/packages/replicache/src/sync/pull.ts
+++ b/packages/replicache/src/sync/pull.ts
@@ -49,7 +49,7 @@ import type {
   PullResponseV1,
 } from '../puller.js';
 import {toError} from '../to-error.js';
-import {withRead, withWrite} from '../with-transactions.js';
+import {withRead, withWriteNoImplicitCommit} from '../with-transactions.js';
 import {addDiffsForIndexes, DiffComputationConfig, DiffsMap} from './diff.js';
 import type {ClientGroupID, ClientID} from './ids.js';
 import * as patch from './patch.js';
@@ -305,7 +305,7 @@ export function handlePullResponseV0(
 ): Promise<HandlePullResponseResult> {
   // It is possible that another sync completed while we were pulling. Ensure
   // that is not the case by re-checking the base snapshot.
-  return withWrite(store, async dagWrite => {
+  return withWriteNoImplicitCommit(store, async dagWrite => {
     assert(formatVersion <= FormatVersion.SDD);
     const dagRead = dagWrite;
     const mainHead = await dagRead.getHead(DEFAULT_HEAD_NAME);
@@ -461,7 +461,7 @@ export function handlePullResponseV1(
 ): Promise<HandlePullResponseResult> {
   // It is possible that another sync completed while we were pulling. Ensure
   // that is not the case by re-checking the base snapshot.
-  return withWrite(store, async dagWrite => {
+  return withWriteNoImplicitCommit(store, async dagWrite => {
     const dagRead = dagWrite;
     const mainHead = await dagRead.getHead(DEFAULT_HEAD_NAME);
     if (mainHead === undefined) {
@@ -563,7 +563,7 @@ export function maybeEndPull<M extends LocalMeta>(
   replayMutations: Commit<M>[];
   diffs: DiffsMap;
 }> {
-  return withWrite(store, async dagWrite => {
+  return withWriteNoImplicitCommit(store, async dagWrite => {
     const dagRead = dagWrite;
     // Ensure sync head is what the caller thinks it is.
     const syncHeadHash = await dagRead.getHead(SYNC_HEAD_NAME);

--- a/packages/replicache/src/sync/push.test.ts
+++ b/packages/replicache/src/sync/push.test.ts
@@ -206,7 +206,6 @@ test('try push [SDD]', async () => {
         b.chain[b.chain.length - 1].chunk.hash,
       );
       await w.removeHead(SYNC_HEAD_NAME);
-      await w.commit();
     });
     for (let i = 0; i < c.numPendingMutations; i++) {
       await b.addLocal(clientID);
@@ -452,7 +451,6 @@ test('try push [DD31]', async () => {
         b.chain[b.chain.length - 1].chunk.hash,
       );
       await w.removeHead(SYNC_HEAD_NAME);
-      await w.commit();
     });
     for (let i = 0; i < c.numPendingMutations; i++) {
       await b.addLocal(clientID);

--- a/packages/replicache/src/sync/test-helpers.ts
+++ b/packages/replicache/src/sync/test-helpers.ts
@@ -14,7 +14,7 @@ import {
 } from '../db/write.js';
 import {FormatVersion} from '../format-version.js';
 import {SYNC_HEAD_NAME} from '../sync/sync-head-name.js';
-import {withRead, withWrite} from '../with-transactions.js';
+import {withRead, withWriteNoImplicitCommit} from '../with-transactions.js';
 import type {ClientID} from './ids.js';
 
 // See db.test_helpers for addLocal, addSnapshot, etc. We can't put addLocalRebase
@@ -50,7 +50,7 @@ export async function addSyncSnapshot(
 
   // Add sync snapshot.
   const cookie = `sync_cookie_${chain.length}`;
-  await withWrite(store, async dagWrite => {
+  await withWriteNoImplicitCommit(store, async dagWrite => {
     if (formatVersion >= FormatVersion.DD31) {
       const w = await newWriteSnapshotDD31(
         baseSnapshot.chunk.hash,


### PR DESCRIPTION
This is done by adding a new function called `withWriteNoImplicitCommit` which allows manual `commit` if needed.

Towards #135