### PR TITLE
feat(zero-cache): track version of row data in separate table

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
@@ -22,6 +22,7 @@ import {
   type InstancesRow,
   type QueriesRow,
   type RowsRow,
+  type RowsVersionRow,
   setupCVRTables,
 } from './schema/cvr.js';
 import type {CVRVersion, RowID} from './schema/types.js';
@@ -35,6 +36,7 @@ describe('view-syncer/cvr', () => {
     queries: QueriesRow[];
     desires: DesiresRow[];
     rows: RowsRow[];
+    rowsVersion?: RowsVersionRow[];
   };
 
   function setInitialState(
@@ -42,6 +44,16 @@ describe('view-syncer/cvr', () => {
     state: Partial<DBState>,
   ): Promise<void> {
     return db.begin(async tx => {
+      const {instances, rowsVersion} = state;
+      if (instances && !rowsVersion) {
+        state = {
+          ...state,
+          rowsVersion: instances.map(({clientGroupID, version}) => ({
+            clientGroupID,
+            version,
+          })),
+        };
+      }
       for (const [table, rows] of Object.entries(state)) {
         for (const row of rows) {
           await tx`INSERT INTO ${tx('cvr.' + table)} ${tx(row)}`;
@@ -302,14 +314,16 @@ describe('view-syncer/cvr', () => {
       lc,
       Date.UTC(2024, 3, 24),
     );
-    expect(stats).toEqual({
-      instances: 1,
-      queries: 0,
-      desires: 0,
-      clients: 0,
-      rows: 0,
-      statements: 1,
-    });
+    expect(stats).toMatchInlineSnapshot(`
+      {
+        "clients": 0,
+        "desires": 0,
+        "instances": 1,
+        "queries": 0,
+        "rows": 0,
+        "statements": 2,
+      }
+    `);
 
     expect(cvr).toEqual({
       id: 'abc123',
@@ -637,7 +651,7 @@ describe('view-syncer/cvr', () => {
         "instances": 2,
         "queries": 7,
         "rows": 0,
-        "statements": 19,
+        "statements": 20,
       }
     `);
     expect(updated).toEqual({
@@ -959,14 +973,17 @@ describe('view-syncer/cvr', () => {
       lc,
       Date.UTC(2024, 3, 23, 1),
     );
-    expect(stats).toEqual({
-      instances: 1,
-      queries: 0,
-      desires: 0,
-      clients: 0,
-      rows: 0,
-      statements: 1,
-    });
+    expect(stats).toMatchInlineSnapshot(`
+      {
+        "clients": 0,
+        "desires": 0,
+        "instances": 1,
+        "queries": 0,
+        "rows": 0,
+        "statements": 2,
+      }
+    `);
+
     expect(updated).toEqual({
       ...cvr,
       lastActive: 1713834000000,
@@ -1247,14 +1264,16 @@ describe('view-syncer/cvr', () => {
       lc,
       Date.UTC(2024, 3, 23, 1),
     );
-    expect(stats).toEqual({
-      instances: 2,
-      queries: 1,
-      desires: 0,
-      clients: 0,
-      rows: 3,
-      statements: 4,
-    });
+    expect(stats).toMatchInlineSnapshot(`
+      {
+        "clients": 0,
+        "desires": 0,
+        "instances": 2,
+        "queries": 1,
+        "rows": 3,
+        "statements": 5,
+      }
+    `);
 
     expect(await cvrStore.catchupConfigPatches(lc, {stateVersion: '189'}, cvr))
       .toMatchInlineSnapshot(`
@@ -1653,14 +1672,16 @@ describe('view-syncer/cvr', () => {
       lc,
       Date.UTC(2024, 3, 23, 1),
     );
-    expect(stats).toEqual({
-      instances: 2,
-      queries: 1,
-      desires: 0,
-      clients: 0,
-      rows: 2,
-      statements: 4,
-    });
+    expect(stats).toMatchInlineSnapshot(`
+      {
+        "clients": 0,
+        "desires": 0,
+        "instances": 2,
+        "queries": 1,
+        "rows": 2,
+        "statements": 5,
+      }
+    `);
 
     expect(await cvrStore.catchupConfigPatches(lc, {stateVersion: '189'}, cvr))
       .toMatchInlineSnapshot(`
@@ -2108,14 +2129,16 @@ describe('view-syncer/cvr', () => {
       lc,
       Date.UTC(2024, 3, 23, 1),
     );
-    expect(stats).toEqual({
-      instances: 2,
-      queries: 2,
-      desires: 0,
-      clients: 0,
-      rows: 2,
-      statements: 5,
-    });
+    expect(stats).toMatchInlineSnapshot(`
+      {
+        "clients": 0,
+        "desires": 0,
+        "instances": 2,
+        "queries": 2,
+        "rows": 2,
+        "statements": 6,
+      }
+    `);
 
     expect(await cvrStore.catchupConfigPatches(lc, {stateVersion: '189'}, cvr))
       .toMatchInlineSnapshot(`
@@ -2521,14 +2544,16 @@ describe('view-syncer/cvr', () => {
       lc,
       Date.UTC(2024, 3, 23, 1),
     );
-    expect(stats).toEqual({
-      instances: 2,
-      queries: 1,
-      desires: 0,
-      clients: 0,
-      rows: 2,
-      statements: 4,
-    });
+    expect(stats).toMatchInlineSnapshot(`
+      {
+        "clients": 0,
+        "desires": 0,
+        "instances": 2,
+        "queries": 1,
+        "rows": 2,
+        "statements": 5,
+      }
+    `);
 
     expect(await cvrStore.catchupConfigPatches(lc, {stateVersion: '189'}, cvr))
       .toMatchInlineSnapshot(`
@@ -3002,14 +3027,16 @@ describe('view-syncer/cvr', () => {
       lc,
       Date.UTC(2024, 3, 23, 1),
     );
-    expect(stats).toEqual({
-      instances: 1,
-      queries: 0,
-      desires: 0,
-      clients: 0,
-      rows: 0,
-      statements: 1,
-    });
+    expect(stats).toMatchInlineSnapshot(`
+      {
+        "clients": 0,
+        "desires": 0,
+        "instances": 1,
+        "queries": 0,
+        "rows": 0,
+        "statements": 2,
+      }
+    `);
 
     expect(await cvrStore.catchupConfigPatches(lc, {stateVersion: '189'}, cvr))
       .toMatchInlineSnapshot(`
@@ -3246,14 +3273,16 @@ describe('view-syncer/cvr', () => {
       lc,
       Date.UTC(2024, 3, 23, 1),
     );
-    expect(stats).toEqual({
-      instances: 2,
-      queries: 0,
-      desires: 0,
-      clients: 0,
-      rows: 1,
-      statements: 3,
-    });
+    expect(stats).toMatchInlineSnapshot(`
+      {
+        "clients": 0,
+        "desires": 0,
+        "instances": 2,
+        "queries": 0,
+        "rows": 1,
+        "statements": 4,
+      }
+    `);
 
     // Verify round tripping.
     const cvrStore2 = new CVRStore(lc, db, 'abc123');

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -128,7 +128,10 @@ export class CVRUpdater {
     const start = Date.now();
 
     this.#setLastActive(lastActive);
-    const stats = await this._cvrStore.flush(this._orig.version);
+    const stats = await this._cvrStore.flush(
+      this._orig.version,
+      this._cvr.version,
+    );
 
     lc.debug?.(
       `flushed CVR ${JSON.stringify(stats)} in (${Date.now() - start} ms)`,

--- a/packages/zero-cache/src/services/view-syncer/schema/init.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/init.ts
@@ -1,11 +1,16 @@
 import type {LogContext} from '@rocicorp/logger';
+import type {PendingQuery, Row} from 'postgres';
 import {
   runSchemaMigrations,
   type IncrementalMigrationMap,
   type Migration,
 } from '../../../db/migration.js';
-import type {PostgresDB, PostgresTransaction} from '../../../types/pg.js';
-import {PG_SCHEMA, setupCVRTables} from './cvr.js';
+import type {PostgresDB} from '../../../types/pg.js';
+import {
+  CREATE_CVR_ROWS_VERSION_TABLE,
+  PG_SCHEMA,
+  setupCVRTables,
+} from './cvr.js';
 
 const setupMigration: Migration = {
   migrateSchema: setupCVRTables,
@@ -17,7 +22,8 @@ export async function initViewSyncerSchema(
   db: PostgresDB,
 ): Promise<void> {
   const schemaVersionMigrationMap: IncrementalMigrationMap = {
-    2: {migrateSchema: migrateV1toV2},
+    2: migrateV1toV2,
+    3: migrateV2ToV3,
   };
 
   await runSchemaMigrations(
@@ -30,6 +36,31 @@ export async function initViewSyncerSchema(
   );
 }
 
-async function migrateV1toV2(_: LogContext, tx: PostgresTransaction) {
-  await tx`ALTER TABLE cvr.instances ADD "replicaVersion" TEXT`;
-}
+const migrateV1toV2: Migration = {
+  migrateSchema: async (_, tx) => {
+    await tx`ALTER TABLE cvr.instances ADD "replicaVersion" TEXT`;
+  },
+};
+
+const migrateV2ToV3: Migration = {
+  migrateSchema: async (_, tx) => {
+    await tx.unsafe(CREATE_CVR_ROWS_VERSION_TABLE);
+  },
+
+  /** Populates the cvr.rowsVersion table with versions from cvr.instances. */
+  migrateData: async (lc, tx) => {
+    const pending: PendingQuery<Row[]>[] = [];
+    for await (const versions of tx<{clientGroupID: string; version: string}[]>`
+      SELECT "clientGroupID", "version" FROM cvr.instances`.cursor(5000)) {
+      for (const version of versions) {
+        pending.push(
+          tx`INSERT INTO cvr."rowsVersion" ${tx(version)} 
+               ON CONFLICT ("clientGroupID")
+               DO UPDATE SET ${tx(version)}`.execute(),
+        );
+      }
+    }
+    lc.info?.(`initializing rowsVersion for ${pending.length} cvrs`);
+    await Promise.all(pending);
+  },
+};


### PR DESCRIPTION
Introduces a new `cvr.rowsVersion` table in the `cvr` schema that tracks the version of the data in the `cvr.rows` table.

Currently, this is updated transactionally with other cvr updates so there is no change in behavior yet.

This will facilitate updating row data asynchronously and knowing when the information in the database is up to date, or awaiting catchup.

There is logic in the `cvrStore.load()` path to wait (up to a maximum limit) for a CVR to catch up if the row data is behind. This will only come into play once asynchronous writes are added. Currently, rows data is still atomically updated with the overall cvr data.