### PR TITLE
fix(zero-cache): fix CHANGE_STREAMER_URI and shutdown

### DIFF
--- a/packages/zero-cache/src/server/life-cycle.ts
+++ b/packages/zero-cache/src/server/life-cycle.ts
@@ -45,7 +45,11 @@ export class Terminator {
     for (const signal of GRACEFUL_SHUTDOWN) {
       proc.on(signal, () => {
         this.#drainStart = Date.now();
-        kill(this.#userFacing, signal);
+        if (this.#userFacing.size) {
+          kill(this.#userFacing, signal);
+        } else {
+          exit(0);
+        }
       });
     }
 

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.test.ts
@@ -1,7 +1,5 @@
 import {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
-import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.js';
-import {randInt} from '../../../../shared/src/rand.js';
 import {
   afterEach,
   beforeEach,
@@ -12,6 +10,8 @@ import {
   vi,
 } from 'vitest';
 import WebSocket from 'ws';
+import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.js';
+import {randInt} from '../../../../shared/src/rand.js';
 import type {Source} from '../../types/streams.js';
 import {Subscription} from '../../types/subscription.js';
 import {ReplicationMessages} from '../replicator/test-utils.js';

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
@@ -5,8 +5,8 @@ import Fastify, {
   type FastifyReply,
   type FastifyRequest,
 } from 'fastify';
-import * as v from '../../../../shared/src/valita.js';
 import WebSocket from 'ws';
+import * as v from '../../../../shared/src/valita.js';
 import {jsonValueSchema} from '../../types/bigint-json.js';
 import {type Source, streamIn, streamOut} from '../../types/streams.js';
 import {URLParams} from '../../types/url-params.js';
@@ -97,13 +97,14 @@ export class ChangeStreamerHttpClient implements ChangeStreamer {
   constructor(lc: LogContext, uriOrPort: string | number = DEFAULT_PORT) {
     this.#lc = lc;
     this.#uri =
-      typeof uriOrPort === 'string'
+      (typeof uriOrPort === 'string'
         ? uriOrPort
-        : `ws://localhost:${uriOrPort}` +
-          CHANGES_URL_PATTERN.replace(':version', 'v0');
+        : `ws://localhost:${uriOrPort}`) +
+      CHANGES_URL_PATTERN.replace(':version', 'v0');
   }
 
   subscribe(ctx: SubscriberContext): Source<Downstream> {
+    this.#lc.info?.(`connecting to change-streamer@${this.#uri}`);
     const params = getParams(ctx);
     const ws = new WebSocket(this.#uri + `?${params.toString()}`);
 

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -3,11 +3,11 @@ import {ident} from 'pg-format';
 import {LogicalReplicationService} from 'pg-logical-replication';
 import {AbortError} from '../../../../shared/src/abort-error.js';
 import {assert, unreachable} from '../../../../shared/src/asserts.js';
-import {StatementRunner} from '../../db/statements.js';
-import {liteValues} from '../../types/lite.js';
 import {Database} from '../../../../zqlite/src/db.js';
+import {StatementRunner} from '../../db/statements.js';
 import {stringify} from '../../types/bigint-json.js';
 import type {LexiVersion} from '../../types/lexi-version.js';
+import {liteValues} from '../../types/lite.js';
 import {liteTableName} from '../../types/names.js';
 import type {Source} from '../../types/streams.js';
 import type {
@@ -103,7 +103,7 @@ export class IncrementalSyncer {
         }
         processor.abort(lc);
       } catch (e) {
-        lc.error?.('Received error from ChangeStreamer', e);
+        lc.error?.('received error from change-streamer', e);
         processor.abort(lc, e);
       } finally {
         downstream.cancel();


### PR DESCRIPTION
Fix handling of the `CHANGE_STREAMER_URI` variable so that the URL path is appended to it.

Properly shut down the replication-manager on `SIGTERM`, which was being ignored because there are no `user-facing` workers to wait for.

Improve logging around the change-streamer connection.