### PR TITLE
chore(zero-cache): Move version string to types

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/schema/paths.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/paths.ts
@@ -1,6 +1,6 @@
-import {versionFromLexi, versionToLexi} from '../../../types/lexi-version.js';
 import {rowIDHash} from '../../../types/row-key.js';
 import type {CVRVersion, ClientRecord, QueryRecord, RowID} from './types.js';
+import {versionFromString, versionString} from './types.js';
 
 // At a glance
 //
@@ -157,35 +157,5 @@ export class CVRPaths {
     client: ClientRecord | {id: string},
   ): string {
     return `${this.metadataPatchVersionPrefix(v)}q/${query.id}/c/${client.id}`;
-  }
-}
-
-export function versionString(v: CVRVersion) {
-  // The separator (e.g. ":") needs to be lexicographically greater than the
-  // storage key path separator (e.g. "/") so that "01/row-hash" is less than "01:01/row-hash".
-  // In particular, the traditional separator for major.minor versions (".") does not
-  // satisfy this quality.
-  return v.minorVersion
-    ? `${v.stateVersion}:${versionToLexi(v.minorVersion)}`
-    : v.stateVersion;
-}
-
-export function versionFromString(str: string): CVRVersion {
-  const parts = str.split(':');
-  const stateVersion = parts[0];
-  switch (parts.length) {
-    case 1: {
-      versionFromLexi(stateVersion); // Purely for validation.
-      return {stateVersion};
-    }
-    case 2: {
-      const minorVersion = versionFromLexi(parts[1]);
-      if (minorVersion > BigInt(Number.MAX_SAFE_INTEGER)) {
-        throw new Error(`minorVersion ${parts[1]} exceeds max safe integer`);
-      }
-      return {stateVersion, minorVersion: Number(minorVersion)};
-    }
-    default:
-      throw new TypeError(`Invalid version string ${str}`);
   }
 }


### PR DESCRIPTION
It is going to be used for Postgres too so it should not be in paths.