### PR TITLE
feat(zql): statement cache that handles re-entry

### DIFF
--- a/packages/zqlite/src/internal/statement-cache.test.ts
+++ b/packages/zqlite/src/internal/statement-cache.test.ts
@@ -1,0 +1,56 @@
+import {expect, test} from 'vitest';
+import {CachedStatement, StatementCache} from './statement-cache.js';
+import Database from 'better-sqlite3';
+
+test('Same sql results in same statement instance. The same instance is not outstanding twice.', () => {
+  const db = new Database(':memory:');
+  const cache = new StatementCache(db);
+
+  const expected: CachedStatement[] = [];
+  for (let i = 0; i < 100; ++i) {
+    const stmt = cache.get(`SELECT ${i}`);
+    cache.return(stmt);
+    expected.push(stmt);
+    expect(cache.size).toBe(expected.length);
+  }
+
+  const duplicatedExpected: CachedStatement[] = [];
+  for (let i = 0; i < 100; ++i) {
+    // get a statement that is in the cache
+    const stmt = cache.get(`SELECT ${i}`);
+    // check that it is the one we put in the cache
+    expect(stmt.statement).toBe(expected[i].statement);
+
+    // get it again. It is not in the cache now (we have it in hand above)
+    // so we should get a new instance.
+    const stmt2 = cache.get(`SELECT ${i}`);
+    expect(stmt.statement).not.toBe(stmt2.statement);
+    duplicatedExpected.push(stmt2);
+
+    // cache size keeps going down until we return the statements
+    expect(cache.size).toBe(expected.length - i - 1);
+  }
+
+  for (let i = 0; i < 100; ++i) {
+    cache.return(expected[i]);
+    expect(cache.size).toBe(i + 1);
+  }
+  for (let i = 0; i < 100; ++i) {
+    cache.return(duplicatedExpected[i]);
+    expect(cache.size).toBe(100 + i + 1);
+  }
+
+  // drops the least recently used 100 statements
+  cache.drop(100);
+
+  expect(cache.size).toBe(100);
+  // the most recently used are `duplicatedExpected` and should all be
+  // present in the cache
+  for (let i = 0; i < 100; ++i) {
+    const stmt = cache.get(`SELECT ${i}`);
+    expect(stmt.statement).toBe(duplicatedExpected[i].statement);
+  }
+
+  // all statements are outstanding
+  expect(cache.size).toBe(0);
+});

--- a/packages/zqlite/src/internal/statement-cache.ts
+++ b/packages/zqlite/src/internal/statement-cache.ts
@@ -1,53 +1,167 @@
 import type {Database} from 'better-sqlite3';
 import type {Statement} from 'better-sqlite3';
+import {assert} from 'shared/src/asserts.js';
 
+export type CachedStatement = {
+  sql: string;
+  statement: Statement;
+};
+
+type Entry = CachedStatement & {
+  prev?: Entry | undefined;
+  next?: Entry | undefined;
+};
+
+/**
+ * SQLite statement preparation isn't cheap as it involves evaluating possible
+ * query plans and picking the best one (in addition to parsing the SQL).
+ *
+ * This statement cache prevents the need to re-prepare the same statement
+ * multiple times.
+ *
+ * One extra wrinkle is that a single statement cannot be used by multiple
+ * callers at the same time. As in, we can't `iterate` the same statement
+ * many times concurrently.
+ *
+ * Given that, statements are removed from the cache while in use.
+ * - `get` removes the statement from the cache
+ * - `return` adds it back.
+ *
+ * If a request for the same sql is made while a
+ * statement is gotten, a new statement will be prepared.
+ * Both statements can be returned to the cache even though they both
+ * serve the same SQL. Having both copies returned to the cache allows
+ * the cache to serve multiple callers concurrently in the future.
+ *
+ * It is not an error to fail to call `return` on a statement.
+ * Failing to call return will only prevent the statement from being reused
+ * by other callers. It will not cause a resource leak.
+ */
 export class StatementCache {
-  readonly #cache = new Map<
-    string,
-    {
-      statement: Statement;
-      inUse: boolean;
-    }
-  >();
+  #head?: Entry | undefined;
+  #tail?: Entry | undefined;
   readonly #db: Database;
+  #size = 0;
 
+  /**
+   * The db connection used to prepare the statement.
+   * It is an error to use a statement prepared on one connection with another connection.
+   * @param db
+   */
   constructor(db: Database) {
     this.#db = db;
   }
 
-  get db(): Database {
-    return this.#db;
+  get size() {
+    return this.#size;
   }
 
-  get(sql: string): Statement {
-    let entry = this.#cache.get(sql);
-    if (!entry) {
-      const statement = this.#prepare(sql);
-      entry = {
-        statement,
-        inUse: false,
-      };
-      this.#cache.set(sql, entry);
+  drop(n: number) {
+    assert(n >= 0, 'Cannot drop a negative number of items');
+    assert(n <= this.#size, 'Cannot drop more items than are in the cache');
+    if (n === this.#size) {
+      this.#head = undefined;
+      this.#tail = undefined;
+      this.#size = 0;
+      return;
     }
-    if (entry.inUse) {
-      throw new Error('Statement in use!');
+
+    let entry = this.#tail;
+    const originalN = n;
+    while (entry && n > 0) {
+      if (!entry.next) {
+        break;
+      }
+      entry = entry.next;
+      --n;
     }
-    entry.inUse = true;
-    return entry.statement;
+    assert(entry, 'Malformed list');
+
+    entry.prev!.next = undefined;
+    entry.prev = undefined;
+    this.#size -= originalN;
   }
 
-  return(sql: string): void {
-    const entry = this.#cache.get(sql);
-    if (!entry) {
-      throw new Error('Statement not found!');
+  /**
+   * Prepares a statement for the given sql unless one is already cached.
+   * If one is cached, it is removed from the cache and returned.
+   *
+   * Since `get` removes the item from the cache it is not an error to fail to call
+   * `return`. The gotten statement will be correctly garbage collected.
+   *
+   * When a gotten statement is not returned, future calls to
+   * `get` with the same `sql` will prepare a new statement.
+   *
+   * @param sql
+   * @returns
+   */
+  get(sql: string): CachedStatement {
+    sql = normalizeWhitespace(sql);
+    let entry = this.#head;
+    while (entry) {
+      if (entry.sql === sql) {
+        const {sql, statement} = entry;
+        if (entry === this.#head) {
+          this.#head = entry.prev;
+        }
+        if (entry === this.#tail) {
+          this.#tail = entry.next;
+        }
+        unlink(entry);
+        --this.#size;
+        return {sql, statement};
+      }
+      entry = entry.prev;
     }
-    if (!entry.inUse) {
-      throw new Error('Statement not in use!');
-    }
-    entry.inUse = false;
+    const statement = this.#db.prepare(sql);
+    return {sql, statement};
   }
 
-  #prepare(sql: string): Statement {
-    return this.#db.prepare(sql);
+  /**
+   * Handles `get` and `return` for the caller by invoking them before
+   * and after the callback.
+   */
+  use(sql: string, cb: (statement: CachedStatement) => void) {
+    const statement = this.get(sql);
+    try {
+      cb(statement);
+    } finally {
+      this.return(statement);
+    }
   }
+
+  /**
+   * Add a statement back to the cache so someone else can use it later.
+   * @param statement
+   */
+  return(statement: CachedStatement) {
+    const entry: Entry = {
+      sql: statement.sql,
+      statement: statement.statement,
+      prev: this.#head,
+    };
+    if (this.#head) {
+      this.#head.next = entry;
+    }
+    if (!this.#tail) {
+      this.#tail = entry;
+    }
+    this.#head = entry;
+    ++this.#size;
+  }
+}
+
+function unlink(entry: Entry) {
+  if (entry.prev) {
+    entry.prev.next = entry.next;
+  }
+  if (entry.next) {
+    entry.next.prev = entry.prev;
+  }
+  entry.prev = undefined;
+  entry.next = undefined;
+}
+
+function normalizeWhitespace(sql: string) {
+  return sql.replaceAll(/\s+/g, ' ');
 }

--- a/packages/zqlite/src/table-source.ts
+++ b/packages/zqlite/src/table-source.ts
@@ -189,14 +189,14 @@ export class TableSource<T extends PipelineEntity> implements Source<T> {
           genMap(
             // using `iterate` allows us to enforce `limit` in the `view`
             // by having the `view` stop pulling.
-            stmt.iterate(...getConditionBindParams(sortedConditions)),
+            stmt.statement.iterate(...getConditionBindParams(sortedConditions)),
             v => [v, 1],
           ),
         ),
         createPullResponseMessage(msg, this.#name, sort),
       );
     } finally {
-      this.#historyStatements.return(sql);
+      this.#historyStatements.return(stmt);
     }
   }
 


### PR DESCRIPTION
Cache prepared statements.

Handles the case where the same statement is asked for twice by two callers at the same time which would come up in a self join.

Follows the same scheme as https://www.sqlite.org/src/artifact?ci=trunk&filename=src/tclsqlite.c `dbPrepareAndBind`