### PR TITLE
feat(zql): don't buffer values, immediately send

### DIFF
--- a/packages/zql/src/zql/ivm/materialite.ts
+++ b/packages/zql/src/zql/ivm/materialite.ts
@@ -88,17 +88,11 @@ export class Materialite {
 
   #rollback() {
     this.#currentTx = null;
-    for (const source of this.#dirtySources) {
-      source.onRollback();
-    }
   }
 
   #commit() {
     this.#version = must(this.#currentTx);
     this.#currentTx = null;
-    for (const source of this.#dirtySources) {
-      source.onCommitEnqueue(this.#version);
-    }
     for (const source of this.#dirtySources) {
       source.onCommitted(this.#version);
     }

--- a/packages/zql/src/zql/ivm/source/set-source.test.ts
+++ b/packages/zql/src/zql/ivm/source/set-source.test.ts
@@ -93,7 +93,8 @@ test('replace', async () => {
   );
 });
 
-// the pending items are not included in the next tx
+// we don't do any rollbacks. If Materialite throws then
+// it has diverged from Replicache and we're in a bad state.
 test('rollback', async () => {
   const m = new Materialite();
   const source = m.newSetSource(comparator);
@@ -108,11 +109,11 @@ test('rollback', async () => {
   }
   await Promise.resolve();
 
-  expect([...source.value]).toEqual([]);
+  expect([...source.value]).toEqual([{id: 1}]);
 
   source.add({id: 2});
   await Promise.resolve();
-  expect([...source.value]).toEqual([{id: 2}]);
+  expect([...source.value]).toEqual([{id: 1}, {id: 2}]);
 });
 
 test('withNewOrdering - we do not update the derived thing / withNewOrdering is not tied to the original. User must do that.', async () => {

--- a/packages/zql/src/zql/ivm/source/source.ts
+++ b/packages/zql/src/zql/ivm/source/source.ts
@@ -16,9 +16,6 @@ export interface Source<T extends object> {
 }
 
 export interface SourceInternal {
-  // Add values to queues
-  onCommitEnqueue(version: Version): void;
   // Now that the graph has computed itself fully, notify effects / listeners
   onCommitted(version: Version): void;
-  onRollback(): void;
 }


### PR DESCRIPTION
We don't need all the `pending` code since we don't need to support `rollback`.

Simplifies sources a bit.