### PR TITLE
fix(zql): Remove split-push from exists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27873,7 +27873,9 @@
       "dependencies": {
         "@databases/escape-identifier": "^1.0.3",
         "@databases/sql": "^3.3.0",
-        "@rocicorp/logger": "^5.3.0",
+        "@rocicorp/logger": "^5.3.0"
+      },
+      "devDependencies": {
         "vitest": "^2.1.5"
       }
     },

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -723,6 +723,15 @@ describe('view-syncer/pipeline-driver', () => {
           "queryHash": "hash1",
           "row": undefined,
           "rowKey": {
+            "id": "1",
+          },
+          "table": "issues",
+          "type": "remove",
+        },
+        {
+          "queryHash": "hash1",
+          "row": undefined,
+          "rowKey": {
             "issueID": "1",
             "labelID": "1",
             "legacyID": "1-1",
@@ -737,15 +746,6 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "1",
           },
           "table": "labels",
-          "type": "remove",
-        },
-        {
-          "queryHash": "hash1",
-          "row": undefined,
-          "rowKey": {
-            "id": "1",
-          },
-          "table": "issues",
           "type": "remove",
         },
       ]
@@ -1019,6 +1019,15 @@ describe('view-syncer/pipeline-driver', () => {
           "queryHash": "hash1",
           "row": undefined,
           "rowKey": {
+            "id": "2",
+          },
+          "table": "issues",
+          "type": "remove",
+        },
+        {
+          "queryHash": "hash1",
+          "row": undefined,
+          "rowKey": {
             "issueID": "2",
             "labelID": "1",
             "legacyID": "2-1",
@@ -1033,15 +1042,6 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "1",
           },
           "table": "labels",
-          "type": "remove",
-        },
-        {
-          "queryHash": "hash1",
-          "row": undefined,
-          "rowKey": {
-            "id": "2",
-          },
-          "table": "issues",
           "type": "remove",
         },
         {

--- a/packages/zql/src/ivm/exists.push.test.ts
+++ b/packages/zql/src/ivm/exists.push.test.ts
@@ -197,24 +197,6 @@ suite('EXISTS 1 to many', () => {
           "exists",
           "push",
           {
-            "child": {
-              "row": {
-                "id": "i1",
-                "title": "issue 1",
-              },
-              "type": "remove",
-            },
-            "row": {
-              "id": "c1",
-              "issueID": "i1",
-            },
-            "type": "child",
-          },
-        ],
-        [
-          "exists",
-          "push",
-          {
             "row": {
               "id": "c1",
               "issueID": "i1",
@@ -249,24 +231,6 @@ suite('EXISTS 1 to many', () => {
                 "issueID": "i1",
               },
             },
-          },
-        ],
-        [
-          "exists",
-          "push",
-          {
-            "child": {
-              "row": {
-                "id": "i1",
-                "title": "issue 1",
-              },
-              "type": "remove",
-            },
-            "row": {
-              "id": "c2",
-              "issueID": "i1",
-            },
-            "type": "child",
           },
         ],
         [
@@ -317,24 +281,6 @@ suite('EXISTS 1 to many', () => {
           "take",
           "push",
           {
-            "child": {
-              "row": {
-                "id": "i1",
-                "title": "issue 1",
-              },
-              "type": "remove",
-            },
-            "row": {
-              "id": "c1",
-              "issueID": "i1",
-            },
-            "type": "child",
-          },
-        ],
-        [
-          "take",
-          "push",
-          {
             "row": {
               "id": "c1",
               "issueID": "i1",
@@ -357,24 +303,6 @@ suite('EXISTS 1 to many', () => {
           "take",
           "push",
           {
-            "child": {
-              "row": {
-                "id": "i1",
-                "title": "issue 1",
-              },
-              "type": "remove",
-            },
-            "row": {
-              "id": "c2",
-              "issueID": "i1",
-            },
-            "type": "child",
-          },
-        ],
-        [
-          "take",
-          "push",
-          {
             "row": {
               "id": "c2",
               "issueID": "i1",
@@ -388,29 +316,17 @@ suite('EXISTS 1 to many', () => {
     expect(pushes).toMatchInlineSnapshot(`
       [
         {
-          "child": {
-            "change": {
-              "node": {
-                "relationships": {},
-                "row": {
-                  "id": "i1",
-                  "title": "issue 1",
-                },
-              },
-              "type": "remove",
-            },
-            "relationshipName": "issue",
-          },
-          "row": {
-            "id": "c1",
-            "issueID": "i1",
-          },
-          "type": "child",
-        },
-        {
           "node": {
             "relationships": {
-              "issue": [],
+              "issue": [
+                {
+                  "relationships": {},
+                  "row": {
+                    "id": "i1",
+                    "title": "issue 1",
+                  },
+                },
+              ],
             },
             "row": {
               "id": "c1",
@@ -440,29 +356,17 @@ suite('EXISTS 1 to many', () => {
           "type": "add",
         },
         {
-          "child": {
-            "change": {
-              "node": {
-                "relationships": {},
-                "row": {
-                  "id": "i1",
-                  "title": "issue 1",
-                },
-              },
-              "type": "remove",
-            },
-            "relationshipName": "issue",
-          },
-          "row": {
-            "id": "c2",
-            "issueID": "i1",
-          },
-          "type": "child",
-        },
-        {
           "node": {
             "relationships": {
-              "issue": [],
+              "issue": [
+                {
+                  "relationships": {},
+                  "row": {
+                    "id": "i1",
+                    "title": "issue 1",
+                  },
+                },
+              ],
             },
             "row": {
               "id": "c2",
@@ -1308,25 +1212,6 @@ suite('EXISTS', () => {
           "exists",
           "push",
           {
-            "child": {
-              "row": {
-                "id": "c1",
-                "issueID": "i1",
-                "text": "i1 c1 text",
-              },
-              "type": "remove",
-            },
-            "row": {
-              "id": "i1",
-              "text": "first issue",
-            },
-            "type": "child",
-          },
-        ],
-        [
-          "exists",
-          "push",
-          {
             "row": {
               "id": "i1",
               "text": "first issue",
@@ -1340,30 +1225,18 @@ suite('EXISTS', () => {
     expect(pushes).toMatchInlineSnapshot(`
       [
         {
-          "child": {
-            "change": {
-              "node": {
-                "relationships": {},
-                "row": {
-                  "id": "c1",
-                  "issueID": "i1",
-                  "text": "i1 c1 text",
-                },
-              },
-              "type": "remove",
-            },
-            "relationshipName": "comments",
-          },
-          "row": {
-            "id": "i1",
-            "text": "first issue",
-          },
-          "type": "child",
-        },
-        {
           "node": {
             "relationships": {
-              "comments": [],
+              "comments": [
+                {
+                  "relationships": {},
+                  "row": {
+                    "id": "c1",
+                    "issueID": "i1",
+                    "text": "i1 c1 text",
+                  },
+                },
+              ],
             },
             "row": {
               "id": "i1",
@@ -1674,25 +1547,6 @@ suite('EXISTS', () => {
           "exists",
           "push",
           {
-            "child": {
-              "row": {
-                "id": "c1",
-                "issueID": "i1",
-                "text": "i1 c1 text",
-              },
-              "type": "remove",
-            },
-            "row": {
-              "id": "i1",
-              "text": "first issue",
-            },
-            "type": "child",
-          },
-        ],
-        [
-          "exists",
-          "push",
-          {
             "row": {
               "id": "i1",
               "text": "first issue",
@@ -1717,30 +1571,18 @@ suite('EXISTS', () => {
     expect(pushes).toMatchInlineSnapshot(`
       [
         {
-          "child": {
-            "change": {
-              "node": {
-                "relationships": {},
-                "row": {
-                  "id": "c1",
-                  "issueID": "i1",
-                  "text": "i1 c1 text",
-                },
-              },
-              "type": "remove",
-            },
-            "relationshipName": "comments",
-          },
-          "row": {
-            "id": "i1",
-            "text": "first issue",
-          },
-          "type": "child",
-        },
-        {
           "node": {
             "relationships": {
-              "comments": [],
+              "comments": [
+                {
+                  "relationships": {},
+                  "row": {
+                    "id": "c1",
+                    "issueID": "i1",
+                    "text": "i1 c1 text",
+                  },
+                },
+              ],
             },
             "row": {
               "id": "i1",
@@ -2229,25 +2071,6 @@ suite('NOT EXISTS', () => {
           "exists",
           "push",
           {
-            "child": {
-              "row": {
-                "id": "c4",
-                "issueID": "i2",
-                "text": "i2 c4 text",
-              },
-              "type": "add",
-            },
-            "row": {
-              "id": "i2",
-              "text": "second issue",
-            },
-            "type": "child",
-          },
-        ],
-        [
-          "exists",
-          "push",
-          {
             "row": {
               "id": "i2",
               "text": "second issue",
@@ -2261,39 +2084,9 @@ suite('NOT EXISTS', () => {
     expect(pushes).toMatchInlineSnapshot(`
       [
         {
-          "child": {
-            "change": {
-              "node": {
-                "relationships": {},
-                "row": {
-                  "id": "c4",
-                  "issueID": "i2",
-                  "text": "i2 c4 text",
-                },
-              },
-              "type": "add",
-            },
-            "relationshipName": "comments",
-          },
-          "row": {
-            "id": "i2",
-            "text": "second issue",
-          },
-          "type": "child",
-        },
-        {
           "node": {
             "relationships": {
-              "comments": [
-                {
-                  "relationships": {},
-                  "row": {
-                    "id": "c4",
-                    "issueID": "i2",
-                    "text": "i2 c4 text",
-                  },
-                },
-              ],
+              "comments": [],
             },
             "row": {
               "id": "i2",
@@ -2604,25 +2397,6 @@ suite('NOT EXISTS', () => {
           "exists",
           "push",
           {
-            "child": {
-              "row": {
-                "id": "c1",
-                "issueID": "i2",
-                "text": "i2 c1 text",
-              },
-              "type": "add",
-            },
-            "row": {
-              "id": "i2",
-              "text": "second issue",
-            },
-            "type": "child",
-          },
-        ],
-        [
-          "exists",
-          "push",
-          {
             "row": {
               "id": "i2",
               "text": "second issue",
@@ -2648,39 +2422,9 @@ suite('NOT EXISTS', () => {
           "type": "add",
         },
         {
-          "child": {
-            "change": {
-              "node": {
-                "relationships": {},
-                "row": {
-                  "id": "c1",
-                  "issueID": "i2",
-                  "text": "i2 c1 text",
-                },
-              },
-              "type": "add",
-            },
-            "relationshipName": "comments",
-          },
-          "row": {
-            "id": "i2",
-            "text": "second issue",
-          },
-          "type": "child",
-        },
-        {
           "node": {
             "relationships": {
-              "comments": [
-                {
-                  "relationships": {},
-                  "row": {
-                    "id": "c1",
-                    "issueID": "i2",
-                    "text": "i2 c1 text",
-                  },
-                },
-              ],
+              "comments": [],
             },
             "row": {
               "id": "i2",

--- a/packages/zql/src/ivm/exists.ts
+++ b/packages/zql/src/ivm/exists.ts
@@ -144,19 +144,23 @@ export class Exists implements Operator {
               size = this.#fetchSize(change.node);
             }
             if (size === 1) {
-              const type = this.#not ? 'remove' : 'add';
-              // The node for the remove pushed below will contain the child
-              // added by this change in its
-              // relationships[this.#relationshipName],
-              // so this child add needs to be sent first.  This balance
-              // is important for outputs doing ref counting,
-              if (type === 'remove') {
-                this.#output.push(change);
+              if (this.#not) {
+                this.#output.push({
+                  type: 'remove',
+                  node: {
+                    row: change.node.row,
+                    relationships: {
+                      ...change.node.relationships,
+                      [this.#relationshipName]: () => [],
+                    },
+                  },
+                });
+              } else {
+                this.#output.push({
+                  type: 'add',
+                  node: change.node,
+                });
               }
-              this.#output.push({
-                type,
-                node: change.node,
-              });
             } else {
               this.#pushWithFilter(change, size);
             }
@@ -177,18 +181,25 @@ export class Exists implements Operator {
               size = this.#fetchSize(change.node);
             }
             if (size === 0) {
-              const type = this.#not ? 'add' : 'remove';
-              // The node for the remove pushed below will not contain the child
-              // removed by this change in its
-              // relationships[this.#relationshipName],
-              // so this child remove needs to be sent.
-              if (type === 'remove') {
-                this.#output.push(change);
+              if (this.#not) {
+                this.#output.push({
+                  type: 'add',
+                  node: change.node,
+                });
+              } else {
+                this.#output.push({
+                  type: 'remove',
+                  node: {
+                    row: change.node.row,
+                    relationships: {
+                      ...change.node.relationships,
+                      [this.#relationshipName]: () => [
+                        change.child.change.node,
+                      ],
+                    },
+                  },
+                });
               }
-              this.#output.push({
-                type,
-                node: change.node,
-              });
             } else {
               this.#pushWithFilter(change, size);
             }

--- a/packages/zql/src/ivm/exists.ts
+++ b/packages/zql/src/ivm/exists.ts
@@ -145,6 +145,10 @@ export class Exists implements Operator {
             }
             if (size === 1) {
               if (this.#not) {
+                // Since the add child change currently being processed is not
+                // pushed to output, the added child needs to be excluded from
+                // the remove being pushed to output (since the child has
+                // never been added to the output).
                 this.#output.push({
                   type: 'remove',
                   node: {
@@ -187,6 +191,9 @@ export class Exists implements Operator {
                   node: change.node,
                 });
               } else {
+                // Since the remove child change currently being processed is
+                // not pushed to output, the removed child needs to be added to
+                // the remove being pushed to output.
                 this.#output.push({
                   type: 'remove',
                   node: {


### PR DESCRIPTION
Rework the logic in Exist that currently results in a "split push" to push a single Change.  