### PR TITLE
fix(zero-cache): avoid masking the log message when there is an Error

### DIFF
--- a/packages/zero-cache/src/server/logging.ts
+++ b/packages/zero-cache/src/server/logging.ts
@@ -56,8 +56,8 @@ const consoleJsonLogSink: LogSink = {
       stringify({
         level: level.toUpperCase(),
         ...context,
-        ...message,
         ...lastObj,
+        ...message,
       }),
     );
   },
@@ -68,7 +68,7 @@ function errorOrObject(v: unknown): object | undefined {
     return {
       ...v, // some properties of Error subclasses may be enumerable
       name: v.name,
-      message: v.message,
+      errorMsg: v.message,
       stack: v.stack,
       ...('cause' in v ? {cause: errorOrObject(v.cause)} : null),
     };


### PR DESCRIPTION
The original logged `message` usually has important information. Don't mask it with the `Error.message`.