### PR TITLE
feat(zql): remove `MissingParameterError`

### DIFF
--- a/packages/zql/src/builder/builder.ts
+++ b/packages/zql/src/builder/builder.ts
@@ -26,7 +26,6 @@ import type {Input, Storage} from '../ivm/operator.js';
 import {Skip} from '../ivm/skip.js';
 import type {Source} from '../ivm/source.js';
 import {Take} from '../ivm/take.js';
-import {MissingParameterError} from './error.js';
 import {createPredicate} from './filter.js';
 
 export type StaticQueryParameters = {
@@ -139,12 +138,7 @@ export function bindStaticParameters(
         staticQueryParameters,
         'Static query params do not exist',
       )[value.anchor];
-      assert(anchor !== undefined, `Missing parameter: ${value.anchor}`);
-      const resolvedValue = anchor[value.field];
-      // eslint-disable-next-line eqeqeq
-      if (resolvedValue == null) {
-        throw new MissingParameterError();
-      }
+      const resolvedValue = anchor?.[value.field] ?? null;
       return {
         type: 'literal',
         value: resolvedValue as LiteralValue,

--- a/packages/zql/src/builder/error.ts
+++ b/packages/zql/src/builder/error.ts
@@ -1,1 +1,0 @@
-export class MissingParameterError extends Error {}


### PR DESCRIPTION
now that we can check against `null`, missing params is not an error. A missing param defaults to a `null` value.

To be used in permission code where the `authData` may not exist.