### PR TITLE
prod(zbugs): set lb algorithm to least oustanding requests

### DIFF
--- a/prod/templates/sandbox/vpc.yml
+++ b/prod/templates/sandbox/vpc.yml
@@ -249,13 +249,18 @@ Resources:
         HttpCode: "200"
       TargetGroupAttributes:
         - Key: deregistration_delay.timeout_seconds
-          Value: "0"
+          # Allow 3 minutes to drain connections on update
+          Value: 180
         - Key: stickiness.enabled
           Value: true
         - Key: stickiness.type
           Value: lb_cookie
         - Key: stickiness.lb_cookie.duration_seconds
-          Value: 300
+          # Note: stickiness duration is the lower-bound on
+          #       connection lifetime when shedding load
+          Value: 180
+        - Key: load_balancing.algorithm.type
+          Value: least_outstanding_requests
   PublicLBListener:
     Type: "AWS::ElasticLoadBalancingV2::Listener"
     Properties:

--- a/prod/templates/vpc.yml
+++ b/prod/templates/vpc.yml
@@ -250,13 +250,18 @@ Resources:
         HttpCode: "200"
       TargetGroupAttributes:
         - Key: deregistration_delay.timeout_seconds
-          Value: "0"
+          # Allow 3 minutes to drain connections on update
+          Value: 180
         - Key: stickiness.enabled
           Value: true
         - Key: stickiness.type
           Value: lb_cookie
         - Key: stickiness.lb_cookie.duration_seconds
-          Value: 300
+          # Note: stickiness duration is the lower-bound on
+          #       connection lifetime when shedding load
+          Value: 180
+        - Key: load_balancing.algorithm.type
+          Value: least_outstanding_requests
 
   PublicLBListener:
     Type: "AWS::ElasticLoadBalancingV2::Listener"


### PR DESCRIPTION
* Set the load balancing algorithm to "least outstanding requests"
* Fix the deregistration delay to be 3 minutes (this is the amount of time an outgoing task gets to drain requests)
* Reduce the cookie stickiness duration to 3 minutes. This essentially becomes the lower bound on connection lifetime when shedding requests.

Next:
* Enable auto-scaling on sandbox