### PR TITLE
fix(zero-cache): wait for litestream locks instead of erroring

### DIFF
--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -11,6 +11,9 @@ import {setUpMessageHandlers} from '../workers/replicator.js';
 import {configFromEnv} from './config.js';
 import {createLogContext} from './logging.js';
 
+// As recommended by https://litestream.io/tips/#busy-timeout
+const REPLICA_LOCK_TIMEOUT_MS = 5000;
+
 const MAX_CHANGE_DB_CONNECTIONS = 5;
 
 export default async function runWorker(parent: Worker) {
@@ -38,6 +41,7 @@ export default async function runWorker(parent: Worker) {
 
   const replica = new Database(lc, config.REPLICA_DB_FILE);
   replica.pragma('journal_mode = WAL');
+  replica.pragma(`busy_timeout = ${REPLICA_LOCK_TIMEOUT_MS}`);
 
   const changeStreamer = await initializeStreamer(
     lc,


### PR DESCRIPTION
Sets `PRAGMA busy_timeout = 5000` as recommended by https://litestream.io/tips/#busy-timeout

This will allow the replicator to wait for up to 5 seconds if attempting to commit while litestream has the lock (simulated by manually holding a `BEGIN IMMEDIATE` transaction in sqlite):

<img width="864" alt="Screenshot 2024-09-12 at 17 47 53" src="https://github.com/user-attachments/assets/5a8f3f55-08d8-448f-86e3-ca00c5284c44">

If the lock is held for more than 5 seconds, the replicator fails and the task dies. We can increase this timeout if deemed prudent, but for now it is set to the value recommended by litestream.

Fixes #2362