### PR TITLE
feat(zero-cache): generate config patches

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/client-handler.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.test.ts
@@ -10,7 +10,7 @@ import {Subscription} from '../../types/subscription.js';
 import {ClientHandler} from './client-handler.js';
 
 describe('view-syncer/client-handler', () => {
-  test('poke handler', async () => {
+  test('poke handler', () => {
     const poke1Version = {stateVersion: '121'};
     const poke2Version = {stateVersion: '123'};
 
@@ -35,41 +35,50 @@ describe('view-syncer/client-handler', () => {
 
     let pokers = handlers.map(client => client.startPoke(poke1Version));
     for (const poker of pokers) {
-      await poker.addPatch(
-        {stateVersion: '11z', minorVersion: 1},
-        {type: 'client', op: 'put', id: 'foo'},
-      );
-      await poker.addPatch(
-        {stateVersion: '120', minorVersion: 1},
-        {type: 'client', op: 'put', id: 'bar'},
-      );
-      await poker.addPatch(
-        {stateVersion: '121'},
-        {type: 'client', op: 'put', id: 'baz'},
-      );
+      poker.addPatch({
+        toVersion: {stateVersion: '11z', minorVersion: 1},
+        patch: {type: 'client', op: 'put', id: 'foo'},
+      });
+      poker.addPatch({
+        toVersion: {stateVersion: '120', minorVersion: 1},
+        patch: {type: 'client', op: 'put', id: 'bar'},
+      });
+      poker.addPatch({
+        toVersion: {stateVersion: '121'},
+        patch: {type: 'client', op: 'put', id: 'baz'},
+      });
 
-      await poker.addPatch(
-        {stateVersion: '11z', minorVersion: 1},
-        {type: 'query', op: 'put', id: 'foohash', clientID: 'foo'},
-        {table: 'issues'},
-      );
-      await poker.addPatch(
-        {stateVersion: '120', minorVersion: 2},
-        {type: 'query', op: 'del', id: 'barhash', clientID: 'foo'},
-      );
-      await poker.addPatch(
-        {stateVersion: '121'},
-        {type: 'query', op: 'put', id: 'bazhash'},
-        {table: 'labels'},
-      );
+      poker.addPatch({
+        toVersion: {stateVersion: '11z', minorVersion: 1},
+        patch: {
+          type: 'query',
+          op: 'put',
+          id: 'foohash',
+          clientID: 'foo',
+          ast: {table: 'issues'},
+        },
+      });
+      poker.addPatch({
+        toVersion: {stateVersion: '120', minorVersion: 2},
+        patch: {type: 'query', op: 'del', id: 'barhash', clientID: 'foo'},
+      });
+      poker.addPatch({
+        toVersion: {stateVersion: '121'},
+        patch: {
+          type: 'query',
+          op: 'put',
+          id: 'bazhash',
+          ast: {table: 'labels'},
+        },
+      });
 
-      await poker.end();
+      poker.end();
     }
 
     // Now send another (empty) poke with everyone at the same baseCookie.
     pokers = handlers.map(client => client.startPoke(poke2Version));
     for (const poker of pokers) {
-      await poker.end();
+      poker.end();
     }
 
     // Cancel the subscriptions to collect the unconsumed messages.

--- a/packages/zero-cache/src/services/view-syncer/schema/paths.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/paths.test.ts
@@ -134,6 +134,38 @@ describe('view-syncer/schema/paths', () => {
     }
   });
 
+  test('metadata patch prefixes', () => {
+    const paths = new CVRPaths('fbr');
+
+    const v1: CVRVersion = {stateVersion: '1ab'};
+    const v2: CVRVersion = {stateVersion: '1ab', minorVersion: 1};
+    const v3: CVRVersion = {stateVersion: '1ac'};
+
+    expect(paths.metadataPatchPrefix()).toBe('/vs/cvr/fbr/p/m/');
+    expect(paths.metadataPatchVersionPrefix(v1)).toBe('/vs/cvr/fbr/p/m/1ab/');
+    expect(paths.metadataPatchVersionPrefix(v2)).toBe(
+      '/vs/cvr/fbr/p/m/1ab:01/',
+    );
+    expect(paths.metadataPatchVersionPrefix(v3)).toBe('/vs/cvr/fbr/p/m/1ac/');
+
+    const ordered = [
+      paths.metadataPatchVersionPrefix(v1),
+      paths.clientPatch(v1, {id: 'foo'}),
+      paths.metadataPatchVersionPrefix(v2),
+      paths.clientPatch(v2, {id: 'foo'}),
+      paths.metadataPatchVersionPrefix(oneAfter(v2)),
+      paths.metadataPatchVersionPrefix(v3),
+      paths.queryPatch(v3, {id: 'foo'}),
+      paths.metadataPatchVersionPrefix(oneAfter(v3)),
+    ];
+    for (let i = 0; i < ordered.length; i++) {
+      for (let j = i + 1; j < ordered.length; j++) {
+        expect(compareUTF8(ordered[i], ordered[j])).toBeLessThan(0);
+        expect(compareUTF8(ordered[j], ordered[i])).toBeGreaterThan(0);
+      }
+    }
+  });
+
   test('last active paths', () => {
     expect(lastActiveIndex.dayPrefix(Date.UTC(2024, 3, 19, 1, 2, 3))).toBe(
       '/vs/lastActive/2024-04-19',

--- a/packages/zero-cache/src/services/view-syncer/schema/paths.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/paths.ts
@@ -114,46 +114,45 @@ export class CVRPaths {
     return `${this.root}/d/r/`;
   }
 
-  clientPatch(
-    cvrVersion: CVRVersion,
-    client: ClientRecord | {id: string},
-  ): string {
-    const v = versionString(cvrVersion);
-    return `${this.root}/p/m/${v}/c/${client.id}`;
-  }
-
   rowPatchVersionPrefix(cvrVersion: CVRVersion): string {
     const v = versionString(cvrVersion);
     return `${this.root}/p/d/${v}/`;
   }
 
-  rowPatch(cvrVersion: CVRVersion, row: RowID): string {
-    const v = versionString(cvrVersion);
-    return `${this.root}/p/d/${v}/r/${rowIDHash(row)}`;
+  rowPatch(v: CVRVersion, row: RowID): string {
+    return `${this.rowPatchVersionPrefix(v)}r/${rowIDHash(row)}`;
   }
 
   versionFromPatchPath(path: string): CVRVersion {
-    const start = this.root.length + '/p/d/'.length;
+    const start = this.root.length + '/p/d/'.length; // Also works for '/p/m/' for metadata patches.
     const end = path.indexOf('/', start);
     const version = path.substring(start, end);
     return versionFromString(version);
   }
 
-  queryPatch(
-    cvrVersion: CVRVersion,
-    query: QueryRecord | {id: string},
-  ): string {
+  metadataPatchPrefix(): string {
+    return `${this.root}/p/m/`;
+  }
+
+  metadataPatchVersionPrefix(cvrVersion: CVRVersion): string {
     const v = versionString(cvrVersion);
-    return `${this.root}/p/m/${v}/q/${query.id}`;
+    return `${this.root}/p/m/${v}/`;
+  }
+
+  clientPatch(v: CVRVersion, client: ClientRecord | {id: string}): string {
+    return `${this.metadataPatchVersionPrefix(v)}c/${client.id}`;
+  }
+
+  queryPatch(v: CVRVersion, query: QueryRecord | {id: string}): string {
+    return `${this.metadataPatchVersionPrefix(v)}q/${query.id}`;
   }
 
   desiredQueryPatch(
-    cvrVersion: CVRVersion,
+    v: CVRVersion,
     query: QueryRecord | {id: string},
     client: ClientRecord | {id: string},
   ): string {
-    const v = versionString(cvrVersion);
-    return `${this.root}/p/m/${v}/q/${query.id}/c/${client.id}`;
+    return `${this.metadataPatchVersionPrefix(v)}q/${query.id}/c/${client.id}`;
   }
 }
 

--- a/packages/zero-cache/src/services/view-syncer/schema/types.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/types.ts
@@ -225,3 +225,7 @@ export const clientPatchSchema = patchSchema.extend({
 });
 
 export type ClientPatch = v.Infer<typeof clientPatchSchema>;
+
+export const metadataPatchSchema = v.union(clientPatchSchema, queryPatchSchema);
+
+export type MetadataPatch = v.Infer<typeof metadataPatchSchema>;


### PR DESCRIPTION
Adds logic for generating (possibly catchup) config patches from the CVR patch log.

Also contains some preparation for sending pokes in the ClientHandler.