### PR TITLE
feat(zql): expose json columns through ZQL API

### DIFF
--- a/packages/zero-client/src/client/zero.json.test.ts
+++ b/packages/zero-client/src/client/zero.json.test.ts
@@ -1,0 +1,40 @@
+import {expect, test} from 'vitest';
+import {zeroForTest} from './test-utils.js';
+
+test('we can create rows with json columns and query those rows', async () => {
+  const z = zeroForTest({
+    schema: {
+      version: 1,
+      tables: {
+        track: {
+          columns: {
+            id: {type: 'string'},
+            title: {type: 'string'},
+            artists: {type: 'json'},
+          },
+          primaryKey: ['id'],
+          tableName: 'track',
+          relationships: {},
+        },
+      },
+    },
+  });
+
+  await z.mutate.track.create({
+    id: 'track-1',
+    title: 'track 1',
+    artists: ['artist 1', 'artist 2'],
+  });
+  await z.mutate.track.create({
+    id: 'track-2',
+    title: 'track 2',
+    artists: ['artist 2', 'artist 3'],
+  });
+
+  const tracks = z.query.track.run();
+
+  expect(tracks).toEqual([
+    {id: 'track-1', title: 'track 1', artists: ['artist 1', 'artist 2']},
+    {id: 'track-2', title: 'track 2', artists: ['artist 2', 'artist 3']},
+  ]);
+});

--- a/packages/zql/src/zql/ivm/schema.ts
+++ b/packages/zql/src/zql/ivm/schema.ts
@@ -13,7 +13,7 @@ export type SchemaValue = {
   optional?: boolean;
 };
 
-export type TableSchemaBase = {
+export type SourceOrTableSchema = {
   readonly tableName: string;
   readonly primaryKey: PrimaryKey;
   readonly columns: Record<string, SchemaValue>;
@@ -21,7 +21,7 @@ export type TableSchemaBase = {
 /**
  * Information about the nodes output by an operator.
  */
-export type TableSchema = TableSchemaBase & {
+export type TableSchema = SourceOrTableSchema & {
   readonly relationships: {[key: string]: TableSchema};
   readonly isHidden: boolean;
   readonly compareRows: (r1: Row, r2: Row) => number;

--- a/packages/zql/src/zql/query/expression.ts
+++ b/packages/zql/src/zql/query/expression.ts
@@ -5,6 +5,7 @@ import type {
 } from '../../../../zero-protocol/src/ast.js';
 import type {
   GetFieldTypeNoNullOrUndefined,
+  NoJsonSelector,
   Operator,
   Parameter,
   Selector,
@@ -33,7 +34,7 @@ type GenericDisjunction<TSchema extends TableSchema> = {
 
 export function cmp<
   TSchema extends TableSchema,
-  TSelector extends Selector<TSchema>,
+  TSelector extends NoJsonSelector<TSchema>,
   TOperator extends Operator,
   TParamAnchor = never,
   TParamField extends keyof TParamAnchor = never,
@@ -51,7 +52,7 @@ export function cmp<
 ): GenericCondition<TSchema>;
 export function cmp<
   TSchema extends TableSchema,
-  TSelector extends Selector<TSchema>,
+  TSelector extends NoJsonSelector<TSchema>,
   TParamAnchor = never,
   TParamField extends keyof TParamAnchor = never,
   TParamTypeBound extends GetFieldTypeNoNullOrUndefined<
@@ -87,7 +88,7 @@ export function cmp(
     type: 'simple',
     field,
     op,
-    value,
+    value: value as ValuePosition,
   };
 }
 

--- a/packages/zql/src/zql/query/query-impl.query.test.ts
+++ b/packages/zql/src/zql/query/query-impl.query.test.ts
@@ -2,7 +2,7 @@ import {describe, expect, test} from 'vitest';
 import {deepClone} from '../../../../shared/src/deep-clone.js';
 import {must} from '../../../../shared/src/must.js';
 import {newQuery, type QueryDelegate, QueryImpl} from './query-impl.js';
-import {issueSchema} from './test/testSchemas.js';
+import {issueSchema, userSchema} from './test/testSchemas.js';
 import type {AdvancedQuery} from './query-internal.js';
 import type {DefaultQueryResultRow} from './query.js';
 import {QueryDelegateImpl} from './test/query-delegate.js';
@@ -34,6 +34,10 @@ function addData(queryDelegate: QueryDelegate) {
     row: {
       id: '0001',
       name: 'Alice',
+      metadata: {
+        registrar: 'github',
+        login: 'alicegh',
+      },
     },
   });
   userSource.push({
@@ -41,6 +45,11 @@ function addData(queryDelegate: QueryDelegate) {
     row: {
       id: '0002',
       name: 'Bob',
+      metadata: {
+        registar: 'google',
+        login: 'bob@gmail.com',
+        altContacts: ['bobwave', 'bobyt', 'bobplus'],
+      },
     },
   });
   issueSource.push({
@@ -446,6 +455,10 @@ describe('joins and filters', () => {
           {
             id: '0001',
             name: 'Alice',
+            metadata: {
+              login: 'alicegh',
+              registrar: 'github',
+            },
           },
         ],
         ownerId: '0001',
@@ -461,6 +474,11 @@ describe('joins and filters', () => {
           {
             id: '0002',
             name: 'Bob',
+            metadata: {
+              altContacts: ['bobwave', 'bobyt', 'bobplus'],
+              login: 'bob@gmail.com',
+              registar: 'google',
+            },
           },
         ],
         ownerId: '0002',
@@ -622,6 +640,10 @@ test('run', () => {
         {
           id: '0001',
           name: 'Alice',
+          metadata: {
+            login: 'alicegh',
+            registrar: 'github',
+          },
         },
       ],
       ownerId: '0001',
@@ -637,6 +659,11 @@ test('run', () => {
         {
           id: '0002',
           name: 'Bob',
+          metadata: {
+            altContacts: ['bobwave', 'bobyt', 'bobplus'],
+            login: 'bob@gmail.com',
+            registar: 'google',
+          },
         },
       ],
       ownerId: '0002',
@@ -672,4 +699,30 @@ test('view creation is wrapped in context.batchViewUpdates call', () => {
   ).materialize(viewFactory);
   expect(viewFactoryCalls).toEqual(1);
   expect(view).toBe(testView);
+});
+
+test('json columns are returned as JS objects', () => {
+  const queryDelegate = new QueryDelegateImpl();
+  addData(queryDelegate);
+
+  const rows = newQuery(queryDelegate, userSchema).run();
+  expect(rows).toEqual([
+    {
+      id: '0001',
+      metadata: {
+        login: 'alicegh',
+        registrar: 'github',
+      },
+      name: 'Alice',
+    },
+    {
+      id: '0002',
+      metadata: {
+        altContacts: ['bobwave', 'bobyt', 'bobplus'],
+        login: 'bob@gmail.com',
+        registar: 'google',
+      },
+      name: 'Bob',
+    },
+  ]);
 });

--- a/packages/zql/src/zql/query/schema.ts
+++ b/packages/zql/src/zql/query/schema.ts
@@ -1,6 +1,6 @@
-import type {TableSchemaBase} from '../ivm/schema.js';
+import type {SourceOrTableSchema} from '../ivm/schema.js';
 
-export type TableSchema = TableSchemaBase & {
+export type TableSchema = SourceOrTableSchema & {
   readonly relationships: {readonly [name: string]: Relationship};
 };
 

--- a/packages/zql/src/zql/query/test/testSchemas.ts
+++ b/packages/zql/src/zql/query/test/testSchemas.ts
@@ -138,6 +138,7 @@ export const userSchema = {
   columns: {
     id: {type: 'string'},
     name: {type: 'string'},
+    metadata: {type: 'json', optional: true},
   },
   primaryKey: ['id'],
   relationships: {


### PR DESCRIPTION
This returns the JSON column as `any`. To allow the user to type their json columns (by specifying the shape of the data) will require quite a bit more work.

Allowing users to type their JSON columns (in schema-v2) would look something like:
```ts
schema('issue')
  .columns(
    json<{
     field1: string;
     field2: boolean;
     field3: number[];
    }>('metadata').optional()
  )
```
---

I tried using `ReadonlyJSONValue` (instead of any) but `infinite depth errors` started showing up in code that added a listener to `ArrayView`. `any` / `ReadonlyJSONValue` will also  go away from this API once we allow users to define the shape of their JSON data in the schema.