### PR TITLE
feat(zero-react): delay unsubscribing queries

### DIFF
--- a/packages/zero-react/package.json
+++ b/packages/zero-react/package.json
@@ -6,7 +6,8 @@
   "module": "true",
   "scripts": {
     "check-types": "tsc",
-    "check-types:watch": "tsc --watch"
+    "check-types:watch": "tsc --watch",
+    "test": "vitest run"
   },
   "peerDependencies": {
     "react": "^18.3.1"

--- a/packages/zero-react/package.json
+++ b/packages/zero-react/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "check-types": "tsc",
     "check-types:watch": "tsc --watch",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:watch": "vitest watch"
   },
   "peerDependencies": {
     "react": "^18.3.1"

--- a/packages/zero-react/src/use-query.test.ts
+++ b/packages/zero-react/src/use-query.test.ts
@@ -1,24 +1,34 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {beforeEach, describe, expect, test, vi} from 'vitest';
-import {getAllViews, ViewStore} from './use-query.js';
 import type {AdvancedQuery} from '../../zql/src/query/query-internal.js';
+import type {ResultType} from '../../zql/src/query/typed-view.js';
+import {getAllViewsSizeForTesting, ViewStore} from './use-query.js';
 
-function newMockQuery(query: string): AdvancedQuery<any, any> {
+function newMockQuery(
+  query: string,
+  singular = false,
+): AdvancedQuery<any, any> {
+  const view = newView();
   return {
     hash() {
       return query;
     },
     materialize() {
-      return newView();
+      return view;
     },
-    format: {singular: false},
+    format: {singular},
   } as unknown as AdvancedQuery<any, any>;
 }
 
 function newView() {
   return {
-    addListener(_cb: () => void) {},
-    destroy() {},
+    listeners: new Set<() => void>(),
+    addListener(cb: () => void) {
+      this.listeners.add(cb);
+    },
+    destroy() {
+      this.listeners.clear();
+    },
   };
 }
 
@@ -36,7 +46,7 @@ describe('ViewStore', () => {
 
       expect(view1).toBe(view2);
 
-      expect(viewStore[getAllViews]().size).toBe(1);
+      expect(getAllViewsSizeForTesting(viewStore)).toBe(1);
     });
 
     test('removing a duplicate query does not destroy the shared view', () => {
@@ -52,7 +62,7 @@ describe('ViewStore', () => {
 
       vi.advanceTimersByTime(100);
 
-      expect(viewStore[getAllViews]().size).toBe(1);
+      expect(getAllViewsSizeForTesting(viewStore)).toBe(1);
     });
   });
 
@@ -71,7 +81,7 @@ describe('ViewStore', () => {
 
       vi.advanceTimersByTime(100);
 
-      expect(viewStore[getAllViews]().size).toBe(0);
+      expect(getAllViewsSizeForTesting(viewStore)).toBe(0);
     });
 
     test('removing a unique query destroys the view', () => {
@@ -83,7 +93,7 @@ describe('ViewStore', () => {
       cleanup();
 
       vi.advanceTimersByTime(100);
-      expect(viewStore[getAllViews]().size).toBe(0);
+      expect(getAllViewsSizeForTesting(viewStore)).toBe(0);
     });
 
     test('view destruction is delayed via setTimeout', () => {
@@ -95,10 +105,10 @@ describe('ViewStore', () => {
       cleanup();
 
       vi.advanceTimersByTime(5);
-      expect(viewStore[getAllViews]().size).toBe(1);
+      expect(getAllViewsSizeForTesting(viewStore)).toBe(1);
       vi.advanceTimersByTime(10);
 
-      expect(viewStore[getAllViews]().size).toBe(0);
+      expect(getAllViewsSizeForTesting(viewStore)).toBe(0);
     });
 
     test('subscribing to a view scheduled for cleanup prevents the cleanup', () => {
@@ -108,21 +118,21 @@ describe('ViewStore', () => {
 
       cleanup();
 
-      expect(viewStore[getAllViews]().size).toBe(1);
+      expect(getAllViewsSizeForTesting(viewStore)).toBe(1);
       vi.advanceTimersByTime(5);
-      expect(viewStore[getAllViews]().size).toBe(1);
+      expect(getAllViewsSizeForTesting(viewStore)).toBe(1);
 
       const view2 = viewStore.getView('client1', newMockQuery('query1'), true);
       const cleanup2 = view.subscribeReactInternals(() => {});
       vi.advanceTimersByTime(100);
 
-      expect(viewStore[getAllViews]().size).toBe(1);
+      expect(getAllViewsSizeForTesting(viewStore)).toBe(1);
 
       expect(view2).toBe(view);
 
       cleanup2();
       vi.advanceTimersByTime(100);
-      expect(viewStore[getAllViews]().size).toBe(0);
+      expect(getAllViewsSizeForTesting(viewStore)).toBe(0);
     });
 
     test('destroying the same underlying view twice is a no-op', () => {
@@ -134,7 +144,7 @@ describe('ViewStore', () => {
       cleanup();
 
       vi.advanceTimersByTime(100);
-      expect(viewStore[getAllViews]().size).toBe(0);
+      expect(getAllViewsSizeForTesting(viewStore)).toBe(0);
     });
   });
 
@@ -146,6 +156,77 @@ describe('ViewStore', () => {
       const view2 = viewStore.getView('client2', newMockQuery('query1'), true);
 
       expect(view1).not.toBe(view2);
+    });
+  });
+
+  describe('collapse multiple empty on data', () => {
+    test('plural', () => {
+      const viewStore = new ViewStore();
+      const q = newMockQuery('query1');
+      const {listeners} = q.materialize() as unknown as {
+        listeners: Set<(data: unknown, resultType: ResultType) => void>;
+      };
+      const view = viewStore.getView('client1', q, true);
+
+      const cleanup = view.subscribeReactInternals(() => {});
+
+      listeners.forEach(cb => cb([], 'unknown'));
+
+      const snapshot1 = view.getSnapshot();
+
+      listeners.forEach(cb => cb([], 'unknown'));
+
+      const snapshot2 = view.getSnapshot();
+
+      expect(snapshot1).toBe(snapshot2);
+
+      listeners.forEach(cb => cb([{a: 1}], 'unknown'));
+
+      // TODO: Assert that data[0] is the same object as passed into the listener.
+      expect(view.getSnapshot()).toEqual([[{a: 1}], {type: 'unknown'}]);
+
+      listeners.forEach(cb => cb([], 'complete'));
+      const snapshot3 = view.getSnapshot();
+      expect(snapshot3).toEqual([[], {type: 'complete'}]);
+
+      listeners.forEach(cb => cb([], 'complete'));
+      const snapshot4 = view.getSnapshot();
+      expect(snapshot3).toBe(snapshot4);
+
+      cleanup();
+    });
+
+    test('singular', () => {
+      const viewStore = new ViewStore();
+      const q = newMockQuery('query1', true);
+      const {listeners} = q.materialize() as unknown as {
+        listeners: Set<(...args: unknown[]) => void>;
+      };
+      const view = viewStore.getView('client1', q, true);
+
+      const cleanup = view.subscribeReactInternals(() => {});
+
+      listeners.forEach(cb => cb(undefined, 'unknown'));
+      const snapshot1 = view.getSnapshot();
+      expect(snapshot1).toEqual([undefined, {type: 'unknown'}]);
+
+      listeners.forEach(cb => cb(undefined, 'unknown'));
+      const snapshot2 = view.getSnapshot();
+      expect(snapshot1).toBe(snapshot2);
+
+      listeners.forEach(cb => cb({a: 1}, 'unknown'));
+      // TODO: Assert that data is the same object as passed into the listener.
+      expect(view.getSnapshot()).toEqual([{a: 1}, {type: 'unknown'}]);
+
+      listeners.forEach(cb => cb(undefined, 'complete'));
+      const snapshot3 = view.getSnapshot();
+      expect(snapshot3).toEqual([undefined, {type: 'complete'}]);
+
+      listeners.forEach(cb => cb(undefined, 'complete'));
+      const snapshot4 = view.getSnapshot();
+      expect(snapshot3).toBe(snapshot4);
+
+      cleanup();
     });
   });
 });

--- a/packages/zero-react/src/use-query.test.ts
+++ b/packages/zero-react/src/use-query.test.ts
@@ -1,0 +1,151 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {beforeEach, describe, expect, test, vi} from 'vitest';
+import {getAllViews, ViewStore} from './use-query.js';
+import type {AdvancedQuery} from '../../zql/src/query/query-internal.js';
+
+function newMockQuery(query: string): AdvancedQuery<any, any> {
+  return {
+    hash() {
+      return query;
+    },
+    materialize() {
+      return newView();
+    },
+    format: {singular: false},
+  } as unknown as AdvancedQuery<any, any>;
+}
+
+function newView() {
+  return {
+    addListener(_cb: () => void) {},
+    destroy() {},
+  };
+}
+
+describe('ViewStore', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  describe('duplicate queries', () => {
+    test('duplicate queries do not create duplicate views', () => {
+      const viewStore = new ViewStore();
+
+      const view1 = viewStore.getView('client1', newMockQuery('query1'), true);
+      const view2 = viewStore.getView('client1', newMockQuery('query1'), true);
+
+      expect(view1).toBe(view2);
+
+      expect(viewStore[getAllViews]().size).toBe(1);
+    });
+
+    test('removing a duplicate query does not destroy the shared view', () => {
+      const viewStore = new ViewStore();
+
+      const view1 = viewStore.getView('client1', newMockQuery('query1'), true);
+      const view2 = viewStore.getView('client1', newMockQuery('query1'), true);
+
+      const cleanup1 = view1.subscribeReactInternals(() => {});
+      view2.subscribeReactInternals(() => {});
+
+      cleanup1();
+
+      vi.advanceTimersByTime(100);
+
+      expect(viewStore[getAllViews]().size).toBe(1);
+    });
+  });
+
+  describe('destruction', () => {
+    test('removing all duplicate queries destroys the shared view', () => {
+      const viewStore = new ViewStore();
+
+      const view1 = viewStore.getView('client1', newMockQuery('query1'), true);
+      const view2 = viewStore.getView('client1', newMockQuery('query1'), true);
+
+      const cleanup1 = view1.subscribeReactInternals(() => {});
+      const cleanup2 = view2.subscribeReactInternals(() => {});
+
+      cleanup1();
+      cleanup2();
+
+      vi.advanceTimersByTime(100);
+
+      expect(viewStore[getAllViews]().size).toBe(0);
+    });
+
+    test('removing a unique query destroys the view', () => {
+      const viewStore = new ViewStore();
+
+      const view = viewStore.getView('client1', newMockQuery('query1'), true);
+
+      const cleanup = view.subscribeReactInternals(() => {});
+      cleanup();
+
+      vi.advanceTimersByTime(100);
+      expect(viewStore[getAllViews]().size).toBe(0);
+    });
+
+    test('view destruction is delayed via setTimeout', () => {
+      const viewStore = new ViewStore();
+
+      const view = viewStore.getView('client1', newMockQuery('query1'), true);
+
+      const cleanup = view.subscribeReactInternals(() => {});
+      cleanup();
+
+      vi.advanceTimersByTime(5);
+      expect(viewStore[getAllViews]().size).toBe(1);
+      vi.advanceTimersByTime(10);
+
+      expect(viewStore[getAllViews]().size).toBe(0);
+    });
+
+    test('subscribing to a view scheduled for cleanup prevents the cleanup', () => {
+      const viewStore = new ViewStore();
+      const view = viewStore.getView('client1', newMockQuery('query1'), true);
+      const cleanup = view.subscribeReactInternals(() => {});
+
+      cleanup();
+
+      expect(viewStore[getAllViews]().size).toBe(1);
+      vi.advanceTimersByTime(5);
+      expect(viewStore[getAllViews]().size).toBe(1);
+
+      const view2 = viewStore.getView('client1', newMockQuery('query1'), true);
+      const cleanup2 = view.subscribeReactInternals(() => {});
+      vi.advanceTimersByTime(100);
+
+      expect(viewStore[getAllViews]().size).toBe(1);
+
+      expect(view2).toBe(view);
+
+      cleanup2();
+      vi.advanceTimersByTime(100);
+      expect(viewStore[getAllViews]().size).toBe(0);
+    });
+
+    test('destroying the same underlying view twice is a no-op', () => {
+      const viewStore = new ViewStore();
+      const view = viewStore.getView('client1', newMockQuery('query1'), true);
+      const cleanup = view.subscribeReactInternals(() => {});
+
+      cleanup();
+      cleanup();
+
+      vi.advanceTimersByTime(100);
+      expect(viewStore[getAllViews]().size).toBe(0);
+    });
+  });
+
+  describe('clients', () => {
+    test('the same query for different clients results in different views', () => {
+      const viewStore = new ViewStore();
+
+      const view1 = viewStore.getView('client1', newMockQuery('query1'), true);
+      const view2 = viewStore.getView('client2', newMockQuery('query1'), true);
+
+      expect(view1).not.toBe(view2);
+    });
+  });
+});

--- a/packages/zero-react/src/use-query.test.ts
+++ b/packages/zero-react/src/use-query.test.ts
@@ -1,5 +1,5 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import {beforeEach, describe, expect, test, vi} from 'vitest';
+import type {Schema} from '../../zero-schema/src/mod.js';
 import type {AdvancedQuery} from '../../zql/src/query/query-internal.js';
 import type {ResultType} from '../../zql/src/query/typed-view.js';
 import {getAllViewsSizeForTesting, ViewStore} from './use-query.js';
@@ -7,7 +7,7 @@ import {getAllViewsSizeForTesting, ViewStore} from './use-query.js';
 function newMockQuery(
   query: string,
   singular = false,
-): AdvancedQuery<any, any> {
+): AdvancedQuery<Schema, string> {
   const view = newView();
   return {
     hash() {
@@ -17,7 +17,7 @@ function newMockQuery(
       return view;
     },
     format: {singular},
-  } as unknown as AdvancedQuery<any, any>;
+  } as unknown as AdvancedQuery<Schema, string>;
 }
 
 function newView() {

--- a/packages/zero-react/vitest.config.ts
+++ b/packages/zero-react/vitest.config.ts
@@ -1,0 +1,1 @@
+export {default} from '../shared/src/tool/vitest-config.js';


### PR DESCRIPTION
strict mode will mount, unmount, remount a component causing `changeDesiredQueries` to remove the query then re-add it. This creates flickering for users who do not have a preload or covering query higher up in the component hierarchy.

It also creates unnecessary query churn in dev mode.

https://discord.com/channels/830183651022471199/1322102519987572747