### PR TITLE
fix(zero-cache): surface errors in initial-sync

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/initial-sync.ts
@@ -73,10 +73,7 @@ export async function initialSync(
     );
     await Promise.all(
       tables.map(table =>
-        copiers.process(db => {
-          copy(lc, table, db, tx);
-          return [];
-        }),
+        copiers.process(db => copy(lc, table, db, tx).then(() => [])),
       ),
     );
     copiers.setDone();


### PR DESCRIPTION
Use `TransactionPool.process()` instead of `TransactionPool.processReadTask()` to directly surface errors in the copy task (as opposed to the cryptic invalid transaction snapshot that otherwise results).