### PR TITLE
feat(zero-cache): copy before index (faster initial sync)

### DIFF
--- a/packages/zero-cache/src/db/migration-lite.ts
+++ b/packages/zero-cache/src/db/migration-lite.ts
@@ -63,6 +63,7 @@ export async function runSchemaMigrations(
   setupMigration: Migration,
   incrementalMigrationMap: IncrementalMigrationMap,
 ): Promise<void> {
+  const start = Date.now();
   log = log.withContext(
     'initSchema',
     randInt(0, Number.MAX_SAFE_INTEGER).toString(36),
@@ -138,7 +139,11 @@ export async function runSchemaMigrations(
     }
 
     assert(versions.dataVersion === codeVersion);
-    log.info?.(`Running ${debugName} at schema v${codeVersion}`);
+    log.info?.(
+      `Running ${debugName} at schema v${codeVersion} (${
+        Date.now() - start
+      } ms)`,
+    );
   } catch (e) {
     log.error?.('Error in ensureSchemaMigrated', e);
     throw e;


### PR DESCRIPTION
Copy tables / rows before creating indexes. On a 1GB dataset, this doubles the speed of initial sync, though improvements may be larger for tables with more complex indexes.

Before:
<img width="691" alt="Screenshot 2025-02-18 at 18 46 27" src="https://github.com/user-attachments/assets/c64c4d04-9a9f-4459-8fcd-1131d329fa10" />



After:
<img width="680" alt="Screenshot 2025-02-19 at 08 27 52" src="https://github.com/user-attachments/assets/e31f120c-ac1b-4442-8b94-55f83a2ddb15" />
