### PR TITLE
feat(zero-react): remove empty data render, fix `use-element-resize`

### DIFF
--- a/apps/zbugs/src/hooks/use-element-size.ts
+++ b/apps/zbugs/src/hooks/use-element-size.ts
@@ -1,12 +1,12 @@
 import {useLayoutEffect, useState} from 'react';
 
-export function useElementSize(elm: HTMLElement | null) {
+export function useElementSize(elm: React.RefObject<HTMLElement>) {
   const [size, setSize] = useState<{width: number; height: number} | null>(
     null,
   );
 
   useLayoutEffect(() => {
-    if (!elm) {
+    if (!elm.current) {
       return;
     }
 
@@ -20,7 +20,7 @@ export function useElementSize(elm: HTMLElement | null) {
       }
     });
 
-    observer.observe(elm);
+    observer.observe(elm.current);
 
     return () => {
       observer.disconnect();

--- a/apps/zbugs/src/pages/list/list-page.tsx
+++ b/apps/zbugs/src/pages/list/list-page.tsx
@@ -239,7 +239,7 @@ export function ListPage({onReady}: {onReady: () => void}) {
 
   const listRef = useRef<HTMLDivElement>(null);
   const tableWrapperRef = useRef<HTMLDivElement>(null);
-  const size = useElementSize(tableWrapperRef.current);
+  const size = useElementSize(tableWrapperRef);
 
   const virtualizer = useVirtualizer({
     count: issues.length,

--- a/packages/zero-react/src/use-query.tsx
+++ b/packages/zero-react/src/use-query.tsx
@@ -253,6 +253,7 @@ class ViewWrapper<
     this.#onDematerialized = onDematerialized;
     this.#reactInternals = new Set();
     this.#query = query;
+    this.#materializeIfNeeded();
   }
 
   #onData = (


### PR DESCRIPTION
Every time we mount a component we do a render with no data then a render with data.

I made a change to fix this previously and it caused the zbugs issue list to render no data when going back.

This was not a bug in the change but rather a bug in our `use-element-size` hook which is now fixed.

---

# Strict mode

Before (13 renders):

https://github.com/user-attachments/assets/acb23c80-a34f-4286-a455-478ee10a73ab

After (5 renders)


https://github.com/user-attachments/assets/a75226de-54e8-4c2e-bc6c-b018fda0fda7

# Non-strict mode

Before (6 renders):

https://github.com/user-attachments/assets/cac35de1-63c0-45c7-bf61-afa88837730d

After (2 renders):


https://github.com/user-attachments/assets/343818f4-32b4-4ce0-ba1c-68765b0611f7

