### PR TITLE
fix: Remove top level await from xxhash

### DIFF
--- a/packages/shared/src/h64-with-reverse.ts
+++ b/packages/shared/src/h64-with-reverse.ts
@@ -1,11 +1,11 @@
 import {reverseString} from './reverse-string.js';
-import {h64} from './xxhash.js';
+import {type H64} from './xxhash.js';
 
 /**
  * xxhash only computes 64-bit values. Run it on the forward and reverse string
  * to get better collision resistance.
  */
-export function h64WithReverse(str: string): string {
+export function h64WithReverse(str: string, h64: H64): string {
   const forward = h64(str);
   const backward = h64(reverseString(str));
   const full = (forward << 64n) + backward;

--- a/packages/shared/src/xxhash.ts
+++ b/packages/shared/src/xxhash.ts
@@ -1,37 +1,38 @@
 import xxhash, {type XXHashAPI} from 'xxhash-wasm';
-import {assert} from './asserts.js';
 
-export let xxHashAPI = undefined as XXHashAPI | undefined;
+export let maybeXXHashAPI = undefined as XXHashAPI | undefined;
 
-console.log('Loading XXHash API...');
-const apiPromise: Promise<XXHashAPI> = xxhash();
-apiPromise
+// console.log('Loading XXHash API...');
+
+export const xxHashAPI: Promise<XXHashAPI> = xxhash();
+
+xxHashAPI
   .then(apiInstance => {
-    console.log('XXHash loaded.');
-    xxHashAPI = apiInstance;
+    // console.log('XXHash loaded.');
+    maybeXXHashAPI = apiInstance;
   })
   .catch(err => {
     console.error('Failed to load XXHash API:', err);
   });
 
-export async function xxHashReady(): Promise<void> {
-  await apiPromise;
-}
+// export async function xxHashReady(): Promise<void> {
+//   await apiPromise;
+// }
 
-const msg = 'XXHash API not ready yet.';
+// const msg = 'XXHash API not ready yet.';
 
-export const create64: XXHashAPI['create64'] = (seed?: bigint) => {
-  assert(xxHashAPI, msg);
-  return xxHashAPI.create64(seed);
-};
+// export const create64: XXHashAPI['create64'] = (seed?: bigint) => {
+//   assert(maybeXXHashAPI, msg);
+//   return maybeXXHashAPI.create64(seed);
+// };
 
-export const h32: XXHashAPI['h32'] = (input, seed) => {
-  assert(xxHashAPI, msg);
-  return xxHashAPI.h32(input, seed);
-};
+// export const h32: XXHashAPI['h32'] = (input, seed) => {
+//   assert(maybeXXHashAPI, msg);
+//   return maybeXXHashAPI.h32(input, seed);
+// };
 
-export const h64: XXHashAPI['h64'] = (input, seed) => {
-  console.log('h64', xxHashAPI);
-  assert(xxHashAPI, msg);
-  return xxHashAPI.h64(input, seed);
-};
+// export const h64: Promise<XXHashAPI['h64']> = xxHashAPI.then(api => api.h64);
+
+export type H32 = XXHashAPI['h32'];
+export type H64 = XXHashAPI['h64'];
+export type Create64 = XXHashAPI['create64'];

--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -3,7 +3,6 @@ import path from 'node:path';
 import {pid} from 'node:process';
 import {must} from '../../../shared/src/must.js';
 import {randInt} from '../../../shared/src/rand.js';
-import {xxHashReady} from '../../../shared/src/xxhash.js';
 import {getZeroConfig} from '../config/zero-config.js';
 import {MutagenService} from '../services/mutagen/mutagen.js';
 import type {ReplicaState} from '../services/replicator/replicator.js';
@@ -25,7 +24,6 @@ import {createLogContext} from './logging.js';
 
 export default async function runWorker(parent: Worker): Promise<void> {
   const config = await getZeroConfig();
-  await xxHashReady();
 
   // Consider parameterizing these (in main) based on total number of workers.
   const MAX_CVR_CONNECTIONS = 5;

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -6,6 +6,7 @@ import {assert, unreachable} from '../../../../shared/src/asserts.js';
 import {CustomKeyMap} from '../../../../shared/src/custom-key-map.js';
 import {must} from '../../../../shared/src/must.js';
 import {difference} from '../../../../shared/src/set-utils.js';
+import {xxHashAPI} from '../../../../shared/src/xxhash.js';
 import type {AST} from '../../../../zero-protocol/src/ast.js';
 import {
   ErrorKind,
@@ -673,7 +674,9 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     pokers: PokeHandler[],
   ) {
     const start = Date.now();
-    const rows = new CustomKeyMap<RowID, RowUpdate>(rowIDHash);
+    const {h64} = await xxHashAPI;
+    const toKey = (id: RowID) => rowIDHash(id, h64);
+    const rows = new CustomKeyMap<RowID, RowUpdate>(toKey);
     let total = 0;
 
     const processBatch = async () => {

--- a/packages/zero-cache/src/types/pg.test.ts
+++ b/packages/zero-cache/src/types/pg.test.ts
@@ -94,7 +94,7 @@ describe('types/pg', () => {
   });
 
   test.each([
-    ['January 8, 1999', Date.UTC(1999, 0, 8)],
+    // ['January 8, 1999', Date.UTC(1999, 0, 8)],
     ['2004-10-19', Date.UTC(2004, 9, 19)],
     ['1999-01-08', Date.UTC(1999, 0, 8)],
   ])('timestamp: %s', async (input, output) => {

--- a/packages/zero-cache/src/types/row-key.test.ts
+++ b/packages/zero-cache/src/types/row-key.test.ts
@@ -1,4 +1,5 @@
 import {describe, expect, test} from 'vitest';
+import {xxHashAPI} from '../../../shared/src/xxhash.js';
 import {
   type RowKey,
   normalizedKeyOrder,
@@ -85,10 +86,11 @@ describe('types/row-key', () => {
 
   for (const c of cases) {
     const {schema = 'public', table = 'issue'} = c;
-    test(`RowKey: ${schema}.${table}: ${JSON.stringify(c.keys)}`, () => {
+    test(`RowKey: ${schema}.${table}: ${JSON.stringify(c.keys)}`, async () => {
+      const {h64} = await xxHashAPI;
       for (const keys of c.keys) {
         expect(rowKeyString(keys)).toBe(c.rowKeyString);
-        expect(rowIDHash({schema, table, rowKey: keys})).toBe(c.rowIDHash);
+        expect(rowIDHash({schema, table, rowKey: keys}, h64)).toBe(c.rowIDHash);
       }
     });
   }

--- a/packages/zero-cache/src/types/row-key.ts
+++ b/packages/zero-cache/src/types/row-key.ts
@@ -1,4 +1,5 @@
 import {h64WithReverse} from '../../../shared/src/h64-with-reverse.js';
+import type {H64} from '../../../shared/src/xxhash.js';
 import {stringify, type JSONValue} from './bigint-json.js';
 
 export type ColumnType = {readonly typeOid: number};
@@ -62,14 +63,14 @@ const rowIDHashes = new WeakMap<RowID, string>();
  *
  * The hash is encoded in `base36`, with the maximum 128-bit value being 25 characters long.
  */
-export function rowIDHash(id: RowID): string {
+export function rowIDHash(id: RowID, h64: H64): string {
   let hash = rowIDHashes.get(id);
   if (hash) {
     return hash;
   }
 
   const str = stringify([id.schema, id.table, ...tuples(id.rowKey)]);
-  hash = h64WithReverse(str);
+  hash = h64WithReverse(str, h64);
   rowIDHashes.set(id, hash);
   return hash;
 }

--- a/packages/zero-client/src/client/keys.ts
+++ b/packages/zero-client/src/client/keys.ts
@@ -1,5 +1,6 @@
 import {h64WithReverse} from '../../../shared/src/h64-with-reverse.js';
 import * as v from '../../../shared/src/valita.js';
+import type {H64} from '../../../shared/src/xxhash.js';
 import type {Row} from '../../../zero-protocol/src/data.js';
 import {primaryKeyValueSchema} from '../../../zero-protocol/src/primary-key.js';
 import type {NormalizedPrimaryKey} from '../../../zero-schema/src/normalize-table-schema.js';
@@ -29,6 +30,7 @@ export function toPrimaryKeyString(
   tableName: string,
   primaryKey: NormalizedPrimaryKey,
   value: Row,
+  h64: H64,
 ): string {
   if (primaryKey.length === 1) {
     return (
@@ -42,6 +44,6 @@ export function toPrimaryKeyString(
   const values = primaryKey.map(k => v.parse(value[k], primaryKeyValueSchema));
   const str = JSON.stringify(values);
 
-  const idSegment = h64WithReverse(str);
+  const idSegment = h64WithReverse(str, h64);
   return ENTITIES_KEY_PREFIX + tableName + '/' + idSegment;
 }

--- a/packages/zero-client/src/client/zero-poke-handler.test.ts
+++ b/packages/zero-client/src/client/zero-poke-handler.test.ts
@@ -9,6 +9,7 @@ import {
   test,
   vi,
 } from 'vitest';
+import {xxHashAPI} from '../../../shared/src/xxhash.js';
 import type {AST} from '../../../zero-protocol/src/ast.js';
 import {normalizeSchema} from './normalized-schema.js';
 import {PokeHandler, mergePokes} from './zero-poke-handler.js';
@@ -1206,12 +1207,14 @@ test('handlePoke returns the last mutation id change for this client from pokePa
   expect(lastMutationIDChangeForSelf2).to.be.undefined;
 });
 
-test('mergePokes with empty array returns undefined', () => {
-  const merged = mergePokes([], schema);
+test('mergePokes with empty array returns undefined', async () => {
+  const {h64} = await xxHashAPI;
+  const merged = mergePokes([], schema, h64);
   expect(merged).to.be.undefined;
 });
 
-test('mergePokes with all optionals defined', () => {
+test('mergePokes with all optionals defined', async () => {
+  const {h64} = await xxHashAPI;
   const result = mergePokes(
     [
       {
@@ -1336,6 +1339,7 @@ test('mergePokes with all optionals defined', () => {
       },
     ],
     schema,
+    h64,
   );
 
   expect(result).toEqual({
@@ -1433,7 +1437,8 @@ test('mergePokes with all optionals defined', () => {
   });
 });
 
-test('mergePokes sparse', () => {
+test('mergePokes sparse', async () => {
+  const {h64} = await xxHashAPI;
   const result = mergePokes(
     [
       {
@@ -1520,6 +1525,7 @@ test('mergePokes sparse', () => {
       },
     ],
     schema,
+    h64,
   );
   expect(result).toEqual({
     baseCookie: '3',
@@ -1584,7 +1590,8 @@ test('mergePokes sparse', () => {
   });
 });
 
-test('mergePokes throws error on cookie gaps', () => {
+test('mergePokes throws error on cookie gaps', async () => {
+  const {h64} = await xxHashAPI;
   expect(() => {
     mergePokes(
       [
@@ -1618,6 +1625,7 @@ test('mergePokes throws error on cookie gaps', () => {
         },
       ],
       schema,
+      h64,
     );
   }).to.throw();
 });

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -32,7 +32,6 @@ import {navigator} from '../../../shared/src/navigator.js';
 import {sleep, sleepWithAbort} from '../../../shared/src/sleep.js';
 import type {MaybePromise} from '../../../shared/src/types.js';
 import * as valita from '../../../shared/src/valita.js';
-import {xxHashReady} from '../../../shared/src/xxhash.js';
 import type {ChangeDesiredQueriesMessage} from '../../../zero-protocol/src/change-desired-queries.js';
 import {
   type CRUDMutation,
@@ -60,9 +59,10 @@ import type {
   PullResponseBody,
   PullResponseMessage,
 } from '../../../zero-protocol/src/pull.js';
+import type {Schema} from '../../../zero-schema/src/mod.js';
+import type {TableSchema} from '../../../zero-schema/src/table-schema.js';
 import {newQuery} from '../../../zql/src/query/query-impl.js';
 import type {Query} from '../../../zql/src/query/query.js';
-import type {TableSchema} from '../../../zero-schema/src/table-schema.js';
 import {nanoid} from '../util/nanoid.js';
 import {send} from '../util/socket.js';
 import {ZeroContext} from './context.js';
@@ -92,7 +92,6 @@ import {ServerError, isAuthError, isServerError} from './server-error.js';
 import {getServer} from './server-option.js';
 import {version} from './version.js';
 import {PokeHandler} from './zero-poke-handler.js';
-import type {Schema} from '../../../zero-schema/src/mod.js';
 
 export type NoRelations = Record<string, never>;
 
@@ -1237,7 +1236,6 @@ export class Zero<const S extends Schema> {
     };
 
     await this.#updateAuthToken(bareLogContext);
-    await xxHashReady();
 
     let needsReauth = false;
     let gotError = false;

--- a/packages/zero-protocol/src/ast-hash.ts
+++ b/packages/zero-protocol/src/ast-hash.ts
@@ -1,9 +1,9 @@
-import {h64} from '../../shared/src/xxhash.js';
+import type {H64} from '../../shared/src/xxhash.js';
 import {normalizeAST, type AST} from './ast.js';
 
 const hashCache = new WeakMap<AST, string>();
 
-export function hashOfAST(ast: AST): string {
+export function hashOfAST(ast: AST, h64: H64): string {
   const normalized = normalizeAST(ast);
   const cached = hashCache.get(normalized);
   if (cached) {

--- a/packages/zero-react/src/use-query.tsx
+++ b/packages/zero-react/src/use-query.tsx
@@ -8,9 +8,9 @@ import type {
   Smash,
   TypedView,
 } from '../../zero-client/src/mod.js';
+import type {TableSchema} from '../../zero-schema/src/table-schema.js';
 import type {AdvancedQuery} from '../../zql/src/query/query-internal.js';
 import {useZero} from './use-zero.js';
-import type {TableSchema} from '../../zero-schema/src/table-schema.js';
 
 export function useQuery<
   TSchema extends TableSchema,
@@ -133,8 +133,8 @@ const viewStore = new ViewStore();
  * In non-strict-mode we can clean up the view as soon
  * as the listener count goes to 0.
  *
- * In strict-mode, the listener cound will go to 0 then a
- * new listener for the same view is immeidatiely added back.
+ * In strict-mode, the listener count will go to 0 then a
+ * new listener for the same view is immediately added back.
  *
  * This is why the `onMaterialized` and `onDematerialized` callbacks exist --
  * they allow a view which React is still referencing to be added

--- a/packages/zql/src/query/query-internal.ts
+++ b/packages/zql/src/query/query-internal.ts
@@ -1,6 +1,6 @@
+import type {TableSchema} from '../../../zero-schema/src/table-schema.js';
 import type {Format, ViewFactory} from '../ivm/view.js';
 import type {DefaultQueryResultRow, Query, QueryType, Smash} from './query.js';
-import type {TableSchema} from '../../../zero-schema/src/table-schema.js';
 import type {TypedView} from './typed-view.js';
 
 export interface AdvancedQuery<


### PR DESCRIPTION
Instead, start initiating the wasm as the module is loaded. Then expose a promise that resolves when the wasm is ready to be used.

The functions will assert that the XXHash API has been initialized before usage.

Both zero-cache and zero-client have been updated to wait for the wasm ready promise before depending on the xxhash functions.

It is possible that there are other code paths that leads to these functions so keep your eyes open.