### PR TITLE
fix(reflect-create): npm run build no lint

### DIFF
--- a/mirror/reflect-cli/templates/create/package.json
+++ b/mirror/reflect-cli/templates/create/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "npm run lint && tsc && vite build",
+    "build": "tsc && vite build",
     "preview": "vite preview",
     "watch": "concurrently --kill-others 'npx reflect dev --silence-startup-message' 'VITE_REFLECT_URL=http://127.0.0.1:8080/ npm run dev'"
   },


### PR DESCRIPTION
The build script in templates/create/package.json was trying to run lint which does not exist. This was causing the build to fail.