### PR TITLE
chore(zero-cache): improve error message when the `--replica-file` cannot be opened

### DIFF
--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -68,7 +68,7 @@ export default async function runWorker(
       }
       if (e instanceof DatabaseInitError) {
         throw new Error(
-          `Cannot open ZERO_REPLICA_FILE at: "${config.replicaFile}". Please check that the path is valid.`,
+          `Cannot open ZERO_REPLICA_FILE at "${config.replicaFile}". Please check that the path is valid.`,
           {cause: e},
         );
       }

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -1,5 +1,6 @@
 import {assert} from '../../../shared/src/asserts.js';
 import {must} from '../../../shared/src/must.js';
+import {DatabaseInitError} from '../../../zqlite/src/db.js';
 import {getZeroConfig} from '../config/zero-config.js';
 import {deleteLiteDB} from '../db/delete-lite-db.js';
 import {initializeChangeSource} from '../services/change-source/pg/change-source.js';
@@ -64,6 +65,12 @@ export default async function runWorker(
         //       a semantic wipe instead of a file delete.
         deleteLiteDB(config.replicaFile);
         continue; // execute again with a fresh initial-sync
+      }
+      if (e instanceof DatabaseInitError) {
+        throw new Error(
+          `Cannot open ZERO_REPLICA_FILE at: "${config.replicaFile}". Please check that the path is valid.`,
+          {cause: e},
+        );
       }
       throw e;
     }


### PR DESCRIPTION
Another #papercut that we see a lot, particularly among Windows users that copy the quickstart config verbatim.

The error message now includes "ZERO_REPLICA_FILE" and the (invalid) path. 

<img width="1049" alt="Screenshot 2025-01-22 at 19 04 08" src="https://github.com/user-attachments/assets/e4bd4a92-dd78-4245-88eb-5a63549e863f" />
