### PR TITLE
fix(zero-cache): handle NULL characters in JSON columns

### DIFF
--- a/packages/zero-cache/src/integration/integration.pg-test.ts
+++ b/packages/zero-cache/src/integration/integration.pg-test.ts
@@ -36,6 +36,9 @@ import {stream, type Sink} from '../types/streams.ts';
 // Adjust to debug.
 const LOG_LEVEL: LogLevel = 'error';
 
+// Note: The NULL unicode character \u0000 is specifically used to verify
+//       end-to-end JSON compatibility. In particular, any intermediate
+//       JSONB storage of row contents would not be able to handle it.
 const INITIAL_PG_SETUP = `
       CREATE TABLE foo(
         id TEXT PRIMARY KEY, 
@@ -51,7 +54,7 @@ const INITIAL_PG_SETUP = `
           'bar',
           'baz',
           true,
-          '{"foo":"bar"}',
+          '{"foo":"bar\\u0000"}',
           'true',
           '123',
           '"string"');
@@ -114,7 +117,7 @@ const INITIAL_CUSTOM_SETUP: ChangeStreamMessage[] = [
         id: 'bar',
         ['far_id']: 'baz',
         b: true,
-        j1: {foo: 'bar'},
+        j1: {foo: 'bar\u0000'},
         j2: true,
         j3: 123,
         j4: 'string',
@@ -641,7 +644,7 @@ describe('integration', {timeout: 30000}, () => {
                 id: 'bar',
                 ['far_id']: 'baz',
                 b: true,
-                j1: {foo: 'bar'},
+                j1: {foo: 'bar\u0000'},
                 j2: true,
                 j3: 123,
                 j4: 'string',
@@ -730,7 +733,7 @@ describe('integration', {timeout: 30000}, () => {
                 ['far_id']: 'not_baz',
                 id: 'bar',
                 j1: {
-                  foo: 'bar',
+                  foo: 'bar\u0000',
                 },
                 j2: true,
                 j3: 123,

--- a/packages/zero-cache/src/services/change-source/pg/sync-schema.ts
+++ b/packages/zero-cache/src/services/change-source/pg/sync-schema.ts
@@ -29,7 +29,7 @@ export async function initSyncSchema(
       migrateSchema: () => {
         throw new AutoResetSignal('upgrading replica to new schema');
       },
-      minSafeVersion: 4,
+      minSafeVersion: 1,
     },
   };
 

--- a/packages/zero-cache/src/services/change-streamer/schema/init.ts
+++ b/packages/zero-cache/src/services/change-streamer/schema/init.ts
@@ -56,9 +56,18 @@ export async function initChangeStreamerSchema(
     },
   };
 
+  const migrateV3ToV4 = {
+    migrateSchema: async (_: LogContext, db: PostgresTransaction) => {
+      await db`
+      ALTER TABLE ${db(schema)}."changeLog" ALTER "change" TYPE JSON;
+      `;
+    },
+  };
+
   const schemaVersionMigrationMap: IncrementalMigrationMap = {
     2: {migrateSchema: migrateV1toV2},
     3: migrateV2ToV3,
+    4: migrateV3ToV4,
   };
 
   await runSchemaMigrations(

--- a/packages/zero-cache/src/services/change-streamer/schema/tables.ts
+++ b/packages/zero-cache/src/services/change-streamer/schema/tables.ts
@@ -29,11 +29,14 @@ export type ChangeLogEntry = {
 };
 
 function createChangeLogTable(shardID: string) {
+  // Note: The "change" column used to be JSONB, but that was problematic in that
+  // it does not handle the NULL unicode character.
+  // https://vladimir.varank.in/notes/2021/01/you-dont-insert-unicode-null-character-as-postgres-jsonb/
   return `
   CREATE TABLE ${schema(shardID)}."changeLog" (
     watermark  TEXT,
     pos        INT8,
-    change     JSONB NOT NULL,
+    change     JSON NOT NULL,
     precommit  TEXT,  -- Only exists on commit entries. Purely for debugging.
     PRIMARY KEY (watermark, pos)
   );


### PR DESCRIPTION
Postgres supports encoding NULL unicode characters in JSON columns, but not in JSONB columns.

https://vladimir.varank.in/notes/2021/01/you-dont-insert-unicode-null-character-as-postgres-jsonb/

Change the datatype of the changeLog to store messages in JSON instead of JSONB so that it can properly ferry these values.

https://discord.com/channels/830183651022471199/1339712194539163669/1339730002966610015