### PR TITLE
feat(zero-cache): bring back the reusable part of the ServiceRunner

### DIFF
--- a/packages/zero-cache/src/services/runner.test.ts
+++ b/packages/zero-cache/src/services/runner.test.ts
@@ -15,10 +15,11 @@ describe('services/runner', () => {
       this.id = id;
     }
 
-    async run(): Promise<void> {
+    run(): Promise<void> {
       return this.resolver.promise;
     }
 
+    // eslint-disable-next-line require-await
     async stop(): Promise<void> {
       this.resolver.resolve();
     }
@@ -30,7 +31,7 @@ describe('services/runner', () => {
     (s: TestService) => s.valid,
   );
 
-  test('caching', async () => {
+  test('caching', () => {
     const s1 = runner.getService('foo');
     const s2 = runner.getService('bar');
     const s3 = runner.getService('foo');
@@ -57,7 +58,7 @@ describe('services/runner', () => {
     expect(s1).not.toBe(s2);
   });
 
-  test('validity', async () => {
+  test('validity', () => {
     const s1 = runner.getService('foo');
     s1.valid = false;
 

--- a/packages/zero-cache/src/services/runner.ts
+++ b/packages/zero-cache/src/services/runner.ts
@@ -1,6 +1,10 @@
 import {LogContext} from '@rocicorp/logger';
 import {Service} from './service.js';
 
+/**
+ * Manages the creation and lifecycle of objects that implement
+ * {@link Service}.
+ */
 export class ServiceRunner<S extends Service> {
   readonly #lc: LogContext;
   readonly #instances = new Map<string, S>();
@@ -17,6 +21,10 @@ export class ServiceRunner<S extends Service> {
     this.#isValid = isValid;
   }
 
+  /**
+   * Creates and runs the Service with the given `id`, returning
+   * an existing one if it is still running a valid.
+   */
   getService(id: string): S {
     const existing = this.#instances.get(id);
     if (existing && this.#isValid(existing)) {
@@ -28,7 +36,7 @@ export class ServiceRunner<S extends Service> {
       .run()
       .catch(e => {
         this.#lc.error?.(
-          `Error in run of ${service.constructor?.name} ${id}`,
+          `Error running ${service.constructor?.name} ${service.id}`,
           e,
         );
         this.#lc.info?.(e.toString());


### PR DESCRIPTION
i.e. [getService()](https://github.com/rocicorp/mono/blob/785b03cd45dc2c79a40c6c4eab138d5104c41440/packages/zero-cache/src/services/service-runner.ts#L141)

This will be used to compose parts of the upcoming Syncer worker implementation