### PR TITLE
fix(zero-react): useSyncExternalStore shim

### DIFF
--- a/apps/zbugs/package.json
+++ b/apps/zbugs/package.json
@@ -46,6 +46,7 @@
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.0",
     "use-debounce": "^10.0.4",
+    "use-sync-external-store": "^1.4.0",
     "usehooks-ts": "^3.1.0",
     "wouter": "^3.3.5"
   },
@@ -59,6 +60,7 @@
     "@types/react": "18.2.13",
     "@types/react-dom": "18.2.6",
     "@types/react-window": "^1.8.8",
+    "@types/use-sync-external-store": "^0.0.6",
     "@typescript-eslint/eslint-plugin": "^5.16.0",
     "@vitejs/plugin-react": "^4.2.1",
     "eslint": "^8.15.0",

--- a/apps/zbugs/src/components/login-provider.tsx
+++ b/apps/zbugs/src/components/login-provider.tsx
@@ -1,4 +1,5 @@
-import {useCallback, useSyncExternalStore} from 'react';
+import {useCallback} from 'react';
+import {useSyncExternalStore} from 'use-sync-external-store/shim';
 import {loginContext} from '../hooks/use-login.js';
 import {clearJwt} from '../jwt.js';
 import {authRef} from '../zero-setup.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.0",
         "use-debounce": "^10.0.4",
+        "use-sync-external-store": "^1.4.0",
         "usehooks-ts": "^3.1.0",
         "wouter": "^3.3.5"
       },
@@ -65,6 +66,7 @@
         "@types/react": "18.2.13",
         "@types/react-dom": "18.2.6",
         "@types/react-window": "^1.8.8",
+        "@types/use-sync-external-store": "^0.0.6",
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@vitejs/plugin-react": "^4.2.1",
         "eslint": "^8.15.0",
@@ -4026,6 +4028,13 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.7.4",
@@ -14737,11 +14746,12 @@
       }
     },
     "node_modules/use-sync-external-store": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
-      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
+      "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
+      "license": "MIT",
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/usehooks-ts": {
@@ -15979,8 +15989,12 @@
     },
     "packages/zero-react": {
       "version": "0.0.0",
+      "dependencies": {
+        "use-sync-external-store": "^1.4.0"
+      },
       "devDependencies": {
         "@types/react": "18.2.13",
+        "@types/use-sync-external-store": "^0.0.6",
         "react": ">=16.0 <19.0",
         "zero-client": "0.0.0"
       },
@@ -19032,6 +19046,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
+    },
+    "@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "6.7.4",
@@ -26452,9 +26472,9 @@
       }
     },
     "use-sync-external-store": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
-      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
+      "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
       "requires": {}
     },
     "usehooks-ts": {
@@ -26841,6 +26861,7 @@
         "@types/react": "18.2.13",
         "@types/react-dom": "18.2.6",
         "@types/react-window": "^1.8.8",
+        "@types/use-sync-external-store": "^0.0.6",
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@vitejs/plugin-react": "^4.2.1",
         "classnames": "^2.5.1",
@@ -26872,6 +26893,7 @@
         "typescript": "^5.6.3",
         "universal-user-agent": "^7.0.2",
         "use-debounce": "^10.0.4",
+        "use-sync-external-store": "^1.4.0",
         "usehooks-ts": "^3.1.0",
         "vite": "^5.4.9",
         "vite-plugin-svgr": "^4.2.0",
@@ -27148,7 +27170,9 @@
       "version": "file:packages/zero-react",
       "requires": {
         "@types/react": "18.2.13",
+        "@types/use-sync-external-store": "^0.0.6",
         "react": ">=16.0 <19.0",
+        "use-sync-external-store": "^1.4.0",
         "zero-client": "0.0.0"
       }
     },

--- a/packages/zero-react/package.json
+++ b/packages/zero-react/package.json
@@ -13,7 +13,11 @@
   },
   "devDependencies": {
     "@types/react": "18.2.13",
+    "@types/use-sync-external-store": "^0.0.6",
     "react": ">=16.0 <19.0",
     "zero-client": "0.0.0"
+  },
+  "dependencies": {
+    "use-sync-external-store": "^1.4.0"
   }
 }

--- a/packages/zero-react/package.json
+++ b/packages/zero-react/package.json
@@ -9,15 +9,14 @@
     "check-types:watch": "tsc --watch"
   },
   "peerDependencies": {
-    "react": ">=16.0 <19.0"
+    "react": ">=16.0 <19.0",
+    "use-sync-external-store": "^1.4.0"
   },
   "devDependencies": {
     "@types/react": "18.2.13",
     "@types/use-sync-external-store": "^0.0.6",
     "react": ">=16.0 <19.0",
+    "use-sync-external-store": "^1.4.0",
     "zero-client": "0.0.0"
-  },
-  "dependencies": {
-    "use-sync-external-store": "^1.4.0"
   }
 }

--- a/packages/zero-react/src/use-query.tsx
+++ b/packages/zero-react/src/use-query.tsx
@@ -1,4 +1,4 @@
-import {useSyncExternalStore} from 'react';
+import {useSyncExternalStore} from 'use-sync-external-store/shim';
 import {deepClone} from '../../shared/src/deep-clone.js';
 import type {Immutable} from '../../shared/src/immutable.js';
 import type {
@@ -8,10 +8,10 @@ import type {
   Smash,
   TypedView,
 } from '../../zero-client/src/mod.js';
-import type {AdvancedQuery} from '../../zql/src/query/query-internal.js';
-import {useZero} from './use-zero.js';
 import type {TableSchema} from '../../zero-schema/src/table-schema.js';
+import type {AdvancedQuery} from '../../zql/src/query/query-internal.js';
 import type {ResultType} from '../../zql/src/query/typed-view.js';
+import {useZero} from './use-zero.js';
 
 export type QueryResultDetails = Readonly<{
   type: ResultType;


### PR DESCRIPTION
https://bugs.rocicorp.dev/issue/3388

This is to allow zero-react to work prior to the release of react 18.