### PR TITLE
chore(replicache): No EventTarget in noop broadcast channel.

### DIFF
--- a/packages/replicache/src/broadcast-channel.ts
+++ b/packages/replicache/src/broadcast-channel.ts
@@ -1,24 +1,36 @@
-class NoopBroadcastChannel extends EventTarget implements BroadcastChannel {
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import {notImplemented} from 'shared/src/asserts.js';
+
+class NoopBroadcastChannel implements BroadcastChannel {
   readonly name: string;
 
-  onmessage:
-    | ((this: BroadcastChannel, ev: MessageEvent<unknown>) => unknown)
-    | null = null;
+  onmessage: ((this: BroadcastChannel, ev: MessageEvent<any>) => any) | null =
+    null;
 
   onmessageerror:
-    | ((this: BroadcastChannel, ev: MessageEvent<unknown>) => unknown)
+    | ((this: BroadcastChannel, ev: MessageEvent<any>) => any)
     | null = null;
 
   constructor(name: string) {
-    super();
     this.name = name;
+  }
+
+  addEventListener(): void {
+    notImplemented();
+  }
+  removeEventListener(): void {
+    notImplemented();
+  }
+  dispatchEvent(): boolean {
+    notImplemented();
   }
 
   close(): void {
     // noop
   }
 
-  postMessage(_message: unknown): void {
+  postMessage(_message: any): void {
     // noop
   }
 }


### PR DESCRIPTION
We used to `extend EventTarget` in the noop broadcast channel, but that's not available in React Native. Instead, we just use a plain object and add the `addEventListener` and `dispatchEvent` methods ourselves.