### PR TITLE
zeppliear: temporarily remove count to make things work end to end

### DIFF
--- a/apps/zeppliear/frontend/app.tsx
+++ b/apps/zeppliear/frontend/app.tsx
@@ -88,7 +88,7 @@ const App = ({undoManager}: AppProps) => {
     )
     .join(zero.query.label, 'label', 'issueLabel.labelID', 'label.id');
 
-  const {filteredQuery, hasNonViewFilters, viewCountQuery} = filterQuery(
+  const {filteredQuery, hasNonViewFilters} = filterQuery(
     issueListQuery,
     view,
     priorityFilter,
@@ -105,7 +105,8 @@ const App = ({undoManager}: AppProps) => {
     labelFilter,
   ] as const;
   const filteredIssues = useQuery(filteredAndOrderedQuery, deps);
-  const viewIssueCount = useQuery(viewCountQuery, deps)[0]?.count ?? 0;
+  // const viewIssueCount = useQuery(viewCountQuery, deps)[0]?.count ?? 0;
+  const viewIssueCount = 0;
 
   const handleCreateIssue = useCallback(
     async (issue: Omit<Issue, 'kanbanOrder'>) => {


### PR DESCRIPTION
The backend doesn't know what to do with aggregations like `count`