### PR TITLE
feat(replicache): Include type in error message

### DIFF
--- a/packages/replicache/src/size-of-value.ts
+++ b/packages/replicache/src/size-of-value.ts
@@ -63,7 +63,7 @@ export function getSizeOfValue(value: unknown): number {
       }
   }
 
-  throw new Error('invalid value');
+  throw new Error(`Invalid value. type: ${typeof value}, value: ${value}`);
 }
 
 function isSmi(value: number): boolean {


### PR DESCRIPTION
In getSizeOfValue, if the value is an invalid type we throw an error. This error message now includes the typeof the value.

https://discord.com/channels/830183651022471199/1169588647683694593/1169588647683694593