### PR TITLE
chore(zero-cache): tune litestream checkpointing parameters

### DIFF
--- a/litestream.yml
+++ b/litestream.yml
@@ -3,3 +3,5 @@ dbs:
   - path: /data/db/sync-replica.db
     replicas:
       - url: ${REPLICA_URL}
+  - checkpoint-interval: 10s
+  - max-checkpoint-page-count: 4000


### PR DESCRIPTION
Decrease the checkpoint-interval to 10 seconds (from the default value of 1 minute), and decrease the forced checkpoint threshold to 4000 pages (from the default of 10000 pages). This will hopefully reduce the amount of time that litestream locks the db file.