### PR TITLE
fix(zero-cache): view-syncer lifecycle fixes

### DIFF
--- a/packages/zero-cache/src/services/runner.ts
+++ b/packages/zero-cache/src/services/runner.ts
@@ -34,13 +34,13 @@ export class ServiceRunner<S extends Service> {
     this.#instances.set(id, service);
     void service
       .run()
-      .catch(e => {
-        this.#lc.error?.(
-          `Error running ${service.constructor?.name} ${service.id}`,
-          e,
-        );
-        this.#lc.info?.(e.toString());
-      })
+      .catch(
+        e =>
+          this.#lc.error?.(
+            `Error running ${service.constructor?.name} ${service.id}`,
+            e,
+          ),
+      )
       .finally(() => {
         this.#instances.delete(id);
       });

--- a/packages/zero-cache/src/workers/connection.ts
+++ b/packages/zero-cache/src/workers/connection.ts
@@ -1,8 +1,11 @@
+import {trace} from '@opentelemetry/api';
 import {Lock} from '@rocicorp/lock';
 import type {LogContext} from '@rocicorp/logger';
 import type {JWTPayload} from 'jose';
 import type {CloseEvent, Data, ErrorEvent} from 'ws';
 import WebSocket from 'ws';
+import {startAsyncSpan, startSpan} from '../../../otel/src/span.js';
+import {version} from '../../../otel/src/version.js';
 import {unreachable} from '../../../shared/src/asserts.js';
 import * as valita from '../../../shared/src/valita.js';
 import {type ErrorBody} from '../../../zero-protocol/src/error.js';
@@ -23,9 +26,6 @@ import type {
 } from '../services/view-syncer/view-syncer.js';
 import {findErrorForClient} from '../types/error-for-client.js';
 import type {Source} from '../types/streams.js';
-import {trace} from '@opentelemetry/api';
-import {version} from '../../../otel/src/version.js';
-import {startAsyncSpan} from '../../../otel/src/span.js';
 
 const tracer = trace.getTracer('syncer-ws-server', version);
 
@@ -216,22 +216,13 @@ export class Connection {
           lc.error?.('TODO: implement deleteClients');
           break;
         case 'initConnection': {
-          await startAsyncSpan(
+          // TODO (mlaw): tell mutagens about the new token too
+          this.#outboundStream = startSpan(
             tracer,
             'connection.initConnection',
-            async () => {
-              // TODO (mlaw): tell mutagens about the new token too
-              this.#outboundStream = await viewSyncer.initConnection(
-                this.#syncContext,
-                msg,
-              );
-              if (this.#closed) {
-                this.#outboundStream.cancel();
-              } else {
-                void this.#proxyOutbound(this.#outboundStream);
-              }
-            },
+            () => viewSyncer.initConnection(this.#syncContext, msg),
           );
+          void this.#proxyOutbound(this.#outboundStream);
           break;
         }
         default:


### PR DESCRIPTION
Restructure view-syncer / connection life-cycles to avoid a buildup of work on the lock for connections that have already disconnected.

* New connections are immediately set up, in both `connection.ts` and the `#clients` variable in `view-syncer.ts`, rather than waiting on the lock for the `initConnection` message to be processed. This ensures that if the connection is closed by the browser before the `initConnection` message is able to be processed, we properly drop the work and release the connection.
* The idle timeout logic has been removed. Shutdown now happens if the pending rows have been flushed and no keepalive has been signaled.
* Once the view-syncer has been shutdown, any queued work on the lock is aborted. This avoids the buildup of work that is wasted on clients that have already disconnected, as well as the potential for multiple view-syncers in the same process operating on the CVR.