### PR TITLE
fix(reflect-cli): fix behavior when reflect is run outside of a git dir

### DIFF
--- a/mirror/reflect-cli/src/app-config.ts
+++ b/mirror/reflect-cli/src/app-config.ts
@@ -54,13 +54,12 @@ export type AppConfig = v.Infer<typeof appConfigSchema>;
  * Finds the root of the git repository.
  */
 function findGitRoot(p = process.cwd()): string | undefined {
-  if (!fs.existsSync(p)) {
-    return undefined;
-  }
-
   const gitDir = path.join(p, '.git');
   if (fs.existsSync(gitDir)) {
     return p;
+  }
+  if (p === path.sep || !fs.existsSync(p)) {
+    return undefined;
   }
   const parent = path.join(p, '..');
   return findGitRoot(parent);


### PR DESCRIPTION
Avoid infinite recursion when `reflect` is run outside of an app directory.
 
![Screenshot 2023-10-19 at 5 19 36 PM](https://github.com/rocicorp/mono/assets/132324914/50ac808d-6f18-42fc-9d60-f162ede32543)
