### PR TITLE
feat(reflect-cli): Restart dev server on crash

### DIFF
--- a/mirror/reflect-cli/src/dev/miniflare-wrapper.ts
+++ b/mirror/reflect-cli/src/dev/miniflare-wrapper.ts
@@ -1,0 +1,127 @@
+import {resolver} from '@rocicorp/resolver';
+import {Miniflare, MiniflareOptions} from 'miniflare';
+import * as readline from 'node:readline';
+import color from 'picocolors';
+
+declare const TESTING: boolean;
+
+let readlineInstanceForTesting: readline.Interface | undefined;
+
+export function fakeCrashForTesting() {
+  if (TESTING) {
+    readlineInstanceForTesting?.emit('line', 'Segmentation fault');
+  }
+}
+
+/**
+ * This is a wrapper of Miniflare that looks for crashes and restarts the
+ * server. It detects crashes by looking at stderr output.
+ */
+export class MiniflareWrapper {
+  #mf: Miniflare;
+  readonly #options: MiniflareOptions;
+  #readyResolver = resolver<URL>();
+
+  constructor(options: MiniflareOptions) {
+    this.#options = {
+      ...options,
+      handleRuntimeStdio: (stdout, stderr) =>
+        this.#handleRuntimeStdio(stdout, stderr),
+    };
+    this.#mf = this.#createMiniflare();
+  }
+
+  dispose(): Promise<void> {
+    return this.#mf.dispose();
+  }
+
+  get ready(): Promise<URL> {
+    return this.#readyResolver.promise;
+  }
+
+  async restart() {
+    await this.#mf.dispose();
+    this.#mf = this.#createMiniflare();
+    await this.#mf.ready;
+  }
+
+  #createMiniflare() {
+    this.#readyResolver = resolver<URL>();
+    const mf = new Miniflare(this.#options);
+    mf.ready.then(
+      url => this.#readyResolver.resolve(url),
+      e => this.#readyResolver.reject(e),
+    );
+    return mf;
+  }
+
+  #handleRuntimeStdio(
+    stdout: NodeJS.ReadableStream,
+    stderr: NodeJS.ReadableStream,
+  ) {
+    readline.createInterface(stdout).on('line', data => console.log(data));
+    const rli = readline.createInterface(stderr);
+    rli.on('line', data => {
+      switch (classifyStdErrMessage(data)) {
+        case StdErrClassification.Debug:
+          console.log(data);
+          return;
+        case StdErrClassification.Crash:
+          console.error(color.red(data));
+          console.error(color.red('Detected server crash...'));
+          this.restart().catch(e => {
+            console.error('Failed to restart dev server', e);
+          });
+          return;
+        case StdErrClassification.Unknown:
+          console.error(color.red(data));
+          break;
+        case StdErrClassification.Silence:
+          break;
+      }
+    });
+
+    if (TESTING) {
+      readlineInstanceForTesting = rli;
+    }
+  }
+}
+const enum StdErrClassification {
+  Unknown,
+  Crash,
+  Debug,
+  Silence,
+}
+
+// Based on observed stderr as well as
+// https://github.com/cloudflare/workers-sdk/blob/main/packages/wrangler/src/dev/miniflare.ts#L449
+const classifications = new Map<string | RegExp, StdErrClassification>([
+  ['Segmentation fault', StdErrClassification.Crash],
+
+  [
+    'Not symbolizing stack traces because $LLVM_SYMBOLIZER is not set',
+    StdErrClassification.Debug,
+  ],
+
+  ['disconnected: worker_do_not_log;', StdErrClassification.Debug],
+
+  // Matches stack traces from workerd
+  //  - on unix: groups of 9 hex digits separated by spaces
+  //  - on windows: groups of 12 hex digits, or a single digit 0, separated by spaces
+  [/stack:( (0|[a-f\d]{4,})){3,}/, StdErrClassification.Silence],
+]);
+
+export function classifyStdErrMessage(message: string): StdErrClassification {
+  for (const [pattern, classification] of classifications) {
+    if (typeof pattern === 'string') {
+      if (message.includes(pattern)) {
+        return classification;
+      }
+    } else {
+      if (pattern.test(message)) {
+        return classification;
+      }
+    }
+  }
+  return StdErrClassification.Unknown;
+}

--- a/mirror/reflect-cli/src/dev/start-dev-server.test.ts
+++ b/mirror/reflect-cli/src/dev/start-dev-server.test.ts
@@ -1,0 +1,100 @@
+import {afterEach, expect, jest, test} from '@jest/globals';
+import getPort from 'get-port';
+import {sleep} from 'shared/src/sleep.js';
+import {MiniflareWrapper, fakeCrashForTesting} from './miniflare-wrapper.js';
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+function getCode(i: number) {
+  const encoder = new TextEncoder();
+  return encoder.encode(`
+  export default {
+    fetch() {
+      return new Response('${i}', {
+        headers: {'content-type': 'application/json'},
+      });
+    }
+  };
+`);
+}
+
+test('restart', async () => {
+  let i = 0;
+  const port = await getPort();
+  const mf = new MiniflareWrapper({
+    port,
+    modules: [
+      {
+        type: 'ESModule',
+        path: 'dummy.js',
+        get contents() {
+          return getCode(i++);
+        },
+      },
+    ],
+  });
+  const url = await mf.ready;
+
+  const resp = await fetch(url);
+  expect(await resp.json()).toBe(0);
+
+  await mf.restart();
+
+  {
+    const resp = await fetch(url);
+    expect(await resp.json()).toBe(1);
+  }
+
+  await mf.dispose();
+});
+
+test('induced fake crash', async () => {
+  let i = 0;
+
+  const log: unknown[] = [];
+  jest.spyOn(console, 'error').mockImplementation((...args) => log.push(args));
+
+  const port = await getPort();
+  const mf = new MiniflareWrapper({
+    port,
+    modules: [
+      {
+        type: 'ESModule',
+        path: 'dummy.js',
+        get contents() {
+          return getCode(i++);
+        },
+      },
+    ],
+  });
+  const url = await mf.ready;
+
+  const resp = await fetch(url);
+  expect(await resp.json()).toBe(0);
+
+  fakeCrashForTesting();
+
+  // Wait for stderr to propagate.
+  await sleep(10);
+
+  {
+    await mf.ready;
+    const resp = await fetch(url);
+    expect(await resp.json()).toBe(1);
+  }
+
+  expect(log).toMatchInlineSnapshot(`
+  [
+    [
+      "[31mSegmentation fault[39m",
+    ],
+    [
+      "[31mDetected server crash...[39m",
+    ],
+  ]
+  `);
+
+  await mf.dispose();
+});

--- a/mirror/reflect-cli/src/dev/start-dev-server.ts
+++ b/mirror/reflect-cli/src/dev/start-dev-server.ts
@@ -1,7 +1,6 @@
 import type {LogLevel} from '@rocicorp/logger';
 import type {OutputFile} from 'esbuild';
 import getPort from 'get-port';
-import {Miniflare} from 'miniflare';
 import {SERVER_VARIABLE_PREFIX} from 'mirror-schema/src/external/vars.js';
 import {nanoid} from 'nanoid';
 import * as path from 'node:path';
@@ -9,10 +8,11 @@ import {mustFindAppConfigRoot} from '../app-config.js';
 import {buildReflectServerContent} from '../compile.js';
 import {ErrorWrapper} from '../error.js';
 import {getScriptTemplate} from '../get-script-template.js';
+import {MiniflareWrapper} from './miniflare-wrapper.js';
 import {listDevVars} from './vars.js';
 
 /**
- * Returns a function that shuts down the dev server.
+ * To shut down the dev server, abort the passed in signal.
  */
 export async function startDevServer(
   code: OutputFile,
@@ -35,7 +35,7 @@ export async function startDevServer(
   );
 
   // Create a new Miniflare instance, starting a workerd server
-  const mf = new Miniflare({
+  const mf = new MiniflareWrapper({
     port,
     modules: [
       {

--- a/mirror/reflect-cli/tool/build.js
+++ b/mirror/reflect-cli/tool/build.js
@@ -35,6 +35,7 @@ async function main() {
     define: {
       REFLECT_VERSION: JSON.stringify(reflectVersion),
       REFLECT_CLI_NAME: JSON.stringify(reflectCliName),
+      TESTING: 'false',
     },
   });
 }

--- a/packages/shared/src/tool/jest-config.js
+++ b/packages/shared/src/tool/jest-config.js
@@ -36,6 +36,7 @@ export const jestConfig = {
   globals: {
     ['REFLECT_VERSION']: getReflectVersion(),
     ['REFLECT_CLI_NAME']: 'reflect-cli',
+    ['TESTING']: true,
   },
   // Disable prettier for inline snapshots since it is broken
   // https://github.com/jestjs/jest/issues/14305


### PR DESCRIPTION
We now filter stderr coming from `workerd`. If it looks like the message is a crash, we restart the dev server.

https://www.notion.so/replicache/Fix-symbolizer-error-in-Reflect-feba8ebf1fa9489db9ee30c1feeca069