### PR TITLE
chore(zero-cache): treat intentional shutdowns as level INFO (graceful)

### DIFF
--- a/packages/zero-cache/src/server/life-cycle.ts
+++ b/packages/zero-cache/src/server/life-cycle.ts
@@ -90,10 +90,13 @@ export class Terminator {
       return this.#exit(code);
     }
     if (type === 'supporting') {
-      this.#lc.error?.(
+      // The replication-manager has no user-facing workers.
+      // In this case, code === 0 shutdowns are not errors.
+      const log = code === 0 && this.#userFacing.size === 0 ? 'info' : 'error';
+      this.#lc[log]?.(
         `shutting down because supporting worker exited with code ${code}`,
       );
-      return this.#exit(-1);
+      return this.#exit(log === 'error' ? -1 : code);
     }
     if (this.#drainStart === 0) {
       this.#lc.error?.(

--- a/packages/zero-cache/src/services/running-state.ts
+++ b/packages/zero-cache/src/services/running-state.ts
@@ -81,10 +81,10 @@ export class RunningState {
    */
   stop(lc: LogContext, err?: unknown): void {
     if (this.shouldRun()) {
-      if (err) {
-        lc.error?.(`stopping ${this.#serviceName} with error`, err);
-      } else {
+      if (!err || err instanceof AbortError) {
         lc.info?.(`stopping ${this.#serviceName}`);
+      } else {
+        lc.error?.(`stopping ${this.#serviceName} with error`, err);
       }
       this.#controller.abort();
     }


### PR DESCRIPTION
Log intentional shutdowns as level `INFO` rather than `ERROR`, and handle them gracefully if there are no user-facing workers to drain. This is the case for the `replication-manager`.