### PR TITLE
fix(zeppliear): do not `exec` then `subscribe`, just `subscribe`

### DIFF
--- a/apps/zeppliear/frontend/zql.tsx
+++ b/apps/zeppliear/frontend/zql.tsx
@@ -1,5 +1,5 @@
 import type {FromSet} from '@rocicorp/zql/src/zql/query/entity-query.js';
-import {useEffect, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import type {EntityQuery} from 'zero-client';
 
 export function useQuery<From extends FromSet, Return>(
@@ -7,18 +7,36 @@ export function useQuery<From extends FromSet, Return>(
   dependencies: readonly unknown[] = [],
 ): Return {
   const [snapshot, setSnapshot] = useState([] as Return);
+  const [lastDeps, setLastDeps] = useState<readonly unknown[] | undefined>();
+  const unsubscribeRef = useRef<() => void>();
+  const statementRef = useRef<ReturnType<(typeof q)['prepare']>>();
 
-  useEffect(() => {
+  if (
+    lastDeps === undefined ||
+    lastDeps.length !== dependencies.length ||
+    lastDeps.some((v, i) => v !== dependencies[i])
+  ) {
+    setLastDeps(dependencies);
     const statement = q.prepare();
-    void statement.exec().then(v => setSnapshot(v as Return));
-    const unsubscribe = statement.subscribe(v => setSnapshot(v as Return));
-    return () => {
-      unsubscribe();
-      statement.destroy();
-    };
+    if (unsubscribeRef.current && statementRef.current) {
+      unsubscribeRef.current();
+      statementRef.current.destroy();
+    }
+    statementRef.current = statement;
+    unsubscribeRef.current = statement.subscribe(v => {
+      setSnapshot(v as Return);
+    });
+  }
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, dependencies);
+  useEffect(
+    () => () => {
+      if (unsubscribeRef.current && statementRef.current) {
+        unsubscribeRef.current();
+        statementRef.current.destroy();
+      }
+    },
+    [],
+  );
 
   return snapshot;
 }


### PR DESCRIPTION
Repaints caused by effects don't run within the same frame as the render that called them so you can end up with weird artifacting.

I was fixing that by swapping `useEffect` to `useState` and it so happened to also remove the need for the extra `exec`:

```ts
void statement.exec().then(v => setSnapshot(v as Return));
const unsubscribe = statement.subscribe(v => setSnapshot(v as Return));
```

Everything updates, no exec needed:

https://github.com/rocicorp/mono/assets/1009003/e1c4ec6c-c4f7-424a-8449-e86975912f88


Here is an example of rendering being split across many frames with `useEffect`:


https://github.com/rocicorp/mono/assets/1009003/1766f4c3-736b-4e7f-b967-3b86b93abf94

Notice that in the first frame the issues are removed from the board. In the second frame the sizes of the scrollbars change (follow my mouse). What I'm doing in that video stepping through a screen recording of `useEffect` frame by frame.

And here is the same test with the changes in this PR. Everything changes synchronously across the board.

https://github.com/rocicorp/mono/assets/1009003/6662a025-e7f3-4f40-a645-131ae687e081

