### PR TITLE
feat(zero-cache): async row-record CVR flushes

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr-store.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.pg-test.ts
@@ -1,29 +1,45 @@
-import {beforeEach, describe, expect, test} from 'vitest';
+import {beforeEach, describe, expect, test, vi, type Mock} from 'vitest';
+import {CustomKeyMap} from '../../../../shared/src/custom-key-map.js';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.js';
 import {sleep} from '../../../../shared/src/sleep.js';
 import {testDBs} from '../../test/db.js';
+import {versionToLexi} from '../../types/lexi-version.js';
 import type {PostgresDB} from '../../types/pg.js';
+import {rowIDString, type RowID} from '../../types/row-key.js';
 import {CVRStore, OwnershipError} from './cvr-store.js';
-import type {CVRSnapshot} from './cvr.js';
-import {type RowsRow, setupCVRTables} from './schema/cvr.js';
+import {
+  CVRQueryDrivenUpdater,
+  type CVRSnapshot,
+  type RowUpdate,
+} from './cvr.js';
+import {setupCVRTables, type RowsRow} from './schema/cvr.js';
 import type {CVRVersion} from './schema/types.js';
 
 describe('view-syncer/cvr-store', () => {
   const lc = createSilentLogContext();
   let db: PostgresDB;
   let store: CVRStore;
+  // vi.useFakeTimers() does not play well with the postgres client.
+  // Inject a manual mock instead.
+  let setTimeoutFn: Mock<typeof setTimeout>;
 
   const TASK_ID = 'my-task';
   const CVR_ID = 'my-cvr';
   const CONNECT_TIME = Date.UTC(2024, 10, 22);
+  const ON_FAILURE = (e: unknown) => {
+    throw e;
+  };
 
   beforeEach(async () => {
     db = await testDBs.create('view_syncer_cvr_schema');
     await db.begin(tx => setupCVRTables(lc, tx));
     await db.unsafe(`
-    INSERT INTO cvr.instances("clientGroupID", version, "lastActive")
-      VALUES('${CVR_ID}', '01', '2024-09-04');
-    INSERT INTO cvr."rowsVersion"("clientGroupID", version)
+    INSERT INTO cvr.instances ("clientGroupID", version, "lastActive", "replicaVersion")
+      VALUES('${CVR_ID}', '01', '2024-09-04', '01');
+    INSERT INTO cvr.queries ("clientGroupID", "queryHash", "clientAST", 
+                             "patchVersion", "transformationHash", "transformationVersion")
+      VALUES('${CVR_ID}', 'foo', '{"table":"issues"}', '01', 'foo-transformed', '01');
+    INSERT INTO cvr."rowsVersion" ("clientGroupID", version)
       VALUES('${CVR_ID}', '01');
     INSERT INTO cvr.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
       VALUES('${CVR_ID}', '', 'issues', '{"id":"1"}', '01', '01', NULL);
@@ -52,7 +68,19 @@ describe('view-syncer/cvr-store', () => {
     INSERT INTO cvr.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
       VALUES('${CVR_ID}', '', 'issues', '{"id":"12"}', '01', '03', '{"foo":2,"bar":3}');
       `);
-    store = new CVRStore(lc, db, TASK_ID, CVR_ID, 10, 5);
+
+    setTimeoutFn = vi.fn();
+    store = new CVRStore(
+      lc,
+      db,
+      TASK_ID,
+      CVR_ID,
+      ON_FAILURE,
+      10,
+      5,
+      DEFERRED_ROW_LIMIT,
+      setTimeoutFn as unknown as typeof setTimeout,
+    );
   });
 
   test('wait for row catchup', async () => {
@@ -95,7 +123,7 @@ describe('view-syncer/cvr-store', () => {
           "grantedAt": 1732233600000,
           "lastActive": 1725408000000,
           "owner": "my-task",
-          "replicaVersion": null,
+          "replicaVersion": "01",
           "version": "02",
         },
       ]
@@ -118,7 +146,7 @@ describe('view-syncer/cvr-store', () => {
           "grantedAt": 1732233600001,
           "lastActive": 1725408000000,
           "owner": "other-task",
-          "replicaVersion": null,
+          "replicaVersion": "01",
           "version": "01",
         },
       ]
@@ -291,5 +319,191 @@ describe('view-syncer/cvr-store', () => {
         },
       ]
     `);
+  });
+
+  const DEFERRED_ROW_LIMIT = 5;
+
+  test('deferred row updates', async () => {
+    const now = Date.UTC(2024, 10, 23);
+    let cvr = await store.load(CONNECT_TIME);
+
+    // 12 rows set up in beforeEach().
+    expect(await db`SELECT COUNT(*) FROM cvr.rows`).toEqual([{count: 12n}]);
+
+    let updater = new CVRQueryDrivenUpdater(store, cvr, '02', '01');
+    updater.trackQueries(
+      lc,
+      [{id: 'foo', transformationHash: 'foo-transformed'}],
+      [],
+    );
+
+    let rows = new CustomKeyMap<RowID, RowUpdate>(rowIDString);
+    for (let i = 0; i < DEFERRED_ROW_LIMIT + 1; i++) {
+      const id = String(20 + i);
+      rows.set(
+        {schema: 'public', table: 'issues', rowKey: {id}},
+        {version: '02', contents: {id}, refCounts: {foo: 1}},
+      );
+    }
+    await updater.received(lc, rows);
+    cvr = (await updater.flush(lc, CONNECT_TIME, now)).cvr;
+
+    expect(await db`SELECT * FROM cvr.instances`).toMatchInlineSnapshot(`
+      Result [
+        {
+          "clientGroupID": "my-cvr",
+          "grantedAt": 1732233600000,
+          "lastActive": 1732320000000,
+          "owner": "my-task",
+          "replicaVersion": "01",
+          "version": "02",
+        },
+      ]
+    `);
+
+    // rowsVersion === '01' (flush deferred).
+    expect(await db`SELECT * FROM cvr."rowsVersion"`).toMatchInlineSnapshot(`
+      Result [
+        {
+          "clientGroupID": "my-cvr",
+          "version": "01",
+        },
+      ]
+    `);
+
+    // Still only 12 rows.
+    expect(await db`SELECT COUNT(*) FROM cvr.rows`).toEqual([{count: 12n}]);
+
+    // Flush was scheduled.
+    expect(setTimeoutFn).toHaveBeenCalledOnce();
+
+    // Before flushing, simulate another CVR update, this time within
+    // the DEFERRED_LIMIT. It should still be deferred because there
+    // are now pending rows waiting to be flushed.
+    updater = new CVRQueryDrivenUpdater(store, cvr, '03', '01');
+    updater.trackQueries(
+      lc,
+      [{id: 'foo', transformationHash: 'foo-transformed'}],
+      [],
+    );
+
+    rows = new CustomKeyMap<RowID, RowUpdate>(rowIDString);
+    for (let i = 0; i < DEFERRED_ROW_LIMIT - 1; i++) {
+      const id = String(40 + i);
+      rows.set(
+        {schema: 'public', table: 'issues', rowKey: {id}},
+        {version: '03', contents: {id}, refCounts: {foo: 1}},
+      );
+    }
+    await updater.received(lc, rows);
+    await updater.flush(lc, CONNECT_TIME, now);
+
+    expect(await db`SELECT * FROM cvr.instances`).toMatchInlineSnapshot(`
+      Result [
+        {
+          "clientGroupID": "my-cvr",
+          "grantedAt": 1732233600000,
+          "lastActive": 1732320000000,
+          "owner": "my-task",
+          "replicaVersion": "01",
+          "version": "03",
+        },
+      ]
+    `);
+
+    // rowsVersion === '01' (flush deferred).
+    expect(await db`SELECT * FROM cvr."rowsVersion"`).toMatchInlineSnapshot(`
+      Result [
+        {
+          "clientGroupID": "my-cvr",
+          "version": "01",
+        },
+      ]
+    `);
+
+    // Still only 12 rows.
+    expect(await db`SELECT COUNT(*) FROM cvr.rows`).toEqual([{count: 12n}]);
+
+    // Now run the flush logic.
+    await setTimeoutFn.mock.calls[0][0]();
+
+    // rowsVersion === '03' (flushed).
+    expect(await db`SELECT * FROM cvr."rowsVersion"`).toMatchInlineSnapshot(`
+      Result [
+        {
+          "clientGroupID": "my-cvr",
+          "version": "03",
+        },
+      ]
+    `);
+
+    // 12 + 6 + 4.
+    expect(await db`SELECT COUNT(*) FROM cvr.rows`).toEqual([{count: 22n}]);
+  });
+
+  test('deferred row stress test', async () => {
+    const now = Date.UTC(2024, 10, 23);
+    let cvr = await store.load(CONNECT_TIME);
+
+    // Use real setTimeout.
+    setTimeoutFn.mockImplementation((cb, ms) => setTimeout(cb, ms));
+
+    // 12 rows set up in beforeEach().
+    expect(await db`SELECT COUNT(*) FROM cvr.rows`).toEqual([{count: 12n}]);
+
+    // Commit 30 flushes of 10 rows each.
+    for (let i = 20; i < 320; i += 10) {
+      const version = versionToLexi(i);
+      const updater = new CVRQueryDrivenUpdater(store, cvr, version, '01');
+      updater.trackQueries(
+        lc,
+        [{id: 'foo', transformationHash: 'foo-transformed'}],
+        [],
+      );
+
+      const rows = new CustomKeyMap<RowID, RowUpdate>(rowIDString);
+      for (let j = 0; j < 10; j++) {
+        const id = String(i + j);
+        rows.set(
+          {schema: 'public', table: 'issues', rowKey: {id}},
+          {version, contents: {id}, refCounts: {foo: 1}},
+        );
+      }
+      await updater.received(lc, rows);
+      cvr = (await updater.flush(lc, CONNECT_TIME, now)).cvr;
+
+      // add a random sleep for varying the asynchronicity
+      // between the CVR flush and the async row flush.
+      await sleep(Math.random() * 1);
+    }
+
+    expect(await db`SELECT * FROM cvr.instances`).toMatchInlineSnapshot(`
+      Result [
+        {
+          "clientGroupID": "my-cvr",
+          "grantedAt": 1732233600000,
+          "lastActive": 1732320000000,
+          "owner": "my-task",
+          "replicaVersion": "01",
+          "version": "18m",
+        },
+      ]
+    `);
+
+    // Should block until all pending rows are flushed.
+    await store.flushed();
+
+    // rowsVersion should match cvr.instances version
+    expect(await db`SELECT * FROM cvr."rowsVersion"`).toMatchInlineSnapshot(`
+            Result [
+              {
+                "clientGroupID": "my-cvr",
+                "version": "18m",
+              },
+            ]
+          `);
+
+    // 12 + (30 * 10)
+    expect(await db`SELECT COUNT(*) FROM cvr.rows`).toEqual([{count: 312n}]);
   });
 });

--- a/packages/zero-cache/src/services/view-syncer/cvr-store.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.ts
@@ -1,5 +1,5 @@
 import type {LogContext} from '@rocicorp/logger';
-import {resolver} from '@rocicorp/resolver';
+import {resolver, type Resolver} from '@rocicorp/resolver';
 import type {MaybeRow, PendingQuery, Row} from 'postgres';
 import {assert} from '../../../../shared/src/asserts.js';
 import {CustomKeyMap} from '../../../../shared/src/custom-key-map.js';
@@ -8,6 +8,7 @@ import {
   type ReadonlyJSONValue,
 } from '../../../../shared/src/json.js';
 import {must} from '../../../../shared/src/must.js';
+import {promiseVoid} from '../../../../shared/src/resolved-promises.js';
 import {sleep} from '../../../../shared/src/sleep.js';
 import {astSchema} from '../../../../zero-protocol/src/ast.js';
 import {ErrorKind} from '../../../../zero-protocol/src/error.js';
@@ -40,6 +41,7 @@ import {
   type RowRecord,
   versionFromString,
   versionString,
+  versionToNullableCookie,
 } from './schema/types.js';
 
 type NotNull<T> = T extends null ? never : T;
@@ -50,17 +52,91 @@ export type CVRFlushStats = {
   desires: number;
   clients: number;
   rows: number;
+  rowsDeferred: number;
   statements: number;
 };
 
+/**
+ * The RowRecordCache is an in-memory cache of the `cvr.rows` tables that
+ * operates as both a write-through and write-back cache.
+ *
+ * For "small" CVR updates (i.e. zero or small numbers of rows) the
+ * RowRecordCache operates as write-through, executing commits in
+ * {@link executeRowUpdates()} before they are {@link apply}-ed to the
+ * in-memory state.
+ *
+ * For "large" CVR updates (i.e. with many rows), the cache switches to a
+ * write-back mode of operation, in which {@link executeRowUpdates()} is a
+ * no-op, and {@link apply()} initiates a background task to flush the pending
+ * row changes to the store. This allows the client poke to be completed and
+ * committed on the client without waiting for the heavyweight operation of
+ * committing the row records to the CVR store.
+ *
+ * Note that when the cache is in write-back mode, all updates become
+ * write-back (i.e. asynchronously flushed) until the pending update queue is
+ * fully flushed. This is required because updates must be applied in version
+ * order. As with all pending work systems in zero-cache, multiple pending
+ * updates are coalesced to reduce buildup of work.
+ *
+ * ### High level consistency
+ *
+ * Note that the above caching scheme only applies to the row data in `cvr.rows`
+ * and corresponding `cvr.rowsVersion` tables. CVR metadata and query
+ * information, on the other hand, are always committed before completing the
+ * client poke. In this manner, the difference between the `version` column in
+ * `cvr.instances` and the analogous column in `cvr.rowsVersion` determines
+ * whether the data in the store is consistent, or whether it is awaiting a
+ * pending update.
+ *
+ * The logic in {@link CVRStore.load()} takes this into account by loading both
+ * the `cvr.instances` version and the `cvr.rowsVersion` version and checking
+ * if they are in sync, waiting for a configurable delay until they are.
+ *
+ * ### Eventual conversion
+ *
+ * In the event of a continual stream of mutations (e.g. an animation-style
+ * app), it is conceivable that the row record data be continually behind
+ * the CVR metadata. In order to effect eventual convergence, a new view-syncer
+ * signals the current view-syncer to stop updating by writing new `owner`
+ * information to the `cvr.instances` row. This effectively stops the mutation
+ * processing (in {@link CVRStore.#checkVersionAndOwnership}) so that the row
+ * data can eventually catch up, allowing the new view-syncer to take over.
+ *
+ * Of course, there is the pathological situation in which a view-syncer
+ * process crashes before the pending row updates are flushed. In this case,
+ * the wait timeout will elapse and the CVR considered invalid.
+ */
 class RowRecordCache {
+  // The state in the #cache is always in sync with the CVR metadata
+  // (i.e. cvr.instances). It may contain information that has not yet
+  // been flushed to cvr.rows.
   #cache: Promise<CustomKeyMap<RowID, RowRecord>> | undefined;
+  readonly #lc: LogContext;
   readonly #db: PostgresDB;
   readonly #cvrID: string;
+  readonly #failService: (e: unknown) => void;
+  readonly #deferredRowFlushThreshold: number;
+  readonly #setTimeout: typeof setTimeout;
 
-  constructor(db: PostgresDB, cvrID: string) {
+  // Write-back cache state.
+  readonly #pending = new CustomKeyMap<RowID, RowRecord>(rowIDString);
+  #pendingRowsVersion: CVRVersion | null = null;
+  #flushing: Resolver<void> | null = null;
+
+  constructor(
+    lc: LogContext,
+    db: PostgresDB,
+    cvrID: string,
+    failService: (e: unknown) => void,
+    deferredRowFlushThreshold = 100,
+    setTimeoutFn = setTimeout,
+  ) {
+    this.#lc = lc;
     this.#db = db;
     this.#cvrID = cvrID;
+    this.#failService = failService;
+    this.#deferredRowFlushThreshold = deferredRowFlushThreshold;
+    this.#setTimeout = setTimeoutFn;
   }
 
   async #ensureLoaded(): Promise<CustomKeyMap<RowID, RowRecord>> {
@@ -93,7 +169,26 @@ class RowRecordCache {
     return this.#ensureLoaded();
   }
 
-  async flush(rowRecords: Iterable<RowRecord>) {
+  /**
+   * Applies the `rowRecords` corresponding to the `rowsVersion`
+   * to the cache, indicating whether the corresponding updates
+   * (generated by {@link executeRowUpdates}) were `flushed`.
+   *
+   * If `flushed` is false, the RowRecordCache will flush the records
+   * asynchronously.
+   *
+   * Note that `apply()` indicates that the CVR metadata associated with
+   * the `rowRecords` was successfully committed, which essentially means
+   * that this process has the unconditional right (and responsibility) of
+   * following up with a flush of the `rowRecords`. In particular, the
+   * commit of row records are not conditioned on the version or ownership
+   * columns of the `cvr.instances` row.
+   */
+  async apply(
+    rowRecords: Iterable<RowRecord>,
+    rowsVersion: CVRVersion,
+    flushed: boolean,
+  ) {
     const cache = await this.#ensureLoaded();
     for (const row of rowRecords) {
       if (row.refCounts === null) {
@@ -101,10 +196,71 @@ class RowRecordCache {
       } else {
         cache.set(row.id, row);
       }
+      if (!flushed) {
+        this.#pending.set(row.id, row);
+      }
+    }
+    this.#pendingRowsVersion = rowsVersion;
+    // Initiate a flush if not already flushing.
+    if (!flushed && this.#flushing === null) {
+      this.#flushing = resolver();
+      this.#setTimeout(() => this.#flush(), 0);
     }
   }
 
+  async #flush() {
+    const flushing = must(this.#flushing);
+    try {
+      while (this.#pending.size) {
+        const start = Date.now();
+
+        const {rows, rowsVersion} = await this.#db.begin(tx => {
+          // Note: This code block is synchronous, guaranteeing that the
+          // #pendingRowsVersion is consistent with the #pending rows.
+          const rows = this.#pending.size;
+          const rowsVersion = must(this.#pendingRowsVersion);
+          this.executeRowUpdates(
+            tx,
+            rowsVersion,
+            [...this.#pending.values()],
+            'force',
+          );
+          this.#pending.clear();
+          return {rows, rowsVersion};
+        });
+        this.#lc.debug?.(
+          `flushed ${rows} rows to ${versionString(rowsVersion)} (${
+            Date.now() - start
+          } ms)`,
+        );
+        // Note: apply() may have called while the transaction was committing,
+        //       which will result in looping to commit the next #pending batch.
+      }
+      this.#lc.debug?.(
+        `pending rows flushed to ${versionToNullableCookie(
+          this.#pendingRowsVersion,
+        )}`,
+      );
+      flushing.resolve();
+      this.#flushing = null;
+    } catch (e) {
+      flushing.reject(e);
+      this.#failService(e);
+    }
+  }
+
+  /**
+   * Returns a promise that resolves when all outstanding row-records
+   * have been committed.
+   */
+  flushed(): Promise<void> {
+    return this.#flushing ? this.#flushing.promise : promiseVoid;
+  }
+
   clear() {
+    // Note: Only the #cache is cleared. #pending updates, on the other hand,
+    // comprise canonical (i.e. already flushed) data and must be flushed
+    // even if the snapshot of the present state (the #cache) is cleared.
     this.#cache = undefined;
   }
 
@@ -124,6 +280,13 @@ class RowRecordCache {
     const end = versionString(upToCVR.version);
     lc.debug?.(`scanning row patches for clients from ${start}`);
 
+    // Before accessing the CVR db, pending row records must be flushed.
+    // Note that because catchupRowPatches() is called from within the
+    // view syncer lock, this flush is guaranteed to complete since no
+    // new CVR updates can happen while the lock is held.
+    await this.flushed();
+    const flushMs = Date.now() - startMs;
+
     const query =
       excludeQueryHashes.length === 0
         ? sql<RowsRow[]>`SELECT * FROM cvr.rows
@@ -139,14 +302,25 @@ class RowRecordCache {
 
     yield* query.cursor(10000);
 
-    lc.debug?.(`finished row catchup (${Date.now() - startMs} ms)`);
+    const totalMs = Date.now() - startMs;
+    lc.debug?.(
+      `finished row catchup (flush: ${flushMs} ms, total: ${totalMs} ms)`,
+    );
   }
 
   executeRowUpdates(
     tx: PostgresTransaction,
     version: CVRVersion,
     rowRecordsToFlush: RowRecord[],
+    mode: 'allow-defer' | 'force',
   ): PendingQuery<Row[]>[] {
+    if (
+      mode === 'allow-defer' && // defer if there are pending updates or
+      (this.#pending.size > 0 || // the new batch is above the limit.
+        rowRecordsToFlush.length > this.#deferredRowFlushThreshold)
+    ) {
+      return [];
+    }
     const rowRecordRows = rowRecordsToFlush.map(r =>
       rowRecordToRowsRow(this.#cvrID, r),
     );
@@ -242,14 +416,24 @@ export class CVRStore {
     db: PostgresDB,
     taskID: string,
     cvrID: string,
+    failService: (e: unknown) => void,
     loadAttemptIntervalMs = LOAD_ATTEMPT_INTERVAL_MS,
     maxLoadAttempts = MAX_LOAD_ATTEMPTS,
+    deferredRowFlushThreshold = 100, // somewhat arbitrary
+    setTimeoutFn = setTimeout,
   ) {
     this.#lc = lc;
     this.#db = db;
     this.#taskID = taskID;
     this.#id = cvrID;
-    this.#rowCache = new RowRecordCache(db, cvrID);
+    this.#rowCache = new RowRecordCache(
+      lc,
+      db,
+      cvrID,
+      failService,
+      deferredRowFlushThreshold,
+      setTimeoutFn,
+    );
     this.#loadAttemptIntervalMs = loadAttemptIntervalMs;
     this.#maxLoadAttempts = maxLoadAttempts;
   }
@@ -637,7 +821,8 @@ export class CVRStore {
     const result = await tx<
       Pick<InstancesRow, 'version' | 'owner' | 'grantedAt'>[]
     >`SELECT "version", "owner", "grantedAt" FROM cvr.instances 
-        WHERE "clientGroupID" = ${this.#id}`.execute(); // Note: execute() immediately to send the query before others.
+        WHERE "clientGroupID" = ${this.#id}
+        FOR UPDATE`.execute(); // Note: execute() immediately to send the query before others.
     const {version, owner, grantedAt} =
       result.length > 0
         ? result[0]
@@ -665,6 +850,7 @@ export class CVRStore {
       desires: 0,
       clients: 0,
       rows: 0,
+      rowsDeferred: 0,
       statements: 0,
     };
     const existingRowRecords = await this.getRowRecords();
@@ -680,10 +866,15 @@ export class CVRStore {
         );
       },
     );
-    stats.rows = rowRecordsToFlush.length;
-    await this.#db.begin(tx => {
+    const rowsFlushed = await this.#db.begin(async tx => {
       const pipelined: Promise<unknown>[] = [
-        // Read the version and ownership to detect concurrent writes.
+        // #checkVersionAndOwnership() executes a `SELECT ... FOR UPDATE`
+        // query to acquire a row-level lock so that version-updating
+        // transactions are effectively serialized per cvr.instance.
+        //
+        // Note that `rowsVersion` updates, on the other hand, are not subject
+        // to this lock and can thus commit / be-committed independently of
+        // cvr.instances.
         this.#checkVersionAndOwnership(
           tx,
           expectedCurrentVersion,
@@ -705,15 +896,23 @@ export class CVRStore {
         tx,
         newVersion,
         rowRecordsToFlush,
+        'allow-defer',
       );
       pipelined.push(...rowUpdates);
       stats.statements += rowUpdates.length;
 
       // Make sure Errors thrown by pipelined statements
       // are propagated up the stack.
-      return Promise.all(pipelined);
+      await Promise.all(pipelined);
+
+      if (rowUpdates.length === 0) {
+        stats.rowsDeferred = rowRecordsToFlush.length;
+        return false;
+      }
+      stats.rows = rowRecordsToFlush.length;
+      return true;
     });
-    await this.#rowCache.flush(rowRecordsToFlush);
+    await this.#rowCache.apply(rowRecordsToFlush, newVersion, rowsFlushed);
     return stats;
   }
 
@@ -736,6 +935,11 @@ export class CVRStore {
       this.#writes.clear();
       this.#pendingRowRecordPuts.clear();
     }
+  }
+
+  /** Resolves when all pending updates are flushed. */
+  flushed(): Promise<void> {
+    return this.#rowCache.flushed();
   }
 }
 

--- a/packages/zero-cache/src/services/view-syncer/schema/init.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/init.ts
@@ -25,6 +25,9 @@ export async function initViewSyncerSchema(
     2: migrateV1toV2,
     3: migrateV2ToV3,
     4: migrateV3ToV4,
+    // v5 enables asynchronous row-record flushing, and thus relies on
+    // the logic that updates and checks the rowsVersion table in v3.
+    5: {minSafeVersion: 3},
   };
 
   await runSchemaMigrations(

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -87,6 +87,9 @@ describe('view-syncer/service', () => {
     baseCookie: null,
     schemaVersion: 2,
   };
+  const ON_FAILURE = (e: unknown) => {
+    throw e;
+  };
 
   const messages = new ReplicationMessages({issues: 'id', users: 'id'});
   const zeroMessages = new ReplicationMessages(
@@ -259,7 +262,7 @@ describe('view-syncer/service', () => {
       {op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY},
     ]);
 
-    const cvrStore = new CVRStore(lc, cvrDB, TASK_ID, serviceID);
+    const cvrStore = new CVRStore(lc, cvrDB, TASK_ID, serviceID, ON_FAILURE);
     const cvr = await cvrStore.load(Date.now());
     expect(cvr).toMatchObject({
       clients: {
@@ -307,7 +310,7 @@ describe('view-syncer/service', () => {
       },
     ]);
 
-    const cvrStore = new CVRStore(lc, cvrDB, TASK_ID, serviceID);
+    const cvrStore = new CVRStore(lc, cvrDB, TASK_ID, serviceID, ON_FAILURE);
     const cvr = await cvrStore.load(Date.now());
     expect(cvr).toMatchObject({
       clients: {
@@ -2007,7 +2010,7 @@ describe('view-syncer/service', () => {
   test('waits for replica to catch up', async () => {
     // Before connecting, artificially set the CVR version to '07',
     // which is ahead of the current replica version '00'.
-    const cvrStore = new CVRStore(lc, cvrDB, TASK_ID, serviceID);
+    const cvrStore = new CVRStore(lc, cvrDB, TASK_ID, serviceID, ON_FAILURE);
     await new CVRQueryDrivenUpdater(
       cvrStore,
       await cvrStore.load(Date.now()),
@@ -2168,7 +2171,7 @@ describe('view-syncer/service', () => {
   });
 
   test('sends reset for CVR from different replica version up', async () => {
-    const cvrStore = new CVRStore(lc, cvrDB, TASK_ID, serviceID);
+    const cvrStore = new CVRStore(lc, cvrDB, TASK_ID, serviceID, ON_FAILURE);
     await new CVRQueryDrivenUpdater(
       cvrStore,
       await cvrStore.load(Date.now()),
@@ -2219,7 +2222,7 @@ describe('view-syncer/service', () => {
   });
 
   test('sends invalid base cookie if client is ahead of CVR', async () => {
-    const cvrStore = new CVRStore(lc, cvrDB, TASK_ID, serviceID);
+    const cvrStore = new CVRStore(lc, cvrDB, TASK_ID, serviceID, ON_FAILURE);
     await new CVRQueryDrivenUpdater(
       cvrStore,
       await cvrStore.load(Date.now()),


### PR DESCRIPTION
### Feature

For large CVR updates, send the `pokeEnd` to the client without waiting for the row information to be committed to the CVR DB. This bounds the delay from Postgres writes on the UX.

### Implementation

Evolves the in-memory write-through `RowRecordCache` to switch to a write-back mode for large CVR updates with many rows. CVR commits still always persist the CVR version, metadata, and query information synchronously, but row updates may now happen asynchronously.

This works in concert with #3112 to authoritatively know when the data in the CVR is up to date, and #3114 to guarantee that an old zero-cache will stop writing to a CVR when a new zero-cache is granted ownership to it.

### Example 

Logs from an artificially augmented zbugs dataset (with 35k rows):

```
// Initial hydration of 35000 rows
cvrVersion=00:01 stateVersion=00 processing 10000 (of 10000) rows (434 ms)
cvrVersion=00:01 stateVersion=00 processing 10000 (of 20000) rows (843 ms)
cvrVersion=00:01 stateVersion=00 processing 10000 (of 30000) rows (1258 ms)
cvrVersion=00:01 stateVersion=00 processing 10000 (of 40000) rows (1651 ms)
cvrVersion=00:01 stateVersion=00 processing 5260 (of 45260) rows (1801 ms)

// CVR flush with `rowsDeferred`
cvrVersion=00:01 stateVersion=00 flushed CVR 
{"instances":2,"...,"rows":0,"rowsDeferred":35851,"statements":8} in (99 ms)

// Rows asynchronously flushed after poke end
flushed 35851 rows to 00:02 (978 ms)
pending rows flushed to 00:02

// delete query removes ~35000 rows
pokeID=00:04 starting poke from 00:03 to 00:04
cvrVersion=00:03 stateVersion=00 found 35841 (of 35851) rows for executed / removed queries 1ccw7gmrnyoog
cvrVersion=00:03 stateVersion=00 computed 24672 delete patches (36 ms)

// CVR flush with `rowsDeferred`
cvrVersion=00:03 stateVersion=00 flushed CVR 
{"instances":2,...,"rows":0,"rowsDeferred":35841,"statements":3} in (45 ms)
cvrVersion=00:03 stateVersion=00 finished processing queries (92 ms)

pokeID=00:05 starting poke from 00:04 to 00:05
cvrVersion=00:05 stateVersion=00 hydrating 1 queries
pokeID=00:06 starting poke from 00:05 to 00:06

// Hydration for comments query
created TableSource for comment
cvrVersion=00:05 stateVersion=00 processing 10000 (of 10000) rows (564 ms)
cvrVersion=00:05 stateVersion=00 found 0 (of 11179) rows for executed / removed queries 17vzb915vjszy
cvrVersion=00:05 stateVersion=00 processing 10000 (of 20000) rows (1149 ms)
cvrVersion=00:05 stateVersion=00 processing 10000 (of 30000) rows (1720 ms)
cvrVersion=00:05 stateVersion=00 processing 6834 (of 36834) rows (2120 ms)

// CVR flush with rowsDeferred
cvrVersion=00:05 stateVersion=00 flushed CVR 
{"instances":2,...,"rows":0,"rowsDeferred":36735,"statements":3} in (89 ms)

// Asynchronously flush rows from preceding CVR flushes
flushed 35841 rows to 00:04 (2465 ms)
flushed 36735 rows to 00:06 (956 ms)
pending rows flushed to 00:06

// Small CVR updates (e.g. advancements) are not deferred
4gdqdc => 4gdqt4: 1 changes
pokeID=4gdqt4 starting poke from 4gdqdc to 4gdqt4
newVersion=4gdqt4 applying 1 to advance to 4gdqt4
Advanced to 4gdqt4
newVersion=4gdqt4 processing 1 (of 1) rows (1 ms)
newVersion=4gdqt4 flushed CVR 
{"instances":2,"...,"rows":1,"rowsDeferred":0,"statements":4} in (4 ms)
newVersion=4gdqt4 finished processing advancement (5 ms)
```

### Notes / Room for Improvement

* When there is an old client that needs catchup, we must block on the asynchronous row updates before performing the row catchup scan. There are situations when this row catchup can be skipped by examining the config catchup first.
* When a CVR is loaded, it will wait for the `rowsVersion` to catch up with the main `version`. We can bound this time further by looking at the `lastActive` time in `cvr.instances` to know if the previous owner crashed before updating the rows.