### PR TITLE
chore(zqlite): [3/n] pull in `@databases` to do escaping of SQLite queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3704,6 +3704,24 @@
         "postcss-selector-parser": "^6.0.10"
       }
     },
+    "node_modules/@databases/escape-identifier": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@databases/escape-identifier/-/escape-identifier-1.0.3.tgz",
+      "integrity": "sha512-Su36iSVzaHxpVdISVMViUX/32sLvzxVgjZpYhzhotxZUuLo11GVWsiHwqkvUZijTLUxcDmUqEwGJO3O/soLuZA==",
+      "dependencies": {
+        "@databases/validate-unicode": "^1.0.0"
+      }
+    },
+    "node_modules/@databases/sql": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@databases/sql/-/sql-3.3.0.tgz",
+      "integrity": "sha512-vj9huEy4mjJ48GS1Z8yvtMm4BYAnFYACUds25ym6Gd/gsnngkJ17fo62a6mmbNNwCBS/8467PmZR01Zs/06TjA=="
+    },
+    "node_modules/@databases/validate-unicode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@databases/validate-unicode/-/validate-unicode-1.0.0.tgz",
+      "integrity": "sha512-dLKqxGcymeVwEb/6c44KjOnzaAafFf0Wxa8xcfEjx/qOl3rdijsKYBAtIGhtVtOlpPf/PFKfgTuFurSPn/3B/g=="
+    },
     "node_modules/@drdgvhbh/postgres-error-codes": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@drdgvhbh/postgres-error-codes/-/postgres-error-codes-0.0.6.tgz",
@@ -26206,6 +26224,8 @@
       "name": "@rocicorp/zqlite",
       "version": "0.0.0",
       "dependencies": {
+        "@databases/escape-identifier": "^1.0.3",
+        "@databases/sql": "^3.3.0",
         "@rocicorp/logger": "^5.2.2",
         "better-sqlite3": "^11.0.0",
         "pg-logical-replication": "^2.0.5",
@@ -27853,6 +27873,24 @@
       "integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==",
       "dev": true,
       "requires": {}
+    },
+    "@databases/escape-identifier": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@databases/escape-identifier/-/escape-identifier-1.0.3.tgz",
+      "integrity": "sha512-Su36iSVzaHxpVdISVMViUX/32sLvzxVgjZpYhzhotxZUuLo11GVWsiHwqkvUZijTLUxcDmUqEwGJO3O/soLuZA==",
+      "requires": {
+        "@databases/validate-unicode": "^1.0.0"
+      }
+    },
+    "@databases/sql": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@databases/sql/-/sql-3.3.0.tgz",
+      "integrity": "sha512-vj9huEy4mjJ48GS1Z8yvtMm4BYAnFYACUds25ym6Gd/gsnngkJ17fo62a6mmbNNwCBS/8467PmZR01Zs/06TjA=="
+    },
+    "@databases/validate-unicode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@databases/validate-unicode/-/validate-unicode-1.0.0.tgz",
+      "integrity": "sha512-dLKqxGcymeVwEb/6c44KjOnzaAafFf0Wxa8xcfEjx/qOl3rdijsKYBAtIGhtVtOlpPf/PFKfgTuFurSPn/3B/g=="
     },
     "@drdgvhbh/postgres-error-codes": {
       "version": "0.0.6",
@@ -30086,6 +30124,8 @@
     "@rocicorp/zqlite": {
       "version": "file:packages/zqlite",
       "requires": {
+        "@databases/escape-identifier": "^1.0.3",
+        "@databases/sql": "^3.3.0",
         "@rocicorp/eslint-config": "^0.5.1",
         "@rocicorp/logger": "^5.2.2",
         "@rocicorp/prettier-config": "^0.2.0",

--- a/packages/zqlite/package.json
+++ b/packages/zqlite/package.json
@@ -31,9 +31,11 @@
   },
   "prettier": "@rocicorp/prettier-config",
   "dependencies": {
+    "@databases/escape-identifier": "^1.0.3",
+    "@databases/sql": "^3.3.0",
     "@rocicorp/logger": "^5.2.2",
-    "zql": "0.0.0",
     "better-sqlite3": "^11.0.0",
-    "pg-logical-replication": "^2.0.5"
+    "pg-logical-replication": "^2.0.5",
+    "zql": "0.0.0"
   }
 }

--- a/packages/zqlite/src/internal/sql.test.ts
+++ b/packages/zqlite/src/internal/sql.test.ts
@@ -1,0 +1,19 @@
+import {expect, test} from 'vitest';
+import {compile, sql} from './sql.js';
+
+test('can do empty slots', () => {
+  const str = compile(sql`INSERT INTO foo (id, name) VALUES (?, ?)`);
+  expect(str).toMatchInlineSnapshot(
+    `"INSERT INTO foo (id, name) VALUES (?, ?)"`,
+  );
+});
+
+test('quotes identifiers as advertised', () => {
+  const str = compile(sql`SELECT * FROM ${sql.ident('foo', 'bar')}`);
+  expect(str).toMatchInlineSnapshot(`"SELECT * FROM "foo"."bar""`);
+});
+
+test('escapes identifiers as advertised', () => {
+  const str = compile(sql`SELECT * FROM ${sql.ident('foo"bar')}`);
+  expect(str).toMatchInlineSnapshot(`"SELECT * FROM "foo""bar""`);
+});

--- a/packages/zqlite/src/internal/sql.ts
+++ b/packages/zqlite/src/internal/sql.ts
@@ -1,0 +1,14 @@
+import type {SQLQuery, FormatConfig} from '@databases/sql';
+import baseSql from '@databases/sql';
+import {escapeSQLiteIdentifier} from '@databases/escape-identifier';
+
+const sqliteFormat: FormatConfig = {
+  escapeIdentifier: str => escapeSQLiteIdentifier(str),
+  formatValue: value => ({placeholder: '?', value}),
+};
+
+export function compile(sql: SQLQuery): string {
+  return sql.format(sqliteFormat).text;
+}
+
+export const sql = baseSql.default;


### PR DESCRIPTION
To address the issue where `TableSource` does not handle cases where identifiers include 

```
[ | " | ] | `
```