### PR TITLE
fix(zero-cache): explicitly cap connections for each db client

### DIFF
--- a/packages/zero-cache/src/services/invalidation-watcher/invalidation-watcher.ts
+++ b/packages/zero-cache/src/services/invalidation-watcher/invalidation-watcher.ts
@@ -443,7 +443,7 @@ export class InvalidationWatcherService
       return this.#latestReader;
     }
     const {init, cleanup} = sharedReadOnlySnapshot();
-    const reader = new TransactionPool(lc, Mode.READONLY, init, cleanup, 1, 3); // TODO: Choose maxWorkers more intelligently / dynamically.
+    const reader = new TransactionPool(lc, Mode.READONLY, init, cleanup, 1, 4); // TODO: Choose maxWorkers more intelligently / dynamically.
     reader.run(this.#replica).catch(e => lc.error?.(e));
 
     const snapshotQuery = await reader.processReadTask(queryStateVersion);

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -502,7 +502,7 @@ class TransactionProcessor {
       setSnapshot,
       undefined,
       1,
-      5, // TODO: Parameterize the max workers for the readers pool.
+      3,
     );
   }
 

--- a/packages/zero-cache/src/services/service-runner.ts
+++ b/packages/zero-cache/src/services/service-runner.ts
@@ -76,13 +76,18 @@ export class ServiceRunner
     this.#lc = lc;
     this.#storage = new DurableStorage(state.storage);
     this.#env = env;
+    // Connections are capped to stay within the DO limit of 6 TCP connections.
+    // Note that the Replicator uses one extra connection for replication.
+    //
     // TODO: We should have separate upstream URIs for the Replicator (direct connection)
     //       vs mutagen (can be a pooled connection).
     this.#upstream = postgres(this.#env.UPSTREAM_URI, {
       ...postgresTypeConfig(),
+      max: 1,
     });
     this.#replica = postgres(this.#env.SYNC_REPLICA_URI, {
       ...postgresTypeConfig(),
+      max: 4,
     });
     this.#runReplicator = runReplicator;
   }


### PR DESCRIPTION
Avoid hitting the 6 connection TCP limit by explicitly capping the connection counts in the postgres.js clients.

Bump up the max transaction pool size for the View Syncer now that it is no longer competing with the Replicator for connections.