### PR TITLE
feat(zero-cache): ACK VersionChanges received from the Replicator

### DIFF
--- a/packages/zero-cache/src/services/service-runner.ts
+++ b/packages/zero-cache/src/services/service-runner.ts
@@ -10,7 +10,6 @@ import {DurableStorage} from '../storage/durable-storage.js';
 import type {JSONObject} from '../types/bigint-json.js';
 import {PostgresDB, postgresTypeConfig} from '../types/pg.js';
 import {streamIn, type CancelableAsyncIterable} from '../types/streams.js';
-import {Subscription} from '../types/subscription.js';
 import {
   InvalidationWatcher,
   InvalidationWatcherService,
@@ -279,10 +278,6 @@ class ReplicatorStub implements Replicator {
     }
     ws.accept();
 
-    const subscription: Subscription<VersionChange> =
-      new Subscription<VersionChange>({cleanup: () => closer.close()});
-    const closer = streamIn(lc, ws, subscription, versionChangeSchema);
-
-    return subscription;
+    return streamIn(lc, ws, versionChangeSchema);
   }
 }


### PR DESCRIPTION
Add an ACK protocol to the websocket connection between the Replicator and ViewSyncer, and hook it into the `Subscription` class on both sides, so that the Replicator knows when the ViewSyncer has processed its message (in the same way that it would have when the communication was in-proc).

This ferries flow-control semantics across the websocket, allowing the Replicator to coalesce and clean up state (e.g. with reference counting) according to the progress of the View Syncers. This will facilitate the [sharing and cleanup of database transaction snapshot IDs](https://www.notion.so/replicache/Replication-View-Syncer-Snapshot-Sharing-9039679239094ca4a387a79acbc79106).

@tantaman with this you'll be able to add a `consumed` callback to the `Subscription<VersionChange>` [in the Replicator](https://github.com/rocicorp/mono/blob/ab6982a0d9ed234d18727836b7ca7852c00a0969/packages/zero-cache/src/services/replicator/incremental-sync.ts#L145) for cleaning up read snapshots.

@cesara I hope this doesn't disrupt your pending migration in the routing layer