### PR TITLE
Fix missing advanced.js

### DIFF
--- a/packages/zero/package.json
+++ b/packages/zero/package.json
@@ -84,7 +84,7 @@
     },
     "./advanced": {
       "types": "./out/zero/src/advanced.d.ts",
-      "default": "./out/zero/src/advanced.js"
+      "default": "./out/advanced.js"
     },
     "./schema": {
       "types": "./out/zero-schema/src/mod.d.ts",


### PR DESCRIPTION
I think this will fix that `advanced.js` is missing [causing an error](https://discord.com/channels/830183651022471199/1288232858795769917/1304156264309456977) when trying to use the `@rocicorp/zero/advanced` package.