### PR TITLE
chore(zqlite): add a zql<->zqlite integration test example

### DIFF
--- a/packages/zqlite/src/zql.test.ts
+++ b/packages/zqlite/src/zql.test.ts
@@ -1,0 +1,46 @@
+import Database from 'better-sqlite3';
+import {expect, test} from 'vitest';
+import {createContext} from './context.js';
+import {ZQLite} from './ZQLite.js';
+import {EntityQuery} from 'zql/src/zql/query/entity-query.js';
+
+test('smoke test', async () => {
+  const db = new Database(':memory:');
+  const z = new ZQLite(db);
+  const context = createContext(z, db);
+
+  db.prepare('CREATE TABLE foo (id TEXT PRIMARY KEY, name TEXT)').run();
+
+  type Foo = {
+    id: string;
+    name: string;
+  };
+
+  // The EntityQuery is what we would get from `zero.query`
+  // in zero-client tests
+  // e.g. const z = newZero();
+  // const q = z.query.foo;
+  const q = new EntityQuery<{foo: Foo}>(context, 'foo');
+
+  // A source represents a table.
+  // Adding to the source is like inserting into the table.
+  // This is analogous to `mutators` in zero-client tests
+  // e.g., z.mutate.foo.create({id: '1', name: 'one'});
+  const source = context.getSource('foo');
+  z.tx(() => {
+    source.add({id: '1', name: 'one'});
+    source.add({id: '2', name: 'two'});
+    source.add({id: '3', name: 'three'});
+  });
+
+  const stmt = q.select('*').prepare();
+  const rows = await stmt.exec();
+
+  expect(rows).toEqual([
+    {id: '1', name: 'one'},
+    {id: '2', name: 'two'},
+    {id: '3', name: 'three'},
+  ]);
+
+  stmt.destroy();
+});


### PR DESCRIPTION
The comments reference the zql<->zero-client integration tests here: https://github.com/rocicorp/mono/tree/main/packages/zero-client/src/client/zql

Discussed in: https://rocicorp.slack.com/archives/C013XFG80JC/p1722432672929039 to help @cesara ramp on getting existing integration tests to run against ZQLite.