### PR TITLE
feat(reflect-server): Reduce frequency of GC

### DIFF
--- a/packages/reflect-server/src/process/process-pending.test.ts
+++ b/packages/reflect-server/src/process/process-pending.test.ts
@@ -1425,6 +1425,7 @@ describe('processPending', () => {
         c.maxProcessedMutationTimestamp,
         fakeBufferSizer,
         c.maxMutationsToProcess ?? Number.MAX_SAFE_INTEGER,
+        () => true,
       );
       if (c.expectedError) {
         let expectedE;

--- a/packages/reflect-server/src/process/process-pending.ts
+++ b/packages/reflect-server/src/process/process-pending.ts
@@ -29,6 +29,7 @@ export async function processPending(
   maxProcessedMutationTimestamp: number,
   bufferSizer: BufferSizer,
   maxMutationsToProcess: number,
+  shouldGCClients: (now: number) => boolean,
 ): Promise<{maxProcessedMutationTimestamp: number; nothingToProcess: boolean}> {
   const start = Date.now();
   lc = lc.withContext('numClients', clients.size);
@@ -126,6 +127,7 @@ export async function processPending(
     mutators,
     disconnectHandler,
     storage,
+    shouldGCClients,
   );
   sendPokes(lc, pokesByClientID, clients, bufferMs, start);
   lc.debug?.('clearing pending mutations');

--- a/packages/reflect-server/src/process/process-room.test.ts
+++ b/packages/reflect-server/src/process/process-room.test.ts
@@ -652,6 +652,7 @@ describe('processRoom', () => {
         mutators,
         () => Promise.resolve(),
         storage,
+        () => true,
       );
       if (c.expectedError) {
         try {

--- a/packages/reflect-server/src/process/process-room.ts
+++ b/packages/reflect-server/src/process/process-room.ts
@@ -30,6 +30,7 @@ export async function processRoom(
   mutators: MutatorMap,
   disconnectHandler: DisconnectHandler,
   storage: DurableStorage,
+  shouldGCClients: (now: number) => boolean,
 ): Promise<Map<ClientID, Poke[]>> {
   const cache = new EntryCache(storage);
   const clientIDs = [...clients.keys()];
@@ -75,6 +76,7 @@ export async function processRoom(
       disconnectHandler,
       clients,
       cache,
+      shouldGCClients,
     )),
   );
 

--- a/packages/reflect-server/src/server/client-gc.ts
+++ b/packages/reflect-server/src/server/client-gc.ts
@@ -13,6 +13,12 @@ import {
 import {userValueKey, userValueSchema} from '../types/user-value.js';
 import {putVersion} from '../types/version.js';
 
+/**
+ * Thw frequency at which we run the client GC. This is used to not do gc in
+ * every processFrame.
+ */
+export const CLIENT_GC_FREQUENCY = 10 * 1000;
+
 // 2 weeks
 export const GC_MAX_AGE = 2 * 7 * 24 * 60 * 60 * 1000;
 


### PR DESCRIPTION
Now we only run the collect client GC every 10s

Without this change we would run the collect clients on every process frame. This reduces the amount of work we do on each frame.