### PR TITLE
fix(zero-cache): handle subscribers ahead of the change-streamer change-log

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/error-type-enum.ts
+++ b/packages/zero-cache/src/services/change-streamer/error-type-enum.ts
@@ -3,9 +3,7 @@
 export const Unknown = 0;
 export const WrongReplicaVersion = 1;
 export const WatermarkTooOld = 2;
-export const WatermarkNotFound = 3;
 
 export type Unknown = typeof Unknown;
 export type WrongReplicaVersion = typeof WrongReplicaVersion;
 export type WatermarkTooOld = typeof WatermarkTooOld;
-export type WatermarkNotFound = typeof WatermarkNotFound;

--- a/packages/zero-cache/src/services/change-streamer/storer.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.pg-test.ts
@@ -215,22 +215,6 @@ describe('change-streamer/storer', () => {
     ]);
   });
 
-  test('watermark not found', async () => {
-    // '123' is some watermark from the future.
-    const [sub, _, stream] = createSubscriber('123');
-    storer.catchup(sub);
-
-    expect(await drain(stream)).toEqual([
-      [
-        'error',
-        {
-          type: ErrorType.WatermarkNotFound,
-          message: 'cannot catch up from requested watermark 123',
-        },
-      ],
-    ]);
-  });
-
   test('queued if transaction in progress', async () => {
     const [sub1, _0, stream1] = createSubscriber('03');
     const [sub2, _1, stream2] = createSubscriber('06');


### PR DESCRIPTION
Because the `change-streamer` forwards messages to view-syncers immediately, and concurrently stores and acks upstream, it is possible for a replica to be ahead of the change log if a server is killed before the change can be stored. 

Handle this case by considering the subscriber "caught up" if it is ahead of the change log. The existing forwarder logic already handles filtering out messages that have already been seen.

https://discord.com/channels/830183651022471199/1288232858795769917/1334328586265563260

https://discord.com/channels/830183651022471199/1332721644527157319