### PR TITLE
feat(mirror): add type-checking to GROUP BY and ORDER BY

### DIFF
--- a/mirror/cloudflare-api/src/sql.ts
+++ b/mirror/cloudflare-api/src/sql.ts
@@ -105,15 +105,15 @@ function where(
 
 // https://developers.cloudflare.com/analytics/analytics-engine/sql-reference/#group-by-clause
 export interface GroupBy<T extends SelectSchema> extends OrderBy<T> {
-  groupBy(...expressions: [string, ...string[]]): OrderBy<T>;
+  groupBy(...expressions: [keyof T, ...(keyof T)[]]): OrderBy<T>;
 }
 
 export type Direction = 'ASC' | 'DESC';
 
 // https://developers.cloudflare.com/analytics/analytics-engine/sql-reference/#order-by-clause
 export interface OrderBy<T extends SelectSchema> extends Limit<T> {
-  orderBy(expression: string): Limit<T>;
-  orderBy(expression: string, dir: Direction): Limit<T>;
+  orderBy(expression: keyof T): Limit<T>;
+  orderBy(expression: keyof T, dir: Direction): Limit<T>;
 }
 
 // https://developers.cloudflare.com/analytics/analytics-engine/sql-reference/#limit-clause
@@ -241,12 +241,12 @@ export class SelectBuilder<T extends SelectSchema> implements Where<T> {
     );
   }
 
-  groupBy(...expressions: [string, ...string[]]): SelectBuilder<T> {
+  groupBy(...expressions: [keyof T, ...(keyof T)[]]): SelectBuilder<T> {
     return this.#with(`GROUP BY ${expressions.join(`, `)}`);
   }
 
-  orderBy(expression: string, dir: Direction = 'ASC'): SelectBuilder<T> {
-    return this.#with(`ORDER BY ${expression} ${dir}`);
+  orderBy(expression: keyof T, dir: Direction = 'ASC'): SelectBuilder<T> {
+    return this.#with(`ORDER BY ${String(expression)} ${dir}`);
   }
 
   limit(n: number | undefined): SelectBuilder<T> {


### PR DESCRIPTION
Leverage type checking for `GROUP BY` and `ORDER BY` clauses.

Technically, like `WHERE` clauses, the clauses can be more complex expressions based on column values / aliases, but in the large majority of cases (and for our purposes), we only use aliases, so the type checking is convenient. We can revisit this or add a more flexible versions of these methods if the need arises.

![Screenshot 2023-11-09 at 11 52 10 PM](https://github.com/rocicorp/mono/assets/132324914/eeecedb0-e3a2-46ee-9cf7-d12d83838670)
