### PR TITLE
feat(zero-cache): implement `write-authorizer`

### DIFF
--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -9,7 +9,9 @@ import {must} from 'shared/src/must.js';
 
 export type Action = 'select' | 'insert' | 'update' | 'delete';
 
-const policySchema = v.array(v.tuple([v.literal('allow'), astSchema]));
+const ruleSchema = v.tuple([v.literal('allow'), astSchema]);
+export type Rule = v.Infer<typeof ruleSchema>;
+const policySchema = v.array(ruleSchema);
 export type Policy = v.Infer<typeof policySchema>;
 
 const assetSchema = v.object({

--- a/packages/zero-cache/src/services/mutagen/write-authorizer.test.ts
+++ b/packages/zero-cache/src/services/mutagen/write-authorizer.test.ts
@@ -1,0 +1,187 @@
+import {beforeEach, describe, expect, test} from 'vitest';
+import {WriteAuthorizerImpl} from './write-authorizer.js';
+import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
+import type {Rule, ZeroConfig} from '../../config/zero-config.js';
+import {Database} from 'zqlite/src/db.js';
+
+const lc = createSilentLogContext();
+const baseConfig: ZeroConfig = {
+  upstreamUri: 'upstream',
+  cvrDbUri: 'cvr',
+  changeDbUri: 'change',
+  replicaId: 'replica',
+  replicaDbFile: 'replica',
+  log: {level: 'debug'},
+};
+
+const allowIfSubject = [
+  'allow',
+  {
+    table: 'foo',
+    where: [
+      {
+        type: 'simple',
+        field: 'id',
+        op: '=',
+        value: {anchor: 'authData', field: 'sub', type: 'static'},
+      },
+    ],
+    orderBy: [['id', 'asc']],
+  },
+] satisfies Rule;
+
+describe('can insert/update/delete/upsert', () => {
+  let replica: Database;
+  beforeEach(() => {
+    replica = new Database(lc, ':memory:');
+    replica.exec(/*sql*/ `CREATE TABLE foo (id TEXT PRIMARY KEY, a TEXT);
+      INSERT INTO foo VALUES ('1', 'a');`);
+  });
+
+  test.each([
+    {
+      name: 'no policies',
+      expected: true,
+      authorization: undefined,
+    },
+    {
+      name: 'empty (deny) table policy',
+      expected: false,
+      authorization: {
+        foo: {
+          table: {
+            insert: [],
+            update: [],
+            delete: [],
+          },
+        },
+      },
+    },
+    {
+      name: 'empty (deny) column policy',
+      expected: false,
+      authorization: {
+        foo: {
+          column: {
+            a: {
+              insert: [],
+              update: [],
+              delete: [],
+            },
+          },
+        },
+      },
+    },
+    {
+      name: 'empty (deny) row policy',
+      expected: false,
+      authorization: {
+        foo: {
+          row: {
+            insert: [],
+            update: [],
+            delete: [],
+          },
+        },
+      },
+    },
+    {
+      name: 'empty (deny) cell policy',
+      expected: false,
+      authorization: {
+        foo: {
+          cell: {
+            a: {
+              insert: [],
+              update: [],
+              delete: [],
+            },
+          },
+        },
+      },
+    },
+    {
+      name: 'row - allow if subject',
+      expected: true,
+      sub: '1',
+      authorization: {
+        foo: {
+          row: {
+            update: [allowIfSubject],
+            delete: [allowIfSubject],
+          },
+        },
+      },
+    },
+    {
+      name: 'row - allow if subject denies when the subject is different',
+      expected: false,
+      sub: '2',
+      authorization: {
+        foo: {
+          row: {
+            insert: [],
+            update: [allowIfSubject],
+            delete: [allowIfSubject],
+          },
+        },
+      },
+    },
+    {
+      name: 'upsert uses insert policy if nothing exists',
+      id: '2',
+      expected: false,
+      actions: ['Upsert'],
+      authorization: {
+        foo: {
+          row: {
+            insert: [],
+          },
+        },
+      },
+    },
+    {
+      name: 'upsert uses update policy if something exists',
+      id: '1',
+      expected: false,
+      actions: ['Upsert'],
+      authorization: {
+        foo: {
+          row: {
+            update: [],
+          },
+        },
+      },
+    },
+  ] satisfies {
+    name: string;
+    sub?: string | undefined;
+    id?: string | undefined;
+    actions?: ('Insert' | 'Update' | 'Delete' | 'Upsert')[] | undefined;
+    expected: boolean;
+    authorization: ZeroConfig['authorization'];
+  }[])('$name', ({authorization, sub, id, actions, expected}) => {
+    const authorizer = new WriteAuthorizerImpl(
+      lc,
+      {
+        ...baseConfig,
+        authorization,
+      },
+      replica,
+      'cg',
+    );
+    const jwtPayload = {
+      sub: sub ?? '1',
+    };
+    for (const op of actions ??
+      (['Insert', 'Update', 'Delete', 'Upsert'] as const)) {
+      expect(
+        authorizer[`can${op}`](jwtPayload, {
+          id: {id: id ?? 1},
+          entityType: 'foo',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any),
+      ).toBe(expected);
+    }
+  });
+});

--- a/packages/zero-cache/src/services/mutagen/write-authorizer.ts
+++ b/packages/zero-cache/src/services/mutagen/write-authorizer.ts
@@ -1,0 +1,235 @@
+import {Database} from 'zqlite/src/db.js';
+import type {
+  AuthorizationConfig,
+  Policy,
+  ZeroConfig,
+} from '../../config/zero-config.js';
+import type {CreateOp, DeleteOp, SetOp, UpdateOp} from 'zero-protocol';
+import type {BuilderDelegate} from 'zql/src/zql/builder/builder.js';
+import {buildPipeline} from 'zql/src/zql/builder/builder.js';
+import type {NormalizedTableSpec} from '../view-syncer/pipeline-driver.js';
+import {normalize} from '../view-syncer/pipeline-driver.js';
+import {listTables} from '../../db/lite-tables.js';
+import {TableSource} from 'zqlite/src/table-source.js';
+import {assert} from 'shared/src/asserts.js';
+import {mapLiteDataTypeToZqlSchemaValue} from '../../types/lite.js';
+import {DatabaseStorage} from '../view-syncer/database-storage.js';
+import {LogContext} from '@rocicorp/logger';
+import path from 'path';
+import {tmpdir} from 'node:os';
+import {pid} from 'node:process';
+import {randInt} from 'shared/src/rand.js';
+import {StatementCache} from 'zqlite/src/internal/statement-cache.js';
+import {sql, compile} from 'zqlite/src/internal/sql.js';
+import type {Row} from 'zql/src/zql/ivm/data.js';
+import type {JWTPayload} from 'jose';
+import type {JSONValue} from 'shared/src/json.js';
+
+export interface WriteAuthorizer {
+  canInsert(authData: JWTPayload, op: CreateOp): boolean;
+  canUpdate(authData: JWTPayload, op: UpdateOp): boolean;
+  canDelete(authData: JWTPayload, op: DeleteOp): boolean;
+  canUpsert(authData: JWTPayload, op: SetOp): boolean;
+}
+
+export class WriteAuthorizerImpl {
+  readonly #authorizationConfig: AuthorizationConfig;
+  readonly #replica: Database;
+  readonly #builderDelegate: BuilderDelegate;
+  readonly #tableSpecs: Map<string, NormalizedTableSpec>;
+  readonly #tables = new Map<string, TableSource>();
+  readonly #statementCache: StatementCache;
+
+  constructor(
+    lc: LogContext,
+    config: ZeroConfig,
+    replica: Database,
+    cgID: string,
+  ) {
+    this.#authorizationConfig = config.authorization ?? {};
+    this.#replica = replica;
+    const tmpDir = config.storageDbTmpDir ?? tmpdir();
+    const writeAuthzStorage = DatabaseStorage.create(
+      lc,
+      path.join(tmpDir, `mutagen-${pid}-${randInt(1000000, 9999999)}`),
+    );
+    const cgStorage = writeAuthzStorage.createClientGroupStorage(cgID);
+    this.#builderDelegate = {
+      getSource: name => this.#getSource(name),
+      createStorage: () => cgStorage.createStorage(),
+    };
+    this.#tableSpecs = new Map(
+      listTables(replica).map(spec => [spec.name, normalize(spec)]),
+    );
+    this.#statementCache = new StatementCache(replica);
+  }
+
+  canInsert(authData: JWTPayload, op: CreateOp) {
+    return this.#canDo('insert', authData, op);
+  }
+
+  canUpdate(authData: JWTPayload, op: UpdateOp) {
+    return this.#canDo('update', authData, op);
+  }
+
+  canDelete(authData: JWTPayload, op: DeleteOp) {
+    return this.#canDo('delete', authData, op);
+  }
+
+  canUpsert(authData: JWTPayload, op: SetOp) {
+    const preMutationRow = this.#getPreMutationRow(op);
+    if (preMutationRow) {
+      return this.canUpdate(authData, {
+        op: 'update',
+        entityType: op.entityType,
+        id: op.id,
+        partialValue: op.value,
+      });
+    }
+
+    return this.canInsert(authData, {
+      op: 'create',
+      entityType: op.entityType,
+      id: op.id,
+      value: op.value,
+    });
+  }
+
+  #getSource(tableName: string) {
+    let source = this.#tables.get(tableName);
+    if (source) {
+      return source;
+    }
+    const tableSpec = this.#tableSpecs.get(tableName);
+    if (!tableSpec) {
+      throw new Error(`Table ${tableName} not found`);
+    }
+    const {columns, primaryKey} = tableSpec;
+    assert(primaryKey.length);
+    source = new TableSource(
+      this.#replica,
+      tableName,
+      Object.fromEntries(
+        Object.entries(columns).map(([name, {dataType}]) => [
+          name,
+          mapLiteDataTypeToZqlSchemaValue(dataType),
+        ]),
+      ),
+      [primaryKey[0], ...primaryKey.slice(1)],
+    );
+    this.#tables.set(tableName, source);
+
+    return source;
+  }
+
+  /**
+   * Evaluation order is from static to dynamic, broad to specific.
+   * table -> column -> row -> cell.
+   *
+   * If any step fails, the entire operation is denied.
+   *
+   * That is, table rules supersede column rules, which supersede row rules,
+   *
+   * All steps must allow for the operation to be allowed.
+   */
+  #canDo<A extends keyof ActionOpMap>(
+    action: A,
+    authData: JWTPayload,
+    op: ActionOpMap[A],
+  ) {
+    const rules = this.#authorizationConfig[op.entityType];
+    if (!rules) {
+      return true;
+    }
+
+    const tableRules = rules.table;
+    if (
+      tableRules &&
+      !this.#passesPolicy(tableRules[action], authData, undefined)
+    ) {
+      return false;
+    }
+
+    const columnRules = rules.column;
+    if (columnRules) {
+      for (const rule of Object.values(columnRules)) {
+        if (!this.#passesPolicy(rule[action], authData, undefined)) {
+          return false;
+        }
+      }
+    }
+
+    let preMutationRow: Row | undefined;
+    if (op.op !== 'create') {
+      preMutationRow = this.#getPreMutationRow(op);
+    }
+
+    const rowRules = rules.row;
+    if (
+      rowRules &&
+      !this.#passesPolicy(rowRules[action], authData, preMutationRow)
+    ) {
+      return false;
+    }
+
+    const cellRules = rules.cell;
+    if (cellRules) {
+      for (const rule of Object.values(cellRules)) {
+        if (!this.#passesPolicy(rule[action], authData, preMutationRow)) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  #getPreMutationRow(op: SetOp | UpdateOp | DeleteOp) {
+    return this.#statementCache.use(
+      compile(sql`SELECT * FROM ${sql.ident(op.entityType)} WHERE id = ?`),
+      stmt => stmt.statement.get<Row | undefined>(op.id.id),
+    );
+  }
+
+  #passesPolicy(
+    policy: Policy | undefined,
+    authData: JWTPayload,
+    preMutationRow: Row | undefined,
+  ) {
+    if (!policy) {
+      return true;
+    }
+
+    for (const [_, rule] of policy) {
+      const input = buildPipeline(rule, this.#builderDelegate, {
+        authData: authData as Record<string, JSONValue>,
+        preMutationRow,
+      });
+      try {
+        const res = input.fetch({});
+        for (const _ of res) {
+          // if any row is returned at all, the
+          // rule passes.
+          return true;
+        }
+      } finally {
+        input.destroy();
+      }
+    }
+
+    // no rows returned by any rules? The policy fails.
+    return false;
+  }
+}
+
+type ActionOpMap = {
+  insert: CreateOp;
+  update: UpdateOp;
+  delete: DeleteOp;
+};
+
+export class WriteAuthorizationFailed extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -43,11 +43,11 @@ export type RowEdit = {
 export type RowChange = RowAdd | RowRemove | RowEdit;
 
 /** Normalized TableSpec information for faster processing. */
-type NormalizedTableSpec = TableSpec & {
+export type NormalizedTableSpec = TableSpec & {
   readonly boolColumns: Set<string>;
 };
 
-function normalize(tableSpec: TableSpec): NormalizedTableSpec {
+export function normalize(tableSpec: TableSpec): NormalizedTableSpec {
   const {primaryKey, columns} = tableSpec;
   return {
     ...tableSpec,


### PR DESCRIPTION
Evaluation of write policies is in order from static to dynamic, broad to specific.

table policy -> column policy -> row policy -> cell policy.

If any step fails, the entire operation is denied.

That is, table rules supersede column rules, which supersede row rules.

All steps must allow for the write to be allowed.