### PR TITLE
feat(zero-cache): Evict inactive queries 

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr-store.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.ts
@@ -109,6 +109,7 @@ export class CVRStore {
   readonly #rowCache: RowRecordCache;
   readonly #loadAttemptIntervalMs: number;
   readonly #maxLoadAttempts: number;
+  #rowCount: number = 0;
 
   constructor(
     lc: LogContext,
@@ -642,6 +643,7 @@ export class CVRStore {
     };
     if (this.#pendingRowRecordUpdates.size) {
       const existingRowRecords = await this.getRowRecords();
+      this.#rowCount = existingRowRecords.size;
       for (const [id, row] of this.#pendingRowRecordUpdates.entries()) {
         if (this.#forceUpdates.has(id)) {
           continue;
@@ -716,12 +718,16 @@ export class CVRStore {
       stats.rows += this.#pendingRowRecordUpdates.size;
       return true;
     });
-    await this.#rowCache.apply(
+    this.#rowCount = await this.#rowCache.apply(
       this.#pendingRowRecordUpdates,
       newVersion,
       rowsFlushed,
     );
     return stats;
+  }
+
+  get rowCount(): number {
+    return this.#rowCount;
   }
 
   async flush(

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -294,11 +294,14 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
     return getInactiveQueries(this._cvr);
   }
 
-  deleteDesiredQueries(clientID: string, queries: string[]): PatchToVersion[] {
+  deleteDesiredQueries(
+    clientID: string,
+    queryHashes: string[],
+  ): PatchToVersion[] {
     const patches: PatchToVersion[] = [];
     const client = this.#ensureClient(clientID);
     const current = new Set(client.desiredQueryIDs);
-    const unwanted = new Set(queries);
+    const unwanted = new Set(queryHashes);
     const remove = intersection(unwanted, current);
     if (remove.size === 0) {
       return patches;

--- a/packages/zero-cache/src/services/view-syncer/row-record-cache.ts
+++ b/packages/zero-cache/src/services/view-syncer/row-record-cache.ts
@@ -164,7 +164,7 @@ export class RowRecordCache {
     rowRecords: Map<RowID, RowRecord | null>,
     rowsVersion: CVRVersion,
     flushed: boolean,
-  ) {
+  ): Promise<number> {
     const cache = await this.#ensureLoaded();
     for (const [id, row] of rowRecords.entries()) {
       if (row === null || row.refCounts === null) {
@@ -182,6 +182,7 @@ export class RowRecordCache {
       this.#flushing = resolver();
       this.#setTimeout(() => this.#flush(), 0);
     }
+    return cache.size;
   }
 
   async #flush() {

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -625,6 +625,7 @@ describe('view-syncer/service', () => {
       },
     ]);
 
+    const inactivatedAt = Date.now();
     // Change the set of queries.
     await vs.changeDesiredQueries(SYNC_CONTEXT, [
       'changeDesiredQueries',
@@ -648,7 +649,7 @@ describe('view-syncer/service', () => {
     expect(cvr).toMatchObject({
       clients: {
         foo: {
-          desiredQueryIDs: ['query-hash2'],
+          desiredQueryIDs: ['query-hash2', 'query-hash1'],
           id: 'foo',
         },
       },
@@ -658,6 +659,17 @@ describe('view-syncer/service', () => {
           ast: EXPECTED_LMIDS_AST,
           internal: true,
           id: 'lmids',
+        },
+        'query-hash1': {
+          ast: ISSUES_QUERY,
+          desiredBy: {
+            foo: {
+              inactivatedAt: expect.closeTo(inactivatedAt, 10),
+              ttl: undefined,
+              version: {minorVersion: 2, stateVersion: '00'},
+            },
+          },
+          id: 'query-hash1',
         },
         'query-hash2': {
           ast: USERS_QUERY,

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -58,6 +58,7 @@ import {
 import {DrainCoordinator} from './drain-coordinator.ts';
 import {PipelineDriver} from './pipeline-driver.ts';
 import {initViewSyncerSchema} from './schema/init.ts';
+import type {ClientQueryRecord} from './schema/types.ts';
 import {Snapshotter} from './snapshotter.ts';
 import {pickToken, type SyncContext, ViewSyncerService} from './view-syncer.ts';
 
@@ -664,7 +665,7 @@ describe('view-syncer/service', () => {
           ast: ISSUES_QUERY,
           desiredBy: {
             foo: {
-              inactivatedAt: expect.closeTo(inactivatedAt, 10),
+              inactivatedAt: expect.any(Number),
               ttl: undefined,
               version: {minorVersion: 2, stateVersion: '00'},
             },
@@ -679,6 +680,14 @@ describe('view-syncer/service', () => {
       },
       version: {stateVersion: '00', minorVersion: 2},
     });
+    expect(
+      (cvr.queries['query-hash1'] as ClientQueryRecord).desiredBy.foo
+        .inactivatedAt,
+    ).toBeGreaterThanOrEqual(inactivatedAt);
+    expect(
+      (cvr.queries['query-hash1'] as ClientQueryRecord).desiredBy.foo
+        .inactivatedAt,
+    ).toBeLessThanOrEqual(inactivatedAt + 10);
   });
 
   test('initial hydration', async () => {

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -259,9 +259,15 @@ const labels = table('labels')
     name: string(),
   })
   .primaryKey('id');
+const users = table('users')
+  .columns({
+    id: string(),
+    name: string(),
+  })
+  .primaryKey('id');
 
 const schema = createSchema(1, {
-  tables: [issues, comments, issueLabels, labels],
+  tables: [issues, comments, issueLabels, labels, users],
   relationships: [
     relationships(comments, connect => ({
       issue: connect.many({
@@ -283,6 +289,7 @@ const canSeeIssue = (
   authData: AuthData,
   eb: ExpressionBuilder<Schema, 'issues'>,
 ) => eb.cmpLit(authData.role, '=', 'admin');
+
 const permissions = await definePermissions<AuthData, typeof schema>(
   schema,
   () => ({
@@ -311,6 +318,7 @@ const permissionsAll = await definePermissions<AuthData, typeof schema>(
     comments: ANYONE_CAN_DO_ANYTHING,
     issueLabels: ANYONE_CAN_DO_ANYTHING,
     labels: ANYONE_CAN_DO_ANYTHING,
+    users: ANYONE_CAN_DO_ANYTHING,
   }),
 );
 
@@ -477,6 +485,15 @@ async function setup(permissions: PermissionsConfig | undefined) {
     return received;
   }
 
+  async function nextPokeParts(
+    client: Queue<Downstream>,
+  ): Promise<PokePartBody[]> {
+    const pokes = await nextPoke(client);
+    return pokes
+      .filter((msg: Downstream) => msg[0] === 'pokePart')
+      .map(([, body]) => body);
+  }
+
   async function expectNoPokes(client: Queue<Downstream>) {
     // Use the dequeue() API that cancels the dequeue() request after a timeout.
     const timedOut = 'nothing' as unknown as Downstream;
@@ -497,6 +514,7 @@ async function setup(permissions: PermissionsConfig | undefined) {
     connect,
     connectWithQueueAndSource,
     nextPoke,
+    nextPokeParts,
     expectNoPokes,
   };
 }
@@ -539,6 +557,7 @@ describe('view-syncer/service', () => {
     source: Source<Downstream>;
   };
   let nextPoke: (client: Queue<Downstream>) => Promise<Downstream[]>;
+  let nextPokeParts: (client: Queue<Downstream>) => Promise<PokePartBody[]>;
   let expectNoPokes: (client: Queue<Downstream>) => Promise<void>;
 
   const SYNC_CONTEXT: SyncContext = {
@@ -565,6 +584,7 @@ describe('view-syncer/service', () => {
       connect,
       connectWithQueueAndSource,
       nextPoke,
+      nextPokeParts,
       expectNoPokes,
     } = await setup(permissionsAll));
   });
@@ -1070,6 +1090,29 @@ describe('view-syncer/service', () => {
               },
             ],
             "pokeID": "01:02",
+            "rowsPatch": [
+              {
+                "id": {
+                  "id": "100",
+                },
+                "op": "del",
+                "tableName": "users",
+              },
+              {
+                "id": {
+                  "id": "101",
+                },
+                "op": "del",
+                "tableName": "users",
+              },
+              {
+                "id": {
+                  "id": "102",
+                },
+                "op": "del",
+                "tableName": "users",
+              },
+            ],
           },
         ],
         [
@@ -3564,6 +3607,663 @@ describe('view-syncer/service', () => {
         ]
       `);
 
+      await expectNoPokes(client);
+    });
+  });
+
+  describe('LRU', () => {
+    // USERS_QUERY has 3 rows
+    // COMMENTS_QUERY has 2 rows
+    // ISSUES_QUERY has 4 rows
+
+    test('LRU eviction - 2 queries, 1 with ttl', async () => {
+      vs.maxRowCount = 4;
+
+      vi.setSystemTime(Date.UTC(2025, 1, 20));
+
+      // If we have both USERS_QUERY and COMMENTS_QUERY we should evict the older one.
+      const client = connect(SYNC_CONTEXT, [
+        {op: 'put', hash: 'user-query-hash', ast: USERS_QUERY},
+        {op: 'put', hash: 'comment-query-hash', ast: COMMENTS_QUERY, ttl: 10},
+      ]);
+
+      await nextPoke(client);
+
+      stateChanges.push({state: 'version-ready'});
+      expect(await nextPokeParts(client)).toMatchInlineSnapshot(`
+        [
+          {
+            "gotQueriesPatch": [
+              {
+                "ast": {
+                  "orderBy": [
+                    [
+                      "id",
+                      "asc",
+                    ],
+                  ],
+                  "table": "users",
+                },
+                "hash": "user-query-hash",
+                "op": "put",
+              },
+              {
+                "ast": {
+                  "orderBy": [
+                    [
+                      "id",
+                      "asc",
+                    ],
+                  ],
+                  "table": "comments",
+                },
+                "hash": "comment-query-hash",
+                "op": "put",
+              },
+            ],
+            "lastMutationIDChanges": {
+              "foo": 42,
+            },
+            "pokeID": "01",
+            "rowsPatch": [
+              {
+                "op": "put",
+                "tableName": "users",
+                "value": {
+                  "id": "100",
+                  "name": "Alice",
+                },
+              },
+              {
+                "op": "put",
+                "tableName": "users",
+                "value": {
+                  "id": "101",
+                  "name": "Bob",
+                },
+              },
+              {
+                "op": "put",
+                "tableName": "users",
+                "value": {
+                  "id": "102",
+                  "name": "Candice",
+                },
+              },
+              {
+                "op": "put",
+                "tableName": "comments",
+                "value": {
+                  "id": "1",
+                  "issueID": "1",
+                  "text": "comment 1",
+                },
+              },
+              {
+                "op": "put",
+                "tableName": "comments",
+                "value": {
+                  "id": "2",
+                  "issueID": "1",
+                  "text": "comment 2",
+                },
+              },
+            ],
+          },
+        ]
+      `);
+
+      expect(
+        (
+          await cvrDB`SELECT count(*) from cvr_abc.rows where cvr_abc.rows.table != 'zero_abc.clients'`.values()
+        )[0][0],
+      ).toBe(5n);
+
+      await expectNoPokes(client);
+
+      // We now mark the USERS_QUERY as inactive. Since we are above the desired
+      // row count we will evict the USERS_QUERY and get rowsPatch deletes.
+      await vs.changeDesiredQueries(SYNC_CONTEXT, [
+        'changeDesiredQueries',
+        {
+          desiredQueriesPatch: [{op: 'del', hash: 'user-query-hash'}],
+        },
+      ]);
+
+      stateChanges.push({state: 'version-ready'});
+      await nextPoke(client);
+      expect((await nextPoke(client))[1]).toMatchInlineSnapshot(`
+        [
+          "pokePart",
+          {
+            "desiredQueriesPatches": {
+              "foo": [
+                {
+                  "hash": "user-query-hash",
+                  "op": "del",
+                },
+              ],
+            },
+            "pokeID": "01:02",
+          },
+        ]
+      `);
+
+      stateChanges.push({state: 'version-ready'});
+      expect(await nextPokeParts(client)).toMatchInlineSnapshot(`
+        [
+          {
+            "gotQueriesPatch": [
+              {
+                "hash": "user-query-hash",
+                "op": "del",
+              },
+            ],
+            "pokeID": "01:03",
+            "rowsPatch": [
+              {
+                "id": {
+                  "id": "100",
+                },
+                "op": "del",
+                "tableName": "users",
+              },
+              {
+                "id": {
+                  "id": "101",
+                },
+                "op": "del",
+                "tableName": "users",
+              },
+              {
+                "id": {
+                  "id": "102",
+                },
+                "op": "del",
+                "tableName": "users",
+              },
+            ],
+          },
+        ]
+      `);
+
+      await expectNoPokes(client);
+
+      // Now we inactive the COMMENTS_QUERY which has a ttl of 10
+      await vs.changeDesiredQueries(SYNC_CONTEXT, [
+        'changeDesiredQueries',
+        {
+          desiredQueriesPatch: [{op: 'del', hash: 'comment-query-hash'}],
+        },
+      ]);
+
+      stateChanges.push({state: 'version-ready'});
+      await nextPoke(client);
+      await expectNoPokes(client);
+
+      // We fast forward to after the COMMENTS_QUERY has expired.
+      vi.setSystemTime(Date.now() + 11);
+      stateChanges.push({state: 'version-ready'});
+      expect(await nextPokeParts(client)).toMatchInlineSnapshot(`
+        [
+          {
+            "gotQueriesPatch": [
+              {
+                "hash": "comment-query-hash",
+                "op": "del",
+              },
+            ],
+            "pokeID": "01:05",
+            "rowsPatch": [
+              {
+                "id": {
+                  "id": "1",
+                },
+                "op": "del",
+                "tableName": "comments",
+              },
+              {
+                "id": {
+                  "id": "2",
+                },
+                "op": "del",
+                "tableName": "comments",
+              },
+            ],
+          },
+        ]
+      `);
+      await expectNoPokes(client);
+    });
+
+    test('LRU eviction - 3 queries no ttl', async () => {
+      vs.maxRowCount = 4;
+
+      vi.setSystemTime(Date.UTC(2025, 1, 20));
+
+      // This test is similar to the previous one but we have 3 queries with no ttl.
+      // We will inactivate users firts, then comments and finally issues.
+      // after each, we will check that the oldest query is evicted.
+      const client = connect(SYNC_CONTEXT, [
+        {op: 'put', hash: 'user-query-hash', ast: USERS_QUERY},
+        {op: 'put', hash: 'comment-query-hash', ast: COMMENTS_QUERY},
+        {op: 'put', hash: 'issue-query-hash', ast: ISSUES_QUERY},
+      ]);
+
+      await nextPoke(client);
+
+      stateChanges.push({state: 'version-ready'});
+      expect(await nextPokeParts(client)).toMatchInlineSnapshot(`
+        [
+          {
+            "gotQueriesPatch": [
+              {
+                "ast": {
+                  "orderBy": [
+                    [
+                      "id",
+                      "asc",
+                    ],
+                  ],
+                  "table": "users",
+                },
+                "hash": "user-query-hash",
+                "op": "put",
+              },
+              {
+                "ast": {
+                  "orderBy": [
+                    [
+                      "id",
+                      "asc",
+                    ],
+                  ],
+                  "table": "comments",
+                },
+                "hash": "comment-query-hash",
+                "op": "put",
+              },
+              {
+                "ast": {
+                  "orderBy": [
+                    [
+                      "id",
+                      "asc",
+                    ],
+                  ],
+                  "table": "issues",
+                  "where": {
+                    "left": {
+                      "name": "id",
+                      "type": "column",
+                    },
+                    "op": "IN",
+                    "right": {
+                      "type": "literal",
+                      "value": [
+                        "1",
+                        "2",
+                        "3",
+                        "4",
+                      ],
+                    },
+                    "type": "simple",
+                  },
+                },
+                "hash": "issue-query-hash",
+                "op": "put",
+              },
+            ],
+            "lastMutationIDChanges": {
+              "foo": 42,
+            },
+            "pokeID": "01",
+            "rowsPatch": [
+              {
+                "op": "put",
+                "tableName": "users",
+                "value": {
+                  "id": "100",
+                  "name": "Alice",
+                },
+              },
+              {
+                "op": "put",
+                "tableName": "users",
+                "value": {
+                  "id": "101",
+                  "name": "Bob",
+                },
+              },
+              {
+                "op": "put",
+                "tableName": "users",
+                "value": {
+                  "id": "102",
+                  "name": "Candice",
+                },
+              },
+              {
+                "op": "put",
+                "tableName": "comments",
+                "value": {
+                  "id": "1",
+                  "issueID": "1",
+                  "text": "comment 1",
+                },
+              },
+              {
+                "op": "put",
+                "tableName": "comments",
+                "value": {
+                  "id": "2",
+                  "issueID": "1",
+                  "text": "comment 2",
+                },
+              },
+              {
+                "op": "put",
+                "tableName": "issues",
+                "value": {
+                  "big": 9007199254740991,
+                  "id": "1",
+                  "json": null,
+                  "owner": "100",
+                  "parent": null,
+                  "title": "parent issue foo",
+                },
+              },
+              {
+                "op": "put",
+                "tableName": "issues",
+                "value": {
+                  "big": -9007199254740991,
+                  "id": "2",
+                  "json": null,
+                  "owner": "101",
+                  "parent": null,
+                  "title": "parent issue bar",
+                },
+              },
+              {
+                "op": "put",
+                "tableName": "issues",
+                "value": {
+                  "big": 123,
+                  "id": "3",
+                  "json": null,
+                  "owner": "102",
+                  "parent": "1",
+                  "title": "foo",
+                },
+              },
+              {
+                "op": "put",
+                "tableName": "issues",
+                "value": {
+                  "big": 100,
+                  "id": "4",
+                  "json": null,
+                  "owner": "101",
+                  "parent": "2",
+                  "title": "bar",
+                },
+              },
+            ],
+          },
+        ]
+      `);
+
+      expect(
+        (
+          await cvrDB`SELECT count(*) from cvr_abc.rows where cvr_abc.rows.table != 'zero_abc.clients'`.values()
+        )[0][0],
+      ).toBe(9n);
+
+      await expectNoPokes(client);
+
+      // We now mark the queries as inactive in the order users, comments and
+      // then issues moving the time forward after each inactivation. This means
+      // that the oldest query will be evicted each time.
+      await vs.changeDesiredQueries(SYNC_CONTEXT, [
+        'changeDesiredQueries',
+        {
+          desiredQueriesPatch: [{op: 'del', hash: 'user-query-hash'}],
+        },
+      ]);
+      vi.setSystemTime(Date.now() + 1);
+      await vs.changeDesiredQueries(SYNC_CONTEXT, [
+        'changeDesiredQueries',
+        {
+          desiredQueriesPatch: [{op: 'del', hash: 'comment-query-hash'}],
+        },
+      ]);
+      vi.setSystemTime(Date.now() + 1);
+      await vs.changeDesiredQueries(SYNC_CONTEXT, [
+        'changeDesiredQueries',
+        {
+          desiredQueriesPatch: [{op: 'del', hash: 'issue-query-hash'}],
+        },
+      ]);
+
+      stateChanges.push({state: 'version-ready'});
+      expect(await nextPoke(client)).toMatchInlineSnapshot(`
+        [
+          [
+            "pokeStart",
+            {
+              "baseCookie": "01",
+              "cookie": "01:01",
+              "pokeID": "01:01",
+            },
+          ],
+          [
+            "pokeEnd",
+            {
+              "cookie": "01:01",
+              "pokeID": "01:01",
+            },
+          ],
+        ]
+      `);
+      expect(await nextPoke(client)).toMatchInlineSnapshot(`
+        [
+          [
+            "pokeStart",
+            {
+              "baseCookie": "01:01",
+              "cookie": "01:02",
+              "pokeID": "01:02",
+            },
+          ],
+          [
+            "pokeEnd",
+            {
+              "cookie": "01:02",
+              "pokeID": "01:02",
+            },
+          ],
+        ]
+      `);
+      expect(await nextPoke(client)).toMatchInlineSnapshot(`
+        [
+          [
+            "pokeStart",
+            {
+              "baseCookie": "01:02",
+              "cookie": "01:03",
+              "pokeID": "01:03",
+            },
+          ],
+          [
+            "pokeEnd",
+            {
+              "cookie": "01:03",
+              "pokeID": "01:03",
+            },
+          ],
+        ]
+      `);
+
+      expect(await nextPokeParts(client)).toMatchInlineSnapshot(`
+        [
+          {
+            "desiredQueriesPatches": {
+              "foo": [
+                {
+                  "hash": "user-query-hash",
+                  "op": "del",
+                },
+              ],
+            },
+            "pokeID": "01:04",
+          },
+        ]
+      `);
+      expect(await nextPokeParts(client)).toMatchInlineSnapshot(`
+        [
+          {
+            "gotQueriesPatch": [
+              {
+                "hash": "user-query-hash",
+                "op": "del",
+              },
+            ],
+            "pokeID": "01:05",
+            "rowsPatch": [
+              {
+                "id": {
+                  "id": "100",
+                },
+                "op": "del",
+                "tableName": "users",
+              },
+              {
+                "id": {
+                  "id": "101",
+                },
+                "op": "del",
+                "tableName": "users",
+              },
+              {
+                "id": {
+                  "id": "102",
+                },
+                "op": "del",
+                "tableName": "users",
+              },
+            ],
+          },
+        ]
+      `);
+      await expectNoPokes(client);
+
+      stateChanges.push({state: 'version-ready'});
+      expect(await nextPokeParts(client)).toMatchInlineSnapshot(`
+        [
+          {
+            "desiredQueriesPatches": {
+              "foo": [
+                {
+                  "hash": "comment-query-hash",
+                  "op": "del",
+                },
+              ],
+            },
+            "pokeID": "01:06",
+          },
+        ]
+      `);
+      expect(await nextPokeParts(client)).toMatchInlineSnapshot(`
+        [
+          {
+            "gotQueriesPatch": [
+              {
+                "hash": "comment-query-hash",
+                "op": "del",
+              },
+            ],
+            "pokeID": "01:07",
+            "rowsPatch": [
+              {
+                "id": {
+                  "id": "1",
+                },
+                "op": "del",
+                "tableName": "comments",
+              },
+              {
+                "id": {
+                  "id": "2",
+                },
+                "op": "del",
+                "tableName": "comments",
+              },
+            ],
+          },
+        ]
+      `);
+      await expectNoPokes(client);
+
+      stateChanges.push({state: 'version-ready'});
+      expect(await nextPokeParts(client)).toMatchInlineSnapshot(`
+        [
+          {
+            "desiredQueriesPatches": {
+              "foo": [
+                {
+                  "hash": "issue-query-hash",
+                  "op": "del",
+                },
+              ],
+            },
+            "pokeID": "01:08",
+          },
+        ]
+      `);
+      expect(await nextPokeParts(client)).toMatchInlineSnapshot(`
+        [
+          {
+            "gotQueriesPatch": [
+              {
+                "hash": "issue-query-hash",
+                "op": "del",
+              },
+            ],
+            "pokeID": "01:09",
+            "rowsPatch": [
+              {
+                "id": {
+                  "id": "1",
+                },
+                "op": "del",
+                "tableName": "issues",
+              },
+              {
+                "id": {
+                  "id": "2",
+                },
+                "op": "del",
+                "tableName": "issues",
+              },
+              {
+                "id": {
+                  "id": "3",
+                },
+                "op": "del",
+                "tableName": "issues",
+              },
+              {
+                "id": {
+                  "id": "4",
+                },
+                "op": "del",
+                "tableName": "issues",
+              },
+            ],
+          },
+        ]
+      `);
       await expectNoPokes(client);
     });
   });

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -1,4 +1,4 @@
-import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {h128} from '../../../../shared/src/hash.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {Queue} from '../../../../shared/src/queue.ts';
@@ -674,7 +674,13 @@ describe('view-syncer/service', () => {
         },
         'query-hash2': {
           ast: USERS_QUERY,
-          desiredBy: {foo: {version: {stateVersion: '00', minorVersion: 2}}},
+          desiredBy: {
+            foo: {
+              inactivatedAt: undefined,
+              ttl: undefined,
+              version: {stateVersion: '00', minorVersion: 2},
+            },
+          },
           id: 'query-hash2',
         },
       },
@@ -3205,6 +3211,302 @@ describe('view-syncer/service', () => {
       ]
     `);
   });
+
+  describe('expired queries', () => {
+    const now = Date.UTC(2025, 1, 19);
+    beforeEach(() => {
+      vi.setSystemTime(now);
+      return () => {
+        vi.restoreAllMocks();
+      };
+    });
+
+    test('expired query is removed', async () => {
+      const client = connect(SYNC_CONTEXT, [
+        {op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY, ttl: 10},
+      ]);
+
+      stateChanges.push({state: 'version-ready'});
+      expect(await nextPoke(client)).toMatchInlineSnapshot(`
+        [
+          [
+            "pokeStart",
+            {
+              "baseCookie": null,
+              "cookie": "00:01",
+              "pokeID": "00:01",
+            },
+          ],
+          [
+            "pokePart",
+            {
+              "desiredQueriesPatches": {
+                "foo": [
+                  {
+                    "ast": {
+                      "orderBy": [
+                        [
+                          "id",
+                          "asc",
+                        ],
+                      ],
+                      "table": "issues",
+                      "where": {
+                        "left": {
+                          "name": "id",
+                          "type": "column",
+                        },
+                        "op": "IN",
+                        "right": {
+                          "type": "literal",
+                          "value": [
+                            "1",
+                            "2",
+                            "3",
+                            "4",
+                          ],
+                        },
+                        "type": "simple",
+                      },
+                    },
+                    "hash": "query-hash1",
+                    "op": "put",
+                  },
+                ],
+              },
+              "pokeID": "00:01",
+            },
+          ],
+          [
+            "pokeEnd",
+            {
+              "cookie": "00:01",
+              "pokeID": "00:01",
+            },
+          ],
+        ]
+      `);
+
+      expect(await nextPoke(client)).toMatchInlineSnapshot(`
+        [
+          [
+            "pokeStart",
+            {
+              "baseCookie": "00:01",
+              "cookie": "01",
+              "pokeID": "01",
+              "schemaVersions": {
+                "maxSupportedVersion": 3,
+                "minSupportedVersion": 2,
+              },
+            },
+          ],
+          [
+            "pokePart",
+            {
+              "gotQueriesPatch": [
+                {
+                  "ast": {
+                    "orderBy": [
+                      [
+                        "id",
+                        "asc",
+                      ],
+                    ],
+                    "table": "issues",
+                    "where": {
+                      "left": {
+                        "name": "id",
+                        "type": "column",
+                      },
+                      "op": "IN",
+                      "right": {
+                        "type": "literal",
+                        "value": [
+                          "1",
+                          "2",
+                          "3",
+                          "4",
+                        ],
+                      },
+                      "type": "simple",
+                    },
+                  },
+                  "hash": "query-hash1",
+                  "op": "put",
+                },
+              ],
+              "lastMutationIDChanges": {
+                "foo": 42,
+              },
+              "pokeID": "01",
+              "rowsPatch": [
+                {
+                  "op": "put",
+                  "tableName": "issues",
+                  "value": {
+                    "big": 9007199254740991,
+                    "id": "1",
+                    "json": null,
+                    "owner": "100",
+                    "parent": null,
+                    "title": "parent issue foo",
+                  },
+                },
+                {
+                  "op": "put",
+                  "tableName": "issues",
+                  "value": {
+                    "big": -9007199254740991,
+                    "id": "2",
+                    "json": null,
+                    "owner": "101",
+                    "parent": null,
+                    "title": "parent issue bar",
+                  },
+                },
+                {
+                  "op": "put",
+                  "tableName": "issues",
+                  "value": {
+                    "big": 123,
+                    "id": "3",
+                    "json": null,
+                    "owner": "102",
+                    "parent": "1",
+                    "title": "foo",
+                  },
+                },
+                {
+                  "op": "put",
+                  "tableName": "issues",
+                  "value": {
+                    "big": 100,
+                    "id": "4",
+                    "json": null,
+                    "owner": "101",
+                    "parent": "2",
+                    "title": "bar",
+                  },
+                },
+              ],
+            },
+          ],
+          [
+            "pokeEnd",
+            {
+              "cookie": "01",
+              "pokeID": "01",
+            },
+          ],
+        ]
+      `);
+
+      // Mark query-hash1 as inactive
+      await vs.changeDesiredQueries(SYNC_CONTEXT, [
+        'changeDesiredQueries',
+        {
+          desiredQueriesPatch: [{op: 'del', hash: 'query-hash1'}],
+        },
+      ]);
+
+      stateChanges.push({state: 'version-ready'});
+
+      expect(await nextPoke(client)).toMatchInlineSnapshot(`
+        [
+          [
+            "pokeStart",
+            {
+              "baseCookie": "01",
+              "cookie": "01:01",
+              "pokeID": "01:01",
+            },
+          ],
+          [
+            "pokeEnd",
+            {
+              "cookie": "01:01",
+              "pokeID": "01:01",
+            },
+          ],
+        ]
+      `);
+
+      await expectNoPokes(client);
+
+      // Set time past expiresAt for query-hash1
+      vi.setSystemTime(now + 11);
+      stateChanges.push({state: 'version-ready'});
+
+      expect(await nextPoke(client)).toMatchInlineSnapshot(`
+        [
+          [
+            "pokeStart",
+            {
+              "baseCookie": "01:01",
+              "cookie": "01:02",
+              "pokeID": "01:02",
+              "schemaVersions": {
+                "maxSupportedVersion": 3,
+                "minSupportedVersion": 2,
+              },
+            },
+          ],
+          [
+            "pokePart",
+            {
+              "gotQueriesPatch": [
+                {
+                  "hash": "query-hash1",
+                  "op": "del",
+                },
+              ],
+              "pokeID": "01:02",
+              "rowsPatch": [
+                {
+                  "id": {
+                    "id": "1",
+                  },
+                  "op": "del",
+                  "tableName": "issues",
+                },
+                {
+                  "id": {
+                    "id": "2",
+                  },
+                  "op": "del",
+                  "tableName": "issues",
+                },
+                {
+                  "id": {
+                    "id": "3",
+                  },
+                  "op": "del",
+                  "tableName": "issues",
+                },
+                {
+                  "id": {
+                    "id": "4",
+                  },
+                  "op": "del",
+                  "tableName": "issues",
+                },
+              ],
+            },
+          ],
+          [
+            "pokeEnd",
+            {
+              "cookie": "01:02",
+              "pokeID": "01:02",
+            },
+          ],
+        ]
+      `);
+
+      await expectNoPokes(client);
+    });
+  });
 });
 
 describe('permissions', () => {
@@ -3762,7 +4064,7 @@ describe('permissions', () => {
   });
 
   test('query for comments does not return issue rows as those are gotten by the permission system', async () => {
-    const client = await connect(
+    const client = connect(
       {
         ...SYNC_CONTEXT,
         tokenData: {

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -58,7 +58,6 @@ import {
 import {DrainCoordinator} from './drain-coordinator.ts';
 import {PipelineDriver} from './pipeline-driver.ts';
 import {initViewSyncerSchema} from './schema/init.ts';
-import type {ClientQueryRecord} from './schema/types.ts';
 import {Snapshotter} from './snapshotter.ts';
 import {pickToken, type SyncContext, ViewSyncerService} from './view-syncer.ts';
 
@@ -612,6 +611,8 @@ describe('view-syncer/service', () => {
   });
 
   test('responds to changeDesiredQueries patch', async () => {
+    const now = Date.UTC(2025, 1, 20);
+    vi.setSystemTime(now);
     connect(SYNC_CONTEXT, [
       {op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY},
     ]);
@@ -665,7 +666,7 @@ describe('view-syncer/service', () => {
           ast: ISSUES_QUERY,
           desiredBy: {
             foo: {
-              inactivatedAt: expect.any(Number),
+              inactivatedAt,
               ttl: undefined,
               version: {minorVersion: 2, stateVersion: '00'},
             },
@@ -686,14 +687,6 @@ describe('view-syncer/service', () => {
       },
       version: {stateVersion: '00', minorVersion: 2},
     });
-    expect(
-      (cvr.queries['query-hash1'] as ClientQueryRecord).desiredBy.foo
-        .inactivatedAt,
-    ).toBeGreaterThanOrEqual(inactivatedAt);
-    expect(
-      (cvr.queries['query-hash1'] as ClientQueryRecord).desiredBy.foo
-        .inactivatedAt,
-    ).toBeLessThanOrEqual(inactivatedAt + 10);
   });
 
   test('initial hydration', async () => {
@@ -3126,7 +3119,8 @@ describe('view-syncer/service', () => {
     drainCoordinator.drainNextIn(0);
     expect(drainCoordinator.shouldDrain()).toBe(true);
     const now = Date.now();
-    await sleep(3); // Bump time forward to verify that the timeout is reset later.
+    // Bump time forward to verify that the timeout is reset later.
+    vi.setSystemTime(now + 3);
 
     // Enqueue a dummy task so that the view-syncer can elect to drain.
     stateChanges.push({state: 'version-ready'});
@@ -3217,7 +3211,7 @@ describe('view-syncer/service', () => {
     beforeEach(() => {
       vi.setSystemTime(now);
       return () => {
-        vi.restoreAllMocks();
+        vi.useRealTimers();
       };
     });
 
@@ -3548,6 +3542,8 @@ describe('permissions', () => {
   });
 
   afterEach(async () => {
+    // Restores fake date if used.
+    vi.useRealTimers();
     await vs.stop();
     await viewSyncerDone;
     await testDBs.drop(cvrDB);

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -593,6 +593,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         lc.debug?.(`applying ${desiredQueriesPatch.length} query patches`);
         // cvr = ... For #syncQueryPipelineSet().
         cvr = await this.#updatePatchesForDesiredQueries(lc, cvr, updater => {
+          const now = Date.now();
           const patches: PatchToVersion[] = [];
           for (const patch of desiredQueriesPatch) {
             switch (patch.op) {
@@ -600,9 +601,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
                 patches.push(...updater.putDesiredQueries(clientID, [patch]));
                 break;
               case 'del':
-                patches.push(
-                  ...updater.deleteDesiredQueries(clientID, [patch.hash]),
-                );
+                updater.markDesiredQueryAsInactive(clientID, patch.hash, now);
                 break;
               case 'clear':
                 patches.push(...updater.clearDesiredQueries(clientID));

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -52,6 +52,7 @@ import {CVRStore} from './cvr-store.ts';
 import {
   CVRConfigDrivenUpdater,
   CVRQueryDrivenUpdater,
+  getInactiveQueries,
   type CVRSnapshot,
   type RowUpdate,
 } from './cvr.ts';
@@ -102,6 +103,10 @@ export interface ViewSyncer {
 
 const DEFAULT_KEEPALIVE_MS = 5_000;
 
+// We have previously said that the goal is to have 20MB on the client.
+// If we assume each row is ~1KB, then we can have 20,000 rows.
+const DEFAULT_MAX_ROW_COUNT = 20_000;
+
 function randomID() {
   return randInt(1, Number.MAX_SAFE_INTEGER).toString(36);
 }
@@ -132,6 +137,13 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   #authData: JWTPayload | undefined;
   #permissions: LoadedPermissions | null = null; // Guaranteed if #pipelinesSynced.
 
+  /**
+   * The {@linkcode maxRowCount} is used for the eviction of queries when the
+   * number of rows in the CVR exceeds this value. The eviction process will
+   * remove queries that are inactive.
+   */
+  maxRowCount: number;
+
   constructor(
     lc: LogContext,
     taskID: string,
@@ -142,6 +154,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     versionChanges: Subscription<ReplicaState>,
     drainCoordinator: DrainCoordinator,
     keepaliveMs = DEFAULT_KEEPALIVE_MS,
+    maxRowCount = DEFAULT_MAX_ROW_COUNT,
   ) {
     this.id = clientGroupID;
     this.#shardID = shardID;
@@ -160,6 +173,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       // loop will then await #cvrStore.flushed() which rejects if necessary.
       () => this.#stateChanges.cancel(),
     );
+    this.maxRowCount = maxRowCount;
 
     // Wait for the first connection to init.
     this.keepalive();
@@ -218,10 +232,12 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           }
 
           // Check if any queries have expired.
-          if (hasExpiredQueries(cvr)) {
-            lc.info?.('queries have expired');
-            await this.#syncQueryPipelineSet(lc, cvr);
-            this.#pipelinesSynced = true;
+          if (await this.#removeExpiredQueries(lc, cvr)) {
+            return;
+          }
+
+          // Removes evictable queries if the row count exceeds the max.
+          if (await this.#evictQueries(lc, cvr)) {
             return;
           }
 
@@ -270,6 +286,77 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       this.#lc.info?.('view-syncer stopped');
       this.#stopped.resolve();
     }
+  }
+
+  /**
+   * @returns true if any queries were removed.
+   */
+  async #removeExpiredQueries(
+    lc: LogContext,
+    cvr: CVRSnapshot,
+  ): Promise<boolean> {
+    if (hasExpiredQueries(cvr)) {
+      lc.info?.('queries have expired');
+      await this.#syncQueryPipelineSet(lc, cvr);
+      this.#pipelinesSynced = true;
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * @returns true if any queries were evicted.
+   */
+  #evictQueries(lc: LogContext, cvr: CVRSnapshot): Promise<boolean> {
+    return startAsyncSpan(tracer, 'vs.#evictQueries', async () => {
+      if (this.#cvrStore.rowCount <= this.maxRowCount) {
+        return false;
+      }
+
+      const inactiveQueries = getInactiveQueries(cvr);
+      if (inactiveQueries.length === 0) {
+        return false;
+      }
+
+      let anyEvicted = false;
+
+      // cvr = ... For #syncQueryPipelineSet().
+      cvr = await this.#updatePatchesForDesiredQueries(lc, cvr, updater => {
+        const patches: PatchToVersion[] = [];
+
+        for (const {hash} of inactiveQueries) {
+          // We only get here after we have removed the queries that have expired.
+          // The remaining ones are inactive but haven't expired. However, when we
+          // get here we want to remove them because we are above the desired row
+          // count.
+
+          // We need to remove it for all the clients that have this query.
+          for (const clientID in cvr.clients) {
+            if (hasOwn(cvr.clients, clientID)) {
+              const patchesDueToClient = updater.deleteDesiredQueries(
+                clientID,
+                [hash],
+              );
+              patches.push(...patchesDueToClient);
+            }
+          }
+
+          // We remove one query at a time. Once that has been removed we check again
+          // if we are still above the desired row count.
+          if (patches.length > 0) {
+            anyEvicted = true;
+            break;
+          }
+        }
+        return patches;
+      });
+
+      if (this.#pipelinesSynced) {
+        await this.#syncQueryPipelineSet(lc, cvr);
+      }
+
+      return anyEvicted;
+    });
   }
 
   #totalHydrationTimeMs(): number {

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -12,6 +12,7 @@ import {
 import {version} from '../../../../otel/src/version.ts';
 import {assert, unreachable} from '../../../../shared/src/asserts.ts';
 import {CustomKeyMap} from '../../../../shared/src/custom-key-map.ts';
+import {hasOwn} from '../../../../shared/src/has-own.ts';
 import {must} from '../../../../shared/src/must.ts';
 import {randInt} from '../../../../shared/src/rand.ts';
 import type {AST} from '../../../../zero-protocol/src/ast.ts';
@@ -64,6 +65,7 @@ import {
   versionToCookie,
   type CVRVersion,
   type NullableCVRVersion,
+  type QueryRecord,
   type RowID,
 } from './schema/types.ts';
 import {ResetPipelinesSignal} from './snapshotter.ts';
@@ -213,6 +215,14 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
             }, DB=${this.#pipelines.replicaVersion}`;
             lc.info?.(`resetting CVR: ${message}`);
             throw new ErrorForClient({kind: ErrorKind.ClientNotFound, message});
+          }
+
+          // Check if any queries have expired.
+          if (hasExpiredQueries(cvr)) {
+            lc.info?.('queries have expired');
+            await this.#syncQueryPipelineSet(lc, cvr);
+            this.#pipelinesSynced = true;
+            return;
           }
 
           if (this.#pipelinesSynced) {
@@ -699,6 +709,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
       // Convert queries to their transformed ast's and hashes
       const transformationHashToHash = new Map<string, string>();
+      const now = Date.now();
       const serverQueries = Object.entries(cvr.queries).map(([id, q]) => {
         const {query, hash: transformationHash} = transformAndHashQuery(
           lc,
@@ -714,16 +725,16 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           // the query cannot be run and is `undefined`.
           ast: query,
           transformationHash,
-          desired: q.internal || Object.keys(q.desiredBy).length > 0,
+          expired: expired(now, q),
         };
       });
 
       const addQueries = serverQueries.filter(
-        q => q.desired && !hydratedQueries.has(q.transformationHash),
+        q => !q.expired && !hydratedQueries.has(q.transformationHash),
       );
-      const removeQueries = serverQueries.filter(q => !q.desired);
+      const removeQueries = serverQueries.filter(q => q.expired);
       const desiredQueries = new Set(
-        serverQueries.filter(q => q.desired).map(q => q.transformationHash),
+        serverQueries.filter(q => !q.expired).map(q => q.transformationHash),
       );
       const unhydrateQueries = [...hydratedQueries].filter(
         transformationHash => !desiredQueries.has(transformationHash),
@@ -1259,4 +1270,34 @@ export function pickToken(
     message:
       'No token provided. An unauthenticated client cannot connect to an authenticated client group.',
   });
+}
+
+function expired(now: number, q: QueryRecord) {
+  if (q.internal) {
+    return false;
+  }
+  const {desiredBy} = q;
+  for (const clientID in desiredBy) {
+    if (hasOwn(desiredBy, clientID)) {
+      const {ttl, inactivatedAt} = desiredBy[clientID];
+      // eslint-disable-next-line eqeqeq
+      if (ttl == null || inactivatedAt == null) {
+        return false;
+      }
+      if (inactivatedAt + ttl > now) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+function hasExpiredQueries(cvr: CVRSnapshot): boolean {
+  const now = Date.now();
+  for (const q of Object.values(cvr.queries)) {
+    if (expired(now, q)) {
+      return true;
+    }
+  }
+  return false;
 }


### PR DESCRIPTION
We now evict inactive queries from the cache. This is done by keeping
track of the time a query was inactivated. When the number of rows in
the RowRecordCache is larger than the desired rows then we evict the
oldest inactive query. After that the run loop starts over and we might
evict another one.