### PR TITLE
fix(zql): only select syncable columns in the write authorizer

### DIFF
--- a/packages/zero-cache/src/auth/write-authorizer.test.ts
+++ b/packages/zero-cache/src/auth/write-authorizer.test.ts
@@ -53,8 +53,8 @@ const schema = createSchema(1, {
 let replica: Database;
 beforeEach(() => {
   replica = new Database(lc, ':memory:');
-  replica.exec(/*sql*/ `CREATE TABLE foo (id TEXT PRIMARY KEY, a TEXT);
-      INSERT INTO foo VALUES ('1', 'a');`);
+  replica.exec(/*sql*/ `CREATE TABLE foo (id TEXT PRIMARY KEY, a TEXT, b TEXT_NOT_SUPPORTED);
+      INSERT INTO foo (id, a) VALUES ('1', 'a');`);
 });
 
 describe('normalize ops', () => {

--- a/packages/zero-cache/src/auth/write-authorizer.ts
+++ b/packages/zero-cache/src/auth/write-authorizer.ts
@@ -381,7 +381,10 @@ export class WriteAuthorizerImpl implements WriteAuthorizer {
 
     const ret = this.#statementRunner.get(
       compile(
-        sql`SELECT * FROM ${sql.ident(op.tableName)} WHERE ${sql.join(
+        sql`SELECT ${sql.join(
+          Object.keys(spec.zqlSpec).map(c => sql.ident(c)),
+          sql`,`,
+        )} FROM ${sql.ident(op.tableName)} WHERE ${sql.join(
           conditions,
           sql` AND `,
         )}`,


### PR DESCRIPTION
https://discord.com/channels/830183651022471199/1330784397439406171/1331443590760501328

Another issue with write authorization as it stands today -- when using ZQL for write permissions, we can only consider the fields which are expressible in ZQL.