### PR TITLE
feat(zero-cache): pass Row and AuthData references to authz rules

### DIFF
--- a/apps/zbugs/zero.config.ts
+++ b/apps/zbugs/zero.config.ts
@@ -4,10 +4,10 @@ import {defineConfig, Queries} from 'zero-cache/src/config/define-config.js';
 import {must} from 'shared/src/must';
 import {Schema, schema} from './src/domain/schema-shared';
 
-type AuthData = {aud: string};
+type AuthData = {sub: string};
 
 const allowIfCrewMember = (queries: Queries<Schema>) => (authData: AuthData) =>
-  queries.user.where('id', '=', authData.aud).where('role', '=', 'crew');
+  queries.user.where('id', '=', authData.sub).where('role', '=', 'crew');
 
 defineConfig<AuthData, Schema>(schema, queries => ({
   upstreamUri: must(process.env.UPSTREAM_URI),
@@ -38,7 +38,7 @@ defineConfig<AuthData, Schema>(schema, queries => ({
           (authData, row) =>
             queries.issue
               .where('id', '=', row.id)
-              .where('creatorID', '=', authData.aud),
+              .where('creatorID', '=', authData.sub),
           allowIfCrewMember(queries),
         ],
       },
@@ -50,7 +50,7 @@ defineConfig<AuthData, Schema>(schema, queries => ({
           (authData, row) =>
             queries.comment
               .where('id', '=', row.id)
-              .where('creatorID', '=', authData.aud),
+              .where('creatorID', '=', authData.sub),
         ],
       },
     },

--- a/packages/zero-cache/src/config/__snapshots__/define-config.test.ts.snap
+++ b/packages/zero-cache/src/config/__snapshots__/define-config.test.ts.snap
@@ -1,0 +1,456 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`instance authorization rules 1`] = `
+"{
+  "upstreamUri": "",
+  "cvrDbUri": "",
+  "changeDbUri": "",
+  "replicaDbFile": "",
+  "replicaId": "",
+  "log": {
+    "level": "info"
+  },
+  "authorization": {
+    "issue": {
+      "row": {
+        "update": [
+          [
+            "allow",
+            {
+              "table": "issue",
+              "where": [
+                {
+                  "type": "simple",
+                  "op": "=",
+                  "field": "id",
+                  "value": {
+                    "type": "static",
+                    "anchor": "preMutationRow",
+                    "field": "id"
+                  }
+                },
+                {
+                  "type": "simple",
+                  "op": "=",
+                  "field": "creatorID",
+                  "value": {
+                    "type": "static",
+                    "anchor": "authData",
+                    "field": "sub"
+                  }
+                }
+              ]
+            }
+          ],
+          [
+            "allow",
+            {
+              "table": "user",
+              "where": [
+                {
+                  "type": "simple",
+                  "op": "=",
+                  "field": "id",
+                  "value": {
+                    "type": "static",
+                    "anchor": "authData",
+                    "field": "sub"
+                  }
+                },
+                {
+                  "type": "simple",
+                  "op": "=",
+                  "field": "role",
+                  "value": "crew"
+                }
+              ]
+            }
+          ]
+        ]
+      }
+    },
+    "comment": {
+      "row": {
+        "update": [
+          [
+            "allow",
+            {
+              "table": "comment",
+              "where": [
+                {
+                  "type": "simple",
+                  "op": "=",
+                  "field": "id",
+                  "value": {
+                    "type": "static",
+                    "anchor": "preMutationRow",
+                    "field": "id"
+                  }
+                },
+                {
+                  "type": "simple",
+                  "op": "=",
+                  "field": "creatorID",
+                  "value": {
+                    "type": "static",
+                    "anchor": "authData",
+                    "field": "sub"
+                  }
+                }
+              ]
+            }
+          ]
+        ]
+      },
+      "cell": {
+        "creatorID": {
+          "update": [
+            [
+              "allow",
+              {
+                "table": "user",
+                "where": [
+                  {
+                    "type": "simple",
+                    "op": "=",
+                    "field": "id",
+                    "value": {
+                      "type": "static",
+                      "anchor": "authData",
+                      "field": "sub"
+                    }
+                  },
+                  {
+                    "type": "simple",
+                    "op": "=",
+                    "field": "role",
+                    "value": "crew"
+                  }
+                ]
+              }
+            ]
+          ]
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`static authorization rules 1`] = `
+"{
+  "upstreamUri": "",
+  "cvrDbUri": "",
+  "changeDbUri": "",
+  "replicaDbFile": "",
+  "replicaId": "",
+  "log": {
+    "level": "info"
+  },
+  "authorization": {
+    "user": {
+      "table": {
+        "select": [
+          [
+            "allow",
+            {
+              "table": "user"
+            }
+          ]
+        ],
+        "insert": [
+          [
+            "allow",
+            {
+              "table": "user"
+            }
+          ]
+        ],
+        "update": [
+          [
+            "allow",
+            {
+              "table": "user"
+            }
+          ]
+        ],
+        "delete": [
+          [
+            "allow",
+            {
+              "table": "user"
+            }
+          ]
+        ]
+      },
+      "column": {
+        "id": {
+          "select": [
+            [
+              "allow",
+              {
+                "table": "user"
+              }
+            ]
+          ],
+          "insert": [
+            [
+              "allow",
+              {
+                "table": "user"
+              }
+            ]
+          ],
+          "update": [
+            [
+              "allow",
+              {
+                "table": "user"
+              }
+            ]
+          ],
+          "delete": [
+            [
+              "allow",
+              {
+                "table": "user"
+              }
+            ]
+          ]
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`static authorization rules 2`] = `
+"{
+  "upstreamUri": "",
+  "cvrDbUri": "",
+  "changeDbUri": "",
+  "replicaDbFile": "",
+  "replicaId": "",
+  "log": {
+    "level": "info"
+  },
+  "authorization": {
+    "user": {
+      "table": {
+        "select": [
+          [
+            "allow",
+            {
+              "table": "user",
+              "where": [
+                {
+                  "type": "simple",
+                  "op": "=",
+                  "field": "id",
+                  "value": {
+                    "type": "static",
+                    "anchor": "authData",
+                    "field": "sub"
+                  }
+                },
+                {
+                  "type": "simple",
+                  "op": "=",
+                  "field": "role",
+                  "value": "crew"
+                }
+              ]
+            }
+          ]
+        ],
+        "insert": [
+          [
+            "allow",
+            {
+              "table": "user",
+              "where": [
+                {
+                  "type": "simple",
+                  "op": "=",
+                  "field": "id",
+                  "value": {
+                    "type": "static",
+                    "anchor": "authData",
+                    "field": "sub"
+                  }
+                },
+                {
+                  "type": "simple",
+                  "op": "=",
+                  "field": "role",
+                  "value": "crew"
+                }
+              ]
+            }
+          ]
+        ],
+        "update": [
+          [
+            "allow",
+            {
+              "table": "user",
+              "where": [
+                {
+                  "type": "simple",
+                  "op": "=",
+                  "field": "id",
+                  "value": {
+                    "type": "static",
+                    "anchor": "authData",
+                    "field": "sub"
+                  }
+                },
+                {
+                  "type": "simple",
+                  "op": "=",
+                  "field": "role",
+                  "value": "crew"
+                }
+              ]
+            }
+          ]
+        ],
+        "delete": [
+          [
+            "allow",
+            {
+              "table": "user",
+              "where": [
+                {
+                  "type": "simple",
+                  "op": "=",
+                  "field": "id",
+                  "value": {
+                    "type": "static",
+                    "anchor": "authData",
+                    "field": "sub"
+                  }
+                },
+                {
+                  "type": "simple",
+                  "op": "=",
+                  "field": "role",
+                  "value": "crew"
+                }
+              ]
+            }
+          ]
+        ]
+      },
+      "column": {
+        "login": {
+          "select": [
+            [
+              "allow",
+              {
+                "table": "user",
+                "where": [
+                  {
+                    "type": "simple",
+                    "op": "=",
+                    "field": "id",
+                    "value": {
+                      "type": "static",
+                      "anchor": "authData",
+                      "field": "sub"
+                    }
+                  },
+                  {
+                    "type": "simple",
+                    "op": "=",
+                    "field": "role",
+                    "value": "crew"
+                  }
+                ]
+              }
+            ]
+          ],
+          "insert": [
+            [
+              "allow",
+              {
+                "table": "user",
+                "where": [
+                  {
+                    "type": "simple",
+                    "op": "=",
+                    "field": "id",
+                    "value": {
+                      "type": "static",
+                      "anchor": "authData",
+                      "field": "sub"
+                    }
+                  },
+                  {
+                    "type": "simple",
+                    "op": "=",
+                    "field": "role",
+                    "value": "crew"
+                  }
+                ]
+              }
+            ]
+          ],
+          "update": [
+            [
+              "allow",
+              {
+                "table": "user",
+                "where": [
+                  {
+                    "type": "simple",
+                    "op": "=",
+                    "field": "id",
+                    "value": {
+                      "type": "static",
+                      "anchor": "authData",
+                      "field": "sub"
+                    }
+                  },
+                  {
+                    "type": "simple",
+                    "op": "=",
+                    "field": "role",
+                    "value": "crew"
+                  }
+                ]
+              }
+            ]
+          ],
+          "delete": [
+            [
+              "allow",
+              {
+                "table": "user",
+                "where": [
+                  {
+                    "type": "simple",
+                    "op": "=",
+                    "field": "id",
+                    "value": {
+                      "type": "static",
+                      "anchor": "authData",
+                      "field": "sub"
+                    }
+                  },
+                  {
+                    "type": "simple",
+                    "op": "=",
+                    "field": "role",
+                    "value": "crew"
+                  }
+                ]
+              }
+            ]
+          ]
+        }
+      }
+    }
+  }
+}"
+`;

--- a/packages/zero-cache/src/config/config-query.ts
+++ b/packages/zero-cache/src/config/config-query.ts
@@ -30,10 +30,6 @@ export class ConfigQuery<
     return new ConfigQuery(schema, ast, format);
   }
 
-  get ast() {
-    return this._completeAst();
-  }
-
   materialize(): TypedView<Smash<TReturn>> {
     throw new Error('ConfigQuery cannot be materialized');
   }

--- a/packages/zero-cache/src/config/define-config.test.ts
+++ b/packages/zero-cache/src/config/define-config.test.ts
@@ -1,0 +1,259 @@
+import {vi, test, expect, beforeEach, MockInstance} from 'vitest';
+import fs from 'fs';
+import {defineConfig, Queries} from './define-config.js';
+import {afterEach} from 'node:test';
+
+type AuthData = {sub: string};
+
+const userSchema = {
+  tableName: 'user',
+  columns: {
+    id: {type: 'string'},
+    login: {type: 'string'},
+    name: {type: 'string'},
+    avatar: {type: 'string'},
+    role: {type: 'string'},
+  },
+  primaryKey: ['id'],
+  relationships: {},
+} as const;
+
+const issueSchema = {
+  tableName: 'issue',
+  columns: {
+    id: {type: 'string'},
+    title: {type: 'string'},
+    open: {type: 'boolean'},
+    modified: {type: 'number'},
+    created: {type: 'number'},
+    creatorID: {type: 'string'},
+    description: {type: 'string'},
+    labelIDs: {type: 'string'},
+  },
+  primaryKey: ['id'],
+  relationships: {
+    labels: {
+      source: 'id',
+      junction: {
+        schema: () => issueLabelSchema,
+        sourceField: 'issueID',
+        destField: 'labelID',
+      },
+      dest: {
+        field: 'id',
+        schema: () => labelSchema,
+      },
+    },
+    comments: {
+      source: 'id',
+      dest: {
+        field: 'issueID',
+        schema: () => commentSchema,
+      },
+    },
+    creator: {
+      source: 'creatorID',
+      dest: {
+        field: 'id',
+        schema: () => userSchema,
+      },
+    },
+  },
+} as const;
+
+const commentSchema = {
+  tableName: 'comment',
+  columns: {
+    id: {type: 'string'},
+    issueID: {type: 'string'},
+    created: {type: 'number'},
+    body: {type: 'string'},
+    creatorID: {type: 'string'},
+  },
+  primaryKey: ['id'],
+  relationships: {
+    creator: {
+      source: 'creatorID',
+      dest: {
+        field: 'id',
+        schema: () => userSchema,
+      },
+    },
+  },
+} as const;
+
+const labelSchema = {
+  tableName: 'label',
+  columns: {
+    id: {type: 'string'},
+    name: {type: 'string'},
+  },
+  primaryKey: ['id'],
+  relationships: {},
+} as const;
+
+const issueLabelSchema = {
+  tableName: 'issueLabel',
+  columns: {
+    id: {type: 'string'},
+    issueID: {type: 'string'},
+    labelID: {type: 'string'},
+  },
+  primaryKey: ['id'],
+  relationships: {},
+} as const;
+
+export const schema = {
+  user: userSchema,
+  issue: issueSchema,
+  comment: commentSchema,
+  label: labelSchema,
+  issueLabel: issueLabelSchema,
+} as const;
+
+const baseConfig = {
+  upstreamUri: '',
+  cvrDbUri: '',
+  changeDbUri: '',
+  replicaDbFile: '',
+  replicaId: '',
+  log: {
+    level: 'info',
+  },
+} as const;
+
+let writeFileSyncMock: MockInstance;
+beforeEach(() => {
+  writeFileSyncMock = vi
+    .spyOn(fs, 'writeFileSync')
+    .mockImplementation(() => {});
+});
+
+afterEach(() => {
+  writeFileSyncMock.mockRestore();
+});
+
+test('static authorization rules', () => {
+  const config = {
+    ...baseConfig,
+    authorization: {
+      user: {
+        table: {
+          select: [],
+          insert: [],
+          update: [],
+          delete: [],
+        },
+        column: {
+          id: {
+            select: [],
+            insert: [],
+            update: [],
+            delete: [],
+          },
+        },
+      },
+    },
+  };
+  defineConfig(schema, () => config);
+
+  expect(writeFileSyncMock.mock.calls[0][1]).toEqual(
+    JSON.stringify(config, null, 2),
+  );
+
+  defineConfig(schema, queries => ({
+    ...baseConfig,
+    authorization: {
+      user: {
+        table: {
+          select: [() => queries.user],
+          insert: [() => queries.user],
+          update: [() => queries.user],
+          delete: [() => queries.user],
+        },
+        column: {
+          id: {
+            select: [() => queries.user],
+            insert: [() => queries.user],
+            update: [() => queries.user],
+            delete: [() => queries.user],
+          },
+        },
+      },
+    },
+  }));
+
+  expect(writeFileSyncMock.mock.calls[1][1]).toMatchSnapshot();
+
+  const policy = (queries: Queries<typeof schema>) => [
+    (authData: AuthData) =>
+      queries.user.where('id', '=', authData.sub).where('role', '=', 'crew'),
+  ];
+  defineConfig<AuthData, typeof schema>(schema, queries => ({
+    ...baseConfig,
+    authorization: {
+      user: {
+        table: {
+          select: policy(queries),
+          insert: policy(queries),
+          update: policy(queries),
+          delete: policy(queries),
+        },
+        column: {
+          login: {
+            select: policy(queries),
+            insert: policy(queries),
+            update: policy(queries),
+            delete: policy(queries),
+          },
+        },
+      },
+    },
+  }));
+
+  expect(writeFileSyncMock.mock.calls[2][1]).toMatchSnapshot();
+});
+
+test('instance authorization rules', () => {
+  defineConfig<AuthData, typeof schema>(schema, queries => ({
+    ...baseConfig,
+    authorization: {
+      issue: {
+        row: {
+          update: [
+            (authData, row) =>
+              queries.issue
+                .where('id', '=', row.id)
+                .where('creatorID', '=', authData.sub),
+            (authData, _row) =>
+              queries.user
+                .where('id', '=', authData.sub)
+                .where('role', '=', 'crew'),
+          ],
+        },
+      },
+      comment: {
+        row: {
+          update: [
+            (authData, row) =>
+              queries.comment
+                .where('id', '=', row.id)
+                .where('creatorID', '=', authData.sub),
+          ],
+        },
+        cell: {
+          creatorID: {
+            update: [
+              (authData, _row) =>
+                queries.user
+                  .where('id', '=', authData.sub)
+                  .where('role', '=', 'crew'),
+            ],
+          },
+        },
+      },
+    },
+  }));
+
+  expect(writeFileSyncMock.mock.calls[0][1]).toMatchSnapshot();
+});

--- a/packages/zero-cache/src/config/refs.ts
+++ b/packages/zero-cache/src/config/refs.ts
@@ -1,0 +1,21 @@
+import {staticParam} from 'zql/src/zql/query/query-impl.js';
+
+export const authDataRef = new Proxy(
+  {},
+  {
+    get(_target, prop, _receiver) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return staticParam<any, any>('authData', prop as string);
+    },
+  },
+);
+
+export const preMutationRowRef = new Proxy(
+  {},
+  {
+    get(_target, prop, _receiver) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return staticParam<any, any>('preMutationRow', prop as string);
+    },
+  },
+);


### PR DESCRIPTION
Authorization rules need access to the execution context to do anything meaningful.

E.g., the login state, the row being mutated or read.

- `AuthDataRef` allows users to write queries against `AuthData` in their config and access that data at runtime.
- `RowRef` allows users to write queries against the row being mutated or read

Below is a policy to allow the creator of the issue or a roci crew member to update an issue. This policy leverages both `AuthDataRef` and `RowRef` --
![CleanShot 2024-09-25 at 13 48 45](https://github.com/user-attachments/assets/09550ce1-3ca8-4c69-9e6d-6683fa083011)

`authData` and `row` allow the user to access the properties of these items which are filled in at the runtime of the query.
