### PR TITLE
[RFC] feat(zql): `must` to ensure a param exists or disable the query

### DIFF
--- a/apps/zbugs/src/pages/list/list-page.tsx
+++ b/apps/zbugs/src/pages/list/list-page.tsx
@@ -27,12 +27,12 @@ export default function ListPage() {
   // TODO: this can go away once we have filter-by-subquery, you should be able
   // to filter by label.name directly.
   const creatorID = useQuery(
-    z.query.user.where('login', creator ?? '').one(),
-    creator !== null,
+    z.query.user.must(creator, (q, creator) => q.where('login', creator)).one(),
   )?.id;
   const assigneeID = useQuery(
-    z.query.user.where('login', assignee ?? '').one(),
-    assignee !== null,
+    z.query.user
+      .must(assignee, (q, assignee) => q.where('login', assignee))
+      .one(),
   )?.id;
   const labelIDs = useQuery(z.query.label.where('name', 'IN', labels));
 

--- a/packages/zero-react/src/use-query.tsx
+++ b/packages/zero-react/src/use-query.tsx
@@ -10,12 +10,16 @@ import type {
 } from '../../zero-client/src/mod.js';
 import type {Immutable} from '../../shared/src/immutable.js';
 import {useZero} from './use-zero.js';
+import {DisabledQuery} from '../../zql/src/zql/query/query-impl.js';
 
 export function useQuery<
   TSchema extends TableSchema,
   TReturn extends QueryType,
 >(q: Query<TSchema, TReturn>, enable: boolean = true): Smash<TReturn> {
   const z = useZero();
+  if (q instanceof DisabledQuery) {
+    enable = false;
+  }
   const view = viewStore.getView(
     z.clientID,
     q as QueryImpl<TSchema, TReturn>,

--- a/packages/zql/src/zql/query/query.ts
+++ b/packages/zql/src/zql/query/query.ts
@@ -213,6 +213,11 @@ export interface Query<
     cb: (query: Query<TSchema, TReturn>, value: T) => Query<TSchema, TReturn>,
   ): Query<TSchema, TReturn>;
 
+  must<T>(
+    value: T | null | undefined,
+    cb: (query: Query<TSchema, TReturn>, value: T) => Query<TSchema, TReturn>,
+  ): Query<TSchema, TReturn>;
+
   where<TSelector extends Selector<TSchema>, TOperator extends Operator>(
     field: TSelector,
     op: TOperator,


### PR DESCRIPTION
last sidetrack --

A `must` method that disables the query if the parameter is null or undefined. 


![CleanShot 2024-10-22 at 09 54 58](https://github.com/user-attachments/assets/a9de844f-64a3-459a-824a-23cb1b4684eb)

The other option for this is to follow SQL null semantics:

https://github.com/rocicorp/mono/compare/main...mlaw/null-where

which is more concise but maybe unexpected?

![CleanShot 2024-10-22 at 09 55 31](https://github.com/user-attachments/assets/c44ac692-e01d-4d69-a882-c2622ec09b41)

idk `must` would be confusing to me if I didn't create it. I like the `follow SQL null semantics` option.