### PR TITLE
prod(sandbox): adjust connection parameters for aurora-based CVR db

### DIFF
--- a/packages/zero-cache/src/types/pg.ts
+++ b/packages/zero-cache/src/types/pg.ts
@@ -186,8 +186,8 @@ export function pgClient(
   return postgres(connectionURI, {
     ...postgresTypeConfig(),
     onnotice,
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    max_lifetime: maxLifetimeSeconds,
+    ['max_lifetime']: maxLifetimeSeconds,
+    ['connect_timeout']: 60, // scale-from-zero dbs need more than 30 seconds
     ssl: ssl === 'disable' || ssl === 'false' ? false : (ssl as 'prefer'),
     ...options,
   });

--- a/prod/templates/sandbox/template.yml
+++ b/prod/templates/sandbox/template.yml
@@ -203,8 +203,8 @@ Resources:
               # limit: 190 max_connections / (10 tasks * 1.2 maximum-percent)
               Value: 15
             - Name: ZERO_CVR_MAX_CONNS
-              # limit: 5000 max_connections / (10 tasks * 1.2 maximum-percent)
-              Value: 400
+              # limit: 2000 max_connections / (10 tasks * 1.2 maximum-percent)
+              Value: 160
             - Name: ZERO_SCHEMA_FILE
               Value: /opt/app/packages/zero-cache/zero-schema.json
           Secrets:


### PR DESCRIPTION
Adjust connection counts to fit into the `max_connections` of 2000, and increase the connect timeout to handle slow startup when scaling from zero.