### PR TITLE
chore(zql): Simplify query Schema

### DIFF
--- a/packages/zql/src/zql/query/schema.ts
+++ b/packages/zql/src/zql/query/schema.ts
@@ -1,4 +1,4 @@
-import {ValueType} from '../ivm/schema.js';
+import type {PrimaryKeys, ValueType} from '../ivm/schema.js';
 
 /**
  * `related` calls need to know what the available relationships are.
@@ -11,10 +11,7 @@ export type SchemaValue = {
 
 export type Schema = {
   readonly table: string;
-  readonly primaryKey: readonly [
-    keyof Schema['fields'],
-    ...(keyof Schema['fields'])[],
-  ];
+  readonly primaryKey: PrimaryKeys;
   readonly fields: Record<string, SchemaValue>;
   readonly relationships?: {
     [key: string]:


### PR DESCRIPTION
Extracting the field does not really do anything here. It just gives us string.

We could change Schema to have a parameterized type but it does not seem worth it yet.

Instead we can just use the simpler type directly.