### PR TITLE
chore(zero-cache): rename dispatcher, remove unused host logic

### DIFF
--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -2,7 +2,7 @@ import {resolver} from '@rocicorp/resolver';
 import {availableParallelism} from 'node:os';
 import path from 'node:path';
 import {getZeroConfig} from '../config/zero-config.js';
-import {Dispatcher, type Workers} from '../services/dispatcher/dispatcher.js';
+import {SyncDispatcher} from '../services/dispatcher/sync-dispatcher.js';
 import type {Service} from '../services/service.js';
 import {initViewSyncerSchema} from '../services/view-syncer/schema/init.js';
 import {pgClient} from '../types/pg.js';
@@ -141,8 +141,7 @@ export default async function runWorker(
   const {port} = config;
 
   if (numSyncers) {
-    const workers: Workers = {syncers};
-    mainServices.push(new Dispatcher(lc, parent, () => workers, {port}));
+    mainServices.push(new SyncDispatcher(lc, parent, syncers, {port}));
   }
 
   parent?.send(['ready', {ready: true}]);

--- a/packages/zero-cache/src/services/dispatcher/sync-dispatcher.test.ts
+++ b/packages/zero-cache/src/services/dispatcher/sync-dispatcher.test.ts
@@ -1,5 +1,5 @@
 import {expect, test} from 'vitest';
-import {parseSyncPath} from './dispatcher.js';
+import {parseSyncPath} from './sync-dispatcher.js';
 
 test.each([
   ['/sync/v1/connect', {version: '1'}],


### PR DESCRIPTION
Rename `Dispatcher` to `SyncDispatcher`, and remove the unused dispatch-by-host logic, which has been subsumed by the `TenantDispatcher` in the multi-tenant entrypoint..