### PR TITLE
fix(mirror-server): use 4xx status codes for deprecation errors

### DIFF
--- a/mirror/mirror-server/src/functions/app/create.function.test.ts
+++ b/mirror/mirror-server/src/functions/app/create.function.test.ts
@@ -231,10 +231,10 @@ describe('app-create function', () => {
       await callCreate(appName, '0.35.0', undefined, {
         rec: new SemVer('0.35.1'),
       });
-      throw new Error('Expected unavailable');
+      throw new Error('Expected out-of-range');
     } catch (e) {
       expect(e).toBeInstanceOf(HttpsError);
-      expect((e as HttpsError).code).toBe('unavailable');
+      expect((e as HttpsError).code).toBe('out-of-range');
     }
 
     const resp = await callCreate(appName, '0.35.1', undefined, {

--- a/mirror/mirror-server/src/functions/app/create.function.ts
+++ b/mirror/mirror-server/src/functions/app/create.function.ts
@@ -58,7 +58,7 @@ export const create = (firestore: Firestore, testDistTags?: DistTags) =>
         gt(minNonDeprecated, new SemVer(userAgent.version))
       ) {
         throw new HttpsError(
-          'unavailable',
+          'out-of-range',
           'This version of Reflect is deprecated. Please update to @rocicorp/reflect@latest to create a new app.',
         );
       }
@@ -159,7 +159,7 @@ function supportsWorkersForPlatforms(userAgent: UserAgent): boolean {
   const {type: agent, version} = userAgent;
   if (agent !== 'reflect-cli') {
     throw new HttpsError(
-      'unavailable',
+      'invalid-argument',
       'Please use @rocicorp/reflect to create and publish apps.',
     );
   }

--- a/mirror/mirror-server/src/functions/app/tail.handler.ts
+++ b/mirror/mirror-server/src/functions/app/tail.handler.ts
@@ -48,7 +48,7 @@ export const tail = (
 
         if (scriptRef) {
           throw new HttpsError(
-            'unavailable',
+            'out-of-range',
             'The App does not support this version of tail. ' +
               'Please try again with `npx @rocicorp/reflect@latest`.',
           );

--- a/mirror/mirror-server/src/functions/validators/version.test.ts
+++ b/mirror/mirror-server/src/functions/validators/version.test.ts
@@ -7,15 +7,15 @@ import {
   Request,
 } from 'firebase-functions/v2/https';
 import type {AuthData} from 'firebase-functions/v2/tasks';
-import {validateSchema} from './schema.js';
 import {
   baseRequestFields,
   baseResponseFields,
 } from 'mirror-protocol/src/base.js';
+import {SemVer} from 'semver';
 import * as v from 'shared/src/valita.js';
+import {validateSchema} from './schema.js';
 import type {Callable} from './types.js';
 import {userAgentVersion, type DistTags} from './version.js';
-import {SemVer} from 'semver';
 
 const testRequestSchema = v.object({
   ...baseRequestFields,
@@ -69,7 +69,7 @@ describe('user agent version check', () => {
       agent: 'reflect-cli',
       version: '0.35.1',
       distTags: {sup: '0.36.0'},
-      errorCode: 'unavailable',
+      errorCode: 'out-of-range',
     },
     {
       name: 'unregulated agent',

--- a/mirror/mirror-server/src/functions/validators/version.ts
+++ b/mirror/mirror-server/src/functions/validators/version.ts
@@ -72,7 +72,7 @@ function checkAgent(
   const minSupported = distTags[DistTag.MinSupported];
   if (minSupported && gt(minSupported, version)) {
     throw new HttpsError(
-      'unavailable',
+      'out-of-range',
       'This version of Reflect is no longer supported. Please update to @rocicorp/reflect@latest.',
     );
   }


### PR DESCRIPTION
Use `out-of-range` and `invalid-argument` for client side agent / version errors.

These map to 4xx errors and will thus require a higher threshold before alerting.
`unavailable`, on the other hand, is a 5xx error, and is generally meant to represent transient server-side errors.