### PR TITLE
feat(mirror): track connection lifetimes from FetchEvents in a separate dataset

### DIFF
--- a/mirror/mirror-cli/src/publish-tail-workers.ts
+++ b/mirror/mirror-cli/src/publish-tail-workers.ts
@@ -23,6 +23,10 @@ export async function publishTailWorkersHandler(
           binding: 'runningConnectionSecondsDS',
           dataset: 'RunningConnectionSeconds',
         },
+        {
+          binding: 'connectionLifetimesDS',
+          dataset: 'ConnectionLifetimes',
+        },
       ],
     },
     /* eslint-enable @typescript-eslint/naming-convention */

--- a/mirror/mirror-workers/src/connections-reporter/connections-reporter.test.ts
+++ b/mirror/mirror-workers/src/connections-reporter/connections-reporter.test.ts
@@ -1,25 +1,41 @@
-import {afterEach, describe, expect, jest, test} from '@jest/globals';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from '@jest/globals';
 import {CONNECTION_SECONDS_CHANNEL_NAME} from 'shared/src/events/connection-seconds.js';
 import type {Env} from './index.js';
-import reporter from './index.js';
+import reporter, {AUTH_DATA_HEADER_NAME} from './index.js';
 
 describe('connections reporter', () => {
-  const dataset = {
+  const runningConnectionSecondsDS = {
     writeDataPoint: jest.fn(),
   };
+  const connectionLifetimesDS = {
+    writeDataPoint: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
 
   afterEach(() => {
     jest.resetAllMocks();
   });
 
   function env(): Env {
-    return {runningConnectionSecondsDS: dataset};
+    return {runningConnectionSecondsDS, connectionLifetimesDS};
   }
 
-  test('reports valid data points', () => {
+  test('reports valid running connection seconds', () => {
     reporter.tail(
       [
         {
+          event: null,
+          eventTimestamp: null,
           scriptTags: [
             'appID:foo',
             'appName:bar',
@@ -62,6 +78,8 @@ describe('connections reporter', () => {
           ],
         },
         {
+          event: null,
+          eventTimestamp: null,
           scriptTags: ['missing:tags'],
           diagnosticsChannelEvents: [
             {
@@ -75,6 +93,8 @@ describe('connections reporter', () => {
           ],
         },
         {
+          event: null,
+          eventTimestamp: null,
           scriptTags: [
             'appID:boo',
             'appName:far',
@@ -120,12 +140,108 @@ describe('connections reporter', () => {
       ],
       env(),
     );
-    expect(dataset.writeDataPoint).toBeCalledTimes(4);
-    expect(dataset.writeDataPoint.mock.calls.map(call => call[0])).toEqual([
+    expect(runningConnectionSecondsDS.writeDataPoint).toBeCalledTimes(4);
+    expect(
+      runningConnectionSecondsDS.writeDataPoint.mock.calls.map(call => call[0]),
+    ).toEqual([
       {blobs: ['baz', 'foo'], doubles: [48.5, 60]},
       {blobs: ['baz', 'foo'], doubles: [40.2, 60]},
       {blobs: ['faz', 'boo'], doubles: [31.5, 60]},
       {blobs: ['faz', 'boo'], doubles: [15.2, 30]},
+    ]);
+  });
+
+  test('reports RoomDO connection lifetimes', () => {
+    const TAIL_EVENT_TIME = 123456;
+    jest.setSystemTime(TAIL_EVENT_TIME);
+
+    reporter.tail(
+      [
+        {
+          event: {
+            request: {
+              headers: {
+                [AUTH_DATA_HEADER_NAME]: 'REDACTED',
+              },
+            },
+          },
+          eventTimestamp: 98765,
+          scriptTags: [
+            'appID:foo',
+            'appName:bar',
+            'teamID:baz',
+            'teamLabel:bonk',
+          ],
+          diagnosticsChannelEvents: [],
+        },
+        {
+          event: {
+            request: {
+              headers: {
+                // Not from RoomDO
+              },
+            },
+          },
+          eventTimestamp: 98765,
+          scriptTags: [
+            'appID:foo',
+            'appName:bar',
+            'teamID:baz',
+            'teamLabel:bonk',
+          ],
+          diagnosticsChannelEvents: [],
+        },
+        {
+          event: {
+            request: {
+              headers: {
+                [AUTH_DATA_HEADER_NAME]: 'REDACTED',
+              },
+            },
+          },
+          eventTimestamp: null,
+          scriptTags: ['missing:tags'],
+          diagnosticsChannelEvents: [],
+        },
+        {
+          event: {
+            /* not a fetch event */
+          },
+          eventTimestamp: 87328,
+          scriptTags: [
+            'appID:boo',
+            'appName:far',
+            'teamID:faz',
+            'teamLabel:funk',
+          ],
+          diagnosticsChannelEvents: [],
+        },
+        {
+          event: {
+            request: {
+              headers: {
+                [AUTH_DATA_HEADER_NAME]: 'REDACTED',
+              },
+            },
+          },
+          eventTimestamp: 87328,
+          scriptTags: [
+            'appID:boo',
+            'appName:far',
+            'teamID:faz',
+            'teamLabel:funk',
+          ],
+          diagnosticsChannelEvents: [],
+        },
+      ],
+      env(),
+    );
+    expect(connectionLifetimesDS.writeDataPoint).toBeCalledTimes(2);
+    expect(
+      connectionLifetimesDS.writeDataPoint.mock.calls.map(call => call[0]),
+    ).toEqual([
+      {blobs: ['baz', 'foo'], doubles: [98765, TAIL_EVENT_TIME]},
+      {blobs: ['faz', 'boo'], doubles: [87328, TAIL_EVENT_TIME]},
     ]);
   });
 });

--- a/mirror/mirror-workers/src/connections-reporter/index.ts
+++ b/mirror/mirror-workers/src/connections-reporter/index.ts
@@ -6,57 +6,120 @@ import {
 import {type ScriptTags, parseScriptTags} from '../script-tags.js';
 
 export interface Env {
-  // blob1  | blob2 | double1 | double2
-  // -----------------------------------
-  // teamID | appID | elapsed | interval
+  // blob1  | blob2 | double1 | double2  | timestamp
+  // -----------------------------------------------------------
+  // teamID | appID | elapsed | interval | (report time)
   runningConnectionSecondsDS: AnalyticsEngineDataset;
+
+  // blob1  | blob2 | double1    | double2  | timestamp
+  // -------------------------------------------------------------------------
+  // teamID | appID | start-time | end-time | (report time should == end-time)
+  connectionLifetimesDS: AnalyticsEngineDataset;
 }
 
 function reportConnectionSeconds(
   runningConnectionSecondsDS: AnalyticsEngineDataset,
-  scriptTags: ScriptTags,
+  tags: ScriptTags,
   diagnosticChannelMessage: unknown,
 ) {
   const report = v.parse(diagnosticChannelMessage, reportSchema); // Note: 'strict'
   if (report.elapsed <= 0 || report.interval <= 0) {
     console.warn(
-      `Suspicious ConnectionSecondsReport from ${scriptTags.appID} (${scriptTags.appName}.${scriptTags.teamLabel})`,
+      `Suspicious ConnectionSecondsReport from ${tags.appID} (${tags.appName}.${tags.teamLabel})`,
       report,
     );
     return;
   }
   runningConnectionSecondsDS.writeDataPoint({
-    blobs: [scriptTags.teamID, scriptTags.appID],
+    blobs: [tags.teamID, tags.appID],
     doubles: [report.elapsed, report.interval],
   });
+  console.info(
+    `Reported connection seconds for ${tags.appName}.${tags.teamLabel}`,
+    report,
+  );
 }
 
 // To make tests easier to mock, be explicit about which fields we read.
-type TailItem = Pick<TraceItem, 'scriptTags' | 'diagnosticsChannelEvents'>;
+type TailItem = Pick<
+  TraceItem,
+  'scriptTags' | 'diagnosticsChannelEvents' | 'eventTimestamp' | 'event'
+>;
 
-export default {
-  tail(events: TailItem[], env: Env) {
-    for (const {scriptTags, diagnosticsChannelEvents} of events) {
-      let tags: ScriptTags;
-      try {
-        tags = parseScriptTags(scriptTags ?? []);
-      } catch (e) {
-        console.error(`Missing expected script tags: ${String(e)}`, scriptTags);
-        continue;
-      }
-      for (const e of diagnosticsChannelEvents) {
-        if (e.channel === CONNECTION_SECONDS_CHANNEL_NAME) {
-          try {
-            reportConnectionSeconds(
-              env.runningConnectionSecondsDS,
-              tags,
-              e.message,
-            );
-          } catch (e) {
-            console.error(`Invalid ConnectionSecondsReport: ${String(e)}`, e);
-          }
+function reportRunningConnectionElapsedSeconds(
+  events: TailItem[],
+  runningConnectionSecondsDS: AnalyticsEngineDataset,
+) {
+  for (const {scriptTags, diagnosticsChannelEvents} of events) {
+    if (diagnosticsChannelEvents.length === 0) {
+      continue; // Optimization: Avoid parsing script tags.
+    }
+    let tags: ScriptTags;
+    try {
+      tags = parseScriptTags(scriptTags ?? []);
+    } catch (e) {
+      console.error(`Missing expected script tags: ${String(e)}`, scriptTags);
+      continue;
+    }
+    for (const e of diagnosticsChannelEvents) {
+      if (e.channel === CONNECTION_SECONDS_CHANNEL_NAME) {
+        try {
+          reportConnectionSeconds(runningConnectionSecondsDS, tags, e.message);
+        } catch (e) {
+          console.error(`Invalid ConnectionSecondsReport: ${String(e)}`, e);
         }
       }
     }
+  }
+}
+
+export const AUTH_DATA_HEADER_NAME = 'x-reflect-auth-data';
+
+function reportConnectionLifetimes(
+  events: TailItem[],
+  connectionLifetimesDS: AnalyticsEngineDataset,
+) {
+  const endTime = Date.now();
+  for (const {scriptTags, event, eventTimestamp} of events) {
+    // Test if this is a FetchEvent received by the RoomDO. This is determined by the
+    // presence of the "x-reflect-auth-data" header. This effectively filters out the
+    // duplicate FetchEvents created by the intervening WorkerRouter and AuthDO, as
+    // well as unrelated FetchEvents like metrics reports.
+    const fetch = event as TraceItemFetchEventInfo;
+    const authData = fetch?.request?.headers?.[AUTH_DATA_HEADER_NAME];
+    if (!authData) {
+      continue;
+    }
+    let tags: ScriptTags;
+    try {
+      tags = parseScriptTags(scriptTags ?? []);
+    } catch (e) {
+      console.error(`Missing expected script tags: ${String(e)}`, scriptTags);
+      continue;
+    }
+    if (!eventTimestamp) {
+      console.error(`Missing eventTimestamp in FetchEvent`);
+      continue;
+    }
+    connectionLifetimesDS.writeDataPoint({
+      blobs: [tags.teamID, tags.appID],
+      doubles: [eventTimestamp, endTime],
+    });
+    console.info(
+      `Reported connection lifetime for ${tags.appName}.${tags.teamLabel} (${
+        (endTime - eventTimestamp) / 1000
+      } seconds)`,
+    );
+  }
+}
+
+export default {
+  tail(events: TailItem[], env: Env) {
+    reportConnectionLifetimes(events, env.connectionLifetimesDS);
+
+    reportRunningConnectionElapsedSeconds(
+      events,
+      env.runningConnectionSecondsDS,
+    );
   },
 };


### PR DESCRIPTION
In addition to tracking the elapsed running times of connections from within the RoomDO, track total connection lifetimes from the FetchEvents they produce. The former is subject to manipulation from malicious code, while the latter has the downside of not having information for connections that have not yet closed.

Ideally, the two datasets should produce similar connection seconds, modulo:
* delay from when a connection is closed to when a FetchEvent is surfaced
* missing information from connections that are still open
* Cloudflare clocks

We will make the decision of how best to use both datasets when we have real data from running apps.