### PR TITLE
chore(zero-cache): plumb an "appID" to code that reads `permissions`, `clients`, `schemaVersions`

### DIFF
--- a/packages/zero-cache/src/auth/load-permissions.test.ts
+++ b/packages/zero-cache/src/auth/load-permissions.test.ts
@@ -14,11 +14,11 @@ describe('auth/load-permissions', () => {
   beforeEach(() => {
     replica = new Database(createSilentLogContext(), ':memory:');
     replica.exec(/* sql */ `
-      CREATE TABLE "zero.permissions" (
+      CREATE TABLE "zero_app.permissions" (
         permissions JSON,
         hash TEXT
       );
-      INSERT INTO "zero.permissions" (permissions) VALUES (NULL);
+      INSERT INTO "zero_app.permissions" (permissions) VALUES (NULL);
       `);
     db = new StatementRunner(replica);
   });
@@ -27,13 +27,13 @@ describe('auth/load-permissions', () => {
     const permissions =
       typeof perms === 'string' ? perms : JSON.stringify(perms);
     replica
-      .prepare(`UPDATE "zero.permissions" SET permissions = ?, hash = ?`)
+      .prepare(`UPDATE "zero_app.permissions" SET permissions = ?, hash = ?`)
       .run(permissions, h128(permissions).toString(16));
   }
 
   test('loads supported permissions', () => {
     setPermissions({tables: {}});
-    expect(loadPermissions(lc, db, 'zero')).toMatchInlineSnapshot(`
+    expect(loadPermissions(lc, db, 'zero_app')).toMatchInlineSnapshot(`
       {
         "hash": "4fa6194de2f465d532971ce1b9b513e9",
         "permissions": {
@@ -46,7 +46,7 @@ describe('auth/load-permissions', () => {
   test('invalid permissions', () => {
     setPermissions(`{"tablez":{}}`);
     expect(() =>
-      loadPermissions(lc, db, 'zero'),
+      loadPermissions(lc, db, 'zero_app'),
     ).toThrowErrorMatchingInlineSnapshot(
       `
       [Error: Could not parse upstream permissions: '{"tablez":{}}'.
@@ -58,7 +58,7 @@ describe('auth/load-permissions', () => {
   test('permissions invalid JSON', () => {
     setPermissions(`I'm not JSON`);
     expect(() =>
-      loadPermissions(lc, db, 'zero'),
+      loadPermissions(lc, db, 'zero_app'),
     ).toThrowErrorMatchingInlineSnapshot(
       `
       [Error: Could not parse upstream permissions: 'I'm not JSON'.
@@ -70,7 +70,7 @@ describe('auth/load-permissions', () => {
   test('invalid long permissions', () => {
     setPermissions(`{"baz": 108, "foo":"ba${'a'.repeat(1000)}r"}`);
     expect(() =>
-      loadPermissions(lc, db, 'zero'),
+      loadPermissions(lc, db, 'zero_app'),
     ).toThrowErrorMatchingInlineSnapshot(
       `
       [Error: Could not parse upstream permissions: '{"baz": 108, "foo":"baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...'.

--- a/packages/zero-cache/src/auth/load-permissions.test.ts
+++ b/packages/zero-cache/src/auth/load-permissions.test.ts
@@ -33,7 +33,7 @@ describe('auth/load-permissions', () => {
 
   test('loads supported permissions', () => {
     setPermissions({tables: {}});
-    expect(loadPermissions(lc, db)).toMatchInlineSnapshot(`
+    expect(loadPermissions(lc, db, 'zero')).toMatchInlineSnapshot(`
       {
         "hash": "4fa6194de2f465d532971ce1b9b513e9",
         "permissions": {
@@ -45,7 +45,9 @@ describe('auth/load-permissions', () => {
 
   test('invalid permissions', () => {
     setPermissions(`{"tablez":{}}`);
-    expect(() => loadPermissions(lc, db)).toThrowErrorMatchingInlineSnapshot(
+    expect(() =>
+      loadPermissions(lc, db, 'zero'),
+    ).toThrowErrorMatchingInlineSnapshot(
       `
       [Error: Could not parse upstream permissions: '{"tablez":{}}'.
       This may happen if Permissions with a new internal format are deployed before the supporting server has been fully rolled out.]
@@ -55,7 +57,9 @@ describe('auth/load-permissions', () => {
 
   test('permissions invalid JSON', () => {
     setPermissions(`I'm not JSON`);
-    expect(() => loadPermissions(lc, db)).toThrowErrorMatchingInlineSnapshot(
+    expect(() =>
+      loadPermissions(lc, db, 'zero'),
+    ).toThrowErrorMatchingInlineSnapshot(
       `
       [Error: Could not parse upstream permissions: 'I'm not JSON'.
       This may happen if Permissions with a new internal format are deployed before the supporting server has been fully rolled out.]
@@ -65,7 +69,9 @@ describe('auth/load-permissions', () => {
 
   test('invalid long permissions', () => {
     setPermissions(`{"baz": 108, "foo":"ba${'a'.repeat(1000)}r"}`);
-    expect(() => loadPermissions(lc, db)).toThrowErrorMatchingInlineSnapshot(
+    expect(() =>
+      loadPermissions(lc, db, 'zero'),
+    ).toThrowErrorMatchingInlineSnapshot(
       `
       [Error: Could not parse upstream permissions: '{"baz": 108, "foo":"baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...'.
       This may happen if Permissions with a new internal format are deployed before the supporting server has been fully rolled out.]

--- a/packages/zero-cache/src/auth/load-permissions.ts
+++ b/packages/zero-cache/src/auth/load-permissions.ts
@@ -19,9 +19,10 @@ export type LoadedPermissions = {
 export function loadPermissions(
   lc: LogContext,
   replica: StatementRunner,
+  appID: string,
 ): LoadedPermissions {
   const {permissions, hash} = replica.get(
-    `SELECT permissions, hash FROM "zero.permissions"`,
+    `SELECT permissions, hash FROM "${appID}.permissions"`,
   );
   if (permissions === null) {
     lc.warn?.(
@@ -54,15 +55,16 @@ export function loadPermissions(
 export function reloadPermissionsIfChanged(
   lc: LogContext,
   replica: StatementRunner,
+  appID: string,
   current: LoadedPermissions | null,
 ): {permissions: LoadedPermissions; changed: boolean} {
   if (current === null) {
-    return {permissions: loadPermissions(lc, replica), changed: true};
+    return {permissions: loadPermissions(lc, replica, appID), changed: true};
   }
-  const {hash} = replica.get(`SELECT hash FROM "zero.permissions"`);
+  const {hash} = replica.get(`SELECT hash FROM "${appID}.permissions"`);
   return hash === current.hash
     ? {permissions: current, changed: false}
-    : {permissions: loadPermissions(lc, replica), changed: true};
+    : {permissions: loadPermissions(lc, replica, appID), changed: true};
 }
 
 export function getSchema(lc: LogContext, replica: Database): Schema {

--- a/packages/zero-cache/src/auth/read-authorizer.query.test.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.query.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable arrow-body-style */
+import {LogContext} from '@rocicorp/logger';
 import {beforeEach, describe, expect, test} from 'vitest';
 import {assert} from '../../../shared/src/asserts.ts';
 import {h128} from '../../../shared/src/hash.ts';
@@ -47,7 +48,6 @@ import {TableSource} from '../../../zqlite/src/table-source.ts';
 import type {LogConfig, ZeroConfig} from '../config/zero-config.ts';
 import {transformQuery} from './read-authorizer.ts';
 import {WriteAuthorizerImpl} from './write-authorizer.ts';
-import {LogContext} from '@rocicorp/logger';
 
 const logConfig: LogConfig = {
   format: 'text',
@@ -481,11 +481,11 @@ let writeAuthorizer: WriteAuthorizerImpl;
 beforeEach(() => {
   replica = new Database(lc, ':memory:');
   replica.exec(`
-    CREATE TABLE "zero.permissions" (permissions JSON, hash TEXT);
+    CREATE TABLE "app.permissions" (permissions JSON, hash TEXT);
   `);
   const permsJSON = JSON.stringify(permissions);
   replica
-    .prepare(`INSERT INTO "zero.permissions" (permissions, hash) VALUES (?, ?)`)
+    .prepare(`INSERT INTO "app.permissions" (permissions, hash) VALUES (?, ?)`)
     .run(permsJSON, h128(permsJSON).toString(16));
 
   const sources = new Map<string, Source>();
@@ -540,7 +540,13 @@ beforeEach(() => {
     must(queryDelegate.getSource(table.name));
   }
 
-  writeAuthorizer = new WriteAuthorizerImpl(lc, zeroConfig, replica, 'cg');
+  writeAuthorizer = new WriteAuthorizerImpl(
+    lc,
+    zeroConfig,
+    replica,
+    'app',
+    'cg',
+  );
 });
 const lc = createSilentLogContext();
 

--- a/packages/zero-cache/src/auth/write-authorizer.test.ts
+++ b/packages/zero-cache/src/auth/write-authorizer.test.ts
@@ -58,8 +58,8 @@ beforeEach(() => {
   replica.exec(/*sql*/ `
     CREATE TABLE foo (id TEXT PRIMARY KEY, a TEXT, b TEXT_NOT_SUPPORTED);
     INSERT INTO foo (id, a) VALUES ('1', 'a');
-    CREATE TABLE "zero.permissions" (permissions JSON, hash TEXT);
-    INSERT INTO "zero.permissions" (permissions) VALUES (NULL);
+    CREATE TABLE "the_app.permissions" (permissions JSON, hash TEXT);
+    INSERT INTO "the_app.permissions" (permissions) VALUES (NULL);
     `);
 });
 
@@ -68,7 +68,7 @@ function setPermissions(permissions: PermissionsConfig) {
   replica
     .prepare(
       /* sql */ `
-    UPDATE "zero.permissions" SET permissions = ?, hash = ?`,
+    UPDATE "the_app.permissions" SET permissions = ?, hash = ?`,
     )
     .run(json, h128(json).toString(16));
 }
@@ -78,7 +78,13 @@ describe('normalize ops', () => {
   // upsert where row exists
   // upsert where row does not exist
   test('upsert converted to update if row exists', () => {
-    const authorizer = new WriteAuthorizerImpl(lc, zeroConfig, replica, 'cg');
+    const authorizer = new WriteAuthorizerImpl(
+      lc,
+      zeroConfig,
+      replica,
+      'the_app',
+      'cg',
+    );
     const normalized = authorizer.normalizeOps([
       {
         op: 'upsert',
@@ -97,7 +103,13 @@ describe('normalize ops', () => {
     ]);
   });
   test('upsert converted to insert if row does not exist', () => {
-    const authorizer = new WriteAuthorizerImpl(lc, zeroConfig, replica, 'cg');
+    const authorizer = new WriteAuthorizerImpl(
+      lc,
+      zeroConfig,
+      replica,
+      'the_app',
+      'cg',
+    );
     const normalized = authorizer.normalizeOps([
       {
         op: 'upsert',
@@ -123,7 +135,13 @@ describe('default deny', () => {
       tables: {},
     });
 
-    const authorizer = new WriteAuthorizerImpl(lc, zeroConfig, replica, 'cg');
+    const authorizer = new WriteAuthorizerImpl(
+      lc,
+      zeroConfig,
+      replica,
+      'the_app',
+      'cg',
+    );
 
     expect(
       authorizer.canPostMutation({sub: '2'}, [
@@ -160,7 +178,13 @@ describe('default deny', () => {
       },
     });
 
-    const authorizer = new WriteAuthorizerImpl(lc, zeroConfig, replica, 'cg');
+    const authorizer = new WriteAuthorizerImpl(
+      lc,
+      zeroConfig,
+      replica,
+      'the_app',
+      'cg',
+    );
 
     const op: InsertOp = {
       op: 'insert',
@@ -191,7 +215,13 @@ describe('default deny', () => {
       },
     });
 
-    const authorizer = new WriteAuthorizerImpl(lc, zeroConfig, replica, 'cg');
+    const authorizer = new WriteAuthorizerImpl(
+      lc,
+      zeroConfig,
+      replica,
+      'the_app',
+      'cg',
+    );
 
     const op: UpdateOp = {
       op: 'update',
@@ -221,7 +251,13 @@ describe('default deny', () => {
       },
     });
 
-    const authorizer = new WriteAuthorizerImpl(lc, zeroConfig, replica, 'cg');
+    const authorizer = new WriteAuthorizerImpl(
+      lc,
+      zeroConfig,
+      replica,
+      'the_app',
+      'cg',
+    );
 
     const op: UpdateOp = {
       op: 'update',
@@ -251,7 +287,13 @@ describe('pre & post mutation', () => {
       },
     });
 
-    const authorizer = new WriteAuthorizerImpl(lc, zeroConfig, replica, 'cg');
+    const authorizer = new WriteAuthorizerImpl(
+      lc,
+      zeroConfig,
+      replica,
+      'the_app',
+      'cg',
+    );
 
     const op: DeleteOp = {
       op: 'delete',
@@ -280,7 +322,13 @@ describe('pre & post mutation', () => {
       },
     });
 
-    const authorizer = new WriteAuthorizerImpl(lc, zeroConfig, replica, 'cg');
+    const authorizer = new WriteAuthorizerImpl(
+      lc,
+      zeroConfig,
+      replica,
+      'the_app',
+      'cg',
+    );
 
     const op: InsertOp = {
       op: 'insert',
@@ -311,7 +359,13 @@ describe('pre & post mutation', () => {
       },
     });
 
-    const authorizer = new WriteAuthorizerImpl(lc, zeroConfig, replica, 'cg');
+    const authorizer = new WriteAuthorizerImpl(
+      lc,
+      zeroConfig,
+      replica,
+      'the_app',
+      'cg',
+    );
 
     const op: UpdateOp = {
       op: 'update',
@@ -341,7 +395,13 @@ describe('pre & post mutation', () => {
       },
     });
 
-    const authorizer = new WriteAuthorizerImpl(lc, zeroConfig, replica, 'cg');
+    const authorizer = new WriteAuthorizerImpl(
+      lc,
+      zeroConfig,
+      replica,
+      'the_app',
+      'cg',
+    );
 
     const op: UpdateOp = {
       op: 'update',

--- a/packages/zero-cache/src/auth/write-authorizer.ts
+++ b/packages/zero-cache/src/auth/write-authorizer.ts
@@ -72,6 +72,7 @@ export class WriteAuthorizerImpl implements WriteAuthorizer {
   readonly #tables = new Map<string, TableSource>();
   readonly #statementRunner: StatementRunner;
   readonly #lc: LogContext;
+  readonly #appID: string;
   readonly #clientGroupID: string;
   readonly #logConfig: LogConfig;
 
@@ -81,8 +82,10 @@ export class WriteAuthorizerImpl implements WriteAuthorizer {
     lc: LogContext,
     config: ZeroConfig,
     replica: Database,
+    appID: string,
     cgID: string,
   ) {
+    this.#appID = appID;
     this.#clientGroupID = cgID;
     this.#lc = lc.withContext('class', 'WriteAuthorizerImpl');
     this.#logConfig = config.log;
@@ -107,6 +110,7 @@ export class WriteAuthorizerImpl implements WriteAuthorizer {
     this.#loadedPermissions = reloadPermissionsIfChanged(
       this.#lc,
       this.#statementRunner,
+      this.#appID,
       this.#loadedPermissions,
     ).permissions;
   }

--- a/packages/zero-cache/src/services/mutagen/mutagen.authz.pg-test.ts
+++ b/packages/zero-cache/src/services/mutagen/mutagen.authz.pg-test.ts
@@ -350,7 +350,13 @@ beforeEach(async () => {
     .prepare(`UPDATE "zero.permissions" SET permissions = ?, hash = ?`)
     .run(perms, h128(perms).toString(16));
 
-  authorizer = new WriteAuthorizerImpl(lc, zeroConfig, replica, SHARD_ID);
+  authorizer = new WriteAuthorizerImpl(
+    lc,
+    zeroConfig,
+    replica,
+    'zero',
+    SHARD_ID,
+  );
   lmid = 0;
 });
 

--- a/packages/zero-cache/src/services/mutagen/mutagen.ts
+++ b/packages/zero-cache/src/services/mutagen/mutagen.ts
@@ -60,6 +60,7 @@ export class MutagenService implements Mutagen, Service {
 
   constructor(
     lc: LogContext,
+    appID: string,
     shardID: string,
     clientGroupID: string,
     upstream: PostgresDB,
@@ -76,6 +77,7 @@ export class MutagenService implements Mutagen, Service {
       this.#lc,
       config,
       this.#replica,
+      appID,
       clientGroupID,
     );
 

--- a/packages/zero-cache/src/services/view-syncer/client-handler.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.test.ts
@@ -13,6 +13,7 @@ import {ErrorForClient} from '../../types/error-for-client.ts';
 import {Subscription} from '../../types/subscription.ts';
 import {ClientHandler, ensureSafeJSON, type Patch} from './client-handler.ts';
 
+const APP_ID = 'zapp';
 const SHARD_ID = 'xyz';
 
 describe('view-syncer/client-handler', () => {
@@ -37,6 +38,7 @@ describe('view-syncer/client-handler', () => {
       'g1',
       'id1',
       'ws1',
+      APP_ID,
       SHARD_ID,
       '121',
       PROTOCOL_VERSION,
@@ -126,6 +128,7 @@ describe('view-syncer/client-handler', () => {
         'g1',
         'id1',
         'ws1',
+        APP_ID,
         SHARD_ID,
         '121',
         PROTOCOL_VERSION,
@@ -138,6 +141,7 @@ describe('view-syncer/client-handler', () => {
         'g1',
         'id2',
         'ws2',
+        APP_ID,
         SHARD_ID,
         '120:01',
         PROTOCOL_VERSION,
@@ -150,6 +154,7 @@ describe('view-syncer/client-handler', () => {
         'g1',
         'id3',
         'ws3',
+        APP_ID,
         SHARD_ID,
         '11z',
         PROTOCOL_VERSION,
@@ -179,7 +184,7 @@ describe('view-syncer/client-handler', () => {
           op: 'put',
           id: {
             schema: '',
-            table: 'zero_xyz.clients',
+            table: 'zapp_xyz.clients',
             rowKey: {clientID: 'bar'},
           },
           contents: {
@@ -220,7 +225,7 @@ describe('view-syncer/client-handler', () => {
           op: 'put',
           id: {
             schema: '',
-            table: 'zero_xyz.clients',
+            table: 'zapp_xyz.clients',
             rowKey: {clientID: 'foo'},
           },
           contents: {
@@ -254,7 +259,7 @@ describe('view-syncer/client-handler', () => {
           op: 'put',
           id: {
             schema: '',
-            table: 'zero_xyz.clients',
+            table: 'zapp_xyz.clients',
             rowKey: {clientID: 'foo'},
           },
           contents: {
@@ -396,6 +401,7 @@ describe('view-syncer/client-handler', () => {
       'g1',
       'id1',
       'ws1',
+      APP_ID,
       SHARD_ID,
       '120',
       PROTOCOL_VERSION,
@@ -437,7 +443,7 @@ describe('view-syncer/client-handler', () => {
       {
         type: 'row',
         op: 'put',
-        id: {schema: '', table: 'zero_xyz.clients', rowKey: {clientID: 'boo'}},
+        id: {schema: '', table: 'zapp_xyz.clients', rowKey: {clientID: 'boo'}},
         contents: {
           clientGroupID: 'g1',
           clientID: 'boo',
@@ -459,6 +465,7 @@ describe('view-syncer/client-handler', () => {
         'g1',
         'id1',
         'ws1',
+        APP_ID,
         SHARD_ID,
         '121',
         PROTOCOL_VERSION,

--- a/packages/zero-cache/src/services/view-syncer/client-handler.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.ts
@@ -24,7 +24,6 @@ import {
   type SchemaVersions,
 } from '../../types/schema-versions.ts';
 import type {Subscription} from '../../types/subscription.ts';
-import {unescapedSchema as schema} from '../change-source/pg/schema/shard.ts';
 import {
   cmpVersions,
   cookieToVersion,
@@ -95,6 +94,7 @@ export class ClientHandler {
     clientGroupID: string,
     clientID: string,
     wsID: string,
+    appID: string,
     shardID: string,
     baseCookie: string | null,
     protocolVersion: number,
@@ -104,7 +104,7 @@ export class ClientHandler {
     this.#clientGroupID = clientGroupID;
     this.clientID = clientID;
     this.wsID = wsID;
-    this.#zeroClientsTable = `${schema(shardID)}.clients`;
+    this.#zeroClientsTable = `${appID}_${shardID}.clients`;
     this.#lc = lc;
     this.#downstream = downstream;
     this.#baseVersion = cookieToVersion(baseCookie);
@@ -304,7 +304,7 @@ export class ClientHandler {
   }
 }
 
-// Note: The zero_{SHARD_ID}.clients table is set up in replicator/initial-sync.ts.
+// Note: The {APP_ID}_{SHARD_ID}.clients table is set up in replicator/initial-sync.ts.
 const lmidRowSchema = v.object({
   clientGroupID: v.string(),
   clientID: v.string(),

--- a/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
@@ -32,6 +32,7 @@ import {
 } from './schema/cvr.ts';
 import type {CVRVersion, RowID} from './schema/types.ts';
 
+const APP_ID = 'dapp';
 const SHARD_ID = 'jkl';
 
 const LAST_CONNECT = Date.UTC(2024, 2, 1);
@@ -649,7 +650,7 @@ describe('view-syncer/cvr', () => {
       },
     } satisfies CVRSnapshot);
 
-    const updater = new CVRConfigDrivenUpdater(cvrStore, cvr, SHARD_ID);
+    const updater = new CVRConfigDrivenUpdater(cvrStore, cvr, APP_ID, SHARD_ID);
 
     // This removes and adds desired queries to the existing fooClient.
     expect(updater.deleteDesiredQueries('fooClient', ['oneHash', 'twoHash']))
@@ -818,7 +819,7 @@ describe('view-syncer/cvr', () => {
           id: 'lmids',
           internal: true,
           ast: {
-            table: `zero_${SHARD_ID}.clients`,
+            table: `${APP_ID}_${SHARD_ID}.clients`,
             schema: '',
             where: {
               type: 'simple',
@@ -935,7 +936,7 @@ describe('view-syncer/cvr', () => {
         {
           clientAST: {
             schema: '',
-            table: `zero_${SHARD_ID}.clients`,
+            table: `${APP_ID}_${SHARD_ID}.clients`,
             where: {
               left: {
                 type: 'column',
@@ -1066,7 +1067,12 @@ describe('view-syncer/cvr', () => {
 
     // Add the deleted desired query back. This ensures that the
     // desired query update statement is an UPSERT.
-    const updater2 = new CVRConfigDrivenUpdater(cvrStore2, reloaded, SHARD_ID);
+    const updater2 = new CVRConfigDrivenUpdater(
+      cvrStore2,
+      reloaded,
+      APP_ID,
+      SHARD_ID,
+    );
     expect(
       updater2.putDesiredQueries('fooClient', [
         {hash: 'oneHash', ast: {table: 'issues'}, ttl: undefined},
@@ -1155,7 +1161,7 @@ describe('view-syncer/cvr', () => {
       ON_FAILURE,
     );
     const cvr = await cvrStore.load(lc, LAST_CONNECT);
-    const updater = new CVRConfigDrivenUpdater(cvrStore, cvr, SHARD_ID);
+    const updater = new CVRConfigDrivenUpdater(cvrStore, cvr, APP_ID, SHARD_ID);
 
     // Same desired query set. Nothing should change except last active time.
     expect(
@@ -4221,7 +4227,12 @@ describe('view-syncer/cvr', () => {
         }
       `);
 
-      const updater = new CVRConfigDrivenUpdater(cvrStore, cvr, SHARD_ID);
+      const updater = new CVRConfigDrivenUpdater(
+        cvrStore,
+        cvr,
+        APP_ID,
+        SHARD_ID,
+      );
       updater.markDesiredQueryAsInactive('fooClient', 'oneHash', now);
 
       const {cvr: updated} = await updater.flush(lc, true, LAST_CONNECT, now);
@@ -4363,7 +4374,12 @@ describe('view-syncer/cvr', () => {
         },
       });
 
-      const updater = new CVRConfigDrivenUpdater(cvrStore, cvr, SHARD_ID);
+      const updater = new CVRConfigDrivenUpdater(
+        cvrStore,
+        cvr,
+        APP_ID,
+        SHARD_ID,
+      );
       updater.markDesiredQueryAsInactive('fooClient', 'oneHash', now);
 
       const {cvr: updated} = await updater.flush(lc, true, LAST_CONNECT, now);
@@ -4495,7 +4511,7 @@ describe('view-syncer/cvr', () => {
       ON_FAILURE,
     );
     const cvr = await cvrStore.load(lc, LAST_CONNECT);
-    const updater = new CVRConfigDrivenUpdater(cvrStore, cvr, SHARD_ID);
+    const updater = new CVRConfigDrivenUpdater(cvrStore, cvr, APP_ID, SHARD_ID);
 
     expect(updater.deleteClient('client-b')).toMatchInlineSnapshot(`
       [
@@ -4874,7 +4890,7 @@ describe('view-syncer/cvr', () => {
       }
     `);
 
-    const updater = new CVRConfigDrivenUpdater(cvrStore, cvr, SHARD_ID);
+    const updater = new CVRConfigDrivenUpdater(cvrStore, cvr, APP_ID, SHARD_ID);
 
     // No patches because client-b is from a different group.
     expect(updater.deleteClient('client-b')).toEqual([]);
@@ -5081,7 +5097,12 @@ describe('view-syncer/cvr', () => {
 
     {
       const cvr = await cvrStore.load(lc, LAST_CONNECT);
-      const updater = new CVRConfigDrivenUpdater(cvrStore, cvr, SHARD_ID);
+      const updater = new CVRConfigDrivenUpdater(
+        cvrStore,
+        cvr,
+        APP_ID,
+        SHARD_ID,
+      );
 
       updater.deleteClientGroup('def456');
       const {cvr: updated2} = await updater.flush(

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -13,7 +13,6 @@ import type {AST} from '../../../../zero-protocol/src/ast.ts';
 import {stringify, type JSONObject} from '../../types/bigint-json.ts';
 import type {LexiVersion} from '../../types/lexi-version.ts';
 import {rowIDString} from '../../types/row-key.ts';
-import {unescapedSchema as schema} from '../change-source/pg/schema/shard.ts';
 import type {Patch, PatchToVersion} from './client-handler.ts';
 import type {CVRFlushStats, CVRStore} from './cvr-store.ts';
 import {KeyColumns} from './key-columns.ts';
@@ -154,10 +153,17 @@ export class CVRUpdater {
  * but the `stateVersion` of the CVR does not change.
  */
 export class CVRConfigDrivenUpdater extends CVRUpdater {
+  readonly #appID: string;
   readonly #shardID;
 
-  constructor(cvrStore: CVRStore, cvr: CVRSnapshot, shardID: string) {
+  constructor(
+    cvrStore: CVRStore,
+    cvr: CVRSnapshot,
+    appID: string,
+    shardID: string,
+  ) {
     super(cvrStore, cvr, cvr.replicaVersion);
+    this.#appID = appID;
     this.#shardID = shardID;
   }
 
@@ -178,7 +184,7 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
         id: CLIENT_LMID_QUERY_ID,
         ast: {
           schema: '',
-          table: `${schema(this.#shardID)}.clients`,
+          table: `${this.#appID}_${this.#shardID}.clients`,
           where: {
             type: 'simple',
             left: {

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -42,7 +42,8 @@ describe('view-syncer/pipeline-driver', () => {
     pipelines = new PipelineDriver(
       lc,
       logConfig,
-      new Snapshotter(lc, dbFile.path),
+      new Snapshotter(lc, dbFile.path, 'zeroz'),
+      'zeroz',
       new DatabaseStorage(storage).createClientGroupStorage('foo-client-group'),
       'pipeline-driver.test.ts',
     );
@@ -51,14 +52,14 @@ describe('view-syncer/pipeline-driver', () => {
     initReplicationState(db, ['zero_data'], '123');
     initChangeLog(db);
     db.exec(`
-      CREATE TABLE "zero.schemaVersions" (
+      CREATE TABLE "zeroz.schemaVersions" (
         -- Note: Using "INT" to avoid the special semantics of "INTEGER PRIMARY KEY" in SQLite.
         "lock"                INT PRIMARY KEY,
         "minSupportedVersion" INT,
         "maxSupportedVersion" INT,
         _0_version            TEXT NOT NULL
       );
-      INSERT INTO "zero.schemaVersions" ("lock", "minSupportedVersion", "maxSupportedVersion", _0_version)    
+      INSERT INTO "zeroz.schemaVersions" ("lock", "minSupportedVersion", "maxSupportedVersion", _0_version)    
         VALUES (1, 1, 1, '123');
       CREATE TABLE issues (
         id TEXT PRIMARY KEY,
@@ -286,7 +287,7 @@ describe('view-syncer/pipeline-driver', () => {
   });
   const zeroMessages = new ReplicationMessages(
     {schemaVersions: 'lock'},
-    'zero',
+    'zeroz',
   );
 
   test('replica version', () => {

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -68,6 +68,7 @@ export class PipelineDriver {
   readonly #lc: LogContext;
   readonly #snapshotter: Snapshotter;
   readonly #storage: ClientGroupStorage;
+  readonly #appID: string;
   readonly #clientGroupID: string;
   readonly #logConfig: LogConfig;
   #tableSpecs: Map<string, LiteAndZqlSpec> | null = null;
@@ -78,12 +79,14 @@ export class PipelineDriver {
     lc: LogContext,
     logConfig: LogConfig,
     snapshotter: Snapshotter,
+    appID: string,
     storage: ClientGroupStorage,
     clientGroupID: string,
   ) {
     this.#lc = lc.withContext('clientGroupID', clientGroupID);
     this.#snapshotter = snapshotter;
     this.#storage = storage;
+    this.#appID = appID;
     this.#clientGroupID = clientGroupID;
     this.#logConfig = logConfig;
   }
@@ -136,11 +139,15 @@ export class PipelineDriver {
   }
 
   /**
-   * Returns the current upstream zero.permissions, or `null` if none are defined.
+   * Returns the current upstream {app}.permissions, or `null` if none are defined.
    */
   currentPermissions(): LoadedPermissions {
     assert(this.initialized(), 'Not yet initialized');
-    return loadPermissions(this.#lc, this.#snapshotter.current().db);
+    return loadPermissions(
+      this.#lc,
+      this.#snapshotter.current().db,
+      this.#appID,
+    );
   }
 
   advanceWithoutDiff(): string {

--- a/packages/zero-cache/src/services/view-syncer/snapshotter.ts
+++ b/packages/zero-cache/src/services/view-syncer/snapshotter.ts
@@ -87,12 +87,14 @@ import {
 export class Snapshotter {
   readonly #lc: LogContext;
   readonly #dbFile: string;
+  readonly #appID: string;
   #curr: Snapshot | undefined;
   #prev: Snapshot | undefined;
 
-  constructor(lc: LogContext, dbFile: string) {
+  constructor(lc: LogContext, dbFile: string, appID: string) {
     this.#lc = lc;
     this.#dbFile = dbFile;
+    this.#appID = appID;
   }
 
   /**
@@ -102,7 +104,7 @@ export class Snapshotter {
    */
   init(): this {
     assert(this.#curr === undefined, 'Already initialized');
-    this.#curr = Snapshot.create(this.#lc, this.#dbFile);
+    this.#curr = Snapshot.create(this.#lc, this.#dbFile, this.#appID);
     this.#lc.debug?.(`Initial snapshot at version ${this.#curr.version}`);
     return this;
   }
@@ -156,14 +158,14 @@ export class Snapshotter {
    */
   advance(tables: Map<string, LiteAndZqlSpec>): SnapshotDiff {
     const {prev, curr} = this.advanceWithoutDiff();
-    return new Diff(tables, prev, curr);
+    return new Diff(this.#appID, tables, prev, curr);
   }
 
   advanceWithoutDiff() {
     assert(this.#curr !== undefined, 'Snapshotter has not been initialized');
     const next = this.#prev
       ? this.#prev.resetToHead()
-      : Snapshot.create(this.#lc, this.#curr.db.db.name);
+      : Snapshot.create(this.#lc, this.#curr.db.db.name, this.#appID);
     this.#prev = this.#curr;
     this.#curr = next;
     return {prev: this.#prev, curr: this.#curr};
@@ -230,14 +232,14 @@ export class ResetPipelinesSignal extends Error {
   }
 }
 
-function getSchemaVersions(db: StatementRunner): SchemaVersions {
+function getSchemaVersions(db: StatementRunner, appID: string): SchemaVersions {
   return db.get(
-    'SELECT minSupportedVersion, maxSupportedVersion FROM "zero.schemaVersions"',
+    `SELECT minSupportedVersion, maxSupportedVersion FROM "${appID}.schemaVersions"`,
   );
 }
 
 class Snapshot {
-  static create(lc: LogContext, dbFile: string) {
+  static create(lc: LogContext, dbFile: string, appID: string) {
     const conn = new Database(lc, dbFile);
     conn.pragma('synchronous = OFF'); // Applied changes are ephemeral; COMMIT is never called.
     const [{journal_mode: mode}] = conn.pragma('journal_mode') as [
@@ -253,27 +255,25 @@ class Snapshot {
     );
 
     const db = new StatementRunner(conn);
+    return new Snapshot(db, appID);
+  }
+
+  readonly db: StatementRunner;
+  readonly #appID: string;
+  readonly version: string;
+  readonly schemaVersions: SchemaVersions;
+
+  constructor(db: StatementRunner, appID: string) {
     db.beginConcurrent();
     // Note: The subsequent read is necessary to acquire the read lock
     // (which results in the logical creation of the snapshot). Calling
     // `BEGIN CONCURRENT` alone does not result in acquiring the read lock.
     const {stateVersion} = getReplicationState(db);
-    const schemaVersions = getSchemaVersions(db);
-    return new Snapshot(db, stateVersion, schemaVersions);
-  }
 
-  readonly db: StatementRunner;
-  readonly version: string;
-  readonly schemaVersions: SchemaVersions;
-
-  constructor(
-    db: StatementRunner,
-    version: string,
-    schemaVersions: SchemaVersions,
-  ) {
     this.db = db;
-    this.version = version;
-    this.schemaVersions = schemaVersions;
+    this.#appID = appID;
+    this.version = stateVersion;
+    this.schemaVersions = getSchemaVersions(db, appID);
   }
 
   numChangesSince(prevVersion: string) {
@@ -326,24 +326,24 @@ class Snapshot {
 
   resetToHead(): Snapshot {
     this.db.rollback();
-    this.db.beginConcurrent();
-    const {stateVersion} = getReplicationState(this.db);
-    const schemaVersions = getSchemaVersions(this.db);
-    return new Snapshot(this.db, stateVersion, schemaVersions);
+    return new Snapshot(this.db, this.#appID);
   }
 }
 
 class Diff implements SnapshotDiff {
+  readonly #permissionsTable: string;
   readonly tables: Map<string, LiteAndZqlSpec>;
   readonly prev: Snapshot;
   readonly curr: Snapshot;
   readonly changes: number;
 
   constructor(
+    appID: string,
     tables: Map<string, LiteAndZqlSpec>,
     prev: Snapshot,
     curr: Snapshot,
   ) {
+    this.#permissionsTable = `${appID}.permissions`;
     this.tables = tables;
     this.prev = prev;
     this.curr = curr;
@@ -402,11 +402,11 @@ class Diff implements SnapshotDiff {
             }
 
             if (
-              table === 'zero.permissions' &&
+              table === this.#permissionsTable &&
               prevValue.permissions !== nextValue.permissions
             ) {
               throw new ResetPipelinesSignal(
-                `zero.permissions have changed ${prevValue.hash} => ${nextValue.hash}`,
+                `Permissions have changed ${prevValue.hash} => ${nextValue.hash}`,
               );
             }
 

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -61,6 +61,7 @@ import {initViewSyncerSchema} from './schema/init.ts';
 import {Snapshotter} from './snapshotter.ts';
 import {pickToken, type SyncContext, ViewSyncerService} from './view-syncer.ts';
 
+const APP_ID = 'this_app';
 const SHARD_ID = 'abc';
 const logConfig: LogConfig = {
   format: 'text',
@@ -71,7 +72,7 @@ const logConfig: LogConfig = {
 
 const EXPECTED_LMIDS_AST: AST = {
   schema: '',
-  table: 'zero_abc.clients',
+  table: 'this_app_abc.clients',
   where: {
     type: 'simple',
     op: '=',
@@ -327,7 +328,7 @@ async function setup(permissions: PermissionsConfig | undefined) {
   replica.pragma('journal_mode = WAL2');
   replica.pragma('busy_timeout = 1');
   replica.exec(`
-  CREATE TABLE "zero_abc.clients" (
+  CREATE TABLE "this_app_abc.clients" (
     "clientGroupID"  TEXT,
     "clientID"       TEXT,
     "lastMutationID" INTEGER,
@@ -335,13 +336,13 @@ async function setup(permissions: PermissionsConfig | undefined) {
     _0_version       TEXT NOT NULL,
     PRIMARY KEY ("clientGroupID", "clientID")
   );
-  CREATE TABLE "zero.schemaVersions" (
+  CREATE TABLE "this_app.schemaVersions" (
     "lock"                INT PRIMARY KEY,
     "minSupportedVersion" INT,
     "maxSupportedVersion" INT,
     _0_version            TEXT NOT NULL
   );
-  CREATE TABLE "zero.permissions" (
+  CREATE TABLE "this_app.permissions" (
     "lock"        INT PRIMARY KEY,
     "permissions" JSON,
     "hash"        TEXT,
@@ -379,11 +380,11 @@ async function setup(permissions: PermissionsConfig | undefined) {
     _0_version TEXT NOT NULL
   );
 
-  INSERT INTO "zero_abc.clients" ("clientGroupID", "clientID", "lastMutationID", _0_version)
+  INSERT INTO "this_app_abc.clients" ("clientGroupID", "clientID", "lastMutationID", _0_version)
     VALUES ('9876', 'foo', 42, '01');
-  INSERT INTO "zero.schemaVersions" ("lock", "minSupportedVersion", "maxSupportedVersion", _0_version)    
+  INSERT INTO "this_app.schemaVersions" ("lock", "minSupportedVersion", "maxSupportedVersion", _0_version)    
     VALUES (1, 2, 3, '01'); 
-  INSERT INTO "zero.permissions" ("lock", "permissions", "hash", _0_version)
+  INSERT INTO "this_app.permissions" ("lock", "permissions", "hash", _0_version)
     VALUES (1, NULL, NULL, '01');
 
   INSERT INTO users (id, name, _0_version) VALUES ('100', 'Alice', '01');
@@ -416,6 +417,7 @@ async function setup(permissions: PermissionsConfig | undefined) {
   ).createClientGroupStorage(serviceID);
   const vs = new ViewSyncerService(
     lc,
+    APP_ID,
     TASK_ID,
     serviceID,
     SHARD_ID,
@@ -423,7 +425,8 @@ async function setup(permissions: PermissionsConfig | undefined) {
     new PipelineDriver(
       lc.withContext('component', 'pipeline-driver'),
       logConfig,
-      new Snapshotter(lc, replicaDbFile.path),
+      new Snapshotter(lc, replicaDbFile.path, APP_ID),
+      APP_ID,
       operatorStorage,
       'view-syncer.pg-test.ts',
     ),
@@ -433,7 +436,7 @@ async function setup(permissions: PermissionsConfig | undefined) {
   if (permissions) {
     const json = JSON.stringify(permissions);
     replica
-      .prepare(`UPDATE "zero.permissions" SET permissions = ?, hash = ?`)
+      .prepare(`UPDATE "this_app.permissions" SET permissions = ?, hash = ?`)
       .run(json, h128(json).toString(16));
   }
   const viewSyncerDone = vs.run();
@@ -506,12 +509,12 @@ const messages = new ReplicationMessages({
   users: 'id',
   issueLabels: ['issueID', 'labelID'],
 });
-const zeroMessages = new ReplicationMessages(
+const appMessages = new ReplicationMessages(
   {
     schemaVersions: 'lock',
     permissions: 'lock',
   },
-  'zero',
+  'this_app',
 );
 
 describe('view-syncer/service', () => {
@@ -863,7 +866,7 @@ describe('view-syncer/service', () => {
           },
           "rowVersion": "01",
           "schema": "",
-          "table": "zero_abc.clients",
+          "table": "this_app_abc.clients",
         },
         {
           "clientGroupID": "9876",
@@ -1402,7 +1405,7 @@ describe('view-syncer/service', () => {
           },
           "rowVersion": "01",
           "schema": "",
-          "table": "zero_abc.clients",
+          "table": "this_app_abc.clients",
         },
         {
           "clientGroupID": "9876",
@@ -1767,7 +1770,7 @@ describe('view-syncer/service', () => {
           },
           "rowVersion": "01",
           "schema": "",
-          "table": "zero_abc.clients",
+          "table": "this_app_abc.clients",
         },
         {
           "clientGroupID": "9876",
@@ -1917,7 +1920,7 @@ describe('view-syncer/service', () => {
           },
           "rowVersion": "01",
           "schema": "",
-          "table": "zero_abc.clients",
+          "table": "this_app_abc.clients",
         },
         {
           "clientGroupID": "9876",
@@ -2149,7 +2152,7 @@ describe('view-syncer/service', () => {
         big: 9007199254740991n,
       }),
       messages.delete('issues', {id: '2'}),
-      zeroMessages.update('schemaVersions', {
+      appMessages.update('schemaVersions', {
         lock: true,
         minSupportedVersion: 3,
       }),
@@ -3660,7 +3663,7 @@ describe('permissions', () => {
     };
     replicator.processTransaction(
       '05',
-      zeroMessages.update('permissions', {
+      appMessages.update('permissions', {
         lock: 1,
         permissions: relaxed,
         hash: h128(JSON.stringify(relaxed)).toString(16),

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -106,6 +106,7 @@ function randomID() {
 
 export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   readonly id: string;
+  readonly #appID: string;
   readonly #shardID: string;
   readonly #lc: LogContext;
   readonly #pipelines: PipelineDriver;
@@ -132,6 +133,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
   constructor(
     lc: LogContext,
+    appID: string,
     taskID: string,
     clientGroupID: string,
     shardID: string,
@@ -142,6 +144,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     keepaliveMs = DEFAULT_KEEPALIVE_MS,
   ) {
     this.id = clientGroupID;
+    this.#appID = appID;
     this.#shardID = shardID;
     this.#lc = lc;
     this.#pipelines = pipelineDriver;
@@ -371,6 +374,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         this.id,
         clientID,
         wsID,
+        this.#appID,
         this.#shardID,
         baseCookie,
         protocolVersion,
@@ -435,6 +439,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     const updater = new CVRConfigDrivenUpdater(
       this.#cvrStore,
       cvr,
+      this.#appID,
       this.#shardID,
     );
 


### PR DESCRIPTION
Replaces the "zero" constant name with an `appID` parameter in code that reads the replicated `permissions`, `clients`, and `schemaVersions` tables.

This value plumbed from the top level config, and is currently hard-coded to "zero", so this PR in and of itself has no behavioral change.

This is in preparation for transitioning the existing `--shard-id` parameter to an `--app-id`. 

Context: https://www.notion.so/replicache/Zero-Upstream-Organization-1a33bed8954580e9a03fdddf81690fcc