### PR TITLE
chore(zero-cache): improve view syncer logging

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/queries.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/queries.pg-test.ts
@@ -1,6 +1,5 @@
 import type {AST} from '@rocicorp/zql/src/zql/ast/ast.js';
 import {assert} from 'shared/src/asserts.js';
-import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {testDBs} from '../../test/db.js';
 import type {PostgresDB} from '../../types/pg.js';
@@ -10,7 +9,6 @@ import {QueryHandler} from './queries.js';
 
 describe('view-syncer/queries', () => {
   let db: PostgresDB;
-  const lc = createSilentLogContext();
 
   beforeEach(async () => {
     db = await testDBs.create('view_syncer_queries_test');
@@ -158,7 +156,7 @@ describe('view-syncer/queries', () => {
     const {queryIDs, transformedAST} = first.value;
     expect(queryIDs).toEqual(['queryHash', 'queryHash2']);
     const expanded = transformedAST.query();
-    const resultParser = queryHandler.resultParser(lc, 'foo-cvr');
+    const resultParser = queryHandler.resultParser('foo-cvr');
     const results = await db.unsafe(expanded.query, expanded.values);
 
     // This is what gets synced to the client (contents) and stored in the CVR (record).
@@ -320,7 +318,7 @@ describe('view-syncer/queries', () => {
     // expect(queryIDs).toEqual(['queryHash', 'queryHash2']);
     expect(queryIDs).toEqual(['queryHash']);
     const expanded = transformedAST.query();
-    const resultParser = queryHandler.resultParser(lc, 'foo-cvr');
+    const resultParser = queryHandler.resultParser('foo-cvr');
     expect(expanded.query).toBe(
       'SELECT public.issues._0_version AS "public/issues/_0_version", ' +
         'public.issues.id AS "public/issues/id", ' +
@@ -506,7 +504,7 @@ describe('view-syncer/queries', () => {
     const {queryIDs, transformedAST} = first.value;
     expect(queryIDs).toEqual(['queryHash', 'queryHash2']);
     const expanded = transformedAST.query();
-    const resultParser = queryHandler.resultParser(lc, 'foo-cvr');
+    const resultParser = queryHandler.resultParser('foo-cvr');
     const results = await db.unsafe(expanded.query, expanded.values);
 
     // This is what gets synced to the client (contents) and stored in the CVR (record).
@@ -680,7 +678,7 @@ describe('view-syncer/queries', () => {
     // expect(queryIDs).toEqual(['queryHash', 'queryHash2']);
     expect(queryIDs).toEqual(['queryHash']);
     const expanded = transformedAST.query();
-    const resultParser = queryHandler.resultParser(lc, 'foo-cvr');
+    const resultParser = queryHandler.resultParser('foo-cvr');
     expect(expanded.query).toBe(
       'SELECT public.issues._0_version AS "public/issues/_0_version", ' +
         'public.issues.id AS "public/issues/id", ' +

--- a/packages/zero-cache/src/services/view-syncer/queries.ts
+++ b/packages/zero-cache/src/services/view-syncer/queries.ts
@@ -1,4 +1,3 @@
-import type {LogContext} from '@rocicorp/logger';
 import type {AST} from '@rocicorp/zql/src/zql/ast/ast.js';
 import {assert} from 'shared/src/asserts.js';
 import {stringify, type JSONObject} from '../../types/bigint-json.js';
@@ -99,8 +98,8 @@ export class QueryHandler {
    * Returns an object for deconstructing each result from executed queries
    * into its constituent tables and rows.
    */
-  resultParser(lc: LogContext, cvrID: string) {
-    return new ResultParser(lc, this.#tables, cvrID);
+  resultParser(cvrID: string) {
+    return new ResultParser(this.#tables, cvrID);
   }
 
   tableSpec(schema: string, table: string) {
@@ -114,12 +113,10 @@ export type ParsedRow = {
 };
 
 class ResultParser {
-  readonly #lc: LogContext;
   readonly #tables: TableSchemas;
   readonly #paths: CVRPaths;
 
-  constructor(lc: LogContext, tables: TableSchemas, cvrID: string) {
-    this.#lc = lc;
+  constructor(tables: TableSchemas, cvrID: string) {
     this.#tables = tables;
     this.#paths = new CVRPaths(cvrID);
   }
@@ -206,9 +203,6 @@ class ResultParser {
         rowResult.contents = {...rowResult.contents, ...row};
       }
     }
-    this.#lc
-      .withContext('queryIDs', queryIDs)
-      .debug?.(`processed ${results.length} results`);
     return parsed;
   }
 }


### PR DESCRIPTION
Remove extraneous (not useful) log statements. Add total row counts (to match total elapsed time) for each query.