### PR TITLE
fix(zero-cache): include the location hint when getting ReplicatorDO stub

### DIFF
--- a/packages/zero-cache/src/services/location.ts
+++ b/packages/zero-cache/src/services/location.ts
@@ -1,0 +1,31 @@
+import {assert} from 'shared/src/asserts.js';
+import type {ServiceRunnerEnv} from './service-runner.js';
+
+export function getDOLocation(env: ServiceRunnerEnv) {
+  const locationHint = env.DO_LOCATION_HINT;
+  assertDOLocation(locationHint);
+  return {locationHint};
+}
+
+const DO_LOCATION_HINTS: ReadonlySet<string> = new Set([
+  'wnam',
+  'enam',
+  'sam',
+  'weur',
+  'eeur',
+  'apac',
+  'oc',
+  'afr',
+  'me',
+]);
+
+function assertDOLocation(
+  val: string,
+): asserts val is DurableObjectLocationHint {
+  assert(
+    DO_LOCATION_HINTS.has(val),
+    `${val} is not a valid location hint value.  Supported values: ${[
+      ...DO_LOCATION_HINTS.values(),
+    ].join(',')}.`,
+  );
+}

--- a/packages/zero-cache/src/services/service-runner.ts
+++ b/packages/zero-cache/src/services/service-runner.ts
@@ -16,6 +16,7 @@ import {
   InvalidationWatcherService,
 } from './invalidation-watcher/invalidation-watcher.js';
 import type {InvalidationWatcherRegistry} from './invalidation-watcher/registry.js';
+import {getDOLocation} from './location.js';
 import {Mutagen, MutagenService} from './mutagen/mutagen.js';
 import {
   REGISTER_FILTERS_PATTERN,
@@ -137,7 +138,7 @@ export class ServiceRunner
 
   #getReplicatorStub(): ReplicatorStub {
     const id = this.#env.replicatorDO.idFromName(REPLICATOR_ID);
-    const stub = this.#env.replicatorDO.get(id);
+    const stub = this.#env.replicatorDO.get(id, getDOLocation(this.#env));
     return new ReplicatorStub(this.#lc, stub);
   }
 


### PR DESCRIPTION
The first time the ReplicatorDO stub is accessed, it _should_ be close to the RunnerDO, but add the location hint to make this safer.