### PR TITLE
feat(replicache): Delay pull in hidden tabs

### DIFF
--- a/packages/replicache/src/replicache.ts
+++ b/packages/replicache/src/replicache.ts
@@ -9,6 +9,7 @@ import {consoleLogSink, LogContext, TeeLogSink} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
 import {AbortError} from 'shared/src/abort-error.js';
 import {assert, assertNotUndefined} from 'shared/src/asserts.js';
+import {getDocumentVisibilityWatcher} from 'shared/src/document-visible.js';
 import {getDocument} from 'shared/src/get-document.js';
 import type {JSONValue, ReadonlyJSONValue} from 'shared/src/json.js';
 import {must} from 'shared/src/must.js';
@@ -580,9 +581,16 @@ export class Replicache<MD extends MutatorDefs = {}> {
       requestOptions;
     this.#requestOptions = {maxDelayMs, minDelayMs};
 
+    const visibilityWatcher = getDocumentVisibilityWatcher(
+      getDocument(),
+      0,
+      this.#closeAbortController.signal,
+    );
+
     this.#pullConnectionLoop = new ConnectionLoop(
       this.#lc.withContext('PULL'),
       new PullDelegate(this, () => this.#invokePull()),
+      visibilityWatcher,
     );
 
     this.#pushConnectionLoop = new ConnectionLoop(

--- a/packages/shared/src/document-visible.ts
+++ b/packages/shared/src/document-visible.ts
@@ -15,7 +15,7 @@ export function getDocumentVisibilityWatcher(
     : new DocumentVisibilityWatcherNoDoc();
 }
 
-interface DocumentVisibilityWatcher {
+export interface DocumentVisibilityWatcher {
   readonly visibilityState: DocumentVisibilityState;
   waitForVisible(): Promise<unknown>;
   waitForHidden(): Promise<unknown>;
@@ -28,7 +28,7 @@ class DocumentVisibilityWatcherImpl implements DocumentVisibilityWatcher {
 
   // This trails doc.visibilityState by hiddenIntervalMS when being hidden. This
   // is because we want to wait for the tab to be hidden for a while before
-  // disconnecting.
+  // considering as hidden.
   visibilityState: DocumentVisibilityState;
 
   readonly #promises = new Set<{


### PR DESCRIPTION
If a tab is hidden (document.visibilityState === 'hidden'), we fall back to the `pullInterval` when `pull` is called. If `pull({now: true}` is called we ignore the visibility state and pull immediately.