### PR TITLE
chore(zeppliear): Remove .npmrc file

### DIFF
--- a/apps/zeppliear/.npmrc
+++ b/apps/zeppliear/.npmrc
@@ -1,1 +1,0 @@
-unsafe-perm = true


### PR DESCRIPTION
It was a remnant of the past and is no longer needed.