### PR TITLE
feat(zero-cache): track and log how many rows a query considers on hydration

### DIFF
--- a/packages/zero-cache/bench/benchmark.ts
+++ b/packages/zero-cache/bench/benchmark.ts
@@ -32,6 +32,7 @@ export function bench(opts: Options) {
       const {columns, primaryKey} = tableSpec;
 
       source = new TableSource(
+        'benchmark',
         db,
         name,
         Object.fromEntries(

--- a/packages/zero-cache/src/auth/read-authorizer.query.test.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.query.test.ts
@@ -458,6 +458,7 @@ beforeEach(() => {
       )`);
 
       source = new TableSource(
+        'read-auth-test',
         replica,
         name,
         tableSchema.columns,

--- a/packages/zero-cache/src/auth/write-authorizer.ts
+++ b/packages/zero-cache/src/auth/write-authorizer.ts
@@ -72,6 +72,7 @@ export class WriteAuthorizerImpl implements WriteAuthorizer {
   readonly #tables = new Map<string, TableSource>();
   readonly #statementRunner: StatementRunner;
   readonly #lc: LogContext;
+  readonly #clientGroupID: string;
 
   constructor(
     lc: LogContext,
@@ -81,6 +82,7 @@ export class WriteAuthorizerImpl implements WriteAuthorizer {
     replica: Database,
     cgID: string,
   ) {
+    this.#clientGroupID = cgID;
     this.#lc = lc.withContext('class', 'WriteAuthorizerImpl');
     this.#schema = schema;
     this.#permissionsConfig = permissions ?? {};
@@ -230,6 +232,7 @@ export class WriteAuthorizerImpl implements WriteAuthorizer {
     const {columns, primaryKey} = tableSpec.tableSpec;
     assert(primaryKey.length);
     source = new TableSource(
+      this.#clientGroupID,
       this.#replica,
       tableName,
       Object.fromEntries(

--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -47,6 +47,11 @@ test('zero-cache --help', () => {
                                                    Note that this number must allow for at least one connection per                                  
                                                    sync worker, or zero-cache will fail to start. See --numSyncWorkers                               
                                                                                                                                                      
+     --query-hydration-stats boolean               optional                                                                                          
+       ZERO_QUERY_HYDRATION_STATS env                                                                                                                
+                                                   Track and log the number of rows considered by each query in the system.                          
+                                                   This is useful for debugging and performance tuning.                                              
+                                                                                                                                                     
      --change-db string                            required                                                                                          
        ZERO_CHANGE_DB env                                                                                                                            
                                                    Yet another Postgres database, used to store a replication log.                                   

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -4,6 +4,7 @@
 
 import {parseOptions, type Config} from '../../../shared/src/options.js';
 import * as v from '../../../shared/src/valita.js';
+import {runtimeDebugFlags} from '../../../zqlite/src/runtime-debug.js';
 import {singleProcessMode} from '../types/processes.js';
 
 /**
@@ -178,6 +179,14 @@ export const zeroOptions = {
       type: v.number().optional(),
       hidden: true, // Passed from main thread to sync workers
     },
+  },
+
+  queryHydrationStats: {
+    type: v.boolean().optional(),
+    desc: [
+      `Track and log the number of rows considered by each query in the system.`,
+      `This is useful for debugging and performance tuning.`,
+    ],
   },
 
   change: {
@@ -368,6 +377,10 @@ export function getZeroConfig(
 ): ZeroConfig {
   if (!loadedConfig || singleProcessMode()) {
     loadedConfig = parseOptions(zeroOptions, argv, ZERO_ENV_VAR_PREFIX, env);
+
+    if (loadedConfig.queryHydrationStats) {
+      runtimeDebugFlags.trackRowsVended = true;
+    }
   }
 
   return loadedConfig;

--- a/packages/zero-cache/src/scripts/run-query.ts
+++ b/packages/zero-cache/src/scripts/run-query.ts
@@ -33,6 +33,7 @@ const host: QueryDelegate = {
       return source;
     }
     source = new TableSource(
+      '',
       db,
       name,
       normalizedSchema.tables[name].columns,
@@ -68,7 +69,8 @@ const end = performance.now();
 let totalRowsConsidered = 0;
 for (const source of sources.values()) {
   const entires = [
-    ...(runtimeDebugStats.rowsVended.get(source.table)?.entries() ?? []),
+    ...(runtimeDebugStats.getRowsVended('')?.get(source.table)?.entries() ??
+      []),
   ];
   totalRowsConsidered += entires.reduce((acc, entry) => acc + entry[1], 0);
   console.log(source.table + ' VENDED: ', entires);

--- a/packages/zero-cache/src/server/multi/config.test.ts
+++ b/packages/zero-cache/src/server/multi/config.test.ts
@@ -185,6 +185,11 @@ test('zero-cache --help', () => {
                                                    Note that this number must allow for at least one connection per                                  
                                                    sync worker, or zero-cache will fail to start. See --numSyncWorkers                               
                                                                                                                                                      
+     --query-hydration-stats boolean               optional                                                                                          
+       ZERO_QUERY_HYDRATION_STATS env                                                                                                                
+                                                   Track and log the number of rows considered by each query in the system.                          
+                                                   This is useful for debugging and performance tuning.                                              
+                                                                                                                                                     
      --change-db string                            required                                                                                          
        ZERO_CHANGE_DB env                                                                                                                            
                                                    Yet another Postgres database, used to store a replication log.                                   

--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -122,6 +122,7 @@ export default async function runWorker(
         logger,
         new Snapshotter(logger, replicaFile),
         operatorStorage.createClientGroupStorage(id),
+        id,
       ),
       sub,
       drainCoordinator,

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -35,6 +35,7 @@ describe('view-syncer/pipeline-driver', () => {
       lc,
       new Snapshotter(lc, dbFile.path),
       new DatabaseStorage(storage).createClientGroupStorage('foo-client-group'),
+      'pipeline-driver.test.ts',
     );
 
     db = dbFile.connect(lc);

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -379,6 +379,7 @@ async function setup(permissions: PermissionsConfig = {}) {
       lc.withContext('component', 'pipeline-driver'),
       new Snapshotter(lc, replicaDbFile.path),
       operatorStorage,
+      'view-syncer.pg-test.ts',
     ),
     stateChanges,
     drainCoordinator,

--- a/packages/zqlite/src/query.test.ts
+++ b/packages/zqlite/src/query.test.ts
@@ -32,7 +32,13 @@ beforeEach(() => {
         PRIMARY KEY (${schema.primaryKey.map(k => `"${k}"`).join(', ')})
       )`);
 
-      source = new TableSource(db, name, schema.columns, schema.primaryKey);
+      source = new TableSource(
+        'query.test.ts',
+        db,
+        name,
+        schema.columns,
+        schema.primaryKey,
+      );
 
       sources.set(name, source);
       return source;

--- a/packages/zqlite/src/table-source.test.ts
+++ b/packages/zqlite/src/table-source.test.ts
@@ -170,7 +170,13 @@ describe('fetching from a table source', () => {
       expectedRows: allRows.filter(r => r.a === 1 && r.b === 2),
     },
   ] as const)('$name', ({sourceArgs, fetchArgs, expectedRows}) => {
-    const source = new TableSource(db, sourceArgs[0], sourceArgs[1], ['id']);
+    const source = new TableSource(
+      'table-source.test.ts',
+      db,
+      sourceArgs[0],
+      sourceArgs[1],
+      ['id'],
+    );
     const c = source.connect(sourceArgs[2]);
     const out = new Catch(c);
     c.setOutput(out);
@@ -253,7 +259,13 @@ describe('fetched value types', () => {
         /* sql */ `INSERT INTO foo (id, a, b, c, d) VALUES (?, ?, ?, ?, ?);`,
       );
       stmt.run(c.input);
-      const source = new TableSource(db, 'foo', columns, ['id']);
+      const source = new TableSource(
+        'table-source.test.ts',
+        db,
+        'foo',
+        columns,
+        ['id'],
+      );
       const input = source.connect([['id', 'asc']]);
 
       if (c.output) {
@@ -275,6 +287,7 @@ test('pushing values does the correct writes and outputs', () => {
     /* sql */ `CREATE TABLE foo (a, b, c, d, ignored, columns, PRIMARY KEY (a, b));`,
   );
   const source = new TableSource(
+    'table-source.test.ts',
     db1,
     'foo',
     {
@@ -538,6 +551,7 @@ test('getByKey', () => {
   );
 
   const source = new TableSource(
+    'table-source.test.ts',
     db,
     'foo',
     {

--- a/packages/zqlite/src/table-source.ts
+++ b/packages/zqlite/src/table-source.ts
@@ -91,15 +91,18 @@ export class TableSource implements Source {
   readonly #table: string;
   readonly #columns: Record<string, SchemaValue>;
   readonly #primaryKey: PrimaryKey;
+  readonly #clientGroupID: string;
   #stmts: Statements;
   #overlay?: Overlay | undefined;
 
   constructor(
+    clientGroupID: string,
     db: Database,
     tableName: string,
     columns: Record<string, SchemaValue>,
     primaryKey: readonly [string, ...string[]],
   ) {
+    this.#clientGroupID = clientGroupID;
     this.#table = tableName;
     this.#columns = columns;
     this.#primaryKey = primaryKey;
@@ -311,7 +314,7 @@ export class TableSource implements Source {
   ): IterableIterator<Row> {
     for (const row of rowIterator) {
       if (runtimeDebugFlags.trackRowsVended) {
-        runtimeDebugStats.rowVended(this.#table, query);
+        runtimeDebugStats.rowVended(this.#clientGroupID, this.#table, query);
       }
       yield fromSQLiteTypes(valueTypes, row);
     }

--- a/packages/zqlite/src/test/source-factory.ts
+++ b/packages/zqlite/src/test/source-factory.ts
@@ -24,5 +24,5 @@ export const createSource: SourceFactory = (
     )}));`,
   );
   db.exec(query);
-  return new TableSource(db, tableName, columns, primaryKey);
+  return new TableSource('zqlite-test', db, tableName, columns, primaryKey);
 };


### PR DESCRIPTION
This logs how many rows were vended per source per query. 1 AST may create many SQL queries across many sources. We want to know how many rows each of those queries returned to ZQL.

`rows considered / vended` is different than the number of rows processed by the pipelineDriver. The sources themselves may have done a full table scan to produce a small number of rows.

Queries are hydrated one at a time per client group so we can safely use this global state when partitioned on client group id.

---

We can probably use OTEL metrics to accomplish this but I need to investigate:
1. If OTEL tracks the trace correctly through generators
2. If there are limitations on the number of unique keys we can create when tracking metrics
3. Getting the OTEL collector running on AWS so we can see these during load tests

---

Example output for a single query hash (1j5stgwsqzo9k) / AST:

```
worker = syncer pid = 90784 component = view - syncer clientGroupID = dguov9jeau34c091v8 instance = 1wiv7lxqtjo class = Statement path = / tmp / zbugs - sync - replica.db sql =
SELECT
  "id",
  "shortID",
  "title",
  "open",
  "modified",
  "created",
  "creatorID",
  "assigneeID",
  "description",
  "visibility",
  "_0_version"
FROM
  "issue"
WHERE
  (
    (
      "shortID" = ?
      AND ? IS NOT ?
      AND ? = ?
    )
    OR (
      "shortID" = ?
      AND "visibility" = ?
    )
  )
ORDER BY
  "id" asc method = iterate type = total Slow query 485.3249589999996 worker = syncer pid = 90784 component = view - syncer clientGroupID = dguov9jeau34c091v8 instance = 1wiv7lxqtjo hash = 1j5stgwsqzo9k hydrationTimeMs = 486 zero_0.clients VENDED: 
[] worker = syncer pid = 90784 component = view - syncer clientGroupID = dguov9jeau34c091v8 instance = 1wiv7lxqtjo hash = 1j5stgwsqzo9k hydrationTimeMs = 486 user VENDED: 
[
["SELECT "id","login","name","avatar","role","githubID","_0_version" FROM "user" WHERE "id" = ? ORDER BY "id" asc",
1002]]
worker=syncer pid=90784 component=view-syncer clientGroupID=dguov9jeau34c091v8 instance=1wiv7lxqtjo hash=1j5stgwsqzo9k hydrationTimeMs=486 label VENDED: 
[] worker = syncer pid = 90784 component = view - syncer clientGroupID = dguov9jeau34c091v8 instance = 1wiv7lxqtjo hash = 1j5stgwsqzo9k hydrationTimeMs = 486 issue VENDED: 
[
["SELECT "id","shortID","title","open","modified","created","creatorID","assigneeID","description","visibility","_0_version" FROM "issue" WHERE (("shortID" = ? AND ? IS NOT ? AND ? = ?) OR ("shortID" = ? AND "visibility" = ?)) ORDER BY "id" asc",
1],
  
["SELECT "id","shortID","title","open","modified","created","creatorID","assigneeID","description","visibility","_0_version" FROM "issue" WHERE "id" = ? AND ((? IS NOT ? AND ? = ?) OR "visibility" = ?) ORDER BY "id" asc",
2]]
worker=syncer pid=90784 component=view-syncer clientGroupID=dguov9jeau34c091v8 instance=1wiv7lxqtjo hash=1j5stgwsqzo9k hydrationTimeMs=486 comment VENDED: 
[
["SELECT "id","issueID","created","body","creatorID","_0_version" FROM "comment" WHERE "issueID" = ? ORDER BY "created" asc, "id" asc",
1001],
  
["SELECT "id","issueID","created","body","creatorID","_0_version" FROM "comment" WHERE (("created" > ?) OR ("created" = ? AND "id" > ?) OR ("created" = ? AND "id" = ?)) ORDER BY "created" asc, "id" asc",
1],
  
["SELECT "id","issueID","created","body","creatorID","_0_version" FROM "comment" WHERE "id" = ? ORDER BY "id" asc",
1001],
  
["SELECT "id","issueID","created","body","creatorID","_0_version" FROM "comment" WHERE (("id" > ?) OR ("id" = ?)) ORDER BY "id" asc",
1]]
worker=syncer pid=90784 component=view-syncer clientGroupID=dguov9jeau34c091v8 instance=1wiv7lxqtjo hash=1j5stgwsqzo9k hydrationTimeMs=486 emoji VENDED: 
[
["SELECT "id","value","annotation","subjectID","creatorID","created","_0_version" FROM "emoji" WHERE "subjectID" = ? ORDER BY "id" asc",
10010],
  
["SELECT "id","value","annotation","subjectID","creatorID","created","_0_version" FROM "emoji" WHERE (("id" > ?) OR ("id" = ?)) ORDER BY "id" asc",
2002]]
worker=syncer pid=90784 component=view-syncer clientGroupID=dguov9jeau34c091v8 instance=1wiv7lxqtjo hash=1j5stgwsqzo9k hydrationTimeMs=486 issueLabel VENDED: 
[] worker = syncer pid = 90784 component = view - syncer clientGroupID = dguov9jeau34c091v8 instance = 1wiv7lxqtjo hash = 1j5stgwsqzo9k hydrationTimeMs = 486 viewState VENDED: 
[] worker = syncer pid = 90784 component = view - syncer clientGroupID = dguov9jeau34c091v8 instance = 1wiv7lxqtjo hash = 1j5stgwsqzo9k hydrationTimeMs = 486
Total rows considered: 15021
```