### PR TITLE
feat(zero-cache): automaticaly set REPLICA IDENTITY for tables without PKs

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg-test.ts
@@ -45,7 +45,7 @@ describe('change-source/pg/end-to-mid-test', {timeout: 10000}, () => {
     await upstream.unsafe(`
     CREATE TYPE ENUMZ AS ENUM ('1', '2', '3');
     CREATE TABLE foo(
-      id TEXT PRIMARY KEY,
+      id TEXT NOT NULL,
       int INT4,
       big BIGINT,
       flt FLOAT8,
@@ -64,6 +64,7 @@ describe('change-source/pg/end-to-mid-test', {timeout: 10000}, () => {
     -- since the set of allowed schemas is restricted.
     CREATE SCHEMA IF NOT EXISTS zero;
 
+    CREATE UNIQUE INDEX foo_key ON foo (id);
     CREATE PUBLICATION zero_some_public FOR TABLE foo (id, int);
     CREATE PUBLICATION zero_all_test FOR TABLES IN SCHEMA zero;
     `);

--- a/packages/zero-cache/src/services/change-source/pg/schema/validation.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/validation.ts
@@ -3,13 +3,18 @@ import {
   mapPostgresToLite,
   warnIfDataTypeSupported,
 } from '../../../../db/pg-to-lite.js';
-import type {TableSpec} from '../../../../db/specs.js';
+import {Default} from '../../../../db/postgres-replica-identity-enum.js';
+import type {PublishedTableSpec} from '../../../../db/specs.js';
 import {ZERO_VERSION_COLUMN_NAME} from '../../../replicator/schema/replication-state.js';
 import {unescapedSchema} from './shard.js';
 
 const ALLOWED_IDENTIFIER_CHARS = /^[A-Za-z_]+[A-Za-z0-9_-]*$/;
 
-export function validate(lc: LogContext, shardID: string, table: TableSpec) {
+export function validate(
+  lc: LogContext,
+  shardID: string,
+  table: PublishedTableSpec,
+) {
   const shardSchema = unescapedSchema(shardID);
   if (!['public', 'zero', shardSchema].includes(table.schema)) {
     // This may be relaxed in the future. We would need a plan for support in the AST first.
@@ -22,7 +27,7 @@ export function validate(lc: LogContext, shardID: string, table: TableSpec) {
       `Table "${table.name}" uses reserved column name "${ZERO_VERSION_COLUMN_NAME}"`,
     );
   }
-  if (!table.primaryKey?.length) {
+  if (!table.primaryKey?.length && table.replicaIdentity === Default) {
     lc.warn?.(
       `\n\n\n` +
         `Table "${table.name}" needs a primary key in order to be synced to clients. ` +


### PR DESCRIPTION
Fixes: [Support prisma join tables](https://bugs.rocicorp.dev/issue/3198)

For tables without a `PRIMARY KEY`, look for a suitable index to use as the [`REPLICA IDENTITY USING INDEX`](https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-REPLICA-IDENTITY):
* unique
* non-partial
* immediate
* non-null columns only

(For example, the [indexes created by Prisma for join tables](https://www.prisma.io/docs/orm/prisma-schema/data-model/relations/many-to-many-relations#implicit-many-to-many-relations) satisfies these criteria)

If found, initial-sync will set the replica identity of the PRIMARY KEY-less table such that it can fully participate in replication and sync.