### PR TITLE
fix(zql): bring back the `enqueue` step for sources

### DIFF
--- a/packages/zql/src/zql/ivm/materialite.ts
+++ b/packages/zql/src/zql/ivm/materialite.ts
@@ -88,11 +88,17 @@ export class Materialite {
 
   #rollback() {
     this.#currentTx = null;
+    for (const source of this.#dirtySources) {
+      source.onRollback();
+    }
   }
 
   #commit() {
     this.#version = must(this.#currentTx);
     this.#currentTx = null;
+    for (const source of this.#dirtySources) {
+      source.onCommitEnqueue(this.#version);
+    }
     for (const source of this.#dirtySources) {
       source.onCommitted(this.#version);
     }

--- a/packages/zql/src/zql/ivm/source/set-source.test.ts
+++ b/packages/zql/src/zql/ivm/source/set-source.test.ts
@@ -109,11 +109,11 @@ test('rollback', async () => {
   }
   await Promise.resolve();
 
-  expect([...source.value]).toEqual([{id: 1}]);
+  expect([...source.value]).toEqual([]);
 
   source.add({id: 2});
   await Promise.resolve();
-  expect([...source.value]).toEqual([{id: 1}, {id: 2}]);
+  expect([...source.value]).toEqual([{id: 2}]);
 });
 
 test('withNewOrdering - we do not update the derived thing / withNewOrdering is not tied to the original. User must do that.', async () => {

--- a/packages/zql/src/zql/ivm/source/source.ts
+++ b/packages/zql/src/zql/ivm/source/source.ts
@@ -16,6 +16,9 @@ export interface Source<T extends object> {
 }
 
 export interface SourceInternal {
+  // Add values to queues
+  onCommitEnqueue(version: Version): void;
   // Now that the graph has computed itself fully, notify effects / listeners
   onCommitted(version: Version): void;
+  onRollback(): void;
 }


### PR DESCRIPTION
Turns out to be an order of magnitude faster to enqueue writes into a single collection when there are many writes. I expected it to be faster but not _that_ much faster.