### PR TITLE
fix(zero-cache): decouple cvr.{rows,rowsVersion} from cvr.instances

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/schema/init.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/init.ts
@@ -28,6 +28,7 @@ export async function initViewSyncerSchema(
     // v5 enables asynchronous row-record flushing, and thus relies on
     // the logic that updates and checks the rowsVersion table in v3.
     5: {minSafeVersion: 3},
+    6: migrateV5ToV6,
   };
 
   await runSchemaMigrations(
@@ -73,5 +74,12 @@ const migrateV3ToV4: Migration = {
   migrateSchema: async (_, tx) => {
     await tx`ALTER TABLE cvr.instances ADD "owner" TEXT`;
     await tx`ALTER TABLE cvr.instances ADD "grantedAt" TIMESTAMPTZ`;
+  },
+};
+
+const migrateV5ToV6: Migration = {
+  migrateSchema: async (_, tx) => {
+    await tx`ALTER TABLE cvr."rows" DROP CONSTRAINT fk_rows_client_group`;
+    await tx`ALTER TABLE cvr."rowsVersion" DROP CONSTRAINT fk_rows_version_client_group`;
   },
 };


### PR DESCRIPTION
Remove the `FOREIGN KEY` constraints on `cvr.rows` and `cvr.rowsVersion`, as it prevents them from being updated without affecting the`cvr.instances` row lock acquired by `SELECT ... FOR UPDATE`. Having a `FOREIGN KEY` relationship can otherwise cause a deadlock when the two types of update compete.

```json
    "name": "PostgresError",
    "severity_local": "ERROR",
    "severity": "ERROR",
    "code": "40P01",
    "detail": "Process 12983 waits for ShareLock on transaction 5208711; blocked by process 12984.\nProcess 12984 waits for ShareLock on transaction 5208712; blocked by process 12983.",
    "hint": "See server log for query details.",
    "where": "while inserting index tuple (0,154) in relation \"rowsVersion\"",
    "file": "deadlock.c",
    "line": "1135",
    "routine": "DeadLockReport",
    "errorMsg": "deadlock detected",
```

The rows tables are designed to be updated independently from the cvr.instances data. So while the foreign key relationship logically exists, we need Postgres to treat them independently to freely allow concurrent updates.

Reference: https://www.postgresql.org/docs/current/explicit-locking.html#LOCKING-ROWS

> The FOR UPDATE lock mode is also acquired by any DELETE on a row, and also by an UPDATE that modifies the values of certain columns. Currently, the set of columns considered for the UPDATE case are those that have a unique index on them that can be used in a foreign key (so partial indexes and expressional indexes are not considered), but this may change in the future.