### PR TITLE
chore: Make reflect-client use ReplicacheImpl

### DIFF
--- a/packages/replicache/perf/replicache.ts
+++ b/packages/replicache/perf/replicache.ts
@@ -1,19 +1,18 @@
 import {resolver} from '@rocicorp/resolver';
 import {assert} from 'shared/src/asserts.js';
 import {deepEqual} from 'shared/src/json.js';
+import {dropIDBStoreWithMemFallback} from '../src/kv/idb-store-with-mem-fallback.js';
 import {
   IndexDefinitions,
   JSONValue,
   MutatorDefs,
   PatchOperation,
   ReadTransaction,
-  Replicache,
   ReplicacheOptions,
   TEST_LICENSE_KEY,
   WriteTransaction,
-} from '../out/replicache.js';
-import {dropIDBStoreWithMemFallback} from '../src/kv/idb-store-with-mem-fallback.js';
-import type {ReplicacheInternalAPI} from '../src/replicache-options.js';
+} from '../src/mod.js';
+import {ReplicacheImpl as Replicache} from '../src/replicache-impl.js';
 import {uuid} from '../src/uuid.js';
 import {
   TestDataObject,
@@ -322,33 +321,16 @@ export function benchmarkRebase(opts: {
 }
 
 class ReplicachePerfTest<MD extends MutatorDefs> extends Replicache<MD> {
-  readonly #internalAPI: ReplicacheInternalAPI;
   constructor(options: Omit<ReplicacheOptions<MD>, 'licenseKey'>) {
-    let internalAPI!: ReplicacheInternalAPI;
     super({
       ...options,
       licenseKey: TEST_LICENSE_KEY,
-      exposeInternalAPI: (api: ReplicacheInternalAPI) => {
-        internalAPI = api;
-      },
+
       enableLicensing: false,
       enableMutationRecovery: false,
       enableScheduledRefresh: false,
       enableScheduledPersist: false,
-    } as ReplicacheOptions<MD>);
-    this.#internalAPI = internalAPI;
-  }
-
-  get onUpdateNeeded() {
-    return () => {};
-  }
-
-  persist(): Promise<void> {
-    return this.#internalAPI.persist();
-  }
-
-  refresh(): Promise<void> {
-    return this.#internalAPI.refresh();
+    });
   }
 }
 

--- a/packages/replicache/src/replicache-options.ts
+++ b/packages/replicache/src/replicache-options.ts
@@ -244,16 +244,4 @@ export type ReplicacheInternalOptions = {
    * Defaults to true.
    */
   enablePullAndPushInOpen?: boolean | undefined;
-
-  /**
-   * Allows exposing parts of the internal API to a subclass. This works when
-   * thing have been minified and with the npm package.
-   */
-  exposeInternalAPI?: (api: ReplicacheInternalAPI) => void;
 };
-
-export interface ReplicacheInternalAPI {
-  persist(): Promise<void>;
-  refresh(): Promise<void>;
-  lastMutationID(): number;
-}

--- a/packages/replicache/src/test-util.ts
+++ b/packages/replicache/src/test-util.ts
@@ -17,7 +17,6 @@ import {
 } from './persist/idb-databases-store-db-name.js';
 import type {PullResponseV1} from './puller.js';
 import type {
-  ReplicacheInternalAPI,
   ReplicacheInternalOptions,
   ReplicacheOptions,
 } from './replicache-options.js';
@@ -39,19 +38,11 @@ export class ReplicacheTest<
   // eslint-disable-next-line @typescript-eslint/ban-types
   MD extends MutatorDefs = {},
 > extends Replicache<MD> {
-  readonly #internalAPI!: ReplicacheInternalAPI;
   readonly #impl: ReplicacheImpl<MD>;
   recoverMutationsFake: sinon.SinonSpy<[r: Promise<boolean>], Promise<boolean>>;
 
   constructor(options: ReplicacheOptions<MD>) {
-    let internalAPI!: ReplicacheInternalAPI;
-    super({
-      ...options,
-      exposeInternalAPI: (api: ReplicacheInternalAPI) => {
-        internalAPI = api;
-      },
-    } as ReplicacheOptions<MD>);
-    this.#internalAPI = internalAPI;
+    super(options);
     this.#impl = getImpl(this);
     this.recoverMutationsFake = this.onRecoverMutations = sinon.fake(r => r);
   }
@@ -69,7 +60,7 @@ export class ReplicacheTest<
   }
 
   persist() {
-    return this.#internalAPI.persist();
+    return this.#impl.persist();
   }
 
   recoverMutations(): Promise<boolean> {


### PR DESCRIPTION
and remove `exposeInternalAPI` hacks