### PR TITLE
feat(zero-cache): decode auth token on connect

### DIFF
--- a/apps/zbugs/package.json
+++ b/apps/zbugs/package.json
@@ -20,7 +20,7 @@
     "@schickling/fps-meter": "^0.1.2",
     "classnames": "^2.5.1",
     "fastify": "^5.0.0",
-    "jose": "^5.9.2",
+    "jose": "^5.9.3",
     "nanoid": "^4.0.2",
     "postgres": "^3.4.4",
     "react": ">=16.0 <19.0",

--- a/apps/zbugs/src/jwt.ts
+++ b/apps/zbugs/src/jwt.ts
@@ -1,14 +1,10 @@
 import {decodeJwt} from 'jose';
 
 export function getJwt() {
-  const cookies = document.cookie.split(';');
-  const jwtCookie = cookies.find(cookie => cookie.trim().startsWith('jwt='));
-
-  if (!jwtCookie) {
+  const token = getRawJwt();
+  if (!token) {
     return undefined;
   }
-
-  const token = jwtCookie.split('=')[1].trim();
   const payload = decodeJwt(token);
   const currentTime = Math.floor(Date.now() / 1000);
   if (payload.exp && payload.exp < currentTime) {
@@ -16,6 +12,17 @@ export function getJwt() {
   }
 
   return payload;
+}
+
+export function getRawJwt() {
+  const cookies = document.cookie.split(';');
+  const jwtCookie = cookies.find(cookie => cookie.trim().startsWith('jwt='));
+
+  if (!jwtCookie) {
+    return undefined;
+  }
+
+  return jwtCookie.split('=')[1].trim();
 }
 
 export function clearJwt() {

--- a/apps/zbugs/src/main.tsx
+++ b/apps/zbugs/src/main.tsx
@@ -6,6 +6,10 @@ import {ZeroProvider} from 'zero-react/src/use-zero.js';
 import {type Schema, schema} from './domain/schema.js';
 import './index.css';
 import Root from './root.js';
+import {getJwt, getRawJwt} from './jwt.js';
+
+const jwt = getJwt();
+const encodedJwt = getRawJwt();
 
 const qs = new URLSearchParams(location.search);
 const hiddenTabDisconnectDelayMinutes = qs.get('keepalive') ? 60 : 5;
@@ -16,7 +20,8 @@ console.info(
 const z = new Zero({
   logLevel: 'info',
   server: import.meta.env.VITE_PUBLIC_SERVER,
-  userID: 'anon',
+  userID: jwt?.sub ?? 'anon',
+  auth: encodedJwt,
   schemas: schema,
   hiddenTabDisconnectDelay: hiddenTabDisconnectDelayMinutes * 60 * 1000,
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,7 @@
         "@schickling/fps-meter": "^0.1.2",
         "classnames": "^2.5.1",
         "fastify": "^5.0.0",
-        "jose": "^5.9.2",
+        "jose": "^5.9.3",
         "nanoid": "^4.0.2",
         "postgres": "^3.4.4",
         "react": ">=16.0 <19.0",
@@ -323,14 +323,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "apps/zbugs/node_modules/jose": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.2.tgz",
-      "integrity": "sha512-ILI2xx/I57b20sd7rHZvgiiQrmp2mcotwsAH+5ajbpFQbrYVQdNHYlQhoA5cFb78CgtBOxtC05TeA+mcgkuCqQ==",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
       }
     },
     "apps/zbugs/node_modules/nanoid": {
@@ -9939,6 +9931,14 @@
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
       "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
     },
+    "node_modules/jose": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.3.tgz",
+      "integrity": "sha512-egLIoYSpcd+QUF+UHgobt5YzI2Pkw/H39ou9suW687MY6PmCwPmkNV/4TNjn1p2tX5xO3j0d0sq5hiYE24bSlg==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -17370,6 +17370,7 @@
         "datadog": "0.0.0",
         "eventemitter3": "^5.0.1",
         "fastify": "^5.0.0",
+        "jose": "^5.9.3",
         "json-custom-numbers": "^3.1.1",
         "pg": "^8.11.3",
         "pg-format": "npm:pg-format-fix@^1.0.5",
@@ -24123,6 +24124,11 @@
         }
       }
     },
+    "jose": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.3.tgz",
+      "integrity": "sha512-egLIoYSpcd+QUF+UHgobt5YzI2Pkw/H39ou9suW687MY6PmCwPmkNV/4TNjn1p2tX5xO3j0d0sq5hiYE24bSlg=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -29149,7 +29155,7 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.6",
         "fastify": "^5.0.0",
-        "jose": "^5.9.2",
+        "jose": "^5.9.3",
         "nanoid": "^4.0.2",
         "postcss-preset-env": "^7.4.3",
         "postgres": "^3.4.4",
@@ -29282,11 +29288,6 @@
             "eslint-visitor-keys": "^3.3.0"
           }
         },
-        "jose": {
-          "version": "5.9.2",
-          "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.2.tgz",
-          "integrity": "sha512-ILI2xx/I57b20sd7rHZvgiiQrmp2mcotwsAH+5ajbpFQbrYVQdNHYlQhoA5cFb78CgtBOxtC05TeA+mcgkuCqQ=="
-        },
         "nanoid": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
@@ -29319,6 +29320,7 @@
         "dotenv": "^16.4.5",
         "eventemitter3": "^5.0.1",
         "fastify": "^5.0.0",
+        "jose": "^5.9.3",
         "json-custom-numbers": "^3.1.1",
         "pg": "^8.11.3",
         "pg-format": "npm:pg-format-fix@^1.0.5",

--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -24,11 +24,11 @@
     "@rocicorp/lock": "^1.0.4",
     "@rocicorp/logger": "^5.2.2",
     "@rocicorp/resolver": "^1.0.2",
-    "zqlite": "0.0.0",
     "compare-utf8": "^0.1.1",
     "datadog": "0.0.0",
     "eventemitter3": "^5.0.1",
     "fastify": "^5.0.0",
+    "jose": "^5.9.3",
     "json-custom-numbers": "^3.1.1",
     "pg": "^8.11.3",
     "pg-format": "npm:pg-format-fix@^1.0.5",
@@ -37,7 +37,8 @@
     "postgres-array": "^3.0.2",
     "xxhash-wasm": "^1.0.2",
     "zero-protocol": "0.0.0",
-    "zql": "0.0.0"
+    "zql": "0.0.0",
+    "zqlite": "0.0.0"
   },
   "devDependencies": {
     "@rocicorp/eslint-config": "^0.5.1",

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -10,6 +10,7 @@ import {must} from 'shared/src/must.js';
 export type Action = 'select' | 'insert' | 'update' | 'delete';
 
 const policySchema = v.array(v.tuple([v.literal('allow'), astSchema]));
+export type Policy = v.Infer<typeof policySchema>;
 
 const assetSchema = v.object({
   select: policySchema.optional(),
@@ -49,6 +50,7 @@ const zeroConfigSchemaSansAuthorization = v.object({
   numSyncWorkers: v.number().optional(),
   changeStreamerUri: v.string().optional(),
   litestream: v.boolean().optional(),
+  jwtSecret: v.string().optional(),
 
   log: logConfigSchema,
 });

--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -68,7 +68,7 @@ export default async function runWorker(parent: Worker) {
   const mutagenFactory = (id: string) =>
     new MutagenService(lc, id, upstreamDB, config.authorization ?? {});
 
-  new Syncer(lc, viewSyncerFactory, mutagenFactory, parent).run();
+  new Syncer(lc, config, viewSyncerFactory, mutagenFactory, parent).run();
 
   await dbWarmup;
   parent.send(['ready', {ready: true}]);

--- a/packages/zero-cache/src/services/dispatcher/connect-params.ts
+++ b/packages/zero-cache/src/services/dispatcher/connect-params.ts
@@ -1,3 +1,4 @@
+import type {IncomingHttpHeaders} from 'node:http2';
 import {URLParams} from 'zero-cache/src/types/url-params.js';
 
 export type ConnectParams = {
@@ -8,9 +9,14 @@ export type ConnectParams = {
   readonly lmID: number;
   readonly wsID: string;
   readonly debugPerf: boolean;
+  readonly auth: string | undefined;
+  readonly userID: string;
 };
 
-export function getConnectParams(url: URL):
+export function getConnectParams(
+  url: URL,
+  headers: IncomingHttpHeaders,
+):
   | {
       params: ConnectParams;
       error: null;
@@ -28,8 +34,10 @@ export function getConnectParams(url: URL):
     const timestamp = params.getInteger('ts', true);
     const lmID = params.getInteger('lmid', true);
     const wsID = params.get('wsid', false) ?? '';
+    const userID = params.get('userID', false) ?? '';
     const debugPerf = params.getBoolean('debugPerf');
 
+    const maybeAuthToken = headers['sec-websocket-protocol'];
     return {
       params: {
         clientID,
@@ -39,6 +47,8 @@ export function getConnectParams(url: URL):
         lmID,
         wsID,
         debugPerf,
+        auth: maybeAuthToken ? decodeURIComponent(maybeAuthToken) : undefined,
+        userID,
       },
       error: null,
     };

--- a/packages/zero-cache/src/services/dispatcher/dispatcher.ts
+++ b/packages/zero-cache/src/services/dispatcher/dispatcher.ts
@@ -50,6 +50,7 @@ export class Dispatcher implements Service {
     const {headers, url} = req;
     const {params, error} = getConnectParams(
       new URL(url ?? '', 'http://unused/'),
+      headers,
     );
     if (error !== null) {
       throw new Error(error);

--- a/packages/zero-cache/src/workers/connection.ts
+++ b/packages/zero-cache/src/workers/connection.ts
@@ -20,6 +20,7 @@ import type {
 } from '../services/view-syncer/view-syncer.js';
 import {findErrorForClient} from '../types/error-for-client.js';
 import type {Source} from '../types/streams.js';
+import type {JWTPayload} from 'jose';
 
 /**
  * Represents a connection between the client and server.
@@ -45,6 +46,7 @@ export class Connection {
 
   constructor(
     lc: LogContext,
+    _authData: JWTPayload,
     viewSyncer: ViewSyncer,
     mutagen: Mutagen,
     connectParams: ConnectParams,

--- a/packages/zero-cache/src/workers/syncer.test.ts
+++ b/packages/zero-cache/src/workers/syncer.test.ts
@@ -1,0 +1,49 @@
+import {describe, expect, test} from 'vitest';
+import {decodeAndCheckToken} from './syncer.js';
+import {SignJWT} from 'jose';
+
+function makeJWT(payload: Record<string, unknown> = {sub: 'testID'}) {
+  return new SignJWT(payload)
+    .setProtectedHeader({alg: 'HS256'})
+    .setExpirationTime('30days')
+    .sign(new TextEncoder().encode('testing-secret'));
+}
+
+describe('decodeAndCheckToken', () => {
+  test('no secret', async () => {
+    await expect(async () =>
+      decodeAndCheckToken(await makeJWT(), undefined, 'testID'),
+    ).rejects.toThrow('JWT secret was not set in `zero.config.ts`');
+  });
+
+  test('invalid token', async () => {
+    await expect(() =>
+      decodeAndCheckToken(
+        'invalid',
+        new TextEncoder().encode('testing-secret'),
+        'testID',
+      ),
+    ).rejects.toThrow();
+  });
+
+  test('valid token', async () => {
+    const jwt = await makeJWT();
+    const decoded = await decodeAndCheckToken(
+      jwt,
+      new TextEncoder().encode('testing-secret'),
+      'testID',
+    );
+    expect(decoded.sub).toBe('testID');
+  });
+
+  test('userID != sub', async () => {
+    const jwt = await makeJWT({sub: 'otherID'});
+    await expect(() =>
+      decodeAndCheckToken(
+        jwt,
+        new TextEncoder().encode('testing-secret'),
+        'testID',
+      ),
+    ).rejects.toThrow('JWT subject does not match the userID');
+  });
+});


### PR DESCRIPTION
The client passes an auth token when constructing `new Zero` but the server wasn't doing anything with it.

- get the token from the upgrade request headers
- decode the token
- save in the connection for later use in mutagen