### PR TITLE
refactor(reflect-client,reflect-react): Change presence return type from set to array

### DIFF
--- a/apps/reflect.net/components/Demo/Demo.tsx
+++ b/apps/reflect.net/components/Demo/Demo.tsx
@@ -369,7 +369,7 @@ export function Demo({
           <div className="online-dot"></div>
           Active Users:&nbsp;
           <span id="active-user-count">
-            {Math.max(presentClientIDs.size + botIDs.length, 1)}
+            {Math.max(presentClientIDs.length + botIDs.length, 1)}
           </span>
         </div>
       </div>

--- a/apps/reflect.net/demo/alive/CursorField.tsx
+++ b/apps/reflect.net/demo/alive/CursorField.tsx
@@ -19,7 +19,7 @@ export function CursorField({
   stage: Rect;
   docSize: Size;
   r: Reflect<M>;
-  presentClientIDs: ReadonlySet<string>;
+  presentClientIDs: ReadonlyArray<string>;
   botIDs: string[];
   myClientID: string;
   hideLocalArrow: boolean;
@@ -45,7 +45,7 @@ export function CursorField({
         height: docSize.height,
       }}
     >
-      {[...clientIDs].map(cid => (
+      {clientIDs.map(cid => (
         <Cursor
           key={`c-${cid}`}
           r={r}
@@ -58,7 +58,7 @@ export function CursorField({
           stage={stage}
         />
       ))}
-      {[...botIDs].map(bid => (
+      {botIDs.map(bid => (
         <Cursor
           key={`b-${bid}`}
           r={r}

--- a/apps/reflect.net/demo/alive/Puzzle.tsx
+++ b/apps/reflect.net/demo/alive/Puzzle.tsx
@@ -36,7 +36,7 @@ export function Puzzle({
   setBodyClass,
 }: {
   r: Reflect<M>;
-  presentClientIDs: ReadonlySet<string>;
+  presentClientIDs: ReadonlyArray<string>;
   home: Rect;
   stage: Rect;
   setBodyClass: (cls: string, enabled: boolean) => void;

--- a/apps/reflect.net/demo/alive/piece-info.ts
+++ b/apps/reflect.net/demo/alive/piece-info.ts
@@ -10,7 +10,7 @@ export type PieceInfo = PieceModel & {
 
 export async function getPieceInfos(
   tx: ReadTransaction,
-  presentClientIDs: ReadonlySet<string>,
+  presentClientIDs: ReadonlyArray<string>,
 ): Promise<Record<string, PieceInfo>> {
   const lp = await listPieces(tx);
   const mp: Record<string, PieceInfo> = {};

--- a/packages/reflect-client/src/client/presence-manager.test.ts
+++ b/packages/reflect-client/src/client/presence-manager.test.ts
@@ -15,11 +15,11 @@ test('initial only this client present', async () => {
   );
 
   const {promise: presentPromise, resolve: presentResolve} =
-    resolver<ReadonlySet<ClientID>>();
+    resolver<ReadonlyArray<ClientID>>();
   presenceManager.addSubscription(present => {
     presentResolve(present);
   });
-  expect(await presentPromise).to.deep.equal(new Set(['c1']));
+  expect(await presentPromise).to.have.members(['c1']);
 });
 
 test('addSubscription', async () => {
@@ -37,7 +37,7 @@ test('addSubscription', async () => {
     {op: 'put', key: 'c2', value: 1},
   ]);
 
-  const resolvers1: Resolver<ReadonlySet<ClientID>>[] = [
+  const resolvers1: Resolver<ReadonlyArray<ClientID>>[] = [
     resolver(),
     resolver(),
   ];
@@ -46,9 +46,9 @@ test('addSubscription', async () => {
     resolvers1[sub1CallCount++].resolve(present);
   });
 
-  expect(await resolvers1[0].promise).to.deep.equal(new Set(['c1', 'c2']));
+  expect(await resolvers1[0].promise).to.have.members(['c1', 'c2']);
 
-  const resolvers2: Resolver<ReadonlySet<ClientID>>[] = [
+  const resolvers2: Resolver<ReadonlyArray<ClientID>>[] = [
     resolver(),
     resolver(),
   ];
@@ -57,16 +57,12 @@ test('addSubscription', async () => {
     resolvers2[sub2CallCount++].resolve(present);
   });
 
-  expect(await resolvers2[0].promise).to.deep.equal(new Set(['c1', 'c2']));
+  expect(await resolvers2[0].promise).to.have.members(['c1', 'c2']);
 
   await presenceManager.updatePresence([{op: 'put', key: 'c3', value: 1}]);
 
-  expect(await resolvers1[1].promise).to.deep.equal(
-    new Set(['c1', 'c2', 'c3']),
-  );
-  expect(await resolvers2[1].promise).to.deep.equal(
-    new Set(['c1', 'c2', 'c3']),
-  );
+  expect(await resolvers1[1].promise).to.have.members(['c1', 'c2', 'c3']);
+  expect(await resolvers2[1].promise).to.have.members(['c1', 'c2', 'c3']);
 });
 
 test('calling function returned by addSubscription removes subscription', async () => {
@@ -84,7 +80,7 @@ test('calling function returned by addSubscription removes subscription', async 
     {op: 'put', key: 'c2', value: 1},
   ]);
 
-  const resolvers1: Resolver<ReadonlySet<ClientID>>[] = [
+  const resolvers1: Resolver<ReadonlyArray<ClientID>>[] = [
     resolver(),
     resolver(),
     resolver(),
@@ -97,7 +93,7 @@ test('calling function returned by addSubscription removes subscription', async 
     }
     resolvers1[sub1CallCount++].resolve(present);
   });
-  const resolvers2: Resolver<ReadonlySet<ClientID>>[] = [
+  const resolvers2: Resolver<ReadonlyArray<ClientID>>[] = [
     resolver(),
     resolver(),
     resolver(),
@@ -106,25 +102,19 @@ test('calling function returned by addSubscription removes subscription', async 
   presenceManager.addSubscription(present => {
     resolvers2[sub2CallCount++].resolve(present);
   });
-  expect(await resolvers1[0].promise).to.deep.equal(new Set(['c1', 'c2']));
-  expect(await resolvers2[0].promise).to.deep.equal(new Set(['c1', 'c2']));
+  expect(await resolvers1[0].promise).to.have.members(['c1', 'c2']);
+  expect(await resolvers2[0].promise).to.have.members(['c1', 'c2']);
 
   await presenceManager.updatePresence([{op: 'put', key: 'c3', value: 1}]);
 
-  expect(await resolvers1[1].promise).to.deep.equal(
-    new Set(['c1', 'c2', 'c3']),
-  );
-  expect(await resolvers2[1].promise).to.deep.equal(
-    new Set(['c1', 'c2', 'c3']),
-  );
+  expect(await resolvers1[1].promise).to.have.members(['c1', 'c2', 'c3']);
+  expect(await resolvers2[1].promise).to.have.members(['c1', 'c2', 'c3']);
 
   removeSub1();
   sub1ErrorIfCalled = true;
   await presenceManager.updatePresence([{op: 'put', key: 'c4', value: 1}]);
 
-  expect(await resolvers2[2].promise).to.deep.equal(
-    new Set(['c1', 'c2', 'c3', 'c4']),
-  );
+  expect(await resolvers2[2].promise).to.have.members(['c1', 'c2', 'c3', 'c4']);
   expect(sub1CallCount).to.equal(2);
   expect(sub2CallCount).to.equal(3);
 });
@@ -144,7 +134,7 @@ test('clearSubscriptions', async () => {
     {op: 'put', key: 'c2', value: 1},
   ]);
 
-  const resolvers1: Resolver<ReadonlySet<ClientID>>[] = [
+  const resolvers1: Resolver<ReadonlyArray<ClientID>>[] = [
     resolver(),
     resolver(),
     resolver(),
@@ -157,7 +147,7 @@ test('clearSubscriptions', async () => {
     }
     resolvers1[sub1CallCount++].resolve(present);
   });
-  const resolvers2: Resolver<ReadonlySet<ClientID>>[] = [
+  const resolvers2: Resolver<ReadonlyArray<ClientID>>[] = [
     resolver(),
     resolver(),
     resolver(),
@@ -170,17 +160,13 @@ test('clearSubscriptions', async () => {
     }
     resolvers2[sub2CallCount++].resolve(present);
   });
-  expect(await resolvers1[0].promise).to.deep.equal(new Set(['c1', 'c2']));
-  expect(await resolvers2[0].promise).to.deep.equal(new Set(['c1', 'c2']));
+  expect(await resolvers1[0].promise).to.have.members(['c1', 'c2']);
+  expect(await resolvers2[0].promise).to.have.members(['c1', 'c2']);
 
   await presenceManager.updatePresence([{op: 'put', key: 'c3', value: 1}]);
 
-  expect(await resolvers1[1].promise).to.deep.equal(
-    new Set(['c1', 'c2', 'c3']),
-  );
-  expect(await resolvers2[1].promise).to.deep.equal(
-    new Set(['c1', 'c2', 'c3']),
-  );
+  expect(await resolvers1[1].promise).to.have.members(['c1', 'c2', 'c3']);
+  expect(await resolvers2[1].promise).to.have.members(['c1', 'c2', 'c3']);
 
   presenceManager.clearSubscriptions();
   sub1ErrorIfCalled = true;
@@ -201,7 +187,7 @@ test('updatePresence', async () => {
     logContextPromise,
   );
 
-  const resolvers: Resolver<ReadonlySet<ClientID>>[] = [
+  const resolvers: Resolver<ReadonlyArray<ClientID>>[] = [
     resolver(),
     resolver(),
     resolver(),
@@ -210,7 +196,7 @@ test('updatePresence', async () => {
   presenceManager.addSubscription(present => {
     resolvers[subCallCount++].resolve(present);
   });
-  expect(await resolvers[0].promise).to.deep.equal(new Set(['c1']));
+  expect(await resolvers[0].promise).to.have.members(['c1']);
 
   await presenceManager.updatePresence([
     {op: 'clear'},
@@ -218,14 +204,14 @@ test('updatePresence', async () => {
     {op: 'put', key: 'c2', value: 1},
   ]);
 
-  expect(await resolvers[1].promise).to.deep.equal(new Set(['c1', 'c2']));
+  expect(await resolvers[1].promise).to.have.members(['c1', 'c2']);
 
   await presenceManager.updatePresence([
     {op: 'del', key: 'c2'},
     {op: 'put', key: 'c3', value: 1},
   ]);
 
-  expect(await resolvers[2].promise).to.deep.equal(new Set(['c1', 'c3']));
+  expect(await resolvers[2].promise).to.have.members(['c1', 'c3']);
 });
 
 test('updatePresence self clientID always included', async () => {
@@ -237,7 +223,7 @@ test('updatePresence self clientID always included', async () => {
     logContextPromise,
   );
 
-  const resolvers: Resolver<ReadonlySet<ClientID>>[] = [
+  const resolvers: Resolver<ReadonlyArray<ClientID>>[] = [
     resolver(),
     resolver(),
     resolver(),
@@ -246,14 +232,14 @@ test('updatePresence self clientID always included', async () => {
   presenceManager.addSubscription(present => {
     resolvers[subCallCount++].resolve(present);
   });
-  expect(await resolvers[0].promise).to.deep.equal(new Set(['c1']));
+  expect(await resolvers[0].promise).to.have.members(['c1']);
 
   await presenceManager.updatePresence([
     {op: 'clear'},
     {op: 'put', key: 'c2', value: 1},
   ]);
 
-  expect(await resolvers[1].promise).to.deep.equal(new Set(['c1', 'c2']));
+  expect(await resolvers[1].promise).to.have.members(['c1', 'c2']);
 
   await presenceManager.updatePresence([
     {op: 'del', key: 'c1'},
@@ -261,7 +247,7 @@ test('updatePresence self clientID always included', async () => {
     {op: 'put', key: 'c3', value: 1},
   ]);
 
-  expect(await resolvers[2].promise).to.deep.equal(new Set(['c1', 'c3']));
+  expect(await resolvers[2].promise).to.have.members(['c1', 'c3']);
 });
 
 test('updatePresence doesnt fire subscriptions if set is equal', async () => {
@@ -273,7 +259,7 @@ test('updatePresence doesnt fire subscriptions if set is equal', async () => {
     logContextPromise,
   );
 
-  const resolvers: Resolver<ReadonlySet<ClientID>>[] = [
+  const resolvers: Resolver<ReadonlyArray<ClientID>>[] = [
     resolver(),
     resolver(),
     resolver(),
@@ -282,7 +268,7 @@ test('updatePresence doesnt fire subscriptions if set is equal', async () => {
   presenceManager.addSubscription(present => {
     resolvers[subCallCount++].resolve(present);
   });
-  expect(await resolvers[0].promise).to.deep.equal(new Set(['c1']));
+  expect(await resolvers[0].promise).to.have.members(['c1']);
 
   await presenceManager.updatePresence([
     {op: 'clear'},
@@ -290,7 +276,7 @@ test('updatePresence doesnt fire subscriptions if set is equal', async () => {
     {op: 'put', key: 'c2', value: 1},
   ]);
 
-  expect(await resolvers[1].promise).to.deep.equal(new Set(['c1', 'c2']));
+  expect(await resolvers[1].promise).to.have.members(['c1', 'c2']);
 
   // subscription not called
   await presenceManager.updatePresence([{op: 'put', key: 'c1', value: 1}]);
@@ -301,7 +287,7 @@ test('updatePresence doesnt fire subscriptions if set is equal', async () => {
     {op: 'put', key: 'c3', value: 1},
   ]);
 
-  expect(await resolvers[2].promise).to.deep.equal(new Set(['c1', 'c3']));
+  expect(await resolvers[2].promise).to.have.members(['c1', 'c3']);
 });
 
 test('handleDisconnect', async () => {
@@ -313,7 +299,7 @@ test('handleDisconnect', async () => {
     logContextPromise,
   );
 
-  const resolvers: Resolver<ReadonlySet<ClientID>>[] = [
+  const resolvers: Resolver<ReadonlyArray<ClientID>>[] = [
     resolver(),
     resolver(),
     resolver(),
@@ -323,18 +309,18 @@ test('handleDisconnect', async () => {
   presenceManager.addSubscription(present => {
     resolvers[subCallCount++].resolve(present);
   });
-  expect(await resolvers[0].promise).to.deep.equal(new Set(['c1']));
+  expect(await resolvers[0].promise).to.have.members(['c1']);
 
   await presenceManager.updatePresence([
     {op: 'clear'},
     {op: 'put', key: 'c2', value: 1},
   ]);
 
-  expect(await resolvers[1].promise).to.deep.equal(new Set(['c1', 'c2']));
+  expect(await resolvers[1].promise).to.have.members(['c1', 'c2']);
 
   await presenceManager.handleDisconnect();
 
-  expect(await resolvers[2].promise).to.deep.equal(new Set(['c1']));
+  expect(await resolvers[2].promise).to.have.members(['c1']);
 
   await presenceManager.updatePresence([
     {op: 'clear'},
@@ -342,5 +328,5 @@ test('handleDisconnect', async () => {
     {op: 'put', key: 'c3', value: 1},
   ]);
 
-  expect(await resolvers[3].promise).to.deep.equal(new Set(['c1', 'c3']));
+  expect(await resolvers[3].promise).to.have.members(['c1', 'c3']);
 });

--- a/packages/reflect-react/src/index.test.tsx
+++ b/packages/reflect-react/src/index.test.tsx
@@ -53,14 +53,14 @@ test('updating', async () => {
 
   expect(callbacks.length).toEqual(1);
   await act(() => {
-    callbacks[0](new Set(['client1', 'client2']));
+    callbacks[0](['client1', 'client2']);
   });
 
   expect(root?.toJSON()).toEqual('["client1","client2"]');
 
   expect(callbacks.length).toEqual(1);
   await act(() => {
-    callbacks[0](new Set(['client3']));
+    callbacks[0](['client3']);
   });
 
   expect(root?.toJSON()).toEqual('["client3"]');
@@ -99,7 +99,7 @@ test('cleanup', async () => {
   expect(callbacks.length).toEqual(1);
   expect(removeFnCalls).toEqual([0]);
   await act(() => {
-    callbacks[0](new Set(['client1', 'client2']));
+    callbacks[0](['client1', 'client2']);
   });
 
   expect(root?.toJSON()).toEqual('["client1","client2"]');

--- a/packages/reflect-react/src/index.ts
+++ b/packages/reflect-react/src/index.ts
@@ -2,7 +2,7 @@ import {useEffect, useState} from 'react';
 import type {ClientID} from 'reflect-shared';
 
 export type SubscribeToPresenceCallback = (
-  presentClientIDs: ReadonlySet<ClientID>,
+  presentClientIDs: ReadonlyArray<ClientID>,
 ) => void;
 
 export type PresenceSubscribable = {
@@ -11,10 +11,10 @@ export type PresenceSubscribable = {
 
 export function usePresence(
   r: PresenceSubscribable | null | undefined,
-): ReadonlySet<ClientID> {
-  const [presentClientIDs, setPresentClientIDs] = useState(
-    new Set() as ReadonlySet<ClientID>,
-  );
+): ReadonlyArray<ClientID> {
+  const [presentClientIDs, setPresentClientIDs] = useState<
+    ReadonlyArray<ClientID>
+  >([]);
   useEffect(() => {
     if (!r) {
       return;
@@ -25,7 +25,7 @@ export function usePresence(
 
     return () => {
       unsubscribe();
-      setPresentClientIDs(new Set() as ReadonlySet<ClientID>);
+      setPresentClientIDs([]);
     };
   }, [r]);
 


### PR DESCRIPTION
ReadonlyArray is more friendly to work with than ReadonlySet.