### PR TITLE
chore(zero-cache): set windowsHide for litestream subprocesses

### DIFF
--- a/packages/zero-cache/src/services/litestream/commands.ts
+++ b/packages/zero-cache/src/services/litestream/commands.ts
@@ -63,7 +63,7 @@ async function tryRestore(config: ZeroLitestreamConfig) {
   const proc = spawn(
     litestream,
     ['restore', '-if-db-not-exists', '-if-replica-exists', config.replicaFile],
-    {env, stdio: 'inherit'},
+    {env, stdio: 'inherit', windowsHide: true},
   );
   const {promise, resolve, reject} = resolver();
   proc.on('error', reject);
@@ -84,5 +84,9 @@ export function startReplicaBackupProcess(
   config: ZeroLitestreamConfig,
 ): ChildProcess {
   const {litestream, env} = getLitestream(config);
-  return spawn(litestream, ['replicate'], {env, stdio: 'inherit'});
+  return spawn(litestream, ['replicate'], {
+    env,
+    stdio: 'inherit',
+    windowsHide: true,
+  });
 }


### PR DESCRIPTION
This doesn't fix the popups for all of the other Workers (which are created via `fork()`), but we might as well do this for `litestream`, which is invoked via `spawn()`.

https://discord.com/channels/830183651022471199/1288232858795769917/1329188972743622676