### PR TITLE
chore(zql): Extract a SchemaBase type

### DIFF
--- a/packages/zql/src/zql/ivm/memory-source.ts
+++ b/packages/zql/src/zql/ivm/memory-source.ts
@@ -80,9 +80,9 @@ export class MemorySource implements Source {
       tableName: this.#tableName,
       columns: this.#columns,
       primaryKey: this.#primaryKeys,
-      compareRows: connection.compareRows,
       relationships: {},
       isHidden: false,
+      compareRows: connection.compareRows,
     };
   }
 

--- a/packages/zql/src/zql/ivm/schema.ts
+++ b/packages/zql/src/zql/ivm/schema.ts
@@ -13,19 +13,17 @@ export type SchemaValue = {
 
 export type PrimaryKeys = readonly [string, ...string[]];
 
+export type SchemaBase = {
+  readonly tableName: string;
+  readonly primaryKey: PrimaryKeys;
+  readonly columns: Record<string, SchemaValue>;
+};
+
 /**
  * Information about the nodes output by an operator.
  */
-export type Schema = {
-  tableName: string;
-  primaryKey: PrimaryKeys;
-  columns: Record<string, SchemaValue>;
-  isHidden: boolean;
-
-  /**
-   * Compares two rows in the output of an operator.
-   */
-  compareRows: (r1: Row, r2: Row) => number;
-
-  relationships?: Record<string, Schema>;
+export type Schema = SchemaBase & {
+  readonly relationships?: {[key: string]: Schema};
+  readonly isHidden: boolean;
+  readonly compareRows: (r1: Row, r2: Row) => number;
 };

--- a/packages/zql/src/zql/query/schema.ts
+++ b/packages/zql/src/zql/query/schema.ts
@@ -1,28 +1,13 @@
-import type {PrimaryKeys, SchemaValue, ValueType} from '../ivm/schema.js';
+import type {SchemaBase} from '../ivm/schema.js';
 
-export type Schema = {
-  readonly tableName: string;
-  readonly primaryKey: PrimaryKeys;
-  readonly columns: Record<string, SchemaValue>;
-  readonly relationships?: {
-    [key: string]:
-      | FieldRelationship<Schema, Schema>
-      | JunctionRelationship<Schema, Schema, Schema>;
-  };
+export type Schema = SchemaBase & {
+  readonly relationships?: Record<string, Relationship>;
 };
-
-export function columnTypes(schema: Schema): Record<string, ValueType> {
-  const columns: Record<string, ValueType> = {};
-  for (const [key, value] of Object.entries(schema.columns)) {
-    columns[key] = value.type;
-  }
-  return columns;
-}
 
 /**
  * A schema might have a relationship to itself.
  * Given we cannot reference a variable in the same statement we initialize
- * the variable, we use a lazy function to get around this.
+ * the variable, we use a function to get around this.
  */
 export type Lazy<T> = () => T;
 

--- a/packages/zqlite/src/table-source.ts
+++ b/packages/zqlite/src/table-source.ts
@@ -142,9 +142,9 @@ export class TableSource implements Source {
       tableName: this.#table,
       columns: this.#columns,
       primaryKey: this.#primaryKey,
-      compareRows: connection.compareRows,
       relationships: {},
       isHidden: false,
+      compareRows: connection.compareRows,
     };
   }
 


### PR DESCRIPTION
I wanted to make `relationships` shared too but TypeScript doesn't like the recursive type definition it introduces.