### PR TITLE
Site title adjustment

### DIFF
--- a/apps/reflect.net/pages/index.tsx
+++ b/apps/reflect.net/pages/index.tsx
@@ -32,7 +32,7 @@ export default function Home() {
   return (
     <div className={styles.container}>
       <Head>
-        <title>Reflect: High-performance sync for multiplayer web apps</title>
+        <title>Reflect - High-performance sync for multiplayer web apps</title>
         <meta
           name="description"
           content="60FPS sync, automatic persistence, server authority, optional offline, fine-grained auth, and more..."


### PR DESCRIPTION
For some reason the colon in our title was preventing our site from appearing with the proper title, "Reflect"... instead it has been showing "reflect.net" This should fix it.