### PR TITLE
feat(zero-cache): fork EntryCache from reflect

### DIFF
--- a/packages/zero-cache/src/storage/write-cache.test.ts
+++ b/packages/zero-cache/src/storage/write-cache.test.ts
@@ -1,0 +1,698 @@
+import type {Patch} from 'reflect-protocol';
+import * as valita from 'shared/src/valita.js';
+import {describe, expect, test} from 'vitest';
+import {runWithDurableObjectStorage} from '../test/do.js';
+import {DurableStorage} from './durable-storage.js';
+import type {ListOptions} from './storage.js';
+import {EntryCache} from './write-cache.js';
+
+type Case = {
+  name: string;
+  pendingKeys: string[];
+  pendingKeysBatch: string[];
+  deletedKeys: string[];
+  deletedKeysBatch: string[];
+  listAndScanOpts?: {
+    opts: ListOptions;
+    expected: [string, string][];
+  };
+  expected: [string, string][];
+  expectedPending: Patch;
+};
+describe('entry-cache', () => {
+  const durableEntryKeys: string[] = ['bar-1', 'baz-1', 'foo-1'];
+
+  const cases: Case[] = [
+    {
+      name: 'all entries',
+      pendingKeys: [],
+      pendingKeysBatch: [],
+      deletedKeys: [],
+      deletedKeysBatch: [],
+      expected: [
+        ['bar-1', 'orig-bar-1'],
+        ['baz-1', 'orig-baz-1'],
+        ['foo-1', 'orig-foo-1'],
+      ],
+      expectedPending: [],
+    },
+    {
+      name: 'prefix',
+      pendingKeys: [],
+      pendingKeysBatch: [],
+      deletedKeys: [],
+      deletedKeysBatch: [],
+      listAndScanOpts: {
+        opts: {prefix: 'foo'},
+        expected: [['foo-1', 'orig-foo-1']],
+      },
+      expected: [
+        ['bar-1', 'orig-bar-1'],
+        ['baz-1', 'orig-baz-1'],
+        ['foo-1', 'orig-foo-1'],
+      ],
+      expectedPending: [],
+    },
+    {
+      name: 'limit',
+      pendingKeys: [],
+      pendingKeysBatch: [],
+      deletedKeys: [],
+      deletedKeysBatch: [],
+      listAndScanOpts: {
+        opts: {limit: 2},
+        expected: [
+          ['bar-1', 'orig-bar-1'],
+          ['baz-1', 'orig-baz-1'],
+        ],
+      },
+      expected: [
+        ['bar-1', 'orig-bar-1'],
+        ['baz-1', 'orig-baz-1'],
+        ['foo-1', 'orig-foo-1'],
+      ],
+      expectedPending: [],
+    },
+    {
+      name: 'prefix, limit',
+      pendingKeys: [],
+      pendingKeysBatch: [],
+      deletedKeys: [],
+      deletedKeysBatch: [],
+      listAndScanOpts: {
+        opts: {prefix: 'foo', limit: 2},
+        expected: [['foo-1', 'orig-foo-1']],
+      },
+      expected: [
+        ['bar-1', 'orig-bar-1'],
+        ['baz-1', 'orig-baz-1'],
+        ['foo-1', 'orig-foo-1'],
+      ],
+      expectedPending: [],
+    },
+    {
+      name: 'start',
+      pendingKeys: [],
+      pendingKeysBatch: [],
+      deletedKeys: [],
+      deletedKeysBatch: [],
+      listAndScanOpts: {
+        opts: {start: {key: 'baz-1'}},
+        expected: [
+          ['baz-1', 'orig-baz-1'],
+          ['foo-1', 'orig-foo-1'],
+        ],
+      },
+      expected: [
+        ['bar-1', 'orig-bar-1'],
+        ['baz-1', 'orig-baz-1'],
+        ['foo-1', 'orig-foo-1'],
+      ],
+      expectedPending: [],
+    },
+    {
+      name: 'start, exclusive',
+      pendingKeys: [],
+      pendingKeysBatch: [],
+      deletedKeys: [],
+      deletedKeysBatch: [],
+      listAndScanOpts: {
+        opts: {start: {key: 'baz-1', exclusive: true}},
+        expected: [['foo-1', 'orig-foo-1']],
+      },
+      expected: [
+        ['bar-1', 'orig-bar-1'],
+        ['baz-1', 'orig-baz-1'],
+        ['foo-1', 'orig-foo-1'],
+      ],
+      expectedPending: [],
+    },
+    {
+      name: 'prefix, limit, start, exclusive',
+      pendingKeys: [],
+      pendingKeysBatch: [],
+      deletedKeys: [],
+      deletedKeysBatch: [],
+      listAndScanOpts: {
+        opts: {
+          prefix: 'b',
+          limit: 1,
+          start: {key: 'bar-1', exclusive: true},
+        },
+        expected: [['baz-1', 'orig-baz-1']],
+      },
+      expected: [
+        ['bar-1', 'orig-bar-1'],
+        ['baz-1', 'orig-baz-1'],
+        ['foo-1', 'orig-foo-1'],
+      ],
+      expectedPending: [],
+    },
+
+    {
+      name: 'all entries (with pending puts)',
+      pendingKeys: ['baz-2'],
+      pendingKeysBatch: ['baz-3', 'foo-1'],
+      deletedKeys: [],
+      deletedKeysBatch: [],
+      expected: [
+        ['bar-1', 'orig-bar-1'],
+        ['baz-1', 'orig-baz-1'],
+        ['baz-2', 'new-baz-2'],
+        ['baz-3', 'new-baz-3'],
+        ['foo-1', 'new-foo-1'],
+      ],
+      expectedPending: [
+        {op: 'put', key: 'foo-1', value: 'new-foo-1'},
+        {op: 'put', key: 'baz-2', value: 'new-baz-2'},
+        {op: 'put', key: 'baz-3', value: 'new-baz-3'},
+      ],
+    },
+    {
+      name: 'prefix (with pending puts)',
+      pendingKeys: ['baz-2'],
+      pendingKeysBatch: ['baz-3', 'baz-4'],
+      deletedKeys: [],
+      deletedKeysBatch: [],
+      listAndScanOpts: {
+        opts: {prefix: 'ba'},
+        expected: [
+          ['bar-1', 'orig-bar-1'],
+          ['baz-1', 'orig-baz-1'],
+          ['baz-2', 'new-baz-2'],
+          ['baz-3', 'new-baz-3'],
+          ['baz-4', 'new-baz-4'],
+        ],
+      },
+      expected: [
+        ['bar-1', 'orig-bar-1'],
+        ['baz-1', 'orig-baz-1'],
+        ['baz-2', 'new-baz-2'],
+        ['baz-3', 'new-baz-3'],
+        ['baz-4', 'new-baz-4'],
+        ['foo-1', 'orig-foo-1'],
+      ],
+      expectedPending: [
+        {op: 'put', key: 'baz-2', value: 'new-baz-2'},
+        {op: 'put', key: 'baz-3', value: 'new-baz-3'},
+        {op: 'put', key: 'baz-4', value: 'new-baz-4'},
+      ],
+    },
+    {
+      name: 'limit (with pending puts)',
+      pendingKeys: ['baz-2'],
+      pendingKeysBatch: ['baz-3', 'baz-4'],
+      deletedKeys: [],
+      deletedKeysBatch: [],
+      listAndScanOpts: {
+        opts: {limit: 4},
+        expected: [
+          ['bar-1', 'orig-bar-1'],
+          ['baz-1', 'orig-baz-1'],
+          ['baz-2', 'new-baz-2'],
+          ['baz-3', 'new-baz-3'],
+        ],
+      },
+      expected: [
+        ['bar-1', 'orig-bar-1'],
+        ['baz-1', 'orig-baz-1'],
+        ['baz-2', 'new-baz-2'],
+        ['baz-3', 'new-baz-3'],
+        ['baz-4', 'new-baz-4'],
+        ['foo-1', 'orig-foo-1'],
+      ],
+      expectedPending: [
+        {op: 'put', key: 'baz-2', value: 'new-baz-2'},
+        {op: 'put', key: 'baz-3', value: 'new-baz-3'},
+        {op: 'put', key: 'baz-4', value: 'new-baz-4'},
+      ],
+    },
+    {
+      name: 'prefix, limit (with pending puts)',
+      pendingKeys: ['baz-2'],
+      pendingKeysBatch: ['baz-3', 'baz-4'],
+      deletedKeys: [],
+      deletedKeysBatch: [],
+      listAndScanOpts: {
+        opts: {prefix: 'baz', limit: 2},
+        expected: [
+          ['baz-1', 'orig-baz-1'],
+          ['baz-2', 'new-baz-2'],
+        ],
+      },
+      expected: [
+        ['bar-1', 'orig-bar-1'],
+        ['baz-1', 'orig-baz-1'],
+        ['baz-2', 'new-baz-2'],
+        ['baz-3', 'new-baz-3'],
+        ['baz-4', 'new-baz-4'],
+        ['foo-1', 'orig-foo-1'],
+      ],
+      expectedPending: [
+        {op: 'put', key: 'baz-2', value: 'new-baz-2'},
+        {op: 'put', key: 'baz-3', value: 'new-baz-3'},
+        {op: 'put', key: 'baz-4', value: 'new-baz-4'},
+      ],
+    },
+    {
+      name: 'start (with pending puts)',
+      pendingKeys: ['baz-2'],
+      pendingKeysBatch: ['baz-3', 'baz-4'],
+      deletedKeys: [],
+      deletedKeysBatch: [],
+      listAndScanOpts: {
+        opts: {start: {key: 'baz-1'}},
+        expected: [
+          ['baz-1', 'orig-baz-1'],
+          ['baz-2', 'new-baz-2'],
+          ['baz-3', 'new-baz-3'],
+          ['baz-4', 'new-baz-4'],
+          ['foo-1', 'orig-foo-1'],
+        ],
+      },
+      expected: [
+        ['bar-1', 'orig-bar-1'],
+        ['baz-1', 'orig-baz-1'],
+        ['baz-2', 'new-baz-2'],
+        ['baz-3', 'new-baz-3'],
+        ['baz-4', 'new-baz-4'],
+        ['foo-1', 'orig-foo-1'],
+      ],
+      expectedPending: [
+        {op: 'put', key: 'baz-2', value: 'new-baz-2'},
+        {op: 'put', key: 'baz-3', value: 'new-baz-3'},
+        {op: 'put', key: 'baz-4', value: 'new-baz-4'},
+      ],
+    },
+    {
+      name: 'start, exclusive (with pending puts)',
+      pendingKeys: ['baz-2'],
+      pendingKeysBatch: ['baz-3', 'baz-4'],
+      deletedKeys: [],
+      deletedKeysBatch: [],
+      listAndScanOpts: {
+        opts: {start: {key: 'baz-1', exclusive: true}},
+        expected: [
+          ['baz-2', 'new-baz-2'],
+          ['baz-3', 'new-baz-3'],
+          ['baz-4', 'new-baz-4'],
+          ['foo-1', 'orig-foo-1'],
+        ],
+      },
+      expected: [
+        ['bar-1', 'orig-bar-1'],
+        ['baz-1', 'orig-baz-1'],
+        ['baz-2', 'new-baz-2'],
+        ['baz-3', 'new-baz-3'],
+        ['baz-4', 'new-baz-4'],
+        ['foo-1', 'orig-foo-1'],
+      ],
+      expectedPending: [
+        {op: 'put', key: 'baz-2', value: 'new-baz-2'},
+        {op: 'put', key: 'baz-3', value: 'new-baz-3'},
+        {op: 'put', key: 'baz-4', value: 'new-baz-4'},
+      ],
+    },
+    {
+      name: 'prefix, limit, start, exclusive (with pending puts)',
+      pendingKeys: ['baz-2'],
+      pendingKeysBatch: ['baz-3', 'baz-4'],
+      deletedKeys: [],
+      deletedKeysBatch: [],
+      listAndScanOpts: {
+        opts: {
+          prefix: 'b',
+          limit: 3,
+          start: {key: 'bar-1', exclusive: true},
+        },
+        expected: [
+          ['baz-1', 'orig-baz-1'],
+          ['baz-2', 'new-baz-2'],
+          ['baz-3', 'new-baz-3'],
+        ],
+      },
+      expected: [
+        ['bar-1', 'orig-bar-1'],
+        ['baz-1', 'orig-baz-1'],
+        ['baz-2', 'new-baz-2'],
+        ['baz-3', 'new-baz-3'],
+        ['baz-4', 'new-baz-4'],
+        ['foo-1', 'orig-foo-1'],
+      ],
+      expectedPending: [
+        {op: 'put', key: 'baz-2', value: 'new-baz-2'},
+        {op: 'put', key: 'baz-3', value: 'new-baz-3'},
+        {op: 'put', key: 'baz-4', value: 'new-baz-4'},
+      ],
+    },
+
+    {
+      name: 'all entries (with pending puts and dels)',
+      pendingKeys: ['baz-2', 'baz-3'],
+      pendingKeysBatch: ['baz-4', 'baz-5'],
+      deletedKeys: ['baz-1', 'baz-2'],
+      deletedKeysBatch: ['baz-5', 'baz-6'],
+      expected: [
+        ['bar-1', 'orig-bar-1'],
+        ['baz-3', 'new-baz-3'],
+        ['baz-4', 'new-baz-4'],
+        ['foo-1', 'orig-foo-1'],
+      ],
+      expectedPending: [
+        {op: 'del', key: 'baz-2'},
+        {op: 'put', key: 'baz-3', value: 'new-baz-3'},
+        {op: 'put', key: 'baz-4', value: 'new-baz-4'},
+        {op: 'del', key: 'baz-5'},
+        {op: 'del', key: 'baz-1'},
+        {op: 'del', key: 'baz-6'},
+      ],
+    },
+    {
+      name: 'prefix (with pending puts and dels)',
+      pendingKeys: ['baz-2', 'baz-3'],
+      pendingKeysBatch: ['baz-4', 'baz-5'],
+      deletedKeys: ['baz-1', 'baz-2'],
+      deletedKeysBatch: ['baz-5', 'baz-6'],
+      listAndScanOpts: {
+        opts: {prefix: 'ba'},
+        expected: [
+          ['bar-1', 'orig-bar-1'],
+          ['baz-3', 'new-baz-3'],
+          ['baz-4', 'new-baz-4'],
+        ],
+      },
+      expected: [
+        ['bar-1', 'orig-bar-1'],
+        ['baz-3', 'new-baz-3'],
+        ['baz-4', 'new-baz-4'],
+        ['foo-1', 'orig-foo-1'],
+      ],
+      expectedPending: [
+        {op: 'del', key: 'baz-2'},
+        {op: 'put', key: 'baz-3', value: 'new-baz-3'},
+        {op: 'put', key: 'baz-4', value: 'new-baz-4'},
+        {op: 'del', key: 'baz-5'},
+        {op: 'del', key: 'baz-1'},
+        {op: 'del', key: 'baz-6'},
+      ],
+    },
+    {
+      name: 'limit (with pending puts and dels)',
+      pendingKeys: ['baz-2', 'baz-3'],
+      pendingKeysBatch: ['baz-4', 'baz-5', 'baz-6', 'baz-7'],
+      deletedKeys: ['baz-1', 'baz-2'],
+      deletedKeysBatch: ['baz-5', 'baz-7'],
+      listAndScanOpts: {
+        opts: {limit: 3},
+        expected: [
+          ['bar-1', 'orig-bar-1'],
+          ['baz-3', 'new-baz-3'],
+          ['baz-4', 'new-baz-4'],
+        ],
+      },
+      expected: [
+        ['bar-1', 'orig-bar-1'],
+        ['baz-3', 'new-baz-3'],
+        ['baz-4', 'new-baz-4'],
+        ['baz-6', 'new-baz-6'],
+        ['foo-1', 'orig-foo-1'],
+      ],
+      expectedPending: [
+        {op: 'del', key: 'baz-2'},
+        {op: 'put', key: 'baz-3', value: 'new-baz-3'},
+        {op: 'put', key: 'baz-4', value: 'new-baz-4'},
+        {op: 'del', key: 'baz-5'},
+        {op: 'put', key: 'baz-6', value: 'new-baz-6'},
+        {op: 'del', key: 'baz-7'},
+        {op: 'del', key: 'baz-1'},
+      ],
+    },
+    {
+      name: 'prefix, limit (with pending puts and dels)',
+      pendingKeys: ['baz-2', 'baz-3'],
+      pendingKeysBatch: ['baz-4', 'baz-5', 'baz-6', 'baz-7'],
+      deletedKeys: ['baz-1', 'baz-2'],
+      deletedKeysBatch: ['baz-5', 'baz-7'],
+      listAndScanOpts: {
+        opts: {prefix: 'baz', limit: 2},
+        expected: [
+          ['baz-3', 'new-baz-3'],
+          ['baz-4', 'new-baz-4'],
+        ],
+      },
+      expected: [
+        ['bar-1', 'orig-bar-1'],
+        ['baz-3', 'new-baz-3'],
+        ['baz-4', 'new-baz-4'],
+        ['baz-6', 'new-baz-6'],
+        ['foo-1', 'orig-foo-1'],
+      ],
+      expectedPending: [
+        {op: 'del', key: 'baz-2'},
+        {op: 'put', key: 'baz-3', value: 'new-baz-3'},
+        {op: 'put', key: 'baz-4', value: 'new-baz-4'},
+        {op: 'del', key: 'baz-5'},
+        {op: 'put', key: 'baz-6', value: 'new-baz-6'},
+        {op: 'del', key: 'baz-7'},
+        {op: 'del', key: 'baz-1'},
+      ],
+    },
+    {
+      name: 'start (with pending puts and dels)',
+      pendingKeys: ['baz-2', 'baz-3'],
+      pendingKeysBatch: ['baz-4', 'baz-5'],
+      deletedKeys: ['baz-1', 'baz-2'],
+      deletedKeysBatch: ['baz-5', 'baz-6'],
+      listAndScanOpts: {
+        opts: {start: {key: 'baz-3'}},
+        expected: [
+          ['baz-3', 'new-baz-3'],
+          ['baz-4', 'new-baz-4'],
+          ['foo-1', 'orig-foo-1'],
+        ],
+      },
+      expected: [
+        ['bar-1', 'orig-bar-1'],
+        ['baz-3', 'new-baz-3'],
+        ['baz-4', 'new-baz-4'],
+        ['foo-1', 'orig-foo-1'],
+      ],
+      expectedPending: [
+        {op: 'del', key: 'baz-2'},
+        {op: 'put', key: 'baz-3', value: 'new-baz-3'},
+        {op: 'put', key: 'baz-4', value: 'new-baz-4'},
+        {op: 'del', key: 'baz-5'},
+        {op: 'del', key: 'baz-1'},
+        {op: 'del', key: 'baz-6'},
+      ],
+    },
+    {
+      name: 'start, exclusive (with pending puts and dels)',
+      pendingKeys: ['baz-2', 'baz-3'],
+      pendingKeysBatch: ['baz-4', 'baz-5'],
+      deletedKeys: ['baz-1', 'baz-2'],
+      deletedKeysBatch: ['baz-5', 'baz-6'],
+      listAndScanOpts: {
+        opts: {start: {key: 'baz-3', exclusive: true}},
+        expected: [
+          ['baz-4', 'new-baz-4'],
+          ['foo-1', 'orig-foo-1'],
+        ],
+      },
+      expected: [
+        ['bar-1', 'orig-bar-1'],
+        ['baz-3', 'new-baz-3'],
+        ['baz-4', 'new-baz-4'],
+        ['foo-1', 'orig-foo-1'],
+      ],
+      expectedPending: [
+        {op: 'del', key: 'baz-2'},
+        {op: 'put', key: 'baz-3', value: 'new-baz-3'},
+        {op: 'put', key: 'baz-4', value: 'new-baz-4'},
+        {op: 'del', key: 'baz-5'},
+        {op: 'del', key: 'baz-1'},
+        {op: 'del', key: 'baz-6'},
+      ],
+    },
+    {
+      name: 'prefix, limit, start, exclusive (with pending puts and dels)',
+      pendingKeys: ['baz-2', 'baz-3'],
+      pendingKeysBatch: ['baz-4', 'baz-5'],
+      deletedKeys: ['baz-1', 'baz-2'],
+      deletedKeysBatch: ['baz-5', 'baz-6'],
+      listAndScanOpts: {
+        opts: {
+          prefix: 'b',
+          limit: 2,
+          start: {key: 'bar-1', exclusive: true},
+        },
+        expected: [
+          ['baz-3', 'new-baz-3'],
+          ['baz-4', 'new-baz-4'],
+        ],
+      },
+      expected: [
+        ['bar-1', 'orig-bar-1'],
+        ['baz-3', 'new-baz-3'],
+        ['baz-4', 'new-baz-4'],
+        ['foo-1', 'orig-foo-1'],
+      ],
+      expectedPending: [
+        {op: 'del', key: 'baz-2'},
+        {op: 'put', key: 'baz-3', value: 'new-baz-3'},
+        {op: 'put', key: 'baz-4', value: 'new-baz-4'},
+        {op: 'del', key: 'baz-5'},
+        {op: 'del', key: 'baz-1'},
+        {op: 'del', key: 'baz-6'},
+      ],
+    },
+  ];
+
+  for (const c of cases) {
+    test(c.name, async () => {
+      await runWithDurableObjectStorage(async storage => {
+        const durable = new DurableStorage(storage);
+
+        for (const k of durableEntryKeys) {
+          await durable.put(k, `orig-${k}`);
+        }
+
+        const cache = new EntryCache(durable);
+
+        expect(cache.isDirty()).toBe(false);
+        expect(await cache.get('foo-1', valita.string())).toEqual('orig-foo-1');
+        expect(cache.isDirty()).toBe(false);
+
+        for (const k of c.pendingKeys) {
+          await cache.put(k, `new-${k}`);
+        }
+
+        const entriesToPut: Record<string, string> = {};
+        for (const k of c.pendingKeysBatch) {
+          entriesToPut[k] = `new-${k}`;
+        }
+        await cache.putEntries(entriesToPut);
+
+        expect(cache.isDirty()).toBe(c.pendingKeys.length > 0);
+
+        for (const k of c.deletedKeys) {
+          await cache.del(k);
+        }
+        await cache.delEntries(c.deletedKeysBatch);
+
+        expect(cache.isDirty()).toBe(
+          c.pendingKeys.length + c.deletedKeys.length > 0,
+        );
+
+        const entries = [...(await cache.list({}, valita.string()))];
+        expect(entries).toEqual(c.expected);
+        if (c.listAndScanOpts) {
+          const entries = [
+            ...(await cache.list(c.listAndScanOpts.opts, valita.string())),
+          ];
+          expect(entries).toEqual(c.listAndScanOpts.expected);
+        }
+
+        // Test scan()
+        const results: [string, string][] = [];
+        for await (const entry of cache.scan({}, valita.string())) {
+          results.push(entry);
+        }
+        expect(results).toEqual(c.expected);
+
+        if (c.listAndScanOpts) {
+          const results: [string, string][] = [];
+          for await (const entry of cache.scan(
+            c.listAndScanOpts.opts,
+            valita.string(),
+          )) {
+            results.push(entry);
+          }
+          expect(results).toEqual(c.listAndScanOpts.expected);
+        }
+
+        // Test batchScan() with a variety of batch sizes.
+        for (const batchSize of [1, 2, 3, 128]) {
+          const results: [string, string][] = [];
+          for await (const batch of cache.batchScan(
+            {},
+            valita.string(),
+            batchSize,
+          )) {
+            results.push(...batch);
+          }
+          expect(results).toEqual(c.expected);
+        }
+        if (c.listAndScanOpts) {
+          for (const batchSize of [1, 2, 3, 128]) {
+            const results: [string, string][] = [];
+            for await (const batch of cache.batchScan(
+              c.listAndScanOpts.opts,
+              valita.string(),
+              batchSize,
+            )) {
+              results.push(...batch);
+            }
+            expect(results).toEqual(c.listAndScanOpts.expected);
+          }
+        }
+
+        // Test getEntries
+        await testGetEntries(durableEntryKeys, cache, c);
+        await testGetEntries([...durableEntryKeys, ...c.pendingKeys], cache, c);
+
+        const durableEntriesBeforeFlush = [
+          ...(await durable.list({}, valita.string())),
+        ];
+        expect(durableEntriesBeforeFlush).toEqual(
+          durableEntryKeys.map(k => [k, `orig-${k}`]),
+        );
+
+        expect(cache.pending()).toEqual(c.expectedPending);
+        const expectedCounts = {
+          delCount: 0,
+          putCount: 0,
+        };
+        for (const {op} of c.expectedPending) {
+          if (op === 'del') {
+            expectedCounts.delCount++;
+          }
+          if (op === 'put') {
+            expectedCounts.putCount++;
+          }
+        }
+        expect(cache.pendingCounts()).toEqual(expectedCounts);
+
+        await cache.flush();
+        expect(cache.isDirty()).toBe(false);
+
+        const durableEntriesAfterFlush = [
+          ...(await durable.list({}, valita.string())),
+        ];
+
+        expect(durableEntriesAfterFlush).toEqual(c.expected);
+      });
+    });
+  }
+});
+
+async function testGetEntries(keys: string[], cache: EntryCache, c: Case) {
+  const compareEntries = (
+    [k1, _1]: [string, string],
+    [k2, _2]: [string, string],
+  ) => {
+    if (k1 === k2) {
+      return 0;
+    } else if (k1 < k2) {
+      return -1;
+    }
+    return 1;
+  };
+  const sortedResultEntries = [
+    ...(await cache.getEntries(keys, valita.string())).entries(),
+  ].sort(compareEntries);
+  const sortedExpectedEntries = c.expected
+    .filter(([k]) => keys.includes(k))
+    .sort(compareEntries);
+  expect(sortedResultEntries).toEqual(sortedExpectedEntries);
+}

--- a/packages/zero-cache/src/storage/write-cache.ts
+++ b/packages/zero-cache/src/storage/write-cache.ts
@@ -1,0 +1,287 @@
+import {compareUTF8} from 'compare-utf8';
+import type {DelOp, PutOp} from 'reflect-protocol';
+import type {ReadonlyJSONValue} from 'shared/src/json.js';
+import * as valita from 'shared/src/valita.js';
+import {batchScan, scan} from './scan-storage.js';
+import type {ListOptions, Storage} from './storage.js';
+
+/**
+ * Implements a read/write cache for key/value pairs on top of some lower-level
+ * storage.
+ *
+ * This is designed to be stacked: EntryCache itself implements Storage so that
+ * you can create multiple layers of caches and control when they flush.
+ *
+ * TODO: We can remove the read side of this since DO does caching itself internally!
+ */
+export class EntryCache implements Storage {
+  #storage: Storage;
+  #cache: Map<string, {value?: ReadonlyJSONValue | undefined; dirty: boolean}> =
+    new Map();
+
+  constructor(storage: Storage) {
+    this.#storage = storage;
+  }
+
+  #put<T extends ReadonlyJSONValue>(key: string, value: T) {
+    this.#cache.set(key, {value, dirty: true});
+  }
+
+  // eslint-disable-next-line require-await
+  async put<T extends ReadonlyJSONValue>(key: string, value: T): Promise<void> {
+    this.#put(key, value);
+  }
+
+  // eslint-disable-next-line require-await
+  async putEntries<T extends ReadonlyJSONValue>(
+    entries: Record<string, T>,
+  ): Promise<void> {
+    for (const [key, value] of Object.entries(entries)) {
+      this.#put(key, value);
+    }
+  }
+
+  #del(key: string) {
+    this.#cache.set(key, {value: undefined, dirty: true});
+  }
+
+  // eslint-disable-next-line require-await
+  async del(key: string): Promise<void> {
+    this.#del(key);
+  }
+
+  // eslint-disable-next-line require-await
+  async delEntries(keys: string[]): Promise<void> {
+    for (const key of keys) {
+      this.#del(key);
+    }
+  }
+
+  async get<T extends ReadonlyJSONValue>(
+    key: string,
+    schema: valita.Type<T>,
+  ): Promise<T | undefined> {
+    const cached = this.#cache.get(key);
+    if (cached) {
+      // We don't validate on cache hits partly for perf reasons and also
+      // because we should have already validated with same schema during
+      // initial read.
+      return cached.value as T | undefined;
+    }
+    const value = await this.#storage.get(key, schema);
+    this.#cache.set(key, {value, dirty: false});
+    return value;
+  }
+
+  async getEntries<T extends ReadonlyJSONValue>(
+    keys: string[],
+    schema: valita.Type<T>,
+  ): Promise<Map<string, T>> {
+    const result = new Map<string, T>();
+    const keysToGetFromStorage = [];
+    for (const key of keys) {
+      const cached = this.#cache.get(key);
+      if (cached) {
+        // We don't validate on cache hits partly for perf reasons and also
+        // because we should have already validated with same schema during
+        // initial read.
+        if (cached.value !== undefined) {
+          result.set(key, cached.value as T);
+        }
+      } else {
+        keysToGetFromStorage.push(key);
+      }
+    }
+    const fromStorage = await this.#storage.getEntries(
+      keysToGetFromStorage,
+      schema,
+    );
+    for (const [key, value] of fromStorage.entries()) {
+      this.#cache.set(key, {value, dirty: false});
+      result.set(key, value);
+    }
+    return result;
+  }
+
+  /**
+   * @returns Whether there are any pending writes in the cache. Note that
+   * redundant writes (e.g. deleting a non-existing key) are still considered writes.
+   */
+  isDirty(): boolean {
+    for (const value of this.#cache.values()) {
+      if (value.dirty) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  pending(): (PutOp | DelOp)[] {
+    const res: (PutOp | DelOp)[] = [];
+    for (const [key, {value, dirty}] of this.#cache.entries()) {
+      if (dirty) {
+        if (value === undefined) {
+          res.push({op: 'del', key});
+        } else {
+          res.push({op: 'put', key, value});
+        }
+      }
+    }
+    return res;
+  }
+
+  pendingCounts(): {
+    delCount: number;
+    putCount: number;
+  } {
+    const counts = {
+      delCount: 0,
+      putCount: 0,
+    };
+    for (const {value, dirty} of this.#cache.values()) {
+      if (dirty) {
+        if (value === undefined) {
+          counts.delCount++;
+        } else {
+          counts.putCount++;
+        }
+      }
+    }
+    return counts;
+  }
+
+  async flush(): Promise<void> {
+    // Note the order of operations: all del()` and put() calls are
+    // invoked before await. This ensures atomicity of the flushed
+    // writes, as described in:
+    //
+    // https://developers.cloudflare.com/workers/learning/using-durable-objects/#accessing-persistent-storage-from-a-durable-object
+    const promises = [];
+    for (const [key, {value, dirty}] of this.#cache.entries()) {
+      if (dirty) {
+        if (value === undefined) {
+          promises.push(this.#storage.del(key));
+        } else {
+          promises.push(this.#storage.put(key, value));
+        }
+      }
+    }
+    await Promise.all(promises);
+    this.#cache.clear();
+  }
+
+  scan<T extends ReadonlyJSONValue>(
+    options: ListOptions,
+    schema: valita.Type<T>,
+  ): AsyncIterable<[key: string, value: T]> {
+    return scan(this, options, schema);
+  }
+
+  batchScan<T extends ReadonlyJSONValue>(
+    options: ListOptions,
+    schema: valita.Type<T>,
+    batchSize: number,
+  ): AsyncIterable<Map<string, T>> {
+    return batchScan(this, options, schema, batchSize);
+  }
+
+  async list<T extends ReadonlyJSONValue>(
+    options: ListOptions,
+    schema: valita.Type<T>,
+  ): Promise<Map<string, T>> {
+    const {prefix, start, limit} = options;
+    const startKey = start?.key;
+    const exclusive = start?.exclusive;
+
+    // if the caller specified a limit, and we have local deletes, adjust
+    // how many we fetch from the underlying storage.
+    let adjustedLimit = limit;
+    if (adjustedLimit !== undefined) {
+      let deleted = 0;
+      for (const [, {value, dirty}] of this.#cache.entries()) {
+        if (dirty && value === undefined) {
+          deleted++;
+        }
+      }
+      adjustedLimit += deleted;
+    }
+
+    const base = new Map(
+      await this.#storage.list({...options, limit: adjustedLimit}, schema),
+    );
+
+    // build a list of pending changes to overlay atop stored values
+    const pending: [string, T | undefined][] = [];
+    for (const entry of this.#cache.entries()) {
+      const [k, v] = entry;
+
+      if (
+        v.dirty &&
+        (!prefix || k.startsWith(prefix)) &&
+        (!startKey ||
+          (exclusive
+            ? compareUTF8(k, startKey) > 0
+            : compareUTF8(k, startKey) >= 0))
+      ) {
+        if (v.value === undefined) {
+          pending.push([k, undefined]);
+        } else {
+          pending.push([k, valita.parse(v.value, schema)]);
+        }
+      }
+    }
+
+    // The map of entries coming back from DurableStorage is utf8 sorted.
+    // Maintain this by merging the pending changes in-order
+    pending.sort(([a], [b]) => compareUTF8(a, b));
+
+    const out = new Map<string, T>();
+    const a = base.entries();
+    const b = pending.values();
+
+    let iterResultA = a.next();
+    let iterResultB = b.next();
+    let count = 0;
+
+    function add(k: string, v: T | undefined) {
+      if (v !== undefined) {
+        out.set(k, v);
+        count++;
+      }
+    }
+
+    while (
+      !(iterResultB.done && iterResultA.done) &&
+      (!limit || count < limit)
+    ) {
+      if (!iterResultB.done) {
+        const [bKey, bValue] = iterResultB.value;
+
+        if (!iterResultA.done) {
+          const [aKey, aValue] = iterResultA.value;
+
+          const cmp = compareUTF8(aKey, bKey);
+          if (cmp === 0) {
+            add(bKey, bValue);
+            iterResultA = a.next();
+            iterResultB = b.next();
+          } else if (cmp < 0) {
+            add(aKey, aValue);
+            iterResultA = a.next();
+          } else {
+            add(bKey, bValue);
+            iterResultB = b.next();
+          }
+        } else {
+          add(bKey, bValue);
+          iterResultB = b.next();
+        }
+      } else {
+        add(iterResultA.value[0], iterResultA.value[1]);
+        iterResultA = a.next();
+      }
+    }
+
+    return out;
+  }
+}


### PR DESCRIPTION
This is a straight copy from `reflect-server`, except for changes in the test to adapt it to vitest + Miniflare 3.

In a subsequent step, this will adapted to the intended semantics for Zero (including removal of read caching and renaming it to WriteCache).