### PR TITLE
fix(zero-cache): fix tenant dispatch errors

### DIFF
--- a/packages/zero-cache/src/server/multi/tenant-dispatcher.ts
+++ b/packages/zero-cache/src/server/multi/tenant-dispatcher.ts
@@ -41,6 +41,6 @@ export class TenantDispatcher extends HttpService {
 
       return {payload: t.id, receiver: t.worker};
     }
-    throw new Error(`no matching tenant for: ${u}`);
+    throw new Error(`no matching tenant for: ${host}${pathname}`);
   }
 }

--- a/packages/zero-cache/src/services/dispatcher/websocket-handoff.test.ts
+++ b/packages/zero-cache/src/services/dispatcher/websocket-handoff.test.ts
@@ -114,7 +114,7 @@ describe('dispatcher/websocket-handoff', () => {
     installWebSocketHandoff(
       createSilentLogContext(),
       () => {
-        throw new Error('really long stri' + 'i'.repeat(150) + 'ng');
+        throw new Error('こんにちは' + 'あ'.repeat(150));
       },
       server,
     );
@@ -129,11 +129,13 @@ describe('dispatcher/websocket-handoff', () => {
     expect(error).toMatchInlineSnapshot(`
       {
         "code": 1002,
-        "reason": "Error: really long striiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii...",
+        "reason": "Error: こんにちはああああああああああああああああああああああああああああああああ...",
       }
     `);
     // close messages must be less than or equal to 123 bytes:
     // https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close#reason
-    expect(error.reason.length).toBeLessThanOrEqual(123);
+    expect(new TextEncoder().encode(error.reason).length).toBeLessThanOrEqual(
+      123,
+    );
   });
 });

--- a/packages/zero-cache/src/services/dispatcher/websocket-handoff.test.ts
+++ b/packages/zero-cache/src/services/dispatcher/websocket-handoff.test.ts
@@ -114,22 +114,26 @@ describe('dispatcher/websocket-handoff', () => {
     installWebSocketHandoff(
       createSilentLogContext(),
       () => {
-        throw new Error('fooz barz');
+        throw new Error('really long stri' + 'i'.repeat(150) + 'ng');
       },
       server,
     );
 
     const ws = new WebSocket(`ws://localhost:${port}/`);
-    const {promise, resolve} = resolver<unknown>();
+    const {promise, resolve} = resolver<{code: number; reason: string}>();
     ws.on('close', (code, reason) =>
       resolve({code, reason: reason.toString('utf-8')}),
     );
 
-    expect(await promise).toMatchInlineSnapshot(`
+    const error = await promise;
+    expect(error).toMatchInlineSnapshot(`
       {
         "code": 1002,
-        "reason": "Error: fooz barz",
+        "reason": "Error: really long striiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii...",
       }
     `);
+    // close messages must be less than or equal to 123 bytes:
+    // https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close#reason
+    expect(error.reason.length).toBeLessThanOrEqual(123);
   });
 });

--- a/packages/zero-cache/src/services/dispatcher/websocket-handoff.ts
+++ b/packages/zero-cache/src/services/dispatcher/websocket-handoff.ts
@@ -82,8 +82,8 @@ function truncate(val: string, maxBytes = 123) {
     return val;
   }
   val = val.substring(0, maxBytes - 3);
-  while (encoder.encode(val).length > maxBytes - 3) {
-    val.substring(0, val.length - 1);
+  while (encoder.encode(val + '...').length > maxBytes) {
+    val = val.substring(0, val.length - 1);
   }
   return val + '...';
 }

--- a/packages/zero-cache/src/services/dispatcher/websocket-handoff.ts
+++ b/packages/zero-cache/src/services/dispatcher/websocket-handoff.ts
@@ -51,12 +51,13 @@ export function installWebSocketHandoff<P>(
       // https://nodejs.org/api/http.html#event-upgrade
       receiver.send(data, socket as Socket);
     } catch (error) {
-      lc.warn?.(`dispatch error: ${String(error)}`, error);
+      const errMsg = String(error);
+      lc.warn?.(`dispatch error: ${errMsg}`, error);
       // Returning an error on the HTTP handshake looks like a hanging connection
       // (at least from Chrome) and doesn't report any meaningful error in the browser.
       // Instead, finish the upgrade to a websocket and then close it with an error.
       wss.handleUpgrade(message as IncomingMessage, socket, head, ws =>
-        ws.close(1002 /* "protocol error" */, String(error)),
+        ws.close(1002 /* "protocol error" */, truncate(errMsg)),
       );
     }
   };
@@ -71,6 +72,12 @@ export function installWebSocketHandoff<P>(
       handle(message, socket as Socket, Buffer.from(head));
     });
   }
+}
+
+// close messages must be less than or equal to 123 bytes:
+// https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close#reason
+function truncate(val: string, maxLen = 123) {
+  return val.length <= maxLen ? val : val.substring(0, maxLen - 3) + '...';
 }
 
 export function installWebSocketReceiver<P>(

--- a/packages/zero-cache/src/services/dispatcher/websocket-handoff.ts
+++ b/packages/zero-cache/src/services/dispatcher/websocket-handoff.ts
@@ -76,8 +76,16 @@ export function installWebSocketHandoff<P>(
 
 // close messages must be less than or equal to 123 bytes:
 // https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close#reason
-function truncate(val: string, maxLen = 123) {
-  return val.length <= maxLen ? val : val.substring(0, maxLen - 3) + '...';
+function truncate(val: string, maxBytes = 123) {
+  const encoder = new TextEncoder();
+  if (encoder.encode(val).length <= maxBytes) {
+    return val;
+  }
+  val = val.substring(0, maxBytes - 3);
+  while (encoder.encode(val).length > maxBytes - 3) {
+    val.substring(0, val.length - 1);
+  }
+  return val + '...';
 }
 
 export function installWebSocketReceiver<P>(


### PR DESCRIPTION
An error during tenant dispatch was causing the server to crash:

https://discord.com/channels/830183651022471199/1324367282952077352/1324368361471348749

This was due to an Error thrown from the `ws` library when the close message exceeds the websocket spec of 123 bytes.

```
/Users/ocean/roci/mono/node_modules/ws/lib/sender.js:195
        throw new RangeError('The message must not be greater than 123 bytes');
        ^
```

Make the error message smaller by only including the host and path, and also truncate long error messages at the library level.