### PR TITLE
fix(replicache-perf): build command was wrong

### DIFF
--- a/.github/workflows/perf-smoke.yml
+++ b/.github/workflows/perf-smoke.yml
@@ -25,9 +25,6 @@ jobs:
       - name: Install Playwright Deps
         run: npx playwright install --with-deps
 
-      - run: npm run build
-        working-directory: packages/replicache-perf
-
       - name: Run benchmark
         working-directory: packages/replicache-perf
         run: |

--- a/packages/replicache-perf/package.json
+++ b/packages/replicache-perf/package.json
@@ -6,7 +6,7 @@
     "check-types": "tsc --noEmit",
     "lint": "eslint --ext .ts,.tsx,.js,.jsx src/",
     "build": "node tool/build.js",
-    "perf": "npm run build && node src/runner.js"
+    "perf": "npm run build && node out/runner.js"
   },
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
The `npm run perf` command was invoking the wrong file