### PR TITLE
feat(mirror-server): enforce a limit on the number of server variables

### DIFF
--- a/mirror/mirror-schema/src/vars.ts
+++ b/mirror/mirror-schema/src/vars.ts
@@ -1,0 +1,3 @@
+export const SERVER_VARIABLE_PREFIX = 'REFLECT_VAR_';
+export const ALLOWED_SERVER_VARIABLE_CHARS = /^[A-Za-z0-9_]+$/;
+export const MAX_SERVER_VARIABLES = 50;

--- a/mirror/mirror-server/src/functions/vars/delete.function.ts
+++ b/mirror/mirror-server/src/functions/vars/delete.function.ts
@@ -5,10 +5,11 @@ import {
   deleteVarsResponseSchema,
 } from 'mirror-protocol/src/vars.js';
 import {appDataConverter, appPath} from 'mirror-schema/src/app.js';
+import {SERVER_VARIABLE_PREFIX} from 'mirror-schema/src/vars.js';
 import {appAuthorization, userAuthorization} from '../validators/auth.js';
 import {validateSchema} from '../validators/schema.js';
 import {userAgentVersion} from '../validators/version.js';
-import {SERVER_VAR_PREFIX, deploymentAfter} from './shared.js';
+import {deploymentAtOrAfter} from './shared.js';
 
 export const deleteFn = (firestore: Firestore) =>
   validateSchema(deleteVarsRequestSchema, deleteVarsResponseSchema)
@@ -23,7 +24,7 @@ export const deleteFn = (firestore: Firestore) =>
 
       const secretNames: string[] = [];
       for (const name of vars) {
-        const secretName = `${SERVER_VAR_PREFIX}${name}`;
+        const secretName = `${SERVER_VARIABLE_PREFIX}${name}`;
         if (secrets[secretName]) {
           secretNames.push(secretName);
         }
@@ -51,5 +52,5 @@ export const deleteFn = (firestore: Firestore) =>
         // No deployment to re-deploy.
         return {success: true};
       }
-      return deploymentAfter(firestore, appID, result.writeTime);
+      return deploymentAtOrAfter(firestore, appID, result.writeTime);
     });

--- a/mirror/mirror-server/src/functions/vars/list.function.ts
+++ b/mirror/mirror-server/src/functions/vars/list.function.ts
@@ -5,12 +5,12 @@ import {
   listVarsResponseSchema,
 } from 'mirror-protocol/src/vars.js';
 import type {EncryptedBytes} from 'mirror-schema/src/bytes.js';
+import {SERVER_VARIABLE_PREFIX} from 'mirror-schema/src/vars.js';
 import {SecretsCache, SecretsClient} from '../../secrets/index.js';
 import {getAppSecrets} from '../app/secrets.js';
 import {appAuthorization, userAuthorization} from '../validators/auth.js';
 import {validateSchema} from '../validators/schema.js';
 import {userAgentVersion} from '../validators/version.js';
-import {SERVER_VAR_PREFIX} from './shared.js';
 
 export const list = (firestore: Firestore, secretsClient: SecretsClient) =>
   validateSchema(listVarsRequestSchema, listVarsResponseSchema)
@@ -25,10 +25,10 @@ export const list = (firestore: Firestore, secretsClient: SecretsClient) =>
       } = context;
 
       const vars = Object.entries(appSecrets)
-        .filter(([name]) => name.startsWith(SERVER_VAR_PREFIX))
+        .filter(([name]) => name.startsWith(SERVER_VARIABLE_PREFIX))
         .map(
           ([name, val]) =>
-            [name.substring(SERVER_VAR_PREFIX.length), val] as [
+            [name.substring(SERVER_VARIABLE_PREFIX.length), val] as [
               string,
               EncryptedBytes,
             ],

--- a/mirror/mirror-server/src/functions/vars/set.function.test.ts
+++ b/mirror/mirror-server/src/functions/vars/set.function.test.ts
@@ -17,6 +17,7 @@ import {
 } from 'mirror-schema/src/deployment.js';
 import {getApp, setApp, setUser} from 'mirror-schema/src/test-helpers.js';
 import {userPath} from 'mirror-schema/src/user.js';
+import {MAX_SERVER_VARIABLES} from 'mirror-schema/src/vars.js';
 import {watch} from 'mirror-schema/src/watch.js';
 import {SecretsCache} from '../../secrets/index.js';
 import {TestSecrets} from '../../secrets/test-utils.js';
@@ -197,5 +198,31 @@ describe('vars-set', () => {
       success: true,
       deploymentPath: deploymentPath(APP_ID, '2345'),
     });
+  });
+
+  test('set max vars', async () => {
+    expect(
+      await callSet(
+        Object.fromEntries(
+          Array(MAX_SERVER_VARIABLES - 2)
+            .fill(0)
+            .map((_, i) => [`KEY_${i}`, `VAL_${i}`]),
+        ),
+      ),
+    ).toEqual({
+      success: true,
+    });
+  });
+
+  test('rejects more than max vars', async () => {
+    const result = await callSet(
+      Object.fromEntries(
+        Array(MAX_SERVER_VARIABLES - 1)
+          .fill(0)
+          .map((_, i) => [`KEY_${i}`, `VAL_${i}`]),
+      ),
+    ).catch(e => e);
+    expect(result).toBeInstanceOf(HttpsError);
+    expect((result as HttpsError).code).toBe('resource-exhausted');
   });
 });

--- a/mirror/mirror-server/src/functions/vars/set.function.ts
+++ b/mirror/mirror-server/src/functions/vars/set.function.ts
@@ -12,13 +12,17 @@ import {
 } from 'mirror-schema/src/app.js';
 import type {EncryptedBytes} from 'mirror-schema/src/bytes.js';
 import {encryptUtf8} from 'mirror-schema/src/crypto.js';
+import {
+  ALLOWED_SERVER_VARIABLE_CHARS,
+  MAX_SERVER_VARIABLES,
+  SERVER_VARIABLE_PREFIX,
+} from 'mirror-schema/src/vars.js';
 import {SecretsCache, SecretsClient} from '../../secrets/index.js';
 import {appAuthorization, userAuthorization} from '../validators/auth.js';
+import {getDataOrFail} from '../validators/data.js';
 import {validateSchema} from '../validators/schema.js';
 import {userAgentVersion} from '../validators/version.js';
-import {SERVER_VAR_PREFIX, deploymentAfter} from './shared.js';
-
-const ALLOWED_VAR_CHARS = /^[A-Za-z0-9_]+$/;
+import {deploymentAtOrAfter} from './shared.js';
 
 export const set = (firestore: Firestore, secretsClient: SecretsClient) =>
   validateSchema(setVarsRequestSchema, setVarsResponseSchema)
@@ -29,11 +33,11 @@ export const set = (firestore: Firestore, secretsClient: SecretsClient) =>
       const secrets = new SecretsCache(secretsClient);
       const {appID, vars} = request;
       const {
-        app: {runningDeployment},
+        app: {name},
       } = context;
 
       for (const name of Object.keys(vars)) {
-        if (!ALLOWED_VAR_CHARS.test(name)) {
+        if (!ALLOWED_SERVER_VARIABLE_CHARS.test(name)) {
           throw new HttpsError(
             'invalid-argument',
             'Server Variable names can only contain alphanumeric characters and underscores',
@@ -46,7 +50,7 @@ export const set = (firestore: Firestore, secretsClient: SecretsClient) =>
         Object.entries(vars).map(
           ([name, value]) =>
             [
-              `${SERVER_VAR_PREFIX}${name}`,
+              `${SERVER_VARIABLE_PREFIX}${name}`,
               encryptUtf8(
                 value,
                 Buffer.from(encryptionKey.payload, 'base64url'),
@@ -55,16 +59,44 @@ export const set = (firestore: Firestore, secretsClient: SecretsClient) =>
             ] as [string, EncryptedBytes],
         ),
       ) as AppSecrets;
-      const result = await firestore
+
+      const appDoc = firestore
         .doc(appPath(appID))
-        .withConverter(appDataConverter)
-        .set(
-          {secrets: encrypted},
-          {mergeFields: Object.keys(encrypted).map(name => `secrets.${name}`)},
+        .withConverter(appDataConverter);
+
+      const runningDeployment = await firestore.runTransaction(async tx => {
+        const {secrets: currSecrets, runningDeployment} = getDataOrFail(
+          await tx.get(appDoc),
+          'not-found',
+          `App ${name} was deleted`,
         );
+        const mergedSecrets = {
+          ...currSecrets,
+          ...encrypted,
+        };
+        if (
+          Object.keys(mergedSecrets).filter(name =>
+            name.startsWith(SERVER_VARIABLE_PREFIX),
+          ).length > MAX_SERVER_VARIABLES
+        ) {
+          throw new HttpsError(
+            'resource-exhausted',
+            `Up to ${MAX_SERVER_VARIABLES} Server Variables are allowed.\n` +
+              `Use 'npx @rocicorp/reflect vars delete' to remove unused variables.`,
+          );
+        }
+        tx.set(appDoc, {secrets: mergedSecrets}, {merge: true});
+        return runningDeployment;
+      });
       if (!runningDeployment) {
         // No deployment to re-deploy.
         return {success: true};
       }
-      return deploymentAfter(firestore, appID, result.writeTime);
+      // Read the app back to get the write time. Note that the deployment
+      // may have been written to the doc already.
+      const app = await appDoc.get();
+      if (!app.updateTime) {
+        throw new HttpsError('not-found', `App ${name} was deleted`);
+      }
+      return deploymentAtOrAfter(firestore, appID, app.updateTime);
     });

--- a/mirror/mirror-server/src/functions/vars/shared.ts
+++ b/mirror/mirror-server/src/functions/vars/shared.ts
@@ -6,11 +6,9 @@ import {
 } from 'mirror-schema/src/deployment.js';
 import {TimeoutError, watch} from 'mirror-schema/src/watch.js';
 
-export const SERVER_VAR_PREFIX = 'REFLECT_VAR_';
-
 const DEPLOYMENT_WAIT_TIMEOUT = 5000;
 
-export async function deploymentAfter(
+export async function deploymentAtOrAfter(
   firestore: Firestore,
   appID: string,
   updateTime: Timestamp,
@@ -25,7 +23,7 @@ export async function deploymentAfter(
       firestore
         .collection(deploymentsCollection(appID))
         .withConverter(deploymentDataConverter)
-        .where('requestTime', '>', updateTime)
+        .where('requestTime', '>=', updateTime)
         .orderBy('requestTime')
         .limitToLast(1),
       DEPLOYMENT_WAIT_TIMEOUT,


### PR DESCRIPTION
Enforce a limit of 50 server variables. The number is somewhat arbitrary, but it needs to be less than [Cloudflare's Environment Variable limit of 128](https://developers.cloudflare.com/workers/platform/limits/#:~:text=The%20maximum%20number%20of%20environment,size%20limitation%20of%205%20KB.), with room for our own internal variables.

Also move some constants / limits into `mirror-schema` so that the analogous constraints can be enforced on Dev Variables.

#1150  