### PR TITLE
chore(zero-protocol): bump to v4, start renaming delPatch.id to delPatch.value

### DIFF
--- a/packages/zero-client/src/client/zero-poke-handler.test.ts
+++ b/packages/zero-client/src/client/zero-poke-handler.test.ts
@@ -1328,7 +1328,18 @@ test('mergePokes with all optionals defined', () => {
                 hash: 'h1',
               },
             ],
-            rowsPatch: [{op: 'del', tableName: 'issues', id: {id: 'issue3'}}],
+            rowsPatch: [
+              {
+                op: 'del',
+                tableName: 'issues',
+                id: {id: 'issue3', other: 'ignored'},
+              },
+              {
+                op: 'del',
+                tableName: 'issues',
+                value: {id: 'issue4', other: 'ignored'},
+              },
+            ],
           },
         ],
       },
@@ -1425,6 +1436,10 @@ test('mergePokes with all optionals defined', () => {
         {
           op: 'del',
           key: 'e/issues/issue3',
+        },
+        {
+          op: 'del',
+          key: 'e/issues/issue4',
         },
       ],
     },

--- a/packages/zero-client/src/client/zero-poke-handler.ts
+++ b/packages/zero-client/src/client/zero-poke-handler.ts
@@ -6,6 +6,7 @@ import type {
 } from '../../../replicache/src/impl.js';
 import type {ClientID, PatchOperation} from '../../../replicache/src/mod.js';
 import {getBrowserGlobalMethod} from '../../../shared/src/browser-env.js';
+import {must} from '../../../shared/src/must.js';
 import type {
   ClientsPatchOp,
   PokeEndBody,
@@ -14,13 +15,13 @@ import type {
   QueriesPatchOp,
   RowPatchOp,
 } from '../../../zero-protocol/src/mod.js';
+import type {NormalizedSchema} from '../../../zero-schema/src/normalized-schema.js';
 import {
   toClientsKey,
   toDesiredQueriesKey,
   toGotQueriesKey,
   toPrimaryKeyString,
 } from './keys.js';
-import type {NormalizedSchema} from '../../../zero-schema/src/normalized-schema.js';
 
 type PokeAccumulator = {
   readonly pokeStart: PokeStartBody;
@@ -317,7 +318,7 @@ function rowsPatchOpToReplicachePatchOp(
         key: toPrimaryKeyString(
           op.tableName,
           schema.tables[op.tableName].primaryKey,
-          op.id,
+          must(op.value ?? op.id),
         ),
       };
     case 'put':

--- a/packages/zero-protocol/src/ast.test.ts
+++ b/packages/zero-protocol/src/ast.test.ts
@@ -244,5 +244,5 @@ test('protocol version', () => {
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
   expect(hash).toEqual('1g60qx4dfwety');
-  expect(PROTOCOL_VERSION).toEqual(3);
+  expect(PROTOCOL_VERSION).toEqual(4);
 });

--- a/packages/zero-protocol/src/protocol-version.ts
+++ b/packages/zero-protocol/src/protocol-version.ts
@@ -12,7 +12,7 @@ import {assert} from '../../shared/src/asserts.js';
  * release. The server (`zero-cache`) must be deployed before clients start
  * running the new code.
  */
-export const PROTOCOL_VERSION = 3;
+export const PROTOCOL_VERSION = 4;
 
 /**
  * The minimum protocol version supported by the server. The contract for

--- a/packages/zero-protocol/src/row-patch.ts
+++ b/packages/zero-protocol/src/row-patch.ts
@@ -23,7 +23,7 @@ const delOpSchema = v.object({
   // Either `id` or `value` must be set.
   // Migration plan:
   // - Start setting `value` on the server instead of `id` and
-  //   set MIN_SUPPORTED_PROTOCOL_VERSION = 4.
+  //   set MIN_SERVER_SUPPORTED_PROTOCOL_VERSION = 4.
   // - Remove `id` and make `value` required to make
   //   MIN_SERVER_SUPPORTED_PROTOCOL_VERSION = 5.
   id: primaryKeyValueRecordSchema.optional(),

--- a/packages/zero-protocol/src/row-patch.ts
+++ b/packages/zero-protocol/src/row-patch.ts
@@ -20,7 +20,14 @@ const updateOpSchema = v.object({
 const delOpSchema = v.object({
   op: v.literal('del'),
   tableName: v.string(),
-  id: primaryKeyValueRecordSchema,
+  // Either `id` or `value` must be set.
+  // Migration plan:
+  // - Start setting `value` on the server instead of `id` and
+  //   set MIN_SUPPORTED_PROTOCOL_VERSION = 4.
+  // - Remove `id` and make `value` required to make
+  //   MIN_SERVER_SUPPORTED_PROTOCOL_VERSION = 5.
+  id: primaryKeyValueRecordSchema.optional(),
+  value: rowSchema.optional(),
 });
 
 const clearOpSchema = v.object({


### PR DESCRIPTION
Start the migration to send the full row in `del` patches to make the protocol agnostic to the primary key.

* A new (optional) `value` field is introduced to hold the full row value
* `id` is made optional
* server must set one or the other
* client accepts either; the logic for extracting the key from the full row is already in place

TODO: Remove obsolete `update` patch.