### PR TITLE
exists can get `remove` events for items with `0` count

### DIFF
--- a/packages/zql/src/ivm/exists.ts
+++ b/packages/zql/src/ivm/exists.ts
@@ -143,6 +143,7 @@ export class Exists implements Operator {
           case 'remove': {
             let size = this.#getSize(change.row);
             if (size !== undefined) {
+              console.log('SIZE', size, change.row);
               assert(size > 0);
               size--;
               this.#setSize(change.row, size);


### PR DESCRIPTION
We have the following query & pipeline:

```ts
comment.whereExists('issue').take(1)
```

```mermaid
flowchart TD;
    Comment --> Join{comment.issueId = issue.id}
    Issue --> Join
    Join --> exists[issue exists]
    exists --> take[take 1]
```

And initial state:

issue
|id|
|--|
|i1|

comment
|id|issueId|
|--|--|
|c1|i1|
|c2|i1|
|c3|i1|

take contains `c1` in its window.

Then we send a `remove` change for `i1`.

The graph will process the change like so:

1. remove is pushed into issue source
2. remove is pushed into join
3. join fetches c1,c2,c3
4. join starts a loop and pushes [c1, remove i1] (c2,c3 are next up in the loop but not pushed yet)
5. exists pushes remove c1 (because i1 no longer exists)
6. take loses its item and fetches to re-fill its window

This fetch from take lands us into join while join still has to push `c2,c3` (step 4). The fetch will grab `c2` and later join will also push `c2`, causing duplicate events downstream.


---

## Potential option to address this --

Facts:
1. Fetches only return down a single path
2. Pushes go down all paths

Given (1) and (2), a fetch cannot alter future pushes as that would cause other branches to miss data.
A `fetch`, however, can be altered by future pushes as those pushes will eventually make it to the fetcher.

In the specific example of this PR, could `join` behave differently when responding to a `fetch` while it is pushing?

When join processes the fetch, could it decide to omit any and all rows from the fetch that are going to be present in the pushes it still has left to send?

```ts
*fetch() {
  for (node of upstream.fetch()) {
    if (futurePushes.contains(node)) { continue }
    yield node;
  }
}
```

"future pushes" are those pushes the operators knows it will send but has not yet sent. 

Downside: 
- join must eagerly collect everything it will eventually push before pushing it

We don't have lazy pushes today so while this doesn't regress from the status quo it does preclude making push lazy.

> Given (1) and (2), a fetch cannot alter future pushes as that would cause other branches to miss data.

is that true? If we can make push lazy then we could stop the push once `take` is happy. In this case `take` would have to convert the node from its `fetch` that satisfied it to a push to downstream.
