### PR TITLE
fix(zbugs): README link typo

### DIFF
--- a/apps/zbugs/README.md
+++ b/apps/zbugs/README.md
@@ -1,6 +1,6 @@
 # Welcome
 
-This is the source code for [zbugs](bugs.rocicorp.dev).
+This is the source code for [zbugs](https://bugs.rocicorp.dev/).
 
 We deploy this continuously (on trunk) to aws and is our dogfood of Zero.
 


### PR DESCRIPTION
Fixes md link to the app so it doesn't try to relatively redirect in github.

> Caught this while trying to find the link