### PR TITLE
fix(zero-cache): reset the replica for new permissions schema

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/schema/init.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.pg-test.ts
@@ -8,7 +8,6 @@ import {
 import {expectTablesToMatch, initDB, testDBs} from '../../../../test/db.ts';
 import type {PostgresDB} from '../../../../types/pg.ts';
 import {initShardSchema, updateShardSchema} from './init.ts';
-import {METADATA_PUBLICATION_PREFIX} from './shard.ts';
 
 const SHARD_ID = 'shard_schema_test_id';
 
@@ -113,25 +112,6 @@ describe('change-streamer/pg/schema/init', () => {
         ['zero.schemaVersions']: [
           {minSupportedVersion: 2, maxSupportedVersion: 3},
         ],
-      },
-    },
-    {
-      name: '3 to 4',
-      upstreamSetup: `
-          CREATE SCHEMA IF NOT EXISTS zero;
-          CREATE TABLE zero."schemaVersions" 
-            ("lock" BOOL PRIMARY KEY, "minSupportedVersion" INT4, "maxSupportedVersion" INT4);
-          INSERT INTO zero."schemaVersions" 
-            ("lock", "minSupportedVersion", "maxSupportedVersion") VALUES (true, 2, 3);
-          CREATE PUBLICATION ${METADATA_PUBLICATION_PREFIX}${SHARD_ID} FOR TABLE zero."schemaVersions";
-        `,
-      existingVersionHistory: {
-        minSafeVersion: 1,
-        dataVersion: 3,
-        schemaVersion: 3,
-      },
-      upstreamPostState: {
-        [`zero_${SHARD_ID}.versionHistory`]: [CURRENT_SCHEMA_VERSIONS],
       },
     },
   ];

--- a/packages/zero-cache/src/services/change-source/pg/schema/init.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.ts
@@ -10,8 +10,6 @@ import {AutoResetSignal} from '../../../change-streamer/schema/tables.ts';
 import type {ShardConfig} from '../shard-config.ts';
 import {
   dropShard,
-  ensureGlobalTables,
-  METADATA_PUBLICATION_PREFIX,
   setupTablesAndReplication,
   unescapedSchema,
 } from './shard.ts';
@@ -56,22 +54,11 @@ async function runShardMigrations(
   };
 
   const schemaVersionMigrationMap: IncrementalMigrationMap = {
-    3: {
+    4: {
       migrateSchema: () => {
         throw new AutoResetSignal('resetting to upgrade shard schema');
       },
-      minSafeVersion: 3,
-    },
-    // The zero.permissions table was added to the global zero shard.
-    4: {
-      migrateSchema: async (_, tx) => {
-        await ensureGlobalTables(tx);
-
-        const pub = METADATA_PUBLICATION_PREFIX + shard.id;
-        await tx`ALTER PUBLICATION ${tx(pub)} ADD TABLE zero.permissions`;
-        // Touch the row to replicate the existing contents.
-        await tx`UPDATE zero.permissions SET permissions = permissions`;
-      },
+      minSafeVersion: 4,
     },
   };
 

--- a/packages/zero-cache/src/services/change-source/pg/sync-schema.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/sync-schema.pg-test.ts
@@ -20,8 +20,8 @@ const SHARD_ID = 'sync_schema_test_id';
 
 // Update as necessary.
 const CURRENT_SCHEMA_VERSIONS = {
-  dataVersion: 3,
-  schemaVersion: 3,
+  dataVersion: 4,
+  schemaVersion: 4,
   minSafeVersion: 1,
   lock: 1, // Internal column, always 1
 };

--- a/packages/zero-cache/src/services/change-source/pg/sync-schema.ts
+++ b/packages/zero-cache/src/services/change-source/pg/sync-schema.ts
@@ -25,11 +25,11 @@ export async function initSyncSchema(
 
   const schemaVersionMigrationMap: IncrementalMigrationMap = {
     // There's no incremental migration from v1. Just reset the replica.
-    3: {
+    4: {
       migrateSchema: () => {
         throw new AutoResetSignal('upgrading replica to new schema');
       },
-      minSafeVersion: 3,
+      minSafeVersion: 4,
     },
   };
 

--- a/prod/sst/sst.config.ts
+++ b/prod/sst/sst.config.ts
@@ -49,7 +49,7 @@ export default $config({
       AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY!,
       ZERO_LOG_FORMAT: "json",
       ZERO_REPLICA_FILE: "sync-replica.db",
-      ZERO_LITESTREAM_BACKUP_URL: $interpolate`s3://${replicationBucket.name}/backup`,
+      ZERO_LITESTREAM_BACKUP_URL: $interpolate`s3://${replicationBucket.name}/backup/20250211-00`,
       ZERO_IMAGE_URL: process.env.ZERO_IMAGE_URL!,
     };
 


### PR DESCRIPTION
Doing a surgical upgrade from v3 to v4 isn't working out. Just do a reset.