### PR TITLE
pref(zql): check constraint before filter

### DIFF
--- a/packages/zql/src/ivm/memory-source.ts
+++ b/packages/zql/src/ivm/memory-source.ts
@@ -328,14 +328,14 @@ export class MemorySource implements Source {
       comparator,
     );
 
-    const withFilters = conn.optionalFilters.length
-      ? generateWithFilter(withOverlay, matchesFilters)
-      : withOverlay;
-
-    yield* generateWithConstraint(
-      generateWithStart(withFilters, req, comparator),
+    const withConstraint = generateWithConstraint(
+      generateWithStart(withOverlay, req, comparator),
       req.constraint,
     );
+
+    yield* conn.optionalFilters.length
+      ? generateWithFilter(withConstraint, matchesFilters)
+      : withConstraint;
   }
 
   #cleanup(req: FetchRequest, connection: Connection): Stream<Node> {


### PR DESCRIPTION
Otherwise we wastefully filter rows which are past the end of the constraint but which do not match the filter.  In the worse case if none of the rows match the filter, we do a full table scan applying the filter to every row.

Fixes https://bugs.rocicorp.dev/issue/3147