### PR TITLE
chore(zero-cache): benchmark hydration and mutation at different WAL sizes

### DIFF
--- a/packages/zero-cache/bench/bench.ts
+++ b/packages/zero-cache/bench/bench.ts
@@ -1,0 +1,3 @@
+import {bench} from './benchmark.js';
+
+bench();

--- a/packages/zero-cache/bench/benchmark.ts
+++ b/packages/zero-cache/bench/benchmark.ts
@@ -12,7 +12,7 @@ import {mapLiteDataTypeToZqlSchemaValue} from '../src/types/lite.js';
 import {schema} from './schema.js';
 
 // load up some data!
-function bench() {
+export function bench() {
   const db = new Database(createSilentLogContext(), '/tmp/sync-replica.db');
   const sources = new Map<string, Source>();
   const tableSpecs = new Map(listTables(db).map(spec => [spec.name, spec]));
@@ -65,5 +65,3 @@ function bench() {
   const end = performance.now();
   console.log(`hydrate took ${end - start}ms`);
 }
-
-bench();

--- a/packages/zero-cache/bench/wal_bench.ts
+++ b/packages/zero-cache/bench/wal_bench.ts
@@ -1,0 +1,3 @@
+import {wal_benchmark} from './wal_benchmark.js';
+
+wal_benchmark({runs: 100, modify: 1000});

--- a/packages/zero-cache/bench/wal_benchmark.ts
+++ b/packages/zero-cache/bench/wal_benchmark.ts
@@ -1,0 +1,62 @@
+import {statSync} from 'fs';
+import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
+import {randInt} from 'shared/src/rand.js';
+import {Database} from 'zqlite/src/db.js';
+import {bench} from './benchmark.js';
+
+const DB_FILE = '/tmp/sync-replica.db';
+
+const lc = createSilentLogContext();
+
+type Options = {
+  runs: number;
+  modify: number;
+};
+
+export function wal_benchmark(opts: Options) {
+  const db = new Database(lc, DB_FILE);
+  // Start from scratch.
+  db.pragma('wal_checkpoint(TRUNCATE)');
+
+  // Lock the database to prevent WAL checkpointing.
+  const lock = new Database(lc, DB_FILE, {readonly: true});
+  lock.exec('begin immediate');
+
+  const ids = db
+    .prepare('select id from issue')
+    .all<{id: string}>()
+    .map(row => row.id);
+
+  const perturb = db.prepare(
+    `INSERT INTO issue (id, _0_version) VALUES (?, '')
+         ON CONFLICT DO UPDATE SET modified=EXCLUDED.modified+1
+      `,
+  );
+  console.log(`warmup`);
+  bench();
+
+  console.log(`\nmodifying ${opts.modify} rows per iteration`);
+  for (let i = 0; i < opts.runs; i++) {
+    console.log(
+      '\nWAL     size',
+      (statSync(`${DB_FILE}-wal`).size / 1024 / 1024).toPrecision(4),
+      'MB',
+    );
+    bench();
+
+    const start = performance.now();
+    // Perturb random entries in the db.
+    randomEntries(ids, opts.modify).forEach(id => perturb.run(id));
+    const end = performance.now();
+
+    console.log(`modify  took ${end - start}ms`);
+  }
+}
+
+function randomEntries(source: string[], count: number): string[] {
+  const result: string[] = [];
+  for (let i = 0; i < count; i++) {
+    result.push(source[randInt(0, source.length - 1)]);
+  }
+  return result;
+}

--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -12,7 +12,8 @@
     "lint": "eslint --ext .ts,.tsx,.js,.jsx src/",
     "local": "node --loader ts-node/esm tool/local.ts",
     "start": "node --require 'dotenv/config' --no-warnings --loader ts-node/esm ./src/server/main.ts",
-    "bench": "node --require 'dotenv/config' --no-warnings --loader ts-node/esm ./bench/benchmark.ts"
+    "bench": "node --require 'dotenv/config' --no-warnings --loader ts-node/esm ./bench/bench.ts",
+    "wal_bench": "node --require 'dotenv/config' --no-warnings --loader ts-node/esm ./bench/wal_bench.ts"
   },
   "dependencies": {
     "@drdgvhbh/postgres-error-codes": "^0.0.6",


### PR DESCRIPTION
```sh
zero-cache $ npm run wal_bench

warmup
hydrate took 341.2232918739319ms

modifying 1000 rows per iteration

WAL     size 0.000 MB
hydrate took 295.35808277130127ms
modify  took 118.91216707229614ms

WAL     size 16.00 MB
hydrate took 281.914834022522ms
modify  took 266.4399166107178ms

WAL     size 31.10 MB
hydrate took 283.3121671676636ms
modify  took 516.3127093315125ms

WAL     size 46.80 MB
hydrate took 283.14133405685425ms
modify  took 769.6897501945496ms

WAL     size 62.49 MB
hydrate took 282.4225001335144ms
modify  took 1030.80091714859ms

WAL     size 77.65 MB
hydrate took 299.8173747062683ms
modify  took 1256.2394580841064ms

WAL     size 92.89 MB
hydrate took 296.94487476348877ms
modify  took 1473.4130420684814ms

...

WAL     size 1007 MB
hydrate took 325.2248330116272ms
modify  took 16135.208708286285ms

WAL     size 1022 MB
hydrate took 311.0252079963684ms
modify  took 16419.949209213257ms

WAL     size 1037 MB
hydrate took 332.2174582481384ms
modify  took 16653.09466600418ms

WAL     size 1051 MB
hydrate took 318.7569169998169ms
modify  took 16857.952916145325ms

...

AL     size 1411 MB
hydrate took 363.24974966049194ms
modify  took 22744.777583122253ms

WAL     size 1425 MB
hydrate took 328.5024161338806ms
modify  took 22900.60887479782ms

WAL     size 1440 MB
hydrate took 363.806125164032ms
modify  took 23181.26133298874ms

WAL     size 1453 MB
hydrate took 328.7392086982727ms
modify  took 23385.63158273697ms

WAL     size 1468 MB
hydrate took 365.86791610717773ms
modify  took 23621.893958091736ms
```
