### PR TITLE
feat(zero-schema): encode the protocol version in the permissions JSON

### DIFF
--- a/packages/zero-cache/src/auth/read-authorizer.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.ts
@@ -61,7 +61,7 @@ function transformQueryInternal(
   query: AST,
   permissionRules: PermissionsConfig,
 ): AST | undefined {
-  const rowSelectRules = permissionRules[query.table]?.row?.select;
+  const rowSelectRules = permissionRules.tables[query.table]?.row?.select;
 
   if (rowSelectRules && rowSelectRules.length === 0) {
     // The table cannot be read, ever. Nuke the query since

--- a/packages/zero-cache/src/auth/write-authorizer.test.ts
+++ b/packages/zero-cache/src/auth/write-authorizer.test.ts
@@ -1,5 +1,6 @@
 import {beforeEach, describe, expect, test} from 'vitest';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import {PROTOCOL_VERSION} from '../../../zero-protocol/src/protocol-version.ts';
 import type {
   DeleteOp,
   InsertOp,
@@ -62,7 +63,7 @@ describe('normalize ops', () => {
     const authorizer = new WriteAuthorizerImpl(
       lc,
       zeroConfig,
-      {},
+      undefined,
       replica,
       'cg',
     );
@@ -87,7 +88,7 @@ describe('normalize ops', () => {
     const authorizer = new WriteAuthorizerImpl(
       lc,
       zeroConfig,
-      {},
+      undefined,
       replica,
       'cg',
     );
@@ -116,9 +117,12 @@ describe('pre & post mutation', () => {
       lc,
       zeroConfig,
       {
-        foo: {
-          row: {
-            delete: [allowIfSubject],
+        protocolVersion: PROTOCOL_VERSION,
+        tables: {
+          foo: {
+            row: {
+              delete: [allowIfSubject],
+            },
           },
         },
       },
@@ -147,9 +151,12 @@ describe('pre & post mutation', () => {
       lc,
       zeroConfig,
       {
-        foo: {
-          row: {
-            insert: [allowIfSubject],
+        protocolVersion: PROTOCOL_VERSION,
+        tables: {
+          foo: {
+            row: {
+              insert: [allowIfSubject],
+            },
           },
         },
       },
@@ -178,10 +185,13 @@ describe('pre & post mutation', () => {
       lc,
       zeroConfig,
       {
-        foo: {
-          row: {
-            update: {
-              preMutation: [allowIfSubject],
+        protocolVersion: PROTOCOL_VERSION,
+        tables: {
+          foo: {
+            row: {
+              update: {
+                preMutation: [allowIfSubject],
+              },
             },
           },
         },
@@ -211,10 +221,13 @@ describe('pre & post mutation', () => {
       lc,
       zeroConfig,
       {
-        foo: {
-          row: {
-            update: {
-              postMutation: [allowIfAIsSubject],
+        protocolVersion: PROTOCOL_VERSION,
+        tables: {
+          foo: {
+            row: {
+              update: {
+                postMutation: [allowIfAIsSubject],
+              },
             },
           },
         },

--- a/packages/zero-cache/src/auth/write-authorizer.ts
+++ b/packages/zero-cache/src/auth/write-authorizer.ts
@@ -13,6 +13,7 @@ import {
   primaryKeyValueSchema,
   type PrimaryKeyValue,
 } from '../../../zero-protocol/src/primary-key.ts';
+import {PROTOCOL_VERSION} from '../../../zero-protocol/src/protocol-version.ts';
 import type {
   CRUDOp,
   DeleteOp,
@@ -84,7 +85,10 @@ export class WriteAuthorizerImpl implements WriteAuthorizer {
     this.#lc = lc.withContext('class', 'WriteAuthorizerImpl');
     this.#logConfig = config.log;
     this.#schema = getSchema(this.#lc, replica);
-    this.#permissionsConfig = permissions ?? {};
+    this.#permissionsConfig = permissions ?? {
+      protocolVersion: PROTOCOL_VERSION,
+      tables: {},
+    };
     this.#replica = replica;
     const tmpDir = config.storageDBTmpDir ?? tmpdir();
     const writeAuthzStorage = DatabaseStorage.create(
@@ -288,7 +292,7 @@ export class WriteAuthorizerImpl implements WriteAuthorizer {
     authData: JWTPayload | undefined,
     op: ActionOpMap[A],
   ) {
-    const rules = this.#permissionsConfig[op.tableName];
+    const rules = this.#permissionsConfig.tables[op.tableName];
     if (rules?.row === undefined && rules?.cell === undefined) {
       return true;
     }

--- a/packages/zero-cache/src/integration/integration.pg-test.ts
+++ b/packages/zero-cache/src/integration/integration.pg-test.ts
@@ -22,6 +22,8 @@ import type {ChangeDesiredQueriesMessage} from '../../../zero-protocol/src/chang
 import type {InitConnectionMessage} from '../../../zero-protocol/src/connect.ts';
 import type {PokeStartMessage} from '../../../zero-protocol/src/poke.ts';
 import {PROTOCOL_VERSION} from '../../../zero-protocol/src/protocol-version.ts';
+import type {Schema} from '../../../zero-schema/src/builder/schema-builder.ts';
+import type {PermissionsConfig} from '../../../zero-schema/src/compiled-permissions.ts';
 import type {ChangeStreamMessage} from '../services/change-source/protocol/current/downstream.ts';
 import {
   changeSourceUpstreamSchema,
@@ -284,13 +286,16 @@ describe('integration', {timeout: 30000}, () => {
   let customDownstream: Promise<Sink<ChangeStreamMessage>>;
 
   const SCHEMA = {
-    permissions: {},
+    permissions: {
+      protocolVersion: PROTOCOL_VERSION,
+      tables: {},
+    } satisfies PermissionsConfig,
     schema: {
       version: 1,
       tables: {},
       relationships: {},
-    },
-  } as const;
+    } satisfies Schema,
+  };
 
   const mockExit = vi
     .spyOn(process, 'exit')

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -286,7 +286,12 @@ const permissions: PermissionsConfig | undefined = await definePermissions<
   },
 }));
 
-async function setup(permissions: PermissionsConfig = {}) {
+async function setup(
+  permissions: PermissionsConfig = {
+    protocolVersion: PROTOCOL_VERSION,
+    tables: {},
+  },
+) {
   const lc = createSilentLogContext();
   const storageDB = new Database(lc, ':memory:');
   storageDB.prepare(CREATE_STORAGE_TABLE).run();

--- a/packages/zero-cache/src/workers/connection.ts
+++ b/packages/zero-cache/src/workers/connection.ts
@@ -14,7 +14,7 @@ import * as ErrorKind from '../../../zero-protocol/src/error-kind-enum.ts';
 import {type ErrorBody} from '../../../zero-protocol/src/error.ts';
 import type {PongMessage} from '../../../zero-protocol/src/pong.ts';
 import {
-  MIN_SERVER_SUPPORTED_PROTOCOL_VERSION,
+  MIN_SERVER_SUPPORTED_SYNC_PROTOCOL,
   PROTOCOL_VERSION,
 } from '../../../zero-protocol/src/protocol-version.ts';
 import {upstreamSchema} from '../../../zero-protocol/src/up.ts';
@@ -111,7 +111,7 @@ export class Connection {
   init() {
     if (
       this.#protocolVersion > PROTOCOL_VERSION ||
-      this.#protocolVersion < MIN_SERVER_SUPPORTED_PROTOCOL_VERSION
+      this.#protocolVersion < MIN_SERVER_SUPPORTED_SYNC_PROTOCOL
     ) {
       this.#closeWithError({
         kind: ErrorKind.VersionNotSupported,

--- a/packages/zero-protocol/src/protocol-version.ts
+++ b/packages/zero-protocol/src/protocol-version.ts
@@ -15,7 +15,8 @@ import {assert} from '../../shared/src/asserts.ts';
 export const PROTOCOL_VERSION = 5;
 
 /**
- * The minimum protocol version supported by the server. The contract for
+ * The minimum server-supported sync protocol version (i.e. the version
+ * declared in the "/sync/v{#}/connect" URL). The contract for
  * backwards compatibility is that a `zero-cache` supports the current
  * `PROTOCOL_VERSION` and at least the previous one (i.e. `PROTOCOL_VERSION - 1`)
  * if not earlier ones as well. This corresponds to supporting clients running
@@ -24,6 +25,16 @@ export const PROTOCOL_VERSION = 5;
  * closed with a `VersionNotSupported` error.
  */
 // TODO: Bump to 5 before returning responses with pokeEnd.cookie.
-export const MIN_SERVER_SUPPORTED_PROTOCOL_VERSION = 2;
+export const MIN_SERVER_SUPPORTED_SYNC_PROTOCOL = 2;
 
-assert(MIN_SERVER_SUPPORTED_PROTOCOL_VERSION < PROTOCOL_VERSION);
+assert(MIN_SERVER_SUPPORTED_SYNC_PROTOCOL < PROTOCOL_VERSION);
+
+/**
+ * The minimum server-supported upstream permissions protocol version
+ * (i.e. the `protocolVersion` stored with the compiled permissions JSON).
+ * This should correspond to the last time the AST definition was
+ * changed in a backwards-incompatible way.
+ */
+export const MIN_SERVER_SUPPORTED_PERMISSIONS_PROTOCOL = 4;
+
+assert(MIN_SERVER_SUPPORTED_PERMISSIONS_PROTOCOL < PROTOCOL_VERSION);

--- a/packages/zero-schema/src/compiled-permissions.ts
+++ b/packages/zero-schema/src/compiled-permissions.ts
@@ -20,11 +20,17 @@ const assetSchema = v.object({
 
 export type AssetPermissions = v.Infer<typeof assetSchema>;
 
-export const permissionsConfigSchema = v.record(
-  v.object({
-    row: assetSchema.optional(),
-    cell: v.record(assetSchema).optional(),
-  }),
-);
+export const permissionsConfigSchema = v.object({
+  protocolVersion: v.number(),
+  tables: v.record(
+    v.object({
+      row: assetSchema.optional(),
+      cell: v.record(assetSchema).optional(),
+    }),
+  ),
+});
 
+export type TablePermissions = v.Infer<
+  typeof permissionsConfigSchema.shape.tables
+>;
 export type PermissionsConfig = v.Infer<typeof permissionsConfigSchema>;

--- a/packages/zero-schema/src/permissions.test.ts
+++ b/packages/zero-schema/src/permissions.test.ts
@@ -50,49 +50,12 @@ test('permission rules create query ASTs', async () => {
 
   expect(config).toMatchInlineSnapshot(`
     {
-      "users": {
-        "cell": undefined,
-        "row": {
-          "delete": [
-            [
-              "allow",
-              {
-                "left": {
-                  "anchor": "authData",
-                  "field": "role",
-                  "type": "static",
-                },
-                "op": "=",
-                "right": {
-                  "type": "literal",
-                  "value": "admin",
-                },
-                "type": "simple",
-              },
-            ],
-          ],
-          "insert": [
-            [
-              "allow",
-              {
-                "left": {
-                  "anchor": "authData",
-                  "field": "role",
-                  "type": "static",
-                },
-                "op": "=",
-                "right": {
-                  "type": "literal",
-                  "value": "admin",
-                },
-                "type": "simple",
-              },
-            ],
-          ],
-          "select": undefined,
-          "update": {
-            "postMutation": undefined,
-            "preMutation": [
+      "protocolVersion": 5,
+      "tables": {
+        "users": {
+          "cell": undefined,
+          "row": {
+            "delete": [
               [
                 "allow",
                 {
@@ -110,6 +73,46 @@ test('permission rules create query ASTs', async () => {
                 },
               ],
             ],
+            "insert": [
+              [
+                "allow",
+                {
+                  "left": {
+                    "anchor": "authData",
+                    "field": "role",
+                    "type": "static",
+                  },
+                  "op": "=",
+                  "right": {
+                    "type": "literal",
+                    "value": "admin",
+                  },
+                  "type": "simple",
+                },
+              ],
+            ],
+            "select": undefined,
+            "update": {
+              "postMutation": undefined,
+              "preMutation": [
+                [
+                  "allow",
+                  {
+                    "left": {
+                      "anchor": "authData",
+                      "field": "role",
+                      "type": "static",
+                    },
+                    "op": "=",
+                    "right": {
+                      "type": "literal",
+                      "value": "admin",
+                    },
+                    "type": "simple",
+                  },
+                ],
+              ],
+            },
           },
         },
       },
@@ -157,149 +160,152 @@ test('nested parameters', async () => {
 
   expect(config).toMatchInlineSnapshot(`
     {
-      "users": {
-        "cell": undefined,
-        "row": {
-          "delete": [
-            [
-              "allow",
-              {
-                "conditions": [
-                  {
-                    "left": {
-                      "anchor": "authData",
-                      "field": "role",
-                      "type": "static",
-                    },
-                    "op": "=",
-                    "right": {
-                      "type": "literal",
-                      "value": "admin",
-                    },
-                    "type": "simple",
-                  },
-                  {
-                    "left": {
-                      "anchor": "authData",
-                      "field": [
-                        "attributes",
-                        "role",
-                      ],
-                      "type": "static",
-                    },
-                    "op": "=",
-                    "right": {
-                      "type": "literal",
-                      "value": "admin",
-                    },
-                    "type": "simple",
-                  },
-                ],
-                "type": "or",
-              },
-            ],
-          ],
-          "insert": [
-            [
-              "allow",
-              {
-                "conditions": [
-                  {
-                    "left": {
-                      "anchor": "authData",
-                      "field": "role",
-                      "type": "static",
-                    },
-                    "op": "=",
-                    "right": {
-                      "type": "literal",
-                      "value": "admin",
-                    },
-                    "type": "simple",
-                  },
-                  {
-                    "left": {
-                      "anchor": "authData",
-                      "field": [
-                        "attributes",
-                        "role",
-                      ],
-                      "type": "static",
-                    },
-                    "op": "=",
-                    "right": {
-                      "type": "literal",
-                      "value": "admin",
-                    },
-                    "type": "simple",
-                  },
-                ],
-                "type": "or",
-              },
-            ],
-          ],
-          "select": [
-            [
-              "allow",
-              {
-                "conditions": [
-                  {
-                    "left": {
-                      "anchor": "authData",
-                      "field": "role",
-                      "type": "static",
-                    },
-                    "op": "=",
-                    "right": {
-                      "type": "literal",
-                      "value": "admin",
-                    },
-                    "type": "simple",
-                  },
-                  {
-                    "left": {
-                      "anchor": "authData",
-                      "field": [
-                        "attributes",
-                        "role",
-                      ],
-                      "type": "static",
-                    },
-                    "op": "=",
-                    "right": {
-                      "type": "literal",
-                      "value": "admin",
-                    },
-                    "type": "simple",
-                  },
-                ],
-                "type": "or",
-              },
-            ],
-          ],
-          "update": {
-            "postMutation": undefined,
-            "preMutation": [
+      "protocolVersion": 5,
+      "tables": {
+        "users": {
+          "cell": undefined,
+          "row": {
+            "delete": [
               [
                 "allow",
                 {
-                  "left": {
-                    "name": "user_id",
-                    "type": "column",
-                  },
-                  "op": "=",
-                  "right": {
-                    "anchor": "authData",
-                    "field": [
-                      "attributes",
-                      "id",
-                    ],
-                    "type": "static",
-                  },
-                  "type": "simple",
+                  "conditions": [
+                    {
+                      "left": {
+                        "anchor": "authData",
+                        "field": "role",
+                        "type": "static",
+                      },
+                      "op": "=",
+                      "right": {
+                        "type": "literal",
+                        "value": "admin",
+                      },
+                      "type": "simple",
+                    },
+                    {
+                      "left": {
+                        "anchor": "authData",
+                        "field": [
+                          "attributes",
+                          "role",
+                        ],
+                        "type": "static",
+                      },
+                      "op": "=",
+                      "right": {
+                        "type": "literal",
+                        "value": "admin",
+                      },
+                      "type": "simple",
+                    },
+                  ],
+                  "type": "or",
                 },
               ],
             ],
+            "insert": [
+              [
+                "allow",
+                {
+                  "conditions": [
+                    {
+                      "left": {
+                        "anchor": "authData",
+                        "field": "role",
+                        "type": "static",
+                      },
+                      "op": "=",
+                      "right": {
+                        "type": "literal",
+                        "value": "admin",
+                      },
+                      "type": "simple",
+                    },
+                    {
+                      "left": {
+                        "anchor": "authData",
+                        "field": [
+                          "attributes",
+                          "role",
+                        ],
+                        "type": "static",
+                      },
+                      "op": "=",
+                      "right": {
+                        "type": "literal",
+                        "value": "admin",
+                      },
+                      "type": "simple",
+                    },
+                  ],
+                  "type": "or",
+                },
+              ],
+            ],
+            "select": [
+              [
+                "allow",
+                {
+                  "conditions": [
+                    {
+                      "left": {
+                        "anchor": "authData",
+                        "field": "role",
+                        "type": "static",
+                      },
+                      "op": "=",
+                      "right": {
+                        "type": "literal",
+                        "value": "admin",
+                      },
+                      "type": "simple",
+                    },
+                    {
+                      "left": {
+                        "anchor": "authData",
+                        "field": [
+                          "attributes",
+                          "role",
+                        ],
+                        "type": "static",
+                      },
+                      "op": "=",
+                      "right": {
+                        "type": "literal",
+                        "value": "admin",
+                      },
+                      "type": "simple",
+                    },
+                  ],
+                  "type": "or",
+                },
+              ],
+            ],
+            "update": {
+              "postMutation": undefined,
+              "preMutation": [
+                [
+                  "allow",
+                  {
+                    "left": {
+                      "name": "user_id",
+                      "type": "column",
+                    },
+                    "op": "=",
+                    "right": {
+                      "anchor": "authData",
+                      "field": [
+                        "attributes",
+                        "id",
+                      ],
+                      "type": "static",
+                    },
+                    "type": "simple",
+                  },
+                ],
+              ],
+            },
           },
         },
       },

--- a/packages/zero-schema/src/permissions.ts
+++ b/packages/zero-schema/src/permissions.ts
@@ -5,10 +5,11 @@ import {
   type Condition,
   type Parameter,
 } from '../../zero-protocol/src/ast.ts';
-import {StaticQuery} from '../../zql/src/query/static-query.ts';
+import {PROTOCOL_VERSION} from '../../zero-protocol/src/protocol-version.ts';
 import type {ExpressionBuilder} from '../../zql/src/query/expression.ts';
 import {staticParam} from '../../zql/src/query/query-impl.ts';
 import type {Query} from '../../zql/src/query/query.ts';
+import {StaticQuery} from '../../zql/src/query/static-query.ts';
 import type {Schema} from './builder/schema-builder.ts';
 import type {
   AssetPermissions as CompiledAssetPermissions,
@@ -94,10 +95,13 @@ function compilePermissions<TAuthDataShape, TSchema extends Schema>(
     return undefined;
   }
   const nameMapper = clientToServer(schema.tables);
-  const ret: CompiledPermissionsConfig = {};
+  const ret: CompiledPermissionsConfig = {
+    protocolVersion: PROTOCOL_VERSION,
+    tables: {},
+  };
   for (const [tableName, tableConfig] of Object.entries(authz)) {
     const serverName = schema.tables[tableName].serverName ?? tableName;
-    ret[serverName] = {
+    ret.tables[serverName] = {
       row: compileRowConfig(
         nameMapper,
         tableName,


### PR DESCRIPTION
Change the schema of the permissions JSON object to include the `PROTOCOL_VERSION` with which it was compiled. (Design: https://www.notion.so/replicache/Permissions-Deployment-1933bed895458002b4c8c3a2ab02c11b?pvs=4#1933bed8954580399706dce2889a2274)

This will serve a similar purpose to the protocol version declare in the `/sync/v{#}/connect` url path, allowing the server to determine compatibility and output a useful error message in the case of incompatibilities (as opposed to [cryptic valita errors](https://discord.com/channels/830183651022471199/1337466220894617650/1337750510991708161)).

The checking of the new `protocolVersion` field is not yet implemented. This will be bundled with the change that retrieves the permissions object from upstream.