### PR TITLE
fix(zbugs): Misc search ui fixes

### DIFF
--- a/apps/zbugs/src/hooks/use-click-outside.ts
+++ b/apps/zbugs/src/hooks/use-click-outside.ts
@@ -7,6 +7,10 @@ export const useClickOutside = (
   const handleClick = useCallback(
     (event: MouseEvent | TouchEvent) => {
       const target = event.target as Node | null;
+      if (!target || !target.isConnected) {
+        // target got removed from document?
+        return;
+      }
       const isOutside = Array.isArray(ref)
         ? ref
             .map(r => r.current)

--- a/apps/zbugs/src/hooks/use-keypress.ts
+++ b/apps/zbugs/src/hooks/use-keypress.ts
@@ -7,11 +7,12 @@ export function useKeypress(
   allowOnInputElements = false,
 ) {
   useEffect(() => {
-    function handleKeypress(event: KeyboardEvent) {
+    function handleKeypress(e: KeyboardEvent) {
       if (
-        event.key === key &&
-        (allowOnInputElements || shouldAllow(event.target as HTMLElement))
+        e.key === key &&
+        (allowOnInputElements || shouldAllow(e.target as HTMLElement))
       ) {
+        e.preventDefault();
         callback();
       }
     }

--- a/apps/zbugs/src/pages/list/list-page.tsx
+++ b/apps/zbugs/src/pages/list/list-page.tsx
@@ -177,6 +177,12 @@ export function ListPage() {
     updateTextFilterQueryString(text);
   };
 
+  const clearAndHideSearch = () => {
+    setTextFilter('');
+    updateTextFilterQueryString('');
+    setForceSearchMode(false);
+  };
+
   const Row = ({index, style}: {index: number; style: CSSProperties}) => {
     const issue = issues[index];
     if (firstRowRendered === false) {
@@ -242,24 +248,20 @@ export function ListPage() {
   const searchMode = forceSearchMode || Boolean(textFilter);
   const searchBox = useRef<HTMLHeadingElement>(null);
   const startSearchButton = useRef<HTMLButtonElement>(null);
-  useKeypress('/', () => startSearch());
+  useKeypress('/', () => setForceSearchMode(true));
   useClickOutside([searchBox, startSearchButton], () =>
     setForceSearchMode(false),
   );
-  const startSearch = () => {
-    if (forceSearchMode) {
-      // If already in search mode, toggle it off
-      setForceSearchMode(false);
-      searchBox.current?.querySelector('input')?.blur(); // Remove focus from input
-    } else {
-      // If not in search mode, activate it
-      setForceSearchMode(true);
-      setTimeout(() => searchBox.current?.querySelector('input')?.focus(), 0);
-    }
-  };
   const handleSearchKeyUp = (e: KeyboardEvent) => {
     if (e.key === 'Escape') {
-      searchBox.current?.querySelector('input')?.blur();
+      clearAndHideSearch();
+    }
+  };
+  const toggleSearchMode = () => {
+    if (searchMode) {
+      clearAndHideSearch();
+    } else {
+      setForceSearchMode(true);
     }
   };
 
@@ -283,16 +285,16 @@ export function ListPage() {
                 onBlur={() => setForceSearchMode(false)}
                 onKeyUp={handleSearchKeyUp}
                 placeholder="Search…"
+                autoFocus={true}
               />
               {textFilter && (
-                <div
+                <Button
                   className="clear-search"
-                  onClick={() => onTextFilterChange('')} // Clear the search field
-                  role="button"
+                  onAction={() => setTextFilter('')} // Clear the search field
                   aria-label="Clear search"
                 >
                   &times;
-                </div>
+                </Button>
               )}
             </div>
           ) : (
@@ -304,7 +306,7 @@ export function ListPage() {
           ref={startSearchButton}
           className="search-toggle"
           eventName="Toggle Search"
-          onAction={startSearch}
+          onAction={toggleSearchMode}
         ></Button>
       </div>
       <div className="list-view-filter-container">


### PR DESCRIPTION
- Use autofocus instead of setTimeout
- Clear button `✖️` should clear the text and not hide the search UI.
- The magnifying glass `🔍` should clear and hide the search UI if the search UI is shown