### PR TITLE
feat(zero-cache): log reason when shutting down because of another zero-cache

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/change-source.ts
@@ -879,7 +879,7 @@ function translateError(e: unknown): Error {
     return new Error(String(e));
   }
   if (e instanceof DatabaseError && e.code === PG_ADMIN_SHUTDOWN) {
-    return new AbortError(e.message, {cause: e});
+    return new ShutdownSignal(e);
   }
   return e;
 }
@@ -903,5 +903,15 @@ export class UnsupportedSchemaChangeError extends Error {
     super(
       'Replication halted. Schema changes cannot be reliably replicated without event trigger support. Resync the replica to recover.',
     );
+  }
+}
+
+class ShutdownSignal extends AbortError {
+  readonly name = 'ShutdownSignal';
+
+  constructor(cause: unknown) {
+    super('shutdown signal received (e.g. another zero-cache starting up)', {
+      cause,
+    });
   }
 }


### PR DESCRIPTION
Developers often mistakenly run multiple `zero-cache` instances pointed to the same upstream db. This results in flapping, where the instances continually kill each other in order to take over the replication slot.

Log the reason for shutdown so that it is clearer what's going on.

<img width="648" alt="Screenshot 2025-01-03 at 10 48 25" src="https://github.com/user-attachments/assets/9cbd848b-5f44-44a5-a647-11836641af87" />
