### PR TITLE
chore(zero-cache): move options to separate file

### DIFF
--- a/packages/zero-cache/src/scripts/deploy-permissions-options.ts
+++ b/packages/zero-cache/src/scripts/deploy-permissions-options.ts
@@ -1,0 +1,47 @@
+import * as v from '../../../shared/src/valita.ts';
+import {zeroOptions} from '../config/zero-config.ts';
+
+export const deployPermissionsOptions = {
+  schema: {
+    path: {
+      type: v.string().default('schema.ts'),
+      desc: [
+        'Relative path to the file containing the schema definition.',
+        'The file must have a default export of type SchemaConfig.',
+      ],
+      alias: 'p',
+    },
+  },
+
+  upstream: {
+    db: {
+      ...zeroOptions.upstream.db,
+      type: v.string().optional(),
+      desc: [
+        `The upstream Postgres database to deploy permissions to.`,
+        `This is ignored if an {bold output-file} is specified.`,
+      ],
+    },
+  },
+
+  output: {
+    file: {
+      type: v.string().optional(),
+      desc: [
+        `Outputs the permissions to a file with the requested {bold output-format}.`,
+      ],
+    },
+
+    format: {
+      type: v.union(v.literal('sql'), v.literal('json')).default('sql'),
+      desc: [
+        `The desired format of the output file.`,
+        ``,
+        `A {bold sql} file can be executed via "psql -f <file.sql>", or "\\\\i <file.sql>"`,
+        `from within the psql console, or copied and pasted into a migration script.`,
+        ``,
+        `The {bold json} format is available for general debugging.`,
+      ],
+    },
+  },
+};

--- a/packages/zero-cache/src/scripts/deploy-permissions.ts
+++ b/packages/zero-cache/src/scripts/deploy-permissions.ts
@@ -12,54 +12,10 @@ import {
   type PermissionsConfig,
 } from '../../../zero-schema/src/compiled-permissions.ts';
 import {isSchemaConfig} from '../../../zero-schema/src/schema-config.ts';
-import {ZERO_ENV_VAR_PREFIX, zeroOptions} from '../config/zero-config.ts';
+import {ZERO_ENV_VAR_PREFIX} from '../config/zero-config.ts';
 import {ensureGlobalTables} from '../services/change-source/pg/schema/shard.ts';
 import {pgClient, type PostgresDB} from '../types/pg.ts';
-
-export const deployPermissionsOptions = {
-  schema: {
-    path: {
-      type: v.string().default('schema.ts'),
-      desc: [
-        'Relative path to the file containing the schema definition.',
-        'The file must have a default export of type SchemaConfig.',
-      ],
-      alias: 'p',
-    },
-  },
-
-  upstream: {
-    db: {
-      ...zeroOptions.upstream.db,
-      type: v.string().optional(),
-      desc: [
-        `The upstream Postgres database to deploy permissions to.`,
-        `This is ignored if an {bold output-file} is specified.`,
-      ],
-    },
-  },
-
-  output: {
-    file: {
-      type: v.string().optional(),
-      desc: [
-        `Outputs the permissions to a file with the requested {bold output-format}.`,
-      ],
-    },
-
-    format: {
-      type: v.union(v.literal('sql'), v.literal('json')).default('sql'),
-      desc: [
-        `The desired format of the output file.`,
-        ``,
-        `A {bold sql} file can be executed via "psql -f <file.sql>", or "\\\\i <file.sql>"`,
-        `from within the psql console, or copied and pasted into a migration script.`,
-        ``,
-        `The {bold json} format is available for general debugging.`,
-      ],
-    },
-  },
-};
+import {deployPermissionsOptions} from './deploy-permissions-options.ts';
 
 const config = parseOptions(
   deployPermissionsOptions,

--- a/packages/zero-cache/src/scripts/transform-query.ts
+++ b/packages/zero-cache/src/scripts/transform-query.ts
@@ -8,10 +8,8 @@ import * as v from '../../../shared/src/valita.ts';
 import {transformAndHashQuery} from '../auth/read-authorizer.ts';
 import {ZERO_ENV_VAR_PREFIX, zeroOptions} from '../config/zero-config.ts';
 import {pgClient} from '../types/pg.ts';
-import {
-  deployPermissionsOptions,
-  loadPermissions,
-} from './deploy-permissions.ts';
+import {deployPermissionsOptions} from './deploy-permissions-options.ts';
+import {loadPermissions} from './deploy-permissions.ts';
 
 const options = {
   cvr: zeroOptions.cvr,


### PR DESCRIPTION
Move the deployment options to a separate file so that importing them does not execute the main script.