### PR TITLE
feat(zero-client): attach custom mutator implementations to `zero` in…

### DIFF
--- a/packages/replicache/src/replicache-impl.ts
+++ b/packages/replicache/src/replicache-impl.ts
@@ -1409,13 +1409,13 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}> {
   #register<Return extends ReadonlyJSONValue | void, Args extends JSONValue>(
     name: string,
     mutatorImpl: (tx: WriteTransaction, args?: Args) => MaybePromise<Return>,
-  ): (...args: Args[]) => Promise<Return> {
+  ): (args?: Args) => Promise<Return> {
     this.#mutatorRegistry[name] = mutatorImpl as (
       tx: WriteTransaction,
       args: JSONValue | undefined,
     ) => Promise<void | JSONValue>;
 
-    return (...args: Args[]): Promise<Return> =>
+    return (args?: Args): Promise<Return> =>
       this.#mutate(name, mutatorImpl, args, performance.now());
   }
 
@@ -1441,7 +1441,7 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}> {
   >(
     name: string,
     mutatorImpl: (tx: WriteTransaction, args?: A) => MaybePromise<R>,
-    args: A[] | undefined,
+    args: A | undefined,
     timestamp: number,
   ): Promise<R> {
     const frozenArgs = deepFreeze(args ?? null);
@@ -1477,7 +1477,7 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}> {
           dbWrite,
           this.#lc,
         );
-        const result: R = await mutatorImpl(tx, ...(args ?? []));
+        const result: R = await mutatorImpl(tx, args);
         throwIfClosed(dbWrite);
         const lastMutationID = await dbWrite.getMutationID();
         const diffs = await dbWrite.commitWithDiffs(

--- a/packages/zero-client/src/client/crud.ts
+++ b/packages/zero-client/src/client/crud.ts
@@ -307,7 +307,7 @@ function defaultOptionalFieldsToNull(
   return rv;
 }
 
-async function insertImpl(
+export async function insertImpl(
   tx: WriteTransaction,
   arg: InsertOp,
   schema: Schema,
@@ -326,7 +326,7 @@ async function insertImpl(
   }
 }
 
-async function upsertImpl(
+export async function upsertImpl(
   tx: WriteTransaction,
   arg: InsertOp | UpsertOp,
   schema: Schema,
@@ -343,7 +343,7 @@ async function upsertImpl(
   await tx.set(key, val);
 }
 
-async function updateImpl(
+export async function updateImpl(
   tx: WriteTransaction,
   arg: UpdateOp,
   schema: Schema,
@@ -367,7 +367,7 @@ async function updateImpl(
   await tx.set(key, next);
 }
 
-async function deleteImpl(
+export async function deleteImpl(
   tx: WriteTransaction,
   arg: DeleteOp,
   schema: Schema,

--- a/packages/zero-client/src/client/custom.test.ts
+++ b/packages/zero-client/src/client/custom.test.ts
@@ -1,29 +1,28 @@
-import {expectTypeOf, test} from 'vitest';
-
+import {expect, expectTypeOf, test} from 'vitest';
 import {schema} from '../../../zql/src/query/test/test-schemas.ts';
 import type {CustomMutatorDefs, MakeCustomMutatorInterfaces} from './custom.ts';
+import {zeroForTest} from './test-utils.ts';
+import {nanoid} from '../util/nanoid.ts';
 type Schema = typeof schema;
 
 test('argument types are preserved on the generated mutator interface', () => {
   const mutators = {
     issue: {
-      setTitle: (tx, id: string, title: string) => {
-        tx.mutate.issue.update({id, title});
-      },
+      setTitle: (tx, id: string, title: string) =>
+        tx.mutate.issue.update({id, title}),
       setProps: (
         tx,
         id: string,
         title: string,
         status: 'open' | 'closed',
         assignee: string,
-      ) => {
+      ) =>
         tx.mutate.issue.update({
           id,
           title,
           closed: status === 'closed',
           ownerId: assignee,
-        });
-      },
+        }),
     },
     nonTableNamespace: {
       doThing: (_tx, _arg1: string, _arg2: number) => {
@@ -47,4 +46,65 @@ test('argument types are preserved on the generated mutator interface', () => {
       readonly doThing: (arg1: string, arg2: number) => void;
     };
   }>();
+});
+
+test('custom mutators write to the local store', async () => {
+  const z = zeroForTest({
+    logLevel: 'debug',
+    schema,
+    mutators: {
+      issue: {
+        setTitle: async (tx, id: string, title: string) => {
+          await tx.mutate.issue.update({id, title});
+        },
+        deleteTwoIssues: async (tx, id1: string, id2: string) => {
+          await Promise.all([
+            tx.mutate.issue.delete({id: id1}),
+            tx.mutate.issue.delete({id: id2}),
+          ]);
+        },
+        create: async tx => {
+          await tx.mutate.issue.insert({
+            id: nanoid(),
+            title: '',
+            closed: false,
+            ownerId: '',
+            description: '',
+          });
+        },
+      },
+      customNamespace: {
+        clown: async (tx, id: string) => {
+          await tx.mutate.issue.update({id, title: '🤡'});
+        },
+      },
+    },
+  });
+
+  await z.mutate.issue.insert({
+    id: '1',
+    title: 'foo',
+    closed: false,
+    ownerId: '',
+    description: '',
+  });
+
+  let issues = z.query.issue.run();
+  expect(issues[0].title).toEqual('foo');
+
+  await z.mutate.issue.setTitle('1', 'bar');
+  issues = z.query.issue.run();
+  expect(issues[0].title).toEqual('bar');
+
+  await z.mutate.customNamespace.clown('1');
+  issues = z.query.issue.run();
+  expect(issues[0].title).toEqual('🤡');
+
+  await z.mutate.issue.create();
+  issues = z.query.issue.run();
+  expect(issues.length).toEqual(2);
+
+  await z.mutate.issue.deleteTwoIssues(issues[0].id, issues[1].id);
+  issues = z.query.issue.run();
+  expect(issues.length).toEqual(0);
 });

--- a/packages/zero-client/src/client/custom.ts
+++ b/packages/zero-client/src/client/custom.ts
@@ -1,7 +1,19 @@
+import {must} from '../../../shared/src/must.ts';
 import type {Schema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import type {TableSchema} from '../../../zero-schema/src/table-schema.ts';
+import type {ReadonlyJSONValue} from '../../../shared/src/json.ts';
 import type {ClientID} from '../types/client-state.ts';
-import type {DeleteID, InsertValue, UpdateValue, UpsertValue} from './crud.ts';
+import {
+  deleteImpl,
+  insertImpl,
+  updateImpl,
+  upsertImpl,
+  type DeleteID,
+  type InsertValue,
+  type UpdateValue,
+  type UpsertValue,
+} from './crud.ts';
+import type {WriteTransaction} from './replicache-types.ts';
 
 /**
  * The shape which a user's custom mutator definitions must conform to.
@@ -20,9 +32,11 @@ export type CustomMutatorDefs<S extends Schema> = {
 
 export type CustomMutatorImpl<S extends Schema> = (
   tx: Transaction<S>,
+  // TODO: many args. See commit: 52657c2f934b4a458d628ea77e56ce92b61eb3c6 which did have many args.
+  // The issue being that it will be a protocol change to support varargs.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ...args: any[]
-) => void;
+  args: any,
+) => Promise<void>;
 
 /**
  * The shape exposed on the `Zero.mutate` instance.
@@ -84,7 +98,7 @@ export type TableCRUD<S extends TableSchema> = {
    * `undefined`. Such fields will be assigned the value `null` optimistically
    * and then the default value as defined by the server.
    */
-  insert: (value: InsertValue<S>) => void;
+  insert: (value: InsertValue<S>) => Promise<void>;
 
   /**
    * Writes a row unconditionally, overwriting any existing row with the same
@@ -92,18 +106,70 @@ export type TableCRUD<S extends TableSchema> = {
    * set to `undefined`. Such fields will be assigned the value `null`
    * optimistically and then the default value as defined by the server.
    */
-  upsert: (value: UpsertValue<S>) => void;
+  upsert: (value: UpsertValue<S>) => Promise<void>;
 
   /**
    * Updates a row with the same primary key. If no such row exists, this
    * function does nothing. All non-primary-key fields can be omitted or set to
    * `undefined`. Such fields will be left unchanged from previous value.
    */
-  update: (value: UpdateValue<S>) => void;
+  update: (value: UpdateValue<S>) => Promise<void>;
 
   /**
    * Deletes the row with the specified primary key. If no such row exists, this
    * function does nothing.
    */
-  delete: (id: DeleteID<S>) => void;
+  delete: (id: DeleteID<S>) => Promise<void>;
 };
+
+export class TransactionImpl implements Transaction<Schema> {
+  constructor(repTx: WriteTransaction, schema: Schema) {
+    must(repTx.reason === 'initial' || repTx.reason === 'rebase');
+    this.clientID = repTx.clientID;
+    this.mutationID = repTx.mutationID;
+    this.reason = repTx.reason === 'initial' ? 'optimistic' : 'rebase';
+    this.mutate = makeSchemaCRUD(schema, repTx);
+  }
+
+  readonly clientID: ClientID;
+  readonly mutationID: number;
+  readonly reason: TransactionReason;
+  readonly mutate: SchemaCRUD<Schema>;
+}
+
+export function makeReplicacheMutator(
+  mutator: CustomMutatorImpl<Schema>,
+  schema: Schema,
+) {
+  return (repTx: WriteTransaction, args: ReadonlyJSONValue): Promise<void> => {
+    const tx = new TransactionImpl(repTx, schema);
+    return mutator(tx, args);
+  };
+}
+
+function makeSchemaCRUD(schema: Schema, tx: WriteTransaction) {
+  const mutate: Record<string, TableCRUD<TableSchema>> = {};
+  for (const [name] of Object.entries(schema.tables)) {
+    mutate[name] = makeTableCRUD(schema, name, tx);
+  }
+  return mutate;
+}
+
+function makeTableCRUD(
+  schema: Schema,
+  tableName: string,
+  tx: WriteTransaction,
+) {
+  const table = must(schema.tables[tableName]);
+  const {primaryKey} = table;
+  return {
+    insert: (value: InsertValue<TableSchema>) =>
+      insertImpl(tx, {op: 'insert', tableName, primaryKey, value}, schema),
+    upsert: (value: UpsertValue<TableSchema>) =>
+      upsertImpl(tx, {op: 'upsert', tableName, primaryKey, value}, schema),
+    update: (value: UpdateValue<TableSchema>) =>
+      updateImpl(tx, {op: 'update', tableName, primaryKey, value}, schema),
+    delete: (id: DeleteID<TableSchema>) =>
+      deleteImpl(tx, {op: 'delete', tableName, primaryKey, value: id}, schema),
+  };
+}

--- a/packages/zero-client/src/client/options.ts
+++ b/packages/zero-client/src/client/options.ts
@@ -9,7 +9,7 @@ import type {CustomMutatorDefs} from './custom.ts';
  */
 export interface ZeroOptions<
   S extends Schema,
-  MD extends CustomMutatorDefs<S> = Record<string, never>,
+  MD extends CustomMutatorDefs<S> | undefined = undefined,
 > {
   /**
    * URL to the zero-cache. This can be a simple hostname, e.g.
@@ -77,7 +77,7 @@ export interface ZeroOptions<
    */
   schema: S;
 
-  mutators?: MD | undefined;
+  mutators?: MD;
 
   /**
    * `onOnlineChange` is called when the Zero instance's online status changes.
@@ -152,7 +152,7 @@ export interface ZeroOptions<
 
 export interface ZeroAdvancedOptions<
   S extends Schema,
-  MD extends CustomMutatorDefs<S> = Record<string, never>,
+  MD extends CustomMutatorDefs<S> | undefined = undefined,
 > extends ZeroOptions<S, MD> {
   /**
    * UI rendering libraries will often provide a utility for batching multiple

--- a/packages/zero-client/src/client/test-utils.ts
+++ b/packages/zero-client/src/client/test-utils.ts
@@ -33,6 +33,7 @@ import {
   exposedToTestingSymbol,
   onSetConnectionStateSymbol,
 } from './zero.ts';
+import type {CustomMutatorDefs} from './custom.ts';
 
 type ConnectionState = Enum<typeof ConnectionState>;
 type ErrorKind = Enum<typeof ErrorKind>;
@@ -69,7 +70,10 @@ export class MockSocket extends EventTarget {
   }
 }
 
-export class TestZero<const S extends Schema> extends Zero<S> {
+export class TestZero<
+  const S extends Schema,
+  MD extends CustomMutatorDefs<S> = CustomMutatorDefs<S>,
+> extends Zero<S, MD> {
   #connectionStateResolvers: Set<{
     state: ConnectionState;
     resolve: (state: ConnectionState) => void;
@@ -206,10 +210,13 @@ declare const TESTING: boolean;
 
 let testZeroCounter = 0;
 
-export function zeroForTest<const S extends Schema>(
-  options: Partial<ZeroOptions<S>> = {},
+export function zeroForTest<
+  const S extends Schema,
+  MD extends CustomMutatorDefs<S> = CustomMutatorDefs<S>,
+>(
+  options: Partial<ZeroOptions<S, MD>> = {},
   errorOnUpdateNeeded = true,
-): TestZero<S> {
+): TestZero<S, MD> {
   // Special case kvStore. If not present we default to 'mem'. This allows
   // passing `undefined` to get the default behavior.
   const newOptions = {...options};
@@ -233,7 +240,7 @@ export function zeroForTest<const S extends Schema>(
         }
       : undefined,
     ...newOptions,
-  } satisfies ZeroOptions<S>);
+  } satisfies ZeroOptions<S, MD>);
 
   return r;
 }

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -113,6 +113,12 @@ import {
 import {getServer} from './server-option.ts';
 import {version} from './version.ts';
 import {PokeHandler} from './zero-poke-handler.ts';
+import {
+  makeReplicacheMutator,
+  type CustomMutatorDefs,
+  type CustomMutatorImpl,
+  type MakeCustomMutatorInterfaces,
+} from './custom.ts';
 
 type ConnectionState = Enum<typeof ConnectionState>;
 type PingResult = Enum<typeof PingResult>;
@@ -148,7 +154,10 @@ interface TestZero {
   }) => LogOptions;
 }
 
-function asTestZero<S extends Schema>(z: Zero<S>): TestZero {
+function asTestZero<
+  S extends Schema,
+  MD extends CustomMutatorDefs<S> | undefined,
+>(z: Zero<S, MD>): TestZero {
   return z as TestZero;
 }
 
@@ -239,7 +248,10 @@ export function getInternalReplicacheImplForTesting<
   return must(internalReplicacheImplMap.get(z)) as ReplicacheImpl<MD>;
 }
 
-export class Zero<const S extends Schema> {
+export class Zero<
+  const S extends Schema,
+  MD extends CustomMutatorDefs<S> | undefined = undefined,
+> {
   readonly version = version;
 
   readonly #rep: ReplicacheImpl<WithCRUD<MutatorDefs>>;
@@ -341,7 +353,7 @@ export class Zero<const S extends Schema> {
   // 2. client successfully connects
   #totalToConnectStart: number | undefined = undefined;
 
-  readonly #options: ZeroOptions<S>;
+  readonly #options: ZeroOptions<S, MD>;
 
   readonly query: MakeEntityQueriesFromSchema<S>;
 
@@ -356,7 +368,7 @@ export class Zero<const S extends Schema> {
   /**
    * Constructs a new Zero client.
    */
-  constructor(options: ZeroOptions<S>) {
+  constructor(options: ZeroOptions<S, MD>) {
     const {
       userID,
       storageKey,
@@ -395,8 +407,19 @@ export class Zero<const S extends Schema> {
     const logOptions = this.#logOptions;
 
     const replicacheMutators = {
-      ['_zero_crud']: makeCRUDMutator(schema),
+      [CRUD_MUTATION_NAME]: makeCRUDMutator(schema),
     };
+
+    for (const [namespace, mutatorsForNamespace] of Object.entries(
+      options.mutators ?? {},
+    )) {
+      for (const [name, mutator] of Object.entries(
+        mutatorsForNamespace as Record<string, CustomMutatorImpl<Schema>>,
+      )) {
+        (replicacheMutators as MutatorDefs)[customMutatorKey(namespace, name)] =
+          makeReplicacheMutator(mutator, schema);
+      }
+    }
 
     this.storageKey = storageKey ?? '';
 
@@ -463,7 +486,24 @@ export class Zero<const S extends Schema> {
     this.#onClientStateNotFound = onClientStateNotFoundCallback;
     this.#rep.onClientStateNotFound = onClientStateNotFoundCallback;
 
-    const {mutate, mutateBatch} = makeCRUDMutate<S>(schema, rep.mutate);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const {mutate, mutateBatch} = makeCRUDMutate<S>(schema, rep.mutate) as any;
+
+    for (const [namespace, mutatorsForNamespace] of Object.entries(
+      options.mutators ?? {},
+    )) {
+      let existing = mutate[namespace];
+      if (existing === undefined) {
+        existing = {};
+        mutate[namespace] = existing;
+      }
+
+      for (const name of Object.keys(
+        mutatorsForNamespace as Record<string, CustomMutatorImpl<Schema>>,
+      )) {
+        existing[name] = must(rep.mutate[customMutatorKey(namespace, name)]);
+      }
+    }
     this.mutate = mutate;
     this.mutateBatch = mutateBatch;
 
@@ -607,7 +647,9 @@ export class Zero<const S extends Schema> {
    * await zero.mutate.issue.update({id: '1', title: 'Updated title'});
    * ```
    */
-  readonly mutate: DBMutator<S>;
+  readonly mutate: MD extends CustomMutatorDefs<S>
+    ? DBMutator<S> & MakeCustomMutatorInterfaces<S, MD>
+    : DBMutator<S>;
 
   /**
    * Provides a way to batch multiple CRUD mutations together:
@@ -1695,3 +1737,7 @@ class TimedOutError extends Error {
 }
 
 class CloseError extends Error {}
+
+function customMutatorKey(namespace: string, name: string) {
+  return `${namespace}.${name}`;
+}


### PR DESCRIPTION
…stance

Additionally:

- mutators are async! Update their signatures
- ~~support varargs to custom mutators~~ edit: going to roll this change back and do it separately.