### PR TITLE
feat(zero-cache): reference env vars from compiled config

### DIFF
--- a/apps/zbugs/package.json
+++ b/apps/zbugs/package.json
@@ -11,7 +11,7 @@
     "check-format": "prettier --check './**/*.{js,jsx,json,ts,tsx,html,css,md}'",
     "lint": "eslint --ext .ts,.tsx,.js,.jsx src/",
     "preview": "vite preview",
-    "zero": "node --no-warnings --loader ts-node/esm ./zero.config.ts ; cd ../../packages/zero-cache && ZERO_CONFIG_PATH=\"../../apps/zbugs/zero.config.json\" npm run start"
+    "zero": "node --no-warnings --loader ts-node/esm ./zero.config.ts ; cd ../../packages/zero-cache ; ZERO_CONFIG_PATH=\"../../apps/zbugs/zero.config.json\" npm run start -- dotenv_config_path=../../apps/zbugs/.env"
   },
   "dependencies": {
     "@fastify/cookie": "^10.0.0",

--- a/apps/zbugs/zero.config.ts
+++ b/apps/zbugs/zero.config.ts
@@ -1,8 +1,7 @@
 import 'dotenv/config';
-import process from 'node:process';
-import {must} from 'shared/src/must.js';
 import {
   defineConfig,
+  runtimeEnv,
   type Queries,
 } from 'zero-cache/src/config/define-config.js';
 import {type Schema, schema} from './src/domain/schema-shared.js';
@@ -13,13 +12,14 @@ const allowIfCrewMember = (queries: Queries<Schema>) => (authData: AuthData) =>
   queries.user.where('id', '=', authData.sub).where('role', '=', 'crew');
 
 defineConfig<AuthData, Schema>(schema, queries => ({
-  upstreamUri: must(process.env.UPSTREAM_URI),
-  cvrDbUri: must(process.env.CVR_DB_URI),
-  changeDbUri: must(process.env.CHANGE_DB_URI),
+  upstreamUri: runtimeEnv('UPSTREAM_URI'),
+  cvrDbUri: runtimeEnv('CVR_DB_URI'),
+  changeDbUri: runtimeEnv('CHANGE_DB_URI'),
 
-  replicaId: must(process.env.REPLICA_ID),
-  replicaDbFile: must(process.env.REPLICA_DB_FILE),
-  jwtSecret: must(process.env.JWT_SECRET),
+  replicaId: runtimeEnv('REPLICA_ID'),
+  replicaDbFile: runtimeEnv('REPLICA_DB_FILE'),
+  jwtSecret: runtimeEnv('JWT_SECRET'),
+  litestream: runtimeEnv('LITESTREAM'),
 
   log: {
     level: 'debug',

--- a/packages/zero-cache/src/config/define-config.ts
+++ b/packages/zero-cache/src/config/define-config.ts
@@ -14,7 +14,8 @@ import type {
   Action,
   AssetAuthorization as CompiledAssetAuthorization,
   AuthorizationConfig as CompiledAuthorizationConfig,
-  ZeroConfig as CompiledZeroConfig,
+  ZeroConfigType as CompiledZeroConfig,
+  EnvRef,
   ZeroConfigSansAuthorization,
 } from './zero-config.js';
 
@@ -66,6 +67,10 @@ export type ZeroConfig<
   authorization?: AuthorizationConfig<TAuthDataShape, TSchemas>;
 };
 
+export function runtimeEnv(key: string): EnvRef {
+  return {tag: 'env', name: key};
+}
+
 export function defineConfig<TAuthDataShape, TSchemas extends SchemaDefs>(
   schemas: TSchemas,
   definer: (queries: Queries<TSchemas>) => ZeroConfig<TAuthDataShape, TSchemas>,
@@ -87,7 +92,6 @@ function compileConfig<TAuthDataShape, TSchemas extends SchemaDefs>(
 ): CompiledZeroConfig {
   return {
     ...config,
-    // To be completed in a follow up PR
     authorization: compileAuthorization(config.authorization),
   };
 }

--- a/packages/zero-cache/src/server/logging.ts
+++ b/packages/zero-cache/src/server/logging.ts
@@ -1,18 +1,18 @@
 import {LogContext, TeeLogSink, consoleLogSink} from '@rocicorp/logger';
 import {DatadogLogSink} from 'datadog/src/datadog-log-sink.js';
 import {pid} from 'node:process';
-import type {LogConfig} from '../config/zero-config.js';
+import {type LogConfig} from '../config/zero-config.js';
 
 const DATADOG_SOURCE = 'zeroWorker';
 
-function createLogSink(env: LogConfig) {
-  if (env.datadogLogsApiKey === undefined) {
+function createLogSink(config: LogConfig) {
+  if (config.datadogLogsApiKey === undefined) {
     return consoleLogSink;
   }
   return new TeeLogSink([
     new DatadogLogSink({
-      apiKey: env.datadogLogsApiKey,
-      service: env.datadogServiceLabel ?? '',
+      apiKey: config.datadogLogsApiKey,
+      service: config.datadogServiceLabel ?? '',
       source: DATADOG_SOURCE,
     }),
     consoleLogSink,

--- a/packages/zero-cache/src/services/mutagen/mutagen.ts
+++ b/packages/zero-cache/src/services/mutagen/mutagen.ts
@@ -17,7 +17,7 @@ import {
 import {ErrorForClient} from '../../types/error-for-client.js';
 import type {PostgresDB, PostgresTransaction} from '../../types/pg.js';
 import type {Service} from '../service.js';
-import type {ZeroConfig} from '../../config/zero-config.js';
+import {type ZeroConfig} from '../../config/zero-config.js';
 import {Database} from 'zqlite/src/db.js';
 import {WriteAuthorizerImpl, type WriteAuthorizer} from './write-authorizer.js';
 import type {JWTPayload} from 'jose';

--- a/packages/zero-cache/src/services/mutagen/write-authorizer.test.ts
+++ b/packages/zero-cache/src/services/mutagen/write-authorizer.test.ts
@@ -1,11 +1,15 @@
 import {beforeEach, describe, expect, test} from 'vitest';
 import {WriteAuthorizerImpl} from './write-authorizer.js';
 import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
-import type {Rule, ZeroConfig} from '../../config/zero-config.js';
+import {
+  ZeroConfig,
+  type Rule,
+  type ZeroConfigType,
+} from '../../config/zero-config.js';
 import {Database} from 'zqlite/src/db.js';
 
 const lc = createSilentLogContext();
-const baseConfig: ZeroConfig = {
+const baseConfig: ZeroConfigType = {
   upstreamUri: 'upstream',
   cvrDbUri: 'cvr',
   changeDbUri: 'change',
@@ -159,14 +163,14 @@ describe('can insert/update/delete/upsert', () => {
     id?: string | undefined;
     actions?: ('Insert' | 'Update' | 'Delete' | 'Upsert')[] | undefined;
     expected: boolean;
-    authorization: ZeroConfig['authorization'];
+    authorization: ZeroConfigType['authorization'];
   }[])('$name', ({authorization, sub, id, actions, expected}) => {
     const authorizer = new WriteAuthorizerImpl(
       lc,
-      {
+      new ZeroConfig({
         ...baseConfig,
         authorization,
-      },
+      }),
       replica,
       'cg',
     );

--- a/packages/zero-cache/src/workers/syncer.ts
+++ b/packages/zero-cache/src/workers/syncer.ts
@@ -13,7 +13,7 @@ import {Subscription} from '../types/subscription.js';
 import {Connection} from './connection.js';
 import {createNotifierFrom, subscribeTo} from './replicator.js';
 import {jwtVerify, type JWTPayload} from 'jose';
-import type {ZeroConfig} from '../config/zero-config.js';
+import {type ZeroConfig} from '../config/zero-config.js';
 import assert from 'assert';
 import {must} from 'shared/src/must.js';
 


### PR DESCRIPTION
We only have access to the AWS and Vercel environment after deployment. Given that, the JSON config needs to resolve some environment variables at runtime instead of build time.

---

Values in the compiled config can now be literals or references to the environment.

![CleanShot 2024-09-30 at 17 04 14](https://github.com/user-attachments/assets/03e25dc0-2719-497d-bdb5-06ed706e3099)


If the value references the environment then `ZeroConfig` will resolve it at runtime.

![CleanShot 2024-09-30 at 17 03 40](https://github.com/user-attachments/assets/f3e0e0ad-2a1d-44d5-9f2e-c9e9ee1d26ce)

