### PR TITLE
fix(zero-cache): propagate env varz to tenants

### DIFF
--- a/packages/zero-cache/src/server/multi/main.ts
+++ b/packages/zero-cache/src/server/multi/main.ts
@@ -55,6 +55,7 @@ export default async function runWorker(
   const tenants = config.tenants.map(tenant => ({
     ...tenant,
     worker: childWorker('./server/main.ts', {
+      ...process.env, // propagate all ENV variables from this process
       ...baseEnv, // defaults
       ['ZERO_TENANT_ID']: tenant.id,
       ['ZERO_PORT']: String((tenantPort += 2)), // and bump the port by 2 thereafter.


### PR DESCRIPTION
Propagate the parent's ENV vars to tenant zero-caches, so that variables such as `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` find their way to the `litestream` subprocess.