### PR TITLE
wip(zero-cache): Mark desired query as inactive

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr-store.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.ts
@@ -459,7 +459,7 @@ export class CVRStore {
     });
   }
 
-  insertDesiredQuery(
+  putDesiredQuery(
     newVersion: CVRVersion,
     query: {id: string},
     client: {id: string},

--- a/packages/zero-cache/src/services/view-syncer/cvr-store.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.ts
@@ -202,7 +202,15 @@ export class CVRStore {
         tx<QueriesRow[]>`
         SELECT * FROM ${this.#cvr('queries')} 
           WHERE "clientGroupID" = ${id} AND (deleted IS NULL OR deleted = FALSE)`,
-        tx<DesiresRow[]>`SELECT * FROM ${this.#cvr('desires')}
+        tx<DesiresRow[]>`SELECT 
+          "clientGroupID",
+          "clientID",
+          "queryHash",
+          "patchVersion",
+          "deleted",
+          EXTRACT(EPOCH FROM "ttl") * 1000 AS "ttl",
+          "inactivatedAt"
+          FROM ${this.#cvr('desires')}
           WHERE "clientGroupID" = ${id} AND (deleted IS NULL OR deleted = FALSE)`,
       ]);
 
@@ -278,9 +286,8 @@ export class CVRStore {
       const query = cvr.queries[row.queryHash];
       if (query && !query.internal) {
         query.desiredBy[row.clientID] = {
-          expiresAt: row.expiresAt,
-          inactivatedAt: row.inactivatedAt,
-          ttl: row.ttl,
+          inactivatedAt: row.inactivatedAt ?? undefined,
+          ttl: row.ttl ?? undefined,
           version: versionFromString(row.patchVersion),
         };
       }
@@ -457,19 +464,17 @@ export class CVRStore {
     query: {id: string},
     client: {id: string},
     deleted: boolean,
-    expiresAt: number | null,
-    inactivatedAt: number | null,
-    ttl: number | null,
+    inactivatedAt: number | undefined,
+    ttl: number | undefined,
   ): void {
     const change: DesiresRow = {
       clientGroupID: this.#id,
       clientID: client.id,
       deleted,
-      expiresAt,
-      inactivatedAt,
+      inactivatedAt: inactivatedAt ?? null,
       patchVersion: versionString(newVersion),
       queryHash: query.id,
-      ttl,
+      ttl: ttl ?? null,
     };
     this.#writes.add({
       stats: {desires: 1},

--- a/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
@@ -299,9 +299,8 @@ describe('view-syncer/cvr', () => {
           desiredBy: {
             fooClient: {
               version: {stateVersion: '1a9', minorVersion: 1},
-              expiresAt: null,
-              inactivatedAt: null,
-              ttl: null,
+              inactivatedAt: undefined,
+              ttl: undefined,
             },
           },
           patchVersion: {stateVersion: '1a9', minorVersion: 2},
@@ -405,9 +404,8 @@ describe('view-syncer/cvr', () => {
           desiredBy: {
             fooClient: {
               version: {stateVersion: '1a9', minorVersion: 1},
-              expiresAt: null,
-              inactivatedAt: null,
-              ttl: null,
+              inactivatedAt: undefined,
+              ttl: undefined,
             },
           },
           patchVersion: {stateVersion: '1a9', minorVersion: 2},
@@ -637,15 +635,13 @@ describe('view-syncer/cvr', () => {
           desiredBy: {
             dooClient: {
               version: {stateVersion: '1a8'},
-              expiresAt: null,
-              inactivatedAt: null,
-              ttl: null,
+              inactivatedAt: undefined,
+              ttl: undefined,
             },
             fooClient: {
               version: {stateVersion: '1a9', minorVersion: 1},
-              expiresAt: null,
-              inactivatedAt: null,
-              ttl: null,
+              inactivatedAt: undefined,
+              ttl: undefined,
             },
           },
           patchVersion: {stateVersion: '1a9', minorVersion: 2},
@@ -850,9 +846,8 @@ describe('view-syncer/cvr', () => {
           desiredBy: {
             barClient: {
               version: {stateVersion: '1aa', minorVersion: 1},
-              expiresAt: null,
-              inactivatedAt: null,
-              ttl: null,
+              inactivatedAt: undefined,
+              ttl: undefined,
             },
           },
           patchVersion: {stateVersion: '1a9', minorVersion: 2},
@@ -863,15 +858,13 @@ describe('view-syncer/cvr', () => {
           desiredBy: {
             barClient: {
               version: {stateVersion: '1aa', minorVersion: 1},
-              expiresAt: null,
-              inactivatedAt: null,
-              ttl: null,
+              inactivatedAt: undefined,
+              ttl: undefined,
             },
             fooClient: {
               version: {stateVersion: '1aa', minorVersion: 1},
-              expiresAt: null,
-              inactivatedAt: null,
-              ttl: null,
+              inactivatedAt: undefined,
+              ttl: undefined,
             },
           },
         },
@@ -881,9 +874,8 @@ describe('view-syncer/cvr', () => {
           desiredBy: {
             fooClient: {
               version: {stateVersion: '1aa', minorVersion: 1},
-              expiresAt: null,
-              inactivatedAt: null,
-              ttl: null,
+              inactivatedAt: undefined,
+              ttl: undefined,
             },
           },
         },
@@ -1561,9 +1553,8 @@ describe('view-syncer/cvr', () => {
           desiredBy: {
             fooClient: {
               version: {stateVersion: '1a9', minorVersion: 1},
-              expiresAt: null,
-              inactivatedAt: null,
-              ttl: null,
+              inactivatedAt: undefined,
+              ttl: undefined,
             },
           },
           transformationHash: 'serverOneHash',
@@ -2013,9 +2004,8 @@ describe('view-syncer/cvr', () => {
           desiredBy: {
             fooClient: {
               version: {stateVersion: '1a9', minorVersion: 1},
-              expiresAt: null,
-              inactivatedAt: null,
-              ttl: null,
+              inactivatedAt: undefined,
+              ttl: undefined,
             },
           },
           transformationHash: 'serverTwoHash',
@@ -2611,9 +2601,8 @@ describe('view-syncer/cvr', () => {
           desiredBy: {
             fooClient: {
               version: {stateVersion: '1a9', minorVersion: 1},
-              expiresAt: null,
-              inactivatedAt: null,
-              ttl: null,
+              inactivatedAt: undefined,
+              ttl: undefined,
             },
           },
           transformationHash: 'updatedServerOneHash',
@@ -2626,9 +2615,8 @@ describe('view-syncer/cvr', () => {
           desiredBy: {
             fooClient: {
               version: {stateVersion: '1a9', minorVersion: 1},
-              expiresAt: null,
-              inactivatedAt: null,
-              ttl: null,
+              inactivatedAt: undefined,
+              ttl: undefined,
             },
           },
           transformationHash: 'updatedServerTwoHash',
@@ -3309,9 +3297,8 @@ describe('view-syncer/cvr', () => {
             },
             "desiredBy": {
               "fooClient": {
-                "expiresAt": null,
-                "inactivatedAt": null,
-                "ttl": null,
+                "inactivatedAt": undefined,
+                "ttl": undefined,
                 "version": {
                   "minorVersion": 1,
                   "stateVersion": "1a9",
@@ -3334,9 +3321,8 @@ describe('view-syncer/cvr', () => {
             },
             "desiredBy": {
               "fooClient": {
-                "expiresAt": null,
-                "inactivatedAt": null,
-                "ttl": null,
+                "inactivatedAt": undefined,
+                "ttl": undefined,
                 "version": {
                   "minorVersion": 1,
                   "stateVersion": "1a9",
@@ -4114,6 +4100,294 @@ describe('view-syncer/cvr', () => {
           table: 'issues',
         },
       ],
+    });
+  });
+
+  describe('markDesiredQueryAsInactive', () => {
+    test('no ttl', async () => {
+      const now = Date.UTC(2025, 2, 18);
+
+      const initialState: DBState = {
+        instances: [
+          {
+            clientGroupID: 'abc123',
+            version: '1aa',
+            replicaVersion: '120',
+            lastActive: now,
+          },
+        ],
+        clients: [
+          {
+            clientGroupID: 'abc123',
+            clientID: 'fooClient',
+            patchVersion: '1a9:01',
+            deleted: null,
+          },
+        ],
+        queries: [
+          {
+            clientGroupID: 'abc123',
+            queryHash: 'oneHash',
+            clientAST: {table: 'issues'},
+            transformationHash: null,
+            transformationVersion: null,
+            patchVersion: null,
+            internal: null,
+            deleted: null,
+          },
+        ],
+        desires: [
+          {
+            clientGroupID: 'abc123',
+            clientID: 'fooClient',
+            queryHash: 'oneHash',
+            patchVersion: '1a9:01',
+            deleted: null,
+            expiresAt: null,
+            inactivatedAt: null,
+            ttl: null,
+          },
+        ],
+        rows: [
+          {
+            clientGroupID: 'abc123',
+            rowKey: ROW_KEY1,
+            rowVersion: '03',
+            refCounts: {oneHash: 1},
+            patchVersion: '1a0',
+            schema: 'public',
+            table: 'issues',
+          },
+          {
+            clientGroupID: 'abc123',
+            rowKey: ROW_KEY2,
+            rowVersion: '03',
+            refCounts: {oneHash: 1},
+            patchVersion: '1a0',
+            schema: 'public',
+            table: 'issues',
+          },
+        ],
+      };
+
+      await setInitialState(db, initialState);
+
+      const cvrStore = new CVRStore(
+        lc,
+        db,
+        SHARD_ID,
+        'my-task',
+        'abc123',
+        ON_FAILURE,
+      );
+      const cvr = await cvrStore.load(lc, LAST_CONNECT);
+      expect(cvr).toMatchInlineSnapshot(`
+        {
+          "clients": {
+            "fooClient": {
+              "desiredQueryIDs": [
+                "oneHash",
+              ],
+              "id": "fooClient",
+            },
+          },
+          "id": "abc123",
+          "lastActive": 1742256000000,
+          "queries": {
+            "oneHash": {
+              "ast": {
+                "table": "issues",
+              },
+              "desiredBy": {
+                "fooClient": {
+                  "inactivatedAt": undefined,
+                  "ttl": undefined,
+                  "version": {
+                    "minorVersion": 1,
+                    "stateVersion": "1a9",
+                  },
+                },
+              },
+              "id": "oneHash",
+              "patchVersion": undefined,
+              "transformationHash": undefined,
+              "transformationVersion": undefined,
+            },
+          },
+          "replicaVersion": "120",
+          "version": {
+            "stateVersion": "1aa",
+          },
+        }
+      `);
+
+      const updater = new CVRConfigDrivenUpdater(cvrStore, cvr, SHARD_ID);
+      updater.markDesiredQueryAsInactive('fooClient', 'oneHash', now);
+
+      const {cvr: updated} = await updater.flush(lc, true, LAST_CONNECT, now);
+      expect(updated).toEqual({
+        clients: {
+          fooClient: {
+            desiredQueryIDs: ['oneHash'],
+            id: 'fooClient',
+          },
+        },
+        id: 'abc123',
+        lastActive: now,
+        queries: {
+          oneHash: {
+            ast: {
+              table: 'issues',
+            },
+            desiredBy: {
+              fooClient: {
+                inactivatedAt: now,
+                ttl: undefined,
+                version: {
+                  minorVersion: 1,
+                  stateVersion: '1aa',
+                },
+              },
+            },
+            id: 'oneHash',
+            patchVersion: undefined,
+            transformationHash: undefined,
+            transformationVersion: undefined,
+          },
+        },
+        replicaVersion: '120',
+        version: {
+          minorVersion: 1,
+          stateVersion: '1aa',
+        },
+      });
+    });
+
+    test('with ttl', async () => {
+      const now = Date.UTC(2025, 2, 18);
+      const ttl = 10_000;
+
+      const initialState: DBState = {
+        instances: [
+          {
+            clientGroupID: 'abc123',
+            version: '1aa',
+            replicaVersion: '120',
+            lastActive: now,
+          },
+        ],
+        clients: [
+          {
+            clientGroupID: 'abc123',
+            clientID: 'fooClient',
+            patchVersion: '1a9:01',
+            deleted: null,
+          },
+        ],
+        queries: [
+          {
+            clientGroupID: 'abc123',
+            queryHash: 'oneHash',
+            clientAST: {table: 'issues'},
+            transformationHash: null,
+            transformationVersion: null,
+            patchVersion: null,
+            internal: null,
+            deleted: null,
+          },
+        ],
+        desires: [
+          {
+            clientGroupID: 'abc123',
+            clientID: 'fooClient',
+            queryHash: 'oneHash',
+            patchVersion: '1a9:01',
+            deleted: null,
+            expiresAt: null,
+            inactivatedAt: null,
+            ttl: ttl / 1000,
+          },
+        ],
+        rows: [
+          {
+            clientGroupID: 'abc123',
+            rowKey: ROW_KEY1,
+            rowVersion: '03',
+            refCounts: {oneHash: 1},
+            patchVersion: '1a0',
+            schema: 'public',
+            table: 'issues',
+          },
+          {
+            clientGroupID: 'abc123',
+            rowKey: ROW_KEY2,
+            rowVersion: '03',
+            refCounts: {oneHash: 1},
+            patchVersion: '1a0',
+            schema: 'public',
+            table: 'issues',
+          },
+        ],
+      };
+
+      await setInitialState(db, initialState);
+
+      const cvrStore = new CVRStore(
+        lc,
+        db,
+        SHARD_ID,
+        'my-task',
+        'abc123',
+        ON_FAILURE,
+      );
+      const cvr = await cvrStore.load(lc, LAST_CONNECT);
+      expect(cvr.queries).toEqual({
+        oneHash: {
+          ast: {
+            table: 'issues',
+          },
+          desiredBy: {
+            fooClient: {
+              inactivatedAt: undefined,
+              ttl,
+              version: {
+                minorVersion: 1,
+                stateVersion: '1a9',
+              },
+            },
+          },
+          id: 'oneHash',
+          patchVersion: undefined,
+          transformationHash: undefined,
+          transformationVersion: undefined,
+        },
+      });
+
+      const updater = new CVRConfigDrivenUpdater(cvrStore, cvr, SHARD_ID);
+      updater.markDesiredQueryAsInactive('fooClient', 'oneHash', now);
+
+      const {cvr: updated} = await updater.flush(lc, true, LAST_CONNECT, now);
+      expect(updated.queries).toEqual({
+        oneHash: {
+          ast: {
+            table: 'issues',
+          },
+          desiredBy: {
+            fooClient: {
+              inactivatedAt: now,
+              ttl,
+              version: {
+                minorVersion: 1,
+                stateVersion: '1aa',
+              },
+            },
+          },
+          id: 'oneHash',
+          patchVersion: undefined,
+          transformationHash: undefined,
+          transformationVersion: undefined,
+        },
+      });
     });
   });
 });

--- a/packages/zero-cache/src/services/view-syncer/cvr.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.test.ts
@@ -1,0 +1,96 @@
+import {expect, test} from 'vitest';
+import {getInactiveDesiredQueries, type CVR} from './cvr.ts';
+
+type QueryDef = {
+  hash: string;
+  ttl: number | undefined;
+  inactivatedAt: number | undefined;
+};
+
+function makeCVR(clientID: string, queries: QueryDef[]): CVR {
+  return {
+    clients: {
+      [clientID]: {
+        desiredQueryIDs: queries.map(({hash}) => hash),
+        id: clientID,
+      },
+    },
+    id: 'abc123',
+    lastActive: Date.UTC(2024, 1, 19),
+    queries: Object.fromEntries(
+      queries.map(({hash, ttl, inactivatedAt}) => [
+        hash,
+        {
+          ast: {
+            table: 'issues',
+          },
+          desiredBy: {
+            [clientID]: {
+              inactivatedAt,
+              ttl,
+              version: {
+                minorVersion: 1,
+                stateVersion: '1a9',
+              },
+            },
+          },
+          id: hash,
+          patchVersion: undefined,
+          transformationHash: undefined,
+          transformationVersion: undefined,
+        },
+      ]),
+    ),
+    replicaVersion: '120',
+    version: {
+      stateVersion: '1aa',
+    },
+  };
+}
+
+test.each([
+  {
+    queries: [
+      {hash: 'h1', ttl: 1000, inactivatedAt: 1000},
+      {hash: 'h2', ttl: 1000, inactivatedAt: 2000},
+      {hash: 'h3', ttl: 1000, inactivatedAt: 3000},
+    ],
+    expected: ['h1', 'h2', 'h3'],
+  },
+  {
+    queries: [
+      {hash: 'h1', ttl: 2000, inactivatedAt: 1000},
+      {hash: 'h2', ttl: 1000, inactivatedAt: 1000},
+      {hash: 'h3', ttl: 3000, inactivatedAt: 1000},
+    ],
+    expected: ['h2', 'h1', 'h3'],
+  },
+  {
+    queries: [
+      {hash: 'h1', ttl: undefined, inactivatedAt: 1000},
+      {hash: 'h2', ttl: 2000, inactivatedAt: 1000},
+      {hash: 'h3', ttl: undefined, inactivatedAt: 3000},
+    ],
+    expected: ['h2', 'h1', 'h3'],
+  },
+  {
+    queries: [
+      {hash: 'h1', ttl: 500, inactivatedAt: undefined},
+      {hash: 'h2', ttl: undefined, inactivatedAt: undefined},
+      {hash: 'h3', ttl: 1000, inactivatedAt: 500},
+    ],
+    expected: ['h3'],
+  },
+  {
+    queries: [
+      {hash: 'h1', ttl: 1000, inactivatedAt: 1000},
+      {hash: 'h2', ttl: undefined, inactivatedAt: 2000},
+      {hash: 'h3', ttl: undefined, inactivatedAt: undefined},
+    ],
+    expected: ['h1', 'h2'],
+  },
+])('getInactiveQueries %o', ({queries, expected}) => {
+  const clientID = 'clientX';
+  const cvr = makeCVR(clientID, queries);
+  expect(getInactiveDesiredQueries(cvr, clientID)).toEqual(expected);
+});

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -237,7 +237,7 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
       });
 
       this._cvrStore.putQuery(query);
-      this._cvrStore.insertDesiredQuery(
+      this._cvrStore.putDesiredQuery(
         newVersion,
         query,
         client,
@@ -272,7 +272,7 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
     };
 
     // No need to put query... nothing changed.
-    this._cvrStore.insertDesiredQuery(
+    this._cvrStore.putDesiredQuery(
       newVersion,
       query,
       client,
@@ -310,7 +310,7 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
 
       delete query.desiredBy[clientID];
       this._cvrStore.putQuery(query);
-      this._cvrStore.insertDesiredQuery(
+      this._cvrStore.putDesiredQuery(
         newVersion,
         query,
         client,

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -219,15 +219,13 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
     client.desiredQueryIDs = [...union(current, needed)].sort(compareUTF8);
 
     for (const id of needed) {
-      const {ast, ttl = null} = must(queries.find(({hash}) => hash === id));
+      const {ast, ttl} = must(queries.find(({hash}) => hash === id));
       const query = this._cvr.queries[id] ?? {id, ast, desiredBy: {}};
       assertNotInternal(query);
 
-      const expiresAt = null;
-      const inactivatedAt = null;
+      const inactivatedAt = undefined;
 
       query.desiredBy[clientID] = {
-        expiresAt,
         inactivatedAt,
         ttl,
         version: newVersion,
@@ -244,12 +242,51 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
         query,
         client,
         false,
-        expiresAt,
         inactivatedAt,
         ttl,
       );
     }
     return patches;
+  }
+
+  markDesiredQueryAsInactive(
+    clientID: string,
+    hash: string,
+    now: number,
+  ): void {
+    const client = this.#ensureClient(clientID);
+    assert(client.desiredQueryIDs.includes(hash));
+    const newVersion = this._ensureNewVersion();
+
+    const query = this._cvr.queries[hash];
+    assert(query, `Query ${hash} not found`);
+    assertNotInternal(query);
+
+    const {inactivatedAt, ttl} = must(query.desiredBy[clientID]);
+    assert(inactivatedAt === undefined, `Query ${hash} is already inactivated`);
+
+    query.desiredBy[clientID] = {
+      inactivatedAt: now,
+      ttl: ttl ?? undefined,
+      version: newVersion,
+    };
+
+    // No need to put query... nothing changed.
+    this._cvrStore.insertDesiredQuery(
+      newVersion,
+      query,
+      client,
+      false,
+      now,
+      ttl ?? undefined,
+    );
+  }
+
+  /**
+   * Returns non active queries in the order that we want to remove them.
+   */
+  getInactiveDesiredQueries(clientID: string): string[] {
+    return getInactiveDesiredQueries(this._cvr, clientID);
   }
 
   deleteDesiredQueries(clientID: string, queries: string[]): PatchToVersion[] {
@@ -278,9 +315,8 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
         query,
         client,
         true,
-        null,
-        null,
-        null,
+        undefined,
+        undefined,
       );
       patches.push({
         toVersion: newVersion,
@@ -696,4 +732,46 @@ function mergeRefCounts(
   }
 
   return Object.values(merged).some(v => v > 0) ? merged : null;
+}
+
+export function getInactiveDesiredQueries(
+  cvr: CVR,
+  clientID: string,
+): string[] {
+  const client = cvr.clients[clientID];
+  if (!client) {
+    return [];
+  }
+
+  const inactive: {
+    hash: string;
+    inactivatedAt: number;
+    ttl: number | undefined;
+  }[] = [];
+  for (const queryID of client.desiredQueryIDs) {
+    const query = must(cvr.queries[queryID], `Query ${queryID} not found`);
+    if (query.internal) {
+      continue;
+    }
+    const {inactivatedAt, ttl} = must(query.desiredBy[clientID]);
+    // eslint-disable-next-line eqeqeq
+    if (inactivatedAt != null) {
+      inactive.push({hash: queryID, inactivatedAt, ttl: ttl ?? undefined});
+    }
+  }
+  // First sort all the queries that have TTL. Oldest first.
+  return inactive
+    .sort((a, b) => {
+      if (a.ttl === b.ttl) {
+        return a.inactivatedAt - b.inactivatedAt;
+      }
+      if (a.ttl === undefined) {
+        return 1;
+      }
+      if (b.ttl === undefined) {
+        return -1;
+      }
+      return a.inactivatedAt + a.ttl - b.inactivatedAt - b.ttl;
+    })
+    .map(({hash}) => hash);
 }

--- a/packages/zero-cache/src/services/view-syncer/schema/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/cvr.ts
@@ -143,8 +143,9 @@ export type DesiresRow = {
   patchVersion: string;
   deleted: boolean | null;
   ttl: number | null;
-  expiresAt: number | null;
   inactivatedAt: number | null;
+  /** @deprecated */
+  expiresAt?: number | null;
 };
 
 function createDesiresTable(shardID: string) {
@@ -156,7 +157,7 @@ CREATE TABLE ${schema(shardID)}.desires (
   "patchVersion"       TEXT NOT NULL,
   "deleted"            BOOL,  -- put vs del "desired" query
   "ttl"                INTERVAL,  -- Time to live for this client
-  "expiresAt"          TIMESTAMPTZ,  -- Time at which this row expires
+  "expiresAt"          TIMESTAMPTZ,  -- DEPRECATED Time at which this row expires
   "inactivatedAt"      TIMESTAMPTZ,  -- Time at which this row was inactivated
 
   PRIMARY KEY ("clientGroupID", "clientID", "queryHash"),

--- a/packages/zero-cache/src/services/view-syncer/schema/types.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/types.ts
@@ -163,22 +163,20 @@ export const internalQueryRecordSchema = baseQueryRecordSchema.extend({
 export type InternalQueryRecord = v.Infer<typeof internalQueryRecordSchema>;
 
 const clientLRUSchema = v.object({
-  /**
-   * The time to delete the query. This is the {@linkcode ttl} plus the {@linkcode inactivatedAt}.
-   */
-  expiresAt: v.number().nullable(),
+  // /** @deprecated */
+  expiresAt: v.number().nullable().optional(),
 
   /**
    * The time at which the query was last inactivated. If this undefined or
    * missing then the query is active.
    */
-  inactivatedAt: v.number().nullable(),
+  inactivatedAt: v.number().nullable().optional(),
 
   /**
    * TTL, time to live in milliseconds. If the query is not updated within this time.
    * The time to live is the time after it has become inactive.
    */
-  ttl: v.number().nullable(),
+  ttl: v.number().nullable().optional(),
 
   /**
    * The version at which the desired query info changed (i.e. individual `patchVersion`s).


### PR DESCRIPTION
and getInactiveDesiredQueries which returns all inactive queries in the order that we want to try to remove them.