### PR TITLE
refactor(zbugs): don't use zero-cache-dev in zbugs.

### DIFF
--- a/apps/zbugs/package.json
+++ b/apps/zbugs/package.json
@@ -12,7 +12,7 @@
     "check-format": "prettier --check .",
     "lint": "eslint --ext .ts,.tsx,.js,.jsx src/",
     "preview": "vite preview",
-    "zero": "zero-cache-dev",
+    "zero": "npm run zero-build-schema && tsx ../../packages/zero-cache/src/server/multi/main.ts",
     "zero-build-schema": "tsx ../../packages/zero-schema/src/build-schema.ts",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/packages/zero/src/zero-cache-dev.ts
+++ b/packages/zero/src/zero-cache-dev.ts
@@ -28,11 +28,11 @@ function killProcess(childProcess: ChildProcess | undefined) {
 }
 
 function log(msg: string) {
-  console.log(chalk.green(msg));
+  console.log(chalk.green('> ' + msg));
 }
 
 function logError(msg: string) {
-  console.error(chalk.red(msg));
+  console.error(chalk.red('> ' + msg));
 }
 
 async function main() {


### PR DESCRIPTION
Using zero-cache-dev requires building and installing from root to pick up changes in zero-cache code.  

By doing `tsx ../../packages/zero-cache/src/server/multi/main.ts` this approach picks up changes in zero-cache code with just restarting `npm run zero`.