### PR TITLE
chore(zero-cache): fix TransactionPool error propagation

### DIFF
--- a/packages/zero-cache/src/db/transaction-pool.ts
+++ b/packages/zero-cache/src/db/transaction-pool.ts
@@ -107,14 +107,13 @@ export class TransactionPool {
    *
    * Returns {@link done()}.
    */
-  async run(db: PostgresDB): Promise<void> {
+  run(db: PostgresDB): Promise<void> {
     assert(!this.#db, 'already running');
     this.#db = db;
     for (let i = 0; i < this.#numWorkers; i++) {
       this.#addWorker(db);
     }
-    await this.done();
-    this.#lc.debug?.('transaction pool done');
+    return this.done();
   }
 
   /**
@@ -164,6 +163,7 @@ export class TransactionPool {
       // guarantees that the pool is in a terminal state and no new workers can be added.
       await Promise.all(this.#workers);
     }
+    this.#lc.debug?.('transaction pool done');
   }
 
   #addWorker(db: PostgresDB) {


### PR DESCRIPTION
Fix the perennial "unhandled error" issue that happens in tests by not throwing the error from both `TransactionPool.run()` and `TransactionPool.done()`.