### PR TITLE
Some alterations to playwright script to make it run better locally.

### DIFF
--- a/apps/zbugs/playwright/README.md
+++ b/apps/zbugs/playwright/README.md
@@ -1,0 +1,10 @@
+# Running playwright tests locally
+
+- Add ZERO_AUTH_SECRET="my-localhost-testing-secret" env
+- URL="http://localhost:5174" PERCENT_DIRECT=1 npx playwright test --ui
+
+TODO: You are supposed to be able to run in a real browser and debug by
+replacing --ui with --headed, but this doesn't work for me. I get:
+
+TypeError: Cannot redefine property: Symbol($$jest-matchers-object)
+at /Users/aa/work/mono/node_modules/@vitest/expect/dist/index.js:589:10

--- a/apps/zbugs/playwright/smoke.spec.ts
+++ b/apps/zbugs/playwright/smoke.spec.ts
@@ -1,21 +1,18 @@
 import {test} from '@playwright/test';
 
 const userCookies = [
-  'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIwRnczbjZFUVM4bXpFMTI2QUZKeDEiLCJpYXQiOjE3MzM5NTkyMDksIm5hbWUiOiJyb2NpYm90MSIsInJvbGUiOiJjcmV3IiwiZXhwIjoxODIwMzU5MjEwfQ._KK8Zyf5qV6ICCR2qrPyh_-G15hTm_XKnXrzUKOlB28',
-  'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIwRnczbjZFUVM4bXpFMTI2QUZKeDAiLCJpYXQiOjE3MzMyOTc5MTUsInJvbGUiOiJjcmV3IiwibmFtZSI6InJvY2lib3QiLCJleHAiOjE4MTk2OTc5MTV9.mmBeGC_r6y1p3YFqnMN5fRmwm5dBAOHBJVPVHIfOSNA',
-  'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIwRnczbjZFUVM4bXpFMTI2QUZKeDIiLCJpYXQiOjE3MzM5NTkyNzUsIm5hbWUiOiJyb2NpYm90MiIsInJvbGUiOiJjcmV3IiwiZXhwIjoxODIwMzU5Mjc1fQ.qGQTHFmnPyfAu3xGlWyEuSREcnwcZCKwyiW9ckRrPZY',
-  'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIwRnczbjZFUVM4bXpFMTI2QUZKeDMiLCJpYXQiOjE3MzM5NzQwMDIsIm5hbWUiOiJyb2NpYm90MyIsInJvbGUiOiJjcmV3IiwiZXhwIjoxODIwMzc0MDA0fQ.dpXsIDlMzNUlQpWY0c3Vh1hrBo36hNDmsXHyy59NhaQ',
-  'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIwRnczbjZFUVM4bXpFMTI2QUZKeDQiLCJpYXQiOjE3MzM5NzM5NDUsIm5hbWUiOiJyb2NpYm90NCIsInJvbGUiOiJjcmV3IiwiZXhwIjoxODIwMzczOTQ1fQ.MDaVc59EXXDpiUbod2cJ3GwcJhAJ5KJa88CuuWT4P2o',
+  'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJPZVZucjF5NWJFTV9ZZzA2c1VGdEQiLCJpYXQiOjE3MzQxMzY3NDYsInJvbGUiOiJjcmV3IiwibmFtZSI6ImFib29kbWFuIiwiZXhwIjoxNzM2NzI4NzQ2fQ.muDyQMOsjYi--80bl3kxyxzIHmZbA1lCdsK6z3B58LI',
 ];
 
 const DELAY_START = parseInt(process.env.DELAY_START ?? '0');
 const DELAY_PER_ITERATION = parseInt(process.env.DELAY_PER_ITERATION ?? '4800');
 const NUM_ITERATIONS = parseInt(process.env.NUM_ITERATIONS ?? '10');
-const URL = process.env.URL ?? 'https://bugs-sandbox.rocicorp.dev';
-const DIRECT_URL =
-  process.env.DIRECT_URL ?? 'https://bugs-sandbox.rocicorp.dev/issue/3020';
+const SITE_URL = process.env.URL ?? 'https://bugs-sandbox.rocicorp.dev';
+const ISSUE_ID = process.env.ISSUE_ID ?? '175';
+const DIRECT_URL = process.env.DIRECT_URL ?? `${SITE_URL}/issue/${ISSUE_ID}`;
 const PERCENT_DIRECT = parseFloat(process.env.PERCENT_DIRECT ?? '0.75');
 const AWS_BATCH_JOB_ARRAY_INDEX = process.env.AWS_BATCH_JOB_ARRAY_INDEX ?? '-1';
+const ENTER_PASSWORD = process.env.ENTER_PASSWORD === '1';
 
 test('loadtest', async ({page, browser, context}) => {
   // print environment variables
@@ -25,7 +22,7 @@ test('loadtest', async ({page, browser, context}) => {
     {
       name: 'jwt',
       value: userCookies[Math.floor(Math.random() * userCookies.length)],
-      domain: 'bugs-sandbox.rocicorp.dev',
+      domain: new URL(SITE_URL).host,
       path: '/',
       expires: -1,
       httpOnly: false,
@@ -44,12 +41,14 @@ test('loadtest', async ({page, browser, context}) => {
     console.log('Opening direct issue:', DIRECT_URL);
     await page.goto(DIRECT_URL);
   } else {
-    console.log('Opening main page:', URL);
-    await page.goto(URL);
+    console.log('Opening main page:', SITE_URL);
+    await page.goto(SITE_URL);
   }
-  await page.getByLabel('VISITOR PASSWORD').click();
-  await page.getByLabel('VISITOR PASSWORD').fill('zql');
-  await page.getByLabel('VISITOR PASSWORD').press('Enter');
+  if (ENTER_PASSWORD) {
+    await page.getByLabel('VISITOR PASSWORD').click();
+    await page.getByLabel('VISITOR PASSWORD').fill('zql');
+    await page.getByLabel('VISITOR PASSWORD').press('Enter');
+  }
   let cgID = '';
   const start = Date.now();
   // if it went to direct url, do this branch of code
@@ -74,20 +73,26 @@ test('loadtest', async ({page, browser, context}) => {
   for (let i = 0; i < NUM_ITERATIONS; i++) {
     const iterationStart = Date.now();
 
-    await openIssueByTitle(page, `Test Issue`);
+    // navigate into test issue
+    await openIssueByID(page, ISSUE_ID);
+
+    // every other time comment on the issue
     if (i % 2 === 0) {
       await commentOnNewIssue(page, 'This is a test comment');
     }
+
+    // do some filters
     console.log(AWS_BATCH_JOB_ARRAY_INDEX, cgID, 'Filtering by open');
     await page.locator('.nav-item', {hasText: 'Open'}).click();
     console.log(AWS_BATCH_JOB_ARRAY_INDEX, cgID, 'Filtering by closed');
     await page.locator('.nav-item', {hasText: 'Closed'}).click();
     console.log(AWS_BATCH_JOB_ARRAY_INDEX, cgID, 'Filtering by all');
     await page.locator('.nav-item', {hasText: 'All'}).click();
+
+    // filter by creator and pick a random creator
     await page.locator('.add-filter').click();
     await page.getByText('Filtered by:+ Filter').click();
     await page.getByRole('button', {name: '+ Filter'}).click();
-    // select creator
     await page.locator('div.add-filter-modal > div:nth-child(1)').click();
 
     let elm = await page.locator(
@@ -100,8 +105,9 @@ test('loadtest', async ({page, browser, context}) => {
       `Filtering by ${await elm.allTextContents()}`,
     );
     await elm.click();
+
+    // filter by assignee and pick a random assignee
     await page.getByRole('button', {name: '+ Filter'}).click();
-    // select assignee
     await page.locator('div.add-filter-modal > div:nth-child(2)').click();
     elm = await page.locator(
       `#options-listbox > li:nth-child(${Math.floor(Math.random() * 5) + 2})`,
@@ -113,6 +119,8 @@ test('loadtest', async ({page, browser, context}) => {
       `Filtering by ${await elm.allTextContents()}`,
     );
     await elm.click();
+
+    // remove filters
     console.log(AWS_BATCH_JOB_ARRAY_INDEX, cgID, 'Removing user filter');
     await page
       .locator('.list-view-filter-container .pill.user')
@@ -120,7 +128,11 @@ test('loadtest', async ({page, browser, context}) => {
       .click();
     console.log(AWS_BATCH_JOB_ARRAY_INDEX, cgID, 'Removing label filter');
     await page.locator('.list-view-filter-container .pill.user').last().click();
+
+    // show all issues
     await page.locator('.nav-item', {hasText: 'All'}).click();
+
+    // scroll to bottom of page
     await page.evaluate(() => {
       window.scrollTo({
         top: document.body.scrollHeight + 1000000,
@@ -153,23 +165,6 @@ async function waitForIssueList(page) {
     const issues = document.querySelectorAll('.issue-list .row');
     return issues.length > 1;
   });
-}
-
-async function checkIssueExists(page, title: string) {
-  //scroll tho the end of issue list
-  await page.evaluate(() => {
-    window.scrollTo({
-      top: document.body.scrollHeight + 1000000,
-      behavior: 'smooth',
-    });
-  });
-  return (
-    (await page
-      .locator('.issue-list .row', {
-        hasText: title,
-      })
-      .count()) > 0
-  );
 }
 
 async function navigateToAll(page) {
@@ -241,19 +236,17 @@ async function commentOnNewIssue(page, comment: string) {
   await navigateToAll(page);
 }
 
-async function openIssueByTitle(page, issueTitle: string): Promise<boolean> {
+async function openIssueByID(page, issueID: string): Promise<boolean> {
   await page.locator('.nav-item', {hasText: 'All'}).click();
   await waitForIssueList(page);
 
-  if (!(await checkIssueExists(page, issueTitle))) {
-    console.log(`Issue "${issueTitle}" does not exist, skipping`);
-    return false;
-  }
-
   await page
-    .locator('.issue-list .row', {hasText: issueTitle})
+    .locator(`.issue-list .row a[href="/issue/${issueID}"]`)
     .first()
     .scrollIntoViewIfNeeded();
-  await page.locator('.issue-list .row', {hasText: issueTitle}).first().click();
+  await page
+    .locator(`.issue-list .row a[href="/issue/${issueID}"]`)
+    .first()
+    .click();
   return true;
 }


### PR DESCRIPTION
- Added README with instructions to run

- Changed the cookie since I do not have the key these cookies were encrypted with. We can change it back how it was, but please update README with what key to use.

- DRY usages of URL, so less error-prone

- Pass in ISSUE_ID rather than hard-coding since we won't have issue 300x locally. Also default to issue 175. With the local data, this is an issue that has some comments and show up in recently modified. That's why I chose it. In sandbox maybe choose a different (constant) issueID like 3020, put that ISSUE_ID in the Docker env, and just blow away its comments and emojis each time.

- Make whether a password is needed configurable via ENTER_PASSWORD env var. Locally we don't need this. **NOTE: you'll have to add this env to docker container to run against sandbox**.

- Refactor openIssueByText() -> openIssueByID() since we already have the issueID. Also remove the waiting for the row to be visible stuff since I do not thing it was waiting at all (the scroll is not instant, and there was no awaiting on that). Also the issue being looked for here ("Test Issue") would always be near top since it was recently modified.

- Add some comments.