### PR TITLE
fix(zero-cache): propagate CVR loading errors to eliminate assertions

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr-store.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.ts
@@ -1,7 +1,9 @@
 import type {LogContext} from '@rocicorp/logger';
+import {resolver} from '@rocicorp/resolver';
 import {MaybeRow, PendingQuery} from 'postgres';
 import {assert} from 'shared/src/asserts.js';
 import {CustomKeyMap} from 'shared/src/custom-key-map.js';
+import {deepEqual, ReadonlyJSONValue} from 'shared/src/json.js';
 import {must} from 'shared/src/must.js';
 import {astSchema} from 'zero-protocol';
 import type {JSONValue} from '../../types/bigint-json.js';
@@ -33,8 +35,6 @@ import {
   type RowID,
   type RowRecord,
 } from './schema/types.js';
-import {deepEqual, ReadonlyJSONValue} from 'shared/src/json.js';
-import {resolver} from '@rocicorp/resolver';
 
 type NotNull<T> = T extends null ? never : T;
 
@@ -218,7 +218,9 @@ export class CVRStore {
         query.desiredBy[row.clientID] = versionFromString(row.patchVersion);
       }
     }
-    this.#lc.debug?.(`loaded CVR (${Date.now() - start} ms)`);
+    this.#lc.debug?.(
+      `loaded CVR @${versionString(cvr.version)} (${Date.now() - start} ms)`,
+    );
 
     return cvr;
   }


### PR DESCRIPTION
Ensure that the CVR is loaded for every function that needs it, rather than assuming that the service successfully loads it at start time.

The theory for why the assertion was firing for Nate is that the initial load of the CVR failed, which ultimately fails the Service, but the Service object itself had some requests queued up on the lock, and once they were invoked, the `#cvr` snapshot was null.

Instead, we ensure that the CVR is loaded when acquiring the lock, and pass it down to the functions that need it. This way, the failure to load the CVR would be surfaced directly instead of returning a cryptic assertion failure.