### PR TITLE
chore(reflect-cli): Treat ENOENT as a warning when copying files

### DIFF
--- a/mirror/reflect-cli/src/app-config.ts
+++ b/mirror/reflect-cli/src/app-config.ts
@@ -282,15 +282,24 @@ function copyAndEditFile(
   edit: (content: string) => string,
   logConsole: boolean,
 ) {
-  const srcPath = path.resolve(dir, src);
-  const dstPath = path.resolve(dir, dst);
-  const content = fs.readFileSync(srcPath, 'utf-8');
-  const edited = edit(content);
-  if (fs.existsSync(dstPath) && fs.readFileSync(dstPath, 'utf-8') === edited) {
-    return;
-  }
-  fs.writeFileSync(dstPath, edited, 'utf-8');
-  if (logConsole) {
-    console.log(`Updated ${dst} from ${src}`);
+  try {
+    const srcPath = path.resolve(dir, src);
+    const dstPath = path.resolve(dir, dst);
+    const content = fs.readFileSync(srcPath, 'utf-8');
+    const edited = edit(content);
+    if (
+      fs.existsSync(dstPath) &&
+      fs.readFileSync(dstPath, 'utf-8') === edited
+    ) {
+      return;
+    }
+    fs.writeFileSync(dstPath, edited, 'utf-8');
+    if (logConsole) {
+      console.log(`Updated ${dst} from ${src}`);
+    }
+  } catch (e) {
+    // In case the user has deleted the template source file, classify this as a
+    // warning instead.
+    throw new ErrorWrapper(e, 'WARNING');
   }
 }


### PR DESCRIPTION
https://console.cloud.google.com/logs/query;query=resource.type%3D%22cloud_run_revision%22%20AND%20resource.labels.project_id%3D%22reflect-mirror-prod%22;cursorTimestamp=2023-12-06T13:56:56.027270Z;startTime=2023-12-06T13:12:13.000Z;endTime=2023-12-06T14:07:32.048Z?project=reflect-mirror-prod