### PR TITLE
feat(zeppliear): improve preload and add commentPreload url param option for aggressive comment preload

### DIFF
--- a/apps/zeppliear/src/issue-detail.tsx
+++ b/apps/zeppliear/src/issue-detail.tsx
@@ -27,6 +27,7 @@ import {
   Order,
   Priority,
   Status,
+  commentsForIssueQuery,
   orderQuery,
 } from './issue.js';
 import type {IssuesProps} from './issues-props.js';
@@ -116,21 +117,9 @@ export default function IssueDetail({
     queryDeps.concat(issue),
   );
 
-  const comments = useQuery(
-    zero.query.comment
-      .where('issueID', '=', detailIssueID ?? '')
-      .join(zero.query.member, 'member', 'comment.creatorID', 'member.id')
-      .select(
-        'comment.id',
-        'comment.issueID',
-        'comment.created',
-        'comment.creatorID',
-        'comment.body',
-        'member.name',
-      )
-      .asc('comment.created'),
-    [detailIssueID],
-  );
+  const comments = useQuery(commentsForIssueQuery(zero, detailIssueID ?? ''), [
+    detailIssueID,
+  ]);
 
   const handleClose = useCallback(() => {
     setDetailIssueID(null);

--- a/apps/zeppliear/src/issue.ts
+++ b/apps/zeppliear/src/issue.ts
@@ -307,6 +307,31 @@ export type IssueQuery = EntityQuery<
   }[]
 >;
 
+function commentBaseQuery(z: Zero<Collections>) {
+  return z.query.comment
+    .join(z.query.member, 'member', 'comment.creatorID', 'member.id')
+    .select(
+      'comment.id',
+      'comment.issueID',
+      'comment.created',
+      'comment.creatorID',
+      'comment.body',
+      'member.name',
+    )
+    .asc('comment.created');
+}
+
+export function commentsForIssuesQuery(
+  z: Zero<Collections>,
+  issueIDs: string[],
+) {
+  return commentBaseQuery(z).where('comment.issueID', 'IN', issueIDs);
+}
+
+export function commentsForIssueQuery(z: Zero<Collections>, issueID: string) {
+  return commentBaseQuery(z).where('comment.issueID', '=', issueID);
+}
+
 export function orderQuery<R>(
   // TODO: having to know the return type of the query to take it in as an arg is...
   // confusing at best.


### PR DESCRIPTION
1. Don't preload status and priority sorts, as the modified sort preload already gives us the first few pages of results, and the greatly slow down mutation propagation.
2. Lower issue list preload from 3000 to 2000 to further speed up mutation propagation.
2. Add a ?commentPreload=true url param for aggressively preloading the comments of the first 10k issues sorted by modified.  This results in a idbstore of roughly 20MB.
3. Don't preload comments for rows rendered for less than 250ms.
4. Allow up to 5 issues's comments to be preloaded in parallel.
5. Add a MAX_LOW_PRIORITY_PRELOAD_QUEUE_SIZE of 250.
