### PR TITLE
fix(zql): split push overlay logic for join

### DIFF
--- a/packages/zql/src/ivm/catch.ts
+++ b/packages/zql/src/ivm/catch.ts
@@ -46,10 +46,13 @@ export type CaughtChange =
  */
 export class Catch implements Output {
   #input: Input;
+  readonly #fetchOnPush: boolean;
   readonly pushes: CaughtChange[] = [];
+  readonly pushesWithFetch: {change: CaughtChange; fetch: CaughtNode[]}[] = [];
 
-  constructor(input: Input) {
+  constructor(input: Input, fetchOnPush = false) {
     this.#input = input;
+    this.#fetchOnPush = fetchOnPush;
     input.setOutput(this);
   }
 
@@ -62,7 +65,17 @@ export class Catch implements Output {
   }
 
   push(change: Change) {
-    this.pushes.push(expandChange(change));
+    const fetch = this.#fetchOnPush
+      ? [...this.#input.fetch({})].map(expandNode)
+      : [];
+    const expandedChange = expandChange(change);
+    if (this.#fetchOnPush) {
+      this.pushesWithFetch.push({
+        change: expandedChange,
+        fetch,
+      });
+    }
+    this.pushes.push(expandedChange);
   }
 
   reset() {

--- a/packages/zql/src/ivm/exists.push.test.ts
+++ b/packages/zql/src/ivm/exists.push.test.ts
@@ -235,6 +235,46 @@ suite('EXISTS 1 to many', () => {
               "start": {
                 "basis": "after",
                 "row": {
+                  "id": "c3",
+                  "issueID": "i1",
+                },
+              },
+            },
+          ],
+          [
+            ":exists(issue)",
+            "fetch",
+            {
+              "constraint": undefined,
+              "start": {
+                "basis": "at",
+                "row": {
+                  "id": "c3",
+                  "issueID": "i1",
+                },
+              },
+            },
+          ],
+          [
+            ":exists(issue)",
+            "push",
+            {
+              "row": {
+                "id": "c3",
+                "issueID": "i1",
+              },
+              "type": "remove",
+            },
+          ],
+          [
+            ":exists(issue)",
+            "fetch",
+            {
+              "constraint": undefined,
+              "reverse": true,
+              "start": {
+                "basis": "after",
+                "row": {
                   "id": "c4",
                   "issueID": "i2",
                 },
@@ -275,6 +315,28 @@ suite('EXISTS 1 to many', () => {
           "push",
           {
             "row": {
+              "id": "c3",
+              "issueID": "i1",
+            },
+            "type": "add",
+          },
+        ],
+        [
+          ":take",
+          "push",
+          {
+            "row": {
+              "id": "c2",
+              "issueID": "i1",
+            },
+            "type": "remove",
+          },
+        ],
+        [
+          ":take",
+          "push",
+          {
+            "row": {
               "id": "c4",
               "issueID": "i2",
             },
@@ -286,7 +348,7 @@ suite('EXISTS 1 to many', () => {
           "push",
           {
             "row": {
-              "id": "c2",
+              "id": "c3",
               "issueID": "i1",
             },
             "type": "remove",
@@ -312,6 +374,46 @@ suite('EXISTS 1 to many', () => {
             },
             "row": {
               "id": "c1",
+              "issueID": "i1",
+            },
+          },
+          "type": "remove",
+        },
+        {
+          "node": {
+            "relationships": {
+              "issue": [
+                {
+                  "relationships": {},
+                  "row": {
+                    "id": "i1",
+                    "title": "issue 1",
+                  },
+                },
+              ],
+            },
+            "row": {
+              "id": "c3",
+              "issueID": "i1",
+            },
+          },
+          "type": "add",
+        },
+        {
+          "node": {
+            "relationships": {
+              "issue": [
+                {
+                  "relationships": {},
+                  "row": {
+                    "id": "i1",
+                    "title": "issue 1",
+                  },
+                },
+              ],
+            },
+            "row": {
+              "id": "c2",
               "issueID": "i1",
             },
           },
@@ -351,7 +453,7 @@ suite('EXISTS 1 to many', () => {
               ],
             },
             "row": {
-              "id": "c2",
+              "id": "c3",
               "issueID": "i1",
             },
           },

--- a/packages/zql/src/ivm/exists.ts
+++ b/packages/zql/src/ivm/exists.ts
@@ -196,11 +196,7 @@ export class Exists implements Operator {
             case 'remove': {
               let size = this.#getSize(change.node);
               if (size !== undefined) {
-                // Work around for issue https://bugs.rocicorp.dev/issue/3204
-                // assert(size > 0);
-                if (size === 0) {
-                  return;
-                }
+                assert(size > 0);
                 size--;
                 this.#setSize(change.node, size);
               } else {

--- a/packages/zql/src/ivm/join.push.test.ts
+++ b/packages/zql/src/ivm/join.push.test.ts
@@ -5845,7 +5845,7 @@ suite('test overlay on many:one pushes', () => {
     },
   } as const;
 
-  test('fetch two parents, add one child', () => {
+  test('add child', () => {
     const {log, data, actualStorage, pushesWithFetch} = runPushTest({
       sources,
       sourceContents: {
@@ -6246,7 +6246,7 @@ suite('test overlay on many:one pushes', () => {
     `);
   });
 
-  test('fetch two parents with one child, remove one child', () => {
+  test('remove child', () => {
     const {log, data, actualStorage, pushesWithFetch} = runPushTest({
       sources,
       sourceContents: {
@@ -6626,7 +6626,7 @@ suite('test overlay on many:one pushes', () => {
     `);
   });
 
-  test('fetch two parents with one child, edit child', () => {
+  test('edit child', () => {
     const {log, data, actualStorage, pushesWithFetch} = runPushTest({
       sources,
       sourceContents: {
@@ -7059,7 +7059,7 @@ suite('test overlay on many:one pushes', () => {
     `);
   });
 
-  test('fetch two parents with one child and one grandchild, edit grandchild', () => {
+  test('edit grandchild', () => {
     const sources: Sources = {
       issue: {
         columns: {
@@ -8209,6 +8209,3547 @@ suite('test overlay on many:one pushes', () => {
               "row": {
                 "id": "i3",
                 "ownerID": "u2",
+              },
+            },
+          ],
+        },
+      ]
+    `);
+  });
+});
+
+suite('test overlay on many:many (no junction) pushes', () => {
+  const sources: Sources = {
+    issue: {
+      columns: {
+        id: {type: 'string'},
+        ownerName: {type: 'string'},
+      },
+      primaryKeys: ['id'],
+    },
+    user: {
+      columns: {
+        id: {type: 'string'},
+        name: {type: 'string'},
+        num: {type: 'number'},
+      },
+      primaryKeys: ['id'],
+    },
+  } as const;
+
+  const ast: AST = {
+    table: 'issue',
+    orderBy: [['id', 'asc']],
+    related: [
+      {
+        system: 'client',
+        correlation: {parentField: ['ownerName'], childField: ['name']},
+        subquery: {
+          table: 'user',
+          alias: 'ownerByName',
+          orderBy: [
+            ['num', 'asc'],
+            ['id', 'asc'],
+          ],
+        },
+      },
+    ],
+  } as const;
+
+  const format: Format = {
+    singular: false,
+    relationships: {
+      ownerByName: {
+        singular: false,
+        relationships: {},
+      },
+    },
+  } as const;
+
+  test('add child', () => {
+    const {log, data, actualStorage, pushesWithFetch} = runPushTest({
+      sources,
+      sourceContents: {
+        issue: [
+          {id: 'i0', ownerName: 'Fritz'},
+          {id: 'i1', ownerName: 'Aaron'},
+          {id: 'i2', ownerName: 'Aaron'},
+          {id: 'i3', ownerName: 'Arv'},
+        ],
+        user: [
+          {id: 'u0', name: 'Fritz', num: 0},
+          {id: 'u1', name: 'Aaron', num: 1},
+          {id: 'u3', name: 'Aaron', num: 3},
+          {id: 'u4', name: 'Arv', num: 4},
+        ],
+      },
+      ast,
+      format,
+      pushes: [['user', {type: 'add', row: {id: 'u2', name: 'Aaron', num: 2}}]],
+      fetchOnPush: true,
+    });
+
+    expect(log).toMatchInlineSnapshot(`
+      [
+        [
+          ".ownerByName:source(user)",
+          "push",
+          {
+            "row": {
+              "id": "u2",
+              "name": "Aaron",
+              "num": 2,
+            },
+            "type": "add",
+          },
+        ],
+        [
+          ":source(issue)",
+          "fetch",
+          {
+            "constraint": {
+              "ownerName": "Aaron",
+            },
+          },
+        ],
+        [
+          ":join(ownerByName)",
+          "push",
+          {
+            "child": {
+              "row": {
+                "id": "u2",
+                "name": "Aaron",
+                "num": 2,
+              },
+              "type": "add",
+            },
+            "row": {
+              "id": "i1",
+              "ownerName": "Aaron",
+            },
+            "type": "child",
+          },
+        ],
+        [
+          ":join(ownerByName)",
+          "fetch",
+          {},
+        ],
+        [
+          ":source(issue)",
+          "fetch",
+          {},
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Fritz",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Aaron",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Aaron",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Arv",
+            },
+          },
+        ],
+        [
+          ":join(ownerByName)",
+          "push",
+          {
+            "child": {
+              "row": {
+                "id": "u2",
+                "name": "Aaron",
+                "num": 2,
+              },
+              "type": "add",
+            },
+            "row": {
+              "id": "i2",
+              "ownerName": "Aaron",
+            },
+            "type": "child",
+          },
+        ],
+        [
+          ":join(ownerByName)",
+          "fetch",
+          {},
+        ],
+        [
+          ":source(issue)",
+          "fetch",
+          {},
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Fritz",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Aaron",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Aaron",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Arv",
+            },
+          },
+        ],
+      ]
+    `);
+    expect(data).toMatchInlineSnapshot(`
+      [
+        {
+          "id": "i0",
+          "ownerByName": [
+            {
+              "id": "u0",
+              "name": "Fritz",
+              "num": 0,
+            },
+          ],
+          "ownerName": "Fritz",
+        },
+        {
+          "id": "i1",
+          "ownerByName": [
+            {
+              "id": "u1",
+              "name": "Aaron",
+              "num": 1,
+            },
+            {
+              "id": "u2",
+              "name": "Aaron",
+              "num": 2,
+            },
+            {
+              "id": "u3",
+              "name": "Aaron",
+              "num": 3,
+            },
+          ],
+          "ownerName": "Aaron",
+        },
+        {
+          "id": "i2",
+          "ownerByName": [
+            {
+              "id": "u1",
+              "name": "Aaron",
+              "num": 1,
+            },
+            {
+              "id": "u2",
+              "name": "Aaron",
+              "num": 2,
+            },
+            {
+              "id": "u3",
+              "name": "Aaron",
+              "num": 3,
+            },
+          ],
+          "ownerName": "Aaron",
+        },
+        {
+          "id": "i3",
+          "ownerByName": [
+            {
+              "id": "u4",
+              "name": "Arv",
+              "num": 4,
+            },
+          ],
+          "ownerName": "Arv",
+        },
+      ]
+    `);
+    expect(actualStorage).toMatchInlineSnapshot(`
+      {
+        ":join(ownerByName)": {
+          ""pKeySet","Aaron","i1",": true,
+          ""pKeySet","Aaron","i2",": true,
+          ""pKeySet","Arv","i3",": true,
+          ""pKeySet","Fritz","i0",": true,
+        },
+      }
+    `);
+    expect(pushesWithFetch).toMatchInlineSnapshot(`
+      [
+        {
+          "change": {
+            "child": {
+              "change": {
+                "node": {
+                  "relationships": {},
+                  "row": {
+                    "id": "u2",
+                    "name": "Aaron",
+                    "num": 2,
+                  },
+                },
+                "type": "add",
+              },
+              "relationshipName": "ownerByName",
+            },
+            "row": {
+              "id": "i1",
+              "ownerName": "Aaron",
+            },
+            "type": "child",
+          },
+          "fetch": [
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u0",
+                      "name": "Fritz",
+                      "num": 0,
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i0",
+                "ownerName": "Fritz",
+              },
+            },
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u1",
+                      "name": "Aaron",
+                      "num": 1,
+                    },
+                  },
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u2",
+                      "name": "Aaron",
+                      "num": 2,
+                    },
+                  },
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u3",
+                      "name": "Aaron",
+                      "num": 3,
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i1",
+                "ownerName": "Aaron",
+              },
+            },
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u1",
+                      "name": "Aaron",
+                      "num": 1,
+                    },
+                  },
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u3",
+                      "name": "Aaron",
+                      "num": 3,
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i2",
+                "ownerName": "Aaron",
+              },
+            },
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u4",
+                      "name": "Arv",
+                      "num": 4,
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i3",
+                "ownerName": "Arv",
+              },
+            },
+          ],
+        },
+        {
+          "change": {
+            "child": {
+              "change": {
+                "node": {
+                  "relationships": {},
+                  "row": {
+                    "id": "u2",
+                    "name": "Aaron",
+                    "num": 2,
+                  },
+                },
+                "type": "add",
+              },
+              "relationshipName": "ownerByName",
+            },
+            "row": {
+              "id": "i2",
+              "ownerName": "Aaron",
+            },
+            "type": "child",
+          },
+          "fetch": [
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u0",
+                      "name": "Fritz",
+                      "num": 0,
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i0",
+                "ownerName": "Fritz",
+              },
+            },
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u1",
+                      "name": "Aaron",
+                      "num": 1,
+                    },
+                  },
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u2",
+                      "name": "Aaron",
+                      "num": 2,
+                    },
+                  },
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u3",
+                      "name": "Aaron",
+                      "num": 3,
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i1",
+                "ownerName": "Aaron",
+              },
+            },
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u1",
+                      "name": "Aaron",
+                      "num": 1,
+                    },
+                  },
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u2",
+                      "name": "Aaron",
+                      "num": 2,
+                    },
+                  },
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u3",
+                      "name": "Aaron",
+                      "num": 3,
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i2",
+                "ownerName": "Aaron",
+              },
+            },
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u4",
+                      "name": "Arv",
+                      "num": 4,
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i3",
+                "ownerName": "Arv",
+              },
+            },
+          ],
+        },
+      ]
+    `);
+  });
+
+  test('remove child', () => {
+    const {log, data, actualStorage, pushesWithFetch} = runPushTest({
+      sources,
+      sourceContents: {
+        issue: [
+          {id: 'i0', ownerName: 'Fritz'},
+          {id: 'i1', ownerName: 'Aaron'},
+          {id: 'i2', ownerName: 'Aaron'},
+          {id: 'i3', ownerName: 'Arv'},
+        ],
+        user: [
+          {id: 'u0', name: 'Fritz', num: 0},
+          {id: 'u1', name: 'Aaron', num: 1},
+          {id: 'u2', name: 'Aaron', num: 2},
+          {id: 'u3', name: 'Aaron', num: 3},
+          {id: 'u4', name: 'Arv', num: 4},
+        ],
+      },
+      ast,
+      format,
+      pushes: [
+        ['user', {type: 'remove', row: {id: 'u2', name: 'Aaron', num: 2}}],
+      ],
+      fetchOnPush: true,
+    });
+
+    expect(log).toMatchInlineSnapshot(`
+      [
+        [
+          ".ownerByName:source(user)",
+          "push",
+          {
+            "row": {
+              "id": "u2",
+              "name": "Aaron",
+              "num": 2,
+            },
+            "type": "remove",
+          },
+        ],
+        [
+          ":source(issue)",
+          "fetch",
+          {
+            "constraint": {
+              "ownerName": "Aaron",
+            },
+          },
+        ],
+        [
+          ":join(ownerByName)",
+          "push",
+          {
+            "child": {
+              "row": {
+                "id": "u2",
+                "name": "Aaron",
+                "num": 2,
+              },
+              "type": "remove",
+            },
+            "row": {
+              "id": "i1",
+              "ownerName": "Aaron",
+            },
+            "type": "child",
+          },
+        ],
+        [
+          ":join(ownerByName)",
+          "fetch",
+          {},
+        ],
+        [
+          ":source(issue)",
+          "fetch",
+          {},
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Fritz",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Aaron",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Aaron",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Arv",
+            },
+          },
+        ],
+        [
+          ":join(ownerByName)",
+          "push",
+          {
+            "child": {
+              "row": {
+                "id": "u2",
+                "name": "Aaron",
+                "num": 2,
+              },
+              "type": "remove",
+            },
+            "row": {
+              "id": "i2",
+              "ownerName": "Aaron",
+            },
+            "type": "child",
+          },
+        ],
+        [
+          ":join(ownerByName)",
+          "fetch",
+          {},
+        ],
+        [
+          ":source(issue)",
+          "fetch",
+          {},
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Fritz",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Aaron",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Aaron",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Arv",
+            },
+          },
+        ],
+      ]
+    `);
+    expect(data).toMatchInlineSnapshot(`
+      [
+        {
+          "id": "i0",
+          "ownerByName": [
+            {
+              "id": "u0",
+              "name": "Fritz",
+              "num": 0,
+            },
+          ],
+          "ownerName": "Fritz",
+        },
+        {
+          "id": "i1",
+          "ownerByName": [
+            {
+              "id": "u1",
+              "name": "Aaron",
+              "num": 1,
+            },
+            {
+              "id": "u3",
+              "name": "Aaron",
+              "num": 3,
+            },
+          ],
+          "ownerName": "Aaron",
+        },
+        {
+          "id": "i2",
+          "ownerByName": [
+            {
+              "id": "u1",
+              "name": "Aaron",
+              "num": 1,
+            },
+            {
+              "id": "u3",
+              "name": "Aaron",
+              "num": 3,
+            },
+          ],
+          "ownerName": "Aaron",
+        },
+        {
+          "id": "i3",
+          "ownerByName": [
+            {
+              "id": "u4",
+              "name": "Arv",
+              "num": 4,
+            },
+          ],
+          "ownerName": "Arv",
+        },
+      ]
+    `);
+    expect(actualStorage).toMatchInlineSnapshot(`
+      {
+        ":join(ownerByName)": {
+          ""pKeySet","Aaron","i1",": true,
+          ""pKeySet","Aaron","i2",": true,
+          ""pKeySet","Arv","i3",": true,
+          ""pKeySet","Fritz","i0",": true,
+        },
+      }
+    `);
+    expect(pushesWithFetch).toMatchInlineSnapshot(`
+      [
+        {
+          "change": {
+            "child": {
+              "change": {
+                "node": {
+                  "relationships": {},
+                  "row": {
+                    "id": "u2",
+                    "name": "Aaron",
+                    "num": 2,
+                  },
+                },
+                "type": "remove",
+              },
+              "relationshipName": "ownerByName",
+            },
+            "row": {
+              "id": "i1",
+              "ownerName": "Aaron",
+            },
+            "type": "child",
+          },
+          "fetch": [
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u0",
+                      "name": "Fritz",
+                      "num": 0,
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i0",
+                "ownerName": "Fritz",
+              },
+            },
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u1",
+                      "name": "Aaron",
+                      "num": 1,
+                    },
+                  },
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u3",
+                      "name": "Aaron",
+                      "num": 3,
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i1",
+                "ownerName": "Aaron",
+              },
+            },
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u1",
+                      "name": "Aaron",
+                      "num": 1,
+                    },
+                  },
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u2",
+                      "name": "Aaron",
+                      "num": 2,
+                    },
+                  },
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u3",
+                      "name": "Aaron",
+                      "num": 3,
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i2",
+                "ownerName": "Aaron",
+              },
+            },
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u4",
+                      "name": "Arv",
+                      "num": 4,
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i3",
+                "ownerName": "Arv",
+              },
+            },
+          ],
+        },
+        {
+          "change": {
+            "child": {
+              "change": {
+                "node": {
+                  "relationships": {},
+                  "row": {
+                    "id": "u2",
+                    "name": "Aaron",
+                    "num": 2,
+                  },
+                },
+                "type": "remove",
+              },
+              "relationshipName": "ownerByName",
+            },
+            "row": {
+              "id": "i2",
+              "ownerName": "Aaron",
+            },
+            "type": "child",
+          },
+          "fetch": [
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u0",
+                      "name": "Fritz",
+                      "num": 0,
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i0",
+                "ownerName": "Fritz",
+              },
+            },
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u1",
+                      "name": "Aaron",
+                      "num": 1,
+                    },
+                  },
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u3",
+                      "name": "Aaron",
+                      "num": 3,
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i1",
+                "ownerName": "Aaron",
+              },
+            },
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u1",
+                      "name": "Aaron",
+                      "num": 1,
+                    },
+                  },
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u3",
+                      "name": "Aaron",
+                      "num": 3,
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i2",
+                "ownerName": "Aaron",
+              },
+            },
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u4",
+                      "name": "Arv",
+                      "num": 4,
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i3",
+                "ownerName": "Arv",
+              },
+            },
+          ],
+        },
+      ]
+    `);
+  });
+
+  test('edit child', () => {
+    const {log, data, actualStorage, pushesWithFetch} = runPushTest({
+      sources,
+      sourceContents: {
+        issue: [
+          {id: 'i0', ownerName: 'Fritz'},
+          {id: 'i1', ownerName: 'Aaron'},
+          {id: 'i2', ownerName: 'Aaron'},
+          {id: 'i3', ownerName: 'Arv'},
+        ],
+        user: [
+          {id: 'u0', name: 'Fritz', num: 0},
+          {id: 'u1', name: 'Aaron', num: 1},
+          {id: 'u2', name: 'Aaron', num: 2},
+          {id: 'u3', name: 'Aaron', num: 3},
+          {id: 'u4', name: 'Arv', num: 4},
+        ],
+      },
+      ast,
+      format,
+      pushes: [
+        [
+          'user',
+          {
+            type: 'edit',
+            oldRow: {id: 'u2', name: 'Aaron', num: 2},
+            row: {id: 'u2', name: 'Aaron', num: 5},
+          },
+        ],
+      ],
+      fetchOnPush: true,
+    });
+
+    expect(log).toMatchInlineSnapshot(`
+      [
+        [
+          ".ownerByName:source(user)",
+          "push",
+          {
+            "oldRow": {
+              "id": "u2",
+              "name": "Aaron",
+              "num": 2,
+            },
+            "row": {
+              "id": "u2",
+              "name": "Aaron",
+              "num": 5,
+            },
+            "type": "edit",
+          },
+        ],
+        [
+          ":source(issue)",
+          "fetch",
+          {
+            "constraint": {
+              "ownerName": "Aaron",
+            },
+          },
+        ],
+        [
+          ":join(ownerByName)",
+          "push",
+          {
+            "child": {
+              "oldRow": {
+                "id": "u2",
+                "name": "Aaron",
+                "num": 2,
+              },
+              "row": {
+                "id": "u2",
+                "name": "Aaron",
+                "num": 5,
+              },
+              "type": "edit",
+            },
+            "row": {
+              "id": "i1",
+              "ownerName": "Aaron",
+            },
+            "type": "child",
+          },
+        ],
+        [
+          ":join(ownerByName)",
+          "fetch",
+          {},
+        ],
+        [
+          ":source(issue)",
+          "fetch",
+          {},
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Fritz",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Aaron",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Aaron",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Arv",
+            },
+          },
+        ],
+        [
+          ":join(ownerByName)",
+          "push",
+          {
+            "child": {
+              "oldRow": {
+                "id": "u2",
+                "name": "Aaron",
+                "num": 2,
+              },
+              "row": {
+                "id": "u2",
+                "name": "Aaron",
+                "num": 5,
+              },
+              "type": "edit",
+            },
+            "row": {
+              "id": "i2",
+              "ownerName": "Aaron",
+            },
+            "type": "child",
+          },
+        ],
+        [
+          ":join(ownerByName)",
+          "fetch",
+          {},
+        ],
+        [
+          ":source(issue)",
+          "fetch",
+          {},
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Fritz",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Aaron",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Aaron",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Arv",
+            },
+          },
+        ],
+      ]
+    `);
+    expect(data).toMatchInlineSnapshot(`
+      [
+        {
+          "id": "i0",
+          "ownerByName": [
+            {
+              "id": "u0",
+              "name": "Fritz",
+              "num": 0,
+            },
+          ],
+          "ownerName": "Fritz",
+        },
+        {
+          "id": "i1",
+          "ownerByName": [
+            {
+              "id": "u1",
+              "name": "Aaron",
+              "num": 1,
+            },
+            {
+              "id": "u3",
+              "name": "Aaron",
+              "num": 3,
+            },
+            {
+              "id": "u2",
+              "name": "Aaron",
+              "num": 5,
+            },
+          ],
+          "ownerName": "Aaron",
+        },
+        {
+          "id": "i2",
+          "ownerByName": [
+            {
+              "id": "u1",
+              "name": "Aaron",
+              "num": 1,
+            },
+            {
+              "id": "u3",
+              "name": "Aaron",
+              "num": 3,
+            },
+            {
+              "id": "u2",
+              "name": "Aaron",
+              "num": 5,
+            },
+          ],
+          "ownerName": "Aaron",
+        },
+        {
+          "id": "i3",
+          "ownerByName": [
+            {
+              "id": "u4",
+              "name": "Arv",
+              "num": 4,
+            },
+          ],
+          "ownerName": "Arv",
+        },
+      ]
+    `);
+    expect(actualStorage).toMatchInlineSnapshot(`
+      {
+        ":join(ownerByName)": {
+          ""pKeySet","Aaron","i1",": true,
+          ""pKeySet","Aaron","i2",": true,
+          ""pKeySet","Arv","i3",": true,
+          ""pKeySet","Fritz","i0",": true,
+        },
+      }
+    `);
+    expect(pushesWithFetch).toMatchInlineSnapshot(`
+      [
+        {
+          "change": {
+            "child": {
+              "change": {
+                "oldRow": {
+                  "id": "u2",
+                  "name": "Aaron",
+                  "num": 2,
+                },
+                "row": {
+                  "id": "u2",
+                  "name": "Aaron",
+                  "num": 5,
+                },
+                "type": "edit",
+              },
+              "relationshipName": "ownerByName",
+            },
+            "row": {
+              "id": "i1",
+              "ownerName": "Aaron",
+            },
+            "type": "child",
+          },
+          "fetch": [
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u0",
+                      "name": "Fritz",
+                      "num": 0,
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i0",
+                "ownerName": "Fritz",
+              },
+            },
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u1",
+                      "name": "Aaron",
+                      "num": 1,
+                    },
+                  },
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u3",
+                      "name": "Aaron",
+                      "num": 3,
+                    },
+                  },
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u2",
+                      "name": "Aaron",
+                      "num": 5,
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i1",
+                "ownerName": "Aaron",
+              },
+            },
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u1",
+                      "name": "Aaron",
+                      "num": 1,
+                    },
+                  },
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u2",
+                      "name": "Aaron",
+                      "num": 2,
+                    },
+                  },
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u3",
+                      "name": "Aaron",
+                      "num": 3,
+                    },
+                  },
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u2",
+                      "name": "Aaron",
+                      "num": 2,
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i2",
+                "ownerName": "Aaron",
+              },
+            },
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u4",
+                      "name": "Arv",
+                      "num": 4,
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i3",
+                "ownerName": "Arv",
+              },
+            },
+          ],
+        },
+        {
+          "change": {
+            "child": {
+              "change": {
+                "oldRow": {
+                  "id": "u2",
+                  "name": "Aaron",
+                  "num": 2,
+                },
+                "row": {
+                  "id": "u2",
+                  "name": "Aaron",
+                  "num": 5,
+                },
+                "type": "edit",
+              },
+              "relationshipName": "ownerByName",
+            },
+            "row": {
+              "id": "i2",
+              "ownerName": "Aaron",
+            },
+            "type": "child",
+          },
+          "fetch": [
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u0",
+                      "name": "Fritz",
+                      "num": 0,
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i0",
+                "ownerName": "Fritz",
+              },
+            },
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u1",
+                      "name": "Aaron",
+                      "num": 1,
+                    },
+                  },
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u3",
+                      "name": "Aaron",
+                      "num": 3,
+                    },
+                  },
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u2",
+                      "name": "Aaron",
+                      "num": 5,
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i1",
+                "ownerName": "Aaron",
+              },
+            },
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u1",
+                      "name": "Aaron",
+                      "num": 1,
+                    },
+                  },
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u3",
+                      "name": "Aaron",
+                      "num": 3,
+                    },
+                  },
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u2",
+                      "name": "Aaron",
+                      "num": 5,
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i2",
+                "ownerName": "Aaron",
+              },
+            },
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {},
+                    "row": {
+                      "id": "u4",
+                      "name": "Arv",
+                      "num": 4,
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i3",
+                "ownerName": "Arv",
+              },
+            },
+          ],
+        },
+      ]
+    `);
+  });
+
+  test('edit grandchild', () => {
+    const sources: Sources = {
+      issue: {
+        columns: {
+          id: {type: 'string'},
+          ownerName: {type: 'string'},
+        },
+        primaryKeys: ['id'],
+      },
+      user: {
+        columns: {
+          id: {type: 'string'},
+          name: {type: 'string'},
+          stateID: {type: 'string'},
+        },
+        primaryKeys: ['id'],
+      },
+      state: {
+        columns: {
+          id: {type: 'string'},
+          name: {type: 'string'},
+        },
+        primaryKeys: ['id'],
+      },
+    } as const;
+
+    const ast: AST = {
+      table: 'issue',
+      orderBy: [['id', 'asc']],
+      related: [
+        {
+          system: 'client',
+          correlation: {parentField: ['ownerName'], childField: ['name']},
+          subquery: {
+            table: 'user',
+            alias: 'ownerByName',
+            orderBy: [['id', 'asc']],
+            related: [
+              {
+                system: 'client',
+                correlation: {parentField: ['stateID'], childField: ['id']},
+                subquery: {
+                  table: 'state',
+                  alias: 'state',
+                  orderBy: [['id', 'asc']],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    } as const;
+
+    const format: Format = {
+      singular: false,
+      relationships: {
+        ownerByName: {
+          singular: false,
+          relationships: {
+            state: {
+              singular: true,
+              relationships: {},
+            },
+          },
+        },
+      },
+    } as const;
+    const {log, data, actualStorage, pushesWithFetch} = runPushTest({
+      sources,
+      sourceContents: {
+        issue: [
+          {id: 'i0', ownerName: 'Fritz'},
+          {id: 'i1', ownerName: 'Aaron'},
+          {id: 'i2', ownerName: 'Aaron'},
+          {id: 'i3', ownerName: 'Arv'},
+        ],
+        user: [
+          {id: 'u0', name: 'Fritz', stateID: 's1'},
+          {id: 'u1', name: 'Aaron', stateID: 's1'},
+          {id: 'u2', name: 'Aaron', stateID: 's0'},
+          {id: 'u3', name: 'Aaron', stateID: 's0'},
+          {id: 'u4', name: 'Arv', stateID: 's1'},
+        ],
+        state: [
+          {id: 's0', name: 'Hawaii'},
+          {id: 's1', name: 'CA'},
+        ],
+      },
+      ast,
+      format,
+      pushes: [
+        [
+          'state',
+          {
+            type: 'edit',
+            oldRow: {id: 's0', name: 'Hawaii'},
+            row: {id: 's0', name: 'HI'},
+          },
+        ],
+      ],
+      fetchOnPush: true,
+    });
+
+    expect(log).toMatchInlineSnapshot(`
+      [
+        [
+          ".ownerByName.state:source(state)",
+          "push",
+          {
+            "oldRow": {
+              "id": "s0",
+              "name": "Hawaii",
+            },
+            "row": {
+              "id": "s0",
+              "name": "HI",
+            },
+            "type": "edit",
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "stateID": "s0",
+            },
+          },
+        ],
+        [
+          ".ownerByName:join(state)",
+          "push",
+          {
+            "child": {
+              "oldRow": {
+                "id": "s0",
+                "name": "Hawaii",
+              },
+              "row": {
+                "id": "s0",
+                "name": "HI",
+              },
+              "type": "edit",
+            },
+            "row": {
+              "id": "u2",
+              "name": "Aaron",
+              "stateID": "s0",
+            },
+            "type": "child",
+          },
+        ],
+        [
+          ":source(issue)",
+          "fetch",
+          {
+            "constraint": {
+              "ownerName": "Aaron",
+            },
+          },
+        ],
+        [
+          ":join(ownerByName)",
+          "push",
+          {
+            "child": {
+              "child": {
+                "oldRow": {
+                  "id": "s0",
+                  "name": "Hawaii",
+                },
+                "row": {
+                  "id": "s0",
+                  "name": "HI",
+                },
+                "type": "edit",
+              },
+              "row": {
+                "id": "u2",
+                "name": "Aaron",
+                "stateID": "s0",
+              },
+              "type": "child",
+            },
+            "row": {
+              "id": "i1",
+              "ownerName": "Aaron",
+            },
+            "type": "child",
+          },
+        ],
+        [
+          ":join(ownerByName)",
+          "fetch",
+          {},
+        ],
+        [
+          ":source(issue)",
+          "fetch",
+          {},
+        ],
+        [
+          ".ownerByName:join(state)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Fritz",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Fritz",
+            },
+          },
+        ],
+        [
+          ".ownerByName.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s1",
+            },
+          },
+        ],
+        [
+          ".ownerByName:join(state)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Aaron",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Aaron",
+            },
+          },
+        ],
+        [
+          ".ownerByName.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s1",
+            },
+          },
+        ],
+        [
+          ".ownerByName.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s0",
+            },
+          },
+        ],
+        [
+          ".ownerByName.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s0",
+            },
+          },
+        ],
+        [
+          ".ownerByName:join(state)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Aaron",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Aaron",
+            },
+          },
+        ],
+        [
+          ".ownerByName.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s1",
+            },
+          },
+        ],
+        [
+          ".ownerByName.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s0",
+            },
+          },
+        ],
+        [
+          ".ownerByName.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s0",
+            },
+          },
+        ],
+        [
+          ".ownerByName:join(state)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Arv",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Arv",
+            },
+          },
+        ],
+        [
+          ".ownerByName.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s1",
+            },
+          },
+        ],
+        [
+          ":join(ownerByName)",
+          "push",
+          {
+            "child": {
+              "child": {
+                "oldRow": {
+                  "id": "s0",
+                  "name": "Hawaii",
+                },
+                "row": {
+                  "id": "s0",
+                  "name": "HI",
+                },
+                "type": "edit",
+              },
+              "row": {
+                "id": "u2",
+                "name": "Aaron",
+                "stateID": "s0",
+              },
+              "type": "child",
+            },
+            "row": {
+              "id": "i2",
+              "ownerName": "Aaron",
+            },
+            "type": "child",
+          },
+        ],
+        [
+          ":join(ownerByName)",
+          "fetch",
+          {},
+        ],
+        [
+          ":source(issue)",
+          "fetch",
+          {},
+        ],
+        [
+          ".ownerByName:join(state)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Fritz",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Fritz",
+            },
+          },
+        ],
+        [
+          ".ownerByName.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s1",
+            },
+          },
+        ],
+        [
+          ".ownerByName:join(state)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Aaron",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Aaron",
+            },
+          },
+        ],
+        [
+          ".ownerByName.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s1",
+            },
+          },
+        ],
+        [
+          ".ownerByName.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s0",
+            },
+          },
+        ],
+        [
+          ".ownerByName.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s0",
+            },
+          },
+        ],
+        [
+          ".ownerByName:join(state)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Aaron",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Aaron",
+            },
+          },
+        ],
+        [
+          ".ownerByName.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s1",
+            },
+          },
+        ],
+        [
+          ".ownerByName.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s0",
+            },
+          },
+        ],
+        [
+          ".ownerByName.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s0",
+            },
+          },
+        ],
+        [
+          ".ownerByName:join(state)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Arv",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Arv",
+            },
+          },
+        ],
+        [
+          ".ownerByName.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s1",
+            },
+          },
+        ],
+        [
+          ".ownerByName:join(state)",
+          "push",
+          {
+            "child": {
+              "oldRow": {
+                "id": "s0",
+                "name": "Hawaii",
+              },
+              "row": {
+                "id": "s0",
+                "name": "HI",
+              },
+              "type": "edit",
+            },
+            "row": {
+              "id": "u3",
+              "name": "Aaron",
+              "stateID": "s0",
+            },
+            "type": "child",
+          },
+        ],
+        [
+          ":source(issue)",
+          "fetch",
+          {
+            "constraint": {
+              "ownerName": "Aaron",
+            },
+          },
+        ],
+        [
+          ":join(ownerByName)",
+          "push",
+          {
+            "child": {
+              "child": {
+                "oldRow": {
+                  "id": "s0",
+                  "name": "Hawaii",
+                },
+                "row": {
+                  "id": "s0",
+                  "name": "HI",
+                },
+                "type": "edit",
+              },
+              "row": {
+                "id": "u3",
+                "name": "Aaron",
+                "stateID": "s0",
+              },
+              "type": "child",
+            },
+            "row": {
+              "id": "i1",
+              "ownerName": "Aaron",
+            },
+            "type": "child",
+          },
+        ],
+        [
+          ":join(ownerByName)",
+          "fetch",
+          {},
+        ],
+        [
+          ":source(issue)",
+          "fetch",
+          {},
+        ],
+        [
+          ".ownerByName:join(state)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Fritz",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Fritz",
+            },
+          },
+        ],
+        [
+          ".ownerByName.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s1",
+            },
+          },
+        ],
+        [
+          ".ownerByName:join(state)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Aaron",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Aaron",
+            },
+          },
+        ],
+        [
+          ".ownerByName.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s1",
+            },
+          },
+        ],
+        [
+          ".ownerByName.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s0",
+            },
+          },
+        ],
+        [
+          ".ownerByName.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s0",
+            },
+          },
+        ],
+        [
+          ".ownerByName:join(state)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Aaron",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Aaron",
+            },
+          },
+        ],
+        [
+          ".ownerByName.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s1",
+            },
+          },
+        ],
+        [
+          ".ownerByName.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s0",
+            },
+          },
+        ],
+        [
+          ".ownerByName.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s0",
+            },
+          },
+        ],
+        [
+          ".ownerByName:join(state)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Arv",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Arv",
+            },
+          },
+        ],
+        [
+          ".ownerByName.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s1",
+            },
+          },
+        ],
+        [
+          ":join(ownerByName)",
+          "push",
+          {
+            "child": {
+              "child": {
+                "oldRow": {
+                  "id": "s0",
+                  "name": "Hawaii",
+                },
+                "row": {
+                  "id": "s0",
+                  "name": "HI",
+                },
+                "type": "edit",
+              },
+              "row": {
+                "id": "u3",
+                "name": "Aaron",
+                "stateID": "s0",
+              },
+              "type": "child",
+            },
+            "row": {
+              "id": "i2",
+              "ownerName": "Aaron",
+            },
+            "type": "child",
+          },
+        ],
+        [
+          ":join(ownerByName)",
+          "fetch",
+          {},
+        ],
+        [
+          ":source(issue)",
+          "fetch",
+          {},
+        ],
+        [
+          ".ownerByName:join(state)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Fritz",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Fritz",
+            },
+          },
+        ],
+        [
+          ".ownerByName.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s1",
+            },
+          },
+        ],
+        [
+          ".ownerByName:join(state)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Aaron",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Aaron",
+            },
+          },
+        ],
+        [
+          ".ownerByName.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s1",
+            },
+          },
+        ],
+        [
+          ".ownerByName.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s0",
+            },
+          },
+        ],
+        [
+          ".ownerByName.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s0",
+            },
+          },
+        ],
+        [
+          ".ownerByName:join(state)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Aaron",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Aaron",
+            },
+          },
+        ],
+        [
+          ".ownerByName.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s1",
+            },
+          },
+        ],
+        [
+          ".ownerByName.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s0",
+            },
+          },
+        ],
+        [
+          ".ownerByName.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s0",
+            },
+          },
+        ],
+        [
+          ".ownerByName:join(state)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Arv",
+            },
+          },
+        ],
+        [
+          ".ownerByName:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "name": "Arv",
+            },
+          },
+        ],
+        [
+          ".ownerByName.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s1",
+            },
+          },
+        ],
+      ]
+    `);
+    expect(data).toMatchInlineSnapshot(`
+      [
+        {
+          "id": "i0",
+          "ownerByName": [
+            {
+              "id": "u0",
+              "name": "Fritz",
+              "state": {
+                "id": "s1",
+                "name": "CA",
+              },
+              "stateID": "s1",
+            },
+          ],
+          "ownerName": "Fritz",
+        },
+        {
+          "id": "i1",
+          "ownerByName": [
+            {
+              "id": "u1",
+              "name": "Aaron",
+              "state": {
+                "id": "s1",
+                "name": "CA",
+              },
+              "stateID": "s1",
+            },
+            {
+              "id": "u2",
+              "name": "Aaron",
+              "state": {
+                "id": "s0",
+                "name": "HI",
+              },
+              "stateID": "s0",
+            },
+            {
+              "id": "u3",
+              "name": "Aaron",
+              "state": {
+                "id": "s0",
+                "name": "HI",
+              },
+              "stateID": "s0",
+            },
+          ],
+          "ownerName": "Aaron",
+        },
+        {
+          "id": "i2",
+          "ownerByName": [
+            {
+              "id": "u1",
+              "name": "Aaron",
+              "state": {
+                "id": "s1",
+                "name": "CA",
+              },
+              "stateID": "s1",
+            },
+            {
+              "id": "u2",
+              "name": "Aaron",
+              "state": {
+                "id": "s0",
+                "name": "HI",
+              },
+              "stateID": "s0",
+            },
+            {
+              "id": "u3",
+              "name": "Aaron",
+              "state": {
+                "id": "s0",
+                "name": "HI",
+              },
+              "stateID": "s0",
+            },
+          ],
+          "ownerName": "Aaron",
+        },
+        {
+          "id": "i3",
+          "ownerByName": [
+            {
+              "id": "u4",
+              "name": "Arv",
+              "state": {
+                "id": "s1",
+                "name": "CA",
+              },
+              "stateID": "s1",
+            },
+          ],
+          "ownerName": "Arv",
+        },
+      ]
+    `);
+    expect(actualStorage).toMatchInlineSnapshot(`
+      {
+        ".ownerByName:join(state)": {
+          ""pKeySet","s0","u2",": true,
+          ""pKeySet","s0","u3",": true,
+          ""pKeySet","s1","u0",": true,
+          ""pKeySet","s1","u1",": true,
+          ""pKeySet","s1","u4",": true,
+        },
+        ":join(ownerByName)": {
+          ""pKeySet","Aaron","i1",": true,
+          ""pKeySet","Aaron","i2",": true,
+          ""pKeySet","Arv","i3",": true,
+          ""pKeySet","Fritz","i0",": true,
+        },
+      }
+    `);
+    expect(pushesWithFetch).toMatchInlineSnapshot(`
+      [
+        {
+          "change": {
+            "child": {
+              "change": {
+                "child": {
+                  "change": {
+                    "oldRow": {
+                      "id": "s0",
+                      "name": "Hawaii",
+                    },
+                    "row": {
+                      "id": "s0",
+                      "name": "HI",
+                    },
+                    "type": "edit",
+                  },
+                  "relationshipName": "state",
+                },
+                "row": {
+                  "id": "u2",
+                  "name": "Aaron",
+                  "stateID": "s0",
+                },
+                "type": "child",
+              },
+              "relationshipName": "ownerByName",
+            },
+            "row": {
+              "id": "i1",
+              "ownerName": "Aaron",
+            },
+            "type": "child",
+          },
+          "fetch": [
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s1",
+                            "name": "CA",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u0",
+                      "name": "Fritz",
+                      "stateID": "s1",
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i0",
+                "ownerName": "Fritz",
+              },
+            },
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s1",
+                            "name": "CA",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u1",
+                      "name": "Aaron",
+                      "stateID": "s1",
+                    },
+                  },
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s0",
+                            "name": "HI",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u2",
+                      "name": "Aaron",
+                      "stateID": "s0",
+                    },
+                  },
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s0",
+                            "name": "Hawaii",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u3",
+                      "name": "Aaron",
+                      "stateID": "s0",
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i1",
+                "ownerName": "Aaron",
+              },
+            },
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s1",
+                            "name": "CA",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u1",
+                      "name": "Aaron",
+                      "stateID": "s1",
+                    },
+                  },
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s0",
+                            "name": "Hawaii",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u2",
+                      "name": "Aaron",
+                      "stateID": "s0",
+                    },
+                  },
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s0",
+                            "name": "Hawaii",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u3",
+                      "name": "Aaron",
+                      "stateID": "s0",
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i2",
+                "ownerName": "Aaron",
+              },
+            },
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s1",
+                            "name": "CA",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u4",
+                      "name": "Arv",
+                      "stateID": "s1",
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i3",
+                "ownerName": "Arv",
+              },
+            },
+          ],
+        },
+        {
+          "change": {
+            "child": {
+              "change": {
+                "child": {
+                  "change": {
+                    "oldRow": {
+                      "id": "s0",
+                      "name": "Hawaii",
+                    },
+                    "row": {
+                      "id": "s0",
+                      "name": "HI",
+                    },
+                    "type": "edit",
+                  },
+                  "relationshipName": "state",
+                },
+                "row": {
+                  "id": "u2",
+                  "name": "Aaron",
+                  "stateID": "s0",
+                },
+                "type": "child",
+              },
+              "relationshipName": "ownerByName",
+            },
+            "row": {
+              "id": "i2",
+              "ownerName": "Aaron",
+            },
+            "type": "child",
+          },
+          "fetch": [
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s1",
+                            "name": "CA",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u0",
+                      "name": "Fritz",
+                      "stateID": "s1",
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i0",
+                "ownerName": "Fritz",
+              },
+            },
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s1",
+                            "name": "CA",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u1",
+                      "name": "Aaron",
+                      "stateID": "s1",
+                    },
+                  },
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s0",
+                            "name": "HI",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u2",
+                      "name": "Aaron",
+                      "stateID": "s0",
+                    },
+                  },
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s0",
+                            "name": "Hawaii",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u3",
+                      "name": "Aaron",
+                      "stateID": "s0",
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i1",
+                "ownerName": "Aaron",
+              },
+            },
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s1",
+                            "name": "CA",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u1",
+                      "name": "Aaron",
+                      "stateID": "s1",
+                    },
+                  },
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s0",
+                            "name": "HI",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u2",
+                      "name": "Aaron",
+                      "stateID": "s0",
+                    },
+                  },
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s0",
+                            "name": "Hawaii",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u3",
+                      "name": "Aaron",
+                      "stateID": "s0",
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i2",
+                "ownerName": "Aaron",
+              },
+            },
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s1",
+                            "name": "CA",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u4",
+                      "name": "Arv",
+                      "stateID": "s1",
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i3",
+                "ownerName": "Arv",
+              },
+            },
+          ],
+        },
+        {
+          "change": {
+            "child": {
+              "change": {
+                "child": {
+                  "change": {
+                    "oldRow": {
+                      "id": "s0",
+                      "name": "Hawaii",
+                    },
+                    "row": {
+                      "id": "s0",
+                      "name": "HI",
+                    },
+                    "type": "edit",
+                  },
+                  "relationshipName": "state",
+                },
+                "row": {
+                  "id": "u3",
+                  "name": "Aaron",
+                  "stateID": "s0",
+                },
+                "type": "child",
+              },
+              "relationshipName": "ownerByName",
+            },
+            "row": {
+              "id": "i1",
+              "ownerName": "Aaron",
+            },
+            "type": "child",
+          },
+          "fetch": [
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s1",
+                            "name": "CA",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u0",
+                      "name": "Fritz",
+                      "stateID": "s1",
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i0",
+                "ownerName": "Fritz",
+              },
+            },
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s1",
+                            "name": "CA",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u1",
+                      "name": "Aaron",
+                      "stateID": "s1",
+                    },
+                  },
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s0",
+                            "name": "HI",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u2",
+                      "name": "Aaron",
+                      "stateID": "s0",
+                    },
+                  },
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s0",
+                            "name": "HI",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u3",
+                      "name": "Aaron",
+                      "stateID": "s0",
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i1",
+                "ownerName": "Aaron",
+              },
+            },
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s1",
+                            "name": "CA",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u1",
+                      "name": "Aaron",
+                      "stateID": "s1",
+                    },
+                  },
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s0",
+                            "name": "HI",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u2",
+                      "name": "Aaron",
+                      "stateID": "s0",
+                    },
+                  },
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s0",
+                            "name": "Hawaii",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u3",
+                      "name": "Aaron",
+                      "stateID": "s0",
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i2",
+                "ownerName": "Aaron",
+              },
+            },
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s1",
+                            "name": "CA",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u4",
+                      "name": "Arv",
+                      "stateID": "s1",
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i3",
+                "ownerName": "Arv",
+              },
+            },
+          ],
+        },
+        {
+          "change": {
+            "child": {
+              "change": {
+                "child": {
+                  "change": {
+                    "oldRow": {
+                      "id": "s0",
+                      "name": "Hawaii",
+                    },
+                    "row": {
+                      "id": "s0",
+                      "name": "HI",
+                    },
+                    "type": "edit",
+                  },
+                  "relationshipName": "state",
+                },
+                "row": {
+                  "id": "u3",
+                  "name": "Aaron",
+                  "stateID": "s0",
+                },
+                "type": "child",
+              },
+              "relationshipName": "ownerByName",
+            },
+            "row": {
+              "id": "i2",
+              "ownerName": "Aaron",
+            },
+            "type": "child",
+          },
+          "fetch": [
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s1",
+                            "name": "CA",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u0",
+                      "name": "Fritz",
+                      "stateID": "s1",
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i0",
+                "ownerName": "Fritz",
+              },
+            },
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s1",
+                            "name": "CA",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u1",
+                      "name": "Aaron",
+                      "stateID": "s1",
+                    },
+                  },
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s0",
+                            "name": "HI",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u2",
+                      "name": "Aaron",
+                      "stateID": "s0",
+                    },
+                  },
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s0",
+                            "name": "HI",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u3",
+                      "name": "Aaron",
+                      "stateID": "s0",
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i1",
+                "ownerName": "Aaron",
+              },
+            },
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s1",
+                            "name": "CA",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u1",
+                      "name": "Aaron",
+                      "stateID": "s1",
+                    },
+                  },
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s0",
+                            "name": "HI",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u2",
+                      "name": "Aaron",
+                      "stateID": "s0",
+                    },
+                  },
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s0",
+                            "name": "HI",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u3",
+                      "name": "Aaron",
+                      "stateID": "s0",
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i2",
+                "ownerName": "Aaron",
+              },
+            },
+            {
+              "relationships": {
+                "ownerByName": [
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s1",
+                            "name": "CA",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u4",
+                      "name": "Arv",
+                      "stateID": "s1",
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i3",
+                "ownerName": "Arv",
               },
             },
           ],

--- a/packages/zql/src/ivm/join.push.test.ts
+++ b/packages/zql/src/ivm/join.push.test.ts
@@ -6933,7 +6933,7 @@ suite('test overlay on many:one pushes', () => {
                     "relationships": {},
                     "row": {
                       "id": "u1",
-                      "name": "Boogs",
+                      "name": "Aaron",
                     },
                   },
                 ],
@@ -7152,8 +7152,8 @@ suite('test overlay on many:one pushes', () => {
           'state',
           {
             type: 'edit',
-            oldRow: {id: 's1', name: 'CA'},
-            row: {id: 's1', name: 'California'},
+            oldRow: {id: 's0', name: 'Hawaii'},
+            row: {id: 's0', name: 'HI'},
           },
         ],
       ],
@@ -7167,12 +7167,12 @@ suite('test overlay on many:one pushes', () => {
           "push",
           {
             "oldRow": {
-              "id": "s1",
-              "name": "CA",
+              "id": "s0",
+              "name": "Hawaii",
             },
             "row": {
-              "id": "s1",
-              "name": "California",
+              "id": "s0",
+              "name": "HI",
             },
             "type": "edit",
           },
@@ -7182,7 +7182,7 @@ suite('test overlay on many:one pushes', () => {
           "fetch",
           {
             "constraint": {
-              "stateID": "s1",
+              "stateID": "s0",
             },
           },
         ],
@@ -7192,19 +7192,19 @@ suite('test overlay on many:one pushes', () => {
           {
             "child": {
               "oldRow": {
-                "id": "s1",
-                "name": "CA",
+                "id": "s0",
+                "name": "Hawaii",
               },
               "row": {
-                "id": "s1",
-                "name": "California",
+                "id": "s0",
+                "name": "HI",
               },
               "type": "edit",
             },
             "row": {
-              "id": "u2",
-              "name": "Arv",
-              "stateID": "s1",
+              "id": "u0",
+              "name": "Fritz",
+              "stateID": "s0",
             },
             "type": "child",
           },
@@ -7214,7 +7214,7 @@ suite('test overlay on many:one pushes', () => {
           "fetch",
           {
             "constraint": {
-              "ownerID": "u2",
+              "ownerID": "u0",
             },
           },
         ],
@@ -7225,25 +7225,353 @@ suite('test overlay on many:one pushes', () => {
             "child": {
               "child": {
                 "oldRow": {
-                  "id": "s1",
-                  "name": "CA",
+                  "id": "s0",
+                  "name": "Hawaii",
                 },
                 "row": {
-                  "id": "s1",
-                  "name": "California",
+                  "id": "s0",
+                  "name": "HI",
                 },
                 "type": "edit",
               },
               "row": {
-                "id": "u2",
-                "name": "Arv",
-                "stateID": "s1",
+                "id": "u0",
+                "name": "Fritz",
+                "stateID": "s0",
               },
               "type": "child",
             },
             "row": {
-              "id": "i3",
-              "ownerID": "u2",
+              "id": "i0",
+              "ownerID": "u0",
+            },
+            "type": "child",
+          },
+        ],
+        [
+          ":join(owner)",
+          "fetch",
+          {},
+        ],
+        [
+          ":source(issue)",
+          "fetch",
+          {},
+        ],
+        [
+          ".owner:join(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "u0",
+            },
+          },
+        ],
+        [
+          ".owner:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "u0",
+            },
+          },
+        ],
+        [
+          ".owner.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s0",
+            },
+          },
+        ],
+        [
+          ".owner:join(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "u1",
+            },
+          },
+        ],
+        [
+          ".owner:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "u1",
+            },
+          },
+        ],
+        [
+          ".owner.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s0",
+            },
+          },
+        ],
+        [
+          ".owner:join(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "u1",
+            },
+          },
+        ],
+        [
+          ".owner:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "u1",
+            },
+          },
+        ],
+        [
+          ".owner.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s0",
+            },
+          },
+        ],
+        [
+          ".owner:join(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "u2",
+            },
+          },
+        ],
+        [
+          ".owner:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "u2",
+            },
+          },
+        ],
+        [
+          ".owner.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s1",
+            },
+          },
+        ],
+        [
+          ".owner:join(state)",
+          "push",
+          {
+            "child": {
+              "oldRow": {
+                "id": "s0",
+                "name": "Hawaii",
+              },
+              "row": {
+                "id": "s0",
+                "name": "HI",
+              },
+              "type": "edit",
+            },
+            "row": {
+              "id": "u1",
+              "name": "Aaron",
+              "stateID": "s0",
+            },
+            "type": "child",
+          },
+        ],
+        [
+          ":source(issue)",
+          "fetch",
+          {
+            "constraint": {
+              "ownerID": "u1",
+            },
+          },
+        ],
+        [
+          ":join(owner)",
+          "push",
+          {
+            "child": {
+              "child": {
+                "oldRow": {
+                  "id": "s0",
+                  "name": "Hawaii",
+                },
+                "row": {
+                  "id": "s0",
+                  "name": "HI",
+                },
+                "type": "edit",
+              },
+              "row": {
+                "id": "u1",
+                "name": "Aaron",
+                "stateID": "s0",
+              },
+              "type": "child",
+            },
+            "row": {
+              "id": "i1",
+              "ownerID": "u1",
+            },
+            "type": "child",
+          },
+        ],
+        [
+          ":join(owner)",
+          "fetch",
+          {},
+        ],
+        [
+          ":source(issue)",
+          "fetch",
+          {},
+        ],
+        [
+          ".owner:join(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "u0",
+            },
+          },
+        ],
+        [
+          ".owner:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "u0",
+            },
+          },
+        ],
+        [
+          ".owner.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s0",
+            },
+          },
+        ],
+        [
+          ".owner:join(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "u1",
+            },
+          },
+        ],
+        [
+          ".owner:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "u1",
+            },
+          },
+        ],
+        [
+          ".owner.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s0",
+            },
+          },
+        ],
+        [
+          ".owner:join(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "u1",
+            },
+          },
+        ],
+        [
+          ".owner:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "u1",
+            },
+          },
+        ],
+        [
+          ".owner.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s0",
+            },
+          },
+        ],
+        [
+          ".owner:join(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "u2",
+            },
+          },
+        ],
+        [
+          ".owner:source(user)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "u2",
+            },
+          },
+        ],
+        [
+          ".owner.state:source(state)",
+          "fetch",
+          {
+            "constraint": {
+              "id": "s1",
+            },
+          },
+        ],
+        [
+          ":join(owner)",
+          "push",
+          {
+            "child": {
+              "child": {
+                "oldRow": {
+                  "id": "s0",
+                  "name": "Hawaii",
+                },
+                "row": {
+                  "id": "s0",
+                  "name": "HI",
+                },
+                "type": "edit",
+              },
+              "row": {
+                "id": "u1",
+                "name": "Aaron",
+                "stateID": "s0",
+              },
+              "type": "child",
+            },
+            "row": {
+              "id": "i2",
+              "ownerID": "u1",
             },
             "type": "child",
           },
@@ -7377,7 +7705,7 @@ suite('test overlay on many:one pushes', () => {
             "name": "Fritz",
             "state": {
               "id": "s0",
-              "name": "Hawaii",
+              "name": "HI",
             },
             "stateID": "s0",
           },
@@ -7390,7 +7718,7 @@ suite('test overlay on many:one pushes', () => {
             "name": "Aaron",
             "state": {
               "id": "s0",
-              "name": "Hawaii",
+              "name": "HI",
             },
             "stateID": "s0",
           },
@@ -7403,7 +7731,7 @@ suite('test overlay on many:one pushes', () => {
             "name": "Aaron",
             "state": {
               "id": "s0",
-              "name": "Hawaii",
+              "name": "HI",
             },
             "stateID": "s0",
           },
@@ -7416,7 +7744,7 @@ suite('test overlay on many:one pushes', () => {
             "name": "Arv",
             "state": {
               "id": "s1",
-              "name": "California",
+              "name": "CA",
             },
             "stateID": "s1",
           },
@@ -7448,29 +7776,29 @@ suite('test overlay on many:one pushes', () => {
                 "child": {
                   "change": {
                     "oldRow": {
-                      "id": "s1",
-                      "name": "CA",
+                      "id": "s0",
+                      "name": "Hawaii",
                     },
                     "row": {
-                      "id": "s1",
-                      "name": "California",
+                      "id": "s0",
+                      "name": "HI",
                     },
                     "type": "edit",
                   },
                   "relationshipName": "state",
                 },
                 "row": {
-                  "id": "u2",
-                  "name": "Arv",
-                  "stateID": "s1",
+                  "id": "u0",
+                  "name": "Fritz",
+                  "stateID": "s0",
                 },
                 "type": "child",
               },
               "relationshipName": "owner",
             },
             "row": {
-              "id": "i3",
-              "ownerID": "u2",
+              "id": "i0",
+              "ownerID": "u0",
             },
             "type": "child",
           },
@@ -7485,7 +7813,7 @@ suite('test overlay on many:one pushes', () => {
                           "relationships": {},
                           "row": {
                             "id": "s0",
-                            "name": "Hawaii",
+                            "name": "HI",
                           },
                         },
                       ],
@@ -7569,7 +7897,303 @@ suite('test overlay on many:one pushes', () => {
                           "relationships": {},
                           "row": {
                             "id": "s1",
-                            "name": "California",
+                            "name": "CA",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u2",
+                      "name": "Arv",
+                      "stateID": "s1",
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i3",
+                "ownerID": "u2",
+              },
+            },
+          ],
+        },
+        {
+          "change": {
+            "child": {
+              "change": {
+                "child": {
+                  "change": {
+                    "oldRow": {
+                      "id": "s0",
+                      "name": "Hawaii",
+                    },
+                    "row": {
+                      "id": "s0",
+                      "name": "HI",
+                    },
+                    "type": "edit",
+                  },
+                  "relationshipName": "state",
+                },
+                "row": {
+                  "id": "u1",
+                  "name": "Aaron",
+                  "stateID": "s0",
+                },
+                "type": "child",
+              },
+              "relationshipName": "owner",
+            },
+            "row": {
+              "id": "i1",
+              "ownerID": "u1",
+            },
+            "type": "child",
+          },
+          "fetch": [
+            {
+              "relationships": {
+                "owner": [
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s0",
+                            "name": "HI",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u0",
+                      "name": "Fritz",
+                      "stateID": "s0",
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i0",
+                "ownerID": "u0",
+              },
+            },
+            {
+              "relationships": {
+                "owner": [
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s0",
+                            "name": "HI",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u1",
+                      "name": "Aaron",
+                      "stateID": "s0",
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i1",
+                "ownerID": "u1",
+              },
+            },
+            {
+              "relationships": {
+                "owner": [
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s0",
+                            "name": "Hawaii",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u1",
+                      "name": "Aaron",
+                      "stateID": "s0",
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i2",
+                "ownerID": "u1",
+              },
+            },
+            {
+              "relationships": {
+                "owner": [
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s1",
+                            "name": "CA",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u2",
+                      "name": "Arv",
+                      "stateID": "s1",
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i3",
+                "ownerID": "u2",
+              },
+            },
+          ],
+        },
+        {
+          "change": {
+            "child": {
+              "change": {
+                "child": {
+                  "change": {
+                    "oldRow": {
+                      "id": "s0",
+                      "name": "Hawaii",
+                    },
+                    "row": {
+                      "id": "s0",
+                      "name": "HI",
+                    },
+                    "type": "edit",
+                  },
+                  "relationshipName": "state",
+                },
+                "row": {
+                  "id": "u1",
+                  "name": "Aaron",
+                  "stateID": "s0",
+                },
+                "type": "child",
+              },
+              "relationshipName": "owner",
+            },
+            "row": {
+              "id": "i2",
+              "ownerID": "u1",
+            },
+            "type": "child",
+          },
+          "fetch": [
+            {
+              "relationships": {
+                "owner": [
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s0",
+                            "name": "HI",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u0",
+                      "name": "Fritz",
+                      "stateID": "s0",
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i0",
+                "ownerID": "u0",
+              },
+            },
+            {
+              "relationships": {
+                "owner": [
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s0",
+                            "name": "HI",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u1",
+                      "name": "Aaron",
+                      "stateID": "s0",
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i1",
+                "ownerID": "u1",
+              },
+            },
+            {
+              "relationships": {
+                "owner": [
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s0",
+                            "name": "HI",
+                          },
+                        },
+                      ],
+                    },
+                    "row": {
+                      "id": "u1",
+                      "name": "Aaron",
+                      "stateID": "s0",
+                    },
+                  },
+                ],
+              },
+              "row": {
+                "id": "i2",
+                "ownerID": "u1",
+              },
+            },
+            {
+              "relationships": {
+                "owner": [
+                  {
+                    "relationships": {
+                      "state": [
+                        {
+                          "relationships": {},
+                          "row": {
+                            "id": "s1",
+                            "name": "CA",
                           },
                         },
                       ],

--- a/packages/zql/src/ivm/join.ts
+++ b/packages/zql/src/ivm/join.ts
@@ -350,7 +350,7 @@ export class Join implements Input {
         assert(editNewApplied);
         editOldApplied = true;
         applied = true;
-        yield overlay.node;
+        yield overlay.oldNode;
       }
     }
 

--- a/packages/zql/src/ivm/join.ts
+++ b/packages/zql/src/ivm/join.ts
@@ -3,7 +3,7 @@ import type {CompoundKey, System} from '../../../zero-protocol/src/ast.ts';
 import type {Row, Value} from '../../../zero-protocol/src/data.ts';
 import type {PrimaryKey} from '../../../zero-protocol/src/primary-key.ts';
 import type {Change, ChildChange} from './change.ts';
-import {compareValues, type Node} from './data.ts';
+import {compareValues, valuesEqual, type Node} from './data.ts';
 import {
   throwOutput,
   type FetchRequest,
@@ -29,6 +29,12 @@ type Args = {
   hidden: boolean;
   system: System;
 };
+
+type ChildChangeOverlay = {
+  change: Change;
+  position: Row | undefined;
+};
+
 /**
  * The Join operator joins the output from two upstream inputs. Zero's join
  * is a little different from SQL's join in that we output hierarchical data,
@@ -49,6 +55,8 @@ export class Join implements Input {
   readonly #schema: SourceSchema;
 
   #output: Output = throwOutput;
+
+  #inprogressChildChange: ChildChangeOverlay | undefined;
 
   constructor({
     parent,
@@ -192,26 +200,35 @@ export class Join implements Input {
 
   #pushChild(change: Change): void {
     const pushChildChange = (childRow: Row, change: Change) => {
-      const parentNodes = this.#parent.fetch({
-        constraint: Object.fromEntries(
-          this.#parentKey.map((key, i) => [key, childRow[this.#childKey[i]]]),
-        ),
-      });
-
-      for (const parentNode of parentNodes) {
-        const childChange: ChildChange = {
-          type: 'child',
-          node: this.#processParentNode(
-            parentNode.row,
-            parentNode.relationships,
-            'fetch',
+      this.#inprogressChildChange = {
+        change,
+        position: undefined,
+      };
+      try {
+        const parentNodes = this.#parent.fetch({
+          constraint: Object.fromEntries(
+            this.#parentKey.map((key, i) => [key, childRow[this.#childKey[i]]]),
           ),
-          child: {
-            relationshipName: this.#relationshipName,
-            change,
-          },
-        };
-        this.#output.push(childChange);
+        });
+
+        for (const parentNode of parentNodes) {
+          this.#inprogressChildChange.position = parentNode.row;
+          const childChange: ChildChange = {
+            type: 'child',
+            node: this.#processParentNode(
+              parentNode.row,
+              parentNode.relationships,
+              'fetch',
+            ),
+            child: {
+              relationshipName: this.#relationshipName,
+              change,
+            },
+          };
+          this.#output.push(childChange);
+        }
+      } finally {
+        this.#inprogressChildChange = undefined;
       }
     };
 
@@ -238,6 +255,106 @@ export class Join implements Input {
       default:
         unreachable(change);
     }
+  }
+
+  *#generateChildStreamWithOverlay(
+    stream: Stream<Node>,
+    overlay: Change,
+  ): Stream<Node> {
+    let applied = false;
+    let editOldApplied = false;
+    let editNewApplied = false;
+    for (const child of stream) {
+      let yieldChild = true;
+      if (!applied) {
+        switch (overlay.type) {
+          case 'add': {
+            if (
+              this.#child
+                .getSchema()
+                .compareRows(overlay.node.row, child.row) === 0
+            ) {
+              applied = true;
+              yieldChild = false;
+            }
+            break;
+          }
+          case 'remove': {
+            if (
+              this.#child.getSchema().compareRows(overlay.node.row, child.row) <
+              0
+            ) {
+              applied = true;
+              yield overlay.node;
+            }
+            break;
+          }
+          case 'edit': {
+            if (
+              this.#child
+                .getSchema()
+                .compareRows(overlay.oldNode.row, child.row) < 0
+            ) {
+              editOldApplied = true;
+              if (editNewApplied) {
+                applied = true;
+              }
+              yield overlay.oldNode;
+            }
+            if (
+              this.#child
+                .getSchema()
+                .compareRows(overlay.node.row, child.row) === 0
+            ) {
+              editNewApplied = true;
+              if (editOldApplied) {
+                applied = true;
+              }
+              yieldChild = false;
+            }
+            break;
+          }
+          case 'child': {
+            if (
+              this.#child
+                .getSchema()
+                .compareRows(overlay.node.row, child.row) === 0
+            ) {
+              applied = true;
+              yield {
+                row: child.row,
+                relationships: {
+                  ...child.relationships,
+                  [overlay.child.relationshipName]: () =>
+                    this.#generateChildStreamWithOverlay(
+                      child.relationships[overlay.child.relationshipName](),
+                      overlay.child.change,
+                    ),
+                },
+              };
+              yieldChild = false;
+            }
+            break;
+          }
+        }
+      }
+      if (yieldChild) {
+        yield child;
+      }
+    }
+    if (!applied) {
+      if (overlay.type === 'remove') {
+        applied = true;
+        yield overlay.node;
+      } else if (overlay.type === 'edit') {
+        assert(editNewApplied);
+        editOldApplied = true;
+        applied = true;
+        yield overlay.node;
+      }
+    }
+
+    assert(applied);
   }
 
   #processParentNode(
@@ -283,7 +400,8 @@ export class Join implements Input {
           );
         }
       }
-      return this.#child[method]({
+
+      const stream = this.#child[method]({
         constraint: Object.fromEntries(
           this.#childKey.map((key, i) => [
             key,
@@ -291,6 +409,25 @@ export class Join implements Input {
           ]),
         ),
       });
+
+      if (
+        this.#inprogressChildChange &&
+        this.#isJoinMatch(
+          parentNodeRow,
+          this.#inprogressChildChange.change.node.row,
+        ) &&
+        this.#inprogressChildChange.position &&
+        this.#schema.compareRows(
+          parentNodeRow,
+          this.#inprogressChildChange.position,
+        ) > 0
+      ) {
+        return this.#generateChildStreamWithOverlay(
+          stream,
+          this.#inprogressChildChange.change,
+        );
+      }
+      return stream;
     };
 
     return {
@@ -300,6 +437,15 @@ export class Join implements Input {
         [this.#relationshipName]: childStream,
       },
     };
+  }
+
+  #isJoinMatch(parent: Row, child: Row) {
+    for (let i = 0; i < this.#parentKey.length; i++) {
+      if (!valuesEqual(parent[this.#parentKey[i]], child[this.#childKey[i]])) {
+        return false;
+      }
+    }
+    return true;
   }
 }
 

--- a/packages/zql/src/ivm/test/push-tests.ts
+++ b/packages/zql/src/ivm/test/push-tests.ts
@@ -54,6 +54,7 @@ export type PushTest = {
   ast: AST;
   format: Format;
   pushes: Pushes;
+  fetchOnPush?: boolean | undefined;
 };
 
 export function runPushTest(t: PushTest) {
@@ -112,10 +113,33 @@ export function runPushTest(t: PushTest) {
   expect(actualStorage).toEqual(actualStorage2);
 
   view.flush();
+
+  if (!t.fetchOnPush) {
+    return {
+      log,
+      actualStorage,
+      pushes: catchOp.pushes,
+      data,
+    };
+  }
+
+  const {
+    finalOutput: catchOp2,
+    log: log3,
+    actualStorage: actualStorage3,
+  } = innerTest(j => {
+    const c = new Catch(j, t.fetchOnPush);
+    c.fetch();
+    return c;
+  });
+
+  expect(actualStorage).toEqual(actualStorage3);
+
   return {
-    log,
+    log: log3,
     actualStorage,
-    pushes: catchOp.pushes,
+    pushes: catchOp2.pushes,
+    pushesWithFetch: catchOp2.pushesWithFetch,
     data,
   };
 }


### PR DESCRIPTION
Adds overlay logic to join for when join splits a push from its child input, in to multiple pushes to its output (because the child matches/matched multiple parents).