### PR TITLE
feat(mirror): aggregate hourly connection seconds metrics

### DIFF
--- a/mirror/cloudflare-api/src/analytics.ts
+++ b/mirror/cloudflare-api/src/analytics.ts
@@ -26,7 +26,7 @@ export class Analytics {
   }
 
   async #query(statement: string) {
-    console.info(`QUERY: ${statement}`);
+    console.info(`QUERY: ${statement.replace(/\s+/g, ' ')}`);
     const resp = await cfCall(this.#apiToken, this.#resource, {
       method: 'POST',
       body: statement,

--- a/mirror/mirror-cli/package.json
+++ b/mirror/mirror-cli/package.json
@@ -12,7 +12,7 @@
     "@inquirer/select": "^1.2.11",
     "@rocicorp/reflect": "0.38.202311130825+d3dbae",
     "esbuild": "^0.19.4",
-    "firebase-admin": "^11.10.1",
+    "mirror-server": "0.0.1",
     "pkg-up": "^4.0.0",
     "reflect-cli": "0.0.0",
     "semver": "^7.5.4",
@@ -35,7 +35,6 @@
     "@types/yargs": "^17.0.10",
     "cloudflare-api": "0.0.0",
     "mirror-workers": "0.0.0",
-    "mirror-server": "0.0.1",
     "typescript": "^5.2.2"
   },
   "files": [

--- a/mirror/mirror-cli/src/backfill-metrics.ts
+++ b/mirror/mirror-cli/src/backfill-metrics.ts
@@ -1,0 +1,47 @@
+import {Analytics} from 'cloudflare-api/src/analytics.js';
+import {getFirestore} from 'firebase-admin/firestore';
+import {aggregateHourBefore} from 'mirror-server/src/metrics/aggregate.js';
+import {sleep} from 'shared/src/sleep.js';
+import {getProviderConfig} from './cf.js';
+import type {CommonYargsArgv, YargvToInterface} from './yarg-types.js';
+
+export function backfillMetricsOptions(yargs: CommonYargsArgv) {
+  return yargs
+    .option('start-date', {
+      desc: 'Date from which to begin the backfill, hour by hour',
+      type: 'string',
+      default: '2023-10-14',
+    })
+    .option('max-runs', {
+      desc: 'Maximum number of hours to backfill',
+      type: 'number',
+      default: Number.MAX_SAFE_INTEGER,
+    });
+}
+
+type BackfillMetricsHandlerArgs = YargvToInterface<
+  ReturnType<typeof backfillMetricsOptions>
+>;
+
+export async function backfillMetricsHandler(
+  yargs: BackfillMetricsHandlerArgs,
+) {
+  const {startDate, maxRuns} = yargs;
+  const firestore = getFirestore();
+  const config = await getProviderConfig(yargs);
+  const analytics = new Analytics(config);
+  const startTime = new Date(startDate);
+  const now = Date.now();
+
+  for (let runs = 0; startTime.getTime() < now && runs < maxRuns; runs++) {
+    (await aggregateHourBefore(firestore, analytics, startTime)).forEach(
+      result => {
+        if (result.status === 'rejected') {
+          throw result.reason;
+        }
+      },
+    );
+    startTime.setHours(startTime.getHours() + 1);
+    await sleep(1000);
+  }
+}

--- a/mirror/mirror-cli/src/index.ts
+++ b/mirror/mirror-cli/src/index.ts
@@ -1,6 +1,10 @@
 import {hideBin} from 'yargs/helpers';
 import {addDeploymentsOptionsHandler} from './add-deployment-options.js';
 import {
+  backfillMetricsHandler,
+  backfillMetricsOptions,
+} from './backfill-metrics.js';
+import {
   backupAnalyticsHandler,
   backupAnalyticsOptions,
 } from './backup-analytics.js';
@@ -242,6 +246,14 @@ function createCLIParser(argv: string[]) {
     backupAnalyticsHandler,
   );
 
+  // backfill-metrics
+  reflectCLI.command(
+    'backfill-metrics',
+    'Backfills aggregated metrics into Firestore. Also suitable for rerunning aggregations if Cloudflare Analytics data is delayed.',
+    backfillMetricsOptions,
+    backfillMetricsHandler,
+  );
+
   // sum-usage
   reflectCLI.command(
     'sum-usage',
@@ -279,7 +291,7 @@ function createCLIParser(argv: string[]) {
   );
 
   reflectCLI.command(
-    'runQuery',
+    'run-query',
     'Runs a specific query against Firestore to see if an index is necessary (which would appear in an Error message)',
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     () => {},

--- a/mirror/mirror-server/package.json
+++ b/mirror/mirror-server/package.json
@@ -23,7 +23,6 @@
   "main": "out/index.js",
   "dependencies": {
     "@badrap/valita": "^0.3.0",
-    "@google-cloud/firestore": "^6.6.1",
     "@google-cloud/functions-framework": "^3.2.0",
     "@google-cloud/secret-manager": "^5.0.1",
     "cors": "^2.8.5",

--- a/mirror/mirror-server/src/functions/metrics/aggregate.function.ts
+++ b/mirror/mirror-server/src/functions/metrics/aggregate.function.ts
@@ -1,0 +1,79 @@
+import type {Firestore} from '@google-cloud/firestore';
+import {Analytics} from 'cloudflare-api/src/analytics.js';
+import {logger} from 'firebase-functions';
+import {onSchedule} from 'firebase-functions/v2/scheduler';
+import {
+  PROVIDER_COLLECTION,
+  providerDataConverter,
+} from 'mirror-schema/src/provider.js';
+import {aggregateHourBefore} from '../../metrics/aggregate.js';
+import {
+  SecretsCache,
+  apiTokenName,
+  type SecretsClient,
+} from '../../secrets/index.js';
+
+export const aggregate = (firestore: Firestore, secretsClient: SecretsClient) =>
+  onSchedule(
+    {
+      // Every hour on the 1st, 5th, and 30th minute, the first to compute results
+      // aggressively, and the second to catch any results due to delays in Workers
+      // Analytics Engine. The last aggregation is always expected to be a no-op, but
+      // performed to see if are pathological scenarios in which delays last longer than
+      // 5 minutes. The mirror-cli's `backfill-metrics` command can be used for one-off
+      // delays / outages.
+      schedule: '1,5,30 * * * *',
+      retryCount: 3,
+    },
+    async event => {
+      const secrets = new SecretsCache(secretsClient);
+      const scheduleTime = new Date(event.scheduleTime);
+
+      const providers = await firestore
+        .collection(PROVIDER_COLLECTION)
+        .withConverter(providerDataConverter)
+        .get();
+
+      let failure;
+      for (const doc of providers.docs) {
+        const provider = doc.id;
+        const {accountID} = doc.data();
+        const apiToken = await secrets.getSecretPayload(apiTokenName(provider));
+        const analytics = new Analytics({apiToken, accountID});
+
+        const updates = await aggregateHourBefore(
+          firestore,
+          analytics,
+          scheduleTime,
+        );
+        let updated = 0;
+        let unchanged = 0;
+
+        for (const update of updates) {
+          if (update.status === 'rejected') {
+            failure = update.reason;
+          } else if (update.value) {
+            updated++;
+          } else {
+            unchanged++;
+          }
+        }
+
+        if (scheduleTime.getUTCMinutes() >= 30 && updated > 0) {
+          // Log an error so that it gets reported.
+          logger.error(
+            new Error(
+              `Updated metrics for ${updated} apps more than 30 minutes after the hour`,
+            ),
+          );
+        } else {
+          logger.info(
+            `Updated metrics for ${updated} apps (${unchanged} unchanged)`,
+          );
+        }
+      }
+      if (failure) {
+        throw failure; // Throw errors so that retries kick in.
+      }
+    },
+  );

--- a/mirror/mirror-server/src/functions/metrics/index.ts
+++ b/mirror/mirror-server/src/functions/metrics/index.ts
@@ -1,1 +1,2 @@
+export {aggregate} from './aggregate.function.js';
 export {backup} from './backup.function.js';

--- a/mirror/mirror-server/src/index.ts
+++ b/mirror/mirror-server/src/index.ts
@@ -75,6 +75,7 @@ export const env = {
 };
 
 export const metrics = {
+  aggregate: metricsFunctions.aggregate(getFirestore(), secrets),
   backup: metricsFunctions.backup(getFirestore(), getStorage(), secrets),
 };
 

--- a/mirror/mirror-server/src/metrics/aggregate.test.ts
+++ b/mirror/mirror-server/src/metrics/aggregate.test.ts
@@ -1,0 +1,164 @@
+import {afterEach, describe, expect, jest, test} from '@jest/globals';
+import {Analytics} from 'cloudflare-api/src/analytics.js';
+import {initializeApp} from 'firebase-admin/app';
+import {getFirestore} from 'firebase-admin/firestore';
+import {monthMetricsPath, totalMetricsPath} from 'mirror-schema/src/metrics.js';
+import {FetchMocker} from 'shared/src/fetch-mocker.js';
+import {aggregateHourBefore} from './aggregate.js';
+
+const QUERY_RESULT = {
+  meta: [
+    {name: 'teamID', type: 'String'},
+    {name: 'appID', type: 'String'},
+    {name: 'totalElapsed', type: 'Float64'},
+    {name: 'totalPeriod', type: 'Float64'},
+  ],
+  data: [
+    {
+      teamID: 'Itbj8PWpHEm',
+      appID: 'ln2b4mz2',
+      totalElapsed: 8321.108,
+      totalPeriod: 7401.156,
+    },
+    {
+      teamID: 'CV9Uwl0iwnd',
+      appID: 'louhf2oo',
+      totalElapsed: 109.055,
+      totalPeriod: 116.241,
+    },
+    {
+      teamID: 'CzCv9TyiF7u',
+      appID: 'lmjdhbbp',
+      totalElapsed: 9778.55,
+      totalPeriod: 3255.52,
+    },
+    {
+      teamID: '7b4eqY3OWih',
+      appID: 'lof5fld8',
+      totalElapsed: 1368521.747,
+      totalPeriod: 72572.993,
+    },
+    {
+      teamID: 'LySsDFFXARU',
+      appID: 'lox33rd9',
+      totalElapsed: 101.94,
+      totalPeriod: 124.589,
+    },
+  ],
+  rows: 5,
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  rows_before_limit_at_least: 16146,
+};
+
+describe('aggregateHourBefore', () => {
+  initializeApp({projectId: 'metrics-aggregation-test'});
+  const firestore = getFirestore();
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('success', async () => {
+    const fetcher = new FetchMocker().result(
+      'POST',
+      '/analytics',
+      QUERY_RESULT,
+    );
+
+    const date = new Date(Date.UTC(2023, 9, 10, 13, 14, 15, 16));
+    const startTime = Date.UTC(2023, 9, 10, 12) / 1000;
+    const endTime = Date.UTC(2023, 9, 10, 13) / 1000;
+
+    await aggregateHourBefore(
+      firestore,
+      new Analytics({apiToken: 'api-token', accountID: 'cf-account'}),
+      date,
+    );
+
+    expect(fetcher.bodys()).toEqual([
+      `SELECT
+          teamID,
+          appID,
+          SUM(elapsed) AS totalElapsed,
+          SUM(period) AS totalPeriod
+          FROM (
+          SELECT
+          blob1 AS teamID,
+          blob2 AS appID,
+          double1 AS elapsed,
+          double2 AS period,
+          timestamp
+          FROM RunningConnectionSeconds
+          WHERE (timestamp >= toDateTime(${startTime})) AND (timestamp < toDateTime(${endTime}))
+          )
+          GROUP BY teamID, appID
+          FORMAT JSON`,
+    ]);
+
+    for (const usage of QUERY_RESULT.data) {
+      const {teamID, appID, totalElapsed, totalPeriod} = usage;
+      const expectedTeamMonth = {
+        teamID,
+        appID: null,
+        yearMonth: 202310,
+        total: {
+          cs: totalElapsed,
+          rs: totalPeriod,
+        },
+        day: {
+          '10': {
+            hour: {
+              '12': {
+                cs: totalElapsed,
+                rs: totalPeriod,
+              },
+            },
+            total: {
+              cs: totalElapsed,
+              rs: totalPeriod,
+            },
+          },
+        },
+      };
+      expect(
+        (
+          await firestore.doc(monthMetricsPath('2023', '10', teamID)).get()
+        ).data(),
+      ).toEqual(expectedTeamMonth);
+      expect(
+        (
+          await firestore
+            .doc(monthMetricsPath('2023', '10', teamID, appID))
+            .get()
+        ).data(),
+      ).toEqual({
+        ...expectedTeamMonth,
+        appID,
+      });
+
+      const expectedTeamTotal = {
+        teamID,
+        appID: null,
+        total: {
+          cs: totalElapsed,
+          rs: totalPeriod,
+        },
+        year: {
+          '2023': {
+            cs: totalElapsed,
+            rs: totalPeriod,
+          },
+        },
+      };
+      expect(
+        (await firestore.doc(totalMetricsPath(teamID)).get()).data(),
+      ).toEqual(expectedTeamTotal);
+      expect(
+        (await firestore.doc(totalMetricsPath(teamID, appID)).get()).data(),
+      ).toEqual({
+        ...expectedTeamTotal,
+        appID,
+      });
+    }
+  });
+});

--- a/mirror/mirror-server/src/metrics/aggregate.ts
+++ b/mirror/mirror-server/src/metrics/aggregate.ts
@@ -1,0 +1,63 @@
+import type {Firestore} from '@google-cloud/firestore';
+import type {Analytics} from 'cloudflare-api/src/analytics.js';
+import {logger} from 'firebase-functions';
+import {runningConnectionSeconds} from 'mirror-schema/src/datasets.js';
+import {CONNECTION_SECONDS, ROOM_SECONDS} from 'mirror-schema/src/metrics.js';
+import * as v from 'shared/src/valita.js';
+import {Ledger} from './ledger.js';
+
+export const sums = {
+  schema: v.object({
+    teamID: v.string(),
+    appID: v.string(),
+    totalElapsed: v.number(),
+    totalPeriod: v.number(),
+  }),
+  expr: {
+    totalElapsed: 'SUM(elapsed)',
+    totalPeriod: 'SUM(period)',
+  },
+} as const;
+
+export async function aggregateHourBefore(
+  firestore: Firestore,
+  analytics: Analytics,
+  date: Date,
+) {
+  const end = new Date(
+    Date.UTC(
+      date.getUTCFullYear(),
+      date.getUTCMonth(),
+      date.getUTCDate(),
+      date.getUTCHours(),
+    ),
+  );
+  const start = new Date(end.getTime() - 3600 * 1000);
+  const results = await analytics.query(
+    runningConnectionSeconds
+      .selectStar()
+      .where('timestamp', '>=', start)
+      .and('timestamp', '<', end)
+      .select(sums)
+      .groupBy('teamID', 'appID'),
+  );
+
+  logger.info(
+    `Aggregated connection seconds from ${start.toISOString()} for ${
+      results.rows
+    } apps`,
+  );
+  return Promise.allSettled(
+    results.data.map(({teamID, appID, totalElapsed, totalPeriod}) =>
+      new Ledger(firestore).set(
+        teamID,
+        appID,
+        start,
+        new Map([
+          [CONNECTION_SECONDS, totalElapsed],
+          [ROOM_SECONDS, totalPeriod],
+        ]),
+      ),
+    ),
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -169,7 +169,7 @@
         "@inquirer/select": "^1.2.11",
         "@rocicorp/reflect": "0.38.202311130825+d3dbae",
         "esbuild": "^0.19.4",
-        "firebase-admin": "^11.10.1",
+        "mirror-server": "0.0.1",
         "pkg-up": "^4.0.0",
         "reflect-cli": "0.0.0",
         "semver": "^7.5.4",
@@ -693,7 +693,6 @@
       "hasInstallScript": true,
       "dependencies": {
         "@badrap/valita": "^0.3.0",
-        "@google-cloud/firestore": "^6.6.1",
         "@google-cloud/functions-framework": "^3.2.0",
         "@google-cloud/secret-manager": "^5.0.1",
         "cors": "^2.8.5",
@@ -57515,7 +57514,7 @@
         "@types/yargs": "^17.0.10",
         "cloudflare-api": "0.0.0",
         "esbuild": "^0.19.4",
-        "firebase-admin": "^11.10.1",
+        "mirror-server": "0.0.1",
         "mirror-workers": "0.0.0",
         "pkg-up": "^4.0.0",
         "reflect-cli": "0.0.0",
@@ -57783,7 +57782,6 @@
       "version": "file:mirror/mirror-server",
       "requires": {
         "@badrap/valita": "^0.3.0",
-        "@google-cloud/firestore": "^6.6.1",
         "@google-cloud/functions-framework": "^3.2.0",
         "@google-cloud/secret-manager": "^5.0.1",
         "@jest-mock/express": "^2.0.2",


### PR DESCRIPTION
Aggregates an hour's worth of connection seconds metrics for all apps (as described in [Mirror Billing](https://www.notion.so/replicache/Mirror-Billing-9ef6511dac994056b16046e519aa0cd8?pvs=4#90b0940d6cfc4235bb51339ef1754262)) every hour.

`metrics-aggregate` is a cloud scheduled function that runs on the 1st, 5th, and 30th minute of each hour to aggregate the previous hour's worth of metrics from Workers Analytics Engine, storing it in the Firestore metrics ledgers for downstream viewing / processing (a future `reflect usage` command and usage-based billing). The 1st and 5th minute aggregations are meant to catch all data points in the steady state; the 30th minute is to flag pathological delays in Workers Analytics Engine's data point ingestion.

A mirror-cli `backfill-metrics` command can be manually run to perform the same aggregation. This was used to backfill metrics prior to when the `metrics-aggregation` function was created, and can also be used to fix / re-aggregate metrics in case there were issues with the Cloud Function or with Workers Analytics Engine. (Note that the ledger supports redundant or amended updates). 