### PR TITLE
feat(replicache)!: Return promise for push/pull

### DIFF
--- a/packages/replicache/src/connection-loop.test.ts
+++ b/packages/replicache/src/connection-loop.test.ts
@@ -15,6 +15,12 @@ setup(() => {
   clock = useFakeTimers(0);
 });
 
+async function tickUntilTimeIs(t: number) {
+  while (Date.now() < t) {
+    await clock.tickAsync(50);
+  }
+}
+
 teardown(() => {
   clock.restore();
   loop?.close();
@@ -23,20 +29,13 @@ teardown(() => {
 
 let loop: ConnectionLoop | undefined;
 
-const ps = new Set();
-
 function send(now = false) {
   if (!loop) {
     throw new Error();
   }
-  const p = loop.send(now);
-  ps.add(p);
-  return p;
-}
-
-async function waitForAll() {
-  await Promise.allSettled(ps);
-  ps.clear();
+  loop.send(now).catch(() => {
+    // ignore
+  });
 }
 
 let counter = 0;
@@ -89,16 +88,16 @@ test('basic sequential by awaiting', async () => {
   const debounceDelay = 3;
   loop = createLoop({requestTime, debounceDelay});
 
-  loop.send(false);
+  send();
   await clock.runAllAsync();
   expect(Date.now()).to.equal(requestTime + debounceDelay);
 
   expect(log).to.deep.equal(['send:0:3', 'true:0:203']);
 
-  loop.send(false);
+  send();
   await clock.runAllAsync();
 
-  loop.send(false);
+  send();
   await clock.runAllAsync();
 
   expect(log).to.deep.equal([
@@ -144,8 +143,6 @@ test('debounce', async () => {
     'send:1:110',
     'true:1:160',
   ]);
-
-  await waitForAll();
 });
 
 test('sync calls collapsed', async () => {
@@ -172,8 +169,6 @@ test('sync calls collapsed', async () => {
   expect(Date.now()).to.equal(debounceDelay + requestTime);
 
   expect(log).to.deep.equal(['send:0:5', 'true:0:55']);
-
-  await waitForAll();
 });
 
 test('concurrent connections', async () => {
@@ -259,9 +254,6 @@ test('concurrent connections', async () => {
     'true:2:155',
     'true:3:185',
   ]);
-
-  await clock.runAllAsync();
-  await waitForAll();
 });
 
 test('maxConnections 1', async () => {
@@ -306,9 +298,6 @@ test('maxConnections 1', async () => {
     'send:2:185',
     'true:2:275',
   ]);
-
-  await clock.runAllAsync();
-  await waitForAll();
 });
 
 test('Adjust delay', async () => {
@@ -383,7 +372,6 @@ test('Adjust delay', async () => {
     'true:5:388',
     'true:4:405',
   ]);
-  await waitForAll();
 });
 
 for (const errorKind of [false, 'throw'] as const) {
@@ -672,59 +660,78 @@ test('Send now', async () => {
 
   // Do not send before debounceDelay
   send();
-  while (Date.now() < 50) {
-    await clock.tickAsync(50);
-  }
+  await tickUntilTimeIs(50);
+
   expect(log).to.deep.equal([50]);
 
   // Take minDelayMs into account
   send();
-  while (Date.now() < 250) {
-    await clock.tickAsync(50);
-  }
+  await tickUntilTimeIs(250);
   expect(log).to.deep.equal([50, 250]);
 
   // send now should ignore both minDelayMs and debounceDelay
   send(true);
-  while (Date.now() < 450) {
-    await clock.tickAsync(50);
-  }
+  await tickUntilTimeIs(450);
   expect(log).to.deep.equal([50, 250, 250]);
 
   nextInvokeSendResult = false;
   send();
-  while (Date.now() < 500) {
-    await clock.tickAsync(50);
-  }
+  await tickUntilTimeIs(500);
   expect(log).to.deep.equal([50, 250, 250, 500]);
 
-  while (Date.now() < 1900) {
-    await clock.tickAsync(50);
-  }
+  await tickUntilTimeIs(1900);
   expect(log).to.deep.equal([50, 250, 250, 500, 700, 1100, 1900]);
 
   // Keep trying with exponential backoff, hitting maxDelayMs
-  while (Date.now() < 2900) {
-    await clock.tickAsync(50);
-  }
+  await tickUntilTimeIs(2900);
   expect(log).to.deep.equal([50, 250, 250, 500, 700, 1100, 1900, 2900]);
 
   // Even when there are errors and we have exponential backoff, send now should
   // send immediately.
   send(true);
-  while (Date.now() < 3900) {
-    await clock.tickAsync(50);
-  }
+  await tickUntilTimeIs(3900);
   expect(log).to.deep.equal([
     50, 250, 250, 500, 700, 1100, 1900, 2900, 2900, 3900,
   ]);
 
   nextInvokeSendResult = true;
   send(true);
-  while (Date.now() < 10_000) {
-    await clock.tickAsync(50);
-  }
+  await tickUntilTimeIs(10_000);
   expect(log).to.deep.equal([
     50, 250, 250, 500, 700, 1100, 1900, 2900, 2900, 3900, 3900,
   ]);
+});
+
+test('Send promise', async () => {
+  let nextInvokeSendResult: boolean | Error = true;
+  loop = new ConnectionLoop({
+    // eslint-disable-next-line require-await
+    async invokeSend() {
+      if (nextInvokeSendResult instanceof Error) {
+        throw nextInvokeSendResult;
+      }
+      return nextInvokeSendResult;
+    },
+    debounceDelay: 50,
+    minDelayMs: 200,
+    maxDelayMs: 1_000,
+    maxConnections: 1,
+    watchdogTimer: null,
+  });
+
+  const p1 = loop.send(false);
+  await tickUntilTimeIs(50);
+  expect(await p1).to.be.undefined;
+
+  const expectedError = new Error('xxx');
+  nextInvokeSendResult = expectedError;
+  const p2 = loop.send(false);
+  await tickUntilTimeIs(250);
+  let err;
+  try {
+    await p2;
+  } catch (e) {
+    err = e;
+  }
+  expect(err).to.equal(expectedError);
 });

--- a/packages/replicache/src/pending-mutation.test.ts
+++ b/packages/replicache/src/pending-mutation.test.ts
@@ -47,7 +47,7 @@ test('pending mutation', async () => {
 
   rep.pullURL = 'https://diff.com/pull';
   fetchMock.post(rep.pullURL, makePullResponseV1(clientID, 2));
-  rep.pull();
+  void rep.pull();
   await tickAFewTimes(100);
   await rep.mutate.addData({a: 3});
   const addAMutation = {id: 3, name: 'addData', args: {a: 3}, clientID};
@@ -57,7 +57,7 @@ test('pending mutation', async () => {
 
   fetchMock.reset();
   fetchMock.post(rep.pullURL, makePullResponseV1(clientID, 3));
-  rep.pull();
+  void rep.pull();
   await tickAFewTimes(100);
   expect(await rep.experimentalPendingMutations()).to.deep.equal([]);
 });

--- a/packages/replicache/src/replicache-mutation-recovery-dd31.test.ts
+++ b/packages/replicache/src/replicache-mutation-recovery-dd31.test.ts
@@ -1551,7 +1551,7 @@ suite('DD31', () => {
       throws: new Error('Simulate fetch error in push'),
     }));
 
-    rep.pull();
+    void rep.pull();
 
     await tickAFewTimes();
     expect(rep.online).to.equal(false);
@@ -1565,7 +1565,7 @@ suite('DD31', () => {
       patch: [],
     });
 
-    rep.pull();
+    void rep.pull();
     expect(rep.recoverMutationsFake.callCount).to.equal(1);
     while (!rep.online) {
       await tickAFewTimes();

--- a/packages/replicache/src/replicache-mutation-recovery.test.ts
+++ b/packages/replicache/src/replicache-mutation-recovery.test.ts
@@ -1105,7 +1105,7 @@ suite('SDD', () => {
       throws: new Error('Simulate fetch error in push'),
     }));
 
-    rep.pull();
+    void rep.pull();
 
     await tickAFewTimes();
     expect(rep.online).to.equal(false);
@@ -1119,7 +1119,7 @@ suite('SDD', () => {
       patch: [],
     });
 
-    rep.pull();
+    void rep.pull();
     expect(rep.recoverMutationsFake.callCount).to.equal(1);
     while (!rep.online) {
       await tickAFewTimes();

--- a/packages/replicache/src/replicache-persist.test.ts
+++ b/packages/replicache/src/replicache-persist.test.ts
@@ -97,7 +97,7 @@ test('basic persist & load', async () => {
     ]),
   );
 
-  rep.pull();
+  await rep.pull();
 
   // maxWaitAttempts * waitMs should be at least PERSIST_TIMEOUT
   // plus some buffer for the persist process to complete

--- a/packages/replicache/src/replicache-pull.test.ts
+++ b/packages/replicache/src/replicache-pull.test.ts
@@ -81,7 +81,7 @@ test('pull', async () => {
       },
     ]),
   );
-  rep.pull();
+  void rep.pull();
   await tickAFewTimes();
   expect(deleteCount).to.equal(2);
 
@@ -140,7 +140,7 @@ test('pull', async () => {
     pullURL,
     makePullResponseV1(clientID, 6, [{op: 'del', key: '/todo/14323534'}], ''),
   );
-  rep.pull();
+  void rep.pull();
   await tickAFewTimes();
 
   expect(deleteCount).to.equal(4);
@@ -212,7 +212,7 @@ test('pull request is only sent when pullURL or non-default puller are set', asy
   fetchMock.reset();
   fetchMock.postAny({});
 
-  rep.pull();
+  void rep.pull();
   await tickAFewTimes();
 
   expect(fetchMock.calls()).to.have.length(0);
@@ -223,7 +223,7 @@ test('pull request is only sent when pullURL or non-default puller are set', asy
   rep.pullURL = 'https://diff.com/pull';
   fetchMock.post(rep.pullURL, {lastMutationID: 0, patch: []});
 
-  rep.pull();
+  void rep.pull();
   await tickAFewTimes();
   expect(fetchMock.calls()).to.have.length.greaterThan(0);
 
@@ -233,7 +233,7 @@ test('pull request is only sent when pullURL or non-default puller are set', asy
 
   rep.pullURL = '';
 
-  rep.pull();
+  void rep.pull();
   await tickAFewTimes();
   expect(fetchMock.calls()).to.have.length(0);
 
@@ -255,7 +255,7 @@ test('pull request is only sent when pullURL or non-default puller are set', asy
     });
   };
 
-  rep.pull();
+  void rep.pull();
   await tickAFewTimes();
 
   expect(fetchMock.calls()).to.have.length(0);
@@ -276,7 +276,7 @@ test('pull request is only sent when pullURL or non-default puller are set', asy
 
   rep.puller = getDefaultPuller(rep);
 
-  rep.pull();
+  void rep.pull();
   await tickAFewTimes();
 
   expect(fetchMock.calls()).to.have.length(0);
@@ -304,7 +304,7 @@ test('Client Group not found on server', async () => {
   expect(rep.isClientGroupDisabled).false;
 
   rep.puller = puller;
-  rep.pull();
+  void rep.pull();
 
   await waitForSync(rep);
 
@@ -338,7 +338,7 @@ test('Version not supported on server', async () => {
     });
 
     rep.puller = puller;
-    rep.pull();
+    void rep.pull();
 
     await promise;
 

--- a/packages/replicache/src/replicache-push.test.ts
+++ b/packages/replicache/src/replicache-push.test.ts
@@ -296,7 +296,7 @@ test('Version not supported on server', async () => {
     rep.pusher = pusher as Pusher;
 
     await rep.mutate.noop();
-    await rep.invokePush();
+    await rep.push(true);
 
     expect(onUpdateNeededStub.callCount).to.equal(1);
     expect(onUpdateNeededStub.lastCall.args).deep.equal([reason]);
@@ -337,7 +337,7 @@ test('ClientStateNotFound on server', async () => {
   rep.pusher = pusher as Pusher;
 
   await rep.mutate.noop();
-  await rep.invokePush();
+  await rep.push(true);
 
   expect(onUpdateNeededStub.callCount).equal(0);
   expect(onClientStateNotFound.callCount).equal(1);

--- a/packages/replicache/src/replicache-subscribe.test.ts
+++ b/packages/replicache/src/replicache-subscribe.test.ts
@@ -692,7 +692,7 @@ test('subscribe pull and index update', async () => {
       makePullResponseV1(clientID, lastMutationID++, opt.patch),
     );
 
-    rep.pull();
+    void rep.pull();
     await tickUntil(() => log.length >= opt.expectedLog.length);
     expect(queryCallCount).to.equal(expectedQueryCallCount);
     expect(log).to.deep.equal(opt.expectedLog);

--- a/packages/replicache/src/replicache.test.ts
+++ b/packages/replicache/src/replicache.test.ts
@@ -490,7 +490,7 @@ test('HTTP status pull', async () => {
 
   const consoleErrorStub = sinon.stub(console, 'error');
 
-  rep.pull();
+  void rep.pull(true);
 
   await tickAFewTimes(20, 10);
 
@@ -1255,7 +1255,7 @@ test('onSync', async () => {
 
   const {clientID} = rep;
   fetchMock.postOnce(pullURL, makePullResponseV1(clientID, 2));
-  rep.pull();
+  await rep.pull();
   await tickAFewTimes(15);
 
   expect(onSync.callCount).to.equal(2);
@@ -1419,7 +1419,7 @@ test('push and pull concurrently', async () => {
   resetSpies();
 
   await add({b: 1});
-  rep.pull();
+  await rep.pull();
 
   await clock.tickAsync(10);
 
@@ -1452,7 +1452,7 @@ test('schemaVersion pull', async () => {
     schemaVersion,
   });
 
-  rep.pull();
+  await rep.pull();
   await tickAFewTimes();
 
   const req = await fetchMock.lastCall().request.json();
@@ -1552,7 +1552,7 @@ test('pull and index update', async () => {
       return makePullResponseV1(clientID, lastMutationID++, opt.patch);
     });
 
-    rep.pull();
+    await rep.pull();
 
     await tickUntil(() => pullDone);
     await tickAFewTimes();
@@ -1631,7 +1631,7 @@ async function populateDataUsingPull<
     })),
   });
 
-  rep.pull();
+  await rep.pull();
 
   // Allow pull to finish (larger than PERSIST_TIMEOUT)
   await clock.tickAsync(22 * 1000);
@@ -1665,21 +1665,21 @@ test('pull mutate options', async () => {
   await tickUntilTimeIs(1000);
 
   while (Date.now() < 1150) {
-    rep.pull();
+    void rep.pull();
     await clock.tickAsync(10);
   }
 
   rep.requestOptions.minDelayMs = 500;
 
   while (Date.now() < 2000) {
-    rep.pull();
+    void rep.pull();
     await clock.tickAsync(100);
   }
 
   rep.requestOptions.minDelayMs = 25;
 
   while (Date.now() < 2500) {
-    rep.pull();
+    void rep.pull();
     await clock.tickAsync(5);
   }
 
@@ -2195,7 +2195,7 @@ test('mutation timestamps are immutable', async () => {
 
   // Create a mutation and verify it has been assigned current time.
   await rep.mutate.foo(null);
-  await rep.invokePush();
+  await rep.push(true);
   expect(pending).deep.equal([
     {
       clientID: rep.clientID,
@@ -2234,7 +2234,7 @@ test('mutation timestamps are immutable', async () => {
   expect(val).equal('dog');
 
   // Check that mutation timestamp did not change
-  await rep.invokePush();
+  await rep.push(true);
   expect(pending).deep.equal([
     {
       clientID: rep.clientID,

--- a/packages/replicache/src/replicache.ts
+++ b/packages/replicache/src/replicache.ts
@@ -114,7 +114,6 @@ export interface TestingReplicacheWithTesting extends Replicache {
 
 type TestingInstance = {
   beginPull: () => Promise<BeginPullResult>;
-  invokePush: () => Promise<boolean>;
   isClientGroupDisabled: () => boolean;
   licenseActivePromise: Promise<boolean>;
   licenseCheckPromise: Promise<boolean>;
@@ -573,7 +572,6 @@ export class Replicache<MD extends MutatorDefs = {}> {
         maybeEndPull: (syncHead, requestID) =>
           this.#maybeEndPull(syncHead, requestID),
         onPushInvoked: () => undefined,
-        invokePush: () => this.#invokePush(),
         onBeginPull: () => undefined,
         beginPull: () => this.#beginPull(),
         onRecoverMutations: r => r,
@@ -673,8 +671,8 @@ export class Replicache<MD extends MutatorDefs = {}> {
     await this.#licenseCheck(resolveLicenseCheck);
 
     if (this.#enablePullAndPushInOpen) {
-      this.pull();
-      this.push();
+      this.pull().catch(noop);
+      this.push().catch(noop);
     }
 
     const {signal} = this.#closeAbortController;
@@ -1251,24 +1249,36 @@ export class Replicache<MD extends MutatorDefs = {}> {
    * non-zero (which it is by default) pushes happen automatically shortly after
    * mutations.
    *
+   * If the server endpoint fails push will be continuously retried with an
+   * exponential backoff.
+   *
    * @param [now=false] If true, push will happen immediately and ignore
    *   {@link pushDelay}, {@link RequestOptions.minDelayMs} as well as the
    *   exponential backoff in case of errors.
+   * @returns A promise that resolves when the next push completes. In case of
+   * errors the first error will reject the returned promise. Subsequent errors
+   * will not be reflected in the promise.
    */
-  push(now = false): void {
-    this.#pushConnectionLoop.send(now);
+  push(now = false): Promise<void> {
+    return this.#pushConnectionLoop.send(now);
   }
 
   /**
    * Pull pulls changes from the {@link pullURL}. If there are any changes local
    * changes will get replayed on top of the new server state.
    *
+   * If the server endpoint fails pull will be continuously retried with an
+   * exponential backoff.
+   *
    * @param [now=false] If true, pull will happen immediately and ignore
    *   {@link RequestOptions.minDelayMs} as well as the exponential backoff in
    *   case of errors.
+   * @returns A promise that resolves when the next pull completes. In case of
+   * errors the first error will reject the returned promise. Subsequent errors
+   * will not be reflected in the promise.
    */
-  pull(now = false): void {
-    this.#pullConnectionLoop.send(now);
+  pull(now = false): Promise<void> {
+    return this.#pullConnectionLoop.send(now);
   }
 
   /**
@@ -1691,7 +1701,7 @@ export class Replicache<MD extends MutatorDefs = {}> {
           DEFAULT_HEAD_NAME,
           this.#subscriptions,
         );
-        this.#pushConnectionLoop.send(false);
+        this.#pushConnectionLoop.send(false).catch(noop);
         await this.#checkChange(ref, diffs);
         void this.#schedulePersist();
         return {result, ref};

--- a/packages/replicache/src/test-util.ts
+++ b/packages/replicache/src/test-util.ts
@@ -63,10 +63,6 @@ export class ReplicacheTest<
     return getTestInstance(this).maybeEndPull(syncHead, requestID);
   }
 
-  invokePush(): Promise<boolean> {
-    return getTestInstance(this).invokePush();
-  }
-
   persist() {
     return this.#internalAPI.persist();
   }


### PR DESCRIPTION
BREAKING CHANGE!

push and pull now returns a promise which is fulfilled when the next push/pull is fulfilled.

In case of errors, we retry the push/pull but this is not reflected in the promise.