### PR TITLE
feat(zeppliear): `npm run start-zero-cache` for zeppliear

### DIFF
--- a/apps/zeppliear/README.md
+++ b/apps/zeppliear/README.md
@@ -8,19 +8,20 @@ Running at [zeppliear.vercel.app](https://zeppliear.vercel.app/).
 
 # To run fastify replicator and sync-runner locally
 
-update .env URIs to point to your internal ip address (169._._._ or 192._._._) do not use the 127.0.0.1 address
+add .env file:
 
 ```
-UPSTREAM_URI = "postgresql://user:password@add.your.host.ip:6432/postgres"
-SYNC_REPLICA_URI = "postgres://user:password@add.your.host.ip:6433/postgres"
-REPLICATOR_HOST="127.0.0.1:3001"
+UPSTREAM_URI = "postgresql://user:password@127.0.0.1:6432/postgres"
+REPLICA_ID = "r1"
+REPLICA_DB_FILE = "/tmp/sync-replica.db"
+LOG_LEVEL = "debug"
 ```
 
 Open two windows one with docker-compose and the other workers:
 
 ```
 cd docker && docker-compose up
-npm run start-workers
+npm run start-zero-cache
 ```
 
 # To run web locally

--- a/apps/zeppliear/package.json
+++ b/apps/zeppliear/package.json
@@ -15,9 +15,7 @@
     "publish-worker-sandbox": "npm run wrangler-sandbox -- publish",
     "worker-logs-sandbox": "npm run wrangler-sandbox -- tail",
     "worker-logs-prod": "npm run wrangler-prod -- tail",
-    "start-workers": "concurrently --kill-others 'npm run start-replicator' 'npm run start-service-runner'",
-    "start-replicator": "node --require 'dotenv/config' --loader ts-node/esm ../../packages/zero-cache/src/services/index-replicator.ts",
-    "start-service-runner": "node --require 'dotenv/config' --loader ts-node/esm ../../packages/zero-cache/src/services/index-service-runner.ts"
+    "start-zero-cache": "cd ../../packages/zero-cache && npm run start -- dotenv_config_path=../../apps/zeppliear/.env"
   },
   "dependencies": {
     "@emotion/react": "^11.8.2",

--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -4,8 +4,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start-replicator": "node --require 'dotenv/config' --loader ts-node/esm ./src/services/index-replicator.ts",
-    "start-service-runner": "node --require 'dotenv/config' --loader ts-node/esm ./src/services/index-service-runner.ts",
     "test": "vitest run",
     "test:watch": "vitest ",
     "check-types": "tsc --noEmit",
@@ -13,7 +11,7 @@
     "check-format": "prettier --check *",
     "lint": "eslint --ext .ts,.tsx,.js,.jsx src/",
     "local": "node --loader ts-node/esm tool/local.ts",
-    "start": "concurrently --kill-others 'npm run start-replicator' 'npm run start-service-runner'"
+    "start": "node --require 'dotenv/config' --no-warnings --loader ts-node/esm ./src/server/main.ts"
   },
   "dependencies": {
     "@drdgvhbh/postgres-error-codes": "^0.0.6",


### PR DESCRIPTION
Update the script and README for starting the new zero-cache implementation.

* currently, only replication works (and the `/status` handler). 
* view syncer stuff needs to be implemented / wired-up before "/sync" connections can be handled 

<img width="1031" alt="Screenshot 2024-08-22 at 09 35 29" src="https://github.com/user-attachments/assets/1e026a67-a842-41cc-a67c-5267c247b2f4">
