### PR TITLE
chore(zero): rm wa-sqlite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15116,12 +15116,6 @@
         }
       }
     },
-    "node_modules/wa-sqlite": {
-      "version": "0.9.13",
-      "resolved": "git+ssh://git@github.com/rhashimoto/wa-sqlite.git#ca2084cdd188c56532ba3e272696d0b9e21a23bf",
-      "integrity": "sha512-qxRofJXgBcJzZZQSyaC7zSyCu4tY19MWfI4/OM731fcwS9v4vSzagt+GJnT7ZGpPrgtdvNEBv0TePqEkMEuMug==",
-      "dev": true
-    },
     "node_modules/weak-map": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.8.tgz",
@@ -16254,7 +16248,6 @@
         "replicache": "15.2.1",
         "shared": "0.0.0",
         "typescript": "^5.6.3",
-        "wa-sqlite": "github:rhashimoto/wa-sqlite#ca2084cdd188c56532ba3e272696d0b9e21a23bf",
         "zero-protocol": "0.0.0",
         "zod": "^3.21.4"
       }
@@ -26751,12 +26744,6 @@
         "why-is-node-running": "^2.3.0"
       }
     },
-    "wa-sqlite": {
-      "version": "git+ssh://git@github.com/rhashimoto/wa-sqlite.git#ca2084cdd188c56532ba3e272696d0b9e21a23bf",
-      "integrity": "sha512-qxRofJXgBcJzZZQSyaC7zSyCu4tY19MWfI4/OM731fcwS9v4vSzagt+GJnT7ZGpPrgtdvNEBv0TePqEkMEuMug==",
-      "dev": true,
-      "from": "wa-sqlite@github:rhashimoto/wa-sqlite#ca2084cdd188c56532ba3e272696d0b9e21a23bf"
-    },
     "weak-map": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.8.tgz",
@@ -27349,7 +27336,6 @@
         "replicache": "15.2.1",
         "shared": "0.0.0",
         "typescript": "^5.6.3",
-        "wa-sqlite": "github:rhashimoto/wa-sqlite#ca2084cdd188c56532ba3e272696d0b9e21a23bf",
         "zero-protocol": "0.0.0",
         "zod": "^3.21.4"
       },

--- a/packages/shared/src/tool/vitest-config.ts
+++ b/packages/shared/src/tool/vitest-config.ts
@@ -37,7 +37,6 @@ export default {
   // https://github.com/vitest-dev/vitest/issues/5332#issuecomment-1977785593
   optimizeDeps: {
     include: ['vitest > @vitest/expect > chai'],
-    exclude: ['wa-sqlite'],
   },
   define,
   esbuild: {

--- a/packages/zql/package.json
+++ b/packages/zql/package.json
@@ -25,7 +25,6 @@
     "replicache": "15.2.1",
     "shared": "0.0.0",
     "typescript": "^5.6.3",
-    "wa-sqlite": "github:rhashimoto/wa-sqlite#ca2084cdd188c56532ba3e272696d0b9e21a23bf",
     "zero-protocol": "0.0.0",
     "zod": "^3.21.4"
   },


### PR DESCRIPTION
this was used in early benchmarking of ivm1 to test client side db impl vs sqlite-in-browser. No longer used.