### PR TITLE
fix(zbugs): Mobile inline video fix

### DIFF
--- a/apps/zbugs/src/components/markdown.tsx
+++ b/apps/zbugs/src/components/markdown.tsx
@@ -20,6 +20,7 @@ const rehypeImageToVideo: Plugin = () => {
           autoplay: true,
           loop: true,
           muted: true,
+          playsinline: true,
         };
       }
     });


### PR DESCRIPTION
Prevents the inline embedded video from popping up as fullscreen on mobile.