### PR TITLE
feat(zero-cache): remove TASK_ID and the one-subscriber-per-id ChangeStreamer semantics

### DIFF
--- a/packages/zero-cache/src/server/config.ts
+++ b/packages/zero-cache/src/server/config.ts
@@ -2,7 +2,6 @@ import * as v from 'shared/src/valita.js';
 
 const configSchema = v.object({
   ['REPLICA_ID']: v.string(),
-  ['TASK_ID']: v.string().optional(),
   ['UPSTREAM_URI']: v.string(),
   ['CVR_DB_URI']: v.string(),
   ['CHANGE_DB_URI']: v.string(),

--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -1,3 +1,4 @@
+import {pid} from 'node:process';
 import {must} from 'shared/src/must.js';
 import {Database} from 'zqlite/src/db.js';
 import {ChangeStreamerHttpClient} from '../services/change-streamer/change-streamer-http.js';
@@ -24,7 +25,7 @@ export default async function runWorker(parent: Worker) {
 
   const replicator = new ReplicatorService(
     lc,
-    config.TASK_ID ?? 'z1', // To eventually accommodate multiple zero-caches.
+    `replicator-${pid}`,
     changeStreamer,
     replica,
     // TODO: Run two replicators: one for litestream backup and one for serving requests,

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -261,7 +261,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   subscribe(ctx: SubscriberContext): Source<Downstream> {
     const {id, watermark} = ctx;
     const downstream = Subscription.create<Downstream>({
-      cleanup: () => this.#forwarder.remove(id, subscriber),
+      cleanup: () => this.#forwarder.remove(subscriber),
     });
     const subscriber = new Subscriber(id, watermark, downstream);
     if (ctx.replicaVersion !== this.#replicaVersion) {

--- a/packages/zero-cache/src/services/change-streamer/change-streamer.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer.ts
@@ -55,10 +55,7 @@ export interface ChangeStreamer {
 
 export type SubscriberContext = {
   /**
-   * Subscriber id.
-   *
-   * Only one subscription per `id` is maintained. Old subscriptions
-   * with the same `id` will be closed.
+   * Subscriber id. This is only used for debugging.
    */
   id: string;
 


### PR DESCRIPTION
Remove the `TASK_ID` environment variable and the one-subscriber-per-id semantics in the ChangeStreamer. It adds complexity without much benefit.

The id field is kept around purely for debugging. Add the `pid` to the component name for convenience.