### PR TITLE
chore(zero): Pin valita to 0.3.11.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15360,7 +15360,7 @@
       "version": "15.2.1",
       "license": "https://roci.dev/terms.html",
       "dependencies": {
-        "@badrap/valita": "^0.3.11",
+        "@badrap/valita": "0.3.11",
         "@rocicorp/lock": "^1.0.4",
         "@rocicorp/logger": "^5.3.0",
         "@rocicorp/resolver": "^1.0.2"
@@ -15485,7 +15485,7 @@
     "packages/shared": {
       "version": "0.0.0",
       "dependencies": {
-        "@badrap/valita": "^0.3.11",
+        "@badrap/valita": "0.3.11",
         "@rocicorp/logger": "^5.3.0",
         "@rocicorp/resolver": "^1.0.2",
         "chalk-template": "^1.1.0",
@@ -15594,7 +15594,7 @@
       "name": "@rocicorp/zero",
       "version": "0.7.2024120108+6d0413",
       "dependencies": {
-        "@badrap/valita": "^0.3.11",
+        "@badrap/valita": "0.3.11",
         "@databases/escape-identifier": "^1.0.3",
         "@databases/sql": "^3.3.0",
         "@drdgvhbh/postgres-error-codes": "^0.0.6",
@@ -15839,30 +15839,10 @@
         "@esbuild/win32-x64": "0.20.2"
       }
     },
-    "packages/zero-integration-test": {
-      "version": "0.0.0",
-      "extraneous": true,
-      "dependencies": {
-        "@badrap/valita": "^0.3.11",
-        "@rocicorp/logger": "^5.3.0",
-        "@rocicorp/resolver": "^1.0.2",
-        "semver": "^7.5.4"
-      },
-      "devDependencies": {
-        "@rocicorp/eslint-config": "^0.5.1",
-        "@rocicorp/prettier-config": "^0.2.0",
-        "@types/semver": "^7.5.1",
-        "@vitest/browser": "^2.0.3",
-        "fast-check": "^3.18.0",
-        "pkg-up": "^5.0.0",
-        "typescript": "^5.6.3",
-        "vitest": "^2.0.3"
-      }
-    },
     "packages/zero-protocol": {
       "version": "0.0.0",
       "dependencies": {
-        "@badrap/valita": "^0.3.11"
+        "@badrap/valita": "0.3.11"
       },
       "devDependencies": {
         "@rocicorp/eslint-config": "^0.5.1",
@@ -17782,7 +17762,7 @@
     "@rocicorp/zero": {
       "version": "file:packages/zero",
       "requires": {
-        "@badrap/valita": "^0.3.11",
+        "@badrap/valita": "0.3.11",
         "@databases/escape-identifier": "^1.0.3",
         "@databases/sql": "^3.3.0",
         "@drdgvhbh/postgres-error-codes": "^0.0.6",
@@ -24192,7 +24172,7 @@
     "replicache": {
       "version": "file:packages/replicache",
       "requires": {
-        "@badrap/valita": "^0.3.11",
+        "@badrap/valita": "0.3.11",
         "@rocicorp/eslint-config": "^0.5.1",
         "@rocicorp/lock": "^1.0.4",
         "@rocicorp/logger": "^5.3.0",
@@ -24476,7 +24456,7 @@
     "shared": {
       "version": "file:packages/shared",
       "requires": {
-        "@badrap/valita": "^0.3.11",
+        "@badrap/valita": "0.3.11",
         "@cloudflare/workers-types": "^4.20231010.0",
         "@rocicorp/eslint-config": "^0.5.1",
         "@rocicorp/logger": "^5.3.0",
@@ -26805,7 +26785,7 @@
     "zero-protocol": {
       "version": "file:packages/zero-protocol",
       "requires": {
-        "@badrap/valita": "^0.3.11",
+        "@badrap/valita": "0.3.11",
         "@rocicorp/eslint-config": "^0.5.1",
         "@rocicorp/prettier-config": "^0.2.0",
         "shared": "0.0.0",

--- a/packages/replicache/package.json
+++ b/packages/replicache/package.json
@@ -22,7 +22,7 @@
     "prepare": "rm -f node_modules/fetch-mock/esm/client.d.ts"
   },
   "dependencies": {
-    "@badrap/valita": "^0.3.11",
+    "@badrap/valita": "0.3.11",
     "@rocicorp/lock": "^1.0.4",
     "@rocicorp/logger": "^5.3.0",
     "@rocicorp/resolver": "^1.0.2"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint --ext .ts,.tsx,.js,.jsx src/"
   },
   "dependencies": {
-    "@badrap/valita": "^0.3.11",
+    "@badrap/valita": "0.3.11",
     "@rocicorp/logger": "^5.3.0",
     "@rocicorp/resolver": "^1.0.2",
     "chalk-template": "^1.1.0",

--- a/packages/zero-protocol/package.json
+++ b/packages/zero-protocol/package.json
@@ -13,7 +13,7 @@
     "test:watch": "vitest watch"
   },
   "dependencies": {
-    "@badrap/valita": "^0.3.11"
+    "@badrap/valita": "0.3.11"
   },
   "devDependencies": {
     "@rocicorp/eslint-config": "^0.5.1",

--- a/packages/zero/package.json
+++ b/packages/zero/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint --ext .ts,.tsx,.js,.jsx src/"
   },
   "dependencies": {
-    "@badrap/valita": "^0.3.11",
+    "@badrap/valita": "0.3.11",
     "@databases/escape-identifier": "^1.0.3",
     "@databases/sql": "^3.3.0",
     "@drdgvhbh/postgres-error-codes": "^0.0.6",


### PR DESCRIPTION
There is a breaking change in 0.3.15. The func() method on OptionalType has been removed.