### PR TITLE
chore(zero-cache): move dispatcher drain handling into the Terminator

### DIFF
--- a/packages/zero-cache/src/server/life-cycle.test.ts
+++ b/packages/zero-cache/src/server/life-cycle.test.ts
@@ -12,11 +12,32 @@ describe('shutdown', () => {
   let proc: EventEmitter;
   let terminator: Terminator;
   let events: string[];
+  let dispatcher: TestService;
   let changeStreamer: TestWorker;
   let replicator: TestWorker;
   let syncer1: TestWorker;
   let syncer2: TestWorker;
   let all: TestWorker[];
+
+  class TestService implements SingletonService {
+    readonly id = 'test-service';
+    drained = false;
+    stopped = false;
+
+    run() {
+      return promiseVoid;
+    }
+
+    drain(): Promise<void> {
+      this.drained = true;
+      return promiseVoid;
+    }
+
+    stop() {
+      this.stopped = true;
+      return promiseVoid;
+    }
+  }
 
   class TestWorker implements SingletonService {
     readonly id: string;
@@ -70,6 +91,9 @@ describe('shutdown', () => {
       code => proc.emit('exit', code) as never,
     );
     events = [];
+    dispatcher = new TestService();
+    terminator.addFrontlineService(dispatcher);
+
     changeStreamer = startWorker('cs', 'supporting');
     replicator = startWorker('rep', 'supporting');
     syncer1 = startWorker('s1', 'user-facing');
@@ -87,6 +111,9 @@ describe('shutdown', () => {
 
       await syncer1.draining.promise;
       await syncer2.draining.promise;
+
+      expect(dispatcher.drained).toBe(true);
+      expect(dispatcher.stopped).toBe(true);
 
       syncer1.finishDrain.resolve();
       syncer2.finishDrain.resolve();
@@ -122,6 +149,10 @@ describe('shutdown', () => {
     void fn();
 
     await Promise.allSettled(all.map(w => w.stopped.promise));
+
+    // no drain(), just stop().
+    expect(dispatcher.drained).toBe(false);
+    expect(dispatcher.stopped).toBe(true);
 
     // sort() because order doesn't matter.
     expect(events.sort()).toEqual(

--- a/packages/zero-cache/src/server/life-cycle.ts
+++ b/packages/zero-cache/src/server/life-cycle.ts
@@ -28,6 +28,7 @@ export class Terminator {
   readonly #userFacing = new Set<Worker>();
   readonly #all = new Set<Worker>();
   readonly #exit: (code: number) => never;
+  readonly #frontlineServices: SingletonService[] = [];
 
   #drainStart = 0;
 
@@ -47,9 +48,11 @@ export class Terminator {
     }
 
     // ... which will result in sending `SIGTERM` to the remaining workers.
-    proc.on('exit', code =>
-      kill(this.#all, code === 0 ? GRACEFUL_SHUTDOWN[0] : FORCEFUL_SHUTDOWN[0]),
-    );
+    proc.on('exit', code => {
+      const signal = code === 0 ? GRACEFUL_SHUTDOWN[0] : FORCEFUL_SHUTDOWN[0];
+      this.#stopServices(signal);
+      kill(this.#all, signal);
+    });
 
     // For other (catchable) kill signals, exit with a non-zero error code
     // to send a `SIGQUIT` to all workers. For this signal, workers are
@@ -63,11 +66,22 @@ export class Terminator {
 
   #startDrain(signal: 'SIGTERM' | 'SIGINT' = 'SIGTERM') {
     this.#drainStart = Date.now();
+    this.#stopServices(signal);
     if (this.#userFacing.size) {
       kill(this.#userFacing, signal);
     } else {
       kill(this.#all, signal);
     }
+  }
+
+  #stopServices(signal: NodeJS.Signals) {
+    stop(this.#lc, this.#frontlineServices, signal);
+    this.#frontlineServices.splice(0);
+  }
+
+  /** Adds a "frontline" service that is killed on any signal. */
+  addFrontlineService(service: SingletonService) {
+    this.#frontlineServices.push(service);
   }
 
   addWorker(worker: Worker, type: WorkerType): Worker {
@@ -132,6 +146,23 @@ function kill(workers: Iterable<Worker>, signal: NodeJS.Signals) {
   }
 }
 
+function stop(
+  lc: LogContext,
+  services: SingletonService[],
+  signal: NodeJS.Signals,
+) {
+  const GRACEFUL_SIGNALS = GRACEFUL_SHUTDOWN as readonly NodeJS.Signals[];
+
+  services.forEach(async svc => {
+    if (GRACEFUL_SIGNALS.includes(signal) && svc.drain) {
+      lc.info?.(`draining ${svc.constructor.name} ${svc.id} (${signal})`);
+      await svc.drain();
+    }
+    lc.info?.(`stopping ${svc.constructor.name} ${svc.id} (${signal})`);
+    await svc.stop();
+  });
+}
+
 /**
  * Runs the specified services, stopping them on `SIGTERM` or `SIGINT` with
  * an optional {@link SingletonService.drain drain()}, or stopping them
@@ -146,18 +177,7 @@ export async function runUntilKilled(
   ...services: SingletonService[]
 ): Promise<void> {
   for (const signal of [...GRACEFUL_SHUTDOWN, ...FORCEFUL_SHUTDOWN]) {
-    parent.once(signal, () => {
-      const GRACEFUL_SIGNALS = GRACEFUL_SHUTDOWN as readonly NodeJS.Signals[];
-
-      services.forEach(async svc => {
-        if (GRACEFUL_SIGNALS.includes(signal) && svc.drain) {
-          lc.info?.(`draining ${svc.constructor.name} ${svc.id} (${signal})`);
-          await svc.drain();
-        }
-        lc.info?.(`stopping ${svc.constructor.name} ${svc.id} (${signal})`);
-        await svc.stop();
-      });
-    });
+    parent.once(signal, () => stop(lc, services, signal));
   }
 
   try {

--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -14,7 +14,7 @@ import {
   type ReplicaFileMode,
   subscribeTo,
 } from '../workers/replicator.js';
-import {GRACEFUL_SHUTDOWN, Terminator, type WorkerType} from './life-cycle.js';
+import {Terminator, type WorkerType} from './life-cycle.js';
 import {createLogContext} from './logging.js';
 
 const startMs = Date.now();
@@ -111,16 +111,11 @@ if (numSyncers) {
   const workers: Workers = {syncers};
 
   const dispatcher = new Dispatcher(lc, () => workers);
+  terminator.addFrontlineService(dispatcher);
+
   try {
     await dispatcher.run();
   } catch (err) {
     terminator.logErrorAndExit(err);
-  }
-
-  for (const signal of GRACEFUL_SHUTDOWN) {
-    process.on(signal, () => {
-      lc.info?.('drain mode: no longer accepting connections');
-      return dispatcher.stop();
-    });
   }
 }

--- a/packages/zero-cache/src/services/dispatcher/dispatcher.ts
+++ b/packages/zero-cache/src/services/dispatcher/dispatcher.ts
@@ -3,7 +3,7 @@ import Fastify, {type FastifyInstance} from 'fastify';
 import {IncomingMessage} from 'http';
 import {h32} from '../../../../shared/src/xxhash.js';
 import type {Worker} from '../../types/processes.js';
-import type {Service} from '../service.js';
+import type {SingletonService} from '../service.js';
 import {getConnectParams} from './connect-params.js';
 import {installWebSocketHandoff} from './websocket-handoff.js';
 
@@ -19,7 +19,7 @@ export type Options = {
   port: number;
 };
 
-export class Dispatcher implements Service {
+export class Dispatcher implements SingletonService {
   readonly id = 'dispatcher';
   readonly #lc: LogContext;
   readonly #workersByHostname: (hostname: string) => Workers;
@@ -72,6 +72,7 @@ export class Dispatcher implements Service {
   }
 
   async stop(): Promise<void> {
+    this.#lc.info?.('drain: no longer accepting connections');
     await this.#fastify.close();
   }
 }


### PR DESCRIPTION
Introduce the concept of same-process "frontline Services" that the Terminator stops in addition to the user-facing and supporting Workers.

This consolidates drain logic to facilitate upcoming drain detection based on health checks.