### PR TITLE
chore(reflect): Check for client tombstone

### DIFF
--- a/packages/reflect-protocol/src/error.ts
+++ b/packages/reflect-protocol/src/error.ts
@@ -10,6 +10,7 @@ export const errorKindSchema = v.union(
   v.literal('InvalidConnectionRequest'),
   v.literal('InvalidConnectionRequestBaseCookie'),
   v.literal('InvalidConnectionRequestLastMutationID'),
+  v.literal('InvalidConnectionRequestClientDeleted'),
   v.literal('InvalidMessage'),
   v.literal('InvalidPush'),
   v.literal('RoomClosed'),

--- a/packages/reflect-server/src/process/process-frame.test.ts
+++ b/packages/reflect-server/src/process/process-frame.test.ts
@@ -1190,7 +1190,7 @@ describe('processFrame', () => {
         ['-/p/c2/clientDeleteHandler', userValue(true, startVersion + 2, true)],
         ['test-client-delete-c2', userValue(true, startVersion + 2)],
       ]),
-      clientTombstoneEntries: [['clientTombstone/c2', {userID: 'u2'}]],
+      clientTombstoneEntries: [['clientTombstone/c2', {}]],
       expectedClientRecords: new Map([
         [
           'c1',
@@ -1330,7 +1330,7 @@ describe('processFrame', () => {
         ['-/p/c2/clientDeleteHandler', userValue(true, startVersion + 2, true)],
         ['test-client-delete-c2', userValue(true, startVersion + 2)],
       ]),
-      clientTombstoneEntries: [['clientTombstone/c2', {userID: 'u2'}]],
+      clientTombstoneEntries: [['clientTombstone/c2', {}]],
       expectedClientRecords: new Map([
         [
           'c1',
@@ -1452,7 +1452,7 @@ describe('processFrame', () => {
         ],
       ]),
       expectedClientDeletedCalls: ['c2'],
-      clientTombstoneEntries: [['clientTombstone/c2', {userID: 'u2'}]],
+      clientTombstoneEntries: [['clientTombstone/c2', {}]],
       expectedVersion: startVersion + 1,
       expectedConnectedClients: ['c1'],
     },
@@ -1543,7 +1543,7 @@ describe('processFrame', () => {
       expectedVersion: startVersion + 1,
       expectedDisconnectedCalls: ['c1'],
       expectedClientDeletedCalls: ['c1'],
-      clientTombstoneEntries: [['clientTombstone/c1', {userID: 'testUser1'}]],
+      clientTombstoneEntries: [['clientTombstone/c1', {}]],
       shouldGCClients: true,
     },
     {
@@ -1563,7 +1563,7 @@ describe('processFrame', () => {
       expectedVersion: startVersion + 1,
       expectedDisconnectedCalls: ['c1'],
       expectedClientDeletedCalls: ['c1'],
-      clientTombstoneEntries: [['clientTombstone/c1', {userID: 'testUser1'}]],
+      clientTombstoneEntries: [['clientTombstone/c1', {}]],
       clientDeleteHandlerThrows: true,
       shouldGCClients: true,
     },
@@ -1582,7 +1582,7 @@ describe('processFrame', () => {
       expectedVersion: startVersion,
       expectedDisconnectedCalls: ['c1'],
       expectedClientDeletedCalls: ['c1'],
-      clientTombstoneEntries: [['clientTombstone/c1', {userID: 'testUser1'}]],
+      clientTombstoneEntries: [['clientTombstone/c1', {}]],
       clientDeleteHandlerThrows: true,
       disconnectHandlerThrows: true,
       shouldGCClients: true,

--- a/packages/reflect-server/src/server/client-gc.test.ts
+++ b/packages/reflect-server/src/server/client-gc.test.ts
@@ -317,9 +317,7 @@ Map {
 
     expect(await storage.list({}, jsonSchema)).toMatchInlineSnapshot(`
 Map {
-  "clientTombstone/client-b" => {
-    "userID": "u1",
-  },
+  "clientTombstone/client-b" => {},
   "clientV1/client-a" => {
     "baseCookie": 1,
     "clientGroupID": "client-group-id",
@@ -435,9 +433,7 @@ Map {
 
     expect(await storage.list({}, jsonSchema)).toMatchInlineSnapshot(`
 Map {
-  "clientTombstone/client-b" => {
-    "userID": "u1",
-  },
+  "clientTombstone/client-b" => {},
   "clientV1/client-a" => {
     "baseCookie": 1,
     "clientGroupID": "client-group-id",
@@ -531,9 +527,7 @@ Map {
     // client-b gets a lastSeen of now
     expect(await storage.list({}, jsonSchema)).toMatchInlineSnapshot(`
 Map {
-  "clientTombstone/client-d" => {
-    "userID": "u1",
-  },
+  "clientTombstone/client-d" => {},
   "clientV1/client-a" => {
     "baseCookie": 1,
     "clientGroupID": "client-group-id",

--- a/packages/reflect-server/src/server/connect.ts
+++ b/packages/reflect-server/src/server/connect.ts
@@ -11,6 +11,7 @@ import type {DurableStorage} from '../storage/durable-storage.js';
 import {
   ClientRecord,
   getClientRecord,
+  hasClientTombstone,
   putClientRecord,
 } from '../types/client-record.js';
 import type {
@@ -107,6 +108,19 @@ export async function handleConnection(
         existingRecord.userID,
       );
       closeWithErrorLocal('InvalidConnectionRequest', 'Unexpected userID');
+      return;
+    }
+  } else {
+    if (await hasClientTombstone(requestClientID, storage)) {
+      lc.info?.(
+        'Client with clientID',
+        requestClientID,
+        'is deleted and cannot reconnect.',
+      );
+      closeWithErrorLocal(
+        'InvalidConnectionRequestClientDeleted',
+        'Client is deleted',
+      );
       return;
     }
   }


### PR DESCRIPTION
When connecting we need to check if the client id has been deleted.

Also, simplify the tombstone data. We do not need the userID field. It was never user before and not checked in a schema so this change should be safe.