### PR TITLE
feat(zero-cache): make litestream snapshot timing more precise

### DIFF
--- a/packages/zero-cache/src/services/litestream/commands.ts
+++ b/packages/zero-cache/src/services/litestream/commands.ts
@@ -51,6 +51,11 @@ function getLitestream(
     incrementalBackupIntervalMinutes,
     snapshotBackupIntervalHours,
   } = config.litestream;
+
+  // Set the snapshot interval to something smaller than x hours so that
+  // the hourly check triggers on the hour, rather than the hour after.
+  const snapshotBackupIntervalMinutes = snapshotBackupIntervalHours * 60 - 5;
+
   return {
     litestream: must(executable, `Missing --litestream-executable`),
     env: {
@@ -61,8 +66,8 @@ function getLitestream(
         incrementalBackupIntervalMinutes,
       ),
       ['ZERO_LITESTREAM_LOG_LEVEL']: logLevelOverride ?? logLevel,
-      ['ZERO_LITESTREAM_SNAPSHOT_BACKUP_INTERVAL_HOURS']: String(
-        snapshotBackupIntervalHours,
+      ['ZERO_LITESTREAM_SNAPSHOT_BACKUP_INTERVAL_MINUTES']: String(
+        snapshotBackupIntervalMinutes,
       ),
       ['ZERO_LOG_FORMAT']: config.log.format,
       ['LITESTREAM_CONFIG']: configPath,

--- a/packages/zero-cache/src/services/litestream/config.yml
+++ b/packages/zero-cache/src/services/litestream/config.yml
@@ -3,7 +3,8 @@ dbs:
     monitor-interval: 1m
     replicas:
       - url: ${ZERO_LITESTREAM_BACKUP_URL}
-        retention: ${ZERO_LITESTREAM_SNAPSHOT_BACKUP_INTERVAL_HOURS}h
+        retention: ${ZERO_LITESTREAM_SNAPSHOT_BACKUP_INTERVAL_MINUTES}m
+        retention-check-interval: 1h
         sync-interval: ${ZERO_LITESTREAM_INCREMENTAL_BACKUP_INTERVAL_MINUTES}m
 
 logging:


### PR DESCRIPTION
The retention check happens every hour, so set the retention interval to something before the hour, otherwise the snaphot will always happen an hour later.