### PR TITLE
fix(zero-cache): fix an edge case for resetting CVRs

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -155,7 +155,8 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         }
         await this.#runInLockWithCVR(async cvr => {
           if (
-            cvr.replicaVersion !== null &&
+            (cvr.replicaVersion !== null ||
+              cvr.version.stateVersion !== '00') &&
             cvr.replicaVersion !== this.#pipelines.replicaVersion
           ) {
             const msg = `Replica Version mismatch: CVR=${

--- a/packages/zero-cache/src/types/error-for-client.ts
+++ b/packages/zero-cache/src/types/error-for-client.ts
@@ -1,7 +1,6 @@
 import type {ErrorMessage} from '../../../zero-protocol/src/mod.js';
 
 export class ErrorForClient extends Error {
-  readonly name = 'ErrorForClient';
   readonly errorMessage;
   constructor(errorMessage: ErrorMessage, options?: ErrorOptions) {
     super(JSON.stringify(errorMessage), options);


### PR DESCRIPTION
Cover an edge case when a CVR still needs to be reset; if the cvr never saw any replicated changes to bump the version.