### PR TITLE
feat(zero-client)!: Remove oldReplicacheQuery

### DIFF
--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -540,15 +540,6 @@ export class Zero<MD extends MutatorDefs, QD extends QueryDefs> {
   }
 
   /**
-   * Transactionally read Zero data.
-   */
-  oldReplicacheQuery<R>(
-    body: (tx: ReadTransaction) => Promise<R> | R,
-  ): Promise<R> {
-    return this.#rep.query(body);
-  }
-
-  /**
    * Watches Zero for changes.
    *
    * The `callback` gets called whenever the underlying data changes and the


### PR DESCRIPTION
BREAKING CHANGE

Remove the old query method and update tests to use query.name.select instead.