### PR TITLE
feat(zero-cache): deprecate protocolVersion from the Permissions format

### DIFF
--- a/packages/zero-cache/src/auth/load-permissions.test.ts
+++ b/packages/zero-cache/src/auth/load-permissions.test.ts
@@ -52,7 +52,7 @@ describe('auth/load-permissions', () => {
     setPermissions(`{"protocolVersion": 108}`);
     expect(() => loadPermissions(lc, db)).toThrowErrorMatchingInlineSnapshot(
       `
-      [Error: Could not parse upstream permissions: '{"protocolVersion": 108}...'.
+      [Error: Could not parse upstream permissions: '{"protocolVersion": 108}'.
       This may happen if Permissions with a new internal format are deployed before the supporting server has been fully rolled out.]
     `,
     );
@@ -62,7 +62,17 @@ describe('auth/load-permissions', () => {
     setPermissions(`I'm not JSON`);
     expect(() => loadPermissions(lc, db)).toThrowErrorMatchingInlineSnapshot(
       `
-      [Error: Could not parse upstream permissions: 'I'm not JSON...'.
+      [Error: Could not parse upstream permissions: 'I'm not JSON'.
+      This may happen if Permissions with a new internal format are deployed before the supporting server has been fully rolled out.]
+    `,
+    );
+  });
+
+  test('invalid long permissions', () => {
+    setPermissions(`{"protocolVersion": 108, "foo":"ba${'a'.repeat(1000)}r"}`);
+    expect(() => loadPermissions(lc, db)).toThrowErrorMatchingInlineSnapshot(
+      `
+      [Error: Could not parse upstream permissions: '{"protocolVersion": 108, "foo":"baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...'.
       This may happen if Permissions with a new internal format are deployed before the supporting server has been fully rolled out.]
     `,
     );

--- a/packages/zero-cache/src/auth/load-permissions.test.ts
+++ b/packages/zero-cache/src/auth/load-permissions.test.ts
@@ -1,10 +1,7 @@
 import {beforeEach, describe, expect, test} from 'vitest';
 import {h128} from '../../../shared/src/hash.ts';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
-import {
-  MIN_SERVER_SUPPORTED_PERMISSIONS_PROTOCOL,
-  PROTOCOL_VERSION,
-} from '../../../zero-protocol/src/protocol-version.ts';
+import {PROTOCOL_VERSION} from '../../../zero-protocol/src/protocol-version.ts';
 import type {PermissionsConfig} from '../../../zero-schema/src/compiled-permissions.ts';
 import {Database} from '../../../zqlite/src/db.ts';
 import {StatementRunner} from '../db/statements.ts';
@@ -51,38 +48,12 @@ describe('auth/load-permissions', () => {
     `);
   });
 
-  test('permissions version ahead', () => {
-    setPermissions({
-      protocolVersion: PROTOCOL_VERSION + 1,
-      tables: {},
-    });
-    expect(() => loadPermissions(lc, db)).toThrowErrorMatchingInlineSnapshot(
-      `
-      [Error: This server supports Permissions protocol versions v4 through v5 and cannot read v6.
-      Please deploy the latest server.]
-    `,
-    );
-  });
-
-  test('permissions version behind', () => {
-    setPermissions({
-      protocolVersion: MIN_SERVER_SUPPORTED_PERMISSIONS_PROTOCOL - 1,
-      tables: {},
-    });
-    expect(() => loadPermissions(lc, db)).toThrowErrorMatchingInlineSnapshot(
-      `
-      [Error: This server supports Permissions protocol versions v4 through v5 and no longer supports v3.
-      Run 'npx zero-deploy-permissions' to deploy Permissions in the latest format.]
-    `,
-    );
-  });
-
   test('invalid permissions', () => {
     setPermissions(`{"protocolVersion": 108}`);
     expect(() => loadPermissions(lc, db)).toThrowErrorMatchingInlineSnapshot(
       `
-      [Error: This server supports Permissions protocol versions v4 through v5.
-      Could not parse upstream permissions at v108]
+      [Error: Could not parse upstream permissions: '{"protocolVersion": 108}...'.
+      This may happen if Permissions with a new internal format are deployed before the supporting server has been fully rolled out.]
     `,
     );
   });
@@ -91,8 +62,8 @@ describe('auth/load-permissions', () => {
     setPermissions(`I'm not JSON`);
     expect(() => loadPermissions(lc, db)).toThrowErrorMatchingInlineSnapshot(
       `
-      [Error: This server supports Permissions protocol versions v4 through v5.
-      Could not parse upstream permissions: I'm not JSON]
+      [Error: Could not parse upstream permissions: 'I'm not JSON...'.
+      This may happen if Permissions with a new internal format are deployed before the supporting server has been fully rolled out.]
     `,
     );
   });

--- a/packages/zero-cache/src/auth/load-permissions.ts
+++ b/packages/zero-cache/src/auth/load-permissions.ts
@@ -9,6 +9,7 @@ import type {TableSchema} from '../../../zero-schema/src/table-schema.ts';
 import type {Database} from '../../../zqlite/src/db.ts';
 import {computeZqlSpecs} from '../db/lite-tables.ts';
 import type {StatementRunner} from '../db/statements.ts';
+import {elide} from '../types/strings.ts';
 
 export type LoadedPermissions = {
   permissions: PermissionsConfig | null;
@@ -40,7 +41,7 @@ export function loadPermissions(
     // TODO: Plumb the --server-version and include in error message.
     throw new Error(
       `Could not parse upstream permissions: ` +
-        `'${String(permissions).substring(0, 100)}...'.\n` +
+        `'${elide(String(permissions), 100)}'.\n` +
         `This may happen if Permissions with a new internal format are ` +
         `deployed before the supporting server has been fully rolled out.`,
       {cause: e},

--- a/packages/zero-cache/src/auth/load-permissions.ts
+++ b/packages/zero-cache/src/auth/load-permissions.ts
@@ -1,9 +1,5 @@
 import type {LogContext} from '@rocicorp/logger';
 import * as v from '../../../shared/src/valita.ts';
-import {
-  MIN_SERVER_SUPPORTED_PERMISSIONS_PROTOCOL,
-  PROTOCOL_VERSION,
-} from '../../../zero-protocol/src/protocol-version.ts';
 import type {Schema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import {
   permissionsConfigSchema,
@@ -18,10 +14,6 @@ export type LoadedPermissions = {
   permissions: PermissionsConfig | null;
   hash: string | null;
 };
-
-const errorPreamble =
-  `This server supports Permissions protocol versions v` +
-  `${MIN_SERVER_SUPPORTED_PERMISSIONS_PROTOCOL} through v${PROTOCOL_VERSION}`;
 
 export function loadPermissions(
   lc: LogContext,
@@ -45,24 +37,13 @@ export function loadPermissions(
     obj = JSON.parse(permissions);
     parsed = v.parse(obj, permissionsConfigSchema);
   } catch (e) {
+    // TODO: Plumb the --server-version and include in error message.
     throw new Error(
-      `${errorPreamble}.\nCould not parse upstream permissions${
-        obj ? ` at v${obj.protocolVersion}` : `: ${permissions}`
-      }`,
+      `Could not parse upstream permissions: ` +
+        `'${String(permissions).substring(0, 100)}...'.\n` +
+        `This may happen if Permissions with a new internal format are ` +
+        `deployed before the supporting server has been fully rolled out.`,
       {cause: e},
-    );
-  }
-  if (parsed.protocolVersion > PROTOCOL_VERSION) {
-    throw new Error(
-      `${errorPreamble} and cannot read ` +
-        `v${parsed.protocolVersion}.\nPlease deploy the latest server.`,
-    );
-  }
-  if (parsed.protocolVersion < MIN_SERVER_SUPPORTED_PERMISSIONS_PROTOCOL) {
-    throw new Error(
-      `${errorPreamble} and no longer supports ` +
-        `v${parsed.protocolVersion}.\nRun 'npx zero-deploy-permissions' ` +
-        `to deploy Permissions in the latest format.`,
     );
   }
   lc.debug?.(`Loaded permissions (hash: ${hash})`);

--- a/packages/zero-cache/src/types/strings.test.ts
+++ b/packages/zero-cache/src/types/strings.test.ts
@@ -1,0 +1,20 @@
+import {describe, expect, test} from 'vitest';
+import {elide} from './strings.ts';
+
+describe('types/strings', () => {
+  test('elide byte count', () => {
+    const elidedASCII = elide('fo' + 'o'.repeat(150), 123);
+    expect(elidedASCII).toMatchInlineSnapshot(
+      `"fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo..."`,
+    );
+    expect(elidedASCII).toHaveLength(123);
+
+    const elidedFullWidth = elide('こんにちは' + 'あ'.repeat(150), 123);
+    expect(elidedFullWidth).toMatchInlineSnapshot(
+      `"こんにちはあああああああああああああああああああああああああああああああああああ..."`,
+    );
+    expect(
+      new TextEncoder().encode(elidedFullWidth).length,
+    ).toBeLessThanOrEqual(123);
+  });
+});

--- a/packages/zero-cache/src/types/strings.ts
+++ b/packages/zero-cache/src/types/strings.ts
@@ -1,0 +1,11 @@
+export function elide(val: string, maxBytes: number) {
+  const encoder = new TextEncoder();
+  if (encoder.encode(val).length <= maxBytes) {
+    return val;
+  }
+  val = val.substring(0, maxBytes - 3);
+  while (encoder.encode(val + '...').length > maxBytes) {
+    val = val.substring(0, val.length - 1);
+  }
+  return val + '...';
+}

--- a/packages/zero-cache/src/types/ws.ts
+++ b/packages/zero-cache/src/types/ws.ts
@@ -1,5 +1,6 @@
 import type {LogContext} from '@rocicorp/logger';
 import type {WebSocket} from 'ws';
+import {elide} from './strings.ts';
 
 // https://github.com/Luka967/websocket-close-codes
 export const PROTOCOL_ERROR = 1002;
@@ -16,19 +17,8 @@ export function closeWithError(
   const endpoint = ws.url ?? 'client';
   const errMsg = String(err);
   lc.warn?.(`closing connection to ${endpoint} with error`, errMsg);
-  ws.close(code, truncate(errMsg));
-}
 
-// close messages must be less than or equal to 123 bytes:
-// https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close#reason
-function truncate(val: string, maxBytes = 123) {
-  const encoder = new TextEncoder();
-  if (encoder.encode(val).length <= maxBytes) {
-    return val;
-  }
-  val = val.substring(0, maxBytes - 3);
-  while (encoder.encode(val + '...').length > maxBytes) {
-    val = val.substring(0, val.length - 1);
-  }
-  return val + '...';
+  // close messages must be less than or equal to 123 bytes:
+  // https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close#reason
+  ws.close(code, elide(errMsg, 123));
 }

--- a/packages/zero-schema/src/compiled-permissions.ts
+++ b/packages/zero-schema/src/compiled-permissions.ts
@@ -21,7 +21,8 @@ const assetSchema = v.object({
 export type AssetPermissions = v.Infer<typeof assetSchema>;
 
 export const permissionsConfigSchema = v.object({
-  protocolVersion: v.number(),
+  // TODO: Remove protocolVersion
+  protocolVersion: v.number().optional(),
   tables: v.record(
     v.object({
       row: assetSchema.optional(),


### PR DESCRIPTION
Using the (wire + AST) `protocolVersion` in the Permissions protocol will be too sensitive. For the percentage of users that don't bother to wait for server deployments to complete before deploying new permissions (e.g. zbugs), this will unnecessarily result in errors every time we change the wire-protocol.

Because the Permissions only relies on the AST schema, consider the data "supported" if it (strictly) parses with its valita schema. This means that semantic changes must be accompanied by a change in the AST format, which unsupporting code will correctly fail to parse. This should pretty much always be the case; we just have to never, e.g. change the meaning of an existing field or something like that.