### PR TITLE
feat: Enable logpush for mirror dispatch worker

### DIFF
--- a/mirror/mirror-cli/src/publish-dispatcher.ts
+++ b/mirror/mirror-cli/src/publish-dispatcher.ts
@@ -181,5 +181,6 @@ async function publishDispatcherScript({
     // no_minimal_subrequests is required to dispatch to non-namespaced workers by Custom Domain.
     compatibility_flags: ['no_minimal_subrequests'],
     /* eslint-enable @typescript-eslint/naming-convention */
+    logpush: true,
   });
 }


### PR DESCRIPTION
This can give us visibility into some errors / exceptions that cause the DO to shutdown before we manage to send logs to datadog via our own DatadogLogSink.  

Enabling it for the dispatch worker also enables it for all user workers in the dispatch namespace.

https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/reference/observability/#workers-trace-events-logpush