### PR TITLE
chore(zero-client): Allow importing replicache sources

### DIFF
--- a/apps/reflect.net/next.config.js
+++ b/apps/reflect.net/next.config.js
@@ -1,3 +1,6 @@
+import {readFileSync} from 'node:fs';
+import webpack from 'webpack';
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
@@ -7,6 +10,15 @@ const nextConfig = {
       '.js': ['.js', '.ts'],
       '.jsx': ['.jsx', '.tsx'],
     };
+
+    const s = readFileSync('../../packages/replicache/package.json', 'utf8');
+    const REPLICACHE_VERSION = JSON.parse(s).version;
+    config.plugins.push(
+      new webpack.DefinePlugin({
+        REPLICACHE_VERSION: JSON.stringify(REPLICACHE_VERSION),
+      }),
+    );
+
     return config;
   },
   transpilePackages: ['shared'],

--- a/apps/zeppliear/frontend/issue-modal.tsx
+++ b/apps/zeppliear/frontend/issue-modal.tsx
@@ -1,13 +1,10 @@
-import CloseIcon from './assets/icons/close.svg';
-import Modal from './modal';
-import React, {useState} from 'react';
-import {Issue, Priority, Status} from './issue';
 import {nanoid} from 'nanoid';
-
+import {useState} from 'react';
+import CloseIcon from './assets/icons/close.svg';
+import {Issue, Priority, Status} from './issue';
+import Modal from './modal';
 import PriorityMenu from './priority-menu';
 import StatusMenu from './status-menu';
-
-// import { showInfo, showWarning } from 'utils/notification';
 
 interface Props {
   isOpen: boolean;

--- a/apps/zeppliear/next.config.js
+++ b/apps/zeppliear/next.config.js
@@ -1,3 +1,6 @@
+import {readFileSync} from 'node:fs';
+import webpack from 'webpack';
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   eslint: {
@@ -23,6 +26,14 @@ const nextConfig = {
       '.js': ['.js', '.ts'],
       '.jsx': ['.jsx', '.tsx'],
     };
+
+    const s = readFileSync('../../packages/replicache/package.json', 'utf8');
+    const REPLICACHE_VERSION = JSON.parse(s).version;
+    config.plugins.push(
+      new webpack.DefinePlugin({
+        REPLICACHE_VERSION: JSON.stringify(REPLICACHE_VERSION),
+      }),
+    );
 
     return config;
   },

--- a/apps/zeppliear/pages/d/[id].tsx
+++ b/apps/zeppliear/pages/d/[id].tsx
@@ -1,8 +1,8 @@
-import type {Comment, Issue} from '@/frontend/issue.js';
 import {UndoManager} from '@rocicorp/undo';
 import {useEffect, useRef, useState} from 'react';
 import {Zero} from 'zero-client';
 import App, {Collections} from '../../frontend/app';
+import type {Comment, Issue} from '../../frontend/issue.js';
 import {M, mutators} from '../../frontend/mutators';
 
 export default function Home() {

--- a/apps/zeppliear/tsconfig.json
+++ b/apps/zeppliear/tsconfig.json
@@ -7,10 +7,6 @@
     "jsx": "preserve",
     "noEmit": true,
     "isolatedModules": true,
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["*"]
-    },
     "module": "esnext"
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],

--- a/mirror/reflect-cli/src/app-config.ts
+++ b/mirror/reflect-cli/src/app-config.ts
@@ -1,6 +1,7 @@
 import {doc, getDoc, getFirestore} from 'firebase/firestore';
 import {createApp} from 'mirror-protocol/src/app.js';
 import {ensureTeam} from 'mirror-protocol/src/team.js';
+import {isValidAppName} from 'mirror-schema/src/external/app.js';
 import {
   appNameIndexDataConverter,
   appNameIndexPath,
@@ -8,14 +9,12 @@ import {
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {pkgUpSync} from 'pkg-up';
-
 import * as v from 'shared/src/valita.js';
 import {ErrorWrapper, UserError} from './error.js';
 import type {AuthContext} from './handler.js';
 import {logErrorAndExit} from './log-error-and-exit.js';
-import {makeRequester} from './requester.js';
-import {isValidAppName} from 'mirror-schema/src/external/app.js';
 import {getLogger} from './logger.js';
+import {makeRequester} from './requester.js';
 // { srcFile: destFile }
 const templateFiles = v.record(v.string());
 

--- a/packages/datadog/src/mod.ts
+++ b/packages/datadog/src/mod.ts
@@ -1,1 +1,4 @@
-export {DatadogLogSink, DatadogLogSinkOptions} from './datadog-log-sink.js';
+export {
+  DatadogLogSink,
+  type DatadogLogSinkOptions,
+} from './datadog-log-sink.js';

--- a/packages/reflect-client/rollup.config.js
+++ b/packages/reflect-client/rollup.config.js
@@ -1,3 +1,6 @@
 import {makeInputOptions} from 'shared/src/tool/rollup-dts.js';
 
-export default makeInputOptions('out/.dts/mod.d.ts', 'out/reflect-client.d.ts');
+export default makeInputOptions(
+  'out/.dts/reflect-client/src/mod.d.ts',
+  'out/reflect-client.d.ts',
+);

--- a/packages/reflect-client/tsconfig.json
+++ b/packages/reflect-client/tsconfig.json
@@ -1,7 +1,18 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "lib": ["dom", "es2022"]
+    "lib": ["dom", "es2022"],
+    "paths": {
+      "replicache": ["../replicache/src/mod.ts"],
+      "replicache/src/*": ["../replicache/src/*"],
+      "shared/src/*": ["../shared/src/*"],
+      "reflect-shared": ["../reflect-shared/src/mod.ts"],
+      "reflect-shared/src/*": ["../reflect-shared/src/*"],
+      "datadog": ["../datadog/src/mod.ts"],
+      "datadog/src/*": ["../datadog/src/*"],
+      "reflect-protocol": ["../reflect-protocol/src/mod.ts"],
+      "reflect-protocol/src/*": ["../reflect-protocol/src/*"]
+    }
   },
   "include": ["src/**/*.ts"]
 }

--- a/packages/reflect-shared/rollup.config.js
+++ b/packages/reflect-shared/rollup.config.js
@@ -1,3 +1,6 @@
 import {makeInputOptions} from 'shared/src/tool/rollup-dts.js';
 
-export default makeInputOptions('out/.dts/mod.d.ts', 'out/reflect-shared.d.ts');
+export default makeInputOptions(
+  'out/.dts/reflect-shared/src/mod.d.ts',
+  'out/reflect-shared.d.ts',
+);

--- a/packages/reflect-shared/tsconfig.json
+++ b/packages/reflect-shared/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "replicache": ["../replicache/src/mod.ts"],
+      "replicache/src/*": ["../replicache/src/*"]
+    }
+  },
   "include": ["src/**/*.ts", "src/**/*.js"]
 }

--- a/packages/replicache/rollup.config.js
+++ b/packages/replicache/rollup.config.js
@@ -1,3 +1,6 @@
 import {makeInputOptions} from 'shared/src/tool/rollup-dts.js';
 
-export default makeInputOptions('out/.dts/mod.d.ts', 'out/replicache.d.ts');
+export default makeInputOptions(
+  'out/.dts/replicache/src/mod.d.ts',
+  'out/replicache.d.ts',
+);

--- a/packages/replicache/src/dag/lazy-store.ts
+++ b/packages/replicache/src/dag/lazy-store.ts
@@ -602,7 +602,7 @@ class ChunksCache {
     this.cacheEntries.delete(hash);
   }
 
-  #delete(hash: Hash): void {
+  #deleteEntryByHash(hash: Hash): void {
     this.#refCounts.delete(hash);
     this.#refs.delete(hash);
     const cacheEntry = this.cacheEntries.get(hash);
@@ -619,7 +619,7 @@ class ChunksCache {
     for (const [hash, count] of refCountUpdates) {
       if (count === 0) {
         if (!this.#evictsAndDeletesSuspended) {
-          this.#delete(hash);
+          this.#deleteEntryByHash(hash);
         } else {
           this.#refCounts.set(hash, 0);
           this.#suspendedDeletes.push(hash);
@@ -663,7 +663,7 @@ class ChunksCache {
       this.#evictsAndDeletesSuspended = false;
       for (const hash of this.#suspendedDeletes) {
         if (this.#refCounts.get(hash) === 0) {
-          this.#delete(hash);
+          this.#deleteEntryByHash(hash);
         }
       }
       this.#ensureCacheSizeLimit();

--- a/packages/replicache/tsconfig.json
+++ b/packages/replicache/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "lib": ["dom", "es2022"]
+    "lib": ["dom", "es2022"],
+    "paths": {
+      "shared/src/*": ["../shared/src/*"]
+    }
   },
   "include": ["src/**/*.ts"]
 }

--- a/packages/zero-client/rollup.config.js
+++ b/packages/zero-client/rollup.config.js
@@ -1,3 +1,6 @@
 import {makeInputOptions} from 'shared/src/tool/rollup-dts.js';
 
-export default makeInputOptions('out/.dts/mod.d.ts', 'out/zero-client.d.ts');
+export default makeInputOptions(
+  'out/.dts/zero-client/src/mod.d.ts',
+  'out/zero-client.d.ts',
+);

--- a/packages/zero-client/src/client/metrics.ts
+++ b/packages/zero-client/src/client/metrics.ts
@@ -79,7 +79,7 @@ export class MetricManager {
   #host: string;
   #reporter: MetricsReporter;
   #lc: LogContext;
-  #timerID: number | null;
+  #timerID: ReturnType<typeof setInterval> | null;
 
   constructor(opts: MetricManagerOptions) {
     this.#reportIntervalMs = opts.reportIntervalMs;

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -23,27 +23,27 @@ import {
 import {ROOM_ID_REGEX, isValidRoomID} from 'reflect-shared/src/room-id.js';
 import type {MutatorDefs, ReadTransaction} from 'reflect-shared/src/types.js';
 import {
-  ClientGroupID,
-  ClientID,
-  ExperimentalWatchCallbackForOptions,
-  ExperimentalWatchNoIndexCallback,
-  ExperimentalWatchOptions,
   MaybePromise,
-  PullRequestV0,
-  PullRequestV1,
+  Replicache,
+  UpdateNeededReason as ReplicacheUpdateNeededReason,
+} from 'replicache';
+import {dropDatabase} from 'replicache/src/persist/collect-idb-databases.js';
+import type {
   Puller,
   PullerResultV0,
   PullerResultV1,
-  PushRequestV0,
-  PushRequestV1,
-  Pusher,
-  PusherResult,
-  Replicache,
-  ReplicacheOptions,
-  UpdateNeededReason as ReplicacheUpdateNeededReason,
+} from 'replicache/src/puller.js';
+import type {Pusher, PusherResult} from 'replicache/src/pusher.js';
+import type {ReplicacheOptions} from 'replicache/src/replicache-options.js';
+import type {
+  WatchCallbackForOptions as ExperimentalWatchCallbackForOptions,
+  WatchNoIndexCallback as ExperimentalWatchNoIndexCallback,
+  WatchOptions as ExperimentalWatchOptions,
   SubscribeOptions,
-  dropDatabase,
-} from 'replicache';
+} from 'replicache/src/subscriptions.js';
+import type {ClientGroupID, ClientID} from 'replicache/src/sync/ids.js';
+import type {PullRequestV0, PullRequestV1} from 'replicache/src/sync/pull.js';
+import type {PushRequestV0, PushRequestV1} from 'replicache/src/sync/push.js';
 import {assert} from 'shared/src/asserts.js';
 import {getDocumentVisibilityWatcher} from 'shared/src/document-visible.js';
 import {getDocument} from 'shared/src/get-document.js';

--- a/packages/zero-client/tsconfig.json
+++ b/packages/zero-client/tsconfig.json
@@ -1,7 +1,18 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "lib": ["dom", "esnext"]
+    "lib": ["dom", "esnext"],
+    "paths": {
+      "@rocicorp/zql": ["../zql/src/mod.ts"],
+      "@rocicorp/zql/src/*": ["../zql/src/*"],
+      "reflect-protocol": ["../reflect-protocol/src/mod.ts"],
+      "reflect-shared/src/*": ["../reflect-shared/src/*"],
+      "replicache": ["../replicache/src/mod.ts"],
+      "replicache/src/*": ["../replicache/src/*"],
+      "shared/src/*": ["../shared/src/*"],
+      "zero-protocol": ["../zero-protocol/src/mod.ts"],
+      "zero-protocol/src/*": ["../zero-protocol/src/*"]
+    }
   },
   "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
Instead of using NodeJS resolution, we now use the paths property in tsconfig.json to allow importing replicache sources directly.

This is in preparation for the upcoming changes to the replicache to allow zero client to provide custom subscriptions for zql.