### PR TITLE
fix(reflect-server): auth-do sent invalid errors

### DIFF
--- a/mirror/mirror-server/src/functions/app/tail.handler.ts
+++ b/mirror/mirror-server/src/functions/app/tail.handler.ts
@@ -77,10 +77,7 @@ export const tail = (
         let createTailResult;
         try {
           createTailResult = await createTail(
-            new GlobalScript(
-              {apiToken: await apiToken, accountID},
-              cfWorkerName,
-            ),
+            new GlobalScript({apiToken, accountID}, cfWorkerName),
             filters,
             debug,
             packageVersion,

--- a/packages/reflect-server/src/server/auth-do.test.ts
+++ b/packages/reflect-server/src/server/auth-do.test.ts
@@ -7,6 +7,7 @@ import {
   jest,
   test,
 } from '@jest/globals';
+import type {TailErrorMessage} from 'reflect-protocol/src/tail.js';
 import {assert} from 'shared/src/asserts.js';
 import {newInvalidateAllAuthRequest} from '../client/auth.js';
 import {
@@ -2364,7 +2365,7 @@ describe('tail', () => {
       testApiToken: string | null;
       authApiKey?: string;
       testRoomID: string | null;
-      expectedError?: unknown;
+      expectedError?: TailErrorMessage;
     },
   ) => {
     test(name, async () => {
@@ -2414,26 +2415,38 @@ describe('tail', () => {
   t('without api token', {
     testApiToken: null,
     testRoomID: 'testRoomID1',
-    expectedError: ['error', 'Unauthorized', 'auth required'],
+    expectedError: {
+      type: 'error',
+      kind: 'Unauthorized',
+      message: 'auth required',
+    },
   });
   t('wrong api token', {
     testApiToken: 'wrong',
     testRoomID: 'testRoomID1',
-    expectedError: ['error', 'Unauthorized', 'auth required'],
+    expectedError: {
+      type: 'error',
+      kind: 'Unauthorized',
+      message: 'auth required',
+    },
   });
   t('without api token but with roomID', {
     testApiToken: null,
     testRoomID: 'hello',
-    expectedError: ['error', 'Unauthorized', 'auth required'],
+    expectedError: {
+      type: 'error',
+      kind: 'Unauthorized',
+      message: 'auth required',
+    },
   });
   t('missing room id', {
     testApiToken: TEST_AUTH_API_KEY,
     testRoomID: null,
-    expectedError: [
-      'error',
-      'InvalidConnectionRequest',
-      'roomID parameter required',
-    ],
+    expectedError: {
+      type: 'error',
+      kind: 'InvalidConnectionRequest',
+      message: 'roomID parameter required',
+    },
   });
   t('api token with spaces', {
     testApiToken: 'a b c',

--- a/packages/reflect-server/src/server/auth-do.ts
+++ b/packages/reflect-server/src/server/auth-do.ts
@@ -21,6 +21,7 @@ import {sleep} from '../util/sleep.js';
 import {
   SEC_WEBSOCKET_PROTOCOL_HEADER,
   createWSAndCloseWithError,
+  createWSAndCloseWithTailError,
 } from '../util/socket.js';
 import {AlarmManager, TimeoutID} from './alarms.js';
 import {createAuthAPIHeaders} from './auth-api-headers.js';
@@ -320,7 +321,7 @@ export class BaseAuthDO implements DurableObject {
     // See comment in #connectImpl for more details.
 
     const closeWithErrorLocal = (errorKind: TailErrorKind, msg: string) =>
-      createWSAndCloseWithError(lc, request, errorKind, msg);
+      createWSAndCloseWithTailError(lc, request, errorKind, msg);
 
     // For tail we send the REFLECT_AUTH_API_KEY in the Sec-WebSocket-Protocol
     // header and it is always required


### PR DESCRIPTION
This was using the wrong method to send errors, which meant that the errors were not formatted correctly, leading to valita validation errors in the mirror-server.

Fixes #1172