### PR TITLE
chore(zql): add noop output to ivm operators

### DIFF
--- a/packages/zql/src/ivm/exists.ts
+++ b/packages/zql/src/ivm/exists.ts
@@ -5,12 +5,13 @@ import type {CompoundKey} from '../../../zero-protocol/src/ast.js';
 import type {Row} from '../../../zero-protocol/src/data.js';
 import {rowForChange, type Change} from './change.js';
 import {normalizeUndefined, type NormalizedValue} from './data.js';
-import type {
-  FetchRequest,
-  Input,
-  Operator,
-  Output,
-  Storage,
+import {
+  throwOutput,
+  type FetchRequest,
+  type Input,
+  type Operator,
+  type Output,
+  type Storage,
 } from './operator.js';
 import type {SourceSchema} from './schema.js';
 import {first} from './stream.js';
@@ -37,7 +38,7 @@ export class Exists implements Operator {
   readonly #parentJoinKey: CompoundKey;
   readonly #skipCache: boolean;
 
-  #output: Output | undefined;
+  #output: Output = throwOutput;
 
   constructor(
     input: Input,
@@ -91,8 +92,6 @@ export class Exists implements Operator {
   }
 
   push(change: Change) {
-    assert(this.#output, 'Output not set');
-
     switch (change.type) {
       // add, remove and edit cannot change the size of the
       // this.#relationshipName relationship, so simply #pushWithFilter
@@ -216,7 +215,7 @@ export class Exists implements Operator {
   #pushWithFilter(change: Change, size?: number): void {
     const row = rowForChange(change);
     if (this.#filter(row, size)) {
-      must(this.#output).push(change);
+      this.#output.push(change);
     }
   }
 

--- a/packages/zql/src/ivm/fan-in.ts
+++ b/packages/zql/src/ivm/fan-in.ts
@@ -4,7 +4,13 @@ import {must} from '../../../shared/src/must.js';
 import type {Change} from './change.js';
 import type {Node} from './data.js';
 import type {FanOut} from './fan-out.js';
-import type {FetchRequest, Input, Operator, Output} from './operator.js';
+import {
+  throwOutput,
+  type FetchRequest,
+  type Input,
+  type Operator,
+  type Output,
+} from './operator.js';
 import type {SourceSchema} from './schema.js';
 import type {Stream} from './stream.js';
 
@@ -26,7 +32,7 @@ export class FanIn implements Operator {
   readonly #inputs: readonly Input[];
   readonly #fanOut: FanOut;
   readonly #schema: SourceSchema;
-  #output: Output | undefined;
+  #output: Output = throwOutput;
 
   constructor(fanOut: FanOut, inputs: Input[]) {
     this.#inputs = inputs;
@@ -71,6 +77,6 @@ export class FanIn implements Operator {
 
   push(change: Change) {
     this.#fanOut.onFanInReceivedPush();
-    this.#output?.push(change);
+    this.#output.push(change);
   }
 }

--- a/packages/zql/src/ivm/filter.ts
+++ b/packages/zql/src/ivm/filter.ts
@@ -1,9 +1,15 @@
-import {assert, unreachable} from '../../../shared/src/asserts.js';
+import {unreachable} from '../../../shared/src/asserts.js';
 import type {Row} from '../../../zero-protocol/src/data.js';
 import type {Change} from './change.js';
 import type {Node} from './data.js';
 import {maybeSplitAndPushEditChange} from './maybe-split-and-push-edit-change.js';
-import type {FetchRequest, Input, Operator, Output} from './operator.js';
+import {
+  throwOutput,
+  type FetchRequest,
+  type Input,
+  type Operator,
+  type Output,
+} from './operator.js';
 import type {SourceSchema} from './schema.js';
 import type {Stream} from './stream.js';
 
@@ -24,7 +30,7 @@ export class Filter implements Operator {
   readonly #mode: Mode;
   readonly #predicate: (row: Row) => boolean;
 
-  #output: Output | undefined;
+  #output: Output = throwOutput;
 
   constructor(input: Input, mode: Mode, predicate: (row: Row) => boolean) {
     this.#input = input;
@@ -62,8 +68,6 @@ export class Filter implements Operator {
   }
 
   push(change: Change) {
-    assert(this.#output, 'Output not set');
-
     switch (change.type) {
       case 'add':
       case 'remove':

--- a/packages/zql/src/ivm/join.ts
+++ b/packages/zql/src/ivm/join.ts
@@ -4,7 +4,13 @@ import type {Row, Value} from '../../../zero-protocol/src/data.js';
 import type {PrimaryKey} from '../../../zero-protocol/src/primary-key.js';
 import type {Change, ChildChange} from './change.js';
 import {valuesEqual, type Node} from './data.js';
-import type {FetchRequest, Input, Output, Storage} from './operator.js';
+import {
+  throwOutput,
+  type FetchRequest,
+  type Input,
+  type Output,
+  type Storage,
+} from './operator.js';
 import type {SourceSchema} from './schema.js';
 import {take, type Stream} from './stream.js';
 
@@ -42,7 +48,7 @@ export class Join implements Input {
   readonly #relationshipName: string;
   readonly #schema: SourceSchema;
 
-  #output: Output | null = null;
+  #output: Output = throwOutput;
 
   constructor({
     parent,
@@ -122,8 +128,6 @@ export class Join implements Input {
   }
 
   #pushParent(change: Change): void {
-    assert(this.#output, 'Output not set');
-
     switch (change.type) {
       case 'add':
         this.#output.push({
@@ -194,8 +198,6 @@ export class Join implements Input {
 
   #pushChild(change: Change): void {
     const pushChildChange = (childRow: Row, change: Change) => {
-      assert(this.#output, 'Output not set');
-
       const parentNodes = this.#parent.fetch({
         constraint: Object.fromEntries(
           this.#parentKey.map((key, i) => [key, childRow[this.#childKey[i]]]),

--- a/packages/zql/src/ivm/operator.ts
+++ b/packages/zql/src/ivm/operator.ts
@@ -74,6 +74,16 @@ export interface Output {
 }
 
 /**
+ * An implementation of Output that throws if pushed to. It is used as the
+ * initial value for for an operator's output before it is set.
+ */
+export const throwOutput: Output = {
+  push(_change: Change): void {
+    throw new Error('Output not set');
+  },
+};
+
+/**
  * Operators are arranged into pipelines.
  * They are stateful.
  * Each operator is an input to the next operator in the chain and an output

--- a/packages/zql/src/ivm/skip.ts
+++ b/packages/zql/src/ivm/skip.ts
@@ -1,9 +1,15 @@
-import {assert} from '../../../shared/src/asserts.js';
 import type {Row} from '../../../zero-protocol/src/data.js';
 import type {AddChange, Change, ChildChange, RemoveChange} from './change.js';
 import type {Comparator, Node} from './data.js';
 import {maybeSplitAndPushEditChange} from './maybe-split-and-push-edit-change.js';
-import type {FetchRequest, Input, Operator, Output, Start} from './operator.js';
+import {
+  throwOutput,
+  type FetchRequest,
+  type Input,
+  type Operator,
+  type Output,
+  type Start,
+} from './operator.js';
 import type {SourceSchema} from './schema.js';
 import type {Stream} from './stream.js';
 
@@ -21,7 +27,7 @@ export class Skip implements Operator {
   readonly #bound: Bound;
   readonly #comparator: Comparator;
 
-  #output: Output | undefined;
+  #output: Output = throwOutput;
 
   constructor(input: Input, bound: Bound) {
     this.#input = input;
@@ -74,8 +80,6 @@ export class Skip implements Operator {
   }
 
   push(change: Change): void {
-    assert(this.#output, 'Output not set');
-
     const shouldBePresent = (row: Row) => this.#shouldBePresent(row);
     if (change.type === 'edit') {
       maybeSplitAndPushEditChange(change, shouldBePresent, this.#output);

--- a/packages/zql/src/ivm/snitch.ts
+++ b/packages/zql/src/ivm/snitch.ts
@@ -1,8 +1,13 @@
-import {assert, unreachable} from '../../../shared/src/asserts.js';
+import {unreachable} from '../../../shared/src/asserts.js';
 import type {Row} from '../../../zero-protocol/src/data.js';
 import type {Change} from './change.js';
 import type {Node} from './data.js';
-import type {FetchRequest, Input, Operator, Output} from './operator.js';
+import {
+  type FetchRequest,
+  type Input,
+  type Operator,
+  type Output,
+} from './operator.js';
 import type {SourceSchema} from './schema.js';
 import type {Stream} from './stream.js';
 
@@ -51,7 +56,6 @@ export class Snitch implements Operator {
   }
 
   fetch(req: FetchRequest): Stream<Node> {
-    assert(this.#output);
     this.#log([this.#name, 'fetch', req]);
     return this.fetchGenerator(req);
   }
@@ -69,7 +73,6 @@ export class Snitch implements Operator {
   }
 
   cleanup(req: FetchRequest) {
-    assert(this.#output);
     this.#log([this.#name, 'cleanup', req]);
     return this.#input.cleanup(req);
   }

--- a/packages/zql/src/ivm/take.ts
+++ b/packages/zql/src/ivm/take.ts
@@ -12,12 +12,13 @@ import {
 } from './change.js';
 import type {Constraint} from './constraint.js';
 import {compareValues, type Comparator, type Node} from './data.js';
-import type {
-  FetchRequest,
-  Input,
-  Operator,
-  Output,
-  Storage,
+import {
+  throwOutput,
+  type FetchRequest,
+  type Input,
+  type Operator,
+  type Output,
+  type Storage,
 } from './operator.js';
 import type {SourceSchema} from './schema.js';
 import {first, take, type Stream} from './stream.js';
@@ -54,7 +55,7 @@ export class Take implements Operator {
   readonly #partitionKey: PartitionKey | undefined;
   readonly #partitionKeyComparator: Comparator | undefined;
 
-  #output: Output | null = null;
+  #output: Output = throwOutput;
 
   constructor(
     input: Input,
@@ -231,8 +232,6 @@ export class Take implements Operator {
       return;
     }
 
-    assert(this.#output, 'Output not set');
-
     const {takeState, takeStateKey, maxBound, constraint} =
       this.#getStateAndConstraint(rowForChange(change));
     if (!takeState) {
@@ -385,8 +384,6 @@ export class Take implements Operator {
   }
 
   #pushEditChange(change: EditChange): void {
-    assert(this.#output, 'Output not set');
-
     if (
       this.#partitionKeyComparator &&
       this.#partitionKeyComparator(change.oldNode.row, change.node.row) !== 0
@@ -430,7 +427,7 @@ export class Take implements Operator {
         change.node.row,
         maxBound,
       );
-      this.#output!.push(change);
+      this.#output.push(change);
     };
 
     // The bounds row was changed.


### PR DESCRIPTION
Instead of having to keep checking if output is set we initialize it to a noop Output object.