### PR TITLE
chore(zero-cache): restructure types to avoid casting

### DIFF
--- a/packages/zero-cache/src/db/queries.ts
+++ b/packages/zero-cache/src/db/queries.ts
@@ -1,7 +1,5 @@
 import {compareUTF8} from 'compare-utf8';
 import type postgres from 'postgres';
-import {assertNotUndefined} from 'shared/src/asserts.js';
-import type {JSONValue} from '../types/bigint-json.js';
 import {PostgresDB, typeNameByOID} from '../types/pg.js';
 import type {RowKey, RowKeyType} from '../types/row-key.js';
 
@@ -36,16 +34,7 @@ export function lookupRowsWithKeys(
   // See https://github.com/porsager/postgres/issues/842
   const colType = (col: string) =>
     db.unsafe(typeNameByOID[rowKeyType[col].typeOid]);
-  // RowKey = JSONObject includes `undefined` for convenience of use in DO storage
-  // APIs, but `undefiend` is not accepted in the Postgres API. In practice, we
-  // never set any value to `undefined`. This check guarantees it.
-  const keys = rowKeys.map(rowKey => {
-    for (const v of Object.values(rowKey)) {
-      assertNotUndefined(v);
-    }
-    return rowKey as Record<string, postgres.SerializableParameter<JSONValue>>;
-  });
-  const values = keys
+  const values = rowKeys
     .map(row =>
       colNames
         .map(col => db`${row[col]}::${colType(col)}`)

--- a/packages/zero-cache/src/services/view-syncer/schema/types.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/types.ts
@@ -1,6 +1,6 @@
 import * as v from 'shared/src/valita.js';
 import {astSchema} from 'zero-protocol';
-import {jsonObjectSchema} from '../../../types/bigint-json.js';
+import {jsonValueSchema} from '../../../types/bigint-json.js';
 import {versionFromLexi} from '../../../types/lexi-version.js';
 import {versionString} from './paths.js';
 
@@ -172,7 +172,7 @@ export type QueryRecord = v.Infer<typeof queryRecordSchema>;
 export const rowIDSchema = v.object({
   schema: v.string(),
   table: v.string(),
-  rowKey: jsonObjectSchema,
+  rowKey: v.record(jsonValueSchema),
 });
 
 export const metaRecordSchema = v.union(

--- a/packages/zero-cache/src/types/bigint-json.ts
+++ b/packages/zero-cache/src/types/bigint-json.ts
@@ -30,20 +30,21 @@ export type JSONValue =
 
 export type JSONObject = {readonly [prop: string]: JSONValue | undefined};
 
-export const jsonObjectSchema: v.Type<JSONObject> = v.lazy(() => {
-  const jsonValueSchema: v.Type<JSONValue> = v.lazy(() =>
-    v.union(
-      v.null(),
-      v.string(),
-      v.number(),
-      v.bigint(),
-      v.boolean(),
-      v.readonly(v.array(jsonValueSchema)),
-      jsonObjectSchema,
-    ),
+export const jsonValueSchema: v.Type<JSONValue> = v.lazy(() => {
+  const jsonObjectSchema = v.readonly(v.record(jsonValueSchema));
+
+  return v.union(
+    v.null(),
+    v.string(),
+    v.number(),
+    v.bigint(),
+    v.boolean(),
+    v.readonly(v.array(jsonValueSchema)),
+    jsonObjectSchema,
   );
-  return v.readonly(v.record(jsonValueSchema));
 });
+
+export const jsonObjectSchema = v.readonly(v.record(jsonValueSchema));
 
 /**
  * Parses JSON strings that may contain arbitrarily large integers. Integers

--- a/packages/zero-cache/src/types/row-key.ts
+++ b/packages/zero-cache/src/types/row-key.ts
@@ -1,10 +1,11 @@
 import {compareUTF8} from 'compare-utf8';
+import type postgres from 'postgres';
 import xxh from 'xxhashjs'; // TODO: Use xxhash-wasm
-import {stringify, type JSONObject} from './bigint-json.js';
+import {stringify, type JSONValue} from './bigint-json.js';
 
 export type ColumnType = {typeOid: number};
 export type RowKeyType = Record<string, ColumnType>;
-export type RowKey = JSONObject;
+export type RowKey = Record<string, postgres.SerializableParameter<JSONValue>>;
 
 // Aliased for documentation purposes when dealing with full rows vs row keys.
 // The actual structure of the objects is the same.


### PR DESCRIPTION
Add an explicit `jsonValueSchema` and redefine the `rowKey` schema to be a record of (never undefined) JSONValues so that postgres APIs accept it as is.