### PR TITLE
[RFC] feat(zbugs): affordance for "updated since last viewed"

### DIFF
--- a/apps/zbugs/docker/init_upstream/init.sql
+++ b/apps/zbugs/docker/init_upstream/init.sql
@@ -38,6 +38,13 @@ CREATE TABLE issue (
     "labelIDs" TEXT
 );
 
+CREATE TABLE "viewState" (
+    "userID" VARCHAR REFERENCES "user"(id) ON DELETE CASCADE,
+    "issueID" VARCHAR REFERENCES issue(id) ON DELETE CASCADE,
+    "viewed" double precision,
+    PRIMARY KEY ("userID", "issueID")
+);
+
 CREATE TABLE comment (
     id VARCHAR PRIMARY KEY,
     "issueID" VARCHAR REFERENCES issue(id) ON DELETE CASCADE,

--- a/apps/zbugs/src/domain/schema.ts
+++ b/apps/zbugs/src/domain/schema.ts
@@ -60,7 +60,25 @@ const issueSchema = {
         schema: () => userSchema,
       },
     },
+    viewState: {
+      source: 'id',
+      dest: {
+        field: 'issueID',
+        schema: () => viewStateSchema,
+      },
+    },
   },
+} as const;
+
+const viewStateSchema = {
+  tableName: 'viewState',
+  columns: {
+    issueID: {type: 'string'},
+    userID: {type: 'string'},
+    viewed: {type: 'number'},
+  },
+  primaryKey: ['userID', 'issueID'],
+  relationships: {},
 } as const;
 
 const commentSchema = {
@@ -112,6 +130,7 @@ export const schema = {
     comment: commentSchema,
     label: labelSchema,
     issueLabel: issueLabelSchema,
+    viewState: viewStateSchema,
   },
 } as const;
 

--- a/apps/zbugs/src/index.css
+++ b/apps/zbugs/src/index.css
@@ -311,6 +311,10 @@ h1 {
   padding-left: 2.5rem;
 }
 
+.row.unread {
+  border-right: 1px solid var(--color-primary-cta);
+}
+
 .primary-content .row {
   display: flex;
   flex-direction: row;

--- a/apps/zbugs/src/pages/list/list-page.tsx
+++ b/apps/zbugs/src/pages/list/list-page.tsx
@@ -33,7 +33,10 @@ export default function ListPage() {
   )?.id;
   const labelIDs = useQuery(z.query.label.where('name', 'IN', labels));
 
-  let q = z.query.issue.orderBy('modified', 'desc').related('labels');
+  let q = z.query.issue
+    .orderBy('modified', 'desc')
+    .related('labels')
+    .related('viewState', q => q.where('userID', z.userID).one());
 
   if (status === 'open') {
     q = q.where('open', true);
@@ -96,7 +99,10 @@ export default function ListPage() {
     return (
       <div
         key={issue.id}
-        className="row"
+        className={classNames(
+          'row',
+          issue.modified > (issue.viewState?.viewed ?? 0) ? 'unread' : null,
+        )}
         style={{
           ...style,
         }}

--- a/packages/zero-cache/src/services/mutagen/mutagen.ts
+++ b/packages/zero-cache/src/services/mutagen/mutagen.ts
@@ -332,7 +332,11 @@ function getUpdateSQL(
   for (const key of primaryKey) {
     id[key] = v.parse(value[key], primaryKeyValueSchema);
   }
-  return tx`UPDATE ${tx(table)} SET ${tx(value)} WHERE ${tx(id)}`;
+  return tx`UPDATE ${tx(table)} SET ${tx(value)} WHERE ${Object.entries(
+    id,
+  ).flatMap(([key, value], i) =>
+    i ? [tx`AND`, tx`${tx(key)} = ${value}`] : tx`${tx(key)} = ${value}`,
+  )}`;
 }
 
 function getDeleteSQL(


### PR DESCRIPTION
I find that this really really helps me to keep track of what issues I have not read yet. Given we don't have notifications I think this is pretty important to have to stay on top of updates.

We can of course fix the colors or how the affordance works but the video below demonstrates the idea.

Orange issues are issues that have been updated since you last viewed them. Grey issues have had no updates since their last viewing. Now whenever you land on the issue list, you don't have to remember what issues you last saw. You can just glance and look for orange issues and ignore grey ones.

"why not sort by modified and look at the top issues?"

Doesn't really help. Do you remember which were the top 10 issues since last time you viewed the page and what order they were in? If not, you don't really know if there have been any changes. Or maybe the top issue updated since you last viewed so it stayed at the top.

----

# Demo:

In the left screen, I'm up to date on all issues. On the right, a user is modifying issues. My left screen then reflects the unread state for issues that have changed.


https://github.com/user-attachments/assets/b4f59965-a28a-4d10-bb6d-4aedc44ef487


