### PR TITLE
feat(zero-cache): handle SIGINT and SIGQUIT like SIGTERM

### DIFF
--- a/packages/zero-cache/src/services/runner.ts
+++ b/packages/zero-cache/src/services/runner.ts
@@ -56,12 +56,14 @@ export async function runOrExit(
   lc: LogContext,
   ...services: Service[]
 ): Promise<void> {
-  process.once('SIGTERM', () => {
-    for (const svc of services) {
-      lc.info?.(`exiting ${svc.constructor.name} (${svc.id}) for SIGTERM`);
-      void svc.stop();
-    }
-  });
+  for (const signal of ['SIGINT', 'SIGQUIT', 'SIGTERM'] as const) {
+    process.once(signal, () => {
+      for (const svc of services) {
+        lc.info?.(`exiting ${svc.constructor.name} (${svc.id}) for ${signal}`);
+        void svc.stop();
+      }
+    });
+  }
 
   try {
     await Promise.all(services.map(svc => svc.run()));


### PR DESCRIPTION
Note: SIGKILL and SIGSTOP cannot be listened to, as per https://nodejs.org/api/process.html#process_signal_events (Node will throw an error if you try).