### PR TITLE
feat(zero-cache): add plumbing for handing off a socket multiple times

### DIFF
--- a/packages/zero-cache/src/services/dispatcher/dispatcher.ts
+++ b/packages/zero-cache/src/services/dispatcher/dispatcher.ts
@@ -1,7 +1,7 @@
 import {LogContext} from '@rocicorp/logger';
-import {IncomingMessage} from 'http';
 import UrlPattern from 'url-pattern';
 import {h32} from '../../../../shared/src/xxhash.js';
+import type {IncomingMessageSubset} from '../../types/http.js';
 import type {Worker} from '../../types/processes.js';
 import {HttpService, type Options} from '../http-service.js';
 import {getConnectParams} from './connect-params.js';
@@ -26,13 +26,13 @@ export class Dispatcher extends HttpService {
   ) {
     super('dispatcher', lc, opts, fastify => {
       fastify.get('/', (_req, res) => res.send('OK'));
-      installWebSocketHandoff(lc, fastify.server, req => this.#handoff(req));
+      installWebSocketHandoff(lc, req => this.#handoff(req), fastify.server);
     });
 
     this.#workersByHostname = workersByHostname;
   }
 
-  #handoff(req: IncomingMessage) {
+  #handoff(req: IncomingMessageSubset) {
     const {headers, url: u} = req;
     const url = new URL(u ?? '', 'http://unused/');
     const syncPath = parseSyncPath(url);

--- a/packages/zero-cache/src/services/dispatcher/websocket-handoff.ts
+++ b/packages/zero-cache/src/services/dispatcher/websocket-handoff.ts
@@ -3,32 +3,45 @@ import {IncomingMessage, Server} from 'node:http';
 import {Socket} from 'node:net';
 import type {WebSocket, WebSocketServer} from 'ws';
 import {
+  serializableSubset,
+  type IncomingMessageSubset,
+} from '../../types/http.js';
+import {
   MESSAGE_TYPES,
+  parentWorker,
   type Receiver,
   type Sender,
 } from '../../types/processes.js';
 
-export type WebSocketHandoff<P> = (message: IncomingMessage) => {
+export type WebSocketHandoff<P> = (message: IncomingMessageSubset) => {
   payload: P;
   receiver: Receiver;
 };
 
 export type WebSocketReceiver<P> = (ws: WebSocket, payload: P) => void;
 
+/**
+ * Installs websocket handoff logic from either or both of
+ * an HTTP `server` receiving requests, or a `parent` process
+ * that is handing off requests to this process.
+ */
 export function installWebSocketHandoff<P>(
   lc: LogContext,
-  server: Server,
   handoff: WebSocketHandoff<P>,
+  server: Server | undefined,
+  parent = parentWorker,
 ) {
-  server.on('upgrade', (req, socket, head) => {
+  const handle = (
+    message: IncomingMessageSubset,
+    socket: Socket,
+    head: Buffer,
+  ) => {
     try {
-      const {payload, receiver} = handoff(req);
-      const {headers, method = 'GET'} = req;
-
+      const {payload, receiver} = handoff(message);
       const data = [
         'handoff',
         {
-          message: {headers, method},
+          message: serializableSubset(message),
           head,
           payload,
         },
@@ -42,6 +55,14 @@ export function installWebSocketHandoff<P>(
       socket.write(`HTTP/1.1 400 Bad Request\r\n${String(error)}`);
       return;
     }
+  };
+
+  server?.on('upgrade', handle);
+
+  // Double-handoff: handoff messages from this worker's parent.
+  parent?.onMessageType<Handoff<P>>('handoff', (msg, socket) => {
+    const {message, head} = msg;
+    handle(message, socket as Socket, Buffer.from(head));
   });
 }
 
@@ -60,18 +81,6 @@ export function installWebSocketReceiver<P>(
     );
   });
 }
-
-// Contains the subset of http.IncomingRequest passed from the main thread
-// to the syncer thread to hand off the upgrade of the request to a WebSocket.
-// This is specific to the handoff receiver implementation
-// WebSocketServer.handleUpgrade(), which takes the http.IncomingMessage type but only
-// inspects the "headers" and "method" fields. It is the solution recommended
-// by the author of the 'ws' library:
-// https://github.com/websockets/ws/issues/154#issuecomment-304511349
-type IncomingMessageSubset = {
-  headers: Record<string, string | string[] | undefined>;
-  method: string;
-};
 
 type Handoff<P> = [
   typeof MESSAGE_TYPES.handoff,

--- a/packages/zero-cache/src/types/http.ts
+++ b/packages/zero-cache/src/types/http.ts
@@ -1,0 +1,46 @@
+import type {IncomingMessage} from 'http';
+
+/**
+ * Contains the subset of {@link IncomingMessage} fields suitable for
+ * passing across processes.
+ */
+export type IncomingMessageSubset = Pick<
+  IncomingMessage,
+  | 'headers'
+  | 'headersDistinct'
+  | 'httpVersion'
+  | 'method'
+  | 'rawHeaders'
+  | 'rawTrailers'
+  | 'trailers'
+  | 'trailersDistinct'
+  | 'url'
+>;
+
+export function serializableSubset(
+  msg: IncomingMessageSubset,
+): IncomingMessageSubset {
+  const {
+    headers,
+    headersDistinct,
+    httpVersion,
+    method = 'GET',
+    rawHeaders,
+    rawTrailers,
+    trailers,
+    trailersDistinct,
+    url,
+  } = msg;
+
+  return {
+    headers,
+    headersDistinct,
+    httpVersion,
+    method,
+    rawHeaders,
+    rawTrailers,
+    trailers,
+    trailersDistinct,
+    url,
+  };
+}


### PR DESCRIPTION
Extends the websocket handoff logic to accept messages from the parent process as a source of handoffs (as opposed to an http server).

This will allow multiple handoffs, each with their own child Worker selection logic, e.g.
* `multi/main.ts` selects a tenant based on host / url, then
* `server/main.ts` selects a sync worker by `clientGroupID`

This will allow the multi-tenant logic remain abstracted from the details of zero-cache dispatch, and preserve the direct-to-client socket communication in the sync worker.