### PR TITLE
feat(zero-cache): optimize after schema changes. handle lock contention

### DIFF
--- a/packages/zqlite/src/db.ts
+++ b/packages/zqlite/src/db.ts
@@ -72,7 +72,16 @@ export class Database {
   }
 
   close(): void {
-    this.#db.pragma('optimize');
+    const start = Date.now();
+    try {
+      this.#db.pragma('optimize');
+      const elapsed = Date.now() - start;
+      if (elapsed > 2) {
+        this.#lc.debug?.(`PRAGMA optimized (${elapsed} ms)`);
+      }
+    } catch (e) {
+      this.#lc.warn?.('error running PRAGMA optimize', e);
+    }
     this.#db.close();
   }
 


### PR DESCRIPTION
Add a call to `PRAGMA optimize` after performing schema changes (as recommended in https://www.sqlite.org/lang_analyze.html).

Set a `busy_timeout` for all replica files, i.e. in the `view-syncer` as well as in the `replication-manager`, now that we are introducing (occasional) multiple writes.

Catch and log exceptions if the optimize-on-close call fails (e.g. with a lock timeout), since the application can/should continue running if the optimize could not acquire the lock.