### PR TITLE
feat(zero-cache): track and send lastMutationIDChanges in pokes

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../../test/do.js';
 import {createSilentLogContext} from '../../test/logger.js';
 import {rowIDHash} from '../../types/row-key.js';
+import {cond, or} from '../../zql/query-test-util.js';
 import type {PatchToVersion} from './client-handler.js';
 import {
   CVRConfigDrivenUpdater,
@@ -316,6 +317,23 @@ describe('view-syncer/cvr', () => {
           },
         },
         queries: {
+          lmids: {
+            id: 'lmids',
+            internal: true,
+            ast: {
+              schema: 'zero',
+              table: 'clients',
+              select: [
+                ['clientID', 'clientID'],
+                ['lastMutationID', 'lastMutationID'],
+              ],
+              where: or(
+                ...['dooClient', 'fooClient', 'barClient', 'bonkClient'].map(
+                  id => cond('clientID', '=', id),
+                ),
+              ),
+            },
+          },
           oneHash: {
             id: 'oneHash',
             ast: {table: 'issues'},
@@ -350,6 +368,7 @@ describe('view-syncer/cvr', () => {
         ['/vs/cvr/abc123/m/c/bonkClient']: updated.clients.bonkClient,
         ['/vs/cvr/abc123/m/c/dooClient']: updated.clients.dooClient,
         ['/vs/cvr/abc123/m/c/fooClient']: updated.clients.fooClient,
+        ['/vs/cvr/abc123/m/q/lmids']: updated.queries.lmids,
         ['/vs/cvr/abc123/m/q/oneHash']: updated.queries.oneHash,
         ['/vs/cvr/abc123/m/q/threeHash']: updated.queries.threeHash,
         ['/vs/cvr/abc123/m/q/fourHash']: updated.queries.fourHash,

--- a/packages/zero-cache/src/services/view-syncer/queries.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/queries.pg-test.ts
@@ -304,8 +304,9 @@ describe('view-syncer/queries', () => {
     const expanded = transformedAST.query();
     const resultParser = queryHandler.resultParser(lc, 'foo-cvr');
     expect(expanded.query).toBe(
-      'SELECT issues._0_version AS "issues/_0_version", ' +
-        'issues.id AS "issues/id", issues.title AS "issues/title" ' +
+      'SELECT public.issues._0_version AS "public/issues/_0_version", ' +
+        'public.issues.id AS "public/issues/id", ' +
+        'public.issues.title AS "public/issues/title" ' +
         'FROM issues',
     );
     const results = await db.unsafe(expanded.query, expanded.values);

--- a/packages/zero-cache/src/services/view-syncer/schema/types.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/types.ts
@@ -108,7 +108,7 @@ export const clientRecordSchema = cvrRecordSchema.extend({
 
 export type ClientRecord = v.Infer<typeof clientRecordSchema>;
 
-export const queryRecordSchema = cvrRecordSchema.extend({
+export const baseQueryRecordSchema = v.object({
   /** The client-specified ID used to identify this query. Typically a hash. */
   id: v.string(),
 
@@ -149,6 +149,22 @@ export const queryRecordSchema = cvrRecordSchema.extend({
    * queries with a newer `transformationVersion`.
    */
   transformationVersion: cvrVersionSchema.optional(),
+});
+
+/**
+ * Internal queries track rows in the database for internal use, such as the
+ * `lastMutationID`s in the `zero.clients` table. They participate in the standard
+ * invalidation / update logic for row contents, but not in the desired/got or
+ * size-based quota logic for client-requested queries.
+ */
+export const internalQueryRecordSchema = baseQueryRecordSchema.extend({
+  internal: v.literal(true),
+});
+
+export type InternalQueryRecord = v.Infer<typeof internalQueryRecordSchema>;
+
+export const clientQueryRecordSchema = baseQueryRecordSchema.extend({
+  internal: v.literal(false).optional(),
 
   // For queries, the `patchVersion` indicates when query was added to the got set,
   // and is absent if not yet gotten.
@@ -162,6 +178,13 @@ export const queryRecordSchema = cvrRecordSchema.extend({
   // estimatedBytes: v.number(),
   // lru information?
 });
+
+export type ClientQueryRecord = v.Infer<typeof clientQueryRecordSchema>;
+
+export const queryRecordSchema = v.union(
+  clientQueryRecordSchema,
+  internalQueryRecordSchema,
+);
 
 export type QueryRecord = v.Infer<typeof queryRecordSchema>;
 

--- a/packages/zero-cache/src/zql/normalize.test.ts
+++ b/packages/zero-cache/src/zql/normalize.test.ts
@@ -26,14 +26,15 @@ describe('zql/normalize-query-hash', () => {
           schema: 'zero',
           table: 'clients',
           select: [
-            ['clientID', 'clientID'],
-            ['lastMutationID', 'lastMutationID'],
+            ['clients.clientID', 'clientID'],
+            ['zero.clients.lastMutationID', 'lastMutationID'],
           ],
           orderBy: [['clientID'], 'asc'],
         },
       ],
       query:
-        'SELECT "clientID" AS "clientID", "lastMutationID" AS "lastMutationID" ' +
+        'SELECT clients."clientID" AS "clientID", ' +
+        'zero.clients."lastMutationID" AS "lastMutationID" ' +
         'FROM zero.clients ORDER BY "clientID" asc',
     },
     {

--- a/packages/zero-cache/src/zql/normalize.ts
+++ b/packages/zero-cache/src/zql/normalize.ts
@@ -155,9 +155,7 @@ export class Normalized {
 
 function selector(x: string): string {
   const parts = x.split('.');
-  return parts.length === 2
-    ? `${ident(parts[0])}.${ident(parts[1])}`
-    : ident(x);
+  return parts.map(id => ident(id)).join('.');
 }
 
 const SEED = 0x1234567890;


### PR DESCRIPTION
Tracks the `lastMutationID` of relevant `clientID`s in the `zero.clients` table and sends changes in pokes.

### Main logic

* `view-syncer/schema/types.ts`: Introduces the concept of an "internal" query in the CVR, which participates in the same sync / invalidation logic as that of client-requested queries, but is excluded from the desired / got query patches and future size-calculation logic.
* `view-syncer/cvr.ts`: Updates an internal `"lmids"` query to track a view's set of `clientID`s whenever the set of clients changes.
* `view-syncer/client-handler.ts`: Identifies row patches for the `zero.clients` table and translates the row contents into updates to the `lastMutationIDChanges` field of the poke part body.

### Supporting logic
* `zero-cache/src/zql/...`: Server-side zql libraries are modified to support the tracking of schemas in query expansion and row parsing. This is needed to handle queries on the `zero.clients` table.
* `view-syncer/client-handler.ts`: Adds support for INT8 postgres columns (e.g. `lastMutationID`), which are parsed from Postgres as `bigint` values, by checking that the values are within the safe range and converting them to `number` values before serializing them into pokes.