### PR TITLE
chore(permissions): commentary on why policies are an array of rules

### DIFF
--- a/packages/zero-schema/src/permissions.ts
+++ b/packages/zero-schema/src/permissions.ts
@@ -21,6 +21,7 @@ type PermissionRule<TAuthDataShape, TSchema extends TableSchema> = (
 ) => Condition;
 
 type AssetPermissions<TAuthDataShape, TSchema extends TableSchema> = {
+  // Why an array of rules?: https://github.com/rocicorp/mono/pull/3184/files#r1869680716
   select?: PermissionRule<TAuthDataShape, TSchema>[] | undefined;
   insert?: PermissionRule<TAuthDataShape, TSchema>[] | undefined;
   update?:
@@ -107,6 +108,11 @@ function compileRowConfig<TAuthDataShape, TSchema extends TableSchema>(
   };
 }
 
+/**
+ * What is this "allow" and why are permissions policies an array of rules?
+ *
+ * Please read: https://github.com/rocicorp/mono/pull/3184/files#r1869680716
+ */
 function compileRules<TAuthDataShape, TSchema extends TableSchema>(
   rules: PermissionRule<TAuthDataShape, TSchema>[] | undefined,
   expressionBuilder: ExpressionBuilder<TSchema>,


### PR DESCRIPTION
This knowledge only existed in my head. I think it is important to capture because the array of `allowIf, denyIf` concept reads so well compared to the alternatives.

https://github.com/rocicorp/mono/pull/3184/files#r1869680716