### PR TITLE
refactor(reflect-server): don't await log flush in withLock

### DIFF
--- a/packages/reflect-server/src/util/lock.ts
+++ b/packages/reflect-server/src/util/lock.ts
@@ -85,7 +85,10 @@ export class LoggingLock {
       }
     });
     if (flushAfterLock) {
-      await lc.flush();
+      // Do not await, log flushes can be very slow (10s of seconds).
+      // The logical success/failure of withLock does not
+      // depend on this calls result.
+      void lc.flush();
     }
     return result;
   }


### PR DESCRIPTION
Darick recently made a similar change to zero-cache, noting he saw log context flushes taking up to 30 seconds.

This is outside of the actual lock inside withLock, so it probably is not causing big hold ups, but I think its still better not to await here.