### PR TITLE
feat(zero-cache): use per-replicator slots instead of a global singleton slot

### DIFF
--- a/packages/zero-cache/src/services/replicator/replicator.ts
+++ b/packages/zero-cache/src/services/replicator/replicator.ts
@@ -4,12 +4,18 @@ import type {Service} from '../service.js';
 import {initSyncSchema} from './schema/sync-schema.js';
 
 export class Replicator implements Service {
-  readonly id = 'replicator';
+  readonly id: string;
   readonly #lc: LogContext;
   readonly #upstreamUri: string;
   readonly #syncReplica: postgres.Sql;
 
-  constructor(lc: LogContext, upstreamUri: string, syncReplicaUri: string) {
+  constructor(
+    lc: LogContext,
+    replicaID: string,
+    upstreamUri: string,
+    syncReplicaUri: string,
+  ) {
+    this.id = replicaID;
     this.#lc = lc
       .withContext('component', 'Replicator')
       .withContext('serviceID', this.id);
@@ -22,7 +28,12 @@ export class Replicator implements Service {
   }
 
   async start() {
-    await initSyncSchema(this.#lc, this.#syncReplica, this.#upstreamUri);
+    await initSyncSchema(
+      this.#lc,
+      this.id,
+      this.#syncReplica,
+      this.#upstreamUri,
+    );
   }
   async stop() {}
 }

--- a/packages/zero-cache/src/services/replicator/schema/migration.pg-test.ts
+++ b/packages/zero-cache/src/services/replicator/schema/migration.pg-test.ts
@@ -28,7 +28,8 @@ describe('schema/migration', () => {
   };
 
   const logMigrationHistory =
-    (name: string) => async (_log: LogContext, tx: postgres.TransactionSql) => {
+    (name: string) =>
+    async (_log: LogContext, _id: string, tx: postgres.TransactionSql) => {
       const meta = await getSyncSchemaMeta(tx);
       await tx`INSERT INTO migration_history ${tx({
         event: `${name}-at(${meta.version})`,
@@ -203,6 +204,7 @@ describe('schema/migration', () => {
       try {
         await runSyncSchemaMigrations(
           createSilentLogContext(),
+          'foo-bar-replica-id',
           db,
           'postgres://upstream',
           c.migrations,

--- a/packages/zero-cache/src/services/replicator/schema/migration.ts
+++ b/packages/zero-cache/src/services/replicator/schema/migration.ts
@@ -12,6 +12,7 @@ import * as v from 'shared/src/valita.js';
 export type Migration =
   | ((
       log: LogContext,
+      replicaID: string,
       tx: postgres.TransactionSql,
       upstreamUri: string,
     ) => Promise<void>)
@@ -29,6 +30,7 @@ export type VersionMigrationMap = {
  */
 export async function runSyncSchemaMigrations(
   log: LogContext,
+  replicaID: string,
   sql: postgres.Sql,
   upstreamUri: string,
   versionMigrationMap: VersionMigrationMap,
@@ -78,6 +80,7 @@ export async function runSyncSchemaMigrations(
             if (meta.version < dest) {
               meta = await migrateSyncSchemaVersion(
                 log,
+                replicaID,
                 tx,
                 upstreamUri,
                 meta,
@@ -177,6 +180,7 @@ async function setSyncSchemaVersion(
 
 async function migrateSyncSchemaVersion(
   log: LogContext,
+  replicaID: string,
   tx: postgres.TransactionSql,
   upstreamUri: string,
   meta: SyncSchemaMeta,
@@ -184,7 +188,7 @@ async function migrateSyncSchemaVersion(
   migration: Migration,
 ): Promise<SyncSchemaMeta> {
   if (typeof migration === 'function') {
-    await migration(log, tx, upstreamUri);
+    await migration(log, replicaID, tx, upstreamUri);
   } else {
     meta = ensureRollbackLimit(migration.minSafeRollbackVersion, log, meta);
   }

--- a/packages/zero-cache/src/services/replicator/schema/sync-schema.ts
+++ b/packages/zero-cache/src/services/replicator/schema/sync-schema.ts
@@ -19,11 +19,13 @@ const SCHEMA_VERSION_MIGRATION_MAP: VersionMigrationMap = {
 
 export async function initSyncSchema(
   log: LogContext,
+  replicaID: string,
   db: postgres.Sql,
   upstreamUri: string,
 ): Promise<void> {
   await runSyncSchemaMigrations(
     log,
+    replicaID,
     db,
     upstreamUri,
     SCHEMA_VERSION_MIGRATION_MAP,


### PR DESCRIPTION
Adds the replica ID as a suffix to the "zero_slot_" name used for the replication slot on the upstream DB. This allows us to potentially run multiple Replicators, which may be necessary for things like upstream schema migrations (e.g. adding existing tables to a publication).