### PR TITLE
fix(zbugs): Prevent spurious emoji toast on issue page

### DIFF
--- a/apps/zbugs/src/pages/issue/issue-page.tsx
+++ b/apps/zbugs/src/pages/issue/issue-page.tsx
@@ -794,28 +794,27 @@ function useEmojiChangeListener(
       return;
     }
 
-    if (!lastEmojis.current) {
-      return;
-    }
-    const added: Emoji[] = [];
-    const removed: Emoji[] = [];
+    if (lastEmojis.current) {
+      const added: Emoji[] = [];
+      const removed: Emoji[] = [];
 
-    for (const [id, emoji] of newEmojis) {
-      if (!lastEmojis.current.has(id)) {
-        added.push(emoji);
+      for (const [id, emoji] of newEmojis) {
+        if (!lastEmojis.current.has(id)) {
+          added.push(emoji);
+        }
       }
-    }
 
-    for (const [id, emoji] of lastEmojis.current) {
-      if (!newEmojis.has(id)) {
-        removed.push(emoji);
+      for (const [id, emoji] of lastEmojis.current) {
+        if (!newEmojis.has(id)) {
+          removed.push(emoji);
+        }
       }
-    }
 
-    if (added.length !== 0 || removed.length !== 0) {
-      cb(added, removed);
-    }
+      if (added.length !== 0 || removed.length !== 0) {
+        cb(added, removed);
+      }
 
-    lastEmojis.current = newEmojis;
+      lastEmojis.current = newEmojis;
+    }
   }, [cb, emojis, issueID, result.type]);
 }


### PR DESCRIPTION
The problem was that the IssuePage was being reused between J/K navigation and the `useEmojiChangeListener` was being reused between issues and when things are reused Refs do not get reset. The assumption here was that we would get a new `IssuePage` instance when navigating.

One solution is to add a `key` to the `IssuePage` in `root.tsx` but this was the first instance where we needed to do that and I felt like there might be some benefits of not tearing down and recreating the `IssuePage` when navigating.

So, instead I made the `useEmojiChangeListener` take the issue.id into account and reset the `lastEmojis` when the issue.id changes.

```
  // When the issue.id changes we reset lastEmojis to undefined.
  // First time we get the complete emojis for issue.id we update the lastEmojis.current.
  // After that as long as issue.id does not change we update lastEmojis.current with the new emojis.
```