### PR TITLE
chore(zero-cache): add all-test to run pg-test.ts files in miniflare environment

### DIFF
--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -5,9 +5,10 @@
   "type": "module",
   "scripts": {
     "build": "node build.js",
-    "miniflare-test": "npm run build && vitest run --config vitest.config.miniflare.ts",
+    "miniflare-test": "npm run build && vitest run --config vitest.config.miniflare.ts '.test.ts' ",
     "node-test": "vitest run --config vitest.config.node.ts",
     "pg-test": "vitest run --config vitest.config.pg.ts",
+    "all-test": "npm run build && vitest run --config vitest.config.miniflare.ts",
     "miniflare-test:watch": "vitest --config vitest.config.miniflare.ts",
     "node-test:watch": "vitest --config vitest.config.node.ts",
     "pg-test:watch": "vitest --config vitest.config.pg.ts",

--- a/packages/zero-cache/vitest.config.miniflare.ts
+++ b/packages/zero-cache/vitest.config.miniflare.ts
@@ -3,7 +3,7 @@ import {defineWorkersConfig} from '@cloudflare/vitest-pool-workers/config';
 export default defineWorkersConfig({
   test: {
     name: 'miniflare',
-    include: ['src/**/*.test.?(c|m)[jt]s?(x)'],
+    include: ['src/**/*.*test.?(c|m)[jt]s?(x)'],
     poolOptions: {
       workers: {
         main: './out/test/miniflare-environment.js',


### PR DESCRIPTION
Sorry for the back-and-forth on this! Just to be clear:

The (1) miniflare without pg tests (`npm run test`) and (2) pg without miniflare tests (`npm run pg-test`) run fine, but I'm also trying to run the pg tests with the miniflare environment (`npm run all-test`). 

That's where we get the `Error: No such module` issue, presumably because it tries to load that module that imports `node:util`. I think this is will be fixed by integrating your esbuild-plugin into vitest.

<img width="803" alt="Screenshot 2024-04-30 at 16 42 48" src="https://github.com/rocicorp/mono/assets/132324914/3003fc69-213c-4a55-ab5c-c5899deed575">
