### PR TITLE
chore(zero-cache): remove PG-specific fields from Change specification

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -1,5 +1,4 @@
 import {LogContext} from '@rocicorp/logger';
-import {Pgoutput} from 'pg-logical-replication';
 import {StatementRunner} from 'zero-cache/src/db/statements.js';
 import {PostgresDB} from 'zero-cache/src/types/pg.js';
 import {Sink, Source} from 'zero-cache/src/types/streams.js';
@@ -15,6 +14,7 @@ import {
   SubscriberContext,
 } from './change-streamer.js';
 import {Forwarder} from './forwarder.js';
+import {MessageCommit} from './schema/change.js';
 import {initChangeStreamerSchema} from './schema/init.js';
 import {ensureReplicationConfig, ReplicationConfig} from './schema/tables.js';
 import {Storer} from './storer.js';
@@ -40,7 +40,14 @@ export async function initializeStreamer(
 
 export type ChangeStream = {
   changes: Source<ChangeEntry>;
-  acks: Sink<Pgoutput.MessageCommit>;
+
+  /**
+   * A Sink to push the MessageCommit messages that have been successfully
+   * stored by the {@link Storer}. The ACKs should contain the full MessageCommit
+   * that was received from the `changes` Source, which may contain implementation
+   * specific fields needed by the ChangeSource implementation.
+   */
+  acks: Sink<MessageCommit>;
 };
 
 /** Encapsulates an upstream-specific implementation of a stream of Changes. */

--- a/packages/zero-cache/src/services/change-streamer/forwarder.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/forwarder.test.ts
@@ -15,12 +15,12 @@ describe('change-streamer/forwarder', () => {
     const [sub4, stream4] = createSubscriber('00', true);
 
     forwarder.add(sub1);
-    forwarder.forward({watermark: '11', change: messages.begin('123')});
+    forwarder.forward({watermark: '11', change: messages.begin()});
     forwarder.add(sub2);
     forwarder.forward({watermark: '12', change: messages.truncate('issues')});
-    forwarder.forward({watermark: '13', change: messages.commit('lsn')});
+    forwarder.forward({watermark: '13', change: messages.commit()});
     forwarder.add(sub3);
-    forwarder.forward({watermark: '14', change: messages.begin('456')});
+    forwarder.forward({watermark: '14', change: messages.begin()});
     forwarder.add(sub4);
 
     for (const sub of [sub1, sub2, sub3, sub4]) {
@@ -34,10 +34,7 @@ describe('change-streamer/forwarder', () => {
           "change",
           {
             "change": {
-              "commitLsn": "123",
-              "commitTime": 0n,
               "tag": "begin",
-              "xid": 0,
             },
             "watermark": "11",
           },
@@ -80,10 +77,6 @@ describe('change-streamer/forwarder', () => {
           "change",
           {
             "change": {
-              "commitEndLsn": "lsn",
-              "commitLsn": null,
-              "commitTime": 0n,
-              "flags": 0,
               "tag": "commit",
             },
             "watermark": "13",
@@ -93,10 +86,7 @@ describe('change-streamer/forwarder', () => {
           "change",
           {
             "change": {
-              "commitLsn": "456",
-              "commitTime": 0n,
               "tag": "begin",
-              "xid": 0,
             },
             "watermark": "14",
           },
@@ -112,10 +102,7 @@ describe('change-streamer/forwarder', () => {
           "change",
           {
             "change": {
-              "commitLsn": "456",
-              "commitTime": 0n,
               "tag": "begin",
-              "xid": 0,
             },
             "watermark": "14",
           },
@@ -128,10 +115,7 @@ describe('change-streamer/forwarder', () => {
           "change",
           {
             "change": {
-              "commitLsn": "456",
-              "commitTime": 0n,
               "tag": "begin",
-              "xid": 0,
             },
             "watermark": "14",
           },

--- a/packages/zero-cache/src/services/change-streamer/schema/change.ts
+++ b/packages/zero-cache/src/services/change-streamer/schema/change.ts
@@ -1,4 +1,19 @@
 import {Pgoutput} from 'pg-logical-replication';
+import {JSONValue} from 'shared/src/json.js';
+
+export type MessageBegin = {
+  tag: 'begin';
+
+  // Upstream-specific fields should be preserved but ignored.
+  [field: string]: JSONValue;
+};
+
+export type MessageCommit = {
+  tag: 'commit';
+
+  // Upstream-specific fields should be preserved but ignored.
+  [field: string]: JSONValue;
+};
 
 /**
  * For now, a Change is a subset of the message types sent in the Postgres
@@ -6,10 +21,9 @@ import {Pgoutput} from 'pg-logical-replication';
  * changes) or generalized in the future.
  */
 export type Change =
-  | Pgoutput.MessageBegin
-  | Pgoutput.MessageCommit
+  | MessageBegin
   | Pgoutput.MessageInsert
   | Pgoutput.MessageUpdate
   | Pgoutput.MessageDelete
   | Pgoutput.MessageTruncate
-  | Pgoutput.MessageCommit;
+  | MessageCommit;

--- a/packages/zero-cache/src/services/change-streamer/subscriber.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/subscriber.test.ts
@@ -9,18 +9,18 @@ describe('change-streamer/subscriber', () => {
     const [sub, stream] = createSubscriber('00');
 
     // Send some messages while it is catching up.
-    sub.send({watermark: '11', change: messages.begin('123')});
-    sub.send({watermark: '12', change: messages.commit('124')});
+    sub.send({watermark: '11', change: messages.begin()});
+    sub.send({watermark: '12', change: messages.commit()});
 
     // Send catchup messages.
-    sub.catchup({watermark: '01', change: messages.begin('012')});
-    sub.catchup({watermark: '02', change: messages.commit('013')});
+    sub.catchup({watermark: '01', change: messages.begin()});
+    sub.catchup({watermark: '02', change: messages.commit()});
 
     sub.setCaughtUp();
 
     // Send some messages after catchup.
-    sub.send({watermark: '21', change: messages.begin('321')});
-    sub.send({watermark: '22', change: messages.commit('322')});
+    sub.send({watermark: '21', change: messages.begin()});
+    sub.send({watermark: '22', change: messages.commit()});
 
     sub.close();
 
@@ -30,10 +30,7 @@ describe('change-streamer/subscriber', () => {
           "change",
           {
             "change": {
-              "commitLsn": "012",
-              "commitTime": 0n,
               "tag": "begin",
-              "xid": 0,
             },
             "watermark": "01",
           },
@@ -42,10 +39,6 @@ describe('change-streamer/subscriber', () => {
           "change",
           {
             "change": {
-              "commitEndLsn": "013",
-              "commitLsn": null,
-              "commitTime": 0n,
-              "flags": 0,
               "tag": "commit",
             },
             "watermark": "02",
@@ -55,10 +48,7 @@ describe('change-streamer/subscriber', () => {
           "change",
           {
             "change": {
-              "commitLsn": "123",
-              "commitTime": 0n,
               "tag": "begin",
-              "xid": 0,
             },
             "watermark": "11",
           },
@@ -67,10 +57,6 @@ describe('change-streamer/subscriber', () => {
           "change",
           {
             "change": {
-              "commitEndLsn": "124",
-              "commitLsn": null,
-              "commitTime": 0n,
-              "flags": 0,
               "tag": "commit",
             },
             "watermark": "12",
@@ -80,10 +66,7 @@ describe('change-streamer/subscriber', () => {
           "change",
           {
             "change": {
-              "commitLsn": "321",
-              "commitTime": 0n,
               "tag": "begin",
-              "xid": 0,
             },
             "watermark": "21",
           },
@@ -92,10 +75,6 @@ describe('change-streamer/subscriber', () => {
           "change",
           {
             "change": {
-              "commitEndLsn": "322",
-              "commitLsn": null,
-              "commitTime": 0n,
-              "flags": 0,
               "tag": "commit",
             },
             "watermark": "22",
@@ -111,21 +90,21 @@ describe('change-streamer/subscriber', () => {
     // Technically, catchup should never send any messages if the subscriber
     // is ahead, since the watermark query would return no results. But pretend it
     // does just to ensure that catchup messages are subject to the filter.
-    sub.catchup({watermark: '01', change: messages.begin('01')});
-    sub.catchup({watermark: '02', change: messages.begin('02')});
+    sub.catchup({watermark: '01', change: messages.begin()});
+    sub.catchup({watermark: '02', change: messages.begin()});
     sub.setCaughtUp();
 
     // Still lower than the watermark ...
-    sub.send({watermark: '121', change: messages.begin('12')});
-    sub.send({watermark: '123', change: messages.begin('13')});
+    sub.send({watermark: '121', change: messages.begin()});
+    sub.send({watermark: '123', change: messages.begin()});
 
     // These should be sent.
-    sub.send({watermark: '124', change: messages.begin('23')});
-    sub.send({watermark: '125', change: messages.begin('24')});
+    sub.send({watermark: '124', change: messages.begin()});
+    sub.send({watermark: '125', change: messages.begin()});
 
     // Replays should be ignored.
-    sub.send({watermark: '124', change: messages.begin('23')});
-    sub.send({watermark: '125', change: messages.begin('24')});
+    sub.send({watermark: '124', change: messages.begin()});
+    sub.send({watermark: '125', change: messages.begin()});
 
     sub.close();
     expect(stream).toMatchInlineSnapshot(`
@@ -134,10 +113,7 @@ describe('change-streamer/subscriber', () => {
           "change",
           {
             "change": {
-              "commitLsn": "23",
-              "commitTime": 0n,
               "tag": "begin",
-              "xid": 0,
             },
             "watermark": "124",
           },
@@ -146,10 +122,7 @@ describe('change-streamer/subscriber', () => {
           "change",
           {
             "change": {
-              "commitLsn": "24",
-              "commitTime": 0n,
               "tag": "begin",
-              "xid": 0,
             },
             "watermark": "125",
           },

--- a/packages/zero-cache/src/services/replicator/incremental-sync.message-processor.test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.message-processor.test.ts
@@ -50,18 +50,18 @@ describe('replicator/message-processor', () => {
         ['04', messages.begin()],
         ['05', messages.insert('foo', {id: 123})],
         ['06', messages.insert('foo', {id: 234})],
-        ['07', messages.commit('0/E')],
+        ['07', messages.commit()],
 
         // Induce a failure with a missing 'begin' message.
         ['08', messages.insert('foo', {id: 456})],
         ['09', messages.insert('foo', {id: 345})],
-        ['0a', messages.commit('0/31')],
+        ['0a', messages.commit()],
 
         // This should be dropped.
         ['0b', messages.begin()],
         ['0c', messages.insert('foo', {id: 789})],
         ['0d', messages.insert('foo', {id: 987})],
-        ['0e', messages.commit('0/51')],
+        ['0e', messages.commit()],
       ],
       acknowledged: ['07'],
       expectedVersionChanges: 1,
@@ -78,11 +78,11 @@ describe('replicator/message-processor', () => {
       messages: [
         ['05', messages.begin()],
         ['06', messages.insert('foo', {id: 123})],
-        ['08', messages.commit('0/4')],
+        ['08', messages.commit()],
 
         ['09', messages.begin()],
         ['0a', messages.insert('foo', {id: 234})],
-        ['0c', messages.commit('0/A')],
+        ['0c', messages.commit()],
 
         // Simulate Postgres resending the first two transactions (e.g. reconnecting after
         // the acknowledgements were lost). Both should be dropped (i.e. rolled back).
@@ -92,7 +92,7 @@ describe('replicator/message-processor', () => {
         // This would not actually happen, but it allows us to confirm that no mutations
         // are applied.
         ['07', messages.insert('foo', {id: 456})],
-        ['08', messages.commit('0/4')],
+        ['08', messages.commit()],
 
         ['09', messages.begin()],
         ['0a', messages.insert('foo', {id: 234})],
@@ -100,13 +100,13 @@ describe('replicator/message-processor', () => {
         // This would not actually happen, but it allows us to confirm that no mutations
         // are applied.
         ['0b', messages.insert('foo', {id: 654})],
-        ['0c', messages.commit('0/A')],
+        ['0c', messages.commit()],
 
         // This should succeed.
         ['0d', messages.begin()],
         ['0e', messages.insert('foo', {id: 789})],
         ['0f', messages.insert('foo', {id: 987})],
-        ['0g', messages.commit('0/F')],
+        ['0g', messages.commit()],
       ],
       acknowledged: [
         '08',

--- a/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
@@ -81,15 +81,15 @@ describe('replicator/incremental-sync', {retry: 3}, () => {
       );
       `,
       downstream: [
-        {watermark: '03', change: issues.begin('0/06')},
+        {watermark: '03', change: issues.begin()},
         {watermark: '04', change: issues.insert('issues', {issueID: 123})},
         {
           watermark: '05',
           change: issues.insert('issues', {issueID: 456, bool: false}),
         },
-        {watermark: '06', change: issues.commit('0/06')},
+        {watermark: '06', change: issues.commit()},
 
-        {watermark: '07', change: issues.begin('0/0B')},
+        {watermark: '07', change: issues.begin()},
         {
           watermark: '08',
           change: issues.insert('issues', {
@@ -105,7 +105,7 @@ describe('replicator/incremental-sync', {retry: 3}, () => {
           watermark: '0a',
           change: issues.insert('issues', {issueID: 234, flt: 123.456}),
         },
-        {watermark: '0b', change: issues.commit('0/0B')},
+        {watermark: '0b', change: issues.commit()},
       ],
       data: {
         issues: [
@@ -197,7 +197,7 @@ describe('replicator/incremental-sync', {retry: 3}, () => {
       );
       `,
       downstream: [
-        {watermark: '02', change: orgIssues.begin('0/06')},
+        {watermark: '02', change: orgIssues.begin()},
         {
           watermark: '03',
           change: orgIssues.insert('issues', {orgID: 1, issueID: 123}),
@@ -210,9 +210,9 @@ describe('replicator/incremental-sync', {retry: 3}, () => {
           watermark: '05',
           change: orgIssues.insert('issues', {orgID: 2, issueID: 789}),
         },
-        {watermark: '06', change: orgIssues.commit('0/06')},
+        {watermark: '06', change: orgIssues.commit()},
 
-        {watermark: '07', change: orgIssues.begin('0/0A')},
+        {watermark: '07', change: orgIssues.begin()},
         {
           watermark: '08',
           change: orgIssues.update('issues', {
@@ -235,7 +235,7 @@ describe('replicator/incremental-sync', {retry: 3}, () => {
             {orgID: 1, issueID: 123},
           ),
         },
-        {watermark: '0a', change: orgIssues.commit('0/0A')},
+        {watermark: '0a', change: orgIssues.commit()},
       ],
       data: {
         issues: [
@@ -301,7 +301,7 @@ describe('replicator/incremental-sync', {retry: 3}, () => {
       );
       `,
       downstream: [
-        {watermark: '02', change: orgIssues.begin('0/07')},
+        {watermark: '02', change: orgIssues.begin()},
         {
           watermark: '03',
           change: orgIssues.insert('issues', {orgID: 1, issueID: 123}),
@@ -318,9 +318,9 @@ describe('replicator/incremental-sync', {retry: 3}, () => {
           watermark: '06',
           change: orgIssues.insert('issues', {orgID: 2, issueID: 987}),
         },
-        {watermark: '07', change: orgIssues.commit('0/07')},
+        {watermark: '07', change: orgIssues.commit()},
 
-        {watermark: '08', change: orgIssues.begin('0/0C')},
+        {watermark: '08', change: orgIssues.begin()},
         {
           watermark: '09',
           change: orgIssues.delete('issues', {orgID: 1, issueID: 123}),
@@ -333,7 +333,7 @@ describe('replicator/incremental-sync', {retry: 3}, () => {
           watermark: '0b',
           change: orgIssues.delete('issues', {orgID: 2, issueID: 987}),
         },
-        {watermark: '0c', change: orgIssues.commit('0/0C')},
+        {watermark: '0c', change: orgIssues.commit()},
       ],
       data: {
         issues: [
@@ -375,7 +375,7 @@ describe('replicator/incremental-sync', {retry: 3}, () => {
       CREATE TABLE baz(id INTEGER PRIMARY KEY, _0_version TEXT NOT NULL);
       `,
       downstream: [
-        {watermark: '02', change: fooBarBaz.begin('0/0E')},
+        {watermark: '02', change: fooBarBaz.begin()},
         {watermark: '03', change: fooBarBaz.insert('foo', {id: 1})},
         {watermark: '04', change: fooBarBaz.insert('foo', {id: 2})},
         {watermark: '05', change: fooBarBaz.insert('foo', {id: 3})},
@@ -387,12 +387,12 @@ describe('replicator/incremental-sync', {retry: 3}, () => {
         {watermark: '0b', change: fooBarBaz.insert('baz', {id: 9})},
         {watermark: '0c', change: fooBarBaz.truncate('foo', 'baz')},
         {watermark: '0d', change: fooBarBaz.truncate('foo')}, // Redundant. Shouldn't cause problems.
-        {watermark: '0e', change: fooBarBaz.commit('0/0E')},
+        {watermark: '0e', change: fooBarBaz.commit()},
 
-        {watermark: '0f', change: fooBarBaz.begin('0/12')},
+        {watermark: '0f', change: fooBarBaz.begin()},
         {watermark: '0g', change: fooBarBaz.truncate('foo')},
         {watermark: '0h', change: fooBarBaz.insert('foo', {id: 101})},
-        {watermark: '0i', change: fooBarBaz.commit('0/12')},
+        {watermark: '0i', change: fooBarBaz.commit()},
       ],
       data: {
         foo: [{id: 101n, ['_0_version']: '0e'}],
@@ -454,7 +454,7 @@ describe('replicator/incremental-sync', {retry: 3}, () => {
       );
       `,
       downstream: [
-        {watermark: '02', change: orgIssues.begin('0/08')},
+        {watermark: '02', change: orgIssues.begin()},
         {
           watermark: '03',
           change: orgIssues.insert('issues', {orgID: 1, issueID: 123}),
@@ -483,7 +483,7 @@ describe('replicator/incremental-sync', {retry: 3}, () => {
             description: 'foo',
           }),
         },
-        {watermark: '08', change: orgIssues.commit('0/08')},
+        {watermark: '08', change: orgIssues.commit()},
       ],
       data: {
         issues: [

--- a/packages/zero-cache/src/services/view-syncer/snapshotter.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/snapshotter.test.ts
@@ -107,7 +107,7 @@ describe('view-syncer/snapshotter', () => {
       messages.update('issues', {id: 5, owner: 10, desc: 'bard'}, {id: 2}),
     );
     replicator.processMessage(lc, '08', messages.delete('issues', {id: 3}));
-    replicator.processMessage(lc, '09', messages.commit('0/2'));
+    replicator.processMessage(lc, '09', messages.commit());
 
     const diff1 = s1.advance();
     expect(diff1.prev.version).toBe('00');
@@ -243,7 +243,7 @@ describe('view-syncer/snapshotter', () => {
       '0c',
       messages.update('issues', {id: 2, owner: 10, desc: 'bard'}, {id: 5}),
     );
-    replicator.processMessage(lc, '0d', messages.commit('0/4'));
+    replicator.processMessage(lc, '0d', messages.commit());
 
     const diff2 = s1.advance();
     expect(diff2.prev.version).toBe('01');
@@ -355,7 +355,7 @@ describe('view-syncer/snapshotter', () => {
 
     replicator.processMessage(lc, '05', messages.begin());
     replicator.processMessage(lc, '06', messages.truncate('comments'));
-    replicator.processMessage(lc, '07', messages.commit('0/2'));
+    replicator.processMessage(lc, '07', messages.commit());
 
     const diff = s.advance();
     expect(diff.prev.version).toBe('00');
@@ -373,7 +373,7 @@ describe('view-syncer/snapshotter', () => {
 
     replicator.processMessage(lc, '05', messages.begin());
     replicator.processMessage(lc, '06', messages.truncate('users'));
-    replicator.processMessage(lc, '07', messages.commit('0/2'));
+    replicator.processMessage(lc, '07', messages.commit());
 
     const diff = s.advance();
     expect(diff.prev.version).toBe('00');
@@ -413,7 +413,7 @@ describe('view-syncer/snapshotter', () => {
     replicator.processMessage(lc, '05', messages.begin());
     replicator.processMessage(lc, '06', messages.truncate('issues'));
     replicator.processMessage(lc, '07', messages.truncate('users'));
-    replicator.processMessage(lc, '08', messages.commit('0/2'));
+    replicator.processMessage(lc, '08', messages.commit());
 
     const diff = s.advance();
     expect(diff.prev.version).toBe('00');
@@ -492,7 +492,7 @@ describe('view-syncer/snapshotter', () => {
       '08',
       messages.insert('users', {id: 30, handle: 'candice'}),
     );
-    replicator.processMessage(lc, '09', messages.commit('0/2'));
+    replicator.processMessage(lc, '09', messages.commit());
 
     const diff = s.advance();
     expect(diff.prev.version).toBe('00');
@@ -549,7 +549,7 @@ describe('view-syncer/snapshotter', () => {
 
     replicator.processMessage(lc, '05', messages.begin());
     replicator.processMessage(lc, '06', messages.insert('comments', {id: 1}));
-    replicator.processMessage(lc, '07', messages.commit('0/2'));
+    replicator.processMessage(lc, '07', messages.commit());
 
     const diff = s.advance();
     let currStmts = 0;
@@ -585,7 +585,7 @@ describe('view-syncer/snapshotter', () => {
 
     replicator.processMessage(lc, '05', messages.begin());
     replicator.processMessage(lc, '06', messages.truncate('users'));
-    replicator.processMessage(lc, '07', messages.commit('0/2'));
+    replicator.processMessage(lc, '07', messages.commit());
 
     const diff = s.advance();
     let currStmts = 0;


### PR DESCRIPTION
Generalize the `Change` type used in the change-streamer protocol by removing PG-specific fields (e.g. LSN fields in the `begin` and `commit` messages). These fields are now treated as internal and still used in the protocol between the Storer and the ChangeSource (for acking commits), but all downstream logic should be otherwise agnostic to it.

Update tests so that there is less confusion between the watermarks and (former) LSN values used to create the messages.