### PR TITLE
fix(zql): only iterate the current value rather than all values for t…

### DIFF
--- a/packages/zql/src/zql/ivm/graph/operators/distinct-operator.test.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/distinct-operator.test.ts
@@ -30,7 +30,9 @@ test('distinct', () => {
 
   expect(items).toEqual([
     [
+      [{id: 'a'}, 1],
       [{id: 'b'}, 1],
+      [{id: 'a'}, -1],
       [{id: 'c'}, -1],
     ],
   ]);


### PR DESCRIPTION
…he current version

`handleDiff` now only iterates over the input `multiset`.

Before it would:
1. iterate the `multiset`
2. iterate all values seen so far in the current version