### PR TITLE
feat(replicache): In push() and pull() don't reject for network errors.

### DIFF
--- a/packages/replicache/src/connection-loop.test.ts
+++ b/packages/replicache/src/connection-loop.test.ts
@@ -723,7 +723,7 @@ test('Send promise', async () => {
 
   const p1 = loop.send(false);
   await tickUntilTimeIs(50);
-  expect(await p1).to.be.undefined;
+  expect(await p1).undefined;
 
   const expectedError = new Error('xxx');
   nextInvokeSendResult = expectedError;
@@ -731,6 +731,11 @@ test('Send promise', async () => {
   await tickUntilTimeIs(250);
   const err = await p2;
   expect(err?.error).to.equal(expectedError);
+
+  nextInvokeSendResult = false;
+  const p3 = loop.send(false);
+  await tickUntilTimeIs(500);
+  expect(await p3).undefined;
 });
 
 suite('Send when closed should resolve with error', () => {


### PR DESCRIPTION
It's very common for people to call pull() in their poke handler and not think of the fact that it can reject. In some configurations, this unhandled rejection causes a pretty dramatic error message.

As of this change, there is no longer a way to know if push()/pull() completes successfully. If users want this, we can extend the return value to indicate success without rejecting.

See: https://www.notion.so/replicache/Push-and-pull-should-not-reject-in-case-of-network-error-f24db68009a54a8388124fb2685df888