### PR TITLE
chore(permissions): rename `augmentQuery` to `transformQuery`

### DIFF
--- a/packages/zero-cache/src/auth/read-authorizer.query.test.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.query.test.ts
@@ -27,7 +27,7 @@ import type {
   UpdateOp,
 } from '../../../zero-protocol/src/push.js';
 import {assert} from '../../../shared/src/asserts.js';
-import {augmentQuery} from './read-authorizer.js';
+import {transformQuery} from './read-authorizer.js';
 import type {Query, QueryType} from '../../../zql/src/query/query.js';
 import {Catch} from '../../../zql/src/ivm/catch.js';
 import {buildPipeline} from '../../../zql/src/builder/builder.js';
@@ -896,7 +896,7 @@ function runReadQueryWithPermissions(
   authData: AuthData,
   query: Query<TableSchema, QueryType>,
 ) {
-  const updatedAst = must(augmentQuery(ast(query), permissions));
+  const updatedAst = must(transformQuery(ast(query), permissions));
   const pipeline = buildPipeline(updatedAst, queryDelegate, {
     authData,
     preMutationRow: undefined,

--- a/packages/zero-cache/src/auth/read-authorizer.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.ts
@@ -5,7 +5,7 @@ import {dnf} from '../../../zql/src/query/dnf.js';
 /**
  * For a given AST, apply the read-auth rules.
  */
-export function augmentQuery(
+export function transformQuery(
   query: AST,
   auth: AuthorizationConfig,
 ): AST | undefined {
@@ -26,7 +26,7 @@ export function augmentQuery(
     where: updatedWhere ? dnf(updatedWhere) : undefined,
     related: query.related
       ?.map(sq => {
-        const subquery = augmentQuery(sq.subquery, auth);
+        const subquery = transformQuery(sq.subquery, auth);
         if (subquery) {
           return {
             ...sq,
@@ -79,7 +79,7 @@ function augmentCondition(
         conditions: cond.conditions.map(c => augmentCondition(c, auth)),
       };
     case 'correlatedSubquery': {
-      const query = augmentQuery(cond.related.subquery, auth);
+      const query = transformQuery(cond.related.subquery, auth);
       const replacement = query
         ? {
             ...cond,


### PR DESCRIPTION
This better matches terminology used in the `view-syncer`