### PR TITLE
chore(reflect): Client tombstone and userID

### DIFF
--- a/packages/reflect-server/src/ff/fast-forward.test.ts
+++ b/packages/reflect-server/src/ff/fast-forward.test.ts
@@ -1,10 +1,10 @@
-import {test, expect} from '@jest/globals';
+import {expect, test} from '@jest/globals';
+import {fastForwardRoom} from '../ff/fast-forward.js';
 import {DurableStorage} from '../storage/durable-storage.js';
 import type {ClientPoke} from '../types/client-poke.js';
 import {ClientRecordMap, putClientRecord} from '../types/client-record.js';
 import type {ClientID} from '../types/client-state.js';
-import {putUserValue, UserValue} from '../types/user-value.js';
-import {fastForwardRoom} from '../ff/fast-forward.js';
+import {UserValue, putUserValue} from '../types/user-value.js';
 import {createSilentLogContext, mockMathRandom} from '../util/test-utils.js';
 
 const {roomDO} = getMiniflareBindings();
@@ -36,6 +36,7 @@ test('fastForward', async () => {
             baseCookie: 0,
             clientGroupID: 'cg1',
             lastMutationIDVersion: 1,
+            userID: 'u1',
           },
         ],
       ]),
@@ -53,6 +54,7 @@ test('fastForward', async () => {
             baseCookie: 10,
             clientGroupID: 'cg1',
             lastMutationIDVersion: 20,
+            userID: 'u1',
           },
         ],
       ]),
@@ -82,6 +84,7 @@ test('fastForward', async () => {
             clientGroupID: 'cg1',
             lastMutationID: 1,
             lastMutationIDVersion: 20,
+            userID: 'u1',
           },
         ],
       ]),
@@ -108,6 +111,7 @@ test('fastForward', async () => {
             baseCookie: 40,
             clientGroupID: 'cg1',
             lastMutationIDVersion: 41,
+            userID: 'u1',
           },
         ],
       ]),
@@ -153,6 +157,7 @@ test('fastForward', async () => {
             baseCookie: 40,
             clientGroupID: 'cg1',
             lastMutationIDVersion: 41,
+            userID: 'u1',
           },
         ],
         [
@@ -162,6 +167,7 @@ test('fastForward', async () => {
             baseCookie: 41,
             clientGroupID: 'cg1',
             lastMutationIDVersion: CURRENT_VERSION_FOR_TEST,
+            userID: 'u1',
           },
         ],
       ]),
@@ -223,6 +229,7 @@ test('fastForward', async () => {
             baseCookie: 40,
             clientGroupID: 'cg1',
             lastMutationIDVersion: 41,
+            userID: 'u1',
           },
         ],
         [
@@ -232,6 +239,7 @@ test('fastForward', async () => {
             baseCookie: 41,
             clientGroupID: 'cg1',
             lastMutationIDVersion: CURRENT_VERSION_FOR_TEST,
+            userID: 'u1',
           },
         ],
       ]),
@@ -271,6 +279,7 @@ test('fastForward', async () => {
             baseCookie: 30,
             clientGroupID: 'cg1',
             lastMutationIDVersion: 41,
+            userID: 'u1',
           },
         ],
         [
@@ -280,6 +289,7 @@ test('fastForward', async () => {
             baseCookie: 30,
             clientGroupID: 'cg1',
             lastMutationIDVersion: 31,
+            userID: 'u1',
           },
         ],
         [
@@ -289,6 +299,7 @@ test('fastForward', async () => {
             baseCookie: 40,
             clientGroupID: 'cg1',
             lastMutationIDVersion: 31,
+            userID: 'u1',
           },
         ],
         [
@@ -298,6 +309,7 @@ test('fastForward', async () => {
             baseCookie: 30,
             clientGroupID: 'cg2',
             lastMutationIDVersion: 40,
+            userID: 'u2',
           },
         ],
         [
@@ -307,6 +319,7 @@ test('fastForward', async () => {
             baseCookie: 40,
             clientGroupID: 'cg2',
             lastMutationIDVersion: 40,
+            userID: 'u2',
           },
         ],
       ]),
@@ -386,6 +399,7 @@ test('fastForward', async () => {
             baseCookie: 40,
             clientGroupID: 'cg1',
             lastMutationIDVersion: 41,
+            userID: 'u1',
           },
         ],
         [
@@ -395,6 +409,7 @@ test('fastForward', async () => {
             baseCookie: 41,
             clientGroupID: 'cg1',
             lastMutationIDVersion: CURRENT_VERSION_FOR_TEST,
+            userID: 'u1',
           },
         ],
         [
@@ -404,6 +419,7 @@ test('fastForward', async () => {
             baseCookie: 40,
             clientGroupID: 'cg2',
             lastMutationIDVersion: 41,
+            userID: 'u2',
           },
         ],
         [
@@ -413,6 +429,7 @@ test('fastForward', async () => {
             baseCookie: 41,
             clientGroupID: 'cg2',
             lastMutationIDVersion: CURRENT_VERSION_FOR_TEST,
+            userID: 'u2',
           },
         ],
       ]),

--- a/packages/reflect-server/src/process/process-frame.ts
+++ b/packages/reflect-server/src/process/process-frame.ts
@@ -102,7 +102,9 @@ export async function processFrame(
     const gcCache = new EntryCache(cache);
     await collectClients(
       lc,
+      env,
       gcCache,
+      closeHandler,
       new Set(clientIDs),
       now,
       GC_MAX_AGE,

--- a/packages/reflect-server/src/process/process-mutation.test.ts
+++ b/packages/reflect-server/src/process/process-mutation.test.ts
@@ -26,7 +26,8 @@ import {
 const {roomDO} = getMiniflareBindings();
 const id = roomDO.newUniqueId();
 const version = 2;
-const auth: AuthData = {userID: 'testUser1', foo: 'bar'};
+const userID = 'testUser1';
+const auth: AuthData = {userID, foo: 'bar'};
 const env: Env = {env: 'baby'};
 
 test('processMutation', async () => {
@@ -61,6 +62,7 @@ test('processMutation', async () => {
         baseCookie: null,
         lastMutationID: 1,
         lastMutationIDVersion: 1,
+        userID,
       }),
       pendingMutation: pendingMutation({
         clientID: 'c1',
@@ -85,6 +87,7 @@ test('processMutation', async () => {
         baseCookie: null,
         lastMutationID: 1,
         lastMutationIDVersion: 1,
+        userID,
       }),
       pendingMutation: pendingMutation({
         clientID: 'c1',
@@ -109,6 +112,7 @@ test('processMutation', async () => {
         baseCookie: null,
         lastMutationID: 1,
         lastMutationIDVersion: 1,
+        userID,
       }),
       pendingMutation: pendingMutation({
         clientID: 'c1',
@@ -134,6 +138,7 @@ test('processMutation', async () => {
         baseCookie: null,
         lastMutationID: 1,
         lastMutationIDVersion: 1,
+        userID,
       }),
       pendingMutation: pendingMutation({
         clientID: 'c1',
@@ -159,6 +164,7 @@ test('processMutation', async () => {
         baseCookie: null,
         lastMutationID: 1,
         lastMutationIDVersion: 1,
+        userID,
       }),
       pendingMutation: pendingMutation({
         clientID: 'c1',

--- a/packages/reflect-server/src/server/client-gc.ts
+++ b/packages/reflect-server/src/server/client-gc.ts
@@ -70,7 +70,9 @@ export function updateLastSeen(
 
 export async function collectClients(
   lc: LogContext,
+  env: Env,
   storage: Storage,
+  closeHandler: CloseHandler,
   connectedClients: Set<ClientID>,
   now: number,
   maxAge: number,
@@ -93,13 +95,24 @@ export async function collectClients(
   );
 
   if (clientsToCollect.length > 0) {
-    await delClientRecords(clientsToCollect, storage);
+    for (const clientID of clientsToCollect) {
+      await callCloseHandler(
+        lc,
+        clientID,
+        env,
+        closeHandler,
+        nextVersion,
+        storage,
+      );
+    }
+
     await collectOldUserSpaceClientKeys(
       lc,
       storage,
       clientsToCollect,
       nextVersion,
     );
+    await delClientRecords(clientsToCollect, storage);
 
     await putVersion(nextVersion, storage);
   }

--- a/packages/reflect-server/src/server/close-beacon.ts
+++ b/packages/reflect-server/src/server/close-beacon.ts
@@ -40,11 +40,10 @@ export async function closeBeacon(
 
   const storedConnectedClients = await getConnectedClients(storage);
   if (storedConnectedClients.has(clientID)) {
-    const clientRecord = must(await getClientRecord(clientID, storage));
     await putClientRecord(
       clientID,
       {
-        ...clientRecord,
+        ...existingRecord,
         lastMutationIDAtClose: lastMutationID,
       },
       storage,

--- a/packages/reflect-server/src/server/push.test.ts
+++ b/packages/reflect-server/src/server/push.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, test} from '@jest/globals';
 import {LogContext} from '@rocicorp/logger';
-import type {Mutation} from 'reflect-protocol';
+import type {Mutation, PushBody} from 'reflect-protocol';
 import {handlePush} from '../server/push.js';
 import {DurableStorage} from '../storage/durable-storage.js';
 import {
@@ -274,6 +274,7 @@ describe('handlePush', () => {
             lastMutationID: 2,
             lastMutationIDVersion: 1,
             lastSeen: 50,
+            userID: 'u1',
           }),
         ],
       ]),
@@ -312,6 +313,7 @@ describe('handlePush', () => {
             lastMutationID: 2,
             lastMutationIDVersion: 1,
             lastSeen: 50,
+            userID: 'u1',
           }),
         ],
         [
@@ -322,6 +324,7 @@ describe('handlePush', () => {
             lastMutationID: 0,
             lastMutationIDVersion: null,
             lastSeen: 50,
+            userID: 'u1',
           }),
         ],
       ]),
@@ -1045,7 +1048,7 @@ describe('handlePush', () => {
       expect(await listClientRecords(storage)).toEqual(c.clientRecords);
 
       const requestID = randomID();
-      const push = {
+      const push: PushBody = {
         clientGroupID,
         mutations: c.mutations,
         pushVersion: 1,

--- a/packages/reflect-server/src/server/push.ts
+++ b/packages/reflect-server/src/server/push.ts
@@ -222,6 +222,7 @@ export async function handlePush(
     });
     inserts.push([insertIndex, mWithNormalizedTimestamp]);
   }
+
   await Promise.all(
     newClientIDs.map(clientID =>
       putClientRecord(
@@ -232,6 +233,7 @@ export async function handlePush(
           lastMutationID: 0,
           lastMutationIDVersion: null,
           lastSeen: now(),
+          userID: client.auth.userID,
         },
         storage,
       ),

--- a/packages/reflect-server/src/server/room-do-close-beacon.test.ts
+++ b/packages/reflect-server/src/server/room-do-close-beacon.test.ts
@@ -92,6 +92,7 @@ describe('Close beacon behavior', () => {
           lastMutationID: 0,
           lastMutationIDVersion: null,
           lastSeen: 0,
+          userID,
         },
       },
     },
@@ -143,6 +144,7 @@ describe('Close beacon behavior', () => {
           lastMutationID: 2,
           lastMutationIDVersion: null,
           lastSeen: 0,
+          userID,
         },
       },
     },
@@ -158,6 +160,7 @@ describe('Close beacon behavior', () => {
           lastMutationID: 3,
           lastMutationIDVersion: null,
           lastSeen: 0,
+          userID,
         },
       },
     },
@@ -173,6 +176,7 @@ describe('Close beacon behavior', () => {
           lastMutationID: 2,
           lastMutationIDVersion: null,
           lastSeen: 0,
+          userID,
         },
       },
     },
@@ -213,6 +217,7 @@ describe('Close beacon behavior', () => {
           lastMutationIDVersion: null,
           lastSeen: 0,
           lastMutationIDAtClose: 10,
+          userID,
         },
       },
     },
@@ -311,6 +316,7 @@ describe('Close beacon behavior', () => {
         lastMutationID: c.storedLastMutationID,
         lastMutationIDVersion: null,
         lastSeen: 0,
+        userID,
       };
       await putClientRecord(clientID, clientRecord, storage);
 

--- a/packages/reflect-server/src/util/test-utils.ts
+++ b/packages/reflect-server/src/util/test-utils.ts
@@ -139,12 +139,14 @@ export function clientRecord({
   lastMutationID = 1,
   lastMutationIDVersion = 1,
   lastSeen = 1000,
+  userID = 'testUser1',
 }: {
   clientGroupID: ClientGroupID;
   baseCookie?: NullableVersion | undefined;
   lastMutationID?: number | undefined;
   lastMutationIDVersion?: NullableVersion | undefined;
   lastSeen?: number | undefined;
+  userID?: string | undefined;
 }): ClientRecord {
   return {
     clientGroupID,
@@ -152,6 +154,7 @@ export function clientRecord({
     lastMutationID,
     lastMutationIDVersion,
     lastSeen,
+    userID,
   };
 }
 


### PR DESCRIPTION
The ClientRecord now gets a userID. This is the userID that created the client. When we connect we verify that the userID is the same as the one that created the client.

When we delete a client we remove the entry under `clientV1/` but we also write a `clientTombstone/${clientID}` entry.

This also fixes an issue where the closeHandler was not being called when the client was deleted because it was too old.

Followup to #1418