### PR TITLE
chore(shared): avoid promise wrapping in the common case

### DIFF
--- a/packages/shared/src/queue.test.ts
+++ b/packages/shared/src/queue.test.ts
@@ -173,21 +173,23 @@ describe('Queue', () => {
 
   test('a consumer blocks until tasks are available', async () => {
     const queue = new Queue<number>();
-    const promise = queue.dequeue().then(head => {
+    const promise = (async () => {
+      const head = await queue.dequeue();
       const tasks = queue.drain();
       expect(head).toEqual(1);
       expect(tasks).toEqual([]);
-    });
+    })();
     queue.enqueue(1);
     await promise;
   });
 
   test('drain will get all tasks that were accumulated in the prior tick', async () => {
     const queue = new Queue<number>();
-    const promise = queue.dequeue().then(head => {
+    const promise = (async () => {
+      const head = await queue.dequeue();
       const tasks = queue.drain();
       expect([head, ...tasks]).toEqual([1, 2, 3]);
-    });
+    })();
     queue.enqueue(1);
     queue.enqueue(2);
     queue.enqueue(3);
@@ -197,20 +199,22 @@ describe('Queue', () => {
   test('a consumer is called if tasks are already available', async () => {
     const queue = new Queue<number>();
     queue.enqueue(1);
-    const promise = queue.dequeue().then(head => {
+    const promise = (async () => {
+      const head = await queue.dequeue();
       const tasks = queue.drain();
       expect([head, ...tasks]).toEqual([1]);
-    });
+    })();
     await promise;
   });
 
   test('drain will get all tasks that were accumulated in the prior tick | 2', async () => {
     const queue = new Queue<number>();
     queue.enqueue(1);
-    const promise = queue.dequeue().then(head => {
+    const promise = (async () => {
+      const head = await queue.dequeue();
       const tasks = queue.drain();
       expect([head, ...tasks]).toEqual([1, 2, 3]);
-    });
+    })();
     queue.enqueue(2);
     queue.enqueue(3);
     await promise;

--- a/packages/zero-cache/src/types/streams.ts
+++ b/packages/zero-cache/src/types/streams.ts
@@ -201,13 +201,14 @@ export async function streamOut<T extends JSONValue>(
         // lc.debug?.(`pipelining`, data);
         sink.send(data);
 
-        void acks.dequeue().then(({ack}) => {
+        void (async () => {
+          const {ack} = await acks.dequeue();
           // lc.debug?.(`received ack`, ack);
           if (ack !== id) {
             throw new Error(`Unexpected ack for ${id}: ${ack}`);
           }
           consumed();
-        });
+        })();
       }
     } else {
       lc.debug?.(`started synchronous outbound stream`);


### PR DESCRIPTION
A small optimization that avoids a `Promise.resolve()` wrapper for common case enqueueing.

`dequeue()` now returns `Promise<T> | T`, which makes a couple of call sights that relied `then()` slightly more complicated, but overall the reduction in Promise creation seems worth it.