### PR TITLE
chore(zero-schema): Do not use namespaces for columns.

### DIFF
--- a/packages/zero-client/src/mod.ts
+++ b/packages/zero-client/src/mod.ts
@@ -1,10 +1,10 @@
 export {
-  IDBNotFoundError,
-  TransactionClosedError,
   dropAllDatabases,
   dropDatabase,
   getDefaultPuller,
+  IDBNotFoundError,
   makeIDBName,
+  TransactionClosedError,
 } from '../../replicache/src/mod.js';
 export type {
   AsyncIterableIteratorToArray,
@@ -33,17 +33,17 @@ export type {
   IterableUnion,
   JSONObject,
   JSONValue,
+  KeyTypeForScanOptions,
   KVRead,
   KVStore,
   KVWrite,
-  KeyTypeForScanOptions,
   MaybePromise,
   MutatorDefs,
   MutatorReturn,
   PatchOperation,
-  ReadTransaction,
   ReadonlyJSONObject,
   ReadonlyJSONValue,
+  ReadTransaction,
   ScanIndexOptions,
   ScanNoIndexOptions,
   ScanOptionIndexedStartKey,
@@ -57,16 +57,16 @@ export type {
   VersionNotSupportedResponse,
   WriteTransaction,
 } from '../../replicache/src/mod.js';
+export * as column from '../../zero-schema/src/column.js';
 export {
-  definePermissions,
   ANYONE_CAN,
+  definePermissions,
   NOBODY_CAN,
 } from '../../zero-schema/src/permissions.js';
 export {createSchema} from '../../zero-schema/src/schema.js';
 export {
   createTableSchema,
   type TableSchema,
-  column,
 } from '../../zero-schema/src/table-schema.js';
 export {escapeLike} from '../../zql/src/query/escape-like.js';
 export type {
@@ -79,9 +79,9 @@ export type {
   QueryReturnType,
   QueryRowType,
   QueryType,
-  Smash,
   Row,
   Rows,
+  Smash,
 } from '../../zql/src/query/query.js';
 export type {TypedView} from '../../zql/src/query/typed-view.js';
 export type {ZeroOptions} from './client/options.js';

--- a/packages/zero-schema/src/column.ts
+++ b/packages/zero-schema/src/column.ts
@@ -1,0 +1,43 @@
+export function string<T extends string = string>(optional: boolean = false) {
+  return {
+    type: 'string',
+    optional,
+    customType: null as unknown as T,
+  } as const;
+}
+
+export function number<T extends number = number>(optional: boolean = false) {
+  return {
+    type: 'number',
+    optional,
+    customType: null as unknown as T,
+  } as const;
+}
+
+export function boolean<T extends boolean = boolean>(
+  optional: boolean = false,
+) {
+  return {
+    type: 'boolean',
+    optional,
+    customType: null as unknown as T,
+  } as const;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function json<T = any>(optional: boolean = false) {
+  return {
+    type: 'json',
+    optional,
+    customType: null as unknown as T,
+  } as const;
+}
+
+export function enumeration<T extends string>(optional: boolean = false) {
+  return {
+    type: 'string',
+    kind: 'enum',
+    customType: null as unknown as T,
+    optional,
+  } as const;
+}

--- a/packages/zero-schema/src/table-schema.ts
+++ b/packages/zero-schema/src/table-schema.ts
@@ -28,46 +28,6 @@ type EnumSchemaValue<T> = {
   customType: T;
 };
 
-export const column = {
-  string<T extends string = string>(optional: boolean = false) {
-    return {
-      type: 'string',
-      optional,
-      customType: null as unknown as T,
-    } as const;
-  },
-  number<T extends number = number>(optional: boolean = false) {
-    return {
-      type: 'number',
-      optional,
-      customType: null as unknown as T,
-    } as const;
-  },
-  boolean<T extends boolean = boolean>(optional: boolean = false) {
-    return {
-      type: 'boolean',
-      optional,
-      customType: null as unknown as T,
-    } as const;
-  },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  json<T = any>(optional: boolean = false) {
-    return {
-      type: 'json',
-      optional,
-      customType: null as unknown as T,
-    } as const;
-  },
-  enumeration<T extends string>(optional: boolean = false) {
-    return {
-      type: 'string',
-      kind: 'enum',
-      customType: null as unknown as T,
-      optional,
-    } as const;
-  },
-};
-
 export type TableSchema = {
   readonly tableName: string;
   readonly columns: Record<string, SchemaValue | ValueType>;

--- a/packages/zql/src/query/query.test.ts
+++ b/packages/zql/src/query/query.test.ts
@@ -2,7 +2,13 @@
 import {describe, expectTypeOf, test} from 'vitest';
 import type {ReadonlyJSONValue} from '../../../shared/src/json.js';
 import {
-  column,
+  boolean,
+  enumeration,
+  json,
+  number,
+  string,
+} from '../../../zero-schema/src/column.js';
+import {
   type Supertype,
   type TableSchema,
 } from '../../../zero-schema/src/table-schema.js';
@@ -84,7 +90,6 @@ function timestamp(n: number): Timestamp {
   return n as Timestamp;
 }
 
-const {string, number, json, enumeration, boolean} = column;
 const schemaWithAdvancedTypes = {
   tableName: 'schemaWithAdvancedTypes',
   columns: {


### PR DESCRIPTION
This does not change the public API. Instead it exports the module which has some benefits like better tree shaking.