### PR TITLE
feat(replicache): Hook for clients removed

### DIFF
--- a/packages/replicache/src/replicache-options.ts
+++ b/packages/replicache/src/replicache-options.ts
@@ -4,6 +4,7 @@ import type {CreateStore} from './kv/store.js';
 import type {Puller} from './puller.js';
 import type {Pusher} from './pusher.js';
 import type {MutatorDefs, RequestOptions} from './replicache.js';
+import type {ClientID} from './sync/ids.js';
 
 /**
  * The options passed to {@link Replicache}.
@@ -253,6 +254,12 @@ export type ReplicacheInternalOptions = {
    * thing have been minified and with the npm package.
    */
   exposeInternalAPI?: (api: ReplicacheInternalAPI) => void;
+
+  /**
+   * Called when clients are removed from the database. This is used to tell the
+   * server about clientIDs that have been removed.
+   */
+  onClientsRemoved?: (clientIDs: Set<ClientID>) => void;
 };
 
 export interface ReplicacheInternalAPI {


### PR DESCRIPTION
When a client is remove which can happen in these cases:
- collect idb databases collects if older than 14 days and no pending mutations
- Collect old clients collects if older than 7 days and no pending mutations

We call an an onClientRemoved hook which can be used to tell the server that these clients are now gone from the client.