### PR TITLE
refactor(zql): common interface for `DifferenceIndex`

### DIFF
--- a/packages/zql/src/zql/ivm/graph/operators/difference-index.test.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/difference-index.test.ts
@@ -1,8 +1,8 @@
 import {expect, test} from 'vitest';
-import {DifferenceIndex} from './difference-index.js';
+import {MemoryBackedDifferenceIndex} from './difference-index.js';
 
 test('get', () => {
-  const index = new DifferenceIndex<string, number>(x => x);
+  const index = new MemoryBackedDifferenceIndex<string, number>(x => x);
   index.add('a', [1, 1]);
   index.add('a', [1, 1]);
   index.add('a', [2, 1]);
@@ -17,12 +17,12 @@ test('get', () => {
 });
 
 test('compact', () => {
-  const index = new DifferenceIndex<string, number>(x => x);
+  const index = new MemoryBackedDifferenceIndex<string, number>(x => x);
   index.add('a', [1, 1]);
   index.add('a', [1, 1]);
   index.add('a', [2, 1]);
   index.add('b', [3, 2]);
-  index.compact(new Set(['a', 'b']));
+  index.compact();
 
   expect(index.get('a')).toEqual([
     [1, 2],
@@ -37,14 +37,13 @@ test('compact', () => {
     [1, -1],
   ]);
 
-  index.compact(new Set(['b']));
+  index.compact();
   expect(index.get('a')).toEqual([
-    [1, 2],
+    [1, 1],
     [2, 1],
-    [1, -1],
   ]);
 
-  index.compact(new Set(['a']));
+  index.compact();
   expect(index.get('a')).toEqual([
     [1, 1],
     [2, 1],
@@ -53,11 +52,11 @@ test('compact', () => {
   index.add('a', [1, -1]);
   index.add('a', [2, -1]);
   index.add('a', [1, -1]);
-  index.compact(new Set(['a']));
+  index.compact();
 
   expect(index.get('a')).toEqual([[1, -1]]);
 
   index.add('a', [1, 1]);
-  index.compact(new Set(['a']));
+  index.compact();
   expect(index.get('a')).toEqual(undefined);
 });

--- a/packages/zql/src/zql/ivm/graph/operators/source-backed-difference-index.ts
+++ b/packages/zql/src/zql/ivm/graph/operators/source-backed-difference-index.ts
@@ -2,11 +2,13 @@ import type {Primitive} from '../../../ast/ast.js';
 import type {Entry} from '../../multiset.js';
 import type {SourceHashIndex} from '../../source/source-hash-index.js';
 import type {PipelineEntity} from '../../types.js';
+import type {DifferenceIndex} from './difference-index.js';
 
-export class SourceHashIndexBackedDifferenceIndex<
+export class SourceBackedDifferenceIndex<
   Key extends Primitive,
   V extends PipelineEntity,
-> {
+> implements DifferenceIndex<Key, V>
+{
   readonly #overlayIndex: Map<Key, Entry<V>[]>;
   readonly #sourceIndex: SourceHashIndex<Key, V>;
 
@@ -46,4 +48,6 @@ export class SourceHashIndexBackedDifferenceIndex<
   compact() {
     this.#overlayIndex.clear();
   }
+
+  trackKeyForCompaction(_key: Key) {}
 }


### PR DESCRIPTION
`MemoryBacked` and `SourceBacked` are no longer special cases in `Join`

When backing ZQL with SQLite some more changes need to be made around how `join` behaves when the difference index is `SourceBacked`. The refactor here makes those future changes a bit simpler.