### PR TITLE
chore(replicache): Add onClientsDeleted callback

### DIFF
--- a/packages/replicache/src/persist/client-gc.test.ts
+++ b/packages/replicache/src/persist/client-gc.test.ts
@@ -76,8 +76,8 @@ test('initClientGC starts 5 min interval that collects clients that have been in
     'client1',
     dagStore,
     CLIENT_MAX_INACTIVE_TIME,
-    onClientsDeleted,
     GC_INTERVAL,
+    onClientsDeleted,
     new LogContext(),
     controller.signal,
   );

--- a/packages/replicache/src/persist/client-gc.test.ts
+++ b/packages/replicache/src/persist/client-gc.test.ts
@@ -1,6 +1,6 @@
 import {LogContext} from '@rocicorp/logger';
 import {type SinonFakeTimers, useFakeTimers} from 'sinon';
-import {afterEach, beforeEach, expect, test} from 'vitest';
+import {afterEach, beforeEach, expect, test, vi} from 'vitest';
 import {assertNotUndefined} from '../../../shared/src/asserts.ts';
 import type {Read} from '../dag/store.ts';
 import {TestStore} from '../dag/test-store.ts';
@@ -13,7 +13,12 @@ import {
   initClientGC,
 } from './client-gc.ts';
 import {makeClientV4, setClientsForTesting} from './clients-test-helpers.ts';
-import {type ClientMap, getClients, setClient} from './clients.ts';
+import {
+  type ClientMap,
+  getClients,
+  type OnClientsDeleted,
+  setClient,
+} from './clients.ts';
 
 let clock: SinonFakeTimers;
 const START_TIME = 0;
@@ -66,10 +71,12 @@ test('initClientGC starts 5 min interval that collects clients that have been in
   await setClientsForTesting(clientMap, dagStore);
 
   const controller = new AbortController();
+  const onClientsDeleted = vi.fn<OnClientsDeleted>();
   initClientGC(
     'client1',
     dagStore,
     CLIENT_MAX_INACTIVE_TIME,
+    onClientsDeleted,
     GC_INTERVAL,
     new LogContext(),
     controller.signal,
@@ -96,6 +103,9 @@ test('initClientGC starts 5 min interval that collects clients that have been in
       client4,
     });
   });
+  expect(onClientsDeleted).toHaveBeenCalledTimes(1);
+  expect(onClientsDeleted).toHaveBeenCalledWith(['client2']);
+  onClientsDeleted.mockClear();
 
   // Update client4's heartbeat to now
   const client4WUpdatedHeartbeat = {
@@ -120,6 +130,9 @@ test('initClientGC starts 5 min interval that collects clients that have been in
       client4: client4WUpdatedHeartbeat,
     });
   });
+  expect(onClientsDeleted).toHaveBeenCalledTimes(1);
+  expect(onClientsDeleted).toHaveBeenCalledWith(['client3']);
+  onClientsDeleted.mockClear();
 
   clock.tick(24 * HOURS - 5 * MINUTES * 2 + 1);
   await clock.tickAsync(5 * MINUTES);
@@ -133,4 +146,6 @@ test('initClientGC starts 5 min interval that collects clients that have been in
       client1,
     });
   });
+  expect(onClientsDeleted).toHaveBeenCalledTimes(1);
+  expect(onClientsDeleted).toHaveBeenCalledWith(['client4']);
 });

--- a/packages/replicache/src/persist/client-gc.ts
+++ b/packages/replicache/src/persist/client-gc.ts
@@ -27,8 +27,8 @@ export function initClientGC(
   clientID: ClientID,
   dagStore: Store,
   clientMaxInactiveTime: number,
-  onClientsDeleted: OnClientsDeleted,
   gcInterval: number,
+  onClientsDeleted: OnClientsDeleted,
   lc: LogContext,
   signal: AbortSignal,
 ): void {

--- a/packages/replicache/src/persist/clients.test.ts
+++ b/packages/replicache/src/persist/clients.test.ts
@@ -18,7 +18,7 @@ import {deepFreeze} from '../frozen-json.ts';
 import {assertHash, fakeHash, newRandomHash} from '../hash.ts';
 import type {IndexDefinitions} from '../index-defs.ts';
 import type {ClientGroupID, ClientID} from '../sync/ids.ts';
-import {withRead, withWriteNoImplicitCommit} from '../with-transactions.ts';
+import {withRead, withWrite} from '../with-transactions.ts';
 import {
   type ClientGroup,
   getClientGroup,
@@ -295,9 +295,8 @@ test('getClient', async () => {
 
 test('updateClients throws errors if clients head exist but the chunk it references does not', async () => {
   const dagStore = new TestStore();
-  await withWriteNoImplicitCommit(dagStore, async (write: Write) => {
+  await withWrite(dagStore, async (write: Write) => {
     await write.setHead('clients', randomStuffHash);
-    await write.commit();
   });
   await withRead(dagStore, async (read: Read) => {
     let e;
@@ -312,7 +311,7 @@ test('updateClients throws errors if clients head exist but the chunk it referen
 
 test('updateClients throws errors if chunk pointed to by clients head does not contain a valid ClientMap', async () => {
   const dagStore = new TestStore();
-  await withWriteNoImplicitCommit(dagStore, async (write: Write) => {
+  await withWrite(dagStore, async (write: Write) => {
     const headHash = headClient1Hash;
     const chunk = write.createChunk(
       deepFreeze({
@@ -326,7 +325,6 @@ test('updateClients throws errors if chunk pointed to by clients head does not c
       write.putChunk(chunk),
       write.setHead('clients', chunk.hash),
     ]);
-    await write.commit();
   });
   await withRead(dagStore, async (read: Read) => {
     let e;
@@ -393,9 +391,8 @@ test('setClient', async () => {
   const dagStore = new TestStore();
 
   const t = async (clientID: ClientID, client: ClientV5) => {
-    await withWriteNoImplicitCommit(dagStore, async (write: Write) => {
+    await withWrite(dagStore, async (write: Write) => {
       await setClient(clientID, client, write);
-      await write.commit();
     });
 
     await withRead(dagStore, async (read: Read) => {
@@ -439,10 +436,9 @@ test('getClientGroupID', async () => {
     expectedClientGroupID: ClientGroupID | undefined,
     expectedClientGroup: ClientGroup | undefined,
   ) => {
-    await withWriteNoImplicitCommit(dagStore, async write => {
+    await withWrite(dagStore, async write => {
       await setClient(clientID, client, write);
       await setClientGroup(clientGroupID, clientGroup, write);
-      await write.commit();
     });
 
     const actualClientGroupID = await withRead(dagStore, read =>
@@ -545,7 +541,7 @@ describe('findMatchingClient', () => {
     await b.addGenesis(clientID);
     await b.addLocal(clientID, []);
 
-    await withWriteNoImplicitCommit(perdag, async write => {
+    await withWrite(perdag, async write => {
       const client: ClientV5 = {
         clientGroupID,
         headHash: b.chain[1].chunk.hash,
@@ -563,8 +559,6 @@ describe('findMatchingClient', () => {
         disabled: initialDisabled,
       };
       await setClientGroup(clientGroupID, clientGroup, write);
-
-      await write.commit();
     });
 
     await withRead(perdag, async read => {
@@ -646,9 +640,8 @@ describe('findMatchingClient', () => {
       mutatorNames: initialMutatorNames,
       disabled: false,
     };
-    await withWriteNoImplicitCommit(perdag, async write => {
+    await withWrite(perdag, async write => {
       await setClientGroup(clientGroupID, clientGroup, write);
-      await write.commit();
     });
 
     await chainBuilder.removeHead();
@@ -736,10 +729,9 @@ describe('initClientV6', () => {
           disabled: false,
         };
 
-        await withWriteNoImplicitCommit(perdag, async write => {
+        await withWrite(perdag, async write => {
           await setClient(clientID1, client1, write);
           await setClientGroup(clientGroupID, clientGroup1, write);
-          await write.commit();
         });
 
         const clientID2 = makeClientID();
@@ -820,10 +812,9 @@ describe('initClientV6', () => {
           disabled: false,
         };
 
-        await withWriteNoImplicitCommit(perdag, async write => {
+        await withWrite(perdag, async write => {
           await setClient(clientID1, client1, write);
           await setClientGroup(clientGroupID1, clientGroup1, write);
-          await write.commit();
         });
 
         const clientID2 = makeClientID();
@@ -938,10 +929,9 @@ describe('initClientV6', () => {
           disabled: false,
         };
 
-        await withWriteNoImplicitCommit(perdag, async write => {
+        await withWrite(perdag, async write => {
           await setClient(clientID1, client1, write);
           await setClientGroup(clientGroupID1, clientGroup1, write);
-          await write.commit();
         });
 
         const clientID2 = makeClientID();

--- a/packages/replicache/src/persist/clients.ts
+++ b/packages/replicache/src/persist/clients.ts
@@ -604,3 +604,8 @@ export async function setClients(
   await dagWrite.setHead(CLIENTS_HEAD_NAME, chunk.hash);
   return chunk.hash;
 }
+
+/**
+ * Callback function for when Replicache has deleted one or more clients.
+ */
+export type OnClientsDeleted = (clientIDs: ClientID[]) => void;

--- a/packages/replicache/src/persist/collect-idb-databases.test.ts
+++ b/packages/replicache/src/persist/collect-idb-databases.test.ts
@@ -9,7 +9,6 @@ import {fakeHash} from '../hash.ts';
 import {IDBStore} from '../kv/idb-store.ts';
 import {hasMemStore} from '../kv/mem-store.ts';
 import {TestMemStore} from '../kv/test-mem-store.ts';
-import type {OnClientsDeleted} from '../replicache-impl.ts';
 import {getKVStoreProvider} from '../replicache.ts';
 import type {ClientID} from '../sync/ids.ts';
 import {withWrite} from '../with-transactions.ts';
@@ -19,7 +18,7 @@ import {
   makeClientMapDD31,
   setClientsForTesting,
 } from './clients-test-helpers.ts';
-import type {ClientMap} from './clients.ts';
+import type {ClientMap, OnClientsDeleted} from './clients.ts';
 import {
   collectIDBDatabases,
   dropAllDatabases,

--- a/packages/replicache/src/persist/collect-idb-databases.test.ts
+++ b/packages/replicache/src/persist/collect-idb-databases.test.ts
@@ -1,6 +1,6 @@
 import {LogContext} from '@rocicorp/logger';
 import {type SinonFakeTimers, useFakeTimers} from 'sinon';
-import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {assertNotUndefined} from '../../../shared/src/asserts.ts';
 import type {Store} from '../dag/store.ts';
 import {TestStore} from '../dag/test-store.ts';
@@ -9,8 +9,10 @@ import {fakeHash} from '../hash.ts';
 import {IDBStore} from '../kv/idb-store.ts';
 import {hasMemStore} from '../kv/mem-store.ts';
 import {TestMemStore} from '../kv/test-mem-store.ts';
+import type {OnClientsDeleted} from '../replicache-impl.ts';
 import {getKVStoreProvider} from '../replicache.ts';
-import {withWrite, withWriteNoImplicitCommit} from '../with-transactions.ts';
+import type {ClientID} from '../sync/ids.ts';
+import {withWrite} from '../with-transactions.ts';
 import {makeClientGroupMap} from './client-groups.test.ts';
 import {type ClientGroupMap, setClientGroups} from './client-groups.ts';
 import {
@@ -62,63 +64,61 @@ describe('collectIDBDatabases', () => {
     lastOpenedTimestampMS,
   });
 
-  const NO_LEGACY = [false];
-  const INCLUDE_LEGACY = [false, true];
-
   const t = (
     name: string,
     entries: Entries,
     now: number,
     expectedDatabases: string[],
-    legacyValues = INCLUDE_LEGACY,
+    expectedClientsDeleted?: ClientID[],
   ) => {
-    for (const legacy of legacyValues) {
-      test(name + ' > time ' + now + (legacy ? ' > legacy' : ''), async () => {
-        const store = new IDBDatabasesStore(_ => new TestMemStore());
-        const dropStore = (name: string) => store.deleteDatabases([name]);
-        const clientDagStores = new Map<IndexedDBName, Store>();
-        for (const [db, clients, clientGroups] of entries) {
-          const dagStore = new TestStore();
-          clientDagStores.set(db.name, dagStore);
-          if (legacy) {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const {lastOpenedTimestampMS: _, ...rest} = db;
-            await store.putDatabaseForTesting(rest);
-          } else {
-            await store.putDatabaseForTesting(db);
-          }
+    test(name + ' > time ' + now, async () => {
+      const store = new IDBDatabasesStore(_ => new TestMemStore());
+      const dropStore = (name: string) => store.deleteDatabases([name]);
+      const clientDagStores = new Map<IndexedDBName, Store>();
+      for (const [db, clients, clientGroups] of entries) {
+        const dagStore = new TestStore();
+        clientDagStores.set(db.name, dagStore);
 
-          await setClientsForTesting(clients, dagStore);
-          if (clientGroups) {
-            await withWriteNoImplicitCommit(dagStore, async tx => {
-              await setClientGroups(clientGroups, tx);
-              await tx.commit();
-            });
-          }
+        await store.putDatabaseForTesting(db);
+
+        await setClientsForTesting(clients, dagStore);
+        if (clientGroups) {
+          await withWrite(dagStore, async tx => {
+            await setClientGroups(clientGroups, tx);
+          });
         }
+      }
 
-        const newDagStore = (name: string) => {
-          const dagStore = clientDagStores.get(name);
-          assertNotUndefined(dagStore);
-          return dagStore;
-        };
+      const newDagStore = (name: string) => {
+        const dagStore = clientDagStores.get(name);
+        assertNotUndefined(dagStore);
+        return dagStore;
+      };
 
-        const maxAge = 1000;
+      const maxAge = 1000;
 
-        await collectIDBDatabases(
-          store,
-          now,
-          maxAge,
-          maxAge,
-          dropStore,
-          newDagStore,
+      const onClientsDeleted = vi.fn<OnClientsDeleted>();
+
+      await collectIDBDatabases(
+        store,
+        now,
+        maxAge,
+        dropStore,
+        onClientsDeleted,
+        newDagStore,
+      );
+
+      expect(Object.keys(await store.getDatabases())).to.deep.equal(
+        expectedDatabases,
+      );
+
+      if (expectedClientsDeleted) {
+        expect(onClientsDeleted).toHaveBeenCalledOnce();
+        expect(onClientsDeleted).toHaveBeenLastCalledWith(
+          expectedClientsDeleted,
         );
-
-        expect(Object.keys(await store.getDatabases())).to.deep.equal(
-          expectedDatabases,
-        );
-      });
-    }
+      }
+    });
   };
 
   t('empty', [], 0, []);
@@ -261,26 +261,6 @@ describe('collectIDBDatabases', () => {
         makeIndexedDBDatabase({
           name: 'a',
           lastOpenedTimestampMS: 0,
-          replicacheFormatVersion: FormatVersion.SDD - 1,
-        }),
-        makeClientMapDD31({
-          clientA1: {
-            headHash: fakeHash('a1'),
-            heartbeatTimestampMs: 0,
-          },
-        }),
-      ],
-    ];
-    t('one idb, one client, old format version', entries, 0, ['a']);
-    t('one idb, one client, old format version', entries, 1000, []);
-  }
-
-  {
-    const entries: Entries = [
-      [
-        makeIndexedDBDatabase({
-          name: 'a',
-          lastOpenedTimestampMS: 0,
           replicacheFormatVersion: FormatVersion.V6,
         }),
         makeClientMapDD31({
@@ -303,33 +283,194 @@ describe('collectIDBDatabases', () => {
         }),
       ],
     ];
+    t('one idb, one client, with pending mutations', entries, 0, ['a']);
+    t('one idb, one client, with pending mutations', entries, 1000, ['a']);
+    t('one idb, one client, with pending mutations', entries, 2000, ['a']);
+    t('one idb, one client, with pending mutations', entries, 5000, ['a']);
+  }
+
+  {
+    const entries: Entries = [
+      [
+        makeIndexedDBDatabase({name: 'a', lastOpenedTimestampMS: 0}),
+        makeClientMapDD31({
+          clientA1: {
+            headHash: fakeHash('a1'),
+            heartbeatTimestampMs: 0,
+            clientGroupID: 'clientGroupA1',
+          },
+        }),
+        makeClientGroupMap({
+          clientGroupA1: {
+            headHash: fakeHash('a1'),
+            mutationIDs: {
+              clientA1: 2,
+            },
+            lastServerAckdMutationIDs: {
+              clientA1: 2,
+            },
+          },
+        }),
+      ],
+    ];
+
     t(
-      'one idb, one client, with pending mutations',
+      'one idb with one client without any pending mutations should call onClientIDsDeleted',
       entries,
-      0,
-      ['a'],
-      NO_LEGACY,
+      5000,
+      [],
+      ['clientA1'],
     );
+  }
+
+  {
+    const entries: Entries = [
+      [
+        makeIndexedDBDatabase({name: 'a', lastOpenedTimestampMS: 0}),
+        makeClientMapDD31({
+          clientA1: {
+            headHash: fakeHash('a1'),
+            heartbeatTimestampMs: 0,
+            clientGroupID: 'clientGroupA1',
+          },
+          clientA2: {
+            headHash: fakeHash('a2'),
+            heartbeatTimestampMs: 0,
+            clientGroupID: 'clientGroupA1',
+          },
+        }),
+        makeClientGroupMap({
+          clientGroupA1: {
+            headHash: fakeHash('a1'),
+            mutationIDs: {
+              clientA1: 2,
+              clientA2: 5,
+            },
+            lastServerAckdMutationIDs: {
+              clientA1: 2,
+              clientA2: 5,
+            },
+          },
+        }),
+      ],
+    ];
+
     t(
-      'one idb, one client, with pending mutations',
+      'one idb with two clients without any pending mutations should call onClientIDsDeleted',
       entries,
-      1000,
-      ['a'],
-      NO_LEGACY,
+      5000,
+      [],
+      ['clientA1', 'clientA2'],
     );
+  }
+
+  {
+    const entries: Entries = [
+      [
+        makeIndexedDBDatabase({name: 'a', lastOpenedTimestampMS: 0}),
+        makeClientMapDD31({
+          clientA1: {
+            headHash: fakeHash('a1'),
+            heartbeatTimestampMs: 0,
+            clientGroupID: 'clientGroupA1',
+          },
+        }),
+        makeClientGroupMap({
+          clientGroupA1: {
+            headHash: fakeHash('a1'),
+            mutationIDs: {
+              clientA1: 2,
+            },
+            lastServerAckdMutationIDs: {
+              clientA1: 2,
+            },
+          },
+        }),
+      ],
+      [
+        makeIndexedDBDatabase({name: 'b', lastOpenedTimestampMS: 0}),
+        makeClientMapDD31({
+          clientB1: {
+            headHash: fakeHash('b1'),
+            heartbeatTimestampMs: 0,
+            clientGroupID: 'clientGroupB1',
+          },
+        }),
+        makeClientGroupMap({
+          clientGroupB1: {
+            headHash: fakeHash('b1'),
+            mutationIDs: {
+              clientB1: 2,
+            },
+            lastServerAckdMutationIDs: {
+              clientB1: 2,
+            },
+          },
+        }),
+      ],
+    ];
+
     t(
-      'one idb, one client, with pending mutations',
+      'two idb with one client in each without any pending mutations should call onClientIDsDeleted',
       entries,
-      2000,
-      ['a'],
-      NO_LEGACY,
+      5000,
+      [],
+      ['clientA1', 'clientB1'],
     );
+  }
+
+  {
+    const entries: Entries = [
+      [
+        makeIndexedDBDatabase({name: 'a', lastOpenedTimestampMS: 0}),
+        makeClientMapDD31({
+          clientA1: {
+            headHash: fakeHash('a1'),
+            heartbeatTimestampMs: 0,
+            clientGroupID: 'clientGroupA1',
+          },
+        }),
+        makeClientGroupMap({
+          clientGroupA1: {
+            headHash: fakeHash('a1'),
+            mutationIDs: {
+              clientA1: 2,
+            },
+            lastServerAckdMutationIDs: {
+              clientA1: 1,
+            },
+          },
+        }),
+      ],
+      [
+        makeIndexedDBDatabase({name: 'b', lastOpenedTimestampMS: 0}),
+        makeClientMapDD31({
+          clientB1: {
+            headHash: fakeHash('b1'),
+            heartbeatTimestampMs: 0,
+            clientGroupID: 'clientGroupB1',
+          },
+        }),
+        makeClientGroupMap({
+          clientGroupB1: {
+            headHash: fakeHash('b1'),
+            mutationIDs: {
+              clientB1: 2,
+            },
+            lastServerAckdMutationIDs: {
+              clientB1: 2,
+            },
+          },
+        }),
+      ],
+    ];
+
     t(
-      'one idb, one client, with pending mutations',
+      'two idb with one client in each, one client has pending mutations should call onClientIDsDeleted',
       entries,
       5000,
       ['a'],
-      NO_LEGACY,
+      ['clientB1'],
     );
   }
 });

--- a/packages/replicache/src/persist/collect-idb-databases.ts
+++ b/packages/replicache/src/persist/collect-idb-databases.ts
@@ -37,9 +37,9 @@ export function initCollectIDBDatabases(
   collectInterval: number,
   initialCollectDelay: number,
   maxAge: number,
+  onClientsDeleted: OnClientsDeleted,
   lc: LogContext,
   signal: AbortSignal,
-  onClientsDeleted: OnClientsDeleted,
 ): void {
   let initial = true;
   initBgIntervalProcess(

--- a/packages/replicache/src/persist/collect-idb-databases.ts
+++ b/packages/replicache/src/persist/collect-idb-databases.ts
@@ -9,7 +9,6 @@ import {assertHash, newRandomHash} from '../hash.ts';
 import {IDBStore} from '../kv/idb-store.ts';
 import type {DropStore, StoreProvider} from '../kv/store.ts';
 import {createLogContext} from '../log-options.ts';
-import type {OnClientsDeleted} from '../replicache-impl.ts';
 import {getKVStoreProvider} from '../replicache.ts';
 import type {ClientID} from '../sync/ids.ts';
 import {withRead} from '../with-transactions.ts';
@@ -17,6 +16,7 @@ import {
   clientGroupHasPendingMutations,
   getClientGroups,
 } from './client-groups.ts';
+import type {OnClientsDeleted} from './clients.ts';
 import {getClients} from './clients.ts';
 import type {IndexedDBDatabase} from './idb-databases-store.ts';
 import {IDBDatabasesStore} from './idb-databases-store.ts';

--- a/packages/replicache/src/persist/collect-idb-databases.ts
+++ b/packages/replicache/src/persist/collect-idb-databases.ts
@@ -163,7 +163,9 @@ function gatherDatabaseInfoForCollect(
   now: number,
   maxAge: number,
   newDagStore: typeof defaultNewDagStore,
-): MaybePromise<[canCollect: false] | [canCollect: true, ClientID[]]> {
+): MaybePromise<
+  [canCollect: false] | [canCollect: true, clientIDs: ClientID[]]
+> {
   if (db.replicacheFormatVersion > FormatVersion.Latest) {
     return [false];
   }
@@ -286,7 +288,7 @@ export function deleteAllReplicacheData(
  */
 function gatherPendingMutationsInClientGroups(
   perdag: Store,
-): Promise<[canCollect: false] | [canCollect: true, ClientID[]]> {
+): Promise<[canCollect: false] | [canCollect: true, clientIDs: ClientID[]]> {
   return withRead(perdag, async read => {
     const clientGroups = await getClientGroups(read);
     for (const clientGroup of clientGroups.values()) {

--- a/packages/replicache/src/persist/collect-idb-databases.ts
+++ b/packages/replicache/src/persist/collect-idb-databases.ts
@@ -1,5 +1,6 @@
 import type {LogContext, LogLevel, LogSink} from '@rocicorp/logger';
 import {assert} from '../../../shared/src/asserts.ts';
+import type {MaybePromise} from '../../../shared/src/types.ts';
 import {initBgIntervalProcess} from '../bg-interval.ts';
 import {StoreImpl} from '../dag/store-impl.ts';
 import type {Store} from '../dag/store.ts';
@@ -8,13 +9,15 @@ import {assertHash, newRandomHash} from '../hash.ts';
 import {IDBStore} from '../kv/idb-store.ts';
 import type {DropStore, StoreProvider} from '../kv/store.ts';
 import {createLogContext} from '../log-options.ts';
+import type {OnClientsDeleted} from '../replicache-impl.ts';
 import {getKVStoreProvider} from '../replicache.ts';
+import type {ClientID} from '../sync/ids.ts';
 import {withRead} from '../with-transactions.ts';
 import {
   clientGroupHasPendingMutations,
   getClientGroups,
 } from './client-groups.ts';
-import {type ClientMap, getClients} from './clients.ts';
+import {getClients} from './clients.ts';
 import type {IndexedDBDatabase} from './idb-databases-store.ts';
 import {IDBDatabasesStore} from './idb-databases-store.ts';
 
@@ -22,17 +25,6 @@ import {IDBDatabasesStore} from './idb-databases-store.ts';
  * How frequently to try to collect
  */
 export const COLLECT_IDB_INTERVAL = 12 * 60 * 60 * 1000; // 12 hours
-
-/**
- * If an IDB database is older than MAX_AGE, then it can be collected.
- */
-export const SDD_IDB_MAX_AGE = 30 * 24 * 60 * 60 * 1000; // 1 month
-
-/**
- * If an IDB database is older than DD31_MAX_AGE **and** has no pending
- * mutations, then it can be collected.
- */
-export const DD31_IDB_MAX_AGE = 14 * 24 * 60 * 60 * 1000; // 2 weeks
 
 /**
  * We delay the initial collection to prevent doing it at startup.
@@ -44,10 +36,10 @@ export function initCollectIDBDatabases(
   kvDropStore: DropStore,
   collectInterval: number,
   initialCollectDelay: number,
-  sddMaxAge: number,
-  dd31MaxAge: number,
+  maxAge: number,
   lc: LogContext,
   signal: AbortSignal,
+  onClientsDeleted: OnClientsDeleted,
 ): void {
   let initial = true;
   initBgIntervalProcess(
@@ -56,9 +48,9 @@ export function initCollectIDBDatabases(
       await collectIDBDatabases(
         idbDatabasesStore,
         Date.now(),
-        sddMaxAge,
-        dd31MaxAge,
+        maxAge,
         kvDropStore,
+        onClientsDeleted,
       );
     },
     () => {
@@ -79,35 +71,44 @@ export function initCollectIDBDatabases(
 export async function collectIDBDatabases(
   idbDatabasesStore: IDBDatabasesStore,
   now: number,
-  sddMaxAge: number,
-  dd31MaxAge: number,
+  maxAge: number,
   kvDropStore: DropStore,
+  onClientsDeleted: OnClientsDeleted,
   newDagStore = defaultNewDagStore,
 ): Promise<void> {
   const databases = await idbDatabasesStore.getDatabases();
 
   const dbs = Object.values(databases) as IndexedDBDatabase[];
-  const canCollectResults = await Promise.all(
+  const collectResults = await Promise.all(
     dbs.map(
       async db =>
         [
           db.name,
-          await canCollectDatabase(db, now, sddMaxAge, dd31MaxAge, newDagStore),
+          await gatherDatabaseInfoForCollect(db, now, maxAge, newDagStore),
         ] as const,
     ),
   );
 
-  const namesToRemove = canCollectResults
-    .filter(result => result[1])
-    .map(result => result[0]);
+  const dbNamesToRemove: string[] = [];
+  const clientIDsToRemove: ClientID[] = [];
+  for (const [dbName, [canCollect, clientIDs]] of collectResults) {
+    if (canCollect) {
+      dbNamesToRemove.push(dbName);
+      clientIDsToRemove.push(...clientIDs);
+    }
+  }
 
   const {errors} = await dropDatabases(
     idbDatabasesStore,
-    namesToRemove,
+    dbNamesToRemove,
     kvDropStore,
   );
   if (errors.length) {
     throw errors[0];
+  }
+
+  if (clientIDsToRemove.length) {
+    onClientsDeleted(clientIDsToRemove);
   }
 }
 
@@ -152,62 +153,37 @@ function defaultNewDagStore(name: string): Store {
   return new StoreImpl(perKvStore, newRandomHash, assertHash);
 }
 
-async function canCollectDatabase(
+/**
+ * If the database is older than maxAge and there are no pending mutations we
+ * return `true` and an array of the clientIDs in that db. If the database is
+ * too new or there are pending mutations we return `[false]`.
+ */
+function gatherDatabaseInfoForCollect(
   db: IndexedDBDatabase,
   now: number,
-  sddMaxAge: number,
-  dd31MaxAge: number,
+  maxAge: number,
   newDagStore: typeof defaultNewDagStore,
-): Promise<boolean> {
+): MaybePromise<[canCollect: false] | [canCollect: true, ClientID[]]> {
   if (db.replicacheFormatVersion > FormatVersion.Latest) {
-    return false;
+    return [false];
   }
 
   // 0 is used in testing
-  if (db.lastOpenedTimestampMS !== undefined) {
-    const isDD31 = db.replicacheFormatVersion >= FormatVersion.DD31;
+  assert(db.lastOpenedTimestampMS !== undefined);
 
-    // - For SDD we can delete the database if it is older than maxAge.
-    // - For DD31 we can delete the database if it is older than dd31MaxAge and
-    //   there are no pending mutations.
-    if (now - db.lastOpenedTimestampMS < (isDD31 ? dd31MaxAge : sddMaxAge)) {
-      return false;
-    }
-
-    if (!isDD31) {
-      return true;
-    }
-
-    // If increase the format version we need to decide how to deal with this
-    // logic.
-    assert(
-      db.replicacheFormatVersion === FormatVersion.DD31 ||
-        db.replicacheFormatVersion === FormatVersion.V6 ||
-        db.replicacheFormatVersion === FormatVersion.V7,
-    );
-    return !(await anyPendingMutationsInClientGroups(newDagStore(db.name)));
+  // - For DD31 we can delete the database if it is older than maxAge and
+  //   there are no pending mutations.
+  if (now - db.lastOpenedTimestampMS < maxAge) {
+    return [false];
   }
-
-  // For legacy databases we do not have a lastOpenedTimestampMS so we check the
-  // time stamps of the clients
-  const perdag = newDagStore(db.name);
-  const clientMap = await withRead(perdag, getClients);
-  await perdag.close();
-
-  return allClientsOlderThan(clientMap, now, sddMaxAge);
-}
-
-function allClientsOlderThan(
-  clients: ClientMap,
-  now: number,
-  maxAge: number,
-): boolean {
-  for (const client of clients.values()) {
-    if (now - client.heartbeatTimestampMs < maxAge) {
-      return false;
-    }
-  }
-  return true;
+  // If increase the format version we need to decide how to deal with this
+  // logic.
+  assert(
+    db.replicacheFormatVersion === FormatVersion.DD31 ||
+      db.replicacheFormatVersion === FormatVersion.V6 ||
+      db.replicacheFormatVersion === FormatVersion.V7,
+  );
+  return gatherPendingMutationsInClientGroups(newDagStore(db.name));
 }
 
 /**
@@ -303,14 +279,23 @@ export function deleteAllReplicacheData(
   return dropAllDatabases(opts);
 }
 
-async function anyPendingMutationsInClientGroups(
+/**
+ * If the there are pending mutations in any of the clients in this db we return
+ * `[false]`. Otherwise we return `true` and an array of the clientIDs to
+ * remove.
+ */
+function gatherPendingMutationsInClientGroups(
   perdag: Store,
-): Promise<boolean> {
-  const clientGroups = await withRead(perdag, getClientGroups);
-  for (const clientGroup of clientGroups.values()) {
-    if (clientGroupHasPendingMutations(clientGroup)) {
-      return true;
+): Promise<[canCollect: false] | [canCollect: true, ClientID[]]> {
+  return withRead(perdag, async read => {
+    const clientGroups = await getClientGroups(read);
+    for (const clientGroup of clientGroups.values()) {
+      if (clientGroupHasPendingMutations(clientGroup)) {
+        return [false];
+      }
     }
-  }
-  return false;
+
+    const clients = await getClients(read);
+    return [true, [...clients.keys()]];
+  });
 }

--- a/packages/replicache/src/replicache-impl.ts
+++ b/packages/replicache/src/replicache-impl.ts
@@ -63,7 +63,6 @@ import {
   COLLECT_IDB_INTERVAL,
   initCollectIDBDatabases,
   INITIAL_COLLECT_IDB_DELAY,
-  SDD_IDB_MAX_AGE,
 } from './persist/collect-idb-databases.ts';
 import {HEARTBEAT_INTERVAL, startHeartbeats} from './persist/heartbeat.ts';
 import {
@@ -160,6 +159,11 @@ export interface MakeSubscriptionsManager {
   (queryInternal: QueryInternal, lc: LogContext): SubscriptionsManager;
 }
 
+/**
+ * Callback function for when Replicache has deleted one or more clients.
+ */
+export type OnClientsDeleted = (clientIDs: ClientID[]) => void;
+
 export interface ReplicacheImplOptions {
   /**
    * Defaults to true.
@@ -192,6 +196,11 @@ export interface ReplicacheImplOptions {
    * from an existing client group.
    */
   enableClientGroupForking?: boolean | undefined;
+
+  /**
+   * Callback for when Replicache has deleted clients.
+   */
+  onClientsDeleted?: OnClientsDeleted | undefined;
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -408,6 +417,9 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}> {
       enableScheduledRefresh = true,
       enablePullAndPushInOpen = true,
       enableClientGroupForking = true,
+      onClientsDeleted = clientIDs => {
+        this.#lc.info?.('ClientIDs deleted', clientIDs);
+      },
     } = implOptions;
     this.auth = auth ?? '';
     this.pullURL = pullURL;
@@ -510,6 +522,7 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}> {
       profileIDResolver.resolve,
       clientGroupIDResolver.resolve,
       readyResolver.resolve,
+      onClientsDeleted,
     );
   }
 
@@ -520,6 +533,7 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}> {
     profileIDResolver: (profileID: string) => void,
     resolveClientGroupID: (clientGroupID: ClientGroupID) => void,
     resolveReady: () => void,
+    onClientsDeleted: OnClientsDeleted,
   ): Promise<void> {
     const {clientID} = this;
     // If we are currently closing a Replicache instance with the same name,
@@ -575,10 +589,10 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}> {
       this.#kvStoreProvider.drop,
       COLLECT_IDB_INTERVAL,
       INITIAL_COLLECT_IDB_DELAY,
-      SDD_IDB_MAX_AGE,
       2 * clientMaxAgeMs,
       this.#lc,
       signal,
+      onClientsDeleted,
     );
     initClientGroupGC(this.perdag, this.#lc, signal);
     initNewClientChannel(

--- a/packages/replicache/src/replicache-impl.ts
+++ b/packages/replicache/src/replicache-impl.ts
@@ -57,6 +57,7 @@ import {disableClientGroup} from './persist/client-groups.ts';
 import {
   ClientStateNotFoundError,
   initClientV6,
+  type OnClientsDeleted,
   hasClientState as persistHasClientState,
 } from './persist/clients.ts';
 import {
@@ -158,11 +159,6 @@ const updateNeededReasonNewClientGroup: UpdateNeededReason = {
 export interface MakeSubscriptionsManager {
   (queryInternal: QueryInternal, lc: LogContext): SubscriptionsManager;
 }
-
-/**
- * Callback function for when Replicache has deleted one or more clients.
- */
-export type OnClientsDeleted = (clientIDs: ClientID[]) => void;
 
 export interface ReplicacheImplOptions {
   /**
@@ -580,6 +576,7 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}> {
       clientID,
       this.perdag,
       clientMaxAgeMs,
+      onClientsDeleted,
       GC_INTERVAL,
       this.#lc,
       signal,

--- a/packages/replicache/src/replicache-impl.ts
+++ b/packages/replicache/src/replicache-impl.ts
@@ -576,8 +576,8 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}> {
       clientID,
       this.perdag,
       clientMaxAgeMs,
-      onClientsDeleted,
       GC_INTERVAL,
+      onClientsDeleted,
       this.#lc,
       signal,
     );
@@ -587,9 +587,9 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}> {
       COLLECT_IDB_INTERVAL,
       INITIAL_COLLECT_IDB_DELAY,
       2 * clientMaxAgeMs,
+      onClientsDeleted,
       this.#lc,
       signal,
-      onClientsDeleted,
     );
     initClientGroupGC(this.perdag, this.#lc, signal);
     initNewClientChannel(

--- a/packages/shared/src/resolved-promises.ts
+++ b/packages/shared/src/resolved-promises.ts
@@ -1,4 +1,4 @@
-export const promiseTrue = Promise.resolve(true);
-export const promiseFalse = Promise.resolve(false);
+export const promiseTrue = Promise.resolve(true as const);
+export const promiseFalse = Promise.resolve(false as const);
 export const promiseUndefined = Promise.resolve(undefined);
 export const promiseVoid = Promise.resolve();


### PR DESCRIPTION
Replicache has 3 different gc processes:

- Collect IDB (also applies to mem if you keep your browser open long enough)
  - When this happens we look at all the clients in the store before deleting it and call the callback.
- Collect Client:
  - When a client gets collected we call the callback
- Collect Client Group:
  - A client group is only collected if it no longer has any clients in it so there is nothing to do in this case.


This callback will be used in Zero to tell the server about the deleted clients.