### PR TITLE
refactor(mono):remove @cloudflare/workers-types from syncpack exceptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,12 +32,9 @@
     "versionGroups": [
       {
         "dependencies": [
-          "@cloudflare/workers-types",
           "vitest"
         ],
         "packages": [
-          "mirror-cli",
-          "mirror-workers",
           "zero-cache"
         ],
         "label": "@cloudflare/vitest-pool-workers only works with Vitest 1.3.0: https://developers.cloudflare.com/workers/testing/vitest-integration/get-started/write-your-first-test/#install-vitest-and-cloudflarevitest-pool-workers"


### PR DESCRIPTION
Everything is now on the same `@cloudflare/workers-types` as of https://github.com/rocicorp/mono/commit/493747c88ff16e9fe4885b9c615339868ab32a81