### PR TITLE
feat(schema): added strong optional typing

### DIFF
--- a/packages/zero-schema/src/column.ts
+++ b/packages/zero-schema/src/column.ts
@@ -1,43 +1,142 @@
-export function string<T extends string = string>(optional: boolean = false) {
+export function string<T extends string = string>(): {
+  type: 'string';
+  optional: false;
+  customType: T;
+};
+export function string<T extends string = string>(
+  optional: false,
+): {
+  type: 'string';
+  optional: false;
+  customType: T;
+};
+export function string<T extends string = string>(
+  optional: true,
+): {
+  type: 'string';
+  optional: true;
+  customType: T;
+};
+export function string<T extends string = string>(optional?: boolean) {
   return {
     type: 'string',
-    optional,
+    optional: optional ?? false,
     customType: null as unknown as T,
   } as const;
 }
 
-export function number<T extends number = number>(optional: boolean = false) {
+export function number<T extends number = number>(): {
+  type: 'number';
+  optional: false;
+  customType: T;
+};
+export function number<T extends number = number>(
+  optional: false,
+): {
+  type: 'number';
+  optional: false;
+  customType: T;
+};
+export function number<T extends number = number>(
+  optional: true,
+): {
+  type: 'number';
+  optional: true;
+  customType: T;
+};
+export function number<T extends number = number>(optional?: boolean) {
   return {
     type: 'number',
-    optional,
+    optional: optional ?? false,
     customType: null as unknown as T,
   } as const;
 }
 
+export function boolean<T extends boolean = boolean>(): {
+  type: 'boolean';
+  optional: false;
+  customType: T;
+};
 export function boolean<T extends boolean = boolean>(
-  optional: boolean = false,
-) {
+  optional: false,
+): {
+  type: 'boolean';
+  optional: false;
+  customType: T;
+};
+export function boolean<T extends boolean = boolean>(
+  optional: true,
+): {
+  type: 'boolean';
+  optional: true;
+  customType: T;
+};
+export function boolean<T extends boolean = boolean>(optional?: boolean) {
   return {
     type: 'boolean',
-    optional,
+    optional: optional ?? false,
     customType: null as unknown as T,
   } as const;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function json<T = any>(optional: boolean = false) {
+export function json<T = any>(): {
+  type: 'json';
+  optional: false;
+  customType: T;
+};
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function json<T = any>(
+  optional: false,
+): {
+  type: 'json';
+  optional: false;
+  customType: T;
+};
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function json<T = any>(
+  optional: true,
+): {
+  type: 'json';
+  optional: true;
+  customType: T;
+};
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function json<T = any>(optional?: boolean) {
   return {
     type: 'json',
-    optional,
+    optional: optional ?? false,
     customType: null as unknown as T,
   } as const;
 }
 
-export function enumeration<T extends string>(optional: boolean = false) {
+export function enumeration<T extends string>(): {
+  type: 'string';
+  kind: 'enum';
+  optional: false;
+  customType: T;
+};
+export function enumeration<T extends string>(
+  optional: false,
+): {
+  type: 'string';
+  kind: 'enum';
+  optional: false;
+  customType: T;
+};
+export function enumeration<T extends string>(
+  optional: true,
+): {
+  type: 'string';
+  kind: 'enum';
+  optional: true;
+  customType: T;
+};
+export function enumeration<T extends string>(optional?: boolean) {
   return {
     type: 'string',
     kind: 'enum',
     customType: null as unknown as T,
-    optional,
+    optional: optional ?? false,
   } as const;
 }


### PR DESCRIPTION
This adds strong typing to the optional property passed into e.g. `column.string(false)`, instead of `optional: boolean`

```
const _demo = string(false)
//     ^ { type: 'string', optional: false, customType: string }

const _demo2 = string()
//     ^ { type: 'string', optional: false, customType: string }

const _demo3 = string(true)
//     ^ { type: 'string', optional: true, customType: string }
```