### PR TITLE
fix(reflect-server): fix period calculation to be usable as room-seconds

### DIFF
--- a/packages/reflect-server/src/events/connection-lifetimes.test.ts
+++ b/packages/reflect-server/src/events/connection-lifetimes.test.ts
@@ -1,0 +1,39 @@
+import {describe, expect, jest, test} from '@jest/globals';
+import type {AlarmScheduler} from '../server/alarms.js';
+import {ConnectionLifetimeReporter} from './connection-lifetimes.js';
+
+describe('connection-lifetimes', () => {
+  const scheduler = {
+    setTimeout: jest.fn().mockImplementation(() => 123),
+  };
+
+  function newReporter() {
+    const reporter = new ConnectionLifetimeReporter(
+      scheduler as unknown as AlarmScheduler,
+    );
+    return reporter;
+  }
+
+  test('timeout scheduling', () => {
+    const reporter = newReporter();
+    expect(scheduler.setTimeout).not.toBeCalled;
+
+    void reporter.onConnectionCountChange(2);
+    expect(scheduler.setTimeout).not.toBeCalled;
+
+    reporter.onConnectionCountChange(3);
+    expect(scheduler.setTimeout).not.toBeCalled;
+
+    reporter.onConnectionCountChange(1);
+    expect(scheduler.setTimeout).toBeCalledTimes(1);
+
+    reporter.onConnectionCountChange(2);
+    expect(scheduler.setTimeout).toBeCalledTimes(1);
+
+    reporter.onConnectionCountChange(2);
+    expect(scheduler.setTimeout).toBeCalledTimes(1);
+
+    reporter.onConnectionCountChange(0);
+    expect(scheduler.setTimeout).toBeCalledTimes(2);
+  });
+});

--- a/packages/reflect-server/src/events/connection-lifetimes.ts
+++ b/packages/reflect-server/src/events/connection-lifetimes.ts
@@ -1,0 +1,29 @@
+import type {AlarmScheduler} from '../server/alarms.js';
+import type {ConnectionCountTracker} from '../types/client-state.js';
+
+export const CONNECTION_CLOSED_FLUSH_INTERVAL_MS = 20 * 1000;
+
+export class ConnectionLifetimeReporter implements ConnectionCountTracker {
+  readonly #scheduler: AlarmScheduler;
+  #currentCount: number = 0;
+
+  constructor(scheduler: AlarmScheduler) {
+    this.#scheduler = scheduler;
+  }
+
+  onConnectionCountChange(currentCount: number): void {
+    const prevCount = this.#currentCount;
+    this.#currentCount = currentCount;
+
+    // The sole purpose of this class is to schedule a TailEvent (via an Alarm)
+    // after a connection closes. This prevents the FetchEvents corresponding
+    // to the closed connection from being buffered, since that delays the time
+    // at which our tail worker receives the FetchEvents and results in
+    // overcounting the lifetime of the connection.
+    if (this.#currentCount < prevCount) {
+      this.#scheduler.setTimeout(lc => {
+        lc.info?.('Empty Alarm to flush FetchEvent of closed connection');
+      }, CONNECTION_CLOSED_FLUSH_INTERVAL_MS);
+    }
+  }
+}

--- a/packages/reflect-server/src/server/room-do.ts
+++ b/packages/reflect-server/src/server/room-do.ts
@@ -8,6 +8,7 @@ import type {Env, MutatorDefs} from 'reflect-shared';
 import {version} from 'reflect-shared';
 import {BufferSizer} from 'shared/src/buffer-sizer.js';
 import * as valita from 'shared/src/valita.js';
+import {ConnectionLifetimeReporter} from '../events/connection-lifetimes.js';
 import {ConnectionSecondsReporter} from '../events/connection-seconds.js';
 import type {MutatorMap} from '../process/process-mutation.js';
 import {processPending} from '../process/process-pending.js';
@@ -112,6 +113,7 @@ export class BaseRoomDO<MD extends MutatorDefs> implements DurableObject {
 
   readonly #alarm: AlarmManager;
   readonly #connectionSecondsReporter: ConnectionSecondsReporter;
+  readonly #connectionLifetimeReporter: ConnectionLifetimeReporter;
   readonly #env: Env;
 
   constructor(options: RoomDOOptions<MD>) {
@@ -140,9 +142,13 @@ export class BaseRoomDO<MD extends MutatorDefs> implements DurableObject {
     this.#connectionSecondsReporter = new ConnectionSecondsReporter(
       this.#alarm.scheduler,
     );
+    this.#connectionLifetimeReporter = new ConnectionLifetimeReporter(
+      this.#alarm.scheduler,
+    );
     this.#env = env;
     this.#clients = new ConnectionCountTrackingClientMap(
       this.#connectionSecondsReporter,
+      this.#connectionLifetimeReporter,
     );
 
     this.#initRoutes();

--- a/packages/reflect-server/src/types/client-state.test.ts
+++ b/packages/reflect-server/src/types/client-state.test.ts
@@ -15,13 +15,16 @@ describe('client count tracking map', () => {
   const state1 = {} as ClientState;
   const state2 = {} as ClientState;
   const state3 = {} as ClientState;
-  const tracker = {
+  const tracker1 = {
+    onConnectionCountChange: jest.fn(),
+  };
+  const tracker2 = {
     onConnectionCountChange: jest.fn(),
   };
   let map: ConnectionCountTrackingClientMap;
 
   beforeEach(() => {
-    map = new ConnectionCountTrackingClientMap(tracker);
+    map = new ConnectionCountTrackingClientMap(tracker1, tracker2);
   });
 
   afterEach(() => {
@@ -29,68 +32,90 @@ describe('client count tracking map', () => {
   });
 
   test('put', () => {
-    expect(tracker.onConnectionCountChange).not.toBeCalled;
+    expect(tracker1.onConnectionCountChange).not.toBeCalled;
+    expect(tracker2.onConnectionCountChange).not.toBeCalled;
 
     map.set('foo', state1);
 
-    expect(tracker.onConnectionCountChange).toHaveBeenCalledTimes(1);
-    expect(tracker.onConnectionCountChange.mock.lastCall?.[0]).toBe(1);
+    expect(tracker1.onConnectionCountChange).toHaveBeenCalledTimes(1);
+    expect(tracker1.onConnectionCountChange.mock.lastCall?.[0]).toBe(1);
+    expect(tracker2.onConnectionCountChange).toHaveBeenCalledTimes(1);
+    expect(tracker2.onConnectionCountChange.mock.lastCall?.[0]).toBe(1);
 
     // Overwrites existing key. Final count should be the same.
     map.set('foo', state2);
 
-    expect(tracker.onConnectionCountChange).toHaveBeenCalledTimes(2);
-    expect(tracker.onConnectionCountChange.mock.lastCall?.[0]).toBe(1);
+    expect(tracker1.onConnectionCountChange).toHaveBeenCalledTimes(2);
+    expect(tracker1.onConnectionCountChange.mock.lastCall?.[0]).toBe(1);
+    expect(tracker2.onConnectionCountChange).toHaveBeenCalledTimes(2);
+    expect(tracker2.onConnectionCountChange.mock.lastCall?.[0]).toBe(1);
 
     map.set('bar', state3);
 
-    expect(tracker.onConnectionCountChange).toHaveBeenCalledTimes(3);
-    expect(tracker.onConnectionCountChange.mock.lastCall?.[0]).toBe(2);
+    expect(tracker1.onConnectionCountChange).toHaveBeenCalledTimes(3);
+    expect(tracker1.onConnectionCountChange.mock.lastCall?.[0]).toBe(2);
+    expect(tracker2.onConnectionCountChange).toHaveBeenCalledTimes(3);
+    expect(tracker2.onConnectionCountChange.mock.lastCall?.[0]).toBe(2);
   });
 
   test('delete', () => {
-    expect(tracker.onConnectionCountChange).not.toBeCalled;
+    expect(tracker1.onConnectionCountChange).not.toBeCalled;
+    expect(tracker2.onConnectionCountChange).not.toBeCalled;
 
     map.set('foo', state1);
     map.set('bar', state2);
     map.set('baz', state3);
 
-    expect(tracker.onConnectionCountChange).toHaveBeenCalledTimes(3);
-    expect(tracker.onConnectionCountChange.mock.lastCall?.[0]).toBe(3);
+    expect(tracker1.onConnectionCountChange).toHaveBeenCalledTimes(3);
+    expect(tracker1.onConnectionCountChange.mock.lastCall?.[0]).toBe(3);
+    expect(tracker2.onConnectionCountChange).toHaveBeenCalledTimes(3);
+    expect(tracker2.onConnectionCountChange.mock.lastCall?.[0]).toBe(3);
 
     expect(map.delete('foo')).toBe(true);
 
-    expect(tracker.onConnectionCountChange).toHaveBeenCalledTimes(4);
-    expect(tracker.onConnectionCountChange.mock.lastCall?.[0]).toBe(2);
+    expect(tracker1.onConnectionCountChange).toHaveBeenCalledTimes(4);
+    expect(tracker1.onConnectionCountChange.mock.lastCall?.[0]).toBe(2);
+    expect(tracker2.onConnectionCountChange).toHaveBeenCalledTimes(4);
+    expect(tracker2.onConnectionCountChange.mock.lastCall?.[0]).toBe(2);
 
     expect(map.delete('foo')).toBe(false);
 
-    expect(tracker.onConnectionCountChange).toHaveBeenCalledTimes(4);
+    expect(tracker1.onConnectionCountChange).toHaveBeenCalledTimes(4);
+    expect(tracker2.onConnectionCountChange).toHaveBeenCalledTimes(4);
 
     expect(map.delete('bar')).toBe(true);
 
-    expect(tracker.onConnectionCountChange).toHaveBeenCalledTimes(5);
-    expect(tracker.onConnectionCountChange.mock.lastCall?.[0]).toBe(1);
+    expect(tracker1.onConnectionCountChange).toHaveBeenCalledTimes(5);
+    expect(tracker1.onConnectionCountChange.mock.lastCall?.[0]).toBe(1);
+    expect(tracker2.onConnectionCountChange).toHaveBeenCalledTimes(5);
+    expect(tracker2.onConnectionCountChange.mock.lastCall?.[0]).toBe(1);
 
     expect(map.delete('baz')).toBe(true);
 
-    expect(tracker.onConnectionCountChange).toHaveBeenCalledTimes(6);
-    expect(tracker.onConnectionCountChange.mock.lastCall?.[0]).toBe(0);
+    expect(tracker1.onConnectionCountChange).toHaveBeenCalledTimes(6);
+    expect(tracker1.onConnectionCountChange.mock.lastCall?.[0]).toBe(0);
+    expect(tracker2.onConnectionCountChange).toHaveBeenCalledTimes(6);
+    expect(tracker2.onConnectionCountChange.mock.lastCall?.[0]).toBe(0);
   });
 
   test('clear', () => {
-    expect(tracker.onConnectionCountChange).not.toBeCalled;
+    expect(tracker1.onConnectionCountChange).not.toBeCalled;
+    expect(tracker2.onConnectionCountChange).not.toBeCalled;
 
     map.set('foo', state1);
     map.set('bar', state2);
     map.set('baz', state3);
 
-    expect(tracker.onConnectionCountChange).toHaveBeenCalledTimes(3);
-    expect(tracker.onConnectionCountChange.mock.lastCall?.[0]).toBe(3);
+    expect(tracker1.onConnectionCountChange).toHaveBeenCalledTimes(3);
+    expect(tracker1.onConnectionCountChange.mock.lastCall?.[0]).toBe(3);
+    expect(tracker2.onConnectionCountChange).toHaveBeenCalledTimes(3);
+    expect(tracker2.onConnectionCountChange.mock.lastCall?.[0]).toBe(3);
 
     map.clear();
 
-    expect(tracker.onConnectionCountChange).toHaveBeenCalledTimes(4);
-    expect(tracker.onConnectionCountChange.mock.lastCall?.[0]).toBe(0);
+    expect(tracker1.onConnectionCountChange).toHaveBeenCalledTimes(4);
+    expect(tracker1.onConnectionCountChange.mock.lastCall?.[0]).toBe(0);
+    expect(tracker2.onConnectionCountChange).toHaveBeenCalledTimes(4);
+    expect(tracker2.onConnectionCountChange.mock.lastCall?.[0]).toBe(0);
   });
 });

--- a/packages/reflect-server/src/types/client-state.ts
+++ b/packages/reflect-server/src/types/client-state.ts
@@ -13,15 +13,17 @@ export class ConnectionCountTrackingClientMap
   extends Map<ClientID, ClientState>
   implements ClientMap
 {
-  #countTracker: ConnectionCountTracker;
+  #countTrackers: readonly ConnectionCountTracker[];
 
-  constructor(countTracker: ConnectionCountTracker) {
+  constructor(...countTrackers: readonly ConnectionCountTracker[]) {
     super();
-    this.#countTracker = countTracker;
+    this.#countTrackers = countTrackers;
   }
 
   #trackCount() {
-    this.#countTracker.onConnectionCountChange(this.size);
+    this.#countTrackers.forEach(tracker =>
+      tracker.onConnectionCountChange(this.size),
+    );
   }
 
   clear(): void {


### PR DESCRIPTION
Fix the calculation of the `period` (over which the `elapsed` connection seconds are calculated) to be semantically equivalent to "room seconds", which we may use for usage billing instead (@aboodman)

Separate the delayed-alarm logic (for forcing the flush of closed connection's FetchEvents) into a separate class to separate concerns. 