### PR TITLE
wip(zero-client): Immutable apply change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12564,10 +12564,11 @@
       }
     },
     "node_modules/solid-js": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.3.tgz",
-      "integrity": "sha512-5ba3taPoZGt9GY3YlsCB24kCg0Lv/rie/HTD4kG6h4daZZz7+yK02xn8Vx8dLYBc9i6Ps5JwAbEiqjmKaLB3Ag==",
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.4.tgz",
+      "integrity": "sha512-ipQl8FJ31bFUoBNScDQTG3BjN6+9Rg+Q+f10bUbnO6EOTTf5NGerJeHc7wyu5I4RMHEl/WwZwUmy/PTRgxxZ8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.0",
         "seroval": "^1.1.0",
@@ -15942,7 +15943,7 @@
       "version": "0.0.0",
       "devDependencies": {
         "@solidjs/testing-library": "^0.8.10",
-        "solid-js": "^1.0.0",
+        "solid-js": "^1.9.4",
         "zero-advanced": "0.0.0"
       },
       "peerDependencies": {
@@ -24898,9 +24899,9 @@
       }
     },
     "solid-js": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.3.tgz",
-      "integrity": "sha512-5ba3taPoZGt9GY3YlsCB24kCg0Lv/rie/HTD4kG6h4daZZz7+yK02xn8Vx8dLYBc9i6Ps5JwAbEiqjmKaLB3Ag==",
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.4.tgz",
+      "integrity": "sha512-ipQl8FJ31bFUoBNScDQTG3BjN6+9Rg+Q+f10bUbnO6EOTTf5NGerJeHc7wyu5I4RMHEl/WwZwUmy/PTRgxxZ8g==",
       "dev": true,
       "requires": {
         "csstype": "^3.1.0",
@@ -27021,7 +27022,7 @@
       "version": "file:packages/zero-solid",
       "requires": {
         "@solidjs/testing-library": "^0.8.10",
-        "solid-js": "^1.0.0",
+        "solid-js": "^1.9.4",
         "zero-advanced": "0.0.0"
       }
     },

--- a/packages/zero-solid/package.json
+++ b/packages/zero-solid/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@solidjs/testing-library": "^0.8.10",
-    "solid-js": "^1.0.0",
+    "solid-js": "^1.9.4",
     "zero-advanced": "0.0.0"
   }
 }

--- a/packages/zql/src/ivm/array-view.ts
+++ b/packages/zql/src/ivm/array-view.ts
@@ -26,7 +26,7 @@ export class ArrayView<V extends View> implements Output, TypedView<V> {
 
   // Synthetic "root" entry that has a single "" relationship, so that we can
   // treat all changes, including the root change, generically.
-  readonly #root: Entry;
+  #root: Entry;
 
   onDestroy: (() => void) | undefined;
 
@@ -90,7 +90,7 @@ export class ArrayView<V extends View> implements Output, TypedView<V> {
   #hydrate() {
     this.#dirty = true;
     for (const node of this.#input.fetch({})) {
-      applyChange(
+      this.#root = applyChange(
         this.#root,
         {type: 'add', node},
         this.#schema,
@@ -103,7 +103,13 @@ export class ArrayView<V extends View> implements Output, TypedView<V> {
 
   push(change: Change): void {
     this.#dirty = true;
-    applyChange(this.#root, change, this.#schema, '', this.#format);
+    this.#root = applyChange(
+      this.#root,
+      change,
+      this.#schema,
+      '',
+      this.#format,
+    );
   }
 
   flush() {

--- a/packages/zql/src/ivm/view-apply-change.test.ts
+++ b/packages/zql/src/ivm/view-apply-change.test.ts
@@ -1,0 +1,128 @@
+import {expect, suite, test} from 'vitest';
+import type {Change} from './change.js';
+import type {SourceSchema} from './schema.js';
+import {applyChange} from './view-apply-change.js';
+import type {Format} from './view.js';
+
+suite('applyChange', () => {
+  type Row = {id: number; s: string};
+  const parentEntry = {children: []};
+  const schema: SourceSchema = {
+    tableName: 'table',
+    columns: {
+      id: {type: 'number'},
+      s: {type: 'string'},
+    },
+    primaryKey: ['id'],
+    relationships: {},
+    isHidden: false,
+    system: 'client',
+    compareRows: (a, b) => (a.id as number) - (b.id as number),
+    sort: [['id', 'asc']],
+  };
+  const relationship = 'children';
+  const format: Format = {singular: false, relationships: {}};
+
+  test('add keeps object identity', () => {
+    const row1 = {id: 1, s: 'a'};
+    const change: Change = {
+      type: 'add',
+      node: {row: row1, relationships: {}},
+    };
+    const newEntry = applyChange(
+      parentEntry,
+      change,
+      schema,
+      relationship,
+      format,
+    );
+    expect((newEntry['children'] as Row[])[0]).toBe(row1);
+
+    const row2 = {id: 2, s: 'b'};
+    const change2: Change = {
+      type: 'add',
+      node: {row: row2, relationships: {}},
+    };
+    const newEntry2 = applyChange(
+      newEntry,
+      change2,
+      schema,
+      relationship,
+      format,
+    );
+    expect((newEntry2['children'] as Row[])[1]).toBe(row2);
+    expect((newEntry2['children'] as Row[])[0]).toBe(row1);
+    expect(newEntry2).not.toBe(newEntry);
+  });
+
+  test('remove keeps object identity', () => {
+    const row1 = {id: 1, s: 'a'};
+    const change1: Change = {
+      type: 'add',
+      node: {row: row1, relationships: {}},
+    };
+    const row2 = {id: 2, s: 'b'};
+    const change2: Change = {
+      type: 'add',
+      node: {row: row2, relationships: {}},
+    };
+    const change3: Change = {
+      type: 'remove',
+      node: {row: row1, relationships: {}},
+    };
+
+    let newEntry = applyChange(
+      parentEntry,
+      change1,
+      schema,
+      relationship,
+      format,
+    );
+    newEntry = applyChange(newEntry, change2, schema, relationship, format);
+    newEntry = applyChange(newEntry, change3, schema, relationship, format);
+    expect((newEntry['children'] as Row[])[0]).toBe(row2);
+  });
+
+  test('edit keeps object identity', () => {
+    const row1 = {id: 1, s: 'a'};
+    const change1: Change = {
+      type: 'add',
+      node: {row: row1, relationships: {}},
+    };
+    const row2 = {id: 2, s: 'b'};
+    const change2: Change = {
+      type: 'add',
+      node: {row: row2, relationships: {}},
+    };
+    const change3: Change = {
+      type: 'edit',
+      node: {row: {id: 1, s: 'a2'}, relationships: {}},
+      oldNode: {row: row1, relationships: {}},
+    };
+    let newEntry = applyChange(
+      parentEntry,
+      change1,
+      schema,
+      relationship,
+      format,
+    );
+    newEntry = applyChange(newEntry, change2, schema, relationship, format);
+    newEntry = applyChange(newEntry, change3, schema, relationship, format);
+    expect(newEntry).toMatchInlineSnapshot(`
+      {
+        "children": [
+          {
+            "id": 1,
+            "s": "a2",
+          },
+          {
+            "id": 2,
+            "s": "b",
+          },
+        ],
+      }
+    `);
+    expect((newEntry['children'] as Row[])[0]).toBe(change3.node.row);
+    expect((newEntry['children'] as Row[])[1]).toBe(change2.node.row);
+  });
+});


### PR DESCRIPTION
This is an old branch that I had that changes applyChange to treat the data as immutable and it copies the minimal amount of objects to create a new object.

It has bit rotted a bit but the goal is to remove the deepClone which was initially only used in React but now it is used in Solid too. Doing a deepClone copies everything. This branch only copies the objects that change.