### PR TITLE
fix(react): Allows useQuery to work again when server is null.

### DIFF
--- a/packages/zero-react/src/use-query.tsx
+++ b/packages/zero-react/src/use-query.tsx
@@ -29,7 +29,7 @@ export function useQuery<
   const view = viewStore.getView(
     z.clientID,
     q as AdvancedQuery<TSchema, TTable, TReturn>,
-    enable && z.server !== null,
+    enable,
   );
   // https://react.dev/reference/react/useSyncExternalStore
   return useSyncExternalStore(


### PR DESCRIPTION
Fixes https://bugs.rocicorp.dev/issue/3497

This was broken with:

https://github.com/rocicorp/mono/pull/3409#discussion_r1894702111

I don't think the server check was actually needed to accomplish the goal of that PR, but will check w/ chase. Want to land this now to unblock user with canary.