### PR TITLE
chore(replicache)!: Remove Pull/Push V0

### DIFF
--- a/packages/replicache/src/get-default-puller.ts
+++ b/packages/replicache/src/get-default-puller.ts
@@ -3,7 +3,6 @@ import {
   assertObject,
   assertString,
 } from '../../shared/src/asserts.js';
-import {assertJSONValue} from '../../shared/src/json.js';
 import {callDefaultFetch} from './call-default-fetch.js';
 import {assertCookie} from './cookies.js';
 import {
@@ -13,12 +12,9 @@ import {
 import {assertHTTPRequestInfo} from './http-request-info.js';
 import {assertPatchOperations} from './patch-operation.js';
 import type {
-  PullResponseOKV0,
-  PullResponseV0,
   PullResponseV1,
   Puller,
   PullerResult,
-  PullerResultV0,
   PullerResultV1,
 } from './puller.js';
 import type {PullRequest} from './sync/pull.js';
@@ -57,19 +53,6 @@ export function isDefaultPuller(puller: Puller): boolean {
   return defaultPullers.has(puller);
 }
 
-export function assertPullResponseV0(v: unknown): asserts v is PullResponseV0 {
-  assertObject(v);
-  if (isClientStateNotFoundResponse(v) || isVersionNotSupportedResponse(v)) {
-    return;
-  }
-  const v2 = v as Partial<PullResponseOKV0>;
-  if (v2.cookie !== undefined) {
-    assertJSONValue(v2.cookie);
-  }
-  assertNumber(v2.lastMutationID);
-  assertPatchOperations(v2.patch);
-}
-
 export function assertPullResponseV1(v: unknown): asserts v is PullResponseV1 {
   assertObject(v);
   if (isClientStateNotFoundResponse(v) || isVersionNotSupportedResponse(v)) {
@@ -98,13 +81,5 @@ export function assertPullerResultV1(v: unknown): asserts v is PullerResultV1 {
   assertHTTPRequestInfo(v.httpRequestInfo);
   if (v.response !== undefined) {
     assertPullResponseV1(v.response);
-  }
-}
-
-export function assertPullerResultV0(v: unknown): asserts v is PullerResultV0 {
-  assertObject(v);
-  assertHTTPRequestInfo(v.httpRequestInfo);
-  if (v.response !== undefined) {
-    assertPullResponseV0(v.response);
   }
 }

--- a/packages/replicache/src/mod.ts
+++ b/packages/replicache/src/mod.ts
@@ -46,14 +46,7 @@ export {
   dropDatabase,
   type DropDatabaseOptions,
 } from './persist/collect-idb-databases.js';
-export type {
-  Puller,
-  PullerResult,
-  PullerResultV1,
-  PullResponse,
-  PullResponseOKV1,
-  PullResponseV1,
-} from './puller.js';
+export type {Puller, PullerResult, PullResponse} from './puller.js';
 export type {Pusher, PusherResult, PushError, PushResponse} from './pusher.js';
 export type {ReplicacheOptions} from './replicache-options.js';
 export {makeIDBName, Replicache} from './replicache.js';

--- a/packages/replicache/src/mod.ts
+++ b/packages/replicache/src/mod.ts
@@ -47,19 +47,16 @@ export {
   type DropDatabaseOptions,
 } from './persist/collect-idb-databases.js';
 export type {
-  PullResponse,
-  PullResponseOKV0,
-  PullResponseOKV1,
-  PullResponseV0,
-  PullResponseV1,
   Puller,
   PullerResult,
-  PullerResultV0,
   PullerResultV1,
+  PullResponse,
+  PullResponseOKV1,
+  PullResponseV1,
 } from './puller.js';
-export type {PushError, PushResponse, Pusher, PusherResult} from './pusher.js';
+export type {Pusher, PusherResult, PushError, PushResponse} from './pusher.js';
 export type {ReplicacheOptions} from './replicache-options.js';
-export {Replicache, makeIDBName} from './replicache.js';
+export {makeIDBName, Replicache} from './replicache.js';
 export {makeScanResult} from './scan-iterator.js';
 export type {
   AsyncIterableIteratorToArray,
@@ -86,7 +83,7 @@ export type {
 } from './subscriptions.js';
 export type {ClientGroupID, ClientID} from './sync/ids.js';
 export {PullError} from './sync/pull-error.js';
-export type {PullRequest, PullRequestV0, PullRequestV1} from './sync/pull.js';
+export type {PullRequest, PullRequestV1} from './sync/pull.js';
 export type {
   MutationV0,
   MutationV1,

--- a/packages/replicache/src/mod.ts
+++ b/packages/replicache/src/mod.ts
@@ -76,14 +76,8 @@ export type {
 } from './subscriptions.js';
 export type {ClientGroupID, ClientID} from './sync/ids.js';
 export {PullError} from './sync/pull-error.js';
-export type {PullRequest, PullRequestV1} from './sync/pull.js';
-export type {
-  MutationV0,
-  MutationV1,
-  PushRequest,
-  PushRequestV0,
-  PushRequestV1,
-} from './sync/push.js';
+export type {PullRequest} from './sync/pull.js';
+export type {Mutation, PushRequest} from './sync/push.js';
 export {TEST_LICENSE_KEY} from './test-license-key.js';
 export {TransactionClosedError} from './transaction-closed-error.js';
 export type {

--- a/packages/replicache/src/puller.ts
+++ b/packages/replicache/src/puller.ts
@@ -1,4 +1,3 @@
-import type {ReadonlyJSONValue} from '../../shared/src/json.js';
 import type {Cookie} from './cookies.js';
 import type {
   ClientStateNotFoundResponse,
@@ -12,11 +11,6 @@ import type {
 import type {ClientID} from './sync/ids.js';
 import type {PullRequest} from './sync/pull.js';
 
-export type PullerResultV0 = {
-  response?: PullResponseV0 | undefined;
-  httpRequestInfo: HTTPRequestInfo;
-};
-
 // TODO(arv): Does it really make sense to call this httpRequestInfo? It is
 // really the response status code and error message!
 
@@ -25,7 +19,7 @@ export type PullerResultV1 = {
   httpRequestInfo: HTTPRequestInfo;
 };
 
-export type PullerResult = PullerResultV1 | PullerResultV0;
+export type PullerResult = PullerResultV1;
 
 /**
  * Puller is the function type used to do the fetch part of a pull.
@@ -41,15 +35,6 @@ export type Puller = (
   requestBody: PullRequest,
   requestID: string,
 ) => Promise<PullerResult>;
-
-/**
- * The shape of a pull response under normal circumstances.
- */
-export type PullResponseOKV0 = {
-  cookie?: ReadonlyJSONValue | undefined;
-  lastMutationID: number;
-  patch: PatchOperation[];
-};
 
 /**
  * The shape of a pull response under normal circumstances.
@@ -74,15 +59,6 @@ export type PullResponseOKV1Internal = {
  * PullResponse defines the shape and type of the response of a pull. This is
  * the JSON you should return from your pull server endpoint.
  */
-export type PullResponseV0 =
-  | PullResponseOKV0
-  | ClientStateNotFoundResponse
-  | VersionNotSupportedResponse;
-
-/**
- * PullResponse defines the shape and type of the response of a pull. This is
- * the JSON you should return from your pull server endpoint.
- */
 export type PullResponseV1 =
   | PullResponseOKV1
   | ClientStateNotFoundResponse
@@ -93,4 +69,4 @@ export type PullResponseV1Internal =
   | ClientStateNotFoundResponse
   | VersionNotSupportedResponse;
 
-export type PullResponse = PullResponseV1 | PullResponseV0;
+export type PullResponse = PullResponseV1;

--- a/packages/replicache/src/sync/pull.test.ts
+++ b/packages/replicache/src/sync/pull.test.ts
@@ -29,20 +29,15 @@ import {
 } from '../error-responses.js';
 import * as FormatVersion from '../format-version-enum.js';
 import {type FrozenJSONValue, deepFreeze} from '../frozen-json.js';
-import {
-  assertPullResponseV0,
-  assertPullResponseV1,
-} from '../get-default-puller.js';
+import {assertPullResponseV1} from '../get-default-puller.js';
 import {assertHash, emptyHash, fakeHash} from '../hash.js';
 import type {HTTPRequestInfo} from '../http-request-info.js';
 import type {IndexDefinitions} from '../index-defs.js';
 import type {PatchOperation} from '../patch-operation.js';
 import type {
   PullResponseOKV1,
-  PullResponseV0,
   PullResponseV1,
   Puller,
-  PullerResultV0,
   PullerResultV1,
 } from '../puller.js';
 import {testSubscriptionsManagerOptions} from '../test-util.js';
@@ -56,7 +51,6 @@ import * as HandlePullResponseResultEnum from './handle-pull-response-result-typ
 import {
   type BeginPullResponseV1,
   PULL_VERSION_DD31,
-  type PullRequestV0,
   type PullRequestV1,
   beginPullV1,
   handlePullResponseV1,
@@ -784,18 +778,18 @@ describe('maybe end try pull', () => {
 });
 
 type FakePullerArgs = {
-  expPullReq: PullRequestV1 | PullRequestV0;
+  expPullReq: PullRequestV1;
   expRequestID: string;
-  resp?: PullResponseV1 | PullResponseV0 | undefined;
+  resp?: PullResponseV1 | undefined;
   err?: string | undefined;
 };
 
 function makeFakePuller(options: FakePullerArgs): Puller {
   return async (
-    pullReq: PullRequestV1 | PullRequestV0,
+    pullReq: PullRequestV1,
     requestID: string,
     // eslint-disable-next-line require-await
-  ): Promise<PullerResultV1 | PullerResultV0> => {
+  ): Promise<PullerResultV1> => {
     expect(options.expPullReq).to.deep.equal(pullReq);
     expect(options.expRequestID).to.equal(requestID);
 
@@ -832,15 +826,8 @@ function makeFakePuller(options: FakePullerArgs): Puller {
       };
     }
 
-    if (isPullRequestV1(options.expPullReq)) {
-      assertPullResponseV1(resp);
-      return {
-        response: resp,
-        httpRequestInfo,
-      };
-    }
-
-    assertPullResponseV0(resp);
+    assert(isPullRequestV1(options.expPullReq));
+    assertPullResponseV1(resp);
     return {
       response: resp,
       httpRequestInfo,

--- a/packages/replicache/src/sync/push.ts
+++ b/packages/replicache/src/sync/push.ts
@@ -31,24 +31,6 @@ export const PUSH_VERSION_SDD = 0;
 export const PUSH_VERSION_DD31 = 1;
 
 /**
- * Mutation describes a single mutation done on the client. This is the legacy
- * version (V0) and it is used when recovering mutations from old clients.
- */
-export type MutationV0 = {
-  readonly id: number;
-  readonly name: string;
-  readonly args: ReadonlyJSONValue;
-  readonly timestamp: number;
-};
-
-const mutationV0Schema: valita.Type<MutationV0> = valita.readonlyObject({
-  id: valita.number(),
-  name: valita.string(),
-  args: jsonSchema,
-  timestamp: valita.number(),
-});
-
-/**
  * Mutation describes a single mutation done on the client.
  */
 export type MutationV1 = {
@@ -59,43 +41,14 @@ export type MutationV1 = {
   readonly clientID: ClientID;
 };
 
+export type Mutation = MutationV1;
+
 const mutationV1Schema: valita.Type<MutationV1> = valita.readonlyObject({
   id: valita.number(),
   name: valita.string(),
   args: jsonSchema,
   timestamp: valita.number(),
   clientID: clientIDSchema,
-});
-
-type FrozenMutationV0 = Omit<MutationV0, 'args'> & {
-  readonly args: FrozenJSONValue;
-};
-
-/**
- * The JSON value used as the body when doing a POST to the [push
- * endpoint](/reference/server-push). This is the legacy version (V0) and it is
- * still used when recovering mutations from old clients.
- */
-export type PushRequestV0 = {
-  pushVersion: 0;
-  /**
-   * `schemaVersion` can optionally be used to specify to the push endpoint
-   * version information about the mutators the app is using (e.g., format of
-   * mutator args).
-   */
-  schemaVersion: string;
-  profileID: string;
-
-  clientID: ClientID;
-  mutations: MutationV0[];
-};
-
-const pushRequestV0Schema: valita.Type<PushRequestV0> = valita.object({
-  pushVersion: valita.literal(0),
-  schemaVersion: valita.string(),
-  profileID: valita.string(),
-  clientID: clientIDSchema,
-  mutations: valita.array(mutationV0Schema),
 });
 
 /**
@@ -124,13 +77,7 @@ const pushRequestV1Schema = valita.object({
   mutations: valita.array(mutationV1Schema),
 });
 
-export type PushRequest = PushRequestV0 | PushRequestV1;
-
-export function assertPushRequestV0(
-  value: unknown,
-): asserts value is PushRequestV0 {
-  valita.assert(value, pushRequestV0Schema);
-}
+export type PushRequest = PushRequestV1;
 
 export function assertPushRequestV1(
   value: unknown,
@@ -141,7 +88,11 @@ export function assertPushRequestV1(
 /**
  * Mutation describes a single mutation done on the client.
  */
-type FrozenMutationV1 = FrozenMutationV0 & {
+type FrozenMutationV1 = {
+  readonly id: number;
+  readonly name: string;
+  readonly args: FrozenJSONValue;
+  readonly timestamp: number;
   readonly clientID: ClientID;
 };
 
@@ -213,7 +164,7 @@ export async function push(
 
 async function callPusher(
   pusher: Pusher,
-  body: PushRequestV0 | PushRequestV1,
+  body: PushRequestV1,
   requestID: string,
 ): Promise<PusherResult> {
   let pusherResult: PusherResult;

--- a/packages/zero-client/src/client/zero-rate.test.ts
+++ b/packages/zero-client/src/client/zero-rate.test.ts
@@ -1,6 +1,6 @@
 import * as sinon from 'sinon';
 import {afterEach, beforeEach, expect, test} from 'vitest';
-import type {PushRequestV1} from '../../../replicache/src/mod.js';
+import type {PushRequest} from '../../../replicache/src/sync/push.js';
 import {ErrorKind} from '../../../zero-protocol/src/error.js';
 import type {Mutation} from '../../../zero-protocol/src/push.js';
 import {MockSocket, tickAFewTimes, zeroForTest} from './test-utils.js';
@@ -29,7 +29,7 @@ test('connection stays alive on rate limit error', async () => {
 
   const mockSocket = await z.socket;
 
-  const pushReq: PushRequestV1 = {
+  const pushReq: PushRequest = {
     profileID: 'p1',
     clientGroupID: await z.clientGroupID,
     pushVersion: 1,

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -2,11 +2,9 @@ import {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
 import * as sinon from 'sinon';
 import {afterEach, beforeEach, expect, suite, test} from 'vitest';
-import type {
-  PullRequestV1,
-  PushRequestV1,
-} from '../../../replicache/src/mod.js';
 import type {ReplicacheImpl} from '../../../replicache/src/replicache-impl.js';
+import type {PullRequest} from '../../../replicache/src/sync/pull.js';
+import type {PushRequest} from '../../../replicache/src/sync/push.js';
 import {assert} from '../../../shared/src/asserts.js';
 import {TestLogSink} from '../../../shared/src/logging-test-utils.js';
 import * as valita from '../../../shared/src/valita.js';
@@ -19,6 +17,7 @@ import {
   initConnectionMessageSchema,
   type QueriesPatchOp,
 } from '../../../zero-protocol/src/mod.js';
+import {PROTOCOL_VERSION} from '../../../zero-protocol/src/protocol-version.js';
 import {
   type Mutation,
   MutationType,
@@ -49,7 +48,6 @@ import {
   PULL_TIMEOUT_MS,
   RUN_LOOP_INTERVAL_MS,
 } from './zero.js';
-import {PROTOCOL_VERSION} from '../../../zero-protocol/src/protocol-version.js';
 
 let realSetTimeout: typeof setTimeout;
 let clock: sinon.SinonFakeTimers;
@@ -767,7 +765,7 @@ test('pusher sends one mutation per push message', async () => {
         requestID = 'test-request-id',
       } = push;
 
-      const pushReq: PushRequestV1 = {
+      const pushReq: PushRequest = {
         profileID: 'p1',
         clientGroupID: clientGroupID ?? (await r.clientGroupID),
         pushVersion: 1,
@@ -982,7 +980,7 @@ test('pusher adjusts mutation timestamps to be unix timestamps', async () => {
   ];
   const requestID = 'test-request-id';
 
-  const pushReq: PushRequestV1 = {
+  const pushReq: PushRequest = {
     profileID: 'p1',
     clientGroupID: await r.clientGroupID,
     pushVersion: 1,
@@ -1013,7 +1011,7 @@ test('puller with mutation recovery pull, success response', async () => {
 
   const mockSocket = await r.socket;
 
-  const pullReq: PullRequestV1 = {
+  const pullReq: PullRequest = {
     profileID: 'test-profile-id',
     clientGroupID: 'test-client-group-id',
     cookie: '1',
@@ -1062,7 +1060,7 @@ test('puller with mutation recovery pull, response timeout', async () => {
 
   const mockSocket = await r.socket;
 
-  const pullReq: PullRequestV1 = {
+  const pullReq: PullRequest = {
     profileID: 'test-profile-id',
     clientGroupID: 'test-client-group-id',
     cookie: '1',
@@ -1097,7 +1095,7 @@ test('puller with mutation recovery pull, response timeout', async () => {
 
 test('puller with normal non-mutation recovery pull', async () => {
   const r = zeroForTest();
-  const pullReq: PullRequestV1 = {
+  const pullReq: PullRequest = {
     profileID: 'test-profile-id',
     clientGroupID: await r.clientGroupID,
     cookie: '1',
@@ -1598,7 +1596,7 @@ async function testWaitsForConnection(
 
 test('pusher waits for connection', async () => {
   await testWaitsForConnection(async r => {
-    const pushReq: PushRequestV1 = {
+    const pushReq: PushRequest = {
       profileID: 'p1',
       clientGroupID: await r.clientGroupID,
       pushVersion: 1,
@@ -1611,7 +1609,7 @@ test('pusher waits for connection', async () => {
 
 test('puller waits for connection', async () => {
   await testWaitsForConnection(r => {
-    const pullReq: PullRequestV1 = {
+    const pullReq: PullRequest = {
       profileID: 'test-profile-id',
       clientGroupID: 'test-client-group-id',
       cookie: 1,

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -9,12 +9,10 @@ import {
   type ClientID,
   type ExperimentalNoIndexDiff,
   type MutatorDefs,
-  type PullRequestV0,
-  type PullRequestV1,
+  type PullRequest,
   type Puller,
-  type PullerResultV1,
-  type PushRequestV0,
-  type PushRequestV1,
+  type PullerResult,
+  type PushRequest,
   type Pusher,
   type PusherResult,
   type ReplicacheOptions,
@@ -1109,10 +1107,7 @@ export class Zero<const S extends Schema> {
     resolver.resolve(pullResponseMessage[1]);
   }
 
-  async #pusher(
-    req: PushRequestV0 | PushRequestV1,
-    requestID: string,
-  ): Promise<PusherResult> {
+  async #pusher(req: PushRequest, requestID: string): Promise<PusherResult> {
     // The deprecation of pushVersion 0 predates zero-client
     assert(req.pushVersion === 1);
     // If we are connecting we wait until we are connected.
@@ -1407,10 +1402,7 @@ export class Zero<const S extends Schema> {
     }
   }
 
-  async #puller(
-    req: PullRequestV0 | PullRequestV1,
-    requestID: string,
-  ): Promise<PullerResultV1> {
+  async #puller(req: PullRequest, requestID: string): Promise<PullerResult> {
     // The deprecation of pushVersion 0 predates zero-client
     assert(req.pullVersion === 1);
     const lc = this.#lc.withContext('requestID', requestID);


### PR DESCRIPTION
BREAKING CHANGE!

This removes support for the old pull and push formats.

 - PullResponseOKV0
 - PullResponseV0
 - PullerResultV0
 - MutationV0
 - PushRequestV0

It also removes the V1 types in favor of the non versioned ones now that there is only one version.
