### PR TITLE
feat(zero-cache): require that upstream tables have a primary key

### DIFF
--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -39,12 +39,12 @@ export const CREATE_REPLICATION_TABLES =
   // * `spec` defines the invalidation function to run,
   //
   // * `bits` indicates the number of bits used to create the
-  //    corresponding tag in the `invalidation_index`. The former is requested
-  //    by View Syncers, while the latter is decided by the system.
+  //    corresponding tag in the `invalidation_index`. The 'spec' is requested
+  //    by View Syncers, while 'bits' is decided by the system.
   //
   //    For example, we may decide to start off with 32-bit hashes and later
   //    determine that it is worth increasing the table size to 40-bit hashes
-  //    in order to reduce the number collisions. During the transition, the
+  //    in order to reduce the number of collisions. During the transition, the
   //    Replicator would compute both sizes until the new size has sufficient
   //    coverage (over old versions).
   //

--- a/packages/zero-cache/src/services/replicator/initial-sync.ts
+++ b/packages/zero-cache/src/services/replicator/initial-sync.ts
@@ -48,8 +48,11 @@ export async function startPostgresReplication(
   const tablesStmts = Object.values(published.tables).map(table => {
     if (ZERO_VERSION_COLUMN_NAME in table.columns) {
       throw new Error(
-        `Table ${table.name} uses reserved name column name ${ZERO_VERSION_COLUMN_NAME}`,
+        `Table ${table.name} uses reserved column name ${ZERO_VERSION_COLUMN_NAME}`,
       );
+    }
+    if (table.primaryKey.length === 0) {
+      throw new Error(`Table ${table.name} does not have a PRIMARY KEY`);
     }
     schemas.add(table.schema);
     // Add the _0_version column with a default value of "00".


### PR DESCRIPTION
Adds a check in the initial sync step that the published upstream tables have a primary key.

Add tests for validation errors (including use of the reserved `_0_version` column).