### PR TITLE
chore(zbugs): One more crack at shortIDs.

### DIFF
--- a/apps/zbugs/docker/init_upstream/init.sql
+++ b/apps/zbugs/docker/init_upstream/init.sql
@@ -215,6 +215,6 @@ CREATE INDEX comment_issueid_idx ON "comment" ("issueID");
 SELECT
     *
 FROM
-    pg_create_logical_replication_slot('zero_slot_r1', 'pgoutput');
+    pg_create_logical_replication_slot('zero_0', 'pgoutput');
 
 VACUUM;

--- a/apps/zbugs/src/pages/issue/issue-page.tsx
+++ b/apps/zbugs/src/pages/issue/issue-page.tsx
@@ -25,8 +25,9 @@ export default function IssuePage() {
   const z = useZero();
   const params = useParams();
 
-  const idField = params.shortID ? 'shortID' : 'id';
-  const id = params.shortID ? parseInt(params.shortID) : must(params.id);
+  const idStr = must(params.id);
+  const idField = isNaN(parseInt(idStr)) ? 'id' : 'shortID';
+  const id = idField === 'shortID' ? parseInt(idStr) : idStr;
 
   const listContext = useHistoryState<ListContext | undefined>();
 
@@ -162,7 +163,7 @@ export default function IssuePage() {
                 <span className="breadcrumb-item">&rarr;</span>
               </>
             ) : null}
-            <span className="breadcrumb-item">ZB-{issue.shortID}</span>
+            <span className="breadcrumb-item">Issue {issue.shortID}</span>
           </div>
           <div className="edit-buttons">
             {!editing ? (

--- a/apps/zbugs/src/root.tsx
+++ b/apps/zbugs/src/root.tsx
@@ -24,7 +24,6 @@ export default function Root() {
         <div className="primary-content">
           <Switch>
             <Route path={routes.home} component={ListPage} />
-            <Route path={routes.pendingIssue} component={IssuePage} />
             <Route path={routes.issue} component={IssuePage} />
             <Route component={ErrorPage} />
           </Switch>

--- a/apps/zbugs/src/routes.ts
+++ b/apps/zbugs/src/routes.ts
@@ -3,7 +3,7 @@ export const links = {
     return '/';
   },
   issue({id, shortID}: {id: string; shortID?: number | undefined}) {
-    return shortID ? `/issue/${shortID}` : `/issue/pending/${id}`;
+    return shortID ? `/issue/${shortID}` : `/issue/${id}`;
   },
   login(pathname: string, search: string | undefined) {
     return (
@@ -26,6 +26,5 @@ export type ListContext = {
 
 export const routes = {
   home: '/',
-  issue: '/issue/:shortID?',
-  pendingIssue: '/issue/pending/:id?',
+  issue: '/issue/:id',
 } as const;


### PR DESCRIPTION
~~Matt brought of the question of what happens if a user gets ahold of a long ID? Do they have to know about '/pending' ?~~

~~I don't really buy this argument. The shortID is nicer - why would a user have a long ID in the first place.~~

~~But say it was like development or something, it's easy enough to remember the URL convention.~~

~~That said, I don't like how much the /pending/<longID> URL flashes, and having the two routes is slightly annoying. So using a single char prefix to distinguish the two cases instead.~~

~~Yes I can just use isNumeric() and yes the chances of it getting the wrong thing are astronomical. But I like not having to think about that math.~~

Nevermind, I don't like the way it looks when the URL doesn't match the issue title in the UI. Aesthetics win again.