### PR TITLE
fix(zero-cache): fix an edge case when row keys change

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -514,6 +514,9 @@ export class CVRQueryDrivenUpdater extends CVRUpdater {
             lc.debug?.(`replacing ${stringify(oldID)} with ${stringify(id)}`);
             this.#replacedRows.set(oldID, true);
             this._cvrStore.delRowRecord(oldID);
+            // Force the updates for these rows to happen, even if they look like
+            // no-ops on their own.
+            this._cvrStore.forceUpdates(oldID, id);
           }
         }
       }


### PR DESCRIPTION
When converting row keys in the CVR, fix an edge case in which a converted row is added-and-deleted. In this case, the right poke happens, but the new (deleted) row was not being persisted in the row cache, and thus would not show up when catching up other clients.

In doing so, the special case for deletes is removed the no-op write removal logic, and is instead replaced by a manual override to force the updates for specific rows.