### PR TITLE
feat(zero-cache): add "level" to the structured logs

### DIFF
--- a/packages/zero-cache/src/server/logging.ts
+++ b/packages/zero-cache/src/server/logging.ts
@@ -55,6 +55,7 @@ const consoleJsonLogSink: LogSink = {
 
     console[level](
       stringify({
+        level,
         ...context,
         ...message,
         ...lastObj,


### PR DESCRIPTION
This doesn't happen automatically in our setup. The information is probably lost somewhere between the docker container and the log driver.