### PR TITLE
feat(zql): support parameters in the query builder

### DIFF
--- a/packages/zero-protocol/src/ast.ts
+++ b/packages/zero-protocol/src/ast.ts
@@ -62,24 +62,15 @@ export const simpleConditionSchema = v.object({
     v.number(),
     v.boolean(),
     readonly(v.array(v.union(v.string(), v.number(), v.boolean()))),
+    v.object({
+      type: v.literal('static'),
+      anchor: v.union(v.literal('authData'), v.literal('preMutationRow')),
+      field: v.string(),
+    }),
   ),
 });
 
-export const parameterizedConditionSchema = v.object({
-  type: v.literal('parameterized'),
-  op: simpleOperatorSchema,
-  field: selectorSchema,
-  value: v.object({
-    type: v.literal('static'),
-    anchor: v.union(v.literal('authData'), v.literal('preMutationRow')),
-    field: v.string(),
-  }),
-});
-
-export const conditionSchema = v.union(
-  simpleConditionSchema,
-  parameterizedConditionSchema,
-);
+export const conditionSchema = simpleConditionSchema;
 
 // Split out so that its inferred type can be checked against
 // Omit<CorrelatedSubQuery, 'correlation'> in ast-type-test.ts.

--- a/packages/zql/src/zql/ast/ast.ts
+++ b/packages/zql/src/zql/ast/ast.ts
@@ -68,7 +68,7 @@ export type CorrelatedSubQuery = {
  * ivm1 supports Conjunctions and Disjunctions.
  * We'll support them in the future.
  */
-export type Condition = SimpleCondition | ParameterizedCondition;
+export type Condition = SimpleCondition;
 export type SimpleCondition = {
   type: 'simple';
   op: SimpleOperator;
@@ -84,15 +84,13 @@ export type SimpleCondition = {
    * `null` is absent since we do not have an `IS` or `IS NOT`
    * operator defined and `null != null` in SQL.
    */
-  value: string | number | boolean | ReadonlyArray<string | number | boolean>;
+  value:
+    | string
+    | number
+    | boolean
+    | ReadonlyArray<string | number | boolean>
+    | Parameter;
 };
-export type ParameterizedCondition = {
-  type: 'parameterized';
-  op: SimpleOperator;
-  field: string;
-  value: Parameter;
-};
-
 /**
  * A parameter is a value that is not known at the time the query is written
  * and is resolved at runtime.
@@ -110,7 +108,7 @@ export type ParameterizedCondition = {
  * AncestorParameters refer to rows encountered while running the query.
  * They are used by subqueries to refer to rows emitted by parent queries.
  */
-type Parameter = StaticParameter;
+export type Parameter = StaticParameter;
 type StaticParameter = {
   type: 'static';
   // The "namespace" of the injected parameter.

--- a/packages/zql/src/zql/builder/filter.test.ts
+++ b/packages/zql/src/zql/builder/filter.test.ts
@@ -61,7 +61,7 @@ test('basics', () => {
         expect(predicate({foo: a})).toBe(eval(`a ${jsOp} b`));
 
         const parameterizedCondition = {
-          type: 'parameterized',
+          type: 'simple',
           field: 'foo',
           op: op as SimpleOperator,
           value: {type: 'static', anchor: 'authData', field: 'bar'},

--- a/packages/zql/src/zql/builder/filter.ts
+++ b/packages/zql/src/zql/builder/filter.ts
@@ -3,6 +3,7 @@ import {SimpleOperator, Condition} from '../ast/ast.js';
 import {Row, Value} from '../ivm/data.js';
 import {getLikePredicate} from './like.js';
 import {StaticQueryParameters} from './builder.js';
+import {Parameter} from '../ast/ast.js';
 
 export type NonNullValue = Exclude<Value, null | undefined>;
 export type SimplePredicate = (rhs: NonNullValue) => boolean;
@@ -11,44 +12,38 @@ export function createPredicate(
   condition: Condition,
   staticQueryParameters: StaticQueryParameters | undefined,
 ) {
-  switch (condition.type) {
-    case 'simple': {
-      const impl = createPredicateImpl(condition.value, condition.op);
-      return (row: Row) => {
-        const lhs = row[condition.field];
-        if (lhs === null || lhs === undefined) {
-          return false;
-        }
-        return impl(lhs);
-      };
-    }
-    case 'parameterized': {
-      assert(
-        staticQueryParameters !== undefined,
-        'Got a parameterized condition but no staticQueryParameters',
-      );
-      const anchor = staticQueryParameters[condition.value.anchor];
-      assert(
-        anchor !== undefined,
-        `Missing parameter: ${condition.value.anchor}`,
-      );
-      const value = anchor[condition.value.field];
-      const impl = createPredicateImpl(
-        value as NonNullValue | readonly NonNullValue[],
-        condition.op,
-      );
-      return (row: Row) => {
-        const lhs = row[condition.field];
-        if (lhs === null || lhs === undefined) {
-          return false;
-        }
-        return impl(lhs);
-      };
-    }
-    default:
-      condition satisfies never;
-      throw new Error(`Unexpected condition type: ${condition}`);
+  const {value} = condition;
+  if (isParameter(value)) {
+    assert(
+      staticQueryParameters !== undefined,
+      'Got a parameterized condition but no staticQueryParameters',
+    );
+    const anchor = staticQueryParameters[value.anchor];
+    assert(anchor !== undefined, `Missing parameter: ${value.anchor}`);
+    const impl = createPredicateImpl(
+      anchor[value.field] as NonNullValue | readonly NonNullValue[],
+      condition.op,
+    );
+    return (row: Row) => {
+      const lhs = row[condition.field];
+      if (lhs === null || lhs === undefined) {
+        return false;
+      }
+      return impl(lhs);
+    };
   }
+  const impl = createPredicateImpl(value, condition.op);
+  return (row: Row) => {
+    const lhs = row[condition.field];
+    if (lhs === null || lhs === undefined) {
+      return false;
+    }
+    return impl(lhs);
+  };
+}
+
+function isParameter(value: unknown): value is Parameter {
+  return typeof value === 'object' && value !== null && 'type' in value;
 }
 
 function createPredicateImpl(

--- a/packages/zql/src/zql/query/query-impl.ts
+++ b/packages/zql/src/zql/query/query-impl.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {assert} from 'shared/src/asserts.js';
 import {AST, Ordering} from '../ast/ast.js';
@@ -11,6 +12,7 @@ import {
   GetFieldTypeNoNullOrUndefined,
   MakeSingular,
   Operator,
+  Parameter,
   Query,
   QueryType,
   SchemaToRow,
@@ -46,6 +48,17 @@ export type CommitListener = () => void;
 export interface QueryDelegate extends BuilderDelegate {
   addServerQuery(ast: AST): () => void;
   onTransactionCommit(cb: CommitListener): () => void;
+}
+
+export function staticParam<TAnchor, TField extends keyof TAnchor>(
+  anchorClass: 'authData' | 'preMutationRow',
+  field: TField,
+): Parameter<TAnchor, TField, TAnchor[TField]> {
+  return {
+    type: 'static',
+    anchor: anchorClass,
+    field,
+  };
 }
 
 export abstract class AbstractQuery<
@@ -227,20 +240,19 @@ export abstract class AbstractQuery<
     throw new Error(`Invalid relationship ${relationship as string}`);
   }
 
-  where<TSelector extends Selector<TSchema>>(
-    field: TSelector,
+  where(
+    field: any,
     opOrValue:
       | Operator
-      | GetFieldTypeNoNullOrUndefined<TSchema, TSelector, Operator>,
-    value?: GetFieldTypeNoNullOrUndefined<TSchema, TSelector, Operator>,
+      | GetFieldTypeNoNullOrUndefined<any, any, any>
+      | Parameter<any, any, any>,
+    value?:
+      | GetFieldTypeNoNullOrUndefined<any, any, any>
+      | Parameter<any, any, any>,
   ): Query<TSchema, TReturn> {
     let op: Operator;
     if (value === undefined) {
-      value = opOrValue as GetFieldTypeNoNullOrUndefined<
-        TSchema,
-        TSelector,
-        Operator
-      >;
+      value = opOrValue;
       op = '=';
     } else {
       op = opOrValue as Operator;

--- a/packages/zql/src/zql/query/query.test.ts
+++ b/packages/zql/src/zql/query/query.test.ts
@@ -2,6 +2,7 @@
 import {describe, expectTypeOf, test} from 'vitest';
 import {Query} from './query.js';
 import {Schema} from './schema.js';
+import {staticParam} from './query-impl.js';
 
 const mockQuery = {
   select() {
@@ -333,6 +334,18 @@ describe('types', () => {
         b: boolean;
       }>
     >();
+  });
+
+  test('where-parameters', () => {
+    type AuthData = {
+      aud: string;
+    };
+    const query = mockQuery as unknown as Query<TestSchema>;
+
+    query.where('s', '=', staticParam<AuthData, 'aud'>('authData', 'aud'));
+
+    const p = staticParam<AuthData, 'aud'>('authData', 'aud');
+    query.where('b', '=', p);
   });
 
   test('where-optional-op', () => {

--- a/packages/zql/src/zql/query/query.ts
+++ b/packages/zql/src/zql/query/query.ts
@@ -165,6 +165,13 @@ export type DefaultQueryResultRow<TSchema extends Schema> = {
 /** Expands/simplifies */
 type Expand<T> = T extends infer O ? {[K in keyof O]: O[K]} : never;
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export type Parameter<T, TField extends keyof T, _TReturn = T[TField]> = {
+  type: 'static';
+  anchor: 'authData' | 'preMutationRow';
+  field: TField;
+};
+
 export interface Query<
   TSchema extends Schema,
   TReturn extends QueryType = DefaultQueryResultRow<TSchema>,
@@ -209,6 +216,36 @@ export interface Query<
   where<TSelector extends Selector<TSchema>>(
     field: TSelector,
     value: GetFieldTypeNoNullOrUndefined<TSchema, TSelector, '='>,
+  ): Query<TSchema, TReturn>;
+
+  where<
+    TSelector extends Selector<TSchema>,
+    TOperator extends Operator,
+    TParamAnchor,
+    TParamField extends keyof TParamAnchor,
+    TParamTypeBound extends GetFieldTypeNoNullOrUndefined<
+      TSchema,
+      TSelector,
+      TOperator
+    >,
+  >(
+    field: TSelector,
+    op: TOperator,
+    value: Parameter<TParamAnchor, TParamField, TParamTypeBound>,
+  ): Query<TSchema, TReturn>;
+
+  where<
+    TSelector extends Selector<TSchema>,
+    TParamAnchor,
+    TParamField extends keyof TParamAnchor,
+    TParamTypeBound extends GetFieldTypeNoNullOrUndefined<
+      TSchema,
+      TSelector,
+      '='
+    >,
+  >(
+    field: TSelector,
+    value: Parameter<TParamAnchor, TParamField, TParamTypeBound>,
   ): Query<TSchema, TReturn>;
 
   start(


### PR DESCRIPTION
So we can do queries of the form:

```ts
z.issue.where('ownerID', '=', authData.aud)
```

or

```ts
z.issue.sub((iq) => z.comment.where('issueID', '=', iq.id))
```

rather than always requiring the right hand side of the `where` to be a value.