### PR TITLE
Fixes windows build and deprecation of deprecation of pkg-up package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@floating-ui/react": "^0.26.28",
         "@headlessui/react": "^2.1.8",
         "@octokit/core": "^6.1.2",
-        "@rocicorp/zero": "0.10.2024122400+dfd80d",
+        "@rocicorp/zero": "0.10.2024122300+1d64e6",
         "@schickling/fps-meter": "^0.1.2",
         "@tanstack/react-virtual": "^3.10.9",
         "classnames": "^2.5.1",
@@ -15788,7 +15788,7 @@
     },
     "packages/zero": {
       "name": "@rocicorp/zero",
-      "version": "0.10.2024122400+dfd80d",
+      "version": "0.10.2024122300+1d64e6",
       "dependencies": {
         "@badrap/valita": "0.3.11",
         "@databases/escape-identifier": "^1.0.3",
@@ -26951,7 +26951,7 @@
         "@octokit/core": "^6.1.2",
         "@rocicorp/eslint-config": "^0.5.1",
         "@rocicorp/prettier-config": "^0.2.0",
-        "@rocicorp/zero": "0.10.2024122400+dfd80d",
+        "@rocicorp/zero": "0.10.2024122300+1d64e6",
         "@schickling/fps-meter": "^0.1.2",
         "@tailwindcss/forms": "^0.5.0",
         "@tanstack/react-virtual": "^3.10.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7521,29 +7521,17 @@
         }
       }
     },
-    "node_modules/find-up": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
-      "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
+    "node_modules/find-up-simple": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.0.tgz",
+      "integrity": "sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==",
       "dev": true,
-      "dependencies": {
-        "locate-path": "^7.1.0",
-        "path-exists": "^5.0.0"
-      },
+      "license": "MIT",
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/find-up/node_modules/path-exists": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
-      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
-      "dev": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/flat-cache": {
@@ -8688,21 +8676,6 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
-    },
-    "node_modules/locate-path": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
-      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^6.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/lodash": {
       "version": "4.17.21",
@@ -10420,53 +10393,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-locate": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
-      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-locate/node_modules/p-limit": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
-      "dev": true,
-      "dependencies": {
-        "yocto-queue": "^1.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-locate/node_modules/yocto-queue": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.1.1.tgz",
-      "integrity": "sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true
+    },
+    "node_modules/package-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/package-up/-/package-up-5.0.0.tgz",
+      "integrity": "sha512-MQEgDUvXCa3sGvqHg3pzHO8e9gqTCMPVrWUko3vPQGntwegmFo52mZb2abIVTjFnUcW0BcPz0D93jV5Cas1DWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up-simple": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/packet-reader": {
       "version": "1.0.0",
@@ -10805,22 +10752,6 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/pkg-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-5.0.0.tgz",
-      "integrity": "sha512-NbJJ+WABU/AKhl3ooFwMc3+dQi0StEYrFj1g+D7BlaE07pL98rBLP21XMfNyGlckzHOt4onU5OuLE1GNkQqVsA==",
-      "deprecated": "Renamed to package-up",
-      "dev": true,
-      "dependencies": {
-        "find-up": "^6.2.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/playwright": {
@@ -15691,7 +15622,7 @@
         "@types/strip-ansi": "^3.0.0",
         "@vitest/browser": "^2.1.5",
         "fast-check": "^3.18.0",
-        "pkg-up": "^5.0.0",
+        "package-up": "^5.0.0",
         "type-fest": "^4.30.0",
         "typescript": "^5.6.3",
         "vitest": "^2.1.5"
@@ -21447,23 +21378,11 @@
       "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
       "requires": {}
     },
-    "find-up": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
-      "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
-      "dev": true,
-      "requires": {
-        "locate-path": "^7.1.0",
-        "path-exists": "^5.0.0"
-      },
-      "dependencies": {
-        "path-exists": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
-          "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
-          "dev": true
-        }
-      }
+    "find-up-simple": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.0.tgz",
+      "integrity": "sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==",
+      "dev": true
     },
     "flat-cache": {
       "version": "3.0.4",
@@ -22320,15 +22239,6 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
-    },
-    "locate-path": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
-      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
-      "dev": true,
-      "requires": {
-        "p-locate": "^6.0.0"
-      }
     },
     "lodash": {
       "version": "4.17.21",
@@ -23516,37 +23426,20 @@
         "yocto-queue": "^0.1.0"
       }
     },
-    "p-locate": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
-      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
-      "dev": true,
-      "requires": {
-        "p-limit": "^4.0.0"
-      },
-      "dependencies": {
-        "p-limit": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-          "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
-          "dev": true,
-          "requires": {
-            "yocto-queue": "^1.0.0"
-          }
-        },
-        "yocto-queue": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.1.1.tgz",
-          "integrity": "sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==",
-          "dev": true
-        }
-      }
-    },
     "package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true
+    },
+    "package-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/package-up/-/package-up-5.0.0.tgz",
+      "integrity": "sha512-MQEgDUvXCa3sGvqHg3pzHO8e9gqTCMPVrWUko3vPQGntwegmFo52mZb2abIVTjFnUcW0BcPz0D93jV5Cas1DWA==",
+      "dev": true,
+      "requires": {
+        "find-up-simple": "^1.0.0"
+      }
     },
     "packet-reader": {
       "version": "1.0.0",
@@ -23792,15 +23685,6 @@
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
       "integrity": "sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==",
       "dev": true
-    },
-    "pkg-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-5.0.0.tgz",
-      "integrity": "sha512-NbJJ+WABU/AKhl3ooFwMc3+dQi0StEYrFj1g+D7BlaE07pL98rBLP21XMfNyGlckzHOt4onU5OuLE1GNkQqVsA==",
-      "dev": true,
-      "requires": {
-        "find-up": "^6.2.0"
-      }
     },
     "playwright": {
       "version": "1.43.1",
@@ -24957,7 +24841,7 @@
         "lodash.kebabcase": "^4.1.1",
         "lodash.merge": "^4.6.2",
         "lodash.snakecase": "^4.1.1",
-        "pkg-up": "^5.0.0",
+        "package-up": "^5.0.0",
         "semver": "^7.5.4",
         "strip-ansi": "^7.1.0",
         "type-fest": "^4.30.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -37,7 +37,7 @@
     "@types/strip-ansi": "^3.0.0",
     "@vitest/browser": "^2.1.5",
     "fast-check": "^3.18.0",
-    "pkg-up": "^5.0.0",
+    "package-up": "^5.0.0",
     "type-fest": "^4.30.0",
     "typescript": "^5.6.3",
     "vitest": "^2.1.5"

--- a/packages/shared/src/tool/get-external-from-package-json.js
+++ b/packages/shared/src/tool/get-external-from-package-json.js
@@ -3,7 +3,7 @@
 /* eslint-env es2022 */
 
 import {readFile} from 'node:fs/promises';
-import {pkgUp} from 'pkg-up';
+import {packageUp} from 'package-up';
 import {resolve as resolvePath} from 'node:path';
 import {fileURLToPath} from 'node:url';
 import {isInternalPackage} from './internal-packages.js';
@@ -15,7 +15,7 @@ import {isInternalPackage} from './internal-packages.js';
  */
 export async function getExternalFromPackageJSON(basePath, includePeerDeps) {
   const cwd = basePath.startsWith('file:') ? fileURLToPath(basePath) : basePath;
-  const path = await pkgUp({cwd});
+  const path = await packageUp({cwd});
 
   if (!path) {
     throw new Error('Could not find package.json');

--- a/packages/shared/src/tool/get-external-from-package-json.js
+++ b/packages/shared/src/tool/get-external-from-package-json.js
@@ -4,6 +4,8 @@
 
 import {readFile} from 'node:fs/promises';
 import {pkgUp} from 'pkg-up';
+import {resolve as resolvePath} from 'node:path';
+import {fileURLToPath} from 'node:url';
 import {isInternalPackage} from './internal-packages.js';
 
 /**
@@ -12,7 +14,9 @@ import {isInternalPackage} from './internal-packages.js';
  * @returns {Promise<string[]>}
  */
 export async function getExternalFromPackageJSON(basePath, includePeerDeps) {
-  const path = await pkgUp({cwd: basePath});
+  const cwd = basePath.startsWith('file:') ? fileURLToPath(basePath) : basePath;
+  const path = await pkgUp({cwd});
+
   if (!path) {
     throw new Error('Could not find package.json');
   }
@@ -46,7 +50,7 @@ function getRecursiveExternals(name, includePeerDeps) {
       includePeerDeps,
     );
   }
-  const depPath = new URL(`../../../${name}/package.json`, import.meta.url)
-    .pathname;
+  const depPath = resolvePath(`../${name}`);
+
   return getExternalFromPackageJSON(depPath, includePeerDeps);
 }

--- a/packages/zero/tool/build.js
+++ b/packages/zero/tool/build.js
@@ -4,6 +4,7 @@ import * as esbuild from 'esbuild';
 import assert from 'node:assert/strict';
 import {readFile} from 'node:fs/promises';
 import {builtinModules} from 'node:module';
+import {resolve as resolvePath} from 'node:path';
 import {makeDefine, sharedOptions} from '../../shared/src/build.js';
 import {getExternalFromPackageJSON} from '../../shared/src/tool/get-external-from-package-json.js';
 
@@ -12,7 +13,8 @@ import {getExternalFromPackageJSON} from '../../shared/src/tool/get-external-fro
  * @returns {string}
  */
 function basePath(path) {
-  return new URL('../' + path, import.meta.url).pathname;
+  const base = resolvePath(path);
+  return base;
 }
 
 /**
@@ -29,8 +31,9 @@ async function getExternal(includePeerDeps) {
    * @param {string} internalPackageName
    */
   async function addExternalDepsFor(internalPackageName) {
+    const internalPackageDir = basePath('../' + internalPackageName);
     for (const dep of await getExternalFromPackageJSON(
-      basePath('../' + internalPackageName),
+      internalPackageDir,
       includePeerDeps,
     )) {
       externalSet.add(dep);


### PR DESCRIPTION
- Replace use of `URL(...).pathname` with `node:path.resolve` to address path name differences on Windows
- update `pkg-up` dependency to `package-up` (package got renamed)
![image](https://github.com/user-attachments/assets/bc4bec27-fa0a-41c9-b8b0-b54e65c3c4f1)
