### PR TITLE
chore(zql): Derive SetSource and TreeView comparator from order.

### DIFF
--- a/packages/zero-client/src/client/zql/order-limit-integration.test.ts
+++ b/packages/zero-client/src/client/zql/order-limit-integration.test.ts
@@ -1,5 +1,4 @@
 import {describe, expect, test} from 'vitest';
-import {canonicalComparator} from 'zql/src/zql/context/zero-context.js';
 import {makeComparator} from 'zql/src/zql/ivm/compare.js';
 import {Comparator, joinSymbol} from 'zql/src/zql/ivm/types.js';
 import {must} from '../../../../shared/src/must.js';
@@ -81,6 +80,8 @@ describe('sorting and limiting with different query operations', async () => {
     }
     return ret.sort(comp);
   };
+
+  const canonicalComparator = makeComparator([[['unused', 'id'], 'asc']]);
 
   test.each([
     {

--- a/packages/zql/src/zql/context/test-context.ts
+++ b/packages/zql/src/zql/context/test-context.ts
@@ -1,4 +1,3 @@
-import {compareUTF8} from 'compare-utf8';
 import {must} from 'shared/src/must.js';
 import type {AST} from '../ast/ast.js';
 import {DifferenceStream} from '../ivm/graph/difference-stream.js';
@@ -28,7 +27,6 @@ export class TestContext implements Context {
   getSource<T extends PipelineEntity>(name: string): Source<T> {
     if (!this.#sources.has(name)) {
       const source = this.materialite.newSetSource(
-        (l: T, r: T) => compareUTF8(l.id as string, r.id as string),
         [[[name, 'id'], 'asc']],
         name,
       ) as unknown as Source<PipelineEntity>;
@@ -69,7 +67,6 @@ export class InfiniteSourceContext implements Context {
       );
     } else {
       source = this.materialite.newSetSource<X>(
-        (l: X, r: X) => compareUTF8(l.id as string, r.id as string),
         [[[name, 'id'], 'asc']],
         name,
       ) as unknown as Source<PipelineEntity>;

--- a/packages/zql/src/zql/context/zero-context.ts
+++ b/packages/zql/src/zql/context/zero-context.ts
@@ -1,4 +1,3 @@
-import {compareUTF8} from 'compare-utf8';
 import type {ExperimentalNoIndexDiff} from 'replicache';
 import {assert} from 'shared/src//asserts.js';
 import type {AST} from '../ast/ast.js';
@@ -70,7 +69,6 @@ class ZeroSource {
 
   constructor(materialite: Materialite, name: string, addWatch: AddWatch) {
     this.#canonicalSource = materialite.newSetSource<Entity>(
-      canonicalComparator,
       [[[name, 'id'], 'asc']],
       name,
     );
@@ -108,6 +106,3 @@ class ZeroSource {
     return this.#canonicalSource;
   }
 }
-
-export const canonicalComparator = (l: Entity, r: Entity) =>
-  compareUTF8(l.id, r.id);

--- a/packages/zql/src/zql/ivm/compare.ts
+++ b/packages/zql/src/zql/ivm/compare.ts
@@ -1,6 +1,7 @@
 import {unreachable} from 'shared/src/asserts.js';
 import type {Ordering} from '../ast/ast.js';
 import {getValueFromEntity} from './source/util.js';
+import {compareUTF8} from 'compare-utf8';
 
 export function compareEntityFields<T>(lVal: T, rVal: T) {
   if (lVal === rVal) {
@@ -11,6 +12,16 @@ export function compareEntityFields<T>(lVal: T, rVal: T) {
   }
   if (rVal === null || rVal === undefined) {
     return 1;
+  }
+  if (typeof lVal === 'string') {
+    // We compare all strings in zql as UTF-8. If we were only dealing with zql
+    // on both client and server we could choose any ordering we want. But we
+    // also need to consider that we sometimes ask other systems to sort for
+    // us - specifically the database backing the source. So we need to choose
+    // a sort that database can do too. UTF-8 is a commonly used collation and
+    // the default encoding of many systems (though sadly not javascript).
+    // For more, see: https://blog.replicache.dev/blog/replicache-11-adventures-in-text-encoding.
+    return compareUTF8(lVal, rVal as string);
   }
   if (lVal < rVal) {
     return -1;

--- a/packages/zql/src/zql/ivm/graph/difference-stream.test.ts
+++ b/packages/zql/src/zql/ivm/graph/difference-stream.test.ts
@@ -128,11 +128,7 @@ test('map, filter, linearCount', () => {
 
 test('cleaning up the only user of a stream cleans up the entire pipeline', () => {
   const materialite = new Materialite();
-  const set = materialite.newSetSource<Elem>(
-    (l, r) => l.x - r.x,
-    [[['elem', 'x'], 'asc']],
-    'elem',
-  );
+  const set = materialite.newSetSource<Elem>([[['elem', 'x'], 'asc']], 'elem');
 
   let notifyCount = 0;
   const final = set.stream
@@ -151,11 +147,7 @@ test('cleaning up the only user of a stream cleans up the entire pipeline', () =
 
 test('cleaning up the only user of a stream cleans up the entire pipeline but stops at a used fork', () => {
   const materialite = new Materialite();
-  const set = materialite.newSetSource<Elem>(
-    (l, r) => l.x - r.x,
-    [[['elem', 'x'], 'asc']],
-    'elem',
-  );
+  const set = materialite.newSetSource<Elem>([[['elem', 'x'], 'asc']], 'elem');
 
   let notifyCount = 0;
   const stream1 = set.stream.effect(_ => notifyCount++);

--- a/packages/zql/src/zql/ivm/materialite.ts
+++ b/packages/zql/src/zql/ivm/materialite.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore next.js is having issues finding the .d.ts
-import type {Comparator, PipelineEntity} from './types.js';
+import type {PipelineEntity} from './types.js';
 import {must} from 'shared/src/must.js';
 import {SetSource} from './source/set-source.js';
 import type {Ordering} from '../ast/ast.js';
@@ -41,12 +41,8 @@ export class Materialite {
     };
   }
 
-  newSetSource<T extends PipelineEntity>(
-    comparator: Comparator<T>,
-    order: Ordering,
-    name: string,
-  ) {
-    return new SetSource<T>(this.#internal, comparator, order, name);
+  newSetSource<T extends PipelineEntity>(order: Ordering, name: string) {
+    return new SetSource<T>(this.#internal, order, name);
   }
 
   constructSource<T extends PipelineEntity>(

--- a/packages/zql/src/zql/ivm/view/tree-view.ts
+++ b/packages/zql/src/zql/ivm/view/tree-view.ts
@@ -36,17 +36,16 @@ export class TreeView<T extends PipelineEntity> extends AbstractView<T, T[]> {
   constructor(
     context: Context,
     stream: DifferenceStream<T>,
-    comparator: Comparator<T>,
-    order: Ordering | undefined,
+    order: Ordering,
     limit?: number | undefined,
     name: string = '',
   ) {
     super(context, stream, name);
     this.#limit = limit;
+    this.#comparator = makeComparator(order);
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    this.#data = new BTree(undefined, comparator);
-    this.#comparator = comparator;
+    this.#data = new BTree(undefined, this.#comparator);
     this.#order = order;
     if (limit !== undefined) {
       this.#add = this.#limitedAdd;

--- a/packages/zql/src/zql/query/statement.ts
+++ b/packages/zql/src/zql/query/statement.ts
@@ -6,7 +6,6 @@ import {
 } from '../ast-to-ivm/pipeline-builder.js';
 import type {AST} from '../ast/ast.js';
 import type {Context} from '../context/context.js';
-import {makeComparator} from '../ivm/compare.js';
 import type {DifferenceStream} from '../ivm/graph/difference-stream.js';
 import {TreeView} from '../ivm/view/tree-view.js';
 import type {View} from '../ivm/view/view.js';
@@ -169,7 +168,6 @@ async function createMaterialization<Return>(ast: AST, context: Context) {
     pipeline as unknown as DifferenceStream<
       Return extends [] ? Return[number] : never
     >,
-    makeComparator<Record<string, unknown>>(orderBy),
     orderBy,
     limit,
   ) as unknown as View<Return extends [] ? Return[number] : Return>;


### PR DESCRIPTION
They needed to always be in sync so just compute one from the other to enforce this.