### PR TITLE
feat(zero-cache): graceful/gradual shutdown (i.e. rolling restarts)

### DIFF
--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -3,18 +3,18 @@ import {getZeroConfig} from '../config/zero-config.js';
 import {ChangeStreamerHttpServer} from '../services/change-streamer/change-streamer-http.js';
 import {initializeStreamer} from '../services/change-streamer/change-streamer-service.js';
 import {initializeChangeSource} from '../services/change-streamer/pg/change-source.js';
-import {runOrExit} from '../services/runner.js';
 import {pgClient} from '../types/pg.js';
 import {
   parentWorker,
   singleProcessMode,
   type Worker,
 } from '../types/processes.js';
+import {exitAfter, runUntilKilled} from './life-cycle.js';
 import {createLogContext} from './logging.js';
 
 const MAX_CHANGE_DB_CONNECTIONS = 5;
 
-export default async function runWorker(parent: Worker) {
+export default async function runWorker(parent: Worker): Promise<void> {
   const config = await getZeroConfig();
   const lc = createLogContext(config.log, {worker: 'change-streamer'});
 
@@ -48,12 +48,12 @@ export default async function runWorker(parent: Worker) {
     changeStreamer,
   );
 
-  void runOrExit(lc, changeStreamer, changeStreamerWebServer);
-
   parent.send(['ready', {ready: true}]);
+
+  return runUntilKilled(lc, parent, changeStreamer, changeStreamerWebServer);
 }
 
 // fork()
 if (!singleProcessMode()) {
-  void runWorker(must(parentWorker));
+  exitAfter(runWorker(must(parentWorker)));
 }

--- a/packages/zero-cache/src/server/life-cycle.test.ts
+++ b/packages/zero-cache/src/server/life-cycle.test.ts
@@ -1,0 +1,137 @@
+import {resolver} from '@rocicorp/resolver';
+import EventEmitter from 'node:events';
+import {createSilentLogContext} from 'shared/src/logging-test-utils.js';
+import {promiseVoid} from 'shared/src/resolved-promises.js';
+import {beforeEach, describe, expect, test} from 'vitest';
+import type {SingletonService} from '../services/service.js';
+import {inProcChannel} from '../types/processes.js';
+import {runUntilKilled, Terminator, type WorkerType} from './life-cycle.js';
+
+describe('shutdown', () => {
+  const lc = createSilentLogContext();
+  let proc: EventEmitter;
+  let terminator: Terminator;
+  let events: string[];
+  let changeStreamer: TestWorker;
+  let replicator: TestWorker;
+  let syncer1: TestWorker;
+  let syncer2: TestWorker;
+  let all: TestWorker[];
+
+  class TestWorker implements SingletonService {
+    readonly id: string;
+    readonly type: WorkerType;
+    draining = resolver();
+    finishDrain = resolver();
+    running = resolver();
+    stopped = resolver();
+
+    constructor(id: string, type: WorkerType) {
+      this.id = id;
+      this.type = type;
+    }
+
+    run() {
+      this.running.resolve();
+      return this.stopped.promise;
+    }
+
+    drain(): Promise<void> {
+      events.push(`drain ${this.type}`);
+      this.draining.resolve();
+      return this.finishDrain.promise;
+    }
+
+    stop() {
+      events.push(`stop ${this.type}`);
+      this.stopped.resolve();
+      return promiseVoid;
+    }
+  }
+
+  function startWorker(id: string, type: WorkerType): TestWorker {
+    const worker = new TestWorker(id, type);
+    const [parentPort, childPort] = inProcChannel();
+
+    terminator.addWorker(parentPort, type);
+
+    void runUntilKilled(lc, childPort, worker).then(
+      () => parentPort.emit('close', 0),
+      err => parentPort.emit('error', err),
+    );
+    return worker;
+  }
+
+  beforeEach(async () => {
+    proc = new EventEmitter();
+    terminator = new Terminator(
+      lc,
+      proc,
+      code => proc.emit('exit', code) as never,
+    );
+    events = [];
+    changeStreamer = startWorker('cs', 'supporting');
+    replicator = startWorker('rep', 'supporting');
+    syncer1 = startWorker('s1', 'user-facing');
+    syncer2 = startWorker('s2', 'user-facing');
+
+    all = [changeStreamer, replicator, syncer1, syncer2];
+
+    await Promise.all(all.map(w => w.running.promise));
+  });
+
+  test.each([['SIGTERM'], ['SIGINT']])(
+    'graceful shutdown: %s',
+    async signal => {
+      proc.emit(signal);
+
+      await syncer1.draining.promise;
+      await syncer2.draining.promise;
+
+      syncer1.finishDrain.resolve();
+      syncer2.finishDrain.resolve();
+
+      await changeStreamer.draining.promise;
+      await replicator.draining.promise;
+
+      changeStreamer.finishDrain.resolve();
+      replicator.finishDrain.resolve();
+
+      await Promise.all(all.map(w => w.stopped.promise));
+
+      expect(events).toEqual([
+        'drain user-facing',
+        'drain user-facing',
+        'stop user-facing',
+        'stop user-facing',
+        'drain supporting',
+        'drain supporting',
+        'stop supporting',
+        'stop supporting',
+      ]);
+    },
+  );
+
+  test.each([
+    ['SIGQUIT', () => proc.emit('SIGQUIT'), []],
+    ['supporting worker exits', () => replicator.stop(), ['stop supporting']],
+    ['supporting worker error', () => changeStreamer.stopped.reject('foo'), []],
+    ['user-facing worker exits', () => syncer1.stop(), ['stop user-facing']],
+    ['user-facing worker error', () => syncer2.stopped.reject('foo'), []],
+  ])('forceful shutdown: %s', async (_name, fn, additionalEvents) => {
+    void fn();
+
+    await Promise.allSettled(all.map(w => w.stopped.promise));
+
+    // sort() because order doesn't matter.
+    expect(events.sort()).toEqual(
+      [
+        'stop supporting',
+        'stop supporting',
+        'stop user-facing',
+        'stop user-facing',
+        ...additionalEvents,
+      ].sort(),
+    );
+  });
+});

--- a/packages/zero-cache/src/server/life-cycle.ts
+++ b/packages/zero-cache/src/server/life-cycle.ts
@@ -1,0 +1,165 @@
+import {LogContext} from '@rocicorp/logger';
+import type {EventEmitter} from 'stream';
+import type {SingletonService} from '../services/service.js';
+import type {Worker} from '../types/processes.js';
+
+/**
+ * * `user-facing` workers serve external requests and are the first to
+ *   receive a `SIGTERM` or `SIGINT` signal for graceful shutdown.
+ *
+ * * `supporting` workers support `user-facing` workers and are sent
+ *   the `SIGTERM` signal only after all `user-facing` workers have
+ *   exited.
+ *
+ * For other kill signals, such as `SIGQUIT`, all workers
+ * are stopped without draining. Additionally, if any worker exits
+ * unexpectedly, all workers sent an immediate `SIGQUIT` signal.
+ */
+export type WorkerType = 'user-facing' | 'supporting';
+
+export const GRACEFUL_SHUTDOWN = ['SIGTERM', 'SIGINT'] as const;
+export const FORCEFUL_SHUTDOWN = ['SIGQUIT'] as const;
+
+/**
+ * Handles termination signals and coordination of graceful shutdown.
+ */
+export class Terminator {
+  readonly #lc: LogContext;
+  readonly #userFacing = new Set<Worker>();
+  readonly #all = new Set<Worker>();
+  readonly #exit: (code: number) => never;
+
+  #drainStart = 0;
+
+  constructor(
+    lc: LogContext,
+    // testing hooks
+    proc: EventEmitter = process,
+    exit = (code: number) => process.exit(code),
+  ) {
+    this.#lc = lc.withContext('component', 'terminator');
+
+    // Propagate `SIGTERM` and `SIGINT` to all user-facing workers,
+    // initiating a graceful shutdown. The terminator process will
+    // exit once all user-facing workers have exited ...
+    for (const signal of GRACEFUL_SHUTDOWN) {
+      proc.on(signal, () => {
+        this.#drainStart = Date.now();
+        kill(this.#userFacing, signal);
+      });
+    }
+
+    // ... which will result in sending `SIGTERM` to the remaining workers.
+    proc.on('exit', code =>
+      kill(this.#all, code === 0 ? GRACEFUL_SHUTDOWN[0] : FORCEFUL_SHUTDOWN[0]),
+    );
+
+    // For other (catchable) kill signals, exit with a non-zero error code
+    // to send a `SIGQUIT` to all workers. For this signal, workers are
+    // stopped immediately without draining. See `runUntilKilled()`.
+    for (const signal of FORCEFUL_SHUTDOWN) {
+      proc.on(signal, () => exit(-1));
+    }
+
+    this.#exit = exit;
+  }
+
+  addWorker(worker: Worker, type: WorkerType): Worker {
+    if (type === 'user-facing') {
+      this.#userFacing.add(worker);
+    }
+    this.#all.add(worker);
+
+    worker.on('error', err => this.logErrorAndExit(err));
+    worker.on('close', code => this.#onExit(code, worker, type));
+    return worker;
+  }
+
+  logErrorAndExit(err: unknown): never {
+    this.#lc.error?.(`shutting down for error`, err);
+    this.#exit(-1);
+  }
+
+  #onExit(code: number, worker: Worker, type: WorkerType) {
+    if (code !== 0) {
+      this.#lc.error?.(`shutting down because worker exited with code ${code}`);
+      return this.#exit(code);
+    }
+    if (type === 'supporting') {
+      this.#lc.error?.(
+        `shutting down because supporting worker exited with code ${code}`,
+      );
+      return this.#exit(-1);
+    }
+    if (this.#drainStart === 0) {
+      this.#lc.error?.(
+        `shutting down because user-facing worker exited before SIGTERM`,
+      );
+      return this.#exit(-1);
+    }
+
+    // user-facing worker finished draining.
+    this.#userFacing.delete(worker);
+    this.#all.delete(worker);
+
+    if (this.#userFacing.size === 0) {
+      this.#lc.info?.(
+        `all user-facing workers drained (${Date.now() - this.#drainStart} ms)`,
+      );
+      return this.#exit(0);
+    }
+  }
+}
+
+function kill(workers: Iterable<Worker>, signal: NodeJS.Signals) {
+  for (const worker of workers) {
+    worker.kill(signal);
+  }
+}
+
+/**
+ * Runs the specified services, stopping them on `SIGTERM` or `SIGINT` with
+ * an optional {@link SingletonService.drain drain()}, or stopping them
+ * without draining for `SIGQUIT`.
+ *
+ * @returns a Promise that resolves/rejects when any of the services stops/throws.
+ */
+
+export async function runUntilKilled(
+  lc: LogContext,
+  parent: Worker,
+  ...services: SingletonService[]
+): Promise<void> {
+  for (const signal of [...GRACEFUL_SHUTDOWN, ...FORCEFUL_SHUTDOWN]) {
+    parent.once(signal, () => {
+      const GRACEFUL_SIGNALS = GRACEFUL_SHUTDOWN as readonly NodeJS.Signals[];
+
+      services.forEach(async svc => {
+        if (GRACEFUL_SIGNALS.includes(signal) && svc.drain) {
+          lc.info?.(`draining ${svc.constructor.name} (${svc.id})`);
+          await svc.drain();
+        }
+        lc.info?.(`stopping ${svc.constructor.name} (${svc.id}) for ${signal}`);
+        await svc.stop();
+      });
+    });
+  }
+
+  try {
+    // Run all services and resolve when any of them stops.
+    const svc = await Promise.race(
+      services.map(svc => svc.run().then(() => svc)),
+    );
+    lc.info?.(`${svc.constructor.name} (${svc.id}) stopped`);
+  } catch (e) {
+    lc.error?.(`exiting on error`, e);
+    throw e;
+  }
+}
+
+export function exitAfter(running: Promise<void>) {
+  void running.then(
+    () => process.exit(0),
+    () => process.exit(-1),
+  );
+}

--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -14,21 +14,19 @@ import {
   type ReplicaFileMode,
   subscribeTo,
 } from '../workers/replicator.js';
+import {GRACEFUL_SHUTDOWN, Terminator, type WorkerType} from './life-cycle.js';
 import {createLogContext} from './logging.js';
 
 const startMs = Date.now();
 const config = await getZeroConfig();
 const lc = createLogContext(config.log, {worker: 'dispatcher'});
 
-function logErrorAndExit(err: unknown) {
-  lc.error?.(err);
-  process.exit(1);
-}
-
+const terminator = new Terminator(lc);
 const ready: Promise<void>[] = [];
 
 function loadWorker(
   modulePath: string,
+  type: WorkerType,
   id?: string | number,
   ...args: string[]
 ): Worker {
@@ -42,18 +40,16 @@ function loadWorker(
   const {promise, resolve} = resolver();
   ready.push(promise);
 
-  return worker
-    .onceMessageType('ready', () => {
-      lc.debug?.(`${name} ready (${Date.now() - startMs} ms)`);
-      resolve();
-    })
-    .on('close', logErrorAndExit);
+  return terminator.addWorker(worker, type).onceMessageType('ready', () => {
+    lc.debug?.(`${name} ready (${Date.now() - startMs} ms)`);
+    resolve();
+  });
 }
 
 const {promise: changeStreamerReady, resolve} = resolver();
 const changeStreamer = config.changeStreamerConnStr
   ? resolve()
-  : loadWorker('./change-streamer.ts').once('message', resolve);
+  : loadWorker('./change-streamer.ts', 'supporting').once('message', resolve);
 
 const numSyncers = config.numSyncWorkers
   ? Number(config.numSyncWorkers)
@@ -75,10 +71,12 @@ await changeStreamerReady;
 
 if (config.litestream) {
   const mode: ReplicaFileMode = 'backup';
-  const replicator = loadWorker('./replicator.ts', mode, mode).once(
-    'message',
-    () => subscribeTo(lc, replicator),
-  );
+  const replicator = loadWorker(
+    './replicator.ts',
+    'supporting',
+    mode,
+    mode,
+  ).once('message', () => subscribeTo(lc, replicator));
   const notifier = createNotifierFrom(lc, replicator);
   if (changeStreamer) {
     handleSubscriptionsFrom(lc, changeStreamer, notifier);
@@ -88,13 +86,15 @@ if (config.litestream) {
 const syncers: Worker[] = [];
 if (numSyncers) {
   const mode: ReplicaFileMode = config.litestream ? 'serving-copy' : 'serving';
-  const replicator = loadWorker('./replicator.ts', mode, mode).once(
-    'message',
-    () => subscribeTo(lc, replicator),
-  );
+  const replicator = loadWorker(
+    './replicator.ts',
+    'supporting',
+    mode,
+    mode,
+  ).once('message', () => subscribeTo(lc, replicator));
   const notifier = createNotifierFrom(lc, replicator);
   for (let i = 0; i < numSyncers; i++) {
-    syncers.push(loadWorker('./syncer.ts', i + 1));
+    syncers.push(loadWorker('./syncer.ts', 'user-facing', i + 1));
   }
   syncers.forEach(syncer => handleSubscriptionsFrom(lc, syncer, notifier));
 }
@@ -113,6 +113,13 @@ if (numSyncers) {
   try {
     await dispatcher.run();
   } catch (err) {
-    logErrorAndExit(err);
+    terminator.logErrorAndExit(err);
+  }
+
+  for (const signal of GRACEFUL_SHUTDOWN) {
+    process.on(signal, () => {
+      lc.info?.('drain mode: no longer accepting connections');
+      return dispatcher.stop();
+    });
   }
 }

--- a/packages/zero-cache/src/services/runner.ts
+++ b/packages/zero-cache/src/services/runner.ts
@@ -46,34 +46,12 @@ export class ServiceRunner<S extends Service> {
       });
     return service;
   }
-}
 
-/**
- * Runs the specified services, exiting on SIGTERM, or logging an error and
- * exiting the process if any of them fail.
- */
-export async function runOrExit(
-  lc: LogContext,
-  ...services: Service[]
-): Promise<void> {
-  for (const signal of ['SIGINT', 'SIGQUIT', 'SIGTERM'] as const) {
-    process.once(signal, () => {
-      for (const svc of services) {
-        lc.info?.(`exiting ${svc.constructor.name} (${svc.id}) for ${signal}`);
-        void svc.stop();
-      }
-    });
+  get size() {
+    return this.#instances.size;
   }
 
-  try {
-    // Exit if any of the services stop.
-    const svc = await Promise.race(
-      services.map(svc => svc.run().then(() => svc)),
-    );
-    lc.info?.(`exiting because ${svc.constructor.name} (${svc.id}) stopped`);
-    process.exit(0);
-  } catch (e) {
-    lc.error?.(`exiting on error`, e);
-    process.exit(-1);
+  getServices(): Iterable<S> {
+    return this.#instances.values();
   }
 }

--- a/packages/zero-cache/src/services/service.ts
+++ b/packages/zero-cache/src/services/service.ts
@@ -29,3 +29,12 @@ export interface ActivityBasedService extends Service {
    */
   keepalive(): boolean;
 }
+
+export interface SingletonService extends Service {
+  /**
+   * `drain` is called when the process receives the `SIGTERM` signal
+   * to initiate graceful shutdown. The process will wait until the
+   * return Promise resolves, after which {@link stop()} will be called.
+   */
+  drain?(): Promise<void>;
+}

--- a/packages/zero-cache/src/types/processes.test.ts
+++ b/packages/zero-cache/src/types/processes.test.ts
@@ -29,6 +29,24 @@ describe('types/processes', () => {
     ]);
   });
 
+  test('in-proc channel kill', () => {
+    const [port1, port2] = inProcChannel();
+
+    const signals1: unknown[] = [];
+    const signals2: unknown[] = [];
+
+    port1.on('SIGTERM', data => signals1.push(data));
+    port1.on('SIGQUIT', data => signals1.push(data));
+    port2.on('SIGTERM', data => signals2.push(data));
+    port2.on('SIGQUIT', data => signals2.push(data));
+
+    port1.kill('SIGQUIT');
+    expect(signals2).toEqual(['SIGQUIT']);
+
+    port2.kill();
+    expect(signals1).toEqual(['SIGTERM']);
+  });
+
   type NotifyMessage = ['notify', {uuid: string}];
   type SubscribeMessage = ['subscribe', {foo: string}];
 

--- a/packages/zero-cache/src/types/processes.ts
+++ b/packages/zero-cache/src/types/processes.ts
@@ -69,6 +69,8 @@ export interface Receiver {
     sendHandle?: SendHandle,
     callback?: (error: Error | null) => void,
   ): boolean;
+
+  kill(signal?: NodeJS.Signals): void;
 }
 
 export interface Sender extends EventEmitter {
@@ -125,7 +127,7 @@ function wrap<P extends EventEmitter>(proc: P): P & Sender {
   }) as P & Sender;
 }
 
-type Proc = Pick<ChildProcess, 'send'> & EventEmitter;
+type Proc = Pick<ChildProcess, 'send' | 'kill'> & EventEmitter;
 
 /**
  * The parentWorker for forked processes, or `null` if the process was not forked.
@@ -145,21 +147,21 @@ export function childWorker(absModulePath: string, ...args: string[]): Worker {
   if (singleProcessMode()) {
     const [parent, child] = inProcChannel();
     import(absModulePath)
-      .then(({default: runWorker}) => runWorker(parent, ...args))
+      .then(({default: runWorker}) =>
+        runWorker(parent, ...args).then(
+          () => child.emit('close', 0),
+          (err: unknown) => child.emit('error', err),
+        ),
+      )
       .catch(err => child.emit('error', err));
     return child;
   }
-  const worker = wrap(fork(absModulePath, args, {serialization: 'advanced'}));
-
-  // Propagate all listenable termination signals to the workers.
-  // Note: https://nodejs.org/api/process.html#process_signal_events
-  // > * 'SIGKILL' cannot have a listener installed, it will unconditionally terminate Node.js on all platforms.
-  // > * 'SIGSTOP' cannot have a listener installed.
-  for (const sig of ['SIGINT', 'SIGQUIT', 'SIGTERM'] as const) {
-    process.on(sig, () => worker.kill(sig));
-  }
-  process.on('exit', () => worker.kill());
-  return worker;
+  return wrap(
+    fork(absModulePath, args, {
+      detached: true, // do not automatically propagate SIGINT
+      serialization: 'advanced', // use structured clone for IPC
+    }),
+  );
 }
 
 /**
@@ -189,8 +191,13 @@ export function inProcChannel(): [Worker, Worker] {
       return true;
     };
 
+  const kill =
+    (dest: EventEmitter) =>
+    (signal: NodeJS.Signals = 'SIGTERM') =>
+      dest.emit(signal, signal);
+
   return [
-    wrap(Object.assign(worker1, {send: sendTo(worker2)})),
-    wrap(Object.assign(worker2, {send: sendTo(worker1)})),
+    wrap(Object.assign(worker1, {send: sendTo(worker2), kill: kill(worker2)})),
+    wrap(Object.assign(worker2, {send: sendTo(worker1), kill: kill(worker1)})),
   ];
 }

--- a/packages/zero-cache/src/workers/syncer.ts
+++ b/packages/zero-cache/src/workers/syncer.ts
@@ -1,7 +1,11 @@
 import {LogContext} from '@rocicorp/logger';
+import {resolver} from '@rocicorp/resolver';
 import assert from 'assert';
 import {jwtVerify, type JWTPayload} from 'jose';
+import {pid} from 'process';
 import {must} from 'shared/src/must.js';
+import {promiseVoid} from 'shared/src/resolved-promises.js';
+import {sleep} from 'shared/src/sleep.js';
 import {MessagePort} from 'worker_threads';
 import {WebSocketServer, type WebSocket} from 'ws';
 import {type ZeroConfig} from '../config/zero-config.js';
@@ -10,7 +14,11 @@ import {installWebSocketReceiver} from '../services/dispatcher/websocket-handoff
 import type {Mutagen} from '../services/mutagen/mutagen.js';
 import type {ReplicaState} from '../services/replicator/replicator.js';
 import {ServiceRunner} from '../services/runner.js';
-import type {ActivityBasedService, Service} from '../services/service.js';
+import type {
+  ActivityBasedService,
+  Service,
+  SingletonService,
+} from '../services/service.js';
 import type {ViewSyncer} from '../services/view-syncer/view-syncer.js';
 import type {Worker} from '../types/processes.js';
 import {Subscription} from '../types/subscription.js';
@@ -28,13 +36,15 @@ export type SyncerWorkerData = {
  * and {@link Subscription} to version notifications from the Replicator
  * worker.
  */
-export class Syncer {
+export class Syncer implements SingletonService {
+  readonly id = `syncer-${pid}`;
   readonly #lc: LogContext;
   readonly #viewSyncers: ServiceRunner<ViewSyncer & ActivityBasedService>;
   readonly #mutagens: ServiceRunner<Mutagen & Service>;
   readonly #connections = new Map<string, Connection>();
   readonly #parent: Worker;
   readonly #wss: WebSocketServer;
+  readonly #stopped = resolver();
   #jwtSecretBytes: Uint8Array | undefined;
 
   constructor(
@@ -106,10 +116,31 @@ export class Syncer {
     this.#connections.set(clientID, connection);
   };
 
-  run() {}
+  run() {
+    return this.#stopped.promise;
+  }
+
+  /**
+   * Graceful shutdown involves shutting down view syncers one at a time, pausing
+   * for the duration of view syncer's hydration between each one. This paces the
+   * disconnects to avoid creating a backlog of hydrations in the receiving server
+   * when the clients reconnect.
+   */
+  async drain() {
+    const start = Date.now();
+    this.#lc.info?.(`draining ${this.#viewSyncers.size} view-syncers`);
+    for (const viewSyncer of this.#viewSyncers.getServices()) {
+      const hydrationTimeMs = viewSyncer.totalHydrationTimeMs();
+      await viewSyncer.stop();
+      await sleep(hydrationTimeMs);
+    }
+    this.#lc.info?.(`finished draining (${Date.now() - start} ms)`);
+  }
 
   stop() {
     this.#wss.close();
+    this.#stopped.resolve();
+    return promiseVoid;
   }
 }
 


### PR DESCRIPTION
### Load estimation (`view-syncer.ts`, `pipeline-driver.ts`)
* pipeline-driver tracks the time it takes for each pipeline to hydrate
* the view-syncer exports the total hydration time of all of its pipelines
* this is used to estimate the amount of cpu time the connection will incur on re-connect

### Drain (`syncer.ts`)
* The new `SingletonService` subtype of `Service` has an optional `drain()` method
* The `Syncer` responds to `drain()` by closing view-syncers, one at a time, pausing for the view-syncer's total hydration time between each, to give the destination task a chance to hydrate the new connection.

### Graceful vs Forceful shutdown (`life-cycle.ts`)
* We handle `SIGTERM` and `SIGINT` signals as graceful shutdown, which means awaiting `drain()` before calling `stop()`.
  * `SIGTERM` is what AWS sends: https://aws.amazon.com/blogs/containers/graceful-shutdowns-with-ecs/
  * `SIGINT` is our way to exercise this path in development (via `Ctrl-C`)
* `SIGQUIT` is interpreted as a forceful shutdown, which results in calling `stop()` on all services without `drain()`.

### User-facing vs Supporting workers (`life-cycle.ts`)
* Finally, workers are classified as either `user-facing` (i.e. syncers) or `supporting` (replicator, change-streamer).
* A graceful shutdown signal is handled by the main thread (in the `Terminator` class) by first sending the signal to all `user-facing` workers.
* When all of the `user-facing` workers have exited, the main process also exits, resulting in sending the shutdown signal to all remaining workers.
* For any other situation in which a worker (whether it be `user-facing` or `supporting`) exits unexpectedly, the server shuts down forcefully.

-----

Graceful (`SIGTERM`, `Ctrl-C`):

<img width="1728" alt="Screenshot 2024-10-05 at 13 19 53" src="https://github.com/user-attachments/assets/6d289552-10ea-4760-ace7-a1cb1dcbee3e">

-----

Forceful (`SIGQUT`, `kill -3`):

<img width="1728" alt="Screenshot 2024-10-05 at 13 20 35" src="https://github.com/user-attachments/assets/fa546017-492c-4a46-8184-1915bf48e604">

