### PR TITLE
fix(reflect-cli): rename "vars" to "env" and use "environment variables" nomenclature

### DIFF
--- a/mirror/reflect-cli/src/create-cli-parser.ts
+++ b/mirror/reflect-cli/src/create-cli-parser.ts
@@ -5,7 +5,7 @@ import {tryDeprecationCheck, version} from './version.js';
 
 export class CommandLineArgsError extends Error {}
 
-export const scriptName = `npx @rocicorp/reflect`;
+export const scriptName = `npx reflect`;
 
 export function createCLIParserBase(argv: string[]): Argv<{
   v: boolean | undefined;

--- a/mirror/reflect-cli/src/index.ts
+++ b/mirror/reflect-cli/src/index.ts
@@ -91,32 +91,32 @@ function createCLIParser(argv: string[]) {
   );
 
   // vars
-  reflectCLI.command('vars', '🟰  Manage Server Variables', yargs => {
+  reflectCLI.command('env', '🟰  Manage environment variables', yargs => {
     yargs
       .option('dev', {
-        describe: 'Manage Dev Variables for `npx @rocicorp/reflect dev`',
+        describe: 'Manage local variables for `npx reflect dev`',
         type: 'boolean',
         default: false,
       })
       .command(
         'list',
-        'List Server Variables',
+        'List environment variables',
         listVarsOptions,
         handleWith(listVarsHandler).andCleanup(),
       )
       .command(
         'set <keysAndValues..>',
-        'Set one or more Server Variables',
+        'Set one or more environment variables',
         setVarsOptions,
         handleWith(setVarsHandler).andCleanup(),
       )
       .command(
         'delete <keys..>',
-        'Delete one or more Server Variables',
+        'Delete one or more environment variables',
         deleteVarsOptions,
         handleWith(deleteVarsHandler).andCleanup(),
       )
-      .demandCommand(1, 'Available vars commands:\n');
+      .demandCommand(1, 'Available commands:\n');
   });
 
   // delete


### PR DESCRIPTION
As per https://www.notion.so/replicache/Server-Vars-DX-Review-9adebacf10af4456985a1e11a05723be?pvs=4#00f52a2b52a2443b99d7dc2e1cf654eb

![Screenshot 2023-11-03 at 12 11 27 PM](https://github.com/rocicorp/mono/assets/132324914/864bc8f6-3ea6-4014-80d7-c76ed3ff4c9f)

![Screenshot 2023-11-03 at 12 12 47 PM](https://github.com/rocicorp/mono/assets/132324914/31244996-2a91-498b-ab10-3ce4be9bc7ff)
