### PR TITLE
feat(sandbox): run sandbox with 5x8-core

### DIFF
--- a/prod/templates/sandbox/template.yml
+++ b/prod/templates/sandbox/template.yml
@@ -111,10 +111,10 @@ Resources:
             - !GetAtt VPC.Outputs.SG
             - !Ref InternalServicesSG
       DeploymentConfiguration:
-        # Run up to 10 tasks, capping updates to 2 tasks at a time
-        MaximumPercent: 125
+        # Run up to 7 tasks, capping updates to 2 tasks at a time
+        MaximumPercent: 140
         MinimumHealthyPercent: 50
-      DesiredCount: 8
+      DesiredCount: 5
       TaskDefinition: !Ref "TaskDefinitionViewSyncer"
       LoadBalancers:
         - ContainerName: "view-syncer-container"
@@ -175,8 +175,8 @@ Resources:
     Type: AWS::ECS::TaskDefinition
     Properties:
       Family: sandbox-view-syncer-task-definition
-      Cpu: 4096
-      Memory: 8192
+      Cpu: 8192
+      Memory: 16384
       NetworkMode: awsvpc
       RequiresCompatibilities:
         - FARGATE
@@ -187,8 +187,8 @@ Resources:
         OperatingSystemFamily: LINUX
       ContainerDefinitions:
         - Name: view-syncer-container
-          Cpu: 4096
-          Memory: 8192
+          Cpu: 8192
+          Memory: 16384
           Image: !Sub ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/zero-zbugs-sandbox:${Tag}
           PortMappings:
             - Name: "4848"
@@ -209,11 +209,11 @@ Resources:
             - Name: ZERO_LOG_LEVEL
               Value: debug
             - Name: ZERO_UPSTREAM_MAX_CONNS
-              # limit: 190 max_connections / (8 tasks * 1.25 maximum-percent)
-              Value: 15
+              # limit: 190 max_connections / (5 tasks * 1.4 maximum-percent)
+              Value: 25
             - Name: ZERO_CVR_MAX_CONNS
-              # limit: 5000 max_connections / (8 tasks * 1.25 maximum-percent)
-              Value: 450
+              # limit: 5000 max_connections / (5 tasks * 1.4 maximum-percent)
+              Value: 700
             - Name: ZERO_SCHEMA_FILE
               Value: /opt/app/packages/zero-cache/zero-schema.json
           Secrets:


### PR DESCRIPTION
This results in a total of 5x7 = 35 syncer cores