### PR TITLE
chore(zql): include help in the primary key error message

### DIFF
--- a/packages/zql/src/zql/builder/builder.ts
+++ b/packages/zql/src/zql/builder/builder.ts
@@ -256,7 +256,11 @@ export function assertOrderingIncludesPK(
     throw new Error(
       `Ordering must include all primary key fields. Missing: ${missingFields.join(
         ', ',
-      )}`,
+      )}. ZQL automatically appends primary key fields to the ordering if they are missing 
+      so a common cause of this error is a casing mismatch between Postgres and ZQL.
+      E.g., "userid" vs "userID".
+      You may want to add double-quotes around your Postgres column names to prevent Postgres from lower-casing them:
+      https://www.postgresql.org/docs/current/sql-syntax-lexical.htm`,
     );
   }
 }


### PR DESCRIPTION
Putting remediation options in an exception message was common practice for tooling at Meta. LMK what you think.

This is to address the error the tldraw folks ran into here: https://discord.com/channels/830183651022471199/1300833980706455744/1301242167465087036