### PR TITLE
fix(zero-cache): fix logging to handle bigints

### DIFF
--- a/packages/zero-cache/src/types/streams.ts
+++ b/packages/zero-cache/src/types/streams.ts
@@ -50,7 +50,7 @@ export function streamIn<T extends JSONValue>(
     try {
       const value = BigIntJSON.parse(data);
       const msg = v.parse(value, schema);
-      lc.debug?.(`received`, BigIntJSON.stringify(msg));
+      lc.debug?.(`received`, data);
       sink.push(msg);
     } catch (e) {
       closer.close(e);


### PR DESCRIPTION
Now that row data is being streamed through VersionChange messages, the logging must be bigint aware.