### PR TITLE
chore(zero-cache): rename returned field for clarity

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.test.ts
@@ -825,7 +825,7 @@ describe('view-syncer/cvr', () => {
     const cvr = await cvrStore.load();
     const updater = new CVRQueryDrivenUpdater(cvrStore, cvr, '1aa');
 
-    const {cvrVersion: newVersion, queryPatches} = updater.trackQueries(
+    const {newVersion, queryPatches} = updater.trackQueries(
       lc,
       [{id: 'oneHash', transformationHash: 'serverOneHash'}],
       [],
@@ -1225,7 +1225,7 @@ describe('view-syncer/cvr', () => {
     const cvr = await cvrStore.load();
     const updater = new CVRQueryDrivenUpdater(cvrStore, cvr, '1ba');
 
-    const {cvrVersion: newVersion, queryPatches} = updater.trackQueries(
+    const {newVersion, queryPatches} = updater.trackQueries(
       lc,
       [{id: 'oneHash', transformationHash: 'serverTwoHash'}],
       [],
@@ -1580,7 +1580,7 @@ describe('view-syncer/cvr', () => {
     const cvr = await cvrStore.load();
     const updater = new CVRQueryDrivenUpdater(cvrStore, cvr, '1ba');
 
-    const {cvrVersion: newVersion, queryPatches} = updater.trackQueries(
+    const {newVersion, queryPatches} = updater.trackQueries(
       lc,
       [
         {id: 'oneHash', transformationHash: 'updatedServerOneHash'},
@@ -1954,7 +1954,7 @@ describe('view-syncer/cvr', () => {
     const cvr = await cvrStore.load();
     const updater = new CVRQueryDrivenUpdater(cvrStore, cvr, '1ba');
 
-    const {cvrVersion: newVersion, queryPatches} = updater.trackQueries(
+    const {newVersion, queryPatches} = updater.trackQueries(
       lc,
       [],
       ['oneHash'],
@@ -2300,7 +2300,7 @@ describe('view-syncer/cvr', () => {
     `);
     const updater = new CVRQueryDrivenUpdater(cvrStore, cvr, '1ba');
 
-    const {cvrVersion: newVersion, queryPatches} = updater.trackQueries(
+    const {newVersion, queryPatches} = updater.trackQueries(
       lc,
       [
         {id: 'oneHash', transformationHash: 'serverOneHash'},

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -295,7 +295,7 @@ export class CVRQueryDrivenUpdater extends CVRUpdater {
     executed: {id: string; transformationHash: string}[],
     removed: string[],
     catchupFrom: NullableCVRVersion,
-  ): {cvrVersion: CVRVersion; queryPatches: PatchToVersion[]} {
+  ): {newVersion: CVRVersion; queryPatches: PatchToVersion[]} {
     assert(this.#existingRows === undefined, `trackQueries already called`);
 
     const queryPatches: Patch[] = [
@@ -316,7 +316,7 @@ export class CVRQueryDrivenUpdater extends CVRUpdater {
         this._cvrStore.catchupConfigPatches(startingVersion);
     }
     return {
-      cvrVersion: this._cvr.version,
+      newVersion: this._cvr.version,
       queryPatches: queryPatches.map(patch => ({
         patch,
         toVersion: this._cvr.version,

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -406,14 +406,14 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
     // Note: This kicks of background PG queries for CVR data associated with the
     // executed and removed queries.
-    const {cvrVersion, queryPatches} = updater.trackQueries(
+    const {newVersion, queryPatches} = updater.trackQueries(
       lc,
       addQueries.map(hash => ({id: hash, transformationHash: hash})),
       removeQueries,
       minClientVersion,
     );
     const pokers = [...this.#clients.values()].map(c =>
-      c.startPoke(cvrVersion),
+      c.startPoke(newVersion),
     );
     for (const patch of queryPatches) {
       pokers.forEach(poker => poker.addPatch(patch));


### PR DESCRIPTION
Rename the returned field from `cvrVersion` to `newVersion` for clarity, particularly with an upcoming PR that will reference the old version. 