### PR TITLE
feat(zero-cache): upstream zero.permissions table and deploy tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27600,7 +27600,8 @@
       "bin": {
         "zero-build-schema": "out/zero/src/build-schema.js",
         "zero-cache": "out/zero/src/cli.js",
-        "zero-cache-dev": "out/zero/src/zero-cache-dev.js"
+        "zero-cache-dev": "out/zero/src/zero-cache-dev.js",
+        "zero-deploy-permissions": "out/zero/src/deploy-permissions.js"
       },
       "devDependencies": {
         "@rocicorp/eslint-config": "^0.7.0",

--- a/packages/zero-cache/src/integration/integration.pg-test.ts
+++ b/packages/zero-cache/src/integration/integration.pg-test.ts
@@ -258,6 +258,35 @@ const INITIAL_CUSTOM_SETUP: ChangeStreamMessage[] = [
   [
     'data',
     {
+      tag: 'create-table',
+      spec: {
+        schema: 'zero',
+        name: 'permissions',
+        primaryKey: ['lock'],
+        columns: {
+          lock: {pos: 0, dataType: 'bool', notNull: true},
+          permissions: {pos: 1, dataType: 'json'},
+          hash: {pos: 2, dataType: 'text'},
+        },
+      },
+    },
+  ],
+  [
+    'data',
+    {
+      tag: 'create-index',
+      spec: {
+        name: 'zero_permissions_key',
+        schema: 'zero',
+        tableName: 'permissions',
+        columns: {lock: 'ASC'},
+        unique: true,
+      },
+    },
+  ],
+  [
+    'data',
+    {
       tag: 'insert',
       relation: {
         schema: 'zero',

--- a/packages/zero-cache/src/scripts/deploy-permissions.ts
+++ b/packages/zero-cache/src/scripts/deploy-permissions.ts
@@ -1,0 +1,158 @@
+import {consoleLogSink, LogContext} from '@rocicorp/logger';
+import 'dotenv/config';
+import {writeFile} from 'node:fs/promises';
+import {basename, dirname, join, relative, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {tsImport} from 'tsx/esm/api';
+import {parseOptions} from '../../../shared/src/options.ts';
+import * as v from '../../../shared/src/valita.ts';
+import {
+  permissionsConfigSchema,
+  type PermissionsConfig,
+} from '../../../zero-schema/src/compiled-permissions.ts';
+import {isSchemaConfig} from '../../../zero-schema/src/schema-config.ts';
+import {ZERO_ENV_VAR_PREFIX, zeroOptions} from '../config/zero-config.ts';
+import {ensureGlobalTables} from '../services/change-source/pg/schema/shard.ts';
+import {pgClient, type PostgresDB} from '../types/pg.ts';
+
+const options = {
+  schema: {
+    path: {
+      type: v.string().default('schema.ts'),
+      desc: [
+        'Relative path to the file containing the schema definition.',
+        'The file must have a default export of type SchemaConfig.',
+      ],
+      alias: 'p',
+    },
+  },
+
+  upstream: {
+    db: {
+      ...zeroOptions.upstream.db,
+      type: v.string().optional(),
+      desc: [
+        `The upstream Postgres database to deploy permissions to.`,
+        `This is ignored if an {bold output-file} is specified.`,
+      ],
+    },
+  },
+
+  output: {
+    file: {
+      type: v.string().optional(),
+      desc: [
+        `If specified, outputs the permissions JSON to a file. The`,
+        `contents must be manually deployed to the upstream database, e.g.:`,
+        ``,
+        `{bold UPDATE zero.permissions SET permissions = \\{json\\}}`,
+      ],
+    },
+
+    pretty: {
+      type: v.boolean().optional(),
+      desc: [`Formats the JSON with indentation.`],
+    },
+  },
+};
+
+const config = parseOptions(
+  options,
+  process.argv.slice(2),
+  ZERO_ENV_VAR_PREFIX,
+);
+
+async function loadPermissions(
+  lc: LogContext,
+  schema: typeof config.schema,
+): Promise<PermissionsConfig> {
+  lc.info?.(`Loading permissions from ${schema.path}`);
+  const dir = dirname(fileURLToPath(import.meta.url));
+  const absoluteSchemaPath = resolve(config.schema.path);
+  let relativePath = join(
+    relative(dir, dirname(absoluteSchemaPath)),
+    basename(absoluteSchemaPath),
+  );
+
+  // tsImport doesn't expect to receive slashes in the Windows format when running
+  // on Windows. They need to be converted to *nix format.
+  relativePath = relativePath.replace(/\\/g, '/');
+
+  let module;
+  try {
+    module = await tsImport(relativePath, import.meta.url);
+  } catch (e) {
+    lc.error?.(`Failed to load zero schema from ${absoluteSchemaPath}:`, e);
+    process.exit(1);
+  }
+
+  if (!isSchemaConfig(module)) {
+    throw new Error(
+      `Schema file ${schema.path} must export [schema] and [permissions].`,
+    );
+  }
+  try {
+    const schemaConfig = module;
+    const perms =
+      await (schemaConfig.permissions as unknown as Promise<unknown>);
+    return v.parse(perms, permissionsConfigSchema);
+  } catch (e) {
+    lc.error?.(`Failed to parse Permissions object`, e);
+    process.exit(1);
+  }
+}
+
+async function validatePermissions(
+  _lc: LogContext,
+  _db: PostgresDB,
+  _permissions: PermissionsConfig,
+) {
+  // TODO: Validate that the permissions rules match the upstream table / column names.
+}
+
+async function deployPermissions(
+  lc: LogContext,
+  upstreamURI: string,
+  permissions: PermissionsConfig,
+) {
+  const db = pgClient(lc, upstreamURI);
+  try {
+    await validatePermissions(lc, db, permissions);
+    await ensureGlobalTables(db);
+
+    lc.info?.(`Deploying permissions to upstream@${db.options.host}`);
+
+    const {hash, changed} = await db.begin(async tx => {
+      const [{hash: beforeHash}] = await tx<{hash: string}[]>`
+        SELECT hash from zero.permissions`;
+      const [{hash}] = await tx<{hash: string}[]>`
+        UPDATE zero.permissions SET ${db({permissions})} RETURNING hash`;
+
+      return {hash: hash.substring(0, 7), changed: beforeHash !== hash};
+    });
+    if (changed) {
+      lc.info?.(`Deployed new permissions (hash=${hash})`);
+    } else {
+      lc.info?.(`Permissions unchanged (hash=${hash})`);
+    }
+  } finally {
+    await db.end();
+  }
+}
+
+const lc = new LogContext('debug', {}, consoleLogSink);
+
+const permissions = await loadPermissions(lc, config.schema);
+if (config.output.file) {
+  await writeFile(
+    config.output.file,
+    JSON.stringify(permissions, null, config.output.pretty ? 2 : 0),
+  );
+  lc.info?.(`Wrote permissions JSON to ${config.output.file}`);
+} else if (config.upstream.db) {
+  await deployPermissions(lc, config.upstream.db, permissions);
+} else {
+  lc.error?.(`No --output-file or --upstream-db specified`);
+  // Shows the usage text.
+  parseOptions(options, ['--help'], ZERO_ENV_VAR_PREFIX);
+}

--- a/packages/zero-cache/src/services/change-source/custom/change-source.test.ts
+++ b/packages/zero-cache/src/services/change-source/custom/change-source.test.ts
@@ -160,6 +160,35 @@ describe('change-source/custom', () => {
       [
         'data',
         {
+          tag: 'create-table',
+          spec: {
+            schema: 'zero',
+            name: 'permissions',
+            primaryKey: ['lock'],
+            columns: {
+              lock: {pos: 0, dataType: 'bool', notNull: true},
+              permissions: {pos: 1, dataType: 'json'},
+              hash: {pos: 2, dataType: 'text'},
+            },
+          },
+        },
+      ],
+      [
+        'data',
+        {
+          tag: 'create-index',
+          spec: {
+            name: 'zero_permissions_key',
+            schema: 'zero',
+            tableName: 'permissions',
+            columns: {lock: 'ASC'},
+            unique: true,
+          },
+        },
+      ],
+      [
+        'data',
+        {
           tag: 'insert',
           relation: {
             schema: 'zero',

--- a/packages/zero-cache/src/services/change-source/custom/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/custom/change-source.ts
@@ -205,6 +205,10 @@ function getRequiredTables(
       lastMutationID: {type: 'number'},
       userID: {type: 'string'},
     },
+    [`zero.permissions`]: {
+      permissions: {type: 'json'},
+      hash: {type: 'string'},
+    },
     [`zero.schemaVersions`]: {
       minSupportedVersion: {type: 'number'},
       maxSupportedVersion: {type: 'number'},

--- a/packages/zero-cache/src/services/change-source/pg/schema/init.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.pg-test.ts
@@ -13,8 +13,8 @@ const SHARD_ID = 'shard_schema_test_id';
 
 // Update as necessary.
 const CURRENT_SCHEMA_VERSIONS = {
-  dataVersion: 3,
-  schemaVersion: 3,
+  dataVersion: 4,
+  schemaVersion: 4,
   minSafeVersion: 1,
   lock: 'v',
 } as const;

--- a/packages/zero-cache/src/services/change-source/pg/schema/init.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.ts
@@ -10,6 +10,7 @@ import {AutoResetSignal} from '../../../change-streamer/schema/tables.ts';
 import type {ShardConfig} from '../shard-config.ts';
 import {
   dropShard,
+  ensureGlobalTables,
   setupTablesAndReplication,
   unescapedSchema,
 } from './shard.ts';
@@ -60,6 +61,8 @@ async function runShardMigrations(
       },
       minSafeVersion: 3,
     },
+    // The zero.permissions table was added to the global zero shard.
+    4: {migrateSchema: (_, tx) => ensureGlobalTables(tx)},
   };
 
   await runSchemaMigrations(

--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.pg-test.ts
@@ -42,6 +42,7 @@ describe('change-source/pg', () => {
     ]);
 
     await expectTables(db, {
+      ['zero.permissions']: [{lock: true, permissions: null, hash: null}],
       ['zero.schemaVersions']: [
         {lock: true, minSupportedVersion: 1, maxSupportedVersion: 1},
       ],
@@ -87,6 +88,7 @@ describe('change-source/pg', () => {
     ]);
 
     await expectTables(db, {
+      ['zero.permissions']: [{lock: true, permissions: null, hash: null}],
       ['zero.schemaVersions']: [
         {lock: true, minSupportedVersion: 1, maxSupportedVersion: 1},
       ],
@@ -122,6 +124,7 @@ describe('change-source/pg', () => {
     ]);
 
     await expectTables(db, {
+      ['zero.permissions']: [{lock: true, permissions: null, hash: null}],
       ['zero.schemaVersions']: [
         {lock: true, minSupportedVersion: 1, maxSupportedVersion: 1},
       ],
@@ -158,6 +161,7 @@ describe('change-source/pg', () => {
     ]);
 
     await expectTables(db, {
+      ['zero.permissions']: [{lock: true, permissions: null, hash: null}],
       ['zero.schemaVersions']: [
         {lock: true, minSupportedVersion: 1, maxSupportedVersion: 1},
       ],
@@ -224,6 +228,7 @@ describe('change-source/pg', () => {
     ]);
 
     await expectTables(db, {
+      ['zero.permissions']: [{lock: true, permissions: null, hash: null}],
       ['zero.schemaVersions']: [
         {lock: true, minSupportedVersion: 1, maxSupportedVersion: 1},
       ],
@@ -262,6 +267,7 @@ describe('change-source/pg', () => {
     ]);
 
     await expectTables(db, {
+      ['zero.permissions']: [{lock: true, permissions: null, hash: null}],
       ['zero.schemaVersions']: [
         {lock: true, minSupportedVersion: 1, maxSupportedVersion: 1},
       ],

--- a/packages/zero/package.json
+++ b/packages/zero/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "rm -rf out && npm run build-server && npm run build-client",
     "build-client": "tsc -p tsconfig.client.json && tsc-alias -p tsconfig.client.json && npx tsx tool/build.js",
-    "build-server": "tsc -p tsconfig.server.json && tsc-alias -p tsconfig.server.json && chmod +x out/zero/src/cli.js out/zero/src/build-schema.js out/zero/src/zero-cache-dev.js",
+    "build-server": "tsc -p tsconfig.server.json && tsc-alias -p tsconfig.server.json && chmod +x out/zero/src/cli.js out/zero/src/build-schema.js out/zero/src/deploy-permissions.js out/zero/src/zero-cache-dev.js",
     "test": "vitest run",
     "test:watch": "vitest",
     "check-types": "tsc",
@@ -99,7 +99,8 @@
   "bin": {
     "zero-build-schema": "./out/zero/src/build-schema.js",
     "zero-cache": "./out/zero/src/cli.js",
-    "zero-cache-dev": "./out/zero/src/zero-cache-dev.js"
+    "zero-cache-dev": "./out/zero/src/zero-cache-dev.js",
+    "zero-deploy-permissions": "./out/zero/src/deploy-permissions.js"
   },
   "engines": {
     "node": ">=20"

--- a/packages/zero/src/deploy-permissions.ts
+++ b/packages/zero/src/deploy-permissions.ts
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import '../../zero-cache/src/scripts/deploy-permissions.ts';

--- a/packages/zero/tsconfig.server.json
+++ b/packages/zero/tsconfig.server.json
@@ -8,6 +8,7 @@
     "src/cli.ts",
     "src/build-schema.ts",
     "src/zero-cache-dev.ts",
+    "src/deploy-permissions.ts",
     "src/change-protocol/*"
   ]
 }


### PR DESCRIPTION
Adds an upstream-global (i.e. unsharded) `zero.permissions` table to hold the permissions JSON object, and an `npx zero-deploy-permissions` tool to deploy it to an upstream postgres.

The table is not yet consulted; that is coming soon, along with integration with `npx zero-cache-dev`.

### Deploy DX

`--help`:

<img width="732" alt="Screenshot 2025-02-10 at 16 49 39" src="https://github.com/user-attachments/assets/a3917803-12e1-4a66-a772-4f3677181d9b" />

In the directory with `.env`:

<img width="339" alt="Screenshot 2025-02-10 at 16 51 24" src="https://github.com/user-attachments/assets/ac6f0b17-81f2-4aab-8f6b-8c10ebb9fb99" />

With an `--output-file`:

<img width="528" alt="Screenshot 2025-02-10 at 16 51 55" src="https://github.com/user-attachments/assets/7cc793db-90bd-4bac-a380-b3504b7621de" />
