### PR TITLE
chore(zql): Remove Arrays from QueryRowType completely.

### DIFF
--- a/packages/zero-react/src/use-query.tsx
+++ b/packages/zero-react/src/use-query.tsx
@@ -6,7 +6,7 @@ import {deepClone} from 'shared/src/deep-clone.js';
 
 export function useQuery<
   TSchema extends Schema,
-  TReturn extends Array<QueryResultRow>,
+  TReturn extends QueryResultRow,
 >(q: Query<TSchema, TReturn> | undefined | false): Smash<TReturn> {
   const [snapshot, setSnapshot] = useState<Smash<TReturn>>([]);
   const [, setView] = useState<TypedView<Smash<TReturn>> | undefined>(

--- a/packages/zql/src/zql/query/query-impl.ts
+++ b/packages/zql/src/zql/query/query-impl.ts
@@ -27,14 +27,14 @@ import {TypedView} from './typed-view.js';
 
 export function newQuery<
   TSchema extends Schema,
-  TReturn extends Array<QueryResultRow> = Array<DefaultQueryResultRow<TSchema>>,
+  TReturn extends QueryResultRow = DefaultQueryResultRow<TSchema>,
 >(delegate: QueryDelegate, schema: TSchema): Query<TSchema, TReturn> {
   return new QueryImpl(delegate, schema);
 }
 
 function newQueryWithAST<
   TSchema extends Schema,
-  TReturn extends Array<QueryResultRow>,
+  TReturn extends QueryResultRow,
 >(delegate: QueryDelegate, schema: TSchema, ast: AST): Query<TSchema, TReturn> {
   return new QueryImpl(delegate, schema, ast);
 }
@@ -47,7 +47,7 @@ export interface QueryDelegate extends BuilderDelegate {
 
 class QueryImpl<
   TSchema extends Schema,
-  TReturn extends Array<QueryResultRow> = Array<DefaultQueryResultRow<TSchema>>,
+  TReturn extends QueryResultRow = DefaultQueryResultRow<TSchema>,
 > implements Query<TSchema, TReturn>
 {
   readonly #ast: AST;
@@ -68,7 +68,7 @@ class QueryImpl<
 
   select<TFields extends Selector<TSchema>[]>(
     ..._fields: TFields
-  ): Query<TSchema, AddSelections<TSchema, TFields, TReturn>[]> {
+  ): Query<TSchema, AddSelections<TSchema, TFields, TReturn>> {
     // we return all columns for now so we ignore the selection set and only use it for type inference
     return newQueryWithAST(this.#delegate, this.#schema, this.#ast);
   }
@@ -124,19 +124,13 @@ class QueryImpl<
     relationship: TRelationship,
   ): Query<
     TSchema,
-    Array<
-      AddSubselect<
-        Query<
-          PullSchemaForRelationship<TSchema, TRelationship>,
-          Array<
-            DefaultQueryResultRow<
-              PullSchemaForRelationship<TSchema, TRelationship>
-            >
-          >
-        >,
-        TReturn,
-        TRelationship & string
-      >
+    AddSubselect<
+      Query<
+        PullSchemaForRelationship<TSchema, TRelationship>,
+        DefaultQueryResultRow<PullSchemaForRelationship<TSchema, TRelationship>>
+      >,
+      TReturn,
+      TRelationship & string
     >
   >;
   related<
@@ -148,11 +142,7 @@ class QueryImpl<
     cb: (
       query: Query<
         PullSchemaForRelationship<TSchema, TRelationship>,
-        Array<
-          DefaultQueryResultRow<
-            PullSchemaForRelationship<TSchema, TRelationship>
-          >
-        >
+        DefaultQueryResultRow<PullSchemaForRelationship<TSchema, TRelationship>>
       >,
     ) => TSub = q => q as any,
   ) {

--- a/packages/zql/src/zql/query/query.test.ts
+++ b/packages/zql/src/zql/query/query.test.ts
@@ -134,6 +134,7 @@ describe('types', () => {
     query.related('doesNotExist', q => q);
 
     const query2 = query.related('test', q => q.select('b')).select('s');
+
     expectTypeOf(query2.materialize().data).toMatchTypeOf<
       Array<{
         readonly s: string;


### PR DESCRIPTION
The query class doesn't actually care about this detail and constantly working around the 'arrayness' of QueryRowType adds unnecessary complexity.

Only ArrayView cares about this and we can easily add the Array wrapper back at the last minute before we hand the type to ArrayView (actually TypedArrayView).