### PR TITLE
refactor(zql): move selector lifting code to `util`, add tests

### DIFF
--- a/packages/zql/src/zql/ast-to-ivm/pipeline-builder.ts
+++ b/packages/zql/src/zql/ast-to-ivm/pipeline-builder.ts
@@ -13,7 +13,8 @@ import type {
   SimpleHavingCondition,
 } from '../ast/ast.js';
 import {DifferenceStream, concat} from '../ivm/graph/difference-stream.js';
-import {isJoinResult, StringOrNumber} from '../ivm/types.js';
+import {getValueFromEntity} from '../ivm/source/util.js';
+import type {StringOrNumber} from '../ivm/types.js';
 
 function getId(e: Entity) {
   return e.id;
@@ -494,36 +495,4 @@ function patternToRegExp(source: string, flags: '' | 'i' = ''): RegExp {
     }
   }
   return new RegExp(pattern + '$', flags);
-}
-
-export function getValueFromEntity(
-  entity: Record<string, unknown>,
-  qualifiedColumn: readonly [table: string | null, column: string],
-) {
-  if (isJoinResult(entity) && qualifiedColumn[0] !== null) {
-    if (qualifiedColumn[1] === '*') {
-      return (entity as Record<string, unknown>)[qualifiedColumn[0]];
-    }
-    return getOrLiftValue(
-      (entity as Record<string, unknown>)[must(qualifiedColumn[0])] as Record<
-        string,
-        unknown
-      >,
-      qualifiedColumn[1],
-    );
-  }
-  return getOrLiftValue(entity, qualifiedColumn[1]);
-}
-
-export function getOrLiftValue(
-  containerOrValue:
-    | Record<string, unknown>
-    | Array<Record<string, unknown>>
-    | undefined,
-  field: string,
-) {
-  if (Array.isArray(containerOrValue)) {
-    return containerOrValue.map(x => x?.[field]);
-  }
-  return containerOrValue?.[field];
 }

--- a/packages/zql/src/zql/ivm/graph/operators/full-agg-operators.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/full-agg-operators.ts
@@ -1,6 +1,6 @@
-import {getValueFromEntity} from '../../../ast-to-ivm/pipeline-builder.js';
 import type {Selector} from '../../../ast/ast.js';
 import type {Multiset} from '../../multiset.js';
+import {getValueFromEntity} from '../../source/util.js';
 import type {DifferenceStream} from '../difference-stream.js';
 import {LinearUnaryOperator} from './linear-unary-operator.js';
 

--- a/packages/zql/src/zql/ivm/source/util.test.ts
+++ b/packages/zql/src/zql/ivm/source/util.test.ts
@@ -1,0 +1,45 @@
+import {expect, test} from 'vitest';
+import {joinSymbol} from '../types.js';
+import {getOrLiftValue, getValueFromEntity} from './util.js';
+
+test('getValueFromEntity#normalSelect', () => {
+  const entity = {
+    b: 1,
+    c: 2,
+  };
+  const qualifiedColumn = ['a', 'b'] as const;
+  const result = getValueFromEntity(entity, qualifiedColumn);
+  expect(result).toEqual(1);
+});
+
+test('getValueFromEntity#joinResult', () => {
+  const entity = {
+    [joinSymbol]: true,
+    a: {
+      b: 1,
+      c: 2,
+    },
+  };
+  const qualifiedColumn = ['a', 'b'] as const;
+  const result = getValueFromEntity(entity, qualifiedColumn);
+  expect(result).toEqual(1);
+});
+
+test('getValueFromEntity: joinResult with *', () => {
+  const entity = {
+    [joinSymbol]: true,
+    a: {
+      b: 1,
+      c: 2,
+    },
+  };
+  const qualifiedColumn = ['a', '*'] as const;
+  const result = getValueFromEntity(entity, qualifiedColumn);
+  expect(result).toEqual(entity.a);
+});
+
+test('lift field from array', () => {
+  const entities = [{b: 1}, {b: 2}];
+  const result = getOrLiftValue(entities, 'b');
+  expect(result).toEqual([1, 2]);
+});

--- a/packages/zql/src/zql/ivm/source/util.ts
+++ b/packages/zql/src/zql/ivm/source/util.ts
@@ -1,4 +1,6 @@
+import {must} from 'shared/src/must.js';
 import type {Ordering, Selector} from '../../ast/ast.js';
+import {isJoinResult} from '../types.js';
 
 export function sourcesAreIdentical(
   sourceAName: string,
@@ -25,4 +27,36 @@ export function sourcesAreIdentical(
 
 export function selectorsAreEqual(l: Selector, r: Selector) {
   return l[0] === r[0] && l[1] === r[1];
+}
+
+export function getValueFromEntity(
+  entity: Record<string, unknown>,
+  qualifiedColumn: readonly [table: string | null, column: string],
+) {
+  if (isJoinResult(entity) && qualifiedColumn[0] !== null) {
+    if (qualifiedColumn[1] === '*') {
+      return (entity as Record<string, unknown>)[qualifiedColumn[0]];
+    }
+    return getOrLiftValue(
+      (entity as Record<string, unknown>)[must(qualifiedColumn[0])] as Record<
+        string,
+        unknown
+      >,
+      qualifiedColumn[1],
+    );
+  }
+  return getOrLiftValue(entity, qualifiedColumn[1]);
+}
+
+export function getOrLiftValue(
+  containerOrValue:
+    | Record<string, unknown>
+    | Array<Record<string, unknown>>
+    | undefined,
+  field: string,
+) {
+  if (Array.isArray(containerOrValue)) {
+    return containerOrValue.map(x => x?.[field]);
+  }
+  return containerOrValue?.[field];
 }

--- a/packages/zql/src/zql/query/statement.ts
+++ b/packages/zql/src/zql/query/statement.ts
@@ -1,14 +1,12 @@
 import {assert} from 'shared/src/asserts.js';
 import type {Entity} from '../../entity.js';
-import {
-  buildPipeline,
-  getValueFromEntity,
-} from '../ast-to-ivm/pipeline-builder.js';
+import {buildPipeline} from '../ast-to-ivm/pipeline-builder.js';
 import type {AST, Ordering, Selector} from '../ast/ast.js';
 import type {Context} from '../context/context.js';
 import {compareEntityFields} from '../ivm/compare.js';
 import type {DifferenceStream} from '../ivm/graph/difference-stream.js';
 import type {Source} from '../ivm/source/source.js';
+import {getValueFromEntity} from '../ivm/source/util.js';
 import {TreeView} from '../ivm/view/tree-view.js';
 import type {View} from '../ivm/view/view.js';
 import type {MakeHumanReadable} from './entity-query.js';


### PR DESCRIPTION
For `join` to produce the information `group-by` needs to optimize itself, `join` needs to be aware of what it is joining. In other words, we can no longer pass in `lambdas` to pull the join key.

E.g.,

We need to do:

```
new JoinOperator(aSelector: Selector[], bSelector: Selector[])`
```

instead of:

```
new JoinOperator(aSelector: a => a.key, bSelector: b => b.key)
```

Which means these functions need to be used by join. Moving them to somewhere common.