### PR TITLE
feat(zero-schema): Add runtime assertion for all relationship tables in createSchema

### DIFF
--- a/packages/zero-schema/src/normalize-table-schema.ts
+++ b/packages/zero-schema/src/normalize-table-schema.ts
@@ -30,18 +30,26 @@ export class NormalizedTableSchema implements TableSchema {
   readonly columns: Record<string, SchemaValue>;
   readonly relationships: {readonly [name: string]: NormalizedRelationship};
 
-  constructor(tableSchema: TableSchema, tableSchemaCache: TableSchemaCache) {
+  constructor(
+    tableSchema: TableSchema,
+    tableSchemaCache: TableSchemaCache,
+    assertDest: AssertDestFunc,
+  ) {
     this.tableName = tableSchema.tableName;
     const primaryKey = normalizePrimaryKey(tableSchema.primaryKey);
     this.primaryKey = primaryKey;
     this.columns = normalizeColumns(tableSchema.columns, primaryKey);
     tableSchemaCache.set(tableSchema, this);
     this.relationships = normalizeRelationships(
+      this.tableName,
       tableSchema.relationships,
       tableSchemaCache,
+      assertDest,
     );
   }
 }
+
+const noop = () => {};
 
 export function normalizeTableSchema(
   tableSchema: TableSchema | NormalizedTableSchema,
@@ -50,20 +58,28 @@ export function normalizeTableSchema(
     tableSchema,
     tableSchema.tableName,
     new Map(),
+    noop,
   );
 }
 
+export type AssertDestFunc = (
+  tableName: string,
+  relationShipName: string,
+  destTableName: string,
+) => void;
+
 export function normalizeTableSchemaWithCache(
   tableSchema: TableSchema | NormalizedTableSchema,
-  expectedName: string,
+  expectedTableName: string,
   tableSchemaCache: TableSchemaCache,
+  assertDest: AssertDestFunc,
 ): NormalizedTableSchema {
   if (tableSchema instanceof NormalizedTableSchema) {
     return tableSchema;
   }
   assert(
-    tableSchema.tableName === expectedName,
-    `Table name mismatch: "${tableSchema.tableName}" !== "${expectedName}"`,
+    tableSchema.tableName === expectedTableName,
+    `Table name mismatch: "${tableSchema.tableName}" !== "${expectedTableName}"`,
   );
 
   let normalizedTableSchema = tableSchemaCache.get(tableSchema);
@@ -74,6 +90,7 @@ export function normalizeTableSchemaWithCache(
   normalizedTableSchema = new NormalizedTableSchema(
     tableSchema,
     tableSchemaCache,
+    assertDest,
   );
   return normalizedTableSchema as NormalizedTableSchema;
 }
@@ -137,13 +154,23 @@ type NormalizedRelationships = {
 };
 
 function normalizeRelationships(
+  tableName: string,
   relationships: Relationships,
   tableSchemaCache: TableSchemaCache,
+  assertDest: AssertDestFunc,
 ): NormalizedRelationships {
   const rv: Writable<NormalizedRelationships> = {};
   if (relationships) {
-    for (const [name, relationship] of sortedEntries(relationships)) {
-      rv[name] = normalizeRelationship(relationship, tableSchemaCache);
+    for (const [relationshipName, relationship] of sortedEntries(
+      relationships,
+    )) {
+      rv[relationshipName] = normalizeRelationship(
+        tableName,
+        relationshipName,
+        relationship,
+        tableSchemaCache,
+        assertDest,
+      );
     }
   }
   return rv;
@@ -173,13 +200,28 @@ type NormalizedRelationship =
   | NormalizedJunctionRelationship;
 
 function normalizeRelationship(
+  tableName: string,
+  relationshipName: string,
   relationship: Relationship,
   tableSchemaCache: TableSchemaCache,
+  assertDest: AssertDestFunc,
 ): NormalizedRelationship {
   if (isFieldRelationship(relationship)) {
-    return normalizeFieldRelationship(relationship, tableSchemaCache);
+    return normalizeFieldRelationship(
+      tableName,
+      relationshipName,
+      relationship,
+      tableSchemaCache,
+      assertDest,
+    );
   }
-  return normalizeJunctionRelationship(relationship, tableSchemaCache);
+  return normalizeJunctionRelationship(
+    tableName,
+    relationshipName,
+    relationship,
+    tableSchemaCache,
+    assertDest,
+  );
 }
 
 type NormalizedFieldRelationship = {
@@ -189,8 +231,11 @@ type NormalizedFieldRelationship = {
 };
 
 function normalizeFieldRelationship(
+  tableName: string,
+  relationshipName: string,
   relationship: FieldRelationship,
   tableSchemaCache: TableSchemaCache,
+  assertDest: AssertDestFunc,
 ): NormalizedFieldRelationship {
   const sourceField = normalizeFieldName(relationship.sourceField);
   const destField = normalizeFieldName(relationship.destField);
@@ -198,13 +243,16 @@ function normalizeFieldRelationship(
     sourceField.length === destField.length,
     'Source and destination fields must have the same length',
   );
+  const destSchema = normalizeLazyTableSchema(
+    relationship.destSchema,
+    tableSchemaCache,
+    assertDest,
+  );
+  assertDest(tableName, relationshipName, destSchema.tableName);
   return {
     sourceField,
     destField,
-    destSchema: normalizeLazyTableSchema(
-      relationship.destSchema,
-      tableSchemaCache,
-    ),
+    destSchema,
   };
 }
 
@@ -214,18 +262,34 @@ export type NormalizedJunctionRelationship = readonly [
 ];
 
 function normalizeJunctionRelationship(
+  tableName: string,
+  relationshipName: string,
   relationship: JunctionRelationship,
   tableSchemaCache: TableSchemaCache,
+  assertDest: AssertDestFunc,
 ): NormalizedJunctionRelationship {
   return [
-    normalizeFieldRelationship(relationship[0], tableSchemaCache),
-    normalizeFieldRelationship(relationship[1], tableSchemaCache),
+    normalizeFieldRelationship(
+      tableName,
+      relationshipName,
+      relationship[0],
+      tableSchemaCache,
+      assertDest,
+    ),
+    normalizeFieldRelationship(
+      tableName,
+      relationshipName,
+      relationship[1],
+      tableSchemaCache,
+      assertDest,
+    ),
   ];
 }
 
 function normalizeLazyTableSchema<TS extends TableSchema>(
   tableSchema: TS | (() => TS),
   buildCache: TableSchemaCache,
+  assertDest: AssertDestFunc,
 ): NormalizedTableSchema {
   const tableSchemaInstance =
     typeof tableSchema === 'function' ? tableSchema() : tableSchema;
@@ -233,6 +297,7 @@ function normalizeLazyTableSchema<TS extends TableSchema>(
     tableSchemaInstance,
     tableSchemaInstance.tableName, // Don't care about name here.
     buildCache,
+    assertDest,
   );
 }
 
@@ -248,8 +313,14 @@ export function normalizeTables(
   tables: Record<string, TableSchema>,
 ): Record<string, NormalizedTableSchema> {
   const result: Record<string, NormalizedTableSchema> = {};
+  const assertDest: AssertDestFunc = tableName => tableName in tables;
   for (const [name, table] of sortedEntries(tables)) {
-    result[name] = normalizeTableSchemaWithCache(table, name, new Map());
+    result[name] = normalizeTableSchemaWithCache(
+      table,
+      name,
+      new Map(),
+      assertDest,
+    );
   }
   return result;
 }

--- a/packages/zero-schema/src/normalized-schema.test.ts
+++ b/packages/zero-schema/src/normalized-schema.test.ts
@@ -136,11 +136,12 @@ test('Mutually resolving relationships should be supported', () => {
     primaryKey: ['id'],
     columns: {
       id: {type: 'string'},
+      fooField: {type: 'string'},
     },
     relationships: {
       bar: {
-        sourceField: ['bar-source'],
-        destField: ['field'],
+        sourceField: ['fooField'],
+        destField: ['barField'],
         destSchema: () => barTableSchema,
       },
     },
@@ -151,11 +152,12 @@ test('Mutually resolving relationships should be supported', () => {
     primaryKey: ['id'],
     columns: {
       id: {type: 'string'},
+      barField: {type: 'string'},
     },
     relationships: {
       foo: {
-        sourceField: ['foo-source'],
-        destField: ['field'],
+        sourceField: ['barField'],
+        destField: ['fooField'],
         destSchema: () => fooTableSchema,
       },
     },

--- a/packages/zero-schema/src/normalized-schema.ts
+++ b/packages/zero-schema/src/normalized-schema.ts
@@ -10,6 +10,8 @@ import {
 } from './normalize-table-schema.js';
 import type {Schema} from './schema.js';
 
+const normalizedCache = new WeakMap<Schema, NormalizedSchema>();
+
 /**
  * Creates a normalized schema from a schema.
  *
@@ -20,7 +22,12 @@ export function normalizeSchema(schema: Schema): NormalizedSchema {
   if (schema instanceof NormalizedSchema) {
     return schema;
   }
-  return new NormalizedSchema(schema);
+
+  let s;
+  if (!(s = normalizedCache.get(schema))) {
+    normalizedCache.set(schema, (s = new NormalizedSchema(schema)));
+  }
+  return s;
 }
 
 export class NormalizedSchema {

--- a/packages/zero-schema/src/normalized-schema.ts
+++ b/packages/zero-schema/src/normalized-schema.ts
@@ -1,7 +1,9 @@
+import {assert} from '../../shared/src/asserts.js';
 import {sortedEntries} from '../../shared/src/sorted-entries.js';
 import type {Writable} from '../../shared/src/writable.js';
 import {
   normalizeTableSchemaWithCache,
+  type AssertDestFunc,
   type DecycledNormalizedTableSchema,
   type NormalizedTableSchema,
   type TableSchemaCache,
@@ -46,8 +48,22 @@ function normalizeTables(tables: Schema['tables']): {
     readonly [table: string]: NormalizedTableSchema;
   }> = {};
   const tableSchemaCache: TableSchemaCache = new Map();
+  const assertDest: AssertDestFunc = (
+    tableName,
+    relationShipName,
+    destTableName,
+  ) =>
+    assert(
+      destTableName in tables,
+      `Relationship "${tableName}"."${relationShipName}" destination "${destTableName}" is missing in schema`,
+    );
   for (const [name, table] of sortedEntries(tables)) {
-    rv[name] = normalizeTableSchemaWithCache(table, name, tableSchemaCache);
+    rv[name] = normalizeTableSchemaWithCache(
+      table,
+      name,
+      tableSchemaCache,
+      assertDest,
+    );
   }
   return rv;
 }

--- a/packages/zero-schema/src/schema.test.ts
+++ b/packages/zero-schema/src/schema.test.ts
@@ -25,3 +25,101 @@ test('Unexpected tableName should throw', () => {
     'createSchema tableName mismatch, expected bar === bars',
   );
 });
+
+test('Missing table in direct relationship should throw', () => {
+  const bar = {
+    tableName: 'bar',
+    primaryKey: ['id'],
+    columns: {
+      id: {type: 'number'},
+    },
+  } as const;
+
+  const foo = {
+    tableName: 'foo',
+    primaryKey: ['id'],
+    columns: {
+      id: {type: 'number'},
+      bar_id: {type: 'number'},
+    },
+    relationships: {
+      bar: {
+        sourceField: 'bar_id',
+        destSchema: () => bar,
+        destField: 'id',
+      },
+    },
+  } as const;
+
+  const schema = {
+    version: 1,
+    tables: {
+      foo: foo,
+    },
+  } as const;
+
+  expect(() => createSchema(schema)).toThrow(
+    'createSchema relationship missing, foo relationship bar not present in schema.tables',
+  );
+});
+
+test('Missing table in junction relationship should throw', () => {
+  const baz = {
+    tableName: 'baz',
+    primaryKey: ['id'],
+    columns: {
+      id: {type: 'number'},
+    },
+  } as const;
+
+  const bar = {
+    tableName: 'bar',
+    primaryKey: ['id'],
+    columns: {
+      id: {type: 'number'},
+      baz_id: {type: 'number'},
+    },
+    relationships: {
+      baz: {
+        sourceField: 'baz_id',
+        destSchema: () => baz,
+        destField: 'id',
+      },
+    },
+  } as const;
+
+  const foo = {
+    tableName: 'foo',
+    primaryKey: ['id'],
+    columns: {
+      id: {type: 'number'},
+      bar_id: {type: 'number'},
+    },
+    relationships: {
+      baz: [
+        {
+          sourceField: 'bar_id',
+          destSchema: () => bar,
+          destField: 'id',
+        },
+        {
+          sourceField: 'baz_id',
+          destSchema: () => baz,
+          destField: 'id',
+        },
+      ],
+    },
+  } as const;
+
+  const schema = {
+    version: 1,
+    tables: {
+      foo: foo,
+      bar: bar,
+    },
+  } as const;
+
+  expect(() => createSchema(schema)).toThrow(
+    'createSchema relationship missing, foo relationship baz not present in schema.tables',
+  );
+});

--- a/packages/zero-schema/src/schema.test.ts
+++ b/packages/zero-schema/src/schema.test.ts
@@ -21,8 +21,8 @@ test('Unexpected tableName should throw', () => {
       },
     },
   } as const;
-  expect(() => createSchema(schema)).toThrow(
-    'createSchema tableName mismatch, expected bar === bars',
+  expect(() => createSchema(schema)).toThrowErrorMatchingInlineSnapshot(
+    `[Error: Table name mismatch: "bars" !== "bar"]`,
   );
 });
 
@@ -40,11 +40,11 @@ test('Missing table in direct relationship should throw', () => {
     primaryKey: ['id'],
     columns: {
       id: {type: 'number'},
-      bar_id: {type: 'number'},
+      barID: {type: 'number'},
     },
     relationships: {
-      bar: {
-        sourceField: 'bar_id',
+      barRelation: {
+        sourceField: 'barID',
         destSchema: () => bar,
         destField: 'id',
       },
@@ -54,57 +54,57 @@ test('Missing table in direct relationship should throw', () => {
   const schema = {
     version: 1,
     tables: {
-      foo: foo,
+      foo,
     },
   } as const;
 
-  expect(() => createSchema(schema)).toThrow(
-    'createSchema relationship missing, foo relationship bar not present in schema.tables',
+  expect(() => createSchema(schema)).toThrowErrorMatchingInlineSnapshot(
+    `[Error: Relationship "foo"."barRelation" destination "bar" is missing in schema]`,
   );
 });
 
 test('Missing table in junction relationship should throw', () => {
-  const baz = {
-    tableName: 'baz',
+  const tableA = {
+    tableName: 'tableA',
     primaryKey: ['id'],
     columns: {
       id: {type: 'number'},
     },
   } as const;
 
-  const bar = {
-    tableName: 'bar',
+  const tableB = {
+    tableName: 'tableB',
     primaryKey: ['id'],
     columns: {
       id: {type: 'number'},
-      baz_id: {type: 'number'},
+      aID: {type: 'number'},
     },
     relationships: {
-      baz: {
-        sourceField: 'baz_id',
-        destSchema: () => baz,
+      relationBToA: {
+        sourceField: 'aID',
+        destSchema: () => tableA,
         destField: 'id',
       },
     },
   } as const;
 
-  const foo = {
-    tableName: 'foo',
+  const tableC = {
+    tableName: 'tableC',
     primaryKey: ['id'],
     columns: {
       id: {type: 'number'},
-      bar_id: {type: 'number'},
+      bID: {type: 'number'},
     },
     relationships: {
-      baz: [
+      relationCToB: [
         {
-          sourceField: 'bar_id',
-          destSchema: () => bar,
+          sourceField: 'bID',
+          destSchema: () => tableB,
           destField: 'id',
         },
         {
-          sourceField: 'baz_id',
-          destSchema: () => baz,
+          sourceField: 'aID',
+          destSchema: () => tableA,
           destField: 'id',
         },
       ],
@@ -114,12 +114,12 @@ test('Missing table in junction relationship should throw', () => {
   const schema = {
     version: 1,
     tables: {
-      foo: foo,
-      bar: bar,
+      tableB,
+      tableC,
     },
   } as const;
 
-  expect(() => createSchema(schema)).toThrow(
-    'createSchema relationship missing, foo relationship baz not present in schema.tables',
+  expect(() => createSchema(schema)).toThrowErrorMatchingInlineSnapshot(
+    `[Error: Relationship "tableB"."relationBToA" destination "tableA" is missing in schema]`,
   );
 });

--- a/packages/zero-schema/src/schema.test.ts
+++ b/packages/zero-schema/src/schema.test.ts
@@ -123,3 +123,189 @@ test('Missing table in junction relationship should throw', () => {
     `[Error: Relationship "tableB"."relationBToA" destination "tableA" is missing in schema]`,
   );
 });
+
+test('Missing column in direct relationship destination should throw', () => {
+  const bar = {
+    tableName: 'bar',
+    primaryKey: ['id'],
+    columns: {
+      id: {type: 'number'},
+    },
+  } as const;
+
+  const foo = {
+    tableName: 'foo',
+    primaryKey: ['id'],
+    columns: {
+      id: {type: 'number'},
+      barID: {type: 'number'},
+    },
+    relationships: {
+      barRelation: {
+        sourceField: 'barID',
+        destSchema: () => bar,
+        destField: 'missing',
+      },
+    },
+  } as const;
+
+  const schema = {
+    version: 1,
+    tables: {
+      foo,
+      bar,
+    },
+  } as const;
+
+  expect(() => createSchema(schema)).toThrowErrorMatchingInlineSnapshot(
+    `[Error: Column "missing" is missing in table "bar"]`,
+  );
+});
+
+test('Missing column in direct relationship source should throw', () => {
+  const bar = {
+    tableName: 'bar',
+    primaryKey: ['id'],
+    columns: {
+      id: {type: 'number'},
+    },
+  } as const;
+
+  const foo = {
+    tableName: 'foo',
+    primaryKey: ['id'],
+    columns: {
+      id: {type: 'number'},
+      barID: {type: 'number'},
+    },
+    relationships: {
+      barRelation: {
+        sourceField: 'missing',
+        destSchema: () => bar,
+        destField: 'id',
+      },
+    },
+  } as const;
+
+  const schema = {
+    version: 1,
+    tables: {
+      foo,
+      bar,
+    },
+  } as const;
+
+  expect(() => createSchema(schema)).toThrowErrorMatchingInlineSnapshot(
+    `[Error: Column "missing" is missing in table "foo"]`,
+  );
+});
+
+test('Missing column in junction relationship destination should throw', () => {
+  const tableA = {
+    tableName: 'tableA',
+    primaryKey: ['id'],
+    columns: {
+      id: {type: 'number'},
+    },
+    relationships: {
+      relationAToB: [
+        {
+          sourceField: 'id',
+          destSchema: () => junctionTable,
+          destField: 'aID',
+        },
+        {
+          sourceField: 'aID',
+          destSchema: () => tableB,
+          destField: 'missing',
+        },
+      ],
+    },
+  } as const;
+
+  const tableB = {
+    tableName: 'tableB',
+    primaryKey: ['id'],
+    columns: {
+      id: {type: 'number'},
+    },
+  } as const;
+
+  const junctionTable = {
+    tableName: 'junctionTable',
+    primaryKey: ['id'],
+    columns: {
+      id: {type: 'number'},
+      aID: {type: 'number'},
+      bID: {type: 'number'},
+    },
+  } as const;
+
+  const schema = {
+    version: 1,
+    tables: {
+      tableA,
+      tableB,
+      junctionTable,
+    },
+  } as const;
+
+  expect(() => createSchema(schema)).toThrowErrorMatchingInlineSnapshot(
+    `[Error: Column "missing" is missing in table "tableB"]`,
+  );
+});
+
+test('Missing column in junction relationship source should throw', () => {
+  const tableA = {
+    tableName: 'tableA',
+    primaryKey: ['id'],
+    columns: {
+      id: {type: 'number'},
+    },
+    relationships: {
+      relationAToB: [
+        {
+          sourceField: 'id',
+          destSchema: () => junctionTable,
+          destField: 'aID',
+        },
+        {
+          sourceField: 'missing',
+          destSchema: () => tableB,
+          destField: 'id',
+        },
+      ],
+    },
+  } as const;
+
+  const tableB = {
+    tableName: 'tableB',
+    primaryKey: ['id'],
+    columns: {
+      id: {type: 'number'},
+    },
+  } as const;
+
+  const junctionTable = {
+    tableName: 'junctionTable',
+    primaryKey: ['id'],
+    columns: {
+      id: {type: 'number'},
+      aID: {type: 'number'},
+      bID: {type: 'number'},
+    },
+  } as const;
+
+  const schema = {
+    version: 1,
+    tables: {
+      tableA,
+      tableB,
+      junctionTable,
+    },
+  } as const;
+
+  expect(() => createSchema(schema)).toThrowErrorMatchingInlineSnapshot(
+    `[Error: Column "missing" is missing in table "junctionTable"]`,
+  );
+});

--- a/packages/zero-schema/src/schema.ts
+++ b/packages/zero-schema/src/schema.ts
@@ -1,9 +1,14 @@
 import {assert} from '../../shared/src/asserts.js';
-import type {TableSchema} from './table-schema.js';
+import {
+  type FieldRelationship,
+  type Relationship,
+  type TableSchema,
+  isFieldRelationship,
+} from './table-schema.js';
 
 export type Schema = {
   readonly version: number;
-  readonly tables: {readonly [table: string]: TableSchema};
+  readonly tables: { readonly [table: string]: TableSchema };
 };
 
 export function createSchema<const S extends Schema>(schema: S): S {
@@ -12,6 +17,67 @@ export function createSchema<const S extends Schema>(schema: S): S {
       tableName === table.tableName,
       `createSchema tableName mismatch, expected ${tableName} === ${table.tableName}`,
     );
+
+    // Assert that all relationship -> destSchema entries are present in schema.tables
+    const { relationships } = table;
+    if (relationships) {
+      for (const [
+        relationshipName,
+        relationship,
+      ] of Object.entries(relationships)) {
+        checkRelationship(
+          relationship,
+          tableName,
+          relationshipName as keyof S['tables'][typeof tableName]['relationships'],
+          schema,
+        );
+      }
+    }
   }
   return schema as S;
+}
+
+function checkDestSchema<
+  S extends Schema,
+  TableName extends keyof S['tables'],
+  RelationshipName extends keyof S['tables'][TableName]['relationships'],
+>(
+  schema: S,
+  tableName: TableName,
+  relationshipName: RelationshipName,
+  relationship: FieldRelationship,
+) {
+  const destSchema =
+    typeof relationship.destSchema === 'function'
+      ? relationship.destSchema()
+      : relationship.destSchema;
+
+  assert(
+    schema.tables[destSchema.tableName],
+    `createSchema relationship missing, ${String(tableName)} relationship ${String(relationshipName)} not present in schema.tables`,
+  );
+}
+
+function checkRelationship<
+  const S extends Schema,
+  TableName extends keyof S['tables'],
+  RelationshipName extends keyof S['tables'][TableName]['relationships'],
+>(
+  relationship: Relationship,
+  tableName: TableName,
+  relationshipName: RelationshipName,
+  schema: S,
+) {
+  if (isFieldRelationship(relationship)) {
+    checkDestSchema(schema, tableName, relationshipName, relationship);
+  } else {
+    for (const junctionRelationship of relationship) {
+      checkDestSchema(
+        schema,
+        tableName,
+        relationshipName,
+        junctionRelationship,
+      );
+    }
+  }
 }

--- a/packages/zero-schema/src/schema.ts
+++ b/packages/zero-schema/src/schema.ts
@@ -7,6 +7,8 @@ export type Schema = {
 };
 
 export function createSchema<const S extends Schema>(schema: S): S {
+  // normalizeSchema will throw if the schema is invalid.
   normalizeSchema(schema);
+  // We still want to return s to cause less surprises.
   return schema as S;
 }

--- a/packages/zero-schema/src/schema.ts
+++ b/packages/zero-schema/src/schema.ts
@@ -1,83 +1,12 @@
-import {assert} from '../../shared/src/asserts.js';
-import {
-  type FieldRelationship,
-  type Relationship,
-  type TableSchema,
-  isFieldRelationship,
-} from './table-schema.js';
+import {normalizeSchema} from './normalized-schema.js';
+import {type TableSchema} from './table-schema.js';
 
 export type Schema = {
   readonly version: number;
-  readonly tables: { readonly [table: string]: TableSchema };
+  readonly tables: {readonly [table: string]: TableSchema};
 };
 
 export function createSchema<const S extends Schema>(schema: S): S {
-  for (const [tableName, table] of Object.entries(schema.tables)) {
-    assert(
-      tableName === table.tableName,
-      `createSchema tableName mismatch, expected ${tableName} === ${table.tableName}`,
-    );
-
-    // Assert that all relationship -> destSchema entries are present in schema.tables
-    const { relationships } = table;
-    if (relationships) {
-      for (const [
-        relationshipName,
-        relationship,
-      ] of Object.entries(relationships)) {
-        checkRelationship(
-          relationship,
-          tableName,
-          relationshipName as keyof S['tables'][typeof tableName]['relationships'],
-          schema,
-        );
-      }
-    }
-  }
+  normalizeSchema(schema);
   return schema as S;
-}
-
-function checkDestSchema<
-  S extends Schema,
-  TableName extends keyof S['tables'],
-  RelationshipName extends keyof S['tables'][TableName]['relationships'],
->(
-  schema: S,
-  tableName: TableName,
-  relationshipName: RelationshipName,
-  relationship: FieldRelationship,
-) {
-  const destSchema =
-    typeof relationship.destSchema === 'function'
-      ? relationship.destSchema()
-      : relationship.destSchema;
-
-  assert(
-    schema.tables[destSchema.tableName],
-    `createSchema relationship missing, ${String(tableName)} relationship ${String(relationshipName)} not present in schema.tables`,
-  );
-}
-
-function checkRelationship<
-  const S extends Schema,
-  TableName extends keyof S['tables'],
-  RelationshipName extends keyof S['tables'][TableName]['relationships'],
->(
-  relationship: Relationship,
-  tableName: TableName,
-  relationshipName: RelationshipName,
-  schema: S,
-) {
-  if (isFieldRelationship(relationship)) {
-    checkDestSchema(schema, tableName, relationshipName, relationship);
-  } else {
-    for (const junctionRelationship of relationship) {
-      checkDestSchema(
-        schema,
-        tableName,
-        relationshipName,
-        junctionRelationship,
-      );
-    }
-  }
 }


### PR DESCRIPTION
zbugs: [Potential for a better error message when a table is referenced in a relationship but not included in createSchema](https://bugs.rocicorp.dev/issue/3370)

Thank you @arv for the work on https://github.com/rocicorp/mono/pull/3477. It pointed me in the direction of where to look code wise. I wanted to expand the work that was done to resolve the issue I ran into where defining a `destSchema` for a table that isn't referenced in `schema.tables` causes an error.

I added test cases for two potential ways to have a missing table. If anyone can think of other scenarios I can gladly write more tests.

My only question about adding this, while I think it improves the DX and will help people to ensure their schema is valid, is there any concern about runtime cost and having `createSchema` doing this additional work?