### PR TITLE
feat(zero-cache): cache and resuse the last TransactionPool

### DIFF
--- a/packages/zero-cache/src/types/pg.ts
+++ b/packages/zero-cache/src/types/pg.ts
@@ -32,9 +32,6 @@ export const postgresTypeConfig = () => ({
       parse: BigIntJSON.parse,
     },
   },
-  // Named prepared statements are not supported by Hyperdrive.
-  // https://developers.cloudflare.com/hyperdrive/configuration/connect-to-postgres/#postgresjs
-  prepare: false,
 });
 
 export type PostgresDB = postgres.Sql<{


### PR DESCRIPTION
Cache the last TransactionPool, and reuse it when view syncers resubscribe when changing queries, etc. Only replace it when a new version is received from the database.

The existing reference counting logic is still used, with one extra reference for the cached instance.