### PR TITLE
chore(tests): fix flaky tests

### DIFF
--- a/packages/shared/src/tool/vitest-config.ts
+++ b/packages/shared/src/tool/vitest-config.ts
@@ -61,6 +61,9 @@ export default {
       name: 'chromium',
       screenshotFailures: false,
     },
+    deps: {
+      inline: true, // Bundle dependencies inline
+    },
     typecheck: {
       enabled: false,
     },


### PR DESCRIPTION
My tests often fail with `TypeError: Failed to fetch dynamically imported module:` when running in CI.

Try to fix by inlining deps.