### PR TITLE
fix(zero-cache): escape all the identifiers

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/initial-sync.ts
@@ -1,5 +1,4 @@
 import type {LogContext} from '@rocicorp/logger';
-import {ident} from 'pg-format';
 import postgres from 'postgres';
 import {Database} from '../../../../../zqlite/src/db.js';
 import {
@@ -19,6 +18,7 @@ import {
 import {liteValues} from '../../../types/lite.js';
 import {liteTableName} from '../../../types/names.js';
 import {pgClient, type PostgresDB} from '../../../types/pg.js';
+import {id} from '../../../types/sql.js';
 import {initChangeLog} from '../../replicator/schema/change-log.js';
 import {
   initReplicationState,
@@ -217,13 +217,13 @@ async function copy(
   let totalRows = 0;
   const tableName = liteTableName(table);
   const selectColumns = Object.keys(table.columns)
-    .map(c => ident(c))
+    .map(c => id(c))
     .join(',');
   const insertColumns = [
     ...Object.keys(table.columns),
     ZERO_VERSION_COLUMN_NAME,
   ];
-  const insertColumnList = insertColumns.map(c => ident(c)).join(',');
+  const insertColumnList = insertColumns.map(c => id(c)).join(',');
   const insertStmt = to.prepare(
     `INSERT INTO "${tableName}" (${insertColumnList}) VALUES (${new Array(
       insertColumns.length,
@@ -235,7 +235,7 @@ async function copy(
     .map(({rowFilter}) => rowFilter)
     .filter(f => !!f); // remove nulls
   const selectStmt =
-    `SELECT ${selectColumns} FROM ${ident(table.schema)}.${ident(table.name)}` +
+    `SELECT ${selectColumns} FROM ${id(table.schema)}.${id(table.name)}` +
     (filterConditions.length === 0
       ? ''
       : ` WHERE ${filterConditions.join(' OR ')}`);

--- a/packages/zero-cache/src/services/change-streamer/pg/schema/ddl.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/schema/ddl.ts
@@ -1,6 +1,7 @@
-import {ident as id, literal as lit} from 'pg-format';
+import {literal as lit} from 'pg-format';
 import * as v from '../../../../../../shared/src/valita.js';
 import {filteredTableSpec, indexSpec} from '../../../../db/specs.js';
+import {id} from '../../../../types/sql.js';
 import {indexDefinitionsQuery, publishedTableQuery} from './published.js';
 
 // Sent in the 'version' tag of "ddlStart" and "ddlUpdate" event messages.

--- a/packages/zero-cache/src/services/change-streamer/pg/schema/shard.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/schema/shard.ts
@@ -1,8 +1,9 @@
 import type {LogContext} from '@rocicorp/logger';
-import {ident, literal} from 'pg-format';
+import {literal} from 'pg-format';
 import {assert} from '../../../../../../shared/src/asserts.js';
 import {warnIfDataTypeSupported} from '../../../../db/pg-to-lite.js';
 import type {PostgresDB, PostgresTransaction} from '../../../../types/pg.js';
+import {id} from '../../../../types/sql.js';
 import {ZERO_VERSION_COLUMN_NAME} from '../../../replicator/schema/replication-state.js';
 import type {ShardConfig} from '../shard-config.js';
 import {createEventTriggerStatements} from './ddl.js';
@@ -10,7 +11,7 @@ import {getPublicationInfo, type PublicationInfo} from './published.js';
 
 // Creates a function that appends `_SHARD_ID` to the input.
 export function append(shardID: string) {
-  return (name: string) => ident(name + '_' + shardID);
+  return (name: string) => id(name + '_' + shardID);
 }
 
 export function schemaFor(shardID: string) {
@@ -67,7 +68,7 @@ function shardSetup(shardID: string, publications: string[]): string {
     PRIMARY KEY("clientGroupID", "clientID")
   );
 
-  CREATE PUBLICATION ${ident(metadataPublication)}
+  CREATE PUBLICATION ${id(metadataPublication)}
     FOR TABLE zero."schemaVersions", TABLE ${schema}."clients";
 
   CREATE TABLE ${schema}."shardConfig" (

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -1,6 +1,5 @@
 import type {LogContext} from '@rocicorp/logger';
 import {SqliteError} from 'better-sqlite3-bedrock';
-import {ident as id} from 'pg-format';
 import {LogicalReplicationService} from 'pg-logical-replication';
 import {AbortError} from '../../../../shared/src/abort-error.js';
 import {assert, unreachable} from '../../../../shared/src/asserts.js';
@@ -21,6 +20,7 @@ import {stringify} from '../../types/bigint-json.js';
 import type {LexiVersion} from '../../types/lexi-version.js';
 import {liteRow} from '../../types/lite.js';
 import {liteTableName} from '../../types/names.js';
+import {id} from '../../types/sql.js';
 import type {Source} from '../../types/streams.js';
 import type {
   ChangeStreamer,

--- a/packages/zero-cache/src/test/lite.ts
+++ b/packages/zero-cache/src/test/lite.ts
@@ -1,10 +1,10 @@
 import {LogContext} from '@rocicorp/logger';
 import {unlink} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
-import {ident} from 'pg-format';
 import {expect} from 'vitest';
 import {randInt} from '../../../shared/src/rand.js';
 import {Database} from '../../../zqlite/src/db.js';
+import {id} from '../types/sql.js';
 
 export class DbFile {
   readonly path;
@@ -33,10 +33,10 @@ export function initDB(
     }
     for (const [name, rows] of Object.entries(tables ?? {})) {
       const columns = Object.keys(rows[0]);
-      const cols = columns.map(c => ident(c)).join(',');
+      const cols = columns.map(c => id(c)).join(',');
       const vals = new Array(columns.length).fill('?').join(',');
       const insertStmt = db.prepare(
-        `INSERT INTO ${ident(name)} (${cols}) VALUES (${vals})`,
+        `INSERT INTO ${id(name)} (${cols}) VALUES (${vals})`,
       );
       for (const row of rows) {
         insertStmt.run(Object.values(row));
@@ -52,7 +52,7 @@ export function expectTables(
 ) {
   for (const [table, expected] of Object.entries(tables ?? {})) {
     const actual = db
-      .prepare(`SELECT * FROM ${ident(table)}`)
+      .prepare(`SELECT * FROM ${id(table)}`)
       .safeIntegers(numberType === 'bigint')
       .all();
     expect(actual).toEqual(expect.arrayContaining(expected));
@@ -67,7 +67,7 @@ export function expectMatchingObjectsInTables(
 ) {
   for (const [table, expected] of Object.entries(tables ?? {})) {
     const actual = db
-      .prepare(`SELECT * FROM ${ident(table)}`)
+      .prepare(`SELECT * FROM ${id(table)}`)
       .safeIntegers(numberType === 'bigint')
       .all();
     expect(actual).toMatchObject(expected);


### PR DESCRIPTION
Escape all identifiers in manually constructed sql commands (and not just pg reserved words).