### PR TITLE
chore(zero-cache): add the commit watermark to "begin" messages

### DIFF
--- a/packages/zero-cache/src/services/change-source/protocol/current/control.ts
+++ b/packages/zero-cache/src/services/change-source/protocol/current/control.ts
@@ -6,27 +6,6 @@
 import * as v from '../../../../../../shared/src/valita.js';
 
 /**
- * Indicates that upstream has requested an acknowledgment from the ChangeStreamer,
- * often referred to as a heartbeat or keepalive message. The ChangeStreamer responds
- * to these messages immediately.
- */
-export const ackRequestedSchema = v.object({
-  tag: v.literal('ack-requested'),
-
-  /**
-   * If specified, indicates the latest watermark on upstream, which may encompass
-   * changes that are unrelated to the ChangeStreamer's subscription. If the
-   * ChangeStreamer has consumed and acked all of its data messages, it will include
-   * this watermark in its acknowledgment to indicate that it is caught up and
-   * upstream can purge its logs up to that watermark. If, on the other hand, it is
-   * still processing data messages, it will acknowledge immediately without a
-   * watermark to indicate that it is still "alive" but upstream logs still need to
-   * be preserved.
-   */
-  latestUpstreamWatermark: v.string().optional(),
-});
-
-/**
  * Indicates that replication cannot continue and that the replica must be resynced
  * from scratch. The replication-manager will shutdown in response to this message,
  * and upon being restarted, it will wipe the current replica and resync if the

--- a/packages/zero-cache/src/services/change-source/protocol/current/downstream.ts
+++ b/packages/zero-cache/src/services/change-source/protocol/current/downstream.ts
@@ -7,7 +7,15 @@ import {
   rollbackSchema,
 } from './data.js';
 
-const begin = v.tuple([v.literal('begin'), beginSchema]);
+const begin = v.union(
+  // TODO: Migrate to the commitWatermark containing schema.
+  v.tuple([v.literal('begin'), beginSchema]),
+  v.tuple([
+    v.literal('begin'),
+    beginSchema,
+    v.object({commitWatermark: v.string()}),
+  ]),
+);
 const data = v.tuple([v.literal('data'), dataChangeSchema]);
 const commit = v.tuple([
   v.literal('commit'),

--- a/packages/zero-cache/src/services/change-source/protocol/version.test.ts
+++ b/packages/zero-cache/src/services/change-source/protocol/version.test.ts
@@ -38,6 +38,9 @@ test('protocol versions', () => {
   // Then update the version number of the `CHANGE_SOURCE_PATH`
   // in current and export it appropriately as the new version
   // in `mod.ts`.
-  t(current, '1wkotqe19ed3k', '/changes/v0/stream');
-  t(v0, '1wkotqe19ed3k', '/changes/v0/stream');
+  t(current, '2knq376164laf', '/changes/v0/stream');
+  // During initial development, we use v0 as a non-stable
+  // version (i.e. breaking change are allowed). Once the
+  // protocol graduates to v1, versions must be stable.
+  t(v0, '2knq376164laf', '/changes/v0/stream');
 });


### PR DESCRIPTION
The first step in migrating to replica schema v2 (https://bugs.rocicorp.dev/issue/3404).

The ChangeSource and ChangeStreamer now use the `commitLSN` for the `commitWatermark` of `begin` messages and the `watermark` of `commit` messages. The former are not used yet, but will be in a subsequent step. 