### PR TITLE
fix(reflect-cli): create a team for users running team-level commands

### DIFF
--- a/mirror/reflect-cli/src/apps.ts
+++ b/mirror/reflect-cli/src/apps.ts
@@ -6,17 +6,17 @@ import {
   where,
 } from 'firebase/firestore';
 import {
+  APP_COLLECTION,
   AppView,
   appViewDataConverter,
-  APP_COLLECTION,
 } from 'mirror-schema/src/external/app.js';
 
 import type {DeploymentView} from 'mirror-schema/src/external/deployment.js';
 import color from 'picocolors';
-import type {CommonYargsArgv, YargvToInterface} from './yarg-types.js';
 import type {AuthContext} from './handler.js';
-import {getSingleTeam} from './teams.js';
 import {getLogger} from './logger.js';
+import {getSingleTeam} from './teams.js';
+import type {CommonYargsArgv, YargvToInterface} from './yarg-types.js';
 
 export function appListOptions(yargs: CommonYargsArgv) {
   return yargs.option('output', {
@@ -35,11 +35,7 @@ export async function appListHandler(
   authContext: AuthContext,
 ): Promise<void> {
   const firestore = getFirestore();
-  const teamID = await getSingleTeam(
-    firestore,
-    authContext.user.userID,
-    'admin',
-  );
+  const teamID = await getSingleTeam(firestore, authContext, 'admin');
   const q = query(
     collection(firestore, APP_COLLECTION).withConverter(appViewDataConverter),
     where('teamID', '==', teamID),

--- a/mirror/reflect-cli/src/keys/create.ts
+++ b/mirror/reflect-cli/src/keys/create.ts
@@ -27,11 +27,11 @@ import {makeRequester} from '../requester.js';
 
 import {must} from 'shared/src/must.js';
 import type {AuthContext} from '../handler.js';
+import {getLogger} from '../logger.js';
 import {padColumns} from '../table.js';
 import {getSingleTeam} from '../teams.js';
 import type {CommonYargsArgv, YargvToInterface} from '../yarg-types.js';
 import {CREATED_APPS} from './list.js';
-import {getLogger} from '../logger.js';
 
 export function createKeyOptions(yargs: CommonYargsArgv) {
   return yargs.positional('name', {
@@ -61,7 +61,7 @@ export async function createKeyHandler(
 
   const {userID} = authContext.user;
   const firestore = getFirestore();
-  const teamID = await getSingleTeam(firestore, userID, 'admin');
+  const teamID = await getSingleTeam(firestore, authContext, 'admin');
   const requester = makeRequester(userID);
 
   const {allPermissions} = await listApiKeys.call({

--- a/mirror/reflect-cli/src/keys/delete.ts
+++ b/mirror/reflect-cli/src/keys/delete.ts
@@ -1,10 +1,10 @@
 import {getFirestore} from 'firebase/firestore';
 import {deleteApiKeys} from 'mirror-protocol/src/api-keys.js';
 import type {AuthContext} from '../handler.js';
+import {getLogger} from '../logger.js';
 import {makeRequester} from '../requester.js';
 import {getSingleTeam} from '../teams.js';
 import type {CommonYargsArgv, YargvToInterface} from '../yarg-types.js';
-import {getLogger} from '../logger.js';
 
 export function deleteKeysOptions(yargs: CommonYargsArgv) {
   return yargs.positional('names', {
@@ -26,7 +26,7 @@ export async function deleteKeysHandler(
   const {names} = yargs;
   const {userID} = authContext.user;
   const firestore = getFirestore();
-  const teamID = await getSingleTeam(firestore, userID, 'admin');
+  const teamID = await getSingleTeam(firestore, authContext, 'admin');
 
   const {deleted} = await deleteApiKeys.call({
     requester: makeRequester(userID),

--- a/mirror/reflect-cli/src/keys/edit.ts
+++ b/mirror/reflect-cli/src/keys/edit.ts
@@ -2,11 +2,11 @@ import {getFirestore} from 'firebase/firestore';
 import {editApiKey, listApiKeys} from 'mirror-protocol/src/api-keys.js';
 import color from 'picocolors';
 import type {AuthContext} from '../handler.js';
+import {getLogger} from '../logger.js';
 import {makeRequester} from '../requester.js';
 import {getSingleTeam} from '../teams.js';
 import type {CommonYargsArgv, YargvToInterface} from '../yarg-types.js';
 import {promptForKeyConfiguration} from './create.js';
-import {getLogger} from '../logger.js';
 
 export function editKeyOptions(yargs: CommonYargsArgv) {
   return yargs.positional('name', {
@@ -25,7 +25,7 @@ export async function editKeyHandler(
   const {name} = yargs;
   const {userID} = authContext.user;
   const firestore = getFirestore();
-  const teamID = await getSingleTeam(firestore, userID, 'admin');
+  const teamID = await getSingleTeam(firestore, authContext, 'admin');
   const requester = makeRequester(userID);
 
   const {keys, allPermissions} = await listApiKeys.call({

--- a/mirror/reflect-cli/src/keys/list.ts
+++ b/mirror/reflect-cli/src/keys/list.ts
@@ -3,11 +3,11 @@ import {listApiKeys} from 'mirror-protocol/src/api-keys.js';
 import {APP_CREATE_PERMISSION} from 'mirror-schema/src/external/api-key.js';
 import color from 'picocolors';
 import type {AuthContext} from '../handler.js';
+import {getLogger} from '../logger.js';
 import {makeRequester} from '../requester.js';
 import {padColumns} from '../table.js';
 import {getSingleTeam} from '../teams.js';
 import type {CommonYargsArgv, YargvToInterface} from '../yarg-types.js';
-import {getLogger} from '../logger.js';
 
 export function listKeysOptions(yargs: CommonYargsArgv) {
   return yargs.option('show', {
@@ -29,7 +29,7 @@ export async function listKeysHandler(
 
   const {userID} = authContext.user;
   const firestore = getFirestore();
-  const teamID = await getSingleTeam(firestore, userID, 'admin');
+  const teamID = await getSingleTeam(firestore, authContext, 'admin');
 
   const {keys, allPermissions} = await listApiKeys.call({
     requester: makeRequester(userID),

--- a/mirror/reflect-cli/src/teams.ts
+++ b/mirror/reflect-cli/src/teams.ts
@@ -5,25 +5,30 @@ import {
   userViewDataConverter,
 } from 'mirror-schema/src/external/user.js';
 import {must} from 'shared/src/must.js';
+import {ensureTeamID} from './app-config.js';
+import {ErrorWithSeverity} from './error.js';
+import type {AuthContext} from './handler.js';
 
 export async function getSingleTeam(
   firestore: Firestore,
-  userID: string,
+  authContext: AuthContext,
   restrictToRole?: Role,
 ): Promise<string> {
-  const teams = await getTeams(firestore, userID, restrictToRole);
+  const teams = await getTeams(
+    firestore,
+    authContext.user.userID,
+    restrictToRole,
+  );
   switch (teams.size) {
     case 0:
-      throw new Error(
-        `You are not ${
-          restrictToRole === 'admin' ? 'an admin' : 'a member'
-        } of any teams`,
-      );
+      // User has no apps (and thus no team). Create a team for the user.
+      return ensureTeamID(authContext);
     case 1:
       return teams.keys().next().value;
     default:
-      throw new Error(
+      throw new ErrorWithSeverity(
         'This version of @rocicorp/reflect does not support multiple teams. Please update to the latest version.',
+        'WARNING',
       );
   }
 }


### PR DESCRIPTION
For `reflect apps list|delete` and `reflect keys create|list|edit|delete`, create a team if the user does not have one (i.e. has yet to publish an app).

This eliminates the confusing "Error: You are not an admin of any teams" error message.

Fixes #1451 