### PR TITLE
fix(zql): Fix possible collisions in generated IDs.

### DIFF
--- a/packages/zero-client/src/client/zql/distinct-integration.test.ts
+++ b/packages/zero-client/src/client/zql/distinct-integration.test.ts
@@ -105,19 +105,19 @@ describe('distinct', async () => {
         .distinct('track.id'),
       expected: [
         {
-          id: '1_1-1',
+          id: '1:1-1',
           track: {id: '1', length: 100, title: 'a', albumId: '1'},
           trackArtist: {id: '1-1', artistId: '1', trackId: '1'},
           [joinSymbol]: true,
         },
         {
-          id: '1-2_2',
+          id: '2:1-2',
           track: {id: '2', length: 200, title: 'b', albumId: '1'},
           trackArtist: {id: '1-2', artistId: '1', trackId: '2'},
           [joinSymbol]: true,
         },
         {
-          id: '1-3_3',
+          id: '3:1-3',
           track: {id: '3', length: 300, title: 'c', albumId: '1'},
           trackArtist: {id: '1-3', artistId: '1', trackId: '3'},
           [joinSymbol]: true,
@@ -137,21 +137,21 @@ describe('distinct', async () => {
         .distinct('track.id'),
       expected: [
         {
-          id: '1_1_1-1',
+          id: '1:1-1:1',
           track: {id: '1', length: 100, title: 'a', albumId: '1'},
           trackArtist: {id: '1-1', artistId: '1', trackId: '1'},
           artist: {id: '1', name: 'a'},
           [joinSymbol]: true,
         },
         {
-          id: '1_1-2_2',
+          id: '2:1-2:1',
           track: {id: '2', length: 200, title: 'b', albumId: '1'},
           trackArtist: {id: '1-2', artistId: '1', trackId: '2'},
           artist: {id: '1', name: 'a'},
           [joinSymbol]: true,
         },
         {
-          id: '1_1-3_3',
+          id: '3:1-3:1',
           track: {id: '3', length: 300, title: 'c', albumId: '1'},
           trackArtist: {id: '1-3', artistId: '1', trackId: '3'},
           artist: {id: '1', name: 'a'},

--- a/packages/zero-client/src/client/zql/integration.test.ts
+++ b/packages/zero-client/src/client/zql/integration.test.ts
@@ -519,35 +519,35 @@ test('join', async () => {
 
   expect(rows).toEqual([
     {
-      id: 'a_a_a-a',
+      id: 'a:a-a:a',
       issue: issues[0],
       issueLabel: issueLabels[0],
       label: labels[0],
       [joinSymbol]: true,
     },
     {
-      id: 'a_a-b_b',
+      id: 'a:a-b:b',
       issue: issues[0],
       issueLabel: issueLabels[1],
       label: labels[1],
       [joinSymbol]: true,
     },
     {
-      id: 'b_b_b-b',
+      id: 'b:b-b:b',
       issue: issues[1],
       issueLabel: issueLabels[2],
       label: labels[1],
       [joinSymbol]: true,
     },
     {
-      id: 'b_b-c_c',
+      id: 'b:b-c:c',
       issue: issues[1],
       issueLabel: issueLabels[3],
       label: labels[2],
       [joinSymbol]: true,
     },
     {
-      id: 'c_c_c-c',
+      id: 'c:c-c:c',
       issue: issues[2],
       issueLabel: issueLabels[4],
       label: labels[2],

--- a/packages/zero-client/src/client/zql/join-integration.test.ts
+++ b/packages/zero-client/src/client/zql/join-integration.test.ts
@@ -46,7 +46,7 @@ test('direct foreign key join: join a track to an album', async () => {
 
   expect(rows).toEqual([
     {
-      id: '1_1',
+      id: '1:1',
       track,
       album,
       [joinSymbol]: true,
@@ -62,17 +62,17 @@ test('direct foreign key join: join a track to an album', async () => {
   // re-add a track for that album
   await z.mutate.track.create({
     id: '2',
-    title: 'Track 1',
+    title: 'Track 2',
     length: 100,
     albumId: '1',
   });
 
   rows = await stmt.exec();
   const track2Album1 = {
-    id: '1_2',
+    id: '2:1',
     track: {
       id: '2',
-      title: 'Track 1',
+      title: 'Track 2',
       length: 100,
       albumId: '1',
     },
@@ -115,7 +115,7 @@ test('direct foreign key join: join a track to an album', async () => {
 
   rows = await stmt.exec();
   const track3Album3 = {
-    id: '3_3',
+    id: '3:3',
     track: {
       id: '3',
       title: 'Track 3',
@@ -141,7 +141,7 @@ test('direct foreign key join: join a track to an album', async () => {
 
   rows = await stmt.exec();
   const track4Album2 = {
-    id: '2_4',
+    id: '4:2',
     track: {
       id: '4',
       title: 'Track 4',
@@ -167,7 +167,7 @@ test('direct foreign key join: join a track to an album', async () => {
 
   rows = await stmt.exec();
   const track5Album1 = {
-    id: '1_5',
+    id: '5:1',
     track: {
       id: '5',
       title: 'Track 5',
@@ -363,7 +363,7 @@ test('junction and foreign key join, followed by aggregation: compose a playlist
 
   expect(rows).toEqual([
     {
-      id: '1_1-1_1_1_1-1',
+      id: '1-1:1:1:1-1:1',
       playlistTrack: {id: '1-1', playlistId: '1', trackId: '1', position: 1},
       track: {id: '1', title: 'Track 1', length: 100, albumId: '1'},
       album: {id: '1', title: 'Album 1', artistId: '1'},
@@ -372,7 +372,8 @@ test('junction and foreign key join, followed by aggregation: compose a playlist
       [joinSymbol]: true,
     },
     {
-      id: '1_1_1-2_2_2-1',
+      // TODO(aa): Where is the `1` id at the end coming from?
+      id: '1-2:2:1:2-1:1',
       playlistTrack: {id: '1-2', playlistId: '1', trackId: '2', position: 2},
       track: {id: '2', title: 'Track 2', length: 100, albumId: '1'},
       album: {id: '1', title: 'Album 1', artistId: '1'},
@@ -385,7 +386,7 @@ test('junction and foreign key join, followed by aggregation: compose a playlist
       [joinSymbol]: true,
     },
     {
-      id: '1_1-3_3_2_3-1',
+      id: '1-3:3:2:3-1:1',
       playlistTrack: {id: '1-3', playlistId: '1', trackId: '3', position: 3},
       track: {id: '3', title: 'Track 3', length: 100, albumId: '2'},
       album: {id: '2', title: 'Album 2', artistId: '1'},
@@ -394,7 +395,7 @@ test('junction and foreign key join, followed by aggregation: compose a playlist
       [joinSymbol]: true,
     },
     {
-      id: '1_1-4_4_2_4-1',
+      id: '1-4:4:2:4-1:1',
       playlistTrack: {id: '1-4', playlistId: '1', trackId: '4', position: 4},
       track: {id: '4', title: 'Track 4', length: 100, albumId: '2'},
       album: {id: '2', title: 'Album 2', artistId: '1'},

--- a/packages/zero-client/src/client/zql/left-join-integration.test.ts
+++ b/packages/zero-client/src/client/zql/left-join-integration.test.ts
@@ -48,9 +48,9 @@ test('left-join and aggregation to gather artists for a track', async () => {
   const rows = await stmt.exec();
   expect(rows).toEqual([
     {
-      id: '1_1_1_1-1',
-      trackArtist: {id: '1-1', trackId: '1', artistId: '1'},
+      id: '1:1-1:1:1',
       track: {id: '1', title: 'Track 1', length: 1000, albumId: '1'},
+      trackArtist: {id: '1-1', trackId: '1', artistId: '1'},
       artists: [
         {id: '1', name: 'Artist 1'},
         {id: '2', name: 'Artist 2'},
@@ -62,9 +62,9 @@ test('left-join and aggregation to gather artists for a track', async () => {
       [joinSymbol]: true,
     },
     {
-      id: '1_1_2_2-1',
-      trackArtist: {id: '2-1', trackId: '2', artistId: '1'},
+      id: '2:2-1:1:1',
       track: {id: '2', title: 'Track 2', length: 2000, albumId: '1'},
+      trackArtist: {id: '2-1', trackId: '2', artistId: '1'},
       artists: [
         {id: '1', name: 'Artist 1'},
         {id: '2', name: 'Artist 2'},
@@ -76,24 +76,24 @@ test('left-join and aggregation to gather artists for a track', async () => {
       [joinSymbol]: true,
     },
     {
-      id: '1_3',
+      id: '3:::1',
       track: {id: '3', title: 'Track 3', length: 3000, albumId: '1'},
-      album: {id: '1', title: 'Album 1', artistId: '1'},
       artists: [],
+      album: {id: '1', title: 'Album 1', artistId: '1'},
       [joinSymbol]: true,
     },
     {
-      id: '1_4',
+      id: '4:::1',
       track: {id: '4', title: 'Track 4', length: 4000, albumId: '1'},
-      album: {id: '1', title: 'Album 1', artistId: '1'},
       artists: [],
+      album: {id: '1', title: 'Album 1', artistId: '1'},
       [joinSymbol]: true,
     },
     {
-      id: '1_5',
+      id: '5:::1',
       track: {id: '5', title: 'Track 5', length: 5000, albumId: '1'},
-      album: {id: '1', title: 'Album 1', artistId: '1'},
       artists: [],
+      album: {id: '1', title: 'Album 1', artistId: '1'},
       [joinSymbol]: true,
     },
   ]);
@@ -127,7 +127,7 @@ test('left-join through single table', async () => {
 
   expect(rows).toEqual([
     {
-      id: '1_1',
+      id: '1:1',
       track: {id: '1', albumId: '1', title: 'track 1', length: 1},
       album: {id: '1', artistId: '', title: 'album 1'},
       [joinSymbol]: true,
@@ -145,13 +145,13 @@ test('left-join through single table', async () => {
 
   expect(rows).toEqual([
     {
-      id: '1_1',
+      id: '1:1',
       track: {id: '1', albumId: '1', title: 'track 1', length: 1},
       album: {id: '1', artistId: '', title: 'album 1'},
       [joinSymbol]: true,
     },
     {
-      id: '2',
+      id: '2:',
       track: {id: '2', albumId: '2', title: 'track 2', length: 2},
       [joinSymbol]: true,
     },
@@ -167,13 +167,13 @@ test('left-join through single table', async () => {
 
   expect(rows).toEqual([
     {
-      id: '1_1',
+      id: '1:1',
       track: {id: '1', albumId: '1', title: 'track 1', length: 1},
       album: {id: '1', artistId: '', title: 'album 1'},
       [joinSymbol]: true,
     },
     {
-      id: '2_2',
+      id: '2:2',
       album: {id: '2', artistId: '', title: 'album 2'},
       track: {id: '2', albumId: '2', title: 'track 2', length: 2},
       [joinSymbol]: true,
@@ -186,7 +186,7 @@ test('left-join through single table', async () => {
 
   expect(rows).toEqual([
     {
-      id: '2_2',
+      id: '2:2',
       album: {id: '2', artistId: '', title: 'album 2'},
       track: {id: '2', albumId: '2', title: 'track 2', length: 2},
       [joinSymbol]: true,
@@ -199,7 +199,7 @@ test('left-join through single table', async () => {
 
   expect(rows).toEqual([
     {
-      id: '2',
+      id: '2:',
       track: {id: '2', albumId: '2', title: 'track 2', length: 2},
       [joinSymbol]: true,
     },
@@ -277,21 +277,21 @@ test('left-join through junction edge', async () => {
 
   expect(rows).toEqual([
     {
-      id: '1_1_1-1',
-      trackArtist: {id: '1-1', trackId: '1', artistId: '1'},
+      id: '1:1-1:1',
       track: {id: '1', albumId: '1', title: 'track 1', length: 1},
+      trackArtist: {id: '1-1', trackId: '1', artistId: '1'},
       artists: {id: '1', name: 'artist 1'},
       [joinSymbol]: true,
     },
     {
-      id: '1_1-2_2',
-      trackArtist: {id: '1-2', trackId: '1', artistId: '2'},
+      id: '1:1-2:2',
       track: {id: '1', albumId: '1', title: 'track 1', length: 1},
+      trackArtist: {id: '1-2', trackId: '1', artistId: '2'},
       artists: {id: '2', name: 'artist 2'},
       [joinSymbol]: true,
     },
     {
-      id: '2',
+      id: '2::',
       track: {id: '2', albumId: '1', title: 'track 2', length: 1},
       [joinSymbol]: true,
     },

--- a/packages/zero-client/src/client/zql/order-limit-integration.test.ts
+++ b/packages/zero-client/src/client/zql/order-limit-integration.test.ts
@@ -45,10 +45,7 @@ describe('sorting and limiting with different query operations', async () => {
   const joinAlbumToArtist = (album: Album) => {
     const artist = must(indexedArtists[album.artistId]);
     return {
-      id:
-        album.id < artist.id
-          ? album.id + '_' + artist.id
-          : artist.id + '_' + album.id,
+      id: `${album.id}:${artist.id}`,
       album,
       artist,
       [joinSymbol]: true,
@@ -59,13 +56,8 @@ describe('sorting and limiting with different query operations', async () => {
     const tas = indexedTrackArtists[t.id];
     return tas.map(ta => {
       const a = indexedArtists[ta.artistId];
-      const firstJoinId =
-        t.id < ta.id ? t.id + '_' + ta.id : ta.id + '_' + t.id;
       return {
-        id:
-          firstJoinId < a.id
-            ? firstJoinId + '_' + a.id
-            : a.id + '_' + firstJoinId,
+        id: `${t.id}:${ta.id}:${a.id}`,
         [joinSymbol]: true,
         track: t,
         trackArtist: ta,

--- a/packages/zql/src/zql/ivm/graph/operators/difference-index.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/difference-index.ts
@@ -1,11 +1,5 @@
 import type {Primitive} from '../../../ast/ast.js';
 import type {Entry} from '../../multiset.js';
-import {
-  JoinResult,
-  StringOrNumber,
-  isJoinResult,
-  joinSymbol,
-} from '../../types.js';
 
 /**
  * Indexes difference events by a key.
@@ -90,82 +84,4 @@ export class DifferenceIndex<Key extends Primitive | undefined, V> {
   toString() {
     return JSON.stringify([...this.#index]);
   }
-}
-
-export function concatIds(idA: string | number, idB: string | number) {
-  let ret;
-  if (idA.toString() < idB.toString()) {
-    ret = idA + '_' + idB;
-  } else {
-    ret = idB + '_' + idA;
-  }
-
-  return ret;
-}
-
-// TODO(aa): In the case where `innerValue` is undefined, the id component for
-// that value is not included in the generated id. This can create collisions
-// when there are multiple levels of joins going on. We should just emit an
-// empty id in that case, e.g., `foo_` when the right side of the join is
-// undefined.
-export function combineRows<
-  AValue,
-  BValue,
-  AAlias extends string,
-  BAlias extends string,
->(
-  outerValue: AValue,
-  innerValue: BValue | undefined,
-  outerAlias: AAlias | undefined,
-  innerAlias: BAlias | undefined,
-  getOuterValueIdentity: (value: AValue) => StringOrNumber,
-  getInnerValueIdentity: (value: BValue) => StringOrNumber,
-): JoinResult<AValue, BValue, AAlias, BAlias> {
-  // Flatten our join results so we don't
-  // end up arbitrarily deep after many joins.
-  // This handles the case of: A JOIN B JOIN C ...
-  // A JOIN B produces {a, b}
-  // A JOIN B JOIN C would produce {a_b: {a, b}, c} if we didn't flatten here.
-  if (innerValue === undefined && isJoinResult(outerValue)) {
-    return outerValue as JoinResult<AValue, BValue, AAlias, BAlias>;
-  } else if (innerValue === undefined) {
-    return {
-      [joinSymbol]: true,
-      id: getOuterValueIdentity(outerValue as unknown as AValue & BValue),
-      [outerAlias!]: outerValue,
-    } as JoinResult<AValue, BValue, AAlias, BAlias>;
-  } else if (isJoinResult(outerValue) && isJoinResult(innerValue)) {
-    return {
-      ...outerValue,
-      ...innerValue,
-      id: concatIds(outerValue.id, innerValue.id),
-    } as JoinResult<AValue, BValue, AAlias, BAlias>;
-  } else if (isJoinResult(outerValue)) {
-    return {
-      ...outerValue,
-      [innerAlias!]: innerValue,
-      id: concatIds(
-        outerValue.id,
-        getInnerValueIdentity(innerValue as unknown as AValue & BValue),
-      ),
-    } as JoinResult<AValue, BValue, AAlias, BAlias>;
-  } else if (isJoinResult(innerValue)) {
-    return {
-      ...innerValue,
-      [outerAlias!]: outerValue,
-      id: concatIds(
-        getOuterValueIdentity(outerValue as unknown as AValue & BValue),
-        innerValue.id,
-      ),
-    } as JoinResult<AValue, BValue, AAlias, BAlias>;
-  }
-  return {
-    [joinSymbol]: true,
-    id: concatIds(
-      getOuterValueIdentity(outerValue as unknown as AValue & BValue),
-      getInnerValueIdentity(innerValue as unknown as AValue & BValue),
-    ),
-    [outerAlias!]: outerValue,
-    [innerAlias!]: innerValue,
-  } as JoinResult<AValue, BValue, AAlias, BAlias>;
 }

--- a/packages/zql/src/zql/ivm/graph/operators/left-join-operator.test.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/left-join-operator.test.ts
@@ -59,7 +59,7 @@ test('left join', () => {
   expect(items).toEqual([
     [
       {
-        id: '1',
+        id: '1:',
         [joinSymbol]: true,
         track: {
           id: '1',
@@ -96,7 +96,7 @@ test('left join', () => {
   expect(items).toEqual([
     [
       {
-        id: '1_1',
+        id: '1:1',
         [joinSymbol]: true,
         track: {
           id: '1',
@@ -114,7 +114,7 @@ test('left join', () => {
     ],
     [
       {
-        id: '1',
+        id: '1:',
         [joinSymbol]: true,
         track: {
           id: '1',
@@ -152,7 +152,7 @@ test('left join', () => {
   expect(items).toEqual([
     [
       {
-        id: '1_1',
+        id: '1:1',
         [joinSymbol]: true,
         track: {
           id: '1',
@@ -221,8 +221,8 @@ test('left join', () => {
     [
       [
         {
-          id: '1',
-          title: 'Track One',
+          id: '2',
+          title: 'Track Two',
           length: 1,
           albumId: '1',
         },
@@ -238,11 +238,11 @@ test('left join', () => {
   expect(items).toEqual([
     [
       {
-        id: '1_1',
+        id: '2:1',
         [joinSymbol]: true,
         track: {
-          id: '1',
-          title: 'Track One',
+          id: '2',
+          title: 'Track Two',
           length: 1,
           albumId: '1',
         },
@@ -250,6 +250,42 @@ test('left join', () => {
           id: '1',
           title: 'Album One',
           artistId: '1',
+        },
+      },
+      1,
+    ],
+  ]);
+
+  // special chars
+  items.length = 0;
+  trackInput.newDifference(
+    version,
+    [
+      [
+        {
+          id: ':%?',
+          title: 'Track :%?',
+          length: 1,
+          albumId: '2',
+        },
+        1,
+      ],
+    ],
+    undefined,
+  );
+  trackInput.commit(version);
+  ++version;
+
+  expect(items).toEqual([
+    [
+      {
+        id: '%3A%25%3F:',
+        [joinSymbol]: true,
+        track: {
+          id: ':%?',
+          title: 'Track :%?',
+          length: 1,
+          albumId: '2',
         },
       },
       1,
@@ -370,7 +406,7 @@ test('junction table left join', () => {
   expect(items).toEqual([
     [
       {
-        id: '1',
+        id: '1::',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         [joinSymbol]: true,
       },
@@ -378,7 +414,7 @@ test('junction table left join', () => {
     ],
     [
       {
-        id: '1_1-1',
+        id: '1:1-1:',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         trackArtist: {id: '1-1', trackId: '1', artistId: '1'},
         [joinSymbol]: true,
@@ -387,7 +423,7 @@ test('junction table left join', () => {
     ],
     [
       {
-        id: '1',
+        id: '1::',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         [joinSymbol]: true,
       },
@@ -395,7 +431,7 @@ test('junction table left join', () => {
     ],
     [
       {
-        id: '1_1-2',
+        id: '1:1-2:',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         trackArtist: {id: '1-2', trackId: '1', artistId: '2'},
         [joinSymbol]: true,
@@ -404,7 +440,7 @@ test('junction table left join', () => {
     ],
     [
       {
-        id: '1_1_1-1',
+        id: '1:1-1:1',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         trackArtist: {id: '1-1', trackId: '1', artistId: '1'},
         artist: {id: '1', name: 'Artist One'},
@@ -414,7 +450,7 @@ test('junction table left join', () => {
     ],
     [
       {
-        id: '1_1-1',
+        id: '1:1-1:',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         trackArtist: {id: '1-1', trackId: '1', artistId: '1'},
         [joinSymbol]: true,
@@ -423,7 +459,7 @@ test('junction table left join', () => {
     ],
     [
       {
-        id: '1_1-2_2',
+        id: '1:1-2:2',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         trackArtist: {id: '1-2', trackId: '1', artistId: '2'},
         artist: {id: '2', name: 'Artist Two'},
@@ -433,7 +469,7 @@ test('junction table left join', () => {
     ],
     [
       {
-        id: '1_1-2',
+        id: '1:1-2:',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         trackArtist: {id: '1-2', trackId: '1', artistId: '2'},
         [joinSymbol]: true,
@@ -446,7 +482,7 @@ test('junction table left join', () => {
   expect([...normalize(items, x => x.id)]).toEqual([
     [
       {
-        id: '1_1_1-1',
+        id: '1:1-1:1',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         trackArtist: {id: '1-1', trackId: '1', artistId: '1'},
         artist: {id: '1', name: 'Artist One'},
@@ -456,7 +492,7 @@ test('junction table left join', () => {
     ],
     [
       {
-        id: '1_1-2_2',
+        id: '1:1-2:2',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         trackArtist: {id: '1-2', trackId: '1', artistId: '2'},
         artist: {id: '2', name: 'Artist Two'},
@@ -491,7 +527,7 @@ test('junction table left join', () => {
   expect(items).toEqual([
     [
       {
-        id: '1_1_1-1',
+        id: '1:1-1:1',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         trackArtist: {id: '1-1', trackId: '1', artistId: '1'},
         artist: {id: '1', name: 'Artist One'},
@@ -501,7 +537,7 @@ test('junction table left join', () => {
     ],
     [
       {
-        id: '1_1-2_2',
+        id: '1:1-2:2',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         trackArtist: {id: '1-2', trackId: '1', artistId: '2'},
         artist: {id: '2', name: 'Artist Two'},
@@ -534,7 +570,7 @@ test('junction table left join', () => {
   expect(items).toEqual([
     [
       {
-        id: '1_1_1-1',
+        id: '1:1-1:1',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         trackArtist: {id: '1-1', trackId: '1', artistId: '1'},
         artist: {id: '1', name: 'Artist One'},
@@ -544,7 +580,7 @@ test('junction table left join', () => {
     ],
     [
       {
-        id: '1_1-2_2',
+        id: '1:1-2:2',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         trackArtist: {id: '1-2', trackId: '1', artistId: '2'},
         artist: {id: '2', name: 'Artist Two'},
@@ -583,7 +619,7 @@ test('junction table left join', () => {
   expect(items).toEqual([
     [
       {
-        id: '1_1_1-1',
+        id: '1:1-1:1',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         trackArtist: {id: '1-1', trackId: '1', artistId: '1'},
         artist: {id: '1', name: 'Artist One'},
@@ -593,7 +629,7 @@ test('junction table left join', () => {
     ],
     [
       {
-        id: '1_1-2_2',
+        id: '1:1-2:2',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         trackArtist: {id: '1-2', trackId: '1', artistId: '2'},
         artist: {id: '2', name: 'Artist Two'},
@@ -603,7 +639,7 @@ test('junction table left join', () => {
     ],
     [
       {
-        id: '1',
+        id: '1::',
         track: {
           id: '1',
           title: 'Track One',
@@ -646,7 +682,7 @@ test('junction table left join', () => {
   expect(items).toEqual([
     [
       {
-        id: '1_1_1-1',
+        id: '1:1-1:1',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         trackArtist: {id: '1-1', trackId: '1', artistId: '1'},
         artist: {id: '1', name: 'Artist One'},
@@ -656,7 +692,7 @@ test('junction table left join', () => {
     ],
     [
       {
-        id: '1',
+        id: '1::',
         track: {
           id: '1',
           title: 'Track One',
@@ -669,7 +705,7 @@ test('junction table left join', () => {
     ],
     [
       {
-        id: '1_1-2_2',
+        id: '1:1-2:2',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         trackArtist: {id: '1-2', trackId: '1', artistId: '2'},
         artist: {id: '2', name: 'Artist Two'},
@@ -706,7 +742,7 @@ test('junction table left join', () => {
   expect(items).toEqual([
     [
       {
-        id: '1_1_1-1',
+        id: '1:1-1:1',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         trackArtist: {id: '1-1', trackId: '1', artistId: '1'},
         artist: {id: '1', name: 'Artist One'},
@@ -716,7 +752,7 @@ test('junction table left join', () => {
     ],
     [
       {
-        id: '1_1-1',
+        id: '1:1-1:',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         trackArtist: {id: '1-1', trackId: '1', artistId: '1'},
         [joinSymbol]: true,
@@ -725,7 +761,7 @@ test('junction table left join', () => {
     ],
     [
       {
-        id: '1_1-2_2',
+        id: '1:1-2:2',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         trackArtist: {id: '1-2', trackId: '1', artistId: '2'},
         artist: {id: '2', name: 'Artist Two'},
@@ -735,7 +771,7 @@ test('junction table left join', () => {
     ],
     [
       {
-        id: '1_1-2',
+        id: '1:1-2:',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         trackArtist: {id: '1-2', trackId: '1', artistId: '2'},
         [joinSymbol]: true,
@@ -767,7 +803,7 @@ test('junction table left join', () => {
   expect(items).toEqual([
     [
       {
-        id: '2',
+        id: '2::',
         track: {id: '2', title: 'Track Two', length: 1, albumId: '2'},
         [joinSymbol]: true,
       },
@@ -889,7 +925,7 @@ test('repro 1', () => {
   expect(items).toEqual([
     [
       {
-        id: '1_1_1-1',
+        id: '1:1-1:1',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         trackArtist: {id: '1-1', trackId: '1', artistId: '1'},
         artist: {id: '1', name: 'Artist One'},
@@ -899,7 +935,7 @@ test('repro 1', () => {
     ],
     [
       {
-        id: '1',
+        id: '1::',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         [joinSymbol]: true,
       },
@@ -907,7 +943,7 @@ test('repro 1', () => {
     ],
     [
       {
-        id: '1_1-2_2',
+        id: '1:1-2:2',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         trackArtist: {id: '1-2', trackId: '1', artistId: '2'},
         artist: {id: '2', name: 'Artist Two'},
@@ -945,7 +981,7 @@ test('repro 1', () => {
   expect(items).toEqual([
     [
       {
-        id: '1_1_1-1',
+        id: '1:1-1:1',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         trackArtist: {id: '1-1', trackId: '1', artistId: '1'},
         artist: {id: '1', name: 'Artist One'},
@@ -955,7 +991,7 @@ test('repro 1', () => {
     ],
     [
       {
-        id: '1_1-2_2',
+        id: '1:1-2:2',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         trackArtist: {id: '1-2', trackId: '1', artistId: '2'},
         artist: {id: '2', name: 'Artist Two'},
@@ -965,7 +1001,7 @@ test('repro 1', () => {
     ],
     [
       {
-        id: '1',
+        id: '1::',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         [joinSymbol]: true,
       },
@@ -1004,8 +1040,8 @@ test('add track & album, then remove album', () => {
     [
       [
         {
-          id: '1',
-          title: 'Track One',
+          id: '2',
+          title: 'Track Two',
           length: 1,
           albumId: '1',
         },
@@ -1035,16 +1071,16 @@ test('add track & album, then remove album', () => {
   expect(items).toEqual([
     [
       {
-        id: '1',
-        track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
+        id: '2:',
+        track: {id: '2', title: 'Track Two', length: 1, albumId: '1'},
         [joinSymbol]: true,
       },
       1,
     ],
     [
       {
-        id: '1_1',
-        track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
+        id: '2:1',
+        track: {id: '2', title: 'Track Two', length: 1, albumId: '1'},
         album: {id: '1', title: 'Album One', artistId: '1'},
         [joinSymbol]: true,
       },
@@ -1052,8 +1088,8 @@ test('add track & album, then remove album', () => {
     ],
     [
       {
-        id: '1',
-        track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
+        id: '2:',
+        track: {id: '2', title: 'Track Two', length: 1, albumId: '1'},
         [joinSymbol]: true,
       },
       -1,
@@ -1082,8 +1118,8 @@ test('add track & album, then remove album', () => {
   expect(items).toEqual([
     [
       {
-        id: '1_1',
-        track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
+        id: '2:1',
+        track: {id: '2', title: 'Track Two', length: 1, albumId: '1'},
         album: {id: '1', title: 'Album One', artistId: '1'},
         [joinSymbol]: true,
       },
@@ -1091,8 +1127,8 @@ test('add track & album, then remove album', () => {
     ],
     [
       {
-        id: '1',
-        track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
+        id: '2:',
+        track: {id: '2', title: 'Track Two', length: 1, albumId: '1'},
         [joinSymbol]: true,
       },
       1,
@@ -1172,7 +1208,7 @@ test('one to many, remove the one, add the one', () => {
   expect(items).toEqual([
     [
       {
-        id: '1',
+        id: '1:',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         [joinSymbol]: true,
       },
@@ -1180,7 +1216,7 @@ test('one to many, remove the one, add the one', () => {
     ],
     [
       {
-        id: '1_1-1',
+        id: '1:1-1',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         trackArtist: {id: '1-1', trackId: '1', artistId: '1'},
         [joinSymbol]: true,
@@ -1189,7 +1225,7 @@ test('one to many, remove the one, add the one', () => {
     ],
     [
       {
-        id: '1',
+        id: '1:',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         [joinSymbol]: true,
       },
@@ -1197,7 +1233,7 @@ test('one to many, remove the one, add the one', () => {
     ],
     [
       {
-        id: '1_1-2',
+        id: '1:1-2',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         trackArtist: {id: '1-2', trackId: '1', artistId: '2'},
         [joinSymbol]: true,
@@ -1228,7 +1264,7 @@ test('one to many, remove the one, add the one', () => {
   expect(items).toEqual([
     [
       {
-        id: '1_1-1',
+        id: '1:1-1',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         trackArtist: {id: '1-1', trackId: '1', artistId: '1'},
         [joinSymbol]: true,
@@ -1237,7 +1273,7 @@ test('one to many, remove the one, add the one', () => {
     ],
     [
       {
-        id: '1_1-2',
+        id: '1:1-2',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         trackArtist: {id: '1-2', trackId: '1', artistId: '2'},
         [joinSymbol]: true,
@@ -1268,7 +1304,7 @@ test('one to many, remove the one, add the one', () => {
   expect(items).toEqual([
     [
       {
-        id: '1_1-1',
+        id: '1:1-1',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         trackArtist: {id: '1-1', trackId: '1', artistId: '1'},
         [joinSymbol]: true,
@@ -1277,7 +1313,7 @@ test('one to many, remove the one, add the one', () => {
     ],
     [
       {
-        id: '1_1-2',
+        id: '1:1-2',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         trackArtist: {id: '1-2', trackId: '1', artistId: '2'},
         [joinSymbol]: true,
@@ -1406,7 +1442,7 @@ test('two tracks, only 1 is linked to artists', () => {
   expect(items).toEqual([
     [
       {
-        id: '1',
+        id: '1::',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         [joinSymbol]: true,
       },
@@ -1414,7 +1450,7 @@ test('two tracks, only 1 is linked to artists', () => {
     ],
     [
       {
-        id: '2',
+        id: '2::',
         track: {id: '2', albumId: '1', title: 'track 2', length: 1},
         [joinSymbol]: true,
       },
@@ -1422,7 +1458,7 @@ test('two tracks, only 1 is linked to artists', () => {
     ],
     [
       {
-        id: '1_1_1-1',
+        id: '1:1-1:1',
         trackArtist: {id: '1-1', trackId: '1', artistId: '1'},
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         artist: {id: '1', name: 'Artist One'},
@@ -1432,7 +1468,7 @@ test('two tracks, only 1 is linked to artists', () => {
     ],
     [
       {
-        id: '1',
+        id: '1::',
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         [joinSymbol]: true,
       },
@@ -1440,7 +1476,7 @@ test('two tracks, only 1 is linked to artists', () => {
     ],
     [
       {
-        id: '1_1-2_2',
+        id: '1:1-2:2',
         trackArtist: {id: '1-2', trackId: '1', artistId: '2'},
         track: {id: '1', title: 'Track One', length: 1, albumId: '1'},
         artist: {id: '2', name: 'Artist Two'},

--- a/packages/zql/src/zql/ivm/graph/operators/left-join-operator.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/left-join-operator.ts
@@ -13,9 +13,9 @@ import {
   StringOrNumber,
   Version,
 } from '../../types.js';
-import {combineRows, DifferenceIndex} from './difference-index.js';
+import {DifferenceIndex} from './difference-index.js';
 import {JoinOperatorBase} from './join-operator-base.js';
-import type {JoinArgs} from './join-operator.js';
+import {makeJoinResult, JoinArgs} from './join-operator.js';
 import {SourceHashIndexBackedDifferenceIndex} from './source-backed-difference-index.js';
 
 export class LeftJoinOperator<
@@ -209,7 +209,7 @@ export class LeftJoinOperator<
       aKey !== undefined ? this.#indexB.index.get(aKey) : undefined;
     if (bEntries === undefined || bEntries.length === 0) {
       const joinEntry = [
-        combineRows(
+        makeJoinResult(
           aValue,
           undefined,
           this.#joinArgs.aTable,
@@ -226,7 +226,7 @@ export class LeftJoinOperator<
 
     for (const [bValue, bMult] of bEntries) {
       const joinEntry = [
-        combineRows(
+        makeJoinResult(
           aValue,
           bValue,
           this.#joinArgs.aTable,
@@ -276,7 +276,7 @@ export class LeftJoinOperator<
     const ret: Entry<JoinResult<AValue, BValue, ATable, BAlias>>[] = [];
     for (const [aRow, aMult] of aEntries) {
       const joinEntry = [
-        combineRows(
+        makeJoinResult(
           aRow,
           bValue,
           this.#joinArgs.aTable,


### PR DESCRIPTION
fix(zql): Fix possible collisions in generated IDs for JoinResult.

combineRows() creates a JoinResult entry for the result of a join operation. As part of this, it generates a new ID for the entry which is a combination of the IDs from the incoming inner and outer sides of the join.
    
The generated IDs need to be unique per row over the entire set of generated values, but there were some cases where combineRows() could create non-unique rows:

 - The helper function concatIDs was sorting the IDs. This means that [inner:1, outer:2] would end up colliding with `[inner:2, outer:1]`.
 - concatIDs was using underscore as a separator, but the incoming IDs are arbitrary strings that can contain underscore. This, combined with the fact that combineRows() was skipping undefined inner rows when generating IDs meant that `[inner:undefined, outer:1_1]` would collide with: `[inner:1, outer: 1]`.

To fix made the following changes:

- Stop sorting ids. They are always emitted as "outer_inner".
- Stop skipping ids for undefined inner row. If inner is undefined, emit "outer_".
- Escape underscore with backslash. This is not technically necessary with above two, but it will make it easier to debug by making it clear what the IDs of the incoming rows are.
    
Also:
    
- Change separator from '_' to ':'. Popular id formats like nanoid use '_', so it will be easier to read to avoid this char.
- Restructure combineRows to reduce number of branches by introducing a helper, and rename to makeJoinResult() to better self-document the purpose of the function.
- Move makeJoinResult() to join-operator.ts, closer to where it is used.