### PR TITLE
Revert "fix(zero-cache): use LSNs as watermarks in the change-streamer

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -129,7 +129,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     this.#replicationConfig = replicationConfig;
     this.#source = source;
     this.#storer = new Storer(
-      this.#lc,
+      lc,
       changeDB,
       commit => this.#stream?.acks.push(commit),
     );

--- a/packages/zero-cache/src/services/change-streamer/forwarder.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/forwarder.test.ts
@@ -9,18 +9,18 @@ describe('change-streamer/forwarder', () => {
   test('in transaction queueing', () => {
     const forwarder = new Forwarder();
 
-    const [sub1, stream1] = createSubscriber('0/0', true);
-    const [sub2, stream2] = createSubscriber('0/0', true);
-    const [sub3, stream3] = createSubscriber('0/0', true);
-    const [sub4, stream4] = createSubscriber('0/0', true);
+    const [sub1, stream1] = createSubscriber('00', true);
+    const [sub2, stream2] = createSubscriber('00', true);
+    const [sub3, stream3] = createSubscriber('00', true);
+    const [sub4, stream4] = createSubscriber('00', true);
 
     forwarder.add(sub1);
-    forwarder.forward({watermark: '0/11', change: messages.begin('123')});
+    forwarder.forward({watermark: '11', change: messages.begin('123')});
     forwarder.add(sub2);
-    forwarder.forward({watermark: '0/12', change: messages.truncate('issues')});
-    forwarder.forward({watermark: '0/13', change: messages.commit('lsn')});
+    forwarder.forward({watermark: '12', change: messages.truncate('issues')});
+    forwarder.forward({watermark: '13', change: messages.commit('lsn')});
     forwarder.add(sub3);
-    forwarder.forward({watermark: '0/14', change: messages.begin('456')});
+    forwarder.forward({watermark: '14', change: messages.begin('456')});
     forwarder.add(sub4);
 
     for (const sub of [sub1, sub2, sub3, sub4]) {
@@ -39,7 +39,7 @@ describe('change-streamer/forwarder', () => {
               "tag": "begin",
               "xid": 0,
             },
-            "watermark": "0/11",
+            "watermark": "11",
           },
         ],
         [
@@ -73,7 +73,7 @@ describe('change-streamer/forwarder', () => {
               "restartIdentity": false,
               "tag": "truncate",
             },
-            "watermark": "0/12",
+            "watermark": "12",
           },
         ],
         [
@@ -86,7 +86,7 @@ describe('change-streamer/forwarder', () => {
               "flags": 0,
               "tag": "commit",
             },
-            "watermark": "0/13",
+            "watermark": "13",
           },
         ],
         [
@@ -98,7 +98,7 @@ describe('change-streamer/forwarder', () => {
               "tag": "begin",
               "xid": 0,
             },
-            "watermark": "0/14",
+            "watermark": "14",
           },
         ],
       ]
@@ -117,7 +117,7 @@ describe('change-streamer/forwarder', () => {
               "tag": "begin",
               "xid": 0,
             },
-            "watermark": "0/14",
+            "watermark": "14",
           },
         ],
       ]
@@ -133,7 +133,7 @@ describe('change-streamer/forwarder', () => {
               "tag": "begin",
               "xid": 0,
             },
-            "watermark": "0/14",
+            "watermark": "14",
           },
         ],
       ]

--- a/packages/zero-cache/src/services/change-streamer/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/change-source.ts
@@ -6,6 +6,7 @@ import {
 } from 'pg-logical-replication';
 import {StatementRunner} from 'zero-cache/src/db/statements.js';
 import {stringify} from 'zero-cache/src/types/bigint-json.js';
+import {toLexiVersion} from 'zero-cache/src/types/lsn.js';
 import {registerPostgresTypeParsers} from 'zero-cache/src/types/pg.js';
 import {Subscription} from 'zero-cache/src/types/subscription.js';
 import {Database} from 'zqlite/src/db.js';
@@ -123,8 +124,10 @@ function messageToChangeEntry(lsn: string, msg: Pgoutput.Message) {
     case 'update':
     case 'delete':
     case 'truncate':
-    case 'commit':
-      return {watermark: lsn, change};
+    case 'commit': {
+      const watermark = toLexiVersion(lsn);
+      return {watermark, change};
+    }
 
     default:
       change satisfies never; // All Change types are covered.

--- a/packages/zero-cache/src/services/change-streamer/schema/tables.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/schema/tables.test.ts
@@ -41,7 +41,7 @@ describe('change-streamer/schema/tables', () => {
 
     await db`
     INSERT INTO cdc."ChangeLog" (watermark, pos, change)
-        values ('0/184', 0, JSONB('{"foo":"bar"}'));
+        values ('184', 0, JSONB('{"foo":"bar"}'));
     `;
 
     // Should be a no-op.
@@ -60,7 +60,7 @@ describe('change-streamer/schema/tables', () => {
       ],
       ['cdc.ChangeLog']: [
         {
-          watermark: '0/184',
+          watermark: '184',
           pos: 0n,
           change: {foo: 'bar'},
         },

--- a/packages/zero-cache/src/services/change-streamer/schema/tables.ts
+++ b/packages/zero-cache/src/services/change-streamer/schema/tables.ts
@@ -21,7 +21,7 @@ export type ChangeLogEntry = {
 
 const CREATE_CHANGE_LOG_TABLE = `
   CREATE TABLE cdc."ChangeLog" (
-    watermark  pg_lsn,
+    watermark  TEXT,
     pos        INT8,
     change     JSONB NOT NULL,
 

--- a/packages/zero-cache/src/services/change-streamer/storer.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.test.ts
@@ -23,12 +23,12 @@ describe('change-streamer/storer', () => {
       await setupCDCTables(lc, tx);
       await Promise.all(
         [
-          {watermark: '0/1', pos: 0, change: {foo: 'bar'}},
-          {watermark: '0/1', pos: 1, change: {foo: 'boo'}},
-          {watermark: '0/2', pos: 0, change: {bar: 'boo'}},
-          {watermark: '0/2', pos: 1, change: {baz: 'moo'}},
-          {watermark: '0/3', pos: 0, change: {boo: 'doo'}},
-          {watermark: '0/4', pos: 0, change: {moo: 'foo'}},
+          {watermark: '01', pos: 0, change: {foo: 'bar'}},
+          {watermark: '01', pos: 1, change: {foo: 'boo'}},
+          {watermark: '02', pos: 0, change: {bar: 'boo'}},
+          {watermark: '02', pos: 1, change: {baz: 'moo'}},
+          {watermark: '03', pos: 0, change: {boo: 'doo'}},
+          {watermark: '04', pos: 0, change: {moo: 'foo'}},
         ].map(row => tx`INSERT INTO cdc."ChangeLog" ${tx(row)}`),
       );
     });
@@ -59,15 +59,15 @@ describe('change-streamer/storer', () => {
   }
 
   test('no queueing if not in transaction', async () => {
-    const [sub, _, stream] = createSubscriber('0/0');
+    const [sub, _, stream] = createSubscriber('00');
 
     // This should be buffered until catchup is complete.
-    sub.send({watermark: '0/5', change: messages.begin('123')});
+    sub.send({watermark: '05', change: messages.begin('123')});
 
     // Catchup should start immediately since there are no txes in progress.
     storer.catchup(sub);
 
-    expect(await drainUntil('0/5', stream)).toMatchInlineSnapshot(`
+    expect(await drainUntil('05', stream)).toMatchInlineSnapshot(`
       [
         [
           "change",
@@ -75,7 +75,7 @@ describe('change-streamer/storer', () => {
             "change": {
               "foo": "bar",
             },
-            "watermark": "0/1",
+            "watermark": "01",
           },
         ],
         [
@@ -84,7 +84,7 @@ describe('change-streamer/storer', () => {
             "change": {
               "foo": "boo",
             },
-            "watermark": "0/1",
+            "watermark": "01",
           },
         ],
         [
@@ -93,7 +93,7 @@ describe('change-streamer/storer', () => {
             "change": {
               "bar": "boo",
             },
-            "watermark": "0/2",
+            "watermark": "02",
           },
         ],
         [
@@ -102,7 +102,7 @@ describe('change-streamer/storer', () => {
             "change": {
               "baz": "moo",
             },
-            "watermark": "0/2",
+            "watermark": "02",
           },
         ],
         [
@@ -111,7 +111,7 @@ describe('change-streamer/storer', () => {
             "change": {
               "boo": "doo",
             },
-            "watermark": "0/3",
+            "watermark": "03",
           },
         ],
         [
@@ -120,7 +120,7 @@ describe('change-streamer/storer', () => {
             "change": {
               "moo": "foo",
             },
-            "watermark": "0/4",
+            "watermark": "04",
           },
         ],
         [
@@ -132,7 +132,7 @@ describe('change-streamer/storer', () => {
               "tag": "begin",
               "xid": 0,
             },
-            "watermark": "0/5",
+            "watermark": "05",
           },
         ],
       ]
@@ -140,24 +140,24 @@ describe('change-streamer/storer', () => {
   });
 
   test('queued if transaction in progress', async () => {
-    const [sub1, _0, stream1] = createSubscriber('0/2');
-    const [sub2, _1, stream2] = createSubscriber('0/3');
+    const [sub1, _0, stream1] = createSubscriber('02');
+    const [sub2, _1, stream2] = createSubscriber('03');
 
     // This should be buffered until catchup is complete.
-    sub1.send({watermark: '0/7', change: messages.begin('456')});
-    sub2.send({watermark: '0/7', change: messages.begin('456')});
+    sub1.send({watermark: '07', change: messages.begin('456')});
+    sub2.send({watermark: '07', change: messages.begin('456')});
 
     // Start a transaction before enqueuing catchup.
-    storer.store({watermark: '0/5', change: messages.begin('123')});
+    storer.store({watermark: '05', change: messages.begin('123')});
     // Enqueue catchup before transaction completes.
     storer.catchup(sub1);
     storer.catchup(sub2);
     // Finish the transaction.
-    storer.store({watermark: '0/6', change: messages.commit('312')});
+    storer.store({watermark: '06', change: messages.commit('312')});
 
     // Catchup should wait for the transaction to complete before querying
     // the database, and start after watermark '02'.
-    expect(await drainUntil('0/7', stream1)).toMatchInlineSnapshot(`
+    expect(await drainUntil('07', stream1)).toMatchInlineSnapshot(`
       [
         [
           "change",
@@ -165,7 +165,7 @@ describe('change-streamer/storer', () => {
             "change": {
               "boo": "doo",
             },
-            "watermark": "0/3",
+            "watermark": "03",
           },
         ],
         [
@@ -174,7 +174,7 @@ describe('change-streamer/storer', () => {
             "change": {
               "moo": "foo",
             },
-            "watermark": "0/4",
+            "watermark": "04",
           },
         ],
         [
@@ -186,7 +186,7 @@ describe('change-streamer/storer', () => {
               "tag": "begin",
               "xid": 0,
             },
-            "watermark": "0/5",
+            "watermark": "05",
           },
         ],
         [
@@ -199,7 +199,7 @@ describe('change-streamer/storer', () => {
               "flags": 0,
               "tag": "commit",
             },
-            "watermark": "0/6",
+            "watermark": "06",
           },
         ],
         [
@@ -211,7 +211,7 @@ describe('change-streamer/storer', () => {
               "tag": "begin",
               "xid": 0,
             },
-            "watermark": "0/7",
+            "watermark": "07",
           },
         ],
       ]
@@ -219,7 +219,7 @@ describe('change-streamer/storer', () => {
 
     // Catchup should wait for the transaction to complete before querying
     // the database, and start after watermark '03'.
-    expect(await drainUntil('0/7', stream2)).toMatchInlineSnapshot(`
+    expect(await drainUntil('07', stream2)).toMatchInlineSnapshot(`
       [
         [
           "change",
@@ -227,7 +227,7 @@ describe('change-streamer/storer', () => {
             "change": {
               "moo": "foo",
             },
-            "watermark": "0/4",
+            "watermark": "04",
           },
         ],
         [
@@ -239,7 +239,7 @@ describe('change-streamer/storer', () => {
               "tag": "begin",
               "xid": 0,
             },
-            "watermark": "0/5",
+            "watermark": "05",
           },
         ],
         [
@@ -252,7 +252,7 @@ describe('change-streamer/storer', () => {
               "flags": 0,
               "tag": "commit",
             },
-            "watermark": "0/6",
+            "watermark": "06",
           },
         ],
         [
@@ -264,7 +264,7 @@ describe('change-streamer/storer', () => {
               "tag": "begin",
               "xid": 0,
             },
-            "watermark": "0/7",
+            "watermark": "07",
           },
         ],
       ]
@@ -272,29 +272,29 @@ describe('change-streamer/storer', () => {
   });
 
   test('catchup does not include subsequent transactions', async () => {
-    const [sub, _0, stream] = createSubscriber('0/4');
+    const [sub, _0, stream] = createSubscriber('04');
 
     // This should be buffered until catchup is complete.
-    sub.send({watermark: '0/9', change: messages.begin('789')});
+    sub.send({watermark: '09', change: messages.begin('789')});
 
     // Start a transaction before enqueuing catchup.
-    storer.store({watermark: '0/5', change: messages.begin('123')});
+    storer.store({watermark: '05', change: messages.begin('123')});
     // Enqueue catchup before transaction completes.
     storer.catchup(sub);
     // Finish the transaction.
-    storer.store({watermark: '0/6', change: messages.commit('312')});
+    storer.store({watermark: '06', change: messages.commit('312')});
 
     // And finish another the transaction. In reality, these would be
     // sent by the forwarder, but we skip it in the test to confirm that
     // catchup doesn't include the next transaction.
-    storer.store({watermark: '0/7', change: messages.begin('456')});
-    storer.store({watermark: '0/8', change: messages.commit('654')});
+    storer.store({watermark: '07', change: messages.begin('456')});
+    storer.store({watermark: '08', change: messages.commit('654')});
 
     // Messages should catchup from after '04' and include '05' and '06'
     // from the pending transaction. '07' and '08' should not be included
     // in the snapshot used for catchup. We confirm this by sending the '09'
     // message and ensuring that that was sent.
-    expect(await drainUntil('0/9', stream)).toMatchInlineSnapshot(`
+    expect(await drainUntil('09', stream)).toMatchInlineSnapshot(`
       [
         [
           "change",
@@ -305,7 +305,7 @@ describe('change-streamer/storer', () => {
               "tag": "begin",
               "xid": 0,
             },
-            "watermark": "0/5",
+            "watermark": "05",
           },
         ],
         [
@@ -318,7 +318,7 @@ describe('change-streamer/storer', () => {
               "flags": 0,
               "tag": "commit",
             },
-            "watermark": "0/6",
+            "watermark": "06",
           },
         ],
         [
@@ -330,7 +330,7 @@ describe('change-streamer/storer', () => {
               "tag": "begin",
               "xid": 0,
             },
-            "watermark": "0/9",
+            "watermark": "09",
           },
         ],
       ]
@@ -338,25 +338,25 @@ describe('change-streamer/storer', () => {
   });
 
   test('change positioning and replay detection', async () => {
-    storer.store({watermark: '0/5', change: messages.begin('123')});
-    storer.store({watermark: '0/5', change: messages.truncate('issues')});
-    storer.store({watermark: '0/6', change: messages.commit('321')});
+    storer.store({watermark: '05', change: messages.begin('123')});
+    storer.store({watermark: '05', change: messages.truncate('issues')});
+    storer.store({watermark: '06', change: messages.commit('321')});
     expect(await commits.dequeue()).toBe('321');
 
     // Simulate a replay.
-    storer.store({watermark: '0/5', change: messages.begin('123')});
-    storer.store({watermark: '0/5', change: messages.truncate('issues')});
-    storer.store({watermark: '0/6', change: messages.commit('321')});
+    storer.store({watermark: '05', change: messages.begin('123')});
+    storer.store({watermark: '05', change: messages.truncate('issues')});
+    storer.store({watermark: '06', change: messages.commit('321')});
     // ACK should be resent.
     expect(await commits.dequeue()).toBe('321');
 
     // Continue to the next transaction.
-    storer.store({watermark: '0/7', change: messages.begin('456')});
-    storer.store({watermark: '0/7', change: messages.truncate('issues')});
-    storer.store({watermark: '0/8', change: messages.commit('654')});
+    storer.store({watermark: '07', change: messages.begin('456')});
+    storer.store({watermark: '07', change: messages.truncate('issues')});
+    storer.store({watermark: '08', change: messages.commit('654')});
     expect(await commits.dequeue()).toBe('654');
 
-    expect(await db`SELECT * FROM cdc."ChangeLog" WHERE watermark >= '0/5'`)
+    expect(await db`SELECT * FROM cdc."ChangeLog" WHERE watermark >= '05'`)
       .toMatchInlineSnapshot(`
       Result [
         {
@@ -367,7 +367,7 @@ describe('change-streamer/storer', () => {
             "xid": 0,
           },
           "pos": 0n,
-          "watermark": "0/5",
+          "watermark": "05",
         },
         {
           "change": {
@@ -398,7 +398,7 @@ describe('change-streamer/storer', () => {
             "tag": "truncate",
           },
           "pos": 1n,
-          "watermark": "0/5",
+          "watermark": "05",
         },
         {
           "change": {
@@ -409,7 +409,7 @@ describe('change-streamer/storer', () => {
             "tag": "commit",
           },
           "pos": 2n,
-          "watermark": "0/6",
+          "watermark": "06",
         },
         {
           "change": {
@@ -419,7 +419,7 @@ describe('change-streamer/storer', () => {
             "xid": 0,
           },
           "pos": 0n,
-          "watermark": "0/7",
+          "watermark": "07",
         },
         {
           "change": {
@@ -450,7 +450,7 @@ describe('change-streamer/storer', () => {
             "tag": "truncate",
           },
           "pos": 1n,
-          "watermark": "0/7",
+          "watermark": "07",
         },
         {
           "change": {
@@ -461,7 +461,7 @@ describe('change-streamer/storer', () => {
             "tag": "commit",
           },
           "pos": 2n,
-          "watermark": "0/8",
+          "watermark": "08",
         },
       ]
     `);

--- a/packages/zero-cache/src/services/change-streamer/subscriber.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/subscriber.test.ts
@@ -6,21 +6,21 @@ describe('change-streamer/subscriber', () => {
   const messages = new ReplicationMessages({issues: 'id'});
 
   test('catchup and backlog', () => {
-    const [sub, stream] = createSubscriber('0/0');
+    const [sub, stream] = createSubscriber('00');
 
     // Send some messages while it is catching up.
-    sub.send({watermark: '0/11', change: messages.begin('123')});
-    sub.send({watermark: '0/12', change: messages.commit('124')});
+    sub.send({watermark: '11', change: messages.begin('123')});
+    sub.send({watermark: '12', change: messages.commit('124')});
 
     // Send catchup messages.
-    sub.catchup({watermark: '0/1', change: messages.begin('012')});
-    sub.catchup({watermark: '0/2', change: messages.commit('013')});
+    sub.catchup({watermark: '01', change: messages.begin('012')});
+    sub.catchup({watermark: '02', change: messages.commit('013')});
 
     sub.setCaughtUp();
 
     // Send some messages after catchup.
-    sub.send({watermark: '0/21', change: messages.begin('321')});
-    sub.send({watermark: '0/22', change: messages.commit('322')});
+    sub.send({watermark: '21', change: messages.begin('321')});
+    sub.send({watermark: '22', change: messages.commit('322')});
 
     sub.close();
 
@@ -35,7 +35,7 @@ describe('change-streamer/subscriber', () => {
               "tag": "begin",
               "xid": 0,
             },
-            "watermark": "0/1",
+            "watermark": "01",
           },
         ],
         [
@@ -48,7 +48,7 @@ describe('change-streamer/subscriber', () => {
               "flags": 0,
               "tag": "commit",
             },
-            "watermark": "0/2",
+            "watermark": "02",
           },
         ],
         [
@@ -60,7 +60,7 @@ describe('change-streamer/subscriber', () => {
               "tag": "begin",
               "xid": 0,
             },
-            "watermark": "0/11",
+            "watermark": "11",
           },
         ],
         [
@@ -73,7 +73,7 @@ describe('change-streamer/subscriber', () => {
               "flags": 0,
               "tag": "commit",
             },
-            "watermark": "0/12",
+            "watermark": "12",
           },
         ],
         [
@@ -85,7 +85,7 @@ describe('change-streamer/subscriber', () => {
               "tag": "begin",
               "xid": 0,
             },
-            "watermark": "0/21",
+            "watermark": "21",
           },
         ],
         [
@@ -98,7 +98,7 @@ describe('change-streamer/subscriber', () => {
               "flags": 0,
               "tag": "commit",
             },
-            "watermark": "0/22",
+            "watermark": "22",
           },
         ],
       ]
@@ -106,22 +106,22 @@ describe('change-streamer/subscriber', () => {
   });
 
   test('watermark filtering', () => {
-    const [sub, stream] = createSubscriber('0/123');
+    const [sub, stream] = createSubscriber('123');
 
     // Technically, catchup should never send any messages if the subscriber
     // is ahead, since the watermark query would return no results. But pretend it
     // does just to ensure that catchup messages are subject to the filter.
-    sub.catchup({watermark: '0/1', change: messages.begin('01')});
-    sub.catchup({watermark: '0/2', change: messages.begin('02')});
+    sub.catchup({watermark: '01', change: messages.begin('01')});
+    sub.catchup({watermark: '02', change: messages.begin('02')});
     sub.setCaughtUp();
 
     // Still lower than the watermark ...
-    sub.send({watermark: '0/121', change: messages.begin('12')});
-    sub.send({watermark: '0/123', change: messages.begin('13')});
+    sub.send({watermark: '121', change: messages.begin('12')});
+    sub.send({watermark: '123', change: messages.begin('13')});
 
     // These should be sent.
-    sub.send({watermark: '0/124', change: messages.begin('23')});
-    sub.send({watermark: '0/125', change: messages.begin('24')});
+    sub.send({watermark: '124', change: messages.begin('23')});
+    sub.send({watermark: '125', change: messages.begin('24')});
 
     sub.close();
     expect(stream).toMatchInlineSnapshot(`
@@ -135,7 +135,7 @@ describe('change-streamer/subscriber', () => {
               "tag": "begin",
               "xid": 0,
             },
-            "watermark": "0/124",
+            "watermark": "124",
           },
         ],
         [
@@ -147,7 +147,7 @@ describe('change-streamer/subscriber', () => {
               "tag": "begin",
               "xid": 0,
             },
-            "watermark": "0/125",
+            "watermark": "125",
           },
         ],
       ]

--- a/packages/zero-cache/src/services/change-streamer/subscriber.ts
+++ b/packages/zero-cache/src/services/change-streamer/subscriber.ts
@@ -1,5 +1,4 @@
 import {assert} from 'shared/src/asserts.js';
-import {compareLSN} from 'zero-cache/src/types/lsn.js';
 import {Subscription} from 'zero-cache/src/types/subscription.js';
 import {ChangeEntry, Downstream, ErrorType} from './change-streamer.js';
 
@@ -29,7 +28,7 @@ export class Subscriber {
 
   send(change: ChangeEntry) {
     const {watermark} = change;
-    if (compareLSN(watermark, this.watermark) > 0) {
+    if (watermark > this.watermark) {
       if (this.#backlog) {
         this.#backlog.push(change);
       } else {
@@ -57,7 +56,7 @@ export class Subscriber {
 
   #send(change: ChangeEntry) {
     const {watermark} = change;
-    if (compareLSN(watermark, this.watermark) > 0) {
+    if (watermark > this.watermark) {
       this.#downstream.push(['change', change]);
     }
   }

--- a/packages/zero-cache/src/services/change-streamer/test-utils.ts
+++ b/packages/zero-cache/src/services/change-streamer/test-utils.ts
@@ -1,4 +1,3 @@
-import {toLexiVersion} from 'zero-cache/src/types/lsn.js';
 import {Subscription} from 'zero-cache/src/types/subscription.js';
 import {Downstream} from './change-streamer.js';
 import {Subscriber} from './subscriber.js';
@@ -6,12 +5,9 @@ import {Subscriber} from './subscriber.js';
 let nextID = 1;
 
 export function createSubscriber(
-  watermark = '0/0',
+  watermark = '00',
   caughtUp = false,
 ): [Subscriber, Downstream[], Subscription<Downstream>] {
-  // Sanity check the watermark.
-  toLexiVersion(watermark);
-
   const id = '' + nextID++;
   const received: Downstream[] = [];
   const sub = Subscription.create<Downstream>({

--- a/packages/zero-cache/src/types/lsn.test.ts
+++ b/packages/zero-cache/src/types/lsn.test.ts
@@ -1,6 +1,6 @@
 import {expect, test} from 'vitest';
 import {versionFromLexi, type LexiVersion} from './lexi-version.js';
-import {compareLSN, toLexiVersion, type LSN} from './lsn.js';
+import {toLexiVersion, type LSN} from './lsn.js';
 
 test('lsn to LexiVersion', () => {
   type Case = [LSN, LexiVersion, bigint];
@@ -13,18 +13,5 @@ test('lsn to LexiVersion', () => {
   for (const [lsn, lexi, ver] of cases) {
     expect(toLexiVersion(lsn)).toBe(lexi);
     expect(versionFromLexi(lexi).toString()).toBe(ver.toString());
-  }
-});
-
-test('compareLSN', () => {
-  type Case = [LSN, LSN, number];
-  const cases: Case[] = [
-    ['0/0', '00/00', 0],
-    ['0/A', '0/0a', 0],
-    ['16/B374D848', '16/B374D850', -1],
-    ['16/B374D848', '16/B374D840', 1],
-  ];
-  for (const [a, b, cmp] of cases) {
-    expect(compareLSN(a, b)).toBe(cmp);
   }
 });

--- a/packages/zero-cache/src/types/lsn.ts
+++ b/packages/zero-cache/src/types/lsn.ts
@@ -13,19 +13,10 @@ import {versionToLexi, type LexiVersion} from './lexi-version.js';
  */
 export type LSN = string;
 
-function toBigInt(lsn: LSN): bigint {
+export function toLexiVersion(lsn: LSN): LexiVersion {
   const parts = lsn.split('/');
   assert(parts.length === 2, `Malformed LSN: "${lsn}"`);
   const high = BigInt(`0x${parts[0]}`);
   const low = BigInt(`0x${parts[1]}`);
-  return (high << 32n) + low;
-}
-
-export function toLexiVersion(lsn: LSN): LexiVersion {
-  return versionToLexi(toBigInt(lsn));
-}
-
-export function compareLSN(a: LSN, b: LSN): number {
-  const diff = toBigInt(a) - toBigInt(b);
-  return diff < 0n ? -1 : diff === 0n ? 0 : 1;
+  return versionToLexi((high << 32n) + low);
 }


### PR DESCRIPTION
On second thought I think using lexi version is cleaner. Work in progress.