### PR TITLE
wip(zero): Add ttl etc to cvr desires table

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr-store.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.ts
@@ -277,7 +277,12 @@ export class CVRStore {
 
       const query = cvr.queries[row.queryHash];
       if (query && !query.internal) {
-        query.desiredBy[row.clientID] = versionFromString(row.patchVersion);
+        query.desiredBy[row.clientID] = {
+          expiresAt: row.expiresAt ?? undefined,
+          inactivatedAt: row.inactivatedAt ?? undefined,
+          ttl: row.ttl ?? undefined,
+          version: versionFromString(row.patchVersion),
+        };
       }
     }
     lc.debug?.(
@@ -452,13 +457,19 @@ export class CVRStore {
     query: {id: string},
     client: {id: string},
     deleted: boolean,
+    expiresAt: number | undefined,
+    inactivatedAt: number | undefined,
+    ttl: number | undefined,
   ): void {
     const change: DesiresRow = {
       clientGroupID: this.#id,
       clientID: client.id,
-      queryHash: query.id,
-      patchVersion: versionString(newVersion),
       deleted,
+      expiresAt: expiresAt ?? null,
+      inactivatedAt: inactivatedAt ?? null,
+      patchVersion: versionString(newVersion),
+      queryHash: query.id,
+      ttl: ttl ?? null,
     };
     this.#writes.add({
       stats: {desires: 1},

--- a/packages/zero-cache/src/services/view-syncer/cvr-store.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.ts
@@ -278,9 +278,9 @@ export class CVRStore {
       const query = cvr.queries[row.queryHash];
       if (query && !query.internal) {
         query.desiredBy[row.clientID] = {
-          expiresAt: row.expiresAt ?? undefined,
-          inactivatedAt: row.inactivatedAt ?? undefined,
-          ttl: row.ttl ?? undefined,
+          expiresAt: row.expiresAt,
+          inactivatedAt: row.inactivatedAt,
+          ttl: row.ttl,
           version: versionFromString(row.patchVersion),
         };
       }
@@ -457,19 +457,19 @@ export class CVRStore {
     query: {id: string},
     client: {id: string},
     deleted: boolean,
-    expiresAt: number | undefined,
-    inactivatedAt: number | undefined,
-    ttl: number | undefined,
+    expiresAt: number | null,
+    inactivatedAt: number | null,
+    ttl: number | null,
   ): void {
     const change: DesiresRow = {
       clientGroupID: this.#id,
       clientID: client.id,
       deleted,
-      expiresAt: expiresAt ?? null,
-      inactivatedAt: inactivatedAt ?? null,
+      expiresAt,
+      inactivatedAt,
       patchVersion: versionString(newVersion),
       queryHash: query.id,
-      ttl: ttl ?? null,
+      ttl,
     };
     this.#writes.add({
       stats: {desires: 1},

--- a/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
@@ -299,6 +299,9 @@ describe('view-syncer/cvr', () => {
           desiredBy: {
             fooClient: {
               version: {stateVersion: '1a9', minorVersion: 1},
+              expiresAt: null,
+              inactivatedAt: null,
+              ttl: null,
             },
           },
           patchVersion: {stateVersion: '1a9', minorVersion: 2},
@@ -400,7 +403,12 @@ describe('view-syncer/cvr', () => {
           ast: {table: 'issues'},
           transformationHash: 'twoHash',
           desiredBy: {
-            fooClient: {version: {stateVersion: '1a9', minorVersion: 1}},
+            fooClient: {
+              version: {stateVersion: '1a9', minorVersion: 1},
+              expiresAt: null,
+              inactivatedAt: null,
+              ttl: null,
+            },
           },
           patchVersion: {stateVersion: '1a9', minorVersion: 2},
         },
@@ -627,8 +635,18 @@ describe('view-syncer/cvr', () => {
           transformationHash: 'twoHash',
           transformationVersion: undefined,
           desiredBy: {
-            dooClient: {version: {stateVersion: '1a8'}},
-            fooClient: {version: {stateVersion: '1a9', minorVersion: 1}},
+            dooClient: {
+              version: {stateVersion: '1a8'},
+              expiresAt: null,
+              inactivatedAt: null,
+              ttl: null,
+            },
+            fooClient: {
+              version: {stateVersion: '1a9', minorVersion: 1},
+              expiresAt: null,
+              inactivatedAt: null,
+              ttl: null,
+            },
           },
           patchVersion: {stateVersion: '1a9', minorVersion: 2},
         },
@@ -830,7 +848,12 @@ describe('view-syncer/cvr', () => {
           transformationHash: 'twoHash',
           transformationVersion: undefined,
           desiredBy: {
-            barClient: {version: {stateVersion: '1aa', minorVersion: 1}},
+            barClient: {
+              version: {stateVersion: '1aa', minorVersion: 1},
+              expiresAt: null,
+              inactivatedAt: null,
+              ttl: null,
+            },
           },
           patchVersion: {stateVersion: '1a9', minorVersion: 2},
         },
@@ -838,15 +861,30 @@ describe('view-syncer/cvr', () => {
           id: 'threeHash',
           ast: {table: 'comments'},
           desiredBy: {
-            barClient: {version: {stateVersion: '1aa', minorVersion: 1}},
-            fooClient: {version: {stateVersion: '1aa', minorVersion: 1}},
+            barClient: {
+              version: {stateVersion: '1aa', minorVersion: 1},
+              expiresAt: null,
+              inactivatedAt: null,
+              ttl: null,
+            },
+            fooClient: {
+              version: {stateVersion: '1aa', minorVersion: 1},
+              expiresAt: null,
+              inactivatedAt: null,
+              ttl: null,
+            },
           },
         },
         fourHash: {
           id: 'fourHash',
           ast: {table: 'users'},
           desiredBy: {
-            fooClient: {version: {stateVersion: '1aa', minorVersion: 1}},
+            fooClient: {
+              version: {stateVersion: '1aa', minorVersion: 1},
+              expiresAt: null,
+              inactivatedAt: null,
+              ttl: null,
+            },
           },
         },
       },
@@ -1521,7 +1559,12 @@ describe('view-syncer/cvr', () => {
           id: 'oneHash',
           ast: {table: 'issues'},
           desiredBy: {
-            fooClient: {version: {stateVersion: '1a9', minorVersion: 1}},
+            fooClient: {
+              version: {stateVersion: '1a9', minorVersion: 1},
+              expiresAt: null,
+              inactivatedAt: null,
+              ttl: null,
+            },
           },
           transformationHash: 'serverOneHash',
           transformationVersion: {stateVersion: '1aa', minorVersion: 1},
@@ -1968,7 +2011,12 @@ describe('view-syncer/cvr', () => {
           id: 'oneHash',
           ast: {table: 'issues'},
           desiredBy: {
-            fooClient: {version: {stateVersion: '1a9', minorVersion: 1}},
+            fooClient: {
+              version: {stateVersion: '1a9', minorVersion: 1},
+              expiresAt: null,
+              inactivatedAt: null,
+              ttl: null,
+            },
           },
           transformationHash: 'serverTwoHash',
           transformationVersion: {stateVersion: '1ba', minorVersion: 1},
@@ -2561,7 +2609,12 @@ describe('view-syncer/cvr', () => {
           id: 'oneHash',
           ast: {table: 'issues'},
           desiredBy: {
-            fooClient: {version: {stateVersion: '1a9', minorVersion: 1}},
+            fooClient: {
+              version: {stateVersion: '1a9', minorVersion: 1},
+              expiresAt: null,
+              inactivatedAt: null,
+              ttl: null,
+            },
           },
           transformationHash: 'updatedServerOneHash',
           transformationVersion: newVersion,
@@ -2571,7 +2624,12 @@ describe('view-syncer/cvr', () => {
           id: 'twoHash',
           ast: {table: 'issues'},
           desiredBy: {
-            fooClient: {version: {stateVersion: '1a9', minorVersion: 1}},
+            fooClient: {
+              version: {stateVersion: '1a9', minorVersion: 1},
+              expiresAt: null,
+              inactivatedAt: null,
+              ttl: null,
+            },
           },
           transformationHash: 'updatedServerTwoHash',
           transformationVersion: newVersion,
@@ -3251,9 +3309,9 @@ describe('view-syncer/cvr', () => {
             },
             "desiredBy": {
               "fooClient": {
-                "expiresAt": undefined,
-                "inactivatedAt": undefined,
-                "ttl": undefined,
+                "expiresAt": null,
+                "inactivatedAt": null,
+                "ttl": null,
                 "version": {
                   "minorVersion": 1,
                   "stateVersion": "1a9",
@@ -3276,9 +3334,9 @@ describe('view-syncer/cvr', () => {
             },
             "desiredBy": {
               "fooClient": {
-                "expiresAt": undefined,
-                "inactivatedAt": undefined,
-                "ttl": undefined,
+                "expiresAt": null,
+                "inactivatedAt": null,
+                "ttl": null,
                 "version": {
                   "minorVersion": 1,
                   "stateVersion": "1a9",

--- a/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
@@ -261,6 +261,9 @@ describe('view-syncer/cvr', () => {
           queryHash: 'oneHash',
           patchVersion: '1a9:01',
           deleted: false,
+          expiresAt: null,
+          inactivatedAt: null,
+          ttl: null,
         },
       ],
       rows: [],
@@ -293,7 +296,11 @@ describe('view-syncer/cvr', () => {
           id: 'oneHash',
           ast: {table: 'issues'},
           transformationHash: 'twoHash',
-          desiredBy: {fooClient: {stateVersion: '1a9', minorVersion: 1}},
+          desiredBy: {
+            fooClient: {
+              version: {stateVersion: '1a9', minorVersion: 1},
+            },
+          },
           patchVersion: {stateVersion: '1a9', minorVersion: 2},
         },
       },
@@ -348,6 +355,9 @@ describe('view-syncer/cvr', () => {
           queryHash: 'oneHash',
           patchVersion: '1a9:01',
           deleted: false,
+          expiresAt: null,
+          inactivatedAt: null,
+          ttl: null,
         },
       ],
       rows: [],
@@ -389,7 +399,9 @@ describe('view-syncer/cvr', () => {
           id: 'oneHash',
           ast: {table: 'issues'},
           transformationHash: 'twoHash',
-          desiredBy: {fooClient: {stateVersion: '1a9', minorVersion: 1}},
+          desiredBy: {
+            fooClient: {version: {stateVersion: '1a9', minorVersion: 1}},
+          },
           patchVersion: {stateVersion: '1a9', minorVersion: 2},
         },
       },
@@ -565,6 +577,9 @@ describe('view-syncer/cvr', () => {
           queryHash: 'oneHash',
           patchVersion: '1a8',
           deleted: false,
+          expiresAt: null,
+          inactivatedAt: null,
+          ttl: null,
         },
         {
           clientGroupID: 'abc123',
@@ -572,6 +587,9 @@ describe('view-syncer/cvr', () => {
           queryHash: 'oneHash',
           patchVersion: '1a9:01',
           deleted: false,
+          expiresAt: null,
+          inactivatedAt: null,
+          ttl: null,
         },
       ],
       rows: [],
@@ -609,8 +627,8 @@ describe('view-syncer/cvr', () => {
           transformationHash: 'twoHash',
           transformationVersion: undefined,
           desiredBy: {
-            dooClient: {stateVersion: '1a8'},
-            fooClient: {stateVersion: '1a9', minorVersion: 1},
+            dooClient: {version: {stateVersion: '1a8'}},
+            fooClient: {version: {stateVersion: '1a9', minorVersion: 1}},
           },
           patchVersion: {stateVersion: '1a9', minorVersion: 2},
         },
@@ -640,8 +658,8 @@ describe('view-syncer/cvr', () => {
 
     expect(
       updater.putDesiredQueries('fooClient', [
-        {hash: 'fourHash', ast: {table: 'users'}},
-        {hash: 'threeHash', ast: {table: 'comments'}},
+        {hash: 'fourHash', ast: {table: 'users'}, ttl: undefined},
+        {hash: 'threeHash', ast: {table: 'comments'}, ttl: undefined},
       ]),
     ).toMatchInlineSnapshot(`
         [
@@ -681,8 +699,8 @@ describe('view-syncer/cvr', () => {
     // This adds a new barClient with desired queries.
     expect(
       updater.putDesiredQueries('barClient', [
-        {hash: 'oneHash', ast: {table: 'issues'}},
-        {hash: 'threeHash', ast: {table: 'comments'}},
+        {hash: 'oneHash', ast: {table: 'issues'}, ttl: undefined},
+        {hash: 'threeHash', ast: {table: 'comments'}, ttl: undefined},
       ]),
     ).toMatchInlineSnapshot(`
       [
@@ -811,21 +829,25 @@ describe('view-syncer/cvr', () => {
           ast: {table: 'issues'},
           transformationHash: 'twoHash',
           transformationVersion: undefined,
-          desiredBy: {barClient: {stateVersion: '1aa', minorVersion: 1}},
+          desiredBy: {
+            barClient: {version: {stateVersion: '1aa', minorVersion: 1}},
+          },
           patchVersion: {stateVersion: '1a9', minorVersion: 2},
         },
         threeHash: {
           id: 'threeHash',
           ast: {table: 'comments'},
           desiredBy: {
-            barClient: {stateVersion: '1aa', minorVersion: 1},
-            fooClient: {stateVersion: '1aa', minorVersion: 1},
+            barClient: {version: {stateVersion: '1aa', minorVersion: 1}},
+            fooClient: {version: {stateVersion: '1aa', minorVersion: 1}},
           },
         },
         fourHash: {
           id: 'fourHash',
           ast: {table: 'users'},
-          desiredBy: {fooClient: {stateVersion: '1aa', minorVersion: 1}},
+          desiredBy: {
+            fooClient: {version: {stateVersion: '1aa', minorVersion: 1}},
+          },
         },
       },
     } satisfies CVRSnapshot);
@@ -941,6 +963,9 @@ describe('view-syncer/cvr', () => {
           deleted: true,
           patchVersion: '1aa:01',
           queryHash: 'oneHash',
+          expiresAt: null,
+          inactivatedAt: null,
+          ttl: null,
         },
         {
           clientGroupID: 'abc123',
@@ -948,6 +973,9 @@ describe('view-syncer/cvr', () => {
           deleted: false,
           patchVersion: '1aa:01',
           queryHash: 'fourHash',
+          expiresAt: null,
+          inactivatedAt: null,
+          ttl: null,
         },
         {
           clientGroupID: 'abc123',
@@ -955,6 +983,9 @@ describe('view-syncer/cvr', () => {
           deleted: false,
           patchVersion: '1aa:01',
           queryHash: 'threeHash',
+          expiresAt: null,
+          inactivatedAt: null,
+          ttl: null,
         },
         {
           clientGroupID: 'abc123',
@@ -962,6 +993,9 @@ describe('view-syncer/cvr', () => {
           deleted: false,
           patchVersion: '1aa:01',
           queryHash: 'oneHash',
+          expiresAt: null,
+          inactivatedAt: null,
+          ttl: null,
         },
         {
           clientGroupID: 'abc123',
@@ -969,6 +1003,9 @@ describe('view-syncer/cvr', () => {
           deleted: false,
           patchVersion: '1aa:01',
           queryHash: 'threeHash',
+          expiresAt: null,
+          inactivatedAt: null,
+          ttl: null,
         },
         {
           clientGroupID: 'abc123',
@@ -976,6 +1013,9 @@ describe('view-syncer/cvr', () => {
           deleted: true,
           patchVersion: '1aa:01',
           queryHash: 'oneHash',
+          expiresAt: null,
+          inactivatedAt: null,
+          ttl: null,
         },
       ],
 
@@ -999,7 +1039,7 @@ describe('view-syncer/cvr', () => {
     const updater2 = new CVRConfigDrivenUpdater(cvrStore2, reloaded, SHARD_ID);
     expect(
       updater2.putDesiredQueries('fooClient', [
-        {hash: 'oneHash', ast: {table: 'issues'}},
+        {hash: 'oneHash', ast: {table: 'issues'}, ttl: undefined},
       ]),
     ).toMatchInlineSnapshot(`
       [
@@ -1067,6 +1107,9 @@ describe('view-syncer/cvr', () => {
           queryHash: 'oneHash',
           patchVersion: '1a9:01',
           deleted: false,
+          expiresAt: null,
+          inactivatedAt: null,
+          ttl: null,
         },
       ],
       rows: [],
@@ -1087,7 +1130,7 @@ describe('view-syncer/cvr', () => {
     // Same desired query set. Nothing should change except last active time.
     expect(
       updater.putDesiredQueries('fooClient', [
-        {hash: 'oneHash', ast: {table: 'issues'}},
+        {hash: 'oneHash', ast: {table: 'issues'}, ttl: undefined},
       ]),
     ).toMatchInlineSnapshot(`[]`);
 
@@ -1205,6 +1248,9 @@ describe('view-syncer/cvr', () => {
           queryHash: 'oneHash',
           patchVersion: '1a9:01',
           deleted: null,
+          expiresAt: null,
+          inactivatedAt: null,
+          ttl: null,
         },
       ],
       rows: [
@@ -1474,7 +1520,9 @@ describe('view-syncer/cvr', () => {
         oneHash: {
           id: 'oneHash',
           ast: {table: 'issues'},
-          desiredBy: {fooClient: {stateVersion: '1a9', minorVersion: 1}},
+          desiredBy: {
+            fooClient: {version: {stateVersion: '1a9', minorVersion: 1}},
+          },
           transformationHash: 'serverOneHash',
           transformationVersion: {stateVersion: '1aa', minorVersion: 1},
           patchVersion: {stateVersion: '1aa', minorVersion: 1},
@@ -1559,6 +1607,9 @@ describe('view-syncer/cvr', () => {
           deleted: null,
           patchVersion: '1a9:01',
           queryHash: 'oneHash',
+          expiresAt: null,
+          inactivatedAt: null,
+          ttl: null,
         },
       ],
       rows: [
@@ -1677,6 +1728,9 @@ describe('view-syncer/cvr', () => {
           queryHash: 'oneHash',
           patchVersion: '1a9:01',
           deleted: null,
+          expiresAt: null,
+          inactivatedAt: null,
+          ttl: null,
         },
       ],
       rows: [
@@ -1913,7 +1967,9 @@ describe('view-syncer/cvr', () => {
         oneHash: {
           id: 'oneHash',
           ast: {table: 'issues'},
-          desiredBy: {fooClient: {stateVersion: '1a9', minorVersion: 1}},
+          desiredBy: {
+            fooClient: {version: {stateVersion: '1a9', minorVersion: 1}},
+          },
           transformationHash: 'serverTwoHash',
           transformationVersion: {stateVersion: '1ba', minorVersion: 1},
           patchVersion: {stateVersion: '1aa', minorVersion: 1},
@@ -1984,6 +2040,9 @@ describe('view-syncer/cvr', () => {
           deleted: null,
           patchVersion: '1a9:01',
           queryHash: 'oneHash',
+          expiresAt: null,
+          inactivatedAt: null,
+          ttl: null,
         },
       ],
       rows: [
@@ -2193,6 +2252,9 @@ describe('view-syncer/cvr', () => {
           queryHash: 'oneHash',
           patchVersion: '1a9:01',
           deleted: null,
+          expiresAt: null,
+          inactivatedAt: null,
+          ttl: null,
         },
         {
           clientGroupID: 'abc123',
@@ -2200,6 +2262,9 @@ describe('view-syncer/cvr', () => {
           queryHash: 'twoHash',
           patchVersion: '1a9:01',
           deleted: null,
+          expiresAt: null,
+          inactivatedAt: null,
+          ttl: null,
         },
       ],
       rows: [
@@ -2495,7 +2560,9 @@ describe('view-syncer/cvr', () => {
         oneHash: {
           id: 'oneHash',
           ast: {table: 'issues'},
-          desiredBy: {fooClient: {stateVersion: '1a9', minorVersion: 1}},
+          desiredBy: {
+            fooClient: {version: {stateVersion: '1a9', minorVersion: 1}},
+          },
           transformationHash: 'updatedServerOneHash',
           transformationVersion: newVersion,
           patchVersion: {stateVersion: '1aa', minorVersion: 1},
@@ -2503,7 +2570,9 @@ describe('view-syncer/cvr', () => {
         twoHash: {
           id: 'twoHash',
           ast: {table: 'issues'},
-          desiredBy: {fooClient: {stateVersion: '1a9', minorVersion: 1}},
+          desiredBy: {
+            fooClient: {version: {stateVersion: '1a9', minorVersion: 1}},
+          },
           transformationHash: 'updatedServerTwoHash',
           transformationVersion: newVersion,
           patchVersion: {stateVersion: '1aa', minorVersion: 1},
@@ -2592,6 +2661,9 @@ describe('view-syncer/cvr', () => {
           deleted: null,
           patchVersion: '1a9:01',
           queryHash: 'oneHash',
+          expiresAt: null,
+          inactivatedAt: null,
+          ttl: null,
         },
         {
           clientGroupID: 'abc123',
@@ -2599,6 +2671,9 @@ describe('view-syncer/cvr', () => {
           deleted: null,
           patchVersion: '1a9:01',
           queryHash: 'twoHash',
+          expiresAt: null,
+          inactivatedAt: null,
+          ttl: null,
         },
       ],
       rows: [
@@ -3078,6 +3153,9 @@ describe('view-syncer/cvr', () => {
           queryHash: 'oneHash',
           patchVersion: '1a9:01',
           deleted: null,
+          expiresAt: null,
+          inactivatedAt: null,
+          ttl: null,
         },
         {
           clientGroupID: 'abc123',
@@ -3085,6 +3163,9 @@ describe('view-syncer/cvr', () => {
           queryHash: 'twoHash',
           patchVersion: '1a9:01',
           deleted: null,
+          expiresAt: null,
+          inactivatedAt: null,
+          ttl: null,
         },
       ],
       rows: [
@@ -3170,8 +3251,13 @@ describe('view-syncer/cvr', () => {
             },
             "desiredBy": {
               "fooClient": {
-                "minorVersion": 1,
-                "stateVersion": "1a9",
+                "expiresAt": undefined,
+                "inactivatedAt": undefined,
+                "ttl": undefined,
+                "version": {
+                  "minorVersion": 1,
+                  "stateVersion": "1a9",
+                },
               },
             },
             "id": "oneHash",
@@ -3190,8 +3276,13 @@ describe('view-syncer/cvr', () => {
             },
             "desiredBy": {
               "fooClient": {
-                "minorVersion": 1,
-                "stateVersion": "1a9",
+                "expiresAt": undefined,
+                "inactivatedAt": undefined,
+                "ttl": undefined,
+                "version": {
+                  "minorVersion": 1,
+                  "stateVersion": "1a9",
+                },
               },
             },
             "id": "twoHash",
@@ -3480,6 +3571,9 @@ describe('view-syncer/cvr', () => {
           queryHash: 'oneHash',
           patchVersion: '1a9:01',
           deleted: null,
+          expiresAt: null,
+          inactivatedAt: null,
+          ttl: null,
         },
       ],
       rows: [
@@ -3703,6 +3797,9 @@ describe('view-syncer/cvr', () => {
           deleted: null,
           patchVersion: '1a9:01',
           queryHash: 'oneHash',
+          expiresAt: null,
+          inactivatedAt: null,
+          ttl: null,
         },
       ],
       rows: [
@@ -3786,6 +3883,9 @@ describe('view-syncer/cvr', () => {
           queryHash: 'oneHash',
           patchVersion: '1a9:01',
           deleted: null,
+          expiresAt: null,
+          inactivatedAt: null,
+          ttl: null,
         },
       ],
       rows: [
@@ -3931,6 +4031,9 @@ describe('view-syncer/cvr', () => {
           queryHash: 'oneHash',
           patchVersion: '1a9:01',
           deleted: null,
+          expiresAt: null,
+          inactivatedAt: null,
+          ttl: null,
         },
       ],
       rows: [

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -219,12 +219,12 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
     client.desiredQueryIDs = [...union(current, needed)].sort(compareUTF8);
 
     for (const id of needed) {
-      const {ast, ttl} = must(queries.find(({hash}) => hash === id));
+      const {ast, ttl = null} = must(queries.find(({hash}) => hash === id));
       const query = this._cvr.queries[id] ?? {id, ast, desiredBy: {}};
       assertNotInternal(query);
 
-      const expiresAt = undefined;
-      const inactivatedAt = undefined;
+      const expiresAt = null;
+      const inactivatedAt = null;
 
       query.desiredBy[clientID] = {
         expiresAt,
@@ -278,9 +278,9 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
         query,
         client,
         true,
-        undefined,
-        undefined,
-        undefined,
+        null,
+        null,
+        null,
       );
       patches.push({
         toVersion: newVersion,

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -205,7 +205,7 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
 
   putDesiredQueries(
     clientID: string,
-    queries: Readonly<{hash: string; ast: AST}>[],
+    queries: Readonly<{hash: string; ast: AST; ttl?: number | undefined}>[],
   ): PatchToVersion[] {
     const patches: PatchToVersion[] = [];
     const client = this.#ensureClient(clientID);
@@ -219,11 +219,19 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
     client.desiredQueryIDs = [...union(current, needed)].sort(compareUTF8);
 
     for (const id of needed) {
-      const {ast} = must(queries.find(({hash}) => hash === id));
+      const {ast, ttl} = must(queries.find(({hash}) => hash === id));
       const query = this._cvr.queries[id] ?? {id, ast, desiredBy: {}};
       assertNotInternal(query);
 
-      query.desiredBy[clientID] = newVersion;
+      const expiresAt = undefined;
+      const inactivatedAt = undefined;
+
+      query.desiredBy[clientID] = {
+        expiresAt,
+        inactivatedAt,
+        ttl,
+        version: newVersion,
+      };
       this._cvr.queries[id] = query;
       patches.push({
         toVersion: newVersion,
@@ -231,7 +239,15 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
       });
 
       this._cvrStore.putQuery(query);
-      this._cvrStore.insertDesiredQuery(newVersion, query, client, false);
+      this._cvrStore.insertDesiredQuery(
+        newVersion,
+        query,
+        client,
+        false,
+        expiresAt,
+        inactivatedAt,
+        ttl,
+      );
     }
     return patches;
   }
@@ -257,7 +273,15 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
 
       delete query.desiredBy[clientID];
       this._cvrStore.putQuery(query);
-      this._cvrStore.insertDesiredQuery(newVersion, query, client, true);
+      this._cvrStore.insertDesiredQuery(
+        newVersion,
+        query,
+        client,
+        true,
+        undefined,
+        undefined,
+        undefined,
+      );
       patches.push({
         toVersion: newVersion,
         patch: {type: 'query', op: 'del', id, clientID},

--- a/packages/zero-cache/src/services/view-syncer/schema/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/cvr.ts
@@ -142,6 +142,9 @@ export type DesiresRow = {
   queryHash: string;
   patchVersion: string;
   deleted: boolean | null;
+  ttl: number | null;
+  expiresAt: number | null;
+  inactivatedAt: number | null;
 };
 
 function createDesiresTable(shardID: string) {
@@ -152,6 +155,9 @@ CREATE TABLE ${schema(shardID)}.desires (
   "queryHash"          TEXT,
   "patchVersion"       TEXT NOT NULL,
   "deleted"            BOOL,  -- put vs del "desired" query
+  "ttl"                INTERVAL,  -- Time to live for this client
+  "expiresAt"          TIMESTAMPTZ,  -- Time at which this row expires
+  "inactivatedAt"      TIMESTAMPTZ,  -- Time at which this row was inactivated
 
   PRIMARY KEY ("clientGroupID", "clientID", "queryHash"),
 
@@ -172,6 +178,12 @@ CREATE TABLE ${schema(shardID)}.desires (
 -- For catchup patches.
 CREATE INDEX desires_patch_version
   ON ${schema(shardID)}.desires ("patchVersion");
+
+CREATE INDEX desires_expires_at
+  ON ${schema(shardID)}.desires ("expiresAt");
+
+CREATE INDEX desires_inactivated_at
+  ON ${schema(shardID)}.desires ("inactivatedAt");
 `;
 }
 

--- a/packages/zero-cache/src/services/view-syncer/schema/init.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/init.ts
@@ -71,6 +71,23 @@ export async function initViewSyncerSchema(
     },
   };
 
+  const migrateV6ToV7: Migration = {
+    migrateSchema: async (_, tx) => {
+      await tx`ALTER TABLE ${tx(schema)}.desires ADD "expiresAt" TIMESTAMPTZ`;
+      await tx`ALTER TABLE ${tx(
+        schema,
+      )}.desires ADD "inactivatedAt" TIMESTAMPTZ`;
+      await tx`ALTER TABLE ${tx(schema)}.desires ADD "ttl" INTERVAL`;
+
+      await tx`CREATE INDEX desires_expires_at ON ${tx(
+        schema,
+      )}.desires ("expiresAt")`;
+      await tx`CREATE INDEX desires_inactivated_at ON ${tx(
+        schema,
+      )}.desires ("inactivatedAt")`;
+    },
+  };
+
   const schemaVersionMigrationMap: IncrementalMigrationMap = {
     2: migrateV1toV2,
     3: migrateV2ToV3,
@@ -79,6 +96,7 @@ export async function initViewSyncerSchema(
     // the logic that updates and checks the rowsVersion table in v3.
     5: {minSafeVersion: 3},
     6: migrateV5ToV6,
+    7: migrateV6ToV7,
   };
 
   await runSchemaMigrations(

--- a/packages/zero-cache/src/services/view-syncer/schema/types.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/types.ts
@@ -162,6 +162,30 @@ export const internalQueryRecordSchema = baseQueryRecordSchema.extend({
 
 export type InternalQueryRecord = v.Infer<typeof internalQueryRecordSchema>;
 
+const clientLRUSchema = v.object({
+  /**
+   * The time to delete the query. This is the {@linkcode ttl} plus the {@linkcode inactivatedAt}.
+   */
+  expiresAt: v.number().optional(),
+
+  /**
+   * The time at which the query was last inactivated. If this undefined or
+   * missing then the query is active.
+   */
+  inactivatedAt: v.number().optional(),
+
+  /**
+   * TTL, time to live in milliseconds. If the query is not updated within this time.
+   * The time to live is the time after it has become inactive.
+   */
+  ttl: v.number().optional(),
+
+  /**
+   * The version at which the desired query info changed (i.e. individual `patchVersion`s).
+   */
+  version: cvrVersionSchema,
+});
+
 export const clientQueryRecordSchema = baseQueryRecordSchema.extend({
   internal: v.literal(false).optional(),
 
@@ -171,11 +195,7 @@ export const clientQueryRecordSchema = baseQueryRecordSchema.extend({
 
   // Maps each of the desiring client's IDs to the version at which
   // the queryID was added to their desired query set (i.e. individual `patchVersion`s).
-  desiredBy: v.record(cvrVersionSchema),
-
-  // TODO: Iron this out.
-  // estimatedBytes: v.number(),
-  // lru information?
+  desiredBy: v.record(clientLRUSchema),
 });
 
 export type ClientQueryRecord = v.Infer<typeof clientQueryRecordSchema>;

--- a/packages/zero-cache/src/services/view-syncer/schema/types.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/types.ts
@@ -166,19 +166,19 @@ const clientLRUSchema = v.object({
   /**
    * The time to delete the query. This is the {@linkcode ttl} plus the {@linkcode inactivatedAt}.
    */
-  expiresAt: v.number().optional(),
+  expiresAt: v.number().nullable(),
 
   /**
    * The time at which the query was last inactivated. If this undefined or
    * missing then the query is active.
    */
-  inactivatedAt: v.number().optional(),
+  inactivatedAt: v.number().nullable(),
 
   /**
    * TTL, time to live in milliseconds. If the query is not updated within this time.
    * The time to live is the time after it has become inactive.
    */
-  ttl: v.number().optional(),
+  ttl: v.number().nullable(),
 
   /**
    * The version at which the desired query info changed (i.e. individual `patchVersion`s).

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -584,7 +584,7 @@ describe('view-syncer/service', () => {
       queries: {
         'query-hash1': {
           ast: ISSUES_QUERY,
-          desiredBy: {foo: {stateVersion: '00', minorVersion: 1}},
+          desiredBy: {foo: {version: {stateVersion: '00', minorVersion: 1}}},
           id: 'query-hash1',
         },
       },
@@ -643,7 +643,7 @@ describe('view-syncer/service', () => {
         },
         'query-hash2': {
           ast: USERS_QUERY,
-          desiredBy: {foo: {stateVersion: '00', minorVersion: 2}},
+          desiredBy: {foo: {version: {stateVersion: '00', minorVersion: 2}}},
           id: 'query-hash2',
         },
       },

--- a/packages/zero-client/src/client/context.ts
+++ b/packages/zero-client/src/client/context.ts
@@ -15,7 +15,8 @@ import {ENTITIES_KEY_PREFIX, sourceNameFromKey} from './keys.ts';
 
 export type AddQuery = (
   ast: AST,
-  gotCallback?: GotCallback | undefined,
+  ttl: number | undefined,
+  gotCallback: GotCallback | undefined,
 ) => () => void;
 
 /**
@@ -49,8 +50,12 @@ export class ZeroContext implements QueryDelegate {
     return this.#mainSources.getSource(name);
   }
 
-  addServerQuery(ast: AST, gotCallback?: GotCallback | undefined) {
-    return this.#addQuery(ast, gotCallback);
+  addServerQuery(
+    ast: AST,
+    ttl?: number | undefined,
+    gotCallback?: GotCallback | undefined,
+  ) {
+    return this.#addQuery(ast, ttl, gotCallback);
   }
 
   createStorage(): Storage {

--- a/packages/zero-client/src/client/query-manager.ts
+++ b/packages/zero-client/src/client/query-manager.ts
@@ -32,7 +32,12 @@ export class QueryManager {
   readonly #send: (change: ChangeDesiredQueriesMessage) => void;
   readonly #queries: Map<
     QueryHash,
-    {normalized: AST; count: number; gotCallbacks: GotCallback[]}
+    {
+      normalized: AST;
+      count: number;
+      gotCallbacks: GotCallback[];
+      ttl: number | undefined;
+    }
   > = new Map();
   readonly #recentQueriesMaxSize: number;
   readonly #recentQueries: Set<string> = new Set();
@@ -109,9 +114,9 @@ export class QueryManager {
         patch.set(hash, {op: 'del', hash});
       }
     }
-    for (const [hash, {normalized}] of this.#queries) {
+    for (const [hash, {normalized, ttl}] of this.#queries) {
       if (!existingQueryHashes.has(hash)) {
-        patch.set(hash, {op: 'put', hash, ast: normalized});
+        patch.set(hash, {op: 'put', hash, ast: normalized, ttl});
       }
     }
 
@@ -135,7 +140,11 @@ export class QueryManager {
     return patch;
   }
 
-  add(ast: AST, gotCallback?: GotCallback | undefined): () => void {
+  add(
+    ast: AST,
+    ttl?: number | undefined,
+    gotCallback?: GotCallback | undefined,
+  ): () => void {
     const normalized = normalizeAST(ast);
     const astHash = hashOfAST(normalized);
     let entry = this.#queries.get(astHash);
@@ -146,14 +155,34 @@ export class QueryManager {
         normalized: serverAST,
         count: 1,
         gotCallbacks: gotCallback === undefined ? [] : [gotCallback],
+        ttl,
       };
       this.#queries.set(astHash, entry);
       this.#send([
         'changeDesiredQueries',
-        {desiredQueriesPatch: [{op: 'put', hash: astHash, ast: serverAST}]},
+        {
+          desiredQueriesPatch: [
+            {op: 'put', hash: astHash, ast: serverAST, ttl},
+          ],
+        },
       ]);
     } else {
       ++entry.count;
+
+      // If the query already exists and the new ttl is larger than the old one
+      // we send a changeDesiredQueries message to the server to update the ttl.
+      if (ttl !== undefined && (entry.ttl === undefined || ttl > entry.ttl)) {
+        entry.ttl = ttl;
+        this.#send([
+          'changeDesiredQueries',
+          {
+            desiredQueriesPatch: [
+              {op: 'put', hash: astHash, ast: entry.normalized, ttl},
+            ],
+          },
+        ]);
+      }
+
       if (gotCallback) {
         entry.gotCallbacks.push(gotCallback);
       }

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -68,6 +68,7 @@ import {
   type NameMapper,
   clientToServer,
 } from '../../../zero-schema/src/name-mapper.ts';
+import {customMutatorKey} from '../../../zql/src/mutate/custom.ts';
 import {newQuery} from '../../../zql/src/query/query-impl.ts';
 import type {Query} from '../../../zql/src/query/query.ts';
 import {nanoid} from '../util/nanoid.ts';
@@ -81,6 +82,11 @@ import {
   makeCRUDMutate,
   makeCRUDMutator,
 } from './crud.ts';
+import type {
+  CustomMutatorDefs,
+  CustomMutatorImpl,
+  MakeCustomMutatorInterfaces,
+} from './custom.ts';
 import {makeReplicacheMutator} from './custom.ts';
 import {DeleteClientsManager} from './delete-clients-manager.ts';
 import {shouldEnableAnalytics} from './enable-analytics.ts';
@@ -123,12 +129,6 @@ import {
 import {getServer} from './server-option.ts';
 import {version} from './version.ts';
 import {PokeHandler} from './zero-poke-handler.ts';
-import type {
-  CustomMutatorDefs,
-  CustomMutatorImpl,
-  MakeCustomMutatorInterfaces,
-} from './custom.ts';
-import {customMutatorKey} from '../../../zql/src/mutate/custom.ts';
 
 type ConnectionState = Enum<typeof ConnectionState>;
 type PingResult = Enum<typeof PingResult>;
@@ -548,7 +548,7 @@ export class Zero<
 
     this.#zeroContext = new ZeroContext(
       this.#ivmSources.main,
-      (ast, gotCallback) => this.#queryManager.add(ast, gotCallback),
+      (ast, ttl, gotCallback) => this.#queryManager.add(ast, ttl, gotCallback),
       batchViewUpdates,
     );
 

--- a/packages/zero-protocol/src/connect.test.ts
+++ b/packages/zero-protocol/src/connect.test.ts
@@ -19,7 +19,13 @@ test('encode/decodeSecProtocols round-trip', () => {
                       ast: fc.constant({
                         table: 'table',
                       }),
-                      ttl: fc.option(fc.double(), {nil: undefined}),
+                      ttl: fc.option(
+                        fc.double({
+                          noDefaultInfinity: true,
+                          noNaN: true,
+                        }),
+                        {nil: undefined},
+                      ),
                     },
                     {requiredKeys: ['op', 'hash', 'ast']},
                   ),

--- a/packages/zero-protocol/src/connect.test.ts
+++ b/packages/zero-protocol/src/connect.test.ts
@@ -12,13 +12,17 @@ test('encode/decodeSecProtocols round-trip', () => {
             {
               desiredQueriesPatch: fc.array(
                 fc.oneof(
-                  fc.record({
-                    op: fc.constant<'put'>('put'),
-                    hash: fc.string(),
-                    ast: fc.constant({
-                      table: 'table',
-                    }),
-                  }),
+                  fc.record(
+                    {
+                      op: fc.constant<'put'>('put'),
+                      hash: fc.string(),
+                      ast: fc.constant({
+                        table: 'table',
+                      }),
+                      ttl: fc.option(fc.double(), {nil: undefined}),
+                    },
+                    {requiredKeys: ['op', 'hash', 'ast']},
+                  ),
                   fc.record({
                     op: fc.constant<'del'>('del'),
                     hash: fc.string(),

--- a/packages/zero-protocol/src/queries-patch.ts
+++ b/packages/zero-protocol/src/queries-patch.ts
@@ -1,10 +1,11 @@
 import * as v from '../../shared/src/valita.ts';
 import {astSchema} from './ast.ts';
 
-const putOpSchema = v.object({
+export const putOpSchema = v.object({
   op: v.literal('put'),
   hash: v.string(),
   ast: astSchema,
+  ttl: v.number().optional(),
 });
 
 const delOpSchema = v.object({

--- a/packages/zql/src/query/query-impl.query-kitchen-sink.test.ts
+++ b/packages/zql/src/query/query-impl.query-kitchen-sink.test.ts
@@ -324,180 +324,183 @@ describe('kitchen sink query', () => {
     expect(queryDelegate.addedServerQueries).toMatchInlineSnapshot(`
       [
         {
-          "limit": 6,
-          "orderBy": [
-            [
-              "title",
-              "asc",
+          "ast": {
+            "limit": 6,
+            "orderBy": [
+              [
+                "title",
+                "asc",
+              ],
+              [
+                "id",
+                "asc",
+              ],
             ],
-            [
-              "id",
-              "asc",
-            ],
-          ],
-          "related": [
-            {
-              "correlation": {
-                "childField": [
-                  "id",
-                ],
-                "parentField": [
-                  "ownerId",
-                ],
-              },
-              "subquery": {
-                "alias": "owner",
-                "orderBy": [
-                  [
+            "related": [
+              {
+                "correlation": {
+                  "childField": [
                     "id",
-                    "asc",
                   ],
-                ],
-                "table": "user",
-              },
-              "system": "client",
-            },
-            {
-              "correlation": {
-                "childField": [
-                  "issueId",
-                ],
-                "parentField": [
-                  "id",
-                ],
-              },
-              "subquery": {
-                "alias": "comments",
-                "limit": 2,
-                "orderBy": [
-                  [
-                    "createdAt",
-                    "desc",
+                  "parentField": [
+                    "ownerId",
                   ],
-                  [
-                    "id",
-                    "asc",
+                },
+                "subquery": {
+                  "alias": "owner",
+                  "orderBy": [
+                    [
+                      "id",
+                      "asc",
+                    ],
                   ],
-                ],
-                "related": [
-                  {
-                    "correlation": {
-                      "childField": [
-                        "commentId",
-                      ],
-                      "parentField": [
-                        "id",
-                      ],
-                    },
-                    "subquery": {
-                      "alias": "revisions",
-                      "limit": 1,
-                      "orderBy": [
-                        [
-                          "id",
-                          "desc",
-                        ],
-                      ],
-                      "table": "revision",
-                    },
-                    "system": "client",
-                  },
-                ],
-                "table": "comment",
+                  "table": "user",
+                },
+                "system": "client",
               },
-              "system": "client",
-            },
-            {
-              "correlation": {
-                "childField": [
-                  "issueId",
-                ],
-                "parentField": [
-                  "id",
-                ],
-              },
-              "hidden": true,
-              "subquery": {
-                "alias": "labels",
-                "orderBy": [
-                  [
+              {
+                "correlation": {
+                  "childField": [
                     "issueId",
-                    "asc",
                   ],
-                  [
-                    "labelId",
-                    "asc",
+                  "parentField": [
+                    "id",
                   ],
-                ],
-                "related": [
-                  {
-                    "correlation": {
-                      "childField": [
-                        "id",
-                      ],
-                      "parentField": [
-                        "labelId",
-                      ],
-                    },
-                    "subquery": {
-                      "alias": "labels",
-                      "orderBy": [
-                        [
-                          "id",
-                          "asc",
+                },
+                "subquery": {
+                  "alias": "comments",
+                  "limit": 2,
+                  "orderBy": [
+                    [
+                      "createdAt",
+                      "desc",
+                    ],
+                    [
+                      "id",
+                      "asc",
+                    ],
+                  ],
+                  "related": [
+                    {
+                      "correlation": {
+                        "childField": [
+                          "commentId",
                         ],
-                      ],
-                      "table": "label",
+                        "parentField": [
+                          "id",
+                        ],
+                      },
+                      "subquery": {
+                        "alias": "revisions",
+                        "limit": 1,
+                        "orderBy": [
+                          [
+                            "id",
+                            "desc",
+                          ],
+                        ],
+                        "table": "revision",
+                      },
+                      "system": "client",
                     },
-                    "system": "client",
-                  },
-                ],
-                "table": "issueLabel",
-              },
-              "system": "client",
-            },
-          ],
-          "start": {
-            "exclusive": true,
-            "row": {
-              "id": "101",
-              "title": "Issue 1",
-            },
-          },
-          "table": "issue",
-          "where": {
-            "conditions": [
-              {
-                "left": {
-                  "name": "ownerId",
-                  "type": "column",
+                  ],
+                  "table": "comment",
                 },
-                "op": "IN",
-                "right": {
-                  "type": "literal",
-                  "value": [
-                    "001",
-                    "002",
-                    "003",
+                "system": "client",
+              },
+              {
+                "correlation": {
+                  "childField": [
+                    "issueId",
+                  ],
+                  "parentField": [
+                    "id",
                   ],
                 },
-                "type": "simple",
-              },
-              {
-                "left": {
-                  "name": "closed",
-                  "type": "column",
+                "hidden": true,
+                "subquery": {
+                  "alias": "labels",
+                  "orderBy": [
+                    [
+                      "issueId",
+                      "asc",
+                    ],
+                    [
+                      "labelId",
+                      "asc",
+                    ],
+                  ],
+                  "related": [
+                    {
+                      "correlation": {
+                        "childField": [
+                          "id",
+                        ],
+                        "parentField": [
+                          "labelId",
+                        ],
+                      },
+                      "subquery": {
+                        "alias": "labels",
+                        "orderBy": [
+                          [
+                            "id",
+                            "asc",
+                          ],
+                        ],
+                        "table": "label",
+                      },
+                      "system": "client",
+                    },
+                  ],
+                  "table": "issueLabel",
                 },
-                "op": "=",
-                "right": {
-                  "type": "literal",
-                  "value": false,
-                },
-                "type": "simple",
+                "system": "client",
               },
             ],
-            "type": "and",
+            "start": {
+              "exclusive": true,
+              "row": {
+                "id": "101",
+                "title": "Issue 1",
+              },
+            },
+            "table": "issue",
+            "where": {
+              "conditions": [
+                {
+                  "left": {
+                    "name": "ownerId",
+                    "type": "column",
+                  },
+                  "op": "IN",
+                  "right": {
+                    "type": "literal",
+                    "value": [
+                      "001",
+                      "002",
+                      "003",
+                    ],
+                  },
+                  "type": "simple",
+                },
+                {
+                  "left": {
+                    "name": "closed",
+                    "type": "column",
+                  },
+                  "op": "=",
+                  "right": {
+                    "type": "literal",
+                    "value": false,
+                  },
+                  "type": "simple",
+                },
+              ],
+              "type": "and",
+            },
           },
+          "ttl": undefined,
         },
       ]
     `);

--- a/packages/zql/src/query/static-query.ts
+++ b/packages/zql/src/query/static-query.ts
@@ -22,15 +22,6 @@ export class StaticQuery<
   TTable extends keyof TSchema['tables'] & string,
   TReturn = PullRow<TTable, TSchema>,
 > extends AbstractQuery<TSchema, TTable, TReturn> {
-  constructor(
-    schema: TSchema,
-    tableName: TTable,
-    ast: AST = {table: tableName},
-    format?: Format | undefined,
-  ) {
-    super(schema, tableName, ast, format);
-  }
-
   expressionBuilder() {
     return new ExpressionBuilder(this._exists);
   }
@@ -45,9 +36,10 @@ export class StaticQuery<
     schema: TSchema,
     tableName: TTable,
     ast: AST,
+    ttl: number | undefined,
     format: Format | undefined,
   ): Query<TSchema, TTable, TReturn> {
-    return new StaticQuery(schema, tableName, ast, format);
+    return new StaticQuery(schema, tableName, ast, ttl, format);
   }
 
   get ast() {

--- a/packages/zql/src/query/test/query-delegate.ts
+++ b/packages/zql/src/query/test/query-delegate.ts
@@ -30,7 +30,7 @@ export class QueryDelegateImpl implements QueryDelegate {
   readonly #sources: Record<string, Source> = makeSources();
   readonly #commitListeners: Set<CommitListener> = new Set();
 
-  readonly addedServerQueries: AST[] = [];
+  readonly addedServerQueries: {ast: AST; ttl: number | undefined}[] = [];
   readonly gotCallbacks: (GotCallback | undefined)[] = [];
   synchronouslyCallNextGotCallback = false;
 
@@ -54,8 +54,12 @@ export class QueryDelegateImpl implements QueryDelegate {
       listener();
     }
   }
-  addServerQuery(ast: AST, gotCallback?: GotCallback | undefined): () => void {
-    this.addedServerQueries.push(ast);
+  addServerQuery(
+    ast: AST,
+    ttl?: number | undefined,
+    gotCallback?: GotCallback | undefined,
+  ): () => void {
+    this.addedServerQueries.push({ast, ttl});
     this.gotCallbacks.push(gotCallback);
     if (this.synchronouslyCallNextGotCallback) {
       this.synchronouslyCallNextGotCallback = false;


### PR DESCRIPTION
Different clients may have different ttl for the same query. We therefore save this in the CVR desires table.

This adds 3 new columns;

 - ttl: If any, the time to live in ms after the query has become inactive. (stored as an INTERVAL).
 - expiresAt: The time at which the query will expire. This gets set when the query become inactive and the client tells the server so.
 - inactivatedAt: The time at which the query became inactive.

These columns are read/written into the CVR but not yet used.