### PR TITLE
fix(zbugs): only show toasts for newer comments

### DIFF
--- a/apps/zbugs/src/pages/issue/comment.tsx
+++ b/apps/zbugs/src/pages/issue/comment.tsx
@@ -71,7 +71,6 @@ const Comment = memo(({id, issueID, comment, height}: Props) => {
         />{' '}
         {comment.creator?.login}
       </p>
-      {comment.id}
       <span id={permalink} className={style.commentTimestamp}>
         <Link href={`#${permalink}`}>
           <RelativeTime timestamp={comment.created} />


### PR DESCRIPTION
Also fix an issue where sort was underspecified.  

Fixes: https://bugs.rocicorp.dev/issue/3254