### PR TITLE
feat(zero-cache): allow multiple zero-cache shards to use the same CVR db

### DIFF
--- a/packages/zero-cache/src/db/migration.ts
+++ b/packages/zero-cache/src/db/migration.ts
@@ -1,7 +1,6 @@
 import type {LogContext} from '@rocicorp/logger';
 import type postgres from 'postgres';
 import {assert} from '../../../shared/src/asserts.ts';
-import {randInt} from '../../../shared/src/rand.ts';
 import * as v from '../../../shared/src/valita.ts';
 import type {PostgresDB, PostgresTransaction} from '../types/pg.ts';
 
@@ -64,10 +63,7 @@ export async function runSchemaMigrations(
   setupMigration: Migration,
   incrementalMigrationMap: IncrementalMigrationMap,
 ): Promise<void> {
-  log = log.withContext(
-    'initSchema',
-    randInt(0, Number.MAX_SAFE_INTEGER).toString(36),
-  );
+  log = log.withContext('initSchema', schemaName);
   try {
     const versionMigrations = sorted(incrementalMigrationMap);
     assert(

--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -109,7 +109,7 @@ export default async function runWorker(
     // but it is done here in the main thread because it is wasteful to have all of
     // the Syncers attempt the migration in parallel.
     const cvrDB = pgClient(lc, config.cvr.db);
-    await initViewSyncerSchema(lc, cvrDB);
+    await initViewSyncerSchema(lc, cvrDB, config.shard.id);
     void cvrDB.end();
   }
 

--- a/packages/zero-cache/src/services/view-syncer/cvr-store.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.pg-test.ts
@@ -23,6 +23,8 @@ import {
 import {setupCVRTables, type RowsRow} from './schema/cvr.ts';
 import type {CVRVersion} from './schema/types.ts';
 
+const SHARD_ID = 'sdf';
+
 describe('view-syncer/cvr-store', () => {
   const lc = createSilentLogContext();
   let db: PostgresDB;
@@ -40,40 +42,40 @@ describe('view-syncer/cvr-store', () => {
 
   beforeEach(async () => {
     db = await testDBs.create('view_syncer_cvr_schema');
-    await db.begin(tx => setupCVRTables(lc, tx));
+    await db.begin(tx => setupCVRTables(lc, tx, SHARD_ID));
     await db.unsafe(`
-    INSERT INTO cvr.instances ("clientGroupID", version, "lastActive", "replicaVersion")
+    INSERT INTO cvr_sdf.instances ("clientGroupID", version, "lastActive", "replicaVersion")
       VALUES('${CVR_ID}', '03', '2024-09-04', '01');
-    INSERT INTO cvr.queries ("clientGroupID", "queryHash", "clientAST", 
+    INSERT INTO cvr_sdf.queries ("clientGroupID", "queryHash", "clientAST", 
                              "patchVersion", "transformationHash", "transformationVersion")
       VALUES('${CVR_ID}', 'foo', '{"table":"issues"}', '01', 'foo-transformed', '01');
-    INSERT INTO cvr."rowsVersion" ("clientGroupID", version)
+    INSERT INTO cvr_sdf."rowsVersion" ("clientGroupID", version)
       VALUES('${CVR_ID}', '03');
-    INSERT INTO cvr.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
+    INSERT INTO cvr_sdf.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
       VALUES('${CVR_ID}', '', 'issues', '{"id":"1"}', '01', '01', NULL);
-    INSERT INTO cvr.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
+    INSERT INTO cvr_sdf.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
       VALUES('${CVR_ID}', '', 'issues', '{"id":"2"}', '01', '01', '{"foo":1}');
-    INSERT INTO cvr.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
+    INSERT INTO cvr_sdf.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
       VALUES('${CVR_ID}', '', 'issues', '{"id":"3"}', '01', '01', '{"bar":2}');
-    INSERT INTO cvr.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
+    INSERT INTO cvr_sdf.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
       VALUES('${CVR_ID}', '', 'issues', '{"id":"4"}', '01', '01', '{"foo":2,"bar":3}');
 
-    INSERT INTO cvr.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
+    INSERT INTO cvr_sdf.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
       VALUES('${CVR_ID}', '', 'issues', '{"id":"5"}', '01', '02', NULL);
-    INSERT INTO cvr.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
+    INSERT INTO cvr_sdf.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
       VALUES('${CVR_ID}', '', 'issues', '{"id":"6"}', '01', '02', '{"foo":1}');
-    INSERT INTO cvr.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
+    INSERT INTO cvr_sdf.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
       VALUES('${CVR_ID}', '', 'issues', '{"id":"7"}', '01', '02', '{"bar":2}');
-    INSERT INTO cvr.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
+    INSERT INTO cvr_sdf.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
       VALUES('${CVR_ID}', '', 'issues', '{"id":"8"}', '01', '02', '{"foo":2,"bar":3}');
 
-    INSERT INTO cvr.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
+    INSERT INTO cvr_sdf.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
       VALUES('${CVR_ID}', '', 'issues', '{"id":"9"}', '01', '03', NULL);
-    INSERT INTO cvr.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
+    INSERT INTO cvr_sdf.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
       VALUES('${CVR_ID}', '', 'issues', '{"id":"10"}', '01', '03', '{"foo":1}');
-    INSERT INTO cvr.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
+    INSERT INTO cvr_sdf.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
       VALUES('${CVR_ID}', '', 'issues', '{"id":"11"}', '01', '03', '{"bar":2}');
-    INSERT INTO cvr.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
+    INSERT INTO cvr_sdf.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
       VALUES('${CVR_ID}', '', 'issues', '{"id":"12"}', '01', '03', '{"foo":2,"bar":3}');
       `);
 
@@ -81,6 +83,7 @@ describe('view-syncer/cvr-store', () => {
     store = new CVRStore(
       lc,
       db,
+      SHARD_ID,
       TASK_ID,
       CVR_ID,
       ON_FAILURE,
@@ -97,7 +100,7 @@ describe('view-syncer/cvr-store', () => {
 
   test('wait for row catchup', async () => {
     // Simulate the CVR being ahead of the rows.
-    await db`UPDATE cvr.instances SET version = '04'`;
+    await db`UPDATE cvr_sdf.instances SET version = '04'`;
 
     // start a CVR load.
     const loading = store.load(lc, CONNECT_TIME);
@@ -106,8 +109,8 @@ describe('view-syncer/cvr-store', () => {
 
     // Simulate catching up.
     await db`
-    UPDATE cvr.instances SET version = '05:01';
-    UPDATE cvr."rowsVersion" SET version = '05:01';
+    UPDATE cvr_sdf.instances SET version = '05:01';
+    UPDATE cvr_sdf."rowsVersion" SET version = '05:01';
     `.simple();
 
     const cvr = await loading;
@@ -119,7 +122,7 @@ describe('view-syncer/cvr-store', () => {
 
   test('fail after max attempts if rows behind', async () => {
     // Simulate the CVR being ahead of the rows.
-    await db`UPDATE cvr.instances SET version = '04'`;
+    await db`UPDATE cvr_sdf.instances SET version = '04'`;
 
     await expect(
       store.load(lc, CONNECT_TIME),
@@ -128,7 +131,7 @@ describe('view-syncer/cvr-store', () => {
     );
 
     // Verify that the store signaled an ownership change to 'my-task' at CONNECT_TIME.
-    expect(await db`SELECT * FROM cvr.instances`).toMatchInlineSnapshot(`
+    expect(await db`SELECT * FROM cvr_sdf.instances`).toMatchInlineSnapshot(`
       Result [
         {
           "clientGroupID": "my-cvr",
@@ -144,14 +147,14 @@ describe('view-syncer/cvr-store', () => {
 
   test('wrong owner', async () => {
     // Simulate the CVR being owned by someone else.
-    await db`UPDATE cvr.instances SET owner = 'other-task', "grantedAt" = ${
+    await db`UPDATE cvr_sdf.instances SET owner = 'other-task', "grantedAt" = ${
       CONNECT_TIME + 1
     }`;
 
     await expect(store.load(lc, CONNECT_TIME)).rejects.toThrow(OwnershipError);
 
     // Verify that no ownership change was signaled.
-    expect(await db`SELECT * FROM cvr.instances`).toMatchInlineSnapshot(`
+    expect(await db`SELECT * FROM cvr_sdf.instances`).toMatchInlineSnapshot(`
       Result [
         {
           "clientGroupID": "my-cvr",
@@ -366,7 +369,7 @@ describe('view-syncer/cvr-store', () => {
     let cvr = await store.load(lc, CONNECT_TIME);
 
     // 12 rows set up in beforeEach().
-    expect(await db`SELECT COUNT(*) FROM cvr.rows`).toEqual([{count: 12n}]);
+    expect(await db`SELECT COUNT(*) FROM cvr_sdf.rows`).toEqual([{count: 12n}]);
 
     let updater = new CVRQueryDrivenUpdater(store, cvr, '04', '01');
     updater.trackQueries(
@@ -386,7 +389,7 @@ describe('view-syncer/cvr-store', () => {
     await updater.received(lc, rows);
     cvr = (await updater.flush(lc, CONNECT_TIME, now)).cvr;
 
-    expect(await db`SELECT * FROM cvr.instances`).toMatchInlineSnapshot(`
+    expect(await db`SELECT * FROM cvr_sdf.instances`).toMatchInlineSnapshot(`
       Result [
         {
           "clientGroupID": "my-cvr",
@@ -400,7 +403,8 @@ describe('view-syncer/cvr-store', () => {
     `);
 
     // rowsVersion === '03' (flush deferred).
-    expect(await db`SELECT * FROM cvr."rowsVersion"`).toMatchInlineSnapshot(`
+    expect(await db`SELECT * FROM cvr_sdf."rowsVersion"`)
+      .toMatchInlineSnapshot(`
       Result [
         {
           "clientGroupID": "my-cvr",
@@ -410,7 +414,7 @@ describe('view-syncer/cvr-store', () => {
     `);
 
     // Still only 12 rows.
-    expect(await db`SELECT COUNT(*) FROM cvr.rows`).toEqual([{count: 12n}]);
+    expect(await db`SELECT COUNT(*) FROM cvr_sdf.rows`).toEqual([{count: 12n}]);
 
     // Flush was scheduled.
     expect(setTimeoutFn).toHaveBeenCalledOnce();
@@ -436,7 +440,7 @@ describe('view-syncer/cvr-store', () => {
     await updater.received(lc, rows);
     await updater.flush(lc, CONNECT_TIME, now);
 
-    expect(await db`SELECT * FROM cvr.instances`).toMatchInlineSnapshot(`
+    expect(await db`SELECT * FROM cvr_sdf.instances`).toMatchInlineSnapshot(`
       Result [
         {
           "clientGroupID": "my-cvr",
@@ -450,7 +454,8 @@ describe('view-syncer/cvr-store', () => {
     `);
 
     // rowsVersion === '03' (flush deferred).
-    expect(await db`SELECT * FROM cvr."rowsVersion"`).toMatchInlineSnapshot(`
+    expect(await db`SELECT * FROM cvr_sdf."rowsVersion"`)
+      .toMatchInlineSnapshot(`
       Result [
         {
           "clientGroupID": "my-cvr",
@@ -460,13 +465,14 @@ describe('view-syncer/cvr-store', () => {
     `);
 
     // Still only 12 rows.
-    expect(await db`SELECT COUNT(*) FROM cvr.rows`).toEqual([{count: 12n}]);
+    expect(await db`SELECT COUNT(*) FROM cvr_sdf.rows`).toEqual([{count: 12n}]);
 
     // Now run the flush logic.
     await setTimeoutFn.mock.calls[0][0]();
 
     // rowsVersion === '05' (flushed).
-    expect(await db`SELECT * FROM cvr."rowsVersion"`).toMatchInlineSnapshot(`
+    expect(await db`SELECT * FROM cvr_sdf."rowsVersion"`)
+      .toMatchInlineSnapshot(`
       Result [
         {
           "clientGroupID": "my-cvr",
@@ -476,7 +482,7 @@ describe('view-syncer/cvr-store', () => {
     `);
 
     // 12 + 6 + 4.
-    expect(await db`SELECT COUNT(*) FROM cvr.rows`).toEqual([{count: 22n}]);
+    expect(await db`SELECT COUNT(*) FROM cvr_sdf.rows`).toEqual([{count: 22n}]);
   });
 
   test('deferred row stress test', async () => {
@@ -487,7 +493,7 @@ describe('view-syncer/cvr-store', () => {
     setTimeoutFn.mockImplementation((cb, ms) => setTimeout(cb, ms));
 
     // 12 rows set up in beforeEach().
-    expect(await db`SELECT COUNT(*) FROM cvr.rows`).toEqual([{count: 12n}]);
+    expect(await db`SELECT COUNT(*) FROM cvr_sdf.rows`).toEqual([{count: 12n}]);
 
     // Commit 30 flushes of 10 rows each.
     for (let i = 20; i < 320; i += 10) {
@@ -515,7 +521,7 @@ describe('view-syncer/cvr-store', () => {
       await sleep(Math.random() * 1);
     }
 
-    expect(await db`SELECT * FROM cvr.instances`).toMatchInlineSnapshot(`
+    expect(await db`SELECT * FROM cvr_sdf.instances`).toMatchInlineSnapshot(`
       Result [
         {
           "clientGroupID": "my-cvr",
@@ -531,8 +537,9 @@ describe('view-syncer/cvr-store', () => {
     // Should block until all pending rows are flushed.
     await store.flushed(lc);
 
-    // rowsVersion should match cvr.instances version
-    expect(await db`SELECT * FROM cvr."rowsVersion"`).toMatchInlineSnapshot(`
+    // rowsVersion should match cvr_sdf.instances version
+    expect(await db`SELECT * FROM cvr_sdf."rowsVersion"`)
+      .toMatchInlineSnapshot(`
             Result [
               {
                 "clientGroupID": "my-cvr",
@@ -542,7 +549,9 @@ describe('view-syncer/cvr-store', () => {
           `);
 
     // 12 + (30 * 10)
-    expect(await db`SELECT COUNT(*) FROM cvr.rows`).toEqual([{count: 312n}]);
+    expect(await db`SELECT COUNT(*) FROM cvr_sdf.rows`).toEqual([
+      {count: 312n},
+    ]);
   });
 
   test('deferred row stress test with empty updates', async () => {
@@ -553,7 +562,7 @@ describe('view-syncer/cvr-store', () => {
     setTimeoutFn.mockImplementation((cb, ms) => setTimeout(cb, ms));
 
     // 12 rows set up in beforeEach().
-    expect(await db`SELECT COUNT(*) FROM cvr.rows`).toEqual([{count: 12n}]);
+    expect(await db`SELECT COUNT(*) FROM cvr_sdf.rows`).toEqual([{count: 12n}]);
 
     // Commit 30 flushes of 10 rows each.
     for (let i = 20; i < 320; i += 10) {
@@ -597,7 +606,7 @@ describe('view-syncer/cvr-store', () => {
     await updater.received(lc, rows);
     await updater.flush(lc, CONNECT_TIME, now);
 
-    expect(await db`SELECT * FROM cvr.instances`).toMatchInlineSnapshot(`
+    expect(await db`SELECT * FROM cvr_sdf.instances`).toMatchInlineSnapshot(`
       Result [
         {
           "clientGroupID": "my-cvr",
@@ -613,8 +622,9 @@ describe('view-syncer/cvr-store', () => {
     // Should block until all pending rows are flushed.
     await store.flushed(lc);
 
-    // rowsVersion should match cvr.instances version
-    expect(await db`SELECT * FROM cvr."rowsVersion"`).toMatchInlineSnapshot(`
+    // rowsVersion should match cvr_sdf.instances version
+    expect(await db`SELECT * FROM cvr_sdf."rowsVersion"`)
+      .toMatchInlineSnapshot(`
             Result [
               {
                 "clientGroupID": "my-cvr",
@@ -624,7 +634,9 @@ describe('view-syncer/cvr-store', () => {
           `);
 
     // 12 + (30 * 10)
-    expect(await db`SELECT COUNT(*) FROM cvr.rows`).toEqual([{count: 312n}]);
+    expect(await db`SELECT COUNT(*) FROM cvr_sdf.rows`).toEqual([
+      {count: 312n},
+    ]);
   });
 
   test('large batch row updates', async () => {
@@ -632,7 +644,7 @@ describe('view-syncer/cvr-store', () => {
     let cvr = await store.load(lc, CONNECT_TIME);
 
     // 12 rows set up in beforeEach().
-    expect(await db`SELECT COUNT(*) FROM cvr.rows`).toEqual([{count: 12n}]);
+    expect(await db`SELECT COUNT(*) FROM cvr_sdf.rows`).toEqual([{count: 12n}]);
 
     const updater = new CVRQueryDrivenUpdater(store, cvr, '04', '01');
     updater.trackQueries(
@@ -653,7 +665,7 @@ describe('view-syncer/cvr-store', () => {
     await updater.received(lc, rows);
     cvr = (await updater.flush(lc, CONNECT_TIME, now)).cvr;
 
-    expect(await db`SELECT * FROM cvr.instances`).toMatchInlineSnapshot(`
+    expect(await db`SELECT * FROM cvr_sdf.instances`).toMatchInlineSnapshot(`
     Result [
       {
         "clientGroupID": "my-cvr",
@@ -667,7 +679,8 @@ describe('view-syncer/cvr-store', () => {
   `);
 
     // rowsVersion === '03' (flush deferred).
-    expect(await db`SELECT * FROM cvr."rowsVersion"`).toMatchInlineSnapshot(`
+    expect(await db`SELECT * FROM cvr_sdf."rowsVersion"`)
+      .toMatchInlineSnapshot(`
     Result [
       {
         "clientGroupID": "my-cvr",
@@ -677,7 +690,7 @@ describe('view-syncer/cvr-store', () => {
   `);
 
     // Still only 12 rows.
-    expect(await db`SELECT COUNT(*) FROM cvr.rows`).toEqual([{count: 12n}]);
+    expect(await db`SELECT COUNT(*) FROM cvr_sdf.rows`).toEqual([{count: 12n}]);
 
     // Flush was scheduled.
     expect(setTimeoutFn).toHaveBeenCalledOnce();
@@ -686,7 +699,8 @@ describe('view-syncer/cvr-store', () => {
     await setTimeoutFn.mock.calls[0][0]();
 
     // rowsVersion === '04' (flushed).
-    expect(await db`SELECT * FROM cvr."rowsVersion"`).toMatchInlineSnapshot(`
+    expect(await db`SELECT * FROM cvr_sdf."rowsVersion"`)
+      .toMatchInlineSnapshot(`
     Result [
       {
         "clientGroupID": "my-cvr",
@@ -696,6 +710,8 @@ describe('view-syncer/cvr-store', () => {
   `);
 
     // 12 + 1023 = 1035
-    expect(await db`SELECT COUNT(*) FROM cvr.rows`).toEqual([{count: 1035n}]);
+    expect(await db`SELECT COUNT(*) FROM cvr_sdf.rows`).toEqual([
+      {count: 1035n},
+    ]);
   });
 });

--- a/packages/zero-cache/src/services/view-syncer/schema/init.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/init.ts
@@ -6,21 +6,85 @@ import {
   type Migration,
 } from '../../../db/migration.ts';
 import type {PostgresDB} from '../../../types/pg.ts';
-import {
-  CREATE_CVR_ROWS_VERSION_TABLE,
-  PG_SCHEMA,
-  setupCVRTables,
-} from './cvr.ts';
+import {createRowsVersionTable, cvrSchema, setupCVRTables} from './cvr.ts';
 
-const setupMigration: Migration = {
-  migrateSchema: setupCVRTables,
-  minSafeVersion: 1,
-};
+async function migrateFromLegacySchema(
+  lc: LogContext,
+  db: PostgresDB,
+  newSchema: string,
+) {
+  const result = await db`SELECT * FROM pg_namespace WHERE nspname = 'cvr'`;
+  if (result.length > 0) {
+    lc.info?.(`Migrated cvr to ${newSchema}`);
+    await db`ALTER SCHEMA cvr RENAME TO ${db(newSchema)}`;
+  }
+}
 
 export async function initViewSyncerSchema(
   log: LogContext,
   db: PostgresDB,
+  shardID: string,
 ): Promise<void> {
+  const schema = cvrSchema(shardID);
+
+  await migrateFromLegacySchema(log, db, schema);
+
+  const setupMigration: Migration = {
+    migrateSchema: (lc, tx) => setupCVRTables(lc, tx, shardID),
+    minSafeVersion: 1,
+  };
+
+  const migrateV1toV2: Migration = {
+    migrateSchema: async (_, tx) => {
+      await tx`ALTER TABLE ${tx(schema)}.instances ADD "replicaVersion" TEXT`;
+    },
+  };
+
+  const migrateV2ToV3: Migration = {
+    migrateSchema: async (_, tx) => {
+      await tx.unsafe(createRowsVersionTable(shardID));
+    },
+
+    /** Populates the cvr.rowsVersion table with versions from cvr.instances. */
+    migrateData: async (lc, tx) => {
+      const pending: PendingQuery<Row[]>[] = [];
+      for await (const versions of tx<
+        {clientGroupID: string; version: string}[]
+      >`
+      SELECT "clientGroupID", "version" FROM ${tx(schema)}.instances`.cursor(
+        5000,
+      )) {
+        for (const version of versions) {
+          pending.push(
+            tx`INSERT INTO ${tx(schema)}."rowsVersion" ${tx(version)} 
+               ON CONFLICT ("clientGroupID")
+               DO UPDATE SET ${tx(version)}`.execute(),
+          );
+        }
+      }
+      lc.info?.(`initializing rowsVersion for ${pending.length} cvrs`);
+      await Promise.all(pending);
+    },
+  };
+
+  const migrateV3ToV4: Migration = {
+    migrateSchema: async (_, tx) => {
+      await tx`ALTER TABLE ${tx(schema)}.instances ADD "owner" TEXT`;
+      await tx`ALTER TABLE ${tx(schema)}.instances ADD "grantedAt" TIMESTAMPTZ`;
+    },
+  };
+
+  const migrateV5ToV6: Migration = {
+    migrateSchema: async (_, tx) => {
+      await tx`
+      ALTER TABLE ${tx(schema)}."rows" 
+        DROP CONSTRAINT fk_rows_client_group`;
+      await tx`
+      ALTER TABLE ${tx(schema)}."rowsVersion" 
+        DROP CONSTRAINT fk_rows_version_client_group`;
+    },
+  };
+
   const schemaVersionMigrationMap: IncrementalMigrationMap = {
     2: migrateV1toV2,
     3: migrateV2ToV3,
@@ -34,52 +98,9 @@ export async function initViewSyncerSchema(
   await runSchemaMigrations(
     log,
     'view-syncer',
-    PG_SCHEMA,
+    cvrSchema(shardID),
     db,
     setupMigration,
     schemaVersionMigrationMap,
   );
 }
-
-const migrateV1toV2: Migration = {
-  migrateSchema: async (_, tx) => {
-    await tx`ALTER TABLE cvr.instances ADD "replicaVersion" TEXT`;
-  },
-};
-
-const migrateV2ToV3: Migration = {
-  migrateSchema: async (_, tx) => {
-    await tx.unsafe(CREATE_CVR_ROWS_VERSION_TABLE);
-  },
-
-  /** Populates the cvr.rowsVersion table with versions from cvr.instances. */
-  migrateData: async (lc, tx) => {
-    const pending: PendingQuery<Row[]>[] = [];
-    for await (const versions of tx<{clientGroupID: string; version: string}[]>`
-      SELECT "clientGroupID", "version" FROM cvr.instances`.cursor(5000)) {
-      for (const version of versions) {
-        pending.push(
-          tx`INSERT INTO cvr."rowsVersion" ${tx(version)} 
-               ON CONFLICT ("clientGroupID")
-               DO UPDATE SET ${tx(version)}`.execute(),
-        );
-      }
-    }
-    lc.info?.(`initializing rowsVersion for ${pending.length} cvrs`);
-    await Promise.all(pending);
-  },
-};
-
-const migrateV3ToV4: Migration = {
-  migrateSchema: async (_, tx) => {
-    await tx`ALTER TABLE cvr.instances ADD "owner" TEXT`;
-    await tx`ALTER TABLE cvr.instances ADD "grantedAt" TIMESTAMPTZ`;
-  },
-};
-
-const migrateV5ToV6: Migration = {
-  migrateSchema: async (_, tx) => {
-    await tx`ALTER TABLE cvr."rows" DROP CONSTRAINT fk_rows_client_group`;
-    await tx`ALTER TABLE cvr."rowsVersion" DROP CONSTRAINT fk_rows_version_client_group`;
-  },
-};

--- a/packages/zero-cache/src/services/view-syncer/schema/init.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/init.ts
@@ -15,7 +15,7 @@ async function migrateFromLegacySchema(
 ) {
   const result = await db`SELECT * FROM pg_namespace WHERE nspname = 'cvr'`;
   if (result.length > 0) {
-    lc.info?.(`Migrated cvr to ${newSchema}`);
+    lc.info?.(`Migrating cvr to ${newSchema}`);
     await db`ALTER SCHEMA cvr RENAME TO ${db(newSchema)}`;
   }
 }

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -142,6 +142,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     this.#cvrStore = new CVRStore(
       lc,
       db,
+      shardID,
       taskID,
       clientGroupID,
       // On failure, cancel the #stateChanges subscription. The run()


### PR DESCRIPTION
For dev instances, "preview" instances, and sharding, zero-caches with different `--shard-id` values can point to the same UPSTREAM_DB 

They can now also point to the same CVR_DB, as they will each operate in their own `cvr_{shard-id}` schema.

Data from the existing global `cvr` schema will be migrated the first time.

(Similar change for the CHANGE_DB is forthcoming)

https://bugs.rocicorp.dev/issue/3502