### PR TITLE
chore(zql): log if `next` in `table-source` takes too long

### DIFF
--- a/packages/otel/src/log-options.ts
+++ b/packages/otel/src/log-options.ts
@@ -28,16 +28,16 @@ export const logOptions = {
   },
 
   slowRowThreshold: {
-    type: v.number().default(3),
+    type: v.number().default(2),
     desc: [
       `The number of ms a row must take to fetch from table-source before it is considered slow.`,
     ],
   },
 
   ivmSampling: {
-    type: v.number().default(0),
+    type: v.number().default(5000),
     desc: [
-      `How often to take collect IVM metrics. 1 means always, 100 means 1% of the time, 0 means never`,
+      `How often to collect IVM metrics. 1 out of N requests will be sampled where N is this value.`,
     ],
   },
 };

--- a/packages/otel/src/log-options.ts
+++ b/packages/otel/src/log-options.ts
@@ -1,0 +1,45 @@
+import * as v from '../../shared/src/valita.ts';
+import {type Config} from '../../shared/src/options.ts';
+
+export const logOptions = {
+  level: v
+    .union(
+      v.literal('debug'),
+      v.literal('info'),
+      v.literal('warn'),
+      v.literal('error'),
+    )
+    .default('info'),
+
+  format: {
+    type: v.union(v.literal('text'), v.literal('json')).default('text'),
+    desc: [
+      `Use {bold text} for developer-friendly console logging`,
+      `and {bold json} for consumption by structured-logging services`,
+    ],
+  },
+
+  traceCollector: {
+    type: v.string().optional(),
+    desc: [
+      `The URL of the trace collector to which to send trace data. Traces are sent over http.`,
+      `Port defaults to 4318 for most collectors.`,
+    ],
+  },
+
+  slowRowThreshold: {
+    type: v.number().default(3),
+    desc: [
+      `The number of ms a row must take to fetch from table-source before it is considered slow.`,
+    ],
+  },
+
+  ivmSampling: {
+    type: v.number().default(0),
+    desc: [
+      `How often to take collect IVM metrics. 1 means always, 100 means 1% of the time, 0 means never`,
+    ],
+  },
+};
+
+export type LogConfig = Config<typeof logOptions>;

--- a/packages/otel/src/maybe-time.ts
+++ b/packages/otel/src/maybe-time.ts
@@ -1,0 +1,21 @@
+import type {LogContext} from '@rocicorp/logger';
+
+export function timeSampled<T>(
+  lc: LogContext,
+  numerator: number,
+  denominator: number,
+  cb: () => T,
+  threshold: number = 0,
+) {
+  if (denominator > 0 && numerator % denominator === 0) {
+    const start = performance.now();
+    const result = cb();
+    const duration = performance.now() - start;
+    if (duration > threshold) {
+      lc.info?.(`duration: ${duration}ms`);
+    }
+
+    return result;
+  }
+  return cb();
+}

--- a/packages/otel/src/maybe-time.ts
+++ b/packages/otel/src/maybe-time.ts
@@ -6,13 +6,14 @@ export function timeSampled<T>(
   denominator: number,
   cb: () => T,
   threshold: number = 0,
+  prefix: () => string = () => '',
 ) {
   if (denominator > 0 && numerator % denominator === 0) {
     const start = performance.now();
     const result = cb();
     const duration = performance.now() - start;
     if (duration > threshold) {
-      lc.info?.(`duration: ${duration}ms`);
+      lc.info?.(`${prefix()} duration: ${duration}ms`);
     }
 
     return result;

--- a/packages/zero-cache/bench/benchmark.ts
+++ b/packages/zero-cache/bench/benchmark.ts
@@ -7,12 +7,20 @@ import type {Source} from '../../zql/src/ivm/source.ts';
 import {newQuery, type QueryDelegate} from '../../zql/src/query/query-impl.ts';
 import {Database} from '../../zqlite/src/db.ts';
 import {TableSource} from '../../zqlite/src/table-source.ts';
+import type {LogConfig} from '../src/config/zero-config.ts';
 import {computeZqlSpecs} from '../src/db/lite-tables.ts';
 import {mapLiteDataTypeToZqlSchemaValue} from '../src/types/lite.ts';
 import {schema} from './schema.ts';
 
 type Options = {
   dbFile: string;
+};
+
+const logConfig: LogConfig = {
+  format: 'text',
+  level: 'debug',
+  ivmSampling: 0,
+  slowRowThreshold: 0,
 };
 
 // load up some data!
@@ -33,6 +41,8 @@ export function bench(opts: Options) {
       const {columns, primaryKey} = spec.tableSpec;
 
       source = new TableSource(
+        lc,
+        logConfig,
         'benchmark',
         db,
         name,
@@ -74,5 +84,6 @@ export function bench(opts: Options) {
   q.materialize();
 
   const end = performance.now();
+  // eslint-disable-next-line no-console
   console.log(`materialize\ttook ${end - start}ms`);
 }

--- a/packages/zero-cache/src/auth/read-authorizer.query.test.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.query.test.ts
@@ -42,6 +42,17 @@ import {Database} from '../../../zqlite/src/db.ts';
 import {TableSource} from '../../../zqlite/src/table-source.ts';
 import {transformQuery} from './read-authorizer.ts';
 import {WriteAuthorizerImpl} from './write-authorizer.ts';
+import type {LogConfig, ZeroConfig} from '../config/zero-config.ts';
+
+const logConfig: LogConfig = {
+  format: 'text',
+  level: 'debug',
+  ivmSampling: 0,
+  slowRowThreshold: 0,
+};
+const zeroConfig = {
+  log: logConfig,
+} as unknown as ZeroConfig;
 
 const user = table('user')
   .columns({
@@ -488,6 +499,8 @@ beforeEach(() => {
       )`);
 
       source = new TableSource(
+        lc,
+        logConfig,
         'read-auth-test',
         replica,
         name,
@@ -520,7 +533,7 @@ beforeEach(() => {
 
   writeAuthorizer = new WriteAuthorizerImpl(
     lc,
-    {},
+    zeroConfig,
     schema,
     permissions,
     replica,

--- a/packages/zero-cache/src/auth/write-authorizer.test.ts
+++ b/packages/zero-cache/src/auth/write-authorizer.test.ts
@@ -10,8 +10,18 @@ import {string, table} from '../../../zero-schema/src/builder/table-builder.ts';
 import type {Rule} from '../../../zero-schema/src/compiled-permissions.ts';
 import {Database} from '../../../zqlite/src/db.ts';
 import {WriteAuthorizerImpl} from './write-authorizer.ts';
+import type {LogConfig, ZeroConfig} from '../config/zero-config.ts';
 
 const lc = createSilentLogContext();
+const logConfig: LogConfig = {
+  format: 'text',
+  level: 'debug',
+  ivmSampling: 0,
+  slowRowThreshold: 0,
+};
+const zeroConfig = {
+  log: logConfig,
+} as unknown as ZeroConfig;
 
 const allowIfSubject = [
   'allow',
@@ -64,7 +74,7 @@ describe('normalize ops', () => {
   test('upsert converted to update if row exists', () => {
     const authorizer = new WriteAuthorizerImpl(
       lc,
-      {},
+      zeroConfig,
       schema,
       {},
       replica,
@@ -90,7 +100,7 @@ describe('normalize ops', () => {
   test('upsert converted to insert if row does not exist', () => {
     const authorizer = new WriteAuthorizerImpl(
       lc,
-      {},
+      zeroConfig,
       schema,
       {},
       replica,
@@ -119,7 +129,7 @@ describe('pre & post mutation', () => {
   test('delete is run pre-mutation', () => {
     const authorizer = new WriteAuthorizerImpl(
       lc,
-      {},
+      zeroConfig,
       schema,
       {
         foo: {
@@ -151,7 +161,7 @@ describe('pre & post mutation', () => {
   test('insert is run post-mutation', () => {
     const authorizer = new WriteAuthorizerImpl(
       lc,
-      {},
+      zeroConfig,
       schema,
       {
         foo: {
@@ -183,7 +193,7 @@ describe('pre & post mutation', () => {
   test('update is run pre-mutation when specified', () => {
     const authorizer = new WriteAuthorizerImpl(
       lc,
-      {},
+      zeroConfig,
       schema,
       {
         foo: {
@@ -217,7 +227,7 @@ describe('pre & post mutation', () => {
   test('update is run post-mutation when specified', () => {
     const authorizer = new WriteAuthorizerImpl(
       lc,
-      {},
+      zeroConfig,
       schema,
       {
         foo: {

--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -91,6 +91,14 @@ test('zero-cache --help', () => {
                                                    The URL of the trace collector to which to send trace data. Traces are sent over http.            
                                                    Port defaults to 4318 for most collectors.                                                        
                                                                                                                                                      
+     --log-slow-row-threshold number               default: 3                                                                                        
+       ZERO_LOG_SLOW_ROW_THRESHOLD env                                                                                                               
+                                                   The number of ms a row must take to fetch from table-source before it is considered slow.         
+                                                                                                                                                     
+     --log-ivm-sampling number                     default: 0                                                                                        
+       ZERO_LOG_IVM_SAMPLING env                                                                                                                     
+                                                   How often to take collect IVM metrics. 1 means always, 100 means 1% of the time, 0 means never    
+                                                                                                                                                     
      --shard-id string                             default: "0"                                                                                      
        ZERO_SHARD_ID env                                                                                                                             
                                                    Unique identifier for the zero-cache shard.                                                       

--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -91,13 +91,13 @@ test('zero-cache --help', () => {
                                                    The URL of the trace collector to which to send trace data. Traces are sent over http.            
                                                    Port defaults to 4318 for most collectors.                                                        
                                                                                                                                                      
-     --log-slow-row-threshold number               default: 3                                                                                        
+     --log-slow-row-threshold number               default: 2                                                                                        
        ZERO_LOG_SLOW_ROW_THRESHOLD env                                                                                                               
                                                    The number of ms a row must take to fetch from table-source before it is considered slow.         
                                                                                                                                                      
-     --log-ivm-sampling number                     default: 0                                                                                        
+     --log-ivm-sampling number                     default: 5000                                                                                     
        ZERO_LOG_IVM_SAMPLING env                                                                                                                     
-                                                   How often to take collect IVM metrics. 1 means always, 100 means 1% of the time, 0 means never    
+                                                   How often to collect IVM metrics. 1 out of N requests will be sampled where N is this value.      
                                                                                                                                                      
      --shard-id string                             default: "0"                                                                                      
        ZERO_SHARD_ID env                                                                                                                             

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -6,6 +6,8 @@ import {parseOptions, type Config} from '../../../shared/src/options.ts';
 import * as v from '../../../shared/src/valita.ts';
 import {runtimeDebugFlags} from '../../../zqlite/src/runtime-debug.ts';
 import {singleProcessMode} from '../types/processes.ts';
+import {logOptions} from '../../../otel/src/log-options.ts';
+export type {LogConfig} from '../../../otel/src/log-options.ts';
 
 /**
  * Configures the view of the upstream database replicated to this zero-cache.
@@ -50,35 +52,6 @@ const shardOptions = {
 };
 
 export type ShardConfig = Config<typeof shardOptions>;
-
-const logOptions = {
-  level: v
-    .union(
-      v.literal('debug'),
-      v.literal('info'),
-      v.literal('warn'),
-      v.literal('error'),
-    )
-    .default('info'),
-
-  format: {
-    type: v.union(v.literal('text'), v.literal('json')).default('text'),
-    desc: [
-      `Use {bold text} for developer-friendly console logging`,
-      `and {bold json} for consumption by structured-logging services`,
-    ],
-  },
-
-  traceCollector: {
-    type: v.string().optional(),
-    desc: [
-      `The URL of the trace collector to which to send trace data. Traces are sent over http.`,
-      `Port defaults to 4318 for most collectors.`,
-    ],
-  },
-};
-
-export type LogConfig = Config<typeof logOptions>;
 
 const perUserMutationLimit = {
   max: {

--- a/packages/zero-cache/src/scripts/run-query.ts
+++ b/packages/zero-cache/src/scripts/run-query.ts
@@ -18,11 +18,19 @@ import {
 } from '../../../zqlite/src/runtime-debug.ts';
 import {TableSource} from '../../../zqlite/src/table-source.ts';
 import {getSchema} from '../auth/load-schema.ts';
-import {getDebugConfig} from '../config/zero-config.ts';
+import {getDebugConfig, type LogConfig} from '../config/zero-config.ts';
 
 const config = getDebugConfig();
 const schemaAndPermissions = await getSchema(config);
 runtimeDebugFlags.trackRowsVended = true;
+
+const lc = createSilentLogContext();
+const logConfig: LogConfig = {
+  format: 'text',
+  level: 'debug',
+  ivmSampling: 0,
+  slowRowThreshold: 0,
+};
 
 const db = new Database(createSilentLogContext(), config.replicaFile);
 const sources = new Map<string, TableSource>();
@@ -33,6 +41,8 @@ const host: QueryDelegate = {
       return source;
     }
     source = new TableSource(
+      lc,
+      logConfig,
       '',
       db,
       name,

--- a/packages/zero-cache/src/server/multi/config.test.ts
+++ b/packages/zero-cache/src/server/multi/config.test.ts
@@ -69,7 +69,9 @@ test('parse options', () => {
         },
         "log": {
           "format": "text",
+          "ivmSampling": 0,
           "level": "info",
+          "slowRowThreshold": 3,
         },
         "perUserMutationLimit": {
           "windowMs": 60000,
@@ -130,7 +132,9 @@ test('parse options', () => {
         "ZERO_LITESTREAM_CONFIG_PATH": "./src/services/litestream/config.yml",
         "ZERO_LITESTREAM_LOG_LEVEL": "warn",
         "ZERO_LOG_FORMAT": "text",
+        "ZERO_LOG_IVM_SAMPLING": "0",
         "ZERO_LOG_LEVEL": "info",
+        "ZERO_LOG_SLOW_ROW_THRESHOLD": "3",
         "ZERO_PER_USER_MUTATION_LIMIT_WINDOW_MS": "60000",
         "ZERO_PORT": "4848",
         "ZERO_SCHEMA_FILE": "zero-schema.json",
@@ -319,6 +323,14 @@ test('zero-cache --help', () => {
        ZERO_LOG_TRACE_COLLECTOR env                                                                                                                  
                                                    The URL of the trace collector to which to send trace data. Traces are sent over http.            
                                                    Port defaults to 4318 for most collectors.                                                        
+                                                                                                                                                     
+     --log-slow-row-threshold number               default: 3                                                                                        
+       ZERO_LOG_SLOW_ROW_THRESHOLD env                                                                                                               
+                                                   The number of ms a row must take to fetch from table-source before it is considered slow.         
+                                                                                                                                                     
+     --log-ivm-sampling number                     default: 0                                                                                        
+       ZERO_LOG_IVM_SAMPLING env                                                                                                                     
+                                                   How often to take collect IVM metrics. 1 means always, 100 means 1% of the time, 0 means never    
                                                                                                                                                      
      --shard-id string                             default: "0"                                                                                      
        ZERO_SHARD_ID env                                                                                                                             

--- a/packages/zero-cache/src/server/multi/config.test.ts
+++ b/packages/zero-cache/src/server/multi/config.test.ts
@@ -69,9 +69,9 @@ test('parse options', () => {
         },
         "log": {
           "format": "text",
-          "ivmSampling": 0,
+          "ivmSampling": 5000,
           "level": "info",
-          "slowRowThreshold": 3,
+          "slowRowThreshold": 2,
         },
         "perUserMutationLimit": {
           "windowMs": 60000,
@@ -132,9 +132,9 @@ test('parse options', () => {
         "ZERO_LITESTREAM_CONFIG_PATH": "./src/services/litestream/config.yml",
         "ZERO_LITESTREAM_LOG_LEVEL": "warn",
         "ZERO_LOG_FORMAT": "text",
-        "ZERO_LOG_IVM_SAMPLING": "0",
+        "ZERO_LOG_IVM_SAMPLING": "5000",
         "ZERO_LOG_LEVEL": "info",
-        "ZERO_LOG_SLOW_ROW_THRESHOLD": "3",
+        "ZERO_LOG_SLOW_ROW_THRESHOLD": "2",
         "ZERO_PER_USER_MUTATION_LIMIT_WINDOW_MS": "60000",
         "ZERO_PORT": "4848",
         "ZERO_SCHEMA_FILE": "zero-schema.json",
@@ -324,13 +324,13 @@ test('zero-cache --help', () => {
                                                    The URL of the trace collector to which to send trace data. Traces are sent over http.            
                                                    Port defaults to 4318 for most collectors.                                                        
                                                                                                                                                      
-     --log-slow-row-threshold number               default: 3                                                                                        
+     --log-slow-row-threshold number               default: 2                                                                                        
        ZERO_LOG_SLOW_ROW_THRESHOLD env                                                                                                               
                                                    The number of ms a row must take to fetch from table-source before it is considered slow.         
                                                                                                                                                      
-     --log-ivm-sampling number                     default: 0                                                                                        
+     --log-ivm-sampling number                     default: 5000                                                                                     
        ZERO_LOG_IVM_SAMPLING env                                                                                                                     
-                                                   How often to take collect IVM metrics. 1 means always, 100 means 1% of the time, 0 means never    
+                                                   How often to collect IVM metrics. 1 out of N requests will be sampled where N is this value.      
                                                                                                                                                      
      --shard-id string                             default: "0"                                                                                      
        ZERO_SHARD_ID env                                                                                                                             

--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -120,6 +120,7 @@ export default async function runWorker(
       cvrDB,
       new PipelineDriver(
         logger,
+        config.log,
         new Snapshotter(logger, replicaFile),
         operatorStorage.createClientGroupStorage(id),
         id,

--- a/packages/zero-cache/src/services/mutagen/mutagen.authz.pg-test.ts
+++ b/packages/zero-cache/src/services/mutagen/mutagen.authz.pg-test.ts
@@ -25,6 +25,17 @@ import {testDBs} from '../../test/db.ts';
 import type {PostgresDB} from '../../types/pg.ts';
 import {zeroSchema} from './mutagen-test-shared.ts';
 import {processMutation} from './mutagen.ts';
+import type {LogConfig, ZeroConfig} from '../../config/zero-config.ts';
+
+const logConfig: LogConfig = {
+  format: 'text',
+  level: 'debug',
+  ivmSampling: 0,
+  slowRowThreshold: 0,
+};
+const zeroConfig = {
+  log: logConfig,
+} as unknown as ZeroConfig;
 
 const SHARD_ID = '0';
 const CG_ID = 'abc';
@@ -294,7 +305,7 @@ beforeEach(async () => {
   createReplicaTables(replica);
   authorizer = new WriteAuthorizerImpl(
     lc,
-    {},
+    zeroConfig,
     schema,
     permissionsConfig,
     replica,

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -15,6 +15,14 @@ import {
 import {CREATE_STORAGE_TABLE, DatabaseStorage} from './database-storage.ts';
 import {PipelineDriver} from './pipeline-driver.ts';
 import {ResetPipelinesSignal, Snapshotter} from './snapshotter.ts';
+import type {LogConfig} from '../../config/zero-config.ts';
+
+const logConfig: LogConfig = {
+  format: 'text',
+  level: 'debug',
+  ivmSampling: 0,
+  slowRowThreshold: 0,
+};
 
 describe('view-syncer/pipeline-driver', () => {
   let dbFile: DbFile;
@@ -33,6 +41,7 @@ describe('view-syncer/pipeline-driver', () => {
 
     pipelines = new PipelineDriver(
       lc,
+      logConfig,
       new Snapshotter(lc, dbFile.path),
       new DatabaseStorage(storage).createClientGroupStorage('foo-client-group'),
       'pipeline-driver.test.ts',

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -21,6 +21,7 @@ import type {SchemaVersions} from '../../types/schema-versions.ts';
 import {getSubscriptionState} from '../replicator/schema/replication-state.ts';
 import type {ClientGroupStorage} from './database-storage.ts';
 import {type SnapshotDiff, Snapshotter} from './snapshotter.ts';
+import type {LogConfig} from '../../config/zero-config.ts';
 
 export type RowAdd = {
   readonly type: 'add';
@@ -64,12 +65,14 @@ export class PipelineDriver {
   readonly #snapshotter: Snapshotter;
   readonly #storage: ClientGroupStorage;
   readonly #clientGroupID: string;
+  readonly #logConfig: LogConfig;
   #tableSpecs: Map<string, LiteAndZqlSpec> | null = null;
   #streamer: Streamer | null = null;
   #replicaVersion: string | null = null;
 
   constructor(
     lc: LogContext,
+    logConfig: LogConfig,
     snapshotter: Snapshotter,
     storage: ClientGroupStorage,
     clientGroupID: string,
@@ -78,6 +81,7 @@ export class PipelineDriver {
     this.#snapshotter = snapshotter;
     this.#storage = storage;
     this.#clientGroupID = clientGroupID;
+    this.#logConfig = logConfig;
   }
 
   /**
@@ -339,6 +343,8 @@ export class PipelineDriver {
 
     const {db} = this.#snapshotter.current();
     source = new TableSource(
+      this.#lc,
+      this.#logConfig,
       this.#clientGroupID,
       db.db,
       tableName,

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -52,8 +52,15 @@ import {PipelineDriver} from './pipeline-driver.ts';
 import {initViewSyncerSchema} from './schema/init.ts';
 import {Snapshotter} from './snapshotter.ts';
 import {pickToken, type SyncContext, ViewSyncerService} from './view-syncer.ts';
+import type {LogConfig} from '../../config/zero-config.ts';
 
 const SHARD_ID = 'ABC';
+const logConfig: LogConfig = {
+  format: 'text',
+  level: 'debug',
+  ivmSampling: 0,
+  slowRowThreshold: 0,
+};
 
 const EXPECTED_LMIDS_AST: AST = {
   schema: '',
@@ -378,6 +385,7 @@ async function setup(permissions: PermissionsConfig = {}) {
     cvrDB,
     new PipelineDriver(
       lc.withContext('component', 'pipeline-driver'),
+      logConfig,
       new Snapshotter(lc, replicaDbFile.path),
       operatorStorage,
       'view-syncer.pg-test.ts',

--- a/packages/zql/src/builder/builder.test.ts
+++ b/packages/zql/src/builder/builder.test.ts
@@ -9,9 +9,21 @@ import {
   buildPipeline,
   groupSubqueryConditions,
 } from './builder.ts';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import type {LogConfig} from '../../../otel/src/log-options.ts';
+
+const lc = createSilentLogContext();
+const logConfig: LogConfig = {
+  format: 'text',
+  level: 'debug',
+  ivmSampling: 0,
+  slowRowThreshold: 0,
+};
 
 export function testSources() {
   const users = createSource(
+    lc,
+    logConfig,
     'table',
     {
       id: {type: 'number'},
@@ -28,7 +40,13 @@ export function testSources() {
   users.push({type: 'add', row: {id: 6, name: 'darick', recruiterID: 3}});
   users.push({type: 'add', row: {id: 7, name: 'alex', recruiterID: 1}});
 
-  const states = createSource('table', {code: {type: 'string'}}, ['code']);
+  const states = createSource(
+    lc,
+    logConfig,
+    'table',
+    {code: {type: 'string'}},
+    ['code'],
+  );
   states.push({type: 'add', row: {code: 'CA'}});
   states.push({type: 'add', row: {code: 'HI'}});
   states.push({type: 'add', row: {code: 'AZ'}});
@@ -36,6 +54,8 @@ export function testSources() {
   states.push({type: 'add', row: {code: 'GA'}});
 
   const userStates = createSource(
+    lc,
+    logConfig,
     'table',
     {userID: {type: 'number'}, stateCode: {type: 'string'}},
     ['userID', 'stateCode'],

--- a/packages/zql/src/ivm/array-view.test.ts
+++ b/packages/zql/src/ivm/array-view.test.ts
@@ -10,11 +10,25 @@ import type {Input} from './operator.ts';
 import type {SourceSchema} from './schema.ts';
 import {Take} from './take.ts';
 import {createSource} from './test/source-factory.ts';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import type {LogConfig} from '../../../otel/src/log-options.ts';
+
+const lc = createSilentLogContext();
+const logConfig: LogConfig = {
+  format: 'text',
+  level: 'debug',
+  ivmSampling: 0,
+  slowRowThreshold: 0,
+};
 
 test('basics', () => {
-  const ms = createSource('table', {a: {type: 'number'}, b: {type: 'string'}}, [
-    'a',
-  ]);
+  const ms = createSource(
+    lc,
+    logConfig,
+    'table',
+    {a: {type: 'number'}, b: {type: 'string'}},
+    ['a'],
+  );
   ms.push({row: {a: 1, b: 'a'}, type: 'add'});
   ms.push({row: {a: 2, b: 'b'}, type: 'add'});
 
@@ -74,9 +88,13 @@ test('basics', () => {
 });
 
 test('single-format', () => {
-  const ms = createSource('table', {a: {type: 'number'}, b: {type: 'string'}}, [
-    'a',
-  ]);
+  const ms = createSource(
+    lc,
+    logConfig,
+    'table',
+    {a: {type: 'number'}, b: {type: 'string'}},
+    ['a'],
+  );
   ms.push({row: {a: 1, b: 'a'}, type: 'add'});
 
   const view = new ArrayView(
@@ -117,9 +135,13 @@ test('single-format', () => {
 });
 
 test('hydrate-empty', () => {
-  const ms = createSource('table', {a: {type: 'number'}, b: {type: 'string'}}, [
-    'a',
-  ]);
+  const ms = createSource(
+    lc,
+    logConfig,
+    'table',
+    {a: {type: 'number'}, b: {type: 'string'}},
+    ['a'],
+  );
 
   const view = new ArrayView(
     ms.connect([
@@ -142,6 +164,8 @@ test('hydrate-empty', () => {
 
 test('tree', () => {
   const ms = createSource(
+    lc,
+    logConfig,
     'table',
     {id: {type: 'number'}, name: {type: 'string'}, childID: {type: 'number'}},
     ['id'],
@@ -414,6 +438,8 @@ test('tree', () => {
 
 test('tree-single', () => {
   const ms = createSource(
+    lc,
+    logConfig,
     'table',
     {id: {type: 'number'}, name: {type: 'string'}, childID: {type: 'number'}},
     ['id'],
@@ -908,9 +934,13 @@ test('collapse-single', () => {
 });
 
 test('basic with edit pushes', () => {
-  const ms = createSource('table', {a: {type: 'number'}, b: {type: 'string'}}, [
-    'a',
-  ]);
+  const ms = createSource(
+    lc,
+    logConfig,
+    'table',
+    {a: {type: 'number'}, b: {type: 'string'}},
+    ['a'],
+  );
   ms.push({row: {a: 1, b: 'a'}, type: 'add'});
   ms.push({row: {a: 2, b: 'b'}, type: 'add'});
 
@@ -957,6 +987,8 @@ test('basic with edit pushes', () => {
 
 test('tree edit', () => {
   const ms = createSource(
+    lc,
+    logConfig,
     'table',
     {
       id: {type: 'number'},
@@ -1101,9 +1133,13 @@ test('tree edit', () => {
 });
 
 test('edit to change the order', () => {
-  const ms = createSource('table', {a: {type: 'number'}, b: {type: 'string'}}, [
-    'a',
-  ]);
+  const ms = createSource(
+    lc,
+    logConfig,
+    'table',
+    {a: {type: 'number'}, b: {type: 'string'}},
+    ['a'],
+  );
   for (const row of [
     {a: 10, b: 'a'},
     {a: 20, b: 'b'},

--- a/packages/zql/src/ivm/destroy.test.ts
+++ b/packages/zql/src/ivm/destroy.test.ts
@@ -5,11 +5,25 @@ import {FanOut} from './fan-out.ts';
 import {Filter} from './filter.ts';
 import {Snitch} from './snitch.ts';
 import {createSource} from './test/source-factory.ts';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import type {LogConfig} from '../../../otel/src/log-options.ts';
+
+const lc = createSilentLogContext();
+const logConfig: LogConfig = {
+  format: 'text',
+  level: 'debug',
+  ivmSampling: 0,
+  slowRowThreshold: 0,
+};
 
 test('destroy source connections', () => {
-  const ms = createSource('table', {a: {type: 'string'}, b: {type: 'string'}}, [
-    'a',
-  ]);
+  const ms = createSource(
+    lc,
+    logConfig,
+    'table',
+    {a: {type: 'string'}, b: {type: 'string'}},
+    ['a'],
+  );
   const connection1 = ms.connect([['a', 'asc']]);
   const connection2 = ms.connect([['a', 'asc']]);
 
@@ -56,9 +70,13 @@ test('destroy source connections', () => {
 });
 
 test('destroy a pipeline that has forking', () => {
-  const ms = createSource('table', {a: {type: 'number'}, b: {type: 'string'}}, [
-    'a',
-  ]);
+  const ms = createSource(
+    lc,
+    logConfig,
+    'table',
+    {a: {type: 'number'}, b: {type: 'string'}},
+    ['a'],
+  );
   const connector = ms.connect([['a', 'asc']]);
   const fanOut = new FanOut(connector);
   const filter1 = new Filter(fanOut, () => true);

--- a/packages/zql/src/ivm/exists.fetch.test.ts
+++ b/packages/zql/src/ivm/exists.fetch.test.ts
@@ -12,6 +12,8 @@ import {Join} from './join.ts';
 import {MemoryStorage} from './memory-storage.ts';
 import {Snitch, type SnitchMessage} from './snitch.ts';
 import {createSource} from './test/source-factory.ts';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import type {LogConfig} from '../../../otel/src/log-options.ts';
 
 const base = {
   columns: [
@@ -25,6 +27,14 @@ const base = {
     relationshipName: 'comments',
   },
 } as const;
+
+const lc = createSilentLogContext();
+const logConfig: LogConfig = {
+  format: 'text',
+  level: 'debug',
+  ivmSampling: 0,
+  slowRowThreshold: 0,
+};
 
 const oneParentWithChildTest: FetchTest = {
   ...base,
@@ -1898,7 +1908,13 @@ function fetchTest(t: FetchTest, reverse: boolean = false): FetchTestResults {
 
   const sources = t.sources.map((rows, i) => {
     const ordering = t.sorts?.[i] ?? [['id', 'asc']];
-    const source = createSource(`t${i}`, t.columns[i], t.primaryKeys[i]);
+    const source = createSource(
+      lc,
+      logConfig,
+      `t${i}`,
+      t.columns[i],
+      t.primaryKeys[i],
+    );
     for (const row of rows) {
       source.push({type: 'add', row});
     }

--- a/packages/zql/src/ivm/fan-out-fan-in.test.ts
+++ b/packages/zql/src/ivm/fan-out-fan-in.test.ts
@@ -4,11 +4,25 @@ import {FanIn} from './fan-in.ts';
 import {FanOut} from './fan-out.ts';
 import {Filter} from './filter.ts';
 import {createSource} from './test/source-factory.ts';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import type {LogConfig} from '../../../otel/src/log-options.ts';
+
+const lc = createSilentLogContext();
+const logConfig: LogConfig = {
+  format: 'text',
+  level: 'debug',
+  ivmSampling: 0,
+  slowRowThreshold: 0,
+};
 
 test('fan-out pushes along all paths', () => {
-  const s = createSource('table', {a: {type: 'number'}, b: {type: 'string'}}, [
-    'a',
-  ]);
+  const s = createSource(
+    lc,
+    logConfig,
+    'table',
+    {a: {type: 'number'}, b: {type: 'string'}},
+    ['a'],
+  );
   const connector = s.connect([['a', 'asc']]);
   const fanOut = new FanOut(connector);
   const catch1 = new Catch(fanOut);
@@ -47,9 +61,13 @@ test('fan-out pushes along all paths', () => {
 });
 
 test('fan-out,fan-in pairing does not duplicate pushes', () => {
-  const s = createSource('table', {a: {type: 'number'}, b: {type: 'string'}}, [
-    'a',
-  ]);
+  const s = createSource(
+    lc,
+    logConfig,
+    'table',
+    {a: {type: 'number'}, b: {type: 'string'}},
+    ['a'],
+  );
   const connector = s.connect([['a', 'asc']]);
   const fanOut = new FanOut(connector);
   const filter1 = new Filter(fanOut, () => true);
@@ -99,6 +117,8 @@ test('fan-out,fan-in pairing does not duplicate pushes', () => {
 
 test('fan-in fetch', () => {
   const s = createSource(
+    lc,
+    logConfig,
     'table',
     {a: {type: 'boolean'}, b: {type: 'boolean'}},
     ['a', 'b'],
@@ -149,9 +169,13 @@ test('fan-in fetch', () => {
 });
 
 test('cleanup called once per branch', () => {
-  const s = createSource('table', {a: {type: 'number'}, b: {type: 'string'}}, [
-    'a',
-  ]);
+  const s = createSource(
+    lc,
+    logConfig,
+    'table',
+    {a: {type: 'number'}, b: {type: 'string'}},
+    ['a'],
+  );
   const connector = s.connect([['a', 'asc']]);
   const fanOut = new FanOut(connector);
   const filter1 = new Filter(fanOut, () => true);

--- a/packages/zql/src/ivm/filter.test.ts
+++ b/packages/zql/src/ivm/filter.test.ts
@@ -2,11 +2,25 @@ import {expect, test} from 'vitest';
 import {Catch} from './catch.ts';
 import {Filter} from './filter.ts';
 import {createSource} from './test/source-factory.ts';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import type {LogConfig} from '../../../otel/src/log-options.ts';
+
+const lc = createSilentLogContext();
+const logConfig: LogConfig = {
+  format: 'text',
+  level: 'debug',
+  ivmSampling: 0,
+  slowRowThreshold: 0,
+};
 
 test('basics', () => {
-  const ms = createSource('table', {a: {type: 'number'}, b: {type: 'string'}}, [
-    'a',
-  ]);
+  const ms = createSource(
+    lc,
+    logConfig,
+    'table',
+    {a: {type: 'number'}, b: {type: 'string'}},
+    ['a'],
+  );
   ms.push({type: 'add', row: {a: 3, b: 'foo'}});
   ms.push({type: 'add', row: {a: 2, b: 'bar'}});
   ms.push({type: 'add', row: {a: 1, b: 'foo'}});
@@ -49,9 +63,13 @@ test('basics', () => {
 });
 
 test('edit', () => {
-  const ms = createSource('table', {a: {type: 'number'}, x: {type: 'number'}}, [
-    'a',
-  ]);
+  const ms = createSource(
+    lc,
+    logConfig,
+    'table',
+    {a: {type: 'number'}, x: {type: 'number'}},
+    ['a'],
+  );
   for (const row of [
     {a: 1, x: 1},
     {a: 2, x: 2},

--- a/packages/zql/src/ivm/join.fetch.test.ts
+++ b/packages/zql/src/ivm/join.fetch.test.ts
@@ -13,6 +13,16 @@ import {MemoryStorage} from './memory-storage.ts';
 import type {SourceSchema} from './schema.ts';
 import {Snitch, type SnitchMessage} from './snitch.ts';
 import {createSource} from './test/source-factory.ts';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import type {LogConfig} from '../../../otel/src/log-options.ts';
+
+const lc = createSilentLogContext();
+const logConfig: LogConfig = {
+  format: 'text',
+  level: 'debug',
+  ivmSampling: 0,
+  slowRowThreshold: 0,
+};
 
 suite('fetch one:many', () => {
   const base = {
@@ -2139,7 +2149,13 @@ function fetchTest(t: FetchTest): FetchTestResults {
 
   const sources = t.sources.map((rows, i) => {
     const ordering = t.sorts?.[i] ?? [['id', 'asc']];
-    const source = createSource(`t${i}`, t.columns[i], t.primaryKeys[i]);
+    const source = createSource(
+      lc,
+      logConfig,
+      `t${i}`,
+      t.columns[i],
+      t.primaryKeys[i],
+    );
     for (const row of rows) {
       source.push({type: 'add', row});
     }

--- a/packages/zql/src/ivm/join.sibling.test.ts
+++ b/packages/zql/src/ivm/join.sibling.test.ts
@@ -12,6 +12,16 @@ import type {Input} from './operator.ts';
 import {Snitch, type SnitchMessage} from './snitch.ts';
 import type {SourceChange} from './source.ts';
 import {createSource} from './test/source-factory.ts';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import type {LogConfig} from '../../../otel/src/log-options.ts';
+
+const lc = createSilentLogContext();
+const logConfig: LogConfig = {
+  format: 'text',
+  level: 'debug',
+  ivmSampling: 0,
+  slowRowThreshold: 0,
+};
 
 suite('sibling relationships tests with issues, comments, and owners', () => {
   const base = {
@@ -865,7 +875,13 @@ function pushSiblingTest(t: PushTestSibling): PushTestSiblingResults {
 
   const sources = t.sources.map((rows, i) => {
     const ordering = t.sorts?.[i] ?? [['id', 'asc']];
-    const source = createSource('test', t.columns[i], t.primaryKeys[i]);
+    const source = createSource(
+      lc,
+      logConfig,
+      'test',
+      t.columns[i],
+      t.primaryKeys[i],
+    );
     for (const row of rows) {
       source.push({type: 'add', row});
     }

--- a/packages/zql/src/ivm/memory-source.test.ts
+++ b/packages/zql/src/ivm/memory-source.test.ts
@@ -11,10 +11,22 @@ import {
   overlaysForStartAtForTest,
 } from './memory-source.ts';
 import {createSource} from './test/source-factory.ts';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import type {LogConfig} from '../../../otel/src/log-options.ts';
+
+const lc = createSilentLogContext();
+const logConfig: LogConfig = {
+  format: 'text',
+  level: 'debug',
+  ivmSampling: 0,
+  slowRowThreshold: 0,
+};
 
 test('schema', () => {
   compareRowsTest((order: Ordering) => {
-    const ms = createSource('table', {a: {type: 'string'}}, ['a']);
+    const ms = createSource(lc, logConfig, 'table', {a: {type: 'string'}}, [
+      'a',
+    ]);
     return ms.connect(order).getSchema().compareRows;
   });
 });
@@ -97,6 +109,8 @@ test('indexes get cleaned up when not needed', () => {
 
 test('push edit change', () => {
   const ms = createSource(
+    lc,
+    logConfig,
     'table',
     {a: {type: 'string'}, b: {type: 'string'}, c: {type: 'string'}},
     ['a'],
@@ -134,6 +148,8 @@ test('push edit change', () => {
 
 test('fetch during push edit change', () => {
   const ms = createSource(
+    lc,
+    logConfig,
     'table',
     {a: {type: 'string'}, b: {type: 'string'}, c: {type: 'string'}},
     ['a'],

--- a/packages/zql/src/ivm/skip.test.ts
+++ b/packages/zql/src/ivm/skip.test.ts
@@ -4,10 +4,22 @@ import type {FetchRequest} from './operator.ts';
 import {type Bound, Skip} from './skip.ts';
 import type {SourceChange} from './source.ts';
 import {createSource} from './test/source-factory.ts';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import type {LogConfig} from '../../../otel/src/log-options.ts';
+
+const lc = createSilentLogContext();
+const logConfig: LogConfig = {
+  format: 'text',
+  level: 'debug',
+  ivmSampling: 0,
+  slowRowThreshold: 0,
+};
 
 suite('fetch', () => {
   function t(c: {skipBound: Bound; fetchRequest: FetchRequest}) {
     const ms = createSource(
+      lc,
+      logConfig,
       'users',
       {
         id: {type: 'number'},
@@ -876,6 +888,8 @@ suite('fetch', () => {
 suite('push', () => {
   function t(c: {name?: string; skipBound: Bound; pushes: SourceChange[]}) {
     const ms = createSource(
+      lc,
+      logConfig,
       'users',
       {
         id: {type: 'number'},

--- a/packages/zql/src/ivm/source.test.ts
+++ b/packages/zql/src/ivm/source.test.ts
@@ -11,6 +11,16 @@ import type {Node} from './data.ts';
 import type {FetchRequest, Input, Output, Start} from './operator.ts';
 import type {SourceChange} from './source.ts';
 import {createSource} from './test/source-factory.ts';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import type {LogConfig} from '../../../otel/src/log-options.ts';
+
+const lc = createSilentLogContext();
+const logConfig: LogConfig = {
+  format: 'text',
+  level: 'debug',
+  ivmSampling: 0,
+  slowRowThreshold: 0,
+};
 
 function asNodes(rows: Row[]) {
   return rows.map(row => ({
@@ -51,7 +61,7 @@ class OverlaySpy implements Output {
 
 test('simple-fetch', () => {
   const sort = [['a', 'asc']] as const;
-  const s = createSource('table', {a: {type: 'number'}}, ['a']);
+  const s = createSource(lc, logConfig, 'table', {a: {type: 'number'}}, ['a']);
   const out = new Catch(s.connect(sort));
   expect(out.fetch()).toEqual([]);
 
@@ -73,6 +83,8 @@ test('simple-fetch', () => {
 test('fetch-with-constraint', () => {
   const sort = [['a', 'asc']] as const;
   const s = createSource(
+    lc,
+    logConfig,
     'table',
     {
       a: {type: 'number'},
@@ -129,6 +141,8 @@ test('fetch-with-constraint', () => {
 test('fetch-start', () => {
   const sort = [['a', 'asc']] as const;
   const s = createSource(
+    lc,
+    logConfig,
     'table',
     {
       a: {type: 'number'},
@@ -170,6 +184,8 @@ test('fetch-start', () => {
 test('fetch-start reverse', () => {
   const sort = [['a', 'asc']] as const;
   const s = createSource(
+    lc,
+    logConfig,
     'table',
     {
       a: {type: 'number'},
@@ -220,6 +236,8 @@ suite('fetch-with-constraint-and-start', () => {
   }) {
     const sort = [['a', 'asc']] as const;
     const s = createSource(
+      lc,
+      logConfig,
       'table',
       c.columns ?? {
         a: {type: 'number'},
@@ -481,7 +499,7 @@ suite('fetch-with-constraint-and-start', () => {
 
 test('push', () => {
   const sort = [['a', 'asc']] as const;
-  const s = createSource('table', {a: {type: 'number'}}, ['a']);
+  const s = createSource(lc, logConfig, 'table', {a: {type: 'number'}}, ['a']);
   const out = new Catch(s.connect(sort));
 
   expect(out.pushes).toEqual([]);
@@ -532,7 +550,7 @@ test('overlay-source-isolation', () => {
   // only shows up in the cases it is supposed to.
 
   const sort = [['a', 'asc']] as const;
-  const s = createSource('table', {a: {type: 'number'}}, ['a']);
+  const s = createSource(lc, logConfig, 'table', {a: {type: 'number'}}, ['a']);
   const o1 = new OverlaySpy(s.connect(sort));
   const o2 = new OverlaySpy(s.connect(sort));
   const o3 = new OverlaySpy(s.connect(sort));
@@ -565,7 +583,9 @@ suite('overlay-vs-fetch-start', () => {
     change: SourceChange;
   }) {
     const sort = [['a', 'asc']] as const;
-    const s = createSource('table', {a: {type: 'number'}}, ['a']);
+    const s = createSource(lc, logConfig, 'table', {a: {type: 'number'}}, [
+      'a',
+    ]);
     for (const row of c.startData) {
       s.push({type: 'add', row});
     }
@@ -1336,6 +1356,8 @@ suite('overlay-vs-constraint', () => {
   }) {
     const sort = [['a', 'asc']] as const;
     const s = createSource(
+      lc,
+      logConfig,
       'table',
       {
         a: {type: 'number'},
@@ -1511,6 +1533,8 @@ suite('overlay-vs-filter', () => {
       ['b', 'asc'],
     ] as const;
     const s = createSource(
+      lc,
+      logConfig,
       'table',
       {
         a: {type: 'number'},
@@ -1932,6 +1956,8 @@ suite('overlay-vs-constraint-and-start', () => {
   }) {
     const sort = [['a', 'asc']] as const;
     const s = createSource(
+      lc,
+      logConfig,
       'table',
       c.columns ?? {
         a: {type: 'number'},
@@ -2417,6 +2443,8 @@ test('per-output-sorts', () => {
     ['a', 'asc'],
   ] as const;
   const s = createSource(
+    lc,
+    logConfig,
     'table',
     {
       a: {type: 'number'},
@@ -2452,7 +2480,9 @@ test('streams-are-one-time-only', () => {
   // the server, they are backed by cursors over streaming SQL queries which
   // can't be rewound or branched. This test ensures that streas from all
   // sources behave this way for consistency.
-  const source = createSource('table', {a: {type: 'number'}}, ['a']);
+  const source = createSource(lc, logConfig, 'table', {a: {type: 'number'}}, [
+    'a',
+  ]);
   source.push({type: 'add', row: {a: 1}});
   source.push({type: 'add', row: {a: 2}});
   source.push({type: 'add', row: {a: 3}});
@@ -2482,6 +2512,8 @@ test('streams-are-one-time-only', () => {
 
 test('json is a valid type to read and write to/from a source', () => {
   const source = createSource(
+    lc,
+    logConfig,
     'table',
     {a: {type: 'number'}, j: {type: 'json'}},
     ['a'],
@@ -2550,6 +2582,8 @@ test('json is a valid type to read and write to/from a source', () => {
 
 test('IS and IS NOT comparisons against null', () => {
   const source = createSource(
+    lc,
+    logConfig,
     'table',
     {
       a: {type: 'number'},
@@ -2655,6 +2689,8 @@ test('IS and IS NOT comparisons against null', () => {
 
 test('constant/literal expression', () => {
   const source = createSource(
+    lc,
+    logConfig,
     'table',
     {n: {type: 'number'}, b: {type: 'boolean'}, s: {type: 'string'}},
     ['n'],

--- a/packages/zql/src/ivm/take.push.test.ts
+++ b/packages/zql/src/ivm/take.push.test.ts
@@ -11,6 +11,16 @@ import {Snitch, type SnitchMessage} from './snitch.ts';
 import type {SourceChange} from './source.ts';
 import {Take, type PartitionKey} from './take.ts';
 import {createSource} from './test/source-factory.ts';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import type {LogConfig} from '../../../otel/src/log-options.ts';
+
+const lc = createSilentLogContext();
+const logConfig: LogConfig = {
+  format: 'text',
+  level: 'debug',
+  ivmSampling: 0,
+  slowRowThreshold: 0,
+};
 
 suite('take with no partition', () => {
   const base = {
@@ -3781,7 +3791,7 @@ suite('take with partition', () => {
 
 function takeTest(t: TakeTest): TakeTestReults {
   const log: SnitchMessage[] = [];
-  const source = createSource('table', t.columns, t.primaryKey);
+  const source = createSource(lc, logConfig, 'table', t.columns, t.primaryKey);
   for (const row of t.sourceRows) {
     source.push({type: 'add', row});
   }

--- a/packages/zql/src/ivm/test/join-push-tests.ts
+++ b/packages/zql/src/ivm/test/join-push-tests.ts
@@ -14,6 +14,16 @@ import {Snitch, type SnitchMessage} from '../snitch.ts';
 import type {Source, SourceChange} from '../source.ts';
 import type {Format} from '../view.ts';
 import {createSource} from './source-factory.ts';
+import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import type {LogConfig} from '../../../../otel/src/log-options.ts';
+
+const lc = createSilentLogContext();
+const logConfig: LogConfig = {
+  format: 'text',
+  level: 'debug',
+  ivmSampling: 0,
+  slowRowThreshold: 0,
+};
 
 function makeSource(
   rows: readonly Row[],
@@ -23,7 +33,7 @@ function makeSource(
   snitchName: string,
   log: SnitchMessage[],
 ): {source: Source; snitch: Snitch} {
-  const source = createSource('test', columns, primaryKeys);
+  const source = createSource(lc, logConfig, 'test', columns, primaryKeys);
   for (const row of rows) {
     source.push({type: 'add', row});
   }

--- a/packages/zql/src/ivm/test/source-factory.ts
+++ b/packages/zql/src/ivm/test/source-factory.ts
@@ -2,22 +2,30 @@ import type {PrimaryKey} from '../../../../zero-protocol/src/primary-key.ts';
 import type {SchemaValue} from '../../../../zero-schema/src/table-schema.ts';
 import {MemorySource} from '../memory-source.ts';
 import type {Source} from '../source.ts';
+import type {LogConfig} from '../../../../otel/src/log-options.ts';
+import type {LogContext} from '@rocicorp/logger';
 
 export type SourceFactory = (
+  lc: LogContext,
+  logConfig: LogConfig,
   tableName: string,
   columns: Record<string, SchemaValue>,
   primaryKey: PrimaryKey,
 ) => Source;
 
 export const createSource: SourceFactory = (
+  lc: LogContext,
+  logConfig: LogConfig,
   tableName: string,
   columns: Record<string, SchemaValue>,
   primaryKey: PrimaryKey,
 ): Source => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const {sourceFactory} = globalThis as any;
+  const {sourceFactory} = globalThis as {
+    sourceFactory?: SourceFactory;
+  };
   if (sourceFactory) {
-    return sourceFactory(tableName, columns, primaryKey);
+    return sourceFactory(lc, logConfig, tableName, columns, primaryKey);
   }
 
   return new MemorySource(tableName, columns, primaryKey);

--- a/packages/zql/src/query/query-impl.query.test.ts
+++ b/packages/zql/src/query/query-impl.query.test.ts
@@ -12,6 +12,8 @@ import {newQuery, type QueryDelegate, QueryImpl} from './query-impl.ts';
 import type {AdvancedQuery} from './query-internal.ts';
 import {QueryDelegateImpl} from './test/query-delegate.ts';
 import {schema} from './test/test-schemas.ts';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import type {LogConfig} from '../../../otel/src/log-options.ts';
 
 /**
  * Some basic manual tests to get us started.
@@ -27,6 +29,14 @@ import {schema} from './test/test-schemas.ts';
  * and the generative testing will cover more than we can possibly
  * write by hand.
  */
+
+const lc = createSilentLogContext();
+const logConfig: LogConfig = {
+  format: 'text',
+  level: 'debug',
+  ivmSampling: 0,
+  slowRowThreshold: 0,
+};
 
 function addData(queryDelegate: QueryDelegate) {
   const userSource = must(queryDelegate.getSource('user'));
@@ -1013,8 +1023,20 @@ test('join with compound keys', () => {
   });
 
   const sources = {
-    a: createSource('a', schema.tables.a.columns, schema.tables.a.primaryKey),
-    b: createSource('b', schema.tables.b.columns, schema.tables.b.primaryKey),
+    a: createSource(
+      lc,
+      logConfig,
+      'a',
+      schema.tables.a.columns,
+      schema.tables.a.primaryKey,
+    ),
+    b: createSource(
+      lc,
+      logConfig,
+      'b',
+      schema.tables.b.columns,
+      schema.tables.b.primaryKey,
+    ),
   };
 
   const queryDelegate = new QueryDelegateImpl(sources);

--- a/packages/zql/src/query/test/query-delegate.ts
+++ b/packages/zql/src/query/test/query-delegate.ts
@@ -1,3 +1,5 @@
+import type {LogConfig} from '../../../../otel/src/log-options.ts';
+import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import type {AST} from '../../../../zero-protocol/src/ast.ts';
 import {MemoryStorage} from '../../ivm/memory-storage.ts';
 import type {Source} from '../../ivm/source.ts';
@@ -15,6 +17,14 @@ import {
   revisionSchema,
   userSchema,
 } from './test-schemas.ts';
+
+const lc = createSilentLogContext();
+const logConfig: LogConfig = {
+  format: 'text',
+  level: 'debug',
+  ivmSampling: 0,
+  slowRowThreshold: 0,
+};
 
 export class QueryDelegateImpl implements QueryDelegate {
   readonly #sources: Record<string, Source> = makeSources();
@@ -72,12 +82,38 @@ function makeSources() {
   };
 
   return {
-    user: createSource('user', user.columns, user.primaryKey),
-    issue: createSource('issue', issue.columns, issue.primaryKey),
-    comment: createSource('comment', comment.columns, comment.primaryKey),
-    revision: createSource('revision', revision.columns, revision.primaryKey),
-    label: createSource('label', label.columns, label.primaryKey),
+    user: createSource(lc, logConfig, 'user', user.columns, user.primaryKey),
+    issue: createSource(
+      lc,
+      logConfig,
+      'issue',
+      issue.columns,
+      issue.primaryKey,
+    ),
+    comment: createSource(
+      lc,
+      logConfig,
+      'comment',
+      comment.columns,
+      comment.primaryKey,
+    ),
+    revision: createSource(
+      lc,
+      logConfig,
+      'revision',
+      revision.columns,
+      revision.primaryKey,
+    ),
+    label: createSource(
+      lc,
+      logConfig,
+      'label',
+      label.columns,
+      label.primaryKey,
+    ),
     issueLabel: createSource(
+      lc,
+      logConfig,
       'issueLabel',
       issueLabel.columns,
       issueLabel.primaryKey,

--- a/packages/zqlite/src/query.test.ts
+++ b/packages/zqlite/src/query.test.ts
@@ -7,8 +7,18 @@ import {newQuery, type QueryDelegate} from '../../zql/src/query/query-impl.ts';
 import {schema} from '../../zql/src/query/test/test-schemas.ts';
 import {Database} from './db.ts';
 import {TableSource, toSQLiteTypeName} from './table-source.ts';
+import type {LogConfig} from '../../otel/src/log-options.ts';
 
 let queryDelegate: QueryDelegate;
+
+const lc = createSilentLogContext();
+const logConfig: LogConfig = {
+  format: 'text',
+  level: 'debug',
+  ivmSampling: 0,
+  slowRowThreshold: 0,
+};
+
 beforeEach(() => {
   const db = new Database(createSilentLogContext(), ':memory:');
   const sources = new Map<string, Source>();
@@ -31,6 +41,8 @@ beforeEach(() => {
       )`);
 
       source = new TableSource(
+        lc,
+        logConfig,
         'query.test.ts',
         db,
         name,

--- a/packages/zqlite/src/table-source.test.ts
+++ b/packages/zqlite/src/table-source.test.ts
@@ -14,6 +14,7 @@ import {
   TableSource,
   UnsupportedValueError,
 } from './table-source.ts';
+import type {LogConfig} from '../../otel/src/log-options.ts';
 
 const columns = {
   id: {type: 'string'},
@@ -21,6 +22,14 @@ const columns = {
   b: {type: 'number'},
   c: {type: 'number'},
 } as const;
+
+const lc = createSilentLogContext();
+const logConfig: LogConfig = {
+  format: 'text',
+  level: 'debug',
+  ivmSampling: 0,
+  slowRowThreshold: 0,
+};
 
 describe('fetching from a table source', () => {
   type Foo = {id: string; a: number; b: number; c: number};
@@ -173,6 +182,8 @@ describe('fetching from a table source', () => {
     },
   ] as const)('$name', ({sourceArgs, fetchArgs, expectedRows}) => {
     const source = new TableSource(
+      lc,
+      logConfig,
       'table-source.test.ts',
       db,
       sourceArgs[0],
@@ -262,6 +273,8 @@ describe('fetched value types', () => {
       );
       stmt.run(c.input);
       const source = new TableSource(
+        lc,
+        logConfig,
         'table-source.test.ts',
         db,
         'foo',
@@ -301,9 +314,15 @@ describe('no primary key', () => {
   stmt.run(['far', 234, 567, 333]);
   stmt.run(['boo', 345, 112, 444]);
   stmt.run(['foo', 345, 789, 555]);
-  const source = new TableSource('table-source.test.ts', db, 'foo', columns, [
-    'id',
-  ]);
+  const source = new TableSource(
+    lc,
+    logConfig,
+    'table-source.test.ts',
+    db,
+    'foo',
+    columns,
+    ['id'],
+  );
 
   test.each([
     [['id'], true],
@@ -318,7 +337,15 @@ describe('no primary key', () => {
     'requires primary key to be uniquely indexed: %o',
     (key, valid) => {
       const createSource = () =>
-        new TableSource('table-source.test.ts', db, 'foo', columns, key);
+        new TableSource(
+          lc,
+          logConfig,
+          'table-source.test.ts',
+          db,
+          'foo',
+          columns,
+          key,
+        );
       if (valid) {
         createSource();
       } else {
@@ -407,6 +434,8 @@ test('pushing values does the correct writes and outputs', () => {
     /* sql */ `CREATE TABLE foo (a, b, c, d, ignored, columns, PRIMARY KEY (a, b));`,
   );
   const source = new TableSource(
+    lc,
+    logConfig,
     'table-source.test.ts',
     db1,
     'foo',
@@ -671,6 +700,8 @@ test('getByKey', () => {
   );
 
   const source = new TableSource(
+    lc,
+    logConfig,
     'table-source.test.ts',
     db,
     'foo',

--- a/packages/zqlite/src/table-source.ts
+++ b/packages/zqlite/src/table-source.ts
@@ -74,6 +74,8 @@ type Statements = {
   readonly checkExists: Statement;
 };
 
+let eventCount = 0;
+
 /**
  * A source that is backed by a SQLite table.
  *
@@ -316,15 +318,16 @@ export class TableSource implements Source {
     query: string,
   ): IterableIterator<Row> {
     let result;
-    let row = 0;
     try {
       do {
         result = timeSampled(
           this.#lc,
-          ++row,
+          ++eventCount,
           this.#logConfig.ivmSampling,
           () => rowIterator.next(),
           this.#logConfig.slowRowThreshold,
+          () =>
+            `table-source.next took too long for ${query}. Are you missing an index?`,
         );
         if (result.done) {
           break;

--- a/packages/zqlite/src/test/source-factory.ts
+++ b/packages/zqlite/src/test/source-factory.ts
@@ -1,3 +1,4 @@
+import type {LogContext} from '@rocicorp/logger';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
 import type {PrimaryKey} from '../../../zero-protocol/src/primary-key.ts';
 import type {SchemaValue} from '../../../zero-schema/src/table-schema.ts';
@@ -6,8 +7,11 @@ import type {SourceFactory} from '../../../zql/src/ivm/test/source-factory.ts';
 import {Database} from '../db.ts';
 import {compile, sql} from '../internal/sql.ts';
 import {TableSource} from '../table-source.ts';
+import type {LogConfig} from '../../../otel/src/log-options.ts';
 
 export const createSource: SourceFactory = (
+  lc: LogContext,
+  logConfig: LogConfig,
   tableName: string,
   columns: Record<string, SchemaValue>,
   primaryKey: PrimaryKey,
@@ -24,5 +28,13 @@ export const createSource: SourceFactory = (
     )}));`,
   );
   db.exec(query);
-  return new TableSource('zqlite-test', db, tableName, columns, primaryKey);
+  return new TableSource(
+    lc,
+    logConfig,
+    'zqlite-test',
+    db,
+    tableName,
+    columns,
+    primaryKey,
+  );
 };


### PR DESCRIPTION
Exists and join will query both sides of a join.


Example:

```ts
z.query.issue.whereExists('comment')
```

Will query:
1. comment.issueID
2. issue.id

because something on the left or the right can change.

A user was missing an index on the opposite side of their join, causing fetches of parent rows to be very slow.

Pulling a single row from SQLite should not take more than 1ms. This adds some logging if/when it does.

https://rocicorp.slack.com/archives/C013XFG80JC/p1738069279890379?thread_ts=1737997408.519909&cid=C013XFG80JC