### PR TITLE
fix(mirror-server): reference the firebase-admin/firestore lib only

### DIFF
--- a/mirror/mirror-server/src/functions/app/create.function.test.ts
+++ b/mirror/mirror-server/src/functions/app/create.function.test.ts
@@ -1,8 +1,7 @@
-import {Timestamp} from '@google-cloud/firestore';
 import {afterEach, beforeEach, describe, expect, test} from '@jest/globals';
 import {initializeApp} from 'firebase-admin/app';
 import type {DecodedIdToken} from 'firebase-admin/auth';
-import {getFirestore} from 'firebase-admin/firestore';
+import {Timestamp, getFirestore} from 'firebase-admin/firestore';
 import {https} from 'firebase-functions/v2';
 import {HttpsError, type Request} from 'firebase-functions/v2/https';
 import {appPath} from 'mirror-schema/src/deployment.js';

--- a/mirror/mirror-server/src/functions/app/create.function.ts
+++ b/mirror/mirror-server/src/functions/app/create.function.ts
@@ -1,5 +1,5 @@
-import {FieldValue} from '@google-cloud/firestore';
 import type {Firestore, WithFieldValue} from 'firebase-admin/firestore';
+import {FieldValue} from 'firebase-admin/firestore';
 import {logger} from 'firebase-functions';
 import {HttpsError} from 'firebase-functions/v2/https';
 import {

--- a/mirror/mirror-server/src/functions/app/delete.function.ts
+++ b/mirror/mirror-server/src/functions/app/delete.function.ts
@@ -1,5 +1,4 @@
-import {Timestamp} from '@google-cloud/firestore';
-import {FieldValue, type Firestore} from 'firebase-admin/firestore';
+import {FieldValue, Timestamp, type Firestore} from 'firebase-admin/firestore';
 import {logger} from 'firebase-functions';
 import {
   deleteAppRequestSchema,

--- a/mirror/mirror-server/src/functions/app/tail.handler.test.ts
+++ b/mirror/mirror-server/src/functions/app/tail.handler.test.ts
@@ -1,7 +1,7 @@
-import type {Firestore} from '@google-cloud/firestore';
 import {getMockReq, getMockRes} from '@jest-mock/express';
 import {beforeEach, describe, expect, jest, test} from '@jest/globals';
 import type {Auth} from 'firebase-admin/auth';
+import type {Firestore} from 'firebase-admin/firestore';
 import type {https} from 'firebase-functions/v2';
 import {
   fakeFirestore,

--- a/mirror/mirror-server/src/functions/metrics/aggregate.function.ts
+++ b/mirror/mirror-server/src/functions/metrics/aggregate.function.ts
@@ -1,5 +1,5 @@
-import type {Firestore} from '@google-cloud/firestore';
 import {Analytics} from 'cloudflare-api/src/analytics.js';
+import type {Firestore} from 'firebase-admin/firestore';
 import {logger} from 'firebase-functions';
 import {onSchedule} from 'firebase-functions/v2/scheduler';
 import {

--- a/mirror/mirror-server/src/functions/metrics/backup.function.ts
+++ b/mirror/mirror-server/src/functions/metrics/backup.function.ts
@@ -1,5 +1,5 @@
-import type {Firestore} from '@google-cloud/firestore';
 import {Analytics} from 'cloudflare-api/src/analytics.js';
+import type {Firestore} from 'firebase-admin/firestore';
 import type {Storage} from 'firebase-admin/storage';
 import {logger} from 'firebase-functions';
 import {onSchedule} from 'firebase-functions/v2/scheduler';

--- a/mirror/mirror-server/src/functions/validators/auth.test.ts
+++ b/mirror/mirror-server/src/functions/validators/auth.test.ts
@@ -1,6 +1,6 @@
-import {Timestamp} from '@google-cloud/firestore';
 import {describe, expect, test} from '@jest/globals';
 import type {Firestore} from 'firebase-admin/firestore';
+import {Timestamp} from 'firebase-admin/firestore';
 import {https} from 'firebase-functions/v2';
 import {
   FunctionsErrorCode,

--- a/mirror/mirror-server/src/functions/vars/delete.function.ts
+++ b/mirror/mirror-server/src/functions/vars/delete.function.ts
@@ -1,5 +1,5 @@
-import {FieldValue} from '@google-cloud/firestore';
 import type {Firestore} from 'firebase-admin/firestore';
+import {FieldValue} from 'firebase-admin/firestore';
 import {
   deleteVarsRequestSchema,
   deleteVarsResponseSchema,

--- a/mirror/mirror-server/src/functions/vars/shared.ts
+++ b/mirror/mirror-server/src/functions/vars/shared.ts
@@ -1,4 +1,4 @@
-import type {Firestore, Timestamp} from '@google-cloud/firestore';
+import type {Firestore, Timestamp} from 'firebase-admin/firestore';
 import {logger} from 'firebase-functions';
 import {HttpsError} from 'firebase-functions/v2/https';
 import {

--- a/mirror/mirror-server/src/metrics/aggregate.ts
+++ b/mirror/mirror-server/src/metrics/aggregate.ts
@@ -1,5 +1,5 @@
-import type {Firestore} from '@google-cloud/firestore';
 import type {Analytics} from 'cloudflare-api/src/analytics.js';
+import type {Firestore} from 'firebase-admin/firestore';
 import {logger} from 'firebase-functions';
 import {runningConnectionSeconds} from 'mirror-schema/src/datasets.js';
 import {CONNECTION_SECONDS, ROOM_SECONDS} from 'mirror-schema/src/metrics.js';

--- a/mirror/mirror-server/src/test-helpers.ts
+++ b/mirror/mirror-server/src/test-helpers.ts
@@ -1,4 +1,4 @@
-import {Timestamp} from '@google-cloud/firestore';
+import {Timestamp} from 'firebase-admin/firestore';
 import {declaredParams} from 'firebase-functions/params';
 import type {Deployment} from 'mirror-schema/src/deployment.js';
 import assert from 'node:assert';


### PR DESCRIPTION
Always reference the `firebase-admin/firestore` lib instead of `@google-cloud/firestore` as the latter can result in referencing a different version in the mono repo.

![Screenshot 2023-11-16 at 10 03 38 AM](https://github.com/rocicorp/mono/assets/132324914/46699f73-956f-4777-ac9f-628039d2bd23)

Fixes #1240