### PR TITLE
fix(zero-cache): reduce flakiness of worker-thread based test

### DIFF
--- a/packages/zero-cache/vitest.config.ts
+++ b/packages/zero-cache/vitest.config.ts
@@ -23,7 +23,6 @@ function inlineWASM(): PluginOption {
 
 export default defineConfig({
   test: {
-    testTimeout: 20_000,
     include: ['src/**/*.test.?(c|m)[jt]s?(x)'],
     retry: 3,
     globalSetup: ['./test/pg-container-setup.ts'],


### PR DESCRIPTION
Test failures seem to stem from some randomness in the vitest runner (which internally uses worker threads). Adding a pause before initiating the handoff fixes the flakiness locally.

Also shorten the overall test timeout so that it can retry sooner. This helped before adding the pause, and may no longer be needed, but it doesn't hurt to keep.
