### PR TITLE
feat(zero-cache): define a "status" message for the change-protocol

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg-test.ts
@@ -106,11 +106,12 @@ describe('change-source/pg/end-to-mid-test', () => {
     const data: DataChange[] = [];
     for (;;) {
       const change = await downstream.dequeue();
-      if (change[0] !== 'control') {
+      const [type] = change;
+      if (type !== 'control' && type !== 'status') {
         replicator.processMessage(lc, change);
       }
 
-      switch (change[0]) {
+      switch (type) {
         case 'begin':
           break;
         case 'data':
@@ -119,6 +120,7 @@ describe('change-source/pg/end-to-mid-test', () => {
         case 'commit':
         case 'rollback':
         case 'control':
+        case 'status':
           return data;
         default:
           change satisfies never;

--- a/packages/zero-cache/src/services/change-source/pg/change-source.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.pg-test.ts
@@ -229,7 +229,7 @@ describe('change-source/pg', () => {
         {tag: 'commit'},
         {watermark: begin1[2]?.commitWatermark},
       ]);
-      acks.push(commit1);
+      acks.push(['status', {}, commit1[2]]);
 
       // Write more upstream changes.
       await upstream.begin(async tx => {

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -34,7 +34,7 @@ import type {
 } from '../../../db/specs.js';
 import {StatementRunner} from '../../../db/statements.js';
 import {stringify} from '../../../types/bigint-json.js';
-import {max, oneAfter, versionToLexi} from '../../../types/lexi-version.js';
+import {oneAfter, type LexiVersion} from '../../../types/lexi-version.js';
 import {
   pgClient,
   registerPostgresTypeParsers,
@@ -282,20 +282,34 @@ class PostgresChangeSource implements ChangeSource {
       {acknowledge: {auto: false, timeoutSeconds: 0}},
     )
       .on('start', resolve)
-      .on(
-        'heartbeat',
-        (lsn, _time, respond) => acker?.onHeartbeat(lsn, respond),
-      )
-      .on('data', (lsn, msg) => {
-        acker?.onData(lsn);
+      .on('heartbeat', (lsn, time, respond) => {
+        if (respond) {
+          // immediately set a timeout that responds with a keepalive if it
+          // takes too long for the 'status' message to flow to (and back from)
+          // the change-streamer.
+          acker?.keepalive();
+
+          // lock to ensure in-order processing
+          void lock.withLock(() => {
+            changes.push([
+              'status',
+              {lsn, time},
+              {watermark: toLexiVersion(lsn)},
+            ]);
+          });
+        }
+      })
+      .on('data', (lsn, msg) =>
         // lock to ensure in-order processing
-        return lock.withLock(async () => {
+        lock.withLock(async () => {
           for (const change of await changeMaker.makeChanges(lsn, msg)) {
             changes.push(change);
           }
-        });
-      })
+        }),
+      )
       .on('error', handleError);
+
+    acker = new Acker(service);
 
     service
       .subscribe(
@@ -311,11 +325,10 @@ class PostgresChangeSource implements ChangeSource {
 
     await started;
     this.#lc.info?.(`started replication stream@${slot}`);
-    acker = new Acker(service, clientStart);
 
     return {
       changes,
-      acks: {push: commit => acker.onAck(commit[2].watermark)},
+      acks: {push: commit => acker.ack(commit[2].watermark)},
     };
   }
 
@@ -344,35 +357,40 @@ class PostgresChangeSource implements ChangeSource {
 // Exported for testing.
 export class Acker {
   #service: LogicalReplicationService;
-  #lastAck: string;
-  #lastData: string = versionToLexi(0);
+  #keepaliveTimer: NodeJS.Timeout | undefined;
 
-  constructor(service: LogicalReplicationService, initialWatermark: string) {
+  constructor(service: LogicalReplicationService) {
     this.#service = service;
-    this.#lastAck = initialWatermark;
   }
 
-  onData(lsn: string) {
-    this.#lastData = max(this.#lastData, toLexiVersion(lsn));
+  keepalive() {
+    // Sets a timeout to send a standby status update in response to
+    // a primary keepalive message.
+    //
+    // https://www.postgresql.org/docs/current/protocol-replication.html#PROTOCOL-REPLICATION-PRIMARY-KEEPALIVE-MESSAGE
+    //
+    // A primary keepalive message is streamed to the change-streamer as a
+    // 'status' message, which in turn responds with an ack. However, in the
+    // event that the change-streamer is backed up processing preceding
+    // changes, this timeout will fire to send a status update that does not
+    // change the confirmed flush position. This timeout must be shorter than
+    // the `wal_sender_timeout`, which defaults to 60 seconds.
+    //
+    // https://www.postgresql.org/docs/current/runtime-config-replication.html#GUC-WAL-SENDER-TIMEOUT
+    this.#keepaliveTimer ??= setTimeout(() => this.#sendAck(), 1000);
   }
 
-  onHeartbeat(lsn: string, respond: boolean) {
-    // Heartbeats bump the last ack unless we are behind received data.
-    if (this.#lastAck >= this.#lastData) {
-      this.#lastAck = max(this.#lastAck, toLexiVersion(lsn));
-    }
-    if (respond) {
-      this.#sendAck();
-    }
+  ack(watermark: LexiVersion) {
+    this.#sendAck(watermark);
   }
 
-  onAck(lexiVersion: string) {
-    this.#lastAck = max(this.#lastAck, lexiVersion);
-    this.#sendAck();
-  }
+  #sendAck(watermark?: LexiVersion) {
+    clearTimeout(this.#keepaliveTimer);
+    this.#keepaliveTimer = undefined;
 
-  #sendAck() {
-    const lsn = fromLexiVersion(this.#lastAck);
+    // Note: Sending '0/0' means "keep alive but do not update confirmed_flush_lsn"
+    // https://github.com/postgres/postgres/blob/3edc67d337c2e498dad1cd200e460f7c63e512e6/src/backend/replication/walsender.c#L2457
+    const lsn = watermark ? fromLexiVersion(watermark) : '0/0';
     void this.#service.acknowledge(lsn);
   }
 }

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -328,7 +328,7 @@ class PostgresChangeSource implements ChangeSource {
 
     return {
       changes,
-      acks: {push: commit => acker.ack(commit[2].watermark)},
+      acks: {push: status => acker.ack(status[2].watermark)},
     };
   }
 

--- a/packages/zero-cache/src/services/change-source/protocol/current/downstream.ts
+++ b/packages/zero-cache/src/services/change-source/protocol/current/downstream.ts
@@ -6,6 +6,7 @@ import {
   dataChangeSchema,
   rollbackSchema,
 } from './data.js';
+import {statusMessageSchema} from './status.js';
 
 const begin = v.tuple([
   v.literal('begin'),
@@ -38,6 +39,7 @@ export type ChangeStreamControl = v.Infer<typeof changeStreamControlSchema>;
 export const changeStreamMessageSchema = v.union(
   changeStreamDataSchema,
   changeStreamControlSchema,
+  statusMessageSchema,
 );
 
 export type ChangeStreamMessage = v.Infer<typeof changeStreamMessageSchema>;

--- a/packages/zero-cache/src/services/change-source/protocol/current/mod.ts
+++ b/packages/zero-cache/src/services/change-source/protocol/current/mod.ts
@@ -2,4 +2,5 @@ export * from './control.js';
 export * from './data.js';
 export * from './downstream.js';
 export * from './path.js';
+export * from './status.js';
 export * from './upstream.js';

--- a/packages/zero-cache/src/services/change-source/protocol/current/status.ts
+++ b/packages/zero-cache/src/services/change-source/protocol/current/status.ts
@@ -1,0 +1,42 @@
+import * as v from '../../../../../../shared/src/valita.js';
+
+/**
+ * The StatusMessage payload itself is unspecified. The `zero-cache` will
+ * send the Commit payload when acknowledging a completed transaction, and
+ * will echo back whatever message was sent from the ChangeSource when
+ * acknowledging a downstream StatusMessage.
+ */
+export const statusSchema = v.object({});
+
+export const statusMessageSchema = v.tuple([
+  v.literal('status'),
+  statusSchema,
+  v.object({watermark: v.string()}),
+]);
+
+/**
+ * A StatusMessage conveys positional information from both the ChangeSource
+ * and the `zero-cache`.
+ *
+ * A StatusMessage from the ChangeSource indicates a position in its change
+ * log. Generally, the watermarks sent in `Commit` messages already convey
+ * this information, but a StatusMessage may also be sent to indicate that the
+ * log has progressed without any corresponding changes relevant to the
+ * subscriber. The watermarks of commit messages and status messages must be
+ * monotonic in the stream of messages from the ChangeSource.
+ *
+ * The `zero-cache` sends StatusMessages to the ChangeSource:
+ *
+ * * when it has processed a `Commit` received from the ChangeSource
+ *
+ * * when it receives a `StatusMessage` and all preceding `Commit` messages
+ *   have been processed
+ *
+ * This allows the ChangeSource to clean up change log entries appropriately.
+ *
+ * Note that StatusMessages from the ChangeSource are optional. If a
+ * ChangeSource implementation can track subscriber progress and clean up
+ * its change log purely from Commit-driven StatusMessages there is no need
+ * for the ChangeSource to send StatusMessages.
+ */
+export type StatusMessage = v.Infer<typeof statusMessageSchema>;

--- a/packages/zero-cache/src/services/change-source/protocol/current/upstream.ts
+++ b/packages/zero-cache/src/services/change-source/protocol/current/upstream.ts
@@ -1,17 +1,6 @@
 import * as v from '../../../../../../shared/src/valita.js';
+import {statusMessageSchema} from './status.js';
 
-/**
- * An acknowledgement is sent from the Change Streamer to the Change Source to
- * either or both:
- * * Indicate that it is connected and running, e.g. in response to an
- *   "ack-requested" message.
- * * Indicate that it is caught up to a specific `watermark`.
- */
-export const ackSchema = v.union(
-  v.tuple([v.literal('ack')]),
-  v.tuple([v.literal('ack'), v.object({watermark: v.string()})]),
-);
-
-/** At the moment, the only upstream messages are acks.  */
-export const changeSourceUpstreamSchema = ackSchema;
+/** At the moment, the only upstream messages are status messages.  */
+export const changeSourceUpstreamSchema = statusMessageSchema;
 export type ChangeSourceUpstream = v.Infer<typeof changeSourceUpstreamSchema>;

--- a/packages/zero-cache/src/services/change-source/protocol/version.test.ts
+++ b/packages/zero-cache/src/services/change-source/protocol/version.test.ts
@@ -38,9 +38,9 @@ test('protocol versions', () => {
   // Then update the version number of the `CHANGE_SOURCE_PATH`
   // in current and export it appropriately as the new version
   // in `mod.ts`.
-  t(current, 'r7gl2fs37kac', '/changes/v0/stream');
+  t(current, '2z9neqzcgdxo7', '/changes/v0/stream');
   // During initial development, we use v0 as a non-stable
   // version (i.e. breaking change are allowed). Once the
   // protocol graduates to v1, versions must be stable.
-  t(v0, 'r7gl2fs37kac', '/changes/v0/stream');
+  t(v0, '2z9neqzcgdxo7', '/changes/v0/stream');
 });

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -8,13 +8,17 @@ import {TransactionPool} from '../../db/transaction-pool.js';
 import type {JSONValue} from '../../types/bigint-json.js';
 import type {PostgresDB} from '../../types/pg.js';
 import {type Commit} from '../change-source/protocol/current/downstream.js';
+import type {StatusMessage} from '../change-source/protocol/current/status.js';
 import type {Service} from '../service.js';
 import type {WatermarkedChange} from './change-streamer-service.js';
 import {type ChangeEntry} from './change-streamer.js';
 import * as ErrorType from './error-type-enum.js';
 import {Subscriber} from './subscriber.js';
 
-type QueueEntry = ['change', WatermarkedChange] | ['subscriber', Subscriber];
+type QueueEntry =
+  | ['change', WatermarkedChange]
+  | ['subscriber', Subscriber]
+  | StatusMessage;
 
 type PendingTransaction = {
   pool: TransactionPool;
@@ -57,7 +61,7 @@ export class Storer implements Service {
   readonly #lc: LogContext;
   readonly #db: PostgresDB;
   readonly #replicaVersion: string;
-  readonly #onCommit: (c: Commit) => void;
+  readonly #onConsumed: (c: Commit | StatusMessage) => void;
   readonly #queue = new Queue<QueueEntry>();
   readonly stopped = resolver<false>();
 
@@ -65,12 +69,12 @@ export class Storer implements Service {
     lc: LogContext,
     db: PostgresDB,
     replicaVersion: string,
-    onCommit: (c: Commit) => void,
+    onConsumed: (c: Commit | StatusMessage) => void,
   ) {
     this.#lc = lc;
     this.#db = db;
     this.#replicaVersion = replicaVersion;
-    this.#onCommit = onCommit;
+    this.#onConsumed = onConsumed;
   }
 
   async getLastStoredWatermark(): Promise<string | null> {
@@ -110,20 +114,25 @@ export class Storer implements Service {
     void this.#queue.enqueue(['change', entry]);
   }
 
+  status(s: StatusMessage) {
+    void this.#queue.enqueue(s);
+  }
+
   catchup(sub: Subscriber) {
     void this.#queue.enqueue(['subscriber', sub]);
   }
 
   async run() {
     let tx: PendingTransaction | null = null;
-    let next: QueueEntry | false;
+    let msg: QueueEntry | false;
 
     const catchupQueue: Subscriber[] = [];
     while (
-      (next = await Promise.race([this.#queue.dequeue(), this.stopped.promise]))
+      (msg = await Promise.race([this.#queue.dequeue(), this.stopped.promise]))
     ) {
-      if (next[0] === 'subscriber') {
-        const subscriber = next[1];
+      const [msgType] = msg;
+      if (msgType === 'subscriber') {
+        const subscriber = msg[1];
         if (tx) {
           catchupQueue.push(subscriber); // Wait for the current tx to complete.
         } else {
@@ -131,8 +140,12 @@ export class Storer implements Service {
         }
         continue;
       }
-      // next[0] === 'change'
-      const [watermark, downstream] = next[1];
+      if (msgType === 'status') {
+        this.#onConsumed(msg);
+        continue;
+      }
+      // msgType === 'change'
+      const [watermark, downstream] = msg[1];
       const [tag, change] = downstream;
       if (tag === 'begin') {
         assert(!tx, 'received BEGIN in the middle of a transaction');
@@ -165,7 +178,7 @@ export class Storer implements Service {
         tx = null;
 
         // ACK the LSN to the upstream Postgres.
-        this.#onCommit(downstream);
+        this.#onConsumed(downstream);
 
         // Before beginning the next transaction, open a READONLY snapshot to
         // concurrently catchup any queued subscribers.


### PR DESCRIPTION
Adds a `['status', ..., {watermark: string}]` message to the `change-protocol` that encapsulates the communication of log positions between a ChangeSource and the `zero-cache`.

Move the ack logic previously confined to the Postgres implementation down into the ChangeStreamerService implementation so that it is applicable to all ChangeSource implementations.

@cbnsndwch 