### PR TITLE
A couple more Windows compat measures

### DIFF
--- a/packages/zero-schema/src/build-schema.ts
+++ b/packages/zero-schema/src/build-schema.ts
@@ -18,10 +18,12 @@ async function main() {
 
   const dirname = path.dirname(fileURLToPath(import.meta.url));
   const absoluteConfigPath = path.resolve(config.schema.path);
-  const relativePath = path.join(
+  let relativePath = path.join(
     path.relative(dirname, path.dirname(absoluteConfigPath)),
     path.basename(absoluteConfigPath),
   );
+
+  relativePath = relativePath.replace(/\\/g, "/");
 
   try {
     const module = await tsImport(relativePath, import.meta.url);


### PR DESCRIPTION
- handle windows path separators in relative path to schema file
- fix import path format for child worker forks

Addresses the comments in #3448 