### PR TITLE
fix(mirror-server): Downgrade CF Analytics rate limiting to warning (for realz)

### DIFF
--- a/mirror/cloudflare-api/src/fetch.ts
+++ b/mirror/cloudflare-api/src/fetch.ts
@@ -129,7 +129,7 @@ export interface FetchResult<ResponseType = unknown> {
 }
 
 export enum Errors {
-  TooManyRequests = 429,
+  TooManyRequests = 971,
   CouldNotRouteToScript = 7003,
   CustomHostnameNotFound = 1436,
   DispatchNamespaceNotFound = 100119,


### PR DESCRIPTION
Take 2 of https://github.com/rocicorp/mono/pull/1465

The CF error code is 971, not 429 (the HTTP error code).

#1380 

<img width="1383" alt="Screenshot 2024-04-26 at 16 42 08" src="https://github.com/rocicorp/mono/assets/132324914/b9aa06f9-c8c6-45c4-a3b6-3ce5a2f630c2">
