### PR TITLE
[rfc] feat(permissions): wire read permissions into the view-syncer

### DIFF
--- a/apps/zbugs/schema.ts
+++ b/apps/zbugs/schema.ts
@@ -247,6 +247,7 @@ const authorization = defineAuthorization<AuthData, Schema>(schema, () => {
           preMutation: [allowIfIssueCreator, allowIfAdmin],
         },
         delete: [allowIfIssueCreator, allowIfAdmin],
+        // select: [allowIfAdmin],
       },
     },
     comment: {

--- a/packages/zero-cache/src/auth/read-authorizer.query.test.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.query.test.ts
@@ -1493,4 +1493,7 @@ function toIdsOnly(nodes: Node[]): any[] {
   });
 }
 
-// TODO (mlaw): test that `exists` does not provide an oracle
+// TODO (mlaw): test that `exists` does not provide an oracle.
+// TODO (mlaw): test that permission rules are not subject to permission rules.
+// TODO (mlaw): test the reactive (push) case for all the above.
+// TODO (mlaw): add an example framework to the schema to allow users to easily test their own permissions.

--- a/packages/zero-cache/src/auth/read-authorizer.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.ts
@@ -68,6 +68,10 @@ function transformQueryInternal(
     return undefined;
   }
 
+  // Rules must be added to where AFTER the where has been transformed.
+  // If they're added before transforming the where we can end up recursively
+  // adding rules. That is, adding rules to the permission rules.
+  // Permissions rules themselves are not subject to permission checks.
   const updatedWhere = addRulesToWhere(
     query.where ? transformCondition(query.where, permissionRules) : undefined,
     rowSelectRules,

--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -87,6 +87,7 @@ export default async function runWorker(
       ),
       sub,
       drainCoordinator,
+      authorization,
     );
   };
 

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -175,6 +175,7 @@ describe('view-syncer/service', () => {
       ),
       stateChanges,
       drainCoordinator,
+      {},
     );
     viewSyncerDone = vs.run();
   });


### PR DESCRIPTION
Still needs tests. Putting up to get a quick check on the approach before investing in tests. Works in zbugs (see below).


https://github.com/user-attachments/assets/1c6c9eec-0d20-480a-b2c8-9d5542dc13fb


- Transforms the received AST to an AST w/ permissions applied
- Keys this with the hash of the original AST. An AST must only have a single transformation per client group.
- Stores transformation hash so we can detect if/when it changes and hydrate a new pipeline