### PR TITLE
chore(zero-cache): remove Promise from Replicator.subscribe() signature

### DIFF
--- a/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
@@ -705,7 +705,7 @@ describe('replicator/incremental-sync', {retry: 3}, () => {
       );
 
       const syncing = syncer.run(lc);
-      const notifications = await syncer.subscribe();
+      const notifications = syncer.subscribe();
 
       const versions: string[] = ['00'];
       const versionReady = notifications[Symbol.asyncIterator]();

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -121,8 +121,8 @@ export class IncrementalSyncer {
     lc.info?.('IncrementalSyncer stopped');
   }
 
-  subscribe(): Promise<CancelableAsyncIterable<ReplicaVersionReady>> {
-    return Promise.resolve(this.#notifier.addSubscription());
+  subscribe(): CancelableAsyncIterable<ReplicaVersionReady> {
+    return this.#notifier.addSubscription();
   }
 
   async stop(lc: LogContext, err?: unknown) {

--- a/packages/zero-cache/src/services/replicator/replicator.ts
+++ b/packages/zero-cache/src/services/replicator/replicator.ts
@@ -29,7 +29,7 @@ export interface Replicator {
    * the next message. The messages themselves contain no information; the subscriber queries
    * the SQLite replica for the latest replicated changes.
    */
-  subscribe(): Promise<CancelableAsyncIterable<ReplicaVersionReady>>;
+  subscribe(): CancelableAsyncIterable<ReplicaVersionReady>;
 }
 
 export class ReplicatorService implements Replicator, Service {
@@ -83,7 +83,7 @@ export class ReplicatorService implements Replicator, Service {
     await this.#incrementalSyncer.run(this.#lc);
   }
 
-  subscribe(): Promise<CancelableAsyncIterable<ReplicaVersionReady>> {
+  subscribe(): CancelableAsyncIterable<ReplicaVersionReady> {
     return this.#incrementalSyncer.subscribe();
   }
 

--- a/packages/zero-cache/src/services/service-runner.ts
+++ b/packages/zero-cache/src/services/service-runner.ts
@@ -206,7 +206,7 @@ class ReplicatorStub implements Replicator {
     return v.parse(data, jsonObjectSchema);
   }
 
-  subscribe(): Promise<CancelableAsyncIterable<ReplicaVersionReady>> {
+  subscribe(): CancelableAsyncIterable<ReplicaVersionReady> {
     const lc = this.#lc.withContext('method', 'versionChanges');
     const ws = new WebSocket(
       `http://${this.#host}${VERSION_CHANGES_PATTERN.replace(
@@ -215,7 +215,7 @@ class ReplicatorStub implements Replicator {
       )}`,
     );
 
-    return Promise.resolve(streamIn(lc, ws, emptySchema));
+    return streamIn(lc, ws, emptySchema);
   }
 }
 


### PR DESCRIPTION
The `CancelableAsyncIterator` type already encapsulates asynchronous semantics, so there's no need for the method to return a Promise. This simplifies wrapper implementations.