### PR TITLE
fix(replicache): Better name type check

### DIFF
--- a/packages/replicache/src/replicache.test.ts
+++ b/packages/replicache/src/replicache.test.ts
@@ -2473,3 +2473,24 @@ test('concurrent puts and gets', async () => {
   const v2 = await rep.query(tx => tx.get('a'));
   expect(v2).to.equal(4);
 });
+
+test('Invalid name', () => {
+  expect(
+    () => new ReplicacheTest({name: '', licenseKey: TEST_LICENSE_KEY}),
+  ).to.throw('name is required and must be non-empty');
+  expect(
+    () =>
+      new Replicache({
+        name: 1 as unknown as string,
+        licenseKey: TEST_LICENSE_KEY,
+      }),
+  ).to.throw('name is required and must be non-empty');
+
+  expect(
+    () =>
+      new ReplicacheTest({
+        name: true as unknown as string,
+        licenseKey: TEST_LICENSE_KEY,
+      }),
+  ).to.throw(TypeError);
+});

--- a/packages/replicache/src/replicache.ts
+++ b/packages/replicache/src/replicache.ts
@@ -492,8 +492,8 @@ export class Replicache<MD extends MutatorDefs = {}> {
     this.auth = auth ?? '';
     this.pullURL = pullURL;
     this.pushURL = pushURL;
-    if (name === undefined || name === '') {
-      throw new Error('name is required and must be non-empty');
+    if (typeof name !== 'string' || !name) {
+      throw new TypeError('name is required and must be non-empty');
     }
     this.name = name;
     this.schemaVersion = schemaVersion;


### PR DESCRIPTION
The previous code allowed a bunch of non strings to make it into the name which eventually fails validation when readin the idb databases.