### PR TITLE
feat(mirror): report the RoomID in ConnectionLifetimes data points

### DIFF
--- a/mirror/mirror-schema/src/datasets.ts
+++ b/mirror/mirror-schema/src/datasets.ts
@@ -21,6 +21,7 @@ export const connectionLifetimes = new Dataset(
   v.object({
     teamID: v.string(),
     appID: v.string(),
+    roomID: v.string(),
     startTime: v.number(),
     endTime: v.number(),
   }),

--- a/mirror/mirror-workers/src/connections-reporter/connections-reporter.test.ts
+++ b/mirror/mirror-workers/src/connections-reporter/connections-reporter.test.ts
@@ -11,7 +11,7 @@ import {
   CONNECTION_SECONDS_V1_CHANNEL_NAME,
 } from 'shared/src/events/connection-seconds.js';
 import type {Env} from './index.js';
-import reporter, {AUTH_DATA_HEADER_NAME} from './index.js';
+import reporter, {AUTH_DATA_HEADER_NAME, ROOM_ID_HEADER_NAME} from './index.js';
 
 describe('connections reporter', () => {
   const runningConnectionSecondsDS = {
@@ -292,6 +292,7 @@ describe('connections reporter', () => {
             request: {
               headers: {
                 [AUTH_DATA_HEADER_NAME]: 'REDACTED',
+                [ROOM_ID_HEADER_NAME]: 'my-room-yo',
               },
             },
           },
@@ -351,6 +352,7 @@ describe('connections reporter', () => {
             request: {
               headers: {
                 [AUTH_DATA_HEADER_NAME]: 'REDACTED',
+                [ROOM_ID_HEADER_NAME]: 'yo-my-room',
               },
             },
           },
@@ -370,8 +372,8 @@ describe('connections reporter', () => {
     expect(
       connectionLifetimesDS.writeDataPoint.mock.calls.map(call => call[0]),
     ).toEqual([
-      {blobs: ['baz', 'foo'], doubles: [98765, TAIL_EVENT_TIME]},
-      {blobs: ['faz', 'boo'], doubles: [87328, TAIL_EVENT_TIME]},
+      {blobs: ['baz', 'foo', 'my-room-yo'], doubles: [98765, TAIL_EVENT_TIME]},
+      {blobs: ['faz', 'boo', 'yo-my-room'], doubles: [87328, TAIL_EVENT_TIME]},
     ]);
   });
 });

--- a/mirror/mirror-workers/src/connections-reporter/index.ts
+++ b/mirror/mirror-workers/src/connections-reporter/index.ts
@@ -95,6 +95,7 @@ function reportRunningConnectionElapsedSeconds(
 }
 
 export const AUTH_DATA_HEADER_NAME = 'x-reflect-auth-data';
+export const ROOM_ID_HEADER_NAME = 'x-reflect-room-id';
 
 function reportConnectionLifetimes(
   events: TailItem[],
@@ -111,6 +112,7 @@ function reportConnectionLifetimes(
     if (!authData) {
       continue;
     }
+    const roomID = fetch?.request?.headers?.[ROOM_ID_HEADER_NAME] ?? '';
     let tags: ScriptTags;
     try {
       tags = parseScriptTags(scriptTags ?? []);
@@ -123,7 +125,7 @@ function reportConnectionLifetimes(
       continue;
     }
     connectionLifetimesDS.writeDataPoint(
-      connectionLifetimes.dataPoint({...tags, startTime, endTime}),
+      connectionLifetimes.dataPoint({...tags, roomID, startTime, endTime}),
     );
     console.info(
       `Reported connection lifetime for ${tags.appName}.${tags.teamLabel} (${


### PR DESCRIPTION
Although we don't use the `ConnectionLifetimes` data because of the [double-counting issue](https://www.notion.so/replicache/Usage-Tracking-Methodologies-Limitations-e94b29188b024038bfbcc183a6d88189), we may use the information at some point, and it doesn't hurt to attach the `roomID` to each data point as we do for `RunningConnectionSeconds` in #1239.