### PR TITLE
chore(zero-cache): update schema in benchmark

### DIFF
--- a/packages/zero-cache/bench/double.ts
+++ b/packages/zero-cache/bench/double.ts
@@ -1,0 +1,50 @@
+import 'dotenv/config';
+import {createSilentLogContext} from '../../shared/src/logging-test-utils.js';
+import {Database} from '../../zqlite/src/db.js';
+
+type Options = {
+  dbFile: string;
+};
+
+export function double(opts: Options) {
+  const {dbFile} = opts;
+  const db = new Database(createSilentLogContext(), dbFile);
+
+  const insertIssue = db.prepare(
+    `INSERT INTO issue (
+      id, shortID, title, open, modified, created, 
+      creatorID, assigneeID, description, labelIDs, _0_version
+    ) VALUES (
+      @id, @shortID, @title, @open, @modified, @created, 
+      @creatorID, @assigneeID, @description, @labelIDs, @_0_version
+    );`,
+  );
+  const issueLabels = db.prepare(`SELECT * from issueLabel WHERE issueID = ?`);
+  const insertIssueLabel = db.prepare(
+    `INSERT INTO issueLabel (
+      labelID, issueID, _0_version
+    ) VALUES (
+      @labelID, @issueID, @_0_version
+     )`,
+  );
+
+  let newIssues = 0;
+  let newIssueLabels = 1;
+  for (const issue of db.prepare(`SELECT * FROM issue`).all() as any[]) {
+    newIssues++;
+    const id = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER).toString(36);
+    const newIssue = {...(issue as any), id};
+    insertIssue.run(newIssue);
+
+    for (const issueLabel of issueLabels.all(issue.id) as any[]) {
+      newIssueLabels++;
+      const newIssueLabel = {...issueLabel, issueID: id};
+      insertIssueLabel.run(newIssueLabel);
+    }
+  }
+
+  console.info(`Created ${newIssues} new issues with ${newIssueLabels} labels`);
+  db.close();
+}
+
+double({dbFile: '/tmp/bench/zbugs-sync-replica.db'});

--- a/packages/zero-cache/bench/schema.ts
+++ b/packages/zero-cache/bench/schema.ts
@@ -95,7 +95,7 @@ const issueLabelSchema: TableSchema = {
     labelID: {type: 'string'},
   },
   // mutators require an ID field still.
-  primaryKey: ['id'],
+  primaryKey: ['labelID', 'issueID'],
   relationships: {},
 };
 

--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -14,6 +14,7 @@
     "local": "tsx tool/local.ts",
     "start": "tsx ./src/server/main.ts",
     "bench": "tsx ./bench/bench.ts",
+    "double": "tsx ./bench/double.ts",
     "wal_bench": "tsx ./bench/wal-bench.ts",
     "wal2_bench": "tsx ./bench/wal2-bench.ts"
   },


### PR DESCRIPTION
Also add a utility for synthetically doubling the size of the data (for running the benchmark on a larger database).