### PR TITLE
feat(zql): support `enum` types in the query API

### DIFF
--- a/packages/zero-client/src/mod.ts
+++ b/packages/zero-client/src/mod.ts
@@ -62,6 +62,7 @@ export {createSchema} from '../../zero-schema/src/schema.js';
 export {
   createTableSchema,
   type TableSchema,
+  column,
 } from '../../zero-schema/src/table-schema.js';
 export {escapeLike} from '../../zql/src/query/escape-like.js';
 export type {


### PR DESCRIPTION
we should really start doing data validation though.

![CleanShot 2024-12-09 at 23 47 49@2x](https://github.com/user-attachments/assets/b6016ca6-beed-405f-a09c-c7bf97d0dd98)
