### PR TITLE
chore(shared): copy over tests from refactored code

### DIFF
--- a/packages/shared/src/queue.ts
+++ b/packages/shared/src/queue.ts
@@ -58,12 +58,11 @@ export class Queue<T> {
     return this.#produced.length;
   }
 
-  //todo(darick): add a test for this
-  asAsyncIterator(
-    cleanup = () => {
-      /* nop */
-    },
-  ): AsyncIterator<T> {
+  asAsyncIterable(cleanup = NOOP): AsyncIterable<T> {
+    return {[Symbol.asyncIterator]: () => this.asAsyncIterator(cleanup)};
+  }
+
+  asAsyncIterator(cleanup = NOOP): AsyncIterator<T> {
     return {
       next: async () => {
         try {
@@ -81,3 +80,5 @@ export class Queue<T> {
     };
   }
 }
+
+const NOOP = () => {};


### PR DESCRIPTION
Addresses an old TODO from https://github.com/rocicorp/mono/pull/811/files#r1303569154, where code was refactored but tests were not.