### PR TITLE
feat(zero-cache): auto-reset replica if upstream is reset

### DIFF
--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -46,15 +46,15 @@ export default async function runWorker(
   let changeStreamer: ChangeStreamerService | undefined;
 
   for (const first of [true, false]) {
-    // Note: This performs initial sync of the replica if necessary.
-    const {changeSource, replicationConfig} = await initializeChangeSource(
-      lc,
-      config.upstream.db,
-      config.shard,
-      config.replicaFile,
-    );
-
     try {
+      // Note: This performs initial sync of the replica if necessary.
+      const {changeSource, replicationConfig} = await initializeChangeSource(
+        lc,
+        config.upstream.db,
+        config.shard,
+        config.replicaFile,
+      );
+
       changeStreamer = await initializeStreamer(
         lc,
         changeDB,
@@ -65,7 +65,9 @@ export default async function runWorker(
       break;
     } catch (e) {
       if (first && e instanceof AutoResetSignal) {
-        lc.warn?.(`auto-reset: resetting replica ${config.replicaFile}`);
+        lc.warn?.(`resetting replica ${config.replicaFile}`, e);
+        // TODO: Make deleteLiteDB work with litestream. It will probably have to be
+        //       a semantic wipe instead of a file delete.
         deleteLiteDB(config.replicaFile);
         continue; // execute again with a fresh initial-sync
       }

--- a/packages/zero-cache/src/services/change-streamer/pg/schema/init.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/schema/init.ts
@@ -1,5 +1,4 @@
 import type {LogContext} from '@rocicorp/logger';
-import {AbortError} from '../../../../../../shared/src/abort-error.js';
 import {
   getVersionHistory,
   runSchemaMigrations,
@@ -7,6 +6,7 @@ import {
   type Migration,
 } from '../../../../db/migration.js';
 import type {PostgresDB, PostgresTransaction} from '../../../../types/pg.js';
+import {AutoResetSignal} from '../../schema/tables.js';
 import type {ShardConfig} from '../shard-config.js';
 import {getPublicationInfo, type PublishedSchema} from './published.js';
 import {
@@ -39,9 +39,7 @@ export async function updateShardSchema(
   const {id} = shardConfig;
   const {schemaVersion} = await getVersionHistory(db, unescapedSchema(id));
   if (schemaVersion === 0) {
-    throw new AbortError(
-      `upstream shard ${id} is not initialized. Delete the replica and resync.`,
-    );
+    throw new AutoResetSignal(`upstream shard ${id} is not initialized`);
   }
   return runShardMigrations(lc, db, shardConfig);
 }

--- a/packages/zero-cache/src/services/change-streamer/schema/tables.ts
+++ b/packages/zero-cache/src/services/change-streamer/schema/tables.ts
@@ -102,7 +102,7 @@ export async function ensureReplicationConfig(
 
     if (resetRequired) {
       if (autoReset) {
-        throw new AutoResetSignal();
+        throw new AutoResetSignal('reset required by replication stream');
       }
       lc.warn?.('reset required but auto-reset is disabled');
     }


### PR DESCRIPTION
Automatically wipe the replica and rerun initial sync if the upstream DB has been reset (e.g. replication slot is missing, or shard schema is gone). 

This handles a common pattern of developers clearing their upstream DB but not clearing their replica file. The system now recovers from this automatically by clearing the replica file and retrying, obviating the need for developers to know about the replica file (e.g. it may be in a docker volume).