### PR TITLE
Allow `Row` helper to work with singular queries.

### DIFF
--- a/packages/zql/src/query/query.ts
+++ b/packages/zql/src/query/query.ts
@@ -91,7 +91,7 @@ export type PullRow<TTable extends string, TSchema extends ZeroSchema> = {
   >;
 };
 
-export type Row<T extends TableSchema | Query<ZeroSchema, string>> =
+export type Row<T extends TableSchema | Query<ZeroSchema, string, any>> =
   T extends TableSchema
     ? {
         readonly [K in keyof T['columns']]: SchemaValueToTSType<


### PR DESCRIPTION
Fixes https://bugs.rocicorp.dev/issue/3503