### PR TITLE
feat(shared) re-add `clone` to `btree-set`

### DIFF
--- a/packages/shared/src/btree-set.test.ts
+++ b/packages/shared/src/btree-set.test.ts
@@ -11,6 +11,51 @@ test('delete', () => {
   expect(t.size).toBe(0);
 });
 
+test('clone', () => {
+  // Test that cloned set has same elements as original
+  const t1 = new BTreeSet<number>((a, b) => a - b);
+  for (let i = 0; i < 100; i++) {
+    t1.add(i);
+  }
+  const t2 = t1.clone();
+
+  // Verify t2 has all elements from t1
+  for (let i = 0; i < 100; i++) {
+    expect(t2.has(i)).toBe(true);
+  }
+  expect(t2.size).toBe(t1.size);
+
+  // Mutations to t2 don't affect t1
+  for (let i = 0; i < 50; i++) {
+    t2.delete(i);
+  }
+  expect(t2.size).toBe(50);
+  expect(t1.size).toBe(100);
+  for (let i = 0; i < 50; i++) {
+    expect(t2.has(i)).toBe(false);
+    expect(t1.has(i)).toBe(true);
+  }
+  for (let i = 50; i < 100; i++) {
+    expect(t2.has(i)).toBe(true);
+    expect(t1.has(i)).toBe(true);
+  }
+
+  // Mutations to t1 don't affect t2
+  for (let i = 50; i < 100; i++) {
+    t1.delete(i);
+  }
+  expect(t2.size).toBe(50);
+  expect(t1.size).toBe(50);
+  for (let i = 0; i < 50; i++) {
+    expect(t1.has(i)).toBe(true);
+    expect(t2.has(i)).toBe(false);
+  }
+  for (let i = 50; i < 100; i++) {
+    expect(t1.has(i)).toBe(false);
+    expect(t2.has(i)).toBe(true);
+  }
+});
+
 suite('iterators', () => {
   const t = new BTreeSet<number>((a, b) => a - b);
   t.add(10);

--- a/packages/shared/src/btree-set.ts
+++ b/packages/shared/src/btree-set.ts
@@ -24,6 +24,14 @@ export class BTreeSet<K> {
     this.size = 0;
   }
 
+  clone() {
+    this.#root.isShared = true;
+    const ret = new BTreeSet<K>(this.comparator);
+    ret.#root = this.#root;
+    ret.size = this.size;
+    return ret;
+  }
+
   get(key: K): K | undefined {
     return this.#root.get(key, this);
   }


### PR DESCRIPTION
This'll be needed to support reads in custom mutators on the client.

Design: https://www.notion.so/replicache/Custom-Mutators-1353bed8954580f09875f1484e7ce7d4#18b3bed8954580f38321e897032b0fdf