### PR TITLE
feat(zero-cache): server setup for zero-cache on worker threads

### DIFF
--- a/packages/zero-cache/src/env.d.ts
+++ b/packages/zero-cache/src/env.d.ts
@@ -1,8 +1,0 @@
-import type {DurableObjectNamespace} from '@cloudflare/workers-types';
-
-// https://developers.cloudflare.com/workers/testing/vitest-integration/get-started/migrate-from-miniflare-2/#access-bindings
-declare module 'cloudflare:test' {
-  interface ProvidedEnv {
-    runnerDO: DurableObjectNamespace;
-  }
-}

--- a/packages/zero-cache/src/server/config.ts
+++ b/packages/zero-cache/src/server/config.ts
@@ -1,0 +1,23 @@
+import * as v from 'shared/src/valita.js';
+
+const configSchema = v.object({
+  ['REPLICA_ID']: v.string(),
+  ['UPSTREAM_URI']: v.string(),
+  ['REPLICA_DB_FILE']: v.string(),
+  ['LOG_LEVEL']: v.union(
+    v.literal('debug'),
+    v.literal('info'),
+    v.literal('error'),
+  ),
+  ['DATADOG_LOGS_API_KEY']: v.string().optional(),
+  ['DATADOG_SERVICE_LABEL']: v.string().optional(),
+});
+
+export type Config = v.Infer<typeof configSchema>;
+
+export function configFromEnv(): Config {
+  const env = Object.fromEntries(
+    Object.keys(configSchema.shape).map(key => [key, process.env[key]]),
+  );
+  return v.parse(env, configSchema);
+}

--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -1,0 +1,34 @@
+import {SHARE_ENV, Worker} from 'node:worker_threads';
+import {Dispatcher, Workers} from '../services/dispatcher/dispatcher.js';
+import {createLogContext} from '../services/logging.js';
+import {configFromEnv} from './config.js';
+
+const env = configFromEnv();
+const lc = createLogContext(env, {thread: 'main'});
+
+function logErrorAndExit(err: unknown) {
+  lc.error?.(err);
+  process.exit(1);
+}
+
+const replicator = new Worker('./src/server/replicator.ts', {
+  env: SHARE_ENV,
+  workerData: {subscriberPorts: []}, // TODO
+  transferList: [
+    /* subscriberPorts here too */
+  ],
+}).on('error', logErrorAndExit);
+
+const workers: Workers = {
+  replicator,
+  syncers: [
+    /* TODO */
+  ],
+};
+
+const dispatcher = new Dispatcher(lc, () => workers);
+try {
+  await dispatcher.run();
+} catch (err) {
+  logErrorAndExit(err);
+}

--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -1,0 +1,18 @@
+import {parentPort, workerData} from 'node:worker_threads';
+import {createLogContext} from '../services/logging.js';
+import {ReplicatorService} from '../services/replicator/replicator.js';
+import {ReplicatorWorkerData, runAsWorker} from '../workers/replicator.js';
+import {configFromEnv} from './config.js';
+
+const config = configFromEnv();
+
+void runAsWorker(
+  new ReplicatorService(
+    createLogContext(config, {thread: 'replicator'}),
+    config.REPLICA_ID, // TODO: Parameterize replicaID
+    config.UPSTREAM_URI,
+    config.REPLICA_DB_FILE,
+  ),
+  parentPort,
+  workerData as ReplicatorWorkerData,
+);

--- a/packages/zero-cache/src/services/dispatcher/dispatcher.ts
+++ b/packages/zero-cache/src/services/dispatcher/dispatcher.ts
@@ -1,0 +1,49 @@
+import {LogContext} from '@rocicorp/logger';
+import Fastify, {FastifyInstance, FastifyReply, FastifyRequest} from 'fastify';
+import {Worker} from 'worker_threads';
+import {getStatusFromWorker} from '../../workers/replicator.js';
+import {Service} from '../service.js';
+
+export const STATUS_URL_PATTERN = '/api/system/:version/status';
+export const CONNECT_URL_PATTERN = '/api/sync/:version/connect';
+
+export type Workers = {
+  replicator: Worker;
+  syncers: Worker[];
+};
+
+export class Dispatcher implements Service {
+  readonly id = 'dispatcher';
+  readonly #lc: LogContext;
+  readonly #workersByHostname: (hostname: string) => Workers;
+  readonly #fastify: FastifyInstance;
+
+  constructor(
+    lc: LogContext,
+    workersByHostname: (hostname: string) => Workers,
+  ) {
+    this.#lc = lc;
+    this.#workersByHostname = workersByHostname;
+    this.#fastify = Fastify();
+    this.#fastify.get(STATUS_URL_PATTERN, (req, res) => this.#status(req, res));
+    this.#fastify.addHook('onRequest', (req, _, done) => {
+      this.#lc?.debug?.(`received request`, req.hostname, req.url);
+      done();
+    });
+  }
+
+  async #status(request: FastifyRequest, reply: FastifyReply) {
+    const {replicator} = this.#workersByHostname(request.hostname);
+    const status = await getStatusFromWorker(replicator);
+    await reply.send(JSON.stringify(status));
+  }
+
+  async run(): Promise<void> {
+    const address = await this.#fastify.listen({port: 3000});
+    this.#lc.info?.(`Server listening at ${address}`);
+  }
+
+  async stop(): Promise<void> {
+    await this.#fastify.close();
+  }
+}

--- a/packages/zero-cache/src/services/logging.ts
+++ b/packages/zero-cache/src/services/logging.ts
@@ -1,11 +1,14 @@
-import {TeeLogSink, consoleLogSink} from '@rocicorp/logger';
+import {LogContext, TeeLogSink, consoleLogSink} from '@rocicorp/logger';
 import {DatadogLogSink} from 'datadog/src/datadog-log-sink.js';
-import type {ServiceRunnerEnv} from './service-runner.js';
+import {threadId} from 'node:worker_threads';
+import {Config} from '../server/config.js';
 
 const DEFAULT_LOG_LEVEL = 'info';
 const DATADOG_SOURCE = 'zeroWorker';
 
-export function createLogSink(env: ServiceRunnerEnv) {
+export function createLogSink(
+  env: Pick<Config, 'DATADOG_LOGS_API_KEY' | 'DATADOG_SERVICE_LABEL'>,
+) {
   if (env.DATADOG_LOGS_API_KEY === undefined) {
     return consoleLogSink;
   }
@@ -19,6 +22,17 @@ export function createLogSink(env: ServiceRunnerEnv) {
   ]);
 }
 
-export function getLogLevel(env: ServiceRunnerEnv) {
+export function getLogLevel(env: Pick<Config, 'LOG_LEVEL'>) {
   return env.LOG_LEVEL ?? DEFAULT_LOG_LEVEL;
+}
+
+export function createLogContext(
+  env: Pick<
+    Config,
+    'DATADOG_LOGS_API_KEY' | 'DATADOG_SERVICE_LABEL' | 'LOG_LEVEL'
+  >,
+  context: {thread: string},
+): LogContext {
+  const ctx = {...context, threadID: threadId};
+  return new LogContext(getLogLevel(env), ctx, createLogSink(env));
 }

--- a/packages/zero-cache/src/workers/replicator.test.ts
+++ b/packages/zero-cache/src/workers/replicator.test.ts
@@ -1,0 +1,61 @@
+import {Queue} from 'shared/src/queue.js';
+import {describe, expect, test, vi} from 'vitest';
+import {
+  Replicator,
+  ReplicaVersionReady,
+} from 'zero-cache/src/services/replicator/replicator.js';
+import {Service} from 'zero-cache/src/services/service.js';
+import {Subscription} from 'zero-cache/src/types/subscription.js';
+import {getStatusFromWorker, runAsWorker} from './replicator.js';
+
+describe('workers/replicator', () => {
+  test('status', async () => {
+    const replicator = {
+      status: vi.fn().mockResolvedValue({status: 'yo'}),
+      subscribe: vi.fn(),
+      run: vi.fn(),
+    };
+
+    const {port1: parentPort, port2: childPort} = new MessageChannel();
+
+    void runAsWorker(
+      replicator as unknown as Replicator & Service,
+      parentPort,
+      {subscriberPorts: []},
+    );
+    expect(replicator.run).toHaveBeenCalledOnce;
+
+    // Simulate a status request from the parent.
+    const status = await getStatusFromWorker(childPort);
+    expect(status).toEqual({status: 'yo'});
+  });
+});
+
+test('subscription', async () => {
+  const subscription = Subscription.create<ReplicaVersionReady>();
+
+  const replicator = {
+    status: vi.fn(),
+    subscribe: () => subscription,
+    run: vi.fn(),
+  };
+
+  const statusChannel = new MessageChannel();
+  const {port1: notificationPort, port2: syncerPort} = new MessageChannel();
+
+  void runAsWorker(
+    replicator as unknown as Replicator & Service,
+    statusChannel.port1,
+    {subscriberPorts: [syncerPort]},
+  );
+  expect(replicator.run).toHaveBeenCalledOnce;
+
+  const notifications = new Queue<unknown>();
+  notificationPort.on('message', msg => notifications.enqueue(msg));
+  notificationPort.postMessage({});
+
+  subscription.push({foo: 'bar'});
+  subscription.push({foo: 'baz'});
+  expect(await notifications.dequeue()).toEqual({foo: 'bar'});
+  expect(await notifications.dequeue()).toEqual({foo: 'baz'});
+});

--- a/packages/zero-cache/src/workers/replicator.ts
+++ b/packages/zero-cache/src/workers/replicator.ts
@@ -1,0 +1,58 @@
+import {resolver} from '@rocicorp/resolver';
+import {assert} from 'shared/src/asserts.js';
+import {MessagePort, Worker} from 'worker_threads';
+import {Replicator} from 'zero-cache/src/services/replicator/replicator.js';
+import {Service} from 'zero-cache/src/services/service.js';
+
+export type ReplicatorWorkerData = {
+  subscriberPorts: MessagePort[];
+};
+
+function validate(workerData: unknown): ReplicatorWorkerData {
+  // Sanity check that the WorkerThread is initialized with the expected data.
+  const data = workerData as ReplicatorWorkerData;
+  const {subscriberPorts} = data;
+  assert(Array.isArray(subscriberPorts));
+  subscriberPorts.forEach(port => assert(port instanceof MessagePort));
+  return data;
+}
+
+export function runAsWorker(
+  replicator: Replicator & Service,
+  parentPort: MessagePort | null,
+  workerData: ReplicatorWorkerData,
+): Promise<void> {
+  const {subscriberPorts} = validate(workerData);
+
+  // Respond to status requests from the parent (main) thread.
+  const statusPort = parentPort;
+  assert(statusPort);
+  statusPort.on('message', async () => {
+    const status = await replicator.status();
+    statusPort.postMessage(status);
+  });
+
+  // Start a subscription for the MessageChannel of every Syncer Thread.
+  for (const subscriber of subscriberPorts) {
+    const subscription = replicator.subscribe();
+    subscriber.once('close', () => subscription.cancel());
+
+    void (async () => {
+      for await (const msg of subscription) {
+        subscriber.postMessage(msg);
+      }
+      subscriber.close();
+    })();
+  }
+
+  return replicator.run();
+}
+
+export function getStatusFromWorker(
+  replicator: Worker | MessagePort, // MessagePort used in tests.
+): Promise<unknown> {
+  const {promise, resolve} = resolver<unknown>();
+  replicator.postMessage({});
+  replicator.once('message', resolve);
+  return promise;
+}


### PR DESCRIPTION
* `src/server/main.ts`: Entry point, main thread.
  * `src/services/dispatcher/dispatcher.ts`: Fastfy/web-server running in the main thread, dispatching requests to workers via [MessageChannels](https://nodejs.org/api/worker_threads.html#class-messagechannel)
  * Also loads the replicator thread as a Worker ...
* `src/server/replicator.ts`: Runs the replicator thread
   * `src/workers/replicator.ts`: Encapsulates inter-worker communication (MessageChannels) with the Replicator 

TODO: Setup for the syncer thread.