### PR TITLE
fix(reflect-cli): require Node 18+ for cli

### DIFF
--- a/mirror/reflect-cli/src/create-cli-parser.ts
+++ b/mirror/reflect-cli/src/create-cli-parser.ts
@@ -1,3 +1,4 @@
+import {SemVer} from 'semver';
 import makeCLI, {Argv} from 'yargs';
 import {initFirebase} from './firebase.js';
 import {tryDeprecationCheck, version} from './version.js';
@@ -67,6 +68,17 @@ export function createCLIParserBase(argv: string[]): Argv<{
   // version
   reflectCLI.command('version', false, {}, () => {
     console.log(version);
+  });
+
+  reflectCLI.middleware(() => {
+    const nodeVersion = new SemVer(process.versions.node);
+    if (nodeVersion.major < 18) {
+      console.log(
+        `\nNode.js v18 or higher is required. (Current: v${nodeVersion})`,
+      );
+      console.log('Please update to newer version.\n');
+      process.exit(-1);
+    }
   });
 
   reflectCLI.middleware(async argv => {


### PR DESCRIPTION
`reflect-cli` will now exit with an error if the Node version is pre-18.

```
$ npx reflect status

Node.js v18 or higher is required.
Please update to newer version. (Current: v16.13.0)

$
```

Fixes #1142
