### PR TITLE
feat(zero-cache): Invalidation Watcher implementation

### DIFF
--- a/packages/zero-cache/src/services/invalidation-watcher/hash-subscriptions.test.ts
+++ b/packages/zero-cache/src/services/invalidation-watcher/hash-subscriptions.test.ts
@@ -1,0 +1,115 @@
+import {describe, expect, test} from '@jest/globals';
+import {Subscription} from '../../types/subscription.js';
+import {HashSubscriptions} from './hash-subscriptions.js';
+import type {QueryInvalidationUpdate} from './invalidation-watcher.js';
+
+describe('invalidation-watcher/hash-subscriptions', () => {
+  test('add, remove, compute updates', () => {
+    const hashes = new HashSubscriptions();
+
+    const sub1 = new Subscription<QueryInvalidationUpdate>();
+    const req1 = {
+      queries: {
+        q1: {
+          filters: [],
+          hashes: ['h1', 'h2'],
+        },
+        q2: {
+          filters: [],
+          hashes: ['h2', 'h3'],
+        },
+      },
+    };
+    const sub2 = new Subscription<QueryInvalidationUpdate>();
+    const req2 = {
+      queries: {
+        q1: {
+          filters: [],
+          hashes: ['h3', 'h4'],
+        },
+        q2: {
+          filters: [],
+          hashes: ['h5', 'h6'],
+        },
+      },
+    };
+    const sub3 = new Subscription<QueryInvalidationUpdate>();
+    const req3 = {
+      queries: {
+        q1: {
+          filters: [],
+          hashes: ['h6', 'h7'],
+        },
+        q2: {
+          filters: [],
+          hashes: ['h8', 'h9'],
+        },
+      },
+    };
+
+    hashes.add(sub1, req1);
+    hashes.add(sub2, req2);
+    hashes.add(sub3, req3);
+
+    expect(
+      hashes.computeInvalidationUpdates(new Set(['h1', 'h2', 'h5', 'h6'])),
+    ).toEqual(
+      new Map([
+        [sub1, new Set(['q1', 'q2'])],
+        [sub2, new Set(['q2'])],
+        [sub3, new Set(['q1'])],
+      ]),
+    );
+    expect(
+      hashes.computeInvalidationUpdate(new Set(['h1', 'h2', 'h5', 'h6']), sub1),
+    ).toEqual(new Set(['q1', 'q2']));
+    expect(
+      hashes.computeInvalidationUpdate(new Set(['h1', 'h2', 'h5', 'h6']), sub2),
+    ).toEqual(new Set(['q2']));
+    expect(
+      hashes.computeInvalidationUpdate(new Set(['h1', 'h2', 'h5', 'h6']), sub3),
+    ).toEqual(new Set(['q1']));
+
+    hashes.remove(sub2, req2);
+
+    expect(
+      hashes.computeInvalidationUpdates(new Set(['h1', 'h2', 'h5', 'h6'])),
+    ).toEqual(
+      new Map([
+        [sub1, new Set(['q1', 'q2'])],
+        [sub3, new Set(['q1'])],
+      ]),
+    );
+    expect(
+      hashes.computeInvalidationUpdate(new Set(['h1', 'h2', 'h5', 'h6']), sub1),
+    ).toEqual(new Set(['q1', 'q2']));
+    expect(
+      hashes.computeInvalidationUpdate(new Set(['h1', 'h2', 'h5', 'h6']), sub3),
+    ).toEqual(new Set(['q1']));
+    expect(
+      hashes.computeInvalidationUpdate(new Set(['h1', 'h2', 'h5', 'h6']), sub2),
+    ).toEqual(new Set());
+
+    hashes.remove(sub3, req3);
+
+    expect(
+      hashes.computeInvalidationUpdates(
+        new Set(['h1', 'h2', 'h5', 'h6', 'h7', 'h8']),
+      ),
+    ).toEqual(new Map([[sub1, new Set(['q1', 'q2'])]]));
+    expect(
+      hashes.computeInvalidationUpdate(
+        new Set(['h1', 'h2', 'h5', 'h6', 'h7', 'h8']),
+        sub1,
+      ),
+    ).toEqual(new Set(['q1', 'q2']));
+
+    hashes.remove(sub1, req1);
+
+    expect(
+      hashes.computeInvalidationUpdates(
+        new Set(['h1', 'h2', 'h5', 'h6', 'h7', 'h8']),
+      ),
+    ).toEqual(new Map());
+  });
+});

--- a/packages/zero-cache/src/services/invalidation-watcher/hash-subscriptions.ts
+++ b/packages/zero-cache/src/services/invalidation-watcher/hash-subscriptions.ts
@@ -1,0 +1,109 @@
+import type {Subscription} from '../../types/subscription.js';
+import type {
+  QueryInvalidationUpdate,
+  WatchRequest,
+} from './invalidation-watcher.js';
+
+type SubscriptionsToQueryIDs = Map<
+  Subscription<QueryInvalidationUpdate>,
+  Set<string>
+>;
+
+/**
+ * Tracks the hashes that are relevant to Subscriptions and the queries to which
+ * they correspond, for constructing {@link QueryInvalidationUpdate} messages
+ * from a set of invalidated hashes.
+ */
+export class HashSubscriptions {
+  readonly #hashToSubscription = new Map<string, SubscriptionsToQueryIDs>();
+
+  empty() {
+    return this.#hashToSubscription.size === 0;
+  }
+
+  add(sub: Subscription<QueryInvalidationUpdate>, req: WatchRequest) {
+    for (const [queryID, {hashes}] of Object.entries(req.queries)) {
+      hashes.forEach(hash => {
+        const queryIDs = ensureMap(this.#hashToSubscription, hash);
+        ensureSet(queryIDs, sub).add(queryID);
+      });
+    }
+  }
+
+  remove(sub: Subscription<QueryInvalidationUpdate>, req: WatchRequest) {
+    for (const {hashes} of Object.values(req.queries)) {
+      hashes.forEach(hash => {
+        const subscriptions = this.#hashToSubscription.get(hash);
+        if (subscriptions) {
+          subscriptions.delete(sub);
+          if (subscriptions.size === 0) {
+            this.#hashToSubscription.delete(hash);
+          }
+        }
+      });
+    }
+  }
+
+  /**
+   * Computes the invalidated query IDs for all Subscriptions based on
+   * the specified invalidation `hashes`.
+   */
+  computeInvalidationUpdates(
+    hashes: Set<string>,
+  ): Map<Subscription<QueryInvalidationUpdate>, Set<string>> {
+    const updates = new Map<
+      Subscription<QueryInvalidationUpdate>,
+      Set<string>
+    >();
+
+    for (const hash of hashes) {
+      const subscriptionsToQueryIDs = this.#hashToSubscription.get(hash);
+      if (subscriptionsToQueryIDs) {
+        for (const [subscription, queryIDs] of subscriptionsToQueryIDs) {
+          queryIDs.forEach(queryID => {
+            ensureSet(updates, subscription).add(queryID);
+          });
+        }
+      }
+    }
+
+    return updates;
+  }
+
+  /**
+   * Computes the invalidated query IDs for the specified `subscription`
+   * based on the specified invalidation `hashes`.
+   */
+  computeInvalidationUpdate(
+    hashes: Set<string>,
+    subscription: Subscription<QueryInvalidationUpdate>,
+  ): Set<string> {
+    const queryIDs = new Set<string>();
+
+    for (const hash of hashes) {
+      this.#hashToSubscription
+        .get(hash)
+        ?.get(subscription)
+        ?.forEach(queryID => queryIDs.add(queryID));
+    }
+    return queryIDs;
+  }
+}
+
+function ensureMap<K1, K2, V>(m: Map<K1, Map<K2, V>>, k: K1): Map<K2, V> {
+  let map = m.get(k);
+  if (map === undefined) {
+    map = new Map<K2, V>();
+    m.set(k, map);
+  }
+  return map;
+}
+
+export function ensureSet<K, V>(m: Map<K, Set<V>>, k: K): Set<V> {
+  let s = m.get(k);
+  if (s === undefined) {
+    s = new Set<V>();
+    m.set(k, s);
+  }
+  return s;
+}

--- a/packages/zero-cache/src/services/invalidation-watcher/invalidation-watcher.pg-test.ts
+++ b/packages/zero-cache/src/services/invalidation-watcher/invalidation-watcher.pg-test.ts
@@ -1,0 +1,498 @@
+import {afterEach, beforeEach, describe, expect, test} from '@jest/globals';
+import type postgres from 'postgres';
+import {Queue} from 'shared/src/queue.js';
+import {sleep} from 'shared/src/sleep.js';
+import {initDB, testDBs} from '../../test/db.js';
+import {createSilentLogContext} from '../../test/logger.js';
+import {normalizeFilterSpec} from '../../types/invalidation.js';
+import {Subscription} from '../../types/subscription.js';
+import {CREATE_REPLICATION_TABLES} from '../replicator/incremental-sync.js';
+import {CREATE_INVALIDATION_TABLES} from '../replicator/invalidation.js';
+import type {
+  RegisterInvalidationFiltersResponse,
+  Replicator,
+  VersionChange,
+} from '../replicator/replicator.js';
+import {
+  InvalidationWatcherService,
+  WatchRequest,
+  type QueryInvalidationUpdate,
+} from './invalidation-watcher.js';
+
+describe('invalidation-watcher', () => {
+  let db: postgres.Sql;
+
+  beforeEach(async () => {
+    db = await testDBs.create('invalidation_watcher_test');
+    await db.unsafe(
+      `CREATE SCHEMA _zero;` +
+        CREATE_INVALIDATION_TABLES +
+        CREATE_REPLICATION_TABLES,
+    );
+  });
+
+  afterEach(async () => {
+    await testDBs.drop(db);
+  });
+
+  type Case = {
+    name: string;
+    setupDB?: string;
+    registerFilterResponses?: RegisterInvalidationFiltersResponse[];
+    versionChanges: [stmt: string, change: VersionChange][];
+    incrementalWatchRequest?: WatchRequest;
+    expectedIncrementalUpdates: Omit<QueryInvalidationUpdate, 'reader'>[];
+    coalescedWatchRequest?: WatchRequest;
+    expectedCoalescedUpdates: Omit<QueryInvalidationUpdate, 'reader'>[];
+  };
+
+  const FOO_SPEC1 = normalizeFilterSpec({
+    schema: 'public',
+    table: 'foo',
+    filteredColumns: {id: '='},
+  });
+
+  const FOO_SPEC2 = normalizeFilterSpec({
+    schema: 'public',
+    table: 'foo',
+    filteredColumns: {id: '=', name: '='},
+    selectedColumns: ['id', 'name'],
+  });
+
+  const FOO_SPEC3 = normalizeFilterSpec({
+    schema: 'public',
+    table: 'foo',
+    filteredColumns: {name: '='},
+    selectedColumns: ['id', 'name'],
+  });
+
+  const BAR_SPEC1 = normalizeFilterSpec({
+    schema: 'public',
+    table: 'bar',
+    filteredColumns: {id: '='},
+  });
+
+  const BAR_SPEC2 = normalizeFilterSpec({
+    schema: 'public',
+    table: 'bar',
+    filteredColumns: {},
+    selectedColumns: ['id', 'name'],
+  });
+
+  const BAR_SPEC3 = normalizeFilterSpec({
+    schema: 'public',
+    table: 'bar',
+    filteredColumns: {name: '='},
+    selectedColumns: ['id', 'name'],
+  });
+
+  const INCREMENTAL_WATCH_REQUEST = {
+    queries: {
+      q1: {filters: [FOO_SPEC1, FOO_SPEC2], hashes: ['beefcafe', '01010101']},
+      q2: {filters: [FOO_SPEC1], hashes: ['0abc1230']},
+      q3: {filters: [FOO_SPEC3], hashes: ['12344321']},
+    },
+  };
+  const COALESCED_WATCH_REQUEST = {
+    queries: {
+      q1: {filters: [BAR_SPEC1], hashes: ['01234567']},
+      q2: {filters: [BAR_SPEC2], hashes: ['87654321']},
+      q3: {filters: [BAR_SPEC3], hashes: ['01100110']},
+    },
+  };
+
+  const cases: Case[] = [
+    {
+      name: 'update with hashes',
+      setupDB: `
+      INSERT INTO _zero."TxLog" ("stateVersion", lsn, time, xid)
+        VALUES ('0a', '0/511', '2024-04-15T00:00:01Z', 103);
+      `,
+      versionChanges: [
+        [
+          `
+        INSERT INTO _zero."TxLog" ("stateVersion", lsn, time, xid)
+          VALUES ('101', '0/511', '2024-04-15T00:00:02Z', 123);
+        INSERT INTO _zero."InvalidationIndex" (hash, "stateVersion")
+          VALUES ('\\xbeefcafe', '101');
+        INSERT INTO _zero."InvalidationIndex" (hash, "stateVersion")
+          VALUES ('\\x01234567', '0a');
+        INSERT INTO _zero."InvalidationIndex" (hash, "stateVersion")
+          VALUES ('\\x0abc1230', '0a');
+        INSERT INTO _zero."InvalidationIndex" (hash, "stateVersion")
+          VALUES ('\\x87654321', '101');  
+        `,
+          {
+            newVersion: '101',
+            prevVersion: '0a',
+            invalidations: {['beefcafe']: '101', ['87654321']: '101'},
+          },
+        ],
+      ],
+      expectedIncrementalUpdates: [
+        {
+          newVersion: '0a', // Initial update
+          fromVersion: '0a',
+          invalidatedQueries: new Set(),
+        },
+        {
+          newVersion: '101',
+          fromVersion: '0a',
+          invalidatedQueries: new Set(['q1']),
+        },
+      ],
+      expectedCoalescedUpdates: [
+        {
+          newVersion: '101',
+          fromVersion: '0a',
+          invalidatedQueries: new Set(['q2']),
+        },
+      ],
+    },
+    {
+      name: 'update without hashes',
+      setupDB: `
+      INSERT INTO _zero."TxLog" ("stateVersion", lsn, time, xid)
+        VALUES ('0a', '0/511', '2024-04-15T00:00:01Z', 103);
+      `,
+      versionChanges: [
+        [
+          `
+        INSERT INTO _zero."TxLog" ("stateVersion", lsn, time, xid)
+          VALUES ('101', '0/511', '2024-04-15T00:00:02Z', 123);
+        INSERT INTO _zero."InvalidationIndex" (hash, "stateVersion")
+          VALUES ('\\xbeefcafe', '101');
+        INSERT INTO _zero."InvalidationIndex" (hash, "stateVersion")
+          VALUES ('\\x01234567', '0a');
+        INSERT INTO _zero."InvalidationIndex" (hash, "stateVersion")
+          VALUES ('\\x0abc1230', '0a');
+        INSERT INTO _zero."InvalidationIndex" (hash, "stateVersion")
+          VALUES ('\\x87654321', '101'); 
+          `,
+          {newVersion: '101', prevVersion: '0a'},
+        ],
+      ],
+      expectedIncrementalUpdates: [
+        {
+          newVersion: '0a',
+          fromVersion: '0a',
+          invalidatedQueries: new Set(),
+        },
+        {
+          newVersion: '101',
+          fromVersion: '0a',
+          invalidatedQueries: new Set(['q1']),
+        },
+      ],
+      expectedCoalescedUpdates: [
+        {
+          newVersion: '101',
+          fromVersion: '0a',
+          invalidatedQueries: new Set(['q2']),
+        },
+      ],
+    },
+    {
+      name: 'snapshot ahead of update',
+      setupDB: `
+      INSERT INTO _zero."TxLog" ("stateVersion", lsn, time, xid)
+        VALUES ('01', '0/511', '2024-04-15T00:00:00Z', 100);
+      `,
+      versionChanges: [
+        [
+          `
+        INSERT INTO _zero."TxLog" ("stateVersion", lsn, time, xid)
+          VALUES ('101', '0/511', '2024-04-15T00:00:02Z', 123);
+        INSERT INTO _zero."InvalidationIndex" (hash, "stateVersion")
+          VALUES ('\\xbeefcafe', '101');
+        INSERT INTO _zero."InvalidationIndex" (hash, "stateVersion")
+          VALUES ('\\x01234567', '0a');
+        INSERT INTO _zero."InvalidationIndex" (hash, "stateVersion")
+          VALUES ('\\x01010101', '01');
+        INSERT INTO _zero."InvalidationIndex" (hash, "stateVersion")
+          VALUES ('\\x0abc1230', '0a');
+        INSERT INTO _zero."InvalidationIndex" (hash, "stateVersion")
+          VALUES ('\\x87654321', '101');           
+          `,
+          {
+            newVersion: '0a',
+            prevVersion: '01',
+            invalidations: {['01234567']: '0a', ['0abc1230']: '0a'},
+          },
+        ],
+      ],
+      expectedIncrementalUpdates: [
+        {
+          newVersion: '01',
+          fromVersion: '01',
+          invalidatedQueries: new Set(),
+        },
+        {
+          newVersion: '101',
+          fromVersion: '01',
+          invalidatedQueries: new Set(['q1', 'q2']),
+        },
+      ],
+      expectedCoalescedUpdates: [
+        {
+          newVersion: '101',
+          fromVersion: '01',
+          invalidatedQueries: new Set(['q1', 'q2']),
+        },
+      ],
+    },
+    {
+      name: 'incremental updates',
+      versionChanges: [
+        [
+          `
+        INSERT INTO _zero."TxLog" ("stateVersion", lsn, time, xid)
+          VALUES ('01', '0/511', '2024-04-15T00:00:00Z', 101);
+        INSERT INTO _zero."InvalidationIndex" (hash, "stateVersion")
+          VALUES ('\\x01010101', '01');
+          `,
+          {newVersion: '01', prevVersion: '00'},
+        ],
+        [
+          `
+        INSERT INTO _zero."TxLog" ("stateVersion", lsn, time, xid)
+          VALUES ('0a', '0/511', '2024-04-15T00:00:01Z', 111);
+        INSERT INTO _zero."InvalidationIndex" (hash, "stateVersion")
+          VALUES ('\\x01234567', '0a');
+        INSERT INTO _zero."InvalidationIndex" (hash, "stateVersion")
+          VALUES ('\\x0abc1230', '0a');
+          `,
+          {newVersion: '0a', prevVersion: '01'},
+        ],
+        [
+          `
+        INSERT INTO _zero."TxLog" ("stateVersion", lsn, time, xid)
+          VALUES ('101', '0/511', '2024-04-15T00:00:02Z', 123);
+        INSERT INTO _zero."InvalidationIndex" (hash, "stateVersion")
+          VALUES ('\\xbeefcafe', '101');
+        INSERT INTO _zero."InvalidationIndex" (hash, "stateVersion")
+          VALUES ('\\x87654321', '101');
+          `,
+          {newVersion: '101', prevVersion: '0a'},
+        ],
+      ],
+      expectedIncrementalUpdates: [
+        {
+          newVersion: '00',
+          fromVersion: '00',
+          invalidatedQueries: new Set(),
+        },
+        {
+          newVersion: '01',
+          fromVersion: '00',
+          invalidatedQueries: new Set(['q1']),
+        },
+        {
+          newVersion: '0a',
+          fromVersion: '01',
+          invalidatedQueries: new Set(['q2']),
+        },
+        {
+          newVersion: '101',
+          fromVersion: '0a',
+          invalidatedQueries: new Set(['q1']),
+        },
+      ],
+      expectedCoalescedUpdates: [
+        {
+          newVersion: '101',
+          fromVersion: '00',
+          invalidatedQueries: new Set(['q1', 'q2']),
+        },
+      ],
+    },
+    {
+      name: 'initial filter invalidation',
+      setupDB: `
+      INSERT INTO _zero."TxLog" ("stateVersion", lsn, time, xid)
+        VALUES ('0a', '0/511', '2024-04-15T00:00:01Z', 103);
+      INSERT INTO _zero."InvalidationIndex" (hash, "stateVersion")
+          VALUES ('\\x12344321', '04');
+      INSERT INTO _zero."InvalidationIndex" (hash, "stateVersion")
+          VALUES ('\\x01100110', '01');
+      `,
+      versionChanges: [
+        [
+          `
+        INSERT INTO _zero."TxLog" ("stateVersion", lsn, time, xid)
+          VALUES ('101', '0/511', '2024-04-15T00:00:02Z', 123);
+        INSERT INTO _zero."InvalidationIndex" (hash, "stateVersion")
+          VALUES ('\\xbeefcafe', '101');
+        INSERT INTO _zero."InvalidationIndex" (hash, "stateVersion")
+          VALUES ('\\x87654321', '101'); 
+          `,
+          {newVersion: '101', prevVersion: '0a'},
+        ],
+      ],
+      incrementalWatchRequest: {
+        ...INCREMENTAL_WATCH_REQUEST,
+        fromVersion: '01',
+      },
+      coalescedWatchRequest: {
+        ...COALESCED_WATCH_REQUEST,
+        fromVersion: '01',
+      },
+      registerFilterResponses: [
+        {
+          specs: [
+            {id: FOO_SPEC1.id, fromStateVersion: '01'}, // already registered
+            {id: FOO_SPEC2.id, fromStateVersion: '02'}, // newly registered
+            {id: FOO_SPEC3.id, fromStateVersion: '01'}, // already registered
+          ],
+        },
+        {specs: [{id: BAR_SPEC1.id, fromStateVersion: '09'}]},
+      ],
+      expectedIncrementalUpdates: [
+        {
+          newVersion: '0a',
+          fromVersion: '01',
+          // Initial update invalidates:
+          // - q1 as its FOO_SPEC2 was newly registered,
+          // - q3 because the '12344321' hash at "04" is newer than fromVersion: "01".
+          invalidatedQueries: new Set(['q1', 'q3']),
+        },
+        {
+          newVersion: '101',
+          fromVersion: '0a',
+          invalidatedQueries: new Set(['q1']),
+        },
+      ],
+      expectedCoalescedUpdates: [
+        {
+          // The invalidation of q1 (from the newly registered BAR_SPEC1)
+          // from the initial update should be coalesced
+          // with the incremental update invalidating q2.
+          // Note that q3 is *not* invalidated because its hash version ("01")
+          // is less than or equal to fromVersion
+          newVersion: '101',
+          fromVersion: '01',
+          invalidatedQueries: new Set(['q1', 'q2']),
+        },
+      ],
+    },
+  ];
+
+  for (const c of cases) {
+    test(c.name, async () => {
+      await initDB(db, c.setupDB);
+
+      const versionChanges = new Subscription<VersionChange>();
+      const registerFilterResponses = c.registerFilterResponses ?? [];
+      const replicator: Replicator = {
+        versionChanges: () => versionChanges,
+        registerInvalidationFilters: () =>
+          Promise.resolve(registerFilterResponses.shift() ?? {specs: []}),
+      };
+
+      const lc = createSilentLogContext();
+      const watcher = new InvalidationWatcherService(
+        'id',
+        lc,
+        {getReplicator: () => Promise.resolve(replicator)},
+        db,
+      );
+      const watcherDone = watcher.run();
+
+      const incrementalSub = await watcher.watch(
+        c.incrementalWatchRequest ?? INCREMENTAL_WATCH_REQUEST,
+      );
+
+      // Read from the incrementalSub in the background.
+      const incrementalUpdates = (async () => {
+        const updates: QueryInvalidationUpdate[] = [];
+        if (c.expectedIncrementalUpdates.length) {
+          let i = 0;
+          for await (const update of incrementalSub) {
+            updates.push(update);
+            if (++i === c.expectedIncrementalUpdates.length) {
+              break;
+            }
+          }
+        }
+        return updates;
+      })();
+
+      const coalescedSub = await watcher.watch(
+        c.coalescedWatchRequest ?? COALESCED_WATCH_REQUEST,
+      );
+
+      for (const [stmt, versionChange] of c.versionChanges) {
+        await db.unsafe(stmt);
+        versionChanges.push(versionChange);
+        // Allow time for the incremental update loop to take a snapshot and process.
+        await sleep(10);
+      }
+
+      const updates = await incrementalUpdates;
+      for (let i = 0; i < updates.length; i++) {
+        expect(updates[i]).toMatchObject(c.expectedIncrementalUpdates[i]);
+      }
+
+      if (c.expectedCoalescedUpdates.length) {
+        let i = 0;
+        for await (const update of coalescedSub) {
+          expect(update).toMatchObject(c.expectedCoalescedUpdates[i]);
+          if (++i === c.expectedCoalescedUpdates.length) {
+            break;
+          }
+        }
+      }
+
+      await watcher.stop();
+      await watcherDone;
+    });
+  }
+
+  test('unsubscribe from Replicator when no watchers', async () => {
+    const subscriptionOpened = new Queue<true>();
+    const subscriptionClosed = new Queue<true>();
+    const replicator: Replicator = {
+      versionChanges: () => {
+        void subscriptionOpened.enqueue(true);
+        return new Subscription<VersionChange>({
+          cleanup: () => void subscriptionClosed.enqueue(true),
+        });
+      },
+      registerInvalidationFilters: () => Promise.resolve({specs: []}),
+    };
+
+    const watcher = new InvalidationWatcherService(
+      'id',
+      createSilentLogContext(),
+      {getReplicator: () => Promise.resolve(replicator)},
+      db,
+    );
+    const watcherDone = watcher.run();
+
+    const sub1 = await watcher.watch(INCREMENTAL_WATCH_REQUEST);
+    expect(await subscriptionOpened.dequeue()).toBe(true);
+    const sub2 = await watcher.watch(INCREMENTAL_WATCH_REQUEST);
+
+    expect(subscriptionOpened.size()).toBe(0);
+    expect(subscriptionClosed.size()).toBe(0);
+
+    sub1.cancel();
+    expect(subscriptionClosed.size()).toBe(0);
+    sub2.cancel();
+    expect(await subscriptionClosed.dequeue()).toBe(true);
+    expect(subscriptionClosed.size()).toBe(0); // Only called once
+
+    const sub3 = await watcher.watch(INCREMENTAL_WATCH_REQUEST);
+    expect(await subscriptionOpened.dequeue()).toBe(true);
+
+    expect(subscriptionOpened.size()).toBe(0);
+    expect(subscriptionClosed.size()).toBe(0);
+
+    sub3.cancel();
+    expect(await subscriptionClosed.dequeue()).toBe(true);
+    expect(subscriptionClosed.size()).toBe(0);
+
+    await watcher.stop();
+    await watcherDone;
+  });
+});

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -33,6 +33,7 @@ import {
   InvalidationFilters,
   InvalidationProcessor,
 } from './invalidation.js';
+import {queryStateVersion} from './queries.js';
 import type {VersionChange} from './replicator.js';
 import {PublicationInfo, getPublicationInfo} from './tables/published.js';
 import {toLexiVersion} from './types/lsn.js';
@@ -607,8 +608,7 @@ class TransactionProcessor {
     };
 
     return this.#writer.process(tx => {
-      const prevVersion = tx<{max: LexiVersion | null}[]>`
-      SELECT MAX("stateVersion") FROM _zero."TxLog";`;
+      const prevVersion = queryStateVersion(tx);
       prevVersion
         .then(result => (this.#prevVersion = result[0].max ?? '00'))
         .catch(e => this.fail(e));

--- a/packages/zero-cache/src/services/replicator/invalidation.ts
+++ b/packages/zero-cache/src/services/replicator/invalidation.ts
@@ -16,6 +16,7 @@ import {
 import type {LexiVersion} from '../../types/lexi-version.js';
 import type {RowKeyType, RowValue} from '../../types/row-key.js';
 import {rowKeyString} from '../../types/row-key.js';
+import {queryStateVersion} from './queries.js';
 import type {
   RegisterInvalidationFiltersRequest,
   RegisterInvalidationFiltersResponse,
@@ -178,8 +179,7 @@ export class Invalidator {
         }
 
         // Get the current stateVersion.
-        const stateVersion = await tx<{max: LexiVersion | null}[]>`
-        SELECT MAX("stateVersion") FROM _zero."TxLog";`;
+        const stateVersion = await queryStateVersion(tx);
         const fromStateVersion = stateVersion[0].max ?? '00';
 
         const unregistered = specs.filter(row => row.fromStateVersion === null);

--- a/packages/zero-cache/src/services/replicator/queries.ts
+++ b/packages/zero-cache/src/services/replicator/queries.ts
@@ -1,0 +1,8 @@
+import type postgres from 'postgres';
+import type {LexiVersion} from '../../types/lexi-version.js';
+
+export function queryStateVersion(db: postgres.Sql) {
+  return db<
+    {max: LexiVersion | null}[]
+  >`SELECT MAX("stateVersion") FROM _zero."TxLog";`;
+}

--- a/packages/zero-cache/src/services/replicator/registry.ts
+++ b/packages/zero-cache/src/services/replicator/registry.ts
@@ -1,0 +1,18 @@
+import type {Replicator} from './replicator.js';
+
+export interface ReplicatorRegistry {
+  /**
+   * Gets the global Replicator.
+   *
+   * In v0, everything is running in a single ServiceRunnerDO and thus this will always be
+   * an in memory object.
+   *
+   * When sharding is added, a stub object that communicates with the Replicator in
+   * another DO (via rpc / websocket) may be returned.
+   *
+   * Note that callers should be wary of caching the returned object, as the Replicator may
+   * shut down and restart, etc. Generally, the registry should be queried from the registry
+   * whenever attempting to communicate with it.
+   */
+  getReplicator(): Promise<Replicator>;
+}

--- a/packages/zero-cache/src/types/lexi-version.test.ts
+++ b/packages/zero-cache/src/types/lexi-version.test.ts
@@ -1,5 +1,5 @@
 import {expect, test} from '@jest/globals';
-import {versionFromLexi, versionToLexi} from './lexi-version.js';
+import {max, min, versionFromLexi, versionToLexi} from './lexi-version.js';
 
 test('LexiVersion encoding', () => {
   type Case = [number | bigint, string];
@@ -28,9 +28,20 @@ test('LexiVersion sorting', () => {
   // A few explicit tests.
   expect(versionToLexi(35).localeCompare(versionToLexi(36))).toBe(-1);
   expect(versionToLexi(36).localeCompare(versionToLexi(35))).toBe(1);
+  expect(min(versionToLexi(36), versionToLexi(35))).toBe(versionToLexi(35));
+  expect(max(versionToLexi(36), versionToLexi(35))).toBe(versionToLexi(36));
+
   expect(versionToLexi(1000).localeCompare(versionToLexi(9))).toBe(1);
+  expect(min(versionToLexi(1000), versionToLexi(9))).toBe(versionToLexi(9));
+  expect(max(versionToLexi(1000), versionToLexi(9))).toBe(versionToLexi(1000));
+
   expect(versionToLexi(89).localeCompare(versionToLexi(1234))).toBe(-1);
+  expect(min(versionToLexi(89), versionToLexi(1234))).toBe(versionToLexi(89));
+  expect(max(versionToLexi(89), versionToLexi(1234))).toBe(versionToLexi(1234));
+
   expect(versionToLexi(238).localeCompare(versionToLexi(238))).toBe(0);
+  expect(min(versionToLexi(238), versionToLexi(238))).toBe(versionToLexi(238));
+  expect(max(versionToLexi(238), versionToLexi(238))).toBe(versionToLexi(238));
 
   const cmp = (a: number, b: number) =>
     a === b ? 0 : (a - b) / Math.abs(a - b);
@@ -44,6 +55,10 @@ test('LexiVersion sorting', () => {
     const lexiV2 = versionToLexi(v2);
 
     expect(cmp(v1, v2)).toEqual(lexiV1.localeCompare(lexiV2));
+    expect(versionToLexi(Math.min(v1, v2))).toBe(min(lexiV1, lexiV2));
+    expect(versionToLexi(Math.min(v1, v2))).toBe(min(lexiV2, lexiV1));
+    expect(versionToLexi(Math.max(v1, v2))).toBe(max(lexiV1, lexiV2));
+    expect(versionToLexi(Math.max(v1, v2))).toBe(max(lexiV2, lexiV1));
   }
 });
 

--- a/packages/zero-cache/src/types/lexi-version.ts
+++ b/packages/zero-cache/src/types/lexi-version.ts
@@ -61,3 +61,11 @@ export function versionFromLexi(lexiVersion: LexiVersion): bigint {
   );
   return parseBigInt(base36Version, 36);
 }
+
+export function max(a: LexiVersion, b: LexiVersion): LexiVersion {
+  return a > b ? a : b;
+}
+
+export function min(a: LexiVersion, b: LexiVersion): LexiVersion {
+  return a < b ? a : b;
+}


### PR DESCRIPTION
Implementation of the `Invalidation Watcher`, the starting point from which all View Syncer queries originate.

* Initial sync, catchup, or query-set changes start with a View Syncer calling `watch()` with filters and hashes corresponding to its set of queries, from which the Invalidation Watcher computes an initial invalidation message indicating which queries have been invalidated since the CVR version.
* From there, incremental invalidation messages are computed from the global Replicator `versionChanges()` stream for the View Syncer for any change in which its hashes are invalidated. 