### PR TITLE
feat(zero-cache): deprecate unnecessary fields from change-protocol

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -479,9 +479,15 @@ class ChangeMaker {
           ['begin', msg, {commitWatermark: toLexiVersion(must(msg.commitLsn))}],
         ];
 
-      case 'delete':
-        assert(msg.key);
-        return [['data', msg as MessageDelete]];
+      case 'delete': {
+        const key = msg.key ?? msg.old;
+        if (!key) {
+          throw new Error(
+            `Invalid DELETE msg (missing key): ${stringify(msg)}`,
+          );
+        }
+        return [['data', msg.key ? (msg as MessageDelete) : {...msg, key}]];
+      }
 
       case 'insert':
       case 'update':

--- a/packages/zero-cache/src/services/change-source/protocol/current/data.ts
+++ b/packages/zero-cache/src/services/change-source/protocol/current/data.ts
@@ -25,16 +25,20 @@ export const rollbackSchema = v.object({
 });
 
 export const relationSchema = v.object({
-  tag: v.literal('relation'),
   schema: v.string(),
   name: v.string(),
-  replicaIdentity: v.union(
-    v.literal('default'),
-    v.literal('nothing'),
-    v.literal('full'),
-    v.literal('index'),
-  ),
   keyColumns: v.array(v.string()),
+
+  // Deprecated tags will be removed in a later release.
+  tag: v.literal('relation').optional(),
+  replicaIdentity: v
+    .union(
+      v.literal('default'),
+      v.literal('nothing'),
+      v.literal('full'),
+      v.literal('index'),
+    )
+    .optional(),
 });
 
 export const rowSchema = v.record(jsonValueSchema);

--- a/packages/zero-cache/src/services/change-source/protocol/version.test.ts
+++ b/packages/zero-cache/src/services/change-source/protocol/version.test.ts
@@ -38,9 +38,9 @@ test('protocol versions', () => {
   // Then update the version number of the `CHANGE_SOURCE_PATH`
   // in current and export it appropriately as the new version
   // in `mod.ts`.
-  t(current, '1kfqmopbfu1mq', '/changes/v0/stream');
+  t(current, '268ode0tvphut', '/changes/v0/stream');
   // During initial development, we use v0 as a non-stable
   // version (i.e. breaking change are allowed). Once the
   // protocol graduates to v1, versions must be stable.
-  t(v0, '1kfqmopbfu1mq', '/changes/v0/stream');
+  t(v0, '268ode0tvphut', '/changes/v0/stream');
 });

--- a/packages/zero-cache/src/services/replicator/change-processor.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.ts
@@ -387,9 +387,6 @@ class TransactionProcessor {
   }
 
   processDelete(del: MessageDelete) {
-    // REPLICA IDENTITY DEFAULT means the `key` must be set.
-    // https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html
-    assert(del.relation.replicaIdentity === 'default');
     const table = liteTableName(del.relation);
     const rowKey = liteRow(del.key, this.#tableSpec(table));
 


### PR DESCRIPTION
Make a couple of unnecessary fields optional in the change-protocol, to be removed in a later release.

@cbnsndwch 