### PR TITLE
fix(replicache): Wrap persist in a lock.

### DIFF
--- a/packages/zero-client/src/client/zero.bench.ts
+++ b/packages/zero-client/src/client/zero.bench.ts
@@ -1,6 +1,5 @@
 import {resolver} from '@rocicorp/resolver';
 import {bench, describe, expect} from 'vitest';
-import {sleep} from '../../../shared/src/sleep.js';
 import type {Row} from '../../../zql/src/query/query.js';
 import {getInternalReplicacheImplForTesting, Zero} from './zero.js';
 
@@ -44,7 +43,6 @@ async function withZero(
   });
   await f(z);
   if (persist) {
-    await sleep(500);
     await getInternalReplicacheImplForTesting(z).persist();
   }
   await z.close();


### PR DESCRIPTION
This was triggered in the zero perf benchmark which calls persist. Sometimes this call got overlapped with the scheduled persist call which raised the assert.

Instead of asserting in this condition we wait until the current persist operation is done.