### PR TITLE
fix(shared): Immutable type too deep

### DIFF
--- a/packages/shared/src/immutable.test.ts
+++ b/packages/shared/src/immutable.test.ts
@@ -1,0 +1,47 @@
+import {expectTypeOf, test} from 'vitest';
+import type {Immutable, ImmutableArray} from './immutable.ts';
+import type {ReadonlyJSONValue} from './json.ts';
+
+test('type testing immutable', () => {
+  const x = [
+    {
+      a: 1,
+      b: '2',
+      c: [1, 2, 3],
+    },
+  ];
+  const xi = x as Immutable<typeof x>;
+  expectTypeOf(xi[0].c).toEqualTypeOf<ImmutableArray<number>>();
+});
+
+test('testing with readonly array', () => {
+  type NumberOrArray = number | ReadonlyArray<NumberOrArray>;
+  type X = ImmutableArray<NumberOrArray>;
+  const x: X = [1];
+  expectTypeOf(x).toEqualTypeOf<ImmutableArray<NumberOrArray>>();
+});
+
+test('type from discord', () => {
+  function f(
+    flagsUpdate: ImmutableArray<{
+      readonly userID: string;
+      readonly value: ReadonlyJSONValue;
+    }>,
+  ) {
+    return flagsUpdate;
+  }
+
+  expectTypeOf(f).returns.toEqualTypeOf<
+    ImmutableArray<{
+      readonly userID: string;
+      readonly value: ReadonlyJSONValue;
+    }>
+  >();
+
+  f([
+    {
+      userID: '1',
+      value: [1],
+    },
+  ]);
+});

--- a/packages/shared/src/immutable.ts
+++ b/packages/shared/src/immutable.ts
@@ -5,7 +5,7 @@ type Primitive = undefined | null | boolean | string | number | symbol | bigint;
  */
 export type Immutable<T> = T extends Primitive
   ? T
-  : T extends Array<infer U>
+  : T extends ReadonlyArray<infer U>
   ? ImmutableArray<U>
   : ImmutableObject<T>;
 // This does not deal with Maps or Sets (or Date or RegExp or ...).


### PR DESCRIPTION
We were getting:

```
Type instantiation is excessively deep and possibly infinite.ts(2589)
```

When a ReadonlyArray was passed into `Immutable`. The reason was that we were using `extends Array<infer U>`, but ReadonlyArray does not extend Array.