### PR TITLE
chore(zero-cache): betterer shutdown message

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/change-source.ts
@@ -910,8 +910,11 @@ class ShutdownSignal extends AbortError {
   readonly name = 'ShutdownSignal';
 
   constructor(cause: unknown) {
-    super('shutdown signal received (e.g. another zero-cache starting up)', {
-      cause,
-    });
+    super(
+      'shutdown signal received (e.g. another zero-cache taking over the replication stream)',
+      {
+        cause,
+      },
+    );
   }
 }


### PR DESCRIPTION
"shutdown signal received (e.g. another zero-cache taking over the replication stream)"