### PR TITLE
fix(zero-cache): fix replication bootstrapping in the dedicated ReplicatorDO world

### DIFF
--- a/packages/zero-cache/src/services/invalidation-watcher/invalidation-watcher.pg-test.ts
+++ b/packages/zero-cache/src/services/invalidation-watcher/invalidation-watcher.pg-test.ts
@@ -387,6 +387,7 @@ describe('invalidation-watcher', () => {
         versionChanges: () => Promise.resolve(versionChanges),
         registerInvalidationFilters: () =>
           Promise.resolve(registerFilterResponses.shift() ?? {specs: []}),
+        status: () => Promise.resolve({}),
       };
 
       const lc = createSilentLogContext();
@@ -461,6 +462,7 @@ describe('invalidation-watcher', () => {
         );
       },
       registerInvalidationFilters: () => Promise.resolve({specs: []}),
+      status: () => Promise.resolve({}),
     };
 
     const watcher = new InvalidationWatcherService(
@@ -502,6 +504,7 @@ describe('invalidation-watcher', () => {
     const replicator: Replicator = {
       versionChanges: () => Promise.reject('unused'),
       registerInvalidationFilters: () => Promise.reject('unused'),
+      status: () => Promise.resolve({}),
     };
     const watcher = new InvalidationWatcherService(
       'id',

--- a/packages/zero-cache/src/services/invalidation-watcher/invalidation-watcher.ts
+++ b/packages/zero-cache/src/services/invalidation-watcher/invalidation-watcher.ts
@@ -194,13 +194,6 @@ export class InvalidationWatcherService
     assert(!this.#started, `InvalidationWatcher has already been started`);
     this.#started = true;
 
-    // Ensure that the Replicator is running. This is what kicks of the creation of the
-    // upstream zero.clients table and the replication to the replica. Note that even though
-    // the Replicator is queried from within the `while` loop, it should be proactively called
-    // before that, because ViewSyncers will call getTableSchema(), which also relies on
-    // replication having initialized, before sending a watch request.
-    void this.#registry.getReplicator();
-
     this.#lc.info?.('started');
     while (
       await Promise.race([

--- a/packages/zero-cache/src/services/paths.ts
+++ b/packages/zero-cache/src/services/paths.ts
@@ -6,3 +6,5 @@ export const VERSION_CHANGES_PATTERN = '/internal/replicator/:version/changes';
 
 export const REGISTER_FILTERS_PATTERN =
   '/internal/replicator/:version/register';
+
+export const REPLICATOR_STATUS_PATTERN = '/internal/replicator/:version/status';

--- a/packages/zero-cache/src/services/replicator-do.ts
+++ b/packages/zero-cache/src/services/replicator-do.ts
@@ -1,7 +1,11 @@
 import {LogContext, LogLevel, LogSink} from '@rocicorp/logger';
 import {BaseContext, Router, bodyOnly, post} from 'cf-shared/src/router.js';
 import {streamOut} from '../types/streams.js';
-import {REGISTER_FILTERS_PATTERN, VERSION_CHANGES_PATTERN} from './paths.js';
+import {
+  REGISTER_FILTERS_PATTERN,
+  REPLICATOR_STATUS_PATTERN,
+  VERSION_CHANGES_PATTERN,
+} from './paths.js';
 import {registerInvalidationFiltersRequest} from './replicator/replicator.js';
 import {ServiceRunner, ServiceRunnerEnv} from './service-runner.js';
 
@@ -34,7 +38,13 @@ export class ReplicatorDO {
   #initRoutes() {
     this.#router.register(REGISTER_FILTERS_PATTERN, this.#registerFilters);
     this.#router.register(VERSION_CHANGES_PATTERN, this.#versionChanges);
+    this.#router.register(REPLICATOR_STATUS_PATTERN, this.#status);
   }
+
+  #status = post().handleJSON(async () => {
+    const replicator = await this.#serviceRunner.getReplicator();
+    return replicator.status();
+  });
 
   #registerFilters = post()
     .with(bodyOnly(registerInvalidationFiltersRequest))

--- a/packages/zero-cache/src/services/replicator/replicator.ts
+++ b/packages/zero-cache/src/services/replicator/replicator.ts
@@ -1,6 +1,7 @@
 import {Lock} from '@rocicorp/lock';
 import type {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
+import type {ReadonlyJSONObject} from 'shared/src/json.js';
 import * as v from 'shared/src/valita.js';
 import {normalizedFilterSpecSchema} from '../../types/invalidation.js';
 import type {PostgresDB} from '../../types/pg.js';
@@ -55,6 +56,13 @@ export const versionChangeSchema = v.object({
 export type VersionChange = v.Infer<typeof versionChangeSchema>;
 
 export interface Replicator {
+  /**
+   * Returns an opaque message for human-readable consumption. This is
+   * purely for ensuring that the Replicator has started at least once to
+   * bootstrap a new replica.
+   */
+  status(): Promise<ReadonlyJSONObject>;
+
   /**
    * Registers a set of InvalidationFilterSpecs.
    *
@@ -139,6 +147,10 @@ export class ReplicatorService implements Replicator, Service {
       txSerializer,
       invalidationFilters,
     );
+  }
+
+  status() {
+    return Promise.resolve({status: 'ok'});
   }
 
   async run() {


### PR DESCRIPTION
Add a `/status` endpoint that gets sent from non-Replicator DO's at startup to ensure that the Replicator gets its initial run.