### PR TITLE
feat(zero-cache): Deal with edit changes in zero-cache 

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -77,97 +77,104 @@ describe('view-syncer/pipeline-driver', () => {
 
     expect([...pipelines.addQuery('hash1', ISSUES_AND_COMMENTS)])
       .toMatchInlineSnapshot(`
-      [
-        {
-          "queryHash": "hash1",
-          "row": {
-            "_0_version": "00",
-            "closed": false,
-            "id": "3",
+        [
+          {
+            "queryHash": "hash1",
+            "row": {
+              "_0_version": "00",
+              "closed": false,
+              "id": "3",
+            },
+            "rowKey": {
+              "id": "3",
+            },
+            "table": "issues",
+            "type": "add",
           },
-          "rowKey": {
-            "id": "3",
+          {
+            "queryHash": "hash1",
+            "row": {
+              "_0_version": "00",
+              "closed": true,
+              "id": "2",
+            },
+            "rowKey": {
+              "id": "2",
+            },
+            "table": "issues",
+            "type": "add",
           },
-          "table": "issues",
-        },
-        {
-          "queryHash": "hash1",
-          "row": {
-            "_0_version": "00",
-            "closed": true,
-            "id": "2",
+          {
+            "queryHash": "hash1",
+            "row": {
+              "_0_version": "00",
+              "id": "22",
+              "issueID": "2",
+              "upvotes": 20000,
+            },
+            "rowKey": {
+              "id": "22",
+            },
+            "table": "comments",
+            "type": "add",
           },
-          "rowKey": {
-            "id": "2",
+          {
+            "queryHash": "hash1",
+            "row": {
+              "_0_version": "00",
+              "id": "21",
+              "issueID": "2",
+              "upvotes": 10000,
+            },
+            "rowKey": {
+              "id": "21",
+            },
+            "table": "comments",
+            "type": "add",
           },
-          "table": "issues",
-        },
-        {
-          "queryHash": "hash1",
-          "row": {
-            "_0_version": "00",
-            "id": "22",
-            "issueID": "2",
-            "upvotes": 20000,
+          {
+            "queryHash": "hash1",
+            "row": {
+              "_0_version": "00",
+              "id": "20",
+              "issueID": "2",
+              "upvotes": 1,
+            },
+            "rowKey": {
+              "id": "20",
+            },
+            "table": "comments",
+            "type": "add",
           },
-          "rowKey": {
-            "id": "22",
+          {
+            "queryHash": "hash1",
+            "row": {
+              "_0_version": "00",
+              "closed": false,
+              "id": "1",
+            },
+            "rowKey": {
+              "id": "1",
+            },
+            "table": "issues",
+            "type": "add",
           },
-          "table": "comments",
-        },
-        {
-          "queryHash": "hash1",
-          "row": {
-            "_0_version": "00",
-            "id": "21",
-            "issueID": "2",
-            "upvotes": 10000,
+          {
+            "queryHash": "hash1",
+            "row": {
+              "_0_version": "00",
+              "id": "10",
+              "issueID": "1",
+              "upvotes": 0,
+            },
+            "rowKey": {
+              "id": "10",
+            },
+            "table": "comments",
+            "type": "add",
           },
-          "rowKey": {
-            "id": "21",
-          },
-          "table": "comments",
-        },
-        {
-          "queryHash": "hash1",
-          "row": {
-            "_0_version": "00",
-            "id": "20",
-            "issueID": "2",
-            "upvotes": 1,
-          },
-          "rowKey": {
-            "id": "20",
-          },
-          "table": "comments",
-        },
-        {
-          "queryHash": "hash1",
-          "row": {
-            "_0_version": "00",
-            "closed": false,
-            "id": "1",
-          },
-          "rowKey": {
-            "id": "1",
-          },
-          "table": "issues",
-        },
-        {
-          "queryHash": "hash1",
-          "row": {
-            "_0_version": "00",
-            "id": "10",
-            "issueID": "1",
-            "upvotes": 0,
-          },
-          "rowKey": {
-            "id": "10",
-          },
-          "table": "comments",
-        },
-      ]
-    `);
+        ]
+      `);
   });
 
   test('insert', () => {
@@ -200,6 +207,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "31",
           },
           "table": "comments",
+          "type": "add",
         },
         {
           "queryHash": "hash1",
@@ -212,6 +220,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "4",
           },
           "table": "issues",
+          "type": "add",
         },
         {
           "queryHash": "hash1",
@@ -225,6 +234,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "41",
           },
           "table": "comments",
+          "type": "add",
         },
       ]
     `);
@@ -250,6 +260,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "21",
           },
           "table": "comments",
+          "type": "remove",
         },
         {
           "queryHash": "hash1",
@@ -258,6 +269,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "1",
           },
           "table": "issues",
+          "type": "remove",
         },
         {
           "queryHash": "hash1",
@@ -266,6 +278,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "10",
           },
           "table": "comments",
+          "type": "remove",
         },
       ]
     `);
@@ -290,6 +303,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "22",
           },
           "table": "comments",
+          "type": "remove",
         },
         {
           "queryHash": "hash1",
@@ -303,6 +317,31 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "22",
           },
           "table": "comments",
+          "type": "add",
+        },
+      ]
+    `);
+
+    replicator.processTransaction(
+      '135',
+      messages.update('comments', {id: '22', upvotes: 10}),
+    );
+
+    expect([...pipelines.advance().changes]).toMatchInlineSnapshot(`
+      [
+        {
+          "queryHash": "hash1",
+          "row": {
+            "_0_version": "134",
+            "id": "22",
+            "issueID": "3",
+            "upvotes": 10,
+          },
+          "rowKey": {
+            "id": "22",
+          },
+          "table": "comments",
+          "type": "edit",
         },
       ]
     `);
@@ -366,6 +405,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "4",
           },
           "table": "issues",
+          "type": "add",
         },
       ]
     `);
@@ -389,6 +429,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "41",
           },
           "table": "comments",
+          "type": "add",
         },
       ]
     `);
@@ -404,6 +445,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "4",
           },
           "table": "issues",
+          "type": "remove",
         },
         {
           "queryHash": "hash1",
@@ -412,6 +454,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "41",
           },
           "table": "comments",
+          "type": "remove",
         },
       ]
     `);

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.test.ts
@@ -10,7 +10,6 @@ import type {
   QueriesPatch,
 } from 'zero-protocol';
 import type {AST} from 'zql/src/zql/ast/ast.js';
-import {setEditChangesEnabled} from 'zql/src/zql/ivm/source.js';
 import {Database} from 'zqlite/src/db.js';
 import {testDBs} from '../../test/db.js';
 import type {PostgresDB} from '../../types/pg.js';
@@ -33,8 +32,6 @@ import {PipelineDriver} from './pipeline-driver.js';
 import {initViewSyncerSchema} from './schema/pg-migrations.js';
 import {Snapshotter} from './snapshotter.js';
 import {SyncContext, ViewSyncerService} from './view-syncer.js';
-
-setEditChangesEnabled(false);
 
 const EXPECTED_LMIDS_AST: AST = {
   schema: '',
@@ -633,7 +630,7 @@ describe('view-syncer/service', () => {
           "clientGroupID": "9876",
           "patchVersion": "01",
           "refCounts": {
-            "query-hash1": 1,
+            "query-hash1": 2,
           },
           "rowKey": {
             "id": "1",

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.test.ts
@@ -630,7 +630,7 @@ describe('view-syncer/service', () => {
           "clientGroupID": "9876",
           "patchVersion": "01",
           "refCounts": {
-            "query-hash1": 2,
+            "query-hash1": 1,
           },
           "rowKey": {
             "id": "1",

--- a/packages/zero-client/src/client/context.test.ts
+++ b/packages/zero-client/src/client/context.test.ts
@@ -4,14 +4,8 @@ import {Catch} from 'zql/src/zql/ivm/catch.js';
 import {Join} from 'zql/src/zql/ivm/join.js';
 import {MemorySource} from 'zql/src/zql/ivm/memory-source.js';
 import {MemoryStorage} from 'zql/src/zql/ivm/memory-storage.js';
-import {setEditChangesEnabled} from 'zql/src/zql/ivm/source.js';
 import {AddQuery, ZeroContext} from './context.js';
 import {ENTITIES_KEY_PREFIX} from './keys.js';
-
-declare const TESTING: boolean;
-if (TESTING) {
-  setEditChangesEnabled(true);
-}
 
 test('getSource', () => {
   const schemas = {

--- a/packages/zero-client/src/client/context.ts
+++ b/packages/zero-client/src/client/context.ts
@@ -5,7 +5,7 @@ import {Row} from 'zql/src/zql/ivm/data.js';
 import {MemorySource} from 'zql/src/zql/ivm/memory-source.js';
 import {MemoryStorage} from 'zql/src/zql/ivm/memory-storage.js';
 import {Storage} from 'zql/src/zql/ivm/operator.js';
-import {editChangesEnabled, Source} from 'zql/src/zql/ivm/source.js';
+import {Source} from 'zql/src/zql/ivm/source.js';
 import {CommitListener, QueryDelegate} from 'zql/src/zql/query/query-impl.js';
 import {Schema} from 'zql/src/zql/query/schema.js';
 import {ENTITIES_KEY_PREFIX} from './keys.js';
@@ -85,30 +85,19 @@ export class ZeroContext implements QueryDelegate {
               row: diff.newValue as Row,
             });
             break;
-          case 'change': {
+          case 'change':
             assert(typeof diff.newValue === 'object');
             assert(typeof diff.oldValue === 'object');
 
-            if (editChangesEnabled()) {
-              // Edit changes are not yet supported everywhere. For now we only
-              // generate them in tests.
-              source.push({
-                type: 'edit',
-                row: diff.newValue as Row,
-                oldRow: diff.oldValue as Row,
-              });
-            } else {
-              source.push({
-                type: 'remove',
-                row: diff.oldValue as Row,
-              });
-              source.push({
-                type: 'add',
-                row: diff.newValue as Row,
-              });
-            }
+            // Edit changes are not yet supported everywhere. For now we only
+            // generate them in tests.
+            source.push({
+              type: 'edit',
+              row: diff.newValue as Row,
+              oldRow: diff.oldValue as Row,
+            });
+
             break;
-          }
           default:
             unreachable(diff);
         }

--- a/packages/zql/src/zql/ivm/source.ts
+++ b/packages/zql/src/zql/ivm/source.ts
@@ -2,21 +2,6 @@ import {Ordering, SimpleCondition} from '../ast/ast.js';
 import {Row} from './data.js';
 import {Input} from './operator.js';
 
-// zero-cache doesn't understand the `declare` syntax yet, and it includes this
-// file so we enable testing mode manually by calling setEditChangesEnabled()
-// where needed in the tests.
-// declare const TESTING: boolean;
-
-let editChangesEnabledState = false;
-
-export function setEditChangesEnabled(b: boolean): void {
-  editChangesEnabledState = b;
-}
-
-export function editChangesEnabled(): boolean {
-  return editChangesEnabledState;
-}
-
 export type SourceChangeAdd = {
   type: 'add';
   row: Row;

--- a/packages/zqlite/src/table-source.ts
+++ b/packages/zqlite/src/table-source.ts
@@ -113,16 +113,16 @@ export class TableSource implements Source {
         compile(
           sql`INSERT INTO ${sql.ident(this.#table)} (${sql.join(
             Object.keys(this.#columns).map(c => sql.ident(c)),
-            sql`, `,
+            sql`,`,
           )}) VALUES (${sql.__dangerous__rawValue(
-            new Array(Object.keys(this.#columns).length).fill('?').join(', '),
+            new Array(Object.keys(this.#columns).length).fill('?').join(','),
           )})`,
         ),
       ),
       delete: db.prepare(
         compile(
           sql`DELETE FROM ${sql.ident(this.#table)} WHERE ${sql.join(
-            this.#primaryKey.map(k => sql`${sql.ident(k)} = ?`),
+            this.#primaryKey.map(k => sql`${sql.ident(k)}=?`),
             sql` AND `,
           )}`,
         ),
@@ -134,11 +134,11 @@ export class TableSource implements Source {
               compile(
                 sql`UPDATE ${sql.ident(this.#table)} SET ${sql.join(
                   nonPrimaryKeys(this.#columns, this.#primaryKey).map(
-                    c => sql`${sql.ident(c)} = ?`,
+                    c => sql`${sql.ident(c)}=?`,
                   ),
-                  sql`, `,
+                  sql`,`,
                 )} WHERE ${sql.join(
-                  this.#primaryKey.map(k => sql`${sql.ident(k)} = ?`),
+                  this.#primaryKey.map(k => sql`${sql.ident(k)}=?`),
                   sql` AND `,
                 )}`,
               ),
@@ -149,7 +149,7 @@ export class TableSource implements Source {
           sql`SELECT 1 AS "exists" FROM ${sql.ident(
             this.#table,
           )} WHERE ${sql.join(
-            this.#primaryKey.map(k => sql`${sql.ident(k)} = ?`),
+            this.#primaryKey.map(k => sql`${sql.ident(k)}=?`),
             sql` AND `,
           )} LIMIT 1`,
         ),
@@ -158,7 +158,7 @@ export class TableSource implements Source {
         .prepare(
           compile(
             sql`SELECT * FROM ${sql.ident(this.#table)} WHERE ${sql.join(
-              this.#primaryKey.map(k => sql`${sql.ident(k)} = ?`),
+              this.#primaryKey.map(k => sql`${sql.ident(k)}=?`),
               sql` AND`,
             )}`,
           ),


### PR DESCRIPTION
This now allows for the edit changes to be handled in zero-cache.

To allow this I had to add a type property to the RowChange type so that
we can distinguish between the different types of changes.