### PR TITLE
feat(mirror-server): App Secrets infra and real REFLECT_AUTH_API_KEY

### DIFF
--- a/mirror/README.md
+++ b/mirror/README.md
@@ -93,6 +93,15 @@ running admin auth commands from the `mirror-cli`.
   - Role: `Owner`
   - Role: `Service Account Token Creator`
 
+### Encryption Key
+
+Each stack uses an encryption key (stored in the Secret Manager) for encrypting app
+secrets at rest (in Firestore). Run the following `mirror-cli` command to set this up:
+
+```
+$ npm run mirror -- --stack=<stack-name> gen-encryption-key
+```
+
 ### Cloudflare Account
 
 A Cloudflare account is needed to run workers and Durable Objects.

--- a/mirror/mirror-cli/src/backfill-reflect-auth-api-keys.ts
+++ b/mirror/mirror-cli/src/backfill-reflect-auth-api-keys.ts
@@ -1,0 +1,64 @@
+import {randomBytes} from 'crypto';
+import {getFirestore} from 'firebase-admin/firestore';
+import {
+  APP_COLLECTION,
+  appDataConverter,
+  ENCRYPTION_KEY_SECRET_NAME,
+} from 'mirror-schema/src/app.js';
+import {encryptUtf8} from 'mirror-schema/src/crypto.js';
+import {getSecret} from './secrets.js';
+import type {CommonYargsArgv, YargvToInterface} from './yarg-types.js';
+
+const REFLECT_AUTH_API_KEY = 'REFLECT_AUTH_API_KEY';
+
+export function backfillReflectAuthApiKeyOptions(yargs: CommonYargsArgv) {
+  return yargs.option('dry-run', {
+    desc: 'Print what would be done but do not commit.',
+    type: 'boolean',
+    default: true,
+  });
+}
+
+type BackfillReflectAuthApiKeyHandlerArgs = YargvToInterface<
+  ReturnType<typeof backfillReflectAuthApiKeyOptions>
+>;
+
+export async function backfillReflectAuthApiKeyHandler(
+  yargs: BackfillReflectAuthApiKeyHandlerArgs,
+) {
+  const {stack, dryRun} = yargs;
+  const encryptionKey = await getSecret(stack, ENCRYPTION_KEY_SECRET_NAME);
+  const firestore = getFirestore();
+  const appsUpdate = await firestore.runTransaction(async txn => {
+    const apps = await txn.get(
+      firestore.collection(APP_COLLECTION).withConverter(appDataConverter),
+    );
+
+    let appsUpdated = 0;
+
+    apps.docs.forEach(doc => {
+      const data = doc.data();
+      if (data.secrets?.[REFLECT_AUTH_API_KEY]) {
+        console.log(`App ${doc.id} already has a REFLECT_AUTH_API_KEY`);
+        return;
+      }
+
+      const randomKey = randomBytes(32).toString('base64url');
+      const encryptedBytes = encryptUtf8(
+        randomKey,
+        Buffer.from(encryptionKey.payload, 'base64url'),
+        {version: encryptionKey.version},
+      );
+      txn.update(doc.ref, `secrets.${REFLECT_AUTH_API_KEY}`, encryptedBytes);
+      appsUpdated++;
+    });
+
+    if (dryRun) {
+      throw new Error(
+        `Would have updated ${appsUpdated} apps. Set --dry-run=false to commit.`,
+      );
+    }
+    return appsUpdated;
+  });
+  console.log(`${appsUpdate} apps updated`);
+}

--- a/mirror/mirror-cli/src/cf.ts
+++ b/mirror/mirror-cli/src/cf.ts
@@ -1,11 +1,11 @@
-import type {CommonYargsArgv, YargvToInterface} from './yarg-types.js';
-import {getSecret} from './secrets.js';
 import {getFirestore} from 'firebase-admin/firestore';
 import {
-  providerPath,
   providerDataConverter,
+  providerPath,
   type Provider,
 } from 'mirror-schema/src/provider.js';
+import {getSecret} from './secrets.js';
+import type {CommonYargsArgv, YargvToInterface} from './yarg-types.js';
 
 export type ProviderConfig = Provider & {
   apiToken: string;
@@ -25,6 +25,6 @@ export async function getProviderConfig(
     throw new Error(`No "${provider}" provider is setup for ${stack}`);
   }
 
-  const apiToken = await getSecret(stack, `${provider}_api_token`);
+  const apiToken = (await getSecret(stack, `${provider}_api_token`)).payload;
   return {...providerData, apiToken};
 }

--- a/mirror/mirror-cli/src/gen-encryption-key.ts
+++ b/mirror/mirror-cli/src/gen-encryption-key.ts
@@ -1,0 +1,30 @@
+import {ENCRYPTION_KEY_SECRET_NAME} from 'mirror-schema/src/app.js';
+import crypto from 'node:crypto';
+import {storeSecret} from './secrets.js';
+import type {CommonYargsArgv, YargvToInterface} from './yarg-types.js';
+
+export function genEncryptionKeyOptions(yargs: CommonYargsArgv) {
+  return yargs
+    .option('bits', {
+      type: 'number',
+      default: 256,
+    })
+    .option('add-new-version', {
+      type: 'boolean',
+      desc: 'Adds a new version of the secret (i.e. rotation)',
+      default: false,
+    });
+}
+
+type GenEncyptionKeyHandlerArgs = YargvToInterface<
+  ReturnType<typeof genEncryptionKeyOptions>
+>;
+
+export async function genEncryptionKeyHandler(
+  yargs: GenEncyptionKeyHandlerArgs,
+) {
+  const {stack, bits, addNewVersion} = yargs;
+  const buffer = crypto.randomBytes(bits / 8);
+  const key = buffer.toString('base64url');
+  await storeSecret(stack, ENCRYPTION_KEY_SECRET_NAME, key, addNewVersion);
+}

--- a/mirror/mirror-cli/src/index.ts
+++ b/mirror/mirror-cli/src/index.ts
@@ -1,5 +1,9 @@
 import {hideBin} from 'yargs/helpers';
 import {addDeploymentsOptionsHandler} from './add-deployment-options.js';
+import {
+  backfillReflectAuthApiKeyHandler,
+  backfillReflectAuthApiKeyOptions,
+} from './backfill-reflect-auth-api-keys.js';
 import {certificatesHandler, certificatesOptions} from './certificates.js';
 import {
   checkProviderHandler,
@@ -21,6 +25,10 @@ import {
 } from './delete-team-subdomains.js';
 import {dnsRecordsHandler, dnsRecordsOptions} from './dns-records.js';
 import {initFirebase} from './firebase.js';
+import {
+  genEncryptionKeyHandler,
+  genEncryptionKeyOptions,
+} from './gen-encryption-key.js';
 import {getWorkerHandler, getWorkerOptions} from './get-worker.js';
 import {grantSuperHandler, grantSuperOptions} from './grant-super.js';
 import {
@@ -144,6 +152,14 @@ function createCLIParser(argv: string[]) {
     checkProviderHandler,
   );
 
+  // gen-encryption-key
+  reflectCLI.command(
+    'gen-encryption-key',
+    'Generates and stores the APP_SECRET_ENCRYPTION_KEY used for encrypting at-rest secrets.',
+    genEncryptionKeyOptions,
+    genEncryptionKeyHandler,
+  );
+
   // wfp
   reflectCLI.command(
     'wfp <appID>',
@@ -214,6 +230,13 @@ function createCLIParser(argv: string[]) {
     'Execute a Worker Analytics SQL Query',
     queryAnalyticsOptions,
     queryAnalyticsHandler,
+  );
+
+  reflectCLI.command(
+    'backfill-reflect-auth-api-key',
+    'Backfills apps with a random, encrypted REFLECT_AUTH_API_KEY secret',
+    backfillReflectAuthApiKeyOptions,
+    backfillReflectAuthApiKeyHandler,
   );
 
   reflectCLI.command(

--- a/mirror/mirror-schema/src/crypto.test.ts
+++ b/mirror/mirror-schema/src/crypto.test.ts
@@ -1,16 +1,12 @@
 import {expect, test} from '@jest/globals';
 import crypto from 'node:crypto';
-import {decrypt, encrypt} from './crypto.js';
+import {decryptUtf8, encryptUtf8} from './crypto.js';
 
 test('encryption / decryption', () => {
   const key = crypto.randomBytes(32);
   const keySpec = {version: '2'};
 
-  const encrypted1 = encrypt(
-    Buffer.from('this is the plaintext', 'utf-8'),
-    key,
-    keySpec,
-  );
+  const encrypted1 = encryptUtf8('this is the plaintext', key, keySpec);
 
   expect(encrypted1.key).toEqual(keySpec);
   expect(encrypted1.iv.length).toBe(16);
@@ -19,11 +15,7 @@ test('encryption / decryption', () => {
     'this is the plaintext',
   );
 
-  const encrypted2 = encrypt(
-    Buffer.from('this is the plaintext', 'utf-8'),
-    key,
-    keySpec,
-  );
+  const encrypted2 = encryptUtf8('this is the plaintext', key, keySpec);
   expect(encrypted2.key).toEqual(keySpec);
   expect(encrypted2.iv.length).toBe(16);
   expect(encrypted2.ciphertext.length).toBe(32); // Two cipher blocks
@@ -37,13 +29,9 @@ test('encryption / decryption', () => {
     Buffer.from(encrypted2.ciphertext).toString('hex'),
   );
 
-  const decrypted1 = decrypt(encrypted1, key);
-  expect(Buffer.from(decrypted1).toString('utf-8')).toBe(
-    'this is the plaintext',
-  );
+  const decrypted1 = decryptUtf8(encrypted1, key);
+  expect(decrypted1).toBe('this is the plaintext');
 
-  const decrypted2 = decrypt(encrypted2, key);
-  expect(Buffer.from(decrypted2).toString('utf-8')).toBe(
-    'this is the plaintext',
-  );
+  const decrypted2 = decryptUtf8(encrypted2, key);
+  expect(decrypted2).toBe('this is the plaintext');
 });

--- a/mirror/mirror-schema/src/crypto.ts
+++ b/mirror/mirror-schema/src/crypto.ts
@@ -5,20 +5,24 @@ import {
   type KeySpec,
 } from './bytes.js';
 
-export function encrypt(
-  plaintext: Uint8Array,
+export function encryptUtf8(
+  plaintext: string,
   key: Uint8Array,
   keySpec: KeySpec,
+  ivOrLen: Uint8Array | number = 16,
   algo?: string,
-  ivLen = 16,
 ): EncryptedBytes {
-  const iv = crypto.randomBytes(ivLen);
+  const iv =
+    typeof ivOrLen === 'number' ? crypto.randomBytes(ivOrLen) : ivOrLen;
   const cipher = crypto.createCipheriv(
     algo ?? DEFAULT_CIPHER_ALGORITHM,
     key,
     iv,
   );
-  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const ciphertext = Buffer.concat([
+    cipher.update(plaintext, 'utf-8'),
+    cipher.final(),
+  ]);
   const encryptedBytes: EncryptedBytes = {
     key: keySpec,
     iv,
@@ -30,15 +34,18 @@ export function encrypt(
   return encryptedBytes;
 }
 
-export function decrypt(
+export function decryptUtf8(
   encryptedBytes: EncryptedBytes,
   key: Uint8Array,
-): Uint8Array {
+): string {
   const {algo, iv, ciphertext} = encryptedBytes;
   const decipher = crypto.createDecipheriv(
     algo ?? DEFAULT_CIPHER_ALGORITHM,
     key,
     iv,
   );
-  return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  return Buffer.concat([
+    decipher.update(ciphertext),
+    decipher.final(),
+  ]).toString('utf-8');
 }

--- a/mirror/mirror-schema/src/deployment.ts
+++ b/mirror/mirror-schema/src/deployment.ts
@@ -46,13 +46,7 @@ export function defaultOptions(): DeploymentOptions {
   return {vars: defaultVars()};
 }
 
-export const deploymentSecretsSchema = v.object({
-  /* eslint-disable @typescript-eslint/naming-convention */
-  REFLECT_AUTH_API_KEY: v.string(),
-  DATADOG_LOGS_API_KEY: v.string(),
-  DATADOG_METRICS_API_KEY: v.string(),
-  /* eslint-enable @typescript-eslint/naming-convention */
-});
+export const deploymentSecretsSchema = v.record(v.string());
 
 export type DeploymentSecrets = v.Infer<typeof deploymentSecretsSchema>;
 

--- a/mirror/mirror-schema/src/test-helpers.ts
+++ b/mirror/mirror-schema/src/test-helpers.ts
@@ -8,11 +8,11 @@ import {
   teamMembershipPath,
 } from 'mirror-schema/src/membership.js';
 import {
+  appNameIndexDataConverter,
+  appNameIndexPath,
+  sanitizeForLabel,
   teamDataConverter,
   teamPath,
-  appNameIndexPath,
-  appNameIndexDataConverter,
-  sanitizeForLabel,
   type AppNameIndex,
   type Team,
 } from 'mirror-schema/src/team.js';
@@ -24,10 +24,10 @@ import {
 import {must} from 'shared/src/must.js';
 import {DeploymentSecrets, defaultOptions} from './deployment.js';
 import {
+  DEFAULT_PROVIDER_ID,
+  providerDataConverter,
   providerPath,
   type Provider,
-  providerDataConverter,
-  DEFAULT_PROVIDER_ID,
 } from './provider.js';
 
 export function fakeFirestore(): Firestore {
@@ -192,6 +192,7 @@ export async function setApp(
     provider = DEFAULT_PROVIDER_ID,
     cfScriptName = 'cf-script-name',
     serverReleaseChannel = 'stable',
+    secrets = {},
   } = app;
   const newApp: App = {
     name,
@@ -202,6 +203,7 @@ export async function setApp(
     cfScriptName,
     serverReleaseChannel,
     deploymentOptions: defaultOptions(),
+    secrets,
   };
   await firestore
     .doc(appPath(appID))

--- a/mirror/mirror-server/src/functions/app/delete.function.ts
+++ b/mirror/mirror-server/src/functions/app/delete.function.ts
@@ -1,26 +1,25 @@
 import {FieldValue, type Firestore} from 'firebase-admin/firestore';
+import {logger} from 'firebase-functions';
 import {
   deleteAppRequestSchema,
   deleteAppResponseSchema,
 } from 'mirror-protocol/src/app.js';
 import {appDataConverter, appPath} from 'mirror-schema/src/app.js';
 import {
-  teamDataConverter,
-  teamPath,
-  appNameIndexPath,
-} from 'mirror-schema/src/team.js';
-import {appAuthorization, userAuthorization} from '../validators/auth.js';
-import {validateSchema} from '../validators/schema.js';
-import {getDataOrFail} from '../validators/data.js';
-import {
   DeploymentSpec,
   defaultOptions,
   deploymentsCollection,
 } from 'mirror-schema/src/deployment.js';
-import {NULL_SECRETS} from './secrets.js';
-import {requestDeployment} from './deploy.function.js';
-import {logger} from 'firebase-functions';
+import {
+  appNameIndexPath,
+  teamDataConverter,
+  teamPath,
+} from 'mirror-schema/src/team.js';
+import {appAuthorization, userAuthorization} from '../validators/auth.js';
+import {getDataOrFail} from '../validators/data.js';
+import {validateSchema} from '../validators/schema.js';
 import {userAgentVersion} from '../validators/version.js';
+import {requestDeployment} from './deploy.function.js';
 
 const NULL_SPEC: DeploymentSpec = {
   appModules: [],
@@ -28,7 +27,7 @@ const NULL_SPEC: DeploymentSpec = {
   serverVersionRange: '',
   hostname: '',
   options: defaultOptions(),
-  hashesOfSecrets: NULL_SECRETS,
+  hashesOfSecrets: {},
 };
 
 // Note: 'delete' is a reserved word, so we have to call the variable something else.

--- a/mirror/mirror-server/src/functions/app/publish.function.test.ts
+++ b/mirror/mirror-server/src/functions/app/publish.function.test.ts
@@ -1,6 +1,7 @@
-import {describe, expect, test, jest, beforeAll, afterAll} from '@jest/globals';
+import {afterAll, beforeAll, describe, expect, jest, test} from '@jest/globals';
 import {initializeApp} from 'firebase-admin/app';
 import {getFirestore} from 'firebase-admin/firestore';
+import type {Storage} from 'firebase-admin/storage';
 import {https} from 'firebase-functions/v2';
 import {
   FunctionsErrorCode,
@@ -8,25 +9,25 @@ import {
   Request,
 } from 'firebase-functions/v2/https';
 import type {AuthData} from 'firebase-functions/v2/tasks';
-import {publish} from './publish.function.js';
 import type {PublishRequest} from 'mirror-protocol/src/publish.js';
-import type {Storage} from 'firebase-admin/storage';
+import {appDataConverter} from 'mirror-schema/src/app.js';
 import {
   appPath,
   defaultOptions,
   deploymentDataConverter,
 } from 'mirror-schema/src/deployment.js';
-import {appDataConverter} from 'mirror-schema/src/app.js';
-import {userDataConverter, userPath} from 'mirror-schema/src/user.js';
-import {serverDataConverter, serverPath} from 'mirror-schema/src/server.js';
-import {mockFunctionParamsAndSecrets} from '../../test-helpers.js';
 import {
   DEFAULT_PROVIDER_ID,
   providerDataConverter,
   providerPath,
 } from 'mirror-schema/src/provider.js';
-import type {DistTags} from '../validators/version.js';
+import {serverDataConverter, serverPath} from 'mirror-schema/src/server.js';
+import {userDataConverter, userPath} from 'mirror-schema/src/user.js';
 import {SemVer} from 'semver';
+import {TestSecrets} from '../../secrets/test-utils.js';
+import {mockFunctionParamsAndSecrets} from '../../test-helpers.js';
+import type {DistTags} from '../validators/version.js';
+import {publish} from './publish.function.js';
 
 mockFunctionParamsAndSecrets();
 
@@ -210,7 +211,13 @@ describe('publish', () => {
         },
       } as unknown as Storage;
       const publishFunction = https.onCall(
-        publish(firestore, storage, 'modulez', c.testDistTags ?? {}),
+        publish(
+          firestore,
+          new TestSecrets(),
+          storage,
+          'modulez',
+          c.testDistTags ?? {},
+        ),
       );
 
       let error: HttpsError | undefined = undefined;

--- a/mirror/mirror-server/src/functions/app/publish.function.ts
+++ b/mirror/mirror-server/src/functions/app/publish.function.ts
@@ -18,6 +18,7 @@ import * as semver from 'semver';
 import {gtr} from 'semver';
 import {isSupportedSemverRange} from 'shared/src/mirror/is-supported-semver-range.js';
 import {assertAllModulesHaveUniqueNames} from '../../cloudflare/module-assembler.js';
+import {SecretsCache, type Secrets} from '../../secrets/index.js';
 import {appAuthorization, userAuthorization} from '../validators/auth.js';
 import {getDataOrFail} from '../validators/data.js';
 import {validateSchema} from '../validators/schema.js';
@@ -28,6 +29,7 @@ import {getAppSecrets} from './secrets.js';
 
 export const publish = (
   firestore: Firestore,
+  secretsClient: Secrets,
   storage: Storage,
   bucketName: string,
   testDistTags?: DistTags,
@@ -37,6 +39,7 @@ export const publish = (
     .validate(userAuthorization())
     .validate(appAuthorization(firestore))
     .handle(async (publishRequest, context) => {
+      const secrets = new SecretsCache(secretsClient);
       const {
         serverVersionRange,
         appID,
@@ -55,6 +58,7 @@ export const publish = (
 
       const spec = await computeDeploymentSpec(
         firestore,
+        secrets,
         {
           ...app,
           serverReleaseChannel,
@@ -101,6 +105,7 @@ export const publish = (
 
 export async function computeDeploymentSpec(
   firestore: Firestore,
+  secrets: Secrets,
   app: App,
   serverVersionRange: string,
 ): Promise<Omit<DeploymentSpec, 'appModules' | 'appVersion' | 'description'>> {
@@ -113,10 +118,11 @@ export async function computeDeploymentSpec(
     throw new HttpsError('invalid-argument', 'Unsupported desired version');
   }
 
+  const {serverReleaseChannel, secrets: appSecrets = {}} = app;
   const serverVersion = await findNewestMatchingVersion(
     firestore,
     range,
-    app.serverReleaseChannel,
+    serverReleaseChannel,
   );
   logger.log(
     `Found matching version for ${serverVersionRange}: ${serverVersion}`,
@@ -135,7 +141,7 @@ export async function computeDeploymentSpec(
     defaultZone: {zoneName},
   } = provider;
 
-  const {hashes: hashesOfSecrets} = await getAppSecrets();
+  const {hashes: hashesOfSecrets} = await getAppSecrets(secrets, appSecrets);
 
   return {
     serverVersionRange,

--- a/mirror/mirror-server/src/functions/app/tail.handler.test.ts
+++ b/mirror/mirror-server/src/functions/app/tail.handler.test.ts
@@ -11,20 +11,9 @@ import {
 } from 'mirror-schema/src/test-helpers.js';
 import {sleep} from 'shared/src/sleep.js';
 import type WebSocket from 'ws';
-import type {SecretValue, Secrets} from '../../secrets/index.js';
+import {TestSecrets} from '../../secrets/test-utils.js';
 import {mockFunctionParamsAndSecrets} from '../../test-helpers.js';
 import {tail} from './tail.handler.js';
-
-class MockSecrets implements Secrets {
-  getSecret(name: string, version = 'latest'): Promise<SecretValue> {
-    expect(name).toBe(`tail-test-provider_api_token`);
-    expect(version).toBe('latest');
-    return Promise.resolve({
-      payload: 'tail-test-provider-api-token',
-      version: '1',
-    });
-  }
-}
 
 export class MockSocket {
   readonly url: string | URL;
@@ -66,7 +55,7 @@ export class MockSocket {
 
 mockFunctionParamsAndSecrets();
 
-describe('test tail', () => {
+describe('app-tail', () => {
   let firestore: Firestore;
   let auth: Auth;
   let wsMock: MockSocket;
@@ -104,7 +93,11 @@ describe('test tail', () => {
     createTailFunction = tail(
       firestore,
       auth,
-      new MockSecrets(),
+      new TestSecrets([
+        'tail-test-provider_api_token',
+        'latest',
+        'tail-test-provider-api-token',
+      ]),
       createCloudflareTailMock,
     );
     await setUser(firestore, 'foo', 'foo@bar.com', 'bob', {fooTeam: 'admin'});

--- a/mirror/mirror-server/src/index.ts
+++ b/mirror/mirror-server/src/index.ts
@@ -44,17 +44,25 @@ export const error = {
 };
 
 export const app = {
-  create: https.onCall(baseHttpsOptions, appFunctions.create(getFirestore())),
+  create: https.onCall(
+    baseHttpsOptions,
+    appFunctions.create(getFirestore(), secrets),
+  ),
   publish: https.onCall(
     {
       ...baseHttpsOptions,
       secrets: [...DEPLOYMENT_SECRETS_NAMES],
       memory: '512MiB',
     },
-    appFunctions.publish(getFirestore(), getStorage(), modulesBucketName),
+    appFunctions.publish(
+      getFirestore(),
+      secrets,
+      getStorage(),
+      modulesBucketName,
+    ),
   ),
   deploy: appFunctions.deploy(getFirestore(), getStorage(), secrets),
-  autoDeploy: appFunctions.autoDeploy(getFirestore()),
+  autoDeploy: appFunctions.autoDeploy(getFirestore(), secrets),
   rename: https.onCall(baseHttpsOptions, appFunctions.rename(getFirestore())),
   tail: https.onRequest(
     {
@@ -74,12 +82,12 @@ export const room = {
       ...baseHttpsOptions,
       secrets: [...DEPLOYMENT_SECRETS_NAMES],
     },
-    roomFunctions.tail(getFirestore(), getAuth()),
+    roomFunctions.tail(getFirestore(), getAuth(), secrets),
   ),
 };
 
 export const server = {
-  autoDeploy: serverFunctions.autoDeploy(getFirestore()),
+  autoDeploy: serverFunctions.autoDeploy(getFirestore(), secrets),
 };
 
 export const team = {

--- a/mirror/mirror-server/src/secrets/test-utils.ts
+++ b/mirror/mirror-server/src/secrets/test-utils.ts
@@ -1,0 +1,31 @@
+import type {SecretValue, Secrets} from './index.js';
+
+export class TestSecrets implements Secrets {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  static readonly LATEST_ALIAS = '3';
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  static readonly TEST_KEY = 'Pmf1KOQv-bK5b4FFmI7ct3pvRX8X13ZsfogYqONgXPw';
+
+  readonly #expectations: [name: string, version: string, value: string][] = [];
+
+  constructor(
+    ...expectations: [name: string, version: string, value: string][]
+  ) {
+    this.#expectations.push(...expectations);
+  }
+
+  getSecret(name: string, requested = 'latest'): Promise<SecretValue> {
+    for (let i = 0; i < this.#expectations.length; i++) {
+      const [n, v, payload] = this.#expectations[i];
+      if (n === name && v === requested) {
+        this.#expectations.splice(i, 1);
+        const version =
+          requested === 'latest' ? TestSecrets.LATEST_ALIAS : requested;
+        return Promise.resolve({version, payload});
+      }
+    }
+    return Promise.reject(
+      new Error(`Unexpected request for secret ${name}@v${requested}`),
+    );
+  }
+}


### PR DESCRIPTION
* Each stack is now initialized with a random 256-bit encryption key stored in SecretsManager
  * `mirror --stack=<stack> gen-encryption-key`
* This encryption key is used to encrypt "App Secrets", which are app-specific values encrypted at rest (in Firestore), and decrypted and transmitted to Cloudflare as Cloudflare secrets at deployment time.
* When an app is created, it automatically gets a random `REFLECT_AUTH_API_KEY` that is encrypted as an App Secret. This decommissions the previous `dummy-api-key` and fixes #679 
  * `mirror backfill-reflect-auth-api-key` backfills existing apps with this secret.
* The App Secrets infra will also be used for storing "Server Variables" (#1150) on behalf of the developer, as secrets prefixed with `REFLECT_VAR_`. 
