### PR TITLE
feat(zero-cache): lite variant of schema migration logic

### DIFF
--- a/packages/zero-cache/src/db/migration-lite.test.ts
+++ b/packages/zero-cache/src/db/migration-lite.test.ts
@@ -1,0 +1,229 @@
+import type {LogContext} from '@rocicorp/logger';
+import type {Database as Db} from 'better-sqlite3';
+import Database from 'better-sqlite3';
+import {unlink} from 'fs/promises';
+import {tmpdir} from 'os';
+import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
+import {randInt} from 'shared/src/rand.js';
+import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {
+  SchemaVersions,
+  VersionMigrationMap,
+  getSchemaVersions,
+  runSchemaMigrations,
+} from './migration-lite.js';
+
+describe('db/migration-lite', () => {
+  const debugName = 'debug-name';
+
+  type Case = {
+    name: string;
+    preSchema?: SchemaVersions;
+    migrations: VersionMigrationMap;
+    postSchema: SchemaVersions;
+    expectedErr?: string;
+    expectedMigrationHistory?: {event: string}[];
+  };
+
+  const logMigrationHistory = (name: string) => (_log: LogContext, db: Db) => {
+    const meta = getSchemaVersions(db);
+    db.prepare(`INSERT INTO MigrationHistory (event) VALUES (?)`).run(
+      `${name}-at(${meta.version})`,
+    );
+  };
+
+  const cases: Case[] = [
+    {
+      name: 'sorts and runs multiple migrations',
+      preSchema: {
+        version: 2,
+        maxVersion: 2,
+        minSafeRollbackVersion: 1,
+      },
+      migrations: {
+        5: {
+          pre: logMigrationHistory('pre-second'),
+          run: logMigrationHistory('second'),
+        },
+        4: {run: logMigrationHistory('first')},
+        7: {minSafeRollbackVersion: 2},
+        8: {run: logMigrationHistory('third')},
+      },
+      expectedMigrationHistory: [
+        {event: 'first-at(2)'},
+        {event: 'pre-second-at(4)'},
+        {event: 'second-at(4)'},
+        {event: 'third-at(7)'},
+      ],
+      postSchema: {
+        version: 8,
+        maxVersion: 8,
+        minSafeRollbackVersion: 2,
+      },
+    },
+    {
+      name: 'initial migration',
+      migrations: {1: {run: () => Promise.resolve()}},
+      postSchema: {
+        version: 1,
+        maxVersion: 1,
+        minSafeRollbackVersion: 0,
+      },
+    },
+    {
+      name: 'updates max version',
+      preSchema: {
+        version: 12,
+        maxVersion: 12,
+        minSafeRollbackVersion: 6,
+      },
+      migrations: {13: {run: () => Promise.resolve()}},
+      postSchema: {
+        version: 13,
+        maxVersion: 13,
+        minSafeRollbackVersion: 6,
+      },
+    },
+    {
+      name: 'preserves other versions',
+      preSchema: {
+        version: 12,
+        maxVersion: 14,
+        minSafeRollbackVersion: 6,
+      },
+      migrations: {13: {run: () => Promise.resolve()}},
+      postSchema: {
+        version: 13,
+        maxVersion: 14,
+        minSafeRollbackVersion: 6,
+      },
+    },
+    {
+      name: 'rollback to earlier version',
+      preSchema: {
+        version: 10,
+        maxVersion: 10,
+        minSafeRollbackVersion: 8,
+      },
+      migrations: {8: {run: () => Promise.reject('should not be run')}},
+      postSchema: {
+        version: 8,
+        maxVersion: 10,
+        minSafeRollbackVersion: 8,
+      },
+    },
+    {
+      name: 'disallows rollback before rollback limit',
+      preSchema: {
+        version: 10,
+        maxVersion: 10,
+        minSafeRollbackVersion: 8,
+      },
+      migrations: {7: {run: () => Promise.reject('should not be run')}},
+      postSchema: {
+        version: 10,
+        maxVersion: 10,
+        minSafeRollbackVersion: 8,
+      },
+      expectedErr: `Error: Cannot run ${debugName} at schema v7 because rollback limit is v8`,
+    },
+    {
+      name: 'bump rollback limit',
+      preSchema: {
+        version: 10,
+        maxVersion: 10,
+        minSafeRollbackVersion: 0,
+      },
+      migrations: {11: {minSafeRollbackVersion: 3}},
+      postSchema: {
+        version: 11,
+        maxVersion: 11,
+        minSafeRollbackVersion: 3,
+      },
+    },
+    {
+      name: 'rollback limit bump does not move backwards',
+      preSchema: {
+        version: 10,
+        maxVersion: 10,
+        minSafeRollbackVersion: 6,
+      },
+      migrations: {11: {minSafeRollbackVersion: 3}},
+      postSchema: {
+        version: 11,
+        maxVersion: 11,
+        minSafeRollbackVersion: 6,
+      },
+    },
+    {
+      name: 'only updates version for successful migrations',
+      preSchema: {
+        version: 12,
+        maxVersion: 12,
+        minSafeRollbackVersion: 6,
+      },
+      migrations: {
+        13: {run: logMigrationHistory('successful')},
+        14: {run: () => Promise.reject('fails to get to 14')},
+      },
+      postSchema: {
+        version: 13,
+        maxVersion: 13,
+        minSafeRollbackVersion: 6,
+      },
+      expectedMigrationHistory: [{event: 'successful-at(12)'}],
+      expectedErr: 'fails to get to 14',
+    },
+  ];
+
+  let dbFile: string;
+  let db: Db;
+
+  beforeEach(() => {
+    dbFile = `${tmpdir()}/migration-test-${randInt(10000, 99999)}.db`;
+    db = new Database(dbFile);
+    db.pragma('journal_mode = WAL');
+    db.pragma('synchronous = NORMAL');
+    db.prepare(`CREATE TABLE "MigrationHistory" (event TEXT)`).run();
+  });
+
+  afterEach(async () => {
+    db.close();
+    await unlink(dbFile);
+  });
+
+  for (const c of cases) {
+    test(c.name, async () => {
+      if (c.preSchema) {
+        getSchemaVersions(db); // Ensures that the table is created.
+        db.prepare(
+          `
+          INSERT INTO _zero_SchemaVersions (version, maxVersion, minSafeRollbackVersion)
+          VALUES (@version, @maxVersion, @minSafeRollbackVersion)
+        `,
+        ).run(c.preSchema);
+      }
+
+      let err: string | undefined;
+      try {
+        await runSchemaMigrations(
+          createSilentLogContext(),
+          debugName,
+          dbFile,
+          c.migrations,
+        );
+      } catch (e) {
+        if (!c.expectedErr) {
+          throw e;
+        }
+        err = String(e);
+      }
+      expect(err).toBe(c.expectedErr);
+
+      expect(getSchemaVersions(db)).toEqual(c.postSchema);
+      expect(db.prepare(`SELECT * FROM "MigrationHistory"`).all()).toEqual(
+        c.expectedMigrationHistory ?? [],
+      );
+    });
+  }
+});

--- a/packages/zero-cache/src/db/migration-lite.ts
+++ b/packages/zero-cache/src/db/migration-lite.ts
@@ -1,0 +1,243 @@
+import type {LogContext} from '@rocicorp/logger';
+import type {Database as Db} from 'better-sqlite3';
+import Database from 'better-sqlite3';
+import {assert} from 'shared/src/asserts.js';
+import {randInt} from 'shared/src/rand.js';
+import * as v from 'shared/src/valita.js';
+
+/**
+ * A PreMigrationFn executes logic outside of a database transaction, and is
+ * suitable for potentially long running polling operations.
+ */
+type PreMigrationFn = (log: LogContext, db: Db) => Promise<void> | void;
+
+type MigrationFn = (log: LogContext, tx: Db) => Promise<void> | void;
+
+/**
+ * Encapsulates the logic for upgrading to a new schema. After the
+ * Migration code successfully completes, {@link runSchemaMigrations}
+ * will update the schema version and commit the transaction.
+ */
+export type Migration =
+  | {pre?: PreMigrationFn; run: MigrationFn}
+  // A special Migration type that pushes the rollback limit forward.
+  | {minSafeRollbackVersion: number};
+
+/** Mapping from schema version to their respective migrations. */
+export type VersionMigrationMap = {
+  [destinationVersion: number]: Migration;
+};
+
+/**
+ * Ensures that the schema is compatible with the current code, updating and
+ * migrating the schema if necessary.
+ */
+export async function runSchemaMigrations(
+  log: LogContext,
+  debugName: string,
+  dbPath: string,
+  versionMigrationMap: VersionMigrationMap,
+): Promise<void> {
+  log = log.withContext(
+    'initSchema',
+    randInt(0, Number.MAX_SAFE_INTEGER).toString(36),
+  );
+  const db = new Database(dbPath);
+  db.pragma('foreign_keys = OFF');
+  db.pragma('journal_mode = WAL');
+  db.pragma('synchronous = OFF'); // For schema initialization we'll wait for the disk flush on close.
+
+  try {
+    const versionMigrations = sorted(versionMigrationMap);
+    if (versionMigrations.length === 0) {
+      log.info?.(`No versions/migrations to manage.`);
+      return;
+    }
+    const codeSchemaVersion =
+      versionMigrations[versionMigrations.length - 1][0];
+    log.info?.(
+      `Checking schema for compatibility with ${debugName} at schema v${codeSchemaVersion}`,
+    );
+
+    let meta = await runTransaction(log, db, tx => {
+      const meta = getSchemaVersions(tx);
+      if (codeSchemaVersion < meta.minSafeRollbackVersion) {
+        throw new Error(
+          `Cannot run ${debugName} at schema v${codeSchemaVersion} because rollback limit is v${meta.minSafeRollbackVersion}`,
+        );
+      }
+
+      if (meta.version > codeSchemaVersion) {
+        log.info?.(
+          `Schema is at v${meta.version}. Resetting to v${codeSchemaVersion}`,
+        );
+        return setSchemaVersion(tx, meta, codeSchemaVersion);
+      }
+      return meta;
+    });
+
+    if (meta.version < codeSchemaVersion) {
+      for (const [dest, migration] of versionMigrations) {
+        if (meta.version < dest) {
+          log.info?.(`Migrating schema from v${meta.version} to v${dest}`);
+          void log.flush(); // Flush logs before each migration to help debug crash-y migrations.
+
+          // Run the optional PreMigration step before starting the transaction.
+          if ('pre' in migration) {
+            await migration.pre(log, db);
+          }
+
+          meta = await runTransaction(log, db, async tx => {
+            // Fetch meta from within the transaction to make the migration atomic.
+            let meta = getSchemaVersions(tx);
+            if (meta.version < dest) {
+              meta = await migrateSchemaVersion(log, tx, meta, dest, migration);
+              assert(meta.version === dest);
+            }
+            return meta;
+          });
+        }
+      }
+    }
+
+    assert(meta.version === codeSchemaVersion);
+    log.info?.(`Running ${debugName} at schema v${codeSchemaVersion}`);
+  } catch (e) {
+    log.error?.('Error in ensureSchemaMigrated', e);
+    throw e;
+  } finally {
+    db.close();
+    void log.flush(); // Flush the logs but do not block server progress on it.
+  }
+}
+
+function sorted(
+  versionMigrationMap: VersionMigrationMap,
+): [number, Migration][] {
+  const versionMigrations: [number, Migration][] = [];
+  for (const [v, m] of Object.entries(versionMigrationMap)) {
+    versionMigrations.push([Number(v), m]);
+  }
+  return versionMigrations.sort(([a], [b]) => a - b);
+}
+
+// Exposed for tests.
+export const schemaVersions = v.object({
+  version: v.number(),
+  maxVersion: v.number(),
+  minSafeRollbackVersion: v.number(),
+});
+
+// Exposed for tests.
+export type SchemaVersions = v.Infer<typeof schemaVersions>;
+
+// Exposed for tests
+export function getSchemaVersions(db: Db): SchemaVersions {
+  // Note: The `lock` column transparently ensures that at most one row exists.
+  db.prepare(
+    `
+    CREATE TABLE IF NOT EXISTS _zero_SchemaVersions (
+      version INTEGER NOT NULL,
+      maxVersion INTEGER NOT NULL,
+      minSafeRollbackVersion INTEGER NOT NULL,
+
+      lock INTEGER PRIMARY KEY DEFAULT 1 CHECK (lock=1)
+    );
+  `,
+  ).run();
+  const result = db
+    .prepare(
+      'SELECT version, maxVersion, minSafeRollbackVersion FROM _zero_SchemaVersions',
+    )
+    .get() as SchemaVersions;
+  return result ?? {version: 0, maxVersion: 0, minSafeRollbackVersion: 0};
+}
+
+function setSchemaVersion(
+  db: Db,
+  prev: SchemaVersions,
+  newVersion: number,
+): SchemaVersions {
+  assert(newVersion > 0);
+  const meta = {
+    ...prev,
+    version: newVersion,
+    maxVersion: Math.max(newVersion, prev.maxVersion),
+  };
+
+  db.prepare(
+    `
+    INSERT INTO _zero_SchemaVersions (version, maxVersion, minSafeRollbackVersion, lock)
+    VALUES (@version, @maxVersion, @minSafeRollbackVersion, 1)
+    ON CONFLICT (lock) DO UPDATE
+    SET version=EXCLUDED.version, 
+        maxVersion=EXCLUDED.maxVersion,
+        minSafeRollbackVersion=EXCLUDED.minSafeRollbackVersion
+  `,
+  ).run(meta);
+
+  return meta;
+}
+
+async function migrateSchemaVersion(
+  log: LogContext,
+  tx: Db,
+  meta: SchemaVersions,
+  destinationVersion: number,
+  migration: Migration,
+): Promise<SchemaVersions> {
+  if ('run' in migration) {
+    await migration.run(log, tx);
+  } else {
+    meta = ensureRollbackLimit(migration.minSafeRollbackVersion, log, meta);
+  }
+  return setSchemaVersion(tx, meta, destinationVersion);
+}
+
+/**
+ * Bumps the rollback limit [[toAtLeast]] the specified version.
+ * Leaves the rollback limit unchanged if it is equal or greater.
+ */
+function ensureRollbackLimit(
+  toAtLeast: number,
+  log: LogContext,
+  meta: SchemaVersions,
+): SchemaVersions {
+  // Sanity check to maintain the invariant that running code is never
+  // earlier than the rollback limit.
+  assert(toAtLeast <= meta.version + 1);
+
+  if (meta.minSafeRollbackVersion >= toAtLeast) {
+    // The rollback limit must never move backwards.
+    log.debug?.(
+      `rollback limit is already at ${meta.minSafeRollbackVersion}, don't need to bump to ${toAtLeast}`,
+    );
+    return meta;
+  }
+  log.info?.(
+    `bumping rollback limit from ${meta.minSafeRollbackVersion} to ${toAtLeast}`,
+  );
+  return {
+    ...meta,
+    minSafeRollbackVersion: toAtLeast,
+  };
+}
+
+// Note: We use a custom transaction wrapper (instead of db.begin(...)) in order
+// to support async operations within the transaction.
+async function runTransaction<T>(
+  log: LogContext,
+  db: Db,
+  tx: (db: Db) => Promise<T> | T,
+): Promise<T> {
+  db.prepare('BEGIN EXCLUSIVE').run();
+  try {
+    const result = await tx(db);
+    db.prepare('COMMIT').run();
+    return result;
+  } catch (e) {
+    db.prepare('ROLLBACK').run();
+    log.error?.('Aborted transaction due to error', e);
+    throw e;
+  }
+}


### PR DESCRIPTION
This is a straight port of [`migration.ts`](https://github.com/rocicorp/mono/blob/main/packages/zero-cache/src/db/migration.ts) (schema migration for a Postgres-backed store) adapted for a SQLite store. 