### PR TITLE
fix(zero-cache): fix catching of mutagen retryable / control flow errors

### DIFF
--- a/packages/zero-cache/src/services/mutagen/mutagen.ts
+++ b/packages/zero-cache/src/services/mutagen/mutagen.ts
@@ -13,11 +13,11 @@ import {
 import {
   MutationType,
   type CRUDMutation,
-  type InsertOp,
   type DeleteOp,
+  type InsertOp,
   type Mutation,
-  type UpsertOp,
   type UpdateOp,
+  type UpsertOp,
 } from '../../../../zero-protocol/src/push.js';
 import type {AuthorizationConfig} from '../../../../zero-schema/src/compiled-authorization.js';
 import {Database} from '../../../../zqlite/src/db.js';
@@ -193,7 +193,7 @@ export async function processMutation(
           // Simulates a concurrent request for testing. In production this is a noop.
           const done = onTxStart?.();
           try {
-            return processMutationWithTx(
+            return await processMutationWithTx(
               tx,
               authData,
               shardID,


### PR DESCRIPTION
Fix mutagen to reliably catch and handle retryable / control flow errors.

This was revealed by a persistently flaky test:

<img width="565" alt="Screenshot 2024-11-15 at 18 21 56" src="https://github.com/user-attachments/assets/0736b780-e2e8-4462-b8a4-e0cde26dca86">

Also clean up some test deprecation.