### PR TITLE
fix: Call return in mergeAsyncIterables if present

### DIFF
--- a/packages/replicache/src/merge-async-iterables.ts
+++ b/packages/replicache/src/merge-async-iterables.ts
@@ -27,7 +27,7 @@ export async function* mergeAsyncIterables<A, B>(
   while (true) {
     if (iterResultA.done) {
       if (iterResultB.done) {
-        return;
+        break;
       }
       yield iterResultB.value;
       iterResultB = await b.next();
@@ -52,5 +52,13 @@ export async function* mergeAsyncIterables<A, B>(
       yield iterResultB.value;
       iterResultB = await b.next();
     }
+  }
+
+  // Both done. Call return if defined.
+  if (a.return) {
+    await a.return();
+  }
+  if (b.return) {
+    await b.return();
   }
 }


### PR DESCRIPTION
Sometimes iterator do cleanup work in `return`. This change ensures that `return` is called on the iterators used in `mergeAsyncIterables`.

https://discord.com/channels/830183651022471199/830183651022471202/1225550392201449482