### PR TITLE
Handle mutagen errors correctly

### DIFF
--- a/packages/reflect-protocol/src/error.ts
+++ b/packages/reflect-protocol/src/error.ts
@@ -13,6 +13,11 @@ export const errorKindSchema = v.union(
   v.literal('InvalidConnectionRequestClientDeleted'),
   v.literal('InvalidMessage'),
   v.literal('InvalidPush'),
+  // TODO: This error should include the ID of the mutation that failed so that
+  // the app can update the UI if it wants. This requires restructuring the
+  // protocol types a little since some error kinds will have additional info
+  // and others will not.
+  v.literal('MutationFailed'),
   v.literal('RoomClosed'),
   v.literal('RoomNotFound'),
   v.literal('Unauthorized'),

--- a/packages/zero-cache/src/services/connection.ts
+++ b/packages/zero-cache/src/services/connection.ts
@@ -4,7 +4,7 @@ import {Downstream, PongMessage, upstreamSchema} from 'zero-protocol';
 import type {ServiceRunner} from './service-runner.js';
 import type {SyncContext, ViewSyncer} from './view-syncer/view-syncer.js';
 // TODO(mlaw): break dependency on reflect-server
-import {closeWithError} from 'reflect-server/socket';
+import {closeWithError, sendError} from 'reflect-server/socket';
 import type {CancelableAsyncIterable} from '../types/streams.js';
 import type {Mutagen} from './mutagen/mutagen.js';
 
@@ -85,7 +85,10 @@ export class Connection {
             );
           }
           for (const mutation of mutations) {
-            await this.#mutagen.processMutation(mutation);
+            const error = await this.#mutagen.processMutation(mutation);
+            if (error !== undefined) {
+              sendError(lc, ws, 'MutationFailed', error);
+            }
           }
           break;
         }


### PR DESCRIPTION
Application-level errors should still bump the lastMutationID so that sync doesn't get stuck. Then the error should be reported back to the app.