### PR TITLE
fix(mirror-server): properly pass query parameters in the API gateway

### DIFF
--- a/mirror/mirror-server/src/functions/api/apps.function.test.ts
+++ b/mirror/mirror-server/src/functions/api/apps.function.test.ts
@@ -300,7 +300,9 @@ describe('api-apps', () => {
       const url = `https://api.reflect-server.net${c.path}${c.query ?? ''}`;
       const request = {
         method: c.method,
-        path: c.path,
+        path: c.path.includes('?')
+          ? c.path.substring(0, c.path.indexOf('?'))
+          : c.path,
         url,
         originalUrl: url,
         headers: {authorization: `Basic ${c.token}`},

--- a/mirror/mirror-server/src/functions/api/apps.function.ts
+++ b/mirror/mirror-server/src/functions/api/apps.function.ts
@@ -60,7 +60,7 @@ export const apps =
       const workerURL = `https://${hostname}${workerPath}${query}`;
 
       logger.info(`Proxying request: ${request.method} ${workerURL}`);
-      const resp = await fetch(`https://${hostname}${workerPath}`, {
+      const resp = await fetch(workerURL, {
         method: request.method,
         headers: {[API_KEY_HEADER_NAME]: reflectAPIKey},
         body: request.rawBody,


### PR DESCRIPTION
Also fixed the test that to verify it by properly simulating the behavior of an express `Request`. 