### PR TITLE
feat(zero-deploy-permissions): add "json" and "pretty" output formats

### DIFF
--- a/packages/zero-cache/src/scripts/deploy-permissions.ts
+++ b/packages/zero-cache/src/scripts/deploy-permissions.ts
@@ -124,16 +124,16 @@ async function deployPermissions(
 async function writePermissionsFile(
   perms: PermissionsConfig,
   file: string,
-  format: 'sql' | 'json',
+  format: 'sql' | 'json' | 'pretty',
 ) {
   const contents =
     format === 'sql'
       ? `UPDATE zero.permissions SET permissions = ${literal(
           JSON.stringify(perms),
         )};`
-      : JSON.stringify(perms, null, 2);
+      : JSON.stringify(perms, null, format === 'pretty' ? 2 : 0);
   await writeFile(file, contents);
-  lc.info?.(`Wrote permissions ${format} to ${config.output.file}`);
+  lc.info?.(`Wrote ${format} permissions to ${config.output.file}`);
 }
 
 const permissions = await loadPermissions(lc, config.schema.path);

--- a/packages/zero-cache/src/scripts/permissions.ts
+++ b/packages/zero-cache/src/scripts/permissions.ts
@@ -43,14 +43,17 @@ export const deployPermissionsOptions = {
     },
 
     format: {
-      type: v.union(v.literal('sql'), v.literal('json')).default('sql'),
+      type: v
+        .union(v.literal('sql'), v.literal('json'), v.literal('pretty'))
+        .default('sql'),
       desc: [
         `The desired format of the output file.`,
         ``,
         `A {bold sql} file can be executed via "psql -f <file.sql>", or "\\\\i <file.sql>"`,
         `from within the psql console, or copied and pasted into a migration script.`,
         ``,
-        `The {bold json} format is available for general debugging.`,
+        `The {bold json} and {bold pretty} formats are available for non-pg backends`,
+        `and general debugging.`,
       ],
     },
   },


### PR DESCRIPTION
* `json`: one-line json, useful for custom backends
* `pretty`: indented json for debugging

@cbnsndwch 