### PR TITLE
feat(zero-pg): add the zero-pg package to `zero`

### DIFF
--- a/packages/zero-pg/package.json
+++ b/packages/zero-pg/package.json
@@ -20,7 +20,9 @@
   "dependencies": {
     "@databases/escape-identifier": "^1.0.3",
     "@databases/sql": "^3.3.0",
-    "@rocicorp/logger": "^5.3.0",
+    "@rocicorp/logger": "^5.3.0"
+  },
+  "devDependencies": {
     "vitest": "^2.1.5"
   }
 }

--- a/packages/zero-pg/src/mod.ts
+++ b/packages/zero-pg/src/mod.ts
@@ -1,0 +1,9 @@
+export {createPushHandler} from './custom.ts';
+export type {CustomMutatorDefs, CustomMutatorImpl} from './custom.ts';
+export type {Transaction} from './custom.ts';
+export type {
+  DBConnection,
+  DBTransaction,
+  ConnectionProvider,
+  Row,
+} from './db.ts';

--- a/packages/zero/package.json
+++ b/packages/zero/package.json
@@ -92,6 +92,10 @@
     "./change-protocol/v0": {
       "types": "./out/zero/src/change-protocol/v0.d.ts",
       "default": "./out/zero/src/change-protocol/v0.js"
+    },
+    "./pg": {
+      "types": "./out/zero-pg/src/mod.d.ts",
+      "default": "./out/pg.js"
     }
   },
   "bin": {

--- a/packages/zero/src/pg.ts
+++ b/packages/zero/src/pg.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-imports
+export * from '../../zero-pg/src/mod.ts';

--- a/packages/zero/tool/build.ts
+++ b/packages/zero/tool/build.ts
@@ -52,12 +52,13 @@ async function getExternal(includePeerDeps: boolean): Promise<string[]> {
     'datadog',
     'replicache',
     'shared',
+    'zero-advanced',
     'zero-cache',
     'zero-client',
+    'zero-pg',
     'zero-protocol',
     'zero-react',
     'zero-solid',
-    'zero-advanced',
     'zql',
     'zqlite',
   ]) {
@@ -102,6 +103,7 @@ async function buildZeroClient() {
         react: basePath('src/react.ts'),
         solid: basePath('src/solid.ts'),
         advanced: basePath('src/advanced.ts'),
+        pg: basePath('src/pg.ts'),
       };
   const result = await esbuild.build({
     ...sharedOptions(minify, metafile),

--- a/packages/zero/tsconfig.server.json
+++ b/packages/zero/tsconfig.server.json
@@ -9,6 +9,7 @@
     "src/build-schema.ts",
     "src/zero-cache-dev.ts",
     "src/deploy-permissions.ts",
-    "src/change-protocol/*"
+    "src/change-protocol/*",
+    "src/pg.ts"
   ]
 }


### PR DESCRIPTION
So users can `import {createPushHandler} from '@rocicorp/zero/pg'`

Usage example to follow in zbugs update(s).