### PR TITLE
fix(mirror-server): handle fp imprecision by ignoring tiny deltas

### DIFF
--- a/mirror/mirror-server/src/metrics/ledger.test.ts
+++ b/mirror/mirror-server/src/metrics/ledger.test.ts
@@ -142,6 +142,50 @@ describe('metrics ledger', () => {
       },
     },
     {
+      name: 'ignore insignificant FP delta',
+      teamID: TEAM1,
+      appID: APP1,
+      hour: new Date(Date.UTC(2023, 0, 31, 23)),
+      metrics: [[CONNECTION_SECONDS, 10.2300000000001]],
+      expectUpdated: false,
+      expectedAppMonth: {
+        teamID: TEAM1,
+        appID: APP1,
+        yearMonth: 202301,
+        total: {cs: 10.23},
+        day: {
+          ['31']: {
+            total: {cs: 10.23},
+            hour: {['23']: {cs: 10.23}},
+          },
+        },
+      },
+      expectedTeamMonth: {
+        teamID: TEAM1,
+        appID: null,
+        yearMonth: 202301,
+        total: {cs: 10.23},
+        day: {
+          ['31']: {
+            total: {cs: 10.23},
+            hour: {['23']: {cs: 10.23}},
+          },
+        },
+      },
+      expectedAppTotal: {
+        teamID: TEAM1,
+        appID: APP1,
+        total: {cs: 10.23},
+        year: {['2023']: {cs: 10.23}},
+      },
+      expectedTeamTotal: {
+        teamID: TEAM1,
+        appID: null,
+        total: {cs: 10.23},
+        year: {['2023']: {cs: 10.23}},
+      },
+    },
+    {
       name: 'update different app, same team',
       teamID: TEAM1,
       appID: APP2,


### PR DESCRIPTION
This avoids updating (and flagging) metrics when the deltas are due to differences in FP precision when comparing values from Firestore with values from Workers Analytics.

```
{"severity":"INFO","message":"No metrics update for 7b4eqY3OWih/loxv5ldt/2023-11-14T23[cs,rs]"}
{"severity":"INFO","message":"Updating metrics 7b4eqY3OWih/loxvdsq5/2023-11-14T23[cs,rs] { rs: 458.692, cs: 673.7860000000001 } Map(2) { 'cs' => 673.786, 'rs' => 458.692 }"}
{"severity":"INFO","message":"No metrics update for 198SeL9eaaF/lopf2078/2023-11-14T23[cs,rs]"}
{"severity":"INFO","message":"No metrics update for 7b4eqY3OWih/loxv9i52/2023-11-14T23[cs,rs]"}
```