### PR TITLE
chore(zql): make join aware of fields being accessed

### DIFF
--- a/packages/zql/src/zql/ivm/graph/difference-stream.ts
+++ b/packages/zql/src/zql/ivm/graph/difference-stream.ts
@@ -176,12 +176,11 @@ export class DifferenceStream<T extends PipelineEntity> {
   }
 
   leftJoin<
-    Key extends Primitive,
     BValue extends PipelineEntity,
     AAlias extends string | undefined,
     BAlias extends string | undefined,
   >(
-    args: Omit<JoinArgs<Key, T, BValue, AAlias, BAlias>, 'a' | 'output'>,
+    args: Omit<JoinArgs<T, BValue, AAlias, BAlias>, 'a' | 'output'>,
   ): DifferenceStream<JoinResult<T, BValue, AAlias, BAlias>> {
     const stream = new DifferenceStream<
       JoinResult<T, BValue, AAlias, BAlias>
@@ -196,12 +195,11 @@ export class DifferenceStream<T extends PipelineEntity> {
   }
 
   join<
-    Key extends Primitive,
     BValue extends PipelineEntity,
     AAlias extends string | undefined,
     BAlias extends string | undefined,
   >(
-    args: Omit<JoinArgs<Key, T, BValue, AAlias, BAlias>, 'a' | 'output'>,
+    args: Omit<JoinArgs<T, BValue, AAlias, BAlias>, 'a' | 'output'>,
   ): DifferenceStream<JoinResult<T, BValue, AAlias, BAlias>> {
     const stream = new DifferenceStream<
       JoinResult<T, BValue, AAlias, BAlias>

--- a/packages/zql/src/zql/ivm/graph/operators/join-operator.test.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/join-operator.test.ts
@@ -33,13 +33,15 @@ test('unbalanced input', () => {
   const albumInput = new DifferenceStream<Album>();
 
   const output = trackInput.join({
-    aAs: 'track',
-    getAJoinKey: track => track.albumId,
-    getAPrimaryKey: track => track.id,
+    aTable: 'track',
+    aPrimaryKeyColumns: ['id'],
+    aJoinColumn: ['track', 'albumId'],
+
     b: albumInput,
+    bTable: 'album',
     bAs: 'album',
-    getBJoinKey: album => album.id,
-    getBPrimaryKey: album => album.id,
+    bPrimaryKeyColumns: ['id'],
+    bJoinColumn: ['album', 'id'],
   });
 
   const items: [JoinResult<Track, Album, 'track', 'album'>, number][] = [];
@@ -185,13 +187,15 @@ test('basic join', () => {
   const albumInput = new DifferenceStream<Album>();
 
   const output = trackInput.join({
-    aAs: 'track',
-    getAJoinKey: track => track.albumId,
-    getAPrimaryKey: track => track.id,
+    aTable: 'track',
+    aPrimaryKeyColumns: ['id'],
+    aJoinColumn: ['track', 'albumId'],
+
     b: albumInput,
+    bTable: 'album',
     bAs: 'album',
-    getBJoinKey: album => album.id,
-    getBPrimaryKey: album => album.id,
+    bPrimaryKeyColumns: ['id'],
+    bJoinColumn: ['album', 'id'],
   });
 
   const items: [JoinResult<Track, Album, 'track', 'album'>, number][] = [];
@@ -264,24 +268,27 @@ test('join through a junction table', () => {
   const artistInput = new DifferenceStream<Artist>();
 
   const trackAndTrackArtistOutput = trackInput.join({
-    aAs: 'track',
-    getAJoinKey: track => track.id,
-    getAPrimaryKey: track => track.id,
+    aTable: 'track',
+    aPrimaryKeyColumns: ['id'],
+    aJoinColumn: ['track', 'id'],
+
     b: trackArtistInput,
+    bTable: 'trackArtist',
     bAs: 'trackArtist',
-    getBJoinKey: trackArtist => trackArtist.trackId,
-    getBPrimaryKey: trackArtist =>
-      trackArtist.trackId + '-' + trackArtist.artistId,
+    bPrimaryKeyColumns: ['trackId', 'artistId'],
+    bJoinColumn: ['trackArtist', 'trackId'],
   });
 
   const output = trackAndTrackArtistOutput.join({
-    aAs: undefined,
-    getAJoinKey: x => x.trackArtist.artistId,
-    getAPrimaryKey: x => x.id,
+    aTable: undefined,
+    aPrimaryKeyColumns: ['id'],
+    aJoinColumn: ['trackArtist', 'artistId'],
+
     b: artistInput,
+    bTable: 'artist',
     bAs: 'artist',
-    getBJoinKey: x => x.id,
-    getBPrimaryKey: x => x.id,
+    bPrimaryKeyColumns: ['id'],
+    bJoinColumn: ['artist', 'id'],
   });
 
   const items: [
@@ -618,24 +625,27 @@ test('add many items to the same source as separate calls in the same tick', () 
   const artistInput = new DifferenceStream<Artist>();
 
   const trackAndTrackArtistOutput = trackInput.join({
-    aAs: 'track',
-    getAJoinKey: track => track.id,
-    getAPrimaryKey: track => track.id,
+    aTable: 'track',
+    aPrimaryKeyColumns: ['id'],
+    aJoinColumn: ['track', 'id'],
+
     b: trackArtistInput,
+    bTable: 'trackArtist',
     bAs: 'trackArtist',
-    getBJoinKey: trackArtist => trackArtist.trackId,
-    getBPrimaryKey: trackArtist =>
-      trackArtist.trackId + '-' + trackArtist.artistId,
+    bPrimaryKeyColumns: ['trackId', 'artistId'],
+    bJoinColumn: ['trackArtist', 'trackId'],
   });
 
   const output = trackAndTrackArtistOutput.join({
-    aAs: undefined,
-    getAJoinKey: x => x.trackArtist.artistId,
-    getAPrimaryKey: x => x.id,
+    aTable: undefined,
+    aPrimaryKeyColumns: ['id'],
+    aJoinColumn: ['trackArtist', 'artistId'],
+
     b: artistInput,
+    bTable: 'artist',
     bAs: 'artist',
-    getBJoinKey: x => x.id,
-    getBPrimaryKey: x => x.id,
+    bPrimaryKeyColumns: ['id'],
+    bJoinColumn: ['artist', 'id'],
   });
 
   const items: [

--- a/packages/zql/src/zql/ivm/graph/operators/join-operator.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/join-operator.ts
@@ -1,4 +1,4 @@
-import type {Primitive} from '../../../ast/ast.js';
+import type {Selector} from '../../../ast/ast.js';
 import {genCached, genConcat, genFlatMap} from '../../../util/iterables.js';
 import type {Entry, Multiset} from '../../multiset.js';
 import type {
@@ -7,26 +7,36 @@ import type {
   StringOrNumber,
   Version,
 } from '../../types.js';
+import {
+  getPrimaryKeyValuesAsStringUnqualified,
+  getValueFromEntity,
+} from '../../source/util.js';
 import type {DifferenceStream} from '../difference-stream.js';
 import {combineRows, DifferenceIndex} from './difference-index.js';
 import {JoinOperatorBase} from './join-operator-base.js';
 
 export type JoinArgs<
-  Key extends Primitive,
   AValue extends PipelineEntity,
   BValue extends PipelineEntity,
-  AAlias extends string | undefined,
+  ATable extends string | undefined,
   BAlias extends string | undefined,
 > = {
   a: DifferenceStream<AValue>;
-  aAs: AAlias | undefined;
-  getAJoinKey: (value: AValue) => Key | undefined;
-  getAPrimaryKey: (value: AValue) => StringOrNumber;
+  // a is currently un-aliasable in ZQL. Hence `aTable` not `aAlias`.
+  // The value is `undefined` if the `a` stream is producing a `join` result.
+  aTable: ATable | undefined;
+  aPrimaryKeyColumns: readonly (keyof AValue & string)[];
+  // join column is a selector since we could be joining a join result to another
+  // join result.
+  aJoinColumn: Selector;
   b: DifferenceStream<BValue>;
-  bAs: BAlias | undefined;
-  getBJoinKey: (value: BValue) => Key | undefined;
-  getBPrimaryKey: (value: BValue) => StringOrNumber;
-  output: DifferenceStream<JoinResult<AValue, BValue, AAlias, BAlias>>;
+  // bTable is always defined at the moment.
+  // Seems like this will not be true if the B input is ever a query rather than a table.
+  bTable: string;
+  bAs: BAlias;
+  bPrimaryKeyColumns: readonly (keyof BValue & string)[];
+  bJoinColumn: Selector;
+  output: DifferenceStream<JoinResult<AValue, BValue, ATable, BAlias>>;
 };
 
 /**
@@ -51,10 +61,9 @@ export type JoinArgs<
  * From which the `select` operator can extract the desired fields.
  */
 export class InnerJoinOperator<
-  K extends Primitive,
   AValue extends PipelineEntity,
   BValue extends PipelineEntity,
-  AAlias extends string | undefined,
+  ATable extends string | undefined,
   BAlias extends string | undefined,
 > extends JoinOperatorBase<
   AValue,
@@ -62,23 +71,49 @@ export class InnerJoinOperator<
   // If AValue or BValue are join results
   // then they should be lifted and need no aliasing
   // since they're already aliased
-  JoinResult<AValue, BValue, AAlias, BAlias>
+  JoinResult<AValue, BValue, ATable, BAlias>
 > {
-  readonly #indexA: DifferenceIndex<K, AValue>;
-  readonly #indexB: DifferenceIndex<K, BValue>;
-  readonly #joinArgs;
+  readonly #indexA: DifferenceIndex<StringOrNumber, AValue>;
+  readonly #indexB: DifferenceIndex<StringOrNumber, BValue>;
+  readonly #getAPrimaryKey;
+  readonly #getBPrimaryKey;
+  readonly #getAJoinKey;
+  readonly #getBJoinKey;
+  readonly #joinArgs: JoinArgs<AValue, BValue, ATable, BAlias>;
 
-  constructor(joinArgs: JoinArgs<K, AValue, BValue, AAlias, BAlias>) {
+  constructor(joinArgs: JoinArgs<AValue, BValue, ATable, BAlias>) {
     super(joinArgs.a, joinArgs.b, joinArgs.output, (version, inputA, inputB) =>
       this.#join(version, inputA, inputB),
     );
-    this.#indexA = new DifferenceIndex<K, AValue>(joinArgs.getAPrimaryKey);
-    this.#indexB = new DifferenceIndex<K, BValue>(joinArgs.getBPrimaryKey);
+
+    this.#getAPrimaryKey = (value: AValue) =>
+      getPrimaryKeyValuesAsStringUnqualified(
+        value,
+        joinArgs.aPrimaryKeyColumns,
+      );
+    this.#getBPrimaryKey = (value: BValue) =>
+      getPrimaryKeyValuesAsStringUnqualified(
+        value,
+        joinArgs.bPrimaryKeyColumns,
+      );
+
+    this.#getAJoinKey = (value: AValue) =>
+      getValueFromEntity(value, joinArgs.aJoinColumn) as StringOrNumber;
+    this.#getBJoinKey = (value: BValue) =>
+      getValueFromEntity(value, joinArgs.bJoinColumn) as StringOrNumber;
+
+    this.#indexA = new DifferenceIndex<StringOrNumber, AValue>(
+      this.#getAPrimaryKey,
+    );
+    this.#indexB = new DifferenceIndex<StringOrNumber, BValue>(
+      this.#getBPrimaryKey,
+    );
+
     this.#joinArgs = joinArgs;
   }
 
-  #aKeysForCompaction = new Set<K>();
-  #bKeysForCompaction = new Set<K>();
+  #aKeysForCompaction = new Set<StringOrNumber>();
+  #bKeysForCompaction = new Set<StringOrNumber>();
   #lastVersion = -1;
   #join(
     version: Version,
@@ -97,21 +132,21 @@ export class InnerJoinOperator<
     }
 
     const iterablesToReturn: Multiset<
-      JoinResult<AValue, BValue, AAlias, BAlias>
+      JoinResult<AValue, BValue, ATable, BAlias>
     >[] = [];
 
     if (inputB !== undefined) {
       iterablesToReturn.push(
         genFlatMap(inputB, entry => {
-          const key = this.#joinArgs.getBJoinKey(entry[0]);
+          const key = this.#getBJoinKey(entry[0]);
           const ret = this.#joinOne(
             entry,
             key,
             this.#indexA,
             this.#joinArgs.bAs,
-            this.#joinArgs.aAs,
-            this.#joinArgs.getBPrimaryKey,
-            this.#joinArgs.getAPrimaryKey,
+            this.#joinArgs.aTable,
+            this.#getBPrimaryKey,
+            this.#getAPrimaryKey,
           );
           if (key !== undefined) {
             this.#indexB.add(key, entry);
@@ -125,15 +160,15 @@ export class InnerJoinOperator<
     if (inputA !== undefined) {
       iterablesToReturn.push(
         genFlatMap(inputA, entry => {
-          const key = this.#joinArgs.getAJoinKey(entry[0]);
+          const key = this.#getAJoinKey(entry[0]);
           const ret = this.#joinOne(
             entry,
             key,
             this.#indexB,
-            this.#joinArgs.aAs,
+            this.#joinArgs.aTable,
             this.#joinArgs.bAs,
-            this.#joinArgs.getAPrimaryKey,
-            this.#joinArgs.getBPrimaryKey,
+            this.#getAPrimaryKey,
+            this.#getBPrimaryKey,
           );
           if (key !== undefined) {
             this.#indexA.add(key, entry);
@@ -149,13 +184,13 @@ export class InnerJoinOperator<
 
   #joinOne<OuterValue, InnerValue>(
     outerEntry: Entry<OuterValue>,
-    outerKey: K | undefined,
-    innerIndex: DifferenceIndex<K, InnerValue>,
+    outerKey: StringOrNumber,
+    innerIndex: DifferenceIndex<StringOrNumber, InnerValue>,
     outerAlias: string | undefined,
     innerAlias: string | undefined,
     getOuterValueIdentity: (value: OuterValue) => StringOrNumber,
     getInnerValueIdentity: (value: InnerValue) => StringOrNumber,
-  ): Entry<JoinResult<AValue, BValue, AAlias, BAlias>>[] {
+  ): Entry<JoinResult<AValue, BValue, ATable, BAlias>>[] {
     const outerValue = outerEntry[0];
     const outerMult = outerEntry[1];
 
@@ -168,7 +203,7 @@ export class InnerJoinOperator<
       return [];
     }
 
-    const ret: Entry<JoinResult<AValue, BValue, AAlias, BAlias>>[] = [];
+    const ret: Entry<JoinResult<AValue, BValue, ATable, BAlias>>[] = [];
     for (const [innerValue, innerMult] of innerEtnries) {
       const value = combineRows(
         outerValue,
@@ -180,7 +215,7 @@ export class InnerJoinOperator<
       );
 
       ret.push([
-        value as JoinResult<AValue, BValue, AAlias, BAlias>,
+        value as JoinResult<AValue, BValue, ATable, BAlias>,
         outerMult * innerMult,
       ] as const);
     }

--- a/packages/zql/src/zql/ivm/graph/operators/left-join-operator.test.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/left-join-operator.test.ts
@@ -45,13 +45,15 @@ test('left join', () => {
   const albumInput = new DifferenceStream<Album>();
 
   const output = trackInput.leftJoin({
-    aAs: 'track',
-    getAJoinKey: track => track.albumId,
-    getAPrimaryKey: track => track.id,
+    aTable: 'track',
+    aPrimaryKeyColumns: ['id'],
+    aJoinColumn: ['track', 'albumId'],
+
     b: albumInput,
+    bTable: 'album',
     bAs: 'album',
-    getBJoinKey: album => album.id,
-    getBPrimaryKey: album => album.id,
+    bPrimaryKeyColumns: ['id'],
+    bJoinColumn: ['album', 'id'],
   });
 
   const items: [JoinResult<Track, Album, 'track', 'album'>, number][] = [];
@@ -287,23 +289,27 @@ test('junction table left join', () => {
   const artistInput = new DifferenceStream<Artist>();
 
   const trackTrackArtist = trackInput.leftJoin({
-    aAs: 'track',
-    getAJoinKey: track => track.id,
-    getAPrimaryKey: track => track.id,
+    aTable: 'track',
+    aPrimaryKeyColumns: ['id'],
+    aJoinColumn: ['track', 'id'],
+
     b: trackArtistInput,
+    bTable: 'trackArtist',
     bAs: 'trackArtist',
-    getBJoinKey: trackArtist => trackArtist.trackId,
-    getBPrimaryKey: trackArtist => trackArtist.id,
+    bPrimaryKeyColumns: ['id'],
+    bJoinColumn: ['trackArtist', 'trackId'],
   });
 
   const output = trackTrackArtist.leftJoin({
-    aAs: undefined,
-    getAJoinKey: x => x.trackArtist?.artistId,
-    getAPrimaryKey: x => x?.id,
+    aTable: undefined,
+    aPrimaryKeyColumns: ['id'],
+    aJoinColumn: ['trackArtist', 'artistId'],
+
     b: artistInput,
+    bTable: 'artist',
     bAs: 'artist',
-    getBJoinKey: artist => artist.id,
-    getBPrimaryKey: artist => artist.id,
+    bPrimaryKeyColumns: ['id'],
+    bJoinColumn: ['artist', 'id'],
   });
 
   const items: [
@@ -796,23 +802,27 @@ test('repro 1', () => {
   const artistInput = new DifferenceStream<Artist>();
 
   const trackTrackArtist = trackInput.leftJoin({
-    aAs: 'track',
-    getAJoinKey: track => track.id,
-    getAPrimaryKey: track => track.id,
+    aTable: 'track',
+    aPrimaryKeyColumns: ['id'],
+    aJoinColumn: ['track', 'id'],
+
     b: trackArtistInput,
+    bTable: 'trackArtist',
     bAs: 'trackArtist',
-    getBJoinKey: trackArtist => trackArtist.trackId,
-    getBPrimaryKey: trackArtist => trackArtist.id,
+    bPrimaryKeyColumns: ['id'],
+    bJoinColumn: ['trackArtist', 'trackId'],
   });
 
   const output = trackTrackArtist.leftJoin({
-    aAs: undefined,
-    getAJoinKey: x => x.trackArtist?.artistId,
-    getAPrimaryKey: x => x?.id,
+    aTable: undefined,
+    aPrimaryKeyColumns: ['id'],
+    aJoinColumn: ['trackArtist', 'artistId'],
+
     b: artistInput,
+    bTable: 'artist',
     bAs: 'artist',
-    getBJoinKey: artist => artist.id,
-    getBPrimaryKey: artist => artist.id,
+    bPrimaryKeyColumns: ['id'],
+    bJoinColumn: ['artist', 'id'],
   });
 
   const items: [
@@ -982,13 +992,15 @@ test('add track & album, then remove album', () => {
   const albumInput = new DifferenceStream<Album>();
 
   const output = trackInput.leftJoin({
-    aAs: 'track',
-    getAJoinKey: track => track.albumId,
-    getAPrimaryKey: track => track.id,
+    aTable: 'track',
+    aPrimaryKeyColumns: ['id'],
+    aJoinColumn: ['track', 'albumId'],
+
     b: albumInput,
+    bTable: 'album',
     bAs: 'album',
-    getBJoinKey: album => album.id,
-    getBPrimaryKey: album => album.id,
+    bPrimaryKeyColumns: ['id'],
+    bJoinColumn: ['album', 'id'],
   });
 
   const items: [JoinResult<Track, Album, 'track', 'album'>, number][] = [];
@@ -1104,13 +1116,15 @@ test('one to many, remove the one, add the one', () => {
   const trackArtistInput = new DifferenceStream<TrackArtist>();
 
   const output = trackInput.leftJoin({
-    aAs: 'track',
-    getAJoinKey: track => track.id,
-    getAPrimaryKey: track => track.id,
+    aTable: 'track',
+    aPrimaryKeyColumns: ['id'],
+    aJoinColumn: ['track', 'id'],
+
     b: trackArtistInput,
+    bTable: 'trackArtist',
     bAs: 'trackArtist',
-    getBJoinKey: trackArtist => trackArtist.trackId,
-    getBPrimaryKey: trackArtist => trackArtist.id,
+    bPrimaryKeyColumns: ['id'],
+    bJoinColumn: ['trackArtist', 'trackId'],
   });
 
   const items: [
@@ -1288,23 +1302,27 @@ test('two tracks, only 1 is linked to artists', () => {
   const artistInput = new DifferenceStream<Artist>();
 
   const trackTrackArtist = trackInput.leftJoin({
-    aAs: 'track',
-    getAJoinKey: track => track.id,
-    getAPrimaryKey: track => track.id,
+    aTable: 'track',
+    aPrimaryKeyColumns: ['id'],
+    aJoinColumn: ['track', 'id'],
+
     b: trackArtistInput,
+    bTable: 'trackArtist',
     bAs: 'trackArtist',
-    getBJoinKey: trackArtist => trackArtist.trackId,
-    getBPrimaryKey: trackArtist => trackArtist.id,
+    bPrimaryKeyColumns: ['id'],
+    bJoinColumn: ['trackArtist', 'trackId'],
   });
 
   const output = trackTrackArtist.leftJoin({
-    aAs: undefined,
-    getAJoinKey: x => x.trackArtist?.artistId,
-    getAPrimaryKey: x => x?.id,
+    aTable: undefined,
+    aPrimaryKeyColumns: ['id'],
+    aJoinColumn: ['trackArtist', 'artistId'],
+
     b: artistInput,
+    bTable: 'artist',
     bAs: 'artist',
-    getBJoinKey: artist => artist.id,
-    getBPrimaryKey: artist => artist.id,
+    bPrimaryKeyColumns: ['id'],
+    bJoinColumn: ['artist', 'id'],
   });
 
   const items: [
@@ -1446,13 +1464,15 @@ export function orderIsRemovedFromRequest(join: 'leftJoin' | 'join') {
   const trackInput = new DifferenceStream<Track>();
   const albumInput = new DifferenceStream<Album>();
   const output = trackInput[join]({
-    aAs: 'track',
-    getAJoinKey: x => x.albumId,
-    getAPrimaryKey: x => x.id,
+    aTable: 'track',
+    aPrimaryKeyColumns: ['id'],
+    aJoinColumn: ['track', 'albumId'],
+
     b: albumInput,
+    bTable: 'album',
     bAs: 'album',
-    getBJoinKey: x => x.id,
-    getBPrimaryKey: x => x.id,
+    bPrimaryKeyColumns: ['id'],
+    bJoinColumn: ['album', 'id'],
   });
 
   const trackInputSpy = vi.spyOn(trackInput, 'messageUpstream');
@@ -1481,13 +1501,15 @@ export function orderIsRemovedFromReply(join: 'leftJoin' | 'join') {
   const trackInput = new DifferenceStream<Track>();
   const albumInput = new DifferenceStream<Album>();
   const output = trackInput[join]({
-    aAs: 'track',
-    getAJoinKey: x => x.albumId,
-    getAPrimaryKey: x => x.id,
+    aTable: 'track',
+    aPrimaryKeyColumns: ['id'],
+    aJoinColumn: ['track', 'albumId'],
+
     b: albumInput,
+    bTable: 'album',
     bAs: 'album',
-    getBJoinKey: x => x.id,
-    getBPrimaryKey: x => x.id,
+    bPrimaryKeyColumns: ['id'],
+    bJoinColumn: ['album', 'id'],
   });
 
   const outputSpy = vi.spyOn(output, 'newDifference');

--- a/packages/zql/src/zql/ivm/source/util.ts
+++ b/packages/zql/src/zql/ivm/source/util.ts
@@ -1,4 +1,3 @@
-import {must} from 'shared/src/must.js';
 import type {Ordering, Selector} from '../../ast/ast.js';
 import {isJoinResult} from '../types.js';
 
@@ -37,13 +36,13 @@ export function getValueFromEntity(
     if (qualifiedColumn[1] === '*') {
       return (entity as Record<string, unknown>)[qualifiedColumn[0]];
     }
-    return getOrLiftValue(
-      (entity as Record<string, unknown>)[must(qualifiedColumn[0])] as Record<
-        string,
-        unknown
-      >,
-      qualifiedColumn[1],
-    );
+
+    const row = (entity as Record<string, unknown>)[qualifiedColumn[0]];
+    if (row === undefined) {
+      return undefined;
+    }
+
+    return getOrLiftValue(row as Record<string, unknown>, qualifiedColumn[1]);
   }
   return getOrLiftValue(entity, qualifiedColumn[1]);
 }
@@ -59,4 +58,21 @@ export function getOrLiftValue(
     return containerOrValue.map(x => x?.[field]);
   }
   return containerOrValue?.[field];
+}
+
+export function getPrimaryKeyValuesAsStringUnqualified(
+  entity: Record<string, unknown>,
+  primaryKey: readonly string[],
+) {
+  let ret = '';
+  let first = true;
+  for (const col of primaryKey) {
+    if (!first) {
+      ret += '-';
+    } else {
+      first = false;
+    }
+    ret += entity[col];
+  }
+  return ret;
 }


### PR DESCRIPTION
join needs to be aware of the fields being access in the `on` condition so we can't pass it opaque lambdas anymore.

Join being aware of the fields used allows it to:
1. Pick an index for the inner loop
2. Tell downstream operators how results are grouped, if at all

for (2), join emits groupings of rows for 1:many relationships if the `1` side is the outer loop of the join. Useful to know for queries of the form:

```
SELECT issue.id, agg_array(comments.*) FROM issue JOIN comment ON issue.id = comment.issue_id GROUP BY issue.id
```

So `GROUP BY` doesn't need to collect every row and sort them.