### PR TITLE
feat(zql): Allow alternating order bys

### DIFF
--- a/packages/zero-client/src/client/zql/count-integration.test.ts
+++ b/packages/zero-client/src/client/zql/count-integration.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, test} from 'vitest';
 import * as agg from 'zql/src/zql/query/agg.js';
-import {exp, or} from '../../../../zql/src/zql/query/entity-query.js';
+import {exp, or} from 'zql/src/zql/query/entity-query.js';
 import {
   createRandomAlbums,
   createRandomArtists,

--- a/packages/zql/src/zql/ivm/view/tree-view.test.ts
+++ b/packages/zql/src/zql/ivm/view/tree-view.test.ts
@@ -98,17 +98,13 @@ test('replace', () => {
       const context = makeTestContext();
       const {materialite} = context;
       const orderBy = [[['test', 'x'], 'asc']] as const;
+      const comparator: Comparator<{x: number}> = (l, r) => l.x - r.x;
       const source = materialite.newSetSource<{x: number}>(
-        (l, r) => l.x - r.x,
+        comparator,
         orderBy,
         'test',
       );
-      const view = new TreeView(
-        context,
-        source.stream,
-        (l, r) => l.x - r.x,
-        orderBy,
-      );
+      const view = new TreeView(context, source.stream, comparator, orderBy);
 
       materialite.tx(() => {
         arr.forEach(x => source.add({x}));

--- a/packages/zql/src/zql/query/entity-query.ts
+++ b/packages/zql/src/zql/query/entity-query.ts
@@ -485,9 +485,6 @@ export class EntityQuery<From extends FromSet, Return = []> {
 
   orderBy(selector: SimpleSelector<From>, dir: 'asc' | 'desc' = 'asc') {
     const ast = this.#ast;
-    if (ast.orderBy && ast.orderBy.length > 1 && ast.orderBy[0][1] !== dir) {
-      throw new Misuse('Cannot mix ASC and DESC in ORDER BY (yet!)');
-    }
     const entry = [qualifySelector(ast, selector), dir] as const;
     const orderBy = ast.orderBy ? [...ast.orderBy, entry] : [entry];
     return new EntityQuery<From, Return>(this.#context, this.#name, {


### PR DESCRIPTION
This was already working but the AST factory methods did not allow it.