### PR TITLE
chore(zero-cache): move debugging options into debugging scripts

### DIFF
--- a/packages/zero-cache/src/auth/load-schema.ts
+++ b/packages/zero-cache/src/auth/load-schema.ts
@@ -12,7 +12,7 @@ import {computeZqlSpecs} from '../db/lite-tables.ts';
 let loadedPermissions: Promise<{permissions: PermissionsConfig}> | undefined;
 
 export function getPermissions(
-  config: ZeroConfig,
+  config: Pick<ZeroConfig, 'schema'>,
 ): Promise<{permissions: PermissionsConfig}> {
   if (loadedPermissions) {
     return loadedPermissions;

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -387,26 +387,6 @@ export const zeroOptions = {
   },
 };
 
-const debugOptions = {
-  ...zeroOptions,
-  debug: {
-    ast: {
-      type: v.string().optional(),
-      desc: ['AST for the query to be transformed or timed.'],
-    },
-    hash: {
-      type: v.string().optional(),
-      desc: ['Hash of the query to fetch the AST for.'],
-    },
-    query: {
-      type: v.string().optional(),
-      desc: [
-        `Query to be timed in the form of: z.query.table.where(...).related(...).etc`,
-      ],
-    },
-  },
-};
-
 export type ZeroConfig = Config<typeof zeroOptions>;
 
 export const ZERO_ENV_VAR_PREFIX = 'ZERO_';
@@ -426,11 +406,4 @@ export function getZeroConfig(
   }
 
   return loadedConfig;
-}
-
-export function getDebugConfig(
-  env: NodeJS.ProcessEnv = process.env,
-  argv = process.argv.slice(2),
-) {
-  return parseOptions(debugOptions, argv, ZERO_ENV_VAR_PREFIX, env);
 }

--- a/packages/zero-cache/src/scripts/run-query.ts
+++ b/packages/zero-cache/src/scripts/run-query.ts
@@ -3,6 +3,8 @@ import chalk from 'chalk';
 import 'dotenv/config';
 
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import {parseOptions} from '../../../shared/src/options.ts';
+import * as v from '../../../shared/src/valita.ts';
 import type {AST} from '../../../zero-protocol/src/ast.ts';
 import {buildPipeline} from '../../../zql/src/builder/builder.ts';
 import {Catch} from '../../../zql/src/ivm/catch.ts';
@@ -18,9 +20,34 @@ import {
 } from '../../../zqlite/src/runtime-debug.ts';
 import {TableSource} from '../../../zqlite/src/table-source.ts';
 import {getSchema} from '../auth/load-schema.ts';
-import {getDebugConfig, type LogConfig} from '../config/zero-config.ts';
+import {
+  ZERO_ENV_VAR_PREFIX,
+  zeroOptions,
+  type LogConfig,
+} from '../config/zero-config.ts';
 
-const config = getDebugConfig();
+const options = {
+  replicaFile: zeroOptions.replicaFile,
+  debug: {
+    ast: {
+      type: v.string().optional(),
+      desc: ['AST for the query to be transformed or timed.'],
+    },
+    query: {
+      type: v.string().optional(),
+      desc: [
+        `Query to be timed in the form of: z.query.table.where(...).related(...).etc`,
+      ],
+    },
+  },
+};
+
+const config = parseOptions(
+  options,
+  process.argv.slice(2),
+  ZERO_ENV_VAR_PREFIX,
+);
+
 runtimeDebugFlags.trackRowsVended = true;
 
 const lc = createSilentLogContext();

--- a/packages/zero-cache/src/scripts/transform-query.ts
+++ b/packages/zero-cache/src/scripts/transform-query.ts
@@ -3,12 +3,30 @@ import 'dotenv/config';
 
 import {consoleLogSink, LogContext} from '@rocicorp/logger';
 import {must} from '../../../shared/src/must.ts';
+import {parseOptions} from '../../../shared/src/options.ts';
+import * as v from '../../../shared/src/valita.ts';
 import {getPermissions} from '../auth/load-schema.ts';
 import {transformAndHashQuery} from '../auth/read-authorizer.ts';
-import {getDebugConfig} from '../config/zero-config.ts';
+import {ZERO_ENV_VAR_PREFIX, zeroOptions} from '../config/zero-config.ts';
 import {pgClient} from '../types/pg.ts';
 
-const config = getDebugConfig();
+const options = {
+  cvr: zeroOptions.cvr,
+  schema: zeroOptions.schema,
+  debug: {
+    hash: {
+      type: v.string().optional(),
+      desc: ['Hash of the query to fetch the AST for.'],
+    },
+  },
+};
+
+const config = parseOptions(
+  options,
+  process.argv.slice(2),
+  ZERO_ENV_VAR_PREFIX,
+);
+
 const schema = await getPermissions(config);
 
 const cvrDB = pgClient(


### PR DESCRIPTION
Move the options relevant to each script into the script itself. This should make it more sustainable to add other scripts (like an up-and-coming `deploy-permissions` script) without making the main server options a nexus.