### PR TITLE
fix(zero-build-schema): exit with error

### DIFF
--- a/packages/zero/src/build-schema.ts
+++ b/packages/zero/src/build-schema.ts
@@ -2,3 +2,4 @@
 /* eslint-disable no-console */
 console.warn('zero-build-schema is deprecated.\n');
 console.info('Run `npx zero-deploy-permissions` to deploy permissions.\n');
+process.exit(-1);


### PR DESCRIPTION
Exit the deprecated `npx zero-build-schema` with an error code so that it (more likely) disrupt any deployment process that uses it.