### PR TITLE
feat(zero-cache): add an `app-config` for authorization rules

### DIFF
--- a/packages/zero-cache/src/config/app-config.ts
+++ b/packages/zero-cache/src/config/app-config.ts
@@ -9,6 +9,7 @@
 import {AST} from 'zql/src/zql/ast/ast.js';
 import * as v from 'shared/src/valita.js';
 import {astSchema} from 'zero-protocol';
+import fs from 'node:fs/promises';
 
 type Action = 'read' | 'insert' | 'update' | 'delete';
 type RuleType = 'allow';
@@ -52,8 +53,19 @@ export type AuthorizationConfig = {
   };
 };
 
-export const zeroConfigSchema = v.object({
+export const appConfigSchema = v.object({
   authorization: authorizationConfigSchema,
 });
 
-export type ZeroConfig = v.Infer<typeof zeroConfigSchema>;
+export type AppConfig = v.Infer<typeof appConfigSchema>;
+
+let loadedConfig: Promise<AppConfig> | undefined;
+export function getAppConfig(path: string) {
+  if (loadedConfig) {
+    return loadedConfig;
+  }
+  loadedConfig = fs
+    .readFile(path, 'utf-8')
+    .then(rawContent => v.parse(JSON.parse(rawContent), appConfigSchema));
+  return loadedConfig;
+}

--- a/packages/zero-cache/src/server/config.ts
+++ b/packages/zero-cache/src/server/config.ts
@@ -15,6 +15,7 @@ const configSchema = v.object({
   ),
   ['DATADOG_LOGS_API_KEY']: v.string().optional(),
   ['DATADOG_SERVICE_LABEL']: v.string().optional(),
+  ['APP_CONFIG_PATH']: v.string(),
 });
 
 export type Config = v.Infer<typeof configSchema>;

--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -16,6 +16,7 @@ import {Subscription} from '../types/subscription.js';
 import {Syncer} from '../workers/syncer.js';
 import {configFromEnv} from './config.js';
 import {createLogContext} from './logging.js';
+import {getAppConfig} from '../config/app-config.js';
 
 export default async function runWorker(parent: Worker) {
   const config = configFromEnv();
@@ -64,7 +65,9 @@ export default async function runWorker(parent: Worker) {
       sub,
     );
 
-  const mutagenFactory = (id: string) => new MutagenService(lc, id, upstreamDB);
+  const appConfig = await getAppConfig(config.APP_CONFIG_PATH);
+  const mutagenFactory = (id: string) =>
+    new MutagenService(lc, id, upstreamDB, appConfig.authorization);
 
   new Syncer(lc, viewSyncerFactory, mutagenFactory, parent).run();
 

--- a/packages/zero-cache/src/services/mutagen/mutagen.test.ts
+++ b/packages/zero-cache/src/services/mutagen/mutagen.test.ts
@@ -44,71 +44,87 @@ describe('processMutation', () => {
     await testDBs.drop(db);
   });
 
-  test('new client with no last mutation id', async () => {
-    await expectTables(db, {
-      idonly: [],
-      ['zero.clients']: [],
-    });
+  test(
+    'new client with no last mutation id',
+    async () => {
+      await expectTables(db, {
+        idonly: [],
+        ['zero.clients']: [],
+      });
 
-    const error = await processMutation(undefined, db, 'abc', {
-      type: MutationType.CRUD,
-      id: 1,
-      clientID: '123',
-      name: '_zero_crud',
-      args: [
+      const error = await processMutation(
+        undefined,
+        db,
+        'abc',
         {
-          ops: [
+          type: MutationType.CRUD,
+          id: 1,
+          clientID: '123',
+          name: '_zero_crud',
+          args: [
             {
-              op: 'create',
-              entityType: 'idonly',
-              id: {id: '1'},
-              value: {},
+              ops: [
+                {
+                  op: 'create',
+                  entityType: 'idonly',
+                  id: {id: '1'},
+                  value: {},
+                },
+              ],
             },
           ],
+          timestamp: Date.now(),
         },
-      ],
-      timestamp: Date.now(),
-    });
+        {},
+      );
 
-    expect(error).undefined;
+      expect(error).undefined;
 
-    await expectTables(db, {
-      idonly: [{id: '1'}],
-      ['zero.clients']: [
-        {
-          clientGroupID: 'abc',
-          clientID: '123',
-          lastMutationID: 1n,
-          userID: null,
-        },
-      ],
-    });
-  });
+      await expectTables(db, {
+        idonly: [{id: '1'}],
+        ['zero.clients']: [
+          {
+            clientGroupID: 'abc',
+            clientID: '123',
+            lastMutationID: 1n,
+            userID: null,
+          },
+        ],
+      });
+    },
+    {},
+  );
 
   test('next sequential mutation for previously seen client', async () => {
     await db`
       INSERT INTO zero.clients ("clientGroupID", "clientID", "lastMutationID") 
          VALUES ('abc', '123', 2)`;
 
-    const error = await processMutation(undefined, db, 'abc', {
-      type: MutationType.CRUD,
-      id: 3,
-      clientID: '123',
-      name: '_zero_crud',
-      args: [
-        {
-          ops: [
-            {
-              op: 'create',
-              entityType: 'idonly',
-              id: {id: '1'},
-              value: {},
-            },
-          ],
-        },
-      ],
-      timestamp: Date.now(),
-    });
+    const error = await processMutation(
+      undefined,
+      db,
+      'abc',
+      {
+        type: MutationType.CRUD,
+        id: 3,
+        clientID: '123',
+        name: '_zero_crud',
+        args: [
+          {
+            ops: [
+              {
+                op: 'create',
+                entityType: 'idonly',
+                id: {id: '1'},
+                value: {},
+              },
+            ],
+          },
+        ],
+        timestamp: Date.now(),
+      },
+      {},
+    );
 
     expect(error).undefined;
 
@@ -130,25 +146,31 @@ describe('processMutation', () => {
       INSERT INTO zero.clients ("clientGroupID", "clientID", "lastMutationID") 
         VALUES ('abc', '123', 2)`;
 
-    const error = await processMutation(undefined, db, 'abc', {
-      type: MutationType.CRUD,
-      id: 2,
-      clientID: '123',
-      name: '_zero_crud',
-      args: [
-        {
-          ops: [
-            {
-              op: 'create',
-              entityType: 'idonly',
-              id: {id: '1'},
-              value: {},
-            },
-          ],
-        },
-      ],
-      timestamp: Date.now(),
-    });
+    const error = await processMutation(
+      undefined,
+      db,
+      'abc',
+      {
+        type: MutationType.CRUD,
+        id: 2,
+        clientID: '123',
+        name: '_zero_crud',
+        args: [
+          {
+            ops: [
+              {
+                op: 'create',
+                entityType: 'idonly',
+                id: {id: '1'},
+                value: {},
+              },
+            ],
+          },
+        ],
+        timestamp: Date.now(),
+      },
+      {},
+    );
 
     expect(error).undefined;
 
@@ -172,25 +194,31 @@ describe('processMutation', () => {
       INSERT INTO idonly (id) VALUES ('1');
       `.simple();
 
-    const error = await processMutation(undefined, db, 'abc', {
-      type: MutationType.CRUD,
-      id: 2,
-      clientID: '123',
-      name: '_zero_crud',
-      args: [
-        {
-          ops: [
-            {
-              op: 'create',
-              entityType: 'idonly',
-              id: {id: '1'}, // This would result in a duplicate key value if applied.
-              value: {},
-            },
-          ],
-        },
-      ],
-      timestamp: Date.now(),
-    });
+    const error = await processMutation(
+      undefined,
+      db,
+      'abc',
+      {
+        type: MutationType.CRUD,
+        id: 2,
+        clientID: '123',
+        name: '_zero_crud',
+        args: [
+          {
+            ops: [
+              {
+                op: 'create',
+                entityType: 'idonly',
+                id: {id: '1'}, // This would result in a duplicate key value if applied.
+                value: {},
+              },
+            ],
+          },
+        ],
+        timestamp: Date.now(),
+      },
+      {},
+    );
 
     expect(error).undefined;
 
@@ -213,25 +241,31 @@ describe('processMutation', () => {
         VALUES ('abc', '123', 1)`;
 
     await expect(
-      processMutation(undefined, db, 'abc', {
-        type: MutationType.CRUD,
-        id: 3,
-        clientID: '123',
-        name: '_zero_crud',
-        args: [
-          {
-            ops: [
-              {
-                op: 'create',
-                entityType: 'idonly',
-                id: {id: '1'},
-                value: {},
-              },
-            ],
-          },
-        ],
-        timestamp: Date.now(),
-      }),
+      processMutation(
+        undefined,
+        db,
+        'abc',
+        {
+          type: MutationType.CRUD,
+          id: 3,
+          clientID: '123',
+          name: '_zero_crud',
+          args: [
+            {
+              ops: [
+                {
+                  op: 'create',
+                  entityType: 'idonly',
+                  id: {id: '1'},
+                  value: {},
+                },
+              ],
+            },
+          ],
+          timestamp: Date.now(),
+        },
+        {},
+      ),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       `[Error: ["error","InvalidPush","Push contains unexpected mutation id 3 for client 123. Expected mutation id 2."]]`,
     );
@@ -250,58 +284,64 @@ describe('processMutation', () => {
   });
 
   test('process create, set, update, delete all at once', async () => {
-    const error = await processMutation(undefined, db, 'abc', {
-      type: MutationType.CRUD,
-      id: 1,
-      clientID: '123',
-      name: '_zero_crud',
-      args: [
-        {
-          ops: [
-            {
-              op: 'create',
-              entityType: 'id_and_cols',
-              id: {id: '1'},
-              value: {
-                col1: 'create',
-                col2: 'create',
+    const error = await processMutation(
+      undefined,
+      db,
+      'abc',
+      {
+        type: MutationType.CRUD,
+        id: 1,
+        clientID: '123',
+        name: '_zero_crud',
+        args: [
+          {
+            ops: [
+              {
+                op: 'create',
+                entityType: 'id_and_cols',
+                id: {id: '1'},
+                value: {
+                  col1: 'create',
+                  col2: 'create',
+                },
               },
-            },
-            {
-              op: 'set',
-              entityType: 'id_and_cols',
-              id: {id: '2'},
-              value: {
-                col1: 'set',
-                col2: 'set',
+              {
+                op: 'set',
+                entityType: 'id_and_cols',
+                id: {id: '2'},
+                value: {
+                  col1: 'set',
+                  col2: 'set',
+                },
               },
-            },
-            {
-              op: 'update',
-              entityType: 'id_and_cols',
-              id: {id: '1'},
-              partialValue: {
-                col1: 'update',
+              {
+                op: 'update',
+                entityType: 'id_and_cols',
+                id: {id: '1'},
+                partialValue: {
+                  col1: 'update',
+                },
               },
-            },
-            {
-              op: 'set',
-              entityType: 'id_and_cols',
-              id: {id: '1'},
-              value: {
-                col2: 'set',
+              {
+                op: 'set',
+                entityType: 'id_and_cols',
+                id: {id: '1'},
+                value: {
+                  col2: 'set',
+                },
               },
-            },
-            {
-              op: 'delete',
-              entityType: 'id_and_cols',
-              id: {id: '2'},
-            },
-          ],
-        },
-      ],
-      timestamp: Date.now(),
-    } satisfies CRUDMutation);
+              {
+                op: 'delete',
+                entityType: 'id_and_cols',
+                id: {id: '2'},
+              },
+            ],
+          },
+        ],
+        timestamp: Date.now(),
+      } satisfies CRUDMutation,
+      {},
+    );
 
     expect(error).undefined;
 
@@ -325,27 +365,33 @@ describe('processMutation', () => {
   });
 
   test('fk failure', async () => {
-    const error = await processMutation(undefined, db, 'abc', {
-      type: MutationType.CRUD,
-      id: 1,
-      clientID: '123',
-      name: '_zero_crud',
-      args: [
-        {
-          ops: [
-            {
-              op: 'create',
-              entityType: 'fk_ref',
-              id: {id: '1'},
-              value: {
-                ref: '1',
+    const error = await processMutation(
+      undefined,
+      db,
+      'abc',
+      {
+        type: MutationType.CRUD,
+        id: 1,
+        clientID: '123',
+        name: '_zero_crud',
+        args: [
+          {
+            ops: [
+              {
+                op: 'create',
+                entityType: 'fk_ref',
+                id: {id: '1'},
+                value: {
+                  ref: '1',
+                },
               },
-            },
-          ],
-        },
-      ],
-      timestamp: Date.now(),
-    } satisfies CRUDMutation);
+            ],
+          },
+        ],
+        timestamp: Date.now(),
+      } satisfies CRUDMutation,
+      {},
+    );
 
     expect(error).toEqual(
       'PostgresError: insert or update on table "fk_ref" violates foreign key constraint "fk_ref_ref_fkey"',


### PR DESCRIPTION
Users will place their authorization rules into this config (see https://www.notion.so/replicache/Authorization-b7027641479b4c188d79c6ace5f83e64).

These rules are then threaded down into `mutagen` so we can apply them for write time authz. The threading of the argument happens here but the application does not yet happen.

---

This is called `app-config` to differentiate it from the existing `config`.

The main way they're different is that `app-config` can be checked in and does not directly reference secrets.

Since that is not much of a difference, my proposal is to:
1. Get rid of [`config`](https://github.com/rocicorp/mono/blob/main/packages/zero-cache/src/server/config.ts)
2. Rename `app-config` to `zero.config`
3. Roll everything into that.

In order to not reference secrets users would call an `env` function in their `zero.config.ts`.

e.g.,

```ts
export const zeroConfig = {
  log: {
    datadogApiKey: env('DATADOG_LOGS_API_KEY'),
   level: 'debug',
  },
  ...
};
```

I'll do this once I have a way to compile the config from a `ts` file to `json`.