### PR TITLE
feat(zero, zbugs): refactor code so we can start zero before react

### DIFF
--- a/apps/zbugs/src/components/nav.tsx
+++ b/apps/zbugs/src/components/nav.tsx
@@ -74,7 +74,7 @@ export function Nav() {
             <div className="logged-in-user-container">
               <div className="logged-in-user">
                 {/* Need access to user avatar */}
-                <span>{login.loginState?.login}</span>
+                <span>{login.loginState?.decoded.name}</span>
               </div>
               <button
                 className="logout-button"

--- a/apps/zbugs/src/hooks/use-login.tsx
+++ b/apps/zbugs/src/hooks/use-login.tsx
@@ -1,15 +1,10 @@
-import {createContext, useContext, useState} from 'react';
-import {clearJwt, getJwt, getRawJwt} from '../jwt.js';
+import {createContext, useContext, useEffect, useState} from 'react';
+import {clearJwt} from '../jwt.js';
+import {type LoginState, authRef} from '../zero-setup.js';
 
 export type LoginContext = {
   logout: () => void;
   loginState: LoginState | undefined;
-};
-
-export type LoginState = {
-  token: string;
-  userID: string;
-  login: string;
 };
 
 const loginContext = createContext<LoginContext | undefined>(undefined);
@@ -24,24 +19,18 @@ export function useLogin() {
 }
 
 export function LoginProvider({children}: {children: React.ReactNode}) {
-  const jwt = getJwt();
-  const encodedJwt = getRawJwt();
   const [loginState, setLoginState] = useState<LoginState | undefined>(
-    jwt && encodedJwt && jwt.sub
-      ? {
-          token: encodedJwt,
-          userID: jwt.sub,
-          login: jwt.name as string,
-        }
-      : undefined,
+    authRef.get(),
   );
+
+  useEffect(() => authRef.onChange(setLoginState), []);
 
   return (
     <loginContext.Provider
       value={{
         logout: () => {
           clearJwt();
-          setLoginState(undefined);
+          authRef.set(undefined);
         },
         loginState,
       }}

--- a/apps/zbugs/src/pages/issue/comment.tsx
+++ b/apps/zbugs/src/pages/issue/comment.tsx
@@ -49,7 +49,7 @@ export default function Comment({id, issueID}: {id: string; issueID: string}) {
       ) : (
         <Markdown>{comment.body}</Markdown>
       )}
-      {editing || comment.creatorID !== login.loginState?.userID ? null : (
+      {editing || comment.creatorID !== login.loginState?.decoded.sub ? null : (
         <div className={style.commentActions}>
           <button onMouseDown={edit}>Edit</button>
           <button onMouseDown={remove}>Delete</button>

--- a/apps/zbugs/src/root.tsx
+++ b/apps/zbugs/src/root.tsx
@@ -3,48 +3,15 @@ import {ZeroProvider} from '@rocicorp/zero/react';
 import {useEffect, useState} from 'react';
 import {Route, Switch} from 'wouter';
 import {Nav} from './components/nav.js';
-import {type Schema, schema} from './domain/schema.js';
-import {useLogin} from './hooks/use-login.js';
+import {type Schema} from './domain/schema.js';
 import ErrorPage from './pages/error/error-page.js';
 import IssuePage from './pages/issue/issue-page.js';
 import ListPage from './pages/list/list-page.js';
-import {mark} from './perf-log.js';
+import {zeroRef} from './zero-setup.js';
 
 export default function Root() {
-  const login = useLogin();
-
   const [z, setZ] = useState<Zero<Schema> | undefined>();
-
-  useEffect(() => {
-    mark('root effect start');
-    const z = new Zero({
-      logLevel: 'info',
-      server: import.meta.env.VITE_PUBLIC_SERVER,
-      userID: login.loginState?.userID ?? 'anon',
-      auth: login.loginState?.token,
-      schema,
-    });
-    setZ(z);
-
-    // To enable accessing zero in the devtools easily.
-    (window as {z?: Zero<Schema>}).z = z;
-
-    const baseIssueQuery = z.query.issue
-      .related('creator')
-      .related('labels')
-      .related('comments', c => c.limit(10).related('creator'))
-      .orderBy('modified', 'desc');
-
-    const {complete} = baseIssueQuery.preload();
-    complete.then(() => mark('issue preload complete'));
-
-    z.query.user.preload();
-    z.query.label.preload();
-
-    return () => {
-      z.close();
-    };
-  }, [login]);
+  useEffect(() => zeroRef.onChange(z => setZ(z)), []);
 
   if (!z) {
     return null;

--- a/apps/zbugs/src/zero-setup.ts
+++ b/apps/zbugs/src/zero-setup.ts
@@ -1,0 +1,56 @@
+import {Ref, Zero} from '@rocicorp/zero';
+import {type Schema, schema} from './domain/schema.js';
+import {getJwt, getRawJwt} from './jwt.js';
+import {mark} from './perf-log.js';
+
+export type LoginState = {
+  encoded: string;
+  decoded: {
+    sub: string;
+    name: string;
+  };
+};
+
+const zeroRef = new Ref<Zero<Schema>>();
+const authRef = new Ref<LoginState>();
+const jwt = getJwt();
+const encodedJwt = getRawJwt();
+
+authRef.set(
+  encodedJwt && jwt
+    ? {
+        encoded: encodedJwt,
+        decoded: jwt as LoginState['decoded'],
+      }
+    : undefined,
+);
+
+authRef.onChange(auth => {
+  zeroRef.get()?.close();
+  mark('creating new zero');
+  const z = new Zero({
+    logLevel: 'info',
+    server: import.meta.env.VITE_PUBLIC_SERVER,
+    userID: auth?.decoded?.sub ?? 'anon',
+    auth: auth?.encoded,
+    schema,
+  });
+  zeroRef.set(z);
+
+  // To enable accessing zero in the devtools easily.
+  (window as {z?: Zero<Schema>}).z = z;
+
+  const baseIssueQuery = z.query.issue
+    .related('creator')
+    .related('labels')
+    .related('comments', c => c.limit(10).related('creator'))
+    .orderBy('modified', 'desc');
+
+  const {complete} = baseIssueQuery.preload();
+  complete.then(() => mark('issue preload complete'));
+
+  z.query.user.preload();
+  z.query.label.preload();
+});
+
+export {zeroRef, authRef};

--- a/packages/zero-client/src/client/ref.ts
+++ b/packages/zero-client/src/client/ref.ts
@@ -1,0 +1,25 @@
+type Listener<T> = (v: T | undefined) => void;
+
+export class Ref<T> {
+  #listeners = new Set<Listener<T>>();
+  #current: T | undefined;
+
+  set(value: T | undefined) {
+    this.#current = value;
+    for (const listener of this.#listeners) {
+      listener(value);
+    }
+  }
+
+  get() {
+    return this.#current;
+  }
+
+  onChange(listener: Listener<T>) {
+    this.#listeners.add(listener);
+    listener(this.#current);
+    return () => {
+      this.#listeners.delete(listener);
+    };
+  }
+}

--- a/packages/zero-client/src/mod.ts
+++ b/packages/zero-client/src/mod.ts
@@ -71,3 +71,4 @@ export type {TableSchema} from '../../zql/src/zql/query/schema.js';
 export type {TypedView} from '../../zql/src/zql/query/typed-view.js';
 export type {ZeroOptions} from './client/options.js';
 export {Zero, type Schema} from './client/zero.js';
+export {Ref} from './client/ref.js';


### PR DESCRIPTION
Rather than setting up zero in `useEffect` we set it up outside React in `zero-setup.ts`.

To wire that into react, `zero-setup` publishes a reference that can be observed by React.

The react component now looks like:
![CleanShot 2024-10-11 at 13 38 35](https://github.com/user-attachments/assets/87013c80-de32-4ed3-9055-4e0a7a58232e)


I actually prefer this setup as `zero-setup` can be the same across all frameworks and we also don't run into the `double create` of Zero in `StrictMode` doing it this way.

----

Next up will be splitting the bundle so `zero-setup.ts` can run right away while React and Zbugs are still downloading.