### PR TITLE
chore(zero-cache): increase test timeouts for running on remote pg instances

### DIFF
--- a/packages/zero-cache/src/integration/integration.pg-test.ts
+++ b/packages/zero-cache/src/integration/integration.pg-test.ts
@@ -27,7 +27,7 @@ import {childWorker, type Worker} from '../types/processes.js';
 // Adjust to debug.
 const LOG_LEVEL: LogLevel = 'error';
 
-describe('integration', {timeout: 10000}, () => {
+describe('integration', {timeout: 30000}, () => {
   let upDB: PostgresDB;
   let cvrDB: PostgresDB;
   let changeDB: PostgresDB;
@@ -105,7 +105,7 @@ describe('integration', {timeout: 10000}, () => {
       ['ZERO_SCHEMA_JSON']: JSON.stringify(SCHEMA),
       ['ZERO_NUM_SYNC_WORKERS']: '1',
     };
-  });
+  }, 30000);
 
   const FOO_QUERY: AST = {
     table: 'foo',
@@ -153,7 +153,7 @@ describe('integration', {timeout: 10000}, () => {
       replicaDbFile.delete();
       replicaDbFile2.delete();
     }
-  });
+  }, 30000);
 
   const WATERMARK_REGEX = /[0-9a-z]{4,}/;
 

--- a/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg-test.ts
@@ -26,7 +26,7 @@ const SHARD_ID = 'change_source_end_to_mid_test_id';
  * - Applying the changes to the replica with a MessageProcessor
  * - Verifying the resulting SQLite schema and/or data on the replica.
  */
-describe('change-source/pg/end-to-mid-test', {timeout: 10000}, () => {
+describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
   let lc: LogContext;
   let upstream: PostgresDB;
   let replicaDbFile: DbFile;
@@ -83,7 +83,7 @@ describe('change-source/pg/end-to-mid-test', {timeout: 10000}, () => {
     changes = stream.changes;
     downstream = drainToQueue(changes);
     replicator = createMessageProcessor(replica);
-  });
+  }, 30000);
 
   afterAll(async () => {
     changes?.cancel();

--- a/packages/zero-cache/src/services/change-source/pg/change-source.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.pg-test.ts
@@ -35,7 +35,7 @@ import {dropEventTriggerStatements} from './schema/ddl-test-utils.js';
 
 const SHARD_ID = 'change_source_test_id';
 
-describe('change-source/pg', {timeout: 10000}, () => {
+describe('change-source/pg', {timeout: 30000}, () => {
   let logSink: TestLogSink;
   let lc: LogContext;
   let upstream: PostgresDB;
@@ -84,7 +84,7 @@ describe('change-source/pg', {timeout: 10000}, () => {
         {tableCopyWorkers: 5, rowBatchSize: 10000},
       )
     ).changeSource;
-  });
+  }, 30000);
 
   afterEach(async () => {
     streams.forEach(s => s.changes.cancel());

--- a/packages/zero-cache/src/test/db.ts
+++ b/packages/zero-cache/src/test/db.ts
@@ -39,6 +39,7 @@ class TestDBs {
     }
 
     const {sql} = this;
+    await sql`DROP DATABASE IF EXISTS ${sql(database)}`;
     await sql`CREATE DATABASE ${sql(database)}`;
 
     const {host, port, user: username, pass} = sql.options;


### PR DESCRIPTION
Increase test timeouts for integration-level postgres tests to run on custom (remote) pg instances like Aurora