### PR TITLE
feat(zql): fix `IS` to take null, fix `Row` to take `Query`

### DIFF
--- a/apps/zbugs/src/pages/issue/comment.tsx
+++ b/apps/zbugs/src/pages/issue/comment.tsx
@@ -1,7 +1,6 @@
 import type {Row} from '@rocicorp/zero';
 import classNames from 'classnames';
 import {memo, useState} from 'react';
-import type {Schema} from '../../../schema.js';
 import {makePermalink} from '../../comment-permalink.js';
 import {Button} from '../../components/button.js';
 import {CanEdit} from '../../components/can-edit.js';
@@ -10,21 +9,17 @@ import {EmojiPanel} from '../../components/emoji-panel.js';
 import {Link} from '../../components/link.js';
 import {Markdown} from '../../components/markdown.js';
 import {RelativeTime} from '../../components/relative-time.js';
-import {type Emoji} from '../../emoji-utils.js';
 import {useHash} from '../../hooks/use-hash.js';
 import {useLogin} from '../../hooks/use-login.js';
 import {useZero} from '../../hooks/use-zero.js';
 import {CommentComposer} from './comment-composer.js';
 import style from './comment.module.css';
+import type {commentQuery} from './issue-page.js';
 
 type Props = {
   id: string;
   issueID: string;
-  comment: Row<Schema['tables']['comment']> & {
-    readonly creator: Row<Schema['tables']['user']> | undefined;
-  } & {
-    readonly emoji: readonly Emoji[];
-  };
+  comment: Row<ReturnType<typeof commentQuery>>;
   /**
    * Height of the comment. Used to keep the layout stable when comments are
    * being "loaded".

--- a/apps/zbugs/src/pages/issue/issue-page.tsx
+++ b/apps/zbugs/src/pages/issue/issue-page.tsx
@@ -61,6 +61,17 @@ const emojiToastShowDuration = 3_000;
 // to load.
 export const INITIAL_COMMENT_LIMIT = 101;
 
+export function commentQuery(z: Zero<Schema>, displayed: IssueRow | undefined) {
+  return z.query.comment
+    .where('issueID', 'IS', displayed?.id ?? null)
+    .related('creator', creator => creator.one())
+    .related('emoji', emoji =>
+      emoji.related('creator', creator => creator.one()),
+    )
+    .orderBy('created', 'asc')
+    .orderBy('id', 'asc');
+}
+
 export function IssuePage({onReady}: {onReady: () => void}) {
   const z = useZero();
   const params = useParams();
@@ -232,14 +243,7 @@ export function IssuePage({onReady}: {onReady: () => void}) {
   const [displayAllComments, setDisplayAllComments] = useState(false);
 
   const [allComments, allCommentsResult] = useQuery(
-    z.query.comment
-      .where('issueID', displayed?.id ?? '')
-      .related('creator', creator => creator.one())
-      .related('emoji', emoji =>
-        emoji.related('creator', creator => creator.one()),
-      )
-      .orderBy('created', 'asc')
-      .orderBy('id', 'asc'),
+    commentQuery(z, displayed),
     displayAllComments && displayed !== undefined,
   );
 

--- a/packages/zql/src/query/query.test.ts
+++ b/packages/zql/src/query/query.test.ts
@@ -521,6 +521,9 @@ describe('types', () => {
     query.where('s', '=', null);
     // @ts-expect-error - cannot compare with undefined
     query.where('s', '=', undefined);
+
+    // IS can compare to null
+    query.where('s', 'IS', null);
   });
 
   test('start', () => {

--- a/packages/zql/src/query/query.ts
+++ b/packages/zql/src/query/query.ts
@@ -50,6 +50,8 @@ export type GetFieldTypeNoUndefined<
       SchemaValueToTSType<TSchema['columns'][TColumn]>,
       null | undefined
     >[]
+  : TOperator extends 'IS' | 'IS NOT'
+  ? Exclude<SchemaValueToTSType<TSchema['columns'][TColumn]>, undefined> | null
   : Exclude<SchemaValueToTSType<TSchema['columns'][TColumn]>, undefined>;
 
 export type Row<T extends TableSchema | Query<TableSchema>> =
@@ -57,7 +59,9 @@ export type Row<T extends TableSchema | Query<TableSchema>> =
     ? {
         [K in keyof T['columns']]: SchemaValueToTSType<T['columns'][K]>;
       }
-    : QueryRowType<T & Query<TableSchema>>;
+    : T extends Query<TableSchema>
+    ? QueryRowType<T>
+    : never;
 
 export type Rows<T extends TableSchema | Query<TableSchema>> =
   T extends TableSchema ? Row<T>[] : QueryReturnType<T & Query<TableSchema>>;

--- a/packages/zqlite/src/query.test.ts
+++ b/packages/zqlite/src/query.test.ts
@@ -1,4 +1,4 @@
-import {beforeEach, expect, test} from 'vitest';
+import {beforeEach, expect, expectTypeOf, test} from 'vitest';
 import {createSilentLogContext} from '../../shared/src/logging-test-utils.js';
 import {must} from '../../shared/src/must.js';
 import {normalizeTableSchema} from '../../zero-schema/src/normalize-table-schema.js';
@@ -8,6 +8,7 @@ import {newQuery, type QueryDelegate} from '../../zql/src/query/query-impl.js';
 import {schemas} from '../../zql/src/query/test/testSchemas.js';
 import {Database} from './db.js';
 import {TableSource, toSQLiteTypeName} from './table-source.js';
+import type {Row} from '../../zql/src/query/query.js';
 
 let queryDelegate: QueryDelegate;
 beforeEach(() => {
@@ -123,6 +124,24 @@ beforeEach(() => {
       name: 'bug',
     },
   });
+});
+
+test('row type', () => {
+  const query = newQuery(queryDelegate, schemas.issue)
+    .whereExists('labels', q => q.where('name', '=', 'bug'))
+    .related('labels');
+  type RT = Row<typeof query>;
+  expectTypeOf<RT>().toEqualTypeOf<{
+    readonly id: string;
+    readonly title: string;
+    readonly description: string;
+    readonly closed: boolean;
+    readonly ownerId: string | null;
+    readonly labels: readonly {
+      readonly id: string;
+      readonly name: string;
+    }[];
+  }>();
 });
 
 test('basic query', () => {


### PR DESCRIPTION
This came up from a user here: https://discord.com/channels/830183651022471199/1322274277453594705/1322276660627898470

The question was how they could derive the types to use for `props` in a component from a query.
