### PR TITLE
feat(zero-cache): avoid applying application permissions to internal queries

### DIFF
--- a/packages/zero-cache/src/auth/read-authorizer.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.ts
@@ -28,8 +28,11 @@ export function transformAndHashQuery(
   query: AST,
   permissionRules: PermissionsConfig | null,
   authData: JWTPayload | undefined,
+  internalQuery: boolean | null | undefined,
 ): TransformedAndHashed {
-  const transformed = transformQuery(query, permissionRules, authData);
+  const transformed = internalQuery
+    ? query // application permissions do not apply to internal queries
+    : transformQuery(query, permissionRules, authData);
   return transformed
     ? {
         query: transformed,

--- a/packages/zero-cache/src/scripts/transform-query.ts
+++ b/packages/zero-cache/src/scripts/transform-query.ts
@@ -36,13 +36,14 @@ const cvrDB = pgClient(
 );
 
 const rows =
-  await cvrDB`select "clientAST" from "cvr"."queries" where "queryHash" = ${must(
+  await cvrDB`select "clientAST", "internal" from "cvr"."queries" where "queryHash" = ${must(
     config.debug.hash,
   )} limit 1;`;
 
 lc.info?.(
   JSON.stringify(
-    transformAndHashQuery(rows[0].clientAST, permissions, {}).query,
+    transformAndHashQuery(rows[0].clientAST, permissions, {}, rows[0].internal)
+      .query,
   ),
 );
 

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -612,6 +612,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           ast,
           must(this.#permissions).permissions,
           this.#authData,
+          query.internal,
         );
       assert(
         transformedAst !== undefined && newTransformationHash !== undefined,
@@ -660,6 +661,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           q.ast,
           must(this.#permissions).permissions,
           this.#authData,
+          q.internal,
         );
         assert(
           query !== undefined && transformationHash !== undefined,


### PR DESCRIPTION
This never mattered before, but will matter when permissions are flipped to disallow by default.