### PR TITLE
fix(zql): Remove assert that start must match constraint

### DIFF
--- a/packages/zql/src/ivm/memory-source.ts
+++ b/packages/zql/src/ivm/memory-source.ts
@@ -263,20 +263,7 @@ export class MemorySource implements Source {
       }
     }
 
-    const {constraint} = req;
-    const matchesConstraint = constraint
-      ? (row: Row) => constraintMatchesRow(constraint, row)
-      : (_: Row) => true;
-
     const startAt = req.start?.row;
-    if (startAt) {
-      if (req.constraint) {
-        // There's no problem supporting startAt outside of constraints, but I
-        // don't think we have a use case for this – if we see it, it's probably
-        // a bug.
-        assert(matchesConstraint(startAt), 'Start row must match constraint');
-      }
-    }
 
     // If there is a constraint, we want to start our scan at the first row that
     // matches the constraint. But because the next OrderPart can be `desc`,

--- a/packages/zql/src/ivm/skip.test.ts
+++ b/packages/zql/src/ivm/skip.test.ts
@@ -1,16 +1,12 @@
 import {expect, suite, test} from 'vitest';
 import {Catch} from './catch.js';
-import type {Start} from './operator.js';
 import {type Bound, Skip} from './skip.js';
 import type {SourceChange} from './source.js';
 import {createSource} from './test/source-factory.js';
+import type {FetchRequest} from './operator.js';
 
 suite('fetch', () => {
-  function t(c: {
-    skipBound: Bound;
-    fetchBound: Start | undefined;
-    fetchReverse?: boolean | undefined;
-  }) {
+  function t(c: {skipBound: Bound; fetchRequest: FetchRequest}) {
     const ms = createSource(
       'users',
       {
@@ -57,14 +53,14 @@ suite('fetch', () => {
 
     const skip = new Skip(conn, c.skipBound);
     const out = new Catch(skip);
-    return out.fetch({start: c.fetchBound, reverse: c.fetchReverse});
+    return out.fetch(c.fetchRequest);
   }
 
   test('c1', () => {
     expect(
       t({
         skipBound: {row: {startDate: '2023-03-31', id: 5}, exclusive: false},
-        fetchBound: undefined,
+        fetchRequest: {},
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -100,7 +96,7 @@ suite('fetch', () => {
     expect(
       t({
         skipBound: {row: {startDate: '2023-03-31', id: 5}, exclusive: true},
-        fetchBound: undefined,
+        fetchRequest: {},
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -136,7 +132,7 @@ suite('fetch', () => {
     expect(
       t({
         skipBound: {row: {startDate: '2023-04-01', id: 5}, exclusive: false},
-        fetchBound: undefined,
+        fetchRequest: {},
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -172,7 +168,7 @@ suite('fetch', () => {
     expect(
       t({
         skipBound: {row: {startDate: '2023-04-01', id: 5}, exclusive: true},
-        fetchBound: undefined,
+        fetchRequest: {},
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -200,7 +196,7 @@ suite('fetch', () => {
     expect(
       t({
         skipBound: {row: {startDate: '2023-04-02', id: 4}, exclusive: false},
-        fetchBound: undefined,
+        fetchRequest: {},
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -228,7 +224,7 @@ suite('fetch', () => {
     expect(
       t({
         skipBound: {row: {startDate: '2023-04-02', id: 4}, exclusive: true},
-        fetchBound: undefined,
+        fetchRequest: {},
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -256,7 +252,9 @@ suite('fetch', () => {
     expect(
       t({
         skipBound: {row: {startDate: '2023-04-01', id: 5}, exclusive: false},
-        fetchBound: {row: {startDate: '2023-03-30', id: 5}, basis: 'at'},
+        fetchRequest: {
+          start: {row: {startDate: '2023-03-30', id: 5}, basis: 'at'},
+        },
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -292,7 +290,9 @@ suite('fetch', () => {
     expect(
       t({
         skipBound: {row: {startDate: '2023-04-01', id: 5}, exclusive: false},
-        fetchBound: {row: {startDate: '2023-03-30', id: 5}, basis: 'after'},
+        fetchRequest: {
+          start: {row: {startDate: '2023-03-30', id: 5}, basis: 'after'},
+        },
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -328,7 +328,9 @@ suite('fetch', () => {
     expect(
       t({
         skipBound: {row: {startDate: '2023-04-01', id: 5}, exclusive: false},
-        fetchBound: {row: {startDate: '2023-04-01', id: 5}, basis: 'at'},
+        fetchRequest: {
+          start: {row: {startDate: '2023-04-01', id: 5}, basis: 'at'},
+        },
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -364,7 +366,9 @@ suite('fetch', () => {
     expect(
       t({
         skipBound: {row: {startDate: '2023-04-01', id: 5}, exclusive: false},
-        fetchBound: {row: {startDate: '2023-04-01', id: 5}, basis: 'after'},
+        fetchRequest: {
+          start: {row: {startDate: '2023-04-01', id: 5}, basis: 'after'},
+        },
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -392,7 +396,9 @@ suite('fetch', () => {
     expect(
       t({
         skipBound: {row: {startDate: '2023-04-01', id: 5}, exclusive: true},
-        fetchBound: {row: {startDate: '2023-04-01', id: 5}, basis: 'at'},
+        fetchRequest: {
+          start: {row: {startDate: '2023-04-01', id: 5}, basis: 'at'},
+        },
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -420,7 +426,9 @@ suite('fetch', () => {
     expect(
       t({
         skipBound: {row: {startDate: '2023-04-02', id: 5}, exclusive: false},
-        fetchBound: {row: {startDate: '2023-04-01', id: 5}, basis: 'at'},
+        fetchRequest: {
+          start: {row: {startDate: '2023-04-01', id: 5}, basis: 'at'},
+        },
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -448,7 +456,9 @@ suite('fetch', () => {
     expect(
       t({
         skipBound: {row: {startDate: '2023-04-02', id: 5}, exclusive: true},
-        fetchBound: {row: {startDate: '2023-04-01', id: 5}, basis: 'at'},
+        fetchRequest: {
+          start: {row: {startDate: '2023-04-01', id: 5}, basis: 'at'},
+        },
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -475,7 +485,9 @@ suite('fetch', () => {
     expect(
       t({
         skipBound: {row: {startDate: '2023-04-02', id: 5}, exclusive: true},
-        fetchBound: {row: {startDate: '2023-04-01', id: 5}, basis: 'after'},
+        fetchRequest: {
+          start: {row: {startDate: '2023-04-01', id: 5}, basis: 'after'},
+        },
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -503,7 +515,9 @@ suite('fetch', () => {
     expect(
       t({
         skipBound: {row: {startDate: '2023-04-02', id: 5}, exclusive: true},
-        fetchBound: {row: {startDate: '2023-04-02', id: 5}, basis: 'after'},
+        fetchRequest: {
+          start: {row: {startDate: '2023-04-02', id: 5}, basis: 'after'},
+        },
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -531,9 +545,42 @@ suite('fetch', () => {
     expect(
       t({
         skipBound: {row: {startDate: '2023-04-02', id: 5}, exclusive: true},
-        fetchBound: {row: {startDate: '2030-04-02', id: 5}, basis: 'after'},
+        fetchRequest: {
+          start: {row: {startDate: '2030-04-02', id: 5}, basis: 'after'},
+        },
       }),
     ).toMatchInlineSnapshot(`[]`);
+  });
+
+  test('fetch request constraint does not match bounds', () => {
+    expect(
+      t({
+        skipBound: {row: {startDate: '2023-04-01', id: 5}, exclusive: false},
+        fetchRequest: {constraint: {id: 6}},
+      }),
+    ).toMatchInlineSnapshot(`
+      [
+        {
+          "relationships": {},
+          "row": {
+            "id": 6,
+            "name": "Darick",
+            "startDate": "2023-09-01",
+          },
+        },
+      ]
+    `);
+  });
+
+  test('fetch request constraint does not match bounds, only row matches constraint is before bounds', () => {
+    expect(
+      t({
+        skipBound: {row: {startDate: '2023-04-01', id: 5}, exclusive: false},
+        fetchRequest: {constraint: {id: 3}},
+      }),
+    ).toMatchInlineSnapshot(`
+      []
+    `);
   });
 
   suite('reverse', () => {
@@ -544,8 +591,7 @@ suite('fetch', () => {
             row: {startDate: '2023-03-31', id: 5},
             exclusive: false,
           },
-          fetchBound: undefined,
-          fetchReverse: true,
+          fetchRequest: {reverse: true},
         }),
       ).toMatchInlineSnapshot(`
         [
@@ -581,8 +627,7 @@ suite('fetch', () => {
       expect(
         t({
           skipBound: {row: {startDate: '2023-03-31', id: 5}, exclusive: true},
-          fetchBound: undefined,
-          fetchReverse: true,
+          fetchRequest: {reverse: true},
         }),
       ).toMatchInlineSnapshot(`
         [
@@ -621,8 +666,7 @@ suite('fetch', () => {
             row: {startDate: '2023-04-01', id: 5},
             exclusive: false,
           },
-          fetchBound: undefined,
-          fetchReverse: true,
+          fetchRequest: {reverse: true},
         }),
       ).toMatchInlineSnapshot(`
         [
@@ -661,8 +705,7 @@ suite('fetch', () => {
             row: {startDate: '2023-04-01', id: 5},
             exclusive: true,
           },
-          fetchBound: undefined,
-          fetchReverse: true,
+          fetchRequest: {reverse: true},
         }),
       ).toMatchInlineSnapshot(`
         [
@@ -693,8 +736,10 @@ suite('fetch', () => {
             row: {startDate: '2023-04-01', id: 5},
             exclusive: false,
           },
-          fetchBound: {row: {startDate: '2023-03-30', id: 5}, basis: 'at'},
-          fetchReverse: true,
+          fetchRequest: {
+            start: {row: {startDate: '2023-03-30', id: 5}, basis: 'at'},
+            reverse: true,
+          },
         }),
       ).toMatchInlineSnapshot(`[]`);
     });
@@ -706,8 +751,10 @@ suite('fetch', () => {
             row: {startDate: '2023-04-01', id: 5},
             exclusive: false,
           },
-          fetchBound: {row: {startDate: '2023-04-01', id: 5}, basis: 'at'},
-          fetchReverse: true,
+          fetchRequest: {
+            start: {row: {startDate: '2023-04-01', id: 5}, basis: 'at'},
+            reverse: true,
+          },
         }),
       ).toMatchInlineSnapshot(`
         [
@@ -730,8 +777,10 @@ suite('fetch', () => {
             row: {startDate: '2023-04-01', id: 5},
             exclusive: false,
           },
-          fetchBound: {row: {startDate: '2023-03-30', id: 5}, basis: 'after'},
-          fetchReverse: true,
+          fetchRequest: {
+            start: {row: {startDate: '2023-03-30', id: 5}, basis: 'after'},
+            reverse: true,
+          },
         }),
       ).toMatchInlineSnapshot(`[]`);
     });
@@ -740,8 +789,10 @@ suite('fetch', () => {
       expect(
         t({
           skipBound: {row: {startDate: '2023-04-01', id: 5}, exclusive: true},
-          fetchBound: {row: {startDate: '2023-04-01', id: 5}, basis: 'at'},
-          fetchReverse: true,
+          fetchRequest: {
+            start: {row: {startDate: '2023-04-01', id: 5}, basis: 'at'},
+            reverse: true,
+          },
         }),
       ).toMatchInlineSnapshot(`[]`);
     });
@@ -750,8 +801,10 @@ suite('fetch', () => {
       expect(
         t({
           skipBound: {row: {startDate: '2023-04-00', id: 5}, exclusive: true},
-          fetchBound: {row: {startDate: '2023-09-01', id: 5}, basis: 'after'},
-          fetchReverse: true,
+          fetchRequest: {
+            start: {row: {startDate: '2023-09-01', id: 5}, basis: 'after'},
+            reverse: true,
+          },
         }),
       ).toMatchInlineSnapshot(`
         [
@@ -771,8 +824,10 @@ suite('fetch', () => {
       expect(
         t({
           skipBound: {row: {startDate: '2023-04-02', id: 5}, exclusive: true},
-          fetchBound: {row: {startDate: '2023-04-02', id: 5}, basis: 'after'},
-          fetchReverse: true,
+          fetchRequest: {
+            start: {row: {startDate: '2023-04-02', id: 5}, basis: 'after'},
+            reverse: true,
+          },
         }),
       ).toMatchInlineSnapshot(`[]`);
     });
@@ -781,8 +836,10 @@ suite('fetch', () => {
       expect(
         t({
           skipBound: {row: {startDate: '2020-08-01', id: 2}, exclusive: true},
-          fetchBound: {row: {startDate: '2023-06-01', id: 7}, basis: 'after'},
-          fetchReverse: true,
+          fetchRequest: {
+            start: {row: {startDate: '2023-06-01', id: 7}, basis: 'after'},
+            reverse: true,
+          },
         }),
       ).toMatchInlineSnapshot(`
         [


### PR DESCRIPTION
This assert has the comment:
```
        // There's no problem supporting startAt outside of constraints, but I
        // don't think we have a use case for this – if we see it, it's probably
        // a bug.
```
This was probably true when there was just filter, take and join.

However, now there is a case where this happens, specifically with skip.  

Scenario:

Query has a related and a startAt (i.e. Join and Skip operators).

1. join receives a push from child input
2. join fetches from parent input with `constraint: { parentKey: parentValue }`.
3. skip fetches from input with `constraint: { parentKey: parentValue }, startAt: bound`.

Skips bound is whatever row the user passed to query.startAt, and it may not match constraint.

This assert was only ever done in MemorySource, so TableSource did not have to be updated.