### PR TITLE
feat(zql)!: `tables` and `relationships` are now arrays not objects

### DIFF
--- a/apps/zbugs/schema.ts
+++ b/apps/zbugs/schema.ts
@@ -189,26 +189,16 @@ type AuthData = {
   role: 'crew' | 'user';
 };
 
-export const schema = createSchema(
-  5,
-  {
-    user,
-    issue,
-    comment,
-    label,
-    issueLabel,
-    viewState,
-    emoji,
-    userPref,
-  },
-  {
+export const schema = createSchema(5, {
+  tables: [user, issue, comment, label, issueLabel, viewState, emoji, userPref],
+  relationships: [
     userRelationships,
     issueRelationships,
     commentRelationships,
     issueLabelRelationships,
     emojiRelationships,
-  },
-);
+  ],
+});
 
 export type Schema = typeof schema;
 type TableName = keyof Schema['tables'];

--- a/packages/zero-cache/bench/schema.ts
+++ b/packages/zero-cache/bench/schema.ts
@@ -86,20 +86,10 @@ const commentRelationships = relationships(comment, connect => ({
   }),
 }));
 
-export const schema = createSchema(
-  1,
-  {
-    member,
-    issue,
-    comment,
-    label,
-    issueLabel,
-  },
-  {
-    issueRelationships,
-    commentRelationships,
-  },
-);
+export const schema = createSchema(1, {
+  tables: [member, issue, comment, label, issueLabel],
+  relationships: [issueRelationships, commentRelationships],
+});
 
 type AppSchema = typeof schema;
 export type {AppSchema as Schema};

--- a/packages/zero-cache/src/auth/read-authorizer.query.test.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.query.test.ts
@@ -266,9 +266,8 @@ type AuthData = {
   };
 };
 
-const schema = createSchema(
-  1,
-  {
+const schema = createSchema(1, {
+  tables: [
     user,
     issue,
     comment,
@@ -277,8 +276,8 @@ const schema = createSchema(
     viewState,
     project,
     projectMember,
-  },
-  {
+  ],
+  relationships: [
     userRelationships,
     issueRelationships,
     commentRelationships,
@@ -286,8 +285,8 @@ const schema = createSchema(
     viewStateRelationships,
     projectRelationships,
     projectMemberRelationships,
-  },
-);
+  ],
+});
 
 type Schema = typeof schema;
 

--- a/packages/zero-cache/src/auth/read-authorizer.test.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.test.ts
@@ -90,20 +90,14 @@ const adminReadableRelationships = relationships(adminReadable, connect => ({
   }),
 }));
 
-const schema = createSchema(
-  1,
-  {
-    unreadable,
-    readable,
-    adminReadable,
-    readableThruUnreadable,
-  },
-  {
-    readableThruUnreadable: readableThruUnreadableRelationships,
-    readable: readableRelationships,
-    adminReadable: adminReadableRelationships,
-  },
-);
+const schema = createSchema(1, {
+  tables: [unreadable, readable, adminReadable, readableThruUnreadable],
+  relationships: [
+    readableThruUnreadableRelationships,
+    readableRelationships,
+    adminReadableRelationships,
+  ],
+});
 
 type Schema = typeof schema;
 

--- a/packages/zero-cache/src/auth/write-authorizer.test.ts
+++ b/packages/zero-cache/src/auth/write-authorizer.test.ts
@@ -40,12 +40,14 @@ const allowIfAIsSubject = [
 ] satisfies Rule;
 
 const schema = createSchema(1, {
-  foo: table('foo')
-    .columns({
-      id: string(),
-      a: string(),
-    })
-    .primaryKey('id'),
+  tables: [
+    table('foo')
+      .columns({
+        id: string(),
+        a: string(),
+      })
+      .primaryKey('id'),
+  ],
 });
 
 let replica: Database;

--- a/packages/zero-cache/src/services/mutagen/mutagen.authz.pg-test.ts
+++ b/packages/zero-cache/src/services/mutagen/mutagen.authz.pg-test.ts
@@ -121,68 +121,70 @@ function createReplicaTables(db: Database) {
 }
 
 const schema = createSchema(TEST_SCHEMA_VERSION, {
-  user: table('user')
-    .columns({
-      id: string(),
-      role: string(),
-    })
-    .primaryKey('id'),
+  tables: [
+    table('user')
+      .columns({
+        id: string(),
+        role: string(),
+      })
+      .primaryKey('id'),
 
-  roCell: table('roCell')
-    .columns({
-      id: string(),
-      a: string(),
-      b: string(),
-    })
-    .primaryKey('id'),
+    table('roCell')
+      .columns({
+        id: string(),
+        a: string(),
+        b: string(),
+      })
+      .primaryKey('id'),
 
-  roRow: table('roRow')
-    .columns({
-      id: string(),
-      a: string(),
-      b: string(),
-    })
-    .primaryKey('id'),
+    table('roRow')
+      .columns({
+        id: string(),
+        a: string(),
+        b: string(),
+      })
+      .primaryKey('id'),
 
-  adminOnlyCell: table('adminOnlyCell')
-    .columns({
-      id: string(),
-      a: string(),
-      adminLocked: boolean(),
-    })
-    .primaryKey('id'),
+    table('adminOnlyCell')
+      .columns({
+        id: string(),
+        a: string(),
+        adminLocked: boolean(),
+      })
+      .primaryKey('id'),
 
-  adminOnlyRow: table('adminOnlyRow')
-    .columns({
-      id: string(),
-      a: string(),
-      adminLocked: boolean(),
-    })
-    .primaryKey('id'),
+    table('adminOnlyRow')
+      .columns({
+        id: string(),
+        a: string(),
+        adminLocked: boolean(),
+      })
+      .primaryKey('id'),
 
-  loggedInRow: table('loggedInRow')
-    .columns({
-      id: string(),
-      a: string(),
-    })
-    .primaryKey('id'),
+    table('loggedInRow')
+      .columns({
+        id: string(),
+        a: string(),
+      })
+      .primaryKey('id'),
 
-  userMatch: table('userMatch')
-    .columns({
-      id: string(),
-      a: string(),
-    })
-    .primaryKey('id'),
+    table('userMatch')
+      .columns({
+        id: string(),
+        a: string(),
+      })
+      .primaryKey('id'),
 
-  dataTypeTest: table('dataTypeTest')
-    .columns({
-      id: string(),
-      j: json().optional(),
-      b: boolean().optional(),
-      r: number().optional(),
-      i: number().optional(),
-    })
-    .primaryKey('id'),
+    table('dataTypeTest')
+      .columns({
+        id: string(),
+        j: json().optional(),
+        b: boolean().optional(),
+        r: number().optional(),
+        i: number().optional(),
+      })
+      .primaryKey('id'),
+  ],
 });
 
 type Schema = typeof schema;

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -234,22 +234,18 @@ const comments = table('comments')
   })
   .primaryKey('id');
 
-const schema = createSchema(
-  1,
-  {
-    issues,
-    comments,
-  },
-  {
-    commentRelationships: relationships(comments, connect => ({
+const schema = createSchema(1, {
+  tables: [issues, comments],
+  relationships: [
+    relationships(comments, connect => ({
       issue: connect.many({
         sourceField: ['issueID'],
         destField: ['id'],
         destSchema: issues,
       }),
     })),
-  },
-);
+  ],
+});
 type Schema = typeof schema;
 
 type AuthData = {

--- a/packages/zero-client/src/client/context.test.ts
+++ b/packages/zero-client/src/client/context.test.ts
@@ -15,18 +15,20 @@ const testBatchViewUpdates = (applyViewUpdates: () => void) =>
 
 test('getSource', () => {
   const schema = createSchema(1, {
-    users: table('users')
-      .columns({
-        id: string(),
-        name: string(),
-      })
-      .primaryKey('id'),
-    userStates: table('userStates')
-      .columns({
-        userID: string(),
-        stateCode: string(),
-      })
-      .primaryKey('userID', 'stateCode'),
+    tables: [
+      table('users')
+        .columns({
+          id: string(),
+          name: string(),
+        })
+        .primaryKey('id'),
+      table('userStates')
+        .columns({
+          userID: string(),
+          stateCode: string(),
+        })
+        .primaryKey('userID', 'stateCode'),
+    ],
   });
 
   const context = new ZeroContext(
@@ -88,12 +90,14 @@ test('getSource', () => {
   `);
 });
 const schema = createSchema(1, {
-  t1: table('t1')
-    .columns({
-      id: string(),
-      name: string(),
-    })
-    .primaryKey('id'),
+  tables: [
+    table('t1')
+      .columns({
+        id: string(),
+        name: string(),
+      })
+      .primaryKey('id'),
+  ],
 });
 
 test('processChanges', () => {
@@ -196,18 +200,20 @@ test('processChanges wraps source updates with batchViewUpdates', () => {
 
 test('transactions', () => {
   const schema = createSchema(1, {
-    server: table('server')
-      .columns({
-        id: string(),
-      })
-      .primaryKey('id'),
-    flair: table('flair')
-      .columns({
-        id: string(),
-        serverID: string(),
-        description: string(),
-      })
-      .primaryKey('id'),
+    tables: [
+      table('server')
+        .columns({
+          id: string(),
+        })
+        .primaryKey('id'),
+      table('flair')
+        .columns({
+          id: string(),
+          serverID: string(),
+          description: string(),
+        })
+        .primaryKey('id'),
+    ],
   });
 
   const context = new ZeroContext(

--- a/packages/zero-client/src/client/worker-test.ts
+++ b/packages/zero-client/src/client/worker-test.ts
@@ -44,12 +44,14 @@ async function testBasics(userID: string) {
   const r = zeroForTest({
     userID,
     schema: createSchema(1, {
-      e: table('e')
-        .columns({
-          id: string(),
-          value: number(),
-        })
-        .primaryKey('id'),
+      tables: [
+        table('e')
+          .columns({
+            id: string(),
+            value: number(),
+          })
+          .primaryKey('id'),
+      ],
     }),
   });
 

--- a/packages/zero-client/src/client/zero-poke-handler.test.ts
+++ b/packages/zero-client/src/client/zero-poke-handler.test.ts
@@ -30,18 +30,20 @@ afterEach(() => {
 });
 
 const schema = createSchema(1, {
-  issues: table('issues')
-    .columns({
-      id: string(),
-      title: string(),
-    })
-    .primaryKey('id'),
-  labels: table('labels')
-    .columns({
-      id: string(),
-      name: string(),
-    })
-    .primaryKey('id'),
+  tables: [
+    table('issues')
+      .columns({
+        id: string(),
+        title: string(),
+      })
+      .primaryKey('id'),
+    table('labels')
+      .columns({
+        id: string(),
+        name: string(),
+      })
+      .primaryKey('id'),
+  ],
 });
 
 test('completed poke plays on first raf', async () => {

--- a/packages/zero-client/src/client/zero-rate.test.ts
+++ b/packages/zero-client/src/client/zero-rate.test.ts
@@ -57,12 +57,14 @@ test('connection stays alive on rate limit error', async () => {
 test('a mutation after a rate limit error causes limited mutations to be resent', async () => {
   const z = zeroForTest({
     schema: createSchema(1, {
-      issue: table('issue')
-        .columns({
-          id: string(),
-          value: number(),
-        })
-        .primaryKey('id'),
+      tables: [
+        table('issue')
+          .columns({
+            id: string(),
+            value: number(),
+          })
+          .primaryKey('id'),
+      ],
     }),
   });
   await z.triggerConnected();
@@ -97,12 +99,14 @@ test('a mutation after a rate limit error causes limited mutations to be resent'
 test('previously confirmed mutations are not resent after a rate limit error', async () => {
   const z = zeroForTest({
     schema: createSchema(1, {
-      issue: table('issue')
-        .columns({
-          id: string(),
-          value: number(),
-        })
-        .primaryKey('id'),
+      tables: [
+        table('issue')
+          .columns({
+            id: string(),
+            value: number(),
+          })
+          .primaryKey('id'),
+      ],
     }),
   });
   await z.triggerConnected();

--- a/packages/zero-client/src/client/zero.json.test.ts
+++ b/packages/zero-client/src/client/zero.json.test.ts
@@ -5,13 +5,15 @@ import {createSchema, json, string, table} from '../mod.js';
 test('we can create rows with json columns and query those rows', async () => {
   const z = zeroForTest({
     schema: createSchema(1, {
-      track: table('track')
-        .columns({
-          id: string(),
-          title: string(),
-          artists: json<string[]>(),
-        })
-        .primaryKey('id'),
+      tables: [
+        table('track')
+          .columns({
+            id: string(),
+            title: string(),
+            artists: json<string[]>(),
+          })
+          .primaryKey('id'),
+      ],
     }),
   });
 

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -84,12 +84,14 @@ test('onOnlineChange callback', async () => {
   const z = zeroForTest({
     logLevel: 'debug',
     schema: createSchema(1, {
-      foo: table('foo')
-        .columns({
-          id: string(),
-          val: string(),
-        })
-        .primaryKey('id'),
+      tables: [
+        table('foo')
+          .columns({
+            id: string(),
+            val: string(),
+          })
+          .primaryKey('id'),
+      ],
     }),
     onOnlineChange: online => {
       if (online) {
@@ -509,12 +511,14 @@ suite('initConnection', () => {
   test('sends desired queries patch in sec-protocol header', async () => {
     const r = zeroForTest({
       schema: createSchema(1, {
-        e: table('e')
-          .columns({
-            id: string(),
-            value: string(),
-          })
-          .primaryKey('id'),
+        tables: [
+          table('e')
+            .columns({
+              id: string(),
+              value: string(),
+            })
+            .primaryKey('id'),
+        ],
       }),
     });
 
@@ -553,12 +557,14 @@ suite('initConnection', () => {
     const r = zeroForTest({
       maxHeaderLength: 0,
       schema: createSchema(1, {
-        e: table('e')
-          .columns({
-            id: string(),
-            value: string(),
-          })
-          .primaryKey('id'),
+        tables: [
+          table('e')
+            .columns({
+              id: string(),
+              value: string(),
+            })
+            .primaryKey('id'),
+        ],
       }),
     });
     const mockSocket = await r.socket;
@@ -594,12 +600,14 @@ suite('initConnection', () => {
   test('sends changeDesiredQueries if new queries are added after initConnection but before connected', async () => {
     const r = zeroForTest({
       schema: createSchema(1, {
-        e: table('e')
-          .columns({
-            id: string(),
-            value: string(),
-          })
-          .primaryKey('id'),
+        tables: [
+          table('e')
+            .columns({
+              id: string(),
+              value: string(),
+            })
+            .primaryKey('id'),
+        ],
       }),
     });
 
@@ -649,12 +657,14 @@ suite('initConnection', () => {
   test('changeDesiredQueries does not include queries sent with initConnection', async () => {
     const r = zeroForTest({
       schema: createSchema(1, {
-        e: table('e')
-          .columns({
-            id: string(),
-            value: string(),
-          })
-          .primaryKey('id'),
+        tables: [
+          table('e')
+            .columns({
+              id: string(),
+              value: string(),
+            })
+            .primaryKey('id'),
+        ],
       }),
     });
 
@@ -674,12 +684,14 @@ suite('initConnection', () => {
   test('changeDesiredQueries does include removal of a query sent with initConnection if it was removed before `connected`', async () => {
     const r = zeroForTest({
       schema: createSchema(1, {
-        e: table('e')
-          .columns({
-            id: string(),
-            value: string(),
-          })
-          .primaryKey('id'),
+        tables: [
+          table('e')
+            .columns({
+              id: string(),
+              value: string(),
+            })
+            .primaryKey('id'),
+        ],
       }),
     });
 
@@ -1105,12 +1117,14 @@ test('smokeTest', async () => {
     const r = zeroForTest({
       ...serverOptions,
       schema: createSchema(1, {
-        issues: table('issues')
-          .columns({
-            id: string(),
-            value: number(),
-          })
-          .primaryKey('id'),
+        tables: [
+          table('issues')
+            .columns({
+              id: string(),
+              value: number(),
+            })
+            .primaryKey('id'),
+        ],
       }),
     });
 
@@ -2028,12 +2042,14 @@ test('kvStore option', async () => {
       userID,
       kvStore,
       schema: createSchema(1, {
-        e: table('e')
-          .columns({
-            id: string(),
-            value: number(),
-          })
-          .primaryKey('id'),
+        tables: [
+          table('e')
+            .columns({
+              id: string(),
+              value: number(),
+            })
+            .primaryKey('id'),
+        ],
       }),
     });
     const idIsAView = r.query.e.where('id', '=', 'a').materialize();
@@ -2125,19 +2141,21 @@ test('Zero close should stop timeout, close delayed', async () => {
 test('ensure we get the same query object back', () => {
   const z = zeroForTest({
     schema: createSchema(1, {
-      issue: table('issue')
-        .columns({
-          id: string(),
-          title: string(),
-        })
-        .primaryKey('id'),
-      comment: table('comment')
-        .columns({
-          id: string(),
-          issueID: string(),
-          text: string(),
-        })
-        .primaryKey('id'),
+      tables: [
+        table('issue')
+          .columns({
+            id: string(),
+            title: string(),
+          })
+          .primaryKey('id'),
+        table('comment')
+          .columns({
+            id: string(),
+            issueID: string(),
+            text: string(),
+          })
+          .primaryKey('id'),
+      ],
     }),
   });
   const issueQuery1 = z.query.issue;
@@ -2154,19 +2172,21 @@ test('ensure we get the same query object back', () => {
 test('the type of collection should be inferred from options with parse', () => {
   const r = zeroForTest({
     schema: createSchema(1, {
-      issue: table('issue')
-        .columns({
-          id: string(),
-          title: string(),
-        })
-        .primaryKey('id'),
-      comment: table('comment')
-        .columns({
-          id: string(),
-          issueID: string(),
-          text: string(),
-        })
-        .primaryKey('id'),
+      tables: [
+        table('issue')
+          .columns({
+            id: string(),
+            title: string(),
+          })
+          .primaryKey('id'),
+        table('comment')
+          .columns({
+            id: string(),
+            issueID: string(),
+            text: string(),
+          })
+          .primaryKey('id'),
+      ],
     }),
   });
 
@@ -2183,26 +2203,28 @@ suite('CRUD', () => {
   const makeZero = () =>
     zeroForTest({
       schema: createSchema(1, {
-        issue: table('issue')
-          .columns({
-            id: string(),
-            title: string().optional(),
-          })
-          .primaryKey('id'),
-        comment: table('comment')
-          .columns({
-            id: string(),
-            issueID: string(),
-            text: string().optional(),
-          })
-          .primaryKey('id'),
-        compoundPKTest: table('compoundPKTest')
-          .columns({
-            id1: string(),
-            id2: string(),
-            text: string(),
-          })
-          .primaryKey('id1', 'id2'),
+        tables: [
+          table('issue')
+            .columns({
+              id: string(),
+              title: string().optional(),
+            })
+            .primaryKey('id'),
+          table('comment')
+            .columns({
+              id: string(),
+              issueID: string(),
+              text: string().optional(),
+            })
+            .primaryKey('id'),
+          table('compoundPKTest')
+            .columns({
+              id1: string(),
+              id2: string(),
+              text: string(),
+            })
+            .primaryKey('id1', 'id2'),
+        ],
       }),
     });
 
@@ -2347,12 +2369,14 @@ suite('CRUD', () => {
   test('do not expose _zero_crud', () => {
     const z = zeroForTest({
       schema: createSchema(1, {
-        issue: table('issue')
-          .columns({
-            id: string(),
-            title: string(),
-          })
-          .primaryKey('id'),
+        tables: [
+          table('issue')
+            .columns({
+              id: string(),
+              title: string(),
+            })
+            .primaryKey('id'),
+        ],
       }),
     });
 
@@ -2378,22 +2402,24 @@ suite('CRUD with compound primary key', () => {
   const makeZero = () =>
     zeroForTest({
       schema: createSchema(1, {
-        issue: table('issue')
-          .columns({
-            ids: string(),
-            idn: number(),
-            title: string(),
-          })
-          .primaryKey('idn', 'ids'),
-        comment: table('comment')
-          .columns({
-            ids: string(),
-            idn: number(),
-            issueIDs: string(),
-            issueIDn: number(),
-            text: string(),
-          })
-          .primaryKey('idn', 'ids'),
+        tables: [
+          table('issue')
+            .columns({
+              ids: string(),
+              idn: number(),
+              title: string(),
+            })
+            .primaryKey('idn', 'ids'),
+          table('comment')
+            .columns({
+              ids: string(),
+              idn: number(),
+              issueIDs: string(),
+              issueIDn: number(),
+              text: string(),
+            })
+            .primaryKey('idn', 'ids'),
+        ],
       }),
     });
 
@@ -2501,19 +2527,21 @@ suite('CRUD with compound primary key', () => {
 test('mutate is a function for batching', async () => {
   const z = zeroForTest({
     schema: createSchema(1, {
-      issue: table('issue')
-        .columns({
-          id: string(),
-          title: string(),
-        })
-        .primaryKey('id'),
-      comment: table('comment')
-        .columns({
-          id: string(),
-          issueID: string(),
-          text: string(),
-        })
-        .primaryKey('id'),
+      tables: [
+        table('issue')
+          .columns({
+            id: string(),
+            title: string(),
+          })
+          .primaryKey('id'),
+        table('comment')
+          .columns({
+            id: string(),
+            issueID: string(),
+            text: string(),
+          })
+          .primaryKey('id'),
+      ],
     }),
   });
   const issueView = z.query.issue.materialize();
@@ -2551,19 +2579,21 @@ test('mutate is a function for batching', async () => {
 test('calling mutate on the non batch version should throw inside a batch', async () => {
   const z = zeroForTest({
     schema: createSchema(1, {
-      issue: table('issue')
-        .columns({
-          id: string(),
-          title: string(),
-        })
-        .primaryKey('id'),
-      comment: table('comment')
-        .columns({
-          id: string(),
-          issueID: string(),
-          text: string(),
-        })
-        .primaryKey('id'),
+      tables: [
+        table('issue')
+          .columns({
+            id: string(),
+            title: string(),
+          })
+          .primaryKey('id'),
+        table('comment')
+          .columns({
+            id: string(),
+            issueID: string(),
+            text: string(),
+          })
+          .primaryKey('id'),
+      ],
     }),
   });
   const commentView = z.query.comment.materialize();

--- a/packages/zero-schema/src/builder/schema-builder.test.ts
+++ b/packages/zero-schema/src/builder/schema-builder.test.ts
@@ -118,15 +118,10 @@ test('building a schema', () => {
     ),
   }));
 
-  const schema = createSchema(
-    1,
-    {user, issue, issueLabel, label},
-    {
-      userRelationships,
-      issueRelationships,
-      labelRelationships,
-    },
-  );
+  const schema = createSchema(1, {
+    tables: [user, issue, issueLabel, label],
+    relationships: [userRelationships, issueRelationships, labelRelationships],
+  });
 
   const q = mockQuery as unknown as Query<typeof schema, 'user'>;
   const iq = mockQuery as unknown as Query<typeof schema, 'issue'>;

--- a/packages/zero-schema/src/builder/schema-builder.ts
+++ b/packages/zero-schema/src/builder/schema-builder.ts
@@ -32,13 +32,13 @@ export type Schema = {
  * do not require bumping the schema version.
  */
 export function createSchema<
-  const TTables extends readonly [...TableBuilderWithColumns<TableSchema>[]],
-  const TRelationships extends readonly [...Relationships[]],
+  const TTables extends readonly TableBuilderWithColumns<TableSchema>[],
+  const TRelationships extends readonly Relationships[],
 >(
   version: number,
   options: {
     readonly tables: TTables;
-    readonly relationships: TRelationships;
+    readonly relationships?: TRelationships | undefined;
   },
 ): {
   version: number;
@@ -59,9 +59,19 @@ export function createSchema<
   const retRelationships: Record<string, Record<string, Relationship>> = {};
 
   options.tables.forEach(table => {
+    if (retTables[table.schema.name]) {
+      throw new Error(
+        `Table "${table.schema.name}" is defined more than once in the schema`,
+      );
+    }
     retTables[table.schema.name] = table.build();
   });
-  options.relationships.forEach(relationships => {
+  options.relationships?.forEach(relationships => {
+    if (retRelationships[relationships.name]) {
+      throw new Error(
+        `Relationships for table "${relationships.name}" are defined more than once in the schema`,
+      );
+    }
     retRelationships[relationships.name] = relationships.relationships;
     checkRelationship(
       relationships.relationships,

--- a/packages/zero-schema/src/permissions.test.ts
+++ b/packages/zero-schema/src/permissions.test.ts
@@ -17,7 +17,7 @@ const userSchema = table('user')
   })
   .primaryKey('id');
 
-const schema = createSchema(1, {userSchema});
+const schema = createSchema(1, {tables: [userSchema]});
 
 type AuthData = {
   sub: string;

--- a/packages/zero-schema/src/schema-config.test.ts
+++ b/packages/zero-schema/src/schema-config.test.ts
@@ -19,7 +19,10 @@ test('round trip', async () => {
       destSchema: circular,
     }),
   }));
-  const schema = createSchema(1, {circular}, {circularRelationships});
+  const schema = createSchema(1, {
+    tables: [circular],
+    relationships: [circularRelationships],
+  });
 
   const schemaAndPermissions = {
     schema,

--- a/packages/zero-schema/src/schema.test.ts
+++ b/packages/zero-schema/src/schema.test.ts
@@ -4,11 +4,9 @@ import {number, string, table} from './builder/table-builder.js';
 import {relationships} from './builder/relationship-builder.js';
 
 test('Key name does not matter', () => {
-  const schema = createSchema(
-    1,
-    {foo: table('bar').columns({id: string()}).primaryKey('id')},
-    {},
-  );
+  const schema = createSchema(1, {
+    tables: [table('bar').columns({id: string()}).primaryKey('id')],
+  });
 
   expectTypeOf(schema.tables.bar).toEqualTypeOf<{
     name: 'bar';
@@ -21,7 +19,7 @@ test('Key name does not matter', () => {
 
 test('Missing primary key is an error', () => {
   expect(() =>
-    createSchema(1, {foo: table('foo').columns({id: string()})}, {}),
+    createSchema(1, {tables: [table('foo').columns({id: string()})]}),
   ).toThrowErrorMatchingInlineSnapshot(
     `[Error: Table "foo" is missing a primary key]`,
   );
@@ -50,7 +48,7 @@ test('Missing table in direct relationship should throw', () => {
   }));
 
   expect(() =>
-    createSchema(1, {foo}, {fooRelationships}),
+    createSchema(1, {tables: [foo], relationships: [fooRelationships]}),
   ).toThrowErrorMatchingInlineSnapshot(
     `[Error: For relationship "foo"."barRelation", destination table "bar" is missing in the schema]`,
   );
@@ -102,11 +100,10 @@ test('Missing table in junction relationship should throw', () => {
   }));
 
   expect(() =>
-    createSchema(
-      1,
-      {tableB, tableC},
-      {tableBRelationships, tableCRelationships},
-    ),
+    createSchema(1, {
+      tables: [tableB, tableC],
+      relationships: [tableBRelationships, tableCRelationships],
+    }),
   ).toThrowErrorMatchingInlineSnapshot(
     `[Error: For relationship "tableB"."relationBToA", destination table "tableA" is missing in the schema]`,
   );
@@ -159,7 +156,7 @@ test('Missing column in direct relationship source should throw', () => {
   }));
 
   expect(() =>
-    createSchema(1, {bar, foo}, {fooRelationships}),
+    createSchema(1, {tables: [bar, foo], relationships: [fooRelationships]}),
   ).toThrowErrorMatchingInlineSnapshot(
     `[Error: For relationship "foo"."barRelation", the source field "missing" is missing in the table schema "foo"]`,
   );
@@ -240,7 +237,10 @@ test('Missing column in junction relationship source should throw', () => {
   }));
 
   expect(() =>
-    createSchema(1, {tableA, tableB, junctionTable}, {tableARelationships}),
+    createSchema(1, {
+      tables: [tableA, tableB, junctionTable],
+      relationships: [tableARelationships],
+    }),
   ).toThrowErrorMatchingInlineSnapshot(
     `[Error: For relationship "tableA"."relationAToB", the source field "missing" is missing in the table schema "junctionTable"]`,
   );

--- a/packages/zero-schema/src/table-schema.test.ts
+++ b/packages/zero-schema/src/table-schema.test.ts
@@ -59,18 +59,10 @@ test('relationship schema types', () => {
     ),
   }));
 
-  const schema = createSchema(
-    1,
-    {
-      issueLabel,
-      comment,
-      label,
-      issue,
-    },
-    {
-      issueRelationships,
-    },
-  );
+  const schema = createSchema(1, {
+    tables: [issueLabel, comment, label, issue],
+    relationships: [issueRelationships],
+  });
 
   expectTypeOf(schema.tables.issueLabel).toMatchTypeOf<TableSchema>();
 

--- a/packages/zero-solid/src/solid-view.test.ts
+++ b/packages/zero-solid/src/solid-view.test.ts
@@ -110,12 +110,14 @@ test('queryComplete promise', async () => {
 });
 
 const schema = createSchema(1, {
-  test: table('test')
-    .columns({
-      a: number(),
-      b: string(),
-    })
-    .primaryKey('a'),
+  tables: [
+    table('test')
+      .columns({
+        a: number(),
+        b: string(),
+      })
+      .primaryKey('a'),
+  ],
 });
 
 type TestReturn = {

--- a/packages/zero-solid/src/use-query.test.ts
+++ b/packages/zero-solid/src/use-query.test.ts
@@ -11,12 +11,14 @@ import {number, string, table} from '../../zero-client/src/mod.js';
 
 function setupTestEnvironment() {
   const schema = createSchema(1, {
-    table: table('table')
-      .columns({
-        a: number(),
-        b: string(),
-      })
-      .primaryKey('a'),
+    tables: [
+      table('table')
+        .columns({
+          a: number(),
+          b: string(),
+        })
+        .primaryKey('a'),
+    ],
   });
   const ms = new MemorySource(
     schema.tables.table.name,

--- a/packages/zql/src/query/query-impl.query.test.ts
+++ b/packages/zql/src/query/query-impl.query.test.ts
@@ -1019,14 +1019,10 @@ test('join with compound keys', () => {
     }),
   }));
 
-  const schema = createSchema(
-    1,
-    {
-      a,
-      b,
-    },
-    {aRelationships},
-  );
+  const schema = createSchema(1, {
+    tables: [a, b],
+    relationships: [aRelationships],
+  });
 
   const sources = {
     a: createSource('a', schema.tables.a.columns, schema.tables.a.primaryKey),

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -314,7 +314,12 @@ export abstract class AbstractQuery<
     let cond: Condition;
 
     if (typeof fieldOrExpressionFactory === 'function') {
-      cond = fieldOrExpressionFactory(new ExpressionBuilder(this._exists));
+      cond = fieldOrExpressionFactory(
+        new ExpressionBuilder(this._exists) as ExpressionBuilder<
+          TSchema,
+          TTable
+        >,
+      );
     } else {
       assert(opOrValue !== undefined, 'Invalid condition');
       cond = cmp(fieldOrExpressionFactory, opOrValue, value);

--- a/packages/zql/src/query/query.test.ts
+++ b/packages/zql/src/query/query.test.ts
@@ -164,23 +164,22 @@ const testWithMoreRelationshipsRelationships = relationships(
   }),
 );
 
-const schema = createSchema(
-  1,
-  {
+const schema = createSchema(1, {
+  tables: [
     testSchema,
     schemaWithEnums,
     schemaWithJson,
     schemaWithAdvancedTypes,
     testWithRelationships,
     testWithMoreRelationships,
-  },
-  {
+  ],
+  relationships: [
     testWithRelationshipsRelationships,
     testWithMoreRelationshipsRelationships,
     withAdvancedTypesRelationships,
     schemaWithEnumsRelationships,
-  },
-);
+  ],
+});
 
 type Schema = typeof schema;
 type SchemaWithEnums = Schema['tables']['testWithEnums'];
@@ -599,16 +598,10 @@ describe('schema structure', () => {
       }),
     }));
 
-    const schema = createSchema(
-      1,
-      {
-        comment,
-        issue,
-      },
-      {
-        issueRelationships,
-      },
-    );
+    const schema = createSchema(1, {
+      tables: [comment, issue],
+      relationships: [issueRelationships],
+    });
 
     takeSchema(schema.tables.issue);
   });
@@ -651,11 +644,10 @@ describe('schema structure', () => {
       }),
     }));
 
-    const schema = createSchema(
-      1,
-      {issue, comment},
-      {issueRelationships, commentRelationships},
-    );
+    const schema = createSchema(1, {
+      tables: [issue, comment],
+      relationships: [issueRelationships, commentRelationships],
+    });
     takeSchema(schema.tables.issue);
   });
 });

--- a/packages/zql/src/query/test/test-schemas.ts
+++ b/packages/zql/src/query/test/test-schemas.ts
@@ -142,24 +142,16 @@ const labelRelationships = relationships(label, ({many}) => ({
   ),
 }));
 
-export const schema = createSchema(
-  1,
-  {
-    issue,
-    user,
-    comment,
-    revision,
-    label,
-    issueLabel,
-  },
-  {
+export const schema = createSchema(1, {
+  tables: [issue, user, comment, revision, label, issueLabel],
+  relationships: [
     issueRelationships,
     userRelationships,
     commentRelationships,
     revisionRelationships,
     labelRelationships,
-  },
-);
+  ],
+});
 
 export const issueSchema = schema.tables.issue;
 export const commentSchema = schema.tables.comment;


### PR DESCRIPTION
Uses:

```ts
{
  [K in TTables[number]['schema']['name']]: ...
}
```

to pull unique names from array members to use as object keys.

And then

```ts
Extract<
      TTables[number]['schema'],
      {name: K}
    >
```

to pull the corresponding value type with the given name from the array.