### PR TITLE
fix(mirror-server): downgrade orphaned login errors on server

### DIFF
--- a/mirror/mirror-server/src/functions/error/report.function.test.ts
+++ b/mirror/mirror-server/src/functions/error/report.function.test.ts
@@ -134,6 +134,17 @@ describe('error-report function', () => {
       },
       code: 'cancelled',
     },
+    {
+      name: 'login orphan',
+      request: {
+        action: 'cmd_publish',
+        error: {
+          desc: 'Error: Login did not complete within 2 minutes',
+          stack,
+        },
+      },
+      code: 'cancelled',
+    },
   ];
   for (const c of cases) {
     test(c.name, async () => {

--- a/mirror/mirror-server/src/functions/error/report.function.ts
+++ b/mirror/mirror-server/src/functions/error/report.function.ts
@@ -82,5 +82,9 @@ function shouldBeWarning(action: string, desc: string): boolean {
       return true;
     }
   }
+  if (desc.startsWith('Error: Login did not complete within 2 minutes')) {
+    // Downgraded to warning by cli: https://github.com/rocicorp/mono/pull/1187
+    return true;
+  }
   return false;
 }


### PR DESCRIPTION
Server-side equivalent of https://github.com/rocicorp/mono/pull/1187 while old clients are still out there.