### PR TITLE
feat(zero-cache): CVR ownership coordination

### DIFF
--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -77,6 +77,7 @@ export default async function runWorker(
       .withContext('clientGroupID', id);
     return new ViewSyncerService(
       logger,
+      must(config.taskID, 'main must set --task-id'),
       id,
       config.shard.id,
       cvrDB,

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -120,6 +120,7 @@ export class CVRUpdater {
 
   async flush(
     lc: LogContext,
+    lastConnectTime: number,
     lastActive = Date.now(),
   ): Promise<{
     cvr: CVRSnapshot;
@@ -131,6 +132,7 @@ export class CVRUpdater {
     const stats = await this._cvrStore.flush(
       this._orig.version,
       this._cvr.version,
+      lastConnectTime,
     );
 
     lc.debug?.(
@@ -277,9 +279,9 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
     ];
   }
 
-  flush(lc: LogContext, lastActive = Date.now()) {
+  flush(lc: LogContext, lastConnectTime: number, lastActive = Date.now()) {
     // TODO: Add cleanup of no-longer-desired got queries and constituent rows.
-    return super.flush(lc, lastActive);
+    return super.flush(lc, lastConnectTime, lastActive);
   }
 }
 

--- a/packages/zero-cache/src/services/view-syncer/schema/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/cvr.ts
@@ -23,6 +23,8 @@ export type InstancesRow = {
   version: string;
   lastActive: number;
   replicaVersion: string | null;
+  owner: string | null;
+  grantedAt: number | null;
 };
 
 const CREATE_CVR_INSTANCES_TABLE = `
@@ -30,7 +32,9 @@ CREATE TABLE cvr.instances (
   "clientGroupID"  TEXT PRIMARY KEY,
   "version"        TEXT NOT NULL,        -- Sortable representation of CVRVersion, e.g. "5nbqa2w:09"
   "lastActive"     TIMESTAMPTZ NOT NULL, -- For garbage collection
-  "replicaVersion" TEXT                  -- Identifies the replica (i.e. initial-sync point) from which the CVR data comes.
+  "replicaVersion" TEXT,                 -- Identifies the replica (i.e. initial-sync point) from which the CVR data comes.
+  "owner"          TEXT,                 -- The ID of the task / server that has been granted ownership of the CVR.
+  "grantedAt"      TIMESTAMPTZ           -- The time at which the current owner was last granted ownership (most recent connection time).
 );
 `;
 

--- a/packages/zero-cache/src/services/view-syncer/schema/init.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/init.ts
@@ -24,6 +24,7 @@ export async function initViewSyncerSchema(
   const schemaVersionMigrationMap: IncrementalMigrationMap = {
     2: migrateV1toV2,
     3: migrateV2ToV3,
+    4: migrateV3ToV4,
   };
 
   await runSchemaMigrations(
@@ -62,5 +63,12 @@ const migrateV2ToV3: Migration = {
     }
     lc.info?.(`initializing rowsVersion for ${pending.length} cvrs`);
     await Promise.all(pending);
+  },
+};
+
+const migrateV3ToV4: Migration = {
+  migrateSchema: async (_, tx) => {
+    await tx`ALTER TABLE cvr.instances ADD "owner" TEXT`;
+    await tx`ALTER TABLE cvr.instances ADD "grantedAt" TIMESTAMPTZ`;
   },
 };


### PR DESCRIPTION
### CVR ownership schema

Adds two columns to the `cvr.instances` table:
* `owner` is the `--task-id` (e.g. AWS TaskARN) of the current zero-cache operating on the CVR
* `grantedAt` is the latest time at which ownership was "granted" to this task

For the latter, the latest connection time is used, effectively making the AWS loadbalancer the arbiter of which task "owns" the CVR.

* For multi-node mode to work, session-stickiness (i.e. cookies) is still necessary to avoid bouncing a user back and forth.
* However, this coordination still has an important role In single-node mode. During a rolling restart, this change will force an ownership handoff when a second tab connects to the new task.
* This will facilitate upcoming asynchronous row updates by allowing the old and new tasks to gracefully coordinate and flush / await pending changes.

### Coordination and signaling

The `owner` and `grantedAt` fields are examined (1) when a CVR is loaded and (2) updated when changes are flushed.

Note that for the latter the new ownership columns are examined _in addition to_ the existing version check used to detect concurrent modifications. By adding these new checks, it is possible for a new task to claim ownership of the CVR without necessarily changing its contents. This will allow the previous owner to notice the change, flush any asynchronous updates (coming soon), and relinquish control of the CVR.