### PR TITLE
fix(reflect-cli): report npm errors as warnings

### DIFF
--- a/mirror/reflect-cli/src/create.ts
+++ b/mirror/reflect-cli/src/create.ts
@@ -1,8 +1,8 @@
-import {execSync} from 'node:child_process';
 import {existsSync} from 'node:fs';
 import {mkdir} from 'node:fs/promises';
 import color from 'picocolors';
 import validateProjectName from 'validate-npm-package-name';
+import {execOrReportWarning} from './exec.js';
 import {logErrorAndExit} from './log-error-and-exit.js';
 import {scaffold} from './scaffold.js';
 import type {CommonYargsArgv, YargvToInterface} from './yarg-types.js';
@@ -37,7 +37,7 @@ export async function createHandler(createYargs: CreatedHandlerArgs) {
   await mkdir(name, {recursive: true});
   await scaffold(name, name);
   console.log(color.cyan(`Installing @rocicorp/reflect`));
-  execSync(`npm install --silent`, {
+  execOrReportWarning(`npm install --silent`, {
     cwd: name,
     stdio: ['ignore', 'inherit', 'inherit'],
   });

--- a/mirror/reflect-cli/src/exec.ts
+++ b/mirror/reflect-cli/src/exec.ts
@@ -1,0 +1,13 @@
+import {execSync, ExecSyncOptions} from 'node:child_process';
+import {ErrorWrapper} from './error.js';
+
+export function execOrReportWarning(
+  command: string,
+  options: ExecSyncOptions,
+): string | Buffer {
+  try {
+    return execSync(command, options);
+  } catch (e) {
+    throw new ErrorWrapper(e, 'WARNING');
+  }
+}

--- a/mirror/reflect-cli/src/handler.ts
+++ b/mirror/reflect-cli/src/handler.ts
@@ -20,7 +20,7 @@ export function handleWith<T extends ArgumentsCamelCase<CommonYargsOptions>>(
         await handler(args);
         success = true;
       } catch (e) {
-        await reportE(args, eventName, e, 'ERROR');
+        await reportE(args, eventName, e);
         const message = e instanceof Error ? e.message : String(e);
         console.error(`\n${color.red(color.bold('Error'))}: ${message}`);
       } finally {

--- a/mirror/reflect-cli/src/init.ts
+++ b/mirror/reflect-cli/src/init.ts
@@ -1,11 +1,11 @@
-import {execSync} from 'node:child_process';
 import {existsSync} from 'node:fs';
 import color from 'picocolors';
 import {configFileExists} from './app-config.js';
+import {execOrReportWarning} from './exec.js';
 import {logErrorAndExit, noFormat} from './log-error-and-exit.js';
 import {copyTemplate} from './scaffold.js';
-import type {CommonYargsArgv, YargvToInterface} from './yarg-types.js';
 import {findReflectVersion} from './version.js';
+import type {CommonYargsArgv, YargvToInterface} from './yarg-types.js';
 
 export function initOptions(yargs: CommonYargsArgv) {
   return yargs;
@@ -41,7 +41,7 @@ export async function initHandler(_: InitHandlerArgs) {
   console.log(`Installing @rocicorp/reflect`);
 
   const reflectVersion = await findReflectVersion();
-  execSync(`npm add '@rocicorp/reflect@^${reflectVersion}'`, {
+  execOrReportWarning(`npm add '@rocicorp/reflect@^${reflectVersion}'`, {
     stdio: ['ignore', 'inherit', 'inherit'],
   });
 


### PR DESCRIPTION
Reports errors from `npm install` or `npm add` as warnings so that they require a higher threshold for alerts. Such errors are generally out of our control and do not represent a call to action.

Fixes #1129

![Screenshot 2023-10-24 at 6 19 16 PM](https://github.com/rocicorp/mono/assets/132324914/78dc7dc4-7138-4f87-93c5-0513b5c87f42)
