### PR TITLE
Ignore values returned by the server for cookies we have already seen

### DIFF
--- a/packages/replicache/src/pending-mutation.test.ts
+++ b/packages/replicache/src/pending-mutation.test.ts
@@ -50,7 +50,7 @@ test('pending mutation', async () => {
   ]);
 
   rep.pullURL = 'https://diff.com/pull';
-  fetchMock.post(rep.pullURL, makePullResponseV1(clientID, 2));
+  fetchMock.post(rep.pullURL, makePullResponseV1(clientID, 2, undefined, 1));
   rep.pullIgnorePromise();
   await tickAFewTimes(100);
   await rep.mutate.addData({a: 3});
@@ -60,7 +60,7 @@ test('pending mutation', async () => {
   ]);
 
   fetchMock.reset();
-  fetchMock.post(rep.pullURL, makePullResponseV1(clientID, 3));
+  fetchMock.post(rep.pullURL, makePullResponseV1(clientID, 3, undefined, 2));
   rep.pullIgnorePromise();
   await tickAFewTimes(100);
   expect(await rep.experimentalPendingMutations()).to.deep.equal([]);

--- a/packages/replicache/src/replicache-subscribe.test.ts
+++ b/packages/replicache/src/replicache-subscribe.test.ts
@@ -674,6 +674,7 @@ test('subscribe pull and index update', async () => {
   );
 
   let lastMutationID = 0;
+  let cookie = 0;
 
   let expectedQueryCallCount = 1;
 
@@ -689,7 +690,7 @@ test('subscribe pull and index update', async () => {
     const {clientID} = rep;
     fetchMock.post(
       pullURL,
-      makePullResponseV1(clientID, lastMutationID++, opt.patch),
+      makePullResponseV1(clientID, lastMutationID++, opt.patch, cookie++),
     );
 
     rep.pullIgnorePromise();

--- a/packages/replicache/src/replicache.test.ts
+++ b/packages/replicache/src/replicache.test.ts
@@ -487,7 +487,7 @@ test('HTTP status pull', async () => {
         return {status: 204};
       default: {
         okCalled = true;
-        return {body: makePullResponseV1(clientID, 0), status: 200};
+        return {body: makePullResponseV1(clientID, undefined), status: 200};
       }
     }
   });
@@ -1286,7 +1286,7 @@ test('onSync', async () => {
   expect(onSync.callCount).to.equal(0);
 
   const {clientID} = rep;
-  fetchMock.postOnce(pullURL, makePullResponseV1(clientID, 2));
+  fetchMock.postOnce(pullURL, makePullResponseV1(clientID, 2, undefined, 1));
   await rep.pull();
   await tickAFewTimes(15);
 
@@ -1444,7 +1444,7 @@ test('push and pull concurrently', async () => {
   });
   fetchMock.post(pullURL, () => {
     requests.push(pullURL);
-    return makePullResponseV1(clientID, 0, [], null);
+    return makePullResponseV1(clientID, 0, [], 1);
   });
 
   await add({a: 0});
@@ -1574,6 +1574,7 @@ test('pull and index update', async () => {
   const {clientID} = rep;
 
   let lastMutationID = 0;
+  let lastCookie = 0;
   async function testPull(opt: {
     patch: PatchOperation[];
     expectedResult: JSONValue;
@@ -1581,7 +1582,12 @@ test('pull and index update', async () => {
     let pullDone = false;
     fetchMock.post(pullURL, () => {
       pullDone = true;
-      return makePullResponseV1(clientID, lastMutationID++, opt.patch);
+      return makePullResponseV1(
+        clientID,
+        lastMutationID++,
+        opt.patch,
+        lastCookie++,
+      );
     });
 
     await rep.pull();
@@ -1691,7 +1697,7 @@ test('pull mutate options', async () => {
 
   fetchMock.post(pullURL, () => {
     log.push(Date.now());
-    return makePullResponseV1(clientID, 0, [], '');
+    return makePullResponseV1(clientID, undefined, [], '');
   });
 
   await tickUntilTimeIs(1000);

--- a/packages/replicache/src/sync/pull.test.ts
+++ b/packages/replicache/src/sync/pull.test.ts
@@ -253,26 +253,21 @@ test('begin try pull SDD', async () => {
       },
     },
     {
-      name: 'new patch, same lmid, same cookie -> beginPull succeeds w/syncHead set',
+      name: 'new patch, same lmid, same cookie -> beginPull succeeds w/no syncHead set',
       numPendingMutations: 0,
       pullResult: {
         ...goodPullResp,
         lastMutationID: baseLastMutationID,
         cookie: baseCookie,
       },
-      expNewSyncHead: {
-        cookie: baseCookie,
-        lastMutationID: baseLastMutationID,
-        valueMap: goodPullRespValueMap,
-        indexes: ['2'],
-      },
+      expNewSyncHead: undefined,
       expBeginPullResult: {
         httpRequestInfo: goodHttpRequestInfo,
         syncHead: emptyHash,
       },
     },
     {
-      name: 'no patch, new lmid, same cookie -> beginPull succeeds w/syncHead set',
+      name: 'no patch, new lmid, same cookie -> beginPull succeeds w/no syncHead set',
       numPendingMutations: 0,
       pullResult: {
         ...goodPullResp,
@@ -280,12 +275,7 @@ test('begin try pull SDD', async () => {
         cookie: baseCookie,
         patch: [],
       },
-      expNewSyncHead: {
-        cookie: baseCookie,
-        lastMutationID: baseLastMutationID + 1,
-        valueMap: baseValueMap,
-        indexes: ['2'],
-      },
+      expNewSyncHead: undefined,
       expBeginPullResult: {
         httpRequestInfo: goodHttpRequestInfo,
         syncHead: emptyHash,
@@ -312,18 +302,13 @@ test('begin try pull SDD', async () => {
       },
     },
     {
-      name: 'new patch, new lmid, same cookie -> beginPull succeeds w/syncHead set',
+      name: 'new patch, new lmid, same cookie -> beginPull succeeds w/no syncHead set',
       numPendingMutations: 0,
       pullResult: {
         ...goodPullResp,
         cookie: baseCookie,
       },
-      expNewSyncHead: {
-        cookie: baseCookie,
-        lastMutationID: goodPullResp.lastMutationID,
-        valueMap: goodPullRespValueMap,
-        indexes: ['2'],
-      },
+      expNewSyncHead: undefined,
       expBeginPullResult: {
         httpRequestInfo: goodHttpRequestInfo,
         syncHead: emptyHash,
@@ -767,7 +752,7 @@ test('begin try pull DD31', async () => {
       },
     },
     {
-      name: 'no patch, new lmid, same cookie -> beginPull succeeds w/syncHead set',
+      name: 'no patch, new lmid, same cookie -> beginPull succeeds w/no syncHead set',
       numPendingMutations: 0,
       pullResult: {
         ...goodPullResp,
@@ -775,12 +760,7 @@ test('begin try pull DD31', async () => {
         cookie: baseCookie,
         patch: [],
       },
-      expNewSyncHead: {
-        cookie: baseCookie,
-        lastMutationID: baseLastMutationID + 1,
-        valueMap: baseValueMap,
-        indexes: ['2'],
-      },
+      expNewSyncHead: undefined,
       expBeginPullResult: {
         httpRequestInfo: goodHttpRequestInfo,
         syncHead: emptyHash,
@@ -807,18 +787,13 @@ test('begin try pull DD31', async () => {
       },
     },
     {
-      name: 'new patch, new lmid, same cookie -> beginPull succeeds w/syncHead set',
+      name: 'new patch, new lmid, same cookie -> beginPull succeeds w/no syncHead set',
       numPendingMutations: 0,
       pullResult: {
         ...goodPullResp,
         cookie: baseCookie,
       },
-      expNewSyncHead: {
-        cookie: baseCookie,
-        lastMutationID: goodPullResp.lastMutationIDChanges[clientID],
-        valueMap: goodPullRespValueMap,
-        indexes: ['2'],
-      },
+      expNewSyncHead: undefined,
       expBeginPullResult: {
         httpRequestInfo: goodHttpRequestInfo,
         syncHead: emptyHash,
@@ -1713,7 +1688,7 @@ test('pull for client group with multiple client local changes', async () => {
   const lc = new LogContext();
 
   const pullResponse = {
-    cookie: 1,
+    cookie: 2,
     lastMutationIDChanges: {
       [clientID1]: 11,
       [clientID2]: 21,

--- a/packages/replicache/src/test-util.ts
+++ b/packages/replicache/src/test-util.ts
@@ -193,7 +193,7 @@ export async function replicacheForTesting<
   const {clientID} = rep;
   // Wait for open to be done.
   await rep.clientGroupID;
-  fetchMock.post(pullURL, makePullResponseV1(clientID, 0, [], null));
+  fetchMock.post(pullURL, makePullResponseV1(clientID, undefined, [], null));
   fetchMock.post(pushURL, 'ok');
   await tickAFewTimes();
   return rep;
@@ -316,13 +316,14 @@ export const testSubscriptionsManagerOptions: DiffComputationConfig = {
 
 export function makePullResponseV1(
   clientID: ClientID,
-  lastMutationID: number,
+  lastMutationID: number | undefined,
   patch: PatchOperation[] = [],
   cookie: Cookie = '',
 ): PullResponseV1 {
   return {
     cookie,
-    lastMutationIDChanges: {[clientID]: lastMutationID},
+    lastMutationIDChanges:
+      lastMutationID === undefined ? {} : {[clientID]: lastMutationID},
     patch,
   };
 }


### PR DESCRIPTION
Fixes #689 & #754

- a null cookie returned by the server is also ignored since it matches the initial state where the client has no cookie.

I did find this reference:
https://github.com/rocicorp/mono/issues/125

> we'll write a new snapshot if the server returns the same cookie or lmid **as long as the patch is non-empty**. **The state associated with a lmid and a cookie is not unique.**

Emphasis mine. The latter sentence goes against what I know so far about Replicache.

The persistent storage layer is already ignoring the case where the same cookie is received. See: https://github.com/rocicorp/mono/issues/754