### PR TITLE
feat(zql): build queries over types with shared structure

### DIFF
--- a/packages/zql/src/zql/query/schema.ts
+++ b/packages/zql/src/zql/query/schema.ts
@@ -4,6 +4,17 @@ export type TableSchema = TableSchemaBase & {
   readonly relationships: {readonly [name: string]: Relationship};
 };
 
+export type Supertype<TSchemas extends TableSchema[]> = {
+  tableName: TSchemas[number]['tableName'];
+  primaryKey: TSchemas[number]['primaryKey'];
+  columns: {
+    [K in keyof TSchemas[number]['columns']]: TSchemas[number]['columns'][K];
+  };
+  relationships: {
+    [K in keyof TSchemas[number]['relationships']]: TSchemas[number]['relationships'][K];
+  };
+};
+
 /**
  * A schema might have a relationship to itself.
  * Given we cannot reference a variable in the same statement we initialize


### PR DESCRIPTION
This came up again today on Zoom and it struck me as being pretty simple.

Adds a ~~`Intersect`~~ `Supertype` type which returns a query builder over the common elements of the provided types.

```ts
const allowIfCreator = (
    q: Query<Intersect<typeof query.comment, typeof query.issue>>,
) => {
  return (authData: AuthData, row: {id: string}) =>
    q.where('id', row.id).where('creatorID', authData.sub);
};
```

![CleanShot 2024-10-21 at 20 53 02@2x](https://github.com/user-attachments/assets/b1b380f9-3822-4bbf-bd27-21943a4294de)

![CleanShot 2024-10-21 at 20 53 56@2x](https://github.com/user-attachments/assets/a297c579-f59d-43b0-ac1e-7b622df687ae)

![CleanShot 2024-10-21 at 21 11 28@2x](https://github.com/user-attachments/assets/65a38437-2612-4c1f-8ac3-e272c9be6cdc)

