### PR TITLE
feat(zero-cache): make the JSONB row key part of the ChangeLog primary key

### DIFF
--- a/packages/zero-cache/src/db/queries.pg-test.ts
+++ b/packages/zero-cache/src/db/queries.pg-test.ts
@@ -1,11 +1,16 @@
-import type postgres from 'postgres';
+import pg from 'pg';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {testDBs} from '../test/db.js';
+import type {PostgresDB} from '../types/pg.js';
 import type {RowKey} from '../types/row-key.js';
 import {lookupRowsWithKeys} from './queries.js';
 
+const {
+  types: {builtins},
+} = pg;
+
 describe('db/queries', () => {
-  let db: postgres.Sql;
+  let db: PostgresDB;
 
   beforeEach(async () => {
     db = await testDBs.create('db_queries_test');
@@ -42,13 +47,50 @@ describe('db/queries', () => {
       db,
       'public',
       'foo',
-      {id: {typeOid: 23}, str: {typeOid: 25}},
+      {id: {typeOid: builtins.INT4}, str: {typeOid: builtins.TEXT}},
       rowKeys,
     );
     expect(results).toEqual([
       {id: 1, str: 'one', val: 'foo'},
       {id: 3, str: 'three', val: 'bonk'},
       {id: 5, str: 'five', val: 'boom'},
+    ]);
+  });
+
+  test('lookupRowsWithJsonKeys', async () => {
+    await db.unsafe(`
+    CREATE TABLE foo (
+      id int,
+      key jsonb,
+      val text,
+      PRIMARY KEY(id, key)
+    );
+    INSERT INTO foo (id, key, val) VALUES (1, '{"a":1}', 'foo');
+    INSERT INTO foo (id, key, val) VALUES (2, '{"a":{"b":2}}', 'bar');
+    INSERT INTO foo (id, key, val) VALUES (3, '{}', 'bonk');
+    INSERT INTO foo (id, key, val) VALUES (4, '{"c":3}', 'boo');
+    INSERT INTO foo (id, key, val) VALUES (5, '{"d":{"e":"f"}}', 'boom');
+    `);
+
+    const rowKeys: RowKey[] = [
+      {id: 1, key: {a: 1}},
+      {id: 3, key: {}},
+      {id: 3, key: {b: 2}}, // Should not match
+      {id: 4, key: {c: 4}}, // Should not match
+      {id: 5, key: {d: {e: 'f'}}},
+    ];
+
+    const results = await lookupRowsWithKeys(
+      db,
+      'public',
+      'foo',
+      {id: {typeOid: builtins.INT4}, key: {typeOid: builtins.JSONB}},
+      rowKeys,
+    );
+    expect(results).toEqual([
+      {id: 1, key: {a: 1}, val: 'foo'},
+      {id: 3, key: {}, val: 'bonk'},
+      {id: 5, key: {d: {e: 'f'}}, val: 'boom'},
     ]);
   });
 });

--- a/packages/zero-cache/src/db/queries.ts
+++ b/packages/zero-cache/src/db/queries.ts
@@ -1,6 +1,6 @@
 import {compareUTF8} from 'compare-utf8';
 import type postgres from 'postgres';
-import {typeNameByOID} from '../types/pg.js';
+import {PostgresDB, typeNameByOID} from '../types/pg.js';
 import type {RowKey, RowKeyType} from '../types/row-key.js';
 
 /**
@@ -20,7 +20,7 @@ import type {RowKey, RowKeyType} from '../types/row-key.js';
  * "WHERE IN (array or keys)" query when there is a large number of keys.
  */
 export function lookupRowsWithKeys(
-  db: postgres.Sql,
+  db: PostgresDB,
   schema: string,
   table: string,
   rowKeyType: RowKeyType,

--- a/packages/zero-cache/src/db/transaction-pool.pg-test.ts
+++ b/packages/zero-cache/src/db/transaction-pool.pg-test.ts
@@ -5,6 +5,7 @@ import {sleep} from 'shared/src/sleep.js';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {expectTables, testDBs} from '../test/db.js';
 import {createSilentLogContext} from '../test/logger.js';
+import type {PostgresDB} from '../types/pg.js';
 import {
   TransactionPool,
   sharedReadOnlySnapshot,
@@ -12,7 +13,7 @@ import {
 } from './transaction-pool.js';
 
 describe('db/transaction-pool', () => {
-  let db: postgres.Sql<{bigint: bigint}>;
+  let db: PostgresDB;
   const lc = createSilentLogContext();
 
   beforeEach(async () => {

--- a/packages/zero-cache/src/services/invalidation-watcher/invalidation-watcher.pg-test.ts
+++ b/packages/zero-cache/src/services/invalidation-watcher/invalidation-watcher.pg-test.ts
@@ -1,10 +1,10 @@
-import type postgres from 'postgres';
 import {Queue} from 'shared/src/queue.js';
 import {sleep} from 'shared/src/sleep.js';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {initDB, testDBs} from '../../test/db.js';
 import {createSilentLogContext} from '../../test/logger.js';
 import {normalizeFilterSpec} from '../../types/invalidation.js';
+import type {PostgresDB} from '../../types/pg.js';
 import {Subscription} from '../../types/subscription.js';
 import type {
   RegisterInvalidationFiltersResponse,
@@ -20,7 +20,7 @@ import {
 } from './invalidation-watcher.js';
 
 describe('invalidation-watcher', () => {
-  let db: postgres.Sql;
+  let db: PostgresDB;
 
   beforeEach(async () => {
     db = await testDBs.create('invalidation_watcher_test');

--- a/packages/zero-cache/src/services/invalidation-watcher/invalidation-watcher.ts
+++ b/packages/zero-cache/src/services/invalidation-watcher/invalidation-watcher.ts
@@ -1,6 +1,5 @@
 import type {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
-import type postgres from 'postgres';
 import {assert} from 'shared/src/asserts.js';
 import {union} from 'shared/src/set-utils.js';
 import * as v from 'shared/src/valita.js';
@@ -10,6 +9,7 @@ import {
 } from '../../db/transaction-pool.js';
 import {normalizedFilterSpecSchema} from '../../types/invalidation.js';
 import {max, min, type LexiVersion} from '../../types/lexi-version.js';
+import type {PostgresDB} from '../../types/pg.js';
 import type {CancelableAsyncIterable} from '../../types/streams.js';
 import {Subscription} from '../../types/subscription.js';
 import {queryStateVersion} from '../replicator/queries.js';
@@ -152,7 +152,7 @@ export class InvalidationWatcherService
   readonly id: string;
   readonly #lc: LogContext;
   readonly #registry: ReplicatorRegistry;
-  readonly #replica: postgres.Sql;
+  readonly #replica: PostgresDB;
 
   readonly #readers = new Map<TransactionPool, number>();
   readonly #hashSubscriptions = new HashSubscriptions();
@@ -171,7 +171,7 @@ export class InvalidationWatcherService
     serviceID: string,
     lc: LogContext,
     registry: ReplicatorRegistry,
-    replica: postgres.Sql,
+    replica: PostgresDB,
   ) {
     this.id = serviceID;
     this.#lc = lc

--- a/packages/zero-cache/src/services/replicator/incremental-sync.message-processor.pg-test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.message-processor.pg-test.ts
@@ -1,18 +1,18 @@
 import {Lock} from '@rocicorp/lock';
 import type {LogContext} from '@rocicorp/logger';
 import type {Pgoutput} from 'pg-logical-replication';
-import type postgres from 'postgres';
 import {Queue} from 'shared/src/queue.js';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {expectTables, testDBs} from '../../test/db.js';
 import {createSilentLogContext} from '../../test/logger.js';
+import type {PostgresDB} from '../../types/pg.js';
 import {MessageProcessor} from './incremental-sync.js';
 import {InvalidationFilters} from './invalidation.js';
 import type {VersionChange} from './replicator.js';
 import {setupReplicationTables} from './tables/replication.js';
 
 describe('replicator/message-processor', () => {
-  let replica: postgres.Sql;
+  let replica: PostgresDB;
 
   beforeEach(async () => {
     replica = await testDBs.create('message_processor_test_replica');

--- a/packages/zero-cache/src/services/replicator/incremental-sync.pg-test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.pg-test.ts
@@ -1,5 +1,4 @@
 import {Lock} from '@rocicorp/lock';
-import type postgres from 'postgres';
 import {sleep} from 'shared/src/sleep.js';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {
@@ -15,6 +14,7 @@ import {
   type InvalidationFilterSpec,
 } from '../../types/invalidation.js';
 import {versionFromLexi, type LexiVersion} from '../../types/lexi-version.js';
+import type {PostgresDB} from '../../types/pg.js';
 import {IncrementalSyncer} from './incremental-sync.js';
 import {replicationSlot, setupUpstream} from './initial-sync.js';
 import {InvalidationFilters, Invalidator} from './invalidation.js';
@@ -26,8 +26,8 @@ import type {TableSpec} from './tables/specs.js';
 const REPLICA_ID = 'incremental_sync_test_id';
 
 describe('replicator/incremental-sync', () => {
-  let upstream: postgres.Sql;
-  let replica: postgres.Sql;
+  let upstream: PostgresDB;
+  let replica: PostgresDB;
   let syncer: IncrementalSyncer;
   let invalidator: Invalidator;
 
@@ -410,7 +410,6 @@ describe('replicator/incremental-sync', () => {
             schema: 'public',
             table: 'issues',
             op: 's',
-            rowKeyHash: 'mB47UNOLHRciNkgYYlEm1A',
             rowKey: {issueID: 123},
             row: {
               issueID: 123,
@@ -428,7 +427,7 @@ describe('replicator/incremental-sync', () => {
             schema: 'public',
             table: 'issues',
             op: 's',
-            rowKeyHash: 'Lap0XW7zwx6r-rGbUDWBrw',
+
             rowKey: {issueID: 456},
             row: {
               issueID: 456,
@@ -446,7 +445,6 @@ describe('replicator/incremental-sync', () => {
             schema: 'public',
             table: 'issues',
             op: 's',
-            rowKeyHash: 'yyqwdGt-8VzhDgeVMot1pw',
             rowKey: {issueID: 789},
             row: {
               issueID: 789,
@@ -464,7 +462,6 @@ describe('replicator/incremental-sync', () => {
             schema: 'public',
             table: 'issues',
             op: 's',
-            rowKeyHash: 'iXRVI9CkqApw0uyS73RXSQ',
             rowKey: {issueID: 987},
             row: {
               issueID: 987,
@@ -482,7 +479,6 @@ describe('replicator/incremental-sync', () => {
             schema: 'public',
             table: 'issues',
             op: 's',
-            rowKeyHash: 'ItM1pBE76QO2FqTP1IS3rA',
             rowKey: {issueID: 234},
             row: {
               issueID: 234,
@@ -653,7 +649,6 @@ describe('replicator/incremental-sync', () => {
             schema: 'public',
             table: 'issues',
             op: 's',
-            rowKeyHash: 'd4LTXQRobCPxSnobs_FcLg',
             rowKey: {orgID: 1, issueID: 123},
             row: {
               orgID: 1,
@@ -667,7 +662,6 @@ describe('replicator/incremental-sync', () => {
             schema: 'public',
             table: 'issues',
             op: 's',
-            rowKeyHash: 'HFQhV6itMdKyZv81WpOGAg',
             rowKey: {orgID: 1, issueID: 456},
             row: {
               orgID: 1,
@@ -681,7 +675,6 @@ describe('replicator/incremental-sync', () => {
             schema: 'public',
             table: 'issues',
             op: 's',
-            rowKeyHash: 'kHZmjyGbDssRKHHEbU2z2g',
             rowKey: {orgID: 2, issueID: 789},
             row: {
               orgID: 2,
@@ -695,7 +688,6 @@ describe('replicator/incremental-sync', () => {
             schema: 'public',
             table: 'issues',
             op: 's',
-            rowKeyHash: 'HFQhV6itMdKyZv81WpOGAg',
             rowKey: {orgID: 1, issueID: 456},
             row: {
               orgID: 1,
@@ -709,7 +701,6 @@ describe('replicator/incremental-sync', () => {
             schema: 'public',
             table: 'issues',
             op: 'd',
-            rowKeyHash: 'd4LTXQRobCPxSnobs_FcLg',
             rowKey: {orgID: 1, issueID: 123},
             row: null,
           },
@@ -718,7 +709,6 @@ describe('replicator/incremental-sync', () => {
             schema: 'public',
             table: 'issues',
             op: 's',
-            rowKeyHash: '2qJu-IDPIs7PqBsrtmwZRg',
             rowKey: {orgID: 2, issueID: 123},
             row: {
               orgID: 2,
@@ -816,7 +806,6 @@ describe('replicator/incremental-sync', () => {
             schema: 'public',
             table: 'issues',
             op: 's',
-            rowKeyHash: 'd4LTXQRobCPxSnobs_FcLg',
             rowKey: {orgID: 1, issueID: 123},
             row: {
               orgID: 1,
@@ -830,7 +819,6 @@ describe('replicator/incremental-sync', () => {
             schema: 'public',
             table: 'issues',
             op: 's',
-            rowKeyHash: 'HFQhV6itMdKyZv81WpOGAg',
             rowKey: {orgID: 1, issueID: 456},
             row: {
               orgID: 1,
@@ -844,7 +832,6 @@ describe('replicator/incremental-sync', () => {
             schema: 'public',
             table: 'issues',
             op: 's',
-            rowKeyHash: 'kHZmjyGbDssRKHHEbU2z2g',
             rowKey: {orgID: 2, issueID: 789},
             row: {
               orgID: 2,
@@ -858,7 +845,6 @@ describe('replicator/incremental-sync', () => {
             schema: 'public',
             table: 'issues',
             op: 's',
-            rowKeyHash: '3TEkNvn8CfoW4xZsp43_Cg',
             rowKey: {orgID: 2, issueID: 987},
             row: {
               orgID: 2,
@@ -872,7 +858,6 @@ describe('replicator/incremental-sync', () => {
             schema: 'public',
             table: 'issues',
             op: 'd',
-            rowKeyHash: 'd4LTXQRobCPxSnobs_FcLg',
             rowKey: {orgID: 1, issueID: 123},
             row: null,
           },
@@ -881,7 +866,6 @@ describe('replicator/incremental-sync', () => {
             schema: 'public',
             table: 'issues',
             op: 'd',
-            rowKeyHash: 'HFQhV6itMdKyZv81WpOGAg',
             rowKey: {orgID: 1, issueID: 456},
             row: null,
           },
@@ -890,7 +874,6 @@ describe('replicator/incremental-sync', () => {
             schema: 'public',
             table: 'issues',
             op: 'd',
-            rowKeyHash: '3TEkNvn8CfoW4xZsp43_Cg',
             rowKey: {orgID: 2, issueID: 987},
             row: null,
           },
@@ -1078,7 +1061,6 @@ describe('replicator/incremental-sync', () => {
             schema: 'public',
             table: 'bar',
             op: 's',
-            rowKeyHash: 'fa47EdYvwqHKjgDA9ZGxmg',
             rowKey: {id: 4},
             row: {id: 4, ['_0_version']: '01'},
           },
@@ -1087,7 +1069,6 @@ describe('replicator/incremental-sync', () => {
             schema: 'public',
             table: 'bar',
             op: 's',
-            rowKeyHash: 'dTBYbmDGWw6O3zYGoshFkA',
             rowKey: {id: 5},
             row: {id: 5, ['_0_version']: '01'},
           },
@@ -1096,7 +1077,6 @@ describe('replicator/incremental-sync', () => {
             schema: 'public',
             table: 'bar',
             op: 's',
-            rowKeyHash: 'LQ0Dp-So9WR8sPPTypl-',
             rowKey: {id: 6},
             row: {id: 6, ['_0_version']: '01'},
           },
@@ -1105,8 +1085,7 @@ describe('replicator/incremental-sync', () => {
             schema: 'public',
             table: 'foo',
             op: 't',
-            rowKeyHash: '',
-            rowKey: null,
+            rowKey: {},
             row: null,
           },
           {
@@ -1114,8 +1093,7 @@ describe('replicator/incremental-sync', () => {
             schema: 'public',
             table: 'baz',
             op: 't',
-            rowKeyHash: '',
-            rowKey: null,
+            rowKey: {},
             row: null,
           },
           {
@@ -1123,8 +1101,7 @@ describe('replicator/incremental-sync', () => {
             schema: 'public',
             table: 'foo',
             op: 't',
-            rowKeyHash: '',
-            rowKey: null,
+            rowKey: {},
             row: null,
           },
           {
@@ -1132,7 +1109,6 @@ describe('replicator/incremental-sync', () => {
             schema: 'public',
             table: 'foo',
             op: 's',
-            rowKeyHash: 'TNPmtn5B494le1zcxmsLRQ',
             rowKey: {id: 101},
             row: {id: 101, ['_0_version']: '02'},
           },
@@ -1314,7 +1290,6 @@ describe('replicator/incremental-sync', () => {
             schema: 'public',
             table: 'issues',
             op: 's',
-            rowKeyHash: 'HFQhV6itMdKyZv81WpOGAg',
             rowKey: {orgID: 1, issueID: 456},
             row: {
               orgID: 1,

--- a/packages/zero-cache/src/services/replicator/invalidation.pg-test.ts
+++ b/packages/zero-cache/src/services/replicator/invalidation.pg-test.ts
@@ -1,5 +1,4 @@
 import {Lock} from '@rocicorp/lock';
-import type postgres from 'postgres';
 import {randInt} from 'shared/src/rand.js';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {
@@ -13,6 +12,7 @@ import {
   invalidationHash,
   normalizeFilterSpec,
 } from '../../types/invalidation.js';
+import type {PostgresDB} from '../../types/pg.js';
 import {
   InvalidationFilters,
   InvalidationProcessor,
@@ -24,7 +24,7 @@ import {CREATE_REPLICATION_TABLES} from './tables/replication.js';
 import {TableTracker, type RowChange} from './types/table-tracker.js';
 
 describe('replicator/invalidation', () => {
-  let db: postgres.Sql;
+  let db: PostgresDB;
   let invalidator: Invalidator;
 
   const FOO_SPEC1 = normalizeFilterSpec({

--- a/packages/zero-cache/src/services/replicator/replicator.ts
+++ b/packages/zero-cache/src/services/replicator/replicator.ts
@@ -3,7 +3,7 @@ import type {LogContext} from '@rocicorp/logger';
 import postgres from 'postgres';
 import * as v from 'shared/src/valita.js';
 import {normalizedFilterSpecSchema} from '../../types/invalidation.js';
-import {postgresTypeConfig} from '../../types/pg.js';
+import {PostgresDB, postgresTypeConfig} from '../../types/pg.js';
 import type {CancelableAsyncIterable} from '../../types/streams.js';
 import type {Service} from '../service.js';
 import {IncrementalSyncer} from './incremental-sync.js';
@@ -101,7 +101,7 @@ export class ReplicatorService implements Replicator, Service {
   readonly id: string;
   readonly #lc: LogContext;
   readonly #upstreamUri: string;
-  readonly #syncReplica: postgres.Sql;
+  readonly #syncReplica: PostgresDB;
   readonly #incrementalSyncer: IncrementalSyncer;
   readonly #invalidator: Invalidator;
 

--- a/packages/zero-cache/src/services/replicator/tables/replication.ts
+++ b/packages/zero-cache/src/services/replicator/tables/replication.ts
@@ -28,8 +28,7 @@ export const CREATE_REPLICATION_TABLES =
   // The change log contains row changes.
   //
   // * `op`        : 't' for table truncation, 's' for set (insert/update), and 'd' for delete
-  // * `rowKeyHash`: Hash of the row key for row identification (see {@link rowKeyHash}). Empty string for truncate op.
-  // * `rowKey`    : JSON row key, as `{[$columnName]: $columnValue}`, or NULL for TRUNCATE
+  // * `rowKey`    : JSONB row key, as `{[$columnName]: $columnValue}`, or '{}' for TRUNCATE
   // * `row`       : JSON formatted full row contents, NULL for DELETE / TRUNCATE
   //
   // Note that the `row` data is stored as JSON rather than JSONB to prioritize write
@@ -41,10 +40,9 @@ export const CREATE_REPLICATION_TABLES =
     "schema"       VARCHAR(128) NOT NULL,
     "table"        VARCHAR(128) NOT NULL,
     "op"           CHAR         NOT NULL,
-    "rowKeyHash"   VARCHAR(22)  NOT NULL,
-    "rowKey"       JSON,
+    "rowKey"       JSONB        NOT NULL,
     "row"          JSON,
-    CONSTRAINT PK_change_log PRIMARY KEY("stateVersion", "schema", "table", "rowKeyHash")
+    CONSTRAINT PK_change_log PRIMARY KEY("stateVersion", "schema", "table", "rowKey")
   );
 `; /**
  * Migration step that sets up the initialized Sync Replica for incremental replication.

--- a/packages/zero-cache/src/test/db.ts
+++ b/packages/zero-cache/src/test/db.ts
@@ -2,7 +2,7 @@ import postgres from 'postgres';
 import {assert} from 'shared/src/asserts.js';
 import {sleep} from 'shared/src/sleep.js';
 import {afterAll, expect} from 'vitest';
-import {postgresTypeConfig} from '../types/pg.js';
+import {PostgresDB, postgresTypeConfig} from '../types/pg.js';
 
 class TestDBs {
   // Connects to the main "postgres" DB of the local Postgres cluster.
@@ -19,7 +19,7 @@ class TestDBs {
   });
   readonly #dbs: Record<string, postgres.Sql> = {};
 
-  async create(database: string) {
+  async create(database: string): Promise<PostgresDB> {
     assert(!(database in this.#dbs), `${database} has already been created`);
 
     await this.#sql`

--- a/packages/zero-cache/src/types/bigint-json.ts
+++ b/packages/zero-cache/src/types/bigint-json.ts
@@ -16,6 +16,17 @@ function numberParser(_: unknown, v: string) {
   return BigInt(v);
 }
 
+// Variant of postgres.JSONValue adapted to include bigints
+export type JSONValue =
+  | null
+  | string
+  | number
+  | bigint
+  | boolean
+  | Date // serialized as `string`
+  | readonly JSONValue[]
+  | {readonly [prop: string | number]: undefined | JSONValue};
+
 /**
  * Parses JSON strings that may contain arbitrarily large integers. Integers
  * larger than {@link Number.MAX_SAFE_INTEGER} are deserialized as a `bigint`.
@@ -23,7 +34,7 @@ function numberParser(_: unknown, v: string) {
 export function parse(
   str: string,
   reviver?: (k: string, v: unknown) => unknown,
-): unknown {
+): JSONValue {
   return customParse(str, reviver, numberParser);
 }
 

--- a/packages/zero-cache/src/types/pg.ts
+++ b/packages/zero-cache/src/types/pg.ts
@@ -2,7 +2,7 @@ import {OID} from '@postgresql-typed/oids';
 import pg from 'pg';
 import postgres from 'postgres';
 import array from 'postgres-array';
-import {BigIntJSON} from './bigint-json.js';
+import {BigIntJSON, type JSONValue} from './bigint-json.js';
 
 const {
   types: {builtins, setTypeParser},
@@ -33,6 +33,16 @@ export const postgresTypeConfig = () => ({
     },
   },
 });
+
+export type PostgresDB = postgres.Sql<{
+  bigint: bigint;
+  json: JSONValue;
+}>;
+
+export type PostgresTransaction = postgres.TransactionSql<{
+  bigint: bigint;
+  json: JSONValue;
+}>;
 
 export const typeNameByOID: Record<number, string> = Object.fromEntries(
   Object.entries(OID).map(([name, oid]) => [

--- a/packages/zero-cache/src/types/row-key.ts
+++ b/packages/zero-cache/src/types/row-key.ts
@@ -1,11 +1,11 @@
 import {compareUTF8} from 'compare-utf8';
 import type postgres from 'postgres';
 import xxh from 'xxhashjs'; // TODO: Use xxhash-wasm
-import {stringify} from './bigint-json.js';
+import {stringify, type JSONValue} from './bigint-json.js';
 
 export type ColumnType = {typeOid: number};
 export type RowKeyType = Record<string, ColumnType>;
-export type RowKey = Record<string, postgres.SerializableParameter>;
+export type RowKey = Record<string, postgres.SerializableParameter<JSONValue>>;
 
 // Aliased for documentation purposes when dealing with full rows vs row keys.
 // The actual structure of the objects is the same.


### PR DESCRIPTION
Replace the `rowKeyHash` in the `ChangeLog` with the JSONB-typed `rowKey` itself.

The View Syncer CVR cannot always rely on the `rowKeyHash` for looking up row contents, because not all rows in the CVR will be from the ChangeLog. Thus, the CVR will have to store row keys (JSON objects) itself, so there is no need for the `rowKeyHash` indirection in the `ChangeLog`. 

The row key hash will still be used for the Durable Object keys in the CVR, which are limited to 2kb. But that will be an internal implementation detail of the CVR and not part of the replicated database schema. 

Review notes:
* The main change is in [replication.ts](https://github.com/rocicorp/mono/pull/1623/files#diff-5100aa784640d2d105b95b7d65bce006725e2b9dc3ce4c244dbdd78fbf1116d9) and [incremental-sync.ts](https://github.com/rocicorp/mono/pull/1623/files#diff-7bd6aae40b9d5e36f65800edfc83e44a97e444e7693e1e8f325927b4389b4c4aR479)
* The [queries.pg-test.ts](https://github.com/rocicorp/mono/pull/1623/files#diff-8357542ac2ba5af9e1ef93128df36db9a5396f9b41149d2a6f6e31baf87126a4R60) verifies that json objects can be supplied as parameters to the postgres client library
* The rest amounts to type changes to satisfy the postgres client library.