### PR TITLE
chore(zql): EntityQuery does not need the prefix

### DIFF
--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -1477,7 +1477,7 @@ export class Zero<QD extends QueryDefs> {
     const context = this.#zqlContext;
     // Not using parse yet
     for (const name of Object.keys(queryDefs)) {
-      rv[name] = new EntityQuery(context, name, ENTITIES_KEY_PREFIX);
+      rv[name] = new EntityQuery(context, name);
     }
 
     return rv as MakeEntityQueriesFromQueryDefs<QD>;

--- a/packages/zql/src/zql/ast-to-ivm/pipeline-builder.test.ts
+++ b/packages/zql/src/zql/ast-to-ivm/pipeline-builder.test.ts
@@ -26,11 +26,9 @@ type E1 = z.infer<typeof e1>;
 
 const context = makeTestContext();
 
-const entitiesPrefix = 'e/';
-
 const comparator = (l: E1, r: E1) => compareUTF8(l.id, r.id);
 test('A simple select', () => {
-  const q = new EntityQuery<{e1: E1}>(context, 'e1', entitiesPrefix);
+  const q = new EntityQuery<{e1: E1}>(context, 'e1');
   const m = new Materialite();
   let s = m.newSetSource<E1>(comparator);
   let pipeline = buildPipeline(
@@ -69,7 +67,7 @@ test('A simple select', () => {
 });
 
 test('Count', () => {
-  const q = new EntityQuery<{e1: E1}>(context, 'e1', entitiesPrefix);
+  const q = new EntityQuery<{e1: E1}>(context, 'e1');
   const m = new Materialite();
   const s = m.newSetSource<E1>(comparator);
   const pipeline = buildPipeline(
@@ -99,7 +97,7 @@ test('Count', () => {
 });
 
 test('Where', () => {
-  const q = new EntityQuery<{e1: E1}>(context, 'e1', entitiesPrefix);
+  const q = new EntityQuery<{e1: E1}>(context, 'e1');
   const m = new Materialite();
   const s = m.newSetSource<E1>(comparator);
   const pipeline = buildPipeline(

--- a/packages/zql/src/zql/query/entity-query.test.ts
+++ b/packages/zql/src/zql/query/entity-query.test.ts
@@ -22,8 +22,6 @@ function ast(q: WeakKey): AST {
   return rest;
 }
 
-const entitiesPrefix = 'e/';
-
 const context = makeTestContext();
 test('query types', () => {
   const sym = Symbol('sym');
@@ -36,7 +34,7 @@ test('query types', () => {
     [sym]: boolean;
   };
 
-  const q = new EntityQuery<{e1: E1}>(context, 'e1', entitiesPrefix);
+  const q = new EntityQuery<{e1: E1}>(context, 'e1');
 
   // @ts-expect-error - selecting fields that do not exist in the schema is a type error
   q.select('does-not-exist');
@@ -157,16 +155,8 @@ test('join types', () => {
     name: string;
   };
 
-  const issueQuery = new EntityQuery<{issue: Issue}>(
-    context,
-    'issue',
-    entitiesPrefix,
-  );
-  const userQuery = new EntityQuery<{user: User}>(
-    context,
-    'user',
-    entitiesPrefix,
-  );
+  const issueQuery = new EntityQuery<{issue: Issue}>(context, 'issue');
+  const userQuery = new EntityQuery<{user: User}>(context, 'user');
 
   expectTypeOf(
     issueQuery
@@ -249,16 +239,8 @@ test('left join types', () => {
     name: string;
   };
 
-  const issueQuery = new EntityQuery<{issue: Issue}>(
-    context,
-    'issue',
-    entitiesPrefix,
-  );
-  const userQuery = new EntityQuery<{user: User}>(
-    context,
-    'user',
-    entitiesPrefix,
-  );
+  const issueQuery = new EntityQuery<{issue: Issue}>(context, 'issue');
+  const userQuery = new EntityQuery<{user: User}>(context, 'user');
 
   const r1 = issueQuery
     .leftJoin(userQuery, 'owner', 'ownerId', 'id')
@@ -468,7 +450,7 @@ test('FieldValue type', () => {
     FieldAsOperatorInput<E, 'optB', 'NOT LIKE'>
   >().toEqualTypeOf<never>();
 
-  const q = new EntityQuery<E>(context, 'e', entitiesPrefix);
+  const q = new EntityQuery<E>(context, 'e');
   q.where('n', '<', 1);
   q.where('s', '>', 'a');
   q.where('b', '=', true);
@@ -523,7 +505,7 @@ const dummyObject: E1 = {
 };
 describe('ast', () => {
   test('select', () => {
-    const q = new EntityQuery<{e1: E1}>(context, 'e1', entitiesPrefix);
+    const q = new EntityQuery<{e1: E1}>(context, 'e1');
 
     // each individual field is selectable on its own
     Object.keys(dummyObject).forEach(k => {
@@ -560,7 +542,7 @@ describe('ast', () => {
   });
 
   test('where', () => {
-    let q = new EntityQuery<{e1: E1}>(context, 'e1', entitiesPrefix);
+    let q = new EntityQuery<{e1: E1}>(context, 'e1');
 
     // where is applied
     q = q.where('id', '=', 'a');
@@ -653,7 +635,7 @@ describe('ast', () => {
   });
 
   test('limit', () => {
-    const q = new EntityQuery<{e1: E1}>(context, 'e1', entitiesPrefix);
+    const q = new EntityQuery<{e1: E1}>(context, 'e1');
     expect(ast(q.limit(10))).toEqual({
       orderBy: [['id'], 'asc'],
       table: 'e1',
@@ -662,7 +644,7 @@ describe('ast', () => {
   });
 
   test('asc/desc', () => {
-    const q = new EntityQuery<{e1: E1}>(context, 'e1', entitiesPrefix);
+    const q = new EntityQuery<{e1: E1}>(context, 'e1');
 
     // order methods update the ast
     expect(ast(q.asc('id'))).toEqual({
@@ -680,7 +662,7 @@ describe('ast', () => {
   });
 
   test('independent of method call order', () => {
-    const base = new EntityQuery<{e1: E1}>(context, 'e1', entitiesPrefix);
+    const base = new EntityQuery<{e1: E1}>(context, 'e1');
 
     const calls = {
       select(q: typeof base) {
@@ -719,7 +701,7 @@ describe('ast', () => {
   });
 
   test('or', () => {
-    const q = new EntityQuery<{e1: E1}>(context, 'e1', entitiesPrefix);
+    const q = new EntityQuery<{e1: E1}>(context, 'e1');
 
     expect(ast(q.where(or(exp('a', '=', 123), exp('c', '=', 'abc'))))).toEqual({
       table: 'e1',
@@ -872,7 +854,7 @@ describe('ast', () => {
   });
 
   test('consecutive wheres/ands should be merged', () => {
-    const q = new EntityQuery<{e1: E1}>(context, 'e1', entitiesPrefix);
+    const q = new EntityQuery<{e1: E1}>(context, 'e1');
 
     expect(
       ast(
@@ -1022,7 +1004,7 @@ describe('ast', () => {
   });
 
   test('consecutive ors', () => {
-    const q = new EntityQuery<{e1: E1}>(context, 'e1', entitiesPrefix);
+    const q = new EntityQuery<{e1: E1}>(context, 'e1');
 
     expect(
       ast(q.where(or(exp('a', '=', 123), exp('a', '=', 456)))).where,
@@ -1136,7 +1118,7 @@ describe('NOT', () => {
 
     for (const c of cases) {
       test(`${c.in} -> ${c.out}`, () => {
-        const q = new EntityQuery<{e1: E1}>(context, 'e1', entitiesPrefix);
+        const q = new EntityQuery<{e1: E1}>(context, 'e1');
         expect(ast(q.where(not(exp('a', c.in, 1)))).where).toEqual({
           type: 'simple',
           op: c.out,
@@ -1223,7 +1205,7 @@ describe("De Morgan's Law", () => {
 });
 
 test('where is always qualified', () => {
-  const q = new EntityQuery<{e1: E1}>(context, 'e1', 'e1');
+  const q = new EntityQuery<{e1: E1}>(context, 'e1');
   expect(ast(q.where(exp('a', '=', 1))).where).toEqual({
     type: 'simple',
     field: 'e1.a',
@@ -1269,7 +1251,7 @@ test('where is always qualified', () => {
 });
 
 describe('all references to columns are always qualified', () => {
-  const q = new EntityQuery<{e1: E1}>(context, 'e1', 'e1');
+  const q = new EntityQuery<{e1: E1}>(context, 'e1');
   test.each([
     {
       test: 'unqalified where',
@@ -1411,8 +1393,8 @@ suite('Return type for EntityQuery', () => {
     name: string;
   };
 
-  const issueQuery = new EntityQuery<{issue: Issue}>(context, 'issue', 'e/');
-  const userQuery = new EntityQuery<{user: User}>(context, 'user', 'e/');
+  const issueQuery = new EntityQuery<{issue: Issue}>(context, 'issue');
+  const userQuery = new EntityQuery<{user: User}>(context, 'user');
 
   test('select', () => {
     const s = issueQuery.select('issue.id', 'issue.title');

--- a/packages/zql/src/zql/query/entity-query.ts
+++ b/packages/zql/src/zql/query/entity-query.ts
@@ -241,17 +241,14 @@ type SimpleCondition<
 
 export class EntityQuery<From extends FromSet, Return = []> {
   readonly #ast: AST;
-  // TODO(arv): Remove #prefix. It is not used and dealt with in the context.
-  readonly #prefix: string;
   readonly #name: string;
   readonly #context: Context;
 
-  constructor(context: Context, tableName: string, prefix: string, ast?: AST) {
+  constructor(context: Context, tableName: string, ast?: AST) {
     this.#ast = ast ?? {
       table: tableName,
       orderBy: [['id'], 'asc'],
     };
-    this.#prefix = prefix;
     this.#name = tableName;
     this.#context = context;
 
@@ -288,7 +285,6 @@ export class EntityQuery<From extends FromSet, Return = []> {
     return new EntityQuery<From, CombineSelections<From, Fields>[]>(
       this.#context,
       this.#name,
-      this.#prefix,
       {
         ...this.#ast,
         select: [...select],
@@ -313,7 +309,7 @@ export class EntityQuery<From extends FromSet, Return = []> {
     >,
     Return
   > {
-    return new EntityQuery(this.#context, this.#name, this.#prefix, {
+    return new EntityQuery(this.#context, this.#name, {
       ...this.#ast,
       joins: [
         ...(this.#ast.joins ?? []),
@@ -344,7 +340,7 @@ export class EntityQuery<From extends FromSet, Return = []> {
     >,
     Return
   > {
-    return new EntityQuery(this.#context, this.#name, this.#prefix, {
+    return new EntityQuery(this.#context, this.#name, {
       ...this.#ast,
       joins: [
         ...(this.#ast.joins ?? []),
@@ -359,27 +355,17 @@ export class EntityQuery<From extends FromSet, Return = []> {
   }
 
   groupBy<Fields extends SimpleSelector<From>[]>(...x: Fields) {
-    return new EntityQuery<From, Return>(
-      this.#context,
-      this.#name,
-      this.#prefix,
-      {
-        ...this.#ast,
-        groupBy: x as string[],
-      },
-    );
+    return new EntityQuery<From, Return>(this.#context, this.#name, {
+      ...this.#ast,
+      groupBy: x as string[],
+    });
   }
 
   distinct<Field extends SimpleSelector<From>>(field: Field) {
-    return new EntityQuery<From, Return>(
-      this.#context,
-      this.#name,
-      this.#prefix,
-      {
-        ...this.#ast,
-        distinct: field,
-      },
-    );
+    return new EntityQuery<From, Return>(this.#context, this.#name, {
+      ...this.#ast,
+      distinct: field,
+    });
   }
 
   where(expr: WhereCondition<From>): EntityQuery<From, Return>;
@@ -457,18 +443,13 @@ export class EntityQuery<From extends FromSet, Return = []> {
       };
     }
 
-    return new EntityQuery<From, Return>(
-      this.#context,
-      this.#name,
-      this.#prefix,
-      {
-        ...this.#ast,
-        // Can't use satisfies here because WhereCondition is recursive.
-        // Tests ensure that the expected AST output satisfies the Condition
-        // type.
-        [whereOrHaving]: cond as Condition,
-      },
-    );
+    return new EntityQuery<From, Return>(this.#context, this.#name, {
+      ...this.#ast,
+      // Can't use satisfies here because WhereCondition is recursive.
+      // Tests ensure that the expected AST output satisfies the Condition
+      // type.
+      [whereOrHaving]: cond as Condition,
+    });
   }
 
   limit(n: number) {
@@ -476,15 +457,10 @@ export class EntityQuery<From extends FromSet, Return = []> {
       throw new Misuse('Limit already set');
     }
 
-    return new EntityQuery<From, Return>(
-      this.#context,
-      this.#name,
-      this.#prefix,
-      {
-        ...this.#ast,
-        limit: n,
-      },
-    );
+    return new EntityQuery<From, Return>(this.#context, this.#name, {
+      ...this.#ast,
+      limit: n,
+    });
   }
 
   asc(...x: SimpleSelector<From>[]) {
@@ -492,15 +468,10 @@ export class EntityQuery<From extends FromSet, Return = []> {
       x.push('id');
     }
 
-    return new EntityQuery<From, Return>(
-      this.#context,
-      this.#name,
-      this.#prefix,
-      {
-        ...this.#ast,
-        orderBy: [x.map(x => qualifySelector(this.#ast, x)), 'asc'],
-      },
-    );
+    return new EntityQuery<From, Return>(this.#context, this.#name, {
+      ...this.#ast,
+      orderBy: [x.map(x => qualifySelector(this.#ast, x)), 'asc'],
+    });
   }
 
   desc(...x: SimpleSelector<From>[]) {
@@ -508,15 +479,10 @@ export class EntityQuery<From extends FromSet, Return = []> {
       x.push('id');
     }
 
-    return new EntityQuery<From, Return>(
-      this.#context,
-      this.#name,
-      this.#prefix,
-      {
-        ...this.#ast,
-        orderBy: [x.map(x => qualifySelector(this.#ast, x)), 'desc'],
-      },
-    );
+    return new EntityQuery<From, Return>(this.#context, this.#name, {
+      ...this.#ast,
+      orderBy: [x.map(x => qualifySelector(this.#ast, x)), 'desc'],
+    });
   }
 
   prepare(): Statement<Return> {

--- a/packages/zql/src/zql/query/order-limit.test.ts
+++ b/packages/zql/src/zql/query/order-limit.test.ts
@@ -1,5 +1,5 @@
 import {beforeEach, describe, expect, test} from 'vitest';
-import {makeTestContext, TestContext} from '../context/test-context.js';
+import {TestContext, makeTestContext} from '../context/test-context.js';
 import type {Source} from '../ivm/source/source.js';
 import {EntityQuery} from './entity-query.js';
 
@@ -15,7 +15,7 @@ describe('a limited window is correctly maintained over differences', () => {
   beforeEach(() => {
     context = makeTestContext();
     source = context.getSource<E>('e');
-    q = new EntityQuery<{e: E}>(context, 'e', 'e');
+    q = new EntityQuery<{e: E}>(context, 'e');
     Array.from({length: 10}, (_, i) => source.add({id: letters[i * 2 + 3]}));
   });
 

--- a/packages/zql/src/zql/query/statement.test.ts
+++ b/packages/zql/src/zql/query/statement.test.ts
@@ -12,11 +12,9 @@ const e1 = z.object({
 
 type E1 = z.infer<typeof e1>;
 
-const entitiesPrefix = 'e/';
-
 test('basic materialization', async () => {
   const context = makeTestContext();
-  const q = new EntityQuery<{e1: E1}>(context, 'e1', entitiesPrefix);
+  const q = new EntityQuery<{e1: E1}>(context, 'e1');
 
   const stmt = q.select('id', 'n').where('n', '>', 100).prepare();
 
@@ -48,7 +46,7 @@ test('basic materialization', async () => {
 test('sorted materialization', async () => {
   const context = makeTestContext();
   type E1 = z.infer<typeof e1>;
-  const q = new EntityQuery<{e1: E1}>(context, 'e1', entitiesPrefix);
+  const q = new EntityQuery<{e1: E1}>(context, 'e1');
   const ascStatement = q.select('id').asc('n').prepare();
   const descStatement = q.select('id').desc('n').prepare();
 
@@ -81,7 +79,7 @@ test('sorted materialization', async () => {
 test('sorting is stable via suffixing the primary key to the order', async () => {
   const context = makeTestContext();
   type E1 = z.infer<typeof e1>;
-  const q = new EntityQuery<{e1: E1}>(context, 'e1', entitiesPrefix);
+  const q = new EntityQuery<{e1: E1}>(context, 'e1');
 
   const ascStatement = q.select('id').asc('n').prepare();
   const descStatement = q.select('id').desc('n').prepare();
@@ -148,7 +146,7 @@ test('makeComparator', () => {
 
 test('destroying the statement stops updating the view', async () => {
   const context = makeTestContext();
-  const q = new EntityQuery<{e1: E1}>(context, 'e1', entitiesPrefix);
+  const q = new EntityQuery<{e1: E1}>(context, 'e1');
 
   const stmt = q.select('id', 'n').prepare();
 
@@ -176,10 +174,7 @@ test('destroying the statement stops updating the view', async () => {
 
 test('ensure we get callbacks when subscribing and unsubscribing', async () => {
   const context = makeTestContext();
-  const q = new EntityQuery<{e1: E1}>(context, 'e1', entitiesPrefix).select(
-    'id',
-    'n',
-  );
+  const q = new EntityQuery<{e1: E1}>(context, 'e1').select('id', 'n');
 
   const statement = q.prepare();
   const unsubscribe = statement.subscribe(_ => {


### PR DESCRIPTION
The prefix is only needed by the replicache subscription