### PR TITLE
fix(mirror-server): fix app-create update key call

### DIFF
--- a/mirror/mirror-server/src/index.ts
+++ b/mirror/mirror-server/src/index.ts
@@ -63,7 +63,10 @@ export const api = {
 
 export const app = {
   create: https.onCall(
-    baseHttpsOptions,
+    {
+      ...baseHttpsOptions,
+      secrets: [INTERNAL_FUNCTION_SECRET_NAME],
+    },
     appFunctions.create(getFirestore(), secrets),
   ),
   publish: https.onCall(


### PR DESCRIPTION
Fix app-create's configuration to be able to call the internal `apiKeys-update` function.