### PR TITLE
feat(zero-client): export `CustomMutatorDefs` and `CustomMutatorImpl` via `@rocicorp/zero/react`

### DIFF
--- a/packages/zero-client/src/client/custom.ts
+++ b/packages/zero-client/src/client/custom.ts
@@ -45,12 +45,12 @@ export type CustomMutatorDefs<S extends Schema> = {
   };
 };
 
-export type CustomMutatorImpl<S extends Schema> = (
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type CustomMutatorImpl<S extends Schema, TArgs = any> = (
   tx: Transaction<S>,
   // TODO: many args. See commit: 52657c2f934b4a458d628ea77e56ce92b61eb3c6 which did have many args.
   // The issue being that it will be a protocol change to support varargs.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  args: any,
+  args: TArgs,
 ) => Promise<void>;
 
 /**

--- a/packages/zero-react/src/mod.ts
+++ b/packages/zero-react/src/mod.ts
@@ -1,4 +1,8 @@
 export type {Expand} from '../../shared/src/expand.ts';
+export type {
+  CustomMutatorDefs,
+  CustomMutatorImpl,
+} from '../../zero-client/src/client/custom.ts';
 export type {PrimaryKey} from '../../zero-protocol/src/primary-key.ts';
 export type {Schema} from '../../zero-schema/src/builder/schema-builder.ts';
 export type {

--- a/packages/zero-react/src/use-zero.tsx
+++ b/packages/zero-react/src/use-zero.tsx
@@ -1,27 +1,32 @@
 import {createContext, useContext} from 'react';
 import type {Zero} from '../../zero-client/src/client/zero.ts';
 import type {Schema} from '../../zero-schema/src/builder/schema-builder.ts';
+import type {CustomMutatorDefs} from '../../zero-client/src/client/custom.ts';
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const ZeroContext = createContext<unknown | undefined>(undefined);
 
-export function useZero<S extends Schema>(): Zero<S> {
+export function useZero<
+  S extends Schema,
+  MD extends CustomMutatorDefs<S> | undefined = undefined,
+>(): Zero<S, MD> {
   const zero = useContext(ZeroContext);
   if (zero === undefined) {
     throw new Error('useZero must be used within a ZeroProvider');
   }
-  return zero as Zero<S>;
+  return zero as Zero<S, MD>;
 }
 
-export function createUseZero<S extends Schema>() {
-  return () => useZero<S>();
+export function createUseZero<
+  S extends Schema,
+  MD extends CustomMutatorDefs<S> | undefined = undefined,
+>() {
+  return () => useZero<S, MD>();
 }
 
-export function ZeroProvider<S extends Schema>({
-  children,
-  zero,
-}: {
-  children: React.ReactNode;
-  zero: Zero<S>;
-}) {
+export function ZeroProvider<
+  S extends Schema,
+  MD extends CustomMutatorDefs<S> | undefined = undefined,
+>({children, zero}: {children: React.ReactNode; zero: Zero<S, MD>}) {
   return <ZeroContext.Provider value={zero}>{children}</ZeroContext.Provider>;
 }


### PR DESCRIPTION
## Why

As a developer testing early support for custom mutators I need a way to provide typings for my custom mutator definitions when calling `new Zero` and `useZero`, so that intellisense works in my IDE

`CustomMutatorDefs` and `CustomMutatorImpl` are not currently exported via `@rocicorp/zero/react` and the default value of `undefined` for the `MD` type param in `Zero` and `useZero` make it impractical to 

## What 

- adds an optional second parameter `TArgs` to `CustomMutatorImpl` to allow custom mutators to specify the type of input data
- exports `CustomMutatorDefs` and `CustomMutatorImpl` from `@rocicorp/zero/react` for use in apps