### PR TITLE
chore(shared): add tests verifying rejection of duplicate flags/aliases

### DIFF
--- a/packages/shared/src/options.test.ts
+++ b/packages/shared/src/options.test.ts
@@ -729,6 +729,36 @@ test('envSchema', () => {
   `);
 });
 
+test('duplicate flag detection', () => {
+  expect(() =>
+    parseOptions(
+      {
+        fooBar: v.string().optional(),
+        foo: {bar: v.number().optional()},
+      },
+      [],
+    ),
+  ).toThrowError('Two or more option definitions have the same name');
+});
+
+test('duplicate short flag', () => {
+  expect(() =>
+    parseOptions(
+      {
+        foo: {
+          type: v.string().optional(),
+          alias: 'b',
+        },
+        bar: {
+          type: v.number().optional(),
+          alias: 'b',
+        },
+      },
+      [],
+    ),
+  ).toThrowError('Two or more option definitions have the same alias');
+});
+
 test.each([
   [
     'missing required flag',


### PR DESCRIPTION
The `commandLineArgs()` library already takes care of this for us.