### PR TITLE
feat(zero-cache): reorganize help text for consistency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4149,10 +4149,9 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/ansi-colors": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "dev": true,
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
       "engines": {
         "node": ">=6"
       }
@@ -15095,6 +15094,7 @@
         "@rocicorp/logger": "^5.3.0",
         "@rocicorp/resolver": "^1.0.2",
         "@rocicorp/zero-sqlite3": "^1.0.3",
+        "ansi-colors": "^4.1.3",
         "camelcase": "^8.0.0",
         "command-line-args": "^6.0.1",
         "command-line-usage": "^7.0.3",
@@ -15149,6 +15149,7 @@
         "@rocicorp/logger": "^5.3.0",
         "@rocicorp/resolver": "^1.0.2",
         "@rocicorp/zero-sqlite3": "^1.0.3",
+        "ansi-colors": "^4.1.3",
         "camelcase": "^8.0.0",
         "command-line-args": "^6.0.1",
         "command-line-usage": "^7.0.3",
@@ -17002,6 +17003,7 @@
         "@rocicorp/prettier-config": "^0.2.0",
         "@rocicorp/resolver": "^1.0.2",
         "@rocicorp/zero-sqlite3": "^1.0.3",
+        "ansi-colors": "^4.1.3",
         "camelcase": "^8.0.0",
         "command-line-args": "^6.0.1",
         "command-line-usage": "^7.0.3",
@@ -18290,10 +18292,9 @@
       }
     },
     "ansi-colors": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "dev": true
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -25842,6 +25843,7 @@
         "@types/pg": "^8.11.2",
         "@types/pg-format": "^1.0.5",
         "@types/ws": "^8.5.12",
+        "ansi-colors": "^4.1.3",
         "camelcase": "^8.0.0",
         "command-line-args": "^6.0.1",
         "command-line-usage": "^7.0.3",

--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -27,6 +27,7 @@
     "@rocicorp/logger": "^5.3.0",
     "@rocicorp/resolver": "^1.0.2",
     "@rocicorp/zero-sqlite3": "^1.0.3",
+    "ansi-colors": "^4.1.3",
     "camelcase": "^8.0.0",
     "command-line-args": "^6.0.1",
     "command-line-usage": "^7.0.3",

--- a/packages/zero-cache/src/config/config.test.ts
+++ b/packages/zero-cache/src/config/config.test.ts
@@ -381,26 +381,28 @@ test('--help', () => {
   expect(logger.error).toHaveBeenCalledOnce();
   expect(stripAnsi(logger.error.mock.calls[0][0])).toMatchInlineSnapshot(`
     "
-     -p, --port number                  blah blah blah                                                       
-                                        default: 4848                                                        
-                                        env: PORT                                                            
+     -p, --port number                  default: 4848                                                        
+       PORT env                                                                                              
+                                        blah blah blah                                                       
                                                                                                              
-     --replicaDBFile string             env: REPLICA_DB_FILE                                                 
+     --replicaDBFile string             required                                                             
+       REPLICA_DB_FILE env                                                                                   
                                                                                                              
-     --litestream boolean               env: LITESTREAM                                                      
+     --litestream boolean               optional                                                             
+       LITESTREAM env                                                                                        
                                                                                                              
      --logFormat text,json              default: "text"                                                      
-                                        env: LOG_FORMAT                                                      
+       LOG_FORMAT env                                                                                        
                                                                                                              
-     --shardID string                   blah blah blah                                                       
-                                        default: "0"                                                         
-                                        env: SHARD_ID                                                        
+     --shardID string                   default: "0"                                                         
+       SHARD_ID env                                                                                          
+                                        blah blah blah                                                       
                                                                                                              
      --shardPublications string[]       default: []                                                          
-                                        env: SHARD_PUBLICATIONS                                              
+       SHARD_PUBLICATIONS env                                                                                
                                                                                                              
      --tuple a,c,e,g,i,k,b,d,f,h,j,l    default: ["a","b"]                                                   
-                                        env: TUPLE                                                           
+       TUPLE env                                                                                             
                                                                                                              
     "
   `);
@@ -414,26 +416,28 @@ test('-h', () => {
   expect(logger.error).toHaveBeenCalledOnce();
   expect(stripAnsi(logger.error.mock.calls[0][0])).toMatchInlineSnapshot(`
     "
-     -p, --port number                  blah blah blah                                                       
-                                        default: 4848                                                        
-                                        env: PORT                                                            
+     -p, --port number                  default: 4848                                                        
+       PORT env                                                                                              
+                                        blah blah blah                                                       
                                                                                                              
-     --replicaDBFile string             env: REPLICA_DB_FILE                                                 
+     --replicaDBFile string             required                                                             
+       REPLICA_DB_FILE env                                                                                   
                                                                                                              
-     --litestream boolean               env: LITESTREAM                                                      
+     --litestream boolean               optional                                                             
+       LITESTREAM env                                                                                        
                                                                                                              
      --logFormat text,json              default: "text"                                                      
-                                        env: LOG_FORMAT                                                      
+       LOG_FORMAT env                                                                                        
                                                                                                              
-     --shardID string                   blah blah blah                                                       
-                                        default: "0"                                                         
-                                        env: SHARD_ID                                                        
+     --shardID string                   default: "0"                                                         
+       SHARD_ID env                                                                                          
+                                        blah blah blah                                                       
                                                                                                              
      --shardPublications string[]       default: []                                                          
-                                        env: SHARD_PUBLICATIONS                                              
+       SHARD_PUBLICATIONS env                                                                                
                                                                                                              
      --tuple a,c,e,g,i,k,b,d,f,h,j,l    default: ["a","b"]                                                   
-                                        env: TUPLE                                                           
+       TUPLE env                                                                                             
                                                                                                              
     "
   `);

--- a/packages/zero/package.json
+++ b/packages/zero/package.json
@@ -24,6 +24,7 @@
     "@rocicorp/logger": "^5.3.0",
     "@rocicorp/resolver": "^1.0.2",
     "@rocicorp/zero-sqlite3": "^1.0.3",
+    "ansi-colors": "^4.1.3",
     "camelcase": "^8.0.0",
     "command-line-args": "^6.0.1",
     "command-line-usage": "^7.0.3",


### PR DESCRIPTION
Reorganize `--help` layout so that elements are always in the same place (flag, env, etc.)

Add `required` or `optional` tag to complement `default: ...` so that the element is displayed for all flags. 

<img width="761" alt="Screenshot 2024-11-03 at 15 04 29" src="https://github.com/user-attachments/assets/da0a22fd-e4bf-4bd2-b134-260bf69e3794">
