### PR TITLE
feat(zero-cache): simply and abstract transaction processing logic

### DIFF
--- a/packages/zero-cache/src/db/transaction-pool.pg-test.ts
+++ b/packages/zero-cache/src/db/transaction-pool.pg-test.ts
@@ -1,0 +1,180 @@
+import {PG_UNIQUE_VIOLATION} from '@drdgvhbh/postgres-error-codes';
+import {afterEach, beforeEach, describe, expect, test} from '@jest/globals';
+import postgres from 'postgres';
+import {sleep} from 'shared/src/sleep.js';
+import {expectTables, testDBs} from '../test/db.js';
+import {createSilentLogContext} from '../test/logger.js';
+import {TransactionPool} from './transaction-pool.js';
+
+describe('db/transaction-pool', () => {
+  let db: postgres.Sql<{bigint: bigint}>;
+  const lc = createSilentLogContext();
+
+  beforeEach(async () => {
+    db = await testDBs.create('transaction_pool');
+    await db`
+    CREATE TABLE foo (
+      id int PRIMARY KEY,
+      val text
+    );
+    CREATE TABLE tasks (
+      id SERIAL
+    );`.simple();
+  });
+
+  afterEach(async () => {
+    await testDBs.drop(db);
+  });
+
+  // Add a sleep in before each task to exercise concurrency. Otherwise
+  // it's always just the first worker that churns through all of the tasks.
+  const task = (stmt: string) => async (tx: postgres.TransactionSql) => {
+    await sleep(5);
+    return [tx.unsafe(stmt)];
+  };
+
+  test('single transaction, serialized processing', async () => {
+    const single = new TransactionPool(lc);
+
+    single.process(task(`INSERT INTO foo (id) VALUES (1)`));
+    single.process(task(`INSERT INTO foo (id) VALUES (6)`));
+    single.process(task(`UPDATE foo SET val = 'foo' WHERE id < 5`));
+    single.process(task(`INSERT INTO foo (id) VALUES (3)`));
+    single.setDone();
+
+    await single.run(db);
+
+    await expectTables(db, {
+      ['public.foo']: [
+        {id: 1, val: 'foo'},
+        {id: 3, val: null},
+        {id: 6, val: null},
+      ],
+    });
+  });
+
+  test('multiple transactions', async () => {
+    const pool = new TransactionPool(lc, 3);
+
+    pool.process(task(`INSERT INTO foo (id) VALUES (1)`));
+    pool.process(task(`INSERT INTO foo (id, val) VALUES (6, 'foo')`));
+    pool.process(task(`INSERT INTO foo (id) VALUES (3)`));
+    pool.process(task(`INSERT INTO foo (id) VALUES (2)`));
+    pool.process(task(`INSERT INTO foo (id, val) VALUES (8, 'foo')`));
+    pool.process(task(`INSERT INTO foo (id) VALUES (5)`));
+    pool.setDone();
+
+    await pool.run(db);
+
+    await expectTables(db, {
+      ['public.foo']: [
+        {id: 1, val: null},
+        {id: 2, val: null},
+        {id: 3, val: null},
+        {id: 5, val: null},
+        {id: 6, val: 'foo'},
+        {id: 8, val: 'foo'},
+      ],
+    });
+  });
+
+  test('multiple transactions with init', async () => {
+    const pool = new TransactionPool(
+      lc,
+      3,
+      task(`INSERT INTO tasks (id) VALUES (DEFAULT);`),
+    );
+
+    pool.process(task(`INSERT INTO foo (id) VALUES (1)`));
+    pool.process(task(`INSERT INTO foo (id, val) VALUES (6, 'foo')`));
+    pool.process(task(`INSERT INTO foo (id) VALUES (3)`));
+    pool.process(task(`INSERT INTO foo (id) VALUES (2)`));
+    pool.process(task(`INSERT INTO foo (id, val) VALUES (8, 'foo')`));
+    pool.process(task(`INSERT INTO foo (id) VALUES (5)`));
+    pool.setDone();
+
+    await pool.run(db);
+
+    await expectTables(db, {
+      ['public.foo']: [
+        {id: 1, val: null},
+        {id: 2, val: null},
+        {id: 3, val: null},
+        {id: 5, val: null},
+        {id: 6, val: 'foo'},
+        {id: 8, val: 'foo'},
+      ],
+      ['public.tasks']: [{id: 1}, {id: 2}, {id: 3}],
+    });
+  });
+
+  test('external failure before running', async () => {
+    const pool = new TransactionPool(lc, 3);
+
+    pool.process(task(`INSERT INTO foo (id) VALUES (1)`));
+    pool.process(task(`INSERT INTO foo (id, val) VALUES (6, 'foo')`));
+    pool.process(task(`INSERT INTO foo (id) VALUES (3)`));
+    pool.process(task(`INSERT INTO foo (id) VALUES (2)`));
+    pool.process(task(`INSERT INTO foo (id, val) VALUES (8, 'foo')`));
+    pool.process(task(`INSERT INTO foo (id) VALUES (5)`));
+    pool.setDone();
+
+    // Set the failure before running.
+    pool.fail(new Error('oh nose'));
+
+    const result = await pool.run(db).catch(e => e);
+    expect(result).toBeInstanceOf(Error);
+
+    // Nothing should have succeeded.
+    await expectTables(db, {
+      ['public.foo']: [],
+    });
+  });
+
+  test('external failure while running', async () => {
+    const pool = new TransactionPool(lc, 3);
+
+    pool.process(task(`INSERT INTO foo (id) VALUES (1)`));
+    pool.process(task(`INSERT INTO foo (id, val) VALUES (6, 'foo')`));
+    pool.process(task(`INSERT INTO foo (id) VALUES (3)`));
+    pool.process(task(`INSERT INTO foo (id) VALUES (2)`));
+    pool.process(task(`INSERT INTO foo (id, val) VALUES (8, 'foo')`));
+    pool.process(task(`INSERT INTO foo (id) VALUES (5)`));
+
+    const result = pool.run(db).catch(e => e);
+
+    // Set the failure after running.
+    pool.fail(new Error('oh nose'));
+    expect(await result).toBeInstanceOf(Error);
+
+    // Nothing should have succeeded.
+    await expectTables(db, {
+      ['public.foo']: [],
+    });
+  });
+
+  test('postgres error is surfaced', async () => {
+    const pool = new TransactionPool(lc, 3);
+
+    // With a total of 4 insert statements with id = 1, at least one tx is guaranteed to fail.
+    pool.process(task(`INSERT INTO foo (id) VALUES (1)`));
+    pool.process(task(`INSERT INTO foo (id, val) VALUES (6, 'foo')`));
+    pool.process(task(`INSERT INTO foo (id, val) VALUES (1, 'bad')`));
+    pool.process(task(`INSERT INTO foo (id) VALUES (3)`));
+    pool.process(task(`INSERT INTO foo (id) VALUES (2)`));
+    pool.process(task(`INSERT INTO foo (id, val) VALUES (1, 'double')`));
+    pool.process(task(`INSERT INTO foo (id) VALUES (5)`));
+    pool.process(task(`INSERT INTO foo (id, val) VALUES (1, 'oof')`));
+
+    const result = await pool.run(db).catch(e => e);
+
+    // Ensure that the postgres error is surfaced.
+    expect(result).toBeInstanceOf(postgres.PostgresError);
+    expect((result as postgres.PostgresError).code).toBe(PG_UNIQUE_VIOLATION);
+
+    // Nothing should have succeeded.
+    await expectTables(db, {
+      ['public.foo']: [],
+    });
+  });
+});

--- a/packages/zero-cache/src/db/transaction-pool.ts
+++ b/packages/zero-cache/src/db/transaction-pool.ts
@@ -1,0 +1,187 @@
+import type {LogContext} from '@rocicorp/logger';
+import type postgres from 'postgres';
+import {assert} from 'shared/src/asserts.js';
+import {Queue} from 'shared/src/queue.js';
+
+type MaybePromise<T> = Promise<T> | T;
+
+export type Statement = postgres.PendingQuery<
+  (postgres.Row & Iterable<postgres.Row>)[]
+>;
+
+/**
+ * A {@link Task} is logic run from within a transaction in a {@link TransactionPool}.
+ * It can return a list of `Statements` (for write transactions), which the transaction
+ * will execute asynchronously and await when it receives the 'done' signal, or it can
+ * return a `Promise<void>` (typical for read transactions) that is awaited when
+ * the task is processed.
+ */
+export type Task = (
+  tx: postgres.TransactionSql,
+  lc: LogContext,
+) => MaybePromise<Statement[] | void>;
+
+/**
+ * A TransactionPool is a pool of one or more {@link postgres.TransactionSql}
+ * objects that participate in processing a dynamic queue of tasks.
+ *
+ * This can be used for serializing a set of tasks that arrive asynchronously
+ * to a single transaction (for writing) or performing parallel reads across
+ * multiple connections at the same snapshot (e.g. read only snapshot transactions).
+ */
+export class TransactionPool {
+  readonly #lc: LogContext;
+  readonly #init: Task | undefined;
+  readonly #tasks = new Queue<Task | Error | 'done'>();
+  readonly #workers: Promise<unknown>[] = [];
+
+  #numWorkers: number;
+  #db: postgres.Sql | undefined; // set when running. stored to allow dynamic pool sizing.
+
+  #done = false;
+  #failure: Error | undefined;
+
+  /**
+   * @param numWorkers The number of transaction objects to use to process tasks.
+   * TODO: Add `maxWorkers` option for dynamic pool sizing.
+   * @param init A {@link Task} that is run in each Transaction before it begins
+   *             processing general tasks. This can be used to to set the transaction
+   *             mode, export/set snapshots, etc.
+   */
+  constructor(lc: LogContext, numWorkers = 1, init?: Task) {
+    this.#lc = lc;
+    this.#numWorkers = numWorkers;
+    this.#init = init;
+  }
+
+  /**
+   * Starts the pool of workers to process Tasks with transactions opened from the
+   * specified {@link db}.
+   *
+   * Returns a promise that resolves when all workers have closed their transactions,
+   * which happens after they have all received the {@link setDone} signal, or if
+   * processing was aborted with {@link fail}.
+   */
+  async run(db: postgres.Sql): Promise<void> {
+    assert(!this.#db, 'already running');
+    this.#db = db;
+    for (let i = 0; i < this.#numWorkers; i++) {
+      this.#addWorker(db);
+    }
+    await Promise.all(this.#workers);
+    this.#lc.debug?.('transaction pool done');
+  }
+
+  #addWorker(db: postgres.Sql) {
+    const lc = this.#lc.withContext('worker', `#${this.#workers.length + 1}`);
+    const worker = async (tx: postgres.TransactionSql) => {
+      lc.debug?.('started worker');
+
+      const pending: Promise<unknown>[] = [];
+
+      let task: Task | Error | 'done' =
+        this.#init ?? (await this.#tasks.dequeue());
+
+      while (task !== 'done') {
+        if (this.#failure || task instanceof Error) {
+          await Promise.all(pending); // avoid unhandled rejections
+          throw this.#failure ?? task;
+        }
+        const result = await task(tx, this.#lc);
+        if (Array.isArray(result)) {
+          // Execute the statements (i.e. send to the db) immediately and add them to
+          // `pending` for the final await.
+          //
+          // Optimization: Fail immediately on rejections to prevent more tasks from
+          // queueing up. This can save a lot of time if an initial task fails before
+          // many subsequent tasks (e.g. transaction replay detection).
+          pending.push(
+            ...result.map(stmt => stmt.execute().catch(e => this.fail(e))),
+          );
+          lc.debug?.(`executed ${result.length} statement(s)`, result);
+        }
+        // await the next task.
+        task = await this.#tasks.dequeue();
+      }
+
+      lc.debug?.('worker done');
+      return Promise.all(pending);
+    };
+
+    this.#workers.push(db.begin(worker));
+
+    // After adding the worker, enqueue a signal if we are in either of the terminal
+    // states (both of which prevent more tasks from being enqueued), to ensure that
+    // the new worker eventually exits.
+    if (this.#done) {
+      void this.#tasks.enqueue('done');
+    }
+    if (this.#failure) {
+      void this.#tasks.enqueue(this.#failure);
+    }
+  }
+
+  process(task: Task) {
+    assert(!this.#done, 'already set done');
+    if (this.#failure) {
+      this.#lc.debug?.('dropping task after failure');
+      return;
+    }
+    // TODO: Add dynamic pool sizing with a maxWorkers parameter.
+    void this.#tasks.enqueue(task);
+  }
+
+  /**
+   * Signals to all workers to end their transaction once all pending tasks have
+   * been completed.
+   */
+  setDone() {
+    assert(!this.#done, 'already set done');
+    this.#done = true;
+
+    for (let i = 0; i < this.#workers.length; i++) {
+      void this.#tasks.enqueue('done');
+    }
+  }
+
+  /**
+   * Signals all workers to fail their transactions with the given {@link err}.
+   */
+  fail(err: unknown) {
+    if (!this.#failure) {
+      this.#failure = ensureError(err); // Fail fast: this is checked in the worker loop.
+      if (this.#failure instanceof ControlFlowError) {
+        this.#lc.debug?.(this.#failure);
+      } else {
+        this.#lc.error?.(this.#failure);
+      }
+
+      for (let i = 0; i < this.#workers.length; i++) {
+        // Enqueue the Error to terminate any workers waiting for tasks.
+        void this.#tasks.enqueue(this.#failure);
+      }
+    }
+  }
+}
+
+/**
+ * A superclass of Errors used for control flow that is needed to handle
+ * another Error but does not constitute an error condition itself (e.g.
+ * aborting transactions after a previous one fails). Subclassing this Error
+ * will result in lowering the log level from `error` to `debug`.
+ */
+export class ControlFlowError extends Error {
+  constructor(err: unknown) {
+    super();
+    this.cause = err;
+  }
+}
+
+function ensureError(err: unknown): Error {
+  if (err instanceof Error) {
+    return err;
+  }
+  const error = new Error();
+  error.cause = err;
+  return error;
+}


### PR DESCRIPTION
Replace the previously `resolver`-heavy logic in the MessageProcessor with a more linear `TransactionPool` that utilizes a `Queue` instead of a `Lock` to serialize logic. This conveniently generalizes to a "work queue" that can shared amongst multiple workers, which will be used for invalidation reads.