### PR TITLE
feat(replicache): add getter for cookie to ReplicacheImpl

### DIFF
--- a/packages/replicache/src/replicache.test.ts
+++ b/packages/replicache/src/replicache.test.ts
@@ -68,6 +68,28 @@ test('name cannot be empty', () => {
   ).to.throw(/name.*must be non-empty/);
 });
 
+test('cookie', async () => {
+  const pullURL = 'https://pull.com/rep';
+  const rep = await replicacheForTesting('test2', {
+    pullURL,
+  });
+  expect(await rep.impl.cookie).to.equal(null);
+
+  let pullDone = false;
+  fetchMock.post(pullURL, () => {
+    pullDone = true;
+    return makePullResponseV1(rep.clientID, 0, [], 'newCookie');
+  });
+
+  await rep.pull();
+
+  await tickUntil(() => pullDone);
+  await tickAFewTimes();
+
+  expect(await rep.impl.cookie).to.equal('newCookie');
+  fetchMock.reset();
+});
+
 test('get, has, scan on empty db', async () => {
   const rep = await replicacheForTesting('test2');
   async function t(tx: ReadTransaction) {

--- a/packages/replicache/src/test-util.ts
+++ b/packages/replicache/src/test-util.ts
@@ -111,6 +111,10 @@ export class ReplicacheTest<
   set onRecoverMutations(v) {
     this.#impl.onRecoverMutations = v;
   }
+
+  get impl() {
+    return this.#impl;
+  }
 }
 
 export const reps: Set<ReplicacheTest> = new Set();


### PR DESCRIPTION
This allows us to get rid of hacks to get the cookie in zero and reflect.