### PR TITLE
More release process changes:

### DIFF
--- a/packages/reflect/package.json
+++ b/packages/reflect/package.json
@@ -17,7 +17,6 @@
     "check-types": "tsc --noEmit",
     "lint": "eslint --ext .ts,.tsx,.js,.jsx tool/",
     "//": "Force is used to ensure reflect-shared is rebuilt picking up the latest version from this package.json",
-    "prepack": "turbo run test --force",
     "postpack": "node tool/check-version.js && node tool/check-ambient-context.js",
     "create-canary": "node tool/create-canary.js"
   },


### PR DESCRIPTION
- Fix errors in canary script
- Remove 'npm test' from publish! Since we're always building HEAD and we have continuous tests, no longer need!