### PR TITLE
prod(zbugs): run deploy-permissions as part of continuous deploy

### DIFF
--- a/.github/workflows/sst-prod-deploy.yml
+++ b/.github/workflows/sst-prod-deploy.yml
@@ -62,10 +62,10 @@ jobs:
           docker buildx inspect --bootstrap
           docker buildx build --platform linux/amd64 --build-arg ZERO_VERSION=rocicorp-zero-*.tgz -t ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$ECR_IMAGE_ZERO_CACHE:${{ env.SHA }} -f ./Dockerfile --push .
       - name: Generate Schema
+        # TODO: Remove this when upstream permissions are rolled out.
         run: |
           cd packages/zero
           npx tsx src/build-schema.ts --schema-path ../../apps/zbugs/schema.ts --schema-output ../../prod/sst/zero-schema.json
-
       - name: Deploy SST app
         env:
           ZERO_UPSTREAM_DB: ${{ secrets.PROD_ZERO_UPSTREAM_DB }}
@@ -77,9 +77,13 @@ jobs:
           AWS_REGION: ${{ vars.AWS_DEFAULT_REGION }}
           AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
           ZERO_IMAGE_URL: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_DEFAULT_REGION }}.amazonaws.com/${{ env.ECR_IMAGE_ZERO_CACHE }}:${{ env.SHA }}
-          DOMAIN_NAME: "zbugs-sync.rocicorp.dev"
+          DOMAIN_NAME: 'zbugs-sync.rocicorp.dev'
           DOMAIN_CERT: ${{ vars.PROD_CERTIFICATE_ARN }}
         run: |
           cd prod/sst
           npm install
           npx sst deploy --stage production
+      - name: Deploy Permissions
+        run: |
+          cd packages/zero
+          npx tsx src/deploy-permissions.ts --schema-path ../../apps/zbugs/schema.ts --upstream-db ${{ secrets.PROD_ZERO_UPSTREAM_DB }}

--- a/.github/workflows/sst-sandbox-deploy.yml
+++ b/.github/workflows/sst-sandbox-deploy.yml
@@ -62,10 +62,10 @@ jobs:
           docker buildx inspect --bootstrap
           docker buildx build --platform linux/amd64 --build-arg ZERO_VERSION=rocicorp-zero-*.tgz -t ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$ECR_IMAGE_ZERO_CACHE:${{ env.SHA }} -f ./Dockerfile --push .
       - name: Generate Schema
+        # TODO: Remove this when upstream permissions are rolled out.
         run: |
           cd packages/zero
           npx tsx src/build-schema.ts --schema-path ../../apps/zbugs/schema.ts --schema-output ../../prod/sst/zero-schema.json
-
       - name: Deploy SST app
         env:
           ZERO_UPSTREAM_DB: ${{ secrets.SANDBOX_ZERO_UPSTREAM_DB }}
@@ -77,9 +77,13 @@ jobs:
           AWS_REGION: ${{ vars.AWS_DEFAULT_REGION }}
           AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
           ZERO_IMAGE_URL: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_DEFAULT_REGION }}.amazonaws.com/${{ env.ECR_IMAGE_ZERO_CACHE }}:${{ env.SHA }}
-          DOMAIN_NAME: "zbugs-sync-sandbox.rocicorp.dev"
+          DOMAIN_NAME: 'zbugs-sync-sandbox.rocicorp.dev'
           DOMAIN_CERT: ${{ vars.SANDBOX_CERTIFICATE_ARN }}
         run: |
           cd prod/sst
           npm install
           npx sst deploy --stage sandbox
+      - name: Deploy Permissions
+        run: |
+          cd packages/zero
+          npx tsx src/deploy-permissions.ts --schema-path ../../apps/zbugs/schema.ts --upstream-db ${{ secrets.SANDBOX_ZERO_UPSTREAM_DB }}


### PR DESCRIPTION
Runs the new `zero-deploy-permissions` command from #3755 to deploy the zbugs permissions.