### PR TITLE
feat(zero-cache): include the oid in the PublishedTableSpec

### DIFF
--- a/packages/zero-cache/src/db/create.pg-test.ts
+++ b/packages/zero-cache/src/db/create.pg-test.ts
@@ -346,9 +346,10 @@ describe('tables/create', () => {
         await db.unsafe(createStatement);
 
         const published = await getPublicationInfo(db, ['zero_all']);
-        expect(published.tables).toEqual([
+        expect(published.tables).toMatchObject([
           {
             ...(c.dstTableSpec ?? c.srcTableSpec),
+            oid: expect.any(Number),
             publications: {['zero_all']: {rowFilter: null}},
           },
         ]);

--- a/packages/zero-cache/src/db/specs.ts
+++ b/packages/zero-cache/src/db/specs.ts
@@ -21,7 +21,8 @@ export const tableSpec = liteTableSpec.extend({
   schema: v.string(),
 });
 
-export const filteredTableSpec = tableSpec.extend({
+export const publishedTableSpec = tableSpec.extend({
+  oid: v.number(),
   publications: v.record(v.object({rowFilter: v.string().nullable()})),
 });
 
@@ -29,7 +30,7 @@ export type LiteTableSpec = Readonly<v.Infer<typeof liteTableSpec>>;
 
 export type TableSpec = Readonly<v.Infer<typeof tableSpec>>;
 
-export type FilteredTableSpec = Readonly<v.Infer<typeof filteredTableSpec>>;
+export type PublishedTableSpec = Readonly<v.Infer<typeof publishedTableSpec>>;
 
 export const directionSchema = v.union(v.literal('ASC'), v.literal('DESC'));
 

--- a/packages/zero-cache/src/services/change-streamer/pg/initial-sync.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/initial-sync.pg-test.ts
@@ -3,9 +3,9 @@ import {createSilentLogContext} from '../../../../../shared/src/logging-test-uti
 import {Database} from '../../../../../zqlite/src/db.js';
 import {listIndexes, listTables} from '../../../db/lite-tables.js';
 import type {
-  FilteredTableSpec,
   LiteIndexSpec,
   LiteTableSpec,
+  PublishedTableSpec,
 } from '../../../db/specs.js';
 import {getConnectionURI, initDB, testDBs} from '../../../test/db.js';
 import {expectTables, initDB as initLiteDB} from '../../../test/lite.js';
@@ -18,7 +18,7 @@ import {UnsupportedTableSchemaError} from './schema/validation.js';
 
 const SHARD_ID = 'initial_sync_test_id';
 
-const ZERO_SCHEMA_VERSIONS_SPEC: FilteredTableSpec = {
+const ZERO_SCHEMA_VERSIONS_SPEC: PublishedTableSpec = {
   columns: {
     minSupportedVersion: {
       characterMaximumLength: null,
@@ -42,13 +42,14 @@ const ZERO_SCHEMA_VERSIONS_SPEC: FilteredTableSpec = {
       pos: 3,
     },
   },
+  oid: expect.any(Number),
   name: 'schemaVersions',
   primaryKey: ['lock'],
   publications: {[`_zero_metadata_${SHARD_ID}`]: {rowFilter: null}},
   schema: 'zero',
 } as const;
 
-const ZERO_CLIENTS_SPEC: FilteredTableSpec = {
+const ZERO_CLIENTS_SPEC: PublishedTableSpec = {
   columns: {
     clientGroupID: {
       pos: 1,
@@ -79,6 +80,7 @@ const ZERO_CLIENTS_SPEC: FilteredTableSpec = {
       dflt: null,
     },
   },
+  oid: expect.any(Number),
   name: 'clients',
   primaryKey: ['clientGroupID', 'clientID'],
   schema: `zero_${SHARD_ID}`,
@@ -154,7 +156,7 @@ describe('replicator/initial-sync', () => {
     setupUpstreamQuery?: string;
     requestedPublications?: string[];
     setupReplicaQuery?: string;
-    published: Record<string, FilteredTableSpec>;
+    published: Record<string, PublishedTableSpec>;
     upstream?: Record<string, object[]>;
     replicatedSchema: Record<string, LiteTableSpec>;
     replicatedIndices?: LiteIndexSpec[];
@@ -323,6 +325,7 @@ describe('replicator/initial-sync', () => {
               notNull: true,
             },
           },
+          oid: expect.any(Number),
           name: 'issues',
           primaryKey: ['orgID', 'issueID'],
           schema: 'public',
@@ -561,6 +564,7 @@ describe('replicator/initial-sync', () => {
               dflt: null,
             },
           },
+          oid: expect.any(Number),
           name: 'users',
           primaryKey: ['userID'],
           schema: 'public',
@@ -652,6 +656,7 @@ describe('replicator/initial-sync', () => {
               dflt: null,
             },
           },
+          oid: expect.any(Number),
           name: 'users',
           primaryKey: ['userID'],
           schema: 'public',
@@ -767,6 +772,7 @@ describe('replicator/initial-sync', () => {
               dflt: null,
             },
           },
+          oid: expect.any(Number),
           name: 'issues',
           primaryKey: ['orgID', 'issueID'],
           schema: 'public',
@@ -884,7 +890,7 @@ describe('replicator/initial-sync', () => {
         Object.fromEntries(
           tables.map(table => [`${table.schema}.${table.name}`, table]),
         ),
-      ).toEqual(c.published);
+      ).toMatchObject(c.published);
       expect(new Set(publications.map(p => p.pubname))).toEqual(
         new Set(c.resultingPublications),
       );

--- a/packages/zero-cache/src/services/change-streamer/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/initial-sync.ts
@@ -9,7 +9,7 @@ import {
   mapPostgresToLite,
   mapPostgresToLiteIndex,
 } from '../../../db/pg-to-lite.js';
-import type {FilteredTableSpec, IndexSpec} from '../../../db/specs.js';
+import type {IndexSpec, PublishedTableSpec} from '../../../db/specs.js';
 import {
   importSnapshot,
   Mode,
@@ -210,7 +210,7 @@ function startTableCopyWorkers(
   return tableCopiers;
 }
 
-function createLiteTables(tx: Database, tables: FilteredTableSpec[]) {
+function createLiteTables(tx: Database, tables: PublishedTableSpec[]) {
   for (const t of tables) {
     tx.exec(createTableStatement(mapPostgresToLite(t)));
   }
@@ -224,7 +224,7 @@ function createLiteIndices(tx: Database, indices: IndexSpec[]) {
 
 async function copy(
   lc: LogContext,
-  table: FilteredTableSpec,
+  table: PublishedTableSpec,
   from: PostgresDB,
   to: Database,
 ) {

--- a/packages/zero-cache/src/services/change-streamer/pg/schema/ddl.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/schema/ddl.pg-test.ts
@@ -103,6 +103,7 @@ describe('change-source/tables/ddl', () => {
     schema: {
       tables: [
         {
+          oid: expect.any(Number),
           schema: 'pub',
           name: 'boo',
           columns: {
@@ -135,6 +136,7 @@ describe('change-source/tables/ddl', () => {
           },
         },
         {
+          oid: expect.any(Number),
           schema: 'pub',
           name: 'foo',
           columns: {
@@ -167,6 +169,7 @@ describe('change-source/tables/ddl', () => {
           },
         },
         {
+          oid: expect.any(Number),
           schema: 'pub',
           name: 'yoo',
           columns: {
@@ -282,6 +285,7 @@ describe('change-source/tables/ddl', () => {
         },
         schema: {
           tables: inserted(DDL_START.schema.tables, 0, {
+            oid: expect.any(Number),
             schema: 'pub',
             name: 'bar',
             columns: {
@@ -384,6 +388,7 @@ describe('change-source/tables/ddl', () => {
         },
         schema: {
           tables: replaced(DDL_START.schema.tables, 1, 1, {
+            oid: expect.any(Number),
             schema: 'pub',
             name: 'food',
             columns: {
@@ -455,6 +460,7 @@ describe('change-source/tables/ddl', () => {
         version: 1,
         schema: {
           tables: replaced(DDL_START.schema.tables, 1, 1, {
+            oid: expect.any(Number),
             schema: 'pub',
             name: 'foo',
             columns: {
@@ -519,6 +525,7 @@ describe('change-source/tables/ddl', () => {
         schema: {
           indexes: DDL_START.schema.indexes,
           tables: replaced(DDL_START.schema.tables, 1, 1, {
+            oid: expect.any(Number),
             schema: 'pub',
             name: 'foo',
             columns: {
@@ -576,6 +583,7 @@ describe('change-source/tables/ddl', () => {
         schema: {
           indexes: DDL_START.schema.indexes,
           tables: replaced(DDL_START.schema.tables, 1, 1, {
+            oid: expect.any(Number),
             schema: 'pub',
             name: 'foo',
             columns: {
@@ -625,6 +633,7 @@ describe('change-source/tables/ddl', () => {
         },
         schema: {
           tables: replaced(DDL_START.schema.tables, 1, 1, {
+            oid: expect.any(Number),
             schema: 'pub',
             name: 'foo',
             columns: {
@@ -694,6 +703,7 @@ describe('change-source/tables/ddl', () => {
         },
         schema: {
           tables: replaced(DDL_START.schema.tables, 1, 1, {
+            oid: expect.any(Number),
             schema: 'pub',
             name: 'foo',
             columns: {
@@ -734,6 +744,7 @@ describe('change-source/tables/ddl', () => {
         schema: {
           tables: [
             {
+              oid: expect.any(Number),
               schema: 'pub',
               name: 'boo',
               columns: {
@@ -827,6 +838,7 @@ describe('change-source/tables/ddl', () => {
         schema: {
           indexes: DDL_START.schema.indexes,
           tables: replaced(DDL_START.schema.tables, 2, 1, {
+            oid: expect.any(Number),
             schema: 'pub',
             name: 'yoo',
             columns: {
@@ -872,6 +884,7 @@ describe('change-source/tables/ddl', () => {
         schema: {
           indexes: DDL_START.schema.indexes,
           tables: replaced(DDL_START.schema.tables, 1, 1, {
+            oid: expect.any(Number),
             schema: 'pub',
             name: 'foo',
             columns: {
@@ -921,6 +934,7 @@ describe('change-source/tables/ddl', () => {
           tables: [
             ...DDL_START.schema.tables,
             {
+              oid: expect.any(Number),
               schema: 'zero',
               name: 'foo',
               columns: {
@@ -972,13 +986,15 @@ describe('change-source/tables/ddl', () => {
       ]);
 
       const {content: start} = messages[3] as Pgoutput.MessageMessage;
-      expect(JSON.parse(new TextDecoder().decode(start))).toEqual({
+      expect(JSON.parse(new TextDecoder().decode(start))).toMatchObject({
         ...DDL_START,
         context: {query},
       } satisfies DdlStartEvent);
 
       const {content: update} = messages[4] as Pgoutput.MessageMessage;
-      expect(JSON.parse(new TextDecoder().decode(update))).toEqual(ddlUpdate);
+      expect(JSON.parse(new TextDecoder().decode(update))).toMatchObject(
+        ddlUpdate,
+      );
     },
   );
 

--- a/packages/zero-cache/src/services/change-streamer/pg/schema/ddl.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/schema/ddl.ts
@@ -1,6 +1,6 @@
 import {literal as lit} from 'pg-format';
 import * as v from '../../../../../../shared/src/valita.js';
-import {filteredTableSpec, indexSpec} from '../../../../db/specs.js';
+import {indexSpec, publishedTableSpec} from '../../../../db/specs.js';
 import {id} from '../../../../types/sql.js';
 import {indexDefinitionsQuery, publishedTableQuery} from './published.js';
 
@@ -19,7 +19,7 @@ const triggerEvent = v.object({
 // The Schema type encapsulates a snapshot of the tables and indexes that
 // are published / relevant to the shard.
 const publishedSchema = v.object({
-  tables: v.array(filteredTableSpec),
+  tables: v.array(publishedTableSpec),
   indexes: v.array(indexSpec),
 });
 

--- a/packages/zero-cache/src/services/change-streamer/pg/schema/published.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/schema/published.pg-test.ts
@@ -1,5 +1,6 @@
 import type postgres from 'postgres';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {assert} from '../../../../../../shared/src/asserts.js';
 import {testDBs} from '../../../../test/db.js';
 import {type PublicationInfo, getPublicationInfo} from './published.js';
 
@@ -34,6 +35,7 @@ describe('tables/published', () => {
         ],
         tables: [
           {
+            oid: expect.any(Number),
             schema: 'zero',
             name: 'clients',
             columns: {
@@ -92,6 +94,7 @@ describe('tables/published', () => {
         ],
         tables: [
           {
+            oid: expect.any(Number),
             schema: 'test',
             name: 'users',
             columns: {
@@ -217,6 +220,7 @@ describe('tables/published', () => {
         ],
         tables: [
           {
+            oid: expect.any(Number),
             schema: 'test',
             name: 'users',
             columns: {
@@ -280,6 +284,7 @@ describe('tables/published', () => {
         ],
         tables: [
           {
+            oid: expect.any(Number),
             schema: 'test',
             name: 'users',
             columns: {
@@ -346,6 +351,7 @@ describe('tables/published', () => {
         ],
         tables: [
           {
+            oid: expect.any(Number),
             schema: 'test',
             name: 'users',
             columns: {
@@ -424,6 +430,7 @@ describe('tables/published', () => {
         ],
         tables: [
           {
+            oid: expect.any(Number),
             schema: 'test',
             name: 'users',
             columns: {
@@ -488,6 +495,7 @@ describe('tables/published', () => {
         ],
         tables: [
           {
+            oid: expect.any(Number),
             schema: 'test',
             name: 'issues',
             columns: {
@@ -572,6 +580,7 @@ describe('tables/published', () => {
         ],
         tables: [
           {
+            oid: expect.any(Number),
             schema: 'test',
             name: 'issues',
             columns: {
@@ -608,6 +617,7 @@ describe('tables/published', () => {
             publications: {['zero_tables']: {rowFilter: null}},
           },
           {
+            oid: expect.any(Number),
             schema: 'test',
             name: 'users',
             columns: {
@@ -630,6 +640,7 @@ describe('tables/published', () => {
             publications: {['zero_tables']: {rowFilter: null}},
           },
           {
+            oid: expect.any(Number),
             schema: 'zero',
             name: 'clients',
             columns: {
@@ -688,6 +699,7 @@ describe('tables/published', () => {
         ],
         tables: [
           {
+            oid: expect.any(Number),
             schema: 'test',
             name: 'issues',
             columns: {
@@ -739,7 +751,7 @@ describe('tables/published', () => {
       },
     },
     {
-      name: 'unique indices',
+      name: 'unique indexes',
       setupQuery: `
       CREATE SCHEMA test;
       CREATE TABLE test.issues (
@@ -763,6 +775,7 @@ describe('tables/published', () => {
         ],
         tables: [
           {
+            oid: expect.any(Number),
             schema: 'test',
             name: 'issues',
             columns: {
@@ -811,7 +824,7 @@ describe('tables/published', () => {
       },
     },
     {
-      name: 'compound indices',
+      name: 'compound indexes',
       setupQuery: `
       CREATE SCHEMA test;
       CREATE TABLE test.foo (
@@ -843,6 +856,7 @@ describe('tables/published', () => {
         ],
         tables: [
           {
+            oid: expect.any(Number),
             schema: 'test',
             name: 'foo',
             columns: {
@@ -927,6 +941,7 @@ describe('tables/published', () => {
         ],
         tables: [
           {
+            oid: expect.any(Number),
             schema: 'test',
             name: 'foo',
             columns: {
@@ -1010,7 +1025,8 @@ describe('tables/published', () => {
                 'zero_tables',
               ],
         );
-        expect(tables).toEqual(c.expectedResult);
+        assert(c.expectedResult);
+        expect(tables).toMatchObject(c.expectedResult);
       } catch (e) {
         if (c.expectedError) {
           expect(c.expectedError).toMatch(String(e));


### PR DESCRIPTION
Include a table's `oid` in the `PublishedTableSpec` (renamed from `FilteredTableSpec`) so that two independent snapshots can be correctly diffed without the constraint that the difference results from a single DDL statement (which we currently rely on for event-trigger-based schema diffs).