### PR TITLE
chore(zero-cache): switch to esm-friendly ansi library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4152,6 +4152,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
       "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -4201,6 +4202,14 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/ansis": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.3.2.tgz",
+      "integrity": "sha512-cFthbBlt+Oi0i9Pv/j6YdVWJh54CtjGACaMPCIrEV4Ha7HWsIjXDwseYV79TIL0B4+KfSwD5S70PeQDkPUd1rA==",
+      "engines": {
+        "node": ">=15"
       }
     },
     "node_modules/any-promise": {
@@ -15090,7 +15099,7 @@
         "@rocicorp/logger": "^5.3.0",
         "@rocicorp/resolver": "^1.0.2",
         "@rocicorp/zero-sqlite3": "^1.0.3",
-        "ansi-colors": "^4.1.3",
+        "ansis": "^3.3.2",
         "camelcase": "^8.0.0",
         "command-line-args": "^6.0.1",
         "command-line-usage": "^7.0.3",
@@ -15145,7 +15154,7 @@
         "@rocicorp/logger": "^5.3.0",
         "@rocicorp/resolver": "^1.0.2",
         "@rocicorp/zero-sqlite3": "^1.0.3",
-        "ansi-colors": "^4.1.3",
+        "ansis": "^3.3.2",
         "camelcase": "^8.0.0",
         "command-line-args": "^6.0.1",
         "command-line-usage": "^7.0.3",
@@ -15182,7 +15191,6 @@
         "@types/ws": "^8.5.12",
         "concurrently": "^8.2.1",
         "shared": "0.0.0",
-        "strip-ansi": "^7.1.0",
         "typescript": "^5.6.3",
         "vitest": "^2.0.3"
       }
@@ -15206,18 +15214,6 @@
         "@types/node": "*"
       }
     },
-    "packages/zero-cache/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
     "packages/zero-cache/node_modules/camelcase": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
@@ -15235,21 +15231,6 @@
       "integrity": "sha512-6faShkdFugNQCLwucjPcY5ARoW1SlbnrZjmGl0IrrqewpvxvhSLHimCVzqeuULCbG0fQv7Dtk1yDbG3xv7Veog==",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "packages/zero-cache/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "packages/zero-client": {
@@ -16978,7 +16959,7 @@
         "@rocicorp/prettier-config": "^0.2.0",
         "@rocicorp/resolver": "^1.0.2",
         "@rocicorp/zero-sqlite3": "^1.0.3",
-        "ansi-colors": "^4.1.3",
+        "ansis": "^3.3.2",
         "camelcase": "^8.0.0",
         "command-line-args": "^6.0.1",
         "command-line-usage": "^7.0.3",
@@ -18269,7 +18250,8 @@
     "ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -18301,6 +18283,11 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
+    },
+    "ansis": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.3.2.tgz",
+      "integrity": "sha512-cFthbBlt+Oi0i9Pv/j6YdVWJh54CtjGACaMPCIrEV4Ha7HWsIjXDwseYV79TIL0B4+KfSwD5S70PeQDkPUd1rA=="
     },
     "any-promise": {
       "version": "1.3.0",
@@ -25818,7 +25805,7 @@
         "@types/pg": "^8.11.2",
         "@types/pg-format": "^1.0.5",
         "@types/ws": "^8.5.12",
-        "ansi-colors": "^4.1.3",
+        "ansis": "^3.3.2",
         "camelcase": "^8.0.0",
         "command-line-args": "^6.0.1",
         "command-line-usage": "^7.0.3",
@@ -25838,7 +25825,6 @@
         "postgres": "^3.4.4",
         "postgres-array": "^3.0.2",
         "shared": "0.0.0",
-        "strip-ansi": "^7.1.0",
         "tsx": "^4.19.1",
         "typescript": "^5.6.3",
         "vitest": "^2.0.3",
@@ -25867,12 +25853,6 @@
             "@types/node": "*"
           }
         },
-        "ansi-regex": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-          "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-          "dev": true
-        },
         "camelcase": {
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
@@ -25882,15 +25862,6 @@
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.2.tgz",
           "integrity": "sha512-6faShkdFugNQCLwucjPcY5ARoW1SlbnrZjmGl0IrrqewpvxvhSLHimCVzqeuULCbG0fQv7Dtk1yDbG3xv7Veog=="
-        },
-        "strip-ansi": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-          "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^6.0.1"
-          }
         }
       }
     },

--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -27,7 +27,7 @@
     "@rocicorp/logger": "^5.3.0",
     "@rocicorp/resolver": "^1.0.2",
     "@rocicorp/zero-sqlite3": "^1.0.3",
-    "ansi-colors": "^4.1.3",
+    "ansis": "^3.3.2",
     "camelcase": "^8.0.0",
     "command-line-args": "^6.0.1",
     "command-line-usage": "^7.0.3",
@@ -64,7 +64,6 @@
     "@types/ws": "^8.5.12",
     "concurrently": "^8.2.1",
     "shared": "0.0.0",
-    "strip-ansi": "^7.1.0",
     "typescript": "^5.6.3",
     "vitest": "^2.0.3"
   },

--- a/packages/zero-cache/src/config/config.test.ts
+++ b/packages/zero-cache/src/config/config.test.ts
@@ -1,5 +1,5 @@
 import {SilentLogger} from '@rocicorp/logger';
-import stripAnsi from 'strip-ansi';
+import {Ansis} from 'ansis';
 import {expect, test, vi} from 'vitest';
 import * as v from '../../../shared/src/valita.js';
 import {
@@ -8,6 +8,9 @@ import {
   type Config,
   type Options,
 } from './config.js';
+
+// For some reason, Typescript doesn't figure out `import ansis from 'ansis'`
+const ansis = new Ansis();
 
 const options = {
   port: {
@@ -379,7 +382,7 @@ test('--help', () => {
     ExitAfterUsage,
   );
   expect(logger.error).toHaveBeenCalledOnce();
-  expect(stripAnsi(logger.error.mock.calls[0][0])).toMatchInlineSnapshot(`
+  expect(ansis.strip(logger.error.mock.calls[0][0])).toMatchInlineSnapshot(`
     "
      --port, -p number                  default: 4848                                                        
        PORT env                                                                                              
@@ -414,7 +417,7 @@ test('-h', () => {
     ExitAfterUsage,
   );
   expect(logger.error).toHaveBeenCalledOnce();
-  expect(stripAnsi(logger.error.mock.calls[0][0])).toMatchInlineSnapshot(`
+  expect(ansis.strip(logger.error.mock.calls[0][0])).toMatchInlineSnapshot(`
     "
      --port, -p number                  default: 4848                                                        
        PORT env                                                                                              

--- a/packages/zero-cache/src/config/config.ts
+++ b/packages/zero-cache/src/config/config.ts
@@ -1,5 +1,5 @@
 import type {OptionalLogger} from '@rocicorp/logger';
-import c from 'ansi-colors';
+import {italic, underline} from 'ansis';
 import camelcase from 'camelcase';
 import type {OptionDefinition} from 'command-line-args';
 import commandLineArgs from 'command-line-args';
@@ -269,7 +269,7 @@ export function parseOptions<T extends Options>(
 
     const spec = [
       (required
-        ? c.italic('required')
+        ? italic('required')
         : defaultValue !== undefined
         ? `default: ${JSON.stringify(defaultValue)}`
         : 'optional') + '\n',
@@ -280,10 +280,10 @@ export function parseOptions<T extends Options>(
 
     const typeLabel = [
       literals.size
-        ? String([...literals].map(l => c.underline(l)))
+        ? String([...literals].map(underline))
         : multiple
-        ? c.underline(`${terminalType}[]`)
-        : c.underline(terminalType),
+        ? underline(`${terminalType}[]`)
+        : underline(terminalType),
       `  ${env} env`,
     ];
 

--- a/packages/zero/package.json
+++ b/packages/zero/package.json
@@ -24,7 +24,7 @@
     "@rocicorp/logger": "^5.3.0",
     "@rocicorp/resolver": "^1.0.2",
     "@rocicorp/zero-sqlite3": "^1.0.3",
-    "ansi-colors": "^4.1.3",
+    "ansis": "^3.3.2",
     "camelcase": "^8.0.0",
     "command-line-args": "^6.0.1",
     "command-line-usage": "^7.0.3",


### PR DESCRIPTION
I like `ansis`, but let me know if you know of a better lib.

For some reason, `ansi-colors` remains in `package-lock.json` as a dev dependency. Not sure why.