### PR TITLE
fix(zero-cache-dev): fix zero-cache-dev for multitenant

### DIFF
--- a/packages/zero/src/zero-cache-dev.ts
+++ b/packages/zero/src/zero-cache-dev.ts
@@ -1,16 +1,16 @@
 #!/usr/bin/env node
 
-import {spawn, type ChildProcess} from 'node:child_process';
-import {watch} from 'chokidar';
-import {parseOptionsAdvanced} from '../../shared/src/options.js';
 import {resolver} from '@rocicorp/resolver';
-import {buildSchemaOptions} from '../../zero-schema/src/build-schema-options.js';
+import chalk from 'chalk';
+import {watch} from 'chokidar';
+import 'dotenv/config';
+import {spawn, type ChildProcess} from 'node:child_process';
+import {parseOptionsAdvanced} from '../../shared/src/options.js';
 import {
   ZERO_ENV_VAR_PREFIX,
   zeroOptions,
 } from '../../zero-cache/src/config/zero-config.js';
-import 'dotenv/config';
-import chalk from 'chalk';
+import {buildSchemaOptions} from '../../zero-schema/src/build-schema-options.js';
 
 const buildSchemaScript = 'zero-build-schema';
 const zeroCacheScript = 'zero-cache';
@@ -46,6 +46,8 @@ async function main() {
     },
     process.argv.slice(2),
     ZERO_ENV_VAR_PREFIX,
+    false,
+    true, // allowPartial, required by server/multi/config.ts
   );
 
   const {unknown: zeroCacheArgs} = parseOptionsAdvanced(


### PR DESCRIPTION
Flags parsing needs to `allowPartial` for multi-tenant flag parsing logic.

https://discord.com/channels/830183651022471199/1325206399218614282/1326159204293152811