### PR TITLE
chore(zql): make `Reply` required so we do not forget to pass it down

### DIFF
--- a/packages/zql/src/zql/ivm/graph/difference-stream.test.ts
+++ b/packages/zql/src/zql/ivm/graph/difference-stream.test.ts
@@ -15,11 +15,15 @@ test('map', () => {
     expect(x).toEqual({x: 4});
   });
 
-  s.newDifference(1, [
-    [{x: 2}, 1],
-    [{x: 2}, 1],
-    [{x: 2}, 1],
-  ]);
+  s.newDifference(
+    1,
+    [
+      [{x: 2}, 1],
+      [{x: 2}, 1],
+      [{x: 2}, 1],
+    ],
+    undefined,
+  );
   s.commit(1);
 
   expect(expectRan).toBe(3);
@@ -33,11 +37,15 @@ test('filter', () => {
     expect(x).toEqual({x: 2});
   });
 
-  s.newDifference(1, [
-    [{x: 1}, 1],
-    [{x: 2}, 1],
-    [{x: 3}, 1],
-  ]);
+  s.newDifference(
+    1,
+    [
+      [{x: 1}, 1],
+      [{x: 2}, 1],
+      [{x: 3}, 1],
+    ],
+    undefined,
+  );
   s.commit(1);
 
   expect(expectRan).toBe(1);
@@ -54,21 +62,29 @@ test('count', () => {
     }
   });
 
-  s.newDifference(1, [
-    [{x: 1}, 1],
-    [{x: 2}, 1],
-    [{x: 3}, 1],
-  ]);
+  s.newDifference(
+    1,
+    [
+      [{x: 1}, 1],
+      [{x: 2}, 1],
+      [{x: 3}, 1],
+    ],
+    undefined,
+  );
   s.commit(1);
 
   expect(expectRan).toBe(1);
 
-  s.newDifference(2, [
-    [{x: 1}, 1],
-    [{x: 2}, 1],
-    [{x: 3}, 1],
-    [{x: 3}, 1],
-  ]);
+  s.newDifference(
+    2,
+    [
+      [{x: 1}, 1],
+      [{x: 2}, 1],
+      [{x: 3}, 1],
+      [{x: 3}, 1],
+    ],
+    undefined,
+  );
   expectedCount = 7;
   s.commit(2);
 
@@ -91,15 +107,19 @@ test('map, filter, linearCount', () => {
       }
     });
 
-  s.newDifference(1, [[{x: 1}, 1]]);
+  s.newDifference(1, [[{x: 1}, 1]], undefined);
   s.commit(1);
 
   expect(expectRan).toBe(1);
 
-  s.newDifference(2, [
-    [{x: 1}, 1],
-    [{x: 2}, 1],
-  ]);
+  s.newDifference(
+    2,
+    [
+      [{x: 1}, 1],
+      [{x: 2}, 1],
+    ],
+    undefined,
+  );
   expectedCount = 3;
   s.commit(2);
 
@@ -160,7 +180,7 @@ test('adding data runs the operator', () => {
     ran = true;
   });
   expect(ran).toBe(false);
-  stream.newDifference(1, []);
+  stream.newDifference(1, [], undefined);
   expect(ran).toBe(true);
 });
 
@@ -170,7 +190,7 @@ test('commit notifies the operator', () => {
   stream.effect(() => {
     ran = true;
   });
-  stream.newDifference(1, [[{}, 1]]);
+  stream.newDifference(1, [[{}, 1]], undefined);
   expect(ran).toBe(false);
   stream.commit(1);
   expect(ran).toBe(true);
@@ -201,7 +221,10 @@ test('replying to a message only notifies along the requesting path', () => {
 
   const msg = createPullMessage([[], 'asc'], 'select');
 
-  s2Dbg.messageUpstream(msg);
+  x.messageUpstream(msg, {
+    commit: () => {},
+    newDifference: () => {},
+  });
 
   expect(notified).toEqual([]);
 

--- a/packages/zql/src/zql/ivm/graph/difference-stream.ts
+++ b/packages/zql/src/zql/ivm/graph/difference-stream.ts
@@ -29,7 +29,7 @@ export type Listener<T> = {
   newDifference: (
     version: Version,
     multiset: Multiset<T>,
-    reply?: Reply | undefined,
+    reply: Reply | undefined,
   ) => void;
   commit: (version: Version) => void;
 };
@@ -81,11 +81,7 @@ export class DifferenceStream<T extends object> {
     return this;
   }
 
-  newDifference(
-    version: Version,
-    data: Multiset<T>,
-    reply?: Reply | undefined,
-  ) {
+  newDifference(version: Version, data: Multiset<T>, reply: Reply | undefined) {
     if (reply) {
       const requestors = this.#requestors.get(reply.replyingTo);
       for (const requestor of must(requestors)) {

--- a/packages/zql/src/zql/ivm/graph/operators/binary-operator.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/binary-operator.ts
@@ -26,16 +26,16 @@ export class BinaryOperator<
   ) {
     super(output);
     this.#listener1 = {
-      newDifference: (version, data) => {
-        output.newDifference(version, fn(version, data, undefined));
+      newDifference: (version, data, reply) => {
+        output.newDifference(version, fn(version, data, undefined), reply);
       },
       commit: version => {
         this.commit(version);
       },
     };
     this.#listener2 = {
-      newDifference: (version, data) => {
-        output.newDifference(version, fn(version, undefined, data));
+      newDifference: (version, data, reply) => {
+        output.newDifference(version, fn(version, undefined, data), reply);
       },
       commit: version => {
         this.commit(version);

--- a/packages/zql/src/zql/ivm/graph/operators/concat-operator.test.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/concat-operator.test.ts
@@ -19,10 +19,14 @@ test('All branches notify', () => {
     items.push(d);
   });
 
-  inputs[0].newDifference(version, [
-    [{x: 1}, 1],
-    [{x: 2}, 2],
-  ]);
+  inputs[0].newDifference(
+    version,
+    [
+      [{x: 1}, 1],
+      [{x: 2}, 2],
+    ],
+    undefined,
+  );
   inputs[0].commit(version);
 
   expect(items).toEqual([
@@ -35,9 +39,9 @@ test('All branches notify', () => {
   items.length = 0;
   version++;
 
-  inputs[0].newDifference(version, [[{x: 0}, 1]]);
-  inputs[1].newDifference(version, [[{x: 1}, 1]]);
-  inputs[2].newDifference(version, [[{x: 2}, 2]]);
+  inputs[0].newDifference(version, [[{x: 0}, 1]], undefined);
+  inputs[1].newDifference(version, [[{x: 1}, 1]], undefined);
+  inputs[2].newDifference(version, [[{x: 2}, 2]], undefined);
   inputs[0].commit(version);
   inputs[1].commit(version);
   inputs[2].commit(version);
@@ -58,10 +62,14 @@ test('Test with single input', () => {
     items.push(d);
   });
 
-  input.newDifference(version, [
-    [{x: 1}, 1],
-    [{x: 2}, 2],
-  ]);
+  input.newDifference(
+    version,
+    [
+      [{x: 1}, 1],
+      [{x: 2}, 2],
+    ],
+    undefined,
+  );
   input.commit(version);
 
   expect(items).toEqual([

--- a/packages/zql/src/zql/ivm/graph/operators/concat-operator.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/concat-operator.ts
@@ -16,8 +16,8 @@ export class ConcatOperator<T extends object> implements Operator {
     this.#inputs = inputs;
     this.#output = output;
     this.#listener = {
-      newDifference: (version, data) => {
-        output.newDifference(version, data);
+      newDifference: (version, data, reply) => {
+        output.newDifference(version, data, reply);
       },
       commit: version => {
         this.commit(version);

--- a/packages/zql/src/zql/ivm/graph/operators/difference-effect-operator.test.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/difference-effect-operator.test.ts
@@ -16,7 +16,7 @@ test('calls effect with raw difference events', () => {
     mult = m;
   });
 
-  input.newDifference(1, [[{x: 1}, 1]]);
+  input.newDifference(1, [[{x: 1}, 1]], undefined);
 
   // effect not run until commit
   expect(called).toBe(false);
@@ -29,7 +29,7 @@ test('calls effect with raw difference events', () => {
   called = false;
   value = 0;
   mult = 0;
-  input.newDifference(2, [[{x: 1}, -1]]);
+  input.newDifference(2, [[{x: 1}, -1]], undefined);
 
   // effect not run until commit
   expect(called).toBe(false);

--- a/packages/zql/src/zql/ivm/graph/operators/distinct-operator.test.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/distinct-operator.test.ts
@@ -16,12 +16,16 @@ test('distinct', () => {
     items.push(d);
   });
 
-  input.newDifference(version, [
-    [{id: 'a'}, 1],
-    [{id: 'b'}, 2],
-    [{id: 'a'}, -1],
-    [{id: 'c'}, -3],
-  ]);
+  input.newDifference(
+    version,
+    [
+      [{id: 'a'}, 1],
+      [{id: 'b'}, 2],
+      [{id: 'a'}, -1],
+      [{id: 'c'}, -3],
+    ],
+    undefined,
+  );
   input.commit(version);
 
   expect(items).toEqual([
@@ -33,28 +37,28 @@ test('distinct', () => {
 
   version++;
   items.length = 0;
-  input.newDifference(version, [[{id: 'b'}, -2]]);
+  input.newDifference(version, [[{id: 'b'}, -2]], undefined);
   input.commit(version);
   expect(items).toEqual([[[{id: 'b'}, -1]]]);
 
   version++;
   items.length = 0;
-  input.newDifference(version, [[{id: 'd'}, -1]]);
-  input.newDifference(version, [[{id: 'd'}, 1]]);
+  input.newDifference(version, [[{id: 'd'}, -1]], undefined);
+  input.newDifference(version, [[{id: 'd'}, 1]], undefined);
   input.commit(version);
   expect(items).toEqual([[[{id: 'd'}, -1]], [[{id: 'd'}, 1]]]);
 
   version++;
   items.length = 0;
-  input.newDifference(version, [[{id: 'e'}, -1]]);
-  input.newDifference(version, [[{id: 'e'}, 5]]);
+  input.newDifference(version, [[{id: 'e'}, -1]], undefined);
+  input.newDifference(version, [[{id: 'e'}, 5]], undefined);
   input.commit(version);
   expect(items).toEqual([[[{id: 'e'}, -1]], [[{id: 'e'}, 2]]]);
 
   version++;
   items.length = 0;
-  input.newDifference(version, [[{id: 'e'}, 5]]);
-  input.newDifference(version, [[{id: 'e'}, -6]]);
+  input.newDifference(version, [[{id: 'e'}, 5]], undefined);
+  input.newDifference(version, [[{id: 'e'}, -6]], undefined);
   input.commit(version);
   expect(items).toEqual([[[{id: 'e'}, 1]], [[{id: 'e'}, -2]]]);
 });
@@ -70,12 +74,16 @@ test('distinct all', () => {
     items.push([item, mult]);
   });
 
-  input.newDifference(version, [
-    [{id: 'a'}, 1],
-    [{id: 'b'}, 2],
-    [{id: 'a'}, -1],
-    [{id: 'c'}, -3],
-  ]);
+  input.newDifference(
+    version,
+    [
+      [{id: 'a'}, 1],
+      [{id: 'b'}, 2],
+      [{id: 'a'}, -1],
+      [{id: 'c'}, -3],
+    ],
+    undefined,
+  );
   input.commit(version);
   check([
     [{id: 'a'}, 1],
@@ -85,33 +93,41 @@ test('distinct all', () => {
   ]);
 
   // output b and negative c
-  input.newDifference(version, [
-    [{id: 'b'}, 1],
-    [{id: 'c'}, -1],
-  ]);
+  input.newDifference(
+    version,
+    [
+      [{id: 'b'}, 1],
+      [{id: 'c'}, -1],
+    ],
+    undefined,
+  );
   input.commit(version);
   check([]);
 
   // move c to positive
-  input.newDifference(version, [[{id: 'c'}, 6]]);
+  input.newDifference(version, [[{id: 'c'}, 6]], undefined);
   input.commit(version);
   check([[{id: 'c'}, 1]]);
 
   // bring back a
-  input.newDifference(version, [[{id: 'a'}, 1]]);
+  input.newDifference(version, [[{id: 'a'}, 1]], undefined);
   input.commit(version);
   check([[{id: 'a'}, 1]]);
 
   // delete b fully
-  input.newDifference(version, [[{id: 'b'}, -3]]);
+  input.newDifference(version, [[{id: 'b'}, -3]], undefined);
   input.commit(version);
   check([[{id: 'b'}, -1]]);
 
   // more a and b. should be ignored.
-  input.newDifference(version, [
-    [{id: 'a'}, 1],
-    [{id: 'b'}, -1],
-  ]);
+  input.newDifference(
+    version,
+    [
+      [{id: 'a'}, 1],
+      [{id: 'b'}, -1],
+    ],
+    undefined,
+  );
   input.commit(version);
   check([]);
 

--- a/packages/zql/src/zql/ivm/graph/operators/filter-operator.test.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/filter-operator.test.ts
@@ -14,12 +14,16 @@ test('does not emit any rows that fail the filter', () => {
     items.push(e);
   });
 
-  input.newDifference(1, [
-    [{id: 1}, 1],
-    [{id: 2}, 2],
-    [{id: 1}, -1],
-    [{id: 2}, -2],
-  ]);
+  input.newDifference(
+    1,
+    [
+      [{id: 1}, 1],
+      [{id: 2}, 2],
+      [{id: 1}, -1],
+      [{id: 2}, -2],
+    ],
+    undefined,
+  );
   input.commit(1);
 
   expect(items.length).toBe(0);
@@ -34,12 +38,16 @@ test('emits all rows that pass the filter (including deletes / retractions)', ()
     items.push([e, mult]);
   });
 
-  input.newDifference(1, [
-    [{id: 1}, 1],
-    [{id: 2}, 2],
-    [{id: 1}, -1],
-    [{id: 2}, -2],
-  ]);
+  input.newDifference(
+    1,
+    [
+      [{id: 1}, 1],
+      [{id: 2}, 2],
+      [{id: 1}, -1],
+      [{id: 2}, -2],
+    ],
+    undefined,
+  );
   input.commit(1);
 
   expect(items).toEqual([
@@ -62,12 +70,16 @@ test('test that filter is lazy / the filter is not actually run until we pull on
     msgs.push(data);
   });
 
-  input.newDifference(1, [
-    [{id: 1}, 1],
-    [{id: 2}, 2],
-    [{id: 1}, -1],
-    [{id: 2}, -2],
-  ]);
+  input.newDifference(
+    1,
+    [
+      [{id: 1}, 1],
+      [{id: 2}, 2],
+      [{id: 1}, -1],
+      [{id: 2}, -2],
+    ],
+    undefined,
+  );
   input.commit(1);
 
   // we run the graph but the filter is not run until we pull on it

--- a/packages/zql/src/zql/ivm/graph/operators/full-agg-operators.test.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/full-agg-operators.test.ts
@@ -10,53 +10,69 @@ test('count', () => {
   });
 
   // does not count things that do not exist
-  input.newDifference(1, [
+  input.newDifference(
+    1,
     [
-      {
-        x: 'foo',
-      },
-      0,
+      [
+        {
+          x: 'foo',
+        },
+        0,
+      ],
     ],
-  ]);
+    undefined,
+  );
   check(1, [[{x: 'foo', count: 0}, 1]]);
 
   // counts multiplicity of 1
-  input.newDifference(2, [
+  input.newDifference(
+    2,
     [
-      {
-        x: 'foo',
-      },
-      1,
+      [
+        {
+          x: 'foo',
+        },
+        1,
+      ],
     ],
-  ]);
+    undefined,
+  );
   check(2, [
     [{x: 'foo', count: 0}, -1],
     [{x: 'foo', count: 1}, 1],
   ]);
 
   // decrements if an item is removed
-  input.newDifference(3, [
+  input.newDifference(
+    3,
     [
-      {
-        x: 'foo',
-      },
-      -1,
+      [
+        {
+          x: 'foo',
+        },
+        -1,
+      ],
     ],
-  ]);
+    undefined,
+  );
   check(3, [
     [{x: 'foo', count: 1}, -1],
     [{x: 'foo', count: 0}, 1],
   ]);
 
   // double counts doubly present items
-  input.newDifference(4, [
+  input.newDifference(
+    4,
     [
-      {
-        x: 'foo',
-      },
-      2,
+      [
+        {
+          x: 'foo',
+        },
+        2,
+      ],
     ],
-  ]);
+    undefined,
+  );
   check(4, [
     [{x: 'foo', count: 0}, -1],
     [{x: 'foo', count: 2}, 1],
@@ -81,77 +97,93 @@ test('average', () => {
   });
 
   // does not avg things that do not exist
-  input.newDifference(1, [
+  input.newDifference(
+    1,
     [
-      {
-        x: 1,
-      },
-      0,
+      [
+        {
+          x: 1,
+        },
+        0,
+      ],
     ],
-  ]);
+    undefined,
+  );
   check(1, [[{x: 0}, 1]]);
 
   // averages things that exist
-  input.newDifference(1, [
+  input.newDifference(
+    1,
     [
-      {
-        x: 1,
-      },
-      1,
+      [
+        {
+          x: 1,
+        },
+        1,
+      ],
+      [
+        {
+          x: 2,
+        },
+        1,
+      ],
+      [
+        {
+          x: 3,
+        },
+        1,
+      ],
     ],
-    [
-      {
-        x: 2,
-      },
-      1,
-    ],
-    [
-      {
-        x: 3,
-      },
-      1,
-    ],
-  ]);
+    undefined,
+  );
   check(2, [
     [{x: 0}, -1],
     [{x: 2}, 1],
   ]);
 
   // updates the average when new items enter
-  input.newDifference(1, [
+  input.newDifference(
+    1,
     [
-      {
-        x: 4,
-      },
-      1,
+      [
+        {
+          x: 4,
+        },
+        1,
+      ],
+      [
+        {
+          x: 5,
+        },
+        1,
+      ],
     ],
-    [
-      {
-        x: 5,
-      },
-      1,
-    ],
-  ]);
+    undefined,
+  );
   check(3, [
     [{x: 2}, -1],
     [{x: 3}, 1],
   ]);
 
   // updates the average when items leave
-  input.newDifference(1, [
+  input.newDifference(
+    1,
     [
-      {
-        x: 4,
-      },
-      -1,
+      [
+        {
+          x: 4,
+        },
+        -1,
+      ],
+      [
+        {
+          x: 5,
+        },
+        -1,
+      ],
     ],
-    [
-      {
-        x: 5,
-      },
-      -1,
-    ],
-  ]);
+    undefined,
+  );
   check(4, [
     [{x: 3}, -1],
     [{x: 2}, 1],
@@ -173,77 +205,93 @@ test('sum', () => {
   });
 
   // does not sum things that do not exist
-  input.newDifference(1, [
+  input.newDifference(
+    1,
     [
-      {
-        x: 1,
-      },
-      0,
+      [
+        {
+          x: 1,
+        },
+        0,
+      ],
     ],
-  ]);
+    undefined,
+  );
   check(1, [[{x: 0}, 1]]);
 
   // sums things that exist
-  input.newDifference(1, [
+  input.newDifference(
+    1,
     [
-      {
-        x: 1,
-      },
-      1,
+      [
+        {
+          x: 1,
+        },
+        1,
+      ],
+      [
+        {
+          x: 2,
+        },
+        1,
+      ],
+      [
+        {
+          x: 3,
+        },
+        1,
+      ],
     ],
-    [
-      {
-        x: 2,
-      },
-      1,
-    ],
-    [
-      {
-        x: 3,
-      },
-      1,
-    ],
-  ]);
+    undefined,
+  );
   check(2, [
     [{x: 0}, -1],
     [{x: 6}, 1],
   ]);
 
   // updates the sum when new items enter
-  input.newDifference(1, [
+  input.newDifference(
+    1,
     [
-      {
-        x: 4,
-      },
-      1,
+      [
+        {
+          x: 4,
+        },
+        1,
+      ],
+      [
+        {
+          x: 5,
+        },
+        1,
+      ],
     ],
-    [
-      {
-        x: 5,
-      },
-      1,
-    ],
-  ]);
+    undefined,
+  );
   check(3, [
     [{x: 6}, -1],
     [{x: 15}, 1],
   ]);
 
   // updates the sum when items leave
-  input.newDifference(1, [
+  input.newDifference(
+    1,
     [
-      {
-        x: 4,
-      },
-      -1,
+      [
+        {
+          x: 4,
+        },
+        -1,
+      ],
+      [
+        {
+          x: 5,
+        },
+        -1,
+      ],
     ],
-    [
-      {
-        x: 5,
-      },
-      -1,
-    ],
-  ]);
+    undefined,
+  );
   check(4, [
     [{x: 15}, -1],
     [{x: 6}, 1],

--- a/packages/zql/src/zql/ivm/graph/operators/join-operator.test.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/join-operator.test.ts
@@ -43,32 +43,40 @@ test('unbalanced input', () => {
     items.push([e, m]);
   });
 
-  trackInput.newDifference(1, [
+  trackInput.newDifference(
+    1,
     [
-      {
-        id: 1,
-        title: 'Track One',
-        length: 1,
-        albumId: 1,
-      },
-      1,
+      [
+        {
+          id: 1,
+          title: 'Track One',
+          length: 1,
+          albumId: 1,
+        },
+        1,
+      ],
     ],
-  ]);
+    undefined,
+  );
 
   trackInput.commit(1);
   expect(items).toEqual([]);
   items.length = 0;
 
   // now add to the other side
-  albumInput.newDifference(2, [
+  albumInput.newDifference(
+    2,
     [
-      {
-        id: 1,
-        title: 'Album One',
-      },
-      1,
+      [
+        {
+          id: 1,
+          title: 'Album One',
+        },
+        1,
+      ],
     ],
-  ]);
+    undefined,
+  );
 
   albumInput.commit(2);
   expect(items).toEqual([
@@ -93,15 +101,19 @@ test('unbalanced input', () => {
   items.length = 0;
 
   // now try deleting items
-  albumInput.newDifference(3, [
+  albumInput.newDifference(
+    3,
     [
-      {
-        id: 1,
-        title: 'Album One',
-      },
-      -1,
+      [
+        {
+          id: 1,
+          title: 'Album One',
+        },
+        -1,
+      ],
     ],
-  ]);
+    undefined,
+  );
   albumInput.commit(3);
   // Join result is retracted and no new output is produced
   // since this is an inner join, not left join.
@@ -127,15 +139,19 @@ test('unbalanced input', () => {
   items.length = 0;
 
   // add it back
-  albumInput.newDifference(4, [
+  albumInput.newDifference(
+    4,
     [
-      {
-        id: 1,
-        title: 'Album One',
-      },
-      1,
+      [
+        {
+          id: 1,
+          title: 'Album One',
+        },
+        1,
+      ],
     ],
-  ]);
+    undefined,
+  );
   albumInput.commit(4);
 
   expect(items).toEqual([
@@ -179,27 +195,35 @@ test('basic join', () => {
     items.push([e, m]);
   });
 
-  trackInput.newDifference(1, [
+  trackInput.newDifference(
+    1,
     [
-      {
-        id: 1,
-        title: 'Track One',
-        length: 1,
-        albumId: 1,
-      },
-      1,
+      [
+        {
+          id: 1,
+          title: 'Track One',
+          length: 1,
+          albumId: 1,
+        },
+        1,
+      ],
     ],
-  ]);
+    undefined,
+  );
 
-  albumInput.newDifference(1, [
+  albumInput.newDifference(
+    1,
     [
-      {
-        id: 1,
-        title: 'Album One',
-      },
-      1,
+      [
+        {
+          id: 1,
+          title: 'Album One',
+        },
+        1,
+      ],
     ],
-  ]);
+    undefined,
+  );
 
   check([
     [
@@ -265,49 +289,61 @@ test('join through a junction table', () => {
   });
 
   ++version;
-  trackInput.newDifference(version, [
+  trackInput.newDifference(
+    version,
     [
-      {
-        id: 1,
-        title: 'Track One',
-        length: 1,
-        albumId: 1,
-      },
-      1,
+      [
+        {
+          id: 1,
+          title: 'Track One',
+          length: 1,
+          albumId: 1,
+        },
+        1,
+      ],
     ],
-  ]);
-  trackArtistInput.newDifference(version, [
+    undefined,
+  );
+  trackArtistInput.newDifference(
+    version,
     [
-      {
-        trackId: 1,
-        artistId: 1,
-      },
-      1,
+      [
+        {
+          trackId: 1,
+          artistId: 1,
+        },
+        1,
+      ],
+      [
+        {
+          trackId: 1,
+          artistId: 2,
+        },
+        1,
+      ],
     ],
+    undefined,
+  );
+  artistInput.newDifference(
+    version,
     [
-      {
-        trackId: 1,
-        artistId: 2,
-      },
-      1,
+      [
+        {
+          id: 1,
+          name: 'Artist One',
+        },
+        1,
+      ],
+      [
+        {
+          id: 2,
+          name: 'Artist Two',
+        },
+        1,
+      ],
     ],
-  ]);
-  artistInput.newDifference(version, [
-    [
-      {
-        id: 1,
-        name: 'Artist One',
-      },
-      1,
-    ],
-    [
-      {
-        id: 2,
-        name: 'Artist Two',
-      },
-      1,
-    ],
-  ]);
+    undefined,
+  );
 
   trackInput.commit(version);
   trackArtistInput.commit(version);
@@ -339,15 +375,19 @@ test('join through a junction table', () => {
 
   // remove an artist
   ++version;
-  artistInput.newDifference(version, [
+  artistInput.newDifference(
+    version,
     [
-      {
-        id: 2,
-        name: 'Artist Two',
-      },
-      -1,
+      [
+        {
+          id: 2,
+          name: 'Artist Two',
+        },
+        -1,
+      ],
     ],
-  ]);
+    undefined,
+  );
   artistInput.commit(version);
 
   // artist-two row is retracted
@@ -367,15 +407,19 @@ test('join through a junction table', () => {
 
   // remove a track-artist link
   ++version;
-  trackArtistInput.newDifference(version, [
+  trackArtistInput.newDifference(
+    version,
     [
-      {
-        trackId: 1,
-        artistId: 2,
-      },
-      -1,
+      [
+        {
+          trackId: 1,
+          artistId: 2,
+        },
+        -1,
+      ],
     ],
-  ]);
+    undefined,
+  );
   trackArtistInput.commit(version);
 
   // should be no output -- the track-artist link is gone
@@ -384,17 +428,21 @@ test('join through a junction table', () => {
 
   // remove the track
   ++version;
-  trackInput.newDifference(version, [
+  trackInput.newDifference(
+    version,
     [
-      {
-        id: 1,
-        title: 'Track One',
-        length: 1,
-        albumId: 1,
-      },
-      -1,
+      [
+        {
+          id: 1,
+          title: 'Track One',
+          length: 1,
+          albumId: 1,
+        },
+        -1,
+      ],
     ],
-  ]);
+    undefined,
+  );
   trackInput.commit(version);
 
   // all rows are retracted
@@ -414,25 +462,33 @@ test('join through a junction table', () => {
 
   // remove remaining track-artist link
   ++version;
-  trackArtistInput.newDifference(version, [
+  trackArtistInput.newDifference(
+    version,
     [
-      {
-        trackId: 1,
-        artistId: 1,
-      },
-      -1,
+      [
+        {
+          trackId: 1,
+          artistId: 1,
+        },
+        -1,
+      ],
     ],
-  ]);
+    undefined,
+  );
   // remove remaining artist
-  artistInput.newDifference(version, [
+  artistInput.newDifference(
+    version,
     [
-      {
-        id: 1,
-        name: 'Artist One',
-      },
-      -1,
+      [
+        {
+          id: 1,
+          name: 'Artist One',
+        },
+        -1,
+      ],
     ],
-  ]);
+    undefined,
+  );
   trackArtistInput.commit(version);
   artistInput.commit(version);
 
@@ -441,64 +497,88 @@ test('join through a junction table', () => {
   items.length = 0;
 
   ++version;
-  artistInput.newDifference(version, [
+  artistInput.newDifference(
+    version,
     [
-      {
-        id: 1,
-        name: 'Artist A',
-      },
-      1,
+      [
+        {
+          id: 1,
+          name: 'Artist A',
+        },
+        1,
+      ],
     ],
-  ]);
-  artistInput.newDifference(version, [
+    undefined,
+  );
+  artistInput.newDifference(
+    version,
     [
-      {
-        id: 2,
-        name: 'Artist B',
-      },
-      1,
+      [
+        {
+          id: 2,
+          name: 'Artist B',
+        },
+        1,
+      ],
     ],
-  ]);
-  trackInput.newDifference(version, [
+    undefined,
+  );
+  trackInput.newDifference(
+    version,
     [
-      {
-        id: 1,
-        title: 'Track A',
-        length: 1,
-        albumId: 1,
-      },
-      1,
+      [
+        {
+          id: 1,
+          title: 'Track A',
+          length: 1,
+          albumId: 1,
+        },
+        1,
+      ],
     ],
-  ]);
-  trackInput.newDifference(version, [
+    undefined,
+  );
+  trackInput.newDifference(
+    version,
     [
-      {
-        id: 2,
-        title: 'Track B',
-        length: 1,
-        albumId: 1,
-      },
-      1,
+      [
+        {
+          id: 2,
+          title: 'Track B',
+          length: 1,
+          albumId: 1,
+        },
+        1,
+      ],
     ],
-  ]);
-  trackArtistInput.newDifference(version, [
+    undefined,
+  );
+  trackArtistInput.newDifference(
+    version,
     [
-      {
-        trackId: 1,
-        artistId: 1,
-      },
-      1,
+      [
+        {
+          trackId: 1,
+          artistId: 1,
+        },
+        1,
+      ],
     ],
-  ]);
-  trackArtistInput.newDifference(version, [
+    undefined,
+  );
+  trackArtistInput.newDifference(
+    version,
     [
-      {
-        trackId: 2,
-        artistId: 2,
-      },
-      1,
+      [
+        {
+          trackId: 2,
+          artistId: 2,
+        },
+        1,
+      ],
     ],
-  ]);
+    undefined,
+  );
   artistInput.commit(version);
   trackInput.commit(version);
   trackArtistInput.commit(version);
@@ -564,64 +644,88 @@ test('add many items to the same source as separate calls in the same tick', () 
 
   // add some artists
   ++version;
-  artistInput.newDifference(version, [
+  artistInput.newDifference(
+    version,
     [
-      {
-        id: 1,
-        name: 'Artist A',
-      },
-      1,
+      [
+        {
+          id: 1,
+          name: 'Artist A',
+        },
+        1,
+      ],
     ],
-  ]);
-  artistInput.newDifference(version, [
+    undefined,
+  );
+  artistInput.newDifference(
+    version,
     [
-      {
-        id: 2,
-        name: 'Artist B',
-      },
-      1,
+      [
+        {
+          id: 2,
+          name: 'Artist B',
+        },
+        1,
+      ],
     ],
-  ]);
-  trackInput.newDifference(version, [
+    undefined,
+  );
+  trackInput.newDifference(
+    version,
     [
-      {
-        id: 1,
-        title: 'Track A',
-        length: 1,
-        albumId: 1,
-      },
-      1,
+      [
+        {
+          id: 1,
+          title: 'Track A',
+          length: 1,
+          albumId: 1,
+        },
+        1,
+      ],
     ],
-  ]);
-  trackInput.newDifference(version, [
+    undefined,
+  );
+  trackInput.newDifference(
+    version,
     [
-      {
-        id: 2,
-        title: 'Track B',
-        length: 1,
-        albumId: 1,
-      },
-      1,
+      [
+        {
+          id: 2,
+          title: 'Track B',
+          length: 1,
+          albumId: 1,
+        },
+        1,
+      ],
     ],
-  ]);
-  trackArtistInput.newDifference(version, [
+    undefined,
+  );
+  trackArtistInput.newDifference(
+    version,
     [
-      {
-        trackId: 1,
-        artistId: 1,
-      },
-      1,
+      [
+        {
+          trackId: 1,
+          artistId: 1,
+        },
+        1,
+      ],
     ],
-  ]);
-  trackArtistInput.newDifference(version, [
+    undefined,
+  );
+  trackArtistInput.newDifference(
+    version,
     [
-      {
-        trackId: 2,
-        artistId: 2,
-      },
-      1,
+      [
+        {
+          trackId: 2,
+          artistId: 2,
+        },
+        1,
+      ],
     ],
-  ]);
+    undefined,
+  );
   artistInput.commit(version);
   trackInput.commit(version);
   trackArtistInput.commit(version);

--- a/packages/zql/src/zql/ivm/graph/operators/left-join-operator.test.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/left-join-operator.test.ts
@@ -59,17 +59,21 @@ test('left join', () => {
   });
 
   let version = 1;
-  trackInput.newDifference(version, [
+  trackInput.newDifference(
+    version,
     [
-      {
-        id: '1',
-        title: 'Track One',
-        length: 1,
-        albumId: '1',
-      },
-      1,
+      [
+        {
+          id: '1',
+          title: 'Track One',
+          length: 1,
+          albumId: '1',
+        },
+        1,
+      ],
     ],
-  ]);
+    undefined,
+  );
   trackInput.commit(version);
   ++version;
 
@@ -93,16 +97,20 @@ test('left join', () => {
   items.length = 0;
 
   // now add an album
-  albumInput.newDifference(version, [
+  albumInput.newDifference(
+    version,
     [
-      {
-        id: '1',
-        title: 'Album One',
-        artistId: '1',
-      },
-      1,
+      [
+        {
+          id: '1',
+          title: 'Album One',
+          artistId: '1',
+        },
+        1,
+      ],
     ],
-  ]);
+    undefined,
+  );
   albumInput.commit(version);
   ++version;
 
@@ -144,17 +152,21 @@ test('left join', () => {
 
   // now remove a track.
   // The joined row should be retracted since the track is no longer present.
-  trackInput.newDifference(version, [
+  trackInput.newDifference(
+    version,
     [
-      {
-        id: '1',
-        title: 'Track One',
-        length: 1,
-        albumId: '1',
-      },
-      -1,
+      [
+        {
+          id: '1',
+          title: 'Track One',
+          length: 1,
+          albumId: '1',
+        },
+        -1,
+      ],
     ],
-  ]);
+    undefined,
+  );
   trackInput.commit(version);
   ++version;
 
@@ -183,16 +195,20 @@ test('left join', () => {
 
   // now remove the album. Nothing should be output since there
   // was nothing output last time.
-  albumInput.newDifference(version, [
+  albumInput.newDifference(
+    version,
     [
-      {
-        id: '1',
-        title: 'Album One',
-        artistId: '1',
-      },
-      -1,
+      [
+        {
+          id: '1',
+          title: 'Album One',
+          artistId: '1',
+        },
+        -1,
+      ],
     ],
-  ]);
+    undefined,
+  );
   albumInput.commit(version);
   ++version;
 
@@ -201,16 +217,20 @@ test('left join', () => {
 
   // now add an album first
   // nothing should be output since there's no track on the left to join with the album
-  albumInput.newDifference(version, [
+  albumInput.newDifference(
+    version,
     [
-      {
-        id: '1',
-        title: 'Album One',
-        artistId: '1',
-      },
-      1,
+      [
+        {
+          id: '1',
+          title: 'Album One',
+          artistId: '1',
+        },
+        1,
+      ],
     ],
-  ]);
+    undefined,
+  );
   albumInput.commit(version);
   ++version;
 
@@ -218,17 +238,21 @@ test('left join', () => {
   items.length = 0;
 
   // now add a track back
-  trackInput.newDifference(version, [
+  trackInput.newDifference(
+    version,
     [
-      {
-        id: '1',
-        title: 'Track One',
-        length: 1,
-        albumId: '1',
-      },
-      1,
+      [
+        {
+          id: '1',
+          title: 'Track One',
+          length: 1,
+          albumId: '1',
+        },
+        1,
+      ],
     ],
-  ]);
+    undefined,
+  );
   trackInput.commit(version);
   ++version;
 
@@ -289,51 +313,63 @@ test('junction table left join', () => {
     items.push([e, m]);
   });
 
-  trackInput.newDifference(version, [
+  trackInput.newDifference(
+    version,
     [
-      {
-        id: '1',
-        title: 'Track One',
-        length: 1,
-        albumId: '1',
-      },
-      1,
+      [
+        {
+          id: '1',
+          title: 'Track One',
+          length: 1,
+          albumId: '1',
+        },
+        1,
+      ],
     ],
-  ]);
-  trackArtistInput.newDifference(version, [
+    undefined,
+  );
+  trackArtistInput.newDifference(
+    version,
     [
-      {
-        id: '1-1',
-        trackId: '1',
-        artistId: '1',
-      },
-      1,
+      [
+        {
+          id: '1-1',
+          trackId: '1',
+          artistId: '1',
+        },
+        1,
+      ],
+      [
+        {
+          id: '1-2',
+          trackId: '1',
+          artistId: '2',
+        },
+        1,
+      ],
     ],
+    undefined,
+  );
+  artistInput.newDifference(
+    version,
     [
-      {
-        id: '1-2',
-        trackId: '1',
-        artistId: '2',
-      },
-      1,
+      [
+        {
+          id: '1',
+          name: 'Artist One',
+        },
+        1,
+      ],
+      [
+        {
+          id: '2',
+          name: 'Artist Two',
+        },
+        1,
+      ],
     ],
-  ]);
-  artistInput.newDifference(version, [
-    [
-      {
-        id: '1',
-        name: 'Artist One',
-      },
-      1,
-    ],
-    [
-      {
-        id: '2',
-        name: 'Artist Two',
-      },
-      1,
-    ],
-  ]);
+    undefined,
+  );
 
   trackInput.commit(version);
   trackArtistInput.commit(version);
@@ -446,17 +482,21 @@ test('junction table left join', () => {
   ++version;
 
   // remove the track
-  trackInput.newDifference(version, [
+  trackInput.newDifference(
+    version,
     [
-      {
-        id: '1',
-        title: 'Track One',
-        length: 1,
-        albumId: '1',
-      },
-      -1,
+      [
+        {
+          id: '1',
+          title: 'Track One',
+          length: 1,
+          albumId: '1',
+        },
+        -1,
+      ],
     ],
-  ]);
+    undefined,
+  );
   trackInput.commit(version);
   ++version;
 
@@ -485,17 +525,21 @@ test('junction table left join', () => {
   items.length = 0;
 
   // re-add the track
-  trackInput.newDifference(version, [
+  trackInput.newDifference(
+    version,
     [
-      {
-        id: '1',
-        title: 'Track One',
-        length: 1,
-        albumId: '1',
-      },
-      1,
+      [
+        {
+          id: '1',
+          title: 'Track One',
+          length: 1,
+          albumId: '1',
+        },
+        1,
+      ],
     ],
-  ]);
+    undefined,
+  );
   trackInput.commit(version);
   ++version;
 
@@ -524,24 +568,28 @@ test('junction table left join', () => {
   items.length = 0;
 
   // remove the track-artist links
-  trackArtistInput.newDifference(version, [
+  trackArtistInput.newDifference(
+    version,
     [
-      {
-        id: '1-1',
-        trackId: '1',
-        artistId: '1',
-      },
-      -1,
+      [
+        {
+          id: '1-1',
+          trackId: '1',
+          artistId: '1',
+        },
+        -1,
+      ],
+      [
+        {
+          id: '1-2',
+          trackId: '1',
+          artistId: '2',
+        },
+        -1,
+      ],
     ],
-    [
-      {
-        id: '1-2',
-        trackId: '1',
-        artistId: '2',
-      },
-      -1,
-    ],
-  ]);
+    undefined,
+  );
   trackArtistInput.commit(version);
   ++version;
   expect(items).toEqual([
@@ -582,24 +630,28 @@ test('junction table left join', () => {
   items.length = 0;
 
   // add the track-artist link
-  trackArtistInput.newDifference(version, [
+  trackArtistInput.newDifference(
+    version,
     [
-      {
-        id: '1-1',
-        trackId: '1',
-        artistId: '1',
-      },
-      1,
+      [
+        {
+          id: '1-1',
+          trackId: '1',
+          artistId: '1',
+        },
+        1,
+      ],
+      [
+        {
+          id: '1-2',
+          trackId: '1',
+          artistId: '2',
+        },
+        1,
+      ],
     ],
-    [
-      {
-        id: '1-2',
-        trackId: '1',
-        artistId: '2',
-      },
-      1,
-    ],
-  ]);
+    undefined,
+  );
   trackArtistInput.commit(version);
   ++version;
 
@@ -641,22 +693,26 @@ test('junction table left join', () => {
   items.length = 0;
 
   // remove the artist
-  artistInput.newDifference(version, [
+  artistInput.newDifference(
+    version,
     [
-      {
-        id: '1',
-        name: 'Artist One',
-      },
-      -1,
+      [
+        {
+          id: '1',
+          name: 'Artist One',
+        },
+        -1,
+      ],
+      [
+        {
+          id: '2',
+          name: 'Artist Two',
+        },
+        -1,
+      ],
     ],
-    [
-      {
-        id: '2',
-        name: 'Artist Two',
-      },
-      -1,
-    ],
-  ]);
+    undefined,
+  );
   artistInput.commit(version);
   ++version;
   expect(items).toEqual([
@@ -702,17 +758,21 @@ test('junction table left join', () => {
   items.length = 0;
 
   // add a track with no links to anyone
-  trackInput.newDifference(version, [
+  trackInput.newDifference(
+    version,
     [
-      {
-        id: '2',
-        title: 'Track Two',
-        length: 1,
-        albumId: '2',
-      },
-      1,
+      [
+        {
+          id: '2',
+          title: 'Track Two',
+          length: 1,
+          albumId: '2',
+        },
+        1,
+      ],
     ],
-  ]);
+    undefined,
+  );
   trackInput.commit(version);
   ++version;
 
@@ -762,58 +822,70 @@ test('repro 1', () => {
     items.push([e, m]);
   });
 
-  trackInput.newDifference(version, [
+  trackInput.newDifference(
+    version,
     [
-      {
-        id: '1',
-        title: 'Track One',
-        length: 1,
-        albumId: '1',
-      },
-      1,
+      [
+        {
+          id: '1',
+          title: 'Track One',
+          length: 1,
+          albumId: '1',
+        },
+        1,
+      ],
     ],
-  ]);
+    undefined,
+  );
   trackInput.commit(version);
   ++version;
 
-  artistInput.newDifference(version, [
+  artistInput.newDifference(
+    version,
     [
-      {
-        id: '1',
-        name: 'Artist One',
-      },
-      1,
+      [
+        {
+          id: '1',
+          name: 'Artist One',
+        },
+        1,
+      ],
+      [
+        {
+          id: '2',
+          name: 'Artist Two',
+        },
+        1,
+      ],
     ],
-    [
-      {
-        id: '2',
-        name: 'Artist Two',
-      },
-      1,
-    ],
-  ]);
+    undefined,
+  );
   artistInput.commit(version);
   ++version;
 
   items.length = 0;
-  trackArtistInput.newDifference(version, [
+  trackArtistInput.newDifference(
+    version,
     [
-      {
-        id: '1-1',
-        trackId: '1',
-        artistId: '1',
-      },
-      1,
+      [
+        {
+          id: '1-1',
+          trackId: '1',
+          artistId: '1',
+        },
+        1,
+      ],
+      [
+        {
+          id: '1-2',
+          trackId: '1',
+          artistId: '2',
+        },
+        1,
+      ],
     ],
-    [
-      {
-        id: '1-2',
-        trackId: '1',
-        artistId: '2',
-      },
-      1,
-    ],
-  ]);
+    undefined,
+  );
   trackArtistInput.commit(version);
   ++version;
   expect(items).toEqual([
@@ -848,24 +920,28 @@ test('repro 1', () => {
   ]);
   items.length = 0;
 
-  trackArtistInput.newDifference(version, [
+  trackArtistInput.newDifference(
+    version,
     [
-      {
-        id: '1-1',
-        trackId: '1',
-        artistId: '1',
-      },
-      -1,
+      [
+        {
+          id: '1-1',
+          trackId: '1',
+          artistId: '1',
+        },
+        -1,
+      ],
+      [
+        {
+          id: '1-2',
+          trackId: '1',
+          artistId: '2',
+        },
+        -1,
+      ],
     ],
-    [
-      {
-        id: '1-2',
-        trackId: '1',
-        artistId: '2',
-      },
-      -1,
-    ],
-  ]);
+    undefined,
+  );
   trackArtistInput.commit(version);
   ++version;
   expect(items).toEqual([
@@ -920,27 +996,35 @@ test('add track & album, then remove album', () => {
   });
 
   let version = 1;
-  trackInput.newDifference(version, [
+  trackInput.newDifference(
+    version,
     [
-      {
-        id: '1',
-        title: 'Track One',
-        length: 1,
-        albumId: '1',
-      },
-      1,
+      [
+        {
+          id: '1',
+          title: 'Track One',
+          length: 1,
+          albumId: '1',
+        },
+        1,
+      ],
     ],
-  ]);
-  albumInput.newDifference(version, [
+    undefined,
+  );
+  albumInput.newDifference(
+    version,
     [
-      {
-        id: '1',
-        title: 'Album One',
-        artistId: '1',
-      },
-      1,
+      [
+        {
+          id: '1',
+          title: 'Album One',
+          artistId: '1',
+        },
+        1,
+      ],
     ],
-  ]);
+    undefined,
+  );
   trackInput.commit(version);
   albumInput.commit(version);
   ++version;
@@ -975,16 +1059,20 @@ test('add track & album, then remove album', () => {
   items.length = 0;
 
   // retract the album
-  albumInput.newDifference(version, [
+  albumInput.newDifference(
+    version,
     [
-      {
-        id: '1',
-        title: 'Album One',
-        artistId: '1',
-      },
-      -1,
+      [
+        {
+          id: '1',
+          title: 'Album One',
+          artistId: '1',
+        },
+        -1,
+      ],
     ],
-  ]);
+    undefined,
+  );
   albumInput.commit(version);
   ++version;
 
@@ -1032,35 +1120,43 @@ test('one to many, remove the one, add the one', () => {
     items.push([e, m]);
   });
 
-  trackInput.newDifference(version, [
+  trackInput.newDifference(
+    version,
     [
-      {
-        id: '1',
-        title: 'Track One',
-        length: 1,
-        albumId: '1',
-      },
-      1,
+      [
+        {
+          id: '1',
+          title: 'Track One',
+          length: 1,
+          albumId: '1',
+        },
+        1,
+      ],
     ],
-  ]);
-  trackArtistInput.newDifference(version, [
+    undefined,
+  );
+  trackArtistInput.newDifference(
+    version,
     [
-      {
-        id: '1-1',
-        trackId: '1',
-        artistId: '1',
-      },
-      1,
+      [
+        {
+          id: '1-1',
+          trackId: '1',
+          artistId: '1',
+        },
+        1,
+      ],
+      [
+        {
+          id: '1-2',
+          trackId: '1',
+          artistId: '2',
+        },
+        1,
+      ],
     ],
-    [
-      {
-        id: '1-2',
-        trackId: '1',
-        artistId: '2',
-      },
-      1,
-    ],
-  ]);
+    undefined,
+  );
   trackInput.commit(version);
   trackArtistInput.commit(version);
   ++version;
@@ -1103,17 +1199,21 @@ test('one to many, remove the one, add the one', () => {
   ]);
   items.length = 0;
 
-  trackInput.newDifference(version, [
+  trackInput.newDifference(
+    version,
     [
-      {
-        id: '1',
-        title: 'Track One',
-        length: 1,
-        albumId: '1',
-      },
-      -1,
+      [
+        {
+          id: '1',
+          title: 'Track One',
+          length: 1,
+          albumId: '1',
+        },
+        -1,
+      ],
     ],
-  ]);
+    undefined,
+  );
   trackInput.commit(version);
   ++version;
 
@@ -1139,17 +1239,21 @@ test('one to many, remove the one, add the one', () => {
   ]);
   items.length = 0;
 
-  trackInput.newDifference(version, [
+  trackInput.newDifference(
+    version,
     [
-      {
-        id: '1',
-        title: 'Track One',
-        length: 1,
-        albumId: '1',
-      },
-      1,
+      [
+        {
+          id: '1',
+          title: 'Track One',
+          length: 1,
+          albumId: '1',
+        },
+        1,
+      ],
     ],
-  ]);
+    undefined,
+  );
   trackInput.commit(version);
   ++version;
 
@@ -1210,60 +1314,72 @@ test('two tracks, only 1 is linked to artists', () => {
     items.push([e, m]);
   });
 
-  trackInput.newDifference(version, [
+  trackInput.newDifference(
+    version,
     [
-      {
-        id: '1',
-        title: 'Track One',
-        length: 1,
-        albumId: '1',
-      },
-      1,
+      [
+        {
+          id: '1',
+          title: 'Track One',
+          length: 1,
+          albumId: '1',
+        },
+        1,
+      ],
+      [
+        {
+          id: '2',
+          albumId: '1',
+          title: 'track 2',
+          length: 1,
+        },
+        1,
+      ],
     ],
+    undefined,
+  );
+  artistInput.newDifference(
+    version,
     [
-      {
-        id: '2',
-        albumId: '1',
-        title: 'track 2',
-        length: 1,
-      },
-      1,
+      [
+        {
+          id: '1',
+          name: 'Artist One',
+        },
+        1,
+      ],
+      [
+        {
+          id: '2',
+          name: 'Artist Two',
+        },
+        1,
+      ],
     ],
-  ]);
-  artistInput.newDifference(version, [
+    undefined,
+  );
+  trackArtistInput.newDifference(
+    version,
     [
-      {
-        id: '1',
-        name: 'Artist One',
-      },
-      1,
+      [
+        {
+          id: '1-1',
+          trackId: '1',
+          artistId: '1',
+        },
+        1,
+      ],
+      [
+        {
+          id: '1-2',
+          trackId: '1',
+          artistId: '2',
+        },
+        1,
+      ],
     ],
-    [
-      {
-        id: '2',
-        name: 'Artist Two',
-      },
-      1,
-    ],
-  ]);
-  trackArtistInput.newDifference(version, [
-    [
-      {
-        id: '1-1',
-        trackId: '1',
-        artistId: '1',
-      },
-      1,
-    ],
-    [
-      {
-        id: '1-2',
-        trackId: '1',
-        artistId: '2',
-      },
-      1,
-    ],
-  ]);
+    undefined,
+  );
   trackInput.commit(version);
   artistInput.commit(version);
   trackArtistInput.commit(version);

--- a/packages/zql/src/zql/ivm/graph/operators/map-operator.test.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/map-operator.test.ts
@@ -15,12 +15,16 @@ test('lazy', () => {
     items.push(d);
   });
 
-  input.newDifference(1, [
-    [{id: 1}, 1],
-    [{id: 2}, 2],
-    [{id: 1}, -1],
-    [{id: 2}, -2],
-  ]);
+  input.newDifference(
+    1,
+    [
+      [{id: 1}, 1],
+      [{id: 2}, 2],
+      [{id: 1}, -1],
+      [{id: 2}, -2],
+    ],
+    undefined,
+  );
   input.commit(1);
 
   // we run the graph but the mapper is not run until we pull on it
@@ -43,12 +47,16 @@ test('applies to rows', () => {
     items.push([e, m]);
   });
 
-  input.newDifference(1, [
-    [{id: 1}, 1],
-    [{id: 2}, 2],
-    [{id: 1}, -1],
-    [{id: 2}, -2],
-  ]);
+  input.newDifference(
+    1,
+    [
+      [{id: 1}, 1],
+      [{id: 2}, 2],
+      [{id: 1}, -1],
+      [{id: 2}, -2],
+    ],
+    undefined,
+  );
   input.commit(1);
 
   expect(items).toEqual([

--- a/packages/zql/src/zql/ivm/graph/operators/reduce-operator.test.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/reduce-operator.test.ts
@@ -44,100 +44,124 @@ test('collects all things with the same key', () => {
     items.push([e, m]);
   });
 
-  input.newDifference(1, [
+  input.newDifference(
+    1,
     [
-      {
-        id: 'a',
-        value: 1,
-        groupKey: 'x',
-      },
-      1,
+      [
+        {
+          id: 'a',
+          value: 1,
+          groupKey: 'x',
+        },
+        1,
+      ],
+      [
+        {
+          id: 'b',
+          value: 2,
+          groupKey: 'x',
+        },
+        2,
+      ],
     ],
-    [
-      {
-        id: 'b',
-        value: 2,
-        groupKey: 'x',
-      },
-      2,
-    ],
-  ]);
+    undefined,
+  );
   check([[{id: 'x', sum: 5}, 1]]);
 
   // retract an item
-  input.newDifference(1, [
+  input.newDifference(
+    1,
     [
-      {
-        id: 'a',
-        value: 1,
-        groupKey: 'x',
-      },
-      -1,
+      [
+        {
+          id: 'a',
+          value: 1,
+          groupKey: 'x',
+        },
+        -1,
+      ],
     ],
-  ]);
+    undefined,
+  );
   check([
     [{id: 'x', sum: 5}, -1],
     [{id: 'x', sum: 4}, 1],
   ]);
 
   // fully retract items that constitute a grouping
-  input.newDifference(1, [
+  input.newDifference(
+    1,
     [
-      {
-        id: 'b',
-        value: 2,
-        groupKey: 'x',
-      },
-      -2,
+      [
+        {
+          id: 'b',
+          value: 2,
+          groupKey: 'x',
+        },
+        -2,
+      ],
     ],
-  ]);
+    undefined,
+  );
   check([[{id: 'x', sum: 4}, -1]]);
 
   // add more entries
-  input.newDifference(1, [
+  input.newDifference(
+    1,
     [
-      {
-        id: 'a',
-        value: 1,
-        groupKey: 'c',
-      },
-      1,
+      [
+        {
+          id: 'a',
+          value: 1,
+          groupKey: 'c',
+        },
+        1,
+      ],
     ],
-  ]);
+    undefined,
+  );
   check([[{id: 'c', sum: 1}, 1]]);
-  input.newDifference(1, [
+  input.newDifference(
+    1,
     [
-      {
-        id: 'b',
-        value: 2,
-        groupKey: 'c',
-      },
-      1,
+      [
+        {
+          id: 'b',
+          value: 2,
+          groupKey: 'c',
+        },
+        1,
+      ],
     ],
-  ]);
+    undefined,
+  );
   check([
     [{id: 'c', sum: 1}, -1],
     [{id: 'c', sum: 3}, 1],
   ]);
 
-  input.newDifference(1, [
+  input.newDifference(
+    1,
     [
-      {
-        id: 'a',
-        value: 1,
-        groupKey: 'c',
-      },
-      -1,
+      [
+        {
+          id: 'a',
+          value: 1,
+          groupKey: 'c',
+        },
+        -1,
+      ],
+      [
+        {
+          id: 'a',
+          value: 2,
+          groupKey: 'c',
+        },
+        1,
+      ],
     ],
-    [
-      {
-        id: 'a',
-        value: 2,
-        groupKey: 'c',
-      },
-      1,
-    ],
-  ]);
+    undefined,
+  );
   check([
     [{id: 'c', sum: 3}, -1],
     [{id: 'c', sum: 4}, 1],

--- a/packages/zql/src/zql/ivm/graph/operators/unary-operator.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/unary-operator.ts
@@ -22,8 +22,8 @@ export class UnaryOperator<I extends object, O extends object>
   ) {
     super(output);
     this.#listener = {
-      newDifference: (version, data) => {
-        output.newDifference(version, fn(version, data));
+      newDifference: (version, data, reply) => {
+        output.newDifference(version, fn(version, data), reply);
       },
       commit: version => {
         this.commit(version);

--- a/packages/zql/src/zql/ivm/source/set-source.ts
+++ b/packages/zql/src/zql/ivm/source/set-source.ts
@@ -77,7 +77,7 @@ export abstract class SetSource<T extends object> implements Source<T> {
           }
         }
 
-        this.#stream.newDifference(version, this.#pending);
+        this.#stream.newDifference(version, this.#pending, undefined);
         this.#pending = [];
       },
       onCommitted: (version: Version) => {


### PR DESCRIPTION
The contents of `Reply` is what will allow `join`, `reduce`, `limit`, `groupBy`, to decide whether or not they can stop processing the Multiset early.

If one operator forgets to pass it to another then we won't apply the expected optimizations.

`Reply` will tell us if the data in the `Multiset` is:
1. Sorted
2. Sorted by which fields.
3. If groups are contiguous on the `groupBy` key. I.e., a `groupBy` with a downstream `limit` doesn't have to scan the entire `Multiset`