### PR TITLE
feat(zero-cache): better watermark scheme for LSNs

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/pg/lsn.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/lsn.test.ts
@@ -9,23 +9,23 @@ test('lsn to/from LexiVersion', () => {
   type Case = [LSN, LexiVersion, bigint];
   const cases: Case[] = [
     ['0/0', '00', 0n],
-    ['0/A', '0a', 10n],
-    ['16/B374D848', '718sh0nk8', 97500059720n],
-    ['FFFFFFFF/FFFFFFFF', 'c3w5e11264sgsf', 2n ** 64n - 1n],
+    ['0/A', '114', 10n],
+    ['16/B374D848', '74z5w2m8w', 97500059720n],
+    ['FFFFFFFF/FFFFFFFF', 'cfklk448oj5v5o', 2n ** 64n - 1n],
   ];
   for (const [lsn, lexi, ver] of cases) {
     expect(toLexiVersion(lsn)).toBe(lexi);
-    expect(versionFromLexi(lexi).toString()).toBe(ver.toString());
+    expect(versionFromLexi(lexi).toString()).toBe((ver << 2n).toString());
     expect(fromLexiVersion(lexi)).toBe(lsn);
   }
 });
 
 test('lsn to/from LexiVersion with offset', () => {
-  expect(toLexiVersion('16/B374D848', 'commit')).toBe('718sh0nk8');
-  expect(toLexiVersion('16/B374D848', 'begin')).toBe('718sh0nk9');
-  expect(toLexiVersion('16/B374D848', 'insert')).toBe('718sh0nka');
+  expect(toLexiVersion('16/B374D848', 'commit')).toBe('74z5w2m8w');
+  expect(toLexiVersion('16/B374D848', 'begin')).toBe('74z5w2m8x');
+  expect(toLexiVersion('16/B374D848', 'insert')).toBe('74z5w2m8y');
 
-  expect(fromLexiVersion('718sh0nk8', 'commit')).toBe('16/B374D848');
-  expect(fromLexiVersion('718sh0nk8', 'begin')).toBe('16/B374D847');
-  expect(fromLexiVersion('718sh0nk8', 'insert')).toBe('16/B374D846');
+  expect(fromLexiVersion('74z5w2m8w')).toBe('16/B374D848');
+  expect(fromLexiVersion('74z5w2m8x')).toBe('16/B374D848');
+  expect(fromLexiVersion('74z5w2m8y')).toBe('16/B374D848');
 });

--- a/packages/zero-cache/src/services/replicator/incremental-sync.message-processor.test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.message-processor.test.ts
@@ -136,9 +136,9 @@ describe('replicator/message-processor', () => {
       replicated: {
         foo: [
           {id: 123, big: null, ['_0_version']: '02'},
-          {id: 234, big: null, ['_0_version']: '04'},
-          {id: 789, big: null, ['_0_version']: '0a'},
-          {id: 987, big: null, ['_0_version']: '0a'},
+          {id: 234, big: null, ['_0_version']: '0g'},
+          {id: 789, big: null, ['_0_version']: '114'},
+          {id: 987, big: null, ['_0_version']: '114'},
         ],
       },
       expectFailure: false,

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -380,7 +380,7 @@ describe('view-syncer/pipeline-driver', () => {
         {
           "queryHash": "hash1",
           "row": {
-            "_0_version": "1fo",
+            "_0_version": "21qo",
             "id": "41",
             "issueID": "4",
             "upvotes": 10,

--- a/packages/zero-cache/src/services/view-syncer/snapshotter.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/snapshotter.test.ts
@@ -247,14 +247,14 @@ describe('view-syncer/snapshotter', () => {
 
     const diff2 = s1.advance();
     expect(diff2.prev.version).toBe('01');
-    expect(diff2.curr.version).toBe('02');
+    expect(diff2.curr.version).toBe('08');
     expect(diff2.changes).toBe(3);
 
     expect([...diff2]).toMatchInlineSnapshot(`
       [
         {
           "nextValue": {
-            "_0_version": "02",
+            "_0_version": "08",
             "desc": "bard",
             "id": 2n,
             "owner": 10n,
@@ -294,12 +294,12 @@ describe('view-syncer/snapshotter', () => {
     }
     expect(thrown).toBeInstanceOf(InvalidDiffError);
 
-    // The diff for s2 goes straight from '00' to '02'.
+    // The diff for s2 goes straight from '00' to '08'.
     // This will coalesce multiple changes to a row, and can result in some noops,
     // (e.g. rows that return to their original state).
     const diff3 = s2.advance();
     expect(diff3.prev.version).toBe('00');
-    expect(diff3.curr.version).toBe('02');
+    expect(diff3.curr.version).toBe('08');
     expect(diff3.changes).toBe(5);
     expect([...diff3]).toMatchInlineSnapshot(`
       [
@@ -330,7 +330,7 @@ describe('view-syncer/snapshotter', () => {
         },
         {
           "nextValue": {
-            "_0_version": "02",
+            "_0_version": "08",
             "desc": "bard",
             "id": 2n,
             "owner": 10n,


### PR DESCRIPTION
Based on @arv's idea: shift the LSN values before adding the offset. This eliminates the requirement from the previous scheme that DML statements be more than 2 bytes in size (or else they could collide with a subsequent 'commit' statement). By shifting first, there is no possibility of collision regardless of record size.