### PR TITLE
fix(zero-cache-dev): better error message during redeploy failures

### DIFF
--- a/packages/zero/src/zero-cache-dev.ts
+++ b/packages/zero/src/zero-cache-dev.ts
@@ -94,9 +94,7 @@ async function main() {
       log(`${deployPermissionsScript} completed successfully.`);
       return true;
     }
-    logError(
-      `Errors in ${path} must be fixed before zero-cache can be started.`,
-    );
+    logError(`Failed to deploy permissions from ${path}.`);
     return false;
   }
 


### PR DESCRIPTION
An error can happen during a redeploy. This doesn't stop an already running server.