### PR TITLE
fix(zero-cache): fix memory leak by avoiding Promise.race()

### DIFF
--- a/packages/zero-cache/src/services/running-state.ts
+++ b/packages/zero-cache/src/services/running-state.ts
@@ -118,9 +118,6 @@ export class RunningState {
 
   /**
    * Returns a Promise that resolves when {@link stop()} is called.
-   * This is used internally to cut off a {@link backoff()} delay, but
-   * can also be used explicitly in a `Promise.race(...)` call to stop
-   * stop waiting for work.
    */
   stopped(): Promise<void> {
     return this.#stopped;


### PR DESCRIPTION
### Background

Using `Promise.race()` (and apparently `Promise.any()`) can result in [working-as-intended memory leaks](https://github.com/nodejs/node/issues/17469#issuecomment-349794909) in Node.js

<img width="806" alt="Screenshot 2025-02-22 at 00 14 25" src="https://github.com/user-attachments/assets/4c266882-4568-4357-9091-8c522de5aaba" />


Another good explanation:

https://levelup.gitconnected.com/unfixable-memory-leaks-in-promise-race-28e5c5a6032c

### Evidence of fix

30 minutes of 200 qps (before):

![before](https://github.com/user-attachments/assets/8fd31931-2474-47a3-b468-0ac5d17bf296)

30 minutes of 200 qps (after):

![after](https://github.com/user-attachments/assets/5f05a824-1402-4ca1-bfbd-ad9d145c6980)

