### PR TITLE
fix(zero-cache): stop incorrectly warning about enums

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.pg-test.ts
@@ -238,6 +238,7 @@ describe('replicator/initial-sync', () => {
     {
       name: 'existing table, default publication',
       setupUpstreamQuery: `
+        CREATE TYPE ENUMZ AS ENUM ('1', '2', '3');
         CREATE TABLE issues(
           "issueID" INTEGER,
           "orgID" INTEGER,
@@ -251,6 +252,7 @@ describe('replicator/initial-sync', () => {
           "date" DATE,
           "time" TIME,
           "serial" SERIAL,
+          "enumz" ENUMZ,
           PRIMARY KEY ("orgID", "issueID")
         );
       `,
@@ -451,8 +453,15 @@ describe('replicator/initial-sync', () => {
               notNull: false,
               dflt: null,
             },
-            ['_0_version']: {
+            enumz: {
               pos: 13,
+              characterMaximumLength: null,
+              dataType: 'TEXT_ENUM_enumz',
+              dflt: null,
+              notNull: false,
+            },
+            ['_0_version']: {
+              pos: 14,
               characterMaximumLength: null,
               dataType: 'TEXT',
               notNull: false,

--- a/packages/zero-cache/src/services/change-source/pg/schema/validation.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/validation.ts
@@ -1,5 +1,8 @@
 import type {LogContext} from '@rocicorp/logger';
-import {warnIfDataTypeSupported} from '../../../../db/pg-to-lite.js';
+import {
+  mapPostgresToLite,
+  warnIfDataTypeSupported,
+} from '../../../../db/pg-to-lite.js';
 import type {TableSpec} from '../../../../db/specs.js';
 import {ZERO_VERSION_COLUMN_NAME} from '../../../replicator/schema/replication-state.js';
 import {unescapedSchema} from './shard.js';
@@ -29,7 +32,7 @@ export function validate(lc: LogContext, shardID: string, table: TableSpec) {
       `Table "${table.name}" has invalid characters.`,
     );
   }
-  for (const [col, spec] of Object.entries(table.columns)) {
+  for (const [col, spec] of Object.entries(mapPostgresToLite(table).columns)) {
     if (!ALLOWED_IDENTIFIER_CHARS.test(col)) {
       throw new UnsupportedTableSchemaError(
         `Column "${col}" in table "${table.name}" has invalid characters.`,


### PR DESCRIPTION
Enums are supported now, but we were incorrectly emitting a warning that they wouldn't be synced.