### PR TITLE
fix(prod): set healthCheckGracePeriodSeconds to match startPeriod

### DIFF
--- a/prod/sst/sst.config.ts
+++ b/prod/sst/sst.config.ts
@@ -81,6 +81,9 @@ export default $config({
         ],
       },
       transform: {
+        service: {
+          healthCheckGracePeriodSeconds: 300, // same as health.startPeriod
+        },
         loadBalancer: {
           idleTimeout: 3600, // Keep idle connections alive
         },
@@ -148,6 +151,9 @@ export default $config({
             }),
       },
       transform: {
+        service: {
+          healthCheckGracePeriodSeconds: 300, // same as health.startPeriod
+        },
         target: {
           healthCheck: {
             enabled: true,


### PR DESCRIPTION
The `healthCheckGracePeriodSeconds` tells the ELB to hold off on declaring a task unhealthy, which serves a similar purpose to the ECS `startPeriod` value for the equivalent configuration in container health checks.

This should fix the occasional "Task failed ELB health checks" error when trying to update tasks.