### PR TITLE
chore(zero-cache): add sanity check, fix test

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/client-handler.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.ts
@@ -248,6 +248,13 @@ export class ClientHandler {
             return; // Nothing changed and nothing was sent.
           }
           this.#pokes.push(['pokeStart', {...pokeStart, cookie}]);
+        } else if (cmpVersions(this.#baseVersion, finalVersion) >= 0) {
+          // Sanity check: If the poke was started, the finalVersion
+          // must be > #baseVersion.
+          throw new Error(
+            `Patches were sent but finalVersion ${finalVersion} is ` +
+              `not greater than baseVersion ${this.#baseVersion}`,
+          );
         }
         flushBody();
         this.#pokes.push([

--- a/packages/zero-client/src/client/zero-poke-handler.test.ts
+++ b/packages/zero-client/src/client/zero-poke-handler.test.ts
@@ -1632,13 +1632,13 @@ test('mergePokes with cookie revisions', () => {
           ],
           pokeEnd: {
             pokeID: 'poke1',
-            cookie: '3', // Never mind, back to 3
+            cookie: '4', // Not 5, but 4.
           },
         },
         {
           pokeStart: {
             pokeID: 'poke2',
-            baseCookie: '3',
+            baseCookie: '4',
             cookie: '7',
             schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
           },


### PR DESCRIPTION
Adds a sanity check that the finalVersion always advances if pokes were sent.

Fix unit test to advance the cookie since a poke was sent (otherwise it is exercising a scenario that should not be possible)