### PR TITLE
fix(zero-cache): avoid adhoc "schema.table" strings

### DIFF
--- a/packages/zero-cache/src/services/replicator/incremental-sync.message-processor.pg-test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.message-processor.pg-test.ts
@@ -305,7 +305,7 @@ describe('replicator/message-processor', () => {
         {
           // Unused in this test.
           publications: [],
-          tables: {},
+          tables: [],
         },
         new Lock(),
         new InvalidationFilters(),

--- a/packages/zero-cache/src/services/replicator/incremental-sync.pg-test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.pg-test.ts
@@ -83,6 +83,10 @@ describe('replicator/incremental-sync', () => {
         "issueID" INTEGER PRIMARY KEY,
         _0_version VARCHAR(38) DEFAULT '00'
       );
+      CREATE TABLE "table-with-special-characters" (
+        "id" INTEGER PRIMARY KEY,
+        _0_version VARCHAR(38) DEFAULT '00'
+      );
       CREATE PUBLICATION zero_data FOR TABLES IN SCHEMA public;
 
       CREATE SCHEMA zero;
@@ -112,6 +116,25 @@ describe('replicator/incremental-sync', () => {
             },
           },
           primaryKey: ['issueID'],
+        },
+        ['public.table-with-special-characters']: {
+          schema: 'public',
+          name: 'table-with-special-characters',
+          columns: {
+            id: {
+              dataType: 'int4',
+              characterMaximumLength: null,
+              columnDefault: null,
+              notNull: true,
+            },
+            ['_0_version']: {
+              dataType: 'varchar',
+              characterMaximumLength: 38,
+              columnDefault: null,
+              notNull: true,
+            },
+          },
+          primaryKey: ['id'],
         },
         ['zero.clients']: {
           schema: 'zero',
@@ -1329,7 +1352,14 @@ describe('replicator/incremental-sync', () => {
       }
 
       const published = await getPublicationInfo(replica, 'zero_');
-      expect(published.tables).toEqual(c.specs);
+      expect(
+        Object.fromEntries(
+          published.tables.map(table => [
+            `${table.schema}.${table.name}`,
+            table,
+          ]),
+        ),
+      ).toEqual(c.specs);
 
       await expectTables(replica, replaceVersions(c.data, versions));
 

--- a/packages/zero-cache/src/services/replicator/initial-sync.pg-test.ts
+++ b/packages/zero-cache/src/services/replicator/initial-sync.pg-test.ts
@@ -226,13 +226,24 @@ describe('replicator/initial-sync', () => {
       );
 
       const published = await getPublicationInfo(upstream, 'zero_');
-      expect(published.tables).toEqual(c.published);
+      expect(
+        Object.fromEntries(
+          published.tables.map(table => [
+            `${table.schema}.${table.name}`,
+            table,
+          ]),
+        ),
+      ).toEqual(c.published);
       expect(published.publications.map(p => p.pubname)).toEqual(
         expect.arrayContaining(c.publications),
       );
 
       const synced = await getPublicationInfo(replica, 'zero_');
-      expect(synced.tables).toMatchObject(c.published);
+      expect(
+        Object.fromEntries(
+          synced.tables.map(table => [`${table.schema}.${table.name}`, table]),
+        ),
+      ).toMatchObject(c.published);
       expect(synced.publications.map(p => p.pubname)).toEqual(
         expect.arrayContaining(c.publications),
       );

--- a/packages/zero-cache/src/services/replicator/initial-sync.ts
+++ b/packages/zero-cache/src/services/replicator/initial-sync.ts
@@ -47,7 +47,7 @@ export async function startPostgresReplication(
   // Create the corresponding schemas and tables in the Sync Replica, with the
   // additional _0_version column to track row versions.
   const schemas = new Set<string>();
-  const tablesStmts = Object.values(published.tables).map(table => {
+  const tablesStmts = published.tables.map(table => {
     if (table.schema === '_zero') {
       throw new Error(`Schema _zero is reserved for internal use`);
     }
@@ -273,7 +273,11 @@ function ensurePublishedTables(
 ): Promise<PublicationInfo> {
   return upstreamDB.begin(async tx => {
     const published = await getPublicationInfo(tx, PUB_PREFIX);
-    if ('zero.clients' in published.tables) {
+    if (
+      published.tables.find(
+        table => table.schema === 'zero' && table.name === 'clients',
+      )
+    ) {
       // upstream is already set up for replication.
       return published;
     }

--- a/packages/zero-cache/src/services/replicator/tables/create.pg-test.ts
+++ b/packages/zero-cache/src/services/replicator/tables/create.pg-test.ts
@@ -119,9 +119,7 @@ describe('tables/create', () => {
       await db.unsafe(createTableStatement(c.tableSpec));
 
       const published = await getPublicationInfo(db, 'zero_');
-      expect(
-        published.tables[`${c.tableSpec.schema}.${c.tableSpec.name}`],
-      ).toEqual(c.tableSpec);
+      expect(published.tables).toEqual(expect.arrayContaining([c.tableSpec]));
     });
   }
 });

--- a/packages/zero-cache/src/services/replicator/tables/published.pg-test.ts
+++ b/packages/zero-cache/src/services/replicator/tables/published.pg-test.ts
@@ -16,7 +16,7 @@ describe('tables/published', () => {
       setupQuery: `CREATE SCHEMA zero`,
       expectedResult: {
         publications: [],
-        tables: {},
+        tables: [],
       },
     },
     {
@@ -39,8 +39,8 @@ describe('tables/published', () => {
             pubtruncate: true,
           },
         ],
-        tables: {
-          ['zero.clients']: {
+        tables: [
+          {
             schema: 'zero',
             name: 'clients',
             columns: {
@@ -59,7 +59,7 @@ describe('tables/published', () => {
             },
             primaryKey: ['clientID'],
           },
-        },
+        ],
       },
     },
     {
@@ -89,8 +89,8 @@ describe('tables/published', () => {
             pubtruncate: true,
           },
         ],
-        tables: {
-          ['test.users']: {
+        tables: [
+          {
             schema: 'test',
             name: 'users',
             columns: {
@@ -151,7 +151,7 @@ describe('tables/published', () => {
             },
             primaryKey: ['user_id'],
           },
-        },
+        ],
       },
     },
     {
@@ -180,8 +180,8 @@ describe('tables/published', () => {
             pubtruncate: true,
           },
         ],
-        tables: {
-          ['test.users']: {
+        tables: [
+          {
             schema: 'test',
             name: 'users',
             columns: {
@@ -212,7 +212,7 @@ describe('tables/published', () => {
             },
             primaryKey: ['user_id'],
           },
-        },
+        ],
       },
     },
     {
@@ -238,8 +238,8 @@ describe('tables/published', () => {
             pubtruncate: true,
           },
         ],
-        tables: {
-          ['test.issues']: {
+        tables: [
+          {
             schema: 'test',
             name: 'issues',
             columns: {
@@ -270,7 +270,7 @@ describe('tables/published', () => {
             },
             primaryKey: ['org_id', 'component_id', 'issue_id'],
           },
-        },
+        ],
       },
     },
     {
@@ -316,8 +316,8 @@ describe('tables/published', () => {
             pubtruncate: true,
           },
         ],
-        tables: {
-          ['test.issues']: {
+        tables: [
+          {
             schema: 'test',
             name: 'issues',
             columns: {
@@ -348,7 +348,7 @@ describe('tables/published', () => {
             },
             primaryKey: ['org_id', 'component_id', 'issue_id'],
           },
-          ['test.users']: {
+          {
             schema: 'test',
             name: 'users',
             columns: {
@@ -367,7 +367,7 @@ describe('tables/published', () => {
             },
             primaryKey: ['user_id'],
           },
-          ['zero.clients']: {
+          {
             schema: 'zero',
             name: 'clients',
             columns: {
@@ -386,7 +386,7 @@ describe('tables/published', () => {
             },
             primaryKey: ['clientID'],
           },
-        },
+        ],
       },
     },
   ];

--- a/packages/zero-cache/src/services/replicator/tables/published.ts
+++ b/packages/zero-cache/src/services/replicator/tables/published.ts
@@ -34,7 +34,7 @@ export type Publication = v.Infer<typeof publicationSchema>;
 
 export type PublicationInfo = {
   publications: Publication[];
-  tables: Record<string, TableSpec>;
+  tables: TableSpec[];
 };
 
 /**
@@ -79,7 +79,7 @@ export async function getPublicationInfo(
 
   const publications = v.parse(result[0], publicationsResultSchema);
   const columns = v.parse(result[1], publishedColumnsSchema);
-  const tables: Record<string, TableSpec> = {};
+  const tables: TableSpec[] = [];
   let table: TableSpec | undefined;
 
   columns.forEach(col => {
@@ -91,7 +91,7 @@ export async function getPublicationInfo(
         columns: {},
         primaryKey: [],
       };
-      tables[`${table.schema}.${table.name}`] = table;
+      tables.push(table);
     }
 
     // https://stackoverflow.com/a/52376230


### PR DESCRIPTION
Avoid using `schema + '.' + table` strings to in sql statements or as keys in maps in production code, as they can fail or be ambiguous for quoted tables. It's still used for constructing test expectations for convenience, but that's safe.

