### PR TITLE
fix(zero-cache): exclude the _0_version field from catchup rows

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/view-syncer.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.test.ts
@@ -776,7 +776,6 @@ describe('view-syncer/service', () => {
                 "entityType": "issues",
                 "op": "put",
                 "value": {
-                  "_0_version": "01",
                   "big": 9007199254740991,
                   "id": "1",
                   "owner": "100.0",


### PR DESCRIPTION
Remove the `_0_version` column from rows fetched for catchup, analogous to how they are removed from rows outputted by pipeline hydration and advancement.

Fixes:

<img width="994" alt="Screenshot 2024-09-12 at 17 30 49" src="https://github.com/user-attachments/assets/6818380b-4488-4cdf-b46c-a18df00cf9ed">
