### PR TITLE
prod(zero-cache): enable circuit breaker rollback

### DIFF
--- a/prod/templates/sandbox/template.yml
+++ b/prod/templates/sandbox/template.yml
@@ -102,7 +102,7 @@ Resources:
         MinimumHealthyPercent: 50
         DeploymentCircuitBreaker:
           Enable: true
-          Rollback: false
+          Rollback: true
       DesiredCount: 10
       TaskDefinition: !Ref "TaskDefinitionViewSyncer"
       LoadBalancers:
@@ -297,7 +297,7 @@ Resources:
         MinimumHealthyPercent: 50
         DeploymentCircuitBreaker:
           Enable: true
-          Rollback: false
+          Rollback: true
       DesiredCount: 1
       TaskDefinition: !Ref "TaskDefinitionReplicationManager"
       ServiceConnectConfiguration:

--- a/prod/templates/template.yml
+++ b/prod/templates/template.yml
@@ -118,7 +118,7 @@ Resources:
         MinimumHealthyPercent: 50
         DeploymentCircuitBreaker:
           Enable: true
-          Rollback: false
+          Rollback: true
       DesiredCount: 10
       TaskDefinition: !Ref "TaskDefinitionViewSyncer"
       LoadBalancers:
@@ -317,7 +317,7 @@ Resources:
         MinimumHealthyPercent: 50
         DeploymentCircuitBreaker:
           Enable: true
-          Rollback: false
+          Rollback: true
       DesiredCount: 1
       TaskDefinition: !Ref "TaskDefinitionReplicationManager"
       ServiceConnectConfiguration:


### PR DESCRIPTION
This should not result in a behavioral difference in Fargate based on our deployment configuration, but enabling it reflects the intention.

https://stackoverflow.com/questions/74269206/ecs-fargate-expected-deployment-circuit-breaker-rollback-behaviour