### PR TITLE
feat(ivm2): define the minimal AST

### DIFF
--- a/packages/zql/src/zql/ast2/ast.ts
+++ b/packages/zql/src/zql/ast2/ast.ts
@@ -10,3 +10,52 @@ export type EqualityOps = '=' | '!=';
 export type OrderOps = '<' | '>' | '<=' | '>=';
 export type InOps = 'IN' | 'NOT IN';
 export type LikeOps = 'LIKE' | 'NOT LIKE' | 'ILIKE' | 'NOT ILIKE';
+
+export type AST = {
+  readonly table: string;
+  readonly alias?: string | undefined;
+
+  // `select` is missing given we return all columns for now.
+
+  readonly subqueries?: readonly SubQuery[] | undefined;
+  readonly where?: Condition | undefined;
+  readonly limit?: number | undefined;
+  readonly orderBy: Ordering;
+};
+
+export type SubQuery = {
+  /**
+   * Only equality correlations are supported for now.
+   * E.g., direct foreign key relationships.
+   */
+  readonly correlation: {
+    readonly parentField: string;
+    readonly childField: string;
+    readonly op: '=';
+  };
+  readonly subquery: AST;
+};
+
+/**
+ * Starting only with SimpleCondition for now.
+ * ivm1 supports Conjunctions and Disjunctions.
+ * We'll support them in the future.
+ */
+export type Condition = SimpleCondition;
+export type SimpleCondition = {
+  type: 'simple';
+  op: SimpleOperator;
+
+  /**
+   * Not a path yet as we're currently not allowing
+   * comparisons across tables. This will need to
+   * be a path through the tree in the near future.
+   */
+  field: string;
+
+  /**
+   * `null` is absent since we do not have an `IS` or `IS NOT`
+   * operator defined and `null != null` in SQL.
+   */
+  value: string | number | boolean;
+};

--- a/packages/zql/src/zql/ivm2/data.ts
+++ b/packages/zql/src/zql/ivm2/data.ts
@@ -86,6 +86,8 @@ export function idEquals(id1: ID, id2: ID): boolean {
  * @returns < 0 if a < b, 0 if a === b, > 0 if a > b
  */
 export function compareValues(a: Value, b: Value): number {
+  // TODO: should `null === null`? Should `undefined === undefined`?
+  // See: https://github.com/rocicorp/mono/pull/2116/files#r1704811479
   if (a === b) {
     return 0;
   }


### PR DESCRIPTION
- no `select` since all columns are returned
- no `paths` for filter since we're not at cross table filters yet
- no `conjunctions` or `disjunctions` since `or` / forking isn't defined yet
- no `schema` since SQLite doesn't have a notion of separate schemas like pg does. Well it sort of does via attached dbs.
- no aggregate/distinct/groupBy/having since those are currently out of scope
- no `join` since we only do subqueries now