### PR TITLE
feat(mirror-server): move backup time to 3AM PDT

### DIFF
--- a/mirror/mirror-server/src/functions/metrics/backup.function.ts
+++ b/mirror/mirror-server/src/functions/metrics/backup.function.ts
@@ -22,6 +22,7 @@ export const backup = (
   secretsClient: SecretsClient,
 ) =>
   // https://cloud.google.com/appengine/docs/flexible/scheduling-jobs-with-cron-yaml#custom-interval
+  // Schedules are interpreted as UTC times, so this actually runs at 3AM or 4AM Pacific time.
   onSchedule('every tuesday 11:00', async event => {
     const secrets = new SecretsCache(secretsClient);
     const now = new Date(event.scheduleTime);


### PR DESCRIPTION
The time specifications appear to be processed in UTC time, so "Tuesday at 4:00" was actually executed on Monday at 8pm pacific time.

Changed to Tuesday 11:00 so that it runs at 3am or 4am Pacific time.