### PR TITLE
chore(ivm): Change relationships from Map to object.

### DIFF
--- a/packages/zql/src/zql/ivm2/data.ts
+++ b/packages/zql/src/zql/ivm2/data.ts
@@ -43,7 +43,7 @@ export type Row = Record<string, Value>;
  */
 export type Node = {
   row: Row;
-  relationships: Map<string, Stream<Node>>;
+  relationships: Record<string, Stream<Node>>;
 };
 
 /**

--- a/packages/zql/src/zql/ivm2/join.test.ts
+++ b/packages/zql/src/zql/ivm2/join.test.ts
@@ -3,7 +3,7 @@ import {Join} from './join.js';
 import {MemorySource, SourceChange} from './memory-source.js';
 import {MemoryStorage} from './memory-storage.js';
 import {Snarf, expandNode} from './snarf.js';
-import type {Row} from './data.js';
+import type {Row, Node} from './data.js';
 import type {FetchRequest, HydrateRequest, Output, Source} from './operator.js';
 import {assert} from 'shared/src/asserts.js';
 import type {Ordering} from '../ast2/ast.js';
@@ -125,7 +125,7 @@ type FetchTest = {
     relationshipName: string;
   }[];
   expectedStorageCounts: Record<string, number>[];
-  expectedHydrate: unknown[];
+  expectedHydrate: Node[];
 };
 
 test('hydrate one:many', () => {

--- a/packages/zql/src/zql/ivm2/join.ts
+++ b/packages/zql/src/zql/ivm2/join.ts
@@ -174,10 +174,10 @@ export class Join implements Operator {
 
     return {
       ...parentNode,
-      relationships: new Map([
+      relationships: {
         ...parentNode.relationships,
-        [this.#relationshipName, childStream],
-      ]),
+        [this.#relationshipName]: childStream,
+      },
     };
   }
 }

--- a/packages/zql/src/zql/ivm2/memory-source.test.ts
+++ b/packages/zql/src/zql/ivm2/memory-source.test.ts
@@ -16,7 +16,7 @@ test('schema', () => {
 function asNodes(rows: Row[]): Node[] {
   return rows.map(row => ({
     row,
-    relationships: new Map(),
+    relationships: {},
   }));
 }
 

--- a/packages/zql/src/zql/ivm2/memory-source.ts
+++ b/packages/zql/src/zql/ivm2/memory-source.ts
@@ -137,7 +137,7 @@ export class MemorySource implements Input {
         const cmp = compare(overlay.change.row, change.row);
         if (overlay.change.type === 'add') {
           if (cmp < 0) {
-            yield {row: overlay.change.row, relationships: new Map()};
+            yield {row: overlay.change.row, relationships: {}};
             overlay = undefined;
           }
         } else if (overlay.change.type === 'remove') {
@@ -153,7 +153,7 @@ export class MemorySource implements Input {
     }
 
     if (overlay && overlay.change.type === 'add') {
-      yield {row: overlay.change.row, relationships: new Map()};
+      yield {row: overlay.change.row, relationships: {}};
     }
   }
 
@@ -166,7 +166,7 @@ export class MemorySource implements Input {
     // Process all items in the iterator, applying overlay as needed.
     for (const row of it) {
       if (!constraint || valuesEqual(row[constraint.key], constraint.value)) {
-        yield {row, relationships: new Map()};
+        yield {row, relationships: {}};
       }
     }
   }
@@ -190,7 +190,7 @@ export class MemorySource implements Input {
           type: change.type,
           node: {
             row: change.row,
-            relationships: new Map(),
+            relationships: {},
           },
         },
         this,

--- a/packages/zql/src/zql/ivm2/operator.ts
+++ b/packages/zql/src/zql/ivm2/operator.ts
@@ -33,7 +33,7 @@ export type Schema = {
   // if ever needed ... none of current operators need.
   // idKeys: string[];
   // columns: Record<string, ValueType>;
-  // relationships: Map<string, Schema>;
+  // relationships: Record<string, Schema>;
   // Compares two rows in the output of an operator.
   compareRows: (r1: Row, r2: Row) => number;
 };

--- a/packages/zql/src/zql/ivm2/snarf.ts
+++ b/packages/zql/src/zql/ivm2/snarf.ts
@@ -17,7 +17,7 @@ export class Snarf implements Output {
   }
 }
 
-function expandChange(change: Change): unknown {
+function expandChange(change: Change): Change {
   if (change.type === 'child') {
     return {
       ...change,
@@ -33,11 +33,11 @@ function expandChange(change: Change): unknown {
   };
 }
 
-export function expandNode(node: Node): unknown {
+export function expandNode(node: Node): Node {
   return {
     ...node,
     relationships: Object.fromEntries(
-      [...node.relationships.entries()].map(([k, v]) => [
+      Object.entries(node.relationships).map(([k, v]) => [
         k,
         [...v].map(expandNode),
       ]),

--- a/packages/zqlite/src/v2/table-source.ts
+++ b/packages/zqlite/src/v2/table-source.ts
@@ -161,7 +161,7 @@ export class TableSource implements Input {
           ...sqlAndBindings.values,
         );
         for (const row of rowIterator) {
-          yield {row, relationships: new Map()};
+          yield {row, relationships: {}};
         }
       } finally {
         this.#statementCache.return(cachedStatement);
@@ -176,7 +176,7 @@ export class TableSource implements Input {
           type: change.type,
           node: {
             row: change.row,
-            relationships: new Map(),
+            relationships: {},
           },
         },
         this,


### PR DESCRIPTION
The map wasn't doing anything for us and testing is easier with plain objects. Originally I was worried about namespacing issues but meh.

This also allows the expandNode() helpers to return Nodes (since an Array does implement Stream).