### PR TITLE
feat(zero-cache): detect schema changes and halt replication for non-superuser

### DIFF
--- a/packages/zero-cache/src/db/short-lived-client.pg-test.ts
+++ b/packages/zero-cache/src/db/short-lived-client.pg-test.ts
@@ -1,0 +1,49 @@
+import {LogContext} from '@rocicorp/logger';
+import {afterAll, beforeAll, describe, expect, test} from 'vitest';
+import {TestLogSink} from '../../../shared/src/logging-test-utils.js';
+import {sleep} from '../../../shared/src/sleep.js';
+import {getConnectionURI, testDBs} from '../test/db.js';
+import type {PostgresDB} from '../types/pg.js';
+import {ShortLivedClient} from './short-lived-client.js';
+
+describe('short-lived-client', () => {
+  let db: PostgresDB;
+  let dbConnStr: string;
+  let logSink: TestLogSink;
+  let lc: LogContext;
+
+  beforeAll(async () => {
+    db = await testDBs.create('short_lived_client_db');
+    dbConnStr = getConnectionURI(db);
+    logSink = new TestLogSink();
+    lc = new LogContext('debug', {}, logSink);
+  });
+
+  afterAll(async () => {
+    await testDBs.end();
+  });
+
+  test('short-lived-client', async () => {
+    const client = new ShortLivedClient(lc, dbConnStr, 'foo app', 5);
+    const db1 = client.db;
+
+    expect(client.db).toBe(db1);
+
+    // Keep the client alive by asking for it every 2 ms.
+    for (let i = 0; i < 5; i++) {
+      await sleep(2);
+      expect(client.db).toBe(db1);
+      expect(logSink.messages).toEqual([]);
+    }
+
+    // Now wait for more than 5 ms. Original client should have been shut down.
+    await sleep(8);
+    const db2 = client.db;
+    expect(db2).not.toBe(db1);
+    expect(logSink.messages[0]).toEqual([
+      'debug',
+      {},
+      ['closing idle upstream connection'],
+    ]);
+  });
+});

--- a/packages/zero-cache/src/db/short-lived-client.ts
+++ b/packages/zero-cache/src/db/short-lived-client.ts
@@ -1,0 +1,59 @@
+import type {LogContext} from '@rocicorp/logger';
+import {pgClient, type PostgresDB} from '../types/pg.js';
+
+/**
+ * Manages on-demand short-lived connections to a DB, shutting down after
+ * an idle delay.
+ */
+export class ShortLivedClient {
+  readonly #lc: LogContext;
+  readonly #dbConnStr: string;
+  readonly #appName: string;
+  readonly #idleDelay: number;
+
+  #db: PostgresDB | null = null;
+  #dbTimeout: IdleTimeout = {};
+
+  constructor(
+    lc: LogContext,
+    dbConnStr: string,
+    appName: string,
+    idleDelay = 10_000,
+  ) {
+    this.#lc = lc;
+    this.#dbConnStr = dbConnStr;
+    this.#appName = appName;
+    this.#idleDelay = idleDelay;
+  }
+
+  /**
+   * Get (or refresh) an upstream DB client that automatically closes
+   * after being idle for 10 seconds.
+   */
+  get db(): PostgresDB {
+    try {
+      if (this.#db) {
+        clearTimeout(this.#dbTimeout.id); // reset in finally
+      } else {
+        this.#db = pgClient(this.#lc, this.#dbConnStr, {
+          connection: {['application_name']: this.#appName},
+        });
+      }
+      return this.#db;
+    } finally {
+      const timeout = {
+        id: setTimeout(() => {
+          // Only close the connection if the #dbTimeout has not been reset.
+          if (this.#dbTimeout === timeout) {
+            this.#lc.debug?.(`closing idle upstream connection`);
+            void this.#db?.end();
+            this.#db = null;
+          }
+        }, this.#idleDelay),
+      };
+      this.#dbTimeout = timeout;
+    }
+  }
+}
+
+type IdleTimeout = {id?: NodeJS.Timeout};

--- a/packages/zero-cache/src/services/change-streamer/pg/schema/ddl-test-utils.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/schema/ddl-test-utils.ts
@@ -1,0 +1,11 @@
+import {append, TAGS} from './ddl.js';
+
+export function dropEventTriggerStatements(shardID: string) {
+  const sharded = append(shardID);
+  const stmts = [`DROP EVENT TRIGGER IF EXISTS ${sharded('zero_ddl_start')};`];
+  for (const tag of TAGS) {
+    const tagID = tag.toLowerCase().replace(' ', '_');
+    stmts.push(`DROP EVENT TRIGGER IF EXISTS ${sharded(`zero_${tagID}`)};`);
+  }
+  return stmts.join('');
+}

--- a/packages/zero-cache/src/services/change-streamer/pg/schema/ddl.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/schema/ddl.ts
@@ -121,7 +121,7 @@ export const replicationEventSchema = v.union(
 export type ReplicationEvent = v.Infer<typeof replicationEventSchema>;
 
 // Creates a function that appends `_SHARD_ID` to the input.
-function append(shardID: string) {
+export function append(shardID: string) {
   return (name: string) => id(name + '_' + shardID);
 }
 
@@ -304,7 +304,8 @@ $$ LANGUAGE plpgsql;
 `;
 }
 
-const TAGS = [
+// Exported for testing.
+export const TAGS = [
   'CREATE TABLE',
   'ALTER TABLE',
   'CREATE INDEX',


### PR DESCRIPTION
This is Part 2 of 2 for supporting database providers that do not provide superuser (specifically, CREATE EVENT TRIGGER) support.

Part 1: allow initial-sync to proceed #2992
Part 2: 🆕 detect when the schema changes during replication

* The ChangeSource queries the `shardConfig` at initialization to determine if it needs to manually detect schema changes.
* If `ddlDetection === false`, "relation" messages from the PG replication stream are used to check if the upstream schema has changed. This is determined by:
  * querying the current (i.e. post-transaction) upstream schemas
  * comparing that against the `initialSchema` in the `shardConfig`
  * also comparing the "relation" message itself against the `initialSchema`

If any of the names, ids, or types of the tables / columns have changed, an `UnsupportedSchemaChangeError` is thrown and replication is halted with an error message:

<img width="1009" alt="Screenshot 2024-11-14 at 13 18 45" src="https://github.com/user-attachments/assets/1f560c2e-63d0-45dc-97e6-3ccbbb615f83">



