### PR TITLE
chore(replicache): Remove usage of enums

### DIFF
--- a/packages/replicache/package.json
+++ b/packages/replicache/package.json
@@ -10,6 +10,7 @@
     "format": "prettier --write .",
     "check-format": "prettier --check .",
     "check-types": "tsc --noEmit && tsc --noEmit --project tool/tsconfig.json",
+    "check-types:watch": "tsc --noEmit --watch",
     "lint": "eslint --ext .ts,.tsx,.js,.jsx src/",
     "build": "rm -rf out && tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && node tool/build.js",
     "build-bundle-sizes": "rm -rf out && node tool/build.js --bundle-sizes",
@@ -71,7 +72,16 @@
     "!*.tsbuildinfo"
   ],
   "eslintConfig": {
-    "extends": "@rocicorp/eslint-config"
+    "extends": "@rocicorp/eslint-config",
+    "rules": {
+      "no-restricted-syntax": [
+        "error",
+        {
+          "selector": "TSEnumDeclaration",
+          "message": "Enums are not allowed"
+        }
+      ]
+    }
   },
   "prettier": "@rocicorp/prettier-config"
 }

--- a/packages/replicache/src/btree/node.test.ts
+++ b/packages/replicache/src/btree/node.test.ts
@@ -5,7 +5,7 @@ import {toRefs} from '../dag/chunk.js';
 import type {Read, Store, Write} from '../dag/store.js';
 import {TestStore} from '../dag/test-store.js';
 import {ChainBuilder} from '../db/test-helpers.js';
-import {FormatVersion} from '../format-version.js';
+import * as FormatVersion from '../format-version-enum.js';
 import {type FrozenJSONValue, deepFreeze} from '../frozen-json.js';
 import {
   type Hash,
@@ -47,7 +47,7 @@ suite('btree node', () => {
   function makeTree(
     node: TreeData,
     dagStore: Store,
-    formatVersion: FormatVersion,
+    formatVersion: FormatVersion.Type,
   ): Promise<Hash> {
     return withWrite(dagStore, async dagWrite => {
       const [h] = await makeTreeInner(node, dagWrite);
@@ -96,7 +96,7 @@ suite('btree node', () => {
   async function readTreeData(
     rootHash: Hash,
     dagRead: Read,
-    formatVersion: FormatVersion,
+    formatVersion: FormatVersion.Type,
   ): Promise<Record<string, unknown>> {
     const chunk = await dagRead.getChunk(rootHash);
     const node = parseBTreeNode(chunk?.data, formatVersion, getEntrySize);
@@ -129,7 +129,7 @@ suite('btree node', () => {
   async function expectTree(
     rootHash: Hash,
     dagStore: Store,
-    formatVersion: FormatVersion,
+    formatVersion: FormatVersion.Type,
     expected: TreeData,
   ) {
     await withRead(dagStore, async dagRead => {
@@ -154,7 +154,7 @@ suite('btree node', () => {
   function doRead<R>(
     rootHash: Hash,
     dagStore: Store,
-    formatVersion: FormatVersion,
+    formatVersion: FormatVersion.Type,
     fn: (r: BTreeRead) => R | Promise<R>,
   ): Promise<R> {
     return withRead(dagStore, dagWrite => {
@@ -172,7 +172,7 @@ suite('btree node', () => {
   function doWrite(
     rootHash: Hash,
     dagStore: Store,
-    formatVersion: FormatVersion,
+    formatVersion: FormatVersion.Type,
     fn: (w: BTreeWrite) => void | Promise<void>,
   ): Promise<Hash> {
     return withWrite(dagStore, async dagWrite => {
@@ -1656,7 +1656,7 @@ suite('Write nodes using ChainBuilder', () => {
     );
   }
 
-  const getBTreeNodes = async (formatVersion: FormatVersion) => {
+  const getBTreeNodes = async (formatVersion: FormatVersion.Type) => {
     const dagStore = new TestStore();
     const clientID = 'client1';
     const b = new ChainBuilder(dagStore, undefined, formatVersion);

--- a/packages/replicache/src/btree/node.ts
+++ b/packages/replicache/src/btree/node.ts
@@ -14,7 +14,7 @@ import {
 import {binarySearch as binarySearchWithFunc} from '../binary-search.js';
 import {skipBTreeNodeAsserts} from '../config.js';
 import type {IndexKey} from '../db/index.js';
-import {FormatVersion} from '../format-version.js';
+import * as FormatVersion from '../format-version-enum.js';
 import {
   type FrozenJSONValue,
   type FrozenTag,
@@ -43,7 +43,7 @@ export type DataNode = BaseNode<FrozenJSONValue>;
 export function makeNodeChunkData<V>(
   level: number,
   entries: ReadonlyArray<Entry<V>>,
-  formatVersion: FormatVersion,
+  formatVersion: FormatVersion.Type,
 ): BaseNode<V> {
   return deepFreeze([
     level,
@@ -173,7 +173,7 @@ export function binarySearchFound(
 
 export function parseBTreeNode(
   v: unknown,
-  formatVersion: FormatVersion,
+  formatVersion: FormatVersion.Type,
   getSizeOfEntry: <K, V>(key: K, value: V) => number,
 ): InternalNode | DataNode {
   if (skipBTreeNodeAsserts && formatVersion >= FormatVersion.V7) {
@@ -291,7 +291,7 @@ abstract class NodeImpl<Value> {
 
 export function toChunkData<V>(
   node: NodeImpl<V>,
-  formatVersion: FormatVersion,
+  formatVersion: FormatVersion.Type,
 ): BaseNode<V> {
   return makeNodeChunkData(node.level, node.entries, formatVersion);
 }

--- a/packages/replicache/src/btree/read.ts
+++ b/packages/replicache/src/btree/read.ts
@@ -1,6 +1,6 @@
 import {deepEqual} from 'shared/src/json.js';
 import type {Read} from '../dag/store.js';
-import type {FormatVersion} from '../format-version.js';
+import type {FormatVersion} from '../format-version-enum.js';
 import type {FrozenJSONValue} from '../frozen-json.js';
 import {type Hash, emptyHash} from '../hash.js';
 import {getSizeOfEntry} from '../size-of-value.js';

--- a/packages/replicache/src/btree/write.ts
+++ b/packages/replicache/src/btree/write.ts
@@ -3,7 +3,7 @@ import {assert} from 'shared/src/asserts.js';
 import type {ReadonlyJSONValue} from 'shared/src/json.js';
 import {type Chunk, type CreateChunk, toRefs} from '../dag/chunk.js';
 import type {Write} from '../dag/store.js';
-import type {FormatVersion} from '../format-version.js';
+import type {FormatVersion} from '../format-version-enum.js';
 import type {FrozenJSONValue} from '../frozen-json.js';
 import {type Hash, emptyHash, newRandomHash} from '../hash.js';
 import {getSizeOfEntry} from '../size-of-value.js';

--- a/packages/replicache/src/dag/key-type-enum.ts
+++ b/packages/replicache/src/dag/key-type-enum.ts
@@ -1,0 +1,13 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+export const ChunkData = 0;
+export const ChunkMeta = 1;
+export const ChunkRefCount = 2;
+export const Head = 3;
+
+export type ChunkData = typeof ChunkData;
+export type ChunkMeta = typeof ChunkMeta;
+export type ChunkRefCount = typeof ChunkRefCount;
+export type Head = typeof Head;
+
+export type Type = ChunkData | ChunkMeta | ChunkRefCount | Head;

--- a/packages/replicache/src/dag/key.test.ts
+++ b/packages/replicache/src/dag/key.test.ts
@@ -1,12 +1,12 @@
 import {expect} from 'chai';
 import {fakeHash} from '../hash.js';
+import * as KeyType from './key-type-enum.js';
 import {
   chunkDataKey,
   chunkMetaKey,
   chunkRefCountKey,
   headKey,
   type Key,
-  KeyType,
   parse,
 } from './key.js';
 

--- a/packages/replicache/src/dag/key.ts
+++ b/packages/replicache/src/dag/key.ts
@@ -1,4 +1,5 @@
 import {type Hash, parse as parseHash} from '../hash.js';
+import * as KeyType from './key-type-enum.js';
 
 export function chunkDataKey(hash: Hash): string {
   return `c/${hash}/d`;
@@ -14,13 +15,6 @@ export function chunkRefCountKey(hash: Hash): string {
 
 export function headKey(name: string): string {
   return `h/${name}`;
-}
-
-export const enum KeyType {
-  ChunkData,
-  ChunkMeta,
-  ChunkRefCount,
-  Head,
 }
 
 export type Key =

--- a/packages/replicache/src/dag/test-store.ts
+++ b/packages/replicache/src/dag/test-store.ts
@@ -13,7 +13,8 @@ import {
   type Refs,
   toRefs as chunkToRefs,
 } from './chunk.js';
-import {KeyType, chunkMetaKey, parse as parseKey} from './key.js';
+import * as KeyType from './key-type-enum.js';
+import {chunkMetaKey, parse as parseKey} from './key.js';
 import {StoreImpl} from './store-impl.js';
 
 export class TestStore extends StoreImpl {

--- a/packages/replicache/src/db/commit.test.ts
+++ b/packages/replicache/src/db/commit.test.ts
@@ -1,7 +1,7 @@
 import {expect} from 'chai';
 import {Chunk, type Refs, toRefs} from '../dag/chunk.js';
 import {TestStore} from '../dag/test-store.js';
-import {FormatVersion} from '../format-version.js';
+import * as FormatVersion from '../format-version-enum.js';
 import {deepFreeze} from '../frozen-json.js';
 import {type Hash, fakeHash, makeNewFakeHashFunction} from '../hash.js';
 import {withRead} from '../with-transactions.js';
@@ -11,7 +11,6 @@ import {
   type CommitData,
   type IndexChangeMetaSDD,
   type Meta,
-  MetaType,
   baseSnapshotFromHash,
   chunkIndexDefinitionEqualIgnoreName,
   commitChain,
@@ -26,10 +25,11 @@ import {
   localMutationsGreaterThan,
   makeCommitData,
 } from './commit.js';
+import * as MetaType from './meta-type-enum.js';
 import {ChainBuilder} from './test-helpers.js';
 
 suite('base snapshot', () => {
-  const t = async (formatVersion: FormatVersion) => {
+  const t = async (formatVersion: FormatVersion.Type) => {
     const clientID = 'client-id';
     const store = new TestStore();
     const b = new ChainBuilder(store, undefined, formatVersion);
@@ -91,7 +91,7 @@ suite('base snapshot', () => {
 });
 
 suite('local mutations', () => {
-  const t = async (formatVersion: FormatVersion) => {
+  const t = async (formatVersion: FormatVersion.Type) => {
     const clientID = 'client-id';
     const store = new TestStore();
     const b = new ChainBuilder(store, undefined, formatVersion);
@@ -199,7 +199,7 @@ test('local mutations greater than', async () => {
 });
 
 suite('chain', () => {
-  const t = async (formatVersion: FormatVersion) => {
+  const t = async (formatVersion: FormatVersion.Type) => {
     const clientID = 'client-id';
     const store = new TestStore();
     const b = new ChainBuilder(store, undefined, formatVersion);

--- a/packages/replicache/src/db/commit.ts
+++ b/packages/replicache/src/db/commit.ts
@@ -21,16 +21,9 @@ import {
 import {type Hash, assertHash} from '../hash.js';
 import type {IndexDefinition} from '../index-defs.js';
 import type {ClientID} from '../sync/ids.js';
+import * as MetaType from './meta-type-enum.js';
 
 export const DEFAULT_HEAD_NAME = 'main';
-
-export const enum MetaType {
-  IndexChangeSDD = 1,
-  LocalSDD = 2,
-  SnapshotSDD = 3,
-  LocalDD31 = 4,
-  SnapshotDD31 = 5,
-}
 
 export function commitIsLocalSDD(
   commit: Commit<Meta>,

--- a/packages/replicache/src/db/index-operation-enum.ts
+++ b/packages/replicache/src/db/index-operation-enum.ts
@@ -1,0 +1,9 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+export const Add = 0;
+export const Remove = 1;
+
+export type Add = typeof Add;
+export type Remove = typeof Remove;
+
+export type Type = Add | Remove;

--- a/packages/replicache/src/db/index.test.ts
+++ b/packages/replicache/src/db/index.test.ts
@@ -5,12 +5,12 @@ import {stringCompare} from 'shared/src/string-compare.js';
 import {asyncIterableToArray} from '../async-iterable-to-array.js';
 import {BTreeWrite} from '../btree/write.js';
 import {TestStore} from '../dag/test-store.js';
-import {FormatVersion} from '../format-version.js';
+import * as FormatVersion from '../format-version-enum.js';
 import {deepFreeze} from '../frozen-json.js';
 import {withWrite} from '../with-transactions.js';
+import * as IndexOperation from './index-operation-enum.js';
 import {
   type IndexKey,
-  IndexOperation,
   KEY_SEPARATOR,
   KEY_VERSION_0,
   decodeIndexKey,
@@ -198,7 +198,7 @@ test('index value', async () => {
     key: string,
     value: JSONValue,
     jsonPointer: string,
-    op: IndexOperation,
+    op: IndexOperation.Type,
     expected: number[] | string,
   ) => {
     const dagStore = new TestStore();

--- a/packages/replicache/src/db/index.ts
+++ b/packages/replicache/src/db/index.ts
@@ -4,6 +4,7 @@ import type {BTreeWrite} from '../btree/write.js';
 import type {FrozenJSONObject, FrozenJSONValue} from '../frozen-json.js';
 import type {Hash} from '../hash.js';
 import type {IndexRecord} from './commit.js';
+import * as IndexOperation from './index-operation-enum.js';
 
 export class IndexRead<BTree = BTreeRead> {
   readonly meta: IndexRecord;
@@ -31,7 +32,7 @@ export class IndexWrite extends IndexRead<BTreeWrite> {
 export async function indexValue(
   lc: LogContext,
   index: BTreeWrite,
-  op: IndexOperation,
+  op: IndexOperation.Type,
   key: string,
   val: FrozenJSONValue,
   jsonPointer: string,
@@ -212,9 +213,4 @@ export function evaluateJSONPointer(
     target = targetOpt;
   }
   return target;
-}
-
-export const enum IndexOperation {
-  Add,
-  Remove,
 }

--- a/packages/replicache/src/db/meta-type-enum.ts
+++ b/packages/replicache/src/db/meta-type-enum.ts
@@ -1,0 +1,20 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+export const IndexChangeSDD = 1;
+export const LocalSDD = 2;
+export const SnapshotSDD = 3;
+export const LocalDD31 = 4;
+export const SnapshotDD31 = 5;
+
+export type IndexChangeSDD = typeof IndexChangeSDD;
+export type LocalSDD = typeof LocalSDD;
+export type SnapshotSDD = typeof SnapshotSDD;
+export type LocalDD31 = typeof LocalDD31;
+export type SnapshotDD31 = typeof SnapshotDD31;
+
+export type Type =
+  | IndexChangeSDD
+  | LocalSDD
+  | SnapshotSDD
+  | LocalDD31
+  | SnapshotDD31;

--- a/packages/replicache/src/db/read.test.ts
+++ b/packages/replicache/src/db/read.test.ts
@@ -2,14 +2,14 @@ import {LogContext} from '@rocicorp/logger';
 import {expect} from 'chai';
 import {mustGetHeadHash} from '../dag/store.js';
 import {TestStore} from '../dag/test-store.js';
-import {FormatVersion} from '../format-version.js';
+import * as FormatVersion from '../format-version-enum.js';
 import {DEFAULT_HEAD_NAME} from './commit.js';
 import {readFromDefaultHead} from './read.js';
 import {initDB} from './test-helpers.js';
 import {newWriteLocal} from './write.js';
 
 suite('basics', () => {
-  const t = async (replicacheFormatVersion: FormatVersion) => {
+  const t = async (replicacheFormatVersion: FormatVersion.Type) => {
     const clientID = 'client-id';
     const dagStore = new TestStore();
     const lc = new LogContext();

--- a/packages/replicache/src/db/read.ts
+++ b/packages/replicache/src/db/read.ts
@@ -1,6 +1,6 @@
 import {BTreeRead} from '../btree/read.js';
 import type {Read as DagRead} from '../dag/store.js';
-import type {FormatVersion} from '../format-version.js';
+import type {FormatVersion} from '../format-version-enum.js';
 import type {FrozenJSONValue} from '../frozen-json.js';
 import type {Hash} from '../hash.js';
 import {

--- a/packages/replicache/src/db/rebase.test.ts
+++ b/packages/replicache/src/db/rebase.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import {BTreeRead} from '../btree/read.js';
 import type {Read} from '../dag/store.js';
 import {TestStore} from '../dag/test-store.js';
-import {FormatVersion} from '../format-version.js';
+import * as FormatVersion from '../format-version-enum.js';
 import type {Hash} from '../hash.js';
 import {SYNC_HEAD_NAME} from '../sync/sync-head-name.js';
 import type {WriteTransaction} from '../transactions.js';
@@ -30,7 +30,7 @@ teardown(() => {
 });
 
 async function createMutationSequenceFixture() {
-  const formatVersion: FormatVersion = FormatVersion.Latest;
+  const formatVersion: FormatVersion.Type = FormatVersion.Latest;
   const clientID = 'test_client_id';
   const store = new TestStore();
   const b = new ChainBuilder(store, undefined, formatVersion);
@@ -140,7 +140,7 @@ async function createMutationSequenceFixture() {
 }
 
 async function createMissingMutatorFixture() {
-  const formatVersion: FormatVersion = FormatVersion.Latest;
+  const formatVersion: FormatVersion.Type = FormatVersion.Latest;
   const consoleErrorStub = sinon.stub(console, 'error');
   const clientID = 'test_client_id';
   const store = new TestStore();
@@ -205,7 +205,7 @@ async function createMissingMutatorFixture() {
 async function commitAndBTree(
   name = SYNC_HEAD_NAME,
   read: Read,
-  formatVersion: FormatVersion,
+  formatVersion: FormatVersion.Type,
 ): Promise<[Commit<Meta>, BTreeRead]> {
   const commit = await commitFromHead(name, read);
   const btreeRead = new BTreeRead(read, formatVersion, commit.valueHash);
@@ -446,7 +446,7 @@ suite('rebaseMutationAndPutCommit', () => {
 
 async function testThrowsErrorOnClientIDMismatch(
   variant: 'commit' | 'putCommit',
-  formatVersion: FormatVersion,
+  formatVersion: FormatVersion.Type,
 ) {
   const clientID = 'test_client_id';
   const store = new TestStore();

--- a/packages/replicache/src/db/rebase.ts
+++ b/packages/replicache/src/db/rebase.ts
@@ -1,7 +1,7 @@
 import type {LogContext} from '@rocicorp/logger';
 import {assert} from 'shared/src/asserts.js';
 import type {Write as DagWrite} from '../dag/store.js';
-import {FormatVersion} from '../format-version.js';
+import * as FormatVersion from '../format-version-enum.js';
 import type {Hash} from '../hash.js';
 import type {ClientID} from '../sync/ids.js';
 import {WriteTransactionImpl} from '../transactions.js';
@@ -25,7 +25,7 @@ async function rebaseMutation(
   mutators: MutatorDefs,
   lc: LogContext,
   mutationClientID: ClientID,
-  formatVersion: FormatVersion,
+  formatVersion: FormatVersion.Type,
 ): Promise<Write> {
   const localMeta = mutation.meta;
   const name = localMeta.mutatorName;
@@ -101,7 +101,7 @@ export async function rebaseMutationAndPutCommit(
   // TODO(greg): mutationClientID can be retrieved from mutation if LocalMeta
   // is a LocalMetaDD31.  As part of DD31 cleanup we can remove this arg.
   mutationClientID: ClientID,
-  formatVersion: FormatVersion,
+  formatVersion: FormatVersion.Type,
 ): Promise<Commit<Meta>> {
   const tx = await rebaseMutation(
     mutation,
@@ -125,7 +125,7 @@ export async function rebaseMutationAndCommit(
   // TODO(greg): mutationClientID can be retrieved from mutation if LocalMeta
   // is a LocalMetaDD31.  As part of DD31 cleanup we can remove this arg.
   mutationClientID: ClientID,
-  formatVersion: FormatVersion,
+  formatVersion: FormatVersion.Type,
 ): Promise<Hash> {
   const dbWrite = await rebaseMutation(
     mutation,

--- a/packages/replicache/src/db/scan.test.ts
+++ b/packages/replicache/src/db/scan.test.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {BTreeWrite} from '../btree/write.js';
 import type {Write} from '../dag/store.js';
 import {TestStore} from '../dag/test-store.js';
-import {FormatVersion} from '../format-version.js';
+import * as FormatVersion from '../format-version-enum.js';
 import {fromKeyForIndexScanInternal} from '../scan-iterator.js';
 import {withWrite} from '../with-transactions.js';
 import {decodeIndexKey} from './index.js';
@@ -41,7 +41,7 @@ test('scan', async () => {
 async function makeBTreeWrite(
   dagWrite: Write,
   entries: Iterable<[string, string]>,
-  formatVersion: FormatVersion,
+  formatVersion: FormatVersion.Type,
 ): Promise<BTreeWrite> {
   const map = new BTreeWrite(dagWrite, formatVersion);
   for (const [k, v] of entries) {

--- a/packages/replicache/src/db/test-helpers.ts
+++ b/packages/replicache/src/db/test-helpers.ts
@@ -13,7 +13,7 @@ import {
   mustGetHeadHash,
 } from '../dag/store.js';
 import {Visitor} from '../dag/visitor.js';
-import {FormatVersion} from '../format-version.js';
+import * as FormatVersion from '../format-version-enum.js';
 import {deepFreeze} from '../frozen-json.js';
 import {type Hash, emptyHash} from '../hash.js';
 import type {IndexDefinition, IndexDefinitions} from '../index-defs.js';
@@ -31,7 +31,6 @@ import {
   type IndexRecord,
   type LocalMeta,
   type Meta,
-  MetaType,
   type SnapshotMetaDD31,
   type SnapshotMetaSDD,
   assertIndexChangeCommit,
@@ -45,6 +44,7 @@ import {
   toChunkIndexDefinition,
 } from './commit.js';
 import {IndexWrite} from './index.js';
+import * as MetaType from './meta-type-enum.js';
 import {
   Write,
   createIndexBTree,
@@ -62,7 +62,7 @@ async function addGenesis(
   clientID: ClientID,
   headName = DEFAULT_HEAD_NAME,
   indexDefinitions: IndexDefinitions,
-  formatVersion: FormatVersion,
+  formatVersion: FormatVersion.Type,
 ): Promise<Chain> {
   expect(chain).to.have.length(0);
   const commit = await createGenesis(
@@ -81,7 +81,7 @@ async function createGenesis(
   clientID: ClientID,
   headName: string,
   indexDefinitions: IndexDefinitions,
-  formatVersion: FormatVersion,
+  formatVersion: FormatVersion.Type,
 ): Promise<Commit<Meta>> {
   await withWriteNoImplicitCommit(store, async w => {
     await initDB(w, headName, clientID, indexDefinitions, formatVersion);
@@ -97,7 +97,7 @@ async function addLocal(
   clientID: ClientID,
   entries: [string, JSONValue][] | undefined,
   headName: string,
-  formatVersion: FormatVersion,
+  formatVersion: FormatVersion.Type,
 ): Promise<Chain> {
   expect(chain).to.have.length.greaterThan(0);
   const i = chain.length;
@@ -120,7 +120,7 @@ async function createLocal(
   i: number,
   clientID: ClientID,
   headName: string,
-  formatVersion: FormatVersion,
+  formatVersion: FormatVersion.Type,
 ): Promise<Commit<Meta>> {
   const lc = new LogContext();
   await withWriteNoImplicitCommit(store, async dagWrite => {
@@ -153,7 +153,7 @@ async function addIndexChange(
   indexName: string | undefined,
   indexDefinition: IndexDefinition | undefined,
   headName: string,
-  formatVersion: FormatVersion,
+  formatVersion: FormatVersion.Type,
 ): Promise<Chain> {
   assert(formatVersion <= FormatVersion.SDD);
   expect(chain).to.have.length.greaterThan(0);
@@ -187,7 +187,7 @@ async function createIndex(
   jsonPointer: string,
   allowEmpty: boolean,
   headName: string,
-  formatVersion: FormatVersion,
+  formatVersion: FormatVersion.Type,
 ): Promise<Commit<Meta>> {
   assert(formatVersion <= FormatVersion.SDD);
   const lc = new LogContext();
@@ -226,7 +226,7 @@ async function addSnapshot(
   cookie: Cookie = `cookie_${chain.length}`,
   lastMutationIDs: Record<ClientID, number> | undefined,
   headName: string,
-  formatVersion: FormatVersion,
+  formatVersion: FormatVersion.Type,
 ): Promise<Chain> {
   expect(chain).to.have.length.greaterThan(0);
   const lc = new LogContext();
@@ -276,12 +276,12 @@ export class ChainBuilder {
   readonly store: Store;
   readonly headName: string;
   chain: Chain;
-  readonly formatVersion: FormatVersion;
+  readonly formatVersion: FormatVersion.Type;
 
   constructor(
     store: Store,
     headName = DEFAULT_HEAD_NAME,
-    formatVersion: FormatVersion = FormatVersion.Latest,
+    formatVersion: FormatVersion.Type = FormatVersion.Latest,
   ) {
     this.store = store;
     this.headName = headName;
@@ -408,7 +408,7 @@ export async function initDB(
   headName: string,
   clientID: ClientID,
   indexDefinitions: IndexDefinitions,
-  formatVersion: FormatVersion,
+  formatVersion: FormatVersion.Type,
 ): Promise<Hash> {
   const basisHash = emptyHash;
   const indexes = await createEmptyIndexMaps(
@@ -447,7 +447,7 @@ export async function initDB(
 async function createEmptyIndexMaps(
   indexDefinitions: IndexDefinitions,
   dagWrite: DagWrite,
-  formatVersion: FormatVersion,
+  formatVersion: FormatVersion.Type,
 ): Promise<Map<string, IndexWrite>> {
   const indexes = new Map();
 
@@ -497,7 +497,7 @@ async function newWriteIndexChange(
   basisHash: Hash,
   dagWrite: DagWrite,
   clientID: ClientID,
-  formatVersion: FormatVersion,
+  formatVersion: FormatVersion.Type,
 ): Promise<Write> {
   assert(formatVersion <= FormatVersion.SDD);
   const basis = await commitFromHash(basisHash, dagWrite);
@@ -524,7 +524,7 @@ async function createIndexForTesting(
   indexes: Map<string, IndexWrite>,
   dagWrite: DagWrite,
   map: BTreeRead,
-  formatVersion: FormatVersion,
+  formatVersion: FormatVersion.Type,
 ): Promise<void> {
   const chunkIndexDefinition: ChunkIndexDefinition = {
     name,

--- a/packages/replicache/src/db/write.test.ts
+++ b/packages/replicache/src/db/write.test.ts
@@ -5,7 +5,7 @@ import {asyncIterableToArray} from '../async-iterable-to-array.js';
 import {BTreeRead} from '../btree/read.js';
 import {mustGetHeadHash} from '../dag/store.js';
 import {TestStore} from '../dag/test-store.js';
-import {FormatVersion} from '../format-version.js';
+import * as FormatVersion from '../format-version-enum.js';
 import {withRead, withWriteNoImplicitCommit} from '../with-transactions.js';
 import {DEFAULT_HEAD_NAME, commitFromHead} from './commit.js';
 import {readIndexesForRead} from './read.js';
@@ -13,7 +13,7 @@ import {initDB} from './test-helpers.js';
 import {newWriteLocal} from './write.js';
 
 suite('basics w/ commit', () => {
-  const t = async (formatVersion: FormatVersion) => {
+  const t = async (formatVersion: FormatVersion.Type) => {
     const clientID = 'client-id';
     const ds = new TestStore();
     const lc = new LogContext();
@@ -102,7 +102,7 @@ suite('basics w/ commit', () => {
 });
 
 suite('basics w/ putCommit', () => {
-  const t = async (formatVersion: FormatVersion) => {
+  const t = async (formatVersion: FormatVersion.Type) => {
     const clientID = 'client-id';
     const ds = new TestStore();
     const lc = new LogContext();

--- a/packages/replicache/src/format-version-enum.ts
+++ b/packages/replicache/src/format-version-enum.ts
@@ -1,0 +1,18 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+export const SDD = 4;
+export const DD31 = 5;
+// V6 added refreshHashes and persistHash to Client to fix ChunkNotFound errors
+export const V6 = 6;
+// V7 added sizeOfEntry to the BTree chunk data.
+export const V7 = 7;
+export const Latest = V7;
+
+export type SDD = typeof SDD;
+export type DD31 = typeof DD31;
+export type V6 = typeof V6;
+export type V7 = typeof V7;
+export type Latest = typeof Latest;
+
+export type Type = SDD | DD31 | V6 | V7 | Latest;
+export type {Type as FormatVersion};

--- a/packages/replicache/src/format-version.ts
+++ b/packages/replicache/src/format-version.ts
@@ -1,16 +1,8 @@
-export const enum FormatVersion {
-  SDD = 4,
-  DD31 = 5,
-  // V6 added refreshHashes and persistHash to Client to fix ChunkNotFound errors
-  V6 = 6,
-  // V7 added sizeOfEntry to the BTree chunk data.
-  V7 = 7,
-  Latest = V7,
-}
+import * as FormatVersion from './format-version-enum.js';
 
-export function parseReplicacheFormatVersion(v: number): FormatVersion {
+export function parseReplicacheFormatVersion(v: number): FormatVersion.Type {
   if (v !== (v | 0) || v < FormatVersion.SDD || v > FormatVersion.Latest) {
     throw new Error(`Unsupported format version: ${v}`);
   }
-  return v as FormatVersion;
+  return v as FormatVersion.Type;
 }

--- a/packages/replicache/src/invoke-kind-enum.ts
+++ b/packages/replicache/src/invoke-kind-enum.ts
@@ -1,0 +1,9 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+export const InitialRun = 0;
+export const Regular = 1;
+
+export type InitialRun = typeof InitialRun;
+export type Regular = typeof Regular;
+
+export type Type = InitialRun | Regular;

--- a/packages/replicache/src/mutation-recovery-test-helper.ts
+++ b/packages/replicache/src/mutation-recovery-test-helper.ts
@@ -10,7 +10,7 @@ import {
   assertLocalMetaDD31,
 } from './db/commit.js';
 import {ChainBuilder} from './db/test-helpers.js';
-import {FormatVersion} from './format-version.js';
+import * as FormatVersion from './format-version-enum.js';
 import {assertHash, newRandomHash} from './hash.js';
 import {IDBStore} from './kv/idb-store.js';
 import {initClientWithClientID} from './persist/clients-test-helpers.js';
@@ -26,7 +26,7 @@ import type {MutatorDefs} from './types.js';
 export async function createPerdag(args: {
   replicacheName: string;
   schemaVersion: string;
-  formatVersion: FormatVersion;
+  formatVersion: FormatVersion.Type;
 }): Promise<Store> {
   const {replicacheName, schemaVersion, formatVersion: formatVersion} = args;
   const idbName = makeIDBNameForTesting(
@@ -96,7 +96,7 @@ export async function createAndPersistClientWithPendingLocalDD31({
   numLocal: number;
   mutatorNames: string[];
   cookie: string | number;
-  formatVersion: FormatVersion;
+  formatVersion: FormatVersion.Type;
   snapshotLastMutationIDs?: Record<ClientID, number> | undefined;
 }): Promise<LocalMetaDD31[]> {
   assert(formatVersion >= FormatVersion.DD31);
@@ -156,7 +156,7 @@ export async function persistSnapshotDD31(
   cookie: string | number,
   mutatorNames: string[],
   snapshotLastMutationIDs: Record<ClientID, number>,
-  formatVersion: FormatVersion,
+  formatVersion: FormatVersion.Type,
 ): Promise<void> {
   const testMemdag = new LazyStore(
     perdag,

--- a/packages/replicache/src/mutation-recovery.ts
+++ b/packages/replicache/src/mutation-recovery.ts
@@ -12,10 +12,8 @@ import {
   isClientStateNotFoundResponse,
   isVersionNotSupportedResponse,
 } from './error-responses.js';
-import {
-  FormatVersion,
-  parseReplicacheFormatVersion as parseFormatVersion,
-} from './format-version.js';
+import * as FormatVersion from './format-version-enum.js';
+import {parseReplicacheFormatVersion as parseFormatVersion} from './format-version.js';
 import {assertHash, newRandomHash} from './hash.js';
 import type {HTTPRequestInfo} from './http-request-info.js';
 import type {CreateStore} from './kv/store.js';
@@ -194,7 +192,7 @@ async function recoverMutationsOfClientV4(
   perdag: Store,
   database: IndexedDBDatabase,
   options: MutationRecoveryOptions,
-  formatVersion: FormatVersion,
+  formatVersion: FormatVersion.Type,
 ): Promise<ClientMap | undefined> {
   assert(database.replicacheFormatVersion === FormatVersion.SDD);
   assertClientV4(client);
@@ -558,7 +556,7 @@ async function recoverMutationsOfClientGroupDD31(
   perdag: Store,
   database: IndexedDBDatabase,
   options: MutationRecoveryOptions,
-  formatVersion: FormatVersion,
+  formatVersion: FormatVersion.Type,
 ): Promise<ClientGroupMap | undefined> {
   assert(database.replicacheFormatVersion >= FormatVersion.DD31);
 

--- a/packages/replicache/src/persist/clients-test-helpers.ts
+++ b/packages/replicache/src/persist/clients-test-helpers.ts
@@ -10,7 +10,7 @@ import {
   getRefs,
   newSnapshotCommitDataSDD,
 } from '../db/commit.js';
-import {FormatVersion} from '../format-version.js';
+import * as FormatVersion from '../format-version-enum.js';
 import {newRandomHash} from '../hash.js';
 import type {IndexDefinitions} from '../index-defs.js';
 import type {ClientID} from '../sync/ids.js';
@@ -100,7 +100,7 @@ export async function initClientWithClientID(
   dagStore: Store,
   mutatorNames: string[],
   indexes: IndexDefinitions,
-  formatVersion: FormatVersion,
+  formatVersion: FormatVersion.Type,
 ): Promise<void> {
   if (formatVersion >= FormatVersion.DD31) {
     await initClientV6(

--- a/packages/replicache/src/persist/clients.test.ts
+++ b/packages/replicache/src/persist/clients.test.ts
@@ -14,7 +14,7 @@ import {
   fromChunk,
 } from '../db/commit.js';
 import {ChainBuilder} from '../db/test-helpers.js';
-import {FormatVersion} from '../format-version.js';
+import * as FormatVersion from '../format-version-enum.js';
 import {deepFreeze} from '../frozen-json.js';
 import {assertHash, fakeHash, newRandomHash} from '../hash.js';
 import type {IndexDefinitions} from '../index-defs.js';

--- a/packages/replicache/src/persist/clients.ts
+++ b/packages/replicache/src/persist/clients.ts
@@ -20,7 +20,7 @@ import {
   toChunkIndexDefinition,
 } from '../db/commit.js';
 import {createIndexBTree} from '../db/write.js';
-import type {FormatVersion} from '../format-version.js';
+import type {FormatVersion} from '../format-version-enum.js';
 import {type FrozenJSONValue, deepFreeze} from '../frozen-json.js';
 import {type Hash, hashSchema} from '../hash.js';
 import {type IndexDefinitions, indexDefinitionsEqual} from '../index-defs.js';

--- a/packages/replicache/src/persist/collect-idb-databases.test.ts
+++ b/packages/replicache/src/persist/collect-idb-databases.test.ts
@@ -4,7 +4,7 @@ import {assertNotUndefined} from 'shared/src/asserts.js';
 import {type SinonFakeTimers, useFakeTimers} from 'sinon';
 import type {Store} from '../dag/store.js';
 import {TestStore} from '../dag/test-store.js';
-import {FormatVersion} from '../format-version.js';
+import * as FormatVersion from '../format-version-enum.js';
 import {fakeHash} from '../hash.js';
 import {IDBStore} from '../kv/idb-store.js';
 import {hasMemStore} from '../kv/mem-store.js';

--- a/packages/replicache/src/persist/collect-idb-databases.ts
+++ b/packages/replicache/src/persist/collect-idb-databases.ts
@@ -3,7 +3,7 @@ import {assert} from 'shared/src/asserts.js';
 import {initBgIntervalProcess} from '../bg-interval.js';
 import {StoreImpl} from '../dag/store-impl.js';
 import type {Store} from '../dag/store.js';
-import {FormatVersion} from '../format-version.js';
+import * as FormatVersion from '../format-version-enum.js';
 import {assertHash, newRandomHash} from '../hash.js';
 import {IDBStore} from '../kv/idb-store.js';
 import type {DropStore, StoreProvider} from '../kv/store.js';

--- a/packages/replicache/src/persist/gather-mem-only-visitor.test.ts
+++ b/packages/replicache/src/persist/gather-mem-only-visitor.test.ts
@@ -2,15 +2,16 @@ import {expect} from 'chai';
 import {LazyStore} from '../dag/lazy-store.js';
 import {TestLazyStore} from '../dag/test-lazy-store.js';
 import {TestStore} from '../dag/test-store.js';
-import {DEFAULT_HEAD_NAME, MetaType} from '../db/commit.js';
+import {DEFAULT_HEAD_NAME} from '../db/commit.js';
+import * as MetaType from '../db/meta-type-enum.js';
 import {ChainBuilder} from '../db/test-helpers.js';
-import {FormatVersion} from '../format-version.js';
+import * as FormatVersion from '../format-version-enum.js';
 import {assertHash, fakeHash, makeNewFakeHashFunction} from '../hash.js';
 import {withRead, withWriteNoImplicitCommit} from '../with-transactions.js';
 import {GatherMemoryOnlyVisitor} from './gather-mem-only-visitor.js';
 
 suite('dag with no memory-only hashes gathers nothing', () => {
-  const t = async (formatVersion: FormatVersion) => {
+  const t = async (formatVersion: FormatVersion.Type) => {
     const clientID = 'client-id';
     const hashFunction = makeNewFakeHashFunction();
     const perdag = new TestStore(undefined, hashFunction);
@@ -51,7 +52,7 @@ suite('dag with no memory-only hashes gathers nothing', () => {
 });
 
 suite('dag with only memory-only hashes gathers everything', () => {
-  const t = async (formatVersion: FormatVersion) => {
+  const t = async (formatVersion: FormatVersion.Type) => {
     const clientID = 'client-id';
     const hashFunction = makeNewFakeHashFunction();
     const perdag = new TestStore(undefined, hashFunction);
@@ -95,7 +96,7 @@ suite('dag with only memory-only hashes gathers everything', () => {
 suite(
   'dag with some persisted hashes and some memory-only hashes on top',
   () => {
-    const t = async (formatVersion: FormatVersion) => {
+    const t = async (formatVersion: FormatVersion.Type) => {
       const clientID = 'client-id';
       const hashFunction = makeNewFakeHashFunction();
       const perdag = new TestStore(undefined, hashFunction);
@@ -172,7 +173,7 @@ suite(
 suite(
   'dag with some permanent hashes and some memory-only hashes on top w index',
   () => {
-    const t = async (formatVersion: FormatVersion) => {
+    const t = async (formatVersion: FormatVersion.Type) => {
       const clientID = 'client-id';
       const hashFunction = makeNewFakeHashFunction();
       const perdag = new TestStore(undefined, hashFunction);

--- a/packages/replicache/src/persist/gather-not-cached-visitor.test.ts
+++ b/packages/replicache/src/persist/gather-not-cached-visitor.test.ts
@@ -1,7 +1,7 @@
 import {expect} from 'chai';
 import {LazyStore} from '../dag/lazy-store.js';
 import {TestStore} from '../dag/test-store.js';
-import {MetaType} from '../db/commit.js';
+import * as MetaType from '../db/meta-type-enum.js';
 import {ChainBuilder} from '../db/test-helpers.js';
 import {assertHash, fakeHash, makeNewFakeHashFunction} from '../hash.js';
 import {withRead, withWriteNoImplicitCommit} from '../with-transactions.js';

--- a/packages/replicache/src/persist/persist.test.ts
+++ b/packages/replicache/src/persist/persist.test.ts
@@ -21,7 +21,7 @@ import {
   createMutatorName,
   getChunkSnapshot,
 } from '../db/test-helpers.js';
-import {FormatVersion} from '../format-version.js';
+import * as FormatVersion from '../format-version-enum.js';
 import {type Hash, assertHash, makeNewFakeHashFunction} from '../hash.js';
 import type {ClientGroupID, ClientID} from '../sync/ids.js';
 import type {WriteTransaction} from '../transactions.js';
@@ -46,15 +46,9 @@ import {
 } from './clients.js';
 import {makeClientID} from './make-client-id.js';
 import {persistDD31} from './persist.js';
+import * as PersistedExpectation from './persisted-expectation-enum.js';
 
 const PERDAG_TEST_SETUP_HEAD_NAME = 'test-setup-head';
-
-enum PersistedExpectation {
-  Snapshot,
-  SnapshotAndLocals,
-  Locals,
-  Nothing,
-}
 
 suite('persistDD31', () => {
   let memdag: LazyStore,
@@ -64,7 +58,7 @@ suite('persistDD31', () => {
     clients: {clientID: ClientID; client: Client}[],
     clientGroupID: ClientGroupID,
     testPersist: (
-      persistedExpectation: PersistedExpectation,
+      persistedExpectation: PersistedExpectation.Type,
       onGatherMemOnlyChunksForTest?: () => Promise<void>,
     ) => Promise<void>;
 
@@ -917,7 +911,7 @@ async function setupPersistTest() {
   assertNotUndefined(clientGroupID);
 
   const testPersist = async (
-    persistedExpectation: PersistedExpectation,
+    persistedExpectation: PersistedExpectation.Type,
     onGatherMemOnlyChunksForTest = () => promiseVoid,
   ) => {
     chunksPersistedSpy.resetHistory();

--- a/packages/replicache/src/persist/persist.ts
+++ b/packages/replicache/src/persist/persist.ts
@@ -17,7 +17,7 @@ import {
   localMutationsGreaterThan,
 } from '../db/commit.js';
 import {rebaseMutationAndPutCommit} from '../db/rebase.js';
-import type {FormatVersion} from '../format-version.js';
+import type {FormatVersion} from '../format-version-enum.js';
 import type {Hash} from '../hash.js';
 import type {ClientGroupID, ClientID} from '../sync/ids.js';
 import type {MutatorDefs} from '../types.js';

--- a/packages/replicache/src/persist/persisted-expectation-enum.ts
+++ b/packages/replicache/src/persist/persisted-expectation-enum.ts
@@ -1,0 +1,13 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+export const Snapshot = 0;
+export const SnapshotAndLocals = 1;
+export const Locals = 2;
+export const Nothing = 3;
+
+export type Snapshot = typeof Snapshot;
+export type SnapshotAndLocals = typeof SnapshotAndLocals;
+export type Locals = typeof Locals;
+export type Nothing = typeof Nothing;
+
+export type Type = Snapshot | SnapshotAndLocals | Locals | Nothing;

--- a/packages/replicache/src/persist/refresh.test.ts
+++ b/packages/replicache/src/persist/refresh.test.ts
@@ -19,7 +19,7 @@ import {
   newSnapshotDD31,
 } from '../db/commit.js';
 import {ChainBuilder} from '../db/test-helpers.js';
-import {FormatVersion} from '../format-version.js';
+import * as FormatVersion from '../format-version-enum.js';
 import {deepFreeze} from '../frozen-json.js';
 import {
   type Hash,

--- a/packages/replicache/src/persist/refresh.ts
+++ b/packages/replicache/src/persist/refresh.ts
@@ -16,7 +16,7 @@ import {
   localMutationsGreaterThan,
 } from '../db/commit.js';
 import {rebaseMutationAndPutCommit} from '../db/rebase.js';
-import type {FormatVersion} from '../format-version.js';
+import type {FormatVersion} from '../format-version-enum.js';
 import type {Hash} from '../hash.js';
 import {
   type DiffComputationConfig,

--- a/packages/replicache/src/replicache-impl.ts
+++ b/packages/replicache/src/replicache-impl.ts
@@ -26,7 +26,7 @@ import {
   isVersionNotSupportedResponse,
   type VersionNotSupportedResponse,
 } from './error-responses.js';
-import {FormatVersion} from './format-version.js';
+import * as FormatVersion from './format-version-enum.js';
 import {deepFreeze} from './frozen-json.js';
 import {getDefaultPuller, isDefaultPuller} from './get-default-puller.js';
 import {getDefaultPusher, isDefaultPusher} from './get-default-pusher.js';
@@ -95,14 +95,10 @@ import {
   type WatchOptions,
   WatchSubscription,
 } from './subscriptions.js';
+import * as HandlePullResponseResultEnum from './sync/handle-pull-response-result-type-enum.js';
 import type {ClientGroupID, ClientID} from './sync/ids.js';
 import {PullError} from './sync/pull-error.js';
-import {
-  beginPullV1,
-  HandlePullResponseResultType,
-  handlePullResponseV1,
-  maybeEndPull,
-} from './sync/pull.js';
+import {beginPullV1, handlePullResponseV1, maybeEndPull} from './sync/pull.js';
 import {push, PUSH_VERSION_DD31} from './sync/push.js';
 import {newRequestID} from './sync/request-id.js';
 import {SYNC_HEAD_NAME} from './sync/sync-head-name.js';
@@ -1070,15 +1066,14 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}> {
     );
 
     switch (result.type) {
-      case HandlePullResponseResultType.Applied:
+      case HandlePullResponseResultEnum.Applied:
         await this.maybeEndPull(result.syncHead, requestID);
         break;
-      case HandlePullResponseResultType.CookieMismatch:
+      case HandlePullResponseResultEnum.CookieMismatch:
         throw new Error(
           'unexpected base cookie for poke: ' + JSON.stringify(poke),
         );
-        break;
-      case HandlePullResponseResultType.NoOp:
+      case HandlePullResponseResultEnum.NoOp:
         break;
     }
   }

--- a/packages/replicache/src/replicache-mutation-recovery-dd31.test.ts
+++ b/packages/replicache/src/replicache-mutation-recovery-dd31.test.ts
@@ -6,7 +6,7 @@ import {stringCompare} from 'shared/src/string-compare.js';
 import sinon from 'sinon';
 import {LazyStore} from './dag/lazy-store.js';
 import {StoreImpl} from './dag/store-impl.js';
-import {FormatVersion} from './format-version.js';
+import * as FormatVersion from './format-version-enum.js';
 import {
   createAndPersistClientWithPendingLocalDD31,
   createAndPersistClientWithPendingLocalSDD,
@@ -68,7 +68,7 @@ suite('DD31', () => {
     expectedLastServerAckdMutationIDs?: Record<ClientID, number> | undefined;
     pullResponse?: PullResponseV1 | undefined;
     pushResponse?: PushResponse | undefined;
-    formatVersion: FormatVersion;
+    formatVersion: FormatVersion.Type;
     expectClientGroupDisabled?: boolean;
   }) {
     sinon.stub(console, 'error');

--- a/packages/replicache/src/replicache-mutation-recovery.test.ts
+++ b/packages/replicache/src/replicache-mutation-recovery.test.ts
@@ -5,7 +5,7 @@ import {randomUint64} from 'shared/src/random-uint64.js';
 import sinon from 'sinon';
 import {LazyStore} from './dag/lazy-store.js';
 import {StoreImpl} from './dag/store-impl.js';
-import {FormatVersion} from './format-version.js';
+import * as FormatVersion from './format-version-enum.js';
 import {
   createAndPersistClientWithPendingLocalSDD,
   createPerdag,

--- a/packages/replicache/src/replicache.ts
+++ b/packages/replicache/src/replicache.ts
@@ -1,6 +1,6 @@
 import type {LogContext} from '@rocicorp/logger';
 import type {MaybePromise} from 'shared/src/types.js';
-import {FormatVersion} from './format-version.js';
+import * as FormatVersion from './format-version-enum.js';
 import {
   dropIDBStoreWithMemFallback,
   newIDBStoreWithMemFallback,

--- a/packages/replicache/src/subscriptions.ts
+++ b/packages/replicache/src/subscriptions.ts
@@ -14,6 +14,7 @@ import type {
 import type {IndexKey} from './db/index.js';
 import {decodeIndexKey} from './db/index.js';
 import type {ScanOptions} from './db/scan.js';
+import * as InvokeKind from './invoke-kind-enum.js';
 import type {DiffComputationConfig, DiffsMap} from './sync/diff.js';
 import {
   type ReadTransaction,
@@ -21,17 +22,12 @@ import {
 } from './transactions.js';
 import type {QueryInternal} from './types.js';
 
-const enum InvokeKind {
-  InitialRun,
-  Regular,
-}
-
 export interface Subscription<R> {
   hasIndexSubscription(indexName: string): boolean;
 
   invoke(
     tx: ReadTransaction,
-    kind: InvokeKind,
+    kind: InvokeKind.Type,
     diffs: DiffsMap | undefined,
   ): Promise<R>;
 
@@ -89,7 +85,7 @@ export class SubscriptionImpl<R> implements Subscription<R> {
 
   invoke(
     tx: ReadTransaction,
-    _kind: InvokeKind,
+    _kind: InvokeKind.Type,
     _diffs: DiffsMap | undefined,
   ): Promise<R> {
     return this.#body(tx);
@@ -214,7 +210,7 @@ export class WatchSubscription implements Subscription<Diff | undefined> {
 
   invoke(
     tx: ReadTransaction,
-    kind: InvokeKind,
+    kind: InvokeKind.Type,
     diffs: DiffsMap | undefined,
   ): Promise<Diff | undefined> {
     const invoke = async <Key extends IndexKey | string>(
@@ -407,7 +403,7 @@ export class SubscriptionsManagerImpl implements SubscriptionsManager {
 
   async #fireSubscriptions(
     subscriptions: Iterable<UnknownSubscription>,
-    kind: InvokeKind,
+    kind: InvokeKind.Type,
     diffs: DiffsMap | undefined,
   ) {
     const subs = [...subscriptions] as readonly Subscription<unknown>[];

--- a/packages/replicache/src/sync/diff.test.ts
+++ b/packages/replicache/src/sync/diff.test.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import type {InternalDiff} from '../btree/node.js';
 import {TestStore} from '../dag/test-store.js';
 import {ChainBuilder} from '../db/test-helpers.js';
-import {FormatVersion} from '../format-version.js';
+import * as FormatVersion from '../format-version-enum.js';
 import type {IndexDefinitions} from '../index-defs.js';
 import {testSubscriptionsManagerOptions} from '../test-util.js';
 import {withRead} from '../with-transactions.js';

--- a/packages/replicache/src/sync/diff.ts
+++ b/packages/replicache/src/sync/diff.ts
@@ -5,7 +5,7 @@ import {allEntriesAsDiff, BTreeRead} from '../btree/read.js';
 import type {Read} from '../dag/store.js';
 import {Commit, commitFromHash, type Meta} from '../db/commit.js';
 import {readIndexesForRead} from '../db/read.js';
-import type {FormatVersion} from '../format-version.js';
+import type {FormatVersion} from '../format-version-enum.js';
 import type {Hash} from '../hash.js';
 
 /**

--- a/packages/replicache/src/sync/handle-pull-response-result-type-enum.ts
+++ b/packages/replicache/src/sync/handle-pull-response-result-type-enum.ts
@@ -1,0 +1,11 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+export const Applied = 0;
+export const NoOp = 1;
+export const CookieMismatch = 2;
+
+export type Applied = typeof Applied;
+export type NoOp = typeof NoOp;
+export type CookieMismatch = typeof CookieMismatch;
+
+export type Type = Applied | NoOp | CookieMismatch;

--- a/packages/replicache/src/sync/patch.test.ts
+++ b/packages/replicache/src/sync/patch.test.ts
@@ -8,7 +8,7 @@ import {
   newWriteSnapshotSDD,
   readIndexesForWrite,
 } from '../db/write.js';
-import {FormatVersion} from '../format-version.js';
+import * as FormatVersion from '../format-version-enum.js';
 import {deepFreeze} from '../frozen-json.js';
 import {
   type PatchOperationInternal,
@@ -18,7 +18,7 @@ import {withWriteNoImplicitCommit} from '../with-transactions.js';
 import {apply} from './patch.js';
 
 suite('patch', () => {
-  const t = (formatVersion: FormatVersion) => {
+  const t = (formatVersion: FormatVersion.Type) => {
     const clientID = 'client-id';
     const store = new TestStore();
     const lc = new LogContext();

--- a/packages/replicache/src/sync/pull.test.ts
+++ b/packages/replicache/src/sync/pull.test.ts
@@ -29,7 +29,7 @@ import {
   isClientStateNotFoundResponse,
   isVersionNotSupportedResponse,
 } from '../error-responses.js';
-import {FormatVersion} from '../format-version.js';
+import * as FormatVersion from '../format-version-enum.js';
 import {type FrozenJSONValue, deepFreeze} from '../frozen-json.js';
 import {
   assertPullResponseV0,
@@ -54,10 +54,10 @@ import {
   withWriteNoImplicitCommit,
 } from '../with-transactions.js';
 import type {DiffsMap} from './diff.js';
+import * as HandlePullResponseResultEnum from './handle-pull-response-result-type-enum.js';
 import {
   type BeginPullResponseV0,
   type BeginPullResponseV1,
-  HandlePullResponseResultType,
   type MaybeEndPullResultV0,
   PULL_VERSION_DD31,
   PULL_VERSION_SDD,
@@ -1088,7 +1088,7 @@ test('begin try pull DD31', async () => {
 });
 
 suite('maybe end try pull', () => {
-  const t = async (formatVersion: FormatVersion) => {
+  const t = async (formatVersion: FormatVersion.Type) => {
     const clientID = 'client-id';
     type Case = {
       name: string;
@@ -1345,7 +1345,7 @@ function makeFakePuller(options: FakePullerArgs): Puller {
 }
 
 suite('changed keys', () => {
-  const t = async (formatVersion: FormatVersion) => {
+  const t = async (formatVersion: FormatVersion.Type) => {
     type IndexDef = {
       name: string;
       prefix: string;
@@ -1825,7 +1825,7 @@ suite('handlePullResponseDD31', () => {
   }: {
     expectedBaseCookieJSON: ReadonlyJSONValue;
     responseCookie: Cookie;
-    expectedResultType: HandlePullResponseResultType;
+    expectedResultType: HandlePullResponseResultEnum.Type;
     setupChain?: (b: ChainBuilder) => Promise<unknown>;
     responseLastMutationIDChanges?: {[clientID: string]: number};
     responsePatch?: PatchOperation[];
@@ -1858,7 +1858,7 @@ suite('handlePullResponseDD31', () => {
     );
 
     expect(result.type).to.equal(expectedResultType);
-    if (result.type === HandlePullResponseResultType.Applied) {
+    if (result.type === HandlePullResponseResultEnum.Applied) {
       assertHash(result.syncHead);
 
       await withRead(store, async dagRead => {
@@ -1894,7 +1894,7 @@ suite('handlePullResponseDD31', () => {
     await t({
       expectedBaseCookieJSON: 1,
       responseCookie: 2,
-      expectedResultType: HandlePullResponseResultType.CookieMismatch,
+      expectedResultType: HandlePullResponseResultEnum.CookieMismatch,
     });
   });
 
@@ -1902,7 +1902,7 @@ suite('handlePullResponseDD31', () => {
     await t({
       expectedBaseCookieJSON: 1,
       responseCookie: 1,
-      expectedResultType: HandlePullResponseResultType.NoOp,
+      expectedResultType: HandlePullResponseResultEnum.NoOp,
       setupChain: b => b.addSnapshot([], clientID1, 1, {}),
     });
   });
@@ -1911,19 +1911,19 @@ suite('handlePullResponseDD31', () => {
     await t({
       expectedBaseCookieJSON: 1,
       responseCookie: 1,
-      expectedResultType: HandlePullResponseResultType.NoOp,
+      expectedResultType: HandlePullResponseResultEnum.NoOp,
       setupChain: b => b.addSnapshot([], clientID1, 1, {[clientID1]: 10}),
     });
     await t({
       expectedBaseCookieJSON: 1,
       responseCookie: 1,
-      expectedResultType: HandlePullResponseResultType.NoOp,
+      expectedResultType: HandlePullResponseResultEnum.NoOp,
       setupChain: b => b.addSnapshot([], clientID1, 1, {[clientID2]: 20}),
     });
     await t({
       expectedBaseCookieJSON: 1,
       responseCookie: 1,
-      expectedResultType: HandlePullResponseResultType.NoOp,
+      expectedResultType: HandlePullResponseResultEnum.NoOp,
       setupChain: b =>
         b.addSnapshot([], clientID1, 1, {
           [clientID1]: 10,
@@ -1936,21 +1936,21 @@ suite('handlePullResponseDD31', () => {
     await t({
       expectedBaseCookieJSON: 1,
       responseCookie: 2,
-      expectedResultType: HandlePullResponseResultType.Applied,
+      expectedResultType: HandlePullResponseResultEnum.Applied,
       setupChain: b => b.addSnapshot([], clientID1, 1, {[clientID1]: 10}),
       responseLastMutationIDChanges: {[clientID1]: 10},
     });
     await t({
       expectedBaseCookieJSON: 1,
       responseCookie: 2,
-      expectedResultType: HandlePullResponseResultType.Applied,
+      expectedResultType: HandlePullResponseResultEnum.Applied,
       setupChain: b => b.addSnapshot([], clientID1, 1, {[clientID2]: 20}),
       responseLastMutationIDChanges: {[clientID2]: 20},
     });
     await t({
       expectedBaseCookieJSON: 1,
       responseCookie: 2,
-      expectedResultType: HandlePullResponseResultType.Applied,
+      expectedResultType: HandlePullResponseResultEnum.Applied,
       setupChain: b =>
         b.addSnapshot([], clientID1, 1, {
           [clientID1]: 10,
@@ -1963,7 +1963,7 @@ suite('handlePullResponseDD31', () => {
     await t({
       expectedBaseCookieJSON: 1,
       responseCookie: 2,
-      expectedResultType: HandlePullResponseResultType.Applied,
+      expectedResultType: HandlePullResponseResultEnum.Applied,
       setupChain: b =>
         b.addSnapshot([], clientID1, 1, {
           [clientID1]: 10,
@@ -1976,7 +1976,7 @@ suite('handlePullResponseDD31', () => {
     await t({
       expectedBaseCookieJSON: 1,
       responseCookie: 2,
-      expectedResultType: HandlePullResponseResultType.Applied,
+      expectedResultType: HandlePullResponseResultEnum.Applied,
       setupChain: b =>
         b.addSnapshot([], clientID1, 1, {
           [clientID1]: 10,
@@ -1989,7 +1989,7 @@ suite('handlePullResponseDD31', () => {
     await t({
       expectedBaseCookieJSON: 1,
       responseCookie: 2,
-      expectedResultType: HandlePullResponseResultType.Applied,
+      expectedResultType: HandlePullResponseResultEnum.Applied,
       setupChain: b =>
         b.addSnapshot([], clientID1, 1, {
           [clientID1]: 10,
@@ -2001,7 +2001,7 @@ suite('handlePullResponseDD31', () => {
     await t({
       expectedBaseCookieJSON: 1,
       responseCookie: 2,
-      expectedResultType: HandlePullResponseResultType.Applied,
+      expectedResultType: HandlePullResponseResultEnum.Applied,
       setupChain: async b => {
         await b.addSnapshot([], clientID1, 1, {
           [clientID1]: 10,
@@ -2018,7 +2018,7 @@ suite('handlePullResponseDD31', () => {
     await t({
       expectedBaseCookieJSON: 1,
       responseCookie: 2,
-      expectedResultType: HandlePullResponseResultType.Applied,
+      expectedResultType: HandlePullResponseResultEnum.Applied,
       setupChain: b => b.addSnapshot([], clientID1, 1, {[clientID1]: 10}),
       responseLastMutationIDChanges: {[clientID1]: 10},
       responsePatch: [
@@ -2034,7 +2034,7 @@ suite('handlePullResponseDD31', () => {
     await t({
       expectedBaseCookieJSON: 1,
       responseCookie: 2,
-      expectedResultType: HandlePullResponseResultType.Applied,
+      expectedResultType: HandlePullResponseResultEnum.Applied,
       setupChain: async b => {
         await b.addSnapshot([], clientID1, 1, {[clientID1]: 10});
         await b.addLocal(clientID1, [['b', 1]]);
@@ -2055,7 +2055,7 @@ suite('handlePullResponseDD31', () => {
     await t({
       expectedBaseCookieJSON: 1,
       responseCookie: 2,
-      expectedResultType: HandlePullResponseResultType.Applied,
+      expectedResultType: HandlePullResponseResultEnum.Applied,
       setupChain: b => b.addSnapshot([], clientID1, 1, {[clientID1]: 10}),
       indexDefinitions: {
         i1: {
@@ -2081,7 +2081,7 @@ suite('handlePullResponseDD31', () => {
     await t({
       expectedBaseCookieJSON: 1,
       responseCookie: 2,
-      expectedResultType: HandlePullResponseResultType.Applied,
+      expectedResultType: HandlePullResponseResultEnum.Applied,
       setupChain: async b => {
         await b.addSnapshot([], clientID1, 1, {[clientID1]: 10});
         await b.addLocal(clientID1, [['b', {id: 'bId', x: 2}]]);

--- a/packages/replicache/src/sync/pull.ts
+++ b/packages/replicache/src/sync/pull.ts
@@ -26,7 +26,7 @@ import {
   updateIndexes,
 } from '../db/write.js';
 import {isErrorResponse} from '../error-responses.js';
-import {FormatVersion} from '../format-version.js';
+import * as FormatVersion from '../format-version-enum.js';
 import {deepFreeze, type FrozenJSONValue} from '../frozen-json.js';
 import {
   assertPullerResultV0,
@@ -52,6 +52,7 @@ import {
   type DiffComputationConfig,
   DiffsMap,
 } from './diff.js';
+import * as HandlePullResponseResultType from './handle-pull-response-result-type-enum.js';
 import type {ClientGroupID, ClientID} from './ids.js';
 import * as patch from './patch.js';
 import {PullError} from './pull-error.js';
@@ -123,7 +124,7 @@ export async function beginPullV0(
   puller: Puller,
   requestID: string,
   store: Store,
-  formatVersion: FormatVersion,
+  formatVersion: FormatVersion.Type,
   lc: LogContext,
   createSyncBranch = true,
 ): Promise<BeginPullResponseV0> {
@@ -201,7 +202,7 @@ export async function beginPullV1(
   puller: Puller,
   requestID: string,
   store: Store,
-  formatVersion: FormatVersion,
+  formatVersion: FormatVersion.Type,
   lc: LogContext,
   createSyncBranch = true,
 ): Promise<BeginPullResponseV1> {
@@ -305,7 +306,7 @@ export function handlePullResponseV0(
   expectedBaseCookie: ReadonlyJSONValue,
   response: PullResponseOKV0,
   clientID: ClientID,
-  formatVersion: FormatVersion,
+  formatVersion: FormatVersion.Type,
 ): Promise<HandlePullResponseResult> {
   // It is possible that another sync completed while we were pulling. Ensure
   // that is not the case by re-checking the base snapshot.
@@ -440,12 +441,6 @@ export function handlePullResponseV0(
   });
 }
 
-export enum HandlePullResponseResultType {
-  Applied,
-  NoOp,
-  CookieMismatch,
-}
-
 type HandlePullResponseResult =
   | {
       type: HandlePullResponseResultType.Applied;
@@ -471,7 +466,7 @@ export function handlePullResponseV1(
   expectedBaseCookie: FrozenJSONValue,
   response: PullResponseOKV1Internal,
   clientID: ClientID,
-  formatVersion: FormatVersion,
+  formatVersion: FormatVersion.Type,
 ): Promise<HandlePullResponseResult> {
   // It is possible that another sync completed while we were pulling. Ensure
   // that is not the case by re-checking the base snapshot.
@@ -581,7 +576,7 @@ export function maybeEndPull<M extends LocalMeta>(
   expectedSyncHead: Hash,
   clientID: ClientID,
   diffConfig: DiffComputationConfig,
-  formatVersion: FormatVersion,
+  formatVersion: FormatVersion.Type,
 ): Promise<{
   syncHead: Hash;
   replayMutations: Commit<M>[];

--- a/packages/replicache/src/sync/push.test.ts
+++ b/packages/replicache/src/sync/push.test.ts
@@ -4,7 +4,7 @@ import {TestStore} from '../dag/test-store.js';
 import {DEFAULT_HEAD_NAME} from '../db/commit.js';
 import {readFromDefaultHead} from '../db/read.js';
 import {ChainBuilder} from '../db/test-helpers.js';
-import {FormatVersion} from '../format-version.js';
+import * as FormatVersion from '../format-version-enum.js';
 import {deepFreeze} from '../frozen-json.js';
 import type {Pusher, PusherResult} from '../pusher.js';
 import {withRead, withWrite} from '../with-transactions.js';

--- a/packages/replicache/src/sync/test-helpers.ts
+++ b/packages/replicache/src/sync/test-helpers.ts
@@ -12,10 +12,10 @@ import {
   newWriteSnapshotSDD,
   readIndexesForWrite,
 } from '../db/write.js';
-import {FormatVersion} from '../format-version.js';
-import {SYNC_HEAD_NAME} from '../sync/sync-head-name.js';
+import * as FormatVersion from '../format-version-enum.js';
 import {withRead, withWriteNoImplicitCommit} from '../with-transactions.js';
 import type {ClientID} from './ids.js';
+import {SYNC_HEAD_NAME} from './sync-head-name.js';
 
 // See db.test_helpers for addLocal, addSnapshot, etc. We can't put addLocalRebase
 // there because sync depends on db, and addLocalRebase depends on sync.
@@ -30,7 +30,7 @@ export async function addSyncSnapshot(
   store: Store,
   takeIndexesFrom: number,
   clientID: ClientID,
-  formatVersion: FormatVersion,
+  formatVersion: FormatVersion.Type,
 ): Promise<Chain> {
   expect(chain.length >= 2).to.be.true;
 


### PR DESCRIPTION
Motivation, enums are not JavaScript plus types. By removing these we can simplify the tool chain in the future.