### PR TITLE
perf,fix(zero-solid): back to produce but pre-reading relationships and optimizing initial view build

### DIFF
--- a/packages/zero-advanced/src/mod.ts
+++ b/packages/zero-advanced/src/mod.ts
@@ -2,7 +2,10 @@ export type {ZeroAdvancedOptions} from '../../zero-client/src/client/options.ts'
 export type {TableSchema} from '../../zero-schema/src/table-schema.ts';
 export type {Change} from '../../zql/src/ivm/change.ts';
 export type {Input, Output} from '../../zql/src/ivm/operator.ts';
-export {applyChange} from '../../zql/src/ivm/view-apply-change.ts';
+export {
+  applyChange,
+  type ViewChange,
+} from '../../zql/src/ivm/view-apply-change.ts';
 export type {Entry, Format, View, ViewFactory} from '../../zql/src/ivm/view.ts';
 export type {AdvancedQuery} from '../../zql/src/query/query-internal.ts';
 export type {HumanReadable, Query} from '../../zql/src/query/query.ts';

--- a/packages/zero-client/src/client/context.ts
+++ b/packages/zero-client/src/client/context.ts
@@ -79,7 +79,6 @@ export class ZeroContext implements QueryDelegate {
   }
 
   processChanges(changes: NoIndexDiff) {
-    console.log('process changes', changes.length);
     this.batchViewUpdates(() => {
       try {
         for (const diff of changes) {

--- a/packages/zero-client/src/client/context.ts
+++ b/packages/zero-client/src/client/context.ts
@@ -79,8 +79,9 @@ export class ZeroContext implements QueryDelegate {
   }
 
   processChanges(changes: NoIndexDiff) {
-    try {
-      this.batchViewUpdates(() => {
+    console.log('process changes', changes.length);
+    this.batchViewUpdates(() => {
+      try {
         for (const diff of changes) {
           const {key} = diff;
           assert(key.startsWith(ENTITIES_KEY_PREFIX));
@@ -123,10 +124,10 @@ export class ZeroContext implements QueryDelegate {
               unreachable(diff);
           }
         }
-      });
-    } finally {
-      this.#endTransaction();
-    }
+      } finally {
+        this.#endTransaction();
+      }
+    });
   }
 
   #endTransaction() {

--- a/packages/zero-solid/src/solid-view.test.ts
+++ b/packages/zero-solid/src/solid-view.test.ts
@@ -540,7 +540,7 @@ test('tree-single', () => {
   expect(view.data).toEqual(undefined);
 });
 
-test.fails('collapse', () => {
+test('collapse', () => {
   const schema: SourceSchema = {
     tableName: 'issue',
     primaryKey: ['id'],
@@ -1700,7 +1700,7 @@ test('edit to preserve relationships', () => {
   ]);
 });
 
-test.fails('edit leaf', () => {
+test('edit leaf', () => {
   const schema: SourceSchema = {
     tableName: 'issue',
     primaryKey: ['id'],

--- a/packages/zero-solid/src/solid-view.ts
+++ b/packages/zero-solid/src/solid-view.ts
@@ -85,6 +85,14 @@ export class SolidView<V> implements Output {
     }
   };
 
+  push(change: Change): void {
+    // Delay updating the solid store state until the transaction commit
+    // (because each update of the solid store is quite expensive), but
+    // read the relationships now as they are only valid to read
+    // when the push is received.
+    this.#pendingChanges.push(materializeRelationships(change));
+  }
+
   #applyChanges<T>(changes: Iterable<T>, mapper: (v: T) => ViewChange): void {
     this.#setState(oldState => {
       // Optimization: if the store is currently empty build up
@@ -109,12 +117,6 @@ export class SolidView<V> implements Output {
     });
   }
 
-  #initialEmptyEntry(): Entry {
-    return {
-      '': this.#format.singular ? undefined : [],
-    };
-  }
-
   #applyChangesToRoot<T>(
     changes: Iterable<T>,
     mapper: (v: T) => ViewChange,
@@ -131,12 +133,10 @@ export class SolidView<V> implements Output {
     }
   }
 
-  push(change: Change): void {
-    // Delay updating the solid store state until the transaction commit
-    // (because each update of the solid store is quite expensive), but
-    // read the relationships now as they are only valid to read
-    // when the push is received.
-    this.#pendingChanges.push(materializeRelationships(change));
+  #initialEmptyEntry(): Entry {
+    return {
+      '': this.#format.singular ? undefined : [],
+    };
   }
 }
 

--- a/packages/zero-solid/src/solid-view.ts
+++ b/packages/zero-solid/src/solid-view.ts
@@ -17,8 +17,8 @@ import {
 } from '../../zero-advanced/src/mod.js';
 import type {Schema} from '../../zero-schema/src/mod.js';
 import type {ResultType} from '../../zql/src/query/typed-view.js';
-import type {Row} from '../../zero-protocol/src/data.ts';
 import type {Node} from '../../zql/src/ivm/data.ts';
+import type {ViewChange} from '../../zql/src/ivm/view-apply-change.ts';
 
 export type QueryResultDetails = {
   readonly type: ResultType;
@@ -37,7 +37,7 @@ export class SolidView<V> implements Output {
   #state: Store<State>;
   #setState: SetStoreFunction<State>;
 
-  #pendingChanges: DrainedChange[] = [];
+  #pendingChanges: ViewChange[] = [];
 
   constructor(
     input: Input,
@@ -51,7 +51,7 @@ export class SolidView<V> implements Output {
     this.#format = format;
     this.#onDestroy = onDestroy;
     [this.#state, this.#setState] = createStore<State>([
-      {'': format.singular ? undefined : []},
+      this.#initialEmptyEntry(),
       queryComplete === true ? complete : unknown,
     ]);
     input.setOutput(this);
@@ -78,65 +78,98 @@ export class SolidView<V> implements Output {
   }
 
   #onTransactionCommit = () => {
-    this.#applyChanges(this.#pendingChanges, c => c);
-  };
-
-  #applyChanges<T>(changes: Iterable<T>, mapper: (v: T) => Change): void {
     try {
-      this.#setState(
-        produce((draftState: State) => {
-          for (const change of changes) {
-            applyChange(
-              draftState[0],
-              mapper(change),
-              this.#input.getSchema(),
-              '',
-              this.#format,
-            );
-          }
-        }),
-      );
+      this.#applyChanges(this.#pendingChanges, c => c);
     } finally {
       this.#pendingChanges = [];
+    }
+  };
+
+  #applyChanges<T>(changes: Iterable<T>, mapper: (v: T) => ViewChange): void {
+    this.#setState(oldState => {
+      // Optimization: if the store is currently empty build up
+      // the view on a new plain old JS object root, and return that
+      // for the new state.  This avoids building up large views from
+      // scratch via solid produce.  The proxy object used by solid produce
+      // is slow and in this case we don't care about solid tracking the fine
+      // grained changes (everything has changed, its all new).  For a test case
+      // with a view with 3000 rows, each row having 2 children, this
+      // optimization reduced #applyChanges time from 743ms to 133ms.
+      if (
+        oldState[0][''] === undefined ||
+        (Array.isArray(oldState[0]['']) && oldState[0][''].length === 0)
+      ) {
+        const root: Entry = this.#initialEmptyEntry();
+        this.#applyChangesToRoot<T>(changes, mapper, root);
+        return [root, oldState[1]];
+      }
+      return produce((draftState: State) => {
+        this.#applyChangesToRoot<T>(changes, mapper, draftState[0]);
+      })(oldState);
+    });
+  }
+
+  #initialEmptyEntry(): Entry {
+    return {
+      '': this.#format.singular ? undefined : [],
+    };
+  }
+
+  #applyChangesToRoot<T>(
+    changes: Iterable<T>,
+    mapper: (v: T) => ViewChange,
+    root: Entry,
+  ) {
+    for (const change of changes) {
+      applyChange(
+        root,
+        mapper(change),
+        this.#input.getSchema(),
+        '',
+        this.#format,
+      );
     }
   }
 
   push(change: Change): void {
-    // Delay setting the state until the transaction commit.
-    this.#pendingChanges.push(drain(change));
+    // Delay updating the solid store state until the transaction commit
+    // (because each update of the solid store is quite expensive), but
+    // read the relationships now as they are only valid to read
+    // when the push is received.
+    this.#pendingChanges.push(materializeRelationships(change));
   }
 }
 
-function drain(change: Change): DrainedChange {
+function materializeRelationships(change: Change): ViewChange {
   switch (change.type) {
     case 'add':
-      return {type: 'add', node: drainNode(change.node)};
+      return {type: 'add', node: materializeNodesRelationships(change.node)};
     case 'remove':
-      return {type: 'remove', node: drainNode(change.node)};
+      return {type: 'remove', node: materializeNodesRelationships(change.node)};
     case 'child':
       return {
         type: 'child',
-        node: drainNode(change.node),
+        node: {row: change.node.row},
         child: {
           relationshipName: change.child.relationshipName,
-          change: drain(change.child.change),
+          change: materializeRelationships(change.child.change),
         },
       };
     case 'edit':
       return {
         type: 'edit',
-        node: drainNode(change.node),
-        oldNode: drainNode(change.oldNode),
+        node: {row: change.node.row},
+        oldNode: {row: change.oldNode.row},
       };
   }
 }
 
-function drainNode(node: Node): DrainedNode {
+function materializeNodesRelationships(node: Node): Node {
   return {
     row: node.row,
     relationships: Object.fromEntries(
       Object.entries(node.relationships).map(([relationship, stream]) => {
-        const drained = [...stream()].map(drainNode);
+        const drained = [...stream()].map(materializeNodesRelationships);
         return [relationship, () => drained];
       }),
     ),
@@ -165,35 +198,3 @@ export function solidViewFactory<
 }
 
 solidViewFactory satisfies ViewFactory<Schema, string, unknown, unknown>;
-
-type DrainedChange = AddChange | RemoveChange | ChildChange | EditChange;
-
-export type AddChange = {
-  type: 'add';
-  node: DrainedNode;
-};
-
-export type RemoveChange = {
-  type: 'remove';
-  node: DrainedNode;
-};
-
-type ChildChange = {
-  type: 'child';
-  node: DrainedNode;
-  child: {
-    relationshipName: string;
-    change: DrainedChange;
-  };
-};
-
-type EditChange = {
-  type: 'edit';
-  node: DrainedNode;
-  oldNode: DrainedNode;
-};
-
-type DrainedNode = {
-  row: Row;
-  relationships: Record<string, () => DrainedNode[]>;
-};

--- a/packages/zql/src/ivm/view-apply-change.ts
+++ b/packages/zql/src/ivm/view-apply-change.ts
@@ -7,14 +7,51 @@ import {
 } from '../../../shared/src/asserts.ts';
 import {must} from '../../../shared/src/must.ts';
 import type {Row} from '../../../zero-protocol/src/data.ts';
-import type {Change} from './change.ts';
-import {drainStreams, type Comparator} from './data.ts';
+import {drainStreams, type Comparator, type Node} from './data.ts';
 import type {SourceSchema} from './schema.ts';
 import type {Entry, EntryList, Format} from './view.ts';
 
+/**
+ * `applyChange` does not consume the `relationships` of `ChildChange#node`,
+ * `EditChange#node` and `EditChange#oldNode`.  The `ViewChange` type
+ * documents and enforces this via the type system.
+ */
+export type ViewChange =
+  | AddViewChange
+  | RemoveViewChange
+  | ChildViewChange
+  | EditViewChange;
+
+export type RowOnlyNode = {row: Row};
+
+export type AddViewChange = {
+  type: 'add';
+  node: Node;
+};
+
+export type RemoveViewChange = {
+  type: 'remove';
+  node: Node;
+};
+
+type ChildViewChange = {
+  type: 'child';
+  node: RowOnlyNode;
+  child: {
+    relationshipName: string;
+    change: ViewChange;
+  };
+};
+
+type EditViewChange = {
+  type: 'edit';
+  node: RowOnlyNode;
+  oldNode: RowOnlyNode;
+};
+
 export function applyChange(
   parentEntry: Entry,
-  change: Change,
+  change: ViewChange,
   schema: SourceSchema,
   relationship: string,
   format: Format,


### PR DESCRIPTION
The `reconcile` optimization approach (https://github.com/rocicorp/mono/pull/3682) was incorrect (I misunderstood how reconcile works), as was revealed by the tests added here: https://github.com/rocicorp/mono/pull/3692.  

This approach goes back to using `produce`, but addresses the correctness issue by using an idea @tantaman came up with of reading the relationships of the changes at the time the push is received, but still queueing them to be applied to the solid store state on transaction completion.   We are careful to only read relationships in the changes actually used by `applyChanges`.

This solved the correctness problem, but while much faster than the 30 seconds prior to us trying to optimize this, the 3000 row initial load case in hello-zero-solid was still spending ~742ms in  SolidView#applyChanges.  
<img width="1434" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/1179b9c4-90eb-4e3d-b0c7-e027ec51fb34" />


This is because the proxy used by solid `produce` is fairly slow.   To address this, I added an optimization for the case where the store's view is currently empty.  If the store is currently empty build up the view on a new plain old JS object root, which is returned for the new state.  This avoids building up large views from scratch using solid `produce`.  This brings the time for the 3000 row initial load case in hello-zero-solid to ~133ms.
<img width="1441" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/0297b057-c826-420c-bdab-66ff2ee1f06d" />

