### PR TITLE
feat(zero-client): maintain the `sync` branch of IVM sources

### DIFF
--- a/packages/replicache/src/replicache-impl.ts
+++ b/packages/replicache/src/replicache-impl.ts
@@ -122,6 +122,7 @@ import {
   withWrite,
   withWriteNoImplicitCommit,
 } from './with-transactions.ts';
+import type {Diff} from './sync/patch.ts';
 
 declare const TESTING: boolean;
 
@@ -1053,7 +1054,14 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}> {
    *
    * @experimental This method is under development and its semantics will change.
    */
-  async poke(poke: PokeInternal): Promise<void> {
+  async poke(
+    poke: PokeInternal,
+    pullApplied: (
+      store: Store,
+      syncHead: Hash,
+      patches: readonly Diff[],
+    ) => Promise<void>,
+  ): Promise<void> {
     await this.#ready;
     // TODO(MP) Previously we created a request ID here and included it with the
     // PullRequest to the server so we could tie events across client and server
@@ -1090,6 +1098,7 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}> {
 
     switch (result.type) {
       case HandlePullResponseResultEnum.Applied:
+        await pullApplied(this.memdag, result.syncHead, result.diffs);
         await this.maybeEndPull(result.syncHead, requestID);
         break;
       case HandlePullResponseResultEnum.CookieMismatch:

--- a/packages/replicache/src/replicache.ts
+++ b/packages/replicache/src/replicache.ts
@@ -371,7 +371,7 @@ export class Replicache<MD extends MutatorDefs = {}> {
    * @experimental This method is under development and its semantics will change.
    */
   poke(poke: Poke): Promise<void> {
-    return this.#impl.poke(poke);
+    return this.#impl.poke(poke, () => Promise.resolve());
   }
 
   /**

--- a/packages/replicache/src/sync/patch.test.ts
+++ b/packages/replicache/src/sync/patch.test.ts
@@ -13,7 +13,7 @@ import {
   assertPatchOperations,
 } from '../patch-operation.ts';
 import {withWriteNoImplicitCommit} from '../with-transactions.ts';
-import {apply} from './patch.ts';
+import {apply, type Diff} from './patch.ts';
 
 type FormatVersion = Enum<typeof FormatVersion>;
 
@@ -30,7 +30,9 @@ describe('patch', () => {
       patch: PatchOperationInternal[];
       expErr?: string | undefined;
       expMap?: Map<string, JSONValue> | undefined;
+      expDiffs?: Diff[] | undefined;
     };
+
     const cases: Case[] = [
       {
         name: 'put',
@@ -40,18 +42,23 @@ describe('patch', () => {
           ['key', 'value'],
           ['foo', 'bar'],
         ]),
+        expDiffs: [{op: 'add', key: 'foo', newValue: 'bar'}],
       },
       {
         name: 'del',
         patch: [{op: 'del', key: 'key'}],
         expErr: undefined,
         expMap: new Map(),
+        expDiffs: [{op: 'del', key: 'key', oldValue: 'value'}],
       },
       {
         name: 'replace',
         patch: [{op: 'put', key: 'key', value: 'newvalue'}],
         expErr: undefined,
         expMap: new Map([['key', 'newvalue']]),
+        expDiffs: [
+          {op: 'change', key: 'key', oldValue: 'value', newValue: 'newvalue'},
+        ],
       },
       {
         name: 'put empty key',
@@ -61,6 +68,7 @@ describe('patch', () => {
           ['key', 'value'],
           ['', 'empty'],
         ]),
+        expDiffs: [{op: 'add', key: '', newValue: 'empty'}],
       },
       {
         name: 'put/replace empty key',
@@ -73,6 +81,10 @@ describe('patch', () => {
           ['key', 'value'],
           ['', 'changed'],
         ]),
+        expDiffs: [
+          {op: 'add', key: '', newValue: 'empty'},
+          {op: 'change', key: '', oldValue: 'empty', newValue: 'changed'},
+        ],
       },
       {
         name: 'put/remove empty key',
@@ -82,12 +94,17 @@ describe('patch', () => {
         ],
         expErr: undefined,
         expMap: new Map([['key', 'value']]),
+        expDiffs: [
+          {op: 'add', key: '', newValue: 'empty'},
+          {op: 'del', key: '', oldValue: 'empty'},
+        ],
       },
       {
         name: 'top-level clear',
         patch: [{op: 'clear'}],
         expErr: undefined,
         expMap: new Map(),
+        expDiffs: [{op: 'clear'}],
       },
       {
         name: 'compound ops',
@@ -102,6 +119,11 @@ describe('patch', () => {
           ['key', 'newvalue'],
           ['baz', 'baz'],
         ]),
+        expDiffs: [
+          {op: 'add', key: 'foo', newValue: 'bar'},
+          {op: 'change', key: 'key', oldValue: 'value', newValue: 'newvalue'},
+          {op: 'add', key: 'baz', newValue: 'baz'},
+        ],
       },
       {
         name: 'no escaping 1',
@@ -111,6 +133,7 @@ describe('patch', () => {
           ['key', 'value'],
           ['~1', 'bar'],
         ]),
+        expDiffs: [{op: 'add', key: '~1', newValue: 'bar'}],
       },
       {
         name: 'no escaping 2',
@@ -120,6 +143,7 @@ describe('patch', () => {
           ['key', 'value'],
           ['~0', 'bar'],
         ]),
+        expDiffs: [{op: 'add', key: '~0', newValue: 'bar'}],
       },
       {
         name: 'no escaping 3',
@@ -129,6 +153,7 @@ describe('patch', () => {
           ['key', 'value'],
           ['/', 'bar'],
         ]),
+        expDiffs: [{op: 'add', key: '/', newValue: 'bar'}],
       },
       {
         name: 'update no merge no constrain no existing',
@@ -138,6 +163,7 @@ describe('patch', () => {
           ['key', 'value'],
           ['foo', {}],
         ]),
+        expDiffs: [{op: 'add', key: 'foo', newValue: {}}],
       },
       {
         name: 'update no merge with constrain no existing',
@@ -147,6 +173,7 @@ describe('patch', () => {
           ['key', 'value'],
           ['foo', {}],
         ]),
+        expDiffs: [{op: 'add', key: 'foo', newValue: {}}],
       },
       {
         name: 'update with merge no constrain no existing',
@@ -158,6 +185,9 @@ describe('patch', () => {
           ['key', 'value'],
           ['foo', {bar: 'baz', fuzzy: 'wuzzy'}],
         ]),
+        expDiffs: [
+          {op: 'add', key: 'foo', newValue: {bar: 'baz', fuzzy: 'wuzzy'}},
+        ],
       },
       {
         name: 'update with merge with constrain no existing',
@@ -174,6 +204,7 @@ describe('patch', () => {
           ['key', 'value'],
           ['foo', {bar: 'baz'}],
         ]),
+        expDiffs: [{op: 'add', key: 'foo', newValue: {bar: 'baz'}}],
       },
       ////
       {
@@ -188,6 +219,14 @@ describe('patch', () => {
           ['key', 'value'],
           ['foo', {bing: 'bong', bar: 'baz'}],
         ]),
+        expDiffs: [
+          {
+            op: 'change',
+            key: 'foo',
+            oldValue: {bing: 'bong', bar: 'baz'},
+            newValue: {bing: 'bong', bar: 'baz'},
+          },
+        ],
       },
       {
         name: 'update no merge with constrain with existing',
@@ -201,6 +240,14 @@ describe('patch', () => {
           ['key', 'value'],
           ['foo', {bar: 'baz'}],
         ]),
+        expDiffs: [
+          {
+            op: 'change',
+            key: 'foo',
+            oldValue: {bing: 'bong', bar: 'baz'},
+            newValue: {bar: 'baz'},
+          },
+        ],
       },
       {
         name: 'update with merge no constrain with existing',
@@ -216,6 +263,14 @@ describe('patch', () => {
           ['key', 'value'],
           ['foo', {bing: 'bong', bar: 'baz2', fuzzy: 'wuzzy'}],
         ]),
+        expDiffs: [
+          {
+            op: 'change',
+            key: 'foo',
+            oldValue: {bing: 'bong', bar: 'baz'},
+            newValue: {bing: 'bong', bar: 'baz2', fuzzy: 'wuzzy'},
+          },
+        ],
       },
       {
         name: 'update with merge with constrain with existing',
@@ -236,6 +291,14 @@ describe('patch', () => {
           ['key', 'value'],
           ['foo', {bing: 'bong', bar: 'baz2'}],
         ]),
+        expDiffs: [
+          {
+            op: 'change',
+            key: 'foo',
+            oldValue: {bing: 'bong', bar: 'baz'},
+            newValue: {bing: 'bong', bar: 'baz2'},
+          },
+        ],
       },
       {
         name: 'update existing is not an object',
@@ -253,6 +316,7 @@ describe('patch', () => {
         ],
         expErr: 'Invalid type: string `bar`, expected object',
         expMap: undefined,
+        expDiffs: undefined,
       },
       {
         name: 'invalid op',
@@ -260,6 +324,7 @@ describe('patch', () => {
         expErr:
           'unknown patch op `BOOM`, expected one of `put`, `del`, `clear`',
         expMap: undefined,
+        expDiffs: undefined,
       },
       {
         name: 'invalid key',
@@ -272,6 +337,7 @@ describe('patch', () => {
         ],
         expErr: 'Invalid type: number `42`, expected string',
         expMap: undefined,
+        expDiffs: undefined,
       },
       {
         name: 'missing value',
@@ -324,7 +390,10 @@ describe('patch', () => {
           let err;
           try {
             assertPatchOperations(ops);
-            await apply(lc, dbWrite, ops);
+            const diffs = await apply(lc, dbWrite, ops);
+            if (c.expDiffs) {
+              expect(diffs).toEqual(c.expDiffs);
+            }
           } catch (e) {
             err = e;
           }

--- a/packages/replicache/src/sync/patch.ts
+++ b/packages/replicache/src/sync/patch.ts
@@ -28,13 +28,23 @@ export async function apply(
   for (const p of patch) {
     switch (p.op) {
       case 'put': {
+        const existing = await dbWrite.get(p.key);
         const frozen = deepFreeze(p.value);
         await dbWrite.put(lc, p.key, frozen);
-        ret.push({
-          op: 'add',
-          key: p.key,
-          newValue: frozen,
-        });
+        if (existing === undefined) {
+          ret.push({
+            op: 'add',
+            key: p.key,
+            newValue: frozen,
+          });
+        } else {
+          ret.push({
+            op: 'change',
+            key: p.key,
+            oldValue: existing,
+            newValue: frozen,
+          });
+        }
         break;
       }
       case 'update': {

--- a/packages/replicache/src/sync/pull.ts
+++ b/packages/replicache/src/sync/pull.ts
@@ -186,6 +186,7 @@ type HandlePullResponseResult =
   | {
       type: HandlePullResponseResultType.Applied;
       syncHead: Hash;
+      diffs: readonly patch.Diff[];
     }
   | {
       type:
@@ -293,11 +294,12 @@ export function handlePullResponseV1(
       formatVersion,
     );
 
-    await patch.apply(lc, dbWrite, response.patch);
+    const diffs = await patch.apply(lc, dbWrite, response.patch);
 
     return {
       type: HandlePullResponseResultType.Applied,
       syncHead: await dbWrite.commit(SYNC_HEAD_NAME),
+      diffs,
     };
   });
 }

--- a/packages/zero-client/src/client/context.ts
+++ b/packages/zero-client/src/client/context.ts
@@ -10,7 +10,7 @@ import type {
   GotCallback,
   QueryDelegate,
 } from '../../../zql/src/query/query-impl.ts';
-import type {IVMSourceBranch} from './ivm-source-repo.ts';
+import {nameFromKey, type IVMSourceBranch} from './ivm-source-repo.ts';
 import {ENTITIES_KEY_PREFIX} from './keys.ts';
 
 export type AddQuery = (
@@ -84,8 +84,7 @@ export class ZeroContext implements QueryDelegate {
         for (const diff of changes) {
           const {key} = diff;
           assert(key.startsWith(ENTITIES_KEY_PREFIX));
-          const slash = key.indexOf('/', ENTITIES_KEY_PREFIX.length);
-          const name = key.slice(ENTITIES_KEY_PREFIX.length, slash);
+          const name = nameFromKey(key);
           const source = this.getSource(name);
           if (!source) {
             continue;

--- a/packages/zero-client/src/client/ivm-source-repo.ts
+++ b/packages/zero-client/src/client/ivm-source-repo.ts
@@ -1,6 +1,15 @@
 import {MemorySource} from '../../../zql/src/ivm/memory-source.ts';
 import type {TableSchema} from '../../../zero-schema/src/table-schema.ts';
 import {wrapIterable} from '../../../shared/src/iterables.ts';
+import type {Store} from '../../../replicache/src/dag/store.ts';
+import {withRead} from '../../../replicache/src/with-transactions.ts';
+import type {Hash} from '../../../replicache/src/hash.ts';
+import {BTreeRead} from '../../../replicache/src/btree/read.ts';
+import * as FormatVersion from '../../../replicache/src/format-version-enum.ts';
+import {ENTITIES_KEY_PREFIX} from './keys.ts';
+import {must} from '../../../shared/src/must.ts';
+import type {Row} from '../../../zero-protocol/src/data.ts';
+import type {Diff} from '../../../replicache/src/sync/patch.ts';
 
 /**
  * Provides handles to IVM sources at different heads.
@@ -11,7 +20,11 @@ import {wrapIterable} from '../../../shared/src/iterables.ts';
 export class IVMSourceRepo {
   readonly #main: IVMSourceBranch;
   readonly #tables: Record<string, TableSchema>;
-  sync: IVMSourceBranch | undefined;
+  // sync is undefined until the first pull
+  #sync: IVMSourceBranch | undefined;
+  // rebase is set to a fork of sync prior to a rebase
+  // rebased mutations are applied to this branch
+  #rebase: IVMSourceBranch | undefined;
 
   constructor(tables: Record<string, TableSchema>) {
     this.#main = new IVMSourceBranch(tables);
@@ -22,12 +35,100 @@ export class IVMSourceRepo {
     return this.#main;
   }
 
-  /**
-   * Creates a new empty branch.
-   */
-  newBranch() {
-    return new IVMSourceBranch(this.#tables);
+  get rebase() {
+    return must(this.#rebase, 'rebase branch does not exist!');
   }
+
+  advanceSyncHead = async (
+    store: Store,
+    syncHeadHash: Hash,
+    patches: readonly Diff[],
+  ): Promise<void> => {
+    /**
+     * The sync head may not exist yet as we do not create it on construction of Zero.
+     * One reason is that the `main` head must exist immediately on startup of Zero since
+     * a user can immediately construct queries on Zero without awaiting. E.g.,
+     *
+     * ```ts
+     * const z = new Zero();
+     * z.query.issue...
+     * ```
+     *
+     * This means that the original plan of:
+     * 1. Create the sync head
+     * 2. Fork sync head
+     * 3. Create main head via applying diffs to the forked sync head
+     *
+     * Does not work since it would require the user to `await` before
+     * they can construct a query.
+     *
+     * Instead, we create an empty `main` head immediately on construction of Zero
+     * which is later filled by `experimentalWatch`.
+     *
+     * To do less work on startup, we defer sync head creation until the
+     * first response from the server.
+     *
+     */
+    if (this.#sync === undefined) {
+      await withRead(store, async dagRead => {
+        const syncSources = new IVMSourceBranch(this.#tables);
+        for await (const entry of new BTreeRead(
+          dagRead,
+          FormatVersion.Latest,
+          syncHeadHash,
+        ).scan(ENTITIES_KEY_PREFIX)) {
+          const name = nameFromKey(entry[0]);
+          const source = must(syncSources.getSource(name));
+          source.push({
+            type: 'add',
+            row: entry[1] as Row,
+          });
+        }
+        this.#sync = syncSources;
+      });
+    } else {
+      // sync head already exists so we advance it from the array of diffs.
+      for (const patch of patches) {
+        if (patch.op === 'clear') {
+          this.#sync.clear();
+          continue;
+        }
+
+        const {key} = patch;
+        const name = nameFromKey(key);
+        const source = must(this.#sync.getSource(name));
+        switch (patch.op) {
+          case 'del':
+            source.push({
+              type: 'remove',
+              row: patch.oldValue as Row,
+            });
+            break;
+          case 'add':
+            source.push({
+              type: 'add',
+              row: patch.newValue as Row,
+            });
+            break;
+          case 'change':
+            source.push({
+              type: 'edit',
+              row: patch.newValue as Row,
+              oldRow: patch.oldValue as Row,
+            });
+            break;
+        }
+      }
+    }
+
+    // Set the branch which can be used for rebasing optimistic mutations.
+    this.#rebase = must(this.#sync).fork();
+  };
+}
+
+export function nameFromKey(key: string): string {
+  const slash = key.indexOf('/', ENTITIES_KEY_PREFIX.length);
+  return key.slice(ENTITIES_KEY_PREFIX.length, slash);
 }
 
 export class IVMSourceBranch {
@@ -55,8 +156,14 @@ export class IVMSourceBranch {
     return source;
   }
 
+  clear() {
+    this.#sources.clear();
+  }
+
   /**
    * Creates a new IVMSourceBranch that is a copy of the current one.
+   * This is a cheap operation since the b-trees are shared until a write is performed
+   * and then only the modified nodes are copied.
    *
    * This is used when:
    * 1. We need to rebase a change. We fork the `sync` branch and run the mutations against the fork.

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -554,7 +554,7 @@ export class Zero<
     this.#metrics.tags.push(`version:${this.version}`);
 
     this.#pokeHandler = new PokeHandler(
-      poke => this.#rep.poke(poke),
+      poke => this.#rep.poke(poke, this.#ivmSources.advanceSyncHead),
       () => this.#onPokeError(),
       rep.clientID,
       schema,

--- a/packages/zql/src/query/test/test-schemas.ts
+++ b/packages/zql/src/query/test/test-schemas.ts
@@ -7,6 +7,7 @@ import {
   string,
   table,
 } from '../../../../zero-schema/src/builder/table-builder.ts';
+import type {Row} from '../query.ts';
 
 const issue = table('issue')
   .from('issues')
@@ -162,3 +163,10 @@ export const issueLabelSchema = schema.tables.issueLabel;
 export const labelSchema = schema.tables.label;
 export const revisionSchema = schema.tables.revision;
 export const userSchema = schema.tables.user;
+
+export type Issue = Row<typeof issueSchema>;
+export type Comment = Row<typeof commentSchema>;
+export type IssueLabel = Row<typeof issueLabelSchema>;
+export type Label = Row<typeof labelSchema>;
+export type Revision = Row<typeof revisionSchema>;
+export type User = Row<typeof userSchema>;


### PR DESCRIPTION
After the first pull is applied, the `sync` branch of the IVM sources is created.

For later pulls, `diffs` are applied to the sync branch to advance it.

The `patch.apply` function was updated to return diffs for the IVM source to apply. The contents of a patch did not have enough information to apply it to IVM sources directly: old values were missing for delete and edit. Rather than doing extra lookups or diffing between dag commits, gathering diffs in `patch.apply` seemed to be the most efficient and minimal change.