### PR TITLE
feat(zero-cache): make heartbeat monitoring based on path rather than port

### DIFF
--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -8,13 +8,13 @@ import {ChangeStreamerHttpServer} from '../services/change-streamer/change-strea
 import {initializeStreamer} from '../services/change-streamer/change-streamer-service.js';
 import type {ChangeStreamerService} from '../services/change-streamer/change-streamer.js';
 import {AutoResetSignal} from '../services/change-streamer/schema/tables.js';
+import {exitAfter, runUntilKilled} from '../services/life-cycle.js';
 import {pgClient} from '../types/pg.js';
 import {
   parentWorker,
   singleProcessMode,
   type Worker,
 } from '../types/processes.js';
-import {exitAfter, runUntilKilled} from './life-cycle.js';
 import {createLogContext} from './logging.js';
 
 export default async function runWorker(

--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -7,6 +7,12 @@ import {getSubscriberContext} from '../services/change-streamer/change-streamer-
 import {SyncDispatcher} from '../services/dispatcher/sync-dispatcher.js';
 import {installWebSocketHandoff} from '../services/dispatcher/websocket-handoff.js';
 import {
+  exitAfter,
+  ProcessManager,
+  runUntilKilled,
+  type WorkerType,
+} from '../services/life-cycle.js';
+import {
   restoreReplica,
   startReplicaBackupProcess,
 } from '../services/litestream/commands.js';
@@ -26,12 +32,6 @@ import {
   type ReplicaFileMode,
   subscribeTo,
 } from '../workers/replicator.js';
-import {
-  exitAfter,
-  ProcessManager,
-  runUntilKilled,
-  type WorkerType,
-} from './life-cycle.js';
 import {createLogContext} from './logging.js';
 
 export default async function runWorker(

--- a/packages/zero-cache/src/server/multi/main.ts
+++ b/packages/zero-cache/src/server/multi/main.ts
@@ -1,5 +1,11 @@
 import 'dotenv/config'; // Imports ENV variables from .env
 import {assert} from '../../../../shared/src/asserts.js';
+import {HttpService} from '../../services/http-service.js';
+import {
+  exitAfter,
+  ProcessManager,
+  runUntilKilled,
+} from '../../services/life-cycle.js';
 import type {Service} from '../../services/service.js';
 import {
   childWorker,
@@ -8,12 +14,6 @@ import {
   type Worker,
 } from '../../types/processes.js';
 import {orTimeout} from '../../types/timeout.js';
-import {
-  exitAfter,
-  HeartbeatMonitor,
-  ProcessManager,
-  runUntilKilled,
-} from '../life-cycle.js';
 import {createLogContext} from '../logging.js';
 import {getMultiZeroConfig} from './config.js';
 import {getTaskID} from './runtime.js';
@@ -104,7 +104,13 @@ export default async function runWorker(
   }
 
   const mainServices: Service[] = [
-    new HeartbeatMonitor(lc, {port: heartbeatMonitorPort}),
+    // TODO: Remove this when health checks are moved to the traffic port.
+    new HttpService(
+      'heartbeat-monitor',
+      lc,
+      {port: heartbeatMonitorPort},
+      () => {},
+    ),
   ];
   if (multiMode) {
     mainServices.push(

--- a/packages/zero-cache/src/server/multi/tenant-dispatcher.ts
+++ b/packages/zero-cache/src/server/multi/tenant-dispatcher.ts
@@ -23,7 +23,6 @@ export class TenantDispatcher extends HttpService {
     opts: Options,
   ) {
     super('tenant-dispatcher', lc, opts, fastify => {
-      fastify.get('/', (_req, res) => res.send('OK'));
       installWebSocketHandoff(lc, req => this.#handoff(req), fastify.server);
     });
 

--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -4,6 +4,7 @@ import {must} from '../../../shared/src/must.js';
 import * as v from '../../../shared/src/valita.js';
 import {getZeroConfig} from '../config/zero-config.js';
 import {ChangeStreamerHttpClient} from '../services/change-streamer/change-streamer-http.js';
+import {exitAfter, runUntilKilled} from '../services/life-cycle.js';
 import {
   ReplicatorService,
   type ReplicatorMode,
@@ -18,7 +19,6 @@ import {
   setUpMessageHandlers,
   setupReplica,
 } from '../workers/replicator.js';
-import {exitAfter, runUntilKilled} from './life-cycle.js';
 import {createLogContext} from './logging.js';
 
 export default async function runWorker(

--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -16,6 +16,7 @@ import {randInt} from '../../../shared/src/rand.js';
 import * as v from '../../../shared/src/valita.js';
 import {getSchema} from '../auth/load-schema.js';
 import {getZeroConfig} from '../config/zero-config.js';
+import {exitAfter, runUntilKilled} from '../services/life-cycle.js';
 import {MutagenService} from '../services/mutagen/mutagen.js';
 import type {ReplicaState} from '../services/replicator/replicator.js';
 import {DatabaseStorage} from '../services/view-syncer/database-storage.js';
@@ -32,7 +33,6 @@ import {
 import {Subscription} from '../types/subscription.js';
 import {replicaFileModeSchema, replicaFileName} from '../workers/replicator.js';
 import {Syncer} from '../workers/syncer.js';
-import {exitAfter, runUntilKilled} from './life-cycle.js';
 import {createLogContext} from './logging.js';
 
 function randomID() {

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
@@ -32,7 +32,6 @@ export class ChangeStreamerHttpServer extends HttpService {
   ) {
     super('change-streamer-http-server', lc, opts, async fastify => {
       await fastify.register(websocket);
-      fastify.get('/', (_req, res) => res.send('OK'));
 
       // fastify does not support optional path components, so we just
       // register both patterns.

--- a/packages/zero-cache/src/services/dispatcher/sync-dispatcher.ts
+++ b/packages/zero-cache/src/services/dispatcher/sync-dispatcher.ts
@@ -24,7 +24,6 @@ export class SyncDispatcher extends HttpService {
     opts: Options,
   ) {
     super('dispatcher', lc, opts, fastify => {
-      fastify.get('/', (_req, res) => res.send('OK'));
       installWebSocketHandoff(lc, req => this.#handoff(req), fastify.server);
     });
 

--- a/packages/zero-cache/src/services/http-service.ts
+++ b/packages/zero-cache/src/services/http-service.ts
@@ -1,5 +1,6 @@
 import {LogContext} from '@rocicorp/logger';
 import Fastify, {type FastifyInstance} from 'fastify';
+import {HeartbeatMonitor} from './life-cycle.js';
 import {RunningState} from './running-state.js';
 import type {Service} from './service.js';
 
@@ -7,12 +8,18 @@ export type Options = {
   port: number;
 };
 
+/**
+ * Common functionality for all HttpServices. These include:
+ * * Responding to health checks at "/"
+ * * Tracking optional heartbeats at "/keepalive" and draining when they stop.
+ */
 export class HttpService implements Service {
   readonly id: string;
   protected readonly _lc: LogContext;
   readonly #fastify: FastifyInstance;
   readonly #port: number;
   readonly #state: RunningState;
+  readonly #heartbeatMonitor: HeartbeatMonitor;
   readonly #init: (fastify: FastifyInstance) => void | Promise<void>;
 
   constructor(
@@ -27,11 +34,17 @@ export class HttpService implements Service {
     this.#port = opts.port;
     this.#init = init;
     this.#state = new RunningState(id);
+    this.#heartbeatMonitor = new HeartbeatMonitor(this._lc);
   }
 
   // start() is used in unit tests.
   // run() is the lifecycle method called by the ServiceRunner.
   async start(): Promise<string> {
+    this.#fastify.get('/', (_req, res) => res.send('OK'));
+    this.#fastify.get('/keepalive', (_req, res) => {
+      this.#heartbeatMonitor.onHeartbeat();
+      return res.send('OK');
+    });
     await this.#init(this.#fastify);
     const address = await this.#fastify.listen({
       host: '::',
@@ -48,6 +61,7 @@ export class HttpService implements Service {
 
   async stop(): Promise<void> {
     this._lc.info?.(`${this.id}: no longer accepting connections`);
+    this.#heartbeatMonitor.stop();
     await this.#fastify.close();
     this.#state.stop(this._lc);
   }

--- a/packages/zero-cache/src/services/life-cycle.test.ts
+++ b/packages/zero-cache/src/services/life-cycle.test.ts
@@ -3,9 +3,13 @@ import EventEmitter from 'node:events';
 import {beforeEach, describe, expect, test} from 'vitest';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.js';
 import {promiseVoid} from '../../../shared/src/resolved-promises.js';
+import {
+  ProcessManager,
+  runUntilKilled,
+  type WorkerType,
+} from '../services/life-cycle.js';
 import type {SingletonService} from '../services/service.js';
 import {inProcChannel} from '../types/processes.js';
-import {ProcessManager, runUntilKilled, type WorkerType} from './life-cycle.js';
 
 describe('shutdown', () => {
   const lc = createSilentLogContext();


### PR DESCRIPTION
Add heartbeat monitoring to all HttpServices on the "/keepalive" path.

This will facilitate moving "mandatory" load balancer health checks (i.e. heartbeats) to the the main traffic port rather than the special 4850 port, using the "/keepalive" path to keep the feature opt-in. (This also will facilitate support for SST).

And with this, both the `view-syncer` and `replication-manager` will be able to detect drains at 4848 and 4849, respectively, with the latter enabled via an internal load balancer.