### PR TITLE
chore(zero-cache): rename newVersion to version in internal protocol

### DIFF
--- a/packages/zero-cache/src/services/invalidation-watcher/invalidation-watcher.pg-test.ts
+++ b/packages/zero-cache/src/services/invalidation-watcher/invalidation-watcher.pg-test.ts
@@ -1,8 +1,8 @@
+import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
 import {Queue} from 'shared/src/queue.js';
 import {sleep} from 'shared/src/sleep.js';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {initDB, testDBs} from '../../test/db.js';
-import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
 import {normalizeFilterSpec} from '../../types/invalidation.js';
 import type {PostgresDB} from '../../types/pg.js';
 import {Subscription} from '../../types/subscription.js';
@@ -131,19 +131,19 @@ describe('invalidation-watcher', () => {
       ],
       expectedIncrementalUpdates: [
         {
-          newVersion: '0a',
+          version: '0a',
           fromVersion: null, // Initial update
           invalidatedQueries: new Set(),
         },
         {
-          newVersion: '101',
+          version: '101',
           fromVersion: '0a',
           invalidatedQueries: new Set(['q1']),
         },
       ],
       expectedCoalescedUpdates: [
         {
-          newVersion: '101',
+          version: '101',
           fromVersion: null,
           invalidatedQueries: new Set(['q2']),
         },
@@ -174,19 +174,19 @@ describe('invalidation-watcher', () => {
       ],
       expectedIncrementalUpdates: [
         {
-          newVersion: '0a',
+          version: '0a',
           fromVersion: null,
           invalidatedQueries: new Set(),
         },
         {
-          newVersion: '101',
+          version: '101',
           fromVersion: '0a',
           invalidatedQueries: new Set(['q1']),
         },
       ],
       expectedCoalescedUpdates: [
         {
-          newVersion: '101',
+          version: '101',
           fromVersion: null,
           invalidatedQueries: new Set(['q2']),
         },
@@ -223,19 +223,19 @@ describe('invalidation-watcher', () => {
       ],
       expectedIncrementalUpdates: [
         {
-          newVersion: '01',
+          version: '01',
           fromVersion: null,
           invalidatedQueries: new Set(),
         },
         {
-          newVersion: '101',
+          version: '101',
           fromVersion: '01',
           invalidatedQueries: new Set(['q1', 'q2']),
         },
       ],
       expectedCoalescedUpdates: [
         {
-          newVersion: '101',
+          version: '101',
           fromVersion: null,
           invalidatedQueries: new Set(['q1', 'q2']),
         },
@@ -278,29 +278,29 @@ describe('invalidation-watcher', () => {
       ],
       expectedIncrementalUpdates: [
         {
-          newVersion: '00',
+          version: '00',
           fromVersion: null,
           invalidatedQueries: new Set(),
         },
         {
-          newVersion: '01',
+          version: '01',
           fromVersion: '00',
           invalidatedQueries: new Set(['q1']),
         },
         {
-          newVersion: '0a',
+          version: '0a',
           fromVersion: '01',
           invalidatedQueries: new Set(['q2']),
         },
         {
-          newVersion: '101',
+          version: '101',
           fromVersion: '0a',
           invalidatedQueries: new Set(['q1']),
         },
       ],
       expectedCoalescedUpdates: [
         {
-          newVersion: '101',
+          version: '101',
           fromVersion: null,
           invalidatedQueries: new Set(['q1', 'q2']),
         },
@@ -349,7 +349,7 @@ describe('invalidation-watcher', () => {
       ],
       expectedIncrementalUpdates: [
         {
-          newVersion: '0a',
+          version: '0a',
           fromVersion: '01',
           // Initial update invalidates:
           // - q1 as its FOO_SPEC2 was newly registered,
@@ -357,7 +357,7 @@ describe('invalidation-watcher', () => {
           invalidatedQueries: new Set(['q1', 'q3']),
         },
         {
-          newVersion: '101',
+          version: '101',
           fromVersion: '0a',
           invalidatedQueries: new Set(['q1']),
         },
@@ -369,7 +369,7 @@ describe('invalidation-watcher', () => {
           // with the incremental update invalidating q2.
           // Note that q3 is *not* invalidated because its hash version ("01")
           // is less than or equal to fromVersion
-          newVersion: '101',
+          version: '101',
           fromVersion: '01',
           invalidatedQueries: new Set(['q1', 'q2']),
         },

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -220,7 +220,7 @@ describe('view-syncer/service', () => {
 
     await watcher.notify({
       fromVersion: null,
-      newVersion: '1xz',
+      version: '1xz',
       invalidatedQueries: new Set(),
     });
 
@@ -461,7 +461,7 @@ describe('view-syncer/service', () => {
 
     await watcher.notify({
       fromVersion: null,
-      newVersion: '1xz',
+      version: '1xz',
       invalidatedQueries: new Set(),
     });
 
@@ -626,7 +626,7 @@ describe('view-syncer/service', () => {
     await watcher.requests.dequeue();
     await watcher.notify({
       fromVersion: null,
-      newVersion: '1xz',
+      version: '1xz',
       invalidatedQueries: new Set(),
     });
 
@@ -803,7 +803,7 @@ describe('view-syncer/service', () => {
     await watcher.requests.dequeue();
     await watcher.notify({
       fromVersion: null,
-      newVersion: '1xz',
+      version: '1xz',
       invalidatedQueries: new Set(),
     });
 

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -325,10 +325,10 @@ export class ViewSyncerService implements ViewSyncer, Service {
     assert(this.#cvr);
     const cvr = this.#cvr;
 
-    const {fromVersion, newVersion, invalidatedQueries, reader} = invalidation;
+    const {fromVersion, version, invalidatedQueries, reader} = invalidation;
     const lc = this.#lc
       .withContext('fromVersion', fromVersion)
-      .withContext('newVersion', newVersion);
+      .withContext('newVersion', version);
 
     const minCVRVersion = [...this.#clients.values()]
       .map(c => c.version())
@@ -357,7 +357,7 @@ export class ViewSyncerService implements ViewSyncer, Service {
 
     lc.info?.(`Executing ${queriesToExecute.length} queries`);
 
-    const updater = new CVRQueryDrivenUpdater(this.#storage, cvr, newVersion);
+    const updater = new CVRQueryDrivenUpdater(this.#storage, cvr, version);
     // Track which queries are being executed and removed.
     const cvrVersion = updater.trackQueries(
       lc,


### PR DESCRIPTION
This is purely to facilitate readability of an upcoming change where we cache reader + version.