### PR TITLE
feat(zero-schema): allow remapping column and table names

### DIFF
--- a/packages/zero-schema/src/builder/schema-builder.test.ts
+++ b/packages/zero-schema/src/builder/schema-builder.test.ts
@@ -2,7 +2,7 @@
  * Relationships as secondary.
  */
 
-import {expectTypeOf, test} from 'vitest';
+import {expect, expectTypeOf, test} from 'vitest';
 import {table, number, string} from './table-builder.js';
 import {relationships} from './relationship-builder.js';
 import type {Query} from '../../../zql/src/query/query.js';
@@ -234,4 +234,45 @@ test('building a schema', () => {
       }[];
     }[]
   >();
+});
+
+test('alternate upstream names', () => {
+  const user = table('user')
+    .upstreamName('users')
+    .columns({
+      id: string().upstreamName('user_id'),
+      name: string().upstreamName('user_name'),
+      recruiterId: number().upstreamName('user_recruiter_id'),
+    })
+    .primaryKey('id');
+
+  expect(user.build()).toMatchInlineSnapshot(`
+    {
+      "columns": {
+        "id": {
+          "customType": null,
+          "optional": false,
+          "type": "string",
+          "upstreamName": "user_id",
+        },
+        "name": {
+          "customType": null,
+          "optional": false,
+          "type": "string",
+          "upstreamName": "user_name",
+        },
+        "recruiterId": {
+          "customType": null,
+          "optional": false,
+          "type": "number",
+          "upstreamName": "user_recruiter_id",
+        },
+      },
+      "name": "user",
+      "primaryKey": [
+        "id",
+      ],
+      "upstreamName": "users",
+    }
+  `);
 });

--- a/packages/zero-schema/src/schema-config.ts
+++ b/packages/zero-schema/src/schema-config.ts
@@ -35,11 +35,13 @@ export const valueTypeSchema: v.Type<ValueType> = v.union(
 
 export const schemaValueSchema = v.readonlyObject({
   type: valueTypeSchema,
+  upstreamName: v.string().optional(),
   optional: v.boolean().optional(),
 });
 
 export const tableSchemaSchema: v.Type<TableSchema> = v.readonlyObject({
   name: v.string(),
+  upstreamName: v.string().optional(),
   columns: v.record(schemaValueSchema),
   primaryKey: primaryKeySchema,
 });

--- a/packages/zero-schema/src/schema.test.ts
+++ b/packages/zero-schema/src/schema.test.ts
@@ -10,8 +10,16 @@ test('Key name does not matter', () => {
 
   expectTypeOf(schema.tables.bar).toEqualTypeOf<{
     name: 'bar';
-    columns: {id: {type: 'string'; optional: false; customType: string}};
+    columns: {
+      id: {
+        type: 'string';
+        optional: false;
+        customType: string;
+        upstreamName: undefined;
+      };
+    };
     primaryKey: ['id'];
+    upstreamName: undefined;
   }>({} as never);
   // @ts-expect-error - no foo table
   schema.tables.foo;

--- a/packages/zero-schema/src/table-schema.ts
+++ b/packages/zero-schema/src/table-schema.ts
@@ -9,6 +9,7 @@ export type ValueType = 'string' | 'number' | 'boolean' | 'null' | 'json';
 export type SchemaValue<T = unknown> =
   | {
       type: ValueType;
+      upstreamName?: string | undefined;
       optional?: boolean | undefined;
     }
   | EnumSchemaValue<T>
@@ -16,6 +17,7 @@ export type SchemaValue<T = unknown> =
 
 export type SchemaValueWithCustomType<T> = {
   type: ValueType;
+  upstreamName?: string | undefined;
   optional?: boolean;
   customType: T;
 };
@@ -23,12 +25,14 @@ export type SchemaValueWithCustomType<T> = {
 export type EnumSchemaValue<T> = {
   kind: 'enum';
   type: 'string';
-  optional?: boolean;
+  upstreamName?: string | undefined;
+  optional?: boolean | undefined;
   customType: T;
 };
 
 export type TableSchema = {
   readonly name: string;
+  readonly upstreamName?: string | undefined;
   readonly columns: Record<string, SchemaValue>;
   readonly primaryKey: PrimaryKey;
 };
@@ -53,8 +57,7 @@ type TypeNameToTypeMap = {
   json: any;
 };
 
-export type ColumnTypeName<T extends SchemaValue | ValueType> =
-  T extends SchemaValue ? T['type'] : T;
+export type ColumnTypeName<T extends SchemaValue> = T['type'];
 
 /**
  * Given a schema value, return the TypeScript type.
@@ -62,20 +65,17 @@ export type ColumnTypeName<T extends SchemaValue | ValueType> =
  * This allows us to create the correct return type for a
  * query that has a selection.
  */
-export type SchemaValueToTSType<T extends SchemaValue | ValueType> =
-  T extends ValueType
-    ? TypeNameToTypeMap[T]
-    : T extends {
-        optional: true;
-      }
-    ?
-        | (T extends SchemaValueWithCustomType<infer V>
-            ? V
-            : TypeNameToTypeMap[ColumnTypeName<T>])
-        | null
-    : T extends SchemaValueWithCustomType<infer V>
-    ? V
-    : TypeNameToTypeMap[ColumnTypeName<T>];
+export type SchemaValueToTSType<T extends SchemaValue> = T extends {
+  optional: true;
+}
+  ?
+      | (T extends SchemaValueWithCustomType<infer V>
+          ? V
+          : TypeNameToTypeMap[ColumnTypeName<T>])
+      | null
+  : T extends SchemaValueWithCustomType<infer V>
+  ? V
+  : TypeNameToTypeMap[ColumnTypeName<T>];
 
 type Connection = {
   readonly sourceField: readonly string[];


### PR DESCRIPTION
This is just the API layer. We'll have to update the query-builder to use these names when creating the AST next (https://rocicorp.slack.com/archives/C013XFG80JC/p1737662271150499?thread_ts=1737653133.055509&cid=C013XFG80JC).

API looks like:

```ts
const user = table('user')
  .upstreamName('users')
  .columns({
    id: string().upstreamName('user_id'),
    name: string().upstreamName('user_name'),
    recruiterId: number().upstreamName('user_recruiter_id'),
  })
  .primaryKey('id');
```