### PR TITLE
chore(zero-cache): avoid awaiting writes executed in a CVR transaction

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -123,9 +123,13 @@ export class CVRUpdater {
 
     this.#setLastActive(lastActive);
     const numEntries = this._cvrStore.numPendingWrites();
-    await this._cvrStore.flush();
+    const statements = await this._cvrStore.flush();
 
-    lc.debug?.(`flushed ${numEntries} CVR entries (${Date.now() - start} ms)`);
+    lc.debug?.(
+      `flushed ${numEntries} CVR entries with ${statements} statements (${
+        Date.now() - start
+      } ms)`,
+    );
     return this._cvr;
   }
 }

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -27,7 +27,7 @@ import {
   type CVRSnapshot,
 } from './cvr.js';
 import {PipelineDriver, RowChange} from './pipeline-driver.js';
-import {cmpVersions, RowID} from './schema/types.js';
+import {cmpVersions, RowID, versionToCookie} from './schema/types.js';
 
 export type SyncContext = {
   readonly clientID: string;
@@ -325,7 +325,9 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     const cvrVersion = this.#cvr.version;
 
     if (cvrVersion.stateVersion !== dbVersion) {
-      this.#lc.info?.(`CVR (${cvrVersion}) is behind db ${dbVersion}`);
+      this.#lc.info?.(
+        `CVR (${versionToCookie(cvrVersion)}) is behind db ${dbVersion}`,
+      );
       return; // hydration needs to be run with the CVR updater.
     }
 


### PR DESCRIPTION
Postgres always executes statements in a transaction in the order in which they are sent/executed, so there is no need to `await` write statements.

Thanks to @grgbkr 's batching of row writes, the number of statements actually executed is relatively small (e.g. 19 statements for ~78000 entries), so this doesn't actually make a huge difference in latency in this case. But the pattern for executing writes without waiting (in a transaction) is a good one to adopt regardless.

Before:
<img width="984" alt="Screenshot 2024-09-01 at 11 29 13 copy" src="https://github.com/user-attachments/assets/7e1c938c-11b3-40a4-a3d6-a6e359f35f1f">

After:
<img width="1048" alt="Screenshot 2024-09-01 at 11 30 04 copy" src="https://github.com/user-attachments/assets/05322478-4246-4d02-bd2c-89464ad21042">
