### PR TITLE
feat(prod): fully migrate to SST for permissions deployment

### DIFF
--- a/.github/workflows/sst-prod-deploy.yml
+++ b/.github/workflows/sst-prod-deploy.yml
@@ -80,7 +80,3 @@ jobs:
           cd prod/sst
           npm install
           npx sst deploy --stage production
-      - name: Deploy Permissions
-        run: |
-          cd packages/zero
-          npx tsx src/deploy-permissions.ts --schema-path ../../apps/zbugs/schema.ts --upstream-db ${{ secrets.PROD_ZERO_UPSTREAM_DB }}

--- a/.github/workflows/sst-sandbox-deploy.yml
+++ b/.github/workflows/sst-sandbox-deploy.yml
@@ -80,7 +80,3 @@ jobs:
           cd prod/sst
           npm install
           npx sst deploy --stage sandbox
-      - name: Deploy Permissions
-        run: |
-          cd packages/zero
-          npx tsx src/deploy-permissions.ts --schema-path ../../apps/zbugs/schema.ts --upstream-db ${{ secrets.SANDBOX_ZERO_UPSTREAM_DB }}

--- a/prod/sst/sst.config.ts
+++ b/prod/sst/sst.config.ts
@@ -3,6 +3,8 @@
 // Load .env file
 require("dotenv").config();
 
+import { join } from "node:path";
+
 export default $config({
   app(input) {
     return {
@@ -167,8 +169,22 @@ export default $config({
           maxCapacity: 10,
         },
       },
-      // Make SST wait for health checks before considering the service "deployed".
-      wait: true,
+      // Set this to `true` to make SST wait for the view-syncer to be deployed
+      // before proceeding (to permissions deployment, etc.). This makes the deployment
+      // take a lot longer and is only necessary if there is an AST format change.
+      wait: false,
     });
+
+    new command.local.Command(
+      "zero-deploy-permissions",
+      {
+        // Pulumi operates with cwd at the package root.
+        dir: join(process.cwd(), "../../packages/zero/"),
+        create: `npx zero-deploy-permissions --schema-path ../../apps/zbugs/schema.ts`,
+      },
+      {
+        dependsOn: viewSyncer,
+      },
+    );
   },
 });


### PR DESCRIPTION
Use SST for deploying permissions, removing the redundant GitHub actions.

Also, set `Service.wait` to `false` by default to keep deployments fast in the common case.

We only need to set them to `true` for the occasional protocol / AST version upgrade, which we can do manually (in the same PR as the protocol change).