### PR TITLE
fix(zero-cache): stop piping stdio between parent and child

### DIFF
--- a/packages/zero-cache/src/types/processes.ts
+++ b/packages/zero-cache/src/types/processes.ts
@@ -190,11 +190,7 @@ export function childWorker(
     detached: platform() !== 'win32',
     serialization: 'advanced', // use structured clone for IPC
     env,
-    // silent: true,
-    stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
   });
-  child.stdout?.pipe(process.stdout);
-  child.stderr?.pipe(process.stderr);
   return wrap(child);
 }
 


### PR DESCRIPTION
Remove the stdio piping between parent/child processes, as it causes event listener warnings. This was a workaround for Windows that should not longer be necessary now that the child processes are no longer `detached`.