### PR TITLE
chore(zero-cache): better cleanup in txpool tests

### DIFF
--- a/packages/zero-cache/src/db/transaction-pool.ts
+++ b/packages/zero-cache/src/db/transaction-pool.ts
@@ -655,7 +655,7 @@ type TimeoutTasks = {
 };
 
 // Production timeout tasks. Overridden in tests.
-const TIMEOUT_TASKS: TimeoutTasks = {
+export const TIMEOUT_TASKS: TimeoutTasks = {
   forInitialWorkers: {
     timeoutMs: KEEPALIVE_TIMEOUT_MS,
     task: KEEPALIVE_TASK,

--- a/packages/zero-cache/src/services/change-streamer/pg/change-source.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/change-source.pg-test.ts
@@ -45,6 +45,7 @@ describe('change-source/pg', () => {
   let streams: ChangeStream[];
 
   beforeEach(async () => {
+    streams = [];
     logSink = new TestLogSink();
     lc = new LogContext('error', {}, logSink);
     upstream = await testDBs.create('change_source_pg_test_upstream');
@@ -82,7 +83,6 @@ describe('change-source/pg', () => {
         replicaDbFile.path,
       )
     ).changeSource;
-    streams = [];
   });
 
   afterEach(async () => {


### PR DESCRIPTION
Ensure TransactionPool objects are cleaned up (i.e. connections closed) even upon failure so that the failures do not cascade into other tests failing to start up.