### PR TITLE
feat(zero-pg): move the `custom mutator` interfaces to `zql`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27231,6 +27231,16 @@
         "@opentelemetry/api": "^1.9.0"
       }
     },
+    "packages/pg-sdk": {
+      "version": "0.0.0",
+      "extraneous": true,
+      "dependencies": {
+        "vitest": "^2.1.5"
+      },
+      "devDependencies": {
+        "@faker-js/faker": "^9.4.0"
+      }
+    },
     "packages/replicache": {
       "version": "15.2.1",
       "license": "https://roci.dev/terms.html",
@@ -27788,6 +27798,16 @@
         "@esbuild/win32-arm64": "0.24.2",
         "@esbuild/win32-ia32": "0.24.2",
         "@esbuild/win32-x64": "0.24.2"
+      }
+    },
+    "packages/zero-pg": {
+      "version": "0.0.0",
+      "extraneous": true,
+      "dependencies": {
+        "vitest": "^2.1.5"
+      },
+      "devDependencies": {
+        "@faker-js/faker": "^9.4.0"
       }
     },
     "packages/zero-protocol": {

--- a/packages/z2s/tsconfig.json
+++ b/packages/z2s/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "lib": ["ESNext.Array", "ESNext", "DOM"]
+    "lib": ["ESNext.Array", "ESNext"]
   },
   "include": ["src/**/*.ts"]
 }

--- a/packages/zero-client/src/client/crud.ts
+++ b/packages/zero-client/src/client/crud.ts
@@ -1,4 +1,3 @@
-import type {Expand} from '../../../shared/src/expand.ts';
 import type {ReadonlyJSONObject} from '../../../shared/src/json.ts';
 import {must} from '../../../shared/src/must.ts';
 import {promiseVoid} from '../../../shared/src/resolved-promises.ts';
@@ -14,44 +13,16 @@ import {
   type UpsertOp,
 } from '../../../zero-protocol/src/push.ts';
 import type {Schema} from '../../../zero-schema/src/builder/schema-builder.ts';
-import type {
-  SchemaValueToTSType,
-  TableSchema,
-} from '../../../zero-schema/src/table-schema.ts';
+import type {TableSchema} from '../../../zero-schema/src/table-schema.ts';
 import type {IVMSourceBranch} from './ivm-source-repo.ts';
 import {toPrimaryKeyString} from './keys.ts';
 import type {MutatorDefs, WriteTransaction} from './replicache-types.ts';
-
-export type InsertValue<S extends TableSchema> = Expand<
-  PrimaryKeyFields<S> & {
-    [K in keyof S['columns'] as S['columns'][K] extends {optional: true}
-      ? K
-      : never]?: SchemaValueToTSType<S['columns'][K]> | undefined;
-  } & {
-    [K in keyof S['columns'] as S['columns'][K] extends {optional: true}
-      ? never
-      : K]: SchemaValueToTSType<S['columns'][K]>;
-  }
->;
-
-export type UpsertValue<S extends TableSchema> = InsertValue<S>;
-
-export type UpdateValue<S extends TableSchema> = Expand<
-  PrimaryKeyFields<S> & {
-    [K in keyof S['columns']]?:
-      | SchemaValueToTSType<S['columns'][K]>
-      | undefined;
-  }
->;
-
-export type DeleteID<S extends TableSchema> = Expand<PrimaryKeyFields<S>>;
-
-type PrimaryKeyFields<S extends TableSchema> = {
-  [K in Extract<
-    S['primaryKey'][number],
-    keyof S['columns']
-  >]: SchemaValueToTSType<S['columns'][K]>;
-};
+import type {
+  InsertValue,
+  UpdateValue,
+  UpsertValue,
+  DeleteID,
+} from '../../../zql/src/mutate/custom.ts';
 
 /**
  * This is the type of the generated mutate.<name>.<verb> function.

--- a/packages/zero-client/src/client/custom.test.ts
+++ b/packages/zero-client/src/client/custom.test.ts
@@ -1,17 +1,17 @@
 import {beforeEach, describe, expect, expectTypeOf, test} from 'vitest';
 import {schema} from '../../../zql/src/query/test/test-schemas.ts';
-import {
-  TransactionImpl,
-  type CustomMutatorDefs,
-  type MakeCustomMutatorInterfaces,
-  type Transaction,
-} from './custom.ts';
+import {TransactionImpl} from './custom.ts';
 import {zeroForTest} from './test-utils.ts';
 import {nanoid} from '../util/nanoid.ts';
 import {createDb} from './test/create-db.ts';
 import {IVMSourceRepo} from './ivm-source-repo.ts';
 import type {WriteTransaction} from './replicache-types.ts';
 import {must} from '../../../shared/src/must.ts';
+import type {
+  CustomMutatorDefs,
+  MakeCustomMutatorInterfaces,
+  Transaction,
+} from '../../../zql/src/mutate/custom.ts';
 type Schema = typeof schema;
 
 test('argument types are preserved on the generated mutator interface', () => {

--- a/packages/zero-client/src/client/custom.ts
+++ b/packages/zero-client/src/client/custom.ts
@@ -3,128 +3,24 @@ import type {Schema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import type {TableSchema} from '../../../zero-schema/src/table-schema.ts';
 import type {ReadonlyJSONValue} from '../../../shared/src/json.ts';
 import type {ClientID} from '../types/client-state.ts';
-import {
-  deleteImpl,
-  insertImpl,
-  updateImpl,
-  upsertImpl,
-  type DeleteID,
-  type InsertValue,
-  type UpdateValue,
-  type UpsertValue,
-} from './crud.ts';
+import {deleteImpl, insertImpl, updateImpl, upsertImpl} from './crud.ts';
 import type {WriteTransaction} from './replicache-types.ts';
 import type {IVMSourceBranch, IVMSourceRepo} from './ivm-source-repo.ts';
 import {newQuery} from '../../../zql/src/query/query-impl.ts';
 import type {Query} from '../../../zql/src/query/query.ts';
 import {ZeroContext} from './context.ts';
-/**
- * The shape which a user's custom mutator definitions must conform to.
- */
-export type CustomMutatorDefs<S extends Schema> = {
-  readonly [Table in keyof S['tables']]?: {
-    readonly [key: string]: CustomMutatorImpl<S>;
-  };
-} & {
-  // The user is not required to associate mutators with tables.
-  // Maybe that have some other arbitrary way to namespace.
-  [namespace: string]: {
-    [key: string]: CustomMutatorImpl<S>;
-  };
-};
-
-export type CustomMutatorImpl<S extends Schema> = (
-  tx: Transaction<S>,
-  // TODO: many args. See commit: 52657c2f934b4a458d628ea77e56ce92b61eb3c6 which did have many args.
-  // The issue being that it will be a protocol change to support varargs.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  args: any,
-) => Promise<void>;
-
-/**
- * The shape exposed on the `Zero.mutate` instance.
- * The signature of a custom mutator takes a `transaction` as its first arg
- * but the user does not provide this arg when calling the mutator.
- *
- * This utility strips the `tx` arg from the user's custom mutator signatures.
- */
-export type MakeCustomMutatorInterfaces<
-  S extends Schema,
-  MD extends CustomMutatorDefs<S>,
-> = {
-  readonly [Table in keyof MD]: {
-    readonly [P in keyof MD[Table]]: MakeCustomMutatorInterface<
-      S,
-      MD[Table][P]
-    >;
-  };
-};
-
-export type MakeCustomMutatorInterface<
-  S extends Schema,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  F,
-> = F extends (tx: Transaction<S>, ...args: infer Args) => void
-  ? (...args: Args) => void
-  : never;
-
-export type TransactionReason = 'optimistic' | 'rebase';
-
-/**
- * An instance of this is passed to custom mutator implementations and
- * allows reading and writing to the database and IVM at the head
- * at which the mutator is being applied.
- */
-export interface Transaction<S extends Schema> {
-  readonly clientID: ClientID;
-  /**
-   * The ID of the mutation that is being applied.
-   */
-  readonly mutationID: number;
-
-  /**
-   * The reason for the transaction.
-   */
-  readonly reason: TransactionReason;
-
-  readonly mutate: SchemaCRUD<S>;
-  readonly query: SchemaQuery<S>;
-}
-
-type SchemaCRUD<S extends Schema> = {
-  [Table in keyof S['tables']]: TableCRUD<S['tables'][Table]>;
-};
-
-export type TableCRUD<S extends TableSchema> = {
-  /**
-   * Writes a row if a row with the same primary key doesn't already exists.
-   * Non-primary-key fields that are 'optional' can be omitted or set to
-   * `undefined`. Such fields will be assigned the value `null` optimistically
-   * and then the default value as defined by the server.
-   */
-  insert: (value: InsertValue<S>) => Promise<void>;
-
-  /**
-   * Writes a row unconditionally, overwriting any existing row with the same
-   * primary key. Non-primary-key fields that are 'optional' can be omitted or
-   * set to `undefined`. Such fields will be assigned the value `null`
-   * optimistically and then the default value as defined by the server.
-   */
-  upsert: (value: UpsertValue<S>) => Promise<void>;
-
-  /**
-   * Updates a row with the same primary key. If no such row exists, this
-   * function does nothing. All non-primary-key fields can be omitted or set to
-   * `undefined`. Such fields will be left unchanged from previous value.
-   */
-  update: (value: UpdateValue<S>) => Promise<void>;
-
-  /**
-   * Deletes the row with the specified primary key. If no such row exists, this
-   * function does nothing.
-   */
-  delete: (id: DeleteID<S>) => Promise<void>;
-};
+import type {
+  CustomMutatorImpl,
+  DeleteID,
+  InsertValue,
+  SchemaCRUD,
+  SchemaQuery,
+  TableCRUD,
+  Transaction,
+  TransactionReason,
+  UpdateValue,
+  UpsertValue,
+} from '../../../zql/src/mutate/custom.ts';
 
 export class TransactionImpl implements Transaction<Schema> {
   constructor(
@@ -158,13 +54,6 @@ export class TransactionImpl implements Transaction<Schema> {
   readonly mutate: SchemaCRUD<Schema>;
   readonly query: SchemaQuery<Schema>;
 }
-
-type SchemaQuery<S extends Schema> = {
-  readonly [K in keyof S['tables'] & string]: Omit<
-    Query<S, K>,
-    'materialize' | 'preload'
-  >;
-};
 
 export function makeReplicacheMutator(
   mutator: CustomMutatorImpl<Schema>,

--- a/packages/zero-client/src/client/options.ts
+++ b/packages/zero-client/src/client/options.ts
@@ -2,7 +2,7 @@ import type {LogLevel} from '@rocicorp/logger';
 import type {StoreProvider} from '../../../replicache/src/kv/store.ts';
 import type {MaybePromise} from '../../../shared/src/types.ts';
 import type {Schema} from '../../../zero-schema/src/builder/schema-builder.ts';
-import type {CustomMutatorDefs} from './custom.ts';
+import type {CustomMutatorDefs} from '../../../zql/src/mutate/custom.ts';
 
 /**
  * Configuration for {@linkcode Zero}.

--- a/packages/zero-client/src/client/test-utils.ts
+++ b/packages/zero-client/src/client/test-utils.ts
@@ -25,7 +25,6 @@ import type {
 import {upstreamSchema} from '../../../zero-protocol/src/up.ts';
 import type {Schema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import * as ConnectionState from './connection-state-enum.ts';
-import type {CustomMutatorDefs} from './custom.ts';
 import type {LogOptions} from './log-options.ts';
 import type {ZeroOptions} from './options.ts';
 import {
@@ -36,6 +35,7 @@ import {
   getInternalReplicacheImplForTesting,
   onSetConnectionStateSymbol,
 } from './zero.ts';
+import type {CustomMutatorDefs} from '../../../zql/src/mutate/custom.ts';
 
 type ConnectionState = Enum<typeof ConnectionState>;
 type ErrorKind = Enum<typeof ErrorKind>;

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -40,7 +40,6 @@ import {
   table,
 } from '../../../zero-schema/src/builder/table-builder.ts';
 import * as ConnectionState from './connection-state-enum.ts';
-import type {CustomMutatorDefs} from './custom.ts';
 import type {DeleteClientsManager} from './delete-clients-manager.ts';
 import type {WSString} from './http-string.ts';
 import type {UpdateNeededReason, ZeroOptions} from './options.ts';
@@ -64,6 +63,7 @@ import {
   PULL_TIMEOUT_MS,
   RUN_LOOP_INTERVAL_MS,
 } from './zero.ts';
+import type {CustomMutatorDefs} from '../../../zql/src/mutate/custom.ts';
 
 let clock: sinon.SinonFakeTimers;
 const startTime = 1678829450000;

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -81,12 +81,7 @@ import {
   makeCRUDMutate,
   makeCRUDMutator,
 } from './crud.ts';
-import {
-  type CustomMutatorDefs,
-  type CustomMutatorImpl,
-  type MakeCustomMutatorInterfaces,
-  makeReplicacheMutator,
-} from './custom.ts';
+import {makeReplicacheMutator} from './custom.ts';
 import {DeleteClientsManager} from './delete-clients-manager.ts';
 import {shouldEnableAnalytics} from './enable-analytics.ts';
 import {
@@ -128,6 +123,11 @@ import {
 import {getServer} from './server-option.ts';
 import {version} from './version.ts';
 import {PokeHandler} from './zero-poke-handler.ts';
+import type {
+  CustomMutatorDefs,
+  CustomMutatorImpl,
+  MakeCustomMutatorInterfaces,
+} from '../../../zql/src/mutate/custom.ts';
 
 type ConnectionState = Enum<typeof ConnectionState>;
 type PingResult = Enum<typeof PingResult>;

--- a/packages/zero-client/src/mod.ts
+++ b/packages/zero-client/src/mod.ts
@@ -92,13 +92,12 @@ export type {
 } from '../../zql/src/query/expression.ts';
 export type {Query, Row} from '../../zql/src/query/query.ts';
 export type {ResultType, TypedView} from '../../zql/src/query/typed-view.ts';
+export type {DBMutator, TableMutator} from './client/crud.ts';
 export type {
-  DBMutator,
   DeleteID,
   InsertValue,
-  TableMutator,
   UpdateValue,
   UpsertValue,
-} from './client/crud.ts';
+} from '../../zql/src/mutate/custom.ts';
 export type {ZeroOptions} from './client/options.ts';
 export {Zero} from './client/zero.ts';

--- a/packages/zql/src/mutate/custom.ts
+++ b/packages/zql/src/mutate/custom.ts
@@ -1,0 +1,155 @@
+import type {Expand} from '../../../shared/src/expand.ts';
+import type {Schema} from '../../../zero-schema/src/builder/schema-builder.ts';
+import type {
+  SchemaValueToTSType,
+  TableSchema,
+} from '../../../zero-schema/src/table-schema.ts';
+import type {Query} from '../query/query.ts';
+
+type ClientID = string;
+
+/**
+ * The shape which a user's custom mutator definitions must conform to.
+ */
+export type CustomMutatorDefs<S extends Schema> = {
+  readonly [Table in keyof S['tables']]?: {
+    readonly [key: string]: CustomMutatorImpl<S>;
+  };
+} & {
+  // The user is not required to associate mutators with tables.
+  // Maybe that have some other arbitrary way to namespace.
+  [namespace: string]: {
+    [key: string]: CustomMutatorImpl<S>;
+  };
+};
+
+export type CustomMutatorImpl<S extends Schema> = (
+  tx: Transaction<S>,
+  // TODO: many args. See commit: 52657c2f934b4a458d628ea77e56ce92b61eb3c6 which did have many args.
+  // The issue being that it will be a protocol change to support varargs.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  args: any,
+) => Promise<void>;
+
+/**
+ * The shape exposed on the `Zero.mutate` instance.
+ * The signature of a custom mutator takes a `transaction` as its first arg
+ * but the user does not provide this arg when calling the mutator.
+ *
+ * This utility strips the `tx` arg from the user's custom mutator signatures.
+ */
+export type MakeCustomMutatorInterfaces<
+  S extends Schema,
+  MD extends CustomMutatorDefs<S>,
+> = {
+  readonly [Table in keyof MD]: {
+    readonly [P in keyof MD[Table]]: MakeCustomMutatorInterface<
+      S,
+      MD[Table][P]
+    >;
+  };
+};
+
+export type MakeCustomMutatorInterface<
+  S extends Schema,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  F,
+> = F extends (tx: Transaction<S>, ...args: infer Args) => void
+  ? (...args: Args) => void
+  : never;
+
+export type TransactionReason = 'optimistic' | 'rebase' | 'server';
+
+/**
+ * An instance of this is passed to custom mutator implementations and
+ * allows reading and writing to the database and IVM at the head
+ * at which the mutator is being applied.
+ */
+export interface Transaction<S extends Schema> {
+  readonly clientID: ClientID;
+  /**
+   * The ID of the mutation that is being applied.
+   */
+  readonly mutationID: number;
+
+  /**
+   * The reason for the transaction.
+   */
+  readonly reason: TransactionReason;
+
+  readonly mutate: SchemaCRUD<S>;
+  readonly query: SchemaQuery<S>;
+}
+
+export type SchemaCRUD<S extends Schema> = {
+  [Table in keyof S['tables']]: TableCRUD<S['tables'][Table]>;
+};
+
+export type TableCRUD<S extends TableSchema> = {
+  /**
+   * Writes a row if a row with the same primary key doesn't already exists.
+   * Non-primary-key fields that are 'optional' can be omitted or set to
+   * `undefined`. Such fields will be assigned the value `null` optimistically
+   * and then the default value as defined by the server.
+   */
+  insert: (value: InsertValue<S>) => Promise<void>;
+
+  /**
+   * Writes a row unconditionally, overwriting any existing row with the same
+   * primary key. Non-primary-key fields that are 'optional' can be omitted or
+   * set to `undefined`. Such fields will be assigned the value `null`
+   * optimistically and then the default value as defined by the server.
+   */
+  upsert: (value: UpsertValue<S>) => Promise<void>;
+
+  /**
+   * Updates a row with the same primary key. If no such row exists, this
+   * function does nothing. All non-primary-key fields can be omitted or set to
+   * `undefined`. Such fields will be left unchanged from previous value.
+   */
+  update: (value: UpdateValue<S>) => Promise<void>;
+
+  /**
+   * Deletes the row with the specified primary key. If no such row exists, this
+   * function does nothing.
+   */
+  delete: (id: DeleteID<S>) => Promise<void>;
+};
+
+export type SchemaQuery<S extends Schema> = {
+  readonly [K in keyof S['tables'] & string]: Omit<
+    Query<S, K>,
+    'materialize' | 'preload'
+  >;
+};
+
+export type DeleteID<S extends TableSchema> = Expand<PrimaryKeyFields<S>>;
+
+type PrimaryKeyFields<S extends TableSchema> = {
+  [K in Extract<
+    S['primaryKey'][number],
+    keyof S['columns']
+  >]: SchemaValueToTSType<S['columns'][K]>;
+};
+
+export type InsertValue<S extends TableSchema> = Expand<
+  PrimaryKeyFields<S> & {
+    [K in keyof S['columns'] as S['columns'][K] extends {optional: true}
+      ? K
+      : never]?: SchemaValueToTSType<S['columns'][K]> | undefined;
+  } & {
+    [K in keyof S['columns'] as S['columns'][K] extends {optional: true}
+      ? never
+      : K]: SchemaValueToTSType<S['columns'][K]>;
+  }
+>;
+
+export type UpsertValue<S extends TableSchema> = InsertValue<S>;
+
+export type UpdateValue<S extends TableSchema> = Expand<
+  PrimaryKeyFields<S> & {
+    [K in keyof S['columns']]?:
+      | SchemaValueToTSType<S['columns'][K]>
+      | undefined;
+  }
+>;


### PR DESCRIPTION
Custom mutator interfaces are required on the client and server. They also depend on the `Query` type, hence the reason to move them to the `zql` package.

@aboodman - this adds a "server" transaction reason. I considered "authoritative" but, while that is accurate, it is not immediately clear what it means to a new user.

```ts
export type TransactionReason = 'optimistic' | 'rebase' | 'server';
```

since `tx` could be a server tx or a client tx in the case where the user shares their mutator code with client and server.