### PR TITLE
feat(zero-cache-dev): set lower defaults

### DIFF
--- a/packages/zero/src/zero-cache-dev.ts
+++ b/packages/zero/src/zero-cache-dev.ts
@@ -97,6 +97,15 @@ async function main() {
           `Running ${zeroCacheScript} at\n\n\thttp://localhost:${config.port}\n`,
         );
         zeroCacheProcess = spawn(zeroCacheScript, zeroCacheArgs || [], {
+          env: {
+            // Set some low defaults so as to use fewer resources and not trip up,
+            // e.g. developers sharing a database.
+            ['ZERO_NUM_SYNC_WORKERS']: '3',
+            ['ZERO_CVR_MAX_CONNS']: '6',
+            ['ZERO_UPSTREAM_MAX_CONNS']: '6',
+            // But let the developer override any of these dev defaults.
+            ...process.env,
+          },
           stdio: 'inherit',
           shell: true,
         });


### PR DESCRIPTION
By default, use fewer cores and db connections when running `zero-cache-dev`.

#papercut: https://discord.com/channels/830183651022471199/1288232858795769917/1331403438642434299