### PR TITLE
feat(z2s): auto generate a schema for testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5832,6 +5832,22 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@faker-js/faker": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.4.0.tgz",
+      "integrity": "sha512-85+k0AxaZSTowL0gXp8zYWDIrWclTbRPg/pm/V0dSFZ6W6D4lhcG3uuZl4zLsEKfEvs69xDbLN2cHQudwp95JA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
+      }
+    },
     "node_modules/@fastify/ajv-compiler": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-4.0.0.tgz",
@@ -27530,6 +27546,9 @@
         "@databases/escape-identifier": "^1.0.3",
         "@databases/sql": "^3.3.0",
         "vitest": "^2.1.5"
+      },
+      "devDependencies": {
+        "@faker-js/faker": "^9.4.0"
       }
     },
     "packages/zero": {
@@ -31058,6 +31077,12 @@
       "version": "8.51.0",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.51.0.tgz",
       "integrity": "sha512-HxjQ8Qn+4SI3/AFv6sOrDB+g6PpUTDwSJiQqOrnneEk8L71161srI9gjzzZvYVbzHiVg/BvcH95+cK/zfIt4pg=="
+    },
+    "@faker-js/faker": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.4.0.tgz",
+      "integrity": "sha512-85+k0AxaZSTowL0gXp8zYWDIrWclTbRPg/pm/V0dSFZ6W6D4lhcG3uuZl4zLsEKfEvs69xDbLN2cHQudwp95JA==",
+      "dev": true
     },
     "@fastify/ajv-compiler": {
       "version": "4.0.0",
@@ -45603,6 +45628,7 @@
       "requires": {
         "@databases/escape-identifier": "^1.0.3",
         "@databases/sql": "^3.3.0",
+        "@faker-js/faker": "^9.4.0",
         "vitest": "^2.1.5"
       }
     },

--- a/packages/z2s/package.json
+++ b/packages/z2s/package.json
@@ -21,5 +21,8 @@
     "@databases/escape-identifier": "^1.0.3",
     "@databases/sql": "^3.3.0",
     "vitest": "^2.1.5"
+  },
+  "devDependencies": {
+    "@faker-js/faker": "^9.4.0"
   }
 }

--- a/packages/z2s/src/test/query-gen.ts
+++ b/packages/z2s/src/test/query-gen.ts
@@ -1,3 +1,0 @@
-/**
- * Given a schema, generate a random zql query using the query builder interface.
- */

--- a/packages/z2s/src/test/query-gen.ts
+++ b/packages/z2s/src/test/query-gen.ts
@@ -1,0 +1,3 @@
+/**
+ * Given a schema, generate a random zql query using the query builder interface.
+ */

--- a/packages/z2s/src/test/schema-gen.test.ts
+++ b/packages/z2s/src/test/schema-gen.test.ts
@@ -1,0 +1,289 @@
+import {expect, test} from 'vitest';
+import {generateSchema} from './schema-gen.ts';
+import {en, Faker, generateMersenne53Randomizer} from '@faker-js/faker';
+
+test('stable generation', () => {
+  const rng = generateMersenne53Randomizer(400);
+  expect(
+    generateSchema(
+      () => rng.next(),
+      new Faker({
+        locale: en,
+        randomizer: rng,
+      }),
+    ),
+  ).toMatchInlineSnapshot(`
+    {
+      "relationships": {
+        "adrenalin": {
+          "decongestant": [
+            {
+              "cardinality": "many",
+              "destField": [
+                "community",
+              ],
+              "destSchema": "decongestant",
+              "sourceField": [
+                "dime",
+              ],
+            },
+          ],
+        },
+        "chops": {},
+        "decongestant": {
+          "adrenalin": [
+            {
+              "cardinality": "many",
+              "destField": [
+                "dime",
+              ],
+              "destSchema": "adrenalin",
+              "sourceField": [
+                "community",
+              ],
+            },
+          ],
+        },
+        "elevator": {},
+        "habit": {},
+        "sanity": {
+          "sanity": [
+            {
+              "cardinality": "one",
+              "destField": [
+                "impostor",
+              ],
+              "destSchema": "sanity",
+              "sourceField": [
+                "impostor",
+              ],
+            },
+          ],
+        },
+        "stranger": {
+          "decongestant": [
+            {
+              "cardinality": "many",
+              "destField": [
+                "traffic",
+              ],
+              "destSchema": "decongestant",
+              "sourceField": [
+                "nougat",
+              ],
+            },
+          ],
+          "habit": [
+            {
+              "cardinality": "one",
+              "destField": [
+                "derby",
+              ],
+              "destSchema": "habit",
+              "sourceField": [
+                "marathon",
+              ],
+            },
+          ],
+        },
+      },
+      "tables": {
+        "adrenalin": {
+          "columns": {
+            "dime": {
+              "optional": true,
+              "type": "string",
+            },
+          },
+          "name": "adrenalin",
+          "primaryKey": [
+            "dime",
+          ],
+        },
+        "chops": {
+          "columns": {
+            "gloom": {
+              "optional": true,
+              "type": "string",
+            },
+            "newsprint": {
+              "optional": true,
+              "type": "string",
+            },
+          },
+          "name": "chops",
+          "primaryKey": [
+            "gloom",
+            "newsprint",
+          ],
+        },
+        "decongestant": {
+          "columns": {
+            "amnesty": {
+              "optional": false,
+              "type": "number",
+            },
+            "circumference": {
+              "optional": true,
+              "type": "json",
+            },
+            "community": {
+              "optional": false,
+              "type": "string",
+            },
+            "ghost": {
+              "optional": true,
+              "type": "number",
+            },
+            "language": {
+              "optional": false,
+              "type": "number",
+            },
+            "lyre": {
+              "optional": false,
+              "type": "string",
+            },
+            "pacemaker": {
+              "optional": false,
+              "type": "boolean",
+            },
+            "status": {
+              "optional": false,
+              "type": "string",
+            },
+            "traffic": {
+              "optional": true,
+              "type": "string",
+            },
+          },
+          "name": "decongestant",
+          "primaryKey": [
+            "lyre",
+          ],
+        },
+        "elevator": {
+          "columns": {
+            "bookcase": {
+              "optional": true,
+              "type": "number",
+            },
+            "phrase": {
+              "optional": false,
+              "type": "boolean",
+            },
+            "pliers": {
+              "optional": false,
+              "type": "string",
+            },
+            "switchboard": {
+              "optional": false,
+              "type": "string",
+            },
+            "widow": {
+              "optional": true,
+              "type": "number",
+            },
+          },
+          "name": "elevator",
+          "primaryKey": [
+            "pliers",
+            "widow",
+          ],
+        },
+        "habit": {
+          "columns": {
+            "adrenalin": {
+              "optional": true,
+              "type": "string",
+            },
+            "derby": {
+              "optional": false,
+              "type": "number",
+            },
+            "independence": {
+              "optional": false,
+              "type": "string",
+            },
+            "lashes": {
+              "optional": true,
+              "type": "boolean",
+            },
+            "reporter": {
+              "optional": false,
+              "type": "boolean",
+            },
+            "resource": {
+              "optional": true,
+              "type": "boolean",
+            },
+            "sandbar": {
+              "optional": true,
+              "type": "string",
+            },
+          },
+          "name": "habit",
+          "primaryKey": [
+            "adrenalin",
+          ],
+        },
+        "sanity": {
+          "columns": {
+            "impostor": {
+              "optional": false,
+              "type": "number",
+            },
+          },
+          "name": "sanity",
+          "primaryKey": [
+            "impostor",
+          ],
+        },
+        "stranger": {
+          "columns": {
+            "footrest": {
+              "optional": true,
+              "type": "json",
+            },
+            "granny": {
+              "optional": false,
+              "type": "string",
+            },
+            "marathon": {
+              "optional": false,
+              "type": "number",
+            },
+            "nougat": {
+              "optional": true,
+              "type": "string",
+            },
+            "pile": {
+              "optional": false,
+              "type": "boolean",
+            },
+            "rawhide": {
+              "optional": false,
+              "type": "string",
+            },
+            "ruin": {
+              "optional": true,
+              "type": "number",
+            },
+            "tuber": {
+              "optional": true,
+              "type": "number",
+            },
+            "valuable": {
+              "optional": false,
+              "type": "number",
+            },
+          },
+          "name": "stranger",
+          "primaryKey": [
+            "ruin",
+          ],
+        },
+      },
+      "version": 1,
+    }
+  `);
+});

--- a/packages/z2s/src/test/schema-gen.ts
+++ b/packages/z2s/src/test/schema-gen.ts
@@ -1,0 +1,151 @@
+import type {Faker} from '@faker-js/faker';
+import type {Schema} from '../../../zero-schema/src/builder/schema-builder.ts';
+import type {
+  RelationshipsSchema,
+  SchemaValue,
+  TableSchema,
+} from '../../../zero-schema/src/table-schema.ts';
+import type {Relationship} from '../../../zero-schema/src/table-schema.ts';
+
+const dbTypes = {
+  string: ['text', 'varchar', 'char'],
+  number: ['int', 'bigint', 'decimal'],
+  boolean: ['bool'],
+  json: ['jsonb', 'json'],
+} as const;
+
+type Rng = () => number;
+
+export function generateSchema(rng: Rng, faker: Faker): Schema {
+  const tables = generateUniqueValues(
+    faker.word.noun,
+    Math.floor(rng() * 10) + 1,
+  ).map(name => generateTable(name, rng, faker));
+  const relationships = generateRelationships(rng, tables);
+
+  return {
+    version: 1,
+    tables: Object.fromEntries(tables.map(table => [table.name, table])),
+    relationships,
+  };
+}
+
+function generateTable(name: string, rng: Rng, faker: Faker): TableSchema {
+  const columns = generateUniqueValues(
+    faker.word.noun,
+    Math.floor(rng() * 10) + 1,
+  ).map(name => generateColumn(name, rng));
+  const numPkColumns = Math.min(rng() < 0.5 ? 1 : 2, columns.length);
+
+  return {
+    name,
+    columns: Object.fromEntries(columns),
+    primaryKey:
+      numPkColumns === 1 ? [columns[0][0]] : [columns[0][0], columns[1][0]],
+  };
+}
+
+function generateRelationships(
+  rng: Rng,
+  tables: TableSchema[],
+): {
+  [table: string]: RelationshipsSchema;
+} {
+  const relationships: {[table: string]: RelationshipsSchema} = {};
+  for (const table of tables) {
+    relationships[table.name] = generateRelationshipsForTable(
+      rng,
+      table,
+      tables,
+    );
+  }
+  return relationships;
+}
+
+function generateRelationshipsForTable(
+  rng: Rng,
+  table: TableSchema,
+  tables: TableSchema[],
+): RelationshipsSchema {
+  const numRelationships = Math.floor(rng() * 3);
+  if (numRelationships === 0) {
+    return {};
+  }
+
+  const shuffledTables = shuffle(rng, tables);
+
+  const relationships: Record<string, Relationship> = {};
+  for (let i = 0; i < numRelationships; i++) {
+    const destTable = shuffledTables[i];
+    const sourceField = selectRandom(rng, Object.keys(table.columns));
+    if (table.columns[sourceField].type === 'json') {
+      continue;
+    }
+
+    const destTargets = Object.entries(destTable.columns).filter(
+      ([_, column]) => column.type === table.columns[sourceField].type,
+    );
+    if (destTargets.length === 0) {
+      continue;
+    }
+
+    const destField = selectRandom(rng, destTargets);
+    const cardinality =
+      destField[1].optional || destField[1].type === 'boolean'
+        ? 'many'
+        : selectRandom(rng, ['one', 'many'] as const);
+
+    relationships[destTable.name] = [
+      {
+        sourceField: [sourceField],
+        destField: [destField[0]],
+        destSchema: destTable.name,
+        cardinality,
+      },
+    ];
+  }
+
+  return relationships;
+}
+
+function shuffle<T>(rng: Rng, array: T[]): T[] {
+  const shuffled = [...array];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  return shuffled;
+}
+
+function generateColumn(name: string, rng: Rng): [string, SchemaValue] {
+  return [
+    name,
+    {
+      type: selectRandom(rng, [
+        'string',
+        'string',
+        'string',
+        'string',
+        'string',
+        'boolean',
+        'number',
+        'number',
+        'number',
+        'json',
+      ]) as keyof typeof dbTypes,
+      optional: rng() < 0.5,
+    },
+  ];
+}
+
+function selectRandom<T>(rng: Rng, values: T[]): T {
+  return values[Math.floor(rng() * values.length)];
+}
+
+function generateUniqueValues<T>(generator: () => T, length: number): T[] {
+  const values = new Set<T>();
+  while (values.size < length) {
+    values.add(generator());
+  }
+  return Array.from(values);
+}

--- a/packages/zero-cache/src/auth/write-authorizer.ts
+++ b/packages/zero-cache/src/auth/write-authorizer.ts
@@ -30,7 +30,7 @@ import {
   bindStaticParameters,
   buildPipeline,
 } from '../../../zql/src/builder/builder.ts';
-import {AuthQuery, authQuery} from '../../../zql/src/query/auth-query.ts';
+import {StaticQuery, staticQuery} from '../../../zql/src/query/static-query.ts';
 import {dnf} from '../../../zql/src/query/dnf.ts';
 import type {Query} from '../../../zql/src/query/query.ts';
 import {Database} from '../../../zqlite/src/db.ts';
@@ -294,7 +294,7 @@ export class WriteAuthorizerImpl implements WriteAuthorizer {
     }
 
     const rowPolicies = rules.row;
-    let rowQuery = authQuery(this.#schema, op.tableName);
+    let rowQuery = staticQuery(this.#schema, op.tableName);
     op.primaryKey.forEach(pk => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       rowQuery = rowQuery.where(pk, '=', op.value[pk] as any);
@@ -447,7 +447,7 @@ export class WriteAuthorizerImpl implements WriteAuthorizer {
     if (policy.length === 0) {
       return false;
     }
-    let rowQueryAst = (rowQuery as AuthQuery<Schema, string>).ast;
+    let rowQueryAst = (rowQuery as StaticQuery<Schema, string>).ast;
     rowQueryAst = bindStaticParameters(
       {
         ...rowQueryAst,

--- a/packages/zero-schema/src/mod.ts
+++ b/packages/zero-schema/src/mod.ts
@@ -1,4 +1,4 @@
-export {authQuery} from '../../zql/src/query/auth-query.ts';
+export {staticQuery} from '../../zql/src/query/static-query.ts';
 export {createSchema, type Schema} from './builder/schema-builder.ts';
 export {definePermissions} from './permissions.ts';
 export {type TableSchema} from './table-schema.ts';

--- a/packages/zero-schema/src/permissions.ts
+++ b/packages/zero-schema/src/permissions.ts
@@ -5,7 +5,7 @@ import {
   type Condition,
   type Parameter,
 } from '../../zero-protocol/src/ast.ts';
-import {AuthQuery} from '../../zql/src/query/auth-query.ts';
+import {StaticQuery} from '../../zql/src/query/static-query.ts';
 import type {ExpressionBuilder} from '../../zql/src/query/expression.ts';
 import {staticParam} from '../../zql/src/query/query-impl.ts';
 import type {Query} from '../../zql/src/query/query.ts';
@@ -75,7 +75,10 @@ export async function definePermissions<TAuthDataShape, TSchema extends Schema>(
     ExpressionBuilder<Schema, string>
   >;
   for (const name of Object.keys(schema.tables)) {
-    expressionBuilders[name] = new AuthQuery(schema, name).expressionBuilder();
+    expressionBuilders[name] = new StaticQuery(
+      schema,
+      name,
+    ).expressionBuilder();
   }
 
   const config = await definer();

--- a/packages/zql/src/query/static-query.ts
+++ b/packages/zql/src/query/static-query.ts
@@ -6,14 +6,18 @@ import {AbstractQuery} from './query-impl.ts';
 import type {HumanReadable, PullRow, Query} from './query.ts';
 import type {TypedView} from './typed-view.ts';
 
-export function authQuery<
+export function staticQuery<
   TSchema extends Schema,
   TTable extends keyof TSchema['tables'] & string,
 >(schema: TSchema, tableName: TTable): Query<TSchema, TTable> {
-  return new AuthQuery<TSchema, TTable>(schema, tableName);
+  return new StaticQuery<TSchema, TTable>(schema, tableName);
 }
 
-export class AuthQuery<
+/**
+ * A query that cannot be run.
+ * Only serves to generate ASTs.
+ */
+export class StaticQuery<
   TSchema extends Schema,
   TTable extends keyof TSchema['tables'] & string,
   TReturn = PullRow<TTable, TSchema>,
@@ -43,7 +47,7 @@ export class AuthQuery<
     ast: AST,
     format: Format | undefined,
   ): Query<TSchema, TTable, TReturn> {
-    return new AuthQuery(schema, tableName, ast, format);
+    return new StaticQuery(schema, tableName, ast, format);
   }
 
   get ast() {


### PR DESCRIPTION
Starting on the `@rocicorp/zero/pg` SDK for custom mutators and I'd like more confidence in our ZQL vs SQL execution.

Adding a way to randomly build queries in order to fuzz our ZQL and ZQL->SQL implementations.