### PR TITLE
fix(zero-cache): Convert bigints back to number when pushing changes into pipeline

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -8,8 +8,10 @@ import {initChangeLog} from '../replicator/schema/change-log.js';
 import {initReplicationState} from '../replicator/schema/replication-state.js';
 import {fakeReplicator, ReplicationMessages} from '../replicator/test-utils.js';
 import {CREATE_STORAGE_TABLE, DatabaseStorage} from './database-storage.js';
-import {PipelineDriver} from './pipeline-driver.js';
+import {PipelineDriver, toRow} from './pipeline-driver.js';
 import {Snapshotter} from './snapshotter.js';
+import {RowValue} from 'zero-cache/src/types/row-key.js';
+import {Row} from 'zql/src/zql/ivm/data.js';
 
 describe('view-syncer/pipeline-driver', () => {
   let dbFile: DbFile;
@@ -420,5 +422,96 @@ describe('view-syncer/pipeline-driver', () => {
     );
 
     expect(() => [...pipelines.advance().changes]).toThrowError();
+  });
+});
+
+describe('toRow', () => {
+  function t({
+    name,
+    rowValue,
+    expectedError,
+    expectedRow,
+  }: {
+    name: string;
+    rowValue: RowValue;
+    expectedError?: string | undefined;
+    expectedRow?: Row | undefined;
+  }) {
+    test(name, () => {
+      try {
+        expect(toRow(rowValue)).toEqual(expectedRow);
+        expect(expectedError).toEqual(undefined);
+      } catch (e) {
+        expect(String(e)).toEqual(expectedError);
+      }
+    });
+  }
+
+  t({
+    name: 'all supported no conversion types',
+    rowValue: {
+      strK: 'bar',
+      numK: 1,
+      boolK: true,
+      nullK: null,
+    },
+    expectedRow: {
+      strK: 'bar',
+      numK: 1,
+      boolK: true,
+      nullK: null,
+    },
+  });
+
+  t({
+    name: 'successful bigint clamp',
+    rowValue: {
+      strK: 'bar',
+      bigintK: 1n,
+    },
+    expectedRow: {
+      strK: 'bar',
+      bigintK: 1,
+    },
+  });
+
+  t({
+    name: 'bigint clamp failed',
+    rowValue: {
+      strK: 'bar',
+      bigintK: 9007199254740992n,
+    },
+    expectedError:
+      'Error: value in column bigintK exceeds the maximum safe value 9007199254740992',
+  });
+
+  t({
+    name: 'unsupported object',
+    rowValue: {
+      strK: 'bar',
+      objK: {},
+    },
+    expectedError:
+      'Error: value in column objK is of an unsupported type. {} object',
+  });
+
+  t({
+    name: 'unsupported array',
+    rowValue: {
+      strK: 'bar',
+      dateK: new Date(1000),
+    },
+    expectedError:
+      'Error: value in column dateK is of an unsupported type. "1970-01-01T00:00:01.000Z" object',
+  });
+
+  t({
+    name: 'unsupported date',
+    rowValue: {
+      strK: 'bar',
+      arrayK: [],
+    },
+    expectedError:
+      'Error: value in column arrayK is of an unsupported type. [] object',
   });
 });


### PR DESCRIPTION
Before making this change incremental pipeline updates were failing with errors like:

```
worker=syncer pid=32173 component=view-syncer serviceID=ruku6nqsfmdcanh8nd clientID=t414rl69i0h2evbbkl wsID=vl7Yo6eIPyTX2Uqy7lagy 
client closed with error {"name":"Error","message":"Unsupported type: 4 bigint","stack":"Error: Unsupported type: 4 bigint
   at compareValues (file:///Users/greg/github/mono/packages/zql/src/zql/ivm/data.ts:94:9)
   at Object.compareRows (file:///Users/greg/github/mono/packages/zql/src/zql/ivm/data.ts:115:20)
   at Take.push (file:///Users/greg/github/mono/packages/zql/src/zql/ivm/take.ts:283:44)
   at TableSource.push (file:///Users/greg/github/mono/packages/zqlite/src/table-source.ts:294:16)
   at PipelineDriver.#push (file:///Users/greg/github/mono/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts:268:12)\n    at #push.next (<anonymous>)   
   at PipelineDriver.#advance (file:///Users/greg/github/mono/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts:205:26)
   at #advance.next (<anonymous>)
   at ViewSyncerService.#processChanges (file:///Users/greg/github/mono/packages/zero-cache/src/services/view-syncer/view-syncer.ts:472:16)\
   at ViewSyncerService.#advancePipelines (file:///Users/greg/github/mono/packages/zero-cache/src/services/view-syncer/view-syncer.ts:524:31)"}
worker=syncer pid=32173 component=view-syncer serviceID=ruku6nqsfmdcanh8nd view-syncer stopped
```