### PR TITLE
fix(zql): Moar tests for take and fixes bugs exposed by tests

### DIFF
--- a/packages/zql/src/zql/ivm2/take.push.test.ts
+++ b/packages/zql/src/zql/ivm2/take.push.test.ts
@@ -13,7 +13,10 @@ import {Change} from './change.js';
 
 suite('take with no partition', () => {
   const base = {
-    columns: {id: 'string' as const, created: 'number' as const},
+    columns: {
+      id: 'string' as const,
+      created: 'number' as const,
+    },
     primaryKeys: ['id'],
     sort: [
       ['created', 'asc'],
@@ -22,270 +25,741 @@ suite('take with no partition', () => {
     partition: undefined,
   };
 
-  takeTest({
-    ...base,
-    name: 'less than limit add row at start',
-    sourceRows: [
-      {id: 'i1', created: 100},
-      {id: 'i2', created: 200},
-      {id: 'i3', created: 300},
-    ],
-    limit: 5,
-    pushes: [{type: 'add', row: {id: 'i4', created: 50}}],
-    expectedMessages: [
-      ['takeSnitch', 'push', {type: 'add', row: {id: 'i4', created: 50}}],
-    ],
-    expectedStorage: {
-      '["take",null]': {
-        bound: {
+  suite('add', () => {
+    takeTest({
+      ...base,
+      name: 'less than limit add row at start',
+      sourceRows: [
+        {id: 'i1', created: 100},
+        {id: 'i2', created: 200},
+        {id: 'i3', created: 300},
+      ],
+      limit: 5,
+      pushes: [{type: 'add', row: {id: 'i4', created: 50}}],
+      expectedMessages: [
+        ['takeSnitch', 'push', {type: 'add', row: {id: 'i4', created: 50}}],
+      ],
+      expectedStorage: {
+        '["take",null]': {
+          bound: {
+            created: 300,
+            id: 'i3',
+          },
+          size: 4,
+        },
+        'maxBound': {
           created: 300,
           id: 'i3',
         },
-        size: 4,
       },
-      'maxBound': {
-        created: 300,
-        id: 'i3',
-      },
-    },
-    expectedOutput: [
-      {type: 'add', node: {row: {id: 'i4', created: 50}, relationships: {}}},
-    ],
-  });
+      expectedOutput: [
+        {type: 'add', node: {row: {id: 'i4', created: 50}, relationships: {}}},
+      ],
+    });
 
-  takeTest({
-    ...base,
-    name: 'less than limit add row at end',
-    sourceRows: [
-      {id: 'i1', created: 100},
-      {id: 'i2', created: 200},
-      {id: 'i3', created: 300},
-    ],
-    limit: 5,
-    pushes: [{type: 'add', row: {id: 'i4', created: 350}}],
-    expectedMessages: [
-      ['takeSnitch', 'push', {type: 'add', row: {id: 'i4', created: 350}}],
-    ],
-    expectedStorage: {
-      '["take",null]': {
-        bound: {
+    takeTest({
+      ...base,
+      name: 'less than limit add row at end',
+      sourceRows: [
+        {id: 'i1', created: 100},
+        {id: 'i2', created: 200},
+        {id: 'i3', created: 300},
+      ],
+      limit: 5,
+      pushes: [{type: 'add', row: {id: 'i4', created: 350}}],
+      expectedMessages: [
+        ['takeSnitch', 'push', {type: 'add', row: {id: 'i4', created: 350}}],
+      ],
+      expectedStorage: {
+        '["take",null]': {
+          bound: {
+            created: 350,
+            id: 'i4',
+          },
+          size: 4,
+        },
+        'maxBound': {
           created: 350,
           id: 'i4',
         },
-        size: 4,
       },
-      'maxBound': {
-        created: 350,
-        id: 'i4',
-      },
-    },
-    expectedOutput: [
-      {type: 'add', node: {row: {id: 'i4', created: 350}, relationships: {}}},
-    ],
-  });
+      expectedOutput: [
+        {type: 'add', node: {row: {id: 'i4', created: 350}, relationships: {}}},
+      ],
+    });
 
-  takeTest({
-    ...base,
-    name: 'at limit add row after bound',
-    sourceRows: [
-      {id: 'i1', created: 100},
-      {id: 'i2', created: 200},
-      {id: 'i3', created: 300},
-      {id: 'i4', created: 400},
-    ],
-    limit: 3,
-    pushes: [{type: 'add', row: {id: 'i5', created: 350}}],
-    expectedMessages: [
-      ['takeSnitch', 'push', {type: 'add', row: {id: 'i5', created: 350}}],
-    ],
-    expectedStorage: {
-      '["take",null]': {
-        bound: {
+    takeTest({
+      ...base,
+      name: 'at limit add row after bound',
+      sourceRows: [
+        {id: 'i1', created: 100},
+        {id: 'i2', created: 200},
+        {id: 'i3', created: 300},
+        {id: 'i4', created: 400},
+      ],
+      limit: 3,
+      pushes: [{type: 'add', row: {id: 'i5', created: 350}}],
+      expectedMessages: [
+        ['takeSnitch', 'push', {type: 'add', row: {id: 'i5', created: 350}}],
+      ],
+      expectedStorage: {
+        '["take",null]': {
+          bound: {
+            created: 300,
+            id: 'i3',
+          },
+          size: 3,
+        },
+        'maxBound': {
           created: 300,
           id: 'i3',
         },
-        size: 3,
       },
-      'maxBound': {
-        created: 300,
-        id: 'i3',
-      },
-    },
-    expectedOutput: [],
-  });
+      expectedOutput: [],
+    });
 
-  takeTest({
-    ...base,
-    name: 'at limit add row at start',
-    sourceRows: [
-      {id: 'i1', created: 100},
-      {id: 'i2', created: 200},
-      {id: 'i3', created: 300},
-    ],
-    limit: 3,
-    pushes: [{type: 'add', row: {id: 'i4', created: 50}}],
-    expectedMessages: [
-      ['takeSnitch', 'push', {type: 'add', row: {id: 'i4', created: 50}}],
-      [
-        'takeSnitch',
-        'fetch',
-        {start: {basis: 'before', row: {id: 'i3', created: 300}}},
+    takeTest({
+      ...base,
+      name: 'at limit add row at start',
+      sourceRows: [
+        {id: 'i1', created: 100},
+        {id: 'i2', created: 200},
+        {id: 'i3', created: 300},
+        {id: 'i4', created: 400},
       ],
-    ],
-    expectedStorage: {
-      '["take",null]': {
-        bound: {
-          created: 200,
-          id: 'i2',
+      limit: 3,
+      pushes: [{type: 'add', row: {id: 'i5', created: 50}}],
+      expectedMessages: [
+        ['takeSnitch', 'push', {type: 'add', row: {id: 'i5', created: 50}}],
+        [
+          'takeSnitch',
+          'fetch',
+          {start: {basis: 'before', row: {id: 'i3', created: 300}}},
+        ],
+      ],
+      expectedStorage: {
+        '["take",null]': {
+          bound: {
+            created: 200,
+            id: 'i2',
+          },
+          size: 3,
         },
-        size: 3,
+        'maxBound': {
+          created: 300,
+          id: 'i3',
+        },
       },
-      'maxBound': {
-        created: 300,
-        id: 'i3',
+      expectedOutput: [
+        {
+          type: 'remove',
+          node: {row: {id: 'i3', created: 300}, relationships: {}},
+        },
+        {type: 'add', node: {row: {id: 'i5', created: 50}, relationships: {}}},
+      ],
+    });
+
+    takeTest({
+      ...base,
+      name: 'at limit add row at end',
+      sourceRows: [
+        {id: 'i1', created: 100},
+        {id: 'i2', created: 200},
+        {id: 'i3', created: 300},
+        {id: 'i4', created: 400},
+      ],
+      limit: 3,
+      pushes: [{type: 'add', row: {id: 'i5', created: 250}}],
+      expectedMessages: [
+        ['takeSnitch', 'push', {type: 'add', row: {id: 'i5', created: 250}}],
+        [
+          'takeSnitch',
+          'fetch',
+          {start: {basis: 'before', row: {id: 'i3', created: 300}}},
+        ],
+      ],
+      expectedStorage: {
+        '["take",null]': {
+          bound: {
+            created: 250,
+            id: 'i5',
+          },
+          size: 3,
+        },
+        'maxBound': {
+          created: 300,
+          id: 'i3',
+        },
       },
-    },
-    expectedOutput: [
-      {
-        type: 'remove',
-        node: {row: {id: 'i3', created: 300}, relationships: {}},
-      },
-      {type: 'add', node: {row: {id: 'i4', created: 50}, relationships: {}}},
-    ],
+      expectedOutput: [
+        {
+          type: 'remove',
+          node: {row: {id: 'i3', created: 300}, relationships: {}},
+        },
+        {type: 'add', node: {row: {id: 'i5', created: 250}, relationships: {}}},
+      ],
+    });
   });
 
-  takeTest({
-    ...base,
-    name: 'at limit add row at end',
-    sourceRows: [
-      {id: 'i1', created: 100},
-      {id: 'i2', created: 200},
-      {id: 'i3', created: 300},
-    ],
-    limit: 3,
-    pushes: [{type: 'add', row: {id: 'i4', created: 250}}],
-    expectedMessages: [
-      ['takeSnitch', 'push', {type: 'add', row: {id: 'i4', created: 250}}],
-      [
-        'takeSnitch',
-        'fetch',
-        {start: {basis: 'before', row: {id: 'i3', created: 300}}},
+  suite('remove', () => {
+    takeTest({
+      ...base,
+      name: 'less than limit remove row at start',
+      sourceRows: [
+        {id: 'i1', created: 100},
+        {id: 'i2', created: 200},
+        {id: 'i3', created: 300},
       ],
-    ],
-    expectedStorage: {
-      '["take",null]': {
-        bound: {
-          created: 250,
+      limit: 5,
+      pushes: [{type: 'remove', row: {id: 'i1', created: 100}}],
+      expectedMessages: [
+        ['takeSnitch', 'push', {type: 'remove', row: {id: 'i1', created: 100}}],
+        [
+          'takeSnitch',
+          'fetch',
+          {
+            start: {
+              basis: 'before',
+              row: {
+                created: 300,
+                id: 'i3',
+              },
+            },
+          },
+        ],
+      ],
+      expectedStorage: {
+        '["take",null]': {
+          bound: {
+            created: 300,
+            id: 'i3',
+          },
+          size: 2,
+        },
+        'maxBound': {
+          created: 300,
+          id: 'i3',
+        },
+      },
+      expectedOutput: [
+        {
+          type: 'remove',
+          node: {row: {id: 'i1', created: 100}, relationships: {}},
+        },
+      ],
+    });
+
+    takeTest({
+      ...base,
+      name: 'less than limit remove row at end',
+      sourceRows: [
+        {id: 'i1', created: 100},
+        {id: 'i2', created: 200},
+        {id: 'i3', created: 300},
+      ],
+      limit: 5,
+      pushes: [{type: 'remove', row: {id: 'i3', created: 300}}],
+      expectedMessages: [
+        ['takeSnitch', 'push', {type: 'remove', row: {id: 'i3', created: 300}}],
+        [
+          'takeSnitch',
+          'fetch',
+          {
+            start: {
+              basis: 'before',
+              row: {
+                created: 300,
+                id: 'i3',
+              },
+            },
+          },
+        ],
+      ],
+      expectedStorage: {
+        '["take",null]': {
+          bound: {
+            created: 200,
+            id: 'i2',
+          },
+          size: 2,
+        },
+        'maxBound': {
+          created: 300,
+          id: 'i3',
+        },
+      },
+      expectedOutput: [
+        {
+          type: 'remove',
+          node: {row: {id: 'i3', created: 300}, relationships: {}},
+        },
+      ],
+    });
+
+    takeTest({
+      ...base,
+      name: 'at limit remove row after bound',
+      sourceRows: [
+        {id: 'i1', created: 100},
+        {id: 'i2', created: 200},
+        {id: 'i3', created: 300},
+        {id: 'i4', created: 400},
+      ],
+      limit: 3,
+      pushes: [{type: 'remove', row: {id: 'i4', created: 400}}],
+      expectedMessages: [
+        ['takeSnitch', 'push', {type: 'remove', row: {id: 'i4', created: 400}}],
+      ],
+      expectedStorage: {
+        '["take",null]': {
+          bound: {
+            created: 300,
+            id: 'i3',
+          },
+          size: 3,
+        },
+        'maxBound': {
+          created: 300,
+          id: 'i3',
+        },
+      },
+      expectedOutput: [],
+    });
+
+    takeTest({
+      ...base,
+      name: 'at limit remove row at start with row after',
+      sourceRows: [
+        {id: 'i1', created: 100},
+        {id: 'i2', created: 200},
+        {id: 'i3', created: 300},
+        {id: 'i4', created: 400},
+      ],
+      limit: 3,
+      pushes: [{type: 'remove', row: {id: 'i1', created: 100}}],
+      expectedMessages: [
+        ['takeSnitch', 'push', {type: 'remove', row: {id: 'i1', created: 100}}],
+        [
+          'takeSnitch',
+          'fetch',
+          {start: {basis: 'before', row: {id: 'i3', created: 300}}},
+        ],
+      ],
+      expectedStorage: {
+        '["take",null]': {
+          bound: {
+            created: 400,
+            id: 'i4',
+          },
+          size: 3,
+        },
+        'maxBound': {
+          created: 400,
           id: 'i4',
         },
-        size: 3,
       },
-      'maxBound': {
-        created: 300,
-        id: 'i3',
-      },
-    },
-    expectedOutput: [
-      {
-        type: 'remove',
-        node: {row: {id: 'i3', created: 300}, relationships: {}},
-      },
-      {type: 'add', node: {row: {id: 'i4', created: 250}, relationships: {}}},
-    ],
-  });
-
-  takeTest({
-    ...base,
-    name: 'less than limit remove row at start',
-    sourceRows: [
-      {id: 'i1', created: 100},
-      {id: 'i2', created: 200},
-      {id: 'i3', created: 300},
-    ],
-    limit: 5,
-    pushes: [{type: 'remove', row: {id: 'i1', created: 100}}],
-    expectedMessages: [
-      ['takeSnitch', 'push', {type: 'remove', row: {id: 'i1', created: 100}}],
-      [
-        'takeSnitch',
-        'fetch',
+      expectedOutput: [
         {
-          start: {
-            basis: 'before',
-            row: {
-              created: 300,
-              id: 'i3',
-            },
-          },
+          type: 'remove',
+          node: {row: {id: 'i1', created: 100}, relationships: {}},
+        },
+        {
+          type: 'add',
+          node: {row: {id: 'i4', created: 400}, relationships: {}},
         },
       ],
-    ],
-    expectedStorage: {
-      '["take",null]': {
-        bound: {
+    });
+
+    takeTest({
+      ...base,
+      name: 'at limit remove row at start no row after',
+      sourceRows: [
+        {id: 'i1', created: 100},
+        {id: 'i2', created: 200},
+        {id: 'i3', created: 300},
+      ],
+      limit: 3,
+      pushes: [{type: 'remove', row: {id: 'i1', created: 100}}],
+      expectedMessages: [
+        ['takeSnitch', 'push', {type: 'remove', row: {id: 'i1', created: 100}}],
+        [
+          'takeSnitch',
+          'fetch',
+          {start: {basis: 'before', row: {id: 'i3', created: 300}}},
+        ],
+      ],
+      expectedStorage: {
+        '["take",null]': {
+          bound: {
+            created: 300,
+            id: 'i3',
+          },
+          size: 2,
+        },
+        'maxBound': {
           created: 300,
           id: 'i3',
         },
-        size: 2,
       },
-      'maxBound': {
-        created: 300,
-        id: 'i3',
-      },
-    },
-    expectedOutput: [
-      {
-        type: 'remove',
-        node: {row: {id: 'i1', created: 100}, relationships: {}},
-      },
-    ],
-  });
-
-  takeTest({
-    ...base,
-    name: 'less than limit remove row at end',
-    sourceRows: [
-      {id: 'i1', created: 100},
-      {id: 'i2', created: 200},
-      {id: 'i3', created: 300},
-    ],
-    limit: 5,
-    pushes: [{type: 'remove', row: {id: 'i3', created: 300}}],
-    expectedMessages: [
-      ['takeSnitch', 'push', {type: 'remove', row: {id: 'i3', created: 300}}],
-      [
-        'takeSnitch',
-        'fetch',
+      expectedOutput: [
         {
-          start: {
-            basis: 'before',
-            row: {
-              created: 300,
-              id: 'i3',
-            },
+          type: 'remove',
+          node: {row: {id: 'i1', created: 100}, relationships: {}},
+        },
+      ],
+    });
+
+    takeTest({
+      ...base,
+      name: 'at limit remove row at end with row after',
+      sourceRows: [
+        {id: 'i1', created: 100},
+        {id: 'i2', created: 200},
+        {id: 'i3', created: 300},
+        {id: 'i4', created: 400},
+      ],
+      limit: 3,
+      pushes: [{type: 'remove', row: {id: 'i3', created: 300}}],
+      expectedMessages: [
+        ['takeSnitch', 'push', {type: 'remove', row: {id: 'i3', created: 300}}],
+        [
+          'takeSnitch',
+          'fetch',
+          {start: {basis: 'before', row: {id: 'i3', created: 300}}},
+        ],
+      ],
+      expectedStorage: {
+        '["take",null]': {
+          bound: {
+            created: 400,
+            id: 'i4',
+          },
+          size: 3,
+        },
+        'maxBound': {
+          created: 400,
+          id: 'i4',
+        },
+      },
+      expectedOutput: [
+        {
+          type: 'remove',
+          node: {row: {id: 'i3', created: 300}, relationships: {}},
+        },
+        {
+          type: 'add',
+          node: {row: {id: 'i4', created: 400}, relationships: {}},
+        },
+      ],
+    });
+
+    takeTest({
+      ...base,
+      name: 'at limit remove row at end, no row after',
+      sourceRows: [
+        {id: 'i1', created: 100},
+        {id: 'i2', created: 200},
+        {id: 'i3', created: 300},
+      ],
+      limit: 3,
+      pushes: [{type: 'remove', row: {id: 'i3', created: 300}}],
+      expectedMessages: [
+        ['takeSnitch', 'push', {type: 'remove', row: {id: 'i3', created: 300}}],
+        [
+          'takeSnitch',
+          'fetch',
+          {start: {basis: 'before', row: {id: 'i3', created: 300}}},
+        ],
+      ],
+      expectedStorage: {
+        '["take",null]': {
+          bound: {
+            created: 200,
+            id: 'i2',
+          },
+          size: 2,
+        },
+        'maxBound': {
+          created: 300,
+          id: 'i3',
+        },
+      },
+      expectedOutput: [
+        {
+          type: 'remove',
+          node: {row: {id: 'i3', created: 300}, relationships: {}},
+        },
+      ],
+    });
+  });
+});
+
+suite('take with partition', () => {
+  const base = {
+    columns: {
+      id: 'string' as const,
+      issueID: 'string' as const,
+      created: 'number' as const,
+    },
+    primaryKeys: ['id'],
+    sort: [
+      ['created', 'asc'],
+      ['id', 'asc'],
+    ] as const,
+  };
+
+  suite('add', () => {
+    takeTest({
+      ...base,
+      partition: {
+        key: 'issueID',
+        values: ['i1', 'i2'],
+      },
+      name: 'less than limit add row at start',
+      sourceRows: [
+        {id: 'c1', issueID: 'i1', created: 100},
+        {id: 'c2', issueID: 'i1', created: 200},
+        {id: 'c3', issueID: 'i1', created: 300},
+        {id: 'c4', issueID: 'i2', created: 400},
+        {id: 'c5', issueID: 'i2', created: 500},
+      ],
+      limit: 5,
+      pushes: [{type: 'add', row: {id: 'c6', issueID: 'i2', created: 150}}],
+      expectedMessages: [
+        [
+          'takeSnitch',
+          'push',
+          {type: 'add', row: {id: 'c6', issueID: 'i2', created: 150}},
+        ],
+      ],
+      expectedStorage: {
+        '["take","i1"]': {
+          bound: {id: 'c3', issueID: 'i1', created: 300},
+          size: 3,
+        },
+        '["take","i2"]': {
+          bound: {id: 'c5', issueID: 'i2', created: 500},
+          size: 3,
+        },
+        'maxBound': {id: 'c5', issueID: 'i2', created: 500},
+      },
+      expectedOutput: [
+        {
+          type: 'add',
+          node: {
+            row: {id: 'c6', issueID: 'i2', created: 150},
+            relationships: {},
           },
         },
       ],
-    ],
-    expectedStorage: {
-      '["take",null]': {
-        bound: {
-          created: 200,
-          id: 'i2',
+    });
+
+    // TODO: Uncomment when constraint+start fetch is fixed in MemorySource.
+    // takeTest({
+    //   ...base,
+    //   name: 'at limit add row at end',
+    //   partition: {
+    //     key: 'issueID',
+    //     values: ['i1', 'i2'],
+    //   },
+    //   sourceRows: [
+    //     {id: 'c1', issueID: 'i1', created: 100},
+    //     {id: 'c2', issueID: 'i1', created: 200},
+    //     // 580 to test that it constrains looking for previous
+    //     // to constraint issueID: 'i2'
+    //     {id: 'c3', issueID: 'i1', created: 580},
+    //     {id: 'c4', issueID: 'i2', created: 400},
+    //     {id: 'c5', issueID: 'i2', created: 500},
+    //     {id: 'c6', issueID: 'i2', created: 600},
+    //     {id: 'c7', issueID: 'i2', created: 700},
+    //   ],
+    //   limit: 3,
+    //   pushes: [{type: 'add', row: {id: 'c8', issueID: 'i2', created: 550}}],
+    //   expectedMessages: [
+    //     [
+    //       'takeSnitch',
+    //       'push',
+    //       {type: 'add', row: {id: 'c8', issueID: 'i2', created: 550}},
+    //     ],
+    //     [
+    //       'takeSnitch',
+    //       'fetch',
+    //       {
+    //         constraint: {
+    //           key: 'issueID',
+    //           value: 'i2',
+    //         },
+    //         start: {
+    //           basis: 'before',
+    //           row: {id: 'c6', issueID: 'i2', created: 600},
+    //         },
+    //       },
+    //     ],
+    //   ],
+    //   expectedStorage: {
+    //     '["take","i1"]': {
+    //       bound: {id: 'c3', issueID: 'i1', created: 580},
+    //       size: 3,
+    //     },
+    //     '["take","i2"]': {
+    //       bound: {id: 'c8', issueID: 'i2', created: 550},
+    //       size: 3,
+    //     },
+    //     'maxBound': {id: 'c6', issueID: 'i2', created: 600},
+    //   },
+    //   expectedOutput: [
+    //     {
+    //       type: 'remove',
+    //       node: {
+    //         row: {id: 'i6', issueID: 'i2', created: 600},
+    //         relationships: {},
+    //       },
+    //     },
+    //     {
+    //       type: 'add',
+    //       node: {
+    //         row: {id: 'c3', issueID: 'i2', created: 550},
+    //         relationships: {},
+    //       },
+    //     },
+    //   ],
+    // });
+
+    takeTest({
+      ...base,
+      name: 'add with non-fetched partition value',
+      partition: {
+        key: 'issueID',
+        values: ['i1', 'i2'],
+      },
+      sourceRows: [
+        {id: 'c1', issueID: 'i1', created: 100},
+        {id: 'c2', issueID: 'i1', created: 200},
+        {id: 'c3', issueID: 'i1', created: 300},
+        {id: 'c4', issueID: 'i2', created: 400},
+        {id: 'c5', issueID: 'i2', created: 500},
+      ],
+      limit: 3,
+      pushes: [{type: 'add', row: {id: 'c6', issueID: '3', created: 550}}],
+      expectedMessages: [
+        [
+          'takeSnitch',
+          'push',
+          {type: 'add', row: {id: 'c6', issueID: '3', created: 550}},
+        ],
+      ],
+      expectedStorage: {
+        '["take","i1"]': {
+          bound: {id: 'c3', issueID: 'i1', created: 300},
+          size: 3,
         },
-        size: 2,
+        '["take","i2"]': {
+          bound: {id: 'c5', issueID: 'i2', created: 500},
+          size: 2,
+        },
+        'maxBound': {id: 'c5', issueID: 'i2', created: 500},
       },
-      'maxBound': {
-        created: 300,
-        id: 'i3',
+      expectedOutput: [],
+    });
+  });
+
+  suite('remove', () => {
+    takeTest({
+      ...base,
+      partition: {
+        key: 'issueID',
+        values: ['i1', 'i2'],
       },
-    },
-    expectedOutput: [
-      {
-        type: 'remove',
-        node: {row: {id: 'i3', created: 300}, relationships: {}},
+      name: 'less than limit remove row at start',
+      sourceRows: [
+        {id: 'c1', issueID: 'i1', created: 100},
+        {id: 'c2', issueID: 'i1', created: 200},
+        {id: 'c3', issueID: 'i1', created: 300},
+        {id: 'c4', issueID: 'i2', created: 400},
+        {id: 'c5', issueID: 'i2', created: 500},
+      ],
+      limit: 5,
+      pushes: [{type: 'remove', row: {id: 'c1', issueID: 'i1', created: 100}}],
+      expectedMessages: [
+        [
+          'takeSnitch',
+          'push',
+          {type: 'remove', row: {id: 'c1', issueID: 'i1', created: 100}},
+        ],
+        [
+          'takeSnitch',
+          'fetch',
+          {
+            constraint: {
+              key: 'issueID',
+              value: 'i1',
+            },
+            start: {
+              basis: 'before',
+              row: {id: 'c3', issueID: 'i1', created: 300},
+            },
+          },
+        ],
+      ],
+      expectedStorage: {
+        '["take","i1"]': {
+          bound: {id: 'c3', issueID: 'i1', created: 300},
+          size: 2,
+        },
+        '["take","i2"]': {
+          bound: {id: 'c5', issueID: 'i2', created: 500},
+          size: 2,
+        },
+        'maxBound': {id: 'c5', issueID: 'i2', created: 500},
       },
-    ],
+      expectedOutput: [
+        {
+          type: 'remove',
+          node: {
+            row: {id: 'c1', issueID: 'i1', created: 100},
+            relationships: {},
+          },
+        },
+      ],
+    });
+
+    takeTest({
+      ...base,
+      partition: {
+        key: 'issueID',
+        values: ['i1', 'i2'],
+      },
+      name: 'remove row unfetched partition',
+      sourceRows: [
+        {id: 'c1', issueID: 'i1', created: 100},
+        {id: 'c2', issueID: 'i1', created: 200},
+        {id: 'c3', issueID: 'i1', created: 300},
+        {id: 'c4', issueID: 'i2', created: 400},
+        {id: 'c5', issueID: 'i2', created: 500},
+        {id: 'c6', issueID: 'i3', created: 600},
+      ],
+      limit: 5,
+      pushes: [{type: 'remove', row: {id: 'c6', issueID: 'i3', created: 600}}],
+      expectedMessages: [
+        [
+          'takeSnitch',
+          'push',
+          {type: 'remove', row: {id: 'c6', issueID: 'i3', created: 600}},
+        ],
+      ],
+      expectedStorage: {
+        '["take","i1"]': {
+          bound: {id: 'c3', issueID: 'i1', created: 300},
+          size: 3,
+        },
+        '["take","i2"]': {
+          bound: {id: 'c5', issueID: 'i2', created: 500},
+          size: 2,
+        },
+        'maxBound': {id: 'c5', issueID: 'i2', created: 500},
+      },
+      expectedOutput: [],
+    });
   });
 });
 

--- a/packages/zql/src/zql/ivm2/test/source-cases.ts
+++ b/packages/zql/src/zql/ivm2/test/source-cases.ts
@@ -49,7 +49,7 @@ class OverlaySpy implements Output {
 }
 
 const cases = {
-  'simple-pull': (createSource: SourceFactory) => {
+  'simple-fetch': (createSource: SourceFactory) => {
     const sort = [['a', 'asc']] as const;
     const ms = createSource('table', {a: 'number'}, ['a']);
     const out = new Catch(ms.connect(sort));
@@ -70,7 +70,7 @@ const cases = {
     expect(out.fetch()).toEqual([]);
   },
 
-  'pull-with-constraint': (createSource: SourceFactory) => {
+  'fetch-with-constraint': (createSource: SourceFactory) => {
     const sort = [['a', 'asc']] as const;
     const ms = createSource(
       'table',


### PR DESCRIPTION
Main bug fixed was due to a mismatch between the behavior i expected from fetch in the context of a 'remove' push.  I expected the 'remove'd row to be in the fetch results, but it is not.  Talked through this with @aboodman and @darkgnotic and we decided this behavior of source is fine and so I adapted the take logic to handle it correctly.

Also updated fetches in push handling to correctly pass the partition key as a constraint.