### PR TITLE
fix(zbugs): improve focus handling

### DIFF
--- a/apps/zbugs/src/components/button.tsx
+++ b/apps/zbugs/src/components/button.tsx
@@ -1,4 +1,4 @@
-import type {CSSProperties, ReactNode} from 'react';
+import {useCallback, type CSSProperties, type ReactNode} from 'react';
 
 interface Props {
   children?: ReactNode | undefined;
@@ -12,10 +12,20 @@ interface Props {
 
 export function Button(props: Props) {
   const {onAction, ...rest} = props;
-  // debugger;
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      onAction?.();
+      // Prevent default to avoid the button taking focus on click, which
+      // wil steal focus from anything focused in response to onAction.
+      e.preventDefault();
+    },
+    [onAction],
+  );
+
   const actionProps = onAction
     ? {
-        onMouseDown: onAction,
+        onMouseDown: handleMouseDown,
         onKeyUp: (e: React.KeyboardEvent<Element>) => {
           if (e.key === ' ') {
             onAction();

--- a/apps/zbugs/src/components/label-picker.tsx
+++ b/apps/zbugs/src/components/label-picker.tsx
@@ -1,10 +1,16 @@
 import {useQuery} from '@rocicorp/zero/react';
 import classNames from 'classnames';
-import {useCallback, useEffect, useRef, useState} from 'react';
+import {useCallback, useRef, useState} from 'react';
 import {useClickOutside} from '../hooks/use-click-outside.js';
 import {useZero} from '../hooks/use-zero.js';
 import {Button} from './button.js';
 import style from './label-picker.module.css';
+
+const focusInput = (input: HTMLInputElement | null) => {
+  if (input) {
+    input.focus();
+  }
+};
 
 export default function LabelPicker({
   selected,
@@ -21,20 +27,11 @@ export default function LabelPicker({
   const z = useZero();
   const labels = useQuery(z.query.label.orderBy('name', 'asc'));
   const ref = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
 
   useClickOutside(
     ref,
     useCallback(() => setIsOpen(false), []),
   );
-
-  useEffect(() => {
-    if (isOpen) {
-      setTimeout(() => {
-        inputRef.current?.focus();
-      }, 0);
-    }
-  }, [isOpen]);
 
   return (
     <div className={style.root} ref={ref}>
@@ -52,7 +49,7 @@ export default function LabelPicker({
           onCreateNewLabel={onCreateNewLabel}
           labels={labels}
           selected={selected}
-          inputRef={inputRef}
+          inputRef={focusInput}
         />
       )}
     </div>
@@ -72,7 +69,7 @@ function LabelPopover({
   onAssociateLabel: (id: string) => void;
   onCreateNewLabel: (name: string) => void;
   labels: readonly {id: string; name: string}[];
-  inputRef: React.RefObject<HTMLInputElement>;
+  inputRef: React.Ref<HTMLInputElement>;
 }) {
   const [input, setInput] = useState('');
   const filteredLabels = labels.filter(label =>

--- a/apps/zbugs/src/pages/issue/issue-composer.tsx
+++ b/apps/zbugs/src/pages/issue/issue-composer.tsx
@@ -1,5 +1,5 @@
 import {nanoid} from 'nanoid';
-import {useCallback, useEffect, useRef, useState} from 'react';
+import {useCallback, useEffect, useState} from 'react';
 import {Button} from '../../components/button.js';
 import Modal from '../../components/modal.js';
 import {useZero} from '../../hooks/use-zero.js';
@@ -10,27 +10,22 @@ interface Props {
   isOpen: boolean;
 }
 
+const focusInput = (input: HTMLInputElement | null) => {
+  if (input) {
+    input.focus();
+  }
+};
+
 export default function IssueComposer({isOpen, onDismiss}: Props) {
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState<string>('');
   const z = useZero();
-
-  const inputRef = useRef<HTMLInputElement>(null); // Separate input ref for focusing
 
   // Function to handle textarea resizing
   function autoResizeTextarea(textarea: HTMLTextAreaElement) {
     textarea.style.height = 'auto';
     textarea.style.height = textarea.scrollHeight + 'px';
   }
-
-  // UseEffect to focus the input field when modal opens
-  useEffect(() => {
-    if (isOpen) {
-      setTimeout(() => {
-        inputRef.current?.focus(); // Focus the input field when modal opens
-      }, 0);
-    }
-  }, [isOpen]);
 
   // Use the useEffect hook to handle the auto-resize logic for textarea
   useEffect(() => {
@@ -88,7 +83,7 @@ export default function IssueComposer({isOpen, onDismiss}: Props) {
             className="new-issue-title"
             placeholder="Issue title"
             value={title}
-            ref={inputRef} // Attach the inputRef to this input field
+            ref={focusInput} // Attach the inputRef to this input field
             onChange={e => setTitle(e.target.value)}
           />
         </div>


### PR DESCRIPTION
Using mousedown instead of click for our buttons causes them to often steal focus from something focused by the buttons action.  

preventDefault on the mousedown event to prevent this focus stealing.  

cc @aboodman 