### PR TITLE
chore(zero-cache): multi-node integration test

### DIFF
--- a/packages/zero-cache/src/server/life-cycle.test.ts
+++ b/packages/zero-cache/src/server/life-cycle.test.ts
@@ -64,11 +64,7 @@ describe('shutdown', () => {
 
   beforeEach(async () => {
     proc = new EventEmitter();
-    processes = new ProcessManager(
-      lc,
-      proc,
-      code => proc.emit('exit', code) as never,
-    );
+    processes = new ProcessManager(lc, proc);
     events = [];
     changeStreamer = startWorker('cs', 'supporting');
     replicator = startWorker('rep', 'supporting');
@@ -225,11 +221,7 @@ describe('shutdown', () => {
 
   test('graceful shutdown with no user-facing workers', async () => {
     proc = new EventEmitter();
-    processes = new ProcessManager(
-      lc,
-      proc,
-      code => proc.emit('exit', code) as never,
-    );
+    processes = new ProcessManager(lc, proc);
     const changeStreamer = startWorker('cs', 'supporting');
     const replicator = startWorker('rep', 'supporting');
     const all = [changeStreamer, replicator];


### PR DESCRIPTION
Adds an integration test configuration that runs a `view-syncer` zero-cache connecting to a `replication-manager` integration test.