### PR TITLE
fix(zero-cache): get publications from the upstream shard

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/decommission.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/decommission.pg-test.ts
@@ -17,7 +17,7 @@ describe('decommission', () => {
 
   beforeEach(async () => {
     lc = createSilentLogContext();
-    upstream = await testDBs.create('initial_sync_upstream');
+    upstream = await testDBs.create('decommission_test');
     replica = new Database(lc, ':memory:');
   });
 


### PR DESCRIPTION
Get the publications from the upstream shard instead of the replica. The latter may be out of sync (if litestream doesn't back up a new replica in time), which we will need to detect in a different way.