### PR TITLE
chore(zero-cache): process forking API improvements

### DIFF
--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -4,6 +4,7 @@
 
 import {parseOptions, type Config} from '../../../shared/src/options.js';
 import * as v from '../../../shared/src/valita.js';
+import {singleProcessMode} from '../types/processes.js';
 
 /**
  * Configures the view of the upstream database replicated to this zero-cache.
@@ -321,9 +322,12 @@ const ENV_VAR_PREFIX = 'ZERO_';
 
 let loadedConfig: ZeroConfig | undefined;
 
-export function getZeroConfig(argv = process.argv.slice(2)): ZeroConfig {
-  if (!loadedConfig) {
-    loadedConfig = parseOptions(zeroOptions, argv, ENV_VAR_PREFIX);
+export function getZeroConfig(
+  env: NodeJS.ProcessEnv = process.env,
+  argv = process.argv.slice(2),
+): ZeroConfig {
+  if (!loadedConfig || singleProcessMode()) {
+    loadedConfig = parseOptions(zeroOptions, argv, ENV_VAR_PREFIX, env);
   }
 
   return loadedConfig;

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -16,8 +16,11 @@ import {
 import {exitAfter, runUntilKilled} from './life-cycle.js';
 import {createLogContext} from './logging.js';
 
-export default async function runWorker(parent: Worker): Promise<void> {
-  const config = getZeroConfig();
+export default async function runWorker(
+  parent: Worker,
+  env: NodeJS.ProcessEnv,
+): Promise<void> {
+  const config = getZeroConfig(env);
   const port = config.changeStreamerPort ?? config.port + 1;
   const lc = createLogContext(config.log, {worker: 'change-streamer'});
 
@@ -85,5 +88,5 @@ export default async function runWorker(parent: Worker): Promise<void> {
 
 // fork()
 if (!singleProcessMode()) {
-  void exitAfter(() => runWorker(must(parentWorker)));
+  void exitAfter(() => runWorker(must(parentWorker), process.env));
 }

--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -23,12 +23,13 @@ import {createLogContext} from './logging.js';
 
 export default async function runWorker(
   parent: Worker,
+  env: NodeJS.ProcessEnv,
   ...args: string[]
 ): Promise<void> {
   assert(args.length > 0, `replicator mode not specified`);
   const fileMode = v.parse(args[0], replicaFileModeSchema);
 
-  const config = getZeroConfig(args.slice(1));
+  const config = getZeroConfig(env, args.slice(1));
   const mode: ReplicatorMode = fileMode === 'backup' ? 'backup' : 'serving';
   const workerName = `${mode}-replicator`;
   const lc = createLogContext(config.log, {worker: workerName});
@@ -64,5 +65,7 @@ export default async function runWorker(
 
 // fork()
 if (!singleProcessMode()) {
-  void exitAfter(() => runWorker(must(parentWorker), ...process.argv.slice(2)));
+  void exitAfter(() =>
+    runWorker(must(parentWorker), process.env, ...process.argv.slice(2)),
+  );
 }


### PR DESCRIPTION
* move modulePath resolution logic into `childWorker()` method (with the specification that the `modulePath` is interpreted as relative to `zero-cache/src/`
* add ability to pass ENV into child
* fix `SINGLE_PROCESS=1` mode when loading the config