### PR TITLE
fix(zql): table is not optional, alias is a string

### DIFF
--- a/packages/zql/src/zql/ast/ast.ts
+++ b/packages/zql/src/zql/ast/ast.ts
@@ -26,7 +26,7 @@ export type Aggregation = {
  */
 export type AST = {
   readonly table: string;
-  readonly alias?: number | undefined;
+  readonly alias?: string | undefined;
   readonly select?: [selector: string, alias: string][] | undefined;
   readonly aggregate?: Aggregation[];
   // readonly subQueries?: {

--- a/packages/zql/src/zql/query/entity-query.ts
+++ b/packages/zql/src/zql/query/entity-query.ts
@@ -177,8 +177,6 @@ export type MakeHumanReadable<T> = {} & {
   readonly [P in keyof T]: T[P] extends string ? T[P] : MakeHumanReadable<T[P]>;
 };
 
-let aliasCount = 0;
-
 export type WhereCondition<From extends FromSet> =
   | {
       op: 'AND' | 'OR';
@@ -207,7 +205,6 @@ export class EntityQuery<From extends FromSet, Return = []> {
   constructor(context: Context, tableName: string, ast?: AST) {
     this.#ast = ast ?? {
       table: tableName,
-      alias: aliasCount++,
       orderBy: [['id'], 'asc'],
     };
     this.#name = tableName;


### PR DESCRIPTION
1. table name shouldn't have ever been optional in the AST.
2. I had some notion to use auto-aliasing of tables that were joined in many times, hence the integer. The JOIN API we now have, however, is explicit and allows the user to alias the table themselves. Auto-aliasing is no longer going to be a thing.

---

The auto-aliasing idea is a holdover from when we were going to schematize "edge" information to facilitate joins:

e.g.,
```
user.query('photos').query('comments')
```

but we can do something pretty convenient without any schema information given all entities will have an ID.

e.g.,
```
user.joinFrom('photos', 'owner_id').joinFrom('comments', 'container_id')
```

where we only need to specify the non-primary key portion of the join. In `joinFrom` / `joinTo` the user can explicitly set an alias if needed.