### PR TITLE
fix(zero-solid)!: useQuery return tuple of Accessor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3225,6 +3225,28 @@
       "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
     },
+    "node_modules/@solidjs/testing-library": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@solidjs/testing-library/-/testing-library-0.8.10.tgz",
+      "integrity": "sha512-qdeuIerwyq7oQTIrrKvV0aL9aFeuwTd86VYD3afdq5HYEwoox1OBTJy4y8A3TFZr8oAR0nujYgCzY/8wgHGfeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@testing-library/dom": "^10.4.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "@solidjs/router": ">=0.9.0",
+        "solid-js": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@solidjs/router": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-8.0.0.tgz",
@@ -15989,17 +16011,16 @@
     },
     "packages/zero-react": {
       "version": "0.0.0",
-      "dependencies": {
-        "use-sync-external-store": "^1.4.0"
-      },
       "devDependencies": {
         "@types/react": "18.2.13",
         "@types/use-sync-external-store": "^0.0.6",
         "react": ">=16.0 <19.0",
+        "use-sync-external-store": "^1.4.0",
         "zero-client": "0.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.0 <19.0"
+        "react": ">=16.0 <19.0",
+        "use-sync-external-store": "^1.4.0"
       }
     },
     "packages/zero-schema": {
@@ -16011,6 +16032,7 @@
     "packages/zero-solid": {
       "version": "0.0.0",
       "devDependencies": {
+        "@solidjs/testing-library": "^0.8.10",
         "solid-js": "^1.0.0",
         "zero-advanced": "0.0.0"
       },
@@ -18415,6 +18437,15 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
       "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
+    },
+    "@solidjs/testing-library": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@solidjs/testing-library/-/testing-library-0.8.10.tgz",
+      "integrity": "sha512-qdeuIerwyq7oQTIrrKvV0aL9aFeuwTd86VYD3afdq5HYEwoox1OBTJy4y8A3TFZr8oAR0nujYgCzY/8wgHGfeQ==",
+      "dev": true,
+      "requires": {
+        "@testing-library/dom": "^10.4.0"
+      }
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -27185,6 +27216,7 @@
     "zero-solid": {
       "version": "file:packages/zero-solid",
       "requires": {
+        "@solidjs/testing-library": "^0.8.10",
         "solid-js": "^1.0.0",
         "zero-advanced": "0.0.0"
       }

--- a/packages/zero-solid/package.json
+++ b/packages/zero-solid/package.json
@@ -14,6 +14,7 @@
     "solid-js": "^1.0.0"
   },
   "devDependencies": {
+    "@solidjs/testing-library": "^0.8.10",
     "solid-js": "^1.0.0",
     "zero-advanced": "0.0.0"
   }

--- a/packages/zero-solid/src/solid-view.test.ts
+++ b/packages/zero-solid/src/solid-view.test.ts
@@ -1,8 +1,8 @@
-import {expect, test} from 'vitest';
 import {resolver} from '@rocicorp/resolver';
+import {expect, test} from 'vitest';
 import {MemorySource} from '../../zql/src/ivm/memory-source.js';
-import {SolidView, solidViewFactory} from './solid-view.js';
 import type {Query, Smash} from '../../zql/src/query/query.js';
+import {SolidView, solidViewFactory} from './solid-view.js';
 
 test('basics', () => {
   const ms = new MemorySource(
@@ -25,7 +25,7 @@ test('basics', () => {
     {a: 2, b: 'b'},
   ]);
 
-  expect(view.resultType).toEqual('complete');
+  expect(view.resultDetails).toEqual({type: 'complete'});
 
   ms.push({row: {a: 3, b: 'c'}, type: 'add'});
 
@@ -100,11 +100,11 @@ test('queryComplete promise', async () => {
     {a: 2, b: 'b'},
   ]);
 
-  expect(view.resultType).toEqual('unknown');
+  expect(view.resultDetails).toEqual({type: 'unknown'});
 
   queryCompleteResolver.resolve(true);
   await 1;
-  expect(view.resultType).toEqual('complete');
+  expect(view.resultDetails).toEqual({type: 'complete'});
 });
 
 type TestSchema = {

--- a/packages/zero-solid/src/use-query.test.ts
+++ b/packages/zero-solid/src/use-query.test.ts
@@ -1,0 +1,47 @@
+import {expect, test} from 'vitest';
+import {must} from '../../shared/src/must.js';
+import {MemorySource} from '../../zql/src/ivm/memory-source.js';
+import {newQuery} from '../../zql/src/query/query-impl.js';
+import {QueryDelegateImpl} from '../../zql/src/query/test/query-delegate.js';
+import {useQuery} from './use-query.js';
+
+test('use-query', async () => {
+  const tableSchema = {
+    tableName: 'table',
+    columns: {
+      a: {type: 'number'},
+      b: {type: 'string'},
+    },
+    primaryKey: ['a'],
+    relationships: {},
+  } as const;
+  const ms = new MemorySource(
+    tableSchema.tableName,
+    tableSchema.columns,
+    tableSchema.primaryKey,
+  );
+  ms.push({row: {a: 1, b: 'a'}, type: 'add'});
+  ms.push({row: {a: 2, b: 'b'}, type: 'add'});
+
+  const queryDelegate = new QueryDelegateImpl({table: ms});
+  const tableQuery = newQuery(queryDelegate, tableSchema);
+
+  const [rows, resultType] = useQuery(() => tableQuery);
+  expect(rows()).toEqual([
+    {a: 1, b: 'a'},
+    {a: 2, b: 'b'},
+  ]);
+  expect(resultType()).toEqual({type: 'unknown'});
+
+  must(queryDelegate.gotCallbacks[0])(true);
+  await 1;
+
+  ms.push({row: {a: 3, b: 'c'}, type: 'add'});
+
+  expect(rows()).toEqual([
+    {a: 1, b: 'a'},
+    {a: 2, b: 'b'},
+    {a: 3, b: 'c'},
+  ]);
+  expect(resultType()).toEqual({type: 'complete'});
+});

--- a/packages/zero-solid/src/use-query.ts
+++ b/packages/zero-solid/src/use-query.ts
@@ -1,37 +1,35 @@
-import {type Accessor, createMemo, onCleanup} from 'solid-js';
+import {type Accessor, onCleanup} from 'solid-js';
 import type {
-  Query,
   AdvancedQuery,
+  Query,
   QueryType,
   Smash,
   TableSchema,
 } from '../../zero-advanced/src/mod.js';
-import {solidViewFactory} from './solid-view.js';
 import type {ResultType} from '../../zql/src/query/typed-view.js';
+import {solidViewFactory} from './solid-view.js';
 
 export type QueryResultDetails = Readonly<{
   type: ResultType;
 }>;
 
 export type QueryResult<TReturn extends QueryType> = readonly [
-  Smash<TReturn>,
-  QueryResultDetails,
+  Accessor<Smash<TReturn>>,
+  Accessor<QueryResultDetails>,
 ];
 
 export function useQuery<
   TSchema extends TableSchema,
   TReturn extends QueryType,
->(querySignal: () => Query<TSchema, TReturn>): Accessor<QueryResult<TReturn>> {
-  return createMemo(() => {
-    const query = querySignal();
-    const view = (query as AdvancedQuery<TSchema, TReturn>).materialize(
-      solidViewFactory,
-    );
+>(querySignal: () => Query<TSchema, TReturn>): QueryResult<TReturn> {
+  const query = querySignal();
+  const view = (query as AdvancedQuery<TSchema, TReturn>).materialize(
+    solidViewFactory,
+  );
 
-    onCleanup(() => {
-      view.destroy();
-    });
-
-    return [view.data, {type: view.resultType}] as const;
+  onCleanup(() => {
+    view.destroy();
   });
+
+  return [() => view.data, () => ({type: view.resultType})];
 }

--- a/packages/zero-solid/src/use-query.ts
+++ b/packages/zero-solid/src/use-query.ts
@@ -1,4 +1,4 @@
-import {type Accessor, onCleanup} from 'solid-js';
+import {createMemo, onCleanup, type Accessor} from 'solid-js';
 import type {
   AdvancedQuery,
   Query,
@@ -6,12 +6,7 @@ import type {
   Smash,
   TableSchema,
 } from '../../zero-advanced/src/mod.js';
-import type {ResultType} from '../../zql/src/query/typed-view.js';
-import {solidViewFactory} from './solid-view.js';
-
-export type QueryResultDetails = Readonly<{
-  type: ResultType;
-}>;
+import {solidViewFactory, type QueryResultDetails} from './solid-view.js';
 
 export type QueryResult<TReturn extends QueryType> = readonly [
   Accessor<Smash<TReturn>>,
@@ -22,14 +17,18 @@ export function useQuery<
   TSchema extends TableSchema,
   TReturn extends QueryType,
 >(querySignal: () => Query<TSchema, TReturn>): QueryResult<TReturn> {
-  const query = querySignal();
-  const view = (query as AdvancedQuery<TSchema, TReturn>).materialize(
-    solidViewFactory,
-  );
+  // Wrap in in createMemo to ensure a new view is created if the querySignal changes.
+  const view = createMemo(() => {
+    const query = querySignal();
+    const view = (query as AdvancedQuery<TSchema, TReturn>).materialize(
+      solidViewFactory,
+    );
 
-  onCleanup(() => {
-    view.destroy();
+    onCleanup(() => {
+      view.destroy();
+    });
+    return view;
   });
 
-  return [() => view.data, () => ({type: view.resultType})];
+  return [() => view().data, () => view().resultDetails];
 }


### PR DESCRIPTION
BREAKING CHANGE!

Previously it returned an accessor of a tuple which is not ergonomic.

It forced you to do:

```tsx
const rows = () = useQuery(q)()[0]; // yes you need the ()[0]
</List items={rows()}/>

// or
const res = useQuery(q);
</List items={rows()[0]}/>
```

With this change you can do:

```tsx
const [rows] = useQuery(q);
</List items={rows()}/>
```