### PR TITLE
feat(zero-cache): scope the cvr schema within the appID

### DIFF
--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -43,6 +43,7 @@ export default async function runWorker(
   const config = getZeroConfig(env);
   const lc = createLogContext(config, {worker: 'dispatcher'});
   const taskID = must(config.taskID, `main must set --task-id`);
+  const appID = 'zero'; // TODO: --app-id
 
   const processes = new ProcessManager(lc, parent ?? process);
 
@@ -110,7 +111,7 @@ export default async function runWorker(
     // but it is done here in the main thread because it is wasteful to have all of
     // the Syncers attempt the migration in parallel.
     const cvrDB = pgClient(lc, config.cvr.db);
-    await initViewSyncerSchema(lc, cvrDB, config.shard.id);
+    await initViewSyncerSchema(lc, cvrDB, appID, config.shard.id);
     void cvrDB.end();
   }
 

--- a/packages/zero-cache/src/services/view-syncer/cvr-store.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.pg-test.ts
@@ -23,7 +23,8 @@ import {
 import {setupCVRTables, type RowsRow} from './schema/cvr.ts';
 import type {CVRVersion} from './schema/types.ts';
 
-const SHARD_ID = 'sdf';
+const APP_ID = 'roze';
+const SHARD_ID = '1';
 
 describe('view-syncer/cvr-store', () => {
   const lc = createSilentLogContext();
@@ -42,40 +43,40 @@ describe('view-syncer/cvr-store', () => {
 
   beforeEach(async () => {
     db = await testDBs.create('view_syncer_cvr_schema');
-    await db.begin(tx => setupCVRTables(lc, tx, SHARD_ID));
+    await db.begin(tx => setupCVRTables(lc, tx, APP_ID, SHARD_ID));
     await db.unsafe(`
-    INSERT INTO cvr_sdf.instances ("clientGroupID", version, "lastActive", "replicaVersion")
+    INSERT INTO "roze_1/cvr".instances ("clientGroupID", version, "lastActive", "replicaVersion")
       VALUES('${CVR_ID}', '03', '2024-09-04', '01');
-    INSERT INTO cvr_sdf.queries ("clientGroupID", "queryHash", "clientAST", 
+    INSERT INTO "roze_1/cvr".queries ("clientGroupID", "queryHash", "clientAST", 
                              "patchVersion", "transformationHash", "transformationVersion")
       VALUES('${CVR_ID}', 'foo', '{"table":"issues"}', '01', 'foo-transformed', '01');
-    INSERT INTO cvr_sdf."rowsVersion" ("clientGroupID", version)
+    INSERT INTO "roze_1/cvr"."rowsVersion" ("clientGroupID", version)
       VALUES('${CVR_ID}', '03');
-    INSERT INTO cvr_sdf.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
+    INSERT INTO "roze_1/cvr".rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
       VALUES('${CVR_ID}', '', 'issues', '{"id":"1"}', '01', '01', NULL);
-    INSERT INTO cvr_sdf.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
+    INSERT INTO "roze_1/cvr".rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
       VALUES('${CVR_ID}', '', 'issues', '{"id":"2"}', '01', '01', '{"foo":1}');
-    INSERT INTO cvr_sdf.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
+    INSERT INTO "roze_1/cvr".rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
       VALUES('${CVR_ID}', '', 'issues', '{"id":"3"}', '01', '01', '{"bar":2}');
-    INSERT INTO cvr_sdf.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
+    INSERT INTO "roze_1/cvr".rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
       VALUES('${CVR_ID}', '', 'issues', '{"id":"4"}', '01', '01', '{"foo":2,"bar":3}');
 
-    INSERT INTO cvr_sdf.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
+    INSERT INTO "roze_1/cvr".rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
       VALUES('${CVR_ID}', '', 'issues', '{"id":"5"}', '01', '02', NULL);
-    INSERT INTO cvr_sdf.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
+    INSERT INTO "roze_1/cvr".rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
       VALUES('${CVR_ID}', '', 'issues', '{"id":"6"}', '01', '02', '{"foo":1}');
-    INSERT INTO cvr_sdf.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
+    INSERT INTO "roze_1/cvr".rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
       VALUES('${CVR_ID}', '', 'issues', '{"id":"7"}', '01', '02', '{"bar":2}');
-    INSERT INTO cvr_sdf.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
+    INSERT INTO "roze_1/cvr".rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
       VALUES('${CVR_ID}', '', 'issues', '{"id":"8"}', '01', '02', '{"foo":2,"bar":3}');
 
-    INSERT INTO cvr_sdf.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
+    INSERT INTO "roze_1/cvr".rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
       VALUES('${CVR_ID}', '', 'issues', '{"id":"9"}', '01', '03', NULL);
-    INSERT INTO cvr_sdf.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
+    INSERT INTO "roze_1/cvr".rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
       VALUES('${CVR_ID}', '', 'issues', '{"id":"10"}', '01', '03', '{"foo":1}');
-    INSERT INTO cvr_sdf.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
+    INSERT INTO "roze_1/cvr".rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
       VALUES('${CVR_ID}', '', 'issues', '{"id":"11"}', '01', '03', '{"bar":2}');
-    INSERT INTO cvr_sdf.rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
+    INSERT INTO "roze_1/cvr".rows ("clientGroupID", "schema", "table", "rowKey", "rowVersion", "patchVersion", "refCounts")
       VALUES('${CVR_ID}', '', 'issues', '{"id":"12"}', '01', '03', '{"foo":2,"bar":3}');
       `);
 
@@ -83,6 +84,7 @@ describe('view-syncer/cvr-store', () => {
     store = new CVRStore(
       lc,
       db,
+      APP_ID,
       SHARD_ID,
       TASK_ID,
       CVR_ID,
@@ -100,7 +102,7 @@ describe('view-syncer/cvr-store', () => {
 
   test('wait for row catchup', async () => {
     // Simulate the CVR being ahead of the rows.
-    await db`UPDATE cvr_sdf.instances SET version = '04'`;
+    await db`UPDATE "roze_1/cvr".instances SET version = '04'`;
 
     // start a CVR load.
     const loading = store.load(lc, CONNECT_TIME);
@@ -109,8 +111,8 @@ describe('view-syncer/cvr-store', () => {
 
     // Simulate catching up.
     await db`
-    UPDATE cvr_sdf.instances SET version = '05:01';
-    UPDATE cvr_sdf."rowsVersion" SET version = '05:01';
+    UPDATE "roze_1/cvr".instances SET version = '05:01';
+    UPDATE "roze_1/cvr"."rowsVersion" SET version = '05:01';
     `.simple();
 
     const cvr = await loading;
@@ -122,7 +124,7 @@ describe('view-syncer/cvr-store', () => {
 
   test('fail after max attempts if rows behind', async () => {
     // Simulate the CVR being ahead of the rows.
-    await db`UPDATE cvr_sdf.instances SET version = '04'`;
+    await db`UPDATE "roze_1/cvr".instances SET version = '04'`;
 
     await expect(
       store.load(lc, CONNECT_TIME),
@@ -131,7 +133,8 @@ describe('view-syncer/cvr-store', () => {
     );
 
     // Verify that the store signaled an ownership change to 'my-task' at CONNECT_TIME.
-    expect(await db`SELECT * FROM cvr_sdf.instances`).toMatchInlineSnapshot(`
+    expect(await db`SELECT * FROM "roze_1/cvr".instances`)
+      .toMatchInlineSnapshot(`
       Result [
         {
           "clientGroupID": "my-cvr",
@@ -147,14 +150,15 @@ describe('view-syncer/cvr-store', () => {
 
   test('wrong owner', async () => {
     // Simulate the CVR being owned by someone else.
-    await db`UPDATE cvr_sdf.instances SET owner = 'other-task', "grantedAt" = ${
+    await db`UPDATE "roze_1/cvr".instances SET owner = 'other-task', "grantedAt" = ${
       CONNECT_TIME + 1
     }`;
 
     await expect(store.load(lc, CONNECT_TIME)).rejects.toThrow(OwnershipError);
 
     // Verify that no ownership change was signaled.
-    expect(await db`SELECT * FROM cvr_sdf.instances`).toMatchInlineSnapshot(`
+    expect(await db`SELECT * FROM "roze_1/cvr".instances`)
+      .toMatchInlineSnapshot(`
       Result [
         {
           "clientGroupID": "my-cvr",
@@ -369,7 +373,9 @@ describe('view-syncer/cvr-store', () => {
     let cvr = await store.load(lc, CONNECT_TIME);
 
     // 12 rows set up in beforeEach().
-    expect(await db`SELECT COUNT(*) FROM cvr_sdf.rows`).toEqual([{count: 12n}]);
+    expect(await db`SELECT COUNT(*) FROM "roze_1/cvr".rows`).toEqual([
+      {count: 12n},
+    ]);
 
     let updater = new CVRQueryDrivenUpdater(store, cvr, '04', '01');
     updater.trackQueries(
@@ -389,7 +395,8 @@ describe('view-syncer/cvr-store', () => {
     await updater.received(lc, rows);
     cvr = (await updater.flush(lc, true, CONNECT_TIME, now)).cvr;
 
-    expect(await db`SELECT * FROM cvr_sdf.instances`).toMatchInlineSnapshot(`
+    expect(await db`SELECT * FROM "roze_1/cvr".instances`)
+      .toMatchInlineSnapshot(`
       Result [
         {
           "clientGroupID": "my-cvr",
@@ -403,7 +410,7 @@ describe('view-syncer/cvr-store', () => {
     `);
 
     // rowsVersion === '03' (flush deferred).
-    expect(await db`SELECT * FROM cvr_sdf."rowsVersion"`)
+    expect(await db`SELECT * FROM "roze_1/cvr"."rowsVersion"`)
       .toMatchInlineSnapshot(`
       Result [
         {
@@ -414,7 +421,9 @@ describe('view-syncer/cvr-store', () => {
     `);
 
     // Still only 12 rows.
-    expect(await db`SELECT COUNT(*) FROM cvr_sdf.rows`).toEqual([{count: 12n}]);
+    expect(await db`SELECT COUNT(*) FROM "roze_1/cvr".rows`).toEqual([
+      {count: 12n},
+    ]);
 
     // Flush was scheduled.
     expect(setTimeoutFn).toHaveBeenCalledOnce();
@@ -440,7 +449,8 @@ describe('view-syncer/cvr-store', () => {
     await updater.received(lc, rows);
     await updater.flush(lc, true, CONNECT_TIME, now);
 
-    expect(await db`SELECT * FROM cvr_sdf.instances`).toMatchInlineSnapshot(`
+    expect(await db`SELECT * FROM "roze_1/cvr".instances`)
+      .toMatchInlineSnapshot(`
       Result [
         {
           "clientGroupID": "my-cvr",
@@ -454,7 +464,7 @@ describe('view-syncer/cvr-store', () => {
     `);
 
     // rowsVersion === '03' (flush deferred).
-    expect(await db`SELECT * FROM cvr_sdf."rowsVersion"`)
+    expect(await db`SELECT * FROM "roze_1/cvr"."rowsVersion"`)
       .toMatchInlineSnapshot(`
       Result [
         {
@@ -465,13 +475,15 @@ describe('view-syncer/cvr-store', () => {
     `);
 
     // Still only 12 rows.
-    expect(await db`SELECT COUNT(*) FROM cvr_sdf.rows`).toEqual([{count: 12n}]);
+    expect(await db`SELECT COUNT(*) FROM "roze_1/cvr".rows`).toEqual([
+      {count: 12n},
+    ]);
 
     // Now run the flush logic.
     await setTimeoutFn.mock.calls[0][0]();
 
     // rowsVersion === '05' (flushed).
-    expect(await db`SELECT * FROM cvr_sdf."rowsVersion"`)
+    expect(await db`SELECT * FROM "roze_1/cvr"."rowsVersion"`)
       .toMatchInlineSnapshot(`
       Result [
         {
@@ -482,7 +494,9 @@ describe('view-syncer/cvr-store', () => {
     `);
 
     // 12 + 6 + 4.
-    expect(await db`SELECT COUNT(*) FROM cvr_sdf.rows`).toEqual([{count: 22n}]);
+    expect(await db`SELECT COUNT(*) FROM "roze_1/cvr".rows`).toEqual([
+      {count: 22n},
+    ]);
   });
 
   test('deferred row stress test', async () => {
@@ -493,7 +507,9 @@ describe('view-syncer/cvr-store', () => {
     setTimeoutFn.mockImplementation((cb, ms) => setTimeout(cb, ms));
 
     // 12 rows set up in beforeEach().
-    expect(await db`SELECT COUNT(*) FROM cvr_sdf.rows`).toEqual([{count: 12n}]);
+    expect(await db`SELECT COUNT(*) FROM "roze_1/cvr".rows`).toEqual([
+      {count: 12n},
+    ]);
 
     // Commit 30 flushes of 10 rows each.
     for (let i = 20; i < 320; i += 10) {
@@ -521,7 +537,8 @@ describe('view-syncer/cvr-store', () => {
       await sleep(Math.random() * 1);
     }
 
-    expect(await db`SELECT * FROM cvr_sdf.instances`).toMatchInlineSnapshot(`
+    expect(await db`SELECT * FROM "roze_1/cvr".instances`)
+      .toMatchInlineSnapshot(`
       Result [
         {
           "clientGroupID": "my-cvr",
@@ -537,8 +554,8 @@ describe('view-syncer/cvr-store', () => {
     // Should block until all pending rows are flushed.
     await store.flushed(lc);
 
-    // rowsVersion should match cvr_sdf.instances version
-    expect(await db`SELECT * FROM cvr_sdf."rowsVersion"`)
+    // rowsVersion should match "roze_1/cvr".instances version
+    expect(await db`SELECT * FROM "roze_1/cvr"."rowsVersion"`)
       .toMatchInlineSnapshot(`
             Result [
               {
@@ -549,7 +566,7 @@ describe('view-syncer/cvr-store', () => {
           `);
 
     // 12 + (30 * 10)
-    expect(await db`SELECT COUNT(*) FROM cvr_sdf.rows`).toEqual([
+    expect(await db`SELECT COUNT(*) FROM "roze_1/cvr".rows`).toEqual([
       {count: 312n},
     ]);
   });
@@ -562,7 +579,9 @@ describe('view-syncer/cvr-store', () => {
     setTimeoutFn.mockImplementation((cb, ms) => setTimeout(cb, ms));
 
     // 12 rows set up in beforeEach().
-    expect(await db`SELECT COUNT(*) FROM cvr_sdf.rows`).toEqual([{count: 12n}]);
+    expect(await db`SELECT COUNT(*) FROM "roze_1/cvr".rows`).toEqual([
+      {count: 12n},
+    ]);
 
     // Commit 30 flushes of 10 rows each.
     for (let i = 20; i < 320; i += 10) {
@@ -606,7 +625,8 @@ describe('view-syncer/cvr-store', () => {
     await updater.received(lc, rows);
     await updater.flush(lc, true, CONNECT_TIME, now);
 
-    expect(await db`SELECT * FROM cvr_sdf.instances`).toMatchInlineSnapshot(`
+    expect(await db`SELECT * FROM "roze_1/cvr".instances`)
+      .toMatchInlineSnapshot(`
       Result [
         {
           "clientGroupID": "my-cvr",
@@ -622,8 +642,8 @@ describe('view-syncer/cvr-store', () => {
     // Should block until all pending rows are flushed.
     await store.flushed(lc);
 
-    // rowsVersion should match cvr_sdf.instances version
-    expect(await db`SELECT * FROM cvr_sdf."rowsVersion"`)
+    // rowsVersion should match "roze_1/cvr".instances version
+    expect(await db`SELECT * FROM "roze_1/cvr"."rowsVersion"`)
       .toMatchInlineSnapshot(`
             Result [
               {
@@ -634,7 +654,7 @@ describe('view-syncer/cvr-store', () => {
           `);
 
     // 12 + (30 * 10)
-    expect(await db`SELECT COUNT(*) FROM cvr_sdf.rows`).toEqual([
+    expect(await db`SELECT COUNT(*) FROM "roze_1/cvr".rows`).toEqual([
       {count: 312n},
     ]);
   });
@@ -644,7 +664,9 @@ describe('view-syncer/cvr-store', () => {
     let cvr = await store.load(lc, CONNECT_TIME);
 
     // 12 rows set up in beforeEach().
-    expect(await db`SELECT COUNT(*) FROM cvr_sdf.rows`).toEqual([{count: 12n}]);
+    expect(await db`SELECT COUNT(*) FROM "roze_1/cvr".rows`).toEqual([
+      {count: 12n},
+    ]);
 
     const updater = new CVRQueryDrivenUpdater(store, cvr, '04', '01');
     updater.trackQueries(
@@ -665,7 +687,8 @@ describe('view-syncer/cvr-store', () => {
     await updater.received(lc, rows);
     cvr = (await updater.flush(lc, true, CONNECT_TIME, now)).cvr;
 
-    expect(await db`SELECT * FROM cvr_sdf.instances`).toMatchInlineSnapshot(`
+    expect(await db`SELECT * FROM "roze_1/cvr".instances`)
+      .toMatchInlineSnapshot(`
     Result [
       {
         "clientGroupID": "my-cvr",
@@ -679,7 +702,7 @@ describe('view-syncer/cvr-store', () => {
   `);
 
     // rowsVersion === '03' (flush deferred).
-    expect(await db`SELECT * FROM cvr_sdf."rowsVersion"`)
+    expect(await db`SELECT * FROM "roze_1/cvr"."rowsVersion"`)
       .toMatchInlineSnapshot(`
     Result [
       {
@@ -690,7 +713,9 @@ describe('view-syncer/cvr-store', () => {
   `);
 
     // Still only 12 rows.
-    expect(await db`SELECT COUNT(*) FROM cvr_sdf.rows`).toEqual([{count: 12n}]);
+    expect(await db`SELECT COUNT(*) FROM "roze_1/cvr".rows`).toEqual([
+      {count: 12n},
+    ]);
 
     // Flush was scheduled.
     expect(setTimeoutFn).toHaveBeenCalledOnce();
@@ -699,7 +724,7 @@ describe('view-syncer/cvr-store', () => {
     await setTimeoutFn.mock.calls[0][0]();
 
     // rowsVersion === '04' (flushed).
-    expect(await db`SELECT * FROM cvr_sdf."rowsVersion"`)
+    expect(await db`SELECT * FROM "roze_1/cvr"."rowsVersion"`)
       .toMatchInlineSnapshot(`
     Result [
       {
@@ -710,7 +735,7 @@ describe('view-syncer/cvr-store', () => {
   `);
 
     // 12 + 1023 = 1035
-    expect(await db`SELECT COUNT(*) FROM cvr_sdf.rows`).toEqual([
+    expect(await db`SELECT COUNT(*) FROM "roze_1/cvr".rows`).toEqual([
       {count: 1035n},
     ]);
   });

--- a/packages/zero-cache/src/services/view-syncer/cvr-store.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.ts
@@ -113,6 +113,7 @@ export class CVRStore {
   constructor(
     lc: LogContext,
     db: PostgresDB,
+    appID: string,
     shardID: string,
     taskID: string,
     cvrID: string,
@@ -123,12 +124,13 @@ export class CVRStore {
     setTimeoutFn = setTimeout,
   ) {
     this.#db = db;
-    this.#schema = cvrSchema(shardID);
+    this.#schema = cvrSchema(appID, shardID);
     this.#taskID = taskID;
     this.#id = cvrID;
     this.#rowCache = new RowRecordCache(
       lc,
       db,
+      appID,
       shardID,
       cvrID,
       failService,

--- a/packages/zero-cache/src/services/view-syncer/row-record-cache.ts
+++ b/packages/zero-cache/src/services/view-syncer/row-record-cache.ts
@@ -98,6 +98,7 @@ export class RowRecordCache {
   constructor(
     lc: LogContext,
     db: PostgresDB,
+    appID: string,
     shardID: string,
     cvrID: string,
     failService: (e: unknown) => void,
@@ -106,7 +107,7 @@ export class RowRecordCache {
   ) {
     this.#lc = lc;
     this.#db = db;
-    this.#schema = cvrSchema(shardID);
+    this.#schema = cvrSchema(appID, shardID);
     this.#cvrID = cvrID;
     this.#failService = failService;
     this.#deferredRowFlushThreshold = deferredRowFlushThreshold;

--- a/packages/zero-cache/src/services/view-syncer/schema/init.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/init.ts
@@ -11,12 +11,13 @@ import {createRowsVersionTable, cvrSchema, setupCVRTables} from './cvr.ts';
 export async function initViewSyncerSchema(
   log: LogContext,
   db: PostgresDB,
+  appID: string,
   shardID: string,
 ): Promise<void> {
-  const schema = cvrSchema(shardID);
+  const schema = cvrSchema(appID, shardID);
 
   const setupMigration: Migration = {
-    migrateSchema: (lc, tx) => setupCVRTables(lc, tx, shardID),
+    migrateSchema: (lc, tx) => setupCVRTables(lc, tx, appID, shardID),
     minSafeVersion: 1,
   };
 
@@ -28,7 +29,7 @@ export async function initViewSyncerSchema(
 
   const migrateV2ToV3: Migration = {
     migrateSchema: async (_, tx) => {
-      await tx.unsafe(createRowsVersionTable(shardID));
+      await tx.unsafe(createRowsVersionTable(appID, shardID));
     },
 
     /** Populates the cvr.rowsVersion table with versions from cvr.instances. */
@@ -102,7 +103,7 @@ export async function initViewSyncerSchema(
   await runSchemaMigrations(
     log,
     'view-syncer',
-    cvrSchema(shardID),
+    cvrSchema(appID, shardID),
     db,
     setupMigration,
     schemaVersionMigrationMap,

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -62,7 +62,7 @@ import {Snapshotter} from './snapshotter.ts';
 import {pickToken, type SyncContext, ViewSyncerService} from './view-syncer.ts';
 
 const APP_ID = 'this_app';
-const SHARD_ID = 'abc';
+const SHARD_ID = '2';
 const logConfig: LogConfig = {
   format: 'text',
   level: 'debug',
@@ -72,7 +72,7 @@ const logConfig: LogConfig = {
 
 const EXPECTED_LMIDS_AST: AST = {
   schema: '',
-  table: 'this_app_abc.clients',
+  table: 'this_app_2.clients',
   where: {
     type: 'simple',
     op: '=',
@@ -328,7 +328,7 @@ async function setup(permissions: PermissionsConfig | undefined) {
   replica.pragma('journal_mode = WAL2');
   replica.pragma('busy_timeout = 1');
   replica.exec(`
-  CREATE TABLE "this_app_abc.clients" (
+  CREATE TABLE "this_app_2.clients" (
     "clientGroupID"  TEXT,
     "clientID"       TEXT,
     "lastMutationID" INTEGER,
@@ -380,7 +380,7 @@ async function setup(permissions: PermissionsConfig | undefined) {
     _0_version TEXT NOT NULL
   );
 
-  INSERT INTO "this_app_abc.clients" ("clientGroupID", "clientID", "lastMutationID", _0_version)
+  INSERT INTO "this_app_2.clients" ("clientGroupID", "clientID", "lastMutationID", _0_version)
     VALUES ('9876', 'foo', 42, '01');
   INSERT INTO "this_app.schemaVersions" ("lock", "minSupportedVersion", "maxSupportedVersion", _0_version)    
     VALUES (1, 2, 3, '01'); 
@@ -407,7 +407,7 @@ async function setup(permissions: PermissionsConfig | undefined) {
   `);
 
   const cvrDB = await testDBs.create('view_syncer_service_test');
-  await initViewSyncerSchema(lc, cvrDB, SHARD_ID);
+  await initViewSyncerSchema(lc, cvrDB, APP_ID, SHARD_ID);
 
   const replicator = fakeReplicator(lc, replica);
   const stateChanges: Subscription<ReplicaState> = Subscription.create();
@@ -588,6 +588,7 @@ describe('view-syncer/service', () => {
     const cvrStore = new CVRStore(
       lc,
       cvrDB,
+      APP_ID,
       SHARD_ID,
       TASK_ID,
       serviceID,
@@ -642,6 +643,7 @@ describe('view-syncer/service', () => {
     const cvrStore = new CVRStore(
       lc,
       cvrDB,
+      APP_ID,
       SHARD_ID,
       TASK_ID,
       serviceID,
@@ -852,7 +854,8 @@ describe('view-syncer/service', () => {
       ]
     `);
 
-    expect(await cvrDB`SELECT * from cvr_abc.rows`).toMatchInlineSnapshot(`
+    expect(await cvrDB`SELECT * from "this_app_2/cvr".rows`)
+      .toMatchInlineSnapshot(`
       Result [
         {
           "clientGroupID": "9876",
@@ -866,7 +869,7 @@ describe('view-syncer/service', () => {
           },
           "rowVersion": "01",
           "schema": "",
-          "table": "this_app_abc.clients",
+          "table": "this_app_2.clients",
         },
         {
           "clientGroupID": "9876",
@@ -945,7 +948,9 @@ describe('view-syncer/service', () => {
     await nextPoke(client2);
     await nextPoke(client2);
 
-    expect(await cvrDB`SELECT * from cvr_abc.clients`).toMatchInlineSnapshot(
+    expect(
+      await cvrDB`SELECT * from "this_app_2/cvr".clients`,
+    ).toMatchInlineSnapshot(
       `
       Result [
         {
@@ -964,7 +969,8 @@ describe('view-syncer/service', () => {
     `,
     );
 
-    expect(await cvrDB`SELECT * from cvr_abc.desires`).toMatchInlineSnapshot(`
+    expect(await cvrDB`SELECT * from "this_app_2/cvr".desires`)
+      .toMatchInlineSnapshot(`
       Result [
         {
           "clientGroupID": "9876",
@@ -1077,7 +1083,8 @@ describe('view-syncer/service', () => {
       ]
     `);
 
-    expect(await cvrDB`SELECT * from cvr_abc.clients`).toMatchInlineSnapshot(`
+    expect(await cvrDB`SELECT * from "this_app_2/cvr".clients`)
+      .toMatchInlineSnapshot(`
       Result [
         {
           "clientGroupID": "9876",
@@ -1087,7 +1094,8 @@ describe('view-syncer/service', () => {
         },
       ]
     `);
-    expect(await cvrDB`SELECT * from cvr_abc.desires`).toMatchInlineSnapshot(`
+    expect(await cvrDB`SELECT * from "this_app_2/cvr".desires`)
+      .toMatchInlineSnapshot(`
       Result [
         {
           "clientGroupID": "9876",
@@ -1391,7 +1399,8 @@ describe('view-syncer/service', () => {
       ]
     `);
 
-    expect(await cvrDB`SELECT * from cvr_abc.rows`).toMatchInlineSnapshot(`
+    expect(await cvrDB`SELECT * from "this_app_2/cvr".rows`)
+      .toMatchInlineSnapshot(`
       Result [
         {
           "clientGroupID": "9876",
@@ -1405,7 +1414,7 @@ describe('view-syncer/service', () => {
           },
           "rowVersion": "01",
           "schema": "",
-          "table": "this_app_abc.clients",
+          "table": "this_app_2.clients",
         },
         {
           "clientGroupID": "9876",
@@ -1756,7 +1765,8 @@ describe('view-syncer/service', () => {
       ]
     `);
 
-    expect(await cvrDB`SELECT * from cvr_abc.rows`).toMatchInlineSnapshot(`
+    expect(await cvrDB`SELECT * from "this_app_2/cvr".rows`)
+      .toMatchInlineSnapshot(`
       Result [
         {
           "clientGroupID": "9876",
@@ -1770,7 +1780,7 @@ describe('view-syncer/service', () => {
           },
           "rowVersion": "01",
           "schema": "",
-          "table": "this_app_abc.clients",
+          "table": "this_app_2.clients",
         },
         {
           "clientGroupID": "9876",
@@ -1906,7 +1916,8 @@ describe('view-syncer/service', () => {
       ]
     `);
 
-    expect(await cvrDB`SELECT * from cvr_abc.rows`).toMatchInlineSnapshot(`
+    expect(await cvrDB`SELECT * from "this_app_2/cvr".rows`)
+      .toMatchInlineSnapshot(`
       Result [
         {
           "clientGroupID": "9876",
@@ -1920,7 +1931,7 @@ describe('view-syncer/service', () => {
           },
           "rowVersion": "01",
           "schema": "",
-          "table": "this_app_abc.clients",
+          "table": "this_app_2.clients",
         },
         {
           "clientGroupID": "9876",
@@ -2887,6 +2898,7 @@ describe('view-syncer/service', () => {
     const cvrStore = new CVRStore(
       lc,
       cvrDB,
+      APP_ID,
       SHARD_ID,
       TASK_ID,
       serviceID,
@@ -3050,6 +3062,7 @@ describe('view-syncer/service', () => {
     const cvrStore = new CVRStore(
       lc,
       cvrDB,
+      APP_ID,
       SHARD_ID,
       TASK_ID,
       serviceID,
@@ -3106,6 +3119,7 @@ describe('view-syncer/service', () => {
     const cvrStore = new CVRStore(
       lc,
       cvrDB,
+      APP_ID,
       SHARD_ID,
       TASK_ID,
       serviceID,

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -154,6 +154,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     this.#cvrStore = new CVRStore(
       lc,
       db,
+      appID,
       shardID,
       taskID,
       clientGroupID,


### PR DESCRIPTION
Changes the name of the CVR schema from `cvr_{SHARD_ID}` to `{APP_ID}_{SHARD_ID}/cvr`.

This allows zero-cache's from multiple apps and shards to use the same DB for the CVR.

The appID is still hardcoded to "zero", but will eventually be configurable.

Note that there is no migration for this change; new view-syncer use the new schema and notify clients with unknown CVRs to refresh. This is necessary because there can be multiple view-syncers, and new and old ones must be able to coexist.

https://www.notion.so/replicache/Zero-Upstream-Organization-1a33bed8954580e9a03fdddf81690fcc