### PR TITLE
feat(reflect-cli): `reflect usage` command

### DIFF
--- a/mirror/mirror-schema/src/external/app.ts
+++ b/mirror/mirror-schema/src/external/app.ts
@@ -1,15 +1,17 @@
 import type * as v from 'shared/src/valita.js';
+import {appSchema} from '../app.js';
 import {firestoreDataConverter} from '../converter.js';
 import {deploymentViewSchema} from './deployment.js';
-import {appSchema} from '../app.js';
 
 // The slice of App fields read by the cli.
 // Having the cli use a constrained schema makes it easier to
 // refactor/rewrite other parts of the schema.
 // Pick more fields as necessary.
-const appViewSchema = appSchema.pick('name', 'runningDeployment').extend({
-  runningDeployment: deploymentViewSchema.optional(),
-});
+const appViewSchema = appSchema
+  .pick('name', 'runningDeployment', 'teamID')
+  .extend({
+    runningDeployment: deploymentViewSchema.optional(),
+  });
 
 export type AppView = v.Infer<typeof appViewSchema>;
 

--- a/mirror/mirror-schema/src/external/metrics.ts
+++ b/mirror/mirror-schema/src/external/metrics.ts
@@ -1,0 +1,26 @@
+import type * as v from 'shared/src/valita.js';
+import {firestoreDataConverter} from '../converter.js';
+import {monthMetricsSchema, totalMetricsSchema} from '../metrics.js';
+export {
+  monthMetricsPath,
+  splitDate,
+  totalMetricsPath,
+  type DayOfMonth,
+  type Hour,
+  type MetricsNode,
+  type Month,
+} from '../metrics.js';
+
+const monthMetricsViewSchema = monthMetricsSchema.pick('total', 'day');
+
+export type MonthMetricsView = v.Infer<typeof monthMetricsViewSchema>;
+
+export const monthMetricsViewDataConverter = firestoreDataConverter(
+  monthMetricsViewSchema,
+);
+
+const totalMetricsViewSchema = totalMetricsSchema.pick('year');
+
+export const totalMetricsViewDataConverter = firestoreDataConverter(
+  totalMetricsViewSchema,
+);

--- a/mirror/reflect-cli/package.json
+++ b/mirror/reflect-cli/package.json
@@ -32,6 +32,7 @@
     "@types/semver": "^7.5.1",
     "@types/validate-npm-package-name": "^4.0.0",
     "@types/yargs": "^17.0.10",
+    "chartscii": "^1.3.2",
     "compare-utf8": "^0.1.1",
     "devtools-protocol": "^0.0.1208070",
     "firebase": "9.23.0",

--- a/mirror/reflect-cli/src/colors.ts
+++ b/mirror/reflect-cli/src/colors.ts
@@ -1,0 +1,14 @@
+import color from 'picocolors';
+import style from 'styl3';
+
+const lush = style({theme: 'lush'});
+
+function bgPink(val: string) {
+  return lush.invert(lush.pink(val));
+}
+
+export default {
+  ...color,
+  pink: lush.pink,
+  bgPink,
+};

--- a/mirror/reflect-cli/src/index.ts
+++ b/mirror/reflect-cli/src/index.ts
@@ -13,6 +13,7 @@ import {loginHandler} from './login.js';
 import {publishHandler, publishOptions} from './publish.js';
 import {statusHandler} from './status.js';
 import {tailHandler, tailOptions} from './tail/index.js';
+import {usageHandler, usageOptions} from './usage.js';
 import {deleteVarsHandler, deleteVarsOptions} from './vars/delete.js';
 import {listVarsHandler, listVarsOptions} from './vars/list.js';
 import {setVarsHandler, setVarsOptions} from './vars/set.js';
@@ -36,7 +37,6 @@ async function main(argv: string[]): Promise<void> {
 function createCLIParser(argv: string[]) {
   const reflectCLI = createCLIParserBase(argv);
 
-  // create
   reflectCLI.command(
     'create <name>',
     '🛠  Create a basic Reflect project',
@@ -44,7 +44,6 @@ function createCLIParser(argv: string[]) {
     handleWith(createHandler).andCleanup(),
   );
 
-  // init
   reflectCLI.command(
     ['init', 'lfg'],
     '🚀 Add Reflect and basic mutators to an existing project',
@@ -52,15 +51,13 @@ function createCLIParser(argv: string[]) {
     handleWith(initHandler).andCleanup(),
   );
 
-  // dev
   reflectCLI.command(
     'dev',
-    '👷 Start a local dev server for your Reflect project',
+    '💻 Start a local dev server for your Reflect project',
     devOptions,
     handleWith(devHandler).andCleanup(),
   );
 
-  // login
   reflectCLI.command(
     'login',
     '🔓 Login to Reflect',
@@ -74,15 +71,21 @@ function createCLIParser(argv: string[]) {
     }).andCleanup(),
   );
 
-  // publish
   reflectCLI.command(
     'publish',
-    '🆙 Publish your Reflect project',
+    '🌏 Publish your Reflect project',
     publishOptions,
     handleWith(publishHandler).andCleanup(),
   );
 
-  // tail
+  reflectCLI.command(
+    'status',
+    '💡 Show the status of current deployed app',
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    () => {},
+    handleWith(statusHandler).andCleanup(),
+  );
+
   reflectCLI.command(
     'tail',
     '🦚 Start a log tailing session',
@@ -90,8 +93,7 @@ function createCLIParser(argv: string[]) {
     handleWith(tailHandler).andCleanup(),
   );
 
-  // vars
-  reflectCLI.command('env', '🟰  Manage environment variables', yargs => {
+  reflectCLI.command('env', '🎛️  Manage environment variables', yargs => {
     yargs
       .option('dev', {
         describe: 'Manage local variables for `npx reflect dev`',
@@ -119,20 +121,18 @@ function createCLIParser(argv: string[]) {
       .demandCommand(1, 'Available commands:\n');
   });
 
-  // delete
+  reflectCLI.command(
+    'usage',
+    '📊 Show usage summary (connection time), with monthly, daily, or hourly breakdowns',
+    usageOptions,
+    handleWith(usageHandler).andCleanup(),
+  );
+
   reflectCLI.command(
     'delete',
     '🗑️  Delete one or more Apps and their associated data. If no flags are specified, defaults to the App of the current directory.',
     deleteOptions,
     handleWith(deleteHandler).andCleanup(),
-  );
-
-  reflectCLI.command(
-    'status',
-    '📊 Show the status of current deployed app',
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    () => {},
-    handleWith(statusHandler).andCleanup(),
   );
 
   return reflectCLI;

--- a/mirror/reflect-cli/src/usage.test.ts
+++ b/mirror/reflect-cli/src/usage.test.ts
@@ -1,0 +1,148 @@
+import {describe, expect, test} from '@jest/globals';
+import {daysInMonth, durationString} from './usage.js';
+
+describe('duration string', () => {
+  type Case = {
+    name: string;
+    duration: number;
+    result: string;
+  };
+  const cases: Case[] = [
+    {
+      name: 'less than 10 seconds',
+      duration: 8.9238,
+      result: '0:09',
+    },
+    {
+      name: 'more than 10 seconds',
+      duration: 18.9238,
+      result: '0:19',
+    },
+    {
+      name: 'more than one minute, seconds padding',
+      duration: 60 + 8.9238,
+      result: '1:09',
+    },
+    {
+      name: 'more than one minute, no seconds padding',
+      duration: 60 + 18.9238,
+      result: '1:19',
+    },
+    {
+      name: 'more than 10 minutes, seconds padding',
+      duration: 600 + 8.9238,
+      result: '10:09',
+    },
+    {
+      name: 'more than 10 minutes, no seconds padding',
+      duration: 600 + 18.9238,
+      result: '10:19',
+    },
+    {
+      name: 'more than 1 hour, no minutes, seconds padding',
+      duration: 3600 + 8.9238,
+      result: '1:00:09',
+    },
+    {
+      name: 'more than 1 hour, minutes, seconds padding',
+      duration: 3600 + 60 + 8.9238,
+      result: '1:01:09',
+    },
+    {
+      name: 'more than 1 hour, no minutes or seconds padding',
+      duration: 3600 + 600 + 18.9238,
+      result: '1:10:19',
+    },
+    {
+      name: 'more than 24 hours, no minute or seconds padding',
+      duration: 25 * 3600 + 600 + 18.9238,
+      result: '25:10:19',
+    },
+  ];
+
+  for (const c of cases) {
+    test(c.name, () => {
+      expect(durationString(c.duration)).toBe(c.result);
+    });
+  }
+});
+
+describe('days in month', () => {
+  type Case = {
+    name: string;
+    date: number;
+    days: number;
+  };
+
+  const cases: Case[] = [
+    {
+      name: 'Jan',
+      date: Date.UTC(2023, 0),
+      days: 31,
+    },
+    {
+      name: 'Feb',
+      date: Date.UTC(2023, 1),
+      days: 28,
+    },
+    {
+      name: 'Mar',
+      date: Date.UTC(2023, 2),
+      days: 31,
+    },
+    {
+      name: 'Apr',
+      date: Date.UTC(2023, 3),
+      days: 30,
+    },
+    {
+      name: 'May',
+      date: Date.UTC(2023, 4),
+      days: 31,
+    },
+    {
+      name: 'Jun',
+      date: Date.UTC(2023, 5),
+      days: 30,
+    },
+    {
+      name: 'Jul',
+      date: Date.UTC(2023, 6),
+      days: 31,
+    },
+    {
+      name: 'Aug',
+      date: Date.UTC(2023, 7),
+      days: 31,
+    },
+    {
+      name: 'Sep',
+      date: Date.UTC(2023, 8),
+      days: 30,
+    },
+    {
+      name: 'Oct',
+      date: Date.UTC(2023, 9),
+      days: 31,
+    },
+    {
+      name: 'Nov',
+      date: Date.UTC(2023, 10),
+      days: 30,
+    },
+    {
+      name: 'Dec',
+      date: Date.UTC(2023, 11),
+      days: 31,
+    },
+    {
+      name: 'Leap Year Feb',
+      date: Date.UTC(2024, 1),
+      days: 29,
+    },
+  ];
+
+  for (const c of cases) {
+    expect(daysInMonth(new Date(c.date))).toBe(c.days);
+  }
+});

--- a/mirror/reflect-cli/src/usage.ts
+++ b/mirror/reflect-cli/src/usage.ts
@@ -1,0 +1,210 @@
+import Chartscii from 'chartscii';
+import {doc, getDoc, getFirestore} from 'firebase/firestore';
+import {appPath, appViewDataConverter} from 'mirror-schema/src/external/app.js';
+import {
+  monthMetricsPath,
+  monthMetricsViewDataConverter,
+  splitDate,
+  totalMetricsPath,
+  totalMetricsViewDataConverter,
+  type DayOfMonth,
+  type Hour,
+  type MetricsNode,
+  type Month,
+} from 'mirror-schema/src/external/metrics.js';
+import {must} from 'shared/src/must.js';
+import {readAppConfig} from './app-config.js';
+import {authenticate} from './auth-config.js';
+import color from './colors.js';
+import type {CommonYargsArgv, YargvToInterface} from './yarg-types.js';
+
+export function usageOptions(yargs: CommonYargsArgv) {
+  return yargs
+    .option('year', {
+      desc: 'Show summary of a given year, with monthly totals. Defaults to the current year.',
+      type: 'number',
+    })
+    .option('month', {
+      desc: 'Show summary of a given month, with daily totals.',
+      type: 'number',
+      choices: Array.from({length: 12}, (_, i) => i + 1),
+    })
+    .option('day', {
+      describe: 'Show summary of a given day of the month, with hourly totals.',
+      choices: Array.from({length: 31}, (_, i) => i + 1),
+      type: 'number',
+    })
+    .option('today', {
+      describe: 'Equivalent to --month=<current-month> --day=<current-day>.',
+      type: 'boolean',
+      conflicts: ['year', 'month', 'day'],
+    });
+}
+
+type UsageHandlerArgs = YargvToInterface<ReturnType<typeof usageOptions>>;
+
+export async function usageHandler(yargs: UsageHandlerArgs): Promise<void> {
+  await authenticate(yargs);
+  const firestore = getFirestore();
+  const config = readAppConfig();
+  const appID = config?.apps?.default?.appID;
+  if (!appID) {
+    console.info('Publish your app with `npx reflect publish` to view usage');
+    return;
+  }
+
+  const appDoc = await getDoc(
+    doc(firestore, appPath(appID)).withConverter(appViewDataConverter),
+  );
+  const {teamID} = must(appDoc.data());
+
+  const {year, month, day, today} = yargs;
+  const dayView = today || day !== undefined;
+  const monthView = !dayView && month !== undefined;
+  const yearView = !(dayView || monthView);
+
+  const now = new Date();
+  const date = new Date(
+    year ?? now.getUTCFullYear(),
+    (month ?? now.getUTCMonth() + 1) - 1,
+    day ?? now.getUTCDate(),
+  );
+  const [yyyy, mm, dayOfMonth] = splitDate(date);
+
+  let table: TableData;
+  if (yearView) {
+    const totalMetrics = (
+      await getDoc(
+        doc(firestore, totalMetricsPath(teamID, appID)).withConverter(
+          totalMetricsViewDataConverter,
+        ),
+      )
+    ).data();
+    const yearMetrics = totalMetrics?.year?.[yyyy];
+    table = tableData(yearMetrics, yearMetrics?.month, monthRows(date));
+  } else {
+    const monthMetrics = (
+      await getDoc(
+        doc(firestore, monthMetricsPath(yyyy, mm, teamID, appID)).withConverter(
+          monthMetricsViewDataConverter,
+        ),
+      )
+    ).data();
+    if (monthView) {
+      table = tableData(monthMetrics, monthMetrics?.day, dayRows(date));
+    } else {
+      const dayMetrics = monthMetrics?.day?.[dayOfMonth];
+      table = tableData(dayMetrics, dayMetrics?.hour, hourRows());
+    }
+  }
+
+  const chart = new Chartscii(
+    table.rows,
+    {
+      label: chartTitle(date, {yearView, monthView, dayView}, table.total),
+      width: 90,
+      theme: 'lush',
+      colorLabels: true,
+      reverse: true,
+    } as Chartscii.Options, // chartscii's index.d.ts is not up to date with index.js
+  );
+
+  // Add breakdown durations to the end of the bars.
+  const lines = chart.create().split('\n');
+  let maxDurLen = 0;
+  table.rows.forEach((row, i) => {
+    if (row.value > 0) {
+      const dur = durationString(row.value);
+      lines[lines.length - i - 2] += ` ${dur}`;
+      maxDurLen = Math.max(maxDurLen, dur.length + 1);
+    }
+  });
+  // Extend the x-axis to cover the added duration strings.
+  lines[lines.length - 1] += '═'.repeat(maxDurLen);
+
+  // Output!
+  console.log();
+  console.log(lines.join('\n'));
+}
+
+function chartTitle(
+  date: Date,
+  view: {yearView: boolean; monthView: boolean; dayView: boolean},
+  total: MetricsNode | undefined,
+): string {
+  const {yearView, dayView} = view;
+  const summaryPeriod = new Intl.DateTimeFormat(undefined, {
+    year: 'numeric',
+    month: yearView ? undefined : 'long',
+    day: dayView ? 'numeric' : undefined,
+  }).format(date);
+  const duration = durationString(total?.total?.cs ?? 0);
+  return `Connection time ${
+    dayView ? 'on' : 'in'
+  } ${summaryPeriod} (UTC): ${color.pink(color.bold(duration))}`;
+}
+
+type TableData = {
+  total: MetricsNode | undefined;
+  rows: {label: string; value: number; color: string}[];
+};
+
+function tableData<RowKey extends string>(
+  total: MetricsNode | undefined,
+  breakdown: {[key in RowKey]?: MetricsNode | undefined} | undefined,
+  rowsKeys: RowKeys<RowKey>,
+): TableData {
+  return {
+    total,
+    rows: rowsKeys.all.map(key => ({
+      label: rowsKeys.label(key),
+      value: breakdown?.[key]?.total?.cs ?? 0,
+      color: 'pink',
+    })),
+  };
+}
+
+type RowKeys<T extends string> = {
+  all: T[];
+  label: (key: T) => string;
+};
+
+function monthRows(date: Date): RowKeys<Month> {
+  const shortMonth = new Intl.DateTimeFormat(undefined, {month: 'short'});
+  const year = date.getUTCFullYear();
+  return {
+    all: Array.from({length: 12}, (_, i) => (i + 1).toString()) as Month[],
+    label: month => shortMonth.format(new Date(year, parseInt(month) - 1)),
+  };
+}
+
+function hourRows(): RowKeys<Hour> {
+  return {
+    all: Array.from({length: 24}, (_, i) => i.toString()) as Hour[],
+    label: hour => `${hour.length < 2 ? '0' : ''}${hour}:00`,
+  };
+}
+
+function dayRows(date: Date): RowKeys<DayOfMonth> {
+  return {
+    all: Array.from({length: daysInMonth(date)}, (_, i) =>
+      (i + 1).toString(),
+    ) as DayOfMonth[],
+    label: day => day,
+  };
+}
+
+export function daysInMonth(date: Date) {
+  // Get day 0 of the next month, which is the number of days in this month.
+  return new Date(date.getUTCFullYear(), date.getUTCMonth() + 1, 0).getDate();
+}
+
+export function durationString(dur: number): string {
+  const seconds = Math.round(dur % 60);
+  const minutes = Math.floor((dur / 60) % 60);
+  const hours = Math.floor(dur / 3600);
+  const hh = hours > 0 ? `${hours}:` : '';
+  const mm = hours === 0 || minutes >= 10 ? `${minutes}:` : `0${minutes}:`;
+  const ss = seconds >= 10 ? `${seconds}` : `0${seconds}`;
+  return `${hh}${mm}${ss}`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1639,6 +1639,7 @@
         "@types/semver": "^7.5.1",
         "@types/validate-npm-package-name": "^4.0.0",
         "@types/yargs": "^17.0.10",
+        "chartscii": "^1.3.2",
         "compare-utf8": "^0.1.1",
         "devtools-protocol": "^0.0.1208070",
         "firebase": "9.23.0",
@@ -15551,6 +15552,15 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
+    },
+    "node_modules/chartscii": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/chartscii/-/chartscii-1.3.2.tgz",
+      "integrity": "sha512-jMQRRTQwTnR1QpzqO4rt0FZ8oEpnvKyjBuknXD1Q5wT94yaCBdAaLUEev3guY88mFUE9WCWksMXEDAO8Oed4sw==",
+      "dev": true,
+      "dependencies": {
+        "styl3": "^1.2.4"
+      }
     },
     "node_modules/check-error": {
       "version": "2.0.0",
@@ -32384,6 +32394,12 @@
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw=="
     },
+    "node_modules/styl3": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/styl3/-/styl3-1.4.0.tgz",
+      "integrity": "sha512-RdUDaCy9POYkcAunRcGr+pu1eFcoE4kOQCEpm6Gd0bmTZUXSPzK1dgQOgrNOM9JdAb2/GY2gEUNJN8Hy+mr+8Q==",
+      "dev": true
+    },
     "node_modules/style-to-object": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.1.tgz",
@@ -35865,6 +35881,7 @@
         "@rocicorp/eslint-config": "^0.5.1",
         "@rocicorp/prettier-config": "^0.2.0",
         "@types/node": "^18.16.0",
+        "chartscii": "^1.3.2",
         "compare-utf8": "^0.1.1",
         "devtools-protocol": "^0.0.1208070",
         "firebase": "9.23.0",
@@ -43367,6 +43384,7 @@
         "@rocicorp/prettier-config": "^0.2.0",
         "@rocicorp/resolver": "^1.0.1",
         "@types/node": "^18.16.0",
+        "chartscii": "^1.3.2",
         "compare-utf8": "^0.1.1",
         "devtools-protocol": "^0.0.1208070",
         "esbuild": "^0.19.4",
@@ -48290,6 +48308,15 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
+    },
+    "chartscii": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/chartscii/-/chartscii-1.3.2.tgz",
+      "integrity": "sha512-jMQRRTQwTnR1QpzqO4rt0FZ8oEpnvKyjBuknXD1Q5wT94yaCBdAaLUEev3guY88mFUE9WCWksMXEDAO8Oed4sw==",
+      "dev": true,
+      "requires": {
+        "styl3": "^1.2.4"
+      }
     },
     "check-error": {
       "version": "2.0.0",
@@ -60368,6 +60395,7 @@
         "@types/semver": "^7.5.1",
         "@types/validate-npm-package-name": "^4.0.0",
         "@types/yargs": "^17.0.10",
+        "chartscii": "^1.3.2",
         "compare-utf8": "^0.1.1",
         "devtools-protocol": "^0.0.1208070",
         "esbuild": "^0.19.4",
@@ -62979,6 +63007,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw=="
+    },
+    "styl3": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/styl3/-/styl3-1.4.0.tgz",
+      "integrity": "sha512-RdUDaCy9POYkcAunRcGr+pu1eFcoE4kOQCEpm6Gd0bmTZUXSPzK1dgQOgrNOM9JdAb2/GY2gEUNJN8Hy+mr+8Q==",
+      "dev": true
     },
     "style-to-object": {
       "version": "0.4.1",

--- a/packages/reflect/package.json
+++ b/packages/reflect/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "compare-utf8": "^0.1.1",
+    "chartscii": "^1.3.2",
     "nanoid": "^4.0.2",
     "open": "^9.1.0",
     "picocolors": "^1.0.0",


### PR DESCRIPTION
`reflect usage` command displays bar graphs of connection times for various time periods. 

By default, displays a summary for the current year:

![Screenshot 2023-11-17 at 1 50 42 PM](https://github.com/rocicorp/mono/assets/132324914/ab7fc5b4-f0de-4df9-803f-cb7594c76f6f)

And also supports a month summary:

![Screenshot 2023-11-17 at 1 51 04 PM](https://github.com/rocicorp/mono/assets/132324914/0fa8e752-f9f1-438d-aac0-e2bac9fe478b)

and day summary:

![Screenshot 2023-11-17 at 1 51 24 PM](https://github.com/rocicorp/mono/assets/132324914/7abdc28a-7373-4327-86c6-1b3c3c57448c)

Reordered and refreshed commands and icons for the help message:

![Screenshot 2023-11-17 at 1 55 21 PM](https://github.com/rocicorp/mono/assets/132324914/aba2e785-a4da-41c5-bf80-8730ae7f1659)
