### PR TITLE
feat(reflect-cli): better dx for requiring permissions

### DIFF
--- a/mirror/mirror-server/src/functions/keys/create.function.test.ts
+++ b/mirror/mirror-server/src/functions/keys/create.function.test.ts
@@ -117,6 +117,12 @@ describe('appKeys-create', () => {
     });
   }
 
+  test('no permissions', async () => {
+    const resp = await callCreate('key-needs-permissions', {}).catch(e => e);
+    expect(resp).toBeInstanceOf(HttpsError);
+    expect((resp as HttpsError).code).toBe('invalid-argument');
+  });
+
   test('invalid permissions', async () => {
     const resp = await callCreate('valid-name-but', {
       'invalid:permission': true,

--- a/mirror/mirror-server/src/functions/keys/edit.function.test.ts
+++ b/mirror/mirror-server/src/functions/keys/edit.function.test.ts
@@ -106,7 +106,21 @@ describe('appKeys-edit', () => {
     });
   });
 
-  test('non-existent key permissions', async () => {
+  test('invalid permissions', async () => {
+    const resp = await callEdit('existing-key', {
+      'invalid:permissions': true,
+    }).catch(e => e);
+    expect(resp).toBeInstanceOf(HttpsError);
+    expect((resp as HttpsError).code).toBe('invalid-argument');
+  });
+
+  test('invalid permissions', async () => {
+    const resp = await callEdit('existing-key', {}).catch(e => e);
+    expect(resp).toBeInstanceOf(HttpsError);
+    expect((resp as HttpsError).code).toBe('invalid-argument');
+  });
+
+  test('non-existent key', async () => {
     const resp = await callEdit('non-existing-key', {
       'app:publish': true,
     }).catch(e => e);

--- a/mirror/reflect-cli/src/inquirer.ts
+++ b/mirror/reflect-cli/src/inquirer.ts
@@ -32,13 +32,21 @@ type Choice<Value> = {
   type?: never;
 };
 
-type CheckboxConfig<T> = {
+type Item<Value> = Separator | Choice<Value>;
+
+type CheckboxConfig<Value> = {
   message: string | Promise<string> | (() => Promise<string>);
   prefix?: string | undefined;
   pageSize?: number | undefined;
   instructions?: string | boolean | undefined;
-  choices: readonly (Separator | T)[];
+  choices: readonly Item<Value>[];
   loop?: boolean | undefined;
+  required?: boolean | undefined;
+  validate?:
+    | ((
+        items: readonly Item<Value>[],
+      ) => string | boolean | Promise<string | boolean>)
+    | undefined;
 };
 
 export function confirm(config: ConfirmConfig): Promise<boolean> {
@@ -58,7 +66,7 @@ export function password(config: PasswordConfig): Promise<string> {
   // @ts-ignore type error in jest?!?
   return passwordFn(config);
 }
-export function checkbox<T>(config: CheckboxConfig<Choice<T>>): Promise<T[]> {
+export function checkbox<T>(config: CheckboxConfig<T>): Promise<T[]> {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore type error in jest?!?
   return checkboxFn(config);

--- a/mirror/reflect-cli/src/keys/create.ts
+++ b/mirror/reflect-cli/src/keys/create.ts
@@ -53,13 +53,10 @@ export async function createAppKeyHandler(
       : await checkbox({
           message: `Select permissions for the "${color.bold(name)}" key:`,
           choices: allPerms.map(perm => ({name: perm, value: perm})),
+          instructions: false,
           pageSize: 1000,
+          required: true,
         });
-  if (perms.length === 0) {
-    // TODO: Update version of @inquirer/checkbox that includes validation.
-    console.error(color.yellow('You must select at least one permission.'));
-    process.exit(-1);
-  }
 
   const {value} = await createAppKey({
     requester,

--- a/mirror/reflect-cli/src/keys/edit.ts
+++ b/mirror/reflect-cli/src/keys/edit.ts
@@ -46,12 +46,9 @@ export async function editAppKeyHandler(
       checked: key.permissions[perm],
     })),
     pageSize: 1000,
+    instructions: false,
+    required: true,
   });
-  if (perms.length === 0) {
-    // TODO: Update version of @inquirer/checkbox that includes validation.
-    console.error(color.yellow('You must select at least one permission.'));
-    process.exit(-1);
-  }
 
   await editAppKey({
     requester,


### PR DESCRIPTION
Use the new @inquirer/checkbox version's `required` feature to force a user to choose at least one permission. This obviates the need to print the long list of instructions.

![Screenshot 2023-12-06 at 9 48 56 AM](https://github.com/rocicorp/mono/assets/132324914/7c88e8e3-9b16-4fa9-84b1-7767610eaabf)

Also add enforcement on the server side.
