### PR TITLE
chore(zero-cache): factor out websocket error handling code

### DIFF
--- a/packages/zero-cache/src/services/dispatcher/websocket-handoff.ts
+++ b/packages/zero-cache/src/services/dispatcher/websocket-handoff.ts
@@ -12,6 +12,7 @@ import {
   type Sender,
   type Worker,
 } from '../../types/processes.js';
+import {closeWithProtocolError} from '../../types/ws.js';
 
 export type WebSocketHandoff<P> = (message: IncomingMessageSubset) => {
   payload: P;
@@ -51,13 +52,11 @@ export function installWebSocketHandoff<P>(
       // https://nodejs.org/api/http.html#event-upgrade
       receiver.send(data, socket as Socket);
     } catch (error) {
-      const errMsg = String(error);
-      lc.warn?.(`dispatch error: ${errMsg}`, error);
       // Returning an error on the HTTP handshake looks like a hanging connection
       // (at least from Chrome) and doesn't report any meaningful error in the browser.
       // Instead, finish the upgrade to a websocket and then close it with an error.
       wss.handleUpgrade(message as IncomingMessage, socket, head, ws =>
-        ws.close(1002 /* "protocol error" */, truncate(errMsg)),
+        closeWithProtocolError(lc, ws, error),
       );
     }
   };
@@ -72,20 +71,6 @@ export function installWebSocketHandoff<P>(
       handle(message, socket as Socket, Buffer.from(head));
     });
   }
-}
-
-// close messages must be less than or equal to 123 bytes:
-// https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close#reason
-function truncate(val: string, maxBytes = 123) {
-  const encoder = new TextEncoder();
-  if (encoder.encode(val).length <= maxBytes) {
-    return val;
-  }
-  val = val.substring(0, maxBytes - 3);
-  while (encoder.encode(val + '...').length > maxBytes) {
-    val = val.substring(0, val.length - 1);
-  }
-  return val + '...';
 }
 
 export function installWebSocketReceiver<P>(

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -3,7 +3,6 @@ import {SqliteError} from '@rocicorp/zero-sqlite3';
 import {AbortError} from '../../../../shared/src/abort-error.js';
 import {assert, unreachable} from '../../../../shared/src/asserts.js';
 import {must} from '../../../../shared/src/must.js';
-import {promiseVoid} from '../../../../shared/src/resolved-promises.js';
 import {Database} from '../../../../zqlite/src/db.js';
 import {
   columnDef,
@@ -149,9 +148,8 @@ export class IncrementalSyncer {
     return this.#notifier.subscribe();
   }
 
-  stop(lc: LogContext, err?: unknown): Promise<void> {
+  stop(lc: LogContext, err?: unknown) {
     this.#state.stop(lc, err);
-    return promiseVoid;
   }
 }
 

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -3,6 +3,7 @@ import {SqliteError} from '@rocicorp/zero-sqlite3';
 import {AbortError} from '../../../../shared/src/abort-error.js';
 import {assert, unreachable} from '../../../../shared/src/asserts.js';
 import {must} from '../../../../shared/src/must.js';
+import {promiseVoid} from '../../../../shared/src/resolved-promises.js';
 import {Database} from '../../../../zqlite/src/db.js';
 import {
   columnDef,
@@ -148,8 +149,9 @@ export class IncrementalSyncer {
     return this.#notifier.subscribe();
   }
 
-  async stop(lc: LogContext, err?: unknown) {
+  stop(lc: LogContext, err?: unknown): Promise<void> {
     this.#state.stop(lc, err);
+    return promiseVoid;
   }
 }
 

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -1,6 +1,5 @@
 import type {LogContext} from '@rocicorp/logger';
 import {SqliteError} from '@rocicorp/zero-sqlite3';
-import {LogicalReplicationService} from 'pg-logical-replication';
 import {AbortError} from '../../../../shared/src/abort-error.js';
 import {assert, unreachable} from '../../../../shared/src/asserts.js';
 import {must} from '../../../../shared/src/must.js';
@@ -77,7 +76,6 @@ export class IncrementalSyncer {
   readonly #notifier: Notifier;
 
   readonly #state = new RunningState('IncrementalSyncer');
-  #service: LogicalReplicationService | undefined;
 
   constructor(
     id: string,
@@ -152,7 +150,6 @@ export class IncrementalSyncer {
 
   async stop(lc: LogContext, err?: unknown) {
     this.#state.stop(lc, err);
-    await this.#service?.stop();
   }
 }
 

--- a/packages/zero-cache/src/services/replicator/replicator.ts
+++ b/packages/zero-cache/src/services/replicator/replicator.ts
@@ -1,5 +1,6 @@
 import type {LogContext} from '@rocicorp/logger';
 import type {ReadonlyJSONObject} from '../../../../shared/src/json.js';
+import {promiseVoid} from '../../../../shared/src/resolved-promises.js';
 import {Database} from '../../../../zqlite/src/db.js';
 import type {Source} from '../../types/streams.js';
 import type {ChangeStreamer} from '../change-streamer/change-streamer.js';
@@ -89,7 +90,8 @@ export class ReplicatorService implements Replicator, Service {
     return this.#incrementalSyncer.subscribe();
   }
 
-  async stop() {
-    await this.#incrementalSyncer.stop(this.#lc);
+  stop() {
+    this.#incrementalSyncer.stop(this.#lc);
+    return promiseVoid;
   }
 }

--- a/packages/zero-cache/src/types/ws.test.ts
+++ b/packages/zero-cache/src/types/ws.test.ts
@@ -1,0 +1,49 @@
+import {resolver} from '@rocicorp/resolver';
+import {afterAll, beforeAll, describe, expect, test} from 'vitest';
+import WebSocket, {WebSocketServer} from 'ws';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.js';
+import {randInt} from '../../../shared/src/rand.js';
+import {closeWithProtocolError} from './ws.js';
+
+describe('types/ws', () => {
+  let port: number;
+  let wss: WebSocketServer;
+
+  beforeAll(() => {
+    port = randInt(10000, 20000);
+    wss = new WebSocketServer({port});
+  });
+
+  afterAll(() => {
+    wss.close();
+  });
+
+  test('close with protocol error', async () => {
+    wss.on('connection', ws =>
+      closeWithProtocolError(
+        createSilentLogContext(),
+        ws,
+        'こんにちは' + 'あ'.repeat(150),
+      ),
+    );
+
+    const ws = new WebSocket(`ws://localhost:${port}/`);
+    const {promise, resolve} = resolver<{code: number; reason: string}>();
+    ws.on('close', (code, reason) =>
+      resolve({code, reason: reason.toString('utf-8')}),
+    );
+
+    const error = await promise;
+    expect(error).toMatchInlineSnapshot(`
+      {
+        "code": 1002,
+        "reason": "こんにちはあああああああああああああああああああああああああああああああああああ...",
+      }
+    `);
+    // close messages must be less than or equal to 123 bytes:
+    // https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close#reason
+    expect(new TextEncoder().encode(error.reason).length).toBeLessThanOrEqual(
+      123,
+    );
+  });
+});

--- a/packages/zero-cache/src/types/ws.ts
+++ b/packages/zero-cache/src/types/ws.ts
@@ -1,0 +1,26 @@
+import type {LogContext} from '@rocicorp/logger';
+import type {WebSocket} from 'ws';
+
+export function closeWithProtocolError(
+  lc: LogContext,
+  ws: WebSocket,
+  err: unknown,
+) {
+  const errMsg = String(err);
+  lc.warn?.('closing with protocol error', errMsg);
+  ws.close(1002 /* "protocol error" */, truncate(errMsg));
+}
+
+// close messages must be less than or equal to 123 bytes:
+// https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close#reason
+function truncate(val: string, maxBytes = 123) {
+  const encoder = new TextEncoder();
+  if (encoder.encode(val).length <= maxBytes) {
+    return val;
+  }
+  val = val.substring(0, maxBytes - 3);
+  while (encoder.encode(val + '...').length > maxBytes) {
+    val = val.substring(0, val.length - 1);
+  }
+  return val + '...';
+}


### PR DESCRIPTION
Factor out `closeWithProtocolError()` so that it can be reused in another context.

Also delete some vestigial code.