### PR TITLE
fix(reflect-cli): fix `reflect env set --dev` when there's no .reflect dir

### DIFF
--- a/mirror/reflect-cli/src/dev/vars.test.ts
+++ b/mirror/reflect-cli/src/dev/vars.test.ts
@@ -16,7 +16,7 @@ import {
   deleteDevVars,
   listDevVars,
   setDevVars,
-  setFileOverriddeForTests,
+  setFileOverrideForTests,
 } from './vars.js';
 
 describe('dev vars', () => {
@@ -27,7 +27,7 @@ describe('dev vars', () => {
       path.join(os.tmpdir(), 'reflect-dev-vars-test-'),
     );
     varsFile = path.join(dir, 'dev-vars.env');
-    setFileOverriddeForTests(varsFile);
+    setFileOverrideForTests({dir, file: varsFile});
   });
 
   afterEach(async () => {
@@ -37,7 +37,7 @@ describe('dev vars', () => {
   });
 
   afterAll(() => {
-    setFileOverriddeForTests(undefined);
+    setFileOverrideForTests(undefined);
   });
 
   test('empty list', () => {

--- a/mirror/reflect-cli/src/vars/set.test.ts
+++ b/mirror/reflect-cli/src/vars/set.test.ts
@@ -10,7 +10,7 @@ import {existsSync} from 'node:fs';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import {listDevVars, setFileOverriddeForTests} from '../dev/vars.js';
+import {listDevVars, setFileOverrideForTests} from '../dev/vars.js';
 import {UserError} from '../error.js';
 import {setVarsHandler} from './set.js';
 
@@ -22,7 +22,7 @@ describe('set vars', () => {
       path.join(os.tmpdir(), 'reflect-dev-vars-test-'),
     );
     varsFile = path.join(dir, 'dev-vars.env');
-    setFileOverriddeForTests(varsFile);
+    setFileOverrideForTests({dir, file: varsFile});
   });
 
   afterEach(async () => {
@@ -32,7 +32,7 @@ describe('set vars', () => {
   });
 
   afterAll(() => {
-    setFileOverriddeForTests(undefined);
+    setFileOverrideForTests(undefined);
   });
 
   const ignoredYargs = {


### PR DESCRIPTION
`reflect env set --dev` needs to create the `.reflect` directory if it's not there (e.g. if `reflect dev` has not yet been run).

Fixes #1270