### PR TITLE
feat(prod): wait until view-syncers are deployed

### DIFF
--- a/prod/sst/package-lock.json
+++ b/prod/sst/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "dotenv": "^16.4.7",
-        "sst": "3.6.7"
+        "sst": "3.8.9"
       },
       "devDependencies": {
         "@types/aws-lambda": "8.10.147",
@@ -113,9 +113,9 @@
       "link": true
     },
     "node_modules/sst": {
-      "version": "3.6.7",
-      "resolved": "https://registry.npmjs.org/sst/-/sst-3.6.7.tgz",
-      "integrity": "sha512-Ja0NlhOkRHZ7JbytEkk3f+Dk5Cu63UVqnMWPYXPbu1jgOIwOGwbBHwQketmX2aBjl1rYyj7RYuxt4FsZ2YMPjQ==",
+      "version": "3.8.9",
+      "resolved": "https://registry.npmjs.org/sst/-/sst-3.8.9.tgz",
+      "integrity": "sha512-4gcCaHy6v28+NFALic5PwrVMNHDIaCU00Mw6yjbnz8yczY6OaVrWY5YucdQaynOf7u544VNVe8k5/1c1/5Zk8Q==",
       "dependencies": {
         "aws4fetch": "^1.0.18",
         "jose": "5.2.3",
@@ -125,17 +125,17 @@
         "sst": "bin/sst.mjs"
       },
       "optionalDependencies": {
-        "sst-darwin-arm64": "3.6.7",
-        "sst-darwin-x64": "3.6.7",
-        "sst-linux-arm64": "3.6.7",
-        "sst-linux-x64": "3.6.7",
-        "sst-linux-x86": "3.6.7"
+        "sst-darwin-arm64": "3.8.9",
+        "sst-darwin-x64": "3.8.9",
+        "sst-linux-arm64": "3.8.9",
+        "sst-linux-x64": "3.8.9",
+        "sst-linux-x86": "3.8.9"
       }
     },
     "node_modules/sst-darwin-arm64": {
-      "version": "3.6.7",
-      "resolved": "https://registry.npmjs.org/sst-darwin-arm64/-/sst-darwin-arm64-3.6.7.tgz",
-      "integrity": "sha512-sibkNjNUZVbSo6Ag7y3sxFkNOrq/blJ+w4rakaufFq5wK6sgePMF7DLNoUfhmuNiQAB7ZluCCeVI6WYGQtW6qw==",
+      "version": "3.8.9",
+      "resolved": "https://registry.npmjs.org/sst-darwin-arm64/-/sst-darwin-arm64-3.8.9.tgz",
+      "integrity": "sha512-2NZfaG0NkxYgRtgesNHNvt3ebGk6SSFig9CUORSq6sCpjvhPzhNJFM5SaNqQtuxvOzuePhQ1KI+eFsdo0kjbdw==",
       "cpu": [
         "arm64"
       ],
@@ -145,9 +145,9 @@
       ]
     },
     "node_modules/sst-darwin-x64": {
-      "version": "3.6.7",
-      "resolved": "https://registry.npmjs.org/sst-darwin-x64/-/sst-darwin-x64-3.6.7.tgz",
-      "integrity": "sha512-CfwYN8hILL8ErA2p/NhX3esJ6+pxIFDIQprysLBWSp2lXxrJetPjMZGrq4vvm9pCNlySBuhoiH4/FCxfZhvgww==",
+      "version": "3.8.9",
+      "resolved": "https://registry.npmjs.org/sst-darwin-x64/-/sst-darwin-x64-3.8.9.tgz",
+      "integrity": "sha512-Qwcrn/r3pv0+zOnT0eXP89Tv7/HdMfJd6IdPnM1tjiwSy997XkETyJu/HgCpDcG3t2gjgJQcuIN1T56DueVCeg==",
       "cpu": [
         "x64"
       ],
@@ -157,9 +157,9 @@
       ]
     },
     "node_modules/sst-linux-arm64": {
-      "version": "3.6.7",
-      "resolved": "https://registry.npmjs.org/sst-linux-arm64/-/sst-linux-arm64-3.6.7.tgz",
-      "integrity": "sha512-gUFNTUtolZXB/LDO6p8JMa5fpY3bUeddOsMXDYhiRTwiIBsuJpld1nEgd0DkGxLMq6VYvks1DO8Bv7mJApxM4A==",
+      "version": "3.8.9",
+      "resolved": "https://registry.npmjs.org/sst-linux-arm64/-/sst-linux-arm64-3.8.9.tgz",
+      "integrity": "sha512-bhHfNn7y+YUxxOl0vKgncYMoltBClQt/rn2SewBxGKu4iJHRNQYaNCfhnx8wOmshH1fm8cgKM+vV24jEu+MkkA==",
       "cpu": [
         "arm64"
       ],
@@ -169,9 +169,9 @@
       ]
     },
     "node_modules/sst-linux-x64": {
-      "version": "3.6.7",
-      "resolved": "https://registry.npmjs.org/sst-linux-x64/-/sst-linux-x64-3.6.7.tgz",
-      "integrity": "sha512-yjOwTW631UKSozd88MWxXmNU+J0WnishKEKJltwvF4awxh9JD8MFRGSsQAndKZabPFJgFoAi6WSvlcGS/qwe6w==",
+      "version": "3.8.9",
+      "resolved": "https://registry.npmjs.org/sst-linux-x64/-/sst-linux-x64-3.8.9.tgz",
+      "integrity": "sha512-MxgHb1R4rGj7Uo/EeQkZWUhCwIH0gCHaHNI4PS8OU/QO3fIMXcWVz/zDF0MtEsH8khTka8NUziaLYkmSKaBlkQ==",
       "cpu": [
         "x64"
       ],
@@ -181,9 +181,9 @@
       ]
     },
     "node_modules/sst-linux-x86": {
-      "version": "3.6.7",
-      "resolved": "https://registry.npmjs.org/sst-linux-x86/-/sst-linux-x86-3.6.7.tgz",
-      "integrity": "sha512-F1G7LrTzlC7P2LyVmI2DSR1q6GfpBfqbZ/RyTzxRICBrnwvgfB1xkIH72BEOzqvdfhwgc5Liw8Zic03wCwKDJA==",
+      "version": "3.8.9",
+      "resolved": "https://registry.npmjs.org/sst-linux-x86/-/sst-linux-x86-3.8.9.tgz",
+      "integrity": "sha512-EH7ukIaLj5BXrJQKxV7oYb3kduIbykMkWI3bgPD3mBu+UksT8pE7UY0Awb9p8lkLW90ZYaPv03CiOkvGvXJeDQ==",
       "cpu": [
         "x86"
       ],

--- a/prod/sst/package.json
+++ b/prod/sst/package.json
@@ -12,7 +12,7 @@
   "description": "",
   "dependencies": {
     "dotenv": "^16.4.7",
-    "sst": "3.6.7"
+    "sst": "3.8.9"
   },
   "devDependencies": {
     "@types/aws-lambda": "8.10.147",

--- a/prod/sst/sst.config.ts
+++ b/prod/sst/sst.config.ts
@@ -174,11 +174,13 @@ export default $config({
           maxCapacity: 10,
         },
       },
+      // Make SST wait for health checks before considering the service "deployed".
+      wait: true,
     });
 
     // Deploy permissions after the view-syncer has been fully deployed.
-    viewSyncer.url.apply((url) => {
-      console.info(`Finished deploying view-syncers to ${url}`);
+    viewSyncer.nodes.taskDefinition.apply(() => {
+      console.info(`Finished deploying view-syncers`);
       execSync(
         `npx zero-deploy-permissions --schema-path ../../apps/zbugs/schema.ts`,
         { cwd: "../../packages/zero/" },


### PR DESCRIPTION
Update sst so that we can use the new `wait: true` fanciness.

Also use the `taskDefinition` output instead of the `url` output, as the latter comes from the loadbalancer rather than the view-syncer service.