### PR TITLE
fix(zbugs, zql): Various minor things:

### DIFF
--- a/apps/zbugs/src/pages/issue/issue-page.tsx
+++ b/apps/zbugs/src/pages/issue/issue-page.tsx
@@ -22,7 +22,7 @@ export default function IssuePage() {
   // todo: one should be in the schema
   const q = z.query.issue
     .where('id', params?.id ?? '')
-    .related('creator')
+    .related('creator', creator => creator.one())
     .related('labels')
     .related('comments', comments =>
       comments
@@ -53,6 +53,12 @@ export default function IssuePage() {
   // a 404 here. We can't put the 404 here now because it would flash until we
   // get data.
   if (!issue) {
+    return null;
+  }
+
+  // TODO: This check goes away once Zero's consistency model is implemented.
+  // The query above should not be able to return an incomplete result.
+  if (!issue.creator) {
     return null;
   }
 
@@ -146,7 +152,7 @@ export default function IssuePage() {
         <div className="sidebar-item">
           <p className="issue-detail-label">Creator</p>
           <button className="sidebar-button issue-creator">
-            {issue.creator[0].name}
+            {issue.creator.name}
           </button>
         </div>
 

--- a/apps/zbugs/src/pages/list/list-page.tsx
+++ b/apps/zbugs/src/pages/list/list-page.tsx
@@ -89,7 +89,9 @@ export default function ListPage() {
               <td align="right">
                 <div className="issue-taglist">
                   {issue.labels.map(label => (
-                    <span className="label-item">{label.name}</span>
+                    <span key={label.id} className="label-item">
+                      {label.name}
+                    </span>
                   ))}
                 </div>
               </td>

--- a/packages/zql/src/zql/ivm/array-view.ts
+++ b/packages/zql/src/zql/ivm/array-view.ts
@@ -249,19 +249,25 @@ function applyChange(
       const childSchema = must(
         schema.relationships[change.child.relationshipName],
       );
+      const childFormat = must(
+        format.relationships[change.child.relationshipName],
+      );
       applyChange(
         existing,
         change.child.change,
         childSchema,
         change.child.relationshipName,
-        format,
+        childFormat,
       );
       break;
     }
     case 'edit': {
       if (singular) {
         assertObject(parentEntry[relationship]);
-        parentEntry[relationship] = change.row;
+        parentEntry[relationship] = {
+          ...parentEntry[relationship],
+          ...change.row,
+        };
       } else {
         assertArray(parentEntry[relationship]);
         const view = parentEntry[relationship];


### PR DESCRIPTION
1. Due to lack of subquery consistency, issue.creator can be null. We should fix this by making sure type of subqueries is |undefined. Note that even with subquery consistency this can technically happen because Zero does not guarantee foreign key consistency.

2. Use key on label pills to avoid React complaining.

3. Pass down childFormat in case of child change.

4. Preserve relationships in case of singular edit change.

1, 3, and 4 all need follow up work plus tests, but this unbreaks the UI. I will do more work on it this weekend.