### PR TITLE
fix(zero-cache): log when closing a connection with an error

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/client-handler.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.ts
@@ -114,6 +114,10 @@ export class ClientHandler {
   }
 
   fail(e: unknown) {
+    this.#lc.error?.(
+      `view-syncer closing connection with error: ${String(e)}`,
+      e,
+    );
     this.#pokes.fail(e instanceof Error ? e : new Error(String(e)));
   }
 


### PR DESCRIPTION
This is a potential spot where we close a connection without logging why.