### PR TITLE
fix(zbugs): fix conflict between list-page and issue-page use of history state

### DIFF
--- a/apps/zbugs/src/components/issue-link.tsx
+++ b/apps/zbugs/src/components/issue-link.tsx
@@ -7,16 +7,21 @@ export default function IssueLink({
   children,
   className,
   listContext,
+  scrollOffset,
 }: {
   issue: {id: string; shortID?: number | undefined};
   listContext: ListContext;
-} & Omit<LinkProps<ListContext>, 'href' | 'state'>) {
+  scrollOffset: number;
+} & Omit<LinkProps, 'href' | 'state'>) {
   return (
     <Link
       href={links.issue(issue)}
       title={title}
       className={className}
-      state={listContext}
+      state={{
+        zbugsListContext: listContext,
+        zbugsListScrollOffset: scrollOffset,
+      }}
     >
       {children}
     </Link>

--- a/apps/zbugs/src/components/link.tsx
+++ b/apps/zbugs/src/components/link.tsx
@@ -1,18 +1,19 @@
 import type {ReactNode} from 'react';
 import {navigate} from 'wouter/use-browser-location';
+import type {ZbugsHistoryState} from '../routes.js';
 
-export type Props<S> = {
+export type Props = {
   children: ReactNode;
   href: string;
   className?: string | undefined;
   title?: string | undefined;
-  state?: S | undefined;
+  state?: ZbugsHistoryState | undefined;
 };
 /**
  * The Link from wouter uses onClick and there's no way to change it.
  * We like mousedown here at Rocicorp.
  */
-export function Link<S>({children, href, className, title, state}: Props<S>) {
+export function Link({children, href, className, title, state}: Props) {
   const isPrimary = (e: React.MouseEvent) => {
     if (e.ctrlKey || e.metaKey || e.altKey || e.shiftKey || e.button !== 0) {
       return false;

--- a/apps/zbugs/src/pages/issue/issue-page.tsx
+++ b/apps/zbugs/src/pages/issue/issue-page.tsx
@@ -18,7 +18,7 @@ import UserPicker from '../../components/user-picker.js';
 import type {Schema} from '../../domain/schema.js';
 import {useKeypress} from '../../hooks/use-keypress.js';
 import {useZero} from '../../hooks/use-zero.js';
-import {links, type ListContext} from '../../routes.js';
+import {links, type ListContext, type ZbugsHistoryState} from '../../routes.js';
 import CommentComposer from './comment-composer.js';
 import Comment from './comment.js';
 import RelativeTime from '../../components/relative-time.js';
@@ -31,8 +31,8 @@ export default function IssuePage() {
   const idField = isNaN(parseInt(idStr)) ? 'id' : 'shortID';
   const id = idField === 'shortID' ? parseInt(idStr) : idStr;
 
-  const listContext = useHistoryState<ListContext | undefined>();
-
+  const zbugsHistoryState = useHistoryState<ZbugsHistoryState | undefined>();
+  const listContext = zbugsHistoryState?.zbugsListContext;
   // todo: one should be in the schema
   const q = z.query.issue
     .where(idField, id)
@@ -68,9 +68,12 @@ export default function IssuePage() {
   const [edits, setEdits] = useState<Partial<typeof issue>>({});
   useEffect(() => {
     if (issue?.shortID !== undefined && idField !== 'shortID') {
-      navigate(links.issue(issue), {replace: true, state: listContext});
+      navigate(links.issue(issue), {
+        replace: true,
+        state: zbugsHistoryState,
+      });
     }
-  }, [issue, idField, listContext]);
+  }, [issue, idField, zbugsHistoryState]);
 
   const save = () => {
     if (!editing) {
@@ -103,7 +106,7 @@ export default function IssuePage() {
   );
   useKeypress('j', () => {
     if (next) {
-      navigate(links.issue(next), {state: listContext});
+      navigate(links.issue(next), {state: zbugsHistoryState});
     }
   });
 
@@ -113,7 +116,7 @@ export default function IssuePage() {
   );
   useKeypress('k', () => {
     if (prev) {
-      navigate(links.issue(prev), {state: listContext});
+      navigate(links.issue(prev), {state: zbugsHistoryState});
     }
   });
 
@@ -153,7 +156,14 @@ export default function IssuePage() {
           <div className="issue-breadcrumb">
             {listContext ? (
               <>
-                <Link className="breadcrumb-item" href={listContext.href}>
+                <Link
+                  className="breadcrumb-item"
+                  href={listContext.href}
+                  state={{
+                    zbugsListScrollOffset:
+                      zbugsHistoryState?.zbugsListScrollOffset,
+                  }}
+                >
                   {listContext.title}
                 </Link>
                 <span className="breadcrumb-item">&rarr;</span>

--- a/apps/zbugs/src/routes.ts
+++ b/apps/zbugs/src/routes.ts
@@ -13,6 +13,11 @@ export const links = {
   },
 };
 
+export type ZbugsHistoryState = {
+  readonly zbugsListScrollOffset?: number | undefined;
+  readonly zbugsListContext?: ListContext | undefined;
+};
+
 export type ListContext = {
   readonly href: string;
   readonly title: string;


### PR DESCRIPTION
This was causing an error when using browser back from issue, as issue would momentarily see the history state navigate back to (another bit of a wouter oddity, i wouldn't expect IssuePage to render after the historyState has changed).

<img width="810" alt="image" src="https://github.com/user-attachments/assets/3026e460-e5cf-47bd-a71e-d39476c887b7">

This formalizes our history state more, defining a type for it in routes.ts.

NEW: restores scroll position on breadcrumb navigation in addition to browser back.