### PR TITLE
chore(zero-cache): use an in-memory db for most unit tests

### DIFF
--- a/packages/zero-cache/src/db/statements.test.ts
+++ b/packages/zero-cache/src/db/statements.test.ts
@@ -1,20 +1,15 @@
-import {afterEach, beforeEach, describe, expect, test} from 'vitest';
-import {DbFile, expectTables} from '../test/lite.js';
+import Database from 'better-sqlite3';
+import {beforeEach, describe, expect, test} from 'vitest';
+import {expectTables} from '../test/lite.js';
 import {StatementRunner} from './statements.js';
 
 describe('db/statements', () => {
-  let dbFile: DbFile;
   let db: StatementRunner;
 
   beforeEach(() => {
-    dbFile = new DbFile('statements-test');
-    const conn = dbFile.connect();
+    const conn = new Database(':memory:');
     conn.exec('CREATE TABLE foo(id INT PRIMARY KEY)');
     db = new StatementRunner(conn);
-  });
-
-  afterEach(async () => {
-    await dbFile.unlink();
   });
 
   test('statement caching', () => {

--- a/packages/zero-cache/src/services/replicator/incremental-sync.message-processor.test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.message-processor.test.ts
@@ -1,10 +1,10 @@
 import {LogContext} from '@rocicorp/logger';
-import {Database} from 'better-sqlite3';
+import Database from 'better-sqlite3';
 import type {Pgoutput} from 'pg-logical-replication';
 import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
-import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {beforeEach, describe, expect, test} from 'vitest';
 import {StatementRunner} from 'zero-cache/src/db/statements.js';
-import {DbFile, expectTables} from 'zero-cache/src/test/lite.js';
+import {expectTables} from 'zero-cache/src/test/lite.js';
 import {initChangeLog} from './schema/change-log.js';
 import {
   getSubscriptionState,
@@ -14,13 +14,11 @@ import {createMessageProcessor, ReplicationMessages} from './test-utils.js';
 
 describe('replicator/message-processor', () => {
   let lc: LogContext;
-  let replicaFile: DbFile;
-  let replica: Database;
+  let replica: Database.Database;
 
   beforeEach(() => {
     lc = createSilentLogContext();
-    replicaFile = new DbFile('message_processor_test_replica');
-    replica = replicaFile.connect();
+    replica = new Database(':memory:');
 
     replica.exec(`
     CREATE TABLE "foo" (
@@ -32,10 +30,6 @@ describe('replicator/message-processor', () => {
 
     initReplicationState(replica, ['zero_data', 'zero_metadata'], '0/2');
     initChangeLog(replica);
-  });
-
-  afterEach(async () => {
-    await replicaFile.unlink();
   });
 
   type Case = {

--- a/packages/zero-cache/src/services/replicator/initial-sync.test.ts
+++ b/packages/zero-cache/src/services/replicator/initial-sync.test.ts
@@ -1,11 +1,7 @@
-import {Database} from 'better-sqlite3';
+import Database from 'better-sqlite3';
 import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
-import {
-  DbFile,
-  expectTables,
-  initDB as initLiteDB,
-} from 'zero-cache/src/test/lite.js';
+import {expectTables, initDB as initLiteDB} from 'zero-cache/src/test/lite.js';
 import {PostgresDB} from 'zero-cache/src/types/pg.js';
 import {
   dropReplicationSlot,
@@ -374,19 +370,16 @@ describe('replicator/initial-sync', () => {
   ];
 
   let upstream: PostgresDB;
-  let replicaFile: DbFile;
-  let replica: Database;
+  let replica: Database.Database;
 
   beforeEach(async () => {
     upstream = await testDBs.create('initial_sync_upstream');
-    replicaFile = new DbFile('initial_sync_replica');
-    replica = replicaFile.connect();
+    replica = new Database(':memory:');
   });
 
   afterEach(async () => {
     await dropReplicationSlot(upstream, replicationSlot(REPLICA_ID));
     await testDBs.drop(upstream);
-    await replicaFile.unlink();
   });
 
   for (const c of cases) {

--- a/packages/zero-cache/src/services/replicator/initial-sync.validation.test.ts
+++ b/packages/zero-cache/src/services/replicator/initial-sync.validation.test.ts
@@ -1,7 +1,6 @@
-import {Database} from 'better-sqlite3';
+import Database from 'better-sqlite3';
 import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
-import {DbFile} from 'zero-cache/src/test/lite.js';
 import {PostgresDB} from 'zero-cache/src/types/pg.js';
 import {getConnectionURI, initDB, testDBs} from '../../test/db.js';
 import {initialSync} from './initial-sync.js';
@@ -10,18 +9,15 @@ const REPLICA_ID = 'initial_sync_validation_test_id';
 
 describe('replicator/initial-sync-validation', () => {
   let upstream: PostgresDB;
-  let replicaFile: DbFile;
-  let replica: Database;
+  let replica: Database.Database;
 
   beforeEach(async () => {
     upstream = await testDBs.create('initial_sync_validation_upstream');
-    replicaFile = new DbFile('initial_sync_validation_replica');
-    replica = replicaFile.connect();
+    replica = new Database(':memory:');
   });
 
   afterEach(async () => {
     await testDBs.drop(upstream);
-    await replicaFile.unlink();
   });
 
   type InvalidUpstreamCase = {

--- a/packages/zero-cache/src/services/replicator/schema/change-log.test.ts
+++ b/packages/zero-cache/src/services/replicator/schema/change-log.test.ts
@@ -1,6 +1,7 @@
-import {afterEach, beforeEach, describe, test} from 'vitest';
+import Database from 'better-sqlite3';
+import {beforeEach, describe, test} from 'vitest';
 import {StatementRunner} from 'zero-cache/src/db/statements.js';
-import {DbFile, expectTables} from 'zero-cache/src/test/lite.js';
+import {expectTables} from 'zero-cache/src/test/lite.js';
 import {
   initChangeLog,
   logDeleteOp,
@@ -9,18 +10,12 @@ import {
 } from './change-log.js';
 
 describe('replicator/schema/change-log', () => {
-  let dbFile: DbFile;
   let db: StatementRunner;
 
   beforeEach(() => {
-    dbFile = new DbFile('change_log_test');
-    const conn = dbFile.connect();
+    const conn = new Database(':memory:');
     initChangeLog(conn);
     db = new StatementRunner(conn);
-  });
-
-  afterEach(async () => {
-    await dbFile.unlink();
   });
 
   test('replicator/schema/change-log', () => {

--- a/packages/zero-cache/src/services/replicator/schema/replication-state.test.ts
+++ b/packages/zero-cache/src/services/replicator/schema/replication-state.test.ts
@@ -1,6 +1,7 @@
-import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import Database from 'better-sqlite3';
+import {beforeEach, describe, expect, test} from 'vitest';
 import {StatementRunner} from 'zero-cache/src/db/statements.js';
-import {DbFile, expectTables} from 'zero-cache/src/test/lite.js';
+import {expectTables} from 'zero-cache/src/test/lite.js';
 import {
   getReplicationVersions,
   getSubscriptionState,
@@ -9,17 +10,11 @@ import {
 } from './replication-state.js';
 
 describe('replicator/schema/replication-state', () => {
-  let dbFile: DbFile;
   let db: StatementRunner;
 
   beforeEach(() => {
-    dbFile = new DbFile('replication_state_test');
-    db = new StatementRunner(dbFile.connect());
+    db = new StatementRunner(new Database(':memory:'));
     initReplicationState(db.db, ['zero_data', 'zero_metadata'], '0/0a');
-  });
-
-  afterEach(async () => {
-    await dbFile.unlink();
   });
 
   test('initial replication state', () => {

--- a/packages/zero-cache/src/services/replicator/tables/create.test.ts
+++ b/packages/zero-cache/src/services/replicator/tables/create.test.ts
@@ -1,8 +1,7 @@
-import {Database} from 'better-sqlite3';
+import Database from 'better-sqlite3';
 import type postgres from 'postgres';
 import {afterAll, afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {stripCommentsAndWhitespace} from 'zero-cache/src/db/query-test-util.js';
-import {DbFile} from 'zero-cache/src/test/lite.js';
 import {testDBs} from '../../../test/db.js';
 import {createTableStatement} from './create.js';
 import {listTables} from './list.js';
@@ -347,16 +346,10 @@ describe('tables/create', () => {
   });
 
   describe('sqlite', () => {
-    let dbFile: DbFile;
-    let db: Database;
+    let db: Database.Database;
 
     beforeEach(() => {
-      dbFile = new DbFile('create-tables');
-      db = dbFile.connect();
-    });
-
-    afterEach(async () => {
-      await dbFile.unlink();
+      db = new Database(':memory:');
     });
 
     for (const c of cases) {

--- a/packages/zero-cache/src/services/replicator/tables/list.test.ts
+++ b/packages/zero-cache/src/services/replicator/tables/list.test.ts
@@ -1,6 +1,5 @@
-import type {Database} from 'better-sqlite3';
-import {afterEach, beforeEach, describe, expect, test} from 'vitest';
-import {DbFile} from 'zero-cache/src/test/lite.js';
+import Database from 'better-sqlite3';
+import {describe, expect, test} from 'vitest';
 import {listTables} from './list.js';
 import {TableSpec} from './specs.js';
 
@@ -158,20 +157,9 @@ describe('tables/list', () => {
     },
   ];
 
-  let dbFile: DbFile;
-  let db: Database;
-
-  beforeEach(() => {
-    dbFile = new DbFile('list-tables');
-    db = dbFile.connect();
-  });
-
-  afterEach(async () => {
-    await dbFile.unlink();
-  });
-
   for (const c of cases) {
     test(c.name, () => {
+      const db = new Database(':memory:');
       db.exec(c.setupQuery);
 
       const tables = listTables(db);


### PR DESCRIPTION
Use an in-memory SQLite instance for unit tests that don't exercise file functionality.