### PR TITLE
feat(zero-cache): generate catchup delete and patch ops

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/schema/paths.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/paths.ts
@@ -1,4 +1,4 @@
-import {versionToLexi} from '../../../types/lexi-version.js';
+import {versionFromLexi, versionToLexi} from '../../../types/lexi-version.js';
 import {rowIDHash} from '../../../types/row-key.js';
 import type {CVRVersion, ClientRecord, QueryRecord, RowID} from './types.js';
 
@@ -132,6 +132,13 @@ export class CVRPaths {
     return `${this.root}/p/d/${v}/r/${rowIDHash(row)}`;
   }
 
+  versionFromPatchPath(path: string): CVRVersion {
+    const start = this.root.length + '/p/d/'.length;
+    const end = path.indexOf('/', start);
+    const version = path.substring(start, end);
+    return versionFromString(version);
+  }
+
   queryPatch(
     cvrVersion: CVRVersion,
     query: QueryRecord | {id: string},
@@ -158,4 +165,24 @@ export function versionString(v: CVRVersion) {
   return v.minorVersion
     ? `${v.stateVersion}:${versionToLexi(v.minorVersion)}`
     : v.stateVersion;
+}
+
+export function versionFromString(str: string): CVRVersion {
+  const parts = str.split(':');
+  const stateVersion = parts[0];
+  switch (parts.length) {
+    case 1: {
+      versionFromLexi(stateVersion); // Purely for validation.
+      return {stateVersion};
+    }
+    case 2: {
+      const minorVersion = versionFromLexi(parts[1]);
+      if (minorVersion > BigInt(Number.MAX_SAFE_INTEGER)) {
+        throw new Error(`minorVersion ${parts[1]} exceeds max safe integer`);
+      }
+      return {stateVersion, minorVersion: Number(minorVersion)};
+    }
+    default:
+      throw new TypeError(`Invalid version string ${str}`);
+  }
 }

--- a/packages/zero-cache/src/services/view-syncer/schema/types.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/types.test.ts
@@ -3,6 +3,7 @@ import {
   CVRVersion,
   cmpVersions,
   cookieToVersion,
+  oneAfter,
   versionToNullableCookie,
 } from './types.js';
 
@@ -90,6 +91,38 @@ describe('view-syncer/schema/types', () => {
       test(`invalid cookie: ${c.reason}`, () => {
         expect(() => cookieToVersion(c.cookie)).toThrowError();
       });
+    });
+  });
+
+  (
+    [
+      {
+        version: {stateVersion: '00'},
+        plusOne: {stateVersion: '00', minorVersion: 1},
+      },
+      {
+        version: {stateVersion: '2abc'},
+        plusOne: {stateVersion: '2abc', minorVersion: 1},
+      },
+      {
+        version: {stateVersion: '00', minorVersion: 1},
+        plusOne: {stateVersion: '00', minorVersion: 2},
+      },
+      {
+        version: {stateVersion: '100', minorVersion: 10},
+        plusOne: {stateVersion: '100', minorVersion: 11},
+      },
+      {
+        version: {stateVersion: 'a128adk2f9s', minorVersion: 36},
+        plusOne: {stateVersion: 'a128adk2f9s', minorVersion: 37},
+      },
+    ] satisfies {
+      version: CVRVersion;
+      plusOne: CVRVersion;
+    }[]
+  ).forEach(c => {
+    test(`oneAfter version ${JSON.stringify(c.version)}`, () => {
+      expect(oneAfter(c.version)).toEqual(c.plusOne);
     });
   });
 });

--- a/packages/zero-cache/src/services/view-syncer/schema/types.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/types.ts
@@ -1,8 +1,7 @@
 import * as v from 'shared/src/valita.js';
 import {astSchema} from 'zero-protocol';
 import {jsonValueSchema} from '../../../types/bigint-json.js';
-import {versionFromLexi} from '../../../types/lexi-version.js';
-import {versionString} from './paths.js';
+import {versionFromString, versionString} from './paths.js';
 
 export const cvrVersionSchema = v.object({
   /**
@@ -31,6 +30,13 @@ export const cvrVersionSchema = v.object({
 });
 
 export type CVRVersion = v.Infer<typeof cvrVersionSchema>;
+
+export function oneAfter(v: CVRVersion): CVRVersion {
+  return {
+    stateVersion: v.stateVersion,
+    minorVersion: (v.minorVersion ?? 0) + 1,
+  };
+}
 
 export type NullableCVRVersion = CVRVersion | null;
 
@@ -63,23 +69,7 @@ export function cookieToVersion(cookie: string | null): NullableCVRVersion {
   if (cookie === null) {
     return null;
   }
-  const parts = cookie.split(':');
-  const stateVersion = parts[0];
-  switch (parts.length) {
-    case 1: {
-      versionFromLexi(stateVersion); // Purely for validation.
-      return {stateVersion};
-    }
-    case 2: {
-      const minorVersion = versionFromLexi(parts[1]);
-      if (minorVersion > BigInt(Number.MAX_SAFE_INTEGER)) {
-        throw new Error(`minorVersion ${parts[1]} exceeds max safe integer`);
-      }
-      return {stateVersion, minorVersion: Number(minorVersion)};
-    }
-    default:
-      throw new TypeError(`Invalid cookie ${cookie}`);
-  }
+  return versionFromString(cookie);
 }
 
 // Last Active tracking.


### PR DESCRIPTION
In addition to the patches computed for changes since the latest CVR version, also generate patch ops (`delete` and `constrain`) to catch up clients from older CVR versions by scanning the patch rows in the CVR.

Of interest is the logic necessary to ensure that obsolete deletes aren't sent. Although `put` patches are tracked in the RowRecord, and deleted when that row is updated or deleted, `del` patches are not tracked by any tombstone, so they can be obsoleted by later patches. The catchup logic must ensure that it only sends delete patches that have not been subsumed by newer patches. 