### PR TITLE
fix(zero-cache): ignore NOT NULL when initializing replicated tables

### DIFF
--- a/packages/zero-cache/src/services/replicator/initial-sync.ts
+++ b/packages/zero-cache/src/services/replicator/initial-sync.ts
@@ -3,7 +3,7 @@ import postgres from 'postgres';
 import {sleep} from 'shared/src/sleep.js';
 import {postgresTypeConfig} from '../../types/pg.js';
 import {id, idList} from '../../types/sql.js';
-import {createTableStatement} from './tables/create.js';
+import {createTableStatementIgnoringNotNullConstraint} from './tables/create.js';
 import {PublicationInfo, getPublicationInfo} from './tables/published.js';
 import {ZERO_VERSION_COLUMN_NAME} from './tables/replication.js';
 import type {ColumnSpec} from './tables/specs.js';
@@ -62,7 +62,7 @@ export async function startPostgresReplication(
     schemas.add(table.schema);
     // Add the _0_version column with a default value of "00".
     table.columns[ZERO_VERSION_COLUMN_NAME] = ZERO_VERSION_COLUMN_SPEC;
-    return createTableStatement(table);
+    return createTableStatementIgnoringNotNullConstraint(table);
   });
 
   const schemaStmts = [...schemas].map(

--- a/packages/zero-cache/src/services/replicator/tables/create.ts
+++ b/packages/zero-cache/src/services/replicator/tables/create.ts
@@ -3,15 +3,23 @@ import type {ColumnSpec, TableSpec} from './specs.js';
 
 /**
  * Constructs a `CREATE TABLE` statement for a {@link TableSpec}.
+ *
+ * For replication purposes, the `notNull` (i.e. `NOT NULL`) constraint is ignored.
+ * Although logical replication notifies the subscriber of changes to the table
+ * _structure_, it does not notify the subscriber of changes to table constraints
+ * (other than primary keys). As such, it is unsafe to initialize a replicated table
+ * with a constraint that might be removed without our knowledge.
+ *
+ * Instead, it is sufficient to assume that the data in the logical replication stream
+ * satisfies the constraints of the upstream table.
  */
-export function createTableStatement(spec: TableSpec): string {
+export function createTableStatementIgnoringNotNullConstraint(
+  spec: TableSpec,
+): string {
   function colDef(name: string, colSpec: ColumnSpec): string {
     const parts = [`${id(name)} ${colSpec.dataType}`];
     if (colSpec.characterMaximumLength !== null) {
       parts.push(`(${colSpec.characterMaximumLength})`);
-    }
-    if (colSpec.notNull) {
-      parts.push(' NOT NULL');
     }
     if (colSpec.columnDefault) {
       parts.push(` DEFAULT ${colSpec.columnDefault}`);


### PR DESCRIPTION
Explained in the documentation:

```
 * For replication purposes, the `notNull` (i.e. `NOT NULL`) constraint is ignored.
 * Although logical replication notifies the subscriber of changes to the table
 * _structure_, it does not notify the subscriber of changes to table constraints
 * (other than primary keys). As such, it is unsafe to initialize a replicated table
 * with a constraint that might be removed without our knowledge.
 *
 * Instead, it is sufficient to assume that the data in the logical replication stream
 * satisfies the constraints of the upstream table.
 ```