### PR TITLE
feat(replicache): Export internal Replicache impl

### DIFF
--- a/packages/reflect-client/rollup.config.js
+++ b/packages/reflect-client/rollup.config.js
@@ -1,6 +1,6 @@
-import {makeInputOptions} from 'shared/src/tool/rollup-dts.js';
+import {makeRollupOptions} from 'shared/src/tool/rollup-dts.js';
 
-export default makeInputOptions(
+export default makeRollupOptions(
   'out/.dts/reflect-client/src/mod.d.ts',
   'out/reflect-client.d.ts',
 );

--- a/packages/reflect-react/rollup.config.js
+++ b/packages/reflect-react/rollup.config.js
@@ -1,6 +1,6 @@
-import {makeInputOptions} from 'shared/src/tool/rollup-dts.js';
+import {makeRollupOptions} from 'shared/src/tool/rollup-dts.js';
 
-export default makeInputOptions(
+export default makeRollupOptions(
   'out/.dts/reflect-react/src/mod.d.ts',
   'out/reflect-react.d.ts',
 );

--- a/packages/reflect-server/rollup.config.js
+++ b/packages/reflect-server/rollup.config.js
@@ -1,6 +1,6 @@
-import {makeInputOptions} from 'shared/src/tool/rollup-dts.js';
+import {makeRollupOptions} from 'shared/src/tool/rollup-dts.js';
 
-export default makeInputOptions(
+export default makeRollupOptions(
   'out/.dts/reflect-server/src/mod.d.ts',
   'out/reflect-server.d.ts',
 );

--- a/packages/reflect-shared/rollup.config.js
+++ b/packages/reflect-shared/rollup.config.js
@@ -1,6 +1,6 @@
-import {makeInputOptions} from 'shared/src/tool/rollup-dts.js';
+import {makeRollupOptions} from 'shared/src/tool/rollup-dts.js';
 
-export default makeInputOptions(
+export default makeRollupOptions(
   'out/.dts/reflect-shared/src/mod.d.ts',
   'out/reflect-shared.d.ts',
 );

--- a/packages/replicache/package.json
+++ b/packages/replicache/package.json
@@ -59,13 +59,23 @@
     "node": ">=14.8.0"
   },
   "exports": {
-    "module": "./out/replicache.js",
-    "default": "./out/replicache.js"
+    ".": {
+      "module": "./out/replicache.js",
+      "default": "./out/replicache.js"
+    },
+    "./impl": {
+      "import": "./out/impl.js",
+      "require": "./out/impl.js"
+    }
   },
   "files": [
     "out/cli.cjs",
     "out/replicache.d.ts",
-    "out/replicache.js"
+    "out/replicache.js",
+    "out/impl.d.ts",
+    "out/impl.js",
+    "out/chunk-*.js",
+    "out/chunk-*.d.ts"
   ],
   "eslintConfig": {
     "extends": "@rocicorp/eslint-config"

--- a/packages/replicache/rollup.config.js
+++ b/packages/replicache/rollup.config.js
@@ -1,6 +1,12 @@
-import {makeInputOptions} from 'shared/src/tool/rollup-dts.js';
+import {makeRollupOptions} from 'shared/src/tool/rollup-dts.js';
 
-export default makeInputOptions(
-  'out/.dts/replicache/src/mod.d.ts',
-  'out/replicache.d.ts',
+export default makeRollupOptions(
+  {
+    replicache: 'out/.dts/replicache/src/mod.d.ts',
+    impl: 'out/.dts/replicache/src/replicache-impl.d.ts',
+  },
+  {
+    dir: 'out/',
+    chunkFileNames: 'chunk-[hash].d.ts',
+  },
 );

--- a/packages/shared/src/tool/rollup-dts.js
+++ b/packages/shared/src/tool/rollup-dts.js
@@ -8,17 +8,17 @@ import tsConfigPaths from 'rollup-plugin-tsconfig-paths';
 // We use esbuild for building the actual code.
 
 /**
- * @param {string} input
- * @param {string} outputFile
- * @returns {import('rollup').InputOptions}
+ * @param {import('rollup').InputOption} input
+ * @param {import('rollup').OutputOptions | string} output
+ * @returns {import('rollup').RollupOptions}
  */
-export function makeInputOptions(input, outputFile) {
-  /** @type {import('rollup').InputOptions} */
-  const config = {
+export function makeRollupOptions(input, output) {
+  if (typeof output === 'string') {
+    output = {file: output};
+  }
+  return {
     input,
-    output: {
-      file: outputFile,
-    },
+    output,
     external: ['@rocicorp/lock', '@rocicorp/logger', '@rocicorp/resolver'],
     plugins: [
       tsConfigPaths(),
@@ -28,5 +28,4 @@ export function makeInputOptions(input, outputFile) {
       }),
     ],
   };
-  return config;
 }

--- a/packages/zero-client/rollup.config.js
+++ b/packages/zero-client/rollup.config.js
@@ -1,6 +1,6 @@
-import {makeInputOptions} from 'shared/src/tool/rollup-dts.js';
+import {makeRollupOptions} from 'shared/src/tool/rollup-dts.js';
 
-export default makeInputOptions(
+export default makeRollupOptions(
   'out/.dts/zero-client/src/mod.d.ts',
   'out/zero-client.d.ts',
 );

--- a/packages/zql/rollup.config.js
+++ b/packages/zql/rollup.config.js
@@ -1,3 +1,3 @@
-import {makeInputOptions} from 'shared/src/tool/rollup-dts.js';
+import {makeRollupOptions} from 'shared/src/tool/rollup-dts.js';
 
-export default makeInputOptions('out/.dts/zql/src/index.d.ts', 'out/zql.d.ts');
+export default makeRollupOptions('out/.dts/zql/src/index.d.ts', 'out/zql.d.ts');


### PR DESCRIPTION
This is in preparation for open sourcing Reflect which will depend on Replicache using the replicache npm package.

This exports ReplicacheImpl as "replicache/impl" and Replicache as "replicache".

This requires us to use code splitting for the replicache build (both the esbuild and rollup-dts builds) so that we can export the impl separately from the main Replicache class.