### PR TITLE
fix(zero-cache): correctly handle multiple-column schema changes

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/change-source.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.pg-test.ts
@@ -525,6 +525,7 @@ describe('change-source/pg', {timeout: 30000}, () => {
     ['ALTER TABLE foo RENAME times TO timez', null],
     ['ALTER TABLE foo DROP COLUMN date', null],
     ['ALTER TABLE foo ALTER COLUMN times TYPE TIMESTAMPTZ[]', null],
+    ['ALTER TABLE foo ALTER COLUMN int SET NOT NULL', null],
     [
       // Rename column and rename back
       'ALTER TABLE foo RENAME times TO timez',
@@ -574,7 +575,7 @@ describe('change-source/pg', {timeout: 30000}, () => {
         const downstream = drainToQueue(changes);
 
         // This statement should be successfully converted to Changes.
-        await upstream`INSERT INTO foo(id) VALUES('hello')`;
+        await upstream`INSERT INTO foo(id, int) VALUES('hello', 0)`;
         expect(await downstream.dequeue()).toMatchObject([
           'begin',
           {tag: 'begin'},
@@ -594,8 +595,8 @@ describe('change-source/pg', {timeout: 30000}, () => {
         // effectively freeze replication.
         await upstream.begin(async tx => {
           await tx.unsafe(before);
-          await tx`INSERT INTO foo(id) VALUES('wide')`;
-          await tx`INSERT INTO foo(id) VALUES('world')`;
+          await tx`INSERT INTO foo(id, int) VALUES('wide', 1)`;
+          await tx`INSERT INTO foo(id, int) VALUES('world', 2)`;
           if (after) {
             await tx.unsafe(after);
           }


### PR DESCRIPTION
The previous schema change logic relied on the assumption that for an `ALTER TABLE` statement, only one column change can happen at a time. This is incorrect, as multiple column actions can be present in the statement. 

The corrected logic leverages the tables' `oid` and associated columns' `attnum` values to determine the diffs that need to be applied to the replica. As such, it no longer needs to know what the DDL command was (e.g. `ALTER TABLE` vs `ALTER PUBLICATION`).

https://discord.com/channels/830183651022471199/1333484736814776360/1333497466363973642

Tangential: Also fix the degraded-mode schema change detection logic (e.g. supabase, neon) to detect changes in the columns' NOT NULL attribute.