### PR TITLE
feat(zero-cache): diversify client-group distribution across tasks

### DIFF
--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -1,6 +1,7 @@
 import {resolver} from '@rocicorp/resolver';
 import {availableParallelism} from 'node:os';
 import path from 'node:path';
+import {must} from '../../../shared/src/must.js';
 import {getZeroConfig} from '../config/zero-config.js';
 import {getSubscriberContext} from '../services/change-streamer/change-streamer-http.js';
 import {SyncDispatcher} from '../services/dispatcher/sync-dispatcher.js';
@@ -40,6 +41,7 @@ export default async function runWorker(
   const startMs = Date.now();
   const config = getZeroConfig(env);
   const lc = createLogContext(config, {worker: 'dispatcher'});
+  const taskID = must(config.taskID, `main must set --task-id`);
 
   const processes = new ProcessManager(lc, parent ?? process);
 
@@ -157,7 +159,7 @@ export default async function runWorker(
   const {port} = config;
 
   if (numSyncers) {
-    mainServices.push(new SyncDispatcher(lc, parent, syncers, {port}));
+    mainServices.push(new SyncDispatcher(lc, taskID, parent, syncers, {port}));
   } else if (changeStreamer && parent) {
     // When running as the replication-manager, the dispatcher process
     // hands off websockets from the main (tenant) dispatcher to the

--- a/packages/zero-cache/src/server/multi/runtime.ts
+++ b/packages/zero-cache/src/server/multi/runtime.ts
@@ -15,7 +15,11 @@ export async function getTaskID(lc: LogContext) {
         containerMetadataSchema,
         'passthrough',
       );
-      return taskID;
+      // Task ARN's are long, e.g.
+      // "arn:aws:ecs:us-east-1:712907626835:task/zbugs-prod-Cluster-vvNFcPUVpGHr/0042ea25bf534dc19975e26f61441737"
+      // We only care about the unique ID, i.e. the last path component.
+      const lastSlash = taskID.lastIndexOf('/');
+      return taskID.substring(lastSlash + 1); // works for lastSlash === -1 too
     } catch (e) {
       lc.warn?.('unable to determine task ID. falling back to random ID', e);
     }

--- a/packages/zero-cache/src/services/dispatcher/sync-dispatcher.ts
+++ b/packages/zero-cache/src/services/dispatcher/sync-dispatcher.ts
@@ -51,11 +51,11 @@ export class SyncDispatcher extends HttpService {
       throw new Error(error);
     }
     const {clientGroupID} = params;
-    // Include the TaskID when hashing the clientGroupID to the sync worker.
-    // This diverges the distribution of client groups across workers for
-    // different tasks, so that if one task sheds connections from its most
-    // heavily loaded sync worker, those client groups will be distributed to
-    // different sync workers on the receiving task(s).
+    // Include the TaskID when hash-bucketting the client group to the sync
+    // worker. This diversifies the distribution of client groups (across
+    // workers) for different tasks, so that if one task sheds connections
+    // from its most heavily loaded sync worker(s), those client groups will
+    // be distributed uniformly across workers on the receiving task(s).
     const syncer =
       h32(this.#taskID + '/' + clientGroupID) % this.#syncers.length;
 

--- a/packages/zero-cache/src/services/dispatcher/sync-dispatcher.ts
+++ b/packages/zero-cache/src/services/dispatcher/sync-dispatcher.ts
@@ -13,10 +13,12 @@ const CONNECT_URL_PATTERN = new UrlPattern('(/:base)/sync/v:version/connect');
 
 export class SyncDispatcher extends HttpService {
   readonly id = 'dispatcher';
+  readonly #taskID: string;
   readonly #syncers: Worker[];
 
   constructor(
     lc: LogContext,
+    taskID: string,
     parent: Worker | null,
     syncers: Worker[],
     opts: Options,
@@ -26,6 +28,7 @@ export class SyncDispatcher extends HttpService {
       installWebSocketHandoff(lc, req => this.#handoff(req), fastify.server);
     });
 
+    this.#taskID = taskID;
     this.#syncers = syncers;
     if (parent) {
       installWebSocketHandoff(lc, req => this.#handoff(req), parent);
@@ -48,7 +51,13 @@ export class SyncDispatcher extends HttpService {
       throw new Error(error);
     }
     const {clientGroupID} = params;
-    const syncer = h32(clientGroupID) % this.#syncers.length;
+    // Include the TaskID when hashing the clientGroupID to the sync worker.
+    // This diverges the distribution of client groups across workers for
+    // different tasks, so that if one task sheds connections from its most
+    // heavily loaded sync worker, those client groups will be distributed to
+    // different sync workers on the receiving task(s).
+    const syncer =
+      h32(this.#taskID + '/' + clientGroupID) % this.#syncers.length;
 
     this._lc.debug?.(`connecting ${clientGroupID} to syncer ${syncer}`);
     return {payload: params, receiver: this.#syncers[syncer]};


### PR DESCRIPTION
Include the `taskID` (i.e. of the `view-syncer`) when hashing an incoming connection / client-group to a worker process. This diversifies the distribution of client-groups across processes for different `view-syncer`s, allowing loaded `view-syncer`s to shed client-groups on their most heavily loaded workers to a uniform distribution on the receiving tasks.

Unrelated: Also shorten taskID names; we only need the unique identifier, and not all of the resource namespacing included in the Task ARN.