### PR TITLE
chore(zql): allow the debug script to run query text in addition to asts

### DIFF
--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -391,6 +391,12 @@ const debugOptions = {
       type: v.string().optional(),
       desc: ['Hash of the query to fetch the AST for.'],
     },
+    query: {
+      type: v.string().optional(),
+      desc: [
+        `Query to be timed in the form of: z.query.table.where(...).related(...).etc`,
+      ],
+    },
   },
 };
 


### PR DESCRIPTION
Running ASTs was getting horribly annoying.

```sh
npm run run-query -- --debug-query 'z.query.issue.whereExists("comments")'

> zbugs@0.0.0 run-query
> npm run zero-build-schema && tsx ../../packages/zero-cache/src/scripts/run-query.ts --debug-query z.query.issue.whereExists("comments")


> zbugs@0.0.0 zero-build-schema
> tsx ../../packages/zero-schema/src/build-schema.ts

issue VENDED:  [
  [
    'SELECT "id","shortID","title","open","modified","created","creatorID","assigneeID","description","visibility" FROM "issue" ORDER BY "id" asc',
    10523
  ],
  [
    'SELECT "id","shortID","title","open","modified","created","creatorID","assigneeID","description","visibility" FROM "issue" WHERE (("id" > ?) OR ("id" = ?)) ORDER BY "id" asc',
    10523
  ]
]
comment VENDED:  [
  [
    'SELECT "id","issueID","created","body","creatorID" FROM "comment" WHERE "issueID" = ? ORDER BY "id" asc',
    637
  ]
]
ROWS CONSIDERED: 21683
TIME: 2475.68 ms
```

```sh
npm run run-query -- --debug-query 'z.query.issue.related("comments")'

> zbugs@0.0.0 run-query
> npm run zero-build-schema && tsx ../../packages/zero-cache/src/scripts/run-query.ts --debug-query z.query.issue.related("comments")


> zbugs@0.0.0 zero-build-schema
> tsx ../../packages/zero-schema/src/build-schema.ts

issue VENDED:  [
  [
    'SELECT "id","shortID","title","open","modified","created","creatorID","assigneeID","description","visibility" FROM "issue" ORDER BY "id" asc',
    10523
  ]
]
comment VENDED:  [
  [
    'SELECT "id","issueID","created","body","creatorID" FROM "comment" WHERE "issueID" = ? ORDER BY "id" asc',
    929
  ]
]
ROWS CONSIDERED: 11452
TIME: 226.87 ms
```