### PR TITLE
fix(zero-cache): console.log errors during worker init

### DIFF
--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -55,5 +55,5 @@ export default async function runWorker(parent: Worker): Promise<void> {
 
 // fork()
 if (!singleProcessMode()) {
-  exitAfter(runWorker(must(parentWorker)));
+  void exitAfter(() => runWorker(must(parentWorker)));
 }

--- a/packages/zero-cache/src/server/life-cycle.ts
+++ b/packages/zero-cache/src/server/life-cycle.ts
@@ -161,9 +161,12 @@ export async function runUntilKilled(
   }
 }
 
-export function exitAfter(running: Promise<void>) {
-  void running.then(
-    () => process.exit(0),
-    () => process.exit(-1),
-  );
+export async function exitAfter(run: () => Promise<void>) {
+  try {
+    await run();
+    process.exit(0);
+  } catch (e) {
+    console.error(e);
+    process.exit(-1);
+  }
 }

--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -61,5 +61,5 @@ export default async function runWorker(
 
 // fork()
 if (!singleProcessMode()) {
-  exitAfter(runWorker(must(parentWorker), ...process.argv.slice(2)));
+  void exitAfter(() => runWorker(must(parentWorker), ...process.argv.slice(2)));
 }

--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -84,5 +84,5 @@ export default async function runWorker(parent: Worker): Promise<void> {
 
 // fork()
 if (!singleProcessMode()) {
-  exitAfter(runWorker(must(parentWorker)));
+  void exitAfter(() => runWorker(must(parentWorker)));
 }


### PR DESCRIPTION
`console.error()` errors encountered during worker initialization. Otherwise, the server shuts down without illucidating why the worker exited.