### PR TITLE
feat(zero-cache): http interface to the change-streamer

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.test.ts
@@ -1,0 +1,181 @@
+import {LogContext} from '@rocicorp/logger';
+import {resolver} from '@rocicorp/resolver';
+import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
+import {randInt} from 'shared/src/rand.js';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  MockedFunction,
+  test,
+  vi,
+} from 'vitest';
+import WebSocket from 'ws';
+import {Source} from 'zero-cache/src/types/streams.js';
+import {Subscription} from '../../types/subscription.js';
+import {ReplicationMessages} from '../replicator/test-utils.js';
+import {
+  ChangeStreamerHttpClient,
+  ChangeStreamerHttpServer,
+} from './change-streamer-http.js';
+import {
+  ChangeStreamer,
+  Downstream,
+  SubscriberContext,
+} from './change-streamer.js';
+
+describe('change-streamer/http', () => {
+  let lc: LogContext;
+  let downstream: Subscription<Downstream>;
+  let subscribeFn: MockedFunction<
+    (ctx: SubscriberContext) => Subscription<Downstream>
+  >;
+  let port: number;
+  let server: ChangeStreamerHttpServer;
+  let client: ChangeStreamer;
+  let connectionClosed: Promise<Downstream[]>;
+
+  beforeEach(async () => {
+    lc = createSilentLogContext();
+
+    const {promise, resolve: cleanup} = resolver<Downstream[]>();
+    connectionClosed = promise;
+    downstream = Subscription.create({cleanup});
+    subscribeFn = vi.fn();
+
+    // Run the server for real instead of using `injectWS()`, as that has a
+    // different behavior for ws.close().
+    port = 3000 + Math.floor(randInt(0, 5000));
+    server = new ChangeStreamerHttpServer(
+      lc,
+      {subscribe: subscribeFn.mockImplementation(() => downstream)},
+      {port},
+    );
+    await server.start();
+
+    client = new ChangeStreamerHttpClient(lc, port);
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  async function drain<T>(num: number, sub: Source<T>): Promise<T[]> {
+    const drained: T[] = [];
+    let i = 0;
+    for await (const msg of sub) {
+      drained.push(msg);
+      if (++i === num) {
+        break;
+      }
+    }
+    return drained;
+  }
+
+  describe('request bad requests', () => {
+    test.each([
+      ['no query', `ws://localhost:%PORT%/api/replication/v0/changes`],
+      [
+        'missing required query params',
+        `ws://localhost:%PORT%/api/replication/v0/changes?id=foo&replicaVersion=bar&initial=true`,
+      ],
+    ])('%s', async (_, url) => {
+      url = url.replace('%PORT%', String(port));
+      const {promise: result, resolve} = resolver<unknown>();
+
+      const ws = new WebSocket(url);
+      ws.on('upgrade', () => resolve('success'));
+      ws.on('error', resolve);
+
+      expect(String(await result)).toEqual(
+        'Error: Unexpected server response: 400',
+      );
+    });
+  });
+
+  test('basic messages streamed over websocket', async () => {
+    const ctx = {
+      id: 'foo',
+      replicaVersion: 'abc',
+      watermark: '123',
+      initial: true,
+    };
+    const sub = client.subscribe(ctx);
+
+    downstream.push(['begin', {tag: 'begin'}]);
+    downstream.push(['commit', {tag: 'commit'}, {watermark: '456'}]);
+
+    expect(await drain(2, sub)).toEqual([
+      ['begin', {tag: 'begin'}],
+      ['commit', {tag: 'commit'}, {watermark: '456'}],
+    ]);
+
+    // Draining the client-side subscription should cancel it, closing the
+    // websocket, which should cancel the server-side subscription.
+    expect(await connectionClosed).toEqual([]);
+
+    expect(subscribeFn).toHaveBeenCalledOnce();
+    expect(subscribeFn.mock.calls[0][0]).toEqual(ctx);
+  });
+
+  test('bigint and non-JSON fields', async () => {
+    const sub = client.subscribe({
+      id: 'foo',
+      replicaVersion: 'abc',
+      watermark: '123',
+      initial: true,
+    });
+
+    const messages = new ReplicationMessages({issues: 'id'});
+    const insert = messages.insert('issues', {
+      id: 'foo',
+      big1: BigInt(Number.MAX_SAFE_INTEGER) + 1n,
+      big2: BigInt(Number.MAX_SAFE_INTEGER) + 2n,
+      big3: BigInt(Number.MAX_SAFE_INTEGER) + 3n,
+    });
+
+    // The `parser` field in the PgOutput message is not JSON serializable
+    // (and not part of the exposed type).
+    expect(typeof insert.relation.columns[0].parser).toBe('function');
+
+    // It is automatically omitted from serialization.
+    downstream.push(['data', insert]);
+    expect(await drain(1, sub)).toMatchInlineSnapshot(`
+      [
+        [
+          "data",
+          {
+            "new": {
+              "big1": 9007199254740992n,
+              "big2": 9007199254740993n,
+              "big3": 9007199254740994n,
+              "id": "foo",
+            },
+            "relation": {
+              "columns": [
+                {
+                  "flags": 1,
+                  "name": "id",
+                  "typeMod": -1,
+                  "typeName": null,
+                  "typeOid": 23,
+                  "typeSchema": null,
+                },
+              ],
+              "keyColumns": [
+                "id",
+              ],
+              "name": "issues",
+              "relationOid": 1558331249,
+              "replicaIdentity": "default",
+              "schema": "public",
+              "tag": "relation",
+            },
+            "tag": "insert",
+          },
+        ],
+      ]
+    `);
+  });
+});

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
@@ -1,0 +1,124 @@
+import websocket from '@fastify/websocket';
+import {LogContext} from '@rocicorp/logger';
+import Fastify, {FastifyInstance, FastifyReply, FastifyRequest} from 'fastify';
+import * as v from 'shared/src/valita.js';
+import WebSocket from 'ws';
+import {jsonValueSchema} from 'zero-cache/src/types/bigint-json.js';
+import {Source, streamIn, streamOut} from 'zero-cache/src/types/streams.js';
+import {URLParams} from 'zero-cache/src/types/url-params.js';
+import {RunningState} from '../running-state.js';
+import {Service} from '../service.js';
+import {
+  ChangeStreamer,
+  Downstream,
+  SubscriberContext,
+} from './change-streamer.js';
+
+export const CHANGES_URL_PATTERN = '/api/replication/:version/changes';
+
+export type Options = {
+  port: number; // Defaults to 3001.
+};
+
+export class ChangeStreamerHttpServer implements Service {
+  readonly id = 'change-streamer-http-server';
+  readonly #lc: LogContext;
+  readonly #delegate: ChangeStreamer;
+  readonly #fastify: FastifyInstance;
+  readonly #port: number;
+  readonly #state = new RunningState(this.id);
+
+  constructor(
+    lc: LogContext,
+    delegate: ChangeStreamer,
+    opts: Partial<Options> = {},
+  ) {
+    const {port = 3001} = opts;
+
+    this.#lc = lc.withContext('component', this.id);
+    this.#delegate = delegate;
+
+    this.#fastify = Fastify();
+    this.#port = port;
+  }
+
+  // start() is used in unit tests.
+  // run() is the lifecycle method called by the ServiceRunner.
+  async start(): Promise<void> {
+    await this.#fastify.register(websocket);
+    this.#fastify.addHook('preValidation', this.#checkParams);
+    this.#fastify.get(CHANGES_URL_PATTERN, {websocket: true}, this.#subscribe);
+
+    const address = await this.#fastify.listen({port: this.#port});
+    this.#lc.info?.(`Server listening at ${address}`);
+  }
+
+  async run(): Promise<void> {
+    await this.start();
+    await this.#state.stopped();
+  }
+
+  // Avoid upgrading to a websocket if the params are bad.
+  readonly #checkParams = async (req: FastifyRequest, reply: FastifyReply) => {
+    try {
+      getSubscriberContext(req);
+    } catch (e) {
+      this.#lc.error?.('bad request', String(e));
+      await reply.code(400).send(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  readonly #subscribe = async (ws: WebSocket, req: FastifyRequest) => {
+    const ctx = getSubscriberContext(req); // #checkSubscribe guarantees this.
+    const downstream = this.#delegate.subscribe(ctx);
+    await streamOut(this.#lc, downstream, ws);
+  };
+
+  async stop(): Promise<void> {
+    await this.#fastify.close();
+    this.#state.stop(this.#lc);
+  }
+}
+
+export class ChangeStreamerHttpClient implements ChangeStreamer {
+  readonly #lc: LogContext;
+  readonly #port: number;
+
+  constructor(lc: LogContext, port = 3001) {
+    this.#lc = lc;
+    this.#port = port;
+  }
+
+  subscribe(ctx: SubscriberContext): Source<Downstream> {
+    const params = getParams(ctx);
+    const ws = new WebSocket(
+      `ws://localhost:${this.#port}` +
+        CHANGES_URL_PATTERN.replace(':version', 'v0') +
+        `?${params.toString()}`,
+    );
+
+    return streamIn(this.#lc, ws, downstreamSchema) as Source<Downstream>;
+  }
+}
+
+// TODO: Define this more precisely.
+const downstreamSchema = v.array(jsonValueSchema);
+
+function getSubscriberContext(req: FastifyRequest): SubscriberContext {
+  const url = new URL(req.url, req.headers.origin ?? 'http://localhost');
+  const params = new URLParams(url);
+
+  return {
+    id: params.get('id', true),
+    replicaVersion: params.get('replicaVersion', true),
+    watermark: params.get('watermark', true),
+    initial: params.getBoolean('initial'),
+  };
+}
+
+function getParams(ctx: SubscriberContext): URLSearchParams {
+  return new URLSearchParams({
+    ...ctx,
+    initial: ctx.initial ? 'true' : 'false',
+  });
+}


### PR DESCRIPTION
HTTP proxying implementations of the `ChangeStreamer` interface:
* server-side proxy wraps a `ChangeStreamer` delegate implementation and sends its downstream messages over a websocket
* client-side proxy makes WebSocket connections to that server and implements the `ChangeStreamer` interface

This allows Replicators to subscribe to a `ChangeStreamer` running in another process. 
* In the eventual Replication Manager design, the ReplicationManager + ChangeStreamer will be a separate AWS task.
* For Alpha, we will run a ChangeStreamer in one subprocess to which two Replicators subscribe from other subprocesses, one for `litestream replicate` and for servicing view-syncers.