### PR TITLE
fix(zbugs): broken back button

### DIFF
--- a/apps/zbugs/src/pages/issue/issue-page.tsx
+++ b/apps/zbugs/src/pages/issue/issue-page.tsx
@@ -37,10 +37,10 @@ export default function IssuePage() {
   const [editing, setEditing] = useState<typeof issue | null>(null);
   const [edits, setEdits] = useState<Partial<typeof issue>>({});
   useEffect(() => {
-    if (issue?.shortID !== undefined && idField !== 'shortID') {
-      location.replace(`/issue/${issue.shortID}`);
+    if (match && issue?.shortID !== undefined && idField !== 'shortID') {
+      window.location.replace(`/issue/${issue.shortID}`);
     }
-  }, [issue?.shortID, idField]);
+  }, [issue?.shortID, idField, match]);
 
   const save = () => {
     if (!editing) {


### PR DESCRIPTION
When pressing back, `useRoute` triggers before the `issue-page` is unmounted. This would cause us to `replaceState` again and go to the issue-detail rather than going back to the `issue-list`.

`useRoute` triggering while the issue-page is still mounted seems like a bug in wouter tome. The issue-page should have been unmounted and the list-page been mounted before any `useRoute` hooks trigger.