### PR TITLE
feat(zero-cache): use the db class that logs slow queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6639,10 +6639,6 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
-    "node_modules/@rocicorp/zqlite": {
-      "resolved": "packages/zqlite",
-      "link": true
-    },
     "node_modules/@rollup/plugin-node-resolve": {
       "version": "15.2.3",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.2.3.tgz",
@@ -23822,6 +23818,10 @@
       "resolved": "packages/zql",
       "link": true
     },
+    "node_modules/zqlite": {
+      "resolved": "packages/zqlite",
+      "link": true
+    },
     "packages/btree": {
       "version": "0.0.0",
       "license": "MIT",
@@ -25396,7 +25396,6 @@
         "@rocicorp/lock": "^1.0.4",
         "@rocicorp/logger": "^5.2.2",
         "@rocicorp/resolver": "^1.0.2",
-        "@rocicorp/zqlite": "0.0.0",
         "compare-utf8": "^0.1.1",
         "datadog": "0.0.0",
         "eventemitter3": "^5.0.1",
@@ -25409,7 +25408,8 @@
         "postgres-array": "^3.0.2",
         "xxhash-wasm": "^1.0.2",
         "zero-protocol": "0.0.0",
-        "zql": "0.0.0"
+        "zql": "0.0.0",
+        "zqlite": "0.0.0"
       },
       "devDependencies": {
         "@rocicorp/eslint-config": "^0.5.1",
@@ -26235,7 +26235,6 @@
       }
     },
     "packages/zqlite": {
-      "name": "@rocicorp/zqlite",
       "version": "0.0.0",
       "dependencies": {
         "@databases/escape-identifier": "^1.0.3",
@@ -30026,41 +30025,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@rocicorp/resolver/-/resolver-1.0.2.tgz",
       "integrity": "sha512-TfjMTQp9cNNqNtHFfa+XHEGdA7NnmDRu+ZJH4YF3dso0Xk/b9DMhg/sl+b6CR4ThFZArXXDsG1j8Mwl34wcOZQ=="
-    },
-    "@rocicorp/zqlite": {
-      "version": "file:packages/zqlite",
-      "requires": {
-        "@databases/escape-identifier": "^1.0.3",
-        "@databases/sql": "^3.3.0",
-        "@rocicorp/eslint-config": "^0.5.1",
-        "@rocicorp/logger": "^5.2.2",
-        "@rocicorp/prettier-config": "^0.2.0",
-        "@types/better-sqlite3": "^7.6.0",
-        "fast-check": "^3.18.0",
-        "nanoid": "^4.0.2",
-        "pg-logical-replication": "^2.0.5",
-        "playwright": "^1.43.1",
-        "shared": "0.0.0",
-        "typescript": "^5.5.3",
-        "zql": "0.0.0"
-      },
-      "dependencies": {
-        "fast-check": {
-          "version": "3.19.0",
-          "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.19.0.tgz",
-          "integrity": "sha512-CO2JX/8/PT9bDGO1iXa5h5ey1skaKI1dvecERyhH4pp3PGjwd3KIjMAXEg79Ps9nclsdt4oPbfqiAnLU0EwrAQ==",
-          "dev": true,
-          "requires": {
-            "pure-rand": "^6.1.0"
-          }
-        },
-        "nanoid": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
-          "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
-          "dev": true
-        }
-      }
     },
     "@rollup/plugin-node-resolve": {
       "version": "15.2.3",
@@ -43530,7 +43494,6 @@
         "@rocicorp/logger": "^5.2.2",
         "@rocicorp/prettier-config": "^0.2.0",
         "@rocicorp/resolver": "^1.0.2",
-        "@rocicorp/zqlite": "0.0.0",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@testcontainers/postgresql": "^10.9.0",
         "@types/better-sqlite3": "^7.6.0",
@@ -43557,7 +43520,8 @@
         "vitest": "^2.0.3",
         "xxhash-wasm": "^1.0.2",
         "zero-protocol": "0.0.0",
-        "zql": "0.0.0"
+        "zql": "0.0.0",
+        "zqlite": "0.0.0"
       },
       "dependencies": {
         "@types/node": {
@@ -44016,6 +43980,41 @@
           "version": "3.18.0",
           "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.18.0.tgz",
           "integrity": "sha512-/951xaT0kA40w0GXRsZXEwSTE7LugjZtSA/8vPgFkiPQ8wNp8tRvqWuNDHBgLxJYXtsK11e/7Q4ObkKW5BdTFQ==",
+          "dev": true,
+          "requires": {
+            "pure-rand": "^6.1.0"
+          }
+        },
+        "nanoid": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+          "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+          "dev": true
+        }
+      }
+    },
+    "zqlite": {
+      "version": "file:packages/zqlite",
+      "requires": {
+        "@databases/escape-identifier": "^1.0.3",
+        "@databases/sql": "^3.3.0",
+        "@rocicorp/eslint-config": "^0.5.1",
+        "@rocicorp/logger": "^5.2.2",
+        "@rocicorp/prettier-config": "^0.2.0",
+        "@types/better-sqlite3": "^7.6.0",
+        "fast-check": "^3.18.0",
+        "nanoid": "^4.0.2",
+        "pg-logical-replication": "^2.0.5",
+        "playwright": "^1.43.1",
+        "shared": "0.0.0",
+        "typescript": "^5.5.3",
+        "zql": "0.0.0"
+      },
+      "dependencies": {
+        "fast-check": {
+          "version": "3.19.0",
+          "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.19.0.tgz",
+          "integrity": "sha512-CO2JX/8/PT9bDGO1iXa5h5ey1skaKI1dvecERyhH4pp3PGjwd3KIjMAXEg79Ps9nclsdt4oPbfqiAnLU0EwrAQ==",
           "dev": true,
           "requires": {
             "pure-rand": "^6.1.0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "type": "module",
   "scripts": {
     "download-deps": "bash ./deps/download.sh",
-    "preinstall": "npm install -w @rocicorp/zqlite -w zero-cache better-sqlite3@11.1.2 --no-save --build-from-source --sqlite3=\"$(pwd)/deps/sqlite3\"",
+    "preinstall": "npm install -w zqlite -w zero-cache better-sqlite3@11.1.2 --no-save --build-from-source --sqlite3=\"$(pwd)/deps/sqlite3\"",
     "build": "turbo run build",
     "dev": "turbo run dev",
     "test": "turbo run test",

--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -21,7 +21,7 @@
     "@rocicorp/lock": "^1.0.4",
     "@rocicorp/logger": "^5.2.2",
     "@rocicorp/resolver": "^1.0.2",
-    "@rocicorp/zqlite": "0.0.0",
+    "zqlite": "0.0.0",
     "compare-utf8": "^0.1.1",
     "datadog": "0.0.0",
     "eventemitter3": "^5.0.1",

--- a/packages/zero-cache/src/db/begin-concurrent.test.ts
+++ b/packages/zero-cache/src/db/begin-concurrent.test.ts
@@ -1,12 +1,13 @@
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {DbFile} from '../test/lite.js';
+import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
 
 describe('db/begin-concurrent', () => {
   let dbFile: DbFile;
-
+  const lc = createSilentLogContext();
   beforeEach(() => {
     dbFile = new DbFile('begin-concurrent');
-    const conn = dbFile.connect();
+    const conn = dbFile.connect(lc);
     conn.pragma('journal_mode = WAL');
     conn.pragma('synchronous = NORMAL');
     conn.exec('CREATE TABLE foo(id INTEGER PRIMARY KEY);');
@@ -18,11 +19,11 @@ describe('db/begin-concurrent', () => {
   });
 
   test('independent, concurrent actions before commit', () => {
-    const conn1 = dbFile.connect();
+    const conn1 = dbFile.connect(lc);
     conn1.pragma('journal_mode = WAL');
     conn1.prepare('BEGIN CONCURRENT').run();
 
-    const conn2 = dbFile.connect();
+    const conn2 = dbFile.connect(lc);
     conn2.pragma('journal_mode = WAL');
     conn2.prepare('BEGIN CONCURRENT').run();
 
@@ -40,11 +41,11 @@ describe('db/begin-concurrent', () => {
   });
 
   test('begin concurrent is deferred', () => {
-    const conn1 = dbFile.connect();
+    const conn1 = dbFile.connect(lc);
     conn1.pragma('journal_mode = WAL');
     conn1.prepare('BEGIN CONCURRENT').run();
 
-    const conn2 = dbFile.connect();
+    const conn2 = dbFile.connect(lc);
     conn2.pragma('journal_mode = WAL');
 
     // Note: Like BEGIN DEFERRED, the BEGIN CONCURRENT transaction does not actually start until
@@ -70,13 +71,13 @@ describe('db/begin-concurrent', () => {
   });
 
   test('simulate immediate', () => {
-    const conn1 = dbFile.connect();
+    const conn1 = dbFile.connect(lc);
     conn1.pragma('journal_mode = WAL');
     conn1.prepare('BEGIN CONCURRENT').run();
     // Force the transaction to start immediately by accessing the database.
     expect(conn1.prepare('SELECT * FROM foo').all()).toEqual([]);
 
-    const conn2 = dbFile.connect();
+    const conn2 = dbFile.connect(lc);
     conn2.pragma('journal_mode = WAL');
     conn2.prepare('BEGIN CONCURRENT').run();
     // Force the transaction to start immediately by accessing the database.
@@ -98,13 +99,13 @@ describe('db/begin-concurrent', () => {
   });
 
   test('begin concurrent with savepoints', () => {
-    const conn1 = dbFile.connect();
+    const conn1 = dbFile.connect(lc);
     conn1.pragma('journal_mode = WAL');
     conn1.prepare('BEGIN CONCURRENT').run();
     // Force the transaction to start immediately by accessing the database.
     expect(conn1.prepare('SELECT * FROM foo').all()).toEqual([]);
 
-    const conn2 = dbFile.connect();
+    const conn2 = dbFile.connect(lc);
     conn2.pragma('journal_mode = WAL');
     conn2.prepare('BEGIN CONCURRENT').run();
     // Force the transaction to start immediately by accessing the database.

--- a/packages/zero-cache/src/db/migration-lite.test.ts
+++ b/packages/zero-cache/src/db/migration-lite.test.ts
@@ -1,5 +1,5 @@
 import type {LogContext} from '@rocicorp/logger';
-import type {Database as Db} from 'better-sqlite3';
+import type {Database as Db} from 'zqlite/src/db.js';
 import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {DbFile} from '../test/lite.js';
@@ -178,7 +178,7 @@ describe('db/migration-lite', () => {
 
   beforeEach(() => {
     dbFile = new DbFile('migration-test');
-    db = dbFile.connect();
+    db = dbFile.connect(createSilentLogContext());
     db.pragma('journal_mode = WAL');
     db.pragma('synchronous = NORMAL');
     db.prepare(`CREATE TABLE "MigrationHistory" (event TEXT)`).run();

--- a/packages/zero-cache/src/db/migration-lite.ts
+++ b/packages/zero-cache/src/db/migration-lite.ts
@@ -1,6 +1,6 @@
 import type {LogContext} from '@rocicorp/logger';
-import type {Database as Db} from 'better-sqlite3';
-import Database from 'better-sqlite3';
+import type {Database as Db} from 'zqlite/src/db.js';
+import {Database} from 'zqlite/src/db.js';
 import {assert} from 'shared/src/asserts.js';
 import {randInt} from 'shared/src/rand.js';
 import * as v from 'shared/src/valita.js';
@@ -42,7 +42,7 @@ export async function runSchemaMigrations(
     'initSchema',
     randInt(0, Number.MAX_SAFE_INTEGER).toString(36),
   );
-  const db = new Database(dbPath);
+  const db = new Database(log, dbPath);
   db.pragma('foreign_keys = OFF');
   db.pragma('journal_mode = WAL');
 

--- a/packages/zero-cache/src/db/statements.test.ts
+++ b/packages/zero-cache/src/db/statements.test.ts
@@ -1,13 +1,14 @@
-import Database from 'better-sqlite3';
+import {Database} from 'zqlite/src/db.js';
 import {beforeEach, describe, expect, test} from 'vitest';
 import {expectTables} from '../test/lite.js';
 import {StatementRunner} from './statements.js';
+import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
 
 describe('db/statements', () => {
   let db: StatementRunner;
 
   beforeEach(() => {
-    const conn = new Database(':memory:');
+    const conn = new Database(createSilentLogContext(), ':memory:');
     conn.exec('CREATE TABLE foo(id INT PRIMARY KEY)');
     db = new StatementRunner(conn);
   });

--- a/packages/zero-cache/src/db/statements.ts
+++ b/packages/zero-cache/src/db/statements.ts
@@ -1,5 +1,6 @@
-import {StatementCache} from '@rocicorp/zqlite/src/internal/statement-cache.js';
-import {Database, RunResult} from 'better-sqlite3';
+import {StatementCache} from 'zqlite/src/internal/statement-cache.js';
+import {RunResult} from 'better-sqlite3';
+import {Database} from 'zqlite/src/db.js';
 
 /**
  * A stateless wrapper around a {@link StatementCache} that facilitates single-line

--- a/packages/zero-cache/src/services/replicator/incremental-sync.message-processor.test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.message-processor.test.ts
@@ -1,5 +1,5 @@
 import {LogContext} from '@rocicorp/logger';
-import Database from 'better-sqlite3';
+import {Database} from 'zqlite/src/db.js';
 import type {Pgoutput} from 'pg-logical-replication';
 import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
 import {beforeEach, describe, expect, test} from 'vitest';
@@ -14,11 +14,11 @@ import {createMessageProcessor, ReplicationMessages} from './test-utils.js';
 
 describe('replicator/message-processor', () => {
   let lc: LogContext;
-  let replica: Database.Database;
+  let replica: Database;
 
   beforeEach(() => {
     lc = createSilentLogContext();
-    replica = new Database(':memory:');
+    replica = new Database(lc, ':memory:');
 
     replica.exec(`
     CREATE TABLE "foo" (

--- a/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
@@ -1,5 +1,5 @@
 import {LogContext} from '@rocicorp/logger';
-import Database from 'better-sqlite3';
+import {Database} from 'zqlite/src/db.js';
 import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {StatementRunner} from 'zero-cache/src/db/statements.js';
@@ -51,13 +51,13 @@ const REPLICATED_ZERO_CLIENTS_SPEC: TableSpec = {
 describe('replicator/incremental-sync', {retry: 3}, () => {
   let lc: LogContext;
   let upstream: PostgresDB;
-  let replica: Database.Database;
+  let replica: Database;
   let syncer: IncrementalSyncer;
 
   beforeEach(async () => {
     lc = createSilentLogContext();
     upstream = await testDBs.create('incremental_sync_test_upstream');
-    replica = new Database(':memory:');
+    replica = new Database(lc, ':memory:');
     syncer = new IncrementalSyncer(
       getConnectionURI(upstream),
       REPLICA_ID,

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -1,5 +1,5 @@
 import type {LogContext} from '@rocicorp/logger';
-import {Database} from 'better-sqlite3';
+import {Database} from 'zqlite/src/db.js';
 import {ident} from 'pg-format';
 import {
   LogicalReplicationService,

--- a/packages/zero-cache/src/services/replicator/initial-sync.ts
+++ b/packages/zero-cache/src/services/replicator/initial-sync.ts
@@ -1,5 +1,5 @@
 import type {LogContext} from '@rocicorp/logger';
-import {Database} from 'better-sqlite3';
+import {Database} from 'zqlite/src/db.js';
 import {ident} from 'pg-format';
 import postgres from 'postgres';
 import {

--- a/packages/zero-cache/src/services/replicator/initial-sync.validation.test.ts
+++ b/packages/zero-cache/src/services/replicator/initial-sync.validation.test.ts
@@ -1,4 +1,4 @@
-import Database from 'better-sqlite3';
+import {Database} from 'zqlite/src/db.js';
 import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {PostgresDB} from 'zero-cache/src/types/pg.js';
@@ -9,11 +9,11 @@ const REPLICA_ID = 'initial_sync_validation_test_id';
 
 describe('replicator/initial-sync-validation', () => {
   let upstream: PostgresDB;
-  let replica: Database.Database;
+  let replica: Database;
 
   beforeEach(async () => {
     upstream = await testDBs.create('initial_sync_validation_upstream');
-    replica = new Database(':memory:');
+    replica = new Database(createSilentLogContext(), ':memory:');
   });
 
   afterEach(async () => {

--- a/packages/zero-cache/src/services/replicator/replicator.ts
+++ b/packages/zero-cache/src/services/replicator/replicator.ts
@@ -1,5 +1,5 @@
 import type {LogContext} from '@rocicorp/logger';
-import Database from 'better-sqlite3';
+import {Database} from 'zqlite/src/db.js';
 import type {ReadonlyJSONObject} from 'shared/src/json.js';
 import type {CancelableAsyncIterable} from '../../types/streams.js';
 import type {Service} from '../service.js';
@@ -53,7 +53,7 @@ export class ReplicatorService implements Replicator, Service {
     this.#upstreamUri = upstreamUri;
     this.#syncReplicaDbFile = syncReplicaDbFile;
 
-    const replica = new Database(syncReplicaDbFile);
+    const replica = new Database(this.#lc, syncReplicaDbFile);
     replica.pragma('journal_mode = WAL');
     // TODO: Any other replica setup required here?
 

--- a/packages/zero-cache/src/services/replicator/schema/change-log.test.ts
+++ b/packages/zero-cache/src/services/replicator/schema/change-log.test.ts
@@ -1,4 +1,4 @@
-import Database from 'better-sqlite3';
+import {Database} from 'zqlite/src/db.js';
 import {beforeEach, describe, test} from 'vitest';
 import {StatementRunner} from 'zero-cache/src/db/statements.js';
 import {expectTables} from 'zero-cache/src/test/lite.js';
@@ -8,12 +8,13 @@ import {
   logSetOp,
   logTruncateOp,
 } from './change-log.js';
+import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
 
 describe('replicator/schema/change-log', () => {
   let db: StatementRunner;
 
   beforeEach(() => {
-    const conn = new Database(':memory:');
+    const conn = new Database(createSilentLogContext(), ':memory:');
     initChangeLog(conn);
     db = new StatementRunner(conn);
   });

--- a/packages/zero-cache/src/services/replicator/schema/change-log.ts
+++ b/packages/zero-cache/src/services/replicator/schema/change-log.ts
@@ -1,4 +1,4 @@
-import type {Database} from 'better-sqlite3';
+import type {Database} from 'zqlite/src/db.js';
 import * as v from 'shared/src/valita.js';
 import {StatementRunner} from 'zero-cache/src/db/statements.js';
 import {

--- a/packages/zero-cache/src/services/replicator/schema/replication-state.test.ts
+++ b/packages/zero-cache/src/services/replicator/schema/replication-state.test.ts
@@ -1,4 +1,4 @@
-import Database from 'better-sqlite3';
+import {Database} from 'zqlite/src/db.js';
 import {beforeEach, describe, expect, test} from 'vitest';
 import {StatementRunner} from 'zero-cache/src/db/statements.js';
 import {expectTables} from 'zero-cache/src/test/lite.js';
@@ -8,12 +8,15 @@ import {
   initReplicationState,
   updateReplicationWatermark,
 } from './replication-state.js';
+import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
 
 describe('replicator/schema/replication-state', () => {
   let db: StatementRunner;
 
   beforeEach(() => {
-    db = new StatementRunner(new Database(':memory:'));
+    db = new StatementRunner(
+      new Database(createSilentLogContext(), ':memory:'),
+    );
     initReplicationState(db.db, ['zero_data', 'zero_metadata'], '0/0a');
   });
 

--- a/packages/zero-cache/src/services/replicator/schema/replication-state.ts
+++ b/packages/zero-cache/src/services/replicator/schema/replication-state.ts
@@ -5,7 +5,7 @@
  * after the logical replication handoff when initial data synchronization has completed.
  */
 
-import {Database} from 'better-sqlite3';
+import {Database} from 'zqlite/src/db.js';
 import * as v from 'shared/src/valita.js';
 import {StatementRunner} from 'zero-cache/src/db/statements.js';
 import {toLexiVersion} from 'zero-cache/src/types/lsn.js';

--- a/packages/zero-cache/src/services/replicator/schema/sync-schema.test.ts
+++ b/packages/zero-cache/src/services/replicator/schema/sync-schema.test.ts
@@ -90,12 +90,13 @@ describe('replicator/schema/sync-schema', () => {
     await testDBs.drop(upstream);
     await replicaFile.unlink();
   }, 10000);
+  const lc = createSilentLogContext();
 
   for (const c of cases) {
     test(
       c.name,
       async () => {
-        const replica = replicaFile.connect();
+        const replica = replicaFile.connect(lc);
         await initDB(upstream, c.upstreamSetup, c.upstreamPreState);
         initLiteDB(replica, c.replicaSetup, c.replicaPreState);
 

--- a/packages/zero-cache/src/services/replicator/tables/create.test.ts
+++ b/packages/zero-cache/src/services/replicator/tables/create.test.ts
@@ -1,4 +1,4 @@
-import Database from 'better-sqlite3';
+import {Database} from 'zqlite/src/db.js';
 import type postgres from 'postgres';
 import {afterAll, afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {stripCommentsAndWhitespace} from 'zero-cache/src/db/query-test-util.js';
@@ -7,6 +7,7 @@ import {createTableStatement} from './create.js';
 import {listTables} from './list.js';
 import {getPublicationInfo} from './published.js';
 import type {TableSpec} from './specs.js';
+import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
 
 describe('tables/create', () => {
   type Case = {
@@ -346,10 +347,10 @@ describe('tables/create', () => {
   });
 
   describe('sqlite', () => {
-    let db: Database.Database;
+    let db: Database;
 
     beforeEach(() => {
-      db = new Database(':memory:');
+      db = new Database(createSilentLogContext(), ':memory:');
     });
 
     for (const c of cases) {

--- a/packages/zero-cache/src/services/replicator/tables/list.test.ts
+++ b/packages/zero-cache/src/services/replicator/tables/list.test.ts
@@ -1,7 +1,8 @@
-import Database from 'better-sqlite3';
+import {Database} from 'zqlite/src/db.js';
 import {describe, expect, test} from 'vitest';
 import {listTables} from './list.js';
 import {TableSpec} from './specs.js';
+import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
 
 describe('tables/list', () => {
   type Case = {
@@ -159,7 +160,7 @@ describe('tables/list', () => {
 
   for (const c of cases) {
     test(c.name, () => {
-      const db = new Database(':memory:');
+      const db = new Database(createSilentLogContext(), ':memory:');
       db.exec(c.setupQuery);
 
       const tables = listTables(db);

--- a/packages/zero-cache/src/services/replicator/tables/list.ts
+++ b/packages/zero-cache/src/services/replicator/tables/list.ts
@@ -1,4 +1,4 @@
-import type {Database} from 'better-sqlite3';
+import type {Database} from 'zqlite/src/db.js';
 import {assert} from 'shared/src/asserts.js';
 import {IndexSpec, TableSpec} from './specs.js';
 

--- a/packages/zero-cache/src/services/replicator/test-utils.ts
+++ b/packages/zero-cache/src/services/replicator/test-utils.ts
@@ -1,5 +1,5 @@
 import {LogContext} from '@rocicorp/logger';
-import {Database} from 'better-sqlite3';
+import {Database} from 'zqlite/src/db.js';
 import {Pgoutput} from 'pg-logical-replication';
 import {assert} from 'shared/src/asserts.js';
 import {randInt} from 'shared/src/rand.js';

--- a/packages/zero-cache/src/services/view-syncer/database-storage.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/database-storage.test.ts
@@ -1,14 +1,15 @@
-import Database from 'better-sqlite3';
+import {Database} from 'zqlite/src/db.js';
 import {afterEach} from 'node:test';
 import {beforeEach, describe, expect, test} from 'vitest';
 import {CREATE_STORAGE_TABLE, DatabaseStorage} from './database-storage.js';
+import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
 
 describe('view-syncer/database-storage', () => {
-  let db: Database.Database;
+  let db: Database;
   let storage: DatabaseStorage;
 
   beforeEach(() => {
-    db = new Database(':memory:');
+    db = new Database(createSilentLogContext(), ':memory:');
     db.prepare(CREATE_STORAGE_TABLE).run();
     storage = new DatabaseStorage(db);
   });

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -1,5 +1,6 @@
 import {LogContext} from '@rocicorp/logger';
-import Database, {Database as DB} from 'better-sqlite3';
+import {Database} from 'zqlite/src/db.js';
+import type {Database as DB} from 'zqlite/src/db.js';
 import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
 import {beforeEach, describe, expect, test} from 'vitest';
 import {DbFile} from 'zero-cache/src/test/lite.js';
@@ -20,7 +21,7 @@ describe('view-syncer/pipeline-driver', () => {
   beforeEach(() => {
     dbFile = new DbFile('pipelines_test');
     lc = createSilentLogContext();
-    const storage = new Database(':memory:');
+    const storage = new Database(lc, ':memory:');
     storage.prepare(CREATE_STORAGE_TABLE).run();
 
     pipelines = new PipelineDriver(
@@ -29,7 +30,7 @@ describe('view-syncer/pipeline-driver', () => {
       new DatabaseStorage(storage).createClientGroupStorage('foo-client-group'),
     );
 
-    db = dbFile.connect();
+    db = dbFile.connect(lc);
     initReplicationState(db, ['zero_data'], '0/123');
     initChangeLog(db);
     db.exec(`

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -1,5 +1,5 @@
 import {LogContext} from '@rocicorp/logger';
-import {TableSource} from '@rocicorp/zqlite/src/table-source.js';
+import {TableSource} from 'zqlite/src/table-source.js';
 import {assert} from 'shared/src/asserts.js';
 import {must} from 'shared/src/must.js';
 import {mapLiteDataTypeToZqlSchemaValue} from 'zero-cache/src/types/lite.js';

--- a/packages/zero-cache/src/services/view-syncer/snapshotter.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/snapshotter.test.ts
@@ -19,7 +19,7 @@ describe('view-syncer/snapshotter', () => {
   beforeEach(() => {
     lc = createSilentLogContext();
     dbFile = new DbFile('snapshotter_test');
-    const db = dbFile.connect();
+    const db = dbFile.connect(lc);
     db.pragma('journal_mode = WAL');
     db.exec(
       `

--- a/packages/zero-cache/src/services/view-syncer/snapshotter.ts
+++ b/packages/zero-cache/src/services/view-syncer/snapshotter.ts
@@ -1,5 +1,5 @@
 import {LogContext} from '@rocicorp/logger';
-import Database from 'better-sqlite3';
+import {Database} from 'zqlite/src/db.js';
 import {ident} from 'pg-format';
 import {assert} from 'shared/src/asserts.js';
 import * as v from 'shared/src/valita.js';
@@ -97,7 +97,7 @@ export class Snapshotter {
    */
   init(): this {
     assert(this.#curr === undefined, 'Already initialized');
-    this.#curr = Snapshot.create(this.#dbFile);
+    this.#curr = Snapshot.create(this.#lc, this.#dbFile);
     this.#lc.debug?.(`Initial snapshot at version ${this.#curr.version}`);
     return this;
   }
@@ -153,7 +153,7 @@ export class Snapshotter {
     assert(this.#curr !== undefined, 'Snapshotter has not been initialized');
     const next = this.#prev
       ? this.#prev.resetToHead()
-      : Snapshot.create(this.#curr.db.db.name);
+      : Snapshot.create(this.#lc, this.#curr.db.db.name);
     this.#prev = this.#curr;
     this.#curr = next;
     return new Diff(this.#prev, this.#curr);
@@ -198,8 +198,8 @@ export interface SnapshotDiff extends Iterable<Change> {
 }
 
 class Snapshot {
-  static create(dbFile: string) {
-    const conn = new Database(dbFile);
+  static create(lc: LogContext, dbFile: string) {
+    const conn = new Database(lc, dbFile);
     conn.pragma('journal_mode = WAL');
     conn.pragma('synchronous = OFF'); // Applied changes are ephemeral; COMMIT is never called.
 
@@ -246,7 +246,8 @@ class Snapshot {
     );
     cached.statement.safeIntegers(true);
     try {
-      return cached.statement.get(Object.values(key));
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return cached.statement.get<any>(Object.values(key));
     } finally {
       this.db.statementCache.return(cached);
     }

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.test.ts
@@ -1,4 +1,4 @@
-import Database from 'better-sqlite3';
+import {Database} from 'zqlite/src/db.js';
 import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
 import {Queue} from 'shared/src/queue.js';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
@@ -46,9 +46,9 @@ const EXPECTED_LMIDS_AST: AST = {
 };
 
 describe('view-syncer/service', () => {
-  let storageDB: Database.Database;
+  let storageDB: Database;
   let replicaDbFile: DbFile;
-  let replica: Database.Database;
+  let replica: Database;
   let cvrDB: PostgresDB;
   const lc = createSilentLogContext();
   let versionNotifications: Subscription<ReplicaVersionReady>;
@@ -63,11 +63,12 @@ describe('view-syncer/service', () => {
   const messages = new ReplicationMessages({issues: 'id', users: 'id'});
 
   beforeEach(async () => {
-    storageDB = new Database(':memory:');
+    const lc = createSilentLogContext();
+    storageDB = new Database(lc, ':memory:');
     storageDB.prepare(CREATE_STORAGE_TABLE).run();
 
     replicaDbFile = new DbFile('view_syncer_service_test');
-    replica = replicaDbFile.connect();
+    replica = replicaDbFile.connect(lc);
     initChangeLog(replica);
     initReplicationState(replica, ['zero_data'], '0/1');
 

--- a/packages/zero-cache/src/test/lite.ts
+++ b/packages/zero-cache/src/test/lite.ts
@@ -1,9 +1,10 @@
-import Database from 'better-sqlite3';
+import {Database} from 'zqlite/src/db.js';
 import {unlink} from 'fs/promises';
 import {tmpdir} from 'os';
 import {ident} from 'pg-format';
 import {randInt} from 'shared/src/rand.js';
 import {expect} from 'vitest';
+import {LogContext} from '@rocicorp/logger';
 
 export class DbFile {
   readonly path;
@@ -12,8 +13,8 @@ export class DbFile {
     this.path = `${tmpdir()}/${testName}-${randInt(1000000, 9999999)}.db`;
   }
 
-  connect(): Database.Database {
-    return new Database(this.path);
+  connect(lc: LogContext): Database {
+    return new Database(lc, this.path);
   }
 
   async unlink() {
@@ -22,7 +23,7 @@ export class DbFile {
 }
 
 export function initDB(
-  db: Database.Database,
+  db: Database,
   statements?: string,
   tables?: Record<string, object[]>,
 ) {
@@ -45,7 +46,7 @@ export function initDB(
 }
 
 export function expectTables(
-  db: Database.Database,
+  db: Database,
   tables?: Record<string, unknown[]>,
   numberType: 'number' | 'bigint' = 'number',
 ) {

--- a/packages/zero-integration-test/src/all-integration.ts
+++ b/packages/zero-integration-test/src/all-integration.ts
@@ -1,8 +1,10 @@
 import {ZQLiteZero} from 'zqlite/src/zqlite-zero.js';
 import {SchemaDefs, Zero} from 'zero-client/src/client/zero.js';
 import {test} from 'vitest';
+import {LogContext} from '@rocicorp/logger';
 
 type CreateZeroFunction = <SD extends SchemaDefs>(
+  lc: LogContext,
   z: SD,
 ) => Zero<SD> | ZQLiteZero<SD>;
 

--- a/packages/zero-integration-test/src/zero-client/new-zero.ts
+++ b/packages/zero-integration-test/src/zero-client/new-zero.ts
@@ -1,7 +1,11 @@
+import {LogContext} from '@rocicorp/logger';
 import {QueryDefs, Zero} from 'zero-client';
 import {nanoid} from 'zero-client/src/util/nanoid.js';
 
-export function newZero<QD extends QueryDefs>(schemas: QD): Zero<QD> {
+export function newZero<QD extends QueryDefs>(
+  _lc: LogContext,
+  schemas: QD,
+): Zero<QD> {
   const z = new Zero({
     userID: 'user-' + nanoid(),
     schemas,

--- a/packages/zero-integration-test/src/zqlite/new-zql-lite-zero.ts
+++ b/packages/zero-integration-test/src/zqlite/new-zql-lite-zero.ts
@@ -1,12 +1,14 @@
 import {QueryDefs} from 'zero-client';
 import {ZQLiteZero} from 'zqlite/src/zqlite-zero.js';
-import Database from 'better-sqlite3';
+import {Database} from 'zqlite/src/db.js';
+import {LogContext} from '@rocicorp/logger';
 
 export function newSqliteZero<QD extends QueryDefs>(
+  lc: LogContext,
   schemas: QD,
 ): ZQLiteZero<QD> {
   {
-    const db = new Database(':memory:');
+    const db = new Database(lc, ':memory:');
     const z = new ZQLiteZero({
       schemas,
       db,

--- a/packages/zqlite/package.json
+++ b/packages/zqlite/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rocicorp/zqlite",
+  "name": "zqlite",
   "version": "0.0.0",
   "description": "SQLite source provider for ZQL (for use on the server)",
   "private": true,

--- a/packages/zqlite/src/db.test.ts
+++ b/packages/zqlite/src/db.test.ts
@@ -29,18 +29,18 @@ test('slow queries are logged', () => {
   expect(sink.messages).toEqual([
     [
       'error',
-      {component: 'Database', path: ':memory:', method: 'exec'},
+      {class: 'Database', path: ':memory:', method: 'exec'},
       ['Slow query', 0],
     ],
     [
       'error',
-      {component: 'Database', path: ':memory:', method: 'exec'},
+      {class: 'Database', path: ':memory:', method: 'exec'},
       ['Slow query', 0],
     ],
     [
       'error',
       {
-        component: 'Statement',
+        class: 'Statement',
         path: ':memory:',
         sql: 'SELECT * FROM foo WHERE name = ?',
         method: 'run',
@@ -50,7 +50,7 @@ test('slow queries are logged', () => {
     [
       'error',
       {
-        component: 'Statement',
+        class: 'Statement',
         path: ':memory:',
         sql: 'SELECT * FROM foo WHERE name = ?',
         method: 'get',
@@ -60,7 +60,7 @@ test('slow queries are logged', () => {
     [
       'error',
       {
-        component: 'Statement',
+        class: 'Statement',
         path: ':memory:',
         sql: 'SELECT * FROM foo WHERE name = ?',
         method: 'all',
@@ -70,7 +70,7 @@ test('slow queries are logged', () => {
     [
       'error',
       {
-        component: 'Statement',
+        class: 'Statement',
         path: ':memory:',
         sql: 'SELECT * FROM foo',
         method: 'iterate',
@@ -81,7 +81,7 @@ test('slow queries are logged', () => {
     [
       'error',
       {
-        component: 'Statement',
+        class: 'Statement',
         path: ':memory:',
         sql: 'SELECT * FROM foo',
         method: 'iterate',

--- a/packages/zqlite/src/internal/statement-cache.test.ts
+++ b/packages/zqlite/src/internal/statement-cache.test.ts
@@ -1,9 +1,10 @@
 import {expect, test} from 'vitest';
 import {CachedStatement, StatementCache} from './statement-cache.js';
-import Database from 'better-sqlite3';
+import {Database} from 'zqlite/src/db.js';
+import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
 
 test('Same sql results in same statement instance. The same instance is not outstanding twice.', () => {
-  const db = new Database(':memory:');
+  const db = new Database(createSilentLogContext(), ':memory:');
   const cache = new StatementCache(db);
   const LOOP_COUNT = 100;
   const expected: CachedStatement[] = [];

--- a/packages/zqlite/src/internal/statement-cache.ts
+++ b/packages/zqlite/src/internal/statement-cache.ts
@@ -1,4 +1,4 @@
-import type {Database, Statement} from 'better-sqlite3';
+import type {Database, Statement} from '../db.js';
 import {assert} from 'shared/src/asserts.js';
 
 export type CachedStatementMap = Map<string, Statement[]>;

--- a/packages/zqlite/src/options.ts
+++ b/packages/zqlite/src/options.ts
@@ -1,5 +1,5 @@
 import type {SchemaDefs} from 'zero-client/src/client/zero.js';
-import type {Database} from 'better-sqlite3';
+import type {Database} from 'zqlite/src/db.js';
 
 /**
  * Configuration for [[ZqlLiteZero]].

--- a/packages/zqlite/src/table-source.test.ts
+++ b/packages/zqlite/src/table-source.test.ts
@@ -1,4 +1,4 @@
-import Database from 'better-sqlite3';
+import {Database} from 'zqlite/src/db.js';
 import {describe, expect, test} from 'vitest';
 import {Catch} from 'zql/src/zql/ivm/catch.js';
 import {Change} from 'zql/src/zql/ivm/change.js';
@@ -7,6 +7,7 @@ import {SchemaValue} from 'zql/src/zql/ivm/schema.js';
 import {runCases} from 'zql/src/zql/ivm/test/source-cases.js';
 import {compile, sql} from './internal/sql.js';
 import {TableSource, UnsupportedValueError} from './table-source.js';
+import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
 
 const columns = {
   id: {type: 'string'},
@@ -25,7 +26,7 @@ describe('fetching from a table source', () => {
     ['id', 'asc'],
   ] as const;
   const compoundComparator = makeComparator(compoundOrder);
-  const db = new Database(':memory:');
+  const db = new Database(createSilentLogContext(), ':memory:');
   db.exec(/* sql */ `CREATE TABLE foo (id TEXT PRIMARY KEY, a, b, c);`);
   const stmt = db.prepare(
     /* sql */ `INSERT INTO foo (id, a, b, c) VALUES (?, ?, ?, ?);`,
@@ -246,7 +247,7 @@ describe('fetched value types', () => {
 
   for (const c of cases) {
     test(c.name, () => {
-      const db = new Database(':memory:');
+      const db = new Database(createSilentLogContext(), ':memory:');
       db.exec(/* sql */ `CREATE TABLE foo (id TEXT PRIMARY KEY, a, b, c);`);
       const stmt = db.prepare(
         /* sql */ `INSERT INTO foo (id, a, b, c) VALUES (?, ?, ?, ?);`,
@@ -265,8 +266,8 @@ describe('fetched value types', () => {
 });
 
 test('pushing values does the correct writes and outputs', () => {
-  const db1 = new Database(':memory:');
-  const db2 = new Database(':memory:');
+  const db1 = new Database(createSilentLogContext(), ':memory:');
+  const db2 = new Database(createSilentLogContext(), ':memory:');
   db1.exec(/* sql */ `CREATE TABLE foo (a, b, c, PRIMARY KEY (a, b));`);
   db2.exec(/* sql */ `CREATE TABLE foo (a, b, c, PRIMARY KEY (a, b));`);
   const source = new TableSource(
@@ -424,7 +425,7 @@ test('pushing values does the correct writes and outputs', () => {
 });
 
 test('getByKey', () => {
-  const db = new Database(':memory:');
+  const db = new Database(createSilentLogContext(), ':memory:');
   db.exec(
     /* sql */ `CREATE TABLE foo (id TEXT, a INTEGER, b, c, PRIMARY KEY(id, a));`,
   );
@@ -503,7 +504,7 @@ describe('shared test cases', () => {
       columns: Record<string, SchemaValue>,
       primaryKey: readonly [string, ...string[]],
     ) => {
-      const db = new Database(':memory:');
+      const db = new Database(createSilentLogContext(), ':memory:');
       // create a table with desired columns and primary keys
       const query = compile(
         sql`CREATE TABLE ${sql.ident(name)} (${sql.join(

--- a/packages/zqlite/src/table-source.ts
+++ b/packages/zqlite/src/table-source.ts
@@ -1,5 +1,5 @@
 import type {SQLQuery} from '@databases/sql';
-import {Database, Statement} from 'better-sqlite3';
+import {Database, Statement} from 'zqlite/src/db.js';
 import {assert} from 'shared/src/asserts.js';
 import type {Ordering, SimpleCondition} from 'zql/src/zql/ast/ast.js';
 import {assertOrderingIncludesPK} from 'zql/src/zql/builder/builder.js';
@@ -235,7 +235,7 @@ export class TableSource implements Source {
 
       newReq = {...req, start: undefined};
       this.#stmts.cache.use(sqlAndBindings.text, cachedStatement => {
-        for (const beforeRow of cachedStatement.statement.iterate(
+        for (const beforeRow of cachedStatement.statement.iterate<Row>(
           ...sqlAndBindings.values.map(v => toSQLiteType(v)),
         )) {
           newReq.start = {row: beforeRow, basis: 'at'};
@@ -263,7 +263,7 @@ export class TableSource implements Source {
       const cachedStatement = this.#stmts.cache.get(sqlAndBindings.text);
       try {
         cachedStatement.statement.safeIntegers(true);
-        const rowIterator = cachedStatement.statement.iterate(
+        const rowIterator = cachedStatement.statement.iterate<Row>(
           ...sqlAndBindings.values.map(v => toSQLiteType(v)),
         );
 
@@ -300,8 +300,9 @@ export class TableSource implements Source {
     // need to check for the existence of the row before modifying
     // the db so we don't push it to outputs if it does/doest not exist.
     const exists =
-      this.#stmts.checkExists.get(...pickColumns(this.#primaryKey, change.row))
-        ?.exists === 1;
+      this.#stmts.checkExists.get<{exists: number}>(
+        ...pickColumns(this.#primaryKey, change.row),
+      )?.exists === 1;
     if (change.type === 'add') {
       assert(!exists, 'Row already exists');
     } else {
@@ -340,7 +341,9 @@ export class TableSource implements Source {
    * semantics) of the pipeline.
    */
   getRow(pk: Row): Row | undefined {
-    const row = this.#stmts.getRow.get(this.#primaryKey.map(key => pk[key]));
+    const row = this.#stmts.getRow.get<Row>(
+      this.#primaryKey.map(key => pk[key]),
+    );
     if (row) {
       fromSQLiteTypes(this.#columns, row);
     }
@@ -490,7 +493,7 @@ function assertPrimaryKeyMatch(
   );
   const stmt = db.prepare(sqlAndBindings.text);
   const pkColumns = new Set(
-    stmt.all(...sqlAndBindings.values).map(row => row.name),
+    stmt.all<Row>(...sqlAndBindings.values).map(row => row.name),
   );
 
   assert(pkColumns.size === primaryKey.length);

--- a/packages/zqlite/src/zqlite-zero.ts
+++ b/packages/zqlite/src/zqlite-zero.ts
@@ -7,7 +7,7 @@ import {
   Update,
 } from 'zero-client/src/client/crud.js';
 import type {CRUDOp, CRUDOpKind} from 'zero-protocol/src/push.js';
-import type {Database} from 'better-sqlite3';
+import type {Database} from 'zqlite/src/db.js';
 import type {EntityID} from 'zero-protocol/src/entity.js';
 import {
   SchemaDefs,
@@ -117,7 +117,7 @@ export class ZQLiteZero<SD extends SchemaDefs> {
         assertNotInBatch(entityType, 'update');
         const existingEntity = await db
           .prepare(`SELECT * FROM ${entityType} WHERE id = ?`)
-          .get(value.id);
+          .get<Row>(value.id);
         if (!existingEntity)
           throw new Error(`Entity with id ${value.id} not found`);
         const mergedValue = {...existingEntity, ...value};
@@ -132,7 +132,7 @@ export class ZQLiteZero<SD extends SchemaDefs> {
         assertNotInBatch(entityType, 'delete');
         const existingEntity = await db
           .prepare(`SELECT * FROM ${entityType} WHERE id = ?`)
-          .get(id);
+          .get<Row>(id);
         if (!existingEntity) throw new Error(`Entity with id ${id} not found`);
         await this.zeroContext
           .getSource(entityType)


### PR DESCRIPTION
- based on https://github.com/rocicorp/mono/pull/2324

Finding why things are slow is hard. This makes it easy.

Tested by existing tests and adding a bunch of statuses to repro the slow mutations, made a mutation, checked the logs:

----

worker=syncer pid=89678 component=view-syncer serviceID=rpuncmstjm873ndgud newVersion=5o3n48o applying 2 to advance to 5o3n48o
worker=syncer pid=89679 class=Statement path=/tmp/sync-replica.db sql=SELECT * FROM "issue" WHERE (("modified" < ?) OR ("modified" = ? AND "id" > ?) OR ("modified" = ? AND "id" = ?)) AND "status" IN (SELECT value FROM json_each(?)) ORDER BY "modified" desc, "id" asc method=iterate **type=total Slow query 432.6046670000069**
worker=syncer pid=89678 class=Statement path=/tmp/sync-replica.db sql=SELECT * FROM "issue" WHERE (("modified" < ?) OR ("modified" = ? AND "id" > ?) OR ("modified" = ? AND "id" = ?)) AND "status" IN (SELECT value FROM json_each(?)) ORDER BY "modified" desc, "id" asc method=iterate **type=total Slow query 432.35575000000244**
worker=syncer pid=89679 class=Statement path=/tmp/sync-replica.db sql=SELECT * FROM "issue" WHERE (("modified" < ?) OR ("modified" = ? AND "id" > ?) OR ("modified" = ? AND "id" = ?)) AND "status" IN (SELECT value FROM json_each(?)) ORDER BY "modified" desc, "id" asc method=iterate **type=sqlite Slow query 432.58229200002097**
worker=syncer pid=89678 class=Statement path=/tmp/sync-replica.db sql=SELECT * FROM "issue" WHERE (("modified" < ?) OR ("modified" = ? AND "id" > ?) OR ("modified" = ? AND "id" = ?)) AND "status" IN (SELECT value FROM json_each(?)) ORDER BY "modified" desc, "id" asc method=iterate **type=sqlite Slow query 432.30129200000374**
worker=syncer pid=89678 class=Statement path=/tmp/sync-replica.db sql=SELECT * FROM "issue" WHERE (("modified" < ?) OR ("modified" = ? AND "id" > ?) OR ("modified" = ? AND "id" = ?)) AND "status" IN (SELECT value FROM json_each(?)) ORDER BY "modified" desc, "id" asc method=iterate **type=total Slow query 417.1416670000035**
worker=syncer pid=89678 class=Statement path=/tmp/sync-replica.db sql=SELECT * FROM "issue" WHERE (("modified" < ?) OR ("modified" = ? AND "id" > ?) OR ("modified" = ? AND "id" = ?)) AND "status" IN (SELECT value FROM json_each(?)) ORDER BY "modified" desc, "id" asc method=iterate **type=sqlite Slow query 417.11016599999857**
worker=syncer pid=89679 class=Statement path=/tmp/sync-replica.db sql=SELECT * FROM "issue" WHERE (("modified" < ?) OR ("modified" = ? AND "id" > ?) OR ("modified" = ? AND "id" = ?)) AND "status" IN (SELECT value FROM json_each(?)) ORDER BY "modified" desc, "id" asc method=iterate **type=total Slow query 417.5892920000042**
worker=syncer pid=89679 class=Statement path=/tmp/sync-replica.db sql=SELECT * FROM "issue" WHERE (("modified" < ?) OR ("modified" = ? AND "id" > ?) OR ("modified" = ? AND "id" = ?)) AND "status" IN (SELECT value FROM json_each(?)) ORDER BY "modified" desc, "id" asc method=iterate **type=sqlite Slow query 417.56558300000324**
worker=syncer pid=89678 Advanced to 5o3n48o
