### PR TITLE
feat(zero-cache): initial pipeline sync

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.test.ts
@@ -423,8 +423,8 @@ describe('view-syncer/cvr', () => {
           id: 'lmids',
           internal: true,
           ast: {
-            table: 'clients',
-            schema: 'zero',
+            table: 'zero.clients',
+            schema: '',
             where: [
               {
                 type: 'simple',
@@ -433,6 +433,7 @@ describe('view-syncer/cvr', () => {
                 value: 'abc123',
               },
             ],
+            orderBy: [['clientID', 'asc']],
           },
         },
         oneHash: {
@@ -520,8 +521,8 @@ describe('view-syncer/cvr', () => {
         },
         {
           clientAST: {
-            schema: 'zero',
-            table: 'clients',
+            schema: '',
+            table: 'zero.clients',
             where: [
               {
                 field: 'clientGroupID',
@@ -530,6 +531,7 @@ describe('view-syncer/cvr', () => {
                 value: 'abc123',
               },
             ],
+            orderBy: [['clientID', 'asc']],
           },
           clientGroupID: 'abc123',
           deleted: false,

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -153,8 +153,8 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
     const lmidsQuery: InternalQueryRecord = {
       id: CLIENT_LMID_QUERY_ID,
       ast: {
-        schema: 'zero',
-        table: 'clients',
+        schema: '',
+        table: 'zero.clients',
         where: [
           {
             type: 'simple',
@@ -163,6 +163,7 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
             value: this._cvr.id,
           },
         ],
+        orderBy: [['clientID', 'asc']],
       },
       internal: true,
     };

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -362,7 +362,10 @@ describe('view-syncer/pipeline-driver', () => {
   test('remove query', () => {
     pipelines.init();
     [...pipelines.addQuery('hash1', ISSUES_AND_COMMENTS)];
+
+    expect([...pipelines.addedQueries()]).toEqual(['hash1']);
     pipelines.removeQuery('hash1');
+    expect([...pipelines.addedQueries()]).toEqual([]);
 
     const replicator = fakeReplicator(lc, db);
     replicator.processTransaction(
@@ -372,6 +375,8 @@ describe('view-syncer/pipeline-driver', () => {
       messages.insert('issues', {id: 4}),
     );
 
+    expect(pipelines.currentVersion()).toBe('00');
     expect([...pipelines.advance()]).toHaveLength(0);
+    expect(pipelines.currentVersion()).toBe('183');
   });
 });


### PR DESCRIPTION
Implements the initial hydration of pipelines in the ViewSyncer, minus the CVR updates and sending of entity patches.

This restores much of the [full-query processing logic from the query-based implementation](https://github.com/rocicorp/mono/commit/83afe9350bb98468cf9de09c9bb479345bdf401a#diff-a9b68c0290f3027ccb666ed1d227acd36ec9c0ef1720b70547197cdbb572f028L374), but using pipeline hydration instead of Postgres queries.

TODO is the logic to update the CVR with the new ref counts, as well as sent the corresponding entity patches.

And end-to-end test verifies that a version update kicks off the initial hydration and results in sending a poke to the client, with updates to the query set (but not to the entity set yet).

### Miscellany

Updated query ASTs to specify an `orderBy` field, which is required by the PipelineBuilder