### PR TITLE
chore(mirror): make App `secrets` non-optional

### DIFF
--- a/mirror/mirror-schema/src/app.ts
+++ b/mirror/mirror-schema/src/app.ts
@@ -65,7 +65,7 @@ export const appSchema = v.object({
   // specified by the app developer, transmitted to the Worker via Cloudflare
   // secrets (using the `REFLECT_VAR_` prefix to distinguish them from internal
   // vars / bindings).
-  secrets: appSecretsSchema.optional(),
+  secrets: appSecretsSchema,
 
   // The App document tracks the running and queued deployments and serves as
   // a coordination point for (1) determining if a new deployment is necessary

--- a/mirror/mirror-schema/src/deployment.test.ts
+++ b/mirror/mirror-schema/src/deployment.test.ts
@@ -1,8 +1,8 @@
-import {describe, test, expect} from '@jest/globals';
-import {defaultOptions, deploymentSchema, varsSchema} from './deployment.js';
+import {Timestamp} from '@google-cloud/firestore';
+import {describe, expect, test} from '@jest/globals';
 import {parse} from 'shared/src/valita.js';
 import {appSchema} from './app.js';
-import {Timestamp} from '@google-cloud/firestore';
+import {defaultOptions, deploymentSchema, varsSchema} from './deployment.js';
 
 describe('deployment', () => {
   /* eslint-disable @typescript-eslint/naming-convention */
@@ -73,6 +73,7 @@ describe('deployment', () => {
       teamID: 'boo',
       teamLabel: 'teamlabel',
       deploymentOptions: {vars: {}},
+      secrets: {},
     });
 
     const parsedDeployment = deploymentSchema.parse(

--- a/mirror/mirror-server/src/functions/app/auto-deploy.function.test.ts
+++ b/mirror/mirror-server/src/functions/app/auto-deploy.function.test.ts
@@ -108,6 +108,7 @@ describe('auto-deploy', () => {
             LOG_LEVEL: 'info',
           },
         },
+        secrets: {},
         serverReleaseChannel: 'stable',
 
         runningDeployment: {

--- a/mirror/mirror-server/src/functions/app/deploy.function.ts
+++ b/mirror/mirror-server/src/functions/app/deploy.function.ts
@@ -94,7 +94,7 @@ export async function runDeployment(
     cfScriptName,
     scriptRef,
     name: appName,
-    secrets: encryptedSecrets = {},
+    secrets: encryptedSecrets,
     teamID,
     teamLabel,
   } = must(appDoc.data());

--- a/mirror/mirror-server/src/functions/app/publish.function.test.ts
+++ b/mirror/mirror-server/src/functions/app/publish.function.test.ts
@@ -72,6 +72,7 @@ describe('publish', () => {
         serverReleaseChannel: 'stable',
         teamID: 'fooTeam',
         deploymentOptions: defaultOptions(),
+        secrets: {},
       },
     );
     batch.create(

--- a/mirror/mirror-server/src/functions/app/publish.function.ts
+++ b/mirror/mirror-server/src/functions/app/publish.function.ts
@@ -118,7 +118,7 @@ export async function computeDeploymentSpec(
     throw new HttpsError('invalid-argument', 'Unsupported desired version');
   }
 
-  const {serverReleaseChannel, secrets: appSecrets = {}} = app;
+  const {serverReleaseChannel, secrets: appSecrets} = app;
   const serverVersion = await findNewestMatchingVersion(
     firestore,
     range,

--- a/mirror/mirror-server/src/functions/room/tail.handler.ts
+++ b/mirror/mirror-server/src/functions/room/tail.handler.ts
@@ -42,10 +42,7 @@ export const tail = (
           requester: {userAgent},
         } = tailRequest;
 
-        const {secrets: appSecrets} = await getAppSecrets(
-          secrets,
-          app.secrets ?? {},
-        );
+        const {secrets: appSecrets} = await getAppSecrets(secrets, app.secrets);
 
         const reflectAuthApiKey = appSecrets[REFLECT_AUTH_API_KEY];
         if (!reflectAuthApiKey) {

--- a/mirror/mirror-server/src/functions/server/auto-deploy.function.test.ts
+++ b/mirror/mirror-server/src/functions/server/auto-deploy.function.test.ts
@@ -114,6 +114,7 @@ describe('server auto-deploy', () => {
             LOG_LEVEL: 'info',
           },
         },
+        secrets: {},
         serverReleaseChannel: i % 2 === 0 ? 'test-stable' : 'test-canary',
 
         runningDeployment: {

--- a/mirror/mirror-server/src/functions/validators/auth.test.ts
+++ b/mirror/mirror-server/src/functions/validators/auth.test.ts
@@ -1,10 +1,5 @@
 import {describe, expect, test} from '@jest/globals';
 import type {Firestore} from 'firebase-admin/firestore';
-import {
-  fakeFirestore,
-  setApp,
-  setUser,
-} from 'mirror-schema/src/test-helpers.js';
 import {https} from 'firebase-functions/v2';
 import {
   FunctionsErrorCode,
@@ -12,17 +7,22 @@ import {
   Request,
 } from 'firebase-functions/v2/https';
 import type {AuthData} from 'firebase-functions/v2/tasks';
-import {validateSchema} from './schema.js';
-import {appAuthorization, userAuthorization} from './auth.js';
 import {baseAppRequestFields} from 'mirror-protocol/src/app.js';
 import {baseResponseFields} from 'mirror-protocol/src/base.js';
-import * as v from 'shared/src/valita.js';
-import type {Callable} from './types.js';
-import type {User} from 'mirror-schema/src/user.js';
 import type {App} from 'mirror-schema/src/app.js';
-import type {Role} from 'mirror-schema/src/membership.js';
 import {defaultOptions} from 'mirror-schema/src/deployment.js';
+import type {Role} from 'mirror-schema/src/membership.js';
 import {DEFAULT_PROVIDER_ID} from 'mirror-schema/src/provider.js';
+import {
+  fakeFirestore,
+  setApp,
+  setUser,
+} from 'mirror-schema/src/test-helpers.js';
+import type {User} from 'mirror-schema/src/user.js';
+import * as v from 'shared/src/valita.js';
+import {appAuthorization, userAuthorization} from './auth.js';
+import {validateSchema} from './schema.js';
+import type {Callable} from './types.js';
 
 const testRequestSchema = v.object({
   ...baseAppRequestFields,
@@ -176,6 +176,7 @@ describe('app authorization', () => {
     cfScriptName: 'cfScriptName',
     serverReleaseChannel: 'stable',
     deploymentOptions: defaultOptions(),
+    secrets: {},
   };
   const defaultUser: User = {
     email: 'foo@bar.com',


### PR DESCRIPTION
Make the `secrets` field non-optional since it is now backfilled and initialized upon create.