### PR TITLE
chore(zero-cache): simplify decommission logic

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/decommission.ts
+++ b/packages/zero-cache/src/services/change-source/pg/decommission.ts
@@ -1,6 +1,5 @@
 import type {LogContext} from '@rocicorp/logger';
 import type {PostgresDB} from '../../../types/pg.ts';
-import {dropEventTriggerStatements} from './schema/ddl.ts';
 import {dropShard} from './schema/shard.ts';
 
 export async function decommissionShard(
@@ -13,11 +12,8 @@ export async function decommissionShard(
 
   lc.info?.(`Decommissioning zero shard ${shard}`);
   await db.begin(async tx => {
-    await tx.unsafe(dropEventTriggerStatements(appID, shardID));
-    lc.debug?.(`Dropped event triggers`);
-
     await tx.unsafe(dropShard(appID, shardID));
-    lc.debug?.(`Dropped upstream shard schema ${shard}`);
+    lc.debug?.(`Dropped upstream shard schema ${shard} and event triggers`);
 
     const slots = await tx<{pid: string | null}[]>`
     SELECT pg_terminate_backend(active_pid), active_pid as pid

--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl.ts
@@ -359,6 +359,7 @@ CREATE EVENT TRIGGER ${sharded(`${appID}_${tagID}`)}
   return triggers.join('');
 }
 
+// Exported for testing.
 export function dropEventTriggerStatements(
   appID: string,
   shardID: string | number,


### PR DESCRIPTION
There's no need to manually remove event triggers. Because they invoke functions defined in the shard schema, dropping the shard schema (with cascade) results in removing the functions and triggers. The unit test continues to pass unchanged.