### PR TITLE
fix(zql): fix some weirdness around btree import

### DIFF
--- a/packages/zql/src/zql/btree-class.ts
+++ b/packages/zql/src/zql/btree-class.ts
@@ -1,0 +1,7 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import BTree_ from 'sorted-btree';
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const BTree =
+  ((BTree_ as any).default as typeof BTree_) || (BTree_ as typeof BTree_);
+
+export default BTree;

--- a/packages/zql/src/zql/ivm/source/set-source.ts
+++ b/packages/zql/src/zql/ivm/source/set-source.ts
@@ -6,7 +6,8 @@ import type {MaterialiteForSourceInternal} from '../materialite.js';
 import type {Entry, Multiset} from '../multiset.js';
 import type {Comparator, Version} from '../types.js';
 import type {Source, SourceInternal} from './source.js';
-import BTree, {ISortedMap} from 'sorted-btree';
+import type {ISortedMap} from 'sorted-btree';
+import BTree from '../../btree-class.js';
 
 /**
  * A source that remembers what values it contains.

--- a/packages/zql/src/zql/ivm/view/tree-view.ts
+++ b/packages/zql/src/zql/ivm/view/tree-view.ts
@@ -4,7 +4,8 @@ import type {DifferenceStream} from '../graph/difference-stream.js';
 import {createPullMessage} from '../graph/message.js';
 import type {Multiset} from '../multiset.js';
 import {AbstractView} from './abstract-view.js';
-import BTree, {ISortedMap} from 'sorted-btree';
+import type {ISortedMap} from 'sorted-btree';
+import BTree from '../../btree-class.js';
 import type {Comparator} from '../types.js';
 
 /**


### PR DESCRIPTION
idk.. TypeScript is confused as to where the type exists. This seems to fix it for both NextJS and Vite.

https://github.com/qwertie/btree-typescript/issues/36