### PR TITLE
fix(zero-cache): remove cvr migration from legacy schema

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/schema/init.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/init.ts
@@ -8,26 +8,12 @@ import {
 import type {PostgresDB} from '../../../types/pg.ts';
 import {createRowsVersionTable, cvrSchema, setupCVRTables} from './cvr.ts';
 
-async function migrateFromLegacySchema(
-  lc: LogContext,
-  db: PostgresDB,
-  newSchema: string,
-) {
-  const result = await db`SELECT * FROM pg_namespace WHERE nspname = 'cvr'`;
-  if (result.length > 0) {
-    lc.info?.(`Migrating cvr to ${newSchema}`);
-    await db`ALTER SCHEMA cvr RENAME TO ${db(newSchema)}`;
-  }
-}
-
 export async function initViewSyncerSchema(
   log: LogContext,
   db: PostgresDB,
   shardID: string,
 ): Promise<void> {
   const schema = cvrSchema(shardID);
-
-  await migrateFromLegacySchema(log, db, schema);
 
   const setupMigration: Migration = {
     migrateSchema: (lc, tx) => setupCVRTables(lc, tx, shardID),


### PR DESCRIPTION
The renaming of the legacy `cvr` schema to sharded `cvr_{shard-id}` schemas is not compatible with a multi-node setup: https://discord.com/channels/830183651022471199/1339066868245467157/1339076089309298689

Removing it provides the correct semantics; the new `zero-cache` just starts storing cvrs in the new schema.

The disadvantage is that the old schema does not get cleaned up. This could be addressed in cleanup tool, but it has to be performed manually with the knowledge that the legacy schema is no longer being used.