### PR TITLE
feat(zero-cache): normalization and query string construction for JOINs

### DIFF
--- a/packages/zero-cache/src/zql/invalidation.test.ts
+++ b/packages/zero-cache/src/zql/invalidation.test.ts
@@ -1,11 +1,4 @@
-import type {
-  AST,
-  Condition,
-  Conjunction,
-  Primitive,
-  SimpleCondition,
-  SimpleOperator,
-} from '@rocicorp/zql/src/zql/ast/ast.js';
+import type {AST, Condition, Primitive} from '@rocicorp/zql/src/zql/ast/ast.js';
 import {describe, expect, test} from 'vitest';
 import {
   NormalizedInvalidationFilterSpec,
@@ -13,6 +6,7 @@ import {
 } from '../types/invalidation.js';
 import {computeInvalidationInfo, computeMatchers} from './invalidation.js';
 import {getNormalized} from './normalize.js';
+import {and, cond, or} from './query-test-util.js';
 
 describe('zql/invalidation matchers', () => {
   type Case = {
@@ -651,37 +645,3 @@ describe('zql/invalidation hashes filters and hashes', () => {
     });
   }
 });
-
-// Readability helpers
-
-function and(...conditions: Condition[]): Conjunction {
-  return {
-    type: 'conjunction',
-    op: 'AND',
-    conditions,
-  };
-}
-
-function or(...conditions: Condition[]): Conjunction {
-  return {
-    type: 'conjunction',
-    op: 'OR',
-    conditions,
-  };
-}
-
-function cond(
-  field: string,
-  op: SimpleOperator,
-  value: Primitive,
-): SimpleCondition {
-  return {
-    type: 'simple',
-    field,
-    op,
-    value: {
-      type: 'literal',
-      value,
-    },
-  };
-}

--- a/packages/zero-cache/src/zql/query-test-util.ts
+++ b/packages/zero-cache/src/zql/query-test-util.ts
@@ -1,0 +1,40 @@
+import type {
+  Condition,
+  Conjunction,
+  Primitive,
+  SimpleCondition,
+  SimpleOperator,
+} from '@rocicorp/zql/src/zql/ast/ast.js';
+
+// Readability helpers
+export function and(...conditions: Condition[]): Conjunction {
+  return {
+    type: 'conjunction',
+    op: 'AND',
+    conditions,
+  };
+}
+
+export function or(...conditions: Condition[]): Conjunction {
+  return {
+    type: 'conjunction',
+    op: 'OR',
+    conditions,
+  };
+}
+
+export function cond(
+  field: string,
+  op: SimpleOperator,
+  value: Primitive,
+): SimpleCondition {
+  return {
+    type: 'simple',
+    field,
+    op,
+    value: {
+      type: 'literal',
+      value,
+    },
+  };
+}

--- a/packages/zql/src/zql/ast/ast.test.ts
+++ b/packages/zql/src/zql/ast/ast.test.ts
@@ -193,6 +193,80 @@ describe('zql/ast', () => {
       },
     },
     {
+      name: 'joins',
+      asts: [
+        {
+          table: 'issues',
+          select: [
+            ['id', 'id_alias'],
+            ['name', 'a_name'],
+          ],
+          joins: [
+            {
+              type: 'inner',
+              other: {
+                table: 'users',
+                select: [
+                  ['id', 'id_alias'],
+                  ['name', 'b_alias'],
+                ],
+                orderBy: [['id'], 'asc'],
+              },
+              as: 'owner',
+              on: ['issues.owner_id', 'users.id'],
+            },
+          ],
+          orderBy: [['id'], 'asc'],
+        },
+        {
+          table: 'issues',
+          select: [
+            ['name', 'a_name'],
+            ['id', 'id_alias'],
+          ],
+          joins: [
+            {
+              type: 'inner',
+              other: {
+                table: 'users',
+                select: [
+                  ['name', 'b_alias'],
+                  ['id', 'id_alias'],
+                ],
+                orderBy: [['id'], 'asc'],
+              },
+              as: 'owner',
+              on: ['issues.owner_id', 'users.id'],
+            },
+          ],
+          orderBy: [['id'], 'asc'],
+        },
+      ],
+      normalized: {
+        table: 'issues',
+        select: [
+          ['id', 'id_alias'],
+          ['name', 'a_name'],
+        ],
+        joins: [
+          {
+            type: 'inner',
+            other: {
+              table: 'users',
+              select: [
+                ['id', 'id_alias'],
+                ['name', 'b_alias'],
+              ],
+              orderBy: [['id'], 'asc'],
+            },
+            as: 'owner',
+            on: ['issues.owner_id', 'users.id'],
+          },
+        ],
+        orderBy: [['id'], 'asc'],
+      },
+    },
+    {
       name: 'simple condition',
       asts: [
         {

--- a/packages/zql/src/zql/ast/ast.ts
+++ b/packages/zql/src/zql/ast/ast.ts
@@ -116,6 +116,7 @@ export function normalizeAST(ast: AST): AST {
         )
       : undefined,
     where: where ? sorted(where) : undefined,
+    joins: ast.joins?.map(join => ({...join, other: normalizeAST(join.other)})),
     groupBy: ast.groupBy ? [...ast.groupBy].sort(compareUTF8) : undefined,
     // The order of ORDER BY expressions is semantically significant, so it
     // is left as is (i.e. not sorted).


### PR DESCRIPTION
Adds (super-simple) normalization for JOINs, and support for building query strings with them.

Also fixed query string logic:
* to properly handle / escape "table.col" selector strings in SELECT and ON clauses
* support table and column aliases

Both of these will be needed for upcoming query expansion logic. 