### PR TITLE
chore(zero): review nits from #2677

### DIFF
--- a/packages/zero-cache/src/services/dispatcher/connect-params.ts
+++ b/packages/zero-cache/src/services/dispatcher/connect-params.ts
@@ -1,7 +1,7 @@
 import type {IncomingHttpHeaders} from 'node:http2';
 import {URLParams} from '../../types/url-params.js';
 import {must} from '../../../../shared/src/must.js';
-import {decodeProtocols} from '../../../../zero-protocol/src/connect.js';
+import {decodeSecProtocols} from '../../../../zero-protocol/src/connect.js';
 
 export type ConnectParams = {
   readonly clientID: string;
@@ -41,7 +41,7 @@ export function getConnectParams(
     const wsID = params.get('wsid', false) ?? '';
     const userID = params.get('userID', false) ?? '';
     const debugPerf = params.getBoolean('debugPerf');
-    const [initConnectionMsg, maybeAuthToken] = decodeProtocols(
+    const [initConnectionMsg, maybeAuthToken] = decodeSecProtocols(
       must(headers['sec-websocket-protocol']),
     );
 

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -11,8 +11,8 @@ import {TestLogSink} from '../../../shared/src/logging-test-utils.js';
 import * as valita from '../../../shared/src/valita.js';
 import {
   changeDesiredQueriesMessageSchema,
-  decodeProtocols,
-  encodeProtocols,
+  decodeSecProtocols,
+  encodeSecProtocols,
   ErrorKind,
   initConnectionMessageSchema,
 } from '../../../zero-protocol/src/mod.js';
@@ -325,7 +325,7 @@ suite('createSocket', () => {
       )[0] as unknown as MockSocket;
       expect(`${mockSocket.url}`).equal(expectedURL);
       expect(mockSocket.protocol).equal(
-        encodeProtocols(['initConnection', {desiredQueriesPatch: []}], auth),
+        encodeSecProtocols(['initConnection', {desiredQueriesPatch: []}], auth),
       );
     });
   };
@@ -485,7 +485,7 @@ suite('initConnection', () => {
 
     expect(
       valita.parse(
-        JSON.parse(decodeProtocols(mockSocket.protocol)[0]),
+        JSON.parse(decodeSecProtocols(mockSocket.protocol)[0]),
         initConnectionMessageSchema,
       ),
     ).toEqual([
@@ -551,7 +551,7 @@ suite('initConnection', () => {
 
     expect(
       valita.parse(
-        JSON.parse(decodeProtocols(mockSocket.protocol)[0]),
+        JSON.parse(decodeSecProtocols(mockSocket.protocol)[0]),
         initConnectionMessageSchema,
       ),
     ).toEqual([
@@ -1189,7 +1189,7 @@ test('Authentication', async () => {
     expectedAuthToken: string,
     expectedTimeOfCall: number,
   ) => {
-    expect(decodeProtocols((await r.socket).protocol)[1]).equal(
+    expect(decodeSecProtocols((await r.socket).protocol)[1]).equal(
       expectedAuthToken,
     );
     await r.triggerError(ErrorKind.Unauthorized, 'auth error ' + authCounter);
@@ -1224,7 +1224,7 @@ test('Authentication', async () => {
   {
     await r.waitForConnectionState(ConnectionState.Connecting);
     socket = await r.socket;
-    expect(decodeProtocols(socket.protocol)[1]).equal('new-auth-token-8');
+    expect(decodeSecProtocols(socket.protocol)[1]).equal('new-auth-token-8');
     await r.triggerConnected();
     await r.waitForConnectionState(ConnectionState.Connected);
     // getAuth should not be called again.
@@ -1257,13 +1257,17 @@ test(ErrorKind.AuthInvalidated, async () => {
   });
 
   await r.triggerConnected();
-  expect(decodeProtocols((await r.socket).protocol)[1]).equal('auth-token-1');
+  expect(decodeSecProtocols((await r.socket).protocol)[1]).equal(
+    'auth-token-1',
+  );
 
   await r.triggerError(ErrorKind.AuthInvalidated, 'auth error');
   await r.waitForConnectionState(ConnectionState.Disconnected);
 
   await r.waitForConnectionState(ConnectionState.Connecting);
-  expect(decodeProtocols((await r.socket).protocol)[1]).equal('auth-token-2');
+  expect(decodeSecProtocols((await r.socket).protocol)[1]).equal(
+    'auth-token-2',
+  );
 });
 
 test('Disconnect on error', async () => {

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -51,7 +51,7 @@ import {
   type PushMessage,
   type QueriesPatchOp,
   downstreamSchema,
-  encodeProtocols,
+  encodeSecProtocols,
   nullableVersionSchema,
 } from '../../../zero-protocol/src/mod.js';
 import type {
@@ -1645,7 +1645,7 @@ export async function createSocket(
     new WS(
       // toString() required for RN URL polyfill.
       url.toString(),
-      encodeProtocols(
+      encodeSecProtocols(
         ['initConnection', {desiredQueriesPatch: [...queriesPatch.values()]}],
         auth,
       ),

--- a/packages/zero-protocol/package.json
+++ b/packages/zero-protocol/package.json
@@ -8,7 +8,9 @@
     "check-types:watch": "tsc --watch",
     "format": "prettier --write .",
     "check-format": "prettier --check .",
-    "lint": "eslint --ext .ts,.tsx,.js,.jsx src/"
+    "lint": "eslint --ext .ts,.tsx,.js,.jsx src/",
+    "test": "vitest run",
+    "test:watch": "vitest watch"
   },
   "dependencies": {
     "@badrap/valita": "^0.3.9"

--- a/packages/zero-protocol/src/connect.test.ts
+++ b/packages/zero-protocol/src/connect.test.ts
@@ -1,0 +1,47 @@
+import {expect, test} from 'vitest';
+import fc from 'fast-check';
+import {decodeSecProtocols, encodeSecProtocols} from './connect.js';
+
+test('encode/decodeSecProtocols round-trip', () => {
+  fc.assert(
+    fc.property(
+      fc.record({
+        initConnectionMessage: fc.tuple(
+          fc.constant<'initConnection'>('initConnection'),
+          fc.record({
+            desiredQueriesPatch: fc.array(
+              fc.oneof(
+                fc.record({
+                  op: fc.constant<'put'>('put'),
+                  hash: fc.string(),
+                  ast: fc.constant({
+                    table: 'table',
+                  }),
+                }),
+                fc.record({
+                  op: fc.constant<'del'>('del'),
+                  hash: fc.string(),
+                }),
+              ),
+            ),
+          }),
+        ),
+        authToken: fc.option(
+          fc.stringOf(
+            fc.constantFrom(...'abcdefghijklmnopqrstuvwxyz0123456789-_.'),
+          ),
+          {nil: undefined},
+        ),
+      }),
+      ({initConnectionMessage, authToken}) => {
+        const encoded = encodeSecProtocols(initConnectionMessage, authToken);
+        const [decodedInitConnectionMessage, decodedAuthToken] =
+          decodeSecProtocols(encoded);
+        expect(JSON.parse(decodedInitConnectionMessage)).toEqual(
+          initConnectionMessage,
+        );
+        expect(decodedAuthToken).toEqual(authToken);
+      },
+    ),
+  );
+});

--- a/packages/zero-protocol/src/connect.ts
+++ b/packages/zero-protocol/src/connect.ts
@@ -35,23 +35,28 @@ export type ConnectedMessage = v.Infer<typeof connectedMessageSchema>;
 export type InitConnectionBody = v.Infer<typeof initConnectionBodySchema>;
 export type InitConnectionMessage = v.Infer<typeof initConnectionMessageSchema>;
 
-export function encodeProtocols(
+export function encodeSecProtocols(
   initConnectionMessage: InitConnectionMessage,
   authToken?: string | undefined,
 ) {
+  // base64 encoding the JSON before URI encoding it results in a smaller payload.
   const protocols: string[] = [btoa(JSON.stringify(initConnectionMessage))];
-  if (authToken) {
+  if (authToken !== undefined) {
     protocols.push(authToken);
   }
   return encodeURIComponent(protocols.join(','));
 }
 
-export function decodeProtocols(
+/**
+ * The initConnectionMessage is purposely returned as a string
+ * since it is passed directly into the WebSocket message handler
+ * which does JSON.parse and Valita.parse on the message.
+ */
+export function decodeSecProtocols(
   secProtocol: string,
 ): [initConnectionMessage: string, maybeAuthToken: string | undefined] {
   const ret = decodeURIComponent(secProtocol)
     .split(',')
-    // base64 encoding the JSON before URI encoding it results in a smaller payload.
     .map((s, i) => (i === 0 ? atob(s) : s));
 
   assert(ret.length === 1 || ret.length === 2);


### PR DESCRIPTION
- extra tests
- move comment to `encode` function
- rename `encodeProtocols` to `encodeSecProtocols`