### PR TITLE
feat(zero-cache): avoid rewriting the lmids query

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.test.ts
@@ -530,18 +530,6 @@ describe('view-syncer/cvr', () => {
         },
         {
           clientAST: {
-            table: 'comments',
-          },
-          clientGroupID: 'abc123',
-          deleted: false,
-          internal: null,
-          patchVersion: null,
-          queryHash: 'threeHash',
-          transformationHash: null,
-          transformationVersion: null,
-        },
-        {
-          clientAST: {
             schema: '',
             table: 'zero.clients',
             where: [
@@ -562,6 +550,18 @@ describe('view-syncer/cvr', () => {
           internal: true,
           patchVersion: null,
           queryHash: 'lmids',
+          transformationHash: null,
+          transformationVersion: null,
+        },
+        {
+          clientAST: {
+            table: 'comments',
+          },
+          clientGroupID: 'abc123',
+          deleted: false,
+          internal: null,
+          patchVersion: null,
+          queryHash: 'threeHash',
           transformationHash: null,
           transformationVersion: null,
         },

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -148,29 +148,30 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
 
     this._cvrStore.insertClient(client);
 
-    const lmidsQuery: InternalQueryRecord = {
-      id: CLIENT_LMID_QUERY_ID,
-      ast: {
-        schema: '',
-        table: 'zero.clients',
-        where: [
-          {
-            type: 'simple',
-            field: 'clientGroupID',
-            op: '=',
-            value: this._cvr.id,
-          },
-        ],
-        orderBy: [
-          ['clientGroupID', 'asc'],
-          ['clientID', 'asc'],
-        ],
-      },
-      internal: true,
-    };
-    this._cvr.queries[CLIENT_LMID_QUERY_ID] = lmidsQuery;
-    this._cvrStore.putQuery(lmidsQuery);
-
+    if (!this._cvr.queries[CLIENT_LMID_QUERY_ID]) {
+      const lmidsQuery: InternalQueryRecord = {
+        id: CLIENT_LMID_QUERY_ID,
+        ast: {
+          schema: '',
+          table: 'zero.clients',
+          where: [
+            {
+              type: 'simple',
+              field: 'clientGroupID',
+              op: '=',
+              value: this._cvr.id,
+            },
+          ],
+          orderBy: [
+            ['clientGroupID', 'asc'],
+            ['clientID', 'asc'],
+          ],
+        },
+        internal: true,
+      };
+      this._cvr.queries[CLIENT_LMID_QUERY_ID] = lmidsQuery;
+      this._cvrStore.putQuery(lmidsQuery);
+    }
     return client;
   }
 


### PR DESCRIPTION
The query for last modification ids used to contain an `OR` of all of the `clientIDs`, but now that it no longer does (as of https://github.com/rocicorp/mono/commit/160c4b2ad9d912ab351e83d9589210b247834ad3#diff-bb6552d08e698958f0505e6bfcab7828b0e1df6d8f467a3903383c315380157b), it need not be re-put on every new client. Just write it the first time.