### PR TITLE
fix(zero): fix change-protocol/v0 export paths in package.json

### DIFF
--- a/packages/zero-cache/src/services/change-source/custom/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/custom/change-source.ts
@@ -25,9 +25,8 @@ import {type ChangeSourceUpstream} from '../protocol/current/upstream.ts';
 import {initSyncSchema} from './sync-schema.ts';
 
 /**
- * Initializes a Postgres change source, including the initial sync of the
- * replica, before streaming changes from the corresponding logical replication
- * stream.
+ * Initializes a Custom change source before streaming changes from the
+ * corresponding logical replication stream.
  */
 export async function initializeCustomChangeSource(
   lc: LogContext,

--- a/packages/zero/package.json
+++ b/packages/zero/package.json
@@ -93,8 +93,8 @@
       "default": "./out/advanced.js"
     },
     "./change-protocol/v0": {
-      "types": "./out/zero-cache/src/services/change-source/protocol/current/mod.d.ts",
-      "default": "./out/zero-cache/src/services/change-source/protocol/current/mod.js"
+      "types": "./out/zero/src/change-protocol/v0.d.ts",
+      "default": "./out/zero/src/change-protocol/v0.js"
     }
   },
   "bin": {

--- a/packages/zero/src/change-protocol/v0.ts
+++ b/packages/zero/src/change-protocol/v0.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-imports
+export * from '../../../zero-cache/src/services/change-source/protocol/mod.ts';

--- a/packages/zero/tsconfig.server.json
+++ b/packages/zero/tsconfig.server.json
@@ -7,6 +7,7 @@
     "src/server/*.ts",
     "src/cli.ts",
     "src/build-schema.ts",
-    "src/zero-cache-dev.ts"
+    "src/zero-cache-dev.ts",
+    "src/change-protocol/*"
   ]
 }


### PR DESCRIPTION
The `change-protocol/v0` export paths in `@rocicorp/zero@0.13.2025013101` point to a `mod.ts` file that doesn't exist in the `out` directory, which breaks imports for custom change sources.

This PR fixes this by:

- adding a `change-protocol/v0.ts` file to `zero/src`
- adding the `change-protocol` directory to the `include` setting in `packages/zero/tsconfig.server.json`
- updating the `./change-protocol/v0` export in `packages/zero/package.json` to point to the new file