### PR TITLE
feat(zero-cache): schema path and type definitions for the View Syncer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44725,7 +44725,8 @@
         "postgres": "^3.4.4",
         "postgres-array": "^3.0.2",
         "shared": "0.0.0",
-        "xxhashjs": "^0.2.2"
+        "xxhashjs": "^0.2.2",
+        "zero-protocol": "0.0.0"
       },
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.2.0",
@@ -78125,7 +78126,8 @@
         "shared": "0.0.0",
         "typescript": "^5.4.2",
         "vitest": "1.3.0",
-        "xxhashjs": "^0.2.2"
+        "xxhashjs": "^0.2.2",
+        "zero-protocol": "0.0.0"
       },
       "dependencies": {
         "@cloudflare/vitest-pool-workers": {

--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -31,7 +31,8 @@
     "postgres": "^3.4.4",
     "postgres-array": "^3.0.2",
     "shared": "0.0.0",
-    "xxhashjs": "^0.2.2"
+    "xxhashjs": "^0.2.2",
+    "zero-protocol": "0.0.0"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.2.0",

--- a/packages/zero-cache/src/services/view-syncer/schema/migrations.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/migrations.test.ts
@@ -13,14 +13,11 @@ describe('view-syncer/migrations', () => {
     postState: object;
   };
 
-  const serviceID = '321';
-
   const cases: Case[] = [
     {
       name: 'storage schema meta',
       postState: {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        ['/vs/321/storage_schema_meta']: {
+        ['/vs/storage_schema_meta']: {
           // Update these as necessary.
           version: 1,
           maxVersion: 1,
@@ -40,7 +37,7 @@ describe('view-syncer/migrations', () => {
         await initStorageSchema(
           createSilentLogContext(),
           new DurableStorage(storage),
-          schemaRoot(serviceID),
+          schemaRoot,
           SCHEMA_MIGRATIONS,
         );
 

--- a/packages/zero-cache/src/services/view-syncer/schema/paths.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/paths.test.ts
@@ -1,0 +1,67 @@
+import {describe, expect, test} from 'vitest';
+import {rowKeyHash} from '../../../types/row-key.js';
+import {CVRPaths, LastActiveIndex} from './paths.js';
+
+describe('view-syncer/schema/paths', () => {
+  test('patch path versioning', () => {
+    const paths1 = new CVRPaths('123');
+    expect(paths1.queryPatch({stateVersion: '1zb'}, {id: 'foo-query'})).toBe(
+      '/vs/cvr/123/patches/1zb/queries/foo-query',
+    );
+
+    const paths2 = new CVRPaths('456');
+    expect(
+      paths2.queryPatch(
+        {stateVersion: '2abc', querySetVersion: 35},
+        {id: 'boo-query'},
+      ),
+    ).toBe('/vs/cvr/456/patches/2abc-0z/queries/boo-query');
+    expect(
+      paths2.queryPatch(
+        {stateVersion: '2abc', querySetVersion: 36},
+        {id: 'boo-query'},
+      ),
+    ).toBe('/vs/cvr/456/patches/2abc-110/queries/boo-query');
+  });
+
+  test('row paths', () => {
+    const paths = new CVRPaths('fbr');
+    expect(
+      paths.row({
+        schema: 'public',
+        table: 'issues',
+        rowKeyHash: rowKeyHash({id: 123}),
+      }),
+    ).toBe('/vs/cvr/fbr/rows/public/issues/qse5G7quj_el4_x5CbWzQg');
+    expect(
+      paths.row({
+        schema: 'public',
+        table: 'issues',
+        rowKeyHash: rowKeyHash({id: 124}),
+      }),
+    ).toBe('/vs/cvr/fbr/rows/public/issues/u1Ny9isI-KQXSET6KchNbw');
+    expect(
+      paths.row({
+        schema: 'schema/with/slashes',
+        table: 'table"with"double"quotes',
+        rowKeyHash: rowKeyHash({id: 120}),
+      }),
+    ).toBe(
+      '/vs/cvr/fbr/rows/"schema/with/slashes"/"table\\"with\\"double\\"quotes"/SzkDbDPMPjYy-AcfV3DrQA',
+    );
+  });
+
+  test('last active paths', () => {
+    const paths = new LastActiveIndex();
+
+    expect(paths.dayPrefix(new Date(Date.UTC(2024, 3, 19, 1, 2, 3)))).toBe(
+      '/vs/lastActive/2024-04-19',
+    );
+    expect(paths.dayPrefix(new Date(Date.UTC(2024, 3, 19, 3, 2, 1)))).toBe(
+      '/vs/lastActive/2024-04-19',
+    );
+    expect(
+      paths.entry('foo-cvr', new Date(Date.UTC(2024, 2, 28, 3, 48, 29))),
+    ).toBe('/vs/lastActive/2024-03-28/foo-cvr');
+  });
+});

--- a/packages/zero-cache/src/services/view-syncer/schema/paths.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/paths.ts
@@ -1,7 +1,115 @@
-export function schemaRoot(id: string): string {
-  return `/vs/${id}`;
+import {versionToLexi} from '../../../types/lexi-version.js';
+import type {CVRVersion, QueryRecord, RowID} from './types.js';
+
+// At a glance
+//
+// -----------------------------------------------------------------------
+// Schema Version
+// -----------------------------------------------------------------------
+// /vs/storage_schema_meta
+//
+// -----------------------------------------------------------------------
+// CVR
+// -----------------------------------------------------------------------
+// /vs/cvr/{id}/meta/version: {stateVersion: LexiVersion, querySetVersion?: number}
+// /vs/cvr/{id}/meta/lastActive: {day: Date}  // Updated at most once per day
+//
+// /vs/cvr/{id}/meta/queries/{qid}: QueryRecord (ast, transformationHash)
+// /vs/cvr/{id}/meta/queries/{qid}: QueryRecord
+// /vs/cvr/{id}/meta/queries/{qid}: QueryRecord
+//
+// /vs/cvr/{id}/rows/{schema}/{table}/{row-key-hash}: RowRecord (stateVersion, columns, queries)
+// /vs/cvr/{id}/rows/{schema}/{table}/{row-key-hash}: RowRecord
+// /vs/cvr/{id}/rows/{schema}/{table}/{row-key-hash}: RowRecord
+//
+// /vs/cvr/{id}/patches/{version-str}/rows/{schema}/{table}/{row-key-hash}: RowPatch
+// /vs/cvr/{id}/patches/{version-str}/rows/{schema}/{table}/{row-key-hash}: RowPatch
+// /vs/cvr/{id}/patches/{version-str}/rows/{schema}/{table}/{row-key-hash}: RowPatch
+//          ... interleaved with ...
+// /vs/cvr/{id}/patches/{version-str}/queries/{qid}: QueryPatch
+// /vs/cvr/{id}/patches/{version-str}/queries/{qid}: QueryPatch
+// /vs/cvr/{id}/patches/{version-str}/queries/{qid}: QueryPatch
+//
+// -----------------------------------------------------------------------
+// Last Active Index
+// -----------------------------------------------------------------------
+// /vs/lastActive/{day.toISOString()}/{cvrID}
+// /vs/lastActive/{day.toISOString()}/{cvrID}
+// /vs/lastActive/{day.toISOString()}/{cvrID}
+
+export const schemaRoot = '/vs';
+
+export class LastActiveIndex {
+  entry(cvrID: string, lastActive: Date): string {
+    return `${this.dayPrefix(lastActive)}/${cvrID}`;
+  }
+
+  /** dayPrefix is used for index scans to expunge very old CVRs. */
+  dayPrefix(date: Date): string {
+    const day = new Date(
+      Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+    );
+    const dateStr = day.toISOString();
+    const dayStr = dateStr.substring(0, dateStr.indexOf('T'));
+    return `/vs/lastActive/${dayStr}`;
+  }
 }
 
-export function cvrRoot(id: string): string {
-  return `/vs/${id}/cvr`;
+/** CVR-specific paths. */
+export class CVRPaths {
+  readonly root: string;
+
+  constructor(cvrID: string) {
+    this.root = `/vs/cvr/${cvrID}`;
+  }
+
+  version(): string {
+    return `${this.root}/meta/version`;
+  }
+
+  lastActive(): string {
+    return `${this.root}/meta/lastActive`;
+  }
+
+  query(query: QueryRecord | {id: string}): string {
+    return `${this.root}/meta/queries/${query.id}`;
+  }
+
+  row(row: RowID): string {
+    const schema = pathEscape(row.schema);
+    const table = pathEscape(row.table);
+    const hash = row.rowKeyHash;
+    return `${this.root}/rows/${schema}/${table}/${hash}`;
+  }
+
+  rowPatch(cvrVersion: CVRVersion, row: RowID): string {
+    const v = versionString(cvrVersion);
+    const schema = pathEscape(row.schema);
+    const table = pathEscape(row.table);
+    const hash = row.rowKeyHash;
+    return `${this.root}/patches/${v}/rows/${schema}/${table}/${hash}`;
+  }
+
+  queryPatch(
+    cvrVersion: CVRVersion,
+    query: QueryRecord | {id: string},
+  ): string {
+    const v = versionString(cvrVersion);
+    return `${this.root}/patches/${v}/queries/${query.id}`;
+  }
+}
+
+const pathEscapeChars = /[\\/\\"]/;
+
+function pathEscape(part: string) {
+  // In the common case, schema and table appear as-is in the path, but if the
+  // either have slashes or double quotes, JSON escape them to eliminate any
+  // ambiguities.
+  return pathEscapeChars.test(part) ? JSON.stringify(part) : part;
+}
+
+function versionString(v: CVRVersion) {
+  return v.querySetVersion === undefined
+    ? v.stateVersion
+    : `${v.stateVersion}-${versionToLexi(v.querySetVersion)}`;
 }

--- a/packages/zero-cache/src/services/view-syncer/schema/types.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/types.ts
@@ -1,0 +1,131 @@
+import * as v from 'shared/src/valita.js';
+import {astSchema} from 'zero-protocol';
+
+export const cvrVersionSchema = v.object({
+  /**
+   * The database `stateVersion` with which the rows in the CVR are consistent.
+   */
+  stateVersion: v.string(), // LexiVersion
+
+  /**
+   * `querySetVersion` is an initially absent counter that is incremented when
+   * the stateVersion remains the same but either (1) the query set changes or
+   * (2) query transformations change (the latter of which happens for changes
+   * in server-side logic or authorization policies).
+   *
+   * When the `stateVersion` moves forward, the `queryVersion` can be reset to
+   * absent.
+   */
+  querySetVersion: v.number().optional(),
+});
+
+export type CVRVersion = v.Infer<typeof cvrVersionSchema>;
+
+export const queryRecordSchema = v.object({
+  /** The client-specified ID used to identify this query. */
+  id: v.string(),
+
+  /** The original AST as supplied by the client. */
+  ast: astSchema,
+
+  /**
+   * The hash of the query after server-side transformations, which include:
+   *
+   * * Normalization (which may differ from what the client does)
+   * * Query "explosion" to fetch primary keys of rows for JOINed tables
+   * * Authorization transforms
+   *
+   * Transformations depend on conditions that are independent of the db state version,
+   * such as server-side logic and authorization policies. As such, the version of a CVR
+   * version may need to be advanced independent of db state changes. This is done
+   * via the `querySetVersion` counter of the CVRVersion object, which is used to account
+   * for both changes to the query set and changes to query transformations (which are
+   * effectively remove-old-query + add-new-query).
+   *
+   * Note that the transformed AST itself is **not** stored, as the result of the previous
+   * transformation is not useful in and of itself. If the current transformation results in
+   * a different hash than that of the transformation used for the last version of the CVR,
+   * it is simply handled by invalidating the existing rows, re-executed the query with
+   * the new transformation, and advancing the `querySerVersion`.
+   */
+  transformationHash: v.string(),
+
+  // TODO: Iron this out.
+  // estimatedBytes: v.number(),
+  // evictable: v.boolean().optional(),
+});
+
+export type QueryRecord = v.Infer<typeof queryRecordSchema>;
+
+export const rowIDSchema = v.object({
+  schema: v.string(),
+  table: v.string(),
+  rowKeyHash: v.string(),
+});
+
+export type RowID = v.Infer<typeof rowIDSchema>;
+
+/**
+ * The RowView contains exactly the information needed to look up and project
+ * the view of the row sent to and cached by the client. Specifically, the
+ * primary key of the `ChangeLog` table consists of the columns:
+ * * `stateVersion`
+ * * `schema`
+ * * `table`
+ * * `rowKeyHash`
+ *
+ * From which the `rowKey` and `row` data can be fetched. The `columns` field
+ * is then used to compute the projection of the `row` visible to the client.
+ *
+ * Note that the CVR never stores any row data itself---not even the row key.
+ * This has the benefit of
+ * 1. Resilience to large column values (DO storage has relatively low
+ *    size limits)
+ * 2. A privacy guarantee of only metadata being stored in Cloudflare.
+ *    Database values are only persisted in the Postgres replica.
+ */
+export const rowViewSchema = v.object({
+  id: rowIDSchema,
+  stateVersion: v.string(),
+  columns: v.array(v.string()),
+});
+
+export type RowView = v.Infer<typeof rowViewSchema>;
+
+export const rowRecordSchema = v.object({
+  row: rowViewSchema,
+  queryIDs: v.array(v.string()),
+});
+
+export type RowRecord = v.Infer<typeof rowRecordSchema>;
+
+export const rowPatchSchema = v.object({
+  op: v.union(v.literal('set'), v.literal('del')),
+  // Note that the row key needs to be looked up from the ChangeLog even for
+  // deletes, since only row key hashes are stored in the CVR.
+  //
+  // TODO: Figure out how to handle TRUNCATE, in which case there will not be a ChangeLog
+  //       entry for the (deleted) row at the version in which TRUNCATE happens.
+  //
+  //       We can't use rely on the row's pre-TRUNCATE `stateVersion` because there is
+  //       no guarantee that there is a ChangeLog entry at that version, since the row
+  //       may pre-date all mutations in the ChangeLog).
+  //
+  //       Some options are to:
+  //       1. Add a truncate (i.e. clear table) patch operation to the poke protocol.
+  //       2. Not support TRUNCATE.
+  //       3. Have the clients remember the rowKeyHash for each row. This seems a bit
+  //          wasteful and requires exporting an otherwise server-internal identifier.
+  //       4. Store the actual row key in the delete patch. This would counter the
+  //          benefits of not storing database values in the CVR.
+  row: rowViewSchema,
+});
+
+export type RowPatch = v.Infer<typeof rowPatchSchema>;
+
+export const queryPatch = v.object({
+  op: v.union(v.literal('set'), v.literal('del')),
+  id: v.string(),
+});
+
+export type QueryPatch = v.Infer<typeof queryPatch>;

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.test.ts
@@ -19,7 +19,7 @@ describe('view-syncer/service', () => {
 
       await vs.run();
 
-      expect(await storage.get('/vs/9876/storage_schema_meta')).toEqual({
+      expect(await storage.get('/vs/storage_schema_meta')).toEqual({
         // Update versions as necessary
         version: 1,
         maxVersion: 1,

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -49,7 +49,7 @@ export class ViewSyncerService implements ViewSyncer, Service {
     await initStorageSchema(
       this.#lc,
       this.#storage,
-      schemaRoot(this.id),
+      schemaRoot,
       SCHEMA_MIGRATIONS,
     );
     // TODO: Implement


### PR DESCRIPTION
Defines the valitas types, and the paths at which CVR data will be stored in the View Syncer.

Also changes schema migration to be DO-scoped, rather than View Syncer-scoped.