### PR TITLE
fix(view-syncer): get some view syncer tests to pass

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/view-syncer.all-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.all-test.ts
@@ -178,8 +178,8 @@ describe('view-syncer/service', () => {
       return Promise.resolve(sub);
     }
 
-    async getTableSchemas(): Promise<readonly TableSpec[]> {
-      return tables;
+    getTableSchemas(): Promise<readonly TableSpec[]> {
+      return Promise.resolve(tables);
     }
 
     getInvalidationWatcher(): Promise<InvalidationWatcher> {


### PR DESCRIPTION
The hanging appears to happen when attempting to make a database call from within `runWithDurableStorage()`. Move the database call out to allow more of the view syncer code to be successfully exercised in the test.