### PR TITLE
chore(zero-cache): finish migration of change protocol to include commit watermarks

### DIFF
--- a/packages/zero-cache/src/services/change-source/protocol/current/downstream.ts
+++ b/packages/zero-cache/src/services/change-source/protocol/current/downstream.ts
@@ -7,15 +7,11 @@ import {
   rollbackSchema,
 } from './data.js';
 
-const begin = v.union(
-  // TODO: Migrate to the commitWatermark containing schema.
-  v.tuple([v.literal('begin'), beginSchema]),
-  v.tuple([
-    v.literal('begin'),
-    beginSchema,
-    v.object({commitWatermark: v.string()}),
-  ]),
-);
+const begin = v.tuple([
+  v.literal('begin'),
+  beginSchema,
+  v.object({commitWatermark: v.string()}),
+]);
 const data = v.tuple([v.literal('data'), dataChangeSchema]);
 const commit = v.tuple([
   v.literal('commit'),

--- a/packages/zero-cache/src/services/change-source/protocol/version.test.ts
+++ b/packages/zero-cache/src/services/change-source/protocol/version.test.ts
@@ -38,9 +38,9 @@ test('protocol versions', () => {
   // Then update the version number of the `CHANGE_SOURCE_PATH`
   // in current and export it appropriately as the new version
   // in `mod.ts`.
-  t(current, '2knq376164laf', '/changes/v0/stream');
+  t(current, 'r7gl2fs37kac', '/changes/v0/stream');
   // During initial development, we use v0 as a non-stable
   // version (i.e. breaking change are allowed). Once the
   // protocol graduates to v1, versions must be stable.
-  t(v0, '2knq376164laf', '/changes/v0/stream');
+  t(v0, 'r7gl2fs37kac', '/changes/v0/stream');
 });

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.test.ts
@@ -112,11 +112,11 @@ describe('change-streamer/http', () => {
     } as const;
     const sub = await client.subscribe(ctx);
 
-    downstream.push(['begin', {tag: 'begin'}]);
+    downstream.push(['begin', {tag: 'begin'}, {commitWatermark: '456'}]);
     downstream.push(['commit', {tag: 'commit'}, {watermark: '456'}]);
 
     expect(await drain(2, sub)).toEqual([
-      ['begin', {tag: 'begin'}],
+      ['begin', {tag: 'begin'}, {commitWatermark: '456'}],
       ['commit', {tag: 'commit'}, {watermark: '456'}],
     ]);
 

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg-test.ts
@@ -120,7 +120,7 @@ describe('change-streamer/service', () => {
     });
     const downstream = drainToQueue(sub);
 
-    changes.push(['begin', messages.begin()]);
+    changes.push(['begin', messages.begin(), {commitWatermark: '09'}]);
     changes.push(['data', messages.insert('foo', {id: 'hello'})]);
     changes.push(['data', messages.insert('foo', {id: 'world'})]);
     changes.push([
@@ -159,7 +159,7 @@ describe('change-streamer/service', () => {
 
   test('subscriber catchup and continuation', async () => {
     // Process some changes upstream.
-    changes.push(['begin', messages.begin()]);
+    changes.push(['begin', messages.begin(), {commitWatermark: '09'}]);
     changes.push(['data', messages.insert('foo', {id: 'hello'})]);
     changes.push(['data', messages.insert('foo', {id: 'world'})]);
     changes.push([
@@ -178,7 +178,7 @@ describe('change-streamer/service', () => {
     });
 
     // Process more upstream changes.
-    changes.push(['begin', messages.begin()]);
+    changes.push(['begin', messages.begin(), {commitWatermark: '0b'}]);
     changes.push(['data', messages.delete('foo', {id: 'world'})]);
     changes.push([
       'commit',
@@ -231,7 +231,7 @@ describe('change-streamer/service', () => {
 
   test('subscriber catchup and continuation after rollback', async () => {
     // Process some changes upstream.
-    changes.push(['begin', messages.begin()]);
+    changes.push(['begin', messages.begin(), {commitWatermark: '09'}]);
     changes.push(['data', messages.insert('foo', {id: 'hello'})]);
     changes.push(['data', messages.insert('foo', {id: 'world'})]);
     changes.push([
@@ -250,7 +250,7 @@ describe('change-streamer/service', () => {
     });
 
     // Process more upstream changes.
-    changes.push(['begin', messages.begin()]);
+    changes.push(['begin', messages.begin(), {commitWatermark: '0a'}]);
     changes.push(['data', messages.delete('foo', {id: 'world'})]);
     changes.push(['rollback', messages.rollback()]);
 
@@ -301,7 +301,7 @@ describe('change-streamer/service', () => {
     });
     const downstream = drainToQueue(sub);
 
-    changes.push(['begin', messages.begin()]);
+    changes.push(['begin', messages.begin(), {commitWatermark: '09'}]);
     changes.push([
       'data',
       messages.insert('foo', {
@@ -656,7 +656,7 @@ describe('change-streamer/service', () => {
     await changeDB`INSERT INTO cdc."changeLog" (watermark, pos, change)
       VALUES ('03', 0, ${{intervening: 'entry'}})`;
 
-    changes.push(['begin', messages.begin()]);
+    changes.push(['begin', messages.begin(), {commitWatermark: '05'}]);
     changes.push(['data', messages.insert('foo', {id: 'hello'})]);
     changes.push(['data', messages.insert('foo', {id: 'world'})]);
     changes.push(['commit', messages.commit(), {watermark: '05'}]);

--- a/packages/zero-cache/src/services/change-streamer/forwarder.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/forwarder.test.ts
@@ -15,12 +15,18 @@ describe('change-streamer/forwarder', () => {
     const [sub4, stream4] = createSubscriber('00', true);
 
     forwarder.add(sub1);
-    forwarder.forward(['11', ['begin', messages.begin()]]);
+    forwarder.forward([
+      '11',
+      ['begin', messages.begin(), {commitWatermark: '13'}],
+    ]);
     forwarder.add(sub2);
     forwarder.forward(['12', ['data', messages.truncate('issues')]]);
     forwarder.forward(['13', ['commit', messages.commit(), {watermark: '13'}]]);
     forwarder.add(sub3);
-    forwarder.forward(['14', ['begin', messages.begin()]]);
+    forwarder.forward([
+      '14',
+      ['begin', messages.begin(), {commitWatermark: '15'}],
+    ]);
     forwarder.add(sub4);
 
     for (const sub of [sub1, sub2, sub3, sub4]) {
@@ -34,6 +40,9 @@ describe('change-streamer/forwarder', () => {
           "begin",
           {
             "tag": "begin",
+          },
+          {
+            "commitWatermark": "13",
           },
         ],
         [
@@ -67,6 +76,9 @@ describe('change-streamer/forwarder', () => {
           {
             "tag": "begin",
           },
+          {
+            "commitWatermark": "15",
+          },
         ],
       ]
     `);
@@ -80,6 +92,9 @@ describe('change-streamer/forwarder', () => {
           {
             "tag": "begin",
           },
+          {
+            "commitWatermark": "15",
+          },
         ],
       ]
     `);
@@ -89,6 +104,9 @@ describe('change-streamer/forwarder', () => {
           "begin",
           {
             "tag": "begin",
+          },
+          {
+            "commitWatermark": "15",
           },
         ],
       ]
@@ -107,12 +125,18 @@ describe('change-streamer/forwarder', () => {
     const [sub4, stream4] = createSubscriber('00', true);
 
     forwarder.add(sub1);
-    forwarder.forward(['11', ['begin', messages.begin()]]);
+    forwarder.forward([
+      '11',
+      ['begin', messages.begin(), {commitWatermark: '14'}],
+    ]);
     forwarder.add(sub2);
     forwarder.forward(['12', ['data', messages.truncate('issues')]]);
     forwarder.forward(['13', ['rollback', messages.rollback()]]);
     forwarder.add(sub3);
-    forwarder.forward(['14', ['begin', messages.begin()]]);
+    forwarder.forward([
+      '14',
+      ['begin', messages.begin(), {commitWatermark: '15'}],
+    ]);
     forwarder.add(sub4);
 
     for (const sub of [sub1, sub2, sub3, sub4]) {
@@ -126,6 +150,9 @@ describe('change-streamer/forwarder', () => {
           "begin",
           {
             "tag": "begin",
+          },
+          {
+            "commitWatermark": "14",
           },
         ],
         [
@@ -156,6 +183,9 @@ describe('change-streamer/forwarder', () => {
           {
             "tag": "begin",
           },
+          {
+            "commitWatermark": "15",
+          },
         ],
       ]
     `);
@@ -169,6 +199,9 @@ describe('change-streamer/forwarder', () => {
           {
             "tag": "begin",
           },
+          {
+            "commitWatermark": "15",
+          },
         ],
       ]
     `);
@@ -178,6 +211,9 @@ describe('change-streamer/forwarder', () => {
           "begin",
           {
             "tag": "begin",
+          },
+          {
+            "commitWatermark": "15",
           },
         ],
       ]

--- a/packages/zero-cache/src/services/change-streamer/storer.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.pg-test.ts
@@ -108,7 +108,7 @@ describe('change-streamer/storer', () => {
     const [sub, _, stream] = createSubscriber('00');
 
     // This should be buffered until catchup is complete.
-    sub.send(['07', ['begin', messages.begin()]]);
+    sub.send(['07', ['begin', messages.begin(), {commitWatermark: '08'}]]);
     sub.send(['08', ['commit', messages.commit(), {watermark: '08'}]]);
 
     // Catchup should start immediately since there are no txes in progress.
@@ -121,6 +121,9 @@ describe('change-streamer/storer', () => {
           {
             "foo": "bar",
             "tag": "begin",
+          },
+          {
+            "commitWatermark": "02",
           },
         ],
         [
@@ -145,6 +148,9 @@ describe('change-streamer/storer', () => {
             "boo": "dar",
             "tag": "begin",
           },
+          {
+            "commitWatermark": "04",
+          },
         ],
         [
           "data",
@@ -166,6 +172,9 @@ describe('change-streamer/storer', () => {
           "begin",
           {
             "tag": "begin",
+          },
+          {
+            "commitWatermark": "08",
           },
         ],
         [
@@ -218,19 +227,19 @@ describe('change-streamer/storer', () => {
     const [sub2, _1, stream2] = createSubscriber('06');
 
     // This should be buffered until catchup is complete.
-    sub1.send(['09', ['begin', messages.begin()]]);
+    sub1.send(['09', ['begin', messages.begin(), {commitWatermark: '0a'}]]);
     sub1.send([
       '0a',
       ['commit', messages.commit({buffer: 'me'}), {watermark: '0a'}],
     ]);
-    sub2.send(['09', ['begin', messages.begin()]]);
+    sub2.send(['09', ['begin', messages.begin(), {commitWatermark: '0a'}]]);
     sub2.send([
       '0a',
       ['commit', messages.commit({buffer: 'me'}), {watermark: '0a'}],
     ]);
 
     // Start a transaction before enqueuing catchup.
-    storer.store(['07', ['begin', messages.begin()]]);
+    storer.store(['07', ['begin', messages.begin(), {commitWatermark: '08'}]]);
     // Enqueue catchup before transaction completes.
     storer.catchup(sub1);
     storer.catchup(sub2);
@@ -249,6 +258,9 @@ describe('change-streamer/storer', () => {
           {
             "boo": "dar",
             "tag": "begin",
+          },
+          {
+            "commitWatermark": "04",
           },
         ],
         [
@@ -272,6 +284,9 @@ describe('change-streamer/storer', () => {
           {
             "tag": "begin",
           },
+          {
+            "commitWatermark": "07",
+          },
         ],
         [
           "commit",
@@ -287,6 +302,9 @@ describe('change-streamer/storer', () => {
           "begin",
           {
             "tag": "begin",
+          },
+          {
+            "commitWatermark": "0a",
           },
         ],
         [
@@ -311,6 +329,9 @@ describe('change-streamer/storer', () => {
           {
             "tag": "begin",
           },
+          {
+            "commitWatermark": "07",
+          },
         ],
         [
           "commit",
@@ -326,6 +347,9 @@ describe('change-streamer/storer', () => {
           "begin",
           {
             "tag": "begin",
+          },
+          {
+            "commitWatermark": "0a",
           },
         ],
         [
@@ -423,19 +447,19 @@ describe('change-streamer/storer', () => {
     const [sub2, _1, stream2] = createSubscriber('06');
 
     // This should be buffered until catchup is complete.
-    sub1.send(['09', ['begin', messages.begin()]]);
+    sub1.send(['09', ['begin', messages.begin(), {commitWatermark: '0a'}]]);
     sub1.send([
       '0a',
       ['commit', messages.commit({buffer: 'me'}), {watermark: '0a'}],
     ]);
-    sub2.send(['09', ['begin', messages.begin()]]);
+    sub2.send(['09', ['begin', messages.begin(), {commitWatermark: '0a'}]]);
     sub2.send([
       '0a',
       ['commit', messages.commit({buffer: 'me'}), {watermark: '0a'}],
     ]);
 
     // Start a transaction before enqueuing catchup.
-    storer.store(['07', ['begin', messages.begin()]]);
+    storer.store(['07', ['begin', messages.begin(), {commitWatermark: '08'}]]);
     // Enqueue catchup before transaction completes.
     storer.catchup(sub1);
     storer.catchup(sub2);
@@ -451,6 +475,9 @@ describe('change-streamer/storer', () => {
           {
             "boo": "dar",
             "tag": "begin",
+          },
+          {
+            "commitWatermark": "04",
           },
         ],
         [
@@ -474,6 +501,9 @@ describe('change-streamer/storer', () => {
           {
             "tag": "begin",
           },
+          {
+            "commitWatermark": "0a",
+          },
         ],
         [
           "commit",
@@ -496,6 +526,9 @@ describe('change-streamer/storer', () => {
           "begin",
           {
             "tag": "begin",
+          },
+          {
+            "commitWatermark": "0a",
           },
         ],
         [
@@ -574,14 +607,14 @@ describe('change-streamer/storer', () => {
     const [sub, _0, stream] = createSubscriber('03');
 
     // This should be buffered until catchup is complete.
-    sub.send(['0b', ['begin', messages.begin()]]);
+    sub.send(['0b', ['begin', messages.begin(), {commitWatermark: '0c'}]]);
     sub.send([
       '0c',
       ['commit', messages.commit({waa: 'hoo'}), {watermark: '0c'}],
     ]);
 
     // Start a transaction before enqueuing catchup.
-    storer.store(['07', ['begin', messages.begin()]]);
+    storer.store(['07', ['begin', messages.begin(), {commitWatermark: '08'}]]);
     // Enqueue catchup before transaction completes.
     storer.catchup(sub);
     // Finish the transaction.
@@ -593,7 +626,7 @@ describe('change-streamer/storer', () => {
     // And finish another the transaction. In reality, these would be
     // sent by the forwarder, but we skip it in the test to confirm that
     // catchup doesn't include the next transaction.
-    storer.store(['09', ['begin', messages.begin()]]);
+    storer.store(['09', ['begin', messages.begin(), {commitWatermark: '0a'}]]);
     storer.store(['0a', ['commit', messages.commit(), {watermark: '0a'}]]);
 
     // Wait for the storer to commit that transaction.
@@ -618,6 +651,9 @@ describe('change-streamer/storer', () => {
             "boo": "dar",
             "tag": "begin",
           },
+          {
+            "commitWatermark": "04",
+          },
         ],
         [
           "data",
@@ -640,6 +676,9 @@ describe('change-streamer/storer', () => {
           {
             "tag": "begin",
           },
+          {
+            "commitWatermark": "07",
+          },
         ],
         [
           "commit",
@@ -655,6 +694,9 @@ describe('change-streamer/storer', () => {
           "begin",
           {
             "tag": "begin",
+          },
+          {
+            "commitWatermark": "0c",
           },
         ],
         [
@@ -672,7 +714,7 @@ describe('change-streamer/storer', () => {
   });
 
   test('change positioning and replay detection', async () => {
-    storer.store(['07', ['begin', messages.begin()]]);
+    storer.store(['07', ['begin', messages.begin(), {commitWatermark: '09'}]]);
     storer.store(['08', ['data', messages.truncate('issues')]]);
     storer.store([
       '09',
@@ -685,7 +727,7 @@ describe('change-streamer/storer', () => {
     ]);
 
     // Simulate a replay.
-    storer.store(['07', ['begin', messages.begin()]]);
+    storer.store(['07', ['begin', messages.begin(), {commitWatermark: '09'}]]);
     storer.store(['08', ['data', messages.truncate('issues')]]);
     storer.store([
       '09',
@@ -699,7 +741,7 @@ describe('change-streamer/storer', () => {
     ]);
 
     // Continue to the next transaction.
-    storer.store(['0a', ['begin', messages.begin()]]);
+    storer.store(['0a', ['begin', messages.begin(), {commitWatermark: '0c'}]]);
     storer.store(['0b', ['data', messages.truncate('issues')]]);
     storer.store([
       '0c',

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -297,7 +297,7 @@ function toDownstream(entry: ChangeEntry): WatermarkedChange {
   const {watermark, change} = entry;
   switch (change.tag) {
     case 'begin':
-      return [watermark, ['begin', change]];
+      return [watermark, ['begin', change, {commitWatermark: watermark}]];
     case 'commit':
       return [watermark, ['commit', change, {watermark}]];
     case 'rollback':

--- a/packages/zero-cache/src/services/change-streamer/subscriber.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/subscriber.test.ts
@@ -9,17 +9,17 @@ describe('change-streamer/subscriber', () => {
     const [sub, stream] = createSubscriber('00');
 
     // Send some messages while it is catching up.
-    sub.send(['11', ['begin', messages.begin()]]);
+    sub.send(['11', ['begin', messages.begin(), {commitWatermark: '12'}]]);
     sub.send(['12', ['commit', messages.commit(), {watermark: '12'}]]);
 
     // Send catchup messages.
-    sub.catchup(['01', ['begin', messages.begin()]]);
+    sub.catchup(['01', ['begin', messages.begin(), {commitWatermark: '02'}]]);
     sub.catchup(['02', ['commit', messages.commit(), {watermark: '02'}]]);
 
     sub.setCaughtUp();
 
     // Send some messages after catchup.
-    sub.send(['21', ['begin', messages.begin()]]);
+    sub.send(['21', ['begin', messages.begin(), {commitWatermark: '22'}]]);
     sub.send(['22', ['commit', messages.commit(), {watermark: '22'}]]);
 
     sub.close();
@@ -30,6 +30,9 @@ describe('change-streamer/subscriber', () => {
           "begin",
           {
             "tag": "begin",
+          },
+          {
+            "commitWatermark": "02",
           },
         ],
         [
@@ -46,6 +49,9 @@ describe('change-streamer/subscriber', () => {
           {
             "tag": "begin",
           },
+          {
+            "commitWatermark": "12",
+          },
         ],
         [
           "commit",
@@ -60,6 +66,9 @@ describe('change-streamer/subscriber', () => {
           "begin",
           {
             "tag": "begin",
+          },
+          {
+            "commitWatermark": "22",
           },
         ],
         [
@@ -81,20 +90,20 @@ describe('change-streamer/subscriber', () => {
     // Technically, catchup should never send any messages if the subscriber
     // is ahead, since the watermark query would return no results. But pretend it
     // does just to ensure that catchup messages are subject to the filter.
-    sub.catchup(['01', ['begin', messages.begin()]]);
+    sub.catchup(['01', ['begin', messages.begin(), {commitWatermark: '02'}]]);
     sub.catchup(['02', ['commit', messages.commit(), {watermark: '02'}]]);
     sub.setCaughtUp();
 
     // Still lower than the watermark ...
-    sub.send(['121', ['begin', messages.begin()]]);
+    sub.send(['121', ['begin', messages.begin(), {commitWatermark: '123'}]]);
     sub.send(['123', ['commit', messages.commit(), {watermark: '123'}]]);
 
     // These should be sent.
-    sub.send(['124', ['begin', messages.begin()]]);
+    sub.send(['124', ['begin', messages.begin(), {commitWatermark: '125'}]]);
     sub.send(['125', ['commit', messages.commit(), {watermark: '125'}]]);
 
     // Replays should be ignored.
-    sub.send(['124', ['begin', messages.begin()]]);
+    sub.send(['124', ['begin', messages.begin(), {commitWatermark: '125'}]]);
     sub.send(['125', ['commit', messages.commit(), {watermark: '125'}]]);
 
     sub.close();
@@ -104,6 +113,9 @@ describe('change-streamer/subscriber', () => {
           "begin",
           {
             "tag": "begin",
+          },
+          {
+            "commitWatermark": "125",
           },
         ],
         [
@@ -123,20 +135,20 @@ describe('change-streamer/subscriber', () => {
     const [sub, _, receiver] = createSubscriber('00');
 
     // Send some messages while it is catching up.
-    sub.send(['11', ['begin', messages.begin()]]);
+    sub.send(['11', ['begin', messages.begin(), {commitWatermark: '12'}]]);
     sub.send(['12', ['commit', messages.commit(), {watermark: '12'}]]);
 
     // Send catchup messages.
-    sub.catchup(['01', ['begin', messages.begin()]]);
+    sub.catchup(['01', ['begin', messages.begin(), {commitWatermark: '02'}]]);
     sub.catchup(['02', ['commit', messages.commit(), {watermark: '02'}]]);
 
     sub.setCaughtUp();
 
     // Send some messages after catchup.
-    sub.send(['21', ['begin', messages.begin()]]);
+    sub.send(['21', ['begin', messages.begin(), {commitWatermark: '22'}]]);
     sub.send(['22', ['commit', messages.commit(), {watermark: '22'}]]);
 
-    sub.send(['31', ['begin', messages.begin()]]);
+    sub.send(['31', ['begin', messages.begin(), {commitWatermark: '31'}]]);
 
     expect(sub.acked).toBe('00');
 

--- a/packages/zero-cache/src/services/replicator/incremental-sync.pg-test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.pg-test.ts
@@ -94,12 +94,12 @@ describe('replicator/incremental-sync', () => {
       );
       `,
       downstream: [
-        ['begin', issues.begin()],
+        ['begin', issues.begin(), {commitWatermark: '06'}],
         ['data', issues.insert('issues', {issueID: 123, bool: true})],
         ['data', issues.insert('issues', {issueID: 456, bool: false})],
         ['commit', issues.commit(), {watermark: '06'}],
 
-        ['begin', issues.begin()],
+        ['begin', issues.begin(), {commitWatermark: '0b'}],
         [
           'data',
           issues.insert('issues', {
@@ -235,7 +235,7 @@ describe('replicator/incremental-sync', () => {
       );
       `,
       downstream: [
-        ['begin', orgIssues.begin()],
+        ['begin', orgIssues.begin(), {commitWatermark: '06'}],
         [
           'data',
           orgIssues.insert('issues', {orgID: 1, issueID: 123, bool: true}),
@@ -250,7 +250,7 @@ describe('replicator/incremental-sync', () => {
         ],
         ['commit', orgIssues.commit(), {watermark: '06'}],
 
-        ['begin', orgIssues.begin()],
+        ['begin', orgIssues.begin(), {commitWatermark: '0a'}],
         [
           'data',
           orgIssues.update('issues', {
@@ -340,7 +340,7 @@ describe('replicator/incremental-sync', () => {
       );
       `,
       downstream: [
-        ['begin', orgIssues.begin()],
+        ['begin', orgIssues.begin(), {commitWatermark: '07'}],
         [
           'data',
           orgIssues.insert('issues', {orgID: 1, issueID: 123, bool: true}),
@@ -359,7 +359,7 @@ describe('replicator/incremental-sync', () => {
         ],
         ['commit', orgIssues.commit(), {watermark: '07'}],
 
-        ['begin', orgIssues.begin()],
+        ['begin', orgIssues.begin(), {commitWatermark: '0c'}],
         [
           'data',
           orgIssues.delete('issues', {orgID: 1, issueID: 123, bool: true}),
@@ -420,7 +420,7 @@ describe('replicator/incremental-sync', () => {
       CREATE TABLE baz(id INTEGER PRIMARY KEY, _0_version TEXT);
       `,
       downstream: [
-        ['begin', fooBarBaz.begin()],
+        ['begin', fooBarBaz.begin(), {commitWatermark: '0e'}],
         ['data', fooBarBaz.insert('foo', {id: 1})],
         ['data', fooBarBaz.insert('foo', {id: 2})],
         ['data', fooBarBaz.insert('foo', {id: 3})],
@@ -434,7 +434,7 @@ describe('replicator/incremental-sync', () => {
         ['data', fooBarBaz.truncate('foo')], // Redundant. Shouldn't cause problems.
         ['commit', fooBarBaz.commit(), {watermark: '0e'}],
 
-        ['begin', fooBarBaz.begin()],
+        ['begin', fooBarBaz.begin(), {commitWatermark: '0i'}],
         ['data', fooBarBaz.truncate('foo')],
         ['data', fooBarBaz.insert('foo', {id: 101})],
         ['commit', fooBarBaz.commit(), {watermark: '0i'}],
@@ -498,7 +498,7 @@ describe('replicator/incremental-sync', () => {
       );
       `,
       downstream: [
-        ['begin', orgIssues.begin()],
+        ['begin', orgIssues.begin(), {commitWatermark: '07'}],
         ['data', tables.truncate('transaction')],
         [
           'data',
@@ -552,7 +552,7 @@ describe('replicator/incremental-sync', () => {
       );
       `,
       downstream: [
-        ['begin', orgIssues.begin()],
+        ['begin', orgIssues.begin(), {commitWatermark: '08'}],
         [
           'data',
           orgIssues.insert('issues', {orgID: 1, issueID: 123, bool: true}),
@@ -620,7 +620,7 @@ describe('replicator/incremental-sync', () => {
       name: 'create table',
       setup: ``,
       downstream: [
-        ['begin', fooBarBaz.begin()],
+        ['begin', fooBarBaz.begin(), {commitWatermark: '0e'}],
         [
           'data',
           fooBarBaz.createTable({
@@ -735,7 +735,7 @@ describe('replicator/incremental-sync', () => {
         INSERT INTO foo(id, _0_version) VALUES (3, '00');
       `,
       downstream: [
-        ['begin', fooBarBaz.begin()],
+        ['begin', fooBarBaz.begin(), {commitWatermark: '0e'}],
         ['data', fooBarBaz.renameTable('foo', 'bar')],
         ['data', fooBarBaz.insert('bar', {id: 4})],
         ['commit', fooBarBaz.commit(), {watermark: '0e'}],
@@ -801,7 +801,7 @@ describe('replicator/incremental-sync', () => {
         INSERT INTO foo(id, _0_version) VALUES (3, '00');
       `,
       downstream: [
-        ['begin', fooBarBaz.begin()],
+        ['begin', fooBarBaz.begin(), {commitWatermark: '0e'}],
         [
           'data',
           fooBarBaz.addColumn('foo', 'newInt', {
@@ -936,7 +936,7 @@ describe('replicator/incremental-sync', () => {
         INSERT INTO foo(id, dropMe, _0_version) VALUES (3, 'bye', '00');
       `,
       downstream: [
-        ['begin', fooBarBaz.begin()],
+        ['begin', fooBarBaz.begin(), {commitWatermark: '0e'}],
         ['data', fooBarBaz.update('foo', {id: 3, dropMe: 'stillDropped'})],
         ['data', fooBarBaz.dropColumn('foo', 'dropMe')],
         ['data', fooBarBaz.insert('foo', {id: 4})],
@@ -997,7 +997,7 @@ describe('replicator/incremental-sync', () => {
         INSERT INTO foo(id, renameMe, _0_version) VALUES (3, 'orl', '00');
       `,
       downstream: [
-        ['begin', fooBarBaz.begin()],
+        ['begin', fooBarBaz.begin(), {commitWatermark: '0e'}],
         ['data', fooBarBaz.update('foo', {id: 3, renameMe: 'olrd'})],
         [
           'data',
@@ -1073,7 +1073,7 @@ describe('replicator/incremental-sync', () => {
         INSERT INTO foo(id, renameMe, _0_version) VALUES (3, 'orl', '00');
       `,
       downstream: [
-        ['begin', fooBarBaz.begin()],
+        ['begin', fooBarBaz.begin(), {commitWatermark: '0e'}],
         ['data', fooBarBaz.update('foo', {id: 3, renameMe: 'olrd'})],
         [
           'data',
@@ -1155,7 +1155,7 @@ describe('replicator/incremental-sync', () => {
         INSERT INTO foo(id, num, _0_version) VALUES (3, '3', '00');
       `,
       downstream: [
-        ['begin', fooBarBaz.begin()],
+        ['begin', fooBarBaz.begin(), {commitWatermark: '0e'}],
         ['data', fooBarBaz.update('foo', {id: 3, num: '1'})],
         [
           'data',
@@ -1232,7 +1232,7 @@ describe('replicator/incremental-sync', () => {
         INSERT INTO foo(id, num, _0_version) VALUES (3, '0', '00');
       `,
       downstream: [
-        ['begin', fooBarBaz.begin()],
+        ['begin', fooBarBaz.begin(), {commitWatermark: '0e'}],
         ['data', fooBarBaz.update('foo', {id: 3, num: '1'})],
         [
           'data',
@@ -1320,7 +1320,7 @@ describe('replicator/incremental-sync', () => {
         INSERT INTO foo(id, numburr, _0_version) VALUES (3, '3', '00');
       `,
       downstream: [
-        ['begin', fooBarBaz.begin()],
+        ['begin', fooBarBaz.begin(), {commitWatermark: '0e'}],
         ['data', fooBarBaz.update('foo', {id: 3, numburr: '1'})],
         [
           'data',
@@ -1395,7 +1395,7 @@ describe('replicator/incremental-sync', () => {
         INSERT INTO foo(id, _0_version) VALUES (3, '00');
       `,
       downstream: [
-        ['begin', fooBarBaz.begin()],
+        ['begin', fooBarBaz.begin(), {commitWatermark: '0e'}],
         ['data', fooBarBaz.insert('foo', {id: 4})],
         ['data', fooBarBaz.dropTable('foo')],
         ['commit', fooBarBaz.commit(), {watermark: '0e'}],
@@ -1419,7 +1419,7 @@ describe('replicator/incremental-sync', () => {
         CREATE TABLE foo(id INT8 PRIMARY KEY, handle TEXT, _0_version TEXT);
       `,
       downstream: [
-        ['begin', fooBarBaz.begin()],
+        ['begin', fooBarBaz.begin(), {commitWatermark: '0e'}],
         [
           'data',
           fooBarBaz.createIndex({
@@ -1454,7 +1454,7 @@ describe('replicator/incremental-sync', () => {
         CREATE INDEX drop_me ON foo (handle DESC);
       `,
       downstream: [
-        ['begin', fooBarBaz.begin()],
+        ['begin', fooBarBaz.begin(), {commitWatermark: '0e'}],
         ['data', fooBarBaz.dropIndex('drop_me')],
         ['commit', fooBarBaz.commit(), {watermark: '0e'}],
       ],
@@ -1477,7 +1477,7 @@ describe('replicator/incremental-sync', () => {
       name: 'reserved words in DDL',
       setup: ``,
       downstream: [
-        ['begin', tables.begin()],
+        ['begin', tables.begin(), {commitWatermark: '0e'}],
         [
           'data',
           tables.createTable({

--- a/packages/zero-cache/src/services/replicator/test-utils.ts
+++ b/packages/zero-cache/src/services/replicator/test-utils.ts
@@ -33,7 +33,11 @@ export function fakeReplicator(lc: LogContext, db: Database): FakeReplicator {
   const messageProcessor = createMessageProcessor(db);
   return {
     processTransaction: (watermark, ...msgs) => {
-      messageProcessor.processMessage(lc, ['begin', {tag: 'begin'}]);
+      messageProcessor.processMessage(lc, [
+        'begin',
+        {tag: 'begin'},
+        {commitWatermark: watermark},
+      ]);
       for (const msg of msgs) {
         messageProcessor.processMessage(lc, ['data', msg]);
       }


### PR DESCRIPTION
This is a followup to #3513 to complete the migration of the change protocol to include commit watermarks in the `["begin", ... ]` message.

They are not used yet; this is just a protocol change, which had to be done in two steps because it is sent over the wire between `view-syncer`s and the `replication-manager`.