### PR TITLE
chore(zero-cache): plumb more information through the LogContext

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/client-handler.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.ts
@@ -103,7 +103,7 @@ export class ClientHandler {
     this.clientID = clientID;
     this.wsID = wsID;
     this.#zeroClientsTable = `${schema(shardID)}.clients`;
-    this.#lc = lc.withContext('clientID', clientID);
+    this.#lc = lc;
     this.#pokes = pokes;
     this.#baseVersion = cookieToVersion(baseCookie);
     this.#schemaVersion = schemaVersion;


### PR DESCRIPTION
This will facilitate debugging lock and multiple view-syncer scenarios