### PR TITLE
feat(zero-cache): pre-initialize replication transactions

### DIFF
--- a/packages/zero-cache/src/services/replicator/transaction-train.pg-test.ts
+++ b/packages/zero-cache/src/services/replicator/transaction-train.pg-test.ts
@@ -1,0 +1,150 @@
+import type {LogContext} from '@rocicorp/logger';
+import {resolver} from '@rocicorp/resolver';
+import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
+import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {expectTables, testDBs} from '../../test/db.js';
+import type {LexiVersion} from '../../types/lexi-version.js';
+import type {PostgresDB} from '../../types/pg.js';
+import {CREATE_INVALIDATION_TABLES} from './schema/invalidation.js';
+import {CREATE_REPLICATION_TABLES} from './schema/replication.js';
+import {TransactionFn, TransactionTrainService} from './transaction-train.js';
+
+describe('replicator/transaction-train', () => {
+  let db: PostgresDB;
+  let lc: LogContext;
+  let train: TransactionTrainService;
+  let trainDone: Promise<void>;
+
+  beforeEach(async () => {
+    db = await testDBs.create('transaction_train_test');
+    await db.unsafe(
+      `CREATE SCHEMA _zero;` +
+        CREATE_INVALIDATION_TABLES +
+        CREATE_REPLICATION_TABLES,
+    );
+
+    lc = createSilentLogContext();
+    train = new TransactionTrainService(lc, db);
+    trainDone = train.run();
+  });
+
+  afterEach(async () => {
+    await train.stop();
+    await trainDone;
+    await testDBs.drop(db);
+  });
+
+  const returnVersionsFn: TransactionFn<{
+    stateVersion: LexiVersion;
+    invalidationRegistryVersion: LexiVersion | null;
+  }> = (_writer, _readers, stateVersion, invalidationRegistryVersion) =>
+    Promise.resolve({
+      stateVersion,
+      invalidationRegistryVersion,
+    });
+
+  test('initial (null) versions', async () => {
+    const versions = await train.runNext(returnVersionsFn);
+    expect(versions).toEqual({
+      stateVersion: '00',
+      invalidationRegistryVersion: null,
+    });
+  });
+
+  test('version updates', async () => {
+    const date = new Date(Date.UTC(2024, 4, 31, 1, 2, 3));
+    await train.runNext(writer => {
+      writer.process(tx => [
+        tx`INSERT INTO _zero."TxLog" ${tx({
+          stateVersion: '03',
+          lsn: '00/03',
+          time: date.toISOString(),
+          xid: 123,
+        })}`,
+        tx`UPDATE _zero."InvalidationRegistryVersion" SET ${tx({
+          stateVersionAtLastSpecChange: '02',
+        })}`,
+      ]);
+    });
+
+    const versions = await train.runNext(returnVersionsFn);
+    expect(versions).toEqual({
+      stateVersion: '03',
+      invalidationRegistryVersion: '02',
+    });
+
+    await expectTables(db, {
+      ['_zero.TxLog']: [
+        {
+          stateVersion: '03',
+          lsn: '0/3',
+          time: date,
+          xid: 123,
+        },
+      ],
+      ['_zero.InvalidationRegistryVersion']: [
+        {stateVersionAtLastSpecChange: '02', lock: 'v'},
+      ],
+    });
+  });
+
+  test('blocks on concurrent updates', async () => {
+    const versions1 = await train.runNext(
+      async (
+        writer,
+        readers,
+        stateVersion,
+        invalidationFiltersRegistryVersion,
+      ) => {
+        const {promise: externalTxStarted, resolve: signalExternalTxWaiting} =
+          resolver();
+
+        // Simulate a concurrent lock held by another Replicator.
+        void db
+          .begin(async tx => {
+            void tx`
+            SELECT "stateVersionAtLastSpecChange" as version
+                FROM _zero."InvalidationRegistryVersion" 
+                FOR UPDATE;`
+              .simple()
+              .execute(); // This statement should block the transaction on lock.
+
+            signalExternalTxWaiting(); // Let the train proceed.
+
+            // Write new versions when the lock has been released.
+            await Promise.all([
+              tx`INSERT INTO _zero."TxLog" ${tx({
+                stateVersion: '05',
+                lsn: '00/03',
+                time: new Date().toISOString(),
+                xid: 123,
+              })}`,
+              tx`UPDATE _zero."InvalidationRegistryVersion" SET ${tx({
+                stateVersionAtLastSpecChange: '03',
+              })}`,
+            ]);
+          })
+          .then(() => lc.debug?.('committed concurrent update'));
+
+        await externalTxStarted;
+
+        return returnVersionsFn(
+          writer,
+          readers,
+          stateVersion,
+          invalidationFiltersRegistryVersion,
+        );
+      },
+    );
+    expect(versions1).toEqual({
+      stateVersion: '00',
+      invalidationRegistryVersion: null,
+    });
+
+    const versions2 = await train.runNext(returnVersionsFn);
+    expect(versions2).toEqual({
+      stateVersion: '05',
+      invalidationRegistryVersion: '03',
+    });
+  });
+});

--- a/packages/zero-cache/src/services/replicator/transaction-train.ts
+++ b/packages/zero-cache/src/services/replicator/transaction-train.ts
@@ -1,0 +1,225 @@
+import {Lock} from '@rocicorp/lock';
+import type {LogContext} from '@rocicorp/logger';
+import {assert} from 'shared/src/asserts.js';
+import {Queue} from 'shared/src/queue.js';
+import {
+  Mode,
+  TransactionPool,
+  synchronizedSnapshots,
+} from '../../db/transaction-pool.js';
+import type {LexiVersion} from '../../types/lexi-version.js';
+import type {PostgresDB} from '../../types/pg.js';
+
+export type TransactionFn<T> = (
+  writer: TransactionPool,
+  readers: TransactionPool,
+  preStateVersion: LexiVersion,
+  invalidationRegistryVersion: LexiVersion | null,
+) => Promise<T> | T;
+
+export interface TransactionTrain {
+  /**
+   * Runs the next {@link TransactionFn} after others have completed.
+   *
+   * When the `fn` completes, the train will automatically call {@link TransactionPool.setDone setDone()}
+   * on both the `readers` and `writer` pools (ref-count sharing is not supported) if
+   * not already set done. It is also fine for the `fn` to explicitly call `setDone()` to
+   * await transaction completion if required for the correctness of subsequent actions.
+   */
+  runNext<T>(fn: TransactionFn<T>): Promise<T>;
+}
+
+/**
+ * Transactions handled by the Replicator are inherently serial.
+ * In Postgres [logical replication](https://www.postgresql.org/docs/current/protocol-logical-replication.html#PROTOCOL-LOGICAL-MESSAGES-FLOW):
+ *
+ * > The logical replication protocol sends individual transactions one by one. This means that
+ * > all messages between a pair of Begin and Commit messages belong to the same transaction.
+ *
+ * For correctness, it is important that each transaction be committed before the next one begun.
+ * (Theoretically, more parallelism may be achieved by enabling streaming of in-progress
+ * transactions. This will add a considerable amount of complexity and should be assessed judiciously.)
+ *
+ * In addition, the replication process supports filter registered by the application to produce
+ * invalidation tags committed with each processed transaction. It is important that the
+ * registration of new filters be done in such a way that the version of the registration
+ * corresponds with the version at which the filter becomes active in the replication stream.
+ * Consequently, changes to the set of registered filters (an uncommon event), are also serialized
+ * in the stream of transactions processed by the replicator.
+ *
+ * ```
+ * >-------->------->------->------->------->------->------->
+ * TX 1 | TX 2 | Filter 1 | TX 3 | Filter 2 | TX 4 | TX 5 ...
+ * >-------->------->------->------->------->------->------->
+ * ```
+ *
+ * This serialization is guaranteed by two mechanisms.
+ * 1. Postgres row-level locks are acquired via `SELECT ... FOR UPDATE` statements.
+ * 2. Transaction processing and filter registration are serialized by this TransactionManager class.
+ *
+ * The first guarantees correctness in the midst of multiple Replicators running (e.g. during
+ * a rolling update). The second prevents the holding of a connection while waiting for the lock
+ * in the common case.
+ *
+ * The other job of the TransactionTrain is preemptive transaction initialization.
+ * Every transaction executed by the Replicator needs to both (1) acquire the `SELECT ... FOR UPDATE`
+ * lock and (2) read the current database state version (by querying the `TxLog` table.).
+ * To reduce replication latency, whenever a transaction is committed, the next one is preemptively
+ * initialized so that the initialization cost is incurred while the Replicator is idle rather
+ * than when the next action needs to be processed.
+ */
+export class TransactionTrainService implements TransactionTrain {
+  readonly #lc: LogContext;
+  readonly #replica: PostgresDB;
+  readonly #lock = new Lock();
+
+  #idleTimeout: ReturnType<typeof setTimeout> | undefined;
+  #started = false;
+  #isStopped = false;
+  #txPools = new Queue<TxPools>();
+
+  constructor(lc: LogContext, replica: PostgresDB) {
+    this.#lc = lc;
+    this.#replica = replica;
+  }
+
+  runNext<T>(fn: TransactionFn<T>): Promise<T> {
+    return this.#lock.withLock(async () => {
+      const {writer, readers, stateVersion, invalidationRegistryVersion} =
+        await this.#txPools.dequeue();
+
+      this.#clearIdleTimeout();
+
+      try {
+        return await fn(
+          writer,
+          readers,
+          stateVersion,
+          invalidationRegistryVersion,
+        );
+      } finally {
+        if (writer.isRunning()) {
+          writer.setDone();
+          await writer.done(); // Required for correctness.
+        }
+        if (readers.isRunning()) {
+          readers.setDone();
+        }
+      }
+    });
+  }
+
+  #setIdleTimeout() {
+    // The TransactionPool keeps its (initial) connections alive via keepalive pings.
+    // However, because the TransactionTrain holds locks, unused transactions are
+    // closed and refreshed periodically to avoid blocking database vacuuming.
+    this.#idleTimeout = setTimeout(
+      () => this.runNext(() => this.#lc.debug?.(`refreshing idle transaction`)),
+      IDLE_TIMEOUT_MS,
+    );
+  }
+
+  #clearIdleTimeout() {
+    clearTimeout(this.#idleTimeout);
+    this.#idleTimeout = undefined;
+  }
+
+  #createSnapshotSynchronizedPools() {
+    const {exportSnapshot, cleanupExport, setSnapshot} =
+      synchronizedSnapshots();
+    const writer = new TransactionPool(
+      this.#lc.withContext('pool', 'writer'),
+      Mode.SERIALIZABLE,
+      exportSnapshot,
+      cleanupExport,
+    );
+    const readers = new TransactionPool(
+      this.#lc.withContext('pool', 'readers'),
+      Mode.READONLY,
+      setSnapshot,
+      undefined,
+      2,
+      4, // TODO: Parameterize the max workers for the readers pool.
+    );
+    return {writer, readers};
+  }
+
+  async run(): Promise<void> {
+    assert(!this.#started, `Already started`);
+    this.#started = true;
+
+    while (!this.#isStopped) {
+      const start = Date.now();
+
+      const {writer, readers} = this.#createSnapshotSynchronizedPools();
+      const writerDone = writer.run(this.#replica);
+      const readersDone = readers.run(this.#replica);
+      let txPools: TxPools | undefined;
+
+      try {
+        const versions = await writer.processReadTask(tx =>
+          tx`
+        SELECT MAX("stateVersion") FROM _zero."TxLog";
+        SELECT "stateVersionAtLastSpecChange" as version
+               FROM _zero."InvalidationRegistryVersion" 
+               FOR UPDATE;`.simple(),
+        );
+        const stateVersion = versions[0][0].max ?? '00';
+        const invalidationRegistryVersion = versions[1][0].version;
+        writer.addLoggingContext('version', stateVersion);
+        readers.addLoggingContext('version', stateVersion);
+        this.#lc.debug?.(
+          `initialized tx pools at version ${stateVersion} (${
+            Date.now() - start
+          } ms)`,
+        );
+
+        txPools = {writer, readers, stateVersion, invalidationRegistryVersion};
+
+        this.#setIdleTimeout();
+        void this.#txPools.enqueue(txPools);
+      } catch (e) {
+        // This may happen if the InvalidationRegistryVersion was concurrently updated (e.g. by another Replicator),
+        // i.e. "PostgresError: could not serialize access due to concurrent update".
+        // Terminate the pools and loop to retry.
+        writer.fail(e);
+        readers.fail(e);
+      } finally {
+        readersDone.catch(e => this.#lc.error?.('error from reader pool', e));
+        const writerCleanup = writerDone
+          .catch(e => this.#lc.error?.('error from writer pool', e))
+          .finally(() => txPools && this.#txPools.delete(txPools));
+        // Always wait for the _writer_ to complete before the next loop iteration to
+        // ensure the desired tx visibility semantics. Because errors may occur while
+        // the pools are still queued (connection errors, etc.), also ensure that the
+        // txPools entry is deleted from the Queue.
+        //
+        // The readers pool, on the other hand, may be longer lived and shared with other
+        // components such as the InvalidationWatcher, so do not await that pool.
+        await writerCleanup;
+      }
+    }
+  }
+
+  // eslint-disable-next-line require-await
+  async stop(): Promise<void> {
+    assert(!this.#isStopped, 'Already stopped');
+    this.#isStopped = true;
+
+    // Stop any waiting tx pools.
+    void this.#txPools.dequeue().then(({writer, readers}) => {
+      writer.unref();
+      readers.unref();
+    });
+  }
+}
+
+type TxPools = {
+  writer: TransactionPool;
+  readers: TransactionPool;
+  stateVersion: LexiVersion;
+  invalidationRegistryVersion: LexiVersion | null;
+};
+
+// Close and refresh idle transactions after 5 minutes
+const IDLE_TIMEOUT_MS = 5 * 60_000;


### PR DESCRIPTION
Correctness and latency improvements in the Replicator.

### Correctness

In preparation for a post-DO world where single-writer semantics are not guaranteed by the application runtime, the **Transaction Train** encapsulates row-level locking to use Postgres to serialize replication-related actions on the replica. Specifically, replication and filter registration must be serialized, and in a world where two Replicators may be running during a software upgrade, row-level locking on the `_zero.InvalidationRegistryVersion` table ensures that replication logic is serialized even across multiple processes.

(This logic already existed but was not properly implemented. Replication acquired lock using a `SELECT ... FOR UPDATE` but registration did not.)

### Latency

The **Transaction Train** also reduces replication latency by pre-initializing transactions (snapshot exporting, snapshot sharing, and version lookups) in anticipation for the next replication message, rather than initializing them on demand. This cuts replication time in half from about 40ms to less than 20ms.

**Before**

<img width="1036" alt="Screenshot 2024-05-31 at 14 01 37" src="https://github.com/rocicorp/mono/assets/132324914/625d64ac-f63c-4b12-8fad-a4fe7d60ed2a">


**After**

<img width="1032" alt="Screenshot 2024-05-31 at 14 02 03" src="https://github.com/rocicorp/mono/assets/132324914/8ba8e2be-3c07-4976-b7e8-a290ec6364d7">
