### PR TITLE
feat(zero-cache): associate the replica data with a "replicaVersion"

### DIFF
--- a/packages/zero-cache/src/services/replicator/schema/replication-state.test.ts
+++ b/packages/zero-cache/src/services/replicator/schema/replication-state.test.ts
@@ -22,6 +22,7 @@ describe('replicator/schema/replication-state', () => {
       ['_zero.ReplicationConfig']: [
         {
           lock: 1,
+          replicaVersion: '0a',
           publications: '["zero_data","zero_metadata"]',
         },
       ],
@@ -38,6 +39,7 @@ describe('replicator/schema/replication-state', () => {
 
   test('subscription state', () => {
     expect(getSubscriptionState(db)).toEqual({
+      replicaVersion: '0a',
       publications: ['zero_data', 'zero_metadata'],
       watermark: '0/0a',
     });
@@ -67,6 +69,7 @@ describe('replicator/schema/replication-state', () => {
       nextStateVersion: '0f',
     });
     expect(getSubscriptionState(db)).toEqual({
+      replicaVersion: '0a',
       publications: ['zero_data', 'zero_metadata'],
       watermark: '0/0f',
     });
@@ -87,6 +90,7 @@ describe('replicator/schema/replication-state', () => {
       nextStateVersion: '0r',
     });
     expect(getSubscriptionState(db)).toEqual({
+      replicaVersion: '0a',
       publications: ['zero_data', 'zero_metadata'],
       watermark: '0/1b',
     });


### PR DESCRIPTION
Associate a replica db with a "replicaVersion" indicating the version of the database at which the initial snapshot was performed (with row versions initialized to "00"). 

This will be used to signal to various downstream entities if a replica is ever reset (i.e. dropped and re-synced at a different starting snapshot), upon which associated data and caches need to be correspondingly wiped and reconstructed.