### PR TITLE
fix(mirror): use a string for the version in KeySpec

### DIFF
--- a/mirror/mirror-schema/src/bytes.ts
+++ b/mirror/mirror-schema/src/bytes.ts
@@ -30,7 +30,7 @@ export const keySpecSchema = v.object({
   // or absent for the default secret (which may be context dependent).
   secretName: v.string().optional(),
   // The version of the secret.
-  version: v.number(),
+  version: v.string(),
 });
 
 export type KeySpec = v.Infer<typeof keySpecSchema>;

--- a/mirror/mirror-schema/src/crypto.test.ts
+++ b/mirror/mirror-schema/src/crypto.test.ts
@@ -4,7 +4,7 @@ import {decrypt, encrypt} from './crypto.js';
 
 test('encryption / decryption', () => {
   const key = crypto.randomBytes(32);
-  const keySpec = {version: 2};
+  const keySpec = {version: '2'};
 
   const encrypted1 = encrypt(
     Buffer.from('this is the plaintext', 'utf-8'),


### PR DESCRIPTION
Make the `KeySpec.version` a string field to allow for aliases and reduce string parsing logic.