### PR TITLE
feat(mirror): schema for aggregation of app metrics

### DIFF
--- a/mirror/mirror-schema/firestore.indexes.json
+++ b/mirror/mirror-schema/firestore.indexes.json
@@ -51,5 +51,12 @@
       ]
     }
   ],
-  "fieldOverrides": []
+  "fieldOverrides": [
+    {
+      "collectionGroup": "metrics",
+      "fieldPath": "day",
+      "ttl": false,
+      "indexes": []
+    }
+  ]
 }

--- a/mirror/mirror-schema/package.json
+++ b/mirror/mirror-schema/package.json
@@ -27,6 +27,7 @@
     "@rocicorp/eslint-config": "^0.5.1",
     "@rocicorp/prettier-config": "^0.2.0",
     "firebase-tools": "^12.7.0",
+    "firestore-size": "^2.0.7",
     "shared": "0.0.0",
     "ts-jest": "^29.1.0",
     "typescript": "^5.2.2"

--- a/mirror/mirror-schema/src/metrics.test.ts
+++ b/mirror/mirror-schema/src/metrics.test.ts
@@ -1,0 +1,89 @@
+import {describe, expect, test} from '@jest/globals';
+import sizeof from 'firestore-size';
+import {
+  monthMetricsPath,
+  totalMetricsPath,
+  type DayMetrics,
+  type DayOfMonth,
+  type Hour,
+  type Metrics,
+  type MonthMetrics,
+} from './metrics.js';
+
+describe('metrics schema', () => {
+  const TEAM = '198SeL9eaaF';
+  const APP = 'lm9glnnf';
+
+  function emptyMonth(): MonthMetrics {
+    return {
+      teamID: TEAM,
+      appID: APP,
+      yearMonth: 202311,
+      total: {},
+      day: {},
+    };
+  }
+
+  function fillMonth(values: Metrics): MonthMetrics {
+    const month = emptyMonth();
+    month.total = values;
+    for (let d = 1; d <= 31; d++) {
+      const day = d.toString() as DayOfMonth;
+      const dayMetrics: DayMetrics = {
+        total: values,
+        hour: {},
+      };
+      for (let h = 0; h < 24; h++) {
+        const hour = h.toString() as Hour;
+        dayMetrics.hour[hour] = values;
+      }
+      month.day[day] = dayMetrics;
+    }
+    return month;
+  }
+
+  test('empty document size', () => {
+    expect(sizeof(emptyMonth())).toBe(94);
+  });
+
+  test('document size with two metrics', () => {
+    const values: Metrics = {
+      cs: 10000,
+      cl: 10020,
+    };
+    const month = fillMonth(values);
+    expect(sizeof(month)).toBe(19513);
+  });
+
+  test('document size with 100 metrics', () => {
+    const values: {[key: string]: number} = {};
+    for (let i = 0; i < 100; i++) {
+      values[i < 10 ? `0${i}` : `${i}`] = 10000;
+    }
+    const month = fillMonth(values as Metrics);
+    expect(sizeof(month)).toBe(856041);
+    // 100 metrics is still within the 1MB doc size limit
+    expect(
+      sizeof(month) + monthMetricsPath('2023', '11', TEAM, APP).length,
+    ).toBeLessThan(1024 * 1024);
+  });
+
+  test('document paths', () => {
+    expect(monthMetricsPath('2023', '9', TEAM, APP)).toBe(
+      `apps/${APP}/metrics/202309-${TEAM}`,
+    );
+    expect(monthMetricsPath('2023', '10', TEAM, APP)).toBe(
+      `apps/${APP}/metrics/202310-${TEAM}`,
+    );
+    expect(monthMetricsPath('2023', '9', TEAM)).toBe(
+      `teams/${TEAM}/metrics/202309`,
+    );
+    expect(monthMetricsPath('2023', '10', TEAM)).toBe(
+      `teams/${TEAM}/metrics/202310`,
+    );
+    expect(totalMetricsPath(TEAM, APP)).toBe(
+      `apps/${APP}/metrics/total-${TEAM}`,
+    );
+    expect(totalMetricsPath(TEAM)).toBe(`teams/${TEAM}/metrics/total`);
+  });
+});

--- a/mirror/mirror-schema/src/metrics.ts
+++ b/mirror/mirror-schema/src/metrics.ts
@@ -1,0 +1,265 @@
+import * as v from 'shared/src/valita.js';
+import {firestoreDataConverter} from './converter.js';
+import {appPath} from './deployment.js';
+import * as path from './path.js';
+import {teamPath} from './team.js';
+
+/** Connection seconds reported incrementally from within the RoomDO. */
+export const CONNECTION_SECONDS = 'cs';
+/** Connection seconds computed from completed FetchEvents. */
+export const CONNECTION_LIFETIMES = 'cl';
+
+export const metricSchema = v.union(
+  v.literal(CONNECTION_SECONDS),
+  v.literal(CONNECTION_LIFETIMES),
+);
+
+export type Metric = v.Infer<typeof metricSchema>;
+
+// Data is stored in sparse objects, with short-named fields set
+// when information is available, and 0-valued metrics implied
+// for absent fields.
+export const metricsSchema = v.object({
+  [CONNECTION_SECONDS]: v.number().optional(),
+  [CONNECTION_LIFETIMES]: v.number().optional(),
+});
+
+export type Metrics = v.Infer<typeof metricsSchema>;
+
+export type Hour =
+  | '0'
+  | '1'
+  | '2'
+  | '3'
+  | '4'
+  | '5'
+  | '6'
+  | '7'
+  | '8'
+  | '9'
+  | '10'
+  | '11'
+  | '12'
+  | '13'
+  | '14'
+  | '15'
+  | '16'
+  | '17'
+  | '18'
+  | '19'
+  | '20'
+  | '21'
+  | '22'
+  | '23';
+
+export const dayMetricsSchema = v.object({
+  total: metricsSchema,
+  hour: v.object({
+    ['0']: metricsSchema.optional(),
+    ['1']: metricsSchema.optional(),
+    ['2']: metricsSchema.optional(),
+    ['3']: metricsSchema.optional(),
+    ['4']: metricsSchema.optional(),
+    ['5']: metricsSchema.optional(),
+    ['6']: metricsSchema.optional(),
+    ['7']: metricsSchema.optional(),
+    ['8']: metricsSchema.optional(),
+    ['9']: metricsSchema.optional(),
+    ['10']: metricsSchema.optional(),
+    ['11']: metricsSchema.optional(),
+    ['12']: metricsSchema.optional(),
+    ['13']: metricsSchema.optional(),
+    ['14']: metricsSchema.optional(),
+    ['15']: metricsSchema.optional(),
+    ['16']: metricsSchema.optional(),
+    ['17']: metricsSchema.optional(),
+    ['18']: metricsSchema.optional(),
+    ['19']: metricsSchema.optional(),
+    ['20']: metricsSchema.optional(),
+    ['21']: metricsSchema.optional(),
+    ['22']: metricsSchema.optional(),
+    ['23']: metricsSchema.optional(),
+  }),
+});
+
+export type DayMetrics = v.Infer<typeof dayMetricsSchema>;
+
+export type DayOfMonth =
+  | '1'
+  | '2'
+  | '3'
+  | '4'
+  | '5'
+  | '6'
+  | '7'
+  | '8'
+  | '9'
+  | '10'
+  | '11'
+  | '12'
+  | '13'
+  | '14'
+  | '15'
+  | '16'
+  | '17'
+  | '18'
+  | '19'
+  | '20'
+  | '21'
+  | '22'
+  | '23'
+  | '24'
+  | '25'
+  | '26'
+  | '27'
+  | '28'
+  | '29'
+  | '30'
+  | '31';
+
+export function yearMonth(date: Date): number {
+  return date.getFullYear() * 100 + date.getMonth();
+}
+
+// The MonthMetric sparsely tracks a month's worth of metrics for each hour of each day,
+// with total-day and total-month aggregations. This schema is used to track both per-app
+// metrics and per-team metrics.
+//
+// Nuance: Note that the `teamID` field is present for app-level metrics documents. Although
+// this might seem redundant with the `teamID` in the App doc itself, keeping track of the
+// `teamID` it is necessary here because metrics documents are historic. In the event that
+// we add support for transferring Apps to another team, the schema correctly attributes
+// metrics to the team that the app belonged to when the metrics happened, and metrics for
+// the App under the new team will be written to a different app-level document (the teamID
+// is included in the app-level document ID). As a result, app-level metrics are partitioned
+// across the teams that it has belonged to.
+export const monthMetricsSchema = v.object({
+  // The first three fields are designed to allow Collection Group queries across
+  // teams (i.e. for our own global statistics) and across apps (i.e. for a team's breakdowns).
+  //
+  // Examples:
+  // * Global statistics with team breakdown:
+  //   `collectionGroup('metrics').where('appID', '==', null)`
+  // * Global statistics with app breakdown:
+  //   `collectionGroup('metrics').where('appID', '!=', null)`
+  // * One team's apps:
+  //   `collectionGroup('metrics').where('teamID', '==', teamID).where('appID', '!=', null)`
+  // * One team's metrics with team aggregation and app breakdown:
+  //   `collectionGroup('metrics').where('teamID', '==', teamID)`
+  // * Time ranges: `.where(yearMonth, '>=', 202310)`
+  teamID: v.string(),
+  appID: v.string().nullable(), // null for Team-level metrics.
+  yearMonth: v.number(),
+
+  total: metricsSchema,
+
+  // Note: The `day` field  contains a large subtree of fields that can
+  // consume a lot of storage space for indexing. Since we don't anticipate
+  // needing to sort queries by values in the day/hour range, we exclude
+  // the whole tree from indexes in firestore.indexes.json.
+  day: v.object({
+    ['1']: dayMetricsSchema.optional(),
+    ['2']: dayMetricsSchema.optional(),
+    ['3']: dayMetricsSchema.optional(),
+    ['4']: dayMetricsSchema.optional(),
+    ['5']: dayMetricsSchema.optional(),
+    ['6']: dayMetricsSchema.optional(),
+    ['7']: dayMetricsSchema.optional(),
+    ['8']: dayMetricsSchema.optional(),
+    ['9']: dayMetricsSchema.optional(),
+    ['10']: dayMetricsSchema.optional(),
+    ['11']: dayMetricsSchema.optional(),
+    ['12']: dayMetricsSchema.optional(),
+    ['13']: dayMetricsSchema.optional(),
+    ['14']: dayMetricsSchema.optional(),
+    ['15']: dayMetricsSchema.optional(),
+    ['16']: dayMetricsSchema.optional(),
+    ['17']: dayMetricsSchema.optional(),
+    ['18']: dayMetricsSchema.optional(),
+    ['19']: dayMetricsSchema.optional(),
+    ['20']: dayMetricsSchema.optional(),
+    ['21']: dayMetricsSchema.optional(),
+    ['22']: dayMetricsSchema.optional(),
+    ['23']: dayMetricsSchema.optional(),
+    ['24']: dayMetricsSchema.optional(),
+    ['25']: dayMetricsSchema.optional(),
+    ['26']: dayMetricsSchema.optional(),
+    ['27']: dayMetricsSchema.optional(),
+    ['28']: dayMetricsSchema.optional(),
+    ['29']: dayMetricsSchema.optional(),
+    ['30']: dayMetricsSchema.optional(),
+    ['31']: dayMetricsSchema.optional(),
+  }),
+});
+
+export type MonthMetrics = v.Infer<typeof monthMetricsSchema>;
+
+export const monthMetricsDataConverter =
+  firestoreDataConverter(monthMetricsSchema);
+
+// TotalMetrics tracks the total and per-year aggregations of all metrics.
+// Similarly to MonthMetrics, these are tracked per team and per app.
+export const totalMetricsSchema = v.object({
+  teamID: v.string(),
+  appID: v.string().nullable(),
+
+  total: metricsSchema,
+  // Keyed by string, e.g. "2023"
+  year: v.record(metricsSchema),
+});
+
+export type TotalMetrics = v.Infer<typeof totalMetricsSchema>;
+
+export const totalMetricsDataConverter =
+  firestoreDataConverter(totalMetricsSchema);
+
+export const METRICS_COLLECTION_ID = 'metrics';
+
+export function appMetricsCollection(appID: string): string {
+  return path.append(appPath(appID), METRICS_COLLECTION_ID);
+}
+
+export function teamMetricsCollection(teamID: string): string {
+  return path.append(teamPath(teamID), METRICS_COLLECTION_ID);
+}
+
+export type Month =
+  | '0'
+  | '1'
+  | '2'
+  | '3'
+  | '4'
+  | '5'
+  | '6'
+  | '7'
+  | '8'
+  | '9'
+  | '10'
+  | '11';
+
+export function monthMetricsPath(
+  year: string,
+  month: Month,
+  teamID: string,
+  appID?: string,
+): string {
+  const mm = month.length < 2 ? `0${month}` : month;
+  return metricsDocPath(teamID, appID, `${year}${mm}`);
+}
+
+export function totalMetricsPath(teamID: string, appID?: string): string {
+  return metricsDocPath(teamID, appID, 'total');
+}
+
+function metricsDocPath(
+  teamID: string,
+  appID: string | undefined,
+  docPrefix: string,
+) {
+  const docSuffix = appID ? `-${teamID}` : '';
+  return path.append(
+    appID ? appPath(appID) : teamPath(teamID),
+    METRICS_COLLECTION_ID,
+    `${docPrefix}${docSuffix}`,
+  );
+}

--- a/mirror/mirror-server/src/metrics/ledger.test.ts
+++ b/mirror/mirror-server/src/metrics/ledger.test.ts
@@ -1,0 +1,518 @@
+import {afterAll, describe, expect, test} from '@jest/globals';
+import {initializeApp} from 'firebase-admin/app';
+import {getFirestore} from 'firebase-admin/firestore';
+import {
+  CONNECTION_LIFETIMES,
+  CONNECTION_SECONDS,
+  Metric,
+  Month,
+  MonthMetrics,
+  TotalMetrics,
+  appMetricsCollection,
+  monthMetricsPath,
+  teamMetricsCollection,
+  totalMetricsPath,
+} from 'mirror-schema/src/metrics.js';
+import {Ledger} from './ledger.js';
+
+describe('metrics ledger', () => {
+  initializeApp({projectId: 'metrics-ledger-test'});
+  const firestore = getFirestore();
+  const TEAM1 = 'team1';
+  const TEAM2 = 'team2';
+  const APP1 = 'app1';
+  const APP2 = 'app2';
+  const APP3 = 'app3';
+
+  afterAll(async () => {
+    const batch = firestore.batch();
+    for (const coll of [
+      teamMetricsCollection(TEAM1),
+      teamMetricsCollection(TEAM2),
+      appMetricsCollection(APP1),
+      appMetricsCollection(APP2),
+      appMetricsCollection(APP3),
+    ]) {
+      const docs = await firestore.collection(coll).listDocuments();
+      docs.forEach(doc => batch.delete(doc));
+    }
+    await batch.commit();
+  });
+
+  type Case = {
+    name: string;
+    teamID: string;
+    appID: string;
+    hour: Date;
+    metric: Metric;
+    value: number;
+    expectedTeamMonth?: MonthMetrics;
+    expectedTeamTotal?: TotalMetrics;
+    expectedAppMonth?: MonthMetrics;
+    expectedAppTotal?: TotalMetrics;
+  };
+  const cases: Case[] = [
+    {
+      name: 'no existing ledger docs',
+      teamID: TEAM1,
+      appID: APP1,
+      hour: new Date(2023, 0, 31, 23),
+      metric: CONNECTION_SECONDS,
+      value: 10.23,
+      expectedAppMonth: {
+        teamID: TEAM1,
+        appID: APP1,
+        yearMonth: 202300,
+        total: {cs: 10.23},
+        day: {
+          ['31']: {
+            total: {cs: 10.23},
+            hour: {['23']: {cs: 10.23}},
+          },
+        },
+      },
+      expectedTeamMonth: {
+        teamID: TEAM1,
+        appID: null,
+        yearMonth: 202300,
+        total: {cs: 10.23},
+        day: {
+          ['31']: {
+            total: {cs: 10.23},
+            hour: {['23']: {cs: 10.23}},
+          },
+        },
+      },
+      expectedAppTotal: {
+        teamID: TEAM1,
+        appID: APP1,
+        total: {cs: 10.23},
+        year: {['2023']: {cs: 10.23}},
+      },
+      expectedTeamTotal: {
+        teamID: TEAM1,
+        appID: null,
+        total: {cs: 10.23},
+        year: {['2023']: {cs: 10.23}},
+      },
+    },
+    {
+      name: 'update different app, same team',
+      teamID: TEAM1,
+      appID: APP2,
+      hour: new Date(2023, 0, 31, 23),
+      metric: CONNECTION_SECONDS,
+      value: 32.46,
+      expectedAppMonth: {
+        teamID: TEAM1,
+        appID: APP2,
+        yearMonth: 202300,
+        total: {cs: 32.46},
+        day: {
+          ['31']: {
+            total: {cs: 32.46},
+            hour: {['23']: {cs: 32.46}},
+          },
+        },
+      },
+      expectedTeamMonth: {
+        teamID: TEAM1,
+        appID: null,
+        yearMonth: 202300,
+        total: {cs: 42.69},
+        day: {
+          ['31']: {
+            total: {cs: 42.69},
+            hour: {['23']: {cs: 42.69}},
+          },
+        },
+      },
+      expectedAppTotal: {
+        teamID: TEAM1,
+        appID: APP2,
+        total: {cs: 32.46},
+        year: {['2023']: {cs: 32.46}},
+      },
+      expectedTeamTotal: {
+        teamID: TEAM1,
+        appID: null,
+        total: {cs: 42.69},
+        year: {['2023']: {cs: 42.69}},
+      },
+    },
+    {
+      name: 'update different hour',
+      teamID: TEAM1,
+      appID: APP2,
+      hour: new Date(2023, 0, 31, 20),
+      metric: CONNECTION_SECONDS,
+      value: 24.68,
+      expectedAppMonth: {
+        teamID: TEAM1,
+        appID: APP2,
+        yearMonth: 202300,
+        total: {cs: 57.14},
+        day: {
+          ['31']: {
+            total: {cs: 57.14},
+            hour: {
+              ['20']: {cs: 24.68},
+              ['23']: {cs: 32.46},
+            },
+          },
+        },
+      },
+      expectedTeamMonth: {
+        teamID: TEAM1,
+        appID: null,
+        yearMonth: 202300,
+        total: {cs: 67.37},
+        day: {
+          ['31']: {
+            total: {cs: 67.37},
+            hour: {
+              ['20']: {cs: 24.68},
+              ['23']: {cs: 42.69},
+            },
+          },
+        },
+      },
+      expectedAppTotal: {
+        teamID: TEAM1,
+        appID: APP2,
+        total: {cs: 57.14},
+        year: {['2023']: {cs: 57.14}},
+      },
+      expectedTeamTotal: {
+        teamID: TEAM1,
+        appID: null,
+        total: {cs: 67.37},
+        year: {['2023']: {cs: 67.37}},
+      },
+    },
+    {
+      name: 'update existing value',
+      teamID: TEAM1,
+      appID: APP2,
+      hour: new Date(2023, 0, 31, 20),
+      metric: CONNECTION_SECONDS,
+      value: 21.68,
+      expectedAppMonth: {
+        teamID: TEAM1,
+        appID: APP2,
+        yearMonth: 202300,
+        total: {cs: 54.14},
+        day: {
+          ['31']: {
+            total: {cs: 54.14},
+            hour: {
+              ['20']: {cs: 21.68},
+              ['23']: {cs: 32.46},
+            },
+          },
+        },
+      },
+      expectedTeamMonth: {
+        teamID: TEAM1,
+        appID: null,
+        yearMonth: 202300,
+        total: {cs: 64.37},
+        day: {
+          ['31']: {
+            total: {cs: 64.37},
+            hour: {
+              ['20']: {cs: 21.68},
+              ['23']: {cs: 42.69},
+            },
+          },
+        },
+      },
+      expectedAppTotal: {
+        teamID: TEAM1,
+        appID: APP2,
+        total: {cs: 54.14},
+        year: {['2023']: {cs: 54.14}},
+      },
+      expectedTeamTotal: {
+        teamID: TEAM1,
+        appID: null,
+        total: {cs: 64.37},
+        year: {['2023']: {cs: 64.37}},
+      },
+    },
+    {
+      name: 'update different year',
+      teamID: TEAM1,
+      appID: APP2,
+      hour: new Date(2022, 11, 3, 15),
+      metric: CONNECTION_SECONDS,
+      value: 10.0,
+      expectedAppMonth: {
+        teamID: TEAM1,
+        appID: APP2,
+        yearMonth: 202211,
+        total: {cs: 10.0},
+        day: {
+          ['3']: {
+            total: {cs: 10.0},
+            hour: {['15']: {cs: 10.0}},
+          },
+        },
+      },
+      expectedTeamMonth: {
+        teamID: TEAM1,
+        appID: null,
+        yearMonth: 202211,
+        total: {cs: 10.0},
+        day: {
+          ['3']: {
+            total: {cs: 10.0},
+            hour: {['15']: {cs: 10.0}},
+          },
+        },
+      },
+      expectedAppTotal: {
+        teamID: TEAM1,
+        appID: APP2,
+        total: {cs: 64.14},
+        year: {
+          ['2022']: {cs: 10.0},
+          ['2023']: {cs: 54.14},
+        },
+      },
+      expectedTeamTotal: {
+        teamID: TEAM1,
+        appID: null,
+        total: {cs: 74.37},
+        year: {
+          ['2022']: {cs: 10.0},
+          ['2023']: {cs: 64.37},
+        },
+      },
+    },
+    {
+      name: 'update different metric',
+      teamID: TEAM1,
+      appID: APP2,
+      hour: new Date(2022, 11, 3, 15),
+      metric: CONNECTION_LIFETIMES,
+      value: 11.1,
+      expectedAppMonth: {
+        teamID: TEAM1,
+        appID: APP2,
+        yearMonth: 202211,
+        total: {
+          cs: 10.0,
+          cl: 11.1,
+        },
+        day: {
+          ['3']: {
+            total: {
+              cs: 10.0,
+              cl: 11.1,
+            },
+            hour: {
+              ['15']: {
+                cs: 10.0,
+                cl: 11.1,
+              },
+            },
+          },
+        },
+      },
+      expectedTeamMonth: {
+        teamID: TEAM1,
+        appID: null,
+        yearMonth: 202211,
+        total: {
+          cs: 10.0,
+          cl: 11.1,
+        },
+        day: {
+          ['3']: {
+            total: {
+              cs: 10.0,
+              cl: 11.1,
+            },
+            hour: {
+              ['15']: {
+                cs: 10.0,
+                cl: 11.1,
+              },
+            },
+          },
+        },
+      },
+      expectedAppTotal: {
+        teamID: TEAM1,
+        appID: APP2,
+        total: {
+          cs: 64.14,
+          cl: 11.1,
+        },
+        year: {
+          ['2022']: {
+            cs: 10.0,
+            cl: 11.1,
+          },
+          ['2023']: {cs: 54.14},
+        },
+      },
+      expectedTeamTotal: {
+        teamID: TEAM1,
+        appID: null,
+        total: {
+          cs: 74.37,
+          cl: 11.1,
+        },
+        year: {
+          ['2022']: {
+            cs: 10.0,
+            cl: 11.1,
+          },
+          ['2023']: {cs: 64.37},
+        },
+      },
+    },
+    {
+      name: 'update app in new team',
+      teamID: TEAM2,
+      appID: APP1,
+      hour: new Date(2023, 1, 1, 0),
+      metric: CONNECTION_SECONDS,
+      value: 23.1,
+      expectedAppMonth: {
+        teamID: TEAM2,
+        appID: APP1,
+        yearMonth: 202301,
+        total: {cs: 23.1},
+        day: {
+          ['1']: {
+            total: {cs: 23.1},
+            hour: {['0']: {cs: 23.1}},
+          },
+        },
+      },
+      expectedTeamMonth: {
+        teamID: TEAM2,
+        appID: null,
+        yearMonth: 202301,
+        total: {cs: 23.1},
+        day: {
+          ['1']: {
+            total: {cs: 23.1},
+            hour: {['0']: {cs: 23.1}},
+          },
+        },
+      },
+      expectedAppTotal: {
+        teamID: TEAM2,
+        appID: APP1,
+        total: {cs: 23.1},
+        year: {['2023']: {cs: 23.1}},
+      },
+      expectedTeamTotal: {
+        teamID: TEAM2,
+        appID: null,
+        total: {cs: 23.1},
+        year: {['2023']: {cs: 23.1}},
+      },
+    },
+    {
+      name: 'update different day',
+      teamID: TEAM2,
+      appID: APP1,
+      hour: new Date(2023, 1, 2, 0),
+      metric: CONNECTION_SECONDS,
+      value: 43.1,
+      expectedAppMonth: {
+        teamID: TEAM2,
+        appID: APP1,
+        yearMonth: 202301,
+        total: {cs: 66.2},
+        day: {
+          ['1']: {
+            total: {cs: 23.1},
+            hour: {['0']: {cs: 23.1}},
+          },
+          ['2']: {
+            total: {cs: 43.1},
+            hour: {['0']: {cs: 43.1}},
+          },
+        },
+      },
+      expectedTeamMonth: {
+        teamID: TEAM2,
+        appID: null,
+        yearMonth: 202301,
+        total: {cs: 66.2},
+        day: {
+          ['1']: {
+            total: {cs: 23.1},
+            hour: {['0']: {cs: 23.1}},
+          },
+          ['2']: {
+            total: {cs: 43.1},
+            hour: {['0']: {cs: 43.1}},
+          },
+        },
+      },
+      expectedAppTotal: {
+        teamID: TEAM2,
+        appID: APP1,
+        total: {cs: 66.2},
+        year: {['2023']: {cs: 66.2}},
+      },
+      expectedTeamTotal: {
+        teamID: TEAM2,
+        appID: null,
+        total: {cs: 66.2},
+        year: {['2023']: {cs: 66.2}},
+      },
+    },
+  ];
+  for (const c of cases) {
+    test(c.name, async () => {
+      await new Ledger(firestore).set(
+        c.teamID,
+        c.appID,
+        c.hour,
+        c.metric,
+        c.value,
+      );
+      expect(
+        (
+          await firestore
+            .doc(
+              monthMetricsPath(
+                c.hour.getFullYear().toString(),
+                c.hour.getMonth().toString() as Month,
+                c.teamID,
+                c.appID,
+              ),
+            )
+            .get()
+        ).data(),
+      ).toEqual(c.expectedAppMonth);
+      expect(
+        (
+          await firestore
+            .doc(
+              monthMetricsPath(
+                c.hour.getFullYear().toString(),
+                c.hour.getMonth().toString() as Month,
+                c.teamID,
+              ),
+            )
+            .get()
+        ).data(),
+      ).toEqual(c.expectedTeamMonth);
+      expect(
+        (await firestore.doc(totalMetricsPath(c.teamID, c.appID)).get()).data(),
+      ).toEqual(c.expectedAppTotal);
+      expect(
+        (await firestore.doc(totalMetricsPath(c.teamID)).get()).data(),
+      ).toEqual(c.expectedTeamTotal);
+    });
+  }
+});

--- a/mirror/mirror-server/src/metrics/ledger.ts
+++ b/mirror/mirror-server/src/metrics/ledger.ts
@@ -1,0 +1,116 @@
+import type {Firestore} from '@google-cloud/firestore';
+import {FieldValue} from '@google-cloud/firestore';
+import {
+  Hour,
+  Metrics,
+  monthMetricsDataConverter,
+  monthMetricsPath,
+  totalMetricsDataConverter,
+  totalMetricsPath,
+  yearMonth,
+  type DayOfMonth,
+  type Metric,
+  type Month,
+} from 'mirror-schema/src/metrics.js';
+
+/**
+ * The Ledger contains the logic for atomically updating all aggregations of
+ * an hourly window of a metric's value. This includes:
+ * - daily and monthly totals for the app
+ * - yearly and all-time totals for the app
+ * - daily and monthly totals for the team
+ * - yearly and all-time totals for the team
+ */
+export class Ledger {
+  readonly #firestore: Firestore;
+
+  constructor(firestore: Firestore) {
+    this.#firestore = firestore;
+  }
+
+  /**
+   * Sets the value of the given `metric` for the given `hourWindow`. This
+   * replaces any existing value for that window (which means the method is
+   * idempotent), and updates aggregations accordingly.
+   */
+  set(
+    teamID: string,
+    appID: string,
+    hourWindow: Date,
+    metric: Metric,
+    newValue: number,
+  ): Promise<void> {
+    return this.#firestore.runTransaction(async tx => {
+      const year = hourWindow.getFullYear().toString();
+      const month = hourWindow.getMonth().toString() as Month;
+      const day = hourWindow.getDate().toString() as DayOfMonth;
+      const hour = hourWindow.getHours().toString() as Hour;
+
+      const appMonthDoc = this.#firestore
+        .doc(monthMetricsPath(year, month, teamID, appID))
+        .withConverter(monthMetricsDataConverter);
+      const teamMonthDoc = this.#firestore
+        .doc(monthMetricsPath(year, month, teamID))
+        .withConverter(monthMetricsDataConverter);
+      const appTotalDoc = this.#firestore
+        .doc(totalMetricsPath(teamID, appID))
+        .withConverter(totalMetricsDataConverter);
+      const teamTotalDoc = this.#firestore
+        .doc(totalMetricsPath(teamID))
+        .withConverter(totalMetricsDataConverter);
+
+      const appMonth = (await tx.get(appMonthDoc)).data();
+      const currValue = appMonth?.day?.[day]?.hour?.[hour]?.[metric];
+      const delta = newValue - (currValue ?? 0);
+      const update: Metrics = {[metric]: FieldValue.increment(delta)};
+
+      const monthUpdate = {
+        teamID,
+        appID,
+        yearMonth: yearMonth(hourWindow),
+        total: update,
+        day: {
+          [day]: {
+            total: update,
+            hour: {[hour]: update},
+          },
+        },
+      };
+      const monthFields = [
+        'teamID',
+        'appID',
+        'yearMonth',
+        `total.${metric}`,
+        `day.${day}.total.${metric}`,
+        `day.${day}.hour.${hour}.${metric}`,
+      ];
+
+      tx.set(appMonthDoc, monthUpdate, {mergeFields: monthFields});
+      tx.set(
+        teamMonthDoc,
+        {...monthUpdate, appID: null},
+        {mergeFields: monthFields},
+      );
+
+      const totalUpdate = {
+        teamID,
+        appID,
+        total: update,
+        year: {[year]: update},
+      };
+      const totalFields = [
+        'teamID',
+        'appID',
+        `total.${metric}`,
+        `year.${year}.${metric}`,
+      ];
+
+      tx.set(appTotalDoc, totalUpdate, {mergeFields: totalFields});
+      tx.set(
+        teamTotalDoc,
+        {...totalUpdate, appID: null},
+        {mergeFields: totalFields},
+      );
+    });
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -659,6 +659,7 @@
         "@rocicorp/eslint-config": "^0.5.1",
         "@rocicorp/prettier-config": "^0.2.0",
         "firebase-tools": "^12.7.0",
+        "firestore-size": "^2.0.7",
         "shared": "0.0.0",
         "ts-jest": "^29.1.0",
         "typescript": "^5.2.2"
@@ -19735,6 +19736,12 @@
       "version": "0.21.0",
       "resolved": "https://registry.npmjs.org/firestore-jest-mock/-/firestore-jest-mock-0.21.0.tgz",
       "integrity": "sha512-pGMFVNxBJ+VLI/VCqC4OAXWfWPku0BwgluEXtoiZUyoVH7sXmAlcTDNEy8y8BFWhRFA/mQ2x2oZh3IFHmFmjFg=="
+    },
+    "node_modules/firestore-size": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/firestore-size/-/firestore-size-2.0.7.tgz",
+      "integrity": "sha512-K5D8e+9rrJs8YL/GIiET7ul9x5pV1WAUjK/yjZO360cF8A+71FnZg+ofO9U7g8XCr21mkbyZFM4yEf4o45FEIQ==",
+      "dev": true
     },
     "node_modules/flat-cache": {
       "version": "3.0.4",
@@ -50813,6 +50820,12 @@
       "resolved": "https://registry.npmjs.org/firestore-jest-mock/-/firestore-jest-mock-0.21.0.tgz",
       "integrity": "sha512-pGMFVNxBJ+VLI/VCqC4OAXWfWPku0BwgluEXtoiZUyoVH7sXmAlcTDNEy8y8BFWhRFA/mQ2x2oZh3IFHmFmjFg=="
     },
+    "firestore-size": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/firestore-size/-/firestore-size-2.0.7.tgz",
+      "integrity": "sha512-K5D8e+9rrJs8YL/GIiET7ul9x5pV1WAUjK/yjZO360cF8A+71FnZg+ofO9U7g8XCr21mkbyZFM4yEf4o45FEIQ==",
+      "dev": true
+    },
     "flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -56494,6 +56507,7 @@
         "firebase": "9.23.0",
         "firebase-tools": "^12.7.0",
         "firestore-jest-mock": "^0.21.0",
+        "firestore-size": "^2.0.7",
         "shared": "0.0.0",
         "ts-jest": "^29.1.0",
         "typescript": "^5.2.2"


### PR DESCRIPTION
Firestore schema for aggregating usage metrics reported to Workers Analytics Engine Datasets, as outlined in https://www.notion.so/replicache/Mirror-Billing-9ef6511dac994056b16046e519aa0cd8?pvs=4#90b0940d6cfc4235bb51339ef1754262

This includes the structure of the documents (`<app-level, team-level> x <month-level, total>`) as well as the atomic update / aggregation logic when recording new metric values.

The logic that actually reads from WAE to update the metrics ledgers is forthcoming. This change is schema only.