### PR TITLE
feat(sandbox): run with more db connections (by slowing updates)

### DIFF
--- a/prod/templates/sandbox/template.yml
+++ b/prod/templates/sandbox/template.yml
@@ -111,7 +111,8 @@ Resources:
             - !GetAtt VPC.Outputs.SG
             - !Ref InternalServicesSG
       DeploymentConfiguration:
-        MaximumPercent: 200
+        # Run up to 10 tasks, capping updates to 2 tasks at a time
+        MaximumPercent: 125
         MinimumHealthyPercent: 50
       DesiredCount: 8
       TaskDefinition: !Ref "TaskDefinitionViewSyncer"
@@ -208,11 +209,11 @@ Resources:
             - Name: ZERO_LOG_LEVEL
               Value: debug
             - Name: ZERO_UPSTREAM_MAX_CONNS
-              # limit: 190 max_connections / 8 tasks * 2 (during update)
-              Value: 10
+              # limit: 190 max_connections / (8 tasks * 1.25 maximum-percent)
+              Value: 15
             - Name: ZERO_CVR_MAX_CONNS
-              # limit: 5000 max_connections / 8 tasks * 2 (during update)
-              Value: 300
+              # limit: 5000 max_connections / (8 tasks * 1.25 maximum-percent)
+              Value: 450
             - Name: ZERO_SCHEMA_FILE
               Value: /opt/app/packages/zero-cache/zero-schema.json
           Secrets:


### PR DESCRIPTION
Increase the number of CVR db connections per `view-syncer` from 300 to 450 by slowing the rate of updates from 200% to 125%. This means that updates will restart up to 2 tasks at a time rather than all 8 tasks. 