### PR TITLE
feat(zero-cache): use two CVR connection pools to rate-limit async updates

### DIFF
--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -75,13 +75,29 @@ export default async function runWorker(
   assert(config.cvr.maxConnsPerWorker);
   assert(config.upstream.maxConnsPerWorker);
 
+  // Reserve 90% of the connections for high priority requests,
+  // and 10% of connections for asynchronous row updates.
+  const highPriConns = Math.max(
+    Math.floor(config.cvr.maxConnsPerWorker * 0.9),
+    1,
+  );
+  const lowPriConns = config.cvr.maxConnsPerWorker - highPriConns;
+  lc.debug?.(`CVR db connections: ${highPriConns} high, ${lowPriConns} low`);
+
   const replicaFile = replicaFileName(config.replicaFile, fileMode);
   lc.debug?.(`running view-syncer on ${replicaFile}`);
 
-  const cvrDB = pgClient(lc, config.cvr.db, {
-    max: config.cvr.maxConnsPerWorker,
-    connection: {['application_name']: `zero-sync-worker-${pid}-cvr`},
+  const cvrDBHigh = pgClient(lc, config.cvr.db, {
+    max: highPriConns,
+    connection: {['application_name']: `zero-sync-worker-${pid}-cvr-high`},
   });
+
+  const cvrDBLow = lowPriConns
+    ? pgClient(lc, config.cvr.db, {
+        max: lowPriConns,
+        connection: {['application_name']: `zero-sync-worker-${pid}-cvr-low`},
+      })
+    : cvrDBHigh;
 
   const upstreamDB = pgClient(lc, config.upstream.db, {
     max: config.upstream.maxConnsPerWorker,
@@ -89,8 +105,8 @@ export default async function runWorker(
   });
 
   const dbWarmup = Promise.allSettled([
-    ...Array.from({length: config.cvr.maxConnsPerWorker}, () =>
-      cvrDB`SELECT 1`.simple().execute(),
+    ...Array.from({length: highPriConns}, () =>
+      cvrDBHigh`SELECT 1`.simple().execute(),
     ),
     ...Array.from({length: config.upstream.maxConnsPerWorker}, () =>
       upstreamDB`SELECT 1`.simple().execute(),
@@ -117,7 +133,8 @@ export default async function runWorker(
       must(config.taskID, 'main must set --task-id'),
       id,
       config.shard.id,
-      cvrDB,
+      cvrDBHigh,
+      cvrDBLow,
       new PipelineDriver(
         logger,
         new Snapshotter(logger, replicaFile),

--- a/packages/zero-cache/src/services/view-syncer/cvr-store.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.pg-test.ts
@@ -73,6 +73,7 @@ describe('view-syncer/cvr-store', () => {
     store = new CVRStore(
       lc,
       db,
+      db,
       TASK_ID,
       CVR_ID,
       ON_FAILURE,

--- a/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
@@ -161,7 +161,7 @@ describe('view-syncer/cvr', () => {
   }
 
   test('load first time cvr', async () => {
-    const pgStore = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
+    const pgStore = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
 
     const cvr = await pgStore.load(lc, LAST_CONNECT);
     expect(cvr).toEqual({
@@ -186,7 +186,7 @@ describe('view-syncer/cvr', () => {
     } satisfies CVRSnapshot);
 
     // Verify round tripping.
-    const pgStore2 = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
+    const pgStore2 = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
     const reloaded = await pgStore2.load(lc, LAST_CONNECT);
     expect(reloaded).toEqual(flushed);
 
@@ -251,7 +251,7 @@ describe('view-syncer/cvr', () => {
     };
     await setInitialState(db, initialState);
 
-    const cvrStore = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
+    const cvrStore = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
 
     const cvr = await cvrStore.load(lc, LAST_CONNECT);
     expect(cvr).toEqual({
@@ -332,7 +332,7 @@ describe('view-syncer/cvr', () => {
     };
     await setInitialState(db, initialState);
 
-    const cvrStore = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
+    const cvrStore = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
     const cvr = await cvrStore.load(lc, LAST_CONNECT);
     const updater = new CVRUpdater(cvrStore, cvr, cvr.replicaVersion);
 
@@ -382,7 +382,7 @@ describe('view-syncer/cvr', () => {
     } satisfies CVRSnapshot);
 
     // Verify round tripping.
-    const cvrStore2 = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
+    const cvrStore2 = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
     const reloaded = await cvrStore2.load(lc, LAST_CONNECT);
     expect(reloaded).toEqual(updated);
 
@@ -416,7 +416,7 @@ describe('view-syncer/cvr', () => {
     };
     await setInitialState(db, initialState);
 
-    const cvrStore = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
+    const cvrStore = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
     const cvr = await cvrStore.load(lc, LAST_CONNECT);
     const updater = new CVRUpdater(cvrStore, cvr, cvr.replicaVersion);
 
@@ -452,7 +452,7 @@ describe('view-syncer/cvr', () => {
     };
     await setInitialState(db, initialState);
 
-    const cvrStore = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
+    const cvrStore = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
     const cvr = await cvrStore.load(lc, LAST_CONNECT);
     const updater = new CVRUpdater(cvrStore, cvr, cvr.replicaVersion);
 
@@ -528,7 +528,7 @@ describe('view-syncer/cvr', () => {
     };
     await setInitialState(db, initialState);
 
-    const cvrStore = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
+    const cvrStore = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
     const cvr = await cvrStore.load(lc, LAST_CONNECT);
     expect(cvr).toEqual({
       id: 'abc123',
@@ -956,7 +956,7 @@ describe('view-syncer/cvr', () => {
     });
 
     // Verify round tripping.
-    const cvrStore2 = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
+    const cvrStore2 = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
     const reloaded = await cvrStore2.load(lc, LAST_CONNECT);
     expect(reloaded).toEqual(updated);
 
@@ -1038,7 +1038,7 @@ describe('view-syncer/cvr', () => {
     };
     await setInitialState(db, initialState);
 
-    const cvrStore = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
+    const cvrStore = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
     const cvr = await cvrStore.load(lc, LAST_CONNECT);
     const updater = new CVRConfigDrivenUpdater(cvrStore, cvr, SHARD_ID);
 
@@ -1071,7 +1071,14 @@ describe('view-syncer/cvr', () => {
     } satisfies CVRSnapshot);
 
     // Verify round tripping.
-    const doCVRStore2 = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
+    const doCVRStore2 = new CVRStore(
+      lc,
+      db,
+      db,
+      'my-task',
+      'abc123',
+      ON_FAILURE,
+    );
     const reloaded = await doCVRStore2.load(lc, LAST_CONNECT);
     expect(reloaded).toEqual(updated);
 
@@ -1223,7 +1230,7 @@ describe('view-syncer/cvr', () => {
 
     await setInitialState(db, initialState);
 
-    const cvrStore = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
+    const cvrStore = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
     const cvr = await cvrStore.load(lc, LAST_CONNECT);
     const updater = new CVRQueryDrivenUpdater(cvrStore, cvr, '1aa', '123');
 
@@ -1452,7 +1459,7 @@ describe('view-syncer/cvr', () => {
     } satisfies CVRSnapshot);
 
     // Verify round tripping.
-    const cvrStore2 = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
+    const cvrStore2 = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
     const reloaded = await cvrStore2.load(lc, LAST_CONNECT);
     expect(reloaded).toEqual(updated);
 
@@ -1693,7 +1700,7 @@ describe('view-syncer/cvr', () => {
     };
     await setInitialState(db, initialState);
 
-    let cvrStore = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
+    let cvrStore = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
     let cvr = await cvrStore.load(lc, LAST_CONNECT);
     let updater = new CVRQueryDrivenUpdater(cvrStore, cvr, '1ba', '123');
 
@@ -1887,7 +1894,7 @@ describe('view-syncer/cvr', () => {
     } satisfies CVRSnapshot);
 
     // Verify round tripping.
-    cvrStore = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
+    cvrStore = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
     cvr = await cvrStore.load(lc, LAST_CONNECT);
     expect(cvr).toEqual(updated);
 
@@ -2219,7 +2226,7 @@ describe('view-syncer/cvr', () => {
 
     await setInitialState(db, initialState);
 
-    const cvrStore = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
+    const cvrStore = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
     const cvr = await cvrStore.load(lc, LAST_CONNECT);
     const updater = new CVRQueryDrivenUpdater(cvrStore, cvr, '1ba', '123');
 
@@ -2478,7 +2485,14 @@ describe('view-syncer/cvr', () => {
     } satisfies CVRSnapshot);
 
     // Verify round tripping.
-    const doCVRStore2 = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
+    const doCVRStore2 = new CVRStore(
+      lc,
+      db,
+      db,
+      'my-task',
+      'abc123',
+      ON_FAILURE,
+    );
     const reloaded = await doCVRStore2.load(lc, LAST_CONNECT);
     expect(reloaded).toEqual(updated);
 
@@ -2714,7 +2728,7 @@ describe('view-syncer/cvr', () => {
 
     await setInitialState(db, initialState);
 
-    const cvrStore = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
+    const cvrStore = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
     const cvr = await cvrStore.load(lc, LAST_CONNECT);
     const updater = new CVRQueryDrivenUpdater(cvrStore, cvr, '1ba', '123');
 
@@ -2846,7 +2860,14 @@ describe('view-syncer/cvr', () => {
     } satisfies CVRSnapshot);
 
     // Verify round tripping.
-    const doCVRStore2 = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
+    const doCVRStore2 = new CVRStore(
+      lc,
+      db,
+      db,
+      'my-task',
+      'abc123',
+      ON_FAILURE,
+    );
     const reloaded = await doCVRStore2.load(lc, LAST_CONNECT);
     expect(reloaded).toEqual(updated);
 
@@ -3085,7 +3106,7 @@ describe('view-syncer/cvr', () => {
 
     await setInitialState(db, initialState);
 
-    const cvrStore = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
+    const cvrStore = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
     const cvr = await cvrStore.load(lc, LAST_CONNECT);
     expect(cvr).toMatchInlineSnapshot(`
       {
@@ -3384,7 +3405,14 @@ describe('view-syncer/cvr', () => {
     } satisfies CVRSnapshot);
 
     // Verify round tripping.
-    const doCVRStore2 = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
+    const doCVRStore2 = new CVRStore(
+      lc,
+      db,
+      db,
+      'my-task',
+      'abc123',
+      ON_FAILURE,
+    );
     const reloaded = await doCVRStore2.load(lc, LAST_CONNECT);
     expect(reloaded).toEqual(updated);
 
@@ -3459,7 +3487,7 @@ describe('view-syncer/cvr', () => {
 
     await setInitialState(db, initialState);
 
-    const cvrStore = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
+    const cvrStore = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
     const cvr = await cvrStore.load(lc, LAST_CONNECT);
     const updater = new CVRQueryDrivenUpdater(cvrStore, cvr, '1ba', '120');
 
@@ -3521,7 +3549,7 @@ describe('view-syncer/cvr', () => {
     `);
 
     // Verify round tripping.
-    const cvrStore2 = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
+    const cvrStore2 = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
     const reloaded = await cvrStore2.load(lc, LAST_CONNECT);
     expect(reloaded).toEqual(updated);
 

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -375,6 +375,7 @@ async function setup(permissions: PermissionsConfig = {}) {
     serviceID,
     SHARD_ID,
     cvrDB,
+    cvrDB,
     new PipelineDriver(
       lc.withContext('component', 'pipeline-driver'),
       new Snapshotter(lc, replicaDbFile.path),
@@ -511,7 +512,14 @@ describe('view-syncer/service', () => {
     ]);
     await nextPoke(client);
 
-    const cvrStore = new CVRStore(lc, cvrDB, TASK_ID, serviceID, ON_FAILURE);
+    const cvrStore = new CVRStore(
+      lc,
+      cvrDB,
+      cvrDB,
+      TASK_ID,
+      serviceID,
+      ON_FAILURE,
+    );
     const cvr = await cvrStore.load(lc, Date.now());
     expect(cvr).toMatchObject({
       clients: {
@@ -559,7 +567,14 @@ describe('view-syncer/service', () => {
       },
     ]);
 
-    const cvrStore = new CVRStore(lc, cvrDB, TASK_ID, serviceID, ON_FAILURE);
+    const cvrStore = new CVRStore(
+      lc,
+      cvrDB,
+      cvrDB,
+      TASK_ID,
+      serviceID,
+      ON_FAILURE,
+    );
     const cvr = await cvrStore.load(lc, Date.now());
     expect(cvr).toMatchObject({
       clients: {
@@ -2482,7 +2497,14 @@ describe('view-syncer/service', () => {
   test('waits for replica to catch up', async () => {
     // Before connecting, artificially set the CVR version to '07',
     // which is ahead of the current replica version '00'.
-    const cvrStore = new CVRStore(lc, cvrDB, TASK_ID, serviceID, ON_FAILURE);
+    const cvrStore = new CVRStore(
+      lc,
+      cvrDB,
+      cvrDB,
+      TASK_ID,
+      serviceID,
+      ON_FAILURE,
+    );
     await new CVRQueryDrivenUpdater(
       cvrStore,
       await cvrStore.load(lc, Date.now()),
@@ -2643,7 +2665,14 @@ describe('view-syncer/service', () => {
   });
 
   test('sends reset for CVR from different replica version up', async () => {
-    const cvrStore = new CVRStore(lc, cvrDB, TASK_ID, serviceID, ON_FAILURE);
+    const cvrStore = new CVRStore(
+      lc,
+      cvrDB,
+      cvrDB,
+      TASK_ID,
+      serviceID,
+      ON_FAILURE,
+    );
     await new CVRQueryDrivenUpdater(
       cvrStore,
       await cvrStore.load(lc, Date.now()),
@@ -2692,7 +2721,14 @@ describe('view-syncer/service', () => {
   });
 
   test('sends invalid base cookie if client is ahead of CVR', async () => {
-    const cvrStore = new CVRStore(lc, cvrDB, TASK_ID, serviceID, ON_FAILURE);
+    const cvrStore = new CVRStore(
+      lc,
+      cvrDB,
+      cvrDB,
+      TASK_ID,
+      serviceID,
+      ON_FAILURE,
+    );
     await new CVRQueryDrivenUpdater(
       cvrStore,
       await cvrStore.load(lc, Date.now()),

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -124,7 +124,8 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     taskID: string,
     clientGroupID: string,
     shardID: string,
-    db: PostgresDB,
+    highPriDB: PostgresDB,
+    lowPriDB: PostgresDB,
     pipelineDriver: PipelineDriver,
     versionChanges: Subscription<ReplicaState>,
     drainCoordinator: DrainCoordinator,
@@ -140,7 +141,8 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     this.#keepaliveMs = keepaliveMs;
     this.#cvrStore = new CVRStore(
       lc,
-      db,
+      highPriDB,
+      lowPriDB,
       taskID,
       clientGroupID,
       // On failure, cancel the #stateChanges subscription. The run()


### PR DESCRIPTION
Partition the pool of CVR db connections such that 90% are used for "high priority" (i.e. ux-blocking) updates, leaving the remainder for asynchronous row updates.

The latter are much larger requests (hundreds/thousands of rows), and scheduling them on a separate pool reserves db resources for servicing user-facing requests to prevent them from being slow.

That's the theory, at least. Experiments to follow.