### PR TITLE
feat(zql): scaffolding for `ivm-2`

### DIFF
--- a/packages/zql/src/zql/ast-2/ast.ts
+++ b/packages/zql/src/zql/ast-2/ast.ts
@@ -1,0 +1,2 @@
+type OrderPart = [field: string, direction: 'asc' | 'desc'];
+export type Ordering = OrderPart[];

--- a/packages/zql/src/zql/ivm-2/compare.ts
+++ b/packages/zql/src/zql/ivm-2/compare.ts
@@ -1,0 +1,53 @@
+import {compareUTF8} from 'compare-utf8';
+import {unreachable} from 'shared/src/asserts.js';
+import type {Ordering} from '../ast-2/ast.js';
+import type {Comparator} from '../ivm/types.js';
+import type {Entity} from './types.js';
+
+export function makeComparator<T extends Entity>(
+  order: Ordering,
+): Comparator<T> {
+  return (a, b) => {
+    for (const [field, direction] of order) {
+      const comp = compareEntityFields(a[field], b[field]);
+      if (comp !== 0) {
+        return direction === 'asc' ? comp : -comp;
+      }
+    }
+    return 0;
+  };
+}
+
+export function compareEntityFields<T>(lVal: T, rVal: T) {
+  if (lVal === rVal) {
+    return 0;
+  }
+  if (lVal === null || lVal === undefined) {
+    return -1;
+  }
+  if (rVal === null || rVal === undefined) {
+    return 1;
+  }
+  if (typeof lVal === 'string') {
+    // We compare all strings in zql as UTF-8. If we were only dealing with zql
+    // on both client and server we could choose any ordering we want. But we
+    // also need to consider that we sometimes ask other systems to sort for
+    // us - specifically the database backing the source. So we need to choose
+    // a sort that database can do too. UTF-8 is a commonly used collation and
+    // the default encoding of many systems (though sadly not javascript).
+    // For more, see: https://blog.replicache.dev/blog/replicache-11-adventures-in-text-encoding.
+    return compareUTF8(lVal, rVal as string);
+  }
+  if (lVal < rVal) {
+    return -1;
+  }
+  if (lVal > rVal) {
+    return 1;
+  }
+
+  if (lVal instanceof Date && rVal instanceof Date) {
+    return lVal.getTime() - rVal.getTime();
+  }
+
+  unreachable();
+}

--- a/packages/zql/src/zql/ivm-2/graph/difference-stream.ts
+++ b/packages/zql/src/zql/ivm-2/graph/difference-stream.ts
@@ -1,0 +1,48 @@
+import {assert} from 'shared/src/asserts.js';
+import {must} from 'shared/src/must.js';
+import type {IterableTree} from '../iterable-tree.js';
+import type {Entity} from '../types.js';
+import type {DownstreamNode, UpstreamNode} from './node.js';
+import type {PullRequest} from './pull.js';
+
+/**
+ * This class allows
+ * 1. An `UpstreamNode` to send differences to a set of `DownstreamNode`s
+ * 2. A `DownstreamNode` to request a pull from the `UpstreamNode`
+ *
+ * It admittedly doesn't do much besides manage the list of `#downstreams` and the single `#upstream`.
+ *
+ * It exists as both the `Source` and `Operator` types need this capability.
+ * Acquiring the capability through composition over inheritance feels much cleaner
+ * and causes less problems (class hierarchy struggles) down the line.
+ */
+export class DifferenceStream<T extends Entity> {
+  readonly #downstreams = new Set<DownstreamNode<T>>();
+  #upstream: UpstreamNode<T> | undefined;
+
+  addDownstream(listener: DownstreamNode<T>) {
+    this.#downstreams.add(listener);
+  }
+
+  setUpstream(operator: UpstreamNode<T>) {
+    assert(this.#upstream === undefined, 'upstream already set');
+    this.#upstream = operator;
+    return this;
+  }
+
+  newDifference(version: number, data: IterableTree<T>) {
+    for (const listener of this.#downstreams) {
+      listener.newDifference(version, data);
+    }
+  }
+
+  pull(msg: PullRequest): IterableTree<T> {
+    return must(this.#upstream).pull(msg);
+  }
+
+  commit(version: number) {
+    for (const listener of this.#downstreams) {
+      listener.commit(version);
+    }
+  }
+}

--- a/packages/zql/src/zql/ivm-2/graph/node.ts
+++ b/packages/zql/src/zql/ivm-2/graph/node.ts
@@ -1,0 +1,72 @@
+import type {IterableTree} from '../iterable-tree.js';
+import type {Entity, Version} from '../types.js';
+import type {PullRequest} from './pull.js';
+
+/**
+ * There are three kinds of nodes in the dataflow graph:
+ * 1. Sources
+ * 2. Operators
+ * 3. Views
+ *
+ * Sources and Operators can both be upstream of other nodes.
+ * This interface is implemented by both Sources and Operators.
+ */
+export interface UpstreamNode<T = Entity> {
+  pull(message: PullRequest): IterableTree<T>;
+  /**
+   * Destruction happens from the leaves of the graph to the root.
+   *
+   * This is because an upstream node may have many downstreams
+   * with different lifetimes. The node should exist until all
+   * of its children are gone.
+   */
+  destroy(): void;
+}
+
+/**
+ * Operators and Views are both downstream of other nodes.
+ * Either downstream of a source or downstream of another operator.
+ *
+ * Differences flow down from sources to operators to views (newDifference).
+ * The notification that a transaction has completed also flows
+ * down this same path (commit).
+ *
+ * This interface is implemented by both Operators and Views.
+ */
+export type DownstreamNode<T = Entity> = {
+  /**
+   * All DownstreamNodes in a pipeline, except for the view, are lazy.
+   *
+   * When they receive a `newDifference` call they take the `data` iterable
+   * and transform it into a new iterable that is passed to the next node.
+   *
+   * E.g., filter doesn't actually filter the data, it just creates a new
+   * iterable that will apply the filter when it is iterated.
+   *
+   * ```ts
+   * function *filter(data: IterableTree, p: (t) => boolean) {
+   *   for (const entry of data) {
+   *     if (p(entry[0])) {
+   *       yield entry;
+   *     }
+   *   }
+   * }
+   * ```
+   */
+  newDifference: (version: Version, data: IterableTree<T>) => void;
+
+  /**
+   * Commit events exist so Views and Effects know when to notify external
+   * observers. An effect being a kind of operator that has side effects.
+   *
+   * As an IVM pipeline runs it can pass through inconsistent states.
+   * To prevent those states from being observed, observers are not notified
+   * until the transaction is complete.
+   *
+   * One great example of "inconsistent states" is an update.
+   * An update is modeled as a `remove` followed by an `add`.
+   * If someone were to observe the `remove` before the `add` they would
+   * see the entity as removed when it should have been updated.
+   */
+  commit: (version: Version) => void;
+};

--- a/packages/zql/src/zql/ivm-2/graph/operators/operator.ts
+++ b/packages/zql/src/zql/ivm-2/graph/operators/operator.ts
@@ -1,0 +1,9 @@
+import type {DownstreamNode, UpstreamNode} from '../node.js';
+
+/**
+ * An `Operator` is an internal node in the graph.
+ * Given that, is it both `Upstream` and `Downstream` of other nodes.
+ *
+ * See docs on the `UpstreamNode` and `DownstreamNode` interfaces for more information.
+ */
+export interface Operator extends UpstreamNode, DownstreamNode {}

--- a/packages/zql/src/zql/ivm-2/graph/pull.ts
+++ b/packages/zql/src/zql/ivm-2/graph/pull.ts
@@ -1,0 +1,26 @@
+import type {Condition} from '../../ast/ast.js';
+
+export type PullRequest = {
+  /**
+   * At this stage, `Condition` is likely the wrong shape. Rather than being a `selector` it should
+   * be a path to the field in the IterableTree.
+   *
+   * Think of `issue -> comment -> revision`. When `revision` pulls on `comment`, this pull
+   * needs to specify a path from `issue -> comment -> comment.id` rather than a selector.
+   * You can see an example of this in the test case:
+   * 'loop join with loop join' in this PR: https://github.com/rocicorp/mono/pull/2103
+   *
+   * We'll resolve the `Condition` type in a future PR.
+   */
+  readonly requiredConstraint: Condition;
+  readonly optionalConstraints: Condition[];
+
+  /**
+   * `requiredOrder` is intentionally missing here.
+   * Given we do not allow ordering by subqueries and we do not allow joins,
+   * this implies that the sources are always driving the order of queries.
+   *
+   * Given that, we'll always attach pipelines to the sources
+   * that have the correct order and order should not be required for pull.
+   */
+};

--- a/packages/zql/src/zql/ivm-2/iterable-tree.ts
+++ b/packages/zql/src/zql/ivm-2/iterable-tree.ts
@@ -1,0 +1,31 @@
+import type {Entity} from './types.js';
+
+/**
+ * An `Entry` may have any number of user-defined properties.
+ * To ensure we do not collide with user-defined properties,
+ * we use symbols to denote the properties we use.
+ *
+ * The `entity` symbol is used to denote the entity in the entry.
+ * The `event` symbol is used to denote the event that occurred on the entity.
+ */
+export const event = Symbol();
+export const entity = Symbol();
+
+export type Event = Add | Remove | NoOp;
+export const ADD = 1;
+export const REMOVE = -1;
+export const NOP = 0;
+
+export type Add = typeof ADD;
+export type Remove = typeof REMOVE;
+export type NoOp = typeof NOP;
+
+/**
+ * Please see: https://www.notion.so/replicache/NestedIterable-5123f11b877e41b7bc9f00486d491d8b?pm=c
+ */
+export type Entry<Type = Entity> = {
+  [entity]: Type;
+  [event]: Event;
+  [children: string]: Iterable<Entry>;
+};
+export type IterableTree<T> = Iterable<Entry<T>>;

--- a/packages/zql/src/zql/ivm-2/materialite.ts
+++ b/packages/zql/src/zql/ivm-2/materialite.ts
@@ -1,0 +1,100 @@
+import {must} from 'shared/src/must.js';
+import type {Source} from './source/source.js';
+import type {Version} from './types.js';
+
+/**
+ * The only responsibility of this class is to manage transaction boundaries.
+ *
+ * Transactions exist in the system so Views and Effects know when to notify external
+ * observers.
+ *
+ * As an IVM pipeline runs it can pass through inconsistent states.
+ * To prevent those states from being observed, observers are not notified
+ * until the transaction is complete.
+ *
+ * One great example of "inconsistent states" is an update.
+ * An update is modeled as a `remove` followed by an `add`.
+ * If someone were to observe the `remove` before the `add` they would
+ * see the entity as removed when it should have been updated.
+ */
+export class Materialite {
+  #version: Version;
+  #dirtySources: Set<Source> = new Set();
+  #currentTx: Version | null = null;
+
+  constructor() {
+    this.#version = 0;
+  }
+
+  getTxVersion() {
+    if (this.#currentTx === null) {
+      return this.#version + 1;
+    }
+    return this.#currentTx;
+  }
+
+  addDirtySource(source: Source) {
+    this.#dirtySources.add(source);
+    if (this.#currentTx === null) {
+      this.#commit(true);
+    }
+  }
+
+  tx(fn: () => void) {
+    if (this.#currentTx === null) {
+      this.#currentTx = this.#version + 1;
+    } else {
+      // Nested transaction.
+      // just run the function as we're already inside the
+      // scope of a transaction that will handle rollback and commit.
+      fn();
+      return;
+    }
+    try {
+      try {
+        this._txBegin();
+        fn();
+      } catch (e) {
+        this.#rollback();
+        throw e;
+      }
+      this.#commit();
+    } finally {
+      this.#dirtySources.clear();
+    }
+  }
+
+  /**
+   * These protected methods are so the SQLite backed implementation can
+   * hook into the transaction lifecycle and start/commit/rollback the underlying
+   * SQLite transactions.
+   */
+  protected _txBegin(): void {}
+  protected _txCommit(): void {}
+  protected _txRollback(): void {}
+
+  #rollback() {
+    this.#currentTx = null;
+    this._txRollback();
+  }
+
+  #commit(autoTx = false) {
+    try {
+      if (autoTx) {
+        this.#currentTx = this.#version + 1;
+        this._txBegin();
+      }
+      this.#version = must(this.#currentTx);
+      this.#currentTx = null;
+
+      this._txCommit();
+    } catch (e) {
+      this.#rollback();
+      throw e;
+    }
+
+    for (const source of this.#dirtySources) {
+      source.commit(this.#version);
+    }
+  }
+}

--- a/packages/zql/src/zql/ivm-2/source/source.test.ts
+++ b/packages/zql/src/zql/ivm-2/source/source.test.ts
@@ -1,0 +1,76 @@
+import {expect, test} from 'vitest';
+import {ADD, event, entity, REMOVE} from '../iterable-tree.js';
+import {Materialite} from '../materialite.js';
+import {MemorySource} from './source.js';
+
+test('add and remove outside a tx auto-commits', () => {
+  const m = new Materialite();
+  const s = new MemorySource(m, [['id', 'asc']], 'foo');
+
+  let committed = 0;
+  let dataSeen;
+  let commitCalls = 0;
+  let differenceCalls = 0;
+  s.stream.addDownstream({
+    commit(version) {
+      committed = version;
+      commitCalls++;
+    },
+    newDifference(_version, data) {
+      dataSeen = data;
+      differenceCalls++;
+    },
+  });
+
+  s.add({id: '1', name: 'one'});
+
+  expect(committed).toBe(1);
+  expect(dataSeen).toEqual([
+    {
+      [entity]: {id: '1', name: 'one'},
+      [event]: ADD,
+    },
+  ]);
+  expect(commitCalls).toBe(1);
+  expect(differenceCalls).toBe(1);
+
+  s.remove({id: '1', name: 'one'});
+
+  expect(committed).toBe(2);
+  expect(dataSeen).toEqual([
+    {
+      [entity]: {id: '1', name: 'one'},
+      [event]: REMOVE,
+    },
+  ]);
+  expect(commitCalls).toBe(2);
+  expect(differenceCalls).toBe(2);
+});
+
+test('add and remove inside a tx does not auto-commit', () => {
+  const m = new Materialite();
+  const s = new MemorySource(m, [['id', 'asc']], 'foo');
+
+  let commitCalls = 0;
+  let differenceCalls = 0;
+  s.stream.addDownstream({
+    commit(_) {
+      commitCalls++;
+    },
+    newDifference(_version, _data) {
+      differenceCalls++;
+    },
+  });
+
+  m.tx(() => {
+    s.add({id: '1', name: 'one'});
+    expect(commitCalls).toBe(0);
+    expect(differenceCalls).toBe(1);
+    s.remove({id: '1', name: 'one'});
+    expect(commitCalls).toBe(0);
+    expect(differenceCalls).toBe(2);
+  });
+
+  expect(commitCalls).toBe(1);
+  expect(differenceCalls).toBe(2);
+});

--- a/packages/zql/src/zql/ivm-2/source/source.ts
+++ b/packages/zql/src/zql/ivm-2/source/source.ts
@@ -1,0 +1,105 @@
+import type {Ordering} from '../../ast-2/ast.js';
+import type {Comparator} from '../../ivm/types.js';
+import type {Materialite} from '../materialite.js';
+import BTree from 'btree';
+import {DifferenceStream} from '../graph/difference-stream.js';
+import {ADD, event, entity, REMOVE, Entry} from '../iterable-tree.js';
+import {makeComparator} from '../compare.js';
+import type {Entity, Version} from '../types.js';
+import type {UpstreamNode} from '../graph/node.js';
+import type {PullRequest} from '../graph/pull.js';
+import {gen} from '../../util/iterables.js';
+import {must} from 'shared/src/must.js';
+
+/**
+ * A `Source` is the root of an IVM pipeline.
+ * All events enter a source and flow down through attached
+ * pipelines to the views.
+ *
+ * A `source` only exposes `add` and `remove` as `updates` are modeled as
+ * 1. remove the old value
+ * 2. add the new value
+ *
+ * `commit` is an internal method used by `Materialite` to denote the end of a transaction.
+ */
+export interface Source<T extends Entity = Entity> extends UpstreamNode<T> {
+  readonly stream: DifferenceStream<T>;
+  add(value: T): void;
+  remove(value: T): void;
+
+  commit(version: Version): void;
+}
+
+/**
+ * A `MemorySource` is a `Source` that stores its data in memory.
+ *
+ * This data is kept in sorted order as downstream pipelines will
+ * always expect the data they receive from `pull` to be in sorted order.
+ *
+ * Related:
+ * Incremental Pull: https://www.notion.so/replicache/Incremental-Pull-f3eea25558c843e0b3a8e53034f1e0be
+ * Hydration Planner: https://www.notion.so/replicache/Hydration-Query-Planner-d1a4634b1390459e8e1fa454a2396841
+ */
+export class MemorySource<T extends Entity> implements Source<T> {
+  #tree: BTree<T, undefined>;
+  readonly comparator: Comparator<T>;
+  readonly name: string;
+  readonly #materialite: Materialite;
+  #stream: DifferenceStream<T> | undefined;
+
+  constructor(materialite: Materialite, order: Ordering, name: string) {
+    this.comparator = makeComparator(order);
+    this.#tree = new BTree(undefined, this.comparator);
+    this.name = name;
+    this.#materialite = materialite;
+    this.#stream = new DifferenceStream<T>();
+  }
+
+  get stream() {
+    return must(this.#stream);
+  }
+
+  add(v: T) {
+    this.#tree = this.#tree.with(v, undefined);
+    this.stream.newDifference(this.#materialite.getTxVersion(), [
+      {
+        [entity]: v,
+        [event]: ADD,
+      },
+    ]);
+    this.#materialite.addDirtySource(this as unknown as Source);
+  }
+
+  remove(v: T) {
+    this.stream.newDifference(this.#materialite.getTxVersion(), [
+      {
+        [entity]: v,
+        [event]: REMOVE,
+      },
+    ]);
+    this.#tree = this.#tree.without(v);
+    this.#materialite.addDirtySource(this as unknown as Source);
+  }
+
+  commit(version: number): void {
+    this.stream.commit(version);
+  }
+
+  pull(_message: PullRequest) {
+    const tree = this.#tree;
+    return gen(() => genTreeAsEntries(tree));
+  }
+
+  destroy(): void {
+    this.#stream = undefined;
+  }
+}
+
+function* genTreeAsEntries<T>(tree: BTree<T, undefined>): Generator<Entry<T>> {
+  for (const row of tree.keys()) {
+    yield {
+      [entity]: row,
+      [event]: ADD,
+    };
+  }
+}

--- a/packages/zql/src/zql/ivm-2/types.ts
+++ b/packages/zql/src/zql/ivm-2/types.ts
@@ -1,0 +1,2 @@
+export type Entity = {id: string} & Record<string, unknown>;
+export type Version = number;


### PR DESCRIPTION
So I was trying to figure out the best way to go about updating the IVM code given the core types flowing through it are changing. Rather than update the code and have to track down a million type errors and try to change everything all at once it strikes me as being easier to create an `ivm-2` directory and re-implement (potentially using copy-pasta from the ivm dir) the operators, sources and views.

Once `ivm-2` is done we can swap it into the rest of the machinery (ast, query builder, pipeline builder) and delete the old `ivm` directory.

This PR lays out the scaffolding for IVM and re-introduces (while also fixing, streamlining and renaming):
- Materialite
- Source
- DifferenceStream

The PR also implements the `NestedIterable`. `NestedIterable` has been renamed to `IterableTree` here. I think `IterableTree` is a more accurate of a description since sibling iterables can exist.

Now that we have the scaffolding and `IterableTree`, plugging in the operators should be relatively straightforward.

Next steps:
- Further define `pull`
- A view implementation
- filter/join/topk
- Wiring together with an AST that supports subqueries / implementing a PipelineBuilder that understands subqueries