### PR TITLE
chore(zero-cache): improve error message for insufficient connections

### DIFF
--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -51,12 +51,14 @@ export default async function runWorker(
 
   if (config.upstream.maxConns < numSyncers) {
     throw new Error(
-      `insufficient upstream connections (${config.upstream.maxConns}) for ${numSyncers} syncers`,
+      `Insufficient upstream connections (${config.upstream.maxConns}) for ${numSyncers} syncers.` +
+        `Increase ZERO_UPSTREAM_MAX_CONNS or decrease ZERO_NUM_SYNC_WORKERS (which defaults to available cores).`,
     );
   }
   if (config.cvr.maxConns < numSyncers) {
     throw new Error(
-      `insufficient cvr connections (${config.cvr.maxConns}) for ${numSyncers} syncers`,
+      `Insufficient cvr connections (${config.cvr.maxConns}) for ${numSyncers} syncers.` +
+        `Increase ZERO_CVR_MAX_CONNS or decrease ZERO_NUM_SYNC_WORKERS (which defaults to available cores).`,
     );
   }
 


### PR DESCRIPTION
Include a prescriptive fix when the number of sync workers exceeds the configured maximum connections.

https://discord.com/channels/830183651022471199/1288232858795769917/1329693875702599721