### PR TITLE
fix(zero-cache): do not detach forked processes in windows

### DIFF
--- a/packages/zero-cache/src/types/processes.ts
+++ b/packages/zero-cache/src/types/processes.ts
@@ -5,6 +5,7 @@ import {
   type Serializable,
 } from 'node:child_process';
 import EventEmitter from 'node:events';
+import {platform} from 'node:os';
 import path from 'node:path';
 import {pid} from 'node:process';
 
@@ -182,7 +183,11 @@ export function childWorker(
     return child;
   }
   const child = fork(moduleUrl, args, {
-    detached: true, // do not automatically propagate SIGINT
+    // For production / non-windows, set `detached` to `true` so that SIGINT is
+    // not automatically propagated and graceful shutdown happens as intended.
+    // For Win32, detached: true causes all subprocesses to open in separate
+    // terminals and breaks inter-process kill signals, so set it to false.
+    detached: platform() !== 'win32',
     serialization: 'advanced', // use structured clone for IPC
     env,
     // silent: true,


### PR DESCRIPTION
Setting `detached: true` for forked processes in windows results in opening separate terminals per child process, and breaks inter-process kill-signals that are needed for proper shutdown.

Setting it to `false` breaks graceful shutdown in non-Windows in that the SIGINT signal is automatically propagated to all child workers, whereas we need to control shutdown of children such that all `user-facing` workers exit before `supporting` workers.

The compromise is to only set `detached` to `true` for non-Windows environments. 