### PR TITLE
wip(zero): Expire queries

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -625,6 +625,7 @@ describe('view-syncer/service', () => {
       },
     ]);
 
+    const inactivatedAt = Date.now();
     // Change the set of queries.
     await vs.changeDesiredQueries(SYNC_CONTEXT, [
       'changeDesiredQueries',
@@ -648,7 +649,7 @@ describe('view-syncer/service', () => {
     expect(cvr).toMatchObject({
       clients: {
         foo: {
-          desiredQueryIDs: ['query-hash2'],
+          desiredQueryIDs: ['query-hash2', 'query-hash1'],
           id: 'foo',
         },
       },
@@ -658,6 +659,17 @@ describe('view-syncer/service', () => {
           ast: EXPECTED_LMIDS_AST,
           internal: true,
           id: 'lmids',
+        },
+        'query-hash1': {
+          ast: ISSUES_QUERY,
+          desiredBy: {
+            foo: {
+              inactivatedAt: expect.closeTo(inactivatedAt, 10),
+              ttl: undefined,
+              version: {minorVersion: 2, stateVersion: '00'},
+            },
+          },
+          id: 'query-hash1',
         },
         'query-hash2': {
           ast: USERS_QUERY,

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -58,6 +58,7 @@ import {
 import {DrainCoordinator} from './drain-coordinator.ts';
 import {PipelineDriver} from './pipeline-driver.ts';
 import {initViewSyncerSchema} from './schema/init.ts';
+import type {ClientQueryRecord} from './schema/types.ts';
 import {Snapshotter} from './snapshotter.ts';
 import {pickToken, type SyncContext, ViewSyncerService} from './view-syncer.ts';
 
@@ -664,7 +665,7 @@ describe('view-syncer/service', () => {
           ast: ISSUES_QUERY,
           desiredBy: {
             foo: {
-              inactivatedAt: expect.closeTo(inactivatedAt, 10),
+              inactivatedAt: expect.any(Number),
               ttl: undefined,
               version: {minorVersion: 2, stateVersion: '00'},
             },
@@ -679,6 +680,14 @@ describe('view-syncer/service', () => {
       },
       version: {stateVersion: '00', minorVersion: 2},
     });
+    expect(
+      (cvr.queries['query-hash1'] as ClientQueryRecord).desiredBy.foo
+        .inactivatedAt,
+    ).toBeGreaterThanOrEqual(inactivatedAt);
+    expect(
+      (cvr.queries['query-hash1'] as ClientQueryRecord).desiredBy.foo
+        .inactivatedAt,
+    ).toBeLessThanOrEqual(inactivatedAt + 10);
   });
 
   test('initial hydration', async () => {

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -593,6 +593,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         lc.debug?.(`applying ${desiredQueriesPatch.length} query patches`);
         // cvr = ... For #syncQueryPipelineSet().
         cvr = await this.#updatePatchesForDesiredQueries(lc, cvr, updater => {
+          const now = Date.now();
           const patches: PatchToVersion[] = [];
           for (const patch of desiredQueriesPatch) {
             switch (patch.op) {
@@ -600,9 +601,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
                 patches.push(...updater.putDesiredQueries(clientID, [patch]));
                 break;
               case 'del':
-                patches.push(
-                  ...updater.deleteDesiredQueries(clientID, [patch.hash]),
-                );
+                updater.markDesiredQueryAsInactive(clientID, patch.hash, now);
                 break;
               case 'clear':
                 patches.push(...updater.clearDesiredQueries(clientID));


### PR DESCRIPTION
This adds more parts to support TTL.

When the client sends a `op: del` `'changeDesiredQueries'` message the query is not deleted from the desired queries, but marked as inactive and it gets a expiresAt value.

In the run loop we check if there are expired queries and if there are, we call `#syncQueryPipelineSet` which will call `#addAndRemoveQueries`