### PR TITLE
feat(zero-cache): back-pressure aware handling of websockets

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
@@ -5,7 +5,7 @@ import WebSocket from 'ws';
 import {type Worker} from '../../types/processes.ts';
 import {streamIn, streamOut, type Source} from '../../types/streams.ts';
 import {URLParams} from '../../types/url-params.ts';
-import {closeWithProtocolError} from '../../types/ws.ts';
+import {closeWithError, PROTOCOL_ERROR} from '../../types/ws.ts';
 import {installWebSocketReceiver} from '../dispatcher/websocket-handoff.ts';
 import {HttpService, type Options} from '../http-service.ts';
 import {
@@ -53,7 +53,7 @@ export class ChangeStreamerHttpServer extends HttpService {
     try {
       ctx = getSubscriberContext(req);
     } catch (err) {
-      closeWithProtocolError(this._lc, ws, err);
+      closeWithError(this._lc, ws, err, PROTOCOL_ERROR);
       return;
     }
     await this.#handleSubscription(ws, ctx);

--- a/packages/zero-cache/src/services/dispatcher/websocket-handoff.ts
+++ b/packages/zero-cache/src/services/dispatcher/websocket-handoff.ts
@@ -12,7 +12,7 @@ import {
   type Sender,
   type Worker,
 } from '../../types/processes.ts';
-import {closeWithProtocolError} from '../../types/ws.ts';
+import {closeWithError, PROTOCOL_ERROR} from '../../types/ws.ts';
 
 export type WebSocketHandoff<P> = (message: IncomingMessageSubset) => {
   payload: P;
@@ -56,7 +56,7 @@ export function installWebSocketHandoff<P>(
       // (at least from Chrome) and doesn't report any meaningful error in the browser.
       // Instead, finish the upgrade to a websocket and then close it with an error.
       wss.handleUpgrade(message as IncomingMessage, socket, head, ws =>
-        closeWithProtocolError(lc, ws, error),
+        closeWithError(lc, ws, error, PROTOCOL_ERROR),
       );
     }
   };

--- a/packages/zero-cache/src/types/streams.ts
+++ b/packages/zero-cache/src/types/streams.ts
@@ -89,9 +89,9 @@ export function stream<In extends JSONValue, Out extends JSONValue>(
 
   // Outgoing transform.
   async function sendOut() {
-    for await (const up of outstream) {
+    for await (const msg of outstream) {
       // Upstream backpressure is signaled by the tcp socket buffer.
-      if (!duplex.write(BigIntJSON.stringify(up))) {
+      if (!duplex.write(BigIntJSON.stringify(msg))) {
         const {promise: canWriteMore, resolve: drained} = resolver();
 
         const start = Date.now();

--- a/packages/zero-cache/src/types/streams.ts
+++ b/packages/zero-cache/src/types/streams.ts
@@ -1,10 +1,18 @@
 import type {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
-import type {CloseEvent, ErrorEvent, MessageEvent, WebSocket} from 'ws';
+import {pipeline, Writable, type DuplexOptions} from 'node:stream';
+import {
+  createWebSocketStream,
+  type CloseEvent,
+  type ErrorEvent,
+  type MessageEvent,
+  type WebSocket,
+} from 'ws';
 import {Queue} from '../../../shared/src/queue.ts';
 import * as v from '../../../shared/src/valita.ts';
 import {BigIntJSON, type JSONValue} from './bigint-json.ts';
-import {Subscription} from './subscription.ts';
+import {Subscription, type Options} from './subscription.ts';
+import {closeWithError} from './ws.ts';
 
 export type Source<T> = AsyncIterable<T> & {
   /**
@@ -31,6 +39,120 @@ export type Source<T> = AsyncIterable<T> & {
 export type Sink<T> = {
   push(message: T): void;
 };
+
+/**
+ * Back-pressure-aware transformation of a WebSocket into
+ * upstream and downstream {@link Subscription} objects.
+ */
+// TODO: Change {@link streamIn} and {@link streamOut} to use this
+//       under the covers so that internal communication is also
+//       responsive to backpressure.
+export function stream<In extends JSONValue, Out extends JSONValue>(
+  lc: LogContext,
+  ws: WebSocket,
+  inSchema: v.Type<In>,
+  outOptions: Options<Out> = {},
+  inOptions: Options<In> = {},
+  streamOptions: DuplexOptions = {},
+): {outstream: Sink<Out>; instream: Source<In>} {
+  const endpoint = ws.url ?? 'client';
+  function close(err?: unknown) {
+    if (ws.readyState !== ws.CLOSED && ws.readyState !== ws.CLOSING) {
+      if (err) {
+        closeWithError(lc, ws, err);
+      } else {
+        lc.info?.(`closing conneciton to ${endpoint}`);
+        ws.close();
+      }
+    }
+  }
+
+  const instream = Subscription.create<In>({
+    ...inOptions,
+    cleanup: (unconsumed, err) => {
+      inOptions.cleanup?.(unconsumed, err);
+      close(err);
+    },
+  });
+  const outstream = Subscription.create<Out>({
+    ...outOptions,
+    cleanup: (unconsumed, err) => {
+      outOptions.cleanup?.(unconsumed, err);
+      close(err);
+    },
+  });
+
+  const duplex = createWebSocketStream(ws, {
+    ...streamOptions,
+    decodeStrings: false,
+  });
+
+  // Outgoing transform.
+  async function sendOut() {
+    for await (const up of outstream) {
+      // Upstream backpressure is signaled by the tcp socket buffer.
+      if (!duplex.write(BigIntJSON.stringify(up))) {
+        const {promise: canWriteMore, resolve: drained} = resolver();
+
+        const start = Date.now();
+        duplex.once('drain', drained);
+        await canWriteMore;
+        lc.debug?.(
+          `drained messages to ${endpoint} in ${Date.now() - start} ms`,
+        );
+      }
+    }
+  }
+
+  if (ws.readyState === ws.CONNECTING) {
+    ws.on('open', () => {
+      lc.info?.(`connected to ${endpoint}`);
+      void sendOut();
+    });
+  } else {
+    void sendOut();
+  }
+
+  // Incoming transform.
+  pipeline(
+    duplex,
+    new Writable({
+      decodeStrings: false,
+      write: (chunk, _encoding, callback) => {
+        let msg: In;
+        try {
+          const json = BigIntJSON.parse(chunk.toString());
+          msg = v.parse(json, inSchema, 'passthrough');
+        } catch (err) {
+          callback(ensureError(err));
+          return;
+        }
+        const {result} = instream.push(msg);
+        // Inbound backpressure is exerted by unconsumed
+        // messages in the subscription.
+        void result.then(
+          () => callback(),
+          err => callback(err),
+        );
+      },
+      destroy: (err, callback) => {
+        instream.fail(ensureError(err));
+        callback();
+      },
+      final: callback => {
+        instream.cancel();
+        callback();
+      },
+    }),
+    close,
+  );
+
+  return {outstream, instream};
+}
+
+function ensureError(err: unknown) {
+  return err instanceof Error ? err : new Error(String(err));
+}
 
 const ackSchema = v.object({ack: v.number()});
 

--- a/packages/zero-cache/src/types/subscription.ts
+++ b/packages/zero-cache/src/types/subscription.ts
@@ -274,7 +274,7 @@ export class Subscription<T, M = T> implements Source<T>, Sink<M> {
   }
 }
 
-type Options<M> = {
+export type Options<M> = {
   /**
    * Coalesces messages waiting to be consumed. This is useful for "watermark" type
    * subscriptions in which the consumer is only interested in the cumulative state

--- a/packages/zero-cache/src/types/ws.test.ts
+++ b/packages/zero-cache/src/types/ws.test.ts
@@ -3,7 +3,7 @@ import {afterAll, beforeAll, describe, expect, test} from 'vitest';
 import WebSocket, {WebSocketServer} from 'ws';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
 import {randInt} from '../../../shared/src/rand.ts';
-import {closeWithProtocolError} from './ws.ts';
+import {closeWithError, PROTOCOL_ERROR} from './ws.ts';
 
 describe('types/ws', () => {
   let port: number;
@@ -20,10 +20,11 @@ describe('types/ws', () => {
 
   test('close with protocol error', async () => {
     wss.on('connection', ws =>
-      closeWithProtocolError(
+      closeWithError(
         createSilentLogContext(),
         ws,
         'こんにちは' + 'あ'.repeat(150),
+        PROTOCOL_ERROR,
       ),
     );
 

--- a/packages/zero-cache/src/types/ws.ts
+++ b/packages/zero-cache/src/types/ws.ts
@@ -1,14 +1,22 @@
 import type {LogContext} from '@rocicorp/logger';
 import type {WebSocket} from 'ws';
 
-export function closeWithProtocolError(
+// https://github.com/Luka967/websocket-close-codes
+export const PROTOCOL_ERROR = 1002;
+export const INTERNAL_ERROR = 1011;
+
+export type ErrorCode = typeof PROTOCOL_ERROR | typeof INTERNAL_ERROR;
+
+export function closeWithError(
   lc: LogContext,
   ws: WebSocket,
   err: unknown,
+  code: ErrorCode = INTERNAL_ERROR,
 ) {
+  const endpoint = ws.url ?? 'client';
   const errMsg = String(err);
-  lc.warn?.('closing with protocol error', errMsg);
-  ws.close(1002 /* "protocol error" */, truncate(errMsg));
+  lc.warn?.(`closing connection to ${endpoint} with error`, errMsg);
+  ws.close(code, truncate(errMsg));
 }
 
 // close messages must be less than or equal to 123 bytes:


### PR DESCRIPTION
Transforms the incoming and outgoing streams of a WebSocket into Subscription objects with proper back-pressure signaled backoff. 

This will be used for communicating with the custom Change Source endpoint. (@cbnsndwch)

In the future, we should also change our pre-existing transformation logic (i.e. `streamIn()` and `streamOut()` used for internal websocket communication) to use this under the covers in order to properly handle back pressure there as well.