### PR TITLE
fix(zero-deploy-permissions): allow zero-cache-dev to work for custom upstreams

### DIFF
--- a/packages/zero-cache/src/scripts/deploy-permissions.ts
+++ b/packages/zero-cache/src/scripts/deploy-permissions.ts
@@ -143,6 +143,11 @@ if (config.output.file) {
     config.output.file,
     config.output.format,
   );
+} else if (config.upstream.type !== 'pg') {
+  lc.warn?.(
+    `Permissions deployment is not supported for ${config.upstream.type} upstreams`,
+  );
+  process.exit(-1);
 } else if (config.upstream.db) {
   await deployPermissions(config.upstream.db, permissions, config.force);
 } else {

--- a/packages/zero-cache/src/scripts/permissions.ts
+++ b/packages/zero-cache/src/scripts/permissions.ts
@@ -24,13 +24,14 @@ export const deployPermissionsOptions = {
 
   upstream: {
     db: {
-      ...zeroOptions.upstream.db,
       type: v.string().optional(),
       desc: [
         `The upstream Postgres database to deploy permissions to.`,
         `This is ignored if an {bold output-file} is specified.`,
       ],
     },
+
+    type: zeroOptions.upstream.type,
   },
 
   output: {

--- a/packages/zero/src/zero-cache-dev.ts
+++ b/packages/zero/src/zero-cache-dev.ts
@@ -32,6 +32,10 @@ function log(msg: string) {
   console.log(chalk.green('> ' + msg));
 }
 
+function logWarn(msg: string) {
+  console.log(chalk.yellow('> ' + msg));
+}
+
 function logError(msg: string) {
   console.error(chalk.red('> ' + msg));
 }
@@ -74,6 +78,12 @@ async function main() {
   });
 
   async function deployPermissions(): Promise<boolean> {
+    if (config.upstream.type !== 'pg') {
+      logWarn(
+        `Skipping permissions deployment for ${config.upstream.type} upstream`,
+      );
+      return true;
+    }
     permissionsProcess?.removeAllListeners('exit');
     await killProcess(permissionsProcess);
     permissionsProcess = undefined;


### PR DESCRIPTION
Have `zero-deploy-permissions` error for custom upstreams, and `zero-cache-dev` skip permissions deployment for them.

@cbnsndwch 