### PR TITLE
feat(zero-cache): hook view-syncer to updated CVR logic

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.test.ts
@@ -833,11 +833,8 @@ describe('view-syncer/cvr', () => {
           [
             ROW_ID1,
             {
-              record: {
-                id: ROW_ID1,
-                rowVersion: '03',
-                refCounts: {oneHash: 1},
-              },
+              version: '03',
+              refCounts: {oneHash: 1},
               contents: {id: 'should-show-up-in-patch'},
             },
           ],
@@ -861,22 +858,16 @@ describe('view-syncer/cvr', () => {
           [
             ROW_ID2,
             {
-              record: {
-                id: ROW_ID2,
-                rowVersion: '03',
-                refCounts: {oneHash: 1},
-              },
+              version: '03',
+              refCounts: {oneHash: 1},
               contents: {id: 'same column selection as twoHash'},
             },
           ],
           [
             ROW_ID3,
             {
-              record: {
-                id: ROW_ID3,
-                rowVersion: '09',
-                refCounts: {oneHash: 1},
-              },
+              version: '09',
+              refCounts: {oneHash: 1},
               contents: {id: 'new version patch'},
             },
           ],
@@ -909,11 +900,8 @@ describe('view-syncer/cvr', () => {
           [
             ROW_ID1,
             {
-              record: {
-                id: ROW_ID1,
-                rowVersion: '03',
-                refCounts: {oneHash: 1},
-              },
+              version: '03',
+              refCounts: {oneHash: 1},
               contents: {id: 'should-show-up-in-patch'},
             },
           ],
@@ -1234,11 +1222,8 @@ describe('view-syncer/cvr', () => {
           [
             ROW_ID1,
             {
-              record: {
-                id: ROW_ID1,
-                rowVersion: '03',
-                refCounts: {oneHash: 1},
-              },
+              version: '03',
+              refCounts: {oneHash: 1},
               contents: {id: 'existing patch'},
             },
           ],
@@ -1269,11 +1254,8 @@ describe('view-syncer/cvr', () => {
             // Now referencing ROW_ID2 instead of ROW_ID3
             ROW_ID2,
             {
-              record: {
-                id: ROW_ID2,
-                rowVersion: '09',
-                refCounts: {oneHash: 1},
-              },
+              version: '09',
+              refCounts: {oneHash: 1},
               contents: {id: 'new-row-version-should-bump-cvr-version'},
             },
           ],
@@ -1597,11 +1579,8 @@ describe('view-syncer/cvr', () => {
           [
             ROW_ID1,
             {
-              record: {
-                id: ROW_ID1,
-                rowVersion: '03',
-                refCounts: {oneHash: 1},
-              },
+              version: '03',
+              refCounts: {oneHash: 1},
               contents: {id: 'existing-patch'},
             },
           ],
@@ -1625,13 +1604,8 @@ describe('view-syncer/cvr', () => {
           [
             ROW_ID1,
             {
-              record: {
-                id: ROW_ID1,
-                rowVersion: '03',
-                refCounts: {
-                  twoHash: 1,
-                },
-              },
+              version: '03',
+              refCounts: {twoHash: 1},
               contents: {id: 'existing-patch'},
             },
           ],
@@ -1655,11 +1629,8 @@ describe('view-syncer/cvr', () => {
           // Now referencing ROW_ID2 instead of ROW_ID3
           ROW_ID2,
           {
-            record: {
-              id: ROW_ID2,
-              rowVersion: '09',
-              refCounts: {oneHash: 1},
-            },
+            version: '09',
+            refCounts: {oneHash: 1},
             contents: {
               /* ignored */
             },
@@ -1673,11 +1644,8 @@ describe('view-syncer/cvr', () => {
         [
           ROW_ID2,
           {
-            record: {
-              id: ROW_ID2,
-              rowVersion: '09',
-              refCounts: {twoHash: 1},
-            },
+            version: '09',
+            refCounts: {twoHash: 1},
             contents: {
               /* ignored */
             },
@@ -2314,13 +2282,8 @@ describe('view-syncer/cvr', () => {
           [
             ROW_ID1,
             {
-              record: {
-                id: ROW_ID1,
-                rowVersion: '03',
-                refCounts: {
-                  oneHash: 1,
-                },
-              },
+              version: '03',
+              refCounts: {oneHash: 1},
               contents: {id: 'existing-patch'},
             },
           ],
@@ -2344,11 +2307,8 @@ describe('view-syncer/cvr', () => {
           [
             ROW_ID1,
             {
-              record: {
-                id: ROW_ID1,
-                rowVersion: '03',
-                refCounts: {twoHash: 1},
-              },
+              version: '03',
+              refCounts: {twoHash: 1},
               contents: {id: 'existing-patch'},
             },
           ],
@@ -2371,11 +2331,8 @@ describe('view-syncer/cvr', () => {
         [
           ROW_ID3,
           {
-            record: {
-              id: ROW_ID3,
-              rowVersion: '09',
-              refCounts: {oneHash: 1},
-            },
+            version: '09',
+            refCounts: {oneHash: 1},
             contents: {
               /* ignored */
             },
@@ -2389,11 +2346,8 @@ describe('view-syncer/cvr', () => {
         [
           ROW_ID2,
           {
-            record: {
-              id: ROW_ID2,
-              rowVersion: '03',
-              refCounts: {twoHash: 1},
-            },
+            version: '03',
+            refCounts: {twoHash: 1},
             contents: {
               /* ignored */
             },

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.test.ts
@@ -249,7 +249,6 @@ describe('view-syncer/service', () => {
 
   test('initial hydration', async () => {
     versionNotifications.push({});
-    // TODO: Get RowPatches working.
     expect(await nextPoke()).toMatchInlineSnapshot(`
       [
         [
@@ -299,6 +298,78 @@ describe('view-syncer/service', () => {
                 },
               ],
             },
+            "entitiesPatch": [
+              {
+                "entityID": {
+                  "clientGroupID": "9876",
+                  "clientID": "foo",
+                },
+                "entityType": "zero.clients",
+                "op": "put",
+                "value": {
+                  "clientGroupID": "9876",
+                  "clientID": "foo",
+                  "lastMutationID": 42,
+                  "userID": null,
+                },
+              },
+              {
+                "entityID": {
+                  "id": "1",
+                },
+                "entityType": "issues",
+                "op": "put",
+                "value": {
+                  "big": 9007199254740991,
+                  "id": "1",
+                  "owner": "100",
+                  "parent": null,
+                  "title": "parent issue foo",
+                },
+              },
+              {
+                "entityID": {
+                  "id": "2",
+                },
+                "entityType": "issues",
+                "op": "put",
+                "value": {
+                  "big": -9007199254740991,
+                  "id": "2",
+                  "owner": "101",
+                  "parent": null,
+                  "title": "parent issue bar",
+                },
+              },
+              {
+                "entityID": {
+                  "id": "3",
+                },
+                "entityType": "issues",
+                "op": "put",
+                "value": {
+                  "big": 123,
+                  "id": "3",
+                  "owner": "102",
+                  "parent": "1",
+                  "title": "foo",
+                },
+              },
+              {
+                "entityID": {
+                  "id": "4",
+                },
+                "entityType": "issues",
+                "op": "put",
+                "value": {
+                  "big": 100,
+                  "id": "4",
+                  "owner": "101",
+                  "parent": "2",
+                  "title": "bar",
+                },
+              },
+            ],
             "gotQueriesPatch": [
               {
                 "ast": {
@@ -338,6 +409,77 @@ describe('view-syncer/service', () => {
         ],
       ]
     `);
+
+    expect(await cvrDB`SELECT * from cvr.rows`).toMatchInlineSnapshot(`
+      Result [
+        {
+          "clientGroupID": "9876",
+          "patchVersion": "00:02",
+          "refCounts": {
+            "lmids": 1,
+          },
+          "rowKey": {
+            "clientGroupID": "9876",
+            "clientID": "foo",
+          },
+          "rowVersion": "00",
+          "schema": "",
+          "table": "zero.clients",
+        },
+        {
+          "clientGroupID": "9876",
+          "patchVersion": "00:02",
+          "refCounts": {
+            "query-hash1": 1,
+          },
+          "rowKey": {
+            "id": "1",
+          },
+          "rowVersion": "00",
+          "schema": "",
+          "table": "issues",
+        },
+        {
+          "clientGroupID": "9876",
+          "patchVersion": "00:02",
+          "refCounts": {
+            "query-hash1": 1,
+          },
+          "rowKey": {
+            "id": "2",
+          },
+          "rowVersion": "00",
+          "schema": "",
+          "table": "issues",
+        },
+        {
+          "clientGroupID": "9876",
+          "patchVersion": "00:02",
+          "refCounts": {
+            "query-hash1": 1,
+          },
+          "rowKey": {
+            "id": "3",
+          },
+          "rowVersion": "00",
+          "schema": "",
+          "table": "issues",
+        },
+        {
+          "clientGroupID": "9876",
+          "patchVersion": "00:02",
+          "refCounts": {
+            "query-hash1": 1,
+          },
+          "rowKey": {
+            "id": "4",
+          },
+          "rowVersion": "00",
+          "schema": "",
+          "table": "issues",
+        },
+      ]
+    `);
   });
 
   test('process advancement', async () => {
@@ -365,7 +507,6 @@ describe('view-syncer/service', () => {
     );
 
     versionNotifications.push({});
-    // TODO: Get RowPatches working.
     expect(await nextPoke()).toMatchInlineSnapshot(`
       [
         [
@@ -377,11 +518,109 @@ describe('view-syncer/service', () => {
           },
         ],
         [
+          "pokePart",
+          {
+            "entitiesPatch": [
+              {
+                "entityID": {
+                  "id": "1",
+                },
+                "entityType": "issues",
+                "op": "put",
+                "value": {
+                  "big": 9007199254740991,
+                  "id": "1",
+                  "owner": "100.0",
+                  "parent": null,
+                  "title": "new title",
+                },
+              },
+              {
+                "entityID": {
+                  "id": "2",
+                },
+                "entityType": "issues",
+                "op": "del",
+              },
+            ],
+            "pokeID": "01",
+          },
+        ],
+        [
           "pokeEnd",
           {
             "pokeID": "01",
           },
         ],
+      ]
+    `);
+
+    expect(await cvrDB`SELECT * from cvr.rows`).toMatchInlineSnapshot(`
+      Result [
+        {
+          "clientGroupID": "9876",
+          "patchVersion": "00:02",
+          "refCounts": {
+            "lmids": 1,
+          },
+          "rowKey": {
+            "clientGroupID": "9876",
+            "clientID": "foo",
+          },
+          "rowVersion": "00",
+          "schema": "",
+          "table": "zero.clients",
+        },
+        {
+          "clientGroupID": "9876",
+          "patchVersion": "00:02",
+          "refCounts": {
+            "query-hash1": 1,
+          },
+          "rowKey": {
+            "id": "3",
+          },
+          "rowVersion": "00",
+          "schema": "",
+          "table": "issues",
+        },
+        {
+          "clientGroupID": "9876",
+          "patchVersion": "00:02",
+          "refCounts": {
+            "query-hash1": 1,
+          },
+          "rowKey": {
+            "id": "4",
+          },
+          "rowVersion": "00",
+          "schema": "",
+          "table": "issues",
+        },
+        {
+          "clientGroupID": "9876",
+          "patchVersion": "01",
+          "refCounts": {
+            "query-hash1": 1,
+          },
+          "rowKey": {
+            "id": "1",
+          },
+          "rowVersion": "01",
+          "schema": "",
+          "table": "issues",
+        },
+        {
+          "clientGroupID": "9876",
+          "patchVersion": "01",
+          "refCounts": null,
+          "rowKey": {
+            "id": "2",
+          },
+          "rowVersion": "00",
+          "schema": "",
+          "table": "issues",
+        },
       ]
     `);
   });


### PR DESCRIPTION
* modify the `receive()` API to handle negative ref counts
  * this includes writing a row `del` instead of a `put` if all counts go to zero
* use `receive()` (only) to handle incremental updates