### PR TITLE
chore(zero-cache): use identifier quoting in SQL queries

### DIFF
--- a/packages/zero-cache/src/services/replicator/incremental-sync.pg-test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.pg-test.ts
@@ -56,25 +56,25 @@ describe('replicator/incremental-sync', () => {
       name: 'create tables',
       specs: {},
       data: {
-        ['_zero.tx_log']: [],
-        ['_zero.change_log']: [],
-        ['_zero.invalidation_registry']: [],
-        ['_zero.invalidation_index']: [],
+        ['_zero.TxLog']: [],
+        ['_zero.ChangeLog']: [],
+        ['_zero.InvalidationRegistry']: [],
+        ['_zero.InvalidationIndex']: [],
       },
     },
     {
       name: 'alter version columns',
       setupReplica: `
       CREATE TABLE issues(
-        issue_id INTEGER PRIMARY KEY,
+        "issueID" INTEGER PRIMARY KEY,
         _0_version VARCHAR(38) DEFAULT '00'
       );
       CREATE PUBLICATION zero_data FOR TABLES IN SCHEMA public;
 
       CREATE SCHEMA zero;
       CREATE TABLE zero.clients(
-        client_id TEXT PRIMARY KEY,
-        last_mutation_id TEXT,
+        "clientID" TEXT PRIMARY KEY,
+        "lastMutationID" TEXT,
         _0_version VARCHAR(38) DEFAULT '00'
       );
       CREATE PUBLICATION zero_meta FOR TABLES IN SCHEMA zero;
@@ -84,7 +84,7 @@ describe('replicator/incremental-sync', () => {
           schema: 'public',
           name: 'issues',
           columns: {
-            ['issue_id']: {
+            issueID: {
               dataType: 'int4',
               characterMaximumLength: null,
               columnDefault: null,
@@ -97,19 +97,19 @@ describe('replicator/incremental-sync', () => {
               notNull: true,
             },
           },
-          primaryKey: ['issue_id'],
+          primaryKey: ['issueID'],
         },
         ['zero.clients']: {
           schema: 'zero',
           name: 'clients',
           columns: {
-            ['client_id']: {
+            clientID: {
               dataType: 'text',
               characterMaximumLength: null,
               columnDefault: null,
               notNull: true,
             },
-            ['last_mutation_id']: {
+            lastMutationID: {
               dataType: 'text',
               characterMaximumLength: null,
               columnDefault: null,
@@ -122,28 +122,28 @@ describe('replicator/incremental-sync', () => {
               notNull: true,
             },
           },
-          primaryKey: ['client_id'],
+          primaryKey: ['clientID'],
         },
       },
       data: {
-        ['_zero.tx_log']: [],
-        ['_zero.change_log']: [],
-        ['_zero.invalidation_registry']: [],
-        ['_zero.invalidation_index']: [],
+        ['_zero.TxLog']: [],
+        ['_zero.ChangeLog']: [],
+        ['_zero.InvalidationRegistry']: [],
+        ['_zero.InvalidationIndex']: [],
       },
     },
     {
       name: 'insert rows',
       setupUpstream: `
       CREATE TABLE issues(
-        issue_id INTEGER PRIMARY KEY,
+        "issueID" INTEGER PRIMARY KEY,
         description TEXT
       );
       CREATE PUBLICATION zero_all FOR TABLES IN SCHEMA public;
       `,
       setupReplica: `
       CREATE TABLE issues(
-        issue_id INTEGER PRIMARY KEY,
+        "issueID" INTEGER PRIMARY KEY,
         description TEXT,
         _0_version VARCHAR(38) DEFAULT '00'
       );
@@ -154,7 +154,7 @@ describe('replicator/incremental-sync', () => {
           schema: 'public',
           name: 'issues',
           columns: {
-            ['issue_id']: {
+            issueID: {
               dataType: 'int4',
               characterMaximumLength: null,
               columnDefault: null,
@@ -173,24 +173,24 @@ describe('replicator/incremental-sync', () => {
               notNull: true,
             },
           },
-          primaryKey: ['issue_id'],
+          primaryKey: ['issueID'],
         },
       },
       writeUpstream: [
         `
-      INSERT INTO issues (issue_id) VALUES (123);
-      INSERT INTO issues (issue_id) VALUES (456);
+      INSERT INTO issues ("issueID") VALUES (123);
+      INSERT INTO issues ("issueID") VALUES (456);
       `,
         `
-      INSERT INTO issues (issue_id) VALUES (789);
+      INSERT INTO issues ("issueID") VALUES (789);
       `,
       ],
       expectedTransactions: 2,
       data: {
         ['public.issues']: [
-          {['issueId']: 123, description: null, ['_0Version']: '01'},
-          {['issueId']: 456, description: null, ['_0Version']: '01'},
-          {['issueId']: 789, description: null, ['_0Version']: '02'},
+          {issueID: 123, description: null, ['_0_version']: '01'},
+          {issueID: 456, description: null, ['_0_version']: '01'},
+          {issueID: 789, description: null, ['_0_version']: '02'},
         ],
       },
     },
@@ -198,20 +198,20 @@ describe('replicator/incremental-sync', () => {
       name: 'update rows with multiple key columns and key value updates',
       setupUpstream: `
       CREATE TABLE issues(
-        issue_id INTEGER,
-        org_id INTEGER,
+        "issueID" INTEGER,
+        "orgID" INTEGER,
         description TEXT,
-        PRIMARY KEY(org_id, issue_id)
+        PRIMARY KEY("orgID", "issueID")
       );
       CREATE PUBLICATION zero_all FOR TABLES IN SCHEMA public;
       `,
       setupReplica: `
       CREATE TABLE issues(
-        issue_id INTEGER,
-        org_id INTEGER,
+        "issueID" INTEGER,
+        "orgID" INTEGER,
         description TEXT,
         _0_version VARCHAR(38) DEFAULT '00',
-        PRIMARY KEY(org_id, issue_id)
+        PRIMARY KEY("orgID", "issueID")
       );
       CREATE PUBLICATION zero_all FOR TABLES IN SCHEMA public;
       `,
@@ -220,13 +220,13 @@ describe('replicator/incremental-sync', () => {
           schema: 'public',
           name: 'issues',
           columns: {
-            ['issue_id']: {
+            issueID: {
               dataType: 'int4',
               characterMaximumLength: null,
               columnDefault: null,
               notNull: true,
             },
-            ['org_id']: {
+            orgID: {
               dataType: 'int4',
               characterMaximumLength: null,
               columnDefault: null,
@@ -245,26 +245,26 @@ describe('replicator/incremental-sync', () => {
               notNull: true,
             },
           },
-          primaryKey: ['org_id', 'issue_id'],
+          primaryKey: ['orgID', 'issueID'],
         },
       },
       writeUpstream: [
         `
-      INSERT INTO issues (org_id, issue_id) VALUES (1, 123);
-      INSERT INTO issues (org_id, issue_id) VALUES (1, 456);
-      INSERT INTO issues (org_id, issue_id) VALUES (2, 789);
+      INSERT INTO issues ("orgID", "issueID") VALUES (1, 123);
+      INSERT INTO issues ("orgID", "issueID") VALUES (1, 456);
+      INSERT INTO issues ("orgID", "issueID") VALUES (2, 789);
       `,
         `
-      UPDATE issues SET (description) = ROW('foo') WHERE issue_id = 456;
-      UPDATE issues SET (org_id, description) = ROW(2, 'bar') WHERE issue_id = 123;
+      UPDATE issues SET (description) = ROW('foo') WHERE "issueID" = 456;
+      UPDATE issues SET ("orgID", description) = ROW(2, 'bar') WHERE "issueID" = 123;
       `,
       ],
       expectedTransactions: 2,
       data: {
         ['public.issues']: [
-          {orgId: 2, issueId: 123, description: 'bar', ['_0Version']: '02'},
-          {orgId: 1, issueId: 456, description: 'foo', ['_0Version']: '02'},
-          {orgId: 2, issueId: 789, description: null, ['_0Version']: '01'},
+          {orgID: 2, issueID: 123, description: 'bar', ['_0_version']: '02'},
+          {orgID: 1, issueID: 456, description: 'foo', ['_0_version']: '02'},
+          {orgID: 2, issueID: 789, description: null, ['_0_version']: '01'},
         ],
       },
     },
@@ -272,20 +272,20 @@ describe('replicator/incremental-sync', () => {
       name: 'delete rows',
       setupUpstream: `
       CREATE TABLE issues(
-        issue_id INTEGER,
-        org_id INTEGER,
+        "issueID" INTEGER,
+        "orgID" INTEGER,
         description TEXT,
-        PRIMARY KEY(org_id, issue_id)
+        PRIMARY KEY("orgID", "issueID")
       );
       CREATE PUBLICATION zero_all FOR TABLES IN SCHEMA public;
       `,
       setupReplica: `
       CREATE TABLE issues(
-        issue_id INTEGER,
-        org_id INTEGER,
+        "issueID" INTEGER,
+        "orgID" INTEGER,
         description TEXT,
         _0_version VARCHAR(38) DEFAULT '00',
-        PRIMARY KEY(org_id, issue_id)
+        PRIMARY KEY("orgID", "issueID")
       );
       CREATE PUBLICATION zero_all FOR TABLES IN SCHEMA public;
       `,
@@ -294,13 +294,13 @@ describe('replicator/incremental-sync', () => {
           schema: 'public',
           name: 'issues',
           columns: {
-            ['issue_id']: {
+            issueID: {
               dataType: 'int4',
               characterMaximumLength: null,
               columnDefault: null,
               notNull: true,
             },
-            ['org_id']: {
+            orgID: {
               dataType: 'int4',
               characterMaximumLength: null,
               columnDefault: null,
@@ -319,25 +319,25 @@ describe('replicator/incremental-sync', () => {
               notNull: true,
             },
           },
-          primaryKey: ['org_id', 'issue_id'],
+          primaryKey: ['orgID', 'issueID'],
         },
       },
       writeUpstream: [
         `
-      INSERT INTO issues (org_id, issue_id) VALUES (1, 123);
-      INSERT INTO issues (org_id, issue_id) VALUES (1, 456);
-      INSERT INTO issues (org_id, issue_id) VALUES (2, 789);
-      INSERT INTO issues (org_id, issue_id) VALUES (2, 987);
+      INSERT INTO issues ("orgID", "issueID") VALUES (1, 123);
+      INSERT INTO issues ("orgID", "issueID") VALUES (1, 456);
+      INSERT INTO issues ("orgID", "issueID") VALUES (2, 789);
+      INSERT INTO issues ("orgID", "issueID") VALUES (2, 987);
       `,
         `
-      DELETE FROM issues WHERE org_id = 1;
-      DELETE FROM issues WHERE issue_id = 987;
+      DELETE FROM issues WHERE "orgID" = 1;
+      DELETE FROM issues WHERE "issueID" = 987;
       `,
       ],
       expectedTransactions: 2,
       data: {
         ['public.issues']: [
-          {orgId: 2, issueId: 789, description: null, ['_0Version']: '01'},
+          {orgID: 2, issueID: 789, description: null, ['_0_version']: '01'},
         ],
       },
     },
@@ -369,7 +369,7 @@ describe('replicator/incremental-sync', () => {
           schema: 'public',
           name: 'foo',
           columns: {
-            ['id']: {
+            id: {
               dataType: 'int4',
               characterMaximumLength: null,
               columnDefault: null,
@@ -388,7 +388,7 @@ describe('replicator/incremental-sync', () => {
           schema: 'public',
           name: 'bar',
           columns: {
-            ['id']: {
+            id: {
               dataType: 'int4',
               characterMaximumLength: null,
               columnDefault: null,
@@ -407,7 +407,7 @@ describe('replicator/incremental-sync', () => {
           schema: 'public',
           name: 'baz',
           columns: {
-            ['id']: {
+            id: {
               dataType: 'int4',
               characterMaximumLength: null,
               columnDefault: null,
@@ -444,11 +444,11 @@ describe('replicator/incremental-sync', () => {
       ],
       expectedTransactions: 3,
       data: {
-        ['public.foo']: [{id: 101, ['_0Version']: '03'}],
+        ['public.foo']: [{id: 101, ['_0_version']: '03'}],
         ['public.bar']: [
-          {id: 4, ['_0Version']: '01'},
-          {id: 5, ['_0Version']: '01'},
-          {id: 6, ['_0Version']: '01'},
+          {id: 4, ['_0_version']: '01'},
+          {id: 5, ['_0_version']: '01'},
+          {id: 6, ['_0_version']: '01'},
         ],
         ['public.baz']: [],
       },
@@ -486,7 +486,7 @@ describe('replicator/incremental-sync', () => {
         // TODO: Replace this with the mechanism that will be used to notify ViewSyncers.
         for (let i = 0; i < 100; i++) {
           const result =
-            await replica`SELECT db_version FROM _zero.tx_log`.values();
+            await replica`SELECT "dbVersion" FROM _zero."TxLog"`.values();
           versions = result.flat();
           expect(versions.length).toBeLessThanOrEqual(c.expectedTransactions);
           if (versions.length === c.expectedTransactions) {
@@ -510,11 +510,11 @@ describe('replicator/incremental-sync', () => {
   ): Record<string, object[]> {
     Object.values(data).forEach(table =>
       table.forEach(row => {
-        if ('_0Version' in row) {
-          const v = row['_0Version'] as LexiVersion;
+        if ('_0_version' in row) {
+          const v = row['_0_version'] as LexiVersion;
           const index = Number(versionFromLexi(v));
           if (index > 0) {
-            row['_0Version'] = versions[index - 1];
+            row['_0_version'] = versions[index - 1];
           }
         }
       }),

--- a/packages/zero-cache/src/services/replicator/replicator.ts
+++ b/packages/zero-cache/src/services/replicator/replicator.ts
@@ -21,7 +21,6 @@ export class Replicator implements Service {
       .withContext('serviceID', this.id);
     this.#upstreamUri = upstreamUri;
     this.#syncReplica = postgres(syncReplicaUri, {
-      transform: postgres.camel,
       // eslint-disable-next-line @typescript-eslint/naming-convention
       fetch_types: false,
     });

--- a/packages/zero-cache/src/services/replicator/schema/sync-schema.pg-test.ts
+++ b/packages/zero-cache/src/services/replicator/schema/sync-schema.pg-test.ts
@@ -22,13 +22,13 @@ describe('replicator/sync-schema', () => {
 
   const cases: Case[] = [
     {
-      name: 'sync schema meta',
+      name: 'sync schema versions',
       upstreamPostState: {
         ['zero.clients']: [],
       },
       replicaPostState: {
         ['zero.clients']: [],
-        ['_zero.schema_meta']: [
+        ['_zero.SchemaVersions']: [
           {
             // Update these as necessary.
             version: 4,
@@ -43,20 +43,20 @@ describe('replicator/sync-schema', () => {
       name: 'sync partially published upstream data',
       upstreamSetup: `
         CREATE TABLE unpublished(issue_id INTEGER, org_id INTEGER, PRIMARY KEY (org_id, issue_id));
-        CREATE TABLE users(user_id INTEGER, password TEXT, handle TEXT, PRIMARY KEY (user_id));
-        CREATE PUBLICATION zero_custom FOR TABLE users (user_id, handle);
+        CREATE TABLE users("userID" INTEGER, password TEXT, handle TEXT, PRIMARY KEY ("userID"));
+        CREATE PUBLICATION zero_custom FOR TABLE users ("userID", handle);
     `,
       upstreamPreState: {
         users: [
-          {userId: 123, password: 'not-replicated', handle: '@zoot'},
-          {userId: 456, password: 'super-secret', handle: '@bonk'},
+          {userID: 123, password: 'not-replicated', handle: '@zoot'},
+          {userID: 456, password: 'super-secret', handle: '@bonk'},
         ],
       },
       upstreamPostState: {
         ['zero.clients']: [],
       },
       replicaPostState: {
-        ['_zero.schema_meta']: [
+        ['_zero.SchemaVersions']: [
           {
             // Update these as necessary.
             version: 4,
@@ -67,8 +67,8 @@ describe('replicator/sync-schema', () => {
         ],
         ['zero.clients']: [],
         users: [
-          {userId: 123, handle: '@zoot', ['_0Version']: '00'},
-          {userId: 456, handle: '@bonk', ['_0Version']: '00'},
+          {userID: 123, handle: '@zoot', ['_0_version']: '00'},
+          {userID: 456, handle: '@bonk', ['_0_version']: '00'},
         ],
       },
     },
@@ -127,10 +127,10 @@ describe('replicator/sync-schema', () => {
 
         // Check that internal replication tables have been created.
         await expectTables(replica, {
-          ['_zero.tx_log']: [],
-          ['_zero.change_log']: [],
-          ['_zero.invalidation_registry']: [],
-          ['_zero.invalidation_index']: [],
+          ['_zero.TxLog']: [],
+          ['_zero.ChangeLog']: [],
+          ['_zero.InvalidationRegistry']: [],
+          ['_zero.InvalidationIndex']: [],
         });
 
         // Subscriptions should have been dropped.
@@ -142,8 +142,8 @@ describe('replicator/sync-schema', () => {
         const slots =
           await upstream`SELECT slot_name FROM pg_replication_slots WHERE slot_name = ${replicationSlot(
             REPLICA_ID,
-          )}`;
-        expect(slots[0]).toEqual({slotName: replicationSlot(REPLICA_ID)});
+          )}`.values();
+        expect(slots[0]).toEqual([replicationSlot(REPLICA_ID)]);
       },
       10000,
     );

--- a/packages/zero-cache/src/services/replicator/tables/create.pg-test.ts
+++ b/packages/zero-cache/src/services/replicator/tables/create.pg-test.ts
@@ -25,20 +25,20 @@ describe('tables/create', () => {
         schema: 'public',
         name: 'clients',
         columns: {
-          ['client_id']: {
+          clientID: {
             dataType: 'varchar',
             characterMaximumLength: 180,
             columnDefault: null,
             notNull: true,
           },
-          ['last_mutation_id']: {
+          lastMutationID: {
             dataType: 'int8',
             characterMaximumLength: null,
             columnDefault: null,
             notNull: true,
           },
         },
-        primaryKey: ['client_id'],
+        primaryKey: ['clientID'],
       },
     },
     {

--- a/packages/zero-cache/src/services/replicator/tables/create.ts
+++ b/packages/zero-cache/src/services/replicator/tables/create.ts
@@ -1,3 +1,4 @@
+import {id, idList} from '../../../types/sql.js';
 import type {ColumnSpec, TableSpec} from './specs.js';
 
 /**
@@ -5,7 +6,7 @@ import type {ColumnSpec, TableSpec} from './specs.js';
  */
 export function createTableStatement(spec: TableSpec): string {
   function colDef(name: string, colSpec: ColumnSpec): string {
-    const parts = [`${name} ${colSpec.dataType}`];
+    const parts = [`${id(name)} ${colSpec.dataType}`];
     if (colSpec.characterMaximumLength !== null) {
       parts.push(`(${colSpec.characterMaximumLength})`);
     }
@@ -22,11 +23,11 @@ export function createTableStatement(spec: TableSpec): string {
     colDef(name, col),
   );
   if (spec.primaryKey) {
-    defs.push(`PRIMARY KEY (${spec.primaryKey.join(',')})`);
+    defs.push(`PRIMARY KEY (${idList(spec.primaryKey)})`);
   }
 
   return [
-    `CREATE TABLE ${spec.schema}.${spec.name} (`,
+    `CREATE TABLE ${id(spec.schema)}.${id(spec.name)} (`,
     defs.join(',\n'),
     ');',
   ].join('\n');

--- a/packages/zero-cache/src/services/replicator/tables/published.pg-test.ts
+++ b/packages/zero-cache/src/services/replicator/tables/published.pg-test.ts
@@ -25,8 +25,8 @@ describe('tables/published', () => {
       CREATE SCHEMA zero;
       CREATE PUBLICATION zero_all FOR TABLES IN SCHEMA zero;
       CREATE TABLE zero.clients (
-        client_id VARCHAR (180) PRIMARY KEY,
-        last_mutation_id BIGINT
+        "clientID" VARCHAR (180) PRIMARY KEY,
+        "lastMutationID" BIGINT
       );
       `,
       expectedResult: {
@@ -44,20 +44,20 @@ describe('tables/published', () => {
             schema: 'zero',
             name: 'clients',
             columns: {
-              ['client_id']: {
+              clientID: {
                 dataType: 'varchar',
                 characterMaximumLength: 180,
                 columnDefault: null,
                 notNull: true,
               },
-              ['last_mutation_id']: {
+              lastMutationID: {
                 dataType: 'int8',
                 characterMaximumLength: null,
                 columnDefault: null,
                 notNull: false,
               },
             },
-            primaryKey: ['client_id'],
+            primaryKey: ['clientID'],
           },
         },
       },
@@ -295,8 +295,8 @@ describe('tables/published', () => {
       CREATE PUBLICATION zero_meta FOR TABLES IN SCHEMA zero;
 
       CREATE TABLE zero.clients (
-        client_id VARCHAR (180) PRIMARY KEY,
-        last_mutation_id BIGINT
+        "clientID" VARCHAR (180) PRIMARY KEY,
+        "lastMutationID" BIGINT
       );
       `,
       expectedResult: {
@@ -371,20 +371,20 @@ describe('tables/published', () => {
             schema: 'zero',
             name: 'clients',
             columns: {
-              ['client_id']: {
+              clientID: {
                 dataType: 'varchar',
                 characterMaximumLength: 180,
                 columnDefault: null,
                 notNull: true,
               },
-              ['last_mutation_id']: {
+              lastMutationID: {
                 dataType: 'int8',
                 characterMaximumLength: null,
                 columnDefault: null,
                 notNull: false,
               },
             },
-            primaryKey: ['client_id'],
+            primaryKey: ['clientID'],
           },
         },
       },

--- a/packages/zero-cache/src/services/replicator/tables/published.ts
+++ b/packages/zero-cache/src/services/replicator/tables/published.ts
@@ -10,7 +10,7 @@ const publishedColumnsSchema = v.array(
     pos: v.number(),
     name: v.string(),
     type: v.string(),
-    typeId: v.number(),
+    typeID: v.number(),
     maxLen: v.number(),
     arrayDims: v.number(),
     keyPos: v.number().nullable(),
@@ -56,11 +56,11 @@ export async function getPublicationInfo(
     attnum AS pos, 
     attname AS name, 
     pt.typname AS type, 
-    atttypid AS type_id, 
-    atttypmod AS max_len, 
-    attndims array_dims, 
-    ARRAY_POSITION(conkey, attnum) AS key_pos,
-    attnotnull as not_null,
+    atttypid AS "typeID", 
+    atttypmod AS "maxLen", 
+    attndims "arrayDims", 
+    ARRAY_POSITION(conkey, attnum) AS "keyPos",
+    attnotnull as "notNull",
     pg_get_expr(pd.adbin, pd.adrelid) as default,
     pb.pubname
   FROM pg_attribute
@@ -98,7 +98,7 @@ export async function getPublicationInfo(
     const maxLen =
       col.maxLen < 0
         ? null
-        : col.typeId === 1043 || col.typeId === 1042
+        : col.typeID === 1043 || col.typeID === 1042
         ? col.maxLen - 4
         : col.maxLen;
 

--- a/packages/zero-cache/src/test/db.ts
+++ b/packages/zero-cache/src/test/db.ts
@@ -12,7 +12,6 @@ class TestDBs {
   // max_logical_replication_workers = 20   # default is 4
   readonly #sql = postgres({
     database: 'postgres',
-    transform: postgres.camel,
     onnotice: () => {},
   });
   readonly #dbs: Record<string, postgres.Sql> = {};
@@ -28,7 +27,6 @@ class TestDBs {
 
     const db = postgres({
       database,
-      transform: postgres.camel,
       onnotice: () => {},
     });
     this.#dbs[database] = db;

--- a/packages/zero-cache/src/types/sql.test.ts
+++ b/packages/zero-cache/src/types/sql.test.ts
@@ -1,0 +1,52 @@
+import {describe, expect, test} from '@jest/globals';
+import {id, idList} from './sql.js';
+
+describe('types/sql', () => {
+  type Case = {
+    id: string;
+    escaped: string;
+  };
+
+  const cases: Case[] = [
+    {
+      id: 'simple',
+      escaped: '"simple"',
+    },
+    {
+      id: 'containing"quotes',
+      escaped: '"containing""quotes"',
+    },
+    {
+      id: 'schema.table',
+      escaped: '"schema"."table"',
+    },
+  ];
+
+  for (const c of cases) {
+    test(c.id, () => {
+      expect(id(c.id)).toBe(c.escaped);
+    });
+  }
+
+  type ListCase = {
+    ids: string[];
+    escaped: string;
+  };
+
+  const listCases: ListCase[] = [
+    {
+      ids: ['simple', 'containing"quotes', 'schema.table'],
+      escaped: '"simple","containing""quotes","schema"."table"',
+    },
+    {
+      ids: ['singleton'],
+      escaped: '"singleton"',
+    },
+  ];
+
+  for (const c of listCases) {
+    test(c.ids.join(','), () => {
+      expect(idList(c.ids)).toBe(c.escaped);
+    });
+  }
+});

--- a/packages/zero-cache/src/types/sql.ts
+++ b/packages/zero-cache/src/types/sql.ts
@@ -1,0 +1,15 @@
+/**
+ * Escapes the identifier with double quotes, as per:
+ *
+ * https://www.postgresql.org/docs/16/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+ */
+export function id(name: string): string {
+  return '"' + name.replace(/"/g, '""').replace(/\./g, '"."') + '"';
+}
+
+/**
+ * Escapes and comma-separates a list of identifiers.
+ */
+export function idList(names: Iterable<string>): string {
+  return [...names].map(name => id(name)).join(',');
+}


### PR DESCRIPTION
Use identifier quoting as described in https://www.postgresql.org/docs/16/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS for our manual "unsafe" SQL queries. (The Postgres.js library that we uses does this automatically).

Also, remove the auto camel-case transformation configuration from the postgres client. This would have added variability/complexity on how columns of customer tables are handled.