### PR TITLE
chore(zero-cache): use `Selector` type instead of `string` in `expand…

### DIFF
--- a/packages/zero-cache/src/zql/expansion.test.ts
+++ b/packages/zero-cache/src/zql/expansion.test.ts
@@ -21,7 +21,10 @@ describe('zql/expansion', () => {
   const REQUIRED_COLUMNS: RequiredColumns = (
     schema: string | undefined,
     table: string,
-  ) => [`${schema ? schema + '_' : ''}${table}_key`, `_0_version`];
+  ) => [
+    [table, `${schema ? schema + '_' : ''}${table}_key`],
+    [table, `_0_version`],
+  ];
 
   const cases: Case[] = [
     {
@@ -539,7 +542,7 @@ describe('zql/expansion', () => {
       expect(new Normalized(c.ast).query().query).toBe(
         stripCommentsAndWhitespace(c.original),
       );
-      const expanded = expandSubqueries(c.ast, REQUIRED_COLUMNS, new Set());
+      const expanded = expandSubqueries(c.ast, REQUIRED_COLUMNS, []);
       expect(new Normalized(expanded).query().query).toBe(
         stripCommentsAndWhitespace(c.afterSubqueryExpansion),
       );

--- a/packages/zero-cache/vitest.config.miniflare.ts
+++ b/packages/zero-cache/vitest.config.miniflare.ts
@@ -3,7 +3,7 @@ import {defineWorkersConfig} from '@cloudflare/vitest-pool-workers/config';
 export default defineWorkersConfig({
   test: {
     name: 'miniflare',
-    include: ['src/**/*.*test.?(c|m)[jt]s?(x)'],
+    include: ['src/**/*.test.?(c|m)[jt]s?(x)'],
     poolOptions: {
       workers: {
         main: './out/test/miniflare-environment.js',


### PR DESCRIPTION
…Subqueries`

To properly handle `group by` on the server, we can't have this typed as a raw string that we explode.

The plan for dealing with `group by` is to bubble up the required columns as a json aggregation:

```
SELECT
	issue.id,
	jsonb_agg(jsonb_build_object(
	  'id', "label"."id",
	  '_0_version', "label"._0_version
	)) as "agg/required/label",
	jsonb_agg(jsonb_build_object(
	  'id', "issueLabel".id,
	  '_0_version', "issueLabel"._0_version
	)) as "agg/required/issue"
FROM
	issue
	LEFT JOIN "issueLabel" ON "issueLabel"."issueID" = issue.id
	LEFT JOIN "label" ON label.id = "issueLabel"."labelID"
GROUP BY
	issue.id
```

These aggregations will have dots in them so we can't use any string splitting on `.` to determine what part is the table and what part is the column.

---

> Long term, I'm not sure we should issue these big queries to PG but instead query each table individually ourselves. Mainly to improve invalidation and to reduce the number of queries by de-duplicating the pieces amongst all registered queries.
>
> The downside is we're moving into the world of query planning if we do this but that seems unavoidable. The other risk is the number of rows we'd have to bring into the view syncer since the view-syncer would be doing joins rather than the db server.
