### PR TITLE
fix(zbugs): fix nav active state on issue page

### DIFF
--- a/apps/zbugs/src/pages/list/list-page.tsx
+++ b/apps/zbugs/src/pages/list/list-page.tsx
@@ -32,7 +32,7 @@ export default function ListPage() {
   const login = useLogin();
   const qs = new URLSearchParams(useSearch());
 
-  const status = qs.get('status')?.toLowerCase();
+  const status = qs.get('status')?.toLowerCase() ?? 'open';
   const creator = qs.get('creator');
   const assignee = qs.get('assignee');
   const labels = qs.getAll('label');


### PR DESCRIPTION
Previously open was always highlighted as active when on issue-page, even if the context was closed or all.