### PR TITLE
fix(mirror-server): bump function timeout to 2 minutes

### DIFF
--- a/mirror/mirror-server/src/functions/app/auto-deploy.function.ts
+++ b/mirror/mirror-server/src/functions/app/auto-deploy.function.ts
@@ -1,5 +1,4 @@
 import {Timestamp, type Firestore} from 'firebase-admin/firestore';
-import {logger} from 'firebase-functions';
 import {onDocumentUpdated} from 'firebase-functions/v2/firestore';
 import {HttpsError} from 'firebase-functions/v2/https';
 import _ from 'lodash';
@@ -71,7 +70,6 @@ export async function checkForAutoDeployment(
     );
   }
 
-  logger.info(`Requesting ${autoDeploymentType}`, desiredSpec);
   await requestDeployment(
     firestore,
     appID,

--- a/mirror/mirror-server/src/functions/app/deploy.function.ts
+++ b/mirror/mirror-server/src/functions/app/deploy.function.ts
@@ -253,7 +253,7 @@ function deploymentErrorMessage(
   return {message, severity: 'ERROR'};
 }
 
-export function requestDeployment(
+export async function requestDeployment(
   firestore: Firestore,
   appID: string,
   data: Pick<Deployment, 'requesterID' | 'type' | 'spec'>,
@@ -263,7 +263,8 @@ export function requestDeployment(
   const appDocRef = firestore
     .doc(appPath(appID))
     .withConverter(appDataConverter);
-  return firestore.runTransaction(async tx => {
+  logger.debug(`Requesting ${data.type} for ${appID}`, data);
+  const path = await firestore.runTransaction(async tx => {
     for (let i = 0; i < 5; i++) {
       const deploymentID = newDeploymentID();
       const docRef = firestore
@@ -303,6 +304,8 @@ export function requestDeployment(
       'Failed to generate unused deployment ID',
     );
   });
+  logger.info(`Requested ${path}`);
+  return path;
 }
 
 const DEPLOYMENT_FAILURE_TIMEOUT_MS = 1000 * 60; // 1 minute.

--- a/mirror/mirror-server/src/functions/app/find-newest-matching-version.ts
+++ b/mirror/mirror-server/src/functions/app/find-newest-matching-version.ts
@@ -1,4 +1,5 @@
 import type {Firestore} from 'firebase-admin/firestore';
+import {logger} from 'firebase-functions';
 import {HttpsError} from 'firebase-functions/v2/https';
 import {
   SERVER_COLLECTION,
@@ -11,6 +12,7 @@ export async function findNewestMatchingVersion(
   serverVersionRange: Range,
   serverReleaseChannel: string,
 ): Promise<string> {
+  logger.debug(`Querying server versions for ${serverReleaseChannel} channel`);
   const versions = await firestore
     .collection(SERVER_COLLECTION)
     .withConverter(serverDataConverter)
@@ -24,6 +26,9 @@ export async function findNewestMatchingVersion(
   for (const doc of versions.docs) {
     const version = doc.id;
     if (serverVersionRange.test(version)) {
+      logger.log(
+        `Found matching version for ${serverVersionRange}: ${version}`,
+      );
       return version;
     }
   }

--- a/mirror/mirror-server/src/functions/app/publish.function.ts
+++ b/mirror/mirror-server/src/functions/app/publish.function.ts
@@ -1,6 +1,5 @@
 import type {Firestore} from 'firebase-admin/firestore';
 import type {Storage} from 'firebase-admin/storage';
-import {logger} from 'firebase-functions';
 import {HttpsError} from 'firebase-functions/v2/https';
 import {
   publishRequestSchema,
@@ -96,8 +95,6 @@ export const publish = (
         },
         serverReleaseChannel,
       );
-
-      logger.log(`Requested ${deploymentPath}`);
       return {deploymentPath, success: true};
     });
 
@@ -120,9 +117,6 @@ export async function computeDeploymentSpec(
     firestore,
     range,
     serverReleaseChannel,
-  );
-  logger.log(
-    `Found matching version for ${serverVersionRange}: ${serverVersion}`,
   );
 
   const {provider: providerID, name: appName, teamLabel} = app;

--- a/mirror/mirror-server/src/index.ts
+++ b/mirror/mirror-server/src/index.ts
@@ -28,6 +28,7 @@ initializeApp(appOptions);
 setGlobalOptions({
   serviceAccount: serviceAccountId,
   concurrency: 32, // https://github.com/rocicorp/mono/issues/1280
+  timeoutSeconds: 120,
 });
 
 // Cache the secrets manager client to amortize connection establishment time.


### PR DESCRIPTION
Bump the function timeout to 2 minutes, and add logging to better determine where time is spent when things take longer than expected.

Fixes #1345