### PR TITLE
fix(zql): make valita the source of truth for the `Parameter` type

### DIFF
--- a/packages/zero-protocol/src/ast.test.ts
+++ b/packages/zero-protocol/src/ast.test.ts
@@ -243,6 +243,6 @@ test('protocol version', () => {
   // If this test fails because the AST schema has changed such that
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
-  expect(hash).toEqual('1g60qx4dfwety');
-  expect(PROTOCOL_VERSION).toEqual(3);
+  expect(hash).toEqual('2zzy9s2lcdcms');
+  expect(PROTOCOL_VERSION).toEqual(4);
 });

--- a/packages/zero-protocol/src/protocol-version.ts
+++ b/packages/zero-protocol/src/protocol-version.ts
@@ -12,7 +12,7 @@ import {assert} from '../../shared/src/asserts.js';
  * release. The server (`zero-cache`) must be deployed before clients start
  * running the new code.
  */
-export const PROTOCOL_VERSION = 3;
+export const PROTOCOL_VERSION = 4;
 
 /**
  * The minimum protocol version supported by the server. The contract for


### PR DESCRIPTION
the valita schema and typescript type for `Parameter` drifted.  There's no need to have two types, just infer the `Parameter` type from the valita schema.