### PR TITLE
chore(zero-cache): output usage at INFO instead of ERROR

### DIFF
--- a/packages/zero-cache/src/config/config.test.ts
+++ b/packages/zero-cache/src/config/config.test.ts
@@ -377,12 +377,12 @@ test.each([
 );
 
 test('--help', () => {
-  const logger = {error: vi.fn()};
+  const logger = {info: vi.fn()};
   expect(() => parseOptions(options, ['--help'], 'Z_', {}, logger)).toThrow(
     ExitAfterUsage,
   );
-  expect(logger.error).toHaveBeenCalledOnce();
-  expect(ansis.strip(logger.error.mock.calls[0][0])).toMatchInlineSnapshot(`
+  expect(logger.info).toHaveBeenCalledOnce();
+  expect(ansis.strip(logger.info.mock.calls[0][0])).toMatchInlineSnapshot(`
     "
      --port, -p number                  default: 4848                                                        
        Z_PORT env                                                                                            
@@ -412,12 +412,12 @@ test('--help', () => {
 });
 
 test('-h', () => {
-  const logger = {error: vi.fn()};
+  const logger = {info: vi.fn()};
   expect(() => parseOptions(options, ['-h'], 'ZERO_', {}, logger)).toThrow(
     ExitAfterUsage,
   );
-  expect(logger.error).toHaveBeenCalledOnce();
-  expect(ansis.strip(logger.error.mock.calls[0][0])).toMatchInlineSnapshot(`
+  expect(logger.info).toHaveBeenCalledOnce();
+  expect(ansis.strip(logger.info.mock.calls[0][0])).toMatchInlineSnapshot(`
     "
      --port, -p number                  default: 4848                                                        
        ZERO_PORT env                                                                                         

--- a/packages/zero-cache/src/config/config.ts
+++ b/packages/zero-cache/src/config/config.ts
@@ -432,7 +432,7 @@ function showUsage(
     }
   });
 
-  logger.error?.(
+  logger.info?.(
     commandLineUsage({
       optionList,
       reverseNameOrder: true, // Display --flagName before -alias


### PR DESCRIPTION
Node v20+ outputs ERROR in red, and it's a lot of red.