### PR TITLE
fix(zero-cache): revert SERIALIZABLE for db migrations

### DIFF
--- a/packages/zero-cache/src/db/migration.ts
+++ b/packages/zero-cache/src/db/migration.ts
@@ -137,7 +137,7 @@ export type SchemaVersions = v.Infer<typeof schemaVersions>;
 
 // Exposed for tests
 export async function getSchemaVersions(
-  sql: postgres.TransactionSql,
+  sql: postgres.Sql,
   schemaName: string,
 ): Promise<SchemaVersions> {
   // Note: The `schema_meta.lock` column transparently ensures that at most one row exists.


### PR DESCRIPTION
It appears to interact poorly with multiple migrations trying to `create schema` even though the statement does have `if exists`.

```
thread=syncer threadID=9 initSchema=1pzupbsdlgo Migrating schema from v0 to v1
{
  severity_local: 'NOTICE',
  severity: 'NOTICE',
  code: '42P06',
  message: 'schema "cvr" already exists, skipping',
  file: 'schemacmds.c',
  line: '132',
  routine: 'CreateSchemaCommand'
}
{
  severity_local: 'NOTICE',
  severity: 'NOTICE',
  code: '42P06',
  message: 'schema "cvr" already exists, skipping',
  file: 'schemacmds.c',
  line: '132',
  routine: 'CreateSchemaCommand'
}
{
  severity_local: 'NOTICE',
  severity: 'NOTICE',
  code: '42P07',
  message: 'relation "SchemaVersions" already exists, skipping',
  file: 'parse_utilcmd.c',
  line: '207',
  routine: 'transformCreateStmt'
}
thread=syncer threadID=10 initSchema=qbeaf4w5ag Migrating schema from v0 to v1
thread=syncer threadID=4 initSchema=1wa83d0goe0 Error in ensureSchemaMigrated {"name":"PostgresError","message":"duplicate key value violates unique constraint \"pg_namespace_nspname_index\"","stack":"PostgresError: duplicate key value violates unique constraint \"pg_namespace_nspname_index\"\n    at ErrorResponse (file:///Users/ocean/roci/mono/node_modules/postgres/src/connection.js:788:26)\n    at handle (file:///Users/ocean/roci/mono/node_modules/postgres/src/connection.js:474:6)\n    at Socket.data (file:///Users/ocean/roci/mono/node_modules/postgres/src/connection.js:315:9)\n    at Socket.emit (node:events:513:28)\n    at Socket.emit (node:domain:489:12)\n    at addChunk (node:internal/streams/readable:324:12)\n    at readableAddChunk (node:internal/streams/readable:297:9)\n    at Socket.Readable.push (node:internal/streams/readable:234:10)\n    at TCP.onStreamRead (node:internal/stream_base_commons:190:23)\n    at cachedError (file:///Users/ocean/roci/mono/node_modules/postgres/src/query.js:170:23)\n    at new Query (file:///Users/ocean/roci/mono/node_modules/postgres/src/query.js:36:24)\n    at sql (file:///Users/ocean/roci/mono/node_modules/postgres/src/index.js:112:11)\n    at getSchemaVersions (file:///Users/ocean/roci/mono/packages/zero-cache/src/db/migration.ts:144:28)"}
file:///Users/ocean/roci/mono/node_modules/postgres/src/connection.js:788
    const error = Errors.postgres(parseError(x))
                         ^
Error [PostgresError]: duplicate key value violates unique constraint "pg_namespace_nspname_index"
    at ErrorResponse (file:///Users/ocean/roci/mono/node_modules/postgres/src/connection.js:788:26)
    at handle (file:///Users/ocean/roci/mono/node_modules/postgres/src/connection.js:474:6)
    at Socket.data (file:///Users/ocean/roci/mono/node_modules/postgres/src/connection.js:315:9)
    at Socket.emit (node:events:513:28)
    at Socket.emit (node:domain:489:12)
    at addChunk (node:internal/streams/readable:324:12)
    at readableAddChunk (node:internal/streams/readable:297:9)
    at Socket.Readable.push (node:internal/streams/readable:234:10)
    at TCP.onStreamRead (node:internal/stream_base_commons:190:23)
    at cachedError (file:///Users/ocean/roci/mono/node_modules/postgres/src/query.js:170:23)
    at new Query (file:///Users/ocean/roci/mono/node_modules/postgres/src/query.js:36:24)
    at sql (file:///Users/ocean/roci/mono/node_modules/postgres/src/index.js:112:11)
    at getSchemaVersions (file:///Users/ocean/roci/mono/packages/zero-cache/src/db/migration.ts:144:28) {
  severity_local: 'ERROR',
  severity: 'ERROR',
  code: '23505',
  detail: 'Key (nspname)=(cvr) already exists.',
  schema_name: 'pg_catalog',
  table_name: 'pg_namespace',
  constraint_name: 'pg_namespace_nspname_index',
  file: 'nbtinsert.c',
  line: '666',
  routine: '_bt_check_unique'
}
```