### PR TITLE
chore(reflect-server): Rename presence state key

### DIFF
--- a/packages/reflect-server/src/process/process-frame.test.ts
+++ b/packages/reflect-server/src/process/process-frame.test.ts
@@ -949,9 +949,9 @@ describe('processFrame', () => {
     {
       name: '1 mutation, 2 clients. 1 client should be garbage collected',
       initialUserValues: {
-        '-/c/c1/a': userValue('aa', startVersion),
-        '-/c/c2/b': userValue('bb', startVersion),
-        '-/c/c2/c': userValue('cc', startVersion, true),
+        '-/p/c1/a': userValue('aa', startVersion),
+        '-/p/c2/b': userValue('bb', startVersion),
+        '-/p/c2/c': userValue('cc', startVersion, true),
       },
       pendingMutations: [
         pendingMutation({
@@ -995,17 +995,17 @@ describe('processFrame', () => {
             cookie: startVersion + 2,
             lastMutationIDChanges: {},
             presence: [],
-            patch: [{op: 'del', key: '-/c/c2/b'}],
+            patch: [{op: 'del', key: '-/p/c2/b'}],
             timestamp: undefined,
           },
         },
       ],
       expectedUserValues: new Map([
         ['foo', userValue('bar', startVersion + 1)],
-        ['-/c/c1/a', userValue('aa', startVersion)],
-        ['-/c/c2/b', userValue('bb', startVersion + 2, true)],
+        ['-/p/c1/a', userValue('aa', startVersion)],
+        ['-/p/c2/b', userValue('bb', startVersion + 2, true)],
         // The next one was already deleted so no update to startVersion
-        ['-/c/c2/c', userValue('cc', startVersion, true)],
+        ['-/p/c2/c', userValue('cc', startVersion, true)],
       ]),
       expectedClientRecords: new Map([
         ['c1', clientRecord('cg1', startVersion + 2, 2, startVersion + 1)],
@@ -1018,10 +1018,10 @@ describe('processFrame', () => {
     {
       name: '1 mutation, 3 clients. 1 client should be garbage collected. 1 got disconnected',
       initialUserValues: {
-        '-/c/c1/a': userValue('aa', startVersion),
-        '-/c/c2/b': userValue('bb', startVersion),
-        '-/c/c2/c': userValue('cc', startVersion, true),
-        '-/c/c3/d': userValue('dd', startVersion),
+        '-/p/c1/a': userValue('aa', startVersion),
+        '-/p/c2/b': userValue('bb', startVersion),
+        '-/p/c2/c': userValue('cc', startVersion, true),
+        '-/p/c3/d': userValue('dd', startVersion),
       },
       pendingMutations: [
         pendingMutation({
@@ -1066,7 +1066,7 @@ describe('processFrame', () => {
             cookie: startVersion + 2,
             lastMutationIDChanges: {},
             presence: [],
-            patch: [{op: 'del', key: '-/c/c2/b'}],
+            patch: [{op: 'del', key: '-/p/c2/b'}],
             timestamp: undefined,
           },
         },
@@ -1090,11 +1090,11 @@ describe('processFrame', () => {
       ],
       expectedUserValues: new Map([
         ['foo', userValue('bar', startVersion + 1)],
-        ['-/c/c1/a', userValue('aa', startVersion)],
-        ['-/c/c2/b', userValue('bb', startVersion + 2, true)],
+        ['-/p/c1/a', userValue('aa', startVersion)],
+        ['-/p/c2/b', userValue('bb', startVersion + 2, true)],
         // The next one was already deleted so no update to startVersion
-        ['-/c/c2/c', userValue('cc', startVersion, true)],
-        ['-/c/c3/d', userValue('dd', startVersion)],
+        ['-/p/c2/c', userValue('cc', startVersion, true)],
+        ['-/p/c3/d', userValue('dd', startVersion)],
         ['test-disconnected-c3', userValue(true, startVersion + 3)],
       ]),
       expectedClientRecords: new Map([
@@ -1110,9 +1110,9 @@ describe('processFrame', () => {
     {
       name: '0 mutations, 2 clients. 1 client should be garbage collected',
       initialUserValues: {
-        '-/c/c1/a': userValue('aa', startVersion),
-        '-/c/c2/b': userValue('bb', startVersion),
-        '-/c/c2/c': userValue('cc', startVersion, true),
+        '-/p/c1/a': userValue('aa', startVersion),
+        '-/p/c2/b': userValue('bb', startVersion),
+        '-/p/c2/c': userValue('cc', startVersion, true),
       },
       pendingMutations: [],
       numPendingMutationsToProcess: 0,
@@ -1130,16 +1130,16 @@ describe('processFrame', () => {
             cookie: startVersion + 1,
             lastMutationIDChanges: {},
             presence: [],
-            patch: [{op: 'del', key: '-/c/c2/b'}],
+            patch: [{op: 'del', key: '-/p/c2/b'}],
             timestamp: undefined,
           },
         },
       ],
       expectedUserValues: new Map([
-        ['-/c/c1/a', userValue('aa', startVersion)],
-        ['-/c/c2/b', userValue('bb', startVersion + 1, true)],
+        ['-/p/c1/a', userValue('aa', startVersion)],
+        ['-/p/c2/b', userValue('bb', startVersion + 1, true)],
         // The next one was already deleted so no update to startVersion
-        ['-/c/c2/c', userValue('cc', startVersion, true)],
+        ['-/p/c2/c', userValue('cc', startVersion, true)],
       ]),
       expectedClientRecords: new Map([
         ['c1', clientRecord('cg1', startVersion + 1, 1, startVersion)],
@@ -1154,9 +1154,9 @@ describe('processFrame', () => {
       name: '0 mutations, 2 clients. No gc because it is turned off',
       shouldGCClients: false,
       initialUserValues: {
-        '-/c/c1/a': userValue('aa', startVersion),
-        '-/c/c2/b': userValue('bb', startVersion),
-        '-/c/c2/c': userValue('cc', startVersion, true),
+        '-/p/c1/a': userValue('aa', startVersion),
+        '-/p/c2/b': userValue('bb', startVersion),
+        '-/p/c2/c': userValue('cc', startVersion, true),
       },
       pendingMutations: [],
       numPendingMutationsToProcess: 0,
@@ -1168,9 +1168,9 @@ describe('processFrame', () => {
       storedConnectedClients: ['c1'],
       expectedPokes: [],
       expectedUserValues: new Map([
-        ['-/c/c1/a', userValue('aa', startVersion)],
-        ['-/c/c2/b', userValue('bb', startVersion)],
-        ['-/c/c2/c', userValue('cc', startVersion, true)],
+        ['-/p/c1/a', userValue('aa', startVersion)],
+        ['-/p/c2/b', userValue('bb', startVersion)],
+        ['-/p/c2/c', userValue('cc', startVersion, true)],
       ]),
       expectedClientRecords: new Map([
         ['c1', clientRecord('cg1', null, 1, 1)],

--- a/packages/reflect-server/src/server/client-gc.test.ts
+++ b/packages/reflect-server/src/server/client-gc.test.ts
@@ -64,18 +64,18 @@ describe('collectOldUserSpaceClientKeys', () => {
 
     //  This test does not care about the lastSeen or the version
     await setUserEntries(cache, version, {
-      '-/c/client-a': 1,
-      '-/c/client-a/': 2,
-      '-/c/client-a/more': 3,
-      '-/c/client-b': 4,
-      '-/c/client-b/': 5,
-      '-/c/client-b/more': 6,
-      '-/c/client-c': 7,
-      '-/c/client-c/': 8,
-      '-/c/client-c/more': 9,
-      '-/c/client-d': 10,
-      '-/c/client-d/': 11,
-      '-/c/client-d/more': 12,
+      '-/p/client-a': 1,
+      '-/p/client-a/': 2,
+      '-/p/client-a/more': 3,
+      '-/p/client-b': 4,
+      '-/p/client-b/': 5,
+      '-/p/client-b/more': 6,
+      '-/p/client-c': 7,
+      '-/p/client-c/': 8,
+      '-/p/client-c/more': 9,
+      '-/p/client-d': 10,
+      '-/p/client-d/': 11,
+      '-/p/client-d/more': 12,
     });
     await cache.flush();
 
@@ -91,62 +91,62 @@ describe('collectOldUserSpaceClientKeys', () => {
     const allEntries = await storage.list({}, jsonSchema);
     expect(allEntries).toMatchInlineSnapshot(`
 Map {
-  "user/-/c/client-a" => {
+  "user/-/p/client-a" => {
     "deleted": true,
     "value": 1,
     "version": 2,
   },
-  "user/-/c/client-a/" => {
+  "user/-/p/client-a/" => {
     "deleted": true,
     "value": 2,
     "version": 2,
   },
-  "user/-/c/client-a/more" => {
+  "user/-/p/client-a/more" => {
     "deleted": true,
     "value": 3,
     "version": 2,
   },
-  "user/-/c/client-b" => {
+  "user/-/p/client-b" => {
     "deleted": false,
     "value": 4,
     "version": 1,
   },
-  "user/-/c/client-b/" => {
+  "user/-/p/client-b/" => {
     "deleted": false,
     "value": 5,
     "version": 1,
   },
-  "user/-/c/client-b/more" => {
+  "user/-/p/client-b/more" => {
     "deleted": false,
     "value": 6,
     "version": 1,
   },
-  "user/-/c/client-c" => {
+  "user/-/p/client-c" => {
     "deleted": true,
     "value": 7,
     "version": 2,
   },
-  "user/-/c/client-c/" => {
+  "user/-/p/client-c/" => {
     "deleted": true,
     "value": 8,
     "version": 2,
   },
-  "user/-/c/client-c/more" => {
+  "user/-/p/client-c/more" => {
     "deleted": true,
     "value": 9,
     "version": 2,
   },
-  "user/-/c/client-d" => {
+  "user/-/p/client-d" => {
     "deleted": false,
     "value": 10,
     "version": 1,
   },
-  "user/-/c/client-d/" => {
+  "user/-/p/client-d/" => {
     "deleted": false,
     "value": 11,
     "version": 1,
   },
-  "user/-/c/client-d/more" => {
+  "user/-/p/client-d/more" => {
     "deleted": false,
     "value": 12,
     "version": 1,
@@ -166,12 +166,12 @@ Map {
 
     //  This test does not care about the lastSeen or the version
     await setUserEntries(cache, version, {
-      '-/c/client-a': 1,
-      '-/c/client-b': 2,
-      '-/c/client-c': 3,
+      '-/p/client-a': 1,
+      '-/p/client-b': 2,
+      '-/p/client-c': 3,
     });
     await putUserValue(
-      '-/c/client-a',
+      '-/p/client-a',
       {
         deleted: true,
         value: 1,
@@ -184,17 +184,17 @@ Map {
       const allEntries = await storage.list({}, jsonSchema);
       expect(allEntries).toMatchInlineSnapshot(`
 Map {
-  "user/-/c/client-a" => {
+  "user/-/p/client-a" => {
     "deleted": true,
     "value": 1,
     "version": 2,
   },
-  "user/-/c/client-b" => {
+  "user/-/p/client-b" => {
     "deleted": false,
     "value": 2,
     "version": 2,
   },
-  "user/-/c/client-c" => {
+  "user/-/p/client-c" => {
     "deleted": false,
     "value": 3,
     "version": 2,
@@ -215,17 +215,17 @@ Map {
     const allEntries = await storage.list({}, jsonSchema);
     expect(allEntries).toMatchInlineSnapshot(`
 Map {
-  "user/-/c/client-a" => {
+  "user/-/p/client-a" => {
     "deleted": true,
     "value": 1,
     "version": 2,
   },
-  "user/-/c/client-b" => {
+  "user/-/p/client-b" => {
     "deleted": false,
     "value": 2,
     "version": 2,
   },
-  "user/-/c/client-c" => {
+  "user/-/p/client-c" => {
     "deleted": true,
     "value": 3,
     "version": 3,
@@ -276,14 +276,14 @@ Map {
 
     await putVersion(version, storage);
     await setUserEntries(storage, version, {
-      '-/c/client-a': 1,
-      '-/c/client-a/more': 2,
-      '-/c/client-b': 3,
-      '-/c/client-b/more': 4,
-      '-/c/client-c': 5,
-      '-/c/client-c/more': 6,
-      '-/c/client-d': 7,
-      '-/c/client-d/more': 8,
+      '-/p/client-a': 1,
+      '-/p/client-a/more': 2,
+      '-/p/client-b': 3,
+      '-/p/client-b/more': 4,
+      '-/p/client-c': 5,
+      '-/p/client-c/more': 6,
+      '-/p/client-d': 7,
+      '-/p/client-d/more': 8,
     });
     await setLastSeenEntries(storage, {
       'client-a': 1000,
@@ -331,42 +331,42 @@ Map {
     "client-a",
     "client-c",
   ],
-  "user/-/c/client-a" => {
+  "user/-/p/client-a" => {
     "deleted": false,
     "value": 1,
     "version": 1,
   },
-  "user/-/c/client-a/more" => {
+  "user/-/p/client-a/more" => {
     "deleted": false,
     "value": 2,
     "version": 1,
   },
-  "user/-/c/client-b" => {
+  "user/-/p/client-b" => {
     "deleted": true,
     "value": 3,
     "version": 2,
   },
-  "user/-/c/client-b/more" => {
+  "user/-/p/client-b/more" => {
     "deleted": true,
     "value": 4,
     "version": 2,
   },
-  "user/-/c/client-c" => {
+  "user/-/p/client-c" => {
     "deleted": false,
     "value": 5,
     "version": 1,
   },
-  "user/-/c/client-c/more" => {
+  "user/-/p/client-c/more" => {
     "deleted": false,
     "value": 6,
     "version": 1,
   },
-  "user/-/c/client-d" => {
+  "user/-/p/client-d" => {
     "deleted": false,
     "value": 7,
     "version": 1,
   },
-  "user/-/c/client-d/more" => {
+  "user/-/p/client-d/more" => {
     "deleted": false,
     "value": 8,
     "version": 1,
@@ -455,14 +455,14 @@ Map {
       'client-d': 1500, // different from previous test, so it gets collected
     });
     await setUserEntries(storage, version, {
-      '-/c/client-a': 1,
-      '-/c/client-a/more': 2,
-      '-/c/client-b': 3,
-      '-/c/client-b/more': 4,
-      '-/c/client-c': 5,
-      '-/c/client-c/more': 6,
-      '-/c/client-d': 7,
-      '-/c/client-d/more': 8,
+      '-/p/client-a': 1,
+      '-/p/client-a/more': 2,
+      '-/p/client-b': 3,
+      '-/p/client-b/more': 4,
+      '-/p/client-c': 5,
+      '-/p/client-c/more': 6,
+      '-/p/client-d': 7,
+      '-/p/client-d/more': 8,
     });
     await putConnectedClients(connectedClients, storage);
     await storage.flush();
@@ -515,42 +515,42 @@ Map {
     "client-a",
     "client-c",
   ],
-  "user/-/c/client-a" => {
+  "user/-/p/client-a" => {
     "deleted": false,
     "value": 1,
     "version": 1,
   },
-  "user/-/c/client-a/more" => {
+  "user/-/p/client-a/more" => {
     "deleted": false,
     "value": 2,
     "version": 1,
   },
-  "user/-/c/client-b" => {
+  "user/-/p/client-b" => {
     "deleted": false,
     "value": 3,
     "version": 1,
   },
-  "user/-/c/client-b/more" => {
+  "user/-/p/client-b/more" => {
     "deleted": false,
     "value": 4,
     "version": 1,
   },
-  "user/-/c/client-c" => {
+  "user/-/p/client-c" => {
     "deleted": false,
     "value": 5,
     "version": 1,
   },
-  "user/-/c/client-c/more" => {
+  "user/-/p/client-c/more" => {
     "deleted": false,
     "value": 6,
     "version": 1,
   },
-  "user/-/c/client-d" => {
+  "user/-/p/client-d" => {
     "deleted": true,
     "value": 7,
     "version": 2,
   },
-  "user/-/c/client-d/more" => {
+  "user/-/p/client-d/more" => {
     "deleted": true,
     "value": 8,
     "version": 2,

--- a/packages/reflect-server/src/server/client-gc.ts
+++ b/packages/reflect-server/src/server/client-gc.ts
@@ -23,7 +23,7 @@ export const CLIENT_GC_FREQUENCY = 10 * 1000;
 export const GC_MAX_AGE = 2 * 7 * 24 * 60 * 60 * 1000;
 
 function clientGCSpaceUserKey(clientID: string): string {
-  return `-/c/${clientID}`;
+  return `-/p/${clientID}`;
 }
 
 async function updateLastSeenForClient(
@@ -134,7 +134,7 @@ export async function collectOldUserSpaceClientKeys(
   clientsToCollect: string[],
   nextVersion: number,
 ): Promise<void> {
-  // Delete all the keys starting with '-/c/${clientID}' for all old clients.
+  // Delete all the keys starting with '-/p/${clientID}' for all old clients.
   const ps: Promise<unknown>[] = [];
   for (const clientID of clientsToCollect) {
     for await (const [key, {value, deleted}] of storage.scan(


### PR DESCRIPTION
The feature name we settled on is called "presence state" and therefore it makes more sense to use `-/p/${clientID}` as the key name instead of `-/c/${clientID}`.