### PR TITLE
chore(zero): Distinguish the two different bencher comments

### DIFF
--- a/.github/workflows/bencher-benchmarks-pr.yml
+++ b/.github/workflows/bencher-benchmarks-pr.yml
@@ -46,6 +46,7 @@ jobs:
           --token '${{ secrets.BENCHER_API_TOKEN }}' \
           --adapter json \
           --github-actions '${{ secrets.GITHUB_TOKEN }}' \
+          --ci-id size \
           --branch "$GITHUB_HEAD_REF" \
           --start-point "$GITHUB_BASE_REF" \
           --start-point-hash '${{ github.event.pull_request.base.sha }}' \
@@ -95,6 +96,7 @@ jobs:
           --token '${{ secrets.BENCHER_API_TOKEN }}' \
           --adapter json \
           --github-actions '${{ secrets.GITHUB_TOKEN }}' \
+          --ci-id perf \
           --branch "$GITHUB_HEAD_REF" \
           --start-point "$GITHUB_BASE_REF" \
           --start-point-hash '${{ github.event.pull_request.base.sha }}' \


### PR DESCRIPTION
The github action was thinking that the two different jobs were for the same report.