### PR TITLE
feat(zql)!: table builder for defining table schemas

### DIFF
--- a/apps/zbugs/schema.ts
+++ b/apps/zbugs/schema.ts
@@ -1,201 +1,132 @@
 import {
   createSchema,
-  createTableSchema,
   defineAuthorization,
+  table,
+  column,
   type ExpressionBuilder,
   type TableSchema,
   type TableSchemaToRow,
 } from '@rocicorp/zero';
 
-const userSchema = createTableSchema({
-  tableName: 'user',
-  columns: {
-    id: {type: 'string'},
-    login: {type: 'string'},
-    name: {type: 'string'},
-    avatar: {type: 'string'},
-    role: {type: 'string'},
-  },
-  primaryKey: ['id'],
-  relationships: {},
-});
+const {string, number, boolean} = column;
 
-const issueSchema = createTableSchema({
-  tableName: 'issue',
-  columns: {
-    id: {type: 'string'},
-    shortID: {type: 'number', optional: true},
-    title: {type: 'string'},
-    open: {type: 'boolean'},
-    modified: {type: 'number'},
-    created: {type: 'number'},
-    creatorID: {type: 'string'},
-    assigneeID: {type: 'string', optional: true},
-    description: {type: 'string'},
-    labelIDs: {type: 'string'},
-  },
-  primaryKey: ['id'],
-  relationships: {
-    labels: {
-      source: 'id',
-      junction: {
-        source: 'issueID',
-        dest: {
-          field: 'labelID',
-          schema: () => issueLabelSchema,
-        },
-      },
-      dest: {
-        field: 'id',
-        schema: () => labelSchema,
-      },
-    },
-    comments: {
-      source: 'id',
-      dest: {
-        field: 'issueID',
-        schema: () => commentSchema,
-      },
-    },
-    creator: {
-      source: 'creatorID',
-      dest: {
-        field: 'id',
-        schema: () => userSchema,
-      },
-    },
-    assignee: {
-      source: 'assigneeID',
-      dest: {
-        field: 'id',
-        schema: () => userSchema,
-      },
-    },
-    viewState: {
-      source: 'id',
-      dest: {
-        field: 'issueID',
-        schema: () => viewStateSchema,
-      },
-    },
-    emoji: {
-      source: 'id',
-      dest: {
-        field: 'subjectID',
-        schema: () => emojiSchema,
-      },
-    },
-  },
-});
+const user = table('user')
+  .columns({
+    id: string(),
+    login: string(),
+    name: string(),
+    avatar: string(),
+    role: string(),
+  })
+  .primaryKey('id')
+  .build();
 
-const viewStateSchema = createTableSchema({
-  tableName: 'viewState',
-  columns: {
-    issueID: {type: 'string'},
-    userID: {type: 'string'},
-    viewed: {type: 'number'},
-  },
-  primaryKey: ['userID', 'issueID'],
-  relationships: {},
-});
+const issue = table('issue')
+  .columns({
+    id: string(),
+    shortID: number().optional(),
+    title: string(),
+    open: boolean(),
+    modified: number(),
+    created: number(),
+    creatorID: string(),
+    assigneeID: string().optional(),
+    description: string(),
+    labelIDs: string(),
+  })
+  .primaryKey('id')
+  .relationships(source => ({
+    labels: source('id')
+      .junction(() => issueLabel, 'issueID', 'labelID')
+      .dest(() => label, 'id'),
+    comments: source('id').dest(() => comment, 'issueID'),
+    creator: source('creatorID').dest(user, 'id'),
+    assignee: source('assigneeID').dest(user, 'id'),
+    viewState: source('id').dest(() => viewState, 'issueID'),
+    emoji: source('id').dest(() => emoji, 'subjectID'),
+  }))
+  .build();
 
-const commentSchema = createTableSchema({
-  tableName: 'comment',
-  columns: {
-    id: {type: 'string'},
-    issueID: {type: 'string'},
-    created: {type: 'number'},
-    body: {type: 'string'},
-    creatorID: {type: 'string'},
-  },
-  primaryKey: ['id'],
-  relationships: {
-    creator: {
-      source: 'creatorID',
-      dest: {
-        field: 'id',
-        schema: () => userSchema,
-      },
-    },
-    emoji: {
-      source: 'id',
-      dest: {
-        field: 'subjectID',
-        schema: () => emojiSchema,
-      },
-    },
-  },
-});
+const viewState = table('viewState')
+  .columns({
+    issueID: string(),
+    userID: string(),
+    viewed: number(),
+  })
+  .primaryKey('issueID', 'userID')
+  .build();
 
-const labelSchema = createTableSchema({
-  tableName: 'label',
-  columns: {
-    id: {type: 'string'},
-    name: {type: 'string'},
-  },
-  primaryKey: ['id'],
-  relationships: {},
-});
+const comment = table('comment')
+  .columns({
+    id: string(),
+    issueID: string(),
+    created: number(),
+    body: string(),
+    creatorID: string(),
+  })
+  .primaryKey('id')
+  .relationships(source => ({
+    creator: source('creatorID').dest(user, 'id'),
+    emoji: source('id').dest(() => emoji, 'subjectID'),
+  }))
+  .build();
 
-const issueLabelSchema = createTableSchema({
-  tableName: 'issueLabel',
-  columns: {
-    issueID: {type: 'string'},
-    labelID: {type: 'string'},
-  },
-  primaryKey: ['issueID', 'labelID'],
-  relationships: {},
-});
+const label = table('label')
+  .columns({
+    id: string(),
+    name: string(),
+  })
+  .primaryKey('id')
+  .build();
 
-const emojiSchema = createTableSchema({
-  tableName: 'emoji',
-  columns: {
-    id: {type: 'string'},
-    value: {type: 'string'},
-    annotation: {type: 'string'},
-    subjectID: {type: 'string'},
-    creatorID: {type: 'string'},
-    created: {type: 'number'},
-  },
-  primaryKey: ['id'],
-  relationships: {
-    creator: {
-      source: 'creatorID',
-      dest: {
-        field: 'id',
-        schema: () => userSchema,
-      },
-    },
-  },
-});
+const issueLabel = table('issueLabel')
+  .columns({
+    issueID: string(),
+    labelID: string(),
+  })
+  .primaryKey('issueID', 'labelID')
+  .build();
 
-const userPrefSchema = createTableSchema({
-  tableName: 'userPref',
-  columns: {
-    key: {type: 'string'},
-    userID: {type: 'string'},
-    value: {type: 'string'},
-  },
-  primaryKey: ['key', 'userID'],
-  relationships: {},
-});
+const emoji = table('emoji')
+  .columns({
+    id: string(),
+    value: string(),
+    annotation: string(),
+    subjectID: string(),
+    creatorID: string(),
+    created: number(),
+  })
+  .primaryKey('id')
+  .relationships(source => ({
+    creator: source('creatorID').dest(user, 'id'),
+  }))
+  .build();
+
+const userPref = table('userPref')
+  .columns({
+    userID: string(),
+    key: string(),
+    value: string(),
+  })
+  .primaryKey('key', 'userID') // TODO: this order should be reversed, right?
+  .build();
 
 export const schema = createSchema({
   version: 4,
   tables: {
-    user: userSchema,
-    issue: issueSchema,
-    comment: commentSchema,
-    label: labelSchema,
-    issueLabel: issueLabelSchema,
-    viewState: viewStateSchema,
-    emoji: emojiSchema,
-    userPref: userPrefSchema,
+    user,
+    issue,
+    comment,
+    label,
+    issueLabel,
+    viewState,
+    emoji,
+    userPref,
   },
 });
 
-export type IssueRow = TableSchemaToRow<typeof issueSchema>;
-export type CommentRow = TableSchemaToRow<typeof commentSchema>;
+export type IssueRow = TableSchemaToRow<typeof issue>;
+export type CommentRow = TableSchemaToRow<typeof comment>;
 export type Schema = typeof schema;
 
 /** The contents of the zbugs JWT */
@@ -213,12 +144,12 @@ const authorization = defineAuthorization<AuthData, Schema>(schema, () => {
 
   const allowIfIssueCreator = (
     authData: AuthData,
-    {cmp}: ExpressionBuilder<typeof issueSchema>,
+    {cmp}: ExpressionBuilder<typeof issue>,
   ) => cmp('creatorID', '=', authData.sub);
 
   const allowIfCommentCreator = (
     authData: AuthData,
-    {cmp}: ExpressionBuilder<typeof commentSchema>,
+    {cmp}: ExpressionBuilder<typeof comment>,
   ) => cmp('creatorID', '=', authData.sub);
 
   const allowIfAdmin = (
@@ -228,7 +159,7 @@ const authorization = defineAuthorization<AuthData, Schema>(schema, () => {
 
   const allowIfUserIDMatchesLoggedInUser = (
     authData: AuthData,
-    {cmp}: ExpressionBuilder<typeof viewStateSchema>,
+    {cmp}: ExpressionBuilder<typeof viewState>,
   ) => cmp('userID', '=', authData.sub);
 
   return {

--- a/packages/zero-client/src/mod.ts
+++ b/packages/zero-client/src/mod.ts
@@ -60,10 +60,10 @@ export type {
 export {defineAuthorization} from '../../zero-schema/src/authorization.js';
 export {createSchema} from '../../zero-schema/src/schema.js';
 export {
-  createTableSchema,
   type TableSchemaToRow,
   type TableSchema,
 } from '../../zero-schema/src/table-schema.js';
+export {table, column} from '../../zero-schema/src/table-builder.js';
 export {escapeLike} from '../../zql/src/query/escape-like.js';
 export type {
   ExpressionBuilder,

--- a/packages/zero-schema/src/authorization.test.ts
+++ b/packages/zero-schema/src/authorization.test.ts
@@ -1,21 +1,23 @@
 import {expect, test} from 'vitest';
 import {createSchema} from './schema.js';
-import {createTableSchema, type TableSchema} from './table-schema.js';
+import {type TableSchema} from './table-schema.js';
 import {defineAuthorization} from './authorization.js';
 import type {ExpressionBuilder} from '../../zql/src/query/expression.js';
+import {table, column} from './table-builder.js';
 
-const userSchema = createTableSchema({
-  tableName: 'user',
-  columns: {
-    id: {type: 'string'},
-    login: {type: 'string'},
-    name: {type: 'string'},
-    avatar: {type: 'string'},
-    role: {type: 'string'},
-  },
-  primaryKey: ['id'],
-  relationships: {},
-});
+const {string} = column;
+
+const userSchema = table('user')
+  .columns({
+    id: string(),
+    login: string(),
+    name: string(),
+    avatar: string(),
+    role: string(),
+  })
+  .primaryKey('id')
+  .build();
+
 const schema = createSchema({
   version: 1,
   tables: {

--- a/packages/zero-schema/src/mod.ts
+++ b/packages/zero-schema/src/mod.ts
@@ -1,8 +1,5 @@
 export {authQuery} from '../../zql/src/query/auth-query.js';
-export {
-  createTableSchema,
-  type TableSchema,
-  type TableSchemaToRow,
-} from './table-schema.js';
+export {type TableSchema, type TableSchemaToRow} from './table-schema.js';
+export {table, column} from './table-builder.js';
 export * from './schema.js';
 export {defineAuthorization} from './authorization.js';

--- a/packages/zero-schema/src/table-builder.ts
+++ b/packages/zero-schema/src/table-builder.ts
@@ -1,0 +1,221 @@
+import type {
+  FieldRelationship,
+  JunctionRelationship,
+  SchemaValue,
+  TableSchema,
+} from './table-schema.js';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export function table<TName extends string>(name: TName) {
+  return new TableBuilder({
+    tableName: name,
+    columns: {},
+    primaryKey: null as any,
+    relationships: {},
+  });
+}
+
+export function string() {
+  return new ColumnBuilder({type: 'string', optional: false});
+}
+
+export function number() {
+  return new ColumnBuilder({type: 'number', optional: false});
+}
+
+export function boolean() {
+  return new ColumnBuilder({type: 'boolean', optional: false});
+}
+
+export function json() {
+  return new ColumnBuilder({type: 'json', optional: false});
+}
+
+export const column = {
+  string,
+  number,
+  boolean,
+  json,
+};
+
+type Lazy<T> = () => T;
+
+class TableBuilder<TShape extends TableSchema> {
+  readonly #schema: TShape;
+  constructor(schema: TShape) {
+    this.#schema = schema;
+  }
+
+  columns<TColumns extends Record<string, ColumnBuilder<SchemaValue>>>(
+    columns: TColumns,
+  ): TableBuilderWithColumns<{
+    tableName: TShape['tableName'];
+    columns: {[K in keyof TColumns]: TColumns[K]['schema']};
+    primaryKey: TShape['primaryKey'];
+    relationships: TShape['relationships'];
+  }> {
+    const columnSchemas = Object.fromEntries(
+      Object.entries(columns).map(([k, v]) => [k, v.schema]),
+    ) as {[K in keyof TColumns]: TColumns[K]['schema']};
+    return new TableBuilderWithColumns({
+      ...this.#schema,
+      columns: columnSchemas,
+    }) as any;
+  }
+}
+
+class TableBuilderWithColumns<TShape extends TableSchema> {
+  readonly #schema: TShape;
+
+  constructor(schema: TShape) {
+    this.#schema = schema;
+  }
+
+  primaryKey<TPKColNames extends (keyof TShape['columns'])[]>(
+    ...pkColumnNames: TPKColNames
+  ) {
+    return new TableBuilderWithColumns({
+      ...this.#schema,
+      primaryKey: pkColumnNames,
+    });
+  }
+
+  relationships<
+    TRelationships extends Record<
+      string,
+      | FieldRelationshipBuilder<FieldRelationship>
+      | JunctionRelationshipBuilder<JunctionRelationship>
+    >,
+  >(
+    cb: (
+      source: (
+        field: keyof TShape['columns'] & string,
+      ) => UndeterminedRelationshipBuilder<TShape>,
+    ) => TRelationships,
+  ): TableBuilderWithColumns<{
+    tableName: TShape['tableName'];
+    columns: TShape['columns'];
+    primaryKey: TShape['primaryKey'];
+    relationships: {[K in keyof TRelationships]: TRelationships[K]['schema']};
+  }> {
+    const relationshipSchemas = Object.fromEntries(
+      Object.entries(cb(source)).map(([k, v]) => [k, v.schema]),
+    ) as {[K in keyof TRelationships]: TRelationships[K]['schema']};
+
+    return new TableBuilderWithColumns({
+      ...this.#schema,
+      relationships: relationshipSchemas,
+    }) as any;
+  }
+
+  build() {
+    return this.#schema;
+  }
+}
+
+export function source<TShape extends TableSchema>(
+  sourceField: keyof TShape['columns'] & string,
+) {
+  return new UndeterminedRelationshipBuilder(sourceField);
+}
+
+class UndeterminedRelationshipBuilder<TShape extends TableSchema> {
+  readonly #sourceField;
+  constructor(sourceField: keyof TShape['columns'] & string) {
+    this.#sourceField = sourceField;
+  }
+
+  dest<TDestSchema extends TableSchema>(
+    destSchema: TDestSchema | Lazy<TDestSchema>,
+    destField: keyof TDestSchema['columns'] & string,
+  ) {
+    return new FieldRelationshipBuilder({
+      source: this.#sourceField,
+      dest: {
+        field: destField,
+        schema: destSchema,
+      },
+    });
+  }
+
+  junction<TJunctionSchema extends TableSchema>(
+    junctionSchema: TJunctionSchema | Lazy<TJunctionSchema>,
+    sourceField: keyof TJunctionSchema['columns'] & string,
+    destField: keyof TJunctionSchema['columns'] & string,
+  ) {
+    return new JunctionRelationshipBuilder({
+      source: this.#sourceField,
+      dest: null as any,
+      junction: {
+        source: sourceField,
+        dest: {
+          field: destField,
+          schema: junctionSchema,
+        },
+      },
+    });
+  }
+}
+
+class ColumnBuilder<TShape extends SchemaValue> {
+  readonly #schema: TShape;
+  constructor(schema: TShape) {
+    this.#schema = schema;
+  }
+
+  optional(): ColumnBuilder<{
+    type: TShape['type'];
+    optional: true;
+  }> {
+    return new ColumnBuilder({
+      ...this.#schema,
+      optional: true,
+    } as const);
+  }
+
+  get schema() {
+    return this.#schema;
+  }
+}
+
+class FieldRelationshipBuilder<TShape extends FieldRelationship> {
+  readonly #schema: TShape;
+  constructor(schema: TShape) {
+    this.#schema = schema;
+  }
+
+  get schema() {
+    return this.#schema;
+  }
+}
+
+class JunctionRelationshipBuilder<TShape extends JunctionRelationship> {
+  readonly #schema: TShape;
+  constructor(schema: TShape) {
+    this.#schema = schema;
+  }
+
+  dest<TDestSchema extends TableSchema>(
+    destSchema: TDestSchema | Lazy<TDestSchema>,
+    destField: keyof TDestSchema['columns'] & string,
+  ): JunctionRelationshipBuilder<{
+    source: TShape['source'];
+    junction: TShape['junction'];
+    dest: {
+      field: typeof destField;
+      schema: TDestSchema | Lazy<TDestSchema>;
+    };
+  }> {
+    return new JunctionRelationshipBuilder({
+      ...this.#schema,
+      dest: {
+        field: destField,
+        schema: destSchema,
+      },
+    } as const);
+  }
+
+  get schema() {
+    return this.#schema;
+  }
+}

--- a/packages/zero-schema/src/table-schema.ts
+++ b/packages/zero-schema/src/table-schema.ts
@@ -21,10 +21,6 @@ export type TableSchema = SourceOrTableSchema & {
   readonly relationships: {readonly [name: string]: Relationship};
 };
 
-export function createTableSchema<const T extends TableSchema>(schema: T) {
-  return schema as T;
-}
-
 export type TableSchemaToRow<T extends TableSchema> = {
   [K in keyof T['columns']]: SchemaValueToTSType<T['columns'][K]>;
 };
@@ -83,17 +79,15 @@ export type Supertype<TSchemas extends TableSchema[]> = {
  */
 type Lazy<T> = T | (() => T);
 
-export type Relationship =
-  | FieldRelationship<TableSchema, TableSchema>
-  | JunctionRelationship<TableSchema, TableSchema, TableSchema>;
+export type Relationship = FieldRelationship | JunctionRelationship;
 
 /**
  * A relationship between two entities where
  * that relationship is defined via fields on both entities.
  */
 export type FieldRelationship<
-  TSourceSchema extends TableSchema,
-  TDestSchema extends TableSchema,
+  TSourceSchema extends TableSchema = TableSchema,
+  TDestSchema extends TableSchema = TableSchema,
 > = {
   source: keyof TSourceSchema['columns'];
   dest: {
@@ -107,9 +101,9 @@ export type FieldRelationship<
  * that relationship is defined via a junction table.
  */
 export type JunctionRelationship<
-  TSourceSchema extends TableSchema,
-  TJunctionSchema extends TableSchema,
-  TDestSchema extends TableSchema,
+  TSourceSchema extends TableSchema = TableSchema,
+  TJunctionSchema extends TableSchema = TableSchema,
+  TDestSchema extends TableSchema = TableSchema,
 > = FieldRelationship<TSourceSchema, TDestSchema> & {
   junction: FieldRelationship<TJunctionSchema, TJunctionSchema>;
 };


### PR DESCRIPTION
In pursuit of cleaner schema and permission APIs.

Pros:
- type safe primary keys
- type safe relationship definitions
- autocomplete for relationships and primary keys
- more succinct definitions (40% less lines for the zbugs schema)

Cons:
- Circular structures require dropping back down to base TypeScript types. This is a limitation of TypeScript and has no solution. Even the old `createTableSchema` suffered from this problem as well as Valita (as seen by our annoying AST schemas).

This con really bugs me. We can slightly bypass it by spreading the builder result and only dropping down for the recursive relationship(s) (see `readablePartial`). Still super dumb though.