### PR TITLE
refactor(reflect-cli): move methods into better filenames

### DIFF
--- a/mirror/reflect-cli/package.json
+++ b/mirror/reflect-cli/package.json
@@ -9,7 +9,7 @@
     "format": "prettier --write .",
     "check-format": "prettier --check .",
     "lint": "eslint --ext .ts,.tsx,.js,.jsx src/",
-    "reflect": "node --no-warnings --loader ts-node/esm ./src/index.ts",
+    "reflect": "npm run build && node ./out/index.mjs",
     "reflect-local": "npm run reflect -- --stack sandbox --local",
     "build": "node tool/build.js",
     "check-types": "tsc --noEmit"

--- a/mirror/reflect-cli/src/error.ts
+++ b/mirror/reflect-cli/src/error.ts
@@ -1,0 +1,45 @@
+import {ErrorInfo, Severity, reportError} from 'mirror-protocol/src/error.js';
+import type {ArgumentsCamelCase} from 'yargs';
+import {getAuthentication} from './auth-config.js';
+import {getUserParameters} from './metrics/send-ga-event.js';
+import {version} from './version.js';
+import type {CommonYargsOptions} from './yarg-types.js';
+
+export async function reportE(
+  args: ArgumentsCamelCase<CommonYargsOptions>,
+  eventName: string,
+  e: unknown,
+  severity: Severity,
+) {
+  let userID = '';
+  try {
+    ({userID} = await getAuthentication(args));
+  } catch (e) {
+    /* swallow */
+  }
+  await reportError({
+    action: eventName,
+    error: createErrorInfo(e),
+    severity,
+    requester: {
+      userID,
+      userAgent: {type: 'reflect-cli', version},
+    },
+    agentContext: getUserParameters(version),
+  }).catch(_err => {
+    /* swallow */
+  });
+}
+
+function createErrorInfo(e: unknown): ErrorInfo {
+  if (!(e instanceof Error)) {
+    return {desc: String(e)};
+  }
+  return {
+    desc: String(e),
+    name: e.name,
+    message: e.message,
+    stack: e.stack,
+    cause: createErrorInfo(e.cause),
+  };
+}

--- a/mirror/reflect-cli/src/firebase.ts
+++ b/mirror/reflect-cli/src/firebase.ts
@@ -1,20 +1,6 @@
 import {initializeApp} from 'firebase/app';
+import {connectFirestoreEmulator, getFirestore} from 'firebase/firestore';
 import {connectFunctionsEmulator, getFunctions} from 'firebase/functions';
-import {
-  getFirestore,
-  connectFirestoreEmulator,
-  terminate,
-} from 'firebase/firestore';
-import {
-  sendAnalyticsEvent,
-  getUserParameters,
-} from './metrics/send-ga-event.js';
-import color from 'picocolors';
-import type {ArgumentsCamelCase} from 'yargs';
-import {reportError, ErrorInfo, Severity} from 'mirror-protocol/src/error.js';
-import {version} from './version.js';
-import {getAuthentication} from './auth-config.js';
-import type {CommonYargsOptions} from './yarg-types.js';
 
 function getFirebaseConfig(stack: string) {
   switch (stack) {
@@ -61,81 +47,4 @@ export function initFirebase(args: {stack: string; local: boolean}) {
     // as unit tests from the two packages will otherwise interfere with each other.
     connectFirestoreEmulator(getFirestore(), '127.0.0.1', 8081);
   }
-}
-
-async function reportE(
-  args: ArgumentsCamelCase<CommonYargsOptions>,
-  eventName: string,
-  e: unknown,
-  severity: Severity,
-) {
-  let userID = '';
-  try {
-    ({userID} = await getAuthentication(args));
-  } catch (e) {
-    /* swallow */
-  }
-  await reportError({
-    action: eventName,
-    error: createErrorInfo(e),
-    severity,
-    requester: {
-      userID,
-      userAgent: {type: 'reflect-cli', version},
-    },
-    agentContext: getUserParameters(version),
-  }).catch(_err => {
-    /* swallow */
-  });
-}
-
-// Wraps a command handler with cleanup code (e.g. terminating any Firestore client)
-// to ensure that the process exits after the handler completes.
-export function handleWith<T extends ArgumentsCamelCase<CommonYargsOptions>>(
-  handler: (args: T) => Promise<void>,
-) {
-  return {
-    andCleanup: () => async (args: T) => {
-      let success = false;
-      const eventName =
-        args._ && args._.length ? `cmd_${args._[0]}` : 'cmd_unknown';
-      try {
-        await handler(args);
-        success = true;
-      } catch (e) {
-        await reportE(args, eventName, e, 'ERROR');
-        const message = e instanceof Error ? e.message : String(e);
-        console.error(`\n${color.red(color.bold('Error'))}: ${message}`);
-      } finally {
-        await terminate(getFirestore());
-      }
-
-      // It is tempting to send analytics in parallel with running
-      // the handler, but that appears to cause problems for some commands
-      // for reasons unknown.
-      // https://github.com/rocicorp/mono/issues/1078
-      try {
-        await sendAnalyticsEvent(eventName);
-      } catch (e) {
-        await reportE(args, eventName, e, 'WARNING');
-      }
-
-      if (!success) {
-        process.exit(-1);
-      }
-    },
-  };
-}
-
-function createErrorInfo(e: unknown): ErrorInfo {
-  if (!(e instanceof Error)) {
-    return {desc: String(e)};
-  }
-  return {
-    desc: String(e),
-    name: e.name,
-    message: e.message,
-    stack: e.stack,
-    cause: createErrorInfo(e.cause),
-  };
 }

--- a/mirror/reflect-cli/src/handler.ts
+++ b/mirror/reflect-cli/src/handler.ts
@@ -1,0 +1,45 @@
+import {getFirestore, terminate} from 'firebase/firestore';
+import color from 'picocolors';
+import type {ArgumentsCamelCase} from 'yargs';
+import {reportE} from './error.js';
+import {sendAnalyticsEvent} from './metrics/send-ga-event.js';
+import type {CommonYargsOptions} from './yarg-types.js';
+
+// Wraps a command handler with cleanup code (e.g. terminating any Firestore client)
+// to ensure that the process exits after the handler completes.
+
+export function handleWith<T extends ArgumentsCamelCase<CommonYargsOptions>>(
+  handler: (args: T) => Promise<void>,
+) {
+  return {
+    andCleanup: () => async (args: T) => {
+      let success = false;
+      const eventName =
+        args._ && args._.length ? `cmd_${args._[0]}` : 'cmd_unknown';
+      try {
+        await handler(args);
+        success = true;
+      } catch (e) {
+        await reportE(args, eventName, e, 'ERROR');
+        const message = e instanceof Error ? e.message : String(e);
+        console.error(`\n${color.red(color.bold('Error'))}: ${message}`);
+      } finally {
+        await terminate(getFirestore());
+      }
+
+      // It is tempting to send analytics in parallel with running
+      // the handler, but that appears to cause problems for some commands
+      // for reasons unknown.
+      // https://github.com/rocicorp/mono/issues/1078
+      try {
+        await sendAnalyticsEvent(eventName);
+      } catch (e) {
+        await reportE(args, eventName, e, 'WARNING');
+      }
+
+      if (!success) {
+        process.exit(-1);
+      }
+    },
+  };
+}

--- a/mirror/reflect-cli/src/index.ts
+++ b/mirror/reflect-cli/src/index.ts
@@ -5,15 +5,15 @@ import {
   createCLIParserBase,
 } from './create-cli-parser.js';
 import {createHandler, createOptions} from './create.js';
+import {deleteHandler, deleteOptions} from './delete.js';
 import {devHandler, devOptions} from './dev.js';
-import {handleWith} from './firebase.js';
+import {handleWith} from './handler.js';
+import {initHandler, initOptions} from './init.js';
 import {loginHandler} from './login.js';
 import {publishHandler, publishOptions} from './publish.js';
 import {statusHandler} from './status.js';
 import {tailHandler, tailOptions} from './tail/index.js';
 import type {CommonYargsArgv, YargvToInterface} from './yarg-types.js';
-import {deleteHandler, deleteOptions} from './delete.js';
-import {initHandler, initOptions} from './init.js';
 
 async function main(argv: string[]): Promise<void> {
   const reflectCLI = createCLIParser(argv);


### PR DESCRIPTION
Move methods out of `firebase.ts` to better-named files.

Pure refactoring, no functional changes.