### PR TITLE
chore(zero-cache): include more context in PipelineDriver logging

### DIFF
--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -61,24 +61,28 @@ export default async function runWorker(parent: Worker): Promise<void> {
     id: string,
     sub: Subscription<ReplicaState>,
     drainCoordinator: DrainCoordinator,
-  ) =>
-    new ViewSyncerService(
-      lc,
+  ) => {
+    const logger = lc
+      .withContext('component', 'view-syncer')
+      .withContext('clientGroupID', id);
+    return new ViewSyncerService(
+      logger,
       id,
       config.shard.id,
       cvrDB,
       new PipelineDriver(
-        lc,
+        logger,
         new Snapshotter(lc, config.replicaFile),
         operatorStorage.createClientGroupStorage(id),
       ),
       sub,
       drainCoordinator,
     );
+  };
 
   const mutagenFactory = (id: string) =>
     new MutagenService(
-      lc,
+      lc.withContext('component', 'mutagen').withContext('clientGroupID', id),
       config.shard.id,
       id,
       upstreamDB,

--- a/packages/zero-cache/src/services/mutagen/mutagen.ts
+++ b/packages/zero-cache/src/services/mutagen/mutagen.ts
@@ -65,9 +65,7 @@ export class MutagenService implements Mutagen, Service {
     authorizationConfig: AuthorizationConfig,
   ) {
     this.id = clientGroupID;
-    this.#lc = lc
-      .withContext('component', 'mutagen')
-      .withContext('serviceID', this.id);
+    this.#lc = lc;
     this.#upstream = upstream;
     this.#shardID = shardID;
     this.#replica = new Database(this.#lc, config.replicaFile, {

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -115,9 +115,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   ) {
     this.id = clientGroupID;
     this.#shardID = shardID;
-    this.#lc = lc
-      .withContext('component', 'view-syncer')
-      .withContext('serviceID', this.id);
+    this.#lc = lc;
     this.#pipelines = pipelineDriver;
     this.#stateChanges = versionChanges;
     this.#drainCoordinator = drainCoordinator;


### PR DESCRIPTION
Also use `clientGroupID` context key instead of `serviceID`