### PR TITLE
fix(zbugs): handle `undefined` redirect

### DIFF
--- a/apps/zbugs/api/index.ts
+++ b/apps/zbugs/api/index.ts
@@ -15,7 +15,7 @@ declare module 'fastify' {
 }
 
 const sql = postgres(process.env.UPSTREAM_URI as string);
-type QueryParams = {redirect: string};
+type QueryParams = {redirect?: string | undefined};
 
 export const fastify = Fastify({
   logger: true,
@@ -38,8 +38,10 @@ fastify.register(oauthPlugin, {
   callbackUri: req =>
     `${req.protocol}://${req.hostname}${
       req.port != null ? ':' + req.port : ''
-    }/api/login/github/callback?redirect=${
+    }/api/login/github/callback${
       (req.query as QueryParams).redirect
+        ? `?redirect=${(req.query as QueryParams).redirect}`
+        : ''
     }`,
 });
 


### PR DESCRIPTION
The zbugs app adds a `redirect` parameter to the login request so we can return the user to the last page they were on.

Apparently this `redirect` param can come through as `undefined`.

Report from discord:
https://discord.com/channels/830183651022471199/1288232858795769917/1299175328400543755