### PR TITLE
chore(zero): Fix file size threshold

### DIFF
--- a/.github/workflows/bencher-benchmarks-pr.yml
+++ b/.github/workflows/bencher-benchmarks-pr.yml
@@ -48,7 +48,7 @@ jobs:
           --github-actions '${{ secrets.GITHUB_TOKEN }}' \
           --branch "$GITHUB_HEAD_REF" \
           --start-point "$GITHUB_BASE_REF" \
-          --start-point-hash '${{ github.event.pull_request.base.sha }}' \\
+          --start-point-hash '${{ github.event.pull_request.base.sha }}' \
           --start-point-clone-thresholds \
           --start-point-reset \
           --threshold-measure file-size \

--- a/.github/workflows/bencher-benchmarks-pr.yml
+++ b/.github/workflows/bencher-benchmarks-pr.yml
@@ -48,13 +48,13 @@ jobs:
           --github-actions '${{ secrets.GITHUB_TOKEN }}' \
           --branch "$GITHUB_HEAD_REF" \
           --start-point "$GITHUB_BASE_REF" \
-          --start-point-hash '${{ github.event.pull_request.base.sha }}' \
-          --start-point-max-versions 1 \
+          --start-point-hash '${{ github.event.pull_request.base.sha }}' \\
           --start-point-clone-thresholds \
           --start-point-reset \
           --threshold-measure file-size \
           --threshold-test percentage \
           --threshold-upper-boundary 0.02 \
+          --threshold-max-sample-size 2 \
           --err \
           --file-size out/zero-package.tgz \
           --file-size out/zero.js.br \

--- a/.github/workflows/bencher-benchmarks.yml
+++ b/.github/workflows/bencher-benchmarks.yml
@@ -44,10 +44,10 @@ jobs:
           --adapter json \
           --github-actions '${{ secrets.GITHUB_TOKEN }}' \
           --start-point main \
-          --start-point-max-versions 1 \
           --threshold-measure file-size \
           --threshold-test percentage \
           --threshold-upper-boundary 0.02 \
+          --threshold-max-sample-size 2 \
           --err \
           --file-size out/zero-package.tgz \
           --file-size out/zero.js.br \


### PR DESCRIPTION
Instead of only using max versions of we can use max sample size. This keeps the whole plot but only uses the last report and the current report for the alerts.