### PR TITLE
Revert "feat(zero-cache): use two CVR connection pools to rate-limit async updates"

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr-store.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.pg-test.ts
@@ -73,7 +73,6 @@ describe('view-syncer/cvr-store', () => {
     store = new CVRStore(
       lc,
       db,
-      db,
       TASK_ID,
       CVR_ID,
       ON_FAILURE,

--- a/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
@@ -161,7 +161,7 @@ describe('view-syncer/cvr', () => {
   }
 
   test('load first time cvr', async () => {
-    const pgStore = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
+    const pgStore = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
 
     const cvr = await pgStore.load(lc, LAST_CONNECT);
     expect(cvr).toEqual({
@@ -186,7 +186,7 @@ describe('view-syncer/cvr', () => {
     } satisfies CVRSnapshot);
 
     // Verify round tripping.
-    const pgStore2 = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
+    const pgStore2 = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
     const reloaded = await pgStore2.load(lc, LAST_CONNECT);
     expect(reloaded).toEqual(flushed);
 
@@ -251,7 +251,7 @@ describe('view-syncer/cvr', () => {
     };
     await setInitialState(db, initialState);
 
-    const cvrStore = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
+    const cvrStore = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
 
     const cvr = await cvrStore.load(lc, LAST_CONNECT);
     expect(cvr).toEqual({
@@ -332,7 +332,7 @@ describe('view-syncer/cvr', () => {
     };
     await setInitialState(db, initialState);
 
-    const cvrStore = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
+    const cvrStore = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
     const cvr = await cvrStore.load(lc, LAST_CONNECT);
     const updater = new CVRUpdater(cvrStore, cvr, cvr.replicaVersion);
 
@@ -382,7 +382,7 @@ describe('view-syncer/cvr', () => {
     } satisfies CVRSnapshot);
 
     // Verify round tripping.
-    const cvrStore2 = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
+    const cvrStore2 = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
     const reloaded = await cvrStore2.load(lc, LAST_CONNECT);
     expect(reloaded).toEqual(updated);
 
@@ -416,7 +416,7 @@ describe('view-syncer/cvr', () => {
     };
     await setInitialState(db, initialState);
 
-    const cvrStore = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
+    const cvrStore = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
     const cvr = await cvrStore.load(lc, LAST_CONNECT);
     const updater = new CVRUpdater(cvrStore, cvr, cvr.replicaVersion);
 
@@ -452,7 +452,7 @@ describe('view-syncer/cvr', () => {
     };
     await setInitialState(db, initialState);
 
-    const cvrStore = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
+    const cvrStore = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
     const cvr = await cvrStore.load(lc, LAST_CONNECT);
     const updater = new CVRUpdater(cvrStore, cvr, cvr.replicaVersion);
 
@@ -528,7 +528,7 @@ describe('view-syncer/cvr', () => {
     };
     await setInitialState(db, initialState);
 
-    const cvrStore = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
+    const cvrStore = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
     const cvr = await cvrStore.load(lc, LAST_CONNECT);
     expect(cvr).toEqual({
       id: 'abc123',
@@ -956,7 +956,7 @@ describe('view-syncer/cvr', () => {
     });
 
     // Verify round tripping.
-    const cvrStore2 = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
+    const cvrStore2 = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
     const reloaded = await cvrStore2.load(lc, LAST_CONNECT);
     expect(reloaded).toEqual(updated);
 
@@ -1038,7 +1038,7 @@ describe('view-syncer/cvr', () => {
     };
     await setInitialState(db, initialState);
 
-    const cvrStore = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
+    const cvrStore = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
     const cvr = await cvrStore.load(lc, LAST_CONNECT);
     const updater = new CVRConfigDrivenUpdater(cvrStore, cvr, SHARD_ID);
 
@@ -1071,14 +1071,7 @@ describe('view-syncer/cvr', () => {
     } satisfies CVRSnapshot);
 
     // Verify round tripping.
-    const doCVRStore2 = new CVRStore(
-      lc,
-      db,
-      db,
-      'my-task',
-      'abc123',
-      ON_FAILURE,
-    );
+    const doCVRStore2 = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
     const reloaded = await doCVRStore2.load(lc, LAST_CONNECT);
     expect(reloaded).toEqual(updated);
 
@@ -1230,7 +1223,7 @@ describe('view-syncer/cvr', () => {
 
     await setInitialState(db, initialState);
 
-    const cvrStore = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
+    const cvrStore = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
     const cvr = await cvrStore.load(lc, LAST_CONNECT);
     const updater = new CVRQueryDrivenUpdater(cvrStore, cvr, '1aa', '123');
 
@@ -1459,7 +1452,7 @@ describe('view-syncer/cvr', () => {
     } satisfies CVRSnapshot);
 
     // Verify round tripping.
-    const cvrStore2 = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
+    const cvrStore2 = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
     const reloaded = await cvrStore2.load(lc, LAST_CONNECT);
     expect(reloaded).toEqual(updated);
 
@@ -1700,7 +1693,7 @@ describe('view-syncer/cvr', () => {
     };
     await setInitialState(db, initialState);
 
-    let cvrStore = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
+    let cvrStore = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
     let cvr = await cvrStore.load(lc, LAST_CONNECT);
     let updater = new CVRQueryDrivenUpdater(cvrStore, cvr, '1ba', '123');
 
@@ -1894,7 +1887,7 @@ describe('view-syncer/cvr', () => {
     } satisfies CVRSnapshot);
 
     // Verify round tripping.
-    cvrStore = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
+    cvrStore = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
     cvr = await cvrStore.load(lc, LAST_CONNECT);
     expect(cvr).toEqual(updated);
 
@@ -2226,7 +2219,7 @@ describe('view-syncer/cvr', () => {
 
     await setInitialState(db, initialState);
 
-    const cvrStore = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
+    const cvrStore = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
     const cvr = await cvrStore.load(lc, LAST_CONNECT);
     const updater = new CVRQueryDrivenUpdater(cvrStore, cvr, '1ba', '123');
 
@@ -2485,14 +2478,7 @@ describe('view-syncer/cvr', () => {
     } satisfies CVRSnapshot);
 
     // Verify round tripping.
-    const doCVRStore2 = new CVRStore(
-      lc,
-      db,
-      db,
-      'my-task',
-      'abc123',
-      ON_FAILURE,
-    );
+    const doCVRStore2 = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
     const reloaded = await doCVRStore2.load(lc, LAST_CONNECT);
     expect(reloaded).toEqual(updated);
 
@@ -2728,7 +2714,7 @@ describe('view-syncer/cvr', () => {
 
     await setInitialState(db, initialState);
 
-    const cvrStore = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
+    const cvrStore = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
     const cvr = await cvrStore.load(lc, LAST_CONNECT);
     const updater = new CVRQueryDrivenUpdater(cvrStore, cvr, '1ba', '123');
 
@@ -2860,14 +2846,7 @@ describe('view-syncer/cvr', () => {
     } satisfies CVRSnapshot);
 
     // Verify round tripping.
-    const doCVRStore2 = new CVRStore(
-      lc,
-      db,
-      db,
-      'my-task',
-      'abc123',
-      ON_FAILURE,
-    );
+    const doCVRStore2 = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
     const reloaded = await doCVRStore2.load(lc, LAST_CONNECT);
     expect(reloaded).toEqual(updated);
 
@@ -3106,7 +3085,7 @@ describe('view-syncer/cvr', () => {
 
     await setInitialState(db, initialState);
 
-    const cvrStore = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
+    const cvrStore = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
     const cvr = await cvrStore.load(lc, LAST_CONNECT);
     expect(cvr).toMatchInlineSnapshot(`
       {
@@ -3405,14 +3384,7 @@ describe('view-syncer/cvr', () => {
     } satisfies CVRSnapshot);
 
     // Verify round tripping.
-    const doCVRStore2 = new CVRStore(
-      lc,
-      db,
-      db,
-      'my-task',
-      'abc123',
-      ON_FAILURE,
-    );
+    const doCVRStore2 = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
     const reloaded = await doCVRStore2.load(lc, LAST_CONNECT);
     expect(reloaded).toEqual(updated);
 
@@ -3487,7 +3459,7 @@ describe('view-syncer/cvr', () => {
 
     await setInitialState(db, initialState);
 
-    const cvrStore = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
+    const cvrStore = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
     const cvr = await cvrStore.load(lc, LAST_CONNECT);
     const updater = new CVRQueryDrivenUpdater(cvrStore, cvr, '1ba', '120');
 
@@ -3549,7 +3521,7 @@ describe('view-syncer/cvr', () => {
     `);
 
     // Verify round tripping.
-    const cvrStore2 = new CVRStore(lc, db, db, 'my-task', 'abc123', ON_FAILURE);
+    const cvrStore2 = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
     const reloaded = await cvrStore2.load(lc, LAST_CONNECT);
     expect(reloaded).toEqual(updated);
 

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -375,7 +375,6 @@ async function setup(permissions: PermissionsConfig = {}) {
     serviceID,
     SHARD_ID,
     cvrDB,
-    cvrDB,
     new PipelineDriver(
       lc.withContext('component', 'pipeline-driver'),
       new Snapshotter(lc, replicaDbFile.path),
@@ -512,14 +511,7 @@ describe('view-syncer/service', () => {
     ]);
     await nextPoke(client);
 
-    const cvrStore = new CVRStore(
-      lc,
-      cvrDB,
-      cvrDB,
-      TASK_ID,
-      serviceID,
-      ON_FAILURE,
-    );
+    const cvrStore = new CVRStore(lc, cvrDB, TASK_ID, serviceID, ON_FAILURE);
     const cvr = await cvrStore.load(lc, Date.now());
     expect(cvr).toMatchObject({
       clients: {
@@ -567,14 +559,7 @@ describe('view-syncer/service', () => {
       },
     ]);
 
-    const cvrStore = new CVRStore(
-      lc,
-      cvrDB,
-      cvrDB,
-      TASK_ID,
-      serviceID,
-      ON_FAILURE,
-    );
+    const cvrStore = new CVRStore(lc, cvrDB, TASK_ID, serviceID, ON_FAILURE);
     const cvr = await cvrStore.load(lc, Date.now());
     expect(cvr).toMatchObject({
       clients: {
@@ -2497,14 +2482,7 @@ describe('view-syncer/service', () => {
   test('waits for replica to catch up', async () => {
     // Before connecting, artificially set the CVR version to '07',
     // which is ahead of the current replica version '00'.
-    const cvrStore = new CVRStore(
-      lc,
-      cvrDB,
-      cvrDB,
-      TASK_ID,
-      serviceID,
-      ON_FAILURE,
-    );
+    const cvrStore = new CVRStore(lc, cvrDB, TASK_ID, serviceID, ON_FAILURE);
     await new CVRQueryDrivenUpdater(
       cvrStore,
       await cvrStore.load(lc, Date.now()),
@@ -2665,14 +2643,7 @@ describe('view-syncer/service', () => {
   });
 
   test('sends reset for CVR from different replica version up', async () => {
-    const cvrStore = new CVRStore(
-      lc,
-      cvrDB,
-      cvrDB,
-      TASK_ID,
-      serviceID,
-      ON_FAILURE,
-    );
+    const cvrStore = new CVRStore(lc, cvrDB, TASK_ID, serviceID, ON_FAILURE);
     await new CVRQueryDrivenUpdater(
       cvrStore,
       await cvrStore.load(lc, Date.now()),
@@ -2721,14 +2692,7 @@ describe('view-syncer/service', () => {
   });
 
   test('sends invalid base cookie if client is ahead of CVR', async () => {
-    const cvrStore = new CVRStore(
-      lc,
-      cvrDB,
-      cvrDB,
-      TASK_ID,
-      serviceID,
-      ON_FAILURE,
-    );
+    const cvrStore = new CVRStore(lc, cvrDB, TASK_ID, serviceID, ON_FAILURE);
     await new CVRQueryDrivenUpdater(
       cvrStore,
       await cvrStore.load(lc, Date.now()),

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -124,8 +124,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     taskID: string,
     clientGroupID: string,
     shardID: string,
-    highPriDB: PostgresDB,
-    lowPriDB: PostgresDB,
+    db: PostgresDB,
     pipelineDriver: PipelineDriver,
     versionChanges: Subscription<ReplicaState>,
     drainCoordinator: DrainCoordinator,
@@ -141,8 +140,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     this.#keepaliveMs = keepaliveMs;
     this.#cvrStore = new CVRStore(
       lc,
-      highPriDB,
-      lowPriDB,
+      db,
       taskID,
       clientGroupID,
       // On failure, cancel the #stateChanges subscription. The run()


### PR DESCRIPTION
This had the intended effect of prioritizing CVR flushes but did not result in a significant improvement in user-visible timings. It is likely that the latency (at this current configuration) is not from the DB. 