### PR TITLE
feat(mirror-server): metrics ledger improvements

### DIFF
--- a/mirror/mirror-schema/src/metrics.ts
+++ b/mirror/mirror-schema/src/metrics.ts
@@ -6,12 +6,15 @@ import {teamPath} from './team.js';
 
 /** Connection seconds reported incrementally from within the RoomDO. */
 export const CONNECTION_SECONDS = 'cs';
+/** Seconds that RoomDO's had connections. `cs / rs` is the average number of connections. */
+export const ROOM_SECONDS = 'rs';
 /** Connection seconds computed from completed FetchEvents. */
 export const CONNECTION_LIFETIMES = 'cl';
 
 export const metricSchema = v.union(
   v.literal(CONNECTION_SECONDS),
   v.literal(CONNECTION_LIFETIMES),
+  v.literal(ROOM_SECONDS),
 );
 
 export type Metric = v.Infer<typeof metricSchema>;
@@ -22,6 +25,7 @@ export type Metric = v.Infer<typeof metricSchema>;
 export const metricsSchema = v.object({
   [CONNECTION_SECONDS]: v.number().optional(),
   [CONNECTION_LIFETIMES]: v.number().optional(),
+  [ROOM_SECONDS]: v.number().optional(),
 });
 
 export type Metrics = v.Infer<typeof metricsSchema>;
@@ -118,7 +122,7 @@ export type DayOfMonth =
   | '31';
 
 export function yearMonth(date: Date): number {
-  return date.getFullYear() * 100 + date.getMonth();
+  return date.getUTCFullYear() * 100 + date.getUTCMonth();
 }
 
 // The MonthMetric sparsely tracks a month's worth of metrics for each hour of each day,


### PR DESCRIPTION
Improve the metrics `Ledger` logic to support the update of multiple metrics in a single Transaction. This reduces the number of document writes required to aggregate metrics.

Also, avoid performing any writes if there are no changes to any metric values. This allows us to perform multiple, possibly redundant aggregations cheaply, only increasing the number of writes if the Cloudflare analytics data is late to arrive.

Add a `ROOM_SECONDS` metric that corresponds to the `period` denominator of the `elapsed` connection seconds. This is data that we already track with connection seconds; it now has a place on the ledger should we wish to use it, for example, to compute the average number of connections in a given period.

Finally, fix the ledger logic to use UTC time for determining the month/day/hour slots when storing metric values.

This logic is yet to be plugged in to production; periodic aggregation logic is forthcoming.