### PR TITLE
chore(reflect-server): Allow Node LTS version

### DIFF
--- a/mirror/mirror-server/package.json
+++ b/mirror/mirror-server/package.json
@@ -67,7 +67,7 @@
     "shared"
   ],
   "engines": {
-    "node": "18"
+    "node": ">=18"
   },
   "files": [
     "out"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2075,7 +2075,7 @@
         "typescript": "^5.4.2"
       },
       "engines": {
-        "node": "18"
+        "node": ">=18"
       }
     },
     "mirror/mirror-server/node_modules/@esbuild/android-arm": {
@@ -49628,6 +49628,8 @@
         "@web/test-runner": "^0.18.1",
         "@web/test-runner-playwright": "^0.11.0",
         "chai": "^5.0.0-alpha.2",
+        "command-line-args": "^5.2.1",
+        "command-line-usage": "^6.1.2",
         "compare-utf8": "^0.1.1",
         "esbuild": "^0.20.2",
         "fetch-mock": "^9.11.0",
@@ -49656,7 +49658,7 @@
         "hash-wasm": "^4.9.0",
         "idb": "^7.0.1",
         "playwright": "^1.43.1",
-        "replicache": "^14.2.2",
+        "replicache": "15.0.0",
         "shared": "0.0.0",
         "typescript": "^5.4.2",
         "xbytes": "^1.7.0"
@@ -50027,23 +50029,6 @@
         "@esbuild/win32-arm64": "0.20.2",
         "@esbuild/win32-ia32": "0.20.2",
         "@esbuild/win32-x64": "0.20.2"
-      }
-    },
-    "packages/replicache-perf/node_modules/replicache": {
-      "version": "14.2.2",
-      "resolved": "https://registry.npmjs.org/replicache/-/replicache-14.2.2.tgz",
-      "integrity": "sha512-PBlt6C2X7wSPVUUVBKumHPTXXmPZYO/rqoTQXYLgvzPabYkKBdJbCEHjh9hXNUU5vpkzDeEmOPQqlVus9zCiBg==",
-      "dependencies": {
-        "@badrap/valita": "^0.3.0",
-        "@rocicorp/lock": "^1.0.3",
-        "@rocicorp/logger": "^5.2.1",
-        "@rocicorp/resolver": "^1.0.1"
-      },
-      "bin": {
-        "replicache": "out/cli.cjs"
-      },
-      "engines": {
-        "node": ">=14.8.0"
       }
     },
     "packages/replicache-perf/node_modules/typescript": {
@@ -81003,6 +80988,8 @@
         "@web/test-runner": "^0.18.1",
         "@web/test-runner-playwright": "^0.11.0",
         "chai": "^5.0.0-alpha.2",
+        "command-line-args": "^5.2.1",
+        "command-line-usage": "^6.1.2",
         "compare-utf8": "^0.1.1",
         "esbuild": "^0.20.2",
         "fetch-mock": "^9.11.0",
@@ -81222,7 +81209,7 @@
         "hash-wasm": "^4.9.0",
         "idb": "^7.0.1",
         "playwright": "^1.43.1",
-        "replicache": "^14.2.2",
+        "replicache": "15.0.0",
         "shared": "0.0.0",
         "typescript": "^5.4.2",
         "xbytes": "^1.7.0"
@@ -81388,17 +81375,6 @@
             "@esbuild/win32-arm64": "0.20.2",
             "@esbuild/win32-ia32": "0.20.2",
             "@esbuild/win32-x64": "0.20.2"
-          }
-        },
-        "replicache": {
-          "version": "14.2.2",
-          "resolved": "https://registry.npmjs.org/replicache/-/replicache-14.2.2.tgz",
-          "integrity": "sha512-PBlt6C2X7wSPVUUVBKumHPTXXmPZYO/rqoTQXYLgvzPabYkKBdJbCEHjh9hXNUU5vpkzDeEmOPQqlVus9zCiBg==",
-          "requires": {
-            "@badrap/valita": "^0.3.0",
-            "@rocicorp/lock": "^1.0.3",
-            "@rocicorp/logger": "^5.2.1",
-            "@rocicorp/resolver": "^1.0.1"
           }
         },
         "typescript": {


### PR DESCRIPTION
The package.json was restricting the Node version to 18. This changes it to allow any version of Node that is >=18