### PR TITLE
!chore(zero-cache): use base36 row keys

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/queries.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/queries.pg-test.ts
@@ -1,8 +1,8 @@
 import type {AST} from '@rocicorp/zql/src/zql/ast/ast.js';
 import {assert} from 'shared/src/asserts.js';
+import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {testDBs} from '../../test/db.js';
-import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
 import type {PostgresDB} from '../../types/pg.js';
 import {Normalized} from '../../zql/normalize.js';
 import {getPublicationInfo} from '../replicator/tables/published.js';
@@ -150,7 +150,7 @@ describe('view-syncer/queries', () => {
     expect(resultParser.parseResults(queryIDs, results)).toEqual(
       new Map([
         [
-          '/vs/cvr/foo-cvr/d/r/wfZrxQPRsszHpdfLRWoPzA',
+          '/vs/cvr/foo-cvr/d/r/e3jqcp8k60hejdhju08414x2z',
           {
             contents: {id: '3', owner_id: '102', parent_id: '1', title: 'foo'},
             record: {
@@ -166,7 +166,7 @@ describe('view-syncer/queries', () => {
           },
         ],
         [
-          '/vs/cvr/foo-cvr/d/r/dygxK_hEWhfHvQ8eowTfCQ',
+          '/vs/cvr/foo-cvr/d/r/idb04wek62w1kiltjxjn3fxk',
           {
             contents: {id: '102', name: 'Candice'},
             record: {
@@ -180,7 +180,7 @@ describe('view-syncer/queries', () => {
           },
         ],
         [
-          '/vs/cvr/foo-cvr/d/r/oA1bf0ulYhik9qypZFPeLQ',
+          '/vs/cvr/foo-cvr/d/r/1ngjqp2ckvs2ur64mjoacg55',
           {
             contents: {id: '1', owner_id: '100', title: 'parent issue foo'},
             record: {
@@ -195,7 +195,7 @@ describe('view-syncer/queries', () => {
           },
         ],
         [
-          '/vs/cvr/foo-cvr/d/r/1G9hXQhMWdq9f737TmE6rg',
+          '/vs/cvr/foo-cvr/d/r/9483jb6yy1yq0etzidy62072z',
           {
             contents: {id: '100', name: 'Alice'},
             record: {
@@ -209,7 +209,7 @@ describe('view-syncer/queries', () => {
           },
         ],
         [
-          '/vs/cvr/foo-cvr/d/r/Qxp2tFD-UOgu7-78ZYiLHw',
+          '/vs/cvr/foo-cvr/d/r/7flkrz0yskhi5ko0l0lqjccoe',
           {
             contents: {id: '4', owner_id: '101', parent_id: '2', title: 'bar'},
             record: {
@@ -225,7 +225,7 @@ describe('view-syncer/queries', () => {
           },
         ],
         [
-          '/vs/cvr/foo-cvr/d/r/Z3BOpMPd4QMKJ8IeYx1QvQ',
+          '/vs/cvr/foo-cvr/d/r/epxvfoxp9ktkty20rjo1yyheu',
           {
             contents: {id: '101', name: 'Bob'},
             record: {
@@ -239,7 +239,7 @@ describe('view-syncer/queries', () => {
           },
         ],
         [
-          '/vs/cvr/foo-cvr/d/r/VPg9hxKPhJtHB6oYkGqBpw',
+          '/vs/cvr/foo-cvr/d/r/2z8i982skum71jkx73g5y2gao',
           {
             contents: {id: '2', owner_id: '101', title: 'parent issue bar'},
             record: {
@@ -315,7 +315,7 @@ describe('view-syncer/queries', () => {
     expect(resultParser.parseResults(queryIDs, results)).toEqual(
       new Map([
         [
-          '/vs/cvr/foo-cvr/d/r/Qxp2tFD-UOgu7-78ZYiLHw',
+          '/vs/cvr/foo-cvr/d/r/7flkrz0yskhi5ko0l0lqjccoe',
           {
             contents: {id: '4', title: 'bar'},
             record: {
@@ -326,7 +326,7 @@ describe('view-syncer/queries', () => {
           },
         ],
         [
-          '/vs/cvr/foo-cvr/d/r/VPg9hxKPhJtHB6oYkGqBpw',
+          '/vs/cvr/foo-cvr/d/r/2z8i982skum71jkx73g5y2gao',
           {
             contents: {id: '2', title: 'parent issue bar'},
             record: {
@@ -337,7 +337,7 @@ describe('view-syncer/queries', () => {
           },
         ],
         [
-          '/vs/cvr/foo-cvr/d/r/oA1bf0ulYhik9qypZFPeLQ',
+          '/vs/cvr/foo-cvr/d/r/1ngjqp2ckvs2ur64mjoacg55',
           {
             contents: {id: '1', title: 'parent issue foo'},
             record: {
@@ -348,7 +348,7 @@ describe('view-syncer/queries', () => {
           },
         ],
         [
-          '/vs/cvr/foo-cvr/d/r/wfZrxQPRsszHpdfLRWoPzA',
+          '/vs/cvr/foo-cvr/d/r/e3jqcp8k60hejdhju08414x2z',
           {
             contents: {id: '3', title: 'foo'},
             record: {
@@ -480,7 +480,7 @@ describe('view-syncer/queries', () => {
     expect(resultParser.parseResults(queryIDs, results)).toEqual(
       new Map([
         [
-          '/vs/cvr/foo-cvr/d/r/wfZrxQPRsszHpdfLRWoPzA',
+          '/vs/cvr/foo-cvr/d/r/e3jqcp8k60hejdhju08414x2z',
           {
             contents: {id: '3', owner_id: '102', parent_id: '1', title: 'foo'},
             record: {
@@ -496,7 +496,7 @@ describe('view-syncer/queries', () => {
           },
         ],
         [
-          '/vs/cvr/foo-cvr/d/r/dygxK_hEWhfHvQ8eowTfCQ',
+          '/vs/cvr/foo-cvr/d/r/idb04wek62w1kiltjxjn3fxk',
           {
             contents: {id: '102', name: 'Candice'},
             record: {
@@ -510,7 +510,7 @@ describe('view-syncer/queries', () => {
           },
         ],
         [
-          '/vs/cvr/foo-cvr/d/r/oA1bf0ulYhik9qypZFPeLQ',
+          '/vs/cvr/foo-cvr/d/r/1ngjqp2ckvs2ur64mjoacg55',
           {
             contents: {
               id: '1',
@@ -531,7 +531,7 @@ describe('view-syncer/queries', () => {
           },
         ],
         [
-          '/vs/cvr/foo-cvr/d/r/1G9hXQhMWdq9f737TmE6rg',
+          '/vs/cvr/foo-cvr/d/r/9483jb6yy1yq0etzidy62072z',
           {
             contents: {id: '100', name: 'Alice'},
             record: {
@@ -545,7 +545,7 @@ describe('view-syncer/queries', () => {
           },
         ],
         [
-          '/vs/cvr/foo-cvr/d/r/Qxp2tFD-UOgu7-78ZYiLHw',
+          '/vs/cvr/foo-cvr/d/r/7flkrz0yskhi5ko0l0lqjccoe',
           {
             contents: {id: '4', owner_id: '101', parent_id: '2', title: 'bar'},
             record: {
@@ -561,7 +561,7 @@ describe('view-syncer/queries', () => {
           },
         ],
         [
-          '/vs/cvr/foo-cvr/d/r/Z3BOpMPd4QMKJ8IeYx1QvQ',
+          '/vs/cvr/foo-cvr/d/r/epxvfoxp9ktkty20rjo1yyheu',
           {
             contents: {id: '101', name: 'Bob'},
             record: {
@@ -575,7 +575,7 @@ describe('view-syncer/queries', () => {
           },
         ],
         [
-          '/vs/cvr/foo-cvr/d/r/VPg9hxKPhJtHB6oYkGqBpw',
+          '/vs/cvr/foo-cvr/d/r/2z8i982skum71jkx73g5y2gao',
           {
             contents: {
               id: '2',
@@ -657,7 +657,7 @@ describe('view-syncer/queries', () => {
     expect(resultParser.parseResults(queryIDs, results)).toEqual(
       new Map([
         [
-          '/vs/cvr/foo-cvr/d/r/Qxp2tFD-UOgu7-78ZYiLHw',
+          '/vs/cvr/foo-cvr/d/r/7flkrz0yskhi5ko0l0lqjccoe',
           {
             contents: {id: '4', title: 'bar'},
             record: {
@@ -668,7 +668,7 @@ describe('view-syncer/queries', () => {
           },
         ],
         [
-          '/vs/cvr/foo-cvr/d/r/VPg9hxKPhJtHB6oYkGqBpw',
+          '/vs/cvr/foo-cvr/d/r/2z8i982skum71jkx73g5y2gao',
           {
             contents: {id: '2', title: 'parent issue bar'},
             record: {
@@ -679,7 +679,7 @@ describe('view-syncer/queries', () => {
           },
         ],
         [
-          '/vs/cvr/foo-cvr/d/r/oA1bf0ulYhik9qypZFPeLQ',
+          '/vs/cvr/foo-cvr/d/r/1ngjqp2ckvs2ur64mjoacg55',
           {
             contents: {id: '1', title: 'parent issue foo'},
             record: {
@@ -690,7 +690,7 @@ describe('view-syncer/queries', () => {
           },
         ],
         [
-          '/vs/cvr/foo-cvr/d/r/wfZrxQPRsszHpdfLRWoPzA',
+          '/vs/cvr/foo-cvr/d/r/e3jqcp8k60hejdhju08414x2z',
           {
             contents: {id: '3', title: 'foo'},
             record: {

--- a/packages/zero-cache/src/services/view-syncer/schema/paths.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/paths.test.ts
@@ -68,14 +68,14 @@ describe('view-syncer/schema/paths', () => {
         table: 'issues',
         rowKey: {id: 123},
       }),
-    ).toBe('/vs/cvr/fbr/d/r/hmiZ0jkPKW203clzP4Mg6w');
+    ).toBe('/vs/cvr/fbr/d/r/7voyfyr4kp3iwnbimxjlziq8d');
     expect(
       paths.row({
         schema: 'public',
         table: 'issues',
         rowKey: {id: 124},
       }),
-    ).toBe('/vs/cvr/fbr/d/r/Z1Lzg3qVqQAbTf_PsUvlCg');
+    ).toBe('/vs/cvr/fbr/d/r/5925di8zkpciz02gvhiot6rk0');
     expect(
       paths.row({
         schema: 'public',
@@ -84,8 +84,7 @@ describe('view-syncer/schema/paths', () => {
           this: `could be a really a big row k${'e'.repeat(1000)}y`,
         },
       }),
-    ).toBe('/vs/cvr/fbr/d/r/PNJVDvpmnF-qcv1Mw8AfiQ');
-
+    ).toBe('/vs/cvr/fbr/d/r/bwsh8gfsm99es7mhufgwcgm24');
     expect(
       paths.rowPatch(
         {stateVersion: '28c8', minorVersion: 100},
@@ -97,7 +96,7 @@ describe('view-syncer/schema/paths', () => {
           },
         },
       ),
-    ).toBe('/vs/cvr/fbr/p/d/28c8:12s/r/PNJVDvpmnF-qcv1Mw8AfiQ');
+    ).toBe('/vs/cvr/fbr/p/d/28c8:12s/r/bwsh8gfsm99es7mhufgwcgm24');
   });
 
   test('row patch prefixes', () => {

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -1,5 +1,6 @@
 import type {AST} from '@rocicorp/zql/src/zql/ast/ast.js';
 import {assert} from 'shared/src/asserts.js';
+import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
 import {Queue} from 'shared/src/queue.js';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import type {Downstream, PokePartBody} from 'zero-protocol';
@@ -7,7 +8,6 @@ import {TransactionPool} from '../../db/transaction-pool.js';
 import {DurableStorage} from '../../storage/durable-storage.js';
 import {testDBs} from '../../test/db.js';
 import {FakeDurableObjectStorage} from '../../test/fake-do.js';
-import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
 import type {PostgresDB} from '../../types/pg.js';
 import type {CancelableAsyncIterable} from '../../types/streams.js';
 import {Subscription} from '../../types/subscription.js';
@@ -375,7 +375,7 @@ describe('view-syncer/service', () => {
     expect(rowPatches).toEqual(
       new Map([
         [
-          '/vs/cvr/9876/p/d/1xz/r/Qxp2tFD-UOgu7-78ZYiLHw',
+          '/vs/cvr/9876/p/d/1xz/r/7flkrz0yskhi5ko0l0lqjccoe',
           {
             columns: ['big', 'id', 'title'],
             id: {rowKey: {id: '4'}, schema: 'public', table: 'issues'},
@@ -385,7 +385,7 @@ describe('view-syncer/service', () => {
           },
         ],
         [
-          '/vs/cvr/9876/p/d/1xz/r/VPg9hxKPhJtHB6oYkGqBpw',
+          '/vs/cvr/9876/p/d/1xz/r/2z8i982skum71jkx73g5y2gao',
           {
             columns: ['big', 'id', 'title'],
             id: {rowKey: {id: '2'}, schema: 'public', table: 'issues'},
@@ -395,7 +395,7 @@ describe('view-syncer/service', () => {
           },
         ],
         [
-          '/vs/cvr/9876/p/d/1xz/r/oA1bf0ulYhik9qypZFPeLQ',
+          '/vs/cvr/9876/p/d/1xz/r/1ngjqp2ckvs2ur64mjoacg55',
           {
             columns: ['big', 'id', 'title'],
             id: {rowKey: {id: '1'}, schema: 'public', table: 'issues'},
@@ -405,7 +405,7 @@ describe('view-syncer/service', () => {
           },
         ],
         [
-          '/vs/cvr/9876/p/d/1xz/r/wfZrxQPRsszHpdfLRWoPzA',
+          '/vs/cvr/9876/p/d/1xz/r/e3jqcp8k60hejdhju08414x2z',
           {
             columns: ['big', 'id', 'title'],
             id: {rowKey: {id: '3'}, schema: 'public', table: 'issues'},
@@ -415,7 +415,7 @@ describe('view-syncer/service', () => {
           },
         ],
         [
-          '/vs/cvr/9876/p/d/1xz/r/Fck9j70JNRFEeb3ry5TrEw',
+          '/vs/cvr/9876/p/d/1xz/r/7fxlm9v6qwokjvqa9d20cc09v',
           {
             columns: ['clientGroupID', 'clientID', 'lastMutationID'],
             id: {
@@ -739,7 +739,7 @@ describe('view-syncer/service', () => {
     expect(rowPatches).toEqual(
       new Map([
         [
-          '/vs/cvr/9876/p/d/1xz/r/Qxp2tFD-UOgu7-78ZYiLHw',
+          '/vs/cvr/9876/p/d/1xz/r/7flkrz0yskhi5ko0l0lqjccoe',
           {
             columns: ['big', 'id', 'title'],
             id: {rowKey: {id: '4'}, schema: 'public', table: 'issues'},
@@ -749,7 +749,7 @@ describe('view-syncer/service', () => {
           },
         ],
         [
-          '/vs/cvr/9876/p/d/1xz/r/VPg9hxKPhJtHB6oYkGqBpw',
+          '/vs/cvr/9876/p/d/1xz/r/2z8i982skum71jkx73g5y2gao',
           {
             columns: ['big', 'id', 'title'],
             id: {rowKey: {id: '2'}, schema: 'public', table: 'issues'},
@@ -759,7 +759,7 @@ describe('view-syncer/service', () => {
           },
         ],
         [
-          '/vs/cvr/9876/p/d/1xz/r/oA1bf0ulYhik9qypZFPeLQ',
+          '/vs/cvr/9876/p/d/1xz/r/1ngjqp2ckvs2ur64mjoacg55',
           {
             columns: ['big', 'id', 'title'],
             id: {rowKey: {id: '1'}, schema: 'public', table: 'issues'},
@@ -769,7 +769,7 @@ describe('view-syncer/service', () => {
           },
         ],
         [
-          '/vs/cvr/9876/p/d/1xz/r/wfZrxQPRsszHpdfLRWoPzA',
+          '/vs/cvr/9876/p/d/1xz/r/e3jqcp8k60hejdhju08414x2z',
           {
             columns: ['big', 'id', 'title'],
             id: {rowKey: {id: '3'}, schema: 'public', table: 'issues'},
@@ -779,7 +779,7 @@ describe('view-syncer/service', () => {
           },
         ],
         [
-          '/vs/cvr/9876/p/d/1xz/r/Fck9j70JNRFEeb3ry5TrEw',
+          '/vs/cvr/9876/p/d/1xz/r/7fxlm9v6qwokjvqa9d20cc09v',
           {
             columns: ['clientGroupID', 'clientID', 'lastMutationID'],
             id: {

--- a/packages/zero-cache/src/types/row-key.test.ts
+++ b/packages/zero-cache/src/types/row-key.test.ts
@@ -14,43 +14,43 @@ describe('types/row-key', () => {
     {
       keys: [{foo: 'bar'}, {foo: 'bar'}],
       rowKeyString: '["foo","bar"]',
-      rowIDHash: 'LzYCyoprbpgVX1OvowtR0w',
+      rowIDHash: '3z7dbf9d35nybsu0u6j0qdduu',
     },
     {
       table: 'clients',
       keys: [{foo: 'bar'}, {foo: 'bar'}],
       rowKeyString: '["foo","bar"]',
-      rowIDHash: '5dx4yFSW4NH-U00OUN6nBA',
+      rowIDHash: '369s9ujkm8cshq8maksagrk4z',
     },
     {
       schema: 'zero',
       table: 'clients',
       keys: [{foo: 'bar'}, {foo: 'bar'}],
       rowKeyString: '["foo","bar"]',
-      rowIDHash: 'TP0l9Jbd9d4Jppi30gCF7A',
+      rowIDHash: 'bdi7ujkjhk018p49qckqpjs59',
     },
     {
       schema: 'clients',
       table: 'zero',
       keys: [{foo: 'bar'}, {foo: 'bar'}],
       rowKeyString: '["foo","bar"]',
-      rowIDHash: 'iakA7CJFm2Yxz2vcRy-tgw',
+      rowIDHash: '83rna1e2y74s7ik5skigv9223',
     },
     {
       table: 'issues',
       keys: [{foo: ['bar']}, {foo: ['bar']}],
       rowKeyString: '["foo",["bar"]]',
-      rowIDHash: '-sQXIlhIMvuh7cZ_2j_VUQ',
+      rowIDHash: 'c8pu7tydek3r9wopx9c4o64nl',
     },
     {
       keys: [{foo: 1}, {foo: 1}],
       rowKeyString: '["foo",1]',
-      rowIDHash: '7P8yzu686tZglB9sTe-EUQ',
+      rowIDHash: 'gjssbmsl6avdktnaq8an52jg',
     },
     {
       keys: [{foo: '1'}, {foo: '1'}],
       rowKeyString: '["foo","1"]',
-      rowIDHash: 'PzXFZK-F8o5nIMOJa0TQ6g',
+      rowIDHash: 'cr6zlx3dei78jpjv8qecv5b63',
     },
     {
       // Two-column keys
@@ -59,7 +59,7 @@ describe('types/row-key', () => {
         {bar: ['foo'], foo: 'bar'},
       ],
       rowKeyString: '["bar",["foo"],"foo","bar"]',
-      rowIDHash: 'BPPyZXf9D3XzztvswmthYA',
+      rowIDHash: '73vrcw1djlz99hvz4lqjyt2bw',
     },
     {
       // Three-column keys
@@ -69,12 +69,12 @@ describe('types/row-key', () => {
         {bar: ['foo'], foo: 'bar', baz: 2},
       ],
       rowKeyString: '["bar",["foo"],"baz",2,"foo","bar"]',
-      rowIDHash: '6aqwQTpouYQb9ST-v53efw',
+      rowIDHash: '802jgj2gmrqy0khigiknxueof',
     },
     {
       keys: [{id: 'HhCx1Vi3js'}],
       rowKeyString: '["id","HhCx1Vi3js"]',
-      rowIDHash: 'DRduv2GfSDYjdImfnsw1Aw',
+      rowIDHash: 'd9wwy0a6s1olyhxq8vkvw7kln',
     },
   ];
 


### PR DESCRIPTION
This is a CVR-breaking change that uses base36 encoding for row keys instead of base64.

Profiling (and method naming 😝) indicates that Cloudflare's implementation of `Buffer.toString('base64')` is slow.

<img width="797" alt="Screenshot 2024-05-11 at 10 27 04" src="https://github.com/rocicorp/mono/assets/132324914/ef642b16-d26d-4560-b617-3b212b528876">

Since the string representation is entirely internal, the optimization changes the format of row keys from base64 to base36, the latter of which uses the isolate's native `BigInt.toString(36)` implementation and results in only slightly longer strings (+3 characters).

This is the last of the micro-optimizations, shaving off an additional 5~10ms of CPU time per poke.
