### PR TITLE
fix(sandbox): disable timeouts for requests to change-streamer

### DIFF
--- a/prod/templates/sandbox/template.yml
+++ b/prod/templates/sandbox/template.yml
@@ -302,6 +302,9 @@ Resources:
             ClientAliases:
               - Port: 4849
                 DnsName: "change-streamer.zero-cache-sandbox"
+            Timeout:
+              IdleTimeoutSeconds: 0
+              PerRequestTimeoutSeconds: 0
 
   ReplicationManagerSecrets:
     Type: AWS::SecretsManager::Secret


### PR DESCRIPTION
Another configuration that we need to carry over from the previous incarnation of sandbox. 

<img width="713" alt="Screenshot 2024-12-20 at 15 31 50" src="https://github.com/user-attachments/assets/6f97dbf9-2d1c-40b5-afc0-e1efffeb810e" />

Requests to the `change-streamer` are long-lived websockets and thus should not be subject to timeouts.