### PR TITLE
perf(zero-solid): avoid temp arrays when building from empty

### DIFF
--- a/packages/zero-solid/src/solid-view.ts
+++ b/packages/zero-solid/src/solid-view.ts
@@ -34,6 +34,9 @@ export class SolidView<V> implements Output {
   readonly #format: Format;
   readonly #onDestroy: () => void;
 
+  #state: Store<State>;
+  #setState: SetStoreFunction<State>;
+
   // Optimization: if the store is currently empty we build up
   // the view on a plain old JS object stored at #builderRoot, and return
   // that for the new state on transaction commit.  This avoids building up
@@ -43,9 +46,6 @@ export class SolidView<V> implements Output {
   // test case with a view with 3000 rows, each row having 2 children, this
   // optimization reduced #applyChanges time from 743ms to 133ms.
   #builderRoot: Entry | undefined;
-  #state: Store<State>;
-  #setState: SetStoreFunction<State>;
-
   #pendingChanges: ViewChange[] = [];
 
   constructor(


### PR DESCRIPTION
This further optimizes the case of building from empty by avoiding allocating temp arrays.

Now we only have to allocate temp arrays for storing relationships between push and transaction commit when updating a non empty view, which is often smaller updates.

This didn't have an appreciable impact on the test case we've been using of 3000 rows (with 2, 1 child, relationships per row) in hello-zero-solid, but those rows all have very small non-nested relationships, so thats understandable.  I still think this is a worthwhile optimization despite it adding a bit of complexity.
<img width="1443" alt="image" src="https://github.com/user-attachments/assets/e7c13c3a-6a39-444d-aaad-0eab31d6b78f" />
