### PR TITLE
fix(replicache): Collecting IDB with pending mutations...

### DIFF
--- a/packages/replicache/src/persist/clients-test-helpers.ts
+++ b/packages/replicache/src/persist/clients-test-helpers.ts
@@ -52,7 +52,7 @@ export function makeClientV6(partialClient: PartialClientV6): ClientV6 {
   };
 }
 
-export function makeClientMapDD31(
+export function makeClientMap(
   obj: Record<ClientID, PartialClientV5>,
 ): ClientMapDD31 {
   return new Map(

--- a/packages/replicache/src/replicache-impl.ts
+++ b/packages/replicache/src/replicache-impl.ts
@@ -514,6 +514,7 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}> {
     void this.#open(
       indexes,
       enableClientGroupForking,
+      enableMutationRecovery,
       clientMaxAgeMs,
       profileIDResolver.resolve,
       clientGroupIDResolver.resolve,
@@ -525,6 +526,7 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}> {
   async #open(
     indexes: IndexDefinitions,
     enableClientGroupForking: boolean,
+    enableMutationRecovery: boolean,
     clientMaxAgeMs: number,
     profileIDResolver: (profileID: string) => void,
     resolveClientGroupID: (clientGroupID: ClientGroupID) => void,
@@ -587,6 +589,7 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}> {
       COLLECT_IDB_INTERVAL,
       INITIAL_COLLECT_IDB_DELAY,
       2 * clientMaxAgeMs,
+      enableMutationRecovery,
       onClientsDeleted,
       this.#lc,
       signal,


### PR DESCRIPTION
Allow collecting IDB databases with pending mutations if mutation recovery is disabled.

This is important because in Zero client we have disabled mutation recovery and if we do not collect old IDB databases with pending mutations, we will never collect them.