### PR TITLE
feat(zero-cache): TransactionPool keepalive and idle downsizing

### DIFF
--- a/packages/shared/src/queue.test.ts
+++ b/packages/shared/src/queue.test.ts
@@ -53,6 +53,23 @@ describe('Queue', () => {
     expect(await val3).toBe('c');
   });
 
+  test('dequeues timed out value', async () => {
+    const q = new Queue<string>();
+    const val1 = q.dequeue();
+    const val2 = q.dequeue('timed out', 5);
+    const val3 = q.dequeue();
+    expect(q.size()).toBe(0);
+
+    expect(await val2).toBe('timed out');
+
+    await q.enqueue('a');
+    await q.enqueue('b');
+
+    expect(await val1).toBe('a');
+    expect(await val3).toBe('b');
+    expect(q.size()).toBe(0);
+  });
+
   test('supports mixed order', async () => {
     const q = new Queue<string>();
     expect(q.size()).toBe(0);


### PR DESCRIPTION
Add periodic timeout logic to the TransactionPool to:
1. Keep initial workers alive with a `SELECT 1` keepalive ping
2. Shut down on-demand workers (initial < w < max) after an idle timeout.

To accomplish this, the core `Queue` class is augmented to support an optional timeout and value to return if nothing is produced. The timeout must be done at this level so that the consumer is removed from the Queue when this happens.

Fixes #1840