### PR TITLE
fix(zero-cache): fix false-positive in degraded-mode ddl-change detection

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -20,6 +20,7 @@ import {assert} from '../../../../../shared/src/asserts.ts';
 import {deepEqual} from '../../../../../shared/src/json.ts';
 import {must} from '../../../../../shared/src/must.ts';
 import {
+  equals,
   intersection,
   symmetricDifferences,
 } from '../../../../../shared/src/set-utils.ts';
@@ -803,7 +804,12 @@ export function relationDifferent(a: PublishedTableSpec, b: MessageRelation) {
     a.oid !== b.relationOid ||
     a.schema !== b.schema ||
     a.name !== b.name ||
-    !deepEqual(a.primaryKey, b.keyColumns)
+    // The MessageRelation's `keyColumns` field contains the columns in column
+    // declaration order, whereas the PublishedTableSpec's `primaryKey`
+    // contains the columns in primary key (i.e. index) order. Do an
+    // order-agnostic compare here since it is not possible to detect
+    // key-order changes from the MessageRelation message alone.
+    !equals(new Set(a.primaryKey), new Set(b.keyColumns))
   ) {
     return true;
   }


### PR DESCRIPTION
Fix a false positive in degraded-mode ddl change detection in which a table with a compound key is incorrectly flagged as having its schema changed.

https://discord.com/channels/830183651022471199/1288232858795769917/1341135548944744448

The `keyColumns` sent in Postgres MessageRelation contain columns in table declaration order, whereas the PublishedTableSpec contains columns in key / index order. Since it is not possible to detect index-order changes from the MessageRelation itself, just do an order-agnostic compare.