### PR TITLE
feat(zero-cache): handle replayed transactions from upstream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4228,6 +4228,11 @@
         }
       }
     },
+    "node_modules/@drdgvhbh/postgres-error-codes": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@drdgvhbh/postgres-error-codes/-/postgres-error-codes-0.0.6.tgz",
+      "integrity": "sha512-tAz0Xp+qhq90x0r/3VW96iRdHFw72cYQqXa65u0eFVhSMC27bc2gZ8Ky5WXEmshrl/bCe7QTYBNEF0U5zeSQjw=="
+    },
     "node_modules/@edge-runtime/format": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@edge-runtime/format/-/format-2.0.1.tgz",
@@ -38515,6 +38520,7 @@
     "packages/zero-cache": {
       "version": "0.0.0",
       "dependencies": {
+        "@drdgvhbh/postgres-error-codes": "^0.0.6",
         "@rocicorp/lock": "^1.0.3",
         "@rocicorp/logger": "^5.2.1",
         "@rocicorp/resolver": "^1.0.1",
@@ -38567,6 +38573,7 @@
         "datadog": "0.0.0",
         "esbuild": "^0.19.4",
         "playwright": "^1.39.0",
+        "reflect-client": "0.0.0",
         "reflect-protocol": "0.0.0",
         "reflect-shared": "0.0.0",
         "replicache": "14.2.2",
@@ -40423,6 +40430,11 @@
       "requires": {
         "@datadog/browser-core": "4.42.2"
       }
+    },
+    "@drdgvhbh/postgres-error-codes": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@drdgvhbh/postgres-error-codes/-/postgres-error-codes-0.0.6.tgz",
+      "integrity": "sha512-tAz0Xp+qhq90x0r/3VW96iRdHFw72cYQqXa65u0eFVhSMC27bc2gZ8Ky5WXEmshrl/bCe7QTYBNEF0U5zeSQjw=="
     },
     "@edge-runtime/format": {
       "version": "2.0.1",
@@ -66369,6 +66381,7 @@
       "version": "file:packages/zero-cache",
       "requires": {
         "@cloudflare/workers-types": "^4.20231010.0",
+        "@drdgvhbh/postgres-error-codes": "^0.0.6",
         "@rocicorp/eslint-config": "^0.5.1",
         "@rocicorp/lock": "^1.0.3",
         "@rocicorp/logger": "^5.2.1",
@@ -66411,6 +66424,7 @@
         "datadog": "0.0.0",
         "esbuild": "^0.19.4",
         "playwright": "^1.39.0",
+        "reflect-client": "0.0.0",
         "reflect-protocol": "0.0.0",
         "reflect-shared": "0.0.0",
         "replicache": "14.2.2",

--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -14,6 +14,7 @@
     "local": "node --loader ts-node/esm tool/local.ts"
   },
   "dependencies": {
+    "@drdgvhbh/postgres-error-codes": "^0.0.6",
     "@rocicorp/lock": "^1.0.3",
     "@rocicorp/logger": "^5.2.1",
     "@rocicorp/resolver": "^1.0.1",

--- a/packages/zero-cache/src/services/replicator/incremental-sync.message-processor.pg-test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.message-processor.pg-test.ts
@@ -234,7 +234,6 @@ describe('replicator/message-processor', () => {
         ],
 
         // Simulate a reconnect with the replication stream sending the same tx again.
-        // Currently this results in an error but we should add detection for it.
         '0/2': [
           {tag: 'begin', commitLsn: '0/a', commitTime: 123n, xid: 123},
           {tag: 'insert', relation: FOO_RELATION, new: {id: 123}},
@@ -248,7 +247,7 @@ describe('replicator/message-processor', () => {
           },
         ],
 
-        // This should succeed once replay detection is implemented.
+        // This should succeed.
         '0/40': [
           {tag: 'begin', commitLsn: '0/f', commitTime: 127n, xid: 127},
           {tag: 'insert', relation: FOO_RELATION, new: {id: 789}},
@@ -264,20 +263,18 @@ describe('replicator/message-processor', () => {
       },
       acknowledged: [
         '0/a',
-        // TODO: Make this work.
-        // '0/f',
+        '0/a', // Note: The acknowledgement should be resent.
+        '0/f',
       ],
       replicated: {
         foo: [
           {id: 123, big: null, ['_0_version']: '0a'},
           {id: 234, big: null, ['_0_version']: '0a'},
-          // TODO: Make this work.
-          // {id: 789, big: null, ['_0_version']: '0f'},
-          // {id: 987, big: null, ['_0_version']: '0f'},
+          {id: 789, big: null, ['_0_version']: '0f'},
+          {id: 987, big: null, ['_0_version']: '0f'},
         ],
       },
-      // TODO: Make false
-      expectFailure: true,
+      expectFailure: false,
     },
   ];
 


### PR DESCRIPTION
Handle transactions replayed from upstream (e.g. if the connection was disconnected before the acknowledgment could be received) by dropping the transaction and moving on.