### PR TITLE
feat(zero-cache): wire pusher service through the existing ws connection

### DIFF
--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -33,6 +33,7 @@ import {
   subscribeTo,
 } from '../workers/replicator.ts';
 import {createLogContext} from './logging.ts';
+const clientConnectionBifurcated = false;
 
 export default async function runWorker(
   parent: Worker | null,
@@ -148,7 +149,7 @@ export default async function runWorker(
     syncers.forEach(syncer => handleSubscriptionsFrom(lc, syncer, notifier));
   }
   let mutator: Worker | undefined;
-  if (config.push.url !== undefined) {
+  if (config.push.url !== undefined && clientConnectionBifurcated) {
     mutator = loadWorker('./server/mutator.ts', 'supporting', 'mutator');
   }
 

--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -33,6 +33,7 @@ import {Subscription} from '../types/subscription.ts';
 import {replicaFileModeSchema, replicaFileName} from '../workers/replicator.ts';
 import {Syncer} from '../workers/syncer.ts';
 import {createLogContext} from './logging.ts';
+import {PusherService} from '../services/mutagen/pusher.ts';
 
 function randomID() {
   return randInt(1, Number.MAX_SAFE_INTEGER).toString(36);
@@ -137,11 +138,23 @@ export default function runWorker(
       config,
     );
 
+  const pusherFactory =
+    config.push.url === undefined
+      ? undefined
+      : (id: string) =>
+          new PusherService(
+            lc.withContext('clientGroupID', id),
+            id,
+            must(config.push.url),
+            config.push.apiKey,
+          );
+
   const syncer = new Syncer(
     lc,
     config,
     viewSyncerFactory,
     mutagenFactory,
+    pusherFactory,
     parent,
   );
 


### PR DESCRIPTION
The end state is to put the pusher/mutator on its own websocket connection (https://github.com/rocicorp/mono/pull/3770).

That requires some refactoring of the client. Till that refactor is done (and so you all can use custom mutators while I'm on vacation), handle push messages over the existing websocket connection.