### PR TITLE
refactor(zql): callable relationships

### DIFF
--- a/packages/zero-cache/src/auth/read-authorizer.query.test.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.query.test.ts
@@ -26,8 +26,7 @@ import {
   bindStaticParameters,
   buildPipeline,
 } from '../../../zql/src/builder/builder.ts';
-import {Catch} from '../../../zql/src/ivm/catch.ts';
-import type {Node} from '../../../zql/src/ivm/data.ts';
+import {Catch, type CaughtNode} from '../../../zql/src/ivm/catch.ts';
 import {MemoryStorage} from '../../../zql/src/ivm/memory-storage.ts';
 import type {Source} from '../../../zql/src/ivm/source.ts';
 import type {ExpressionBuilder} from '../../../zql/src/query/expression.ts';
@@ -1526,7 +1525,7 @@ describe('read permissions against nested paths', () => {
 
 // maps over nodes, drops all information from `row` except the id
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function toIdsOnly(nodes: Node[]): any[] {
+function toIdsOnly(nodes: CaughtNode[]): any[] {
   return nodes.map(node => {
     return {
       id: node.row.id,

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -966,6 +966,35 @@ describe('view-syncer/pipeline-driver', () => {
           "table": "labels",
           "type": "add",
         },
+        {
+          "queryHash": "hash1",
+          "row": {
+            "_0_version": "134",
+            "issueID": "2",
+            "labelID": "1",
+            "legacyID": "2-1",
+          },
+          "rowKey": {
+            "issueID": "2",
+            "labelID": "1",
+            "legacyID": "2-1",
+          },
+          "table": "issueLabels",
+          "type": "add",
+        },
+        {
+          "queryHash": "hash1",
+          "row": {
+            "_0_version": "123",
+            "id": "1",
+            "name": "bug",
+          },
+          "rowKey": {
+            "id": "1",
+          },
+          "table": "labels",
+          "type": "add",
+        },
       ]
     `);
 

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -966,35 +966,6 @@ describe('view-syncer/pipeline-driver', () => {
           "table": "labels",
           "type": "add",
         },
-        {
-          "queryHash": "hash1",
-          "row": {
-            "_0_version": "134",
-            "issueID": "2",
-            "labelID": "1",
-            "legacyID": "2-1",
-          },
-          "rowKey": {
-            "issueID": "2",
-            "labelID": "1",
-            "legacyID": "2-1",
-          },
-          "table": "issueLabels",
-          "type": "add",
-        },
-        {
-          "queryHash": "hash1",
-          "row": {
-            "_0_version": "123",
-            "id": "1",
-            "name": "bug",
-          },
-          "rowKey": {
-            "id": "1",
-          },
-          "table": "labels",
-          "type": "add",
-        },
       ]
     `);
 

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -490,7 +490,7 @@ class Streamer {
 
       for (const [relationship, children] of Object.entries(relationships)) {
         const childSchema = must(schema.relationships[relationship]);
-        yield* this.#streamNodes(queryHash, childSchema, op, children);
+        yield* this.#streamNodes(queryHash, childSchema, op, children());
       }
     }
   }

--- a/packages/zql/src/builder/builder.test.ts
+++ b/packages/zql/src/builder/builder.test.ts
@@ -95,23 +95,82 @@ test('source-only', () => {
     ),
   );
 
-  expect(sink.fetch()).toEqual([
-    {row: {id: 1, name: 'aaron', recruiterID: null}, relationships: {}},
-    {row: {id: 7, name: 'alex', recruiterID: 1}, relationships: {}},
-    {row: {id: 5, name: 'cesar', recruiterID: 3}, relationships: {}},
-    {row: {id: 6, name: 'darick', recruiterID: 3}, relationships: {}},
-    {row: {id: 2, name: 'erik', recruiterID: 1}, relationships: {}},
-    {row: {id: 3, name: 'greg', recruiterID: 1}, relationships: {}},
-    {row: {id: 4, name: 'matt', recruiterID: 1}, relationships: {}},
-  ]);
+  expect(sink.fetch()).toMatchInlineSnapshot(`
+    [
+      {
+        "relationships": {},
+        "row": {
+          "id": 1,
+          "name": "aaron",
+          "recruiterID": null,
+        },
+      },
+      {
+        "relationships": {},
+        "row": {
+          "id": 7,
+          "name": "alex",
+          "recruiterID": 1,
+        },
+      },
+      {
+        "relationships": {},
+        "row": {
+          "id": 5,
+          "name": "cesar",
+          "recruiterID": 3,
+        },
+      },
+      {
+        "relationships": {},
+        "row": {
+          "id": 6,
+          "name": "darick",
+          "recruiterID": 3,
+        },
+      },
+      {
+        "relationships": {},
+        "row": {
+          "id": 2,
+          "name": "erik",
+          "recruiterID": 1,
+        },
+      },
+      {
+        "relationships": {},
+        "row": {
+          "id": 3,
+          "name": "greg",
+          "recruiterID": 1,
+        },
+      },
+      {
+        "relationships": {},
+        "row": {
+          "id": 4,
+          "name": "matt",
+          "recruiterID": 1,
+        },
+      },
+    ]
+  `);
 
   sources.users.push({type: 'add', row: {id: 8, name: 'sam'}});
-  expect(sink.pushes).toEqual([
-    {
-      type: 'add',
-      node: {row: {id: 8, name: 'sam'}, relationships: {}},
-    },
-  ]);
+  expect(sink.pushes).toMatchInlineSnapshot(`
+    [
+      {
+        "node": {
+          "relationships": {},
+          "row": {
+            "id": 8,
+            "name": "sam",
+          },
+        },
+        "type": "add",
+      },
+    ]
+  `);
 });
 
 test('filter', () => {
@@ -141,27 +200,78 @@ test('filter', () => {
     ),
   );
 
-  expect(sink.fetch()).toEqual([
-    {row: {id: 6, name: 'darick', recruiterID: 3}, relationships: {}},
-    {row: {id: 5, name: 'cesar', recruiterID: 3}, relationships: {}},
-    {row: {id: 4, name: 'matt', recruiterID: 1}, relationships: {}},
-    {row: {id: 3, name: 'greg', recruiterID: 1}, relationships: {}},
-    {row: {id: 2, name: 'erik', recruiterID: 1}, relationships: {}},
-  ]);
+  expect(sink.fetch()).toMatchInlineSnapshot(`
+    [
+      {
+        "relationships": {},
+        "row": {
+          "id": 6,
+          "name": "darick",
+          "recruiterID": 3,
+        },
+      },
+      {
+        "relationships": {},
+        "row": {
+          "id": 5,
+          "name": "cesar",
+          "recruiterID": 3,
+        },
+      },
+      {
+        "relationships": {},
+        "row": {
+          "id": 4,
+          "name": "matt",
+          "recruiterID": 1,
+        },
+      },
+      {
+        "relationships": {},
+        "row": {
+          "id": 3,
+          "name": "greg",
+          "recruiterID": 1,
+        },
+      },
+      {
+        "relationships": {},
+        "row": {
+          "id": 2,
+          "name": "erik",
+          "recruiterID": 1,
+        },
+      },
+    ]
+  `);
 
   sources.users.push({type: 'add', row: {id: 8, name: 'sam'}});
   sources.users.push({type: 'add', row: {id: 9, name: 'abby'}});
   sources.users.push({type: 'remove', row: {id: 8, name: 'sam'}});
-  expect(sink.pushes).toEqual([
-    {
-      type: 'add',
-      node: {row: {id: 8, name: 'sam'}, relationships: {}},
-    },
-    {
-      type: 'remove',
-      node: {row: {id: 8, name: 'sam'}, relationships: {}},
-    },
-  ]);
+  expect(sink.pushes).toMatchInlineSnapshot(`
+    [
+      {
+        "node": {
+          "relationships": {},
+          "row": {
+            "id": 8,
+            "name": "sam",
+          },
+        },
+        "type": "add",
+      },
+      {
+        "node": {
+          "relationships": {},
+          "row": {
+            "id": 8,
+            "name": "sam",
+          },
+        },
+        "type": "remove",
+      },
+    ]
+  `);
 });
 
 test('self-join', () => {
@@ -190,62 +300,134 @@ test('self-join', () => {
     ),
   );
 
-  expect(sink.fetch()).toEqual([
-    {
-      row: {id: 1, name: 'aaron', recruiterID: null},
-      relationships: {
-        recruiter: [],
+  expect(sink.fetch()).toMatchInlineSnapshot(`
+    [
+      {
+        "relationships": {
+          "recruiter": [],
+        },
+        "row": {
+          "id": 1,
+          "name": "aaron",
+          "recruiterID": null,
+        },
       },
-    },
-    {
-      row: {id: 2, name: 'erik', recruiterID: 1},
-      relationships: {
-        recruiter: [
-          {row: {id: 1, name: 'aaron', recruiterID: null}, relationships: {}},
-        ],
+      {
+        "relationships": {
+          "recruiter": [
+            {
+              "relationships": {},
+              "row": {
+                "id": 1,
+                "name": "aaron",
+                "recruiterID": null,
+              },
+            },
+          ],
+        },
+        "row": {
+          "id": 2,
+          "name": "erik",
+          "recruiterID": 1,
+        },
       },
-    },
-    {
-      row: {id: 3, name: 'greg', recruiterID: 1},
-      relationships: {
-        recruiter: [
-          {row: {id: 1, name: 'aaron', recruiterID: null}, relationships: {}},
-        ],
+      {
+        "relationships": {
+          "recruiter": [
+            {
+              "relationships": {},
+              "row": {
+                "id": 1,
+                "name": "aaron",
+                "recruiterID": null,
+              },
+            },
+          ],
+        },
+        "row": {
+          "id": 3,
+          "name": "greg",
+          "recruiterID": 1,
+        },
       },
-    },
-    {
-      row: {id: 4, name: 'matt', recruiterID: 1},
-      relationships: {
-        recruiter: [
-          {row: {id: 1, name: 'aaron', recruiterID: null}, relationships: {}},
-        ],
+      {
+        "relationships": {
+          "recruiter": [
+            {
+              "relationships": {},
+              "row": {
+                "id": 1,
+                "name": "aaron",
+                "recruiterID": null,
+              },
+            },
+          ],
+        },
+        "row": {
+          "id": 4,
+          "name": "matt",
+          "recruiterID": 1,
+        },
       },
-    },
-    {
-      row: {id: 5, name: 'cesar', recruiterID: 3},
-      relationships: {
-        recruiter: [
-          {row: {id: 3, name: 'greg', recruiterID: 1}, relationships: {}},
-        ],
+      {
+        "relationships": {
+          "recruiter": [
+            {
+              "relationships": {},
+              "row": {
+                "id": 3,
+                "name": "greg",
+                "recruiterID": 1,
+              },
+            },
+          ],
+        },
+        "row": {
+          "id": 5,
+          "name": "cesar",
+          "recruiterID": 3,
+        },
       },
-    },
-    {
-      row: {id: 6, name: 'darick', recruiterID: 3},
-      relationships: {
-        recruiter: [
-          {row: {id: 3, name: 'greg', recruiterID: 1}, relationships: {}},
-        ],
+      {
+        "relationships": {
+          "recruiter": [
+            {
+              "relationships": {},
+              "row": {
+                "id": 3,
+                "name": "greg",
+                "recruiterID": 1,
+              },
+            },
+          ],
+        },
+        "row": {
+          "id": 6,
+          "name": "darick",
+          "recruiterID": 3,
+        },
       },
-    },
-    {
-      row: {id: 7, name: 'alex', recruiterID: 1},
-      relationships: {
-        recruiter: [
-          {row: {id: 1, name: 'aaron', recruiterID: null}, relationships: {}},
-        ],
+      {
+        "relationships": {
+          "recruiter": [
+            {
+              "relationships": {},
+              "row": {
+                "id": 1,
+                "name": "aaron",
+                "recruiterID": null,
+              },
+            },
+          ],
+        },
+        "row": {
+          "id": 7,
+          "name": "alex",
+          "recruiterID": 1,
+        },
       },
-    },
-  ]);
+    ]
+  `);
 
   sources.users.push({type: 'add', row: {id: 8, name: 'sam', recruiterID: 2}});
   sources.users.push({type: 'add', row: {id: 9, name: 'abby', recruiterID: 8}});
@@ -255,74 +437,142 @@ test('self-join', () => {
   });
   sources.users.push({type: 'add', row: {id: 8, name: 'sam', recruiterID: 3}});
 
-  expect(sink.pushes).toEqual([
-    {
-      type: 'add',
-      node: {
-        row: {id: 8, name: 'sam', recruiterID: 2},
-        relationships: {
-          recruiter: [
-            {row: {id: 2, name: 'erik', recruiterID: 1}, relationships: {}},
-          ],
+  expect(sink.pushes).toMatchInlineSnapshot(`
+    [
+      {
+        "node": {
+          "relationships": {
+            "recruiter": [
+              {
+                "relationships": {},
+                "row": {
+                  "id": 2,
+                  "name": "erik",
+                  "recruiterID": 1,
+                },
+              },
+            ],
+          },
+          "row": {
+            "id": 8,
+            "name": "sam",
+            "recruiterID": 2,
+          },
         },
+        "type": "add",
       },
-    },
-    {
-      type: 'add',
-      node: {
-        row: {id: 9, name: 'abby', recruiterID: 8},
-        relationships: {
-          recruiter: [
-            {row: {id: 8, name: 'sam', recruiterID: 2}, relationships: {}},
-          ],
+      {
+        "node": {
+          "relationships": {
+            "recruiter": [
+              {
+                "relationships": {},
+                "row": {
+                  "id": 8,
+                  "name": "sam",
+                  "recruiterID": 2,
+                },
+              },
+            ],
+          },
+          "row": {
+            "id": 9,
+            "name": "abby",
+            "recruiterID": 8,
+          },
         },
+        "type": "add",
       },
-    },
-    {
-      type: 'remove',
-      node: {
-        row: {id: 8, name: 'sam', recruiterID: 2},
-        relationships: {
-          recruiter: [
-            {row: {id: 2, name: 'erik', recruiterID: 1}, relationships: {}},
-          ],
+      {
+        "node": {
+          "relationships": {
+            "recruiter": [
+              {
+                "relationships": {},
+                "row": {
+                  "id": 2,
+                  "name": "erik",
+                  "recruiterID": 1,
+                },
+              },
+            ],
+          },
+          "row": {
+            "id": 8,
+            "name": "sam",
+            "recruiterID": 2,
+          },
         },
+        "type": "remove",
       },
-    },
-    {
-      type: 'child',
-      row: {id: 9, name: 'abby', recruiterID: 8},
-      child: {
-        relationshipName: 'recruiter',
-        change: {
-          type: 'remove',
-          node: {row: {id: 8, name: 'sam', recruiterID: 2}, relationships: {}},
+      {
+        "child": {
+          "change": {
+            "node": {
+              "relationships": {},
+              "row": {
+                "id": 8,
+                "name": "sam",
+                "recruiterID": 2,
+              },
+            },
+            "type": "remove",
+          },
+          "relationshipName": "recruiter",
         },
-      },
-    },
-    {
-      type: 'add',
-      node: {
-        row: {id: 8, name: 'sam', recruiterID: 3},
-        relationships: {
-          recruiter: [
-            {row: {id: 3, name: 'greg', recruiterID: 1}, relationships: {}},
-          ],
+        "row": {
+          "id": 9,
+          "name": "abby",
+          "recruiterID": 8,
         },
+        "type": "child",
       },
-    },
-    {
-      type: 'child',
-      row: {id: 9, name: 'abby', recruiterID: 8},
-      child: {
-        relationshipName: 'recruiter',
-        change: {
-          type: 'add',
-          node: {row: {id: 8, name: 'sam', recruiterID: 3}, relationships: {}},
+      {
+        "node": {
+          "relationships": {
+            "recruiter": [
+              {
+                "relationships": {},
+                "row": {
+                  "id": 3,
+                  "name": "greg",
+                  "recruiterID": 1,
+                },
+              },
+            ],
+          },
+          "row": {
+            "id": 8,
+            "name": "sam",
+            "recruiterID": 3,
+          },
         },
+        "type": "add",
       },
-    },
-  ]);
+      {
+        "child": {
+          "change": {
+            "node": {
+              "relationships": {},
+              "row": {
+                "id": 8,
+                "name": "sam",
+                "recruiterID": 3,
+              },
+            },
+            "type": "add",
+          },
+          "relationshipName": "recruiter",
+        },
+        "row": {
+          "id": 9,
+          "name": "abby",
+          "recruiterID": 8,
+        },
+        "type": "child",
+      },
+    ]
+  `);
 });
 
 test('self-join edit', () => {
@@ -525,67 +775,127 @@ test('multi-join', () => {
     ),
   );
 
-  expect(sink.fetch()).toEqual([
-    {
-      row: {id: 1, name: 'aaron', recruiterID: null},
-      relationships: {
-        userStates: [
-          {
-            row: {userID: 1, stateCode: 'HI'},
-            relationships: {
-              states: [{row: {code: 'HI'}, relationships: {}}],
+  expect(sink.fetch()).toMatchInlineSnapshot(`
+    [
+      {
+        "relationships": {
+          "userStates": [
+            {
+              "relationships": {
+                "states": [
+                  {
+                    "relationships": {},
+                    "row": {
+                      "code": "HI",
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "stateCode": "HI",
+                "userID": 1,
+              },
             },
-          },
-        ],
+          ],
+        },
+        "row": {
+          "id": 1,
+          "name": "aaron",
+          "recruiterID": null,
+        },
       },
-    },
-    {
-      row: {id: 2, name: 'erik', recruiterID: 1},
-      relationships: {
-        userStates: [],
+      {
+        "relationships": {
+          "userStates": [],
+        },
+        "row": {
+          "id": 2,
+          "name": "erik",
+          "recruiterID": 1,
+        },
       },
-    },
-    {
-      row: {id: 3, name: 'greg', recruiterID: 1},
-      relationships: {
-        userStates: [
-          {
-            row: {userID: 3, stateCode: 'AZ'},
-            relationships: {
-              states: [{row: {code: 'AZ'}, relationships: {}}],
+      {
+        "relationships": {
+          "userStates": [
+            {
+              "relationships": {
+                "states": [
+                  {
+                    "relationships": {},
+                    "row": {
+                      "code": "AZ",
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "stateCode": "AZ",
+                "userID": 3,
+              },
             },
-          },
-          {
-            row: {userID: 3, stateCode: 'CA'},
-            relationships: {
-              states: [{row: {code: 'CA'}, relationships: {}}],
+            {
+              "relationships": {
+                "states": [
+                  {
+                    "relationships": {},
+                    "row": {
+                      "code": "CA",
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "stateCode": "CA",
+                "userID": 3,
+              },
             },
-          },
-        ],
+          ],
+        },
+        "row": {
+          "id": 3,
+          "name": "greg",
+          "recruiterID": 1,
+        },
       },
-    },
-  ]);
+    ]
+  `);
 
   sources.userStates.push({type: 'add', row: {userID: 2, stateCode: 'HI'}});
 
-  expect(sink.pushes).toEqual([
-    {
-      type: 'child',
-      row: {id: 2, name: 'erik', recruiterID: 1},
-      child: {
-        relationshipName: 'userStates',
-        change: {
-          type: 'add',
-          node: {
-            row: {userID: 2, stateCode: 'HI'},
-            relationships: {
-              states: [{row: {code: 'HI'}, relationships: {}}],
+  expect(sink.pushes).toMatchInlineSnapshot(`
+    [
+      {
+        "child": {
+          "change": {
+            "node": {
+              "relationships": {
+                "states": [
+                  {
+                    "relationships": {},
+                    "row": {
+                      "code": "HI",
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "stateCode": "HI",
+                "userID": 2,
+              },
             },
+            "type": "add",
           },
+          "relationshipName": "userStates",
         },
+        "row": {
+          "id": 2,
+          "name": "erik",
+          "recruiterID": 1,
+        },
+        "type": "child",
       },
-    },
-  ]);
+    ]
+  `);
 });
 
 test('join with limit', () => {
@@ -633,61 +943,111 @@ test('join with limit', () => {
     ),
   );
 
-  expect(sink.fetch()).toEqual([
-    {
-      row: {id: 1, name: 'aaron', recruiterID: null},
-      relationships: {
-        userStates: [
-          {
-            row: {userID: 1, stateCode: 'HI'},
-            relationships: {
-              states: [{row: {code: 'HI'}, relationships: {}}],
+  expect(sink.fetch()).toMatchInlineSnapshot(`
+    [
+      {
+        "relationships": {
+          "userStates": [
+            {
+              "relationships": {
+                "states": [
+                  {
+                    "relationships": {},
+                    "row": {
+                      "code": "HI",
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "stateCode": "HI",
+                "userID": 1,
+              },
             },
-          },
-        ],
+          ],
+        },
+        "row": {
+          "id": 1,
+          "name": "aaron",
+          "recruiterID": null,
+        },
       },
-    },
-    {
-      row: {id: 2, name: 'erik', recruiterID: 1},
-      relationships: {
-        userStates: [],
+      {
+        "relationships": {
+          "userStates": [],
+        },
+        "row": {
+          "id": 2,
+          "name": "erik",
+          "recruiterID": 1,
+        },
       },
-    },
-    {
-      row: {id: 3, name: 'greg', recruiterID: 1},
-      relationships: {
-        userStates: [
-          {
-            row: {userID: 3, stateCode: 'AZ'},
-            relationships: {
-              states: [{row: {code: 'AZ'}, relationships: {}}],
+      {
+        "relationships": {
+          "userStates": [
+            {
+              "relationships": {
+                "states": [
+                  {
+                    "relationships": {},
+                    "row": {
+                      "code": "AZ",
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "stateCode": "AZ",
+                "userID": 3,
+              },
             },
-          },
-        ],
+          ],
+        },
+        "row": {
+          "id": 3,
+          "name": "greg",
+          "recruiterID": 1,
+        },
       },
-    },
-  ]);
+    ]
+  `);
 
   sources.userStates.push({type: 'add', row: {userID: 2, stateCode: 'HI'}});
 
-  expect(sink.pushes).toEqual([
-    {
-      type: 'child',
-      row: {id: 2, name: 'erik', recruiterID: 1},
-      child: {
-        relationshipName: 'userStates',
-        change: {
-          type: 'add',
-          node: {
-            row: {userID: 2, stateCode: 'HI'},
-            relationships: {
-              states: [{row: {code: 'HI'}, relationships: {}}],
+  expect(sink.pushes).toMatchInlineSnapshot(`
+    [
+      {
+        "child": {
+          "change": {
+            "node": {
+              "relationships": {
+                "states": [
+                  {
+                    "relationships": {},
+                    "row": {
+                      "code": "HI",
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "stateCode": "HI",
+                "userID": 2,
+              },
             },
+            "type": "add",
           },
+          "relationshipName": "userStates",
         },
+        "row": {
+          "id": 2,
+          "name": "erik",
+          "recruiterID": 1,
+        },
+        "type": "child",
       },
-    },
-  ]);
+    ]
+  `);
 });
 
 test('skip', () => {
@@ -706,20 +1066,58 @@ test('skip', () => {
     ),
   );
 
-  expect(sink.fetch()).toEqual([
-    {row: {id: 4, name: 'matt', recruiterID: 1}, relationships: {}},
-    {row: {id: 5, name: 'cesar', recruiterID: 3}, relationships: {}},
-    {row: {id: 6, name: 'darick', recruiterID: 3}, relationships: {}},
-    {row: {id: 7, name: 'alex', recruiterID: 1}, relationships: {}},
-  ]);
+  expect(sink.fetch()).toMatchInlineSnapshot(`
+    [
+      {
+        "relationships": {},
+        "row": {
+          "id": 4,
+          "name": "matt",
+          "recruiterID": 1,
+        },
+      },
+      {
+        "relationships": {},
+        "row": {
+          "id": 5,
+          "name": "cesar",
+          "recruiterID": 3,
+        },
+      },
+      {
+        "relationships": {},
+        "row": {
+          "id": 6,
+          "name": "darick",
+          "recruiterID": 3,
+        },
+      },
+      {
+        "relationships": {},
+        "row": {
+          "id": 7,
+          "name": "alex",
+          "recruiterID": 1,
+        },
+      },
+    ]
+  `);
 
   sources.users.push({type: 'add', row: {id: 8, name: 'sam'}});
-  expect(sink.pushes).toEqual([
-    {
-      type: 'add',
-      node: {row: {id: 8, name: 'sam'}, relationships: {}},
-    },
-  ]);
+  expect(sink.pushes).toMatchInlineSnapshot(`
+    [
+      {
+        "node": {
+          "relationships": {},
+          "row": {
+            "id": 8,
+            "name": "sam",
+          },
+        },
+        "type": "add",
+      },
+    ]
+  `);
 });
 
 test('exists junction', () => {
@@ -898,26 +1296,7 @@ test('exists junction', () => {
       },
       {
         "node": {
-          "relationships": {
-            "zsubq_userStates": [
-              {
-                "relationships": {
-                  "zsubq_states": [
-                    {
-                      "relationships": {},
-                      "row": {
-                        "code": "HI",
-                      },
-                    },
-                  ],
-                },
-                "row": {
-                  "stateCode": "HI",
-                  "userID": 2,
-                },
-              },
-            ],
-          },
+          "relationships": {},
           "row": {
             "id": 2,
             "name": "erik",
@@ -1445,10 +1824,10 @@ test('empty or - nothing goes through', () => {
     ),
   );
 
-  expect(sink.fetch()).toEqual([]);
+  expect(sink.fetch()).toMatchInlineSnapshot(`[]`);
 
   sources.users.push({type: 'add', row: {id: 8, name: 'sam'}});
-  expect(sink.pushes).toEqual([]);
+  expect(sink.pushes).toMatchInlineSnapshot(`[]`);
 });
 
 test('empty and - everything goes through', () => {
@@ -1470,21 +1849,23 @@ test('empty and - everything goes through', () => {
     ),
   );
 
-  expect(sink.fetch().length).toEqual(7);
+  expect(sink.fetch().length).toMatchInlineSnapshot(`7`);
 
   sources.users.push({type: 'add', row: {id: 8, name: 'sam'}});
-  expect(sink.pushes).toEqual([
-    {
-      node: {
-        relationships: {},
-        row: {
-          id: 8,
-          name: 'sam',
+  expect(sink.pushes).toMatchInlineSnapshot(`
+    [
+      {
+        "node": {
+          "relationships": {},
+          "row": {
+            "id": 8,
+            "name": "sam",
+          },
         },
+        "type": "add",
       },
-      type: 'add',
-    },
-  ]);
+    ]
+  `);
 });
 
 test('always false literal comparison - nothing goes through', () => {
@@ -1514,10 +1895,10 @@ test('always false literal comparison - nothing goes through', () => {
     ),
   );
 
-  expect(sink.fetch()).toEqual([]);
+  expect(sink.fetch()).toMatchInlineSnapshot(`[]`);
 
   sources.users.push({type: 'add', row: {id: 8, name: 'sam'}});
-  expect(sink.pushes).toEqual([]);
+  expect(sink.pushes).toMatchInlineSnapshot(`[]`);
 });
 
 test('always true literal comparison - everything goes through', () => {
@@ -1547,78 +1928,82 @@ test('always true literal comparison - everything goes through', () => {
     ),
   );
 
-  expect(sink.fetch()).toEqual([
-    {
-      relationships: {},
-      row: {
-        id: 1,
-        name: 'aaron',
-        recruiterID: null,
-      },
-    },
-    {
-      relationships: {},
-      row: {
-        id: 2,
-        name: 'erik',
-        recruiterID: 1,
-      },
-    },
-    {
-      relationships: {},
-      row: {
-        id: 3,
-        name: 'greg',
-        recruiterID: 1,
-      },
-    },
-    {
-      relationships: {},
-      row: {
-        id: 4,
-        name: 'matt',
-        recruiterID: 1,
-      },
-    },
-    {
-      relationships: {},
-      row: {
-        id: 5,
-        name: 'cesar',
-        recruiterID: 3,
-      },
-    },
-    {
-      relationships: {},
-      row: {
-        id: 6,
-        name: 'darick',
-        recruiterID: 3,
-      },
-    },
-    {
-      relationships: {},
-      row: {
-        id: 7,
-        name: 'alex',
-        recruiterID: 1,
-      },
-    },
-  ]);
-
-  sources.users.push({type: 'add', row: {id: 8, name: 'sam'}});
-  expect(sink.pushes).toEqual([
-    {
-      node: {
-        relationships: {},
-        row: {
-          id: 8,
-          name: 'sam',
+  expect(sink.fetch()).toMatchInlineSnapshot(`
+    [
+      {
+        "relationships": {},
+        "row": {
+          "id": 1,
+          "name": "aaron",
+          "recruiterID": null,
         },
       },
-      type: 'add',
-    },
-  ]);
+      {
+        "relationships": {},
+        "row": {
+          "id": 2,
+          "name": "erik",
+          "recruiterID": 1,
+        },
+      },
+      {
+        "relationships": {},
+        "row": {
+          "id": 3,
+          "name": "greg",
+          "recruiterID": 1,
+        },
+      },
+      {
+        "relationships": {},
+        "row": {
+          "id": 4,
+          "name": "matt",
+          "recruiterID": 1,
+        },
+      },
+      {
+        "relationships": {},
+        "row": {
+          "id": 5,
+          "name": "cesar",
+          "recruiterID": 3,
+        },
+      },
+      {
+        "relationships": {},
+        "row": {
+          "id": 6,
+          "name": "darick",
+          "recruiterID": 3,
+        },
+      },
+      {
+        "relationships": {},
+        "row": {
+          "id": 7,
+          "name": "alex",
+          "recruiterID": 1,
+        },
+      },
+    ]
+  `);
+
+  sources.users.push({type: 'add', row: {id: 8, name: 'sam'}});
+  expect(sink.pushes).toMatchInlineSnapshot(`
+    [
+      {
+        "node": {
+          "relationships": {},
+          "row": {
+            "id": 8,
+            "name": "sam",
+          },
+        },
+        "type": "add",
+      },
+    ]
+  `);
 });
 
 test('groupSubqueryConditions', () => {
@@ -1627,7 +2012,12 @@ test('groupSubqueryConditions', () => {
     conditions: [],
   };
 
-  expect(groupSubqueryConditions(empty)).toEqual([[], []]);
+  expect(groupSubqueryConditions(empty)).toMatchInlineSnapshot(`
+    [
+      [],
+      [],
+    ]
+  `);
 
   const oneSimple: Disjunction = {
     type: 'or',
@@ -1641,10 +2031,25 @@ test('groupSubqueryConditions', () => {
     ],
   };
 
-  expect(groupSubqueryConditions(oneSimple)).toEqual([
-    [],
-    [oneSimple.conditions[0]],
-  ]);
+  expect(groupSubqueryConditions(oneSimple)).toMatchInlineSnapshot(`
+    [
+      [],
+      [
+        {
+          "left": {
+            "name": "id",
+            "type": "column",
+          },
+          "op": "=",
+          "right": {
+            "type": "literal",
+            "value": 1,
+          },
+          "type": "simple",
+        },
+      ],
+    ]
+  `);
 
   const oneSubquery: Disjunction = {
     type: 'or',
@@ -1668,20 +2073,97 @@ test('groupSubqueryConditions', () => {
     ],
   };
 
-  expect(groupSubqueryConditions(oneSubquery)).toEqual([
-    [oneSubquery.conditions[0]],
-    [],
-  ]);
+  expect(groupSubqueryConditions(oneSubquery)).toMatchInlineSnapshot(`
+    [
+      [
+        {
+          "op": "EXISTS",
+          "related": {
+            "correlation": {
+              "childField": [
+                "userID",
+              ],
+              "parentField": [
+                "id",
+              ],
+            },
+            "subquery": {
+              "alias": "userStates",
+              "orderBy": [
+                [
+                  "userID",
+                  "asc",
+                ],
+                [
+                  "stateCode",
+                  "asc",
+                ],
+              ],
+              "table": "userStates",
+            },
+            "system": "client",
+          },
+          "type": "correlatedSubquery",
+        },
+      ],
+      [],
+    ]
+  `);
 
   const oneEach: Disjunction = {
     type: 'or',
     conditions: [oneSimple.conditions[0], oneSubquery.conditions[0]],
   };
 
-  expect(groupSubqueryConditions(oneEach)).toEqual([
-    [oneSubquery.conditions[0]],
-    [oneSimple.conditions[0]],
-  ]);
+  expect(groupSubqueryConditions(oneEach)).toMatchInlineSnapshot(`
+    [
+      [
+        {
+          "op": "EXISTS",
+          "related": {
+            "correlation": {
+              "childField": [
+                "userID",
+              ],
+              "parentField": [
+                "id",
+              ],
+            },
+            "subquery": {
+              "alias": "userStates",
+              "orderBy": [
+                [
+                  "userID",
+                  "asc",
+                ],
+                [
+                  "stateCode",
+                  "asc",
+                ],
+              ],
+              "table": "userStates",
+            },
+            "system": "client",
+          },
+          "type": "correlatedSubquery",
+        },
+      ],
+      [
+        {
+          "left": {
+            "name": "id",
+            "type": "column",
+          },
+          "op": "=",
+          "right": {
+            "type": "literal",
+            "value": 1,
+          },
+          "type": "simple",
+        },
+      ],
+    ]
+  `);
 
   const subqueryInAnd: Disjunction = {
     type: 'or',
@@ -1697,8 +2179,63 @@ test('groupSubqueryConditions', () => {
     ],
   };
 
-  expect(groupSubqueryConditions(subqueryInAnd)).toEqual([
-    [subqueryInAnd.conditions[0]],
-    [subqueryInAnd.conditions[1]],
-  ]);
+  expect(groupSubqueryConditions(subqueryInAnd)).toMatchInlineSnapshot(`
+    [
+      [
+        {
+          "conditions": [
+            {
+              "op": "EXISTS",
+              "related": {
+                "correlation": {
+                  "childField": [
+                    "userID",
+                  ],
+                  "parentField": [
+                    "id",
+                  ],
+                },
+                "subquery": {
+                  "alias": "userStates",
+                  "orderBy": [
+                    [
+                      "userID",
+                      "asc",
+                    ],
+                    [
+                      "stateCode",
+                      "asc",
+                    ],
+                  ],
+                  "table": "userStates",
+                },
+                "system": "client",
+              },
+              "type": "correlatedSubquery",
+            },
+          ],
+          "type": "and",
+        },
+      ],
+      [
+        {
+          "conditions": [
+            {
+              "left": {
+                "name": "id",
+                "type": "column",
+              },
+              "op": "=",
+              "right": {
+                "type": "literal",
+                "value": 1,
+              },
+              "type": "simple",
+            },
+          ],
+          "type": "and",
+        },
+      ],
+    ]
+  `);
 });

--- a/packages/zql/src/builder/builder.test.ts
+++ b/packages/zql/src/builder/builder.test.ts
@@ -1296,7 +1296,26 @@ test('exists junction', () => {
       },
       {
         "node": {
-          "relationships": {},
+          "relationships": {
+            "zsubq_userStates": [
+              {
+                "relationships": {
+                  "zsubq_states": [
+                    {
+                      "relationships": {},
+                      "row": {
+                        "code": "HI",
+                      },
+                    },
+                  ],
+                },
+                "row": {
+                  "stateCode": "HI",
+                  "userID": 2,
+                },
+              },
+            ],
+          },
           "row": {
             "id": 2,
             "name": "erik",

--- a/packages/zql/src/builder/builder.test.ts
+++ b/packages/zql/src/builder/builder.test.ts
@@ -1868,7 +1868,7 @@ test('empty and - everything goes through', () => {
     ),
   );
 
-  expect(sink.fetch().length).toMatchInlineSnapshot(`7`);
+  expect(sink.fetch().length).toEqual(7);
 
   sources.users.push({type: 'add', row: {id: 8, name: 'sam'}});
   expect(sink.pushes).toMatchInlineSnapshot(`
@@ -2031,12 +2031,7 @@ test('groupSubqueryConditions', () => {
     conditions: [],
   };
 
-  expect(groupSubqueryConditions(empty)).toMatchInlineSnapshot(`
-    [
-      [],
-      [],
-    ]
-  `);
+  expect(groupSubqueryConditions(empty)).toEqual([[], []]);
 
   const oneSimple: Disjunction = {
     type: 'or',
@@ -2050,25 +2045,10 @@ test('groupSubqueryConditions', () => {
     ],
   };
 
-  expect(groupSubqueryConditions(oneSimple)).toMatchInlineSnapshot(`
-    [
-      [],
-      [
-        {
-          "left": {
-            "name": "id",
-            "type": "column",
-          },
-          "op": "=",
-          "right": {
-            "type": "literal",
-            "value": 1,
-          },
-          "type": "simple",
-        },
-      ],
-    ]
-  `);
+  expect(groupSubqueryConditions(oneSimple)).toEqual([
+    [],
+    [oneSimple.conditions[0]],
+  ]);
 
   const oneSubquery: Disjunction = {
     type: 'or',
@@ -2092,97 +2072,20 @@ test('groupSubqueryConditions', () => {
     ],
   };
 
-  expect(groupSubqueryConditions(oneSubquery)).toMatchInlineSnapshot(`
-    [
-      [
-        {
-          "op": "EXISTS",
-          "related": {
-            "correlation": {
-              "childField": [
-                "userID",
-              ],
-              "parentField": [
-                "id",
-              ],
-            },
-            "subquery": {
-              "alias": "userStates",
-              "orderBy": [
-                [
-                  "userID",
-                  "asc",
-                ],
-                [
-                  "stateCode",
-                  "asc",
-                ],
-              ],
-              "table": "userStates",
-            },
-            "system": "client",
-          },
-          "type": "correlatedSubquery",
-        },
-      ],
-      [],
-    ]
-  `);
+  expect(groupSubqueryConditions(oneSubquery)).toEqual([
+    [oneSubquery.conditions[0]],
+    [],
+  ]);
 
   const oneEach: Disjunction = {
     type: 'or',
     conditions: [oneSimple.conditions[0], oneSubquery.conditions[0]],
   };
 
-  expect(groupSubqueryConditions(oneEach)).toMatchInlineSnapshot(`
-    [
-      [
-        {
-          "op": "EXISTS",
-          "related": {
-            "correlation": {
-              "childField": [
-                "userID",
-              ],
-              "parentField": [
-                "id",
-              ],
-            },
-            "subquery": {
-              "alias": "userStates",
-              "orderBy": [
-                [
-                  "userID",
-                  "asc",
-                ],
-                [
-                  "stateCode",
-                  "asc",
-                ],
-              ],
-              "table": "userStates",
-            },
-            "system": "client",
-          },
-          "type": "correlatedSubquery",
-        },
-      ],
-      [
-        {
-          "left": {
-            "name": "id",
-            "type": "column",
-          },
-          "op": "=",
-          "right": {
-            "type": "literal",
-            "value": 1,
-          },
-          "type": "simple",
-        },
-      ],
-    ]
-  `);
+  expect(groupSubqueryConditions(oneEach)).toEqual([
+    [oneSubquery.conditions[0]],
+    [oneSimple.conditions[0]],
+  ]);
 
   const subqueryInAnd: Disjunction = {
     type: 'or',
@@ -2198,63 +2101,8 @@ test('groupSubqueryConditions', () => {
     ],
   };
 
-  expect(groupSubqueryConditions(subqueryInAnd)).toMatchInlineSnapshot(`
-    [
-      [
-        {
-          "conditions": [
-            {
-              "op": "EXISTS",
-              "related": {
-                "correlation": {
-                  "childField": [
-                    "userID",
-                  ],
-                  "parentField": [
-                    "id",
-                  ],
-                },
-                "subquery": {
-                  "alias": "userStates",
-                  "orderBy": [
-                    [
-                      "userID",
-                      "asc",
-                    ],
-                    [
-                      "stateCode",
-                      "asc",
-                    ],
-                  ],
-                  "table": "userStates",
-                },
-                "system": "client",
-              },
-              "type": "correlatedSubquery",
-            },
-          ],
-          "type": "and",
-        },
-      ],
-      [
-        {
-          "conditions": [
-            {
-              "left": {
-                "name": "id",
-                "type": "column",
-              },
-              "op": "=",
-              "right": {
-                "type": "literal",
-                "value": 1,
-              },
-              "type": "simple",
-            },
-          ],
-          "type": "and",
-        },
-      ],
-    ]
-  `);
+  expect(groupSubqueryConditions(subqueryInAnd)).toEqual([
+    [subqueryInAnd.conditions[0]],
+    [subqueryInAnd.conditions[1]],
+  ]);
 });

--- a/packages/zql/src/ivm/array-view.test.ts
+++ b/packages/zql/src/ivm/array-view.test.ts
@@ -595,7 +595,7 @@ test('collapse', () => {
         name: 'issue',
       },
       relationships: {
-        labels: [
+        labels: () => [
           {
             row: {
               id: 1,
@@ -604,7 +604,7 @@ test('collapse', () => {
               extra: 'a',
             },
             relationships: {
-              labels: [
+              labels: () => [
                 {
                   row: {
                     id: 1,
@@ -655,9 +655,53 @@ test('collapse', () => {
 
   view.push({
     type: 'child',
-    row: {
-      id: 1,
-      name: 'issue',
+    node: {
+      row: {
+        id: 1,
+        name: 'issue',
+      },
+      relationships: {
+        labels: () => [
+          {
+            row: {
+              id: 1,
+              issueId: 1,
+              labelId: 1,
+              extra: 'a',
+            },
+            relationships: {
+              labels: () => [
+                {
+                  row: {
+                    id: 1,
+                    name: 'label',
+                  },
+                  relationships: {},
+                },
+              ],
+            },
+          },
+          {
+            row: {
+              id: 2,
+              issueId: 1,
+              labelId: 2,
+              extra: 'b',
+            },
+            relationships: {
+              labels: () => [
+                {
+                  row: {
+                    id: 2,
+                    name: 'label2',
+                  },
+                  relationships: {},
+                },
+              ],
+            },
+          },
+        ],
+      },
     },
     child: {
       relationshipName: 'labels',
@@ -671,7 +715,7 @@ test('collapse', () => {
             extra: 'b',
           },
           relationships: {
-            labels: [
+            labels: () => [
               {
                 row: {
                   id: 2,
@@ -707,9 +751,53 @@ test('collapse', () => {
   // edit the hidden row
   view.push({
     type: 'child',
-    row: {
-      id: 1,
-      name: 'issue',
+    node: {
+      row: {
+        id: 1,
+        name: 'issue',
+      },
+      relationships: {
+        labels: () => [
+          {
+            row: {
+              id: 1,
+              issueId: 1,
+              labelId: 1,
+              extra: 'a',
+            },
+            relationships: {
+              labels: () => [
+                {
+                  row: {
+                    id: 1,
+                    name: 'label',
+                  },
+                  relationships: {},
+                },
+              ],
+            },
+          },
+          {
+            row: {
+              id: 2,
+              issueId: 1,
+              labelId: 2,
+              extra: 'b2',
+            },
+            relationships: {
+              labels: () => [
+                {
+                  row: {
+                    id: 2,
+                    name: 'label2',
+                  },
+                  relationships: {},
+                },
+              ],
+            },
+          },
+        ],
+      },
     },
     child: {
       relationshipName: 'labels',
@@ -722,7 +810,17 @@ test('collapse', () => {
             labelId: 2,
             extra: 'b',
           },
-          relationships: {},
+          relationships: {
+            labels: () => [
+              {
+                row: {
+                  id: 2,
+                  name: 'label2',
+                },
+                relationships: {},
+              },
+            ],
+          },
         },
         node: {
           row: {
@@ -731,7 +829,17 @@ test('collapse', () => {
             labelId: 2,
             extra: 'b2',
           },
-          relationships: {},
+          relationships: {
+            labels: () => [
+              {
+                row: {
+                  id: 2,
+                  name: 'label2',
+                },
+                relationships: {},
+              },
+            ],
+          },
         },
       },
     },
@@ -758,19 +866,76 @@ test('collapse', () => {
   // edit the leaf
   view.push({
     type: 'child',
-    row: {
-      id: 1,
-      name: 'issue',
+    node: {
+      row: {
+        id: 1,
+        name: 'issue',
+      },
+      relationships: {
+        labels: () => [
+          {
+            row: {
+              id: 1,
+              issueId: 1,
+              labelId: 1,
+              extra: 'a',
+            },
+            relationships: {
+              labels: () => [
+                {
+                  row: {
+                    id: 1,
+                    name: 'label',
+                  },
+                  relationships: {},
+                },
+              ],
+            },
+          },
+          {
+            row: {
+              id: 2,
+              issueId: 1,
+              labelId: 2,
+              extra: 'b2',
+            },
+            relationships: {
+              labels: () => [
+                {
+                  row: {
+                    id: 2,
+                    name: 'label2x',
+                  },
+                  relationships: {},
+                },
+              ],
+            },
+          },
+        ],
+      },
     },
     child: {
       relationshipName: 'labels',
       change: {
         type: 'child',
-        row: {
-          id: 2,
-          issueId: 1,
-          labelId: 2,
-          extra: 'b2',
+        node: {
+          row: {
+            id: 2,
+            issueId: 1,
+            labelId: 2,
+            extra: 'b2',
+          },
+          relationships: {
+            labels: () => [
+              {
+                row: {
+                  id: 2,
+                  name: 'label2x',
+                },
+                relationships: {},
+              },
+            ],
+          },
         },
         child: {
           relationshipName: 'labels',
@@ -892,7 +1057,7 @@ test('collapse-single', () => {
         name: 'issue',
       },
       relationships: {
-        labels: [
+        labels: () => [
           {
             row: {
               id: 1,
@@ -900,7 +1065,7 @@ test('collapse-single', () => {
               labelId: 1,
             },
             relationships: {
-              labels: [
+              labels: () => [
                 {
                   row: {
                     id: 1,
@@ -1248,7 +1413,7 @@ test('edit to preserve relationships', () => {
     node: {
       row: {id: 1, title: 'issue1'},
       relationships: {
-        labels: [
+        labels: () => [
           {
             row: {id: 1, name: 'label1'},
             relationships: {},
@@ -1262,7 +1427,7 @@ test('edit to preserve relationships', () => {
     node: {
       row: {id: 2, title: 'issue2'},
       relationships: {
-        labels: [
+        labels: () => [
           {
             row: {id: 2, name: 'label2'},
             relationships: {},

--- a/packages/zql/src/ivm/catch.ts
+++ b/packages/zql/src/ivm/catch.ts
@@ -21,7 +21,7 @@ export type CaughtRemoveChange = {
 
 export type CaughtChildChange = {
   type: 'child';
-  node: CaughtNode;
+  row: Row;
   child: {
     relationshipName: string;
     change: CaughtChange;
@@ -30,8 +30,8 @@ export type CaughtChildChange = {
 
 export type CaughtEditChange = {
   type: 'edit';
-  oldNode: CaughtNode;
-  node: CaughtNode;
+  oldRow: Row;
+  row: Row;
 };
 
 export type CaughtChange =
@@ -85,13 +85,13 @@ export function expandChange(change: Change): CaughtChange {
     case 'edit':
       return {
         type: 'edit',
-        oldNode: expandNode(change.oldNode),
-        node: expandNode(change.node),
+        oldRow: change.oldNode.row,
+        row: change.node.row,
       };
     case 'child':
       return {
         type: 'child',
-        node: expandNode(change.node),
+        row: change.node.row,
         child: {
           ...change.child,
           change: expandChange(change.child.change),

--- a/packages/zql/src/ivm/change.ts
+++ b/packages/zql/src/ivm/change.ts
@@ -1,4 +1,3 @@
-import type {Row} from '../../../zero-protocol/src/data.ts';
 import type {Node} from './data.ts';
 
 export type Change = AddChange | RemoveChange | ChildChange | EditChange;
@@ -24,11 +23,13 @@ export type RemoveChange = {
 };
 
 /**
- * The node itself is unchanged, but one of its descendants has changed.
+ * The node's row is unchanged, but one of its descendants has changed.
+ * The node's relationships will reflect the change, `child` specifies the
+ * specific descendant change.
  */
 export type ChildChange = {
   type: 'child';
-  row: Row;
+  node: Node;
   child: {
     relationshipName: string;
     change: Change;
@@ -62,8 +63,3 @@ export type EditChange = {
   node: Node;
   oldNode: Node;
 };
-
-export function rowForChange(change: Change): Row {
-  const {type} = change;
-  return type === 'child' ? change.row : change.node.row;
-}

--- a/packages/zql/src/ivm/data.ts
+++ b/packages/zql/src/ivm/data.ts
@@ -14,7 +14,7 @@ import type {Stream} from './stream.ts';
  */
 export type Node = {
   row: Row;
-  relationships: Record<string, Stream<Node>>;
+  relationships: Record<string, () => Stream<Node>>;
 };
 
 /**

--- a/packages/zql/src/ivm/data.ts
+++ b/packages/zql/src/ivm/data.ts
@@ -109,3 +109,11 @@ export function valuesEqual(a: Value, b: Value): boolean {
   }
   return a === b;
 }
+
+export function drainStreams(node: Node) {
+  for (const stream of Object.values(node.relationships)) {
+    for (const node of stream()) {
+      drainStreams(node);
+    }
+  }
+}

--- a/packages/zql/src/ivm/exists.fetch.test.ts
+++ b/packages/zql/src/ivm/exists.fetch.test.ts
@@ -260,6 +260,15 @@ suite('EXISTS', () => {
             "cleanup",
             {},
           ],
+          [
+            "1",
+            "cleanup",
+            {
+              "constraint": {
+                "issueID": "i1",
+              },
+            },
+          ],
         ],
         "fetch": [
           [
@@ -336,6 +345,15 @@ suite('EXISTS', () => {
             "0",
             "cleanup",
             {},
+          ],
+          [
+            "1",
+            "cleanup",
+            {
+              "constraint": {
+                "issueID": "i2",
+              },
+            },
           ],
           [
             "1",
@@ -639,6 +657,33 @@ suite('EXISTS', () => {
             "cleanup",
             {},
           ],
+          [
+            "1",
+            "cleanup",
+            {
+              "constraint": {
+                "issueID": "i1",
+              },
+            },
+          ],
+          [
+            "1",
+            "cleanup",
+            {
+              "constraint": {
+                "issueID": "i2",
+              },
+            },
+          ],
+          [
+            "1",
+            "cleanup",
+            {
+              "constraint": {
+                "issueID": "i3",
+              },
+            },
+          ],
         ],
         "fetch": [
           [
@@ -743,6 +788,15 @@ suite('NOT EXISTS', () => {
             "cleanup",
             {},
           ],
+          [
+            "1",
+            "cleanup",
+            {
+              "constraint": {
+                "issueID": "i1",
+              },
+            },
+          ],
         ],
         "fetch": [
           [
@@ -793,6 +847,15 @@ suite('NOT EXISTS', () => {
             "1",
             "cleanup",
             {},
+          ],
+          [
+            "0",
+            "cleanup",
+            {
+              "constraint": {
+                "id": "i1",
+              },
+            },
           ],
         ],
         "fetch": [
@@ -970,6 +1033,24 @@ suite('NOT EXISTS', () => {
             "cleanup",
             {
               "constraint": {
+                "issueID": "i1",
+              },
+            },
+          ],
+          [
+            "1",
+            "cleanup",
+            {
+              "constraint": {
+                "issueID": "i3",
+              },
+            },
+          ],
+          [
+            "1",
+            "cleanup",
+            {
+              "constraint": {
                 "issueID": "i2",
               },
             },
@@ -1072,6 +1153,24 @@ suite('NOT EXISTS', () => {
             "1",
             "cleanup",
             {},
+          ],
+          [
+            "0",
+            "cleanup",
+            {
+              "constraint": {
+                "id": "i1",
+              },
+            },
+          ],
+          [
+            "0",
+            "cleanup",
+            {
+              "constraint": {
+                "id": "i3",
+              },
+            },
           ],
         ],
         "fetch": [

--- a/packages/zql/src/ivm/exists.fetch.test.ts
+++ b/packages/zql/src/ivm/exists.fetch.test.ts
@@ -118,18 +118,6 @@ suite('EXISTS', () => {
             },
           ],
           [
-            "0",
-            "fetch",
-            {
-              "start": {
-                "basis": "at",
-                "row": {
-                  "id": "i1",
-                },
-              },
-            },
-          ],
-          [
             "1",
             "fetch",
             {
@@ -223,19 +211,6 @@ suite('EXISTS', () => {
             },
           ],
           [
-            "1",
-            "fetch",
-            {
-              "start": {
-                "basis": "at",
-                "row": {
-                  "id": "c1",
-                  "issueID": "i1",
-                },
-              },
-            },
-          ],
-          [
             "0",
             "fetch",
             {
@@ -285,15 +260,6 @@ suite('EXISTS', () => {
             "cleanup",
             {},
           ],
-          [
-            "1",
-            "cleanup",
-            {
-              "constraint": {
-                "issueID": "i1",
-              },
-            },
-          ],
         ],
         "fetch": [
           [
@@ -301,42 +267,12 @@ suite('EXISTS', () => {
             "fetch",
             {},
           ],
-          [
-            "1",
-            "fetch",
-            {
-              "constraint": {
-                "issueID": "i1",
-              },
-            },
-          ],
         ],
         "initialFetch": [
           [
             "0",
             "fetch",
             {},
-          ],
-          [
-            "1",
-            "fetch",
-            {
-              "constraint": {
-                "issueID": "i1",
-              },
-            },
-          ],
-          [
-            "0",
-            "fetch",
-            {
-              "start": {
-                "basis": "at",
-                "row": {
-                  "id": "i1",
-                },
-              },
-            },
           ],
           [
             "1",
@@ -415,15 +351,6 @@ suite('EXISTS', () => {
             "cleanup",
             {
               "constraint": {
-                "issueID": "i2",
-              },
-            },
-          ],
-          [
-            "1",
-            "cleanup",
-            {
-              "constraint": {
                 "issueID": "i3",
               },
             },
@@ -441,15 +368,6 @@ suite('EXISTS', () => {
             {
               "constraint": {
                 "issueID": "i1",
-              },
-            },
-          ],
-          [
-            "1",
-            "fetch",
-            {
-              "constraint": {
-                "issueID": "i2",
               },
             },
           ],
@@ -479,48 +397,6 @@ suite('EXISTS', () => {
             },
           ],
           [
-            "0",
-            "fetch",
-            {
-              "start": {
-                "basis": "at",
-                "row": {
-                  "id": "i1",
-                },
-              },
-            },
-          ],
-          [
-            "1",
-            "fetch",
-            {
-              "constraint": {
-                "issueID": "i1",
-              },
-            },
-          ],
-          [
-            "1",
-            "fetch",
-            {
-              "constraint": {
-                "issueID": "i2",
-              },
-            },
-          ],
-          [
-            "0",
-            "fetch",
-            {
-              "start": {
-                "basis": "at",
-                "row": {
-                  "id": "i2",
-                },
-              },
-            },
-          ],
-          [
             "1",
             "fetch",
             {
@@ -539,14 +415,11 @@ suite('EXISTS', () => {
             },
           ],
           [
-            "0",
+            "1",
             "fetch",
             {
-              "start": {
-                "basis": "at",
-                "row": {
-                  "id": "i3",
-                },
+              "constraint": {
+                "issueID": "i1",
               },
             },
           ],
@@ -681,28 +554,6 @@ suite('EXISTS', () => {
             },
           ],
           [
-            "1",
-            "fetch",
-            {
-              "start": {
-                "basis": "at",
-                "row": {
-                  "id": "c1",
-                  "issueID": "i1",
-                },
-              },
-            },
-          ],
-          [
-            "0",
-            "fetch",
-            {
-              "constraint": {
-                "id": "i1",
-              },
-            },
-          ],
-          [
             "0",
             "fetch",
             {
@@ -712,15 +563,11 @@ suite('EXISTS', () => {
             },
           ],
           [
-            "1",
+            "0",
             "fetch",
             {
-              "start": {
-                "basis": "at",
-                "row": {
-                  "id": "c2",
-                  "issueID": "i3",
-                },
+              "constraint": {
+                "id": "i1",
               },
             },
           ],
@@ -792,66 +639,12 @@ suite('EXISTS', () => {
             "cleanup",
             {},
           ],
-          [
-            "1",
-            "cleanup",
-            {
-              "constraint": {
-                "issueID": "i1",
-              },
-            },
-          ],
-          [
-            "1",
-            "cleanup",
-            {
-              "constraint": {
-                "issueID": "i2",
-              },
-            },
-          ],
-          [
-            "1",
-            "cleanup",
-            {
-              "constraint": {
-                "issueID": "i3",
-              },
-            },
-          ],
         ],
         "fetch": [
           [
             "0",
             "fetch",
             {},
-          ],
-          [
-            "1",
-            "fetch",
-            {
-              "constraint": {
-                "issueID": "i1",
-              },
-            },
-          ],
-          [
-            "1",
-            "fetch",
-            {
-              "constraint": {
-                "issueID": "i2",
-              },
-            },
-          ],
-          [
-            "1",
-            "fetch",
-            {
-              "constraint": {
-                "issueID": "i3",
-              },
-            },
           ],
         ],
         "initialFetch": [
@@ -870,74 +663,11 @@ suite('EXISTS', () => {
             },
           ],
           [
-            "0",
-            "fetch",
-            {
-              "start": {
-                "basis": "at",
-                "row": {
-                  "id": "i1",
-                },
-              },
-            },
-          ],
-          [
-            "1",
-            "fetch",
-            {
-              "constraint": {
-                "issueID": "i1",
-              },
-            },
-          ],
-          [
             "1",
             "fetch",
             {
               "constraint": {
                 "issueID": "i2",
-              },
-            },
-          ],
-          [
-            "0",
-            "fetch",
-            {
-              "start": {
-                "basis": "at",
-                "row": {
-                  "id": "i2",
-                },
-              },
-            },
-          ],
-          [
-            "1",
-            "fetch",
-            {
-              "constraint": {
-                "issueID": "i2",
-              },
-            },
-          ],
-          [
-            "1",
-            "fetch",
-            {
-              "constraint": {
-                "issueID": "i3",
-              },
-            },
-          ],
-          [
-            "0",
-            "fetch",
-            {
-              "start": {
-                "basis": "at",
-                "row": {
-                  "id": "i3",
-                },
               },
             },
           ],
@@ -1013,15 +743,6 @@ suite('NOT EXISTS', () => {
             "cleanup",
             {},
           ],
-          [
-            "1",
-            "cleanup",
-            {
-              "constraint": {
-                "issueID": "i1",
-              },
-            },
-          ],
         ],
         "fetch": [
           [
@@ -1029,42 +750,12 @@ suite('NOT EXISTS', () => {
             "fetch",
             {},
           ],
-          [
-            "1",
-            "fetch",
-            {
-              "constraint": {
-                "issueID": "i1",
-              },
-            },
-          ],
         ],
         "initialFetch": [
           [
             "0",
             "fetch",
             {},
-          ],
-          [
-            "1",
-            "fetch",
-            {
-              "constraint": {
-                "issueID": "i1",
-              },
-            },
-          ],
-          [
-            "0",
-            "fetch",
-            {
-              "start": {
-                "basis": "at",
-                "row": {
-                  "id": "i1",
-                },
-              },
-            },
           ],
           [
             "1",
@@ -1103,15 +794,6 @@ suite('NOT EXISTS', () => {
             "cleanup",
             {},
           ],
-          [
-            "0",
-            "cleanup",
-            {
-              "constraint": {
-                "id": "i1",
-              },
-            },
-          ],
         ],
         "fetch": [
           [
@@ -1119,43 +801,12 @@ suite('NOT EXISTS', () => {
             "fetch",
             {},
           ],
-          [
-            "0",
-            "fetch",
-            {
-              "constraint": {
-                "id": "i1",
-              },
-            },
-          ],
         ],
         "initialFetch": [
           [
             "1",
             "fetch",
             {},
-          ],
-          [
-            "0",
-            "fetch",
-            {
-              "constraint": {
-                "id": "i1",
-              },
-            },
-          ],
-          [
-            "1",
-            "fetch",
-            {
-              "start": {
-                "basis": "at",
-                "row": {
-                  "id": "c1",
-                  "issueID": "i1",
-                },
-              },
-            },
           ],
           [
             "0",
@@ -1229,18 +880,6 @@ suite('NOT EXISTS', () => {
             {
               "constraint": {
                 "issueID": "i1",
-              },
-            },
-          ],
-          [
-            "0",
-            "fetch",
-            {
-              "start": {
-                "basis": "at",
-                "row": {
-                  "id": "i1",
-                },
               },
             },
           ],
@@ -1331,25 +970,7 @@ suite('NOT EXISTS', () => {
             "cleanup",
             {
               "constraint": {
-                "issueID": "i1",
-              },
-            },
-          ],
-          [
-            "1",
-            "cleanup",
-            {
-              "constraint": {
                 "issueID": "i2",
-              },
-            },
-          ],
-          [
-            "1",
-            "cleanup",
-            {
-              "constraint": {
-                "issueID": "i3",
               },
             },
           ],
@@ -1365,25 +986,7 @@ suite('NOT EXISTS', () => {
             "fetch",
             {
               "constraint": {
-                "issueID": "i1",
-              },
-            },
-          ],
-          [
-            "1",
-            "fetch",
-            {
-              "constraint": {
                 "issueID": "i2",
-              },
-            },
-          ],
-          [
-            "1",
-            "fetch",
-            {
-              "constraint": {
-                "issueID": "i3",
               },
             },
           ],
@@ -1404,48 +1007,6 @@ suite('NOT EXISTS', () => {
             },
           ],
           [
-            "0",
-            "fetch",
-            {
-              "start": {
-                "basis": "at",
-                "row": {
-                  "id": "i1",
-                },
-              },
-            },
-          ],
-          [
-            "1",
-            "fetch",
-            {
-              "constraint": {
-                "issueID": "i1",
-              },
-            },
-          ],
-          [
-            "1",
-            "fetch",
-            {
-              "constraint": {
-                "issueID": "i2",
-              },
-            },
-          ],
-          [
-            "0",
-            "fetch",
-            {
-              "start": {
-                "basis": "at",
-                "row": {
-                  "id": "i2",
-                },
-              },
-            },
-          ],
-          [
             "1",
             "fetch",
             {
@@ -1464,23 +1025,11 @@ suite('NOT EXISTS', () => {
             },
           ],
           [
-            "0",
-            "fetch",
-            {
-              "start": {
-                "basis": "at",
-                "row": {
-                  "id": "i3",
-                },
-              },
-            },
-          ],
-          [
             "1",
             "fetch",
             {
               "constraint": {
-                "issueID": "i3",
+                "issueID": "i2",
               },
             },
           ],
@@ -1524,48 +1073,12 @@ suite('NOT EXISTS', () => {
             "cleanup",
             {},
           ],
-          [
-            "0",
-            "cleanup",
-            {
-              "constraint": {
-                "id": "i1",
-              },
-            },
-          ],
-          [
-            "0",
-            "cleanup",
-            {
-              "constraint": {
-                "id": "i3",
-              },
-            },
-          ],
         ],
         "fetch": [
           [
             "1",
             "fetch",
             {},
-          ],
-          [
-            "0",
-            "fetch",
-            {
-              "constraint": {
-                "id": "i1",
-              },
-            },
-          ],
-          [
-            "0",
-            "fetch",
-            {
-              "constraint": {
-                "id": "i3",
-              },
-            },
           ],
         ],
         "initialFetch": [
@@ -1580,50 +1093,6 @@ suite('NOT EXISTS', () => {
             {
               "constraint": {
                 "id": "i1",
-              },
-            },
-          ],
-          [
-            "1",
-            "fetch",
-            {
-              "start": {
-                "basis": "at",
-                "row": {
-                  "id": "c1",
-                  "issueID": "i1",
-                },
-              },
-            },
-          ],
-          [
-            "0",
-            "fetch",
-            {
-              "constraint": {
-                "id": "i1",
-              },
-            },
-          ],
-          [
-            "0",
-            "fetch",
-            {
-              "constraint": {
-                "id": "i3",
-              },
-            },
-          ],
-          [
-            "1",
-            "fetch",
-            {
-              "start": {
-                "basis": "at",
-                "row": {
-                  "id": "c2",
-                  "issueID": "i3",
-                },
               },
             },
           ],
@@ -1741,48 +1210,6 @@ suite('NOT EXISTS', () => {
             },
           ],
           [
-            "0",
-            "fetch",
-            {
-              "start": {
-                "basis": "at",
-                "row": {
-                  "id": "i1",
-                },
-              },
-            },
-          ],
-          [
-            "1",
-            "fetch",
-            {
-              "constraint": {
-                "issueID": "i1",
-              },
-            },
-          ],
-          [
-            "1",
-            "fetch",
-            {
-              "constraint": {
-                "issueID": "i2",
-              },
-            },
-          ],
-          [
-            "0",
-            "fetch",
-            {
-              "start": {
-                "basis": "at",
-                "row": {
-                  "id": "i2",
-                },
-              },
-            },
-          ],
-          [
             "1",
             "fetch",
             {
@@ -1801,14 +1228,20 @@ suite('NOT EXISTS', () => {
             },
           ],
           [
-            "0",
+            "1",
             "fetch",
             {
-              "start": {
-                "basis": "at",
-                "row": {
-                  "id": "i3",
-                },
+              "constraint": {
+                "issueID": "i1",
+              },
+            },
+          ],
+          [
+            "1",
+            "fetch",
+            {
+              "constraint": {
+                "issueID": "i2",
               },
             },
           ],

--- a/packages/zql/src/ivm/exists.fetch.test.ts
+++ b/packages/zql/src/ivm/exists.fetch.test.ts
@@ -5,8 +5,7 @@ import type {CompoundKey, Ordering} from '../../../zero-protocol/src/ast.ts';
 import type {Row} from '../../../zero-protocol/src/data.ts';
 import type {PrimaryKey} from '../../../zero-protocol/src/primary-key.ts';
 import type {SchemaValue} from '../../../zero-schema/src/table-schema.ts';
-import {Catch} from './catch.ts';
-import type {Node} from './data.ts';
+import {Catch, type CaughtNode} from './catch.ts';
 import {Exists} from './exists.ts';
 import {Join} from './join.ts';
 import {MemoryStorage} from './memory-storage.ts';
@@ -2016,5 +2015,5 @@ type FetchTestResults = {
     cleanup: SnitchMessage[];
   };
   storage: Record<string, JSONValue>;
-  hydrate: Node[];
+  hydrate: CaughtNode[];
 };

--- a/packages/zql/src/ivm/exists.push.test.ts
+++ b/packages/zql/src/ivm/exists.push.test.ts
@@ -409,9 +409,7 @@ suite('EXISTS 1 to many', () => {
         },
         {
           "node": {
-            "relationships": {
-              "issue": [],
-            },
+            "relationships": {},
             "row": {
               "id": "c1",
               "issueID": "i1",
@@ -461,9 +459,7 @@ suite('EXISTS 1 to many', () => {
         },
         {
           "node": {
-            "relationships": {
-              "issue": [],
-            },
+            "relationships": {},
             "row": {
               "id": "c2",
               "issueID": "i1",
@@ -1061,13 +1057,6 @@ suite('EXISTS', () => {
           "text": "first issue",
         },
         {
-          "comments": [
-            {
-              "id": "c4",
-              "issueID": "i2",
-              "text": "i2 c4 text",
-            },
-          ],
           "id": "i2",
           "text": "second issue",
         },
@@ -1110,18 +1099,7 @@ suite('EXISTS', () => {
       [
         {
           "node": {
-            "relationships": {
-              "comments": [
-                {
-                  "relationships": {},
-                  "row": {
-                    "id": "c4",
-                    "issueID": "i2",
-                    "text": "i2 c4 text",
-                  },
-                },
-              ],
-            },
+            "relationships": {},
             "row": {
               "id": "i2",
               "text": "second issue",
@@ -1362,9 +1340,7 @@ suite('EXISTS', () => {
         },
         {
           "node": {
-            "relationships": {
-              "comments": [],
-            },
+            "relationships": {},
             "row": {
               "id": "i1",
               "text": "first issue",
@@ -1639,13 +1615,6 @@ suite('EXISTS', () => {
     expect(data).toMatchInlineSnapshot(`
       [
         {
-          "comments": [
-            {
-              "id": "c1",
-              "issueID": "i2",
-              "text": "i2 c1 text",
-            },
-          ],
           "id": "i2",
           "text": "second issue",
         },
@@ -1739,9 +1708,7 @@ suite('EXISTS', () => {
         },
         {
           "node": {
-            "relationships": {
-              "comments": [],
-            },
+            "relationships": {},
             "row": {
               "id": "i1",
               "text": "first issue",
@@ -1751,18 +1718,7 @@ suite('EXISTS', () => {
         },
         {
           "node": {
-            "relationships": {
-              "comments": [
-                {
-                  "relationships": {},
-                  "row": {
-                    "id": "c1",
-                    "issueID": "i2",
-                    "text": "i2 c1 text",
-                  },
-                },
-              ],
-            },
+            "relationships": {},
             "row": {
               "id": "i2",
               "text": "second issue",
@@ -2283,18 +2239,7 @@ suite('NOT EXISTS', () => {
         },
         {
           "node": {
-            "relationships": {
-              "comments": [
-                {
-                  "relationships": {},
-                  "row": {
-                    "id": "c4",
-                    "issueID": "i2",
-                    "text": "i2 c4 text",
-                  },
-                },
-              ],
-            },
+            "relationships": {},
             "row": {
               "id": "i2",
               "text": "second issue",
@@ -2389,7 +2334,6 @@ suite('NOT EXISTS', () => {
     expect(data).toMatchInlineSnapshot(`
       [
         {
-          "comments": [],
           "id": "i1",
           "text": "first issue",
         },
@@ -2426,9 +2370,7 @@ suite('NOT EXISTS', () => {
       [
         {
           "node": {
-            "relationships": {
-              "comments": [],
-            },
+            "relationships": {},
             "row": {
               "id": "i1",
               "text": "first issue",
@@ -2575,7 +2517,6 @@ suite('NOT EXISTS', () => {
     expect(data).toMatchInlineSnapshot(`
       [
         {
-          "comments": [],
           "id": "i1",
           "text": "first issue",
         },
@@ -2637,9 +2578,7 @@ suite('NOT EXISTS', () => {
       [
         {
           "node": {
-            "relationships": {
-              "comments": [],
-            },
+            "relationships": {},
             "row": {
               "id": "i1",
               "text": "first issue",
@@ -2670,18 +2609,7 @@ suite('NOT EXISTS', () => {
         },
         {
           "node": {
-            "relationships": {
-              "comments": [
-                {
-                  "relationships": {},
-                  "row": {
-                    "id": "c1",
-                    "issueID": "i2",
-                    "text": "i2 c1 text",
-                  },
-                },
-              ],
-            },
+            "relationships": {},
             "row": {
               "id": "i2",
               "text": "second issue",

--- a/packages/zql/src/ivm/exists.push.test.ts
+++ b/packages/zql/src/ivm/exists.push.test.ts
@@ -409,7 +409,9 @@ suite('EXISTS 1 to many', () => {
         },
         {
           "node": {
-            "relationships": {},
+            "relationships": {
+              "issue": [],
+            },
             "row": {
               "id": "c1",
               "issueID": "i1",
@@ -459,7 +461,9 @@ suite('EXISTS 1 to many', () => {
         },
         {
           "node": {
-            "relationships": {},
+            "relationships": {
+              "issue": [],
+            },
             "row": {
               "id": "c2",
               "issueID": "i1",
@@ -1057,6 +1061,13 @@ suite('EXISTS', () => {
           "text": "first issue",
         },
         {
+          "comments": [
+            {
+              "id": "c4",
+              "issueID": "i2",
+              "text": "i2 c4 text",
+            },
+          ],
           "id": "i2",
           "text": "second issue",
         },
@@ -1099,7 +1110,18 @@ suite('EXISTS', () => {
       [
         {
           "node": {
-            "relationships": {},
+            "relationships": {
+              "comments": [
+                {
+                  "relationships": {},
+                  "row": {
+                    "id": "c4",
+                    "issueID": "i2",
+                    "text": "i2 c4 text",
+                  },
+                },
+              ],
+            },
             "row": {
               "id": "i2",
               "text": "second issue",
@@ -1340,7 +1362,9 @@ suite('EXISTS', () => {
         },
         {
           "node": {
-            "relationships": {},
+            "relationships": {
+              "comments": [],
+            },
             "row": {
               "id": "i1",
               "text": "first issue",
@@ -1615,6 +1639,13 @@ suite('EXISTS', () => {
     expect(data).toMatchInlineSnapshot(`
       [
         {
+          "comments": [
+            {
+              "id": "c1",
+              "issueID": "i2",
+              "text": "i2 c1 text",
+            },
+          ],
           "id": "i2",
           "text": "second issue",
         },
@@ -1708,7 +1739,9 @@ suite('EXISTS', () => {
         },
         {
           "node": {
-            "relationships": {},
+            "relationships": {
+              "comments": [],
+            },
             "row": {
               "id": "i1",
               "text": "first issue",
@@ -1718,7 +1751,18 @@ suite('EXISTS', () => {
         },
         {
           "node": {
-            "relationships": {},
+            "relationships": {
+              "comments": [
+                {
+                  "relationships": {},
+                  "row": {
+                    "id": "c1",
+                    "issueID": "i2",
+                    "text": "i2 c1 text",
+                  },
+                },
+              ],
+            },
             "row": {
               "id": "i2",
               "text": "second issue",
@@ -2239,7 +2283,18 @@ suite('NOT EXISTS', () => {
         },
         {
           "node": {
-            "relationships": {},
+            "relationships": {
+              "comments": [
+                {
+                  "relationships": {},
+                  "row": {
+                    "id": "c4",
+                    "issueID": "i2",
+                    "text": "i2 c4 text",
+                  },
+                },
+              ],
+            },
             "row": {
               "id": "i2",
               "text": "second issue",
@@ -2334,6 +2389,7 @@ suite('NOT EXISTS', () => {
     expect(data).toMatchInlineSnapshot(`
       [
         {
+          "comments": [],
           "id": "i1",
           "text": "first issue",
         },
@@ -2370,7 +2426,9 @@ suite('NOT EXISTS', () => {
       [
         {
           "node": {
-            "relationships": {},
+            "relationships": {
+              "comments": [],
+            },
             "row": {
               "id": "i1",
               "text": "first issue",
@@ -2517,6 +2575,7 @@ suite('NOT EXISTS', () => {
     expect(data).toMatchInlineSnapshot(`
       [
         {
+          "comments": [],
           "id": "i1",
           "text": "first issue",
         },
@@ -2578,7 +2637,9 @@ suite('NOT EXISTS', () => {
       [
         {
           "node": {
-            "relationships": {},
+            "relationships": {
+              "comments": [],
+            },
             "row": {
               "id": "i1",
               "text": "first issue",
@@ -2609,7 +2670,18 @@ suite('NOT EXISTS', () => {
         },
         {
           "node": {
-            "relationships": {},
+            "relationships": {
+              "comments": [
+                {
+                  "relationships": {},
+                  "row": {
+                    "id": "c1",
+                    "issueID": "i2",
+                    "text": "i2 c1 text",
+                  },
+                },
+              ],
+            },
             "row": {
               "id": "i2",
               "text": "second issue",

--- a/packages/zql/src/ivm/exists.ts
+++ b/packages/zql/src/ivm/exists.ts
@@ -199,8 +199,9 @@ export class Exists implements Operator {
    * relationship passes the exist/not exists filter condition.
    * If the optional `size` is passed it is used.
    * Otherwise, if there is a stored size for the row it is used.
-   * Otherwise the size is computed by fetching a node for the row from
-   * this.#input (this computed size is also stored).
+   * Otherwise the size is computed by streaming the node's
+   * relationship with this.#relationshipName (this computed size is also
+   * stored).
    */
   #filter(node: Node, size?: number): boolean {
     const exists = (size ?? this.#getOrFetchSize(node)) > 0;

--- a/packages/zql/src/ivm/exists.ts
+++ b/packages/zql/src/ivm/exists.ts
@@ -1,10 +1,8 @@
 import {areEqual} from '../../../shared/src/arrays.ts';
 import {assert, unreachable} from '../../../shared/src/asserts.ts';
-import {must} from '../../../shared/src/must.ts';
 import type {CompoundKey} from '../../../zero-protocol/src/ast.ts';
-import type {Row} from '../../../zero-protocol/src/data.ts';
-import {rowForChange, type Change} from './change.ts';
-import {normalizeUndefined, type NormalizedValue} from './data.ts';
+import {type Change} from './change.ts';
+import {normalizeUndefined, type Node, type NormalizedValue} from './data.ts';
 import {
   throwOutput,
   type FetchRequest,
@@ -76,7 +74,7 @@ export class Exists implements Operator {
 
   *fetch(req: FetchRequest) {
     for (const node of this.#input.fetch(req)) {
-      if (this.#filter(node.row)) {
+      if (this.#filter(node)) {
         yield node;
       }
     }
@@ -84,10 +82,10 @@ export class Exists implements Operator {
 
   *cleanup(req: FetchRequest) {
     for (const node of this.#input.cleanup(req)) {
-      if (this.#filter(node.row)) {
+      if (this.#filter(node)) {
         yield node;
       }
-      this.#delSize(node.row);
+      this.#delSize(node);
     }
   }
 
@@ -101,10 +99,10 @@ export class Exists implements Operator {
         return;
       }
       case 'remove': {
-        const size = this.#getSize(change.node.row);
+        const size = this.#getSize(change.node);
         // If size is undefined, this operator has not output
         // this row before and so it is unnecessary to output a remove for
-        // it.  Which is fortunate, since #fetchSize/#fetchNodeForRow would
+        // it.  Which is fortunate, since #fetchSize would
         // not be able to fetch a Node for this change since it is
         // removed from the source.
         if (size === undefined) {
@@ -112,7 +110,7 @@ export class Exists implements Operator {
         }
 
         this.#pushWithFilter(change, size);
-        this.#delSize(change.node.row);
+        this.#delSize(change.node);
         return;
       }
       case 'child':
@@ -130,13 +128,13 @@ export class Exists implements Operator {
         }
         switch (change.child.change.type) {
           case 'add': {
-            let size = this.#getSize(change.row);
+            let size = this.#getSize(change.node);
             if (size !== undefined) {
               size++;
-              this.#setCachedSize(change.row, size);
-              this.#setSize(change.row, size);
+              this.#setCachedSize(change.node, size);
+              this.#setSize(change.node, size);
             } else {
-              size = this.#fetchSize(change.row);
+              size = this.#fetchSize(change.node);
             }
             if (size === 1) {
               const type = this.#not ? 'remove' : 'add';
@@ -150,7 +148,7 @@ export class Exists implements Operator {
               }
               this.#output.push({
                 type,
-                node: this.#fetchNodeForRow(change.row),
+                node: change.node,
               });
             } else {
               this.#pushWithFilter(change, size);
@@ -158,7 +156,7 @@ export class Exists implements Operator {
             return;
           }
           case 'remove': {
-            let size = this.#getSize(change.row);
+            let size = this.#getSize(change.node);
             if (size !== undefined) {
               // Work around for issue https://bugs.rocicorp.dev/issue/3204
               // assert(size > 0);
@@ -166,10 +164,10 @@ export class Exists implements Operator {
                 return;
               }
               size--;
-              this.#setCachedSize(change.row, size);
-              this.#setSize(change.row, size);
+              this.#setCachedSize(change.node, size);
+              this.#setSize(change.node, size);
             } else {
-              size = this.#fetchSize(change.row);
+              size = this.#fetchSize(change.node);
             }
             if (size === 0) {
               const type = this.#not ? 'add' : 'remove';
@@ -182,7 +180,7 @@ export class Exists implements Operator {
               }
               this.#output.push({
                 type,
-                node: this.#fetchNodeForRow(change.row),
+                node: change.node,
               });
             } else {
               this.#pushWithFilter(change, size);
@@ -197,15 +195,15 @@ export class Exists implements Operator {
   }
 
   /**
-   * Returns whether or not the change's row's this.#relationshipName
+   * Returns whether or not the node's this.#relationshipName
    * relationship passes the exist/not exists filter condition.
    * If the optional `size` is passed it is used.
    * Otherwise, if there is a stored size for the row it is used.
    * Otherwise the size is computed by fetching a node for the row from
    * this.#input (this computed size is also stored).
    */
-  #filter(row: Row, size?: number): boolean {
-    const exists = (size ?? this.#getOrFetchSize(row)) > 0;
+  #filter(node: Node, size?: number): boolean {
+    const exists = (size ?? this.#getOrFetchSize(node)) > 0;
     return this.#not ? !exists : exists;
   }
 
@@ -213,116 +211,92 @@ export class Exists implements Operator {
    * Pushes a change if this.#filter is true for its row.
    */
   #pushWithFilter(change: Change, size?: number): void {
-    const row = rowForChange(change);
-    if (this.#filter(row, size)) {
+    if (this.#filter(change.node, size)) {
       this.#output.push(change);
     }
   }
 
-  #getSize(row: Row): number | undefined {
-    return this.#storage.get(this.#makeSizeStorageKey(row));
+  #getSize(node: Node): number | undefined {
+    return this.#storage.get(this.#makeSizeStorageKey(node));
   }
 
-  #setSize(row: Row, size: number) {
-    this.#storage.set(this.#makeSizeStorageKey(row), size);
+  #setSize(node: Node, size: number) {
+    this.#storage.set(this.#makeSizeStorageKey(node), size);
   }
 
-  #setCachedSize(row: Row, size: number) {
+  #setCachedSize(node: Node, size: number) {
     if (this.#skipCache) {
       return;
     }
 
-    this.#storage.set(this.#makeCacheStorageKey(row), size);
+    this.#storage.set(this.#makeCacheStorageKey(node), size);
   }
 
-  #getCachedSize(row: Row): number | undefined {
+  #getCachedSize(node: Node): number | undefined {
     if (this.#skipCache) {
       return undefined;
     }
 
-    return this.#storage.get(this.#makeCacheStorageKey(row));
+    return this.#storage.get(this.#makeCacheStorageKey(node));
   }
 
-  #delSize(row: Row) {
-    this.#storage.del(this.#makeSizeStorageKey(row));
+  #delSize(node: Node) {
+    this.#storage.del(this.#makeSizeStorageKey(node));
     if (!this.#skipCache) {
-      const cacheKey = this.#makeCacheStorageKey(row);
+      const cacheKey = this.#makeCacheStorageKey(node);
       if (first(this.#storage.scan({prefix: `${cacheKey}/`})) === undefined) {
         this.#storage.del(cacheKey);
       }
     }
   }
 
-  #getOrFetchSize(row: Row): number {
-    const size = this.#getSize(row);
+  #getOrFetchSize(node: Node): number {
+    const size = this.#getSize(node);
     if (size !== undefined) {
       return size;
     }
-    // We fetch this node so we can consume the relationship to
-    // determine its size (we can't consume the relationship of
-    // the node we are going to push or return via fetch to
-    // our output, because the relationships are one time use streams).
-    return this.#fetchSize(row);
+    return this.#fetchSize(node);
   }
 
-  #fetchSize(row: Row) {
-    const cachedSize = this.#getCachedSize(row);
+  #fetchSize(node: Node) {
+    const cachedSize = this.#getCachedSize(node);
     if (cachedSize !== undefined) {
-      this.#setSize(row, cachedSize);
+      this.#setSize(node, cachedSize);
       return cachedSize;
     }
 
-    const relationship =
-      this.#fetchNodeForRow(row).relationships[this.#relationshipName];
+    const relationship = node.relationships[this.#relationshipName];
     assert(relationship);
     let size = 0;
-    for (const _relatedNode of relationship) {
+    for (const _relatedNode of relationship()) {
       size++;
     }
 
-    this.#setCachedSize(row, size);
-    this.#setSize(row, size);
+    this.#setCachedSize(node, size);
+    this.#setSize(node, size);
     return size;
   }
 
-  #fetchNodeForRow(row: Row) {
-    const fetched = must(
-      first(
-        this.#input.fetch({
-          start: {row, basis: 'at'},
-        }),
-      ),
-    );
-    assert(
-      this.getSchema().compareRows(row, fetched.row) === 0,
-      () =>
-        `fetchNodeForRow returned unexpected row, expected ${JSON.stringify(
-          row,
-        )}, received ${JSON.stringify(fetched.row)}`,
-    );
-    return fetched;
-  }
-
-  #makeCacheStorageKey(row: Row): CacheStorageKey {
+  #makeCacheStorageKey(node: Node): CacheStorageKey {
     return `row/${JSON.stringify(
-      this.#getKeyValues(row, this.#parentJoinKey),
+      this.#getKeyValues(node, this.#parentJoinKey),
     )}`;
   }
 
-  #makeSizeStorageKey(row: Row): SizeStorageKey {
+  #makeSizeStorageKey(node: Node): SizeStorageKey {
     return `row/${
       this.#skipCache
         ? ''
-        : JSON.stringify(this.#getKeyValues(row, this.#parentJoinKey))
+        : JSON.stringify(this.#getKeyValues(node, this.#parentJoinKey))
     }/${JSON.stringify(
-      this.#getKeyValues(row, this.#input.getSchema().primaryKey),
+      this.#getKeyValues(node, this.#input.getSchema().primaryKey),
     )}`;
   }
 
-  #getKeyValues(row: Row, def: CompoundKey): NormalizedValue[] {
+  #getKeyValues(node: Node, def: CompoundKey): NormalizedValue[] {
     const values: NormalizedValue[] = [];
     for (const key of def) {
-      values.push(normalizeUndefined(row[key]));
+      values.push(normalizeUndefined(node.row[key]));
     }
     return values;
   }

--- a/packages/zql/src/ivm/exists.ts
+++ b/packages/zql/src/ivm/exists.ts
@@ -2,7 +2,12 @@ import {areEqual} from '../../../shared/src/arrays.ts';
 import {assert, unreachable} from '../../../shared/src/asserts.ts';
 import type {CompoundKey} from '../../../zero-protocol/src/ast.ts';
 import {type Change} from './change.ts';
-import {normalizeUndefined, type Node, type NormalizedValue} from './data.ts';
+import {
+  drainStreams,
+  normalizeUndefined,
+  type Node,
+  type NormalizedValue,
+} from './data.ts';
 import {
   throwOutput,
   type FetchRequest,
@@ -84,6 +89,8 @@ export class Exists implements Operator {
     for (const node of this.#input.cleanup(req)) {
       if (this.#filter(node)) {
         yield node;
+      } else {
+        drainStreams(node);
       }
       this.#delSize(node);
     }

--- a/packages/zql/src/ivm/fan-out-fan-in.test.ts
+++ b/packages/zql/src/ivm/fan-out-fan-in.test.ts
@@ -33,31 +33,111 @@ test('fan-out pushes along all paths', () => {
   s.push({type: 'edit', oldRow: {a: 1, b: 'foo'}, row: {a: 1, b: 'bar'}});
   s.push({type: 'remove', row: {a: 1, b: 'bar'}});
 
-  const expected = [
-    {
-      type: 'add',
-      node: {
-        row: {a: 1, b: 'foo'},
-        relationships: {},
+  expect(catch1.pushes).toMatchInlineSnapshot(`
+    [
+      {
+        "node": {
+          "relationships": {},
+          "row": {
+            "a": 1,
+            "b": "foo",
+          },
+        },
+        "type": "add",
       },
-    },
-    {
-      type: 'edit',
-      oldRow: {a: 1, b: 'foo'},
-      row: {a: 1, b: 'bar'},
-    },
-    {
-      type: 'remove',
-      node: {
-        row: {a: 1, b: 'bar'},
-        relationships: {},
+      {
+        "oldRow": {
+          "a": 1,
+          "b": "foo",
+        },
+        "row": {
+          "a": 1,
+          "b": "bar",
+        },
+        "type": "edit",
       },
-    },
-  ];
-
-  expect(catch1.pushes).toEqual(expected);
-  expect(catch2.pushes).toEqual(expected);
-  expect(catch3.pushes).toEqual(expected);
+      {
+        "node": {
+          "relationships": {},
+          "row": {
+            "a": 1,
+            "b": "bar",
+          },
+        },
+        "type": "remove",
+      },
+    ]
+  `);
+  expect(catch2.pushes).toMatchInlineSnapshot(`
+    [
+      {
+        "node": {
+          "relationships": {},
+          "row": {
+            "a": 1,
+            "b": "foo",
+          },
+        },
+        "type": "add",
+      },
+      {
+        "oldRow": {
+          "a": 1,
+          "b": "foo",
+        },
+        "row": {
+          "a": 1,
+          "b": "bar",
+        },
+        "type": "edit",
+      },
+      {
+        "node": {
+          "relationships": {},
+          "row": {
+            "a": 1,
+            "b": "bar",
+          },
+        },
+        "type": "remove",
+      },
+    ]
+  `);
+  expect(catch3.pushes).toMatchInlineSnapshot(`
+    [
+      {
+        "node": {
+          "relationships": {},
+          "row": {
+            "a": 1,
+            "b": "foo",
+          },
+        },
+        "type": "add",
+      },
+      {
+        "oldRow": {
+          "a": 1,
+          "b": "foo",
+        },
+        "row": {
+          "a": 1,
+          "b": "bar",
+        },
+        "type": "edit",
+      },
+      {
+        "node": {
+          "relationships": {},
+          "row": {
+            "a": 1,
+            "b": "bar",
+          },
+        },
+        "type": "remove",
+      },
+    ]
+  `);
 });
 
 test('fan-out,fan-in pairing does not duplicate pushes', () => {
@@ -81,38 +161,40 @@ test('fan-out,fan-in pairing does not duplicate pushes', () => {
   s.push({type: 'add', row: {a: 2, b: 'foo'}});
   s.push({type: 'add', row: {a: 3, b: 'foo'}});
 
-  expect(out.pushes).toEqual([
-    {
-      node: {
-        relationships: {},
-        row: {
-          a: 1,
-          b: 'foo',
+  expect(out.pushes).toMatchInlineSnapshot(`
+    [
+      {
+        "node": {
+          "relationships": {},
+          "row": {
+            "a": 1,
+            "b": "foo",
+          },
         },
+        "type": "add",
       },
-      type: 'add',
-    },
-    {
-      node: {
-        relationships: {},
-        row: {
-          a: 2,
-          b: 'foo',
+      {
+        "node": {
+          "relationships": {},
+          "row": {
+            "a": 2,
+            "b": "foo",
+          },
         },
+        "type": "add",
       },
-      type: 'add',
-    },
-    {
-      node: {
-        relationships: {},
-        row: {
-          a: 3,
-          b: 'foo',
+      {
+        "node": {
+          "relationships": {},
+          "row": {
+            "a": 3,
+            "b": "foo",
+          },
         },
+        "type": "add",
       },
-      type: 'add',
-    },
-  ]);
+    ]
+  `);
 });
 
 test('fan-in fetch', () => {
@@ -143,29 +225,31 @@ test('fan-in fetch', () => {
   const fanIn = new FanIn(fanOut, [filter1, filter2, filter3, filter4]);
   const out = new Catch(fanIn);
   const result = out.fetch();
-  expect(result).toEqual([
-    {
-      relationships: {},
-      row: {
-        a: false,
-        b: true,
+  expect(result).toMatchInlineSnapshot(`
+    [
+      {
+        "relationships": {},
+        "row": {
+          "a": false,
+          "b": true,
+        },
       },
-    },
-    {
-      relationships: {},
-      row: {
-        a: true,
-        b: false,
+      {
+        "relationships": {},
+        "row": {
+          "a": true,
+          "b": false,
+        },
       },
-    },
-    {
-      relationships: {},
-      row: {
-        a: true,
-        b: true,
+      {
+        "relationships": {},
+        "row": {
+          "a": true,
+          "b": true,
+        },
       },
-    },
-  ]);
+    ]
+  `);
 });
 
 test('cleanup called once per branch', () => {

--- a/packages/zql/src/ivm/filter-push.ts
+++ b/packages/zql/src/ivm/filter-push.ts
@@ -21,7 +21,7 @@ export function filterPush(
       }
       break;
     case 'child':
-      if (predicate(change.row)) {
+      if (predicate(change.node.row)) {
         output.push(change);
       }
       break;

--- a/packages/zql/src/ivm/filter.test.ts
+++ b/packages/zql/src/ivm/filter.test.ts
@@ -29,37 +29,72 @@ test('basics', () => {
   const filter = new Filter(connector, row => row.b === 'foo');
   const out = new Catch(filter);
 
-  expect(out.fetch()).toEqual([
-    {row: {a: 1, b: 'foo'}, relationships: {}},
-    {row: {a: 3, b: 'foo'}, relationships: {}},
-  ]);
-
+  expect(out.fetch()).toMatchInlineSnapshot(`
+    [
+      {
+        "relationships": {},
+        "row": {
+          "a": 1,
+          "b": "foo",
+        },
+      },
+      {
+        "relationships": {},
+        "row": {
+          "a": 3,
+          "b": "foo",
+        },
+      },
+    ]
+  `);
   ms.push({type: 'add', row: {a: 4, b: 'bar'}});
   ms.push({type: 'add', row: {a: 5, b: 'foo'}});
   ms.push({type: 'remove', row: {a: 3, b: 'foo'}});
   ms.push({type: 'remove', row: {a: 2, b: 'bar'}});
 
-  expect(out.pushes).toEqual([
-    {
-      type: 'add',
-      node: {row: {a: 5, b: 'foo'}, relationships: {}},
-    },
-    {
-      type: 'remove',
-      node: {row: {a: 3, b: 'foo'}, relationships: {}},
-    },
-  ]);
+  expect(out.pushes).toMatchInlineSnapshot(`
+    [
+      {
+        "node": {
+          "relationships": {},
+          "row": {
+            "a": 5,
+            "b": "foo",
+          },
+        },
+        "type": "add",
+      },
+      {
+        "node": {
+          "relationships": {},
+          "row": {
+            "a": 3,
+            "b": "foo",
+          },
+        },
+        "type": "remove",
+      },
+    ]
+  `);
 
-  expect(out.cleanup({})).toEqual([
-    {
-      row: {a: 1, b: 'foo'},
-      relationships: {},
-    },
-    {
-      row: {a: 5, b: 'foo'},
-      relationships: {},
-    },
-  ]);
+  expect(out.cleanup({})).toMatchInlineSnapshot(`
+    [
+      {
+        "relationships": {},
+        "row": {
+          "a": 1,
+          "b": "foo",
+        },
+      },
+      {
+        "relationships": {},
+        "row": {
+          "a": 5,
+          "b": "foo",
+        },
+      },
+    ]
+  `);
 });
 
 test('edit', () => {
@@ -82,65 +117,161 @@ test('edit', () => {
   const filter = new Filter(connector, row => (row.x as number) % 2 === 0);
   const out = new Catch(filter);
 
-  expect(out.fetch()).toEqual([{row: {a: 2, x: 2}, relationships: {}}]);
+  expect(out.fetch()).toMatchInlineSnapshot(`
+    [
+      {
+        "relationships": {},
+        "row": {
+          "a": 2,
+          "x": 2,
+        },
+      },
+    ]
+  `);
 
   ms.push({type: 'add', row: {a: 4, x: 4}});
   ms.push({type: 'edit', oldRow: {a: 3, x: 3}, row: {a: 3, x: 6}});
 
-  expect(out.pushes).toEqual([
-    {
-      type: 'add',
-      node: {
-        row: {a: 4, x: 4},
-        relationships: {},
+  expect(out.pushes).toMatchInlineSnapshot(`
+    [
+      {
+        "node": {
+          "relationships": {},
+          "row": {
+            "a": 4,
+            "x": 4,
+          },
+        },
+        "type": "add",
       },
-    },
-    {
-      type: 'add',
-      node: {
-        row: {a: 3, x: 6},
-        relationships: {},
+      {
+        "node": {
+          "relationships": {},
+          "row": {
+            "a": 3,
+            "x": 6,
+          },
+        },
+        "type": "add",
       },
-    },
-  ]);
-
-  expect(out.fetch({})).toEqual([
-    {row: {a: 2, x: 2}, relationships: {}},
-    {row: {a: 3, x: 6}, relationships: {}},
-    {row: {a: 4, x: 4}, relationships: {}},
-  ]);
+    ]
+  `);
+  expect(out.fetch({})).toMatchInlineSnapshot(`
+    [
+      {
+        "relationships": {},
+        "row": {
+          "a": 2,
+          "x": 2,
+        },
+      },
+      {
+        "relationships": {},
+        "row": {
+          "a": 3,
+          "x": 6,
+        },
+      },
+      {
+        "relationships": {},
+        "row": {
+          "a": 4,
+          "x": 4,
+        },
+      },
+    ]
+  `);
 
   out.pushes.length = 0;
   ms.push({type: 'edit', oldRow: {a: 3, x: 6}, row: {a: 3, x: 5}});
-  expect(out.pushes).toEqual([
-    {
-      type: 'remove',
-      node: {
-        row: {a: 3, x: 6},
-        relationships: {},
+  expect(out.pushes).toMatchInlineSnapshot(`
+    [
+      {
+        "node": {
+          "relationships": {},
+          "row": {
+            "a": 3,
+            "x": 6,
+          },
+        },
+        "type": "remove",
       },
-    },
-  ]);
-  expect(out.fetch({})).toEqual([
-    {row: {a: 2, x: 2}, relationships: {}},
-    {row: {a: 4, x: 4}, relationships: {}},
-  ]);
+    ]
+  `);
+  expect(out.fetch({})).toMatchInlineSnapshot(`
+    [
+      {
+        "relationships": {},
+        "row": {
+          "a": 2,
+          "x": 2,
+        },
+      },
+      {
+        "relationships": {},
+        "row": {
+          "a": 4,
+          "x": 4,
+        },
+      },
+    ]
+  `);
 
   out.pushes.length = 0;
   ms.push({type: 'edit', oldRow: {a: 3, x: 5}, row: {a: 3, x: 7}});
-  expect(out.pushes).toEqual([]);
-  expect(out.fetch({})).toEqual([
-    {row: {a: 2, x: 2}, relationships: {}},
-    {row: {a: 4, x: 4}, relationships: {}},
-  ]);
+  expect(out.pushes).toMatchInlineSnapshot(`[]`);
+  expect(out.fetch({})).toMatchInlineSnapshot(`
+    [
+      {
+        "relationships": {},
+        "row": {
+          "a": 2,
+          "x": 2,
+        },
+      },
+      {
+        "relationships": {},
+        "row": {
+          "a": 4,
+          "x": 4,
+        },
+      },
+    ]
+  `);
 
   out.pushes.length = 0;
   ms.push({type: 'edit', oldRow: {a: 2, x: 2}, row: {a: 2, x: 4}});
-  expect(out.pushes).toEqual([
-    {type: 'edit', oldRow: {a: 2, x: 2}, row: {a: 2, x: 4}},
-  ]);
-  expect(out.fetch({})).toEqual([
-    {row: {a: 2, x: 4}, relationships: {}},
-    {row: {a: 4, x: 4}, relationships: {}},
-  ]);
+  expect(out.pushes).toMatchInlineSnapshot(`
+    [
+      {
+        "oldRow": {
+          "a": 2,
+          "x": 2,
+        },
+        "row": {
+          "a": 2,
+          "x": 4,
+        },
+        "type": "edit",
+      },
+    ]
+  `);
+  expect(out.fetch({})).toMatchInlineSnapshot(`
+    [
+      {
+        "relationships": {},
+        "row": {
+          "a": 2,
+          "x": 4,
+        },
+      },
+      {
+        "relationships": {},
+        "row": {
+          "a": 4,
+          "x": 4,
+        },
+      },
+    ]
+  `);
 });

--- a/packages/zql/src/ivm/filter.ts
+++ b/packages/zql/src/ivm/filter.ts
@@ -1,6 +1,6 @@
 import type {Row} from '../../../zero-protocol/src/data.ts';
 import type {Change} from './change.ts';
-import type {Node} from './data.ts';
+import {drainStreams} from './data.ts';
 import {filterPush} from './filter-push.ts';
 import {
   throwOutput,
@@ -10,7 +10,6 @@ import {
   type Output,
 } from './operator.ts';
 import type {SourceSchema} from './schema.ts';
-import type {Stream} from './stream.ts';
 
 /**
  * The Filter operator filters data through a predicate. It is stateless.
@@ -41,18 +40,20 @@ export class Filter implements Operator {
     return this.#input.getSchema();
   }
 
-  fetch(req: FetchRequest) {
-    return this.#filter(this.#input.fetch(req));
-  }
-
-  cleanup(req: FetchRequest) {
-    return this.#filter(this.#input.cleanup(req));
-  }
-
-  *#filter(stream: Stream<Node>) {
-    for (const node of stream) {
+  *fetch(req: FetchRequest) {
+    for (const node of this.#input.fetch(req)) {
       if (this.#predicate(node.row)) {
         yield node;
+      }
+    }
+  }
+
+  *cleanup(req: FetchRequest) {
+    for (const node of this.#input.cleanup(req)) {
+      if (this.#predicate(node.row)) {
+        yield node;
+      } else {
+        drainStreams(node);
       }
     }
   }

--- a/packages/zql/src/ivm/join.fetch.test.ts
+++ b/packages/zql/src/ivm/join.fetch.test.ts
@@ -550,7 +550,7 @@ suite('fetch many:one', () => {
     `);
   });
 
-  test('two parents, one child', () => {
+  test.only('two parents, one child', () => {
     const results = fetchTest({
       ...base,
       sources: [

--- a/packages/zql/src/ivm/join.fetch.test.ts
+++ b/packages/zql/src/ivm/join.fetch.test.ts
@@ -550,7 +550,7 @@ suite('fetch many:one', () => {
     `);
   });
 
-  test.only('two parents, one child', () => {
+  test('two parents, one child', () => {
     const results = fetchTest({
       ...base,
       sources: [

--- a/packages/zql/src/ivm/join.fetch.test.ts
+++ b/packages/zql/src/ivm/join.fetch.test.ts
@@ -5,9 +5,8 @@ import type {CompoundKey, Ordering} from '../../../zero-protocol/src/ast.ts';
 import type {Row} from '../../../zero-protocol/src/data.ts';
 import type {PrimaryKey} from '../../../zero-protocol/src/primary-key.ts';
 import type {SchemaValue} from '../../../zero-schema/src/table-schema.ts';
-import {Catch} from './catch.ts';
+import {Catch, type CaughtNode} from './catch.ts';
 import {SetOfConstraint} from './constraint.ts';
-import type {Node} from './data.ts';
 import {Join, makeStorageKey, makeStorageKeyPrefix} from './join.ts';
 import {MemoryStorage} from './memory-storage.ts';
 import type {SourceSchema} from './schema.ts';
@@ -2289,7 +2288,7 @@ type FetchTest = {
 
 type FetchTestResults = {
   fetchMessages: SnitchMessage[];
-  hydrate: Node[];
+  hydrate: CaughtNode[];
   storage: Record<string, JSONValue>[];
 };
 

--- a/packages/zql/src/ivm/join.push.test.ts
+++ b/packages/zql/src/ivm/join.push.test.ts
@@ -1155,7 +1155,9 @@ suite('push one:many', () => {
       `);
       expect(actualStorage).toMatchInlineSnapshot(`
         {
-          "comments": {},
+          "comments": {
+            ""pKeySet","i1","i1",": true,
+          },
         }
       `);
       expect(pushes).toMatchInlineSnapshot(`
@@ -5640,6 +5642,7 @@ describe('joins with compound join keys', () => {
     expect(actualStorage).toMatchInlineSnapshot(`
       {
         "ab": {
+          ""pKeySet",1,2,0,": true,
           ""pKeySet",4,5,1,": true,
         },
       }

--- a/packages/zql/src/ivm/join.push.test.ts
+++ b/packages/zql/src/ivm/join.push.test.ts
@@ -71,15 +71,6 @@ suite('push one:many', () => {
           },
         ],
         [
-          "comment",
-          "cleanup",
-          {
-            "constraint": {
-              "issueID": "i1",
-            },
-          },
-        ],
-        [
           "comments",
           "push",
           {
@@ -87,6 +78,15 @@ suite('push one:many', () => {
               "id": "i1",
             },
             "type": "remove",
+          },
+        ],
+        [
+          "comment",
+          "cleanup",
+          {
+            "constraint": {
+              "issueID": "i1",
+            },
           },
         ],
       ]
@@ -184,15 +184,6 @@ suite('push one:many', () => {
           },
         ],
         [
-          "comment",
-          "fetch",
-          {
-            "constraint": {
-              "issueID": "i1",
-            },
-          },
-        ],
-        [
           "comments",
           "push",
           {
@@ -200,6 +191,15 @@ suite('push one:many', () => {
               "id": "i1",
             },
             "type": "add",
+          },
+        ],
+        [
+          "comment",
+          "fetch",
+          {
+            "constraint": {
+              "issueID": "i1",
+            },
           },
         ],
       ]
@@ -277,15 +277,6 @@ suite('push one:many', () => {
           },
         ],
         [
-          "comment",
-          "fetch",
-          {
-            "constraint": {
-              "issueID": "i1",
-            },
-          },
-        ],
-        [
           "comments",
           "push",
           {
@@ -293,6 +284,15 @@ suite('push one:many', () => {
               "id": "i1",
             },
             "type": "add",
+          },
+        ],
+        [
+          "comment",
+          "fetch",
+          {
+            "constraint": {
+              "issueID": "i1",
+            },
           },
         ],
       ]
@@ -378,15 +378,6 @@ suite('push one:many', () => {
           },
         ],
         [
-          "comment",
-          "fetch",
-          {
-            "constraint": {
-              "issueID": "i2",
-            },
-          },
-        ],
-        [
           "comments",
           "push",
           {
@@ -394,6 +385,15 @@ suite('push one:many', () => {
               "id": "i2",
             },
             "type": "add",
+          },
+        ],
+        [
+          "comment",
+          "fetch",
+          {
+            "constraint": {
+              "issueID": "i2",
+            },
           },
         ],
       ]
@@ -607,15 +607,6 @@ suite('push one:many', () => {
           },
         ],
         [
-          "comment",
-          "cleanup",
-          {
-            "constraint": {
-              "issueID": "i1",
-            },
-          },
-        ],
-        [
           "comments",
           "push",
           {
@@ -623,6 +614,15 @@ suite('push one:many', () => {
               "id": "i1",
             },
             "type": "remove",
+          },
+        ],
+        [
+          "comment",
+          "cleanup",
+          {
+            "constraint": {
+              "issueID": "i1",
+            },
           },
         ],
       ]
@@ -686,15 +686,6 @@ suite('push one:many', () => {
           },
         ],
         [
-          "comment",
-          "cleanup",
-          {
-            "constraint": {
-              "issueID": "i1",
-            },
-          },
-        ],
-        [
           "comments",
           "push",
           {
@@ -702,6 +693,15 @@ suite('push one:many', () => {
               "id": "i1",
             },
             "type": "remove",
+          },
+        ],
+        [
+          "comment",
+          "cleanup",
+          {
+            "constraint": {
+              "issueID": "i1",
+            },
           },
         ],
       ]
@@ -775,15 +775,6 @@ suite('push one:many', () => {
           },
         ],
         [
-          "comment",
-          "fetch",
-          {
-            "constraint": {
-              "issueID": "i1",
-            },
-          },
-        ],
-        [
           "comments",
           "push",
           {
@@ -791,6 +782,15 @@ suite('push one:many', () => {
               "id": "i1",
             },
             "type": "add",
+          },
+        ],
+        [
+          "comment",
+          "fetch",
+          {
+            "constraint": {
+              "issueID": "i1",
+            },
           },
         ],
         [
@@ -915,15 +915,6 @@ suite('push one:many', () => {
           },
         ],
         [
-          "comment",
-          "cleanup",
-          {
-            "constraint": {
-              "issueID": "i1",
-            },
-          },
-        ],
-        [
           "comments",
           "push",
           {
@@ -931,6 +922,15 @@ suite('push one:many', () => {
               "id": "i1",
             },
             "type": "remove",
+          },
+        ],
+        [
+          "comment",
+          "cleanup",
+          {
+            "constraint": {
+              "issueID": "i1",
+            },
           },
         ],
       ]
@@ -1117,24 +1117,6 @@ suite('push one:many', () => {
             },
           ],
           [
-            "comment",
-            "cleanup",
-            {
-              "constraint": {
-                "issueID": "i1",
-              },
-            },
-          ],
-          [
-            "comment",
-            "fetch",
-            {
-              "constraint": {
-                "issueID": "i1",
-              },
-            },
-          ],
-          [
             "comments",
             "push",
             {
@@ -1173,9 +1155,7 @@ suite('push one:many', () => {
       `);
       expect(actualStorage).toMatchInlineSnapshot(`
         {
-          "comments": {
-            ""pKeySet","i1","i1",": true,
-          },
+          "comments": {},
         }
       `);
       expect(pushes).toMatchInlineSnapshot(`
@@ -1561,6 +1541,17 @@ suite('push one:many', () => {
             },
           ],
           [
+            "comments",
+            "push",
+            {
+              "row": {
+                "id": "i1",
+                "text": "issue 1",
+              },
+              "type": "remove",
+            },
+          ],
+          [
             "comment",
             "cleanup",
             {
@@ -1574,10 +1565,10 @@ suite('push one:many', () => {
             "push",
             {
               "row": {
-                "id": "i1",
-                "text": "issue 1",
+                "id": "i3",
+                "text": "issue 1.3",
               },
-              "type": "remove",
+              "type": "add",
             },
           ],
           [
@@ -1587,17 +1578,6 @@ suite('push one:many', () => {
               "constraint": {
                 "issueID": "i3",
               },
-            },
-          ],
-          [
-            "comments",
-            "push",
-            {
-              "row": {
-                "id": "i3",
-                "text": "issue 1.3",
-              },
-              "type": "add",
             },
           ],
         ]
@@ -1751,15 +1731,6 @@ suite('push many:one', () => {
           },
         ],
         [
-          "user",
-          "fetch",
-          {
-            "constraint": {
-              "id": "u1",
-            },
-          },
-        ],
-        [
           "comments",
           "push",
           {
@@ -1768,6 +1739,15 @@ suite('push many:one', () => {
               "ownerID": "u1",
             },
             "type": "add",
+          },
+        ],
+        [
+          "user",
+          "fetch",
+          {
+            "constraint": {
+              "id": "u1",
+            },
           },
         ],
       ]
@@ -1841,15 +1821,6 @@ suite('push many:one', () => {
           },
         ],
         [
-          "user",
-          "fetch",
-          {
-            "constraint": {
-              "id": "u2",
-            },
-          },
-        ],
-        [
           "comments",
           "push",
           {
@@ -1858,6 +1829,15 @@ suite('push many:one', () => {
               "ownerID": "u2",
             },
             "type": "add",
+          },
+        ],
+        [
+          "user",
+          "fetch",
+          {
+            "constraint": {
+              "id": "u2",
+            },
           },
         ],
       ]
@@ -2456,24 +2436,6 @@ suite('push many:one', () => {
             },
           ],
           [
-            "comment",
-            "cleanup",
-            {
-              "constraint": {
-                "issueID": "i2",
-              },
-            },
-          ],
-          [
-            "comment",
-            "fetch",
-            {
-              "constraint": {
-                "issueID": "i2",
-              },
-            },
-          ],
-          [
             "comments",
             "push",
             {
@@ -2519,6 +2481,15 @@ suite('push many:one', () => {
             },
           ],
           [
+            "comment",
+            "cleanup",
+            {
+              "constraint": {
+                "issueID": "i2",
+              },
+            },
+          ],
+          [
             "user",
             "fetch",
             {
@@ -2544,6 +2515,15 @@ suite('push many:one', () => {
                 "text": "user 1",
               },
               "type": "child",
+            },
+          ],
+          [
+            "comment",
+            "fetch",
+            {
+              "constraint": {
+                "issueID": "i2",
+              },
             },
           ],
         ]
@@ -3163,15 +3143,6 @@ suite('push one:many:many', () => {
           },
         ],
         [
-          "revision",
-          "fetch",
-          {
-            "constraint": {
-              "commentID": "c1",
-            },
-          },
-        ],
-        [
           "revisions",
           "push",
           {
@@ -3206,6 +3177,15 @@ suite('push one:many:many', () => {
               "id": "i1",
             },
             "type": "child",
+          },
+        ],
+        [
+          "revision",
+          "fetch",
+          {
+            "constraint": {
+              "commentID": "c1",
+            },
           },
         ],
       ]
@@ -3300,15 +3280,6 @@ suite('push one:many:many', () => {
           },
         ],
         [
-          "revisions",
-          "fetch",
-          {
-            "constraint": {
-              "issueID": "i1",
-            },
-          },
-        ],
-        [
           "comments",
           "push",
           {
@@ -3316,6 +3287,15 @@ suite('push one:many:many', () => {
               "id": "i1",
             },
             "type": "add",
+          },
+        ],
+        [
+          "revisions",
+          "fetch",
+          {
+            "constraint": {
+              "issueID": "i1",
+            },
           },
         ],
         [
@@ -3428,15 +3408,6 @@ suite('push one:many:many', () => {
           },
         ],
         [
-          "revisions",
-          "cleanup",
-          {
-            "constraint": {
-              "issueID": "i1",
-            },
-          },
-        ],
-        [
           "comments",
           "push",
           {
@@ -3444,6 +3415,15 @@ suite('push one:many:many', () => {
               "id": "i1",
             },
             "type": "remove",
+          },
+        ],
+        [
+          "revisions",
+          "cleanup",
+          {
+            "constraint": {
+              "issueID": "i1",
+            },
           },
         ],
         [
@@ -3744,15 +3724,6 @@ suite('push one:many:one', () => {
           },
         ],
         [
-          "label",
-          "fetch",
-          {
-            "constraint": {
-              "id": "l1",
-            },
-          },
-        ],
-        [
           "labels",
           "push",
           {
@@ -3787,6 +3758,15 @@ suite('push one:many:one', () => {
               "id": "i1",
             },
             "type": "child",
+          },
+        ],
+        [
+          "label",
+          "fetch",
+          {
+            "constraint": {
+              "id": "l1",
+            },
           },
         ],
       ]
@@ -4256,24 +4236,6 @@ describe('edit assignee', () => {
           },
         ],
         [
-          "user",
-          "cleanup",
-          {
-            "constraint": {
-              "userID": "u1",
-            },
-          },
-        ],
-        [
-          "user",
-          "fetch",
-          {
-            "constraint": {
-              "userID": "u1",
-            },
-          },
-        ],
-        [
           "creator",
           "push",
           {
@@ -4293,15 +4255,6 @@ describe('edit assignee', () => {
           },
         ],
         [
-          "user",
-          "cleanup",
-          {
-            "constraint": {
-              "userID": undefined,
-            },
-          },
-        ],
-        [
           "assignee",
           "push",
           {
@@ -4316,10 +4269,19 @@ describe('edit assignee', () => {
         ],
         [
           "user",
-          "fetch",
+          "cleanup",
           {
             "constraint": {
               "userID": "u1",
+            },
+          },
+        ],
+        [
+          "user",
+          "cleanup",
+          {
+            "constraint": {
+              "userID": undefined,
             },
           },
         ],
@@ -4334,6 +4296,24 @@ describe('edit assignee', () => {
               "text": "first issue",
             },
             "type": "add",
+          },
+        ],
+        [
+          "user",
+          "fetch",
+          {
+            "constraint": {
+              "userID": "u1",
+            },
+          },
+        ],
+        [
+          "user",
+          "fetch",
+          {
+            "constraint": {
+              "userID": "u1",
+            },
           },
         ],
       ]
@@ -4542,24 +4522,6 @@ describe('edit assignee', () => {
           },
         ],
         [
-          "user",
-          "cleanup",
-          {
-            "constraint": {
-              "userID": "u1",
-            },
-          },
-        ],
-        [
-          "user",
-          "fetch",
-          {
-            "constraint": {
-              "userID": "u1",
-            },
-          },
-        ],
-        [
           "creator",
           "push",
           {
@@ -4579,15 +4541,6 @@ describe('edit assignee', () => {
           },
         ],
         [
-          "user",
-          "cleanup",
-          {
-            "constraint": {
-              "userID": undefined,
-            },
-          },
-        ],
-        [
           "assignee",
           "push",
           {
@@ -4602,10 +4555,19 @@ describe('edit assignee', () => {
         ],
         [
           "user",
-          "fetch",
+          "cleanup",
           {
             "constraint": {
               "userID": "u1",
+            },
+          },
+        ],
+        [
+          "user",
+          "cleanup",
+          {
+            "constraint": {
+              "userID": undefined,
             },
           },
         ],
@@ -4620,6 +4582,24 @@ describe('edit assignee', () => {
               "text": "first issue",
             },
             "type": "add",
+          },
+        ],
+        [
+          "user",
+          "fetch",
+          {
+            "constraint": {
+              "userID": "u1",
+            },
+          },
+        ],
+        [
+          "user",
+          "fetch",
+          {
+            "constraint": {
+              "userID": "u1",
+            },
           },
         ],
       ]
@@ -4817,24 +4797,6 @@ describe('edit assignee', () => {
           },
         ],
         [
-          "user",
-          "cleanup",
-          {
-            "constraint": {
-              "userID": "u1",
-            },
-          },
-        ],
-        [
-          "user",
-          "fetch",
-          {
-            "constraint": {
-              "userID": "u1",
-            },
-          },
-        ],
-        [
           "creator",
           "push",
           {
@@ -4854,15 +4816,6 @@ describe('edit assignee', () => {
           },
         ],
         [
-          "user",
-          "cleanup",
-          {
-            "constraint": {
-              "userID": "u1",
-            },
-          },
-        ],
-        [
           "assignee",
           "push",
           {
@@ -4877,10 +4830,19 @@ describe('edit assignee', () => {
         ],
         [
           "user",
-          "fetch",
+          "cleanup",
           {
             "constraint": {
-              "userID": undefined,
+              "userID": "u1",
+            },
+          },
+        ],
+        [
+          "user",
+          "cleanup",
+          {
+            "constraint": {
+              "userID": "u1",
             },
           },
         ],
@@ -4895,6 +4857,24 @@ describe('edit assignee', () => {
               "text": "first issue",
             },
             "type": "add",
+          },
+        ],
+        [
+          "user",
+          "fetch",
+          {
+            "constraint": {
+              "userID": "u1",
+            },
+          },
+        ],
+        [
+          "user",
+          "fetch",
+          {
+            "constraint": {
+              "userID": undefined,
+            },
           },
         ],
       ]
@@ -5093,24 +5073,6 @@ describe('edit assignee', () => {
           },
         ],
         [
-          "user",
-          "cleanup",
-          {
-            "constraint": {
-              "userID": "u1",
-            },
-          },
-        ],
-        [
-          "user",
-          "fetch",
-          {
-            "constraint": {
-              "userID": "u1",
-            },
-          },
-        ],
-        [
           "creator",
           "push",
           {
@@ -5130,15 +5092,6 @@ describe('edit assignee', () => {
           },
         ],
         [
-          "user",
-          "cleanup",
-          {
-            "constraint": {
-              "userID": "u1",
-            },
-          },
-        ],
-        [
           "assignee",
           "push",
           {
@@ -5153,10 +5106,19 @@ describe('edit assignee', () => {
         ],
         [
           "user",
-          "fetch",
+          "cleanup",
           {
             "constraint": {
-              "userID": undefined,
+              "userID": "u1",
+            },
+          },
+        ],
+        [
+          "user",
+          "cleanup",
+          {
+            "constraint": {
+              "userID": "u1",
             },
           },
         ],
@@ -5171,6 +5133,24 @@ describe('edit assignee', () => {
               "text": "first issue",
             },
             "type": "add",
+          },
+        ],
+        [
+          "user",
+          "fetch",
+          {
+            "constraint": {
+              "userID": "u1",
+            },
+          },
+        ],
+        [
+          "user",
+          "fetch",
+          {
+            "constraint": {
+              "userID": undefined,
+            },
           },
         ],
       ]
@@ -5419,16 +5399,6 @@ describe('joins with compound join keys', () => {
           },
         ],
         [
-          "b",
-          "fetch",
-          {
-            "constraint": {
-              "b1": 8,
-              "b2": 7,
-            },
-          },
-        ],
-        [
           "ab",
           "push",
           {
@@ -5439,6 +5409,16 @@ describe('joins with compound join keys', () => {
               "id": 2,
             },
             "type": "add",
+          },
+        ],
+        [
+          "b",
+          "fetch",
+          {
+            "constraint": {
+              "b1": 8,
+              "b2": 7,
+            },
           },
         ],
         [
@@ -5616,26 +5596,6 @@ describe('joins with compound join keys', () => {
           },
         ],
         [
-          "b",
-          "cleanup",
-          {
-            "constraint": {
-              "b1": 2,
-              "b2": 1,
-            },
-          },
-        ],
-        [
-          "b",
-          "fetch",
-          {
-            "constraint": {
-              "b1": 2,
-              "b2": 1,
-            },
-          },
-        ],
-        [
           "ab",
           "push",
           {
@@ -5680,7 +5640,6 @@ describe('joins with compound join keys', () => {
     expect(actualStorage).toMatchInlineSnapshot(`
       {
         "ab": {
-          ""pKeySet",1,2,0,": true,
           ""pKeySet",4,5,1,": true,
         },
       }

--- a/packages/zql/src/ivm/join.sibling.test.ts
+++ b/packages/zql/src/ivm/join.sibling.test.ts
@@ -86,15 +86,6 @@ suite('sibling relationships tests with issues, comments, and owners', () => {
           },
         ],
         [
-          "2",
-          "fetch",
-          {
-            "constraint": {
-              "id": "o2",
-            },
-          },
-        ],
-        [
           "1",
           "fetchCount",
           {
@@ -103,6 +94,15 @@ suite('sibling relationships tests with issues, comments, and owners', () => {
             },
           },
           0,
+        ],
+        [
+          "2",
+          "fetch",
+          {
+            "constraint": {
+              "id": "o2",
+            },
+          },
         ],
         [
           "2",
@@ -192,15 +192,6 @@ suite('sibling relationships tests with issues, comments, and owners', () => {
           {
             "constraint": {
               "ownerId": "o2",
-            },
-          },
-        ],
-        [
-          "1",
-          "fetch",
-          {
-            "constraint": {
-              "issueId": "i2",
             },
           },
         ],
@@ -379,15 +370,6 @@ suite('sibling relationships tests with issues, comments, and owners', () => {
           {
             "constraint": {
               "ownerId": "o2",
-            },
-          },
-        ],
-        [
-          "1",
-          "fetch",
-          {
-            "constraint": {
-              "issueId": "i2",
             },
           },
         ],
@@ -599,52 +581,14 @@ suite('sibling relationships tests with issues, comments, and owners', () => {
               "type": "edit",
             },
           ],
-          [
-            "1",
-            "cleanup",
-            {
-              "constraint": {
-                "issueId": "i1",
-              },
-            },
-          ],
-          [
-            "1",
-            "fetch",
-            {
-              "constraint": {
-                "issueId": "i1",
-              },
-            },
-          ],
-          [
-            "2",
-            "cleanup",
-            {
-              "constraint": {
-                "id": "o1",
-              },
-            },
-          ],
-          [
-            "2",
-            "fetch",
-            {
-              "constraint": {
-                "id": "o1",
-              },
-            },
-          ],
         ]
       `);
       expect(storage).toMatchInlineSnapshot(`
         [
           {
-            ""pKeySet","i1","i1",": true,
             ""pKeySet","i2","i2",": true,
           },
           {
-            ""pKeySet","o1","i1",": true,
             ""pKeySet","o2","i2",": true,
           },
         ]
@@ -801,15 +745,6 @@ suite('sibling relationships tests with issues, comments, and owners', () => {
             {
               "constraint": {
                 "ownerId": "o2",
-              },
-            },
-          ],
-          [
-            "1",
-            "fetch",
-            {
-              "constraint": {
-                "issueId": "i2",
               },
             },
           ],

--- a/packages/zql/src/ivm/join.sibling.test.ts
+++ b/packages/zql/src/ivm/join.sibling.test.ts
@@ -548,7 +548,7 @@ suite('sibling relationships tests with issues, comments, and owners', () => {
       ],
     } as const;
 
-    test.only('edit issue', () => {
+    test('edit issue', () => {
       const {log, storage, output} = pushSiblingTest({
         ...base,
         pushes: [
@@ -867,12 +867,6 @@ function pushSiblingTest(t: PushTestSibling): PushTestSiblingResults {
 
   const c = new Catch(finalJoin.join);
   c.fetch();
-
-  const s: Record<string, JSONValue>[] = [];
-  for (const j of joins.values()) {
-    s.push(j.storage.cloneData());
-  }
-  console.log(JSON.stringify(s));
 
   log.length = 0;
 

--- a/packages/zql/src/ivm/join.sibling.test.ts
+++ b/packages/zql/src/ivm/join.sibling.test.ts
@@ -548,7 +548,7 @@ suite('sibling relationships tests with issues, comments, and owners', () => {
       ],
     } as const;
 
-    test('edit issue', () => {
+    test.only('edit issue', () => {
       const {log, storage, output} = pushSiblingTest({
         ...base,
         pushes: [
@@ -586,9 +586,11 @@ suite('sibling relationships tests with issues, comments, and owners', () => {
       expect(storage).toMatchInlineSnapshot(`
         [
           {
+            ""pKeySet","i1","i1",": true,
             ""pKeySet","i2","i2",": true,
           },
           {
+            ""pKeySet","o1","i1",": true,
             ""pKeySet","o2","i2",": true,
           },
         ]
@@ -865,6 +867,12 @@ function pushSiblingTest(t: PushTestSibling): PushTestSiblingResults {
 
   const c = new Catch(finalJoin.join);
   c.fetch();
+
+  const s: Record<string, JSONValue>[] = [];
+  for (const j of joins.values()) {
+    s.push(j.storage.cloneData());
+  }
+  console.log(JSON.stringify(s));
 
   log.length = 0;
 

--- a/packages/zql/src/ivm/join.ts
+++ b/packages/zql/src/ivm/join.ts
@@ -207,7 +207,11 @@ export class Join implements Input {
       for (const parentNode of parentNodes) {
         const childChange: ChildChange = {
           type: 'child',
-          node: parentNode,
+          node: this.#processParentNode(
+            parentNode.row,
+            parentNode.relationships,
+            'fetch',
+          ),
           child: {
             relationshipName: this.#relationshipName,
             change,

--- a/packages/zql/src/ivm/join.ts
+++ b/packages/zql/src/ivm/join.ts
@@ -263,29 +263,29 @@ export class Join implements Input {
     mode: ProcessParentMode,
   ): Node {
     let method: ProcessParentMode = mode;
-    if (mode === 'cleanup') {
-      this.#storage.del(
-        makeStorageKey(
-          this.#parentKey,
-          this.#parent.getSchema().primaryKey,
-          parentNodeRow,
-        ),
-      );
-      const empty =
-        [
-          ...take(
-            this.#storage.scan({
-              prefix: makeStorageKeyPrefix(parentNodeRow, this.#parentKey),
-            }),
-            1,
-          ),
-        ].length === 0;
-      method = empty ? 'cleanup' : 'fetch';
-    }
-
     let storageUpdated = false;
     const childStream = () => {
       if (!storageUpdated) {
+        if (mode === 'cleanup') {
+          this.#storage.del(
+            makeStorageKey(
+              this.#parentKey,
+              this.#parent.getSchema().primaryKey,
+              parentNodeRow,
+            ),
+          );
+          const empty =
+            [
+              ...take(
+                this.#storage.scan({
+                  prefix: makeStorageKeyPrefix(parentNodeRow, this.#parentKey),
+                }),
+                1,
+              ),
+            ].length === 0;
+          method = empty ? 'cleanup' : 'fetch';
+        }
+
         storageUpdated = true;
         // Defer the work to update storage until the child stream
         // is actually accessed

--- a/packages/zql/src/ivm/memory-source.test.ts
+++ b/packages/zql/src/ivm/memory-source.test.ts
@@ -129,19 +129,35 @@ test('push edit change', () => {
     oldRow: {a: 'a', b: 'b', c: 'c'},
     row: {a: 'a', b: 'b2', c: 'c2'},
   });
-  expect(c.pushes).toEqual([
-    {
-      type: 'edit',
-      row: {a: 'a', b: 'b2', c: 'c2'},
-      oldRow: {a: 'a', b: 'b', c: 'c'},
-    },
-  ]);
-  expect(c.fetch()).toEqual([
-    {
-      row: {a: 'a', b: 'b2', c: 'c2'},
-      relationships: {},
-    },
-  ]);
+  expect(c.pushes).toMatchInlineSnapshot(`
+    [
+      {
+        "oldRow": {
+          "a": "a",
+          "b": "b",
+          "c": "c",
+        },
+        "row": {
+          "a": "a",
+          "b": "b2",
+          "c": "c2",
+        },
+        "type": "edit",
+      },
+    ]
+  `);
+  expect(c.fetch()).toMatchInlineSnapshot(`
+    [
+      {
+        "relationships": {},
+        "row": {
+          "a": "a",
+          "b": "b2",
+          "c": "c2",
+        },
+      },
+    ]
+  `);
 
   conn.destroy();
 });
@@ -178,12 +194,18 @@ test('fetch during push edit change', () => {
     oldRow: {a: 'a', b: 'b', c: 'c'},
     row: {a: 'a', b: 'b2', c: 'c2'},
   });
-  expect(fetchDuringPush).toEqual([
-    {
-      row: {a: 'a', b: 'b2', c: 'c2'},
-      relationships: {},
-    },
-  ]);
+  expect(fetchDuringPush).toMatchInlineSnapshot(`
+    [
+      {
+        "relationships": {},
+        "row": {
+          "a": "a",
+          "b": "b2",
+          "c": "c2",
+        },
+      },
+    ]
+  `);
 });
 
 describe('generateWithOverlayInner', () => {

--- a/packages/zql/src/ivm/skip.ts
+++ b/packages/zql/src/ivm/skip.ts
@@ -88,8 +88,7 @@ export class Skip implements Operator {
 
     change satisfies AddChange | RemoveChange | ChildChange;
 
-    const changeRow = change.type === 'child' ? change.row : change.node.row;
-    if (shouldBePresent(changeRow)) {
+    if (shouldBePresent(change.node.row)) {
       this.#output.push(change);
     }
   }

--- a/packages/zql/src/ivm/snitch.ts
+++ b/packages/zql/src/ivm/snitch.ts
@@ -97,7 +97,7 @@ function toChangeRecord(change: Change): ChangeRecord {
     case 'child':
       return {
         type: 'child',
-        row: change.row,
+        row: change.node.row,
         child: toChangeRecord(change.child.change),
       };
     default:

--- a/packages/zql/src/ivm/source.test.ts
+++ b/packages/zql/src/ivm/source.test.ts
@@ -2557,26 +2557,86 @@ test('json is a valid type to read and write to/from a source', () => {
     row: {a: 4, j: {foo: 'bar'}},
   });
   source.push({type: 'remove', row: {a: 5, j: {baz: 'qux'}}});
-  expect(out.pushes).toEqual([
-    {
-      type: 'edit',
-      oldRow: {a: 4, j: {foo: 'foo'}},
-      row: {a: 4, j: {foo: 'bar'}},
-    },
-    {
-      type: 'remove',
-      node: {relationships: {}, row: {a: 5, j: {baz: 'qux'}}},
-    },
-  ]);
-  expect(out.fetch({})).toEqual(
-    asNodes([
-      {a: 1, j: {foo: 'bar'}},
-      {a: 2, j: {baz: 'qux'}},
-      {a: 3, j: {foo: 'foo'}},
-      {a: 4, j: {foo: 'bar'}},
-      {a: 6, j: {foo: 'bar'}},
-    ]),
-  );
+  expect(out.pushes).toMatchInlineSnapshot(`
+    [
+      {
+        "oldRow": {
+          "a": 4,
+          "j": {
+            "foo": "foo",
+          },
+        },
+        "row": {
+          "a": 4,
+          "j": {
+            "foo": "bar",
+          },
+        },
+        "type": "edit",
+      },
+      {
+        "node": {
+          "relationships": {},
+          "row": {
+            "a": 5,
+            "j": {
+              "baz": "qux",
+            },
+          },
+        },
+        "type": "remove",
+      },
+    ]
+  `);
+  expect(out.fetch({})).toMatchInlineSnapshot(`
+    [
+      {
+        "relationships": {},
+        "row": {
+          "a": 1,
+          "j": {
+            "foo": "bar",
+          },
+        },
+      },
+      {
+        "relationships": {},
+        "row": {
+          "a": 2,
+          "j": {
+            "baz": "qux",
+          },
+        },
+      },
+      {
+        "relationships": {},
+        "row": {
+          "a": 3,
+          "j": {
+            "foo": "foo",
+          },
+        },
+      },
+      {
+        "relationships": {},
+        "row": {
+          "a": 4,
+          "j": {
+            "foo": "bar",
+          },
+        },
+      },
+      {
+        "relationships": {},
+        "row": {
+          "a": 6,
+          "j": {
+            "foo": "bar",
+          },
+        },
+      },
+    ]
+  `);
 });
 
 test('IS and IS NOT comparisons against null', () => {
@@ -2609,15 +2669,17 @@ test('IS and IS NOT comparisons against null', () => {
       },
     }),
   );
-  expect(out.fetch({})).toEqual([
-    {
-      relationships: {},
-      row: {
-        a: 3,
-        s: null,
+  expect(out.fetch({})).toMatchInlineSnapshot(`
+    [
+      {
+        "relationships": {},
+        "row": {
+          "a": 3,
+          "s": null,
+        },
       },
-    },
-  ]);
+    ]
+  `);
 
   // nothing `=` null
   out = new Catch(
@@ -2668,22 +2730,24 @@ test('IS and IS NOT comparisons against null', () => {
       },
     }),
   );
-  expect(out.fetch({})).toEqual([
-    {
-      relationships: {},
-      row: {
-        a: 1,
-        s: 'foo',
+  expect(out.fetch({})).toMatchInlineSnapshot(`
+    [
+      {
+        "relationships": {},
+        "row": {
+          "a": 1,
+          "s": "foo",
+        },
       },
-    },
-    {
-      relationships: {},
-      row: {
-        a: 2,
-        s: 'bar',
+      {
+        "relationships": {},
+        "row": {
+          "a": 2,
+          "s": "bar",
+        },
       },
-    },
-  ]);
+    ]
+  `);
 });
 
 test('constant/literal expression', () => {

--- a/packages/zql/src/ivm/source.test.ts
+++ b/packages/zql/src/ivm/source.test.ts
@@ -5,9 +5,8 @@ import type {
 } from '../../../zero-protocol/src/ast.ts';
 import type {Row} from '../../../zero-protocol/src/data.ts';
 import type {SchemaValue} from '../../../zero-schema/src/table-schema.ts';
-import {Catch, expandNode} from './catch.ts';
+import {Catch, expandNode, type CaughtNode} from './catch.ts';
 import type {Constraint} from './constraint.ts';
-import type {Node} from './data.ts';
 import type {FetchRequest, Input, Output, Start} from './operator.ts';
 import type {SourceChange} from './source.ts';
 import {createSource} from './test/source-factory.ts';
@@ -41,7 +40,7 @@ function asChanges(sc: SourceChange[]) {
 
 class OverlaySpy implements Output {
   #input: Input;
-  fetches: Node[][] = [];
+  fetches: CaughtNode[][] = [];
 
   onPush = () => {};
 

--- a/packages/zql/src/ivm/take.fetch.test.ts
+++ b/packages/zql/src/ivm/take.fetch.test.ts
@@ -5,7 +5,7 @@ import type {Ordering} from '../../../zero-protocol/src/ast.ts';
 import type {Row, Value} from '../../../zero-protocol/src/data.ts';
 import type {PrimaryKey} from '../../../zero-protocol/src/primary-key.ts';
 import type {SchemaValue} from '../../../zero-schema/src/table-schema.ts';
-import {Catch} from './catch.ts';
+import {Catch, type CaughtNode} from './catch.ts';
 import type {Node} from './data.ts';
 import {MemoryStorage} from './memory-storage.ts';
 import type {FetchRequest} from './operator.ts';
@@ -1884,11 +1884,11 @@ type PartitionTestResults = {
     cleanup: SnitchMessage[];
   };
   storage: Record<string, JSONValue>;
-  hydrate: Node[];
+  hydrate: CaughtNode[];
 };
 
 type CleanupOnlyPartitionTestResults = {
   messages: SnitchMessage[];
   storage: Record<string, JSONValue>;
-  nodes: Node[];
+  nodes: CaughtNode[];
 };

--- a/packages/zql/src/ivm/take.push-child.test.ts
+++ b/packages/zql/src/ivm/take.push-child.test.ts
@@ -152,30 +152,30 @@ test('child change, parent is within bound', () => {
     `);
 
   expect(pushes).toMatchInlineSnapshot(`
-        [
-          {
-            "child": {
-              "change": {
-                "node": {
-                  "relationships": {},
-                  "row": {
-                    "id": "c3",
-                    "issueID": "i2",
-                    "text": "i2 c3 text",
-                  },
-                },
-                "type": "add",
+    [
+      {
+        "child": {
+          "change": {
+            "node": {
+              "relationships": {},
+              "row": {
+                "id": "c3",
+                "issueID": "i2",
+                "text": "i2 c3 text",
               },
-              "relationshipName": "comments",
             },
-            "row": {
-              "id": "i2",
-              "text": "second issue",
-            },
-            "type": "child",
+            "type": "add",
           },
-        ]
-    `);
+          "relationshipName": "comments",
+        },
+        "row": {
+          "id": "i2",
+          "text": "second issue",
+        },
+        "type": "child",
+      },
+    ]
+  `);
 
   expect(actualStorage['take']).toMatchInlineSnapshot(`
         {

--- a/packages/zql/src/ivm/take.ts
+++ b/packages/zql/src/ivm/take.ts
@@ -4,12 +4,7 @@ import {must} from '../../../shared/src/must.ts';
 import type {Row, Value} from '../../../zero-protocol/src/data.ts';
 import type {PrimaryKey} from '../../../zero-protocol/src/primary-key.ts';
 import {assertOrderingIncludesPK} from '../builder/builder.ts';
-import {
-  rowForChange,
-  type Change,
-  type EditChange,
-  type RemoveChange,
-} from './change.ts';
+import {type Change, type EditChange, type RemoveChange} from './change.ts';
 import type {Constraint} from './constraint.ts';
 import {compareValues, type Comparator, type Node} from './data.ts';
 import {
@@ -233,7 +228,7 @@ export class Take implements Operator {
     }
 
     const {takeState, takeStateKey, maxBound, constraint} =
-      this.#getStateAndConstraint(rowForChange(change));
+      this.#getStateAndConstraint(change.node.row);
     if (!takeState) {
       return;
     }
@@ -377,7 +372,10 @@ export class Take implements Operator {
     } else if (change.type === 'child') {
       // A 'child' change should be pushed to output if its row
       // is <= bound.
-      if (takeState.bound && compareRows(change.row, takeState.bound) <= 0) {
+      if (
+        takeState.bound &&
+        compareRows(change.node.row, takeState.bound) <= 0
+      ) {
         this.#output.push(change);
       }
     }

--- a/packages/zql/src/ivm/view-apply-change.ts
+++ b/packages/zql/src/ivm/view-apply-change.ts
@@ -8,7 +8,7 @@ import {
 import {must} from '../../../shared/src/must.ts';
 import type {Row} from '../../../zero-protocol/src/data.ts';
 import type {Change} from './change.ts';
-import type {Comparator, Node} from './data.ts';
+import {drainStreams, type Comparator} from './data.ts';
 import type {SourceSchema} from './schema.ts';
 import type {Entry, EntryList, Format} from './view.ts';
 
@@ -246,14 +246,6 @@ function makeEntryPreserveRelationships(
     result[relationship] = entry[relationship];
   }
   return result;
-}
-
-function drainStreams(node: Node) {
-  for (const stream of Object.values(node.relationships)) {
-    for (const node of stream()) {
-      drainStreams(node);
-    }
-  }
 }
 
 function getChildEntryList(

--- a/packages/zql/src/ivm/view-apply-change.ts
+++ b/packages/zql/src/ivm/view-apply-change.ts
@@ -27,7 +27,7 @@ export function applyChange(
           change.node.relationships,
         )) {
           const childSchema = must(schema.relationships[relationship]);
-          for (const node of children) {
+          for (const node of children()) {
             applyChange(
               parentEntry,
               {type: change.type, node},
@@ -94,7 +94,7 @@ export function applyChange(
 
         const newView = childFormat.singular ? undefined : ([] as EntryList);
         newEntry[relationship] = newView;
-        for (const node of children) {
+        for (const node of children()) {
           applyChange(
             newEntry,
             {type: 'add', node},
@@ -132,7 +132,11 @@ export function applyChange(
         existing = parentEntry[relationship];
       } else {
         const view = getChildEntryList(parentEntry, relationship);
-        const {pos, found} = binarySearch(view, change.row, schema.compareRows);
+        const {pos, found} = binarySearch(
+          view,
+          change.node.row,
+          schema.compareRows,
+        );
         assert(found, 'node does not exist');
         existing = view[pos];
       }
@@ -246,7 +250,7 @@ function makeEntryPreserveRelationships(
 
 function drainStreams(node: Node) {
   for (const stream of Object.values(node.relationships)) {
-    for (const node of stream) {
+    for (const node of stream()) {
       drainStreams(node);
     }
   }


### PR DESCRIPTION
The `Exist` operators `#fetchNodeForRow` is quite expensive and is a work around for the fact that `Node`'s relationships can only be consumed a single time.  In order to read the relevant relationship, `Exist` has to fetch from source the parent `Node`.   This fetch is pure overhead, we are fetching a row we already have.

This change updates `Node`'s relationships to be callable, so that they can be consumed multiple times.

`Node`'s type changes from 

```
export type Node = {
  row: Row;
  relationships: Record<string, Stream<Node>>;
};
```

to 

```
export type Node = {
  row: Row;
  relationships: Record<string, () => Stream<Node>>;
};
```

This change also updates `ChildChange` to have a `node: Node` rather than a `row: Row` so that the relationships needed by `Exist` are also available on `ChildChange`.  Now all `Change` types use `Node` rather than `Row`.

Finally this addresses an issue with cleanup where Node's filtered by `Exists` or `Filter` were not being drained (as they never reach view-apply-change which does the draining).  Added draining to cleanup in `Exists` and `Filter` for `Node`s not yielded to downstream.