### PR TITLE
feat(zero-cache): allow multiple zero-cache shards to use the same CHANGE db

### DIFF
--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -69,6 +69,7 @@ export default async function runWorker(
 
       changeStreamer = await initializeStreamer(
         lc,
+        shard.id,
         must(taskID, `main must set --task-id`),
         changeDB,
         changeSource,


### PR DESCRIPTION
For dev instances, "preview" instances, and sharding, zero-caches with different `--shard-id` values can point to the same UPSTREAM_DB

They can now also point to the same CHANGE_DB, as they will each operate in their own `cdc_{shard-id}` schema.

Data from the existing global `cdc` schema will be migrated the first time.

This is analogous to the change done for the CVR schema in #3714.

https://bugs.rocicorp.dev/issue/3502

