### PR TITLE
fix(zbugs): fix read state flicker

### DIFF
--- a/apps/zbugs/src/zero-setup.ts
+++ b/apps/zbugs/src/zero-setup.ts
@@ -40,7 +40,11 @@ authRef.onChange(auth => {
   // To enable accessing zero in the devtools easily.
   (window as {z?: Zero<Schema>}).z = z;
 
-  const baseIssueQuery = z.query.issue.related('creator').related('labels');
+  const baseIssueQuery = z.query.issue
+    .related('creator')
+    .related('assignee')
+    .related('labels')
+    .related('viewState', q => q.where('userID', z.userID).one());
 
   const {cleanup, complete} = baseIssueQuery.preload();
   complete.then(() => {


### PR DESCRIPTION
Fixes https://bugs.rocicorp.dev/issue/3078

There would sometimes be a flash of the unread indicator on read issues in list page.

This was hybrid query + consistency issue.

The preload query did not include the 'viewState' relation.  So before the list query was got, the viewState could be undefined (as it was not covered by preload) which was interpreted as unread.
