### PR TITLE
feat(zero): Add a View class.

### DIFF
--- a/packages/zql/src/zql/ivm2/join.ts
+++ b/packages/zql/src/zql/ivm2/join.ts
@@ -59,7 +59,15 @@ export class Join implements Input {
   }
 
   getSchema(): Schema {
-    return this.#parent.getSchema();
+    const parentSchema = this.#parent.getSchema();
+    const childSchema = this.#child.getSchema();
+    return {
+      ...parentSchema,
+      relationships: {
+        ...parentSchema.relationships,
+        [this.#relationshipName]: childSchema,
+      },
+    };
   }
 
   *fetch(req: FetchRequest): Stream<Node> {

--- a/packages/zql/src/zql/ivm2/memory-source.ts
+++ b/packages/zql/src/zql/ivm2/memory-source.ts
@@ -68,6 +68,7 @@ export class MemorySource implements Source {
       columns: this.#columns,
       primaryKey: this.#primaryKeys,
       compareRows: makeComparator(connection.sort),
+      relationships: {},
     };
   }
 

--- a/packages/zql/src/zql/ivm2/schema.ts
+++ b/packages/zql/src/zql/ivm2/schema.ts
@@ -10,4 +10,6 @@ export type Schema = {
   // relationships: Record<string, Schema>;
   // Compares two rows in the output of an operator.
   compareRows: (r1: Row, r2: Row) => number;
+
+  relationships: Record<string, Schema>;
 };

--- a/packages/zql/src/zql/ivm2/stopable-iterator.ts
+++ b/packages/zql/src/zql/ivm2/stopable-iterator.ts
@@ -1,0 +1,23 @@
+/**
+ * An iterator that can be stopped. Useful if the data backing the iterator
+ * changes and you don't want clients to be able to keep iterating.
+ */
+export class StoppableIterator<T> {
+  #iterator: Iterator<T>;
+  #stopped = false;
+
+  constructor(iterator: Iterator<T>) {
+    this.#iterator = iterator;
+  }
+
+  next() {
+    if (this.#stopped) {
+      throw new Error('Iterator has been stopped');
+    }
+    return this.#iterator.next();
+  }
+
+  stop() {
+    this.#stopped = true;
+  }
+}

--- a/packages/zql/src/zql/ivm2/view.test.ts
+++ b/packages/zql/src/zql/ivm2/view.test.ts
@@ -1,0 +1,364 @@
+import {MemorySource} from './memory-source.js';
+import {Entry, View} from './view.js';
+import {expect, test} from 'vitest';
+import {Join} from './join.js';
+import {MemoryStorage} from './memory-storage.js';
+
+test('basics', () => {
+  const ms = new MemorySource({a: 'number', b: 'string'}, ['a']);
+  ms.push({row: {a: 1, b: 'a'}, type: 'add'});
+  ms.push({row: {a: 2, b: 'b'}, type: 'add'});
+
+  const view = new View(ms.connect([['b', 'asc']]));
+
+  let callCount = 0;
+  let data: Entry[] = [];
+  const listener = (d: Iterable<Entry>) => {
+    callCount++;
+    data = [...d];
+  };
+  view.addListener(listener);
+
+  view.hydrate();
+  expect(data).toEqual([
+    {a: 1, b: 'a'},
+    {a: 2, b: 'b'},
+  ]);
+
+  expect(callCount).toBe(1);
+  expect(() => view.hydrate()).toThrow("Can't hydrate twice");
+
+  ms.push({row: {a: 3, b: 'c'}, type: 'add'});
+  expect(callCount).toBe(2);
+  expect(data).toEqual([
+    {a: 1, b: 'a'},
+    {a: 2, b: 'b'},
+    {a: 3, b: 'c'},
+  ]);
+
+  ms.push({row: {a: 2, b: 'b'}, type: 'remove'});
+  expect(callCount).toBe(3);
+  expect(data).toEqual([
+    {a: 1, b: 'a'},
+    {a: 3, b: 'c'},
+  ]);
+
+  view.removeListener(listener);
+  ms.push({row: {a: 1, b: 'a'}, type: 'remove'});
+  expect(callCount).toBe(3);
+
+  view.addListener(listener);
+  ms.push({row: {a: 3, b: 'c'}, type: 'remove'});
+  expect(callCount).toBe(4);
+  expect(data).toEqual([]);
+});
+
+test('tree', () => {
+  const ms = new MemorySource({id: 'number', name: 'string'}, ['id']);
+  ms.push({
+    type: 'add',
+    row: {id: 1, name: 'foo', childID: 2},
+  });
+  ms.push({
+    type: 'add',
+    row: {id: 2, name: 'foobar', childID: null},
+  });
+  ms.push({
+    type: 'add',
+    row: {id: 3, name: 'mon', childID: 4},
+  });
+  ms.push({
+    type: 'add',
+    row: {id: 4, name: 'monkey', childID: null},
+  });
+
+  const join = new Join(
+    ms.connect([['name', 'asc']]),
+    ms.connect([['name', 'desc']]),
+    new MemoryStorage(),
+    'childID',
+    'id',
+    'children',
+  );
+
+  const expand = (entries: Iterable<Entry>): Entry[] =>
+    [...entries].map(e =>
+      e.children
+        ? {
+            ...e,
+            children: expand(e.children as Iterable<Entry>),
+          }
+        : e,
+    );
+
+  const view = new View(join);
+  let data: Entry[] = [];
+  const listener = (d: Iterable<Entry>) => {
+    data = expand(d);
+  };
+  view.addListener(listener);
+
+  view.hydrate();
+  expect(data).toEqual([
+    {
+      id: 1,
+      name: 'foo',
+      childID: 2,
+      children: [
+        {
+          id: 2,
+          name: 'foobar',
+          childID: null,
+        },
+      ],
+    },
+    {
+      id: 2,
+      name: 'foobar',
+      childID: null,
+      children: [],
+    },
+    {
+      id: 3,
+      name: 'mon',
+      childID: 4,
+      children: [
+        {
+          id: 4,
+          name: 'monkey',
+          childID: null,
+        },
+      ],
+    },
+    {
+      id: 4,
+      name: 'monkey',
+      childID: null,
+      children: [],
+    },
+  ]);
+
+  // add parent with child
+  ms.push({type: 'add', row: {id: 5, name: 'chocolate', childID: 2}});
+  expect(data).toEqual([
+    {
+      id: 5,
+      name: 'chocolate',
+      childID: 2,
+      children: [
+        {
+          id: 2,
+          name: 'foobar',
+          childID: null,
+        },
+      ],
+    },
+    {
+      id: 1,
+      name: 'foo',
+      childID: 2,
+      children: [
+        {
+          id: 2,
+          name: 'foobar',
+          childID: null,
+        },
+      ],
+    },
+    {
+      id: 2,
+      name: 'foobar',
+      childID: null,
+      children: [],
+    },
+    {
+      id: 3,
+      name: 'mon',
+      childID: 4,
+      children: [
+        {
+          id: 4,
+          name: 'monkey',
+          childID: null,
+        },
+      ],
+    },
+    {
+      id: 4,
+      name: 'monkey',
+      childID: null,
+      children: [],
+    },
+  ]);
+
+  // remove parent with child
+  ms.push({type: 'remove', row: {id: 5, name: 'chocolate', childID: 2}});
+  expect(data).toEqual([
+    {
+      id: 1,
+      name: 'foo',
+      childID: 2,
+      children: [
+        {
+          id: 2,
+          name: 'foobar',
+          childID: null,
+        },
+      ],
+    },
+    {
+      id: 2,
+      name: 'foobar',
+      childID: null,
+      children: [],
+    },
+    {
+      id: 3,
+      name: 'mon',
+      childID: 4,
+      children: [
+        {
+          id: 4,
+          name: 'monkey',
+          childID: null,
+        },
+      ],
+    },
+    {
+      id: 4,
+      name: 'monkey',
+      childID: null,
+      children: [],
+    },
+  ]);
+
+  // remove just child
+  ms.push({
+    type: 'remove',
+    row: {
+      id: 2,
+      name: 'foobar',
+      childID: null,
+    },
+  });
+  expect(data).toEqual([
+    {
+      id: 1,
+      name: 'foo',
+      childID: 2,
+      children: [],
+    },
+    {
+      id: 3,
+      name: 'mon',
+      childID: 4,
+      children: [
+        {
+          id: 4,
+          name: 'monkey',
+          childID: null,
+        },
+      ],
+    },
+    {
+      id: 4,
+      name: 'monkey',
+      childID: null,
+      children: [],
+    },
+  ]);
+
+  // add child
+  ms.push({
+    type: 'add',
+    row: {
+      id: 2,
+      name: 'foobaz',
+      childID: null,
+    },
+  });
+  expect(data).toEqual([
+    {
+      id: 1,
+      name: 'foo',
+      childID: 2,
+      children: [
+        {
+          id: 2,
+          name: 'foobaz',
+          childID: null,
+        },
+      ],
+    },
+    {
+      id: 2,
+      name: 'foobaz',
+      childID: null,
+      children: [],
+    },
+    {
+      id: 3,
+      name: 'mon',
+      childID: 4,
+      children: [
+        {
+          id: 4,
+          name: 'monkey',
+          childID: null,
+        },
+      ],
+    },
+    {
+      id: 4,
+      name: 'monkey',
+      childID: null,
+      children: [],
+    },
+  ]);
+});
+
+test('stop-iterators', () => {
+  const users = new MemorySource({id: 'number', name: 'string'}, ['id']);
+  users.push({
+    type: 'add',
+    row: {id: 1, name: 'foo', parentID: 3},
+  });
+  users.push({
+    type: 'add',
+    row: {id: 2, name: 'foobar', parentID: 3},
+  });
+  users.push({
+    type: 'add',
+    row: {id: 3, name: 'mon', parentID: null},
+  });
+
+  const join = new Join(
+    users.connect([['name', 'asc']]),
+    users.connect([['name', 'desc']]),
+    new MemoryStorage(),
+    'parentID',
+    'id',
+    'parent',
+  );
+
+  const view = new View(join);
+
+  const iters: Iterator<Entry>[] = [];
+
+  view.addListener(parent => {
+    const it1 = parent[Symbol.iterator]();
+    const e1 = it1.next().value;
+    iters.push(it1);
+    const it2 = e1.parent[Symbol.iterator]();
+    const e2 = it2.next().value;
+    expect(e2).toBeTruthy();
+    iters.push(it2);
+  });
+
+  view.hydrate();
+  expect(iters.length).toBe(2);
+
+  for (const it of iters) {
+    expect(() => it.next()).throws('Iterator has been stopped');
+  }
+});

--- a/packages/zql/src/zql/ivm2/view.ts
+++ b/packages/zql/src/zql/ivm2/view.ts
@@ -1,0 +1,134 @@
+import BTree from 'btree';
+import {Change} from './change.js';
+import {Row, Value} from './data.js';
+import {Input, Output} from './operator.js';
+import {assert} from 'shared/src/asserts.js';
+import {Schema} from './schema.js';
+import {must} from 'shared/src/must.js';
+import {StoppableIterator} from './stopable-iterator.js';
+
+/**
+ * A listener that is called when the view changes. The iterable passed is only
+ * valid for the lifetime of the listener call. If the listener needs to keep
+ * the data around, it should copy it.
+ */
+export type Listener = (data: Iterable<Entry>) => void;
+
+/**
+ * A row with its relationships.
+ */
+export type Entry = Record<string, Value | Iterable<Entry>>;
+
+/**
+ * Implements a materialized view of the output of a Pipeline.
+ */
+export class View implements Output {
+  readonly #input: Input;
+  readonly #entries: EntryList;
+  readonly #listeners = new Set<Listener>();
+
+  #hydrated = false;
+
+  constructor(input: Input) {
+    this.#input = input;
+
+    this.#input.setOutput(this);
+    this.#entries = new EntryList(this.#input.getSchema());
+  }
+
+  addListener(listener: Listener) {
+    assert(!this.#listeners.has(listener), 'Listener already registered');
+    this.#listeners.add(listener);
+  }
+
+  removeListener(listener: Listener) {
+    assert(this.#listeners.has(listener), 'Listener not registered');
+    this.#listeners.delete(listener);
+  }
+
+  #fireListeners() {
+    for (const listener of this.#listeners) {
+      listener(this.#entries);
+    }
+    this.#entries.stopIterators();
+  }
+
+  hydrate() {
+    if (this.#hydrated) {
+      throw new Error("Can't hydrate twice");
+    }
+    this.#hydrated = true;
+
+    for (const node of this.#input.fetch({})) {
+      this.#entries.applyChange({type: 'add', node});
+    }
+    this.#fireListeners();
+  }
+
+  push(change: Change): void {
+    this.#entries.applyChange(change);
+    this.#fireListeners();
+  }
+}
+
+class EntryList {
+  #data: BTree<Entry, undefined>;
+  #schema: Schema;
+  #iterators: StoppableIterator<Entry>[] = [];
+
+  constructor(schema: Schema) {
+    this.#data = new BTree<Entry, undefined>([], (e1, e2) =>
+      schema.compareRows(e1 as Row, e2 as Row),
+    );
+    this.#schema = schema;
+  }
+
+  applyChange(change: Change) {
+    if (change.type === 'add') {
+      const newEntry: Entry = {...change.node.row};
+      const added = this.#data.add(newEntry, undefined);
+      assert(added, 'row already exists');
+      for (const [relationship, children] of Object.entries(
+        change.node.relationships,
+      )) {
+        // TODO: Is there a flag to make TypeScript complain that dictionary access might be undefined?
+        const childSchema = must(this.#schema.relationships[relationship]);
+        const newView = new EntryList(childSchema);
+        newEntry[relationship] = newView;
+        for (const node of children) {
+          newView.applyChange({type: 'add', node});
+        }
+      }
+    } else if (change.type === 'remove') {
+      const deleted = this.#data.delete(change.node.row);
+      assert(deleted, 'row does not exist');
+    } else {
+      change.type satisfies 'child';
+      const [[existing]] = this.#data.entries(change.row);
+      assert(existing, 'parent row does not exist');
+      const child = existing[change.child.relationshipName];
+      assert(child instanceof EntryList);
+      child.applyChange(change.child.change);
+    }
+  }
+
+  [Symbol.iterator]() {
+    const it = new StoppableIterator(this.#data.keys());
+    this.#iterators.push(it);
+    return it;
+  }
+
+  stopIterators() {
+    for (const it of this.#iterators) {
+      it.stop();
+    }
+    this.#iterators = [];
+    for (const entry of this.#data.keys()) {
+      for (const [, child] of Object.entries(entry)) {
+        if (child instanceof EntryList) {
+          child.stopIterators();
+        }
+      }
+    }
+  }
+}

--- a/packages/zqlite/src/v2/table-source.ts
+++ b/packages/zqlite/src/v2/table-source.ts
@@ -125,6 +125,7 @@ export class TableSource implements Source {
       columns: this.#columns,
       primaryKey: this.#primaryKey,
       compareRows: makeComparator(connection.sort),
+      relationships: {},
     };
   }
 


### PR DESCRIPTION
View maintains a materialized view of the output of a pipeline.

The view is maintained in a b-tree. Users can listen for changes and they receive an iterable. The iterable is invalidated as soon as the listener exits, so users will likely have to copy to some other data structure. But I think this would be the case no matter what in React at least, since React needs to be able to re-render at any time.

This class leaves this final copying step to the framework- specific bindings layer above.

This class also changes the output type from Node to "Entry", which smooshes together the Row and its relationships for ergonomics.

I hadn't thought carefully about the output interface before but of course this is what people would want. I was mainly focused on making the internals clean and simple and minimizing copies, but the presence of relationships makes copies a lot harder to avoid anyway.