### PR TITLE
fix(zql): Exist operator: remove cached size reuse across rows during push 

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/storer.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.pg-test.ts
@@ -242,7 +242,9 @@ describe('change-streamer/storer', () => {
     const [sub] = createSubscriber('01');
     storer.catchup(sub, 'backup');
 
-    expect(await fatalErrors.dequeue()).toMatchInlineSnapshot(`[AutoResetSignal: backup replica at watermark 01 is behind change db: 03)]`);
+    expect(await fatalErrors.dequeue()).toMatchInlineSnapshot(
+      `[AutoResetSignal: backup replica at watermark 01 is behind change db: 03)]`,
+    );
   });
 
   test('queued if transaction in progress', async () => {

--- a/packages/zql/src/ivm/exists.fetch.test.ts
+++ b/packages/zql/src/ivm/exists.fetch.test.ts
@@ -224,7 +224,6 @@ suite('EXISTS', () => {
     `);
     expect(storage).toMatchInlineSnapshot(`
       {
-        "row/["i1"]": 1,
         "row/["i1"]/["c1"]": 1,
       }
     `);
@@ -603,9 +602,7 @@ suite('EXISTS', () => {
     `);
     expect(storage).toMatchInlineSnapshot(`
       {
-        "row/["i1"]": 1,
         "row/["i1"]/["c1"]": 1,
-        "row/["i3"]": 1,
         "row/["i3"]/["c2"]": 1,
       }
     `);
@@ -885,7 +882,6 @@ suite('NOT EXISTS', () => {
     `);
     expect(storage).toMatchInlineSnapshot(`
       {
-        "row/["i1"]": 1,
         "row/["i1"]/["c1"]": 1,
       }
     `);
@@ -1209,9 +1205,7 @@ suite('NOT EXISTS', () => {
     `);
     expect(storage).toMatchInlineSnapshot(`
       {
-        "row/["i1"]": 1,
         "row/["i1"]/["c1"]": 1,
-        "row/["i3"]": 1,
         "row/["i3"]/["c2"]": 1,
       }
     `);

--- a/packages/zql/src/ivm/exists.push.test.ts
+++ b/packages/zql/src/ivm/exists.push.test.ts
@@ -253,46 +253,6 @@ suite('EXISTS 1 to many', () => {
             "start": {
               "basis": "after",
               "row": {
-                "id": "c3",
-                "issueID": "i1",
-              },
-            },
-          },
-        ],
-        [
-          "exists",
-          "fetch",
-          {
-            "constraint": undefined,
-            "start": {
-              "basis": "at",
-              "row": {
-                "id": "c3",
-                "issueID": "i1",
-              },
-            },
-          },
-        ],
-        [
-          "exists",
-          "push",
-          {
-            "row": {
-              "id": "c3",
-              "issueID": "i1",
-            },
-            "type": "remove",
-          },
-        ],
-        [
-          "exists",
-          "fetch",
-          {
-            "constraint": undefined,
-            "reverse": true,
-            "start": {
-              "basis": "after",
-              "row": {
                 "id": "c4",
                 "issueID": "i2",
               },
@@ -333,28 +293,6 @@ suite('EXISTS 1 to many', () => {
           "push",
           {
             "row": {
-              "id": "c3",
-              "issueID": "i1",
-            },
-            "type": "add",
-          },
-        ],
-        [
-          "take",
-          "push",
-          {
-            "row": {
-              "id": "c2",
-              "issueID": "i1",
-            },
-            "type": "remove",
-          },
-        ],
-        [
-          "take",
-          "push",
-          {
-            "row": {
               "id": "c4",
               "issueID": "i2",
             },
@@ -366,7 +304,7 @@ suite('EXISTS 1 to many', () => {
           "push",
           {
             "row": {
-              "id": "c3",
+              "id": "c2",
               "issueID": "i1",
             },
             "type": "remove",
@@ -392,46 +330,6 @@ suite('EXISTS 1 to many', () => {
             },
             "row": {
               "id": "c1",
-              "issueID": "i1",
-            },
-          },
-          "type": "remove",
-        },
-        {
-          "node": {
-            "relationships": {
-              "issue": [
-                {
-                  "relationships": {},
-                  "row": {
-                    "id": "i1",
-                    "title": "issue 1",
-                  },
-                },
-              ],
-            },
-            "row": {
-              "id": "c3",
-              "issueID": "i1",
-            },
-          },
-          "type": "add",
-        },
-        {
-          "node": {
-            "relationships": {
-              "issue": [
-                {
-                  "relationships": {},
-                  "row": {
-                    "id": "i1",
-                    "title": "issue 1",
-                  },
-                },
-              ],
-            },
-            "row": {
-              "id": "c2",
               "issueID": "i1",
             },
           },
@@ -471,7 +369,7 @@ suite('EXISTS 1 to many', () => {
               ],
             },
             "row": {
-              "id": "c3",
+              "id": "c2",
               "issueID": "i1",
             },
           },

--- a/packages/zql/src/ivm/exists.push.test.ts
+++ b/packages/zql/src/ivm/exists.push.test.ts
@@ -253,6 +253,46 @@ suite('EXISTS 1 to many', () => {
             "start": {
               "basis": "after",
               "row": {
+                "id": "c3",
+                "issueID": "i1",
+              },
+            },
+          },
+        ],
+        [
+          "exists",
+          "fetch",
+          {
+            "constraint": undefined,
+            "start": {
+              "basis": "at",
+              "row": {
+                "id": "c3",
+                "issueID": "i1",
+              },
+            },
+          },
+        ],
+        [
+          "exists",
+          "push",
+          {
+            "row": {
+              "id": "c3",
+              "issueID": "i1",
+            },
+            "type": "remove",
+          },
+        ],
+        [
+          "exists",
+          "fetch",
+          {
+            "constraint": undefined,
+            "reverse": true,
+            "start": {
+              "basis": "after",
+              "row": {
                 "id": "c4",
                 "issueID": "i2",
               },
@@ -293,6 +333,28 @@ suite('EXISTS 1 to many', () => {
           "push",
           {
             "row": {
+              "id": "c3",
+              "issueID": "i1",
+            },
+            "type": "add",
+          },
+        ],
+        [
+          "take",
+          "push",
+          {
+            "row": {
+              "id": "c2",
+              "issueID": "i1",
+            },
+            "type": "remove",
+          },
+        ],
+        [
+          "take",
+          "push",
+          {
+            "row": {
               "id": "c4",
               "issueID": "i2",
             },
@@ -304,7 +366,7 @@ suite('EXISTS 1 to many', () => {
           "push",
           {
             "row": {
-              "id": "c2",
+              "id": "c3",
               "issueID": "i1",
             },
             "type": "remove",
@@ -330,6 +392,46 @@ suite('EXISTS 1 to many', () => {
             },
             "row": {
               "id": "c1",
+              "issueID": "i1",
+            },
+          },
+          "type": "remove",
+        },
+        {
+          "node": {
+            "relationships": {
+              "issue": [
+                {
+                  "relationships": {},
+                  "row": {
+                    "id": "i1",
+                    "title": "issue 1",
+                  },
+                },
+              ],
+            },
+            "row": {
+              "id": "c3",
+              "issueID": "i1",
+            },
+          },
+          "type": "add",
+        },
+        {
+          "node": {
+            "relationships": {
+              "issue": [
+                {
+                  "relationships": {},
+                  "row": {
+                    "id": "i1",
+                    "title": "issue 1",
+                  },
+                },
+              ],
+            },
+            "row": {
+              "id": "c2",
               "issueID": "i1",
             },
           },
@@ -369,7 +471,7 @@ suite('EXISTS 1 to many', () => {
               ],
             },
             "row": {
-              "id": "c2",
+              "id": "c3",
               "issueID": "i1",
             },
           },
@@ -380,11 +482,9 @@ suite('EXISTS 1 to many', () => {
 
     expect(actualStorage['exists']).toMatchInlineSnapshot(`
       {
-        "row/["i1"]": 0,
         "row/["i1"]/["c1"]": 0,
         "row/["i1"]/["c2"]": 0,
         "row/["i1"]/["c3"]": 0,
-        "row/["i2"]": 1,
         "row/["i2"]/["c4"]": 1,
       }
     `);

--- a/packages/zql/src/ivm/exists.ts
+++ b/packages/zql/src/ivm/exists.ts
@@ -174,7 +174,11 @@ export class Exists implements Operator {
             case 'remove': {
               let size = this.#getSize(change.node);
               if (size !== undefined) {
-                assert(size > 0);
+                // Work around for issue https://bugs.rocicorp.dev/issue/3204
+                // assert(size > 0);
+                if (size === 0) {
+                  return;
+                }
                 size--;
                 this.#setSize(change.node, size);
               } else {

--- a/packages/zql/src/ivm/exists.ts
+++ b/packages/zql/src/ivm/exists.ts
@@ -20,7 +20,16 @@ import type {SourceSchema} from './schema.ts';
 import {first} from './stream.ts';
 
 type SizeStorageKeyPrefix = `row/${string}/`;
-
+// Key is of format
+// `row/${JSON.stringify(parentJoinKeyValues)}/${JSON.stringify(primaryKeyValues)}`
+// This format allows us to look up an existing cached size for a
+// given set of `parentJoinKeyValues` by scanning for prefix
+// `row/${JSON.stringify(parentJoinKeyValues)}/`, and to look up the cached
+// size for a specific row by the full key.
+// If the parent join and primary key are the same, then format is changed to
+// `row//${JSON.stringify(primaryKeyValues)}` to shorten the key, since there
+// is no point in looking up an existing cached size by
+// `parentJoinKeyValues` if the specific rows cached size is missing.
 type SizeStorageKey = `${SizeStorageKeyPrefix}${string}`;
 
 interface ExistsStorage {

--- a/packages/zql/src/ivm/join.ts
+++ b/packages/zql/src/ivm/join.ts
@@ -29,12 +29,6 @@ type Args = {
   hidden: boolean;
   system: System;
 };
-
-type ChildChangeOverlay = {
-  change: Change;
-  position: Row | undefined;
-};
-
 /**
  * The Join operator joins the output from two upstream inputs. Zero's join
  * is a little different from SQL's join in that we output hierarchical data,
@@ -55,8 +49,6 @@ export class Join implements Input {
   readonly #schema: SourceSchema;
 
   #output: Output = throwOutput;
-
-  #inprogressChildChange: ChildChangeOverlay | undefined;
 
   constructor({
     parent,
@@ -214,35 +206,26 @@ export class Join implements Input {
 
   #pushChild(change: Change): void {
     const pushChildChange = (childRow: Row, change: Change) => {
-      this.#inprogressChildChange = {
-        change,
-        position: undefined,
-      };
-      try {
-        const parentNodes = this.#parent.fetch({
-          constraint: Object.fromEntries(
-            this.#parentKey.map((key, i) => [key, childRow[this.#childKey[i]]]),
-          ),
-        });
+      const parentNodes = this.#parent.fetch({
+        constraint: Object.fromEntries(
+          this.#parentKey.map((key, i) => [key, childRow[this.#childKey[i]]]),
+        ),
+      });
 
-        for (const parentNode of parentNodes) {
-          this.#inprogressChildChange.position = parentNode.row;
-          const childChange: ChildChange = {
-            type: 'child',
-            node: this.#processParentNode(
-              parentNode.row,
-              parentNode.relationships,
-              'fetch',
-            ),
-            child: {
-              relationshipName: this.#relationshipName,
-              change,
-            },
-          };
-          this.#output.push(childChange);
-        }
-      } finally {
-        this.#inprogressChildChange = undefined;
+      for (const parentNode of parentNodes) {
+        const childChange: ChildChange = {
+          type: 'child',
+          node: this.#processParentNode(
+            parentNode.row,
+            parentNode.relationships,
+            'fetch',
+          ),
+          child: {
+            relationshipName: this.#relationshipName,
+            change,
+          },
+        };
+        this.#output.push(childChange);
       }
     };
 
@@ -263,8 +246,8 @@ export class Join implements Input {
           pushChildChange(childRow, change);
         } else {
           // The child row was edited in a way that changes the relationship. We
-          // therefore treat this as a remove of the old row followed by an
-          // add of the new row.
+          // therefore treat this as a remove from the old row followed by an
+          // add to the new row.
           pushChildChange(oldChildRow, {
             type: 'remove',
             node: change.oldNode,
@@ -280,106 +263,6 @@ export class Join implements Input {
       default:
         unreachable(change);
     }
-  }
-
-  *#generateChildStreamWithOverlay(
-    stream: Stream<Node>,
-    overlay: Change,
-  ): Stream<Node> {
-    let applied = false;
-    let editOldApplied = false;
-    let editNewApplied = false;
-    for (const child of stream) {
-      let yieldChild = true;
-      if (!applied) {
-        switch (overlay.type) {
-          case 'add': {
-            if (
-              this.#child
-                .getSchema()
-                .compareRows(overlay.node.row, child.row) === 0
-            ) {
-              applied = true;
-              yieldChild = false;
-            }
-            break;
-          }
-          case 'remove': {
-            if (
-              this.#child.getSchema().compareRows(overlay.node.row, child.row) <
-              0
-            ) {
-              applied = true;
-              yield overlay.node;
-            }
-            break;
-          }
-          case 'edit': {
-            if (
-              this.#child
-                .getSchema()
-                .compareRows(overlay.oldNode.row, child.row) < 0
-            ) {
-              editOldApplied = true;
-              if (editNewApplied) {
-                applied = true;
-              }
-              yield overlay.oldNode;
-            }
-            if (
-              this.#child
-                .getSchema()
-                .compareRows(overlay.node.row, child.row) === 0
-            ) {
-              editNewApplied = true;
-              if (editOldApplied) {
-                applied = true;
-              }
-              yieldChild = false;
-            }
-            break;
-          }
-          case 'child': {
-            if (
-              this.#child
-                .getSchema()
-                .compareRows(overlay.node.row, child.row) === 0
-            ) {
-              applied = true;
-              yield {
-                row: child.row,
-                relationships: {
-                  ...child.relationships,
-                  [overlay.child.relationshipName]: () =>
-                    this.#generateChildStreamWithOverlay(
-                      child.relationships[overlay.child.relationshipName](),
-                      overlay.child.change,
-                    ),
-                },
-              };
-              yieldChild = false;
-            }
-            break;
-          }
-        }
-      }
-      if (yieldChild) {
-        yield child;
-      }
-    }
-    if (!applied) {
-      if (overlay.type === 'remove') {
-        applied = true;
-        yield overlay.node;
-      } else if (overlay.type === 'edit') {
-        assert(editNewApplied);
-        editOldApplied = true;
-        applied = true;
-        yield overlay.node;
-      }
-    }
-
-    assert(applied);
   }
 
   #processParentNode(
@@ -425,8 +308,7 @@ export class Join implements Input {
           );
         }
       }
-
-      const stream = this.#child[method]({
+      return this.#child[method]({
         constraint: Object.fromEntries(
           this.#childKey.map((key, i) => [
             key,
@@ -434,25 +316,6 @@ export class Join implements Input {
           ]),
         ),
       });
-
-      if (
-        this.#inprogressChildChange &&
-        this.#isJoinMatch(
-          parentNodeRow,
-          this.#inprogressChildChange.change.node.row,
-        ) &&
-        this.#inprogressChildChange.position &&
-        this.#schema.compareRows(
-          parentNodeRow,
-          this.#inprogressChildChange.position,
-        ) > 0
-      ) {
-        return this.#generateChildStreamWithOverlay(
-          stream,
-          this.#inprogressChildChange.change,
-        );
-      }
-      return stream;
     };
 
     return {
@@ -462,15 +325,6 @@ export class Join implements Input {
         [this.#relationshipName]: childStream,
       },
     };
-  }
-
-  #isJoinMatch(parent: Row, child: Row) {
-    for (let i = 0; i < this.#parentKey.length; i++) {
-      if (!valuesEqual(parent[this.#parentKey[i]], child[this.#childKey[i]])) {
-        return false;
-      }
-    }
-    return true;
   }
 }
 


### PR DESCRIPTION
The overlay solution to split push results in relationship's being inconsistent between Nodes at the same level of the tree during push.  This means its not correct to reuse cached sizes across rows during push. 

With this change initial hydration is really the only time that the cross row cache optimization is having an impact.