### PR TITLE
feat(zql): Make the `op` param to `where` default to '='.

### DIFF
--- a/packages/zql/src/zql/query/query-impl.query-kitchen-sink.test.ts
+++ b/packages/zql/src/zql/query/query-impl.query-kitchen-sink.test.ts
@@ -301,7 +301,7 @@ describe('kitchen sink query', () => {
     addData(queryDelegate);
     const issueQuery = newQuery(queryDelegate, issueSchema)
       .where('ownerId', 'IN', ['001', '002', '003'])
-      .where('closed', '=', false)
+      .where('closed', false)
       .related('owner', q => q.select('name'))
       .related('comments', q =>
         q

--- a/packages/zql/src/zql/query/query-impl.query.test.ts
+++ b/packages/zql/src/zql/query/query-impl.query.test.ts
@@ -13,7 +13,7 @@ import {
   revisionSchema,
   userSchema,
 } from './test/testSchemas.js';
-import { AST } from '../ast/ast.js';
+import {AST} from '../ast/ast.js';
 
 export class QueryDelegateImpl implements QueryDelegate {
   #sources: Record<string, Source> = makeSources();
@@ -33,8 +33,8 @@ export class QueryDelegateImpl implements QueryDelegate {
     }
   }
   addServerQuery(ast: AST): () => void {
-      this.addedServerQueries.push(ast);
-      return () => {};
+    this.addedServerQueries.push(ast);
+    return () => {};
   }
   getSource(name: string): Source {
     return this.#sources[name];

--- a/packages/zql/src/zql/query/query-impl.ts
+++ b/packages/zql/src/zql/query/query-impl.ts
@@ -23,7 +23,7 @@ import {
   Schema,
 } from './schema.js';
 import {TypedView} from './typed-view.js';
-import { Row } from '../ivm/data.js';
+import {Row} from '../ivm/data.js';
 
 export function newQuery<
   TSchema extends Schema,
@@ -240,9 +240,23 @@ class QueryImpl<
 
   where<TSelector extends Selector<TSchema>>(
     field: TSelector,
-    op: Operator,
-    value: GetFieldTypeNoNullOrUndefined<TSchema, TSelector, Operator>,
+    opOrValue:
+      | Operator
+      | GetFieldTypeNoNullOrUndefined<TSchema, TSelector, Operator>,
+    value?: GetFieldTypeNoNullOrUndefined<TSchema, TSelector, Operator>,
   ): Query<TSchema, TReturn, TAs> {
+    let op: Operator;
+    if (value === undefined) {
+      value = opOrValue as GetFieldTypeNoNullOrUndefined<
+        TSchema,
+        TSelector,
+        Operator
+      >;
+      op = '=';
+    } else {
+      op = opOrValue as Operator;
+    }
+
     return newQueryWithAST(this.#delegate, this.#schema, {
       ...this.#ast,
       where: [

--- a/packages/zql/src/zql/query/query.test.ts
+++ b/packages/zql/src/zql/query/query.test.ts
@@ -210,6 +210,26 @@ describe('types', () => {
     >();
   });
 
+  test('where-optional-op', () => {
+    const query = mockQuery as unknown as Query<TestSchema>;
+
+    const query2 = query.where('s', 'foo');
+    expectTypeOf(query2.materialize().data).toMatchTypeOf<Array<{}>>();
+
+    // @ts-expect-error - cannot use a field that does not exist
+    query.where('doesNotExist', 'foo');
+    // @ts-expect-error - value and field types must match
+    query.where('b', 'false');
+
+    expectTypeOf(
+      query.select('b').where('b', true).materialize().data,
+    ).toMatchTypeOf<
+      Array<{
+        b: boolean;
+      }>
+    >();
+  });
+
   test('start', () => {
     const query = mockQuery as unknown as Query<TestSchema>;
     const query2 = query.start({b: true, s: 'foo'});

--- a/packages/zql/src/zql/query/query.ts
+++ b/packages/zql/src/zql/query/query.ts
@@ -226,6 +226,11 @@ export interface Query<
     value: GetFieldTypeNoNullOrUndefined<TSchema, TSelector, Operator>,
   ): Query<TSchema, TReturn, TAs>;
 
+  where<TSelector extends Selector<TSchema>>(
+    field: TSelector,
+    value: GetFieldTypeNoNullOrUndefined<TSchema, TSelector, Operator>,
+  ): Query<TSchema, TReturn>;
+
   start(
     row: Partial<SchemaToRow<TSchema>>,
     opts?: {inclusive: boolean} | undefined,


### PR DESCRIPTION
'=' is overwhelmingly the most common operator and being able to skip saying it is nice.