### PR TITLE
chore(zero, replicache): Let replicache manage the deleted clients head

### DIFF
--- a/packages/replicache/src/deleted-clients.ts
+++ b/packages/replicache/src/deleted-clients.ts
@@ -1,7 +1,6 @@
 import * as v from '../../shared/src/valita.ts';
 import type {Read, Write} from './dag/store.ts';
 import {deepFreeze} from './frozen-json.ts';
-import type {Hash} from './hash.ts';
 import type {ClientID} from './sync/ids.ts';
 
 /**
@@ -13,13 +12,14 @@ export const DELETED_CLIENTS_HEAD_NAME = 'deleted-clients';
 export async function setDeletedClients(
   dagWrite: Write,
   deletedClients: ClientID[],
-): Promise<Hash> {
+): Promise<ClientID[]> {
   // sort and dedupe
-  const chunkData = deepFreeze([...new Set(deletedClients)].sort());
+  const normalized = normalize(deletedClients);
+  const chunkData = deepFreeze(normalized);
   const chunk = dagWrite.createChunk(chunkData, []);
   await dagWrite.putChunk(chunk);
   await dagWrite.setHead(DELETED_CLIENTS_HEAD_NAME, chunk.hash);
-  return chunk.hash;
+  return normalized;
 }
 
 const deletedClientsSchema = v.array(v.string());
@@ -31,4 +31,34 @@ export async function getDeletedClients(dagRead: Read): Promise<ClientID[]> {
   }
   const chunk = await dagRead.mustGetChunk(hash);
   return v.parse(chunk.data, deletedClientsSchema);
+}
+
+/**
+ * Adds deleted clients to the {@linkcode DELETED_CLIENTS_HEAD_NAME} head.
+ * @returns the new list of deleted clients (sorted and deduped).
+ */
+export async function addDeletedClients(
+  dagWrite: Write,
+  clientIDs: ClientID[],
+): Promise<ClientID[]> {
+  const deletedClients = await getDeletedClients(dagWrite);
+  return setDeletedClients(dagWrite, [...deletedClients, ...clientIDs]);
+}
+
+export async function removeDeletedClients(
+  dagWrite: Write,
+  clientIDs: ClientID[],
+): Promise<ClientID[]> {
+  const deletedClients = await getDeletedClients(dagWrite);
+  const newDeletedClients = deletedClients.filter(
+    clientID => !clientIDs.includes(clientID),
+  );
+  return setDeletedClients(dagWrite, newDeletedClients);
+}
+
+/**
+ * Sorts and dedupes the given array.
+ */
+export function normalize<T>(arr: T[]): T[] {
+  return [...new Set(arr)].sort();
 }

--- a/packages/replicache/src/persist/client-gc.ts
+++ b/packages/replicache/src/persist/client-gc.ts
@@ -1,6 +1,7 @@
 import type {LogContext} from '@rocicorp/logger';
 import {initBgIntervalProcess} from '../bg-interval.ts';
 import type {Store} from '../dag/store.ts';
+import {addDeletedClients} from '../deleted-clients.ts';
 import type {ClientID} from '../sync/ids.ts';
 import {withWrite} from '../with-transactions.ts';
 import type {Client, OnClientsDeleted} from './clients.ts';
@@ -75,7 +76,8 @@ function gcClients(
       return clients;
     }
     await setClients(newClients, dagWrite);
-    onClientsDeleted(deletedClients);
+    const normalized = await addDeletedClients(dagWrite, deletedClients);
+    onClientsDeleted(normalized);
     return newClients;
   });
 }

--- a/packages/zero-client/src/client/delete-clients-manager.test.ts
+++ b/packages/zero-client/src/client/delete-clients-manager.test.ts
@@ -27,10 +27,9 @@ beforeEach(() => {
   };
 });
 
-test('onClientsDeleted', async () => {
-  await manager.onClientsDeleted(['a', 'b']);
+test('onClientsDeleted', () => {
+  manager.onClientsDeleted(['a', 'b']);
   expect(send).toBeCalledWith(['deleteClients', {clientIDs: ['a', 'b']}]);
-  expect(await withRead(dagStore, getDeletedClients)).toEqual(['a', 'b']);
 });
 
 test('clientsDeletedOnServer', async () => {

--- a/packages/zero-client/src/client/delete-clients-manager.ts
+++ b/packages/zero-client/src/client/delete-clients-manager.ts
@@ -2,7 +2,7 @@ import type {LogContext} from '@rocicorp/logger';
 import type {Store} from '../../../replicache/src/dag/store.ts';
 import {
   getDeletedClients,
-  setDeletedClients,
+  removeDeletedClients,
 } from '../../../replicache/src/deleted-clients.ts';
 import type {ClientID} from '../../../replicache/src/sync/ids.ts';
 import {
@@ -13,9 +13,9 @@ import type {DeleteClientsMessage} from '../../../zero-protocol/src/delete-clien
 
 /**
  * Replicache will tell us when it deletes clients from the persistent storage
- * due to GC. When this happens we tell the server about the deleted clients. We
- * also store the deleted clients in IDB in case the server is currently
- * offline.
+ * due to GC. When this happens we tell the server about the deleted clients.
+ * Replicache also store the deleted clients in IDB in case the server is
+ * currently offline.
  *
  * The server will reply with the client it actually deleted. When we get that
  * we remove those IDs from our local storage.
@@ -39,19 +39,9 @@ export class DeleteClientsManager {
    * This gets called by Replicache when it deletes clients from the persistent
    * storage.
    */
-  async onClientsDeleted(clientIDs: ClientID[]): Promise<void> {
-    this.#lc.debug?.('onClientsDeleted:', clientIDs);
-    const deletedClients = await withWrite(this.#dagStore, async dagWrite => {
-      const deletedClients = await getDeletedClients(dagWrite);
-      const newDeletedClients = [
-        ...new Set([...deletedClients, ...clientIDs]),
-      ].sort();
-      await setDeletedClients(dagWrite, newDeletedClients);
-      return newDeletedClients;
-    });
-
-    this.#lc.debug?.('DeletedClientsManager, send:', deletedClients);
-    this.#send(['deleteClients', {clientIDs: deletedClients}]);
+  onClientsDeleted(clientIDs: ClientID[]): void {
+    this.#lc.debug?.('DeletedClientsManager, send:', clientIDs);
+    this.#send(['deleteClients', {clientIDs}]);
   }
 
   /**
@@ -77,11 +67,7 @@ export class DeleteClientsManager {
     // then write them back to the dag.
     return withWrite(this.#dagStore, async dagWrite => {
       this.#lc.debug?.('clientsDeletedOnServer:', clientIDs);
-      const currentDeletedClients = await getDeletedClients(dagWrite);
-      const newDeletedClients = currentDeletedClients.filter(
-        c => !clientIDs.includes(c),
-      );
-      await setDeletedClients(dagWrite, newDeletedClients);
+      await removeDeletedClients(dagWrite, clientIDs);
     });
   }
 


### PR DESCRIPTION
Now, replicache writes the deleted clients head as clients are deleted.

This was previously managed by zero since replicache does not really need this information.