### PR TITLE
fix(turbo): explicitly list dependencies not present in `package.json`

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,13 @@
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["out/**", "dist/**", ".next/**", "next-env.d.ts"]
+      "outputs": ["out/**", "dist/**", ".next/**", "next-env.d.ts"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "../zero-client/src/**/*.ts",
+        "../zero-react/src/**/*.ts",
+        "../zero-cache/src/**/*.ts"
+      ]
     },
     "lint": {
       "outputs": []
@@ -24,7 +30,13 @@
     },
     "check-types": {
       "dependsOn": ["^check-types", "build"],
-      "outputs": []
+      "outputs": [],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "../zero-client/src/**/*.ts",
+        "../zero-react/src/**/*.ts",
+        "../zero-cache/src/**/*.ts"
+      ]
     }
   }
 }


### PR DESCRIPTION
PR #2593 was getting "cache hits" on CI from turbo for the `zero` package

![CleanShot 2024-10-08 at 13 19 19](https://github.com/user-attachments/assets/3b64baa7-9aa8-46c9-8c02-22285bec4e19)

Even though a new type was added to zero-client so there should not have been a cache-hit. I think this is because the `zero` package doesn't list a dependency on zero-client, zero-cache or zero-react so when a change happens in those deps a new `.d.ts` is not generated.

We can't list those packages as dependencies for reasons outlined here: https://github.com/rocicorp/mono/pull/2567#discussion_r1788607072

Turns out `turbo` has an `inputs` option so we can list these deps there.