### PR TITLE
[rfc] - Input vs Entity schema

### DIFF
--- a/packages/zql/src/zql/query2/schema.ts
+++ b/packages/zql/src/zql/query2/schema.ts
@@ -20,6 +20,32 @@ export type Schema = {
 };
 
 /**
+ * IVM operators take a slightly different form of `Schema`
+ *
+ * 1. `columns` don't encode optionality. They probably should.
+ * 2. `relationships` does not encode the type of the relationship (junction vs field edge).
+ * 3. `relationships` doesn't support recursive relationships
+ * 4. IVM schema requires a `compareRows` function.
+ * 5. Query schema requires a `table` field.
+ *
+ * 1, 2 and 3 can probably be made common between the two types.
+ * 5 could be thrown into `IVM Schema` and ignored
+ * 4 is fundamentally different but can be computed
+ * from the other information allowing `IVMSchema` to be a subtype of `EntitySchema`.
+ */
+export function toInputArgs(schema: Schema) {
+  const columns: Record<string, ValueType> = {};
+  for (const [key, value] of Object.entries(schema.fields)) {
+    columns[key] = value.type;
+  }
+  return {
+    primaryKey: schema.primaryKey,
+    columns,
+    table: schema.table,
+  };
+}
+
+/**
  * A schema might have a relationship to itself.
  * Given we cannot reference a variable in the same statement we initialize
  * the variable, we use a lazy function to get around this.


### PR DESCRIPTION
We have two schema types.

The type used by `Input.getSchema` and the type used by `Query`.

Two options:

1. Make the schema used in the Query layer a super-type of the IVM schema

```ts
type EntitySchema = {
  readonly table: string;
  primaryKey: readonly [keyof Schema['fields'], ...(keyof Schema['fields'])[]];
  readonly fields: Record<string, SchemaValue>;
  readonly relationships?: {
    [key: string]:
      | FieldRelationship<Schema, Schema>
      | JunctionRelationship<Schema, Schema, Schema>;
  };
};

type InputSchema = EntitySchema & {
  compareRows: (r1: Row, r2: Row) => number;
}
```

2. just keep them divergent and convert via the function in this PR - `toInputArgs`

I'm leaning towards (2) until the types fully stabilize. It is also odd to have the layer below (IVM) depend on the layer above (Query) from option (1). I suppose we can rectify that via:

```ts
type EntitySchema = Omit<InputSchema, 'compareRows'>
```

And adding `Field` and `Junction` relationship concepts to `InputSchema` as well as optionality for value types.