### PR TITLE
fix(zero-cache): fix pipeline resumption after a maintenance pause

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -347,6 +347,49 @@ describe('view-syncer/pipeline-driver', () => {
     `);
   });
 
+  test('release and resume update', () => {
+    pipelines.init();
+    [...pipelines.addQuery('hash1', ISSUES_AND_COMMENTS)];
+
+    // Release and resume.
+    pipelines.release();
+    pipelines.advanceWithoutDiff();
+
+    const replicator = fakeReplicator(lc, db);
+    replicator.processTransaction(
+      '134',
+      messages.update('comments', {id: '22', issueID: '3'}),
+    );
+
+    expect([...pipelines.advance().changes]).toMatchInlineSnapshot(`
+      [
+        {
+          "queryHash": "hash1",
+          "row": undefined,
+          "rowKey": {
+            "id": "22",
+          },
+          "table": "comments",
+          "type": "remove",
+        },
+        {
+          "queryHash": "hash1",
+          "row": {
+            "_0_version": "123",
+            "id": "22",
+            "issueID": "3",
+            "upvotes": 20000,
+          },
+          "rowKey": {
+            "id": "22",
+          },
+          "table": "comments",
+          "type": "add",
+        },
+      ]
+    `);
+  });
+
   test('getRow', () => {
     pipelines.init();
 

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -123,7 +123,11 @@ export class PipelineDriver {
   }
 
   advanceWithoutDiff(): string {
-    return this.#snapshotter.advance().curr.version;
+    const {db, version} = this.#snapshotter.advance().curr;
+    for (const table of this.#tables.values()) {
+      table.setDB(db.db);
+    }
+    return version;
   }
 
   /**


### PR DESCRIPTION
Fix the resumption logic introduced in #2399 to correctly reset the TableSource db's after resuming from a maintenance pause.