### PR TITLE
feat(zqlite): [4/n] write to SQLite as diffs are processed

### DIFF
--- a/packages/zqlite/package.json
+++ b/packages/zqlite/package.json
@@ -11,6 +11,8 @@
     "check-types": "tsc --noEmit",
     "build:bin": "tsc -p tsconfig.bin.json",
     "lint": "eslint --ext .ts,.tsx,.js,.jsx src/",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
     "bench": "vitest bench",
     "test-types": "vitest run --typecheck.only --no-browser.enabled",
     "test-types:watch": "vitest watch --typecheck.only --no-browser.enabled"

--- a/packages/zqlite/src/ZQLite.ts
+++ b/packages/zqlite/src/ZQLite.ts
@@ -1,0 +1,27 @@
+import {Materialite} from 'zql/src/zql/ivm/materialite.js';
+import type {Database} from 'better-sqlite3';
+
+export class ZQLite extends Materialite {
+  readonly #beginStmt;
+  readonly #commitStmt;
+  readonly #rollbackStmt;
+
+  constructor(db: Database) {
+    super();
+    this.#beginStmt = db.prepare('BEGIN');
+    this.#commitStmt = db.prepare('COMMIT');
+    this.#rollbackStmt = db.prepare('ROLLBACK');
+  }
+
+  protected _txBegin(): void {
+    this.#beginStmt.run();
+  }
+
+  protected _txCommit(): void {
+    this.#commitStmt.run();
+  }
+
+  protected _txRollback(): void {
+    this.#rollbackStmt.run();
+  }
+}

--- a/packages/zqlite/src/context.ts
+++ b/packages/zqlite/src/context.ts
@@ -1,14 +1,16 @@
 import type {Context} from 'zql/src/zql/context/context.js';
-import type {Materialite} from 'zql/src/zql/ivm/materialite.js';
 import type {Database} from 'better-sqlite3';
 import {TableSource} from './table-source.js';
 import type {PipelineEntity} from 'zql/src/zql/ivm/types.js';
 import type {Source} from 'zql/src/zql/ivm/source/source.js';
+import type {ZQLite} from './ZQLite.js';
 
 const emptyFunction = () => {};
 
-export function createContext(materialite: Materialite, db: Database): Context {
+export function createContext(materialite: ZQLite, db: Database): Context {
   const sources = new Map<string, Source<PipelineEntity>>();
+  const sql = `SELECT name FROM pragma_table_info(?)`;
+  const columnsStatement = db.prepare(sql);
 
   return {
     materialite,
@@ -17,8 +19,15 @@ export function createContext(materialite: Materialite, db: Database): Context {
       if (existing) {
         return existing as Source<T>;
       }
+      const columns = columnsStatement.all(name);
       existing = materialite.constructSource(
-        internal => new TableSource(db, internal, name),
+        internal =>
+          new TableSource(
+            db,
+            internal,
+            name,
+            columns.map(c => c.name),
+          ),
       );
       sources.set(name, existing);
       return existing as Source<T>;

--- a/packages/zqlite/src/table-source.test.ts
+++ b/packages/zqlite/src/table-source.test.ts
@@ -1,0 +1,107 @@
+import type {PipelineEntity} from 'zql/src/zql/ivm/types.js';
+import Database from 'better-sqlite3';
+import {describe, expect, test} from 'vitest';
+import {createContext} from './context.js';
+import {ZQLite} from './ZQLite.js';
+
+test('add', () => {
+  const db = new Database(':memory:');
+  const context = createContext(new ZQLite(db), db);
+
+  db.prepare('CREATE TABLE foo (id INTEGER PRIMARY KEY, name TEXT)').run();
+
+  const source = context.getSource('foo');
+  source.add({id: 1, name: 'one'});
+  source.add({id: 2, name: 'two'});
+  source.add({id: 3, name: 'three'});
+
+  const stmt = db.prepare('SELECT * FROM foo');
+  const rows = stmt.all();
+  expect(rows).toEqual([
+    {id: 1, name: 'one'},
+    {id: 2, name: 'two'},
+    {id: 3, name: 'three'},
+  ]);
+});
+
+test('delete', () => {
+  const db = new Database(':memory:');
+  const context = createContext(new ZQLite(db), db);
+
+  db.prepare('CREATE TABLE foo (id INTEGER PRIMARY KEY, name TEXT)').run();
+
+  const source = context.getSource('foo');
+  source.add({id: 1, name: 'one'});
+  source.add({id: 2, name: 'two'});
+  source.add({id: 3, name: 'three'});
+
+  source.delete({id: 2, name: 'two'});
+
+  const stmt = db.prepare('SELECT * FROM foo');
+  const rows = stmt.all();
+  expect(rows).toEqual([
+    {id: 1, name: 'one'},
+    {id: 3, name: 'three'},
+  ]);
+});
+
+describe('message upstream', () => {
+  const db = new Database(':memory:');
+  const m = new ZQLite(db);
+  const context = createContext(m, db);
+  db.prepare('CREATE TABLE foo (id INTEGER PRIMARY KEY, name TEXT)').run();
+
+  const source = context.getSource('foo');
+  source.add({id: 1, name: 'one'});
+  source.add({id: 2, name: 'two'});
+  source.add({id: 3, name: 'three'});
+
+  test.each([
+    {
+      name: 'bare selects',
+      sql: 'SELECT * FROM foo',
+      message: {type: 'pull', id: 1, hoistedConditions: []} as const,
+    },
+    {
+      name: 'select with conditions',
+      sql: 'SELECT * FROM foo WHERE id = 1',
+      message: {
+        type: 'pull',
+        id: 1,
+        hoistedConditions: [
+          {
+            selector: ['foo', 'id'],
+            op: '=',
+            value: 1,
+          },
+        ],
+      } as const,
+    },
+    {
+      name: 'select with ordering',
+      sql: 'SELECT * FROM foo ORDER BY id DESC',
+      message: {
+        type: 'pull',
+        id: 1,
+        hoistedConditions: [],
+        order: [[['foo', 'id'], 'desc']],
+      } as const,
+    },
+  ])('$name', ({sql, message}) => {
+    const stmt = db.prepare(sql);
+    const rows = stmt.all();
+
+    let items: PipelineEntity[] = [];
+
+    m.tx(() =>
+      source.stream.messageUpstream(message, {
+        newDifference: (_version, data) => {
+          items = [...data].map(d => d[0]);
+        },
+        commit: () => {},
+      }),
+    );
+
+    expect(rows).toEqual(items);
+  });
+});

--- a/packages/zqlite/src/table-source.ts
+++ b/packages/zqlite/src/table-source.ts
@@ -15,13 +15,14 @@ import type {Entry} from 'zql/src/zql/ivm/multiset.js';
 import type {Source, SourceInternal} from 'zql/src/zql/ivm/source/source.js';
 import type {PipelineEntity, Version} from 'zql/src/zql/ivm/types.js';
 import {genMap, genCached} from 'zql/src/zql/util/iterables.js';
-import type {Database} from 'better-sqlite3';
+import type {Database, Statement} from 'better-sqlite3';
 import type {HoistedCondition} from 'zql/src/zql/ivm/graph/message.js';
 import type {HashIndex} from 'zql/src/zql/ivm/source/source-hash-index.js';
 import {StatementCache} from './internal/statement-cache.js';
 import {TableSourceHashIndex} from './table-source-hash-index.js';
 import {mergeRequests} from 'zql/src/zql/ivm/source/set-source.js';
 import {assert} from 'shared/src/asserts.js';
+import {compile, sql} from './internal/sql.js';
 
 const resolved = Promise.resolve();
 
@@ -50,6 +51,8 @@ export class TableSource<T extends PipelineEntity> implements Source<T> {
   // once.
   readonly #historyStatements: StatementCache;
   readonly #historyRequests: Map<number, PullMsg> = new Map();
+  readonly #insertStmt: Statement;
+  readonly #deleteStmt: Statement;
 
   // Field for debugging.
   #id = id++;
@@ -60,6 +63,7 @@ export class TableSource<T extends PipelineEntity> implements Source<T> {
     db: Database,
     materialite: MaterialiteForSourceInternal,
     name: string,
+    columns: string[],
   ) {
     this.#materialite = materialite;
     this.#name = name;
@@ -73,6 +77,19 @@ export class TableSource<T extends PipelineEntity> implements Source<T> {
     });
     this.#db = db;
     this.#historyStatements = new StatementCache(db);
+    let str = compile(
+      sql`INSERT INTO ${sql.ident(name)} (${sql.join(
+        columns.map(c => sql.ident(c)),
+        sql`, `,
+      )}) VALUES (${sql.__dangerous__rawValue(
+        new Array(columns.length).fill('?').join(', '),
+      )})`,
+    );
+    this.#insertStmt = db.prepare(str);
+    str = compile(
+      sql`DELETE FROM ${sql.ident(name)} WHERE ${sql.ident('id')} = ?`,
+    );
+    this.#deleteStmt = db.prepare(str);
 
     this.#internal = {
       onCommitEnqueue: (version: Version) => {
@@ -90,7 +107,7 @@ export class TableSource<T extends PipelineEntity> implements Source<T> {
         }
 
         if (this.#pending.length !== 0) {
-          this.#stream.newDifference(version, this.#pending, undefined);
+          this.#writeAndSendPending(version);
         }
 
         this.#pending = [];
@@ -160,6 +177,7 @@ export class TableSource<T extends PipelineEntity> implements Source<T> {
           : -1,
       );
     const sql = conditionsAndSortToSQL(this.#name, sortedConditions, sort);
+
     const stmt = this.#historyStatements.get(sql);
 
     try {
@@ -179,6 +197,28 @@ export class TableSource<T extends PipelineEntity> implements Source<T> {
       );
     } finally {
       this.#historyStatements.return(sql);
+    }
+  }
+
+  // TODO(mlaw): we'll need to optimize this.
+  // We're essentially changing the `one at a time` case from this:
+  // https://jsbm.dev/QeaEw5incvxQy
+  // instead of doing `single Iterator`.
+  #writeAndSendPending(version: Version): void {
+    // do the SQLite writes for each item in pending.
+    for (const entry of this.#pending) {
+      if (entry[1] > 0) {
+        // apply the insert
+        this.#insertStmt.run(...Object.values(entry[0]));
+      }
+
+      // run through the pipeline
+      this.#stream.newDifference(version, [entry], undefined);
+
+      if (entry[1] < 0) {
+        // apply the delete
+        this.#deleteStmt.run(entry[0].id);
+      }
     }
   }
 
@@ -233,28 +273,36 @@ export function conditionsAndSortToSQL(
   conditions: HoistedCondition[],
   sort: Ordering | undefined,
 ) {
-  let sql = `SELECT * FROM ${table}`;
+  let query = sql`SELECT * FROM ${sql.ident(table)}`;
   if (conditions.length > 0) {
-    sql += ' WHERE ';
-    sql += conditions
-      .map(c => {
+    query = sql`${query} WHERE ${sql.join(
+      conditions.map(c => {
         if (c.op === 'IN') {
           // we use `json_each` so we do not create a different number of bind params each time we see an `IN`
-          return `${c.selector[1]} ${c.op} (SELECT value FROM json_each(?))`;
+          return sql`${sql.ident(c.selector[1])} ${sql.__dangerous__rawValue(
+            c.op,
+          )} (SELECT value FROM json_each(?))`;
         } else if (c.op === 'ILIKE') {
           // The default configuration of SQLite only supports case-insensitive comparisons of ASCII characters
-          return `${c.selector[1]} LIKE ?`;
+          return sql`${sql.ident(c.selector[1])} LIKE ?`;
         }
-        return `${c.selector[1]} ${c.op} ?`;
-      })
-      .join(' AND ');
+        return sql`${sql.ident(c.selector[1])} ${sql.__dangerous__rawValue(
+          c.op,
+        )} ?`;
+      }),
+      sql` AND `,
+    )}`;
   }
   if (sort) {
-    sql += ' ORDER BY ';
-    sql += sort.map(s => `"${s[0][1]}" ${s[1]}`).join(', ');
+    query = sql`${query} ORDER BY ${sql.join(
+      sort.map(
+        s => sql`${sql.ident(s[0][1])} ${sql.__dangerous__rawValue(s[1])}`,
+      ),
+      sql`, `,
+    )}`;
   }
 
-  return sql;
+  return compile(query);
 }
 
 export function getConditionBindParams(conditions: HoistedCondition[]) {


### PR DESCRIPTION
As each difference event is seen, SQLite is kept up to date.

- see a write? Apply to SQLite then run IVM
- see a delete? Run IVM then apply to SQLite

`table-source.test.ts` passes.

What we really should do is update all the integration tests to be able to run against either Replicache or SQLite. Should be a matter of swapping out their `Context`.