### PR TITLE
chore(zero-cache): configure coverage via vitest.config.js

### DIFF
--- a/packages/zero-cache/README.md
+++ b/packages/zero-cache/README.md
@@ -13,8 +13,5 @@ npm run test
 To view test coverage in the VSCode editor:
 
 - Install the [Coverage Gutters](https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters) extension
-- Update two settings to teach the extension how to find vitest coverage files:
-  1. **Coverage Base Directory**: `**/coverage`
-  2. **Coverage File Names**: Add `clover.xml` to the array in the JSON file
 - Enable Coverage Gutters Watch: `Command-Shift-8`
-- Run `npm run test`
+- Run `npm run test` to update coverage.

--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "vitest run --reporter=basic --coverage",
-    "test:watch": "vitest ",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "check-types": "tsc",
     "check-types:watch": "tsc --watch",
     "format": "prettier --write .",

--- a/packages/zero-cache/vitest.config.ts
+++ b/packages/zero-cache/vitest.config.ts
@@ -1,0 +1,17 @@
+import {defineConfig} from 'vitest/config';
+import {config} from '../shared/src/tool/vitest-config.js';
+
+const {define, esbuild} = config;
+
+export default defineConfig({
+  define,
+  esbuild,
+  test: {
+    reporters: 'basic',
+    coverage: {
+      enabled: true,
+      reporter: [['html'], ['clover', {file: 'coverage.xml'}]],
+      include: ['src/**'],
+    },
+  },
+});

--- a/packages/zero-cache/vitest.workspace.ts
+++ b/packages/zero-cache/vitest.workspace.ts
@@ -1,26 +1,22 @@
-import {defineConfig, defineWorkspace, mergeConfig} from 'vitest/config';
-import {config} from '../shared/src/tool/vitest-config.js';
+import {defineWorkspace} from 'vitest/config';
 
-const {define, esbuild} = config;
-
-const baseConfig = defineConfig({define, esbuild});
-
-const pgConfigForVersion = (version: number) =>
-  mergeConfig(baseConfig, {
-    test: {
-      name: `pg-${version}`,
-      include: ['src/**/*.pg-test.?(c|m)[jt]s?(x)'],
-      globalSetup: [`./test/pg-${version}.ts`],
-    },
-  });
+const pgConfigForVersion = (version: number) => ({
+  extends: './vitest.config.js',
+  test: {
+    name: `pg-${version}`,
+    include: ['src/**/*.pg-test.?(c|m)[jt]s?(x)'],
+    globalSetup: [`./test/pg-${version}.ts`],
+  },
+});
 
 export default defineWorkspace([
-  mergeConfig(baseConfig, {
+  {
+    extends: './vitest.config.js',
     test: {
       name: 'no-pg',
       include: ['src/**/*.test.?(c|m)[jt]s?(x)'],
     },
-  }),
+  },
   pgConfigForVersion(15),
   pgConfigForVersion(16),
   pgConfigForVersion(17),


### PR DESCRIPTION
Configure coverage via `vitest.config.js` such that it is compatible with the default settings of Coverage Gutters.