### PR TITLE
feat(zql): move overlay logic into pure functions

### DIFF
--- a/packages/zql/src/zql/ivm2/memory-source.ts
+++ b/packages/zql/src/zql/ivm2/memory-source.ts
@@ -30,7 +30,7 @@ export class MemorySource implements Source {
   readonly #data: BTree<Row, undefined>;
   readonly #outputs: Output[] = [];
 
-  #overlay: Overlay | null = null;
+  #overlay: Overlay | undefined;
 
   constructor(order: Ordering) {
     this.#schema = {
@@ -52,7 +52,7 @@ export class MemorySource implements Source {
   }
 
   *fetch(req: FetchRequest, output: Output): Stream<Node> {
-    let overlay: Overlay | null = null;
+    let overlay: Overlay | undefined;
 
     // When we receive a push, we send it to each output one at a time. Once the
     // push is sent to an output, it should keep being sent until all datastores
@@ -71,97 +71,41 @@ export class MemorySource implements Source {
       if (req.constraint) {
         const {key, value} = req.constraint;
         if (!valuesEqual(overlay.change.row[key], value)) {
-          overlay = null;
+          overlay = undefined;
         }
       }
     }
 
-    const it = this.#pullWithOverlay(
-      req.start?.row ? this.#data.nextLowerKey(req.start.row) : undefined,
-      req.constraint,
-      overlay ?? undefined,
+    const startAt = req.start?.row
+      ? this.#data.nextLowerKey(req.start.row)
+      : undefined;
+    yield* generateWithStart(
+      generateWithOverlay(
+        startAt,
+        this.#pullWithConstraint(startAt, req.constraint),
+        req.constraint,
+        overlay,
+        this.#schema.compareRows,
+      ),
+      req,
+      this.#schema.compareRows,
     );
-
-    // Figure out the start row.
-    const cursor = new LookaheadIterator(it[Symbol.iterator](), 2);
-
-    let started = req.start === undefined ? true : false;
-    for (const [curr, next] of cursor) {
-      if (!started) {
-        assert(req.start);
-        if (req.start.basis === 'before') {
-          if (
-            next === undefined ||
-            this.#schema.compareRows(next.row, req.start.row) >= 0
-          ) {
-            started = true;
-          }
-        } else if (req.start.basis === 'at') {
-          if (this.#schema.compareRows(curr.row, req.start.row) >= 0) {
-            started = true;
-          }
-        } else if (req.start.basis === 'after') {
-          if (this.#schema.compareRows(curr.row, req.start.row) > 0) {
-            started = true;
-          }
-        }
-      }
-      if (started) {
-        yield curr;
-      }
-    }
   }
 
   dehydrate(req: HydrateRequest, output: Output): Stream<Node> {
     return this.fetch(req, output);
   }
 
-  *#pullWithOverlay(
-    startAt: Row | undefined,
-    constraint: Constraint | undefined,
-    overlay: Overlay | undefined,
-  ): Stream<Node> {
-    const compare = this.#schema.compareRows;
-
-    if (startAt && overlay && compare(overlay.change.row, startAt) < 0) {
-      overlay = undefined;
-    }
-
-    for (const change of this.#pullWithConstraint(startAt, constraint)) {
-      if (overlay) {
-        const cmp = compare(overlay.change.row, change.row);
-        if (overlay.change.type === 'add') {
-          if (cmp < 0) {
-            yield {row: overlay.change.row, relationships: {}};
-            overlay = undefined;
-          }
-        } else if (overlay.change.type === 'remove') {
-          if (cmp < 0) {
-            overlay = undefined;
-          } else if (cmp === 0) {
-            overlay = undefined;
-            continue;
-          }
-        }
-      }
-      yield change;
-    }
-
-    if (overlay && overlay.change.type === 'add') {
-      yield {row: overlay.change.row, relationships: {}};
-    }
-  }
-
   *#pullWithConstraint(
     startAt: Row | undefined,
     constraint: Constraint | undefined,
-  ): Stream<Node> {
+  ): IterableIterator<Row> {
     const it = this.#data.keys(startAt);
 
     // Process all items in the iterator, applying overlay as needed.
     for (const row of it) {
       if (!constraint || valuesEqual(row[constraint.key], constraint.value)) {
-        yield {row, relationships: {}};
+        yield row;
       }
     }
   }
@@ -191,7 +135,7 @@ export class MemorySource implements Source {
         this,
       );
     }
-    this.#overlay = null;
+    this.#overlay = undefined;
     if (change.type === 'add') {
       const added = this.#data.add(change.row, undefined);
       // must suceed since we checked has() above.
@@ -202,5 +146,105 @@ export class MemorySource implements Source {
       // must suceed since we checked has() above.
       assert(removed);
     }
+  }
+}
+
+/**
+ * If the request basis was `before` then the overlay might be the starting point of the stream.
+ *
+ * This can happen in a case like the following:
+ * Store = [1,2,3, 5,6,7]
+ * Overlay = [4]
+ * Request = fetch starting before 5
+ *
+ * In this case, the overlay value of `4` should be the starting point of the stream, not `3`.
+ */
+export function* generateWithStart(
+  it: Iterator<Node>,
+  req: FetchRequest,
+  compare: (r1: Row, r2: Row) => number,
+): Stream<Node> {
+  // Figure out the start row.
+  const cursor = new LookaheadIterator(it, 2);
+
+  let started = req.start === undefined ? true : false;
+  for (const [curr, next] of cursor) {
+    if (!started) {
+      assert(req.start);
+      if (req.start.basis === 'before') {
+        if (next === undefined || compare(next.row, req.start.row) >= 0) {
+          started = true;
+        }
+      } else if (req.start.basis === 'at') {
+        if (compare(curr.row, req.start.row) >= 0) {
+          started = true;
+        }
+      } else if (req.start.basis === 'after') {
+        if (compare(curr.row, req.start.row) > 0) {
+          started = true;
+        }
+      }
+    }
+    if (started) {
+      yield curr;
+    }
+  }
+}
+
+/**
+ * Takes an iterator and overlay.
+ * Splices the overlay into the iterator at the correct position.
+ *
+ * @param startAt - if there is a lower bound to the stream. If the lower bound of the stream
+ * is above the overlay, the overlay will be skipped.
+ * @param rowIterator - the stream into which the overlay should be spliced
+ * @param constraint - constraint that was applied to the rowIterator and should
+ * also be applied to the overlay.
+ * @param overlay - the overlay values to splice in
+ * @param compare - the comparator to use to find the position for the overlay
+ */
+export function* generateWithOverlay(
+  startAt: Row | undefined,
+  rowIterator: IterableIterator<Row>,
+  constraint: Constraint | undefined,
+  overlay: Overlay | undefined,
+  compare: (r1: Row, r2: Row) => number,
+) {
+  if (startAt && overlay && compare(overlay.change.row, startAt) < 0) {
+    overlay = undefined;
+  }
+
+  if (overlay) {
+    if (constraint) {
+      const {key, value} = constraint;
+      const {change} = overlay;
+      if (!valuesEqual(change.row[key], value)) {
+        overlay = undefined;
+      }
+    }
+  }
+
+  for (const row of rowIterator) {
+    if (overlay) {
+      const cmp = compare(overlay.change.row, row);
+      if (overlay.change.type === 'add') {
+        if (cmp < 0) {
+          yield {row: overlay.change.row, relationships: {}};
+          overlay = undefined;
+        }
+      } else if (overlay.change.type === 'remove') {
+        if (cmp < 0) {
+          overlay = undefined;
+        } else if (cmp === 0) {
+          overlay = undefined;
+          continue;
+        }
+      }
+    }
+    yield {row, relationships: {}};
+  }
+
+  if (overlay && overlay.change.type === 'add') {
+    yield {row: overlay.change.row, relationships: {}};
   }
 }


### PR DESCRIPTION
move overlay logic into pure functions so we can re-use it in `TableSource`

I did explore making this its own operator but it needs information that is not available to operators.

The two things that cause headache:
1. `start.basis = before`. This changes how the first element of the stream is determined.
2. `start.row`. This changes whether or not the overlay is included.

Not having access to `start.row` can't be worked around in the case where the `source` is empty. In that case the source emits an empty iterable to its output. An overlay operator doesn't know what to do with this. Is the current overlay above or below the start of the empty stream?