### PR TITLE
fix(zql): prev regression | smarter merging of conditions when history is requested

### DIFF
--- a/packages/zql/src/zql/ivm/source/set-source.test.ts
+++ b/packages/zql/src/zql/ivm/source/set-source.test.ts
@@ -1345,8 +1345,8 @@ describe('merge requests', () => {
             value: 1,
           },
           {
-            selector: ['foo', 'bar'],
-            op: '=',
+            selector: ['foo', 'baz'],
+            op: '>',
             value: 2,
           },
         ],
@@ -1356,14 +1356,14 @@ describe('merge requests', () => {
         type: 'pull',
         hoistedConditions: [
           {
-            selector: ['foo', 'bar'],
-            op: '=',
-            value: 1,
+            selector: ['foo', 'baz'],
+            op: '>',
+            value: 3,
           },
           {
             selector: ['foo', 'bar'],
             op: '=',
-            value: 3,
+            value: 1,
           },
         ],
       },
@@ -1375,6 +1375,11 @@ describe('merge requests', () => {
             selector: ['foo', 'bar'],
             op: '=',
             value: 1,
+          },
+          {
+            op: '>',
+            selector: ['foo', 'baz'],
+            value: 2,
           },
         ],
       },

--- a/packages/zql/src/zql/ivm/source/set-source.ts
+++ b/packages/zql/src/zql/ivm/source/set-source.ts
@@ -496,6 +496,10 @@ export function mergeRequests(a: Request, b: Request | undefined) {
     return a;
   }
 
+  if (a === b) {
+    return a;
+  }
+
   const mergedConditions = mergeConditionLists(
     a.hoistedConditions,
     b.hoistedConditions,


### PR DESCRIPTION
Fixes the regression mentioned here: https://github.com/rocicorp/mono/pull/2002#issuecomment-2166516289

If a source receives two history request message from the same view it is because there is a `union` or `or` downstream of it. This merges the messages into one by widening the scope of conditions or throwing conditions out.

Notes:
- We should convert queries to DNF in the future (https://en.wikipedia.org/wiki/Disjunctive_normal_form).
- We should minimize a message's conditions (combine all ANDs for the same column) before widening (combining all ORs for the same column) so there is only 1 op per column to merge.
- In some cases sending multiple chunks of history is better than widening as each slice could be rather narrow. This might be worth supporting.

