### PR TITLE
feat(zql): reduce unnecessary array copying during normalization

### DIFF
--- a/packages/shared/src/arrays.test.ts
+++ b/packages/shared/src/arrays.test.ts
@@ -1,0 +1,70 @@
+import {describe, expect, test} from '@jest/globals';
+import {defined} from './arrays.js';
+
+describe('shared/arrays', () => {
+  type Case = {
+    input: (number | undefined)[];
+    output: number[];
+  };
+
+  const cases: Case[] = [
+    {
+      input: [],
+      output: [],
+    },
+    {
+      input: [undefined],
+      output: [],
+    },
+    {
+      input: [undefined, undefined],
+      output: [],
+    },
+    {
+      input: [0, undefined],
+      output: [0],
+    },
+    {
+      input: [undefined, 0],
+      output: [0],
+    },
+    {
+      input: [undefined, 0, undefined],
+      output: [0],
+    },
+    {
+      input: [undefined, 0, 1],
+      output: [0, 1],
+    },
+    {
+      input: [0, undefined, 1],
+      output: [0, 1],
+    },
+    {
+      input: [0, undefined, 0, 1],
+      output: [0, 0, 1],
+    },
+    {
+      input: [0, undefined, 0, 1, undefined],
+      output: [0, 0, 1],
+    },
+    {
+      input: [0, undefined, 0, undefined, 1, undefined],
+      output: [0, 0, 1],
+    },
+    {
+      input: [2, 1, 0, undefined, 0, undefined, 1, undefined, 2],
+      output: [2, 1, 0, 0, 1, 2],
+    },
+  ];
+
+  for (const c of cases) {
+    test(`defined(${JSON.stringify(c.input)})`, () => {
+      const output = defined(c.input);
+      expect(output).toEqual(c.output);
+      if (output.length === c.input.length) {
+        expect(output).toBe(c.input); // No copy
+      }
+    });
+  }
+});

--- a/packages/shared/src/arrays.ts
+++ b/packages/shared/src/arrays.ts
@@ -1,0 +1,19 @@
+/**
+ * Returns `arr` as is if none of the elements are `undefined`.
+ * Otherwise returns a new array with only defined elements in `arr`.
+ */
+export function defined<T>(arr: (T | undefined)[]): T[] {
+  // avoid an array copy if possible
+  let i = arr.findIndex(x => x === undefined);
+  if (i < 0) {
+    return arr as T[];
+  }
+  const defined: T[] = arr.slice(0, i) as T[];
+  for (i++; i < arr.length; i++) {
+    const x = arr[i];
+    if (x !== undefined) {
+      defined.push(x);
+    }
+  }
+  return defined;
+}

--- a/packages/zql/src/zql/ast/ast.ts
+++ b/packages/zql/src/zql/ast/ast.ts
@@ -2,6 +2,7 @@
 // https://www.sqlite.org/lang_select.html
 
 import {compareUTF8} from 'compare-utf8';
+import {defined} from 'shared/src/arrays.js';
 
 // TODO: the chosen operator needs to constrain the allowed values for the value
 // input to the query builder.
@@ -137,11 +138,11 @@ function flattened(cond: Condition | undefined): Condition | undefined {
   if (cond.type === 'simple') {
     return cond;
   }
-  const conditions = cond.conditions
-    .flatMap(c =>
+  const conditions = defined(
+    cond.conditions.flatMap(c =>
       c.op === cond.op ? c.conditions.map(c => flattened(c)) : flattened(c),
-    )
-    .reduce((defined, c) => (c ? [...defined, c] : defined), [] as Condition[]);
+    ),
+  );
 
   switch (conditions.length) {
     case 0:


### PR DESCRIPTION
Add an optimized method for producing an array without `undefined` values that avoids copying if possible.

This is used when normalizing zql conditions (for which the common case won't require copying) and will be used in upcoming invalidation processing as well.