### PR TITLE
chore(zbugs): time frontend events to understand where time is spent prior to first issue render

### DIFF
--- a/apps/zbugs/src/pages/list/list-page.tsx
+++ b/apps/zbugs/src/pages/list/list-page.tsx
@@ -8,7 +8,9 @@ import Filter, {type Selection} from '../../components/filter.js';
 import {Link} from '../../components/link.js';
 import {useElementSize} from '../../hooks/use-element-size.js';
 import {useZero} from '../../hooks/use-zero.js';
+import {mark} from '../../perf-log.js';
 
+let firstRowRendered = false;
 export default function ListPage() {
   const z = useZero();
 
@@ -68,6 +70,10 @@ export default function ListPage() {
 
   const Row = ({index, style}: {index: number; style: CSSProperties}) => {
     const issue = issues[index];
+    if (firstRowRendered === false) {
+      mark('first issue row rendered');
+      firstRowRendered = true;
+    }
     return (
       <div
         key={issue.id}

--- a/apps/zbugs/src/perf-log.ts
+++ b/apps/zbugs/src/perf-log.ts
@@ -1,0 +1,32 @@
+let lastMark = {
+  event: 'js-loaded',
+  time: performance.now(),
+};
+const start = performance.now();
+
+// if the queryString includes `perf`, log performance events
+let enabled = false;
+if (location.search.includes('perf')) {
+  enabled = true;
+  console.info('js-loaded', {
+    ...lastMark,
+    elapsed: 0,
+  });
+}
+
+export function mark(event: string) {
+  if (!enabled || typeof performance === 'undefined') {
+    return;
+  }
+  const time = performance.now();
+  console.info({
+    event,
+    sinceLast: time - lastMark.time,
+    elapsed: time - start,
+    time,
+  });
+  lastMark = {
+    event,
+    time,
+  };
+}

--- a/apps/zbugs/src/root.tsx
+++ b/apps/zbugs/src/root.tsx
@@ -8,6 +8,7 @@ import {useLogin} from './hooks/use-login.js';
 import ErrorPage from './pages/error/error-page.js';
 import IssuePage from './pages/issue/issue-page.js';
 import ListPage from './pages/list/list-page.js';
+import {mark} from './perf-log.js';
 
 export default function Root() {
   const login = useLogin();
@@ -15,6 +16,7 @@ export default function Root() {
   const [z, setZ] = useState<Zero<Schema> | undefined>();
 
   useEffect(() => {
+    mark('root effect start');
     const z = new Zero({
       logLevel: 'info',
       server: import.meta.env.VITE_PUBLIC_SERVER,
@@ -33,15 +35,8 @@ export default function Root() {
       .related('comments', c => c.limit(10).related('creator'))
       .orderBy('modified', 'desc');
 
-    // Until we have query priorities, preload the first 50 issues then
-    // all the rest.
-    const {cleanup, complete} = baseIssueQuery.limit(50).preload();
-
-    complete.then(() => {
-      // load remainder of issues
-      baseIssueQuery.preload();
-      cleanup();
-    });
+    const {complete} = baseIssueQuery.preload();
+    complete.then(() => mark('issue preload complete'));
 
     z.query.user.preload();
     z.query.label.preload();


### PR DESCRIPTION
Pushing this to prod to get a better idea as to where to start looking for why zbugs is so slow.

127ms from JS loaded to first issue rendered on localhost.

![CleanShot 2024-10-08 at 21 31 50@2x](https://github.com/user-attachments/assets/0040d462-1cea-485c-9a5c-7b7eff13d84b)
