### PR TITLE
chore(mirror-server): restrict firestore imports in mirror-server

### DIFF
--- a/mirror/mirror-server/package.json
+++ b/mirror/mirror-server/package.json
@@ -70,7 +70,22 @@
     "out"
   ],
   "eslintConfig": {
-    "extends": "@rocicorp/eslint-config"
+    "extends": "@rocicorp/eslint-config",
+    "rules": {
+      "no-restricted-imports": [
+        "error",
+        {
+          "patterns": [
+            {
+              "group": [
+                "@google-cloud/firestore"
+              ],
+              "message": "Use `firebase-admin/firestore` instead"
+            }
+          ]
+        }
+      ]
+    }
   },
   "prettier": "@rocicorp/prettier-config",
   "type": "module"


### PR DESCRIPTION
Ensures that we import from `firebase-admin/firestore` instead of `@google-cloud/firestore` in order to avoid the cross-package issue detailed in #1240

![Screenshot 2023-11-18 at 11 01 21 AM](https://github.com/rocicorp/mono/assets/132324914/8f70d948-5589-4057-8516-d839e60bc74f)
