### PR TITLE
feat(zql): `cmpLit` function

### DIFF
--- a/packages/zql/src/query/expression.ts
+++ b/packages/zql/src/query/expression.ts
@@ -101,6 +101,19 @@ export class ExpressionBuilder<TSchema extends TableSchema> {
     return cmp(field, opOrValue, value);
   }
 
+  cmpLit(
+    left: ASTParameter | LiteralValue,
+    op: Operator,
+    right: ASTParameter | LiteralValue,
+  ): Condition {
+    return {
+      type: 'simple',
+      left: isParameter(left) ? left : {type: 'literal', value: left},
+      right: isParameter(right) ? right : {type: 'literal', value: right},
+      op,
+    };
+  }
+
   and = and;
   or = or;
   not = not;
@@ -203,7 +216,7 @@ export function cmp(
 }
 
 function isParameter(
-  value: ASTParameter | LiteralValue,
+  value: ASTParameter | LiteralValue | null,
 ): value is ASTParameter {
   return (
     typeof value === 'object' && (value as {type: string})?.type === 'static'

--- a/packages/zql/src/query/query-impl.query.test.ts
+++ b/packages/zql/src/query/query-impl.query.test.ts
@@ -865,3 +865,42 @@ test('null compare', () => {
     },
   ]);
 });
+
+test('literal filter', () => {
+  const queryDelegate = new QueryDelegateImpl();
+  addData(queryDelegate);
+
+  let rows = newQuery(queryDelegate, issueSchema)
+    .where(({cmpLit}) => cmpLit(true, '=', false))
+    .run();
+
+  expect(rows).toEqual([]);
+
+  rows = newQuery(queryDelegate, issueSchema)
+    .where(({cmpLit}) => cmpLit(true, '=', true))
+    .run();
+
+  expect(rows).toEqual([
+    {
+      closed: false,
+      description: 'description 1',
+      id: '0001',
+      ownerId: '0001',
+      title: 'issue 1',
+    },
+    {
+      closed: false,
+      description: 'description 2',
+      id: '0002',
+      ownerId: '0002',
+      title: 'issue 2',
+    },
+    {
+      closed: false,
+      description: 'description 3',
+      id: '0003',
+      ownerId: null,
+      title: 'issue 3',
+    },
+  ]);
+});


### PR DESCRIPTION
I tried `lit` on for size but it just felt more awkward.

Example:

```ts
issue.where(({cmp, lit}) => cmp(lit(22), '<', 42));

// vs

issue.where(({cmpLit}) => cmpLit(22, '<', 42));

// 1. cmpLit is less to type
// 2. cmpLit doesn't have the confusing asymmetry of one literal needing to be wrapped in `lit` but not the other
// ultimately I don't like either. Kysely looks to make you drop to raw sql for this. `where(sql`22 < 42`)`
```

cc @aboodman for feedback on `cmp(lit(x), y)` vs `cmpLit(x, y)`