### PR TITLE
feat(zero-cache): replica schema v2

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/sync-schema.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/sync-schema.pg-test.ts
@@ -9,6 +9,7 @@ import {
 import {
   DbFile,
   expectTables as expectLiteTables,
+  expectMatchingObjectsInTables,
   initDB as initLiteDB,
 } from '../../../test/lite.js';
 import type {PostgresDB} from '../../../types/pg.js';
@@ -19,11 +20,12 @@ const SHARD_ID = 'sync_schema_test_id';
 
 // Update as necessary.
 const CURRENT_SCHEMA_VERSIONS = {
-  dataVersion: 1,
-  schemaVersion: 1,
+  dataVersion: 2,
+  schemaVersion: 2,
   minSafeVersion: 1,
   lock: 1, // Internal column, always 1
 };
+const WATERMARK_REGEX = /[0-9a-z]{4,}/;
 
 describe('change-streamer/pg/sync-schema', () => {
   type Case = {
@@ -55,7 +57,7 @@ describe('change-streamer/pg/sync-schema', () => {
             lock: 1,
             minSupportedVersion: 1,
             maxSupportedVersion: 1,
-            ['_0_version']: '00',
+            ['_0_version']: WATERMARK_REGEX,
           },
         ],
         ['_zero.versionHistory']: [CURRENT_SCHEMA_VERSIONS],
@@ -88,13 +90,13 @@ describe('change-streamer/pg/sync-schema', () => {
             lock: 1,
             minSupportedVersion: 1,
             maxSupportedVersion: 1,
-            ['_0_version']: '00',
+            ['_0_version']: WATERMARK_REGEX,
           },
         ],
         ['_zero.versionHistory']: [CURRENT_SCHEMA_VERSIONS],
         users: [
-          {userID: 123, handle: '@zoot', ['_0_version']: '00'},
-          {userID: 456, handle: '@bonk', ['_0_version']: '00'},
+          {userID: 123, handle: '@zoot', ['_0_version']: WATERMARK_REGEX},
+          {userID: 456, handle: '@bonk', ['_0_version']: WATERMARK_REGEX},
         ],
       },
     },
@@ -132,7 +134,7 @@ describe('change-streamer/pg/sync-schema', () => {
         );
 
         await expectTables(upstream, c.upstreamPostState);
-        expectLiteTables(replica, c.replicaPostState);
+        expectMatchingObjectsInTables(replica, c.replicaPostState);
 
         expectLiteTables(replica, {
           ['_zero.changeLog']: [],

--- a/packages/zero-cache/src/services/change-source/pg/sync-schema.ts
+++ b/packages/zero-cache/src/services/change-source/pg/sync-schema.ts
@@ -5,6 +5,7 @@ import {
   type IncrementalMigrationMap,
   type Migration,
 } from '../../../db/migration-lite.js';
+import {AutoResetSignal} from '../../change-streamer/schema/tables.js';
 import {initialSync, type InitialSyncOptions} from './initial-sync.js';
 import type {ShardConfig} from './shard-config.js';
 
@@ -23,12 +24,12 @@ export async function initSyncSchema(
   };
 
   const schemaVersionMigrationMap: IncrementalMigrationMap = {
-    1: setupMigration,
-    // There are no incremental migrations yet, but if we were to, say introduce
-    // another column, initialSync would be updated to create the table with
-    // the new column, and then there would be an incremental migration here at
-    // version `2` that adds the column for databases that were initialized to
-    // version `1`.
+    // There's no incremental migration from v1. Just reset the replica.
+    2: {
+      migrateSchema: () => {
+        throw new AutoResetSignal('resetting replica at obsolete v1');
+      },
+    },
   };
 
   await runSchemaMigrations(

--- a/packages/zero-cache/src/services/replicator/incremental-sync.pg-test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.pg-test.ts
@@ -133,7 +133,7 @@ describe('replicator/incremental-sync', () => {
             time: null,
             bytes: null,
             intArray: null,
-            ['_0_version']: '02',
+            ['_0_version']: '06',
           },
           {
             issueID: 456n,
@@ -146,7 +146,7 @@ describe('replicator/incremental-sync', () => {
             time: null,
             bytes: null,
             intArray: null,
-            ['_0_version']: '02',
+            ['_0_version']: '06',
           },
           {
             issueID: 789n,
@@ -159,7 +159,7 @@ describe('replicator/incremental-sync', () => {
             time: 1728345600123456n,
             bytes: Buffer.from('world'),
             intArray: '[3,2,1]',
-            ['_0_version']: '06',
+            ['_0_version']: '0b',
           },
           {
             issueID: 987n,
@@ -172,7 +172,7 @@ describe('replicator/incremental-sync', () => {
             time: null,
             bytes: null,
             intArray: null,
-            ['_0_version']: '06',
+            ['_0_version']: '0b',
           },
           {
             issueID: 234n,
@@ -185,36 +185,36 @@ describe('replicator/incremental-sync', () => {
             time: null,
             bytes: null,
             intArray: null,
-            ['_0_version']: '06',
+            ['_0_version']: '0b',
           },
         ],
         ['_zero.changeLog']: [
           {
-            stateVersion: '02',
+            stateVersion: '06',
             table: 'issues',
             op: 's',
             rowKey: '{"bool":1,"issueID":123}',
           },
           {
-            stateVersion: '02',
+            stateVersion: '06',
             table: 'issues',
             op: 's',
             rowKey: '{"bool":0,"issueID":456}',
           },
           {
-            stateVersion: '06',
+            stateVersion: '0b',
             table: 'issues',
             op: 's',
             rowKey: '{"bool":1,"issueID":789}',
           },
           {
-            stateVersion: '06',
+            stateVersion: '0b',
             table: 'issues',
             op: 's',
             rowKey: '{"bool":1,"issueID":987}',
           },
           {
-            stateVersion: '06',
+            stateVersion: '0b',
             table: 'issues',
             op: 's',
             rowKey: '{"bool":0,"issueID":234}',
@@ -282,44 +282,44 @@ describe('replicator/incremental-sync', () => {
             issueID: 123n,
             description: 'bar',
             bool: 0n,
-            ['_0_version']: '06',
+            ['_0_version']: '0a',
           },
           {
             orgID: 1n,
             issueID: 456n,
             description: 'foo',
             bool: 1n,
-            ['_0_version']: '06',
+            ['_0_version']: '0a',
           },
           {
             orgID: 2n,
             issueID: 789n,
             description: null,
             bool: 1n,
-            ['_0_version']: '02',
+            ['_0_version']: '06',
           },
         ],
         ['_zero.changeLog']: [
           {
-            stateVersion: '02',
+            stateVersion: '06',
             table: 'issues',
             op: 's',
             rowKey: '{"bool":1,"issueID":789,"orgID":2}',
           },
           {
-            stateVersion: '06',
+            stateVersion: '0a',
             table: 'issues',
             op: 's',
             rowKey: '{"bool":1,"issueID":456,"orgID":1}',
           },
           {
-            stateVersion: '06',
+            stateVersion: '0a',
             table: 'issues',
             op: 'd',
             rowKey: '{"bool":1,"issueID":123,"orgID":1}',
           },
           {
-            stateVersion: '06',
+            stateVersion: '0a',
             table: 'issues',
             op: 's',
             rowKey: '{"bool":0,"issueID":123,"orgID":2}',
@@ -381,30 +381,30 @@ describe('replicator/incremental-sync', () => {
             issueID: 789n,
             bool: 0n,
             description: null,
-            ['_0_version']: '02',
+            ['_0_version']: '07',
           },
         ],
         ['_zero.changeLog']: [
           {
-            stateVersion: '02',
+            stateVersion: '07',
             table: 'issues',
             op: 's',
             rowKey: '{"bool":0,"issueID":789,"orgID":2}',
           },
           {
-            stateVersion: '07',
+            stateVersion: '0c',
             table: 'issues',
             op: 'd',
             rowKey: '{"bool":1,"issueID":123,"orgID":1}',
           },
           {
-            stateVersion: '07',
+            stateVersion: '0c',
             table: 'issues',
             op: 'd',
             rowKey: '{"bool":0,"issueID":456,"orgID":1}',
           },
           {
-            stateVersion: '07',
+            stateVersion: '0c',
             table: 'issues',
             op: 'd',
             rowKey: '{"bool":1,"issueID":987,"orgID":2}',
@@ -440,46 +440,46 @@ describe('replicator/incremental-sync', () => {
         ['commit', fooBarBaz.commit(), {watermark: '0i'}],
       ],
       data: {
-        foo: [{id: 101n, ['_0_version']: '0e'}],
+        foo: [{id: 101n, ['_0_version']: '0i'}],
         bar: [
-          {id: 4n, ['_0_version']: '02'},
-          {id: 5n, ['_0_version']: '02'},
-          {id: 6n, ['_0_version']: '02'},
+          {id: 4n, ['_0_version']: '0e'},
+          {id: 5n, ['_0_version']: '0e'},
+          {id: 6n, ['_0_version']: '0e'},
         ],
         baz: [],
         ['_zero.changeLog']: [
           {
-            stateVersion: '02',
+            stateVersion: '0e',
             table: 'bar',
             op: 's',
             rowKey: '{"id":4}',
           },
           {
-            stateVersion: '02',
+            stateVersion: '0e',
             table: 'bar',
             op: 's',
             rowKey: '{"id":5}',
           },
           {
-            stateVersion: '02',
+            stateVersion: '0e',
             table: 'bar',
             op: 's',
             rowKey: '{"id":6}',
           },
           {
-            stateVersion: '02',
+            stateVersion: '0e',
             table: 'baz',
             op: 't',
             rowKey: '',
           },
           {
-            stateVersion: '0e',
+            stateVersion: '0i',
             table: 'foo',
             op: 't',
             rowKey: '',
           },
           {
-            stateVersion: '0e',
+            stateVersion: '0i',
             table: 'foo',
             op: 's',
             rowKey: '{"id":101}',
@@ -519,19 +519,19 @@ describe('replicator/incremental-sync', () => {
         transaction: [],
         ['_zero.changeLog']: [
           {
-            stateVersion: '02',
+            stateVersion: '07',
             table: 'transaction',
             op: 't',
             rowKey: '',
           },
           {
-            stateVersion: '02',
+            stateVersion: '07',
             table: 'transaction',
             op: 'd',
             rowKey: '{"column":1}',
           },
           {
-            stateVersion: '02',
+            stateVersion: '07',
             table: 'transaction',
             op: 'd',
             rowKey: '{"column":2}',
@@ -591,24 +591,24 @@ describe('replicator/incremental-sync', () => {
             issueID: 456n,
             bool: 0n,
             description: 'foo',
-            ['_0_version']: '02',
+            ['_0_version']: '08',
           },
         ],
         ['_zero.changeLog']: [
           {
-            stateVersion: '02',
+            stateVersion: '08',
             table: 'issues',
             op: 'd',
             rowKey: '{"bool":1,"issueID":123,"orgID":1}',
           },
           {
-            stateVersion: '02',
+            stateVersion: '08',
             table: 'issues',
             op: 's',
             rowKey: '{"bool":0,"issueID":456,"orgID":1}',
           },
           {
-            stateVersion: '02',
+            stateVersion: '08',
             table: 'issues',
             op: 'd',
             rowKey: '{"bool":0,"issueID":789,"orgID":2}',
@@ -657,24 +657,24 @@ describe('replicator/incremental-sync', () => {
       ],
       data: {
         foo: [
-          {id: 'bar', count: 2n, bool: 1n, serial: 1n, ['_0_version']: '02'},
-          {id: 'baz', count: 3n, bool: 0n, serial: 2n, ['_0_version']: '02'},
+          {id: 'bar', count: 2n, bool: 1n, serial: 1n, ['_0_version']: '0e'},
+          {id: 'baz', count: 3n, bool: 0n, serial: 2n, ['_0_version']: '0e'},
         ],
         ['_zero.changeLog']: [
           {
-            stateVersion: '02',
+            stateVersion: '0e',
             table: 'foo',
             op: 'r',
             rowKey: null,
           },
           {
-            stateVersion: '02',
+            stateVersion: '0e',
             table: 'foo',
             op: 's',
             rowKey: '{"id":"bar"}',
           },
           {
-            stateVersion: '02',
+            stateVersion: '0e',
             table: 'foo',
             op: 's',
             rowKey: '{"id":"baz"}',
@@ -742,26 +742,26 @@ describe('replicator/incremental-sync', () => {
       ],
       data: {
         bar: [
-          {id: 1n, ['_0_version']: '02'},
-          {id: 2n, ['_0_version']: '02'},
-          {id: 3n, ['_0_version']: '02'},
-          {id: 4n, ['_0_version']: '02'},
+          {id: 1n, ['_0_version']: '0e'},
+          {id: 2n, ['_0_version']: '0e'},
+          {id: 3n, ['_0_version']: '0e'},
+          {id: 4n, ['_0_version']: '0e'},
         ],
         ['_zero.changeLog']: [
           {
-            stateVersion: '02',
+            stateVersion: '0e',
             table: 'bar',
             op: 'r',
             rowKey: null,
           },
           {
-            stateVersion: '02',
+            stateVersion: '0e',
             table: 'foo',
             op: 'r',
             rowKey: null,
           },
           {
-            stateVersion: '02',
+            stateVersion: '0e',
             table: 'bar',
             op: 's',
             rowKey: '{"id":4}',
@@ -843,39 +843,39 @@ describe('replicator/incremental-sync', () => {
             newInt: 123n,
             newBool: 1n,
             newJSON: null,
-            ['_0_version']: '02',
+            ['_0_version']: '0e',
           },
           {
             id: 2n,
             newInt: 123n,
             newBool: 1n,
             newJSON: null,
-            ['_0_version']: '02',
+            ['_0_version']: '0e',
           },
           {
             id: 3n,
             newInt: 123n,
             newBool: 1n,
             newJSON: null,
-            ['_0_version']: '02',
+            ['_0_version']: '0e',
           },
           {
             id: 4n,
             newInt: 321n,
             newBool: 0n,
             newJSON: 'true',
-            ['_0_version']: '02',
+            ['_0_version']: '0e',
           },
         ],
         ['_zero.changeLog']: [
           {
-            stateVersion: '02',
+            stateVersion: '0e',
             table: 'foo',
             op: 'r',
             rowKey: null,
           },
           {
-            stateVersion: '02',
+            stateVersion: '0e',
             table: 'foo',
             op: 's',
             rowKey: '{"id":4}',
@@ -944,20 +944,20 @@ describe('replicator/incremental-sync', () => {
       ],
       data: {
         foo: [
-          {id: 1n, ['_0_version']: '02'},
-          {id: 2n, ['_0_version']: '02'},
-          {id: 3n, ['_0_version']: '02'},
-          {id: 4n, ['_0_version']: '02'},
+          {id: 1n, ['_0_version']: '0e'},
+          {id: 2n, ['_0_version']: '0e'},
+          {id: 3n, ['_0_version']: '0e'},
+          {id: 4n, ['_0_version']: '0e'},
         ],
         ['_zero.changeLog']: [
           {
-            stateVersion: '02',
+            stateVersion: '0e',
             table: 'foo',
             op: 'r',
             rowKey: null,
           },
           {
-            stateVersion: '02',
+            stateVersion: '0e',
             table: 'foo',
             op: 's',
             rowKey: '{"id":4}',
@@ -1012,20 +1012,20 @@ describe('replicator/incremental-sync', () => {
       ],
       data: {
         foo: [
-          {id: 1n, newName: 'hel', ['_0_version']: '02'},
-          {id: 2n, newName: 'low', ['_0_version']: '02'},
-          {id: 3n, newName: 'olrd', ['_0_version']: '02'},
-          {id: 4n, newName: 'yay', ['_0_version']: '02'},
+          {id: 1n, newName: 'hel', ['_0_version']: '0e'},
+          {id: 2n, newName: 'low', ['_0_version']: '0e'},
+          {id: 3n, newName: 'olrd', ['_0_version']: '0e'},
+          {id: 4n, newName: 'yay', ['_0_version']: '0e'},
         ],
         ['_zero.changeLog']: [
           {
-            stateVersion: '02',
+            stateVersion: '0e',
             table: 'foo',
             op: 'r',
             rowKey: null,
           },
           {
-            stateVersion: '02',
+            stateVersion: '0e',
             table: 'foo',
             op: 's',
             rowKey: '{"id":4}',
@@ -1088,20 +1088,20 @@ describe('replicator/incremental-sync', () => {
       ],
       data: {
         foo: [
-          {id: 1n, newName: 'hel', ['_0_version']: '02'},
-          {id: 2n, newName: 'low', ['_0_version']: '02'},
-          {id: 3n, newName: 'olrd', ['_0_version']: '02'},
-          {id: 4n, newName: 'yay', ['_0_version']: '02'},
+          {id: 1n, newName: 'hel', ['_0_version']: '0e'},
+          {id: 2n, newName: 'low', ['_0_version']: '0e'},
+          {id: 3n, newName: 'olrd', ['_0_version']: '0e'},
+          {id: 4n, newName: 'yay', ['_0_version']: '0e'},
         ],
         ['_zero.changeLog']: [
           {
-            stateVersion: '02',
+            stateVersion: '0e',
             table: 'foo',
             op: 'r',
             rowKey: null,
           },
           {
-            stateVersion: '02',
+            stateVersion: '0e',
             table: 'foo',
             op: 's',
             rowKey: '{"id":4}',
@@ -1170,20 +1170,20 @@ describe('replicator/incremental-sync', () => {
       ],
       data: {
         foo: [
-          {id: 1n, num: 3n, ['_0_version']: '02'},
-          {id: 2n, num: 2n, ['_0_version']: '02'},
-          {id: 3n, num: 1n, ['_0_version']: '02'},
-          {id: 4n, num: 23n, ['_0_version']: '02'},
+          {id: 1n, num: 3n, ['_0_version']: '0e'},
+          {id: 2n, num: 2n, ['_0_version']: '0e'},
+          {id: 3n, num: 1n, ['_0_version']: '0e'},
+          {id: 4n, num: 23n, ['_0_version']: '0e'},
         ],
         ['_zero.changeLog']: [
           {
-            stateVersion: '02',
+            stateVersion: '0e',
             table: 'foo',
             op: 'r',
             rowKey: null,
           },
           {
-            stateVersion: '02',
+            stateVersion: '0e',
             table: 'foo',
             op: 's',
             rowKey: '{"id":4}',
@@ -1247,20 +1247,20 @@ describe('replicator/incremental-sync', () => {
       ],
       data: {
         foo: [
-          {id: 1n, num: 3n, ['_0_version']: '02'},
-          {id: 2n, num: 2n, ['_0_version']: '02'},
-          {id: 3n, num: 1n, ['_0_version']: '02'},
-          {id: 4n, num: 23n, ['_0_version']: '02'},
+          {id: 1n, num: 3n, ['_0_version']: '0e'},
+          {id: 2n, num: 2n, ['_0_version']: '0e'},
+          {id: 3n, num: 1n, ['_0_version']: '0e'},
+          {id: 4n, num: 23n, ['_0_version']: '0e'},
         ],
         ['_zero.changeLog']: [
           {
-            stateVersion: '02',
+            stateVersion: '0e',
             table: 'foo',
             op: 'r',
             rowKey: null,
           },
           {
-            stateVersion: '02',
+            stateVersion: '0e',
             table: 'foo',
             op: 's',
             rowKey: '{"id":4}',
@@ -1335,20 +1335,20 @@ describe('replicator/incremental-sync', () => {
       ],
       data: {
         foo: [
-          {id: 1n, number: 3n, ['_0_version']: '02'},
-          {id: 2n, number: 2n, ['_0_version']: '02'},
-          {id: 3n, number: 1n, ['_0_version']: '02'},
-          {id: 4n, number: 23n, ['_0_version']: '02'},
+          {id: 1n, number: 3n, ['_0_version']: '0e'},
+          {id: 2n, number: 2n, ['_0_version']: '0e'},
+          {id: 3n, number: 1n, ['_0_version']: '0e'},
+          {id: 4n, number: 23n, ['_0_version']: '0e'},
         ],
         ['_zero.changeLog']: [
           {
-            stateVersion: '02',
+            stateVersion: '0e',
             table: 'foo',
             op: 'r',
             rowKey: null,
           },
           {
-            stateVersion: '02',
+            stateVersion: '0e',
             table: 'foo',
             op: 's',
             rowKey: '{"id":4}',
@@ -1403,7 +1403,7 @@ describe('replicator/incremental-sync', () => {
       data: {
         ['_zero.changeLog']: [
           {
-            stateVersion: '02',
+            stateVersion: '0e',
             table: 'foo',
             op: 'r',
             rowKey: null,
@@ -1477,7 +1477,7 @@ describe('replicator/incremental-sync', () => {
       name: 'reserved words in DDL',
       setup: ``,
       downstream: [
-        ['begin', tables.begin(), {commitWatermark: '0e'}],
+        ['begin', tables.begin(), {commitWatermark: '07'}],
         [
           'data',
           tables.createTable({
@@ -1532,7 +1532,7 @@ describe('replicator/incremental-sync', () => {
         transaction: [],
         ['_zero.changeLog']: [
           {
-            stateVersion: '02',
+            stateVersion: '07',
             table: 'transaction',
             op: 'r',
             rowKey: null,

--- a/packages/zero-cache/src/services/replicator/schema/replication-state.test.ts
+++ b/packages/zero-cache/src/services/replicator/schema/replication-state.test.ts
@@ -4,7 +4,7 @@ import {Database} from '../../../../../zqlite/src/db.js';
 import {StatementRunner} from '../../../db/statements.js';
 import {expectTables} from '../../../test/lite.js';
 import {
-  getReplicationVersions,
+  getReplicationState,
   getSubscriptionState,
   initReplicationState,
   updateReplicationWatermark,
@@ -47,7 +47,7 @@ describe('replicator/schema/replication-state', () => {
   });
 
   test('get versions', () => {
-    expect(getReplicationVersions(db)).toEqual({
+    expect(getReplicationState(db)).toEqual({
       stateVersion: '0a',
     });
   });
@@ -62,7 +62,7 @@ describe('replicator/schema/replication-state', () => {
         },
       ],
     });
-    expect(getReplicationVersions(db)).toEqual({
+    expect(getReplicationState(db)).toEqual({
       stateVersion: '0f',
     });
     expect(getSubscriptionState(db)).toEqual({
@@ -80,7 +80,7 @@ describe('replicator/schema/replication-state', () => {
         },
       ],
     });
-    expect(getReplicationVersions(db)).toEqual({
+    expect(getReplicationState(db)).toEqual({
       stateVersion: '0r',
     });
     expect(getSubscriptionState(db)).toEqual({

--- a/packages/zero-cache/src/services/replicator/schema/replication-state.test.ts
+++ b/packages/zero-cache/src/services/replicator/schema/replication-state.test.ts
@@ -32,8 +32,7 @@ describe('replicator/schema/replication-state', () => {
       ['_zero.replicationState']: [
         {
           lock: 1,
-          watermark: '0a',
-          stateVersion: '00',
+          stateVersion: '0a',
         },
       ],
     });
@@ -49,8 +48,7 @@ describe('replicator/schema/replication-state', () => {
 
   test('get versions', () => {
     expect(getReplicationVersions(db)).toEqual({
-      stateVersion: '00',
-      nextStateVersion: '0a',
+      stateVersion: '0a',
     });
   });
 
@@ -60,14 +58,12 @@ describe('replicator/schema/replication-state', () => {
       ['_zero.replicationState']: [
         {
           lock: 1,
-          watermark: '0f',
-          stateVersion: '0a',
+          stateVersion: '0f',
         },
       ],
     });
     expect(getReplicationVersions(db)).toEqual({
-      stateVersion: '0a',
-      nextStateVersion: '0f',
+      stateVersion: '0f',
     });
     expect(getSubscriptionState(db)).toEqual({
       replicaVersion: '0a',
@@ -80,14 +76,12 @@ describe('replicator/schema/replication-state', () => {
       ['_zero.replicationState']: [
         {
           lock: 1,
-          watermark: '0r',
-          stateVersion: '0f',
+          stateVersion: '0r',
         },
       ],
     });
     expect(getReplicationVersions(db)).toEqual({
-      stateVersion: '0f',
-      nextStateVersion: '0r',
+      stateVersion: '0r',
     });
     expect(getSubscriptionState(db)).toEqual({
       replicaVersion: '0a',

--- a/packages/zero-cache/src/services/replicator/schema/replication-state.ts
+++ b/packages/zero-cache/src/services/replicator/schema/replication-state.ts
@@ -13,11 +13,9 @@ export const ZERO_VERSION_COLUMN_NAME = '_0_version';
 
 const CREATE_REPLICATION_STATE_SCHEMA =
   // replicaVersion   : A value identifying the version at which the initial sync happened, i.e.
-  //                    at which all rows were copied and initialized with `_0_version: "00"`. This
-  //                    value is used to distinguish data from other replicas (e.g. if a replica is
-  //                    reset or if there are ever multiple replicas). Data from replicas with
-  //                    different versions are incompatible, as their "00" version will correspond
-  //                    to different snapshots of the upstream database.
+  //                    the version at which all rows were copied, and to `_0_version` was set.
+  //                    This value is used to distinguish data from other replicas (e.g. if a
+  //                    replica is reset or if there are ever multiple replicas).
   // publications     : JSON stringified array of publication names
   // lock             : Auto-magic column for enforcing single-row semantics.
   `
@@ -27,14 +25,13 @@ const CREATE_REPLICATION_STATE_SCHEMA =
     lock INTEGER PRIMARY KEY DEFAULT 1 CHECK (lock=1)
   );
   ` +
-  // watermark        : Lexicographically sortable watermark denoting the point from which replication
-  //                    should continue. For a Postgres upstream, for example, this is the
-  //                    LexiVersion-encoded LSN. This is also used as the state version for rows
-  //                    modified in the **next** transaction.
-  // stateVersion     : The value of the _0_version column for the newest rows in the database.
+  // stateVersion     : The latest version replicated from upstream, starting with the initial
+  //                    `replicaVersion` and moving forward to each subsequent commit watermark
+  //                    (e.g. corresponding to a Postgres LSN). Versions are represented as
+  //                    lexicographically sortable watermarks (e.g. LexiVersions).
+  //
   `
   CREATE TABLE "_zero.replicationState" (
-    watermark TEXT NOT NULL,
     stateVersion TEXT NOT NULL,
     lock INTEGER PRIMARY KEY DEFAULT 1 CHECK (lock=1)
   );
@@ -53,12 +50,11 @@ const subscriptionStateSchema = v
     publications: v.parse(JSON.parse(s.publications), stringArray),
   }));
 
-const versionsSchema = v.object({
+const replicationStateSchema = v.object({
   stateVersion: v.string(),
-  nextStateVersion: v.string(),
 });
 
-export type ReplicationVersions = v.Infer<typeof versionsSchema>;
+export type ReplicationState = v.Infer<typeof replicationStateSchema>;
 
 export function initReplicationState(
   db: Database,
@@ -74,8 +70,7 @@ export function initReplicationState(
   ).run(watermark, JSON.stringify(publications.sort()));
   db.prepare(
     `
-    INSERT INTO "_zero.replicationState" 
-       (watermark, stateVersion) VALUES (?,'00')
+    INSERT INTO "_zero.replicationState" (stateVersion) VALUES (?)
     `,
   ).run(watermark);
 }
@@ -83,7 +78,7 @@ export function initReplicationState(
 export function getSubscriptionState(db: StatementRunner) {
   const result = db.get(
     `
-      SELECT c.replicaVersion, c.publications, s.watermark 
+      SELECT c.replicaVersion, c.publications, s.stateVersion as watermark
         FROM "_zero.replicationConfig" as c
         JOIN "_zero.replicationState" as s
         ON c.lock = s.lock
@@ -96,17 +91,10 @@ export function updateReplicationWatermark(
   db: StatementRunner,
   watermark: string,
 ) {
-  db.run(
-    `UPDATE "_zero.replicationState" SET stateVersion=watermark, watermark=?`,
-    watermark,
-  );
+  db.run(`UPDATE "_zero.replicationState" SET stateVersion=?`, watermark);
 }
 
-export function getReplicationVersions(
-  db: StatementRunner,
-): ReplicationVersions {
-  const result = db.get(
-    `SELECT stateVersion, watermark as nextStateVersion FROM "_zero.replicationState"`,
-  );
-  return v.parse(result, versionsSchema);
+export function getReplicationVersions(db: StatementRunner): ReplicationState {
+  const result = db.get(`SELECT stateVersion FROM "_zero.replicationState"`);
+  return v.parse(result, replicationStateSchema);
 }

--- a/packages/zero-cache/src/services/replicator/schema/replication-state.ts
+++ b/packages/zero-cache/src/services/replicator/schema/replication-state.ts
@@ -94,7 +94,7 @@ export function updateReplicationWatermark(
   db.run(`UPDATE "_zero.replicationState" SET stateVersion=?`, watermark);
 }
 
-export function getReplicationVersions(db: StatementRunner): ReplicationState {
+export function getReplicationState(db: StatementRunner): ReplicationState {
   const result = db.get(`SELECT stateVersion FROM "_zero.replicationState"`);
   return v.parse(result, replicationStateSchema);
 }

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -322,8 +322,15 @@ export class CVRQueryDrivenUpdater extends CVRUpdater {
     stateVersion: LexiVersion,
     replicaVersion: string,
   ) {
-    super(cvrStore, cvr, cvr.replicaVersion ?? replicaVersion);
+    super(cvrStore, cvr, replicaVersion);
 
+    assert(
+      // We should either be setting the cvr.replicaVersion for the first time, or it should
+      // be something newer than the current cvr.replicaVersion. Otherwise, the CVR should
+      // have been rejected by the ViewSyncer.
+      (cvr.replicaVersion ?? replicaVersion) <= replicaVersion,
+      `Cannot sync from an older replicaVersion: CVR=${cvr.replicaVersion}, DB=${replicaVersion}`,
+    );
     assert(stateVersion >= cvr.version.stateVersion);
     if (stateVersion > cvr.version.stateVersion) {
       this._setVersion({stateVersion});

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -322,14 +322,8 @@ export class CVRQueryDrivenUpdater extends CVRUpdater {
     stateVersion: LexiVersion,
     replicaVersion: string,
   ) {
-    super(cvrStore, cvr, replicaVersion);
+    super(cvrStore, cvr, cvr.replicaVersion ?? replicaVersion);
 
-    assert(
-      // We should either be setting the cvr.replicaVersion for the first time, or it should
-      // be the same as the cvr.replicaVersion.
-      (cvr.replicaVersion ?? replicaVersion) === replicaVersion,
-      `CVR replicaVersion: ${cvr.replicaVersion}, DB replicaVersion: ${replicaVersion}`,
-    );
     assert(stateVersion >= cvr.version.stateVersion);
     if (stateVersion > cvr.version.stateVersion) {
       this._setVersion({stateVersion});

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -49,7 +49,7 @@ describe('view-syncer/pipeline-driver', () => {
         _0_version            TEXT NOT NULL
       );
       INSERT INTO "zero.schemaVersions" ("lock", "minSupportedVersion", "maxSupportedVersion", _0_version)    
-        VALUES (1, 1, 1, '00');  
+        VALUES (1, 1, 1, '123');  
       CREATE TABLE issues (
         id TEXT PRIMARY KEY,
         closed BOOL,
@@ -74,16 +74,16 @@ describe('view-syncer/pipeline-driver', () => {
         _0_version TEXT NOT NULL
       );
 
-      INSERT INTO ISSUES (id, closed, ignored, _0_version) VALUES ('1', 0, 1728345600000, '00');
-      INSERT INTO ISSUES (id, closed, ignored, _0_version) VALUES ('2', 1, 1722902400000, '00');
-      INSERT INTO ISSUES (id, closed, ignored, _0_version) VALUES ('3', 0, null, '00');
-      INSERT INTO COMMENTS (id, issueID, upvotes, _0_version) VALUES ('10', '1', 0, '00');
-      INSERT INTO COMMENTS (id, issueID, upvotes, _0_version) VALUES ('20', '2', 1, '00');
-      INSERT INTO COMMENTS (id, issueID, upvotes, _0_version) VALUES ('21', '2', 10000, '00');
-      INSERT INTO COMMENTS (id, issueID, upvotes, _0_version) VALUES ('22', '2', 20000, '00');
+      INSERT INTO ISSUES (id, closed, ignored, _0_version) VALUES ('1', 0, 1728345600000, '123');
+      INSERT INTO ISSUES (id, closed, ignored, _0_version) VALUES ('2', 1, 1722902400000, '123');
+      INSERT INTO ISSUES (id, closed, ignored, _0_version) VALUES ('3', 0, null, '123');
+      INSERT INTO COMMENTS (id, issueID, upvotes, _0_version) VALUES ('10', '1', 0, '123');
+      INSERT INTO COMMENTS (id, issueID, upvotes, _0_version) VALUES ('20', '2', 1, '123');
+      INSERT INTO COMMENTS (id, issueID, upvotes, _0_version) VALUES ('21', '2', 10000, '123');
+      INSERT INTO COMMENTS (id, issueID, upvotes, _0_version) VALUES ('22', '2', 20000, '123');
 
-      INSERT INTO "issueLabels" (issueID, labelID, _0_version) VALUES ('1', '1', '00');
-      INSERT INTO "labels" (id, name, _0_version) VALUES ('1', 'bug', '00');
+      INSERT INTO "issueLabels" (issueID, labelID, _0_version) VALUES ('1', '1', '123');
+      INSERT INTO "labels" (id, name, _0_version) VALUES ('1', 'bug', '123');
       `);
     replicator = fakeReplicator(lc, db);
   });
@@ -291,7 +291,7 @@ describe('view-syncer/pipeline-driver', () => {
           {
             "queryHash": "hash1",
             "row": {
-              "_0_version": "00",
+              "_0_version": "123",
               "closed": false,
               "id": "3",
             },
@@ -304,7 +304,7 @@ describe('view-syncer/pipeline-driver', () => {
           {
             "queryHash": "hash1",
             "row": {
-              "_0_version": "00",
+              "_0_version": "123",
               "closed": true,
               "id": "2",
             },
@@ -317,7 +317,7 @@ describe('view-syncer/pipeline-driver', () => {
           {
             "queryHash": "hash1",
             "row": {
-              "_0_version": "00",
+              "_0_version": "123",
               "id": "22",
               "issueID": "2",
               "upvotes": 20000,
@@ -331,7 +331,7 @@ describe('view-syncer/pipeline-driver', () => {
           {
             "queryHash": "hash1",
             "row": {
-              "_0_version": "00",
+              "_0_version": "123",
               "id": "21",
               "issueID": "2",
               "upvotes": 10000,
@@ -345,7 +345,7 @@ describe('view-syncer/pipeline-driver', () => {
           {
             "queryHash": "hash1",
             "row": {
-              "_0_version": "00",
+              "_0_version": "123",
               "id": "20",
               "issueID": "2",
               "upvotes": 1,
@@ -359,7 +359,7 @@ describe('view-syncer/pipeline-driver', () => {
           {
             "queryHash": "hash1",
             "row": {
-              "_0_version": "00",
+              "_0_version": "123",
               "closed": false,
               "id": "1",
             },
@@ -372,7 +372,7 @@ describe('view-syncer/pipeline-driver', () => {
           {
             "queryHash": "hash1",
             "row": {
-              "_0_version": "00",
+              "_0_version": "123",
               "id": "10",
               "issueID": "1",
               "upvotes": 0,
@@ -407,7 +407,7 @@ describe('view-syncer/pipeline-driver', () => {
         {
           "queryHash": "hash1",
           "row": {
-            "_0_version": "123",
+            "_0_version": "134",
             "id": "31",
             "issueID": "3",
             "upvotes": 0,
@@ -421,7 +421,7 @@ describe('view-syncer/pipeline-driver', () => {
         {
           "queryHash": "hash1",
           "row": {
-            "_0_version": "123",
+            "_0_version": "134",
             "closed": false,
             "id": "4",
           },
@@ -434,7 +434,7 @@ describe('view-syncer/pipeline-driver', () => {
         {
           "queryHash": "hash1",
           "row": {
-            "_0_version": "123",
+            "_0_version": "134",
             "id": "41",
             "issueID": "4",
             "upvotes": 9007199254740991,
@@ -526,7 +526,7 @@ describe('view-syncer/pipeline-driver', () => {
         {
           "queryHash": "hash1",
           "row": {
-            "_0_version": "123",
+            "_0_version": "134",
             "id": "22",
             "issueID": "3",
             "upvotes": 20000,
@@ -550,7 +550,7 @@ describe('view-syncer/pipeline-driver', () => {
         {
           "queryHash": "hash1",
           "row": {
-            "_0_version": "134",
+            "_0_version": "135",
             "id": "22",
             "issueID": "3",
             "upvotes": 10,
@@ -583,107 +583,107 @@ describe('view-syncer/pipeline-driver', () => {
     // The newColumn should be reflected after a reset.
     expect([...pipelines.addQuery('hash1', ISSUES_AND_COMMENTS)])
       .toMatchInlineSnapshot(`
-      [
-        {
-          "queryHash": "hash1",
-          "row": {
-            "_0_version": "123",
-            "closed": false,
-            "id": "3",
-            "newColumn": null,
+        [
+          {
+            "queryHash": "hash1",
+            "row": {
+              "_0_version": "134",
+              "closed": false,
+              "id": "3",
+              "newColumn": null,
+            },
+            "rowKey": {
+              "id": "3",
+            },
+            "table": "issues",
+            "type": "add",
           },
-          "rowKey": {
-            "id": "3",
+          {
+            "queryHash": "hash1",
+            "row": {
+              "_0_version": "134",
+              "closed": true,
+              "id": "2",
+              "newColumn": null,
+            },
+            "rowKey": {
+              "id": "2",
+            },
+            "table": "issues",
+            "type": "add",
           },
-          "table": "issues",
-          "type": "add",
-        },
-        {
-          "queryHash": "hash1",
-          "row": {
-            "_0_version": "123",
-            "closed": true,
-            "id": "2",
-            "newColumn": null,
+          {
+            "queryHash": "hash1",
+            "row": {
+              "_0_version": "123",
+              "id": "22",
+              "issueID": "2",
+              "upvotes": 20000,
+            },
+            "rowKey": {
+              "id": "22",
+            },
+            "table": "comments",
+            "type": "add",
           },
-          "rowKey": {
-            "id": "2",
+          {
+            "queryHash": "hash1",
+            "row": {
+              "_0_version": "123",
+              "id": "21",
+              "issueID": "2",
+              "upvotes": 10000,
+            },
+            "rowKey": {
+              "id": "21",
+            },
+            "table": "comments",
+            "type": "add",
           },
-          "table": "issues",
-          "type": "add",
-        },
-        {
-          "queryHash": "hash1",
-          "row": {
-            "_0_version": "00",
-            "id": "22",
-            "issueID": "2",
-            "upvotes": 20000,
+          {
+            "queryHash": "hash1",
+            "row": {
+              "_0_version": "123",
+              "id": "20",
+              "issueID": "2",
+              "upvotes": 1,
+            },
+            "rowKey": {
+              "id": "20",
+            },
+            "table": "comments",
+            "type": "add",
           },
-          "rowKey": {
-            "id": "22",
+          {
+            "queryHash": "hash1",
+            "row": {
+              "_0_version": "134",
+              "closed": false,
+              "id": "1",
+              "newColumn": null,
+            },
+            "rowKey": {
+              "id": "1",
+            },
+            "table": "issues",
+            "type": "add",
           },
-          "table": "comments",
-          "type": "add",
-        },
-        {
-          "queryHash": "hash1",
-          "row": {
-            "_0_version": "00",
-            "id": "21",
-            "issueID": "2",
-            "upvotes": 10000,
+          {
+            "queryHash": "hash1",
+            "row": {
+              "_0_version": "123",
+              "id": "10",
+              "issueID": "1",
+              "upvotes": 0,
+            },
+            "rowKey": {
+              "id": "10",
+            },
+            "table": "comments",
+            "type": "add",
           },
-          "rowKey": {
-            "id": "21",
-          },
-          "table": "comments",
-          "type": "add",
-        },
-        {
-          "queryHash": "hash1",
-          "row": {
-            "_0_version": "00",
-            "id": "20",
-            "issueID": "2",
-            "upvotes": 1,
-          },
-          "rowKey": {
-            "id": "20",
-          },
-          "table": "comments",
-          "type": "add",
-        },
-        {
-          "queryHash": "hash1",
-          "row": {
-            "_0_version": "123",
-            "closed": false,
-            "id": "1",
-            "newColumn": null,
-          },
-          "rowKey": {
-            "id": "1",
-          },
-          "table": "issues",
-          "type": "add",
-        },
-        {
-          "queryHash": "hash1",
-          "row": {
-            "_0_version": "00",
-            "id": "10",
-            "issueID": "1",
-            "upvotes": 0,
-          },
-          "rowKey": {
-            "id": "10",
-          },
-          "table": "comments",
-          "type": "add",
-        },
-      ]
-    `);
+        ]
+      `);
   });
 
   test('whereExists query', () => {
@@ -738,7 +738,7 @@ describe('view-syncer/pipeline-driver', () => {
         {
           "queryHash": "hash1",
           "row": {
-            "_0_version": "00",
+            "_0_version": "123",
             "closed": false,
             "id": "1",
           },
@@ -761,7 +761,7 @@ describe('view-syncer/pipeline-driver', () => {
         {
           "queryHash": "hash2",
           "row": {
-            "_0_version": "00",
+            "_0_version": "123",
             "closed": false,
             "id": "1",
           },
@@ -774,7 +774,7 @@ describe('view-syncer/pipeline-driver', () => {
         {
           "queryHash": "hash2",
           "row": {
-            "_0_version": "00",
+            "_0_version": "123",
             "issueID": "1",
             "labelID": "1",
           },
@@ -904,7 +904,7 @@ describe('view-syncer/pipeline-driver', () => {
         {
           "queryHash": "hash1",
           "row": {
-            "_0_version": "00",
+            "_0_version": "123",
             "closed": true,
             "id": "2",
           },
@@ -917,7 +917,7 @@ describe('view-syncer/pipeline-driver', () => {
         {
           "queryHash": "hash1",
           "row": {
-            "_0_version": "123",
+            "_0_version": "134",
             "issueID": "2",
             "labelID": "1",
           },
@@ -931,7 +931,7 @@ describe('view-syncer/pipeline-driver', () => {
         {
           "queryHash": "hash1",
           "row": {
-            "_0_version": "00",
+            "_0_version": "123",
             "id": "1",
             "name": "bug",
           },
@@ -944,7 +944,7 @@ describe('view-syncer/pipeline-driver', () => {
         {
           "queryHash": "hash1",
           "row": {
-            "_0_version": "123",
+            "_0_version": "134",
             "issueID": "2",
             "labelID": "1",
           },
@@ -958,7 +958,7 @@ describe('view-syncer/pipeline-driver', () => {
         {
           "queryHash": "hash1",
           "row": {
-            "_0_version": "00",
+            "_0_version": "123",
             "id": "1",
             "name": "bug",
           },
@@ -1038,14 +1038,14 @@ describe('view-syncer/pipeline-driver', () => {
     expect(pipelines.getRow('issues', {id: '1'})).toEqual({
       id: '1',
       closed: false,
-      ['_0_version']: '00',
+      ['_0_version']: '123',
     });
 
     expect(pipelines.getRow('comments', {id: '22'})).toEqual({
       id: '22',
       issueID: '2',
       upvotes: 20000,
-      ['_0_version']: '00',
+      ['_0_version']: '123',
     });
 
     replicator.processTransaction(
@@ -1059,7 +1059,7 @@ describe('view-syncer/pipeline-driver', () => {
       id: '22',
       issueID: '3',
       upvotes: 20000,
-      ['_0_version']: '123',
+      ['_0_version']: '134',
     });
   });
 
@@ -1070,7 +1070,7 @@ describe('view-syncer/pipeline-driver', () => {
     replicator.processTransaction(
       '134',
       messages.insert('issues', {id: '4', closed: 0}),
-      zeroMessages.insert('schemaVersions', {
+      zeroMessages.update('schemaVersions', {
         lock: true,
         minSupportedVersion: 1,
         maxSupportedVersion: 2,
@@ -1087,7 +1087,7 @@ describe('view-syncer/pipeline-driver', () => {
         {
           "queryHash": "hash1",
           "row": {
-            "_0_version": "123",
+            "_0_version": "134",
             "closed": false,
             "id": "4",
           },
@@ -1120,7 +1120,7 @@ describe('view-syncer/pipeline-driver', () => {
         {
           "queryHash": "hash1",
           "row": {
-            "_0_version": "123",
+            "_0_version": "134",
             "closed": false,
             "id": "4",
           },
@@ -1143,7 +1143,7 @@ describe('view-syncer/pipeline-driver', () => {
         {
           "queryHash": "hash1",
           "row": {
-            "_0_version": "134",
+            "_0_version": "156",
             "id": "41",
             "issueID": "4",
             "upvotes": 10,
@@ -1198,9 +1198,9 @@ describe('view-syncer/pipeline-driver', () => {
       messages.insert('issues', {id: '4', closed: 1}),
     );
 
-    expect(pipelines.currentVersion()).toBe('00');
-    expect([...pipelines.advance().changes]).toHaveLength(0);
     expect(pipelines.currentVersion()).toBe('123');
+    expect([...pipelines.advance().changes]).toHaveLength(0);
+    expect(pipelines.currentVersion()).toBe('134');
   });
 
   test('push fails on out of bounds numbers', () => {

--- a/packages/zero-cache/src/services/view-syncer/schema/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/cvr.ts
@@ -27,6 +27,7 @@ export type InstancesRow = {
   grantedAt: number | null;
 };
 
+// TODO: Remove replicaVersion from the table.
 const CREATE_CVR_INSTANCES_TABLE = `
 CREATE TABLE cvr.instances (
   "clientGroupID"  TEXT PRIMARY KEY,

--- a/packages/zero-cache/src/services/view-syncer/schema/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/cvr.ts
@@ -27,7 +27,6 @@ export type InstancesRow = {
   grantedAt: number | null;
 };
 
-// TODO: Remove replicaVersion from the table.
 const CREATE_CVR_INSTANCES_TABLE = `
 CREATE TABLE cvr.instances (
   "clientGroupID"  TEXT PRIMARY KEY,

--- a/packages/zero-cache/src/services/view-syncer/snapshotter.ts
+++ b/packages/zero-cache/src/services/view-syncer/snapshotter.ts
@@ -21,7 +21,7 @@ import {
   TRUNCATE_OP,
 } from '../replicator/schema/change-log.js';
 import {
-  getReplicationVersions,
+  getReplicationState,
   ZERO_VERSION_COLUMN_NAME as ROW_VERSION,
 } from '../replicator/schema/replication-state.js';
 
@@ -257,7 +257,7 @@ class Snapshot {
     // Note: The subsequent read is necessary to acquire the read lock
     // (which results in the logical creation of the snapshot). Calling
     // `BEGIN CONCURRENT` alone does not result in acquiring the read lock.
-    const {stateVersion} = getReplicationVersions(db);
+    const {stateVersion} = getReplicationState(db);
     const schemaVersions = getSchemaVersions(db);
     return new Snapshot(db, stateVersion, schemaVersions);
   }
@@ -327,7 +327,7 @@ class Snapshot {
   resetToHead(): Snapshot {
     this.db.rollback();
     this.db.beginConcurrent();
-    const {stateVersion} = getReplicationVersions(this.db);
+    const {stateVersion} = getReplicationState(this.db);
     const schemaVersions = getSchemaVersions(this.db);
     return new Snapshot(this.db, stateVersion, schemaVersions);
   }

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -337,27 +337,27 @@ async function setup(permissions: PermissionsConfig = {}) {
   );
 
   INSERT INTO "zero_ABC.clients" ("clientGroupID", "clientID", "lastMutationID", _0_version)
-    VALUES ('9876', 'foo', 42, '00');
+    VALUES ('9876', 'foo', 42, '01');
   INSERT INTO "zero.schemaVersions" ("lock", "minSupportedVersion", "maxSupportedVersion", _0_version)    
-    VALUES (1, 2, 3, '00');  
+    VALUES (1, 2, 3, '01');  
 
-  INSERT INTO users (id, name, _0_version) VALUES ('100', 'Alice', '00');
-  INSERT INTO users (id, name, _0_version) VALUES ('101', 'Bob', '00');
-  INSERT INTO users (id, name, _0_version) VALUES ('102', 'Candice', '00');
+  INSERT INTO users (id, name, _0_version) VALUES ('100', 'Alice', '01');
+  INSERT INTO users (id, name, _0_version) VALUES ('101', 'Bob', '01');
+  INSERT INTO users (id, name, _0_version) VALUES ('102', 'Candice', '01');
 
-  INSERT INTO issues (id, title, owner, big, _0_version) VALUES ('1', 'parent issue foo', 100, 9007199254740991, '00');
-  INSERT INTO issues (id, title, owner, big, _0_version) VALUES ('2', 'parent issue bar', 101, -9007199254740991, '00');
-  INSERT INTO issues (id, title, owner, parent, big, _0_version) VALUES ('3', 'foo', 102, 1, 123, '00');
-  INSERT INTO issues (id, title, owner, parent, big, _0_version) VALUES ('4', 'bar', 101, 2, 100, '00');
+  INSERT INTO issues (id, title, owner, big, _0_version) VALUES ('1', 'parent issue foo', 100, 9007199254740991, '01');
+  INSERT INTO issues (id, title, owner, big, _0_version) VALUES ('2', 'parent issue bar', 101, -9007199254740991, '01');
+  INSERT INTO issues (id, title, owner, parent, big, _0_version) VALUES ('3', 'foo', 102, 1, 123, '01');
+  INSERT INTO issues (id, title, owner, parent, big, _0_version) VALUES ('4', 'bar', 101, 2, 100, '01');
   -- The last row should not match the ISSUES_TITLE_QUERY: "WHERE id IN (1, 2, 3, 4)"
   INSERT INTO issues (id, title, owner, parent, big, json, _0_version) VALUES 
-    ('5', 'not matched', 101, 2, 100, '[123,{"foo":456,"bar":789},"baz"]', '00');
+    ('5', 'not matched', 101, 2, 100, '[123,{"foo":456,"bar":789},"baz"]', '01');
 
-  INSERT INTO "issueLabels" (issueID, labelID, _0_version) VALUES ('1', '1', '00');
-  INSERT INTO "labels" (id, name, _0_version) VALUES ('1', 'bug', '00');
+  INSERT INTO "issueLabels" (issueID, labelID, _0_version) VALUES ('1', '1', '01');
+  INSERT INTO "labels" (id, name, _0_version) VALUES ('1', 'bug', '01');
 
-  INSERT INTO "comments" (id, issueID, text, _0_version) VALUES ('1', '1', 'comment 1', '00');
-  INSERT INTO "comments" (id, issueID, text, _0_version) VALUES ('2', '1', 'comment 2', '00');
+  INSERT INTO "comments" (id, issueID, text, _0_version) VALUES ('1', '1', 'comment 1', '01');
+  INSERT INTO "comments" (id, issueID, text, _0_version) VALUES ('2', '1', 'comment 2', '01');
   `);
 
   const cvrDB = await testDBs.create('view_syncer_service_test');
@@ -662,8 +662,8 @@ describe('view-syncer/service', () => {
           "pokeStart",
           {
             "baseCookie": "00:01",
-            "cookie": "00:02",
-            "pokeID": "00:02",
+            "cookie": "01",
+            "pokeID": "01",
             "schemaVersions": {
               "maxSupportedVersion": 3,
               "minSupportedVersion": 2,
@@ -708,7 +708,7 @@ describe('view-syncer/service', () => {
             "lastMutationIDChanges": {
               "foo": 42,
             },
-            "pokeID": "00:02",
+            "pokeID": "01",
             "rowsPatch": [
               {
                 "op": "put",
@@ -764,7 +764,7 @@ describe('view-syncer/service', () => {
         [
           "pokeEnd",
           {
-            "pokeID": "00:02",
+            "pokeID": "01",
           },
         ],
       ]
@@ -774,7 +774,7 @@ describe('view-syncer/service', () => {
       Result [
         {
           "clientGroupID": "9876",
-          "patchVersion": "00:02",
+          "patchVersion": "01",
           "refCounts": {
             "lmids": 1,
           },
@@ -782,59 +782,59 @@ describe('view-syncer/service', () => {
             "clientGroupID": "9876",
             "clientID": "foo",
           },
-          "rowVersion": "00",
+          "rowVersion": "01",
           "schema": "",
           "table": "zero_ABC.clients",
         },
         {
           "clientGroupID": "9876",
-          "patchVersion": "00:02",
+          "patchVersion": "01",
           "refCounts": {
             "query-hash1": 1,
           },
           "rowKey": {
             "id": "1",
           },
-          "rowVersion": "00",
+          "rowVersion": "01",
           "schema": "",
           "table": "issues",
         },
         {
           "clientGroupID": "9876",
-          "patchVersion": "00:02",
+          "patchVersion": "01",
           "refCounts": {
             "query-hash1": 1,
           },
           "rowKey": {
             "id": "2",
           },
-          "rowVersion": "00",
+          "rowVersion": "01",
           "schema": "",
           "table": "issues",
         },
         {
           "clientGroupID": "9876",
-          "patchVersion": "00:02",
+          "patchVersion": "01",
           "refCounts": {
             "query-hash1": 1,
           },
           "rowKey": {
             "id": "3",
           },
-          "rowVersion": "00",
+          "rowVersion": "01",
           "schema": "",
           "table": "issues",
         },
         {
           "clientGroupID": "9876",
-          "patchVersion": "00:02",
+          "patchVersion": "01",
           "refCounts": {
             "query-hash1": 1,
           },
           "rowKey": {
             "id": "4",
           },
-          "rowVersion": "00",
+          "rowVersion": "01",
           "schema": "",
           "table": "issues",
         },
@@ -927,156 +927,156 @@ describe('view-syncer/service', () => {
 
     stateChanges.push({state: 'version-ready'});
     expect(await nextPoke(client)).toMatchInlineSnapshot(`
-    [
       [
-        "pokeStart",
-        {
-          "baseCookie": "00:01",
-          "cookie": "00:02",
-          "pokeID": "00:02",
-          "schemaVersions": {
-            "maxSupportedVersion": 3,
-            "minSupportedVersion": 2,
+        [
+          "pokeStart",
+          {
+            "baseCookie": "00:01",
+            "cookie": "01",
+            "pokeID": "01",
+            "schemaVersions": {
+              "maxSupportedVersion": 3,
+              "minSupportedVersion": 2,
+            },
           },
-        },
-      ],
-      [
-        "pokePart",
-        {
-          "gotQueriesPatch": [
-            {
-              "ast": {
-                "orderBy": [
-                  [
-                    "id",
-                    "asc",
-                  ],
-                ],
-                "table": "issues",
-                "where": {
-                  "left": {
-                    "name": "id",
-                    "type": "column",
-                  },
-                  "op": "IN",
-                  "right": {
-                    "type": "literal",
-                    "value": [
-                      "1",
-                      "2",
-                      "3",
-                      "4",
+        ],
+        [
+          "pokePart",
+          {
+            "gotQueriesPatch": [
+              {
+                "ast": {
+                  "orderBy": [
+                    [
+                      "id",
+                      "asc",
                     ],
+                  ],
+                  "table": "issues",
+                  "where": {
+                    "left": {
+                      "name": "id",
+                      "type": "column",
+                    },
+                    "op": "IN",
+                    "right": {
+                      "type": "literal",
+                      "value": [
+                        "1",
+                        "2",
+                        "3",
+                        "4",
+                      ],
+                    },
+                    "type": "simple",
                   },
-                  "type": "simple",
+                },
+                "hash": "query-hash1",
+                "op": "put",
+              },
+              {
+                "ast": {
+                  "orderBy": [
+                    [
+                      "id",
+                      "asc",
+                    ],
+                  ],
+                  "table": "issues",
+                },
+                "hash": "query-hash2",
+                "op": "put",
+              },
+            ],
+            "lastMutationIDChanges": {
+              "foo": 42,
+            },
+            "pokeID": "01",
+            "rowsPatch": [
+              {
+                "op": "put",
+                "tableName": "issues",
+                "value": {
+                  "big": 9007199254740991,
+                  "id": "1",
+                  "json": null,
+                  "owner": "100",
+                  "parent": null,
+                  "title": "parent issue foo",
                 },
               },
-              "hash": "query-hash1",
-              "op": "put",
-            },
-            {
-              "ast": {
-                "orderBy": [
-                  [
-                    "id",
-                    "asc",
+              {
+                "op": "put",
+                "tableName": "issues",
+                "value": {
+                  "big": -9007199254740991,
+                  "id": "2",
+                  "json": null,
+                  "owner": "101",
+                  "parent": null,
+                  "title": "parent issue bar",
+                },
+              },
+              {
+                "op": "put",
+                "tableName": "issues",
+                "value": {
+                  "big": 123,
+                  "id": "3",
+                  "json": null,
+                  "owner": "102",
+                  "parent": "1",
+                  "title": "foo",
+                },
+              },
+              {
+                "op": "put",
+                "tableName": "issues",
+                "value": {
+                  "big": 100,
+                  "id": "4",
+                  "json": null,
+                  "owner": "101",
+                  "parent": "2",
+                  "title": "bar",
+                },
+              },
+              {
+                "op": "put",
+                "tableName": "issues",
+                "value": {
+                  "big": 100,
+                  "id": "5",
+                  "json": [
+                    123,
+                    {
+                      "bar": 789,
+                      "foo": 456,
+                    },
+                    "baz",
                   ],
-                ],
-                "table": "issues",
+                  "owner": "101",
+                  "parent": "2",
+                  "title": "not matched",
+                },
               },
-              "hash": "query-hash2",
-              "op": "put",
-            },
-          ],
-          "lastMutationIDChanges": {
-            "foo": 42,
+            ],
           },
-          "pokeID": "00:02",
-          "rowsPatch": [
-            {
-              "op": "put",
-              "tableName": "issues",
-              "value": {
-                "big": 9007199254740991,
-                "id": "1",
-                "json": null,
-                "owner": "100",
-                "parent": null,
-                "title": "parent issue foo",
-              },
-            },
-            {
-              "op": "put",
-              "tableName": "issues",
-              "value": {
-                "big": -9007199254740991,
-                "id": "2",
-                "json": null,
-                "owner": "101",
-                "parent": null,
-                "title": "parent issue bar",
-              },
-            },
-            {
-              "op": "put",
-              "tableName": "issues",
-              "value": {
-                "big": 123,
-                "id": "3",
-                "json": null,
-                "owner": "102",
-                "parent": "1",
-                "title": "foo",
-              },
-            },
-            {
-              "op": "put",
-              "tableName": "issues",
-              "value": {
-                "big": 100,
-                "id": "4",
-                "json": null,
-                "owner": "101",
-                "parent": "2",
-                "title": "bar",
-              },
-            },
-            {
-              "op": "put",
-              "tableName": "issues",
-              "value": {
-                "big": 100,
-                "id": "5",
-                "json": [
-                  123,
-                  {
-                    "bar": 789,
-                    "foo": 456,
-                  },
-                  "baz",
-                ],
-                "owner": "101",
-                "parent": "2",
-                "title": "not matched",
-              },
-            },
-          ],
-        },
-      ],
-      [
-        "pokeEnd",
-        {
-          "pokeID": "00:02",
-        },
-      ],
-    ]
-  `);
+        ],
+        [
+          "pokeEnd",
+          {
+            "pokeID": "01",
+          },
+        ],
+      ]
+    `);
 
     expect(await cvrDB`SELECT * from cvr.rows`).toMatchInlineSnapshot(`
       Result [
         {
           "clientGroupID": "9876",
-          "patchVersion": "00:02",
+          "patchVersion": "01",
           "refCounts": {
             "lmids": 1,
           },
@@ -1084,13 +1084,13 @@ describe('view-syncer/service', () => {
             "clientGroupID": "9876",
             "clientID": "foo",
           },
-          "rowVersion": "00",
+          "rowVersion": "01",
           "schema": "",
           "table": "zero_ABC.clients",
         },
         {
           "clientGroupID": "9876",
-          "patchVersion": "00:02",
+          "patchVersion": "01",
           "refCounts": {
             "query-hash1": 1,
             "query-hash2": 1,
@@ -1098,13 +1098,13 @@ describe('view-syncer/service', () => {
           "rowKey": {
             "id": "1",
           },
-          "rowVersion": "00",
+          "rowVersion": "01",
           "schema": "",
           "table": "issues",
         },
         {
           "clientGroupID": "9876",
-          "patchVersion": "00:02",
+          "patchVersion": "01",
           "refCounts": {
             "query-hash1": 1,
             "query-hash2": 1,
@@ -1112,13 +1112,13 @@ describe('view-syncer/service', () => {
           "rowKey": {
             "id": "2",
           },
-          "rowVersion": "00",
+          "rowVersion": "01",
           "schema": "",
           "table": "issues",
         },
         {
           "clientGroupID": "9876",
-          "patchVersion": "00:02",
+          "patchVersion": "01",
           "refCounts": {
             "query-hash1": 1,
             "query-hash2": 1,
@@ -1126,13 +1126,13 @@ describe('view-syncer/service', () => {
           "rowKey": {
             "id": "3",
           },
-          "rowVersion": "00",
+          "rowVersion": "01",
           "schema": "",
           "table": "issues",
         },
         {
           "clientGroupID": "9876",
-          "patchVersion": "00:02",
+          "patchVersion": "01",
           "refCounts": {
             "query-hash1": 1,
             "query-hash2": 1,
@@ -1140,20 +1140,20 @@ describe('view-syncer/service', () => {
           "rowKey": {
             "id": "4",
           },
-          "rowVersion": "00",
+          "rowVersion": "01",
           "schema": "",
           "table": "issues",
         },
         {
           "clientGroupID": "9876",
-          "patchVersion": "00:02",
+          "patchVersion": "01",
           "refCounts": {
             "query-hash2": 1,
           },
           "rowKey": {
             "id": "5",
           },
-          "rowVersion": "00",
+          "rowVersion": "01",
           "schema": "",
           "table": "issues",
         },
@@ -1357,8 +1357,8 @@ describe('view-syncer/service', () => {
         "pokeStart",
         {
           "baseCookie": "00:01",
-          "cookie": "00:02",
-          "pokeID": "00:02",
+          "cookie": "01",
+          "pokeID": "01",
           "schemaVersions": {
             "maxSupportedVersion": 3,
             "minSupportedVersion": 2,
@@ -1385,9 +1385,9 @@ describe('view-syncer/service', () => {
         [
           "pokeStart",
           {
-            "baseCookie": "00:02",
-            "cookie": "01",
-            "pokeID": "01",
+            "baseCookie": "01",
+            "cookie": "123",
+            "pokeID": "123",
             "schemaVersions": {
               "maxSupportedVersion": 3,
               "minSupportedVersion": 2,
@@ -1397,7 +1397,7 @@ describe('view-syncer/service', () => {
         [
           "pokePart",
           {
-            "pokeID": "01",
+            "pokeID": "123",
             "rowsPatch": [
               {
                 "op": "put",
@@ -1424,7 +1424,7 @@ describe('view-syncer/service', () => {
         [
           "pokeEnd",
           {
-            "pokeID": "01",
+            "pokeID": "123",
           },
         ],
       ]
@@ -1434,7 +1434,7 @@ describe('view-syncer/service', () => {
       Result [
         {
           "clientGroupID": "9876",
-          "patchVersion": "00:02",
+          "patchVersion": "01",
           "refCounts": {
             "lmids": 1,
           },
@@ -1442,50 +1442,9 @@ describe('view-syncer/service', () => {
             "clientGroupID": "9876",
             "clientID": "foo",
           },
-          "rowVersion": "00",
+          "rowVersion": "01",
           "schema": "",
           "table": "zero_ABC.clients",
-        },
-        {
-          "clientGroupID": "9876",
-          "patchVersion": "00:02",
-          "refCounts": {
-            "query-hash1": 1,
-            "query-hash2": 1,
-          },
-          "rowKey": {
-            "id": "3",
-          },
-          "rowVersion": "00",
-          "schema": "",
-          "table": "issues",
-        },
-        {
-          "clientGroupID": "9876",
-          "patchVersion": "00:02",
-          "refCounts": {
-            "query-hash1": 1,
-            "query-hash2": 1,
-          },
-          "rowKey": {
-            "id": "4",
-          },
-          "rowVersion": "00",
-          "schema": "",
-          "table": "issues",
-        },
-        {
-          "clientGroupID": "9876",
-          "patchVersion": "00:02",
-          "refCounts": {
-            "query-hash2": 1,
-          },
-          "rowKey": {
-            "id": "5",
-          },
-          "rowVersion": "00",
-          "schema": "",
-          "table": "issues",
         },
         {
           "clientGroupID": "9876",
@@ -1495,7 +1454,7 @@ describe('view-syncer/service', () => {
             "query-hash2": 1,
           },
           "rowKey": {
-            "id": "1",
+            "id": "3",
           },
           "rowVersion": "01",
           "schema": "",
@@ -1504,11 +1463,52 @@ describe('view-syncer/service', () => {
         {
           "clientGroupID": "9876",
           "patchVersion": "01",
+          "refCounts": {
+            "query-hash1": 1,
+            "query-hash2": 1,
+          },
+          "rowKey": {
+            "id": "4",
+          },
+          "rowVersion": "01",
+          "schema": "",
+          "table": "issues",
+        },
+        {
+          "clientGroupID": "9876",
+          "patchVersion": "01",
+          "refCounts": {
+            "query-hash2": 1,
+          },
+          "rowKey": {
+            "id": "5",
+          },
+          "rowVersion": "01",
+          "schema": "",
+          "table": "issues",
+        },
+        {
+          "clientGroupID": "9876",
+          "patchVersion": "123",
+          "refCounts": {
+            "query-hash1": 1,
+            "query-hash2": 1,
+          },
+          "rowKey": {
+            "id": "1",
+          },
+          "rowVersion": "123",
+          "schema": "",
+          "table": "issues",
+        },
+        {
+          "clientGroupID": "9876",
+          "patchVersion": "123",
           "refCounts": null,
           "rowKey": {
             "id": "2",
           },
-          "rowVersion": "00",
+          "rowVersion": "01",
           "schema": "",
           "table": "issues",
         },
@@ -1525,9 +1525,9 @@ describe('view-syncer/service', () => {
         [
           "pokeStart",
           {
-            "baseCookie": "01",
-            "cookie": "123",
-            "pokeID": "123",
+            "baseCookie": "123",
+            "cookie": "124",
+            "pokeID": "124",
             "schemaVersions": {
               "maxSupportedVersion": 3,
               "minSupportedVersion": 2,
@@ -1538,7 +1538,7 @@ describe('view-syncer/service', () => {
           "pokeEnd",
           {
             "cancel": true,
-            "pokeID": "123",
+            "pokeID": "124",
           },
         ],
       ]
@@ -1550,9 +1550,9 @@ describe('view-syncer/service', () => {
         [
           "pokeStart",
           {
-            "baseCookie": "01",
-            "cookie": "123",
-            "pokeID": "123",
+            "baseCookie": "123",
+            "cookie": "124",
+            "pokeID": "124",
             "schemaVersions": {
               "maxSupportedVersion": 3,
               "minSupportedVersion": 2,
@@ -1562,7 +1562,7 @@ describe('view-syncer/service', () => {
         [
           "pokePart",
           {
-            "pokeID": "123",
+            "pokeID": "124",
             "rowsPatch": [
               {
                 "id": {
@@ -1598,7 +1598,7 @@ describe('view-syncer/service', () => {
         [
           "pokeEnd",
           {
-            "pokeID": "123",
+            "pokeID": "124",
           },
         ],
       ]
@@ -1608,7 +1608,7 @@ describe('view-syncer/service', () => {
       Result [
         {
           "clientGroupID": "9876",
-          "patchVersion": "00:02",
+          "patchVersion": "01",
           "refCounts": {
             "lmids": 1,
           },
@@ -1616,27 +1616,16 @@ describe('view-syncer/service', () => {
             "clientGroupID": "9876",
             "clientID": "foo",
           },
-          "rowVersion": "00",
+          "rowVersion": "01",
           "schema": "",
           "table": "zero_ABC.clients",
-        },
-        {
-          "clientGroupID": "9876",
-          "patchVersion": "01",
-          "refCounts": null,
-          "rowKey": {
-            "id": "2",
-          },
-          "rowVersion": "00",
-          "schema": "",
-          "table": "issues",
         },
         {
           "clientGroupID": "9876",
           "patchVersion": "123",
           "refCounts": null,
           "rowKey": {
-            "id": "1",
+            "id": "2",
           },
           "rowVersion": "01",
           "schema": "",
@@ -1644,34 +1633,45 @@ describe('view-syncer/service', () => {
         },
         {
           "clientGroupID": "9876",
-          "patchVersion": "123",
+          "patchVersion": "124",
+          "refCounts": null,
+          "rowKey": {
+            "id": "1",
+          },
+          "rowVersion": "123",
+          "schema": "",
+          "table": "issues",
+        },
+        {
+          "clientGroupID": "9876",
+          "patchVersion": "124",
           "refCounts": null,
           "rowKey": {
             "id": "3",
           },
-          "rowVersion": "00",
+          "rowVersion": "01",
           "schema": "",
           "table": "issues",
         },
         {
           "clientGroupID": "9876",
-          "patchVersion": "123",
+          "patchVersion": "124",
           "refCounts": null,
           "rowKey": {
             "id": "4",
           },
-          "rowVersion": "00",
+          "rowVersion": "01",
           "schema": "",
           "table": "issues",
         },
         {
           "clientGroupID": "9876",
-          "patchVersion": "123",
+          "patchVersion": "124",
           "refCounts": null,
           "rowKey": {
             "id": "5",
           },
-          "rowVersion": "00",
+          "rowVersion": "01",
           "schema": "",
           "table": "issues",
         },
@@ -1826,8 +1826,8 @@ describe('view-syncer/service', () => {
         "pokeStart",
         {
           "baseCookie": "00:02",
-          "cookie": "00:03",
-          "pokeID": "00:03",
+          "cookie": "01",
+          "pokeID": "01",
           "schemaVersions": {
             "maxSupportedVersion": 3,
             "minSupportedVersion": 2,
@@ -1840,8 +1840,8 @@ describe('view-syncer/service', () => {
         "pokeStart",
         {
           "baseCookie": null,
-          "cookie": "00:03",
-          "pokeID": "00:03",
+          "cookie": "01",
+          "pokeID": "01",
           "schemaVersions": {
             "maxSupportedVersion": 3,
             "minSupportedVersion": 2,
@@ -1884,9 +1884,9 @@ describe('view-syncer/service', () => {
         [
           "pokeStart",
           {
-            "baseCookie": "00:03",
-            "cookie": "01",
-            "pokeID": "01",
+            "baseCookie": "01",
+            "cookie": "123",
+            "pokeID": "123",
             "schemaVersions": {
               "maxSupportedVersion": 3,
               "minSupportedVersion": 3,
@@ -1896,7 +1896,7 @@ describe('view-syncer/service', () => {
         [
           "pokePart",
           {
-            "pokeID": "01",
+            "pokeID": "123",
             "rowsPatch": [
               {
                 "op": "put",
@@ -1923,7 +1923,7 @@ describe('view-syncer/service', () => {
         [
           "pokeEnd",
           {
-            "pokeID": "01",
+            "pokeID": "123",
           },
         ],
       ]
@@ -2004,8 +2004,8 @@ describe('view-syncer/service', () => {
       'pokeStart',
       {
         baseCookie: '00:01',
-        cookie: '00:02',
-        pokeID: '00:02',
+        cookie: '01',
+        pokeID: '01',
         schemaVersions: {minSupportedVersion: 2, maxSupportedVersion: 3},
       },
     ]);
@@ -2023,9 +2023,9 @@ describe('view-syncer/service', () => {
         [
           "pokeStart",
           {
-            "baseCookie": "00:02",
-            "cookie": "01",
-            "pokeID": "01",
+            "baseCookie": "01",
+            "cookie": "07",
+            "pokeID": "07",
             "schemaVersions": {
               "maxSupportedVersion": 3,
               "minSupportedVersion": 2,
@@ -2036,7 +2036,7 @@ describe('view-syncer/service', () => {
           "pokeEnd",
           {
             "cancel": true,
-            "pokeID": "01",
+            "pokeID": "07",
           },
         ],
       ]
@@ -2048,9 +2048,9 @@ describe('view-syncer/service', () => {
         [
           "pokeStart",
           {
-            "baseCookie": "00:02",
-            "cookie": "01",
-            "pokeID": "01",
+            "baseCookie": "01",
+            "cookie": "07",
+            "pokeID": "07",
             "schemaVersions": {
               "maxSupportedVersion": 3,
               "minSupportedVersion": 2,
@@ -2060,7 +2060,7 @@ describe('view-syncer/service', () => {
         [
           "pokePart",
           {
-            "pokeID": "01",
+            "pokeID": "07",
             "rowsPatch": [
               {
                 "op": "put",
@@ -2120,7 +2120,7 @@ describe('view-syncer/service', () => {
         [
           "pokeEnd",
           {
-            "pokeID": "01",
+            "pokeID": "07",
           },
         ],
       ]
@@ -2200,8 +2200,8 @@ describe('view-syncer/service', () => {
     const preAdvancement = (await nextPoke(client1))[0][1] as PokeStartBody;
     expect(preAdvancement).toEqual({
       baseCookie: '00:01',
-      cookie: '00:02',
-      pokeID: '00:02',
+      cookie: '01',
+      pokeID: '01',
       schemaVersions: {minSupportedVersion: 2, maxSupportedVersion: 3},
     });
 
@@ -2239,7 +2239,7 @@ describe('view-syncer/service', () => {
           op: 'del',
         },
       ],
-      pokeID: '01',
+      pokeID: '123',
     });
 
     // Connect with another client (i.e. tab) at older version '00:02'
@@ -2260,164 +2260,164 @@ describe('view-syncer/service', () => {
     const response2 = await nextPoke(client2);
     expect(response2[1][1]).toMatchObject({
       ...advancement,
-      pokeID: '01:01',
+      pokeID: '123:01',
     });
     expect(response2).toMatchInlineSnapshot(`
+      [
         [
-          [
-            "pokeStart",
-            {
-              "baseCookie": "00:02",
-              "cookie": "01:01",
-              "pokeID": "01:01",
-              "schemaVersions": {
-                "maxSupportedVersion": 3,
-                "minSupportedVersion": 2,
-              },
+          "pokeStart",
+          {
+            "baseCookie": "01",
+            "cookie": "123:01",
+            "pokeID": "123:01",
+            "schemaVersions": {
+              "maxSupportedVersion": 3,
+              "minSupportedVersion": 2,
             },
-          ],
-          [
-            "pokePart",
-            {
-              "clientsPatch": [
+          },
+        ],
+        [
+          "pokePart",
+          {
+            "clientsPatch": [
+              {
+                "clientID": "bar",
+                "op": "put",
+              },
+            ],
+            "desiredQueriesPatches": {
+              "bar": [
                 {
-                  "clientID": "bar",
-                  "op": "put",
-                },
-              ],
-              "desiredQueriesPatches": {
-                "bar": [
-                  {
-                    "ast": {
-                      "orderBy": [
-                        [
-                          "id",
-                          "asc",
-                        ],
+                  "ast": {
+                    "orderBy": [
+                      [
+                        "id",
+                        "asc",
                       ],
-                      "table": "issues",
-                      "where": {
-                        "left": {
-                          "name": "id",
-                          "type": "column",
-                        },
-                        "op": "IN",
-                        "right": {
-                          "type": "literal",
-                          "value": [
-                            "1",
-                            "2",
-                            "3",
-                            "4",
-                          ],
-                        },
-                        "type": "simple",
+                    ],
+                    "table": "issues",
+                    "where": {
+                      "left": {
+                        "name": "id",
+                        "type": "column",
                       },
+                      "op": "IN",
+                      "right": {
+                        "type": "literal",
+                        "value": [
+                          "1",
+                          "2",
+                          "3",
+                          "4",
+                        ],
+                      },
+                      "type": "simple",
                     },
-                    "hash": "query-hash1",
-                    "op": "put",
                   },
-                ],
-              },
-              "pokeID": "01:01",
-              "rowsPatch": [
-                {
+                  "hash": "query-hash1",
                   "op": "put",
-                  "tableName": "issues",
-                  "value": {
-                    "big": 9007199254740991,
-                    "id": "1",
-                    "json": null,
-                    "owner": "100.0",
-                    "parent": null,
-                    "title": "new title",
-                  },
-                },
-                {
-                  "id": {
-                    "id": "2",
-                  },
-                  "op": "del",
-                  "tableName": "issues",
                 },
               ],
             },
-          ],
-          [
-            "pokeEnd",
-            {
-              "pokeID": "01:01",
-            },
-          ],
-        ]
-      `);
+            "pokeID": "123:01",
+            "rowsPatch": [
+              {
+                "op": "put",
+                "tableName": "issues",
+                "value": {
+                  "big": 9007199254740991,
+                  "id": "1",
+                  "json": null,
+                  "owner": "100.0",
+                  "parent": null,
+                  "title": "new title",
+                },
+              },
+              {
+                "id": {
+                  "id": "2",
+                },
+                "op": "del",
+                "tableName": "issues",
+              },
+            ],
+          },
+        ],
+        [
+          "pokeEnd",
+          {
+            "pokeID": "123:01",
+          },
+        ],
+      ]
+    `);
 
     // client1 should be poked to get the new client2 config,
     // but no new entities.
     expect(await nextPoke(client1)).toMatchInlineSnapshot(`
+      [
+        [
+          "pokeStart",
+          {
+            "baseCookie": "123",
+            "cookie": "123:01",
+            "pokeID": "123:01",
+          },
+        ],
+        [
+          "pokePart",
+          {
+            "clientsPatch": [
+              {
+                "clientID": "bar",
+                "op": "put",
+              },
+            ],
+            "desiredQueriesPatches": {
+              "bar": [
+                {
+                  "ast": {
+                    "orderBy": [
                       [
-                        [
-                          "pokeStart",
-                          {
-                            "baseCookie": "01",
-                            "cookie": "01:01",
-                            "pokeID": "01:01",
-                          },
+                        "id",
+                        "asc",
+                      ],
+                    ],
+                    "table": "issues",
+                    "where": {
+                      "left": {
+                        "name": "id",
+                        "type": "column",
+                      },
+                      "op": "IN",
+                      "right": {
+                        "type": "literal",
+                        "value": [
+                          "1",
+                          "2",
+                          "3",
+                          "4",
                         ],
-                        [
-                          "pokePart",
-                          {
-                            "clientsPatch": [
-                              {
-                                "clientID": "bar",
-                                "op": "put",
-                              },
-                            ],
-                            "desiredQueriesPatches": {
-                              "bar": [
-                                {
-                                  "ast": {
-                                    "orderBy": [
-                                      [
-                                        "id",
-                                        "asc",
-                                      ],
-                                    ],
-                                    "table": "issues",
-                                    "where": {
-                                      "left": {
-                                        "name": "id",
-                                        "type": "column",
-                                      },
-                                      "op": "IN",
-                                      "right": {
-                                        "type": "literal",
-                                        "value": [
-                                          "1",
-                                          "2",
-                                          "3",
-                                          "4",
-                                        ],
-                                      },
-                                      "type": "simple",
-                                    },
-                                  },
-                                  "hash": "query-hash1",
-                                  "op": "put",
-                                },
-                              ],
-                            },
-                            "pokeID": "01:01",
-                          },
-                        ],
-                        [
-                          "pokeEnd",
-                          {
-                            "pokeID": "01:01",
-                          },
-                        ],
-                      ]
-                    `);
+                      },
+                      "type": "simple",
+                    },
+                  },
+                  "hash": "query-hash1",
+                  "op": "put",
+                },
+              ],
+            },
+            "pokeID": "123:01",
+          },
+        ],
+        [
+          "pokeEnd",
+          {
+            "pokeID": "123:01",
+          },
+        ],
+      ]
+    `);
   });
 
   test('catch up new client before advancement', async () => {
@@ -2430,8 +2430,8 @@ describe('view-syncer/service', () => {
     const preAdvancement = (await nextPoke(client1))[0][1] as PokeStartBody;
     expect(preAdvancement).toEqual({
       baseCookie: '00:01',
-      cookie: '00:02',
-      pokeID: '00:02',
+      cookie: '01',
+      pokeID: '01',
       schemaVersions: {minSupportedVersion: 2, maxSupportedVersion: 3},
     });
 
@@ -2462,8 +2462,8 @@ describe('view-syncer/service', () => {
           "pokeStart",
           {
             "baseCookie": null,
-            "cookie": "01:01",
-            "pokeID": "01:01",
+            "cookie": "123:01",
+            "pokeID": "123:01",
             "schemaVersions": {
               "maxSupportedVersion": 3,
               "minSupportedVersion": 2,
@@ -2584,7 +2584,7 @@ describe('view-syncer/service', () => {
             "lastMutationIDChanges": {
               "foo": 42,
             },
-            "pokeID": "01:01",
+            "pokeID": "123:01",
             "rowsPatch": [
               {
                 "op": "put",
@@ -2635,7 +2635,7 @@ describe('view-syncer/service', () => {
         [
           "pokeEnd",
           {
-            "pokeID": "01:01",
+            "pokeID": "123:01",
           },
         ],
       ]
@@ -2644,7 +2644,7 @@ describe('view-syncer/service', () => {
 
   test('waits for replica to catch up', async () => {
     // Before connecting, artificially set the CVR version to '07',
-    // which is ahead of the current replica version '00'.
+    // which is ahead of the current replica version '01'.
     const cvrStore = new CVRStore(lc, cvrDB, TASK_ID, serviceID, ON_FAILURE);
     await new CVRQueryDrivenUpdater(
       cvrStore,
@@ -2675,14 +2675,14 @@ describe('view-syncer/service', () => {
     await expectNoPokes(client);
 
     replica.prepare(`DELETE from issues where id = '3'`).run();
-    updateReplicationWatermark(db, '07');
+    updateReplicationWatermark(db, '06');
     stateChanges.push({state: 'version-ready'});
     await expectNoPokes(client);
 
     replica
       .prepare(`UPDATE issues SET title = 'caught up' where id = '4'`)
       .run();
-    updateReplicationWatermark(db, '09'); // Caught up with stateVersion=07, watermark=09.
+    updateReplicationWatermark(db, '07'); // Caught up with stateVersion=07, watermark=09.
     stateChanges.push({state: 'version-ready'});
 
     // The single poke should only contain issues {id='4', title='caught up'}
@@ -2805,36 +2805,6 @@ describe('view-syncer/service', () => {
     `);
   });
 
-  test('sends reset for CVR from different replica version up', async () => {
-    const cvrStore = new CVRStore(lc, cvrDB, TASK_ID, serviceID, ON_FAILURE);
-    await new CVRQueryDrivenUpdater(
-      cvrStore,
-      await cvrStore.load(lc, Date.now()),
-      '07',
-      '1' + REPLICA_VERSION, // Different replica version.
-    ).flush(lc, Date.now());
-
-    // Connect the client.
-    const client = connect(SYNC_CONTEXT, [
-      {op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY},
-    ]);
-
-    // Signal that the replica is ready.
-    stateChanges.push({state: 'version-ready'});
-
-    let result;
-    try {
-      result = await client.dequeue();
-    } catch (e) {
-      result = e;
-    }
-    expect(result).toBeInstanceOf(ErrorForClient);
-    expect((result as ErrorForClient).errorBody).toEqual({
-      kind: ErrorKind.ClientNotFound,
-      message: 'Replica Version mismatch: CVR=101, DB=01',
-    } satisfies ErrorBody);
-  });
-
   test('sends client not found if CVR is not found', async () => {
     // Connect the client at a non-empty base cookie.
     const client = connect({...SYNC_CONTEXT, baseCookie: '00:02'}, [
@@ -2945,57 +2915,57 @@ describe('view-syncer/service', () => {
 
     stateChanges.push({state: 'version-ready'});
     expect(await nextPoke(client)).toMatchInlineSnapshot(`
-                  [
-                    [
-                      "pokeStart",
-                      {
-                        "baseCookie": "00:02",
-                        "cookie": "01",
-                        "pokeID": "01",
-                        "schemaVersions": {
-                          "maxSupportedVersion": 3,
-                          "minSupportedVersion": 2,
-                        },
-                      },
-                    ],
-                    [
-                      "pokePart",
-                      {
-                        "pokeID": "01",
-                        "rowsPatch": [
-                          {
-                            "id": {
-                              "issueID": "1",
-                              "labelID": "1",
-                            },
-                            "op": "del",
-                            "tableName": "issueLabels",
-                          },
-                          {
-                            "id": {
-                              "id": "1",
-                            },
-                            "op": "del",
-                            "tableName": "labels",
-                          },
-                          {
-                            "id": {
-                              "id": "2",
-                            },
-                            "op": "del",
-                            "tableName": "issues",
-                          },
-                        ],
-                      },
-                    ],
-                    [
-                      "pokeEnd",
-                      {
-                        "pokeID": "01",
-                      },
-                    ],
-                  ]
-                `);
+      [
+        [
+          "pokeStart",
+          {
+            "baseCookie": "01",
+            "cookie": "123",
+            "pokeID": "123",
+            "schemaVersions": {
+              "maxSupportedVersion": 3,
+              "minSupportedVersion": 2,
+            },
+          },
+        ],
+        [
+          "pokePart",
+          {
+            "pokeID": "123",
+            "rowsPatch": [
+              {
+                "id": {
+                  "issueID": "1",
+                  "labelID": "1",
+                },
+                "op": "del",
+                "tableName": "issueLabels",
+              },
+              {
+                "id": {
+                  "id": "1",
+                },
+                "op": "del",
+                "tableName": "labels",
+              },
+              {
+                "id": {
+                  "id": "2",
+                },
+                "op": "del",
+                "tableName": "issues",
+              },
+            ],
+          },
+        ],
+        [
+          "pokeEnd",
+          {
+            "pokeID": "123",
+          },
+        ],
+      ]
+    `);
   });
 });
 
@@ -3054,8 +3024,8 @@ describe('permissions', () => {
           "pokeStart",
           {
             "baseCookie": "00:01",
-            "cookie": "00:02",
-            "pokeID": "00:02",
+            "cookie": "01",
+            "pokeID": "01",
             "schemaVersions": {
               "maxSupportedVersion": 3,
               "minSupportedVersion": 2,
@@ -3100,13 +3070,13 @@ describe('permissions', () => {
             "lastMutationIDChanges": {
               "foo": 42,
             },
-            "pokeID": "00:02",
+            "pokeID": "01",
           },
         ],
         [
           "pokeEnd",
           {
-            "pokeID": "00:02",
+            "pokeID": "01",
           },
         ],
       ]
@@ -3132,8 +3102,8 @@ describe('permissions', () => {
           "pokeStart",
           {
             "baseCookie": null,
-            "cookie": "00:04",
-            "pokeID": "00:04",
+            "cookie": "01:02",
+            "pokeID": "01:02",
             "schemaVersions": {
               "maxSupportedVersion": 3,
               "minSupportedVersion": 2,
@@ -3254,7 +3224,7 @@ describe('permissions', () => {
             "lastMutationIDChanges": {
               "foo": 42,
             },
-            "pokeID": "00:04",
+            "pokeID": "01:02",
             "rowsPatch": [
               {
                 "op": "put",
@@ -3310,7 +3280,7 @@ describe('permissions', () => {
         [
           "pokeEnd",
           {
-            "pokeID": "00:04",
+            "pokeID": "01:02",
           },
         ],
       ]
@@ -3330,8 +3300,8 @@ describe('permissions', () => {
           "pokeStart",
           {
             "baseCookie": "00:01",
-            "cookie": "00:02",
-            "pokeID": "00:02",
+            "cookie": "01",
+            "pokeID": "01",
             "schemaVersions": {
               "maxSupportedVersion": 3,
               "minSupportedVersion": 2,
@@ -3359,13 +3329,13 @@ describe('permissions', () => {
             "lastMutationIDChanges": {
               "foo": 42,
             },
-            "pokeID": "00:02",
+            "pokeID": "01",
           },
         ],
         [
           "pokeEnd",
           {
-            "pokeID": "00:02",
+            "pokeID": "01",
           },
         ],
       ]
@@ -3394,8 +3364,8 @@ describe('permissions', () => {
           "pokeStart",
           {
             "baseCookie": "00:01",
-            "cookie": "00:02",
-            "pokeID": "00:02",
+            "cookie": "01",
+            "pokeID": "01",
             "schemaVersions": {
               "maxSupportedVersion": 3,
               "minSupportedVersion": 2,
@@ -3423,7 +3393,7 @@ describe('permissions', () => {
             "lastMutationIDChanges": {
               "foo": 42,
             },
-            "pokeID": "00:02",
+            "pokeID": "01",
             "rowsPatch": [
               {
                 "op": "put",
@@ -3449,7 +3419,7 @@ describe('permissions', () => {
         [
           "pokeEnd",
           {
-            "pokeID": "00:02",
+            "pokeID": "01",
           },
         ],
       ]

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -193,18 +193,6 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           this.#pipelines.init();
         }
         await this.#runInLockWithCVR(async (lc, cvr) => {
-          if (
-            (cvr.replicaVersion !== null ||
-              cvr.version.stateVersion !== '00') &&
-            cvr.replicaVersion !== this.#pipelines.replicaVersion
-          ) {
-            const message = `Replica Version mismatch: CVR=${
-              cvr.replicaVersion
-            }, DB=${this.#pipelines.replicaVersion}`;
-            lc.info?.(`resetting CVR: ${message}`);
-            throw new ErrorForClient({kind: ErrorKind.ClientNotFound, message});
-          }
-
           if (this.#pipelinesSynced) {
             const result = await this.#advancePipelines(lc, cvr);
             if (result === 'success') {

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -193,6 +193,18 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           this.#pipelines.init();
         }
         await this.#runInLockWithCVR(async (lc, cvr) => {
+          if (
+            cvr.replicaVersion !== null &&
+            cvr.version.stateVersion !== '00' &&
+            this.#pipelines.replicaVersion < cvr.replicaVersion
+          ) {
+            const message = `Cannot sync from older replica: CVR=${
+              cvr.replicaVersion
+            }, DB=${this.#pipelines.replicaVersion}`;
+            lc.info?.(`resetting CVR: ${message}`);
+            throw new ErrorForClient({kind: ErrorKind.ClientNotFound, message});
+          }
+
           if (this.#pipelinesSynced) {
             const result = await this.#advancePipelines(lc, cvr);
             if (result === 'success') {

--- a/prod/templates/sandbox/template.yml
+++ b/prod/templates/sandbox/template.yml
@@ -196,7 +196,7 @@ Resources:
             - Name: ZERO_REPLICA_FILE
               Value: /data/db/sync-replica.db
             - Name: ZERO_LITESTREAM_BACKUP_URL
-              Value: !Sub "s3://${ApplicationBucket}/0102"
+              Value: !Sub "s3://${ApplicationBucket}/0113"
             - Name: ZERO_LOG_LEVEL
               Value: debug
             - Name: ZERO_UPSTREAM_MAX_CONNS
@@ -357,7 +357,7 @@ Resources:
             - Name: ZERO_NUM_SYNC_WORKERS
               Value: "0"
             - Name: ZERO_LITESTREAM_BACKUP_URL
-              Value: !Sub "s3://${ApplicationBucket}/0102"
+              Value: !Sub "s3://${ApplicationBucket}/0113"
             - Name: ZERO_LOG_FORMAT
               Value: json
             - Name: ZERO_REPLICA_FILE

--- a/prod/templates/template.yml
+++ b/prod/templates/template.yml
@@ -212,7 +212,7 @@ Resources:
             - Name: ZERO_REPLICA_FILE
               Value: /data/db/sync-replica.db
             - Name: ZERO_LITESTREAM_BACKUP_URL
-              Value: !Sub "s3://${ApplicationBucket}/1208b"
+              Value: !Sub "s3://${ApplicationBucket}/0113"
             - Name: ZERO_LOG_LEVEL
               Value: debug
             - Name: ZERO_UPSTREAM_MAX_CONNS
@@ -377,7 +377,7 @@ Resources:
             - Name: ZERO_NUM_SYNC_WORKERS
               Value: "0"
             - Name: ZERO_LITESTREAM_BACKUP_URL
-              Value: !Sub "s3://${ApplicationBucket}/1208b"
+              Value: !Sub "s3://${ApplicationBucket}/0113"
             - Name: ZERO_LOG_FORMAT
               Value: json
             - Name: ZERO_REPLICA_FILE


### PR DESCRIPTION
Migrate to replica schema v2: https://bugs.rocicorp.dev/issue/3404

Main change:
* Initial sync sets row versions to the LSN at the initial sync point, rather than '00'
* All subsequent transactions get versions from the associated commit LSN, rather than (confusingly) the previous one

Side effect:
* Newly synced replicas are backwards compatible with CVRs from old replicas, as there's no longer ambiguity in what a row's '00' version is. When a CVR hits a new replica, the rows will be re-downloaded (because they have a later version in the new replica), but we no longer need to drop other client state (clients, queries, pending mutations, etc.).
* If a CVR hits an older replica (for whatever reason ... e.g. upstream gets completely wiped and starts the WAL over), we drop it as we do today.