### PR TITLE
feat(zero-cache): make the index def query independent of the tables query

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/pg/tables/create.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/tables/create.test.ts
@@ -376,14 +376,12 @@ describe('tables/create', () => {
         await db.unsafe(createStatement);
 
         const published = await getPublicationInfo(db);
-        expect(published.tables).toEqual(
-          expect.arrayContaining([
-            {
-              ...(c.dstTableSpec ?? c.srcTableSpec),
-              publications: {['zero_all']: {rowFilter: null}},
-            },
-          ]),
-        );
+        expect(published.tables).toEqual([
+          {
+            ...(c.dstTableSpec ?? c.srcTableSpec),
+            publications: {['zero_all']: {rowFilter: null}},
+          },
+        ]);
       });
     }
   });


### PR DESCRIPTION
Rework the index definitions query to use the same criteria for inclusion, i.e. only including tables that are published by a `zero_`-prefixed publication. The main motivation is to allow this query to be run independently of the tables query, which will be helpful when looking up the information in response to `CREATE INDEX` event triggers. There's a small added benefit in allowing the query to be shipped in the same compound query to PG, eliminating one round trip (though this is not a code path that is executed often). 

Also add an extra `join` parameter (empty by default) that will be used when generating the event trigger function code for refining the tables / indexes returned by the queries.