### PR TITLE
fix(mirror-server): throw CF analytics errors as FetchResultError

### DIFF
--- a/mirror/cloudflare-api/src/analytics.ts
+++ b/mirror/cloudflare-api/src/analytics.ts
@@ -1,5 +1,5 @@
 import * as v from 'shared/src/valita.js';
-import {cfCall} from './fetch.js';
+import {FetchResultError, cfCall} from './fetch.js';
 import type {AccountAccess} from './resources.js';
 import type {SelectSchema, SelectStatement} from './sql.js';
 
@@ -32,9 +32,12 @@ export class Analytics {
       body: statement,
     });
     if (!resp.ok) {
-      throw new Error(
-        `${this.#resource}: ${resp.status}: ${await resp.text()}`,
-      );
+      const body = await resp.text();
+      try {
+        throw new FetchResultError(JSON.parse(body), this.#resource);
+      } catch (e) {
+        throw new Error(`${this.#resource}: ${resp.status}: ${body}`);
+      }
     }
     return resp;
   }


### PR DESCRIPTION
Take 3 of #1465 

Errors from CF analytics used to be plaintext, but now (or at least, sometimes) they conform to the the error format of other Cloudflare fetch responses. Throw them as such so that the error codes can be filtered at higher levels. 

#1380 
