### PR TITLE
feat(z2s): test against pg

### DIFF
--- a/packages/z2s/src/compiler.pg-test.ts
+++ b/packages/z2s/src/compiler.pg-test.ts
@@ -1,0 +1,313 @@
+import {beforeAll} from 'vitest';
+import {testDBs} from '../../zero-cache/src/test/db.ts';
+import type {PostgresDB} from '../../zero-cache/src/types/pg.ts';
+import {compile} from './compiler.ts';
+import {schema} from '../../zql/src/query/test/test-schemas.ts';
+import {Database} from '../../zqlite/src/db.ts';
+import {createSilentLogContext} from '../../shared/src/logging-test-utils.ts';
+import {formatSqlite, sql} from './sql.ts';
+import {type Query} from '../../zql/src/query/query.ts';
+import {
+  astForTestingSymbol,
+  newQuery,
+  QueryImpl,
+} from '../../zql/src/query/query-impl.ts';
+import {newQueryDelegate} from '../../zqlite/src/test/source-factory.ts';
+import {describe, expect, test} from 'vitest';
+import {formatPg} from './sql.ts';
+import type {LogConfig} from '../../otel/src/log-options.ts';
+import type {JSONValue} from '../../shared/src/json.ts';
+import {fromSQLiteTypes, toSQLiteTypes} from '../../zqlite/src/table-source.ts';
+import {type Row} from '../../zero-protocol/src/data.ts';
+
+const lc = createSilentLogContext();
+const logConfig: LogConfig = {
+  format: 'text',
+  level: 'debug',
+  ivmSampling: 0,
+  slowRowThreshold: 0,
+};
+
+const createTableSQL = /*sql*/ `
+CREATE TABLE IF NOT EXISTS "issue" (
+  "id" TEXT PRIMARY KEY,
+  "title" TEXT NOT NULL,
+  "description" TEXT NOT NULL,
+  "closed" BOOLEAN NOT NULL,
+  "ownerId" TEXT
+);
+
+CREATE TABLE IF NOT EXISTS "user" (
+  "id" TEXT PRIMARY KEY,
+  "name" TEXT NOT NULL,
+  "metadata" JSONB
+);
+
+CREATE TABLE IF NOT EXISTS "comment" (
+  "id" TEXT PRIMARY KEY,
+  "authorId" TEXT NOT NULL,
+  "issueId" TEXT NOT NULL,
+  "text" TEXT NOT NULL,
+  "createdAt" BIGINT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "issueLabel" (
+  "issueId" TEXT NOT NULL,
+  "labelId" TEXT NOT NULL,
+  PRIMARY KEY ("issueId", "labelId")
+);
+
+CREATE TABLE IF NOT EXISTS "label" (
+  "id" TEXT PRIMARY KEY,
+  "name" TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "revision" (
+  "id" TEXT PRIMARY KEY,
+  "authorId" TEXT NOT NULL,
+  "commentId" TEXT NOT NULL,
+  "text" TEXT NOT NULL
+);
+`;
+
+let pg: PostgresDB;
+let sqlite: Database;
+type Schema = typeof schema;
+
+let issueQuery: Query<Schema, 'issue'>;
+
+beforeAll(async () => {
+  pg = await testDBs.create('compiler');
+  await pg.unsafe(createTableSQL);
+  sqlite = new Database(lc, ':memory:');
+  sqlite.exec(createTableSQL);
+
+  const testData = {
+    issue: Array.from({length: 3}, (_, i) => ({
+      id: `issue${i + 1}`,
+      title: `Test Issue ${i + 1}`,
+      description: `Description for issue ${i + 1}`,
+      closed: i % 2 === 0,
+      ownerId: i === 0 ? null : `user${i}`,
+    })),
+    user: Array.from({length: 3}, (_, i) => ({
+      id: `user${i + 1}`,
+      name: `User ${i + 1}`,
+      metadata:
+        i === 0
+          ? null
+          : {
+              registrar: i % 2 === 0 ? 'github' : 'google',
+              email: `user${i + 1}@example.com`,
+              altContacts: [`alt${i + 1}@example.com`],
+            },
+    })),
+    comment: Array.from({length: 4}, (_, i) => ({
+      id: `comment${i + 1}`,
+      authorId: `user${(i % 3) + 1}`,
+      issueId: `issue${(i % 3) + 1}`,
+      text: `Comment ${i + 1} text`,
+      createdAt: Date.now() - i * 86400000,
+    })),
+    issueLabel: Array.from({length: 4}, (_, i) => ({
+      issueId: `issue${(i % 3) + 1}`,
+      labelId: `label${(i % 2) + 1}`,
+    })),
+    label: Array.from({length: 2}, (_, i) => ({
+      id: `label${i + 1}`,
+      name: `Label ${i + 1}`,
+    })),
+    revision: Array.from({length: 3}, (_, i) => ({
+      id: `revision${i + 1}`,
+      authorId: `user${(i % 3) + 1}`,
+      commentId: `comment${(i % 4) + 1}`,
+      text: `Revised text ${i + 1}`,
+    })),
+  };
+
+  for (const [table, rows] of Object.entries(testData)) {
+    const columns = Object.keys(rows[0]);
+    await pg`INSERT INTO ${pg(table)} ${pg(rows)}`;
+    const sqliteSql = formatSqlite(
+      sql`INSERT INTO ${sql.ident(table)} (${sql.join(
+        columns.map(c => sql.ident(c)),
+        ', ',
+      )}) VALUES (${sql.join(
+        Object.values(columns).map(_ => sql`?`),
+        ',',
+      )})`,
+    );
+    const stmt = sqlite.prepare(sqliteSql.text);
+    for (const row of rows) {
+      stmt.run(
+        toSQLiteTypes(
+          columns,
+          row,
+          schema.tables[table as keyof Schema['tables']].columns,
+        ),
+      );
+    }
+  }
+
+  const queryDelegate = newQueryDelegate(lc, logConfig, sqlite, schema);
+
+  issueQuery = newQuery(queryDelegate, schema, 'issue');
+
+  // Check that PG, SQLite, and test data are in sync
+  const [
+    issuePgRows,
+    userPgRows,
+    commentPgRows,
+    issueLabelPgRows,
+    labelPgRows,
+    revisionPgRows,
+  ] = await Promise.all([
+    pg`SELECT * FROM "issue"`,
+    pg`SELECT * FROM "user"`,
+    pg`SELECT * FROM "comment"`,
+    pg`SELECT * FROM "issueLabel"`,
+    pg`SELECT * FROM "label"`,
+    pg`SELECT * FROM "revision"`,
+  ]);
+  expect(issuePgRows).toEqual(testData.issue);
+  expect(userPgRows).toEqual(testData.user);
+  expect(commentPgRows.map(noBigint)).toEqual(testData.comment);
+  expect(issueLabelPgRows).toEqual(testData.issueLabel);
+  expect(labelPgRows).toEqual(testData.label);
+  expect(revisionPgRows).toEqual(testData.revision);
+
+  const [
+    issueLiteRows,
+    userLiteRows,
+    commentLiteRows,
+    issueLabelLiteRows,
+    labelLiteRows,
+    revisionLiteRows,
+  ] = await Promise.all([
+    sqlite.prepare('SELECT * FROM "issue"').all<Row>(),
+    sqlite.prepare('SELECT * FROM "user"').all<Row>(),
+    sqlite.prepare('SELECT * FROM "comment"').all<Row>(),
+    sqlite.prepare('SELECT * FROM "issueLabel"').all<Row>(),
+    sqlite.prepare('SELECT * FROM "label"').all<Row>(),
+    sqlite.prepare('SELECT * FROM "revision"').all<Row>(),
+  ]);
+  expect(
+    issueLiteRows.map(row => fromSQLiteTypes(schema.tables.issue.columns, row)),
+  ).toEqual(testData.issue);
+  expect(
+    userLiteRows.map(row => fromSQLiteTypes(schema.tables.user.columns, row)),
+  ).toEqual(testData.user);
+  expect(
+    commentLiteRows.map(row =>
+      fromSQLiteTypes(schema.tables.comment.columns, row),
+    ),
+  ).toEqual(testData.comment);
+  expect(issueLabelLiteRows).toEqual(testData.issueLabel);
+  expect(
+    labelLiteRows.map(row => fromSQLiteTypes(schema.tables.label.columns, row)),
+  ).toEqual(testData.label);
+  expect(revisionLiteRows).toEqual(testData.revision);
+});
+
+function ast(q: Query<Schema, keyof Schema['tables']>) {
+  return (q as QueryImpl<Schema, keyof Schema['tables']>)[astForTestingSymbol];
+}
+
+function noBigint(row: Record<string, unknown>) {
+  if ('createdAt' in row) {
+    return {
+      ...row,
+      createdAt: Number(row.createdAt as bigint),
+    };
+  }
+  return row;
+}
+
+describe('compiling ZQL to SQL', () => {
+  test('basic where clause', async () => {
+    const query = issueQuery.where('title', '=', 'issue 1');
+    const sqlQuery = formatPg(compile(ast(query)));
+    const pgResult = await pg.unsafe(
+      sqlQuery.text,
+      sqlQuery.values as JSONValue[],
+    );
+    expect(query.run()).toEqual(pgResult);
+  });
+
+  test('multiple where clauses', async () => {
+    const query = issueQuery
+      .where('closed', '=', false)
+      .where('ownerId', 'IS NOT', null);
+    const sqlQuery = formatPg(compile(ast(query)));
+    const pgResult = await pg.unsafe(
+      sqlQuery.text,
+      sqlQuery.values as JSONValue[],
+    );
+    expect(query.run()).toEqual(pgResult);
+  });
+
+  test('whereExists with related table', async () => {
+    const query = issueQuery.whereExists('labels', q =>
+      q.where('name', '=', 'bug'),
+    );
+    const sqlQuery = formatPg(compile(ast(query)));
+    const pgResult = await pg.unsafe(
+      sqlQuery.text,
+      sqlQuery.values as JSONValue[],
+    );
+    expect(query.run()).toEqual(pgResult);
+  });
+
+  test('order by and limit', async () => {
+    const query = issueQuery.orderBy('title', 'desc').limit(5);
+    const sqlQuery = formatPg(compile(ast(query)));
+    const pgResult = await pg.unsafe(
+      sqlQuery.text,
+      sqlQuery.values as JSONValue[],
+    );
+    expect(query.run()).toEqual(pgResult);
+  });
+
+  // TODO: we need to hide junction edges for the PG compiled form
+  // before these will pass
+  test.fails('related tables', async () => {
+    const query = issueQuery.related('owner').related('labels');
+    const sqlQuery = formatPg(compile(ast(query)));
+    const pgResult = await pg.unsafe(
+      sqlQuery.text,
+      sqlQuery.values as JSONValue[],
+    );
+    expect(query.run()).toEqual(pgResult);
+  });
+
+  test.fails('nested related with where clauses', async () => {
+    const query = issueQuery
+      .where('closed', '=', false)
+      .related('comments', q =>
+        q.where('createdAt', '>', 1000).related('author'),
+      );
+    const sqlQuery = formatPg(compile(ast(query)));
+    const pgResult = await pg.unsafe(
+      sqlQuery.text,
+      sqlQuery.values as JSONValue[],
+    );
+    expect(query.run()).toEqual(pgResult);
+  });
+
+  test.fails('complex query combining multiple features', async () => {
+    const query = issueQuery
+      .where('closed', '=', false)
+      .whereExists('labels', q => q.where('name', 'IN', ['Label 1', 'Label 2']))
+      .related('owner')
+      .related('comments', q =>
+        q.orderBy('createdAt', 'desc').limit(3).related('author'),
+      )
+      .orderBy('title', 'asc');
+    const sqlQuery = formatPg(compile(ast(query)));
+    const pgResult = await pg.unsafe(
+      sqlQuery.text,
+      sqlQuery.values as JSONValue[],
+    );
+    expect(query.run()).toEqual(pgResult);
+  });
+});

--- a/packages/z2s/src/compiler.ts
+++ b/packages/z2s/src/compiler.ts
@@ -29,8 +29,10 @@ export function select(ast: AST, correlation: SQLQuery | undefined) {
   selectionSet.push(sql.__dangerous__rawValue('*'));
   return sql`SELECT ${sql.join(selectionSet, ',')} FROM ${sql.ident(
     ast.table,
-  )} WHERE (${where(ast.where, ast.table)}) ${
-    correlation ? sql`AND ${correlation}` : sql``
+  )} ${ast.where ? sql`WHERE ${where(ast.where, ast.table)}` : sql``} ${
+    correlation
+      ? sql`${ast.where ? sql`AND` : sql`WHERE`} (${correlation})`
+      : sql``
   } ${orderBy(ast.orderBy)} ${limit(ast.limit)}`;
 }
 

--- a/packages/z2s/vitest.config.ts
+++ b/packages/z2s/vitest.config.ts
@@ -1,0 +1,2 @@
+import config from '../zero-cache/vitest.config.ts';
+export default config;

--- a/packages/z2s/vitest.workspace.ts
+++ b/packages/z2s/vitest.workspace.ts
@@ -1,0 +1,2 @@
+import config from '../zero-cache/vitest.workspace.ts';
+export default config;

--- a/packages/zero-cache/vitest.workspace.ts
+++ b/packages/zero-cache/vitest.workspace.ts
@@ -5,7 +5,7 @@ const pgConfigForVersion = (version: number) => ({
   test: {
     name: `pg-${version}`,
     include: ['src/**/*.pg-test.?(c|m)[jt]s?(x)'],
-    globalSetup: [`./test/pg-${version}.ts`],
+    globalSetup: [`../zero-cache/test/pg-${version}.ts`],
   },
 });
 

--- a/packages/zqlite/src/table-source.ts
+++ b/packages/zqlite/src/table-source.ts
@@ -783,7 +783,7 @@ function getUniqueIndexes(
   );
 }
 
-function toSQLiteTypes(
+export function toSQLiteTypes(
   columns: readonly string[],
   row: Row,
   columnTypes: Record<string, SchemaValue>,

--- a/packages/zqlite/src/test/source-factory.ts
+++ b/packages/zqlite/src/test/source-factory.ts
@@ -6,8 +6,11 @@ import type {Source} from '../../../zql/src/ivm/source.ts';
 import type {SourceFactory} from '../../../zql/src/ivm/test/source-factory.ts';
 import {Database} from '../db.ts';
 import {compile, sql} from '../internal/sql.ts';
-import {TableSource} from '../table-source.ts';
+import {TableSource, toSQLiteTypeName} from '../table-source.ts';
 import type {LogConfig} from '../../../otel/src/log-options.ts';
+import type {QueryDelegate} from '../../../zql/src/query/query-impl.ts';
+import type {Schema} from '../../../zero-schema/src/builder/schema-builder.ts';
+import {MemoryStorage} from '../../../zql/src/ivm/memory-storage.ts';
 
 export const createSource: SourceFactory = (
   lc: LogContext,
@@ -38,3 +41,57 @@ export const createSource: SourceFactory = (
     primaryKey,
   );
 };
+
+export function newQueryDelegate(
+  lc: LogContext,
+  logConfig: LogConfig,
+  db: Database,
+  schema: Schema,
+): QueryDelegate {
+  const sources = new Map<string, Source>();
+  return {
+    getSource: (name: string) => {
+      let source = sources.get(name);
+      if (source) {
+        return source;
+      }
+
+      const tableSchema = schema.tables[name as keyof typeof schema.tables];
+
+      // create the SQLite table
+      db.exec(`
+      CREATE TABLE IF NOT EXISTS "${name}" (
+        ${Object.entries(tableSchema.columns)
+          .map(([name, c]) => `"${name}" ${toSQLiteTypeName(c.type)}`)
+          .join(', ')},
+        PRIMARY KEY (${tableSchema.primaryKey.map(k => `"${k}"`).join(', ')})
+      )`);
+
+      source = new TableSource(
+        lc,
+        logConfig,
+        'query.test.ts',
+        db,
+        name,
+        tableSchema.columns,
+        tableSchema.primaryKey,
+      );
+
+      sources.set(name, source);
+      return source;
+    },
+
+    createStorage() {
+      return new MemoryStorage();
+    },
+    addServerQuery() {
+      return () => {};
+    },
+    onTransactionCommit() {
+      return () => {};
+    },
+    batchViewUpdates<T>(applyViewUpdates: () => T): T {
+      return applyViewUpdates();
+    },
+  };
+}


### PR DESCRIPTION
Reveals that the compiler will need to:
1. support `hidden` tables for junction edges
2. support `one`

Will provide the `format` as an arg to the `compiler` in a follow up PR so we can take `one` and `junction` edges into account.