### PR TITLE
fix(zero-cache): use the new "Rehome" error kind when CVR ownership changes

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr-store.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.ts
@@ -1106,14 +1106,18 @@ export class ConcurrentModificationException extends ErrorWithLevel {
   }
 }
 
-export class OwnershipError extends ErrorWithLevel {
+export class OwnershipError extends ErrorForClient {
   readonly name = 'OwnershipError';
 
   constructor(owner: string | null, grantedAt: number | null) {
     super(
-      `CVR ownership was transferred to ${owner} at ${new Date(
-        grantedAt ?? 0,
-      ).toISOString()}`,
+      {
+        kind: ErrorKind.Rehome,
+        message:
+          `CVR ownership was transferred to ${owner} at ` +
+          `${new Date(grantedAt ?? 0).toISOString()}`,
+        maxBackoffMs: 0,
+      },
       'info',
     );
   }


### PR DESCRIPTION
Use the "Rehome" error kind introduced in #3589 when redirecting the client to the newer view-syncer (instead of "Internal", which looks like something's wrong). 

Also use the `minBackoffMs` directive to have the client reconnect immediately instead of waiting for 5 seconds.