### PR TITLE
fix(zql): deal with missing format for `exists`

### DIFF
--- a/packages/zql/src/ivm/view-apply-change.ts
+++ b/packages/zql/src/ivm/view-apply-change.ts
@@ -141,16 +141,16 @@ export function applyChange(
       const childSchema = must(
         schema.relationships[change.child.relationshipName],
       );
-      const childFormat = must(
-        format.relationships[change.child.relationshipName],
-      );
-      applyChange(
-        existing,
-        change.child.change,
-        childSchema,
-        change.child.relationshipName,
-        childFormat,
-      );
+      const childFormat = format.relationships[change.child.relationshipName];
+      if (childFormat !== undefined) {
+        applyChange(
+          existing,
+          change.child.change,
+          childSchema,
+          change.child.relationshipName,
+          childFormat,
+        );
+      }
       break;
     }
     case 'edit': {


### PR DESCRIPTION
`add` skipped if the format didn't exist. Doing the same for `child`.