### PR TITLE
feat(zero-client): method to convert a schema type to a query type

### DIFF
--- a/packages/zql/src/zql/query/entity-query.ts
+++ b/packages/zql/src/zql/query/entity-query.ts
@@ -17,12 +17,27 @@ import type {
 } from '../ast/ast.js';
 import type {Context} from '../context/context.js';
 import {Misuse} from '../error/misuse.js';
-import type {Entity} from '../schema/entity-schema.js';
+import type {
+  Entity,
+  InferType,
+  RowSchema,
+  TableSchema,
+} from '../schema/entity-schema.js';
 import {AggArray, Aggregate, Max, Min, isAggregate} from './agg.js';
 import {Statement} from './statement.js';
 
 type NotUndefined<T> = Exclude<T, undefined>;
 type WeakKey = object;
+
+export type SchemaToQuery<
+  Table extends TableSchema<Row, Name>,
+  Row extends RowSchema = Table extends TableSchema<infer R, string>
+    ? R
+    : never,
+  Name extends string = Table extends TableSchema<Row, infer N> ? N : never,
+> = EntityQuery<{
+  [key in Name]: InferType<Table> extends Entity ? InferType<Table> : never;
+}>;
 
 export type ValueAsOperatorInput<
   V,

--- a/packages/zql/src/zql/schema/entity-schema.test.ts
+++ b/packages/zql/src/zql/schema/entity-schema.test.ts
@@ -1,14 +1,16 @@
 import * as v from 'shared/src/valita.js';
 import {expectTypeOf, test} from 'vitest';
+import type {EntityQuery, SchemaToQuery} from '../query/entity-query.js';
 import {InferType, table} from './entity-schema.js';
 
 test('basic schema', () => {
-  const userSchema = table({
+  const userSchema = table('user', {
     id: v.string(),
     name: v.string(),
     email: v.string(),
   });
   const issueSchema = table(
+    'issue',
     {
       id: v.string(),
       title: v.string(),
@@ -22,6 +24,21 @@ test('basic schema', () => {
   );
 
   type User = InferType<typeof userSchema>;
+  type UserQuery = SchemaToQuery<typeof userSchema>;
+
+  expectTypeOf<UserQuery>().toMatchTypeOf<
+    EntityQuery<
+      {
+        user: Readonly<{
+          id: string;
+          name: string;
+          email: string;
+        }>;
+      },
+      []
+    >
+  >();
+
   expectTypeOf<User>().toMatchTypeOf<{
     id: string;
     name: string;

--- a/packages/zql/src/zql/schema/entity-schema.ts
+++ b/packages/zql/src/zql/schema/entity-schema.ts
@@ -7,7 +7,7 @@ export type Entity = {
 
 // id will not be required in later iterations where we support compound primary keys.
 // we'll use the `primaryKey` field of `TableSchema` instead.
-export type RowSchema = {id: v.Type<string>};
+export type RowSchema = {id: v.Type<Readonly<string>>};
 
 /**
  * Example:
@@ -32,18 +32,21 @@ export type RowSchema = {id: v.Type<string>};
  *   },
  * );
  */
-export type TableSchema<R extends RowSchema> = {
+export type TableSchema<R extends RowSchema, Name extends string> = {
+  readonly name: Name;
   readonly fields: v.ObjectType<R>;
   readonly primaryKey: (keyof R)[];
   readonly foreignKeys?: ForeignKeys<R> | undefined;
 };
 
-export function table<R extends RowSchema>(
+export function table<R extends RowSchema, Name extends string>(
+  name: Name,
   rowSchema: R,
   primaryKey: (keyof R)[] = ['id'],
   foreignKeys?: ForeignKeys<R> | undefined,
-): TableSchema<R> {
+): TableSchema<R, Name> {
   return {
+    name,
     fields: v.object(rowSchema),
     primaryKey,
     foreignKeys,
@@ -52,8 +55,10 @@ export function table<R extends RowSchema>(
 
 type ForeignKeys<R extends RowSchema> = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key in keyof R]?: () => TableSchema<any>;
+  [key in keyof R]?: () => TableSchema<any, any>;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type InferType<T extends TableSchema<any>> = v.Infer<T['fields']>;
+export type InferType<T extends TableSchema<any, any>> = Readonly<
+  v.Infer<T['fields']>
+>;


### PR DESCRIPTION
To replace `queries` with `schemas` in `zero(...)` we need a way to convert from a schema definition to an EntityQuery.

Add a type utility to do that.

```ts
type UserQuery = SchemaToQuery<typeof userSchema>;
```