### PR TITLE
feat(zero-cache): support re-typing indexed columns

### DIFF
--- a/packages/zero-cache/src/db/specs.ts
+++ b/packages/zero-cache/src/db/specs.ts
@@ -42,7 +42,7 @@ export const liteIndexSpec = v.object({
 
 export type MutableLiteIndexSpec = v.Infer<typeof liteIndexSpec>;
 
-export type LiteIndexSpec = DeepReadonly<MutableLiteIndexSpec>;
+export type LiteIndexSpec = Readonly<MutableLiteIndexSpec>;
 
 export const indexSpec = liteIndexSpec.extend({
   schema: v.string(),

--- a/packages/zero-cache/src/services/change-streamer/pg/change-source.end-to-mid.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/change-source.end-to-mid.test.ts
@@ -359,11 +359,7 @@ describe('change-source/pg/end-to-mid-test', () => {
       ],
     ],
     [
-      // SqliteError: error in index test.bar_username_key after drop column: no such column: \"login\"
-      // https://sqlite.org/forum/forumpost/2e62dba69f?t=c&hist
-      // TODO: In order to support re-typing columns that are indexed,
-      // we would need to drop and re-create related indexes when doing the copy-rename-column dance.
-      'DISABLED: retype unique column with associated index',
+      'retype unique column with associated index',
       'ALTER TABLE test.bar ALTER login TYPE VARCHAR(180);',
       [{tag: 'update-column'}],
       {['test.bar']: []},


### PR DESCRIPTION
Support re-typing of columns that are referenced in indexes. This involves dropping and re-adding the indexes before and after, respectively, copying the data from the old to new column.

With this edge case covered, we should be able to handle any (relevant) schema change that pg throws at us.  🤞 