### PR TITLE
fix(zero-cache): fix readiness detection

### DIFF
--- a/packages/zero-cache/src/server/life-cycle.ts
+++ b/packages/zero-cache/src/server/life-cycle.ts
@@ -1,4 +1,0 @@
-/**
- * Sent as the first message to the `parentPort` when ready / warm.
- */
-export type ReadySignal = {ready: true};


### PR DESCRIPTION
Revert to filtering the 'message' signals and only marking a worker as ready if a `['ready', ... ]` message is received.

The `once('message', ...)` simplification was incorrect because Syncers will send other messages (e.g. `['subscribe', ...]`) to the parent before it is technically "ready" (i.e. db connections are warmed up).