### PR TITLE
fix(zero-cache): use serialization transactions in schema migrations

### DIFF
--- a/packages/zero-cache/src/db/migration.test.ts
+++ b/packages/zero-cache/src/db/migration.test.ts
@@ -10,7 +10,7 @@ import {
   runSchemaMigrations,
 } from './migration.js';
 
-describe('schema/migration', () => {
+describe('db/migration', () => {
   const schemaName = '_zero';
   const debugName = 'debug-name';
 

--- a/packages/zero-cache/src/db/migration.ts
+++ b/packages/zero-cache/src/db/migration.ts
@@ -57,7 +57,7 @@ export async function runSchemaMigrations(
       `Checking schema for compatibility with ${debugName} at schema v${codeSchemaVersion}`,
     );
 
-    let meta = await db.begin(async tx => {
+    let meta = await db.begin('ISOLATION LEVEL SERIALIZABLE', async tx => {
       const meta = await getSchemaVersions(tx, schemaName);
       if (codeSchemaVersion < meta.minSafeRollbackVersion) {
         throw new Error(
@@ -85,7 +85,7 @@ export async function runSchemaMigrations(
             await migration.pre(log, db);
           }
 
-          meta = await db.begin(async tx => {
+          meta = await db.begin('ISOLATION LEVEL SERIALIZABLE', async tx => {
             // Fetch meta from within the transaction to make the migration atomic.
             let meta = await getSchemaVersions(tx, schemaName);
             if (meta.version < dest) {


### PR DESCRIPTION
mainly for peace of mind