### PR TITLE
feat(zero-cache): support array values in conditions

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -1,4 +1,3 @@
-import {LogContext, consoleLogSink} from '@rocicorp/logger';
 import type {AST} from '@rocicorp/zql/src/zql/ast/ast.js';
 import {assert} from 'shared/src/asserts.js';
 import {Queue} from 'shared/src/queue.js';
@@ -25,8 +24,7 @@ import {ViewSyncerService} from './view-syncer.js';
 
 describe('view-syncer/service', () => {
   let db: PostgresDB;
-  const lc = new LogContext('debug', {}, consoleLogSink);
-  createSilentLogContext();
+  const lc = createSilentLogContext();
 
   let storage: FakeDurableObjectStorage;
   let watcher: MockInvalidationWatcher;
@@ -131,6 +129,15 @@ describe('view-syncer/service', () => {
       ['big', 'big'],
     ],
     table: 'issues',
+    where: {
+      type: 'simple',
+      field: 'id',
+      op: 'IN',
+      value: {
+        type: 'literal',
+        value: ['1', '2', '3', '4'],
+      },
+    },
   };
 
   const USERS_NAME_QUERY: AST = {

--- a/packages/zero-cache/src/zql/normalize.test.ts
+++ b/packages/zero-cache/src/zql/normalize.test.ts
@@ -324,6 +324,28 @@ describe('zql/normalize-query-hash', () => {
       values: [1234],
     },
     {
+      name: 'condition with array',
+      asts: [
+        {
+          table: 'issues',
+          select: [
+            ['id', 'i'],
+            ['name', 'n'],
+          ],
+          where: {
+            type: 'simple',
+            field: 'issues.id',
+            op: 'IN',
+            value: {type: 'literal', value: ['1234', '2345', '4567']},
+          },
+          orderBy: [['id'], 'asc'],
+        },
+      ],
+      query:
+        'SELECT id AS i, name AS n FROM issues WHERE issues.id IN ($1, $2, $3) ORDER BY id asc',
+      values: ['1234', '2345', '4567'],
+    },
+    {
       name: 'simple condition (value types affect hash)',
       asts: [
         {

--- a/packages/zero-cache/src/zql/normalize.ts
+++ b/packages/zero-cache/src/zql/normalize.ts
@@ -117,8 +117,18 @@ export class Normalized {
         value: {type, value},
       } = cond;
       assert(type === 'literal');
-      this.#values.push(value);
-      return `${selector(cond.field)} ${cond.op} $${this.#nextParam++}`;
+      if (!Array.isArray(value)) {
+        this.#values.push(value);
+        return `${selector(cond.field)} ${cond.op} $${this.#nextParam++}`;
+      }
+      // Unroll the array
+      let expr = `${selector(cond.field)} ${cond.op} (`;
+      value.forEach((v, i) => {
+        this.#values.push(v);
+        expr += (i ? ', ' : '') + `$${this.#nextParam++}`;
+      });
+      expr += ')';
+      return expr;
     }
 
     return `(${cond.conditions


### PR DESCRIPTION
Support for array values requires unrolling the array of values and assigning placeholders for each of them.

For example, `WHERE id = ${"foo"} AND priority IN ${[1, 2, 3, 4]}`

becomes:

```ts
"WHERE id = $1 AND priority IN ($2, $3, $4, $5)", ["foo", 1, 2, 3, 4]
```