### PR TITLE
feat(zero-cache): eliminate noop CVR writes

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -2,6 +2,7 @@ import type {LogContext} from '@rocicorp/logger';
 import type {AST} from '@rocicorp/zql/src/zql/ast/ast.js';
 import {compareUTF8} from 'compare-utf8';
 import {assert, unreachable} from 'shared/src/asserts.js';
+import {ReadonlyJSONValue, deepEqual} from 'shared/src/json.js';
 import {difference, intersection, union} from 'shared/src/set-utils.js';
 import type {DurableStorage} from '../../storage/durable-storage.js';
 import type {Storage} from '../../storage/storage.js';
@@ -167,6 +168,11 @@ export class CVRUpdater {
 
     this._cvr.lastActive = {epochMillis: newMillis};
     void this._writes.put(this._paths.lastActive(), this._cvr.lastActive);
+  }
+
+  // Exposed for testing.
+  numPendingWrites() {
+    return this._writes.pendingSize();
   }
 
   async flush(lc: LogContext, lastActive = new Date()): Promise<CVRSnapshot> {
@@ -744,7 +750,25 @@ export class CVRQueryDrivenUpdater extends CVRUpdater {
       existing.queriedColumns &&
       Object.keys(existing.queriedColumns).every(col => newQueriedColumns[col])
     ) {
-      return null; // No columns deleted.
+      if (received) {
+        const pending = this._writes.getPending(rowRecordPath);
+        if (
+          pending?.op === 'put' &&
+          deepEqual(
+            pending.value as ReadonlyJSONValue,
+            existing as ReadonlyJSONValue,
+          )
+        ) {
+          // Remove no-op writes from the WriteCache.
+          this._writes.cancelPending(rowRecordPath);
+          this._writes.cancelPending(
+            this._paths.rowPatch(existing.patchVersion, existing.id),
+          );
+        }
+      }
+
+      // No columns deleted.
+      return null;
     }
     const patchVersion = this.#assertNewVersion();
     const {id, rowVersion} = existing;
@@ -800,7 +824,10 @@ function mergeQueriedColumns(
           continue; // removeIDs from existing row.
         }
         if (!merged[col]?.includes(id)) {
-          (merged[col] ??= []).push(id);
+          const len = (merged[col] ??= []).push(id);
+          if (len > 1) {
+            merged[col].sort(); // Determinism is needed for diffing.
+          }
         }
       }
     }

--- a/packages/zero-cache/src/storage/write-cache.ts
+++ b/packages/zero-cache/src/storage/write-cache.ts
@@ -116,6 +116,19 @@ export class WriteCache implements Storage {
     return this.#cache.size;
   }
 
+  getPending(key: string): PutOp | DelOp | undefined {
+    const entry = this.#cache.get(key);
+    if (entry === undefined) {
+      return undefined;
+    }
+    const {value} = entry;
+    return value === undefined ? {op: 'del', key} : {op: 'put', key, value};
+  }
+
+  cancelPending(key: string) {
+    this.#cache.delete(key);
+  }
+
   pending(): (PutOp | DelOp)[] {
     const res: (PutOp | DelOp)[] = [];
     for (const [key, {value}] of this.#cache.entries()) {


### PR DESCRIPTION
Detect when a row record has not changed and avoid re-writing its CVR rows if so (both the record and patch). This greatly reduces the amount of I/O incurred for updates.

Before:
 
<img width="665" alt="Screenshot 2024-06-02 at 10 41 10" src="https://github.com/rocicorp/mono/assets/132324914/b0bdefaf-9084-4d7b-8610-e5bafe527995">


After:

<img width="629" alt="Screenshot 2024-06-02 at 10 49 04" src="https://github.com/rocicorp/mono/assets/132324914/a1902edb-7b79-4117-934a-ba7fb71551ed">
