### PR TITLE
chore(zero-cache): log when a table copy begins

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/initial-sync.ts
@@ -288,6 +288,8 @@ async function copy(
       ? ''
       : ` WHERE ${filterConditions.join(' OR ')}`);
 
+  lc.info?.(`Starting copy of ${tableName}:`, selectStmt);
+
   const cursor = from.unsafe(selectStmt).cursor(BATCH_SIZE);
   for await (const rows of cursor) {
     for (const row of rows) {


### PR DESCRIPTION
To facilitate debugging of issues in initial-sync.