### PR TITLE
feat(zero-cache): create upstream connections lazily

### DIFF
--- a/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
@@ -696,13 +696,7 @@ describe('replicator/incremental-sync', {retry: 3}, () => {
   for (const c of cases) {
     test(c.name, async () => {
       await initDB(upstream, c.setupUpstream);
-      await initialSync(
-        lc,
-        REPLICA_ID,
-        replica,
-        upstream,
-        getConnectionURI(upstream),
-      );
+      await initialSync(lc, REPLICA_ID, replica, getConnectionURI(upstream));
 
       const syncing = syncer.run(lc);
       const notifications = syncer.subscribe();

--- a/packages/zero-cache/src/services/replicator/initial-sync.test.ts
+++ b/packages/zero-cache/src/services/replicator/initial-sync.test.ts
@@ -395,13 +395,7 @@ describe('replicator/initial-sync', () => {
       initLiteDB(replica, c.setupReplicaQuery);
 
       const lc = createSilentLogContext();
-      await initialSync(
-        lc,
-        REPLICA_ID,
-        replica,
-        upstream,
-        getConnectionURI(upstream),
-      );
+      await initialSync(lc, REPLICA_ID, replica, getConnectionURI(upstream));
 
       const {publications, tables} = await getPublicationInfo(upstream);
       expect(

--- a/packages/zero-cache/src/services/replicator/initial-sync.validation.test.ts
+++ b/packages/zero-cache/src/services/replicator/initial-sync.validation.test.ts
@@ -101,7 +101,6 @@ describe('replicator/initial-sync-validation', () => {
         createSilentLogContext(),
         REPLICA_ID,
         replica,
-        upstream,
         getConnectionURI(upstream),
       ).catch(e => e);
 

--- a/packages/zero-cache/src/services/replicator/replicator.ts
+++ b/packages/zero-cache/src/services/replicator/replicator.ts
@@ -1,7 +1,6 @@
 import type {LogContext} from '@rocicorp/logger';
 import Database from 'better-sqlite3';
 import type {ReadonlyJSONObject} from 'shared/src/json.js';
-import type {PostgresDB} from '../../types/pg.js';
 import type {CancelableAsyncIterable} from '../../types/streams.js';
 import type {Service} from '../service.js';
 import {IncrementalSyncer} from './incremental-sync.js';
@@ -36,7 +35,6 @@ export class ReplicatorService implements Replicator, Service {
   readonly id: string;
   readonly #lc: LogContext;
   readonly #upstreamUri: string;
-  readonly #upstream: PostgresDB;
   readonly #syncReplicaDbFile: string;
   readonly #incrementalSyncer: IncrementalSyncer;
 
@@ -44,7 +42,6 @@ export class ReplicatorService implements Replicator, Service {
     lc: LogContext,
     replicaID: string,
     upstreamUri: string,
-    upstream: PostgresDB,
     syncReplicaDbFile: string,
   ) {
     this.id = replicaID;
@@ -52,7 +49,6 @@ export class ReplicatorService implements Replicator, Service {
       .withContext('component', 'Replicator')
       .withContext('serviceID', this.id);
     this.#upstreamUri = upstreamUri;
-    this.#upstream = upstream;
     this.#syncReplicaDbFile = syncReplicaDbFile;
 
     const replica = new Database(syncReplicaDbFile);
@@ -76,7 +72,6 @@ export class ReplicatorService implements Replicator, Service {
       'replicator',
       this.id,
       this.#syncReplicaDbFile,
-      this.#upstream,
       this.#upstreamUri,
     );
 

--- a/packages/zero-cache/src/services/replicator/schema/sync-schema.test.ts
+++ b/packages/zero-cache/src/services/replicator/schema/sync-schema.test.ts
@@ -104,7 +104,6 @@ describe('replicator/schema/sync-schema', () => {
           'test',
           REPLICA_ID,
           replicaFile.path,
-          upstream,
           getConnectionURI(upstream),
         );
 

--- a/packages/zero-cache/src/services/replicator/schema/sync-schema.ts
+++ b/packages/zero-cache/src/services/replicator/schema/sync-schema.ts
@@ -4,7 +4,6 @@ import {
   runSchemaMigrations,
   VersionMigrationMap,
 } from 'zero-cache/src/db/migration-lite.js';
-import {PostgresDB} from 'zero-cache/src/types/pg.js';
 import {initialSync} from '../initial-sync.js';
 
 export async function initSyncSchema(
@@ -12,13 +11,12 @@ export async function initSyncSchema(
   debugName: string,
   replicaID: string,
   dbPath: string,
-  upstream: PostgresDB,
   upstreamURI: string,
 ): Promise<void> {
   const schemaVersionMigrationMap: VersionMigrationMap = {
     1: {minSafeRollbackVersion: 1}, // The inaugural v1 understands the rollback limit.
     2: {
-      run: (log, tx) => initialSync(log, replicaID, tx, upstream, upstreamURI),
+      run: (log, tx) => initialSync(log, replicaID, tx, upstreamURI),
     },
   };
 

--- a/packages/zero-cache/src/services/service-runner.ts
+++ b/packages/zero-cache/src/services/service-runner.ts
@@ -84,7 +84,6 @@ export class ServiceRunner
             this.#lc,
             id,
             this.#env.UPSTREAM_URI,
-            this.#upstream,
             this.#replicaDbFile,
           ),
         'ReplicatorService',


### PR DESCRIPTION
The Replicator only needs upstream connections for initial sync. Create them lazily since the stub will not be shared with any other component in the Replicator Thread.