### PR TITLE
feat(zero-cache): handoff replication from Postgres to Replicator

### DIFF
--- a/packages/zero-cache/src/services/replicator/incremental-sync.pg-test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.pg-test.ts
@@ -1,0 +1,29 @@
+import {afterEach, beforeEach, describe, test} from '@jest/globals';
+import type postgres from 'postgres';
+import {TestDBs, expectTables} from '../../test/db.js';
+import {CREATE_REPLICATION_TABLES} from './incremental-sync.js';
+
+describe('replicator/incremental-sync', () => {
+  const testDBs = new TestDBs();
+  let db: postgres.Sql;
+
+  beforeEach(async () => {
+    db = await testDBs.create('incremental_sync_test');
+    await db`CREATE SCHEMA IF NOT EXISTS zero`;
+  });
+
+  afterEach(async () => {
+    await testDBs.drop(db);
+  });
+
+  test('create tables', async () => {
+    await db.unsafe(CREATE_REPLICATION_TABLES);
+
+    await expectTables(db, {
+      ['zero.tx_log']: [],
+      ['zero.change_log']: [],
+      ['zero.invalidation_registry']: [],
+      ['zero.invalidation_index']: [],
+    });
+  });
+});

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -1,0 +1,74 @@
+/**
+ * Replication metadata, used for invalidation and catchup. These tables
+ * are created atomically with the logical replication handoff, after initial
+ * data synchronization has completed.
+ */
+export const CREATE_REPLICATION_TABLES =
+  // The transaction log maps each LSN to transaction information.
+  // Note that the lsn may become optional for supporting non-Postgres upstreams.
+  `
+  CREATE TABLE zero.tx_log (
+    db_version VARCHAR(38) NOT NULL,
+    lsn PG_LSN             NOT NULL,
+    time TIMESTAMPTZ       NOT NULL,
+    xid INTEGER            NOT NULL,
+    PRIMARY KEY(db_version)
+  );
+` +
+  // The change log contains row changes.
+  //
+  // * `op`: 'i' for INSERT, 'u' for UPDATE, 'd' for DELETE, 't' for TRUNCATE
+  // * `row_key`: Empty string for the TRUNCATE op (because primary keys cannot be NULL).
+  // * `row`: JSON formatted full row contents, NULL for DELETE / TRUNCATE
+  //
+  // Note that the `row` data is stored as JSON rather than JSONB to prioritize write
+  // throughput, as replication is critical bottleneck in the system. Row values are
+  // only needed for catchup, for which JSONB is not particularly advantageous over JSON.
+  `
+  CREATE TABLE zero.change_log (
+    db_version VARCHAR(38)  NOT NULL,
+    table_name VARCHAR(128) NOT NULL,
+    row_key TEXT            NOT NULL,
+    op CHAR(1)              NOT NULL,
+    row JSON,
+    PRIMARY KEY(db_version, table_name, row_key)
+  );
+` +
+  // Invalidation registry.
+  //
+  // * `spec` defines the invalidation function to run,
+  //
+  // * `bits` indicates the number of bits used to create the
+  //    corresponding tag in the `invalidation_index`. The former is requested
+  //    by View Syncers, while the latter is decided by the system.
+  //
+  //    For example, we may decide to start off with 32-bit hashes and later
+  //    determine that it is worth increasing the table size to 40-bit hashes
+  //    in order to reduce the number collisions. During the transition, the
+  //    Replicator would compute both sizes until the new size has sufficient
+  //    coverage (over old versions).
+  //
+  // * `from_db_version` indicates when the Replicator first started running
+  //   the filter. CVRs at or newer than the version are considered covered.
+  //
+  // * `last_requested` records (approximately) the last time the spec was
+  //   requested. This is not exact. It may only be updated if the difference
+  //   exceeds some interval, for example. This is used to clean up specs that
+  //   are no longer used.
+  `
+CREATE TABLE zero.invalidation_registry (
+  spec TEXT                   NOT NULL,
+  bits SMALLINT               NOT NULL,
+  from_db_version VARCHAR(38) NOT NULL,
+  last_requested TIMESTAMPTZ  NOT NULL,
+  PRIMARY KEY(spec, bits)
+);
+` +
+  // Invalidation index.
+  `
+CREATE TABLE zero.invalidation_index (
+  hash           BIGINT      NOT NULL,
+  db_version     VARCHAR(38) NOT NULL,
+  PRIMARY KEY(hash)
+);
+`;

--- a/packages/zero-cache/src/services/replicator/schema/sync-schema.ts
+++ b/packages/zero-cache/src/services/replicator/schema/sync-schema.ts
@@ -1,6 +1,10 @@
 import type {LogContext} from '@rocicorp/logger';
 import type postgres from 'postgres';
-import {startPostgresReplication} from '../initial-sync.js';
+import {
+  handoffPostgresReplication,
+  startPostgresReplication,
+  waitForInitialDataSynchronization,
+} from '../initial-sync.js';
 import {
   runSyncSchemaMigrations,
   type VersionMigrationMap,
@@ -9,6 +13,8 @@ import {
 const SCHEMA_VERSION_MIGRATION_MAP: VersionMigrationMap = {
   1: {minSafeRollbackVersion: 1}, // The inaugural v1 understands the rollback limit.
   2: startPostgresReplication,
+  3: waitForInitialDataSynchronization,
+  4: handoffPostgresReplication,
 };
 
 export async function initSyncSchema(

--- a/packages/zero-cache/src/test/db.ts
+++ b/packages/zero-cache/src/test/db.ts
@@ -4,6 +4,12 @@ import {assert} from 'shared/src/asserts.js';
 
 export class TestDBs {
   // Connects to the main "postgres" DB of the local Postgres cluster.
+  //
+  // Note: In order to run all of the tests successfully, the following
+  // configuration needs to be set in postgresql.conf:
+  //
+  // wal_level = logical                    # default is replica
+  // max_logical_replication_workers = 20   # default is 4
   readonly #sql = postgres({
     database: 'postgres',
     transform: postgres.camel,


### PR DESCRIPTION
Defines migration phases that are run after starting the initial data synchronization in `startPostgresReplication()`:
* `waitForInitialDataSynchronization()`: Polls with `pg_subscription_rel` table with exponential backoff to determine when all tables have completed the initial data synchronization step.
* `handoffPostgresReplication()`: Disables and detaches the Postgres SUBSCRIPTION on the replica so that the replication slot (along with its LSN position in the Write Ahead Log) can be handed off to the Replicator

The latter step also atomically creates the tables used by the Replicator so that the Replicator can begin its logic once the migration is complete.