### PR TITLE
feat(zbugs): Show up to three emojis toasts

### DIFF
--- a/apps/zbugs/src/index.css
+++ b/apps/zbugs/src/index.css
@@ -1277,7 +1277,6 @@ emoji-picker {
   min-height: 0;
   background-color: transparent;
   box-shadow: none;
-  margin: 0;
 }
 
 .Toastify__toast-body {

--- a/apps/zbugs/src/pages/issue/issue-page.tsx
+++ b/apps/zbugs/src/pages/issue/issue-page.tsx
@@ -223,13 +223,12 @@ export function IssuePage() {
         <ToastContainer
           hideProgressBar={true}
           theme="dark"
-          stacked={true}
           containerId="bottom"
           newestOnTop={true}
           closeButton={false}
           position="bottom-center"
           closeOnClick={true}
-          limit={10}
+          limit={3}
           // Auto close is broken. So we will manage it ourselves.
           autoClose={false}
         />


### PR DESCRIPTION
Instead of using stacked we show up to 3 toasts at the same time. When there are more than 3 toasts, the new toasts are shown after the old ones are hidden.