### PR TITLE
feat(zero-cache): take 2: time-slice IVM for fairness and responsiveness

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16828,15 +16828,6 @@
         "lz-string": "bin/bin.js"
       }
     },
-    "node_modules/magic-stopwatch": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/magic-stopwatch/-/magic-stopwatch-1.0.1.tgz",
-      "integrity": "sha512-TEw2BmxonXw6YtluZis5CXRkyuA+4hoX41EK2r2x2TAxCHpjscVHxOdauQ10T6Gu7Er1y4d3ZojsGa+m6jfTEw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/Snazzah"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -27575,7 +27566,6 @@
         "js-xxhash": "^4.0.0",
         "json-custom-numbers": "^3.1.1",
         "kasi": "^1.1.0",
-        "magic-stopwatch": "^1.0.1",
         "nanoid": "^5.0.8",
         "pg": "^8.11.3",
         "pg-format": "npm:pg-format-fix@^1.0.5",
@@ -27635,7 +27625,6 @@
         "fastify": "^5.0.0",
         "jose": "^5.9.3",
         "json-custom-numbers": "^3.1.1",
-        "magic-stopwatch": "^1.0.1",
         "nanoid": "^5.0.8",
         "pg": "^8.11.3",
         "pg-format": "npm:pg-format-fix@^1.0.5",
@@ -32170,7 +32159,6 @@
         "js-xxhash": "^4.0.0",
         "json-custom-numbers": "^3.1.1",
         "kasi": "^1.1.0",
-        "magic-stopwatch": "^1.0.1",
         "nanoid": "^5.0.8",
         "pg": "^8.11.3",
         "pg-format": "npm:pg-format-fix@^1.0.5",
@@ -38781,11 +38769,6 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "devOptional": true
-    },
-    "magic-stopwatch": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/magic-stopwatch/-/magic-stopwatch-1.0.1.tgz",
-      "integrity": "sha512-TEw2BmxonXw6YtluZis5CXRkyuA+4hoX41EK2r2x2TAxCHpjscVHxOdauQ10T6Gu7Er1y4d3ZojsGa+m6jfTEw=="
     },
     "magic-string": {
       "version": "0.30.17",
@@ -45827,7 +45810,6 @@
         "fastify": "^5.0.0",
         "jose": "^5.9.3",
         "json-custom-numbers": "^3.1.1",
-        "magic-stopwatch": "^1.0.1",
         "nanoid": "^5.0.8",
         "pg": "^8.11.3",
         "pg-format": "npm:pg-format-fix@^1.0.5",

--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -39,7 +39,6 @@
     "fastify": "^5.0.0",
     "jose": "^5.9.3",
     "json-custom-numbers": "^3.1.1",
-    "magic-stopwatch": "^1.0.1",
     "nanoid": "^5.0.8",
     "pg": "^8.11.3",
     "pg-format": "npm:pg-format-fix@^1.0.5",

--- a/packages/zero/package.json
+++ b/packages/zero/package.json
@@ -45,7 +45,6 @@
     "js-xxhash": "^4.0.0",
     "json-custom-numbers": "^3.1.1",
     "kasi": "^1.1.0",
-    "magic-stopwatch": "^1.0.1",
     "nanoid": "^5.0.8",
     "pg": "^8.11.3",
     "pg-format": "npm:pg-format-fix@^1.0.5",


### PR DESCRIPTION
When running an IVM pipeline, yield the process every 500ms, preventing a long-running query from hogging the CPU. This should improve fairness as well as eliminate connection timeouts (from missed pongs).

The original implementation in #3651 did not work because the magic stopwatch was used incorrectly. 

The new implementation just uses Date.now().

Verified functionality thanks to @cesara's gigabugs dataset.

Two ViewSyncers (`clientGroupID`) are taking turns processing chunks of their pipelines in the same process (`pid`), and ping-pong is responsive all the while:

<img width="2284" alt="Screenshot 2025-02-06 at 16 03 02" src="https://github.com/user-attachments/assets/b69385b6-7795-4371-a795-87d5cee7b236" />


