### PR TITLE
fix(zero-cache): fix "npm run start" script

### DIFF
--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -12,7 +12,7 @@
     "check-format": "prettier --check .",
     "lint": "eslint --ext .ts,.tsx,.js,.jsx src/",
     "local": "tsx tool/local.ts",
-    "start": "tsx ./src/server/main.ts",
+    "start": "tsx ./src/server/multi/main.ts",
     "bench": "tsx ./bench/bench.ts",
     "double": "tsx ./bench/double.ts",
     "wal_bench": "tsx ./bench/wal-bench.ts",


### PR DESCRIPTION
Point `npm run start` to the new entry multi-tenant entry point in #3272.

(Not sure who uses this, but just to be complete)