### PR TITLE
fix(zero-cache): fix acknowledgement of pg keepalives

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/pg/change-source.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/change-source.test.ts
@@ -1,0 +1,32 @@
+import type {LogicalReplicationService} from 'pg-logical-replication';
+import {expect, test, vi} from 'vitest';
+import {Acker} from './change-source.js';
+
+test('acker', () => {
+  const service = {acknowledge: vi.fn()};
+
+  let acks = 0;
+
+  const expectAck = (expected: string) => {
+    expect(service.acknowledge).toBeCalledTimes(++acks);
+    expect(service.acknowledge.mock.calls[acks - 1][0]).toBe(expected);
+  };
+
+  const acker = new Acker(
+    service as unknown as LogicalReplicationService,
+    '0a',
+  );
+
+  acker.onHeartbeat('0/1', true);
+  expectAck('0/A');
+
+  acker.onData('0/B');
+  acker.onHeartbeat('0/C', true);
+  expectAck('0/A'); // Outstanding data is unacked.
+
+  acker.onAck('0b');
+  expectAck('0/B'); // Now the data is acked.
+
+  acker.onHeartbeat('0/D', true);
+  expectAck('0/D'); // If the data is acked, heartbeats move acks forward.
+});


### PR DESCRIPTION
Postgres `keepalive` messages contain the LSN of the end of the WAL:

https://www.postgresql.org/docs/current/protocol-replication.html#PROTOCOL-REPLICATION-PRIMARY-KEEPALIVE-MESSAGE

The replication streaming logic previously only responded with the LSN of its latest processed replication message. In particular, it is important not to ACK any received data that was not successfully persisted by the `change-streamer`.

However, if all replicated messages have been processed and acknowledged, the end-of-WAL LSN of subsequent keepalive messages must be acknowledged in order to allow postgres to clean up subsequent WAL entries (i.e. that are unrelated to the logical replication stream). Failure to do so results in potentially unbounded WAL growth until a new replication message arrives on the stream.