### PR TITLE
[rfc] feat(zero-cache): only allow one token per client group

### DIFF
--- a/packages/zero-cache/src/auth/error.ts
+++ b/packages/zero-cache/src/auth/error.ts
@@ -1,0 +1,1 @@
+export class AuthError extends Error {}

--- a/packages/zero-cache/src/auth/write-authorizer.ts
+++ b/packages/zero-cache/src/auth/write-authorizer.ts
@@ -47,11 +47,11 @@ type Phase = 'preMutation' | 'postMutation';
 
 export interface WriteAuthorizer {
   canPreMutation(
-    authData: JWTPayload,
+    authData: JWTPayload | undefined,
     ops: Exclude<CRUDOp, UpsertOp>[],
   ): boolean;
   canPostMutation(
-    authData: JWTPayload,
+    authData: JWTPayload | undefined,
     ops: Exclude<CRUDOp, UpsertOp>[],
   ): boolean;
   normalizeOps(ops: CRUDOp[]): Exclude<CRUDOp, UpsertOp>[];
@@ -95,7 +95,10 @@ export class WriteAuthorizerImpl implements WriteAuthorizer {
     this.#statementRunner = new StatementRunner(replica);
   }
 
-  canPreMutation(authData: JWTPayload, ops: Exclude<CRUDOp, UpsertOp>[]) {
+  canPreMutation(
+    authData: JWTPayload | undefined,
+    ops: Exclude<CRUDOp, UpsertOp>[],
+  ) {
     for (const op of ops) {
       switch (op.op) {
         case 'insert':
@@ -116,7 +119,10 @@ export class WriteAuthorizerImpl implements WriteAuthorizer {
     return true;
   }
 
-  canPostMutation(authData: JWTPayload, ops: Exclude<CRUDOp, UpsertOp>[]) {
+  canPostMutation(
+    authData: JWTPayload | undefined,
+    ops: Exclude<CRUDOp, UpsertOp>[],
+  ) {
     this.#statementRunner.beginConcurrent();
     try {
       for (const op of ops) {
@@ -195,15 +201,15 @@ export class WriteAuthorizerImpl implements WriteAuthorizer {
     });
   }
 
-  #canInsert(phase: Phase, authData: JWTPayload, op: InsertOp) {
+  #canInsert(phase: Phase, authData: JWTPayload | undefined, op: InsertOp) {
     return this.#timedCanDo(phase, 'insert', authData, op);
   }
 
-  #canUpdate(phase: Phase, authData: JWTPayload, op: UpdateOp) {
+  #canUpdate(phase: Phase, authData: JWTPayload | undefined, op: UpdateOp) {
     return this.#timedCanDo(phase, 'update', authData, op);
   }
 
-  #canDelete(phase: Phase, authData: JWTPayload, op: DeleteOp) {
+  #canDelete(phase: Phase, authData: JWTPayload | undefined, op: DeleteOp) {
     return this.#timedCanDo(phase, 'delete', authData, op);
   }
 
@@ -237,7 +243,7 @@ export class WriteAuthorizerImpl implements WriteAuthorizer {
   #timedCanDo<A extends keyof ActionOpMap>(
     phase: Phase,
     action: A,
-    authData: JWTPayload,
+    authData: JWTPayload | undefined,
     op: ActionOpMap[A],
   ) {
     const start = performance.now();
@@ -271,7 +277,7 @@ export class WriteAuthorizerImpl implements WriteAuthorizer {
   #canDo<A extends keyof ActionOpMap>(
     phase: Phase,
     action: A,
-    authData: JWTPayload,
+    authData: JWTPayload | undefined,
     op: ActionOpMap[A],
   ) {
     const rules = this.#authorizationConfig[op.tableName];
@@ -386,7 +392,7 @@ export class WriteAuthorizerImpl implements WriteAuthorizer {
   #passesPolicyGroup(
     applicableRowPolicy: Policy | undefined,
     applicableCellPolicies: Policy[],
-    authData: JWTPayload,
+    authData: JWTPayload | undefined,
     rowQuery: Query<TableSchema>,
   ) {
     if (
@@ -414,7 +420,7 @@ export class WriteAuthorizerImpl implements WriteAuthorizer {
 
   #passesPolicy(
     policy: Policy,
-    authData: JWTPayload,
+    authData: JWTPayload | undefined,
     rowQuery: Query<TableSchema>,
   ) {
     let rowQueryAst = (rowQuery as AuthQuery<TableSchema>).ast;
@@ -424,9 +430,9 @@ export class WriteAuthorizerImpl implements WriteAuthorizer {
     };
 
     const input = buildPipeline(rowQueryAst, this.#builderDelegate, {
-      authData: authData as Record<string, JSONValue>,
-      // TODO: We can remove this arg now that the pre-mutation row is got by the
-      // rowQueryAst.
+      authData: authData as undefined | Record<string, JSONValue>,
+      // TODO (mlaw): we need to resurrect `preMutationRow` and `postMutationRow`
+      // to allow writing rules to prevent mutation of a column.
       preMutationRow: undefined,
     });
     try {

--- a/packages/zero-cache/src/services/runner.test.ts
+++ b/packages/zero-cache/src/services/runner.test.ts
@@ -31,38 +31,38 @@ describe('services/runner', () => {
     (s: TestService) => s.valid,
   );
 
-  test('caching', () => {
-    const s1 = runner.getService('foo');
-    const s2 = runner.getService('bar');
-    const s3 = runner.getService('foo');
+  test('caching', async () => {
+    const [s1, s2, s3] = await Promise.all(
+      ['foo', 'bar', 'foo'].map(id => runner.getService(id, undefined)),
+    );
 
     expect(s1).toBe(s3);
     expect(s1).not.toBe(s2);
   });
 
   test('stopped', async () => {
-    const s1 = runner.getService('foo');
+    const s1 = await runner.getService('foo', undefined);
     s1.resolver.resolve();
 
     await sleep(1);
-    const s2 = runner.getService('foo');
+    const s2 = await runner.getService('foo', undefined);
     expect(s1).not.toBe(s2);
   });
 
   test('fails', async () => {
-    const s1 = runner.getService('foo');
+    const s1 = await runner.getService('foo', undefined);
     s1.resolver.reject('foo');
 
     await sleep(1);
-    const s2 = runner.getService('foo');
+    const s2 = await runner.getService('foo', undefined);
     expect(s1).not.toBe(s2);
   });
 
-  test('validity', () => {
-    const s1 = runner.getService('foo');
+  test('validity', async () => {
+    const s1 = await runner.getService('foo', undefined);
     s1.valid = false;
 
-    const s2 = runner.getService('foo');
+    const s2 = await runner.getService('foo', undefined);
     expect(s1).not.toBe(s2);
   });
 });

--- a/packages/zero-cache/src/services/runner.ts
+++ b/packages/zero-cache/src/services/runner.ts
@@ -1,20 +1,35 @@
 import {LogContext} from '@rocicorp/logger';
 import type {Service} from './service.js';
+import type {JWTPayload} from 'jose';
+import {wrapIterable} from '../../../shared/src/iterables.js';
+import {AuthError} from '../auth/error.js';
 
+export type Auth =
+  | {
+      raw: string;
+      decoded: JWTPayload;
+    }
+  | undefined;
 /**
  * Manages the creation and lifecycle of objects that implement
  * {@link Service}.
  */
 export class ServiceRunner<S extends Service> {
   readonly #lc: LogContext;
-  readonly #instances = new Map<string, S>();
-  readonly #create: (id: string) => S;
+  readonly #instances = new Map<
+    string,
+    {
+      auth: Auth;
+      service: S;
+    }
+  >();
+  readonly #create: (id: string, token: JWTPayload | undefined) => S;
   readonly #isValid: (existing: S) => boolean;
 
   constructor(
     lc: LogContext,
-    factory: (id: string) => S,
-    isValid: (existing: S) => boolean = () => true,
+    factory: (id: string, token: JWTPayload | undefined) => S,
+    isValid: (existing: S) => boolean,
   ) {
     this.#lc = lc;
     this.#create = factory;
@@ -25,13 +40,50 @@ export class ServiceRunner<S extends Service> {
    * Creates and runs the Service with the given `id`, returning
    * an existing one if it is still running a valid.
    */
-  getService(id: string): S {
+  async getService(id: string, auth: Auth): Promise<S> {
     const existing = this.#instances.get(id);
-    if (existing && this.#isValid(existing)) {
-      return existing;
+
+    // If the token in the request does not match the token for the service,
+    // we need to either reject the connection request or stop the existing
+    // service and create a new one with the new token.
+    // This is because we enforce that all clients in a client group use the same
+    // auth token. If we allow tokens to diverge then we'd need to:
+    // 1. Update the server to allow an AST to transform into many other ASTs after applying read rules
+    // 2. Somehow deal with the fact that different tabs, with the same user id, could have different permissions and thus
+    // would need different data stores.
+    if (existing && existing.auth?.raw !== auth?.raw) {
+      const newIat = auth?.decoded?.iat;
+      const existingIat = existing.auth?.decoded?.iat;
+      if (newIat === undefined) {
+        // new token is undefined but there is an existing client
+        // with a token.
+        throw new AuthError(
+          'No auth token was provided but an existing tab/window is connected with the same user id and an authentication token',
+        );
+      }
+      // existing token is undefined or new token is newer
+      if (existingIat === undefined || newIat > existingIat) {
+        // stopping the service will make it invalid and it will be recreated
+        await existing.service.stop();
+      } else if (newIat < existingIat) {
+        throw new AuthError(
+          'An existing tab/window is connected with the same user id and newer authentication token',
+        );
+      } else {
+        throw new AuthError(
+          'Cannot determine which token to take. Tokens do not match but have the same issued at time.',
+        );
+      }
     }
-    const service = this.#create(id);
-    this.#instances.set(id, service);
+
+    if (existing && this.#isValid(existing.service)) {
+      return existing.service;
+    }
+    const service = this.#create(id, auth?.decoded);
+    this.#instances.set(id, {
+      auth,
+      service,
+    });
     void service
       .run()
       .catch(e => {
@@ -52,6 +104,6 @@ export class ServiceRunner<S extends Service> {
   }
 
   getServices(): Iterable<S> {
-    return this.#instances.values();
+    return wrapIterable(this.#instances.values()).map(({service}) => service);
   }
 }

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -35,6 +35,7 @@ describe('view-syncer/pipeline-driver', () => {
       lc,
       new Snapshotter(lc, dbFile.path),
       new DatabaseStorage(storage).createClientGroupStorage('foo-client-group'),
+      undefined,
     );
 
     db = dbFile.connect(lc);

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -171,6 +171,7 @@ describe('view-syncer/service', () => {
         lc.withContext('component', 'pipeline-driver'),
         new Snapshotter(lc, replicaDbFile.path),
         operatorStorage,
+        undefined,
       ),
       stateChanges,
       drainCoordinator,

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -65,6 +65,8 @@ export interface ViewSyncer {
     ctx: SyncContext,
     msg: ChangeDesiredQueriesMessage,
   ): Promise<void>;
+
+  onStop(cb: () => void): void;
 }
 
 type ShutdownToken = {
@@ -139,6 +141,10 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         throw e;
       }
     });
+  }
+
+  onStop(cb: () => void): void {
+    void this.#stopped.promise.then(cb);
   }
 
   async run(): Promise<void> {

--- a/packages/zero-cache/src/workers/connection.ts
+++ b/packages/zero-cache/src/workers/connection.ts
@@ -1,6 +1,5 @@
 import {Lock} from '@rocicorp/lock';
 import type {LogContext} from '@rocicorp/logger';
-import type {JWTPayload} from 'jose';
 import type {CloseEvent, Data, ErrorEvent} from 'ws';
 import WebSocket from 'ws';
 import {unreachable} from '../../../shared/src/asserts.js';
@@ -42,7 +41,6 @@ export class Connection {
   readonly #viewSyncer: ViewSyncer;
   readonly #mutagen: Mutagen;
   readonly #mutationLock = new Lock();
-  readonly #authData: JWTPayload;
 
   #outboundStream: Source<Downstream> | undefined;
   #closed = false;
@@ -50,7 +48,6 @@ export class Connection {
   constructor(
     lc: LogContext,
     config: ZeroConfig,
-    authData: JWTPayload,
     viewSyncer: ViewSyncer,
     mutagen: Mutagen,
     connectParams: ConnectParams,
@@ -58,7 +55,6 @@ export class Connection {
     onClose: () => void,
   ) {
     this.#ws = ws;
-    this.#authData = authData;
     const {clientGroupID, clientID, wsID, baseCookie, schemaVersion} =
       connectParams;
     this.#clientGroupID = clientGroupID;
@@ -164,7 +160,6 @@ export class Connection {
             for (const mutation of mutations) {
               const maybeError = await this.#mutagen.processMutation(
                 mutation,
-                this.#authData,
                 schemaVersion,
               );
               if (maybeError !== undefined) {

--- a/packages/zql/src/builder/builder.ts
+++ b/packages/zql/src/builder/builder.ts
@@ -29,8 +29,8 @@ import {Take} from '../ivm/take.js';
 import {createPredicate} from './filter.js';
 
 export type StaticQueryParameters = {
-  authData: Record<string, JSONValue>;
-  preMutationRow: Row | undefined;
+  authData: Record<string, JSONValue> | undefined;
+  preMutationRow?: Row | undefined;
 };
 
 /**


### PR DESCRIPTION
Still needs tests but throwing this up to get a quick check on the approach.

This ensures that two clients within the same client group cannot connect with different tokens. 
- If a client tries to connect with an old token it is reject
- If a client connects with a newer token, all existing connections for that client group are dropped (via onStop)
- If a client connects with a different token but we cannot tell which is newer, an error is thrown and the client is rejected

The token isn't persisted so this invariant only holds across the current session.