### PR TITLE
feat(zero-client): implement rebasing of custom mutators

### DIFF
--- a/packages/zero-client/src/client/ivm-source-repo.test.ts
+++ b/packages/zero-client/src/client/ivm-source-repo.test.ts
@@ -109,7 +109,7 @@ test('fork', () => {
 
 const lc = createSilentLogContext();
 let timestamp = 42;
-async function createDb(
+export async function createDb(
   puts: Array<[string, Issue | Comment | Label | IssueLabel | Revision]>,
 ) {
   const clientID = 'client-id';


### PR DESCRIPTION
I did not update crud mutators to write to the IVM source  during a rebase as the intent is to remove support for CRUD mutators when custom mutators are ready.