### PR TITLE
feat(zero-cache): stop storing row contents in _zero.ChangeLog

### DIFF
--- a/packages/zero-cache/src/services/replicator/incremental-sync.pg-test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.pg-test.ts
@@ -414,16 +414,6 @@ describe('replicator/incremental-sync', () => {
             table: 'issues',
             op: 's',
             rowKey: {issueID: 123},
-            row: {
-              issueID: 123,
-              big: null,
-              flt: null,
-              ints: null,
-              bigs: null,
-              time: null,
-              description: null,
-              ['_0_version']: '01',
-            },
           },
           {
             stateVersion: '01',
@@ -432,16 +422,6 @@ describe('replicator/incremental-sync', () => {
             op: 's',
 
             rowKey: {issueID: 456},
-            row: {
-              issueID: 456,
-              big: null,
-              flt: null,
-              ints: null,
-              bigs: null,
-              time: '2024-03-21T18:50:23.646Z',
-              description: null,
-              ['_0_version']: '01',
-            },
           },
           {
             stateVersion: '02',
@@ -449,16 +429,6 @@ describe('replicator/incremental-sync', () => {
             table: 'issues',
             op: 's',
             rowKey: {issueID: 789},
-            row: {
-              issueID: 789,
-              big: 9223372036854775807n,
-              ints: null,
-              flt: null,
-              bigs: null,
-              time: null,
-              description: null,
-              ['_0_version']: '02',
-            },
           },
           {
             stateVersion: '02',
@@ -466,16 +436,6 @@ describe('replicator/incremental-sync', () => {
             table: 'issues',
             op: 's',
             rowKey: {issueID: 987},
-            row: {
-              issueID: 987,
-              big: null,
-              flt: null,
-              ints: [92233720, 123],
-              bigs: null,
-              time: null,
-              description: null,
-              ['_0_version']: '02',
-            },
           },
           {
             stateVersion: '02',
@@ -483,16 +443,6 @@ describe('replicator/incremental-sync', () => {
             table: 'issues',
             op: 's',
             rowKey: {issueID: 234},
-            row: {
-              issueID: 234,
-              big: null,
-              flt: 123.456,
-              ints: null,
-              bigs: null,
-              time: null,
-              description: null,
-              ['_0_version']: '02',
-            },
           },
         ],
         ['_zero.InvalidationIndex']: [
@@ -721,12 +671,6 @@ describe('replicator/incremental-sync', () => {
             table: 'issues',
             op: 's',
             rowKey: {orgID: 2, issueID: 789},
-            row: {
-              orgID: 2,
-              issueID: 789,
-              description: null,
-              ['_0_version']: '01',
-            },
           },
           {
             stateVersion: '02',
@@ -734,12 +678,6 @@ describe('replicator/incremental-sync', () => {
             table: 'issues',
             op: 's',
             rowKey: {orgID: 1, issueID: 456},
-            row: {
-              orgID: 1,
-              issueID: 456,
-              description: 'foo',
-              ['_0_version']: '02',
-            },
           },
           {
             stateVersion: '02',
@@ -747,7 +685,6 @@ describe('replicator/incremental-sync', () => {
             table: 'issues',
             op: 'd',
             rowKey: {orgID: 1, issueID: 123},
-            row: null,
           },
           {
             stateVersion: '02',
@@ -755,12 +692,6 @@ describe('replicator/incremental-sync', () => {
             table: 'issues',
             op: 's',
             rowKey: {orgID: 2, issueID: 123},
-            row: {
-              orgID: 2,
-              issueID: 123,
-              description: 'bar',
-              ['_0_version']: '02',
-            },
           },
         ],
         ['_zero.InvalidationIndex']: [
@@ -1017,12 +948,6 @@ describe('replicator/incremental-sync', () => {
             table: 'issues',
             op: 's',
             rowKey: {orgID: 2, issueID: 789},
-            row: {
-              orgID: 2,
-              issueID: 789,
-              description: null,
-              ['_0_version']: '01',
-            },
           },
           {
             stateVersion: '02',
@@ -1030,7 +955,6 @@ describe('replicator/incremental-sync', () => {
             table: 'issues',
             op: 'd',
             rowKey: {orgID: 1, issueID: 123},
-            row: null,
           },
           {
             stateVersion: '02',
@@ -1038,7 +962,6 @@ describe('replicator/incremental-sync', () => {
             table: 'issues',
             op: 'd',
             rowKey: {orgID: 1, issueID: 456},
-            row: null,
           },
           {
             stateVersion: '02',
@@ -1046,7 +969,6 @@ describe('replicator/incremental-sync', () => {
             table: 'issues',
             op: 'd',
             rowKey: {orgID: 2, issueID: 987},
-            row: null,
           },
         ],
       },
@@ -1233,7 +1155,6 @@ describe('replicator/incremental-sync', () => {
             table: 'bar',
             op: 's',
             rowKey: {id: 4},
-            row: {id: 4, ['_0_version']: '01'},
           },
           {
             stateVersion: '01',
@@ -1241,7 +1162,6 @@ describe('replicator/incremental-sync', () => {
             table: 'bar',
             op: 's',
             rowKey: {id: 5},
-            row: {id: 5, ['_0_version']: '01'},
           },
           {
             stateVersion: '01',
@@ -1249,7 +1169,6 @@ describe('replicator/incremental-sync', () => {
             table: 'bar',
             op: 's',
             rowKey: {id: 6},
-            row: {id: 6, ['_0_version']: '01'},
           },
           {
             stateVersion: '01',
@@ -1257,7 +1176,6 @@ describe('replicator/incremental-sync', () => {
             table: 'baz',
             op: 't',
             rowKey: {},
-            row: null,
           },
           {
             stateVersion: '02',
@@ -1265,7 +1183,6 @@ describe('replicator/incremental-sync', () => {
             table: 'foo',
             op: 't',
             rowKey: {},
-            row: null,
           },
           {
             stateVersion: '02',
@@ -1273,7 +1190,6 @@ describe('replicator/incremental-sync', () => {
             table: 'foo',
             op: 's',
             rowKey: {id: 101},
-            row: {id: 101, ['_0_version']: '02'},
           },
         ],
         ['_zero.InvalidationIndex']: [
@@ -1454,12 +1370,6 @@ describe('replicator/incremental-sync', () => {
             table: 'issues',
             op: 's',
             rowKey: {orgID: 1, issueID: 456},
-            row: {
-              orgID: 1,
-              issueID: 456,
-              description: 'foo',
-              ['_0_version']: '01',
-            },
           },
         ],
         ['_zero.InvalidationIndex']: [

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -706,7 +706,6 @@ class TransactionProcessor {
       table,
       op: row ? 's' : key ? 'd' : 't',
       rowKey: (key as postgres.JSONValue) ?? {}, // Empty object for truncate
-      row: (row as postgres.JSONValue) ?? null,
     };
     return tx`
     INSERT INTO _zero."ChangeLog" ${tx(change)}
@@ -739,7 +738,6 @@ type ChangeLogEntry = {
   table: string;
   op: 't' | 's' | 'd';
   rowKey: postgres.JSONValue;
-  row: postgres.JSONValue;
 };
 
 function table(db: postgres.Sql, msg: {relation: Pgoutput.MessageRelation}) {

--- a/packages/zero-cache/src/services/replicator/schema/replication.ts
+++ b/packages/zero-cache/src/services/replicator/schema/replication.ts
@@ -35,11 +35,9 @@ export const CREATE_REPLICATION_TABLES =
   //
   // * `op`        : 't' for table truncation, 's' for set (insert/update), and 'd' for delete
   // * `rowKey`    : JSONB row key, as `{[$columnName]: $columnValue}`, or '{}' for TRUNCATE
-  // * `row`       : JSON formatted full row contents, NULL for DELETE / TRUNCATE
   //
-  // Note that the `row` data is stored as JSON rather than JSONB to prioritize write
-  // throughput, as replication is critical bottleneck in the system. Row values are
-  // only needed for catchup, for which JSONB is not particularly advantageous over JSON.
+  // Note that the row data itself is not stored; since catchup is always done at the current
+  // snapshot of the database, row contents can instead be looked up from the database tables.
   `
   CREATE TABLE _zero."ChangeLog" (
     "stateVersion" VARCHAR(38)  NOT NULL,
@@ -47,7 +45,6 @@ export const CREATE_REPLICATION_TABLES =
     "table"        VARCHAR(128) NOT NULL,
     "op"           CHAR         NOT NULL,
     "rowKey"       JSONB        NOT NULL,
-    "row"          JSON,
     CONSTRAINT "PK_change_log" PRIMARY KEY("stateVersion", "schema", "table", "rowKey"),
     CONSTRAINT "RK_change_log" UNIQUE("schema", "table", "rowKey")
   );


### PR DESCRIPTION
Storing copy of each row effectively doubles the I/O involved in replication, and is unnecessary since catchup is always done at the current snapshot of the database, so row contents can be retrieved directly from the tables.