### PR TITLE
feat(zeppliear): re-enable prev/next

### DIFF
--- a/apps/zeppliear/src/issue-detail.tsx
+++ b/apps/zeppliear/src/issue-detail.tsx
@@ -109,12 +109,10 @@ export default function IssueDetail({
   const nextIssues = useQuery(
     getNextIssueQuery(query, issue, order, 'fwd'),
     queryDeps.concat(issue),
-    false, // temporarily disabled - slow query
   );
   const previousIssues = useQuery(
     getNextIssueQuery(query, issue, order, 'prev'),
     queryDeps.concat(issue),
-    false, // temporarily disabled - slow query
   );
 
   const comments = useQuery(


### PR DESCRIPTION
I thought I already did this. Must have gotten lost in the merge.

the queries are quick now:

https://github.com/rocicorp/mono/assets/1009003/cd5c0298-cfba-4c2c-89f3-85595c556599

