### PR TITLE
chore(zero-cache): improve error message for unknown/unsynced columns

### DIFF
--- a/packages/zqlite/src/table-source.ts
+++ b/packages/zqlite/src/table-source.ts
@@ -797,7 +797,9 @@ export function fromSQLiteTypes(
     const valueType = valueTypes[key];
     if (valueType === undefined) {
       throw new Error(
-        `Postgres is missing the column "${key}" but that column was part of a row.`,
+        `Invalid column "${key}". Synced columns include ${Object.keys(
+          valueTypes,
+        ).sort()}`,
       );
     }
     newRow[key] = fromSQLiteType(valueType.type, row[key]);


### PR DESCRIPTION
Improve the error message when an unknown columns is encountered in IVM / write authorizer, use the term "synced columns" instead of "Postgres" to be more specific about what the column is missing from.

https://discord.com/channels/830183651022471199/830183651022471202/1330784397439406171