### PR TITLE
chore(zbugs): don't eagerly render every page

### DIFF
--- a/apps/zbugs/src/root.tsx
+++ b/apps/zbugs/src/root.tsx
@@ -15,15 +15,9 @@ export default function Root() {
         </div>
         <div>
           <Switch>
-            <Route path="/">
-              <ListPage />
-            </Route>
-            <Route path="/issue/:id">
-              <IssuePage />
-            </Route>
-            <Route>
-              <ErrorPage />
-            </Route>
+            <Route path="/" component={ListPage} />
+            <Route path="/issue/:id" component={IssuePage} />
+            <Route component={ErrorPage} />
           </Switch>
         </div>
       </div>


### PR DESCRIPTION
We don't need to render the list page while another page is showing and vice-versa.