### PR TITLE
feat(zero-cache): make litestream defaults less aggressive

### DIFF
--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -219,14 +219,14 @@ test('zero-cache --help', () => {
                                                                 The location of the litestream backup, usually an s3:// URL.                                      
                                                                 If set, the litestream-executable must also be specified.                                         
                                                                                                                                                                   
-     --litestream-incremental-backup-interval-minutes number    default: 5                                                                                        
+     --litestream-incremental-backup-interval-minutes number    default: 15                                                                                       
        ZERO_LITESTREAM_INCREMENTAL_BACKUP_INTERVAL_MINUTES env                                                                                                    
                                                                 The interval between incremental backups of the replica. Shorter intervals                        
                                                                 reduce the amount of change history that needs to be replayed when catching                       
                                                                 up a new view-syncer, at the expense of increasing the number of files needed                     
                                                                 to download for the initial litestream restore.                                                   
                                                                                                                                                                   
-     --litestream-snapshot-backup-interval-hours number         default: 1                                                                                        
+     --litestream-snapshot-backup-interval-hours number         default: 12                                                                                       
        ZERO_LITESTREAM_SNAPSHOT_BACKUP_INTERVAL_HOURS env                                                                                                         
                                                                 The interval between snapshot backups of the replica. Snapshot backups                            
                                                                 make a full copy of the database to a new litestream generation. This                             
@@ -234,7 +234,7 @@ test('zero-cache --help', () => {
                                                                 large database and low write rate can increase this interval to reduce                            
                                                                 network usage for backups (litestream defaults to 24 hours).                                      
                                                                                                                                                                   
-     --litestream-restore-parallelism number                    default: 32                                                                                       
+     --litestream-restore-parallelism number                    default: 48                                                                                       
        ZERO_LITESTREAM_RESTORE_PARALLELISM env                                                                                                                    
                                                                 The number of WAL files to download in parallel when performing the                               
                                                                 initial restore of the replica from the backup.                                                   

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -327,7 +327,7 @@ export const zeroOptions = {
     },
 
     incrementalBackupIntervalMinutes: {
-      type: v.number().default(5),
+      type: v.number().default(15),
       desc: [
         `The interval between incremental backups of the replica. Shorter intervals`,
         `reduce the amount of change history that needs to be replayed when catching`,
@@ -337,7 +337,7 @@ export const zeroOptions = {
     },
 
     snapshotBackupIntervalHours: {
-      type: v.number().default(1),
+      type: v.number().default(12),
       desc: [
         `The interval between snapshot backups of the replica. Snapshot backups`,
         `make a full copy of the database to a new litestream generation. This`,
@@ -348,7 +348,7 @@ export const zeroOptions = {
     },
 
     restoreParallelism: {
-      type: v.number().default(32),
+      type: v.number().default(48),
       desc: [
         `The number of WAL files to download in parallel when performing the`,
         `initial restore of the replica from the backup.`,

--- a/packages/zero-cache/src/server/multi/config.test.ts
+++ b/packages/zero-cache/src/server/multi/config.test.ts
@@ -65,10 +65,10 @@ test('parse options', () => {
         },
         "litestream": {
           "configPath": "./src/services/litestream/config.yml",
-          "incrementalBackupIntervalMinutes": 5,
+          "incrementalBackupIntervalMinutes": 15,
           "logLevel": "warn",
-          "restoreParallelism": 32,
-          "snapshotBackupIntervalHours": 1,
+          "restoreParallelism": 48,
+          "snapshotBackupIntervalHours": 12,
         },
         "log": {
           "format": "text",
@@ -131,10 +131,10 @@ test('parse options', () => {
         "ZERO_INITIAL_SYNC_ROW_BATCH_SIZE": "10000",
         "ZERO_INITIAL_SYNC_TABLE_COPY_WORKERS": "5",
         "ZERO_LITESTREAM_CONFIG_PATH": "./src/services/litestream/config.yml",
-        "ZERO_LITESTREAM_INCREMENTAL_BACKUP_INTERVAL_MINUTES": "5",
+        "ZERO_LITESTREAM_INCREMENTAL_BACKUP_INTERVAL_MINUTES": "15",
         "ZERO_LITESTREAM_LOG_LEVEL": "warn",
-        "ZERO_LITESTREAM_RESTORE_PARALLELISM": "32",
-        "ZERO_LITESTREAM_SNAPSHOT_BACKUP_INTERVAL_HOURS": "1",
+        "ZERO_LITESTREAM_RESTORE_PARALLELISM": "48",
+        "ZERO_LITESTREAM_SNAPSHOT_BACKUP_INTERVAL_HOURS": "12",
         "ZERO_LOG_FORMAT": "text",
         "ZERO_LOG_IVM_SAMPLING": "5000",
         "ZERO_LOG_LEVEL": "info",
@@ -455,14 +455,14 @@ test('zero-cache --help', () => {
                                                                 The location of the litestream backup, usually an s3:// URL.                                      
                                                                 If set, the litestream-executable must also be specified.                                         
                                                                                                                                                                   
-     --litestream-incremental-backup-interval-minutes number    default: 5                                                                                        
+     --litestream-incremental-backup-interval-minutes number    default: 15                                                                                       
        ZERO_LITESTREAM_INCREMENTAL_BACKUP_INTERVAL_MINUTES env                                                                                                    
                                                                 The interval between incremental backups of the replica. Shorter intervals                        
                                                                 reduce the amount of change history that needs to be replayed when catching                       
                                                                 up a new view-syncer, at the expense of increasing the number of files needed                     
                                                                 to download for the initial litestream restore.                                                   
                                                                                                                                                                   
-     --litestream-snapshot-backup-interval-hours number         default: 1                                                                                        
+     --litestream-snapshot-backup-interval-hours number         default: 12                                                                                       
        ZERO_LITESTREAM_SNAPSHOT_BACKUP_INTERVAL_HOURS env                                                                                                         
                                                                 The interval between snapshot backups of the replica. Snapshot backups                            
                                                                 make a full copy of the database to a new litestream generation. This                             
@@ -470,7 +470,7 @@ test('zero-cache --help', () => {
                                                                 large database and low write rate can increase this interval to reduce                            
                                                                 network usage for backups (litestream defaults to 24 hours).                                      
                                                                                                                                                                   
-     --litestream-restore-parallelism number                    default: 32                                                                                       
+     --litestream-restore-parallelism number                    default: 48                                                                                       
        ZERO_LITESTREAM_RESTORE_PARALLELISM env                                                                                                                    
                                                                 The number of WAL files to download in parallel when performing the                               
                                                                 initial restore of the replica from the backup.                                                   


### PR DESCRIPTION
Default to 15-minute sync intervals and 12-hour snapshots.

This makes the restarts download on average 24 files (48 max) and catch up with 7.5 minutes (15 max) of changes, with full db snapshots to s3 happening twice daily.