### PR TITLE
chore(zero-cache): log more information when a client is not found

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr-store.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.ts
@@ -657,7 +657,11 @@ export class CVRStore {
 
     for (const row of desiresRows) {
       const client = cvr.clients[row.clientID];
-      assert(client, 'Client not found');
+      if (!client) {
+        // should be impossible unless CVR is corrupted
+        lc.error?.(`Client ${row.clientID} not found`, cvr);
+        throw new Error(`Client ${row.clientID} not found`);
+      }
       client.desiredQueryIDs.push(row.queryHash);
 
       const query = cvr.queries[row.queryHash];


### PR DESCRIPTION
Logs show an instance of an assert that should not be possible given the CVR schema constraints (i.e. `clientID` is a foreign key reference):

<img width="849" alt="Screenshot 2024-12-19 at 16 58 42" src="https://github.com/user-attachments/assets/a52ed441-0528-423c-89d6-d5e5f0d06905" />

Indeed, the data in the DB looks well formed:

<img width="1229" alt="Screenshot 2024-12-19 at 17 00 41" src="https://github.com/user-attachments/assets/c4456b02-eef8-4c7c-88a8-d802ebd896e2" />

So this incidence is a bit of a mystery. Add more logging to debug if/when it happens again.