### PR TITLE
fix(zero-cache): disable json log format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,4 @@ WORKDIR /opt/app/packages/zero-cache
 RUN chmod +x ./restore-litestream-db.sh
 EXPOSE 4848
 ENTRYPOINT ["/bin/sh", "-c"]
-ENV JSON_LOG_FORMAT=1
 CMD ["(./restore-litestream-db.sh || true) && npx tsx ../../apps/zbugs/zero.config.ts && litestream replicate -config /opt/app/litestream.yml"]

--- a/litestream.yml
+++ b/litestream.yml
@@ -5,3 +5,5 @@ dbs:
       - url: ${REPLICA_URL}
     checkpoint-interval: 10s
     max-checkpoint-page-count: 4000
+logging:
+  level: warn


### PR DESCRIPTION
There's probably some additional configuration needed to make this work. It doesn't detect it automatically.

<img width="1140" alt="Screenshot 2024-10-09 at 18 28 49" src="https://github.com/user-attachments/assets/b0cd086e-ca13-43ae-b62a-f44db71073e7">
