### PR TITLE
chore(replicache): Simplify connection loop slightly

### DIFF
--- a/packages/replicache/src/connection-loop-delegates.ts
+++ b/packages/replicache/src/connection-loop-delegates.ts
@@ -1,24 +1,17 @@
 import type {ConnectionLoopDelegate} from './connection-loop.js';
-import type {OptionalLogger} from '@rocicorp/logger';
 import type {Replicache} from './replicache.js';
 
-class ConnectionLoopDelegateImpl implements OptionalLogger {
+class ConnectionLoopDelegateImpl {
   readonly rep: Replicache;
   readonly invokeSend: () => Promise<boolean>;
-  readonly logger: OptionalLogger;
 
   // TODO: Remove the ability to have more than one concurrent connection and update tests.
   // Bug: https://github.com/rocicorp/replicache-internal/issues/303
   readonly maxConnections = 1;
 
-  constructor(
-    rep: Replicache,
-    invokeSend: () => Promise<boolean>,
-    logger: OptionalLogger,
-  ) {
+  constructor(rep: Replicache, invokeSend: () => Promise<boolean>) {
     this.rep = rep;
     this.invokeSend = invokeSend;
-    this.logger = logger;
   }
 
   get maxDelayMs(): number {
@@ -27,10 +20,6 @@ class ConnectionLoopDelegateImpl implements OptionalLogger {
 
   get minDelayMs(): number {
     return this.rep.requestOptions.minDelayMs;
-  }
-
-  get debug(): ((...args: unknown[]) => void) | undefined {
-    return this.logger.debug;
   }
 }
 

--- a/packages/replicache/src/connection-loop.test.ts
+++ b/packages/replicache/src/connection-loop.test.ts
@@ -1,3 +1,4 @@
+import {LogContext} from '@rocicorp/logger';
 import {expect} from 'chai';
 import {sleep} from 'shared/src/sleep.js';
 import {SinonFakeTimers, useFakeTimers} from 'sinon';
@@ -80,7 +81,7 @@ function createLoop(
     },
   };
 
-  return (loop = new ConnectionLoop(delegate));
+  return (loop = new ConnectionLoop(new LogContext(), delegate));
 }
 
 test('basic sequential by awaiting', async () => {
@@ -604,7 +605,7 @@ test('watchdog timer again', async () => {
 test('mutate minDelayMs', async () => {
   let minDelayMs = 50;
   const log: number[] = [];
-  loop = new ConnectionLoop({
+  loop = new ConnectionLoop(new LogContext(), {
     invokeSend() {
       log.push(Date.now());
       return promiseTrue;
@@ -646,7 +647,7 @@ test('mutate minDelayMs', async () => {
 test('Send now', async () => {
   const log: number[] = [];
   let nextInvokeSendResult: boolean = true;
-  loop = new ConnectionLoop({
+  loop = new ConnectionLoop(new LogContext(), {
     invokeSend() {
       log.push(Date.now());
       return Promise.resolve(nextInvokeSendResult);
@@ -704,7 +705,7 @@ test('Send now', async () => {
 
 test('Send promise', async () => {
   let nextInvokeSendResult: boolean | Error = true;
-  loop = new ConnectionLoop({
+  loop = new ConnectionLoop(new LogContext(), {
     // eslint-disable-next-line require-await
     async invokeSend() {
       if (nextInvokeSendResult instanceof Error) {
@@ -734,7 +735,7 @@ test('Send promise', async () => {
 suite('Send when closed should resolve with error', () => {
   for (const now of [true, false] as const) {
     test(`now = ${now}`, async () => {
-      loop = new ConnectionLoop({
+      loop = new ConnectionLoop(new LogContext(), {
         invokeSend: () => Promise.resolve(true),
         debounceDelay: 100,
         minDelayMs: 200,

--- a/packages/replicache/src/replicache.ts
+++ b/packages/replicache/src/replicache.ts
@@ -581,19 +581,13 @@ export class Replicache<MD extends MutatorDefs = {}> {
     this.#requestOptions = {maxDelayMs, minDelayMs};
 
     this.#pullConnectionLoop = new ConnectionLoop(
-      new PullDelegate(
-        this,
-        () => this.#invokePull(),
-        this.#lc.withContext('PULL'),
-      ),
+      this.#lc.withContext('PULL'),
+      new PullDelegate(this, () => this.#invokePull()),
     );
 
     this.#pushConnectionLoop = new ConnectionLoop(
-      new PushDelegate(
-        this,
-        () => this.#invokePush(),
-        this.#lc.withContext('PUSH'),
-      ),
+      this.#lc.withContext('PUSH'),
+      new PushDelegate(this, () => this.#invokePush()),
     );
 
     this.mutate = this.#registerMutators(mutators);


### PR DESCRIPTION
Move the LogContext into a "normal" property
instead of making the delegate an OptionalLogger.