### PR TITLE
feat(zql): remove cycles from schema before encoding to json

### DIFF
--- a/packages/zero-cache/src/auth/load-schema.ts
+++ b/packages/zero-cache/src/auth/load-schema.ts
@@ -8,6 +8,7 @@ import {readFile} from 'node:fs/promises';
 import * as v from '../../../shared/src/valita.js';
 import type {ZeroConfig} from '../config/zero-config.js';
 import {normalizeSchema} from '../../../zero-schema/src/normalized-schema.js';
+import {replaceSchemaNamesWithPointers} from '../../../zero-schema/src/schema-config.js';
 
 let loadedSchema:
   | Promise<{
@@ -26,7 +27,9 @@ function parseAuthConfig(
   try {
     const config = JSON.parse(input);
     const permissions = v.parse(config.permissions, permissionsConfigSchema);
-    const normalizedSchema = normalizeSchema(config.schema);
+    const normalizedSchema = normalizeSchema(
+      replaceSchemaNamesWithPointers(config.schema),
+    );
     return {
       permissions,
       schema: normalizedSchema,

--- a/packages/zero-schema/src/build-schema.ts
+++ b/packages/zero-schema/src/build-schema.ts
@@ -6,7 +6,10 @@ import {permissionsConfigSchema} from './compiled-permissions.js';
 import * as v from '../../shared/src/valita.js';
 import {parseOptions} from '../../shared/src/options.js';
 import {normalizeSchema} from './normalized-schema.js';
-import {isSchemaConfig} from './schema-config.js';
+import {
+  isSchemaConfig,
+  replacePointersWithSchemaNames,
+} from './schema-config.js';
 
 export const schemaOptions = {
   path: {
@@ -56,11 +59,13 @@ async function main() {
       permissionsConfigSchema,
     );
 
-    const normalizedSchema = normalizeSchema(schemaConfig.schema);
+    const cycleFreeNormalizedSchema = replacePointersWithSchemaNames(
+      normalizeSchema(schemaConfig.schema),
+    );
 
     const output = {
       permissions,
-      schema: normalizedSchema,
+      schema: cycleFreeNormalizedSchema,
     };
 
     await writeFile(config.output, JSON.stringify(output, undefined, 2));
@@ -69,4 +74,5 @@ async function main() {
     process.exit(1);
   }
 }
+
 void main();

--- a/packages/zero-schema/src/normalize-table-schema.ts
+++ b/packages/zero-schema/src/normalize-table-schema.ts
@@ -135,6 +135,25 @@ function normalizeRelationships(
   return rv;
 }
 
+export type DecycledNormalizedTableSchema = Omit<
+  NormalizedTableSchema,
+  'relationships'
+> & {
+  readonly relationships: {
+    readonly [relationship: string]:
+      | DecycledNormalizedFieldRelationship
+      | readonly [
+          DecycledNormalizedFieldRelationship,
+          DecycledNormalizedFieldRelationship,
+        ];
+  };
+};
+
+export type DecycledNormalizedFieldRelationship = Omit<
+  NormalizedFieldRelationship,
+  'destSchema'
+> & {readonly destSchema: string};
+
 type NormalizedRelationship =
   | NormalizedFieldRelationship
   | NormalizedJunctionRelationship;
@@ -175,7 +194,7 @@ function normalizeFieldRelationship(
   };
 }
 
-type NormalizedJunctionRelationship = readonly [
+export type NormalizedJunctionRelationship = readonly [
   NormalizedFieldRelationship,
   NormalizedFieldRelationship,
 ];

--- a/packages/zero-schema/src/normalized-schema.ts
+++ b/packages/zero-schema/src/normalized-schema.ts
@@ -2,6 +2,7 @@ import {sortedEntries} from '../../shared/src/sorted-entries.js';
 import type {Writable} from '../../shared/src/writable.js';
 import {
   normalizeTableSchemaWithCache,
+  type DecycledNormalizedTableSchema,
   type NormalizedTableSchema,
   type TableSchemaCache,
 } from './normalize-table-schema.js';
@@ -31,6 +32,12 @@ export class NormalizedSchema {
     this.tables = normalizeTables(schema.tables);
   }
 }
+
+export type DecycledNormalizedSchema = Omit<NormalizedSchema, 'tables'> & {
+  readonly tables: {
+    readonly [table: string]: DecycledNormalizedTableSchema;
+  };
+};
 
 function normalizeTables(tables: Schema['tables']): {
   readonly [table: string]: NormalizedTableSchema;

--- a/packages/zero-schema/src/schema-config.test.ts
+++ b/packages/zero-schema/src/schema-config.test.ts
@@ -1,0 +1,67 @@
+import {expect, test} from 'vitest';
+import type {Schema} from './schema.js';
+import {normalizeSchema} from './normalized-schema.js';
+import {
+  replacePointersWithSchemaNames,
+  replaceSchemaNamesWithPointers,
+} from './schema-config.js';
+
+test('replace pointers, replace strings', () => {
+  const foo = {
+    tableName: 'foo',
+    columns: {
+      id: {type: 'string'},
+      bar: {type: 'string'},
+    },
+    primaryKey: ['id'],
+    relationships: {
+      self: {
+        sourceField: ['id'],
+        destField: ['id'],
+        destSchema: () => foo,
+      },
+      bar: {
+        sourceField: ['bar'],
+        destField: ['id'],
+        destSchema: () => bar,
+      },
+    },
+  } as const;
+
+  const bar = {
+    tableName: 'bar',
+    columns: {
+      id: {type: 'string'},
+      foo: {type: 'string'},
+    },
+    primaryKey: ['id'],
+    relationships: {
+      self: {
+        sourceField: ['id'],
+        destField: ['id'],
+        destSchema: () => bar,
+      },
+      foo: {
+        sourceField: ['foo'],
+        destField: ['id'],
+        destSchema: () => foo,
+      },
+    },
+  } as const;
+
+  const schema = {
+    version: 1,
+    tables: {
+      foo,
+      bar,
+    },
+  } satisfies Schema;
+
+  const normalized = normalizeSchema(schema);
+
+  const replaced = replacePointersWithSchemaNames(normalized);
+  const normal = replaceSchemaNamesWithPointers(replaced);
+
+  expect(normal).toEqual(normalized);
+  expect(replacePointersWithSchemaNames(normal)).toEqual(replaced);
+});


### PR DESCRIPTION
If a user had a cycle in their relationships then `schema.json` couldn't be built. E.g., https://github.com/rocicorp/mono/pull/3152

This also slims down our zbugs `schema.json` quite a bit since we're not repeating the same schemas in every relationship.

![CleanShot 2024-11-29 at 20 29 24@2x](https://github.com/user-attachments/assets/4a80b8c7-492f-4023-8d7a-c0a141899578)

![CleanShot 2024-11-29 at 20 31 15@2x](https://github.com/user-attachments/assets/a1d315f4-ed01-4a3a-bff6-766fafd310af)

--

I explored some other options (npm/telejson, my own custom impl that works for any set of objects) but their output wasn't that readable. I think it's worth keeping the JSON readable.