### PR TITLE
chore(zero-cache): fix initial validation tests

### DIFF
--- a/packages/zero-cache/src/services/replicator/initial-sync.pg-test.ts
+++ b/packages/zero-cache/src/services/replicator/initial-sync.pg-test.ts
@@ -311,6 +311,7 @@ describe('replicator/initial-sync', () => {
           "issueID" INTEGER PRIMARY KEY, 
           "orgID" INTEGER
         );
+        CREATE PUBLICATION zero_foo FOR TABLES IN SCHEMA _zero;
         `,
       },
       {
@@ -318,6 +319,7 @@ describe('replicator/initial-sync', () => {
         setupUpstreamQuery: `
         CREATE SCHEMA unsupported;
         CREATE TABLE unsupported.issues ("issueID" INTEGER PRIMARY KEY, "orgID" INTEGER);
+        CREATE PUBLICATION zero_foo FOR TABLES IN SCHEMA unsupported;
       `,
       },
       {


### PR DESCRIPTION
Now, unsupported schemas can only appear if they are explicitly published.