### PR TITLE
feat(zero-client, zero-cache): encode initConnection in sec-protocol

### DIFF
--- a/apps/zbugs/zero.config.ts
+++ b/apps/zbugs/zero.config.ts
@@ -43,7 +43,6 @@ defineConfig<AuthData, Schema>(schema, queries => {
     replicaDBFile: runtimeEnv('REPLICA_DB_FILE'),
     jwtSecret: runtimeEnv('JWT_SECRET'),
     litestream: runtimeEnv('LITESTREAM'),
-    warmWebsocket: 32,
     shard: {
       id: runtimeEnv('SHARD_ID'),
       publications: runtimeEnv('PUBLICATIONS'),

--- a/packages/zero-cache/src/services/dispatcher/connect-params.ts
+++ b/packages/zero-cache/src/services/dispatcher/connect-params.ts
@@ -1,5 +1,7 @@
 import type {IncomingHttpHeaders} from 'node:http2';
 import {URLParams} from '../../types/url-params.js';
+import {must} from '../../../../shared/src/must.js';
+import {decodeProtocols} from '../../../../zero-protocol/src/connect.js';
 
 export type ConnectParams = {
   readonly clientID: string;
@@ -12,6 +14,7 @@ export type ConnectParams = {
   readonly debugPerf: boolean;
   readonly auth: string | undefined;
   readonly userID: string;
+  readonly initConnectionMsg: string;
 };
 
 export function getConnectParams(
@@ -38,8 +41,10 @@ export function getConnectParams(
     const wsID = params.get('wsid', false) ?? '';
     const userID = params.get('userID', false) ?? '';
     const debugPerf = params.getBoolean('debugPerf');
+    const [initConnectionMsg, maybeAuthToken] = decodeProtocols(
+      must(headers['sec-websocket-protocol']),
+    );
 
-    const maybeAuthToken = headers['sec-websocket-protocol'];
     return {
       params: {
         clientID,
@@ -50,7 +55,8 @@ export function getConnectParams(
         lmID,
         wsID,
         debugPerf,
-        auth: maybeAuthToken ? decodeURIComponent(maybeAuthToken) : undefined,
+        initConnectionMsg,
+        auth: maybeAuthToken,
         userID,
       },
       error: null,

--- a/packages/zero-cache/src/workers/connection.ts
+++ b/packages/zero-cache/src/workers/connection.ts
@@ -2,7 +2,7 @@ import {Lock} from '@rocicorp/lock';
 import type {LogContext} from '@rocicorp/logger';
 import {unreachable} from '../../../shared/src/asserts.js';
 import * as valita from '../../../shared/src/valita.js';
-import type {CloseEvent, ErrorEvent, MessageEvent} from 'ws';
+import type {CloseEvent, Data, ErrorEvent} from 'ws';
 import WebSocket from 'ws';
 import {
   type ConnectedMessage,
@@ -119,7 +119,11 @@ export class Connection {
     }
   }
 
-  #handleMessage = async (event: MessageEvent) => {
+  handleInitConnection(initConnectionMsg: string) {
+    return this.#handleMessage({data: initConnectionMsg});
+  }
+
+  #handleMessage = async (event: {data: Data}) => {
     const lc = this.#lc;
     const data = event.data.toString();
     const viewSyncer = this.#viewSyncer;

--- a/packages/zero-cache/src/workers/syncer.ts
+++ b/packages/zero-cache/src/workers/syncer.ts
@@ -117,6 +117,7 @@ export class Syncer implements SingletonService {
       },
     );
     this.#connections.set(clientID, connection);
+    await connection.handleInitConnection(params.initConnectionMsg);
   };
 
   run() {


### PR DESCRIPTION
The idea here is to init the connection in 1 less round-trip to the server.
