### PR TITLE
chore(zero-cache): consolidate schema definitions

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/change-source.ts
@@ -40,8 +40,8 @@ import {
   createEventTriggerStatements,
   replicationEventSchema,
   type DdlUpdateEvent,
-  type PublishedSchema,
 } from './schema/ddl.js';
+import type {PublishedSchema} from './schema/published.js';
 import {INTERNAL_PUBLICATION_PREFIX} from './schema/shard.js';
 import {validate} from './schema/validation.js';
 import type {ShardConfig} from './shard-config.js';

--- a/packages/zero-cache/src/services/change-streamer/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/initial-sync.ts
@@ -58,7 +58,7 @@ export async function initialSync(
   });
   try {
     await checkUpstreamConfig(upstreamDB);
-    const {publications, tables, indices} = await ensurePublishedTables(
+    const {publications, tables, indexes} = await ensurePublishedTables(
       lc,
       upstreamDB,
       shard,
@@ -67,7 +67,7 @@ export async function initialSync(
     lc.info?.(`Upstream is setup with publications [${pubNames}]`);
 
     createLiteTables(tx, tables);
-    createLiteIndices(tx, indices);
+    createLiteIndices(tx, indexes);
 
     const {database, host} = upstreamDB.options;
     lc.info?.(`opening replication session to ${database}@${host}`);

--- a/packages/zero-cache/src/services/change-streamer/pg/schema/ddl.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/schema/ddl.ts
@@ -1,8 +1,11 @@
 import {literal as lit} from 'pg-format';
 import * as v from '../../../../../../shared/src/valita.js';
-import {indexSpec, publishedTableSpec} from '../../../../db/specs.js';
 import {id} from '../../../../types/sql.js';
-import {indexDefinitionsQuery, publishedTableQuery} from './published.js';
+import {
+  indexDefinitionsQuery,
+  publishedSchema,
+  publishedTableQuery,
+} from './published.js';
 
 // Sent in the 'version' tag of "ddlStart" and "ddlUpdate" event messages.
 // This is used to ensure that the message constructed in the upstream
@@ -15,15 +18,6 @@ export const PROTOCOL_VERSION = 1;
 const triggerEvent = v.object({
   context: v.object({query: v.string()}).rest(v.string()),
 });
-
-// The Schema type encapsulates a snapshot of the tables and indexes that
-// are published / relevant to the shard.
-const publishedSchema = v.object({
-  tables: v.array(publishedTableSpec),
-  indexes: v.array(indexSpec),
-});
-
-export type PublishedSchema = v.Infer<typeof publishedSchema>;
 
 // All DDL events contain a snapshot of the current tables and indexes that
 // are published / relevant to the shard.

--- a/packages/zero-cache/src/services/change-streamer/pg/schema/published.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/schema/published.pg-test.ts
@@ -58,7 +58,7 @@ describe('tables/published', () => {
             publications: {['zero_all']: {rowFilter: null}},
           },
         ],
-        indices: [],
+        indexes: [],
       },
     },
     {
@@ -194,7 +194,7 @@ describe('tables/published', () => {
             publications: {['zero_data']: {rowFilter: null}},
           },
         ],
-        indices: [],
+        indexes: [],
       },
     },
     {
@@ -250,7 +250,7 @@ describe('tables/published', () => {
             publications: {['zero_data']: {rowFilter: '(org_id = 123)'}},
           },
         ],
-        indices: [],
+        indexes: [],
       },
     },
     {
@@ -317,7 +317,7 @@ describe('tables/published', () => {
             },
           },
         ],
-        indices: [],
+        indexes: [],
       },
     },
     {
@@ -384,7 +384,7 @@ describe('tables/published', () => {
             },
           },
         ],
-        indices: [],
+        indexes: [],
       },
     },
     {
@@ -467,7 +467,7 @@ describe('tables/published', () => {
             publications: {['zero_data']: {rowFilter: null}},
           },
         ],
-        indices: [],
+        indexes: [],
       },
     },
     {
@@ -532,7 +532,7 @@ describe('tables/published', () => {
             publications: {['zero_keys']: {rowFilter: null}},
           },
         ],
-        indices: [],
+        indexes: [],
       },
     },
     {
@@ -663,7 +663,7 @@ describe('tables/published', () => {
             publications: {['_zero_meta']: {rowFilter: null}},
           },
         ],
-        indices: [],
+        indexes: [],
       },
     },
     {
@@ -732,7 +732,7 @@ describe('tables/published', () => {
             },
           },
         ],
-        indices: [
+        indexes: [
           {
             schema: 'test',
             tableName: 'issues',
@@ -805,7 +805,7 @@ describe('tables/published', () => {
             publications: {['zero_data']: {rowFilter: null}},
           },
         ],
-        indices: [
+        indexes: [
           {
             schema: 'test',
             tableName: 'issues',
@@ -889,7 +889,7 @@ describe('tables/published', () => {
             },
           },
         ],
-        indices: [
+        indexes: [
           {
             schema: 'test',
             tableName: 'foo',
@@ -971,7 +971,7 @@ describe('tables/published', () => {
             publications: {['zero_data']: {rowFilter: null}},
           },
         ],
-        indices: [
+        indexes: [
           {
             schema: 'test',
             tableName: 'foo',


### PR DESCRIPTION
Reorganization to have all of the published schema types (and validation) to come from one place.