### PR TITLE
chore(permissions): test permissions against nested paths + bugfix

### DIFF
--- a/packages/zql/src/builder/builder.ts
+++ b/packages/zql/src/builder/builder.ts
@@ -93,16 +93,14 @@ export function bindStaticParameters(
   staticQueryParameters: StaticQueryParameters | undefined,
 ) {
   const visit = (node: AST): AST => {
-    if (node.where) {
-      return {
-        ...node,
-        where: bindCondition(node.where),
-        related: node.related?.map(sq => ({
-          ...sq,
-          subquery: visit(sq.subquery),
-        })),
-      };
-    }
+    return {
+      ...node,
+      where: node.where ? bindCondition(node.where) : undefined,
+      related: node.related?.map(sq => ({
+        ...sq,
+        subquery: visit(sq.subquery),
+      })),
+    };
     return node;
   };
 


### PR DESCRIPTION
Nested paths (e.g., `query.related('relationship', q => q.related(...`) are tested to ensure read policies are applied.

Uncovered a bug where we failed to bind static parameters down `related` calls.