### PR TITLE
chore(zero-cache): move TaskID lookup to top-level module

### DIFF
--- a/packages/zero-cache/src/server/life-cycle.ts
+++ b/packages/zero-cache/src/server/life-cycle.ts
@@ -24,9 +24,10 @@ export const GRACEFUL_SHUTDOWN = ['SIGTERM', 'SIGINT'] as const;
 export const FORCEFUL_SHUTDOWN = ['SIGQUIT'] as const;
 
 /**
- * Handles termination signals and coordination of graceful shutdown.
+ * Handles readiness, termination signals, and coordination of graceful
+ * shutdown.
  */
-export class Terminator {
+export class ProcessManager {
   readonly #lc: LogContext;
   readonly #userFacing = new Set<Worker>();
   readonly #all = new Set<Worker>();
@@ -45,7 +46,7 @@ export class Terminator {
     this.#lc = lc.withContext('component', 'life-cycle');
 
     // Propagate `SIGTERM` and `SIGINT` to all user-facing workers,
-    // initiating a graceful shutdown. The terminator process will
+    // initiating a graceful shutdown. The parent process will
     // exit once all user-facing workers have exited ...
     for (const signal of GRACEFUL_SHUTDOWN) {
       proc.on(signal, () => this.#startDrain(signal));

--- a/packages/zero-cache/src/server/multi/runtime.ts
+++ b/packages/zero-cache/src/server/multi/runtime.ts
@@ -1,6 +1,6 @@
 import type {LogContext} from '@rocicorp/logger';
 import {nanoid} from 'nanoid';
-import * as v from '../../../shared/src/valita.js';
+import * as v from '../../../../shared/src/valita.js';
 
 // https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4-response.html
 const containerMetadataSchema = v.object({['TaskARN']: v.string()});


### PR DESCRIPTION
Look up the Task ID (i.e. AWS ARN) in the top-level main module rather than in each zero-cache tenant.

Also improve some renaming. "Terminator" was cool, but it does more than that now.