### PR TITLE
fix(zero-cache): exit the process if the replicator fails

### DIFF
--- a/packages/zero-cache/src/services/runner.ts
+++ b/packages/zero-cache/src/services/runner.ts
@@ -1,4 +1,5 @@
 import {LogContext} from '@rocicorp/logger';
+import {sleep} from 'shared/src/sleep.js';
 import {Service} from './service.js';
 
 /**
@@ -45,5 +46,19 @@ export class ServiceRunner<S extends Service> {
         this.#instances.delete(id);
       });
     return service;
+  }
+}
+
+/**
+ * Runs a singleton service, logging an error and exiting the process if the
+ * service stops or fails.
+ */
+export async function runOrExit(lc: LogContext, svc: Service): Promise<void> {
+  try {
+    await svc.run();
+  } finally {
+    lc.error?.(`exiting because ${svc.constructor.name} (${svc.id}) stopped`);
+    await sleep(1000); // Allow logs to flush.
+    process.exit(-1);
   }
 }

--- a/packages/zero-cache/src/workers/replicator.test.ts
+++ b/packages/zero-cache/src/workers/replicator.test.ts
@@ -1,15 +1,11 @@
 import {describe, expect, test, vi} from 'vitest';
-import {
-  Replicator,
-  ReplicaVersionReady,
-} from 'zero-cache/src/services/replicator/replicator.js';
-import {Service} from 'zero-cache/src/services/service.js';
+import {ReplicaVersionReady} from 'zero-cache/src/services/replicator/replicator.js';
 import {Subscription} from 'zero-cache/src/types/subscription.js';
 import {inProcChannel} from '../types/processes.js';
 import {
   createNotifierFrom,
   getStatusFromWorker,
-  runAsWorker,
+  setUpMessageHandlers,
   subscribeTo,
 } from './replicator.js';
 
@@ -18,13 +14,11 @@ describe('workers/replicator', () => {
     const replicator = {
       status: vi.fn().mockResolvedValue({status: 'yo'}),
       subscribe: vi.fn(),
-      run: vi.fn(),
     };
 
     const [parent, child] = inProcChannel();
 
-    void runAsWorker(replicator as unknown as Replicator & Service, parent);
-    expect(replicator.run).toHaveBeenCalledOnce;
+    setUpMessageHandlers(replicator, parent);
 
     // Simulate a status request from the parent.
     const status = await getStatusFromWorker(child);
@@ -37,13 +31,11 @@ describe('workers/replicator', () => {
     const replicator = {
       status: vi.fn(),
       subscribe: () => originalSub,
-      run: vi.fn(),
     };
 
     const [parent, child] = inProcChannel();
 
-    void runAsWorker(replicator as unknown as Replicator & Service, parent);
-    expect(replicator.run).toHaveBeenCalledOnce;
+    void setUpMessageHandlers(replicator, parent);
 
     originalSub.push({foo: 'bar'});
     originalSub.push({foo: 'baz'});

--- a/packages/zero-cache/src/workers/replicator.ts
+++ b/packages/zero-cache/src/workers/replicator.ts
@@ -4,14 +4,10 @@ import {
   ReplicaVersionNotifier,
   ReplicaVersionReady,
 } from 'zero-cache/src/services/replicator/replicator.js';
-import {Service} from 'zero-cache/src/services/service.js';
 import {Notifier} from '../services/replicator/notifier.js';
 import {Worker} from '../types/processes.js';
 
-export function runAsWorker(
-  replicator: Replicator & Service,
-  parent: Worker,
-): Promise<void> {
+export function setUpMessageHandlers(replicator: Replicator, parent: Worker) {
   // Respond to status requests from the parent process.
   parent.onMessageType('status', async () => {
     const status = await replicator.status();
@@ -19,8 +15,6 @@ export function runAsWorker(
   });
 
   handleSubscriptionsFrom(parent, replicator);
-
-  return replicator.run();
 }
 
 export function getStatusFromWorker(replicator: Worker): Promise<unknown> {


### PR DESCRIPTION
This prevents the situation in which the zero-cache continues running when the Replicator fails.

https://github.com/rocicorp/mono/issues/2362