### PR TITLE
fix(zero-cache): ignore noop CREATE TABLE / INDEX events

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/pg/schema/ddl.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/schema/ddl.ts
@@ -285,9 +285,11 @@ BEGIN
 
   -- Construct and emit the DdlUpdateEvent message.
 
-  IF target IS NOT NULL
-  THEN
+  IF target IS NOT NULL THEN
     SELECT json_build_object('tag', tag, cmd.object_type, target) INTO event;
+  ELSIF tag LIKE 'CREATE %' THEN
+    PERFORM ${schema}.notice_ignore('noop ' || tag);
+    RETURN;
   ELSE
     SELECT json_build_object('tag', tag) INTO event;
   END IF;


### PR DESCRIPTION
ddl events can be noops for statements such as `CREATE TABLE IF NOT EXISTS ...`

Avoid creating logical replication messages for these noop events, as they otherwise produce malformed messages as `CREATE TABLE` and `CREATE INDEX` events expect a created target. 