### PR TITLE
chore(zero-cache): use the schema load logic in deploy-zero-permissions

### DIFF
--- a/packages/zero-cache/src/scripts/deploy-permissions.ts
+++ b/packages/zero-cache/src/scripts/deploy-permissions.ts
@@ -16,7 +16,7 @@ import {ZERO_ENV_VAR_PREFIX, zeroOptions} from '../config/zero-config.ts';
 import {ensureGlobalTables} from '../services/change-source/pg/schema/shard.ts';
 import {pgClient, type PostgresDB} from '../types/pg.ts';
 
-const options = {
+export const deployOptions = {
   schema: {
     path: {
       type: v.string().default('schema.ts'),
@@ -62,12 +62,12 @@ const options = {
 };
 
 const config = parseOptions(
-  options,
+  deployOptions,
   process.argv.slice(2),
   ZERO_ENV_VAR_PREFIX,
 );
 
-async function loadPermissions(
+export async function loadPermissions(
   lc: LogContext,
   schema: typeof config.schema,
 ): Promise<PermissionsConfig> {
@@ -176,5 +176,5 @@ if (config.output.file) {
 } else {
   lc.error?.(`No --output-file or --upstream-db specified`);
   // Shows the usage text.
-  parseOptions(options, ['--help'], ZERO_ENV_VAR_PREFIX);
+  parseOptions(deployOptions, ['--help'], ZERO_ENV_VAR_PREFIX);
 }

--- a/packages/zero-cache/src/scripts/deploy-permissions.ts
+++ b/packages/zero-cache/src/scripts/deploy-permissions.ts
@@ -16,7 +16,7 @@ import {ZERO_ENV_VAR_PREFIX, zeroOptions} from '../config/zero-config.ts';
 import {ensureGlobalTables} from '../services/change-source/pg/schema/shard.ts';
 import {pgClient, type PostgresDB} from '../types/pg.ts';
 
-export const deployOptions = {
+export const deployPermissionsOptions = {
   schema: {
     path: {
       type: v.string().default('schema.ts'),
@@ -62,7 +62,7 @@ export const deployOptions = {
 };
 
 const config = parseOptions(
-  deployOptions,
+  deployPermissionsOptions,
   process.argv.slice(2),
   ZERO_ENV_VAR_PREFIX,
 );
@@ -176,5 +176,5 @@ if (config.output.file) {
 } else {
   lc.error?.(`No --output-file or --upstream-db specified`);
   // Shows the usage text.
-  parseOptions(deployOptions, ['--help'], ZERO_ENV_VAR_PREFIX);
+  parseOptions(deployPermissionsOptions, ['--help'], ZERO_ENV_VAR_PREFIX);
 }

--- a/packages/zero-cache/src/scripts/transform-query.ts
+++ b/packages/zero-cache/src/scripts/transform-query.ts
@@ -5,14 +5,14 @@ import {consoleLogSink, LogContext} from '@rocicorp/logger';
 import {must} from '../../../shared/src/must.ts';
 import {parseOptions} from '../../../shared/src/options.ts';
 import * as v from '../../../shared/src/valita.ts';
-import {getPermissions} from '../auth/load-schema.ts';
 import {transformAndHashQuery} from '../auth/read-authorizer.ts';
 import {ZERO_ENV_VAR_PREFIX, zeroOptions} from '../config/zero-config.ts';
 import {pgClient} from '../types/pg.ts';
+import {deployOptions, loadPermissions} from './deploy-permissions.ts';
 
 const options = {
   cvr: zeroOptions.cvr,
-  schema: zeroOptions.schema,
+  schema: deployOptions.schema,
   debug: {
     hash: {
       type: v.string().optional(),
@@ -27,7 +27,8 @@ const config = parseOptions(
   ZERO_ENV_VAR_PREFIX,
 );
 
-const schema = await getPermissions(config);
+const lc = new LogContext('debug', {}, consoleLogSink);
+const permissions = await loadPermissions(lc, config.schema);
 
 const cvrDB = pgClient(
   new LogContext('debug', undefined, consoleLogSink),
@@ -39,9 +40,9 @@ const rows =
     config.debug.hash,
   )} limit 1;`;
 
-console.log(
+lc.info?.(
   JSON.stringify(
-    transformAndHashQuery(rows[0].clientAST, schema.permissions, {}).query,
+    transformAndHashQuery(rows[0].clientAST, permissions, {}).query,
   ),
 );
 

--- a/packages/zero-cache/src/scripts/transform-query.ts
+++ b/packages/zero-cache/src/scripts/transform-query.ts
@@ -8,11 +8,14 @@ import * as v from '../../../shared/src/valita.ts';
 import {transformAndHashQuery} from '../auth/read-authorizer.ts';
 import {ZERO_ENV_VAR_PREFIX, zeroOptions} from '../config/zero-config.ts';
 import {pgClient} from '../types/pg.ts';
-import {deployOptions, loadPermissions} from './deploy-permissions.ts';
+import {
+  deployPermissionsOptions,
+  loadPermissions,
+} from './deploy-permissions.ts';
 
 const options = {
   cvr: zeroOptions.cvr,
-  schema: deployOptions.schema,
+  schema: deployPermissionsOptions.schema,
   debug: {
     hash: {
       type: v.string().optional(),


### PR DESCRIPTION
Have the `transform-query` script use the schema loading logic from `deploy-permissions`, to remove a dependency on the soon-to-go-away schema.json logic.