### PR TITLE
chore(zero-cache): log worker errors at level ERROR again

### DIFF
--- a/packages/zero-cache/src/server/life-cycle.ts
+++ b/packages/zero-cache/src/server/life-cycle.ts
@@ -89,7 +89,7 @@ export class Terminator {
 
     worker.on(
       'error',
-      err => this.#lc.warn?.(`error from worker ${worker.pid}`, err),
+      err => this.#lc.error?.(`error from worker ${worker.pid}`, err),
     );
     worker.on('close', (code, signal) =>
       this.#onExit(code, signal, null, type, worker),


### PR DESCRIPTION
Now that the ERR_IPC_CHANNEL_CLOSED error has been fixed, return the logging level for worker errors to ERROR. They still do not (and should not) be treated as an exiting worker; that is covered be the "close" event.