### PR TITLE
fix(zql): do not save undefined keys to `indexA`

### DIFF
--- a/packages/zql/src/zql/ivm/graph/operators/difference-index.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/difference-index.ts
@@ -34,14 +34,6 @@ export class DifferenceIndex<Key extends Primitive | undefined, V> {
     existing.push(value);
   }
 
-  extend(index: DifferenceIndex<Key, V>) {
-    for (const [key, value] of index.#index) {
-      for (const entry of value) {
-        this.add(key, entry);
-      }
-    }
-  }
-
   get(key: Key): Entry<V>[] {
     return this.#index.get(key) ?? [];
   }

--- a/packages/zql/src/zql/ivm/graph/operators/left-join-operator.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/left-join-operator.ts
@@ -120,8 +120,10 @@ export class LeftJoinOperator<
         genFlatMap(inputA, entry => {
           const key = this.#getAJoinKey(entry[0]);
           const ret = this.#joinOneLeft(entry, key);
-          this.#indexA.add(key, entry);
-          this.#aKeysForCompaction.add(key);
+          if (key !== undefined) {
+            this.#indexA.add(key, entry);
+            this.#aKeysForCompaction.add(key);
+          }
           return ret;
         }),
       );


### PR DESCRIPTION
minor improvement: skip entries with undefined keys.