### PR TITLE
chore(zero-cache): always await copiers pool, even on exception

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/initial-sync.ts
@@ -92,14 +92,13 @@ export async function initialSync(
       );
     } finally {
       copiers.setDone();
+      await copiers.done();
     }
-
     await setInitialSchema(upstreamDB, shard.id, published);
 
     initReplicationState(tx, publications, toLexiVersion(lsn));
     initChangeLog(tx);
     lc.info?.(`Synced initial data from ${publications} up to ${lsn}`);
-    await copiers.done();
   } finally {
     await replicationSession.end();
     await upstreamDB.end();


### PR DESCRIPTION
This fixes a test flake in which the "snapshot xxx is not found" if the validation exception is thrown early enough such that the replication session ends without the copiers having started up.

By awaiting the copiers to finish in the `finally` clause, the replication session stays open and the snapshot is guaranteed to exist. 