### PR TITLE
feat(zero-cache): adapt reflect-server storage classes for zero-cache semantics

### DIFF
--- a/packages/zero-cache/src/storage/durable-storage.ts
+++ b/packages/zero-cache/src/storage/durable-storage.ts
@@ -1,6 +1,5 @@
 import type {
   DurableObjectListOptions,
-  DurableObjectPutOptions,
   DurableObjectStorage,
 } from '@cloudflare/workers-types';
 import {compareUTF8} from 'compare-utf8';
@@ -17,16 +16,25 @@ import {
 import {batchScan, scan} from './scan-storage.js';
 import type {ListOptions, Storage} from './storage.js';
 
-const baseAllowConcurrency = true;
-
-// DurableObjects has a lot of clever optimizations we can take advantage of,
-// but they require some thought as to whether they fit with what we are doing.
-// These settings make DO behave more like a basic kv store and thus work
-// better with our existing code.
-// TODO: Evaluate these options and perhaps simplify our code by taking advantage.
-const baseOptions = {
-  // We already control currency with locks at a higher level in the game loop.
-  allowConcurrency: baseAllowConcurrency,
+// DurableObjects has a lot of clever optimizations for simplifying the
+// concurrency semantics of a single application writing to shared state:
+// https://blog.cloudflare.com/durable-objects-easy-fast-correct-choose-three/
+//
+// However, in zero-cache a Durable Object is used to run multiple independent
+// services, along the lines of a VM running containers, each of which
+// may use Durable Object storage within its own namespace/prefix.
+//
+// In this setup, the input / output gate logic of Durable Objects unnecessarily
+// introduce delays from activity of unrelated services. They are thus disabled for
+// zero, which instead relies on standard per-service locking for concurrency within
+// a service, and the WriteCache for isolated atomic transactions.
+const ioOptions = {
+  // Disables input gates, which would otherwise cause the reads from one service to
+  // block the reads of another service.
+  allowConcurrency: true,
+  // Disables output gates, which would otherwise cause the writes from one service
+  // to block outgoing I/O of other services.
+  allowUnconfirmed: true,
 } as const;
 
 /**
@@ -34,39 +42,34 @@ const baseOptions = {
  */
 export class DurableStorage implements Storage {
   readonly #durable: DurableObjectStorage;
-  readonly #baseOptions: Readonly<DurableObjectPutOptions>;
 
-  constructor(durable: DurableObjectStorage, allowUnconfirmed = true) {
+  constructor(durable: DurableObjectStorage) {
     this.#durable = durable;
-    this.#baseOptions = {
-      allowConcurrency: baseAllowConcurrency,
-      allowUnconfirmed,
-    };
   }
 
   put<T extends ReadonlyJSONValue>(key: string, value: T): Promise<void> {
-    return putEntry(this.#durable, key, value, this.#baseOptions);
+    return putEntry(this.#durable, key, value, ioOptions);
   }
 
   putEntries<T extends ReadonlyJSONValue>(
     entries: Record<string, T>,
   ): Promise<void> {
-    return this.#durable.put(entries, this.#baseOptions);
+    return this.#durable.put(entries, ioOptions);
   }
 
   del(key: string): Promise<void> {
-    return delEntry(this.#durable, key, this.#baseOptions);
+    return delEntry(this.#durable, key, ioOptions);
   }
 
   delEntries(keys: string[]): Promise<void> {
-    return this.#durable.delete(keys, this.#baseOptions).then(() => undefined);
+    return this.#durable.delete(keys, ioOptions).then(() => undefined);
   }
 
   get<T extends ReadonlyJSONValue>(
     key: string,
     schema: valita.Type<T>,
   ): Promise<T | undefined> {
-    return getEntry(this.#durable, key, schema, baseOptions);
+    return getEntry(this.#durable, key, schema, ioOptions);
   }
 
   /**
@@ -83,7 +86,7 @@ export class DurableStorage implements Storage {
   ): Promise<Map<string, T>> {
     // Simple case that does not require partitioning.
     if (keys.length <= MAX_ENTRIES_TO_GET) {
-      return getEntries(this.#durable, keys, schema, baseOptions);
+      return getEntries(this.#durable, keys, schema, ioOptions);
     }
     // Partition the keys in groups no larger than MAX_ENTRIES_TO_GET.
     const partitionedKeys = [];
@@ -95,7 +98,7 @@ export class DurableStorage implements Storage {
     // Perform parallel getEntries()
     const partitionedEntries = await Promise.all(
       partitionedKeys.map(partition =>
-        getEntries(this.#durable, partition, schema, baseOptions),
+        getEntries(this.#durable, partition, schema, ioOptions),
       ),
     );
     // Merge and sort to adhere to the sorted-key guarantee of Durable Object APIs.
@@ -141,7 +144,7 @@ export class DurableStorage implements Storage {
 
 function doListOptions(opts: ListOptions): DurableObjectListOptions {
   const doOpts: DurableObjectListOptions = {
-    allowConcurrency: baseAllowConcurrency,
+    allowConcurrency: ioOptions.allowConcurrency,
   };
 
   if (opts.prefix !== undefined) {


### PR DESCRIPTION
The only semantic difference is that in `zero-cache`, `allowUnconfirmed` is always true.

The `EntryCache` has been renamed to `WriteCache`, with caching of reads removed. The computation of pending ops will not be used in zero but is kept for testing purposes.