### PR TITLE
fix(zero-cache): fix deadlocking race condition in change streamer

### DIFF
--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -64,7 +64,7 @@ test('zero-cache --help', () => {
        ZERO_CHANGE_DB env                                                                                                                                         
                                                                 Yet another Postgres database, used to store a replication log.                                   
                                                                                                                                                                   
-     --change-max-conns number                                  default: 1                                                                                        
+     --change-max-conns number                                  default: 5                                                                                        
        ZERO_CHANGE_MAX_CONNS env                                                                                                                                  
                                                                 The maximum number of connections to open to the change database.                                 
                                                                 This is used by the change-streamer for catching up                                               

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -195,7 +195,7 @@ export const zeroOptions = {
     },
 
     maxConns: {
-      type: v.number().default(1),
+      type: v.number().default(5),
       desc: [
         `The maximum number of connections to open to the change database.`,
         `This is used by the {bold change-streamer} for catching up`,

--- a/packages/zero-cache/src/server/multi/config.test.ts
+++ b/packages/zero-cache/src/server/multi/config.test.ts
@@ -55,7 +55,7 @@ test('parse options', () => {
         "auth": {},
         "autoReset": true,
         "change": {
-          "maxConns": 1,
+          "maxConns": 5,
         },
         "cvr": {
           "maxConns": 30,
@@ -129,7 +129,7 @@ test('parse options', () => {
       },
       "env": {
         "ZERO_AUTO_RESET": "true",
-        "ZERO_CHANGE_MAX_CONNS": "1",
+        "ZERO_CHANGE_MAX_CONNS": "5",
         "ZERO_CVR_MAX_CONNS": "30",
         "ZERO_INITIAL_SYNC_ROW_BATCH_SIZE": "10000",
         "ZERO_INITIAL_SYNC_TABLE_COPY_WORKERS": "5",
@@ -304,7 +304,7 @@ test('zero-cache --help', () => {
        ZERO_CHANGE_DB env                                                                                                                                         
                                                                 Yet another Postgres database, used to store a replication log.                                   
                                                                                                                                                                   
-     --change-max-conns number                                  default: 1                                                                                        
+     --change-max-conns number                                  default: 5                                                                                        
        ZERO_CHANGE_MAX_CONNS env                                                                                                                                  
                                                                 The maximum number of connections to open to the change database.                                 
                                                                 This is used by the change-streamer for catching up                                               

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -306,10 +306,8 @@ export class Storer implements Service {
             } ms)`,
           );
         } else {
-          const [{lastWatermark}] = await this.#db<{lastWatermark: string}[]>`
-            SELECT "lastWatermark" FROM ${this.#cdc('replicationState')}`;
           this.#lc.warn?.(
-            `subscriber at watermark ${sub.watermark} is ahead of latest watermark: ${lastWatermark}`,
+            `subscriber at watermark ${sub.watermark} is ahead of latest watermark`,
           );
         }
         // Flushes the backlog of messages buffered during catchup and


### PR DESCRIPTION
Fixes an initialization-time race condition in which results in a deadlock if the first subscriber (the backup replicator) is ahead of the change DB. In this case, the lookup for the initial watermark gets into a deadlock with the catchup transaction if the client only has a single connection.

Though this should only happen in development, it's good to guard against nevertheless.

The fixes are to: 
* remove the lookup of the last watermark when doing catchup. this is informational only anyway.
* set the default connection count to 5 instead of 1. this also speeds up catchup when multiple view-syncers are subscribing at the same time.