### PR TITLE
feat(zero-permissions): deploy permissions via a Lambda in the VPC

### DIFF
--- a/.github/workflows/sst-sandbox-deploy.yml
+++ b/.github/workflows/sst-sandbox-deploy.yml
@@ -78,5 +78,9 @@ jobs:
           DOMAIN_CERT: ${{ vars.SANDBOX_CERTIFICATE_ARN }}
         run: |
           cd prod/sst
+          # The permissions.deployer function's package.json is configured to install
+          # "@rocicorp/zero" from "file:rocicorp-zero.tgz". This allows us to deploy
+          # permissions with the same code that the view-syncer is running.
+          cp ../../packages/zero/pkgs/${{ env.ZERO_VERSION }} ./rocicorp-zero.tgz
           npm install
           npx sst deploy --stage sandbox

--- a/prod/functions/package.json
+++ b/prod/functions/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "functions",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "check-types": "tsc",
+    "format": "prettier --write .",
+    "check-format": "prettier --check .",
+    "lint": "eslint --ext .ts,.tsx,.js,.jsx src/"
+  },
+  "dependencies": {
+    "@rocicorp/zero": "file:rocicorp-zero.tgz"
+  }
+}

--- a/prod/functions/src/permissions.ts
+++ b/prod/functions/src/permissions.ts
@@ -1,0 +1,4 @@
+import { execSync } from "node:child_process";
+
+export const deploy = () =>
+  execSync("npx zero-deploy-permissions", { stdio: "inherit" });

--- a/prod/functions/tsconfig.json
+++ b/prod/functions/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "lib": ["es2022", "dom"],
+    "types": ["node"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
In the sandbox stage, deploy permission using a Lambda in the VPC, as an example of how permissions can be deployed to upstream databases that are not accessible outside of the AWS network.

This is largely how we would recommend users to deploy permissions. The only difference for the `mono` / `zbugs` setup is that because we deploy at head, we install "@rocicorp/zero" via a tarball, whereas users would simply reference their desired version in the function's `package.json` file.

For prod, continue using the local `Command` to deploy permissions, so that both approaches are exercised.