### PR TITLE
chore(zero-cache): plumb an `appID` and use it for naming upstream PG schemas

### DIFF
--- a/packages/z2s/src/test/chinook/get-deps.ts
+++ b/packages/z2s/src/test/chinook/get-deps.ts
@@ -1,10 +1,10 @@
+import {consoleLogSink, LogContext} from '@rocicorp/logger';
 import {existsSync} from 'fs';
-import {writeFile, readFile} from 'fs/promises';
+import {readFile, writeFile} from 'fs/promises';
+import {initialSync} from '../../../../zero-cache/src/services/change-source/pg/initial-sync.ts';
+import {getConnectionURI} from '../../../../zero-cache/src/test/db.ts';
 import type {PostgresDB} from '../../../../zero-cache/src/types/pg.ts';
 import type {Database} from '../../../../zqlite/src/db.ts';
-import {initialSync} from '../../../../zero-cache/src/services/change-source/pg/initial-sync.ts';
-import {consoleLogSink, LogContext} from '@rocicorp/logger';
-import {getConnectionURI} from '../../../../zero-cache/src/test/db.ts';
 
 const PG_URL =
   'https://github.com/lerocha/chinook-database/releases/download/v1.4.5/Chinook_PostgreSql.sql';
@@ -37,6 +37,7 @@ export async function writeChinook(pg: PostgresDB, replica: Database) {
 
   await initialSync(
     new LogContext('debug', {}, consoleLogSink),
+    'zero',
     {id: 'chinook_test', publications: []},
     replica,
     getConnectionURI(pg),

--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -113,8 +113,8 @@ test('zero-cache --help', () => {
      --shard-publications string[]                              default: []                                                                                       
        ZERO_SHARD_PUBLICATIONS env                                                                                                                                
                                                                 Postgres PUBLICATIONs that define the partition of the upstream                                   
-                                                                replicated to the shard. All publication names must begin with the prefix                         
-                                                                zero_, and all tables must be in the public schema.                                               
+                                                                replicated to the shard. Publication names may not begin with an underscore,                      
+                                                                as zero reserves that prefix for internal use.                                                    
                                                                                                                                                                   
                                                                 If unspecified, zero-cache will create and use an internal publication that                       
                                                                 publishes all tables in the public schema, i.e.:                                                  

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -34,8 +34,8 @@ const shardOptions = {
     type: v.array(v.string()).optional(() => []),
     desc: [
       `Postgres {bold PUBLICATION}s that define the partition of the upstream`,
-      `replicated to the shard. All publication names must begin with the prefix`,
-      `{bold zero_}, and all tables must be in the {bold public} schema.`,
+      `replicated to the shard. Publication names may not begin with an underscore,`,
+      `as zero reserves that prefix for internal use.`,
       ``,
       `If unspecified, zero-cache will create and use an internal publication that`,
       `publishes all tables in the {bold public} schema, i.e.:`,

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -46,6 +46,7 @@ export default async function runWorker(
   );
 
   const {autoReset} = config;
+  const appID = 'zero'; // TODO: --app-id
   let changeStreamer: ChangeStreamerService | undefined;
 
   for (const first of [true, false]) {
@@ -56,6 +57,7 @@ export default async function runWorker(
           ? await initializePostgresChangeSource(
               lc,
               upstream.db,
+              appID,
               shard,
               replicaFile,
               initialSync,
@@ -63,6 +65,7 @@ export default async function runWorker(
           : await initializeCustomChangeSource(
               lc,
               upstream.db,
+              appID,
               shard,
               replicaFile,
             );

--- a/packages/zero-cache/src/server/multi/config.test.ts
+++ b/packages/zero-cache/src/server/multi/config.test.ts
@@ -353,8 +353,8 @@ test('zero-cache --help', () => {
      --shard-publications string[]                              default: []                                                                                       
        ZERO_SHARD_PUBLICATIONS env                                                                                                                                
                                                                 Postgres PUBLICATIONs that define the partition of the upstream                                   
-                                                                replicated to the shard. All publication names must begin with the prefix                         
-                                                                zero_, and all tables must be in the public schema.                                               
+                                                                replicated to the shard. Publication names may not begin with an underscore,                      
+                                                                as zero reserves that prefix for internal use.                                                    
                                                                                                                                                                   
                                                                 If unspecified, zero-cache will create and use an internal publication that                       
                                                                 publishes all tables in the public schema, i.e.:                                                  

--- a/packages/zero-cache/src/services/change-source/custom/change-source.test.ts
+++ b/packages/zero-cache/src/services/change-source/custom/change-source.test.ts
@@ -13,6 +13,8 @@ import {
 } from '../protocol/current/upstream.ts';
 import {initializeCustomChangeSource} from './change-source.ts';
 
+const APP_ID = 'bongo';
+
 describe('change-source/custom', () => {
   let lc: LogContext;
   let downstream: Promise<Sink<ChangeStreamMessage>>;
@@ -100,7 +102,7 @@ describe('change-source/custom', () => {
         {
           tag: 'create-table',
           spec: {
-            schema: 'zero_0',
+            schema: 'bongo_0',
             name: 'clients',
             primaryKey: ['clientGroupID', 'clientID'],
             columns: {
@@ -117,8 +119,8 @@ describe('change-source/custom', () => {
         {
           tag: 'create-index',
           spec: {
-            name: 'zero_clients_key',
-            schema: 'zero_0',
+            name: 'bongo_clients_key',
+            schema: 'bongo_0',
             tableName: 'clients',
             columns: {
               clientGroupID: 'ASC',
@@ -133,7 +135,7 @@ describe('change-source/custom', () => {
         {
           tag: 'create-table',
           spec: {
-            schema: 'zero',
+            schema: 'bongo',
             name: 'schemaVersions',
             primaryKey: ['lock'],
             columns: {
@@ -149,8 +151,8 @@ describe('change-source/custom', () => {
         {
           tag: 'create-index',
           spec: {
-            name: 'zero_schemaVersions_key',
-            schema: 'zero',
+            name: 'bongo_schemaVersions_key',
+            schema: 'bongo',
             tableName: 'schemaVersions',
             columns: {lock: 'ASC'},
             unique: true,
@@ -162,7 +164,7 @@ describe('change-source/custom', () => {
         {
           tag: 'create-table',
           spec: {
-            schema: 'zero',
+            schema: 'bongo',
             name: 'permissions',
             primaryKey: ['lock'],
             columns: {
@@ -178,8 +180,8 @@ describe('change-source/custom', () => {
         {
           tag: 'create-index',
           spec: {
-            name: 'zero_permissions_key',
-            schema: 'zero',
+            name: 'bongo_permissions_key',
+            schema: 'bongo',
             tableName: 'permissions',
             columns: {lock: 'ASC'},
             unique: true,
@@ -191,7 +193,7 @@ describe('change-source/custom', () => {
         {
           tag: 'insert',
           relation: {
-            schema: 'zero',
+            schema: 'bongo',
             name: 'schemaVersions',
             keyColumns: ['lock'],
           },
@@ -204,13 +206,14 @@ describe('change-source/custom', () => {
     await initializeCustomChangeSource(
       lc,
       changeSourceURI,
+      APP_ID,
       {id: '0', publications: ['b', 'a']},
       replicaDbFile.path,
     );
 
     expectTables(replicaDbFile.connect(lc), {
       foo: [{id: 'abcde', bar: 'baz', ['_0_version']: '123'}],
-      ['zero.schemaVersions']: [
+      ['bongo.schemaVersions']: [
         {
           lock: 1,
           minSupportedVersion: 1,
@@ -218,7 +221,7 @@ describe('change-source/custom', () => {
           ['_0_version']: '123',
         },
       ],
-      ['zero_0.clients']: [],
+      ['bongo_0.clients']: [],
       ['_zero.replicationState']: [{lock: 1, stateVersion: '123'}],
       ['_zero.replicationConfig']: [
         {

--- a/packages/zero-cache/src/services/change-source/custom/sync-schema.ts
+++ b/packages/zero-cache/src/services/change-source/custom/sync-schema.ts
@@ -11,12 +11,13 @@ import {initialSync} from './change-source.ts';
 export async function initSyncSchema(
   log: LogContext,
   debugName: string,
+  appID: string,
   shard: ShardConfig,
   dbPath: string,
   upstreamURI: string,
 ): Promise<void> {
   const setupMigration: Migration = {
-    migrateSchema: (log, tx) => initialSync(log, shard, tx, upstreamURI),
+    migrateSchema: (log, tx) => initialSync(log, appID, shard, tx, upstreamURI),
     minSafeVersion: 1,
   };
 

--- a/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg-test.ts
@@ -16,6 +16,7 @@ import type {DataChange} from '../protocol/current/data.ts';
 import type {ChangeStreamMessage} from '../protocol/current/downstream.ts';
 import {initializePostgresChangeSource} from './change-source.ts';
 
+const APP_ID = 'orez';
 const SHARD_ID = 'change_source_end_to_mid_test_id';
 
 /**
@@ -60,19 +61,18 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
       uuid UUID
     );
 
-    -- Use the internal zero schema to test tables in a different schema,
-    -- since the set of allowed schemas is restricted.
-    CREATE SCHEMA IF NOT EXISTS zero;
+    CREATE SCHEMA IF NOT EXISTS my;
 
     CREATE UNIQUE INDEX foo_key ON foo (id);
     CREATE PUBLICATION zero_some_public FOR TABLE foo (id, int);
-    CREATE PUBLICATION zero_all_test FOR TABLES IN SCHEMA zero;
+    CREATE PUBLICATION zero_all_test FOR TABLES IN SCHEMA my;
     `);
 
     const source = (
       await initializePostgresChangeSource(
         lc,
         upstreamURI,
+        APP_ID,
         {id: SHARD_ID, publications: ['zero_some_public', 'zero_all_test']},
         replicaDbFile.path,
         {tableCopyWorkers: 5, rowBatchSize: 10000},
@@ -135,15 +135,15 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
   test.each([
     [
       'create table',
-      `CREATE TABLE zero.baz (
+      `CREATE TABLE my.baz (
         id INT8 CONSTRAINT baz_pkey PRIMARY KEY,
         gen INT8 GENERATED ALWAYS AS (id + 1) STORED  -- Should be excluded
        );`,
       [{tag: 'create-table'}, {tag: 'create-index'}],
-      {['zero.baz']: []},
+      {['my.baz']: []},
       [
         {
-          name: 'zero.baz',
+          name: 'my.baz',
           columns: {
             id: {
               characterMaximumLength: null,
@@ -165,20 +165,20 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
       [
         {
           columns: {id: 'ASC'},
-          name: 'zero.baz_pkey',
-          tableName: 'zero.baz',
+          name: 'my.baz_pkey',
+          tableName: 'my.baz',
           unique: true,
         },
       ],
     ],
     [
       'rename table',
-      'ALTER TABLE zero.baz RENAME TO bar;',
+      'ALTER TABLE my.baz RENAME TO bar;',
       [{tag: 'rename-table'}],
-      {['zero.bar']: []},
+      {['my.bar']: []},
       [
         {
-          name: 'zero.bar',
+          name: 'my.bar',
           columns: {
             id: {
               characterMaximumLength: null,
@@ -200,17 +200,17 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
       [
         {
           columns: {id: 'ASC'},
-          name: 'zero.baz_pkey',
-          tableName: 'zero.bar',
+          name: 'my.baz_pkey',
+          tableName: 'my.bar',
           unique: true,
         },
       ],
     ],
     [
       'add column',
-      'ALTER TABLE zero.bar ADD name INT8;',
+      'ALTER TABLE my.bar ADD name INT8;',
       [{tag: 'add-column'}],
-      {['zero.bar']: []},
+      {['my.bar']: []},
       [
         {
           columns: {
@@ -236,16 +236,16 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
               pos: 3,
             },
           },
-          name: 'zero.bar',
+          name: 'my.bar',
         },
       ],
       [],
     ],
     [
       'rename column',
-      'ALTER TABLE zero.bar RENAME name TO handle;',
+      'ALTER TABLE my.bar RENAME name TO handle;',
       [{tag: 'update-column'}],
-      {['zero.bar']: []},
+      {['my.bar']: []},
       [
         {
           columns: {
@@ -271,16 +271,16 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
               pos: 3,
             },
           },
-          name: 'zero.bar',
+          name: 'my.bar',
         },
       ],
       [],
     ],
     [
       'change column data type',
-      'ALTER TABLE zero.bar ALTER handle TYPE TEXT;',
+      'ALTER TABLE my.bar ALTER handle TYPE TEXT;',
       [{tag: 'update-column'}],
-      {['zero.bar']: []},
+      {['my.bar']: []},
       [
         {
           columns: {
@@ -306,7 +306,7 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
               pos: 3,
             },
           },
-          name: 'zero.bar',
+          name: 'my.bar',
         },
       ],
       [],
@@ -314,8 +314,8 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
     [
       'change the primary key',
       `
-      ALTER TABLE zero.bar DROP CONSTRAINT baz_pkey;
-      ALTER TABLE zero.bar ADD PRIMARY KEY (handle);
+      ALTER TABLE my.bar DROP CONSTRAINT baz_pkey;
+      ALTER TABLE my.bar ADD PRIMARY KEY (handle);
       `,
       [
         {tag: 'drop-index'},
@@ -332,7 +332,7 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
         },
         {tag: 'create-index'},
       ],
-      {['zero.bar']: []},
+      {['my.bar']: []},
       [
         {
           columns: {
@@ -358,23 +358,23 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
               pos: 3,
             },
           },
-          name: 'zero.bar',
+          name: 'my.bar',
         },
       ],
       [
         {
           columns: {handle: 'ASC'},
-          name: 'zero.bar_pkey',
-          tableName: 'zero.bar',
+          name: 'my.bar_pkey',
+          tableName: 'my.bar',
           unique: true,
         },
       ],
     ],
     [
       'add unique column to automatically generate index',
-      'ALTER TABLE zero.bar ADD username TEXT UNIQUE;',
+      'ALTER TABLE my.bar ADD username TEXT UNIQUE;',
       [{tag: 'add-column'}, {tag: 'create-index'}],
-      {['zero.bar']: []},
+      {['my.bar']: []},
       [
         {
           columns: {
@@ -407,13 +407,13 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
               pos: 4,
             },
           },
-          name: 'zero.bar',
+          name: 'my.bar',
         },
       ],
       [
         {
-          name: 'zero.bar_username_key',
-          tableName: 'zero.bar',
+          name: 'my.bar_username_key',
+          tableName: 'my.bar',
           columns: {username: 'ASC'},
           unique: true,
         },
@@ -421,9 +421,9 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
     ],
     [
       'rename unique column with associated index',
-      'ALTER TABLE zero.bar RENAME username TO login;',
+      'ALTER TABLE my.bar RENAME username TO login;',
       [{tag: 'update-column'}],
-      {['zero.bar']: []},
+      {['my.bar']: []},
       [
         {
           columns: {
@@ -456,13 +456,13 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
               pos: 4,
             },
           },
-          name: 'zero.bar',
+          name: 'my.bar',
         },
       ],
       [
         {
-          name: 'zero.bar_username_key',
-          tableName: 'zero.bar',
+          name: 'my.bar_username_key',
+          tableName: 'my.bar',
           columns: {login: 'ASC'},
           unique: true,
         },
@@ -470,9 +470,9 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
     ],
     [
       'retype unique column with associated index',
-      'ALTER TABLE zero.bar ALTER login TYPE VARCHAR(180);',
+      'ALTER TABLE my.bar ALTER login TYPE VARCHAR(180);',
       [{tag: 'update-column'}],
-      {['zero.bar']: []},
+      {['my.bar']: []},
       [
         {
           columns: {
@@ -505,13 +505,13 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
               pos: 4,
             },
           },
-          name: 'zero.bar',
+          name: 'my.bar',
         },
       ],
       [
         {
-          name: 'zero.bar_username_key',
-          tableName: 'zero.bar',
+          name: 'my.bar_username_key',
+          tableName: 'my.bar',
           columns: {login: 'ASC'},
           unique: true,
         },
@@ -519,9 +519,9 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
     ],
     [
       'drop column with index',
-      'ALTER TABLE zero.bar DROP login;',
+      'ALTER TABLE my.bar DROP login;',
       [{tag: 'drop-index'}, {tag: 'drop-column'}],
-      {['zero.bar']: []},
+      {['my.bar']: []},
       [
         {
           columns: {
@@ -547,16 +547,16 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
               pos: 3,
             },
           },
-          name: 'zero.bar',
+          name: 'my.bar',
         },
       ],
       [],
     ],
     [
       'add multiple columns',
-      'ALTER TABLE zero.bar ADD foo TEXT, ADD bar TEXT;',
+      'ALTER TABLE my.bar ADD foo TEXT, ADD bar TEXT;',
       [{tag: 'add-column'}, {tag: 'add-column'}],
-      {['zero.bar']: []},
+      {['my.bar']: []},
       [
         {
           columns: {
@@ -596,16 +596,16 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
               pos: 5,
             },
           },
-          name: 'zero.bar',
+          name: 'my.bar',
         },
       ],
       [],
     ],
     [
       'alter, add, and drop columns',
-      'ALTER TABLE zero.bar ALTER foo SET NOT NULL, ADD boo TEXT, DROP bar;',
+      'ALTER TABLE my.bar ALTER foo SET NOT NULL, ADD boo TEXT, DROP bar;',
       [{tag: 'drop-column'}, {tag: 'update-column'}, {tag: 'add-column'}],
-      {['zero.bar']: []},
+      {['my.bar']: []},
       [
         {
           columns: {
@@ -645,7 +645,7 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
               pos: 5,
             },
           },
-          name: 'zero.bar',
+          name: 'my.bar',
         },
       ],
       [],

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -68,7 +68,7 @@ import {updateShardSchema} from './schema/init.ts';
 import {getPublicationInfo, type PublishedSchema} from './schema/published.ts';
 import {
   getInternalShardConfig,
-  INTERNAL_PUBLICATION_PREFIX,
+  internalPublicationPrefix,
   replicaIdentitiesForTablesWithoutPrimaryKeys,
   type InternalShardConfig,
 } from './schema/shard.ts';
@@ -87,6 +87,7 @@ registerPostgresTypeParsers();
 export async function initializePostgresChangeSource(
   lc: LogContext,
   upstreamURI: string,
+  appID: string,
   shard: ShardConfig,
   replicaDbFile: string,
   syncOptions: InitialSyncOptions,
@@ -94,6 +95,7 @@ export async function initializePostgresChangeSource(
   await initSyncSchema(
     lc,
     `replica-${shard.id}`,
+    appID,
     shard,
     replicaDbFile,
     upstreamURI,
@@ -108,7 +110,7 @@ export async function initializePostgresChangeSource(
     // Verify that the publications match what has been synced.
     const requested = [...shard.publications].sort();
     const replicated = replicationConfig.publications
-      .filter(p => !p.startsWith(INTERNAL_PUBLICATION_PREFIX))
+      .filter(p => !p.startsWith(internalPublicationPrefix(appID)))
       .sort();
     if (!deepEqual(requested, replicated)) {
       throw new Error(
@@ -121,7 +123,7 @@ export async function initializePostgresChangeSource(
   // initial sync if not.
   const db = pgClient(lc, upstreamURI);
   try {
-    await checkAndUpdateUpstream(lc, db, shard);
+    await checkAndUpdateUpstream(lc, db, appID, shard);
   } finally {
     await db.end();
   }
@@ -129,6 +131,7 @@ export async function initializePostgresChangeSource(
   const changeSource = new PostgresChangeSource(
     lc,
     upstreamURI,
+    appID,
     shard.id,
     replicationConfig,
   );
@@ -139,9 +142,10 @@ export async function initializePostgresChangeSource(
 async function checkAndUpdateUpstream(
   lc: LogContext,
   db: PostgresDB,
+  appID: string,
   shard: ShardConfig,
 ) {
-  const slot = replicationSlot(shard.id);
+  const slot = replicationSlot(appID, shard.id);
   const result = await db<{restartLSN: LSN | null}[]>`
   SELECT restart_lsn as "restartLSN" FROM pg_replication_slots WHERE slot_name = ${slot}`;
   if (result.length === 0) {
@@ -154,7 +158,7 @@ async function checkAndUpdateUpstream(
     );
   }
   // Perform any shard schema updates
-  await updateShardSchema(lc, db, {
+  await updateShardSchema(lc, db, appID, {
     id: shard.id,
     publications: shard.publications,
   });
@@ -169,29 +173,36 @@ const MAX_ATTEMPTS_IF_REPLICATION_SLOT_ACTIVE = 5;
 class PostgresChangeSource implements ChangeSource {
   readonly #lc: LogContext;
   readonly #upstreamUri: string;
+  readonly #appID: string;
   readonly #shardID: string;
   readonly #replicationConfig: ReplicationConfig;
 
   constructor(
     lc: LogContext,
     upstreamUri: string,
+    appID: string,
     shardID: string,
     replicationConfig: ReplicationConfig,
   ) {
     this.#lc = lc.withContext('component', 'change-source');
     this.#upstreamUri = upstreamUri;
+    this.#appID = appID;
     this.#shardID = shardID;
     this.#replicationConfig = replicationConfig;
   }
 
   async startStream(clientWatermark: string): Promise<ChangeStream> {
     const db = pgClient(this.#lc, this.#upstreamUri);
-    const slot = replicationSlot(this.#shardID);
+    const slot = replicationSlot(this.#appID, this.#shardID);
 
     try {
       await this.#stopExistingReplicationSlotSubscriber(db, slot);
 
-      const config = await getInternalShardConfig(db, this.#shardID);
+      const config = await getInternalShardConfig(
+        db,
+        this.#appID,
+        this.#shardID,
+      );
       this.#lc.info?.(`starting replication stream@${slot}`);
 
       // Enabling ssl according to the logic in:

--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl-test-utils.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl-test-utils.ts
@@ -1,11 +1,13 @@
 import {append, TAGS} from './ddl.ts';
 
-export function dropEventTriggerStatements(shardID: string) {
+export function dropEventTriggerStatements(appID: string, shardID: string) {
   const sharded = append(shardID);
-  const stmts = [`DROP EVENT TRIGGER IF EXISTS ${sharded('zero_ddl_start')};`];
+  const stmts = [
+    `DROP EVENT TRIGGER IF EXISTS ${sharded(`${appID}_ddl_start`)};`,
+  ];
   for (const tag of TAGS) {
     const tagID = tag.toLowerCase().replace(' ', '_');
-    stmts.push(`DROP EVENT TRIGGER IF EXISTS ${sharded(`zero_${tagID}`)};`);
+    stmts.push(`DROP EVENT TRIGGER IF EXISTS ${sharded(`${appID}_${tagID}`)};`);
   }
   return stmts.join('');
 }

--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl.pg-test.ts
@@ -22,6 +22,7 @@ describe('change-source/tables/ddl', () => {
   let notices: Queue<postgres.Notice>;
   let service: LogicalReplicationService;
 
+  const APP_ID = 'zap';
   const SHARD_ID = '0';
 
   beforeEach(async () => {
@@ -34,7 +35,7 @@ describe('change-source/tables/ddl', () => {
     await upstream.unsafe(STARTING_SCHEMA);
 
     await upstream.unsafe(
-      createEventTriggerStatements(SHARD_ID, ['zero_all', 'zero_sum']),
+      createEventTriggerStatements(APP_ID, SHARD_ID, ['zero_all', 'zero_sum']),
     );
 
     await upstream`SELECT pg_create_logical_replication_slot(${SLOT_NAME}, 'pgoutput')`;

--- a/packages/zero-cache/src/services/change-source/pg/schema/published.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/published.ts
@@ -184,9 +184,7 @@ const publicationInfoSchema = publishedSchema.extend({
 export type PublicationInfo = v.Infer<typeof publicationInfoSchema>;
 
 /**
- * Retrieves published tables and columns. By default, includes all
- * publications that start with "zero_" or "_zero_", but this can be
- * overridden by specifying a specific set of `publications`.
+ * Retrieves published tables and columns.
  */
 export async function getPublicationInfo(
   sql: postgres.Sql,

--- a/packages/zero-cache/src/services/change-source/pg/schema/validation.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/validation.ts
@@ -7,6 +7,8 @@ import {Default} from '../../../../db/postgres-replica-identity-enum.ts';
 import type {PublishedTableSpec} from '../../../../db/specs.ts';
 import {ZERO_VERSION_COLUMN_NAME} from '../../../replicator/schema/replication-state.ts';
 
+export const ALLOWED_APP_ID_CHARACTERS = /^[a-z0-9_]+$/;
+
 const ALLOWED_IDENTIFIER_CHARS = /^[A-Za-z_]+[A-Za-z0-9_-]*$/;
 
 export function validate(lc: LogContext, table: PublishedTableSpec) {

--- a/packages/zero-cache/src/services/change-source/pg/sync-schema.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/sync-schema.pg-test.ts
@@ -16,6 +16,7 @@ import type {PostgresDB} from '../../../types/pg.ts';
 import {replicationSlot} from './initial-sync.ts';
 import {initSyncSchema} from './sync-schema.ts';
 
+const APP_ID = 'zeroz';
 const SHARD_ID = 'sync_schema_test_id';
 
 // Update as necessary.
@@ -45,14 +46,14 @@ describe('change-streamer/pg/sync-schema', () => {
     {
       name: 'initial tables',
       upstreamPostState: {
-        [`zero_${SHARD_ID}.clients`]: [],
-        ['zero.schemaVersions']: [
+        [`${APP_ID}_${SHARD_ID}.clients`]: [],
+        [`${APP_ID}.schemaVersions`]: [
           {lock: true, minSupportedVersion: 1, maxSupportedVersion: 1},
         ],
       },
       replicaPostState: {
-        [`zero_${SHARD_ID}.clients`]: [],
-        ['zero.schemaVersions']: [
+        [`${APP_ID}_${SHARD_ID}.clients`]: [],
+        [`${APP_ID}.schemaVersions`]: [
           {
             lock: 1,
             minSupportedVersion: 1,
@@ -78,14 +79,14 @@ describe('change-streamer/pg/sync-schema', () => {
         ],
       },
       upstreamPostState: {
-        [`zero_${SHARD_ID}.clients`]: [],
-        ['zero.schemaVersions']: [
+        [`${APP_ID}_${SHARD_ID}.clients`]: [],
+        [`${APP_ID}.schemaVersions`]: [
           {lock: true, minSupportedVersion: 1, maxSupportedVersion: 1},
         ],
       },
       replicaPostState: {
-        [`zero_${SHARD_ID}.clients`]: [],
-        ['zero.schemaVersions']: [
+        [`${APP_ID}_${SHARD_ID}.clients`]: [],
+        [`${APP_ID}.schemaVersions`]: [
           {
             lock: 1,
             minSupportedVersion: 1,
@@ -127,6 +128,7 @@ describe('change-streamer/pg/sync-schema', () => {
         await initSyncSchema(
           createSilentLogContext(),
           'test',
+          APP_ID,
           {id: SHARD_ID, publications: c.requestedPublications ?? []},
           replicaFile.path,
           getConnectionURI(upstream),
@@ -143,9 +145,10 @@ describe('change-streamer/pg/sync-schema', () => {
         // Slot should still exist.
         const slots =
           await upstream`SELECT slot_name FROM pg_replication_slots WHERE slot_name = ${replicationSlot(
+            APP_ID,
             SHARD_ID,
           )}`.values();
-        expect(slots[0]).toEqual([replicationSlot(SHARD_ID)]);
+        expect(slots[0]).toEqual([replicationSlot(APP_ID, SHARD_ID)]);
       },
       10000,
     );

--- a/packages/zero-cache/src/services/change-source/pg/sync-schema.ts
+++ b/packages/zero-cache/src/services/change-source/pg/sync-schema.ts
@@ -12,6 +12,7 @@ import type {ShardConfig} from './shard-config.ts';
 export async function initSyncSchema(
   log: LogContext,
   debugName: string,
+  appID: string,
   shard: ShardConfig,
   dbPath: string,
   upstreamURI: string,
@@ -19,7 +20,7 @@ export async function initSyncSchema(
 ): Promise<void> {
   const setupMigration: Migration = {
     migrateSchema: (log, tx) =>
-      initialSync(log, shard, tx, upstreamURI, syncOptions),
+      initialSync(log, appID, shard, tx, upstreamURI, syncOptions),
     minSafeVersion: 1,
   };
 

--- a/packages/zero-cache/src/services/mutagen/mutagen-test-shared.ts
+++ b/packages/zero-cache/src/services/mutagen/mutagen-test-shared.ts
@@ -1,24 +1,23 @@
-export function zeroSchema(shardID: string): string {
+export function zeroSchema(appID: string, shardID: string): string {
   return /*sql*/ `
-      CREATE SCHEMA zero_${shardID};
-      CREATE TABLE zero_${shardID}.clients (
+      CREATE SCHEMA ${appID}_${shardID};
+      CREATE TABLE ${appID}_${shardID}.clients (
         "clientGroupID"  TEXT NOT NULL,
         "clientID"       TEXT NOT NULL,
         "lastMutationID" BIGINT,
         "userID"         TEXT,
         PRIMARY KEY ("clientGroupID", "clientID")
       );
-      CREATE SCHEMA zero;
-      CREATE TABLE zero."schemaVersions" (
+      CREATE SCHEMA ${appID};
+      CREATE TABLE ${appID}."schemaVersions" (
         "minSupportedVersion" INT4,
         "maxSupportedVersion" INT4,
 
         -- Ensure that there is only a single row in the table.
         -- Application code can be agnostic to this column, and
         -- simply invoke UPDATE statements on the version columns.
-        "lock" BOOL PRIMARY KEY DEFAULT true,
-        CONSTRAINT zero_schema_versions_single_row_constraint CHECK (lock)
+        "lock" BOOL PRIMARY KEY DEFAULT true CHECK (lock)
       );
-      INSERT INTO zero."schemaVersions" ("lock", "minSupportedVersion", "maxSupportedVersion")
+      INSERT INTO ${appID}."schemaVersions" ("lock", "minSupportedVersion", "maxSupportedVersion")
         VALUES (true, 1, 1);`;
 }

--- a/packages/zero-cache/src/services/view-syncer/client-handler.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.ts
@@ -291,14 +291,14 @@ export class ClientHandler {
       );
       if (clientGroupID !== this.#clientGroupID) {
         this.#lc.error?.(
-          `Received zero.clients row for wrong clientGroupID. Ignoring.`,
+          `Received clients row for wrong clientGroupID. Ignoring.`,
           clientGroupID,
         );
       } else {
         lmids[clientID] = lastMutationID;
       }
     } else {
-      // The 'constrain' and 'del' ops for zero.clients can be ignored.
+      // The 'constrain' and 'del' ops for clients can be ignored.
       patch.op satisfies 'constrain' | 'del';
     }
   }


### PR DESCRIPTION
Adds plumbing for naming upstream schemas by an `appID` rather than forcing `"zero"` and `"zero_{*}"`.

The `appID` value is still hard-coded to `"zero"` at the top-level, so this PR should not result in a behavioral change.

Configurability and migration is forthcoming.

https://www.notion.so/replicache/Zero-Upstream-Organization-1a33bed8954580e9a03fdddf81690fcc