### PR TITLE
fix(zbugs): Fix issue with permalinks

### DIFF
--- a/apps/zbugs/src/comment-permalink.ts
+++ b/apps/zbugs/src/comment-permalink.ts
@@ -1,0 +1,9 @@
+const prefix = 'comment-';
+
+export function parsePermalink(hash: string): string | undefined {
+  return hash.startsWith(prefix) ? hash.slice(prefix.length) : undefined;
+}
+
+export function makePermalink(comment: {id: string}): string {
+  return prefix + comment.id;
+}

--- a/apps/zbugs/src/pages/issue/comment.tsx
+++ b/apps/zbugs/src/pages/issue/comment.tsx
@@ -1,6 +1,7 @@
 import {useQuery} from '@rocicorp/zero/react';
 import classNames from 'classnames';
 import {memo, useState} from 'react';
+import {makePermalink} from '../../comment-permalink.js';
 import {Button} from '../../components/button.js';
 import {CanEdit} from '../../components/can-edit.js';
 import {Confirm} from '../../components/confirm.js';
@@ -28,12 +29,6 @@ type Props = {
   removeRecentEmoji: (id: string) => void;
 };
 
-// eslint-disable-next-line react-refresh/only-export-components
-export function parsePermalink(hash: string): string | undefined {
-  const match = hash.match(/^comment-(.+)$/);
-  return match ? match?.[1] : undefined;
-}
-
 const Comment = memo(
   ({id, issueID, height, recentEmojis, removeRecentEmoji}: Props) => {
     const z = useZero();
@@ -48,7 +43,7 @@ const Comment = memo(
       useState(false);
 
     const hash = useHash();
-    const permalink = comment ? `comment-${comment.id}` : undefined;
+    const permalink = comment && makePermalink(comment);
     const isPermalinked = hash === permalink;
 
     const edit = () => setEditing(true);

--- a/apps/zbugs/src/pages/issue/issue-page.tsx
+++ b/apps/zbugs/src/pages/issue/issue-page.tsx
@@ -23,6 +23,7 @@ import {must} from '../../../../../packages/shared/src/must.js';
 import type {CommentRow, IssueRow, Schema} from '../../../schema.js';
 import statusClosed from '../../assets/icons/issue-closed.svg';
 import statusOpen from '../../assets/icons/issue-open.svg';
+import {parsePermalink} from '../../comment-permalink.js';
 import {Button} from '../../components/button.js';
 import {CanEdit} from '../../components/can-edit.js';
 import {Combobox} from '../../components/combobox.js';
@@ -44,7 +45,7 @@ import {LRUCache} from '../../lru-cache.js';
 import {links, type ListContext, type ZbugsHistoryState} from '../../routes.js';
 import {preload} from '../../zero-setup.js';
 import CommentComposer from './comment-composer.js';
-import Comment, {parsePermalink} from './comment.js';
+import Comment from './comment.js';
 
 const emojiToastShowDuration = 3_000;
 
@@ -171,12 +172,17 @@ export function IssuePage() {
     const commentIndex = comments.findIndex(c => c.id === commentID);
     if (commentIndex !== -1) {
       virtualizer.scrollToIndex(commentIndex, {
-        align: 'center',
+        // auto for minimal amount of scrolling.
+        align: 'auto',
         // The `smooth` scroll behavior is not fully supported with dynamic size.
         // behavior: 'smooth',
       });
     }
-  }, [hash, issue, virtualizer]);
+    // Issue changes any time there is a change in the issue. For example when
+    // the `modified` or `assignee` changes.
+    //
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hash, issue?.id, virtualizer]);
 
   const [deleteConfirmationShown, setDeleteConfirmationShown] = useState(false);
 


### PR DESCRIPTION
The code to handle permalinking was in a `useEffect` which depended on `issue`. Hoever, the `issue` changes all the time (for example when an emoji is added the modified field is updated).

To fix this we manage the dependencies to the `useEffect` manually.