### PR TITLE
fix(replicache): Do not reject send promises

### DIFF
--- a/packages/replicache/src/connection-loop.test.ts
+++ b/packages/replicache/src/connection-loop.test.ts
@@ -731,7 +731,7 @@ test('Send promise', async () => {
   expect(err?.error).to.equal(expectedError);
 });
 
-suite('Send when closed should reject', () => {
+suite('Send when closed should resolve with error', () => {
   for (const now of [true, false] as const) {
     test(`now = ${now}`, async () => {
       loop = new ConnectionLoop({
@@ -753,7 +753,7 @@ suite('Send when closed should reject', () => {
         loop.close();
       }
 
-      const err = await sendP.catch(e => e);
+      const err = await sendP;
       expect(err?.error).instanceOf(Error);
       expect((err?.error as Error).message).equal('Closed');
     });

--- a/packages/replicache/src/connection-loop.ts
+++ b/packages/replicache/src/connection-loop.ts
@@ -91,7 +91,7 @@ export class ConnectionLoop {
    */
   async send(now: boolean): Promise<undefined | {error: unknown}> {
     if (this.#closed) {
-      throw closeError();
+      return {error: closeError()};
     }
     this.#sendCounter++;
     this.#delegate.debug?.('send', now);

--- a/packages/replicache/src/replicache.ts
+++ b/packages/replicache/src/replicache.ts
@@ -1702,7 +1702,8 @@ export class Replicache<MD extends MutatorDefs = {}> {
         // Update this after the commit in case the commit fails.
         this.#lastMutationID = lastMutationID;
 
-        this.#pushConnectionLoop.send(false).catch(noop);
+        // Send is not supposed to reject
+        void this.#pushConnectionLoop.send(false);
         await this.#checkChange(ref, diffs);
         void this.#schedulePersist();
         return {result, ref};


### PR DESCRIPTION
Instead we resolve the promise with an object with an error field if there was an error. We then extract and throw this error in the public pull/push methods.