### PR TITLE
feat(zero-react): query hook that auto-tracks deps

### DIFF
--- a/apps/zbugs/src/pages/list/list-page.tsx
+++ b/apps/zbugs/src/pages/list/list-page.tsx
@@ -24,7 +24,7 @@ export default function ListPage() {
     q = q.where('creatorID', creator);
   }
 
-  const issues = useQuery(q, [open, creator]);
+  const issues = useQuery(q);
   const creators = useQuery(z.query.user);
 
   const addParam = (key: string, value: string) => {

--- a/packages/zero-react/src/use-query.tsx
+++ b/packages/zero-react/src/use-query.tsx
@@ -7,11 +7,7 @@ import {deepClone} from 'shared/src/deep-clone.js';
 export function useQuery<
   TSchema extends Schema,
   TReturn extends Array<QueryResultRow>,
->(
-  q: Query<TSchema, TReturn> | undefined,
-  dependencies: readonly unknown[] = [],
-  enabled = true,
-): Smash<TReturn> {
+>(q: Query<TSchema, TReturn> | undefined, enabled = true): Smash<TReturn> {
   const [snapshot, setSnapshot] = useState<Smash<TReturn>>([]);
   const [, setView] = useState<TypedView<Smash<TReturn>> | undefined>(
     undefined,
@@ -33,7 +29,7 @@ export function useQuery<
     return () => {
       //
     };
-  }, dependencies);
+  }, [JSON.stringify(q?.ast)]);
 
   return snapshot;
 }


### PR DESCRIPTION
This was @arv's original idea. We don't need to use a dependency array and can instead track if the query changed.

