### PR TITLE
feat(zero-cache): support for custom backends (experimental)

### DIFF
--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -134,6 +134,17 @@ export const zeroOptions = {
       ],
     },
 
+    type: {
+      type: v.union(v.literal('pg'), v.literal('custom')).default('pg'),
+      desc: [
+        `The meaning of the {bold upstream-db} depends on the upstream type:`,
+        `* {bold pg}: The connection database string, e.g. "postgres://..."`,
+        `* {bold custom}: The base URI of the change source "endpoint, e.g.`,
+        `          "https://my-change-source.dev/changes/v0/stream?apiKey=..."`,
+      ],
+      hidden: true, // TODO: Unhide when ready to officially support.
+    },
+
     maxConns: {
       type: v.number().default(20),
       desc: [

--- a/packages/zero-cache/src/integration/integration.pg-test.ts
+++ b/packages/zero-cache/src/integration/integration.pg-test.ts
@@ -1,5 +1,7 @@
+import websocket from '@fastify/websocket';
 import type {LogLevel} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
+import Fastify, {type FastifyInstance, type FastifyRequest} from 'fastify';
 import {copyFileSync} from 'fs';
 import {
   afterAll,
@@ -12,6 +14,7 @@ import {
 } from 'vitest';
 import WebSocket from 'ws';
 import {assert} from '../../../shared/src/asserts.ts';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
 import {Queue} from '../../../shared/src/queue.ts';
 import {randInt} from '../../../shared/src/rand.ts';
 import type {AST} from '../../../zero-protocol/src/ast.ts';
@@ -19,52 +22,21 @@ import type {ChangeDesiredQueriesMessage} from '../../../zero-protocol/src/chang
 import type {InitConnectionMessage} from '../../../zero-protocol/src/connect.ts';
 import type {PokeStartMessage} from '../../../zero-protocol/src/poke.ts';
 import {PROTOCOL_VERSION} from '../../../zero-protocol/src/protocol-version.ts';
+import type {ChangeStreamMessage} from '../services/change-source/protocol/current/downstream.ts';
+import {
+  changeSourceUpstreamSchema,
+  type ChangeSourceUpstream,
+} from '../services/change-source/protocol/current/upstream.ts';
 import {getConnectionURI, testDBs} from '../test/db.ts';
 import {DbFile} from '../test/lite.ts';
 import type {PostgresDB} from '../types/pg.ts';
 import {childWorker, type Worker} from '../types/processes.ts';
+import {stream, type Sink} from '../types/streams.ts';
 
 // Adjust to debug.
 const LOG_LEVEL: LogLevel = 'error';
 
-describe('integration', {timeout: 30000}, () => {
-  let upDB: PostgresDB;
-  let cvrDB: PostgresDB;
-  let changeDB: PostgresDB;
-  let replicaDbFile: DbFile;
-  let replicaDbFile2: DbFile;
-  let env: Record<string, string>;
-  let port: number;
-  let port2: number;
-  let zeros: Worker[];
-  let zerosExited: Promise<number>[];
-
-  const SCHEMA = {
-    permissions: {},
-    schema: {
-      version: 1,
-      tables: {},
-    },
-  } as const;
-
-  const mockExit = vi
-    .spyOn(process, 'exit')
-    .mockImplementation(() => void 0 as never);
-
-  afterAll(() => {
-    mockExit.mockRestore();
-  });
-
-  beforeEach(async () => {
-    upDB = await testDBs.create('integration_test_upstream');
-    cvrDB = await testDBs.create('integration_test_cvr');
-    changeDB = await testDBs.create('integration_test_change');
-    replicaDbFile = new DbFile('integration_test_replica');
-    replicaDbFile2 = new DbFile('integration_test_replica2');
-    zeros = [];
-    zerosExited = [];
-
-    await upDB`
+const INITIAL_PG_SETUP = `
       CREATE TABLE foo(
         id TEXT PRIMARY KEY, 
         val TEXT,
@@ -86,7 +58,246 @@ describe('integration', {timeout: 30000}, () => {
 
       CREATE TABLE nopk(id TEXT NOT NULL, val TEXT);
       INSERT INTO nopk(id, val) VALUES ('foo', 'bar');
-    `.simple();
+`;
+
+// Keep this in sync with the INITIAL_PG_SETUP
+const INITIAL_CUSTOM_SETUP: ChangeStreamMessage[] = [
+  ['begin', {tag: 'begin'}, {commitWatermark: '101'}],
+  [
+    'data',
+    {
+      tag: 'create-table',
+      spec: {
+        schema: 'public',
+        name: 'foo',
+        columns: {
+          id: {pos: 0, dataType: 'text', notNull: true},
+          val: {pos: 1, dataType: 'text'},
+          b: {pos: 2, dataType: 'bool'},
+          j1: {pos: 3, dataType: 'json'},
+          j2: {pos: 4, dataType: 'jsonb'},
+          j3: {pos: 5, dataType: 'json'},
+          j4: {pos: 6, dataType: 'json'},
+        },
+      },
+    },
+  ],
+  [
+    'data',
+    {
+      tag: 'create-index',
+      spec: {
+        name: 'foo_key',
+        schema: 'public',
+        tableName: 'foo',
+        columns: {id: 'ASC'},
+        unique: true,
+      },
+    },
+  ],
+  [
+    'data',
+    {
+      tag: 'insert',
+      relation: {
+        tag: 'relation',
+        schema: 'public',
+        name: 'foo',
+        replicaIdentity: 'default',
+        keyColumns: ['id'],
+      },
+      new: {
+        id: 'bar',
+        val: 'baz',
+        b: true,
+        j1: {foo: 'bar'},
+        j2: true,
+        j3: 123,
+        j4: 'string',
+      },
+    },
+  ],
+  [
+    'data',
+    {
+      tag: 'create-table',
+      spec: {
+        schema: 'public',
+        name: 'nopk',
+        columns: {
+          id: {pos: 0, dataType: 'text', notNull: true},
+          val: {pos: 1, dataType: 'text'},
+        },
+      },
+    },
+  ],
+  [
+    'data',
+    {
+      tag: 'insert',
+      relation: {
+        tag: 'relation',
+        schema: 'public',
+        name: 'nopk',
+        replicaIdentity: 'default',
+        keyColumns: [],
+      },
+      new: {
+        id: 'foo',
+        val: 'bar',
+      },
+    },
+  ],
+  // Required internal tables
+  [
+    'data',
+    {
+      tag: 'create-table',
+      spec: {
+        schema: 'zero_0',
+        name: 'clients',
+        primaryKey: ['clientGroupID', 'clientID'],
+        columns: {
+          clientGroupID: {pos: 0, dataType: 'text', notNull: true},
+          clientID: {pos: 1, dataType: 'text', notNull: true},
+          lastMutationID: {pos: 2, dataType: 'bigint'},
+          userID: {pos: 3, dataType: 'text'},
+        },
+      },
+    },
+  ],
+  [
+    'data',
+    {
+      tag: 'create-index',
+      spec: {
+        name: 'zero_clients_key',
+        schema: 'zero_0',
+        tableName: 'clients',
+        columns: {
+          clientGroupID: 'ASC',
+          clientID: 'ASC',
+        },
+        unique: true,
+      },
+    },
+  ],
+  [
+    'data',
+    {
+      tag: 'create-table',
+      spec: {
+        schema: 'zero',
+        name: 'schemaVersions',
+        primaryKey: ['lock'],
+        columns: {
+          lock: {pos: 0, dataType: 'bool', notNull: true},
+          minSupportedVersion: {pos: 1, dataType: 'int'},
+          maxSupportedVersion: {pos: 2, dataType: 'int'},
+        },
+      },
+    },
+  ],
+  [
+    'data',
+    {
+      tag: 'create-index',
+      spec: {
+        name: 'zero_schemaVersions_key',
+        schema: 'zero',
+        tableName: 'schemaVersions',
+        columns: {lock: 'ASC'},
+        unique: true,
+      },
+    },
+  ],
+  [
+    'data',
+    {
+      tag: 'insert',
+      relation: {
+        tag: 'relation',
+        schema: 'zero',
+        name: 'schemaVersions',
+        replicaIdentity: 'default',
+        keyColumns: ['lock'],
+      },
+      new: {lock: true, minSupportedVersion: 1, maxSupportedVersion: 1},
+    },
+  ],
+  ['commit', {tag: 'commit'}, {watermark: '101'}],
+];
+
+describe('integration', {timeout: 30000}, () => {
+  let upDB: PostgresDB;
+  let cvrDB: PostgresDB;
+  let changeDB: PostgresDB;
+  let replicaDbFile: DbFile;
+  let replicaDbFile2: DbFile;
+  let env: Record<string, string>;
+  let port: number;
+  let port2: number;
+  let zeros: Worker[];
+  let zerosExited: Promise<number>[];
+  let customBackend: FastifyInstance;
+  let customChangeSourceURI: string;
+  let customDownstream: Promise<Sink<ChangeStreamMessage>>;
+
+  const SCHEMA = {
+    permissions: {},
+    schema: {
+      version: 1,
+      tables: {},
+    },
+  } as const;
+
+  const mockExit = vi
+    .spyOn(process, 'exit')
+    .mockImplementation(() => void 0 as never);
+
+  afterAll(() => {
+    mockExit.mockRestore();
+  });
+
+  const CHANGE_SOURCE_PATH = '/foo/changes/v0/stream';
+
+  beforeEach(async () => {
+    upDB = await testDBs.create('integration_test_upstream');
+    cvrDB = await testDBs.create('integration_test_cvr');
+    changeDB = await testDBs.create('integration_test_change');
+    replicaDbFile = new DbFile('integration_test_replica');
+    replicaDbFile2 = new DbFile('integration_test_replica2');
+    zeros = [];
+    zerosExited = [];
+
+    customBackend = Fastify();
+    await customBackend.register(websocket);
+
+    const {promise, resolve} = resolver<Sink<ChangeStreamMessage>>();
+    customDownstream = promise;
+    customBackend.get(
+      CHANGE_SOURCE_PATH,
+      {websocket: true},
+      (ws: WebSocket, req: FastifyRequest) => {
+        const {outstream} = stream<ChangeSourceUpstream, ChangeStreamMessage>(
+          createSilentLogContext(),
+          ws,
+          changeSourceUpstreamSchema,
+        );
+        if (req.url.includes('lastWatermark=')) {
+          resolve(outstream);
+        } else {
+          // Initial sync.
+          for (const change of INITIAL_CUSTOM_SETUP) {
+            outstream.push(change);
+          }
+        }
+      },
+    );
+    customChangeSourceURI =
+      (await customBackend.listen({port: 0})) + CHANGE_SOURCE_PATH;
+
+    await upDB.unsafe(INITIAL_PG_SETUP);
 
     port = randInt(5000, 16000);
     port2 = randInt(5000, 16000);
@@ -155,12 +366,20 @@ describe('integration', {timeout: 30000}, () => {
     }
   }, 30000);
 
+  async function streamCustomChanges(changes: ChangeStreamMessage[]) {
+    const sink = await customDownstream;
+    for (const change of changes) {
+      sink.push(change);
+    }
+  }
+
   const WATERMARK_REGEX = /[0-9a-z]{4,}/;
 
   test.each([
-    ['single-node standalone', () => [env]],
+    ['single-node standalone', 'pg', () => [env]],
     [
       'single-node multi-tenant direct-dispatch',
+      'pg',
       () => [
         {
           ['ZERO_PORT']: String(port - 3),
@@ -173,6 +392,7 @@ describe('integration', {timeout: 30000}, () => {
     ],
     [
       'single-node multi-tenant, double-dispatch',
+      'pg',
       () => [
         {
           ['ZERO_PORT']: String(port),
@@ -191,6 +411,7 @@ describe('integration', {timeout: 30000}, () => {
     ],
     [
       'multi-node standalone',
+      'pg',
       () => [
         // The replication-manager must be started first for initial-sync
         {
@@ -208,6 +429,7 @@ describe('integration', {timeout: 30000}, () => {
     ],
     [
       'multi-node multi-tenant',
+      'pg',
       () => [
         // The replication-manager must be started first for initial-sync
         {
@@ -246,246 +468,348 @@ describe('integration', {timeout: 30000}, () => {
         },
       ],
     ],
-  ] satisfies [string, () => Envs][])('%s', async (_name, makeEnvs) => {
-    await startZero(makeEnvs());
-
-    const downstream = new Queue<unknown>();
-    const ws = new WebSocket(
-      `ws://localhost:${port}/zero/sync/v${PROTOCOL_VERSION}/connect` +
-        `?clientGroupID=abc&clientID=def&wsid=123&schemaVersion=1&baseCookie=&ts=123456789&lmid=1`,
-      encodeURIComponent(btoa('{}')), // auth token
-    );
-    ws.on('message', data =>
-      downstream.enqueue(JSON.parse(data.toString('utf-8'))),
-    );
-    ws.on('open', () =>
-      ws.send(
-        JSON.stringify([
-          'initConnection',
-          {
-            desiredQueriesPatch: [
-              {op: 'put', hash: 'query-hash1', ast: FOO_QUERY},
-            ],
-          },
-        ] satisfies InitConnectionMessage),
-      ),
-    );
-
-    expect(await downstream.dequeue()).toMatchObject([
-      'connected',
-      {wsid: '123'},
-    ]);
-    expect(await downstream.dequeue()).toMatchObject([
-      'pokeStart',
-      {pokeID: '00'},
-    ]);
-    expect(await downstream.dequeue()).toMatchObject([
-      'pokeEnd',
-      {pokeID: '00'},
-    ]);
-    expect(await downstream.dequeue()).toMatchObject([
-      'pokeStart',
-      {pokeID: '00:01'},
-    ]);
-    expect(await downstream.dequeue()).toMatchObject([
-      'pokePart',
-      {
-        pokeID: '00:01',
-        clientsPatch: [{op: 'put', clientID: 'def'}],
-        desiredQueriesPatches: {
-          def: [{op: 'put', hash: 'query-hash1', ast: FOO_QUERY}],
+    [
+      'single-node standalone',
+      'custom',
+      () => [
+        {
+          ...env,
+          ['ZERO_UPSTREAM_DB']: customChangeSourceURI,
+          ['ZERO_UPSTREAM_TYPE']: 'custom',
         },
-      },
-    ]);
-    expect(await downstream.dequeue()).toMatchObject([
-      'pokeEnd',
-      {pokeID: '00:01'},
-    ]);
-    const contentPokeStart = (await downstream.dequeue()) as PokeStartMessage;
-    expect(contentPokeStart).toMatchObject([
-      'pokeStart',
-      {pokeID: /[0-9a-z]{2,}/},
-    ]);
-    const contentPokeID = contentPokeStart[1].pokeID;
-    expect(await downstream.dequeue()).toMatchObject([
-      'pokePart',
-      {
-        pokeID: contentPokeID,
-        gotQueriesPatch: [{op: 'put', hash: 'query-hash1', ast: FOO_QUERY}],
-        rowsPatch: [
-          {
-            op: 'put',
-            tableName: 'foo',
-            value: {
-              id: 'bar',
-              val: 'baz',
-              b: true,
-              j1: {foo: 'bar'},
-              j2: true,
-              j3: 123,
-              j4: 'string',
+      ],
+    ],
+  ] satisfies [string, 'pg' | 'custom', () => Envs][])(
+    '%s (%s)',
+    async (_name, backend, makeEnvs) => {
+      await startZero(makeEnvs());
+
+      const downstream = new Queue<unknown>();
+      const ws = new WebSocket(
+        `ws://localhost:${port}/zero/sync/v${PROTOCOL_VERSION}/connect` +
+          `?clientGroupID=abc&clientID=def&wsid=123&schemaVersion=1&baseCookie=&ts=123456789&lmid=1`,
+        encodeURIComponent(btoa('{}')), // auth token
+      );
+      ws.on('message', data =>
+        downstream.enqueue(JSON.parse(data.toString('utf-8'))),
+      );
+      ws.on('open', () =>
+        ws.send(
+          JSON.stringify([
+            'initConnection',
+            {
+              desiredQueriesPatch: [
+                {op: 'put', hash: 'query-hash1', ast: FOO_QUERY},
+              ],
             },
+          ] satisfies InitConnectionMessage),
+        ),
+      );
+
+      expect(await downstream.dequeue()).toMatchObject([
+        'connected',
+        {wsid: '123'},
+      ]);
+      expect(await downstream.dequeue()).toMatchObject([
+        'pokeStart',
+        {pokeID: '00'},
+      ]);
+      expect(await downstream.dequeue()).toMatchObject([
+        'pokeEnd',
+        {pokeID: '00'},
+      ]);
+      expect(await downstream.dequeue()).toMatchObject([
+        'pokeStart',
+        {pokeID: '00:01'},
+      ]);
+      expect(await downstream.dequeue()).toMatchObject([
+        'pokePart',
+        {
+          pokeID: '00:01',
+          clientsPatch: [{op: 'put', clientID: 'def'}],
+          desiredQueriesPatches: {
+            def: [{op: 'put', hash: 'query-hash1', ast: FOO_QUERY}],
           },
-        ],
-      },
-    ]);
-    expect(await downstream.dequeue()).toMatchObject([
-      'pokeEnd',
-      {pokeID: contentPokeID},
-    ]);
-
-    // Trigger an upstream change and verify replication.
-    await upDB`
-    INSERT INTO foo(id, val, b, j1, j2, j3, j4) 
-      VALUES ('voo', 'doo', false, '"foo"', 'false', '456.789', '{"bar":"baz"}')`;
-
-    expect(await downstream.dequeue()).toMatchObject([
-      'pokeStart',
-      {pokeID: WATERMARK_REGEX},
-    ]);
-    expect(await downstream.dequeue()).toMatchObject([
-      'pokePart',
-      {
-        pokeID: WATERMARK_REGEX,
-        rowsPatch: [
-          {
-            op: 'put',
-            tableName: 'foo',
-            value: {
-              id: 'voo',
-              val: 'doo',
-              b: false,
-              j1: 'foo',
-              j2: false,
-              j3: 456.789,
-              j4: {bar: 'baz'},
+        },
+      ]);
+      expect(await downstream.dequeue()).toMatchObject([
+        'pokeEnd',
+        {pokeID: '00:01'},
+      ]);
+      const contentPokeStart = (await downstream.dequeue()) as PokeStartMessage;
+      expect(contentPokeStart).toMatchObject([
+        'pokeStart',
+        {pokeID: /[0-9a-z]{2,}/},
+      ]);
+      const contentPokeID = contentPokeStart[1].pokeID;
+      expect(await downstream.dequeue()).toMatchObject([
+        'pokePart',
+        {
+          pokeID: contentPokeID,
+          gotQueriesPatch: [{op: 'put', hash: 'query-hash1', ast: FOO_QUERY}],
+          rowsPatch: [
+            {
+              op: 'put',
+              tableName: 'foo',
+              value: {
+                id: 'bar',
+                val: 'baz',
+                b: true,
+                j1: {foo: 'bar'},
+                j2: true,
+                j3: 123,
+                j4: 'string',
+              },
             },
-          },
-        ],
-      },
-    ]);
-    expect(await downstream.dequeue()).toMatchObject([
-      'pokeEnd',
-      {pokeID: WATERMARK_REGEX},
-    ]);
+          ],
+        },
+      ]);
+      expect(await downstream.dequeue()).toMatchObject([
+        'pokeEnd',
+        {pokeID: contentPokeID},
+      ]);
 
-    // Test TRUNCATE
-    await upDB`TRUNCATE TABLE foo RESTART IDENTITY`;
+      // Trigger an upstream change and verify replication.
+      if (backend === 'pg') {
+        await upDB`
+          INSERT INTO foo(id, val, b, j1, j2, j3, j4) 
+            VALUES ('voo', 'doo', false, '"foo"', 'false', '456.789', '{"bar":"baz"}')`;
+      } else {
+        await streamCustomChanges([
+          ['begin', {tag: 'begin'}, {commitWatermark: '102'}],
+          [
+            'data',
+            {
+              tag: 'insert',
+              relation: {
+                tag: 'relation',
+                schema: 'public',
+                name: 'foo',
+                replicaIdentity: 'default',
+                keyColumns: ['id'],
+              },
+              new: {
+                id: 'voo',
+                val: 'doo',
+                b: false,
+                j1: 'foo',
+                j2: false,
+                j3: 456.789,
+                j4: {bar: 'baz'},
+              },
+            },
+          ],
+          ['commit', {tag: 'commit'}, {watermark: '102'}],
+        ]);
+      }
 
-    // One canceled poke
-    expect(await downstream.dequeue()).toMatchObject([
-      'pokeStart',
-      {pokeID: WATERMARK_REGEX},
-    ]);
-    expect(await downstream.dequeue()).toMatchObject([
-      'pokeEnd',
-      {pokeID: WATERMARK_REGEX, cancel: true},
-    ]);
+      expect(await downstream.dequeue()).toMatchObject([
+        'pokeStart',
+        {pokeID: WATERMARK_REGEX},
+      ]);
+      expect(await downstream.dequeue()).toMatchObject([
+        'pokePart',
+        {
+          pokeID: WATERMARK_REGEX,
+          rowsPatch: [
+            {
+              op: 'put',
+              tableName: 'foo',
+              value: {
+                id: 'voo',
+                val: 'doo',
+                b: false,
+                j1: 'foo',
+                j2: false,
+                j3: 456.789,
+                j4: {bar: 'baz'},
+              },
+            },
+          ],
+        },
+      ]);
+      expect(await downstream.dequeue()).toMatchObject([
+        'pokeEnd',
+        {pokeID: WATERMARK_REGEX},
+      ]);
 
-    expect(await downstream.dequeue()).toMatchObject([
-      'pokeStart',
-      {pokeID: WATERMARK_REGEX},
-    ]);
-    expect(await downstream.dequeue()).toMatchObject([
-      'pokePart',
-      {
-        pokeID: WATERMARK_REGEX,
-        rowsPatch: [
-          {
-            op: 'del',
-            tableName: 'foo',
-            id: {id: 'bar'},
-          },
-          {
-            op: 'del',
-            tableName: 'foo',
-            id: {id: 'voo'},
-          },
-        ],
-      },
-    ]);
-    expect(await downstream.dequeue()).toMatchObject([
-      'pokeEnd',
-      {pokeID: WATERMARK_REGEX},
-    ]);
+      // Test TRUNCATE
+      if (backend === 'pg') {
+        await upDB`TRUNCATE TABLE foo RESTART IDENTITY`;
+      } else {
+        await streamCustomChanges([
+          ['begin', {tag: 'begin'}, {commitWatermark: '103'}],
+          [
+            'data',
+            {
+              tag: 'truncate',
+              relations: [
+                {
+                  tag: 'relation',
+                  schema: 'public',
+                  name: 'foo',
+                  replicaIdentity: 'default',
+                  keyColumns: ['id'],
+                },
+              ],
+            },
+          ],
+          ['commit', {tag: 'commit'}, {watermark: '103'}],
+        ]);
+      }
 
-    // Test that INSERTs into tables without primary keys are replicated.
-    await upDB.unsafe(`
-      INSERT INTO nopk(id, val) VALUES ('bar', 'baz');
-      CREATE UNIQUE INDEX nopk_key ON nopk (id);
-    `);
-
-    // For now, these no-op pokes indicate that the schema change was
-    // processed but not patches resulted.
-    // TODO: Get rid of empty pokes.
-    for (let i = 0; i < 2; i++) {
+      // One canceled poke
       expect(await downstream.dequeue()).toMatchObject([
         'pokeStart',
         {pokeID: WATERMARK_REGEX},
       ]);
       expect(await downstream.dequeue()).toMatchObject([
         'pokeEnd',
+        {pokeID: WATERMARK_REGEX, cancel: true},
+      ]);
+
+      expect(await downstream.dequeue()).toMatchObject([
+        'pokeStart',
         {pokeID: WATERMARK_REGEX},
       ]);
-    }
-
-    // Now that nopk has a unique index, add a query to retrieve the data.
-    ws.send(
-      JSON.stringify([
-        'changeDesiredQueries',
+      expect(await downstream.dequeue()).toMatchObject([
+        'pokePart',
         {
-          desiredQueriesPatch: [
-            {op: 'put', hash: 'query-hash2', ast: NOPK_QUERY},
+          pokeID: WATERMARK_REGEX,
+          rowsPatch: [
+            {
+              op: 'del',
+              tableName: 'foo',
+              id: {id: 'bar'},
+            },
+            {
+              op: 'del',
+              tableName: 'foo',
+              id: {id: 'voo'},
+            },
           ],
         },
-      ] satisfies ChangeDesiredQueriesMessage),
-    );
+      ]);
+      expect(await downstream.dequeue()).toMatchObject([
+        'pokeEnd',
+        {pokeID: WATERMARK_REGEX},
+      ]);
 
-    // poke confirming the query registration.
-    expect(await downstream.dequeue()).toMatchObject([
-      'pokeStart',
-      {pokeID: WATERMARK_REGEX},
-    ]);
-    expect(await downstream.dequeue()).toMatchObject([
-      'pokePart',
-      {
-        pokeID: WATERMARK_REGEX,
-        desiredQueriesPatches: {
-          def: [{op: 'put', hash: 'query-hash2', ast: NOPK_QUERY}],
+      // Test that INSERTs into tables without primary keys are replicated.
+      if (backend === 'pg') {
+        await upDB.unsafe(`
+      INSERT INTO nopk(id, val) VALUES ('bar', 'baz');
+      CREATE UNIQUE INDEX nopk_key ON nopk (id);
+    `);
+      } else {
+        await streamCustomChanges([
+          ['begin', {tag: 'begin'}, {commitWatermark: '104'}],
+          [
+            'data',
+            {
+              tag: 'insert',
+              relation: {
+                tag: 'relation',
+                schema: 'public',
+                name: 'nopk',
+                replicaIdentity: 'default',
+                keyColumns: [],
+              },
+              new: {
+                id: 'bar',
+                val: 'baz',
+              },
+            },
+          ],
+          [
+            'data',
+            {
+              tag: 'create-index',
+              spec: {
+                name: 'nopk_now_has_key_yay',
+                schema: 'public',
+                tableName: 'nopk',
+                columns: {id: 'ASC'},
+                unique: true,
+              },
+            },
+          ],
+          ['commit', {tag: 'commit'}, {watermark: '104'}],
+        ]);
+      }
+
+      // For now, these no-op pokes indicate that the schema change was
+      // processed but not patches resulted.
+      // TODO: Get rid of empty pokes.
+      for (let i = 0; i < 2; i++) {
+        expect(await downstream.dequeue()).toMatchObject([
+          'pokeStart',
+          {pokeID: WATERMARK_REGEX},
+        ]);
+        expect(await downstream.dequeue()).toMatchObject([
+          'pokeEnd',
+          {pokeID: WATERMARK_REGEX},
+        ]);
+      }
+
+      // Now that nopk has a unique index, add a query to retrieve the data.
+      ws.send(
+        JSON.stringify([
+          'changeDesiredQueries',
+          {
+            desiredQueriesPatch: [
+              {op: 'put', hash: 'query-hash2', ast: NOPK_QUERY},
+            ],
+          },
+        ] satisfies ChangeDesiredQueriesMessage),
+      );
+
+      // poke confirming the query registration.
+      expect(await downstream.dequeue()).toMatchObject([
+        'pokeStart',
+        {pokeID: WATERMARK_REGEX},
+      ]);
+      expect(await downstream.dequeue()).toMatchObject([
+        'pokePart',
+        {
+          pokeID: WATERMARK_REGEX,
+          desiredQueriesPatches: {
+            def: [{op: 'put', hash: 'query-hash2', ast: NOPK_QUERY}],
+          },
         },
-      },
-    ]);
-    expect(await downstream.dequeue()).toMatchObject([
-      'pokeEnd',
-      {pokeID: WATERMARK_REGEX},
-    ]);
+      ]);
+      expect(await downstream.dequeue()).toMatchObject([
+        'pokeEnd',
+        {pokeID: WATERMARK_REGEX},
+      ]);
 
-    // poke containing the row data.
-    expect(await downstream.dequeue()).toMatchObject([
-      'pokeStart',
-      {pokeID: WATERMARK_REGEX},
-    ]);
-    expect(await downstream.dequeue()).toMatchObject([
-      'pokePart',
-      {
-        pokeID: WATERMARK_REGEX,
-        rowsPatch: [
-          {
-            op: 'put',
-            tableName: 'nopk',
-            value: {id: 'bar', val: 'baz'},
-          },
-          {
-            op: 'put',
-            tableName: 'nopk',
-            value: {id: 'foo', val: 'bar'},
-          },
-        ],
-      },
-    ]);
-    expect(await downstream.dequeue()).toMatchObject([
-      'pokeEnd',
-      {pokeID: WATERMARK_REGEX},
-    ]);
-  });
+      // poke containing the row data.
+      expect(await downstream.dequeue()).toMatchObject([
+        'pokeStart',
+        {pokeID: WATERMARK_REGEX},
+      ]);
+      expect(await downstream.dequeue()).toMatchObject([
+        'pokePart',
+        {
+          pokeID: WATERMARK_REGEX,
+          rowsPatch: [
+            {
+              op: 'put',
+              tableName: 'nopk',
+              value: {id: 'bar', val: 'baz'},
+            },
+            {
+              op: 'put',
+              tableName: 'nopk',
+              value: {id: 'foo', val: 'bar'},
+            },
+          ],
+        },
+      ]);
+      expect(await downstream.dequeue()).toMatchObject([
+        'pokeEnd',
+        {pokeID: WATERMARK_REGEX},
+      ]);
+    },
+  );
 });

--- a/packages/zero-cache/src/server/multi/config.test.ts
+++ b/packages/zero-cache/src/server/multi/config.test.ts
@@ -119,6 +119,7 @@ test('parse options', () => {
         "upstream": {
           "db": "foo",
           "maxConns": 20,
+          "type": "pg",
         },
       },
       "env": {
@@ -138,6 +139,7 @@ test('parse options', () => {
         "ZERO_TENANTS_JSON": "{"tenants":[{"id":"ten-boo","host":"Normalize.ME","path":"tenboo","env":{"ZERO_REPLICA_FILE":"tenboo.db","ZERO_CVR_DB":"foo","ZERO_CHANGE_DB":"foo","ZERO_SHARD_ID":"foo"}},{"id":"ten_bar","path":"/tenbar","env":{"ZERO_REPLICA_FILE":"tenbar.db","ZERO_CVR_DB":"bar","ZERO_CHANGE_DB":"bar","ZERO_SHARD_ID":"bar"}},{"id":"tenbaz-123","path":"/tenbaz","env":{"ZERO_REPLICA_FILE":"tenbar.db","ZERO_UPSTREAM_DB":"overridden","ZERO_CVR_DB":"baz","ZERO_CHANGE_DB":"baz","ZERO_SHARD_ID":"foo"}}]}",
         "ZERO_UPSTREAM_DB": "foo",
         "ZERO_UPSTREAM_MAX_CONNS": "20",
+        "ZERO_UPSTREAM_TYPE": "pg",
       },
     }
   `);

--- a/packages/zero-cache/src/services/change-source/custom/change-source.test.ts
+++ b/packages/zero-cache/src/services/change-source/custom/change-source.test.ts
@@ -1,0 +1,212 @@
+import websocket from '@fastify/websocket';
+import {consoleLogSink, LogContext} from '@rocicorp/logger';
+import {resolver} from '@rocicorp/resolver';
+import Fastify, {type FastifyInstance} from 'fastify';
+import {afterEach, beforeEach, describe, test} from 'vitest';
+import type WebSocket from 'ws';
+import {DbFile, expectTables} from '../../../test/lite.ts';
+import {stream, type Sink} from '../../../types/streams.ts';
+import type {ChangeStreamMessage} from '../protocol/current/downstream.ts';
+import {
+  changeSourceUpstreamSchema,
+  type ChangeSourceUpstream,
+} from '../protocol/current/upstream.ts';
+import {initializeCustomChangeSource} from './change-source.ts';
+
+describe('change-source/custom', () => {
+  let lc: LogContext;
+  let downstream: Promise<Sink<ChangeStreamMessage>>;
+  let server: FastifyInstance;
+  let changeSourceURI: string;
+  let replicaDbFile: DbFile;
+
+  beforeEach(async () => {
+    lc = new LogContext('debug', {}, consoleLogSink);
+    server = Fastify();
+    await server.register(websocket);
+
+    const {promise, resolve} = resolver<Sink<ChangeStreamMessage>>();
+    downstream = promise;
+    server.get('/', {websocket: true}, (ws: WebSocket) => {
+      const {outstream} = stream<ChangeSourceUpstream, ChangeStreamMessage>(
+        lc,
+        ws,
+        changeSourceUpstreamSchema,
+      );
+      resolve(outstream);
+    });
+    changeSourceURI = await server.listen({port: 0});
+    lc.info?.(`server running on ${changeSourceURI}`);
+    replicaDbFile = new DbFile('custom-change-source');
+  });
+
+  afterEach(async () => {
+    await server.close();
+    replicaDbFile.delete();
+  });
+
+  async function streamChanges(changes: ChangeStreamMessage[]) {
+    const sink = await downstream;
+    for (const change of changes) {
+      sink.push(change);
+    }
+  }
+
+  test('initial-sync', async () => {
+    void streamChanges([
+      ['begin', {tag: 'begin'}, {commitWatermark: '123'}],
+      [
+        'data',
+        {
+          tag: 'create-table',
+          spec: {
+            schema: 'public',
+            name: 'foo',
+            primaryKey: ['id'],
+            columns: {
+              id: {pos: 0, dataType: 'text', notNull: true},
+              bar: {pos: 1, dataType: 'text'},
+            },
+          },
+        },
+      ],
+      [
+        'data',
+        {
+          tag: 'create-index',
+          spec: {
+            name: 'public_foo_index',
+            schema: 'public',
+            tableName: 'foo',
+            columns: {id: 'ASC'},
+            unique: true,
+          },
+        },
+      ],
+      [
+        'data',
+        {
+          tag: 'insert',
+          relation: {
+            tag: 'relation',
+            schema: 'public',
+            name: 'foo',
+            replicaIdentity: 'default',
+            keyColumns: ['id'],
+          },
+          new: {id: 'abcde', bar: 'baz'},
+        },
+      ],
+      [
+        'data',
+        {
+          tag: 'create-table',
+          spec: {
+            schema: 'zero_0',
+            name: 'clients',
+            primaryKey: ['clientGroupID', 'clientID'],
+            columns: {
+              clientGroupID: {pos: 0, dataType: 'text', notNull: true},
+              clientID: {pos: 1, dataType: 'text', notNull: true},
+              lastMutationID: {pos: 2, dataType: 'bigint'},
+              userID: {pos: 3, dataType: 'text'},
+            },
+          },
+        },
+      ],
+      [
+        'data',
+        {
+          tag: 'create-index',
+          spec: {
+            name: 'zero_clients_key',
+            schema: 'zero_0',
+            tableName: 'clients',
+            columns: {
+              clientGroupID: 'ASC',
+              clientID: 'ASC',
+            },
+            unique: true,
+          },
+        },
+      ],
+      [
+        'data',
+        {
+          tag: 'create-table',
+          spec: {
+            schema: 'zero',
+            name: 'schemaVersions',
+            primaryKey: ['lock'],
+            columns: {
+              lock: {pos: 0, dataType: 'bool', notNull: true},
+              minSupportedVersion: {pos: 1, dataType: 'int'},
+              maxSupportedVersion: {pos: 2, dataType: 'int'},
+            },
+          },
+        },
+      ],
+      [
+        'data',
+        {
+          tag: 'create-index',
+          spec: {
+            name: 'zero_schemaVersions_key',
+            schema: 'zero',
+            tableName: 'schemaVersions',
+            columns: {lock: 'ASC'},
+            unique: true,
+          },
+        },
+      ],
+      [
+        'data',
+        {
+          tag: 'insert',
+          relation: {
+            tag: 'relation',
+            schema: 'zero',
+            name: 'schemaVersions',
+            replicaIdentity: 'default',
+            keyColumns: ['lock'],
+          },
+          new: {lock: true, minSupportedVersion: 1, maxSupportedVersion: 1},
+        },
+      ],
+      ['commit', {tag: 'commit'}, {watermark: '123'}],
+    ]);
+
+    await initializeCustomChangeSource(
+      lc,
+      changeSourceURI,
+      {id: '0', publications: ['b', 'a']},
+      replicaDbFile.path,
+    );
+
+    expectTables(replicaDbFile.connect(lc), {
+      foo: [{id: 'abcde', bar: 'baz', ['_0_version']: '123'}],
+      ['zero.schemaVersions']: [
+        {
+          lock: 1,
+          minSupportedVersion: 1,
+          maxSupportedVersion: 1,
+          ['_0_version']: '123',
+        },
+      ],
+      ['zero_0.clients']: [],
+      ['_zero.replicationState']: [{lock: 1, stateVersion: '123'}],
+      ['_zero.replicationConfig']: [
+        {
+          lock: 1,
+          replicaVersion: '123',
+          publications: '["a","b"]',
+        },
+      ],
+      ['_zero.changeLog']: [
+        // changeLog should be set up but empty, since it is
+        // unnecessary / wasteful to record the initial state
+        // in the change log.
+      ],
+    });
+  });
+});

--- a/packages/zero-cache/src/services/change-source/custom/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/custom/change-source.ts
@@ -1,0 +1,252 @@
+import {LogContext} from '@rocicorp/logger';
+import {WebSocket} from 'ws';
+import {assert, unreachable} from '../../../../../shared/src/asserts.ts';
+import {deepEqual} from '../../../../../shared/src/json.ts';
+import type {SchemaValue} from '../../../../../zero-schema/src/table-schema.ts';
+import {Database} from '../../../../../zqlite/src/db.ts';
+import {computeZqlSpecs} from '../../../db/lite-tables.ts';
+import {StatementRunner} from '../../../db/statements.ts';
+import {stringify} from '../../../types/bigint-json.ts';
+import {registerPostgresTypeParsers} from '../../../types/pg.ts';
+import {stream} from '../../../types/streams.ts';
+import type {
+  ChangeSource,
+  ChangeStream,
+} from '../../change-streamer/change-streamer-service.ts';
+import {type ReplicationConfig} from '../../change-streamer/schema/tables.ts';
+import {ChangeProcessor} from '../../replicator/change-processor.ts';
+import {initChangeLog} from '../../replicator/schema/change-log.ts';
+import {
+  getSubscriptionState,
+  initReplicationState,
+} from '../../replicator/schema/replication-state.ts';
+import type {ShardConfig} from '../pg/shard-config.ts';
+import {changeStreamMessageSchema} from '../protocol/current/downstream.ts';
+import {type ChangeSourceUpstream} from '../protocol/current/upstream.ts';
+import {initSyncSchema} from './sync-schema.ts';
+
+// BigInt support from LogicalReplicationService.
+registerPostgresTypeParsers();
+
+/**
+ * Initializes a Postgres change source, including the initial sync of the
+ * replica, before streaming changes from the corresponding logical replication
+ * stream.
+ */
+export async function initializeCustomChangeSource(
+  lc: LogContext,
+  upstreamURI: string,
+  shard: ShardConfig,
+  replicaDbFile: string,
+): Promise<{replicationConfig: ReplicationConfig; changeSource: ChangeSource}> {
+  await initSyncSchema(
+    lc,
+    `replica-${shard.id}`,
+    shard,
+    replicaDbFile,
+    upstreamURI,
+  );
+
+  const replica = new Database(lc, replicaDbFile);
+  const replicationConfig = getSubscriptionState(new StatementRunner(replica));
+  replica.close();
+
+  if (shard.publications.length) {
+    // Verify that the publications match what has been synced.
+    const requested = [...shard.publications].sort();
+    const replicated = replicationConfig.publications.sort();
+    if (!deepEqual(requested, replicated)) {
+      throw new Error(
+        `Invalid ShardConfig. Requested publications [${requested}] do not match synced publications: [${replicated}]`,
+      );
+    }
+  }
+
+  const changeSource = new CustomChangeSource(
+    lc,
+    upstreamURI,
+    shard.id,
+    replicationConfig,
+  );
+
+  return {replicationConfig, changeSource};
+}
+
+class CustomChangeSource implements ChangeSource {
+  readonly #lc: LogContext;
+  readonly #upstreamUri: string;
+  readonly #shardID: string;
+  readonly #replicationConfig: ReplicationConfig;
+
+  constructor(
+    lc: LogContext,
+    upstreamUri: string,
+    shardID: string,
+    replicationConfig: ReplicationConfig,
+  ) {
+    this.#lc = lc.withContext('component', 'change-source');
+    this.#upstreamUri = upstreamUri;
+    this.#shardID = shardID;
+    this.#replicationConfig = replicationConfig;
+  }
+
+  initialSync(): ChangeStream {
+    return this.#startStream();
+  }
+
+  startStream(clientWatermark: string): Promise<ChangeStream> {
+    return Promise.resolve(this.#startStream(clientWatermark));
+  }
+
+  #startStream(clientWatermark?: string): ChangeStream {
+    const {publications, replicaVersion} = this.#replicationConfig;
+    const url = new URL(this.#upstreamUri);
+    url.searchParams.set('shardID', this.#shardID);
+    for (const pub of publications) {
+      url.searchParams.append('shardPublications', pub);
+    }
+    if (clientWatermark) {
+      assert(replicaVersion.length);
+      url.searchParams.set('lastWatermark', clientWatermark);
+      url.searchParams.set('replicaVersion', replicaVersion);
+    }
+
+    const ws = new WebSocket(url);
+    const {instream, outstream} = stream(
+      this.#lc,
+      ws,
+      changeStreamMessageSchema,
+      // Upstream acks coalesce. If upstream exhibits back-pressure,
+      // only the last ACK is kept / buffered.
+      {coalesce: (curr: ChangeSourceUpstream) => curr},
+    );
+    return {changes: instream, acks: outstream};
+  }
+}
+
+/**
+ * Initial sync for a custom change source makes a request to the
+ * change source endpoint with no `replicaVersion` or `lastWatermark`.
+ * The initial transaction returned by the endpoint is treated as
+ * the initial sync, and the commit watermark of that transaction
+ * becomes the `replicaVersion` of the initialized replica.
+ *
+ * Note that this is equivalent to how the LSN of the Postgres WAL
+ * at initial sync time is the `replicaVersion` (and starting
+ * version for all initially-synced rows).
+ */
+export async function initialSync(
+  lc: LogContext,
+  shard: ShardConfig,
+  tx: Database,
+  upstreamURI: string,
+) {
+  const {id, publications} = shard;
+  const changeSource = new CustomChangeSource(lc, upstreamURI, id, {
+    replicaVersion: '', // ignored for initialSync()
+    publications,
+  });
+  const {changes} = changeSource.initialSync();
+
+  const processor = new ChangeProcessor(
+    new StatementRunner(tx),
+    'INITIAL-SYNC',
+    (_, err) => {
+      throw err;
+    },
+  );
+
+  let num = 0;
+  for await (const change of changes) {
+    const [tag] = change;
+    switch (tag) {
+      case 'begin': {
+        const {commitWatermark} = change[2];
+        lc.info?.(
+          `initial sync of shard ${id} at replicaVersion ${commitWatermark}`,
+        );
+        initReplicationState(tx, [...publications].sort(), commitWatermark);
+        initChangeLog(tx);
+        processor.processMessage(lc, change);
+        break;
+      }
+      case 'data':
+        processor.processMessage(lc, change);
+        if (++num % 1000 === 0) {
+          lc.debug?.(`processed ${num} changes`);
+        }
+        break;
+      case 'commit':
+        processor.processMessage(lc, change);
+        validateInitiallySyncedData(lc, tx, id);
+        lc.info?.(`finished initial-sync of ${num} changes`);
+        return;
+
+      case 'status':
+        break; // Ignored
+      case 'control':
+      case 'rollback':
+        throw new Error(
+          `unexpected message during initial-sync: ${stringify(change)}`,
+        );
+      default:
+        unreachable(change);
+    }
+  }
+  throw new Error(
+    `change source ${upstreamURI} closed before initial-sync completed`,
+  );
+}
+
+// Verify that the upstream tables expected by the sync logic
+// have been properly initialized.
+function getRequiredTables(
+  shardID: string,
+): Record<string, Record<string, SchemaValue>> {
+  return {
+    [`zero_${shardID}.clients`]: {
+      clientGroupID: {type: 'string'},
+      clientID: {type: 'string'},
+      lastMutationID: {type: 'number'},
+      userID: {type: 'string'},
+    },
+    [`zero.schemaVersions`]: {
+      minSupportedVersion: {type: 'number'},
+      maxSupportedVersion: {type: 'number'},
+    },
+  };
+}
+
+function validateInitiallySyncedData(
+  lc: LogContext,
+  db: Database,
+  shardID: string,
+) {
+  const tables = computeZqlSpecs(lc, db);
+  const required = getRequiredTables(shardID);
+  for (const [name, columns] of Object.entries(required)) {
+    const table = tables.get(name)?.zqlSpec;
+    if (!table) {
+      throw new Error(
+        `Upstream is missing the "${name}" table. (Found ${[
+          ...tables.keys(),
+        ]})` +
+          `Please ensure that each table has a unique index over one ` +
+          `or more non-null columns.`,
+      );
+    }
+    for (const [col, {type}] of Object.entries(columns)) {
+      const found = table[col];
+      if (!found) {
+        throw new Error(
+          `Upstream "${table}" table is missing the "${col}" column`,
+        );
+      }
+      if (found.type !== type) {
+        throw new Error(
+          `Upstream "${table}.${col}" column is a ${found.type} type but must be a ${type} type.`,
+        );
+      }
+    }
+  }
+}

--- a/packages/zero-cache/src/services/change-source/custom/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/custom/change-source.ts
@@ -7,7 +7,6 @@ import {Database} from '../../../../../zqlite/src/db.ts';
 import {computeZqlSpecs} from '../../../db/lite-tables.ts';
 import {StatementRunner} from '../../../db/statements.ts';
 import {stringify} from '../../../types/bigint-json.ts';
-import {registerPostgresTypeParsers} from '../../../types/pg.ts';
 import {stream} from '../../../types/streams.ts';
 import type {
   ChangeSource,
@@ -24,9 +23,6 @@ import type {ShardConfig} from '../pg/shard-config.ts';
 import {changeStreamMessageSchema} from '../protocol/current/downstream.ts';
 import {type ChangeSourceUpstream} from '../protocol/current/upstream.ts';
 import {initSyncSchema} from './sync-schema.ts';
-
-// BigInt support from LogicalReplicationService.
-registerPostgresTypeParsers();
 
 /**
  * Initializes a Postgres change source, including the initial sync of the

--- a/packages/zero-cache/src/services/change-source/custom/sync-schema.ts
+++ b/packages/zero-cache/src/services/change-source/custom/sync-schema.ts
@@ -1,0 +1,34 @@
+import type {LogContext} from '@rocicorp/logger';
+
+import {
+  runSchemaMigrations,
+  type IncrementalMigrationMap,
+  type Migration,
+} from '../../../db/migration-lite.ts';
+import type {ShardConfig} from '../pg/shard-config.ts';
+import {initialSync} from './change-source.ts';
+
+export async function initSyncSchema(
+  log: LogContext,
+  debugName: string,
+  shard: ShardConfig,
+  dbPath: string,
+  upstreamURI: string,
+): Promise<void> {
+  const setupMigration: Migration = {
+    migrateSchema: (log, tx) => initialSync(log, shard, tx, upstreamURI),
+    minSafeVersion: 1,
+  };
+
+  const schemaVersionMigrationMap: IncrementalMigrationMap = {
+    1: setupMigration,
+  };
+
+  await runSchemaMigrations(
+    log,
+    debugName,
+    dbPath,
+    setupMigration,
+    schemaVersionMigrationMap,
+  );
+}

--- a/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg-test.ts
@@ -14,7 +14,7 @@ import type {ChangeProcessor} from '../../replicator/change-processor.ts';
 import {createChangeProcessor} from '../../replicator/test-utils.ts';
 import type {DataChange} from '../protocol/current/data.ts';
 import type {ChangeStreamMessage} from '../protocol/current/downstream.ts';
-import {initializeChangeSource} from './change-source.ts';
+import {initializePostgresChangeSource} from './change-source.ts';
 
 const SHARD_ID = 'change_source_end_to_mid_test_id';
 
@@ -70,7 +70,7 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
     `);
 
     const source = (
-      await initializeChangeSource(
+      await initializePostgresChangeSource(
         lc,
         upstreamURI,
         {id: SHARD_ID, publications: ['zero_some_public', 'zero_all_test']},

--- a/packages/zero-cache/src/services/change-source/pg/change-source.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.pg-test.ts
@@ -28,7 +28,7 @@ import type {
   ChangeStreamMessage,
   Commit,
 } from '../protocol/current/downstream.ts';
-import {initializeChangeSource} from './change-source.ts';
+import {initializePostgresChangeSource} from './change-source.ts';
 import {replicationSlot} from './initial-sync.ts';
 import {fromLexiVersion} from './lsn.ts';
 import {dropEventTriggerStatements} from './schema/ddl-test-utils.ts';
@@ -76,7 +76,7 @@ describe('change-source/pg', {timeout: 30000}, () => {
     `);
 
     source = (
-      await initializeChangeSource(
+      await initializePostgresChangeSource(
         lc,
         upstreamURI,
         {id: SHARD_ID, publications: ['zero_foo', 'zero_zero']},
@@ -690,7 +690,7 @@ describe('change-source/pg', {timeout: 30000}, () => {
   test('error on wrong publications', async () => {
     let err;
     try {
-      await initializeChangeSource(
+      await initializePostgresChangeSource(
         lc,
         upstreamURI,
         {id: SHARD_ID, publications: ['zero_different_publication']},

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -83,7 +83,7 @@ registerPostgresTypeParsers();
  * replica, before streaming changes from the corresponding logical replication
  * stream.
  */
-export async function initializeChangeSource(
+export async function initializePostgresChangeSource(
   lc: LogContext,
   upstreamURI: string,
   shard: ShardConfig,
@@ -316,7 +316,7 @@ class PostgresChangeSource implements ChangeSource {
       .subscribe(
         new PgoutputPlugin({
           protoVersion: 1,
-          publicationNames: this.#replicationConfig.publications,
+          publicationNames: [...this.#replicationConfig.publications],
           messages: true,
         }),
         slot,

--- a/packages/zero-cache/src/services/change-streamer/schema/tables.ts
+++ b/packages/zero-cache/src/services/change-streamer/schema/tables.ts
@@ -34,7 +34,7 @@ const CREATE_CHANGE_LOG_TABLE = `
  */
 export type ReplicationConfig = {
   replicaVersion: string;
-  publications: string[];
+  publications: readonly string[];
 };
 
 const CREATE_REPLICATION_CONFIG_TABLE = `

--- a/packages/zero-cache/src/types/streams.ts
+++ b/packages/zero-cache/src/types/streams.ts
@@ -61,7 +61,7 @@ export function stream<In extends JSONValue, Out extends JSONValue>(
       if (err) {
         closeWithError(lc, ws, err);
       } else {
-        lc.info?.(`closing conneciton to ${endpoint}`);
+        lc.info?.(`closing connection to ${endpoint}`);
         ws.close();
       }
     }
@@ -136,7 +136,10 @@ export function stream<In extends JSONValue, Out extends JSONValue>(
         );
       },
       destroy: (err, callback) => {
-        instream.fail(ensureError(err));
+        if (err) {
+          instream.fail(ensureError(err));
+        }
+        // Otherwise, final will handle the cancel.
         callback();
       },
       final: callback => {


### PR DESCRIPTION
Initial experimental support for custom backends via the `change-protocol`.

Enable this by setting:

```
ZERO_UPSTREAM_DB = http://my-change-source-endpoint.dev/changes/v0/stream?...
ZERO_UPSTREAM_TYPE = custom
```

@cbnsndwch 