### PR TITLE
feat(zero-cache): use pg_catalog instead of information_schema

### DIFF
--- a/packages/zero-cache/src/services/replicator/initial-sync.pg-test.ts
+++ b/packages/zero-cache/src/services/replicator/initial-sync.pg-test.ts
@@ -15,7 +15,7 @@ import {
   startPostgresReplication,
   waitForInitialDataSynchronization,
 } from './initial-sync.js';
-import {getPublishedTables} from './tables/published.js';
+import {getPublicationInfo} from './tables/published.js';
 import type {TableSpec} from './tables/specs.js';
 
 const SUB = 'test_sync';
@@ -31,7 +31,7 @@ const ZERO_CLIENTS_SPEC: TableSpec = {
     ['last_mutation_id']: {
       characterMaximumLength: null,
       columnDefault: null,
-      dataType: 'bigint',
+      dataType: 'int8',
     },
   },
   name: 'clients',
@@ -102,12 +102,12 @@ describe('replicator/initial-sync', () => {
             ['issue_id']: {
               characterMaximumLength: null,
               columnDefault: null,
-              dataType: 'integer',
+              dataType: 'int4',
             },
             ['org_id']: {
               characterMaximumLength: null,
               columnDefault: null,
-              dataType: 'integer',
+              dataType: 'int4',
             },
           },
           name: 'issues',
@@ -143,7 +143,7 @@ describe('replicator/initial-sync', () => {
             ['user_id']: {
               characterMaximumLength: null,
               columnDefault: null,
-              dataType: 'integer',
+              dataType: 'int4',
             },
             // Note: password is not published
             ['handle']: {
@@ -232,11 +232,11 @@ describe('replicator/initial-sync', () => {
         ),
       );
 
-      const published = await getPublishedTables(upstream, 'zero_');
-      expect(published).toEqual(c.published);
+      const published = await getPublicationInfo(upstream, 'zero_');
+      expect(published.tables).toEqual(c.published);
 
-      const synced = await getPublishedTables(replica, 'synced_tables');
-      expect(synced).toMatchObject(c.published);
+      const synced = await getPublicationInfo(replica, 'synced_tables');
+      expect(synced.tables).toMatchObject(c.published);
 
       await replica.begin(tx =>
         waitForInitialDataSynchronization(

--- a/packages/zero-cache/src/services/replicator/tables/create.pg-test.ts
+++ b/packages/zero-cache/src/services/replicator/tables/create.pg-test.ts
@@ -9,7 +9,7 @@ import {
 import type postgres from 'postgres';
 import {TestDBs} from '../../../test/db.js';
 import {createTableStatement} from './create.js';
-import {getPublishedTables} from './published.js';
+import {getPublicationInfo} from './published.js';
 import type {TableSpec} from './specs.js';
 
 describe('tables/create', () => {
@@ -26,12 +26,12 @@ describe('tables/create', () => {
         name: 'clients',
         columns: {
           ['client_id']: {
-            dataType: 'character varying',
+            dataType: 'varchar',
             characterMaximumLength: 180,
             columnDefault: null,
           },
           ['last_mutation_id']: {
-            dataType: 'bigint',
+            dataType: 'int8',
             characterMaximumLength: null,
             columnDefault: null,
           },
@@ -46,14 +46,14 @@ describe('tables/create', () => {
         name: 'users',
         columns: {
           ['user_id']: {
-            dataType: 'integer',
+            dataType: 'int4',
             characterMaximumLength: null,
             columnDefault: null,
           },
           handle: {
             characterMaximumLength: 40,
             columnDefault: "'@foo'::text",
-            dataType: 'character varying',
+            dataType: 'varchar',
           },
           address: {
             characterMaximumLength: null,
@@ -61,27 +61,27 @@ describe('tables/create', () => {
             dataType: 'text[]',
           },
           ['timez']: {
-            dataType: 'timestamp with time zone[]',
+            dataType: 'timestamptz[]',
             characterMaximumLength: null,
             columnDefault: null,
           },
           ['bigint_array']: {
             characterMaximumLength: null,
             columnDefault: null,
-            dataType: 'bigint[]',
+            dataType: 'int8[]',
           },
           ['bool_array']: {
             characterMaximumLength: null,
             columnDefault: null,
-            dataType: 'boolean[]',
+            dataType: 'bool[]',
           },
           ['real_array']: {
             characterMaximumLength: null,
             columnDefault: null,
-            dataType: 'real[]',
+            dataType: 'float4[]',
           },
           ['int_array']: {
-            dataType: 'integer[]',
+            dataType: 'int4[]',
             characterMaximumLength: null,
             columnDefault: "'{1,2,3}'::integer[]",
           },
@@ -115,10 +115,10 @@ describe('tables/create', () => {
     test(c.name, async () => {
       await db.unsafe(createTableStatement(c.tableSpec));
 
-      const tables = await getPublishedTables(db, 'zero_');
-      expect(tables[`${c.tableSpec.schema}.${c.tableSpec.name}`]).toEqual(
-        c.tableSpec,
-      );
+      const published = await getPublicationInfo(db, 'zero_');
+      expect(
+        published.tables[`${c.tableSpec.schema}.${c.tableSpec.name}`],
+      ).toEqual(c.tableSpec);
     });
   }
 });

--- a/packages/zero-cache/src/services/replicator/tables/published.pg-test.ts
+++ b/packages/zero-cache/src/services/replicator/tables/published.pg-test.ts
@@ -8,21 +8,23 @@ import {
 } from '@jest/globals';
 import type postgres from 'postgres';
 import {TestDBs} from '../../../test/db.js';
-import {getPublishedTables} from './published.js';
-import type {TableSpec} from './specs.js';
+import {PublicationInfo, getPublicationInfo} from './published.js';
 
 describe('tables/published', () => {
   type Case = {
     name: string;
     setupQuery: string;
-    expectedResult: Record<string, TableSpec>;
+    expectedResult: PublicationInfo;
   };
 
   const cases: Case[] = [
     {
       name: 'Nothing published',
       setupQuery: `CREATE SCHEMA zero`,
-      expectedResult: {},
+      expectedResult: {
+        publications: [],
+        tables: {},
+      },
     },
     {
       name: 'zero.clients',
@@ -35,22 +37,33 @@ describe('tables/published', () => {
       );
       `,
       expectedResult: {
-        ['zero.clients']: {
-          schema: 'zero',
-          name: 'clients',
-          columns: {
-            ['client_id']: {
-              dataType: 'character varying',
-              characterMaximumLength: 180,
-              columnDefault: null,
-            },
-            ['last_mutation_id']: {
-              dataType: 'bigint',
-              characterMaximumLength: null,
-              columnDefault: null,
-            },
+        publications: [
+          {
+            pubname: 'zero_all',
+            pubinsert: true,
+            pubupdate: true,
+            pubdelete: true,
+            pubtruncate: true,
           },
-          primaryKey: ['client_id'],
+        ],
+        tables: {
+          ['zero.clients']: {
+            schema: 'zero',
+            name: 'clients',
+            columns: {
+              ['client_id']: {
+                dataType: 'varchar',
+                characterMaximumLength: 180,
+                columnDefault: null,
+              },
+              ['last_mutation_id']: {
+                dataType: 'int8',
+                characterMaximumLength: null,
+                columnDefault: null,
+              },
+            },
+            primaryKey: ['client_id'],
+          },
         },
       },
     },
@@ -72,57 +85,68 @@ describe('tables/published', () => {
       CREATE PUBLICATION zero_data FOR TABLE test.users;
       `,
       expectedResult: {
-        ['test.users']: {
-          schema: 'test',
-          name: 'users',
-          columns: {
-            ['user_id']: {
-              dataType: 'integer',
-              characterMaximumLength: null,
-              columnDefault: null,
-            },
-            handle: {
-              characterMaximumLength: null,
-              columnDefault: null,
-              dataType: 'text',
-            },
-            address: {
-              characterMaximumLength: null,
-              columnDefault: null,
-              dataType: 'text[]',
-            },
-            ['timez']: {
-              dataType: 'timestamp with time zone[]',
-              characterMaximumLength: null,
-              columnDefault: null,
-            },
-            ['bigint_array']: {
-              characterMaximumLength: null,
-              columnDefault: null,
-              dataType: 'bigint[]',
-            },
-            ['bool_array']: {
-              characterMaximumLength: null,
-              columnDefault: null,
-              dataType: 'boolean[]',
-            },
-            ['real_array']: {
-              characterMaximumLength: null,
-              columnDefault: null,
-              dataType: 'real[]',
-            },
-            ['int_array']: {
-              dataType: 'integer[]',
-              characterMaximumLength: null,
-              columnDefault: "'{1,2,3}'::integer[]",
-            },
-            ['json_val']: {
-              dataType: 'jsonb',
-              characterMaximumLength: null,
-              columnDefault: null,
-            },
+        publications: [
+          {
+            pubname: 'zero_data',
+            pubinsert: true,
+            pubupdate: true,
+            pubdelete: true,
+            pubtruncate: true,
           },
-          primaryKey: ['user_id'],
+        ],
+        tables: {
+          ['test.users']: {
+            schema: 'test',
+            name: 'users',
+            columns: {
+              ['user_id']: {
+                dataType: 'int4',
+                characterMaximumLength: null,
+                columnDefault: null,
+              },
+              handle: {
+                characterMaximumLength: null,
+                columnDefault: null,
+                dataType: 'text',
+              },
+              address: {
+                characterMaximumLength: null,
+                columnDefault: null,
+                dataType: 'text[]',
+              },
+              ['timez']: {
+                dataType: 'timestamptz[]',
+                characterMaximumLength: null,
+                columnDefault: null,
+              },
+              ['bigint_array']: {
+                characterMaximumLength: null,
+                columnDefault: null,
+                dataType: 'int8[]',
+              },
+              ['bool_array']: {
+                characterMaximumLength: null,
+                columnDefault: null,
+                dataType: 'bool[]',
+              },
+              ['real_array']: {
+                characterMaximumLength: null,
+                columnDefault: null,
+                dataType: 'float4[]',
+              },
+              ['int_array']: {
+                dataType: 'int4[]',
+                characterMaximumLength: null,
+                columnDefault: "'{1,2,3}'::integer[]",
+              },
+              ['json_val']: {
+                dataType: 'jsonb',
+                characterMaximumLength: null,
+                columnDefault: null,
+              },
+            },
+            primaryKey: ['user_id'],
+          },
         },
       },
     },
@@ -143,32 +167,43 @@ describe('tables/published', () => {
       CREATE PUBLICATION zero_data FOR TABLE test.users (user_id, timez, int_array, json_val);
       `,
       expectedResult: {
-        ['test.users']: {
-          schema: 'test',
-          name: 'users',
-          columns: {
-            ['user_id']: {
-              dataType: 'integer',
-              characterMaximumLength: null,
-              columnDefault: null,
-            },
-            ['timez']: {
-              dataType: 'timestamp with time zone',
-              characterMaximumLength: null,
-              columnDefault: null,
-            },
-            ['int_array']: {
-              dataType: 'integer[]',
-              characterMaximumLength: null,
-              columnDefault: "'{1,2,3}'::integer[]",
-            },
-            ['json_val']: {
-              dataType: 'jsonb',
-              characterMaximumLength: null,
-              columnDefault: null,
-            },
+        publications: [
+          {
+            pubname: 'zero_data',
+            pubinsert: true,
+            pubupdate: true,
+            pubdelete: true,
+            pubtruncate: true,
           },
-          primaryKey: ['user_id'],
+        ],
+        tables: {
+          ['test.users']: {
+            schema: 'test',
+            name: 'users',
+            columns: {
+              ['user_id']: {
+                dataType: 'int4',
+                characterMaximumLength: null,
+                columnDefault: null,
+              },
+              ['timez']: {
+                dataType: 'timestamptz',
+                characterMaximumLength: null,
+                columnDefault: null,
+              },
+              ['int_array']: {
+                dataType: 'int4[]',
+                characterMaximumLength: null,
+                columnDefault: "'{1,2,3}'::integer[]",
+              },
+              ['json_val']: {
+                dataType: 'jsonb',
+                characterMaximumLength: null,
+                columnDefault: null,
+              },
+            },
+            primaryKey: ['user_id'],
+          },
         },
       },
     },
@@ -186,32 +221,43 @@ describe('tables/published', () => {
       CREATE PUBLICATION zero_keys FOR ALL TABLES;
       `,
       expectedResult: {
-        ['test.issues']: {
-          schema: 'test',
-          name: 'issues',
-          columns: {
-            ['issue_id']: {
-              dataType: 'integer',
-              characterMaximumLength: null,
-              columnDefault: null,
-            },
-            ['description']: {
-              dataType: 'text',
-              characterMaximumLength: null,
-              columnDefault: null,
-            },
-            ['org_id']: {
-              dataType: 'integer',
-              characterMaximumLength: null,
-              columnDefault: null,
-            },
-            ['component_id']: {
-              dataType: 'integer',
-              characterMaximumLength: null,
-              columnDefault: null,
-            },
+        publications: [
+          {
+            pubname: 'zero_keys',
+            pubinsert: true,
+            pubupdate: true,
+            pubdelete: true,
+            pubtruncate: true,
           },
-          primaryKey: ['org_id', 'component_id', 'issue_id'],
+        ],
+        tables: {
+          ['test.issues']: {
+            schema: 'test',
+            name: 'issues',
+            columns: {
+              ['issue_id']: {
+                dataType: 'int4',
+                characterMaximumLength: null,
+                columnDefault: null,
+              },
+              ['description']: {
+                dataType: 'text',
+                characterMaximumLength: null,
+                columnDefault: null,
+              },
+              ['org_id']: {
+                dataType: 'int4',
+                characterMaximumLength: null,
+                columnDefault: null,
+              },
+              ['component_id']: {
+                dataType: 'int4',
+                characterMaximumLength: null,
+                columnDefault: null,
+              },
+            },
+            primaryKey: ['org_id', 'component_id', 'issue_id'],
+          },
         },
       },
     },
@@ -242,66 +288,84 @@ describe('tables/published', () => {
       );
       `,
       expectedResult: {
-        ['test.issues']: {
-          schema: 'test',
-          name: 'issues',
-          columns: {
-            ['issue_id']: {
-              dataType: 'integer',
-              characterMaximumLength: null,
-              columnDefault: null,
-            },
-            ['description']: {
-              dataType: 'text',
-              characterMaximumLength: null,
-              columnDefault: null,
-            },
-            ['org_id']: {
-              dataType: 'integer',
-              characterMaximumLength: null,
-              columnDefault: null,
-            },
-            ['component_id']: {
-              dataType: 'integer',
-              characterMaximumLength: null,
-              columnDefault: null,
-            },
+        publications: [
+          {
+            pubname: 'zero_meta',
+            pubinsert: true,
+            pubupdate: true,
+            pubdelete: true,
+            pubtruncate: true,
           },
-          primaryKey: ['org_id', 'component_id', 'issue_id'],
-        },
-        ['test.users']: {
-          schema: 'test',
-          name: 'users',
-          columns: {
-            ['user_id']: {
-              dataType: 'integer',
-              characterMaximumLength: null,
-              columnDefault: null,
-            },
-            ['handle']: {
-              dataType: 'text',
-              characterMaximumLength: null,
-              columnDefault: "'foo'::text",
-            },
+          {
+            pubname: 'zero_tables',
+            pubinsert: true,
+            pubupdate: true,
+            pubdelete: true,
+            pubtruncate: true,
           },
-          primaryKey: ['user_id'],
-        },
-        ['zero.clients']: {
-          schema: 'zero',
-          name: 'clients',
-          columns: {
-            ['client_id']: {
-              dataType: 'character varying',
-              characterMaximumLength: 180,
-              columnDefault: null,
+        ],
+        tables: {
+          ['test.issues']: {
+            schema: 'test',
+            name: 'issues',
+            columns: {
+              ['issue_id']: {
+                dataType: 'int4',
+                characterMaximumLength: null,
+                columnDefault: null,
+              },
+              ['description']: {
+                dataType: 'text',
+                characterMaximumLength: null,
+                columnDefault: null,
+              },
+              ['org_id']: {
+                dataType: 'int4',
+                characterMaximumLength: null,
+                columnDefault: null,
+              },
+              ['component_id']: {
+                dataType: 'int4',
+                characterMaximumLength: null,
+                columnDefault: null,
+              },
             },
-            ['last_mutation_id']: {
-              dataType: 'bigint',
-              characterMaximumLength: null,
-              columnDefault: null,
-            },
+            primaryKey: ['org_id', 'component_id', 'issue_id'],
           },
-          primaryKey: ['client_id'],
+          ['test.users']: {
+            schema: 'test',
+            name: 'users',
+            columns: {
+              ['user_id']: {
+                dataType: 'int4',
+                characterMaximumLength: null,
+                columnDefault: null,
+              },
+              ['handle']: {
+                dataType: 'text',
+                characterMaximumLength: null,
+                columnDefault: "'foo'::text",
+              },
+            },
+            primaryKey: ['user_id'],
+          },
+          ['zero.clients']: {
+            schema: 'zero',
+            name: 'clients',
+            columns: {
+              ['client_id']: {
+                dataType: 'varchar',
+                characterMaximumLength: 180,
+                columnDefault: null,
+              },
+              ['last_mutation_id']: {
+                dataType: 'int8',
+                characterMaximumLength: null,
+                columnDefault: null,
+              },
+            },
+            primaryKey: ['client_id'],
+          },
         },
       },
     },
@@ -325,7 +389,7 @@ describe('tables/published', () => {
     test(c.name, async () => {
       await db.unsafe(c.setupQuery);
 
-      const tables = await getPublishedTables(db, 'zero_');
+      const tables = await getPublicationInfo(db, 'zero_');
       expect(tables).toEqual(c.expectedResult);
     });
   }


### PR DESCRIPTION
Optimize the lookup of publication table information:
* Lookup publications in the same simple query sent to PG
* Use the raw `pg_catalog` tables instead of the SQL-standard `information_schema` views, as the former is much faster.

This is worth optimizing because incremental replication will always initialize itself by querying and caching the table information from the sync replica.