### PR TITLE
chore(reflect): closeHandler to onClientDelete

### DIFF
--- a/apps/reflect.net/demo/alive/orchestrator-model.ts
+++ b/apps/reflect.net/demo/alive/orchestrator-model.ts
@@ -157,11 +157,11 @@ export async function alive(tx: WriteTransaction) {
   }
 }
 
-export async function closeHandler(tx: WriteTransaction) {
+export async function onClientDelete(tx: WriteTransaction) {
   const assignment = await getClientRoomAssignment(tx, tx.clientID);
   if (assignment !== undefined) {
     console.log(
-      'closeHandler: removing assignment due to unload',
+      'onClientDelete: removing assignment due to unload',
       JSON.stringify(assignment),
     );
     await Promise.all([

--- a/apps/reflect.net/demo/worker/index.ts
+++ b/apps/reflect.net/demo/worker/index.ts
@@ -9,7 +9,7 @@ import {
   newOptionsBuilder,
 } from '@rocicorp/reflect/server';
 import {ensureNotBotController} from '../alive/client-model';
-import {closeHandler} from '../alive/orchestrator-model';
+import {onClientDelete} from '../alive/orchestrator-model';
 import {mutators} from '../shared/mutators';
 
 console.log(version);
@@ -45,7 +45,7 @@ const {
       console.log('disconnectHandler: deleting old client', tx.clientID);
       await ensureNotBotController(tx);
     },
-    closeHandler,
+    onClientDelete,
     maxMutationsPerTurn: 100,
   }))
     .add(logLevel(DEFAULT_LOG_LEVEL))

--- a/packages/reflect-server/src/process/process-disconnects.ts
+++ b/packages/reflect-server/src/process/process-disconnects.ts
@@ -3,8 +3,8 @@ import type {Version} from 'reflect-protocol';
 import type {Env} from 'reflect-shared/src/types.js';
 import type {PendingMutation} from 'replicache';
 import {equals as setEquals} from 'shared/src/set-utils.js';
+import type {ClientDeleteHandler} from '../server/client-delete-handler.js';
 import {collectClientIfDeleted, updateLastSeen} from '../server/client-gc.js';
-import type {CloseHandler} from '../server/close-handler.js';
 import type {DisconnectHandler} from '../server/disconnect.js';
 import {EntryCache} from '../storage/entry-cache.js';
 import {
@@ -23,7 +23,7 @@ export async function processDisconnects(
   lc: LogContext,
   env: Env,
   disconnectHandler: DisconnectHandler,
-  closeHandler: CloseHandler,
+  clientDeleteHandler: ClientDeleteHandler,
   connectedClients: ClientID[],
   pendingMutations: PendingMutation[],
   numPendingMutationsProcessed: number,
@@ -84,7 +84,7 @@ export async function processDisconnects(
         lc,
         env,
         clientID,
-        closeHandler,
+        clientDeleteHandler,
         storage,
         nextVersion,
       );

--- a/packages/reflect-server/src/process/process-frame.test.ts
+++ b/packages/reflect-server/src/process/process-frame.test.ts
@@ -61,9 +61,10 @@ describe('processFrame', () => {
   const startVersion = 1;
   const disconnectHandlerWriteKey = (clientID: string) =>
     `test-disconnected-${clientID}`;
-  const closeHandlerWriteKey = (clientID: string) => `test-closed-${clientID}`;
-  const closeHandlerWritePresenceKey = (clientID: string) =>
-    `-/p/${clientID}/closeHandler`;
+  const clientDeleteHandlerWriteKey = (clientID: string) =>
+    `test-client-delete-${clientID}`;
+  const clientDeleteHandlerWritePresenceKey = (clientID: string) =>
+    `-/p/${clientID}/clientDeleteHandler`;
 
   type Case = {
     name: string;
@@ -79,9 +80,9 @@ describe('processFrame', () => {
     expectedVersion: Version;
     expectedDisconnectedCalls?: ClientID[];
     expectedConnectedClients?: ClientID[];
-    expectedClosedCalls?: ClientID[];
+    expectedClientDeletedCalls?: ClientID[];
     disconnectHandlerThrows?: boolean;
-    closeHandlerThrows?: boolean;
+    clientDeleteHandlerThrows?: boolean;
     shouldGCClients?: boolean;
     clientTombstoneEntries?: [string, ReadonlyJSONValue][];
   };
@@ -1166,12 +1167,12 @@ describe('processFrame', () => {
             presence: [],
             patch: [
               {
-                key: 'test-closed-c2',
+                key: 'test-client-delete-c2',
                 op: 'put',
                 value: true,
               },
               {
-                key: '-/p/c2/closeHandler',
+                key: '-/p/c2/clientDeleteHandler',
                 op: 'del',
               },
               {op: 'del', key: '-/p/c2/b'},
@@ -1186,8 +1187,8 @@ describe('processFrame', () => {
         ['-/p/c2/b', userValue('bb', startVersion + 2, true)],
         // The next one was already deleted so no update to startVersion
         ['-/p/c2/c', userValue('cc', startVersion, true)],
-        ['-/p/c2/closeHandler', userValue(true, startVersion + 2, true)],
-        ['test-closed-c2', userValue(true, startVersion + 2)],
+        ['-/p/c2/clientDeleteHandler', userValue(true, startVersion + 2, true)],
+        ['test-client-delete-c2', userValue(true, startVersion + 2)],
       ]),
       clientTombstoneEntries: [['clientTombstone/c2', {userID: 'u2'}]],
       expectedClientRecords: new Map([
@@ -1204,7 +1205,7 @@ describe('processFrame', () => {
       ]),
       expectedVersion: startVersion + 2,
       expectedConnectedClients: ['c1'],
-      expectedClosedCalls: ['c2'],
+      expectedClientDeletedCalls: ['c2'],
     },
     {
       name: '1 mutation, 3 clients. 1 client should be garbage collected. 1 got disconnected',
@@ -1287,12 +1288,12 @@ describe('processFrame', () => {
             presence: [],
             patch: [
               {
-                key: 'test-closed-c2',
+                key: 'test-client-delete-c2',
                 op: 'put',
                 value: true,
               },
               {
-                key: '-/p/c2/closeHandler',
+                key: '-/p/c2/clientDeleteHandler',
                 op: 'del',
               },
               {op: 'del', key: '-/p/c2/b'},
@@ -1326,8 +1327,8 @@ describe('processFrame', () => {
         ['-/p/c2/c', userValue('cc', startVersion, true)],
         ['-/p/c3/d', userValue('dd', startVersion)],
         ['test-disconnected-c3', userValue(true, startVersion + 3)],
-        ['-/p/c2/closeHandler', userValue(true, startVersion + 2, true)],
-        ['test-closed-c2', userValue(true, startVersion + 2)],
+        ['-/p/c2/clientDeleteHandler', userValue(true, startVersion + 2, true)],
+        ['test-client-delete-c2', userValue(true, startVersion + 2)],
       ]),
       clientTombstoneEntries: [['clientTombstone/c2', {userID: 'u2'}]],
       expectedClientRecords: new Map([
@@ -1355,7 +1356,7 @@ describe('processFrame', () => {
       expectedVersion: startVersion + 3,
       expectedDisconnectedCalls: ['c3'],
       expectedConnectedClients: ['c1'],
-      expectedClosedCalls: ['c2'],
+      expectedClientDeletedCalls: ['c2'],
     },
 
     {
@@ -1402,12 +1403,12 @@ describe('processFrame', () => {
             presence: [],
             patch: [
               {
-                key: 'test-closed-c2',
+                key: 'test-client-delete-c2',
                 op: 'put',
                 value: true,
               },
               {
-                key: '-/p/c2/closeHandler',
+                key: '-/p/c2/clientDeleteHandler',
                 op: 'del',
               },
               {op: 'del', key: '-/p/c2/b'},
@@ -1422,7 +1423,7 @@ describe('processFrame', () => {
         // The next one was already deleted so no update to startVersion
         ['-/p/c2/c', userValue('cc', startVersion, true)],
         [
-          '-/p/c2/closeHandler',
+          '-/p/c2/clientDeleteHandler',
           {
             deleted: true,
             value: true,
@@ -1430,7 +1431,7 @@ describe('processFrame', () => {
           },
         ],
         [
-          'test-closed-c2',
+          'test-client-delete-c2',
           {
             deleted: false,
             value: true,
@@ -1450,7 +1451,7 @@ describe('processFrame', () => {
           }),
         ],
       ]),
-      expectedClosedCalls: ['c2'],
+      expectedClientDeletedCalls: ['c2'],
       clientTombstoneEntries: [['clientTombstone/c2', {userID: 'u2'}]],
       expectedVersion: startVersion + 1,
       expectedConnectedClients: ['c1'],
@@ -1521,7 +1522,7 @@ describe('processFrame', () => {
     },
 
     {
-      name: 'no mutations, 1 client disconnects, close handler should be called',
+      name: 'no mutations, 1 client disconnects, client delete handler should be called',
       pendingMutations: [],
       numPendingMutationsToProcess: 0,
       clients: new Map(),
@@ -1531,22 +1532,22 @@ describe('processFrame', () => {
       expectedPokes: [],
       expectedUserValues: new Map([
         [disconnectHandlerWriteKey('c1'), userValue(true, startVersion + 1)],
-        [closeHandlerWriteKey('c1'), userValue(true, startVersion + 1)],
+        [clientDeleteHandlerWriteKey('c1'), userValue(true, startVersion + 1)],
         [
-          closeHandlerWritePresenceKey('c1'),
+          clientDeleteHandlerWritePresenceKey('c1'),
           userValue(true, startVersion + 1, true),
         ],
       ]),
       expectedClientRecords: recordsWithoutClientID('c1'),
-      // version incremented because close handler changed keys
+      // version incremented because client delete handler changed keys
       expectedVersion: startVersion + 1,
       expectedDisconnectedCalls: ['c1'],
-      expectedClosedCalls: ['c1'],
+      expectedClientDeletedCalls: ['c1'],
       clientTombstoneEntries: [['clientTombstone/c1', {userID: 'testUser1'}]],
       shouldGCClients: true,
     },
     {
-      name: 'no mutations, 1 client disconnects, close handler throws',
+      name: 'no mutations, 1 client disconnects, client delete handler throws',
       pendingMutations: [],
       numPendingMutationsToProcess: 0,
       clients: new Map(),
@@ -1561,13 +1562,13 @@ describe('processFrame', () => {
       // version incremented because disconnect handler changed keys
       expectedVersion: startVersion + 1,
       expectedDisconnectedCalls: ['c1'],
-      expectedClosedCalls: ['c1'],
+      expectedClientDeletedCalls: ['c1'],
       clientTombstoneEntries: [['clientTombstone/c1', {userID: 'testUser1'}]],
-      closeHandlerThrows: true,
+      clientDeleteHandlerThrows: true,
       shouldGCClients: true,
     },
     {
-      name: 'no mutations, 1 client disconnects, disconnect and close handler throw',
+      name: 'no mutations, 1 client disconnects, disconnect and client delete handler throw',
       pendingMutations: [],
       numPendingMutationsToProcess: 0,
       clients: new Map(),
@@ -1577,12 +1578,12 @@ describe('processFrame', () => {
       expectedPokes: [],
       expectedUserValues: new Map(),
       expectedClientRecords: recordsWithoutClientID('c1'),
-      // version not incremented because both disconnect nad close handler threw
+      // version not incremented because both disconnect and client delete handler threw
       expectedVersion: startVersion,
       expectedDisconnectedCalls: ['c1'],
-      expectedClosedCalls: ['c1'],
+      expectedClientDeletedCalls: ['c1'],
       clientTombstoneEntries: [['clientTombstone/c1', {userID: 'testUser1'}]],
-      closeHandlerThrows: true,
+      clientDeleteHandlerThrows: true,
       disconnectHandlerThrows: true,
       shouldGCClients: true,
     },
@@ -1606,7 +1607,7 @@ describe('processFrame', () => {
       const {
         expectedDisconnectedCalls = [],
         expectedConnectedClients = [],
-        expectedClosedCalls = [],
+        expectedClientDeletedCalls = [],
         clientTombstoneEntries = [],
       } = c;
 
@@ -1627,7 +1628,7 @@ describe('processFrame', () => {
       }
 
       const disconnectCallClients: ClientID[] = [];
-      const closedCallClients: ClientID[] = [];
+      const clientDeletedCalls: ClientID[] = [];
       const result = await processFrame(
         createSilentLogContext(),
         env,
@@ -1643,15 +1644,15 @@ describe('processFrame', () => {
           }
         },
         async write => {
-          await write.set(closeHandlerWriteKey(write.clientID), true);
+          await write.set(clientDeleteHandlerWriteKey(write.clientID), true);
 
           // write presence state too... which should be collected
-          await write.set(`-/p/${write.clientID}/closeHandler`, true);
+          await write.set(`-/p/${write.clientID}/clientDeleteHandler`, true);
 
-          closedCallClients.push(write.clientID);
+          clientDeletedCalls.push(write.clientID);
           // Throw after writes to confirm they are not saved.
-          if (c.closeHandlerThrows) {
-            throw new Error('closeHandler threw');
+          if (c.clientDeleteHandlerThrows) {
+            throw new Error('clientDeleteHandler threw');
           }
         },
         c.clients,
@@ -1665,7 +1666,9 @@ describe('processFrame', () => {
         expectedDisconnectedCalls.sort(),
       );
 
-      expect(closedCallClients.sort()).toEqual(expectedClosedCalls.sort());
+      expect(clientDeletedCalls.sort()).toEqual(
+        expectedClientDeletedCalls.sort(),
+      );
 
       const expectedState = new Map([
         ...new Map<string, ReadonlyJSONValue>(

--- a/packages/reflect-server/src/process/process-frame.ts
+++ b/packages/reflect-server/src/process/process-frame.ts
@@ -3,8 +3,8 @@ import type {NullableVersion, Patch, Version} from 'reflect-protocol';
 import type {Env} from 'reflect-shared/src/types.js';
 import {assert} from 'shared/src/asserts.js';
 import {must} from 'shared/src/must.js';
+import type {ClientDeleteHandler} from '../server/client-delete-handler.js';
 import {GC_MAX_AGE, collectClients} from '../server/client-gc.js';
-import type {CloseHandler} from '../server/close-handler.js';
 import type {DisconnectHandler} from '../server/disconnect.js';
 import {EntryCache} from '../storage/entry-cache.js';
 import {unwrapPatch} from '../storage/replicache-transaction.js';
@@ -34,7 +34,7 @@ export async function processFrame(
   numPendingMutationsToProcess: number,
   mutators: MutatorMap,
   disconnectHandler: DisconnectHandler,
-  closeHandler: CloseHandler,
+  clientDeleteHandler: ClientDeleteHandler,
   clients: ClientMap,
   storage: Storage,
   shouldGCClients: (now: number) => boolean,
@@ -104,7 +104,7 @@ export async function processFrame(
       lc,
       env,
       gcCache,
-      closeHandler,
+      clientDeleteHandler,
       new Set(clientIDs),
       now,
       GC_MAX_AGE,
@@ -130,7 +130,7 @@ export async function processFrame(
     lc,
     env,
     disconnectHandler,
-    closeHandler,
+    clientDeleteHandler,
     clientIDs,
     pendingMutations,
     numPendingMutationsToProcess,

--- a/packages/reflect-server/src/process/process-pending.ts
+++ b/packages/reflect-server/src/process/process-pending.ts
@@ -3,7 +3,7 @@ import type {Patch, Poke} from 'reflect-protocol';
 import type {Env} from 'reflect-shared/src/types.js';
 import type {BufferSizer} from 'shared/src/buffer-sizer.js';
 import {must} from 'shared/src/must.js';
-import type {CloseHandler} from '../server/close-handler.js';
+import type {ClientDeleteHandler} from '../server/client-delete-handler.js';
 import type {DisconnectHandler} from '../server/disconnect.js';
 import type {DurableStorage} from '../storage/durable-storage.js';
 import type {ClientID, ClientMap, ClientState} from '../types/client-state.js';
@@ -27,7 +27,7 @@ export async function processPending(
   pendingMutations: PendingMutation[],
   mutators: MutatorMap,
   disconnectHandler: DisconnectHandler,
-  closeHandler: CloseHandler,
+  clientDeleteHandler: ClientDeleteHandler,
   maxProcessedMutationTimestamp: number,
   bufferSizer: BufferSizer,
   maxMutationsToProcess: number,
@@ -129,7 +129,7 @@ export async function processPending(
     endIndex,
     mutators,
     disconnectHandler,
-    closeHandler,
+    clientDeleteHandler,
     storage,
     shouldGCClients,
   );

--- a/packages/reflect-server/src/process/process-room.ts
+++ b/packages/reflect-server/src/process/process-room.ts
@@ -5,7 +5,7 @@ import type {Poke} from 'reflect-protocol';
 import type {Env} from 'reflect-shared/src/types.js';
 import {must} from 'shared/src/must.js';
 import {fastForwardRoom} from '../ff/fast-forward.js';
-import type {CloseHandler} from '../server/close-handler.js';
+import type {ClientDeleteHandler} from '../server/client-delete-handler.js';
 import type {DisconnectHandler} from '../server/disconnect.js';
 import type {DurableStorage} from '../storage/durable-storage.js';
 import {EntryCache} from '../storage/entry-cache.js';
@@ -30,7 +30,7 @@ export async function processRoom(
   numPendingMutationsToProcess: number,
   mutators: MutatorMap,
   disconnectHandler: DisconnectHandler,
-  closeHandler: CloseHandler,
+  clientDeleteHandler: ClientDeleteHandler,
   storage: DurableStorage,
   shouldGCClients: (now: number) => boolean,
 ): Promise<Map<ClientID, Poke[]>> {
@@ -76,7 +76,7 @@ export async function processRoom(
       numPendingMutationsToProcess,
       mutators,
       disconnectHandler,
-      closeHandler,
+      clientDeleteHandler,
       clients,
       cache,
       shouldGCClients,

--- a/packages/reflect-server/src/server/close-beacon.ts
+++ b/packages/reflect-server/src/server/close-beacon.ts
@@ -10,8 +10,11 @@ import {
 } from '../types/client-record.js';
 import {getConnectedClients} from '../types/connected-clients.js';
 import {getVersion, putVersion} from '../types/version.js';
+import {
+  callClientDeleteHandler,
+  type ClientDeleteHandler,
+} from './client-delete-handler.js';
 import {collectOldUserSpaceClientKeys} from './client-gc.js';
-import {callCloseHandler, type CloseHandler} from './close-handler.js';
 
 export async function closeBeacon(
   lc: LogContext,
@@ -20,7 +23,7 @@ export async function closeBeacon(
   roomID: string,
   userID: string,
   lastMutationID: number,
-  closeHandler: CloseHandler,
+  clientDeleteHandler: ClientDeleteHandler,
   storage: Storage,
 ): Promise<Response> {
   lc.debug?.(
@@ -80,7 +83,14 @@ export async function closeBeacon(
   const startVersion = must(await getVersion(cache));
   const nextVersion = startVersion + 1;
 
-  await callCloseHandler(lc, clientID, env, closeHandler, nextVersion, cache);
+  await callClientDeleteHandler(
+    lc,
+    clientID,
+    env,
+    clientDeleteHandler,
+    nextVersion,
+    cache,
+  );
 
   // Use a second cache so that we only update the version if we actually
   // deleted any presence keys.

--- a/packages/reflect-server/src/server/reflect.ts
+++ b/packages/reflect-server/src/server/reflect.ts
@@ -2,7 +2,7 @@ import {consoleLogSink, LogLevel, LogSink, TeeLogSink} from '@rocicorp/logger';
 import type {MutatorDefs} from 'reflect-shared/src/types.js';
 import {BaseAuthDO} from './auth-do.js';
 import type {AuthHandler} from './auth.js';
-import type {CloseHandler} from './close-handler.js';
+import type {ClientDeleteHandler} from './client-delete-handler.js';
 import type {DisconnectHandler} from './disconnect.js';
 import {BaseRoomDO, getDefaultTurnDuration} from './room-do.js';
 import type {RoomStartHandler} from './room-start.js';
@@ -22,7 +22,7 @@ export interface ReflectServerOptions<MD extends MutatorDefs> {
 
   disconnectHandler?: DisconnectHandler | undefined;
 
-  closeHandler?: CloseHandler | undefined;
+  onClientDelete?: ClientDeleteHandler | undefined;
 
   /**
    * Where to send logs. By default logs are sent to `console.log`.
@@ -68,7 +68,7 @@ export type NormalizedOptions<MD extends MutatorDefs> = {
   authHandler?: AuthHandler | undefined;
   roomStartHandler: RoomStartHandler;
   disconnectHandler: DisconnectHandler;
-  closeHandler: CloseHandler;
+  onClientDelete: ClientDeleteHandler;
   logSink: LogSink;
   logLevel: LogLevel;
   datadogMetricsOptions?: DatadogMetricsOptions | undefined;
@@ -143,7 +143,7 @@ function makeNormalizedOptionsGetter<
       authHandler,
       roomStartHandler = noopAsync,
       disconnectHandler = noopAsync,
-      closeHandler = noopAsync,
+      onClientDelete = noopAsync,
       logSinks,
       logLevel = 'debug',
       allowUnconfirmedWrites = false,
@@ -156,7 +156,7 @@ function makeNormalizedOptionsGetter<
       authHandler,
       roomStartHandler,
       disconnectHandler,
-      closeHandler,
+      onClientDelete,
       logSink,
       logLevel,
       allowUnconfirmedWrites,
@@ -178,7 +178,7 @@ function createRoomDOClass<
         mutators,
         roomStartHandler,
         disconnectHandler,
-        closeHandler,
+        onClientDelete,
         logSink,
         logLevel,
         allowUnconfirmedWrites,
@@ -189,7 +189,7 @@ function createRoomDOClass<
         state,
         roomStartHandler,
         disconnectHandler,
-        closeHandler,
+        onClientDelete,
         logSink,
         logLevel,
         allowUnconfirmedWrites,

--- a/packages/reflect-server/src/server/room-do-close-beacon.test.ts
+++ b/packages/reflect-server/src/server/room-do-close-beacon.test.ts
@@ -36,7 +36,7 @@ async function createRoom<MD extends MutatorDefs>(
 const noopHandlers = {
   roomStartHandler: () => Promise.resolve(),
   disconnectHandler: () => Promise.resolve(),
-  closeHandler: () => Promise.resolve(),
+  onClientDelete: () => Promise.resolve(),
 } as const;
 
 async function makeBaseRoomDO(state?: DurableObjectState) {
@@ -77,7 +77,7 @@ describe('Close beacon behavior', () => {
     expectedEntries?: Record<string, UserValue>;
     connectedClients?: ClientID[];
     expectedClientRecords: Record<ClientID, ClientRecord>;
-    closeHandler?: (tx: WriteTransaction) => Promise<void>;
+    onClientDelete?: (tx: WriteTransaction) => Promise<void>;
   }[] = [
     {
       name: 'Config not enabled',
@@ -223,12 +223,12 @@ describe('Close beacon behavior', () => {
     },
 
     {
-      name: 'Same lmid sent with a closeHandler',
+      name: 'Same lmid sent with a onClientDelete',
       expectedStatus: 200,
       storedLastMutationID: 10,
       body: {lastMutationID: 10},
       expectedClientRecords: {},
-      async closeHandler(tx) {
+      async onClientDelete(tx) {
         await tx.set('x/hold', 'door');
         await tx.set(`-/p/${tx.clientID}/collect`, 'me');
       },
@@ -261,13 +261,13 @@ describe('Close beacon behavior', () => {
     },
 
     {
-      name: 'Same lmid sent with a closeHandler throws',
+      name: 'Same lmid sent with a onClientDelete throws',
       expectedStatus: 200,
       storedLastMutationID: 10,
       body: {lastMutationID: 10},
       expectedClientRecords: {},
-      closeHandler: () =>
-        Promise.reject(new Error('closeHandler intentional error')),
+      onClientDelete: () =>
+        Promise.reject(new Error('onClientDelete intentional error')),
     },
   ];
   for (const c of cases) {
@@ -279,7 +279,7 @@ describe('Close beacon behavior', () => {
         expectedEntries = entries,
         connectedClients,
         expectedClientRecords,
-        closeHandler = () => Promise.resolve(),
+        onClientDelete = () => Promise.resolve(),
       } = c;
       const version = 100;
       setConfig('closeBeacon', enabled);
@@ -291,7 +291,7 @@ describe('Close beacon behavior', () => {
       const roomDO = new BaseRoomDO({
         mutators: {},
         ...noopHandlers,
-        closeHandler,
+        onClientDelete,
         state,
         logSink: testLogSink,
         logLevel: 'info',

--- a/packages/reflect-server/src/server/room-do.test.ts
+++ b/packages/reflect-server/src/server/room-do.test.ts
@@ -46,7 +46,7 @@ async function createRoom<MD extends MutatorDefs>(
 const noopHandlers = {
   roomStartHandler: () => Promise.resolve(),
   disconnectHandler: () => Promise.resolve(),
-  closeHandler: () => Promise.resolve(),
+  onClientDelete: () => Promise.resolve(),
 } as const;
 
 test('inits storage schema', async () => {
@@ -510,7 +510,7 @@ describe('good, bad, invalid tail requests', () => {
         mutators: {},
         roomStartHandler: () => Promise.resolve(),
         disconnectHandler: () => Promise.resolve(),
-        closeHandler: () => Promise.resolve(),
+        onClientDelete: () => Promise.resolve(),
         state,
         logSink: testLogSink,
         logLevel: 'info',


### PR DESCRIPTION
This renames the `closeHandler` `ReflectServerOption` to
`onClientDelete`. This is a more accurate name for the handler that is called when a client is
deleted/garbage collected from the server.