### PR TITLE
feat(zero): namespace custom mutators to the table they impact

### DIFF
--- a/packages/zero-client/src/client/custom.test.ts
+++ b/packages/zero-client/src/client/custom.test.ts
@@ -1,0 +1,50 @@
+import {expectTypeOf, test} from 'vitest';
+
+import {schema} from '../../../zql/src/query/test/test-schemas.ts';
+import type {CustomMutatorDefs, MakeCustomMutatorInterfaces} from './custom.ts';
+type Schema = typeof schema;
+
+test('argument types are preserved on the generated mutator interface', () => {
+  const mutators = {
+    issue: {
+      setTitle: (tx, id: string, title: string) => {
+        tx.mutate.issue.update({id, title});
+      },
+      setProps: (
+        tx,
+        id: string,
+        title: string,
+        status: 'open' | 'closed',
+        assignee: string,
+      ) => {
+        tx.mutate.issue.update({
+          id,
+          title,
+          closed: status === 'closed',
+          ownerId: assignee,
+        });
+      },
+    },
+    nonTableNamespace: {
+      doThing: (_tx, _arg1: string, _arg2: number) => {
+        throw new Error('not implemented');
+      },
+    },
+  } satisfies CustomMutatorDefs<Schema>;
+
+  type MutatorsInterface = MakeCustomMutatorInterfaces<Schema, typeof mutators>;
+  expectTypeOf<MutatorsInterface>().toEqualTypeOf<{
+    readonly issue: {
+      readonly setTitle: (id: string, title: string) => void;
+      readonly setProps: (
+        id: string,
+        title: string,
+        status: 'closed' | 'open',
+        assignee: string,
+      ) => void;
+    };
+    readonly nonTableNamespace: {
+      readonly doThing: (arg1: string, arg2: number) => void;
+    };
+  }>();
+});


### PR DESCRIPTION
Rather than having all mutators at the top level, they'll need to be namespaced.

Example:

```ts
const mutators = {
    issue: {
      setTitle: (tx, id: string, title: string) => {
        tx.mutate.issue.update({id, title});
      },
    },
   notATableName: { doThing: () => {} }
};
```

The namespace is not required to match a table name but tables names are provided to intellisense at this callsite.

![CleanShot 2025-01-29 at 14 15 05](https://github.com/user-attachments/assets/1887a9c9-311b-4fda-88b9-8dbd7046f2d7)

