### PR TITLE
feat(zero-client): Add `storageKey` constructor param.

### DIFF
--- a/packages/zero-client/src/client/options.ts
+++ b/packages/zero-client/src/client/options.ts
@@ -38,14 +38,21 @@ export interface ZeroOptions<S extends Schema> {
   /**
    * A unique identifier for the user. Must be non-empty.
    *
-   * For efficiency, a new Zero instance will initialize its state from
-   * the persisted state of an existing Zero instance with the same
-   * `userID`, domain and browser profile.
+   * Each userID gets its own client-side storage so that the app can switch
+   * between users without losing state.
    *
    * This must match the user identified by the `auth` token if
    * `auth` is provided.
    */
   userID: string;
+
+  /**
+   * Distinguishes the storage used by this Zero instance from that of other
+   * instances with the same userID. Useful in the case where the app wants to
+   * have multiple Zero instances for the same user for different parts of the
+   * app.
+   */
+  storageKey?: string | undefined;
 
   /**
    * Determines the level of detail at which Zero logs messages about

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -248,6 +248,7 @@ export class Zero<const S extends Schema> {
   readonly #rep: ReplicacheImpl<WithCRUD<MutatorDefs>>;
   readonly #server: HTTPString | null;
   readonly userID: string;
+  readonly storageKey: string;
 
   readonly #lc: LogContext;
   readonly #logOptions: LogOptions;
@@ -361,6 +362,7 @@ export class Zero<const S extends Schema> {
   constructor(options: ZeroOptions<S>) {
     const {
       userID,
+      storageKey,
       onOnlineChange,
       onUpdateNeeded,
       onClientStateNotFound,
@@ -401,6 +403,8 @@ export class Zero<const S extends Schema> {
       ['_zero_crud']: makeCRUDMutator(normalizedSchema),
     };
 
+    this.storageKey = storageKey ?? '';
+
     const replicacheOptions: ReplicacheOptions<WithCRUD<MutatorDefs>> = {
       // The schema stored in IDB is dependent upon both the application schema
       // and the AST schema (i.e. PROTOCOL_VERSION).
@@ -408,7 +412,7 @@ export class Zero<const S extends Schema> {
       logLevel: logOptions.logLevel,
       logSinks: [logOptions.logSink],
       mutators: replicacheMutators,
-      name: `zero-${userID}`,
+      name: `zero-${userID}-${this.storageKey}`,
       pusher: (req, reqID) => this.#pusher(req, reqID),
       puller: (req, reqID) => this.#puller(req, reqID),
       pushDelay: 0,


### PR DESCRIPTION
I couldn't figure out how to test this. I added a test like this to `zero.test.ts` and it behaves as if the storage isn't shared while I can plainly see it is in the real browser. Also couldn't figure out how to open a debugger to test:

```ts
test('storage partioning', async () => {
  const schema = {
    version: 1,
    tables: {
      foo: {
        columns: {
          id: {type: 'string'},
          val: {type: 'number'},
        },
        primaryKey: ['id'],
        tableName: 'foo',
      },
    },
  } as const;

  const z1 = zeroForTest({
    schema,
    userID: 'u1',
    kvStore: 'idb',
  });

  await z1.mutate.foo.insert({id: 'a', val: 1});
  await z1.close();

  const z2 = zeroForTest({
    schema,
    userID: 'u1',
    kvStore: 'idb',
  });

  const {promise, resolve} = resolver();
  const view = z2.query.foo.where('id', 'a').one().materialize();
  view.addListener((row, type) => {
    console.log(row, type);
    if (type === 'complete') {
      expect(row).deep.equal({id: 'a', val: 1});
      resolve();
    }
  });

  await promise;
});

```