### PR TITLE
chore(zero-cache): use vitest provide() instead of env variable

### DIFF
--- a/packages/zero-cache/src/test/db.ts
+++ b/packages/zero-cache/src/test/db.ts
@@ -1,15 +1,20 @@
 import postgres from 'postgres';
-import {afterAll, expect} from 'vitest';
-import {assert, assertString} from '../../../shared/src/asserts.js';
+import {afterAll, expect, inject} from 'vitest';
+import {assert} from '../../../shared/src/asserts.js';
 import {sleep} from '../../../shared/src/sleep.js';
 import {type PostgresDB, postgresTypeConfig} from '../types/pg.js';
 
+declare module 'vitest' {
+  export interface ProvidedContext {
+    pgContainerConnectionString: string;
+  }
+}
+
 // Set by ./test/pg-container-setup.ts
-assertString(process.env.PG_CONTAINER_CONNECTION_URI);
-const CONNECTION_URI: string = process.env.PG_CONTAINER_CONNECTION_URI;
+const CONNECTION_URI = inject('pgContainerConnectionString');
 assert(
   CONNECTION_URI.length > 0,
-  'pg-container-setup.ts must be executed to setup the PG_CONTAINER_CONNECTION_URI',
+  'pg-container-setup.ts must be executed to setup the pgContainerConnectionString',
 );
 
 export type OnNoticeFn = (n: postgres.Notice) => void;

--- a/packages/zero-cache/test/pg-container-setup.ts
+++ b/packages/zero-cache/test/pg-container-setup.ts
@@ -4,16 +4,15 @@ import {PostgreSqlContainer} from '@testcontainers/postgresql';
 //       to run tests with different versions of Postgres.
 const PG_IMAGE = 'postgres:16.3-alpine3.19';
 
-export default async function () {
+export default async function ({provide}) {
   const container = await new PostgreSqlContainer(PG_IMAGE)
     .withCommand(['postgres', '-c', 'wal_level=logical'])
     .start();
 
   // Referenced by ./src/test/db.ts
-  process.env.PG_CONTAINER_CONNECTION_URI = container.getConnectionUri();
+  provide('pgContainerConnectionString', container.getConnectionUri());
 
   return async () => {
     await container.stop();
-    delete process.env.PG_CONTAINER_CONNECTION_URI;
   };
 }


### PR DESCRIPTION
Using the `provide` / `inject` vitest feature:

https://vitest.dev/config/#provide