### PR TITLE
chore(zero-cache): remove global retry=3 test config

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.test.ts
@@ -21,7 +21,7 @@ import {
 } from './change-streamer.js';
 import {ChangeLogEntry} from './schema/tables.js';
 
-describe('change-streamer/service', {retry: 3}, () => {
+describe('change-streamer/service', () => {
   let lc: LogContext;
   let changeDB: PostgresDB;
   let streamer: ChangeStreamerService;

--- a/packages/zero-cache/src/services/change-streamer/pg/change-source.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/change-source.test.ts
@@ -203,7 +203,7 @@ describe('change-source/pg', () => {
     expect(err).toBeInstanceOf(AbortError);
   });
 
-  test('handoff', async () => {
+  test('handoff', {retry: 3}, async () => {
     const {changes} = await source.startStream();
 
     // Starting another stream should stop the first.

--- a/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
@@ -28,7 +28,7 @@ import {ReplicationMessages} from './test-utils.js';
 
 const REPLICA_ID = 'incremental_sync_test_id';
 
-describe('replicator/incremental-sync', {retry: 3}, () => {
+describe('replicator/incremental-sync', () => {
   let lc: LogContext;
   let upstream: PostgresDB;
   let replica: Database;

--- a/packages/zero-cache/vitest.config.ts
+++ b/packages/zero-cache/vitest.config.ts
@@ -30,7 +30,6 @@ export default defineConfig({
   plugins: [...plugins, inlineWASM()],
   test: {
     include: ['src/**/*.test.?(c|m)[jt]s?(x)'],
-    retry: 3,
     globalSetup: ['./test/pg-container-setup.ts'],
     onConsoleLog(log: string) {
       if (


### PR DESCRIPTION
Keep it on the "handoff" test, which does involve some postgres asynchrony.