### PR TITLE
feat(zero-cache): make view syncer robust against external CVR updates

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -122,7 +122,7 @@ export class CVRUpdater {
     const start = Date.now();
 
     this.#setLastActive(lastActive);
-    const stats = await this._cvrStore.flush();
+    const stats = await this._cvrStore.flush(this._orig.version);
 
     lc.debug?.(
       `flushed CVR ${JSON.stringify(stats)} in (${Date.now() - start} ms)`,

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -111,7 +111,13 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       if (!this.#cvr) {
         this.#cvr = await this.#cvrStore.load();
       }
-      return fn(this.#cvr);
+      try {
+        return await fn(this.#cvr);
+      } catch (e) {
+        // Clear cached state if an error is encountered.
+        this.#cvr = undefined;
+        throw e;
+      }
     });
   }
 


### PR DESCRIPTION
Detect concurrent modifications to the CVR, responding by clearing cached state and aborting the request.

This is not yet at the final desired state where we use homing signals to determine which view syncer should "win", but it is a step towards that, protecting against CVR corruption from concurrent zero-caches.