### PR TITLE
chore(zero-cache): remove redundant ignore-default logic

### DIFF
--- a/packages/zero-cache/src/db/create.pg-test.ts
+++ b/packages/zero-cache/src/db/create.pg-test.ts
@@ -224,9 +224,9 @@ describe('tables/create', () => {
       CREATE TABLE "public"."users" (
          "user_id" int4 NOT NULL,
          "handle" varchar(40),
-         "rank" int8,
-         "admin" bool,
-         "bigint" int8,
+         "rank" int8 DEFAULT 1,
+         "admin" bool DEFAULT false,
+         "bigint" int8 DEFAULT '2147483648'::bigint,
          PRIMARY KEY ("user_id")
       );`,
       dstTableSpec: {
@@ -252,21 +252,21 @@ describe('tables/create', () => {
             characterMaximumLength: null,
             dataType: 'int8',
             notNull: false,
-            dflt: null,
+            dflt: '1',
           },
           admin: {
             pos: 4,
             dataType: 'bool',
             characterMaximumLength: null,
             notNull: false,
-            dflt: null,
+            dflt: 'false',
           },
           bigint: {
             pos: 5,
             characterMaximumLength: null,
             dataType: 'int8',
             notNull: false,
-            dflt: null,
+            dflt: "'2147483648'::bigint",
           },
         },
         primaryKey: ['user_id'],

--- a/packages/zero-cache/src/db/create.ts
+++ b/packages/zero-cache/src/db/create.ts
@@ -24,17 +24,9 @@ export function columnDef(spec: ColumnSpec) {
  * Constructs a `CREATE TABLE` statement for a {@link TableSpec}.
  */
 export function createTableStatement(spec: TableSpec | LiteTableSpec): string {
-  // Note: DEFAULT expressions are ignored for CREATE TABLE statements,
-  // as in that case, row values always come from the replication stream.
   const defs = Object.entries(spec.columns)
     .sort(([_a, {pos: a}], [_b, {pos: b}]) => a - b)
-    .map(
-      ([name, columnSpec]) =>
-        `${id(name)} ${columnDef({
-          ...columnSpec,
-          dflt: null,
-        })}`,
-    );
+    .map(([name, columnSpec]) => `${id(name)} ${columnDef(columnSpec)}`);
   if (spec.primaryKey) {
     defs.push(`PRIMARY KEY (${idList(spec.primaryKey)})`);
   }


### PR DESCRIPTION
The `ignore-default` column value logic was added to the pg-to-lite translation step in order to avoid default-expression parse errors (#2985). 

Remove it from the create-statement step to consolidate all of the replication policy decisions in the pg-to-lite translation step.