### PR TITLE
feat(zql): swap treap to sorted-btree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14673,11 +14673,6 @@
         "get-func-name": "^2.0.1"
       }
     },
-    "node_modules/@vlcn.io/ds-and-algos": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@vlcn.io/ds-and-algos/-/ds-and-algos-3.0.2.tgz",
-      "integrity": "sha512-/uXzD+9uJ7pIpwsrzN2zUX6SldlrDrJ9K8nvUZof0MJOzzXS0xisoOam2u8m0T5RrZ0ShBk2R9r0EjwPZMdv1g=="
-    },
     "node_modules/@wdio/config": {
       "version": "8.36.1",
       "resolved": "https://registry.npmjs.org/@wdio/config/-/config-8.36.1.tgz",
@@ -38453,6 +38448,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/sorted-btree": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sorted-btree/-/sorted-btree-1.8.1.tgz",
+      "integrity": "sha512-395+XIP+wqNn3USkFSrNz7G3Ss/MXlZEqesxvzCRFwL14h6e8LukDHdLBePn5pwbm5OQ9vGu8mDyz2lLDIqamQ=="
+    },
     "node_modules/source-map": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
@@ -49602,8 +49602,8 @@
       "name": "@rocicorp/zql",
       "version": "0.0.0",
       "dependencies": {
-        "@vlcn.io/ds-and-algos": "^3.0.2",
-        "compare-utf8": "^0.1.1"
+        "compare-utf8": "^0.1.1",
+        "sorted-btree": "^1.8.1"
       },
       "devDependencies": {
         "@rocicorp/eslint-config": "^0.5.1",
@@ -55682,13 +55682,13 @@
         "@rocicorp/logger": "^5.2.1",
         "@rocicorp/prettier-config": "^0.2.0",
         "@rocicorp/rails": "^0.10.0",
-        "@vlcn.io/ds-and-algos": "^3.0.2",
         "compare-utf8": "^0.1.1",
         "fast-check": "^3.16.0",
         "nanoid": "^4.0.2",
         "playwright": "^1.43.1",
         "replicache": "15.0.0",
         "shared": "0.0.0",
+        "sorted-btree": "^1.8.1",
         "typescript": "^5.4.2",
         "wa-sqlite": "github:rhashimoto/wa-sqlite#ca2084cdd188c56532ba3e272696d0b9e21a23bf",
         "zod": "^3.21.4"
@@ -58303,11 +58303,6 @@
           }
         }
       }
-    },
-    "@vlcn.io/ds-and-algos": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@vlcn.io/ds-and-algos/-/ds-and-algos-3.0.2.tgz",
-      "integrity": "sha512-/uXzD+9uJ7pIpwsrzN2zUX6SldlrDrJ9K8nvUZof0MJOzzXS0xisoOam2u8m0T5RrZ0ShBk2R9r0EjwPZMdv1g=="
     },
     "@wdio/config": {
       "version": "8.36.1",
@@ -78068,6 +78063,11 @@
           }
         }
       }
+    },
+    "sorted-btree": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sorted-btree/-/sorted-btree-1.8.1.tgz",
+      "integrity": "sha512-395+XIP+wqNn3USkFSrNz7G3Ss/MXlZEqesxvzCRFwL14h6e8LukDHdLBePn5pwbm5OQ9vGu8mDyz2lLDIqamQ=="
     },
     "source-map": {
       "version": "0.7.4",

--- a/packages/zero-client/package.json
+++ b/packages/zero-client/package.json
@@ -12,6 +12,7 @@
     "check-format": "prettier --check *",
     "lint": "eslint --ext .ts,.tsx,.js,.jsx src/",
     "test": "vitest run",
+    "bench": "vitest bench",
     "test:watch": "vitest",
     "check-types": "tsc --noEmit",
     "build-dts": "rm -rf out/.dts/ && tsc --emitDeclarationOnly --outDir out/.dts/ && rollup --config rollup.config.js && rm -rf out/.dts",

--- a/packages/zql/package.json
+++ b/packages/zql/package.json
@@ -34,7 +34,7 @@
   },
   "prettier": "@rocicorp/prettier-config",
   "dependencies": {
-    "@vlcn.io/ds-and-algos": "^3.0.2",
-    "compare-utf8": "^0.1.1"
+    "compare-utf8": "^0.1.1",
+    "sorted-btree": "^1.8.1"
   }
 }

--- a/packages/zql/src/zql/context/zero-context.test.ts
+++ b/packages/zql/src/zql/context/zero-context.test.ts
@@ -34,7 +34,7 @@ test('getSource - no ordering', () => {
   ]);
 
   // source is ordered by id
-  expect([...(source as unknown as SetSource<E1>).value]).toEqual([
+  expect([...(source as unknown as SetSource<E1>).value.keys()]).toEqual([
     {id: '1', str: 'a'},
     {id: '2', str: 'a'},
     {id: '3', str: 'a'},
@@ -42,7 +42,7 @@ test('getSource - no ordering', () => {
 
   callback([{op: 'del', key: 'e1/1', oldValue: {id: '1', str: 'a'}}]);
 
-  expect([...(source as unknown as SetSource<E1>).value]).toEqual([
+  expect([...(source as unknown as SetSource<E1>).value.keys()]).toEqual([
     {id: '2', str: 'a'},
     {id: '3', str: 'a'},
   ]);
@@ -56,7 +56,7 @@ test('getSource - no ordering', () => {
     },
   ]);
 
-  expect([...(source as unknown as SetSource<E1>).value]).toEqual([
+  expect([...(source as unknown as SetSource<E1>).value.keys()]).toEqual([
     {id: '2', str: 'a'},
     {id: '3', str: 'z'},
   ]);

--- a/packages/zql/src/zql/context/zero-context.ts
+++ b/packages/zql/src/zql/context/zero-context.ts
@@ -4,7 +4,7 @@ import {assert} from 'shared/src//asserts.js';
 import type {Entity} from '../../entity.js';
 import type {AST} from '../ast/ast.js';
 import type {Materialite} from '../ivm/materialite.js';
-import type {MutableSetSource} from '../ivm/source/set-source.js';
+import type {SetSource} from '../ivm/source/set-source.js';
 import type {Source} from '../ivm/source/source.js';
 import {mapIter} from '../util/iterables.js';
 import type {Context, SubscriptionDelegate} from './context.js';
@@ -68,7 +68,7 @@ class ZeroSourceStore {
 }
 
 class ZeroSource {
-  readonly #canonicalSource: MutableSetSource<Entity>;
+  readonly #canonicalSource: SetSource<Entity>;
   #receivedFirstDiff = false;
 
   constructor(materialite: Materialite, name: string, addWatch: AddWatch) {

--- a/packages/zql/src/zql/ivm/materialite.ts
+++ b/packages/zql/src/zql/ivm/materialite.ts
@@ -1,8 +1,8 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore next.js is having issues finding the .d.ts
-import type {Comparator} from '@vlcn.io/ds-and-algos/types';
+import type {Comparator} from './types.js';
 import {must} from 'shared/src/must.js';
-import {MutableSetSource} from './source/set-source.js';
+import {SetSource} from './source/set-source.js';
 import type {SourceInternal} from './source/source.js';
 import type {Version} from './types.js';
 
@@ -44,7 +44,7 @@ export class Materialite {
     comparator: Comparator<T>,
     name?: string | undefined,
   ) {
-    return new MutableSetSource<T>(this.#internal, comparator, name);
+    return new SetSource<T>(this.#internal, comparator, name);
   }
 
   /**

--- a/packages/zql/src/zql/ivm/source/set-source.test.ts
+++ b/packages/zql/src/zql/ivm/source/set-source.test.ts
@@ -15,7 +15,7 @@ test('add', () => {
       const source = m.newSetSource(comparator);
 
       arr.forEach(x => source.add({id: x}));
-      expect([...source.value]).toEqual(
+      expect([...source.value.keys()]).toEqual(
         arr.sort(numberComparator).map(x => ({id: x})),
       );
     }),
@@ -30,7 +30,7 @@ test('delete', () => {
 
       arr.forEach(x => source.add({id: x}));
       arr.forEach(x => source.delete({id: x}));
-      expect([...source.value]).toEqual([]);
+      expect([...source.value.keys()]).toEqual([]);
     }),
   );
 });
@@ -44,7 +44,7 @@ test('on', () => {
     expect(value).toEqual(source.value);
     ++callCount;
 
-    expect([...value]).toEqual([{id: 1}, {id: 2}]);
+    expect([...value.keys()]).toEqual([{id: 1}, {id: 2}]);
   });
   m.tx(() => {
     source.add({id: 1});
@@ -89,7 +89,9 @@ test('replace', async () => {
       });
       await Promise.resolve();
 
-      expect([...source.value]).toEqual(arr.map(id => ({id})).sort(comparator));
+      expect([...source.value.keys()]).toEqual(
+        arr.map(id => ({id})).sort(comparator),
+      );
     }),
   );
 });
@@ -110,11 +112,11 @@ test('rollback', async () => {
   }
   await Promise.resolve();
 
-  expect([...source.value]).toEqual([]);
+  expect([...source.value.keys()]).toEqual([]);
 
   source.add({id: 2});
   await Promise.resolve();
-  expect([...source.value]).toEqual([{id: 2}]);
+  expect([...source.value.keys()]).toEqual([{id: 2}]);
 });
 
 test('withNewOrdering - we do not update the derived thing / withNewOrdering is not tied to the original. User must do that.', async () => {
@@ -128,8 +130,8 @@ test('withNewOrdering - we do not update the derived thing / withNewOrdering is 
   });
   await Promise.resolve();
 
-  expect([...source.value]).toEqual([{id: 1}, {id: 2}]);
-  expect([...derived.value]).toEqual([]);
+  expect([...source.value.keys()]).toEqual([{id: 1}, {id: 2}]);
+  expect([...derived.value.keys()]).toEqual([]);
 });
 
 test('withNewOrdering - is correctly ordered', async () => {
@@ -147,8 +149,10 @@ test('withNewOrdering - is correctly ordered', async () => {
       });
       await Promise.resolve();
 
-      expect([...source.value]).toEqual(arr.map(id => ({id})).sort(comparator));
-      expect([...derived.value]).toEqual(
+      expect([...source.value.keys()]).toEqual(
+        arr.map(id => ({id})).sort(comparator),
+      );
+      expect([...derived.value.keys()]).toEqual(
         arr.sort((l, r) => r - l).map(id => ({id})),
       );
     }),

--- a/packages/zql/src/zql/ivm/types.ts
+++ b/packages/zql/src/zql/ivm/types.ts
@@ -8,6 +8,8 @@ type JoinResultBase = {
   [joinSymbol]: true;
 };
 
+export type Comparator<T> = (l: T, r: T) => number;
+
 export type JoinResult<
   AValue,
   BValue,


### PR DESCRIPTION
It is a more complete (can do intersect, diff, range, iterate in reverse order) data structure than my own `Treap` class.

https://github.com/qwertie/btree-typescript

It is also a bit faster on:
- iteration
- insertion
- update

slower on delete but that seems acceptable.

And was easier to pull in than to add reverse iteration (for efficient `desc`) to my treap.