### PR TITLE
feat(zero-cache): eliminate quadratic CVR writes

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr-store.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.pg-test.ts
@@ -387,7 +387,7 @@ describe('view-syncer/cvr-store', () => {
       );
     }
     await updater.received(lc, rows);
-    cvr = (await updater.flush(lc, CONNECT_TIME, now)).cvr;
+    cvr = (await updater.flush(lc, true, CONNECT_TIME, now)).cvr;
 
     expect(await db`SELECT * FROM cvr_sdf.instances`).toMatchInlineSnapshot(`
       Result [
@@ -438,7 +438,7 @@ describe('view-syncer/cvr-store', () => {
       );
     }
     await updater.received(lc, rows);
-    await updater.flush(lc, CONNECT_TIME, now);
+    await updater.flush(lc, true, CONNECT_TIME, now);
 
     expect(await db`SELECT * FROM cvr_sdf.instances`).toMatchInlineSnapshot(`
       Result [
@@ -514,7 +514,7 @@ describe('view-syncer/cvr-store', () => {
         );
       }
       await updater.received(lc, rows);
-      cvr = (await updater.flush(lc, CONNECT_TIME, now)).cvr;
+      cvr = (await updater.flush(lc, true, CONNECT_TIME, now)).cvr;
 
       // add a random sleep for varying the asynchronicity
       // between the CVR flush and the async row flush.
@@ -583,7 +583,7 @@ describe('view-syncer/cvr-store', () => {
         );
       }
       await updater.received(lc, rows);
-      cvr = (await updater.flush(lc, CONNECT_TIME, now)).cvr;
+      cvr = (await updater.flush(lc, true, CONNECT_TIME, now)).cvr;
 
       // add a random sleep for varying the asynchronicity
       // between the CVR flush and the async row flush.
@@ -604,7 +604,7 @@ describe('view-syncer/cvr-store', () => {
     // Empty rows.
     const rows = new CustomKeyMap<RowID, RowUpdate>(rowIDString);
     await updater.received(lc, rows);
-    await updater.flush(lc, CONNECT_TIME, now);
+    await updater.flush(lc, true, CONNECT_TIME, now);
 
     expect(await db`SELECT * FROM cvr_sdf.instances`).toMatchInlineSnapshot(`
       Result [
@@ -663,7 +663,7 @@ describe('view-syncer/cvr-store', () => {
       );
     }
     await updater.received(lc, rows);
-    cvr = (await updater.flush(lc, CONNECT_TIME, now)).cvr;
+    cvr = (await updater.flush(lc, true, CONNECT_TIME, now)).cvr;
 
     expect(await db`SELECT * FROM cvr_sdf.instances`).toMatchInlineSnapshot(`
     Result [

--- a/packages/zero-cache/src/services/view-syncer/cvr-store.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.ts
@@ -709,12 +709,10 @@ export class CVRStore {
   #setLastActive(lastActive: number) {
     this.#writes.add({
       stats: {instances: 1},
-      write: tx => {
-        return tx`
+      write: tx => tx`
         UPDATE ${this.#cvr('instances')} SET ${tx({lastActive})}
           WHERE "clientGroupID" = ${this.#id}
-        `;
-      },
+        `,
     });
   }
 
@@ -1002,7 +1000,7 @@ export class CVRStore {
     }
     if (
       skipNoopFlushes &&
-      this.#pendingRowRecordUpdates.size == 0 &&
+      this.#pendingRowRecordUpdates.size === 0 &&
       this.#writes.size === 0
     ) {
       return null;

--- a/packages/zero-cache/src/services/view-syncer/cvr-store.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.ts
@@ -706,6 +706,18 @@ export class CVRStore {
     });
   }
 
+  #setLastActive(lastActive: number) {
+    this.#writes.add({
+      stats: {instances: 1},
+      write: tx => {
+        return tx`
+        UPDATE ${this.#cvr('instances')} SET ${tx({lastActive})}
+          WHERE "clientGroupID" = ${this.#id}
+        `;
+      },
+    });
+  }
+
   markQueryAsDeleted(version: CVRVersion, queryPatch: QueryPatch): void {
     this.#writes.add({
       stats: {queries: 1},
@@ -955,8 +967,10 @@ export class CVRStore {
   async #flush(
     expectedCurrentVersion: CVRVersion,
     newVersion: CVRVersion,
+    skipNoopFlushes: boolean,
     lastConnectTime: number,
-  ): Promise<CVRFlushStats> {
+    lastActive: number,
+  ): Promise<CVRFlushStats | null> {
     const stats: CVRFlushStats = {
       instances: 0,
       queries: 0,
@@ -986,6 +1000,15 @@ export class CVRStore {
         }
       }
     }
+    if (
+      skipNoopFlushes &&
+      this.#pendingRowRecordUpdates.size == 0 &&
+      this.#writes.size === 0
+    ) {
+      return null;
+    }
+    this.#setLastActive(lastActive);
+
     const rowsFlushed = await this.#db.begin(async tx => {
       const pipelined: Promise<unknown>[] = [
         // #checkVersionAndOwnership() executes a `SELECT ... FOR UPDATE`
@@ -1044,13 +1067,17 @@ export class CVRStore {
   async flush(
     expectedCurrentVersion: CVRVersion,
     newVersion: CVRVersion,
+    skipNoopFlushes: boolean,
     lastConnectTime: number,
-  ): Promise<CVRFlushStats> {
+    lastActive: number,
+  ): Promise<CVRFlushStats | null> {
     try {
       return await this.#flush(
         expectedCurrentVersion,
         newVersion,
+        skipNoopFlushes,
         lastConnectTime,
+        lastActive,
       );
     } catch (e) {
       // Clear cached state if an error (e.g. ConcurrentModificationException) is encountered.

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -135,15 +135,15 @@ export class CVRUpdater {
       lastActive,
     );
 
-    if (flushed) {
-      lc.debug?.(
-        `flushed cvr@${versionString(this._cvr.version)} ` +
-          `${JSON.stringify(flushed)} in (${Date.now() - start} ms)`,
-      );
-      this._cvr.lastActive = lastActive;
-      return {cvr: this._cvr, flushed};
+    if (!flushed) {
+      return {cvr: this._orig, flushed: false};
     }
-    return {cvr: this._orig, flushed: false};
+    lc.debug?.(
+      `flushed cvr@${versionString(this._cvr.version)} ` +
+        `${JSON.stringify(flushed)} in (${Date.now() - start} ms)`,
+    );
+    this._cvr.lastActive = lastActive;
+    return {cvr: this._cvr, flushed};
   }
 }
 

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -116,37 +116,34 @@ export class CVRUpdater {
     return this._cvr.version;
   }
 
-  #setLastActive(now = Date.now()) {
-    this._cvr.lastActive = now;
-    this._cvrStore.putInstance(this._cvr);
-  }
-
   async flush(
     lc: LogContext,
+    skipNoopFlushes: boolean,
     lastConnectTime: number,
     lastActive = Date.now(),
   ): Promise<{
     cvr: CVRSnapshot;
-    stats: CVRFlushStats;
+    flushed: CVRFlushStats | false;
   }> {
     const start = Date.now();
 
-    this.#setLastActive(lastActive);
-    const stats = await this._cvrStore.flush(
+    const flushed = await this._cvrStore.flush(
       this._orig.version,
       this._cvr.version,
+      skipNoopFlushes,
       lastConnectTime,
+      lastActive,
     );
 
-    lc.debug?.(
-      `flushed cvr@${versionString(this._cvr.version)} ${JSON.stringify(
-        stats,
-      )} in (${Date.now() - start} ms)`,
-    );
-    return {
-      cvr: this._cvr,
-      stats,
-    };
+    if (flushed) {
+      lc.debug?.(
+        `flushed cvr@${versionString(this._cvr.version)} ` +
+          `${JSON.stringify(flushed)} in (${Date.now() - start} ms)`,
+      );
+      this._cvr.lastActive = lastActive;
+      return {cvr: this._cvr, flushed};
+    }
+    return {cvr: this._orig, flushed: false};
   }
 }
 
@@ -284,9 +281,14 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
     ];
   }
 
-  flush(lc: LogContext, lastConnectTime: number, lastActive = Date.now()) {
+  flush(
+    lc: LogContext,
+    skipNoopFlushes: boolean,
+    lastConnectTime: number,
+    lastActive = Date.now(),
+  ) {
     // TODO: Add cleanup of no-longer-desired got queries and constituent rows.
-    return super.flush(lc, lastConnectTime, lastActive);
+    return super.flush(lc, skipNoopFlushes, lastConnectTime, lastActive);
   }
 }
 

--- a/packages/zero-cache/src/workers/connection.ts
+++ b/packages/zero-cache/src/workers/connection.ts
@@ -78,7 +78,14 @@ export class Connection {
     this.#wsID = wsID;
     this.#protocolVersion = protocolVersion;
     this.#clientGroupID = clientGroupID;
-    this.#syncContext = {clientID, wsID, baseCookie, schemaVersion, tokenData};
+    this.#syncContext = {
+      clientID,
+      wsID,
+      baseCookie,
+      protocolVersion,
+      schemaVersion,
+      tokenData,
+    };
     this.#lc = lc
       .withContext('connection')
       .withContext('clientID', clientID)


### PR DESCRIPTION
System scalability improvement which eliminates CVR db updates and pokes for replica changes that do not affect the client group. 

This mitigates the quadratic nature of replication processing by pruning processing branches before writing to the CVR postgres DB and downstream clients, limiting the blast radius to IVM push processing. 

* The CVR pruning avoids a flush if there are no pending writes. Note that this means that we will update the `lastActive` field of a CVR less often, but that only affects garbage collection.
* The poke pruning involves buffering the initial `pokeStart` until a subsequent message is sent, and avoiding sending anything at all if the `finalVersion` passed to `pokeEnd` is equal to the client's `baseCookie`

Note that both features rely on the client correctly understanding the revised poke protocol in #3735, and thus the features are only enabled if all of the connected clients are up to `PROTOCOL_VERSION = 5`. If older clients are connected, the pruning does not happen and the previous behavior is invoked. 

In a few releases we can decommission the old versions and make the pruning behavior unconditional.