### PR TITLE
feat(zero-cache): start transactions in the intended mode

### DIFF
--- a/packages/zero-cache/src/services/invalidation-watcher/invalidation-watcher.ts
+++ b/packages/zero-cache/src/services/invalidation-watcher/invalidation-watcher.ts
@@ -4,6 +4,7 @@ import {assert} from 'shared/src/asserts.js';
 import {union} from 'shared/src/set-utils.js';
 import {sleep} from 'shared/src/sleep.js';
 import {
+  Mode,
   TransactionPool,
   sharedReadOnlySnapshot,
 } from '../../db/transaction-pool.js';
@@ -442,7 +443,7 @@ export class InvalidationWatcherService
       return this.#latestReader;
     }
     const {init, cleanup} = sharedReadOnlySnapshot();
-    const reader = new TransactionPool(lc, init, cleanup, 1, 4); // TODO: Choose maxWorkers more intelligently / dynamically.
+    const reader = new TransactionPool(lc, Mode.READONLY, init, cleanup, 1, 4); // TODO: Choose maxWorkers more intelligently / dynamically.
     reader.run(this.#replica).catch(e => lc.error?.(e));
 
     const snapshotQuery = await reader.processReadTask(queryStateVersion);

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -12,6 +12,7 @@ import {assert} from 'shared/src/asserts.js';
 import {sleep} from 'shared/src/sleep.js';
 import {
   ControlFlowError,
+  Mode,
   Statement,
   TransactionPool,
   synchronizedSnapshots,
@@ -485,11 +486,13 @@ class TransactionProcessor {
       synchronizedSnapshots();
     this.#writer = new TransactionPool(
       this.#lc.withContext('pool', 'writer'),
+      Mode.SERIALIZABLE,
       exportSnapshot,
       cleanupExport,
     );
     this.#readers = new TransactionPool(
       this.#lc.withContext('pool', 'readers'),
+      Mode.READONLY,
       setSnapshot,
       undefined,
       1,

--- a/packages/zero-cache/src/services/replicator/invalidation.pg-test.ts
+++ b/packages/zero-cache/src/services/replicator/invalidation.pg-test.ts
@@ -1,12 +1,13 @@
 import {Lock} from '@rocicorp/lock';
+import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
 import {randInt} from 'shared/src/rand.js';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {
+  Mode,
   TransactionPool,
   synchronizedSnapshots,
 } from '../../db/transaction-pool.js';
 import {expectTables, initDB, testDBs} from '../../test/db.js';
-import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
 import {
   NormalizedInvalidationFilterSpec,
   invalidationHash,
@@ -542,11 +543,13 @@ describe('replicator/invalidation', () => {
           synchronizedSnapshots();
         const writer = new TransactionPool(
           lc.withContext('pool', 'writer'),
+          Mode.SERIALIZABLE,
           exportSnapshot,
           cleanupExport,
         );
         const readers = new TransactionPool(
           lc.withContext('pool', 'readers'),
+          Mode.READONLY,
           setSnapshot,
           undefined,
           1, // start with 1 worker

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -4,7 +4,7 @@ import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
 import {Queue} from 'shared/src/queue.js';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import type {Downstream, PokePartBody} from 'zero-protocol';
-import {TransactionPool} from '../../db/transaction-pool.js';
+import {Mode, TransactionPool} from '../../db/transaction-pool.js';
 import {DurableStorage} from '../../storage/durable-storage.js';
 import {testDBs} from '../../test/db.js';
 import {FakeDurableObjectStorage} from '../../test/fake-do.js';
@@ -841,7 +841,7 @@ describe('view-syncer/service', () => {
     }
 
     async notify(invalidation: Omit<QueryInvalidationUpdate, 'reader'>) {
-      const reader = new TransactionPool(lc);
+      const reader = new TransactionPool(lc, Mode.READONLY);
       const readerDone = reader.run(db);
 
       assert(this.subscription, 'no subscription');


### PR DESCRIPTION
Send the intended transaction isolation level in the initial `BEGIN` statement rather than sending an additional `SET TRANSACTION` statement.

This probably does not make a significant difference in performance but is cleaner and reduces log spam.