### PR TITLE
fix(zero): File name did not match package.json

### DIFF
--- a/packages/zero/tool/build.js
+++ b/packages/zero/tool/build.js
@@ -97,7 +97,7 @@ async function buildZeroClient() {
     zero: basePath('src/zero.ts'),
     react: basePath('src/react.ts'),
     solid: basePath('src/solid.ts'),
-    internal: basePath('src/advanced.ts'),
+    advanced: basePath('src/advanced.ts'),
   };
   await esbuild.build({
     ...sharedOptions(false, false),


### PR DESCRIPTION
package.json exports said advanced.js but the build script used "internal"