### PR TITLE
chore(zero): Change the dispatcher listens on to default.

### DIFF
--- a/packages/zero-cache/src/services/dispatcher/dispatcher.ts
+++ b/packages/zero-cache/src/services/dispatcher/dispatcher.ts
@@ -69,7 +69,6 @@ export class Dispatcher implements Service {
 
   async run(): Promise<void> {
     const address = await this.#fastify.listen({
-      host: '::',
       port: this.#port,
     });
     this.#lc.info?.(`Server listening at ${address}`);


### PR DESCRIPTION
Fastify sets this to localhost and IIUC this will make it listen on both ipv4 and ipv6 loopback addresses.

I don't know how this makes it accessible from other computers on AWS as localhost is supposed to be restricted to only local machine but apparently it works so 🤷‍♂️. Maybe dax will see this commit go by and explain.