### PR TITLE
fix(zero-cache): key desired queries on xformation hash

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -586,7 +586,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     );
     const removeQueries = serverQueries.filter(q => !q.desired);
     const desiredQueries = new Set(
-      serverQueries.filter(q => q.desired).map(q => q.id),
+      serverQueries.filter(q => q.desired).map(q => q.transformationHash),
     );
     const unhydrateQueries = [...hydratedQueries].filter(
       transformationHash => !desiredQueries.has(transformationHash),


### PR DESCRIPTION
will add some e2e tests to cover this and #3166. Not sure how both of these got reverted to id. Either oversight or missed when rebasing the original changes.