### PR TITLE
prod(zero-cache): enable deployment circuit breaker

### DIFF
--- a/packages/zero-cache/src/integration/integration.pg-test.ts
+++ b/packages/zero-cache/src/integration/integration.pg-test.ts
@@ -310,4 +310,4 @@ describe('integration', () => {
       {pokeID: expect.any(String)},
     ]);
   });
-});
+}, 10000);

--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -151,7 +151,7 @@ export default async function runWorker(
   }
 
   lc.info?.('waiting for workers to be ready ...');
-  if ((await orTimeout(processes.allWorkersReady(), 30_000)) === 'timed-out') {
+  if ((await orTimeout(processes.allWorkersReady(), 60_000)) === 'timed-out') {
     lc.info?.(`timed out waiting for readiness (${Date.now() - startMs} ms)`);
   } else {
     lc.info?.(`all workers ready (${Date.now() - startMs} ms)`);

--- a/packages/zero-cache/src/server/multi/main.ts
+++ b/packages/zero-cache/src/server/multi/main.ts
@@ -69,7 +69,7 @@ export default async function runWorker(
 
   const s = tenants.length > 1 ? 's' : '';
   lc.info?.(`waiting for zero-cache${s} to be ready ...`);
-  if ((await orTimeout(processes.allWorkersReady(), 30_000)) === 'timed-out') {
+  if ((await orTimeout(processes.allWorkersReady(), 60_000)) === 'timed-out') {
     lc.info?.(`timed out waiting for readiness (${Date.now() - startMs} ms)`);
   } else {
     lc.info?.(`zero-cache${s} ready (${Date.now() - startMs} ms)`);

--- a/prod/templates/sandbox/template.yml
+++ b/prod/templates/sandbox/template.yml
@@ -83,7 +83,7 @@ Resources:
       Cluster: !Ref Cluster
       LaunchType: FARGATE
       EnableExecuteCommand: true
-      HealthCheckGracePeriodSeconds: 5
+      HealthCheckGracePeriodSeconds: 300
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: ENABLED
@@ -100,6 +100,9 @@ Resources:
         # (Connection counts are currently safe for up to 12 tasks at a time)
         MaximumPercent: 120
         MinimumHealthyPercent: 50
+        DeploymentCircuitBreaker:
+          Enable: true
+          Rollback: false
       DesiredCount: 10
       TaskDefinition: !Ref "TaskDefinitionViewSyncer"
       LoadBalancers:
@@ -292,6 +295,9 @@ Resources:
       DeploymentConfiguration:
         MaximumPercent: 200
         MinimumHealthyPercent: 50
+        DeploymentCircuitBreaker:
+          Enable: true
+          Rollback: false
       DesiredCount: 1
       TaskDefinition: !Ref "TaskDefinitionReplicationManager"
       ServiceConnectConfiguration:

--- a/prod/templates/template.yml
+++ b/prod/templates/template.yml
@@ -99,7 +99,7 @@ Resources:
       Cluster: !Ref Cluster
       LaunchType: FARGATE
       EnableExecuteCommand: true
-      HealthCheckGracePeriodSeconds: 5
+      HealthCheckGracePeriodSeconds: 300
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: ENABLED
@@ -116,6 +116,9 @@ Resources:
         # (Connection counts are currently safe for up to 12 tasks at a time)
         MaximumPercent: 120
         MinimumHealthyPercent: 50
+        DeploymentCircuitBreaker:
+          Enable: true
+          Rollback: false
       DesiredCount: 10
       TaskDefinition: !Ref "TaskDefinitionViewSyncer"
       LoadBalancers:
@@ -312,6 +315,9 @@ Resources:
       DeploymentConfiguration:
         MaximumPercent: 200
         MinimumHealthyPercent: 50
+        DeploymentCircuitBreaker:
+          Enable: true
+          Rollback: false
       DesiredCount: 1
       TaskDefinition: !Ref "TaskDefinitionReplicationManager"
       ServiceConnectConfiguration:


### PR DESCRIPTION
This prevents bad deployments from getting stuck. (This was enabled pre-CloudFormation)

Also give our containers the default (5 minute) grace period for becoming health. Not sure why it was reduced to such a low value.