### PR TITLE
feat(zero): add type functions for custom mutators

### DIFF
--- a/packages/zero-client/src/client/custom.ts
+++ b/packages/zero-client/src/client/custom.ts
@@ -1,0 +1,79 @@
+import type {
+  DeleteID,
+  InsertValue,
+  Schema,
+  TableSchema,
+  UpdateValue,
+  UpsertValue,
+} from '../mod.ts';
+import type {ClientID} from '../types/client-state.ts';
+
+/**
+ * The shape which a user's custom mutator definitions must conform to.
+ */
+export type CustomMutatorDefs<S extends Schema> = {
+  readonly [key: string]: CustomMutatorImpl<S>;
+};
+
+export type CustomMutatorImpl<S extends Schema> = (
+  tx: Transaction<S>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ...args: any[]
+) => void;
+
+export type TransactionReason = 'optimistic' | 'rebase';
+
+/**
+ * WriteTransactions are used with *mutators* which are registered using
+ * {@link ReplicacheOptions.mutators} and allows read and write operations on the
+ * database.
+ */
+export interface Transaction<S extends Schema> {
+  readonly clientID: ClientID;
+  /**
+   * The ID of the mutation that is being applied.
+   */
+  readonly mutationID: number;
+
+  /**
+   * The reason for the transaction.
+   */
+  readonly reason: TransactionReason;
+
+  readonly mutate: SchemaCRUD<S>;
+}
+
+type SchemaCRUD<S extends Schema> = {
+  [Table in keyof S['tables']]: TableCRUD<S['tables'][Table]>;
+};
+
+export type TableCRUD<S extends TableSchema> = {
+  /**
+   * Writes a row if a row with the same primary key doesn't already exists.
+   * Non-primary-key fields that are 'optional' can be omitted or set to
+   * `undefined`. Such fields will be assigned the value `null` optimistically
+   * and then the default value as defined by the server.
+   */
+  insert: (value: InsertValue<S>) => void;
+
+  /**
+   * Writes a row unconditionally, overwriting any existing row with the same
+   * primary key. Non-primary-key fields that are 'optional' can be omitted or
+   * set to `undefined`. Such fields will be assigned the value `null`
+   * optimistically and then the default value as defined by the server.
+   */
+  upsert: (value: UpsertValue<S>) => void;
+
+  /**
+   * Updates a row with the same primary key. If no such row exists, this
+   * function does nothing. All non-primary-key fields can be omitted or set to
+   * `undefined`. Such fields will be left unchanged from previous value.
+   */
+  update: (value: UpdateValue<S>) => void;
+
+  /**
+   * Deletes the row with the specified primary key. If no such row exists, this
+   * function does nothing.
+   */
+  delete: (id: DeleteID<S>) => void;
+};

--- a/packages/zero-client/src/client/options.ts
+++ b/packages/zero-client/src/client/options.ts
@@ -2,11 +2,15 @@ import type {LogLevel} from '@rocicorp/logger';
 import type {KVStoreProvider} from '../../../replicache/src/mod.ts';
 import type {MaybePromise} from '../../../shared/src/types.ts';
 import type {Schema} from '../../../zero-schema/src/mod.ts';
+import type {CustomMutatorDefs} from './custom.ts';
 
 /**
  * Configuration for [[Zero]].
  */
-export interface ZeroOptions<S extends Schema> {
+export interface ZeroOptions<
+  S extends Schema,
+  MD extends CustomMutatorDefs<S> = Record<string, never>,
+> {
   /**
    * URL to the zero-cache. This can be a simple hostname, e.g.
    * - "https://myapp-myteam.zero.ms"
@@ -72,6 +76,8 @@ export interface ZeroOptions<S extends Schema> {
    * to one another.
    */
   schema: S;
+
+  mutators?: MD | undefined;
 
   /**
    * `onOnlineChange` is called when the Zero instance's online status changes.
@@ -144,7 +150,10 @@ export interface ZeroOptions<S extends Schema> {
   maxHeaderLength?: number | undefined;
 }
 
-export interface ZeroAdvancedOptions<S extends Schema> extends ZeroOptions<S> {
+export interface ZeroAdvancedOptions<
+  S extends Schema,
+  MD extends CustomMutatorDefs<S> = Record<string, never>,
+> extends ZeroOptions<S, MD> {
   /**
    * UI rendering libraries will often provide a utility for batching multiple
    * state updates into a single render. Some examples are React's


### PR DESCRIPTION
Mainly lifting from https://github.com/rocicorp/mono/pull/3493/files#diff-eb7e31f6f0fe54b4a8955bb87dbf0f33aaa890361470233ad2875cc2e6f4ce7a

tweaks:
- multiple args to mutators
- add a default type parameter for `MD` so it need not be specified