### PR TITLE
fix(mirror-server): Increase the floating point threshold to nanosecond granularity

### DIFF
--- a/mirror/mirror-server/src/metrics/ledger.test.ts
+++ b/mirror/mirror-server/src/metrics/ledger.test.ts
@@ -170,7 +170,7 @@ describe('metrics ledger', () => {
       teamID: TEAM1,
       appID: APP1,
       hour: new Date(Date.UTC(2023, 0, 31, 23)),
-      metrics: [[CONNECTION_SECONDS, 10.2300000000001]],
+      metrics: [[CONNECTION_SECONDS, 10.2300000001]],
       expectUpdated: false,
       expectedAppMonth: {
         teamID: TEAM1,

--- a/mirror/mirror-server/src/metrics/ledger.ts
+++ b/mirror/mirror-server/src/metrics/ledger.ts
@@ -72,7 +72,7 @@ export class Ledger {
             const delta = newValue - currValue;
             return [metric, delta] as [Metric, number];
           })
-          .filter(([_, delta]) => Math.abs(delta) > 1e-11) // Ignore insignificant floating point deltas.
+          .filter(([_, delta]) => Math.abs(delta) > 1e-9) // Nanosecond granularity: ignore insignificant floating point deltas.
           .map(
             ([metric, delta]) =>
               [metric, FieldValue.increment(delta)] as [Metric, FieldValue],


### PR DESCRIPTION
The latest false flag in "unexpected updated metrics" was a caused by a difference of `1.4551915228366852e-11`

![Screenshot 2023-11-30 at 2 14 44 PM](https://github.com/rocicorp/mono/assets/132324914/5c3b1da6-11b6-41f6-be0a-e2b5eb288f6b)

Increase the threshold to nanosecond granularity; this should hopefully ignore floating point imprecision once and for all.
