### PR TITLE
fix(zql,z2s): place `hidden` flag on the correct relationship

### DIFF
--- a/packages/z2s/src/compiler.pg-test.ts
+++ b/packages/z2s/src/compiler.pg-test.ts
@@ -293,7 +293,7 @@ describe('compiling ZQL to SQL', () => {
     expect(query.run()).toEqualNullish(pgResult);
   });
 
-  test.fails('junction relationship', async () => {
+  test('junction relationship', async () => {
     const query = issueQuery.related('labels');
     const sqlQuery = formatPg(compile(ast(query), format(query)));
     const pgResult = await pg.unsafe(
@@ -317,7 +317,7 @@ describe('compiling ZQL to SQL', () => {
     expect(query.run()).toEqual(pgResult);
   });
 
-  test.fails('complex query combining multiple features', async () => {
+  test('complex query combining multiple features', async () => {
     const query = issueQuery
       .where('closed', '=', false)
       .whereExists('labels', q => q.where('name', 'IN', ['Label 1', 'Label 2']))
@@ -326,7 +326,7 @@ describe('compiling ZQL to SQL', () => {
         q.orderBy('createdAt', 'desc').limit(3).related('author'),
       )
       .orderBy('title', 'asc');
-    const sqlQuery = formatPg(compile(ast(query)));
+    const sqlQuery = formatPg(compile(ast(query), format(query)));
     const pgResult = await pg.unsafe(
       sqlQuery.text,
       sqlQuery.values as JSONValue[],

--- a/packages/zql/src/ivm/join.ts
+++ b/packages/zql/src/ivm/join.ts
@@ -76,11 +76,11 @@ export class Join implements Input {
     const childSchema = child.getSchema();
     this.#schema = {
       ...parentSchema,
-      isHidden: hidden,
       relationships: {
         ...parentSchema.relationships,
         [relationshipName]: {
           ...childSchema,
+          isHidden: hidden,
           system,
         },
       },

--- a/packages/zql/src/query/query-impl.ast.test.ts
+++ b/packages/zql/src/query/query-impl.ast.test.ts
@@ -226,6 +226,7 @@ describe('building the AST', () => {
                 "id",
               ],
             },
+            "hidden": true,
             "subquery": {
               "alias": "labels",
               "orderBy": [
@@ -248,7 +249,6 @@ describe('building the AST', () => {
                       "labelId",
                     ],
                   },
-                  "hidden": true,
                   "subquery": {
                     "alias": "labels",
                     "orderBy": [
@@ -325,6 +325,7 @@ describe('building the AST', () => {
                             "id",
                           ],
                         },
+                        "hidden": true,
                         "subquery": {
                           "alias": "labels",
                           "orderBy": [
@@ -347,7 +348,6 @@ describe('building the AST', () => {
                                   "labelId",
                                 ],
                               },
-                              "hidden": true,
                               "subquery": {
                                 "alias": "labels",
                                 "orderBy": [
@@ -441,6 +441,7 @@ describe('building the AST', () => {
                 "id",
               ],
             },
+            "hidden": true,
             "subquery": {
               "alias": "labels",
               "orderBy": [
@@ -463,7 +464,6 @@ describe('building the AST', () => {
                       "labelId",
                     ],
                   },
-                  "hidden": true,
                   "subquery": {
                     "alias": "labels",
                     "orderBy": [

--- a/packages/zql/src/query/query-impl.query-kitchen-sink.test.ts
+++ b/packages/zql/src/query/query-impl.query-kitchen-sink.test.ts
@@ -416,6 +416,7 @@ describe('kitchen sink query', () => {
                   "id",
                 ],
               },
+              "hidden": true,
               "subquery": {
                 "alias": "labels",
                 "orderBy": [
@@ -438,7 +439,6 @@ describe('kitchen sink query', () => {
                         "labelId",
                       ],
                     },
-                    "hidden": true,
                     "subquery": {
                       "alias": "labels",
                       "orderBy": [

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -268,6 +268,7 @@ export abstract class AbstractQuery<
                 parentField: firstRelation.sourceField,
                 childField: firstRelation.destField,
               },
+              hidden: true,
               subquery: {
                 table: junctionSchema,
                 alias: relationship,
@@ -282,7 +283,6 @@ export abstract class AbstractQuery<
                       parentField: secondRelation.sourceField,
                       childField: secondRelation.destField,
                     },
-                    hidden: true,
                     subquery: addPrimaryKeysToAst(
                       this.#schema.tables[destSchema],
                       sq.#ast,


### PR DESCRIPTION
`query-impl` put the `hidden` flag at the final table in a junction edge, which was incorrect. ZQL did the right thing because `join` moved the hidden flag up a level incorrectly. Two errors made a right in this case.

Concretely:
- query impl would hide the `label` table
- join would move the `hidden` flag back up to the `issue-label` table.

The z2s compiler, however, couldn't work properly with the `hidden` flag being placed in the wrong level by `query-impl`