### PR TITLE
chore(zero-cache): restructure rateLimit config schema

### DIFF
--- a/apps/zbugs/zero.config.ts
+++ b/apps/zbugs/zero.config.ts
@@ -54,13 +54,10 @@ export default defineConfig<AuthData, Schema>(schema, query => {
       level: process.env['LOG_LEVEL'] as 'debug' | 'info' | 'warn' | 'error',
       format: process.env['LOG_FORMAT'] as 'text' | 'json' | undefined,
     },
-    rateLimit: {
-      mutationTransactions: {
-        algorithm: 'sliding-window',
-        // 100 writes per minute per user
-        windowMs: 1000 * 60,
-        maxTransactions: 100,
-      },
+    perUserMutationLimit: {
+      // 100 writes per minute per user
+      windowMs: 1000 * 60,
+      max: 100,
     },
 
     authorization: {

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -97,15 +97,10 @@ const logConfigSchema = v.object({
 });
 export type LogConfig = v.Infer<typeof logConfigSchema>;
 
-const rateLimitConfigSchema = v.object({
-  // Limits to `max` transactions per `windowMs` milliseconds.
-  // This uses a sliding window algorithm to track number of transactions in the current window.
-  mutationTransactions: v.object({
-    algorithm: v.literal('sliding-window'),
-    windowMs: v.number(),
-    maxTransactions: v.number(),
-  }),
-});
+const rateLimitSchema = {
+  max: v.number().optional(),
+  windowMs: v.number().default(60_000),
+};
 
 const zeroConfigBase = v.object({
   upstreamDBConnStr: v.string(),
@@ -134,7 +129,7 @@ const zeroConfigBase = v.object({
 
   jwtSecret: v.string().optional(),
 
-  rateLimit: rateLimitConfigSchema.optional(),
+  perUserMutationLimit: v.object(rateLimitSchema),
 });
 
 export type ZeroConfigBase = v.Infer<typeof zeroConfigBase>;

--- a/packages/zero-cache/src/services/mutagen/mutagen.ts
+++ b/packages/zero-cache/src/services/mutagen/mutagen.ts
@@ -79,10 +79,10 @@ export class MutagenService implements Mutagen, Service {
       clientGroupID,
     );
 
-    if (config.rateLimit) {
+    if (config.perUserMutationLimit.max !== undefined) {
       this.#limiter = new SlidingWindowLimiter(
-        config.rateLimit.mutationTransactions.windowMs,
-        config.rateLimit.mutationTransactions.maxTransactions,
+        config.perUserMutationLimit.windowMs,
+        config.perUserMutationLimit.max,
       );
     }
   }

--- a/packages/zero-cache/src/services/mutagen/write-authorizer.test.ts
+++ b/packages/zero-cache/src/services/mutagen/write-authorizer.test.ts
@@ -1,7 +1,7 @@
 import {beforeEach, describe, expect, test} from 'vitest';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.js';
 import {Database} from '../../../../zqlite/src/db.js';
-import {type ZeroConfig, type Rule} from '../../config/zero-config.js';
+import {type Rule, type ZeroConfig} from '../../config/zero-config.js';
 import {WriteAuthorizerImpl} from './write-authorizer.js';
 
 const lc = createSilentLogContext();
@@ -12,6 +12,7 @@ const baseConfig: ZeroConfig = {
   replicaDBFile: 'replica',
   log: {level: 'debug', format: 'json'},
   shard: {id: '0', publications: []},
+  perUserMutationLimit: {windowMs: 60000},
 };
 
 const allowIfSubject = [


### PR DESCRIPTION
Restructure the rate limit schema to be compatible with the upcoming valita-based config / flags framework, which only supports a single level of grouping.

In particular, changed:
* `rateLimit: { mutationTransactions: { ... } }`
* to `perUserMutationLimit: { ... }`

To eventually be settable by flags:
* `--perUserMutationLimitMax`
* `--perUserMutationLimitWindowMs`