### PR TITLE
chore(zero-cache): fix log level when user-facing worker exits

### DIFF
--- a/packages/zero-cache/src/server/life-cycle.ts
+++ b/packages/zero-cache/src/server/life-cycle.ts
@@ -23,6 +23,10 @@ export type WorkerType = 'user-facing' | 'supporting';
 export const GRACEFUL_SHUTDOWN = ['SIGTERM', 'SIGINT'] as const;
 export const FORCEFUL_SHUTDOWN = ['SIGQUIT'] as const;
 
+function isGracefulShutdown(sig: NodeJS.Signals | null) {
+  return sig && (GRACEFUL_SHUTDOWN as readonly NodeJS.Signals[]).includes(sig);
+}
+
 /**
  * Handles readiness, termination signals, and coordination of graceful
  * shutdown.
@@ -143,16 +147,19 @@ export class ProcessManager {
       return this.#exit(log === 'error' ? -1 : code);
     }
 
-    const log = this.#drainStart === 0 ? 'error' : 'warn';
+    const log =
+      this.#drainStart === 0
+        ? 'error'
+        : isGracefulShutdown(sig) || code === 0
+        ? 'info'
+        : 'warn';
     if (sig) {
       this.#lc[log]?.(`${type} worker ${pid} killed with (${sig})`, err ?? '');
-    } else if (code !== 0) {
-      this.#lc[log]?.(
+    } else {
+      this.#lc.info?.(
         `${type} worker ${pid} exited with code (${code})`,
         err ?? '',
       );
-    } else {
-      this.#lc.info?.(`${type} worker ${pid} exited with code (${code})`);
     }
 
     // Exit only if not draining. If a user-facing worker exits unexpectedly

--- a/packages/zero-cache/src/server/life-cycle.ts
+++ b/packages/zero-cache/src/server/life-cycle.ts
@@ -156,7 +156,7 @@ export class ProcessManager {
     if (sig) {
       this.#lc[log]?.(`${type} worker ${pid} killed with (${sig})`, err ?? '');
     } else {
-      this.#lc.info?.(
+      this.#lc[log]?.(
         `${type} worker ${pid} exited with code (${code})`,
         err ?? '',
       );


### PR DESCRIPTION
user-facing workers used to exit with code `0` after draining, but with the new multi-level process tree, the kill signal is reported instead. From the logs, the right thing is happening, so consider this an expected scenario and log as `info` instead of `warn`.