### PR TITLE
feat(reflect-server): implement write endpoints of v1 REST API

### DIFF
--- a/packages/reflect-protocol/src/api/auth.ts
+++ b/packages/reflect-protocol/src/api/auth.ts
@@ -1,11 +1,5 @@
 import * as v from 'shared/src/valita.js';
 
-export const invalidateForUserRequestSchema = v.object({
-  userID: v.string(),
-});
-export const invalidateForRoomRequestSchema = v.object({
-  roomID: v.string(),
-});
 export const connectionsResponseSchema = v.array(
   v.object({
     userID: v.string(),
@@ -13,10 +7,4 @@ export const connectionsResponseSchema = v.array(
   }),
 );
 
-export type InvalidateForUserRequest = v.Infer<
-  typeof invalidateForUserRequestSchema
->;
-export type InvalidateForRoomRequest = v.Infer<
-  typeof invalidateForRoomRequestSchema
->;
 export type ConnectionsResponse = v.Infer<typeof connectionsResponseSchema>;

--- a/packages/reflect-protocol/src/api/room.ts
+++ b/packages/reflect-protocol/src/api/room.ts
@@ -1,7 +1,6 @@
 import * as v from 'shared/src/valita.js';
 
 export const createRoomRequestSchema = v.object({
-  roomID: v.string(),
   jurisdiction: v.literal('eu').optional(),
 });
 

--- a/packages/reflect-server/src/client/auth.ts
+++ b/packages/reflect-server/src/client/auth.ts
@@ -1,15 +1,16 @@
-import type {
-  InvalidateForRoomRequest,
-  InvalidateForUserRequest,
-} from 'reflect-protocol';
-import {AUTH_ROUTES} from '../server/auth-do.js';
+import {
+  INVALIDATE_ALL_CONNECTIONS_PATH,
+  INVALIDATE_ROOM_CONNECTIONS_PATH,
+  INVALIDATE_USER_CONNECTIONS_PATH,
+  fmtPath,
+} from '../server/paths.js';
 import {newAuthedPostRequest} from './authedpost.js';
 
 export function newInvalidateAllAuthRequest(
   reflectServerURL: string,
   authApiKey: string,
 ) {
-  const path = AUTH_ROUTES.authInvalidateAll;
+  const path = fmtPath(INVALIDATE_ALL_CONNECTIONS_PATH);
   const url = new URL(path, reflectServerURL);
   return newAuthedPostRequest(url, authApiKey);
 }
@@ -19,10 +20,9 @@ export function newInvalidateForUserAuthRequest(
   authApiKey: string,
   userID: string,
 ) {
-  const path = AUTH_ROUTES.authInvalidateForUser;
+  const path = fmtPath(INVALIDATE_USER_CONNECTIONS_PATH, {userID});
   const url = new URL(path, reflectServerURL);
-  const req: InvalidateForUserRequest = {userID};
-  return newAuthedPostRequest(url, authApiKey, req);
+  return newAuthedPostRequest(url, authApiKey);
 }
 
 export function newInvalidateForRoomAuthRequest(
@@ -30,8 +30,7 @@ export function newInvalidateForRoomAuthRequest(
   authApiKey: string,
   roomID: string,
 ) {
-  const path = AUTH_ROUTES.authInvalidateForRoom;
+  const path = fmtPath(INVALIDATE_ROOM_CONNECTIONS_PATH, {roomID});
   const url = new URL(path, reflectServerURL);
-  const req: InvalidateForRoomRequest = {roomID};
-  return newAuthedPostRequest(url, authApiKey, req);
+  return newAuthedPostRequest(url, authApiKey);
 }

--- a/packages/reflect-server/src/client/room.ts
+++ b/packages/reflect-server/src/client/room.ts
@@ -2,7 +2,12 @@ import type {CreateRoomRequest} from 'reflect-protocol';
 import * as v from 'shared/src/valita.js';
 import {createAPIHeaders} from '../server/api-headers.js';
 import {AUTH_ROUTES} from '../server/auth-do.js';
-import {CREATE_ROOM_PATH} from '../server/paths.js';
+import {
+  CLOSE_ROOM_PATH,
+  CREATE_ROOM_PATH,
+  DELETE_ROOM_PATH,
+  fmtPath,
+} from '../server/paths.js';
 import {roomStatusSchema, type RoomStatus} from '../server/rooms.js';
 import {newAuthedPostRequest} from './authedpost.js';
 
@@ -129,8 +134,8 @@ export function newCreateRoomRequest(
   roomID: string,
   jurisdiction?: 'eu',
 ) {
-  const url = new URL(CREATE_ROOM_PATH, reflectServerURL);
-  const req: CreateRoomRequest = {roomID, jurisdiction};
+  const url = new URL(fmtPath(CREATE_ROOM_PATH, {roomID}), reflectServerURL);
+  const req: CreateRoomRequest = {jurisdiction};
   return newAuthedPostRequest(url, authApiKey, req);
 }
 
@@ -139,8 +144,7 @@ export function newCloseRoomRequest(
   authApiKey: string,
   roomID: string,
 ) {
-  const path = AUTH_ROUTES.closeRoom.replace(':roomID', roomID);
-  const url = new URL(path, reflectServerURL);
+  const url = new URL(fmtPath(CLOSE_ROOM_PATH, {roomID}), reflectServerURL);
   return newAuthedPostRequest(url, authApiKey);
 }
 
@@ -149,26 +153,6 @@ export function newDeleteRoomRequest(
   authApiKey: string,
   roomID: string,
 ) {
-  const path = AUTH_ROUTES.deleteRoom.replace(':roomID', roomID);
-  const url = new URL(path, reflectServerURL);
-  return newAuthedPostRequest(url, authApiKey);
-}
-export function newForgetRoomRequest(
-  reflectServerURL: string,
-  authApiKey: string,
-  roomID: string,
-) {
-  const path = AUTH_ROUTES.forgetRoom.replace(':roomID', roomID);
-  const url = new URL(path, reflectServerURL);
-  return newAuthedPostRequest(url, authApiKey);
-}
-
-export function newMigrateRoomRequest(
-  reflectServerURL: string,
-  authApiKey: string,
-  roomID: string,
-) {
-  const path = AUTH_ROUTES.migrateRoom.replace(':roomID', roomID);
-  const url = new URL(path, reflectServerURL);
+  const url = new URL(fmtPath(DELETE_ROOM_PATH, {roomID}), reflectServerURL);
   return newAuthedPostRequest(url, authApiKey);
 }

--- a/packages/reflect-server/src/server/paths.test.ts
+++ b/packages/reflect-server/src/server/paths.test.ts
@@ -1,0 +1,58 @@
+import {describe, expect, test} from '@jest/globals';
+import {
+  CREATE_ROOM_PATH,
+  DELETE_ROOM_PATH,
+  INVALIDATE_ALL_CONNECTIONS_PATH,
+  INVALIDATE_USER_CONNECTIONS_PATH,
+  fmtPath,
+} from './paths.js';
+
+describe('paths', () => {
+  type Case = {
+    name: string;
+    pattern: string;
+    groups?: Record<string, string>;
+    result: string;
+  };
+  const cases: Case[] = [
+    {
+      name: 'simple roomID',
+      pattern: CREATE_ROOM_PATH,
+      groups: {roomID: 'foo-room'},
+      result: '/api/v1/rooms/foo-room:create',
+    },
+    {
+      name: 'roomID with special characters',
+      pattern: DELETE_ROOM_PATH,
+      groups: {roomID: 'room/id?with\\special:characters'},
+      result: '/api/v1/rooms/room%2Fid%3Fwith%5Cspecial%3Acharacters:delete',
+    },
+    {
+      name: 'userID',
+      pattern: INVALIDATE_USER_CONNECTIONS_PATH,
+      groups: {userID: 'foo-user'},
+      result: '/api/v1/connections/users/foo-user:invalidate',
+    },
+    {
+      name: 'no groups',
+      pattern: INVALIDATE_ALL_CONNECTIONS_PATH,
+      result: '/api/v1/connections:invalidate',
+    },
+  ];
+
+  cases.forEach(c => {
+    test(c.name, () => {
+      expect(fmtPath(c.pattern, c.groups)).toBe(c.result);
+      const parsed = new URLPattern({pathname: c.pattern}).exec(
+        `http://api.reflect-server.net${c.result}`,
+      );
+      const decoded = Object.fromEntries(
+        Object.entries(parsed?.pathname.groups ?? {}).map(([name, value]) => [
+          name,
+          decodeURIComponent(value),
+        ]),
+      );
+      expect(decoded).toEqual(c.groups ?? {});
+    });
+  });
+});

--- a/packages/reflect-server/src/server/paths.ts
+++ b/packages/reflect-server/src/server/paths.ts
@@ -5,11 +5,31 @@ export const LOG_LOGS_PATH = '/api/logs/v0/log';
 
 export const CONNECT_URL_PATTERN = '/api/sync/:version/connect';
 export const DISCONNECT_BEACON_PATH = '/api/sync/v1/disconnect';
-export const LEGACY_CONNECT_PATH = '/connect';
 
 export const AUTH_CONNECTIONS_PATH = '/api/auth/v0/connections';
-export const CREATE_ROOM_PATH = '/api/room/v0/room/create';
-export const LEGACY_CREATE_ROOM_PATH = '/createRoom';
-export const INTERNAL_CREATE_ROOM_PATH = '/INTERNAL/api/room/v0/room/create';
+
+export const CREATE_ROOM_PATH = '/api/v1/rooms/:roomID\\:create';
+export const CLOSE_ROOM_PATH = '/api/v1/rooms/:roomID\\:close';
+export const DELETE_ROOM_PATH = '/api/v1/rooms/:roomID\\:delete';
+
+export const INVALIDATE_ALL_CONNECTIONS_PATH =
+  '/api/v1/connections\\:invalidate';
+export const INVALIDATE_ROOM_CONNECTIONS_PATH =
+  '/api/v1/connections/rooms/:roomID\\:invalidate';
+export const INVALIDATE_USER_CONNECTIONS_PATH =
+  '/api/v1/connections/users/:userID\\:invalidate';
 
 export const TAIL_URL_PATH = '/api/debug/v0/tail';
+
+export function fmtPath(
+  pathPattern: string,
+  placeholders?: Record<string, string>,
+): string {
+  Object.entries(placeholders ?? {}).forEach(([placeholder, value]) => {
+    pathPattern = pathPattern.replaceAll(
+      `:${placeholder}`,
+      encodeURIComponent(value),
+    );
+  });
+  return pathPattern.replaceAll('\\', '');
+}

--- a/packages/reflect-server/src/server/reflect.ts
+++ b/packages/reflect-server/src/server/reflect.ts
@@ -180,7 +180,6 @@ function createRoomDOClass<
         state,
         roomStartHandler,
         disconnectHandler,
-        authApiKey: getAPIKey(env),
         logSink,
         logLevel,
         allowUnconfirmedWrites,
@@ -202,19 +201,10 @@ function createAuthDOClass<
         roomDO: env.roomDO,
         state,
         authHandler,
-        authApiKey: getAPIKey(env),
         logSink,
         logLevel,
         env: extractVars(env),
       });
     }
   };
-}
-
-function getAPIKey(env: ReflectServerBaseEnv) {
-  const val = env.REFLECT_API_KEY;
-  if (!val) {
-    throw new Error('REFLECT_API_KEY environment var is required');
-  }
-  return val;
 }

--- a/packages/reflect-server/src/server/rooms.test.ts
+++ b/packages/reflect-server/src/server/rooms.test.ts
@@ -1,0 +1,24 @@
+import {describe, expect, test} from '@jest/globals';
+import {
+  CLOSE_ROOM_PATH,
+  CREATE_ROOM_PATH,
+  DELETE_ROOM_PATH,
+  fmtPath,
+} from './paths.js';
+
+describe('rooms', () => {
+  test('makeCreateRoomPath', () => {
+    expect(fmtPath(CREATE_ROOM_PATH, {roomID: 'foo-bar'})).toBe(
+      '/api/v1/rooms/foo-bar:create',
+    );
+    expect(
+      fmtPath(CREATE_ROOM_PATH, {roomID: 'id\\with/slashes-and:colons'}),
+    ).toBe('/api/v1/rooms/id%5Cwith%2Fslashes-and%3Acolons:create');
+    expect(fmtPath(CLOSE_ROOM_PATH, {roomID: 'foo-bar'})).toBe(
+      '/api/v1/rooms/foo-bar:close',
+    );
+    expect(
+      fmtPath(DELETE_ROOM_PATH, {roomID: 'id\\with/slashes-and:colons'}),
+    ).toBe('/api/v1/rooms/id%5Cwith%2Fslashes-and%3Acolons:delete');
+  });
+});

--- a/packages/reflect-server/src/server/rooms.ts
+++ b/packages/reflect-server/src/server/rooms.ts
@@ -3,7 +3,7 @@ import type {CreateRoomRequest} from 'reflect-protocol';
 import * as valita from 'shared/src/valita.js';
 import type {DurableStorage} from '../storage/durable-storage.js';
 import {roomDOFetch} from './auth-do.js';
-import {INTERNAL_CREATE_ROOM_PATH} from './paths.js';
+import {CREATE_ROOM_PATH, fmtPath} from './paths.js';
 
 // RoomRecord keeps information about the room, for example the Durable
 // Object ID of the DO instance that has the room.
@@ -74,8 +74,10 @@ export function internalCreateRoom(
   roomID: string,
   jurisdiction: 'eu' | undefined,
 ) {
-  const url = `https://unused-reflect-room-do.dev${INTERNAL_CREATE_ROOM_PATH}`;
-  const req: CreateRoomRequest = {roomID, jurisdiction};
+  const url = `https://unused-reflect-room-do.dev${fmtPath(CREATE_ROOM_PATH, {
+    roomID,
+  })}`;
+  const req: CreateRoomRequest = {jurisdiction};
   const request = new Request(url, {
     method: 'POST',
     // no auth headers, because this is an internal call

--- a/packages/reflect-server/src/server/worker.ts
+++ b/packages/reflect-server/src/server/worker.ts
@@ -6,9 +6,14 @@ import {Series, reportMetricsSchema} from '../types/report-metrics.js';
 import {isTrueEnvValue} from '../util/env.js';
 import {populateLogContextFromRequest} from '../util/log-context-common.js';
 import {
+  SEC_WEBSOCKET_PROTOCOL_HEADER,
+  createWSAndCloseWithTailError,
+} from '../util/socket.js';
+import {
   AUTH_ROUTES_AUTHED_BY_API_KEY,
   AUTH_ROUTES_CUSTOM_AUTH,
   AUTH_ROUTES_UNAUTHED,
+  AUTH_WEBSOCKET_ROUTES_AUTHED_BY_API_KEY,
 } from './auth-do.js';
 import {createDatadogMetricsSink} from './datadog-metrics-sink.js';
 import {
@@ -23,11 +28,10 @@ import {
   Handler,
   Router,
   WithLogContext,
-  asJSON,
+  body,
   checkAuthAPIKey,
   get,
   post,
-  withBody,
 } from './router.js';
 import {withUnhandledRejectionHandler} from './unhandled-rejection-handler.js';
 
@@ -80,6 +84,16 @@ function registerRoutes(router: WorkerRouter) {
       requireAPIKeyMatchesEnv((ctx, req) => sendToAuthDO(ctx, req)),
     );
   }
+  for (const pattern of Object.values(
+    AUTH_WEBSOCKET_ROUTES_AUTHED_BY_API_KEY,
+  )) {
+    router.register(
+      pattern,
+      requireWebsocketProtocolMatchesAPIKey((ctx, req) =>
+        sendToAuthDO(ctx, req),
+      ),
+    );
+  }
   for (const pattern of Object.values(AUTH_ROUTES_CUSTOM_AUTH)) {
     router.register(pattern, sendToAuthDO);
   }
@@ -98,8 +112,9 @@ function registerRoutes(router: WorkerRouter) {
 // - maybe authenticate requests (but not just utilizing the auth
 //    handler: we want to be able to report metrics for a logged
 //    out user as well)
-const reportMetrics = post<WorkerContext, Response>(
-  withBody(reportMetricsSchema, async ctx => {
+const reportMetrics = post<WorkerContext>()
+  .with(body(reportMetricsSchema))
+  .handle(async ctx => {
     const {lc, body, datadogMetricsOptions} = ctx;
 
     if (!datadogMetricsOptions) {
@@ -123,10 +138,9 @@ const reportMetrics = post<WorkerContext, Response>(
     }
 
     return new Response('ok');
-  }),
-);
+  });
 
-const logLogs = post<WorkerContext, Response>(
+const logLogs = post<WorkerContext>().handle(
   async (ctx: WorkerContext, req: Request) => {
     const {lc, env} = ctx;
 
@@ -188,13 +202,11 @@ const logLogs = post<WorkerContext, Response>(
   },
 );
 
-const hello = get<WorkerContext, Response>(
-  asJSON(() => ({
-    reflectServerVersion: version,
-  })),
-);
+const hello = get<WorkerContext>().handleAsJSON(() => ({
+  reflectServerVersion: version,
+}));
 
-const canaryGet = get<WorkerContext, Response>(
+const canaryGet = get<WorkerContext>().handle(
   (ctx: WorkerContext, req: Request) => {
     const url = new URL(req.url);
     const checkID = url.searchParams.get('id') ?? 'missing';
@@ -211,6 +223,26 @@ function requireAPIKeyMatchesEnv(next: Handler<WorkerContext, Response>) {
     const resp = checkAuthAPIKey(ctx.env.REFLECT_API_KEY, req);
     if (resp) {
       return resp;
+    }
+    return next(ctx, req);
+  };
+}
+
+function requireWebsocketProtocolMatchesAPIKey(
+  next: Handler<WorkerContext, Response>,
+) {
+  return (ctx: WorkerContext, req: Request) => {
+    // For tail we send the REFLECT_API_KEY in the Sec-WebSocket-Protocol
+    // header and it is always required
+    // TODO: Generalize the error protocol if we introduce other auth'ed websocket protocols.
+    const authApiKey = req.headers.get(SEC_WEBSOCKET_PROTOCOL_HEADER);
+    if (authApiKey !== ctx.env.REFLECT_API_KEY) {
+      createWSAndCloseWithTailError(
+        ctx.lc,
+        req,
+        'Unauthorized',
+        'auth required',
+      );
     }
     return next(ctx, req);
   };


### PR DESCRIPTION
## Added

Implements the write endpoints of the [v1 Reflect Server REST API](https://www.notion.so/replicache/Reflect-Server-API-endpoints-3fe5c20672794087b6d7950932f03b92?pvs=4#e0b936f1c6a3434a9440efee12c5a693):
* `/api/v1/rooms/{roomID}:create`
* `/api/v1/rooms/{roomID}:close`
* `/api/v1/rooms/{roomID}:delete`
* `/api/v1/conections:invalidate`
* `/api/v1/connections/rooms/{roomID}:invalidate`
* `/api/v1/connections/users/{userID}:invalidate`

> Note: The read endpoints are still TODO.

## Removed

Deleted legacy endpoints:

* legacy connect
* legacy create room
* migrate room
* forget room
* "internal" create room (see next section)

## Consolidated

* Moved all `authApiKey` enforcement into the `worker` entry point. This includes that for the `tail` websocket request.
* _Removed_ all `authApiKey` enforcement in the Durable Objects. (This is presumably redundant and adds a lot of boilerplate testing.) Now, any api-key-authenticated request that makes it past the worker is considered authenticated. The `authApiKey` is no longer needed in the Durable Objects.
* This means that there's no need for an "internal" (unauthed) version of the createRoom handler in the RoomDO.

## Refactored

* Refactored the validation logic to be chained instead of nested. This helps TypeScript infer the types better (no need for explicit type arguments on parameters) and is easier to read (less nesting).


#679
