### PR TITLE
refactor(zql): add an alias for pipeline types

### DIFF
--- a/packages/zql/src/zql/context/test-context.ts
+++ b/packages/zql/src/zql/context/test-context.ts
@@ -10,12 +10,12 @@ import {
 } from '../ivm/materialite.js';
 import type {Entry} from '../ivm/multiset.js';
 import type {Source, SourceInternal} from '../ivm/source/source.js';
-import type {Version} from '../ivm/types.js';
+import type {PipelineEntity, Version} from '../ivm/types.js';
 import type {Context} from './context.js';
 
 export class TestContext implements Context {
   readonly materialite = new Materialite();
-  readonly #sources = new Map<string, Source<object>>();
+  readonly #sources = new Map<string, Source<PipelineEntity>>();
 
   subscriptionsChangedLog: {type: 'added' | 'removed'; ast: AST}[] = [];
 
@@ -25,7 +25,7 @@ export class TestContext implements Context {
         (l: T, r: T) => compareUTF8(l.id, r.id),
         [[[name, 'id']], 'asc'],
         name,
-      ) as unknown as Source<object>;
+      ) as unknown as Source<PipelineEntity>;
       source.seed([]);
       this.#sources.set(name, source);
     }
@@ -46,10 +46,10 @@ type Gen<T> = {
 };
 export class InfiniteSourceContext implements Context {
   readonly materialite = new Materialite();
-  readonly #sources = new Map<string, Source<object>>();
-  readonly #generators = new Map<string, Gen<object>>();
+  readonly #sources = new Map<string, Source<PipelineEntity>>();
+  readonly #generators = new Map<string, Gen<PipelineEntity>>();
 
-  constructor(generators: Map<string, Gen<object>>) {
+  constructor(generators: Map<string, Gen<PipelineEntity>>) {
     this.#generators = generators;
   }
 
@@ -59,7 +59,7 @@ export class InfiniteSourceContext implements Context {
       return existing as unknown as Source<X>;
     }
 
-    let source: Source<object>;
+    let source: Source<PipelineEntity>;
     if (this.#generators.has(name)) {
       source = this.materialite.constructSource(
         internal =>
@@ -70,7 +70,7 @@ export class InfiniteSourceContext implements Context {
         (l: X, r: X) => compareUTF8(l.id, r.id),
         [[[name, 'id']], 'asc'],
         name,
-      ) as unknown as Source<object>;
+      ) as unknown as Source<PipelineEntity>;
       source.seed([]);
       this.#sources.set(name, source);
     }
@@ -89,12 +89,12 @@ export function makeTestContext(): TestContext {
 }
 
 export function makeInfiniteSourceContext(
-  generators: Map<string, Gen<object>>,
+  generators: Map<string, Gen<PipelineEntity>>,
 ): InfiniteSourceContext {
   return new InfiniteSourceContext(generators);
 }
 
-class InfiniteSuorce<T extends object> implements Source<T> {
+class InfiniteSuorce<T extends PipelineEntity> implements Source<T> {
   readonly #materialite: MaterialiteForSourceInternal;
   readonly #stream: DifferenceStream<T>;
   readonly #internal: SourceInternal;

--- a/packages/zql/src/zql/ivm/graph/difference-stream.ts
+++ b/packages/zql/src/zql/ivm/graph/difference-stream.ts
@@ -2,7 +2,12 @@ import {assert} from 'shared/src/asserts.js';
 import type {Entity} from '../../../entity.js';
 import type {Primitive, Selector} from '../../ast/ast.js';
 import type {Multiset} from '../multiset.js';
-import type {JoinResult, StringOrNumber, Version} from '../types.js';
+import type {
+  JoinResult,
+  PipelineEntity,
+  StringOrNumber,
+  Version,
+} from '../types.js';
 import type {Reply, Request} from './message.js';
 import {ConcatOperator} from './operators/concat-operator.js';
 import {DebugOperator} from './operators/debug-operator.js';
@@ -58,7 +63,7 @@ export type Listener<T> = {
  */
 // T extends object: I believe in the context of ZQL we only deal with object.
 let id = 0;
-export class DifferenceStream<T extends object> {
+export class DifferenceStream<T extends PipelineEntity> {
   /**
    * Operators that are listening to this stream.
    */
@@ -130,7 +135,7 @@ export class DifferenceStream<T extends object> {
     }
   }
 
-  map<O extends object>(f: (value: T) => O): DifferenceStream<O> {
+  map<O extends PipelineEntity>(f: (value: T) => O): DifferenceStream<O> {
     const stream = new DifferenceStream<O>();
     return stream.setUpstream(new MapOperator<T, O>(this, stream, f));
   }
@@ -159,7 +164,7 @@ export class DifferenceStream<T extends object> {
     return stream.setUpstream(new DistinctAllOperator<T>(this, stream, keyFn));
   }
 
-  reduce<K extends Primitive, O extends object>(
+  reduce<K extends Primitive, O extends PipelineEntity>(
     getKey: (value: T) => K,
     getIdentity: (value: T) => string,
     f: (input: Iterable<T>) => O,
@@ -172,7 +177,7 @@ export class DifferenceStream<T extends object> {
 
   leftJoin<
     Key extends Primitive,
-    BValue extends object,
+    BValue extends PipelineEntity,
     AAlias extends string | undefined,
     BAlias extends string | undefined,
   >(
@@ -192,7 +197,7 @@ export class DifferenceStream<T extends object> {
 
   join<
     Key extends Primitive,
-    BValue extends object,
+    BValue extends PipelineEntity,
     AAlias extends string | undefined,
     BAlias extends string | undefined,
   >(
@@ -279,7 +284,7 @@ export class DifferenceStream<T extends object> {
   }
 }
 
-export function concat<T extends object>(
+export function concat<T extends PipelineEntity>(
   streams: DifferenceStream<T>[],
 ): DifferenceStream<T> {
   const stream = new DifferenceStream<T>();

--- a/packages/zql/src/zql/ivm/graph/operators/binary-operator.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/binary-operator.ts
@@ -1,13 +1,13 @@
 import type {Multiset} from '../../multiset.js';
-import type {Version} from '../../types.js';
+import type {PipelineEntity, Version} from '../../types.js';
 import type {DifferenceStream, Listener} from '../difference-stream.js';
 import type {Request} from '../message.js';
 import {OperatorBase} from './operator.js';
 
 export class BinaryOperator<
-  I1 extends object,
-  I2 extends object,
-  O extends object,
+  I1 extends PipelineEntity,
+  I2 extends PipelineEntity,
+  O extends PipelineEntity,
 > extends OperatorBase<O> {
   readonly #listener1: Listener<I1>;
   readonly #input1: DifferenceStream<I1>;

--- a/packages/zql/src/zql/ivm/graph/operators/concat-operator.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/concat-operator.ts
@@ -4,6 +4,7 @@ import {makeComparator} from '../../../query/statement.js';
 import {gen, iterInOrder} from '../../../util/iterables.js';
 import type {Multiset} from '../../multiset.js';
 import {sourcesAreIdentical} from '../../source/util.js';
+import type {PipelineEntity} from '../../types.js';
 import type {DifferenceStream, Listener} from '../difference-stream.js';
 import type {PullMsg, Reply} from '../message.js';
 import type {Operator} from './operator.js';
@@ -15,7 +16,7 @@ let id = 0;
  * one outgoing edge (write handle). It just sends all the input messages from
  * all the incoming operator to the output operators.
  */
-export class ConcatOperator<T extends object> implements Operator {
+export class ConcatOperator<T extends PipelineEntity> implements Operator {
   readonly #listener: Listener<T>;
   readonly #inputs: DifferenceStream<T>[];
   readonly #output: DifferenceStream<T>;

--- a/packages/zql/src/zql/ivm/graph/operators/debug-operator.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/debug-operator.ts
@@ -1,5 +1,5 @@
 import type {Multiset} from '../../multiset.js';
-import type {Version} from '../../types.js';
+import type {PipelineEntity, Version} from '../../types.js';
 import type {DifferenceStream} from '../difference-stream.js';
 import {UnaryOperator} from './unary-operator.js';
 
@@ -7,7 +7,10 @@ import {UnaryOperator} from './unary-operator.js';
  * Allows someone to observe all data flowing through a spot
  * in a pipeline. Forwards the data with no changes made to it.
  */
-export class DebugOperator<T extends object> extends UnaryOperator<T, T> {
+export class DebugOperator<T extends PipelineEntity> extends UnaryOperator<
+  T,
+  T
+> {
   constructor(
     input: DifferenceStream<T>,
     output: DifferenceStream<T>,

--- a/packages/zql/src/zql/ivm/graph/operators/difference-effect-operator.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/difference-effect-operator.ts
@@ -1,5 +1,5 @@
 import type {Multiset} from '../../multiset.js';
-import type {Version} from '../../types.js';
+import type {PipelineEntity, Version} from '../../types.js';
 import type {DifferenceStream} from '../difference-stream.js';
 import {UnaryOperator} from './unary-operator.js';
 
@@ -10,10 +10,9 @@ import {UnaryOperator} from './unary-operator.js';
  * to be run on changes to a query without having to materialize the query
  * results.
  */
-export class DifferenceEffectOperator<T extends object> extends UnaryOperator<
-  T,
-  T
-> {
+export class DifferenceEffectOperator<
+  T extends PipelineEntity,
+> extends UnaryOperator<T, T> {
   readonly #f: (input: T, mult: number) => void;
   #collected: Multiset<T>[] = [];
 

--- a/packages/zql/src/zql/ivm/graph/operators/distinct-operator.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/distinct-operator.ts
@@ -1,7 +1,7 @@
 import type {Entity} from '../../../../entity.js';
 import {genCached, genFilter, genMap} from '../../../util/iterables.js';
 import type {Entry, Multiset} from '../../multiset.js';
-import type {StringOrNumber, Version} from '../../types.js';
+import type {PipelineEntity, StringOrNumber, Version} from '../../types.js';
 import type {DifferenceStream} from '../difference-stream.js';
 import type {Request} from '../message.js';
 import {UnaryOperator} from './unary-operator.js';
@@ -103,7 +103,9 @@ export class DistinctOperator<T extends Entity> extends UnaryOperator<T, T> {
   }
 }
 
-export class DistinctAllOperator<T extends object> extends UnaryOperator<T, T> {
+export class DistinctAllOperator<
+  T extends PipelineEntity,
+> extends UnaryOperator<T, T> {
   #entriesCache = new Map<StringOrNumber, Entry<T>>();
   #keyFn;
 

--- a/packages/zql/src/zql/ivm/graph/operators/filter-operator.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/filter-operator.ts
@@ -1,12 +1,12 @@
 import {genFilter} from '../../../util/iterables.js';
 import type {Multiset} from '../../multiset.js';
+import type {PipelineEntity} from '../../types.js';
 import type {DifferenceStream} from '../difference-stream.js';
 import {LinearUnaryOperator} from './linear-unary-operator.js';
 
-export class FilterOperator<I extends object> extends LinearUnaryOperator<
-  I,
-  I
-> {
+export class FilterOperator<
+  I extends PipelineEntity,
+> extends LinearUnaryOperator<I, I> {
   constructor(
     input: DifferenceStream<I>,
     output: DifferenceStream<I>,

--- a/packages/zql/src/zql/ivm/graph/operators/full-agg-operators.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/full-agg-operators.ts
@@ -5,14 +5,14 @@ import type {DifferenceStream} from '../difference-stream.js';
 import {LinearUnaryOperator} from './linear-unary-operator.js';
 
 export type AggregateOut<
-  V extends object,
+  V extends Record<string, unknown>,
   AggregateResult extends [string, unknown][],
 > = V & {
   [K in AggregateResult[number][0]]: AggregateResult[number][1];
 };
 
 class FullAggregateOperator<
-  V extends object,
+  V extends Record<string, unknown>,
   AggregateResult extends [string, unknown][],
 > extends LinearUnaryOperator<V, AggregateOut<V, AggregateResult>> {
   #lastOutput: AggregateOut<V, AggregateResult> | undefined;
@@ -60,7 +60,7 @@ class FullAggregateOperator<
 }
 
 export class FullCountOperator<
-  V extends object,
+  V extends Record<string, unknown>,
   Alias extends string,
 > extends FullAggregateOperator<V, [[Alias, number]]> {
   #count = 0;
@@ -90,7 +90,7 @@ export class FullCountOperator<
 }
 
 export class FullAvgOperator<
-  V extends object,
+  V extends Record<string, unknown>,
   Alias extends string,
 > extends FullAggregateOperator<V, [[Alias, number]]> {
   #numElements = 0;
@@ -139,7 +139,7 @@ export class FullAvgOperator<
 }
 
 export class FullSumOperator<
-  V extends object,
+  V extends Record<string, unknown>,
   Alias extends string,
 > extends FullAggregateOperator<V, [[Alias, number]]> {
   #sum = 0;

--- a/packages/zql/src/zql/ivm/graph/operators/join-operator-base.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/join-operator-base.ts
@@ -1,15 +1,15 @@
 import {assert} from 'shared/src/asserts.js';
 import type {Multiset} from '../../multiset.js';
-import type {Version} from '../../types.js';
+import type {PipelineEntity, Version} from '../../types.js';
 import type {DifferenceStream, Listener} from '../difference-stream.js';
 
 import type {Reply, Request} from '../message.js';
 import {OperatorBase} from './operator.js';
 
 export class JoinOperatorBase<
-  AValue extends object,
-  BValue extends object,
-  O extends object,
+  AValue extends PipelineEntity,
+  BValue extends PipelineEntity,
+  O extends PipelineEntity,
 > extends OperatorBase<O> {
   readonly #listenerA: Listener<AValue>;
   readonly #inputA: DifferenceStream<AValue>;

--- a/packages/zql/src/zql/ivm/graph/operators/join-operator.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/join-operator.ts
@@ -1,15 +1,20 @@
 import type {Primitive} from '../../../ast/ast.js';
 import {genCached, genConcat, genFlatMap} from '../../../util/iterables.js';
 import type {Entry, Multiset} from '../../multiset.js';
-import type {JoinResult, StringOrNumber, Version} from '../../types.js';
+import type {
+  JoinResult,
+  PipelineEntity,
+  StringOrNumber,
+  Version,
+} from '../../types.js';
 import type {DifferenceStream} from '../difference-stream.js';
 import {combineRows, DifferenceIndex} from './difference-index.js';
 import {JoinOperatorBase} from './join-operator-base.js';
 
 export type JoinArgs<
   Key extends Primitive,
-  AValue extends object,
-  BValue extends object,
+  AValue extends PipelineEntity,
+  BValue extends PipelineEntity,
   AAlias extends string | undefined,
   BAlias extends string | undefined,
 > = {
@@ -47,8 +52,8 @@ export type JoinArgs<
  */
 export class InnerJoinOperator<
   K extends Primitive,
-  AValue extends object,
-  BValue extends object,
+  AValue extends PipelineEntity,
+  BValue extends PipelineEntity,
   AAlias extends string | undefined,
   BAlias extends string | undefined,
 > extends JoinOperatorBase<

--- a/packages/zql/src/zql/ivm/graph/operators/left-join-operator.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/left-join-operator.ts
@@ -4,6 +4,7 @@ import type {Entry, Multiset} from '../../multiset.js';
 import {
   isJoinResult,
   JoinResult,
+  PipelineEntity,
   StringOrNumber,
   Version,
 } from '../../types.js';
@@ -13,8 +14,8 @@ import type {JoinArgs} from './join-operator.js';
 
 export class LeftJoinOperator<
   K extends Primitive,
-  AValue extends object,
-  BValue extends object,
+  AValue extends PipelineEntity,
+  BValue extends PipelineEntity,
   AAlias extends string | undefined,
   BAlias extends string | undefined,
 > extends JoinOperatorBase<

--- a/packages/zql/src/zql/ivm/graph/operators/linear-unary-operator.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/linear-unary-operator.ts
@@ -1,5 +1,5 @@
 import type {Multiset} from '../../multiset.js';
-import type {Version} from '../../types.js';
+import type {PipelineEntity, Version} from '../../types.js';
 import type {DifferenceStream} from '../difference-stream.js';
 import {UnaryOperator} from './unary-operator.js';
 
@@ -16,8 +16,8 @@ import {UnaryOperator} from './unary-operator.js';
  * computations.
  */
 export class LinearUnaryOperator<
-  I extends object,
-  O extends object,
+  I extends PipelineEntity,
+  O extends PipelineEntity,
 > extends UnaryOperator<I, O> {
   constructor(
     input: DifferenceStream<I>,

--- a/packages/zql/src/zql/ivm/graph/operators/map-operator.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/map-operator.ts
@@ -1,11 +1,12 @@
 import {genMap} from '../../../util/iterables.js';
 import type {Multiset} from '../../multiset.js';
+import type {PipelineEntity} from '../../types.js';
 import type {DifferenceStream} from '../difference-stream.js';
 import {LinearUnaryOperator} from './linear-unary-operator.js';
 
 export class MapOperator<
-  I extends object,
-  O extends object,
+  I extends PipelineEntity,
+  O extends PipelineEntity,
 > extends LinearUnaryOperator<I, O> {
   constructor(
     input: DifferenceStream<I>,

--- a/packages/zql/src/zql/ivm/graph/operators/operator.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/operator.ts
@@ -1,4 +1,4 @@
-import type {Version} from '../../types.js';
+import type {PipelineEntity, Version} from '../../types.js';
 import type {DifferenceStream} from '../difference-stream.js';
 import type {Request} from '../message.js';
 
@@ -23,7 +23,9 @@ export class NoOp implements Operator {
  * A dataflow operator (node) that has many incoming edges (stream) and one outgoing edge (stream).
  */
 let id = 0;
-export abstract class OperatorBase<O extends object> implements Operator {
+export abstract class OperatorBase<O extends PipelineEntity>
+  implements Operator
+{
   // downstream output
   readonly #output: DifferenceStream<O>;
   #lastCommit = -1;

--- a/packages/zql/src/zql/ivm/graph/operators/reduce-operator.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/reduce-operator.ts
@@ -2,7 +2,7 @@ import {assert} from 'shared/src/asserts.js';
 import type {Primitive} from '../../../ast/ast.js';
 import {genCached, genFlatMap} from '../../../util/iterables.js';
 import type {Entry, Multiset} from '../../multiset.js';
-import type {StringOrNumber} from '../../types.js';
+import type {PipelineEntity, StringOrNumber} from '../../types.js';
 import type {DifferenceStream} from '../difference-stream.js';
 import {UnaryOperator} from './unary-operator.js';
 
@@ -20,8 +20,8 @@ import {UnaryOperator} from './unary-operator.js';
  */
 export class ReduceOperator<
   K extends Primitive,
-  V extends object,
-  O extends object = V,
+  V extends PipelineEntity,
+  O extends PipelineEntity = V,
 > extends UnaryOperator<V, O> {
   /**
    * The set of all values that have been seen for a given key.

--- a/packages/zql/src/zql/ivm/graph/operators/unary-operator.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/unary-operator.ts
@@ -1,5 +1,5 @@
 import type {Multiset} from '../../multiset.js';
-import type {Version} from '../../types.js';
+import type {PipelineEntity, Version} from '../../types.js';
 import type {DifferenceStream, Listener} from '../difference-stream.js';
 import type {Request} from '../message.js';
 import type {Operator} from './operator.js';
@@ -8,7 +8,7 @@ import {OperatorBase} from './operator.js';
 /**
  * Operator that only takes a single argument
  */
-export class UnaryOperator<I extends object, O extends object>
+export class UnaryOperator<I extends PipelineEntity, O extends PipelineEntity>
   extends OperatorBase<O>
   implements Operator
 {

--- a/packages/zql/src/zql/ivm/materialite.ts
+++ b/packages/zql/src/zql/ivm/materialite.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore next.js is having issues finding the .d.ts
-import type {Comparator} from './types.js';
+import type {Comparator, PipelineEntity} from './types.js';
 import {must} from 'shared/src/must.js';
 import {SetSource} from './source/set-source.js';
 import type {Ordering} from '../ast/ast.js';
@@ -41,7 +41,7 @@ export class Materialite {
     };
   }
 
-  newSetSource<T extends object>(
+  newSetSource<T extends PipelineEntity>(
     comparator: Comparator<T>,
     order: Ordering,
     name: string,
@@ -49,7 +49,7 @@ export class Materialite {
     return new SetSource<T>(this.#internal, comparator, order, name);
   }
 
-  constructSource<T extends object>(
+  constructSource<T extends PipelineEntity>(
     ctor: (internal: MaterialiteForSourceInternal) => Source<T>,
   ) {
     return ctor(this.#internal);

--- a/packages/zql/src/zql/ivm/source/set-source.ts
+++ b/packages/zql/src/zql/ivm/source/set-source.ts
@@ -5,7 +5,7 @@ import {DifferenceStream} from '../graph/difference-stream.js';
 import {createPullResponseMessage, PullMsg, Request} from '../graph/message.js';
 import type {MaterialiteForSourceInternal} from '../materialite.js';
 import type {Entry, Multiset} from '../multiset.js';
-import type {Comparator, Version} from '../types.js';
+import type {Comparator, PipelineEntity, Version} from '../types.js';
 import type {Source, SourceInternal} from './source.js';
 import type {ISortedMap} from 'sorted-btree-roci';
 import BTree from 'sorted-btree-roci';
@@ -18,7 +18,7 @@ import BTree from 'sorted-btree-roci';
  *
  */
 let id = 0;
-export class SetSource<T extends object> implements Source<T> {
+export class SetSource<T extends PipelineEntity> implements Source<T> {
   readonly #stream: DifferenceStream<T>;
   readonly #internal: SourceInternal;
   readonly #listeners = new Set<

--- a/packages/zql/src/zql/ivm/source/source.ts
+++ b/packages/zql/src/zql/ivm/source/source.ts
@@ -1,8 +1,8 @@
 import type {DifferenceStream} from '../graph/difference-stream.js';
-import type {Version} from '../types.js';
+import type {PipelineEntity, Version} from '../types.js';
 import type {Request} from '../graph/message.js';
 
-export interface Source<T extends object> {
+export interface Source<T extends PipelineEntity> {
   readonly stream: DifferenceStream<T>;
   add(value: T): this;
   delete(value: T): this;

--- a/packages/zql/src/zql/ivm/types.ts
+++ b/packages/zql/src/zql/ivm/types.ts
@@ -8,6 +8,8 @@ type JoinResultBase = {
   [joinSymbol]: true;
 };
 
+export type PipelineEntity = Record<string, unknown>;
+
 export type Comparator<T> = (l: T, r: T) => number;
 
 export type JoinResult<

--- a/packages/zql/src/zql/ivm/view/abstract-view.ts
+++ b/packages/zql/src/zql/ivm/view/abstract-view.ts
@@ -3,10 +3,12 @@ import type {DifferenceStream, Listener} from '../graph/difference-stream.js';
 import type {Reply} from '../graph/message.js';
 import type {Materialite} from '../materialite.js';
 import type {Multiset} from '../multiset.js';
-import type {Version} from '../types.js';
+import type {PipelineEntity, Version} from '../types.js';
 import type {View} from './view.js';
 
-export abstract class AbstractView<T extends object, CT> implements View<CT> {
+export abstract class AbstractView<T extends PipelineEntity, CT>
+  implements View<CT>
+{
   readonly #context: Context;
   readonly #stream;
   protected readonly _listener: Listener<T>;

--- a/packages/zql/src/zql/ivm/view/tree-view.ts
+++ b/packages/zql/src/zql/ivm/view/tree-view.ts
@@ -6,7 +6,7 @@ import type {DifferenceStream} from '../graph/difference-stream.js';
 import {createPullMessage, Reply} from '../graph/message.js';
 import type {Entry, Multiset} from '../multiset.js';
 import {selectorsAreEqual} from '../source/util.js';
-import type {Comparator} from '../types.js';
+import type {Comparator, PipelineEntity} from '../types.js';
 import {AbstractView} from './abstract-view.js';
 import {must} from 'shared/src/must.js';
 
@@ -20,7 +20,7 @@ import {must} from 'shared/src/must.js';
  * of the tree.
  */
 let id = 0;
-export class TreeView<T extends object> extends AbstractView<T, T[]> {
+export class TreeView<T extends PipelineEntity> extends AbstractView<T, T[]> {
   #data: BTree<T, undefined>;
 
   #jsSlice: T[] = [];


### PR DESCRIPTION
In case we need to change this type again we can just change the alias.

Updating it from `object` to `Record<string, unknown>` since operators will now need to select fields directly off of their inputs rather than relying on a lambda to do it for them. See https://github.com/rocicorp/mono/pull/1868 for an example. We also need to push the selectors down into `filter` so we can start hoisting filters to the source for efficient pagination & first query run.