### PR TITLE
chore(zero-cache): Build runner.ts stub

### DIFF
--- a/packages/zero-cache/build.js
+++ b/packages/zero-cache/build.js
@@ -1,0 +1,38 @@
+// @ts-check
+/* eslint-env node, es2022 */
+
+import * as esbuild from 'esbuild';
+import * as path from 'path';
+import {sharedOptions} from 'shared/src/build.js';
+import {fileURLToPath} from 'url';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// @cloudflare/vitest-pool-workers/config needs a js file with the miniflare environment.
+function buildMiniflareEnvironment() {
+  return buildInternal({
+    entryPoints: [path.join(dirname, 'test', 'miniflare-environment.ts')],
+    outdir: path.join(dirname, 'out', 'test'),
+    external: [],
+  });
+}
+
+/**
+ * @param {import("esbuild").BuildOptions} options
+ */
+function buildInternal(options) {
+  const shared = sharedOptions(true);
+  return esbuild.build({
+    // Remove process.env. It does not exist in CF workers.
+    define: {'process.env': '{}'},
+    ...shared,
+    ...options,
+  });
+}
+
+try {
+  await buildMiniflareEnvironment();
+} catch (e) {
+  console.error(e);
+  process.exit(1);
+}

--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "miniflare-test": "vitest run --config vitest.config.miniflare.ts",
+    "build": "node build.js",
+    "miniflare-test": "npm run build && vitest run --config vitest.config.miniflare.ts",
     "node-test": "vitest run --config vitest.config.node.ts",
     "pg-test": "vitest run --config vitest.config.pg.ts",
     "miniflare-test:watch": "vitest --config vitest.config.miniflare.ts",

--- a/packages/zero-cache/src/services/runner.ts
+++ b/packages/zero-cache/src/services/runner.ts
@@ -1,0 +1,7 @@
+import type {DurableObjectState} from '@cloudflare/workers-types';
+
+interface Env {}
+
+export class ServiceRunnerDO {
+  constructor(_state: DurableObjectState, _env: Env) {}
+}

--- a/packages/zero-cache/test/miniflare-environment.js
+++ b/packages/zero-cache/test/miniflare-environment.js
@@ -1,9 +1,0 @@
-// @ts-check
-
-export class ServiceRunnerDO {
-  /**
-   * @param {import('@cloudflare/workers-types').DurableObjectState} _state
-   * @param {{}} _env
-   */
-  constructor(_state, _env) {}
-}

--- a/packages/zero-cache/test/miniflare-environment.ts
+++ b/packages/zero-cache/test/miniflare-environment.ts
@@ -1,0 +1,1 @@
+export {ServiceRunnerDO} from '../src/services/runner.js';

--- a/packages/zero-cache/vitest.config.miniflare.ts
+++ b/packages/zero-cache/vitest.config.miniflare.ts
@@ -6,7 +6,7 @@ export default defineWorkersConfig({
     include: ['src/**/*.test.?(c|m)[jt]s?(x)'],
     poolOptions: {
       workers: {
-        main: './test/miniflare-environment.js',
+        main: './out/test/miniflare-environment.js',
         miniflare: {
           compatibilityDate: '2024-04-05',
           compatibilityFlags: ['nodejs_compat'],


### PR DESCRIPTION
We now compile test/miniflare-environment.ts to
out/test/miniflare-environment.js so that
@cloudflare/vitest-pool-workers/config can import it.