### PR TITLE
!feat(reflect-server): remove null fields from APIResponse type

### DIFF
--- a/mirror/mirror-server/src/functions/api/apps.function.test.ts
+++ b/mirror/mirror-server/src/functions/api/apps.function.test.ts
@@ -135,7 +135,7 @@ describe('api-apps', () => {
     query?: string;
     token: string;
     workerUrl?: string;
-    result: APIResponse<ReadonlyJSONValue>;
+    response: APIResponse<ReadonlyJSONValue>;
     pretest?: () => Promise<void>;
   };
   const cases: Case[] = [
@@ -144,9 +144,8 @@ describe('api-apps', () => {
       path: `/v1/apps/${APP_ID}/rooms/yo?dont=forgets&the=query`,
       token: APP_KEY_VALUE,
       workerUrl: `https://my-app-team.reflect-server.bonk/api/v1/rooms/yo?dont=forgets&the=query`,
-      result: {
+      response: {
         result: {room: 'yo'},
-        error: null,
       },
     },
     {
@@ -154,9 +153,8 @@ describe('api-apps', () => {
       path: `/v1/apps/${APP_ID}/connections/all:invalidate`,
       token: APP_KEY_VALUE,
       workerUrl: `https://my-app-team.reflect-server.bonk/api/v1/connections/all:invalidate`,
-      result: {
+      response: {
         result: {},
-        error: null,
       },
     },
     {
@@ -164,13 +162,12 @@ describe('api-apps', () => {
       method: 'POST',
       path: `/v1/apps/${APP_ID}/rooms`,
       token: APP_KEY_VALUE,
-      result: {
+      response: {
         error: {
           code: 405,
           resource: 'request',
           message: 'Unsupported method',
         },
-        result: null,
       },
     },
     {
@@ -178,13 +175,12 @@ describe('api-apps', () => {
       method: 'GET',
       path: `/v1/apps/${APP_ID}/connections/all:invalidate`,
       token: APP_KEY_VALUE,
-      result: {
+      response: {
         error: {
           code: 405,
           resource: 'request',
           message: 'Unsupported method',
         },
-        result: null,
       },
     },
     {
@@ -192,13 +188,12 @@ describe('api-apps', () => {
       method: 'PUT',
       path: `/v1/apps/${APP_ID}/connections/all:invalidate`,
       token: APP_KEY_VALUE,
-      result: {
+      response: {
         error: {
           code: 405,
           resource: 'request',
           message: 'Unsupported method "PUT"',
         },
-        result: null,
       },
     },
     {
@@ -206,13 +201,12 @@ describe('api-apps', () => {
       method: 'GET',
       path: `/v1/apps/${APP_ID}/rooms/yo`,
       token: 'bad header with lots of spaces',
-      result: {
+      response: {
         error: {
           code: 401 as APIErrorCode,
           resource: 'request',
           message: 'Invalid Authorization header',
         },
-        result: null,
       },
     },
     {
@@ -220,13 +214,12 @@ describe('api-apps', () => {
       method: 'GET',
       path: `/v1/apps/${APP_ID}/rooms/yo`,
       token: 'bad-token',
-      result: {
+      response: {
         error: {
           code: 403 as APIErrorCode,
           resource: 'request',
           message: 'Invalid key',
         },
-        result: null,
       },
     },
     {
@@ -234,13 +227,12 @@ describe('api-apps', () => {
       method: 'GET',
       path: `/v1/apps/${APP_ID}/connections/yo`,
       token: APP_KEY_VALUE,
-      result: {
+      response: {
         error: {
           code: 404,
           resource: 'request',
           message: 'Unknown or unreadable resource "connections"',
         },
-        result: null,
       },
     },
     {
@@ -248,13 +240,12 @@ describe('api-apps', () => {
       method: 'POST',
       path: `/v1/apps/${APP_ID}/connections/yo:severe`,
       token: APP_KEY_VALUE,
-      result: {
+      response: {
         error: {
           code: 404,
           resource: 'request',
           message: 'Invalid resource or command "connections:severe"',
         },
-        result: null,
       },
     },
     {
@@ -262,14 +253,13 @@ describe('api-apps', () => {
       method: 'POST',
       path: `/v1/apps/${APP_ID}/rooms/foo:delete`,
       token: APP_KEY_VALUE,
-      result: {
+      response: {
         error: {
           code: 403 as APIErrorCode,
           resource: 'request',
           message:
             'Key "my-app-key" has not been granted "rooms:delete" permission',
         },
-        result: null,
       },
     },
     {
@@ -277,13 +267,12 @@ describe('api-apps', () => {
       method: 'GET',
       path: `/v1/apps/wrong-app/rooms/yo`,
       token: APP_KEY_VALUE,
-      result: {
+      response: {
         error: {
           code: 403 as APIErrorCode,
           resource: 'request',
           message: 'Key "my-app-key" is not authorized for app wrong-app',
         },
-        result: null,
       },
     },
     {
@@ -291,7 +280,7 @@ describe('api-apps', () => {
       method: 'GET',
       path: `/v1/apps/${APP_ID}/rooms/yo`,
       token: APP_KEY_VALUE,
-      result: {
+      response: {
         error: {
           code: 400,
           resource: 'request',
@@ -299,7 +288,6 @@ describe('api-apps', () => {
             'App "za app" is at server version 0.38.202401080000 which does not support the REST API.\n' +
             'Update the app to @rocicorp/reflect@latest and re-publish.',
         },
-        result: null,
       },
       pretest: async () => {
         await firestore
@@ -315,13 +303,12 @@ describe('api-apps', () => {
       method: 'GET',
       path: `/v1/apps/${APP_ID}/rooms/yo`,
       token: APP_KEY_VALUE,
-      result: {
+      response: {
         error: {
           code: 400,
           resource: 'request',
           message: 'App "za app" is not running',
         },
-        result: null,
       },
       pretest: async () => {
         await firestore
@@ -372,7 +359,7 @@ describe('api-apps', () => {
       await appsFunction(request, res);
 
       if (c.workerUrl) {
-        expect(res.send).toBeCalledWith(JSON.stringify(c.result));
+        expect(res.send).toBeCalledWith(JSON.stringify(c.response));
         expect(fetchMocker.requests()).toEqual([[c.method, c.workerUrl]]);
         expect(fetchMocker.headers()).toEqual([
           {'x-reflect-api-key': 'the-reflect-api-key'},
@@ -380,7 +367,7 @@ describe('api-apps', () => {
         expect(fetchMocker.bodys()).toEqual([Buffer.from('buffer body ^_^')]);
       } else {
         expect(res.json).toBeCalled;
-        expect(res.json).toBeCalledWith(c.result);
+        expect(res.json).toBeCalledWith(c.response);
       }
     }),
   );

--- a/packages/reflect-server/src/server/auth-do.test.ts
+++ b/packages/reflect-server/src/server/auth-do.test.ts
@@ -124,19 +124,13 @@ async function expectSuccessfulAPIResponse(
   result: ReadonlyJSONValue = {},
 ) {
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    result,
-    error: null,
-  });
+  expect(await response.json()).toEqual({result});
   expect(response.headers.get('content-type')).toBe('application/json');
 }
 
 async function expectAPIErrorResponse(response: Response, error: APIErrorInfo) {
   expect(response.status).toBe(error.code);
-  expect(await response.json()).toEqual({
-    result: null,
-    error,
-  });
+  expect(await response.json()).toEqual({error});
   expect(response.headers.get('content-type')).toBe('application/json');
 }
 
@@ -247,7 +241,6 @@ test('createRoom allows slashes in roomIDs', async () => {
 
   response = await authDO.fetch(newRoomRecordsRequest());
   expect(await response.json()).toEqual({
-    error: null,
     result: {
       results: [
         {
@@ -265,7 +258,6 @@ test('createRoom allows slashes in roomIDs', async () => {
     newGetRoomRequest('https://teset.roci.dev/', TEST_API_KEY, '/'),
   );
   expect(await response.json()).toEqual({
-    error: null,
     result: {
       roomID: '/',
       jurisdiction: '',

--- a/packages/reflect-server/src/server/room-do.test.ts
+++ b/packages/reflect-server/src/server/room-do.test.ts
@@ -440,7 +440,6 @@ test('good, bad, invalid connect requests', async () => {
     expectedStatus: 405,
     expectedText: null,
     expectedJSON: {
-      result: null,
       error: {
         code: 405,
         resource: 'request',
@@ -497,7 +496,6 @@ describe('good, bad, invalid tail requests', () => {
       request: makeRequest({method: 'POST'}),
       expectedStatus: 405,
       expectedJSON: {
-        result: null,
         error: {
           code: 405,
           resource: 'request',

--- a/packages/reflect-server/src/server/router.test.ts
+++ b/packages/reflect-server/src/server/router.test.ts
@@ -76,7 +76,6 @@ test('Router', async () => {
       path: '/monkey/nuts',
       expectedResponseCode: 404,
       expectedResponseJSON: {
-        result: null,
         error: {
           code: 404,
           resource: 'request',
@@ -135,7 +134,6 @@ test('requireMethod', async () => {
       method: 'POST',
       expectedStatus: 405,
       expectedJSON: {
-        result: null,
         error: {
           code: 405,
           resource: 'request',
@@ -154,7 +152,6 @@ test('requireMethod', async () => {
       method: 'GET',
       expectedStatus: 405,
       expectedJSON: {
-        result: null,
         error: {
           code: 405,
           resource: 'request',
@@ -586,10 +583,7 @@ test('withQueryParams', async () => {
       expect(result).toEqual(c.expected);
     } else {
       expect(response.status).toBe(c.error?.code);
-      expect(await response.json()).toEqual({
-        result: null,
-        error: c.error,
-      });
+      expect(await response.json()).toEqual({error: c.error});
     }
   }
 });
@@ -679,10 +673,7 @@ test('withBody', async () => {
       );
     } else {
       expect(response.status).toBe(c.error?.code);
-      expect(await response.json()).toEqual({
-        result: null,
-        error: c.error,
-      });
+      expect(await response.json()).toEqual({error: c.error});
     }
   }
 });
@@ -762,10 +753,7 @@ describe('withNoBody', () => {
         );
       } else {
         expect(response.status).toBe(c.error?.code);
-        expect(await response.json()).toEqual({
-          result: null,
-          error: c.error,
-        });
+        expect(await response.json()).toEqual({error: c.error});
       }
     });
   }
@@ -848,10 +836,7 @@ test('handleAPIResult', async () => {
       lc: createSilentLogContext(),
     };
     const response = await handler(ctx, request);
-    expect(await response.json()).toEqual({
-      result: c.expected,
-      error: null,
-    });
+    expect(await response.json()).toEqual({result: c.expected});
   }
 });
 

--- a/packages/shared/src/api/responses.ts
+++ b/packages/shared/src/api/responses.ts
@@ -10,21 +10,15 @@ export type APIErrorInfo = {
 };
 
 export type APIResponse<T extends ReadonlyJSONValue> =
-  | {
-      result: T;
-      error: null;
-    }
-  | {
-      result: null;
-      error: APIErrorInfo;
-    };
+  | {result: T}
+  | {error: APIErrorInfo};
 
 export function makeAPIResponse<T extends ReadonlyJSONValue>(
   result: T,
 ): APIResponse<T> {
-  return {result, error: null};
+  return {result};
 }
 
 export function makeAPIError(error: APIErrorInfo): APIResponse<null> {
-  return {result: null, error};
+  return {error};
 }


### PR DESCRIPTION
Remove the null `error` field from a successful response, and the null `result` field from an erroneous response.
