### PR TITLE
wip(zero): Add Time To Live -- TTL

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "download-deps": "bash ./deps/download.sh",
     "build": "turbo run build",
     "dev": "turbo run dev",
-    "test": "turbo run test",
+    "test": "turbo run --concurrency 1 test",
     "lint": "turbo run lint",
     "format": "turbo run format",
     "check-format": "turbo run check-format",

--- a/packages/shared/src/queue.ts
+++ b/packages/shared/src/queue.ts
@@ -1,5 +1,6 @@
 import {resolver, type Resolver} from '@rocicorp/resolver';
 import {assert} from './asserts.ts';
+import {promiseVoid} from './resolved-promises.ts';
 
 /**
  * A Queue allows the consumers to await (possibly future) values,
@@ -19,7 +20,7 @@ export class Queue<T> {
     if (consumer) {
       consumer.resolver.resolve(value);
       clearTimeout(consumer.timeoutID);
-      return Promise.resolve();
+      return promiseVoid;
     }
     return this.#enqueueProduced(Promise.resolve(value), value);
   }
@@ -99,7 +100,7 @@ export class Queue<T> {
    * ```ts
    * // A consumer that, when awoken, drains
    * // all entries in the queue in order to
-   * // proces them in a batch.
+   * // process them in a batch.
    * for (;;) {
    *   const value = await queue.dequeue();
    *   const rest = queue.drain();

--- a/packages/zero-advanced/src/mod.ts
+++ b/packages/zero-advanced/src/mod.ts
@@ -7,5 +7,5 @@ export {
   type ViewChange,
 } from '../../zql/src/ivm/view-apply-change.ts';
 export type {Entry, Format, View, ViewFactory} from '../../zql/src/ivm/view.ts';
-export type {AdvancedQuery} from '../../zql/src/query/query-internal.ts';
+export type {AdvancedQuery} from '../../zql/src/query/advanced-query.ts';
 export type {HumanReadable, Query} from '../../zql/src/query/query.ts';

--- a/packages/zero-cache/src/services/view-syncer/client-handler.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.ts
@@ -15,7 +15,7 @@ import type {
   PokeStartBody,
 } from '../../../../zero-protocol/src/poke.ts';
 import {primaryKeyValueRecordSchema} from '../../../../zero-protocol/src/primary-key.ts';
-import type {RowPatchOp} from '../../../../zero-protocol/src/row-patch.ts';
+import type {DelOp, PutOp} from '../../../../zero-protocol/src/row-patch.ts';
 import type {JSONObject} from '../../types/bigint-json.ts';
 import {getLogLevel} from '../../types/error-for-client.ts';
 import {
@@ -50,6 +50,7 @@ export type DeleteRowPatch = {
 };
 
 export type RowPatch = PutRowPatch | DeleteRowPatch;
+
 export type ConfigPatch = DelQueryPatch | (PutQueryPatch & {ast: AST});
 
 export type Patch = ConfigPatch | RowPatch;
@@ -184,6 +185,8 @@ export class ClientHandler {
       }
     };
 
+    // const deltas: Map<string, number> = new Map();
+
     const addPatch = (patchToVersion: PatchToVersion) => {
       const {patch, toVersion} = patchToVersion;
       if (cmpVersions(toVersion, this.#baseVersion) <= 0) {
@@ -209,7 +212,14 @@ export class ClientHandler {
           if (patch.id.table === this.#zeroClientsTable) {
             this.#updateLMIDs((body.lastMutationIDChanges ??= {}), patch);
           } else {
-            (body.rowsPatch ??= []).push(makeRowPatch(patch));
+            // TODO: Keep track of number of rows per query.
+            const rowPatch = makeRowPatch(patch);
+            const delta = rowPatch.op === 'put' ? 1 : -1;
+            // deltas.set(hash, (deltas.get(hash) ?? 0) - 1);
+            lc.debug?.(
+              `row patch: ${patch.id.table} ${patch.id.rowKey} ${delta}`,
+            );
+            (body.rowsPatch ??= []).push(rowPatch);
           }
           break;
         default:
@@ -305,7 +315,7 @@ const lmidRowSchema = v.object({
   lastMutationID: v.number(), // Actually returned as a bigint, but converted by ensureSafeJSON().
 });
 
-function makeRowPatch(patch: RowPatch): RowPatchOp {
+function makeRowPatch(patch: RowPatch): PutOp | DelOp {
   const {
     op,
     id: {table: tableName, rowKey: id},

--- a/packages/zero-cache/src/services/view-syncer/client-handler.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.ts
@@ -5,8 +5,10 @@ import {
   type JSONObject as SafeJSONObject,
 } from '../../../../shared/src/json.ts';
 import * as v from '../../../../shared/src/valita.ts';
+import type {Writable} from '../../../../shared/src/writable.ts';
 import type {AST} from '../../../../zero-protocol/src/ast.ts';
 import {rowSchema} from '../../../../zero-protocol/src/data.ts';
+import type {DeleteClientsBody} from '../../../../zero-protocol/src/delete-clients.ts';
 import type {Downstream} from '../../../../zero-protocol/src/down.ts';
 import type {
   PokePartBody,
@@ -82,7 +84,7 @@ export class ClientHandler {
   readonly wsID: string;
   readonly #zeroClientsTable: string;
   readonly #lc: LogContext;
-  readonly #pokes: Subscription<Downstream>;
+  readonly #downstream: Subscription<Downstream>;
   #baseVersion: NullableCVRVersion;
   readonly #protocolVersion: number;
   readonly #schemaVersion: number;
@@ -96,14 +98,14 @@ export class ClientHandler {
     baseCookie: string | null,
     protocolVersion: number,
     schemaVersion: number,
-    pokes: Subscription<Downstream>,
+    downstream: Subscription<Downstream>,
   ) {
     this.#clientGroupID = clientGroupID;
     this.clientID = clientID;
     this.wsID = wsID;
     this.#zeroClientsTable = `${schema(shardID)}.clients`;
     this.#lc = lc;
-    this.#pokes = pokes;
+    this.#downstream = downstream;
     this.#baseVersion = cookieToVersion(baseCookie);
     this.#protocolVersion = protocolVersion;
     this.#schemaVersion = schemaVersion;
@@ -123,12 +125,12 @@ export class ClientHandler {
       `view-syncer closing connection with error: ${String(e)}`,
       e,
     );
-    this.#pokes.fail(e instanceof Error ? e : new Error(String(e)));
+    this.#downstream.fail(e instanceof Error ? e : new Error(String(e)));
   }
 
   close(reason: string) {
     this.#lc.debug?.(`view-syncer closing connection: ${reason}`);
-    this.#pokes.cancel();
+    this.#downstream.cancel();
   }
 
   startPoke(
@@ -169,14 +171,14 @@ export class ClientHandler {
     let partCount = 0;
     const ensureBody = () => {
       if (!pokeStarted) {
-        this.#pokes.push(['pokeStart', pokeStart]);
+        this.#downstream.push(['pokeStart', pokeStart]);
         pokeStarted = true;
       }
       return (body ??= {pokeID});
     };
     const flushBody = () => {
       if (body) {
-        this.#pokes.push(['pokePart', body]);
+        this.#downstream.push(['pokePart', body]);
         body = undefined;
         partCount = 0;
       }
@@ -224,13 +226,13 @@ export class ClientHandler {
         try {
           addPatch(patchToVersion);
         } catch (e) {
-          this.#pokes.fail(e instanceof Error ? e : new Error(String(e)));
+          this.#downstream.fail(e instanceof Error ? e : new Error(String(e)));
         }
       },
 
       cancel: () => {
         if (pokeStarted) {
-          this.#pokes.push(['pokeEnd', {pokeID, cancel: true}]);
+          this.#downstream.push(['pokeEnd', {pokeID, cancel: true}]);
         }
       },
 
@@ -240,7 +242,7 @@ export class ClientHandler {
           if (cmpVersions(this.#baseVersion, finalVersion) === 0) {
             return; // Nothing changed and nothing was sent.
           }
-          this.#pokes.push(['pokeStart', {...pokeStart, cookie}]);
+          this.#downstream.push(['pokeStart', {...pokeStart, cookie}]);
         } else if (cmpVersions(this.#baseVersion, finalVersion) >= 0) {
           // Sanity check: If the poke was started, the finalVersion
           // must be > #baseVersion.
@@ -250,13 +252,27 @@ export class ClientHandler {
           );
         }
         flushBody();
-        this.#pokes.push([
+        this.#downstream.push([
           'pokeEnd',
           this.supportsRevisedCookieProtocol() ? {pokeID, cookie} : {pokeID},
         ]);
         this.#baseVersion = finalVersion;
       },
     };
+  }
+
+  sendDeleteClients(
+    deletedClientIDs: string[],
+    deletedClientGroupIDs: string[],
+  ): void {
+    const deleteClientsBody: Writable<DeleteClientsBody> = {};
+    if (deletedClientIDs.length > 0) {
+      deleteClientsBody.clientIDs = deletedClientIDs;
+    }
+    if (deletedClientGroupIDs.length > 0) {
+      deleteClientsBody.clientGroupIDs = deletedClientGroupIDs;
+    }
+    this.#downstream.push(['deleteClients', deleteClientsBody]);
   }
 
   #updateLMIDs(lmids: Record<string, number>, patch: RowPatch) {

--- a/packages/zero-cache/src/services/view-syncer/cvr-store.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.ts
@@ -796,6 +796,35 @@ export class CVRStore {
     });
   }
 
+  deleteClient(clientID: string) {
+    for (const name of ['desires', 'clients'] as const) {
+      this.#writes.add({
+        stats: {[name]: 1},
+        write: tx =>
+          tx`DELETE FROM ${this.#cvr(name)} WHERE "clientID" = ${clientID}`,
+      });
+    }
+  }
+
+  deleteClientGroup(clientGroupID: string) {
+    for (const name of [
+      'desires',
+      'clients',
+      'queries',
+      'instances',
+      'rows',
+      'rowsVersion',
+    ] as const) {
+      this.#writes.add({
+        stats: {[name]: 1},
+        write: tx =>
+          tx`DELETE FROM ${this.#cvr(
+            name,
+          )} WHERE "clientGroupID" = ${clientGroupID}`,
+      });
+    }
+  }
+
   insertDesiredQuery(
     newVersion: CVRVersion,
     query: {id: string},

--- a/packages/zero-cache/src/services/view-syncer/cvr-store.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.ts
@@ -1,7 +1,6 @@
 import {trace} from '@opentelemetry/api';
 import type {LogContext} from '@rocicorp/logger';
-import {resolver, type Resolver} from '@rocicorp/resolver';
-import type {MaybeRow, PendingQuery, Row} from 'postgres';
+import type {MaybeRow, PendingQuery} from 'postgres';
 import {startAsyncSpan} from '../../../../otel/src/span.ts';
 import {version} from '../../../../otel/src/version.ts';
 import {assert} from '../../../../shared/src/asserts.ts';
@@ -12,7 +11,6 @@ import {
   type ReadonlyJSONValue,
 } from '../../../../shared/src/json.ts';
 import {must} from '../../../../shared/src/must.ts';
-import {promiseVoid} from '../../../../shared/src/resolved-promises.ts';
 import {sleep} from '../../../../shared/src/sleep.ts';
 import {astSchema} from '../../../../zero-protocol/src/ast.ts';
 import * as ErrorKind from '../../../../zero-protocol/src/error-kind-enum.ts';
@@ -23,15 +21,14 @@ import type {PostgresDB, PostgresTransaction} from '../../types/pg.ts';
 import {rowIDString} from '../../types/row-key.ts';
 import type {Patch, PatchToVersion} from './client-handler.ts';
 import type {CVR, CVRSnapshot} from './cvr.ts';
+import {RowRecordCache} from './row-record-cache.ts';
 import {
   type ClientsRow,
   cvrSchema,
   type DesiresRow,
   type InstancesRow,
   type QueriesRow,
-  rowRecordToRowsRow,
   type RowsRow,
-  rowsRowToRowRecord,
 } from './schema/cvr.ts';
 import {
   type ClientRecord,
@@ -45,7 +42,6 @@ import {
   type RowRecord,
   versionFromString,
   versionString,
-  versionToNullableCookie,
 } from './schema/types.ts';
 
 export type CVRFlushStats = {
@@ -59,351 +55,6 @@ export type CVRFlushStats = {
 };
 
 const tracer = trace.getTracer('cvr-store', version);
-
-/**
- * The RowRecordCache is an in-memory cache of the `cvr.rows` tables that
- * operates as both a write-through and write-back cache.
- *
- * For "small" CVR updates (i.e. zero or small numbers of rows) the
- * RowRecordCache operates as write-through, executing commits in
- * {@link executeRowUpdates()} before they are {@link apply}-ed to the
- * in-memory state.
- *
- * For "large" CVR updates (i.e. with many rows), the cache switches to a
- * write-back mode of operation, in which {@link executeRowUpdates()} is a
- * no-op, and {@link apply()} initiates a background task to flush the pending
- * row changes to the store. This allows the client poke to be completed and
- * committed on the client without waiting for the heavyweight operation of
- * committing the row records to the CVR store.
- *
- * Note that when the cache is in write-back mode, all updates become
- * write-back (i.e. asynchronously flushed) until the pending update queue is
- * fully flushed. This is required because updates must be applied in version
- * order. As with all pending work systems in zero-cache, multiple pending
- * updates are coalesced to reduce buildup of work.
- *
- * ### High level consistency
- *
- * Note that the above caching scheme only applies to the row data in `cvr.rows`
- * and corresponding `cvr.rowsVersion` tables. CVR metadata and query
- * information, on the other hand, are always committed before completing the
- * client poke. In this manner, the difference between the `version` column in
- * `cvr.instances` and the analogous column in `cvr.rowsVersion` determines
- * whether the data in the store is consistent, or whether it is awaiting a
- * pending update.
- *
- * The logic in {@link CVRStore.load()} takes this into account by loading both
- * the `cvr.instances` version and the `cvr.rowsVersion` version and checking
- * if they are in sync, waiting for a configurable delay until they are.
- *
- * ### Eventual conversion
- *
- * In the event of a continual stream of mutations (e.g. an animation-style
- * app), it is conceivable that the row record data be continually behind
- * the CVR metadata. In order to effect eventual convergence, a new view-syncer
- * signals the current view-syncer to stop updating by writing new `owner`
- * information to the `cvr.instances` row. This effectively stops the mutation
- * processing (in {@link CVRStore.#checkVersionAndOwnership}) so that the row
- * data can eventually catch up, allowing the new view-syncer to take over.
- *
- * Of course, there is the pathological situation in which a view-syncer
- * process crashes before the pending row updates are flushed. In this case,
- * the wait timeout will elapse and the CVR considered invalid.
- */
-class RowRecordCache {
-  // The state in the #cache is always in sync with the CVR metadata
-  // (i.e. cvr.instances). It may contain information that has not yet
-  // been flushed to cvr.rows.
-  #cache: Promise<CustomKeyMap<RowID, RowRecord>> | undefined;
-  readonly #lc: LogContext;
-  readonly #db: PostgresDB;
-  readonly #schema: string;
-  readonly #cvrID: string;
-  readonly #failService: (e: unknown) => void;
-  readonly #deferredRowFlushThreshold: number;
-  readonly #setTimeout: typeof setTimeout;
-
-  // Write-back cache state.
-  readonly #pending = new CustomKeyMap<RowID, RowRecord | null>(rowIDString);
-  #pendingRowsVersion: CVRVersion | null = null;
-  #flushedRowsVersion: CVRVersion | null = null;
-  #flushing: Resolver<void> | null = null;
-
-  constructor(
-    lc: LogContext,
-    db: PostgresDB,
-    shardID: string,
-    cvrID: string,
-    failService: (e: unknown) => void,
-    deferredRowFlushThreshold = 100,
-    setTimeoutFn = setTimeout,
-  ) {
-    this.#lc = lc;
-    this.#db = db;
-    this.#schema = cvrSchema(shardID);
-    this.#cvrID = cvrID;
-    this.#failService = failService;
-    this.#deferredRowFlushThreshold = deferredRowFlushThreshold;
-    this.#setTimeout = setTimeoutFn;
-  }
-
-  #cvr(table: string) {
-    return this.#db(`${this.#schema}.${table}`);
-  }
-
-  async #ensureLoaded(): Promise<CustomKeyMap<RowID, RowRecord>> {
-    if (this.#cache) {
-      return this.#cache;
-    }
-    const r = resolver<CustomKeyMap<RowID, RowRecord>>();
-    // Set this.#cache immediately (before await) so that only one db
-    // query is made even if there are multiple callers.
-    this.#cache = r.promise;
-
-    const cache: CustomKeyMap<RowID, RowRecord> = new CustomKeyMap(rowIDString);
-    for await (const rows of this.#db<RowsRow[]>`
-      SELECT * FROM ${this.#cvr(`rows`)} 
-        WHERE "clientGroupID" = ${this.#cvrID} AND "refCounts" IS NOT NULL`
-      // TODO(arv): Arbitrary page size
-      .cursor(5000)) {
-      for (const row of rows) {
-        const rowRecord = rowsRowToRowRecord(row);
-        cache.set(rowRecord.id, rowRecord);
-      }
-    }
-    r.resolve(cache);
-    return this.#cache;
-  }
-
-  getRowRecords(): Promise<ReadonlyMap<RowID, RowRecord>> {
-    return this.#ensureLoaded();
-  }
-
-  /**
-   * Applies the `rowRecords` corresponding to the `rowsVersion`
-   * to the cache, indicating whether the corresponding updates
-   * (generated by {@link executeRowUpdates}) were `flushed`.
-   *
-   * If `flushed` is false, the RowRecordCache will flush the records
-   * asynchronously.
-   *
-   * Note that `apply()` indicates that the CVR metadata associated with
-   * the `rowRecords` was successfully committed, which essentially means
-   * that this process has the unconditional right (and responsibility) of
-   * following up with a flush of the `rowRecords`. In particular, the
-   * commit of row records are not conditioned on the version or ownership
-   * columns of the `cvr.instances` row.
-   */
-  async apply(
-    rowRecords: Map<RowID, RowRecord | null>,
-    rowsVersion: CVRVersion,
-    flushed: boolean,
-  ) {
-    const cache = await this.#ensureLoaded();
-    for (const [id, row] of rowRecords.entries()) {
-      if (row === null || row.refCounts === null) {
-        cache.delete(id);
-      } else {
-        cache.set(id, row);
-      }
-      if (!flushed) {
-        this.#pending.set(id, row);
-      }
-    }
-    this.#pendingRowsVersion = rowsVersion;
-    // Initiate a flush if not already flushing.
-    if (!flushed && this.#flushing === null) {
-      this.#flushing = resolver();
-      this.#setTimeout(() => this.#flush(), 0);
-    }
-  }
-
-  async #flush() {
-    const flushing = must(this.#flushing);
-    try {
-      while (this.#pendingRowsVersion !== this.#flushedRowsVersion) {
-        const start = Date.now();
-
-        const {rows, rowsVersion} = await this.#db.begin(tx => {
-          // Note: This code block is synchronous, guaranteeing that the
-          // #pendingRowsVersion is consistent with the #pending rows.
-          const rows = this.#pending.size;
-          const rowsVersion = must(this.#pendingRowsVersion);
-          this.executeRowUpdates(tx, rowsVersion, this.#pending, 'force');
-          this.#pending.clear();
-          return {rows, rowsVersion};
-        });
-        this.#lc.debug?.(
-          `flushed ${rows} rows@${versionString(rowsVersion)} (${
-            Date.now() - start
-          } ms)`,
-        );
-        this.#flushedRowsVersion = rowsVersion;
-        // Note: apply() may have called while the transaction was committing,
-        //       which will result in looping to commit the next #pendingRowsVersion.
-      }
-      this.#lc.debug?.(
-        `up to date rows@${versionToNullableCookie(this.#flushedRowsVersion)}`,
-      );
-      flushing.resolve();
-      this.#flushing = null;
-    } catch (e) {
-      flushing.reject(e);
-      this.#failService(e);
-    }
-  }
-
-  hasPendingUpdates() {
-    return this.#flushing !== null;
-  }
-
-  /**
-   * Returns a promise that resolves when all outstanding row-records
-   * have been committed.
-   */
-  flushed(lc: LogContext): Promise<void> {
-    if (this.#flushing) {
-      lc.debug?.('awaiting pending row flush');
-      return this.#flushing.promise;
-    }
-    return promiseVoid;
-  }
-
-  clear() {
-    // Note: Only the #cache is cleared. #pending updates, on the other hand,
-    // comprise canonical (i.e. already flushed) data and must be flushed
-    // even if the snapshot of the present state (the #cache) is cleared.
-    this.#cache = undefined;
-  }
-
-  async *catchupRowPatches(
-    lc: LogContext,
-    afterVersion: NullableCVRVersion,
-    upToCVR: CVRSnapshot,
-    current: CVRVersion,
-    excludeQueryHashes: string[],
-  ): AsyncGenerator<RowsRow[], void, undefined> {
-    if (cmpVersions(afterVersion, upToCVR.version) >= 0) {
-      return;
-    }
-
-    const startMs = Date.now();
-    const start = afterVersion ? versionString(afterVersion) : '';
-    const end = versionString(upToCVR.version);
-    lc.debug?.(`scanning row patches for clients from ${start}`);
-
-    // Before accessing the CVR db, pending row records must be flushed.
-    // Note that because catchupRowPatches() is called from within the
-    // view syncer lock, this flush is guaranteed to complete since no
-    // new CVR updates can happen while the lock is held.
-    await this.flushed(lc);
-    const flushMs = Date.now() - startMs;
-
-    const reader = new TransactionPool(lc, Mode.READONLY).run(this.#db);
-    try {
-      // Verify that we are reading the right version of the CVR.
-      await reader.processReadTask(tx =>
-        checkVersion(tx, this.#schema, this.#cvrID, current),
-      );
-
-      const {query} = await reader.processReadTask(tx => {
-        const query =
-          excludeQueryHashes.length === 0
-            ? tx<RowsRow[]>`SELECT * FROM ${this.#cvr('rows')}
-        WHERE "clientGroupID" = ${this.#cvrID}
-          AND "patchVersion" > ${start}
-          AND "patchVersion" <= ${end}`
-            : // Exclude rows that were already sent as part of query hydration.
-              tx<RowsRow[]>`SELECT * FROM ${this.#cvr('rows')}
-        WHERE "clientGroupID" = ${this.#cvrID}
-          AND "patchVersion" > ${start}
-          AND "patchVersion" <= ${end}
-          AND ("refCounts" IS NULL OR NOT "refCounts" ?| ${excludeQueryHashes})`;
-        return {query};
-      });
-
-      yield* query.cursor(10_000);
-    } finally {
-      reader.setDone();
-    }
-
-    const totalMs = Date.now() - startMs;
-    lc.debug?.(
-      `finished row catchup (flush: ${flushMs} ms, total: ${totalMs} ms)`,
-    );
-  }
-
-  executeRowUpdates(
-    tx: PostgresTransaction,
-    version: CVRVersion,
-    rowUpdates: Map<RowID, RowRecord | null>,
-    mode: 'allow-defer' | 'force',
-  ): PendingQuery<Row[]>[] {
-    if (
-      mode === 'allow-defer' &&
-      // defer if pending rows are being flushed
-      (this.#flushing !== null ||
-        // or if the new batch is above the limit.
-        rowUpdates.size > this.#deferredRowFlushThreshold)
-    ) {
-      return [];
-    }
-    const rowsVersion = {
-      clientGroupID: this.#cvrID,
-      version: versionString(version),
-    };
-    const pending: PendingQuery<Row[]>[] = [
-      tx`INSERT INTO ${this.#cvr('rowsVersion')} ${tx(rowsVersion)}
-           ON CONFLICT ("clientGroupID") 
-           DO UPDATE SET ${tx(rowsVersion)}`.execute(),
-    ];
-
-    const rowRecordRows: RowsRow[] = [];
-    for (const [id, row] of rowUpdates.entries()) {
-      if (row === null) {
-        pending.push(
-          tx`
-          DELETE FROM ${this.#cvr('rows')}
-            WHERE "clientGroupID" = ${this.#cvrID}
-              AND "schema" = ${id.schema}
-              AND "table" = ${id.table}
-              AND "rowKey" = ${id.rowKey}
-       `.execute(),
-        );
-      } else {
-        rowRecordRows.push(rowRecordToRowsRow(this.#cvrID, row));
-      }
-    }
-    if (rowRecordRows.length) {
-      pending.push(
-        tx`
-  INSERT INTO ${this.#cvr('rows')}(
-      "clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts"
-  ) SELECT
-      "clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts"
-    FROM json_to_recordset(${rowRecordRows}) AS x(
-      "clientGroupID" TEXT,
-      "schema" TEXT,
-      "table" TEXT,
-      "rowKey" JSONB,
-      "rowVersion" TEXT,
-      "patchVersion" TEXT,
-      "refCounts" JSONB
-  ) ON CONFLICT ("clientGroupID", "schema", "table", "rowKey")
-    DO UPDATE SET "rowVersion" = excluded."rowVersion",
-      "patchVersion" = excluded."patchVersion",
-      "refCounts" = excluded."refCounts"
-    `.execute(),
-      );
-      this.#lc.debug?.(
-        `flushing ${rowUpdates.size} rows (${rowRecordRows.length} inserts, ${
-          rowUpdates.size - rowRecordRows.length
-        } deletes)`,
-      );
-    }
-    return pending;
-  }
-}
 
 function asQuery(row: QueriesRow): QueryRecord {
   const ast = astSchema.parse(row.clientAST);
@@ -1121,7 +772,7 @@ export class CVRStore {
  * that it only checks the version and is suitable for snapshot reads
  * (i.e. by doing a plain `SELECT` rather than a `SELECT ... FOR UPDATE`).
  */
-async function checkVersion(
+export async function checkVersion(
   tx: PostgresTransaction,
   schema: string,
   clientGroupID: string,

--- a/packages/zero-cache/src/services/view-syncer/cvr-store.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.ts
@@ -725,7 +725,7 @@ export class CVRStore {
     });
   }
 
-  getExpiredQueriesCandidates(): PendingQuery<QueriesRow[]> {
+  getInactiveQueries(): PendingQuery<QueriesRow[]> {
     return this.#db<QueriesRow[]>`SELECT * FROM ${this.#cvr('queries')}
       WHERE "clientGroupID" = ${this.#id} AND "inactivatedAt" IS NOT NULL
       ORDER BY "expiresAt" ASC, "inactivatedAt" ASC`;

--- a/packages/zero-cache/src/services/view-syncer/cvr-test-util.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-test-util.ts
@@ -1,0 +1,43 @@
+import type {PostgresDB} from '../../types/pg.ts';
+import {
+  type ClientsRow,
+  type DesiresRow,
+  type InstancesRow,
+  type QueriesRow,
+  type RowsRow,
+  type RowsVersionRow,
+} from './schema/cvr.ts';
+
+export type DBState = {
+  instances: (Partial<InstancesRow> &
+    Pick<InstancesRow, 'clientGroupID' | 'version'>)[];
+  clients: ClientsRow[];
+  queries: QueriesRow[];
+  desires: DesiresRow[];
+  rows: RowsRow[];
+  rowsVersion?: RowsVersionRow[];
+};
+
+export function setInitialState(
+  prefix: string,
+  db: PostgresDB,
+  state: Partial<DBState>,
+): Promise<void> {
+  return db.begin(async tx => {
+    const {instances, rowsVersion} = state;
+    if (instances && !rowsVersion) {
+      state = {
+        ...state,
+        rowsVersion: instances.map(({clientGroupID, version}) => ({
+          clientGroupID,
+          version,
+        })),
+      };
+    }
+    for (const [table, rows] of Object.entries(state)) {
+      for (const row of rows) {
+        await tx`INSERT INTO ${tx(prefix + '.' + table)} ${tx(row)}`;
+      }
+    }
+  });
+}

--- a/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
@@ -3955,4 +3955,747 @@ describe('view-syncer/cvr', () => {
       ],
     });
   });
+
+  test('deleteClient', async () => {
+    const initialState: DBState = {
+      instances: [
+        {
+          clientGroupID: 'abc123',
+          version: '1aa',
+          replicaVersion: '120',
+          lastActive: Date.UTC(2024, 3, 23),
+        },
+      ],
+      clients: [
+        {
+          clientGroupID: 'abc123',
+          clientID: 'client-a',
+          patchVersion: '1aa',
+          deleted: null,
+        },
+        {
+          clientGroupID: 'abc123',
+          clientID: 'client-b',
+          patchVersion: '1aa',
+          deleted: null,
+        },
+        {
+          clientGroupID: 'abc123',
+          clientID: 'client-c',
+          patchVersion: '1aa',
+          deleted: null,
+        },
+      ],
+      queries: [
+        {
+          clientGroupID: 'abc123',
+          queryHash: 'oneHash',
+          clientAST: {table: 'issues'},
+          transformationHash: null,
+          transformationVersion: null,
+          patchVersion: null,
+          internal: null,
+          deleted: null,
+        },
+      ],
+      desires: [
+        {
+          clientGroupID: 'abc123',
+          clientID: 'client-a',
+          queryHash: 'oneHash',
+          patchVersion: '1a9:01',
+          deleted: null,
+        },
+        {
+          clientGroupID: 'abc123',
+          clientID: 'client-b',
+          queryHash: 'oneHash',
+          patchVersion: '1a9:01',
+          deleted: null,
+        },
+        {
+          clientGroupID: 'abc123',
+          clientID: 'client-c',
+          queryHash: 'oneHash',
+          patchVersion: '1a9:01',
+          deleted: null,
+        },
+      ],
+      rows: [
+        {
+          clientGroupID: 'abc123',
+          rowKey: ROW_KEY1,
+          rowVersion: '03',
+          refCounts: {oneHash: 3},
+          patchVersion: '1a0',
+          schema: 'public',
+          table: 'issues',
+        },
+        {
+          clientGroupID: 'abc123',
+          rowKey: ROW_KEY2,
+          rowVersion: '03',
+          refCounts: {oneHash: 3},
+          patchVersion: '1a0',
+          schema: 'public',
+          table: 'issues',
+        },
+      ],
+    };
+
+    await setInitialState(db, initialState);
+
+    const cvrStore = new CVRStore(
+      lc,
+      db,
+      SHARD_ID,
+      'my-task',
+      'abc123',
+      ON_FAILURE,
+    );
+    const cvr = await cvrStore.load(lc, LAST_CONNECT);
+    const updater = new CVRConfigDrivenUpdater(cvrStore, cvr, SHARD_ID);
+
+    expect(updater.deleteClient('client-b')).toMatchInlineSnapshot(`
+      [
+        {
+          "patch": {
+            "clientID": "client-b",
+            "id": "oneHash",
+            "op": "del",
+            "type": "query",
+          },
+          "toVersion": {
+            "minorVersion": 1,
+            "stateVersion": "1aa",
+          },
+        },
+      ]
+    `);
+
+    const {cvr: updated, flushed} = await updater.flush(
+      lc,
+      true,
+      LAST_CONNECT,
+      Date.UTC(2024, 3, 23, 1),
+    );
+    expect(updated).toMatchInlineSnapshot(`
+      {
+        "clients": {
+          "client-a": {
+            "desiredQueryIDs": [
+              "oneHash",
+            ],
+            "id": "client-a",
+          },
+          "client-c": {
+            "desiredQueryIDs": [
+              "oneHash",
+            ],
+            "id": "client-c",
+          },
+        },
+        "id": "abc123",
+        "lastActive": 1713834000000,
+        "queries": {
+          "oneHash": {
+            "ast": {
+              "table": "issues",
+            },
+            "desiredBy": {
+              "client-a": {
+                "minorVersion": 1,
+                "stateVersion": "1a9",
+              },
+              "client-c": {
+                "minorVersion": 1,
+                "stateVersion": "1a9",
+              },
+            },
+            "id": "oneHash",
+            "patchVersion": undefined,
+            "transformationHash": undefined,
+            "transformationVersion": undefined,
+          },
+        },
+        "replicaVersion": "120",
+        "version": {
+          "minorVersion": 1,
+          "stateVersion": "1aa",
+        },
+      }
+    `);
+    expect(flushed).toMatchInlineSnapshot(`
+      {
+        "clients": 1,
+        "desires": 2,
+        "instances": 2,
+        "queries": 1,
+        "rows": 0,
+        "rowsDeferred": 0,
+        "statements": 7,
+      }
+    `);
+
+    expect(await getAllState(db)).toMatchInlineSnapshot(`
+      {
+        "clients": Result [
+          {
+            "clientGroupID": "abc123",
+            "clientID": "client-a",
+            "deleted": null,
+            "patchVersion": "1aa",
+          },
+          {
+            "clientGroupID": "abc123",
+            "clientID": "client-c",
+            "deleted": null,
+            "patchVersion": "1aa",
+          },
+        ],
+        "desires": Result [
+          {
+            "clientGroupID": "abc123",
+            "clientID": "client-a",
+            "deleted": null,
+            "patchVersion": "1a9:01",
+            "queryHash": "oneHash",
+          },
+          {
+            "clientGroupID": "abc123",
+            "clientID": "client-c",
+            "deleted": null,
+            "patchVersion": "1a9:01",
+            "queryHash": "oneHash",
+          },
+        ],
+        "instances": Result [
+          {
+            "clientGroupID": "abc123",
+            "grantedAt": 1709251200000,
+            "lastActive": 1713834000000,
+            "owner": "my-task",
+            "replicaVersion": "120",
+            "version": "1aa:01",
+          },
+        ],
+        "queries": Result [
+          {
+            "clientAST": {
+              "table": "issues",
+            },
+            "clientGroupID": "abc123",
+            "deleted": false,
+            "internal": null,
+            "patchVersion": null,
+            "queryHash": "oneHash",
+            "transformationHash": null,
+            "transformationVersion": null,
+          },
+        ],
+        "rows": Result [
+          {
+            "clientGroupID": "abc123",
+            "patchVersion": "1a0",
+            "refCounts": {
+              "oneHash": 3,
+            },
+            "rowKey": {
+              "id": "123",
+            },
+            "rowVersion": "03",
+            "schema": "public",
+            "table": "issues",
+          },
+          {
+            "clientGroupID": "abc123",
+            "patchVersion": "1a0",
+            "refCounts": {
+              "oneHash": 3,
+            },
+            "rowKey": {
+              "id": "321",
+            },
+            "rowVersion": "03",
+            "schema": "public",
+            "table": "issues",
+          },
+        ],
+      }
+    `);
+  });
+
+  test('deleteClient from other group', async () => {
+    const initialState: DBState = {
+      instances: [
+        {
+          clientGroupID: 'abc123',
+          version: '1aa',
+          replicaVersion: '120',
+          lastActive: Date.UTC(2024, 3, 23),
+        },
+
+        {
+          clientGroupID: 'def456',
+          version: '1aa',
+          replicaVersion: '120',
+          lastActive: Date.UTC(2024, 3, 23),
+        },
+      ],
+      clients: [
+        {
+          clientGroupID: 'abc123',
+          clientID: 'client-a',
+          patchVersion: '1aa',
+          deleted: null,
+        },
+        {
+          clientGroupID: 'def456',
+          clientID: 'client-b',
+          patchVersion: '1aa',
+          deleted: null,
+        },
+        {
+          clientGroupID: 'abc123',
+          clientID: 'client-c',
+          patchVersion: '1aa',
+          deleted: null,
+        },
+      ],
+      queries: [
+        {
+          clientGroupID: 'abc123',
+          queryHash: 'oneHash',
+          clientAST: {table: 'issues'},
+          transformationHash: null,
+          transformationVersion: null,
+          patchVersion: null,
+          internal: null,
+          deleted: null,
+        },
+        {
+          clientGroupID: 'def456',
+          queryHash: 'oneHash',
+          clientAST: {table: 'issues'},
+          transformationHash: null,
+          transformationVersion: null,
+          patchVersion: null,
+          internal: null,
+          deleted: null,
+        },
+      ],
+      desires: [
+        {
+          clientGroupID: 'abc123',
+          clientID: 'client-a',
+          queryHash: 'oneHash',
+          patchVersion: '1a9:01',
+          deleted: null,
+        },
+        {
+          clientGroupID: 'def456',
+          clientID: 'client-b',
+          queryHash: 'oneHash',
+          patchVersion: '1a9:01',
+          deleted: null,
+        },
+        {
+          clientGroupID: 'abc123',
+          clientID: 'client-c',
+          queryHash: 'oneHash',
+          patchVersion: '1a9:01',
+          deleted: null,
+        },
+      ],
+      rows: [
+        {
+          clientGroupID: 'abc123',
+          rowKey: ROW_KEY1,
+          rowVersion: '03',
+          refCounts: {oneHash: 2},
+          patchVersion: '1a0',
+          schema: 'public',
+          table: 'issues',
+        },
+        {
+          clientGroupID: 'abc123',
+          rowKey: ROW_KEY2,
+          rowVersion: '03',
+          refCounts: {oneHash: 2},
+          patchVersion: '1a0',
+          schema: 'public',
+          table: 'issues',
+        },
+        {
+          clientGroupID: 'def456',
+          rowKey: ROW_KEY1,
+          rowVersion: '03',
+          refCounts: {oneHash: 1},
+          patchVersion: '1a0',
+          schema: 'public',
+          table: 'issues',
+        },
+        {
+          clientGroupID: 'def456',
+          rowKey: ROW_KEY2,
+          rowVersion: '03',
+          refCounts: {oneHash: 1},
+          patchVersion: '1a0',
+          schema: 'public',
+          table: 'issues',
+        },
+      ],
+    };
+
+    await setInitialState(db, initialState);
+
+    const cvrStore = new CVRStore(
+      lc,
+      db,
+      SHARD_ID,
+      'my-task',
+      'abc123',
+      ON_FAILURE,
+    );
+    const cvr = await cvrStore.load(lc, LAST_CONNECT);
+
+    expect(cvr).toMatchInlineSnapshot(`
+      {
+        "clients": {
+          "client-a": {
+            "desiredQueryIDs": [
+              "oneHash",
+            ],
+            "id": "client-a",
+          },
+          "client-c": {
+            "desiredQueryIDs": [
+              "oneHash",
+            ],
+            "id": "client-c",
+          },
+        },
+        "id": "abc123",
+        "lastActive": 1713830400000,
+        "queries": {
+          "oneHash": {
+            "ast": {
+              "table": "issues",
+            },
+            "desiredBy": {
+              "client-a": {
+                "minorVersion": 1,
+                "stateVersion": "1a9",
+              },
+              "client-c": {
+                "minorVersion": 1,
+                "stateVersion": "1a9",
+              },
+            },
+            "id": "oneHash",
+            "patchVersion": undefined,
+            "transformationHash": undefined,
+            "transformationVersion": undefined,
+          },
+        },
+        "replicaVersion": "120",
+        "version": {
+          "stateVersion": "1aa",
+        },
+      }
+    `);
+
+    const updater = new CVRConfigDrivenUpdater(cvrStore, cvr, SHARD_ID);
+
+    // No patches because client-b is from a different group.
+    expect(updater.deleteClient('client-b')).toEqual([]);
+
+    const {cvr: updated} = await updater.flush(
+      lc,
+      true,
+      LAST_CONNECT,
+      Date.UTC(2024, 3, 23, 1),
+    );
+
+    expect(await getAllState(db)).toMatchInlineSnapshot(`
+      {
+        "clients": Result [
+          {
+            "clientGroupID": "abc123",
+            "clientID": "client-a",
+            "deleted": null,
+            "patchVersion": "1aa",
+          },
+          {
+            "clientGroupID": "abc123",
+            "clientID": "client-c",
+            "deleted": null,
+            "patchVersion": "1aa",
+          },
+        ],
+        "desires": Result [
+          {
+            "clientGroupID": "abc123",
+            "clientID": "client-a",
+            "deleted": null,
+            "patchVersion": "1a9:01",
+            "queryHash": "oneHash",
+          },
+          {
+            "clientGroupID": "abc123",
+            "clientID": "client-c",
+            "deleted": null,
+            "patchVersion": "1a9:01",
+            "queryHash": "oneHash",
+          },
+        ],
+        "instances": Result [
+          {
+            "clientGroupID": "def456",
+            "grantedAt": null,
+            "lastActive": 1713830400000,
+            "owner": null,
+            "replicaVersion": "120",
+            "version": "1aa",
+          },
+          {
+            "clientGroupID": "abc123",
+            "grantedAt": 1709251200000,
+            "lastActive": 1713834000000,
+            "owner": "my-task",
+            "replicaVersion": "120",
+            "version": "1aa",
+          },
+        ],
+        "queries": Result [
+          {
+            "clientAST": {
+              "table": "issues",
+            },
+            "clientGroupID": "abc123",
+            "deleted": null,
+            "internal": null,
+            "patchVersion": null,
+            "queryHash": "oneHash",
+            "transformationHash": null,
+            "transformationVersion": null,
+          },
+          {
+            "clientAST": {
+              "table": "issues",
+            },
+            "clientGroupID": "def456",
+            "deleted": null,
+            "internal": null,
+            "patchVersion": null,
+            "queryHash": "oneHash",
+            "transformationHash": null,
+            "transformationVersion": null,
+          },
+        ],
+        "rows": Result [
+          {
+            "clientGroupID": "abc123",
+            "patchVersion": "1a0",
+            "refCounts": {
+              "oneHash": 2,
+            },
+            "rowKey": {
+              "id": "123",
+            },
+            "rowVersion": "03",
+            "schema": "public",
+            "table": "issues",
+          },
+          {
+            "clientGroupID": "abc123",
+            "patchVersion": "1a0",
+            "refCounts": {
+              "oneHash": 2,
+            },
+            "rowKey": {
+              "id": "321",
+            },
+            "rowVersion": "03",
+            "schema": "public",
+            "table": "issues",
+          },
+          {
+            "clientGroupID": "def456",
+            "patchVersion": "1a0",
+            "refCounts": {
+              "oneHash": 1,
+            },
+            "rowKey": {
+              "id": "123",
+            },
+            "rowVersion": "03",
+            "schema": "public",
+            "table": "issues",
+          },
+          {
+            "clientGroupID": "def456",
+            "patchVersion": "1a0",
+            "refCounts": {
+              "oneHash": 1,
+            },
+            "rowKey": {
+              "id": "321",
+            },
+            "rowVersion": "03",
+            "schema": "public",
+            "table": "issues",
+          },
+        ],
+      }
+    `);
+
+    expect(updated).toMatchInlineSnapshot(`
+      {
+        "clients": {
+          "client-a": {
+            "desiredQueryIDs": [
+              "oneHash",
+            ],
+            "id": "client-a",
+          },
+          "client-c": {
+            "desiredQueryIDs": [
+              "oneHash",
+            ],
+            "id": "client-c",
+          },
+        },
+        "id": "abc123",
+        "lastActive": 1713834000000,
+        "queries": {
+          "oneHash": {
+            "ast": {
+              "table": "issues",
+            },
+            "desiredBy": {
+              "client-a": {
+                "minorVersion": 1,
+                "stateVersion": "1a9",
+              },
+              "client-c": {
+                "minorVersion": 1,
+                "stateVersion": "1a9",
+              },
+            },
+            "id": "oneHash",
+            "patchVersion": undefined,
+            "transformationHash": undefined,
+            "transformationVersion": undefined,
+          },
+        },
+        "replicaVersion": "120",
+        "version": {
+          "stateVersion": "1aa",
+        },
+      }
+    `);
+
+    {
+      const cvr = await cvrStore.load(lc, LAST_CONNECT);
+      const updater = new CVRConfigDrivenUpdater(cvrStore, cvr, SHARD_ID);
+
+      updater.deleteClientGroup('def456');
+      const {cvr: updated2} = await updater.flush(
+        lc,
+        true,
+        LAST_CONNECT,
+        Date.UTC(2024, 3, 23, 1),
+      );
+
+      expect(updated2).toEqual(updated);
+
+      expect(await getAllState(db)).toMatchInlineSnapshot(`
+        {
+          "clients": Result [
+            {
+              "clientGroupID": "abc123",
+              "clientID": "client-a",
+              "deleted": null,
+              "patchVersion": "1aa",
+            },
+            {
+              "clientGroupID": "abc123",
+              "clientID": "client-c",
+              "deleted": null,
+              "patchVersion": "1aa",
+            },
+          ],
+          "desires": Result [
+            {
+              "clientGroupID": "abc123",
+              "clientID": "client-a",
+              "deleted": null,
+              "patchVersion": "1a9:01",
+              "queryHash": "oneHash",
+            },
+            {
+              "clientGroupID": "abc123",
+              "clientID": "client-c",
+              "deleted": null,
+              "patchVersion": "1a9:01",
+              "queryHash": "oneHash",
+            },
+          ],
+          "instances": Result [
+            {
+              "clientGroupID": "abc123",
+              "grantedAt": 1709251200000,
+              "lastActive": 1713834000000,
+              "owner": "my-task",
+              "replicaVersion": "120",
+              "version": "1aa",
+            },
+          ],
+          "queries": Result [
+            {
+              "clientAST": {
+                "table": "issues",
+              },
+              "clientGroupID": "abc123",
+              "deleted": null,
+              "internal": null,
+              "patchVersion": null,
+              "queryHash": "oneHash",
+              "transformationHash": null,
+              "transformationVersion": null,
+            },
+          ],
+          "rows": Result [
+            {
+              "clientGroupID": "abc123",
+              "patchVersion": "1a0",
+              "refCounts": {
+                "oneHash": 2,
+              },
+              "rowKey": {
+                "id": "123",
+              },
+              "rowVersion": "03",
+              "schema": "public",
+              "table": "issues",
+            },
+            {
+              "clientGroupID": "abc123",
+              "patchVersion": "1a0",
+              "refCounts": {
+                "oneHash": 2,
+              },
+              "rowKey": {
+                "id": "321",
+              },
+              "rowVersion": "03",
+              "schema": "public",
+              "table": "issues",
+            },
+          ],
+        }
+      `);
+    }
+  });
 });

--- a/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
@@ -609,9 +609,8 @@ describe('view-syncer/cvr', () => {
     const updater = new CVRConfigDrivenUpdater(cvrStore, cvr, SHARD_ID);
 
     // This removes and adds desired queries to the existing fooClient.
-    expect(
-      updater.deleteDesiredQueries('fooClient', ['oneHash', 'twoHash'], now),
-    ).toMatchInlineSnapshot(`
+    expect(updater.deleteDesiredQueries('fooClient', ['oneHash', 'twoHash']))
+      .toMatchInlineSnapshot(`
         [
           {
             "patch": {
@@ -721,24 +720,9 @@ describe('view-syncer/cvr', () => {
     expect(
       updater.putDesiredQueries('bonkClient', [], now),
     ).toMatchInlineSnapshot(
-      `
-                [
-                  {
-                    "patch": {
-                      "id": "bonkClient",
-                      "op": "put",
-                      "type": "client",
-                    },
-                    "toVersion": {
-                      "minorVersion": 1,
-                      "stateVersion": "1aa",
-                    },
-                  },
-                ]
-              `,
+      `[]`,
     );
-    expect(updater.clearDesiredQueries('dooClient', now))
-      .toMatchInlineSnapshot(`
+    expect(updater.clearDesiredQueries('dooClient')).toMatchInlineSnapshot(`
                   [
                     {
                       "patch": {
@@ -4155,6 +4139,9 @@ describe('view-syncer/cvr', () => {
           patchVersion: null,
           internal: null,
           deleted: null,
+          expiresAt: null,
+          inactivatedAt: null,
+          ttl: null,
         },
       ],
       desires: [
@@ -4271,10 +4258,13 @@ describe('view-syncer/cvr', () => {
                 "stateVersion": "1a9",
               },
             },
+            "expiresAt": undefined,
             "id": "oneHash",
+            "inactivatedAt": undefined,
             "patchVersion": undefined,
             "transformationHash": undefined,
             "transformationVersion": undefined,
+            "ttl": undefined,
           },
         },
         "replicaVersion": "120",
@@ -4345,11 +4335,14 @@ describe('view-syncer/cvr', () => {
             },
             "clientGroupID": "abc123",
             "deleted": false,
+            "expiresAt": null,
+            "inactivatedAt": null,
             "internal": null,
             "patchVersion": null,
             "queryHash": "oneHash",
             "transformationHash": null,
             "transformationVersion": null,
+            "ttl": null,
           },
         ],
         "rows": Result [
@@ -4431,6 +4424,9 @@ describe('view-syncer/cvr', () => {
           patchVersion: null,
           internal: null,
           deleted: null,
+          expiresAt: null,
+          inactivatedAt: null,
+          ttl: null,
         },
         {
           clientGroupID: 'def456',
@@ -4441,6 +4437,9 @@ describe('view-syncer/cvr', () => {
           patchVersion: null,
           internal: null,
           deleted: null,
+          expiresAt: null,
+          inactivatedAt: null,
+          ttl: null,
         },
       ],
       desires: [
@@ -4551,10 +4550,13 @@ describe('view-syncer/cvr', () => {
                 "stateVersion": "1a9",
               },
             },
+            "expiresAt": undefined,
             "id": "oneHash",
+            "inactivatedAt": undefined,
             "patchVersion": undefined,
             "transformationHash": undefined,
             "transformationVersion": undefined,
+            "ttl": undefined,
           },
         },
         "replicaVersion": "120",
@@ -4633,11 +4635,14 @@ describe('view-syncer/cvr', () => {
             },
             "clientGroupID": "abc123",
             "deleted": null,
+            "expiresAt": null,
+            "inactivatedAt": null,
             "internal": null,
             "patchVersion": null,
             "queryHash": "oneHash",
             "transformationHash": null,
             "transformationVersion": null,
+            "ttl": null,
           },
           {
             "clientAST": {
@@ -4645,11 +4650,14 @@ describe('view-syncer/cvr', () => {
             },
             "clientGroupID": "def456",
             "deleted": null,
+            "expiresAt": null,
+            "inactivatedAt": null,
             "internal": null,
             "patchVersion": null,
             "queryHash": "oneHash",
             "transformationHash": null,
             "transformationVersion": null,
+            "ttl": null,
           },
         ],
         "rows": Result [
@@ -4742,10 +4750,13 @@ describe('view-syncer/cvr', () => {
                 "stateVersion": "1a9",
               },
             },
+            "expiresAt": undefined,
             "id": "oneHash",
+            "inactivatedAt": undefined,
             "patchVersion": undefined,
             "transformationHash": undefined,
             "transformationVersion": undefined,
+            "ttl": undefined,
           },
         },
         "replicaVersion": "120",
@@ -4818,11 +4829,14 @@ describe('view-syncer/cvr', () => {
               },
               "clientGroupID": "abc123",
               "deleted": null,
+              "expiresAt": null,
+              "inactivatedAt": null,
               "internal": null,
               "patchVersion": null,
               "queryHash": "oneHash",
               "transformationHash": null,
               "transformationVersion": null,
+              "ttl": null,
             },
           ],
           "rows": Result [

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -293,10 +293,6 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
   }
 
   deleteClientGroup(clientGroupID: string): void {
-    assert(
-      this._cvr.id !== clientGroupID,
-      'Cannot delete the client group from itself',
-    );
     this._cvrStore.deleteClientGroup(clientGroupID);
   }
 
@@ -701,8 +697,4 @@ function mergeRefCounts(
   }
 
   return Object.values(merged).some(v => v > 0) ? merged : null;
-}
-
-export function deleteClientGroupFromCVR(_clientGroupID: string) {
-  // TODO: Implement!
 }

--- a/packages/zero-cache/src/services/view-syncer/row-record-cache.ts
+++ b/packages/zero-cache/src/services/view-syncer/row-record-cache.ts
@@ -1,0 +1,372 @@
+import type {LogContext} from '@rocicorp/logger';
+import {type Resolver, resolver} from '@rocicorp/resolver';
+import type {PendingQuery, Row} from 'postgres';
+import {CustomKeyMap} from '../../../../shared/src/custom-key-map.ts';
+import {must} from '../../../../shared/src/must.ts';
+import {promiseVoid} from '../../../../shared/src/resolved-promises.ts';
+import * as Mode from '../../db/mode-enum.ts';
+import {TransactionPool} from '../../db/transaction-pool.ts';
+import type {PostgresDB, PostgresTransaction} from '../../types/pg.ts';
+import {rowIDString} from '../../types/row-key.ts';
+import {checkVersion} from './cvr-store.ts';
+import type {CVRSnapshot} from './cvr.ts';
+import {
+  cvrSchema,
+  rowRecordToRowsRow,
+  type RowsRow,
+  rowsRowToRowRecord,
+} from './schema/cvr.ts';
+import {
+  cmpVersions,
+  type CVRVersion,
+  type NullableCVRVersion,
+  type RowID,
+  type RowRecord,
+  versionString,
+  versionToNullableCookie,
+} from './schema/types.ts';
+
+/**
+ * The RowRecordCache is an in-memory cache of the `cvr.rows` tables that
+ * operates as both a write-through and write-back cache.
+ *
+ * For "small" CVR updates (i.e. zero or small numbers of rows) the
+ * RowRecordCache operates as write-through, executing commits in
+ * {@link executeRowUpdates()} before they are {@link apply}-ed to the
+ * in-memory state.
+ *
+ * For "large" CVR updates (i.e. with many rows), the cache switches to a
+ * write-back mode of operation, in which {@link executeRowUpdates()} is a
+ * no-op, and {@link apply()} initiates a background task to flush the pending
+ * row changes to the store. This allows the client poke to be completed and
+ * committed on the client without waiting for the heavyweight operation of
+ * committing the row records to the CVR store.
+ *
+ * Note that when the cache is in write-back mode, all updates become
+ * write-back (i.e. asynchronously flushed) until the pending update queue is
+ * fully flushed. This is required because updates must be applied in version
+ * order. As with all pending work systems in zero-cache, multiple pending
+ * updates are coalesced to reduce buildup of work.
+ *
+ * ### High level consistency
+ *
+ * Note that the above caching scheme only applies to the row data in `cvr.rows`
+ * and corresponding `cvr.rowsVersion` tables. CVR metadata and query
+ * information, on the other hand, are always committed before completing the
+ * client poke. In this manner, the difference between the `version` column in
+ * `cvr.instances` and the analogous column in `cvr.rowsVersion` determines
+ * whether the data in the store is consistent, or whether it is awaiting a
+ * pending update.
+ *
+ * The logic in {@link CVRStore.load()} takes this into account by loading both
+ * the `cvr.instances` version and the `cvr.rowsVersion` version and checking
+ * if they are in sync, waiting for a configurable delay until they are.
+ *
+ * ### Eventual conversion
+ *
+ * In the event of a continual stream of mutations (e.g. an animation-style
+ * app), it is conceivable that the row record data be continually behind
+ * the CVR metadata. In order to effect eventual convergence, a new view-syncer
+ * signals the current view-syncer to stop updating by writing new `owner`
+ * information to the `cvr.instances` row. This effectively stops the mutation
+ * processing (in {@link CVRStore.#checkVersionAndOwnership}) so that the row
+ * data can eventually catch up, allowing the new view-syncer to take over.
+ *
+ * Of course, there is the pathological situation in which a view-syncer
+ * process crashes before the pending row updates are flushed. In this case,
+ * the wait timeout will elapse and the CVR considered invalid.
+ */
+export class RowRecordCache {
+  // The state in the #cache is always in sync with the CVR metadata
+  // (i.e. cvr.instances). It may contain information that has not yet
+  // been flushed to cvr.rows.
+  #cache: Promise<CustomKeyMap<RowID, RowRecord>> | undefined;
+  readonly #lc: LogContext;
+  readonly #db: PostgresDB;
+  readonly #schema: string;
+  readonly #cvrID: string;
+  readonly #failService: (e: unknown) => void;
+  readonly #deferredRowFlushThreshold: number;
+  readonly #setTimeout: typeof setTimeout;
+
+  // Write-back cache state.
+  readonly #pending = new CustomKeyMap<RowID, RowRecord | null>(rowIDString);
+  #pendingRowsVersion: CVRVersion | null = null;
+  #flushedRowsVersion: CVRVersion | null = null;
+  #flushing: Resolver<void> | null = null;
+
+  constructor(
+    lc: LogContext,
+    db: PostgresDB,
+    shardID: string,
+    cvrID: string,
+    failService: (e: unknown) => void,
+    deferredRowFlushThreshold = 100,
+    setTimeoutFn = setTimeout,
+  ) {
+    this.#lc = lc;
+    this.#db = db;
+    this.#schema = cvrSchema(shardID);
+    this.#cvrID = cvrID;
+    this.#failService = failService;
+    this.#deferredRowFlushThreshold = deferredRowFlushThreshold;
+    this.#setTimeout = setTimeoutFn;
+  }
+
+  #cvr(table: string) {
+    return this.#db(`${this.#schema}.${table}`);
+  }
+
+  async #ensureLoaded(): Promise<CustomKeyMap<RowID, RowRecord>> {
+    if (this.#cache) {
+      return this.#cache;
+    }
+    const r = resolver<CustomKeyMap<RowID, RowRecord>>();
+    // Set this.#cache immediately (before await) so that only one db
+    // query is made even if there are multiple callers.
+    this.#cache = r.promise;
+
+    const cache: CustomKeyMap<RowID, RowRecord> = new CustomKeyMap(rowIDString);
+    for await (const rows of this.#db<RowsRow[]>`
+      SELECT * FROM ${this.#cvr(`rows`)} 
+        WHERE "clientGroupID" = ${this.#cvrID} AND "refCounts" IS NOT NULL`
+      // TODO(arv): Arbitrary page size
+      .cursor(5000)) {
+      for (const row of rows) {
+        const rowRecord = rowsRowToRowRecord(row);
+        cache.set(rowRecord.id, rowRecord);
+      }
+    }
+    r.resolve(cache);
+    return this.#cache;
+  }
+
+  getRowRecords(): Promise<ReadonlyMap<RowID, RowRecord>> {
+    return this.#ensureLoaded();
+  }
+
+  /**
+   * Applies the `rowRecords` corresponding to the `rowsVersion`
+   * to the cache, indicating whether the corresponding updates
+   * (generated by {@link executeRowUpdates}) were `flushed`.
+   *
+   * If `flushed` is false, the RowRecordCache will flush the records
+   * asynchronously.
+   *
+   * Note that `apply()` indicates that the CVR metadata associated with
+   * the `rowRecords` was successfully committed, which essentially means
+   * that this process has the unconditional right (and responsibility) of
+   * following up with a flush of the `rowRecords`. In particular, the
+   * commit of row records are not conditioned on the version or ownership
+   * columns of the `cvr.instances` row.
+   */
+  async apply(
+    rowRecords: Map<RowID, RowRecord | null>,
+    rowsVersion: CVRVersion,
+    flushed: boolean,
+  ) {
+    const cache = await this.#ensureLoaded();
+    for (const [id, row] of rowRecords.entries()) {
+      if (row === null || row.refCounts === null) {
+        cache.delete(id);
+      } else {
+        cache.set(id, row);
+      }
+      if (!flushed) {
+        this.#pending.set(id, row);
+      }
+    }
+    this.#pendingRowsVersion = rowsVersion;
+    // Initiate a flush if not already flushing.
+    if (!flushed && this.#flushing === null) {
+      this.#flushing = resolver();
+      this.#setTimeout(() => this.#flush(), 0);
+    }
+  }
+
+  async #flush() {
+    const flushing = must(this.#flushing);
+    try {
+      while (this.#pendingRowsVersion !== this.#flushedRowsVersion) {
+        const start = Date.now();
+
+        const {rows, rowsVersion} = await this.#db.begin(tx => {
+          // Note: This code block is synchronous, guaranteeing that the
+          // #pendingRowsVersion is consistent with the #pending rows.
+          const rows = this.#pending.size;
+          const rowsVersion = must(this.#pendingRowsVersion);
+          this.executeRowUpdates(tx, rowsVersion, this.#pending, 'force');
+          this.#pending.clear();
+          return {rows, rowsVersion};
+        });
+        this.#lc.debug?.(
+          `flushed ${rows} rows@${versionString(rowsVersion)} (${
+            Date.now() - start
+          } ms)`,
+        );
+        this.#flushedRowsVersion = rowsVersion;
+        // Note: apply() may have called while the transaction was committing,
+        //       which will result in looping to commit the next #pendingRowsVersion.
+      }
+      this.#lc.debug?.(
+        `up to date rows@${versionToNullableCookie(this.#flushedRowsVersion)}`,
+      );
+      flushing.resolve();
+      this.#flushing = null;
+    } catch (e) {
+      flushing.reject(e);
+      this.#failService(e);
+    }
+  }
+
+  hasPendingUpdates() {
+    return this.#flushing !== null;
+  }
+
+  /**
+   * Returns a promise that resolves when all outstanding row-records
+   * have been committed.
+   */
+  flushed(lc: LogContext): Promise<void> {
+    if (this.#flushing) {
+      lc.debug?.('awaiting pending row flush');
+      return this.#flushing.promise;
+    }
+    return promiseVoid;
+  }
+
+  clear() {
+    // Note: Only the #cache is cleared. #pending updates, on the other hand,
+    // comprise canonical (i.e. already flushed) data and must be flushed
+    // even if the snapshot of the present state (the #cache) is cleared.
+    this.#cache = undefined;
+  }
+
+  async *catchupRowPatches(
+    lc: LogContext,
+    afterVersion: NullableCVRVersion,
+    upToCVR: CVRSnapshot,
+    current: CVRVersion,
+    excludeQueryHashes: string[],
+  ): AsyncGenerator<RowsRow[], void, undefined> {
+    if (cmpVersions(afterVersion, upToCVR.version) >= 0) {
+      return;
+    }
+
+    const startMs = Date.now();
+    const start = afterVersion ? versionString(afterVersion) : '';
+    const end = versionString(upToCVR.version);
+    lc.debug?.(`scanning row patches for clients from ${start}`);
+
+    // Before accessing the CVR db, pending row records must be flushed.
+    // Note that because catchupRowPatches() is called from within the
+    // view syncer lock, this flush is guaranteed to complete since no
+    // new CVR updates can happen while the lock is held.
+    await this.flushed(lc);
+    const flushMs = Date.now() - startMs;
+
+    const reader = new TransactionPool(lc, Mode.READONLY).run(this.#db);
+    try {
+      // Verify that we are reading the right version of the CVR.
+      await reader.processReadTask(tx =>
+        checkVersion(tx, this.#schema, this.#cvrID, current),
+      );
+
+      const {query} = await reader.processReadTask(tx => {
+        const query =
+          excludeQueryHashes.length === 0
+            ? tx<RowsRow[]>`SELECT * FROM ${this.#cvr('rows')}
+        WHERE "clientGroupID" = ${this.#cvrID}
+          AND "patchVersion" > ${start}
+          AND "patchVersion" <= ${end}`
+            : // Exclude rows that were already sent as part of query hydration.
+              tx<RowsRow[]>`SELECT * FROM ${this.#cvr('rows')}
+        WHERE "clientGroupID" = ${this.#cvrID}
+          AND "patchVersion" > ${start}
+          AND "patchVersion" <= ${end}
+          AND ("refCounts" IS NULL OR NOT "refCounts" ?| ${excludeQueryHashes})`;
+        return {query};
+      });
+
+      yield* query.cursor(10000);
+    } finally {
+      reader.setDone();
+    }
+
+    const totalMs = Date.now() - startMs;
+    lc.debug?.(
+      `finished row catchup (flush: ${flushMs} ms, total: ${totalMs} ms)`,
+    );
+  }
+
+  executeRowUpdates(
+    tx: PostgresTransaction,
+    version: CVRVersion,
+    rowUpdates: Map<RowID, RowRecord | null>,
+    mode: 'allow-defer' | 'force',
+  ): PendingQuery<Row[]>[] {
+    if (
+      mode === 'allow-defer' &&
+      // defer if pending rows are being flushed
+      (this.#flushing !== null ||
+        // or if the new batch is above the limit.
+        rowUpdates.size > this.#deferredRowFlushThreshold)
+    ) {
+      return [];
+    }
+    const rowsVersion = {
+      clientGroupID: this.#cvrID,
+      version: versionString(version),
+    };
+    const pending: PendingQuery<Row[]>[] = [
+      tx`INSERT INTO ${this.#cvr('rowsVersion')} ${tx(rowsVersion)}
+           ON CONFLICT ("clientGroupID") 
+           DO UPDATE SET ${tx(rowsVersion)}`.execute(),
+    ];
+
+    const rowRecordRows: RowsRow[] = [];
+    for (const [id, row] of rowUpdates.entries()) {
+      if (row === null) {
+        pending.push(
+          tx`
+          DELETE FROM ${this.#cvr('rows')}
+            WHERE "clientGroupID" = ${this.#cvrID}
+              AND "schema" = ${id.schema}
+              AND "table" = ${id.table}
+              AND "rowKey" = ${id.rowKey}
+       `.execute(),
+        );
+      } else {
+        rowRecordRows.push(rowRecordToRowsRow(this.#cvrID, row));
+      }
+    }
+    if (rowRecordRows.length) {
+      pending.push(
+        tx`
+  INSERT INTO ${this.#cvr('rows')}(
+      "clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts"
+  ) SELECT
+      "clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts"
+    FROM json_to_recordset(${rowRecordRows}) AS x(
+      "clientGroupID" TEXT,
+      "schema" TEXT,
+      "table" TEXT,
+      "rowKey" JSONB,
+      "rowVersion" TEXT,
+      "patchVersion" TEXT,
+      "refCounts" JSONB
+  ) ON CONFLICT ("clientGroupID", "schema", "table", "rowKey")
+    DO UPDATE SET "rowVersion" = excluded."rowVersion",
+      "patchVersion" = excluded."patchVersion",
+      "refCounts" = excluded."refCounts"
+    `.execute(),
+      );
+      this.#lc.debug?.(
+        `flushing ${rowUpdates.size} rows (${rowRecordRows.length} inserts, ${
+          rowUpdates.size - rowRecordRows.length
+        } deletes)`,
+      );
+    }
+    return pending;
+  }
+}

--- a/packages/zero-cache/src/services/view-syncer/schema/notes.md
+++ b/packages/zero-cache/src/services/view-syncer/schema/notes.md
@@ -1,0 +1,82 @@
+How to order the queries?
+
+To achieve LRU and TTL we need the queries to be ordered by the time they were last accessed.
+
+```sql
+CREATE TABLE queries (
+  ...
+  last_accessed TIMESTAMP,
+)
+```
+
+a query can be active or inactive. If it is active it will not be removed.
+
+```sql
+CREATE TABLE queries (
+  ...
+  "lastAccessed" TIMESTAMP,
+  "active" BOOLEAN NOT NULL,,
+)
+```
+
+An active query will never be removed, we can remove "lastAccessed" from the table.
+
+```sql
+CREATE TABLE queries (
+  ...
+  "active" BOOLEAN NOT NULL,,
+)
+```
+
+When the query becomes inactive we want to keep it as long as there is space and it has not expired. So when we inactive it we set the inactivated time
+
+```sql
+CREATE TABLE queries (
+  ...
+  "active" BOOLEAN NOT NULL,
+  "ttl" INTEGER,
+  "inactivatedAt" TIMESTAMP,
+)
+```
+
+We can use the "inactiveTime" `NULL` to signify an active query:
+
+```sql
+CREATE TABLE queries (
+  ...
+  "ttl" INTEGER,
+  "inactivatedAt" TIMESTAMP,
+)
+```
+
+When we need to remove a query we want to:
+
+- Remove the oldest inactive query with an expire time
+- Remove the oldest inactive query without an expire time
+- Never remove an active query.
+
+The expire time is computed as the `inactivatedAt + ttl`. We add a column for it even though it is is denormalized. We do this to add an index on "expiresAt".
+(Maybe we do not need that since we are operating on the CVR in memory... we will see.)
+
+```sql
+CREATE TABLE queries (
+  ...
+  "ttl" INTEGER,
+  "inactivatedAt" TIMESTAMP,
+  "expiresAt" TIMESTAMP,
+);
+
+CREATE INDEX queries_index_expires_at ON queries ("expiresAt" NULLS LAST);
+CREATE INDEX queries_index_inactivated_at ON queries ("inactivatedAt" NULLS LAST);
+
+```
+
+If we have not yet been inactivated expiresAt is `NULL`.
+If we have no ttl expiresAt is also `NULL`.
+This way we can order by `expiresAt` and then by `inactivatedAt` to remove the oldest query.
+
+```sql
+SELECT * FROM queries WHERE "inactivatedAt" IS NOT NULL ORDER BY "expiresAt" ASC, "inactivatedAt" ASC
+```
+
+Now we can start from the beginning and remove queries until we have enough space.

--- a/packages/zero-cache/src/services/view-syncer/schema/types.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/types.ts
@@ -173,9 +173,31 @@ export const clientQueryRecordSchema = baseQueryRecordSchema.extend({
   // the queryID was added to their desired query set (i.e. individual `patchVersion`s).
   desiredBy: v.record(cvrVersionSchema),
 
-  // TODO: Iron this out.
-  // estimatedBytes: v.number(),
-  // lru information?
+  /*
+   * This is the time the query became inactive. If the query is active, this
+   * field is absent (or undefined). This is used to determine when the query
+   * should be considered expired. This is a Unix timestamp in milliseconds.
+   */
+  inactivatedAt: v.number().optional(),
+
+  /**
+   * The Time To Live. If absent/undefined, the query is considered to have no
+   * expiration. The expiration time is set when the query becomes inactive and
+   * needs to be updated/reset when the query becomes active again or another
+   * query with the same hash but with a higher TTL is registered.
+   */
+  // TODO: Make sure we update the TTL as needed
+  ttl: v.number().optional(),
+
+  /**
+   * Used with {@linkcode ttl} to determine when the query should be considered
+   * expired. This is a Unix timestamp in milliseconds. This is only used on the
+   * server side to determine when to remove the query from the view.
+   *
+   * The client only works with {@linkcode ttl} and does not need to know about
+   * this field.
+   */
+  expiresAt: v.number().optional(),
 });
 
 export type ClientQueryRecord = v.Infer<typeof clientQueryRecordSchema>;

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -629,7 +629,6 @@ describe('view-syncer/service', () => {
         foo: {
           desiredQueryIDs: ['query-hash1'],
           id: 'foo',
-          patchVersion: {stateVersion: '00', minorVersion: 1},
         },
       },
       id: '9876',

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -1,4 +1,4 @@
-import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {h128} from '../../../../shared/src/hash.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {Queue} from '../../../../shared/src/queue.ts';
@@ -550,6 +550,7 @@ describe('view-syncer/service', () => {
   };
 
   beforeEach(async () => {
+    vi.useFakeTimers();
     ({
       storageDB,
       replicaDbFile,
@@ -569,6 +570,7 @@ describe('view-syncer/service', () => {
   });
 
   afterEach(async () => {
+    vi.useRealTimers();
     await vs.stop();
     await viewSyncerDone;
     await testDBs.drop(cvrDB);

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -421,10 +421,42 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     msg: DeleteClientsMessage,
   ): Promise<void> {
     try {
-      return await this.#runInLockForClient(ctx, msg, this.#deleteClients);
+      await this.#runInLockForClient(ctx, msg, this.#deleteClients);
     } catch (e) {
       this.#lc.error?.('deleteClients failed', e);
     }
+  }
+
+  async updatePatchesForDesiredQueries(
+    lc: LogContext,
+    cvr: CVRSnapshot,
+    fn: (updater: CVRConfigDrivenUpdater) => PatchToVersion[],
+  ): Promise<CVRSnapshot> {
+    const updater = new CVRConfigDrivenUpdater(
+      this.#cvrStore,
+      cvr,
+      this.#shardID,
+    );
+
+    const patches = fn(updater);
+
+    this.#cvr = (await updater.flush(lc, true, this.#lastConnectTime)).cvr;
+
+    if (cmpVersions(cvr.version, this.#cvr.version) < 0) {
+      // Send pokes to catch up clients that are up to date.
+      // (Clients that are behind the cvr.version need to be caught up in
+      //  #syncQueryPipelineSet(), as row data may be needed for catchup)
+      const newCVR = this.#cvr;
+      const pokers = this.#getClients(cvr.version).map(c =>
+        c.startPoke(newCVR.version),
+      );
+      for (const patch of patches) {
+        pokers.forEach(poker => poker.addPatch(patch));
+      }
+      pokers.forEach(poker => poker.end(newCVR.version));
+    }
+
+    return this.#cvr;
   }
 
   // eslint-disable-next-line require-await
@@ -434,10 +466,45 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     {clientIDs, clientGroupIDs}: DeleteClientsBody,
     cvr: CVRSnapshot,
   ): Promise<void> => {
-    lc.debug?.('deleting clients', clientIDs, clientGroupIDs, clientID, cvr);
-    // TODO: Implement deletion of clients
-    // Find all clients from the msg and delete them. Send back the IDs of the
-    // deleted clients to the client.
+    const deletedClientIDs: string[] = [];
+    const deletedClientGroupIDs: string[] = [];
+
+    if (clientIDs?.length || clientGroupIDs?.length) {
+      // cvr = ... For #syncQueryPipelineSet().
+      cvr = await this.updatePatchesForDesiredQueries(lc, cvr, updater => {
+        const patches: PatchToVersion[] = [];
+        if (clientIDs) {
+          for (const cid of clientIDs) {
+            assert(cid !== clientID, 'cannot delete self');
+            const patchesDueToClient = updater.deleteClient(cid);
+            patches.push(...patchesDueToClient);
+            deletedClientIDs.push(cid);
+          }
+        }
+
+        if (clientGroupIDs) {
+          for (const clientGroupID of clientGroupIDs) {
+            updater.deleteClientGroup(clientGroupID);
+          }
+        }
+
+        return patches;
+      });
+    }
+
+    if (this.#pipelinesSynced) {
+      await this.#syncQueryPipelineSet(lc, cvr);
+    }
+
+    // Send 'deleteClients' to the clients.
+    if (deletedClientIDs.length || deletedClientGroupIDs.length) {
+      lc.debug?.('deleting clients', clientIDs, clientGroupIDs);
+
+      const clients = this.#getClients();
+      clients.forEach(c =>
+        c.sendDeleteClients(deletedClientIDs, deletedClientGroupIDs),
+      );
+    }
   };
 
   /**
@@ -523,46 +590,26 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       // Apply requested patches.
       if (desiredQueriesPatch.length) {
         lc.debug?.(`applying ${desiredQueriesPatch.length} query patches`);
-        const updater = new CVRConfigDrivenUpdater(
-          this.#cvrStore,
-          cvr,
-          this.#shardID,
-        );
-
-        const patches: PatchToVersion[] = [];
-        for (const patch of desiredQueriesPatch) {
-          switch (patch.op) {
-            case 'put':
-              patches.push(...updater.putDesiredQueries(clientID, [patch]));
-              break;
-            case 'del':
-              patches.push(
-                ...updater.deleteDesiredQueries(clientID, [patch.hash]),
-              );
-              break;
-            case 'clear':
-              patches.push(...updater.clearDesiredQueries(clientID));
-              break;
+        // cvr = ... For #syncQueryPipelineSet().
+        cvr = await this.updatePatchesForDesiredQueries(lc, cvr, updater => {
+          const patches: PatchToVersion[] = [];
+          for (const patch of desiredQueriesPatch) {
+            switch (patch.op) {
+              case 'put':
+                patches.push(...updater.putDesiredQueries(clientID, [patch]));
+                break;
+              case 'del':
+                patches.push(
+                  ...updater.deleteDesiredQueries(clientID, [patch.hash]),
+                );
+                break;
+              case 'clear':
+                patches.push(...updater.clearDesiredQueries(clientID));
+                break;
+            }
           }
-        }
-
-        this.#cvr = (await updater.flush(lc, true, this.#lastConnectTime)).cvr;
-
-        if (cmpVersions(cvr.version, this.#cvr.version) < 0) {
-          // Send pokes to catch up clients that are up to date.
-          // (Clients that are behind the cvr.version need to be caught up in
-          //  #syncQueryPipelineSet(), as row data may be needed for catchup)
-          const newCVR = this.#cvr;
-          const pokers = this.#getClients(cvr.version).map(c =>
-            c.startPoke(newCVR.version),
-          );
-          for (const patch of patches) {
-            pokers.forEach(poker => poker.addPatch(patch));
-          }
-          pokers.forEach(poker => poker.end(newCVR.version));
-        }
-
-        cvr = this.#cvr; // For #syncQueryPipelineSet().
+          return patches;
+        });
       }
 
       if (this.#pipelinesSynced) {

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -484,6 +484,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
         if (clientGroupIDs) {
           for (const clientGroupID of clientGroupIDs) {
+            assert(clientGroupID !== this.id, 'cannot delete self');
             updater.deleteClientGroup(clientGroupID);
           }
         }

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -427,7 +427,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     }
   }
 
-  async updatePatchesForDesiredQueries(
+  async #updatePatchesForDesiredQueries(
     lc: LogContext,
     cvr: CVRSnapshot,
     fn: (updater: CVRConfigDrivenUpdater) => PatchToVersion[],
@@ -471,7 +471,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
     if (clientIDs?.length || clientGroupIDs?.length) {
       // cvr = ... For #syncQueryPipelineSet().
-      cvr = await this.updatePatchesForDesiredQueries(lc, cvr, updater => {
+      cvr = await this.#updatePatchesForDesiredQueries(lc, cvr, updater => {
         const patches: PatchToVersion[] = [];
         if (clientIDs) {
           for (const cid of clientIDs) {
@@ -592,7 +592,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       if (desiredQueriesPatch.length) {
         lc.debug?.(`applying ${desiredQueriesPatch.length} query patches`);
         // cvr = ... For #syncQueryPipelineSet().
-        cvr = await this.updatePatchesForDesiredQueries(lc, cvr, updater => {
+        cvr = await this.#updatePatchesForDesiredQueries(lc, cvr, updater => {
           const patches: PatchToVersion[] = [];
           for (const patch of desiredQueriesPatch) {
             switch (patch.op) {

--- a/packages/zero-client/src/client/context.ts
+++ b/packages/zero-client/src/client/context.ts
@@ -15,6 +15,7 @@ import {ENTITIES_KEY_PREFIX, sourceNameFromKey} from './keys.ts';
 
 export type AddQuery = (
   ast: AST,
+  ttl: number | undefined,
   gotCallback?: GotCallback | undefined,
 ) => () => void;
 
@@ -49,8 +50,12 @@ export class ZeroContext implements QueryDelegate {
     return this.#mainSources.getSource(name);
   }
 
-  addServerQuery(ast: AST, gotCallback?: GotCallback | undefined) {
-    return this.#addQuery(ast, gotCallback);
+  addServerQuery(
+    ast: AST,
+    ttl: number | undefined,
+    gotCallback?: GotCallback | undefined,
+  ) {
+    return this.#addQuery(ast, ttl, gotCallback);
   }
 
   createStorage(): Storage {

--- a/packages/zero-client/src/client/zero-poke-handler.test.ts
+++ b/packages/zero-client/src/client/zero-poke-handler.test.ts
@@ -1245,6 +1245,7 @@ test('mergePokes with all optionals defined', () => {
                     table: 'issues',
                     orderBy: [['issue_id', 'asc']],
                   },
+                  ttl: 0,
                 },
               ],
             },
@@ -1256,6 +1257,7 @@ test('mergePokes with all optionals defined', () => {
                   table: 'issues',
                   orderBy: [['issue_id', 'asc']],
                 },
+                ttl: 0,
               },
             ],
             rowsPatch: [
@@ -1287,6 +1289,7 @@ test('mergePokes with all optionals defined', () => {
                     table: 'labels',
                     orderBy: [['label_id', 'asc']],
                   },
+                  ttl: 0,
                 },
               ],
             },
@@ -1298,6 +1301,7 @@ test('mergePokes with all optionals defined', () => {
                   table: 'labels',
                   orderBy: [['label_id', 'asc']],
                 },
+                ttl: 0,
               },
             ],
             rowsPatch: [
@@ -1450,6 +1454,7 @@ test('mergePokes sparse', () => {
                   table: 'issues',
                   orderBy: [['issue_id', 'asc']],
                 },
+                ttl: 0,
               },
             ],
             rowsPatch: [
@@ -1480,6 +1485,7 @@ test('mergePokes sparse', () => {
                     table: 'labels',
                     orderBy: [['label_id', 'asc']],
                   },
+                  ttl: 0,
                 },
               ],
             },

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -548,7 +548,7 @@ export class Zero<
 
     this.#zeroContext = new ZeroContext(
       this.#ivmSources.main,
-      (ast, gotCallback) => this.#queryManager.add(ast, gotCallback),
+      (ast, ttl, gotCallback) => this.#queryManager.add(ast, ttl, gotCallback),
       batchViewUpdates,
     );
 

--- a/packages/zero-protocol/src/connect.test.ts
+++ b/packages/zero-protocol/src/connect.test.ts
@@ -8,17 +8,22 @@ test('encode/decodeSecProtocols round-trip', () => {
       fc.record({
         initConnectionMessage: fc.tuple(
           fc.constant<'initConnection'>('initConnection'),
+
           fc.record(
             {
               desiredQueriesPatch: fc.array(
                 fc.oneof(
-                  fc.record({
-                    op: fc.constant<'put'>('put'),
-                    hash: fc.string(),
-                    ast: fc.constant({
-                      table: 'table',
-                    }),
-                  }),
+                  fc.record(
+                    {
+                      op: fc.constant<'put'>('put'),
+                      hash: fc.string(),
+                      ast: fc.constant({
+                        table: 'table',
+                      }),
+                      ttl: fc.double(),
+                    },
+                    {requiredKeys: ['op', 'hash', 'ast']},
+                  ),
                   fc.record({
                     op: fc.constant<'del'>('del'),
                     hash: fc.string(),

--- a/packages/zero-protocol/src/queries-patch.ts
+++ b/packages/zero-protocol/src/queries-patch.ts
@@ -1,10 +1,17 @@
 import * as v from '../../shared/src/valita.ts';
 import {astSchema} from './ast.ts';
 
-const putOpSchema = v.object({
+export const putOpSchema = v.object({
   op: v.literal('put'),
   hash: v.string(),
   ast: astSchema,
+  /**
+   * Time To Live. Over the wire this is a duration in ms. If this is left out
+   * there is no ttl. The time is not very exact and should be taken as a hint.
+   * The server will remove desired queries that are no longer alive, but it
+   * may take a little longer than the ttl.
+   */
+  ttl: v.number().optional(),
 });
 
 const delOpSchema = v.object({

--- a/packages/zero-protocol/src/row-patch.ts
+++ b/packages/zero-protocol/src/row-patch.ts
@@ -36,3 +36,5 @@ const rowPatchOpSchema = v.union(
 
 export const rowsPatchSchema = v.array(rowPatchOpSchema);
 export type RowPatchOp = v.Infer<typeof rowPatchOpSchema>;
+export type PutOp = v.Infer<typeof putOpSchema>;
+export type DelOp = v.Infer<typeof delOpSchema>;

--- a/packages/zero-react/src/use-query.test.ts
+++ b/packages/zero-react/src/use-query.test.ts
@@ -1,6 +1,6 @@
 import {beforeEach, describe, expect, test, vi} from 'vitest';
 import type {Schema} from '../../zero-schema/src/builder/schema-builder.ts';
-import type {AdvancedQuery} from '../../zql/src/query/query-internal.ts';
+import type {AdvancedQuery} from '../../zql/src/query/advanced-query.ts';
 import type {ResultType} from '../../zql/src/query/typed-view.ts';
 import {getAllViewsSizeForTesting, ViewStore} from './use-query.tsx';
 

--- a/packages/zero-schema/src/permissions.ts
+++ b/packages/zero-schema/src/permissions.ts
@@ -89,10 +89,9 @@ export async function definePermissions<TAuthDataShape, TSchema extends Schema>(
     ExpressionBuilder<Schema, string>
   >;
   for (const name of Object.keys(schema.tables)) {
-    expressionBuilders[name] = new StaticQuery(
-      schema,
-      name,
-    ).expressionBuilder();
+    expressionBuilders[name] = new StaticQuery(schema, name, {
+      table: name,
+    }).expressionBuilder();
   }
 
   const config = await definer();

--- a/packages/zero-solid/src/use-query.ts
+++ b/packages/zero-solid/src/use-query.ts
@@ -12,17 +12,26 @@ export type QueryResult<TReturn> = readonly [
   Accessor<QueryResultDetails>,
 ];
 
+export type UseQueryOptions = {
+  ttl?: number | undefined;
+};
+
 export function useQuery<
   TSchema extends Schema,
   TTable extends keyof TSchema['tables'] & string,
   TReturn,
->(querySignal: () => Query<TSchema, TTable, TReturn>): QueryResult<TReturn> {
+>(
+  querySignal: () => Query<TSchema, TTable, TReturn>,
+  options?: UseQueryOptions | Accessor<UseQueryOptions>,
+): QueryResult<TReturn> {
   // Wrap in in createMemo to ensure a new view is created if the querySignal changes.
   const view = createMemo(() => {
-    const query = querySignal();
-    const view = (query as AdvancedQuery<TSchema, TTable, TReturn>).materialize(
-      solidViewFactory,
-    );
+    const ttl = normalize(options)?.ttl;
+    let query = querySignal() as AdvancedQuery<TSchema, TTable, TReturn>;
+    if (ttl !== undefined) {
+      query = query.withTTL(ttl);
+    }
+    const view = query.materialize(solidViewFactory);
 
     onCleanup(() => {
       view.destroy();
@@ -31,4 +40,10 @@ export function useQuery<
   });
 
   return [() => view().data, () => view().resultDetails];
+}
+
+function normalize<T>(
+  options?: T | Accessor<T | undefined> | undefined,
+): T | undefined {
+  return typeof options === 'function' ? (options as Accessor<T>)() : options;
 }

--- a/packages/zql/src/query/advanced-query.ts
+++ b/packages/zql/src/query/advanced-query.ts
@@ -12,4 +12,5 @@ export interface AdvancedQuery<
   materialize<T>(factory: ViewFactory<TSchema, TTable, TReturn, T>): T;
   get format(): Format;
   hash(): string;
+  withTTL(ttl: number | undefined): AdvancedQuery<TSchema, TTable, TReturn>;
 }

--- a/packages/zql/src/query/query-impl.query.test.ts
+++ b/packages/zql/src/query/query-impl.query.test.ts
@@ -1,5 +1,7 @@
 import {describe, expect, test} from 'vitest';
+import type {LogConfig} from '../../../otel/src/log-options.ts';
 import {deepClone} from '../../../shared/src/deep-clone.ts';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
 import {must} from '../../../shared/src/must.ts';
 import {relationships} from '../../../zero-schema/src/builder/relationship-builder.ts';
 import {
@@ -8,12 +10,10 @@ import {
 } from '../../../zero-schema/src/builder/schema-builder.ts';
 import {number, table} from '../../../zero-schema/src/builder/table-builder.ts';
 import {createSource} from '../ivm/test/source-factory.ts';
+import type {AdvancedQuery} from './advanced-query.ts';
 import {newQuery, type QueryDelegate, QueryImpl} from './query-impl.ts';
-import type {AdvancedQuery} from './query-internal.ts';
 import {QueryDelegateImpl} from './test/query-delegate.ts';
 import {schema} from './test/test-schemas.ts';
-import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
-import type {LogConfig} from '../../../otel/src/log-options.ts';
 
 /**
  * Some basic manual tests to get us started.

--- a/packages/zql/src/query/query.test.ts
+++ b/packages/zql/src/query/query.test.ts
@@ -17,9 +17,9 @@ import {
   type Opaque,
   type TableSchema,
 } from '../../../zero-schema/src/table-schema.ts';
+import type {AdvancedQuery} from './advanced-query.ts';
 import type {ExpressionFactory} from './expression.ts';
 import {staticParam} from './query-impl.ts';
-import type {AdvancedQuery} from './query-internal.ts';
 import {type Query, type Row} from './query.ts';
 
 const mockQuery = {

--- a/packages/zql/src/query/static-query.ts
+++ b/packages/zql/src/query/static-query.ts
@@ -10,7 +10,9 @@ export function staticQuery<
   TSchema extends Schema,
   TTable extends keyof TSchema['tables'] & string,
 >(schema: TSchema, tableName: TTable): Query<TSchema, TTable> {
-  return new StaticQuery<TSchema, TTable>(schema, tableName);
+  return new StaticQuery<TSchema, TTable>(schema, tableName, {
+    table: tableName,
+  });
 }
 
 /**
@@ -22,15 +24,6 @@ export class StaticQuery<
   TTable extends keyof TSchema['tables'] & string,
   TReturn = PullRow<TTable, TSchema>,
 > extends AbstractQuery<TSchema, TTable, TReturn> {
-  constructor(
-    schema: TSchema,
-    tableName: TTable,
-    ast: AST = {table: tableName},
-    format?: Format | undefined,
-  ) {
-    super(schema, tableName, ast, format);
-  }
-
   expressionBuilder() {
     return new ExpressionBuilder(this._exists);
   }
@@ -45,9 +38,10 @@ export class StaticQuery<
     schema: TSchema,
     tableName: TTable,
     ast: AST,
+    ttl: number | undefined,
     format: Format | undefined,
-  ): Query<TSchema, TTable, TReturn> {
-    return new StaticQuery(schema, tableName, ast, format);
+  ): StaticQuery<TSchema, TTable, TReturn> {
+    return new StaticQuery(schema, tableName, ast, ttl, format);
   }
 
   get ast() {

--- a/packages/zql/src/query/test/query-delegate.ts
+++ b/packages/zql/src/query/test/query-delegate.ts
@@ -54,8 +54,13 @@ export class QueryDelegateImpl implements QueryDelegate {
       listener();
     }
   }
-  addServerQuery(ast: AST, gotCallback?: GotCallback | undefined): () => void {
+  addServerQuery(
+    ast: AST,
+    _ttl: number,
+    gotCallback?: GotCallback | undefined,
+  ): () => void {
     this.addedServerQueries.push(ast);
+
     this.gotCallbacks.push(gotCallback);
     if (this.synchronouslyCallNextGotCallback) {
       this.synchronouslyCallNextGotCallback = false;


### PR DESCRIPTION
- This adds a ttl option to useQuery. This then gets added to the `QueryImpl`.
- When set, it gets included in changeDesiredQueries messages.
- The `ttl`  and the `expiresAt`) are stored in the CVR.
