### PR TITLE
feat(prod): bump CVR connections

### DIFF
--- a/prod/templates/sandbox/template.yml
+++ b/prod/templates/sandbox/template.yml
@@ -211,8 +211,8 @@ Resources:
               # limit: 190 max_connections / 8 tasks * 2 (during update)
               Value: 10
             - Name: ZERO_CVR_MAX_CONNS
-              # limit: 1708 max_connections / 8 tasks * 2 (during update)
-              Value: 100
+              # limit: 5000 max_connections / 8 tasks * 2 (during update)
+              Value: 300
             - Name: ZERO_SCHEMA_FILE
               Value: /opt/app/packages/zero-cache/zero-schema.json
           Secrets:

--- a/prod/templates/template.yml
+++ b/prod/templates/template.yml
@@ -211,8 +211,8 @@ Resources:
               # limit: 190 max_connections / 8 tasks * 2 (during update)
               Value: 10
             - Name: ZERO_CVR_MAX_CONNS
-              # limit: 1708 max_connections / 8 tasks * 2 (during update)
-              Value: 100
+              # limit: 5000 max_connections / 8 tasks * 2 (during update)
+              Value: 300
             - Name: ZERO_SCHEMA_FILE
               Value: /opt/app/packages/zero-cache/zero-schema.json
             - Name: ZERO_PER_USER_MUTATION_LIMIT_MAX


### PR DESCRIPTION
Bump up CVR connections per task based on the `db.m5.4xlarge` size RDS instance which has a max_connections of 5000.