### PR TITLE
feat(zql)!: support `one` and `many` in schema definitions

### DIFF
--- a/apps/zbugs/schema.ts
+++ b/apps/zbugs/schema.ts
@@ -90,16 +90,16 @@ const userPref = table('userPref')
   .primaryKey('userID', 'key');
 
 // Relationships
-const userRelationships = relationships(user, connect => ({
-  createdIssues: connect({
+const userRelationships = relationships(user, ({many}) => ({
+  createdIssues: many({
     sourceField: ['id'],
     destField: ['creatorID'],
     destSchema: issue,
   }),
 }));
 
-const issueRelationships = relationships(issue, connect => ({
-  labels: connect(
+const issueRelationships = relationships(issue, ({many, one}) => ({
+  labels: many(
     {
       sourceField: ['id'],
       destField: ['issueID'],
@@ -111,71 +111,71 @@ const issueRelationships = relationships(issue, connect => ({
       destSchema: label,
     },
   ),
-  comments: connect({
+  comments: many({
     sourceField: ['id'],
     destField: ['issueID'],
     destSchema: comment,
   }),
-  creator: connect({
+  creator: one({
     sourceField: ['creatorID'],
     destField: ['id'],
     destSchema: user,
   }),
-  assignee: connect({
+  assignee: one({
     sourceField: ['assigneeID'],
     destField: ['id'],
     destSchema: user,
   }),
-  viewState: connect({
+  viewState: many({
     sourceField: ['id'],
     destField: ['issueID'],
     destSchema: viewState,
   }),
-  emoji: connect({
+  emoji: many({
     sourceField: ['id'],
     destField: ['subjectID'],
     destSchema: emoji,
   }),
 }));
 
-const commentRelationships = relationships(comment, connect => ({
-  creator: connect({
+const commentRelationships = relationships(comment, ({one, many}) => ({
+  creator: one({
     sourceField: ['creatorID'],
     destField: ['id'],
     destSchema: user,
   }),
-  emoji: connect({
+  emoji: many({
     sourceField: ['id'],
     destField: ['subjectID'],
     destSchema: emoji,
   }),
-  issue: connect({
+  issue: one({
     sourceField: ['issueID'],
     destField: ['id'],
     destSchema: issue,
   }),
 }));
 
-const issueLabelRelationships = relationships(issueLabel, connect => ({
-  issue: connect({
+const issueLabelRelationships = relationships(issueLabel, ({one}) => ({
+  issue: one({
     sourceField: ['issueID'],
     destField: ['id'],
     destSchema: issue,
   }),
 }));
 
-const emojiRelationships = relationships(emoji, connect => ({
-  creator: connect({
+const emojiRelationships = relationships(emoji, ({one}) => ({
+  creator: one({
     sourceField: ['creatorID'],
     destField: ['id'],
     destSchema: user,
   }),
-  issue: connect({
+  issue: one({
     sourceField: ['subjectID'],
     destField: ['id'],
     destSchema: issue,
   }),
-  comment: connect({
+  comment: one({
     sourceField: ['subjectID'],
     destField: ['id'],
     destSchema: comment,

--- a/apps/zbugs/src/comment-query.ts
+++ b/apps/zbugs/src/comment-query.ts
@@ -4,10 +4,8 @@ import type {IssueRow, Schema} from '../schema.js';
 export function commentQuery(z: Zero<Schema>, displayed: IssueRow | undefined) {
   return z.query.comment
     .where('issueID', 'IS', displayed?.id ?? null)
-    .related('creator', creator => creator.one())
-    .related('emoji', emoji =>
-      emoji.related('creator', creator => creator.one()),
-    )
+    .related('creator')
+    .related('emoji', emoji => emoji.related('creator'))
     .orderBy('created', 'asc')
     .orderBy('id', 'asc');
 }

--- a/apps/zbugs/src/pages/issue/issue-page.tsx
+++ b/apps/zbugs/src/pages/issue/issue-page.tsx
@@ -75,21 +75,17 @@ export function IssuePage({onReady}: {onReady: () => void}) {
   const listContext = zbugsHistoryState?.zbugsListContext;
   const q = z.query.issue
     .where(idField, id)
-    .related('emoji', emoji =>
-      emoji.related('creator', creator => creator.one()),
-    )
-    .related('creator', creator => creator.one())
-    .related('assignee', assignee => assignee.one())
+    .related('emoji', emoji => emoji.related('creator'))
+    .related('creator')
+    .related('assignee')
     .related('labels')
     .related('viewState', viewState =>
       viewState.where('userID', z.userID).one(),
     )
     .related('comments', comments =>
       comments
-        .related('creator', creator => creator.one())
-        .related('emoji', emoji =>
-          emoji.related('creator', creator => creator.one()),
-        )
+        .related('creator')
+        .related('emoji', emoji => emoji.related('creator'))
         .limit(INITIAL_COMMENT_LIMIT)
         .orderBy('created', 'desc')
         .orderBy('id', 'desc'),

--- a/apps/zbugs/src/zero-setup.ts
+++ b/apps/zbugs/src/zero-setup.ts
@@ -60,7 +60,7 @@ export function preload(z: Zero<Schema>) {
 
   const baseIssueQuery = z.query.issue
     .related('labels')
-    .related('viewState', q => q.where('userID', z.userID).one());
+    .related('viewState', q => q.where('userID', z.userID));
 
   const {cleanup, complete} = baseIssueQuery.preload();
   complete.then(() => {
@@ -69,15 +69,11 @@ export function preload(z: Zero<Schema>) {
     baseIssueQuery
       .related('creator')
       .related('assignee')
-      .related('emoji', emoji =>
-        emoji.related('creator', creator => creator.one()),
-      )
+      .related('emoji', emoji => emoji.related('creator'))
       .related('comments', comments =>
         comments
-          .related('creator', creator => creator.one())
-          .related('emoji', emoji =>
-            emoji.related('creator', creator => creator.one()),
-          )
+          .related('creator')
+          .related('emoji', emoji => emoji.related('creator'))
           .limit(INITIAL_COMMENT_LIMIT)
           .orderBy('created', 'desc'),
       )

--- a/packages/zero-cache/bench/schema.ts
+++ b/packages/zero-cache/bench/schema.ts
@@ -54,7 +54,7 @@ const issueLabel = table('issueLabel')
 
 // Relationships
 const issueRelationships = relationships(issue, connect => ({
-  labels: connect(
+  labels: connect.many(
     {
       sourceField: ['id'],
       destField: ['issueID'],
@@ -66,12 +66,12 @@ const issueRelationships = relationships(issue, connect => ({
       destSchema: label,
     },
   ),
-  comments: connect({
+  comments: connect.many({
     sourceField: ['id'],
     destField: ['issueID'],
     destSchema: comment,
   }),
-  creator: connect({
+  creator: connect.many({
     sourceField: ['creatorID'],
     destField: ['id'],
     destSchema: member,
@@ -79,7 +79,7 @@ const issueRelationships = relationships(issue, connect => ({
 }));
 
 const commentRelationships = relationships(comment, connect => ({
-  creator: connect({
+  creator: connect.many({
     sourceField: ['creatorID'],
     destField: ['id'],
     destSchema: member,

--- a/packages/zero-cache/src/auth/read-authorizer.query.test.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.query.test.ts
@@ -110,17 +110,17 @@ const projectMember = table('projectMember')
 
 // Relationships
 const userRelationships = relationships(user, connect => ({
-  ownedIssues: connect({
+  ownedIssues: connect.many({
     sourceField: ['id'],
     destField: ['ownerId'],
     destSchema: issue,
   }),
-  createdIssues: connect({
+  createdIssues: connect.many({
     sourceField: ['id'],
     destField: ['creatorId'],
     destSchema: issue,
   }),
-  viewedIssues: connect(
+  viewedIssues: connect.many(
     {
       sourceField: ['id'],
       destField: ['userId'],
@@ -132,7 +132,7 @@ const userRelationships = relationships(user, connect => ({
       destSchema: issue,
     },
   ),
-  projects: connect(
+  projects: connect.many(
     {
       sourceField: ['id'],
       destField: ['userId'],
@@ -147,22 +147,22 @@ const userRelationships = relationships(user, connect => ({
 }));
 
 const issueRelationships = relationships(issue, connect => ({
-  owner: connect({
+  owner: connect.many({
     sourceField: ['ownerId'],
     destField: ['id'],
     destSchema: user,
   }),
-  creator: connect({
+  creator: connect.many({
     sourceField: ['creatorId'],
     destField: ['id'],
     destSchema: user,
   }),
-  comments: connect({
+  comments: connect.many({
     sourceField: ['id'],
     destField: ['issueId'],
     destSchema: comment,
   }),
-  labels: connect(
+  labels: connect.many(
     {
       sourceField: ['id'],
       destField: ['issueId'],
@@ -174,12 +174,12 @@ const issueRelationships = relationships(issue, connect => ({
       destSchema: label,
     },
   ),
-  project: connect({
+  project: connect.many({
     sourceField: ['projectId'],
     destField: ['id'],
     destSchema: project,
   }),
-  viewState: connect({
+  viewState: connect.many({
     sourceField: ['id'],
     destField: ['issueId'],
     destSchema: viewState,
@@ -187,12 +187,12 @@ const issueRelationships = relationships(issue, connect => ({
 }));
 
 const commentRelationships = relationships(comment, connect => ({
-  issue: connect({
+  issue: connect.many({
     sourceField: ['issueId'],
     destField: ['id'],
     destSchema: issue,
   }),
-  user: connect({
+  user: connect.many({
     sourceField: ['authorId'],
     destField: ['id'],
     destSchema: user,
@@ -200,12 +200,12 @@ const commentRelationships = relationships(comment, connect => ({
 }));
 
 const issueLabelRelationships = relationships(issueLabel, connect => ({
-  issue: connect({
+  issue: connect.many({
     sourceField: ['issueId'],
     destField: ['id'],
     destSchema: issue,
   }),
-  label: connect({
+  label: connect.many({
     sourceField: ['labelId'],
     destField: ['id'],
     destSchema: label,
@@ -213,12 +213,12 @@ const issueLabelRelationships = relationships(issueLabel, connect => ({
 }));
 
 const viewStateRelationships = relationships(viewState, connect => ({
-  user: connect({
+  user: connect.many({
     sourceField: ['userId'],
     destField: ['id'],
     destSchema: user,
   }),
-  issue: connect({
+  issue: connect.many({
     sourceField: ['issueId'],
     destField: ['id'],
     destSchema: issue,
@@ -226,12 +226,12 @@ const viewStateRelationships = relationships(viewState, connect => ({
 }));
 
 const projectRelationships = relationships(project, connect => ({
-  issues: connect({
+  issues: connect.many({
     sourceField: ['id'],
     destField: ['projectId'],
     destSchema: issue,
   }),
-  members: connect(
+  members: connect.many(
     {
       sourceField: ['id'],
       destField: ['projectId'],
@@ -246,12 +246,12 @@ const projectRelationships = relationships(project, connect => ({
 }));
 
 const projectMemberRelationships = relationships(projectMember, connect => ({
-  project: connect({
+  project: connect.many({
     sourceField: ['projectId'],
     destField: ['id'],
     destSchema: project,
   }),
-  user: connect({
+  user: connect.many({
     sourceField: ['userId'],
     destField: ['id'],
     destSchema: user,

--- a/packages/zero-cache/src/auth/read-authorizer.test.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.test.ts
@@ -51,7 +51,7 @@ const adminReadable = table('adminReadable')
 const readableThruUnreadableRelationships = relationships(
   readableThruUnreadable,
   connect => ({
-    unreadable: connect({
+    unreadable: connect.many({
       sourceField: ['unreadableId'],
       destField: ['id'],
       destSchema: unreadable,
@@ -60,17 +60,17 @@ const readableThruUnreadableRelationships = relationships(
 );
 
 const readableRelationships = relationships(readable, connect => ({
-  readable: connect({
+  readable: connect.many({
     sourceField: ['readableId'],
     destField: ['id'],
     destSchema: readable,
   }),
-  unreadable: connect({
+  unreadable: connect.many({
     sourceField: ['unreadableId'],
     destField: ['id'],
     destSchema: unreadable,
   }),
-  readableThruUnreadable: connect({
+  readableThruUnreadable: connect.many({
     sourceField: ['id'],
     destField: ['id'],
     destSchema: readableThruUnreadable,
@@ -78,12 +78,12 @@ const readableRelationships = relationships(readable, connect => ({
 }));
 
 const adminReadableRelationships = relationships(adminReadable, connect => ({
-  self1: connect({
+  self1: connect.many({
     sourceField: ['id'],
     destField: ['id'],
     destSchema: adminReadable,
   }),
-  self2: connect({
+  self2: connect.many({
     sourceField: ['id'],
     destField: ['id'],
     destSchema: adminReadable,

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -242,7 +242,7 @@ const schema = createSchema(
   },
   {
     commentRelationships: relationships(comments, connect => ({
-      issue: connect({
+      issue: connect.many({
         sourceField: ['issueID'],
         destField: ['id'],
         destSchema: issues,

--- a/packages/zero-schema/src/schema-config.test.ts
+++ b/packages/zero-schema/src/schema-config.test.ts
@@ -13,7 +13,7 @@ test('round trip', async () => {
     .primaryKey('id');
 
   const circularRelationships = relationships(circular, connect => ({
-    self: connect({
+    self: connect.many({
       sourceField: ['id'],
       destField: ['id'],
       destSchema: circular,

--- a/packages/zero-schema/src/schema-config.ts
+++ b/packages/zero-schema/src/schema-config.ts
@@ -17,6 +17,7 @@ const relationshipPart = v.readonlyObject({
   sourceField: compoundKeySchema,
   destField: compoundKeySchema,
   destSchema: v.string(),
+  cardinality: v.union(v.literal('one'), v.literal('many')),
 });
 
 export const relationshipSchema: v.Type<Relationship> = v.union(

--- a/packages/zero-schema/src/schema.test.ts
+++ b/packages/zero-schema/src/schema.test.ts
@@ -42,7 +42,7 @@ test('Missing table in direct relationship should throw', () => {
     .primaryKey('id');
 
   const fooRelationships = relationships(foo, connect => ({
-    barRelation: connect({
+    barRelation: connect.many({
       sourceField: ['barID'],
       destField: ['id'],
       destSchema: bar,
@@ -79,7 +79,7 @@ test('Missing table in junction relationship should throw', () => {
     .primaryKey('id');
 
   const tableBRelationships = relationships(tableB, connect => ({
-    relationBToA: connect({
+    relationBToA: connect.many({
       sourceField: ['aID'],
       destField: ['id'],
       destSchema: tableA,
@@ -87,7 +87,7 @@ test('Missing table in junction relationship should throw', () => {
   }));
 
   const tableCRelationships = relationships(tableC, connect => ({
-    relationCToB: connect(
+    relationCToB: connect.many(
       {
         sourceField: ['bID'],
         destField: ['id'],
@@ -127,7 +127,7 @@ test('Missing column in direct relationship destination should throw', () => {
     .primaryKey('id');
 
   relationships(foo, connect => ({
-    barRelation: connect({
+    barRelation: connect.many({
       sourceField: ['barID'],
       // @ts-expect-error - missing column
       destField: ['missing'],
@@ -151,7 +151,7 @@ test('Missing column in direct relationship source should throw', () => {
     .primaryKey('id');
 
   const fooRelationships = relationships(foo, connect => ({
-    barRelation: connect({
+    barRelation: connect.many({
       sourceField: ['missing'],
       destField: ['id'],
       destSchema: bar,
@@ -187,7 +187,7 @@ test('Missing column in junction relationship destination should throw', () => {
     .primaryKey('id');
 
   relationships(tableA, connect => ({
-    relationAToB: connect(
+    relationAToB: connect.many(
       {
         sourceField: ['id'],
         destField: ['aID'],
@@ -225,7 +225,7 @@ test('Missing column in junction relationship source should throw', () => {
     .primaryKey('id');
 
   const tableARelationships = relationships(tableA, connect => ({
-    relationAToB: connect(
+    relationAToB: connect.many(
       {
         sourceField: ['id'],
         destField: ['aID'],

--- a/packages/zero-schema/src/table-schema.test.ts
+++ b/packages/zero-schema/src/table-schema.test.ts
@@ -40,12 +40,12 @@ test('relationship schema types', () => {
     .primaryKey('id');
 
   const issueRelationships = relationships(issue, connect => ({
-    comments: connect({
+    comments: connect.many({
       sourceField: ['id'],
       destField: ['issueID'],
       destSchema: comment,
     }),
-    labels: connect(
+    labels: connect.many(
       {
         sourceField: ['id'],
         destField: ['issueID'],

--- a/packages/zero-schema/src/table-schema.ts
+++ b/packages/zero-schema/src/table-schema.ts
@@ -81,7 +81,11 @@ type Connection = {
   readonly sourceField: readonly string[];
   readonly destField: readonly string[];
   readonly destSchema: string;
+  readonly cardinality: Cardinality;
 };
+
+export type Cardinality = 'one' | 'many';
+
 export type Relationship =
   | readonly [Connection]
   | readonly [Connection, Connection];

--- a/packages/zql/src/query/query-impl.query-kitchen-sink.test.ts
+++ b/packages/zql/src/query/query-impl.query-kitchen-sink.test.ts
@@ -508,168 +508,160 @@ describe('kitchen sink query', () => {
         })),
       }));
     });
-    expect(rows).toEqual([
-      {
-        closed: false,
-        comments: [
-          {
-            authorId: '003',
-            createdAt: 6,
-            id: '206',
-            issueId: '102',
-            revisions: [],
-            text: 'Comment 6',
+    expect(rows).toMatchInlineSnapshot(`
+      [
+        {
+          "closed": false,
+          "comments": [
+            {
+              "authorId": "003",
+              "createdAt": 6,
+              "id": "206",
+              "issueId": "102",
+              "revisions": [],
+              "text": "Comment 6",
+            },
+            {
+              "authorId": "002",
+              "createdAt": 5,
+              "id": "205",
+              "issueId": "102",
+              "revisions": [],
+              "text": "Comment 5",
+            },
+          ],
+          "description": "Description 2",
+          "id": "102",
+          "labels": [
+            {
+              "id": "401",
+              "name": "bug",
+            },
+            {
+              "id": "402",
+              "name": "feature",
+            },
+          ],
+          "owner": {
+            "id": "001",
+            "name": "Alice",
           },
-          {
-            authorId: '002',
-            createdAt: 5,
-            id: '205',
-            issueId: '102',
-            revisions: [],
-            text: 'Comment 5',
+          "ownerId": "001",
+          "title": "Issue 2",
+        },
+        {
+          "closed": false,
+          "comments": [
+            {
+              "authorId": "003",
+              "createdAt": 9,
+              "id": "209",
+              "issueId": "103",
+              "revisions": [
+                {
+                  "authorId": "001",
+                  "commentId": "209",
+                  "id": "303",
+                  "text": "Revision 3",
+                },
+              ],
+              "text": "Comment 9",
+            },
+            {
+              "authorId": "002",
+              "createdAt": 8,
+              "id": "208",
+              "issueId": "103",
+              "revisions": [
+                {
+                  "authorId": "002",
+                  "commentId": "208",
+                  "id": "306",
+                  "text": "Revision 3",
+                },
+              ],
+              "text": "Comment 8",
+            },
+          ],
+          "description": "Description 3",
+          "id": "103",
+          "labels": [
+            {
+              "id": "401",
+              "name": "bug",
+            },
+          ],
+          "owner": {
+            "id": "001",
+            "name": "Alice",
           },
-        ],
-        description: 'Description 2',
-        id: '102',
-        labels: [
-          {
-            id: '401',
-            name: 'bug',
+          "ownerId": "001",
+          "title": "Issue 3",
+        },
+        {
+          "closed": false,
+          "comments": [],
+          "description": "Description 4",
+          "id": "104",
+          "labels": [],
+          "owner": {
+            "id": "002",
+            "name": "Bob",
           },
-          {
-            id: '402',
-            name: 'feature',
+          "ownerId": "002",
+          "title": "Issue 4",
+        },
+        {
+          "closed": false,
+          "comments": [
+            {
+              "authorId": "003",
+              "createdAt": 12,
+              "id": "212",
+              "issueId": "105",
+              "revisions": [],
+              "text": "Comment 12",
+            },
+            {
+              "authorId": "002",
+              "createdAt": 11,
+              "id": "211",
+              "issueId": "105",
+              "revisions": [
+                {
+                  "authorId": "003",
+                  "commentId": "211",
+                  "id": "309",
+                  "text": "Revision 3",
+                },
+              ],
+              "text": "Comment 11",
+            },
+          ],
+          "description": "Description 5",
+          "id": "105",
+          "labels": [],
+          "owner": {
+            "id": "002",
+            "name": "Bob",
           },
-        ],
-        owner: [
-          {
-            id: '001',
-            name: 'Alice',
+          "ownerId": "002",
+          "title": "Issue 5",
+        },
+        {
+          "closed": false,
+          "comments": [],
+          "description": "Description 9",
+          "id": "109",
+          "labels": [],
+          "owner": {
+            "id": "003",
+            "name": "Charlie",
           },
-        ],
-        ownerId: '001',
-        title: 'Issue 2',
-      },
-      {
-        closed: false,
-        comments: [
-          {
-            authorId: '003',
-            createdAt: 9,
-            id: '209',
-            issueId: '103',
-            revisions: [
-              {
-                authorId: '001',
-                commentId: '209',
-                id: '303',
-                text: 'Revision 3',
-              },
-            ],
-            text: 'Comment 9',
-          },
-          {
-            authorId: '002',
-            createdAt: 8,
-            id: '208',
-            issueId: '103',
-            revisions: [
-              {
-                authorId: '002',
-                commentId: '208',
-                id: '306',
-                text: 'Revision 3',
-              },
-            ],
-            text: 'Comment 8',
-          },
-        ],
-        description: 'Description 3',
-        id: '103',
-        labels: [
-          {
-            id: '401',
-            name: 'bug',
-          },
-        ],
-        owner: [
-          {
-            id: '001',
-            name: 'Alice',
-          },
-        ],
-        ownerId: '001',
-        title: 'Issue 3',
-      },
-      {
-        closed: false,
-        comments: [],
-        description: 'Description 4',
-        id: '104',
-        labels: [],
-        owner: [
-          {
-            id: '002',
-            name: 'Bob',
-          },
-        ],
-        ownerId: '002',
-        title: 'Issue 4',
-      },
-      {
-        closed: false,
-        comments: [
-          {
-            authorId: '003',
-            createdAt: 12,
-            id: '212',
-            issueId: '105',
-            revisions: [],
-            text: 'Comment 12',
-          },
-          {
-            authorId: '002',
-            createdAt: 11,
-            id: '211',
-            issueId: '105',
-            revisions: [
-              {
-                authorId: '003',
-                commentId: '211',
-                id: '309',
-                text: 'Revision 3',
-              },
-            ],
-            text: 'Comment 11',
-          },
-        ],
-        description: 'Description 5',
-        id: '105',
-        labels: [],
-        owner: [
-          {
-            id: '002',
-            name: 'Bob',
-          },
-        ],
-        ownerId: '002',
-        title: 'Issue 5',
-      },
-      {
-        closed: false,
-        comments: [],
-        description: 'Description 9',
-        id: '109',
-        labels: [],
-        owner: [
-          {
-            id: '003',
-            name: 'Charlie',
-          },
-        ],
-        ownerId: '003',
-        title: 'Issue 9',
-      },
-    ]);
+          "ownerId": "003",
+          "title": "Issue 9",
+        },
+      ]
+    `);
   });
 });

--- a/packages/zql/src/query/query-impl.query-kitchen-sink.test.ts
+++ b/packages/zql/src/query/query-impl.query-kitchen-sink.test.ts
@@ -498,7 +498,7 @@ describe('kitchen sink query', () => {
     view.addListener(data => {
       rows = [...data].map(row => ({
         ...row,
-        owner: [...row.owner],
+        owner: row.owner,
         comments: [...row.comments].map(comment => ({
           ...comment,
           revisions: [...comment.revisions],

--- a/packages/zql/src/query/query-impl.query.test.ts
+++ b/packages/zql/src/query/query-impl.query.test.ts
@@ -928,7 +928,7 @@ test('join with compound keys', () => {
     .primaryKey('id');
 
   const aRelationships = relationships(a, connect => ({
-    b: connect({
+    b: connect.many({
       sourceField: ['a1', 'a2'],
       destField: ['b1', 'b2'],
       destSchema: b,

--- a/packages/zql/src/query/query-impl.query.test.ts
+++ b/packages/zql/src/query/query-impl.query.test.ts
@@ -443,75 +443,76 @@ describe('joins and filters', () => {
       rows = deepClone(data) as unknown[];
     });
 
-    expect(rows).toEqual([
-      {
-        closed: false,
-        comments: [
-          {
-            authorId: '0001',
-            body: 'comment 1',
-            id: '0001',
-            issueId: '0001',
-          },
-          {
-            authorId: '0002',
-            body: 'comment 2',
-            id: '0002',
-            issueId: '0001',
-          },
-        ],
-        description: 'description 1',
-        id: '0001',
-        labels: [
-          {
-            id: '0001',
-            name: 'label 1',
-          },
-        ],
-        owner: [
-          {
-            id: '0001',
-            name: 'Alice',
-            metadata: {
-              login: 'alicegh',
-              registrar: 'github',
+    expect(rows).toMatchInlineSnapshot(`
+      [
+        {
+          "closed": false,
+          "comments": [
+            {
+              "authorId": "0001",
+              "body": "comment 1",
+              "id": "0001",
+              "issueId": "0001",
             },
-          },
-        ],
-        ownerId: '0001',
-        title: 'issue 1',
-      },
-      {
-        closed: false,
-        comments: [],
-        description: 'description 2',
-        id: '0002',
-        labels: [],
-        owner: [
-          {
-            id: '0002',
-            name: 'Bob',
-            metadata: {
-              altContacts: ['bobwave', 'bobyt', 'bobplus'],
-              login: 'bob@gmail.com',
-              registar: 'google',
+            {
+              "authorId": "0002",
+              "body": "comment 2",
+              "id": "0002",
+              "issueId": "0001",
             },
+          ],
+          "description": "description 1",
+          "id": "0001",
+          "labels": [
+            {
+              "id": "0001",
+              "name": "label 1",
+            },
+          ],
+          "owner": {
+            "id": "0001",
+            "metadata": {
+              "login": "alicegh",
+              "registrar": "github",
+            },
+            "name": "Alice",
           },
-        ],
-        ownerId: '0002',
-        title: 'issue 2',
-      },
-      {
-        closed: false,
-        comments: [],
-        description: 'description 3',
-        id: '0003',
-        labels: [],
-        owner: [],
-        ownerId: null,
-        title: 'issue 3',
-      },
-    ]);
+          "ownerId": "0001",
+          "title": "issue 1",
+        },
+        {
+          "closed": false,
+          "comments": [],
+          "description": "description 2",
+          "id": "0002",
+          "labels": [],
+          "owner": {
+            "id": "0002",
+            "metadata": {
+              "altContacts": [
+                "bobwave",
+                "bobyt",
+                "bobplus",
+              ],
+              "login": "bob@gmail.com",
+              "registar": "google",
+            },
+            "name": "Bob",
+          },
+          "ownerId": "0002",
+          "title": "issue 2",
+        },
+        {
+          "closed": false,
+          "comments": [],
+          "description": "description 3",
+          "id": "0003",
+          "labels": [],
+          "ownerId": null,
+          "title": "issue 3",
+        },
+      ]
+    `);
 
     queryDelegate.getSource('issue').push({
       type: 'remove',
@@ -602,6 +603,80 @@ describe('joins and filters', () => {
       },
     });
   });
+
+  test('schema applied one', () => {
+    const queryDelegate = new QueryDelegateImpl();
+    addData(queryDelegate);
+
+    const query = newQuery(queryDelegate, schema, 'issue')
+      .related('owner')
+      .related('comments', q => q.related('author').related('revisions'))
+      .where('id', '=', '0001');
+    const data = query.run();
+    expect(data).toMatchInlineSnapshot(`
+      [
+        {
+          "closed": false,
+          "comments": [
+            {
+              "author": {
+                "id": "0001",
+                "metadata": {
+                  "login": "alicegh",
+                  "registrar": "github",
+                },
+                "name": "Alice",
+              },
+              "authorId": "0001",
+              "body": "comment 1",
+              "id": "0001",
+              "issueId": "0001",
+              "revisions": [
+                {
+                  "authorId": "0001",
+                  "commentId": "0001",
+                  "id": "0001",
+                  "text": "revision 1",
+                },
+              ],
+            },
+            {
+              "author": {
+                "id": "0002",
+                "metadata": {
+                  "altContacts": [
+                    "bobwave",
+                    "bobyt",
+                    "bobplus",
+                  ],
+                  "login": "bob@gmail.com",
+                  "registar": "google",
+                },
+                "name": "Bob",
+              },
+              "authorId": "0002",
+              "body": "comment 2",
+              "id": "0002",
+              "issueId": "0001",
+              "revisions": [],
+            },
+          ],
+          "description": "description 1",
+          "id": "0001",
+          "owner": {
+            "id": "0001",
+            "metadata": {
+              "login": "alicegh",
+              "registrar": "github",
+            },
+            "name": "Alice",
+          },
+          "ownerId": "0001",
+          "title": "issue 1",
+        },
+      ]
+    `);
+  });
 });
 
 test('limit -1', () => {
@@ -643,75 +718,77 @@ test('run', () => {
     .related('owner')
     .related('comments');
   const rows = issueQuery2.run();
-  expect(rows).toEqual([
-    {
-      closed: false,
-      comments: [
-        {
-          authorId: '0001',
-          body: 'comment 1',
-          id: '0001',
-          issueId: '0001',
-        },
-        {
-          authorId: '0002',
-          body: 'comment 2',
-          id: '0002',
-          issueId: '0001',
-        },
-      ],
-      description: 'description 1',
-      id: '0001',
-      labels: [
-        {
-          id: '0001',
-          name: 'label 1',
-        },
-      ],
-      owner: [
-        {
-          id: '0001',
-          name: 'Alice',
-          metadata: {
-            login: 'alicegh',
-            registrar: 'github',
+  expect(rows).toMatchInlineSnapshot(`
+    [
+      {
+        "closed": false,
+        "comments": [
+          {
+            "authorId": "0001",
+            "body": "comment 1",
+            "id": "0001",
+            "issueId": "0001",
           },
-        },
-      ],
-      ownerId: '0001',
-      title: 'issue 1',
-    },
-    {
-      closed: false,
-      comments: [],
-      description: 'description 2',
-      id: '0002',
-      labels: [],
-      owner: [
-        {
-          id: '0002',
-          name: 'Bob',
-          metadata: {
-            altContacts: ['bobwave', 'bobyt', 'bobplus'],
-            login: 'bob@gmail.com',
-            registar: 'google',
+          {
+            "authorId": "0002",
+            "body": "comment 2",
+            "id": "0002",
+            "issueId": "0001",
           },
+        ],
+        "description": "description 1",
+        "id": "0001",
+        "labels": [
+          {
+            "id": "0001",
+            "name": "label 1",
+          },
+        ],
+        "owner": {
+          "id": "0001",
+          "metadata": {
+            "login": "alicegh",
+            "registrar": "github",
+          },
+          "name": "Alice",
         },
-      ],
-      ownerId: '0002',
-      title: 'issue 2',
-    },
-    {
-      closed: false,
-      comments: [],
-      description: 'description 3',
-      id: '0003',
-      labels: [],
-      owner: [],
-      ownerId: null,
-      title: 'issue 3',
-    },
-  ]);
+        "ownerId": "0001",
+        "title": "issue 1",
+      },
+      {
+        "closed": false,
+        "comments": [],
+        "description": "description 2",
+        "id": "0002",
+        "labels": [],
+        "owner": {
+          "id": "0002",
+          "metadata": {
+            "altContacts": [
+              "bobwave",
+              "bobyt",
+              "bobplus",
+            ],
+            "login": "bob@gmail.com",
+            "registar": "google",
+          },
+          "name": "Bob",
+        },
+        "ownerId": "0002",
+        "title": "issue 2",
+      },
+      {
+        "closed": false,
+        "comments": [],
+        "description": "description 3",
+        "id": "0003",
+        "labels": [],
+        "owner": undefined,
+        "ownerId": null,
+        "title": "issue 3",
+      },
+    ]
+  `);
 });
 
 test('view creation is wrapped in context.batchViewUpdates call', () => {

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -171,7 +171,7 @@ export abstract class AbstractQuery<
     const related = this.#schema.relationships[this.#tableName][relationship];
     assert(related, 'Invalid relationship');
     if (isOneHop(related)) {
-      const {destSchema, destField, sourceField} = related[0];
+      const {destSchema, destField, sourceField, cardinality} = related[0];
       const sq = cb(
         this._newQuery(
           this.#schema,
@@ -180,7 +180,10 @@ export abstract class AbstractQuery<
             table: destSchema,
             alias: relationship,
           },
-          undefined,
+          {
+            relationships: {},
+            singular: cardinality === 'one',
+          },
         ),
       ) as unknown as QueryImpl<any, any>;
 
@@ -240,7 +243,10 @@ export abstract class AbstractQuery<
             table: destSchema,
             alias: relationship,
           },
-          undefined,
+          {
+            relationships: {},
+            singular: secondRelation.cardinality === 'one',
+          },
         ),
       ) as unknown as QueryImpl<Schema, string>;
 

--- a/packages/zql/src/query/query.test.ts
+++ b/packages/zql/src/query/query.test.ts
@@ -77,8 +77,8 @@ const schemaWithEnums = table('testWithEnums')
 
 const schemaWithEnumsRelationships = relationships(
   schemaWithEnums,
-  connect => ({
-    self: connect({
+  ({many}) => ({
+    self: many({
       sourceField: ['s'],
       destField: ['s'],
       destSchema: schemaWithEnums,
@@ -100,7 +100,7 @@ const schemaWithAdvancedTypes = table('schemaWithAdvancedTypes')
 const withAdvancedTypesRelationships = relationships(
   schemaWithAdvancedTypes,
   connect => ({
-    self: connect({
+    self: connect.many({
       sourceField: ['s'],
       destField: ['s'],
       destSchema: schemaWithAdvancedTypes,
@@ -127,7 +127,7 @@ const testWithRelationships = table('testWithRelationships')
 const testWithRelationshipsRelationships = relationships(
   testWithRelationships,
   connect => ({
-    test: connect({
+    test: connect.many({
       sourceField: ['s'],
       destField: ['s'],
       destSchema: testSchema,
@@ -146,17 +146,17 @@ const testWithMoreRelationships = table('testWithMoreRelationships')
 const testWithMoreRelationshipsRelationships = relationships(
   testWithMoreRelationships,
   connect => ({
-    testWithRelationships: connect({
+    testWithRelationships: connect.many({
       sourceField: ['a'],
       destField: ['a'],
       destSchema: testWithRelationships,
     }),
-    test: connect({
+    test: connect.many({
       sourceField: ['s'],
       destField: ['s'],
       destSchema: testSchema,
     }),
-    self: connect({
+    self: connect.many({
       sourceField: ['s'],
       destField: ['s'],
       destSchema: testWithMoreRelationships,
@@ -592,7 +592,7 @@ describe('schema structure', () => {
       .primaryKey('id');
 
     const issueRelationships = relationships(issue, connect => ({
-      comments: connect({
+      comments: connect.many({
         sourceField: ['id'],
         destField: ['issueId'],
         destSchema: comment,
@@ -631,7 +631,7 @@ describe('schema structure', () => {
       .primaryKey('id');
 
     const commentRelationships = relationships(comment, connect => ({
-      issue: connect({
+      issue: connect.many({
         sourceField: ['issueId'],
         destField: ['id'],
         destSchema: issue,
@@ -639,12 +639,12 @@ describe('schema structure', () => {
     }));
 
     const issueRelationships = relationships(issue, connect => ({
-      comments: connect({
+      comments: connect.many({
         sourceField: ['id'],
         destField: ['issueId'],
         destSchema: comment,
       }),
-      parent: connect({
+      parent: connect.many({
         sourceField: ['parentId'],
         destField: ['id'],
         destSchema: issue,

--- a/packages/zql/src/query/test/test-schemas.ts
+++ b/packages/zql/src/query/test/test-schemas.ts
@@ -63,18 +63,18 @@ const revision = table('revision')
   })
   .primaryKey('id');
 
-const issueRelationships = relationships(issue, connect => ({
-  owner: connect({
+const issueRelationships = relationships(issue, ({one, many}) => ({
+  owner: one({
     sourceField: ['ownerId'],
     destField: ['id'],
     destSchema: user,
   }),
-  comments: connect({
+  comments: many({
     sourceField: ['id'],
     destField: ['issueId'],
     destSchema: comment,
   }),
-  labels: connect(
+  labels: many(
     {
       sourceField: ['id'],
       destField: ['issueId'],
@@ -88,47 +88,47 @@ const issueRelationships = relationships(issue, connect => ({
   ),
 }));
 
-const userRelationships = relationships(user, connect => ({
-  issues: connect({
+const userRelationships = relationships(user, ({many}) => ({
+  issues: many({
     sourceField: ['id'],
     destField: ['ownerId'],
     destSchema: issue,
   }),
 }));
 
-const commentRelationships = relationships(comment, connect => ({
-  issue: connect({
+const commentRelationships = relationships(comment, ({one, many}) => ({
+  issue: one({
     sourceField: ['issueId'],
     destField: ['id'],
     destSchema: issue,
   }),
-  revisions: connect({
+  revisions: many({
     sourceField: ['id'],
     destField: ['commentId'],
     destSchema: revision,
   }),
-  author: connect({
+  author: one({
     sourceField: ['authorId'],
     destField: ['id'],
     destSchema: user,
   }),
 }));
 
-const revisionRelationships = relationships(revision, connect => ({
-  comment: connect({
+const revisionRelationships = relationships(revision, ({one}) => ({
+  comment: one({
     sourceField: ['commentId'],
     destField: ['id'],
     destSchema: comment,
   }),
-  author: connect({
+  author: one({
     sourceField: ['authorId'],
     destField: ['id'],
     destSchema: user,
   }),
 }));
 
-const labelRelationships = relationships(label, connect => ({
-  issues: connect(
+const labelRelationships = relationships(label, ({many}) => ({
+  issues: many(
     {
       sourceField: ['id'],
       destField: ['labelId'],


### PR DESCRIPTION
Example:

```ts
const issueRelationships = relationships(issue, ({many, one}) => ({
  labels: many(
    {
      sourceField: ['id'],
      destField: ['issueID'],
      destSchema: issueLabel,
    },
    {
      sourceField: ['labelID'],
      destField: ['id'],
      destSchema: label,
    },
  ),
  comments: many({
    sourceField: ['id'],
    destField: ['issueID'],
    destSchema: comment,
  }),
  creator: one({
    sourceField: ['creatorID'],
    destField: ['id'],
    destSchema: user,
  }),
  assignee: one({
    sourceField: ['assigneeID'],
    destField: ['id'],
    destSchema: user,
  }),
  viewState: many({
    sourceField: ['id'],
    destField: ['issueID'],
    destSchema: viewState,
  }),
  emoji: many({
    sourceField: ['id'],
    destField: ['subjectID'],
    destSchema: emoji,
  }),
}));
```

Which allows us to finally drop all those manual `one` calls for relationships that are known to only return one thing.

![CleanShot 2025-01-17 at 15 11 14](https://github.com/user-attachments/assets/15ebefee-10a3-466f-9adb-e19927ee7e29)

---

I think I'll follow this with an update to throw if a relationship marked as `one` returns more than 1 item.

