### PR TITLE
refactor(zero-cache): Rename CancelableAsyncIterable to "Source"

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/change-streamer-pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-pg.test.ts
@@ -10,7 +10,7 @@ import {
   testDBs,
 } from 'zero-cache/src/test/db.js';
 import {PostgresDB} from 'zero-cache/src/types/pg.js';
-import {CancelableAsyncIterable} from 'zero-cache/src/types/streams.js';
+import {Source} from 'zero-cache/src/types/streams.js';
 import {Database} from 'zqlite/src/db.js';
 import {initialSync, replicationSlot} from '../replicator/initial-sync.js';
 import {getSubscriptionState} from '../replicator/schema/replication-state.js';
@@ -61,9 +61,7 @@ describe('change-streamer/service', {retry: 3}, () => {
     await testDBs.drop(upstream, changeDB);
   });
 
-  function drainToQueue(
-    sub: CancelableAsyncIterable<Downstream>,
-  ): Queue<Downstream> {
+  function drainToQueue(sub: Source<Downstream>): Queue<Downstream> {
     const queue = new Queue<Downstream>();
     void (async () => {
       for await (const msg of sub) {

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-pg.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-pg.ts
@@ -13,7 +13,7 @@ import {
   PostgresDB,
   registerPostgresTypeParsers,
 } from 'zero-cache/src/types/pg.js';
-import {CancelableAsyncIterable} from 'zero-cache/src/types/streams.js';
+import {Source} from 'zero-cache/src/types/streams.js';
 import {Subscription} from 'zero-cache/src/types/subscription.js';
 import {Database} from 'zqlite/src/db.js';
 import {replicationSlot} from '../replicator/initial-sync.js';
@@ -251,7 +251,7 @@ class PostgresChangeStreamer implements ChangeStreamerService {
     return this.#service?.acknowledge(this.#lastLSN);
   };
 
-  subscribe(ctx: SubscriberContext): CancelableAsyncIterable<Downstream> {
+  subscribe(ctx: SubscriberContext): Source<Downstream> {
     const {id, watermark} = ctx;
     const downstream = Subscription.create<Downstream>({
       cleanup: () => this.#forwarder.remove(id, subscriber),

--- a/packages/zero-cache/src/services/change-streamer/change-streamer.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer.ts
@@ -1,4 +1,4 @@
-import {CancelableAsyncIterable} from 'zero-cache/src/types/streams.js';
+import {Source} from 'zero-cache/src/types/streams.js';
 import {Service} from '../service.js';
 import {Change} from './schema/change.js';
 
@@ -44,8 +44,8 @@ export interface ChangeStreamer {
    * which indicates the watermark at which the subscriber is up to
    * date.
    */
-  // TODO: Also take a CancelableAsyncIterable<Upstream> for receiving ACKs.
-  subscribe(ctx: SubscriberContext): CancelableAsyncIterable<Downstream>;
+  // TODO: Also take a Source<Upstream> for receiving ACKs.
+  subscribe(ctx: SubscriberContext): Source<Downstream>;
 }
 
 export type SubscriberContext = {

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -1,5 +1,4 @@
 import type {LogContext} from '@rocicorp/logger';
-import {Database} from 'zqlite/src/db.js';
 import {ident} from 'pg-format';
 import {
   LogicalReplicationService,
@@ -10,11 +9,12 @@ import {assert, unreachable} from 'shared/src/asserts.js';
 import {sleep} from 'shared/src/sleep.js';
 import {StatementRunner} from 'zero-cache/src/db/statements.js';
 import {liteValues} from 'zero-cache/src/types/lite.js';
+import {Database} from 'zqlite/src/db.js';
 import {stringify} from '../../types/bigint-json.js';
 import type {LexiVersion} from '../../types/lexi-version.js';
 import {toLexiVersion} from '../../types/lsn.js';
 import {registerPostgresTypeParsers} from '../../types/pg.js';
-import type {CancelableAsyncIterable} from '../../types/streams.js';
+import type {Source} from '../../types/streams.js';
 import {replicationSlot} from './initial-sync.js';
 import {Notifier} from './notifier.js';
 import {ReplicaVersionReady} from './replicator.js';
@@ -121,7 +121,7 @@ export class IncrementalSyncer {
     lc.info?.('IncrementalSyncer stopped');
   }
 
-  subscribe(): CancelableAsyncIterable<ReplicaVersionReady> {
+  subscribe(): Source<ReplicaVersionReady> {
     return this.#notifier.subscribe();
   }
 

--- a/packages/zero-cache/src/services/replicator/notifier.test.ts
+++ b/packages/zero-cache/src/services/replicator/notifier.test.ts
@@ -1,5 +1,5 @@
 import {beforeEach, describe, expect, test} from 'vitest';
-import {CancelableAsyncIterable} from 'zero-cache/src/types/streams.js';
+import {Source} from 'zero-cache/src/types/streams.js';
 import {Notifier} from './notifier.js';
 import {ReplicaVersionReady} from './replicator.js';
 
@@ -11,7 +11,7 @@ describe('replicator/notifier', () => {
   });
 
   async function expectSingleMessage(
-    sub: CancelableAsyncIterable<ReplicaVersionReady>,
+    sub: Source<ReplicaVersionReady>,
     payload: ReplicaVersionReady,
   ) {
     for await (const msg of sub) {

--- a/packages/zero-cache/src/services/replicator/replicator.ts
+++ b/packages/zero-cache/src/services/replicator/replicator.ts
@@ -1,7 +1,7 @@
 import type {LogContext} from '@rocicorp/logger';
-import {Database} from 'zqlite/src/db.js';
 import type {ReadonlyJSONObject} from 'shared/src/json.js';
-import type {CancelableAsyncIterable} from '../../types/streams.js';
+import {Database} from 'zqlite/src/db.js';
+import type {Source} from '../../types/streams.js';
 import type {Service} from '../service.js';
 import {IncrementalSyncer} from './incremental-sync.js';
 import {initSyncSchema} from './schema/sync-schema.js';
@@ -21,7 +21,7 @@ export interface ReplicaVersionNotifier {
    * the next message. The messages themselves contain no information; the subscriber queries
    * the SQLite replica for the latest replicated changes.
    */
-  subscribe(): CancelableAsyncIterable<ReplicaVersionReady>;
+  subscribe(): Source<ReplicaVersionReady>;
 }
 
 export interface Replicator extends ReplicaVersionNotifier {
@@ -80,7 +80,7 @@ export class ReplicatorService implements Replicator, Service {
     await this.#incrementalSyncer.run(this.#lc);
   }
 
-  subscribe(): CancelableAsyncIterable<ReplicaVersionReady> {
+  subscribe(): Source<ReplicaVersionReady> {
     return this.#incrementalSyncer.subscribe();
   }
 

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -14,7 +14,7 @@ import type {
 } from 'zero-protocol';
 import type {AST} from 'zql/src/zql/ast/ast.js';
 import type {PostgresDB} from '../../types/pg.js';
-import type {CancelableAsyncIterable} from '../../types/streams.js';
+import type {Source} from '../../types/streams.js';
 import {Subscription} from '../../types/subscription.js';
 import {ReplicaVersionReady} from '../replicator/replicator.js';
 import {ZERO_VERSION_COLUMN_NAME} from '../replicator/schema/replication-state.js';
@@ -46,7 +46,7 @@ export interface ViewSyncer {
   initConnection(
     ctx: SyncContext,
     msg: InitConnectionMessage,
-  ): Promise<CancelableAsyncIterable<Downstream>>;
+  ): Promise<Source<Downstream>>;
 
   changeDesiredQueries(
     ctx: SyncContext,
@@ -186,7 +186,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   async initConnection(
     ctx: SyncContext,
     initConnectionMessage: InitConnectionMessage,
-  ): Promise<CancelableAsyncIterable<Downstream>> {
+  ): Promise<Source<Downstream>> {
     const {clientID, wsID, baseCookie} = ctx;
     const lc = this.#lc
       .withContext('clientID', clientID)

--- a/packages/zero-cache/src/types/streams.test.ts
+++ b/packages/zero-cache/src/types/streams.test.ts
@@ -8,7 +8,7 @@ import {randInt} from 'shared/src/rand.js';
 import * as v from 'shared/src/valita.js';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import WebSocket from 'ws';
-import {CancelableAsyncIterable, streamIn, streamOut} from './streams.js';
+import {Source, streamIn, streamOut} from './streams.js';
 import {Subscription} from './subscription.js';
 
 const messageSchema = v.object({
@@ -28,7 +28,7 @@ describe('streams', () => {
   let cleanup: Promise<Message[]>;
 
   let ws: WebSocket;
-  let consumer: CancelableAsyncIterable<Message>;
+  let consumer: Source<Message>;
 
   beforeEach(async () => {
     lc = createSilentLogContext();

--- a/packages/zero-cache/src/types/subscription.ts
+++ b/packages/zero-cache/src/types/subscription.ts
@@ -1,5 +1,5 @@
 import {resolver, type Resolver} from '@rocicorp/resolver';
-import type {CancelableAsyncIterable} from './streams.js';
+import type {Sink, Source} from './streams.js';
 
 /**
  * A Subscription abstracts a continuous, logically infinite stream of messages intended
@@ -60,7 +60,7 @@ import type {CancelableAsyncIterable} from './streams.js';
  *          and {@link Options.cleanup}). This is often the same as the external type
  *          T, but may be diverged to facilitate internal bookkeeping.
  */
-export class Subscription<T, M = T> implements CancelableAsyncIterable<T> {
+export class Subscription<T, M = T> implements Source<T>, Sink<M> {
   /**
    * Convenience factory method for creating a {@link Subscription} with internal message type
    * `M` as a subtype of `T`, defaulting to the same type. The default `publish` method publishes

--- a/packages/zero-cache/src/workers/connection.ts
+++ b/packages/zero-cache/src/workers/connection.ts
@@ -18,7 +18,7 @@ import type {
   ViewSyncer,
 } from '../services/view-syncer/view-syncer.js';
 import {findErrorForClient} from '../types/error-for-client.js';
-import type {CancelableAsyncIterable} from '../types/streams.js';
+import type {Source} from '../types/streams.js';
 
 /**
  * Represents a connection between the client and server.
@@ -38,7 +38,7 @@ export class Connection {
   readonly #viewSyncer: ViewSyncer;
   readonly #mutagen: Mutagen;
 
-  #outboundStream: CancelableAsyncIterable<Downstream> | undefined;
+  #outboundStream: Source<Downstream> | undefined;
   #closed = false;
 
   constructor(
@@ -174,7 +174,7 @@ export class Connection {
     this.#lc.error?.('WebSocket error event', e.message, e.error);
   };
 
-  async #proxyOutbound(outboundStream: CancelableAsyncIterable<Downstream>) {
+  async #proxyOutbound(outboundStream: Source<Downstream>) {
     try {
       for await (const outMsg of outboundStream) {
         this.send(outMsg);


### PR DESCRIPTION
Also add a "Sink" counterpart, both of which are implemented to Subscription.