### PR TITLE
feat(zero-cache): update `dispatcher` to be able to hand-off to `mutator`

### DIFF
--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -147,6 +147,10 @@ export default async function runWorker(
     }
     syncers.forEach(syncer => handleSubscriptionsFrom(lc, syncer, notifier));
   }
+  let mutator: Worker | undefined;
+  if (config.push.url !== undefined) {
+    mutator = loadWorker('./server/mutator.ts', 'supporting', 'mutator');
+  }
 
   lc.info?.('waiting for workers to be ready ...');
   if ((await orTimeout(processes.allWorkersReady(), 60_000)) === 'timed-out') {
@@ -159,7 +163,9 @@ export default async function runWorker(
   const {port} = config;
 
   if (numSyncers) {
-    mainServices.push(new Dispatcher(lc, taskID, parent, syncers, {port}));
+    mainServices.push(
+      new Dispatcher(lc, taskID, parent, syncers, mutator, {port}),
+    );
   } else if (changeStreamer && parent) {
     // When running as the replication-manager, the dispatcher process
     // hands off websockets from the main (tenant) dispatcher to the

--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import {must} from '../../../shared/src/must.ts';
 import {getZeroConfig} from '../config/zero-config.ts';
 import {getSubscriberContext} from '../services/change-streamer/change-streamer-http.ts';
-import {SyncDispatcher} from '../services/dispatcher/sync-dispatcher.ts';
+import {Dispatcher} from '../services/dispatcher/dispatcher.ts';
 import {installWebSocketHandoff} from '../services/dispatcher/websocket-handoff.ts';
 import {
   exitAfter,
@@ -159,7 +159,7 @@ export default async function runWorker(
   const {port} = config;
 
   if (numSyncers) {
-    mainServices.push(new SyncDispatcher(lc, taskID, parent, syncers, {port}));
+    mainServices.push(new Dispatcher(lc, taskID, parent, syncers, {port}));
   } else if (changeStreamer && parent) {
     // When running as the replication-manager, the dispatcher process
     // hands off websockets from the main (tenant) dispatcher to the

--- a/packages/zero-cache/src/server/mutator.ts
+++ b/packages/zero-cache/src/server/mutator.ts
@@ -1,0 +1,28 @@
+import {must} from '../../../shared/src/must.ts';
+import {getZeroConfig} from '../config/zero-config.ts';
+import {exitAfter, runUntilKilled} from '../services/life-cycle.ts';
+import {
+  parentWorker,
+  singleProcessMode,
+  type Worker,
+} from '../types/processes.ts';
+import {Mutator} from '../workers/mutator.ts';
+import {createLogContext} from './logging.ts';
+
+function runWorker(
+  parent: Worker,
+  env: NodeJS.ProcessEnv,
+  ...args: string[]
+): Promise<void> {
+  const config = getZeroConfig(env, args.slice(1));
+  const lc = createLogContext(config, {worker: 'mutator'});
+
+  // TODO: create `PusherFactory`
+  return runUntilKilled(lc, parent, new Mutator());
+}
+
+if (!singleProcessMode()) {
+  void exitAfter(() =>
+    runWorker(must(parentWorker), process.env, ...process.argv.slice(2)),
+  );
+}

--- a/packages/zero-cache/src/services/dispatcher/dispatcher.test.ts
+++ b/packages/zero-cache/src/services/dispatcher/dispatcher.test.ts
@@ -1,15 +1,36 @@
 import {expect, test} from 'vitest';
-import {parseSyncPath} from './dispatcher.ts';
+import {parsePath} from './dispatcher.ts';
 
 test.each([
-  ['/sync/v1/connect', {version: '1'}],
-  ['/sync/v2/connect', {version: '2'}],
-  ['/sync/v3/connect?foo=bar', {version: '3'}],
-  ['/api/sync/v1/connect', {base: 'api', version: '1'}],
-  ['/api/sync/v1/connect?a=b&c=d', {base: 'api', version: '1'}],
-  ['/zero/sync/v1/connect', {base: 'zero', version: '1'}],
-  ['/zero-api/sync/v0/connect', {base: 'zero-api', version: '0'}],
-  ['/zero-api/sync/v2/connect?', {base: 'zero-api', version: '2'}],
+  ['/sync/v1/connect', {version: '1', verb: 'sync'}],
+  ['/sync/v2/connect', {version: '2', verb: 'sync'}],
+  ['/sync/v3/connect?foo=bar', {version: '3', verb: 'sync'}],
+  ['/api/sync/v1/connect', {base: 'api', verb: 'sync', version: '1'}],
+  ['/api/sync/v1/connect?a=b&c=d', {base: 'api', verb: 'sync', version: '1'}],
+  ['/zero/sync/v1/connect', {base: 'zero', verb: 'sync', version: '1'}],
+  ['/zero-api/sync/v0/connect', {base: 'zero-api', verb: 'sync', version: '0'}],
+  [
+    '/zero-api/sync/v2/connect?',
+    {base: 'zero-api', verb: 'sync', version: '2'},
+  ],
+
+  ['/mutate/v1/connect', {version: '1', verb: 'mutate'}],
+  ['/mutate/v2/connect', {version: '2', verb: 'mutate'}],
+  ['/mutate/v3/connect?foo=bar', {version: '3', verb: 'mutate'}],
+  ['/api/mutate/v1/connect', {base: 'api', verb: 'mutate', version: '1'}],
+  [
+    '/api/mutate/v1/connect?a=b&c=d',
+    {base: 'api', verb: 'mutate', version: '1'},
+  ],
+  ['/zero/mutate/v1/connect', {base: 'zero', verb: 'mutate', version: '1'}],
+  [
+    '/zero-api/mutate/v0/connect',
+    {base: 'zero-api', verb: 'mutate', version: '0'},
+  ],
+  [
+    '/zero-api/mutate/v2/connect?',
+    {base: 'zero-api', verb: 'mutate', version: '2'},
+  ],
 
   ['/zero-api/sync/v2/connect/not/match', undefined],
   ['/too/many/components/sync/v0/connect', undefined],
@@ -17,5 +38,5 @@ test.each([
   ['/', undefined],
   ['', undefined],
 ])('parseSyncPath %s', (path, result) => {
-  expect(parseSyncPath(new URL(path, 'http://foo/'))).toEqual(result);
+  expect(parsePath(new URL(path, 'http://foo/'))).toEqual(result);
 });

--- a/packages/zero-cache/src/services/dispatcher/dispatcher.test.ts
+++ b/packages/zero-cache/src/services/dispatcher/dispatcher.test.ts
@@ -1,5 +1,5 @@
 import {expect, test} from 'vitest';
-import {parseSyncPath} from './sync-dispatcher.ts';
+import {parseSyncPath} from './dispatcher.ts';
 
 test.each([
   ['/sync/v1/connect', {version: '1'}],

--- a/packages/zero-cache/src/services/dispatcher/dispatcher.ts
+++ b/packages/zero-cache/src/services/dispatcher/dispatcher.ts
@@ -11,7 +11,7 @@ import {installWebSocketHandoff} from './websocket-handoff.ts';
 // servicing requests on the same domain as the application.
 const CONNECT_URL_PATTERN = new UrlPattern('(/:base)/sync/v:version/connect');
 
-export class SyncDispatcher extends HttpService {
+export class Dispatcher extends HttpService {
   readonly id = 'dispatcher';
   readonly #taskID: string;
   readonly #syncers: Worker[];

--- a/packages/zero-cache/src/services/dispatcher/dispatcher.ts
+++ b/packages/zero-cache/src/services/dispatcher/dispatcher.ts
@@ -6,21 +6,24 @@ import type {Worker} from '../../types/processes.ts';
 import {HttpService, type Options} from '../http-service.ts';
 import {getConnectParams} from './connect-params.ts';
 import {installWebSocketHandoff} from './websocket-handoff.ts';
+import {assert} from '../../../../shared/src/asserts.ts';
 
 // The server allows the client to use any /:base/ path to facilitate
 // servicing requests on the same domain as the application.
-const CONNECT_URL_PATTERN = new UrlPattern('(/:base)/sync/v:version/connect');
+const CONNECT_URL_PATTERN = new UrlPattern('(/:base)/:verb/v:version/connect');
 
 export class Dispatcher extends HttpService {
   readonly id = 'dispatcher';
   readonly #taskID: string;
   readonly #syncers: Worker[];
+  readonly #mutator: Worker | undefined;
 
   constructor(
     lc: LogContext,
     taskID: string,
     parent: Worker | null,
     syncers: Worker[],
+    mutator: Worker | undefined,
     opts: Options,
   ) {
     super('dispatcher', lc, opts, fastify => {
@@ -29,6 +32,7 @@ export class Dispatcher extends HttpService {
 
     this.#taskID = taskID;
     this.#syncers = syncers;
+    this.#mutator = mutator;
     if (parent) {
       installWebSocketHandoff(lc, req => this.#handoff(req), parent);
     }
@@ -37,35 +41,46 @@ export class Dispatcher extends HttpService {
   #handoff(req: IncomingMessageSubset) {
     const {headers, url: u} = req;
     const url = new URL(u ?? '', 'http://unused/');
-    const syncPath = parseSyncPath(url);
-    if (!syncPath) {
-      throw new Error(`Invalid sync URL: ${u}`);
+    const path = parsePath(url);
+    if (!path) {
+      throw new Error(`Invalid URL: ${u}`);
     }
-    const version = Number(syncPath.version);
+    const version = Number(path.version);
     if (Number.isNaN(version)) {
-      throw new Error(`Invalid sync version: ${u}`);
+      throw new Error(`Invalid version: ${u}`);
     }
     const {params, error} = getConnectParams(version, url, headers);
     if (error !== null) {
       throw new Error(error);
     }
     const {clientGroupID} = params;
-    // Include the TaskID when hash-bucketting the client group to the sync
-    // worker. This diversifies the distribution of client groups (across
-    // workers) for different tasks, so that if one task sheds connections
-    // from its most heavily loaded sync worker(s), those client groups will
-    // be distributed uniformly across workers on the receiving task(s).
-    const syncer =
-      h32(this.#taskID + '/' + clientGroupID) % this.#syncers.length;
 
-    this._lc.debug?.(`connecting ${clientGroupID} to syncer ${syncer}`);
-    return {payload: params, receiver: this.#syncers[syncer]};
+    if (path.verb === 'sync') {
+      // Include the TaskID when hash-bucketting the client group to the sync
+      // worker. This diversifies the distribution of client groups (across
+      // workers) for different tasks, so that if one task sheds connections
+      // from its most heavily loaded sync worker(s), those client groups will
+      // be distributed uniformly across workers on the receiving task(s).
+      const syncer =
+        h32(this.#taskID + '/' + clientGroupID) % this.#syncers.length;
+
+      this._lc.debug?.(`connecting ${clientGroupID} to syncer ${syncer}`);
+      return {payload: params, receiver: this.#syncers[syncer]};
+    } else if (path.verb === 'mutate') {
+      assert(
+        this.#mutator !== undefined,
+        'Received a push for a custom mutation but no `push.url` was configured.',
+      );
+      return {payload: params, receiver: this.#mutator};
+    }
+
+    throw new Error(`Invalid verb: ${u}`);
   }
 }
 
-export function parseSyncPath(
+export function parsePath(
   url: URL,
-): {base?: string; version: string} | undefined {
+): {base?: string; verb: 'sync' | 'mutate'; version: string} | undefined {
   // The match() returns both null and undefined.
   return CONNECT_URL_PATTERN.match(url.pathname) || undefined;
 }

--- a/packages/zero-cache/src/workers/mutator.ts
+++ b/packages/zero-cache/src/workers/mutator.ts
@@ -1,0 +1,29 @@
+import {resolver} from '@rocicorp/resolver';
+import type {SingletonService} from '../services/service.ts';
+import {pid} from 'node:process';
+
+// TODO:
+// - install websocket receiver
+// - spin up pusher services for each unique client group that connects
+export class Mutator implements SingletonService {
+  readonly id = `mutator-${pid}`;
+  readonly #stopped;
+
+  constructor() {
+    this.#stopped = resolver();
+  }
+
+  run(): Promise<void> {
+    return this.#stopped.promise;
+  }
+
+  stop(): Promise<void> {
+    this.#stopped.resolve();
+    return this.#stopped.promise;
+  }
+
+  drain(): Promise<void> {
+    this.#stopped.resolve();
+    return this.#stopped.promise;
+  }
+}


### PR DESCRIPTION
Follows the same pattern as `syncer` to set up a `mutator` worker that will receive websocket connections from the dispatcher.