### PR TITLE
feat(zero-cache): add configuration for litestream checkpoint threshold

### DIFF
--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -219,6 +219,14 @@ test('zero-cache --help', () => {
                                                                 The location of the litestream backup, usually an s3:// URL.                                      
                                                                 If set, the litestream-executable must also be specified.                                         
                                                                                                                                                                   
+     --litestream-checkpoint-threshold-mb number                default: 40                                                                                       
+       ZERO_LITESTREAM_CHECKPOINT_THRESHOLD_MB env                                                                                                                
+                                                                The size of the WAL file at which to perform an SQlite checkpoint to apply                        
+                                                                the writes in the WAL to the main database file. Each checkpoint creates                          
+                                                                a new WAL segment file that will be backed up by litestream. Smaller thresholds                   
+                                                                may improve read performance, at the expense of creating more files to download                   
+                                                                when restoring the replica from the backup.                                                       
+                                                                                                                                                                  
      --litestream-incremental-backup-interval-minutes number    default: 15                                                                                       
        ZERO_LITESTREAM_INCREMENTAL_BACKUP_INTERVAL_MINUTES env                                                                                                    
                                                                 The interval between incremental backups of the replica. Shorter intervals                        

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -326,6 +326,17 @@ export const zeroOptions = {
       ],
     },
 
+    checkpointThresholdMB: {
+      type: v.number().default(40),
+      desc: [
+        `The size of the WAL file at which to perform an SQlite checkpoint to apply`,
+        `the writes in the WAL to the main database file. Each checkpoint creates`,
+        `a new WAL segment file that will be backed up by litestream. Smaller thresholds`,
+        `may improve read performance, at the expense of creating more files to download`,
+        `when restoring the replica from the backup.`,
+      ],
+    },
+
     incrementalBackupIntervalMinutes: {
       type: v.number().default(15),
       desc: [

--- a/packages/zero-cache/src/server/multi/config.test.ts
+++ b/packages/zero-cache/src/server/multi/config.test.ts
@@ -64,6 +64,7 @@ test('parse options', () => {
           "tableCopyWorkers": 5,
         },
         "litestream": {
+          "checkpointThresholdMB": 40,
           "configPath": "./src/services/litestream/config.yml",
           "incrementalBackupIntervalMinutes": 15,
           "logLevel": "warn",
@@ -130,6 +131,7 @@ test('parse options', () => {
         "ZERO_CVR_MAX_CONNS": "30",
         "ZERO_INITIAL_SYNC_ROW_BATCH_SIZE": "10000",
         "ZERO_INITIAL_SYNC_TABLE_COPY_WORKERS": "5",
+        "ZERO_LITESTREAM_CHECKPOINT_THRESHOLD_MB": "40",
         "ZERO_LITESTREAM_CONFIG_PATH": "./src/services/litestream/config.yml",
         "ZERO_LITESTREAM_INCREMENTAL_BACKUP_INTERVAL_MINUTES": "15",
         "ZERO_LITESTREAM_LOG_LEVEL": "warn",
@@ -454,6 +456,14 @@ test('zero-cache --help', () => {
        ZERO_LITESTREAM_BACKUP_URL env                                                                                                                             
                                                                 The location of the litestream backup, usually an s3:// URL.                                      
                                                                 If set, the litestream-executable must also be specified.                                         
+                                                                                                                                                                  
+     --litestream-checkpoint-threshold-mb number                default: 40                                                                                       
+       ZERO_LITESTREAM_CHECKPOINT_THRESHOLD_MB env                                                                                                                
+                                                                The size of the WAL file at which to perform an SQlite checkpoint to apply                        
+                                                                the writes in the WAL to the main database file. Each checkpoint creates                          
+                                                                a new WAL segment file that will be backed up by litestream. Smaller thresholds                   
+                                                                may improve read performance, at the expense of creating more files to download                   
+                                                                when restoring the replica from the backup.                                                       
                                                                                                                                                                   
      --litestream-incremental-backup-interval-minutes number    default: 15                                                                                       
        ZERO_LITESTREAM_INCREMENTAL_BACKUP_INTERVAL_MINUTES env                                                                                                    

--- a/packages/zero-cache/src/services/litestream/commands.ts
+++ b/packages/zero-cache/src/services/litestream/commands.ts
@@ -48,6 +48,7 @@ function getLitestream(
     backupURL,
     logLevel,
     configPath,
+    checkpointThresholdMB,
     incrementalBackupIntervalMinutes,
     snapshotBackupIntervalHours,
   } = config.litestream;
@@ -55,6 +56,8 @@ function getLitestream(
   // Set the snapshot interval to something smaller than x hours so that
   // the hourly check triggers on the hour, rather than the hour after.
   const snapshotBackupIntervalMinutes = snapshotBackupIntervalHours * 60 - 5;
+  const minCheckpointPageCount = checkpointThresholdMB * 250; // SQLite page size is 4k
+  const maxCheckpointPageCount = minCheckpointPageCount * 10;
 
   return {
     litestream: must(executable, `Missing --litestream-executable`),
@@ -62,6 +65,12 @@ function getLitestream(
       ...process.env,
       ['ZERO_REPLICA_FILE']: config.replicaFile,
       ['ZERO_LITESTREAM_BACKUP_URL']: must(backupURL),
+      ['ZERO_LITESTREAM_MIN_CHECKPOINT_PAGE_COUNT']: String(
+        minCheckpointPageCount,
+      ),
+      ['ZERO_LITESTREAM_MAX_CHECKPOINT_PAGE_COUNT']: String(
+        maxCheckpointPageCount,
+      ),
       ['ZERO_LITESTREAM_INCREMENTAL_BACKUP_INTERVAL_MINUTES']: String(
         incrementalBackupIntervalMinutes,
       ),

--- a/packages/zero-cache/src/services/litestream/config.yml
+++ b/packages/zero-cache/src/services/litestream/config.yml
@@ -1,5 +1,7 @@
 dbs:
   - path: ${ZERO_REPLICA_FILE}
+    min-checkpoint-page-count: ${ZERO_LITESTREAM_MIN_CHECKPOINT_PAGE_COUNT}
+    max-checkpoint-page-count: ${ZERO_LITESTREAM_MAX_CHECKPOINT_PAGE_COUNT}
     replicas:
       - url: ${ZERO_LITESTREAM_BACKUP_URL}
         retention: ${ZERO_LITESTREAM_SNAPSHOT_BACKUP_INTERVAL_MINUTES}m


### PR DESCRIPTION
Add a configuration option for the wal size threshold at which litestream performs a checkpoint, which corresponds to creating a wal segment that is eventually backed up to s3.