### PR TITLE
feat(z2s): fix `one`, start handling `hidden`

### DIFF
--- a/packages/z2s/src/compiler.output.test.ts
+++ b/packages/z2s/src/compiler.output.test.ts
@@ -5,6 +5,7 @@ import {
   distinctFrom,
   limit,
   orderBy,
+  pullTablesForJunction,
   simple,
   valuePosition,
 } from './compiler.ts';
@@ -485,4 +486,31 @@ test('simple', () => {
       ],
     }
   `);
+});
+
+test('pull tables for junction', () => {
+  expect(
+    pullTablesForJunction({
+      correlation: {
+        parentField: ['id'],
+        childField: ['issue_id'],
+      },
+      subquery: {
+        table: 'issue_label',
+        alias: 'labels',
+        related: [
+          {
+            correlation: {
+              parentField: ['label_id'],
+              childField: ['id'],
+            },
+            subquery: {
+              table: 'label',
+              alias: 'labels',
+            },
+          },
+        ],
+      },
+    }),
+  ).toEqual(['issue_label', 'label']);
 });

--- a/packages/z2s/src/compiler.output.test.ts
+++ b/packages/z2s/src/compiler.output.test.ts
@@ -4,6 +4,7 @@ import {
   correlate,
   distinctFrom,
   limit,
+  makeJunctionJoin,
   orderBy,
   pullTablesForJunction,
   simple,
@@ -512,5 +513,64 @@ test('pull tables for junction', () => {
         ],
       },
     }),
-  ).toEqual(['issue_label', 'label']);
+  ).toMatchInlineSnapshot(`
+    [
+      [
+        "issue_label",
+        {
+          "childField": [
+            "issue_id",
+          ],
+          "parentField": [
+            "id",
+          ],
+        },
+      ],
+      [
+        "label",
+        {
+          "childField": [
+            "id",
+          ],
+          "parentField": [
+            "label_id",
+          ],
+        },
+      ],
+    ]
+  `);
+});
+
+test('make junction join', () => {
+  expect(
+    formatPg(
+      makeJunctionJoin({
+        correlation: {
+          parentField: ['id'],
+          childField: ['issue_id'],
+        },
+        subquery: {
+          table: 'issue_label',
+          alias: 'labels',
+          related: [
+            {
+              correlation: {
+                parentField: ['label_id'],
+                childField: ['id'],
+              },
+              subquery: {
+                table: 'label',
+                alias: 'labels',
+              },
+            },
+          ],
+        },
+      })[0],
+    ),
+  ).toMatchInlineSnapshot(`
+    {
+      "text": ""issue_label" JOIN "label" as "table_1" ON "issue_label"."label_id" = "table_1"."id"",
+      "values": [],
+    }
+  `);
 });

--- a/packages/z2s/src/test/nullish.ts
+++ b/packages/z2s/src/test/nullish.ts
@@ -1,0 +1,53 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {expect} from 'vitest';
+
+/**
+ * `one` relationships will be returned by postgres as `null` vs zql will return them as `undefined`.
+ *
+ * Maybe we should change this in zql. Til then...
+ *
+ * This matcher has the downside of covering up errors where `null` is expected but `undefined` is returned.
+ */
+expect.extend({
+  toEqualNullish(received: any, expected: any) {
+    const normalize = (obj: any): any => {
+      if (obj === null || obj === undefined) {
+        return null;
+      }
+
+      if (typeof obj !== 'object' || obj === null) {
+        return obj;
+      }
+
+      if (Array.isArray(obj)) {
+        return obj.map(normalize);
+      }
+
+      return Object.fromEntries(
+        Object.entries(obj).map(([key, value]) => [key, normalize(value)]),
+      );
+    };
+
+    const normalizedReceived = normalize(received);
+    const normalizedExpected = normalize(expected);
+
+    const pass = this.equals(normalizedReceived, normalizedExpected);
+
+    return {
+      pass,
+      message: () =>
+        pass
+          ? `Expected ${received} not to equal ${expected} (treating null/undefined as equal)`
+          : `Expected ${received} to equal ${expected} (treating null/undefined as equal)`,
+      actual: received,
+      expected,
+    };
+  },
+});
+
+// You'll need to extend the Vitest types
+declare module 'vitest' {
+  interface Assertion {
+    toEqualNullish(expected: any): void;
+  }
+}


### PR DESCRIPTION
This fixes `one` in the compiler.

`hidden` is also mostly fixed. When seeing `hidden` we now translate the hidden path to joins rather than sub-selects.

 The ivm builder is putting `hidden` where I would not expect it so need to figure that out in a future PR.