### PR TITLE
feat(mirror): enforce a max encoded size of 5kb for var name+value

### DIFF
--- a/mirror/mirror-schema/src/external/vars.ts
+++ b/mirror/mirror-schema/src/external/vars.ts
@@ -2,4 +2,5 @@ export {
   ALLOWED_SERVER_VARIABLE_CHARS,
   MAX_SERVER_VARIABLES,
   SERVER_VARIABLE_PREFIX,
+  variableIsWithinSizeLimit,
 } from '../vars.js';

--- a/mirror/mirror-schema/src/vars.test.ts
+++ b/mirror/mirror-schema/src/vars.test.ts
@@ -1,0 +1,68 @@
+import {describe, expect, test} from '@jest/globals';
+import {variableIsWithinSizeLimit} from './vars.js';
+
+describe('vars size limit', () => {
+  type Case = {
+    name: string;
+    key: string;
+    value: string;
+    expected: boolean;
+  };
+
+  const cases: Case[] = [
+    {
+      name: 'ascii <= 5k',
+      key: 'A'.repeat(1024),
+      value: 'B'.repeat(4096),
+      expected: true,
+    },
+    {
+      name: 'ascii > 5k',
+      key: 'A'.repeat(1024),
+      value: 'B'.repeat(4097),
+      expected: false,
+    },
+    {
+      name: 'non-ascii latin1 <= 5k', // 2-byte unicode characters
+      key: '£'.repeat(512),
+      value: 'И'.repeat(2048),
+      expected: true,
+    },
+    {
+      name: 'non-ascii latin1 > 5k', // 2-byte unicode characters
+      key: '£'.repeat(512),
+      value: 'И'.repeat(2049),
+      expected: false,
+    },
+    {
+      name: 'CJK <= 5k', // 3-byte unicode characters
+      key: '中'.repeat(706),
+      value: '文'.repeat(1000),
+      expected: true,
+    },
+    {
+      name: 'CJK > 5k', // 3-byte unicode characters
+      key: '中'.repeat(706),
+      value: '文'.repeat(1001),
+      expected: false,
+    },
+    {
+      name: 'Emoji <= 5k', // 4-byte unicode characters
+      key: '😁'.repeat(256),
+      value: '😜'.repeat(1024),
+      expected: true,
+    },
+    {
+      name: 'Emoji > 5k', // 4-byte unicode characters
+      key: '😁'.repeat(256),
+      value: '😜'.repeat(1025),
+      expected: false,
+    },
+  ];
+
+  for (const c of cases) {
+    test(c.name, () => {
+      expect(variableIsWithinSizeLimit(c.key, c.value)).toBe(c.expected);
+    });
+  }
+});

--- a/mirror/mirror-schema/src/vars.ts
+++ b/mirror/mirror-schema/src/vars.ts
@@ -1,3 +1,15 @@
 export const SERVER_VARIABLE_PREFIX = 'REFLECT_VAR_';
 export const ALLOWED_SERVER_VARIABLE_CHARS = /^[A-Za-z0-9_]+$/;
 export const MAX_SERVER_VARIABLES = 50;
+
+const MAX_ENCODED_VARIABLE_SIZE = 5 * 1024;
+
+export function variableIsWithinSizeLimit(
+  name: string,
+  value: string,
+): boolean {
+  return (
+    Buffer.byteLength(name) + Buffer.byteLength(value) <=
+    MAX_ENCODED_VARIABLE_SIZE
+  );
+}

--- a/mirror/mirror-server/src/functions/vars/set.function.test.ts
+++ b/mirror/mirror-server/src/functions/vars/set.function.test.ts
@@ -123,6 +123,22 @@ describe('vars-set', () => {
     });
   }
 
+  test('variable size limit', async () => {
+    expect(
+      await callSet({
+        ['NOT_TOO_BIG']: 'a'.repeat(5100),
+      }),
+    ).toEqual({
+      success: true,
+    });
+
+    const result = await callSet({
+      ['TOO_BIG']: 'a'.repeat(5121),
+    }).catch(e => e);
+    expect(result).toBeInstanceOf(HttpsError);
+    expect((result as HttpsError).code).toBe('invalid-argument');
+  });
+
   test('set vars with no running deployment', async () => {
     expect(
       await callSet({

--- a/mirror/reflect-cli/src/dev/vars.test.ts
+++ b/mirror/reflect-cli/src/dev/vars.test.ts
@@ -140,6 +140,26 @@ describe('dev vars', () => {
     });
   });
 
+  test('variable size limit', () => {
+    setDevVars({
+      NOT_TOO_BIG: 'a'.repeat(5100),
+    });
+
+    let err;
+    try {
+      setDevVars({
+        TOO_BIG: 'a'.repeat(5121),
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(UserError);
+
+    expect(listDevVars()).toEqual({
+      NOT_TOO_BIG: 'a'.repeat(5100),
+    });
+  });
+
   test('max vars', async () => {
     setDevVars(
       Object.fromEntries(


### PR DESCRIPTION
Enforces a limit of 5kb for the UTF-8 encoded Variable name and value.

This is a conservative policy based on Cloudflare's published limit of [5kb per variable](https://developers.cloudflare.com/workers/platform/limits/#environment-variables).

#1150 