### PR TITLE
feat(permissions): bind params when transforming read queries

### DIFF
--- a/packages/zero-cache/src/auth/read-authorizer.query.test.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.query.test.ts
@@ -900,7 +900,7 @@ function runReadQueryWithPermissions(
   query: Query<TableSchema, QueryType>,
 ) {
   const updatedAst = bindStaticParameters(
-    must(transformQuery(ast(query), permissions)),
+    must(transformQuery(ast(query), permissions, authData)),
     {
       authData,
       preMutationRow: undefined,

--- a/packages/zql/src/builder/builder.ts
+++ b/packages/zql/src/builder/builder.ts
@@ -30,7 +30,7 @@ import {createPredicate} from './filter.js';
 
 export type StaticQueryParameters = {
   authData: Record<string, JSONValue>;
-  preMutationRow: Row | undefined;
+  preMutationRow?: Row | undefined;
 };
 
 /**


### PR DESCRIPTION
All transformations must be applied to the read queries before we hash them. Static parameter transformations were not being applied after adding read permission rules to the query, now they are.

- related: #3104