### PR TITLE
fix(zql): prev/next: sort only on the first field in the reply ordering

### DIFF
--- a/packages/zql/src/zql/complex-expressions.test.ts
+++ b/packages/zql/src/zql/complex-expressions.test.ts
@@ -37,7 +37,7 @@ test.each(singleTableCases)('3 field paging - $name', async ({tracks}) => {
   }
 });
 
-test.skip('double left join & group by w/ 3 field paging & some overlap', async () => {
+test('double left join & group by w/ 3 field paging & some overlap', async () => {
   const artists = createRandomArtists(5);
   const albums = createRandomAlbums(5, artists);
   const tracks = createRandomTracks(10, albums, {

--- a/packages/zql/src/zql/ivm/source/set-source.ts
+++ b/packages/zql/src/zql/ivm/source/set-source.ts
@@ -349,15 +349,14 @@ export class SetSource<T extends PipelineEntity> implements Source<T> {
     }
     const alternateSort = this.#sorts.get(key);
     if (alternateSort !== undefined) {
-      const newOrdering: Ordering = [
-        ordering[0],
-        [[this.#name, 'id'], ordering[0][1]],
-      ];
-      return [alternateSort, newOrdering];
+      // We omit the `id` part when responding to the view so the view can correctly
+      // iterate past the common prefix.
+      const orderForReply: Ordering = [ordering[0]];
+      return [alternateSort, orderForReply];
     }
 
-    // We ignore asc/desc as directionality can be achieved by reversing the order of iteration.
-    // We do not need a separate source.
+    // We ignore asc/desc as directionality can be achieved by reversing the order of iteration
+    // rather than creating a separate source.
     // Must append id for uniqueness.
     const orderBy: Ordering = [
       [firstSelector, 'asc'],
@@ -367,13 +366,11 @@ export class SetSource<T extends PipelineEntity> implements Source<T> {
     const source = this.withNewOrdering(newComparator, orderBy);
 
     this.#sorts.set(key, source);
-    const dir = ordering[0][1];
-    const orderByKeepDirection: Ordering = [
-      [firstSelector, dir],
-      [[this.#name, 'id'], dir],
-    ];
+    // We omit the `id` part when responding to the view so the view can correctly
+    // iterate past the common prefix.
+    const orderForReply: Ordering = [ordering[0]];
 
-    return [source, orderByKeepDirection];
+    return [source, orderForReply];
     2;
   }
 


### PR DESCRIPTION
Fixes the `prev/next` bug in Zeppliear when sorting on `status, modified, id` or `priority, modified, id`, or anything that requires a sort on 3 fields where one or more are not unique was broken.

---

When we create a new source with an alternate ordering, we only order by the first field + the id.

E.g.,

```ts
issue.orderBy('status', 'modified', 'id')
```

will create a new source sorted by `status` and `id`, not `status`, `modified`, and `id`.

This helps prevent an explosion of alternate indices for a source.

The final view, however, is sorted completely. When we send history down to a view that view needs to understand that the source is only sorted by a prefix of it's desired sort. 

> **view sort:** [status, modified, id]
> **source sort:** [status, id]
> **common prefix to view and source:** [status]

When there is only a prefix overlap between the two and the query has a limit, the view will iterate until:

1. limit is fulfilled AND
2. we're at an element with a greater common prefix than the last element seen that put as at `limit`

We were incorrectly computing the common prefix between view and source to be `status`, `id` instead of just `status`.