### PR TITLE
fix(zero-cache): handle errors when starting a replication stream

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -230,11 +230,11 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     void this.#storer.run();
 
     while (this.#state.shouldRun()) {
-      const stream = await this.#source.startStream();
-      this.#stream = stream;
-      let preCommitWatermark = oneAfter(stream.initialWatermark);
-
       try {
+        const stream = await this.#source.startStream();
+        this.#stream = stream;
+        let preCommitWatermark = oneAfter(stream.initialWatermark);
+
         for await (const change of stream.changes) {
           this.#state.resetBackoff();
 
@@ -252,7 +252,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       } catch (e) {
         this.#lc.error?.(`Error in Replication Stream.`, e);
       } finally {
-        stream.changes.cancel();
+        this.#stream?.changes.cancel();
         this.#stream = undefined;
       }
 

--- a/packages/zero-cache/src/services/change-streamer/pg/change-source.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/change-source.test.ts
@@ -161,4 +161,17 @@ describe('change-source/pg', {retry: 3}, () => {
     // Close the stream.
     changes.cancel();
   });
+
+  test('error handling', async () => {
+    // Purposely drop the replication slot to test the error case.
+    await dropReplicationSlot(upstream, replicationSlot(REPLICA_ID));
+
+    let err;
+    try {
+      await source.startStream();
+    } catch (e) {
+      err = e;
+    }
+    expect(err).not.toBeUndefined();
+  });
 });

--- a/packages/zero-cache/src/services/change-streamer/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/change-source.ts
@@ -114,6 +114,7 @@ class PostgresChangeSource implements ChangeSource {
         }
       });
 
+    this.#lc.info?.(`starting replication stream`);
     service
       .subscribe(
         new PgoutputPlugin({
@@ -123,12 +124,15 @@ class PostgresChangeSource implements ChangeSource {
         replicationSlot(this.#replicaID),
         lastLSN,
       )
-      .catch(e => changes.fail(e instanceof Error ? e : new Error(String(e))))
+      .catch(e => {
+        reject(e);
+        changes.fail(e instanceof Error ? e : new Error(String(e)));
+      })
       .finally(() => changes.cancel());
 
     const lsn = await confirmedFlushLSN;
     const watermark = toLexiVersion(lsn);
-    this.#lc.info?.(`started replication stream at ${lsn} (${watermark})`);
+    this.#lc.info?.(`replication stream start at ${lsn} (${watermark})`);
 
     return {
       initialWatermark: watermark,

--- a/packages/zero-cache/src/services/change-streamer/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/change-source.ts
@@ -132,7 +132,7 @@ class PostgresChangeSource implements ChangeSource {
 
     const lsn = await confirmedFlushLSN;
     const watermark = toLexiVersion(lsn);
-    this.#lc.info?.(`replication stream start at ${lsn} (${watermark})`);
+    this.#lc.info?.(`replication stream started at ${lsn} (${watermark})`);
 
     return {
       initialWatermark: watermark,


### PR DESCRIPTION
Fix an error introduced in #2374 that results in swallowing errors upon starting a replication stream.

Add tests for error propagation and retry.