### PR TITLE
feat(zql): Add per-output sorts to Sources (lazy edition).

### DIFF
--- a/packages/zql/src/zql/ivm2/join.fetch.test.ts
+++ b/packages/zql/src/zql/ivm2/join.fetch.test.ts
@@ -7,18 +7,26 @@ import type {Row, Node} from './data.js';
 import {assert} from 'shared/src/asserts.js';
 import type {Ordering} from '../ast2/ast.js';
 import {Catch} from './catch.js';
+import { ValueType } from './schema.js';
 test('hydrate one:many', () => {
-  const joins = [
-    {
-      parentKey: 'id',
-      childKey: 'issueID',
-      relationshipName: 'comments',
-    },
-  ];
+  const base = {
+    columns: [
+      {id: 'string' as const},
+      {id: 'string' as const, issueID: 'string' as const},
+    ],
+    primaryKeys: [['id'], ['id']],
+    joins: [
+      {
+        parentKey: 'id',
+        childKey: 'issueID',
+        relationshipName: 'comments',
+      },
+    ],
+  };
 
   // no data
   fetchTest({
-    joins,
+    ...base,
     sources: [[], []],
     expectedMessages: [['0', 'hydrate', {}]],
     expectedStorageCounts: [{}],
@@ -27,7 +35,7 @@ test('hydrate one:many', () => {
 
   // no parent
   fetchTest({
-    joins,
+    ...base,
     sources: [[], [{id: 'c1', issueID: 'i1'}]],
     expectedMessages: [['0', 'hydrate', {}]],
     expectedStorageCounts: [{}],
@@ -36,7 +44,7 @@ test('hydrate one:many', () => {
 
   // parent, no children
   fetchTest({
-    joins,
+    ...base,
     sources: [[{id: 'i1'}], []],
     expectedMessages: [
       ['0', 'hydrate', {}],
@@ -48,7 +56,7 @@ test('hydrate one:many', () => {
 
   // one parent, one child
   fetchTest({
-    joins,
+    ...base,
     sources: [[{id: 'i1'}], [{id: 'c1', issueID: 'i1'}]],
     expectedMessages: [
       ['0', 'hydrate', {}],
@@ -67,7 +75,7 @@ test('hydrate one:many', () => {
 
   // one parent, wrong child
   fetchTest({
-    joins,
+    ...base,
     sources: [[{id: 'i1'}], [{id: 'c1', issueID: 'i2'}]],
     expectedMessages: [
       ['0', 'hydrate', {}],
@@ -79,7 +87,7 @@ test('hydrate one:many', () => {
 
   // one parent, one child + one wrong child
   fetchTest({
-    joins,
+    ...base,
     sources: [
       [{id: 'i1'}],
       [
@@ -104,7 +112,7 @@ test('hydrate one:many', () => {
 
   // two parents, each with two children
   fetchTest({
-    joins,
+    ...base,
     sources: [
       [{id: 'i2'}, {id: 'i1'}],
       [
@@ -144,17 +152,24 @@ test('hydrate one:many', () => {
 });
 
 test('hydrate many:one', () => {
-  const joins = [
-    {
-      parentKey: 'ownerID',
-      childKey: 'id',
-      relationshipName: 'owner',
-    },
-  ];
+  const base = {
+    columns: [
+      {id: 'string' as const, ownerID: 'string' as const},
+      {id: 'string' as const},
+    ],
+    primaryKeys: [['id'], ['id']],
+    joins: [
+      {
+        parentKey: 'ownerID',
+        childKey: 'id',
+        relationshipName: 'owner',
+      },
+    ],
+  };
 
   // no data
   fetchTest({
-    joins,
+    ...base,
     sources: [[], []],
     expectedMessages: [['0', 'hydrate', {}]],
     expectedStorageCounts: [{}],
@@ -163,7 +178,7 @@ test('hydrate many:one', () => {
 
   // one parent, no child
   fetchTest({
-    joins,
+    ...base,
     sources: [[{id: 'i1', ownerID: 'u1'}], []],
     expectedMessages: [
       ['0', 'hydrate', {}],
@@ -177,7 +192,7 @@ test('hydrate many:one', () => {
 
   // no parent, one child
   fetchTest({
-    joins,
+    ...base,
     sources: [[], [{id: 'u1'}]],
     expectedMessages: [['0', 'hydrate', {}]],
     expectedStorageCounts: [{}],
@@ -186,7 +201,7 @@ test('hydrate many:one', () => {
 
   // one parent, one child
   fetchTest({
-    joins,
+    ...base,
     sources: [[{id: 'i1', ownerID: 'u1'}], [{id: 'u1'}]],
     expectedMessages: [
       ['0', 'hydrate', {}],
@@ -205,7 +220,7 @@ test('hydrate many:one', () => {
 
   // two parents, one child
   fetchTest({
-    joins,
+    ...base,
     sources: [
       [
         {id: 'i2', ownerID: 'u1'},
@@ -237,7 +252,7 @@ test('hydrate many:one', () => {
 
   // two parents, two children
   fetchTest({
-    joins,
+    ...base,
     sources: [
       [
         {id: 'i2', ownerID: 'u2'},
@@ -269,22 +284,30 @@ test('hydrate many:one', () => {
 });
 
 test('hydrate one:many:many', () => {
-  const joins = [
-    {
-      parentKey: 'id',
-      childKey: 'issueID',
-      relationshipName: 'comments',
-    },
-    {
-      parentKey: 'id',
-      childKey: 'commentID',
-      relationshipName: 'revisions',
-    },
-  ];
+  const base = {
+    columns: [
+      {id: 'string' as const},
+      {id: 'string' as const, issueID: 'string' as const},
+      {id: 'string' as const, commentID: 'string' as const},
+    ],
+    primaryKeys: [['id'], ['id'], ['id']],
+    joins: [
+      {
+        parentKey: 'id',
+        childKey: 'issueID',
+        relationshipName: 'comments',
+      },
+      {
+        parentKey: 'id',
+        childKey: 'commentID',
+        relationshipName: 'revisions',
+      },
+    ]
+  }
 
   // no data
   fetchTest({
-    joins,
+    ...base,
     sources: [[], [], []],
     expectedMessages: [['0', 'hydrate', {}]],
     expectedStorageCounts: [{}, {}],
@@ -293,7 +316,7 @@ test('hydrate one:many:many', () => {
 
   // no parent, one comment, no revision
   fetchTest({
-    joins,
+    ...base,
     sources: [[], [{id: 'c1', issueID: 'i1'}], []],
     expectedMessages: [['0', 'hydrate', {}]],
     expectedStorageCounts: [{}, {}],
@@ -302,7 +325,7 @@ test('hydrate one:many:many', () => {
 
   // no parent, one comment, one revision
   fetchTest({
-    joins,
+    ...base,
     sources: [[], [{id: 'c1', issueID: 'i1'}], [{id: 'r1', commentID: 'c1'}]],
     expectedMessages: [['0', 'hydrate', {}]],
     expectedStorageCounts: [{}, {}],
@@ -311,7 +334,7 @@ test('hydrate one:many:many', () => {
 
   // one issue, no comments or revisions
   fetchTest({
-    joins,
+    ...base,
     sources: [[{id: 'i1'}], [], []],
     expectedMessages: [
       ['0', 'hydrate', {}],
@@ -323,7 +346,7 @@ test('hydrate one:many:many', () => {
 
   // one issue, one comment, one revision
   fetchTest({
-    joins,
+    ...base,
     sources: [
       [{id: 'i1'}],
       [{id: 'c1', issueID: 'i1'}],
@@ -356,7 +379,7 @@ test('hydrate one:many:many', () => {
 
   // two issues, four comments, eight revisions
   fetchTest({
-    joins,
+    ...base,
     sources: [
       [{id: 'i2'}, {id: 'i1'}],
       [
@@ -445,18 +468,26 @@ test('hydrate one:many:many', () => {
 });
 
 test('hydrate one:many:one', () => {
-  const joins = [
-    {
-      parentKey: 'id',
-      childKey: 'issueID',
-      relationshipName: 'issuelabels',
-    },
-    {
-      parentKey: 'labelID',
-      childKey: 'id',
-      relationshipName: 'labels',
-    },
-  ];
+  const base = {
+    columns: [
+      {id: 'string' as const},
+      {issueID: 'string' as const, labelID: 'string' as const},
+      {id: 'string' as const},
+    ],
+    primaryKeys: [['id'], ['issueID', 'labelID'], ['id']],
+    joins: [
+      {
+        parentKey: 'id',
+        childKey: 'issueID',
+        relationshipName: 'issuelabels',
+      },
+      {
+        parentKey: 'labelID',
+        childKey: 'id',
+        relationshipName: 'labels',
+      },
+    ],
+  }
 
   const sorts = [
     undefined,
@@ -468,7 +499,7 @@ test('hydrate one:many:one', () => {
 
   // no data
   fetchTest({
-    joins,
+    ...base,
     sources: [[], [], []],
     sorts,
     expectedMessages: [['0', 'hydrate', {}]],
@@ -478,7 +509,7 @@ test('hydrate one:many:one', () => {
 
   // no issues, one issuelabel, one label
   fetchTest({
-    joins,
+    ...base,
     sources: [[], [{issueID: 'i1', labelID: 'l1'}], [{id: 'l1'}]],
     sorts,
     expectedMessages: [['0', 'hydrate', {}]],
@@ -488,7 +519,7 @@ test('hydrate one:many:one', () => {
 
   // one issue, no issuelabels, no labels
   fetchTest({
-    joins,
+    ...base,
     sources: [[{id: 'i1'}], [], []],
     sorts,
     expectedMessages: [
@@ -501,7 +532,7 @@ test('hydrate one:many:one', () => {
 
   // one issue, one issuelabel, no labels
   fetchTest({
-    joins,
+    ...base,
     sources: [[{id: 'i1'}], [{issueID: 'i1', labelID: 'l1'}], []],
     sorts,
     expectedMessages: [
@@ -527,7 +558,7 @@ test('hydrate one:many:one', () => {
 
   // one issue, one issuelabel, one label
   fetchTest({
-    joins,
+    ...base,
     sources: [[{id: 'i1'}], [{issueID: 'i1', labelID: 'l1'}], [{id: 'l1'}]],
     sorts,
     expectedMessages: [
@@ -555,7 +586,7 @@ test('hydrate one:many:one', () => {
 
   // one issue, two issuelabels, two labels
   fetchTest({
-    joins,
+    ...base,
     sources: [
       [{id: 'i1'}],
       [
@@ -597,7 +628,7 @@ test('hydrate one:many:one', () => {
 
   // two issues, four issuelabels, two labels
   fetchTest({
-    joins,
+    ...base,
     sources: [
       [{id: 'i2'}, {id: 'i1'}],
       [
@@ -667,12 +698,12 @@ function fetchTest(t: FetchTest) {
 
   const sources = t.sources.map((rows, i) => {
     const ordering = t.sorts?.[i] ?? [['id', 'asc']];
-    const source = new MemorySource(ordering);
+    const source = new MemorySource(t.columns[i], t.primaryKeys[i]);
     for (const row of rows) {
       source.push({type: 'add', row});
     }
     const snitch = new Snitch(source, String(i), log);
-    source.addOutput(snitch);
+    source.addOutput(snitch, ordering);
     return {
       source,
       snitch,
@@ -768,6 +799,8 @@ function fetchTest(t: FetchTest) {
 }
 
 type FetchTest = {
+  columns: Record<string, ValueType>[];
+  primaryKeys: readonly string[][];
   sources: Row[][];
   sorts?: (Ordering | undefined)[] | undefined;
   joins: {

--- a/packages/zql/src/zql/ivm2/join.ts
+++ b/packages/zql/src/zql/ivm2/join.ts
@@ -52,8 +52,8 @@ export class Join implements Operator {
     this.#output = output;
   }
 
-  get schema(): Schema {
-    return this.#parent.schema;
+  getSchema(_output: Output): Schema {
+    return this.#parent.getSchema(this);
   }
 
   *hydrate(req: HydrateRequest, _: Output): Stream<Node> {

--- a/packages/zql/src/zql/ivm2/memory-source.test.ts
+++ b/packages/zql/src/zql/ivm2/memory-source.test.ts
@@ -1,22 +1,69 @@
-import {test} from 'vitest';
+import {expect, test} from 'vitest';
 import {Ordering} from '../ast2/ast.js';
 import {compareRowsTest} from './data.test.js';
 import {MemorySource} from './memory-source.js';
 import {runCases} from './test/source-cases.js';
 import {ValueType} from './schema.js';
+import {Catch} from './catch.js';
 
 runCases(
   (
     _name: string,
-    _columns: Record<string, ValueType>,
-    order: Ordering,
-    _primaryKeys: readonly string[],
-  ) => new MemorySource(order),
+    columns: Record<string, ValueType>,
+    primaryKeys: readonly string[],
+  ) => new MemorySource(columns, primaryKeys),
 );
 
 test('schema', () => {
   compareRowsTest((order: Ordering) => {
-    const ms = new MemorySource(order);
-    return ms.schema.compareRows;
+    const ms = new MemorySource({a: 'string'}, ['a']);
+    const out = new Catch(ms);
+    ms.addOutput(out, order);
+    return ms.getSchema(out).compareRows;
   });
+});
+
+test('indexes get cleaned up when not needed', () => {
+  const ms = new MemorySource({a: 'string', b: 'string', c: 'string'}, ['a']);
+  expect(ms.getIndexKeys()).toEqual([JSON.stringify([['a', 'asc']])]);
+
+  const c1 = new Catch(ms);
+  ms.addOutput(c1, [['b', 'asc']]);
+  c1.hydrate();
+  expect(ms.getIndexKeys()).toEqual([
+    JSON.stringify([['a', 'asc']]),
+    JSON.stringify([['b', 'asc']]),
+  ]);
+
+  const c2 = new Catch(ms);
+  ms.addOutput(c2, [['b', 'asc']]);
+  c2.hydrate();
+  expect(ms.getIndexKeys()).toEqual([
+    JSON.stringify([['a', 'asc']]),
+    JSON.stringify([['b', 'asc']]),
+  ]);
+
+  const c3 = new Catch(ms);
+  ms.addOutput(c3, [['c', 'asc']]);
+  c3.hydrate();
+  expect(ms.getIndexKeys()).toEqual([
+    JSON.stringify([['a', 'asc']]),
+    JSON.stringify([['b', 'asc']]),
+    JSON.stringify([['c', 'asc']]),
+  ]);
+
+  ms.removeOutput(c3);
+  expect(ms.getIndexKeys()).toEqual([
+    JSON.stringify([['a', 'asc']]),
+    JSON.stringify([['b', 'asc']]),
+  ]);
+
+  ms.removeOutput(c2);
+  expect(ms.getIndexKeys()).toEqual([
+    JSON.stringify([['a', 'asc']]),
+    JSON.stringify([['b', 'asc']]),
+  ]);
+
+  ms.removeOutput(c1);
+  expect(ms.getIndexKeys()).toEqual([JSON.stringify([['a', 'asc']])]);
 });

--- a/packages/zql/src/zql/ivm2/memory-source.ts
+++ b/packages/zql/src/zql/ivm2/memory-source.ts
@@ -5,17 +5,34 @@ import type {
   HydrateRequest,
   Constraint,
 } from './operator.js';
-import {makeComparator, valuesEqual, type Node, type Row} from './data.js';
+import {
+  Comparator,
+  makeComparator,
+  valuesEqual,
+  type Node,
+  type Row,
+} from './data.js';
 import type {Ordering} from '../ast2/ast.js';
 import {assert} from 'shared/src/asserts.js';
 import {LookaheadIterator} from './lookahead-iterator.js';
 import type {Stream} from './stream.js';
 import {Source, SourceChange} from './source.js';
-import {Schema} from './schema.js';
+import {Schema, ValueType} from './schema.js';
 
 export type Overlay = {
   outputIndex: number;
   change: SourceChange;
+};
+
+type Index = {
+  comparator: Comparator;
+  data: BTree<Row, undefined>;
+  usedBy: Set<Output>;
+};
+
+type OutputRegistration = {
+  output: Output;
+  sort: Ordering;
 };
 
 /**
@@ -26,43 +43,130 @@ export type Overlay = {
  * the data they receive from `pull` to be in sorted order.
  */
 export class MemorySource implements Source {
-  readonly #schema: Schema;
-  readonly #data: BTree<Row, undefined>;
-  readonly #outputs: Output[] = [];
+  readonly #columns: Record<string, ValueType>;
+  readonly #primaryKeys: readonly string[];
+  readonly #primaryIndexSort: Ordering;
+  readonly #indexes: Map<string, Index> = new Map();
+  readonly #outputs: OutputRegistration[] = [];
 
   #overlay: Overlay | undefined;
 
-  constructor(order: Ordering) {
-    this.#schema = {
-      compareRows: makeComparator(order),
-      columns: {},
-      primaryKey: [],
+  constructor(
+    columns: Record<string, ValueType>,
+    primaryKeys: readonly string[],
+  ) {
+    this.#columns = columns;
+    this.#primaryKeys = primaryKeys;
+    this.#primaryIndexSort = primaryKeys.map(k => [k, 'asc']);
+    this.#indexes = new Map();
+    const comparator = makeComparator(this.#primaryIndexSort);
+    this.#indexes.set(JSON.stringify(this.#primaryIndexSort), {
+      comparator,
+      data: new BTree<Row, undefined>([], comparator),
+      usedBy: new Set(),
+    });
+  }
+
+  #getRegistrationForOutput(output: Output): OutputRegistration {
+    const reg = this.#outputs.find(r => r.output === output);
+    assert(reg, 'Output not found');
+    return reg;
+  }
+
+  getSchema(output: Output): Schema {
+    const reg = this.#getRegistrationForOutput(output);
+    return {
+      columns: this.#columns,
+      primaryKey: this.#primaryKeys,
+      compareRows: makeComparator(reg.sort),
     };
-    this.#data = new BTree(undefined, this.#schema.compareRows);
   }
 
-  get schema(): Schema {
-    return this.#schema;
+  addOutput(output: Output, sort: Ordering): void {
+    this.#outputs.push({output, sort});
   }
 
-  addOutput(output: Output): void {
-    this.#outputs.push(output);
+  removeOutput(output: Output): void {
+    const idx = this.#outputs.findIndex(r => r.output === output);
+    assert(idx !== -1, 'Output not found');
+    this.#outputs.splice(idx, 1);
+
+    const primaryIndexKey = JSON.stringify(this.#primaryIndexSort);
+
+    for (const [key, index] of this.#indexes) {
+      if (key === primaryIndexKey) {
+        continue;
+      }
+      index.usedBy.delete(output);
+      if (index.usedBy.size === 0) {
+        this.#indexes.delete(key);
+      }
+    }
   }
 
   hydrate(req: HydrateRequest, output: Output) {
     return this.fetch(req, output);
   }
 
+  #getPrimaryIndex(): Index {
+    const index = this.#indexes.get(JSON.stringify(this.#primaryIndexSort));
+    assert(index, 'Primary index not found');
+    return index;
+  }
+
+  #getOrCreateIndex(sort: Ordering, output: Output): Index {
+    const key = JSON.stringify(sort);
+    const index = this.#indexes.get(key);
+    // Future optimization could use existing index if it's the same just sorted
+    // in reverse of needed.
+    if (index) {
+      index.usedBy.add(output);
+      return index;
+    }
+
+    const comparator = makeComparator(sort);
+
+    // When creating these synchronously becomes a problem, a few options:
+    // 1. Allow users to specify needed indexes up front
+    // 2. Create indexes in a different thread asynchronously (this would require
+    // modifying the BTree to be able to be passed over structured-clone, or using
+    // a different library.)
+    // 3. We could even theoretically do (2) on multiple threads and then merge the
+    // results!
+    const data = new BTree<Row, undefined>([], comparator);
+
+    // I checked, there's no special path for adding data in bulk faster.
+    // The constructor takes an array, but it just calls add/set over and over.
+    for (const row of this.#getPrimaryIndex().data.keys()) {
+      data.add(row, undefined);
+    }
+
+    const newIndex = {comparator, data, usedBy: new Set([output])};
+    this.#indexes.set(key, newIndex);
+    return newIndex;
+  }
+
+  // For unit testing that we correctly clean up indexes.
+  getIndexKeys(): string[] {
+    return [...this.#indexes.keys()];
+  }
+
   *fetch(req: FetchRequest, output: Output): Stream<Node> {
     let overlay: Overlay | undefined;
+
+    const callingOutputNum = this.#outputs.findIndex(r => r.output === output);
+    assert(callingOutputNum !== -1, 'Output not found');
+    const reg = this.#outputs[callingOutputNum];
+    const {sort} = reg;
+
+    const index = this.#getOrCreateIndex(sort, output);
+    const {data, comparator} = index;
 
     // When we receive a push, we send it to each output one at a time. Once the
     // push is sent to an output, it should keep being sent until all datastores
     // have received it and the change has been made to the datastore.
     if (this.#overlay) {
-      const callingOutputIndex = this.#outputs.indexOf(output);
-      assert(callingOutputIndex !== -1, 'Output not found');
-      if (callingOutputIndex <= this.#overlay.outputIndex) {
+      if (callingOutputNum <= this.#overlay.outputIndex) {
         overlay = this.#overlay;
       }
     }
@@ -79,18 +183,18 @@ export class MemorySource implements Source {
     }
 
     const startAt = req.start?.row
-      ? this.#data.nextLowerKey(req.start.row)
+      ? data.nextLowerKey(req.start.row)
       : undefined;
     yield* generateWithStart(
       generateWithOverlay(
         startAt,
-        this.#pullWithConstraint(startAt, req.constraint),
+        this.#pullWithConstraint(data, startAt, req.constraint),
         req.constraint,
         overlay,
-        this.#schema.compareRows,
+        comparator,
       ),
       req,
-      this.#schema.compareRows,
+      comparator,
     );
   }
 
@@ -99,10 +203,11 @@ export class MemorySource implements Source {
   }
 
   *#pullWithConstraint(
+    data: BTree<Row, undefined>,
     startAt: Row | undefined,
     constraint: Constraint | undefined,
   ): IterableIterator<Row> {
-    const it = this.#data.keys(startAt);
+    const it = data.keys(startAt);
 
     // Process all items in the iterator, applying overlay as needed.
     for (const row of it) {
@@ -113,40 +218,38 @@ export class MemorySource implements Source {
   }
 
   push(change: SourceChange) {
-    if (change.type === 'add') {
-      if (this.#data.has(change.row)) {
-        throw new Error('Row already exists');
+    for (const [_, {data}] of this.#indexes) {
+      if (change.type === 'add') {
+        assert(!data.has(change.row), 'Row already exists');
+      } else {
+        change.type satisfies 'remove'; // ensures exuaustiveness of `if/else`
+        assert(data.has(change.row), 'Row not found');
       }
-    } else {
-      change.type satisfies 'remove'; // ensures exuaustiveness of `if/else`
-      if (!this.#data.has(change.row)) {
-        throw new Error('Row not found');
-      }
-    }
 
-    for (const [outputIndex, output] of this.#outputs.entries()) {
-      this.#overlay = {outputIndex, change};
-      output.push(
-        {
-          type: change.type,
-          node: {
-            row: change.row,
-            relationships: {},
+      for (const [outputIndex, {output}] of this.#outputs.entries()) {
+        this.#overlay = {outputIndex, change};
+        output.push(
+          {
+            type: change.type,
+            node: {
+              row: change.row,
+              relationships: {},
+            },
           },
-        },
-        this,
-      );
-    }
-    this.#overlay = undefined;
-    if (change.type === 'add') {
-      const added = this.#data.add(change.row, undefined);
-      // must suceed since we checked has() above.
-      assert(added);
-    } else {
-      assert(change.type === 'remove');
-      const removed = this.#data.delete(change.row);
-      // must suceed since we checked has() above.
-      assert(removed);
+          this,
+        );
+      }
+      this.#overlay = undefined;
+      if (change.type === 'add') {
+        const added = data.add(change.row, undefined);
+        // must suceed since we checked has() above.
+        assert(added);
+      } else {
+        assert(change.type === 'remove');
+        const removed = data.delete(change.row);
+        // must suceed since we checked has() above.
+        assert(removed);
+      }
     }
   }
 }

--- a/packages/zql/src/zql/ivm2/operator.ts
+++ b/packages/zql/src/zql/ivm2/operator.ts
@@ -12,7 +12,7 @@ import type {Schema} from './schema.js';
  */
 export interface Input {
   // The schema of the data this input returns.
-  get schema(): Schema;
+  getSchema(output: Output): Schema;
 
   // Request initial result from this operator and initialize its state.
   // Returns nodes sorted in order of schema().comparator.

--- a/packages/zql/src/zql/ivm2/snitch.ts
+++ b/packages/zql/src/zql/ivm2/snitch.ts
@@ -31,8 +31,8 @@ export class Snitch implements Operator {
     this.#output = output;
   }
 
-  get schema(): Schema {
-    return this.#input.schema;
+  getSchema(_: Output): Schema {
+    return this.#input.getSchema(this);
   }
 
   hydrate(req: HydrateRequest, _source: Output) {

--- a/packages/zql/src/zql/ivm2/source.ts
+++ b/packages/zql/src/zql/ivm2/source.ts
@@ -1,3 +1,4 @@
+import { Ordering } from '../ast2/ast.js';
 import {Row} from './data.js';
 import {Input, Output} from './operator.js';
 
@@ -11,6 +12,6 @@ export type SourceChange = {
  * Sources can have multiple outputs.
  */
 export interface Source extends Input {
-  addOutput(output: Output): void;
+  addOutput(output: Output, sort: Ordering): void;
   push(change: SourceChange): void;
 }


### PR DESCRIPTION
At first the plan was to require user to create needed indexes up front.

But on the server this seems like kind of a bummer. Other systems will make use of good indexes that are available but will muddle through if needed indexes aren't there.

This is really nice for dx early-on. There's no reason for us not to do that since we have SQLite.

On the client, all indexes are in-memory. So "muddling through" would mean creating a sort when needed then discarding it. But since we are doing IVM we would likely keep the sort around for life of query. And that's just the same as creating an index on demand. That's what this PR implements.

This does have downsides if the user is constantly adding and removing searches, we might thrash indexes. But that's just the same problem as in a normal database with not having the right indexes -- the db will constantly be sorting the same data over and over.

Long story short, we'll probably also want to allow user to force certain indexes to be created, just as in a normal DB. But it's nice to be able to be able to handle any query on small datasets without config.