### PR TITLE
fix(zero-cache): handle and propagate SIGTERM signals

### DIFF
--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -50,8 +50,6 @@ export default async function runWorker(parent: Worker) {
     replica,
   );
 
-  void runOrExit(lc, changeStreamer);
-
   const replicator = new ReplicatorService(
     lc,
     config.TASK_ID ?? 'z1', // To eventually accommodate multiple zero-caches.
@@ -61,7 +59,7 @@ export default async function runWorker(parent: Worker) {
 
   setUpMessageHandlers(replicator, parent);
 
-  void runOrExit(lc, replicator);
+  void runOrExit(lc, changeStreamer, replicator);
 
   // Signal readiness once the first ReplicaVersionReady notification is received.
   for await (const _ of replicator.subscribe()) {

--- a/packages/zero-cache/src/types/processes.ts
+++ b/packages/zero-cache/src/types/processes.ts
@@ -154,6 +154,7 @@ export function childWorker(module: string, options?: ForkOptions): Worker {
   // Note: It is okay to cast a Processor or ChildProcess as a Worker.
   // The {@link send} method simply restricts the message type for clarity.
   const worker = wrap(fork(module, {...options, serialization: 'advanced'}));
+  process.on('SIGTERM', () => worker.kill('SIGTERM'));
   process.on('exit', () => worker.kill());
   return worker;
 }


### PR DESCRIPTION
AWS sends the `SIGTERM` signal to shut down ECS containers:

https://aws.amazon.com/blogs/containers/graceful-shutdowns-with-ecs/

Node does not propagate `SIGTERM` signals to child processes by default (even with the `process.on('exit', ...)` handler).

Instead, it must be forwarded explicitly. In addition, we add a specific `SIGTERM` handler in the child process to call `service.stop()` on our services to facilitate graceful shutdown.