### PR TITLE
fix(zero-client): Fix worker test

### DIFF
--- a/packages/zero-client/src/client/worker-test.ts
+++ b/packages/zero-client/src/client/worker-test.ts
@@ -24,6 +24,9 @@ onmessage = async (e: MessageEvent) => {
   }
 };
 
+// Tell the main thread that we're ready to receive messages.
+postMessage('ready');
+
 async function testBasics(userID: string) {
   console.log('testBasics', WebSocket, version);
 

--- a/packages/zero-client/src/client/worker.test.ts
+++ b/packages/zero-client/src/client/worker.test.ts
@@ -4,6 +4,9 @@ import {expect, test} from 'vitest';
 test('worker test', async () => {
   const url = new URL('./worker-test.ts', import.meta.url);
   const w = new Worker(url, {type: 'module'});
+  // Wait for the worker "test harness" to be ready since it may have async
+  // modules.
+  await waitForReady(w);
   const userID = 'worker-test-user-id';
   const data = await send(w, {userID});
   if (data !== undefined) {
@@ -11,6 +14,19 @@ test('worker test', async () => {
   }
   expect(data).to.be.undefined;
 });
+
+function waitForReady(w: Worker): Promise<void> {
+  const p = new Promise<void>((resolve, reject) => {
+    w.onmessage = e => {
+      if (e.data === 'ready') {
+        resolve();
+      } else {
+        reject(new Error('Unexpected message: ' + e.data));
+      }
+    };
+  });
+  return withTimeout<void>(p);
+}
 
 function send(w: Worker, data: {userID: string}): Promise<unknown> {
   const p = new Promise((resolve, reject) => {


### PR DESCRIPTION
The #2480 introduced async modules which broke the worker test.

The reason it broke is because the worker was not ready to accept the message by the time the test was sending it.

Add a "ready" handshake to the worker to ensure it is ready to accept messages.