### PR TITLE
prod(zbugs): resync prod replica

### DIFF
--- a/prod/templates/template.yml
+++ b/prod/templates/template.yml
@@ -212,7 +212,7 @@ Resources:
             - Name: ZERO_REPLICA_FILE
               Value: /data/db/sync-replica.db
             - Name: ZERO_LITESTREAM_BACKUP_URL
-              Value: !Sub "s3://${ApplicationBucket}/20250117"
+              Value: !Sub "s3://${ApplicationBucket}/20250118"
             - Name: ZERO_LOG_LEVEL
               Value: debug
             - Name: ZERO_UPSTREAM_MAX_CONNS
@@ -377,7 +377,7 @@ Resources:
             - Name: ZERO_NUM_SYNC_WORKERS
               Value: "0"
             - Name: ZERO_LITESTREAM_BACKUP_URL
-              Value: !Sub "s3://${ApplicationBucket}/20250117"
+              Value: !Sub "s3://${ApplicationBucket}/20250118"
             - Name: ZERO_LOG_FORMAT
               Value: json
             - Name: ZERO_REPLICA_FILE


### PR DESCRIPTION
Resync the prod zbugs replica to refresh everyone's CVRs. 

The theory on the current [(blank page) production issue](https://discord.com/channels/830183651022471199/1288232858795769917/1330306654700437545) is that some bad CVRs were created in the midst of all of the index / key changes that were landing last night.