### PR TITLE
chore(zero-cache): add DDL test for RENAME TABLE

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/pg/schema/ddl.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/schema/ddl.test.ts
@@ -185,6 +185,69 @@ describe('change-source/tables/ddl', () => {
       },
     ],
     [
+      'rename table',
+      `ALTER TABLE pub.foo RENAME TO food`,
+      {
+        type: 'ddl',
+        version: 1,
+        event: {
+          tag: 'ALTER TABLE',
+          context: {query: 'ALTER TABLE pub.foo RENAME TO food'},
+          table: {
+            schema: 'pub',
+            name: 'food',
+            columns: {
+              description: {
+                characterMaximumLength: null,
+                dataType: 'text',
+                notNull: false,
+                dflt: null,
+                pos: 3,
+              },
+              id: {
+                characterMaximumLength: null,
+                dataType: 'text',
+                notNull: true,
+                dflt: null,
+                pos: 1,
+              },
+              name: {
+                characterMaximumLength: null,
+                dataType: 'text',
+                notNull: false,
+                dflt: null,
+                pos: 2,
+              },
+            },
+            primaryKey: ['id'],
+            publications: {
+              ['zero_all']: {rowFilter: null},
+              ['zero_sum']: {rowFilter: null},
+            },
+          },
+          indexes: [
+            {
+              schemaName: 'pub',
+              tableName: 'food',
+              name: 'foo_custom_index',
+              columns: {
+                description: 'ASC',
+                name: 'ASC',
+              },
+              unique: false,
+            },
+            {
+              schemaName: 'pub',
+              tableName: 'food',
+              name: 'foo_name_key',
+              columns: {name: 'ASC'},
+              unique: true,
+            },
+          ],
+        },
+      },
+    ],
+    [
       'add column',
       `ALTER TABLE pub.foo ADD bar text`,
       {


### PR DESCRIPTION
Adds a unit test for `ALTER TABLE foo RENAME TO bar` which illustrates that the current ddl protocol (where only the changed table is captured) is insufficient, as the previous name of the table is not discernable from the message itself.

This is a prelude to (yet) another change in the DDL protocol which will capture full "before" and "after" snapshots of ddl events, and simplify things in the process.