### PR TITLE
feat(zero-cache): compute/commit invalidation tags during replication

### DIFF
--- a/packages/zero-cache/src/services/replicator/incremental-sync.message-processor.pg-test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.message-processor.pg-test.ts
@@ -7,6 +7,7 @@ import {Queue} from 'shared/src/queue.js';
 import {expectTables, testDBs} from '../../test/db.js';
 import {createSilentLogContext} from '../../test/logger.js';
 import {MessageProcessor, setupReplicationTables} from './incremental-sync.js';
+import {InvalidationFilters} from './invalidation.js';
 
 describe('replicator/message-processor', () => {
   let replica: postgres.Sql;
@@ -296,6 +297,7 @@ describe('replicator/message-processor', () => {
           tables: {},
         },
         new Lock(),
+        new InvalidationFilters(),
         (lsn: string) => acknowledgements.enqueue(lsn),
         (_: LogContext, err: unknown) => failures.enqueue(err),
       );

--- a/packages/zero-cache/src/services/replicator/invalidation.pg-test.ts
+++ b/packages/zero-cache/src/services/replicator/invalidation.pg-test.ts
@@ -1,160 +1,559 @@
 import {afterEach, beforeEach, describe, expect, test} from '@jest/globals';
 import {Lock} from '@rocicorp/lock';
 import type postgres from 'postgres';
+import {randInt} from 'shared/src/rand.js';
+import {
+  TransactionPool,
+  synchronizedSnapshots,
+} from '../../db/transaction-pool.js';
 import {expectTables, initDB, testDBs} from '../../test/db.js';
 import {createSilentLogContext} from '../../test/logger.js';
 import {
   NormalizedInvalidationFilterSpec,
+  invalidationHash,
   normalizeFilterSpec,
 } from '../../types/invalidation.js';
 import {CREATE_REPLICATION_TABLES} from './incremental-sync.js';
-import {CREATE_INVALIDATION_TABLES, Invalidator} from './invalidation.js';
+import {
+  CREATE_INVALIDATION_TABLES,
+  InvalidationFilters,
+  InvalidationProcessor,
+  Invalidator,
+} from './invalidation.js';
+import {TableTracker, type RowChange} from './types/table-tracker.js';
 
 describe('replicator/invalidation', () => {
-  let replica: postgres.Sql;
+  let db: postgres.Sql;
   let invalidator: Invalidator;
 
-  const SPEC1 = normalizeFilterSpec({
+  const FOO_SPEC1 = normalizeFilterSpec({
     schema: 'public',
     table: 'foo',
     filteredColumns: {id: '='},
   });
 
-  const SPEC2 = normalizeFilterSpec({
+  const FOO_SPEC2 = normalizeFilterSpec({
     schema: 'public',
     table: 'foo',
+    filteredColumns: {id: '=', name: '='},
+    selectedColumns: ['id', 'name'],
+  });
+
+  const BAR_SPEC1 = normalizeFilterSpec({
+    schema: 'public',
+    table: 'bar',
     filteredColumns: {id: '='},
-    selectedColumns: ['id', 'created'],
+  });
+
+  const BAR_SPEC2 = normalizeFilterSpec({
+    schema: 'public',
+    table: 'bar',
+    filteredColumns: {},
+    selectedColumns: ['id', 'name'],
   });
 
   const DATE1 = new Date(Date.UTC(2024, 2, 27, 1, 2, 3));
   const DATE2 = new Date(Date.UTC(2024, 2, 1, 2, 3, 4));
   const NOW = new Date(Date.UTC(2024, 4, 1, 2, 3, 4));
 
-  beforeEach(async () => {
-    replica = await testDBs.create('invalidation_test');
-    await replica.unsafe(
-      `CREATE SCHEMA _zero;` +
-        CREATE_INVALIDATION_TABLES +
-        CREATE_REPLICATION_TABLES,
-    );
-
-    invalidator = new Invalidator(replica, new Lock());
-  });
-
-  afterEach(async () => {
-    await testDBs.drop(replica);
-  });
-
-  type RegistrationTestCase = {
-    name: string;
-    specs: NormalizedInvalidationFilterSpec[];
-    version: string;
-    setup?: Record<string, Record<string, unknown>[]>;
-    expected?: Record<string, Record<string, unknown>[]>;
-  };
-
-  const regCases: RegistrationTestCase[] = [
-    {
-      name: 'empty registry, no transactions',
-      specs: [SPEC1, SPEC2],
-      version: '00',
-      expected: {
-        ['_zero.InvalidationRegistryVersion']: [
-          {stateVersionAtLastSpecChange: '00', lock: 'v'},
-        ],
-        ['_zero.InvalidationRegistry']: [
-          {
-            id: SPEC2.id,
-            spec: SPEC2,
-            fromStateVersion: '00',
-            lastRequested: NOW,
-          },
-          {
-            id: SPEC1.id,
-            spec: SPEC1,
-            fromStateVersion: '00',
-            lastRequested: NOW,
-          },
-        ],
-      },
-    },
-    {
-      name: 'already registered',
-      setup: {
-        ['_zero.InvalidationRegistry']: [
-          {
-            id: SPEC1.id,
-            spec: SPEC1,
-            fromStateVersion: '03',
-            lastRequested: DATE1,
-          },
-          {
-            id: SPEC2.id,
-            spec: SPEC2,
-            fromStateVersion: '02',
-            lastRequested: DATE2,
-          },
-        ],
-      },
-      specs: [SPEC1, SPEC2],
-      version: '03',
-    },
-    {
-      name: 'partially registered, existing changes',
-      specs: [SPEC1, SPEC2],
-      version: '04',
-      setup: {
-        ['_zero.TxLog']: [
-          {stateVersion: '04', lsn: '0/023', time: DATE2, xid: 123},
-        ],
-        ['_zero.InvalidationRegistryVersion']: [
-          {stateVersionAtLastSpecChange: '02', lock: 'v'},
-        ],
-        ['_zero.InvalidationRegistry']: [
-          {
-            id: SPEC2.id,
-            spec: SPEC2,
-            fromStateVersion: '02',
-            lastRequested: DATE1,
-          },
-        ],
-      },
-      expected: {
-        ['_zero.InvalidationRegistryVersion']: [
-          {stateVersionAtLastSpecChange: '04', lock: 'v'},
-        ],
-        ['_zero.InvalidationRegistry']: [
-          {
-            id: SPEC2.id,
-            spec: SPEC2,
-            fromStateVersion: '02',
-            lastRequested: DATE1,
-          },
-          {
-            id: SPEC1.id,
-            spec: SPEC1,
-            fromStateVersion: '04',
-            lastRequested: NOW,
-          },
-        ],
-      },
-    },
-  ];
-
-  for (const c of regCases) {
-    test(c.name, async () => {
-      await initDB(replica, undefined, c.setup);
-
-      const lc = createSilentLogContext();
-      const resp = await invalidator.registerInvalidationFilters(
-        lc,
-        {specs: c.specs},
-        NOW,
+  describe('registration', () => {
+    beforeEach(async () => {
+      db = await testDBs.create('invalidation_test');
+      await db.unsafe(
+        `CREATE SCHEMA _zero;` +
+          CREATE_INVALIDATION_TABLES +
+          CREATE_REPLICATION_TABLES,
       );
 
-      expect(resp.invalidatingFromVersion).toBe(c.version);
-      await expectTables(replica, c.expected);
+      invalidator = new Invalidator(db, new Lock(), new InvalidationFilters());
     });
-  }
+
+    afterEach(async () => {
+      await testDBs.drop(db);
+    });
+
+    type RegistrationTestCase = {
+      name: string;
+      specs: NormalizedInvalidationFilterSpec[];
+      version: string;
+      setup?: Record<string, Record<string, unknown>[]>;
+      expected?: Record<string, Record<string, unknown>[]>;
+    };
+
+    const regCases: RegistrationTestCase[] = [
+      {
+        name: 'empty registry, no transactions',
+        specs: [FOO_SPEC1, FOO_SPEC2],
+        version: '00',
+        expected: {
+          ['_zero.InvalidationRegistryVersion']: [
+            {stateVersionAtLastSpecChange: '00', lock: 'v'},
+          ],
+          ['_zero.InvalidationRegistry']: [
+            {
+              id: FOO_SPEC2.id,
+              spec: FOO_SPEC2,
+              fromStateVersion: '00',
+              lastRequested: NOW,
+            },
+            {
+              id: FOO_SPEC1.id,
+              spec: FOO_SPEC1,
+              fromStateVersion: '00',
+              lastRequested: NOW,
+            },
+          ],
+        },
+      },
+      {
+        name: 'already registered',
+        setup: {
+          ['_zero.InvalidationRegistry']: [
+            {
+              id: FOO_SPEC1.id,
+              spec: FOO_SPEC1,
+              fromStateVersion: '03',
+              lastRequested: DATE1,
+            },
+            {
+              id: FOO_SPEC2.id,
+              spec: FOO_SPEC2,
+              fromStateVersion: '02',
+              lastRequested: DATE2,
+            },
+          ],
+        },
+        specs: [FOO_SPEC1, FOO_SPEC2],
+        version: '03',
+      },
+      {
+        name: 'partially registered, existing changes',
+        specs: [FOO_SPEC1, FOO_SPEC2],
+        version: '04',
+        setup: {
+          ['_zero.TxLog']: [
+            {stateVersion: '04', lsn: '0/023', time: DATE2, xid: 123},
+          ],
+          ['_zero.InvalidationRegistryVersion']: [
+            {stateVersionAtLastSpecChange: '02', lock: 'v'},
+          ],
+          ['_zero.InvalidationRegistry']: [
+            {
+              id: FOO_SPEC2.id,
+              spec: FOO_SPEC2,
+              fromStateVersion: '02',
+              lastRequested: DATE1,
+            },
+          ],
+        },
+        expected: {
+          ['_zero.InvalidationRegistryVersion']: [
+            {stateVersionAtLastSpecChange: '04', lock: 'v'},
+          ],
+          ['_zero.InvalidationRegistry']: [
+            {
+              id: FOO_SPEC2.id,
+              spec: FOO_SPEC2,
+              fromStateVersion: '02',
+              lastRequested: DATE1,
+            },
+            {
+              id: FOO_SPEC1.id,
+              spec: FOO_SPEC1,
+              fromStateVersion: '04',
+              lastRequested: NOW,
+            },
+          ],
+        },
+      },
+    ];
+
+    for (const c of regCases) {
+      test(c.name, async () => {
+        await initDB(db, undefined, c.setup);
+
+        const lc = createSilentLogContext();
+        const resp = await invalidator.registerInvalidationFilters(
+          lc,
+          {specs: c.specs},
+          NOW,
+        );
+
+        expect(resp.invalidatingFromVersion).toBe(c.version);
+        await expectTables(db, c.expected);
+      });
+    }
+  });
+
+  describe('invalidation-processor', () => {
+    beforeEach(async () => {
+      db = await testDBs.create('invalidation_test');
+      await db.unsafe(
+        `CREATE SCHEMA _zero;` +
+          CREATE_INVALIDATION_TABLES +
+          CREATE_REPLICATION_TABLES +
+          `
+      CREATE TABLE foo (id int PRIMARY KEY, name text);
+      INSERT INTO foo (id, name) VALUES (1, 'one');
+      INSERT INTO foo (id, name) VALUES (2, 'two');
+      INSERT INTO foo (id, name) VALUES (3, 'three');
+
+      CREATE TABLE bar (id text PRIMARY KEY, name text);
+      INSERT INTO bar (id, name) VALUES ('one', 'fun');
+      INSERT INTO bar (id, name) VALUES ('two', 'true');
+      INSERT INTO bar (id, name) VALUES ('three', 'whee');
+        `,
+      );
+
+      const invalidator = new Invalidator(
+        db,
+        new Lock(),
+        new InvalidationFilters(),
+      );
+      await invalidator.registerInvalidationFilters(
+        createSilentLogContext(),
+        {specs: [FOO_SPEC1, FOO_SPEC2, BAR_SPEC1, BAR_SPEC2]},
+        NOW,
+      );
+    });
+
+    afterEach(async () => {
+      await testDBs.drop(db);
+    });
+
+    type InvalidationCase = {
+      name: string;
+      fooChanges?: (RowChange | 'truncate')[];
+      barChanges?: (RowChange | 'truncate')[];
+      expectedHashes: string[];
+    };
+
+    const invalidationCases: InvalidationCase[] = [
+      {
+        name: 'no changes',
+        expectedHashes: [],
+      },
+      {
+        name: 'insert',
+        fooChanges: [
+          {
+            preValue: null,
+            postRowKey: {id: 4},
+            postValue: {id: 4, name: 'for'},
+          },
+        ],
+        expectedHashes: [
+          invalidationHash({
+            schema: 'public',
+            table: 'foo',
+            filteredColumns: {id: '4'},
+          }),
+          invalidationHash({
+            schema: 'public',
+            table: 'foo',
+            filteredColumns: {id: '4', name: '"for"'},
+            selectedColumns: ['id', 'name'],
+          }),
+        ],
+      },
+      {
+        name: 'update',
+        fooChanges: [
+          {
+            preValue: undefined,
+            postRowKey: {id: 3},
+            postValue: {id: 3, name: 'free'},
+          },
+        ],
+        expectedHashes: [
+          invalidationHash({
+            schema: 'public',
+            table: 'foo',
+            filteredColumns: {id: '3'},
+          }),
+          invalidationHash({
+            schema: 'public',
+            table: 'foo',
+            filteredColumns: {id: '3', name: '"three"'},
+            selectedColumns: ['id', 'name'],
+          }),
+          invalidationHash({
+            schema: 'public',
+            table: 'foo',
+            filteredColumns: {id: '3', name: '"free"'},
+            selectedColumns: ['id', 'name'],
+          }),
+        ],
+      },
+      {
+        name: 'delete',
+        fooChanges: [
+          {
+            preValue: undefined,
+            postRowKey: {id: 1},
+            postValue: null,
+          },
+        ],
+        expectedHashes: [
+          invalidationHash({
+            schema: 'public',
+            table: 'foo',
+            filteredColumns: {id: '1'},
+          }),
+          invalidationHash({
+            schema: 'public',
+            table: 'foo',
+            filteredColumns: {id: '1', name: '"one"'},
+            selectedColumns: ['id', 'name'],
+          }),
+        ],
+      },
+      {
+        name: 'update with row key change',
+        fooChanges: [
+          {
+            preValue: undefined,
+            preRowKey: {id: 3},
+            postRowKey: {id: 4},
+            postValue: {id: 4, name: 'more'},
+          },
+        ],
+        expectedHashes: [
+          invalidationHash({
+            schema: 'public',
+            table: 'foo',
+            filteredColumns: {id: '3'},
+          }),
+          invalidationHash({
+            schema: 'public',
+            table: 'foo',
+            filteredColumns: {id: '4'},
+          }),
+          invalidationHash({
+            schema: 'public',
+            table: 'foo',
+            filteredColumns: {id: '3', name: '"three"'},
+            selectedColumns: ['id', 'name'],
+          }),
+          invalidationHash({
+            schema: 'public',
+            table: 'foo',
+            filteredColumns: {id: '4', name: '"more"'},
+            selectedColumns: ['id', 'name'],
+          }),
+        ],
+      },
+      {
+        name: 'multiple changes',
+        fooChanges: [
+          {
+            // insert
+            preValue: null,
+            postRowKey: {id: 4},
+            postValue: {id: 4, name: 'more'},
+          },
+          {
+            // update
+            preValue: undefined,
+            preRowKey: {id: 4},
+            postRowKey: {id: 5},
+            postValue: {id: 5, name: 'live'},
+          },
+          {
+            // delete
+            preValue: undefined,
+            postRowKey: {id: 3},
+            postValue: null,
+          },
+        ],
+        barChanges: [
+          {
+            // update
+            preValue: undefined,
+            postRowKey: {id: 'two'},
+            postValue: {id: 'two', name: 'blue'},
+          },
+          {
+            // delete
+            preValue: undefined,
+            postRowKey: {id: 'three'},
+            postValue: null,
+          },
+        ],
+        expectedHashes: [
+          invalidationHash({
+            schema: 'public',
+            table: 'foo',
+            filteredColumns: {id: '3'},
+          }),
+          invalidationHash({
+            schema: 'public',
+            table: 'foo',
+            filteredColumns: {id: '5'},
+          }),
+          invalidationHash({
+            schema: 'public',
+            table: 'foo',
+            filteredColumns: {id: '3', name: '"three"'},
+            selectedColumns: ['id', 'name'],
+          }),
+          invalidationHash({
+            schema: 'public',
+            table: 'foo',
+            filteredColumns: {id: '5', name: '"live"'},
+            selectedColumns: ['id', 'name'],
+          }),
+          invalidationHash({
+            schema: 'public',
+            table: 'bar',
+            filteredColumns: {id: '"two"'},
+          }),
+          invalidationHash({
+            schema: 'public',
+            table: 'bar',
+            filteredColumns: {id: '"three"'},
+          }),
+          invalidationHash({
+            schema: 'public',
+            table: 'bar',
+            filteredColumns: {},
+            selectedColumns: ['id', 'name'],
+          }),
+        ],
+      },
+      {
+        name: 'multiple changes with truncate',
+        fooChanges: [
+          'truncate',
+          // The rest of the changes need not produce an invalidation tag.
+          {
+            // insert
+            preValue: null,
+            postRowKey: {id: 4},
+            postValue: {id: 4, name: 'more'},
+          },
+          {
+            // update
+            preValue: undefined,
+            preRowKey: {id: 4},
+            postRowKey: {id: 5},
+            postValue: {id: 5, name: 'live'},
+          },
+          {
+            // delete
+            preValue: undefined,
+            postRowKey: {id: 3},
+            postValue: null,
+          },
+        ],
+        barChanges: [
+          {
+            // update
+            preValue: undefined,
+            postRowKey: {id: 'two'},
+            postValue: {id: 'two', name: 'blue'},
+          },
+          {
+            // delete
+            preValue: undefined,
+            postRowKey: {id: 'three'},
+            postValue: null,
+          },
+        ],
+        expectedHashes: [
+          invalidationHash({
+            schema: 'public',
+            table: 'foo',
+            allRows: true,
+          }),
+          invalidationHash({
+            schema: 'public',
+            table: 'bar',
+            filteredColumns: {id: '"two"'},
+          }),
+          invalidationHash({
+            schema: 'public',
+            table: 'bar',
+            filteredColumns: {id: '"three"'},
+          }),
+          invalidationHash({
+            schema: 'public',
+            table: 'bar',
+            filteredColumns: {},
+            selectedColumns: ['id', 'name'],
+          }),
+        ],
+      },
+    ];
+
+    const OLD_VERSION = '02';
+    const NEW_VERSION = '0d';
+
+    for (const c of invalidationCases) {
+      test(c.name, async () => {
+        // Randomly write some of the hashes to an old version (to verify UPSERT).
+        for (const hash of c.expectedHashes) {
+          if (randInt(0, 1)) {
+            await db`
+            INSERT INTO _zero."InvalidationIndex" ${db({
+              hash: Buffer.from(hash, 'hex'),
+              stateVersion: OLD_VERSION,
+            })}
+            `;
+          }
+        }
+
+        const lc = createSilentLogContext();
+        const {exportSnapshot, cleanupExport, setSnapshot} =
+          synchronizedSnapshots();
+        const writer = new TransactionPool(
+          lc.withContext('pool', 'writer'),
+          exportSnapshot,
+          cleanupExport,
+        );
+        const readers = new TransactionPool(
+          lc.withContext('pool', 'readers'),
+          setSnapshot,
+          undefined,
+          1, // start with 1 worker
+          2, // but allow growing the pool to 2 workers
+        );
+        const done = Promise.all([writer.run(db), readers.run(db)]);
+
+        const processor = new InvalidationProcessor(new InvalidationFilters());
+        processor.processInitTasks(readers, writer);
+
+        const fooTable = new TableTracker('public', 'foo', {id: {typeOid: 23}});
+        const barTable = new TableTracker('public', 'bar', {id: {typeOid: 25}});
+
+        for (const change of c.fooChanges ?? []) {
+          if (change === 'truncate') {
+            fooTable.truncate();
+          } else {
+            fooTable.add(change);
+          }
+        }
+        for (const change of c.barChanges ?? []) {
+          if (change === 'truncate') {
+            barTable.truncate();
+          } else {
+            barTable.add(change);
+          }
+        }
+        processor.processFinalTasks(readers, writer, NEW_VERSION, [
+          fooTable,
+          barTable,
+        ]);
+        readers.setDone();
+        writer.setDone();
+        await done;
+
+        const index =
+          await db`SELECT hash, "stateVersion" FROM _zero."InvalidationIndex"`;
+        const hashes = index.map(row => (row.hash as Buffer).toString('hex'));
+        expect(hashes).toEqual(expect.arrayContaining(c.expectedHashes));
+        index.forEach(row => expect(row.stateVersion).toBe(NEW_VERSION));
+      });
+    }
+  });
 });

--- a/packages/zero-cache/src/services/replicator/invalidation.ts
+++ b/packages/zero-cache/src/services/replicator/invalidation.ts
@@ -1,17 +1,26 @@
 import type {Lock} from '@rocicorp/lock';
 import type {LogContext} from '@rocicorp/logger';
+import {resolver} from '@rocicorp/resolver';
 import {stringify} from 'json-custom-numbers';
 import type postgres from 'postgres';
+import {assert} from 'shared/src/asserts.js';
+import {lookupRowsWithKeys} from '../../db/queries.js';
+import type {TransactionPool} from '../../db/transaction-pool.js';
 import {
+  RowTag,
+  invalidationHash,
   parseFilterSpec,
   type InvalidationFilterSpec,
   type NormalizedInvalidationFilterSpec,
 } from '../../types/invalidation.js';
 import type {LexiVersion} from '../../types/lexi-version.js';
+import type {RowKeyType, RowValue} from '../../types/row-key.js';
+import {rowKeyString} from '../../types/row-key.js';
 import type {
   RegisterInvalidationFiltersRequest,
   RegisterInvalidationFiltersResponse,
 } from './replicator.js';
+import type {EffectiveRowChange, TableTracker} from './types/table-tracker.js';
 
 /**
  * Metadata, used for selective invalidation and catchup.
@@ -87,7 +96,7 @@ CREATE TABLE _zero."InvalidationRegistryVersion" (
 CREATE TABLE _zero."InvalidationIndex" (
   hash           BYTEA       NOT NULL,
   "stateVersion" VARCHAR(38) NOT NULL,
-  PRIMARY KEY(hash)
+  CONSTRAINT "PK_InvalidationIndex" PRIMARY KEY(hash)
 );
 ` +
   // A btree over the InvalidationIndex's "stateVersion" column allows
@@ -100,22 +109,20 @@ CREATE INDEX "InvalidationIndex_stateVersion_btree"
   USING BTREE ("stateVersion");
 `;
 
-type CachedFilters = {
-  specs: InvalidationFilterSpec[];
-  version: LexiVersion;
-};
-
 export class Invalidator {
   readonly #replica: postgres.Sql;
   readonly #txSerializer: Lock;
+  readonly #filters: InvalidationFilters;
   readonly #lastRequestedTimes = new Map<string, Date>();
 
-  // Versioned cache of the InvalidationRegistry.
-  cachedFilters: CachedFilters | undefined;
-
-  constructor(replica: postgres.Sql, txSerializer: Lock) {
+  constructor(
+    replica: postgres.Sql,
+    txSerializer: Lock,
+    invalidationFilters: InvalidationFilters,
+  ) {
     this.#replica = replica;
     this.#txSerializer = txSerializer;
+    this.#filters = invalidationFilters;
   }
 
   async registerInvalidationFilters(
@@ -175,7 +182,6 @@ export class Invalidator {
         for (const {id} of unregistered) {
           const spec = specsByID.get(id);
           const row = {id, spec, fromStateVersion, lastRequested: now};
-          lc.info?.(`Registering InvalidationFilterSpec`, spec);
           void tx`
           INSERT INTO _zero."InvalidationRegistry" ${tx(row)}
           `.execute();
@@ -190,26 +196,42 @@ export class Invalidator {
           DO UPDATE SET "stateVersionAtLastSpecChange" = EXCLUDED."stateVersionAtLastSpecChange";
           `.execute();
 
-        await this.#ensureCachedFilters(lc, tx, fromStateVersion);
+        await this.#filters.ensureCachedFilters(lc, tx, fromStateVersion);
 
         return {invalidatingFromVersion: fromStateVersion};
       }),
     );
   }
+}
+
+export type CachedFilters = {
+  readonly specs: InvalidationFilterSpec[];
+  readonly version: LexiVersion;
+};
+
+/**
+ * InvalidationFilters is a shared reference to the most recently loaded and parsed
+ * filters from the InvalidationRegistry.
+ */
+export class InvalidationFilters {
+  // Versioned cache of the InvalidationRegistry.
+  #cachedFilters: CachedFilters | undefined;
 
   /**
-   * Refreshes the CachedFilters, called whenever the set of specs is know to have changed.
+   * Refreshes the CachedFilters, called whenever the set of specs needs to be loaded or
+   * verified against an `expectedVersion`. This must always be called from within the
+   * `txSerializer`.
    *
    * @param expectedVersion The expected version as read from the database. This is checked
    *        against any existing CachedFilters to see if they need to be reloaded. If unset,
    *        cached filters are loaded if not yet loaded.
    */
-  async #ensureCachedFilters(
+  async ensureCachedFilters(
     lc: LogContext,
     db: postgres.Sql,
     expectedVersion?: LexiVersion,
   ): Promise<CachedFilters> {
-    const cached = this.cachedFilters;
+    const cached = this.#cachedFilters;
     if (cached && cached.version === (expectedVersion ?? cached.version)) {
       return cached;
     }
@@ -229,7 +251,203 @@ export class Invalidator {
     lc.info?.(
       `Loaded ${loaded.specs.length} filters at version ${loaded.version}`,
     );
-    this.cachedFilters = loaded;
+    this.#cachedFilters = loaded;
     return loaded;
   }
+}
+
+export class InvalidationProcessor {
+  readonly #filters: InvalidationFilters;
+  readonly #invalidationHashes = new Set<string>();
+
+  #cachedFilters: Promise<CachedFilters> | undefined;
+
+  constructor(filters: InvalidationFilters) {
+    this.#filters = filters;
+  }
+
+  /**
+   * Runs Tasks on the `readers` and `writer` pools to initialize the invalidation processing.
+   *
+   * Implementation: The `writer` task checks the version of the InvalidationRegistry and
+   * loads the filters if the version differs from the cached filters. This must be done on
+   * the `writer` pool to prevent a concurrent update to the InvalidationRegistry via a
+   * `SELECT ... FOR UPDATE`.
+   */
+  processInitTasks(_readers: TransactionPool, writer: TransactionPool) {
+    const {promise, resolve, reject} = resolver<CachedFilters>();
+    this.#cachedFilters = promise;
+
+    writer.process((tx, lc) => {
+      // Perform a SELECT ... FOR UPDATE query to prevent concurrent invalidation filter registration.
+      // Although concurrency should not happen in the steady state because registration is serialized
+      // with transaction processing via the `txSerializer`, enforcing this at the database level provides
+      // protection in the face of multiple Durable Objects running during an update.
+      const stmt = tx`
+      SELECT "stateVersionAtLastSpecChange" as version
+        FROM _zero."InvalidationRegistryVersion" 
+        FOR UPDATE
+      `.simple();
+
+      stmt.then(result => {
+        this.#filters
+          .ensureCachedFilters(lc, tx, result.length ? result[0].version : '00')
+          .then(resolve, reject);
+      }, reject);
+      return [stmt];
+    });
+  }
+
+  /**
+   * Runs Tasks on the `readers` and `writer` pools to complete invalidation processing.
+   * Starts reader tasks to lookup any necessary rows for the given row changes and
+   * computes the corresponding invalidation hashes. Returns a task for the `writer`
+   * pool to commit the hashes, which will block until the hashes are computed.
+   */
+
+  processFinalTasks(
+    readers: TransactionPool,
+    writer: TransactionPool,
+    stateVersion: LexiVersion,
+    tables: Iterable<TableTracker>,
+  ) {
+    // Fire off tasks on the `readers` pool to process the effective row changes of each
+    // table in parallel. Workers will be spawned as necessary up to the configured
+    // maxWorkers parameter of the TransactionPool.
+    for (const table of tables) {
+      readers.process((tx, lc) =>
+        this.#computeInvalidationHashes(lc, tx, table),
+      );
+    }
+
+    writer.process(async (tx, lc) => {
+      // Wait for all #computeInvalidationHashes Tasks on the #readers pool to complete.
+      await readers.done();
+
+      lc.debug?.(
+        `Committing ${this.#invalidationHashes.size} invalidation tags`,
+        [...this.#invalidationHashes],
+      );
+      return [...this.#invalidationHashes].map(
+        hash => tx`
+      INSERT INTO _zero."InvalidationIndex" ${tx({
+        hash: Buffer.from(hash, 'hex'),
+        stateVersion,
+      })}
+        ON CONFLICT ON CONSTRAINT "PK_InvalidationIndex"
+        DO UPDATE SET "stateVersion" = EXCLUDED."stateVersion";
+        `,
+      );
+    });
+  }
+
+  /**
+   * The Task run on the `readers` pool to compute invalidation hashes for the row
+   * changes of a `table`.
+   */
+  async #computeInvalidationHashes(
+    lc: LogContext,
+    tx: postgres.TransactionSql,
+    table: TableTracker,
+  ) {
+    const {truncated, changes} = table.getEffectiveRowChanges();
+    if (truncated) {
+      this.#invalidationHashes.add(
+        invalidationHash({
+          schema: table.schema,
+          table: table.table,
+          allRows: true,
+        }),
+      );
+      // When a table is truncated, all queries for the table are effected.
+      // There is no need to compute any finer-grained invalidation tags.
+      return;
+    }
+    // Lookup preValues for UPDATEs and DELETEs.
+    await lookupUndefinedPreValues(
+      lc,
+      tx,
+      table.schema,
+      table.table,
+      table.rowKeyType,
+      changes,
+    );
+
+    lc.info?.(
+      `Computing invalidation tags for ${changes.size} rows in ${table.schema}.${table.table}`,
+    );
+
+    // Await the cached filters
+    assert(this.#cachedFilters, `#cachedFilters is setup in processInitTasks`);
+    const cachedFilters = await this.#cachedFilters;
+
+    const filters = cachedFilters.specs.filter(
+      f => f.schema === table.schema && f.table === table.table,
+    );
+    const processRow = (row: RowValue) => {
+      // Lazily stringified values of filtered columns.
+      const stringified: Record<string, string> = {};
+
+      for (const filter of filters) {
+        const rowTag: RowTag = {
+          schema: table.schema,
+          table: table.table,
+          filteredColumns: Object.fromEntries(
+            Object.keys(filter.filteredColumns).map(col => [
+              col,
+              (stringified[col] ??= stringify(row[col])),
+            ]),
+          ),
+          selectedColumns: filter.selectedColumns,
+        };
+        this.#invalidationHashes.add(invalidationHash(rowTag));
+      }
+    };
+
+    for (const row of changes.values()) {
+      assert(row.preValue !== undefined); // all preValues should have looked up.
+      if (row.preValue) {
+        processRow(row.preValue);
+      }
+      if (row.postValue) {
+        processRow(row.postValue);
+      }
+      // TODO: For UPDATEs there will be both a preValue and postValue.
+      // Updates only need to produce invalidations if a filter's selectedColumns
+      // or filteredColumns changed. Otherwise, the filter can be skipped.
+    }
+  }
+}
+
+async function lookupUndefinedPreValues(
+  lc: LogContext,
+  tx: postgres.Sql,
+  schema: string,
+  table: string,
+  rowKeyType: RowKeyType,
+  changes: Map<string, EffectiveRowChange>,
+) {
+  const keys = [...changes.values()]
+    .filter(change => change.preValue === undefined)
+    .map(change => change.rowKey);
+  if (keys.length === 0) {
+    return;
+  }
+
+  lc.debug?.(`Looking up ${keys.length} pre-tx values from ${schema}.${table}`);
+
+  let count = 0;
+  const keyCols = Object.keys(rowKeyType);
+  await lookupRowsWithKeys(tx, schema, table, rowKeyType, keys).forEach(row => {
+    const key = rowKeyString(
+      Object.fromEntries(keyCols.map(col => [col, row[col]])),
+    );
+    const c = changes.get(key);
+    assert(c, `Row does not correspond to change ${key}`);
+    assert(c.preValue === undefined, `Unexpected preValue: ${key}`);
+    c.preValue = row;
+    count++;
+  });
+
+  assert(count === keys.length, `Expected ${keys.length}, got ${count}`);
 }

--- a/packages/zero-cache/src/types/invalidation.test.ts
+++ b/packages/zero-cache/src/types/invalidation.test.ts
@@ -35,7 +35,7 @@ describe('types/invalidation', () => {
         filteredColumns: {},
         selectedColumns: ['bar'],
       },
-      hash: '438451ab415ecac', // Different from TableTag
+      hash: '0438451ab415ecac', // Different from TableTag
     },
     {
       name: 'FullTableTag',
@@ -78,6 +78,8 @@ describe('types/invalidation', () => {
   for (const c of hashCases) {
     test(`invalidationHash: ${c.name}`, () => {
       expect(invalidationHash(c.tag)).toBe(c.hash);
+      // Verify back/forth serialization (requires whole-byte padding of hex string).
+      expect(Buffer.from(c.hash, 'hex').toString('hex')).toBe(c.hash);
     });
   }
 

--- a/packages/zero-cache/src/types/invalidation.ts
+++ b/packages/zero-cache/src/types/invalidation.ts
@@ -188,5 +188,8 @@ export function invalidationHash(tag: InvalidationTag): string {
   } else {
     // TableTag (already done)
   }
-  return hasher.digest().toString(16);
+  const hex = hasher.digest().toString(16);
+  // Pad to whole byte lengths to ensure roundtrip integrity when
+  // serialized to/from BYTEA / Buffer.
+  return hex.length % 2 ? '0' + hex : hex;
 }


### PR DESCRIPTION
Building on previous primitives:
* `TransactionPool` / synchronizedSnapshots for read-only transactions consistent with the main write transaction
* `TableTracker` for tracking the effective pre- and post- transaction states of a row
* `lookupRowsWithKeys` for batched lookup of many rows from a table

implements invalidation tagging within the incremental sync logic of replication. Most of the logic is in the `InvalidationProcessor`.