### PR TITLE
chore(zero, replicache): include client group ids in deleted clients

### DIFF
--- a/packages/replicache/src/deleted-clients.ts
+++ b/packages/replicache/src/deleted-clients.ts
@@ -1,7 +1,7 @@
 import * as v from '../../shared/src/valita.ts';
 import type {Read, Write} from './dag/store.ts';
 import {deepFreeze} from './frozen-json.ts';
-import type {ClientID} from './sync/ids.ts';
+import type {ClientGroupID, ClientID} from './sync/ids.ts';
 
 /**
  * We keep track of deleted clients in the {@linkcode DELETED_CLIENTS_HEAD_NAME}
@@ -9,25 +9,37 @@ import type {ClientID} from './sync/ids.ts';
  */
 export const DELETED_CLIENTS_HEAD_NAME = 'deleted-clients';
 
+export const deletedClientsSchema = v.readonlyObject({
+  clientIDs: v.readonlyArray(v.string()),
+  clientGroupIDs: v.readonlyArray(v.string()),
+});
+
+export type DeletedClients = v.Infer<typeof deletedClientsSchema>;
+
 export async function setDeletedClients(
   dagWrite: Write,
-  deletedClients: ClientID[],
-): Promise<ClientID[]> {
+  clientIDs: readonly ClientID[],
+  clientGroupIDs: readonly ClientGroupID[],
+): Promise<DeletedClients> {
   // sort and dedupe
-  const normalized = normalize(deletedClients);
-  const chunkData = deepFreeze(normalized);
+
+  const data = {
+    clientIDs: normalize(clientIDs),
+    clientGroupIDs: normalize(clientGroupIDs),
+  };
+  const chunkData = deepFreeze(data);
   const chunk = dagWrite.createChunk(chunkData, []);
   await dagWrite.putChunk(chunk);
   await dagWrite.setHead(DELETED_CLIENTS_HEAD_NAME, chunk.hash);
-  return normalized;
+  return data;
 }
 
-const deletedClientsSchema = v.array(v.string());
-
-export async function getDeletedClients(dagRead: Read): Promise<ClientID[]> {
+export async function getDeletedClients(
+  dagRead: Read,
+): Promise<DeletedClients> {
   const hash = await dagRead.getHead(DELETED_CLIENTS_HEAD_NAME);
   if (hash === undefined) {
-    return [];
+    return {clientIDs: [], clientGroupIDs: []};
   }
   const chunk = await dagRead.mustGetChunk(hash);
   return v.parse(chunk.data, deletedClientsSchema);
@@ -40,25 +52,37 @@ export async function getDeletedClients(dagRead: Read): Promise<ClientID[]> {
 export async function addDeletedClients(
   dagWrite: Write,
   clientIDs: ClientID[],
-): Promise<ClientID[]> {
-  const deletedClients = await getDeletedClients(dagWrite);
-  return setDeletedClients(dagWrite, [...deletedClients, ...clientIDs]);
+  clientGroupIDs: ClientGroupID[],
+): Promise<DeletedClients> {
+  const {clientIDs: oldClientIDs, clientGroupIDs: oldClientGroupIDs} =
+    await getDeletedClients(dagWrite);
+
+  return setDeletedClients(
+    dagWrite,
+    [...oldClientIDs, ...clientIDs],
+    [...oldClientGroupIDs, ...clientGroupIDs],
+  );
 }
 
 export async function removeDeletedClients(
   dagWrite: Write,
-  clientIDs: ClientID[],
-): Promise<ClientID[]> {
-  const deletedClients = await getDeletedClients(dagWrite);
-  const newDeletedClients = deletedClients.filter(
+  clientIDs: readonly ClientID[],
+  clientGroupIDs: readonly ClientGroupID[],
+): Promise<DeletedClients> {
+  const {clientIDs: oldClientIDs, clientGroupIDs: oldClientGroupIDs} =
+    await getDeletedClients(dagWrite);
+  const newDeletedClients = oldClientIDs.filter(
     clientID => !clientIDs.includes(clientID),
   );
-  return setDeletedClients(dagWrite, newDeletedClients);
+  const newDeletedClientGroups = oldClientGroupIDs.filter(
+    clientGroupID => !clientGroupIDs.includes(clientGroupID),
+  );
+  return setDeletedClients(dagWrite, newDeletedClients, newDeletedClientGroups);
 }
 
 /**
  * Sorts and dedupes the given array.
  */
-export function normalize<T>(arr: T[]): T[] {
+export function normalize<T>(arr: readonly T[]): T[] {
   return [...new Set(arr)].sort();
 }

--- a/packages/replicache/src/persist/client-gc.test.ts
+++ b/packages/replicache/src/persist/client-gc.test.ts
@@ -106,10 +106,13 @@ test('initClientGC starts 5 min interval that collects clients that have been in
     });
   });
   expect(onClientsDeleted).toHaveBeenCalledTimes(1);
-  expect(onClientsDeleted).toHaveBeenCalledWith(['client2']);
+  expect(onClientsDeleted).toHaveBeenCalledWith(['client2'], []);
   onClientsDeleted.mockClear();
 
-  expect(await withRead(dagStore, getDeletedClients)).toEqual(['client2']);
+  expect(await withRead(dagStore, getDeletedClients)).toEqual({
+    clientIDs: ['client2'],
+    clientGroupIDs: [],
+  });
 
   // Update client4's heartbeat to now
   const client4UpdatedHeartbeat = {
@@ -136,12 +139,12 @@ test('initClientGC starts 5 min interval that collects clients that have been in
   });
   expect(onClientsDeleted).toHaveBeenCalledTimes(1);
   // 'client2' is still in the deleted clients list
-  expect(onClientsDeleted).toHaveBeenCalledWith(['client2', 'client3']);
+  expect(onClientsDeleted).toHaveBeenCalledWith(['client2', 'client3'], []);
   onClientsDeleted.mockClear();
 
   // Clear client2 from deleted clients list
   await withWrite(dagStore, dagWrite =>
-    removeDeletedClients(dagWrite, ['client2']),
+    removeDeletedClients(dagWrite, ['client2'], []),
   );
 
   clock.tick(24 * HOURS - 5 * MINUTES * 2 + 1);
@@ -158,5 +161,5 @@ test('initClientGC starts 5 min interval that collects clients that have been in
   });
 
   expect(onClientsDeleted).toHaveBeenCalledTimes(1);
-  expect(onClientsDeleted).toHaveBeenCalledWith(['client3', 'client4']);
+  expect(onClientsDeleted).toHaveBeenCalledWith(['client3', 'client4'], []);
 });

--- a/packages/replicache/src/persist/client-gc.ts
+++ b/packages/replicache/src/persist/client-gc.ts
@@ -76,8 +76,13 @@ function gcClients(
       return clients;
     }
     await setClients(newClients, dagWrite);
-    const normalized = await addDeletedClients(dagWrite, deletedClients);
-    onClientsDeleted(normalized);
+    const {clientIDs, clientGroupIDs} = await addDeletedClients(
+      dagWrite,
+      deletedClients,
+      // gcClients does not delete client groups
+      [],
+    );
+    onClientsDeleted(clientIDs, clientGroupIDs);
     return newClients;
   });
 }

--- a/packages/replicache/src/persist/clients.ts
+++ b/packages/replicache/src/persist/clients.ts
@@ -534,4 +534,7 @@ export async function setClients(
 /**
  * Callback function for when Replicache has deleted one or more clients.
  */
-export type OnClientsDeleted = (clientIDs: ClientID[]) => void;
+export type OnClientsDeleted = (
+  clientIDs: readonly ClientID[],
+  clientGroupIDs: readonly ClientGroupID[],
+) => void;

--- a/packages/replicache/src/replicache-impl.ts
+++ b/packages/replicache/src/replicache-impl.ts
@@ -593,7 +593,13 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}> {
       this.#lc,
       signal,
     );
-    initClientGroupGC(this.perdag, enableMutationRecovery, this.#lc, signal);
+    initClientGroupGC(
+      this.perdag,
+      enableMutationRecovery,
+      onClientsDeleted,
+      this.#lc,
+      signal,
+    );
     initNewClientChannel(
       this.name,
       this.idbName,

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -403,9 +403,9 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     body: InitConnectionBody,
     cvr: CVRSnapshot,
   ): Promise<void> => {
-    const {deletedClients} = body;
-    if (deletedClients) {
-      await this.#deleteClients(lc, clientID, {clientIDs: deletedClients}, cvr);
+    const {deleted} = body;
+    if (deleted && (deleted.clientIDs || deleted.clientGroupIDs)) {
+      await this.#deleteClients(lc, clientID, deleted, cvr);
     }
     await this.#patchQueries(lc, clientID, body, cvr);
   };
@@ -432,10 +432,10 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   readonly #deleteClients = async (
     lc: LogContext,
     clientID: string,
-    {clientIDs}: DeleteClientsBody,
+    {clientIDs, clientGroupIDs}: DeleteClientsBody,
     cvr: CVRSnapshot,
   ): Promise<void> => {
-    lc.debug?.('deleting clients', clientIDs, clientID, cvr);
+    lc.debug?.('deleting clients', clientIDs, clientGroupIDs, clientID, cvr);
     // TODO: Implement deletion of clients
     // Find all clients from the msg and delete them. Send back the IDs of the
     // deleted clients to the client.

--- a/packages/zero-client/src/client/delete-clients-manager.test.ts
+++ b/packages/zero-client/src/client/delete-clients-manager.test.ts
@@ -28,14 +28,20 @@ beforeEach(() => {
 });
 
 test('onClientsDeleted', () => {
-  manager.onClientsDeleted(['a', 'b']);
-  expect(send).toBeCalledWith(['deleteClients', {clientIDs: ['a', 'b']}]);
+  manager.onClientsDeleted(['a', 'b'], []);
+  expect(send).toBeCalledWith([
+    'deleteClients',
+    {clientIDs: ['a', 'b'], clientGroupIDs: []},
+  ]);
 });
 
 test('clientsDeletedOnServer', async () => {
   await withWrite(dagStore, dagWrite =>
-    setDeletedClients(dagWrite, ['c', 'd', 'e']),
+    setDeletedClients(dagWrite, ['c', 'd', 'e'], []),
   );
-  await manager.clientsDeletedOnServer(['c', 'd']);
-  expect(await withRead(dagStore, getDeletedClients)).toEqual(['e']);
+  await manager.clientsDeletedOnServer({clientIDs: ['c', 'd']});
+  expect(await withRead(dagStore, getDeletedClients)).toEqual({
+    clientIDs: ['e'],
+    clientGroupIDs: [],
+  });
 });

--- a/packages/zero-protocol/src/connect.test.ts
+++ b/packages/zero-protocol/src/connect.test.ts
@@ -25,7 +25,13 @@ test('encode/decodeSecProtocols round-trip', () => {
                   }),
                 ),
               ),
-              deletedClients: fc.array(fc.string()),
+              deleted: fc.record(
+                {
+                  clientIDs: fc.array(fc.string()),
+                  clientGroupIDs: fc.array(fc.string()),
+                },
+                {requiredKeys: []},
+              ),
             },
             {requiredKeys: ['desiredQueriesPatch']},
           ),

--- a/packages/zero-protocol/src/connect.ts
+++ b/packages/zero-protocol/src/connect.ts
@@ -1,4 +1,5 @@
 import * as v from '../../shared/src/valita.ts';
+import {deleteClientsBodySchema} from './delete-clients.ts';
 import {queriesPatchSchema} from './queries-patch.ts';
 
 /**
@@ -21,7 +22,7 @@ export const connectedMessageSchema = v.tuple([
 
 const initConnectionBodySchema = v.object({
   desiredQueriesPatch: queriesPatchSchema,
-  deletedClients: v.array(v.string()).optional(),
+  deleted: deleteClientsBodySchema.optional(),
 });
 
 export const initConnectionMessageSchema = v.tuple([

--- a/packages/zero-protocol/src/delete-clients.ts
+++ b/packages/zero-protocol/src/delete-clients.ts
@@ -1,8 +1,11 @@
 import * as v from '../../shared/src/valita.ts';
 
-const deleteClientsBodySchema = v.object({
-  clientIDs: v.array(v.string()),
-});
+export const deleteClientsBodySchema = v.union(
+  v.readonlyObject({
+    clientIDs: v.readonlyArray(v.string()).optional(),
+    clientGroupIDs: v.readonlyArray(v.string()).optional(),
+  }),
+);
 
 export const deleteClientsMessageSchema = v.tuple([
   v.literal('deleteClients'),


### PR DESCRIPTION
Now we store `{clientIDs, clientGroupIDs}` in the deleted clients head and update these as needed.

When sending `deletedClients` (as part of connection, initConnection etc) we send both client IDs and client group IDS.