### PR TITLE
feat(zero-cache): WAL checkpointer coordinates inter-process database GC

### DIFF
--- a/packages/zero-cache/src/db/wal-checkpoint.test.ts
+++ b/packages/zero-cache/src/db/wal-checkpoint.test.ts
@@ -1,0 +1,112 @@
+import {resolver} from '@rocicorp/resolver';
+import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
+import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {Worker} from 'worker_threads';
+import {DbFile} from '../test/lite.js';
+
+describe('db/wal-checkpoint', () => {
+  let dbFile: DbFile;
+
+  const lc = createSilentLogContext();
+
+  beforeEach(() => {
+    dbFile = new DbFile('wal-checkpoint');
+    const conn = dbFile.connect(lc);
+    conn.pragma('journal_mode = WAL');
+    conn.pragma('synchronous = NORMAL');
+    conn.exec(`
+      CREATE TABLE foo(id INTEGER PRIMARY KEY);
+      INSERT INTO foo(id) VALUES(1);
+      INSERT INTO foo(id) VALUES(2);
+      INSERT INTO foo(id) VALUES(3);
+    `);
+    conn.close();
+  });
+
+  afterEach(async () => {
+    await dbFile.unlink();
+  });
+
+  type CheckpointResult = {
+    busy: number;
+    log: number;
+    checkpointed: number;
+  }[];
+
+  test('checkpointing', async () => {
+    // The read lock logic must be run in a different thread.
+    const worker = new Worker(
+      `
+      const {parentPort} = require('worker_threads');
+      const Database = require('better-sqlite3');
+
+      // Acquire a read lock.
+      const reader = new Database('${dbFile.path}');
+      const count = reader.prepare('select count(*) as count from foo');
+
+      reader.prepare('begin concurrent').run();
+      const before = count.get();
+
+      parentPort.postMessage('ready');
+
+      // Release the read lock when a message is posted to this worker.
+      parentPort.once('message', () => {
+        reader.prepare('rollback').run();
+        const after = count.get();
+
+        // Respond with the before and after counts.
+        parentPort.postMessage({before, after});
+      });
+    `,
+      {eval: true},
+    );
+
+    const {promise: running, resolve: setRunning} = resolver();
+    worker.once('message', setRunning);
+    await running;
+
+    const writer = dbFile.connect(lc);
+    writer.pragma('busy_timeout = 50');
+
+    const insert = writer.prepare('INSERT INTO foo(id) VALUES(?)');
+    for (let i = 10; i < 20; i++) {
+      insert.run(i);
+    }
+
+    // A passive wal_checkpoint does not block and won't succeed in
+    // checkpointing, but it returns the state of the wal.
+    expect(
+      (writer.pragma('wal_checkpoint(PASSIVE)') as CheckpointResult)[0],
+    ).toEqual({busy: 0, log: 10, checkpointed: 0});
+
+    // A RESTART should fail with 'busy' while the read lock is held.
+    expect(
+      (writer.pragma('wal_checkpoint(RESTART)') as CheckpointResult)[0],
+    ).toEqual({busy: 1, log: 10, checkpointed: 0});
+
+    // A wal_checkpoint should succeed once the read lock is released.
+    worker.postMessage('release');
+    expect(
+      (writer.pragma('wal_checkpoint(RESTART)') as CheckpointResult)[0],
+    ).toEqual({busy: 0, log: 10, checkpointed: 10});
+
+    const {promise: response, resolve: setResponse} = resolver<unknown>();
+    worker.once('message', setResponse);
+    expect(await response).toEqual({
+      before: {count: 3},
+      after: {count: 13},
+    });
+
+    // New writes should be written from the beginning of the WAL.
+    insert.run(20);
+    insert.run(21);
+    expect(
+      (writer.pragma('wal_checkpoint(PASSIVE)') as CheckpointResult)[0],
+    ).toEqual({busy: 0, log: 2, checkpointed: 2});
+
+    insert.run(22);
+    expect(
+      (writer.pragma('wal_checkpoint(PASSIVE)') as CheckpointResult)[0],
+    ).toEqual({busy: 0, log: 1, checkpointed: 1});
+  });
+});

--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -3,6 +3,7 @@ import {must} from 'shared/src/must.js';
 import {Database} from 'zqlite/src/db.js';
 import {initializeStreamer} from '../services/change-streamer/change-streamer-service.js';
 import {initializeChangeSource} from '../services/change-streamer/pg/change-source.js';
+import {NULL_CHECKPOINTER} from '../services/replicator/checkpointer.js';
 import {ReplicatorService} from '../services/replicator/replicator.js';
 import {runOrExit} from '../services/runner.js';
 import {postgresTypeConfig} from '../types/pg.js';
@@ -55,6 +56,9 @@ export default async function runWorker(parent: Worker) {
     config.TASK_ID ?? 'z1', // To eventually accommodate multiple zero-caches.
     changeStreamer,
     replica,
+    // TODO: Run two replicators: one for litestream backup and one for serving requests,
+    //       and use the WALCheckpointer on the serving replica.
+    NULL_CHECKPOINTER,
   );
 
   setUpMessageHandlers(lc, replicator, parent);

--- a/packages/zero-cache/src/services/change-streamer/schema/change.ts
+++ b/packages/zero-cache/src/services/change-streamer/schema/change.ts
@@ -15,3 +15,5 @@ export type DataChange =
   | Pgoutput.MessageTruncate;
 
 export type Change = MessageBegin | DataChange | MessageCommit;
+
+export type ChangeTag = Change['tag'];

--- a/packages/zero-cache/src/services/replicator/checkpointer.test.ts
+++ b/packages/zero-cache/src/services/replicator/checkpointer.test.ts
@@ -1,0 +1,75 @@
+import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
+import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {Database} from 'zqlite/src/db.js';
+import {DbFile} from '../../test/lite.js';
+import {WALCheckpointer} from './checkpointer.js';
+import {Notifier} from './notifier.js';
+
+describe('replicator/checkpointer', () => {
+  let dbFile: DbFile;
+  let db: Database;
+  let viewSyncer: Database;
+  let notifier: Notifier;
+  let checkpointer: WALCheckpointer;
+
+  const lc = createSilentLogContext();
+
+  beforeEach(() => {
+    dbFile = new DbFile('checkpointer');
+    db = dbFile.connect(lc);
+    db.pragma('journal_mode = WAL');
+    db.pragma('synchronous = NORMAL');
+    db.exec(`
+      CREATE TABLE foo(id INTEGER PRIMARY KEY);
+      INSERT INTO foo(id) VALUES(1);
+      INSERT INTO foo(id) VALUES(2);
+      INSERT INTO foo(id) VALUES(3);
+    `);
+
+    viewSyncer = dbFile.connect(lc);
+    notifier = new Notifier();
+    checkpointer = new WALCheckpointer(lc, dbFile.path, {threshold: 5});
+  });
+
+  afterEach(async () => {
+    checkpointer.stop();
+    await dbFile.unlink();
+  });
+
+  test('checkpointing', {timeout: 100}, async () => {
+    const lock = viewSyncer.prepare('begin immediate');
+    const unlock = viewSyncer.prepare('rollback');
+    lock.run();
+
+    const subscription = notifier.subscribe();
+    void (async function () {
+      for await (const {state} of subscription) {
+        if (state === 'maintenance') {
+          unlock.run();
+        } else if (!viewSyncer.inTransaction) {
+          lock.run();
+        }
+      }
+    })();
+
+    // Checkpoints should fail while the viewSyncer has a lock.
+    expect(viewSyncer.inTransaction);
+
+    db.pragma('busy_timeout = 1');
+    expect(db.pragma('wal_checkpoint(TRUNCATE)')).toMatchObject([
+      {busy: 1, log: 5},
+    ]);
+
+    // The checkpointer should signal a 'maintenance' mode and execute a
+    // checkpoint with the view syncer unlocked.
+    await checkpointer.maybeCheckpoint(10, notifier);
+
+    // Upon completion, the view syncer should be locked again.
+    expect(viewSyncer.inTransaction);
+
+    // But the checkpoint should have succeeded.
+    expect(db.pragma('wal_checkpoint(TRUNCATE)')).toMatchObject([
+      {busy: 1, log: 0},
+    ]);
+  });
+});

--- a/packages/zero-cache/src/services/replicator/checkpointer.ts
+++ b/packages/zero-cache/src/services/replicator/checkpointer.ts
@@ -1,0 +1,224 @@
+import {LogContext} from '@rocicorp/logger';
+import {assert} from 'shared/src/asserts.js';
+import {randInt} from 'shared/src/rand.js';
+import {promiseVoid} from 'shared/src/resolved-promises.js';
+import {orTimeout} from 'zero-cache/src/types/timeout.js';
+import {Database} from 'zqlite/src/db.js';
+import {Notifier} from './notifier.js';
+
+/**
+ * A `Checkpointer` is consulted by the Replicator after each commit and given
+ * the opportunity to perform a blocking WAL checkpoint before the Replicator
+ * continues processing the replication stream.
+ */
+export interface Checkpointer {
+  maybeCheckpoint(
+    numCommittedChanges: number,
+    notifier: Notifier,
+  ): Promise<void>;
+
+  stop(): void;
+}
+
+/**
+ * The `NULL_CHECKPOINTER` is suitable for an environment in which checkpoints are
+ * handled by an external entity, such as a `litestream replicate` process.
+ */
+export const NULL_CHECKPOINTER: Checkpointer = {
+  maybeCheckpoint: () => promiseVoid,
+  stop: () => {},
+} as const;
+
+export type CheckpointerConfig = {
+  /**
+   * The number of outstanding frames or changes at which a blocking
+   * checkpoint is triggered.
+   *
+   * Defaults to 200.
+   */
+  threshold?: number;
+
+  /**
+   * The base timeout to block on an active checkpoint. This timeout is increased
+   * in proportion to the size of WAL divided by the `threshold`. For example, if
+   * the size of the WAL is twice the `threshold`, the timeout will be doubled.
+   *
+   * This dynamic timeout algorithm reduces the amount of system-wide pausing in
+   * the common case, even in the presence of occasional, long-held locks due to
+   * events like a long hydration. If checkpoint is not able to start within the
+   * timeout, the checkpointer gives up and allows the system to progress. As the
+   * size of the WAL grows, the checkpointer will wait for longer timeouts to ensure
+   * that the checkpointing eventually succeeds.
+   *
+   * Defaults to 200 milliseconds.
+   */
+  baseCheckpointTimeoutMs?: number;
+
+  /**
+   * A regular interval at which passive checkpoints are attempted. This allows an
+   * idle task (i.e. no sync connections) to clean up outside of the
+   * replication path.
+   *
+   * Defaults to one minute.
+   */
+  passiveCheckpointPeriodMs?: number;
+};
+
+/**
+ * The `WALCheckpointer` executes checkpoints when the number of WAL log entries
+ * exceeds a configurable threshold. It does this by:
+ *
+ * 1. Broadcasting a `maintenance` ReplicaState message to signal view-syncers to
+ *    release their locks.
+ * 2. Executing `wal_checkpoint(TRUNCATE)` with a busy_timeout proportional to
+ *    the outstanding log size.
+ * 3. Broadcasting a `version-ready` ReplicaState message to signal view-syncers to
+ *    reestablish their locks.
+ *
+ * Points of interest:
+ *
+ * * The checkpointer waits for the `maintenance` broadcast to be sent to over
+ *   IPC channels (in-process blocking), but does not request or wait for ACKs from
+ *   the view syncers. This is because the `wal_checkpoint(TRUNCATE)` command itself
+ *   will block until all read locks are released, up to the configured `busy_timeout`.
+ *
+ * * After performing the checkpoint, however, the checkpointer _does_ request ACKs
+ *   from view-syncers to confirm that they have reestablished their snapshots. There
+ *   is otherwise no way to know when it is safe to continue replication. This is
+ *   expected to be very fast, but to avoid pathological cases the wait is capped at
+ *   100ms.
+ */
+export class WALCheckpointer implements Checkpointer {
+  readonly #lc: LogContext;
+  readonly #db: Database;
+  readonly #threshold: number;
+  readonly #baseCheckpointTimeoutMs: number;
+  readonly #passiveCheckpointTimer: ReturnType<typeof setTimeout>;
+
+  #logSize = 0;
+  #outstandingChanges = 0;
+
+  constructor(
+    lc: LogContext,
+    replicaDbFile: string,
+    cfg: CheckpointerConfig = {},
+  ) {
+    const {
+      threshold = 200,
+      baseCheckpointTimeoutMs = 10,
+      passiveCheckpointPeriodMs = 60_000,
+    } = cfg;
+
+    assert(
+      threshold > 0 &&
+        baseCheckpointTimeoutMs > 0 &&
+        passiveCheckpointPeriodMs > 0,
+      `Invalid config ${JSON.stringify(cfg)}`,
+    );
+
+    const db = new Database(lc, replicaDbFile);
+    db.pragma('journal_mode = WAL');
+
+    this.#lc = lc.withContext('component', 'wal-checkpointer');
+    this.#db = db;
+    this.#threshold = threshold;
+    this.#baseCheckpointTimeoutMs = baseCheckpointTimeoutMs;
+    this.#passiveCheckpointTimer = setInterval(
+      () => this.#checkpoint('PASSIVE'),
+      passiveCheckpointPeriodMs,
+    );
+  }
+
+  stop() {
+    clearTimeout(this.#passiveCheckpointTimer);
+    this.#lc.info?.('stopped');
+  }
+
+  async maybeCheckpoint(changes: number, notifier: Notifier) {
+    this.#outstandingChanges += changes;
+
+    // Simplification: changes and frames equivalently w.r.t. the threshold.
+    if (Math.max(this.#outstandingChanges, this.#logSize) >= this.#threshold) {
+      // If no read locks are held, a PASSIVE checkpoint may suffice.
+      // Regardless of success, #logSize gets updated to determine if a
+      // blocking checkpoint is warranted.
+      this.#checkpoint('PASSIVE');
+    }
+
+    if (this.#logSize >= this.#threshold) {
+      const t0 = Date.now();
+      await this.#enterMaintenanceMode(notifier);
+      const t1 = Date.now();
+
+      // The timeout is proportional to the size of the log compared to the threshold.
+      const timeout =
+        (this.#logSize / this.#threshold) * this.#baseCheckpointTimeoutMs;
+      const result = this.#checkpoint('TRUNCATE', timeout);
+
+      const t2 = Date.now();
+      await this.#exitMaintenanceMode(notifier);
+      const t3 = Date.now();
+
+      this.#lc.info?.(
+        `WAL(busy=${timeout}ms): pre=${t1 - t0}ms checkpoint=${
+          t2 - t1
+        }ms post=${t3 - t2}ms`,
+        result,
+      );
+    }
+  }
+
+  async #enterMaintenanceMode(notifier: Notifier) {
+    await Promise.all(notifier.notifySubscribers({state: 'maintenance'}));
+  }
+
+  async #exitMaintenanceMode(notifier: Notifier) {
+    // Request an ACK when exiting maintenance mode to maximize the chance of
+    // view syncers re-establishing snapshots at the same version. This is expected
+    // to be very fast (single-digit milliseconds).
+    //
+    // However, this is also the chance for view syncers to invoke an occasional
+    // `PRAGMA optimize` call, for which latency may be variable. To avoid holding
+    // up the replication stream indefinitely, we cap the wait at 100ms.
+    const result = await orTimeout(
+      Promise.all(
+        notifier.notifySubscribers({
+          state: 'version-ready',
+          ack: randomACK(),
+        }),
+      ),
+      100,
+    );
+    if (result === 'timed-out') {
+      this.#lc.info?.('timed out waiting for view-syncer resumption');
+    }
+  }
+
+  #checkpoint(mode: CheckpointMode, timeoutMs?: number): CheckpointResult {
+    if (timeoutMs) {
+      this.#db.pragma(`busy_timeout = ${timeoutMs}`);
+    }
+    const result = checkpoint(this.#db, mode);
+
+    this.#logSize = result.log;
+    this.#outstandingChanges = 0;
+    return result;
+  }
+}
+
+type CheckpointMode = 'PASSIVE' | 'FULL' | 'RESTART' | 'TRUNCATE';
+
+type CheckpointResult = {
+  busy: number;
+  log: number;
+  checkpointed: number;
+};
+
+function checkpoint(db: Database, mode: CheckpointMode): CheckpointResult {
+  const result = db.pragma(`wal_checkpoint(${mode})`) as CheckpointResult[];
+  return result[0];
+}
+
+function randomACK() {
+  return randInt(Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER);
+}

--- a/packages/zero-cache/src/services/replicator/incremental-sync.message-processor.test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.message-processor.test.ts
@@ -137,12 +137,13 @@ describe('replicator/message-processor', () => {
       const processor = createMessageProcessor(
         replica,
         (lsn: string) => acknowledgements.push(lsn),
-        () => versionChanges++,
         (_: LogContext, err: unknown) => failures.push(err),
       );
 
       for (const msg of c.messages) {
-        processor.processMessage(lc, msg);
+        if (processor.processMessage(lc, msg) > 0) {
+          versionChanges++;
+        }
       }
 
       expect(acknowledgements).toEqual(c.acknowledged);

--- a/packages/zero-cache/src/services/replicator/replicator.ts
+++ b/packages/zero-cache/src/services/replicator/replicator.ts
@@ -4,6 +4,7 @@ import {Database} from 'zqlite/src/db.js';
 import type {Source} from '../../types/streams.js';
 import {ChangeStreamer} from '../change-streamer/change-streamer.js';
 import type {Service} from '../service.js';
+import {Checkpointer} from './checkpointer.js';
 import {IncrementalSyncer} from './incremental-sync.js';
 
 /** See {@link ReplicaStateNotifier.subscribe()}. */
@@ -66,6 +67,7 @@ export class ReplicatorService implements Replicator, Service {
     id: string,
     changeStreamer: ChangeStreamer,
     replica: Database,
+    checkpointer: Checkpointer,
   ) {
     this.id = id;
     this.#lc = lc
@@ -76,6 +78,7 @@ export class ReplicatorService implements Replicator, Service {
       id,
       changeStreamer,
       replica,
+      checkpointer,
     );
   }
 

--- a/packages/zero-cache/src/services/replicator/test-utils.ts
+++ b/packages/zero-cache/src/services/replicator/test-utils.ts
@@ -38,10 +38,9 @@ export function fakeReplicator(lc: LogContext, db: Database): FakeReplicator {
 export function createMessageProcessor(
   db: Database,
   ack: (lsn: string) => void = NOOP,
-  versions: () => void = NOOP,
   failures: (lc: LogContext, err: unknown) => void = NOOP,
 ): MessageProcessor {
-  return new MessageProcessor(new StatementRunner(db), ack, versions, failures);
+  return new MessageProcessor(new StatementRunner(db), ack, failures);
 }
 
 export class ReplicationMessages<


### PR DESCRIPTION
Contextual PRs:
* `maintenance` mode messages and View Syncer handling of them: 
  * https://github.com/rocicorp/mono/pull/2399
  * https://github.com/rocicorp/mono/pull/2417
* Subscription flow control APIs and inter-process ACKs
  * https://github.com/rocicorp/mono/pull/2407
  * https://github.com/rocicorp/mono/pull/2412

### WAL Checkpointer

* Works with the Replicator to periodically pause the replication stream when the WAL log size reaches or exceeds a configured threshold.
* Broadcasts a `maintenance` message and executes a blocking `wal_checkpoint(TRUNCATE)` call, with a configurable `busy_timeout` that increases with the outstanding log size. Example:

```sh
// Fails because a view-syncer is busy advancing while the checkpointer attempts the checkpoint.
worker=replicator pid=19032 component=wal-checkpointer WAL(busy=56ms): pre=0ms checkpoint=66ms post=43ms {"busy":1,"log":56,"checkpointed":17}

// The next attempt succeeds with a longer `busy_timeout` because the log size grew.
worker=replicator pid=19032 component=wal-checkpointer WAL(busy=83ms): pre=1ms checkpoint=94ms post=2ms {"busy":0,"log":0,"checkpointed":0}
```


* Broadcasts a `version-ready` message to signal View Syncers that they should reestablish their snapshots, and requests inter-process ACK messages to resume the replication stream as soon as View Syncers are done.

** Note **

This is not yet plugged in to the main configuration, as it is incompable with the `litestream replicate` process's checkpointing mechanism (which maintains its own read lock to prevent checkpointing).

The next step is to run Replicators on two different replica files so that one can be used for litestream backup, and the other to service view-syncers. The latter Replicator will use this checkpointer.