### PR TITLE
feat(zero-cache): allow TableSource to work on tables without a `PRIMARY KEY`

### DIFF
--- a/packages/zqlite/src/table-source.test.ts
+++ b/packages/zqlite/src/table-source.test.ts
@@ -1,6 +1,9 @@
 import {describe, expect, test} from 'vitest';
+import type {JSONValue} from '../../shared/src/json.js';
 import {createSilentLogContext} from '../../shared/src/logging-test-utils.js';
+import type {Ordering} from '../../zero-protocol/src/ast.js';
 import type {Row, Value} from '../../zero-protocol/src/data.js';
+import type {PrimaryKey} from '../../zero-protocol/src/primary-key.js';
 import {Catch} from '../../zql/src/ivm/catch.js';
 import type {Change} from '../../zql/src/ivm/change.js';
 import {makeComparator} from '../../zql/src/ivm/data.js';
@@ -11,7 +14,6 @@ import {
   TableSource,
   UnsupportedValueError,
 } from './table-source.js';
-import type {JSONValue} from '../../shared/src/json.js';
 
 const columns = {
   id: {type: 'string'},
@@ -275,6 +277,118 @@ describe('fetched value types', () => {
       }
     });
   }
+});
+
+describe('no primary key', () => {
+  type Foo = {id: string; a: number; b: number; c: number};
+  const columns = {
+    id: {type: 'string'},
+    a: {type: 'number'},
+    b: {type: 'number'},
+    c: {type: 'number'},
+  } as const;
+
+  const db = new Database(createSilentLogContext(), ':memory:');
+  db.exec(/* sql */ `
+        CREATE TABLE foo (id TEXT, a INT, b INT, c INT);
+        CREATE UNIQUE INDEX foo_id_key ON foo (id);
+        CREATE UNIQUE INDEX foo_ab_key ON foo (a, b);
+        `);
+  const stmt = db.prepare(
+    /* sql */ `INSERT INTO foo (id, a, b, c) VALUES (?, ?, ?, ?);`,
+  );
+  stmt.run(['far', 234, 567, 333]);
+  stmt.run(['boo', 345, 112, 444]);
+  stmt.run(['foo', 345, 789, 555]);
+  const source = new TableSource('table-source.test.ts', db, 'foo', columns, [
+    'id',
+  ]);
+
+  test.each([
+    [['id'], true],
+    [['a', 'b'], true],
+    [['b', 'a'], true],
+    [['a'], false],
+    [['b', 'c'], false],
+    [['a', 'c'], false],
+  ] satisfies [PrimaryKey, boolean][])(
+    'requires primary  key to be uniquely indexed: %o',
+    (key, valid) => {
+      const createSource = () =>
+        new TableSource('table-source.test.ts', db, 'foo', columns, key);
+      if (valid) {
+        createSource();
+      } else {
+        expect(createSource).toThrowError('does not have a UNIQUE index');
+      }
+    },
+  );
+
+  test.each([
+    [[['a', 'asc']]],
+    [[['b', 'asc']]],
+    [
+      [
+        ['b', 'asc'],
+        ['c', 'desc'],
+      ],
+    ],
+  ] satisfies [Ordering][])('disallows non-unique orderings: %o', sort => {
+    expect(() => source.connect(sort)).toThrowError(
+      'does not include uniquely indexed columns',
+    );
+  });
+
+  test.each([
+    [
+      [['id', 'asc']],
+      [
+        {id: 'boo', a: 345, b: 112, c: 444},
+        {id: 'far', a: 234, b: 567, c: 333},
+        {id: 'foo', a: 345, b: 789, c: 555},
+      ],
+    ],
+    [
+      [
+        ['a', 'asc'],
+        ['b', 'desc'],
+      ],
+      [
+        {id: 'far', a: 234, b: 567, c: 333},
+        {id: 'foo', a: 345, b: 789, c: 555},
+        {id: 'boo', a: 345, b: 112, c: 444},
+      ],
+    ],
+    [
+      [
+        ['c', 'asc'],
+        ['a', 'asc'],
+        ['b', 'desc'],
+      ],
+      [
+        {id: 'far', a: 234, b: 567, c: 333},
+        {id: 'boo', a: 345, b: 112, c: 444},
+        {id: 'foo', a: 345, b: 789, c: 555},
+      ],
+    ],
+    [
+      [
+        ['c', 'desc'],
+        ['id', 'asc'],
+      ],
+      [
+        {id: 'foo', a: 345, b: 789, c: 555},
+        {id: 'boo', a: 345, b: 112, c: 444},
+        {id: 'far', a: 234, b: 567, c: 333},
+      ],
+    ],
+  ] satisfies [Ordering, Foo[]][])(
+    'allows orderings with unique indexes: %o',
+    (sort, output) => {
+      const input = source.connect(sort);
+      expect([...input.fetch({})].map(node => node.row)).toEqual(output);
+    },
+  );
 });
 
 test('pushing values does the correct writes and outputs', () => {
@@ -799,4 +913,4 @@ describe('optional filters to sql', () => {
   });
 });
 
-// TODO: Add constraint test withj compound keys
+// TODO: Add constraint test with compound keys

--- a/packages/zqlite/src/table-source.test.ts
+++ b/packages/zqlite/src/table-source.test.ts
@@ -293,6 +293,7 @@ describe('no primary key', () => {
         CREATE TABLE foo (id TEXT, a INT, b INT, c INT);
         CREATE UNIQUE INDEX foo_id_key ON foo (id);
         CREATE UNIQUE INDEX foo_ab_key ON foo (a, b);
+        CREATE INDEX foo_c_not_unique ON foo (c);
         `);
   const stmt = db.prepare(
     /* sql */ `INSERT INTO foo (id, a, b, c) VALUES (?, ?, ?, ?);`,
@@ -309,6 +310,8 @@ describe('no primary key', () => {
     [['a', 'b'], true],
     [['b', 'a'], true],
     [['a'], false],
+    [['b'], false],
+    [['c'], false],
     [['b', 'c'], false],
     [['a', 'c'], false],
   ] satisfies [PrimaryKey, boolean][])(
@@ -327,6 +330,7 @@ describe('no primary key', () => {
   test.each([
     [[['a', 'asc']]],
     [[['b', 'asc']]],
+    [[['c', 'asc']]],
     [
       [
         ['b', 'asc'],


### PR DESCRIPTION
Remove the requirement of an explicit `PRIMARY KEY` from TableSource.

Instead, rely on the table's `UNIQUE` indexes.

* TableSource is still configured with a "PrimaryKey" for the purposes of uniquely identifying rows. However, this key can be any uniquely indexed set of columns, and need not be an explicit `PRIMARY KEY` (which, in SQLite, mean the same thing, as the [rowid](https://www.sqlite.org/withoutrowid.html) is the only real "primary key").
* Similarly, the `Ordering` check is relaxed to allow an ordering that includes the columns of any unique index, and not necessarily those of the primary key.

https://bugs.rocicorp.dev/issue/3186
https://bugs.rocicorp.dev/issue/3198