### PR TITLE
chore(zql): add `columns` and `primaryKey` to `schema` type

### DIFF
--- a/packages/zql/src/zql/ivm2/join.ts
+++ b/packages/zql/src/zql/ivm2/join.ts
@@ -6,11 +6,11 @@ import type {
   Input,
   Operator,
   Output,
-  Schema,
   Storage,
 } from './operator.js';
 import type {Stream} from './stream.js';
 import type {Change} from './change.js';
+import type {Schema} from './schema.js';
 
 /**
  * The Join operator joins the output from two upstream inputs. Zero's join

--- a/packages/zql/src/zql/ivm2/memory-source.ts
+++ b/packages/zql/src/zql/ivm2/memory-source.ts
@@ -3,7 +3,6 @@ import type {
   Output,
   FetchRequest,
   HydrateRequest,
-  Schema,
   Constraint,
 } from './operator.js';
 import {makeComparator, valuesEqual, type Node, type Row} from './data.js';
@@ -12,6 +11,7 @@ import {assert} from 'shared/src/asserts.js';
 import {LookaheadIterator} from './lookahead-iterator.js';
 import type {Stream} from './stream.js';
 import {Source, SourceChange} from './source.js';
+import {Schema} from './schema.js';
 
 export type Overlay = {
   outputIndex: number;
@@ -35,6 +35,8 @@ export class MemorySource implements Source {
   constructor(order: Ordering) {
     this.#schema = {
       compareRows: makeComparator(order),
+      columns: {},
+      primaryKey: [],
     };
     this.#data = new BTree(undefined, this.#schema.compareRows);
   }

--- a/packages/zql/src/zql/ivm2/operator.ts
+++ b/packages/zql/src/zql/ivm2/operator.ts
@@ -5,6 +5,7 @@ import type {JSONValue} from 'replicache';
 import type {Change} from './change.js';
 import type {Node, Row, Value} from './data.js';
 import type {Stream} from './stream.js';
+import type {Schema} from './schema.js';
 
 /**
  * Input to an operator. Typically another Operator but can also be a Source.
@@ -29,16 +30,6 @@ export interface Input {
   // propagate the dehydrate message through the graph.
   dehydrate(req: HydrateRequest, output: Output): Stream<Node>;
 }
-
-// Information about the nodes output by an operator.
-export type Schema = {
-  // if ever needed ... none of current operators need.
-  // idKeys: string[];
-  // columns: Record<string, ValueType>;
-  // relationships: Record<string, Schema>;
-  // Compares two rows in the output of an operator.
-  compareRows: (r1: Row, r2: Row) => number;
-};
 
 export type HydrateRequest = {
   constraint?: Constraint | undefined;

--- a/packages/zql/src/zql/ivm2/schema.ts
+++ b/packages/zql/src/zql/ivm2/schema.ts
@@ -1,0 +1,13 @@
+import {Row} from './data.js';
+
+export type ValueType = 'string' | 'number' | 'boolean' | 'null';
+
+// Information about the nodes output by an operator.
+export type Schema = {
+  primaryKey: readonly string[];
+  columns: Record<string, ValueType>;
+
+  // relationships: Record<string, Schema>;
+  // Compares two rows in the output of an operator.
+  compareRows: (r1: Row, r2: Row) => number;
+};

--- a/packages/zql/src/zql/ivm2/snitch.ts
+++ b/packages/zql/src/zql/ivm2/snitch.ts
@@ -4,11 +4,11 @@ import type {
   Input,
   Operator,
   Output,
-  Schema,
 } from './operator.js';
 import type {Change} from './change.js';
 import type {Row} from './data.js';
 import {assert} from 'shared/src/asserts.js';
+import {Schema} from './schema.js';
 
 /**
  * Snitch is an Operator that records all messages it receives. Useful for

--- a/packages/zqlite/src/v2/table-source.test.ts
+++ b/packages/zqlite/src/v2/table-source.test.ts
@@ -4,6 +4,13 @@ import {TableSource} from './table-source.js';
 import {Catch} from 'zql/src/zql/ivm2/catch.js';
 import {makeComparator} from 'zql/src/zql/ivm2/data.js';
 
+const columns = {
+  id: 'string',
+  a: 'number',
+  b: 'number',
+  c: 'number',
+} as const;
+
 describe('fetching from a table source', () => {
   type Foo = {id: string; a: number; b: number; c: number};
   const allRows: Foo[] = [];
@@ -37,19 +44,19 @@ describe('fetching from a table source', () => {
   test.each([
     {
       name: 'simple source with `id` order',
-      sourceArgs: ['foo', ['id', 'a', 'b', 'c'], [['id', 'asc']]],
+      sourceArgs: ['foo', columns, [['id', 'asc']]],
       fetchArgs: {constraint: undefined, start: undefined},
       expectedRows: allRows,
     },
     {
       name: 'simple source with `id` order and constraint',
-      sourceArgs: ['foo', ['id', 'a', 'b', 'c'], [['id', 'asc']]],
+      sourceArgs: ['foo', columns, [['id', 'asc']]],
       fetchArgs: {constraint: {key: 'a', value: 2}, start: undefined},
       expectedRows: allRows.filter(r => r.a === 2),
     },
     {
       name: 'simple source with `id` order and start `before`',
-      sourceArgs: ['foo', ['id', 'a', 'b', 'c'], [['id', 'asc']]],
+      sourceArgs: ['foo', columns, [['id', 'asc']]],
       fetchArgs: {
         constraint: undefined,
         start: {row: allRows[4], basis: 'before'},
@@ -58,7 +65,7 @@ describe('fetching from a table source', () => {
     },
     {
       name: 'simple source with `id` order and start `before` and constraint',
-      sourceArgs: ['foo', ['id', 'a', 'b', 'c'], [['id', 'asc']]],
+      sourceArgs: ['foo', columns, [['id', 'asc']]],
       fetchArgs: {
         constraint: {key: 'b', value: 2},
         start: {row: allRows[4], basis: 'before'},
@@ -67,7 +74,7 @@ describe('fetching from a table source', () => {
     },
     {
       name: 'simple source with `id` order and start `after`',
-      sourceArgs: ['foo', ['id', 'a', 'b', 'c'], [['id', 'asc']]],
+      sourceArgs: ['foo', columns, [['id', 'asc']]],
       fetchArgs: {
         constraint: undefined,
         start: {row: allRows[4], basis: 'after'},
@@ -76,7 +83,7 @@ describe('fetching from a table source', () => {
     },
     {
       name: 'simple source with `id` order and start `after` and constraint',
-      sourceArgs: ['foo', ['id', 'a', 'b', 'c'], [['id', 'asc']]],
+      sourceArgs: ['foo', columns, [['id', 'asc']]],
       fetchArgs: {
         constraint: {key: 'b', value: 2},
         start: {row: allRows[4], basis: 'after'},
@@ -85,7 +92,7 @@ describe('fetching from a table source', () => {
     },
     {
       name: 'simple source with `id` order and start `at`',
-      sourceArgs: ['foo', ['id', 'a', 'b', 'c'], [['id', 'asc']]],
+      sourceArgs: ['foo', columns, [['id', 'asc']]],
       fetchArgs: {
         constraint: undefined,
         start: {row: allRows[4], basis: 'at'},
@@ -94,7 +101,7 @@ describe('fetching from a table source', () => {
     },
     {
       name: 'simple source with `id` order and start `at` and constraint',
-      sourceArgs: ['foo', ['id', 'a', 'b', 'c'], [['id', 'asc']]],
+      sourceArgs: ['foo', columns, [['id', 'asc']]],
       fetchArgs: {
         constraint: {key: 'b', value: 2},
         start: {row: allRows[4], basis: 'at'},
@@ -103,19 +110,19 @@ describe('fetching from a table source', () => {
     },
     {
       name: 'complex source with compound order',
-      sourceArgs: ['foo', ['id', 'a', 'b', 'c'], compoundOrder],
+      sourceArgs: ['foo', columns, compoundOrder],
       fetchArgs: {constraint: undefined, start: undefined},
       expectedRows: allRows.slice().sort(compoundComparator),
     },
     {
       name: 'complex source with compound order and constraint',
-      sourceArgs: ['foo', ['id', 'a', 'b', 'c'], compoundOrder],
+      sourceArgs: ['foo', columns, compoundOrder],
       fetchArgs: {constraint: {key: 'a', value: 2}, start: undefined},
       expectedRows: allRows.filter(r => r.a === 2).sort(compoundComparator),
     },
     {
       name: 'complex source with compound order and start `before`',
-      sourceArgs: ['foo', ['id', 'a', 'b', 'c'], compoundOrder],
+      sourceArgs: ['foo', columns, compoundOrder],
       fetchArgs: {
         constraint: undefined,
         start: {row: allRows[4], basis: 'before'},
@@ -124,7 +131,7 @@ describe('fetching from a table source', () => {
     },
     {
       name: 'complex source with compound order and start `before` and constraint',
-      sourceArgs: ['foo', ['id', 'a', 'b', 'c'], compoundOrder],
+      sourceArgs: ['foo', columns, compoundOrder],
       fetchArgs: {
         constraint: {key: 'b', value: 2},
         start: {row: allRows[4], basis: 'before'},
@@ -136,7 +143,7 @@ describe('fetching from a table source', () => {
     },
     {
       name: 'complex source with compound order and start `after`',
-      sourceArgs: ['foo', ['id', 'a', 'b', 'c'], compoundOrder],
+      sourceArgs: ['foo', columns, compoundOrder],
       fetchArgs: {
         constraint: undefined,
         start: {row: allRows[4], basis: 'after'},
@@ -145,7 +152,7 @@ describe('fetching from a table source', () => {
     },
     {
       name: 'complex source with compound order and start `after` and constraint',
-      sourceArgs: ['foo', ['id', 'a', 'b', 'c'], compoundOrder],
+      sourceArgs: ['foo', columns, compoundOrder],
       fetchArgs: {
         constraint: {key: 'b', value: 2},
         start: {row: allRows[4], basis: 'after'},
@@ -157,7 +164,7 @@ describe('fetching from a table source', () => {
     },
     {
       name: 'complex source with compound order and start `at`',
-      sourceArgs: ['foo', ['id', 'a', 'b', 'c'], compoundOrder],
+      sourceArgs: ['foo', columns, compoundOrder],
       fetchArgs: {
         constraint: undefined,
         start: {row: allRows[4], basis: 'at'},
@@ -166,7 +173,7 @@ describe('fetching from a table source', () => {
     },
     {
       name: 'complex source with compound order and start `at` and constraint',
-      sourceArgs: ['foo', ['id', 'a', 'b', 'c'], compoundOrder],
+      sourceArgs: ['foo', columns, compoundOrder],
       fetchArgs: {
         constraint: {key: 'b', value: 2},
         start: {row: allRows[4], basis: 'at'},
@@ -198,7 +205,11 @@ test('pushing values does the correct writes', () => {
   const source = new TableSource(
     db,
     'foo',
-    ['a', 'b', 'c'],
+    {
+      a: 'number',
+      b: 'number',
+      c: 'number',
+    },
     [['a', 'asc']],
     ['a', 'b'],
   );


### PR DESCRIPTION
`TableSource` needs to know the column definitions to:

1. Map from `number` to `boolean` when reading out of SQLite
2. Map from `missing` to `null` when writing to SQLite

`TableSource` needs to know the primary keys to:

1. Correctly determine the existence of a row
2. Correctly delete a row