### PR TITLE
fix(zero-cache): resync if the change db cannot service the replica

### DIFF
--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -53,7 +53,7 @@ export default async function runWorker(
   for (const first of [true, false]) {
     try {
       // Note: This performs initial sync of the replica if necessary.
-      const {changeSource, replicationConfig} =
+      const {changeSource, subscriptionState} =
         upstream.type === 'pg'
           ? await initializePostgresChangeSource(
               lc,
@@ -75,7 +75,7 @@ export default async function runWorker(
         must(taskID, `main must set --task-id`),
         changeDB,
         changeSource,
-        replicationConfig,
+        subscriptionState,
         autoReset ?? false,
       );
       break;

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -47,11 +47,11 @@ import type {
   ChangeSource,
   ChangeStream,
 } from '../../change-streamer/change-streamer-service.ts';
+import {AutoResetSignal} from '../../change-streamer/schema/tables.ts';
 import {
-  AutoResetSignal,
-  type ReplicationConfig,
-} from '../../change-streamer/schema/tables.ts';
-import {getSubscriptionState} from '../../replicator/schema/replication-state.ts';
+  getSubscriptionState,
+  type SubscriptionState,
+} from '../../replicator/schema/replication-state.ts';
 import type {
   DataChange,
   Identifier,
@@ -90,7 +90,7 @@ export async function initializePostgresChangeSource(
   shard: ShardConfig,
   replicaDbFile: string,
   syncOptions: InitialSyncOptions,
-): Promise<{replicationConfig: ReplicationConfig; changeSource: ChangeSource}> {
+): Promise<{subscriptionState: SubscriptionState; changeSource: ChangeSource}> {
   await initSyncSchema(
     lc,
     `replica-${shard.appID}-${shard.shardNum}`,
@@ -101,13 +101,13 @@ export async function initializePostgresChangeSource(
   );
 
   const replica = new Database(lc, replicaDbFile);
-  const replicationConfig = getSubscriptionState(new StatementRunner(replica));
+  const subscriptionState = getSubscriptionState(new StatementRunner(replica));
   replica.close();
 
   if (shard.publications.length) {
     // Verify that the publications match what has been synced.
     const requested = [...shard.publications].sort();
-    const replicated = replicationConfig.publications
+    const replicated = subscriptionState.publications
       .filter(p => !p.startsWith(internalPublicationPrefix(shard)))
       .sort();
     if (!deepEqual(requested, replicated)) {
@@ -125,7 +125,7 @@ export async function initializePostgresChangeSource(
       lc,
       db,
       shard,
-      replicationConfig.replicaVersion,
+      subscriptionState.replicaVersion,
     );
   } finally {
     await db.end();
@@ -135,10 +135,10 @@ export async function initializePostgresChangeSource(
     lc,
     upstreamURI,
     shard,
-    replicationConfig.replicaVersion,
+    subscriptionState.replicaVersion,
   );
 
-  return {replicationConfig, changeSource};
+  return {subscriptionState, changeSource};
 }
 
 async function checkAndUpdateUpstream(

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg-test.ts
@@ -26,6 +26,7 @@ import type {StatusMessage} from '../change-source/protocol/current/status.ts';
 import {
   getSubscriptionState,
   initReplicationState,
+  type SubscriptionState,
 } from '../replicator/schema/replication-state.ts';
 import {ReplicationMessages} from '../replicator/test-utils.ts';
 import {initializeStreamer} from './change-streamer-service.ts';
@@ -38,12 +39,11 @@ import {
   AutoResetSignal,
   ensureReplicationConfig,
   type ChangeLogEntry,
-  type ReplicationConfig,
 } from './schema/tables.ts';
 
 describe('change-streamer/service', () => {
   let lc: LogContext;
-  let replicaConfig: ReplicationConfig;
+  let replicaConfig: SubscriptionState;
   let changeDB: PostgresDB;
   let streamer: ChangeStreamerService;
   let changes: Subscription<ChangeStreamMessage>;

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -17,6 +17,7 @@ import {
   type ChangeStreamMessage,
 } from '../change-source/protocol/current/downstream.ts';
 import type {ChangeSourceUpstream} from '../change-source/protocol/current/upstream.ts';
+import type {SubscriptionState} from '../replicator/schema/replication-state.ts';
 import {
   DEFAULT_MAX_RETRY_DELAY_MS,
   RunningState,
@@ -34,7 +35,6 @@ import {
   AutoResetSignal,
   ensureReplicationConfig,
   markResetRequired,
-  type ReplicationConfig,
 } from './schema/tables.ts';
 import {Storer} from './storer.ts';
 import {Subscriber} from './subscriber.ts';
@@ -48,7 +48,7 @@ export async function initializeStreamer(
   taskID: string,
   changeDB: PostgresDB,
   changeSource: ChangeSource,
-  replicationConfig: ReplicationConfig,
+  subscriptionState: SubscriptionState,
   autoReset: boolean,
   setTimeoutFn = setTimeout,
 ): Promise<ChangeStreamerService> {
@@ -57,12 +57,12 @@ export async function initializeStreamer(
   await ensureReplicationConfig(
     lc,
     changeDB,
-    replicationConfig,
+    subscriptionState,
     shard,
     autoReset,
   );
 
-  const {replicaVersion} = replicationConfig;
+  const {replicaVersion} = subscriptionState;
   return new ChangeStreamerImpl(
     lc,
     shard,

--- a/packages/zero-cache/src/services/change-streamer/schema/init.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/schema/init.pg-test.ts
@@ -24,7 +24,7 @@ describe('change-streamer/schema/migration', () => {
     await ensureReplicationConfig(
       lc,
       db,
-      {replicaVersion: '123', publications: []},
+      {replicaVersion: '123', publications: [], watermark: '123'},
       shard,
       true,
     );

--- a/packages/zero-cache/src/services/change-streamer/schema/tables.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/schema/tables.pg-test.ts
@@ -38,6 +38,7 @@ describe('change-streamer/schema/tables', () => {
       {
         replicaVersion: '183',
         publications: ['zero_data', 'zero_metadata'],
+        watermark: '183',
       },
       shard,
       true,
@@ -76,6 +77,7 @@ describe('change-streamer/schema/tables', () => {
       {
         replicaVersion: '183',
         publications: ['zero_metadata', 'zero_data'],
+        watermark: '183',
       },
       shard,
       true,
@@ -133,6 +135,7 @@ describe('change-streamer/schema/tables', () => {
       {
         replicaVersion: '183',
         publications: ['zero_metadata', 'zero_data'],
+        watermark: '183',
       },
       shard,
       false,
@@ -146,6 +149,7 @@ describe('change-streamer/schema/tables', () => {
         {
           replicaVersion: '183',
           publications: ['zero_metadata', 'zero_data'],
+          watermark: '183',
         },
         shard,
         true,
@@ -159,6 +163,7 @@ describe('change-streamer/schema/tables', () => {
       {
         replicaVersion: '1g8',
         publications: ['zero_data', 'zero_metadata'],
+        watermark: '1g8',
       },
       shard,
       true,
@@ -182,5 +187,21 @@ describe('change-streamer/schema/tables', () => {
       ],
       ['rezo_8/cdc.changeLog']: [],
     });
+
+    // Different replica version at a non-initial watermark
+    // should trigger a reset.
+    await expect(
+      ensureReplicationConfig(
+        lc,
+        db,
+        {
+          replicaVersion: '1gg',
+          publications: ['zero_data', 'zero_metadata'],
+          watermark: '1zz',
+        },
+        shard,
+        true,
+      ),
+    ).rejects.toThrow(AutoResetSignal);
   });
 });

--- a/packages/zero-cache/src/services/change-streamer/storer.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.pg-test.ts
@@ -33,7 +33,11 @@ describe('change-streamer/storer', () => {
     await ensureReplicationConfig(
       lc,
       db,
-      {replicaVersion: REPLICA_VERSION, publications: []},
+      {
+        replicaVersion: REPLICA_VERSION,
+        publications: [],
+        watermark: REPLICA_VERSION,
+      },
       shard,
       true,
     );

--- a/packages/zero-cache/src/services/replicator/schema/replication-state.ts
+++ b/packages/zero-cache/src/services/replicator/schema/replication-state.ts
@@ -50,6 +50,8 @@ const subscriptionStateSchema = v
     publications: v.parse(JSON.parse(s.publications), stringArray),
   }));
 
+export type SubscriptionState = v.Infer<typeof subscriptionStateSchema>;
+
 const replicationStateSchema = v.object({
   stateVersion: v.string(),
 });
@@ -75,7 +77,7 @@ export function initReplicationState(
   ).run(watermark);
 }
 
-export function getSubscriptionState(db: StatementRunner) {
+export function getSubscriptionState(db: StatementRunner): SubscriptionState {
   const result = db.get(
     `
       SELECT c.replicaVersion, c.publications, s.stateVersion as watermark


### PR DESCRIPTION
The change db clears its data if it sees a replica with a different `replicaVersion` that what it was last initialized with. However, this can only safely be done right after an initial-sync. For any other scenarios, we cannot guarantee that the change db can correctly catch up subscribers, so auto-reset to get the systems back in line with each other.