### PR TITLE
feat(zbugs): add bundle analyzer so we can start paring down size

### DIFF
--- a/apps/zbugs/package.json
+++ b/apps/zbugs/package.json
@@ -17,7 +17,8 @@
     "run-query": "npm run zero-build-schema && tsx ../../packages/zero-cache/src/scripts/run-query.ts",
     "zero-build-schema": "tsx ../../packages/zero-schema/src/build-schema.ts",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "analyze": "analyze -c vite.config.ts"
   },
   "dependencies": {
     "@fastify/cookie": "^10.0.0",
@@ -75,6 +76,7 @@
     "typescript": "^5.6.3",
     "universal-user-agent": "^7.0.2",
     "vite": "^5.4.9",
+    "vite-bundle-analyzer": "^0.16.0",
     "vite-plugin-svgr": "^4.2.0",
     "vite-tsconfig-paths": "^5.0.1",
     "vitest": "^2.1.5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
         "typescript": "^5.6.3",
         "universal-user-agent": "^7.0.2",
         "vite": "^5.4.9",
+        "vite-bundle-analyzer": "^0.16.0",
         "vite-plugin-svgr": "^4.2.0",
         "vite-tsconfig-paths": "^5.0.1",
         "vitest": "^2.1.5"
@@ -14918,6 +14919,15 @@
         }
       }
     },
+    "node_modules/vite-bundle-analyzer": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/vite-bundle-analyzer/-/vite-bundle-analyzer-0.16.0.tgz",
+      "integrity": "sha512-zJEXZuwqoNxBwuCLzpVLrlT3V7RPaPTlqkcHKJMaS98QIOuBMZ10XCeWQ11+lG4wc151KNkAP5xbxsp2kD+rOg==",
+      "dev": true,
+      "bin": {
+        "analyze": "dist/bin.js"
+      }
+    },
     "node_modules/vite-node": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.5.tgz",
@@ -15989,17 +15999,16 @@
     },
     "packages/zero-react": {
       "version": "0.0.0",
-      "dependencies": {
-        "use-sync-external-store": "^1.4.0"
-      },
       "devDependencies": {
         "@types/react": "18.2.13",
         "@types/use-sync-external-store": "^0.0.6",
         "react": ">=16.0 <19.0",
+        "use-sync-external-store": "^1.4.0",
         "zero-client": "0.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.0 <19.0"
+        "react": ">=16.0 <19.0",
+        "use-sync-external-store": "^1.4.0"
       }
     },
     "packages/zero-schema": {
@@ -26581,6 +26590,12 @@
         }
       }
     },
+    "vite-bundle-analyzer": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/vite-bundle-analyzer/-/vite-bundle-analyzer-0.16.0.tgz",
+      "integrity": "sha512-zJEXZuwqoNxBwuCLzpVLrlT3V7RPaPTlqkcHKJMaS98QIOuBMZ10XCeWQ11+lG4wc151KNkAP5xbxsp2kD+rOg==",
+      "dev": true
+    },
     "vite-node": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.5.tgz",
@@ -26896,6 +26911,7 @@
         "use-sync-external-store": "^1.4.0",
         "usehooks-ts": "^3.1.0",
         "vite": "^5.4.9",
+        "vite-bundle-analyzer": "^0.16.0",
         "vite-plugin-svgr": "^4.2.0",
         "vite-tsconfig-paths": "^5.0.1",
         "vitest": "^2.1.5",


### PR DESCRIPTION
```ts
npm run analyze
```
t
![CleanShot 2025-01-07 at 15 33 17](https://github.com/user-attachments/assets/d8a694d5-f5af-4d35-9d55-33b8e4dd7ec0)

One quick win: we could replace `b+tree` with the `treap` we were using a ways back.