### PR TITLE
chore(zero-cache): adjust log levels of thrown errors

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/client-handler.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.ts
@@ -15,6 +15,7 @@ import type {
 } from '../../../../zero-protocol/src/mod.js';
 import {primaryKeyValueRecordSchema} from '../../../../zero-protocol/src/primary-key.js';
 import type {JSONObject} from '../../types/bigint-json.js';
+import {getLogLevel} from '../../types/error-for-client.js';
 import {
   getErrorForClientIfSchemaVersionNotSupported,
   type SchemaVersions,
@@ -114,7 +115,7 @@ export class ClientHandler {
   }
 
   fail(e: unknown) {
-    this.#lc.error?.(
+    this.#lc[getLogLevel(e)]?.(
       `view-syncer closing connection with error: ${String(e)}`,
       e,
     );

--- a/packages/zero-cache/src/services/view-syncer/cvr-store.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.ts
@@ -18,7 +18,7 @@ import {ErrorKind} from '../../../../zero-protocol/src/error.js';
 import {multiInsertParams, multiInsertStatement} from '../../db/queries.js';
 import {Mode, TransactionPool} from '../../db/transaction-pool.js';
 import type {JSONValue} from '../../types/bigint-json.js';
-import {ErrorForClient} from '../../types/error-for-client.js';
+import {ErrorForClient, ErrorWithLevel} from '../../types/error-for-client.js';
 import type {PostgresDB, PostgresTransaction} from '../../types/pg.js';
 import {rowIDString} from '../../types/row-key.js';
 import type {Patch, PatchToVersion} from './client-handler.js';
@@ -1078,17 +1078,18 @@ async function checkVersion(
   }
 }
 
-export class ConcurrentModificationException extends Error {
+export class ConcurrentModificationException extends ErrorWithLevel {
   readonly name = 'ConcurrentModificationException';
 
   constructor(expectedVersion: string, actualVersion: string) {
     super(
       `CVR has been concurrently modified. Expected ${expectedVersion}, got ${actualVersion}`,
+      'warn',
     );
   }
 }
 
-export class OwnershipError extends Error {
+export class OwnershipError extends ErrorWithLevel {
   readonly name = 'OwnershipError';
 
   constructor(owner: string | null, grantedAt: number | null) {
@@ -1096,6 +1097,7 @@ export class OwnershipError extends Error {
       `CVR ownership was transferred to ${owner} at ${new Date(
         grantedAt ?? 0,
       ).toISOString()}`,
+      'info',
     );
   }
 }

--- a/packages/zero-cache/src/types/error-for-client.ts
+++ b/packages/zero-cache/src/types/error-for-client.ts
@@ -14,7 +14,7 @@ export class ErrorWithLevel extends Error {
   }
 }
 
-export function getLogLevel(error: unknown) {
+export function getLogLevel(error: unknown): LogLevel {
   return error instanceof ErrorWithLevel ? error.logLevel : 'error';
 }
 
@@ -22,7 +22,7 @@ export class ErrorForClient extends ErrorWithLevel {
   readonly errorBody;
   constructor(
     errorBody: ErrorBody,
-    logLevel: LogLevel = 'warn', // 'warn' by default most of these are not server errors
+    logLevel: LogLevel = 'warn', // 'warn' by default since these are generally not server issues
     options?: ErrorOptions,
   ) {
     super(JSON.stringify(errorBody), logLevel, options);

--- a/packages/zero-cache/src/types/error-for-client.ts
+++ b/packages/zero-cache/src/types/error-for-client.ts
@@ -1,9 +1,31 @@
+import type {LogLevel} from '@rocicorp/logger';
 import type {ErrorBody} from '../../../zero-protocol/src/error.js';
 
-export class ErrorForClient extends Error {
+export class ErrorWithLevel extends Error {
+  readonly logLevel: LogLevel;
+
+  constructor(
+    msg: string,
+    logLevel: LogLevel = 'error',
+    options?: ErrorOptions,
+  ) {
+    super(msg, options);
+    this.logLevel = logLevel;
+  }
+}
+
+export function getLogLevel(error: unknown) {
+  return error instanceof ErrorWithLevel ? error.logLevel : 'error';
+}
+
+export class ErrorForClient extends ErrorWithLevel {
   readonly errorBody;
-  constructor(errorBody: ErrorBody, options?: ErrorOptions) {
-    super(JSON.stringify(errorBody), options);
+  constructor(
+    errorBody: ErrorBody,
+    logLevel: LogLevel = 'warn', // 'warn' by default most of these are not server errors
+    options?: ErrorOptions,
+  ) {
+    super(JSON.stringify(errorBody), logLevel, options);
     this.errorBody = errorBody;
   }
 }

--- a/packages/zero-cache/src/workers/connection.ts
+++ b/packages/zero-cache/src/workers/connection.ts
@@ -24,7 +24,7 @@ import type {
   TokenData,
   ViewSyncer,
 } from '../services/view-syncer/view-syncer.js';
-import {findErrorForClient} from '../types/error-for-client.js';
+import {findErrorForClient, getLogLevel} from '../types/error-for-client.js';
 import type {Source} from '../types/streams.js';
 
 const tracer = trace.getTracer('syncer-ws-server', version);
@@ -287,7 +287,7 @@ export function sendError(
   thrown?: unknown,
 ) {
   lc = lc.withContext('errorKind', errorBody.kind);
-  const logLevel = thrown ? 'error' : 'info';
+  const logLevel = thrown ? getLogLevel(thrown) : 'info';
   lc[logLevel]?.('Sending error on WebSocket', errorBody, thrown ?? '');
   send(ws, ['error', errorBody]);
 }


### PR DESCRIPTION
Select appropriate log levels for different types of errors to improve the signal-to-noise ratio in server logs.

Some errors like OwnershipError are used for control flow and some are related to client conditions and do not constitute a problem on the server.