### PR TITLE
fix(zero-cache): check shard initialized before updating

### DIFF
--- a/packages/zero-cache/src/db/migration.ts
+++ b/packages/zero-cache/src/db/migration.ts
@@ -204,7 +204,6 @@ export async function createVersionHistoryTable(
     );`.simple();
 }
 
-// Exposed for tests
 export async function getVersionHistory(
   sql: postgres.Sql,
   schemaName: string,

--- a/packages/zero-cache/src/services/change-streamer/pg/change-source.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/change-source.pg-test.ts
@@ -116,7 +116,7 @@ describe('change-source/pg', () => {
     );
   }
 
-  const MAX_ATTEMPTS_IF_REPLICATION_SLOT_ACTIVE = 5;
+  const MAX_ATTEMPTS_IF_REPLICATION_SLOT_ACTIVE = 10;
 
   async function startStream(watermark: string) {
     let err;

--- a/packages/zero-cache/src/services/change-streamer/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/change-source.ts
@@ -297,7 +297,7 @@ class PostgresChangeSource implements ChangeSource {
     SELECT pg_terminate_backend(active_pid), active_pid as pid
       FROM pg_replication_slots WHERE slot_name = ${slot}`;
     if (result.length === 0) {
-      throw new Error(
+      throw new AbortError(
         `replication slot ${slot} is missing. Delete the replica and resync.`,
       );
     }

--- a/packages/zero-cache/src/services/change-streamer/pg/schema/init.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/schema/init.pg-test.ts
@@ -7,7 +7,7 @@ import {
 } from '../../../../db/migration.js';
 import {expectTablesToMatch, initDB, testDBs} from '../../../../test/db.js';
 import type {PostgresDB} from '../../../../types/pg.js';
-import {updateShardSchema} from './init.js';
+import {initShardSchema, updateShardSchema} from './init.js';
 import {GLOBAL_SETUP} from './shard.js';
 
 const SHARD_ID = 'shard_schema_test_id';
@@ -209,11 +209,16 @@ describe('change-streamer/pg/schema/init', () => {
         await createVersionHistoryTable(upstream, schema);
         await upstream`INSERT INTO ${upstream(schema)}."versionHistory"
           ${upstream(c.existingVersionHistory)}`;
+        await updateShardSchema(lc, upstream, {
+          id: SHARD_ID,
+          publications: c.requestedPublications ?? [],
+        });
+      } else {
+        await initShardSchema(lc, upstream, {
+          id: SHARD_ID,
+          publications: c.requestedPublications ?? [],
+        });
       }
-      await updateShardSchema(lc, upstream, {
-        id: SHARD_ID,
-        publications: c.requestedPublications ?? [],
-      });
 
       await expectTablesToMatch(upstream, c.upstreamPostState);
     });

--- a/packages/zero-cache/src/services/change-streamer/pg/schema/init.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/schema/init.ts
@@ -1,5 +1,6 @@
 import type {LogContext} from '@rocicorp/logger';
 import {
+  getVersionHistory,
   runSchemaMigrations,
   type IncrementalMigrationMap,
   type Migration,
@@ -23,13 +24,28 @@ export async function initShardSchema(
   shardConfig: ShardConfig,
 ): Promise<void> {
   await db.unsafe(dropShard(shardConfig.id));
-  return updateShardSchema(lc, db, shardConfig);
+  return runShardMigrations(lc, db, shardConfig);
 }
 
 /**
  * Updates the schema for an existing shard.
  */
 export async function updateShardSchema(
+  lc: LogContext,
+  db: PostgresDB,
+  shardConfig: ShardConfig,
+): Promise<void> {
+  const {id} = shardConfig;
+  const {schemaVersion} = await getVersionHistory(db, unescapedSchema(id));
+  if (schemaVersion === 0) {
+    throw new Error(
+      `upstream shard ${id} is not initialized. Delete the replica and resync.`,
+    );
+  }
+  return runShardMigrations(lc, db, shardConfig);
+}
+
+async function runShardMigrations(
   lc: LogContext,
   db: PostgresDB,
   shardConfig: ShardConfig,

--- a/packages/zero-cache/src/services/change-streamer/pg/schema/init.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/schema/init.ts
@@ -1,4 +1,5 @@
 import type {LogContext} from '@rocicorp/logger';
+import {AbortError} from '../../../../../../shared/src/abort-error.js';
 import {
   getVersionHistory,
   runSchemaMigrations,
@@ -38,7 +39,7 @@ export async function updateShardSchema(
   const {id} = shardConfig;
   const {schemaVersion} = await getVersionHistory(db, unescapedSchema(id));
   if (schemaVersion === 0) {
-    throw new Error(
+    throw new AbortError(
       `upstream shard ${id} is not initialized. Delete the replica and resync.`,
     );
   }

--- a/packages/zero-cache/src/services/running-state.ts
+++ b/packages/zero-cache/src/services/running-state.ts
@@ -110,11 +110,8 @@ export class RunningState {
    */
   stop(lc: LogContext, err?: unknown): void {
     if (this.shouldRun()) {
-      if (!err || err instanceof AbortError) {
-        lc.info?.(`stopping ${this.#serviceName}`);
-      } else {
-        lc.error?.(`stopping ${this.#serviceName} with error`, err);
-      }
+      const log = !err || err instanceof AbortError ? 'info' : 'error';
+      lc[log]?.(`stopping ${this.#serviceName}`, err ?? '');
       this.#controller.abort();
     }
   }


### PR DESCRIPTION
An addendum to #3237, this change in particular catches the case where upstream tables have been cleared but the replication slot still exists, e.g.

https://discord.com/channels/830183651022471199/1319617557488992266/1319698226093363260

Check to ensure that the upstream shard is initialized when starting up `zero-cache`. If it is not, it fails fast with a similar error message prompting the developer to wipe the replica and re-sync:

<img width="874" alt="Screenshot 2024-12-20 at 12 15 02" src="https://github.com/user-attachments/assets/f440870d-92ad-466e-bd14-2bb6bdde7b6a" />

