### PR TITLE
chore(zero-cache): api to run unit tests on custom pg instance

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/pg/schema/shard.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/pg/schema/shard.pg-test.ts
@@ -19,6 +19,7 @@ describe('change-source/pg', () => {
 
   afterEach(async () => {
     await testDBs.drop(db);
+    await testDBs.sql`RESET ROLE; DROP ROLE IF EXISTS supaneon`.simple();
   });
 
   function publications() {

--- a/packages/zero-cache/src/test/db.ts
+++ b/packages/zero-cache/src/test/db.ts
@@ -37,7 +37,7 @@ class TestDBs {
       await this.#drop(exists);
     }
 
-    const sql = this.sql;
+    const {sql} = this;
     await sql`CREATE DATABASE ${sql(database)}`;
 
     const {host, port, user: username, pass} = sql.options;
@@ -66,7 +66,7 @@ class TestDBs {
     await db.end();
 
     for (let i = 0; i < 10; i++) {
-      const sql = this.sql;
+      const {sql} = this;
       await dropReplicationSlotsFor(sql, database);
       try {
         await sql`DROP DATABASE IF EXISTS ${sql(database)} WITH (FORCE)`;

--- a/packages/zero-cache/src/test/db.ts
+++ b/packages/zero-cache/src/test/db.ts
@@ -6,12 +6,12 @@ import {type PostgresDB, postgresTypeConfig} from '../types/pg.js';
 
 declare module 'vitest' {
   export interface ProvidedContext {
-    pgContainerConnectionString: string;
+    pgConnectionString: string;
   }
 }
 
 // Set by ./test/pg-container-setup.ts
-const CONNECTION_URI = inject('pgContainerConnectionString');
+const CONNECTION_URI = inject('pgConnectionString');
 assert(
   CONNECTION_URI,
   'test file must have suffix ".pg-test.ts" to setup postgres container',
@@ -24,7 +24,7 @@ const defaultOnNotice: OnNoticeFn = n => {
 };
 
 class TestDBs {
-  readonly #sql = postgres(CONNECTION_URI, {
+  readonly sql = postgres(CONNECTION_URI, {
     onnotice: n => n.severity !== 'NOTICE' && console.log(n),
     ...postgresTypeConfig(),
   });
@@ -37,7 +37,7 @@ class TestDBs {
       await this.#drop(exists);
     }
 
-    const sql = this.#sql;
+    const sql = this.sql;
     await sql`CREATE DATABASE ${sql(database)}`;
 
     const {host, port, user: username, pass} = sql.options;
@@ -66,7 +66,7 @@ class TestDBs {
     await db.end();
 
     for (let i = 0; i < 10; i++) {
-      const sql = this.#sql;
+      const sql = this.sql;
       await dropReplicationSlotsFor(sql, database);
       try {
         await sql`DROP DATABASE IF EXISTS ${sql(database)} WITH (FORCE)`;
@@ -90,7 +90,7 @@ class TestDBs {
    * it manually.
    */
   async end() {
-    await this.#sql.end();
+    await this.sql.end();
   }
 }
 

--- a/packages/zero-cache/test/pg-container-setup.ts
+++ b/packages/zero-cache/test/pg-container-setup.ts
@@ -7,7 +7,7 @@ export function runPostgresContainer(image: string) {
       .start();
 
     // Referenced by ./src/test/db.ts
-    provide('pgContainerConnectionString', container.getConnectionUri());
+    provide('pgConnectionString', container.getConnectionUri());
 
     return async () => {
       await container.stop();

--- a/packages/zero-cache/vitest.workspace.ts
+++ b/packages/zero-cache/vitest.workspace.ts
@@ -20,4 +20,24 @@ export default defineWorkspace([
   pgConfigForVersion(15),
   pgConfigForVersion(16),
   pgConfigForVersion(17),
+  // To run tests against a custom Postgres instance (e.g. Aurora), specify
+  // the connection string in the CUSTOM_PG environment variable, and optionally
+  // limit the test runner to the "custom-pg" project:
+  //
+  // CUSTOM_PG=postgresql://... npm run test -- --project custom-pg
+  ...(process.env['CUSTOM_PG']
+    ? [
+        {
+          extends: './vitest.config.js',
+          test: {
+            name: 'custom-pg',
+            include: ['src/**/*.pg-test.?(c|m)[jt]s?(x)'],
+            provide: {
+              // Referenced by ./src/test/db.ts
+              pgConnectionString: process.env['CUSTOM_PG'],
+            },
+          },
+        },
+      ]
+    : []),
 ]);


### PR DESCRIPTION
Adds a `CUSTOM_PG=postgresql?... npx run tests` option for running the `zero-cache` tests on a custom PG instance, such as an Aurora instance.

Fix a tests to clean up global state, so that it can be rerun on the same pg instance multiple times. 