### PR TITLE
chore(zero-cache): add method to delete lite db

### DIFF
--- a/packages/zero-cache/src/db/begin-concurrent.test.ts
+++ b/packages/zero-cache/src/db/begin-concurrent.test.ts
@@ -1,6 +1,6 @@
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
-import {DbFile} from '../test/lite.js';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.js';
+import {DbFile} from '../test/lite.js';
 
 describe('db/begin-concurrent', () => {
   let dbFile: DbFile;
@@ -14,8 +14,8 @@ describe('db/begin-concurrent', () => {
     conn.close();
   });
 
-  afterEach(async () => {
-    await dbFile.unlink();
+  afterEach(() => {
+    dbFile.delete();
   });
 
   test('independent, concurrent actions before commit', () => {

--- a/packages/zero-cache/src/db/delete-lite-db.ts
+++ b/packages/zero-cache/src/db/delete-lite-db.ts
@@ -1,0 +1,7 @@
+import {rmSync} from 'fs';
+
+export function deleteLiteDB(dbFile: string) {
+  for (const suffix of ['', '-wal', '-wal2', '-shm']) {
+    rmSync(`${dbFile}${suffix}`, {force: true});
+  }
+}

--- a/packages/zero-cache/src/db/migration-lite.test.ts
+++ b/packages/zero-cache/src/db/migration-lite.test.ts
@@ -197,9 +197,9 @@ describe('db/migration-lite', () => {
     db.prepare(`CREATE TABLE "MigrationHistory" (event TEXT)`).run();
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     db.close();
-    await dbFile.unlink();
+    dbFile.delete();
   });
 
   for (const c of cases) {

--- a/packages/zero-cache/src/db/wal-checkpoint.test.ts
+++ b/packages/zero-cache/src/db/wal-checkpoint.test.ts
@@ -1,7 +1,7 @@
 import {resolver} from '@rocicorp/resolver';
-import {createSilentLogContext} from '../../../shared/src/logging-test-utils.js';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {Worker} from 'worker_threads';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.js';
 import {DbFile} from '../test/lite.js';
 
 describe('db/wal-checkpoint', () => {
@@ -23,8 +23,8 @@ describe('db/wal-checkpoint', () => {
     conn.close();
   });
 
-  afterEach(async () => {
-    await dbFile.unlink();
+  afterEach(() => {
+    dbFile.delete();
   });
 
   type Checkpoint = {

--- a/packages/zero-cache/src/services/change-streamer/pg/change-source.end-to-mid.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/change-source.end-to-mid.pg-test.ts
@@ -83,7 +83,7 @@ describe('change-source/pg/end-to-mid-test', () => {
   afterAll(async () => {
     changes?.cancel();
     await testDBs.drop(upstream);
-    await replicaDbFile.unlink();
+    replicaDbFile.delete();
   });
 
   function drainToQueue(

--- a/packages/zero-cache/src/services/change-streamer/pg/change-source.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/change-source.pg-test.ts
@@ -78,7 +78,7 @@ describe('change-source/pg', () => {
 
   afterEach(async () => {
     await testDBs.drop(upstream);
-    await replicaDbFile.unlink();
+    replicaDbFile.delete();
   });
 
   function drainToQueue(

--- a/packages/zero-cache/src/services/change-streamer/pg/sync-schema.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/sync-schema.pg-test.ts
@@ -110,7 +110,7 @@ describe('change-streamer/pg/sync-schema', () => {
 
   afterEach(async () => {
     await testDBs.drop(upstream);
-    await replicaFile.unlink();
+    replicaFile.delete();
   }, 10000);
   const lc = createSilentLogContext();
 

--- a/packages/zero-cache/src/services/view-syncer/snapshotter.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/snapshotter.test.ts
@@ -63,9 +63,9 @@ describe('view-syncer/snapshotter', () => {
     s = new Snapshotter(lc, dbFile.path).init();
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     s.destroy();
-    await dbFile.unlink();
+    dbFile.delete();
   });
 
   test('initial snapshot', () => {

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -214,7 +214,7 @@ describe('view-syncer/service', () => {
     await vs.stop();
     await viewSyncerDone;
     await testDBs.drop(cvrDB);
-    await replicaDbFile.unlink();
+    replicaDbFile.delete();
   });
 
   const serviceID = '9876';

--- a/packages/zero-cache/src/test/lite.ts
+++ b/packages/zero-cache/src/test/lite.ts
@@ -1,9 +1,9 @@
 import {LogContext} from '@rocicorp/logger';
-import {unlink} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {expect} from 'vitest';
 import {randInt} from '../../../shared/src/rand.js';
 import {Database} from '../../../zqlite/src/db.js';
+import {deleteLiteDB} from '../db/delete-lite-db.js';
 import {id} from '../types/sql.js';
 
 export class DbFile {
@@ -17,8 +17,8 @@ export class DbFile {
     return new Database(lc, this.path);
   }
 
-  async unlink() {
-    await unlink(this.path);
+  delete() {
+    deleteLiteDB(this.path);
   }
 }
 

--- a/packages/zero-cache/src/workers/replicator.ts
+++ b/packages/zero-cache/src/workers/replicator.ts
@@ -1,6 +1,6 @@
 import {LogContext} from '@rocicorp/logger';
-import {rmSync} from 'node:fs';
 import {Database} from '../../../zqlite/src/db.js';
+import {deleteLiteDB} from '../db/delete-lite-db.js';
 import {Notifier} from '../services/replicator/notifier.js';
 import type {
   ReplicaState,
@@ -59,9 +59,7 @@ export function setupReplica(
       // In 'serving-copy' mode, the original file is being used for 'backup'
       // mode, so we make a copy for servicing sync requests.
       const copyLocation = `${replicaDbFile}-serving-copy`;
-      for (const suffix of ['', '-wal', '-shm']) {
-        rmSync(`${copyLocation}${suffix}`, {force: true});
-      }
+      deleteLiteDB(copyLocation);
 
       const start = Date.now();
       lc.info?.(`copying ${replicaDbFile} to ${copyLocation}`);


### PR DESCRIPTION
Add `deleteLiteDB()` method to generalize what's currently used for making a serving replica copy. Improve it to also handl `-wal2` files. 

Use it for deleting test db files.