### PR TITLE
refactor(mirror): rename "bytes" field to "ciphertext"

### DIFF
--- a/mirror/mirror-schema/src/bytes.ts
+++ b/mirror/mirror-schema/src/bytes.ts
@@ -43,7 +43,7 @@ export const encryptedBytesSchema = v.object({
   algo: v.string().optional(), // or DEFAULT_CIPHER_ALGORITHM
   key: keySpecSchema,
   iv: bytesSchema,
-  bytes: bytesSchema,
+  ciphertext: bytesSchema,
 });
 
 export type EncryptedBytes = v.Infer<typeof encryptedBytesSchema>;

--- a/mirror/mirror-schema/src/crypto.test.ts
+++ b/mirror/mirror-schema/src/crypto.test.ts
@@ -14,8 +14,8 @@ test('encryption / decryption', () => {
 
   expect(encrypted1.key).toEqual(keySpec);
   expect(encrypted1.iv.length).toBe(16);
-  expect(encrypted1.bytes.length).toBe(32); // Two cipher blocks
-  expect(Buffer.from(encrypted1.bytes).toString('utf-8')).not.toBe(
+  expect(encrypted1.ciphertext.length).toBe(32); // Two cipher blocks
+  expect(Buffer.from(encrypted1.ciphertext).toString('utf-8')).not.toBe(
     'this is the plaintext',
   );
 
@@ -26,15 +26,15 @@ test('encryption / decryption', () => {
   );
   expect(encrypted2.key).toEqual(keySpec);
   expect(encrypted2.iv.length).toBe(16);
-  expect(encrypted2.bytes.length).toBe(32); // Two cipher blocks
-  expect(Buffer.from(encrypted2.bytes).toString('utf-8')).not.toBe(
+  expect(encrypted2.ciphertext.length).toBe(32); // Two cipher blocks
+  expect(Buffer.from(encrypted2.ciphertext).toString('utf-8')).not.toBe(
     'this is the plaintext',
   );
 
   // Encryptions of the same plaintext should result in different
   // IVs and thus different ciphertexts.
-  expect(Buffer.from(encrypted1.bytes).toString('hex')).not.toEqual(
-    Buffer.from(encrypted2.bytes).toString('hex'),
+  expect(Buffer.from(encrypted1.ciphertext).toString('hex')).not.toEqual(
+    Buffer.from(encrypted2.ciphertext).toString('hex'),
   );
 
   const decrypted1 = decrypt(encrypted1, key);

--- a/mirror/mirror-schema/src/crypto.ts
+++ b/mirror/mirror-schema/src/crypto.ts
@@ -18,11 +18,11 @@ export function encrypt(
     key,
     iv,
   );
-  const bytes = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
   const encryptedBytes: EncryptedBytes = {
     key: keySpec,
     iv,
-    bytes,
+    ciphertext,
   };
   if (algo) {
     encryptedBytes.algo = algo;
@@ -34,11 +34,11 @@ export function decrypt(
   encryptedBytes: EncryptedBytes,
   key: Uint8Array,
 ): Uint8Array {
-  const {algo, iv, bytes} = encryptedBytes;
+  const {algo, iv, ciphertext} = encryptedBytes;
   const decipher = crypto.createDecipheriv(
     algo ?? DEFAULT_CIPHER_ALGORITHM,
     key,
     iv,
   );
-  return Buffer.concat([decipher.update(bytes), decipher.final()]);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
 }


### PR DESCRIPTION
This makes the schema more self descriptive.

#1150 
#679 