### PR TITLE
fix(zero-cache): add explicit datadog dependency

### DIFF
--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -27,6 +27,7 @@
     "@rocicorp/resolver": "^1.0.1",
     "@rocicorp/zql": "0.0.0",
     "compare-utf8": "^0.1.1",
+    "datadog": "0.0.0",
     "eventemitter3": "^5.0.1",
     "json-custom-numbers": "^3.1.1",
     "pg": "^8.11.3",


### PR DESCRIPTION
To get `check-types` to work.