### PR TITLE
fix(zbugs): fix refresh on `j` press

### DIFF
--- a/apps/zbugs/src/pages/issue/issue-page.tsx
+++ b/apps/zbugs/src/pages/issue/issue-page.tsx
@@ -37,10 +37,15 @@ export default function IssuePage() {
   const [editing, setEditing] = useState<typeof issue | null>(null);
   const [edits, setEdits] = useState<Partial<typeof issue>>({});
   useEffect(() => {
-    if (match && issue?.shortID !== undefined && idField !== 'shortID') {
-      window.location.replace(`/issue/${issue.shortID}`);
+    if (
+      match &&
+      (params.id === issue?.id || parseInt(params.id) === issue?.shortID) &&
+      issue?.shortID !== undefined &&
+      idField !== 'shortID'
+    ) {
+      history.replaceState(null, '', `/issue/${issue.shortID}`);
     }
-  }, [issue?.shortID, idField, match]);
+  }, [issue?.shortID, idField, match, params?.id, issue?.id]);
 
   const save = () => {
     if (!editing) {


### PR DESCRIPTION
Revising the approach. There's a bug in `useQuery` returning stale state.