### PR TITLE
feat(zero-cache): run a single PG container for all pg tests

### DIFF
--- a/packages/zero-cache/test/pg-container-setup.ts
+++ b/packages/zero-cache/test/pg-container-setup.ts
@@ -1,0 +1,19 @@
+import {PostgreSqlContainer} from '@testcontainers/postgresql';
+
+// TODO: Pass this in an ENV variable or some appropriate config channel
+//       to run tests with different versions of Postgres.
+const PG_IMAGE = 'postgres:16.3-alpine3.19';
+
+export default async function () {
+  const container = await new PostgreSqlContainer(PG_IMAGE)
+    .withCommand(['postgres', '-c', 'wal_level=logical'])
+    .start();
+
+  // Referenced by ./src/test/db.ts
+  process.env.PG_CONTAINER_CONNECTION_URI = container.getConnectionUri();
+
+  return async () => {
+    await container.stop();
+    delete process.env.PG_CONTAINER_CONNECTION_URI;
+  };
+}

--- a/packages/zero-cache/vitest.config.pg.ts
+++ b/packages/zero-cache/vitest.config.pg.ts
@@ -26,13 +26,7 @@ export default defineConfig({
     name: 'pg',
     include: ['src/**/*.pg-test.?(c|m)[jt]s?(x)'],
     retry: 2,
-    poolOptions: {
-      threads: {
-        minThreads: 1,
-        // Testcontainers can sometimes seg fault.
-        // Try `VITEST_MAX_THREADS=1 npm run pg-test` to mitigate.
-      },
-    },
+    globalSetup: ['./test/pg-container-setup.ts'],
   },
   plugins: [inlineWASM()],
 });


### PR DESCRIPTION
Use vitest's `globalSetup` hook to run a single PG testcontainer rather than one per test. This eliminates the flakiness resulting from running lots of pg containers, and has performance similar to that of running against the (single) local pg instance.