### PR TITLE
feat(zero-cache): increase `busy_timeout` on backup replica to 10 sec

### DIFF
--- a/packages/zero-cache/src/workers/replicator.ts
+++ b/packages/zero-cache/src/workers/replicator.ts
@@ -42,7 +42,11 @@ export function setupReplicaAndCheckpointer(
   // In 'backup' mode, litestream is replicating the file, and
   // locks it to perform its backups and checkpoints.
   if (mode === 'backup') {
-    replica.pragma('busy_timeout = 5000'); // https://litestream.io/tips/#busy-timeout
+    // The official docs recommend a 5 second timeout
+    // (https://litestream.io/tips/#busy-timeout), but since this is
+    // an isolated backup replica, we can wait longer to achieve
+    // higher write throughput.
+    replica.pragma('busy_timeout = 10000');
     return {replica, checkpointer: NULL_CHECKPOINTER};
   }
 


### PR DESCRIPTION
Load tests hit this timeout at 100 connections. 

<img width="2372" alt="Screenshot 2024-09-27 at 16 28 18" src="https://github.com/user-attachments/assets/82a688eb-627e-4842-a7a4-9f8f29ea8bd8">

Bumping it up to see if or how much in increases capacity.