### PR TITLE
chore: Export valita Type as Type

### DIFF
--- a/mirror/mirror-protocol/src/error.ts
+++ b/mirror/mirror-protocol/src/error.ts
@@ -10,7 +10,7 @@ export type ErrorInfo = {
   cause?: ErrorInfo | undefined;
 };
 
-const errorInfoSchema: v.ValitaType<ErrorInfo> = v.lazy<ErrorInfo>(() =>
+const errorInfoSchema: v.Type<ErrorInfo> = v.lazy<ErrorInfo>(() =>
   v.object({
     desc: v.string(), // String(e)
     name: v.string().optional(), // Error.name

--- a/packages/replicache/src/index-defs.ts
+++ b/packages/replicache/src/index-defs.ts
@@ -25,7 +25,7 @@ export type IndexDefinition = {
   readonly allowEmpty?: boolean | undefined;
 };
 
-export const indexDefinitionSchema: valita.ValitaType<IndexDefinition> =
+export const indexDefinitionSchema: valita.Type<IndexDefinition> =
   valita.readonlyObject({
     prefix: valita.string().optional(),
     jsonPointer: valita.string(),

--- a/packages/replicache/src/sync/ids.ts
+++ b/packages/replicache/src/sync/ids.ts
@@ -6,12 +6,11 @@ import * as valita from 'shared/src/valita.js';
  */
 export type ClientGroupID = string;
 
-export const clientGroupIDSchema: valita.ValitaType<ClientGroupID> =
-  valita.string();
+export const clientGroupIDSchema: valita.Type<ClientGroupID> = valita.string();
 
 /**
  * The ID describing a client.
  */
 export type ClientID = string;
 
-export const clientIDSchema: valita.ValitaType<ClientID> = valita.string();
+export const clientIDSchema: valita.Type<ClientID> = valita.string();

--- a/packages/shared/src/valita.ts
+++ b/packages/shared/src/valita.ts
@@ -122,7 +122,7 @@ export type ParseOptionsMode = 'passthrough' | 'strict' | 'strip';
 
 export function parse<T>(
   value: unknown,
-  schema: Type<T>,
+  schema: v.Type<T>,
   mode?: ParseOptionsMode,
 ): T {
   const res = test(value, schema, mode);
@@ -134,7 +134,7 @@ export function parse<T>(
 
 export function is<T>(
   value: unknown,
-  schema: Type<T>,
+  schema: v.Type<T>,
   mode?: ParseOptionsMode,
 ): value is T {
   return test(value, schema, mode).ok;
@@ -142,7 +142,7 @@ export function is<T>(
 
 export function assert<T>(
   value: unknown,
-  schema: Type<T>,
+  schema: v.Type<T>,
   mode?: ParseOptionsMode,
 ): asserts value is T {
   parse(value, schema, mode);
@@ -152,7 +152,7 @@ type Result<T> = {ok: true; value: T} | {ok: false; error: string};
 
 export function test<T>(
   value: unknown,
-  schema: Type<T>,
+  schema: v.Type<T>,
   mode?: ParseOptionsMode,
 ): Result<T> {
   const res = (schema as v.Type<T>).try(value, mode ? {mode} : undefined);
@@ -161,19 +161,6 @@ export function test<T>(
   }
   return res;
 }
-
-// We re-export the valita type `Type` but we only allow the `optional`
-// property. This is to prevent calling `.parse` on it which would not use our
-// formatting of the error message.
-export type Type<T> = Omit<
-  v.Type<T>,
-  'parse' | 'try' | 'assert' | 'map' | 'chain'
->;
-
-// Re-export the valita type `Type` using a longer less convenient name because
-// we do need it in a few places.
-// TODO(arv): Figure out a better way to do this.
-export type ValitaType<T> = v.Type<T>;
 
 /**
  * Shallowly marks the schema as readonly.


### PR DESCRIPTION
I had an idea that I wanted to hide the valita parse instance method but the hiding was just causing problems in practice.