### PR TITLE
prod(sandbox): fix MinimumHealthyPercent for auto scaling

### DIFF
--- a/prod/templates/sandbox/template.yml
+++ b/prod/templates/sandbox/template.yml
@@ -99,7 +99,8 @@ Resources:
         # Run up to 12 tasks, capping updates to 2 tasks at a time
         # (Connection counts are currently safe for up to 12 tasks at a time)
         MaximumPercent: 120
-        MinimumHealthyPercent: 50
+        # 1 out of 10 tasks (for Auto Scaling)
+        MinimumHealthyPercent: 10
         DeploymentCircuitBreaker:
           Enable: true
           Rollback: true


### PR DESCRIPTION
Fix sandbox's `MinimumHealthyPercent` value to be compatible with Autoscaling. 

Deployments otherwise fail because the number of "healthy" tasks (scaled down to 1) is less than the minimum healthy percentage of the DesiredCount.

<img width="1032" alt="Screenshot 2025-01-25 at 19 20 55" src="https://github.com/user-attachments/assets/46aec5e3-cef3-40d2-90bc-18a878af0d0b" />

