### PR TITLE
fix(zero): Add missing type exports

### DIFF
--- a/packages/zero-client/src/mod.ts
+++ b/packages/zero-client/src/mod.ts
@@ -57,25 +57,60 @@ export type {
   VersionNotSupportedResponse,
   WriteTransaction,
 } from '../../replicache/src/mod.js';
+export type {
+  AST,
+  Bound,
+  ColumnReference,
+  CompoundKey,
+  Condition,
+  Conjunction,
+  CorrelatedSubquery,
+  CorrelatedSubqueryCondition,
+  CorrelatedSubqueryConditionOperator,
+  Disjunction,
+  EqualityOps,
+  InOps,
+  LikeOps,
+  LiteralReference,
+  LiteralValue,
+  Ordering,
+  OrderOps,
+  OrderPart,
+  Parameter,
+  SimpleCondition,
+  SimpleOperator,
+  ValuePosition,
+} from '../../zero-protocol/src/ast.js';
+export {relationships} from '../../zero-schema/src/builder/relationship-builder.js';
+export {
+  createSchema,
+  type Schema,
+} from '../../zero-schema/src/builder/schema-builder.js';
+export {
+  boolean,
+  enumeration,
+  json,
+  number,
+  string,
+  table,
+} from '../../zero-schema/src/builder/table-builder.js';
+export type {
+  AssetPermissions as CompiledAssetPermissions,
+  PermissionsConfig as CompiledPermissionsConfig,
+  Policy as CompiledPermissionsPolicy,
+  Rule as CompiledPermissionsRule,
+} from '../../zero-schema/src/compiled-permissions.js';
 export {
   ANYONE_CAN,
   definePermissions,
   NOBODY_CAN,
 } from '../../zero-schema/src/permissions.js';
-export {
-  createSchema,
-  type Schema,
-} from '../../zero-schema/src/builder/schema-builder.js';
+export type {
+  AssetPermissions,
+  PermissionRule,
+  PermissionsConfig,
+} from '../../zero-schema/src/permissions.js';
 export {type TableSchema} from '../../zero-schema/src/table-schema.js';
-export {
-  table,
-  string,
-  number,
-  boolean,
-  enumeration,
-  json,
-} from '../../zero-schema/src/builder/table-builder.js';
-export {relationships} from '../../zero-schema/src/builder/relationship-builder.js';
 export {escapeLike} from '../../zql/src/query/escape-like.js';
 export type {
   ExpressionBuilder,

--- a/packages/zero-protocol/src/ast.ts
+++ b/packages/zero-protocol/src/ast.ts
@@ -241,7 +241,7 @@ export type ColumnReference = {
   readonly name: string;
 };
 
-type LiteralReference = {
+export type LiteralReference = {
   readonly type: 'literal';
   readonly value: LiteralValue;
 };
@@ -298,11 +298,11 @@ export type CorrelatedSubqueryConditionOperator = 'EXISTS' | 'NOT EXISTS';
  * A parameter is a value that is not known at the time the query is written
  * and is resolved at runtime.
  *
- * StaticParameters refer to something provided by the caller.
- * StaticParameters are injected when the query pipeline is built from the AST
+ * Static parameters refer to something provided by the caller.
+ * Static parameters are injected when the query pipeline is built from the AST
  * and do not change for the life of that pipeline.
  *
- * An example StaticParameter is the current authentication data.
+ * An example static parameter is the current authentication data.
  * When a user is authenticated, queries on the server have access
  * to the user's authentication data in order to evaluate authorization rules.
  * Authentication data doesn't change over the life of a query as a change
@@ -311,9 +311,7 @@ export type CorrelatedSubqueryConditionOperator = 'EXISTS' | 'NOT EXISTS';
  * AncestorParameters refer to rows encountered while running the query.
  * They are used by subqueries to refer to rows emitted by parent queries.
  */
-export type Parameter = StaticParameter;
-
-type StaticParameter = {
+export type Parameter = {
   readonly type: 'static';
   // The "namespace" of the injected parameter.
   // Write authorization will send the value of a row

--- a/packages/zero-schema/src/permissions.ts
+++ b/packages/zero-schema/src/permissions.ts
@@ -1,17 +1,17 @@
-import type {Query} from '../../zql/src/query/query.js';
-import type {
-  AssetPermissions as CompiledAssetPermissions,
-  PermissionsConfig as CompiledPermissionsConfig,
-} from './compiled-permissions.js';
-import {AuthQuery} from '../../zql/src/query/auth-query.js';
+import {assert} from '../../shared/src/asserts.js';
 import {
   toStaticParam,
   type Condition,
   type Parameter,
 } from '../../zero-protocol/src/ast.js';
-import {staticParam} from '../../zql/src/query/query-impl.js';
+import {AuthQuery} from '../../zql/src/query/auth-query.js';
 import type {ExpressionBuilder} from '../../zql/src/query/expression.js';
-import {assert} from '../../shared/src/asserts.js';
+import {staticParam} from '../../zql/src/query/query-impl.js';
+import type {Query} from '../../zql/src/query/query.js';
+import type {
+  AssetPermissions as CompiledAssetPermissions,
+  PermissionsConfig as CompiledPermissionsConfig,
+} from './compiled-permissions.js';
 import type {Schema} from './mod.js';
 
 export const ANYONE_CAN = undefined;
@@ -22,7 +22,7 @@ export type Queries<TSchema extends Schema> = {
   [K in keyof TSchema['tables']]: Query<Schema, K & string>;
 };
 
-type PermissionRule<
+export type PermissionRule<
   TAuthDataShape,
   TSchema extends Schema,
   TTable extends keyof TSchema['tables'] & string,
@@ -31,7 +31,7 @@ type PermissionRule<
   eb: ExpressionBuilder<TSchema, TTable>,
 ) => Condition;
 
-type AssetPermissions<
+export type AssetPermissions<
   TAuthDataShape,
   TSchema extends Schema,
   TTable extends keyof TSchema['tables'] & string,


### PR DESCRIPTION
https://bugs.rocicorp.dev/issue/3459

When a library imports `@rocicorp/zero` and uses `definePermission`, and the library has a `tsconfig.json` that includes `declaration: true`, then tsc complains that it cannot infer the type:

```
The inferred type of 'permissions' cannot be named without a reference
to '../node_modules/@rocicorp/zero/out/zero-protocol/src/ast'. This is
likely not portable. A type annotation is necessary.
```

The reason is that `definePermission` has a dependency on the `Condition` type from `ast.ts` from `zero-protocol`, but that file is never loaded by tsc so it does not know about this type.

The solution is to export a type dependency from `ast.ts`. That way `tsc` is happy.

However, to be less magic we now export all the **transitive** dependencies of `definePermission`. This leads to us eventually exporting `AST` etc from `ast.ts`. This is not ideal. I didn't want us to have to commit to the shape of the AST but we are already making it accessible to the outside world via `definePermission` (even though it was not very straight forward to get to it before).