### PR TITLE
fix(zero-cache): ignore "origin" pg replication messages

### DIFF
--- a/packages/zero-cache/src/auth/read-authorizer.test.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.test.ts
@@ -1,4 +1,5 @@
 import {describe, expect, test} from 'vitest';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
 import {must} from '../../../shared/src/must.ts';
 import {relationships} from '../../../zero-schema/src/builder/relationship-builder.ts';
 import type {Schema as ZeroSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
@@ -17,11 +18,10 @@ import {
 } from '../../../zql/src/query/query-impl.ts';
 import type {Query} from '../../../zql/src/query/query.ts';
 import {transformQuery} from './read-authorizer.ts';
-import {consoleLogSink, LogContext} from '@rocicorp/logger';
 
 const mockDelegate = {} as QueryDelegate;
 
-const lc = new LogContext('debug', {}, consoleLogSink);
+const lc = createSilentLogContext();
 
 function ast(q: Query<ZeroSchema, string>) {
   return (q as QueryImpl<ZeroSchema, string>)[astForTestingSymbol];

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -514,9 +514,9 @@ class ChangeMaker {
       case 'type':
         return []; // Nothing need be done for custom types.
       case 'origin':
-        // We do not set the `origin` option in the pgoutput parameters:
-        // https://www.postgresql.org/docs/current/protocol-logical-replication.html#PROTOCOL-LOGICAL-REPLICATION-PARAMS
-        throw new Error(`Unexpected ORIGIN message ${stringify(msg)}`);
+        // No need to detect replication loops since we are not a
+        // PG replication source.
+        return [];
       default:
         msg satisfies never;
         throw new Error(`Unexpected message type ${stringify(msg)}`);


### PR DESCRIPTION
"origin" messages are used for detecting replication loops. There's no need to do that in zero since it is not a PG replication source.

Tangential: silence logging in a unit test.