### PR TITLE
fix(mirror-server): demote some reported errors to warning severity

### DIFF
--- a/mirror/mirror-server/src/functions/error/report.function.test.ts
+++ b/mirror/mirror-server/src/functions/error/report.function.test.ts
@@ -1,8 +1,8 @@
 import {describe, expect, test} from '@jest/globals';
+import {initializeApp} from 'firebase-admin/app';
 import {https} from 'firebase-functions/v2';
 import {HttpsError, type Request} from 'firebase-functions/v2/https';
 import type {ErrorReportingRequest} from 'mirror-protocol/src/error.js';
-import {initializeApp} from 'firebase-admin/app';
 import {report} from './report.function.js';
 
 describe('error-report function', () => {
@@ -60,6 +60,52 @@ describe('error-report function', () => {
     } catch (e) {
       expect(e).toBeInstanceOf(HttpsError);
       expect((e as HttpsError).code).toBe('cancelled');
+      expect((e as HttpsError).message).toBe(
+        'action: error-reporting-test, description: error-reporting-test',
+      );
+    }
+  });
+
+  test('request from roci team', async () => {
+    try {
+      const resp = await errorReportingFunction.run({
+        data: {
+          ...request,
+          requester: {
+            userID: 'hu0ggohMptVpC4GRn6GhfN9dhcO2',
+            userAgent: {type: 'reflect-cli', version: '0.0.1'},
+          },
+        },
+        rawRequest: null as unknown as Request,
+      });
+      console.log(resp);
+    } catch (e) {
+      expect(e).toBeInstanceOf(HttpsError);
+      expect((e as HttpsError).code).toBe('aborted');
+      expect((e as HttpsError).message).toBe(
+        'action: error-reporting-test, description: error-reporting-test',
+      );
+    }
+  });
+
+  test('FirebaseError', async () => {
+    try {
+      const resp = await errorReportingFunction.run({
+        data: {
+          ...request,
+          error: {
+            desc: 'error-reporting-test',
+            name: 'FirebaseError',
+            message: 'error-reporting-test',
+            stack: 'error-reporting-test',
+          },
+        },
+        rawRequest: null as unknown as Request,
+      });
+      console.log(resp);
+    } catch (e) {
+      expect(e).toBeInstanceOf(HttpsError);
+      expect((e as HttpsError).code).toBe('already-exists');
       expect((e as HttpsError).message).toBe(
         'action: error-reporting-test, description: error-reporting-test',
       );

--- a/mirror/mirror-server/src/functions/error/report.function.ts
+++ b/mirror/mirror-server/src/functions/error/report.function.ts
@@ -1,10 +1,19 @@
+import {FunctionsErrorCode, HttpsError} from 'firebase-functions/v2/https';
 import {
   errorReportingRequestSchema,
   errorReportingResponseSchema,
 } from 'mirror-protocol/src/error.js';
-import {HttpsError} from 'firebase-functions/v2/https';
 
 import {validateSchema} from '../validators/schema.js';
+
+const rociTeamUserID: {[id: string]: boolean} = {
+  ['Sr0S3VOyqIN9O06nMACgwqQ3GvK2']: true,
+  ['fH958LU8qyMmfVrfTzE0egkxsHk1']: true,
+  ['IrSbtZGlYGfLKYpiwYLiISdZ7Hl2']: true,
+  ['hu0ggohMptVpC4GRn6GhfN9dhcO2']: true,
+  ['Dplw09NbNaWMVFLAoKYlTbJXuha2']: true,
+  ['02Yam8WlcQfC3lf7Rf803e9eoWp2']: true,
+} as const;
 
 export const report = () =>
   validateSchema(
@@ -14,13 +23,25 @@ export const report = () =>
     const {
       severity,
       action,
-      error: {desc},
+      error: {desc, name},
+      requester: {userID},
     } = request;
+
+    // Default: 5xx error code.
+    let errorCode: FunctionsErrorCode = 'unknown';
+
+    // Choose 4xx error codes for conditions that should only
+    // alert at a higher threshold.
+    if (severity === 'WARNING') {
+      errorCode = 'cancelled';
+    } else if (name === 'FirebaseError') {
+      // Server-returned error has presumably already been reported.
+      errorCode = 'already-exists';
+    } else if (rociTeamUserID[userID]) {
+      errorCode = 'aborted';
+    }
 
     // 4xx and 5xx errors have different alerting thresholds.
     // "cancelled" maps to 499 and "unknown" maps to 500
-    throw new HttpsError(
-      severity === 'WARNING' ? 'cancelled' : 'unknown',
-      `action: ${action}, description: ${desc}`,
-    );
+    throw new HttpsError(errorCode, `action: ${action}, description: ${desc}`);
   });


### PR DESCRIPTION
Classify certain reported errors to warning-level 4xx errors:
* `FirebaseError` is classified as `already-exists` because they are presumably reported by the server event
* Errors from the roci team are classified as `aborted`

Fixes #1132
Fixes #1130