### PR TITLE
feat(zero-cache): filter no-op deletes out of the change stream

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/snapshotter.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/snapshotter.test.ts
@@ -343,16 +343,6 @@ describe('view-syncer/snapshotter', () => {
           },
           "table": "issues",
         },
-        {
-          "nextValue": null,
-          "prevValue": null,
-          "table": "issues",
-        },
-        {
-          "nextValue": null,
-          "prevValue": null,
-          "table": "issues",
-        },
       ]
     `);
   });


### PR DESCRIPTION
Filter no-op deletes (i.e. where the pre-value does not exist) from the change stream.

Replace the recursive `next()` strategy (previously used for initiating a truncate iteration) with an iterative one, which can handle an arbitrary number of no-op deletes without overflowing the stack.