### PR TITLE
fix(zero-cache): speed up initial sync tests

### DIFF
--- a/packages/zero-cache/src/services/replicator/initial-sync.validation.test.ts
+++ b/packages/zero-cache/src/services/replicator/initial-sync.validation.test.ts
@@ -1,0 +1,112 @@
+import {Database} from 'better-sqlite3';
+import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
+import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {DbFile} from 'zero-cache/src/test/lite.js';
+import {PostgresDB} from 'zero-cache/src/types/pg.js';
+import {getConnectionURI, initDB, testDBs} from '../../test/db.js';
+import {initialSync} from './initial-sync.js';
+
+const REPLICA_ID = 'initial_sync_validation_test_id';
+
+describe('replicator/initial-sync-validation', () => {
+  let upstream: PostgresDB;
+  let replicaFile: DbFile;
+  let replica: Database;
+
+  beforeEach(async () => {
+    upstream = await testDBs.create('initial_sync_validation_upstream');
+    replicaFile = new DbFile('initial_sync_validation_replica');
+    replica = replicaFile.connect();
+  });
+
+  afterEach(async () => {
+    await testDBs.drop(upstream);
+    await replicaFile.unlink();
+  });
+
+  type InvalidUpstreamCase = {
+    error: string;
+    setupUpstreamQuery?: string;
+    upstream?: Record<string, object[]>;
+  };
+
+  const invalidUpstreamCases: InvalidUpstreamCase[] = [
+    {
+      error: 'does not have a PRIMARY KEY',
+      setupUpstreamQuery: `
+        CREATE TABLE issues("issueID" INTEGER, "orgID" INTEGER);
+      `,
+    },
+    {
+      error: 'uses reserved column name "_0_version"',
+      setupUpstreamQuery: `
+        CREATE TABLE issues(
+          "issueID" INTEGER PRIMARY KEY, 
+          "orgID" INTEGER, 
+          _0_version INTEGER);
+      `,
+    },
+    {
+      error: 'Schema "_zero" is reserved for internal use',
+      setupUpstreamQuery: `
+        CREATE SCHEMA _zero;
+        CREATE TABLE _zero.is_not_allowed(
+          "issueID" INTEGER PRIMARY KEY, 
+          "orgID" INTEGER
+        );
+        CREATE PUBLICATION zero_foo FOR TABLES IN SCHEMA _zero;
+        `,
+    },
+    {
+      error: 'Only the default "public" schema is supported',
+      setupUpstreamQuery: `
+        CREATE SCHEMA unsupported;
+        CREATE TABLE unsupported.issues ("issueID" INTEGER PRIMARY KEY, "orgID" INTEGER);
+        CREATE PUBLICATION zero_foo FOR TABLES IN SCHEMA unsupported;
+      `,
+    },
+    {
+      error: 'Table "table/with/slashes" has invalid characters',
+      setupUpstreamQuery: `
+        CREATE TABLE "table/with/slashes" ("issueID" INTEGER PRIMARY KEY, "orgID" INTEGER);
+      `,
+    },
+    {
+      error: 'Table "table.with.dots" has invalid characters',
+      setupUpstreamQuery: `
+        CREATE TABLE "table.with.dots" ("issueID" INTEGER PRIMARY KEY, "orgID" INTEGER);
+      `,
+    },
+    {
+      error:
+        'Column "column/with/slashes" in table "issues" has invalid characters',
+      setupUpstreamQuery: `
+        CREATE TABLE issues ("issueID" INTEGER PRIMARY KEY, "column/with/slashes" INTEGER);
+      `,
+    },
+    {
+      error:
+        'Column "column.with.dots" in table "issues" has invalid characters',
+      setupUpstreamQuery: `
+        CREATE TABLE issues ("issueID" INTEGER PRIMARY KEY, "column.with.dots" INTEGER);
+      `,
+    },
+  ];
+
+  for (const c of invalidUpstreamCases) {
+    test(`Invalid upstream: ${c.error}`, async () => {
+      await initDB(upstream, c.setupUpstreamQuery, c.upstream);
+
+      const result = await initialSync(
+        createSilentLogContext(),
+        REPLICA_ID,
+        replica,
+        upstream,
+        getConnectionURI(upstream, 'external'),
+      ).catch(e => e);
+
+      expect(result).toBeInstanceOf(Error);
+      expect(String(result)).toContain(c.error);
+    });
+  }
+});


### PR DESCRIPTION
Speed up initial-sync tests by splitting the validation tests out into a separate file so that they can be run in parallel. These tests no longer create a replication slot so the `afterEach()` slot cleanup logic is also unnecessary.

Also remove an unintentional level of `test()` nesting that was causing all validation tests for each initial-sync test.  😝 