### PR TITLE
fix(zero): add prepack and postpack scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17578,7 +17578,10 @@
         "esbuild": "^0.20.2",
         "replicache": "15.2.1",
         "tsc-alias": "^1.8.10",
-        "typescript": "^5.5.3"
+        "typescript": "^5.5.3",
+        "zero-cache": "0.0.0",
+        "zero-client": "0.0.0",
+        "zero-react": "0.0.0"
       }
     },
     "packages/zero-cache": {
@@ -19442,7 +19445,10 @@
         "tsc-alias": "^1.8.10",
         "typescript": "^5.5.3",
         "ws": "^8.18.0",
-        "xxhash-wasm": "^1.0.2"
+        "xxhash-wasm": "^1.0.2",
+        "zero-cache": "0.0.0",
+        "zero-client": "0.0.0",
+        "zero-react": "0.0.0"
       },
       "dependencies": {
         "esbuild": {

--- a/packages/zero/package.json
+++ b/packages/zero/package.json
@@ -2,8 +2,9 @@
   "name": "@rocicorp/zero",
   "version": "0.0.2024100502+50481a",
   "scripts": {
-    "prepack": "rm -rf deps && mkdir -p deps/sqlite3 && cp -r ../../deps/sqlite3/* deps/sqlite3/",
+    "prepack": "rm -rf deps && mkdir -p deps/sqlite3 && cp -r ../../deps/sqlite3/* deps/sqlite3/ && node tool/prepack.js",
     "preinstall": "node tool/install-sqlite3.js",
+    "postpack": "node tool/postpack.js",
     "build": "rm -rf out && npm run build-server && npm run build-client",
     "build-client": "tsc -p tsconfig.client.json && tsc-alias -p tsconfig.client.json && node tool/build.js",
     "build-server": "tsc -p tsconfig.server.json && tsc-alias -p tsconfig.server.json",
@@ -45,7 +46,10 @@
     "esbuild": "^0.20.2",
     "replicache": "15.2.1",
     "tsc-alias": "^1.8.10",
-    "typescript": "^5.5.3"
+    "typescript": "^5.5.3",
+    "zero-cache": "0.0.0",
+    "zero-client": "0.0.0",
+    "zero-react": "0.0.0"
   },
   "type": "module",
   "main": "out/zero.js",

--- a/packages/zero/tool/install-sqlite3.js
+++ b/packages/zero/tool/install-sqlite3.js
@@ -12,7 +12,7 @@ if (isPartOfMonorepo()) {
 } else {
   // Now run the npm install command
   execSync(
-    `npm install better-sqlite3@11.1.2 --no-save --build-from-source --sqlite3="${cwd()}/deps/sqlite3"`,
+    `npm install better-sqlite3@11.1.2 --no-save --omit=dev --production --build-from-source --sqlite3="${cwd()}/deps/sqlite3"`,
     {
       stdio: 'inherit',
       cwd: cwd(),

--- a/packages/zero/tool/internal-deps.js
+++ b/packages/zero/tool/internal-deps.js
@@ -1,0 +1,1 @@
+export const internalDeps = ['zero-cache', 'zero-client', 'zero-react'];

--- a/packages/zero/tool/postpack.js
+++ b/packages/zero/tool/postpack.js
@@ -1,0 +1,22 @@
+import {readFile, writeFile} from 'node:fs/promises';
+import {internalDeps} from './internal-deps.js';
+
+// See comment in postpack.js for why we need to add internal dependencies to
+// the package.json file.
+
+/**
+ * @param {URL} path
+ * @returns {Promise<void>}
+ */
+async function addZeroInternalPackages(path) {
+  const x = await readFile(path, 'utf-8');
+  const pkg = JSON.parse(x);
+
+  for (const key of internalDeps) {
+    pkg.devDependencies[key] = '0.0.0';
+  }
+
+  await writeFile(path, JSON.stringify(pkg, null, 2) + '\n');
+}
+
+await addZeroInternalPackages(new URL('../package.json', import.meta.url));

--- a/packages/zero/tool/prepack.js
+++ b/packages/zero/tool/prepack.js
@@ -1,0 +1,32 @@
+import {readFile, writeFile} from 'node:fs/promises';
+import {internalDeps} from './internal-deps.js';
+
+// The reason for this script (and postpack) is to remove internal dependencies
+// from the package.json file. We need to do this because we do not publish the
+// internal dependencies to npm. We still need to keep the dependencies in the
+// package.json file so that turbo can build and run things in the right order.
+//
+// We cannot keep the internal packages in `devDependencies` because we have a
+// `preinstall` script to install better-sqlite3 from source and this is using
+// `npm install` which resoves and tries to download the internal packages from
+// npm.
+//
+// The correct solution is to prebuild the better-sqlite3 binary and upload it
+// to npm.
+
+/**
+ * @param {URL} path
+ * @returns {Promise<void>}
+ */
+async function removeZeroInternalPackages(path) {
+  const x = await readFile(path, 'utf-8');
+  const pkg = JSON.parse(x);
+
+  for (const key of internalDeps) {
+    delete pkg.devDependencies[key];
+  }
+
+  await writeFile(path, JSON.stringify(pkg, null, 2) + '\n');
+}
+
+await removeZeroInternalPackages(new URL('../package.json', import.meta.url));


### PR DESCRIPTION
The reason for these scripts is to remove internal dependencies from the package.json file. We need to do this because we do not publish the internal dependencies to npm. We still need to keep the dependencies in the package.json file so that turbo can build and run things in the right order.

We cannot keep the internal packages in `devDependencies` because we have a `preinstall` script to install better-sqlite3 from source and this is using `npm install` which resoves and tries to download the internal packages from npm.

The correct solution is to prebuild the better-sqlite3 binary and upload it to npm.