### PR TITLE
feat(zero-cache): index and primary key-handling overhaul

### DIFF
--- a/packages/zero-cache/src/auth/write-authorizer.ts
+++ b/packages/zero-cache/src/auth/write-authorizer.ts
@@ -20,11 +20,11 @@ import {
   primaryKeyValueSchema,
   type PrimaryKeyValue,
 } from '../../../zero-protocol/src/primary-key.js';
+import type {Schema} from '../../../zero-schema/src/builder/schema-builder.js';
 import type {
   PermissionsConfig,
   Policy,
 } from '../../../zero-schema/src/compiled-permissions.js';
-import type {Schema} from '../../../zero-schema/src/builder/schema-builder.js';
 import type {BuilderDelegate} from '../../../zql/src/builder/builder.js';
 import {
   bindStaticParameters,
@@ -40,11 +40,10 @@ import {
   TableSource,
 } from '../../../zqlite/src/table-source.js';
 import type {ZeroConfig} from '../config/zero-config.js';
-import {listTables} from '../db/lite-tables.js';
+import {computeZqlSpecs} from '../db/lite-tables.js';
 import type {LiteAndZqlSpec} from '../db/specs.js';
 import {StatementRunner} from '../db/statements.js';
 import {DatabaseStorage} from '../services/view-syncer/database-storage.js';
-import {setSpecs} from '../services/view-syncer/pipeline-driver.js';
 import {mapLiteDataTypeToZqlSchemaValue} from '../types/lite.js';
 
 type Phase = 'preMutation' | 'postMutation';
@@ -95,8 +94,7 @@ export class WriteAuthorizerImpl implements WriteAuthorizer {
       getSource: name => this.#getSource(name),
       createStorage: () => cgStorage.createStorage(),
     };
-    this.#tableSpecs = new Map();
-    setSpecs(listTables(replica), this.#tableSpecs);
+    this.#tableSpecs = computeZqlSpecs(this.#lc, replica);
     this.#statementRunner = new StatementRunner(replica);
   }
 

--- a/packages/zero-cache/src/db/create.pg-test.ts
+++ b/packages/zero-cache/src/db/create.pg-test.ts
@@ -96,7 +96,6 @@ describe('tables/create', () => {
             notNull: false,
           },
         },
-        primaryKey: ['clientID'],
       },
     },
     {
@@ -174,7 +173,6 @@ describe('tables/create', () => {
             pos: 3,
           },
         },
-        primaryKey: ['clientID'],
       },
     },
     {
@@ -342,7 +340,6 @@ describe('tables/create', () => {
             pos: 7,
           },
         },
-        primaryKey: ['user_id'],
       },
     },
   ];

--- a/packages/zero-cache/src/db/pg-to-lite.test.ts
+++ b/packages/zero-cache/src/db/pg-to-lite.test.ts
@@ -67,7 +67,6 @@ test('postgres to lite table spec', () => {
           dflt: 'false',
         },
       },
-      primaryKey: ['b', 'a'],
     }),
   ).toEqual({
     name: 'issue',
@@ -136,7 +135,6 @@ test('postgres to lite table spec', () => {
         pos: 5,
       },
     },
-    primaryKey: ['b', 'a'],
   });
 
   // Non-public schema
@@ -173,7 +171,6 @@ test('postgres to lite table spec', () => {
         pos: 1,
       },
     },
-    primaryKey: ['a'],
   });
 });
 

--- a/packages/zero-cache/src/db/pg-to-lite.ts
+++ b/packages/zero-cache/src/db/pg-to-lite.ts
@@ -99,7 +99,9 @@ export function mapPostgresToLiteColumn(
 }
 
 export function mapPostgresToLite(t: TableSpec): LiteTableSpec {
-  const {schema: _, ...liteSpec} = t;
+  // PRIMARY KEYS are not written to the replica. Instead, we rely
+  // UNIQUE indexes, including those created for upstream PRIMARY KEYs.
+  const {schema: _, primaryKey: _dropped, ...liteSpec} = t;
   const name = liteTableName(t);
   return {
     ...liteSpec,

--- a/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg-test.ts
@@ -131,8 +131,8 @@ describe('change-source/pg/end-to-mid-test', {timeout: 10000}, () => {
   test.each([
     [
       'create table',
-      'CREATE TABLE zero.baz (id INT8 PRIMARY KEY);',
-      [{tag: 'create-table'}],
+      'CREATE TABLE zero.baz (id INT8 CONSTRAINT baz_pkey PRIMARY KEY);',
+      [{tag: 'create-table'}, {tag: 'create-index'}],
       {['zero.baz']: []},
       [
         {
@@ -153,10 +153,16 @@ describe('change-source/pg/end-to-mid-test', {timeout: 10000}, () => {
               pos: 2,
             },
           },
-          primaryKey: ['id'],
         },
       ],
-      [],
+      [
+        {
+          columns: {id: 'ASC'},
+          name: 'zero.baz_pkey',
+          tableName: 'zero.baz',
+          unique: true,
+        },
+      ],
     ],
     [
       'rename table',
@@ -182,10 +188,16 @@ describe('change-source/pg/end-to-mid-test', {timeout: 10000}, () => {
               pos: 2,
             },
           },
-          primaryKey: ['id'],
         },
       ],
-      [],
+      [
+        {
+          columns: {id: 'ASC'},
+          name: 'zero.baz_pkey',
+          tableName: 'zero.bar',
+          unique: true,
+        },
+      ],
     ],
     [
       'add column',
@@ -218,7 +230,6 @@ describe('change-source/pg/end-to-mid-test', {timeout: 10000}, () => {
             },
           },
           name: 'zero.bar',
-          primaryKey: ['id'],
         },
       ],
       [],
@@ -254,7 +265,6 @@ describe('change-source/pg/end-to-mid-test', {timeout: 10000}, () => {
             },
           },
           name: 'zero.bar',
-          primaryKey: ['id'],
         },
       ],
       [],
@@ -290,10 +300,54 @@ describe('change-source/pg/end-to-mid-test', {timeout: 10000}, () => {
             },
           },
           name: 'zero.bar',
-          primaryKey: ['id'],
         },
       ],
       [],
+    ],
+    [
+      'change the primary key',
+      `
+      ALTER TABLE zero.bar DROP CONSTRAINT baz_pkey;
+      ALTER TABLE zero.bar ADD PRIMARY KEY (handle);
+      `,
+      [{tag: 'drop-index'}, {tag: 'create-index'}],
+      {['zero.bar']: []},
+      [
+        {
+          columns: {
+            ['_0_version']: {
+              characterMaximumLength: null,
+              dataType: 'TEXT',
+              dflt: null,
+              notNull: false,
+              pos: 2,
+            },
+            id: {
+              characterMaximumLength: null,
+              dataType: 'int8',
+              dflt: null,
+              notNull: false,
+              pos: 1,
+            },
+            handle: {
+              characterMaximumLength: null,
+              dataType: 'TEXT',
+              dflt: null,
+              notNull: false,
+              pos: 3,
+            },
+          },
+          name: 'zero.bar',
+        },
+      ],
+      [
+        {
+          columns: {handle: 'ASC'},
+          name: 'zero.bar_pkey',
+          tableName: 'zero.bar',
+          unique: true,
+        },
+      ],
     ],
     [
       'add unique column to automatically generate index',
@@ -333,7 +387,6 @@ describe('change-source/pg/end-to-mid-test', {timeout: 10000}, () => {
             },
           },
           name: 'zero.bar',
-          primaryKey: ['id'],
         },
       ],
       [
@@ -383,7 +436,6 @@ describe('change-source/pg/end-to-mid-test', {timeout: 10000}, () => {
             },
           },
           name: 'zero.bar',
-          primaryKey: ['id'],
         },
       ],
       [
@@ -433,7 +485,6 @@ describe('change-source/pg/end-to-mid-test', {timeout: 10000}, () => {
             },
           },
           name: 'zero.bar',
-          primaryKey: ['id'],
         },
       ],
       [
@@ -476,7 +527,6 @@ describe('change-source/pg/end-to-mid-test', {timeout: 10000}, () => {
             },
           },
           name: 'zero.bar',
-          primaryKey: ['id'],
         },
       ],
       [],
@@ -513,7 +563,6 @@ describe('change-source/pg/end-to-mid-test', {timeout: 10000}, () => {
               pos: 3,
             },
           },
-          primaryKey: ['id'],
         },
       ],
       [],
@@ -561,7 +610,6 @@ describe('change-source/pg/end-to-mid-test', {timeout: 10000}, () => {
               pos: 3,
             },
           },
-          primaryKey: ['id'],
         },
       ],
       [],
@@ -620,7 +668,6 @@ describe('change-source/pg/end-to-mid-test', {timeout: 10000}, () => {
               pos: 5,
             },
           },
-          primaryKey: ['id'],
         },
       ],
       [],
@@ -640,6 +687,7 @@ describe('change-source/pg/end-to-mid-test', {timeout: 10000}, () => {
         {tag: 'drop-column'},
         {tag: 'drop-column'},
         {tag: 'create-table'},
+        {tag: 'create-index'},
         {tag: 'create-index'},
       ],
       {foo: []},
@@ -669,7 +717,6 @@ describe('change-source/pg/end-to-mid-test', {timeout: 10000}, () => {
               pos: 3,
             },
           },
-          primaryKey: ['id'],
         },
         {
           name: 'boo',
@@ -696,7 +743,6 @@ describe('change-source/pg/end-to-mid-test', {timeout: 10000}, () => {
               pos: 3,
             },
           },
-          primaryKey: ['id'],
         },
       ],
       [
@@ -704,6 +750,12 @@ describe('change-source/pg/end-to-mid-test', {timeout: 10000}, () => {
           name: 'boo_name_key',
           tableName: 'boo',
           columns: {name: 'ASC'},
+          unique: true,
+        },
+        {
+          name: 'boo_pkey',
+          tableName: 'boo',
+          columns: {id: 'ASC'},
           unique: true,
         },
       ],
@@ -743,6 +795,10 @@ describe('change-source/pg/end-to-mid-test', {timeout: 10000}, () => {
         {
           tag: 'drop-index',
           id: {schema: 'public', name: 'boo_name_key'},
+        },
+        {
+          tag: 'drop-index',
+          id: {schema: 'public', name: 'boo_pkey'},
         },
         {
           tag: 'drop-table',
@@ -907,7 +963,58 @@ describe('change-source/pg/end-to-mid-test', {timeout: 10000}, () => {
               pos: 2,
             },
           },
-          primaryKey: ['id'],
+        },
+      ],
+      [],
+    ],
+    [
+      'no primary key',
+      `
+      CREATE TABLE nopk (a TEXT NOT NULL, b TEXT);
+      ALTER PUBLICATION zero_some_public ADD TABLE nopk;
+
+      INSERT INTO nopk (a, b) VALUES ('foo', 'bar');
+      `,
+      [
+        {tag: 'create-table'},
+        {
+          tag: 'insert',
+          relation: {
+            tag: 'relation',
+            schema: 'public',
+            name: 'nopk',
+            replicaIdentity: 'default',
+            keyColumns: [], // Note: This means is will be replicated to SQLite but not synced to clients.
+          },
+        },
+      ],
+      {nopk: [{a: 'foo', b: 'bar'}]},
+      [
+        {
+          name: 'nopk',
+          columns: {
+            a: {
+              characterMaximumLength: null,
+              dataType: 'TEXT',
+              dflt: null,
+              notNull: false,
+              pos: 1,
+            },
+            b: {
+              characterMaximumLength: null,
+              dataType: 'TEXT',
+              dflt: null,
+              notNull: false,
+              pos: 2,
+            },
+            ['_0_version']: {
+              characterMaximumLength: null,
+              dataType: 'TEXT',
+              dflt: null,
+              notNull: false,
+              pos: 3,
+            },
+          },
         },
       ],
       [],

--- a/packages/zero-cache/src/services/change-source/pg/change-source.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.pg-test.ts
@@ -421,8 +421,8 @@ describe('change-source/pg', {timeout: 10000}, () => {
       // effectively freeze replication.
       await upstream.begin(async tx => {
         await tx`INSERT INTO foo(id) VALUES('wide')`;
-        await tx`ALTER TABLE foo DROP CONSTRAINT foo_pk`;
-        await tx`INSERT INTO foo(id) VALUES('world')`;
+        await tx`ALTER TABLE foo RENAME TO "invalid/character$"`;
+        await tx`INSERT INTO "invalid/character$"(id) VALUES('world')`;
       });
 
       // The transaction should be rolled back.
@@ -445,7 +445,7 @@ describe('change-source/pg', {timeout: 10000}, () => {
         {component: 'change-source'},
         [
           expect.stringMatching(
-            'UnsupportedTableSchemaError: Table "foo" does not have a PRIMARY KEY',
+            'UnsupportedTableSchemaError: Table "invalid/character\\$" has invalid characters.',
           ),
           {tag: 'message'},
         ],

--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl.pg-test.ts
@@ -217,6 +217,13 @@ describe('change-source/tables/ddl', () => {
           unique: true,
         },
         {
+          name: 'boo_pkey',
+          schema: 'pub',
+          tableName: 'boo',
+          columns: {id: 'ASC'},
+          unique: true,
+        },
+        {
           name: 'foo_custom_index',
           schema: 'pub',
           tableName: 'foo',
@@ -234,6 +241,13 @@ describe('change-source/tables/ddl', () => {
           unique: true,
         },
         {
+          name: 'foo_pkey',
+          schema: 'pub',
+          tableName: 'foo',
+          columns: {id: 'ASC'},
+          unique: true,
+        },
+        {
           name: 'yoo_custom_index',
           schema: 'pub',
           tableName: 'yoo',
@@ -248,6 +262,13 @@ describe('change-source/tables/ddl', () => {
           schema: 'pub',
           tableName: 'yoo',
           columns: {name: 'ASC'},
+          unique: true,
+        },
+        {
+          name: 'yoo_pkey',
+          schema: 'pub',
+          tableName: 'yoo',
+          columns: {id: 'ASC'},
           unique: true,
         },
       ],
@@ -353,6 +374,13 @@ describe('change-source/tables/ddl', () => {
               tableName: 'bar',
               unique: true,
             },
+            {
+              columns: {id: 'ASC'},
+              name: 'bar_pkey',
+              schema: 'pub',
+              tableName: 'bar',
+              unique: true,
+            },
           ),
         },
       },
@@ -372,7 +400,7 @@ describe('change-source/tables/ddl', () => {
         },
         schema: {
           tables: DDL_START.schema.tables,
-          indexes: inserted(DDL_START.schema.indexes, 2, {
+          indexes: inserted(DDL_START.schema.indexes, 3, {
             columns: {
               name: 'DESC',
               id: 'ASC',
@@ -437,8 +465,8 @@ describe('change-source/tables/ddl', () => {
           }),
           indexes: replaced(
             DDL_START.schema.indexes,
-            1,
             2,
+            3,
             {
               columns: {
                 description: 'ASC',
@@ -452,6 +480,13 @@ describe('change-source/tables/ddl', () => {
             {
               columns: {name: 'ASC'},
               name: 'foo_name_key',
+              schema: 'pub',
+              tableName: 'food',
+              unique: true,
+            },
+            {
+              columns: {id: 'ASC'},
+              name: 'foo_pkey',
               schema: 'pub',
               tableName: 'food',
               unique: true,
@@ -518,7 +553,7 @@ describe('change-source/tables/ddl', () => {
               ['zero_sum']: {rowFilter: null},
             },
           }),
-          indexes: replaced(DDL_START.schema.indexes, 3, 0, {
+          indexes: replaced(DDL_START.schema.indexes, 5, 0, {
             columns: {username: 'ASC'},
             name: 'foo_username_key',
             schema: 'pub',
@@ -696,7 +731,7 @@ describe('change-source/tables/ddl', () => {
           }),
           indexes: replaced(
             DDL_START.schema.indexes,
-            1,
+            2,
             2,
             {
               columns: {
@@ -760,7 +795,7 @@ describe('change-source/tables/ddl', () => {
             },
           }),
           // "foo_custom_index" depended on the "description column"
-          indexes: dropped(DDL_START.schema.indexes, 1, 1),
+          indexes: dropped(DDL_START.schema.indexes, 2, 1),
         },
       },
     ],
@@ -819,6 +854,13 @@ describe('change-source/tables/ddl', () => {
               tableName: 'boo',
               unique: true,
             },
+            {
+              columns: {id: 'ASC'},
+              name: 'boo_pkey',
+              schema: 'pub',
+              tableName: 'boo',
+              unique: true,
+            },
           ],
         },
       },
@@ -843,6 +885,13 @@ describe('change-source/tables/ddl', () => {
               unique: true,
             },
             {
+              columns: {id: 'ASC'},
+              name: 'boo_pkey',
+              schema: 'pub',
+              tableName: 'boo',
+              unique: true,
+            },
+            {
               columns: {name: 'ASC'},
               name: 'foo_name_key',
               schema: 'pub',
@@ -850,8 +899,22 @@ describe('change-source/tables/ddl', () => {
               unique: true,
             },
             {
+              columns: {id: 'ASC'},
+              name: 'foo_pkey',
+              schema: 'pub',
+              tableName: 'foo',
+              unique: true,
+            },
+            {
               columns: {name: 'ASC'},
               name: 'yoo_name_key',
+              schema: 'pub',
+              tableName: 'yoo',
+              unique: true,
+            },
+            {
+              columns: {id: 'ASC'},
+              name: 'yoo_pkey',
               schema: 'pub',
               tableName: 'yoo',
               unique: true,
@@ -970,7 +1033,16 @@ describe('change-source/tables/ddl', () => {
         version: 1,
         event: {tag: 'ALTER PUBLICATION'},
         schema: {
-          indexes: DDL_START.schema.indexes,
+          indexes: [
+            ...DDL_START.schema.indexes,
+            {
+              name: 'foo_pkey',
+              schema: 'zero',
+              tableName: 'foo',
+              columns: {id: 'ASC'},
+              unique: true,
+            },
+          ],
           tables: [
             ...DDL_START.schema.tables,
             {

--- a/packages/zero-cache/src/services/change-source/pg/schema/init.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.pg-test.ts
@@ -1,5 +1,5 @@
 import {LogContext} from '@rocicorp/logger';
-import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {afterEach, beforeEach, describe, test} from 'vitest';
 import {createSilentLogContext} from '../../../../../../shared/src/logging-test-utils.js';
 import {
   createVersionHistoryTable,
@@ -8,14 +8,13 @@ import {
 import {expectTablesToMatch, initDB, testDBs} from '../../../../test/db.js';
 import type {PostgresDB} from '../../../../types/pg.js';
 import {initShardSchema, updateShardSchema} from './init.js';
-import {GLOBAL_SETUP} from './shard.js';
 
 const SHARD_ID = 'shard_schema_test_id';
 
 // Update as necessary.
 const CURRENT_SCHEMA_VERSIONS = {
-  dataVersion: 2,
-  schemaVersion: 2,
+  dataVersion: 3,
+  schemaVersion: 3,
   minSafeVersion: 1,
   lock: 'v',
 } as const;
@@ -113,89 +112,6 @@ describe('change-streamer/pg/schema/init', () => {
         ['zero.schemaVersions']: [
           {minSupportedVersion: 2, maxSupportedVersion: 3},
         ],
-      },
-    },
-    {
-      name: 'migrate from version 1',
-      upstreamSetup:
-        GLOBAL_SETUP +
-        // v1 shard setup.
-        `
-      CREATE SCHEMA IF NOT EXISTS zero_${SHARD_ID};
-
-      CREATE TABLE zero_${SHARD_ID}."clients" (
-        "clientGroupID"  TEXT NOT NULL,
-        "clientID"       TEXT NOT NULL,
-        "lastMutationID" BIGINT NOT NULL,
-        "userID"         TEXT,
-        PRIMARY KEY("clientGroupID", "clientID")
-      );
-
-      CREATE PUBLICATION _zero_metadata_${SHARD_ID}
-        FOR TABLE zero."schemaVersions", TABLE zero_${SHARD_ID}."clients";
-
-      CREATE TABLE zero_${SHARD_ID}."shardConfig" (
-        "publications"  TEXT[] NOT NULL,
-
-        -- Ensure that there is only a single row in the table.
-        "lock" BOOL PRIMARY KEY DEFAULT true,
-        CONSTRAINT single_row_shard_config_0 CHECK (lock)
-      );
-      INSERT INTO zero_${SHARD_ID}."shardConfig" ("lock", "publications")
-        VALUES (true, ARRAY['_zero_metadata_${SHARD_ID}','_zero_public_${SHARD_ID}']);
-      `,
-      existingVersionHistory: {
-        ...CURRENT_SCHEMA_VERSIONS,
-        dataVersion: 1,
-        schemaVersion: 1,
-      },
-      upstreamPostState: {
-        [`zero_${SHARD_ID}.shardConfig`]: [
-          {
-            lock: true,
-            publications: [
-              '_zero_metadata_shard_schema_test_id',
-              '_zero_public_shard_schema_test_id',
-            ],
-            ddlDetection: true,
-            initialSchema: {
-              indexes: [],
-              tables: [
-                {
-                  oid: expect.any(Number),
-                  schema: 'zero',
-                  name: 'schemaVersions',
-                  primaryKey: ['lock'],
-                  publications: {
-                    ['_zero_metadata_shard_schema_test_id']: {rowFilter: null},
-                  },
-                  columns: {
-                    lock: {dataType: 'bool'},
-                    maxSupportedVersion: {dataType: 'int4'},
-                    minSupportedVersion: {dataType: 'int4'},
-                  },
-                },
-                {
-                  oid: expect.any(Number),
-                  schema: 'zero_shard_schema_test_id',
-                  name: 'clients',
-                  primaryKey: ['clientGroupID', 'clientID'],
-                  publications: {
-                    ['_zero_metadata_shard_schema_test_id']: {rowFilter: null},
-                  },
-                  columns: {
-                    clientGroupID: {dataType: 'text'},
-                    clientID: {dataType: 'text'},
-                    lastMutationID: {dataType: 'int8'},
-                    userID: {dataType: 'text'},
-                  },
-                },
-              ],
-            },
-          },
-        ],
-        [`zero_${SHARD_ID}.clients`]: [],
-        [`zero_${SHARD_ID}.versionHistory`]: [CURRENT_SCHEMA_VERSIONS],
       },
     },
   ];

--- a/packages/zero-cache/src/services/change-source/pg/schema/init.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.ts
@@ -5,10 +5,9 @@ import {
   type IncrementalMigrationMap,
   type Migration,
 } from '../../../../db/migration.js';
-import type {PostgresDB, PostgresTransaction} from '../../../../types/pg.js';
+import type {PostgresDB} from '../../../../types/pg.js';
 import {AutoResetSignal} from '../../../change-streamer/schema/tables.js';
 import type {ShardConfig} from '../shard-config.js';
-import {getPublicationInfo, type PublishedSchema} from './published.js';
 import {
   dropShard,
   setupTablesAndReplication,
@@ -55,7 +54,12 @@ async function runShardMigrations(
   };
 
   const schemaVersionMigrationMap: IncrementalMigrationMap = {
-    2: {migrateSchema: (_, tx) => migrateV1toV2(tx, shardConfig.id)},
+    3: {
+      migrateSchema: () => {
+        throw new AutoResetSignal('resetting to upgrade shard schema');
+      },
+      minSafeVersion: 3,
+    },
   };
 
   await runSchemaMigrations(
@@ -66,32 +70,4 @@ async function runShardMigrations(
     setupMigration,
     schemaVersionMigrationMap,
   );
-}
-
-// v1 required superuser / event trigger installation.
-// Therefore, to migrate from v1 to v2:
-//
-// - Add the "ddlDetection" and "initialSchema" columns to "shardConfig"
-// - Set "ddlDetection" to true
-// - Populate the "initialSchema" to the current published schema
-//
-// The last step technically may not match the "initial" schema, but
-// currently it is only used for "ddlDetection = false" setups, so
-// it does not matter.
-async function migrateV1toV2(tx: PostgresTransaction, shardID: string) {
-  const s = unescapedSchema(shardID);
-  const [{publications}] = await tx<{publications: string[]}[]>`
-    SELECT publications FROM ${tx(s)}."shardConfig"
-  `;
-  const {tables, indexes} = await getPublicationInfo(tx, publications);
-  const publishedSchema: PublishedSchema = {tables, indexes};
-
-  void tx`
-  ALTER TABLE ${tx(s)}."shardConfig" ADD "ddlDetection" BOOL`.execute();
-  void tx`
-  ALTER TABLE ${tx(s)}."shardConfig" ADD "initialSchema" JSON`.execute();
-  await tx`
-    UPDATE ${tx(s)}."shardConfig"
-      SET "ddlDetection"  = true, 
-          "initialSchema" = ${publishedSchema}`;
 }

--- a/packages/zero-cache/src/services/change-source/pg/schema/published.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/published.pg-test.ts
@@ -63,7 +63,15 @@ describe('tables/published', () => {
             publications: {['zero_all']: {rowFilter: null}},
           },
         ],
-        indexes: [],
+        indexes: [
+          {
+            name: 'clients_pkey',
+            schema: 'zero',
+            tableName: 'clients',
+            columns: {clientID: 'ASC'},
+            unique: true,
+          },
+        ],
       },
     },
     {
@@ -236,7 +244,16 @@ describe('tables/published', () => {
             publications: {['zero_data']: {rowFilter: null}},
           },
         ],
-        indexes: [],
+        indexes: [
+          {
+            schema: 'test',
+            tableName: 'users',
+            name: 'users_pkey',
+            columns: {['user_id']: 'ASC'},
+            unique: true,
+            isReplicaIdentity: false,
+          },
+        ],
       },
     },
     {
@@ -298,7 +315,16 @@ describe('tables/published', () => {
             publications: {['zero_data']: {rowFilter: '(org_id = 123)'}},
           },
         ],
-        indexes: [],
+        indexes: [
+          {
+            schema: 'test',
+            tableName: 'users',
+            name: 'users_pkey',
+            columns: {['user_id']: 'ASC'},
+            unique: true,
+            isReplicaIdentity: false,
+          },
+        ],
       },
     },
     {
@@ -371,7 +397,16 @@ describe('tables/published', () => {
             },
           },
         ],
-        indexes: [],
+        indexes: [
+          {
+            schema: 'test',
+            tableName: 'users',
+            name: 'users_pkey',
+            columns: {['user_id']: 'ASC'},
+            unique: true,
+            isReplicaIdentity: false,
+          },
+        ],
       },
     },
     {
@@ -444,7 +479,16 @@ describe('tables/published', () => {
             },
           },
         ],
-        indexes: [],
+        indexes: [
+          {
+            schema: 'test',
+            tableName: 'users',
+            name: 'users_pkey',
+            columns: {['user_id']: 'ASC'},
+            unique: true,
+            isReplicaIdentity: false,
+          },
+        ],
       },
     },
     {
@@ -535,7 +579,16 @@ describe('tables/published', () => {
             publications: {['zero_data']: {rowFilter: null}},
           },
         ],
-        indexes: [],
+        indexes: [
+          {
+            schema: 'test',
+            tableName: 'users',
+            name: 'users_pkey',
+            columns: {['user_id']: 'ASC'},
+            unique: true,
+            isReplicaIdentity: false,
+          },
+        ],
       },
     },
     {
@@ -608,7 +661,16 @@ describe('tables/published', () => {
             publications: {['zero_keys']: {rowFilter: null}},
           },
         ],
-        indexes: [],
+        indexes: [
+          {
+            schema: 'test',
+            tableName: 'issues',
+            name: 'issues_pkey',
+            columns: {['issue_id']: 'ASC'},
+            unique: true,
+            isReplicaIdentity: false,
+          },
+        ],
       },
     },
     {
@@ -755,7 +817,36 @@ describe('tables/published', () => {
             publications: {['_zero_meta']: {rowFilter: null}},
           },
         ],
-        indexes: [],
+        indexes: [
+          {
+            schema: 'test',
+            tableName: 'issues',
+            name: 'issues_pkey',
+            columns: {
+              ['component_id']: 'ASC',
+              ['issue_id']: 'ASC',
+              ['org_id']: 'ASC',
+            },
+            unique: true,
+            isReplicaIdentity: false,
+          },
+          {
+            schema: 'test',
+            tableName: 'users',
+            name: 'users_pkey',
+            columns: {['user_id']: 'ASC'},
+            unique: true,
+            isReplicaIdentity: false,
+          },
+          {
+            schema: 'zero',
+            tableName: 'clients',
+            name: 'clients_pkey',
+            columns: {clientID: 'ASC'},
+            unique: true,
+            isReplicaIdentity: false,
+          },
+        ],
       },
     },
     {
@@ -837,6 +928,7 @@ describe('tables/published', () => {
             name: 'issues_component_id',
             columns: {['component_id']: 'ASC'},
             unique: false,
+            isReplicaIdentity: false,
           },
           {
             schema: 'test',
@@ -844,6 +936,15 @@ describe('tables/published', () => {
             name: 'issues_org_id',
             columns: {['org_id']: 'ASC'},
             unique: false,
+            isReplicaIdentity: false,
+          },
+          {
+            schema: 'test',
+            tableName: 'issues',
+            name: 'issues_pkey',
+            columns: {['issue_id']: 'ASC'},
+            unique: true,
+            isReplicaIdentity: false,
           },
         ],
       },
@@ -854,10 +955,9 @@ describe('tables/published', () => {
       CREATE SCHEMA test;
       CREATE TABLE test.issues (
         issue_id INTEGER PRIMARY KEY,
-        org_id INTEGER,
+        org_id INTEGER UNIQUE,
         component_id INTEGER
       );
-      CREATE UNIQUE INDEX issues_org_id ON test.issues (org_id);
       CREATE UNIQUE INDEX issues_component_id ON test.issues (component_id);
       CREATE PUBLICATION zero_data FOR TABLE test.issues;
       `,
@@ -916,13 +1016,99 @@ describe('tables/published', () => {
             name: 'issues_component_id',
             columns: {['component_id']: 'ASC'},
             unique: true,
+            isReplicaIdentity: false,
           },
           {
             schema: 'test',
             tableName: 'issues',
-            name: 'issues_org_id',
+            name: 'issues_org_id_key',
             columns: {['org_id']: 'ASC'},
             unique: true,
+            isReplicaIdentity: false,
+          },
+          {
+            schema: 'test',
+            tableName: 'issues',
+            name: 'issues_pkey',
+            columns: {['issue_id']: 'ASC'},
+            unique: true,
+            isReplicaIdentity: false,
+          },
+        ],
+      },
+    },
+    {
+      name: 'replica identity index',
+      setupQuery: `
+      CREATE SCHEMA test;
+      CREATE TABLE test.issues (
+        issue_id INTEGER NOT NULL,
+        org_id INTEGER NOT NULL,
+        component_id INTEGER
+      );
+      CREATE UNIQUE INDEX issues_key_idx ON test.issues (org_id, issue_id);
+      ALTER TABLE test.issues REPLICA IDENTITY USING INDEX issues_key_idx;
+      CREATE PUBLICATION zero_data FOR TABLE test.issues;
+      `,
+      expectedResult: {
+        publications: [
+          {
+            pubname: 'zero_data',
+            pubinsert: true,
+            pubupdate: true,
+            pubdelete: true,
+            pubtruncate: true,
+          },
+        ],
+        tables: [
+          {
+            oid: expect.any(Number),
+            schema: 'test',
+            name: 'issues',
+            columns: {
+              ['issue_id']: {
+                pos: 1,
+                dataType: 'int4',
+                typeOID: 23,
+                pgTypeClass: PostgresTypeClass.Base,
+                characterMaximumLength: null,
+                notNull: true,
+                dflt: null,
+              },
+              ['org_id']: {
+                pos: 2,
+                dataType: 'int4',
+                typeOID: 23,
+                pgTypeClass: PostgresTypeClass.Base,
+                characterMaximumLength: null,
+                notNull: true,
+                dflt: null,
+              },
+              ['component_id']: {
+                pos: 3,
+                dataType: 'int4',
+                typeOID: 23,
+                pgTypeClass: PostgresTypeClass.Base,
+                characterMaximumLength: null,
+                notNull: false,
+                dflt: null,
+              },
+            },
+            primaryKey: [],
+            publications: {['zero_data']: {rowFilter: null}},
+          },
+        ],
+        indexes: [
+          {
+            schema: 'test',
+            tableName: 'issues',
+            name: 'issues_key_idx',
+            columns: {
+              ['org_id']: 'ASC',
+              ['issue_id']: 'ASC',
+            },
+            unique: true,
+            isReplicaIdentity: true,
           },
         ],
       },
@@ -1009,6 +1195,7 @@ describe('tables/published', () => {
               b: 'DESC',
             },
             unique: false,
+            isReplicaIdentity: false,
           },
           {
             schema: 'test',
@@ -1019,6 +1206,88 @@ describe('tables/published', () => {
               a: 'DESC',
             },
             unique: false,
+            isReplicaIdentity: false,
+          },
+          {
+            schema: 'test',
+            tableName: 'foo',
+            name: 'foo_pkey',
+            columns: {id: 'ASC'},
+            unique: true,
+            isReplicaIdentity: false,
+          },
+        ],
+      },
+    },
+    {
+      name: 'ignores irrelevant indexes',
+      setupQuery: `
+      CREATE SCHEMA test;
+      CREATE TABLE test.issues (
+        issue_id INTEGER PRIMARY KEY,
+        org_id INTEGER CHECK (org_id > 0),
+        component_id INTEGER
+      );
+      CREATE INDEX idx_with_expression ON test.issues (org_id, (component_id + 1));
+      CREATE INDEX partial_idx ON test.issues (component_id) WHERE org_id > 1000;
+      CREATE PUBLICATION zero_data FOR TABLE test.issues;
+      `,
+      expectedResult: {
+        publications: [
+          {
+            pubname: 'zero_data',
+            pubinsert: true,
+            pubupdate: true,
+            pubdelete: true,
+            pubtruncate: true,
+          },
+        ],
+        tables: [
+          {
+            oid: expect.any(Number),
+            schema: 'test',
+            name: 'issues',
+            columns: {
+              ['issue_id']: {
+                pos: 1,
+                dataType: 'int4',
+                typeOID: 23,
+                pgTypeClass: PostgresTypeClass.Base,
+                characterMaximumLength: null,
+                notNull: true,
+                dflt: null,
+              },
+              ['org_id']: {
+                pos: 2,
+                dataType: 'int4',
+                typeOID: 23,
+                pgTypeClass: PostgresTypeClass.Base,
+                characterMaximumLength: null,
+                notNull: false,
+                dflt: null,
+              },
+              ['component_id']: {
+                pos: 3,
+                dataType: 'int4',
+                typeOID: 23,
+                pgTypeClass: PostgresTypeClass.Base,
+                characterMaximumLength: null,
+                notNull: false,
+                dflt: null,
+              },
+            },
+            primaryKey: ['issue_id'],
+            publications: {['zero_data']: {rowFilter: null}},
+          },
+        ],
+        indexes: [
+          {
+            schema: 'test',
+            tableName: 'issues',
+            name: 'issues_pkey',
+            columns: {['issue_id']: 'ASC'},
+            unique: true,
+            isReplicaIdentity: false,
           },
         ],
       },
@@ -1097,6 +1366,7 @@ describe('tables/published', () => {
               bz: 'ASC',
             },
             unique: false,
+            isReplicaIdentity: false,
           },
           {
             schema: 'test',
@@ -1107,6 +1377,15 @@ describe('tables/published', () => {
               az: 'DESC',
             },
             unique: false,
+            isReplicaIdentity: false,
+          },
+          {
+            schema: 'test',
+            tableName: 'foo',
+            name: 'foo_pkey',
+            columns: {id: 'ASC'},
+            unique: true,
+            isReplicaIdentity: false,
           },
         ],
       },

--- a/packages/zero-cache/src/services/change-source/pg/schema/published.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/published.ts
@@ -2,7 +2,7 @@ import {literal} from 'pg-format';
 import type postgres from 'postgres';
 import {equals} from '../../../../../../shared/src/set-utils.js';
 import * as v from '../../../../../../shared/src/valita.js';
-import {indexSpec, publishedTableSpec} from '../../../../db/specs.js';
+import {publishedIndexSpec, publishedTableSpec} from '../../../../db/specs.js';
 
 export function publishedTableQuery(publications: string[]) {
   return `
@@ -95,7 +95,8 @@ export function indexDefinitionsQuery(publications: string[]) {
       pg_indexes.indexname as "name",
       index_column.name as "col",
       CASE WHEN pg_index.indoption[index_column.pos-1] & 1 = 1 THEN 'DESC' ELSE 'ASC' END as "dir",
-      pg_index.indisunique as "unique"
+      pg_index.indisunique as "unique",
+      pg_index.indisreplident as "isReplicaIdentity"
     FROM pg_indexes
     JOIN pg_namespace ON pg_indexes.schemaname = pg_namespace.nspname
     JOIN pg_class pc ON
@@ -112,8 +113,9 @@ export function indexDefinitionsQuery(publications: string[]) {
     ) AS index_column ON true
     LEFT JOIN pg_constraint ON pg_constraint.conindid = pc.oid
     WHERE pb.pubname IN (${literal(publications)})
-      AND pg_constraint.contype is distinct from 'p'
-      AND pg_constraint.contype is distinct from 'f'
+      AND pg_index.indexprs IS NULL
+      AND pg_index.indpred IS NULL
+      AND (pg_constraint.contype IS NULL OR pg_constraint.contype IN ('p', 'u'))
     ORDER BY
       pg_indexes.schemaname,
       pg_indexes.tablename,
@@ -125,16 +127,17 @@ export function indexDefinitionsQuery(publications: string[]) {
       'tableName', "tableName",
       'name', "name",
       'unique', "unique",
+      'isReplicaIdentity', "isReplicaIdentity",
       'columns', json_object_agg(DISTINCT "col", "dir")
     ) AS index FROM indexed_columns 
-      GROUP BY "schema", "tableName", "name", "unique")
+      GROUP BY "schema", "tableName", "name", "unique", "isReplicaIdentity")
 
     SELECT COALESCE(json_agg("index"), '[]'::json) as "indexes" FROM indexes
   `;
 }
 
 const publishedTablesSchema = v.object({tables: v.array(publishedTableSpec)});
-const publishedIndexesSchema = v.object({indexes: v.array(indexSpec)});
+const publishedIndexesSchema = v.object({indexes: v.array(publishedIndexSpec)});
 
 export const publishedSchema = publishedTablesSchema.extend(
   publishedIndexesSchema.shape,

--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.pg-test.ts
@@ -260,12 +260,6 @@ describe('change-source/pg', () => {
 
   const invalidUpstreamCases: InvalidUpstreamCase[] = [
     {
-      error: 'does not have a PRIMARY KEY',
-      setupUpstreamQuery: `
-        CREATE TABLE issues("issueID" INTEGER, "orgID" INTEGER);
-      `,
-    },
-    {
       error: 'uses reserved column name "_0_version"',
       setupUpstreamQuery: `
         CREATE TABLE issues(

--- a/packages/zero-cache/src/services/change-source/pg/schema/validation.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/validation.pg-test.ts
@@ -24,12 +24,6 @@ describe('change-source/pg', () => {
 
   const invalidUpstreamCases: InvalidTableCase[] = [
     {
-      error: 'does not have a PRIMARY KEY',
-      setupUpstreamQuery: `
-        CREATE TABLE issues("issueID" INTEGER, "orgID" INTEGER);
-      `,
-    },
-    {
       error: 'uses reserved column name "_0_version"',
       setupUpstreamQuery: `
         CREATE TABLE issues(

--- a/packages/zero-cache/src/services/change-source/pg/schema/validation.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/validation.ts
@@ -22,9 +22,12 @@ export function validate(lc: LogContext, shardID: string, table: TableSpec) {
       `Table "${table.name}" uses reserved column name "${ZERO_VERSION_COLUMN_NAME}"`,
     );
   }
-  if (table.primaryKey.length === 0) {
-    throw new UnsupportedTableSchemaError(
-      `Table "${table.name}" does not have a PRIMARY KEY`,
+  if (!table.primaryKey?.length) {
+    lc.warn?.(
+      `\n\n\n` +
+        `Table "${table.name}" needs a primary key in order to be synced to clients. ` +
+        `Add one with 'ALTER TABLE "${table.name}" ADD PRIMARY KEY (...)'.` +
+        `\n\n\n`,
     );
   }
   if (!ALLOWED_IDENTIFIER_CHARS.test(table.name)) {

--- a/packages/zero-cache/src/services/change-source/pg/sync-schema.ts
+++ b/packages/zero-cache/src/services/change-source/pg/sync-schema.ts
@@ -29,6 +29,7 @@ export async function initSyncSchema(
       migrateSchema: () => {
         throw new AutoResetSignal('resetting replica at obsolete v1');
       },
+      minSafeVersion: 2,
     },
   };
 

--- a/packages/zero-cache/src/services/change-source/protocol/version.test.ts
+++ b/packages/zero-cache/src/services/change-source/protocol/version.test.ts
@@ -38,9 +38,9 @@ test('protocol versions', () => {
   // Then update the version number of the `CHANGE_SOURCE_PATH`
   // in current and export it appropriately as the new version
   // in `mod.ts`.
-  t(current, '2z9neqzcgdxo7', '/changes/v0/stream');
+  t(current, '1kfqmopbfu1mq', '/changes/v0/stream');
   // During initial development, we use v0 as a non-stable
   // version (i.e. breaking change are allowed). Once the
   // protocol graduates to v1, versions must be stable.
-  t(v0, '2z9neqzcgdxo7', '/changes/v0/stream');
+  t(v0, '1kfqmopbfu1mq', '/changes/v0/stream');
 });

--- a/packages/zero-cache/src/services/replicator/incremental-sync.pg-test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.pg-test.ts
@@ -721,7 +721,6 @@ describe('replicator/incremental-sync', () => {
               pos: 5,
             },
           },
-          primaryKey: ['id'],
         },
       ],
       indexSpecs: [],
@@ -729,7 +728,7 @@ describe('replicator/incremental-sync', () => {
     {
       name: 'rename table',
       setup: `
-        CREATE TABLE foo(id INT8 PRIMARY KEY, _0_version TEXT);
+        CREATE TABLE foo(id INT8, _0_version TEXT);
         INSERT INTO foo(id, _0_version) VALUES (1, '00');
         INSERT INTO foo(id, _0_version) VALUES (2, '00');
         INSERT INTO foo(id, _0_version) VALUES (3, '00');
@@ -787,7 +786,6 @@ describe('replicator/incremental-sync', () => {
               pos: 2,
             },
           },
-          primaryKey: ['id'],
         },
       ],
       indexSpecs: [],
@@ -795,7 +793,7 @@ describe('replicator/incremental-sync', () => {
     {
       name: 'add column',
       setup: `
-        CREATE TABLE foo(id INT8 PRIMARY KEY, _0_version TEXT);
+        CREATE TABLE foo(id INT8, _0_version TEXT);
         INSERT INTO foo(id, _0_version) VALUES (1, '00');
         INSERT INTO foo(id, _0_version) VALUES (2, '00');
         INSERT INTO foo(id, _0_version) VALUES (3, '00');
@@ -922,7 +920,6 @@ describe('replicator/incremental-sync', () => {
               pos: 5,
             },
           },
-          primaryKey: ['id'],
         },
       ],
       indexSpecs: [],
@@ -930,7 +927,7 @@ describe('replicator/incremental-sync', () => {
     {
       name: 'drop column',
       setup: `
-        CREATE TABLE foo(id INT8 PRIMARY KEY, dropMe TEXT, _0_version TEXT);
+        CREATE TABLE foo(id INT8, dropMe TEXT, _0_version TEXT);
         INSERT INTO foo(id, dropMe, _0_version) VALUES (1, 'bye', '00');
         INSERT INTO foo(id, dropMe, _0_version) VALUES (2, 'bye', '00');
         INSERT INTO foo(id, dropMe, _0_version) VALUES (3, 'bye', '00');
@@ -983,7 +980,6 @@ describe('replicator/incremental-sync', () => {
               pos: 2,
             },
           },
-          primaryKey: ['id'],
         },
       ],
       indexSpecs: [],
@@ -991,7 +987,7 @@ describe('replicator/incremental-sync', () => {
     {
       name: 'rename column',
       setup: `
-        CREATE TABLE foo(id INT8 PRIMARY KEY, renameMe TEXT, _0_version TEXT);
+        CREATE TABLE foo(id INT8, renameMe TEXT, _0_version TEXT);
         INSERT INTO foo(id, renameMe, _0_version) VALUES (1, 'hel', '00');
         INSERT INTO foo(id, renameMe, _0_version) VALUES (2, 'low', '00');
         INSERT INTO foo(id, renameMe, _0_version) VALUES (3, 'orl', '00');
@@ -1058,7 +1054,6 @@ describe('replicator/incremental-sync', () => {
               pos: 3,
             },
           },
-          primaryKey: ['id'],
         },
       ],
       indexSpecs: [],
@@ -1066,7 +1061,7 @@ describe('replicator/incremental-sync', () => {
     {
       name: 'rename indexed column',
       setup: `
-        CREATE TABLE foo(id INT8 PRIMARY KEY, renameMe TEXT, _0_version TEXT);
+        CREATE TABLE foo(id INT8, renameMe TEXT, _0_version TEXT);
         CREATE UNIQUE INDEX foo_rename_me ON foo (renameMe);
         INSERT INTO foo(id, renameMe, _0_version) VALUES (1, 'hel', '00');
         INSERT INTO foo(id, renameMe, _0_version) VALUES (2, 'low', '00');
@@ -1134,7 +1129,6 @@ describe('replicator/incremental-sync', () => {
               pos: 3,
             },
           },
-          primaryKey: ['id'],
         },
       ],
       indexSpecs: [
@@ -1149,7 +1143,7 @@ describe('replicator/incremental-sync', () => {
     {
       name: 'retype column',
       setup: `
-        CREATE TABLE foo(id INT8 PRIMARY KEY, num TEXT, _0_version TEXT);
+        CREATE TABLE foo(id INT8, num TEXT, _0_version TEXT);
         INSERT INTO foo(id, num, _0_version) VALUES (1, '3', '00');
         INSERT INTO foo(id, num, _0_version) VALUES (2, '2', '00');
         INSERT INTO foo(id, num, _0_version) VALUES (3, '3', '00');
@@ -1216,7 +1210,6 @@ describe('replicator/incremental-sync', () => {
               pos: 2,
             },
           },
-          primaryKey: ['id'],
         },
       ],
       indexSpecs: [],
@@ -1224,7 +1217,7 @@ describe('replicator/incremental-sync', () => {
     {
       name: 'retype column with indexes',
       setup: `
-        CREATE TABLE foo(id INT8 PRIMARY KEY, num TEXT, _0_version TEXT);
+        CREATE TABLE foo(id INT8, num TEXT, _0_version TEXT);
         CREATE UNIQUE INDEX foo_num ON foo (num);
         CREATE UNIQUE INDEX foo_id_num ON foo (id, num);
         INSERT INTO foo(id, num, _0_version) VALUES (1, '3', '00');
@@ -1293,7 +1286,6 @@ describe('replicator/incremental-sync', () => {
               pos: 2,
             },
           },
-          primaryKey: ['id'],
         },
       ],
       indexSpecs: [
@@ -1314,7 +1306,7 @@ describe('replicator/incremental-sync', () => {
     {
       name: 'rename and retype column',
       setup: `
-        CREATE TABLE foo(id INT8 PRIMARY KEY, numburr TEXT, _0_version TEXT);
+        CREATE TABLE foo(id INT8, numburr TEXT, _0_version TEXT);
         INSERT INTO foo(id, numburr, _0_version) VALUES (1, '3', '00');
         INSERT INTO foo(id, numburr, _0_version) VALUES (2, '2', '00');
         INSERT INTO foo(id, numburr, _0_version) VALUES (3, '3', '00');
@@ -1381,7 +1373,6 @@ describe('replicator/incremental-sync', () => {
               pos: 2,
             },
           },
-          primaryKey: ['id'],
         },
       ],
       indexSpecs: [],
@@ -1389,7 +1380,7 @@ describe('replicator/incremental-sync', () => {
     {
       name: 'drop table',
       setup: `
-        CREATE TABLE foo(id INT8 PRIMARY KEY, _0_version TEXT);
+        CREATE TABLE foo(id INT8, _0_version TEXT);
         INSERT INTO foo(id, _0_version) VALUES (1, '00');
         INSERT INTO foo(id, _0_version) VALUES (2, '00');
         INSERT INTO foo(id, _0_version) VALUES (3, '00');
@@ -1416,7 +1407,7 @@ describe('replicator/incremental-sync', () => {
     {
       name: 'create index',
       setup: `
-        CREATE TABLE foo(id INT8 PRIMARY KEY, handle TEXT, _0_version TEXT);
+        CREATE TABLE foo(id INT8, handle TEXT, _0_version TEXT);
       `,
       downstream: [
         ['begin', fooBarBaz.begin(), {commitWatermark: '0e'}],
@@ -1435,7 +1426,14 @@ describe('replicator/incremental-sync', () => {
         ['commit', fooBarBaz.commit(), {watermark: '0e'}],
       ],
       data: {
-        ['_zero.changeLog']: [],
+        ['_zero.changeLog']: [
+          {
+            stateVersion: '0e',
+            table: 'foo',
+            op: 'r',
+            rowKey: null,
+          },
+        ],
       },
       indexSpecs: [
         {
@@ -1449,7 +1447,7 @@ describe('replicator/incremental-sync', () => {
     {
       name: 'drop index',
       setup: `
-        CREATE TABLE foo(id INT8 PRIMARY KEY, handle TEXT, _0_version TEXT);
+        CREATE TABLE foo(id INT8, handle TEXT, _0_version TEXT);
         CREATE INDEX keep_me ON foo (id DESC, handle ASC);
         CREATE INDEX drop_me ON foo (handle DESC);
       `,
@@ -1565,7 +1563,6 @@ describe('replicator/incremental-sync', () => {
               pos: 2,
             },
           },
-          primaryKey: ['column'],
         },
       ],
     },

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -43,13 +43,14 @@ describe('view-syncer/pipeline-driver', () => {
     initChangeLog(db);
     db.exec(`
       CREATE TABLE "zero.schemaVersions" (
-        "lock"                INTEGER PRIMARY KEY,
-        "minSupportedVersion" INTEGER,
-        "maxSupportedVersion" INTEGER,
+        -- Note: Using "INT" to avoid the special semantics of "INTEGER PRIMARY KEY" in SQLite.
+        "lock"                INT PRIMARY KEY,
+        "minSupportedVersion" INT,
+        "maxSupportedVersion" INT,
         _0_version            TEXT NOT NULL
       );
       INSERT INTO "zero.schemaVersions" ("lock", "minSupportedVersion", "maxSupportedVersion", _0_version)    
-        VALUES (1, 1, 1, '123');  
+        VALUES (1, 1, 1, '123');
       CREATE TABLE issues (
         id TEXT PRIMARY KEY,
         closed BOOL,
@@ -65,9 +66,11 @@ describe('view-syncer/pipeline-driver', () => {
       CREATE TABLE "issueLabels" (
         issueID TEXT,
         labelID TEXT,
+        legacyID TEXT NOT NULL,
         _0_version TEXT NOT NULL,
         PRIMARY KEY (issueID, labelID)
       );
+      CREATE UNIQUE INDEX issues_a ON issueLabels (legacyID);  -- Test that this doesn't trip up IVM.
       CREATE TABLE "labels" (
         id TEXT PRIMARY KEY,
         name TEXT,
@@ -82,7 +85,7 @@ describe('view-syncer/pipeline-driver', () => {
       INSERT INTO COMMENTS (id, issueID, upvotes, _0_version) VALUES ('21', '2', 10000, '123');
       INSERT INTO COMMENTS (id, issueID, upvotes, _0_version) VALUES ('22', '2', 20000, '123');
 
-      INSERT INTO "issueLabels" (issueID, labelID, _0_version) VALUES ('1', '1', '123');
+      INSERT INTO "issueLabels" (issueID, labelID, legacyID, _0_version) VALUES ('1', '1', '1-1', '123');
       INSERT INTO "labels" (id, name, _0_version) VALUES ('1', 'bug', '123');
       `);
     replicator = fakeReplicator(lc, db);
@@ -692,7 +695,11 @@ describe('view-syncer/pipeline-driver', () => {
 
     replicator.processTransaction(
       '134',
-      messages.delete('issueLabels', {issueID: '1', labelID: '1'}),
+      messages.delete('issueLabels', {
+        issueID: '1',
+        labelID: '1',
+        legacyID: '1-1',
+      }),
     );
 
     expect([...pipelines.advance().changes]).toMatchInlineSnapshot(`
@@ -777,6 +784,7 @@ describe('view-syncer/pipeline-driver', () => {
             "_0_version": "123",
             "issueID": "1",
             "labelID": "1",
+            "legacyID": "1-1",
           },
           "rowKey": {
             "issueID": "1",
@@ -896,7 +904,11 @@ describe('view-syncer/pipeline-driver', () => {
 
     replicator.processTransaction(
       '134',
-      messages.insert('issueLabels', {issueID: '2', labelID: '1'}),
+      messages.insert('issueLabels', {
+        issueID: '2',
+        labelID: '1',
+        legacyID: '2-1',
+      }),
     );
 
     expect([...pipelines.advance().changes]).toMatchInlineSnapshot(`
@@ -920,6 +932,7 @@ describe('view-syncer/pipeline-driver', () => {
             "_0_version": "134",
             "issueID": "2",
             "labelID": "1",
+            "legacyID": "2-1",
           },
           "rowKey": {
             "issueID": "2",
@@ -947,6 +960,7 @@ describe('view-syncer/pipeline-driver', () => {
             "_0_version": "134",
             "issueID": "2",
             "labelID": "1",
+            "legacyID": "2-1",
           },
           "rowKey": {
             "issueID": "2",
@@ -973,7 +987,11 @@ describe('view-syncer/pipeline-driver', () => {
 
     replicator.processTransaction(
       '135',
-      messages.delete('issueLabels', {issueID: '2', labelID: '1'}),
+      messages.delete('issueLabels', {
+        issueID: '2',
+        labelID: '1',
+        legacyID: '2-1',
+      }),
     );
 
     expect([...pipelines.advance().changes]).toMatchInlineSnapshot(`

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -14,12 +14,8 @@ import {
   runtimeDebugStats,
 } from '../../../../zqlite/src/runtime-debug.js';
 import {TableSource} from '../../../../zqlite/src/table-source.js';
-import {listTables} from '../../db/lite-tables.js';
-import type {LiteAndZqlSpec, LiteTableSpec} from '../../db/specs.js';
-import {
-  dataTypeToZqlValueType,
-  mapLiteDataTypeToZqlSchemaValue,
-} from '../../types/lite.js';
+import {computeZqlSpecs} from '../../db/lite-tables.js';
+import type {LiteAndZqlSpec} from '../../db/specs.js';
 import type {RowKey} from '../../types/row-key.js';
 import type {SchemaVersions} from '../../types/schema-versions.js';
 import {getSubscriptionState} from '../replicator/schema/replication-state.js';
@@ -51,29 +47,6 @@ export type RowEdit = {
 };
 
 export type RowChange = RowAdd | RowRemove | RowEdit;
-
-/** Normalized TableSpec filters out columns with unsupported data types. */
-export type NormalizedTableSpec = LiteTableSpec;
-
-export function normalize(tableSpec: LiteTableSpec): NormalizedTableSpec {
-  const {primaryKey, columns} = tableSpec;
-  const normalized = {
-    ...tableSpec,
-
-    // Only include columns for which the mapped ZQL Value is defined.
-    columns: Object.fromEntries(
-      Object.entries(columns).filter(([_, spec]) =>
-        dataTypeToZqlValueType(spec.dataType),
-      ),
-    ),
-
-    // Primary keys are normalized here so that downstream
-    // normalization does not need to create new objects.
-    // See row-key.ts: normalizedKeyOrder()
-    primaryKey: [...primaryKey].sort(),
-  };
-  return normalized;
-}
 
 type Pipeline = {
   readonly input: Input;
@@ -117,8 +90,7 @@ export class PipelineDriver {
     assert(!this.#snapshotter.initialized(), 'Already initialized');
 
     const {db} = this.#snapshotter.init().current();
-    this.#tableSpecs = new Map();
-    setSpecs(listTables(db.db), this.#tableSpecs);
+    this.#tableSpecs = computeZqlSpecs(this.#lc, db.db);
     const {replicaVersion} = getSubscriptionState(db);
     this.#replicaVersion = replicaVersion;
   }
@@ -179,7 +151,7 @@ export class PipelineDriver {
     tableSpecs.clear();
 
     const {db} = this.#snapshotter.current();
-    setSpecs(listTables(db.db), tableSpecs);
+    computeZqlSpecs(this.#lc, db.db, tableSpecs);
     const {replicaVersion} = getSubscriptionState(db);
     this.#replicaVersion = replicaVersion;
   }
@@ -354,11 +326,12 @@ export class PipelineDriver {
       throw new Error(
         `table '${tableName}' is not one of: ${[...this.#tableSpecs.keys()]
           .filter(t => !t.includes('.') && !t.startsWith('_litestream_'))
-          .sort()}`,
+          .sort()}. ` +
+          `Check the spelling and ensure that the table has a primary key.`,
       );
     }
     const {primaryKey} = tableSpec.tableSpec;
-    assert(primaryKey.length);
+    assert(primaryKey?.length);
 
     const {db} = this.#snapshotter.current();
     source = new TableSource(
@@ -498,24 +471,6 @@ class Streamer {
       }
     }
   }
-}
-
-export function setSpecs(
-  specs: LiteTableSpec[],
-  tableSpecs: Map<string, LiteAndZqlSpec>,
-) {
-  specs.forEach(spec => {
-    const tableSpec = normalize(spec);
-    tableSpecs.set(spec.name, {
-      tableSpec,
-      zqlSpec: Object.fromEntries(
-        Object.entries(tableSpec.columns).map(([name, {dataType}]) => [
-          name,
-          mapLiteDataTypeToZqlSchemaValue(dataType),
-        ]),
-      ),
-    });
-  });
 }
 
 function* toAdds(nodes: Iterable<Node>): Iterable<Change> {

--- a/packages/zero-cache/src/services/view-syncer/snapshotter.ts
+++ b/packages/zero-cache/src/services/view-syncer/snapshotter.ts
@@ -4,7 +4,7 @@ import {must} from '../../../../shared/src/must.js';
 import * as v from '../../../../shared/src/valita.js';
 import {Database} from '../../../../zqlite/src/db.js';
 import {fromSQLiteTypes} from '../../../../zqlite/src/table-source.js';
-import type {LiteAndZqlSpec, LiteTableSpec} from '../../db/specs.js';
+import type {LiteAndZqlSpec, LiteTableSpecWithKeys} from '../../db/specs.js';
 import {StatementRunner} from '../../db/statements.js';
 import {type JSONValue} from '../../types/bigint-json.js';
 import {
@@ -294,7 +294,7 @@ class Snapshot {
     };
   }
 
-  getRow(table: LiteTableSpec, rowKey: JSONValue) {
+  getRow(table: LiteTableSpecWithKeys, rowKey: JSONValue) {
     const key = normalizedKeyOrder(rowKey as RowKey);
     const conds = Object.keys(key).map(c => `${id(c)}=?`);
     const cols = Object.keys(table.columns);
@@ -312,7 +312,7 @@ class Snapshot {
     }
   }
 
-  getRows(table: LiteTableSpec) {
+  getRows(table: LiteTableSpecWithKeys) {
     const cols = Object.keys(table.columns);
     const cached = this.db.statementCache.get(
       `SELECT ${cols.map(c => id(c)).join(',')} FROM ${id(table.name)}`,

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -304,9 +304,9 @@ async function setup(permissions: PermissionsConfig = {}) {
     PRIMARY KEY ("clientGroupID", "clientID")
   );
   CREATE TABLE "zero.schemaVersions" (
-    "lock"                INTEGER PRIMARY KEY,
-    "minSupportedVersion" INTEGER,
-    "maxSupportedVersion" INTEGER,
+    "lock"                INT PRIMARY KEY,
+    "minSupportedVersion" INT,
+    "maxSupportedVersion" INT,
     _0_version            TEXT NOT NULL
   );
   CREATE TABLE issues (

--- a/packages/zero-cache/src/types/row-key.test.ts
+++ b/packages/zero-cache/src/types/row-key.test.ts
@@ -121,5 +121,7 @@ describe('types/row-key', () => {
     for (const str of notSorted) {
       expect(Object.keys(normalizedKeyOrder(str))).toEqual(['a', 'b', 'c']);
     }
+
+    expect(() => normalizedKeyOrder({})).toThrowError('empty row key');
   });
 });

--- a/packages/zero-cache/src/types/row-key.ts
+++ b/packages/zero-cache/src/types/row-key.ts
@@ -1,3 +1,4 @@
+import {assert} from '../../../shared/src/asserts.js';
 import {h128} from '../../../shared/src/hash.js';
 import {stringify, type JSONValue} from './bigint-json.js';
 
@@ -23,14 +24,19 @@ export function normalizedKeyOrder<V>(
   rowKey: Readonly<Record<string, V>>,
 ): Readonly<Record<string, V>> {
   let last = '';
+  let empty = true;
   for (const col in rowKey) {
+    empty = false;
     if (last > col) {
-      return Object.fromEntries(
-        Object.entries(rowKey).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)),
+      const entries = Object.entries(rowKey).sort(([a], [b]) =>
+        a < b ? -1 : a > b ? 1 : 0,
       );
+      assert(entries.length > 0, 'empty row key');
+      return Object.fromEntries(entries);
     }
     last = col;
   }
+  assert(!empty, 'empty row key');
   // This case iterates over columns and avoids object allocations, which is
   // expected to be the common case (e.g. single column key).
   return rowKey;

--- a/prod/templates/sandbox/template.yml
+++ b/prod/templates/sandbox/template.yml
@@ -196,7 +196,7 @@ Resources:
             - Name: ZERO_REPLICA_FILE
               Value: /data/db/sync-replica.db
             - Name: ZERO_LITESTREAM_BACKUP_URL
-              Value: !Sub "s3://${ApplicationBucket}/0113"
+              Value: !Sub "s3://${ApplicationBucket}/20250117"
             - Name: ZERO_LOG_LEVEL
               Value: debug
             - Name: ZERO_UPSTREAM_MAX_CONNS
@@ -357,7 +357,7 @@ Resources:
             - Name: ZERO_NUM_SYNC_WORKERS
               Value: "0"
             - Name: ZERO_LITESTREAM_BACKUP_URL
-              Value: !Sub "s3://${ApplicationBucket}/0113"
+              Value: !Sub "s3://${ApplicationBucket}/20250117"
             - Name: ZERO_LOG_FORMAT
               Value: json
             - Name: ZERO_REPLICA_FILE

--- a/prod/templates/template.yml
+++ b/prod/templates/template.yml
@@ -212,7 +212,7 @@ Resources:
             - Name: ZERO_REPLICA_FILE
               Value: /data/db/sync-replica.db
             - Name: ZERO_LITESTREAM_BACKUP_URL
-              Value: !Sub "s3://${ApplicationBucket}/0113"
+              Value: !Sub "s3://${ApplicationBucket}/20250117"
             - Name: ZERO_LOG_LEVEL
               Value: debug
             - Name: ZERO_UPSTREAM_MAX_CONNS
@@ -377,7 +377,7 @@ Resources:
             - Name: ZERO_NUM_SYNC_WORKERS
               Value: "0"
             - Name: ZERO_LITESTREAM_BACKUP_URL
-              Value: !Sub "s3://${ApplicationBucket}/0113"
+              Value: !Sub "s3://${ApplicationBucket}/20250117"
             - Name: ZERO_LOG_FORMAT
               Value: json
             - Name: ZERO_REPLICA_FILE


### PR DESCRIPTION
### Bugs fixed:

* Correctly ignore [indexes with expression or partial indexes](https://bugs.rocicorp.dev/issue/3402)
* [Handle primary key changes](https://bugs.rocicorp.dev/issue/3186)

With setup for adding [support for Prisma join tables](https://bugs.rocicorp.dev/issue/3198) (i.e. not implemented yet but this is a step towards it)

### Features

* Support changes to the PRIMARY KEY
* Partial support for tables without PRIMARY KEYs (i.e. removing a roadblock when setting up a project)

### DX

Initial sync / replication no longer fails for tables without a PRIMARY KEY. Instead, a warning is displayed:

<img width="989" alt="Screenshot 2025-01-17 at 12 39 14" src="https://github.com/user-attachments/assets/946a9dce-061d-498f-900f-e21e8d352eac" />

but the data is otherwise replicated to the replica.

However, this data is not synced to the clients, because primary keys are necessary for downstream logic (e.g. IVM, Replicache). 

> Note: From Postgres' perspective, primary keys are also necessary to replicate `UPDATE` and `DELETE` commands, and while the developer is publishing a table with no primary key, Postgres will refuse to execute those commands:

<img width="745" alt="Screenshot 2025-01-17 at 16 27 39" src="https://github.com/user-attachments/assets/f2c5cc03-c29e-4f53-8819-fc1b7276944a" />

Once the user has added a primary key to the table, the table becomes visible to zql and downstream clients. 

Resetting of the replica is not necessary. It is handled just as other schema changes are handled.

### Implementation

* PRIMARY KEYs are no longer written to the SQLite replica.
* Instead, we now replicate primary key indexes from Postgres (in addition to non-primary key indexes that we already replicate)
* In zqlite, we choose an appropriate unique index for IVM operations according to the sort order requested. This was added in #3547 and #3553

### TODO

Some of the code in this PR is setup for upcoming features:

* The `unionKey` is the union of all uniquely indexed columns. These will be used as CVR row keys in order to [facilitate clients migrating between primary keys on client-side schemas](https://rocicorp.slack.com/archives/C013XFG80JC/p1736376499195429?thread_ts=1736355005.417389&cid=C013XFG80JC)
* The `isReplicaIdentity` field looked up for Postgres indexes will be used to support tables with unique indexes but no primary key, such as prisma join tables
