### PR TITLE
fix(zero-cache): gracefully handle upstream postgres restarts

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/change-source.ts
@@ -145,6 +145,10 @@ class PostgresChangeSource implements ChangeSource {
           if (change) {
             changes.push(change);
           }
+        })
+        .on('error', err => {
+          this.#lc.error?.('error from upstream postgres', err);
+          changes.fail(err);
         });
 
       await this.stopExistingReplicationSlotSubscriber(db, slot);


### PR DESCRIPTION
Handle errors from the upstream postgres replication stream (e.g. if postgres is restarted) and let the exponential backoff kick in.

<img width="1473" alt="Screenshot 2024-10-04 at 19 50 20" src="https://github.com/user-attachments/assets/e5b497e4-8266-4ef5-b422-32b6afd86d0f">
