### PR TITLE
fix(zero-cache): avoid unnecesarily running serving-copy

### DIFF
--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -127,7 +127,8 @@ export default async function runWorker(
 
   const syncers: Worker[] = [];
   if (numSyncers) {
-    const mode: ReplicaFileMode = litestream ? 'serving-copy' : 'serving';
+    const mode: ReplicaFileMode =
+      runChangeStreamer && litestream ? 'serving-copy' : 'serving';
     const replicator = loadWorker(
       './server/replicator.ts',
       'supporting',


### PR DESCRIPTION
Only run a replicator in "serving-copy" mode if running all of syncer, change-streamer, and litestream. (Essentially, only in dev). Production view-syncers need not make a copy since they are running litestream backup.