### PR TITLE
feat(zero-cache): map CRUD operations to server names

### DIFF
--- a/packages/replicache/src/patch-operation.ts
+++ b/packages/replicache/src/patch-operation.ts
@@ -20,7 +20,7 @@ export type PatchOperationInternal =
       readonly op: 'update';
       readonly key: string;
       readonly merge?: ReadonlyJSONObject | undefined;
-      readonly constrain?: string[] | undefined;
+      readonly constrain?: readonly string[] | undefined;
     }
   | {
       readonly op: 'del';

--- a/packages/zero-client/src/client/zero-poke-handler.test.ts
+++ b/packages/zero-client/src/client/zero-poke-handler.test.ts
@@ -12,7 +12,8 @@ import {
 import type {AST} from '../../../zero-protocol/src/ast.ts';
 import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import {string, table} from '../../../zero-schema/src/builder/table-builder.ts';
-import {PokeHandler, makeClientNames, mergePokes} from './zero-poke-handler.ts';
+import {serverToClient} from '../../../zero-schema/src/name-mapper.ts';
+import {PokeHandler, mergePokes} from './zero-poke-handler.ts';
 
 let rafStub: MockInstance<(cb: FrameRequestCallback) => number>;
 // The FrameRequestCallback in PokeHandler does not use
@@ -1217,7 +1218,7 @@ test('handlePoke returns the last mutation id change for this client from pokePa
 });
 
 test('mergePokes with empty array returns undefined', () => {
-  const merged = mergePokes([], schema, makeClientNames(schema));
+  const merged = mergePokes([], schema, serverToClient(schema.tables));
   expect(merged).to.be.undefined;
 });
 
@@ -1348,7 +1349,7 @@ test('mergePokes with all optionals defined', () => {
       },
     ],
     schema,
-    makeClientNames(schema),
+    serverToClient(schema.tables),
   );
 
   expect(result).toEqual({
@@ -1535,7 +1536,7 @@ test('mergePokes sparse', () => {
       },
     ],
     schema,
-    makeClientNames(schema),
+    serverToClient(schema.tables),
   );
   expect(result).toEqual({
     baseCookie: '3',
@@ -1634,7 +1635,7 @@ test('mergePokes throws error on cookie gaps', () => {
         },
       ],
       schema,
-      makeClientNames(schema),
+      serverToClient(schema.tables),
     );
   }).to.throw();
 });

--- a/packages/zero-client/src/client/zero-poke-handler.ts
+++ b/packages/zero-client/src/client/zero-poke-handler.ts
@@ -34,34 +34,6 @@ type PokeAccumulator = {
   readonly parts: PokePartBody[];
 };
 
-type ServerToClientColumns = {[serverName: string]: string};
-
-type ClientNames = {
-  tableName: string;
-  columns: ServerToClientColumns | null;
-};
-
-export function makeClientNames(schema: Schema): Map<string, ClientNames> {
-  return new Map(
-    Object.entries(schema.tables).map(
-      ([tableName, {serverName: serverTableName, columns}]) => {
-        let allSame = true;
-        const names: Record<string, string> = {};
-        for (const [name, {serverName}] of Object.entries(columns)) {
-          if (serverName && serverName !== name) {
-            allSame = false;
-          }
-          names[serverName ?? name] = name;
-        }
-        return [
-          serverTableName ?? tableName,
-          {tableName, columns: allSame ? null : names},
-        ];
-      },
-    ),
-  );
-}
-
 /**
  * Handles the multi-part format of zero pokes.
  * As an optimization it also debounces pokes, only poking Replicache with a

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -799,34 +799,7 @@ test('pusher sends one mutation per push message', async () => {
       requestID?: string;
     }[],
   ) => {
-    const r = zeroForTest({
-      schema: createSchema(1, {
-        tables: [
-          table('issue')
-            .from('issues')
-            .columns({
-              id: string(),
-              title: string().optional(),
-            })
-            .primaryKey('id'),
-          table('comment')
-            .from('comments')
-            .columns({
-              id: string(),
-              issueID: string().from('issue_id'),
-              text: string().optional(),
-            })
-            .primaryKey('id'),
-          table('compoundPKTest')
-            .columns({
-              id1: string(),
-              id2: string(),
-              text: string(),
-            })
-            .primaryKey('id1', 'id2'),
-        ],
-      }),
-    });
+    const r = zeroForTest();
 
     await r.triggerConnected();
 

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -19,6 +19,7 @@ import * as ErrorKind from '../../../zero-protocol/src/error-kind-enum.ts';
 import * as MutationType from '../../../zero-protocol/src/mutation-type-enum.ts';
 import {PROTOCOL_VERSION} from '../../../zero-protocol/src/protocol-version.ts';
 import {
+  type CRUDOp,
   type Mutation,
   pushMessageSchema,
 } from '../../../zero-protocol/src/push.ts';
@@ -798,7 +799,35 @@ test('pusher sends one mutation per push message', async () => {
       requestID?: string;
     }[],
   ) => {
-    const r = zeroForTest();
+    const r = zeroForTest({
+      schema: createSchema(1, {
+        tables: [
+          table('issue')
+            .from('issues')
+            .columns({
+              id: string(),
+              title: string().optional(),
+            })
+            .primaryKey('id'),
+          table('comment')
+            .from('comments')
+            .columns({
+              id: string(),
+              issueID: string().from('issue_id'),
+              text: string().optional(),
+            })
+            .primaryKey('id'),
+          table('compoundPKTest')
+            .columns({
+              id1: string(),
+              id2: string(),
+              text: string(),
+            })
+            .primaryKey('id1', 'id2'),
+        ],
+      }),
+    });
+
     await r.triggerConnected();
 
     const mockSocket = await r.socket;
@@ -1009,6 +1038,138 @@ test('pusher sends one mutation per push message', async () => {
         },
       ],
       expectedPushMessages: 3,
+    },
+  ]);
+});
+
+test('pusher maps CRUD mutation names', async () => {
+  const t = async (
+    pushes: {
+      client: CRUDOp[];
+      server: CRUDOp[];
+    }[],
+  ) => {
+    const r = zeroForTest({
+      schema: createSchema(1, {
+        tables: [
+          table('issue')
+            .from('issues')
+            .columns({
+              id: string(),
+              title: string().optional(),
+            })
+            .primaryKey('id'),
+          table('comment')
+            .from('comments')
+            .columns({
+              id: string(),
+              issueId: string().from('issue_id'),
+              text: string().optional(),
+            })
+            .primaryKey('id'),
+          table('compoundPKTest')
+            .columns({
+              id1: string().from('id_1'),
+              id2: string().from('id_2'),
+              text: string(),
+            })
+            .primaryKey('id1', 'id2'),
+        ],
+      }),
+    });
+
+    await r.triggerConnected();
+
+    const mockSocket = await r.socket;
+
+    for (const push of pushes) {
+      const {client, server} = push;
+
+      const pushReq: PushRequest = {
+        profileID: 'p1',
+        clientGroupID: await r.clientGroupID,
+        pushVersion: 1,
+        schemaVersion: '1',
+        mutations: [
+          {
+            // type: MutationType.CRUD,
+            clientID: 'c2',
+            id: 2,
+            name: '_zero_crud',
+            args: {ops: client},
+            timestamp: 3,
+          },
+        ],
+      };
+
+      mockSocket.messages.length = 0;
+
+      await r.pusher(pushReq, 'test-request-id');
+
+      expect(mockSocket.messages).to.have.lengthOf(1);
+      for (let i = 0; i < mockSocket.messages.length; i++) {
+        const raw = mockSocket.messages[i];
+        const msg = valita.parse(JSON.parse(raw), pushMessageSchema);
+        expect(msg[1].mutations[0].args[0]).toEqual({ops: server});
+      }
+    }
+  };
+
+  await t([
+    {
+      client: [
+        {
+          op: 'insert',
+          tableName: 'issue',
+          primaryKey: ['id'],
+          value: {id: 'foo', ownerId: 'bar', closed: true},
+        },
+        {
+          op: 'update',
+          tableName: 'comment',
+          primaryKey: ['id'],
+          value: {id: 'baz', issueId: 'foo', description: 'boom'},
+        },
+        {
+          op: 'upsert',
+          tableName: 'compoundPKTest',
+          primaryKey: ['id1', 'id2'],
+          value: {id1: 'voo', id2: 'doo', text: 'zoo'},
+        },
+        {
+          op: 'delete',
+          tableName: 'comment',
+          primaryKey: ['id'],
+          value: {id: 'boo'},
+        },
+      ],
+
+      server: [
+        {
+          op: 'insert',
+          tableName: 'issues',
+          primaryKey: ['id'],
+          value: {id: 'foo', ownerId: 'bar', closed: true},
+        },
+        {
+          op: 'update',
+          tableName: 'comments',
+          primaryKey: ['id'],
+          value: {id: 'baz', ['issue_id']: 'foo', description: 'boom'},
+        },
+        {
+          op: 'upsert',
+          tableName: 'compoundPKTest',
+          primaryKey: ['id_1', 'id_2'],
+          value: {['id_1']: 'voo', ['id_2']: 'doo', text: 'zoo'},
+        },
+        {
+          op: 'delete',
+          tableName: 'comments',
+          primaryKey: ['id'],
+          value: {id: 'boo'},
+        },
+      ],
     },
   ]);
 });
@@ -2268,15 +2429,17 @@ suite('CRUD', () => {
       schema: createSchema(1, {
         tables: [
           table('issue')
+            .from('issues')
             .columns({
               id: string(),
               title: string().optional(),
             })
             .primaryKey('id'),
           table('comment')
+            .from('comments')
             .columns({
               id: string(),
-              issueID: string(),
+              issueID: string().from('issue_id'),
               text: string().optional(),
             })
             .primaryKey('id'),

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -800,7 +800,6 @@ test('pusher sends one mutation per push message', async () => {
     }[],
   ) => {
     const r = zeroForTest();
-
     await r.triggerConnected();
 
     const mockSocket = await r.socket;

--- a/packages/zero-protocol/src/ast.test.ts
+++ b/packages/zero-protocol/src/ast.test.ts
@@ -5,8 +5,12 @@ import {
   string,
   table,
 } from '../../zero-schema/src/builder/table-builder.ts';
+import {
+  clientToServer,
+  serverToClient,
+} from '../../zero-schema/src/name-mapper.ts';
 import type {AST} from './ast.ts';
-import {astSchema, normalizeAST, toClientAST, toServerAST} from './ast.ts';
+import {astSchema, mapAST, normalizeAST} from './ast.ts';
 import {PROTOCOL_VERSION} from './protocol-version.ts';
 
 test('fields are placed into correct positions', () => {
@@ -326,7 +330,7 @@ test('makeServerAST', () => {
       .primaryKey('id')
       .build(),
   };
-  const serverAST = toServerAST(ast, tables);
+  const serverAST = mapAST(ast, clientToServer(tables));
 
   const json = JSON.stringify(serverAST);
   expect(json).toMatch(/"issues"/);
@@ -467,7 +471,7 @@ test('makeServerAST', () => {
     }
   `);
 
-  const clientAST = toClientAST(serverAST, tables);
+  const clientAST = mapAST(serverAST, serverToClient(tables));
   expect(clientAST).toEqual(ast);
   expect(clientAST).toMatchInlineSnapshot(`
     {

--- a/packages/zero-protocol/src/push.test.ts
+++ b/packages/zero-protocol/src/push.test.ts
@@ -1,0 +1,125 @@
+import {expect, test} from 'vitest';
+import {createSchema} from '../../zero-schema/src/builder/schema-builder.ts';
+import {
+  boolean,
+  string,
+  table,
+} from '../../zero-schema/src/builder/table-builder.ts';
+import {clientToServer} from '../../zero-schema/src/name-mapper.ts';
+import {mapCRUD} from './push.ts';
+
+const schema = createSchema(1, {
+  tables: [
+    table('issue')
+      .from('issues')
+      .columns({
+        id: string(),
+        title: string(),
+        description: string(),
+        closed: boolean(),
+        ownerId: string().from('owner_id').optional(),
+      })
+      .primaryKey('id'),
+    table('comment')
+      .from('comments')
+      .columns({
+        id: string().from('comment_id'),
+        issueId: string().from('issue_id'),
+        description: string(),
+      })
+      .primaryKey('id'),
+    table('noMappings')
+      .columns({
+        id: string(),
+        description: string(),
+      })
+      .primaryKey('id'),
+  ],
+});
+
+test('map names', () => {
+  const mapper = clientToServer(schema.tables);
+  expect(
+    mapCRUD(
+      {
+        ops: [
+          {
+            op: 'insert',
+            tableName: 'issue',
+            primaryKey: ['id'],
+            value: {id: 'foo', ownerId: 'bar', closed: true},
+          },
+          {
+            op: 'update',
+            tableName: 'comment',
+            primaryKey: ['id'],
+            value: {id: 'baz', issueId: 'foo', description: 'boom'},
+          },
+          {
+            op: 'upsert',
+            tableName: 'noMappings',
+            primaryKey: ['id'],
+            value: {id: 'voo', description: 'doo'},
+          },
+          {
+            op: 'delete',
+            tableName: 'comment',
+            primaryKey: ['id'],
+            value: {id: 'boo'},
+          },
+        ],
+      },
+      mapper,
+    ),
+  ).toMatchInlineSnapshot(`
+    {
+      "ops": [
+        {
+          "op": "insert",
+          "primaryKey": [
+            "id",
+          ],
+          "tableName": "issues",
+          "value": {
+            "closed": true,
+            "id": "foo",
+            "owner_id": "bar",
+          },
+        },
+        {
+          "op": "update",
+          "primaryKey": [
+            "comment_id",
+          ],
+          "tableName": "comments",
+          "value": {
+            "comment_id": "baz",
+            "description": "boom",
+            "issue_id": "foo",
+          },
+        },
+        {
+          "op": "upsert",
+          "primaryKey": [
+            "id",
+          ],
+          "tableName": "noMappings",
+          "value": {
+            "description": "doo",
+            "id": "voo",
+          },
+        },
+        {
+          "op": "delete",
+          "primaryKey": [
+            "comment_id",
+          ],
+          "tableName": "comments",
+          "value": {
+            "comment_id": "boo",
+          },
+        },
+      ],
+    }
+  `);
+});

--- a/packages/zero-protocol/tsconfig.json
+++ b/packages/zero-protocol/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*.ts", "../zero-schema/src/name-mapper.ts"]
+  "include": ["src/**/*.ts"]
 }

--- a/packages/zero-protocol/tsconfig.json
+++ b/packages/zero-protocol/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "../zero-schema/src/name-mapper.ts"]
 }

--- a/packages/zero-schema/src/name-mapper.test.ts
+++ b/packages/zero-schema/src/name-mapper.test.ts
@@ -1,0 +1,127 @@
+import {expect, test} from 'vitest';
+import {createSchema} from './builder/schema-builder.ts';
+import {boolean, string, table} from './builder/table-builder.ts';
+import {clientToServer, serverToClient} from './name-mapper.ts';
+
+const schema = createSchema(1, {
+  tables: [
+    table('issue')
+      .from('issues')
+      .columns({
+        id: string(),
+        title: string(),
+        description: string(),
+        closed: boolean(),
+        ownerId: string().from('owner_id').optional(),
+      })
+      .primaryKey('id'),
+    table('comment')
+      .from('comments')
+      .columns({
+        id: string().from('comment_id'),
+        issueId: string().from('issue_id'),
+        description: string(),
+      })
+      .primaryKey('id'),
+    table('noMappings')
+      .columns({
+        id: string(),
+        description: string(),
+      })
+      .primaryKey('id'),
+  ],
+});
+
+test('name mapping to server', () => {
+  const map = serverToClient(schema.tables);
+
+  expect(map.tableName('issues')).toBe('issue');
+  expect(map.tableName('comments')).toBe('comment');
+  expect(map.tableName('noMappings')).toBe('noMappings');
+  expect(() => map.tableName('unknown')).toThrowErrorMatchingInlineSnapshot(
+    `[Error: unknown table "unknown" ]`,
+  );
+
+  expect(map.columnName('issues', 'id')).toBe('id');
+  expect(map.columnName('comments', 'comment_id')).toBe('id');
+  expect(map.columnName('noMappings', 'id')).toBe('id');
+  expect(() =>
+    map.columnName('comments', 'unknown'),
+  ).toThrowErrorMatchingInlineSnapshot(
+    `[Error: unknown column "unknown" of "comments" table ]`,
+  );
+
+  expect(
+    map.row('issues', {id: 'foo', ['owner_id']: 'bar', unknown: 'passthrough'}),
+  ).toEqual({id: 'foo', ownerId: 'bar', unknown: 'passthrough'});
+  expect(
+    map.row('comments', {
+      ['comment_id']: 'baz',
+      ['issue_id']: 'foo',
+      unknown: 'passthrough',
+    }),
+  ).toEqual({id: 'baz', issueId: 'foo', unknown: 'passthrough'});
+  const uncopiedRow = {id: 'boo', description: 'uncopied'};
+  expect(map.row('noMappings', uncopiedRow)).toBe(uncopiedRow);
+
+  expect(map.columns('issues', ['id', 'owner_id', 'unknown'])).toEqual([
+    'id',
+    'ownerId',
+    'unknown',
+  ]);
+  expect(
+    map.columns('comments', ['comment_id', 'issue_id', 'unknown']),
+  ).toEqual(['id', 'issueId', 'unknown']);
+
+  const uncopiedColumns = ['id', 'description'];
+  expect(map.columns('noMappings', uncopiedColumns)).toBe(uncopiedColumns);
+});
+
+test('name mapping to client', () => {
+  const map = clientToServer(schema.tables);
+
+  expect(map.tableName('issue')).toBe('issues');
+  expect(map.tableName('comment')).toBe('comments');
+  expect(map.tableName('noMappings')).toBe('noMappings');
+  expect(() => map.tableName('unknown')).toThrowErrorMatchingInlineSnapshot(
+    `[Error: unknown table "unknown" ]`,
+  );
+
+  expect(map.columnName('issue', 'id')).toBe('id');
+  expect(map.columnName('comment', 'id')).toBe('comment_id');
+  expect(map.columnName('noMappings', 'id')).toBe('id');
+  expect(() =>
+    map.columnName('comments', 'unknown'),
+  ).toThrowErrorMatchingInlineSnapshot(`[Error: unknown table "comments" ]`);
+
+  expect(
+    map.row('issue', {id: 'foo', ownerId: 'bar', unknown: 'passthrough'}),
+  ).toEqual({id: 'foo', ['owner_id']: 'bar', unknown: 'passthrough'});
+  expect(
+    map.row('comment', {
+      id: 'baz',
+      issueId: 'foo',
+      unknown: 'passthrough',
+    }),
+  ).toEqual({
+    ['comment_id']: 'baz',
+    ['issue_id']: 'foo',
+    unknown: 'passthrough',
+  });
+  const uncopiedRow = {id: 'boo', description: 'uncopied'};
+  expect(map.row('noMappings', uncopiedRow)).toBe(uncopiedRow);
+
+  expect(map.columns('issue', ['id', 'ownerId', 'unknown'])).toEqual([
+    'id',
+    'owner_id',
+    'unknown',
+  ]);
+  expect(map.columns('comment', ['id', 'issueId', 'unknown'])).toEqual([
+    'comment_id',
+    'issue_id',
+    'unknown',
+  ]);
+
+  const uncopiedColumns = ['id', 'description'];
+  expect(map.columns('noMappings', uncopiedColumns)).toBe(uncopiedColumns);
+});

--- a/packages/zero-schema/src/name-mapper.ts
+++ b/packages/zero-schema/src/name-mapper.ts
@@ -1,0 +1,118 @@
+import type {JSONValue} from '../../shared/src/json.ts';
+import type {Row, Value} from '../../zero-protocol/src/data.ts';
+import type {TableSchema} from './table-schema.ts';
+
+type ColumnNames = {[src: string]: string};
+
+type DestNames = {
+  tableName: string;
+  columns: ColumnNames;
+  allColumnsSame: boolean;
+};
+
+export function clientToServer(
+  tables: Record<string, TableSchema>,
+): NameMapper {
+  return createMapperFrom('client', tables);
+}
+
+export function serverToClient(
+  tables: Record<string, TableSchema>,
+): NameMapper {
+  return createMapperFrom('server', tables);
+}
+
+function createMapperFrom(
+  src: 'client' | 'server',
+  tables: Record<string, TableSchema>,
+): NameMapper {
+  const mapping = new Map(
+    Object.entries(tables).map(
+      ([tableName, {serverName: serverTableName, columns}]) => {
+        let allColumnsSame = true;
+        const names: Record<string, string> = {};
+        for (const [name, {serverName}] of Object.entries(columns)) {
+          if (serverName && serverName !== name) {
+            allColumnsSame = false;
+          }
+          if (src === 'client') {
+            names[name] = serverName ?? name;
+          } else {
+            names[serverName ?? name] = name;
+          }
+        }
+        return [
+          src === 'client' ? tableName : serverTableName ?? tableName,
+          {
+            tableName:
+              src === 'client' ? serverTableName ?? tableName : tableName,
+            columns: names,
+            allColumnsSame,
+          },
+        ];
+      },
+    ),
+  );
+  return new NameMapper(mapping);
+}
+
+export class NameMapper {
+  readonly #tables = new Map<string, DestNames>();
+
+  constructor(tables: Map<string, DestNames>) {
+    this.#tables = tables;
+  }
+
+  #getTable(src: string, ctx?: JSONValue | undefined): DestNames {
+    const table = this.#tables.get(src);
+    if (!table) {
+      throw new Error(
+        `unknown table "${src}" ${!ctx ? '' : `in ${JSON.stringify(ctx)}`}`,
+      );
+    }
+    return table;
+  }
+
+  tableName(src: string, context?: JSONValue): string {
+    return this.#getTable(src, context).tableName;
+  }
+
+  columnName(table: string, src: string, ctx?: JSONValue): string {
+    const dst = this.#getTable(table, ctx).columns[src];
+    if (!dst) {
+      throw new Error(
+        `unknown column "${src}" of "${table}" table ${
+          !ctx ? '' : `in ${JSON.stringify(ctx)}`
+        }`,
+      );
+    }
+    return dst;
+  }
+
+  row<R extends Row>(table: string, row: R): R {
+    const dest = this.#getTable(table);
+    const {allColumnsSame, columns} = dest;
+    if (allColumnsSame) {
+      return row;
+    }
+    const clientRow: Record<string, Value> = {};
+    for (const col in row) {
+      // Note: columns with unknown names simply pass through.
+      clientRow[columns[col] ?? col] = row[col];
+    }
+    return clientRow as R;
+  }
+
+  columns(
+    table: string,
+    cols: readonly string[] | undefined,
+  ): readonly string[] | undefined {
+    const dest = this.#getTable(table);
+    const {allColumnsSame, columns} = dest;
+
+    // Note: Columns not defined in the schema simply pass through.
+    return cols === undefined || allColumnsSame
+      ? cols
+      : cols.map(col => columns[col] ?? col);
+  }
+}


### PR DESCRIPTION
Maps CRUD operations to their server names if aliased in the schema.

Also consolidates the name mapping logic.