### PR TITLE
feat(zero-cache): sync url parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14169,6 +14169,15 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/url-pattern": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/url-pattern/-/url-pattern-1.0.3.tgz",
+      "integrity": "sha512-uQcEj/2puA4aq1R3A2+VNVBgaWYR24FdWjl7VNW83rnWftlhyzOZ/tBjezRiC2UkIzuxC8Top3IekN3vUf1WxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/use-composed-ref": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
@@ -15135,6 +15144,7 @@
         "semver": "^7.5.4",
         "strip-ansi": "^7.1.0",
         "tsx": "^4.19.1",
+        "url-pattern": "^1.0.3",
         "ws": "^8.18.0",
         "xxhash-wasm": "^1.0.2"
       },
@@ -15190,6 +15200,7 @@
         "postgres-array": "^3.0.2",
         "strip-ansi": "^7.1.0",
         "tsx": "^4.19.1",
+        "url-pattern": "^1.0.3",
         "ws": "^8.18.0",
         "xxhash-wasm": "^1.0.2",
         "zero-protocol": "0.0.0",
@@ -17088,6 +17099,7 @@
         "tsc-alias": "^1.8.10",
         "tsx": "^4.19.1",
         "typescript": "^5.6.3",
+        "url-pattern": "^1.0.3",
         "ws": "^8.18.0",
         "xxhash-wasm": "^1.0.2"
       },
@@ -25350,6 +25362,11 @@
         "requires-port": "^1.0.0"
       }
     },
+    "url-pattern": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/url-pattern/-/url-pattern-1.0.3.tgz",
+      "integrity": "sha512-uQcEj/2puA4aq1R3A2+VNVBgaWYR24FdWjl7VNW83rnWftlhyzOZ/tBjezRiC2UkIzuxC8Top3IekN3vUf1WxA=="
+    },
     "use-composed-ref": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
@@ -25971,6 +25988,7 @@
         "strip-ansi": "^7.1.0",
         "tsx": "^4.19.1",
         "typescript": "^5.6.3",
+        "url-pattern": "^1.0.3",
         "vitest": "^2.0.3",
         "ws": "^8.18.0",
         "xxhash-wasm": "^1.0.2",

--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -46,6 +46,7 @@
     "postgres-array": "^3.0.2",
     "strip-ansi": "^7.1.0",
     "tsx": "^4.19.1",
+    "url-pattern": "^1.0.3",
     "ws": "^8.18.0",
     "xxhash-wasm": "^1.0.2",
     "zero-protocol": "0.0.0",

--- a/packages/zero-cache/src/services/dispatcher/dispatcher.ts
+++ b/packages/zero-cache/src/services/dispatcher/dispatcher.ts
@@ -1,12 +1,18 @@
 import {LogContext} from '@rocicorp/logger';
 import {IncomingMessage} from 'http';
+import UrlPattern from 'url-pattern';
 import {h32} from '../../../../shared/src/xxhash.js';
 import type {Worker} from '../../types/processes.js';
 import {HttpService, type Options} from '../http-service.js';
 import {getConnectParams} from './connect-params.js';
 import {installWebSocketHandoff} from './websocket-handoff.js';
 
-export const CONNECT_URL_PATTERN = '/api/sync/:version/connect';
+const CONNECT_URL_PATTERNS = [
+  new UrlPattern('/zero/sync/:version/connect'),
+  new UrlPattern('/api/sync/:version/connect'),
+];
+
+const SUPPORTED_VERSION = 'v1';
 
 export type Workers = {
   syncers: Worker[];
@@ -30,11 +36,16 @@ export class Dispatcher extends HttpService {
   }
 
   #handoff(req: IncomingMessage) {
-    const {headers, url} = req;
-    const {params, error} = getConnectParams(
-      new URL(url ?? '', 'http://unused/'),
-      headers,
-    );
+    const {headers, url: u} = req;
+    const url = new URL(u ?? '', 'http://unused/');
+    const syncPath = parseSyncPath(url);
+    if (!syncPath) {
+      throw new Error(`Invalid sync URL: ${u}`);
+    }
+    if (syncPath.version !== SUPPORTED_VERSION) {
+      throw new Error(`Unsupported sync version: ${u}`);
+    }
+    const {params, error} = getConnectParams(url, headers);
     if (error !== null) {
       throw new Error(error);
     }
@@ -49,4 +60,14 @@ export class Dispatcher extends HttpService {
     this._lc.debug?.(`connecting ${clientGroupID} to syncer ${syncer}`);
     return {payload: params, receiver: syncers[syncer]};
   }
+}
+
+function parseSyncPath(url: URL): {version: string} | undefined {
+  for (const pattern of CONNECT_URL_PATTERNS) {
+    const m = pattern.match(url.pathname);
+    if (m) {
+      return m;
+    }
+  }
+  return undefined;
 }

--- a/packages/zero/package.json
+++ b/packages/zero/package.json
@@ -43,6 +43,7 @@
     "postgres-array": "^3.0.2",
     "semver": "^7.5.4",
     "strip-ansi": "^7.1.0",
+    "url-pattern": "^1.0.3",
     "tsx": "^4.19.1",
     "ws": "^8.18.0",
     "xxhash-wasm": "^1.0.2"


### PR DESCRIPTION
Accept sync requests on `/zero/sync/{version}/connect` and `/api/sync/{version}/connect`.

Only accept version = "v1" to ensure incompatibility with unknown protocol versions.