### PR TITLE
feat(zql): add `or` and `and` to the AST

### DIFF
--- a/packages/zero-cache/src/services/mutagen/write-authorizer.test.ts
+++ b/packages/zero-cache/src/services/mutagen/write-authorizer.test.ts
@@ -18,14 +18,12 @@ const allowIfSubject = [
   'allow',
   {
     table: 'foo',
-    where: [
-      {
-        type: 'simple',
-        field: 'id',
-        op: '=',
-        value: {anchor: 'authData', field: 'sub', type: 'static'},
-      },
-    ],
+    where: {
+      type: 'simple',
+      field: 'id',
+      op: '=',
+      value: {anchor: 'authData', field: 'sub', type: 'static'},
+    },
     orderBy: [['id', 'asc']],
   },
 ] satisfies Rule;

--- a/packages/zero-cache/src/services/view-syncer/cvr.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.test.ts
@@ -551,14 +551,12 @@ describe('view-syncer/cvr', () => {
           ast: {
             table: `zero_${SHARD_ID}.clients`,
             schema: '',
-            where: [
-              {
-                type: 'simple',
-                op: '=',
-                field: 'clientGroupID',
-                value: 'abc123',
-              },
-            ],
+            where: {
+              type: 'simple',
+              op: '=',
+              field: 'clientGroupID',
+              value: 'abc123',
+            },
             orderBy: [
               ['clientGroupID', 'asc'],
               ['clientID', 'asc'],
@@ -641,14 +639,12 @@ describe('view-syncer/cvr', () => {
           clientAST: {
             schema: '',
             table: `zero_${SHARD_ID}.clients`,
-            where: [
-              {
-                field: 'clientGroupID',
-                op: '=',
-                type: 'simple',
-                value: 'abc123',
-              },
-            ],
+            where: {
+              field: 'clientGroupID',
+              op: '=',
+              type: 'simple',
+              value: 'abc123',
+            },
             orderBy: [
               ['clientGroupID', 'asc'],
               ['clientID', 'asc'],

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -171,14 +171,12 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
         ast: {
           schema: '',
           table: `${schema(this.#shardID)}.clients`,
-          where: [
-            {
-              type: 'simple',
-              field: 'clientGroupID',
-              op: '=',
-              value: this._cvr.id,
-            },
-          ],
+          where: {
+            type: 'simple',
+            field: 'clientGroupID',
+            op: '=',
+            value: this._cvr.id,
+          },
           orderBy: [
             ['clientGroupID', 'asc'],
             ['clientID', 'asc'],

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.test.ts
@@ -47,14 +47,12 @@ const SHARD_ID = 'ABC';
 const EXPECTED_LMIDS_AST: AST = {
   schema: '',
   table: 'zero_ABC.clients',
-  where: [
-    {
-      type: 'simple',
-      op: '=',
-      field: 'clientGroupID',
-      value: '9876',
-    },
-  ],
+  where: {
+    type: 'simple',
+    op: '=',
+    field: 'clientGroupID',
+    value: '9876',
+  },
   orderBy: [
     ['clientGroupID', 'asc'],
     ['clientID', 'asc'],
@@ -221,14 +219,12 @@ describe('view-syncer/service', () => {
 
   const ISSUES_QUERY: AST = {
     table: 'issues',
-    where: [
-      {
-        type: 'simple',
-        field: 'id',
-        op: 'IN',
-        value: ['1', '2', '3', '4'],
-      },
-    ],
+    where: {
+      type: 'simple',
+      field: 'id',
+      op: 'IN',
+      value: ['1', '2', '3', '4'],
+    },
     orderBy: [['id', 'asc']],
   };
 
@@ -362,19 +358,17 @@ describe('view-syncer/service', () => {
                       ],
                     ],
                     "table": "issues",
-                    "where": [
-                      {
-                        "field": "id",
-                        "op": "IN",
-                        "type": "simple",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                    ],
+                    "where": {
+                      "field": "id",
+                      "op": "IN",
+                      "type": "simple",
+                      "value": [
+                        "1",
+                        "2",
+                        "3",
+                        "4",
+                      ],
+                    },
                   },
                   "hash": "query-hash1",
                   "op": "put",
@@ -391,19 +385,17 @@ describe('view-syncer/service', () => {
                     ],
                   ],
                   "table": "issues",
-                  "where": [
-                    {
-                      "field": "id",
-                      "op": "IN",
-                      "type": "simple",
-                      "value": [
-                        "1",
-                        "2",
-                        "3",
-                        "4",
-                      ],
-                    },
-                  ],
+                  "where": {
+                    "field": "id",
+                    "op": "IN",
+                    "type": "simple",
+                    "value": [
+                      "1",
+                      "2",
+                      "3",
+                      "4",
+                    ],
+                  },
                 },
                 "hash": "query-hash1",
                 "op": "put",
@@ -583,19 +575,17 @@ describe('view-syncer/service', () => {
                       ],
                     ],
                     "table": "issues",
-                    "where": [
-                      {
-                        "field": "id",
-                        "op": "IN",
-                        "type": "simple",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                    ],
+                    "where": {
+                      "field": "id",
+                      "op": "IN",
+                      "type": "simple",
+                      "value": [
+                        "1",
+                        "2",
+                        "3",
+                        "4",
+                      ],
+                    },
                   },
                   "hash": "query-hash1",
                   "op": "put",
@@ -625,19 +615,17 @@ describe('view-syncer/service', () => {
                     ],
                   ],
                   "table": "issues",
-                  "where": [
-                    {
-                      "field": "id",
-                      "op": "IN",
-                      "type": "simple",
-                      "value": [
-                        "1",
-                        "2",
-                        "3",
-                        "4",
-                      ],
-                    },
-                  ],
+                  "where": {
+                    "field": "id",
+                    "op": "IN",
+                    "type": "simple",
+                    "value": [
+                      "1",
+                      "2",
+                      "3",
+                      "4",
+                    ],
+                  },
                 },
                 "hash": "query-hash1",
                 "op": "put",
@@ -1365,19 +1353,17 @@ describe('view-syncer/service', () => {
                       ],
                     ],
                     "table": "issues",
-                    "where": [
-                      {
-                        "field": "id",
-                        "op": "IN",
-                        "type": "simple",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                    ],
+                    "where": {
+                      "field": "id",
+                      "op": "IN",
+                      "type": "simple",
+                      "value": [
+                        "1",
+                        "2",
+                        "3",
+                        "4",
+                      ],
+                    },
                   },
                   "hash": "query-hash1",
                   "op": "put",
@@ -1452,19 +1438,17 @@ describe('view-syncer/service', () => {
                       ],
                     ],
                     "table": "issues",
-                    "where": [
-                      {
-                        "field": "id",
-                        "op": "IN",
-                        "type": "simple",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                    ],
+                    "where": {
+                      "field": "id",
+                      "op": "IN",
+                      "type": "simple",
+                      "value": [
+                        "1",
+                        "2",
+                        "3",
+                        "4",
+                      ],
+                    },
                   },
                   "hash": "query-hash1",
                   "op": "put",
@@ -1562,19 +1546,17 @@ describe('view-syncer/service', () => {
                       ],
                     ],
                     "table": "issues",
-                    "where": [
-                      {
-                        "field": "id",
-                        "op": "IN",
-                        "type": "simple",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                    ],
+                    "where": {
+                      "field": "id",
+                      "op": "IN",
+                      "type": "simple",
+                      "value": [
+                        "1",
+                        "2",
+                        "3",
+                        "4",
+                      ],
+                    },
                   },
                   "hash": "query-hash1",
                   "op": "put",
@@ -1591,19 +1573,17 @@ describe('view-syncer/service', () => {
                     ],
                   ],
                   "table": "issues",
-                  "where": [
-                    {
-                      "field": "id",
-                      "op": "IN",
-                      "type": "simple",
-                      "value": [
-                        "1",
-                        "2",
-                        "3",
-                        "4",
-                      ],
-                    },
-                  ],
+                  "where": {
+                    "field": "id",
+                    "op": "IN",
+                    "type": "simple",
+                    "value": [
+                      "1",
+                      "2",
+                      "3",
+                      "4",
+                    ],
+                  },
                 },
                 "hash": "query-hash1",
                 "op": "put",

--- a/packages/zero-protocol/src/ast.test.ts
+++ b/packages/zero-protocol/src/ast.test.ts
@@ -26,7 +26,7 @@ test('fields are placed into correct positions', () => {
       limit: 10,
       orderBy: [],
       related: [],
-      where: [],
+      where: undefined,
       table: 'table',
     }),
   ).toEqual(
@@ -36,7 +36,7 @@ test('fields are placed into correct positions', () => {
       limit: 10,
       table: 'table',
       orderBy: [],
-      where: [],
+      where: undefined,
       alias: 'alias',
     }),
   );
@@ -45,73 +45,106 @@ test('fields are placed into correct positions', () => {
 test('conditions are sorted', () => {
   let ast: AST = {
     table: 'table',
-    where: [
+    where: {
+      type: 'and',
+      conditions: [
+        {
+          type: 'simple',
+          field: 'b',
+          op: '=',
+          value: 'value',
+        },
+        {
+          type: 'simple',
+          field: 'a',
+          op: '=',
+          value: 'value',
+        },
+      ],
+    },
+  };
+
+  expect(normalizeAST(ast).where).toEqual({
+    type: 'and',
+    conditions: [
+      {
+        type: 'simple',
+        field: 'a',
+        op: '=',
+        value: 'value',
+      },
       {
         type: 'simple',
         field: 'b',
         op: '=',
         value: 'value',
       },
-      {
-        type: 'simple',
-        field: 'a',
-        op: '=',
-        value: 'value',
-      },
     ],
-  };
-
-  expect(normalizeAST(ast).where).toEqual([
-    {
-      type: 'simple',
-      field: 'a',
-      op: '=',
-      value: 'value',
-    },
-    {
-      type: 'simple',
-      field: 'b',
-      op: '=',
-      value: 'value',
-    },
-  ]);
+  });
 
   ast = {
     table: 'table',
-    where: [
-      {
-        type: 'simple',
-        field: 'a',
-        op: '=',
-        value: 'y',
-      },
+    where: {
+      type: 'and',
+      conditions: [
+        {
+          type: 'simple',
+          field: 'a',
+          op: '=',
+          value: 'y',
+        },
+        {
+          type: 'simple',
+          field: 'a',
+          op: '=',
+          value: 'x',
+        },
+      ],
+    },
+  };
+
+  expect(normalizeAST(ast).where).toEqual({
+    type: 'and',
+    conditions: [
       {
         type: 'simple',
         field: 'a',
         op: '=',
         value: 'x',
       },
+      {
+        type: 'simple',
+        field: 'a',
+        op: '=',
+        value: 'y',
+      },
     ],
-  };
-
-  expect(normalizeAST(ast).where).toEqual([
-    {
-      type: 'simple',
-      field: 'a',
-      op: '=',
-      value: 'x',
-    },
-    {
-      type: 'simple',
-      field: 'a',
-      op: '=',
-      value: 'y',
-    },
-  ]);
+  });
 
   ast = {
     table: 'table',
-    where: [
+    where: {
+      type: 'and',
+      conditions: [
+        {
+          type: 'simple',
+          field: 'a',
+          op: '<',
+          value: 'x',
+        },
+        {
+          type: 'simple',
+          field: 'a',
+          op: '>',
+          value: 'y',
+        },
+      ],
+    },
+  };
+
+  expect(normalizeAST(ast).where).toEqual({
+    type: 'and',
+    conditions: [
       {
         type: 'simple',
         field: 'a',
@@ -125,22 +158,7 @@ test('conditions are sorted', () => {
         value: 'y',
       },
     ],
-  };
-
-  expect(normalizeAST(ast).where).toEqual([
-    {
-      type: 'simple',
-      field: 'a',
-      op: '<',
-      value: 'x',
-    },
-    {
-      type: 'simple',
-      field: 'a',
-      op: '>',
-      value: 'y',
-    },
-  ]);
+  });
 });
 
 test('related subqueries are sorted', () => {

--- a/packages/zero-protocol/src/ast.ts
+++ b/packages/zero-protocol/src/ast.ts
@@ -9,6 +9,7 @@
 import {compareUTF8} from 'compare-utf8';
 import {must} from '../../shared/src/must.js';
 import * as v from '../../shared/src/valita.js';
+import {defined} from '../../shared/src/arrays.js';
 import type {Row} from './data.js';
 
 export const selectorSchema = v.string();
@@ -68,7 +69,21 @@ export const simpleConditionSchema = v.object({
   ),
 });
 
-export const conditionSchema = simpleConditionSchema;
+export const conditionSchema = v.union(
+  simpleConditionSchema,
+  v.lazy(() => conjunctionSchema),
+  v.lazy(() => disjunctionSchema),
+);
+
+const conjunctionSchema: v.Type<Conjunction> = v.readonlyObject({
+  type: v.literal('and'),
+  conditions: v.readonlyArray(conditionSchema),
+});
+
+const disjunctionSchema: v.Type<Disjunction> = v.readonlyObject({
+  type: v.literal('or'),
+  conditions: v.readonlyArray(conditionSchema),
+});
 
 // Split out so that its inferred type can be checked against
 // Omit<CorrelatedSubQuery, 'correlation'> in ast-type-test.ts.
@@ -76,7 +91,7 @@ export const conditionSchema = simpleConditionSchema;
 // is the only thing added in v.lazy.  The v.lazy is necessary due to the
 // mutually-recursive types, but v.lazy prevents inference of the resulting
 // type.
-export const correlatedSubquerySchemaOmitSubquery = v.object({
+export const correlatedSubquerySchemaOmitSubquery = v.readonlyObject({
   correlation: v.object({
     parentField: v.string(),
     childField: v.string(),
@@ -94,7 +109,7 @@ export const astSchema = v.object({
   schema: v.string().optional(),
   table: v.string(),
   alias: v.string().optional(),
-  where: v.readonlyArray(conditionSchema).optional(),
+  where: conditionSchema.optional(),
   related: v.readonlyArray(correlatedSubquerySchema).optional(),
   limit: v.number().optional(),
   orderBy: orderingSchema.optional(),
@@ -146,7 +161,7 @@ export type AST = {
   // where conditions or choose the _first_ `related` entry.
   // Choosing the first `related` entry is almost always the best choice if
   // one exists.
-  readonly where?: readonly Condition[] | undefined;
+  readonly where?: Condition | undefined;
 
   readonly related?: readonly CorrelatedSubQuery[] | undefined;
   readonly start?: Bound | undefined;
@@ -187,7 +202,7 @@ export type LiteralValue =
  * ivm1 supports Conjunctions and Disjunctions.
  * We'll support them in the future.
  */
-export type Condition = SimpleCondition;
+export type Condition = SimpleCondition | Conjunction | Disjunction;
 
 export type SimpleCondition = {
   type: 'simple';
@@ -205,6 +220,16 @@ export type SimpleCondition = {
    * operator defined and `null != null` in SQL.
    */
   value: ValuePosition;
+};
+
+export type Conjunction = {
+  type: 'and';
+  conditions: readonly Condition[];
+};
+
+export type Disjunction = {
+  type: 'or';
+  conditions: readonly Condition[];
 };
 
 /**
@@ -237,17 +262,17 @@ type StaticParameter = {
 };
 
 const normalizeCache = new WeakMap<AST, Required<AST>>();
-
 export function normalizeAST(ast: AST): Required<AST> {
   const cached = normalizeCache.get(ast);
   if (cached) {
     return cached;
   }
+  const where = flattened(ast.where);
   const normalized = {
     schema: ast.schema,
     table: ast.table,
     alias: ast.alias,
-    where: ast.where ? sortedWhere(ast.where) : undefined,
+    where: where ? sortedWhere(where) : undefined,
     related: ast.related
       ? sortedRelated(
           ast.related.map(
@@ -273,8 +298,14 @@ export function normalizeAST(ast: AST): Required<AST> {
   return normalized;
 }
 
-function sortedWhere(where: readonly Condition[]): readonly Condition[] {
-  return [...where].sort(cmpCondition);
+function sortedWhere(where: Condition): Condition {
+  if (where.type === 'simple') {
+    return where;
+  }
+  return {
+    type: where.type,
+    conditions: where.conditions.map(w => sortedWhere(w)).sort(cmpCondition),
+  };
 }
 
 function sortedRelated(
@@ -284,18 +315,81 @@ function sortedRelated(
 }
 
 function cmpCondition(a: Condition, b: Condition): number {
-  return (
-    compareUTF8MaybeNull(a.field, b.field) ||
-    compareUTF8MaybeNull(a.op, b.op) ||
-    // Comparing the same field with the same op more than once doesn't make logical
-    // sense, but is technically possible. Assume the values are of the same type and
-    // sort by their String forms.
-    compareUTF8MaybeNull(String(a.value), String(b.value))
-  );
+  if (a.type === 'simple') {
+    if (b.type !== 'simple') {
+      return -1; // Order SimpleConditions first to simplify logic for invalidation filtering.
+    }
+    return (
+      compareUTF8MaybeNull(a.field, b.field) ||
+      compareUTF8MaybeNull(a.op, b.op) ||
+      // Comparing the same field with the same op more than once doesn't make logical
+      // sense, but is technically possible. Assume the values are of the same type and
+      // sort by their String forms.
+      compareUTF8MaybeNull(String(a.value), String(b.value))
+    );
+  }
+
+  if (b.type === 'simple') {
+    return 1; // Order SimpleConditions first to simplify logic for invalidation filtering.
+  }
+
+  const val = compareUTF8MaybeNull(a.type, b.type);
+  if (val !== 0) {
+    return val;
+  }
+  for (
+    let l = 0, r = 0;
+    l < a.conditions.length && r < b.conditions.length;
+    l++, r++
+  ) {
+    const val = cmpCondition(a.conditions[l], b.conditions[r]);
+    if (val !== 0) {
+      return val;
+    }
+  }
+  // prefixes first
+  return a.conditions.length - b.conditions.length;
 }
 
 function cmpRelated(a: CorrelatedSubQuery, b: CorrelatedSubQuery): number {
   return compareUTF8(must(a.subquery.alias), must(b.subquery.alias));
+}
+
+/**
+ * Returns a flattened version of the Conditions in which nested Conjunctions with
+ * the same operation ('AND' or 'OR') are flattened to the same level. e.g.
+ *
+ * ```
+ * ((a AND b) AND (c AND (d OR (e OR f)))) -> (a AND b AND c AND (d OR e OR f))
+ * ```
+ *
+ * Also flattens singleton Conjunctions regardless of operator, and removes
+ * empty Conjunctions.
+ */
+function flattened<T extends Condition>(cond: T | undefined): T | undefined {
+  if (cond === undefined) {
+    return undefined;
+  }
+  if (cond.type === 'simple') {
+    return cond;
+  }
+  const conditions = defined(
+    cond.conditions.flatMap(c =>
+      c.type === cond.type ? c.conditions.map(c => flattened(c)) : flattened(c),
+    ),
+  );
+
+  switch (conditions.length) {
+    case 0:
+      return undefined;
+    case 1:
+      return conditions[0] as T;
+    default:
+      return {
+        type: cond.type,
+        conditions,
+      } as unknown as T;
+  }
 }
 
 function compareUTF8MaybeNull(a: string | null, b: string | null): number {

--- a/packages/zql/src/zql/builder/__snapshots__/builder.test.ts.snap
+++ b/packages/zql/src/zql/builder/__snapshots__/builder.test.ts.snap
@@ -19,25 +19,21 @@ exports[`bind static parameters 1`] = `
         "alias": "userStates",
         "related": undefined,
         "table": "userStates",
-        "where": [
-          {
-            "field": "stateCode",
-            "op": "=",
-            "type": "simple",
-            "value": "HI",
-          },
-        ],
+        "where": {
+          "field": "stateCode",
+          "op": "=",
+          "type": "simple",
+          "value": "HI",
+        },
       },
     },
   ],
   "table": "users",
-  "where": [
-    {
-      "field": "id",
-      "op": "=",
-      "type": "simple",
-      "value": 1,
-    },
-  ],
+  "where": {
+    "field": "id",
+    "op": "=",
+    "type": "simple",
+    "value": 1,
+  },
 }
 `;

--- a/packages/zql/src/zql/builder/builder.test.ts
+++ b/packages/zql/src/zql/builder/builder.test.ts
@@ -93,14 +93,12 @@ test('filter', () => {
       {
         table: 'users',
         orderBy: [['id', 'desc']],
-        where: [
-          {
-            type: 'simple',
-            field: 'name',
-            op: '>=',
-            value: 'c',
-          },
-        ],
+        where: {
+          type: 'simple',
+          field: 'name',
+          op: '>=',
+          value: 'c',
+        },
       },
       {
         getSource,
@@ -305,14 +303,12 @@ test('multi-join', () => {
       {
         table: 'users',
         orderBy: [['id', 'asc']],
-        where: [
-          {
-            type: 'simple',
-            field: 'id',
-            op: '<=',
-            value: 3,
-          },
-        ],
+        where: {
+          type: 'simple',
+          field: 'id',
+          op: '<=',
+          value: 3,
+        },
         related: [
           {
             correlation: {
@@ -561,14 +557,12 @@ test('bind static parameters', () => {
   const ast: AST = {
     table: 'users',
     orderBy: [['id', 'asc']],
-    where: [
-      {
-        type: 'simple',
-        field: 'id',
-        op: '=',
-        value: {type: 'static', anchor: 'authData', field: 'userID'},
-      },
-    ],
+    where: {
+      type: 'simple',
+      field: 'id',
+      op: '=',
+      value: {type: 'static', anchor: 'authData', field: 'userID'},
+    },
     related: [
       {
         correlation: {
@@ -579,18 +573,16 @@ test('bind static parameters', () => {
         subquery: {
           table: 'userStates',
           alias: 'userStates',
-          where: [
-            {
-              type: 'simple',
+          where: {
+            type: 'simple',
+            field: 'stateCode',
+            op: '=',
+            value: {
+              type: 'static',
+              anchor: 'preMutationRow',
               field: 'stateCode',
-              op: '=',
-              value: {
-                type: 'static',
-                anchor: 'preMutationRow',
-                field: 'stateCode',
-              },
             },
-          ],
+          },
         },
       },
     ],

--- a/packages/zql/src/zql/builder/filter.ts
+++ b/packages/zql/src/zql/builder/filter.ts
@@ -1,7 +1,7 @@
 import {assert} from '../../../../shared/src/asserts.js';
 import type {
-  Condition,
   LiteralValue,
+  SimpleCondition,
   SimpleOperator,
 } from '../../../../zero-protocol/src/ast.js';
 import type {Row, Value} from '../../../../zero-protocol/src/data.js';
@@ -10,7 +10,7 @@ import {getLikePredicate} from './like.js';
 export type NonNullValue = Exclude<Value, null | undefined>;
 export type SimplePredicate = (rhs: NonNullValue) => boolean;
 
-export function createPredicate(condition: Condition) {
+export function createPredicate(condition: SimpleCondition) {
   const impl = createPredicateImpl(
     condition.value as LiteralValue,
     condition.op,

--- a/packages/zql/src/zql/ivm/source.ts
+++ b/packages/zql/src/zql/ivm/source.ts
@@ -53,10 +53,7 @@ export interface Source {
    * order.
    * @param optionalFilters Optional filters to apply to the source.
    */
-  connect(
-    sort: Ordering,
-    optionalFilters?: readonly Condition[] | undefined,
-  ): SourceInput;
+  connect(sort: Ordering, optionalFilters?: Condition | undefined): SourceInput;
 
   /**
    * Pushes a change into the source and into all connected outputs.

--- a/packages/zql/src/zql/ivm/test/source-cases.ts
+++ b/packages/zql/src/zql/ivm/test/source-cases.ts
@@ -927,6 +927,83 @@ const cases = {
     const it3 = stream[Symbol.iterator]();
     expect(it3.next()).toEqual({done: true, value: undefined});
   },
+
+  // `OR` and nested conditions are not implemented yet so ensure they are not used
+  'throws when passing unsupported filter types to where': (
+    createSource: SourceFactory,
+  ) => {
+    const source = createSource('table', {a: {type: 'number'}}, ['a']);
+    expect(() =>
+      source.connect([['a', 'asc']], {
+        type: 'simple',
+        field: 'a',
+        value: 'a',
+        op: '=',
+      }),
+    ).not.toThrow();
+    expect(() =>
+      source.connect([['a', 'asc']], {
+        type: 'and',
+        conditions: [
+          {
+            type: 'simple',
+            field: 'a',
+            value: 'a',
+            op: '=',
+          },
+        ],
+      }),
+    ).not.toThrow();
+    expect(() =>
+      source.connect([['a', 'asc']], {
+        type: 'or',
+        conditions: [
+          {
+            type: 'simple',
+            field: 'a',
+            value: 'a',
+            op: '=',
+          },
+        ],
+      }),
+    ).toThrow();
+    expect(() =>
+      source.connect([['a', 'asc']], {
+        type: 'and',
+        conditions: [
+          {
+            type: 'and',
+            conditions: [
+              {
+                type: 'simple',
+                field: 'a',
+                value: 'a',
+                op: '=',
+              },
+            ],
+          },
+        ],
+      }),
+    ).toThrow();
+    expect(() =>
+      source.connect([['a', 'asc']], {
+        type: 'and',
+        conditions: [
+          {
+            type: 'or',
+            conditions: [
+              {
+                type: 'simple',
+                field: 'a',
+                value: 'a',
+                op: '=',
+              },
+            ],
+          },
+        ],
+      }),
+    ).toThrow();
+  },
 };
 
 /**

--- a/packages/zql/src/zql/query/query-impl.ast.test.ts
+++ b/packages/zql/src/zql/query/query-impl.ast.test.ts
@@ -36,16 +36,19 @@ describe('building the AST', () => {
     const where = issueQuery.where('id', '=', '1');
     expect(ast(where)).toEqual({
       table: 'issue',
-      where: [{type: 'simple', field: 'id', op: '=', value: '1'}],
+      where: {type: 'simple', field: 'id', op: '=', value: '1'},
     });
 
     const where2 = where.where('title', '=', 'foo');
     expect(ast(where2)).toEqual({
       table: 'issue',
-      where: [
-        {type: 'simple', field: 'id', op: '=', value: '1'},
-        {type: 'simple', field: 'title', op: '=', value: 'foo'},
-      ],
+      where: {
+        type: 'and',
+        conditions: [
+          {type: 'simple', field: 'id', op: '=', value: '1'},
+          {type: 'simple', field: 'title', op: '=', value: 'foo'},
+        ],
+      },
     });
   });
 
@@ -266,5 +269,24 @@ describe('building the AST', () => {
       ],
       table: 'issue',
     });
+  });
+});
+
+test('where expressions', () => {
+  const issueQuery = newQuery(mockDelegate, issueSchema);
+  expect(ast(issueQuery.where('id', '=', '1')).where).toEqual({
+    type: 'simple',
+    field: 'id',
+    op: '=',
+    value: '1',
+  });
+  expect(
+    ast(issueQuery.where('id', '=', '1').where('closed', true)).where,
+  ).toEqual({
+    type: 'and',
+    conditions: [
+      {type: 'simple', field: 'id', op: '=', value: '1'},
+      {type: 'simple', field: 'closed', op: '=', value: true},
+    ],
   });
 });

--- a/packages/zql/src/zql/query/query-impl.query-kitchen-sink.test.ts
+++ b/packages/zql/src/zql/query/query-impl.query-kitchen-sink.test.ts
@@ -403,20 +403,23 @@ describe('kitchen sink query', () => {
           },
         },
         table: 'issue',
-        where: [
-          {
-            field: 'ownerId',
-            op: 'IN',
-            type: 'simple',
-            value: ['001', '002', '003'],
-          },
-          {
-            field: 'closed',
-            op: '=',
-            type: 'simple',
-            value: false,
-          },
-        ],
+        where: {
+          type: 'and',
+          conditions: [
+            {
+              field: 'ownerId',
+              op: 'IN',
+              type: 'simple',
+              value: ['001', '002', '003'],
+            },
+            {
+              field: 'closed',
+              op: '=',
+              type: 'simple',
+              value: false,
+            },
+          ],
+        },
       },
     ]);
 


### PR DESCRIPTION
Much of this was resurrected from IVM-1.  Ty @darkgnotic and @arv for the prior work there.

https://github.com/rocicorp/mono/blob/99205ee78d2966d22d9da4a056b4f252dfe64251/packages/zql/src/zql/ast/ast.ts