### PR TITLE
feat(sandbox): delay service connect requests on change-streamer health

### DIFF
--- a/prod/templates/sandbox/template.yml
+++ b/prod/templates/sandbox/template.yml
@@ -392,6 +392,19 @@ Resources:
             Retries: 3
             # allow for slow `litestream restore` operations
             StartPeriod: 300
+        # Dummy container with a dependency on replication-manager-container
+        # to delay the ECS transition to a RUNNING state until the replication-manager-container
+        # is healthy (as an ECS Task is only transitions to RUNNING once all containers have started).
+        # This, in turn, delays ServiceConnect requests from view-syncers until the
+        # replication-manager-container is HEALTHY. This workaround is described in:
+        # https://github.com/aws/containers-roadmap/issues/2334#issuecomment-2299912626
+        - Name: service-connect-hold
+          Image: public.ecr.aws/docker/library/alpine:edge
+          Cpu: 0
+          Essential: false
+          DependsOn:
+            - ContainerName: replication-manager-container
+              Condition: HEALTHY
 
   LogGroupReplicationManager:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
Follow the workaround described in https://github.com/aws/containers-roadmap/issues/2334#issuecomment-2285926075 to delay ServiceConnect requests to the `change-streamer` until it is healthy.

Once this behavior is vetted, the replication-manager will be modified to delay handing off the replication stream until the first subscription is received (signaling that ServiceConnect has considered the task healthy).