### PR TITLE
fix(zero-cache): suppress spurious errors when tx pool fails

### DIFF
--- a/packages/zero-cache/src/db/transaction-pool.ts
+++ b/packages/zero-cache/src/db/transaction-pool.ts
@@ -149,7 +149,7 @@ export class TransactionPool {
 
         while (task !== 'done') {
           if (this.#failure || task instanceof Error) {
-            await Promise.all(pending); // avoid unhandled rejections
+            await Promise.allSettled(pending); // avoid unhandled rejections
             throw this.#failure ?? task;
           }
           await executeTask(task);


### PR DESCRIPTION
A TransactionPool failure often results in many errors being produced. Use `Promise.allSettled()` to finish pending tasks instead of `Promise.all()` to avoid throwing redundant (unhandled) exceptions.