### PR TITLE
chore(zql): Improve buildPipeline API

### DIFF
--- a/packages/zql/src/zql/builder/builder.test.ts
+++ b/packages/zql/src/zql/builder/builder.test.ts
@@ -43,16 +43,17 @@ function testSources() {
 
 test('source-only', () => {
   const {sources, getSource} = testSources();
-  const sink = buildPipeline(
-    {
-      table: 'users',
-      orderBy: [['name', 'asc']],
-    },
-    {
-      createSink: input => new Catch(input),
-      getSource,
-      createStorage: () => new MemoryStorage(),
-    },
+  const sink = new Catch(
+    buildPipeline(
+      {
+        table: 'users',
+        orderBy: [['name', 'asc']],
+      },
+      {
+        getSource,
+        createStorage: () => new MemoryStorage(),
+      },
+    ),
   );
 
   expect(sink.hydrate()).toEqual([
@@ -76,22 +77,23 @@ test('source-only', () => {
 
 test('filter', () => {
   const {sources, getSource} = testSources();
-  const sink = buildPipeline(
-    {
-      table: 'users',
-      orderBy: [['id', 'desc']],
-      where: {
-        type: 'simple',
-        field: 'name',
-        op: '>=',
-        value: 'c',
+  const sink = new Catch(
+    buildPipeline(
+      {
+        table: 'users',
+        orderBy: [['id', 'desc']],
+        where: {
+          type: 'simple',
+          field: 'name',
+          op: '>=',
+          value: 'c',
+        },
       },
-    },
-    {
-      createSink: input => new Catch(input),
-      getSource,
-      createStorage: () => new MemoryStorage(),
-    },
+      {
+        getSource,
+        createStorage: () => new MemoryStorage(),
+      },
+    ),
   );
 
   expect(sink.hydrate()).toEqual([
@@ -119,30 +121,31 @@ test('filter', () => {
 
 test('self-join', () => {
   const {sources, getSource} = testSources();
-  const sink = buildPipeline(
-    {
-      table: 'users',
-      orderBy: [['id', 'asc']],
-      subqueries: [
-        {
-          correlation: {
-            parentField: 'recruiterID',
-            op: '=',
-            childField: 'id',
+  const sink = new Catch(
+    buildPipeline(
+      {
+        table: 'users',
+        orderBy: [['id', 'asc']],
+        subqueries: [
+          {
+            correlation: {
+              parentField: 'recruiterID',
+              op: '=',
+              childField: 'id',
+            },
+            subquery: {
+              table: 'users',
+              alias: 'recruiter',
+              orderBy: [['id', 'asc']],
+            },
           },
-          subquery: {
-            table: 'users',
-            alias: 'recruiter',
-            orderBy: [['id', 'asc']],
-          },
-        },
-      ],
-    },
-    {
-      createSink: input => new Catch(input),
-      getSource,
-      createStorage: () => new MemoryStorage(),
-    },
+        ],
+      },
+      {
+        getSource,
+        createStorage: () => new MemoryStorage(),
+      },
+    ),
   );
 
   expect(sink.hydrate()).toEqual([
@@ -282,53 +285,54 @@ test('self-join', () => {
 
 test('multi-join', () => {
   const {sources, getSource} = testSources();
-  const sink = buildPipeline(
-    {
-      table: 'users',
-      orderBy: [['id', 'asc']],
-      where: {
-        type: 'simple',
-        field: 'id',
-        op: '<=',
-        value: 3,
-      },
-      subqueries: [
-        {
-          correlation: {
-            parentField: 'id',
-            op: '=',
-            childField: 'userID',
-          },
-          subquery: {
-            table: 'userStates',
-            alias: 'userStates',
-            orderBy: [
-              ['userID', 'asc'],
-              ['stateCode', 'asc'],
-            ],
-            subqueries: [
-              {
-                correlation: {
-                  parentField: 'stateCode',
-                  op: '=',
-                  childField: 'code',
-                },
-                subquery: {
-                  table: 'states',
-                  alias: 'states',
-                  orderBy: [['code', 'asc']],
-                },
-              },
-            ],
-          },
+  const sink = new Catch(
+    buildPipeline(
+      {
+        table: 'users',
+        orderBy: [['id', 'asc']],
+        where: {
+          type: 'simple',
+          field: 'id',
+          op: '<=',
+          value: 3,
         },
-      ],
-    },
-    {
-      createSink: input => new Catch(input),
-      getSource,
-      createStorage: () => new MemoryStorage(),
-    },
+        subqueries: [
+          {
+            correlation: {
+              parentField: 'id',
+              op: '=',
+              childField: 'userID',
+            },
+            subquery: {
+              table: 'userStates',
+              alias: 'userStates',
+              orderBy: [
+                ['userID', 'asc'],
+                ['stateCode', 'asc'],
+              ],
+              subqueries: [
+                {
+                  correlation: {
+                    parentField: 'stateCode',
+                    op: '=',
+                    childField: 'code',
+                  },
+                  subquery: {
+                    table: 'states',
+                    alias: 'states',
+                    orderBy: [['code', 'asc']],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        getSource,
+        createStorage: () => new MemoryStorage(),
+      },
+    ),
   );
 
   expect(sink.hydrate()).toEqual([

--- a/packages/zql/src/zql/ivm2/catch.ts
+++ b/packages/zql/src/zql/ivm2/catch.ts
@@ -12,6 +12,7 @@ export class Catch implements Output {
 
   constructor(input: Input) {
     this.#input = input;
+    this.#input.setOutput(this);
   }
 
   hydrate(req: HydrateRequest = {}) {

--- a/packages/zql/src/zql/ivm2/connector.ts
+++ b/packages/zql/src/zql/ivm2/connector.ts
@@ -20,6 +20,7 @@ export class Connector implements Operator {
 
   constructor(input: Input) {
     this.#input = input;
+    this.#input.setOutput(this);
   }
 
   setOutput(output: Output) {

--- a/packages/zql/src/zql/ivm2/filter.test.ts
+++ b/packages/zql/src/zql/ivm2/filter.test.ts
@@ -11,10 +11,7 @@ test('basics', () => {
 
   const connector = ms.connect([['a', 'asc']]);
   const filter = new Filter(connector, row => row.b === 'foo');
-  connector.setOutput(filter);
-
   const out = new Catch(filter);
-  filter.setOutput(out);
 
   expect(out.hydrate()).toEqual([
     {row: {a: 1, b: 'foo'}, relationships: {}},

--- a/packages/zql/src/zql/ivm2/filter.ts
+++ b/packages/zql/src/zql/ivm2/filter.ts
@@ -24,6 +24,7 @@ export class Filter implements Operator {
   constructor(input: Input, predicate: (row: Row) => boolean) {
     this.#input = input;
     this.#predicate = predicate;
+    this.#input.setOutput(this);
   }
 
   setOutput(output: Output) {

--- a/packages/zql/src/zql/ivm2/join.fetch.test.ts
+++ b/packages/zql/src/zql/ivm2/join.fetch.test.ts
@@ -702,9 +702,7 @@ function fetchTest(t: FetchTest) {
     for (const row of rows) {
       source.push({type: 'add', row});
     }
-    const connector = source.connect(ordering);
-    const snitch = new Snitch(connector, String(i), log);
-    connector.setOutput(snitch);
+    const snitch = new Snitch(source.connect(ordering), String(i), log);
     return {
       source,
       snitch,
@@ -731,8 +729,6 @@ function fetchTest(t: FetchTest) {
       info.childKey,
       info.relationshipName,
     );
-    parent.setOutput(join);
-    child.setOutput(join);
     joins[i] = {
       join,
       storage,
@@ -746,7 +742,6 @@ function fetchTest(t: FetchTest) {
     // left-to-right.
     const finalJoin = joins[0];
     const c = new Catch(finalJoin.join);
-    finalJoin.join.setOutput(c);
 
     const r = c[fetchType]();
 

--- a/packages/zql/src/zql/ivm2/join.push.test.ts
+++ b/packages/zql/src/zql/ivm2/join.push.test.ts
@@ -904,9 +904,7 @@ function pushTest(t: PushTest) {
     for (const row of hydrate) {
       source.push({type: 'add', row});
     }
-    const connector = source.connect(ordering);
-    const snitch = new Snitch(connector, String(i), log);
-    connector.setOutput(snitch);
+    const snitch = new Snitch(source.connect(ordering), String(i), log);
     return {
       source,
       snitch,
@@ -933,8 +931,6 @@ function pushTest(t: PushTest) {
       info.childKey,
       info.relationshipName,
     );
-    parent.setOutput(join);
-    child.setOutput(join);
     joins[i] = {
       join,
       storage,
@@ -945,7 +941,6 @@ function pushTest(t: PushTest) {
   // left-to-right.
   const finalJoin = joins[0];
   const c = new Catch(finalJoin.join);
-  finalJoin.join.setOutput(c);
 
   c.hydrate();
   log.length = 0;

--- a/packages/zql/src/zql/ivm2/join.ts
+++ b/packages/zql/src/zql/ivm2/join.ts
@@ -41,12 +41,16 @@ export class Join implements Operator {
     relationshipName: string,
   ) {
     assert(parent !== child, 'Parent and child must be different operators');
+
     this.#parent = parent;
     this.#child = child;
     this.#storage = storage;
     this.#parentKey = parentKey;
     this.#childKey = childKey;
     this.#relationshipName = relationshipName;
+
+    this.#parent.setOutput(this);
+    this.#child.setOutput(this);
   }
 
   setOutput(output: Output): void {

--- a/packages/zql/src/zql/ivm2/memory-source.test.ts
+++ b/packages/zql/src/zql/ivm2/memory-source.test.ts
@@ -19,7 +19,6 @@ test('schema', () => {
     const ms = new MemorySource({a: 'string'}, ['a']);
     const connector = ms.connect(order);
     const out = new Catch(connector);
-    connector.setOutput(out);
     return connector.getSchema(out).compareRows;
   });
 });
@@ -30,7 +29,6 @@ test('indexes get cleaned up when not needed', () => {
 
   const conn1 = ms.connect([['b', 'asc']]);
   const c1 = new Catch(conn1);
-  conn1.setOutput(c1);
   c1.hydrate();
   expect(ms.getIndexKeys()).toEqual([
     JSON.stringify([['a', 'asc']]),
@@ -39,7 +37,6 @@ test('indexes get cleaned up when not needed', () => {
 
   const conn2 = ms.connect([['b', 'asc']]);
   const c2 = new Catch(conn2);
-  conn2.setOutput(c2);
   c2.hydrate();
   expect(ms.getIndexKeys()).toEqual([
     JSON.stringify([['a', 'asc']]),
@@ -48,7 +45,6 @@ test('indexes get cleaned up when not needed', () => {
 
   const conn3 = ms.connect([['c', 'asc']]);
   const c3 = new Catch(conn3);
-  conn3.setOutput(c3);
   c3.hydrate();
   expect(ms.getIndexKeys()).toEqual([
     JSON.stringify([['a', 'asc']]),

--- a/packages/zql/src/zql/ivm2/snitch.ts
+++ b/packages/zql/src/zql/ivm2/snitch.ts
@@ -25,6 +25,8 @@ export class Snitch implements Operator {
     this.#input = input;
     this.#name = name;
     this.log = log;
+
+    this.#input.setOutput(this);
   }
 
   setOutput(output: Output) {

--- a/packages/zql/src/zql/ivm2/test/source-cases.ts
+++ b/packages/zql/src/zql/ivm2/test/source-cases.ts
@@ -36,6 +36,7 @@ class OverlaySpy implements Output {
 
   constructor(input: Input) {
     this.#input = input;
+    this.#input.setOutput(this);
   }
 
   fetch(req: FetchRequest) {
@@ -53,9 +54,7 @@ const cases = {
     for (const m of ['hydrate', 'fetch'] as const) {
       const sort = [['a', 'asc']] as const;
       const ms = createSource('table', {a: 'number'}, ['a']);
-      const connector = ms.connect(sort);
-      const out = new Catch(connector);
-      connector.setOutput(out);
+      const out = new Catch(ms.connect(sort));
       expect(out[m]()).toEqual([]);
 
       ms.push({type: 'add', row: {a: 3}});
@@ -88,9 +87,7 @@ const cases = {
         },
         ['a'],
       );
-      const connector = ms.connect(sort);
-      const out = new Catch(connector);
-      connector.setOutput(out);
+      const out = new Catch(ms.connect(sort));
       ms.push({type: 'add', row: {a: 3, b: true, c: 1, d: null}});
       ms.push({type: 'add', row: {a: 1, b: true, c: 2, d: null}});
       ms.push({type: 'add', row: {a: 2, b: false, c: null, d: null}});
@@ -142,9 +139,7 @@ const cases = {
       },
       ['a'],
     );
-    const connector = ms.connect(sort);
-    const out = new Catch(connector);
-    connector.setOutput(out);
+    const out = new Catch(ms.connect(sort));
 
     expect(out.fetch({start: {row: {a: 2}, basis: 'before'}})).toEqual(
       asNodes([]),
@@ -191,9 +186,7 @@ const cases = {
   'push': (createSource: SourceFactory) => {
     const sort = [['a', 'asc']] as const;
     const ms = createSource('table', {a: 'number'}, ['a']);
-    const connector = ms.connect(sort);
-    const out = new Catch(connector);
-    connector.setOutput(out);
+    const out = new Catch(ms.connect(sort));
 
     expect(out.pushes).toEqual([]);
 
@@ -246,15 +239,9 @@ const cases = {
 
     const sort = [['a', 'asc']] as const;
     const ms = createSource('table', {a: 'number'}, ['a']);
-    const c1 = ms.connect(sort);
-    const c2 = ms.connect(sort);
-    const c3 = ms.connect(sort);
-    const o1 = new OverlaySpy(c1);
-    const o2 = new OverlaySpy(c2);
-    const o3 = new OverlaySpy(c3);
-    c1.setOutput(o1);
-    c2.setOutput(o2);
-    c3.setOutput(o3);
+    const o1 = new OverlaySpy(ms.connect(sort));
+    const o2 = new OverlaySpy(ms.connect(sort));
+    const o3 = new OverlaySpy(ms.connect(sort));
 
     function fetchAll() {
       o1.fetch({});
@@ -561,9 +548,7 @@ const cases = {
       for (const row of c.startData) {
         ms.push({type: 'add', row});
       }
-      const connector = ms.connect(sort);
-      const out = new OverlaySpy(connector);
-      connector.setOutput(out);
+      const out = new OverlaySpy(ms.connect(sort));
       out.onPush = () =>
         out.fetch({
           start: c.start,
@@ -620,9 +605,7 @@ const cases = {
       for (const row of c.startData) {
         ms.push({type: 'add', row});
       }
-      const connector = ms.connect(sort);
-      const out = new OverlaySpy(connector);
-      connector.setOutput(out);
+      const out = new OverlaySpy(ms.connect(sort));
       out.onPush = () =>
         out.fetch({
           constraint: c.constraint,
@@ -647,12 +630,8 @@ const cases = {
       },
       ['a'],
     );
-    const c1 = ms.connect(sort1);
-    const c2 = ms.connect(sort2);
-    const out1 = new Catch(c1);
-    const out2 = new Catch(c2);
-    c1.setOutput(out1);
-    c2.setOutput(out2);
+    const out1 = new Catch(ms.connect(sort1));
+    const out2 = new Catch(ms.connect(sort2));
 
     ms.push({type: 'add', row: {a: 2, b: 3}});
     ms.push({type: 'add', row: {a: 1, b: 2}});


### PR DESCRIPTION
Now that Source has its own interface, setOutput can be part of Input. This allows:

(a) buildPipeline to treat the whole chain generically, as it was in ivm1.

(b) Each operator can call setOutput() on the prior in its constructor. Not sure what this means for OR, but we can cross that bridge when we get there. I suspect the `Connector` trick might come in handy again.

(c) The interface to buildPipeline() can be prettier - we can just return the last operator and let user build their sink, rather than requiring a factory.