### PR TITLE
feat(zero-cache): tighter replication-manager handoff

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.test.ts
@@ -105,10 +105,11 @@ describe('change-streamer/http', () => {
   test('basic messages streamed over websocket', async () => {
     const ctx = {
       id: 'foo',
+      mode: 'serving',
       replicaVersion: 'abc',
       watermark: '123',
       initial: true,
-    };
+    } as const;
     const sub = await client.subscribe(ctx);
 
     downstream.push(['begin', {tag: 'begin'}]);
@@ -130,6 +131,7 @@ describe('change-streamer/http', () => {
   test('bigint and non-JSON fields', async () => {
     const sub = await client.subscribe({
       id: 'foo',
+      mode: 'serving',
       replicaVersion: 'abc',
       watermark: '123',
       initial: true,

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
@@ -76,6 +76,7 @@ function getSubscriberContext(req: FastifyRequest): SubscriberContext {
 
   return {
     id: params.get('id', true),
+    mode: params.get('mode', false) === 'backup' ? 'backup' : 'serving',
     replicaVersion: params.get('replicaVersion', true),
     watermark: params.get('watermark', true),
     initial: params.getBoolean('initial'),

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg-test.ts
@@ -113,6 +113,7 @@ describe('change-streamer/service', () => {
   test('immediate forwarding, transaction storage', async () => {
     const sub = await streamer.subscribe({
       id: 'myid',
+      mode: 'serving',
       watermark: '01',
       replicaVersion: REPLICA_VERSION,
       initial: true,
@@ -170,6 +171,7 @@ describe('change-streamer/service', () => {
     // Subscribe to the original watermark.
     const sub = await streamer.subscribe({
       id: 'myid',
+      mode: 'serving',
       watermark: '01',
       replicaVersion: REPLICA_VERSION,
       initial: true,
@@ -241,6 +243,7 @@ describe('change-streamer/service', () => {
     // Subscribe to the original watermark.
     const sub = await streamer.subscribe({
       id: 'myid',
+      mode: 'serving',
       watermark: '01',
       replicaVersion: REPLICA_VERSION,
       initial: true,
@@ -291,6 +294,7 @@ describe('change-streamer/service', () => {
   test('data types (forwarded and catchup)', async () => {
     const sub = await streamer.subscribe({
       id: 'myid',
+      mode: 'serving',
       watermark: '01',
       replicaVersion: REPLICA_VERSION,
       initial: true,
@@ -353,6 +357,7 @@ describe('change-streamer/service', () => {
     // Also verify when loading from the Store as opposed to direct forwarding.
     const catchupSub = await streamer.subscribe({
       id: 'myid2',
+      mode: 'serving',
       watermark: '01',
       replicaVersion: REPLICA_VERSION,
       initial: true,
@@ -389,6 +394,7 @@ describe('change-streamer/service', () => {
     // Start two subscribers: one at 06 and one at 04
     await streamer.subscribe({
       id: 'myid1',
+      mode: 'serving',
       watermark: '06',
       replicaVersion: REPLICA_VERSION,
       initial: true,
@@ -396,6 +402,7 @@ describe('change-streamer/service', () => {
 
     const sub2 = await streamer.subscribe({
       id: 'myid2',
+      mode: 'serving',
       watermark: '04',
       replicaVersion: REPLICA_VERSION,
       initial: true,
@@ -444,6 +451,7 @@ describe('change-streamer/service', () => {
     // New connections earlier than 06 should now be rejected.
     const sub3 = await streamer.subscribe({
       id: 'myid2',
+      mode: 'serving',
       watermark: '04',
       replicaVersion: REPLICA_VERSION,
       initial: true,
@@ -462,6 +470,7 @@ describe('change-streamer/service', () => {
   test('wrong replica version', async () => {
     const sub = await streamer.subscribe({
       id: 'myid1',
+      mode: 'serving',
       watermark: '06',
       replicaVersion: REPLICA_VERSION + 'foobar',
       initial: true,
@@ -497,6 +506,15 @@ describe('change-streamer/service', () => {
     );
     void streamer.run();
 
+    // Kick off the initial stream with a serving request.
+    void streamer.subscribe({
+      id: 'myid',
+      mode: 'serving',
+      watermark: '06',
+      replicaVersion: REPLICA_VERSION,
+      initial: true,
+    });
+
     expect(await hasRetried).toBe(true);
   });
 
@@ -517,6 +535,15 @@ describe('change-streamer/service', () => {
     );
     void streamer.run();
 
+    // Kick off the initial stream with a serving request.
+    void streamer.subscribe({
+      id: 'myid',
+      mode: 'serving',
+      watermark: '06',
+      replicaVersion: REPLICA_VERSION,
+      initial: true,
+    });
+
     expect(await requests.dequeue()).toBe(REPLICA_VERSION);
 
     await changeDB`
@@ -532,6 +559,15 @@ describe('change-streamer/service', () => {
       true,
     );
     void streamer.run();
+
+    // Kick off the initial stream with a serving request.
+    void streamer.subscribe({
+      id: 'myid',
+      mode: 'serving',
+      watermark: '06',
+      replicaVersion: REPLICA_VERSION,
+      initial: true,
+    });
 
     expect(await requests.dequeue()).toBe('04');
   });
@@ -562,12 +598,30 @@ describe('change-streamer/service', () => {
     );
     void streamer.run();
 
+    // Kick off the initial stream with a serving request.
+    void streamer.subscribe({
+      id: 'myid',
+      mode: 'serving',
+      watermark: '06',
+      replicaVersion: REPLICA_VERSION,
+      initial: true,
+    });
+
     changes.fail(new Error('doh'));
 
     expect(await hasRetried).toBe(true);
   });
 
   test('reset required', async () => {
+    // Kick off the initial stream with a serving request.
+    void streamer.subscribe({
+      id: 'myid',
+      mode: 'serving',
+      watermark: '06',
+      replicaVersion: REPLICA_VERSION,
+      initial: true,
+    });
+
     changes.push(['control', {tag: 'reset-required'}]);
     await streamerDone;
     await expect(
@@ -576,6 +630,15 @@ describe('change-streamer/service', () => {
   });
 
   test('shutdown on AbortError', async () => {
+    // Kick off the initial stream with a serving request.
+    void streamer.subscribe({
+      id: 'myid',
+      mode: 'serving',
+      watermark: '06',
+      replicaVersion: REPLICA_VERSION,
+      initial: true,
+    });
+
     changes.fail(new AbortError());
     await streamerDone;
   });
@@ -583,6 +646,7 @@ describe('change-streamer/service', () => {
   test('shutdown on unexpected storage error', async () => {
     await streamer.subscribe({
       id: 'myid',
+      mode: 'serving',
       watermark: '01',
       replicaVersion: REPLICA_VERSION,
       initial: true,

--- a/packages/zero-cache/src/services/change-streamer/change-streamer.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer.ts
@@ -1,5 +1,6 @@
 import * as v from '../../../../shared/src/valita.js';
 import type {Source} from '../../types/streams.js';
+import type {ReplicatorMode} from '../replicator/replicator.js';
 import type {Service} from '../service.js';
 import {
   beginSchema,
@@ -57,6 +58,13 @@ export type SubscriberContext = {
    * Subscriber id. This is only used for debugging.
    */
   id: string;
+
+  /**
+   * The ReplicatorMode of the subscriber. 'backup' indicates that the
+   * subscriber is local to the `change-streamer` in the `replication-manager`,
+   * while 'serving' indicates that user-facing requests depend on the subscriber.
+   */
+  mode: ReplicatorMode;
 
   /**
    * The ChangeStreamer will return an Error if the subscriber is

--- a/packages/zero-cache/src/services/replicator/incremental-sync.pg-test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.pg-test.ts
@@ -49,7 +49,7 @@ describe('replicator/incremental-sync', () => {
       REPLICA_ID,
       {subscribe: subscribeFn.mockResolvedValue(downstream)},
       replica,
-      'CONCURRENT',
+      'serving',
     );
   });
 
@@ -1531,6 +1531,7 @@ describe('replicator/incremental-sync', () => {
       await versionReady.next(); // Get the initial nextStateVersion.
       expect(subscribeFn.mock.calls[0][0]).toEqual({
         id: 'incremental_sync_test_id',
+        mode: 'serving',
         replicaVersion: '02',
         watermark: '02',
         initial: true,
@@ -1573,7 +1574,7 @@ describe('replicator/incremental-sync', () => {
           }),
       },
       replica,
-      'CONCURRENT',
+      'serving',
     );
 
     void syncer.run(lc);
@@ -1599,7 +1600,7 @@ describe('replicator/incremental-sync', () => {
           }),
       },
       replica,
-      'CONCURRENT',
+      'serving',
     );
 
     void syncer.run(lc);

--- a/packages/zero-cache/src/services/replicator/replicator.ts
+++ b/packages/zero-cache/src/services/replicator/replicator.ts
@@ -73,7 +73,7 @@ export class ReplicatorService implements Replicator, Service {
       `${taskID}/${id}`,
       changeStreamer,
       replica,
-      mode === 'serving' ? 'CONCURRENT' : 'IMMEDIATE',
+      mode,
     );
   }
 

--- a/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
@@ -208,7 +208,7 @@ describe('view-syncer/cvr', () => {
   });
 
   // Relies on an async homing signal (with no explicit flush, so allow retries)
-  test('load existing cvr', {retry: 2}, async () => {
+  test('load existing cvr', {retry: 3}, async () => {
     const initialState: DBState = {
       instances: [
         {

--- a/prod/templates/template.yml
+++ b/prod/templates/template.yml
@@ -412,6 +412,19 @@ Resources:
             Retries: 3
             # allow for slow `litestream restore` operations
             StartPeriod: 300
+        # Dummy container with a dependency on replication-manager-container
+        # to delay the ECS transition to a RUNNING state until the replication-manager-container
+        # is healthy (as an ECS Task is only transitions to RUNNING once all containers have started).
+        # This, in turn, delays ServiceConnect requests from view-syncers until the
+        # replication-manager-container is HEALTHY. This workaround is described in:
+        # https://github.com/aws/containers-roadmap/issues/2334#issuecomment-2299912626
+        - Name: service-connect-hold
+          Image: public.ecr.aws/docker/library/alpine:edge
+          Cpu: 0
+          Essential: false
+          DependsOn:
+            - ContainerName: replication-manager-container
+              Condition: HEALTHY
 
   LogGroupReplicationManager:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
An initializing `replication-manager` effectively kills the previous `replication-manager` when subscribing to the Postgres replication slot (as there can be only one subscriber).

If routing layers (from `view-syncer` to `replication-manager`) have not been updated to begin sending traffic to the new `replication-manager`, this can result in routing errors (e.g. 503s in AWS ServiceConnect) until the new `replication-manager` is recognized as healthy, during which replication is essentially paused.

This change reduces this gap by:

* Delaying ServiceConnect routing to the `replication-manager` until the container is healthy. This is an AWS-specific [workaround / trick](https://github.com/aws/containers-roadmap/issues/2334#issuecomment-2285926075) that has already been vetted in sandbox (#3436)
* Delaying the Postgres subscription takeover in the `replication-manager` until it receives its first external request from a `view-syncer` (i.e. from a `serving` replicator, as opposed to the internal request from its in-process `backup` replicator). Note: Using the `serving` vs `backup` distinction ensures that things continue to work without delay in local development.

The end result is that the old `replication-manager` can continue serving requests until the new `replication-manager` is recognized by the routing layers as "healthy". Once the new `replication-manager` receives its first request, it then initiates the handoff by killing the old subscriber. 