### PR TITLE
feat(zero-cache): allow Subscription to diverge internal and published message types

### DIFF
--- a/packages/zero-cache/src/services/invalidation-watcher/hash-subscriptions.test.ts
+++ b/packages/zero-cache/src/services/invalidation-watcher/hash-subscriptions.test.ts
@@ -7,7 +7,7 @@ describe('invalidation-watcher/hash-subscriptions', () => {
   test('add, remove, compute updates', () => {
     const hashes = new HashSubscriptions();
 
-    const sub1 = new Subscription<QueryInvalidationUpdate>();
+    const sub1 = Subscription.create<QueryInvalidationUpdate>();
     const req1 = {
       queries: {
         q1: {
@@ -20,7 +20,7 @@ describe('invalidation-watcher/hash-subscriptions', () => {
         },
       },
     };
-    const sub2 = new Subscription<QueryInvalidationUpdate>();
+    const sub2 = Subscription.create<QueryInvalidationUpdate>();
     const req2 = {
       queries: {
         q1: {
@@ -33,7 +33,7 @@ describe('invalidation-watcher/hash-subscriptions', () => {
         },
       },
     };
-    const sub3 = new Subscription<QueryInvalidationUpdate>();
+    const sub3 = Subscription.create<QueryInvalidationUpdate>();
     const req3 = {
       queries: {
         q1: {

--- a/packages/zero-cache/src/services/invalidation-watcher/invalidation-watcher.pg-test.ts
+++ b/packages/zero-cache/src/services/invalidation-watcher/invalidation-watcher.pg-test.ts
@@ -473,7 +473,7 @@ describe('invalidation-watcher', () => {
     test(c.name, async () => {
       await initDB(db, c.setupDB);
 
-      const versionChanges = new Subscription<VersionChange>();
+      const versionChanges = Subscription.create<VersionChange>();
       const registerFilterResponses = c.registerFilterResponses ?? [];
       const replicator: Replicator = {
         versionChanges: () => Promise.resolve(versionChanges),
@@ -548,7 +548,7 @@ describe('invalidation-watcher', () => {
       versionChanges: () => {
         void subscriptionOpened.enqueue(true);
         return Promise.resolve(
-          new Subscription<VersionChange>({
+          Subscription.create<VersionChange>({
             cleanup: () => void subscriptionClosed.enqueue(true),
           }),
         );

--- a/packages/zero-cache/src/services/invalidation-watcher/invalidation-watcher.ts
+++ b/packages/zero-cache/src/services/invalidation-watcher/invalidation-watcher.ts
@@ -274,7 +274,7 @@ export class InvalidationWatcherService
     request: WatchRequest,
   ): Promise<CancelableAsyncIterable<QueryInvalidationUpdate>> {
     const subscription: Subscription<QueryInvalidationUpdate> =
-      new Subscription<QueryInvalidationUpdate>({
+      Subscription.create<QueryInvalidationUpdate>({
         // Coalescing {@link QueryInvalidationUpdate} messages is important in two contexts:
         //
         // * Capping the amount of outstanding work a subscriber has to process when

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -142,7 +142,7 @@ export class IncrementalSyncer {
   versionChanges(): Promise<CancelableAsyncIterable<VersionChange>> {
     const subscribe = (v: VersionChange) => subscription.push(v);
     const subscription: Subscription<VersionChange> =
-      new Subscription<VersionChange>({
+      Subscription.create<VersionChange>({
         coalesce: (curr, prev) => ({
           newVersion: curr.newVersion,
           prevVersion: prev.prevVersion,

--- a/packages/zero-cache/src/services/view-syncer/client-handler.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.test.ts
@@ -1,3 +1,4 @@
+import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
 import {describe, expect, test} from 'vitest';
 import type {
   Downstream,
@@ -5,7 +6,6 @@ import type {
   PokePartMessage,
   PokeStartMessage,
 } from 'zero-protocol';
-import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
 import type {JSONObject} from '../../types/bigint-json.js';
 import {Subscription} from '../../types/subscription.js';
 import {ClientHandler, Patch, ensureSafeJSON} from './client-handler.js';
@@ -17,11 +17,10 @@ describe('view-syncer/client-handler', () => {
 
     const received: Downstream[][] = [[], [], []];
     // Subscriptions that dump unconsumed pokes to `received`
-    const subscriptions = received.map(
-      bucket =>
-        new Subscription<Downstream>({
-          cleanup: msgs => bucket.push(...msgs),
-        }),
+    const subscriptions = received.map(bucket =>
+      Subscription.create<Downstream>({
+        cleanup: msgs => bucket.push(...msgs),
+      }),
     );
 
     const lc = createSilentLogContext();
@@ -319,7 +318,7 @@ describe('view-syncer/client-handler', () => {
       },
     ] satisfies Patch[]) {
       let terminated = false;
-      const downstream = new Subscription<Downstream>({
+      const downstream = Subscription.create<Downstream>({
         cleanup: () => {
           terminated = true;
         },

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -837,7 +837,7 @@ describe('view-syncer/service', () => {
         this.subscription === undefined,
         'Only one subscription expected (at a time) in this test',
       );
-      this.subscription = new Subscription<QueryInvalidationUpdate>({
+      this.subscription = Subscription.create<QueryInvalidationUpdate>({
         consumed: () => this.consumed.enqueue(true),
         cleanup: () => (this.subscription = undefined),
       });

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -177,7 +177,7 @@ export class ViewSyncerService implements ViewSyncer, Service {
     lc.debug?.('initConnection', initConnectionMessage);
 
     // Setup the downstream connection.
-    const downstream = new Subscription<Downstream>({
+    const downstream = Subscription.create<Downstream>({
       cleanup: (_, err) => {
         err
           ? lc.error?.(`client closed with error`, err)

--- a/packages/zero-cache/src/types/streams.test.ts
+++ b/packages/zero-cache/src/types/streams.test.ts
@@ -1,0 +1,136 @@
+import websocket from '@fastify/websocket';
+import type {LogContext} from '@rocicorp/logger';
+import {resolver} from '@rocicorp/resolver';
+import Fastify, {FastifyInstance} from 'fastify';
+import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
+import {Queue} from 'shared/src/queue.js';
+import {randInt} from 'shared/src/rand.js';
+import * as v from 'shared/src/valita.js';
+import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import WebSocket from 'ws';
+import {CancelableAsyncIterable, streamIn, streamOut} from './streams.js';
+import {Subscription} from './subscription.js';
+
+const messageSchema = v.object({
+  from: v.number(),
+  to: v.number(),
+  str: v.string(),
+});
+
+type Message = v.Infer<typeof messageSchema>;
+
+describe('streams', () => {
+  let lc: LogContext;
+
+  let server: FastifyInstance;
+  let producer: Subscription<Message>;
+  let consumed: Queue<Message>;
+  let cleanup: Promise<Message[]>;
+
+  let ws: WebSocket;
+  let consumer: CancelableAsyncIterable<Message>;
+
+  beforeEach(async () => {
+    lc = createSilentLogContext();
+
+    const {promise, resolve} = resolver<Message[]>();
+    cleanup = promise;
+
+    consumed = new Queue();
+    producer = Subscription.create({
+      consumed: m => consumed.enqueue(m),
+      coalesce: (curr, prev) => ({
+        from: prev.from,
+        to: curr.to,
+        str: prev.str + curr.str,
+      }),
+      cleanup: resolve,
+    });
+
+    server = Fastify();
+    await server.register(websocket);
+    server.get('/', {websocket: true}, ws => streamOut(lc, producer, ws));
+
+    // Run the server for real instead of using `injectWS()`, as that has a
+    // different behavior for ws.close().
+    const port = 3000 + Math.floor(randInt(0, 5000));
+    await server.listen({port});
+    lc.info?.(`server running on port ${port}`);
+    ws = new WebSocket(`http://localhost:${port}/`);
+
+    consumer = streamIn(lc, ws, messageSchema);
+  });
+
+  afterEach(async () => {
+    expect(ws.readyState).toSatisfy(x => x === ws.CLOSING || x === ws.CLOSED);
+    await server.close();
+  });
+
+  test('one at a time', async () => {
+    let num = 0;
+
+    producer.push({from: num, to: num + 1, str: 'foo'});
+    for await (const msg of consumer) {
+      if (num > 0) {
+        expect(await consumed.dequeue()).toEqual({
+          from: num - 1,
+          to: num,
+          str: 'foo',
+        });
+      }
+      expect(msg).toEqual({from: num, to: num + 1, str: 'foo'});
+
+      if (num === 3) {
+        break;
+      }
+      num++;
+      producer.push({from: num, to: num + 1, str: 'foo'});
+      expect(consumed.size()).toBe(0);
+    }
+
+    expect(await cleanup).toEqual([]);
+  });
+
+  test('coalesce and cleanup', async () => {
+    producer.push({from: 0, to: 1, str: 'foo'});
+    producer.push({from: 1, to: 2, str: 'bar'});
+    producer.push({from: 2, to: 3, str: 'baz'});
+
+    let i = 0;
+    for await (const msg of consumer) {
+      switch (i++) {
+        case 0:
+          expect(msg).toEqual({from: 0, to: 3, str: 'foobarbaz'});
+          producer.push({from: 3, to: 4, str: 'foo'});
+          producer.push({from: 4, to: 5, str: 'bar'});
+          break;
+        case 1:
+          expect(await consumed.dequeue()).toEqual({
+            from: 0,
+            to: 3,
+            str: 'foobarbaz',
+          });
+          expect(msg).toEqual({from: 3, to: 5, str: 'foobar'});
+          producer.push({from: 5, to: 6, str: 'foo'});
+          producer.push({from: 6, to: 7, str: 'boo'});
+          producer.push({from: 7, to: 8, str: 'doo'});
+          break;
+        case 2:
+          expect(await consumed.dequeue()).toEqual({
+            from: 3,
+            to: 5,
+            str: 'foobar',
+          });
+          expect(msg).toEqual({from: 5, to: 8, str: 'fooboodoo'});
+          producer.push({from: 8, to: 9, str: 'voo'});
+          producer.push({from: 9, to: 10, str: 'doo'});
+          ws.terminate(); // Close the websocket abruptly.
+          break;
+      }
+      expect(consumed.size()).toBe(0);
+    }
+
+    expect(consumed.size()).toBe(0);
+    expect(await cleanup).toEqual([{from: 8, to: 10, str: 'voodoo'}]);
+  });
+});


### PR DESCRIPTION
Allow separation of the internally managed message type from the externally published message type in the `Subscription` class. A convenience factory method facilitates existing use cases in which the types are the same, with the constructor offering the flexibility of separating the types, with a `publish` function used to convert an internal message of type `M` to a external message of type `T`.

This is first used by the WebSocket streaming code to remove the `_streamID` field from the messages serialized over the wire (used for coordinate ACKs). It will also be used by the Replicator to allow attaching a `TransactionPool` object to the pushed messages, allowing internal reference counting, and removing it from the message that is published / serialized over the web socket.

Also add a test for websocket streaming of Subscription messages. 