### PR TITLE
feat!(zql): `query.run` now returns a promise

### DIFF
--- a/packages/z2s/src/compiler.pg-test.ts
+++ b/packages/z2s/src/compiler.pg-test.ts
@@ -240,7 +240,7 @@ describe('compiling ZQL to SQL', () => {
       sqlQuery.text,
       sqlQuery.values as JSONValue[],
     );
-    expect(query.run()).toEqual(pgResult);
+    expect(await query.run()).toEqual(pgResult);
   });
 
   test('multiple where clauses', async () => {
@@ -252,7 +252,7 @@ describe('compiling ZQL to SQL', () => {
       sqlQuery.text,
       sqlQuery.values as JSONValue[],
     );
-    expect(query.run()).toEqual(pgResult);
+    expect(await query.run()).toEqual(pgResult);
   });
 
   test('whereExists with related table', async () => {
@@ -264,7 +264,7 @@ describe('compiling ZQL to SQL', () => {
       sqlQuery.text,
       sqlQuery.values as JSONValue[],
     );
-    expect(query.run()).toEqual(pgResult);
+    expect(await query.run()).toEqual(pgResult);
   });
 
   test('order by and limit', async () => {
@@ -274,7 +274,7 @@ describe('compiling ZQL to SQL', () => {
       sqlQuery.text,
       sqlQuery.values as JSONValue[],
     );
-    expect(query.run()).toEqual(pgResult);
+    expect(await query.run()).toEqual(pgResult);
   });
 
   test('1 to 1 foreign key relationship', async () => {
@@ -284,7 +284,7 @@ describe('compiling ZQL to SQL', () => {
       sqlQuery.text,
       sqlQuery.values as JSONValue[],
     );
-    expect(query.run()).toEqualNullish(pgResult);
+    expect(await query.run()).toEqualNullish(pgResult);
   });
 
   test('1 to many foreign key relationship', async () => {
@@ -294,7 +294,7 @@ describe('compiling ZQL to SQL', () => {
       sqlQuery.text,
       sqlQuery.values as JSONValue[],
     );
-    expect(query.run()).toEqualNullish(pgResult);
+    expect(await query.run()).toEqualNullish(pgResult);
   });
 
   test('junction relationship', async () => {
@@ -304,7 +304,7 @@ describe('compiling ZQL to SQL', () => {
       sqlQuery.text,
       sqlQuery.values as JSONValue[],
     );
-    expect(query.run()).toEqualNullish(pgResult);
+    expect(await query.run()).toEqualNullish(pgResult);
   });
 
   test('nested related with where clauses', async () => {
@@ -318,7 +318,7 @@ describe('compiling ZQL to SQL', () => {
       sqlQuery.text,
       sqlQuery.values as JSONValue[],
     );
-    expect(query.run()).toEqual(pgResult);
+    expect(await query.run()).toEqual(pgResult);
   });
 
   test('complex query combining multiple features', async () => {
@@ -335,6 +335,6 @@ describe('compiling ZQL to SQL', () => {
       sqlQuery.text,
       sqlQuery.values as JSONValue[],
     );
-    expect(query.run()).toEqual(pgResult);
+    expect(await query.run()).toEqual(pgResult);
   });
 });

--- a/packages/z2s/src/test/chinook/chinook.pg-test.ts
+++ b/packages/z2s/src/test/chinook/chinook.pg-test.ts
@@ -104,15 +104,17 @@ beforeAll(async () => {
     memoryQueries[table] = newQuery(memoryQueryDelegate, schema, table) as any;
   });
 
-  tables.forEach(table => {
-    const rows = zqliteQueries[table].run();
-    for (const row of rows) {
-      memorySources[table].push({
-        type: 'add',
-        row,
-      });
-    }
-  });
+  await Promise.all(
+    tables.map(async table => {
+      const rows = await zqliteQueries[table].run();
+      for (const row of rows) {
+        memorySources[table].push({
+          type: 'add',
+          row,
+        });
+      }
+    }),
+  );
 });
 
 describe('basic select', () => {
@@ -177,8 +179,8 @@ async function checkZqlAndSql(
   memoryQuery: Query<Schema, keyof Schema['tables']>,
 ) {
   const pgResult = await runZqlAsSql(pg, zqliteQuery);
-  const zqliteResult = zqliteQuery.run();
-  const zqlMemResult = memoryQuery.run();
+  const zqliteResult = await zqliteQuery.run();
+  const zqlMemResult = await memoryQuery.run();
   // In failure output:
   // `-` is PG
   // `+` is ZQLite

--- a/packages/zero-client/src/client/zero.json.test.ts
+++ b/packages/zero-client/src/client/zero.json.test.ts
@@ -33,7 +33,7 @@ test('we can create rows with json columns and query those rows', async () => {
     artists: ['artist 2', 'artist 3'],
   });
 
-  const tracks = z.query.track.run();
+  const tracks = await z.query.track.run();
 
   expect(tracks).toEqual([
     {id: 'track-1', title: 'track 1', artists: ['artist 1', 'artist 2']},

--- a/packages/zero-protocol/src/connect.test.ts
+++ b/packages/zero-protocol/src/connect.test.ts
@@ -23,6 +23,7 @@ test('encode/decodeSecProtocols round-trip', () => {
                         fc.double({
                           noDefaultInfinity: true,
                           noNaN: true,
+                          min: 0,
                         }),
                         {nil: undefined},
                       ),

--- a/packages/zero-schema/src/builder/schema-builder.test.ts
+++ b/packages/zero-schema/src/builder/schema-builder.test.ts
@@ -35,7 +35,7 @@ const mockQuery = {
   },
 };
 
-test('building a schema', () => {
+test('building a schema', async () => {
   const user = table('user')
     .columns({
       id: string(),
@@ -121,7 +121,7 @@ test('building a schema', () => {
 
   const q = mockQuery as unknown as Query<typeof schema, 'user'>;
   const iq = mockQuery as unknown as Query<typeof schema, 'issue'>;
-  const r = q
+  const r = await q
     .related('recruiter', q => q.related('recruiter', q => q.one()).one())
     .one()
     .run();
@@ -150,7 +150,7 @@ test('building a schema', () => {
   >({} as any);
 
   // recruiter is a singular relationship
-  expectTypeOf(q.related('recruiter').run()).toEqualTypeOf<
+  expectTypeOf(await q.related('recruiter').run()).toEqualTypeOf<
     {
       readonly id: string;
       readonly name: string;
@@ -166,7 +166,7 @@ test('building a schema', () => {
   >();
 
   // recruiter is a singular relationship
-  expectTypeOf(q.related('recruiter', q => q).run()).toEqualTypeOf<
+  expectTypeOf(await q.related('recruiter', q => q).run()).toEqualTypeOf<
     {
       readonly id: string;
       readonly name: string;
@@ -181,7 +181,7 @@ test('building a schema', () => {
     }[]
   >();
 
-  const id1 = iq
+  const id1 = await iq
     .related('owner', q => q.related('ownedIssues', q => q.where('id', '1')))
     .run();
   expectTypeOf(id1).toEqualTypeOf<
@@ -204,7 +204,7 @@ test('building a schema', () => {
     }[]
   >({} as never);
 
-  const id = iq.related('labels').run();
+  const id = await iq.related('labels').run();
   expectTypeOf(id).toEqualTypeOf<
     {
       readonly id: string;
@@ -218,7 +218,7 @@ test('building a schema', () => {
   >();
 
   const lq = mockQuery as unknown as Query<typeof schema, 'label'>;
-  const ld = lq.related('issues').run();
+  const ld = await lq.related('issues').run();
   expectTypeOf(ld).toEqualTypeOf<
     {
       readonly id: number;

--- a/packages/zql/src/query/query-impl.query.test.ts
+++ b/packages/zql/src/query/query-impl.query.test.ts
@@ -617,7 +617,7 @@ describe('joins and filters', () => {
     });
   });
 
-  test('schema applied one', () => {
+  test('schema applied one', async () => {
     const queryDelegate = new QueryDelegateImpl();
     addData(queryDelegate);
 
@@ -625,7 +625,7 @@ describe('joins and filters', () => {
       .related('owner')
       .related('comments', q => q.related('author').related('revisions'))
       .where('id', '=', '0001');
-    const data = query.run();
+    const data = await query.run();
     expect(data).toMatchInlineSnapshot(`
       [
         {
@@ -708,7 +708,7 @@ test('non int limit', () => {
   }).toThrow('Limit must be an integer');
 });
 
-test('run', () => {
+test('run', async () => {
   const queryDelegate = new QueryDelegateImpl();
   addData(queryDelegate);
 
@@ -718,9 +718,9 @@ test('run', () => {
     'issue 1',
   );
 
-  const singleFilterRows = issueQuery1.run();
-  const doubleFilterRows = issueQuery1.where('closed', '=', false).run();
-  const doubleFilterWithNoResultsRows = issueQuery1
+  const singleFilterRows = await issueQuery1.run();
+  const doubleFilterRows = await issueQuery1.where('closed', '=', false).run();
+  const doubleFilterWithNoResultsRows = await issueQuery1
     .where('closed', '=', true)
     .run();
 
@@ -732,7 +732,7 @@ test('run', () => {
     .related('labels')
     .related('owner')
     .related('comments');
-  const rows = issueQuery2.run();
+  const rows = await issueQuery2.run();
   expect(rows).toMatchInlineSnapshot(`
     [
       {
@@ -834,11 +834,11 @@ test('view creation is wrapped in context.batchViewUpdates call', () => {
   expect(view).toBe(testView);
 });
 
-test('json columns are returned as JS objects', () => {
+test('json columns are returned as JS objects', async () => {
   const queryDelegate = new QueryDelegateImpl();
   addData(queryDelegate);
 
-  const rows = newQuery(queryDelegate, schema, 'user').run();
+  const rows = await newQuery(queryDelegate, schema, 'user').run();
   expect(rows).toEqual([
     {
       id: '0001',
@@ -860,11 +860,11 @@ test('json columns are returned as JS objects', () => {
   ]);
 });
 
-test('complex expression', () => {
+test('complex expression', async () => {
   const queryDelegate = new QueryDelegateImpl();
   addData(queryDelegate);
 
-  let rows = newQuery(queryDelegate, schema, 'issue')
+  let rows = await newQuery(queryDelegate, schema, 'issue')
     .where(({or, cmp}) =>
       or(cmp('title', '=', 'issue 1'), cmp('title', '=', 'issue 2')),
     )
@@ -889,7 +889,7 @@ test('complex expression', () => {
     ]
   `);
 
-  rows = newQuery(queryDelegate, schema, 'issue')
+  rows = await newQuery(queryDelegate, schema, 'issue')
     .where(({and, cmp, or}) =>
       and(
         cmp('ownerId', '=', '0001'),
@@ -911,11 +911,11 @@ test('complex expression', () => {
   `);
 });
 
-test('null compare', () => {
+test('null compare', async () => {
   const queryDelegate = new QueryDelegateImpl();
   addData(queryDelegate);
 
-  let rows = newQuery(queryDelegate, schema, 'issue')
+  let rows = await newQuery(queryDelegate, schema, 'issue')
     .where('ownerId', 'IS', null)
     .run();
 
@@ -929,7 +929,7 @@ test('null compare', () => {
     },
   ]);
 
-  rows = newQuery(queryDelegate, schema, 'issue')
+  rows = await newQuery(queryDelegate, schema, 'issue')
     .where('ownerId', 'IS NOT', null)
     .run();
 
@@ -951,17 +951,17 @@ test('null compare', () => {
   ]);
 });
 
-test('literal filter', () => {
+test('literal filter', async () => {
   const queryDelegate = new QueryDelegateImpl();
   addData(queryDelegate);
 
-  let rows = newQuery(queryDelegate, schema, 'issue')
+  let rows = await newQuery(queryDelegate, schema, 'issue')
     .where(({cmpLit}) => cmpLit(true, '=', false))
     .run();
 
   expect(rows).toEqual([]);
 
-  rows = newQuery(queryDelegate, schema, 'issue')
+  rows = await newQuery(queryDelegate, schema, 'issue')
     .where(({cmpLit}) => cmpLit(true, '=', true))
     .run();
 
@@ -990,7 +990,7 @@ test('literal filter', () => {
   ]);
 });
 
-test('join with compound keys', () => {
+test('join with compound keys', async () => {
   const b = table('b')
     .columns({
       id: number(),
@@ -1065,7 +1065,7 @@ test('join with compound keys', () => {
     });
   }
 
-  const rows = newQuery(queryDelegate, schema, 'a').related('b').run();
+  const rows = await newQuery(queryDelegate, schema, 'a').related('b').run();
 
   expect(rows).toMatchInlineSnapshot(`
     [

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -557,7 +557,7 @@ export abstract class AbstractQuery<
 
   abstract materialize(): TypedView<HumanReadable<TReturn>>;
   abstract materialize<T>(factory: ViewFactory<TSchema, TTable, TReturn, T>): T;
-  abstract run(): HumanReadable<TReturn>;
+  abstract run(): Promise<HumanReadable<TReturn>>;
   abstract preload(): {
     cleanup: () => void;
     complete: Promise<void>;
@@ -645,11 +645,11 @@ export class QueryImpl<
     return view as T;
   }
 
-  run() {
+  run(): Promise<HumanReadable<TReturn>> {
     const v: TypedView<HumanReadable<TReturn>> = this.materialize();
     const ret = v.data;
     v.destroy();
-    return ret;
+    return Promise.resolve(ret);
   }
 
   preload(): {

--- a/packages/zql/src/query/query.test.ts
+++ b/packages/zql/src/query/query.test.ts
@@ -208,10 +208,12 @@ describe('types', () => {
   test('simple select with enums', () => {
     const query = mockQuery as unknown as Query<Schema, 'testWithEnums'>;
     expectTypeOf(query.run()).toMatchTypeOf<
-      ReadonlyArray<{
-        s: string;
-        e: 'open' | 'closed';
-      }>
+      Promise<
+        ReadonlyArray<{
+          s: string;
+          e: 'open' | 'closed';
+        }>
+      >
     >();
 
     const q2 = mockQuery as unknown as Query<Schema, 'schemaWithAdvancedTypes'>;
@@ -219,14 +221,16 @@ describe('types', () => {
     // @ts-expect-error - invalid enum value
     q2.where('e', 'bogus');
     expectTypeOf(q2.run()).toMatchTypeOf<
-      ReadonlyArray<{
-        s: string;
-        n: Timestamp;
-        b: boolean;
-        j: {foo: string; bar: boolean};
-        e: 'open' | 'closed';
-        otherId: IdOf<Schema['tables']['testWithEnums']>;
-      }>
+      Promise<
+        ReadonlyArray<{
+          s: string;
+          n: Timestamp;
+          b: boolean;
+          j: {foo: string; bar: boolean};
+          e: 'open' | 'closed';
+          otherId: IdOf<Schema['tables']['testWithEnums']>;
+        }>
+      >
     >();
 
     // @ts-expect-error - 'foo' is not an id of `SchemaWithEnums`
@@ -246,22 +250,24 @@ describe('types', () => {
 
     const query2 = query.related('self');
     expectTypeOf(query2.run()).toMatchTypeOf<
-      ReadonlyArray<{
-        s: string;
-        n: Timestamp;
-        b: boolean;
-        j: {foo: string; bar: boolean};
-        e: 'open' | 'closed';
-        otherId: IdOf<Schema['tables']['testWithEnums']>;
-        self: ReadonlyArray<{
+      Promise<
+        ReadonlyArray<{
           s: string;
           n: Timestamp;
           b: boolean;
           j: {foo: string; bar: boolean};
           e: 'open' | 'closed';
           otherId: IdOf<Schema['tables']['testWithEnums']>;
-        }>;
-      }>
+          self: ReadonlyArray<{
+            s: string;
+            n: Timestamp;
+            b: boolean;
+            j: {foo: string; bar: boolean};
+            e: 'open' | 'closed';
+            otherId: IdOf<Schema['tables']['testWithEnums']>;
+          }>;
+        }>
+      >
     >();
 
     // @ts-expect-error - missing enum value
@@ -322,10 +328,12 @@ describe('types', () => {
 
     const query2 = query.related('self');
     expectTypeOf(query2.run()).toMatchTypeOf<
-      ReadonlyArray<
-        Row<SchemaWithEnums> & {
-          self: ReadonlyArray<Row<SchemaWithEnums>>;
-        }
+      Promise<
+        ReadonlyArray<
+          Row<SchemaWithEnums> & {
+            self: ReadonlyArray<Row<SchemaWithEnums>>;
+          }
+        >
       >
     >();
   });
@@ -342,12 +350,14 @@ describe('types', () => {
   test('one', () => {
     const q1 = mockQuery as unknown as Query<Schema, 'test'>;
     expectTypeOf(q1.one().run()).toMatchTypeOf<
-      | {
-          readonly s: string;
-          readonly b: boolean;
-          readonly n: number;
-        }
-      | undefined
+      Promise<
+        | {
+            readonly s: string;
+            readonly b: boolean;
+            readonly n: number;
+          }
+        | undefined
+      >
     >();
 
     // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/zql/src/query/query.ts
+++ b/packages/zql/src/query/query.ts
@@ -188,7 +188,7 @@ export interface Query<
 
   materialize(): TypedView<HumanReadable<TReturn>>;
 
-  run(): HumanReadable<TReturn>;
+  run(): Promise<HumanReadable<TReturn>>;
 
   preload(): {
     cleanup: () => void;

--- a/packages/zql/src/query/static-query.ts
+++ b/packages/zql/src/query/static-query.ts
@@ -50,8 +50,8 @@ export class StaticQuery<
     throw new Error('AuthQuery cannot be materialized');
   }
 
-  run(): HumanReadable<TReturn> {
-    throw new Error('AuthQuery cannot be run');
+  run(): Promise<HumanReadable<TReturn>> {
+    return Promise.reject(new Error('StaticQuery cannot be run'));
   }
 
   preload(): {

--- a/packages/zqlite/src/query.test.ts
+++ b/packages/zqlite/src/query.test.ts
@@ -94,23 +94,25 @@ test('row type', () => {
     .related('labels');
   type RT = ReturnType<typeof query.run>;
   expectTypeOf<RT>().toEqualTypeOf<
-    {
-      readonly id: string;
-      readonly title: string;
-      readonly description: string;
-      readonly closed: boolean;
-      readonly ownerId: string | null;
-      readonly labels: readonly {
+    Promise<
+      {
         readonly id: string;
-        readonly name: string;
-      }[];
-    }[]
+        readonly title: string;
+        readonly description: string;
+        readonly closed: boolean;
+        readonly ownerId: string | null;
+        readonly labels: readonly {
+          readonly id: string;
+          readonly name: string;
+        }[];
+      }[]
+    >
   >();
 });
 
-test('basic query', () => {
+test('basic query', async () => {
   const query = newQuery(queryDelegate, schema, 'issue');
-  const data = query.run();
+  const data = await query.run();
   expect(data).toMatchInlineSnapshot(`
     [
       {
@@ -138,8 +140,8 @@ test('basic query', () => {
   `);
 });
 
-test('null compare', () => {
-  let rows = newQuery(queryDelegate, schema, 'issue')
+test('null compare', async () => {
+  let rows = await newQuery(queryDelegate, schema, 'issue')
     .where('ownerId', 'IS', null)
     .run();
 
@@ -155,7 +157,7 @@ test('null compare', () => {
     ]
   `);
 
-  rows = newQuery(queryDelegate, schema, 'issue')
+  rows = await newQuery(queryDelegate, schema, 'issue')
     .where('ownerId', 'IS NOT', null)
     .run();
 
@@ -179,11 +181,11 @@ test('null compare', () => {
   `);
 });
 
-test('or', () => {
+test('or', async () => {
   const query = newQuery(queryDelegate, schema, 'issue').where(({or, cmp}) =>
     or(cmp('ownerId', '=', '0001'), cmp('ownerId', '=', '0002')),
   );
-  const data = query.run();
+  const data = await query.run();
   expect(data).toMatchInlineSnapshot(`
     [
       {
@@ -251,7 +253,7 @@ test('where exists retracts when an edit causes a row to no longer match', () =>
   expect(view.data).toMatchInlineSnapshot(`[]`);
 });
 
-test('schema applied `one`', () => {
+test('schema applied `one`', async () => {
   // test only one item is returned when `one` is applied to a relationship in the schema
   const commentSource = must(queryDelegate.getSource('comment'));
   const revisionSource = must(queryDelegate.getSource('revision'));
@@ -288,7 +290,7 @@ test('schema applied `one`', () => {
     .related('owner')
     .related('comments', q => q.related('author').related('revisions'))
     .where('id', '=', '0001');
-  const data = query.run();
+  const data = await query.run();
   expect(data).toMatchInlineSnapshot(`
     [
       {


### PR DESCRIPTION
`query.run` has to return a promise on the server (we're invoking PG) so it'll need to return a promise on the client as well so the code for custom mutators is isomorphic between the two.