### PR TITLE
fix(zero): Do not "bundle" change-protocol

### DIFF
--- a/packages/zero/package.json
+++ b/packages/zero/package.json
@@ -93,7 +93,7 @@
     },
     "./change-protocol": {
       "types": "./out/zero-cache/src/services/change-source/protocol/mod.d.ts",
-      "default": "./out/change-protocol.js"
+      "default": "./out/zero-cache/src/services/change-source/protocol/mod.js"
     }
   },
   "bin": {

--- a/packages/zero/tool/build.js
+++ b/packages/zero/tool/build.js
@@ -108,7 +108,6 @@ async function buildZeroClient() {
         react: basePath('src/react.ts'),
         solid: basePath('src/solid.ts'),
         advanced: basePath('src/advanced.ts'),
-        ['change-protocol']: basePath('src/change-protocol.ts'),
       };
   const result = await esbuild.build({
     ...sharedOptions(minify, metafile),


### PR DESCRIPTION
The server part of zero is not bundled using esbuild. It is just compiled using tsc and the code structure maps the source code structure.

Followup to https://github.com/rocicorp/mono/pull/3491