### PR TITLE
Revert "chore(zero-cache): plumb an "appID" to code that reads `permissions`, `clients`, `schemaVersions`"

### DIFF
--- a/packages/zero-cache/src/auth/load-permissions.test.ts
+++ b/packages/zero-cache/src/auth/load-permissions.test.ts
@@ -14,11 +14,11 @@ describe('auth/load-permissions', () => {
   beforeEach(() => {
     replica = new Database(createSilentLogContext(), ':memory:');
     replica.exec(/* sql */ `
-      CREATE TABLE "zero_app.permissions" (
+      CREATE TABLE "zero.permissions" (
         permissions JSON,
         hash TEXT
       );
-      INSERT INTO "zero_app.permissions" (permissions) VALUES (NULL);
+      INSERT INTO "zero.permissions" (permissions) VALUES (NULL);
       `);
     db = new StatementRunner(replica);
   });
@@ -27,13 +27,13 @@ describe('auth/load-permissions', () => {
     const permissions =
       typeof perms === 'string' ? perms : JSON.stringify(perms);
     replica
-      .prepare(`UPDATE "zero_app.permissions" SET permissions = ?, hash = ?`)
+      .prepare(`UPDATE "zero.permissions" SET permissions = ?, hash = ?`)
       .run(permissions, h128(permissions).toString(16));
   }
 
   test('loads supported permissions', () => {
     setPermissions({tables: {}});
-    expect(loadPermissions(lc, db, 'zero_app')).toMatchInlineSnapshot(`
+    expect(loadPermissions(lc, db)).toMatchInlineSnapshot(`
       {
         "hash": "4fa6194de2f465d532971ce1b9b513e9",
         "permissions": {
@@ -45,9 +45,7 @@ describe('auth/load-permissions', () => {
 
   test('invalid permissions', () => {
     setPermissions(`{"tablez":{}}`);
-    expect(() =>
-      loadPermissions(lc, db, 'zero_app'),
-    ).toThrowErrorMatchingInlineSnapshot(
+    expect(() => loadPermissions(lc, db)).toThrowErrorMatchingInlineSnapshot(
       `
       [Error: Could not parse upstream permissions: '{"tablez":{}}'.
       This may happen if Permissions with a new internal format are deployed before the supporting server has been fully rolled out.]
@@ -57,9 +55,7 @@ describe('auth/load-permissions', () => {
 
   test('permissions invalid JSON', () => {
     setPermissions(`I'm not JSON`);
-    expect(() =>
-      loadPermissions(lc, db, 'zero_app'),
-    ).toThrowErrorMatchingInlineSnapshot(
+    expect(() => loadPermissions(lc, db)).toThrowErrorMatchingInlineSnapshot(
       `
       [Error: Could not parse upstream permissions: 'I'm not JSON'.
       This may happen if Permissions with a new internal format are deployed before the supporting server has been fully rolled out.]
@@ -69,9 +65,7 @@ describe('auth/load-permissions', () => {
 
   test('invalid long permissions', () => {
     setPermissions(`{"baz": 108, "foo":"ba${'a'.repeat(1000)}r"}`);
-    expect(() =>
-      loadPermissions(lc, db, 'zero_app'),
-    ).toThrowErrorMatchingInlineSnapshot(
+    expect(() => loadPermissions(lc, db)).toThrowErrorMatchingInlineSnapshot(
       `
       [Error: Could not parse upstream permissions: '{"baz": 108, "foo":"baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...'.
       This may happen if Permissions with a new internal format are deployed before the supporting server has been fully rolled out.]

--- a/packages/zero-cache/src/auth/load-permissions.ts
+++ b/packages/zero-cache/src/auth/load-permissions.ts
@@ -19,10 +19,9 @@ export type LoadedPermissions = {
 export function loadPermissions(
   lc: LogContext,
   replica: StatementRunner,
-  appID: string,
 ): LoadedPermissions {
   const {permissions, hash} = replica.get(
-    `SELECT permissions, hash FROM "${appID}.permissions"`,
+    `SELECT permissions, hash FROM "zero.permissions"`,
   );
   if (permissions === null) {
     lc.warn?.(
@@ -55,16 +54,15 @@ export function loadPermissions(
 export function reloadPermissionsIfChanged(
   lc: LogContext,
   replica: StatementRunner,
-  appID: string,
   current: LoadedPermissions | null,
 ): {permissions: LoadedPermissions; changed: boolean} {
   if (current === null) {
-    return {permissions: loadPermissions(lc, replica, appID), changed: true};
+    return {permissions: loadPermissions(lc, replica), changed: true};
   }
-  const {hash} = replica.get(`SELECT hash FROM "${appID}.permissions"`);
+  const {hash} = replica.get(`SELECT hash FROM "zero.permissions"`);
   return hash === current.hash
     ? {permissions: current, changed: false}
-    : {permissions: loadPermissions(lc, replica, appID), changed: true};
+    : {permissions: loadPermissions(lc, replica), changed: true};
 }
 
 export function getSchema(lc: LogContext, replica: Database): Schema {

--- a/packages/zero-cache/src/auth/read-authorizer.query.test.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.query.test.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable arrow-body-style */
-import {LogContext} from '@rocicorp/logger';
 import {beforeEach, describe, expect, test} from 'vitest';
 import {assert} from '../../../shared/src/asserts.ts';
 import {h128} from '../../../shared/src/hash.ts';
@@ -48,6 +47,7 @@ import {TableSource} from '../../../zqlite/src/table-source.ts';
 import type {LogConfig, ZeroConfig} from '../config/zero-config.ts';
 import {transformQuery} from './read-authorizer.ts';
 import {WriteAuthorizerImpl} from './write-authorizer.ts';
+import {LogContext} from '@rocicorp/logger';
 
 const logConfig: LogConfig = {
   format: 'text',
@@ -481,11 +481,11 @@ let writeAuthorizer: WriteAuthorizerImpl;
 beforeEach(() => {
   replica = new Database(lc, ':memory:');
   replica.exec(`
-    CREATE TABLE "app.permissions" (permissions JSON, hash TEXT);
+    CREATE TABLE "zero.permissions" (permissions JSON, hash TEXT);
   `);
   const permsJSON = JSON.stringify(permissions);
   replica
-    .prepare(`INSERT INTO "app.permissions" (permissions, hash) VALUES (?, ?)`)
+    .prepare(`INSERT INTO "zero.permissions" (permissions, hash) VALUES (?, ?)`)
     .run(permsJSON, h128(permsJSON).toString(16));
 
   const sources = new Map<string, Source>();
@@ -540,13 +540,7 @@ beforeEach(() => {
     must(queryDelegate.getSource(table.name));
   }
 
-  writeAuthorizer = new WriteAuthorizerImpl(
-    lc,
-    zeroConfig,
-    replica,
-    'app',
-    'cg',
-  );
+  writeAuthorizer = new WriteAuthorizerImpl(lc, zeroConfig, replica, 'cg');
 });
 const lc = createSilentLogContext();
 

--- a/packages/zero-cache/src/auth/write-authorizer.test.ts
+++ b/packages/zero-cache/src/auth/write-authorizer.test.ts
@@ -58,8 +58,8 @@ beforeEach(() => {
   replica.exec(/*sql*/ `
     CREATE TABLE foo (id TEXT PRIMARY KEY, a TEXT, b TEXT_NOT_SUPPORTED);
     INSERT INTO foo (id, a) VALUES ('1', 'a');
-    CREATE TABLE "the_app.permissions" (permissions JSON, hash TEXT);
-    INSERT INTO "the_app.permissions" (permissions) VALUES (NULL);
+    CREATE TABLE "zero.permissions" (permissions JSON, hash TEXT);
+    INSERT INTO "zero.permissions" (permissions) VALUES (NULL);
     `);
 });
 
@@ -68,7 +68,7 @@ function setPermissions(permissions: PermissionsConfig) {
   replica
     .prepare(
       /* sql */ `
-    UPDATE "the_app.permissions" SET permissions = ?, hash = ?`,
+    UPDATE "zero.permissions" SET permissions = ?, hash = ?`,
     )
     .run(json, h128(json).toString(16));
 }
@@ -78,13 +78,7 @@ describe('normalize ops', () => {
   // upsert where row exists
   // upsert where row does not exist
   test('upsert converted to update if row exists', () => {
-    const authorizer = new WriteAuthorizerImpl(
-      lc,
-      zeroConfig,
-      replica,
-      'the_app',
-      'cg',
-    );
+    const authorizer = new WriteAuthorizerImpl(lc, zeroConfig, replica, 'cg');
     const normalized = authorizer.normalizeOps([
       {
         op: 'upsert',
@@ -103,13 +97,7 @@ describe('normalize ops', () => {
     ]);
   });
   test('upsert converted to insert if row does not exist', () => {
-    const authorizer = new WriteAuthorizerImpl(
-      lc,
-      zeroConfig,
-      replica,
-      'the_app',
-      'cg',
-    );
+    const authorizer = new WriteAuthorizerImpl(lc, zeroConfig, replica, 'cg');
     const normalized = authorizer.normalizeOps([
       {
         op: 'upsert',
@@ -135,13 +123,7 @@ describe('default deny', () => {
       tables: {},
     });
 
-    const authorizer = new WriteAuthorizerImpl(
-      lc,
-      zeroConfig,
-      replica,
-      'the_app',
-      'cg',
-    );
+    const authorizer = new WriteAuthorizerImpl(lc, zeroConfig, replica, 'cg');
 
     expect(
       authorizer.canPostMutation({sub: '2'}, [
@@ -178,13 +160,7 @@ describe('default deny', () => {
       },
     });
 
-    const authorizer = new WriteAuthorizerImpl(
-      lc,
-      zeroConfig,
-      replica,
-      'the_app',
-      'cg',
-    );
+    const authorizer = new WriteAuthorizerImpl(lc, zeroConfig, replica, 'cg');
 
     const op: InsertOp = {
       op: 'insert',
@@ -215,13 +191,7 @@ describe('default deny', () => {
       },
     });
 
-    const authorizer = new WriteAuthorizerImpl(
-      lc,
-      zeroConfig,
-      replica,
-      'the_app',
-      'cg',
-    );
+    const authorizer = new WriteAuthorizerImpl(lc, zeroConfig, replica, 'cg');
 
     const op: UpdateOp = {
       op: 'update',
@@ -251,13 +221,7 @@ describe('default deny', () => {
       },
     });
 
-    const authorizer = new WriteAuthorizerImpl(
-      lc,
-      zeroConfig,
-      replica,
-      'the_app',
-      'cg',
-    );
+    const authorizer = new WriteAuthorizerImpl(lc, zeroConfig, replica, 'cg');
 
     const op: UpdateOp = {
       op: 'update',
@@ -287,13 +251,7 @@ describe('pre & post mutation', () => {
       },
     });
 
-    const authorizer = new WriteAuthorizerImpl(
-      lc,
-      zeroConfig,
-      replica,
-      'the_app',
-      'cg',
-    );
+    const authorizer = new WriteAuthorizerImpl(lc, zeroConfig, replica, 'cg');
 
     const op: DeleteOp = {
       op: 'delete',
@@ -322,13 +280,7 @@ describe('pre & post mutation', () => {
       },
     });
 
-    const authorizer = new WriteAuthorizerImpl(
-      lc,
-      zeroConfig,
-      replica,
-      'the_app',
-      'cg',
-    );
+    const authorizer = new WriteAuthorizerImpl(lc, zeroConfig, replica, 'cg');
 
     const op: InsertOp = {
       op: 'insert',
@@ -359,13 +311,7 @@ describe('pre & post mutation', () => {
       },
     });
 
-    const authorizer = new WriteAuthorizerImpl(
-      lc,
-      zeroConfig,
-      replica,
-      'the_app',
-      'cg',
-    );
+    const authorizer = new WriteAuthorizerImpl(lc, zeroConfig, replica, 'cg');
 
     const op: UpdateOp = {
       op: 'update',
@@ -395,13 +341,7 @@ describe('pre & post mutation', () => {
       },
     });
 
-    const authorizer = new WriteAuthorizerImpl(
-      lc,
-      zeroConfig,
-      replica,
-      'the_app',
-      'cg',
-    );
+    const authorizer = new WriteAuthorizerImpl(lc, zeroConfig, replica, 'cg');
 
     const op: UpdateOp = {
       op: 'update',

--- a/packages/zero-cache/src/auth/write-authorizer.ts
+++ b/packages/zero-cache/src/auth/write-authorizer.ts
@@ -72,7 +72,6 @@ export class WriteAuthorizerImpl implements WriteAuthorizer {
   readonly #tables = new Map<string, TableSource>();
   readonly #statementRunner: StatementRunner;
   readonly #lc: LogContext;
-  readonly #appID: string;
   readonly #clientGroupID: string;
   readonly #logConfig: LogConfig;
 
@@ -82,10 +81,8 @@ export class WriteAuthorizerImpl implements WriteAuthorizer {
     lc: LogContext,
     config: ZeroConfig,
     replica: Database,
-    appID: string,
     cgID: string,
   ) {
-    this.#appID = appID;
     this.#clientGroupID = cgID;
     this.#lc = lc.withContext('class', 'WriteAuthorizerImpl');
     this.#logConfig = config.log;
@@ -110,7 +107,6 @@ export class WriteAuthorizerImpl implements WriteAuthorizer {
     this.#loadedPermissions = reloadPermissionsIfChanged(
       this.#lc,
       this.#statementRunner,
-      this.#appID,
       this.#loadedPermissions,
     ).permissions;
   }

--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -17,7 +17,6 @@ import * as v from '../../../shared/src/valita.ts';
 import {getZeroConfig} from '../config/zero-config.ts';
 import {exitAfter, runUntilKilled} from '../services/life-cycle.ts';
 import {MutagenService} from '../services/mutagen/mutagen.ts';
-import {PusherService} from '../services/mutagen/pusher.ts';
 import type {ReplicaState} from '../services/replicator/replicator.ts';
 import {DatabaseStorage} from '../services/view-syncer/database-storage.ts';
 import {DrainCoordinator} from '../services/view-syncer/drain-coordinator.ts';
@@ -34,6 +33,7 @@ import {Subscription} from '../types/subscription.ts';
 import {replicaFileModeSchema, replicaFileName} from '../workers/replicator.ts';
 import {Syncer} from '../workers/syncer.ts';
 import {createLogContext} from './logging.ts';
+import {PusherService} from '../services/mutagen/pusher.ts';
 
 function randomID() {
   return randInt(1, Number.MAX_SAFE_INTEGER).toString(36);
@@ -102,8 +102,6 @@ export default function runWorker(
     path.join(tmpDir, `sync-worker-${pid}-${randInt(1000000, 9999999)}`),
   );
 
-  const appID = 'zero'; // TODO: --app-id
-
   const viewSyncerFactory = (
     id: string,
     sub: Subscription<ReplicaState>,
@@ -115,7 +113,6 @@ export default function runWorker(
       .withContext('instance', randomID());
     return new ViewSyncerService(
       logger,
-      appID,
       must(config.taskID, 'main must set --task-id'),
       id,
       config.shard.id,
@@ -123,8 +120,7 @@ export default function runWorker(
       new PipelineDriver(
         logger,
         config.log,
-        new Snapshotter(logger, replicaFile, appID),
-        appID,
+        new Snapshotter(logger, replicaFile),
         operatorStorage.createClientGroupStorage(id),
         id,
       ),
@@ -136,7 +132,6 @@ export default function runWorker(
   const mutagenFactory = (id: string) =>
     new MutagenService(
       lc.withContext('component', 'mutagen').withContext('clientGroupID', id),
-      appID,
       config.shard.id,
       id,
       upstreamDB,

--- a/packages/zero-cache/src/services/mutagen/mutagen.authz.pg-test.ts
+++ b/packages/zero-cache/src/services/mutagen/mutagen.authz.pg-test.ts
@@ -350,13 +350,7 @@ beforeEach(async () => {
     .prepare(`UPDATE "zero.permissions" SET permissions = ?, hash = ?`)
     .run(perms, h128(perms).toString(16));
 
-  authorizer = new WriteAuthorizerImpl(
-    lc,
-    zeroConfig,
-    replica,
-    'zero',
-    SHARD_ID,
-  );
+  authorizer = new WriteAuthorizerImpl(lc, zeroConfig, replica, SHARD_ID);
   lmid = 0;
 });
 

--- a/packages/zero-cache/src/services/mutagen/mutagen.ts
+++ b/packages/zero-cache/src/services/mutagen/mutagen.ts
@@ -60,7 +60,6 @@ export class MutagenService implements Mutagen, Service {
 
   constructor(
     lc: LogContext,
-    appID: string,
     shardID: string,
     clientGroupID: string,
     upstream: PostgresDB,
@@ -77,7 +76,6 @@ export class MutagenService implements Mutagen, Service {
       this.#lc,
       config,
       this.#replica,
-      appID,
       clientGroupID,
     );
 

--- a/packages/zero-cache/src/services/view-syncer/client-handler.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.test.ts
@@ -13,7 +13,6 @@ import {ErrorForClient} from '../../types/error-for-client.ts';
 import {Subscription} from '../../types/subscription.ts';
 import {ClientHandler, ensureSafeJSON, type Patch} from './client-handler.ts';
 
-const APP_ID = 'zapp';
 const SHARD_ID = 'xyz';
 
 describe('view-syncer/client-handler', () => {
@@ -38,7 +37,6 @@ describe('view-syncer/client-handler', () => {
       'g1',
       'id1',
       'ws1',
-      APP_ID,
       SHARD_ID,
       '121',
       PROTOCOL_VERSION,
@@ -128,7 +126,6 @@ describe('view-syncer/client-handler', () => {
         'g1',
         'id1',
         'ws1',
-        APP_ID,
         SHARD_ID,
         '121',
         PROTOCOL_VERSION,
@@ -141,7 +138,6 @@ describe('view-syncer/client-handler', () => {
         'g1',
         'id2',
         'ws2',
-        APP_ID,
         SHARD_ID,
         '120:01',
         PROTOCOL_VERSION,
@@ -154,7 +150,6 @@ describe('view-syncer/client-handler', () => {
         'g1',
         'id3',
         'ws3',
-        APP_ID,
         SHARD_ID,
         '11z',
         PROTOCOL_VERSION,
@@ -184,7 +179,7 @@ describe('view-syncer/client-handler', () => {
           op: 'put',
           id: {
             schema: '',
-            table: 'zapp_xyz.clients',
+            table: 'zero_xyz.clients',
             rowKey: {clientID: 'bar'},
           },
           contents: {
@@ -225,7 +220,7 @@ describe('view-syncer/client-handler', () => {
           op: 'put',
           id: {
             schema: '',
-            table: 'zapp_xyz.clients',
+            table: 'zero_xyz.clients',
             rowKey: {clientID: 'foo'},
           },
           contents: {
@@ -259,7 +254,7 @@ describe('view-syncer/client-handler', () => {
           op: 'put',
           id: {
             schema: '',
-            table: 'zapp_xyz.clients',
+            table: 'zero_xyz.clients',
             rowKey: {clientID: 'foo'},
           },
           contents: {
@@ -401,7 +396,6 @@ describe('view-syncer/client-handler', () => {
       'g1',
       'id1',
       'ws1',
-      APP_ID,
       SHARD_ID,
       '120',
       PROTOCOL_VERSION,
@@ -443,7 +437,7 @@ describe('view-syncer/client-handler', () => {
       {
         type: 'row',
         op: 'put',
-        id: {schema: '', table: 'zapp_xyz.clients', rowKey: {clientID: 'boo'}},
+        id: {schema: '', table: 'zero_xyz.clients', rowKey: {clientID: 'boo'}},
         contents: {
           clientGroupID: 'g1',
           clientID: 'boo',
@@ -465,7 +459,6 @@ describe('view-syncer/client-handler', () => {
         'g1',
         'id1',
         'ws1',
-        APP_ID,
         SHARD_ID,
         '121',
         PROTOCOL_VERSION,

--- a/packages/zero-cache/src/services/view-syncer/client-handler.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.ts
@@ -24,6 +24,7 @@ import {
   type SchemaVersions,
 } from '../../types/schema-versions.ts';
 import type {Subscription} from '../../types/subscription.ts';
+import {unescapedSchema as schema} from '../change-source/pg/schema/shard.ts';
 import {
   cmpVersions,
   cookieToVersion,
@@ -94,7 +95,6 @@ export class ClientHandler {
     clientGroupID: string,
     clientID: string,
     wsID: string,
-    appID: string,
     shardID: string,
     baseCookie: string | null,
     protocolVersion: number,
@@ -104,7 +104,7 @@ export class ClientHandler {
     this.#clientGroupID = clientGroupID;
     this.clientID = clientID;
     this.wsID = wsID;
-    this.#zeroClientsTable = `${appID}_${shardID}.clients`;
+    this.#zeroClientsTable = `${schema(shardID)}.clients`;
     this.#lc = lc;
     this.#downstream = downstream;
     this.#baseVersion = cookieToVersion(baseCookie);
@@ -304,7 +304,7 @@ export class ClientHandler {
   }
 }
 
-// Note: The {APP_ID}_{SHARD_ID}.clients table is set up in replicator/initial-sync.ts.
+// Note: The zero_{SHARD_ID}.clients table is set up in replicator/initial-sync.ts.
 const lmidRowSchema = v.object({
   clientGroupID: v.string(),
   clientID: v.string(),

--- a/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
@@ -32,7 +32,6 @@ import {
 } from './schema/cvr.ts';
 import type {CVRVersion, RowID} from './schema/types.ts';
 
-const APP_ID = 'dapp';
 const SHARD_ID = 'jkl';
 
 const LAST_CONNECT = Date.UTC(2024, 2, 1);
@@ -650,7 +649,7 @@ describe('view-syncer/cvr', () => {
       },
     } satisfies CVRSnapshot);
 
-    const updater = new CVRConfigDrivenUpdater(cvrStore, cvr, APP_ID, SHARD_ID);
+    const updater = new CVRConfigDrivenUpdater(cvrStore, cvr, SHARD_ID);
 
     // This removes and adds desired queries to the existing fooClient.
     expect(updater.deleteDesiredQueries('fooClient', ['oneHash', 'twoHash']))
@@ -819,7 +818,7 @@ describe('view-syncer/cvr', () => {
           id: 'lmids',
           internal: true,
           ast: {
-            table: `${APP_ID}_${SHARD_ID}.clients`,
+            table: `zero_${SHARD_ID}.clients`,
             schema: '',
             where: {
               type: 'simple',
@@ -936,7 +935,7 @@ describe('view-syncer/cvr', () => {
         {
           clientAST: {
             schema: '',
-            table: `${APP_ID}_${SHARD_ID}.clients`,
+            table: `zero_${SHARD_ID}.clients`,
             where: {
               left: {
                 type: 'column',
@@ -1067,12 +1066,7 @@ describe('view-syncer/cvr', () => {
 
     // Add the deleted desired query back. This ensures that the
     // desired query update statement is an UPSERT.
-    const updater2 = new CVRConfigDrivenUpdater(
-      cvrStore2,
-      reloaded,
-      APP_ID,
-      SHARD_ID,
-    );
+    const updater2 = new CVRConfigDrivenUpdater(cvrStore2, reloaded, SHARD_ID);
     expect(
       updater2.putDesiredQueries('fooClient', [
         {hash: 'oneHash', ast: {table: 'issues'}, ttl: undefined},
@@ -1161,7 +1155,7 @@ describe('view-syncer/cvr', () => {
       ON_FAILURE,
     );
     const cvr = await cvrStore.load(lc, LAST_CONNECT);
-    const updater = new CVRConfigDrivenUpdater(cvrStore, cvr, APP_ID, SHARD_ID);
+    const updater = new CVRConfigDrivenUpdater(cvrStore, cvr, SHARD_ID);
 
     // Same desired query set. Nothing should change except last active time.
     expect(
@@ -4227,12 +4221,7 @@ describe('view-syncer/cvr', () => {
         }
       `);
 
-      const updater = new CVRConfigDrivenUpdater(
-        cvrStore,
-        cvr,
-        APP_ID,
-        SHARD_ID,
-      );
+      const updater = new CVRConfigDrivenUpdater(cvrStore, cvr, SHARD_ID);
       updater.markDesiredQueryAsInactive('fooClient', 'oneHash', now);
 
       const {cvr: updated} = await updater.flush(lc, true, LAST_CONNECT, now);
@@ -4374,12 +4363,7 @@ describe('view-syncer/cvr', () => {
         },
       });
 
-      const updater = new CVRConfigDrivenUpdater(
-        cvrStore,
-        cvr,
-        APP_ID,
-        SHARD_ID,
-      );
+      const updater = new CVRConfigDrivenUpdater(cvrStore, cvr, SHARD_ID);
       updater.markDesiredQueryAsInactive('fooClient', 'oneHash', now);
 
       const {cvr: updated} = await updater.flush(lc, true, LAST_CONNECT, now);
@@ -4511,7 +4495,7 @@ describe('view-syncer/cvr', () => {
       ON_FAILURE,
     );
     const cvr = await cvrStore.load(lc, LAST_CONNECT);
-    const updater = new CVRConfigDrivenUpdater(cvrStore, cvr, APP_ID, SHARD_ID);
+    const updater = new CVRConfigDrivenUpdater(cvrStore, cvr, SHARD_ID);
 
     expect(updater.deleteClient('client-b')).toMatchInlineSnapshot(`
       [
@@ -4890,7 +4874,7 @@ describe('view-syncer/cvr', () => {
       }
     `);
 
-    const updater = new CVRConfigDrivenUpdater(cvrStore, cvr, APP_ID, SHARD_ID);
+    const updater = new CVRConfigDrivenUpdater(cvrStore, cvr, SHARD_ID);
 
     // No patches because client-b is from a different group.
     expect(updater.deleteClient('client-b')).toEqual([]);
@@ -5097,12 +5081,7 @@ describe('view-syncer/cvr', () => {
 
     {
       const cvr = await cvrStore.load(lc, LAST_CONNECT);
-      const updater = new CVRConfigDrivenUpdater(
-        cvrStore,
-        cvr,
-        APP_ID,
-        SHARD_ID,
-      );
+      const updater = new CVRConfigDrivenUpdater(cvrStore, cvr, SHARD_ID);
 
       updater.deleteClientGroup('def456');
       const {cvr: updated2} = await updater.flush(

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -13,6 +13,7 @@ import type {AST} from '../../../../zero-protocol/src/ast.ts';
 import {stringify, type JSONObject} from '../../types/bigint-json.ts';
 import type {LexiVersion} from '../../types/lexi-version.ts';
 import {rowIDString} from '../../types/row-key.ts';
+import {unescapedSchema as schema} from '../change-source/pg/schema/shard.ts';
 import type {Patch, PatchToVersion} from './client-handler.ts';
 import type {CVRFlushStats, CVRStore} from './cvr-store.ts';
 import {KeyColumns} from './key-columns.ts';
@@ -153,17 +154,10 @@ export class CVRUpdater {
  * but the `stateVersion` of the CVR does not change.
  */
 export class CVRConfigDrivenUpdater extends CVRUpdater {
-  readonly #appID: string;
   readonly #shardID;
 
-  constructor(
-    cvrStore: CVRStore,
-    cvr: CVRSnapshot,
-    appID: string,
-    shardID: string,
-  ) {
+  constructor(cvrStore: CVRStore, cvr: CVRSnapshot, shardID: string) {
     super(cvrStore, cvr, cvr.replicaVersion);
-    this.#appID = appID;
     this.#shardID = shardID;
   }
 
@@ -184,7 +178,7 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
         id: CLIENT_LMID_QUERY_ID,
         ast: {
           schema: '',
-          table: `${this.#appID}_${this.#shardID}.clients`,
+          table: `${schema(this.#shardID)}.clients`,
           where: {
             type: 'simple',
             left: {

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -42,8 +42,7 @@ describe('view-syncer/pipeline-driver', () => {
     pipelines = new PipelineDriver(
       lc,
       logConfig,
-      new Snapshotter(lc, dbFile.path, 'zeroz'),
-      'zeroz',
+      new Snapshotter(lc, dbFile.path),
       new DatabaseStorage(storage).createClientGroupStorage('foo-client-group'),
       'pipeline-driver.test.ts',
     );
@@ -52,14 +51,14 @@ describe('view-syncer/pipeline-driver', () => {
     initReplicationState(db, ['zero_data'], '123');
     initChangeLog(db);
     db.exec(`
-      CREATE TABLE "zeroz.schemaVersions" (
+      CREATE TABLE "zero.schemaVersions" (
         -- Note: Using "INT" to avoid the special semantics of "INTEGER PRIMARY KEY" in SQLite.
         "lock"                INT PRIMARY KEY,
         "minSupportedVersion" INT,
         "maxSupportedVersion" INT,
         _0_version            TEXT NOT NULL
       );
-      INSERT INTO "zeroz.schemaVersions" ("lock", "minSupportedVersion", "maxSupportedVersion", _0_version)    
+      INSERT INTO "zero.schemaVersions" ("lock", "minSupportedVersion", "maxSupportedVersion", _0_version)    
         VALUES (1, 1, 1, '123');
       CREATE TABLE issues (
         id TEXT PRIMARY KEY,
@@ -287,7 +286,7 @@ describe('view-syncer/pipeline-driver', () => {
   });
   const zeroMessages = new ReplicationMessages(
     {schemaVersions: 'lock'},
-    'zeroz',
+    'zero',
   );
 
   test('replica version', () => {

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -68,7 +68,6 @@ export class PipelineDriver {
   readonly #lc: LogContext;
   readonly #snapshotter: Snapshotter;
   readonly #storage: ClientGroupStorage;
-  readonly #appID: string;
   readonly #clientGroupID: string;
   readonly #logConfig: LogConfig;
   #tableSpecs: Map<string, LiteAndZqlSpec> | null = null;
@@ -79,14 +78,12 @@ export class PipelineDriver {
     lc: LogContext,
     logConfig: LogConfig,
     snapshotter: Snapshotter,
-    appID: string,
     storage: ClientGroupStorage,
     clientGroupID: string,
   ) {
     this.#lc = lc.withContext('clientGroupID', clientGroupID);
     this.#snapshotter = snapshotter;
     this.#storage = storage;
-    this.#appID = appID;
     this.#clientGroupID = clientGroupID;
     this.#logConfig = logConfig;
   }
@@ -139,15 +136,11 @@ export class PipelineDriver {
   }
 
   /**
-   * Returns the current upstream {app}.permissions, or `null` if none are defined.
+   * Returns the current upstream zero.permissions, or `null` if none are defined.
    */
   currentPermissions(): LoadedPermissions {
     assert(this.initialized(), 'Not yet initialized');
-    return loadPermissions(
-      this.#lc,
-      this.#snapshotter.current().db,
-      this.#appID,
-    );
+    return loadPermissions(this.#lc, this.#snapshotter.current().db);
   }
 
   advanceWithoutDiff(): string {

--- a/packages/zero-cache/src/services/view-syncer/snapshotter.ts
+++ b/packages/zero-cache/src/services/view-syncer/snapshotter.ts
@@ -87,14 +87,12 @@ import {
 export class Snapshotter {
   readonly #lc: LogContext;
   readonly #dbFile: string;
-  readonly #appID: string;
   #curr: Snapshot | undefined;
   #prev: Snapshot | undefined;
 
-  constructor(lc: LogContext, dbFile: string, appID: string) {
+  constructor(lc: LogContext, dbFile: string) {
     this.#lc = lc;
     this.#dbFile = dbFile;
-    this.#appID = appID;
   }
 
   /**
@@ -104,7 +102,7 @@ export class Snapshotter {
    */
   init(): this {
     assert(this.#curr === undefined, 'Already initialized');
-    this.#curr = Snapshot.create(this.#lc, this.#dbFile, this.#appID);
+    this.#curr = Snapshot.create(this.#lc, this.#dbFile);
     this.#lc.debug?.(`Initial snapshot at version ${this.#curr.version}`);
     return this;
   }
@@ -158,14 +156,14 @@ export class Snapshotter {
    */
   advance(tables: Map<string, LiteAndZqlSpec>): SnapshotDiff {
     const {prev, curr} = this.advanceWithoutDiff();
-    return new Diff(this.#appID, tables, prev, curr);
+    return new Diff(tables, prev, curr);
   }
 
   advanceWithoutDiff() {
     assert(this.#curr !== undefined, 'Snapshotter has not been initialized');
     const next = this.#prev
       ? this.#prev.resetToHead()
-      : Snapshot.create(this.#lc, this.#curr.db.db.name, this.#appID);
+      : Snapshot.create(this.#lc, this.#curr.db.db.name);
     this.#prev = this.#curr;
     this.#curr = next;
     return {prev: this.#prev, curr: this.#curr};
@@ -232,14 +230,14 @@ export class ResetPipelinesSignal extends Error {
   }
 }
 
-function getSchemaVersions(db: StatementRunner, appID: string): SchemaVersions {
+function getSchemaVersions(db: StatementRunner): SchemaVersions {
   return db.get(
-    `SELECT minSupportedVersion, maxSupportedVersion FROM "${appID}.schemaVersions"`,
+    'SELECT minSupportedVersion, maxSupportedVersion FROM "zero.schemaVersions"',
   );
 }
 
 class Snapshot {
-  static create(lc: LogContext, dbFile: string, appID: string) {
+  static create(lc: LogContext, dbFile: string) {
     const conn = new Database(lc, dbFile);
     conn.pragma('synchronous = OFF'); // Applied changes are ephemeral; COMMIT is never called.
     const [{journal_mode: mode}] = conn.pragma('journal_mode') as [
@@ -255,25 +253,27 @@ class Snapshot {
     );
 
     const db = new StatementRunner(conn);
-    return new Snapshot(db, appID);
-  }
-
-  readonly db: StatementRunner;
-  readonly #appID: string;
-  readonly version: string;
-  readonly schemaVersions: SchemaVersions;
-
-  constructor(db: StatementRunner, appID: string) {
     db.beginConcurrent();
     // Note: The subsequent read is necessary to acquire the read lock
     // (which results in the logical creation of the snapshot). Calling
     // `BEGIN CONCURRENT` alone does not result in acquiring the read lock.
     const {stateVersion} = getReplicationState(db);
+    const schemaVersions = getSchemaVersions(db);
+    return new Snapshot(db, stateVersion, schemaVersions);
+  }
 
+  readonly db: StatementRunner;
+  readonly version: string;
+  readonly schemaVersions: SchemaVersions;
+
+  constructor(
+    db: StatementRunner,
+    version: string,
+    schemaVersions: SchemaVersions,
+  ) {
     this.db = db;
-    this.#appID = appID;
-    this.version = stateVersion;
-    this.schemaVersions = getSchemaVersions(db, appID);
+    this.version = version;
+    this.schemaVersions = schemaVersions;
   }
 
   numChangesSince(prevVersion: string) {
@@ -326,24 +326,24 @@ class Snapshot {
 
   resetToHead(): Snapshot {
     this.db.rollback();
-    return new Snapshot(this.db, this.#appID);
+    this.db.beginConcurrent();
+    const {stateVersion} = getReplicationState(this.db);
+    const schemaVersions = getSchemaVersions(this.db);
+    return new Snapshot(this.db, stateVersion, schemaVersions);
   }
 }
 
 class Diff implements SnapshotDiff {
-  readonly #permissionsTable: string;
   readonly tables: Map<string, LiteAndZqlSpec>;
   readonly prev: Snapshot;
   readonly curr: Snapshot;
   readonly changes: number;
 
   constructor(
-    appID: string,
     tables: Map<string, LiteAndZqlSpec>,
     prev: Snapshot,
     curr: Snapshot,
   ) {
-    this.#permissionsTable = `${appID}.permissions`;
     this.tables = tables;
     this.prev = prev;
     this.curr = curr;
@@ -402,11 +402,11 @@ class Diff implements SnapshotDiff {
             }
 
             if (
-              table === this.#permissionsTable &&
+              table === 'zero.permissions' &&
               prevValue.permissions !== nextValue.permissions
             ) {
               throw new ResetPipelinesSignal(
-                `Permissions have changed ${prevValue.hash} => ${nextValue.hash}`,
+                `zero.permissions have changed ${prevValue.hash} => ${nextValue.hash}`,
               );
             }
 

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -106,7 +106,6 @@ function randomID() {
 
 export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   readonly id: string;
-  readonly #appID: string;
   readonly #shardID: string;
   readonly #lc: LogContext;
   readonly #pipelines: PipelineDriver;
@@ -133,7 +132,6 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
   constructor(
     lc: LogContext,
-    appID: string,
     taskID: string,
     clientGroupID: string,
     shardID: string,
@@ -144,7 +142,6 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     keepaliveMs = DEFAULT_KEEPALIVE_MS,
   ) {
     this.id = clientGroupID;
-    this.#appID = appID;
     this.#shardID = shardID;
     this.#lc = lc;
     this.#pipelines = pipelineDriver;
@@ -374,7 +371,6 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         this.id,
         clientID,
         wsID,
-        this.#appID,
         this.#shardID,
         baseCookie,
         protocolVersion,
@@ -439,7 +435,6 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     const updater = new CVRConfigDrivenUpdater(
       this.#cvrStore,
       cvr,
-      this.#appID,
       this.#shardID,
     );
 


### PR DESCRIPTION
Temporarily revert to do a release w/o this.

Reverts rocicorp/mono#3865