### PR TITLE
fix(zero-cache): cancel pending transactions if change stream is aborted

### DIFF
--- a/packages/zero-cache/src/services/replicator/incremental-sync.message-processor.test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.message-processor.test.ts
@@ -158,4 +158,14 @@ describe('replicator/message-processor', () => {
       expect(watermark).toBe(c.acknowledged.at(-1));
     });
   }
+
+  test('abort', () => {
+    const processor = createMessageProcessor(replica);
+
+    expect(replica.inTransaction).toBe(false);
+    processor.processMessage(lc, '02', {tag: 'begin'});
+    expect(replica.inTransaction).toBe(true);
+    processor.abort(lc);
+    expect(replica.inTransaction).toBe(false);
+  });
 });

--- a/packages/zero-cache/src/services/running-state.test.ts
+++ b/packages/zero-cache/src/services/running-state.test.ts
@@ -23,7 +23,7 @@ test('cancelOnStop', () => {
   expect(cancelable3.cancel).toHaveBeenCalledOnce();
 });
 
-test('backoff', async () => {
+test('backoff', () => {
   const mockSleep = vi
     .fn()
     .mockImplementation(() => [Promise.resolve(), Promise.resolve()]);

--- a/packages/zero-cache/src/services/running-state.test.ts
+++ b/packages/zero-cache/src/services/running-state.test.ts
@@ -1,0 +1,54 @@
+import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
+import {expect, test, vi} from 'vitest';
+import {RunningState} from './running-state.js';
+
+const lc = createSilentLogContext();
+
+test('cancelOnStop', () => {
+  const state = new RunningState('foo-service');
+
+  const cancelable1 = {cancel: vi.fn()};
+  const cancelable2 = {cancel: vi.fn()};
+  const cancelable3 = {cancel: vi.fn()};
+
+  state.cancelOnStop(cancelable1);
+  const unregister = state.cancelOnStop(cancelable2);
+  state.cancelOnStop(cancelable3);
+
+  unregister();
+  state.stop(lc);
+
+  expect(cancelable1.cancel).toHaveBeenCalledOnce();
+  expect(cancelable2.cancel).not.toHaveBeenCalled();
+  expect(cancelable3.cancel).toHaveBeenCalledOnce();
+});
+
+test('backoff', async () => {
+  const mockSleep = vi
+    .fn()
+    .mockImplementation(() => [Promise.resolve(), Promise.resolve()]);
+  const state = new RunningState(
+    'foo-service',
+    {initialRetryDelay: 1000, maxRetryDelay: 13_000},
+    mockSleep,
+  );
+
+  for (let i = 0; i < 8; i++) {
+    void state.backoff(lc);
+  }
+  void state.resetBackoff();
+  void state.backoff(lc);
+  void state.backoff(lc);
+
+  expect(mockSleep.mock.calls.map(call => call[0])).toEqual([
+    1000, 2000, 4000, 8000, 13_000, 13_000, 13_000, 13_000, 1000, 2000,
+  ]);
+});
+
+test('cancel backoff on stop', async () => {
+  const state = new RunningState('foo-service', {initialRetryDelay: 10_000});
+
+  const timeout = state.backoff(lc);
+  state.stop(lc);
+  await timeout;
+});

--- a/packages/zqlite/src/db.ts
+++ b/packages/zqlite/src/db.ts
@@ -48,6 +48,10 @@ export class Database {
   get name() {
     return this.#db.name;
   }
+
+  get inTransaction() {
+    return this.#db.inTransaction;
+  }
 }
 
 export class Statement {


### PR DESCRIPTION
Avoid any dangling transactions (that can prevent WAL cleanup) if a change stream is aborted midway through a transaction.