### PR TITLE
chore(zero)!: Remove @rocicorp/zero/schema api

### DIFF
--- a/apps/zbugs/src/components/emoji-panel.tsx
+++ b/apps/zbugs/src/components/emoji-panel.tsx
@@ -4,7 +4,7 @@ import {
   PopoverPanel,
   useClose,
 } from '@headlessui/react';
-import type {TableSchemaToRow} from '@rocicorp/zero/schema';
+import type {TableSchemaToRow} from '@rocicorp/zero';
 import {nanoid} from 'nanoid';
 import {useCallback} from 'react';
 import {useQuery} from 'zero-react/src/use-query.js';

--- a/apps/zbugs/src/components/user-picker.tsx
+++ b/apps/zbugs/src/components/user-picker.tsx
@@ -1,4 +1,4 @@
-import {type TableSchemaToRow} from '@rocicorp/zero/schema';
+import {type TableSchemaToRow} from '@rocicorp/zero';
 import {useQuery} from '@rocicorp/zero/react';
 import {useEffect, useState} from 'react';
 import avatarIcon from '../assets/icons/avatar-default.svg';

--- a/apps/zbugs/src/domain/schema.ts
+++ b/apps/zbugs/src/domain/schema.ts
@@ -2,7 +2,7 @@ import {
   createSchema,
   createTableSchema,
   type TableSchemaToRow,
-} from '@rocicorp/zero/schema';
+} from '@rocicorp/zero';
 
 const userSchema = createTableSchema({
   tableName: 'user',

--- a/apps/zbugs/src/pages/issue/issue-page.tsx
+++ b/apps/zbugs/src/pages/issue/issue-page.tsx
@@ -1,5 +1,4 @@
-import type {TableSchemaToRow} from '@rocicorp/zero/schema';
-import type {Zero} from '@rocicorp/zero';
+import type {TableSchemaToRow, Zero} from '@rocicorp/zero';
 import {useQuery} from '@rocicorp/zero/react';
 import {nanoid} from 'nanoid';
 import {useEffect, useMemo, useState} from 'react';

--- a/packages/zero-client/src/client/crud.ts
+++ b/packages/zero-client/src/client/crud.ts
@@ -1,6 +1,6 @@
+import type {Expand} from '../../../shared/src/expand.js';
 import {promiseVoid} from '../../../shared/src/resolved-promises.js';
 import type {MaybePromise} from '../../../shared/src/types.js';
-import type {Expand} from '../../../shared/src/expand.js';
 import type {Row} from '../../../zero-protocol/src/data.js';
 import {
   type PrimaryKey,
@@ -17,11 +17,11 @@ import {
   type UpdateOp,
 } from '../../../zero-protocol/src/push.js';
 import type {NormalizedPrimaryKey} from '../../../zero-schema/src/normalize-table-schema.js';
+import type {Schema} from '../../../zero-schema/src/schema.js';
 import type {TableSchemaToRow} from '../../../zero-schema/src/table-schema.js';
 import {toPrimaryKeyString} from './keys.js';
 import type {NormalizedSchema} from './normalized-schema.js';
 import type {MutatorDefs, WriteTransaction} from './replicache-types.js';
-import type {Schema} from '../../../zero-schema/src/mod.js';
 
 /**
  * If a field is |undefined, add the ? marker to also make the field optional.

--- a/packages/zero-client/src/client/normalized-schema.test.ts
+++ b/packages/zero-client/src/client/normalized-schema.test.ts
@@ -1,7 +1,7 @@
 import {expect, test} from 'vitest';
+import type {Schema} from '../../../zero-schema/src/schema.js';
 import type {TableSchema} from '../../../zero-schema/src/table-schema.js';
 import {normalizeSchema} from './normalized-schema.js';
-import type {Schema} from '../../../zero-schema/src/mod.js';
 
 // Use JSON to preserve the order of properties since
 // the testing framework doesn't care about the order.

--- a/packages/zero-client/src/client/normalized-schema.ts
+++ b/packages/zero-client/src/client/normalized-schema.ts
@@ -5,7 +5,7 @@ import {
   normalizeTableSchemaWithCache,
   type TableSchemaCache,
 } from '../../../zero-schema/src/normalize-table-schema.js';
-import type {Schema} from '../../../zero-schema/src/mod.js';
+import type {Schema} from '../../../zero-schema/src/schema.js';
 
 /**
  * Creates a normalized schema from a schema.

--- a/packages/zero-client/src/client/options.ts
+++ b/packages/zero-client/src/client/options.ts
@@ -1,7 +1,7 @@
 import type {LogLevel} from '@rocicorp/logger';
 import type {KVStoreProvider} from '../../../replicache/src/mod.js';
 import type {MaybePromise} from '../../../shared/src/types.js';
-import type {Schema} from '../../../zero-schema/src/mod.js';
+import type {Schema} from '../../../zero-schema/src/schema.js';
 
 /**
  * Configuration for [[Zero]].

--- a/packages/zero-client/src/client/test-utils.ts
+++ b/packages/zero-client/src/client/test-utils.ts
@@ -19,6 +19,7 @@ import {
   type PullResponseMessage,
   upstreamSchema,
 } from '../../../zero-protocol/src/mod.js';
+import type {Schema} from '../../../zero-schema/src/schema.js';
 import type {LogOptions} from './log-options.js';
 import type {ZeroOptions} from './options.js';
 import {
@@ -29,7 +30,6 @@ import {
   exposedToTestingSymbol,
   onSetConnectionStateSymbol,
 } from './zero.js';
-import type {Schema} from '../../../zero-schema/src/mod.js';
 
 export async function tickAFewTimes(clock: SinonFakeTimers, duration = 100) {
   const n = 10;

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -25,6 +25,7 @@ import {
   pushMessageSchema,
 } from '../../../zero-protocol/src/push.js';
 import type {NullableVersion} from '../../../zero-protocol/src/version.js';
+import type {Schema} from '../../../zero-schema/src/schema.js';
 import type {WSString} from './http-string.js';
 import type {ZeroOptions} from './options.js';
 import type {QueryManager} from './query-manager.js';
@@ -48,7 +49,6 @@ import {
   RUN_LOOP_INTERVAL_MS,
   type UpdateNeededReason,
 } from './zero.js';
-import type {Schema} from '../../../zero-schema/src/mod.js';
 
 let realSetTimeout: typeof setTimeout;
 let clock: sinon.SinonFakeTimers;

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -59,9 +59,10 @@ import type {
   PullResponseBody,
   PullResponseMessage,
 } from '../../../zero-protocol/src/pull.js';
+import type {Schema} from '../../../zero-schema/src/schema.js';
+import type {TableSchema} from '../../../zero-schema/src/table-schema.js';
 import {newQuery} from '../../../zql/src/query/query-impl.js';
 import type {Query} from '../../../zql/src/query/query.js';
-import type {TableSchema} from '../../../zero-schema/src/table-schema.js';
 import {nanoid} from '../util/nanoid.js';
 import {send} from '../util/socket.js';
 import {ZeroContext} from './context.js';
@@ -84,14 +85,13 @@ import {
   getLastConnectErrorValue,
 } from './metrics.js';
 import {type NormalizedSchema, normalizeSchema} from './normalized-schema.js';
-import type {ZeroOptions, ZeroAdvancedOptions} from './options.js';
+import type {ZeroAdvancedOptions, ZeroOptions} from './options.js';
 import {QueryManager} from './query-manager.js';
 import {reloadWithReason, reportReloadReason} from './reload-error-handler.js';
 import {ServerError, isAuthError, isServerError} from './server-error.js';
 import {getServer} from './server-option.js';
 import {version} from './version.js';
 import {PokeHandler} from './zero-poke-handler.js';
-import type {Schema} from '../../../zero-schema/src/mod.js';
 
 export type NoRelations = Record<string, never>;
 

--- a/packages/zero-client/src/mod.ts
+++ b/packages/zero-client/src/mod.ts
@@ -57,8 +57,16 @@ export type {
   VersionNotSupportedResponse,
   WriteTransaction,
 } from '../../replicache/src/mod.js';
-export {QueryImpl} from '../../zql/src/query/query-impl.js';
+export {createSchema, type Schema} from '../../zero-schema/src/schema.js';
+export {
+  createTableSchema,
+  type TableSchema,
+  type TableSchemaToRow,
+} from '../../zero-schema/src/table-schema.js';
+export {authQuery} from '../../zql/src/query/auth-query.js';
 export {escapeLike} from '../../zql/src/query/escape-like.js';
+export {and, cmp, not, or} from '../../zql/src/query/expression.js';
+export {QueryImpl} from '../../zql/src/query/query-impl.js';
 export type {
   DefaultQueryResultRow as EmptyQueryResultRow,
   Query,
@@ -70,4 +78,3 @@ export type {
 export type {TypedView} from '../../zql/src/query/typed-view.js';
 export type {ZeroOptions} from './client/options.js';
 export {Zero} from './client/zero.js';
-export {and, or, not, cmp} from '../../zql/src/query/expression.js';

--- a/packages/zero-react/src/use-zero.tsx
+++ b/packages/zero-react/src/use-zero.tsx
@@ -1,6 +1,6 @@
 import {createContext, useContext} from 'react';
-import type {Zero} from '../../zero-client/src/mod.js';
-import type {Schema} from '../../zero-schema/src/mod.js';
+import type {Zero} from '../../zero-client/src/client/zero.js';
+import type {Schema} from '../../zero-schema/src/schema.js';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const ZeroContext = createContext<Zero<Schema> | undefined>(undefined);

--- a/packages/zero-schema/src/mod.ts
+++ b/packages/zero-schema/src/mod.ts
@@ -1,7 +1,0 @@
-export {authQuery} from '../../zql/src/query/auth-query.js';
-export {
-  createTableSchema,
-  type TableSchema,
-  type TableSchemaToRow,
-} from './table-schema.js';
-export * from './schema.js';

--- a/packages/zero-solid/src/create-zero.ts
+++ b/packages/zero-solid/src/create-zero.ts
@@ -1,7 +1,10 @@
 import {batch} from 'solid-js';
-import {Zero, type ZeroOptions} from '../../zero-client/src/mod.js';
 import type {ZeroAdvancedOptions} from '../../zero-advanced/src/mod.js';
-import type {Schema} from '../../zero-schema/src/mod.js';
+import {
+  Zero,
+  type Schema,
+  type ZeroOptions,
+} from '../../zero-client/src/mod.js';
 
 export function createZero<S extends Schema>(options: ZeroOptions<S>): Zero<S> {
   const opts: ZeroAdvancedOptions<S> = {

--- a/packages/zero/package.json
+++ b/packages/zero/package.json
@@ -82,10 +82,6 @@
     "./advanced": {
       "types": "./out/zero/src/advanced.d.ts",
       "default": "./out/zero/src/advanced.js"
-    },
-    "./schema": {
-      "types": "./out/zero-schema/src/mod.d.ts",
-      "default": "./out/zero-schema/src/mod.js"
     }
   },
   "bin": {

--- a/packages/zero/src/schema.ts
+++ b/packages/zero/src/schema.ts
@@ -1,1 +1,0 @@
-export * from '../../zero-schema/src/mod.js';

--- a/packages/zero/tool/build.js
+++ b/packages/zero/tool/build.js
@@ -57,7 +57,7 @@ async function getExternal(includePeerDeps) {
     'zero-react',
     'zero-solid',
     'zero-advanced',
-    'zer-schema',
+    'zero-schema',
     'zql',
     'zqlite',
   ]) {
@@ -94,10 +94,12 @@ async function verifyDependencies(external) {
 async function buildZeroClient() {
   const define = makeDefine('unknown');
   const entryPoints = {
+    // When adding a file here, make sure that it is included in the tsconfig so
+    // we build the dts as well.
     zero: basePath('src/zero.ts'),
     react: basePath('src/react.ts'),
     solid: basePath('src/solid.ts'),
-    internal: basePath('src/advanced.ts'),
+    advanced: basePath('src/advanced.ts'),
   };
   await esbuild.build({
     ...sharedOptions(false, false),

--- a/packages/zqlite/src/options.ts
+++ b/packages/zqlite/src/options.ts
@@ -1,4 +1,4 @@
-import type {Schema} from '../../zero-schema/src/mod.js';
+import type {Schema} from '../../zero-schema/src/schema.js';
 import type {Database} from './db.js';
 
 /**


### PR DESCRIPTION
BREAKING CHANGE

It should not be exposed like this. `@rocicorp/zero` is our public API. Putting things under sub paths is reserved for non common use cases.