### PR TITLE
!feat(zero-cache): new change streamer schema and protocol

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/forwarder.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/forwarder.test.ts
@@ -15,12 +15,12 @@ describe('change-streamer/forwarder', () => {
     const [sub4, stream4] = createSubscriber('00', true);
 
     forwarder.add(sub1);
-    forwarder.forward({watermark: '11', change: messages.begin()});
+    forwarder.forward(['11', ['begin', messages.begin()]]);
     forwarder.add(sub2);
-    forwarder.forward({watermark: '12', change: messages.truncate('issues')});
-    forwarder.forward({watermark: '13', change: messages.commit()});
+    forwarder.forward(['12', ['data', messages.truncate('issues')]]);
+    forwarder.forward(['13', ['commit', messages.commit(), {watermark: '13'}]]);
     forwarder.add(sub3);
-    forwarder.forward({watermark: '14', change: messages.begin()});
+    forwarder.forward(['14', ['begin', messages.begin()]]);
     forwarder.add(sub4);
 
     for (const sub of [sub1, sub2, sub3, sub4]) {
@@ -31,64 +31,55 @@ describe('change-streamer/forwarder', () => {
     expect(stream1).toMatchInlineSnapshot(`
       [
         [
-          "change",
+          "begin",
           {
-            "change": {
-              "tag": "begin",
-            },
-            "watermark": "11",
+            "tag": "begin",
           },
         ],
         [
-          "change",
+          "data",
           {
-            "change": {
-              "cascade": false,
-              "relations": [
-                {
-                  "columns": [
-                    {
-                      "flags": 1,
-                      "name": "id",
-                      "parser": [Function],
-                      "typeMod": -1,
-                      "typeName": null,
-                      "typeOid": 23,
-                      "typeSchema": null,
-                    },
-                  ],
-                  "keyColumns": [
-                    "id",
-                  ],
-                  "name": "issues",
-                  "relationOid": 1558331249,
-                  "replicaIdentity": "default",
-                  "schema": "public",
-                  "tag": "relation",
-                },
-              ],
-              "restartIdentity": false,
-              "tag": "truncate",
-            },
-            "watermark": "12",
+            "cascade": false,
+            "relations": [
+              {
+                "columns": [
+                  {
+                    "flags": 1,
+                    "name": "id",
+                    "parser": [Function],
+                    "typeMod": -1,
+                    "typeName": null,
+                    "typeOid": 23,
+                    "typeSchema": null,
+                  },
+                ],
+                "keyColumns": [
+                  "id",
+                ],
+                "name": "issues",
+                "relationOid": 1558331249,
+                "replicaIdentity": "default",
+                "schema": "public",
+                "tag": "relation",
+              },
+            ],
+            "restartIdentity": false,
+            "tag": "truncate",
           },
         ],
         [
-          "change",
+          "commit",
           {
-            "change": {
-              "tag": "commit",
-            },
+            "tag": "commit",
+          },
+          {
             "watermark": "13",
           },
         ],
         [
-          "change",
+          "begin",
           {
-            "change": {
-              "tag": "begin",
-            },
-            "watermark": "14",
+            "tag": "begin",
           },
         ],
       ]
@@ -99,12 +90,9 @@ describe('change-streamer/forwarder', () => {
     expect(stream2).toMatchInlineSnapshot(`
       [
         [
-          "change",
+          "begin",
           {
-            "change": {
-              "tag": "begin",
-            },
-            "watermark": "14",
+            "tag": "begin",
           },
         ],
       ]
@@ -112,12 +100,9 @@ describe('change-streamer/forwarder', () => {
     expect(stream3).toMatchInlineSnapshot(`
       [
         [
-          "change",
+          "begin",
           {
-            "change": {
-              "tag": "begin",
-            },
-            "watermark": "14",
+            "tag": "begin",
           },
         ],
       ]

--- a/packages/zero-cache/src/services/change-streamer/forwarder.ts
+++ b/packages/zero-cache/src/services/change-streamer/forwarder.ts
@@ -1,4 +1,4 @@
-import {ChangeEntry} from './change-streamer.js';
+import {WatermarkedChange} from './change-streamer-service.js';
 import {Subscriber} from './subscriber.js';
 
 export class Forwarder {
@@ -34,12 +34,12 @@ export class Forwarder {
    * two components have an equivalent interpretation of whether a Transaction is
    * currently being streamed.
    */
-  forward(entry: ChangeEntry) {
-    const {change} = entry;
+  forward(entry: WatermarkedChange) {
+    const [type] = entry[1];
     for (const active of this.#active.values()) {
       active.send(entry);
     }
-    switch (change.tag) {
+    switch (type) {
       case 'begin':
         // While in a Transaction, all added subscribers are "queued" so that no
         // messages are forwarded to them. This state corresponds to being queued

--- a/packages/zero-cache/src/services/change-streamer/pg/lsn.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/lsn.test.ts
@@ -1,31 +1,21 @@
-import {expect, test} from 'vitest';
+import {describe, expect, test} from 'vitest';
 import {
   versionFromLexi,
   type LexiVersion,
 } from 'zero-cache/src/types/lexi-version.js';
 import {fromLexiVersion, toLexiVersion, type LSN} from './lsn.js';
 
-test('lsn to/from LexiVersion', () => {
+describe('lsn to/from LexiVersion', () => {
   type Case = [LSN, LexiVersion, bigint];
   const cases: Case[] = [
     ['0/0', '00', 0n],
-    ['0/A', '114', 10n],
-    ['16/B374D848', '74z5w2m8w', 97500059720n],
-    ['FFFFFFFF/FFFFFFFF', 'cfklk448oj5v5o', 2n ** 64n - 1n],
+    ['0/A', '0a', 10n],
+    ['16/B374D848', '718sh0nk8', 97500059720n],
+    ['FFFFFFFF/FFFFFFFF', 'c3w5e11264sgsf', 2n ** 64n - 1n],
   ];
-  for (const [lsn, lexi, ver] of cases) {
+  test.each(cases)('convert(%s <=> %s)', (lsn, lexi, ver) => {
     expect(toLexiVersion(lsn)).toBe(lexi);
-    expect(versionFromLexi(lexi).toString()).toBe((ver << 2n).toString());
+    expect(versionFromLexi(lexi).toString()).toBe(ver.toString());
     expect(fromLexiVersion(lexi)).toBe(lsn);
-  }
-});
-
-test('lsn to/from LexiVersion with offset', () => {
-  expect(toLexiVersion('16/B374D848', 'commit')).toBe('74z5w2m8w');
-  expect(toLexiVersion('16/B374D848', 'begin')).toBe('74z5w2m8x');
-  expect(toLexiVersion('16/B374D848', 'insert')).toBe('74z5w2m8y');
-
-  expect(fromLexiVersion('74z5w2m8w')).toBe('16/B374D848');
-  expect(fromLexiVersion('74z5w2m8x')).toBe('16/B374D848');
-  expect(fromLexiVersion('74z5w2m8y')).toBe('16/B374D848');
+  });
 });

--- a/packages/zero-cache/src/services/change-streamer/pg/lsn.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/lsn.ts
@@ -20,104 +20,18 @@ export type LSN = string;
 
 export type RecordType = Change['tag'];
 
-export function toLexiVersion(
-  lsn: LSN,
-  type: RecordType = 'commit',
-): LexiVersion {
+export function toLexiVersion(lsn: LSN): LexiVersion {
   const parts = lsn.split('/');
   assert(parts.length === 2, `Malformed LSN: "${lsn}"`);
   const high = BigInt(`0x${parts[0]}`);
   const low = BigInt(`0x${parts[1]}`);
-  // Shift by 2 bits and add offset().
-  const val = (high << 34n) + (low << 2n) + offset(type);
+  const val = (high << 32n) + low;
   return versionToLexi(val);
 }
 
 export function fromLexiVersion(lexi: LexiVersion): LSN {
   const val = versionFromLexi(lexi);
-  const high = val >> 34n;
-  const low = (val >> 2n) & 0xffffffffn;
+  const high = val >> 32n;
+  const low = val & 0xffffffffn;
   return `${high.toString(16).toUpperCase()}/${low.toString(16).toUpperCase()}`;
-}
-
-/**
- * Postgres defines the "Log sequence number (LSN)" as a value that
- * "increases monotonically with each new WAL record":
- *
- * https://www.postgresql.org/docs/current/glossary.html#:~:text=Log%20sequence%20number%20(LSN)
- *
- * and a WAL record being a "low-level description of an individual data change".
- *
- * Unfortunately, 'begin' and 'commit' transaction markers are not technically
- * "data changes" (i.e. they are not DML statements), and thus do not always
- * have their own LSN.
- *
- * In fact, a 'begin' message always has the same LSN as its transaction's first
- * DML statement. Moreover, executing commands in quick succession can result
- * in a 'commit', the next 'begin', and the subsequent data change all sharing
- * the same LSN:
- *
- *
- * ```json
- * "8F/38B017C0": {
- *   "tag": "insert",
- *   "relation": {
- *   ...
- * }
- * "8F/38B01E18": {
- *   "tag": "commit",
- *   "flags": 0,
- *   "commitLsn": "0000008F/38B01DE8",
- *   "commitEndLsn": "0000008F/38B01E18",
- *   "commitTime": "BigInt(1726014579672237)"
- * },
- * "8F/38B01E18": {
- *   "tag": "begin",
- *   "commitLsn": "0000008F/38B01E98",
- *   "commitTime": "BigInt(1726014580746075)",
- *   "xid": 494599
- * },
- * "8F/38B01E18": {
- *   "tag": "insert",
- *   "relation": {
- *   ...
- * }
- * "8F/38B01EC8": {
- *   "tag": "commit",
- *   "flags": 0,
- *   "commitLsn": "0000008F/38B01E98",
- *   "commitEndLsn": "0000008F/38B01EC8",
- *   "commitTime": "BigInt(1726014580746075)"
- * },
- * ```
- *
- * This renders the LSN unsuitable as a watermark on its own. Even attaching
- * the position of the message within the transaction (with 'begin' starting at 0)
- * does not work since the 'commit' from the previous transaction would be sorted
- * after the 'begin' from the next one if they shared the same LSN.
- *
- * The scheme to convert an LSN to a monotonic value is based on the
- * characteristic that like-LSN records always follow a specific order:
- * - `commit`
- * - `begin`
- * - DML statement (i.e. `insert`, `update`, `delete`, `truncate`)
- *
- * A monotonic watermark is thus computed from the LSN by:
- * - Shifting the LSN by 2 bits.
- * - Adding 1 for `begin` records.
- * - Adding 2 for DML records.
- *
- * This ensures that the resulting watermarks are strictly monotonic and
- * sorted in stream order.
- */
-
-function offset(type: RecordType): bigint {
-  switch (type) {
-    case 'commit':
-      return 0n;
-    case 'begin':
-      return 1n;
-    default:
-      return 2n;
-  }
 }

--- a/packages/zero-cache/src/services/change-streamer/schema/change.ts
+++ b/packages/zero-cache/src/services/change-streamer/schema/change.ts
@@ -1,29 +1,17 @@
 import {Pgoutput} from 'pg-logical-replication';
-import {JSONValue} from 'shared/src/json.js';
 
 export type MessageBegin = {
   tag: 'begin';
-
-  // Upstream-specific fields should be preserved but ignored.
-  [field: string]: JSONValue;
 };
 
 export type MessageCommit = {
   tag: 'commit';
-
-  // Upstream-specific fields should be preserved but ignored.
-  [field: string]: JSONValue;
 };
 
-/**
- * For now, a Change is a subset of the message types sent in the Postgres
- * logical replication stream. This can be augmented (e.g. to include schema
- * changes) or generalized in the future.
- */
-export type Change =
-  | MessageBegin
+export type DataChange =
   | Pgoutput.MessageInsert
   | Pgoutput.MessageUpdate
   | Pgoutput.MessageDelete
-  | Pgoutput.MessageTruncate
-  | MessageCommit;
+  | Pgoutput.MessageTruncate;
+
+export type Change = MessageBegin | DataChange | MessageCommit;

--- a/packages/zero-cache/src/services/change-streamer/schema/tables.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/schema/tables.test.ts
@@ -40,8 +40,8 @@ describe('change-streamer/schema/tables', () => {
     });
 
     await db`
-    INSERT INTO cdc."ChangeLog" (watermark, change)
-        values ('184', JSONB('{"foo":"bar"}'));
+    INSERT INTO cdc."ChangeLog" (watermark, pos, change)
+        values ('184', 1, JSONB('{"foo":"bar"}'));
     `;
 
     // Should be a no-op.
@@ -61,6 +61,7 @@ describe('change-streamer/schema/tables', () => {
       ['cdc.ChangeLog']: [
         {
           watermark: '184',
+          pos: 1n,
           change: {foo: 'bar'},
         },
       ],

--- a/packages/zero-cache/src/services/change-streamer/schema/tables.ts
+++ b/packages/zero-cache/src/services/change-streamer/schema/tables.ts
@@ -17,8 +17,10 @@ export type ChangeLogEntry = {
 
 const CREATE_CHANGE_LOG_TABLE = `
   CREATE TABLE cdc."ChangeLog" (
-    watermark  TEXT PRIMARY KEY,
-    change     JSONB NOT NULL
+    watermark  TEXT,
+    pos        INT8,
+    change     JSONB NOT NULL,
+    PRIMARY KEY (watermark, pos)
   );
 `;
 

--- a/packages/zero-cache/src/services/change-streamer/subscriber.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/subscriber.test.ts
@@ -9,74 +9,65 @@ describe('change-streamer/subscriber', () => {
     const [sub, stream] = createSubscriber('00');
 
     // Send some messages while it is catching up.
-    sub.send({watermark: '11', change: messages.begin()});
-    sub.send({watermark: '12', change: messages.commit()});
+    sub.send(['11', ['begin', messages.begin()]]);
+    sub.send(['12', ['commit', messages.commit(), {watermark: '12'}]]);
 
     // Send catchup messages.
-    sub.catchup({watermark: '01', change: messages.begin()});
-    sub.catchup({watermark: '02', change: messages.commit()});
+    sub.catchup(['01', ['begin', messages.begin()]]);
+    sub.catchup(['02', ['commit', messages.commit(), {watermark: '02'}]]);
 
     sub.setCaughtUp();
 
     // Send some messages after catchup.
-    sub.send({watermark: '21', change: messages.begin()});
-    sub.send({watermark: '22', change: messages.commit()});
+    sub.send(['21', ['begin', messages.begin()]]);
+    sub.send(['22', ['commit', messages.commit(), {watermark: '22'}]]);
 
     sub.close();
 
     expect(stream).toMatchInlineSnapshot(`
       [
         [
-          "change",
+          "begin",
           {
-            "change": {
-              "tag": "begin",
-            },
-            "watermark": "01",
+            "tag": "begin",
           },
         ],
         [
-          "change",
+          "commit",
           {
-            "change": {
-              "tag": "commit",
-            },
+            "tag": "commit",
+          },
+          {
             "watermark": "02",
           },
         ],
         [
-          "change",
+          "begin",
           {
-            "change": {
-              "tag": "begin",
-            },
-            "watermark": "11",
+            "tag": "begin",
           },
         ],
         [
-          "change",
+          "commit",
           {
-            "change": {
-              "tag": "commit",
-            },
+            "tag": "commit",
+          },
+          {
             "watermark": "12",
           },
         ],
         [
-          "change",
+          "begin",
           {
-            "change": {
-              "tag": "begin",
-            },
-            "watermark": "21",
+            "tag": "begin",
           },
         ],
         [
-          "change",
+          "commit",
           {
-            "change": {
-              "tag": "commit",
-            },
+            "tag": "commit",
+          },
+          {
             "watermark": "22",
           },
         ],
@@ -90,40 +81,37 @@ describe('change-streamer/subscriber', () => {
     // Technically, catchup should never send any messages if the subscriber
     // is ahead, since the watermark query would return no results. But pretend it
     // does just to ensure that catchup messages are subject to the filter.
-    sub.catchup({watermark: '01', change: messages.begin()});
-    sub.catchup({watermark: '02', change: messages.begin()});
+    sub.catchup(['01', ['begin', messages.begin()]]);
+    sub.catchup(['02', ['commit', messages.commit(), {watermark: '02'}]]);
     sub.setCaughtUp();
 
     // Still lower than the watermark ...
-    sub.send({watermark: '121', change: messages.begin()});
-    sub.send({watermark: '123', change: messages.begin()});
+    sub.send(['121', ['begin', messages.begin()]]);
+    sub.send(['123', ['commit', messages.commit(), {watermark: '123'}]]);
 
     // These should be sent.
-    sub.send({watermark: '124', change: messages.begin()});
-    sub.send({watermark: '125', change: messages.begin()});
+    sub.send(['124', ['begin', messages.begin()]]);
+    sub.send(['125', ['commit', messages.commit(), {watermark: '125'}]]);
 
     // Replays should be ignored.
-    sub.send({watermark: '124', change: messages.begin()});
-    sub.send({watermark: '125', change: messages.begin()});
+    sub.send(['124', ['begin', messages.begin()]]);
+    sub.send(['125', ['commit', messages.commit(), {watermark: '125'}]]);
 
     sub.close();
     expect(stream).toMatchInlineSnapshot(`
       [
         [
-          "change",
+          "begin",
           {
-            "change": {
-              "tag": "begin",
-            },
-            "watermark": "124",
+            "tag": "begin",
           },
         ],
         [
-          "change",
+          "commit",
           {
-            "change": {
-              "tag": "begin",
-            },
+            "tag": "commit",
+          },
+          {
             "watermark": "125",
           },
         ],

--- a/packages/zero-cache/src/services/view-syncer/snapshotter.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/snapshotter.test.ts
@@ -90,24 +90,25 @@ describe('view-syncer/snapshotter', () => {
     expect(s1.current().version).toBe('00');
     expect(s2.current().version).toBe('00');
 
-    replicator.processMessage(lc, '04', messages.begin());
-    replicator.processMessage(
-      lc,
-      '05',
+    replicator.processMessage(lc, ['begin', messages.begin()]);
+    replicator.processMessage(lc, [
+      'data',
       messages.insert('issues', {id: 4, owner: 20}),
-    );
-    replicator.processMessage(
-      lc,
-      '06',
+    ]);
+    replicator.processMessage(lc, [
+      'data',
       messages.update('issues', {id: 1, owner: 10, desc: 'food'}),
-    );
-    replicator.processMessage(
-      lc,
-      '07',
+    ]);
+    replicator.processMessage(lc, [
+      'data',
       messages.update('issues', {id: 5, owner: 10, desc: 'bard'}, {id: 2}),
-    );
-    replicator.processMessage(lc, '08', messages.delete('issues', {id: 3}));
-    replicator.processMessage(lc, '09', messages.commit());
+    ]);
+    replicator.processMessage(lc, ['data', messages.delete('issues', {id: 3})]);
+    replicator.processMessage(lc, [
+      'commit',
+      messages.commit(),
+      {watermark: '09'},
+    ]);
 
     const diff1 = s1.advance();
     expect(diff1.prev.version).toBe('00');
@@ -236,14 +237,18 @@ describe('view-syncer/snapshotter', () => {
     `);
 
     // Replicate a second transaction
-    replicator.processMessage(lc, '0a', messages.begin());
-    replicator.processMessage(lc, '0b', messages.delete('issues', {id: 4}));
-    replicator.processMessage(
-      lc,
-      '0c',
+    replicator.processMessage(lc, ['begin', messages.begin()]);
+    replicator.processMessage(lc, ['data', messages.delete('issues', {id: 4})]);
+    replicator.processMessage(lc, [
+      'data',
       messages.update('issues', {id: 2, owner: 10, desc: 'bard'}, {id: 5}),
-    );
-    replicator.processMessage(lc, '0d', messages.commit());
+    ]);
+
+    replicator.processMessage(lc, [
+      'commit',
+      messages.commit(),
+      {watermark: '0d'},
+    ]);
 
     const diff2 = s1.advance();
     expect(diff2.prev.version).toBe('01');
@@ -353,9 +358,13 @@ describe('view-syncer/snapshotter', () => {
 
     expect(version).toBe('00');
 
-    replicator.processMessage(lc, '05', messages.begin());
-    replicator.processMessage(lc, '06', messages.truncate('comments'));
-    replicator.processMessage(lc, '07', messages.commit());
+    replicator.processMessage(lc, ['begin', messages.begin()]);
+    replicator.processMessage(lc, ['data', messages.truncate('comments')]);
+    replicator.processMessage(lc, [
+      'commit',
+      messages.commit(),
+      {watermark: '07'},
+    ]);
 
     const diff = s.advance();
     expect(diff.prev.version).toBe('00');
@@ -371,9 +380,13 @@ describe('view-syncer/snapshotter', () => {
 
     expect(version).toBe('00');
 
-    replicator.processMessage(lc, '05', messages.begin());
-    replicator.processMessage(lc, '06', messages.truncate('users'));
-    replicator.processMessage(lc, '07', messages.commit());
+    replicator.processMessage(lc, ['begin', messages.begin()]);
+    replicator.processMessage(lc, ['data', messages.truncate('users')]);
+    replicator.processMessage(lc, [
+      'commit',
+      messages.commit(),
+      {watermark: '07'},
+    ]);
 
     const diff = s.advance();
     expect(diff.prev.version).toBe('00');
@@ -410,10 +423,14 @@ describe('view-syncer/snapshotter', () => {
 
     expect(version).toBe('00');
 
-    replicator.processMessage(lc, '05', messages.begin());
-    replicator.processMessage(lc, '06', messages.truncate('issues'));
-    replicator.processMessage(lc, '07', messages.truncate('users'));
-    replicator.processMessage(lc, '08', messages.commit());
+    replicator.processMessage(lc, ['begin', messages.begin()]);
+    replicator.processMessage(lc, ['data', messages.truncate('issues')]);
+    replicator.processMessage(lc, ['data', messages.truncate('users')]);
+    replicator.processMessage(lc, [
+      'commit',
+      messages.commit(),
+      {watermark: '08'},
+    ]);
 
     const diff = s.advance();
     expect(diff.prev.version).toBe('00');
@@ -480,19 +497,21 @@ describe('view-syncer/snapshotter', () => {
 
     expect(version).toBe('00');
 
-    replicator.processMessage(lc, '05', messages.begin());
-    replicator.processMessage(lc, '06', messages.truncate('users'));
-    replicator.processMessage(
-      lc,
-      '07',
+    replicator.processMessage(lc, ['begin', messages.begin()]);
+    replicator.processMessage(lc, ['data', messages.truncate('users')]);
+    replicator.processMessage(lc, [
+      'data',
       messages.insert('users', {id: 20, handle: 'robert'}),
-    );
-    replicator.processMessage(
-      lc,
-      '08',
+    ]);
+    replicator.processMessage(lc, [
+      'data',
       messages.insert('users', {id: 30, handle: 'candice'}),
-    );
-    replicator.processMessage(lc, '09', messages.commit());
+    ]);
+    replicator.processMessage(lc, [
+      'commit',
+      messages.commit(),
+      {watermark: '09'},
+    ]);
 
     const diff = s.advance();
     expect(diff.prev.version).toBe('00');
@@ -547,9 +566,16 @@ describe('view-syncer/snapshotter', () => {
 
     expect(version).toBe('00');
 
-    replicator.processMessage(lc, '05', messages.begin());
-    replicator.processMessage(lc, '06', messages.insert('comments', {id: 1}));
-    replicator.processMessage(lc, '07', messages.commit());
+    replicator.processMessage(lc, ['begin', messages.begin()]);
+    replicator.processMessage(lc, [
+      'data',
+      messages.insert('comments', {id: 1}),
+    ]);
+    replicator.processMessage(lc, [
+      'commit',
+      messages.commit(),
+      {watermark: '07'},
+    ]);
 
     const diff = s.advance();
     let currStmts = 0;
@@ -583,9 +609,13 @@ describe('view-syncer/snapshotter', () => {
 
     expect(version).toBe('00');
 
-    replicator.processMessage(lc, '05', messages.begin());
-    replicator.processMessage(lc, '06', messages.truncate('users'));
-    replicator.processMessage(lc, '07', messages.commit());
+    replicator.processMessage(lc, ['begin', messages.begin()]);
+    replicator.processMessage(lc, ['data', messages.truncate('users')]);
+    replicator.processMessage(lc, [
+      'commit',
+      messages.commit(),
+      {watermark: '07'},
+    ]);
 
     const diff = s.advance();
     let currStmts = 0;


### PR DESCRIPTION
**BREAKING CHANGE**

⚠️  wipe your replica.db
⚠️  delete the "cdc" schema in your Postgres CHANGE_DB

New scheme for watermarking and ordering Changes in the ChangeDB such that they preserve the order in which they were received from Postgres, regardless of their LSN (which may not represent the correct order).

The scheme is documented in `change-streamer-service.ts`

Also update the ChangeStreamer API such that watermarks are only exported to subscribers in the final `commit` message, so that there is no ambiguity as to which watermark to store and use for subscription resumption. Non-commit messages are only used internally within the change-streamer implementation.

Fixes #2361