### PR TITLE
fix(zero-cache): handle query collisions

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -4,6 +4,7 @@ import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.
 import type {AST} from '../../../../zero-protocol/src/ast.ts';
 import type {Database as DB} from '../../../../zqlite/src/db.ts';
 import {Database} from '../../../../zqlite/src/db.ts';
+import type {LogConfig} from '../../config/zero-config.ts';
 import {DbFile} from '../../test/lite.ts';
 import {initChangeLog} from '../replicator/schema/change-log.ts';
 import {initReplicationState} from '../replicator/schema/replication-state.ts';
@@ -15,7 +16,6 @@ import {
 import {CREATE_STORAGE_TABLE, DatabaseStorage} from './database-storage.ts';
 import {PipelineDriver} from './pipeline-driver.ts';
 import {ResetPipelinesSignal, Snapshotter} from './snapshotter.ts';
-import type {LogConfig} from '../../config/zero-config.ts';
 
 const logConfig: LogConfig = {
   format: 'text',
@@ -397,6 +397,11 @@ describe('view-syncer/pipeline-driver', () => {
           },
         ]
       `);
+
+    // Adding a query with the same hash should be a noop.
+    expect([
+      ...pipelines.addQuery('hash1', ISSUES_AND_COMMENTS),
+    ]).toMatchInlineSnapshot(`[]`);
   });
 
   test('insert', () => {

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -201,11 +201,17 @@ export class PipelineDriver {
    * driver is {@link advance}d. The query and its pipeline can be removed with
    * {@link removeQuery()}.
    *
+   * If a query with an identical hash has already been added, this method
+   * is a no-op and no RowChanges are generated.
+   *
    * @return The rows from the initial hydration of the query.
    */
   *addQuery(hash: string, query: AST): Iterable<RowChange> {
     assert(this.initialized());
-    assert(!this.#pipelines.has(hash), `query ${hash} already added`);
+    if (this.#pipelines.has(hash)) {
+      this.#lc.info?.(`query ${hash} already added`, query);
+      return;
+    }
     const input = buildPipeline(query, {
       getSource: name => this.#getSource(name),
       createStorage: () => this.#createStorage(),

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -1103,6 +1103,8 @@ describe('view-syncer/service', () => {
   test('initial hydration, rows in multiple queries', async () => {
     const client = connect(SYNC_CONTEXT, [
       {op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY},
+      // Test multiple queries that normalize to the same hash.
+      {op: 'put', hash: 'query-hash1.1', ast: ISSUES_QUERY},
       {op: 'put', hash: 'query-hash2', ast: ISSUES_QUERY2},
     ]);
     expect(await nextPoke(client)).toMatchInlineSnapshot(`
@@ -1148,6 +1150,36 @@ describe('view-syncer/service', () => {
                     },
                   },
                   "hash": "query-hash1",
+                  "op": "put",
+                },
+                {
+                  "ast": {
+                    "orderBy": [
+                      [
+                        "id",
+                        "asc",
+                      ],
+                    ],
+                    "table": "issues",
+                    "where": {
+                      "left": {
+                        "name": "id",
+                        "type": "column",
+                      },
+                      "op": "IN",
+                      "right": {
+                        "type": "literal",
+                        "value": [
+                          "1",
+                          "2",
+                          "3",
+                          "4",
+                        ],
+                      },
+                      "type": "simple",
+                    },
+                  },
+                  "hash": "query-hash1.1",
                   "op": "put",
                 },
                 {
@@ -1225,6 +1257,36 @@ describe('view-syncer/service', () => {
                   },
                 },
                 "hash": "query-hash1",
+                "op": "put",
+              },
+              {
+                "ast": {
+                  "orderBy": [
+                    [
+                      "id",
+                      "asc",
+                    ],
+                  ],
+                  "table": "issues",
+                  "where": {
+                    "left": {
+                      "name": "id",
+                      "type": "column",
+                    },
+                    "op": "IN",
+                    "right": {
+                      "type": "literal",
+                      "value": [
+                        "1",
+                        "2",
+                        "3",
+                        "4",
+                      ],
+                    },
+                    "type": "simple",
+                  },
+                },
+                "hash": "query-hash1.1",
                 "op": "put",
               },
               {
@@ -1347,6 +1409,7 @@ describe('view-syncer/service', () => {
           "patchVersion": "01",
           "refCounts": {
             "query-hash1": 1,
+            "query-hash1.1": 1,
             "query-hash2": 1,
           },
           "rowKey": {
@@ -1361,6 +1424,7 @@ describe('view-syncer/service', () => {
           "patchVersion": "01",
           "refCounts": {
             "query-hash1": 1,
+            "query-hash1.1": 1,
             "query-hash2": 1,
           },
           "rowKey": {
@@ -1375,6 +1439,7 @@ describe('view-syncer/service', () => {
           "patchVersion": "01",
           "refCounts": {
             "query-hash1": 1,
+            "query-hash1.1": 1,
             "query-hash2": 1,
           },
           "rowKey": {
@@ -1389,6 +1454,7 @@ describe('view-syncer/service', () => {
           "patchVersion": "01",
           "refCounts": {
             "query-hash1": 1,
+            "query-hash1.1": 1,
             "query-hash2": 1,
           },
           "rowKey": {


### PR DESCRIPTION
Handle the case when multiple queries (with different client hashes) are logically equivalent. This was not expected before but can reasonably happen after applying permissions. It is occasionally encountered when multiple queries are disallowed entirely.

https://bugs.rocicorp.dev/issue/3584

https://rocicorp.slack.com/archives/C08AHHFQMMY/p1739577732367319?thread_ts=1739485390.141439&cid=C08AHHFQMMY