### PR TITLE
chore(zero,zero-cache): Replace strip-ansi with native impl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15615,8 +15615,7 @@
         "lodash.kebabcase": "^4.1.1",
         "lodash.merge": "^4.6.2",
         "lodash.snakecase": "^4.1.1",
-        "semver": "^7.5.4",
-        "strip-ansi": "^7.1.0"
+        "semver": "^7.5.4"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20231010.0",
@@ -15633,18 +15632,6 @@
         "type-fest": "^4.30.0",
         "typescript": "^5.6.3",
         "vitest": "^2.1.5"
-      }
-    },
-    "packages/shared/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "packages/shared/node_modules/chalk": {
@@ -15694,21 +15681,6 @@
       },
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "packages/shared/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "packages/shared/node_modules/type-fest": {
@@ -15767,7 +15739,6 @@
         "postgres": "^3.4.4",
         "postgres-array": "^3.0.2",
         "semver": "^7.5.4",
-        "strip-ansi": "^7.1.0",
         "tsx": "^4.19.1",
         "url-pattern": "^1.0.3",
         "ws": "^8.18.0"
@@ -15846,7 +15817,6 @@
         "@types/ws": "^8.5.12",
         "concurrently": "^8.2.1",
         "shared": "0.0.0",
-        "strip-ansi": "^7.1.0",
         "typescript": "^5.6.3",
         "vitest": "^2.1.5"
       }
@@ -15859,19 +15829,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "packages/zero-cache/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "packages/zero-cache/node_modules/nanoid": {
@@ -15898,22 +15855,6 @@
       "integrity": "sha512-6faShkdFugNQCLwucjPcY5ARoW1SlbnrZjmGl0IrrqewpvxvhSLHimCVzqeuULCbG0fQv7Dtk1yDbG3xv7Veog==",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "packages/zero-cache/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "packages/zero-client": {
@@ -15989,17 +15930,16 @@
     },
     "packages/zero-react": {
       "version": "0.0.0",
-      "dependencies": {
-        "use-sync-external-store": "^1.4.0"
-      },
       "devDependencies": {
         "@types/react": "18.2.13",
         "@types/use-sync-external-store": "^0.0.6",
         "react": ">=16.0 <19.0",
+        "use-sync-external-store": "^1.4.0",
         "zero-client": "0.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.0 <19.0"
+        "react": ">=16.0 <19.0",
+        "use-sync-external-store": "^1.4.0"
       }
     },
     "packages/zero-schema": {
@@ -16016,18 +15956,6 @@
       },
       "peerDependencies": {
         "solid-js": "^1.0.0"
-      }
-    },
-    "packages/zero/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "packages/zero/node_modules/chalk": {
@@ -16146,21 +16074,6 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "packages/zero/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "packages/zql": {
@@ -18126,7 +18039,6 @@
         "postgres-array": "^3.0.2",
         "replicache": "15.2.1",
         "semver": "^7.5.4",
-        "strip-ansi": "^7.1.0",
         "tsc-alias": "^1.8.10",
         "tsx": "^4.19.1",
         "typescript": "^5.6.3",
@@ -18135,11 +18047,6 @@
         "ws": "^8.18.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-          "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="
-        },
         "chalk": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
@@ -18206,14 +18113,6 @@
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
           "integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA=="
-        },
-        "strip-ansi": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-          "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-          "requires": {
-            "ansi-regex": "^6.0.1"
-          }
         }
       }
     },
@@ -24858,17 +24757,11 @@
         "lodash.snakecase": "^4.1.1",
         "package-up": "^5.0.0",
         "semver": "^7.5.4",
-        "strip-ansi": "^7.1.0",
         "type-fest": "^4.30.0",
         "typescript": "^5.6.3",
         "vitest": "^2.1.5"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-          "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="
-        },
         "chalk": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
@@ -24889,14 +24782,6 @@
           "dev": true,
           "requires": {
             "pure-rand": "^6.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-          "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-          "requires": {
-            "ansi-regex": "^6.0.1"
           }
         },
         "type-fest": {
@@ -27057,7 +26942,6 @@
         "postgres": "^3.4.4",
         "postgres-array": "^3.0.2",
         "shared": "0.0.0",
-        "strip-ansi": "^7.1.0",
         "tsx": "^4.19.1",
         "typescript": "^5.6.3",
         "url-pattern": "^1.0.3",
@@ -27077,12 +26961,6 @@
             "@types/node": "*"
           }
         },
-        "ansi-regex": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-          "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-          "dev": true
-        },
         "nanoid": {
           "version": "5.0.8",
           "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.8.tgz",
@@ -27092,15 +26970,6 @@
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.2.tgz",
           "integrity": "sha512-6faShkdFugNQCLwucjPcY5ARoW1SlbnrZjmGl0IrrqewpvxvhSLHimCVzqeuULCbG0fQv7Dtk1yDbG3xv7Veog=="
-        },
-        "strip-ansi": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-          "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^6.0.1"
-          }
         }
       }
     },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -23,8 +23,7 @@
     "lodash.kebabcase": "^4.1.1",
     "lodash.merge": "^4.6.2",
     "lodash.snakecase": "^4.1.1",
-    "semver": "^7.5.4",
-    "strip-ansi": "^7.1.0"
+    "semver": "^7.5.4"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20231010.0",

--- a/packages/shared/src/options.test.ts
+++ b/packages/shared/src/options.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import {SilentLogger} from '@rocicorp/logger';
-import stripAnsi from 'strip-ansi';
+import {stripVTControlCharacters} from 'node:util';
 import type {PartialDeep} from 'type-fest';
 import {expect, test, vi} from 'vitest';
 import {
@@ -835,7 +835,8 @@ test('--help', () => {
     parseOptions(options, ['--help'], 'Z_', {}, logger, exit),
   ).toThrow(ExitAfterUsage);
   expect(logger.info).toHaveBeenCalled();
-  expect(stripAnsi(logger.info.mock.calls[0][0])).toMatchInlineSnapshot(`
+  expect(stripVTControlCharacters(logger.info.mock.calls[0][0]))
+    .toMatchInlineSnapshot(`
     "
      --port, -p number                  default: 4848                                                        
        Z_PORT env                                                                                            
@@ -873,7 +874,8 @@ test('-h', () => {
     parseOptions(options, ['-h'], 'ZERO_', {}, logger, exit),
   ).toThrow(ExitAfterUsage);
   expect(logger.info).toHaveBeenCalled();
-  expect(stripAnsi(logger.info.mock.calls[0][0])).toMatchInlineSnapshot(`
+  expect(stripVTControlCharacters(logger.info.mock.calls[0][0]))
+    .toMatchInlineSnapshot(`
     "
      --port, -p number                  default: 4848                                                        
        ZERO_PORT env                                                                                         
@@ -921,7 +923,8 @@ test('unknown arguments', () => {
     ]
   `);
   expect(logger.info).toHaveBeenCalled();
-  expect(stripAnsi(logger.info.mock.calls[0][0])).toMatchInlineSnapshot(`
+  expect(stripVTControlCharacters(logger.info.mock.calls[0][0]))
+    .toMatchInlineSnapshot(`
     "
      --port, -p number                  default: 4848                                                        
        PORT env                                                                                              

--- a/packages/shared/src/options.test.ts
+++ b/packages/shared/src/options.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import {SilentLogger} from '@rocicorp/logger';
-import {stripVTControlCharacters} from 'node:util';
+import {stripVTControlCharacters as stripAnsi} from 'node:util';
 import type {PartialDeep} from 'type-fest';
 import {expect, test, vi} from 'vitest';
 import {
@@ -835,8 +835,7 @@ test('--help', () => {
     parseOptions(options, ['--help'], 'Z_', {}, logger, exit),
   ).toThrow(ExitAfterUsage);
   expect(logger.info).toHaveBeenCalled();
-  expect(stripVTControlCharacters(logger.info.mock.calls[0][0]))
-    .toMatchInlineSnapshot(`
+  expect(stripAnsi(logger.info.mock.calls[0][0])).toMatchInlineSnapshot(`
     "
      --port, -p number                  default: 4848                                                        
        Z_PORT env                                                                                            
@@ -874,8 +873,7 @@ test('-h', () => {
     parseOptions(options, ['-h'], 'ZERO_', {}, logger, exit),
   ).toThrow(ExitAfterUsage);
   expect(logger.info).toHaveBeenCalled();
-  expect(stripVTControlCharacters(logger.info.mock.calls[0][0]))
-    .toMatchInlineSnapshot(`
+  expect(stripAnsi(logger.info.mock.calls[0][0])).toMatchInlineSnapshot(`
     "
      --port, -p number                  default: 4848                                                        
        ZERO_PORT env                                                                                         
@@ -923,8 +921,7 @@ test('unknown arguments', () => {
     ]
   `);
   expect(logger.info).toHaveBeenCalled();
-  expect(stripVTControlCharacters(logger.info.mock.calls[0][0]))
-    .toMatchInlineSnapshot(`
+  expect(stripAnsi(logger.info.mock.calls[0][0])).toMatchInlineSnapshot(`
     "
      --port, -p number                  default: 4848                                                        
        PORT env                                                                                              

--- a/packages/shared/src/options.ts
+++ b/packages/shared/src/options.ts
@@ -6,7 +6,7 @@ import commandLineUsage from 'command-line-usage';
 import kebabcase from 'lodash.kebabcase';
 import merge from 'lodash.merge';
 import snakeCase from 'lodash.snakecase';
-import {stripVTControlCharacters} from 'node:util';
+import {stripVTControlCharacters as stripAnsi} from 'node:util';
 import {assert} from './asserts.js';
 import {must} from './must.js';
 import * as v from './valita.js';
@@ -516,13 +516,11 @@ function showUsage(
       hide.push(name);
     }
     const text = template(`${name} ${typeLabel ?? ''}`);
-    const lines = stripVTControlCharacters(text).split('\n');
+    const lines = stripAnsi(text).split('\n');
     for (const l of lines) {
       leftWidth = Math.max(leftWidth, l.length + 2);
     }
-    const desc = stripVTControlCharacters(template(description ?? '')).split(
-      '\n',
-    );
+    const desc = stripAnsi(template(description ?? '')).split('\n');
     for (const l of desc) {
       rightWidth = Math.max(rightWidth, l.length + 2);
     }

--- a/packages/shared/src/options.ts
+++ b/packages/shared/src/options.ts
@@ -6,7 +6,7 @@ import commandLineUsage from 'command-line-usage';
 import kebabcase from 'lodash.kebabcase';
 import merge from 'lodash.merge';
 import snakeCase from 'lodash.snakecase';
-import stripAnsi from 'strip-ansi';
+import {stripVTControlCharacters} from 'node:util';
 import {assert} from './asserts.js';
 import {must} from './must.js';
 import * as v from './valita.js';
@@ -516,11 +516,13 @@ function showUsage(
       hide.push(name);
     }
     const text = template(`${name} ${typeLabel ?? ''}`);
-    const lines = stripAnsi(text).split('\n');
+    const lines = stripVTControlCharacters(text).split('\n');
     for (const l of lines) {
       leftWidth = Math.max(leftWidth, l.length + 2);
     }
-    const desc = stripAnsi(template(description ?? '')).split('\n');
+    const desc = stripVTControlCharacters(template(description ?? '')).split(
+      '\n',
+    );
     for (const l of desc) {
       rightWidth = Math.max(rightWidth, l.length + 2);
     }

--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -66,7 +66,6 @@
     "@types/ws": "^8.5.12",
     "concurrently": "^8.2.1",
     "shared": "0.0.0",
-    "strip-ansi": "^7.1.0",
     "typescript": "^5.6.3",
     "vitest": "^2.1.5"
   },

--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -1,4 +1,4 @@
-import {stripVTControlCharacters} from 'node:util';
+import {stripVTControlCharacters as stripAnsi} from 'node:util';
 import {expect, test, vi} from 'vitest';
 import {parseOptions} from '../../../shared/src/options.js';
 import {zeroOptions} from './zero-config.js';
@@ -15,8 +15,7 @@ test('zero-cache --help', () => {
     parseOptions(zeroOptions, ['--help'], 'ZERO_', {}, logger, exit),
   ).toThrow(ExitAfterUsage);
   expect(logger.info).toHaveBeenCalled();
-  expect(stripVTControlCharacters(logger.info.mock.calls[0][0]))
-    .toMatchInlineSnapshot(`
+  expect(stripAnsi(logger.info.mock.calls[0][0])).toMatchInlineSnapshot(`
     "
      --upstream-db string                          required                                                                                          
        ZERO_UPSTREAM_DB env                                                                                                                          

--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -1,4 +1,4 @@
-import stripAnsi from 'strip-ansi';
+import {stripVTControlCharacters} from 'node:util';
 import {expect, test, vi} from 'vitest';
 import {parseOptions} from '../../../shared/src/options.js';
 import {zeroOptions} from './zero-config.js';
@@ -15,7 +15,8 @@ test('zero-cache --help', () => {
     parseOptions(zeroOptions, ['--help'], 'ZERO_', {}, logger, exit),
   ).toThrow(ExitAfterUsage);
   expect(logger.info).toHaveBeenCalled();
-  expect(stripAnsi(logger.info.mock.calls[0][0])).toMatchInlineSnapshot(`
+  expect(stripVTControlCharacters(logger.info.mock.calls[0][0]))
+    .toMatchInlineSnapshot(`
     "
      --upstream-db string                          required                                                                                          
        ZERO_UPSTREAM_DB env                                                                                                                          

--- a/packages/zero-cache/src/server/multi/config.test.ts
+++ b/packages/zero-cache/src/server/multi/config.test.ts
@@ -1,4 +1,4 @@
-import stripAnsi from 'strip-ansi';
+import {stripVTControlCharacters} from 'node:util';
 import {expect, test, vi} from 'vitest';
 import {parseOptions} from '../../../../shared/src/options.js';
 import {getMultiZeroConfig, multiConfigSchema} from './config.js';
@@ -159,7 +159,8 @@ test('zero-cache --help', () => {
     parseOptions(multiConfigSchema, ['--help'], 'ZERO_', {}, logger, exit),
   ).toThrow(ExitAfterUsage);
   expect(logger.info).toHaveBeenCalled();
-  expect(stripAnsi(logger.info.mock.calls[0][0])).toMatchInlineSnapshot(`
+  expect(stripVTControlCharacters(logger.info.mock.calls[0][0]))
+    .toMatchInlineSnapshot(`
     "
      --upstream-db string                          required                                                                                          
        ZERO_UPSTREAM_DB env                                                                                                                          

--- a/packages/zero-cache/src/server/multi/config.test.ts
+++ b/packages/zero-cache/src/server/multi/config.test.ts
@@ -1,4 +1,4 @@
-import {stripVTControlCharacters} from 'node:util';
+import {stripVTControlCharacters as stripAnsi} from 'node:util';
 import {expect, test, vi} from 'vitest';
 import {parseOptions} from '../../../../shared/src/options.js';
 import {getMultiZeroConfig, multiConfigSchema} from './config.js';
@@ -159,8 +159,7 @@ test('zero-cache --help', () => {
     parseOptions(multiConfigSchema, ['--help'], 'ZERO_', {}, logger, exit),
   ).toThrow(ExitAfterUsage);
   expect(logger.info).toHaveBeenCalled();
-  expect(stripVTControlCharacters(logger.info.mock.calls[0][0]))
-    .toMatchInlineSnapshot(`
+  expect(stripAnsi(logger.info.mock.calls[0][0])).toMatchInlineSnapshot(`
     "
      --upstream-db string                          required                                                                                          
        ZERO_UPSTREAM_DB env                                                                                                                          

--- a/packages/zero/package.json
+++ b/packages/zero/package.json
@@ -53,7 +53,6 @@
     "postgres": "^3.4.4",
     "postgres-array": "^3.0.2",
     "semver": "^7.5.4",
-    "strip-ansi": "^7.1.0",
     "tsx": "^4.19.1",
     "url-pattern": "^1.0.3",
     "ws": "^8.18.0"


### PR DESCRIPTION
This PR replaces usages of `strip-ansi` with the [native node implementation](https://nodejs.org/api/util.html#utilstripvtcontrolcharactersstr) as part of the [e18e](https://e18e.dev) initiative.

`stripVTControlCharacter` is available from node v16.11.0 which should be fine as `@rocicorp/zero` requires v20