### PR TITLE
fix(zero-cache): release the db connection after initializing change-source

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/change-source.ts
@@ -55,6 +55,7 @@ export async function initializeChangeSource(
 
   const replica = new Database(lc, replicaDbFile);
   const replicationConfig = getSubscriptionState(new StatementRunner(replica));
+  replica.close();
 
   if (shard.publications.length) {
     // Verify that the publications match what has been synced.


### PR DESCRIPTION
This fixes the 'database is locked' error that we sometimes get in dev when switching between zero-cache modes.