### PR TITLE
fix(zero-cache): fix replication of TRUNCATE statements

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -14,7 +14,7 @@ import {
 } from '../replicator/test-utils.js';
 import {CREATE_STORAGE_TABLE, DatabaseStorage} from './database-storage.js';
 import {PipelineDriver} from './pipeline-driver.js';
-import {ResetPipelineSignal, Snapshotter} from './snapshotter.js';
+import {ResetPipelinesSignal, Snapshotter} from './snapshotter.js';
 
 describe('view-syncer/pipeline-driver', () => {
   let dbFile: DbFile;
@@ -499,7 +499,7 @@ describe('view-syncer/pipeline-driver', () => {
     replicator.processTransaction('134', messages.truncate('comments'));
 
     expect(() => [...pipelines.advance().changes]).toThrowError(
-      ResetPipelineSignal,
+      ResetPipelinesSignal,
     );
   });
 

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -14,7 +14,7 @@ import {
 } from '../replicator/test-utils.js';
 import {CREATE_STORAGE_TABLE, DatabaseStorage} from './database-storage.js';
 import {PipelineDriver} from './pipeline-driver.js';
-import {Snapshotter} from './snapshotter.js';
+import {ResetPipelineSignal, Snapshotter} from './snapshotter.js';
 
 describe('view-syncer/pipeline-driver', () => {
   let dbFile: DbFile;
@@ -490,6 +490,17 @@ describe('view-syncer/pipeline-driver', () => {
         },
       ]
     `);
+  });
+
+  test('truncate', () => {
+    pipelines.init();
+    [...pipelines.addQuery('hash1', ISSUES_AND_COMMENTS)];
+
+    replicator.processTransaction('134', messages.truncate('comments'));
+
+    expect(() => [...pipelines.advance().changes]).toThrowError(
+      ResetPipelineSignal,
+    );
   });
 
   test('update', () => {

--- a/packages/zero-cache/src/services/view-syncer/snapshotter.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/snapshotter.test.ts
@@ -11,12 +11,12 @@ import {
   ReplicationMessages,
   type FakeReplicator,
 } from '../replicator/test-utils.js';
+import {setSpecs} from './pipeline-driver.js';
 import {
   InvalidDiffError,
-  SchemaChangeError,
+  ResetPipelineSignal,
   Snapshotter,
 } from './snapshotter.js';
-import {setSpecs} from './pipeline-driver.js';
 
 describe('view-syncer/snapshotter', () => {
   let lc: LogContext;
@@ -418,22 +418,7 @@ describe('view-syncer/snapshotter', () => {
     s2.destroy();
   });
 
-  test('noop-truncate diff', () => {
-    const {version} = s.current();
-
-    expect(version).toBe('00');
-
-    replicator.processTransaction('07', messages.truncate('comments'));
-
-    const diff = s.advance(tableSpecs);
-    expect(diff.prev.version).toBe('00');
-    expect(diff.curr.version).toBe('01');
-    expect(diff.changes).toBe(1);
-
-    expect([...diff]).toEqual([]);
-  });
-
-  test('truncate diff', () => {
+  test('truncate', () => {
     const {version} = s.current();
 
     expect(version).toBe('00');
@@ -445,157 +430,7 @@ describe('view-syncer/snapshotter', () => {
     expect(diff.curr.version).toBe('01');
     expect(diff.changes).toBe(1);
 
-    expect([...diff]).toMatchInlineSnapshot(`
-      [
-        {
-          "nextValue": null,
-          "prevValue": {
-            "_0_version": "00",
-            "handle": "alice",
-            "id": 10n,
-          },
-          "table": "users",
-        },
-        {
-          "nextValue": null,
-          "prevValue": {
-            "_0_version": "00",
-            "handle": "bob",
-            "id": 20n,
-          },
-          "table": "users",
-        },
-      ]
-    `);
-  });
-
-  test('consecutive truncates', () => {
-    const {version} = s.current();
-
-    expect(version).toBe('00');
-
-    replicator.processTransaction(
-      '08',
-      messages.truncate('issues'),
-      messages.truncate('users'),
-    );
-
-    const diff = s.advance(tableSpecs);
-    expect(diff.prev.version).toBe('00');
-    expect(diff.curr.version).toBe('01');
-    expect(diff.changes).toBe(2);
-
-    expect([...diff]).toMatchInlineSnapshot(`
-      [
-        {
-          "nextValue": null,
-          "prevValue": {
-            "_0_version": "00",
-            "desc": "foo",
-            "id": 1n,
-            "owner": 10n,
-          },
-          "table": "issues",
-        },
-        {
-          "nextValue": null,
-          "prevValue": {
-            "_0_version": "00",
-            "desc": "bar",
-            "id": 2n,
-            "owner": 10n,
-          },
-          "table": "issues",
-        },
-        {
-          "nextValue": null,
-          "prevValue": {
-            "_0_version": "00",
-            "desc": "baz",
-            "id": 3n,
-            "owner": 20n,
-          },
-          "table": "issues",
-        },
-        {
-          "nextValue": null,
-          "prevValue": {
-            "_0_version": "00",
-            "handle": "alice",
-            "id": 10n,
-          },
-          "table": "users",
-        },
-        {
-          "nextValue": null,
-          "prevValue": {
-            "_0_version": "00",
-            "handle": "bob",
-            "id": 20n,
-          },
-          "table": "users",
-        },
-      ]
-    `);
-  });
-
-  test('truncate followed by inserts into same table', () => {
-    const {version} = s.current();
-
-    expect(version).toBe('00');
-
-    replicator.processTransaction(
-      '09',
-      messages.truncate('users'),
-      messages.insert('users', {id: 20, handle: 'robert'}),
-      messages.insert('users', {id: 30, handle: 'candice'}),
-    );
-
-    const diff = s.advance(tableSpecs);
-    expect(diff.prev.version).toBe('00');
-    expect(diff.curr.version).toBe('01');
-    expect(diff.changes).toBe(3);
-
-    expect([...diff]).toMatchInlineSnapshot(`
-      [
-        {
-          "nextValue": null,
-          "prevValue": {
-            "_0_version": "00",
-            "handle": "alice",
-            "id": 10n,
-          },
-          "table": "users",
-        },
-        {
-          "nextValue": null,
-          "prevValue": {
-            "_0_version": "00",
-            "handle": "bob",
-            "id": 20n,
-          },
-          "table": "users",
-        },
-        {
-          "nextValue": {
-            "_0_version": "01",
-            "handle": "robert",
-            "id": 20,
-          },
-          "prevValue": null,
-          "table": "users",
-        },
-        {
-          "nextValue": {
-            "_0_version": "01",
-            "handle": "candice",
-            "id": 30,
-          },
-          "prevValue": null,
-          "table": "users",
-        },
-      ]
-    `);
+    expect(() => [...diff]).toThrowError(ResetPipelineSignal);
   });
 
   test('changelog iterator cleaned up on aborted iteration', () => {
@@ -631,44 +466,6 @@ describe('view-syncer/snapshotter', () => {
     expect(diff.curr.db.statementCache.size).toBe(currStmts + 1);
   });
 
-  test('truncate iterator cleaned up on aborted iteration', () => {
-    const s = new Snapshotter(lc, dbFile.path).init();
-    const {version} = s.current();
-
-    expect(version).toBe('00');
-
-    replicator.processTransaction('07', messages.truncate('users'));
-
-    const diff = s.advance(tableSpecs);
-    let currStmts = 0;
-    let prevStmts = 0;
-
-    const abortError = new Error('aborted iteration');
-    try {
-      for (const change of diff) {
-        expect(change).toEqual({
-          nextValue: null,
-          prevValue: {
-            ['_0_version']: '00',
-            handle: 'alice',
-            id: 10n,
-          },
-          table: 'users',
-        });
-        currStmts = diff.curr.db.statementCache.size;
-        prevStmts = diff.prev.db.statementCache.size;
-        throw abortError;
-      }
-    } catch (e) {
-      expect(e).toBe(abortError);
-    }
-
-    // The Statements for both the ChangeLog (curr) and truncated-row (prev)
-    // iterations should have been returned to the cache.
-    expect(diff.curr.db.statementCache.size).toBe(currStmts + 1);
-    expect(diff.prev.db.statementCache.size).toBe(prevStmts + 1);
-  });
-
   test('schema change diff iteration throws SchemaChangeError', () => {
     const {version} = s.current();
 
@@ -684,6 +481,6 @@ describe('view-syncer/snapshotter', () => {
     expect(diff.curr.version).toBe('01');
     expect(diff.changes).toBe(1);
 
-    expect(() => [...diff]).toThrow(SchemaChangeError);
+    expect(() => [...diff]).toThrow(ResetPipelineSignal);
   });
 });

--- a/packages/zero-cache/src/services/view-syncer/snapshotter.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/snapshotter.test.ts
@@ -14,7 +14,7 @@ import {
 import {setSpecs} from './pipeline-driver.js';
 import {
   InvalidDiffError,
-  ResetPipelineSignal,
+  ResetPipelinesSignal,
   Snapshotter,
 } from './snapshotter.js';
 
@@ -430,7 +430,7 @@ describe('view-syncer/snapshotter', () => {
     expect(diff.curr.version).toBe('01');
     expect(diff.changes).toBe(1);
 
-    expect(() => [...diff]).toThrowError(ResetPipelineSignal);
+    expect(() => [...diff]).toThrowError(ResetPipelinesSignal);
   });
 
   test('changelog iterator cleaned up on aborted iteration', () => {
@@ -481,6 +481,6 @@ describe('view-syncer/snapshotter', () => {
     expect(diff.curr.version).toBe('01');
     expect(diff.changes).toBe(1);
 
-    expect(() => [...diff]).toThrow(ResetPipelineSignal);
+    expect(() => [...diff]).toThrow(ResetPipelinesSignal);
   });
 });

--- a/packages/zero-cache/src/services/view-syncer/snapshotter.ts
+++ b/packages/zero-cache/src/services/view-syncer/snapshotter.ts
@@ -222,8 +222,8 @@ export interface SnapshotDiff extends Iterable<Change> {
  * change or truncate is encountered, which result in aborting the
  * advancement and resetting / rehydrating the pipelines.
  */
-export class ResetPipelineSignal extends Error {
-  readonly name = 'ResetPipelineSignal';
+export class ResetPipelinesSignal extends Error {
+  readonly name = 'ResetPipelinesSignal';
 
   constructor(msg: string) {
     super(msg);
@@ -375,13 +375,13 @@ class Diff implements SnapshotDiff {
             const {table, rowKey, op, stateVersion} = v.parse(value, schema);
             if (op === RESET_OP) {
               // The current map of `TableSpec`s may not have the correct or complete information.
-              throw new ResetPipelineSignal(
+              throw new ResetPipelinesSignal(
                 `schema for table ${table} has changed`,
               );
             }
             if (op === TRUNCATE_OP) {
               // Truncates are also processed by rehydrating pipelines at current.
-              throw new ResetPipelineSignal(
+              throw new ResetPipelinesSignal(
                 `table ${table} has been truncated`,
               );
             }

--- a/packages/zero-cache/src/services/view-syncer/snapshotter.ts
+++ b/packages/zero-cache/src/services/view-syncer/snapshotter.ts
@@ -6,7 +6,7 @@ import {Database} from '../../../../zqlite/src/db.js';
 import {fromSQLiteTypes} from '../../../../zqlite/src/table-source.js';
 import type {LiteAndZqlSpec, LiteTableSpec} from '../../db/specs.js';
 import {StatementRunner} from '../../db/statements.js';
-import {jsonObjectSchema, type JSONValue} from '../../types/bigint-json.js';
+import {type JSONValue} from '../../types/bigint-json.js';
 import {
   normalizedKeyOrder,
   type RowKey,
@@ -219,13 +219,14 @@ export interface SnapshotDiff extends Iterable<Change> {
 
 /**
  * Thrown during an iteration of a {@link SnapshotDiff} when a schema
- * change is encountered.
+ * change or truncate is encountered, which result in aborting the
+ * advancement and resetting / rehydrating the pipelines.
  */
-export class SchemaChangeError extends Error {
-  readonly name = 'SchemaChangeError';
+export class ResetPipelineSignal extends Error {
+  readonly name = 'ResetPipelineSignal';
 
-  constructor(table: string) {
-    super(`schema for table ${table} has changed`);
+  constructor(msg: string) {
+    super(msg);
   }
 }
 
@@ -351,16 +352,13 @@ class Diff implements SnapshotDiff {
 
   [Symbol.iterator](): Iterator<Change> {
     const {changes, cleanup: done} = this.curr.changesSince(this.prev.version);
-    const truncates = new TruncateTracker(this.prev);
 
     const cleanup = () => {
       try {
         // Allow open iterators to clean up their state.
-        truncates.iterReturn(undefined);
         changes.return?.(undefined);
       } finally {
         done();
-        truncates.done();
       }
     };
 
@@ -368,12 +366,6 @@ class Diff implements SnapshotDiff {
       next: () => {
         try {
           for (;;) {
-            // Exhaust the TRUNCATE iteration before continuing the Change sequence.
-            const truncatedRow = truncates.next();
-            if (truncatedRow) {
-              return truncatedRow;
-            }
-
             const {value, done} = changes.next();
             if (done) {
               cleanup();
@@ -383,17 +375,20 @@ class Diff implements SnapshotDiff {
             const {table, rowKey, op, stateVersion} = v.parse(value, schema);
             if (op === RESET_OP) {
               // The current map of `TableSpec`s may not have the correct or complete information.
-              throw new SchemaChangeError(table);
+              throw new ResetPipelineSignal(
+                `schema for table ${table} has changed`,
+              );
+            }
+            if (op === TRUNCATE_OP) {
+              // Truncates are also processed by rehydrating pipelines at current.
+              throw new ResetPipelineSignal(
+                `table ${table} has been truncated`,
+              );
             }
             const {tableSpec, zqlSpec} = must(this.tables.get(table));
-            if (op === TRUNCATE_OP) {
-              truncates.startTruncate(tableSpec);
-              continue; // loop around to pull rows from the TruncateTracker.
-            }
 
             assert(rowKey !== null);
-            let prevValue =
-              truncates.getRowIfNotTruncated(tableSpec, rowKey) ?? null;
+            let prevValue = this.prev.getRow(tableSpec, rowKey) ?? null;
             let nextValue =
               op === SET_OP ? this.curr.getRow(tableSpec, rowKey) : null;
 
@@ -456,80 +451,6 @@ class Diff implements SnapshotDiff {
         'Diff is no longer valid. curr db has advanced.',
       );
     }
-  }
-}
-
-/**
- * `TRUNCATE` changes are handled by:
- * 1. Iterating over all of the rows in the `prev` Snapshot and returning
- *    corresponding `DELETE` row operations for them (i.e. `nextValue: null`).
- * 2. Tracking the fact that a table has been truncated (i.e. all row-deletes
- *    have been returned) so that subsequent lookups of prevValues (e.g. for
- *    inserts after the truncate) correctly return `null`.
- */
-class TruncateTracker {
-  readonly #prev: Snapshot;
-  readonly #truncated = new Set<string>();
-
-  #truncating: {
-    table: string;
-    rows: Iterator<unknown>;
-    cleanup: () => void;
-  } | null = null;
-
-  constructor(prev: Snapshot) {
-    this.#prev = prev;
-  }
-
-  startTruncate(table: LiteTableSpec) {
-    assert(this.#truncating === null);
-    const {rows, cleanup} = this.#prev.getRows(table);
-    this.#truncating = {table: table.name, rows, cleanup};
-  }
-
-  next(): IteratorResult<Change> | null {
-    if (this.#truncating === null) {
-      return null;
-    }
-    const {table} = this.#truncating;
-    const {value, done} = this.#truncating.rows.next();
-    if (done) {
-      this.#truncating.cleanup();
-      this.#truncating = null;
-      this.#truncated.add(table);
-      return null;
-    }
-    const prevValue = v.parse(value, jsonObjectSchema);
-
-    // Sanity check detects if the diff is being accessed after the Snapshots have advanced.
-    if ((prevValue[ROW_VERSION] ?? '~') > this.#prev.version) {
-      throw new InvalidDiffError(
-        `Diff is no longer valid. prev db has advanced past ${
-          this.#prev.version
-        }.`,
-      );
-    }
-
-    return {value: {table, prevValue, nextValue: null} satisfies Change};
-  }
-
-  getRowIfNotTruncated(table: LiteTableSpec, rowKey: RowKey) {
-    // If the row has been returned in a TRUNCATE iteration, its prevValue is henceforth null.
-    return this.#truncated.has(table.name)
-      ? null
-      : this.#prev.getRow(table, rowKey);
-  }
-
-  iterReturn(value: unknown) {
-    this.#truncating?.rows.return?.(value);
-  }
-
-  iterThrow(err: unknown) {
-    this.#truncating?.rows.throw?.(err);
-  }
-
-  done() {
-    this.#truncating?.cleanup();
   }
 }
 

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -1268,7 +1268,7 @@ describe('view-syncer/service', () => {
     });
   });
 
-  test('process advancement', async () => {
+  test('process successful advancement', async () => {
     const client = connect(SYNC_CONTEXT, [
       {op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY},
       {op: 'put', hash: 'query-hash2', ast: ISSUES_QUERY2},
@@ -1507,6 +1507,169 @@ describe('view-syncer/service', () => {
           "refCounts": null,
           "rowKey": {
             "id": "2",
+          },
+          "rowVersion": "00",
+          "schema": "",
+          "table": "issues",
+        },
+      ]
+    `);
+
+    replicator.processTransaction('124', messages.truncate('issues'));
+
+    stateChanges.push({state: 'version-ready'});
+
+    // One canceled poke.
+    expect(await nextPoke(client)).toMatchInlineSnapshot(`
+      [
+        [
+          "pokeStart",
+          {
+            "baseCookie": "01",
+            "cookie": "123",
+            "pokeID": "123",
+            "schemaVersions": {
+              "maxSupportedVersion": 3,
+              "minSupportedVersion": 2,
+            },
+          },
+        ],
+        [
+          "pokeEnd",
+          {
+            "cancel": true,
+            "pokeID": "123",
+          },
+        ],
+      ]
+    `);
+
+    // Then a poke that deletes issues rows in the CVR.
+    expect(await nextPoke(client)).toMatchInlineSnapshot(`
+      [
+        [
+          "pokeStart",
+          {
+            "baseCookie": "01",
+            "cookie": "123",
+            "pokeID": "123",
+            "schemaVersions": {
+              "maxSupportedVersion": 3,
+              "minSupportedVersion": 2,
+            },
+          },
+        ],
+        [
+          "pokePart",
+          {
+            "pokeID": "123",
+            "rowsPatch": [
+              {
+                "id": {
+                  "id": "1",
+                },
+                "op": "del",
+                "tableName": "issues",
+              },
+              {
+                "id": {
+                  "id": "3",
+                },
+                "op": "del",
+                "tableName": "issues",
+              },
+              {
+                "id": {
+                  "id": "4",
+                },
+                "op": "del",
+                "tableName": "issues",
+              },
+              {
+                "id": {
+                  "id": "5",
+                },
+                "op": "del",
+                "tableName": "issues",
+              },
+            ],
+          },
+        ],
+        [
+          "pokeEnd",
+          {
+            "pokeID": "123",
+          },
+        ],
+      ]
+    `);
+
+    expect(await cvrDB`SELECT * from cvr.rows`).toMatchInlineSnapshot(`
+      Result [
+        {
+          "clientGroupID": "9876",
+          "patchVersion": "00:02",
+          "refCounts": {
+            "lmids": 1,
+          },
+          "rowKey": {
+            "clientGroupID": "9876",
+            "clientID": "foo",
+          },
+          "rowVersion": "00",
+          "schema": "",
+          "table": "zero_ABC.clients",
+        },
+        {
+          "clientGroupID": "9876",
+          "patchVersion": "01",
+          "refCounts": null,
+          "rowKey": {
+            "id": "2",
+          },
+          "rowVersion": "00",
+          "schema": "",
+          "table": "issues",
+        },
+        {
+          "clientGroupID": "9876",
+          "patchVersion": "123",
+          "refCounts": null,
+          "rowKey": {
+            "id": "1",
+          },
+          "rowVersion": "01",
+          "schema": "",
+          "table": "issues",
+        },
+        {
+          "clientGroupID": "9876",
+          "patchVersion": "123",
+          "refCounts": null,
+          "rowKey": {
+            "id": "3",
+          },
+          "rowVersion": "00",
+          "schema": "",
+          "table": "issues",
+        },
+        {
+          "clientGroupID": "9876",
+          "patchVersion": "123",
+          "refCounts": null,
+          "rowKey": {
+            "id": "4",
+          },
+          "rowVersion": "00",
+          "schema": "",
+          "table": "issues",
+        },
+        {
+          "clientGroupID": "9876",
+          "patchVersion": "123",
+          "refCounts": null,
+          "rowKey": {
+            "id": "5",
           },
           "rowVersion": "00",
           "schema": "",

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -58,7 +58,7 @@ import {
   type NullableCVRVersion,
   type RowID,
 } from './schema/types.js';
-import {ResetPipelineSignal} from './snapshotter.js';
+import {ResetPipelinesSignal} from './snapshotter.js';
 
 export type TokenData = {
   readonly raw: string;
@@ -957,7 +957,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   #advancePipelines(
     lc: LogContext,
     cvr: CVRSnapshot,
-  ): Promise<'success' | ResetPipelineSignal> {
+  ): Promise<'success' | ResetPipelinesSignal> {
     return startAsyncSpan(tracer, 'vs.#advancePipelines', async () => {
       assert(this.#pipelines.initialized());
       const start = Date.now();
@@ -1000,7 +1000,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           transformationHashToHash,
         );
       } catch (e) {
-        if (e instanceof ResetPipelineSignal) {
+        if (e instanceof ResetPipelinesSignal) {
           pokers.forEach(poker => poker.cancel());
           return e;
         }

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -58,7 +58,7 @@ import {
   type NullableCVRVersion,
   type RowID,
 } from './schema/types.js';
-import {SchemaChangeError} from './snapshotter.js';
+import {ResetPipelineSignal} from './snapshotter.js';
 
 export type TokenData = {
   readonly raw: string;
@@ -210,7 +210,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
             if (result === 'success') {
               return;
             }
-            lc.info?.(`resetting for schema change: ${result.message}`);
+            lc.info?.(`resetting pipelines: ${result.message}`);
             this.#pipelines.reset();
           }
 
@@ -957,7 +957,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   #advancePipelines(
     lc: LogContext,
     cvr: CVRSnapshot,
-  ): Promise<'success' | SchemaChangeError> {
+  ): Promise<'success' | ResetPipelineSignal> {
     return startAsyncSpan(tracer, 'vs.#advancePipelines', async () => {
       assert(this.#pipelines.initialized());
       const start = Date.now();
@@ -1000,7 +1000,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           transformationHashToHash,
         );
       } catch (e) {
-        if (e instanceof SchemaChangeError) {
+        if (e instanceof ResetPipelineSignal) {
           pokers.forEach(poker => poker.cancel());
           return e;
         }


### PR DESCRIPTION
Truncates were initially processed by converting the TRUNCATE event into a sequence of `del` patches that were to be pushed through IVM pipelines. This never worked, as the generation of this sequence opened an iterator over the `prev` database handle, and that database needs to be concurrently advanced by the IVM push.

Instead, truncates are now processed in the same manner as that of schema changes; the advancement is aborted and pipelines are rehydrated from the `curr` database handle.