### PR TITLE
chore(shared): simplify the Queue class

### DIFF
--- a/packages/zero-cache/src/db/transaction-pool.pg-test.ts
+++ b/packages/zero-cache/src/db/transaction-pool.pg-test.ts
@@ -232,7 +232,7 @@ describe('db/transaction-pool', () => {
 
     const blockingTask =
       (stmt: string) => async (tx: postgres.TransactionSql) => {
-        void processing.enqueue(true);
+        processing.enqueue(true);
         await canProceed.dequeue();
         return task(stmt)(tx);
       };
@@ -258,7 +258,7 @@ describe('db/transaction-pool', () => {
 
     // Let all 6 tasks proceed.
     for (let i = 0; i < 6; i++) {
-      void canProceed.enqueue(true);
+      canProceed.enqueue(true);
     }
 
     await pool.done();
@@ -301,7 +301,7 @@ describe('db/transaction-pool', () => {
 
     const blockingTask =
       (stmt: string) => async (tx: postgres.TransactionSql) => {
-        void processing.enqueue(true);
+        processing.enqueue(true);
         await canProceed.dequeue();
         return task(stmt)(tx);
       };
@@ -325,7 +325,7 @@ describe('db/transaction-pool', () => {
     }
     // Let all 5 tasks proceed.
     for (let i = 0; i < 5; i++) {
-      void canProceed.enqueue(true);
+      canProceed.enqueue(true);
     }
 
     // Let the extra workers hit their 50ms idle timeout.
@@ -354,7 +354,7 @@ describe('db/transaction-pool', () => {
 
     // Let all 5 tasks proceed.
     for (let i = 0; i < 5; i++) {
-      void canProceed.enqueue(true);
+      canProceed.enqueue(true);
     }
 
     // Let the new extra workers hit their 50ms idle timeout.
@@ -620,7 +620,7 @@ describe('db/transaction-pool', () => {
 
     const blockingTask =
       (stmt: string) => async (tx: postgres.TransactionSql) => {
-        void processing.enqueue(true);
+        processing.enqueue(true);
         await canProceed.dequeue();
         return task(stmt)(tx);
       };
@@ -651,7 +651,7 @@ describe('db/transaction-pool', () => {
     // first tasks complete (and succeed) before the last task errors, exercising
     // the scenario being tested.
     for (let i = 0; i < 5; i++) {
-      await canProceed.enqueue(true);
+      canProceed.enqueue(true);
     }
 
     // run() should throw the error even though it may not have come from the
@@ -670,7 +670,7 @@ describe('db/transaction-pool', () => {
   test('snapshot synchronization', async () => {
     const processing = new Queue<boolean>();
     const blockingTask = (stmt: string) => (tx: postgres.TransactionSql) => {
-      void processing.enqueue(true);
+      processing.enqueue(true);
       return task(stmt)(tx);
     };
 
@@ -777,7 +777,7 @@ describe('db/transaction-pool', () => {
   test('sharedSnapshot', async () => {
     const processing = new Queue<boolean>();
     const readTask = () => async (tx: postgres.TransactionSql) => {
-      void processing.enqueue(true);
+      processing.enqueue(true);
       return (await tx<{id: number}[]>`SELECT id FROM foo;`.values()).flat();
     };
 
@@ -840,7 +840,7 @@ describe('db/transaction-pool', () => {
   test('externally shared snapshot', async () => {
     const processing = new Queue<boolean>();
     const readTask = () => async (tx: postgres.TransactionSql) => {
-      void processing.enqueue(true);
+      processing.enqueue(true);
       return (await tx<{id: number}[]>`SELECT id FROM foo;`.values()).flat();
     };
 

--- a/packages/zero-cache/src/db/transaction-pool.ts
+++ b/packages/zero-cache/src/db/transaction-pool.ts
@@ -279,10 +279,10 @@ export class TransactionPool {
     // terminal states (both of which prevent more tasks from being enqueued), to ensure
     // that the added worker eventually exits.
     if (this.#done) {
-      void this.#tasks.enqueue('done');
+      this.#tasks.enqueue('done');
     }
     if (this.#failure) {
-      void this.#tasks.enqueue(this.#failure);
+      this.#tasks.enqueue(this.#failure);
     }
   }
 
@@ -297,7 +297,7 @@ export class TransactionPool {
       return;
     }
 
-    void this.#tasks.enqueue(taskTracker);
+    this.#tasks.enqueue(taskTracker);
 
     // Check if the pool size can and should be increased.
     if (this.#numWorkers < this.#maxWorkers) {
@@ -337,7 +337,7 @@ export class TransactionPool {
     this.#done = true;
 
     for (let i = 0; i < this.#numWorkers; i++) {
-      void this.#tasks.enqueue('done');
+      this.#tasks.enqueue('done');
     }
   }
 
@@ -397,7 +397,7 @@ export class TransactionPool {
 
       for (let i = 0; i < this.#numWorkers; i++) {
         // Enqueue the Error to terminate any workers waiting for tasks.
-        void this.#tasks.enqueue(this.#failure);
+        this.#tasks.enqueue(this.#failure);
       }
     }
   }

--- a/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg-test.ts
@@ -97,7 +97,7 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
     const queue = new Queue<ChangeStreamMessage | 'timeout'>();
     void (async () => {
       for await (const msg of sub) {
-        void queue.enqueue(msg);
+        queue.enqueue(msg);
       }
     })();
     return queue;

--- a/packages/zero-cache/src/services/change-source/pg/change-source.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.pg-test.ts
@@ -110,7 +110,7 @@ describe('change-source/pg', {timeout: 30000}, () => {
     const queue = new Queue<ChangeStreamMessage>();
     void (async () => {
       for await (const msg of sub) {
-        void queue.enqueue(msg);
+        queue.enqueue(msg);
       }
     })();
     return queue;

--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl.pg-test.ts
@@ -47,7 +47,7 @@ describe('change-source/tables/ddl', () => {
       .on('heartbeat', (lsn, _time, respond) => {
         respond && void service.acknowledge(lsn);
       })
-      .on('data', (_lsn, msg) => void messages.enqueue(msg));
+      .on('data', (_lsn, msg) => messages.enqueue(msg));
 
     void service.subscribe(
       new PgoutputPlugin({

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg-test.ts
@@ -99,7 +99,7 @@ describe('change-streamer/service', () => {
     const queue = new Queue<Downstream>();
     void (async () => {
       for await (const msg of sub) {
-        void queue.enqueue(msg);
+        queue.enqueue(msg);
       }
     })();
     return queue;
@@ -642,7 +642,7 @@ describe('change-streamer/service', () => {
     const requests = new Queue<string>();
     const source = {
       startStream: vi.fn().mockImplementation(req => {
-        void requests.enqueue(req);
+        requests.enqueue(req);
         return resolver().promise;
       }),
     };

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -116,15 +116,15 @@ export class Storer implements Service {
   }
 
   store(entry: WatermarkedChange) {
-    void this.#queue.enqueue(['change', entry]);
+    this.#queue.enqueue(['change', entry]);
   }
 
   status(s: StatusMessage) {
-    void this.#queue.enqueue(s);
+    this.#queue.enqueue(s);
   }
 
   catchup(sub: Subscriber) {
-    void this.#queue.enqueue(['subscriber', sub]);
+    this.#queue.enqueue(['subscriber', sub]);
   }
 
   async run() {
@@ -323,7 +323,7 @@ export class Storer implements Service {
   }
 
   stop() {
-    void this.#queue.enqueue('stop');
+    this.#queue.enqueue('stop');
     return promiseVoid;
   }
 }

--- a/packages/zero-cache/src/services/mutagen/pusher.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.ts
@@ -1,10 +1,10 @@
-import type {PushBody} from '../../../../zero-protocol/src/push.ts';
-import type {MutationError} from './mutagen.ts';
-import type {Service} from '../service.ts';
-import * as ErrorKind from '../../../../zero-protocol/src/error-kind-enum.ts';
-import {must} from '../../../../shared/src/must.ts';
 import type {LogContext} from '@rocicorp/logger';
+import {must} from '../../../../shared/src/must.ts';
 import {Queue} from '../../../../shared/src/queue.ts';
+import * as ErrorKind from '../../../../zero-protocol/src/error-kind-enum.ts';
+import type {PushBody} from '../../../../zero-protocol/src/push.ts';
+import type {Service} from '../service.ts';
+import type {MutationError} from './mutagen.ts';
 
 export interface Pusher {
   enqueuePush(push: PushBody, jwt: string | undefined): void;
@@ -41,7 +41,7 @@ export class PusherService implements Service {
   }
 
   enqueuePush(push: PushBody, jwt: string | undefined) {
-    void this.#queue.enqueue({push, jwt});
+    this.#queue.enqueue({push, jwt});
   }
 
   run(): Promise<void> {
@@ -50,7 +50,7 @@ export class PusherService implements Service {
   }
 
   stop(): Promise<void> {
-    void this.#queue.enqueue('stop');
+    this.#queue.enqueue('stop');
     return must(this.#stopped, 'Stop was called before `run`');
   }
 }

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -451,10 +451,10 @@ async function setup(permissions: PermissionsConfig | undefined) {
     void (async function () {
       try {
         for await (const msg of source) {
-          await queue.enqueue(msg);
+          queue.enqueue(msg);
         }
       } catch (e) {
-        await queue.enqueueRejection(e);
+        queue.enqueueRejection(e);
       }
     })();
 

--- a/packages/zero-cache/src/types/streams.ts
+++ b/packages/zero-cache/src/types/streams.ts
@@ -182,7 +182,7 @@ export async function streamOut<T extends JSONValue>(
       if (typeof data !== 'string') {
         throw new Error('Expected string message');
       }
-      void acks.enqueue(v.parse(JSON.parse(data), ackSchema));
+      acks.enqueue(v.parse(JSON.parse(data), ackSchema));
     } catch (e) {
       lc.error?.(`error parsing ack`, e);
       closer.close(e);


### PR DESCRIPTION
`enqueue()` formerly returned a Promise that allowed the caller to wait for the item to be consumed.

However, no (application) code actually needs that API.

Since this class is used in some potentially hot paths, remove that functionality to both eliminate an unnecessary `Resolver` per invocation, as well as make the calling code more readable by not requiring the `void` qualifier.