### PR TITLE
wip: Add start to subqueries

### DIFF
--- a/packages/zql/src/ivm/memory-source.ts
+++ b/packages/zql/src/ivm/memory-source.ts
@@ -282,10 +282,9 @@ export class MemorySource implements Source {
     let startAt = req.start?.row;
     if (startAt) {
       if (req.constraint) {
-        // There's no problem supporting startAt outside of constraints, but I
-        // don't think we have a use case for this – if we see it, it's probably
-        // a bug.
-        if (!matchesConstraint(startAt)) {
+        if (startAt[req.constraint.key] === undefined) {
+          startAt = {...startAt, [req.constraint.key]: req.constraint.value};
+        } else if (!matchesConstraint(startAt)) {
           assert(false, 'Start row must match constraint');
         }
       }

--- a/packages/zql/src/ivm/take.ts
+++ b/packages/zql/src/ivm/take.ts
@@ -152,6 +152,9 @@ export class Take implements Operator {
         }
       }
       downstreamEarlyReturn = false;
+    } catch (e) {
+      console.error('error in take initialFetch', e);
+      throw e;
     } finally {
       this.#setTakeState(
         takeStateKey,

--- a/packages/zql/src/query/query-impl.query-kitchen-sink.test.ts
+++ b/packages/zql/src/query/query-impl.query-kitchen-sink.test.ts
@@ -297,7 +297,8 @@ describe('kitchen sink query', () => {
         q
           .orderBy('createdAt', 'desc')
           .related('revisions', q => q.orderBy('id', 'desc').limit(1))
-          .limit(2),
+          .limit(2)
+          .start({createdAt: 10}),
       )
       .related('labels')
       .start({
@@ -345,6 +346,12 @@ describe('kitchen sink query', () => {
                 ['createdAt', 'desc'],
                 ['id', 'asc'],
               ],
+              start: {
+                exclusive: true,
+                row: {
+                  createdAt: 10,
+                },
+              },
               related: [
                 {
                   correlation: {
@@ -547,31 +554,7 @@ describe('kitchen sink query', () => {
       },
       {
         closed: false,
-        comments: [
-          {
-            authorId: '003',
-            createdAt: 12,
-            id: '212',
-            issueId: '105',
-            revisions: [],
-            text: 'Comment 12',
-          },
-          {
-            authorId: '002',
-            createdAt: 11,
-            id: '211',
-            issueId: '105',
-            revisions: [
-              {
-                authorId: '003',
-                commentId: '211',
-                id: '309',
-                text: 'Revision 3',
-              },
-            ],
-            text: 'Comment 11',
-          },
-        ],
+        comments: [],
         description: 'Description 5',
         id: '105',
         labels: [],


### PR DESCRIPTION
gotta put this down for a bit.

it looks like memorysource::fetch() needs to be cleaned up again.

- i think that overlay is probably not being considered for startAt right now.
- it looks like there's another note about overlay vs edit
- the branch to normalize startAt and caculate scanStart are doing overlapping things.

I think there has to be some way to simplify this. I feel like it should involve:

1. Figuring out the index to scan
2. Merging overlay into all index scans in some generic way – either by literally applying the overlay to all indexes eagerly, or by merging it in dynamically
3. Calculating the start position one time