### PR TITLE
fix(zql): apply dnf at the final condition

### DIFF
--- a/packages/zql/src/query/query-impl.ast.test.ts
+++ b/packages/zql/src/query/query-impl.ast.test.ts
@@ -45,6 +45,49 @@ describe('building the AST', () => {
     });
   });
 
+  test('multiple WHERE calls result in a single top level AND', () => {
+    const issueQuery = newQuery(mockDelegate, issueSchema);
+    const where = issueQuery
+      .where('id', '1')
+      .where('title', 'foo')
+      .where('closed', true)
+      .where('ownerId', '2');
+    expect(ast(where)).toMatchInlineSnapshot(`
+      {
+        "table": "issue",
+        "where": {
+          "conditions": [
+            {
+              "field": "id",
+              "op": "=",
+              "type": "simple",
+              "value": "1",
+            },
+            {
+              "field": "title",
+              "op": "=",
+              "type": "simple",
+              "value": "foo",
+            },
+            {
+              "field": "closed",
+              "op": "=",
+              "type": "simple",
+              "value": true,
+            },
+            {
+              "field": "ownerId",
+              "op": "=",
+              "type": "simple",
+              "value": "2",
+            },
+          ],
+          "type": "and",
+        },
+      }
+    `);
+  });
+
   test('start adds a start field', () => {
     const issueQuery = newQuery(mockDelegate, issueSchema);
     const start = issueQuery.start({id: '1'});

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -272,7 +272,7 @@ export abstract class AbstractQuery<
     let cond: Condition;
 
     if (typeof fieldOrExpressionFactory === 'function') {
-      cond = dnf(fieldOrExpressionFactory(expressionBuilder));
+      cond = fieldOrExpressionFactory(expressionBuilder);
     } else {
       assert(opOrValue !== undefined, 'Invalid condition');
       cond = cmp(fieldOrExpressionFactory, opOrValue, value);
@@ -287,7 +287,7 @@ export abstract class AbstractQuery<
       this.#schema,
       {
         ...this.#ast,
-        where: cond,
+        where: dnf(cond),
       },
       this.#format,
     );


### PR DESCRIPTION
calls like:

```ts
issue.where().where().where()
```

would create nested `AND` statements rather than one single flat `AND`.

The `dnf` conversion should happen on the final condition.