### PR TITLE
chore(zero-cache): improve readability of TableTracker

### DIFF
--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -578,7 +578,7 @@ class TransactionProcessor {
       insert.relation.keyColumns.map(col => [col, insert.new[col]]),
     );
     this.#getTableTracker(insert.relation).add({
-      preValue: null,
+      preValue: 'none',
       postRowKey: key,
       postValue: row,
     });
@@ -600,7 +600,7 @@ class TransactionProcessor {
     );
     this.#getTableTracker(update.relation).add({
       preRowKey: oldKey,
-      preValue: undefined,
+      preValue: 'unknown',
       postRowKey: newKey,
       postValue: row,
     });
@@ -631,9 +631,9 @@ class TransactionProcessor {
     const rowKey = del.key;
 
     this.#getTableTracker(del.relation).add({
-      preValue: undefined,
+      preValue: 'unknown',
       postRowKey: rowKey,
-      postValue: null,
+      postValue: 'none',
     });
 
     return this.#writer.process(tx => {
@@ -679,7 +679,7 @@ class TransactionProcessor {
               table.schema,
               table.table,
               change.rowKey,
-              change.postValue,
+              change.postValue === 'none' ? undefined : change.postValue,
             ),
           );
         }
@@ -705,7 +705,7 @@ class TransactionProcessor {
     schema: string,
     table: string,
     key?: RowKeyValue,
-    row?: RowKeyValue | null,
+    row?: RowKeyValue,
   ) {
     const change: ChangeLogEntry = {
       stateVersion: this.#version,

--- a/packages/zero-cache/src/services/replicator/invalidation.pg-test.ts
+++ b/packages/zero-cache/src/services/replicator/invalidation.pg-test.ts
@@ -237,7 +237,7 @@ describe('replicator/invalidation', () => {
         name: 'insert',
         fooChanges: [
           {
-            preValue: null,
+            preValue: 'none',
             postRowKey: {id: 4},
             postValue: {id: 4, name: 'for'},
           },
@@ -260,7 +260,7 @@ describe('replicator/invalidation', () => {
         name: 'update',
         fooChanges: [
           {
-            preValue: undefined,
+            preValue: 'unknown',
             postRowKey: {id: 3},
             postValue: {id: 3, name: 'free'},
           },
@@ -289,9 +289,9 @@ describe('replicator/invalidation', () => {
         name: 'delete',
         fooChanges: [
           {
-            preValue: undefined,
+            preValue: 'unknown',
             postRowKey: {id: 1},
-            postValue: null,
+            postValue: 'none',
           },
         ],
         expectedHashes: [
@@ -312,7 +312,7 @@ describe('replicator/invalidation', () => {
         name: 'update with row key change',
         fooChanges: [
           {
-            preValue: undefined,
+            preValue: 'unknown',
             preRowKey: {id: 3},
             postRowKey: {id: 4},
             postValue: {id: 4, name: 'more'},
@@ -348,36 +348,36 @@ describe('replicator/invalidation', () => {
         fooChanges: [
           {
             // insert
-            preValue: null,
+            preValue: 'none',
             postRowKey: {id: 4},
             postValue: {id: 4, name: 'more'},
           },
           {
             // update
-            preValue: undefined,
+            preValue: 'unknown',
             preRowKey: {id: 4},
             postRowKey: {id: 5},
             postValue: {id: 5, name: 'live'},
           },
           {
             // delete
-            preValue: undefined,
+            preValue: 'unknown',
             postRowKey: {id: 3},
-            postValue: null,
+            postValue: 'none',
           },
         ],
         barChanges: [
           {
             // update
-            preValue: undefined,
+            preValue: 'unknown',
             postRowKey: {id: 'two'},
             postValue: {id: 'two', name: 'blue'},
           },
           {
             // delete
-            preValue: undefined,
+            preValue: 'unknown',
             postRowKey: {id: 'three'},
-            postValue: null,
+            postValue: 'none',
           },
         ],
         expectedHashes: [
@@ -428,36 +428,36 @@ describe('replicator/invalidation', () => {
           // The rest of the changes need not produce an invalidation tag.
           {
             // insert
-            preValue: null,
+            preValue: 'none',
             postRowKey: {id: 4},
             postValue: {id: 4, name: 'more'},
           },
           {
             // update
-            preValue: undefined,
+            preValue: 'unknown',
             preRowKey: {id: 4},
             postRowKey: {id: 5},
             postValue: {id: 5, name: 'live'},
           },
           {
             // delete
-            preValue: undefined,
+            preValue: 'unknown',
             postRowKey: {id: 3},
-            postValue: null,
+            postValue: 'none',
           },
         ],
         barChanges: [
           {
             // update
-            preValue: undefined,
+            preValue: 'unknown',
             postRowKey: {id: 'two'},
             postValue: {id: 'two', name: 'blue'},
           },
           {
             // delete
-            preValue: undefined,
+            preValue: 'unknown',
             postRowKey: {id: 'three'},
-            postValue: null,
+            postValue: 'none',
           },
         ],
         expectedHashes: [

--- a/packages/zero-cache/src/services/replicator/types/table-tracker.test.ts
+++ b/packages/zero-cache/src/services/replicator/types/table-tracker.test.ts
@@ -17,103 +17,107 @@ describe('types/table-tracker', () => {
     {
       name: 'insert',
       changes: [
-        {preValue: null, postRowKey: {id: 1}, postValue: {id: 1, foo: 'bar'}},
+        {preValue: 'none', postRowKey: {id: 1}, postValue: {id: 1, foo: 'bar'}},
       ],
       expected: [
-        {rowKey: {id: 1}, preValue: null, postValue: {id: 1, foo: 'bar'}},
+        {rowKey: {id: 1}, preValue: 'none', postValue: {id: 1, foo: 'bar'}},
       ],
     },
     {
       name: 'update',
       changes: [
         {
-          preValue: undefined,
+          preValue: 'unknown',
           postRowKey: {id: 1},
           postValue: {id: 1, foo: 'bar'},
         },
       ],
       expected: [
-        {rowKey: {id: 1}, preValue: undefined, postValue: {id: 1, foo: 'bar'}},
+        {rowKey: {id: 1}, preValue: 'unknown', postValue: {id: 1, foo: 'bar'}},
       ],
     },
     {
       name: 'insert, update',
       changes: [
-        {preValue: null, postRowKey: {id: 1}, postValue: {id: 1, foo: 'bar'}},
+        {preValue: 'none', postRowKey: {id: 1}, postValue: {id: 1, foo: 'bar'}},
         {
-          preValue: undefined,
+          preValue: 'unknown',
           postRowKey: {id: 1},
           postValue: {id: 1, foo: 'bar'}, // Doesn't matter that it's an equivalent value.
         },
       ],
       expected: [
-        {rowKey: {id: 1}, preValue: null, postValue: {id: 1, foo: 'bar'}},
+        {rowKey: {id: 1}, preValue: 'none', postValue: {id: 1, foo: 'bar'}},
       ],
     },
     {
       name: 'delete',
-      changes: [{preValue: undefined, postRowKey: {id: 1}, postValue: null}],
-      expected: [{rowKey: {id: 1}, preValue: undefined, postValue: null}],
+      changes: [{preValue: 'unknown', postRowKey: {id: 1}, postValue: 'none'}],
+      expected: [{rowKey: {id: 1}, preValue: 'unknown', postValue: 'none'}],
     },
     {
       name: 'insert, delete',
       changes: [
-        {preValue: null, postRowKey: {id: 1}, postValue: {id: 1, foo: 'bar'}},
-        {preValue: undefined, postRowKey: {id: 1}, postValue: null},
+        {preValue: 'none', postRowKey: {id: 1}, postValue: {id: 1, foo: 'bar'}},
+        {preValue: 'unknown', postRowKey: {id: 1}, postValue: 'none'},
       ],
       expected: [], // No effective changes.
     },
     {
       name: 'insert, update, delete',
       changes: [
-        {preValue: null, postRowKey: {id: 1}, postValue: {id: 1, foo: 'bar'}},
+        {preValue: 'none', postRowKey: {id: 1}, postValue: {id: 1, foo: 'bar'}},
         {
-          preValue: undefined,
+          preValue: 'unknown',
           postRowKey: {id: 1},
           postValue: {id: 1, foo: 'bonk'},
         },
-        {preValue: undefined, postRowKey: {id: 1}, postValue: null},
+        {preValue: 'unknown', postRowKey: {id: 1}, postValue: 'none'},
       ],
       expected: [], // No effective changes.
     },
     {
       name: 'insert, delete, insert',
       changes: [
-        {preValue: null, postRowKey: {id: 1}, postValue: {id: 1, foo: 'bar'}},
-        {preValue: undefined, postRowKey: {id: 1}, postValue: null},
-        {preValue: null, postRowKey: {id: 1}, postValue: {id: 1, foo: 'bonk'}},
+        {preValue: 'none', postRowKey: {id: 1}, postValue: {id: 1, foo: 'bar'}},
+        {preValue: 'unknown', postRowKey: {id: 1}, postValue: 'none'},
+        {
+          preValue: 'none',
+          postRowKey: {id: 1},
+          postValue: {id: 1, foo: 'bonk'},
+        },
       ],
       expected: [
-        {rowKey: {id: 1}, preValue: null, postValue: {id: 1, foo: 'bonk'}},
+        {rowKey: {id: 1}, preValue: 'none', postValue: {id: 1, foo: 'bonk'}},
       ],
     },
     {
       name: 'delete, insert',
       changes: [
-        {preValue: undefined, postRowKey: {id: 1}, postValue: null},
-        {preValue: null, postRowKey: {id: 1}, postValue: {id: 1, foo: 'bar'}},
+        {preValue: 'unknown', postRowKey: {id: 1}, postValue: 'none'},
+        {preValue: 'none', postRowKey: {id: 1}, postValue: {id: 1, foo: 'bar'}},
       ],
       expected: [
-        {rowKey: {id: 1}, preValue: undefined, postValue: {id: 1, foo: 'bar'}},
+        {rowKey: {id: 1}, preValue: 'unknown', postValue: {id: 1, foo: 'bar'}},
       ],
     },
     {
       name: 'update, delete',
       changes: [
         {
-          preValue: undefined,
+          preValue: 'unknown',
           postRowKey: {id: 1},
           postValue: {id: 1, foo: 'bar'},
         },
-        {preValue: undefined, postRowKey: {id: 1}, postValue: null},
+        {preValue: 'unknown', postRowKey: {id: 1}, postValue: 'none'},
       ],
-      expected: [{rowKey: {id: 1}, preValue: undefined, postValue: null}],
+      expected: [{rowKey: {id: 1}, preValue: 'unknown', postValue: 'none'}],
     },
     {
       name: 'update with row key change',
       changes: [
         {
-          preValue: undefined,
+          preValue: 'unknown',
           preRowKey: {id: 2},
           postRowKey: {id: 1},
           postValue: {id: 1, foo: 'bar'},
@@ -121,22 +125,22 @@ describe('types/table-tracker', () => {
       ],
       expected: [
         // Effectively an INSERT of the new row.
-        {rowKey: {id: 1}, preValue: null, postValue: {id: 1, foo: 'bar'}},
+        {rowKey: {id: 1}, preValue: 'none', postValue: {id: 1, foo: 'bar'}},
         // Effectively a DELETE of the old row.
-        {rowKey: {id: 2}, preValue: undefined, postValue: null},
+        {rowKey: {id: 2}, preValue: 'unknown', postValue: 'none'},
       ],
     },
     {
       name: 'update to new row key, then back to the old one',
       changes: [
         {
-          preValue: undefined,
+          preValue: 'unknown',
           preRowKey: {id: 2},
           postRowKey: {id: 1},
           postValue: {id: 1, foo: 'bar'},
         },
         {
-          preValue: undefined,
+          preValue: 'unknown',
           preRowKey: {id: 1},
           postRowKey: {id: 2},
           postValue: {id: 2, foo: 'bar'},
@@ -144,59 +148,63 @@ describe('types/table-tracker', () => {
       ],
       expected: [
         // Effectively an UPDATE of the old row. The new row was ephemeral.
-        {rowKey: {id: 2}, preValue: undefined, postValue: {id: 2, foo: 'bar'}},
+        {rowKey: {id: 2}, preValue: 'unknown', postValue: {id: 2, foo: 'bar'}},
       ],
     },
     {
       name: 'update with row key change, re-insert of old row, delete of new row',
       changes: [
         {
-          preValue: undefined,
+          preValue: 'unknown',
           preRowKey: {id: 2},
           postRowKey: {id: 1},
           postValue: {id: 1, foo: 'bar'},
         },
         {
-          preValue: null,
+          preValue: 'none',
           postRowKey: {id: 2},
           postValue: {id: 2, foo: 'boo'},
         },
         {
-          preValue: undefined,
+          preValue: 'unknown',
           postRowKey: {id: 1},
-          postValue: null,
+          postValue: 'none',
         },
       ],
       expected: [
         // Effectively an UPDATE of the old row.
-        {rowKey: {id: 2}, preValue: undefined, postValue: {id: 2, foo: 'boo'}},
+        {rowKey: {id: 2}, preValue: 'unknown', postValue: {id: 2, foo: 'boo'}},
       ],
     },
     {
       name: 'truncate with subsequent actions',
       changes: [
-        {preValue: null, postRowKey: {id: 1}, postValue: {id: 1, foo: 'bar'}},
-        {preValue: null, postRowKey: {id: 2}, postValue: {id: 2, foo: 'boo'}},
+        {preValue: 'none', postRowKey: {id: 1}, postValue: {id: 1, foo: 'bar'}},
+        {preValue: 'none', postRowKey: {id: 2}, postValue: {id: 2, foo: 'boo'}},
         {
-          preValue: undefined,
+          preValue: 'unknown',
           preRowKey: {id: 2},
           postRowKey: {id: 3},
           postValue: {id: 3, foo: 'boo'},
         },
         'truncate',
-        {preValue: null, postRowKey: {id: 1}, postValue: {id: 1, foo: 'bonk'}},
         {
-          preValue: undefined,
+          preValue: 'none',
+          postRowKey: {id: 1},
+          postValue: {id: 1, foo: 'bonk'},
+        },
+        {
+          preValue: 'unknown',
           postRowKey: {id: 4},
           postValue: {id: 4, foo: 'foo'},
         },
       ],
       expectTruncated: true,
       expected: [
-        {rowKey: {id: 1}, preValue: null, postValue: {id: 1, foo: 'bonk'}},
+        {rowKey: {id: 1}, preValue: 'none', postValue: {id: 1, foo: 'bonk'}},
         {
           rowKey: {id: 4},
-          preValue: undefined,
+          preValue: 'unknown',
           postValue: {id: 4, foo: 'foo'},
         },
       ],


### PR DESCRIPTION
Use string constants for `"unknown"` or absent (`"none"`) RowValues instead of `undefined` vs `null`.