### PR TITLE
feat(zero-cache): make service methods return Promises

### DIFF
--- a/packages/zero-cache/src/services/invalidation-watcher/invalidation-watcher.pg-test.ts
+++ b/packages/zero-cache/src/services/invalidation-watcher/invalidation-watcher.pg-test.ts
@@ -384,7 +384,7 @@ describe('invalidation-watcher', () => {
       const versionChanges = new Subscription<VersionChange>();
       const registerFilterResponses = c.registerFilterResponses ?? [];
       const replicator: Replicator = {
-        versionChanges: () => versionChanges,
+        versionChanges: () => Promise.resolve(versionChanges),
         registerInvalidationFilters: () =>
           Promise.resolve(registerFilterResponses.shift() ?? {specs: []}),
       };
@@ -454,9 +454,11 @@ describe('invalidation-watcher', () => {
     const replicator: Replicator = {
       versionChanges: () => {
         void subscriptionOpened.enqueue(true);
-        return new Subscription<VersionChange>({
-          cleanup: () => void subscriptionClosed.enqueue(true),
-        });
+        return Promise.resolve(
+          new Subscription<VersionChange>({
+            cleanup: () => void subscriptionClosed.enqueue(true),
+          }),
+        );
       },
       registerInvalidationFilters: () => Promise.resolve({specs: []}),
     };

--- a/packages/zero-cache/src/services/invalidation-watcher/invalidation-watcher.ts
+++ b/packages/zero-cache/src/services/invalidation-watcher/invalidation-watcher.ts
@@ -190,7 +190,7 @@ export class InvalidationWatcherService
       this.#lc.info?.('subscribing to VersionChanges');
 
       // The Subscription is canceled when there are no longer any watchers.
-      this.#versionChangeSubscription = replicator.versionChanges();
+      this.#versionChangeSubscription = await replicator.versionChanges();
       for await (const versionChange of this.#versionChangeSubscription) {
         await this.#processVersionChange(versionChange);
       }

--- a/packages/zero-cache/src/services/invalidation-watcher/registry.ts
+++ b/packages/zero-cache/src/services/invalidation-watcher/registry.ts
@@ -1,0 +1,8 @@
+import type {InvalidationWatcher} from './invalidation-watcher.js';
+
+export interface InvalidationWatcherRegistry {
+  /**
+   * Gets the InvalidationWatcher running in the current Service Runner.
+   */
+  getInvalidationWatcher(): Promise<InvalidationWatcher>;
+}

--- a/packages/zero-cache/src/services/replicator/incremental-sync.pg-test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.pg-test.ts
@@ -1290,8 +1290,8 @@ describe('replicator/incremental-sync', () => {
       }
 
       const syncing = syncer.run(lc);
-      const incrementalVersionSubscription = syncer.versionChanges();
-      const coalescedVersionSubscription = syncer.versionChanges();
+      const incrementalVersionSubscription = await syncer.versionChanges();
+      const coalescedVersionSubscription = await syncer.versionChanges();
 
       // Listen concurrently to capture incremental version changes.
       const incrementalVersions = (async () => {

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -206,7 +206,7 @@ export class IncrementalSyncer {
     lc.info?.('IncrementalSyncer stopped');
   }
 
-  versionChanges(): CancelableAsyncIterable<VersionChange> {
+  versionChanges(): Promise<CancelableAsyncIterable<VersionChange>> {
     const subscribe = (v: VersionChange) => subscription.push(v);
     const subscription: Subscription<VersionChange> =
       new Subscription<VersionChange>({
@@ -225,7 +225,7 @@ export class IncrementalSyncer {
       });
 
     this.#eventEmitter.on('version', subscribe);
-    return subscription;
+    return Promise.resolve(subscription);
   }
 
   async stop(lc: LogContext, err?: unknown) {

--- a/packages/zero-cache/src/services/replicator/replicator.ts
+++ b/packages/zero-cache/src/services/replicator/replicator.ts
@@ -94,7 +94,7 @@ export interface Replicator {
    * Creates a cancelable subscription to {@link VersionChange} messages for the
    * stream of replicated transactions.
    */
-  versionChanges(): CancelableAsyncIterable<VersionChange>;
+  versionChanges(): Promise<CancelableAsyncIterable<VersionChange>>;
 }
 
 export class ReplicatorService implements Replicator, Service {
@@ -155,7 +155,7 @@ export class ReplicatorService implements Replicator, Service {
     return this.#invalidator.registerInvalidationFilters(this.#lc, req);
   }
 
-  versionChanges(): CancelableAsyncIterable<VersionChange> {
+  versionChanges(): Promise<CancelableAsyncIterable<VersionChange>> {
     return this.#incrementalSyncer.versionChanges();
   }
 

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -1,6 +1,6 @@
 import type {LogContext} from '@rocicorp/logger';
 import * as v from 'shared/src/valita.js';
-import type {InvalidationWatcher} from '../invalidation-watcher/invalidation-watcher.js';
+import type {InvalidationWatcherRegistry} from '../invalidation-watcher/registry.js';
 import type {Service} from '../service.js';
 import type {Storage} from './storage/storage.js';
 
@@ -26,27 +26,27 @@ export class ViewSyncerService implements ViewSyncer, Service {
   readonly id: string;
   readonly #lc: LogContext;
   readonly #storage: Storage;
-  readonly #watcher: InvalidationWatcher;
+  readonly #registry: InvalidationWatcherRegistry;
 
   constructor(
     lc: LogContext,
     clientGroupID: string,
     storage: Storage,
-    watcher: InvalidationWatcher,
+    registry: InvalidationWatcherRegistry,
   ) {
     this.id = clientGroupID;
     this.#lc = lc
       .withContext('component', 'view-syncer')
       .withContext('serviceID', this.id);
     this.#storage = storage;
-    this.#watcher = watcher;
+    this.#registry = registry;
   }
 
   run(): Promise<void> {
     // TODO: Implement
     this.#lc;
     this.#storage;
-    this.#watcher;
+    this.#registry;
 
     throw new Error('todo');
   }


### PR DESCRIPTION
Change `Replicator.versionChanges()` to return a `Promise`, since this will eventually be serviceable by a stub in a sharded world.

Also add a Registry for getting the InvalidationWatcher service.