### PR TITLE
fix(zero): Few miscellaneous fixes

### DIFF
--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -126,7 +126,7 @@ const zeroConfigSchemaSansAuthorization = v.object({
   // In development, the `zero-cache` runs its own `replication-manager`
   // (i.e. `change-streamer`). In production, this URI should point to
   // to the `replication-manager`, which runs a `change-streamer`
-  // on port 2999.
+  // on port 4849.
   changeStreamerConnStr: configStringValueSchema.optional(),
 
   // Indicates that a `litestream replicate` process is backing up

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
@@ -24,7 +24,7 @@ import type {
 
 export const CHANGES_URL_PATTERN = '/api/replication/:version/changes';
 
-export const DEFAULT_PORT = 2999;
+export const DEFAULT_PORT = 4849;
 
 export type Options = {
   port: number;

--- a/packages/zero-cache/src/services/dispatcher/dispatcher.ts
+++ b/packages/zero-cache/src/services/dispatcher/dispatcher.ts
@@ -13,7 +13,7 @@ export type Workers = {
   syncers: Worker[];
 };
 
-export const DEFAULT_PORT = 3000;
+export const DEFAULT_PORT = 4848;
 
 export type Options = {
   port: number;
@@ -69,7 +69,7 @@ export class Dispatcher implements Service {
 
   async run(): Promise<void> {
     const address = await this.#fastify.listen({
-      host: '0.0.0.0',
+      host: '::',
       port: this.#port,
     });
     this.#lc.info?.(`Server listening at ${address}`);

--- a/packages/zero-cache/src/types/schema-versions.ts
+++ b/packages/zero-cache/src/types/schema-versions.ts
@@ -1,4 +1,4 @@
-import {ErrorKind} from 'zero-protocol';
+import {ErrorKind} from 'zero-protocol/src/mod.js';
 import {ErrorForClient} from './error-for-client.js';
 
 export type SchemaVersions = {


### PR DESCRIPTION
- Listen on '::' not '0.0.0.0'. The latter is ipv4 wildcard, the former is all available interfaces. For systems that are configured to prefer ipv6, this should make using 'localhost' on the client side to connect work more reliably.
- Change default ports to 4848 and 4849
- Fix another dang directory improt