### PR TITLE
feat(zero-cache): facilitate migrating beetween primary keys

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -710,6 +710,7 @@ describe('view-syncer/pipeline-driver', () => {
           "rowKey": {
             "issueID": "1",
             "labelID": "1",
+            "legacyID": "1-1",
           },
           "table": "issueLabels",
           "type": "remove",
@@ -789,6 +790,7 @@ describe('view-syncer/pipeline-driver', () => {
           "rowKey": {
             "issueID": "1",
             "labelID": "1",
+            "legacyID": "1-1",
           },
           "table": "issueLabels",
           "type": "add",
@@ -937,6 +939,7 @@ describe('view-syncer/pipeline-driver', () => {
           "rowKey": {
             "issueID": "2",
             "labelID": "1",
+            "legacyID": "2-1",
           },
           "table": "issueLabels",
           "type": "add",
@@ -965,6 +968,7 @@ describe('view-syncer/pipeline-driver', () => {
           "rowKey": {
             "issueID": "2",
             "labelID": "1",
+            "legacyID": "2-1",
           },
           "table": "issueLabels",
           "type": "add",
@@ -1002,6 +1006,7 @@ describe('view-syncer/pipeline-driver', () => {
           "rowKey": {
             "issueID": "2",
             "labelID": "1",
+            "legacyID": "2-1",
           },
           "table": "issueLabels",
           "type": "remove",
@@ -1030,6 +1035,7 @@ describe('view-syncer/pipeline-driver', () => {
           "rowKey": {
             "issueID": "2",
             "labelID": "1",
+            "legacyID": "2-1",
           },
           "table": "issueLabels",
           "type": "remove",


### PR DESCRIPTION
Use the "unionKey" as CVR row keys and del-patches to allow clients to see both the old and new primary key.

This facilitates the migration steps outlined in: https://rocicorp.slack.com/archives/C013XFG80JC/p1736376499195429?thread_ts=1736355005.417389&cid=C013XFG80JC