### PR TITLE
chore(ivm): Fix overlay and start parameter.

### DIFF
--- a/packages/zql/src/zql/ivm2/operator.ts
+++ b/packages/zql/src/zql/ivm2/operator.ts
@@ -42,12 +42,13 @@ export type Constraint = {
 };
 
 export type FetchRequest = HydrateRequest & {
-  start?:
-    | {
-        row: Row;
-        basis: 'before' | 'at' | 'after';
-      }
-    | undefined;
+  // If supplied, `start.row` must have previously been output.
+  start?: Start | undefined;
+};
+
+export type Start = {
+  row: Row;
+  basis: 'before' | 'at' | 'after';
 };
 
 /**


### PR DESCRIPTION
I'm not very happy with this. I think there must be some more elegant way to express it, but at least it passes tests and unblocks others to use `MemorySource`. I will circle back and look for a cleaner approach tomorrow. Suggestions also welcome.