### PR TITLE
fix(zero-cache): fix client catchup

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -1085,6 +1085,25 @@ describe('view-syncer/pipeline-driver', () => {
       upvotes: 20000,
       ['_0_version']: '134',
     });
+
+    [...pipelines.addQuery('hash2', ISSUES_QUERY_WITH_EXISTS)];
+
+    // getRow should work with any row key
+    expect(
+      pipelines.getRow('issueLabels', {issueID: '1', labelID: '1'}),
+    ).toEqual({
+      issueID: '1',
+      labelID: '1',
+      legacyID: '1-1',
+      ['_0_version']: '123',
+    });
+
+    expect(pipelines.getRow('issueLabels', {legacyID: '1-1'})).toEqual({
+      issueID: '1',
+      labelID: '1',
+      legacyID: '1-1',
+      ['_0_version']: '123',
+    });
   });
 
   test('schemaVersions change and insert', () => {

--- a/packages/zqlite/src/table-source.test.ts
+++ b/packages/zqlite/src/table-source.test.ts
@@ -706,6 +706,14 @@ test('getByKey', () => {
     c: true,
   });
 
+  // Ensure that it works with any unique key
+  expect(source.getRow({id: '3'})).toEqual({
+    id: '3',
+    a: Number.MAX_SAFE_INTEGER,
+    b: Number.MIN_SAFE_INTEGER,
+    c: true,
+  });
+
   // Exists but contains an out-of-bounds value.
   expect(() =>
     source.getRow({

--- a/packages/zqlite/src/table-source.ts
+++ b/packages/zqlite/src/table-source.ts
@@ -181,18 +181,6 @@ export class TableSource implements Source {
           )} LIMIT 1`,
         ),
       ),
-      getRow: db
-        .prepare(
-          compile(
-            sql`SELECT ${this.#allColumns} FROM ${sql.ident(
-              this.#table,
-            )} WHERE ${sql.join(
-              this.#primaryKey.map(k => sql`${sql.ident(k)}=?`),
-              sql` AND`,
-            )}`,
-          ),
-        )
-        .safeIntegers(true),
     };
     this.#dbCache.set(db, stmts);
     return stmts;

--- a/packages/zqlite/src/table-source.ts
+++ b/packages/zqlite/src/table-source.ts
@@ -68,7 +68,6 @@ type Statements = {
   readonly delete: Statement;
   readonly update: Statement | undefined;
   readonly checkExists: Statement;
-  readonly getRow: Statement;
 };
 
 /**
@@ -441,15 +440,37 @@ export class TableSource implements Source {
     }
   }
 
+  #getRowStmtCache = new Map<string, string>();
+
+  #getRowStmt(rowKey: Row): string {
+    const keyCols = Object.keys(rowKey);
+    const keyString = JSON.stringify(keyCols);
+    let stmt = this.#getRowStmtCache.get(keyString);
+    if (!stmt) {
+      stmt = compile(
+        sql`SELECT ${this.#allColumns} FROM ${sql.ident(
+          this.#table,
+        )} WHERE ${sql.join(
+          keyCols.map(k => sql`${sql.ident(k)}=?`),
+          sql` AND`,
+        )}`,
+      );
+      this.#getRowStmtCache.set(keyString, stmt);
+    }
+    return stmt;
+  }
+
   /**
-   * Retrieves a row from the backing DB by its primary key, or `undefined` if such a
+   * Retrieves a row from the backing DB by a unique key, or `undefined` if such a
    * row does not exist. This is not used in the IVM pipeline but is useful
    * for retrieving data that is consistent with the state (and type
-   * semantics) of the pipeline.
+   * semantics) of the pipeline. Note that this key may not necessarily correspond
+   * to the `primaryKey` with which this TableSource.
    */
-  getRow(pk: Row): Row | undefined {
-    const row = this.#stmts.getRow.get<Row>(
-      this.#primaryKey.map(key => pk[key]),
+  getRow(rowKey: Row): Row | undefined {
+    const stmt = this.#getRowStmt(rowKey);
+    const row = this.#stmts.cache.use(stmt, cached =>
+      cached.statement.safeIntegers(true).get<Row>(...Object.values(rowKey)),
     );
     if (row) {
       return fromSQLiteTypes(this.#columns, row);

--- a/packages/zqlite/src/table-source.ts
+++ b/packages/zqlite/src/table-source.ts
@@ -458,7 +458,7 @@ export class TableSource implements Source {
   getRow(rowKey: Row): Row | undefined {
     const stmt = this.#getRowStmt(rowKey);
     const row = this.#stmts.cache.use(stmt, cached =>
-      cached.statement.safeIntegers(true).get<Row>(...Object.values(rowKey)),
+      cached.statement.safeIntegers(true).get<Row>(Object.values(rowKey)),
     );
     if (row) {
       return fromSQLiteTypes(this.#columns, row);

--- a/packages/zqlite/src/table-source.ts
+++ b/packages/zqlite/src/table-source.ts
@@ -430,8 +430,7 @@ export class TableSource implements Source {
 
   #getRowStmtCache = new Map<string, string>();
 
-  #getRowStmt(rowKey: Row): string {
-    const keyCols = Object.keys(rowKey);
+  #getRowStmt(keyCols: string[]): string {
     const keyString = JSON.stringify(keyCols);
     let stmt = this.#getRowStmtCache.get(keyString);
     if (!stmt) {
@@ -456,9 +455,12 @@ export class TableSource implements Source {
    * to the `primaryKey` with which this TableSource.
    */
   getRow(rowKey: Row): Row | undefined {
-    const stmt = this.#getRowStmt(rowKey);
+    const keyCols = Object.keys(rowKey);
+    const keyVals = Object.values(rowKey);
+
+    const stmt = this.#getRowStmt(keyCols);
     const row = this.#stmts.cache.use(stmt, cached =>
-      cached.statement.safeIntegers(true).get<Row>(Object.values(rowKey)),
+      cached.statement.safeIntegers(true).get<Row>(keyVals),
     );
     if (row) {
       return fromSQLiteTypes(this.#columns, row);


### PR DESCRIPTION
For client catchup. The CVR rows keys may differ from the TableSource row keys, so the latter must be able to look up rows by any row key.