### PR TITLE
fix(zero-cache): check replication slot before updating upstream schema

### DIFF
--- a/apps/zbugs/docker/init_upstream/init.sql
+++ b/apps/zbugs/docker/init_upstream/init.sql
@@ -274,9 +274,4 @@ CREATE INDEX issue_open_modified_idx ON issue (open, modified);
 
 CREATE INDEX comment_issueid_idx ON "comment" ("issueID");
 
-SELECT
-    *
-FROM
-    pg_create_logical_replication_slot('zero_0', 'pgoutput');
-
 VACUUM;


### PR DESCRIPTION
Check that the replication slot exists before attempting to update the upstream schema.

This detects (earlier) that the upstream is no longer setup as expected and provides a better error message than https://discord.com/channels/830183651022471199/1314733500649312276/1314733632417697802.

<img width="846" alt="Screenshot 2024-12-08 at 18 30 02" src="https://github.com/user-attachments/assets/3358b457-8c1f-46e8-95a7-a2f34cb3a0b1">


Also remove the replication slot setup from `init.sql`. It should be done by `zero-cache` during initial sync.
