### PR TITLE
feat(mirror-server): use 1-based indexing for ledger months

### DIFF
--- a/mirror/mirror-schema/src/metrics.test.ts
+++ b/mirror/mirror-schema/src/metrics.test.ts
@@ -2,7 +2,9 @@ import {describe, expect, test} from '@jest/globals';
 import sizeof from 'firestore-size';
 import {
   monthMetricsPath,
+  splitDate,
   totalMetricsPath,
+  yearMonth,
   type DayMetrics,
   type DayOfMonth,
   type Hour,
@@ -42,6 +44,33 @@ describe('metrics schema', () => {
     return month;
   }
 
+  test('yearmonth', () => {
+    expect(yearMonth(new Date(Date.UTC(2022, 0, 1)))).toBe(202201);
+    expect(yearMonth(new Date(Date.UTC(2023, 8, 30)))).toBe(202309);
+    expect(yearMonth(new Date(Date.UTC(2023, 11, 31)))).toBe(202312);
+  });
+
+  test('splitDate', () => {
+    expect(splitDate(new Date(Date.UTC(2022, 0, 1, 2)))).toEqual([
+      '2022',
+      '01',
+      '1',
+      '2',
+    ]);
+    expect(splitDate(new Date(Date.UTC(2023, 8, 30, 3)))).toEqual([
+      '2023',
+      '09',
+      '30',
+      '3',
+    ]);
+    expect(splitDate(new Date(Date.UTC(2023, 11, 31, 15)))).toEqual([
+      '2023',
+      '12',
+      '31',
+      '15',
+    ]);
+  });
+
   test('empty document size', () => {
     expect(sizeof(emptyMonth())).toBe(94);
   });
@@ -69,13 +98,13 @@ describe('metrics schema', () => {
   });
 
   test('document paths', () => {
-    expect(monthMetricsPath('2023', '9', TEAM, APP)).toBe(
+    expect(monthMetricsPath('2023', '09', TEAM, APP)).toBe(
       `apps/${APP}/metrics/202309-${TEAM}`,
     );
     expect(monthMetricsPath('2023', '10', TEAM, APP)).toBe(
       `apps/${APP}/metrics/202310-${TEAM}`,
     );
-    expect(monthMetricsPath('2023', '9', TEAM)).toBe(
+    expect(monthMetricsPath('2023', '09', TEAM)).toBe(
       `teams/${TEAM}/metrics/202309`,
     );
     expect(monthMetricsPath('2023', '10', TEAM)).toBe(

--- a/mirror/mirror-schema/src/metrics.ts
+++ b/mirror/mirror-schema/src/metrics.ts
@@ -122,7 +122,20 @@ export type DayOfMonth =
   | '31';
 
 export function yearMonth(date: Date): number {
-  return date.getUTCFullYear() * 100 + date.getUTCMonth();
+  return date.getUTCFullYear() * 100 + (date.getUTCMonth() + 1);
+}
+
+export function splitDate(
+  date: Date,
+): [year: string, month: Month, dayOfMonth: DayOfMonth, hour: Hour] {
+  const month = (date.getUTCMonth() + 1).toString();
+  const mm = month.length > 1 ? month : '0' + month;
+  return [
+    date.getUTCFullYear().toString(),
+    mm as Month,
+    date.getUTCDate().toString() as DayOfMonth,
+    date.getUTCHours().toString() as Hour,
+  ];
 }
 
 // The MonthMetric sparsely tracks a month's worth of metrics for each hour of each day,
@@ -228,18 +241,18 @@ export function teamMetricsCollection(teamID: string): string {
 }
 
 export type Month =
-  | '0'
-  | '1'
-  | '2'
-  | '3'
-  | '4'
-  | '5'
-  | '6'
-  | '7'
-  | '8'
-  | '9'
+  | '01'
+  | '02'
+  | '03'
+  | '04'
+  | '05'
+  | '06'
+  | '07'
+  | '08'
+  | '09'
   | '10'
-  | '11';
+  | '11'
+  | '12';
 
 export function monthMetricsPath(
   year: string,
@@ -247,8 +260,7 @@ export function monthMetricsPath(
   teamID: string,
   appID?: string,
 ): string {
-  const mm = month.length < 2 ? `0${month}` : month;
-  return metricsDocPath(teamID, appID, `${year}${mm}`);
+  return metricsDocPath(teamID, appID, `${year}${month}`);
 }
 
 export function totalMetricsPath(teamID: string, appID?: string): string {

--- a/mirror/mirror-server/src/metrics/ledger.ts
+++ b/mirror/mirror-server/src/metrics/ledger.ts
@@ -1,16 +1,14 @@
 import {FieldValue, type Firestore} from 'firebase-admin/firestore';
 import {logger} from 'firebase-functions';
 import {
-  Hour,
   Metrics,
   monthMetricsDataConverter,
   monthMetricsPath,
+  splitDate,
   totalMetricsDataConverter,
   totalMetricsPath,
   yearMonth,
-  type DayOfMonth,
   type Metric,
-  type Month,
 } from 'mirror-schema/src/metrics.js';
 
 /**
@@ -50,10 +48,7 @@ export class Ledger {
     const window = `${teamID}/${appID}/${timeDesc}[${[...newMetrics.keys()]}]`;
 
     return this.#firestore.runTransaction(async tx => {
-      const year = hourWindow.getUTCFullYear().toString();
-      const month = hourWindow.getUTCMonth().toString() as Month;
-      const day = hourWindow.getUTCDate().toString() as DayOfMonth;
-      const hour = hourWindow.getUTCHours().toString() as Hour;
+      const [year, month, day, hour] = splitDate(hourWindow);
 
       const appMonthDoc = this.#firestore
         .doc(monthMetricsPath(year, month, teamID, appID))


### PR DESCRIPTION
Use not-confusing 1-based indexes for months in the ledger (converting from the 0-based indexes used in Javascript Dates). This affects the ledger doc path and the `yearMonth` field in the month docs, neither if which is expected to be used in date arithmetic, so it should be safe to use 1-based values for them. We'll thank ourselves for this later.