### PR TITLE
fix(zero-cache): add a DELETE change for the old key in the ChangeLog

### DIFF
--- a/packages/zero-cache/src/services/replicator/incremental-sync.pg-test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.pg-test.ts
@@ -463,6 +463,14 @@ describe('replicator/incremental-sync', () => {
           {
             stateVersion: '02',
             tableName: 'public.issues',
+            op: 'd',
+            rowKeyHash: 'd4LTXQRobCPxSnobs_FcLg',
+            rowKey: {orgID: 1, issueID: 123},
+            row: null,
+          },
+          {
+            stateVersion: '02',
+            tableName: 'public.issues',
             op: 's',
             rowKeyHash: '2qJu-IDPIs7PqBsrtmwZRg',
             rowKey: {orgID: 2, issueID: 123},
@@ -872,6 +880,14 @@ describe('replicator/incremental-sync', () => {
             op: 'd',
             rowKeyHash: 'kHZmjyGbDssRKHHEbU2z2g',
             rowKey: {orgID: 2, issueID: 789},
+            row: null,
+          },
+          {
+            stateVersion: '01',
+            tableName: 'public.issues',
+            op: 'd',
+            rowKeyHash: 'd4LTXQRobCPxSnobs_FcLg',
+            rowKey: {orgID: 1, issueID: 123},
             row: null,
           },
           {

--- a/packages/zero-cache/src/types/pg.ts
+++ b/packages/zero-cache/src/types/pg.ts
@@ -7,19 +7,26 @@ const {
   types: {builtins, setTypeParser},
 } = pg;
 
+const builtinsINT8ARRAY = 1016; // No definition in builtins for int8[]
+
 /** Registers types for the 'pg' library used by `pg-logical-replication`. */
 export function registerPostgresTypeParsers() {
   setTypeParser(builtins.INT8, val => BigInt(val));
-  setTypeParser(1016, val => array.parse(val, val => BigInt(val)));
+  setTypeParser(builtinsINT8ARRAY, val => array.parse(val, val => BigInt(val)));
 }
+
+// Type these as `number` so that Typescript doesn't complain about
+// referencing external types during type inference.
+const builtinsJSON: number = builtins.JSON;
+const builtinsJSONB: number = builtins.JSONB;
 
 /** Configures types for the Postgres.js client library (`postgres`). */
 export const postgresTypeConfig = () => ({
   types: {
     bigint: postgres.BigInt,
     json: {
-      to: 114, // builtins.JSON
-      from: [114, 3802], // [builtins.JSON, builtins.JSONB]
+      to: builtinsJSON,
+      from: [builtinsJSON, builtinsJSONB],
       serialize: BigIntJSON.stringify,
       parse: BigIntJSON.parse,
     },


### PR DESCRIPTION
This correctly models an UPDATE that changes the key to a DEL of the old key and a SET of the new key.