### PR TITLE
feat(zero-cache): make the change-streamer Change type serializable

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/schema/change.ts
+++ b/packages/zero-cache/src/services/change-streamer/schema/change.ts
@@ -1,4 +1,6 @@
 import {Pgoutput} from 'pg-logical-replication';
+import {JSONObject} from 'zero-cache/src/types/bigint-json.js';
+import {Satisfies} from 'zero-cache/src/types/satisfies.js';
 
 export type MessageBegin = {
   tag: 'begin';
@@ -8,11 +10,34 @@ export type MessageCommit = {
   tag: 'commit';
 };
 
-export type DataChange =
-  | Pgoutput.MessageInsert
-  | Pgoutput.MessageUpdate
-  | Pgoutput.MessageDelete
-  | Pgoutput.MessageTruncate;
+// Omit the `parser: (raw: any) => any;` field from the RelationColumn,
+// which does not serialize to JSON.
+export type RelationColumn = Omit<Pgoutput.RelationColumn, 'parser'>;
+
+export type MessageRelation = Omit<Pgoutput.MessageRelation, 'columns'> & {
+  columns: RelationColumn[];
+};
+
+export type MessageInsert = Omit<Pgoutput.MessageInsert, 'relation'> & {
+  relation: MessageRelation;
+};
+
+export type MessageUpdate = Omit<Pgoutput.MessageUpdate, 'relation'> & {
+  relation: MessageRelation;
+};
+
+export type MessageDelete = Omit<Pgoutput.MessageDelete, 'relation'> & {
+  relation: MessageRelation;
+};
+
+export type MessageTruncate = Omit<Pgoutput.MessageTruncate, 'relations'> & {
+  relations: MessageRelation[];
+};
+
+export type DataChange = Satisfies<
+  JSONObject, // guarantees serialization over IPC or network
+  MessageInsert | MessageUpdate | MessageDelete | MessageTruncate
+>;
 
 export type Change = MessageBegin | DataChange | MessageCommit;
 

--- a/packages/zero-cache/src/types/satisfies.ts
+++ b/packages/zero-cache/src/types/satisfies.ts
@@ -1,0 +1,13 @@
+/**
+ * Utility type that statically confirms that a defined type T
+ * satisfies a wider type U.
+ *
+ * Example:
+ *
+ * ```ts
+ * export MyType = Satisfies<JSONValue, {
+ *  // type definition
+ * }>;
+ * ```
+ */
+export type Satisfies<U, T extends U> = T;


### PR DESCRIPTION
Constraint the original `PgOutput` type definitions to only include JSON serializable fields, so that change streams can be sent over the wire.

This involves omitting the `parser: (any) => any` from the `RelationColumn` type that is transitively referenced through the  `MessageRelation` type.