### PR TITLE
!feat(zql): remove `table` and `column` rules

### DIFF
--- a/apps/zbugs/schema.ts
+++ b/apps/zbugs/schema.ts
@@ -225,7 +225,7 @@ export const authorization = defineAuthorization<AuthData, Schema>(
     return {
       user: {
         // Only the authentication system can write to the user table.
-        table: {
+        row: {
           insert: [],
           update: [],
           delete: [],

--- a/packages/zero-cache/src/services/mutagen/write-authorizer.test.ts
+++ b/packages/zero-cache/src/services/mutagen/write-authorizer.test.ts
@@ -38,34 +38,6 @@ describe('can insert/update/delete/upsert', () => {
       authorization: undefined,
     },
     {
-      name: 'empty (deny) table policy',
-      expected: false,
-      authorization: {
-        foo: {
-          table: {
-            insert: [],
-            update: [],
-            delete: [],
-          },
-        },
-      },
-    },
-    {
-      name: 'empty (deny) column policy',
-      expected: false,
-      authorization: {
-        foo: {
-          column: {
-            a: {
-              insert: [],
-              update: [],
-              delete: [],
-            },
-          },
-        },
-      },
-    },
-    {
       name: 'empty (deny) row policy',
       expected: false,
       authorization: {

--- a/packages/zero-cache/src/services/mutagen/write-authorizer.ts
+++ b/packages/zero-cache/src/services/mutagen/write-authorizer.ts
@@ -180,28 +180,6 @@ export class WriteAuthorizerImpl {
       return true;
     }
 
-    const tableRules = rules.table;
-    if (
-      tableRules &&
-      !this.#passesPolicy(tableRules[action], authData, undefined)
-    ) {
-      return false;
-    }
-
-    const columnRules = rules.column;
-    if (columnRules) {
-      for (const [column, rule] of Object.entries(columnRules)) {
-        if (action === 'update' && op.value[column] === undefined) {
-          // If the column is not being updated, we do not need to check
-          // the column rules.
-          continue;
-        }
-        if (!this.#passesPolicy(rule[action], authData, undefined)) {
-          return false;
-        }
-      }
-    }
-
     let preMutationRow: Row | undefined;
     if (op.op !== 'create') {
       preMutationRow = this.#getPreMutationRow(op);

--- a/packages/zero-schema/src/authorization.test.ts
+++ b/packages/zero-schema/src/authorization.test.ts
@@ -35,7 +35,7 @@ test('authorization rules create query ASTs', async () => {
 
       return {
         user: {
-          table: {
+          row: {
             insert: [allowIfAdmin],
             update: [allowIfAdmin],
             delete: [allowIfAdmin],

--- a/packages/zero-schema/src/compiled-authorization.ts
+++ b/packages/zero-schema/src/compiled-authorization.ts
@@ -17,8 +17,6 @@ export type AssetAuthorization = v.Infer<typeof assetSchema>;
 
 const authorizationConfigSchema = v.record(
   v.object({
-    table: assetSchema.optional(),
-    column: v.record(assetSchema).optional(),
     row: assetSchema.optional(),
     cell: v.record(assetSchema).optional(),
   }),


### PR DESCRIPTION
`row` and `cell` rules can double as `table` and `column` rules by just not correlating on the row.

It might be less confusing to only have row and cell policies too. Having `table`, `row`, `column`, `cell` results in having to understand precedence between the four sets of policies.

```ts
{
  table: {
    select: []
  },
  row: {
    select: [allowIfAdmin]
  }
}
```

It's a bit unclear that the table rule would cause all reads to fail, even though a row rule exists.

Also, a `row` rule behaves as a `table` rule if it doesn't correlate against a row. We can implicitly split these out for the user rather than making them define them separately.