### PR TITLE
feat(zero-cache): fully encompass a CVR row reference with single a row ID hash

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -1,7 +1,6 @@
 import type {AST} from '@rocicorp/zql/src/zql/ast/ast.js';
 import {compareUTF8} from 'compare-utf8';
 import {assert} from 'shared/src/asserts.js';
-import type {DeepReadonly} from 'shared/src/json.js';
 import {difference, equals, intersection, union} from 'shared/src/set-utils.js';
 import type {DurableStorage} from '../../storage/durable-storage.js';
 import type {Storage} from '../../storage/storage.js';
@@ -35,7 +34,13 @@ type CVR = {
 };
 
 /** Exported immutable CVR type. */
-export type CVRSnapshot = DeepReadonly<CVR>;
+export type CVRSnapshot = {
+  readonly id: string;
+  readonly version: CVRVersion;
+  readonly lastActive: LastActive;
+  readonly clients: Readonly<Record<string, ClientRecord>>;
+  readonly queries: Readonly<Record<string, QueryRecord>>;
+};
 
 /** Loads the CVR metadata from storage. */
 export async function loadCVR(
@@ -60,10 +65,10 @@ export async function loadCVR(
       cvr.version = value as CVRVersion;
     } else if (key.endsWith('/lastActive')) {
       cvr.lastActive = value as LastActive;
-    } else if (key.includes('/clients/')) {
+    } else if (key.includes('/c/')) {
       const client = value as ClientRecord;
       cvr.clients[client.id] = client;
-    } else if (key.includes('/queries/')) {
+    } else if (key.includes('/q/')) {
       const query = value as QueryRecord;
       cvr.queries[query.id] = query;
     }

--- a/packages/zero-cache/src/services/view-syncer/queries.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/queries.pg-test.ts
@@ -148,7 +148,7 @@ describe('view-syncer/queries', () => {
     expect(resultParser.parseResults(queryIDs, results)).toEqual(
       new Map([
         [
-          '/vs/cvr/foo-cvr/data/rows/public/issues/VTN6PoW_uOFH6A7zJitQWA',
+          '/vs/cvr/foo-cvr/d/r/wfZrxQPRsszHpdfLRWoPzA',
           {
             contents: {id: '3', owner_id: '102', parent_id: '1', title: 'foo'},
             record: {
@@ -164,7 +164,7 @@ describe('view-syncer/queries', () => {
           },
         ],
         [
-          '/vs/cvr/foo-cvr/data/rows/public/users/oQ3wdcfDaeMjpd_c_UT41A',
+          '/vs/cvr/foo-cvr/d/r/dygxK_hEWhfHvQ8eowTfCQ',
           {
             contents: {id: '102', name: 'Candice'},
             record: {
@@ -178,7 +178,7 @@ describe('view-syncer/queries', () => {
           },
         ],
         [
-          '/vs/cvr/foo-cvr/data/rows/public/issues/SWxRd_XHoK8Ng6sjmBYXTA',
+          '/vs/cvr/foo-cvr/d/r/oA1bf0ulYhik9qypZFPeLQ',
           {
             contents: {id: '1', owner_id: '100', title: 'parent issue foo'},
             record: {
@@ -193,7 +193,7 @@ describe('view-syncer/queries', () => {
           },
         ],
         [
-          '/vs/cvr/foo-cvr/data/rows/public/users/4ItLBN7a0LgsOIlQRdI3NA',
+          '/vs/cvr/foo-cvr/d/r/1G9hXQhMWdq9f737TmE6rg',
           {
             contents: {id: '100', name: 'Alice'},
             record: {
@@ -207,7 +207,7 @@ describe('view-syncer/queries', () => {
           },
         ],
         [
-          '/vs/cvr/foo-cvr/data/rows/public/issues/aq6aYz_LHtaIY45d6IWooA',
+          '/vs/cvr/foo-cvr/d/r/Qxp2tFD-UOgu7-78ZYiLHw',
           {
             contents: {id: '4', owner_id: '101', parent_id: '2', title: 'bar'},
             record: {
@@ -223,7 +223,7 @@ describe('view-syncer/queries', () => {
           },
         ],
         [
-          '/vs/cvr/foo-cvr/data/rows/public/users/bw7Vm-uyPdCUJfhnKYRzSw',
+          '/vs/cvr/foo-cvr/d/r/Z3BOpMPd4QMKJ8IeYx1QvQ',
           {
             contents: {id: '101', name: 'Bob'},
             record: {
@@ -237,7 +237,7 @@ describe('view-syncer/queries', () => {
           },
         ],
         [
-          '/vs/cvr/foo-cvr/data/rows/public/issues/GJhC675wREgz8IQVopmy9w',
+          '/vs/cvr/foo-cvr/d/r/VPg9hxKPhJtHB6oYkGqBpw',
           {
             contents: {id: '2', owner_id: '101', title: 'parent issue bar'},
             record: {

--- a/packages/zero-cache/src/services/view-syncer/schema/paths.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/paths.test.ts
@@ -5,14 +5,14 @@ describe('view-syncer/schema/paths', () => {
   test('patch path versioning', () => {
     const paths1 = new CVRPaths('123');
     expect(paths1.queryPatch({stateVersion: '1zb'}, {id: 'foo-query'})).toBe(
-      '/vs/cvr/123/patches/meta/1zb/queries/foo-query',
+      '/vs/cvr/123/p/m/1zb/q/foo-query',
     );
     expect(
       paths1.queryPatch(
         {stateVersion: '1zb', minorVersion: 0},
         {id: 'foo-query'},
       ),
-    ).toBe('/vs/cvr/123/patches/meta/1zb/queries/foo-query');
+    ).toBe('/vs/cvr/123/p/m/1zb/q/foo-query');
 
     const paths2 = new CVRPaths('456');
     expect(
@@ -20,21 +20,21 @@ describe('view-syncer/schema/paths', () => {
         {stateVersion: '2abc', minorVersion: 35},
         {id: 'boo-query'},
       ),
-    ).toBe('/vs/cvr/456/patches/meta/2abc.0z/queries/boo-query');
+    ).toBe('/vs/cvr/456/p/m/2abc.0z/q/boo-query');
     expect(
       paths2.queryPatch(
         {stateVersion: '2abc', minorVersion: 36},
         {id: 'boo-query'},
       ),
-    ).toBe('/vs/cvr/456/patches/meta/2abc.110/queries/boo-query');
+    ).toBe('/vs/cvr/456/p/m/2abc.110/q/boo-query');
   });
 
   test('client paths', () => {
     const paths = new CVRPaths('abc');
 
-    expect(paths.client({id: 'foo'})).toBe('/vs/cvr/abc/meta/clients/foo');
+    expect(paths.client({id: 'foo'})).toBe('/vs/cvr/abc/m/c/foo');
     expect(paths.clientPatch({stateVersion: '2321'}, {id: 'foo'})).toBe(
-      '/vs/cvr/abc/patches/meta/2321/clients/foo',
+      '/vs/cvr/abc/p/m/2321/c/foo',
     );
   });
 
@@ -46,14 +46,14 @@ describe('view-syncer/schema/paths', () => {
         table: 'issues',
         rowKey: {id: 123},
       }),
-    ).toBe('/vs/cvr/fbr/data/rows/public/issues/qse5G7quj_el4_x5CbWzQg');
+    ).toBe('/vs/cvr/fbr/d/r/hmiZ0jkPKW203clzP4Mg6w');
     expect(
       paths.row({
         schema: 'public',
         table: 'issues',
         rowKey: {id: 124},
       }),
-    ).toBe('/vs/cvr/fbr/data/rows/public/issues/u1Ny9isI-KQXSET6KchNbw');
+    ).toBe('/vs/cvr/fbr/d/r/Z1Lzg3qVqQAbTf_PsUvlCg');
     expect(
       paths.row({
         schema: 'public',
@@ -62,7 +62,7 @@ describe('view-syncer/schema/paths', () => {
           this: `could be a really a big row k${'e'.repeat(1000)}y`,
         },
       }),
-    ).toBe('/vs/cvr/fbr/data/rows/public/issues/4XQuBMS98x-1M2Gg-VMrlA');
+    ).toBe('/vs/cvr/fbr/d/r/PNJVDvpmnF-qcv1Mw8AfiQ');
 
     expect(
       paths.rowPatch(
@@ -75,9 +75,7 @@ describe('view-syncer/schema/paths', () => {
           },
         },
       ),
-    ).toBe(
-      '/vs/cvr/fbr/patches/data/28c8.12s/rows/public/issues/4XQuBMS98x-1M2Gg-VMrlA',
-    );
+    ).toBe('/vs/cvr/fbr/p/d/28c8.12s/r/PNJVDvpmnF-qcv1Mw8AfiQ');
   });
 
   test('last active paths', () => {

--- a/packages/zero-cache/src/types/row-key.test.ts
+++ b/packages/zero-cache/src/types/row-key.test.ts
@@ -1,33 +1,55 @@
 import {describe, expect, test} from 'vitest';
-import {RowKey, rowKeyHash, rowKeyString} from './row-key.js';
+import {RowKey, rowIDHash, rowKeyString} from './row-key.js';
 
 describe('types/row-key', () => {
   type Case = {
+    schema?: string;
+    table?: string;
     keys: RowKey[];
     rowKeyString: string;
-    rowKeyHash: string;
+    rowIDHash: string;
   };
 
   const cases: Case[] = [
     {
       keys: [{foo: 'bar'}, {foo: 'bar'}],
       rowKeyString: '["foo","bar"]',
-      rowKeyHash: 'obTrSkxiG_NZGYmdhk5cCQ',
+      rowIDHash: '8LLAJ0I02S3NY0zq-OEDjg',
+    },
+    {
+      table: 'clients',
+      keys: [{foo: 'bar'}, {foo: 'bar'}],
+      rowKeyString: '["foo","bar"]',
+      rowIDHash: '5dx4yFSW4NH-U00OUN6nBA',
+    },
+    {
+      schema: 'zero',
+      table: 'clients',
+      keys: [{foo: 'bar'}, {foo: 'bar'}],
+      rowKeyString: '["foo","bar"]',
+      rowIDHash: 'TP0l9Jbd9d4Jppi30gCF7A',
+    },
+    {
+      schema: 'clients',
+      table: 'zero',
+      keys: [{foo: 'bar'}, {foo: 'bar'}],
+      rowKeyString: '["foo","bar"]',
+      rowIDHash: 'iakA7CJFm2Yxz2vcRy-tgw',
     },
     {
       keys: [{foo: ['bar']}, {foo: ['bar']}],
       rowKeyString: '["foo",["bar"]]',
-      rowKeyHash: 'EXSpge3fqVTerIyk9DfobA',
+      rowIDHash: '-sQXIlhIMvuh7cZ_2j_VUQ',
     },
     {
       keys: [{foo: 1}, {foo: 1}],
       rowKeyString: '["foo",1]',
-      rowKeyHash: 'xI2eLW2t4cDhxaoLThCOBg',
+      rowIDHash: 'e23vaKv1dD1BiLBAsIi8Pw',
     },
     {
       keys: [{foo: '1'}, {foo: '1'}],
       rowKeyString: '["foo","1"]',
-      rowKeyHash: 'uj8XlgCYqo0xZ-ptdN-X0A',
+      rowIDHash: 'atxG-Vt9iV7gGF5k-EwCgA',
     },
     {
       // Two-column keys
@@ -36,7 +58,7 @@ describe('types/row-key', () => {
         {bar: ['foo'], foo: 'bar'},
       ],
       rowKeyString: '["bar",["foo"],"foo","bar"]',
-      rowKeyHash: 'tjWbs643-85yVQmnKG7yyA',
+      rowIDHash: 'scSYaMl2QedjzT5GN3ALOw',
     },
     {
       // Three-column keys
@@ -46,15 +68,16 @@ describe('types/row-key', () => {
         {bar: ['foo'], foo: 'bar', baz: 2},
       ],
       rowKeyString: '["bar",["foo"],"baz",2,"foo","bar"]',
-      rowKeyHash: 'RgvjgWwor4UuJ-huLJUHIA',
+      rowIDHash: 'kdzO406COLXC4UbkVNUZdQ',
     },
   ];
 
   for (const c of cases) {
-    test(`RowKey: ${c.keys.join(',')}`, () => {
+    const {schema = 'public', table = 'issues'} = c;
+    test(`RowKey: ${schema}.${table}: ${JSON.stringify(c.keys)}`, () => {
       for (const keys of c.keys) {
         expect(rowKeyString(keys)).toBe(c.rowKeyString);
-        expect(rowKeyHash(keys)).toBe(c.rowKeyHash);
+        expect(rowIDHash({schema, table, rowKey: keys})).toBe(c.rowIDHash);
       }
     });
   }


### PR DESCRIPTION
Rows were previously referenced as `/{schema}/{table}/{row-key-hash}`.

This changes the hash to include the table and schema such that a row is fully referenceable by the hash only.

The motivation is for this is to facilitate tracking query -> row posting lists, which will make the CVR update algorithm more efficient (currently requires a full CVR scan) and will likely be needed for IVM as well.

Also shorten the CVR paths to abbreviated prefixes, similar to what is done in the client store.