### PR TITLE
fix: export types for downstream typing

### DIFF
--- a/packages/zero-client/src/mod.ts
+++ b/packages/zero-client/src/mod.ts
@@ -93,6 +93,9 @@ export {
   number,
   string,
   table,
+  type TableBuilderWithColumns,
+  type TableBuilder,
+  type ColumnBuilder,
 } from '../../zero-schema/src/builder/table-builder.js';
 export type {
   AssetPermissions as CompiledAssetPermissions,

--- a/packages/zero-schema/src/builder/table-builder.ts
+++ b/packages/zero-schema/src/builder/table-builder.ts
@@ -112,7 +112,7 @@ export class TableBuilderWithColumns<TShape extends TableSchema> {
   }
 }
 
-class ColumnBuilder<TShape extends SchemaValue<any>> {
+export class ColumnBuilder<TShape extends SchemaValue<any>> {
   readonly #schema: TShape;
   constructor(schema: TShape) {
     this.#schema = schema;


### PR DESCRIPTION
This adds exports for the builder classes so they can be properly typed in downstream packages like `drizzle-zero`.