### PR TITLE
fix(zero-cache): remove a cached tx pool on failure

### DIFF
--- a/packages/zero-cache/src/services/invalidation-watcher/invalidation-watcher.ts
+++ b/packages/zero-cache/src/services/invalidation-watcher/invalidation-watcher.ts
@@ -457,6 +457,16 @@ export class InvalidationWatcherService
     }
     this.#latestReader = {reader, version};
     this.#incrementRefCount(this.#latestReader, 1); // Track the #latestReader cache reference.
+
+    // Remove the reader if a transaction fails.
+    // TODO: Figure out the connection / transaction timeout issue and handle this better.
+    reader.done().catch(e => {
+      if (this.#latestReader?.reader === reader) {
+        lc.error?.(`Error from reader @${version}. Removing from cache.`, e);
+        this.#latestReader = undefined;
+      }
+    });
+
     return this.#latestReader;
   }
 


### PR DESCRIPTION
Initial measure to handle unintentionally closed transactions. Followup will be to determine what timeout causes this, and how best to handle it, whether it be a PG parameter or periodic keep-alive / refresh logic.

#1840