### PR TITLE
feat(zero-cache): define and handle schema change messages in the Change stream API

### DIFF
--- a/packages/zero-cache/src/db/pg-to-lite.ts
+++ b/packages/zero-cache/src/db/pg-to-lite.ts
@@ -67,6 +67,20 @@ function mapPostgresToLiteDefault(
   return match[1];
 }
 
+export function mapPostgresToLiteColumn(
+  table: string,
+  column: {name: string; spec: ColumnSpec},
+): ColumnSpec {
+  const {pos, dataType, notNull, dflt} = column.spec;
+  return {
+    pos,
+    dataType,
+    characterMaximumLength: null,
+    notNull,
+    dflt: mapPostgresToLiteDefault(table, column.name, dataType, dflt),
+  };
+}
+
 export function mapPostgresToLite(t: TableSpec): LiteTableSpec {
   const {schema: _, ...liteSpec} = t;
   const name = liteTableName(t);
@@ -75,18 +89,10 @@ export function mapPostgresToLite(t: TableSpec): LiteTableSpec {
     name,
     columns: {
       ...Object.fromEntries(
-        Object.entries(t.columns).map(
-          ([col, {pos, dataType, notNull, dflt}]) => [
-            col,
-            {
-              pos,
-              dataType,
-              characterMaximumLength: null,
-              notNull,
-              dflt: mapPostgresToLiteDefault(name, col, dataType, dflt),
-            } satisfies ColumnSpec,
-          ],
-        ),
+        Object.entries(t.columns).map(([col, spec]) => [
+          col,
+          mapPostgresToLiteColumn(name, {name: col, spec}),
+        ]),
       ),
       [ZERO_VERSION_COLUMN_NAME]: ZERO_VERSION_COLUMN_SPEC,
     },

--- a/packages/zero-cache/src/services/change-streamer/schema/change.ts
+++ b/packages/zero-cache/src/services/change-streamer/schema/change.ts
@@ -1,4 +1,5 @@
 import * as v from '../../../../../shared/src/valita.js';
+import {columnSpec, indexSpec, tableSpec} from '../../../db/specs.js';
 import {jsonValueSchema, type JSONObject} from '../../../types/bigint-json.js';
 import type {Satisfies} from '../../../types/satisfies.js';
 
@@ -50,25 +51,92 @@ export const truncateSchema = v.object({
   relations: v.array(relationSchema),
 });
 
-export type MessageBegin = v.Infer<typeof beginSchema>;
+const identifierSchema = v.object({
+  schema: v.string(),
+  name: v.string(),
+});
 
+export const createTableSchema = v.object({
+  tag: v.literal('create-table'),
+  spec: tableSpec,
+});
+
+export const renameTableSchema = v.object({
+  tag: v.literal('rename-table'),
+  old: identifierSchema,
+  new: identifierSchema,
+});
+
+const columnSchema = v.object({
+  name: v.string(),
+  spec: columnSpec,
+});
+
+export const addColumnSchema = v.object({
+  tag: v.literal('add-column'),
+  table: identifierSchema,
+  column: columnSchema,
+});
+
+export const updateColumnSchema = v.object({
+  tag: v.literal('update-column'),
+  table: identifierSchema,
+  old: columnSchema,
+  new: columnSchema,
+});
+
+export const dropColumnSchema = v.object({
+  tag: v.literal('drop-column'),
+  table: identifierSchema,
+  column: v.string(),
+});
+
+export const dropTableSchema = v.object({
+  tag: v.literal('drop-table'),
+  id: identifierSchema,
+});
+
+export const createIndexSchema = v.object({
+  tag: v.literal('create-index'),
+  spec: indexSpec,
+});
+
+export const dropIndexSchema = v.object({
+  tag: v.literal('drop-index'),
+  id: identifierSchema,
+});
+
+export type MessageBegin = v.Infer<typeof beginSchema>;
 export type MessageCommit = v.Infer<typeof commitSchema>;
 
 export type MessageRelation = v.Infer<typeof relationSchema>;
-
 export type MessageInsert = v.Infer<typeof insertSchema>;
-
 export type MessageUpdate = v.Infer<typeof updateSchema>;
-
 export type MessageDelete = v.Infer<typeof deleteSchema>;
-
 export type MessageTruncate = v.Infer<typeof truncateSchema>;
+
+export type TableCreate = v.Infer<typeof createTableSchema>;
+export type TableRename = v.Infer<typeof renameTableSchema>;
+export type ColumnAdd = v.Infer<typeof addColumnSchema>;
+export type ColumnUpdate = v.Infer<typeof updateColumnSchema>;
+export type ColumnDrop = v.Infer<typeof dropColumnSchema>;
+export type TableDrop = v.Infer<typeof dropTableSchema>;
+export type IndexCreate = v.Infer<typeof createIndexSchema>;
+export type IndexDrop = v.Infer<typeof dropIndexSchema>;
 
 export const dataChangeSchema = v.union(
   insertSchema,
   updateSchema,
   deleteSchema,
   truncateSchema,
+  createTableSchema,
+  renameTableSchema,
+  addColumnSchema,
+  updateColumnSchema,
+  dropColumnSchema,
+  dropTableSchema,
+  createIndexSchema,
+  dropIndexSchema,
 );
 
 export type DataChange = Satisfies<


### PR DESCRIPTION
Defines schema change operations in the Change stream and processing logic in the Replicator.

This works backwards from #2700 with logic that applies schema changes and logs a "RESET" message in the ChangeLog so that the ViewSyncer / PipelineDriver can reset and hydrate with the updated table specs.

The final (forthcoming) piece will be the conversion of the trigger-generated DDL event messages into Change stream messages.