### PR TITLE
fix(replicache): newRequestID should return a new ID each time

### DIFF
--- a/packages/replicache/src/sync/request-id.test.ts
+++ b/packages/replicache/src/sync/request-id.test.ts
@@ -8,8 +8,15 @@ test('newRequestID()', () => {
     expect(got).to.match(re);
   }
   {
-    const re = /client-[0-9a-f]+-0$/;
+    const re = /client-[0-9a-f]+-1$/;
     const got = newRequestID('client');
     expect(got).to.match(re);
   }
+});
+
+test('make sure we get new IDs every time', () => {
+  const clientID = Math.random().toString(36).slice(2);
+  const id1 = newRequestID(clientID);
+  const id2 = newRequestID(clientID);
+  expect(id1).not.toBe(id2);
 });

--- a/packages/replicache/src/sync/request-id.ts
+++ b/packages/replicache/src/sync/request-id.ts
@@ -21,13 +21,7 @@ const REQUEST_COUNTERS: Map<string, number> = new Map();
  * enough).
  */
 export function newRequestID(clientID: ClientID): string {
-  let counter = REQUEST_COUNTERS.get(clientID);
-  if (!counter) {
-    REQUEST_COUNTERS.set(clientID, 0);
-    counter = 0;
-  } else {
-    counter++;
-    REQUEST_COUNTERS.set(clientID, counter);
-  }
+  const counter = REQUEST_COUNTERS.get(clientID) ?? 0;
+  REQUEST_COUNTERS.set(clientID, counter + 1);
   return `${clientID}-${getSessionID()}-${counter}`;
 }


### PR DESCRIPTION
The old code was generating the same ID over and over.