### PR TITLE
prod(sandbox): setup ServiceConnect configs

### DIFF
--- a/prod/templates/sandbox/template.yml
+++ b/prod/templates/sandbox/template.yml
@@ -116,6 +116,8 @@ Resources:
         MinimumHealthyPercent: 50
       DesiredCount: 10
       TaskDefinition: !Ref "TaskDefinitionViewSyncer"
+      ServiceConnectConfiguration:
+        Enabled: true
       LoadBalancers:
         - ContainerName: "view-syncer-container"
           ContainerPort: 4848
@@ -199,6 +201,7 @@ Resources:
           Essential: true
           Environment:
             - Name: ZERO_CHANGE_STREAMER_URI
+              # TODO: Change to ws://change-streamer:4849 and remove ServiceDiscovery
               Value: ws://replication-manager.internal.local:4849
             - Name: ZERO_LOG_FORMAT
               Value: json
@@ -308,6 +311,10 @@ Resources:
         MinimumHealthyPercent: 50
       DesiredCount: 1
       TaskDefinition: !Ref "TaskDefinitionReplicationManager"
+      ServiceConnectConfiguration:
+        Enabled: true
+        Services:
+          - PortName: "change-streamer"
       ServiceRegistries:
         - RegistryArn: !GetAtt ReplicationManagerRegistry.Arn
 
@@ -345,7 +352,7 @@ Resources:
           Memory: 8192
           Image: !Sub ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/zero-zbugs-sandbox:${Tag}
           PortMappings:
-            - Name: "4849"
+            - Name: "change-streamer"
               ContainerPort: 4849
               HostPort: 4849
               Protocol: tcp


### PR DESCRIPTION
Sets up minimal configuration for view-syncers to connect to the replication-manager via ServiceConnect.

Does not use the endpoint yet. That still uses ServiceDiscovery for the time being.