### PR TITLE
fix(zqlite): convert sqlite types before pushing to outputs

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -1,8 +1,6 @@
 import {LogContext} from '@rocicorp/logger';
 import {TableSource} from '@rocicorp/zqlite/src/table-source.js';
 import {assert} from 'shared/src/asserts.js';
-import {must} from 'shared/src/must.js';
-import {JSONValue} from 'zero-cache/src/types/bigint-json.js';
 import {mapLiteDataTypeToZqlValueType} from 'zero-cache/src/types/lite.js';
 import {AST} from 'zql/src/zql/ast/ast.js';
 import {buildPipeline} from 'zql/src/zql/builder/builder.js';
@@ -190,28 +188,13 @@ export class PipelineDriver {
     };
   }
 
-  #convertTypes(table: string, row: Record<string, JSONValue>): Row {
-    assert(this.#tableSpecs);
-    const spec = must(this.#tableSpecs.get(table));
-    for (const col of spec.boolColumns) {
-      row[col] = !!row[col];
-    }
-    return row as Row;
-  }
-
   *#advance(diff: SnapshotDiff): Iterable<RowChange> {
     for (const {table, prevValue, nextValue} of diff) {
       if (prevValue) {
-        yield* this.#push(table, {
-          type: 'remove',
-          row: this.#convertTypes(table, prevValue),
-        });
+        yield* this.#push(table, {type: 'remove', row: prevValue as Row});
       }
       if (nextValue) {
-        yield* this.#push(table, {
-          type: 'add',
-          row: this.#convertTypes(table, nextValue),
-        });
+        yield* this.#push(table, {type: 'add', row: nextValue as Row});
       }
     }
 

--- a/packages/zqlite/src/table-source.ts
+++ b/packages/zqlite/src/table-source.ts
@@ -288,6 +288,8 @@ export class TableSource implements Source {
       assert(exists, 'Row not found');
     }
 
+    // Outputs should see converted types (e.g. boolean).
+    fromSQLiteTypes(this.#columns, change.row);
     for (const [outputIndex, {output}] of this.#connections.entries()) {
       this.#overlay = {outputIndex, change};
       if (output) {


### PR DESCRIPTION
Fixes the handling of BOOL columns for pushed rows at the TableSource level (instead of doing it in the ViewSyncer https://github.com/rocicorp/mono/pull/2286).