### PR TITLE
chore(zero-cache): use an exception to rollback the postgres.js transaction

### DIFF
--- a/packages/zero-cache/src/db/transaction-pool.ts
+++ b/packages/zero-cache/src/db/transaction-pool.ts
@@ -266,9 +266,10 @@ export class TransactionPool {
       db
         .begin(this.#mode, worker)
         .catch(e => {
-          // RollbackErrors are used to gracefully rollback the postgres.js
-          // transaction block. They should not be thrown up to the application.
-          if (!(e instanceof RollbackSignal)) {
+          if (e instanceof RollbackSignal) {
+            // A RollbackSignal is used to gracefully rollback the postgres.js
+            // transaction block. It should not be thrown up to the application.
+          } else {
             throw e;
           }
         })


### PR DESCRIPTION
Manually executing a `ROLLBACK` statement in a postgres.js transaction works, but the postgres.js code doesn't know about the rollback and will call `COMMIT`, which results emitting a database warning to the logs:

<img width="406" alt="Screenshot 2024-11-14 at 14 48 39" src="https://github.com/user-attachments/assets/c536896c-9b1c-42c6-9a0d-8934a5f29bb9">

To avoid this, change the mechanism for `Transaction.abort()` to throwing an internal Error that causes the postgres.js library to call `ROLLBACK` (instead of `COMMIT`).

Also remove some redundant error logging.