### PR TITLE
chore(zero-cache): move the query into a log context param

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/change-source.ts
@@ -487,10 +487,9 @@ class ChangeMaker {
       event,
     ).map(change => ['data', change] satisfies Data);
 
-    this.#lc.info?.(
-      `${changes.length} schema change(s) for ${event.context.query}`,
-      changes,
-    );
+    this.#lc
+      .withContext('query', event.context.query)
+      .info?.(`${changes.length} schema change(s)`, changes);
 
     return changes;
   }


### PR DESCRIPTION
The query can often be large and contain multiple DDL statements. Ferry it in a LogContext parameter so that it is collapsed by default in structured log viewers.

#user-feedback