### PR TITLE
feat(sandbox): enable sticky LB cookies on sandbox

### DIFF
--- a/prod/templates/sandbox/vpc.yml
+++ b/prod/templates/sandbox/vpc.yml
@@ -250,7 +250,12 @@ Resources:
       TargetGroupAttributes:
         - Key: deregistration_delay.timeout_seconds
           Value: "0"
-
+        - Key: stickiness.enabled
+          Value: true
+        - Key: stickiness.type
+          Value: lb_cookie
+        - Key: stickiness.lb_cookie.duration_seconds
+          Value: 300
   PublicLBListener:
     Type: "AWS::ElasticLoadBalancingV2::Listener"
     Properties:


### PR DESCRIPTION
Proof of concept to see if AWSLB cookies work with our zbugs / zero-cache domain setup.

Per instructions in:

https://docs.aws.amazon.com/prescriptive-guidance/latest/load-balancer-stickiness/alb-cookies-stickiness.html#alb-cookies-code-changes