### PR TITLE
feat(zero-client): preclude use of CRUD mutators when using custom mutators

### DIFF
--- a/packages/zero-client/src/client/test-utils.ts
+++ b/packages/zero-client/src/client/test-utils.ts
@@ -74,7 +74,7 @@ export class MockSocket extends EventTarget {
 
 export class TestZero<
   const S extends Schema,
-  MD extends CustomMutatorDefs<S> = CustomMutatorDefs<S>,
+  MD extends CustomMutatorDefs<S> | undefined = undefined,
 > extends Zero<S, MD> {
   #connectionStateResolvers: Set<{
     state: ConnectionState;
@@ -222,7 +222,7 @@ let testZeroCounter = 0;
 
 export function zeroForTest<
   const S extends Schema,
-  MD extends CustomMutatorDefs<S> = CustomMutatorDefs<S>,
+  MD extends CustomMutatorDefs<S> | undefined = undefined,
 >(
   options: Partial<ZeroOptions<S, MD>> = {},
   errorOnUpdateNeeded = true,

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -3034,7 +3034,7 @@ test('custom mutations get pushed', async () => {
         foo: (tx, {foo}: {foo: number}) =>
           tx.mutate.issues.insert({id: foo.toString(), value: foo}),
       },
-    },
+    } as const satisfies CustomMutatorDefs<typeof schema>,
   });
   await z.triggerConnected();
   const mockSocket = await z.socket;

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -511,8 +511,14 @@ export class Zero<
     this.#rep.onClientStateNotFound = onClientStateNotFoundCallback;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const {mutate, mutateBatch} = makeCRUDMutate<S>(schema, rep.mutate) as any;
+    let {mutate, mutateBatch} = makeCRUDMutate<S>(schema, rep.mutate) as any;
 
+    // custom mutators are incompatible with CRUD mutators.
+    // CRUD mutators are to be removed in a future release.
+    if (options.mutators) {
+      mutate = {};
+      mutateBatch = undefined;
+    }
     for (const [namespace, mutatorsForNamespace] of Object.entries(
       options.mutators ?? {},
     )) {
@@ -684,7 +690,7 @@ export class Zero<
    * ```
    */
   readonly mutate: MD extends CustomMutatorDefs<S>
-    ? DBMutator<S> & MakeCustomMutatorInterfaces<S, MD>
+    ? MakeCustomMutatorInterfaces<S, MD>
     : DBMutator<S>;
 
   /**


### PR DESCRIPTION
If custom mutators are defined, CRUD mutators will no longer be available.

E.g.,

```ts
const z = new Zero({
});
```