### PR TITLE
feat(zero-protocol): client-side of revised-cookie poke protocol

### DIFF
--- a/packages/zero-client/src/client/zero-poke-handler.test.ts
+++ b/packages/zero-client/src/client/zero-poke-handler.test.ts
@@ -1311,6 +1311,9 @@ test('mergePokes with all optionals defined', () => {
             ],
           },
         ],
+        pokeEnd: {
+          pokeID: 'poke1',
+        },
       },
       {
         pokeStart: {
@@ -1346,6 +1349,9 @@ test('mergePokes with all optionals defined', () => {
             ],
           },
         ],
+        pokeEnd: {
+          pokeID: 'poke2',
+        },
       },
     ],
     schema,
@@ -1505,6 +1511,9 @@ test('mergePokes sparse', () => {
             },
           },
         ],
+        pokeEnd: {
+          pokeID: 'poke1',
+        },
       },
       {
         pokeStart: {
@@ -1533,6 +1542,9 @@ test('mergePokes sparse', () => {
             ],
           },
         ],
+        pokeEnd: {
+          pokeID: 'poke2',
+        },
       },
     ],
     schema,
@@ -1601,6 +1613,64 @@ test('mergePokes sparse', () => {
   });
 });
 
+test('mergePokes with cookie revisions', () => {
+  expect(
+    mergePokes(
+      [
+        {
+          pokeStart: {
+            pokeID: 'poke1',
+            baseCookie: '3',
+            cookie: '5',
+            schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
+          },
+          parts: [
+            {
+              pokeID: 'poke1',
+              lastMutationIDChanges: {c1: 1, c2: 2},
+            },
+          ],
+          pokeEnd: {
+            pokeID: 'poke1',
+            cookie: '3', // Never mind, back to 3
+          },
+        },
+        {
+          pokeStart: {
+            pokeID: 'poke2',
+            baseCookie: '3',
+            cookie: '7',
+            schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
+          },
+          parts: [
+            {
+              pokeID: 'poke2',
+              lastMutationIDChanges: {c4: 3},
+            },
+          ],
+          pokeEnd: {
+            pokeID: 'poke2',
+            cookie: '6', // Not 7, but 6.
+          },
+        },
+      ],
+      schema,
+      serverToClient(schema.tables),
+    ),
+  ).toEqual({
+    baseCookie: '3',
+    pullResponse: {
+      cookie: '6',
+      lastMutationIDChanges: {
+        c1: 1,
+        c2: 2,
+        c4: 3,
+      },
+      patch: [],
+    },
+  });
+});
+
 test('mergePokes throws error on cookie gaps', () => {
   expect(() => {
     mergePokes(
@@ -1618,6 +1688,9 @@ test('mergePokes throws error on cookie gaps', () => {
               lastMutationIDChanges: {c1: 1, c2: 2},
             },
           ],
+          pokeEnd: {
+            pokeID: 'poke1',
+          },
         },
         {
           pokeStart: {
@@ -1632,6 +1705,9 @@ test('mergePokes throws error on cookie gaps', () => {
               lastMutationIDChanges: {c4: 3},
             },
           ],
+          pokeEnd: {
+            pokeID: 'poke2',
+          },
         },
       ],
       schema,

--- a/packages/zero-client/src/client/zero-poke-handler.ts
+++ b/packages/zero-client/src/client/zero-poke-handler.ts
@@ -32,6 +32,7 @@ import {
 type PokeAccumulator = {
   readonly pokeStart: PokeStartBody;
   readonly parts: PokePartBody[];
+  readonly pokeEnd: PokeEndBody;
 };
 
 /**
@@ -48,7 +49,7 @@ export class PokeHandler {
   readonly #onPokeError: () => void;
   readonly #clientID: ClientID;
   readonly #lc: LogContext;
-  #receivingPoke: PokeAccumulator | undefined = undefined;
+  #receivingPoke: Omit<PokeAccumulator, 'pokeEnd'> | undefined = undefined;
   readonly #pokeBuffer: PokeAccumulator[] = [];
   #pokePlaybackLoopRunning = false;
   #lastRafPerfTimestamp = 0;
@@ -117,7 +118,7 @@ export class PokeHandler {
       this.#receivingPoke = undefined;
       return;
     }
-    this.#pokeBuffer.push(this.#receivingPoke);
+    this.#pokeBuffer.push({...this.#receivingPoke, pokeEnd});
     this.#receivingPoke = undefined;
     if (!this.#pokePlaybackLoopRunning) {
       this.#startPlaybackLoop();
@@ -207,7 +208,8 @@ export function mergePokes(
     return undefined;
   }
   const {baseCookie} = pokeBuffer[0].pokeStart;
-  const {cookie} = pokeBuffer[pokeBuffer.length - 1].pokeStart;
+  const lastPoke = pokeBuffer[pokeBuffer.length - 1];
+  const cookie = lastPoke.pokeEnd.cookie ?? lastPoke.pokeStart.cookie;
   const mergedPatch: PatchOperationInternal[] = [];
   const mergedLastMutationIDChanges: Record<string, number> = {};
 

--- a/packages/zero-protocol/src/ast.test.ts
+++ b/packages/zero-protocol/src/ast.test.ts
@@ -607,5 +607,5 @@ test('protocol version', () => {
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
   expect(hash).toEqual('2zzy9s2lcdcms');
-  expect(PROTOCOL_VERSION).toEqual(4);
+  expect(PROTOCOL_VERSION).toEqual(5);
 });

--- a/packages/zero-protocol/src/poke.ts
+++ b/packages/zero-protocol/src/poke.ts
@@ -67,6 +67,10 @@ export const pokePartBodySchema = v.object({
 
 export const pokeEndBodySchema = v.object({
   pokeID: v.string(),
+  // If present, this should be the cookie stored with the client,
+  // instead of the cookie presented in pokeStart.
+  // TODO: Consider making this required and removing it from pokeStart.
+  cookie: versionSchema.optional(),
   // If `true`, the poke with id `pokeID` should be discarded without
   // applying it.
   cancel: v.boolean().optional(),

--- a/packages/zero-protocol/src/protocol-version.ts
+++ b/packages/zero-protocol/src/protocol-version.ts
@@ -12,7 +12,7 @@ import {assert} from '../../shared/src/asserts.ts';
  * release. The server (`zero-cache`) must be deployed before clients start
  * running the new code.
  */
-export const PROTOCOL_VERSION = 4;
+export const PROTOCOL_VERSION = 5;
 
 /**
  * The minimum protocol version supported by the server. The contract for
@@ -23,6 +23,7 @@ export const PROTOCOL_VERSION = 4;
  * from protocol versions before `MIN_SERVER_SUPPORTED_PROTOCOL_VERSION` are
  * closed with a `VersionNotSupported` error.
  */
+// TODO: Bump to 5 before returning responses with pokeEnd.cookie.
 export const MIN_SERVER_SUPPORTED_PROTOCOL_VERSION = 2;
 
 assert(MIN_SERVER_SUPPORTED_PROTOCOL_VERSION < PROTOCOL_VERSION);


### PR DESCRIPTION
Adds an optional `cookie` field to `pokeEnd` which overrides the value that was specified in `pokeStart`.

(In the future, we should considering moving the field to only be in `pokeEnd`.)

The motivation for this change is to allow the `view-syncer` to avoid CVR updates for IVM pushes that don't change the CVR (thereby avoiding the quadratic writes to the CVR db). 

When this happens, the associated pokes can either be:
1. cancelled if nothing was sent, or
2. completed (e.g. if catchup rows were sent) with a revised cookie reflecting what is stored in the CVR