### PR TITLE
fix(reflect-server): allow metrics endpoint to accept both body and query params

### DIFF
--- a/packages/reflect-server/src/server/auth-do.ts
+++ b/packages/reflect-server/src/server/auth-do.ts
@@ -60,7 +60,7 @@ import {
 import {
   BaseContext,
   Router,
-  body,
+  bodyOnly,
   get,
   noInputParams,
   post,
@@ -219,7 +219,7 @@ export class BaseAuthDO implements DurableObject {
 
   #createRoom = post()
     .with(roomID())
-    .with(body(createRoomRequestSchema))
+    .with(bodyOnly(createRoomRequestSchema))
     .handleAPIResult((ctx, req) => {
       const {lc, body, roomID} = ctx;
       const {jurisdiction} = body;

--- a/packages/reflect-server/src/server/router.test.ts
+++ b/packages/reflect-server/src/server/router.test.ts
@@ -10,7 +10,7 @@ import {
   BaseContext,
   Handler,
   Router,
-  body,
+  bodyOnly,
   checkAuthAPIKey,
   get,
   post,
@@ -626,7 +626,7 @@ test('withBody', async () => {
 
   const userIdSchema = valita.object({userID: valita.string()});
   const handler = post()
-    .with(body(userIdSchema))
+    .with(bodyOnly(userIdSchema))
     .handle(ctx => {
       const {body} = ctx;
       const {userID} = body;
@@ -707,7 +707,7 @@ describe('withNoBody', () => {
   ];
 
   const handler = post()
-    .with(body(valita.null()))
+    .with(bodyOnly(valita.null()))
     .handle(ctx => {
       const {body} = ctx;
       expect(body).toBe(null);

--- a/packages/reflect-server/src/server/router.ts
+++ b/packages/reflect-server/src/server/router.ts
@@ -165,16 +165,16 @@ export function urlVersion<Context extends BaseContext>() {
   };
 }
 
-// Note: queryParams(), body(), and noInputParams() are mutually exclusive.
-// (Currently, no endpoints read both they query string and the request body, but
-//  if there need arises, inputParams() can be exported).
+// Note: queryParams(), bodyOnly(), and noInputParams() are mutually exclusive.
 export function queryParams<T, Context extends BaseContext>(
   schema: valita.Type<T>,
 ) {
   return inputParams<T, null, Context>(schema, valita.null());
 }
 
-export function body<T, Context extends BaseContext>(schema: valita.Type<T>) {
+export function bodyOnly<T, Context extends BaseContext>(
+  schema: valita.Type<T>,
+) {
   return inputParams<null, T, Context>(valita.null(), schema);
 }
 
@@ -191,6 +191,16 @@ function inputParams<Q, B, Context extends BaseContext>(
     const query = validateQuery(parsedURL, querySchema);
     const body = await validateBody(req, bodySchema);
     return {...ctx, query, body};
+  };
+}
+
+// TODO: Understand why reportMetrics needs both body and query params.
+export function bodyAndArbitraryQueryParams<T, Context extends BaseContext>(
+  schema: valita.Type<T>,
+) {
+  return async (ctx: Context, req: Request) => {
+    const body = await validateBody(req, schema);
+    return {...ctx, body};
   };
 }
 

--- a/packages/reflect-server/src/server/worker.ts
+++ b/packages/reflect-server/src/server/worker.ts
@@ -29,7 +29,7 @@ import {
   Handler,
   Router,
   WithLogContext,
-  body,
+  bodyAndArbitraryQueryParams,
   checkAuthAPIKey,
   get,
   post,
@@ -114,7 +114,7 @@ function registerRoutes(router: WorkerRouter) {
 //    handler: we want to be able to report metrics for a logged
 //    out user as well)
 const reportMetrics = post<WorkerContext>()
-  .with(body(reportMetricsSchema))
+  .with(bodyAndArbitraryQueryParams(reportMetricsSchema))
   .handle(async ctx => {
     const {lc, body, datadogMetricsOptions} = ctx;
 


### PR DESCRIPTION
Fixing in a hurry. Will fill in the testing gap next.