### PR TITLE
feat(zero-cache): support syncing tables from non-public schemas

### DIFF
--- a/packages/zero-cache/src/integration/integration.pg-test.ts
+++ b/packages/zero-cache/src/integration/integration.pg-test.ts
@@ -39,14 +39,14 @@ const LOG_LEVEL: LogLevel = 'error';
 const INITIAL_PG_SETUP = `
       CREATE TABLE foo(
         id TEXT PRIMARY KEY, 
-        val TEXT,
+        far_id TEXT,
         b BOOL,
         j1 JSON,
         j2 JSONB,
         j3 JSON,
         j4 JSON
       );
-      INSERT INTO foo(id, val, b, j1, j2, j3, j4) 
+      INSERT INTO foo(id, far_id, b, j1, j2, j3, j4) 
         VALUES (
           'bar',
           'baz',
@@ -56,8 +56,14 @@ const INITIAL_PG_SETUP = `
           '123',
           '"string"');
 
+      CREATE SCHEMA boo;
+      CREATE TABLE boo.far(id TEXT PRIMARY KEY);
+      INSERT INTO boo.far(id) VALUES ('baz');
+
       CREATE TABLE nopk(id TEXT NOT NULL, val TEXT);
       INSERT INTO nopk(id, val) VALUES ('foo', 'bar');
+
+      CREATE PUBLICATION zero_all FOR TABLE foo, TABLE boo.far, TABLE nopk;
 `;
 
 // Keep this in sync with the INITIAL_PG_SETUP
@@ -72,7 +78,7 @@ const INITIAL_CUSTOM_SETUP: ChangeStreamMessage[] = [
         name: 'foo',
         columns: {
           id: {pos: 0, dataType: 'text', notNull: true},
-          val: {pos: 1, dataType: 'text'},
+          ['far_id']: {pos: 1, dataType: 'text'},
           b: {pos: 2, dataType: 'bool'},
           j1: {pos: 3, dataType: 'json'},
           j2: {pos: 4, dataType: 'jsonb'},
@@ -106,12 +112,52 @@ const INITIAL_CUSTOM_SETUP: ChangeStreamMessage[] = [
       },
       new: {
         id: 'bar',
-        val: 'baz',
+        ['far_id']: 'baz',
         b: true,
         j1: {foo: 'bar'},
         j2: true,
         j3: 123,
         j4: 'string',
+      },
+    },
+  ],
+  [
+    'data',
+    {
+      tag: 'create-table',
+      spec: {
+        schema: 'boo',
+        name: 'far',
+        columns: {
+          id: {pos: 0, dataType: 'text', notNull: true},
+        },
+      },
+    },
+  ],
+  [
+    'data',
+    {
+      tag: 'create-index',
+      spec: {
+        name: 'boo_far_key',
+        schema: 'boo',
+        tableName: 'far',
+        columns: {id: 'ASC'},
+        unique: true,
+      },
+    },
+  ],
+  [
+    'data',
+    {
+      tag: 'insert',
+      relation: {
+        schema: 'boo',
+        name: 'far',
+        keyColumns: ['id'],
+      },
+      new: {
+        id: 'baz',
       },
     },
   ],
@@ -305,6 +351,7 @@ describe('integration', {timeout: 30000}, () => {
       ['ZERO_UPSTREAM_MAX_CONNS']: '3',
       ['ZERO_CVR_DB']: getConnectionURI(cvrDB),
       ['ZERO_CVR_MAX_CONNS']: '3',
+      ['ZERO_SHARD_PUBLICATIONS']: 'zero_all',
       ['ZERO_CHANGE_DB']: getConnectionURI(changeDB),
       ['ZERO_REPLICA_FILE']: replicaDbFile.path,
       ['ZERO_SCHEMA_JSON']: JSON.stringify(SCHEMA),
@@ -315,6 +362,19 @@ describe('integration', {timeout: 30000}, () => {
   const FOO_QUERY: AST = {
     table: 'foo',
     orderBy: [['id', 'asc']],
+    related: [
+      {
+        correlation: {
+          parentField: ['far_id'],
+          childField: ['id'],
+        },
+        subquery: {
+          table: 'boo.far',
+          orderBy: [['id', 'asc']],
+          alias: 'far',
+        },
+      },
+    ],
   };
 
   const NOPK_QUERY: AST = {
@@ -547,12 +607,19 @@ describe('integration', {timeout: 30000}, () => {
               tableName: 'foo',
               value: {
                 id: 'bar',
-                val: 'baz',
+                ['far_id']: 'baz',
                 b: true,
                 j1: {foo: 'bar'},
                 j2: true,
                 j3: 123,
                 j4: 'string',
+              },
+            },
+            {
+              op: 'put',
+              tableName: 'boo.far',
+              value: {
+                id: 'baz',
               },
             },
           ],
@@ -566,8 +633,10 @@ describe('integration', {timeout: 30000}, () => {
       // Trigger an upstream change and verify replication.
       if (backend === 'pg') {
         await upDB`
-          INSERT INTO foo(id, val, b, j1, j2, j3, j4) 
-            VALUES ('voo', 'doo', false, '"foo"', 'false', '456.789', '{"bar":"baz"}')`;
+          INSERT INTO foo(id, far_id, b, j1, j2, j3, j4) 
+            VALUES ('voo', 'doo', false, '"foo"', 'false', '456.789', '{"bar":"baz"}');
+          UPDATE foo SET far_id = 'not_baz' WHERE id = 'bar';
+        `.simple();
       } else {
         await streamCustomChanges([
           ['begin', {tag: 'begin'}, {commitWatermark: '102'}],
@@ -582,13 +651,30 @@ describe('integration', {timeout: 30000}, () => {
               },
               new: {
                 id: 'voo',
-                val: 'doo',
+                ['far_id']: 'doo',
                 b: false,
                 j1: 'foo',
                 j2: false,
                 j3: 456.789,
                 j4: {bar: 'baz'},
               },
+            },
+          ],
+          [
+            'data',
+            {
+              tag: 'update',
+              relation: {
+                schema: 'public',
+                name: 'foo',
+                keyColumns: ['id'],
+              },
+              new: {
+                id: 'bar',
+                ['far_id']: 'not_baz',
+              },
+              key: null,
+              old: null,
             },
           ],
           ['commit', {tag: 'commit'}, {watermark: '102'}],
@@ -608,8 +694,29 @@ describe('integration', {timeout: 30000}, () => {
               op: 'put',
               tableName: 'foo',
               value: {
+                b: true,
+                far_id: 'not_baz',
+                id: 'bar',
+                j1: {
+                  foo: 'bar',
+                },
+                j2: true,
+                j3: 123,
+                j4: 'string',
+              },
+            },
+            // boo.far {id: 'baz'} is no longer referenced by foo {id: 'bar}
+            {
+              id: {id: 'baz'},
+              op: 'del',
+              tableName: 'boo.far',
+            },
+            {
+              op: 'put',
+              tableName: 'foo',
+              value: {
                 id: 'voo',
-                val: 'doo',
+                ['far_id']: 'doo',
                 b: false,
                 j1: 'foo',
                 j2: false,

--- a/packages/zero-cache/src/integration/integration.pg-test.ts
+++ b/packages/zero-cache/src/integration/integration.pg-test.ts
@@ -695,7 +695,7 @@ describe('integration', {timeout: 30000}, () => {
               tableName: 'foo',
               value: {
                 b: true,
-                far_id: 'not_baz',
+                ['far_id']: 'not_baz',
                 id: 'bar',
                 j1: {
                   foo: 'bar',

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -411,7 +411,6 @@ const SET_REPLICA_IDENTITY_DELAY_MS = 500;
 
 class ChangeMaker {
   readonly #lc: LogContext;
-  readonly #shardID: string;
   readonly #shardPrefix: string;
   readonly #shardConfig: InternalShardConfig;
   readonly #upstream: ShortLivedClient;
@@ -426,7 +425,6 @@ class ChangeMaker {
     upstreamURI: string,
   ) {
     this.#lc = lc;
-    this.#shardID = shardID;
     // Note: This matches the prefix used in pg_logical_emit_message() in pg/schema/ddl.ts.
     this.#shardPrefix = `zero/${shardID}`;
     this.#shardConfig = shardConfig;
@@ -600,7 +598,7 @@ class ChangeMaker {
 
     // Validate the new table schemas
     for (const table of nextTbl.values()) {
-      validate(this.#lc, this.#shardID, table);
+      validate(this.#lc, table);
     }
 
     const [droppedIdx, createdIdx] = symmetricDifferences(prevIdx, nextIdx);

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
@@ -122,7 +122,7 @@ export async function initialSync(
         getPublicationInfo(db, publications),
       );
       // Note: If this throws, initial-sync is aborted.
-      validatePublications(lc, shard.id, published);
+      validatePublications(lc, published);
 
       // Now that tables have been validated, kick off the copiers.
       const {tables, indexes} = published;

--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.pg-test.ts
@@ -339,8 +339,6 @@ describe('change-source/pg', () => {
     },
   ];
 
-  const SHARD_ID = 'publication_validation_test_id';
-
   for (const c of invalidUpstreamCases) {
     test(`Invalid publication: ${c.error}`, async () => {
       await initDB(
@@ -354,9 +352,7 @@ describe('change-source/pg', () => {
         'zero_data',
         ...(c.requestedPublications ?? []),
       ]);
-      expect(() => validatePublications(lc, SHARD_ID, published)).toThrowError(
-        c.error,
-      );
+      expect(() => validatePublications(lc, published)).toThrowError(c.error);
     });
   }
 });

--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
@@ -247,7 +247,7 @@ export function validatePublications(
     }
   });
 
-  published.tables.forEach(table => validate(lc, shardID, table));
+  published.tables.forEach(table => validate(lc, table));
 }
 
 type ReplicaIdentities = {

--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
@@ -229,7 +229,6 @@ export async function setupTablesAndReplication(
 
 export function validatePublications(
   lc: LogContext,
-  shardID: string,
   published: PublicationInfo,
 ) {
   // Verify that all publications export the proper events.

--- a/packages/zero-cache/src/services/change-source/pg/schema/validation.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/validation.pg-test.ts
@@ -33,25 +33,6 @@ describe('change-source/pg', () => {
       `,
     },
     {
-      error: 'Only the default "public" schema is supported',
-      setupUpstreamQuery: `
-        CREATE SCHEMA _zero;
-        CREATE TABLE _zero.is_not_allowed(
-          "issueID" INTEGER PRIMARY KEY, 
-          "orgID" INTEGER
-        );
-        CREATE PUBLICATION zero_foo FOR TABLES IN SCHEMA _zero;
-        `,
-    },
-    {
-      error: 'Only the default "public" schema is supported',
-      setupUpstreamQuery: `
-        CREATE SCHEMA unsupported;
-        CREATE TABLE unsupported.issues ("issueID" INTEGER PRIMARY KEY, "orgID" INTEGER);
-        CREATE PUBLICATION zero_foo FOR TABLES IN SCHEMA unsupported;
-      `,
-    },
-    {
       error: 'Table "table/with/slashes" has invalid characters',
       setupUpstreamQuery: `
         CREATE TABLE "table/with/slashes" ("issueID" INTEGER PRIMARY KEY, "orgID" INTEGER);
@@ -90,7 +71,7 @@ describe('change-source/pg', () => {
       expect(pubs.tables.length).toBe(1);
       let result;
       try {
-        validate(lc, '0', pubs.tables[0]);
+        validate(lc, pubs.tables[0]);
       } catch (e) {
         result = e;
       }

--- a/packages/zero-cache/src/services/change-source/pg/schema/validation.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/validation.ts
@@ -6,22 +6,10 @@ import {
 import {Default} from '../../../../db/postgres-replica-identity-enum.ts';
 import type {PublishedTableSpec} from '../../../../db/specs.ts';
 import {ZERO_VERSION_COLUMN_NAME} from '../../../replicator/schema/replication-state.ts';
-import {unescapedSchema} from './shard.ts';
 
 const ALLOWED_IDENTIFIER_CHARS = /^[A-Za-z_]+[A-Za-z0-9_-]*$/;
 
-export function validate(
-  lc: LogContext,
-  shardID: string,
-  table: PublishedTableSpec,
-) {
-  const shardSchema = unescapedSchema(shardID);
-  if (!['public', 'zero', shardSchema].includes(table.schema)) {
-    // This may be relaxed in the future. We would need a plan for support in the AST first.
-    throw new UnsupportedTableSchemaError(
-      'Only the default "public" schema is supported.',
-    );
-  }
+export function validate(lc: LogContext, table: PublishedTableSpec) {
   if (ZERO_VERSION_COLUMN_NAME in table.columns) {
     throw new UnsupportedTableSchemaError(
       `Table "${table.name}" uses reserved column name "${ZERO_VERSION_COLUMN_NAME}"`,

--- a/packages/zero-cache/src/services/mutagen/mutagen.pg-test.ts
+++ b/packages/zero-cache/src/services/mutagen/mutagen.pg-test.ts
@@ -40,7 +40,8 @@ async function createTables(db: PostgresDB) {
         id text,
         PRIMARY KEY(id)
       );
-      CREATE TABLE id_and_cols (
+      CREATE SCHEMA my_schema;
+      CREATE TABLE my_schema.id_and_cols (
         id text,
         col1 text,
         col2 text,
@@ -454,7 +455,7 @@ describe('processMutation', {timeout: 15000}, () => {
             ops: [
               {
                 op: 'insert',
-                tableName: 'id_and_cols',
+                tableName: 'my_schema.id_and_cols',
                 primaryKey: ['id'],
                 value: {
                   id: '1',
@@ -464,7 +465,7 @@ describe('processMutation', {timeout: 15000}, () => {
               },
               {
                 op: 'upsert',
-                tableName: 'id_and_cols',
+                tableName: 'my_schema.id_and_cols',
                 primaryKey: ['id'],
                 value: {
                   id: '2',
@@ -474,7 +475,7 @@ describe('processMutation', {timeout: 15000}, () => {
               },
               {
                 op: 'update',
-                tableName: 'id_and_cols',
+                tableName: 'my_schema.id_and_cols',
                 primaryKey: ['id'],
                 value: {
                   id: '1',
@@ -483,7 +484,7 @@ describe('processMutation', {timeout: 15000}, () => {
               },
               {
                 op: 'update',
-                tableName: 'id_and_cols',
+                tableName: 'my_schema.id_and_cols',
                 primaryKey: ['id'],
                 value: {
                   id: '1',
@@ -492,7 +493,7 @@ describe('processMutation', {timeout: 15000}, () => {
               },
               {
                 op: 'delete',
-                tableName: 'id_and_cols',
+                tableName: 'my_schema.id_and_cols',
                 primaryKey: ['id'],
                 value: {id: '2'},
               },
@@ -508,7 +509,7 @@ describe('processMutation', {timeout: 15000}, () => {
     expect(error).undefined;
 
     await expectTables(db, {
-      ['id_and_cols']: [
+      ['my_schema.id_and_cols']: [
         {
           id: '1',
           col1: 'update',


### PR DESCRIPTION
### Feature

Tables from non-public schemas can be synced to the client.

### Instructions

This requires [creating a publication](https://www.postgresql.org/docs/current/sql-createpublication.html) on upstream (as the default will only sync tables from the "public" schema):

```sql
CREATE PUBLICATION zero_data FOR TABLE foo, TABLE bar, TABLE my_schema.baz, ...;
```

and specifying that publication in the `ZERO_SHARD_PUBLICATIONS` server option:

```env
# .env

ZERO_SHARD_PUBLICATIONS=zero_data
```

Finally, on the client, the schema must be configured to reference the table correctly:

```ts
// schema.ts

const baz = table('baz')
    .from('my_schema.baz')
    .columns({...})
    .build();
```