### PR TITLE
chore(zero-cache): Bump pg-logical-replication version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34456,9 +34456,9 @@
       }
     },
     "node_modules/pg-logical-replication": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pg-logical-replication/-/pg-logical-replication-2.0.3.tgz",
-      "integrity": "sha512-lXu1jlESOfVuPsNPHktossuIIFchU6z2blA23rIidcUi17y8UryI5DP/21wov///Wb4+IaOjIa4B/bTxsD8K2Q==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pg-logical-replication/-/pg-logical-replication-2.0.4.tgz",
+      "integrity": "sha512-D1Uueeh3NZE6zuLlGB5FrnJ2Q9Tt/UxNn276nMcv3GfOqGFKJhrUisDKTQyLsxw2P1o1DxLob6alxXbzAvEEOg==",
       "dependencies": {
         "eventemitter2": ">=6.4.0",
         "pg": ">=6.2.2"
@@ -47548,7 +47548,7 @@
         "json-custom-numbers": "^3.1.1",
         "pg": "^8.11.3",
         "pg-format": "^1.0.4",
-        "pg-logical-replication": "^2.0.3",
+        "pg-logical-replication": "^2.0.4",
         "postgres": "^3.4.4",
         "postgres-array": "^3.0.2",
         "xxhashjs": "^0.2.2",
@@ -73788,9 +73788,9 @@
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
     },
     "pg-logical-replication": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pg-logical-replication/-/pg-logical-replication-2.0.3.tgz",
-      "integrity": "sha512-lXu1jlESOfVuPsNPHktossuIIFchU6z2blA23rIidcUi17y8UryI5DP/21wov///Wb4+IaOjIa4B/bTxsD8K2Q==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pg-logical-replication/-/pg-logical-replication-2.0.4.tgz",
+      "integrity": "sha512-D1Uueeh3NZE6zuLlGB5FrnJ2Q9Tt/UxNn276nMcv3GfOqGFKJhrUisDKTQyLsxw2P1o1DxLob6alxXbzAvEEOg==",
       "requires": {
         "eventemitter2": ">=6.4.0",
         "pg": ">=6.2.2"
@@ -83082,7 +83082,7 @@
         "json-custom-numbers": "^3.1.1",
         "pg": "^8.11.3",
         "pg-format": "^1.0.4",
-        "pg-logical-replication": "^2.0.3",
+        "pg-logical-replication": "^2.0.4",
         "postgres": "^3.4.4",
         "postgres-array": "^3.0.2",
         "rollup-plugin-dts": "^5.3.0",

--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -31,7 +31,7 @@
     "json-custom-numbers": "^3.1.1",
     "pg": "^8.11.3",
     "pg-format": "^1.0.4",
-    "pg-logical-replication": "^2.0.3",
+    "pg-logical-replication": "^2.0.4",
     "postgres": "^3.4.4",
     "postgres-array": "^3.0.2",
     "xxhashjs": "^0.2.2",


### PR DESCRIPTION
to pick up fix that stops using "util".TextDecoder.