### PR TITLE
Add logging to global db setup

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
@@ -83,7 +83,8 @@ export const GLOBAL_SETUP = `
   INSERT INTO zero.permissions (permissions) VALUES (NULL) ON CONFLICT DO NOTHING;
 `;
 
-export async function ensureGlobalTables(db: PostgresDB) {
+export async function ensureGlobalTables(lc: LogContext, db: PostgresDB) {
+  lc.info?.(`Ensuring global db setup.`);
   await db.unsafe(GLOBAL_SETUP);
 }
 


### PR DESCRIPTION
This commit adds some logging to the `ensureGlobalTables` function.

Prior to this, issues connecting to the database would hang with a log:
```
> Running zero-deploy-permissions.
Loading permissions from packages/web/src/schema.ts
```
This isn't super helpful and didn't point me in the right direction of what the issue was.