### PR TITLE
fix(zero-cache): make replication-manager handoff watertight

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/schema/init.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/schema/init.pg-test.ts
@@ -1,0 +1,41 @@
+import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
+import {testDBs} from '../../../test/db.ts';
+import type {PostgresDB} from '../../../types/pg.ts';
+import {getLastWatermarkV2} from './init.ts';
+import {ensureReplicationConfig, setupCDCTables} from './tables.ts';
+
+describe('change-streamer/schema/migration', () => {
+  const lc = createSilentLogContext();
+  let db: PostgresDB;
+
+  beforeEach(async () => {
+    db = await testDBs.create('change_streamer_schema_migration');
+    await db.begin(tx => setupCDCTables(lc, tx));
+  });
+
+  afterEach(async () => {
+    await testDBs.drop(db);
+  });
+
+  test('getLastWatermarkV2', async () => {
+    await ensureReplicationConfig(
+      lc,
+      db,
+      {replicaVersion: '123', publications: []},
+      true,
+    );
+
+    expect(await getLastWatermarkV2(db)).toEqual('123');
+
+    await db`
+    INSERT INTO cdc."changeLog" (watermark, pos, change)
+       VALUES ('136', 2, '{"tag":"commit"}'::json);
+    INSERT INTO cdc."changeLog" (watermark, pos, change)
+       VALUES ('145', 0, '{"tag":"begin"}'::json);
+    INSERT INTO cdc."changeLog" (watermark, pos, change)
+       VALUES ('145', 1, '{"tag":"commit"}'::json);`.simple();
+
+    expect(await getLastWatermarkV2(db)).toEqual('145');
+  });
+});

--- a/packages/zero-cache/src/services/change-streamer/schema/init.ts
+++ b/packages/zero-cache/src/services/change-streamer/schema/init.ts
@@ -5,15 +5,46 @@ import {
   type Migration,
 } from '../../../db/migration.ts';
 import type {PostgresDB, PostgresTransaction} from '../../../types/pg.ts';
-import {PG_SCHEMA, setupCDCTables} from './tables.ts';
+import {
+  CREATE_REPLICATION_STATE_TABLE,
+  PG_SCHEMA,
+  setupCDCTables,
+  type ReplicationState,
+} from './tables.ts';
 
 const setupMigration: Migration = {
   migrateSchema: setupCDCTables,
   minSafeVersion: 1,
 };
 
+async function migrateV1toV2(_: LogContext, db: PostgresTransaction) {
+  await db`ALTER TABLE cdc."replicationConfig" ADD "resetRequired" BOOL`;
+}
+
+const migrateV2ToV3 = {
+  migrateSchema: async (_: LogContext, db: PostgresTransaction) => {
+    await db.unsafe(CREATE_REPLICATION_STATE_TABLE);
+  },
+
+  migrateData: async (_: LogContext, db: PostgresTransaction) => {
+    let lastWatermark = await getLastStoredWatermark(db);
+    if (!lastWatermark) {
+      // If no changes were received since initial-sync, the replicaVersion
+      // serves as the lastWatermark.
+      [{lastWatermark}] = await db<{lastWatermark: string}[]>`
+        SELECT "replicaVersion" as "lastWatermark" FROM cdc."replicationConfig"
+    `;
+    }
+
+    const replicationState: Partial<ReplicationState> = {lastWatermark};
+    await db`TRUNCATE TABLE cdc."replicationState"`;
+    await db`INSERT INTO cdc."replicationState" ${db(replicationState)}`;
+  },
+};
+
 const schemaVersionMigrationMap: IncrementalMigrationMap = {
   2: {migrateSchema: migrateV1toV2},
+  3: migrateV2ToV3,
 };
 
 export async function initChangeStreamerSchema(
@@ -30,6 +61,10 @@ export async function initChangeStreamerSchema(
   );
 }
 
-async function migrateV1toV2(_: LogContext, db: PostgresTransaction) {
-  await db`ALTER TABLE cdc."replicationConfig" ADD "resetRequired" BOOL`;
+async function getLastStoredWatermark(
+  db: PostgresTransaction,
+): Promise<string | null> {
+  const [{max}] = await db<{max: string | null}[]>`
+    SELECT MAX(watermark) as max FROM cdc."changeLog"`;
+  return max;
 }

--- a/packages/zero-cache/src/services/change-streamer/schema/tables.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/schema/tables.pg-test.ts
@@ -47,13 +47,22 @@ describe('change-streamer/schema/tables', () => {
           lock: 1,
         },
       ],
+      ['cdc.replicationState']: [
+        {
+          lastWatermark: '183',
+          owner: null,
+          lock: 1,
+        },
+      ],
       ['cdc.changeLog']: [],
     });
 
     await db`
     INSERT INTO cdc."changeLog" (watermark, pos, change)
         values ('184', 1, JSONB('{"foo":"bar"}'));
-    `;
+    UPDATE cdc."replicationState" 
+        SET "lastWatermark" = '184', owner = 'my-task';
+    `.simple();
 
     // Should be a no-op.
     await ensureReplicationConfig(
@@ -75,6 +84,13 @@ describe('change-streamer/schema/tables', () => {
           lock: 1,
         },
       ],
+      ['cdc.replicationState']: [
+        {
+          lastWatermark: '184',
+          owner: 'my-task',
+          lock: 1,
+        },
+      ],
       ['cdc.changeLog']: [
         {
           watermark: '184',
@@ -92,6 +108,13 @@ describe('change-streamer/schema/tables', () => {
           replicaVersion: '183',
           publications: ['zero_data', 'zero_metadata'],
           resetRequired: true,
+          lock: 1,
+        },
+      ],
+      ['cdc.replicationState']: [
+        {
+          lastWatermark: '184',
+          owner: 'my-task',
           lock: 1,
         },
       ],
@@ -138,6 +161,13 @@ describe('change-streamer/schema/tables', () => {
           replicaVersion: '1g8',
           publications: ['zero_data', 'zero_metadata'],
           resetRequired: null,
+          lock: 1,
+        },
+      ],
+      ['cdc.replicationState']: [
+        {
+          lastWatermark: '1g8',
+          owner: null,
           lock: 1,
         },
       ],

--- a/packages/zero-cache/src/services/change-streamer/storer.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.pg-test.ts
@@ -1,3 +1,4 @@
+import {consoleLogSink, LogContext} from '@rocicorp/logger';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {Queue} from '../../../../shared/src/queue.ts';
@@ -10,12 +11,13 @@ import type {StatusMessage} from '../change-source/protocol/current/status.ts';
 import {ReplicationMessages} from '../replicator/test-utils.ts';
 import {type Downstream} from './change-streamer.ts';
 import * as ErrorType from './error-type-enum.ts';
-import {setupCDCTables} from './schema/tables.ts';
+import {ensureReplicationConfig, setupCDCTables} from './schema/tables.ts';
 import {Storer} from './storer.ts';
 import {createSubscriber} from './test-utils.ts';
 
 describe('change-streamer/storer', () => {
-  const lc = createSilentLogContext();
+  const lc = new LogContext('debug', {}, consoleLogSink);
+  createSilentLogContext();
   let db: PostgresDB;
   let storer: Storer;
   let done: Promise<void>;
@@ -25,8 +27,14 @@ describe('change-streamer/storer', () => {
 
   beforeEach(async () => {
     db = await testDBs.create('change_streamer_storer');
+    await db.begin(tx => setupCDCTables(lc, tx));
+    await ensureReplicationConfig(
+      lc,
+      db,
+      {replicaVersion: REPLICA_VERSION, publications: []},
+      true,
+    );
     await db.begin(async tx => {
-      await setupCDCTables(lc, tx);
       await Promise.all(
         [
           {watermark: '03', pos: 0, change: {tag: 'begin', foo: 'bar'}},
@@ -37,9 +45,13 @@ describe('change-streamer/storer', () => {
           {watermark: '06', pos: 2, change: {tag: 'commit', boo: 'far'}},
         ].map(row => tx`INSERT INTO cdc."changeLog" ${tx(row)}`),
       );
+      await tx`UPDATE cdc."replicationState" SET "lastWatermark" = '06'`;
     });
     consumed = new Queue();
-    storer = new Storer(lc, db, REPLICA_VERSION, msg => consumed.enqueue(msg));
+    storer = new Storer(lc, 'task-id', db, REPLICA_VERSION, msg =>
+      consumed.enqueue(msg),
+    );
+    await storer.assumeOwnershipAndGetWatermark();
     done = storer.run();
   });
 
@@ -103,14 +115,6 @@ describe('change-streamer/storer', () => {
       {watermark: '06', pos: 1n},
       {watermark: '06', pos: 2n},
     ]);
-  });
-
-  test('stored watermarks', async () => {
-    expect(await storer.getLastStoredWatermark()).toBe('06');
-
-    await db`TRUNCATE TABLE cdc."changeLog"`;
-
-    expect(await storer.getLastStoredWatermark()).toBe(null);
   });
 
   test('no queueing if not in transaction', async () => {

--- a/packages/zero-cache/src/services/change-streamer/storer.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.pg-test.ts
@@ -1,4 +1,3 @@
-import {consoleLogSink, LogContext} from '@rocicorp/logger';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {Queue} from '../../../../shared/src/queue.ts';
@@ -16,8 +15,7 @@ import {Storer} from './storer.ts';
 import {createSubscriber} from './test-utils.ts';
 
 describe('change-streamer/storer', () => {
-  const lc = new LogContext('debug', {}, consoleLogSink);
-  createSilentLogContext();
+  const lc = createSilentLogContext();
   let db: PostgresDB;
   let storer: Storer;
   let done: Promise<void>;
@@ -51,7 +49,7 @@ describe('change-streamer/storer', () => {
     storer = new Storer(lc, 'task-id', db, REPLICA_VERSION, msg =>
       consumed.enqueue(msg),
     );
-    await storer.assumeOwnershipAndGetWatermark();
+    await storer.assumeOwnership();
     done = storer.run();
   });
 

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -1,5 +1,8 @@
+import {PG_SERIALIZATION_FAILURE} from '@drdgvhbh/postgres-error-codes';
 import {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
+import postgres from 'postgres';
+import {AbortError} from '../../../../shared/src/abort-error.ts';
 import {assert} from '../../../../shared/src/asserts.ts';
 import {Queue} from '../../../../shared/src/queue.ts';
 import {promiseVoid} from '../../../../shared/src/resolved-promises.ts';
@@ -13,6 +16,7 @@ import type {Service} from '../service.ts';
 import type {WatermarkedChange} from './change-streamer-service.ts';
 import {type ChangeEntry} from './change-streamer.ts';
 import * as ErrorType from './error-type-enum.ts';
+import type {ReplicationState} from './schema/tables.ts';
 import {Subscriber} from './subscriber.ts';
 
 type QueueEntry =
@@ -24,6 +28,7 @@ type PendingTransaction = {
   pool: TransactionPool;
   preCommitWatermark: string;
   pos: number;
+  startingReplicationState: Promise<ReplicationState>;
 };
 
 /**
@@ -59,6 +64,7 @@ type PendingTransaction = {
 export class Storer implements Service {
   readonly id = 'storer';
   readonly #lc: LogContext;
+  readonly #taskID: string;
   readonly #db: PostgresDB;
   readonly #replicaVersion: string;
   readonly #onConsumed: (c: Commit | StatusMessage) => void;
@@ -67,21 +73,25 @@ export class Storer implements Service {
 
   constructor(
     lc: LogContext,
+    taskID: string,
     db: PostgresDB,
     replicaVersion: string,
     onConsumed: (c: Commit | StatusMessage) => void,
   ) {
     this.#lc = lc;
+    this.#taskID = taskID;
     this.#db = db;
     this.#replicaVersion = replicaVersion;
     this.#onConsumed = onConsumed;
   }
 
-  async getLastStoredWatermark(): Promise<string | null> {
-    const result = await this.#db<
-      {max: string | null}[]
-    >`SELECT MAX(watermark) as max FROM cdc."changeLog"`;
-    return result[0].max;
+  async assumeOwnershipAndGetWatermark(): Promise<string> {
+    const db = this.#db;
+    const owner = this.#taskID;
+    const [{lastWatermark}] = await db<{lastWatermark: string}[]>`
+      UPDATE cdc."replicationState" SET ${db({owner})}
+        RETURNING "lastWatermark"`;
+    return lastWatermark;
   }
 
   async purgeRecordsBefore(watermark: string): Promise<number> {
@@ -133,6 +143,7 @@ export class Storer implements Service {
       const [tag, change] = downstream;
       if (tag === 'begin') {
         assert(!tx, 'received BEGIN in the middle of a transaction');
+        const {promise, resolve, reject} = resolver<ReplicationState>();
         tx = {
           pool: new TransactionPool(
             this.#lc.withContext('watermark', watermark),
@@ -140,8 +151,18 @@ export class Storer implements Service {
           ),
           preCommitWatermark: watermark,
           pos: 0,
+          startingReplicationState: promise,
         };
         tx.pool.run(this.#db);
+        // Pipeline a read of the current ReplicationState,
+        // which will be checked before committing.
+        tx.pool.process(tx => {
+          tx<ReplicationState[]>`SELECT * FROM cdc."replicationState"`.then(
+            ([result]) => resolve(result),
+            reject,
+          );
+          return [];
+        });
       } else {
         assert(tx, `received ${tag} outside of transaction`);
         tx.pos++;
@@ -157,8 +178,34 @@ export class Storer implements Service {
       tx.pool.process(tx => [tx`INSERT INTO cdc."changeLog" ${tx(entry)}`]);
 
       if (tag === 'commit') {
-        tx.pool.setDone();
-        await tx.pool.done();
+        const {owner} = await tx.startingReplicationState;
+        if (owner !== this.#taskID) {
+          // Ownership change reflected in the replicationState read in 'begin'.
+          tx.pool.fail(
+            new AbortError(`changeLog ownership has been assumed by ${owner}`),
+          );
+        } else {
+          // Update the replication state.
+          const lastWatermark = watermark;
+          tx.pool.process(tx => [
+            tx`UPDATE cdc."replicationState" SET ${tx({lastWatermark})}`,
+          ]);
+          tx.pool.setDone();
+        }
+
+        try {
+          await tx.pool.done();
+        } catch (e) {
+          if (
+            e instanceof postgres.PostgresError &&
+            e.code === PG_SERIALIZATION_FAILURE
+          ) {
+            // Ownership change happened after the replicationState was read in 'begin'.
+            throw new AbortError(`changeLog ownership has changed`, {cause: e});
+          }
+          throw e;
+        }
+
         tx = null;
 
         // ACK the LSN to the upstream Postgres.
@@ -245,9 +292,10 @@ export class Storer implements Service {
             } ms)`,
           );
         } else {
-          const lastStoredWatermark = await this.getLastStoredWatermark();
+          const [{lastWatermark}] = await this.#db<{lastWatermark: string}[]>`
+            SELECT "lastWatermark" FROM cdc."replicationState"`;
           this.#lc.warn?.(
-            `subscriber at watermark ${sub.watermark} is ahead of latest watermark: ${lastStoredWatermark}`,
+            `subscriber at watermark ${sub.watermark} is ahead of latest watermark: ${lastWatermark}`,
           );
         }
         // Flushes the backlog of messages buffered during catchup and

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -85,12 +85,15 @@ export class Storer implements Service {
     this.#onConsumed = onConsumed;
   }
 
-  async assumeOwnershipAndGetWatermark(): Promise<string> {
+  async assumeOwnership() {
     const db = this.#db;
     const owner = this.#taskID;
-    const [{lastWatermark}] = await db<{lastWatermark: string}[]>`
-      UPDATE cdc."replicationState" SET ${db({owner})}
-        RETURNING "lastWatermark"`;
+    await db`UPDATE cdc."replicationState" SET ${db({owner})}`;
+  }
+
+  async getLastWatermark(): Promise<string> {
+    const [{lastWatermark}] = await this.#db<{lastWatermark: string}[]>`
+      SELECT "lastWatermark" FROM cdc."replicationState"`;
     return lastWatermark;
   }
 


### PR DESCRIPTION
The `replication-manager` reads the `lastWatermark` from the change DB in order to take over the postgres replication slot from the right starting point.

Because the old replication manager is not killed until the replication slot is taken over, there is a potential race condition in which the old replication manager, before shutting down, commits a new change to the change log, moving the watermark forward. This would result in an INSERT conflict when the new replication manager attempts to persist that same transaction.

Although ignoring conflicts is a potential workaround, it has the drawback of masking other types of subtle bugs.

The solution implemented here uses a new `replicationState` table with a single row used to coordinate handoffs. The row contains:
* an `owner` column for claiming ownership (similar to CVR ownership)
* a `lastWatermark` column that is updated whenever a new transaction is committed

When the `replication-manager` starts, it writes itself as the `owner` and reads the `lastWatermark`. This initial write prevents any subsequent writes from the old `replication-manager`, which always reads the `owner` in each transaction before writing the new `lastWatermark`. A change in ownership is detected either:
* via the read, in the case where the ownership change was written before the read, or
* during the commit, which would manifest as a SERIALIZATION_FAILURE because a row that was read during the transaction has changed