### PR TITLE
feat(zero-cache): support jwk url to get keys from

### DIFF
--- a/packages/zero-cache/src/auth/jwt.test.ts
+++ b/packages/zero-cache/src/auth/jwt.test.ts
@@ -47,8 +47,6 @@ describe('jwk', async () => {
   commonTests({jwk: JSON.stringify(publicJwk)}, makeToken);
 });
 
-// describe('jwkUrl', () => {});
-
 function commonTests(
   config: AuthConfig,
   makeToken: (


### PR DESCRIPTION
Couldn't ever get `http.get` mocked for a unit test. Jose requests still went through and bypassed MSW.

https://vitest.dev/guide/mocking#requests

```ts
import {afterAll, afterEach, beforeAll} from 'vitest';
import {setupServer} from 'msw/node';
import {http, HttpResponse} from 'msw';
import {jwks, jwksUrl} from './vite-jwks.js';

const server = setupServer(
  http.get(jwksUrl, () =>
    HttpResponse.json({
      keys: [jwks.pub],
    }),
  ),
);

beforeAll(() => server.listen({onUnhandledRequest: 'error'}));

afterAll(() => server.close());

afterEach(() => server.resetHandlers());
```

