### PR TITLE
feat(view-syncer): updates to View Syncer schema

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/schema/paths.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/paths.test.ts
@@ -1,27 +1,32 @@
 import {describe, expect, test} from 'vitest';
-import {rowKeyHash} from '../../../types/row-key.js';
-import {CVRPaths, LastActiveIndex} from './paths.js';
+import {CVRPaths, lastActiveIndex} from './paths.js';
 
 describe('view-syncer/schema/paths', () => {
   test('patch path versioning', () => {
     const paths1 = new CVRPaths('123');
     expect(paths1.queryPatch({stateVersion: '1zb'}, {id: 'foo-query'})).toBe(
-      '/vs/cvr/123/patches/1zb/queries/foo-query',
+      '/vs/cvr/123/patches/meta/1zb/queries/foo-query',
     );
+    expect(
+      paths1.queryPatch(
+        {stateVersion: '1zb', minorVersion: 0},
+        {id: 'foo-query'},
+      ),
+    ).toBe('/vs/cvr/123/patches/meta/1zb/queries/foo-query');
 
     const paths2 = new CVRPaths('456');
     expect(
       paths2.queryPatch(
-        {stateVersion: '2abc', metaVersion: 35},
+        {stateVersion: '2abc', minorVersion: 35},
         {id: 'boo-query'},
       ),
-    ).toBe('/vs/cvr/456/patches/2abc-0z/queries/boo-query');
+    ).toBe('/vs/cvr/456/patches/meta/2abc-0z/queries/boo-query');
     expect(
       paths2.queryPatch(
-        {stateVersion: '2abc', metaVersion: 36},
+        {stateVersion: '2abc', minorVersion: 36},
         {id: 'boo-query'},
       ),
-    ).toBe('/vs/cvr/456/patches/2abc-110/queries/boo-query');
+    ).toBe('/vs/cvr/456/patches/meta/2abc-110/queries/boo-query');
   });
 
   test('client paths', () => {
@@ -29,7 +34,7 @@ describe('view-syncer/schema/paths', () => {
 
     expect(paths.client({id: 'foo'})).toBe('/vs/cvr/abc/meta/clients/foo');
     expect(paths.clientPatch({stateVersion: '2321'}, {id: 'foo'})).toBe(
-      '/vs/cvr/abc/patches/2321/clients/foo',
+      '/vs/cvr/abc/patches/meta/2321/clients/foo',
     );
   });
 
@@ -39,38 +44,51 @@ describe('view-syncer/schema/paths', () => {
       paths.row({
         schema: 'public',
         table: 'issues',
-        rowKeyHash: rowKeyHash({id: 123}),
+        rowKey: {id: 123},
       }),
     ).toBe('/vs/cvr/fbr/rows/public/issues/qse5G7quj_el4_x5CbWzQg');
     expect(
       paths.row({
         schema: 'public',
         table: 'issues',
-        rowKeyHash: rowKeyHash({id: 124}),
+        rowKey: {id: 124},
       }),
     ).toBe('/vs/cvr/fbr/rows/public/issues/u1Ny9isI-KQXSET6KchNbw');
     expect(
       paths.row({
-        schema: 'schema/with/slashes',
-        table: 'table"with"double"quotes',
-        rowKeyHash: rowKeyHash({id: 120}),
+        schema: 'public',
+        table: 'issues',
+        rowKey: {
+          this: `could be a really a big row k${'e'.repeat(1000)}y`,
+        },
       }),
+    ).toBe('/vs/cvr/fbr/rows/public/issues/4XQuBMS98x-1M2Gg-VMrlA');
+
+    expect(
+      paths.rowPatch(
+        {stateVersion: '28c8', minorVersion: 100},
+        {
+          schema: 'public',
+          table: 'issues',
+          rowKey: {
+            this: `could be a really a big row k${'e'.repeat(1000)}y`,
+          },
+        },
+      ),
     ).toBe(
-      '/vs/cvr/fbr/rows/"schema/with/slashes"/"table\\"with\\"double\\"quotes"/SzkDbDPMPjYy-AcfV3DrQA',
+      '/vs/cvr/fbr/patches/data/28c8-12s/rows/public/issues/4XQuBMS98x-1M2Gg-VMrlA',
     );
   });
 
   test('last active paths', () => {
-    const paths = new LastActiveIndex();
-
-    expect(paths.dayPrefix(new Date(Date.UTC(2024, 3, 19, 1, 2, 3)))).toBe(
+    expect(lastActiveIndex.dayPrefix(Date.UTC(2024, 3, 19, 1, 2, 3))).toBe(
       '/vs/lastActive/2024-04-19',
     );
-    expect(paths.dayPrefix(new Date(Date.UTC(2024, 3, 19, 3, 2, 1)))).toBe(
+    expect(lastActiveIndex.dayPrefix(Date.UTC(2024, 3, 19, 3, 2, 1))).toBe(
       '/vs/lastActive/2024-04-19',
     );
     expect(
-      paths.entry('foo-cvr', new Date(Date.UTC(2024, 2, 28, 3, 48, 29))),
+      lastActiveIndex.entry('foo-cvr', Date.UTC(2024, 2, 28, 3, 48, 29)),
     ).toBe('/vs/lastActive/2024-03-28/foo-cvr');
   });
 });

--- a/packages/zero-cache/src/services/view-syncer/schema/types.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/types.test.ts
@@ -1,0 +1,49 @@
+import {describe, expect, test} from 'vitest';
+import {cmpVersions} from './types.js';
+
+describe('view-syncer/schema/types', () => {
+  test('version comparison', () => {
+    expect(
+      cmpVersions(
+        {stateVersion: '02', minorVersion: 1},
+        {stateVersion: '01', minorVersion: 2},
+      ),
+    ).toBeGreaterThan(0);
+
+    expect(
+      cmpVersions(
+        {stateVersion: '01', minorVersion: 2},
+        {stateVersion: '02', minorVersion: 1},
+      ),
+    ).toBeLessThan(0);
+
+    expect(
+      cmpVersions(
+        {stateVersion: '02', minorVersion: 1},
+        {stateVersion: '02', minorVersion: 2},
+      ),
+    ).toBeLessThan(0);
+
+    expect(
+      cmpVersions(
+        {stateVersion: '02', minorVersion: 2},
+        {stateVersion: '02', minorVersion: 1},
+      ),
+    ).toBeGreaterThan(0);
+
+    expect(
+      cmpVersions({stateVersion: '02'}, {stateVersion: '02', minorVersion: 1}),
+    ).toBeLessThan(0);
+
+    expect(
+      cmpVersions({stateVersion: '02', minorVersion: 1}, {stateVersion: '02'}),
+    ).toBeGreaterThan(0);
+
+    expect(
+      cmpVersions(
+        {stateVersion: '02', minorVersion: 2},
+        {stateVersion: '02', minorVersion: 2},
+      ),
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
* Store the full row key in the `RowRecord`, as it is needed for rows that don't come from the `ChangeLog` (e.g. query results). The row key hash is still used for formatting the DO key to avoid imposing the lower 2KB limit on row keys. (Values can be up to 128KB in size)
* Separate the data and metadata patch indexes so that they can be scanned independently.