### PR TITLE
feat(replicache,zero-client): Implement 'update' patch operation.

### DIFF
--- a/packages/replicache/src/patch-operation.ts
+++ b/packages/replicache/src/patch-operation.ts
@@ -1,5 +1,30 @@
 import {assertArray, assertObject, assertString} from 'shared/src/asserts.js';
-import {ReadonlyJSONValue, assertJSONValue} from 'shared/src/json.js';
+import {
+  ReadonlyJSONObject,
+  ReadonlyJSONValue,
+  assertJSONObject,
+  assertJSONValue,
+} from 'shared/src/json.js';
+
+export type PatchOperationInternal =
+  | {
+      readonly op: 'put';
+      readonly key: string;
+      readonly value: ReadonlyJSONValue;
+    }
+  | {
+      readonly op: 'update';
+      readonly key: string;
+      readonly merge?: ReadonlyJSONObject | undefined;
+      readonly constrain?: string[] | undefined;
+    }
+  | {
+      readonly op: 'del';
+      readonly key: string;
+    }
+  | {
+      readonly op: 'clear';
+    };
 
 /**
  * This type describes the patch field in a {@link PullResponse} and it is used
@@ -21,19 +46,31 @@ export type PatchOperation =
 
 export function assertPatchOperations(
   p: unknown,
-): asserts p is PatchOperation[] {
+): asserts p is PatchOperationInternal[] {
   assertArray(p);
   for (const item of p) {
     assertPatchOperation(item);
   }
 }
 
-function assertPatchOperation(p: unknown): asserts p is PatchOperation {
+function assertPatchOperation(p: unknown): asserts p is PatchOperationInternal {
   assertObject(p);
   switch (p.op) {
     case 'put':
       assertString(p.key);
       assertJSONValue(p.value);
+      break;
+    case 'update':
+      assertString(p.key);
+      if (p.merge !== undefined) {
+        assertJSONObject(p.merge);
+      }
+      if (p.constrain !== undefined) {
+        assertArray(p.constrain);
+        for (const key of p.constrain) {
+          assertString(key);
+        }
+      }
       break;
     case 'del':
       assertString(p.key);

--- a/packages/replicache/src/puller.ts
+++ b/packages/replicache/src/puller.ts
@@ -5,7 +5,10 @@ import type {
   VersionNotSupportedResponse,
 } from './error-responses.js';
 import type {HTTPRequestInfo} from './http-request-info.js';
-import type {PatchOperation} from './patch-operation.js';
+import type {
+  PatchOperation,
+  PatchOperationInternal,
+} from './patch-operation.js';
 import type {ClientID} from './sync/ids.js';
 import type {PullRequest} from './sync/pull.js';
 
@@ -59,6 +62,14 @@ export type PullResponseOKV1 = {
   patch: PatchOperation[];
 };
 
+export type PullResponseOKV1Internal = {
+  cookie: Cookie;
+  // All last mutation IDs from clients in clientGroupID that changed
+  // between PullRequest.cookie and PullResponseOK.cookie.
+  lastMutationIDChanges: Record<ClientID, number>;
+  patch: PatchOperationInternal[];
+};
+
 /**
  * PullResponse defines the shape and type of the response of a pull. This is
  * the JSON you should return from your pull server endpoint.
@@ -74,6 +85,11 @@ export type PullResponseV0 =
  */
 export type PullResponseV1 =
   | PullResponseOKV1
+  | ClientStateNotFoundResponse
+  | VersionNotSupportedResponse;
+
+export type PullResponseV1Internal =
+  | PullResponseOKV1Internal
   | ClientStateNotFoundResponse
   | VersionNotSupportedResponse;
 

--- a/packages/replicache/src/replicache-impl.ts
+++ b/packages/replicache/src/replicache-impl.ts
@@ -114,7 +114,7 @@ import type {
   MaybePromise,
   MutatorDefs,
   MutatorReturn,
-  Poke,
+  PokeInternal,
   QueryInternal,
   RequestOptions,
   UpdateNeededReason,
@@ -1150,7 +1150,7 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}> {
    *
    * @experimental This method is under development and its semantics will change.
    */
-  async poke(poke: Poke): Promise<void> {
+  async poke(poke: PokeInternal): Promise<void> {
     await this.#ready;
     // TODO(MP) Previously we created a request ID here and included it with the
     // PullRequest to the server so we could tie events across client and server

--- a/packages/replicache/src/sync/patch.ts
+++ b/packages/replicache/src/sync/patch.ts
@@ -1,17 +1,46 @@
 import type {LogContext} from '@rocicorp/logger';
 import type {Write} from '../db/write.js';
-import {deepFreeze} from '../frozen-json.js';
-import type {PatchOperation} from '../patch-operation.js';
+import {FrozenJSONObject, FrozenJSONValue, deepFreeze} from '../frozen-json.js';
+import type {PatchOperationInternal} from '../patch-operation.js';
+import {assertObject} from 'shared/src/asserts.js';
+import type {ReadonlyJSONObject, ReadonlyJSONValue} from 'shared/src/json.js';
 
 export async function apply(
   lc: LogContext,
   dbWrite: Write,
-  patch: readonly PatchOperation[],
+  patch: readonly PatchOperationInternal[],
 ): Promise<void> {
   for (const p of patch) {
     switch (p.op) {
       case 'put': {
         await dbWrite.put(lc, p.key, deepFreeze(p.value));
+        break;
+      }
+      case 'update': {
+        const existing = await dbWrite.get(p.key);
+        const entries: [
+          string,
+          FrozenJSONValue | ReadonlyJSONValue | undefined,
+        ][] = [];
+        const addToEntries = (toAdd: FrozenJSONObject | ReadonlyJSONObject) => {
+          for (const [key, value] of Object.entries(toAdd)) {
+            if (
+              !p.constrain ||
+              p.constrain.length === 0 ||
+              p.constrain.indexOf(key) > -1
+            ) {
+              entries.push([key, value]);
+            }
+          }
+        };
+        if (existing !== undefined) {
+          assertObject(existing);
+          addToEntries(existing);
+        }
+        if (p.merge) {
+          addToEntries(p.merge);
+        }
+        await dbWrite.put(lc, p.key, deepFreeze(Object.fromEntries(entries)));
         break;
       }
       case 'del':

--- a/packages/replicache/src/sync/pull.ts
+++ b/packages/replicache/src/sync/pull.ts
@@ -40,7 +40,7 @@ import type {
   PullerResultV0,
   PullerResultV1,
   PullResponseOKV0,
-  PullResponseOKV1,
+  PullResponseOKV1Internal,
   PullResponseV0,
   PullResponseV1,
 } from '../puller.js';
@@ -461,7 +461,7 @@ export function handlePullResponseV1(
   lc: LogContext,
   store: Store,
   expectedBaseCookie: FrozenJSONValue,
-  response: PullResponseOKV1,
+  response: PullResponseOKV1Internal,
   clientID: ClientID,
   formatVersion: FormatVersion,
 ): Promise<HandlePullResponseResult> {

--- a/packages/replicache/src/types.ts
+++ b/packages/replicache/src/types.ts
@@ -1,6 +1,6 @@
 import type {Hash} from './hash.js';
 import type {ReadonlyJSONValue, WriteTransaction} from './mod.js';
-import type {PullResponseV1} from './puller.js';
+import type {PullResponseV1, PullResponseV1Internal} from './puller.js';
 import type {ReadTransactionImpl} from './transactions.js';
 
 export type MaybePromise<T> = T | Promise<T>;
@@ -13,6 +13,12 @@ export type Poke = {
   baseCookie: ReadonlyJSONValue;
   pullResponse: PullResponseV1;
 };
+
+export type PokeInternal = {
+  baseCookie: ReadonlyJSONValue;
+  pullResponse: PullResponseV1Internal;
+};
+
 export type MutatorReturn<T extends ReadonlyJSONValue = ReadonlyJSONValue> =
   MaybePromise<T | void>; /**
  * The type used to describe the mutator definitions passed into [Replicache](classes/Replicache)

--- a/packages/zero-client/src/client/zero-poke-handler.test.ts
+++ b/packages/zero-client/src/client/zero-poke-handler.test.ts
@@ -950,10 +950,11 @@ test('mergePokes with all optionals defined', () => {
               value: {id: 'issue1', title: 'foo1'},
             },
             {
-              op: 'put',
+              op: 'update',
               entityType: 'issue',
               entityID: {id: 'issue2'},
-              value: {id: 'issue2', title: 'bar1'},
+              merge: {id: 'issue2', title: 'bar1'},
+              constrain: ['id', 'title'],
             },
           ],
         },
@@ -1085,9 +1086,10 @@ test('mergePokes with all optionals defined', () => {
           value: {id: 'issue1', title: 'foo1'},
         },
         {
-          op: 'put',
+          op: 'update',
           key: 'e/issue/issue2',
-          value: {id: 'issue2', title: 'bar1'},
+          merge: {id: 'issue2', title: 'bar1'},
+          constrain: ['id', 'title'],
         },
         {
           op: 'put',
@@ -1183,10 +1185,11 @@ test('mergePokes sparse', () => {
               value: {id: 'issue1', title: 'foo1'},
             },
             {
-              op: 'put',
+              op: 'update',
               entityType: 'issue',
               entityID: {id: 'issue2'},
-              value: {id: 'issue2', title: 'bar1'},
+              merge: {id: 'issue2', title: 'bar1'},
+              constrain: ['id', 'title'],
             },
           ],
         },
@@ -1267,9 +1270,10 @@ test('mergePokes sparse', () => {
           value: {id: 'issue1', title: 'foo1'},
         },
         {
-          op: 'put',
+          op: 'update',
           key: 'e/issue/issue2',
-          value: {id: 'issue2', title: 'bar1'},
+          merge: {id: 'issue2', title: 'bar1'},
+          constrain: ['id', 'title'],
         },
         {
           op: 'put',

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -465,7 +465,7 @@ export class Zero<MD extends MutatorDefs, QD extends QueryDefs> {
     this.#metrics.tags.push(`version:${this.version}`);
 
     this.#pokeHandler = new PokeHandler(
-      pokeDD31 => this.#rep.poke(pokeDD31),
+      poke => this.#rep.poke(poke),
       () => this.#onOutOfOrderPoke(),
       rep.clientID,
       this.#lc,

--- a/packages/zero-protocol/src/entities-patch.ts
+++ b/packages/zero-protocol/src/entities-patch.ts
@@ -1,4 +1,4 @@
-import {jsonSchema} from 'shared/src/json-schema.js';
+import {jsonObjectSchema} from 'shared/src/json-schema.js';
 import * as v from 'shared/src/valita.js';
 import {entityIDSchema} from './entity.js';
 
@@ -6,14 +6,14 @@ const putOpSchema = v.object({
   op: v.literal('put'),
   entityType: v.string(),
   entityID: entityIDSchema,
-  value: jsonSchema,
+  value: jsonObjectSchema,
 });
 
 const updateOpSchema = v.object({
   op: v.literal('update'),
   entityType: v.string(),
   entityID: entityIDSchema,
-  merge: jsonSchema.optional(),
+  merge: jsonObjectSchema.optional(),
   constrain: v.array(v.string()).optional(),
 });
 


### PR DESCRIPTION
Add 'update' patch operation support to ReplicacheImpl and update zero PokeHandler to wire entity update ops through from the zero-protocol.

This is exposed only via ReplicacheImpl and not via the public Replicache wrapper.