### PR TITLE
fix(zero-cache): fix graceful shutdown by awaiting process manager before exiting

### DIFF
--- a/packages/zero-cache/src/server/life-cycle.ts
+++ b/packages/zero-cache/src/server/life-cycle.ts
@@ -23,10 +23,6 @@ export type WorkerType = 'user-facing' | 'supporting';
 export const GRACEFUL_SHUTDOWN = ['SIGTERM', 'SIGINT'] as const;
 export const FORCEFUL_SHUTDOWN = ['SIGQUIT'] as const;
 
-function isGracefulShutdown(sig: NodeJS.Signals | null) {
-  return sig && (GRACEFUL_SHUTDOWN as readonly NodeJS.Signals[]).includes(sig);
-}
-
 /**
  * Handles readiness, termination signals, and coordination of graceful
  * shutdown.
@@ -147,19 +143,16 @@ export class ProcessManager {
       return this.#exit(log === 'error' ? -1 : code);
     }
 
-    const log =
-      this.#drainStart === 0
-        ? 'error'
-        : isGracefulShutdown(sig) || code === 0
-        ? 'info'
-        : 'warn';
+    const log = this.#drainStart === 0 ? 'error' : 'warn';
     if (sig) {
       this.#lc[log]?.(`${type} worker ${pid} killed with (${sig})`, err ?? '');
-    } else {
+    } else if (code !== 0) {
       this.#lc[log]?.(
         `${type} worker ${pid} exited with code (${code})`,
         err ?? '',
       );
+    } else {
+      this.#lc.info?.(`${type} worker ${pid} exited with code (${code})`);
     }
 
     // Exit only if not draining. If a user-facing worker exits unexpectedly

--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -151,6 +151,8 @@ export default async function runWorker(
   } catch (err) {
     processes.logErrorAndExit(err);
   }
+
+  await processes.done();
 }
 
 if (!singleProcessMode()) {

--- a/packages/zero-cache/src/server/multi/main.ts
+++ b/packages/zero-cache/src/server/multi/main.ts
@@ -83,6 +83,8 @@ export default async function runWorker(
   } catch (err) {
     processes.logErrorAndExit(err);
   }
+
+  await processes.done();
 }
 
 if (!singleProcessMode()) {


### PR DESCRIPTION
Reverts #3424 as that did not fix the issue.

Instead, have each process managing worker (`multi/main.ts` and `server/main.ts`) await its process manager before exiting. 

This avoids sending an additional `SIGTERM` to child processes when they are still draining.