### PR TITLE
Revert "fix: Call return in mergeAsyncIterables if present"

### DIFF
--- a/packages/replicache/src/merge-async-iterables.test.ts
+++ b/packages/replicache/src/merge-async-iterables.test.ts
@@ -87,38 +87,3 @@ test('mergeAsyncIterables', async () => {
     (a, b) => stringCompare(a[0], b[0]),
   );
 });
-
-test('mergeAsyncIterables with return', async () => {
-  const log: unknown[] = [];
-  const iterA = makeAsyncIterable([1, 2, 3, 4]);
-  const iterB: Iterable<number> = {
-    [Symbol.iterator]() {
-      let i = 0.5;
-      return {
-        next() {
-          log.push('next:' + i);
-          if (i > 3.5) {
-            return {done: true, value: -2};
-          }
-          return {done: false, value: i++};
-        },
-        return() {
-          log.push('return:' + i);
-          return {done: true, value: -22};
-        },
-      };
-    },
-  };
-
-  const merged = mergeAsyncIterables(iterA, iterB, (a, b) => a - b);
-  const result = await asyncIterableToArray(merged);
-  expect(result).to.deep.equal([0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4]);
-  expect(log).to.deep.equal([
-    'next:0.5',
-    'next:1.5',
-    'next:2.5',
-    'next:3.5',
-    'next:4.5',
-    'return:4.5',
-  ]);
-});

--- a/packages/replicache/src/merge-async-iterables.ts
+++ b/packages/replicache/src/merge-async-iterables.ts
@@ -27,7 +27,7 @@ export async function* mergeAsyncIterables<A, B>(
   while (true) {
     if (iterResultA.done) {
       if (iterResultB.done) {
-        break;
+        return;
       }
       yield iterResultB.value;
       iterResultB = await b.next();
@@ -52,13 +52,5 @@ export async function* mergeAsyncIterables<A, B>(
       yield iterResultB.value;
       iterResultB = await b.next();
     }
-  }
-
-  // Both done. Call return if defined.
-  if (a.return) {
-    await a.return();
-  }
-  if (b.return) {
-    await b.return();
   }
 }


### PR DESCRIPTION
Reverts rocicorp/mono#1527

Needs to deal with early exits too