### PR TITLE
feat(zero-cache): use all available cores for syncing

### DIFF
--- a/packages/zero-cache/src/server/life-cycle.ts
+++ b/packages/zero-cache/src/server/life-cycle.ts
@@ -1,10 +1,11 @@
 import {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
+import {constants, setPriority} from 'os';
 import {pid} from 'process';
 import type {EventEmitter} from 'stream';
 import {HttpService, type Options} from '../services/http-service.js';
 import type {SingletonService} from '../services/service.js';
-import type {Worker} from '../types/processes.js';
+import {singleProcessMode, type Worker} from '../types/processes.js';
 
 /**
  * * `user-facing` workers serve external requests and are the first to
@@ -85,6 +86,17 @@ export class ProcessManager {
   }
 
   addWorker(worker: Worker, type: WorkerType, name: string): Worker {
+    if (type === 'supporting' && worker.pid && !singleProcessMode()) {
+      try {
+        setPriority(worker.pid, constants.priority.PRIORITY_HIGH);
+        this.#lc.info?.(`set ${name} (pid=${worker.pid}) to HIGH priority`);
+      } catch (e) {
+        this.#lc.warn?.(
+          `unable to set priority of ${name} (pid=${worker.pid}):`,
+          String(e),
+        );
+      }
+    }
     if (type === 'user-facing') {
       this.#userFacing.add(worker);
     }

--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -37,11 +37,13 @@ export default async function runWorker(
 
   const processes = new ProcessManager(lc, parent ?? process);
 
+  // Run as many sync workers as there are available cores.
+  // To avoid starvation of supporting workers (replicator, change-streamer),
+  // the ProcessManager sets them to a higher priority.
   const numSyncers =
     config.numSyncWorkers !== undefined
       ? config.numSyncWorkers
-      : // Reserve 1 core for the replicator. The change-streamer is not CPU heavy.
-        Math.max(1, availableParallelism() - 1);
+      : Math.max(1, availableParallelism());
 
   if (config.upstream.maxConns < numSyncers) {
     throw new Error(


### PR DESCRIPTION
Use all available cores for syncing

Instead of reserving a core for supporting workers (i.e. replicator), use os process priority to avoid starvation.