### PR TITLE
fix(zero-react, zbugs): hash queries by AST + ClientID

### DIFF
--- a/apps/zbugs/src/hooks/use-login.tsx
+++ b/apps/zbugs/src/hooks/use-login.tsx
@@ -1,4 +1,4 @@
-import {createContext, useContext, useEffect, useState} from 'react';
+import {createContext, useContext, useSyncExternalStore} from 'react';
 import {clearJwt} from '../jwt.js';
 import {type LoginState, authRef} from '../zero-setup.js';
 
@@ -19,11 +19,10 @@ export function useLogin() {
 }
 
 export function LoginProvider({children}: {children: React.ReactNode}) {
-  const [loginState, setLoginState] = useState<LoginState | undefined>(
-    authRef.value,
+  const loginState = useSyncExternalStore(
+    authRef.onChange,
+    authRef.getSnapshot,
   );
-
-  useEffect(() => authRef.onChange(setLoginState), []);
 
   return (
     <loginContext.Provider

--- a/apps/zbugs/src/root.tsx
+++ b/apps/zbugs/src/root.tsx
@@ -1,9 +1,7 @@
-import {Zero} from '@rocicorp/zero';
 import {ZeroProvider} from '@rocicorp/zero/react';
-import {useEffect, useState} from 'react';
+import {useSyncExternalStore} from 'react';
 import {Route, Switch} from 'wouter';
 import {Nav} from './components/nav.js';
-import {type Schema} from './domain/schema.js';
 import ErrorPage from './pages/error/error-page.js';
 import IssuePage from './pages/issue/issue-page.js';
 import ListPage from './pages/list/list-page.js';
@@ -11,8 +9,7 @@ import {zeroRef} from './zero-setup.js';
 import {routes} from './routes.js';
 
 export default function Root() {
-  const [z, setZ] = useState<Zero<Schema> | undefined>();
-  useEffect(() => zeroRef.onChange(z => setZ(z)), []);
+  const z = useSyncExternalStore(zeroRef.onChange, zeroRef.getSnapshot);
 
   if (!z) {
     return null;

--- a/packages/zero-client/src/client/ref.ts
+++ b/packages/zero-client/src/client/ref.ts
@@ -22,11 +22,13 @@ export class Ref<T> {
     return this.#current;
   }
 
-  onChange(listener: Listener<T>) {
+  getSnapshot = () => this.#current;
+
+  onChange = (listener: Listener<T>) => {
     this.#listeners.add(listener);
     listener(this.#current);
     return () => {
       this.#listeners.delete(listener);
     };
-  }
+  };
 }


### PR DESCRIPTION
`useQuery` re-used queries from old instances of Zero. This causes problems on logout as the user id changes and is not tied to the same store anymore.

Before:

https://github.com/user-attachments/assets/8e09cfd0-c7a3-42ad-8587-b088f2a95911

After:

https://github.com/user-attachments/assets/6c12a7e5-5d0f-4ee6-b994-582859439f7f