### PR TITLE
chore(zero-cache): remove logging health endpoint

### DIFF
--- a/packages/zero-cache/src/services/dispatcher/dispatcher.ts
+++ b/packages/zero-cache/src/services/dispatcher/dispatcher.ts
@@ -37,10 +37,6 @@ export class Dispatcher implements Service {
     this.#workersByHostname = workersByHostname;
     this.#fastify = Fastify();
     this.#fastify.get('/', (_req, res) => res.send('OK'));
-    this.#fastify.get('/health', (req, res) => {
-      this.#lc?.debug?.(`health check:`, req.hostname, req.url);
-      return res.send('OK');
-    });
     this.#port = port;
 
     installWebSocketHandoff(this.#fastify.server, req => this.#handoff(req));


### PR DESCRIPTION
Experiment successful and complete. 

There is a way forward: the load balancer stops sending health checks when draining a task.