### PR TITLE
feat(zbugs): useWatchQuery

### DIFF
--- a/apps/zbugs/schema.ts
+++ b/apps/zbugs/schema.ts
@@ -2,10 +2,10 @@ import {
   createSchema,
   createTableSchema,
   definePermissions,
-  type ExpressionBuilder,
-  type TableSchema,
-  type Row,
   NOBODY_CAN,
+  type ExpressionBuilder,
+  type Row,
+  type TableSchema,
 } from '@rocicorp/zero';
 import type {Condition} from 'zero-protocol/src/ast.js';
 
@@ -183,6 +183,8 @@ const userPrefSchema = createTableSchema({
 
 export type IssueRow = Row<typeof issueSchema>;
 export type CommentRow = Row<typeof commentSchema>;
+export type EmojiRow = Row<typeof emojiSchema>;
+export type UserRow = Row<typeof userSchema>;
 export type Schema = typeof schema;
 
 /** The contents of the zbugs JWT */

--- a/apps/zbugs/src/components/emoji-panel.tsx
+++ b/apps/zbugs/src/components/emoji-panel.tsx
@@ -38,14 +38,14 @@ type Props = {
   issueID: string;
   commentID?: string | undefined;
   emojis: readonly Emoji[];
-  recentEmojis?: readonly Emoji[] | undefined;
+  recentEmojiIDs?: readonly string[] | undefined;
   removeRecentEmoji?: ((id: string) => void) | undefined;
 };
 
 export const EmojiPanel = memo(
   forwardRef(
     (
-      {issueID, commentID, emojis, recentEmojis, removeRecentEmoji}: Props,
+      {issueID, commentID, emojis, recentEmojiIDs, removeRecentEmoji}: Props,
       ref: ForwardedRef<HTMLDivElement>,
     ) => {
       const subjectID = commentID ?? issueID;
@@ -102,7 +102,7 @@ export const EmojiPanel = memo(
                 normalizedEmoji={normalizedEmoji}
                 emojis={emojis}
                 addOrRemoveEmoji={addOrRemoveEmoji}
-                recentEmojis={recentEmojis}
+                recentEmojiIDs={recentEmojiIDs}
                 removeRecentEmoji={removeRecentEmoji}
                 subjectID={subjectID}
               />

--- a/apps/zbugs/src/components/filter.tsx
+++ b/apps/zbugs/src/components/filter.tsx
@@ -5,7 +5,7 @@ import labelIcon from '../assets/icons/label.svg';
 import {useZero} from '../hooks/use-zero.js';
 import {Button} from './button.js';
 import {Combobox} from './combobox.js';
-import UserPicker from './user-picker.js';
+import {UserPicker} from './user-picker.js';
 
 export type Selection =
   | {creator: string}

--- a/apps/zbugs/src/components/user-picker.tsx
+++ b/apps/zbugs/src/components/user-picker.tsx
@@ -1,92 +1,86 @@
-import {type Row} from '@rocicorp/zero';
 import {useQuery} from '@rocicorp/zero/react';
-import {useEffect, useMemo, useState} from 'react';
-import {type Schema} from '../../schema.js';
+import {memo, useEffect, useMemo, useState} from 'react';
+import {type UserRow} from '../../schema.js';
 import avatarIcon from '../assets/icons/avatar-default.svg';
 import {useZero} from '../hooks/use-zero.js';
 import {Combobox} from './combobox.js';
 
 type Props = {
-  onSelect?: ((user: User | undefined) => void) | undefined;
+  onSelect?: ((user: UserRow | undefined) => void) | undefined;
   selected?: {login?: string | undefined} | undefined;
   disabled?: boolean | undefined;
   unselectedLabel?: string | undefined;
   placeholder?: string | undefined;
 };
 
-type User = Row<Schema['tables']['user']>;
+export const UserPicker = memo(
+  ({onSelect, selected, disabled, unselectedLabel, placeholder}: Props) => {
+    const z = useZero();
 
-export default function UserPicker({
-  onSelect,
-  selected,
-  disabled,
-  unselectedLabel,
-  placeholder,
-}: Props) {
-  const z = useZero();
+    const [unsortedUsers] = useQuery(z.query.user);
+    // TODO: Support case-insensitive sorting in ZQL.
+    const users = useMemo(
+      () => unsortedUsers.toSorted((a, b) => a.login.localeCompare(b.login)),
+      [unsortedUsers],
+    );
 
-  const [unsortedUsers] = useQuery(z.query.user);
-  // TODO: Support case-insensitive sorting in ZQL.
-  const users = useMemo(
-    () => unsortedUsers.toSorted((a, b) => a.login.localeCompare(b.login)),
-    [unsortedUsers],
-  );
-
-  // Preload the avatar icons so they show up instantly when opening the
-  // dropdown.
-  const [avatars, setAvatars] = useState<Record<string, string>>({});
-  useEffect(() => {
-    let canceled = false;
-    async function preload() {
-      const avatars = await Promise.all(users.map(c => preloadAvatar(c)));
-      if (canceled) {
-        return;
+    // Preload the avatar icons so they show up instantly when opening the
+    // dropdown.
+    const [avatars, setAvatars] = useState<Record<string, string>>({});
+    useEffect(() => {
+      let canceled = false;
+      async function preload() {
+        const avatars = await Promise.all(users.map(c => preloadAvatar(c)));
+        if (canceled) {
+          return;
+        }
+        setAvatars(Object.fromEntries(avatars));
       }
-      setAvatars(Object.fromEntries(avatars));
-    }
-    void preload();
-    return () => {
-      canceled = true;
+      void preload();
+      return () => {
+        canceled = true;
+      };
+    }, [users]);
+
+    const handleSelect = (user: UserRow | undefined) => {
+      onSelect?.(user);
     };
-  }, [users]);
 
-  const handleSelect = (user: User | undefined) => {
-    onSelect?.(user);
-  };
+    const selectedUser =
+      selected && users.find(u => u.login === selected.login);
 
-  const selectedUser = selected && users.find(u => u.login === selected.login);
+    const unselectedItem = {
+      text: unselectedLabel ?? 'Select',
+      icon: avatarIcon,
+      value: undefined,
+    };
+    const defaultItem = {
+      text: placeholder ?? 'Select a user...',
+      icon: avatarIcon,
+      value: undefined,
+    };
 
-  const unselectedItem = {
-    text: unselectedLabel ?? 'Select',
-    icon: avatarIcon,
-    value: undefined,
-  };
-  const defaultItem = {
-    text: placeholder ?? 'Select a user...',
-    icon: avatarIcon,
-    value: undefined,
-  };
+    return (
+      <Combobox
+        disabled={disabled}
+        onChange={c => handleSelect(c)}
+        items={[
+          unselectedItem,
+          ...users.map(u => ({
+            text: u.login,
+            value: u,
+            icon: avatars[u.id],
+          })),
+        ]}
+        defaultItem={defaultItem}
+        selectedValue={selectedUser ?? undefined}
+        className="user-picker"
+      />
+    );
+  },
+);
 
-  return (
-    <Combobox
-      disabled={disabled}
-      onChange={c => handleSelect(c)}
-      items={[
-        unselectedItem,
-        ...users.map(u => ({
-          text: u.login,
-          value: u,
-          icon: avatars[u.id],
-        })),
-      ]}
-      defaultItem={defaultItem}
-      selectedValue={selectedUser ?? undefined}
-      className="user-picker"
-    />
-  );
-}
-
-function preloadAvatar(user: User) {
+function preloadAvatar(user: UserRow): Promise<[string, string]> {
   return new Promise<[string, string]>((res, rej) => {
     fetch(user.avatar)
       .then(response => response.blob())

--- a/apps/zbugs/src/emoji-utils.ts
+++ b/apps/zbugs/src/emoji-utils.ts
@@ -1,9 +1,8 @@
-import type {Row} from '@rocicorp/zero';
 import {assert} from 'shared/src/asserts.js';
-import type {Schema} from '../schema.js';
+import type {EmojiRow, UserRow} from '../schema.js';
 
-export type Emoji = Row<Schema['tables']['emoji']> & {
-  readonly creator: Row<Schema['tables']['user']> | undefined;
+export type Emoji = EmojiRow & {
+  readonly creator: UserRow | undefined;
 };
 
 export function formatEmojiCreatorList(

--- a/apps/zbugs/src/hooks/use-watch-query.tsx
+++ b/apps/zbugs/src/hooks/use-watch-query.tsx
@@ -1,0 +1,151 @@
+import type {Query, QueryType, Row, TableSchema} from '@rocicorp/zero';
+import {useEffect} from 'react';
+import {unreachable} from 'shared/src/asserts.js';
+import type {Change as IVMChange} from 'zql/src/ivm/change.js';
+import type {Input, Output} from 'zql/src/ivm/operator.js';
+import type {Format} from 'zql/src/ivm/view.js';
+import type {AdvancedQuery} from 'zql/src/query/query-internal.js';
+
+export function useWatchQuery<
+  TSchema extends TableSchema,
+  TReturn extends QueryType,
+>(
+  q: Query<TSchema, TReturn>,
+  onChange: (change: Change<TSchema>) => void,
+  enabled = true,
+): void {
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    return (q as AdvancedQuery<TSchema, TReturn>)
+      .materialize(changeViewFactory)
+      .subscribe(onChange);
+  }, [q, onChange, enabled]);
+}
+
+class WatchQuery<TSchema extends TableSchema> implements Output {
+  readonly #subscribers = new Set<Callback<TSchema>>();
+  readonly #onDestroy: () => void;
+  #queryComplete = false;
+  #pendingChanges: IVMChange[] = [];
+
+  constructor(
+    input: Input,
+    onDestroy: () => void = () => void 0,
+    queryComplete: true | Promise<true>,
+  ) {
+    this.#onDestroy = onDestroy;
+    if (queryComplete === true) {
+      this.#queryComplete = true;
+    } else {
+      queryComplete.then(() => {
+        this.#queryComplete = true;
+        this.flush();
+      });
+    }
+    input.setOutput(this);
+  }
+
+  destroy() {
+    this.#onDestroy();
+  }
+
+  push(change: IVMChange): void {
+    this.#pendingChanges.push(change);
+  }
+
+  subscribe(cb: Callback<TSchema>): () => void {
+    this.#subscribers.add(cb);
+    return () => {
+      this.#subscribers.delete(cb);
+    };
+  }
+
+  flush() {
+    if (!this.#queryComplete) {
+      return;
+    }
+
+    for (const change of this.#pendingChanges) {
+      for (const cb of this.#subscribers) {
+        cb(toChange(change));
+      }
+    }
+    this.#pendingChanges = [];
+  }
+}
+
+function changeViewFactory<
+  TSchema extends TableSchema,
+  TReturn extends QueryType,
+>(
+  _query: Query<TSchema, TReturn>,
+  input: Input,
+  _format: Format,
+  onDestroy: () => void,
+  onTransactionCommit: (cb: () => void) => void,
+  queryComplete: true | Promise<true>,
+): WatchQuery<TSchema> {
+  const changeView = new WatchQuery(input, onDestroy, queryComplete);
+  onTransactionCommit(() => {
+    changeView.flush();
+  });
+  return changeView;
+}
+
+export type Change<TSchema extends TableSchema> =
+  | {
+      type: 'add';
+      row: Row<TSchema>;
+    }
+  | {
+      type: 'remove';
+      row: Row<TSchema>;
+    }
+  | {
+      type: 'child';
+      row: Row<TSchema>;
+      child: {
+        relationshipName: string;
+        // TODO: Find this from the relationship.
+        change: Change<TableSchema>;
+      };
+    }
+  | {
+      type: 'edit';
+      row: Row<TSchema>;
+      oldRow: Row<TSchema>;
+    };
+
+export type Callback<TSchema extends TableSchema> = (
+  changes: Change<TSchema>,
+) => void;
+
+function toChange<TSchema extends TableSchema>(
+  change: IVMChange,
+): Change<TSchema> {
+  switch (change.type) {
+    case 'add':
+      return {type: 'add', row: change.node.row as Row<TSchema>};
+    case 'remove':
+      return {type: 'remove', row: change.node.row as Row<TSchema>};
+    case 'child':
+      return {
+        type: 'child',
+        row: change.row as Row<TSchema>,
+        child: {
+          relationshipName: change.child.relationshipName,
+          change: toChange(change.child.change),
+        },
+      };
+    case 'edit':
+      return {
+        type: 'edit',
+        row: change.node.row as Row<TSchema>,
+        oldRow: change.oldNode.row as Row<TSchema>,
+      };
+    default:
+      unreachable(change);
+  }
+}


### PR DESCRIPTION
This is WIP but I want some feedback.

This creates a new hook that takes a callback that gets called with the changes that come out at the end of the pipeline.

This is based on the ideas I had last week (or the week before that?) when I first worked on adding the emoji change callbacks.

Usage:

```ts
useWatchQuery(z.query.comment.where('issueID', id), change => {
  if (change.type === 'add') {
    console.log(change.row, 'was added');
  } else if (change.type === 'remove') {
    console.log(change.row, 'was removed');
  }
});
```

Things that are not obvious/clean.
- Name of the hook?
- The implementation waits for the transaction end but this information is lost in the callback. We could call the callback with an array of all the changes instead.
- What to do about child changes since at this level there is no memory of the previous children?
- Should the hook have an option to also be called for non complete results or maybe add that info to the change objects?