### PR TITLE
chore(zero-cache): logging consistency adjustments

### DIFF
--- a/packages/zero-cache/src/services/mutagen/mutagen.ts
+++ b/packages/zero-cache/src/services/mutagen/mutagen.ts
@@ -4,7 +4,6 @@ import {resolver} from '@rocicorp/resolver';
 import type {JWTPayload} from 'jose';
 import postgres from 'postgres';
 import {assert, unreachable} from '../../../../shared/src/asserts.js';
-import {Mode} from '../../db/transaction-pool.js';
 import {ErrorKind} from '../../../../zero-protocol/src/mod.js';
 import {
   MutationType,
@@ -17,12 +16,13 @@ import {
 } from '../../../../zero-protocol/src/push.js';
 import {Database} from '../../../../zqlite/src/db.js';
 import {type ZeroConfig} from '../../config/zero-config.js';
+import {Mode} from '../../db/transaction-pool.js';
 import {ErrorForClient} from '../../types/error-for-client.js';
 import type {PostgresDB, PostgresTransaction} from '../../types/pg.js';
+import {throwErrorForClientIfSchemaVersionNotSupported} from '../../types/schema-versions.js';
+import {SlidingWindowLimiter} from '../limiter/sliding-window-limiter.js';
 import type {Service} from '../service.js';
 import {WriteAuthorizerImpl, type WriteAuthorizer} from './write-authorizer.js';
-import {SlidingWindowLimiter} from '../limiter/sliding-window-limiter.js';
-import {throwErrorForClientIfSchemaVersionNotSupported} from '../../types/schema-versions.js';
 
 // An error encountered processing a mutation.
 // Returned back to application for display to user.
@@ -58,7 +58,7 @@ export class MutagenService implements Mutagen, Service {
   ) {
     this.id = clientGroupID;
     this.#lc = lc
-      .withContext('component', 'Mutagen')
+      .withContext('component', 'mutagen')
       .withContext('serviceID', this.id);
     this.#upstream = upstream;
     this.#shardID = shardID;

--- a/packages/zqlite/src/db.ts
+++ b/packages/zqlite/src/db.ts
@@ -180,6 +180,6 @@ class LoggingIterableIterator<T> implements IterableIterator<T> {
 
 function logIfSlow(elapsed: number, lc: LogContext, threshold: number): void {
   if (elapsed >= threshold) {
-    lc.error?.('Slow query', elapsed);
+    lc.warn?.('Slow query', elapsed);
   }
 }


### PR DESCRIPTION
Log slow queries at the `WARN` level. Decapitalize the "mutagen" component.