### PR TITLE
feat(reflect-server): standardize API responses and errors

### DIFF
--- a/packages/reflect-server/src/server/api-response.ts
+++ b/packages/reflect-server/src/server/api-response.ts
@@ -1,8 +1,8 @@
 import type {ReadonlyJSONValue} from 'shared/src/json.js';
 import {ErrorWithResponse} from './errors.js';
 
-export type APIErrorCode = 404; // Add more as necessary.
-export type APIResource = 'rooms'; // Add more as necessary.
+export type APIErrorCode = 400 | 404 | 405 | 409; // Add more as necessary.
+export type APIResource = 'request' | 'rooms'; // Add more as necessary.
 
 export type APIErrorInfo = {
   code: APIErrorCode;
@@ -39,6 +39,10 @@ export class APIError extends ErrorWithResponse {
       result: null,
       error: this.#info,
     };
-    return new Response(JSON.stringify(apiResponse));
+    return new Response(JSON.stringify(apiResponse), {status: this.#info.code});
   }
+}
+
+export function roomNotFoundAPIError(roomID: string): APIError {
+  return new APIError(404, 'rooms', `Room "${roomID}" not found`);
 }

--- a/packages/reflect-server/src/server/errors.ts
+++ b/packages/reflect-server/src/server/errors.ts
@@ -6,6 +6,19 @@ export abstract class ErrorWithResponse extends Error {
   abstract response(): Response;
 }
 
+export class ErrorWithForwardedResponse extends ErrorWithResponse {
+  readonly #response: Response;
+
+  constructor(response: Response) {
+    super(`Forwarded response for ${response.url}: ${response.status}`);
+    this.#response = response;
+  }
+
+  response() {
+    return this.#response;
+  }
+}
+
 export class HttpError extends ErrorWithResponse {
   readonly #status: number;
 

--- a/packages/reflect-server/src/server/list.test.ts
+++ b/packages/reflect-server/src/server/list.test.ts
@@ -63,13 +63,15 @@ describe('parse ListOptions', () => {
       name: 'disallow both startKey and startAfterKey',
       queryString: 'maxResults=200&startKey=foo&startAfterKey=bar',
       maxMaxResults: 100,
-      error: 'Cannot specify both startKey and startAfterKey. Got object',
+      error:
+        '400: Cannot specify both startKey and startAfterKey. Got object (request)',
     },
     {
       name: 'bad maxResults',
       queryString: 'maxResults=not-a-number',
       maxMaxResults: 100,
-      error: 'Expected valid number at maxResults. Got "not-a-number"',
+      error:
+        '400: Expected valid number at maxResults. Got "not-a-number" (request)',
     },
   ];
 

--- a/packages/reflect-server/src/server/list.ts
+++ b/packages/reflect-server/src/server/list.ts
@@ -1,6 +1,6 @@
 import * as v from 'shared/src/valita.js';
 import type {ListOptions} from '../storage/storage.js';
-import {HttpError} from './errors.js';
+import {APIError} from './api-response.js';
 
 const numericString = v.string().chain(str => {
   try {
@@ -32,7 +32,7 @@ function queryStringToObj<T>(queryString: string, schema: v.Type<T>): T {
   try {
     return v.parse(queryObj, schema, 'passthrough');
   } catch (e) {
-    throw new HttpError(400, (e as Error).message);
+    throw new APIError(400, 'request', (e as Error).message);
   }
 }
 


### PR DESCRIPTION
Standardize the successful and failure responses of all API endpoints to follow those of the [Reflect API Design Guidelines](https://github.com/rocicorp/mono/pull/new/d-llama/standardize-api-errors-and-responses):

```ts
type Response<T> =
| { 
    result: T;
    error: null;
  }
| { 
    result: null;
    error: {
      code: number;  // Equivalent HTTP error code
      resource: string;  // The resource type associated with the error
      message: string;  // Human readable message
    };
 };
```

All HTTP status codes remain the same. However, `4xx` responses now contain a JSON body with the aforementioned schema to provide details on source of the error. In this manner, a `404` for a misspelled URL can be distinguished from a `404` for a request to a non-existent room.

Additionally, all write commands also return a JSON body, with the result being an empty object for now.

```ts
{
  result: {},
  error: null,
}
```

In addition to providing a schema-driven mechanism for determining success vs failure, this affords the option of adding additional information to the response later.

Code-wise, this is accomplished by making the write endpoints return `void`, with the option of changing it to return a `ReadonlyJSONValue` like read methods, and surfacing errors with exceptions. 