### PR TITLE
feat(mirror): add selectStarPlus() for leveraging default column aliases

### DIFF
--- a/mirror/cloudflare-api/src/dataset.ts
+++ b/mirror/cloudflare-api/src/dataset.ts
@@ -96,6 +96,24 @@ export class Dataset<T extends InputSchema> implements Selectable {
   }
 
   /**
+   * Selects all of the column aliases with additional expressions based on the aliases.
+   */
+  selectStarPlus<S extends SelectSchema>(
+    more: SelectClause<S>,
+  ): Where<OutputSchema<T> & S> {
+    return this.select({
+      schema: v.object({
+        ...this.output.shape,
+        ...more.schema.shape,
+      }),
+      expr: {
+        ...this.#columnAliases,
+        ...more.expr,
+      },
+    });
+  }
+
+  /**
    * Starts a custom "SELECT" statement with the given SelectSchema and accompanying
    * expressions for each alias.
    */

--- a/mirror/cloudflare-api/src/sql.test.ts
+++ b/mirror/cloudflare-api/src/sql.test.ts
@@ -224,6 +224,47 @@ describe('sql', () => {
     });
   });
 
+  describe('selectStarPlus', () => {
+    const selectStarPlus = runningConnectionSeconds.selectStarPlus({
+      schema: v.object({averageConnections: v.number()}),
+      expr: {averageConnections: 'elapsed / interval'},
+    });
+
+    test('toString', () => {
+      expect(selectStarPlus.toString()).toBe(
+        `SELECT
+          blob1 AS teamID,
+          blob2 AS appID,
+          double1 AS elapsed,
+          double2 AS interval,
+          timestamp,
+          elapsed / interval AS averageConnections
+          FROM RunningConnectionSeconds
+          FORMAT JSON`,
+      );
+    });
+
+    test('where', () => {
+      expect(
+        selectStarPlus
+          .where('teamID', '=', 'foo')
+          .and('averageConnections', '>', 2)
+          .toString(),
+      ).toBe(
+        `SELECT
+          blob1 AS teamID,
+          blob2 AS appID,
+          double1 AS elapsed,
+          double2 AS interval,
+          timestamp,
+          elapsed / interval AS averageConnections
+          FROM RunningConnectionSeconds
+          WHERE (teamID = 'foo') AND (averageConnections > 2)
+          FORMAT JSON`,
+      );
+    });
+  });
+
   describe('custom select', () => {
     const selectCustom = runningConnectionSeconds.select({
       schema: v.object({

--- a/mirror/mirror-cli/src/sum-usage.ts
+++ b/mirror/mirror-cli/src/sum-usage.ts
@@ -74,27 +74,20 @@ export async function sumUsageHandler(yargs: SumUsageHandlerArgs) {
 
   const result2 = await analytics.query(
     connectionLifetimes
-      .select({
+      .selectStarPlus({
         schema: v.object({
-          teamID: v.string(),
-          appID: v.string(),
           lifetimeMs: v.number(),
           afterMs: v.number(),
           beforeMs: v.number(),
         }),
         expr: {
-          teamID: 'blob1',
-          appID: 'blob2',
-          // endTime - startTime
-          lifetimeMs: 'double2 - double1',
-          // IF(endTime > endMs, endTime - endMs, 0.0)
-          afterMs: `IF(double2 > ${endMs}, double2 - ${endMs}, 0.0)`,
-          // IF(startMs > startTime, startMs - startTime, 0.0)
-          beforeMs: `IF(${startMs} > double1, ${startMs} - double1, 0.0)`,
+          lifetimeMs: 'endTime - startTime',
+          afterMs: `IF(endTime > ${endMs}, endTime - ${endMs}, 0.0)`,
+          beforeMs: `IF(${startMs} > startTime, ${startMs} - startTime, 0.0)`,
         },
       })
-      .where('double1', '<', endMs)
-      .and('double2', '>', startMs)
+      .where('startTime', '<', endMs)
+      .and('endTime', '>', startMs)
       .select({
         schema: v.object({
           teamID: v.string(),


### PR DESCRIPTION
Add a `dataset.selectStarPlus()` method for creating a `SELECT` statement that combines the default `blobN` => `columnName` mapping with additional expressions based on those column names.

This obviates the need to repeat the blob/double column name mapping when selecting complex column expressions.