### PR TITLE
fix(zero-cache): trigger an initial litestream sync immediately

### DIFF
--- a/packages/zero-cache/src/services/litestream/config.yml
+++ b/packages/zero-cache/src/services/litestream/config.yml
@@ -1,6 +1,5 @@
 dbs:
   - path: ${ZERO_REPLICA_FILE}
-    monitor-interval: 1m
     replicas:
       - url: ${ZERO_LITESTREAM_BACKUP_URL}
         retention: ${ZERO_LITESTREAM_SNAPSHOT_BACKUP_INTERVAL_MINUTES}m


### PR DESCRIPTION
Restore the `monitor-interval` to the default value of `1 second`, which is the rate at which the database is monitored locally. This has the side effect of kicking off the initial replica sync immediately (technically, after 1 second), which is necessary for publishing an initially synced replica from the `replication-manager` to `view-syncers`.

Henceforth, the replica is updated at `ZERO_LITESTREAM_INCREMENTAL_BACKUP_INTERVAL_MINUTES` intervals.