### PR TITLE
feat(zero-cache): add a "rollback" message to the change stream protocol

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/forwarder.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/forwarder.test.ts
@@ -97,4 +97,93 @@ describe('change-streamer/forwarder', () => {
     // sub4 was added in during the second transaction. It gets nothing.
     expect(stream4).toMatchInlineSnapshot(`[]`);
   });
+
+  test('in transaction queueing, rolled back', () => {
+    const forwarder = new Forwarder();
+
+    const [sub1, stream1] = createSubscriber('00', true);
+    const [sub2, stream2] = createSubscriber('00', true);
+    const [sub3, stream3] = createSubscriber('00', true);
+    const [sub4, stream4] = createSubscriber('00', true);
+
+    forwarder.add(sub1);
+    forwarder.forward(['11', ['begin', messages.begin()]]);
+    forwarder.add(sub2);
+    forwarder.forward(['12', ['data', messages.truncate('issues')]]);
+    forwarder.forward(['13', ['rollback', messages.rollback()]]);
+    forwarder.add(sub3);
+    forwarder.forward(['14', ['begin', messages.begin()]]);
+    forwarder.add(sub4);
+
+    for (const sub of [sub1, sub2, sub3, sub4]) {
+      sub.close();
+    }
+
+    // sub1 gets all of the messages, as it was not added in a transaction.
+    expect(stream1).toMatchInlineSnapshot(`
+      [
+        [
+          "begin",
+          {
+            "tag": "begin",
+          },
+        ],
+        [
+          "data",
+          {
+            "relations": [
+              {
+                "keyColumns": [
+                  "id",
+                ],
+                "name": "issues",
+                "replicaIdentity": "default",
+                "schema": "public",
+                "tag": "relation",
+              },
+            ],
+            "tag": "truncate",
+          },
+        ],
+        [
+          "rollback",
+          {
+            "tag": "rollback",
+          },
+        ],
+        [
+          "begin",
+          {
+            "tag": "begin",
+          },
+        ],
+      ]
+    `);
+
+    // sub2 and sub3 were added in a transaction. They only see the next
+    // transaction.
+    expect(stream2).toMatchInlineSnapshot(`
+      [
+        [
+          "begin",
+          {
+            "tag": "begin",
+          },
+        ],
+      ]
+    `);
+    expect(stream3).toMatchInlineSnapshot(`
+      [
+        [
+          "begin",
+          {
+            "tag": "begin",
+          },
+        ],
+      ]
+    `);
+
+    // sub4 was added in during the second transaction. It gets nothing.
+    expect(stream4).toMatchInlineSnapshot(`[]`);
+  });
 });

--- a/packages/zero-cache/src/services/change-streamer/forwarder.ts
+++ b/packages/zero-cache/src/services/change-streamer/forwarder.ts
@@ -45,8 +45,11 @@ export class Forwarder {
         this.#inTransaction = true;
         break;
       case 'commit':
-        // Upon commit, all queued subscribers are transferred to the active set.
-        // This means that they can receive messages starting from the next transaction.
+      case 'rollback':
+        // Upon commit or rollback, all queued subscribers are transferred to
+        // the active set. This means that they can receive messages starting
+        // from the next transaction.
+        //
         // Note that if catchup is still in progress (in the Storer), these messages
         // will be buffered in the backlog until catchup completes.
         this.#inTransaction = false;

--- a/packages/zero-cache/src/services/change-streamer/pg/change-source.end-to-mid.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/change-source.end-to-mid.pg-test.ts
@@ -111,6 +111,7 @@ describe('change-source/pg/end-to-mid-test', () => {
           data.push(change[1]);
           break;
         case 'commit':
+        case 'rollback':
           return data;
         default:
           change satisfies never;

--- a/packages/zero-cache/src/services/change-streamer/schema/change.ts
+++ b/packages/zero-cache/src/services/change-streamer/schema/change.ts
@@ -11,6 +11,10 @@ export const commitSchema = v.object({
   tag: v.literal('commit'),
 });
 
+export const rollbackSchema = v.object({
+  tag: v.literal('rollback'),
+});
+
 export const relationSchema = v.object({
   tag: v.literal('relation'),
   schema: v.string(),
@@ -110,6 +114,7 @@ export const dropIndexSchema = v.object({
 
 export type MessageBegin = v.Infer<typeof beginSchema>;
 export type MessageCommit = v.Infer<typeof commitSchema>;
+export type MessageRollback = v.Infer<typeof rollbackSchema>;
 
 export type MessageRelation = v.Infer<typeof relationSchema>;
 export type MessageInsert = v.Infer<typeof insertSchema>;
@@ -146,6 +151,10 @@ export type DataChange = Satisfies<
   v.Infer<typeof dataChangeSchema>
 >;
 
-export type Change = MessageBegin | DataChange | MessageCommit;
+export type Change =
+  | MessageBegin
+  | DataChange
+  | MessageCommit
+  | MessageRollback;
 
 export type ChangeTag = Change['tag'];

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -271,7 +271,7 @@ export class MessageProcessor {
     }
   }
 
-  /** @return The number of changes committed. */
+  /** @return If a transaction was committed. */
   #processMessage(
     lc: LogContext,
     msg: Change,
@@ -303,6 +303,12 @@ export class MessageProcessor {
 
       this.#acknowledge(watermark);
       return true;
+    }
+
+    if (msg.tag === 'rollback') {
+      this.#currentTx?.abort(lc);
+      this.#currentTx = null;
+      return false;
     }
 
     switch (msg.tag) {

--- a/packages/zero-cache/src/services/replicator/test-utils.ts
+++ b/packages/zero-cache/src/services/replicator/test-utils.ts
@@ -16,6 +16,7 @@ import type {
   MessageDelete,
   MessageInsert,
   MessageRelation,
+  MessageRollback,
   MessageTruncate,
   MessageUpdate,
   TableCreate,
@@ -199,5 +200,9 @@ export class ReplicationMessages<
 
   commit(extra?: object): MessageCommit {
     return {tag: 'commit', ...extra};
+  }
+
+  rollback(): MessageRollback {
+    return {tag: 'rollback'};
   }
 }


### PR DESCRIPTION
Introduce a "rollback" message to the change stream protocol that indicates that the current transaction should be rolled back. This results in rolling back corresponding transactions for both:
* the changeLog in the `change-streamer`
* the sqlite replication transaction in the `replicator`

Initially, this is being used to clean up dangling transactions when processing of the replication stream is halted due to an invalid schema change: #2972

In the future, the rollback message can also be used for processing streaming, in-progress transactions (which can be rolled back) if we add support for that feature of Postgres logical replication.