### PR TITLE
feat(zbugs): split out `markdown` component into its own bundle

### DIFF
--- a/apps/zbugs/src/components/markdown-internal.tsx
+++ b/apps/zbugs/src/components/markdown-internal.tsx
@@ -1,0 +1,14 @@
+import MarkdownBase from 'react-markdown';
+import rehypeRaw from 'rehype-raw';
+import rehypeSanitize from 'rehype-sanitize';
+
+/**
+ * Do not import this component directly. Use `Markdown` instead.
+ */
+export default function Markdown({children}: {children: string}) {
+  return (
+    <MarkdownBase rehypePlugins={[rehypeRaw, rehypeSanitize]}>
+      {children}
+    </MarkdownBase>
+  );
+}

--- a/apps/zbugs/src/components/markdown.tsx
+++ b/apps/zbugs/src/components/markdown.tsx
@@ -1,11 +1,11 @@
-import MarkdownBase from 'react-markdown';
-import rehypeRaw from 'rehype-raw';
-import rehypeSanitize from 'rehype-sanitize';
+import {lazy, Suspense} from 'react';
+
+const MarkdownInternal = lazy(() => import('./markdown-internal.js'));
 
 export default function Markdown({children}: {children: string}) {
   return (
-    <MarkdownBase rehypePlugins={[rehypeRaw, rehypeSanitize]}>
-      {children}
-    </MarkdownBase>
+    <Suspense fallback={<div>{children}</div>}>
+      <MarkdownInternal>{children}</MarkdownInternal>
+    </Suspense>
   );
 }


### PR DESCRIPTION
The markdown dependencies are 341KB 🤯

We don't need them till we show issue detail so delay loading them.

![CleanShot 2024-10-11 at 16 12 06](https://github.com/user-attachments/assets/2b090bf5-b92f-48a4-b69e-0ad10c8bc92b)
