### PR TITLE
fix(zero-cache): correctly handle row key changes in CVR updates

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
@@ -3471,8 +3471,8 @@ describe('view-syncer/cvr', () => {
     expect(newVersion).toEqual({stateVersion: '1bb'});
     expect(queryPatches).toHaveLength(0);
 
-    const NEW_ROW_KEY1 = {...ROW_KEY1, newID: '1foo'};
-    const NEW_ROW_KEY3 = {...ROW_KEY3, newID: '3baz'};
+    const NEW_ROW_KEY1 = {newID: '1foo'};
+    const NEW_ROW_KEY3 = {newID: '3baz'};
 
     // NEW_ROW_KEY1 should replace ROW_KEY1
     expect(
@@ -3484,7 +3484,7 @@ describe('view-syncer/cvr', () => {
             {
               version: '03',
               refCounts: {oneHash: 1},
-              contents: {...NEW_ROW_KEY1, value: 'foobar'},
+              contents: {...ROW_KEY1, ...NEW_ROW_KEY1, value: 'foobar'},
             },
           ],
         ]),
@@ -3496,7 +3496,7 @@ describe('view-syncer/cvr', () => {
           type: 'row',
           op: 'put',
           id: {...ROW_ID1, rowKey: NEW_ROW_KEY1},
-          contents: {...NEW_ROW_KEY1, value: 'foobar'},
+          contents: {...ROW_KEY1, ...NEW_ROW_KEY1, value: 'foobar'},
         },
       },
     ] satisfies PatchToVersion[]);
@@ -3511,7 +3511,7 @@ describe('view-syncer/cvr', () => {
             {
               version: '09',
               refCounts: {oneHash: 1},
-              contents: {...NEW_ROW_KEY3, value: 'barfoo'},
+              contents: {...ROW_KEY3, ...NEW_ROW_KEY3, value: 'barfoo'},
             },
           ],
         ]),
@@ -3523,7 +3523,7 @@ describe('view-syncer/cvr', () => {
           type: 'row',
           op: 'put',
           id: {...ROW_ID3, rowKey: NEW_ROW_KEY3},
-          contents: {...NEW_ROW_KEY3, value: 'barfoo'},
+          contents: {...ROW_KEY3, ...NEW_ROW_KEY3, value: 'barfoo'},
         },
       },
     ] satisfies PatchToVersion[]);

--- a/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
@@ -3396,6 +3396,238 @@ describe('view-syncer/cvr', () => {
     // });
   });
 
+  test('row key changed', async () => {
+    const initialState: DBState = {
+      instances: [
+        {
+          clientGroupID: 'abc123',
+          version: '1ba',
+          replicaVersion: '123',
+          lastActive: Date.UTC(2024, 3, 23),
+        },
+      ],
+      clients: [
+        {
+          clientGroupID: 'abc123',
+          clientID: 'fooClient',
+          patchVersion: '1a9:01',
+          deleted: null,
+        },
+      ],
+      queries: [
+        {
+          clientGroupID: 'abc123',
+          queryHash: 'oneHash',
+          clientAST: {table: 'issues'},
+          transformationHash: 'serverOneHash',
+          transformationVersion: '1aa',
+          patchVersion: '1aa:01',
+          internal: null,
+          deleted: null,
+        },
+      ],
+      desires: [
+        {
+          clientGroupID: 'abc123',
+          clientID: 'fooClient',
+          queryHash: 'oneHash',
+          patchVersion: '1a9:01',
+          deleted: null,
+        },
+      ],
+      rows: [
+        {
+          clientGroupID: 'abc123',
+          rowKey: ROW_KEY1,
+          rowVersion: '03',
+          refCounts: {oneHash: 1},
+          patchVersion: '1aa:01',
+          schema: 'public',
+          table: 'issues',
+        },
+        {
+          clientGroupID: 'abc123',
+          rowKey: ROW_KEY2,
+          rowVersion: '03',
+          refCounts: {oneHash: 1},
+          patchVersion: '1a0',
+          schema: 'public',
+          table: 'issues',
+        },
+      ],
+    };
+
+    await setInitialState(db, initialState);
+
+    const cvrStore = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
+    const cvr = await cvrStore.load(lc, LAST_CONNECT);
+    const updater = new CVRQueryDrivenUpdater(cvrStore, cvr, '1bb', '123');
+
+    const {newVersion, queryPatches} = updater.trackQueries(
+      lc,
+      [{id: 'oneHash', transformationHash: 'serverOneHash'}],
+      [],
+    );
+    expect(newVersion).toEqual({stateVersion: '1bb'});
+    expect(queryPatches).toHaveLength(0);
+
+    const NEW_ROW_KEY1 = {...ROW_KEY1, newID: '1foo'};
+    const NEW_ROW_KEY3 = {...ROW_KEY3, newID: '3baz'};
+
+    // NEW_ROW_KEY1 should replace ROW_KEY1
+    expect(
+      await updater.received(
+        lc,
+        new Map([
+          [
+            {...ROW_ID1, rowKey: NEW_ROW_KEY1},
+            {
+              version: '03',
+              refCounts: {oneHash: 1},
+              contents: {...NEW_ROW_KEY1, value: 'foobar'},
+            },
+          ],
+        ]),
+      ),
+    ).toEqual([
+      {
+        toVersion: {stateVersion: '1aa', minorVersion: 1},
+        patch: {
+          type: 'row',
+          op: 'put',
+          id: {...ROW_ID1, rowKey: NEW_ROW_KEY1},
+          contents: {...NEW_ROW_KEY1, value: 'foobar'},
+        },
+      },
+    ] satisfies PatchToVersion[]);
+
+    // NEW_ROW_KEY3 is new to this CVR.
+    expect(
+      await updater.received(
+        lc,
+        new Map([
+          [
+            {...ROW_ID3, rowKey: NEW_ROW_KEY3},
+            {
+              version: '09',
+              refCounts: {oneHash: 1},
+              contents: {...NEW_ROW_KEY3, value: 'barfoo'},
+            },
+          ],
+        ]),
+      ),
+    ).toEqual([
+      {
+        toVersion: newVersion,
+        patch: {
+          type: 'row',
+          op: 'put',
+          id: {...ROW_ID3, rowKey: NEW_ROW_KEY3},
+          contents: {...NEW_ROW_KEY3, value: 'barfoo'},
+        },
+      },
+    ] satisfies PatchToVersion[]);
+
+    // Note: ROW_ID2 was not received so it is deleted.
+    // ROW_ID1, on the other hand was recognized with the NEW_ROW_KEY1
+    // and so it is not deleted.
+    expect(await updater.deleteUnreferencedRows()).toEqual([
+      {
+        patch: {type: 'row', op: 'del', id: ROW_ID2},
+        toVersion: newVersion,
+      },
+    ] satisfies PatchToVersion[]);
+
+    const {cvr: updated, stats} = await updater.flush(
+      lc,
+      LAST_CONNECT,
+      Date.UTC(2024, 3, 23, 1),
+    );
+    expect(stats).toMatchInlineSnapshot(`
+      {
+        "clients": 0,
+        "desires": 0,
+        "instances": 2,
+        "queries": 0,
+        "rows": 4,
+        "rowsDeferred": 0,
+        "statements": 5,
+      }
+    `);
+
+    // Verify round tripping.
+    const doCVRStore2 = new CVRStore(lc, db, 'my-task', 'abc123', ON_FAILURE);
+    const reloaded = await doCVRStore2.load(lc, LAST_CONNECT);
+    expect(reloaded).toEqual(updated);
+
+    await expectState(db, {
+      instances: [
+        {
+          clientGroupID: 'abc123',
+          lastActive: new Date('2024-04-23T01:00:00Z').getTime(),
+          version: '1bb',
+          replicaVersion: '123',
+          owner: 'my-task',
+          grantedAt: 1709251200000,
+        },
+      ],
+      clients: initialState.clients,
+      queries: [
+        {
+          clientAST: {
+            table: 'issues',
+          },
+          clientGroupID: 'abc123',
+          deleted: null,
+          internal: null,
+          patchVersion: '1aa:01',
+          queryHash: 'oneHash',
+          transformationHash: 'serverOneHash',
+          transformationVersion: '1aa',
+        },
+      ],
+      desires: [
+        {
+          clientGroupID: 'abc123',
+          clientID: 'fooClient',
+          deleted: null,
+          patchVersion: '1a9:01',
+          queryHash: 'oneHash',
+        },
+      ],
+      rows: [
+        // Note: All the state from the previous ROW_KEY1 remains.
+        {
+          clientGroupID: 'abc123',
+          patchVersion: '1aa:01',
+          refCounts: {oneHash: 1},
+          rowKey: NEW_ROW_KEY1,
+          rowVersion: '03',
+          schema: 'public',
+          table: 'issues',
+        },
+        {
+          clientGroupID: 'abc123',
+          patchVersion: '1bb',
+          refCounts: null, // Deleted
+          rowKey: ROW_KEY2,
+          rowVersion: '03',
+          schema: 'public',
+          table: 'issues',
+        },
+        {
+          clientGroupID: 'abc123',
+          patchVersion: '1bb',
+          refCounts: {oneHash: 1},
+          rowKey: NEW_ROW_KEY3,
+          rowVersion: '09',
+          schema: 'public',
+          table: 'issues',
+        },
+      ],
+    });
+  });
+
   test('advance with delete that cancels out add', async () => {
     const initialState: DBState = {
       instances: [

--- a/packages/zero-cache/src/services/view-syncer/key-columns.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/key-columns.test.ts
@@ -1,0 +1,135 @@
+import {describe, expect, test} from 'vitest';
+import {KeyColumns} from './key-columns.js';
+import type {RowID, RowRecord} from './schema/types.js';
+
+describe('key columns', () => {
+  function rowRecord(rowID: RowID): RowRecord {
+    return {
+      id: rowID,
+      refCounts: null,
+      rowVersion: '01',
+      patchVersion: {stateVersion: '01'},
+    };
+  }
+
+  const cvrRows: RowRecord[] = [
+    rowRecord({
+      schema: 'public',
+      table: 'user',
+      rowKey: {id: 'foo'},
+    }),
+    rowRecord({
+      schema: 'public',
+      table: 'user',
+      rowKey: {id: 'bar'},
+    }),
+    rowRecord({
+      schema: 'public',
+      table: 'issueLabel',
+      rowKey: {issueID: 'bar', labelID: 'rab'},
+    }),
+  ];
+
+  test('no change in key', () => {
+    const keyColumns = new KeyColumns(cvrRows);
+    expect(
+      keyColumns.getOldRowID(
+        {
+          schema: 'public',
+          table: 'user',
+          rowKey: {id: 'boo'},
+        },
+        {id: 'boo', value: 'zoo'},
+      ),
+    ).toBeNull();
+
+    expect(
+      keyColumns.getOldRowID(
+        {
+          schema: 'public',
+          table: 'user',
+          rowKey: {id: 'doo'},
+        },
+        {id: 'doo', value: 'foo'},
+      ),
+    ).toBeNull();
+
+    expect(
+      keyColumns.getOldRowID(
+        {
+          schema: 'public',
+          table: 'issueLabel',
+          rowKey: {labelID: 'order', issueID: 'agnostic'},
+        },
+        {labelID: 'order', issueID: 'agnostic', value: 'foo'},
+      ),
+    ).toBeNull();
+  });
+
+  test('expanded key', () => {
+    const keyColumns = new KeyColumns(cvrRows);
+    expect(
+      keyColumns.getOldRowID(
+        {
+          schema: 'public',
+          table: 'user',
+          rowKey: {id: 'boo', username: 'blue'},
+        },
+        {id: 'boo', username: 'blue', value: 'zoo'},
+      ),
+    ).toEqual({
+      schema: 'public',
+      table: 'user',
+      rowKey: {id: 'boo'},
+    });
+
+    expect(
+      keyColumns.getOldRowID(
+        {
+          schema: 'public',
+          table: 'user',
+          rowKey: {id: 'doo', username: 'oof'},
+        },
+        {id: 'doo', username: 'oof', value: 'foo'},
+      ),
+    ).toEqual({
+      schema: 'public',
+      table: 'user',
+      rowKey: {id: 'doo'},
+    });
+  });
+
+  test('completely different key', () => {
+    const keyColumns = new KeyColumns(cvrRows);
+    expect(
+      keyColumns.getOldRowID(
+        {
+          schema: 'public',
+          table: 'issueLabel',
+          rowKey: {id: 'single-key'},
+        },
+        {id: 'single-key', issueID: 'legacy', labelID: 'key'},
+      ),
+    ).toEqual({
+      schema: 'public',
+      table: 'issueLabel',
+      rowKey: {issueID: 'legacy', labelID: 'key'},
+    });
+  });
+
+  test('old key with non-existent column', () => {
+    const keyColumns = new KeyColumns(cvrRows);
+    expect(() =>
+      keyColumns.getOldRowID(
+        {
+          schema: 'public',
+          table: 'issueLabel',
+          rowKey: {id: 'single-key'},
+        },
+        {id: 'single-key', no: 'compound', key: 'here'},
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: {"kind":"ClientNotFound","message":"CVR contains key column \\"issueID\\" that is no longer in the replica"}]`,
+    );
+  });
+});

--- a/packages/zero-cache/src/services/view-syncer/key-columns.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/key-columns.test.ts
@@ -66,6 +66,20 @@ describe('key columns', () => {
     ).toBeNull();
   });
 
+  test('no rows for table', () => {
+    const keyColumns = new KeyColumns(cvrRows);
+    expect(
+      keyColumns.getOldRowID(
+        {
+          schema: 'public',
+          table: 'emoji',
+          rowKey: {id: 'roo'},
+        },
+        {id: 'roo', value: 'woo'},
+      ),
+    ).toBeNull();
+  });
+
   test('expanded key', () => {
     const keyColumns = new KeyColumns(cvrRows);
     expect(

--- a/packages/zero-cache/src/services/view-syncer/key-columns.ts
+++ b/packages/zero-cache/src/services/view-syncer/key-columns.ts
@@ -1,0 +1,79 @@
+import {deepEqual} from '../../../../shared/src/json.js';
+import * as ErrorKind from '../../../../zero-protocol/src/error-kind-enum.js';
+import type {JSONObject} from '../../types/bigint-json.js';
+import {ErrorForClient} from '../../types/error-for-client.js';
+import type {RowID, RowRecord} from './schema/types.js';
+
+/**
+ * KeyColumns track the key columns used to reference rows in the CVR.
+ * This is then used to potentially compute a backwards compatible row
+ * key in the event that pipelines produce a row with a schema that has
+ * a different row key.
+ *
+ * An invariant that is assumed and maintained is that only one key
+ * (i.e. set of columns) is used per table in a given CVR
+ * (not counting deleted rows with non-null refCounts).
+ *
+ * This invariant is maintained by the fact that a full hydration
+ * (and thus full CVR scan) always follows any schema change:
+ * (1) initial hydration when the client connects
+ * (2) re-hydration after upon a receiving ResetPipelinesSignal during an
+ *     advancement (i.e. schema change)
+ *
+ * The ensuing CVR update is then responsible for replacing or deleting
+ * all obsolete row keys.
+ */
+export class KeyColumns {
+  readonly #cvrKeyColumns = new Map<string, readonly string[]>();
+  readonly #sameKey = new Map<string, boolean>();
+
+  constructor(allRowRecords: Iterable<RowRecord>) {
+    for (const existing of allRowRecords) {
+      const {schema, table, rowKey} = existing.id;
+      const fullTableName = `${schema}.${table}`;
+      if (!this.#cvrKeyColumns.has(fullTableName)) {
+        this.#cvrKeyColumns.set(fullTableName, Object.keys(rowKey).sort());
+      }
+    }
+  }
+
+  /**
+   * Gets an "old" RowID (i.e. compatible with what's in the CVR) from the
+   * given `id` and `row` produced by the pipeline. Returns `null` if there
+   * is no old row being replaced.
+   */
+  getOldRowID(id: RowID, row: JSONObject): RowID | null {
+    const {schema, table, rowKey} = id;
+    const fullTableName = `${schema}.${table}`;
+    if (this.#sameKey.get(fullTableName)) {
+      return null;
+    }
+    const cvrKey = this.#cvrKeyColumns.get(fullTableName);
+    if (!cvrKey) {
+      return null; // No rows in the CVR for the given table.
+    }
+    const newKey = Object.keys(rowKey).sort();
+    if (deepEqual(cvrKey, newKey)) {
+      this.#sameKey.set(fullTableName, true);
+      return null;
+    }
+
+    const cvrRowKey = Object.fromEntries(
+      cvrKey.map(col => {
+        const val = row[col];
+        if (val === undefined) {
+          // If the column used by the row key in the CVR no longer exists in
+          // the replica, this CVR should have ideally been rejected via the
+          // schema versioning mechanism. However, since there is no guarantee
+          // of that protection, this sanity check here drops the CVR entirely.
+          throw new ErrorForClient({
+            kind: ErrorKind.ClientNotFound,
+            message: `CVR contains key column "${col}" that is no longer in the replica`,
+          });
+        }
+        return [col, val];
+      }),
+    );
+    return {...id, rowKey: cvrRowKey};
+  }
+}

--- a/packages/zero-cache/src/services/view-syncer/key-columns.ts
+++ b/packages/zero-cache/src/services/view-syncer/key-columns.ts
@@ -45,19 +45,19 @@ export class KeyColumns {
   getOldRowID(id: RowID, row: JSONObject): RowID | null {
     const {schema, table, rowKey} = id;
     const fullTableName = `${schema}.${table}`;
-    if (this.#sameKey.get(fullTableName)) {
-      return null;
-    }
     const cvrKey = this.#cvrKeyColumns.get(fullTableName);
     if (!cvrKey) {
       return null; // No rows in the CVR for the given table.
     }
-    const newKey = Object.keys(rowKey).sort();
-    if (deepEqual(cvrKey, newKey)) {
-      this.#sameKey.set(fullTableName, true);
+    let sameKey = this.#sameKey.get(fullTableName);
+    if (sameKey === undefined) {
+      const newKey = Object.keys(rowKey).sort();
+      sameKey = deepEqual(cvrKey, newKey);
+      this.#sameKey.set(fullTableName, sameKey);
+    }
+    if (sameKey) {
       return null;
     }
-
     const cvrRowKey = Object.fromEntries(
       cvrKey.map(col => {
         const val = row[col];

--- a/packages/zero-cache/src/services/view-syncer/key-columns.ts
+++ b/packages/zero-cache/src/services/view-syncer/key-columns.ts
@@ -17,7 +17,7 @@ import type {RowID, RowRecord} from './schema/types.js';
  * This invariant is maintained by the fact that a full hydration
  * (and thus full CVR scan) always follows any schema change:
  * (1) initial hydration when the client connects
- * (2) re-hydration after upon a receiving ResetPipelinesSignal during an
+ * (2) re-hydration upon a receiving ResetPipelinesSignal during an
  *     advancement (i.e. schema change)
  *
  * The ensuing CVR update is then responsible for replacing or deleting

--- a/prod/templates/sandbox/template.yml
+++ b/prod/templates/sandbox/template.yml
@@ -196,7 +196,7 @@ Resources:
             - Name: ZERO_REPLICA_FILE
               Value: /data/db/sync-replica.db
             - Name: ZERO_LITESTREAM_BACKUP_URL
-              Value: !Sub "s3://${ApplicationBucket}/20250119"
+              Value: !Sub "s3://${ApplicationBucket}/20250121"
             - Name: ZERO_LOG_LEVEL
               Value: debug
             - Name: ZERO_UPSTREAM_MAX_CONNS
@@ -357,7 +357,7 @@ Resources:
             - Name: ZERO_NUM_SYNC_WORKERS
               Value: "0"
             - Name: ZERO_LITESTREAM_BACKUP_URL
-              Value: !Sub "s3://${ApplicationBucket}/20250119"
+              Value: !Sub "s3://${ApplicationBucket}/20250121"
             - Name: ZERO_LOG_FORMAT
               Value: json
             - Name: ZERO_REPLICA_FILE

--- a/prod/templates/template.yml
+++ b/prod/templates/template.yml
@@ -212,7 +212,7 @@ Resources:
             - Name: ZERO_REPLICA_FILE
               Value: /data/db/sync-replica.db
             - Name: ZERO_LITESTREAM_BACKUP_URL
-              Value: !Sub "s3://${ApplicationBucket}/20250119"
+              Value: !Sub "s3://${ApplicationBucket}/20250121"
             - Name: ZERO_LOG_LEVEL
               Value: debug
             - Name: ZERO_UPSTREAM_MAX_CONNS
@@ -377,7 +377,7 @@ Resources:
             - Name: ZERO_NUM_SYNC_WORKERS
               Value: "0"
             - Name: ZERO_LITESTREAM_BACKUP_URL
-              Value: !Sub "s3://${ApplicationBucket}/20250119"
+              Value: !Sub "s3://${ApplicationBucket}/20250121"
             - Name: ZERO_LOG_FORMAT
               Value: json
             - Name: ZERO_REPLICA_FILE


### PR DESCRIPTION
Make the CVR update logic detect row key changes and recognize when two different keys reference the same row.

Algorithm:
* The `KeyColumns` class determines the (potentially old) key columns referenced in the CVR.
  * It does this purely by examining the current CVR rows.
  * This relies on an invariant that a CVR's row keys are self-consistent, explained in the js doc.
* When processing rows produced by the IVM pipeline, check if the row exists in the CVR by either the new key (from the pipeline) or the old key (used by the CVR). This is possible at this point because the full row is available, and thus the old key columns can be looked up.
  * Edge case: If the old key columns no longer exist in the replica, we throw `ClientNotFound` and drop the CVR. This would only happen if the developer didn't properly update their schema versions; the CVR should have ideally been rejected earlier on.
* In the case of the row being referenced by the old key, the old row is deleted (actually deleted from the DB) because it is replaced by the new row. 
* However, the row contents are not sent in the poke if the row's patch version has not changed, so extraneous `put` and `del` patches are avoided. 