### PR TITLE
chore(vitest): use "basic" vitest reporter 

### DIFF
--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "vitest run",
+    "test": "vitest run --reporter=basic",
     "test:watch": "vitest ",
     "check-types": "tsc",
     "check-types:watch": "tsc --watch",


### PR DESCRIPTION
This will facilitate debugging test flakiness by eliminating redundant output for passing tests.