### PR TITLE
feat(zql): Per-output sorts (strict style)

### DIFF
--- a/packages/zql/src/zql/ivm2/join.fetch.test.ts
+++ b/packages/zql/src/zql/ivm2/join.fetch.test.ts
@@ -667,12 +667,12 @@ function fetchTest(t: FetchTest) {
 
   const sources = t.sources.map((rows, i) => {
     const ordering = t.sorts?.[i] ?? [['id', 'asc']];
-    const source = new MemorySource(ordering);
+    const source = new MemorySource({}, [], [ordering]);
     for (const row of rows) {
       source.push({type: 'add', row});
     }
     const snitch = new Snitch(source, String(i), log);
-    source.addOutput(snitch);
+    source.addOutput(snitch, ordering);
     return {
       source,
       snitch,

--- a/packages/zql/src/zql/ivm2/join.push.test.ts
+++ b/packages/zql/src/zql/ivm2/join.push.test.ts
@@ -869,12 +869,12 @@ function pushTest(t: PushTest) {
 
   const sources = t.sources.map((hydrate, i) => {
     const ordering = t.sorts?.[i] ?? [['id', 'asc']];
-    const source = new MemorySource(ordering);
+    const source = new MemorySource({}, [], [ordering]);
     for (const row of hydrate) {
       source.push({type: 'add', row});
     }
     const snitch = new Snitch(source, String(i), log);
-    source.addOutput(snitch);
+    source.addOutput(snitch, ordering);
     return {
       source,
       snitch,

--- a/packages/zql/src/zql/ivm2/join.ts
+++ b/packages/zql/src/zql/ivm2/join.ts
@@ -52,8 +52,8 @@ export class Join implements Operator {
     this.#output = output;
   }
 
-  get schema(): Schema {
-    return this.#parent.schema;
+  getSchema(_output: Output): Schema {
+    return this.#parent.getSchema(this);
   }
 
   *hydrate(req: HydrateRequest, _: Output): Stream<Node> {

--- a/packages/zql/src/zql/ivm2/memory-source.test.ts
+++ b/packages/zql/src/zql/ivm2/memory-source.test.ts
@@ -1,22 +1,40 @@
-import {test} from 'vitest';
+import {expect, test} from 'vitest';
 import {Ordering} from '../ast2/ast.js';
 import {compareRowsTest} from './data.test.js';
 import {MemorySource} from './memory-source.js';
 import {runCases} from './test/source-cases.js';
 import {ValueType} from './schema.js';
+import {Catch} from './catch.js';
 
 runCases(
   (
     _name: string,
-    _columns: Record<string, ValueType>,
-    order: Ordering,
-    _primaryKeys: readonly string[],
-  ) => new MemorySource(order),
+    columns: Record<string, ValueType>,
+    requiredIndexes: Ordering[],
+    primaryKeys: readonly string[],
+  ) => new MemorySource(columns, primaryKeys, requiredIndexes),
 );
 
 test('schema', () => {
   compareRowsTest((order: Ordering) => {
-    const ms = new MemorySource(order);
-    return ms.schema.compareRows;
+    const ms = new MemorySource({a: 'string'}, ['a'], [order]);
+    const out = new Catch(ms);
+    ms.addOutput(out, order);
+    return ms.getSchema(out).compareRows;
   });
+});
+
+test('output-sorts-must-be-pre-registered', () => {
+  const ms = new MemorySource({a: 'string'}, ['a'], [[['a', 'asc']]]);
+
+  // Can add the pre-registered sort.
+  ms.addOutput(new Catch(ms), [['a', 'asc']]);
+
+  // Can't add other sorts.
+  expect(() => ms.addOutput(new Catch(ms), [['a', 'desc']])).throws(
+    'Required index not found: a,desc',
+  );
+  expect(() => ms.addOutput(new Catch(ms), [['b', 'asc']])).throws(
+    'Required index not found: b,asc',
+  );
 });

--- a/packages/zql/src/zql/ivm2/operator.ts
+++ b/packages/zql/src/zql/ivm2/operator.ts
@@ -12,7 +12,7 @@ import type {Schema} from './schema.js';
  */
 export interface Input {
   // The schema of the data this input returns.
-  get schema(): Schema;
+  getSchema(output: Output): Schema;
 
   // Request initial result from this operator and initialize its state.
   // Returns nodes sorted in order of schema().comparator.

--- a/packages/zql/src/zql/ivm2/snitch.ts
+++ b/packages/zql/src/zql/ivm2/snitch.ts
@@ -31,8 +31,8 @@ export class Snitch implements Operator {
     this.#output = output;
   }
 
-  get schema(): Schema {
-    return this.#input.schema;
+  getSchema(_: Output): Schema {
+    return this.#input.getSchema(this);
   }
 
   hydrate(req: HydrateRequest, _source: Output) {

--- a/packages/zql/src/zql/ivm2/source.ts
+++ b/packages/zql/src/zql/ivm2/source.ts
@@ -1,3 +1,4 @@
+import { Ordering } from '../ast2/ast.js';
 import {Row} from './data.js';
 import {Input, Output} from './operator.js';
 
@@ -11,6 +12,6 @@ export type SourceChange = {
  * Sources can have multiple outputs.
  */
 export interface Source extends Input {
-  addOutput(output: Output): void;
+  addOutput(output: Output, sort: Ordering): void;
   push(change: SourceChange): void;
 }

--- a/packages/zql/src/zql/ivm2/test/source-cases.ts
+++ b/packages/zql/src/zql/ivm2/test/source-cases.ts
@@ -9,8 +9,8 @@ import {ValueType} from '../schema.js';
 type SourceFactory = (
   name: string,
   columns: Record<string, ValueType>,
-  order: Ordering,
-  primaryKeys: readonly [string, ...string[]],
+  requiredIndexes: Ordering[],
+  primaryKey: readonly [string, ...string[]],
 ) => Source;
 
 function asNodes(rows: Row[]) {
@@ -53,9 +53,10 @@ const cases = {
   'simple-pull': (createSource: SourceFactory) => {
     // works the same for hydrate and fetch.
     for (const m of ['hydrate', 'fetch'] as const) {
-      const ms = createSource('table', {a: 'number'}, [['a', 'asc']], ['a']);
+      const sort = [['a', 'asc']] as const;
+      const ms = createSource('table', {a: 'number'}, [sort], ['a']);
       const out = new Catch(ms);
-      ms.addOutput(out);
+      ms.addOutput(out, sort);
       expect(out[m]()).toEqual([]);
 
       ms.push({type: 'add', row: {a: 3}});
@@ -77,6 +78,7 @@ const cases = {
   'pull-with-constraint': (createSource: SourceFactory) => {
     // works the same for hydrate and fetch.
     for (const m of ['hydrate', 'fetch'] as const) {
+      const sort = [['a', 'asc']] as const;
       const ms = createSource(
         'table',
         {
@@ -85,11 +87,11 @@ const cases = {
           c: 'number',
           d: 'string',
         },
-        [['a', 'asc']],
+        [sort],
         ['a'],
       );
       const out = new Catch(ms);
-      ms.addOutput(out);
+      ms.addOutput(out, sort);
       ms.push({type: 'add', row: {a: 3, b: true, c: 1, d: null}});
       ms.push({type: 'add', row: {a: 1, b: true, c: 2, d: null}});
       ms.push({type: 'add', row: {a: 2, b: false, c: null, d: null}});
@@ -133,16 +135,17 @@ const cases = {
   },
 
   'fetch-start': (createSource: SourceFactory) => {
+    const sort = [['a', 'asc']] as const;
     const ms = createSource(
       'table',
       {
         a: 'number',
       },
-      [['a', 'asc']],
+      [sort],
       ['a'],
     );
     const out = new Catch(ms);
-    ms.addOutput(out);
+    ms.addOutput(out, sort);
 
     expect(out.fetch({start: {row: {a: 2}, basis: 'before'}})).toEqual(
       asNodes([]),
@@ -187,9 +190,10 @@ const cases = {
   },
 
   'push': (createSource: SourceFactory) => {
-    const ms = createSource('table', {a: 'number'}, [['a', 'asc']], ['a']);
+    const sort = [['a', 'asc']] as const;
+    const ms = createSource('table', {a: 'number'}, [sort], ['a']);
     const out = new Catch(ms);
-    ms.addOutput(out);
+    ms.addOutput(out, sort);
 
     expect(out.pushes).toEqual([]);
 
@@ -240,13 +244,14 @@ const cases = {
     // *other* outputs are pushed to. Then we can observe that the overlay
     // only shows up in the cases it is supposed to.
 
-    const ms = createSource('table', {a: 'number'}, [['a', 'asc']], ['a']);
+    const sort = [['a', 'asc']] as const;
+    const ms = createSource('table', {a: 'number'}, [sort], ['a']);
     const o1 = new OverlaySpy(ms);
     const o2 = new OverlaySpy(ms);
     const o3 = new OverlaySpy(ms);
-    ms.addOutput(o1);
-    ms.addOutput(o2);
-    ms.addOutput(o3);
+    ms.addOutput(o1, sort);
+    ms.addOutput(o2, sort);
+    ms.addOutput(o3, sort);
 
     function fetchAll() {
       o1.fetch({});
@@ -548,12 +553,13 @@ const cases = {
     ];
 
     for (const c of cases) {
-      const ms = createSource('table', {a: 'number'}, [['a', 'asc']], ['a']);
+      const sort = [['a', 'asc']] as const;
+      const ms = createSource('table', {a: 'number'}, [sort], ['a']);
       for (const row of c.startData) {
         ms.push({type: 'add', row});
       }
       const out = new OverlaySpy(ms);
-      ms.addOutput(out);
+      ms.addOutput(out, sort);
       out.onPush = () =>
         out.fetch({
           start: c.start,
@@ -598,20 +604,21 @@ const cases = {
     ];
 
     for (const c of cases) {
+      const sort = [['a', 'asc']] as const;
       const ms = createSource(
         'table',
         {
           a: 'number',
           b: 'boolean',
         },
-        [['a', 'asc']],
+        [sort],
         ['a'],
       );
       for (const row of c.startData) {
         ms.push({type: 'add', row});
       }
       const out = new OverlaySpy(ms);
-      ms.addOutput(out);
+      ms.addOutput(out, sort);
       out.onPush = () =>
         out.fetch({
           constraint: c.constraint,
@@ -623,6 +630,31 @@ const cases = {
         expect(out.fetches, JSON.stringify(c)).toEqual([asNodes(c.expected)]);
       }
     }
+  },
+
+  'per-output-sorts': (createSource: SourceFactory) => {
+    const sort1 = [['a', 'asc']] as const;
+    const sort2 = [['b', 'asc']] as const;
+    const ms = createSource(
+      'table',
+      {
+        a: 'number',
+        b: 'number',
+      },
+      [sort1, sort2],
+      ['a'],
+    );
+    const out1 = new Catch(ms);
+    const out2 = new Catch(ms);
+    ms.addOutput(out1, sort1);
+    ms.addOutput(out2, sort2);
+
+    ms.push({type: 'add', row: {a: 2, b: 3}});
+    ms.push({type: 'add', row: {a: 1, b: 2}});
+    ms.push({type: 'add', row: {a: 3, b: 1}});
+
+    expect(out1.fetch({})).toEqual(asNodes([{a: 1, b: 2}, {a: 2, b: 3}, {a: 3, b: 1}]));
+    expect(out2.fetch({})).toEqual(asNodes([{a: 3, b: 1}, {a: 1, b: 2}, {a: 2, b: 3}]));
   },
 };
 

--- a/packages/zqlite/src/v2/table-source.test.ts
+++ b/packages/zqlite/src/v2/table-source.test.ts
@@ -192,10 +192,10 @@ describe('fetching from a table source', () => {
       db,
       sourceArgs[0],
       sourceArgs[1],
-      sourceArgs[2],
       ['id'],
     );
     const out = new Catch(source);
+    source.addOutput(out, sourceArgs[2]);
     const rows = out.fetch(fetchArgs);
     expect(rows.map(r => r.row)).toEqual(expectedRows);
   });
@@ -209,12 +209,7 @@ test('pushing values does the correct writes', () => {
   const source = new TableSource(
     db,
     'foo',
-    {
-      a: 'number',
-      b: 'number',
-      c: 'number',
-    },
-    [['a', 'asc']],
+    {a: 'number', b: 'number', c: 'number'},
     ['a', 'b'],
   );
 
@@ -264,8 +259,8 @@ describe('shared test cases', () => {
     (
       name: string,
       columns: Record<string, ValueType>,
-      order: Ordering,
-      primaryKeys: readonly [string, ...string[]],
+      _requiredIndexes: readonly Ordering[],
+      primaryKey: readonly [string, ...string[]],
     ) => {
       const db = new Database(':memory:');
       // create a table with desired columns and primary keys
@@ -274,12 +269,12 @@ describe('shared test cases', () => {
           Object.keys(columns).map(c => sql.ident(c)),
           sql`, `,
         )}, PRIMARY KEY (${sql.join(
-          primaryKeys.map(p => sql.ident(p)),
+          primaryKey.map(p => sql.ident(p)),
           sql`, `,
         )}));`,
       );
       db.exec(query);
-      return new TableSource(db, name, columns, order, primaryKeys);
+      return new TableSource(db, name, columns, primaryKey);
     },
     new Set(),
     new Set(),


### PR DESCRIPTION
Add support for per-output sorts to Sources.
    
This version requires all needed indexes to be specified to `MemorySource` up-front at creation time. Contrast with #2176 .