### PR TITLE
feat(reflect-server): implement strict query-string/body parsing in API endpoints

### DIFF
--- a/packages/reflect-server/src/server/list.ts
+++ b/packages/reflect-server/src/server/list.ts
@@ -1,6 +1,5 @@
 import * as v from 'shared/src/valita.js';
 import type {ListOptions} from '../storage/storage.js';
-import {APIError} from './api-errors.js';
 
 const numericString = v.string().chain(str => {
   try {
@@ -14,7 +13,7 @@ const numericString = v.string().chain(str => {
   }
 });
 
-const listParamsSchema = v
+export const listParamsSchema = v
   .object({
     startKey: v.string().optional(),
     startAfterKey: v.string().optional(),
@@ -25,16 +24,7 @@ const listParamsSchema = v
     'Cannot specify both startKey and startAfterKey',
   );
 
-function queryStringToObj<T>(queryString: string, schema: v.Type<T>): T {
-  const queryObj = Object.fromEntries(
-    new URLSearchParams(queryString).entries(),
-  );
-  try {
-    return v.parse(queryObj, schema, 'passthrough');
-  } catch (e) {
-    throw new APIError(400, 'request', (e as Error).message);
-  }
-}
+export type ListParams = v.Infer<typeof listParamsSchema>;
 
 export type ListResults<T> = {
   results: T[];
@@ -48,14 +38,14 @@ export interface ListControl {
 }
 
 export function makeListControl(
-  queryString: string,
+  listParams: ListParams,
   maxMaxResults: number,
 ): ListControl {
   const {
     maxResults: requestedMaxResults = maxMaxResults,
     startKey = '',
     startAfterKey,
-  } = queryStringToObj(queryString, listParamsSchema);
+  } = listParams;
   const maxResults = Math.min(requestedMaxResults, maxMaxResults);
 
   return {

--- a/packages/reflect-server/src/server/router.test.ts
+++ b/packages/reflect-server/src/server/router.test.ts
@@ -4,7 +4,6 @@ import {assert} from 'shared/src/asserts.js';
 import type {JSONObject, ReadonlyJSONValue} from 'shared/src/json.js';
 import {must} from 'shared/src/must.js';
 import * as valita from 'shared/src/valita.js';
-import type {ListOptions} from '../storage/storage.js';
 import {createSilentLogContext} from '../util/test-utils.js';
 import {HttpError} from './errors.js';
 import {
@@ -14,8 +13,8 @@ import {
   body,
   checkAuthAPIKey,
   get,
-  listControl,
   post,
+  queryParams,
   requiredAuthAPIKey,
   roomID,
   urlVersion,
@@ -488,6 +487,97 @@ test('withUserID', async () => {
   }
 });
 
+test('withQueryParams', async () => {
+  type Case = {
+    schema: valita.Type<unknown>;
+    parsedURL: URLPatternURLPatternResult;
+    expected?: {result: {text: string; status: number}};
+    error?: APIErrorInfo;
+  };
+
+  const fooSchema = valita.object({foo: valita.string()});
+
+  const cases: Case[] = [
+    {
+      schema: valita.null(),
+      parsedURL: must(new URLPattern().exec('https://roci.dev/room/monkey')),
+      expected: {result: {text: 'query: null', status: 200}},
+    },
+    {
+      schema: valita.null(),
+      parsedURL: must(new URLPattern().exec('https://roci.dev/room/monkey?')),
+      expected: {result: {text: 'query: null', status: 200}},
+    },
+    {
+      schema: valita.null(),
+      parsedURL: must(
+        new URLPattern().exec('https://roci.dev/room/monkey?foo'),
+      ),
+      error: {
+        code: 400,
+        resource: 'request',
+        message: 'Unexpected query parameters',
+      },
+    },
+    {
+      schema: fooSchema,
+      parsedURL: must(new URLPattern().exec('https://roci.dev/room/monkey?')),
+      error: {
+        code: 400,
+        resource: 'request',
+        message: 'Query string error. Missing property foo',
+      },
+    },
+    {
+      schema: fooSchema,
+      parsedURL: must(
+        new URLPattern().exec('https://roci.dev/room/monkey?foo=bar'),
+      ),
+      expected: {result: {text: 'query: {"foo":"bar"}', status: 200}},
+    },
+    {
+      schema: fooSchema,
+      parsedURL: must(
+        new URLPattern().exec('https://roci.dev/room/monkey?foo=bar&baz=bonk'),
+      ),
+      error: {
+        code: 400,
+        resource: 'request',
+        message: 'Query string error. Unexpected property baz',
+      },
+    },
+  ];
+
+  for (const c of cases) {
+    const handler = get()
+      .with(queryParams(c.schema))
+      .handle(
+        ctx =>
+          new Response(`query: ${JSON.stringify(ctx.query)}`, {status: 200}),
+      );
+    const url = `https://roci.dev/`;
+    const request = new Request(url);
+    const ctx = {
+      parsedURL: c.parsedURL,
+      lc: createSilentLogContext(),
+    };
+
+    const response = await handler(ctx, request);
+    if (response.status === 200) {
+      const result = {
+        result: {status: response.status, text: await response.text()},
+      };
+      expect(result).toEqual(c.expected);
+    } else {
+      expect(response.status).toBe(c.error?.code);
+      expect(await response.json()).toEqual({
+        result: null,
+        error: c.error,
+      });
+    }
+  }
+});
+
 test('withBody', async () => {
   type Case = {
     body: JSONObject | undefined | string;
@@ -570,85 +660,83 @@ test('withBody', async () => {
   }
 });
 
-describe('withListControl', () => {
+describe('withNoBody', () => {
   type Case = {
-    queryString: string;
-    listOptions?: ListOptions;
+    body: string | null | undefined;
+    expected?: {text: string; status: number};
     error?: APIErrorInfo;
   };
 
   const cases: Case[] = [
     {
-      queryString: '',
-      listOptions: {start: {key: '', exclusive: false}, limit: 101},
+      body: undefined,
+      expected: {text: 'ok', status: 200},
     },
     {
-      queryString: 'startKey=foo',
-      listOptions: {start: {key: 'foo', exclusive: false}, limit: 101},
+      body: null,
+      expected: {text: 'ok', status: 200},
     },
     {
-      queryString: 'startAfterKey=bar',
-      listOptions: {start: {key: 'bar', exclusive: true}, limit: 101},
+      body: '', // As per the fetch spec, an empty body string is equivalent to no body.
+      expected: {text: 'ok', status: 200},
     },
     {
-      queryString: 'maxResults=10',
-      listOptions: {start: {key: '', exclusive: false}, limit: 11},
-    },
-    {
-      queryString: 'maxResults=90',
-      listOptions: {start: {key: '', exclusive: false}, limit: 91},
-    },
-    {
-      queryString: 'maxResults=200',
-      listOptions: {start: {key: '', exclusive: false}, limit: 101},
-    },
-    {
-      queryString: 'maxResults=90&startKey=bonk',
-      listOptions: {start: {key: 'bonk', exclusive: false}, limit: 91},
-    },
-    {
-      queryString: 'maxResults=not-a-number',
+      body: ' ',
       error: {
         code: 400,
         resource: 'request',
-        message: 'Expected valid number at maxResults. Got "not-a-number"',
+        message: 'Unexpected request body.',
       },
     },
     {
-      queryString: 'startKey=and&startAfterKey=not-allowed',
+      body: '{}',
       error: {
         code: 400,
         resource: 'request',
-        message: 'Cannot specify both startKey and startAfterKey. Got object',
+        message: 'Unexpected request body.',
+      },
+    },
+    {
+      body: '{"newParam":"should be rejected"}',
+      error: {
+        code: 400,
+        resource: 'request',
+        message: 'Unexpected request body.',
       },
     },
   ];
 
-  const handler = get()
-    .with(listControl(100))
-    .handleJSON(ctx => {
-      const {listControl} = ctx;
-      return listControl.getOptions();
+  const handler = post()
+    .with(body(valita.null()))
+    .handle(ctx => {
+      const {body} = ctx;
+      expect(body).toBe(null);
+      return new Response(`ok`, {status: 200});
     });
 
   for (const c of cases) {
-    test(c.queryString, async () => {
-      const url = `https://roci.dev/?${c.queryString}`;
-      const request = new Request(url);
+    test(`"${String(c.body)}"`, async () => {
+      const url = `https://roci.dev/`;
+      const request = new Request(url, {
+        method: 'post',
+        body: c.body ?? null,
+      });
       const ctx = {
         lc: createSilentLogContext(),
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        parsedURL: new URLPattern().exec(url)!,
+        parsedURL: new URLPattern().exec()!,
       };
 
       const response = await handler(ctx, request);
       if (response.status === 200) {
-        expect(await response.json()).toEqual(c.listOptions);
+        expect({status: response.status, text: await response.text()}).toEqual(
+          c.expected,
+        );
       } else {
         expect(response.status).toBe(c.error?.code);
         expect(await response.json()).toEqual({
-          error: c.error,
           result: null,
+          error: c.error,
         });
       }
     });


### PR DESCRIPTION
Make all API endpoints parse both the query-string and the request body, and reject requests in which either is unexpected. Similarly, for requests that do expect a query-string or body, parse the schema in "strict" mode to reject unknown parameters (even for the query string).

This allows the protocol to be safely extended with new fields / parameters by ensuring that servers with old versions will reject requests that contain unknown (new) parameters, as detailed in the [Extensibility](https://www.notion.so/replicache/Reflect-API-Design-Guidelines-9f7ddc01d3d34667ad2e4c278d610dfb?pvs=4#7476504a13734087a3eb9896861a8817) section of the Reflect API Design Guidelines. 