### PR TITLE
feat(mirror-server): support "Authorization: Basic <app-key>" authentication

### DIFF
--- a/mirror/mirror-server/src/functions/app/tail.handler.ts
+++ b/mirror/mirror-server/src/functions/app/tail.handler.ts
@@ -23,7 +23,7 @@ import {
 } from '../../secrets/index.js';
 import {
   appAuthorization,
-  tokenAuthentication,
+  authorizationHeader,
   userAuthorization,
 } from '../validators/auth.js';
 import {getDataOrFail} from '../validators/data.js';
@@ -38,7 +38,7 @@ export const tail = (
 ) =>
   onRequest(
     validateRequest(tailRequestSchema)
-      .validate(tokenAuthentication(auth))
+      .validate(authorizationHeader(firestore, auth))
       .validate(userAgentVersion())
       .validate(userAuthorization())
       .validate(appAuthorization(firestore))

--- a/mirror/mirror-server/src/functions/keys/verify.ts
+++ b/mirror/mirror-server/src/functions/keys/verify.ts
@@ -1,0 +1,28 @@
+import type {Firestore, QueryDocumentSnapshot} from 'firebase-admin/firestore';
+import {HttpsError} from 'firebase-functions/v2/https';
+import {
+  APP_KEY_COLLECTION_ID,
+  appKeyDataConverter,
+  type AppKey,
+} from 'mirror-schema/src/app-key.js';
+
+export async function verifyKey(
+  firestore: Firestore,
+  key: string,
+): Promise<QueryDocumentSnapshot<AppKey>> {
+  const query = await firestore
+    .collectionGroup(APP_KEY_COLLECTION_ID)
+    .withConverter(appKeyDataConverter)
+    .where('value', '==', key)
+    .get();
+  if (query.size === 0) {
+    throw new HttpsError('permission-denied', `Invalid key`);
+  }
+  if (query.size > 1) {
+    throw new HttpsError(
+      'failed-precondition',
+      `Multiple keys matched.`, // Should never happen (unless random is broken), but fail to be safe.
+    );
+  }
+  return query.docs[0];
+}

--- a/mirror/mirror-server/src/functions/room/tail.handler.ts
+++ b/mirror/mirror-server/src/functions/room/tail.handler.ts
@@ -16,7 +16,7 @@ import {SecretsCache, SecretsClient} from '../../secrets/index.js';
 import {REFLECT_API_KEY, decryptSecrets} from '../app/secrets.js';
 import {
   appAuthorization,
-  tokenAuthentication,
+  authorizationHeader,
   userAuthorization,
 } from '../validators/auth.js';
 import {getDataOrFail} from '../validators/data.js';
@@ -31,7 +31,7 @@ export const tail = (
 ) =>
   onRequest(
     validateRequest(roomTailRequestSchema)
-      .validate(tokenAuthentication(auth))
+      .validate(authorizationHeader(firestore, auth))
       .validate(userAgentVersion())
       .validate(userAuthorization())
       .validate(appAuthorization(firestore))

--- a/mirror/mirror-server/src/functions/token/create.function.ts
+++ b/mirror/mirror-server/src/functions/token/create.function.ts
@@ -1,40 +1,19 @@
 import type {Auth} from 'firebase-admin/auth';
 import type {Firestore} from 'firebase-admin/firestore';
 import {logger} from 'firebase-functions';
-import {HttpsError} from 'firebase-functions/v2/https';
 import {
   createTokenRequestSchema,
   createTokenResponseSchema,
 } from 'mirror-protocol/src/token.js';
-import {
-  APP_KEY_COLLECTION_ID,
-  appKeyDataConverter,
-} from 'mirror-schema/src/app-key.js';
+import {verifyKey} from '../keys/verify.js';
 import {validateSchema} from '../validators/schema.js';
 
 export const create = (firestore: Firestore, auth: Auth) =>
   validateSchema(createTokenRequestSchema, createTokenResponseSchema).handle(
     async request => {
       const {key} = request;
-
-      const query = await firestore
-        .collectionGroup(APP_KEY_COLLECTION_ID)
-        .withConverter(appKeyDataConverter)
-        .where('value', '==', key)
-        .get();
-      if (query.size === 0) {
-        throw new HttpsError('permission-denied', `Invalid key`);
-      }
-      if (query.size > 1) {
-        throw new HttpsError(
-          'failed-precondition',
-          `Multiple keys matched.`, // Should never happen (unless random is broken), but fail to be safe.
-        );
-      }
-      const keyDoc = query.docs[0];
-      const {
-        ref: {path: keyPath},
-      } = keyDoc;
+      const keyDoc = await verifyKey(firestore, key);
+      const keyPath = keyDoc.ref.path;
       logger.info(`Creating custom token for "${keyPath}"`);
       // Note: While we could encode the key's permissions in custom claims of the token,
       // every key authentication looks up the key doc in order to potentially modify

--- a/mirror/mirror-server/src/functions/validators/https.test.ts
+++ b/mirror/mirror-server/src/functions/validators/https.test.ts
@@ -1,61 +1,139 @@
-import {test, jest, expect} from '@jest/globals';
+import {getMockReq, getMockRes} from '@jest-mock/express';
+import {afterAll, beforeAll, describe, expect, jest, test} from '@jest/globals';
+import {initializeApp} from 'firebase-admin/app';
+import type {Auth} from 'firebase-admin/auth';
+import {Timestamp, getFirestore} from 'firebase-admin/firestore';
 import {https} from 'firebase-functions/v2';
 import type {Request} from 'firebase-functions/v2/https';
 import {baseAppRequestFields} from 'mirror-protocol/src/app.js';
-import type {Auth} from 'firebase-admin/auth';
+import {
+  Permissions,
+  appKeyDataConverter,
+  appKeyPath,
+} from 'mirror-schema/src/app-key.js';
+import {appPath} from 'mirror-schema/src/deployment.js';
+import {setApp, setUser} from 'mirror-schema/src/test-helpers.js';
+import {userPath} from 'mirror-schema/src/user.js';
+import * as v from 'shared/src/valita.js';
 import {
   appAuthorization,
-  tokenAuthentication,
+  appOrKeyAuthorization,
+  authorizationHeader,
   userAuthorization,
+  userOrKeyAuthorization,
 } from './auth.js';
 import {validateRequest} from './schema.js';
-import * as v from 'shared/src/valita.js';
-import {fakeFirestore} from 'mirror-schema/src/test-helpers.js';
-import {getMockReq, getMockRes} from '@jest-mock/express';
-import {setUser, setApp} from 'mirror-schema/src/test-helpers.js';
 
 const testRequestSchema = v.object({
   ...baseAppRequestFields,
   foo: v.string(),
 });
 
-test('onRequestBuilder', async () => {
-  const auth = {
-    verifyIdToken: jest
-      .fn()
-      .mockImplementation(() => Promise.resolve({uid: 'foo'})),
-  };
-  const firestore = fakeFirestore();
-  const handler = validateRequest(testRequestSchema)
-    .validate(tokenAuthentication(auth as unknown as Auth))
-    .validate(userAuthorization())
-    .validate(appAuthorization(firestore))
-    .handle((req, ctx) => {
-      const {response} = ctx;
-      response.json({userID: req.requester.userID, appName: ctx.app.name});
-    });
-  const authenticatedFunction = https.onRequest(handler);
+describe('validators/https', () => {
+  initializeApp({projectId: 'https-validator-test'});
+  const firestore = getFirestore();
+  const USER_ID = 'foo';
+  const APP_ID = 'myApp';
+  const APP_KEY_NAME = 'bar-key';
 
-  await setUser(firestore, 'foo', 'foo@bar.com', 'bob', {fooTeam: 'admin'});
-  await setApp(firestore, 'myApp', {teamID: 'fooTeam', name: 'MyAppName'});
+  beforeAll(async () => {
+    await Promise.all([
+      setUser(firestore, USER_ID, 'foo@bar.com', 'bob', {fooTeam: 'admin'}),
+      setApp(firestore, APP_ID, {teamID: 'fooTeam', name: 'MyAppName'}),
+      firestore
+        .doc(appKeyPath(APP_ID, APP_KEY_NAME))
+        .withConverter(appKeyDataConverter)
+        .set({
+          value: 'super-secret-key-value',
+          permissions: {'app:publish': true} as Permissions,
+          created: Timestamp.now(),
+          lastUsed: null,
+        }),
+    ]);
+  });
 
-  const req = getMockReq({
-    body: {
-      requester: {
-        userID: 'foo',
-        userAgent: {type: 'reflect-cli', version: '0.0.1'},
+  afterAll(async () => {
+    const batch = firestore.batch();
+    batch.delete(firestore.doc(userPath(USER_ID)));
+    batch.delete(firestore.doc(appPath(APP_ID)));
+    batch.delete(firestore.doc(appKeyPath(APP_ID, APP_KEY_NAME)));
+    await batch.commit();
+  });
+
+  test('onRequestBuilder', async () => {
+    const auth = {
+      verifyIdToken: jest
+        .fn()
+        .mockImplementation(() => Promise.resolve({uid: 'foo'})),
+    };
+    const handler = validateRequest(testRequestSchema)
+      .validate(authorizationHeader(firestore, auth as unknown as Auth))
+      .validate(userAuthorization())
+      .validate(appAuthorization(firestore))
+      .handle((req, ctx) => {
+        const {response} = ctx;
+        response.json({userID: req.requester.userID, appName: ctx.app.name});
+      });
+    const authenticatedFunction = https.onRequest(handler);
+
+    const req = getMockReq({
+      body: {
+        requester: {
+          userID: 'foo',
+          userAgent: {type: 'reflect-cli', version: '0.0.1'},
+        },
+        foo: 'boo',
+        appID: 'myApp',
       },
-      foo: 'boo',
-      appID: 'myApp',
-    },
-    headers: {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      Authorization: 'Bearer this-is-the-encoded-token',
-    },
-  }) as unknown as Request;
-  const {res} = getMockRes();
+      headers: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        Authorization: 'Bearer this-is-the-encoded-token',
+      },
+    }) as unknown as Request;
+    const {res} = getMockRes();
 
-  await authenticatedFunction(req, res);
-  expect(auth.verifyIdToken).toBeCalledWith('this-is-the-encoded-token');
-  expect(res.json).toBeCalledWith({userID: 'foo', appName: 'MyAppName'});
+    await authenticatedFunction(req, res);
+    expect(auth.verifyIdToken).toBeCalledWith('this-is-the-encoded-token');
+    expect(res.json).toBeCalledWith({userID: 'foo', appName: 'MyAppName'});
+  });
+
+  test('basic authorization', async () => {
+    const auth = {
+      verifyIdToken: jest.fn().mockImplementation(() => {
+        throw new Error('should not be called');
+      }),
+    };
+    const handler = validateRequest(testRequestSchema)
+      .validate(authorizationHeader(firestore, auth as unknown as Auth))
+      .validate(userOrKeyAuthorization())
+      .validate(appOrKeyAuthorization(firestore, 'app:publish'))
+      .handle((req, ctx) => {
+        const {response} = ctx;
+        response.json({userID: req.requester.userID, appName: ctx.app.name});
+      });
+    const authenticatedFunction = https.onRequest(handler);
+
+    const req = getMockReq({
+      body: {
+        requester: {
+          userID: `apps/${APP_ID}/keys/${APP_KEY_NAME}`,
+          userAgent: {type: 'reflect-cli', version: '0.0.1'},
+        },
+        foo: 'boo',
+        appID: 'myApp',
+      },
+      headers: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        Authorization: 'Basic super-secret-key-value',
+      },
+    }) as unknown as Request;
+    const {res} = getMockRes();
+
+    await authenticatedFunction(req, res);
+    expect(auth.verifyIdToken).not.toBeCalled;
+    expect(res.json).toBeCalledWith({
+      userID: `apps/${APP_ID}/keys/${APP_KEY_NAME}`,
+      appName: 'MyAppName',
+    });
+  });
 });


### PR DESCRIPTION
Adds support for `Authorization: Basic <app-key>` [authentication](https://www.notion.so/replicache/Reflect-API-Design-Guidelines-9f7ddc01d3d34667ad2e4c278d610dfb?pvs=4#69e1763b4b82400ea32ca02e52640c1e) in the header validator logic.

This will not affect the only current use of the `authorization()` validator, tail, because it is not configured to support key-based authorization. It will be used in the validator chain of the forthcoming api handler.