### PR TITLE
chore(sandbox): reduce health check interval

### DIFF
--- a/prod/templates/sandbox/template.yml
+++ b/prod/templates/sandbox/template.yml
@@ -231,10 +231,10 @@ Resources:
             Command:
               - CMD-SHELL
               - curl -f http://localhost:4848/ || exit 1
-            Interval: 10
-            Timeout: 60
-            Retries: 10
-            StartPeriod: 10
+            Interval: 5
+            Retries: 3
+            # allow for slow `litestream restore` operations
+            StartPeriod: 300
 
   LogGroupViewSyncer:
     Type: AWS::Logs::LogGroup
@@ -388,9 +388,9 @@ Resources:
             Command:
               - CMD-SHELL
               - curl -f http://localhost:4849/ || exit 1
-            Interval: 300
-            Timeout: 60
-            Retries: 5
+            Interval: 5
+            Retries: 3
+            # allow for slow `litestream restore` operations
             StartPeriod: 300
 
   LogGroupReplicationManager:


### PR DESCRIPTION
Reduce the health check interval so that servers are considered healthy earlier. Keep the start period long, though, to allow for slow startup due to large `litestream restore` operations.

This is an experiment to see if we can reduce the occurrence of 503's from view-syncers to change-streamers when the latter are updated.

<img width="1535" alt="Screenshot 2024-12-20 at 16 43 48" src="https://github.com/user-attachments/assets/690dbb36-f223-4481-a189-08d8eb608f0d" />
