### PR TITLE
fix(zero-cache): do not treat worker errors as exit

### DIFF
--- a/packages/zero-cache/src/server/life-cycle.test.ts
+++ b/packages/zero-cache/src/server/life-cycle.test.ts
@@ -57,7 +57,7 @@ describe('shutdown', () => {
 
     void runUntilKilled(lc, childPort, worker).then(
       () => parentPort.emit('close', 0),
-      err => parentPort.emit('error', err),
+      () => parentPort.emit('close', -1),
     );
     return worker;
   }

--- a/packages/zero-cache/src/server/life-cycle.ts
+++ b/packages/zero-cache/src/server/life-cycle.ts
@@ -87,7 +87,10 @@ export class Terminator {
     }
     this.#all.add(worker);
 
-    worker.on('error', err => this.#onExit(-2, null, err, type, worker));
+    worker.on(
+      'error',
+      err => this.#lc.warn?.(`error from worker ${worker.pid}`, err),
+    );
     worker.on('close', (code, signal) =>
       this.#onExit(code, signal, null, type, worker),
     );
@@ -112,7 +115,7 @@ export class Terminator {
       this.#all.delete(worker);
     }
 
-    const pid = worker?.pid ?? 0;
+    const pid = worker?.pid ?? process.pid;
 
     if (type === 'supporting') {
       // The replication-manager has no user-facing workers.


### PR DESCRIPTION
The `error` event does not necessarily indicate an exit, so do not treat it as such. Log a warning instead.