### PR TITLE
feat(zero-cache): structured JSON logging in AWS (take 2)

### DIFF
--- a/litestream.yml
+++ b/litestream.yml
@@ -5,3 +5,6 @@ dbs:
       - url: ${REPLICA_URL}
     checkpoint-interval: 10s
     max-checkpoint-page-count: 4000
+logging:
+  level: warn
+  type: json

--- a/packages/zero-cache/src/server/logging.ts
+++ b/packages/zero-cache/src/server/logging.ts
@@ -53,11 +53,13 @@ const consoleJsonLogSink: LogSink = {
         }
       : undefined;
 
-    console[level]({
-      ...context,
-      ...message,
-      ...lastObj,
-    });
+    console[level](
+      stringify({
+        ...context,
+        ...message,
+        ...lastObj,
+      }),
+    );
   },
 };
 


### PR DESCRIPTION
The AWS lambda docs suggest that sending the JSON object directly to the console works, but that might only work with lambdas. Other sites suggest that the message needs to be stringified JSON.