### PR TITLE
Revert "fix(sandbox): ServiceConnect"

### DIFF
--- a/prod/templates/sandbox/template.yml
+++ b/prod/templates/sandbox/template.yml
@@ -116,8 +116,6 @@ Resources:
         MinimumHealthyPercent: 50
       DesiredCount: 10
       TaskDefinition: !Ref "TaskDefinitionViewSyncer"
-      ServiceConnectConfiguration:
-        Enabled: true
       LoadBalancers:
         - ContainerName: "view-syncer-container"
           ContainerPort: 4848
@@ -201,7 +199,6 @@ Resources:
           Essential: true
           Environment:
             - Name: ZERO_CHANGE_STREAMER_URI
-              # TODO: Change to ws://change-streamer:4849 and remove ServiceDiscovery
               Value: ws://replication-manager.internal.local:4849
             - Name: ZERO_LOG_FORMAT
               Value: json
@@ -311,10 +308,6 @@ Resources:
         MinimumHealthyPercent: 50
       DesiredCount: 1
       TaskDefinition: !Ref "TaskDefinitionReplicationManager"
-      ServiceConnectConfiguration:
-        Enabled: true
-        Services:
-          - PortName: "change-streamer"
       ServiceRegistries:
         - RegistryArn: !GetAtt ReplicationManagerRegistry.Arn
 


### PR DESCRIPTION
Kept the renaming of the port-mapping to "change-streamer", but reverted the Service Connect stuff.

Fails with:

```
-------------------------------------------------------------------------------------------------
ResourceStatus           ResourceType             LogicalResourceId        ResourceStatusReason   
-------------------------------------------------------------------------------------------------
UPDATE_IN_PROGRESS       AWS::CloudFormation::S   zbugs-sandbox            User Initiated         
                         tack                                                                     
UPDATE_IN_PROGRESS       AWS::CloudFormation::S   VPC                      -                      
                         tack                                                                     
UPDATE_COMPLETE          AWS::CloudFormation::S   VPC                      -                      
                         tack                                                                     
UPDATE_IN_PROGRESS       AWS::ECS::TaskDefiniti   TaskDefinitionReplicat   Requested update       
                         on                       ionManager               requires the creation  
                                                                           of a new physical      
                                                                           resource; hence        
                                                                           creating one.          
UPDATE_IN_PROGRESS       AWS::ECS::TaskDefiniti   TaskDefinitionReplicat   Resource creation      
                         on                       ionManager               Initiated              
UPDATE_COMPLETE          AWS::ECS::TaskDefiniti   TaskDefinitionReplicat   -                      
                         on                       ionManager                                      
UPDATE_IN_PROGRESS       AWS::ECS::Service        ServiceViewSyncer        -                      
UPDATE_FAILED            AWS::ECS::Service        ServiceViewSyncer        Resource handler       
                                                                           returned message:      
                                                                           "Invalid request       
                                                                           provided:              
                                                                           UpdateService error:   
                                                                           No namespace was       
                                                                           present for service    
                                                                           connect in referenced  
                                                                           cluster or service     
                                                                           connect configuration. 
                                                                           (Service: AmazonECS;   
                                                                           Status Code: 400;      
                                                                           Error Code: InvalidPar 
                                                                           ameterException;       
                                                                           Request ID: 0d103eb9-  
                                                                           8be6-48c7-9[69](https://github.com/rocicorp/mono/actions/runs/12382194556/job/34562389957#step:15:70)5-        
                                                                           03f6fec90f29; Proxy:   
                                                                           null)" (RequestToken:  
                                                                           0bfa6ede-5601-14c8-    
                                                                           396b-6194624d2222,     
                                                                           HandlerErrorCode:      
                                                                           InvalidRequest)        
UPDATE_FAILED            AWS::ECS::Service        ServiceReplicationMana   Resource update        
                                                  ger                      cancelled              
UPDATE_ROLLBACK_IN_PRO   AWS::CloudFormation::S   zbugs-sandbox            The following          
GRESS                    tack                                              resource(s) failed to  
                                                                           update:                
                                                                           [ServiceViewSyncer, Se 
                                                                           rviceReplicationManage 
                                                                           r].
```