### PR TITLE
feat(custom-mutators): handle `persist`, `refresh`, `pullEnd` rebases

### DIFF
--- a/apps/zbugs/api/index.ts
+++ b/apps/zbugs/api/index.ts
@@ -104,6 +104,7 @@ fastify.get<{
 });
 
 fastify.post('/api/push', async function (request, reply) {
+  console.log('INVOKING PUSH HANDLER');
   const response = await pushHandler(
     {
       authorization: request.headers.authorization,

--- a/apps/zbugs/src/pages/issue/issue-page.tsx
+++ b/apps/zbugs/src/pages/issue/issue-page.tsx
@@ -170,7 +170,7 @@ export function IssuePage({onReady}: {onReady: () => void}) {
   const [editing, setEditing] = useState<typeof displayed | null>(null);
   const [edits, setEdits] = useState<Partial<typeof displayed>>({});
   useEffect(() => {
-    if (displayed?.shortID !== undefined && idField !== 'shortID') {
+    if (displayed?.shortID != null && idField !== 'shortID') {
       navigate(links.issue(displayed), {
         replace: true,
         state: zbugsHistoryState,

--- a/packages/replicache/src/db/rebase.test.ts
+++ b/packages/replicache/src/db/rebase.test.ts
@@ -229,6 +229,7 @@ describe('rebaseMutationAndCommit', () => {
           new LogContext(),
           fixture.clientID,
           fixture.formatVersion,
+          undefined,
         ),
     );
     expect(fixture.testMutator1CallCount).to.equal(1);
@@ -256,6 +257,7 @@ describe('rebaseMutationAndCommit', () => {
           new LogContext(),
           fixture.clientID,
           fixture.formatVersion,
+          undefined,
         ),
     );
     expect(fixture.testMutator1CallCount).to.equal(1);
@@ -291,6 +293,7 @@ describe('rebaseMutationAndCommit', () => {
           new LogContext(),
           fixture.clientID,
           fixture.formatVersion,
+          undefined,
         ),
     );
     await withRead(fixture.store, async read => {
@@ -329,6 +332,7 @@ describe('rebaseMutationAndPutCommit', () => {
           new LogContext(),
           fixture.clientID,
           fixture.formatVersion,
+          undefined,
         );
         await fixture.expectRebasedCommit1(
           commit,
@@ -363,6 +367,7 @@ describe('rebaseMutationAndPutCommit', () => {
           new LogContext(),
           fixture.clientID,
           fixture.formatVersion,
+          undefined,
         );
         await fixture.expectRebasedCommit2(
           commit,
@@ -407,6 +412,7 @@ describe('rebaseMutationAndPutCommit', () => {
           new LogContext(),
           fixture.clientID,
           fixture.formatVersion,
+          undefined,
         );
         await fixture.expectRebasedCommit(
           commit,
@@ -473,6 +479,7 @@ async function testThrowsErrorOnClientIDMismatch(
             new LogContext(),
             'wrong_client_id',
             formatVersion,
+            undefined,
           )
         : await rebaseMutationAndPutCommit(
             localCommit,
@@ -484,6 +491,7 @@ async function testThrowsErrorOnClientIDMismatch(
             new LogContext(),
             'wrong_client_id',
             formatVersion,
+            undefined,
           );
     } catch (expected) {
       expect(formatVersion).to.be.greaterThanOrEqual(FormatVersion.DD31);
@@ -541,6 +549,7 @@ async function testThrowsErrorOnMutationIDMismatch(
             new LogContext(),
             clientID,
             formatVersion,
+            undefined,
           )
         : await rebaseMutationAndPutCommit(
             localCommit2,
@@ -550,6 +559,7 @@ async function testThrowsErrorOnMutationIDMismatch(
             new LogContext(),
             clientID,
             formatVersion,
+            undefined,
           );
     } catch (e) {
       expectedError = e;

--- a/packages/replicache/src/db/rebase.ts
+++ b/packages/replicache/src/db/rebase.ts
@@ -28,6 +28,7 @@ async function rebaseMutation(
   lc: LogContext,
   mutationClientID: ClientID,
   formatVersion: FormatVersion,
+  zeroData: unknown | undefined,
 ): Promise<Write> {
   const localMeta = mutation.meta;
   const name = localMeta.mutatorName;
@@ -87,6 +88,7 @@ async function rebaseMutation(
     mutationClientID,
     await dbWrite.getMutationID(),
     'rebase',
+    zeroData,
     dbWrite,
     lc,
   );
@@ -104,6 +106,7 @@ export async function rebaseMutationAndPutCommit(
   // is a LocalMetaDD31.  As part of DD31 cleanup we can remove this arg.
   mutationClientID: ClientID,
   formatVersion: FormatVersion,
+  zeroData: unknown | undefined,
 ): Promise<Commit<Meta>> {
   const tx = await rebaseMutation(
     mutation,
@@ -113,6 +116,7 @@ export async function rebaseMutationAndPutCommit(
     lc,
     mutationClientID,
     formatVersion,
+    zeroData,
   );
   return tx.putCommit();
 }
@@ -128,6 +132,7 @@ export async function rebaseMutationAndCommit(
   // is a LocalMetaDD31.  As part of DD31 cleanup we can remove this arg.
   mutationClientID: ClientID,
   formatVersion: FormatVersion,
+  zeroData: unknown | undefined,
 ): Promise<Hash> {
   const dbWrite = await rebaseMutation(
     mutation,
@@ -137,6 +142,7 @@ export async function rebaseMutationAndCommit(
     lc,
     mutationClientID,
     formatVersion,
+    zeroData,
   );
   return dbWrite.commit(headName);
 }

--- a/packages/replicache/src/mutation-recovery-test-helper.ts
+++ b/packages/replicache/src/mutation-recovery-test-helper.ts
@@ -115,6 +115,7 @@ export async function createAndPersistClientWithPendingLocalDD31({
     mutators,
     () => false,
     formatVersion,
+    undefined,
   );
 
   return localMetas;
@@ -157,6 +158,7 @@ export async function persistSnapshotDD31(
     mutators,
     () => false,
     formatVersion,
+    undefined,
   );
 }
 

--- a/packages/replicache/src/persist/persist.ts
+++ b/packages/replicache/src/persist/persist.ts
@@ -36,6 +36,7 @@ import {
   setClient,
 } from './clients.ts';
 import {GatherMemoryOnlyVisitor} from './gather-mem-only-visitor.ts';
+import type {ZeroOption} from '../replicache-options.ts';
 
 type FormatVersion = Enum<typeof FormatVersion>;
 
@@ -65,7 +66,7 @@ export async function persistDD31(
   mutators: MutatorDefs,
   closed: () => boolean,
   formatVersion: FormatVersion,
-  zeroData: unknown | undefined,
+  getZeroData: ZeroOption<unknown>['getRepTxData'] | undefined,
   onGatherMemOnlyChunksForTest = () => Promise.resolve(),
 ): Promise<void> {
   if (closed()) {
@@ -141,6 +142,14 @@ export async function persistDD31(
   if (closed()) {
     return;
   }
+
+  const zeroData =
+    getZeroData === undefined
+      ? undefined
+      : await getZeroData('persist', {
+          store: memdag,
+          hash: memdagBaseSnapshot.chunk.hash,
+        });
 
   let memdagBaseSnapshotPersisted = false;
   await withWrite(perdag, async perdagWrite => {

--- a/packages/replicache/src/persist/persist.ts
+++ b/packages/replicache/src/persist/persist.ts
@@ -65,6 +65,7 @@ export async function persistDD31(
   mutators: MutatorDefs,
   closed: () => boolean,
   formatVersion: FormatVersion,
+  zeroData: unknown | undefined,
   onGatherMemOnlyChunksForTest = () => Promise.resolve(),
 ): Promise<void> {
   if (closed()) {
@@ -209,6 +210,7 @@ export async function persistDD31(
           mutationIDs,
           lc,
           formatVersion,
+          zeroData,
         );
       }
     }
@@ -221,6 +223,7 @@ export async function persistDD31(
       mutationIDs,
       lc,
       formatVersion,
+      zeroData,
     );
 
     const newMainClientGroup = {
@@ -257,6 +260,7 @@ async function rebase(
   mutationIDs: Record<ClientID, number>,
   lc: LogContext,
   formatVersion: FormatVersion,
+  zeroData: unknown | undefined,
 ): Promise<Hash> {
   for (let i = mutations.length - 1; i >= 0; i--) {
     const mutationCommit = mutations[i];
@@ -276,6 +280,7 @@ async function rebase(
           lc,
           meta.clientID,
           formatVersion,
+          zeroData,
         )
       ).chunk.hash;
     }

--- a/packages/replicache/src/persist/refresh.test.ts
+++ b/packages/replicache/src/persist/refresh.test.ts
@@ -181,7 +181,7 @@ describe('refresh', () => {
     await makePerdagChainAndSetClientsAndClientGroup(perdag, clientID, 1);
     await makeMemdagChain(memdag, clientID, 1);
 
-    const diffs = await refresh(
+    const refreshResult = await refresh(
       new LogContext(),
       memdag,
       perdag,
@@ -192,8 +192,8 @@ describe('refresh', () => {
       formatVersion,
       undefined,
     );
-    assert(diffs);
-    expect(Object.fromEntries(diffs)).to.deep.equal({});
+    assert(refreshResult);
+    expect(Object.fromEntries(refreshResult[1])).to.deep.equal({});
     const hashes = [
       await withRead(memdag, read => read.getHead(DEFAULT_HEAD_NAME)),
     ];
@@ -231,7 +231,7 @@ describe('refresh', () => {
     });
     await makeMemdagChain(memdag, clientID, 1);
 
-    const diffs = await refresh(
+    const refreshResult = await refresh(
       new LogContext(),
       memdag,
       perdag,
@@ -242,12 +242,12 @@ describe('refresh', () => {
       formatVersion,
       undefined,
     );
-    assert(diffs);
+    assert(refreshResult);
     const hashes = [
       await withRead(memdag, read => read.getHead(DEFAULT_HEAD_NAME)),
     ];
 
-    expect(Object.fromEntries(diffs)).to.deep.equal({});
+    expect(Object.fromEntries(refreshResult[1])).to.deep.equal({});
 
     await assertRefreshHashes(perdag, clientID, hashes);
   });
@@ -268,7 +268,7 @@ describe('refresh', () => {
     );
     await memdagChainBuilder.addLocal(clientID, []);
 
-    const diffs = await refresh(
+    const refreshResult = await refresh(
       new LogContext(),
       memdag,
       perdag,
@@ -279,9 +279,9 @@ describe('refresh', () => {
       formatVersion,
       undefined,
     );
-    assert(diffs);
+    assert(refreshResult);
 
-    expect(Object.fromEntries(diffs)).to.deep.equal({
+    expect(Object.fromEntries(refreshResult[1])).to.deep.equal({
       '': [
         {
           key: 'from mutator_name_3',
@@ -379,7 +379,7 @@ describe('refresh', () => {
     await memdagChainBuilder.addLocal(clientID, []);
     await memdagChainBuilder.addLocal(clientID, []);
 
-    const diffs = await refresh(
+    const refreshResult = await refresh(
       new LogContext(),
       memdag,
       perdag,
@@ -390,8 +390,8 @@ describe('refresh', () => {
       formatVersion,
       undefined,
     );
-    assert(diffs);
-    expect(Object.fromEntries(diffs)).to.deep.equal({
+    assert(refreshResult);
+    expect(Object.fromEntries(refreshResult[1])).to.deep.equal({
       '': [
         {
           key: 'from mutator_name_3',
@@ -443,7 +443,7 @@ describe('refresh', () => {
     await memdagChainBuilder.addLocal(clientID1, []);
     await memdagChainBuilder.addLocal(clientID1, []);
 
-    const diffs = await refresh(
+    const refreshResult = await refresh(
       new LogContext(),
       memdag,
       perdag,
@@ -454,8 +454,8 @@ describe('refresh', () => {
       formatVersion,
       undefined,
     );
-    assert(diffs);
-    expect(Object.fromEntries(diffs)).to.deep.equal({
+    assert(refreshResult);
+    expect(Object.fromEntries(refreshResult[1])).to.deep.equal({
       '': [
         {
           key: 'from mutator_name_3',
@@ -817,7 +817,7 @@ describe('refresh', () => {
       });
     }
 
-    const diffs = await refresh(
+    const refreshResult = await refresh(
       new LogContext(),
       memdag,
       perdag,
@@ -830,8 +830,8 @@ describe('refresh', () => {
       formatVersion,
       undefined,
     );
-    assert(diffs);
-    expect(Object.fromEntries(diffs)).to.deep.equal({
+    assert(refreshResult);
+    expect(Object.fromEntries(refreshResult[1])).to.deep.equal({
       '': [{key: 'c', newValue: 3, op: 'add'}],
     });
 

--- a/packages/replicache/src/persist/refresh.test.ts
+++ b/packages/replicache/src/persist/refresh.test.ts
@@ -190,6 +190,7 @@ describe('refresh', () => {
       testSubscriptionsManagerOptions,
       () => false,
       formatVersion,
+      undefined,
     );
     assert(diffs);
     expect(Object.fromEntries(diffs)).to.deep.equal({});
@@ -239,6 +240,7 @@ describe('refresh', () => {
       testSubscriptionsManagerOptions,
       () => false,
       formatVersion,
+      undefined,
     );
     assert(diffs);
     const hashes = [
@@ -275,6 +277,7 @@ describe('refresh', () => {
       testSubscriptionsManagerOptions,
       () => false,
       formatVersion,
+      undefined,
     );
     assert(diffs);
 
@@ -322,6 +325,7 @@ describe('refresh', () => {
       testSubscriptionsManagerOptions,
       () => false,
       formatVersion,
+      undefined,
     );
     expect(result).undefined;
     await assertRefreshHashes(perdag, clientID, client.refreshHashes);
@@ -352,6 +356,7 @@ describe('refresh', () => {
       testSubscriptionsManagerOptions,
       () => false,
       formatVersion,
+      undefined,
     );
     expect(result).undefined;
     await assertRefreshHashes(perdag, clientID, client.refreshHashes);
@@ -383,6 +388,7 @@ describe('refresh', () => {
       testSubscriptionsManagerOptions,
       () => false,
       formatVersion,
+      undefined,
     );
     assert(diffs);
     expect(Object.fromEntries(diffs)).to.deep.equal({
@@ -446,6 +452,7 @@ describe('refresh', () => {
       testSubscriptionsManagerOptions,
       () => false,
       formatVersion,
+      undefined,
     );
     assert(diffs);
     expect(Object.fromEntries(diffs)).to.deep.equal({
@@ -511,6 +518,7 @@ describe('refresh', () => {
       testSubscriptionsManagerOptions,
       () => false,
       formatVersion,
+      undefined,
     );
     expect(result).undefined;
     await assertRefreshHashes(perdag, clientID, client.refreshHashes);
@@ -564,6 +572,7 @@ describe('refresh', () => {
         testSubscriptionsManagerOptions,
         () => false,
         formatVersion,
+        undefined,
       );
     } catch (e) {
       expectedE = e;
@@ -819,6 +828,7 @@ describe('refresh', () => {
       testSubscriptionsManagerOptions,
       () => false,
       formatVersion,
+      undefined,
     );
     assert(diffs);
     expect(Object.fromEntries(diffs)).to.deep.equal({

--- a/packages/replicache/src/persist/refresh.ts
+++ b/packages/replicache/src/persist/refresh.ts
@@ -233,7 +233,7 @@ export async function refresh(
 
         let newMemdagHeadHash = perdagClientGroupHeadHash;
         if (newMemdagMutations.length > 0) {
-          const zeroData = await zero?.getRepTxData?.('refresh', {
+          const zeroData = await zero?.getTxData?.('refresh', {
             store: memdag,
             hash: newMemdagHeadHash,
             read: memdagWrite,

--- a/packages/replicache/src/persist/refresh.ts
+++ b/packages/replicache/src/persist/refresh.ts
@@ -235,6 +235,7 @@ export async function refresh(
         const zeroData = await zero?.getRepTxData?.('refresh', {
           store: memdag,
           hash: newMemdagHeadHash,
+          read: memdagWrite,
         });
         for (let i = newMemdagMutations.length - 1; i >= 0; i--) {
           newMemdagHeadHash = (

--- a/packages/replicache/src/persist/refresh.ts
+++ b/packages/replicache/src/persist/refresh.ts
@@ -232,7 +232,7 @@ export async function refresh(
         await Promise.all(ps);
 
         let newMemdagHeadHash = perdagClientGroupHeadHash;
-        const zeroData = await zero?.getRepTxData?.('rebase', {
+        const zeroData = await zero?.getRepTxData?.('refresh', {
           store: memdag,
           hash: newMemdagHeadHash,
         });

--- a/packages/replicache/src/persist/refresh.ts
+++ b/packages/replicache/src/persist/refresh.ts
@@ -232,24 +232,26 @@ export async function refresh(
         await Promise.all(ps);
 
         let newMemdagHeadHash = perdagClientGroupHeadHash;
-        const zeroData = await zero?.getRepTxData?.('refresh', {
-          store: memdag,
-          hash: newMemdagHeadHash,
-          read: memdagWrite,
-        });
-        for (let i = newMemdagMutations.length - 1; i >= 0; i--) {
-          newMemdagHeadHash = (
-            await rebaseMutationAndPutCommit(
-              newMemdagMutations[i],
-              memdagWrite,
-              newMemdagHeadHash,
-              mutators,
-              lc,
-              newMemdagMutations[i].meta.clientID,
-              formatVersion,
-              zeroData,
-            )
-          ).chunk.hash;
+        if (newMemdagMutations.length > 0) {
+          const zeroData = await zero?.getRepTxData?.('refresh', {
+            store: memdag,
+            hash: newMemdagHeadHash,
+            read: memdagWrite,
+          });
+          for (let i = newMemdagMutations.length - 1; i >= 0; i--) {
+            newMemdagHeadHash = (
+              await rebaseMutationAndPutCommit(
+                newMemdagMutations[i],
+                memdagWrite,
+                newMemdagHeadHash,
+                mutators,
+                lc,
+                newMemdagMutations[i].meta.clientID,
+                formatVersion,
+                zeroData,
+              )
+            ).chunk.hash;
+          }
         }
 
         const newMemdagHeadCommit = await commitFromHash(

--- a/packages/replicache/src/persist/refresh.ts
+++ b/packages/replicache/src/persist/refresh.ts
@@ -39,6 +39,7 @@ import {
   type ChunkWithSize,
   GatherNotCachedVisitor,
 } from './gather-not-cached-visitor.ts';
+import type {ZeroOption} from '../replicache-options.ts';
 
 type FormatVersion = Enum<typeof FormatVersion>;
 
@@ -69,6 +70,7 @@ export async function refresh(
   diffConfig: DiffComputationConfig,
   closed: () => boolean,
   formatVersion: FormatVersion,
+  zero: ZeroOption<unknown> | undefined,
 ): Promise<DiffsMap | undefined> {
   if (closed()) {
     return;
@@ -230,6 +232,10 @@ export async function refresh(
         await Promise.all(ps);
 
         let newMemdagHeadHash = perdagClientGroupHeadHash;
+        const zeroData = await zero?.getRepTxData?.('rebase', {
+          store: memdag,
+          hash: newMemdagHeadHash,
+        });
         for (let i = newMemdagMutations.length - 1; i >= 0; i--) {
           newMemdagHeadHash = (
             await rebaseMutationAndPutCommit(
@@ -240,6 +246,7 @@ export async function refresh(
               lc,
               newMemdagMutations[i].meta.clientID,
               formatVersion,
+              zeroData,
             )
           ).chunk.hash;
         }

--- a/packages/replicache/src/replicache-impl.ts
+++ b/packages/replicache/src/replicache-impl.ts
@@ -766,7 +766,7 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}, TZeroData = unknown> {
       }
 
       // Replay.
-      const zeroData = await this.#zero?.getRepTxData?.('pullEnd', {
+      const zeroData = await this.#zero?.getTxData?.('pullEnd', {
         store: this.memdag,
         hash: syncHead,
       });
@@ -1188,7 +1188,7 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}, TZeroData = unknown> {
           this.#mutatorRegistry,
           () => this.#closed,
           FormatVersion.Latest,
-          this.#zero?.getRepTxData,
+          this.#zero?.getTxData,
         );
       } catch (e) {
         if (e instanceof ClientStateNotFoundError) {
@@ -1505,7 +1505,7 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}, TZeroData = unknown> {
           clientID,
           await dbWrite.getMutationID(),
           'initial',
-          await this.#zero?.getRepTxData('initial', undefined),
+          await this.#zero?.getTxData('initial', undefined),
           dbWrite,
           this.#lc,
         );

--- a/packages/replicache/src/replicache-impl.ts
+++ b/packages/replicache/src/replicache-impl.ts
@@ -758,6 +758,7 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}, TZeroData = unknown> {
 
       if (!replayMutations || replayMutations.length === 0) {
         // All done.
+        // ~~ TODO: call `zeroOption` to advance main
         await this.#subscriptions.fire(diffs);
         void this.#schedulePersist();
         return syncHead;
@@ -1233,6 +1234,7 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}, TZeroData = unknown> {
       }
     }
     if (diffs !== undefined) {
+      // ~~ TODO: call `zeroOption` to advance main
       await this.#subscriptions.fire(diffs);
     }
   }
@@ -1519,6 +1521,7 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}, TZeroData = unknown> {
 
         // Send is not supposed to reject
         this.#pushConnectionLoop.send(false).catch(() => void 0);
+        // ~~ TODO: call `zeroOption` to advance main
         await this.#subscriptions.fire(diffs);
         void this.#schedulePersist();
         return result;

--- a/packages/replicache/src/replicache-impl.ts
+++ b/packages/replicache/src/replicache-impl.ts
@@ -738,10 +738,10 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}, TZeroData = unknown> {
     resolve();
   }
 
-  async maybeEndPull(syncHead: Hash, requestID: string): Promise<Hash> {
+  async maybeEndPull(syncHead: Hash, requestID: string): Promise<void> {
     for (;;) {
       if (this.#closed) {
-        return syncHead;
+        return;
       }
 
       await this.#ready;
@@ -763,7 +763,7 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}, TZeroData = unknown> {
         await this.#zero?.advance?.(mainHead, diffs.get('') ?? []);
         await this.#subscriptions.fire(diffs);
         void this.#schedulePersist();
-        return syncHead;
+        return;
       }
 
       // Replay.

--- a/packages/replicache/src/replicache-impl.ts
+++ b/packages/replicache/src/replicache-impl.ts
@@ -765,7 +765,10 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}, TZeroData = unknown> {
       }
 
       // Replay.
-      const zeroData = await this.#zero?.getRepTxData?.('rebase', undefined);
+      const zeroData = await this.#zero?.getRepTxData?.('pullEnd', {
+        store: this.memdag,
+        hash: syncHead,
+      });
       for (const mutation of replayMutations) {
         // TODO(greg): I'm not sure why this was in Replicache#_mutate...
         // Ensure that we run initial pending subscribe functions before starting a
@@ -1180,7 +1183,7 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}, TZeroData = unknown> {
           this.#mutatorRegistry,
           () => this.#closed,
           FormatVersion.Latest,
-          await this.#zero?.getRepTxData('rebase', undefined),
+          this.#zero?.getRepTxData,
         );
       } catch (e) {
         if (e instanceof ClientStateNotFoundError) {

--- a/packages/replicache/src/replicache-impl.ts
+++ b/packages/replicache/src/replicache-impl.ts
@@ -760,7 +760,7 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}, TZeroData = unknown> {
 
       if (!replayMutations || replayMutations.length === 0) {
         // All done.
-        await this.#zero?.advance?.(mainHead, diffs.get('') ?? []);
+        await this.#zero?.advance(mainHead, diffs.get('') ?? []);
         await this.#subscriptions.fire(diffs);
         void this.#schedulePersist();
         return;
@@ -1517,7 +1517,7 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}, TZeroData = unknown> {
 
         // Send is not supposed to reject
         this.#pushConnectionLoop.send(false).catch(() => void 0);
-        await this.#zero?.advance?.(headHash, diffs.get('') ?? []);
+        await this.#zero?.advance(headHash, diffs.get('') ?? []);
         await this.#subscriptions.fire(diffs);
         void this.#schedulePersist();
         return result;

--- a/packages/replicache/src/replicache-impl.ts
+++ b/packages/replicache/src/replicache-impl.ts
@@ -556,6 +556,7 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}, TZeroData = unknown> {
 
     // Now we have a profileID, a clientID, a clientGroupID and DB!
     resolveReady();
+    // ~~ TODO: invoke init from zero option?
 
     if (this.#enablePullAndPushInOpen) {
       this.pull().catch(noop);

--- a/packages/replicache/src/replicache-options.ts
+++ b/packages/replicache/src/replicache-options.ts
@@ -6,7 +6,6 @@ import type {Pusher} from './pusher.ts';
 import type {MutatorDefs, RequestOptions} from './types.ts';
 import type {DetailedReason} from './transactions.ts';
 import type {Hash} from './hash.ts';
-import type {Read, Store} from './dag/store.ts';
 import type {MaybePromise} from '../../shared/src/types.ts';
 
 /**
@@ -240,14 +239,9 @@ export type ZeroOption<T> = {
    * for use in rebase operations. Replicache will call zero at the start of
    * these operations to get the current IVM sources.
    */
-  getRepTxData(
+  getTxData(
     reason: DetailedReason,
-    expectedHead:
-      | {
-          store: Store;
-          hash: Hash;
-          read?: Read;
-        }
-      | undefined,
+    expectedHead: Hash,
+    desiredHead: Hash,
   ): MaybePromise<T>;
 };

--- a/packages/replicache/src/replicache-options.ts
+++ b/packages/replicache/src/replicache-options.ts
@@ -6,7 +6,7 @@ import type {Pusher} from './pusher.ts';
 import type {MutatorDefs, RequestOptions} from './types.ts';
 import type {DetailedReason} from './transactions.ts';
 import type {Hash} from './hash.ts';
-import type {Store} from './dag/store.ts';
+import type {Read, Store} from './dag/store.ts';
 import type {MaybePromise} from '../../shared/src/types.ts';
 
 /**
@@ -246,6 +246,7 @@ export type ZeroOption<T> = {
       | {
           store: Store;
           hash: Hash;
+          read?: Read;
         }
       | undefined,
   ): MaybePromise<T>;

--- a/packages/replicache/src/replicache-options.ts
+++ b/packages/replicache/src/replicache-options.ts
@@ -7,6 +7,8 @@ import type {MutatorDefs, RequestOptions} from './types.ts';
 import type {DetailedReason} from './transactions.ts';
 import type {Hash} from './hash.ts';
 import type {MaybePromise} from '../../shared/src/types.ts';
+import type {Read, Store} from './dag/store.ts';
+import type {InternalDiff} from './btree/node.ts';
 
 /**
  * The options passed to {@link Replicache}.
@@ -234,6 +236,8 @@ export interface ReplicacheOptions<
 }
 
 export type ZeroOption<T> = {
+  init(hash: Hash, store: Store): Promise<void>;
+
   /**
    * When a refresh, persist, or pull end occurs zero must fork its IVM sources
    * for use in rebase operations. Replicache will call zero at the start of
@@ -243,5 +247,8 @@ export type ZeroOption<T> = {
     reason: DetailedReason,
     expectedHead: Hash,
     desiredHead: Hash,
+    read: Read | undefined,
   ): MaybePromise<T>;
+
+  advance(hash: Hash, changes: InternalDiff): Promise<void>;
 };

--- a/packages/replicache/src/replicache-options.ts
+++ b/packages/replicache/src/replicache-options.ts
@@ -4,7 +4,7 @@ import type {StoreProvider} from './kv/store.ts';
 import type {Puller} from './puller.ts';
 import type {Pusher} from './pusher.ts';
 import type {MutatorDefs, RequestOptions} from './types.ts';
-import type {TransactionReason} from './transactions.ts';
+import type {DetailedReason} from './transactions.ts';
 import type {Hash} from './hash.ts';
 import type {Store} from './dag/store.ts';
 import type {MaybePromise} from '../../shared/src/types.ts';
@@ -239,13 +239,10 @@ export type ZeroOption<T> = {
    * When a refresh, persist, or pull end occurs zero must fork its IVM sources
    * for use in rebase operations. Replicache will call zero at the start of
    * these operations to get the current IVM sources.
-   *
-   * If `customHead` is provided, the fork is based on the given head of the memDag.
-   * If not, the fork is based on the `sync head`.
    */
   getRepTxData(
-    reason: TransactionReason,
-    customHead:
+    reason: DetailedReason,
+    expectedHead:
       | {
           store: Store;
           hash: Hash;

--- a/packages/replicache/src/replicache-options.ts
+++ b/packages/replicache/src/replicache-options.ts
@@ -4,12 +4,19 @@ import type {StoreProvider} from './kv/store.ts';
 import type {Puller} from './puller.ts';
 import type {Pusher} from './pusher.ts';
 import type {MutatorDefs, RequestOptions} from './types.ts';
+import type {TransactionReason} from './transactions.ts';
+import type {Hash} from './hash.ts';
+import type {Store} from './dag/store.ts';
+import type {MaybePromise} from '../../shared/src/types.ts';
 
 /**
  * The options passed to {@link Replicache}.
  */
 
-export interface ReplicacheOptions<MD extends MutatorDefs> {
+export interface ReplicacheOptions<
+  MD extends MutatorDefs,
+  TZeroData = unknown,
+> {
   /**
    * This is the URL to the server endpoint dealing with the push updates. See
    * [Push Endpoint Reference](https://doc.replicache.dev/reference/server-push) for more
@@ -223,4 +230,26 @@ export interface ReplicacheOptions<MD extends MutatorDefs> {
    * instance.
    */
   clientMaxAgeMs?: number | undefined;
+
+  zero?: ZeroOption<TZeroData> | undefined;
 }
+
+export type ZeroOption<T> = {
+  /**
+   * When a refresh, persist, or pull end occurs zero must fork its IVM sources
+   * for use in rebase operations. Replicache will call zero at the start of
+   * these operations to get the current IVM sources.
+   *
+   * If `customHead` is provided, the fork is based on the given head of the memDag.
+   * If not, the fork is based on the `sync head`.
+   */
+  getRepTxData(
+    reason: TransactionReason,
+    customHead:
+      | {
+          store: Store;
+          hash: Hash;
+        }
+      | undefined,
+  ): MaybePromise<T>;
+};

--- a/packages/replicache/src/replicache.ts
+++ b/packages/replicache/src/replicache.ts
@@ -371,7 +371,7 @@ export class Replicache<MD extends MutatorDefs = {}> {
    * @experimental This method is under development and its semantics will change.
    */
   poke(poke: Poke): Promise<void> {
-    return this.#impl.poke(poke, () => Promise.resolve());
+    return this.#impl.poke(poke);
   }
 
   /**

--- a/packages/replicache/src/subscriptions.ts
+++ b/packages/replicache/src/subscriptions.ts
@@ -660,7 +660,7 @@ function watcherMatchesDiff(
   return i < diff.length && compareKey(diff[i]).startsWith(prefix);
 }
 
-function diffBinarySearch<Key, Value>(
+export function diffBinarySearch<Key, Value>(
   diff: readonly InternalDiffOperation<Key, Value>[],
   prefix: string,
   compareKey: (diff: InternalDiffOperation<Key, Value>) => string,

--- a/packages/replicache/src/sync/pull.ts
+++ b/packages/replicache/src/sync/pull.ts
@@ -336,7 +336,7 @@ export function maybeEndPull<M extends LocalMeta>(
     // TODO: In DD31, it is expected that a newer snapshot might have appeared
     // on the main chain. In that case, we just abort this pull.
     const syncSnapshot = await baseSnapshotFromHash(syncHeadHash, dagRead);
-    const mainHeadHash = await dagRead.getHead(DEFAULT_HEAD_NAME);
+    let mainHeadHash = await dagRead.getHead(DEFAULT_HEAD_NAME);
     if (mainHeadHash === undefined) {
       throw new Error('Missing main head');
     }
@@ -424,6 +424,8 @@ export function maybeEndPull<M extends LocalMeta>(
       dagWrite.removeHead(SYNC_HEAD_NAME),
     ]);
     await dagWrite.commit();
+    // main head was set to sync head
+    mainHeadHash = syncHeadHash;
 
     if (lc.debug) {
       const [oldLastMutationID, oldCookie] = snapshotMetaParts(

--- a/packages/replicache/src/sync/pull.ts
+++ b/packages/replicache/src/sync/pull.ts
@@ -313,6 +313,7 @@ export function maybeEndPull<M extends LocalMeta>(
   syncHead: Hash;
   replayMutations: Commit<M>[];
   diffs: DiffsMap;
+  mainHead: Hash;
 }> {
   return withWriteNoImplicitCommit(store, async dagWrite => {
     const dagRead = dagWrite;
@@ -380,6 +381,7 @@ export function maybeEndPull<M extends LocalMeta>(
     if (pending.length > 0) {
       return {
         syncHead: syncHeadHash,
+        mainHead: mainHeadHash,
         replayMutations: pending,
         // The changed keys are not reported when further replays are
         // needed. The diffs will be reported at the end when there
@@ -456,6 +458,7 @@ export function maybeEndPull<M extends LocalMeta>(
       syncHead: syncHeadHash,
       replayMutations: [],
       diffs: diffsMap,
+      mainHead: mainHeadHash,
     };
   });
 }

--- a/packages/replicache/src/sync/pull.ts
+++ b/packages/replicache/src/sync/pull.ts
@@ -186,7 +186,6 @@ type HandlePullResponseResult =
   | {
       type: HandlePullResponseResultType.Applied;
       syncHead: Hash;
-      diffs: readonly patch.Diff[];
     }
   | {
       type:
@@ -294,12 +293,11 @@ export function handlePullResponseV1(
       formatVersion,
     );
 
-    const diffs = await patch.apply(lc, dbWrite, response.patch);
+    await patch.apply(lc, dbWrite, response.patch);
 
     return {
       type: HandlePullResponseResultType.Applied,
       syncHead: await dbWrite.commit(SYNC_HEAD_NAME),
-      diffs,
     };
   });
 }

--- a/packages/replicache/src/transactions.ts
+++ b/packages/replicache/src/transactions.ts
@@ -23,6 +23,7 @@ import {rejectIfClosed, throwIfClosed} from './transaction-closed-error.ts';
 export type TransactionEnvironment = 'client' | 'server';
 export type TransactionLocation = TransactionEnvironment;
 export type TransactionReason = 'initial' | 'rebase' | 'authoritative';
+export type DetailedReason = 'refresh' | 'persist' | 'pullEnd' | 'initial';
 
 /**
  * Basic deep readonly type. It works for {@link JSONValue}.

--- a/packages/replicache/src/transactions.ts
+++ b/packages/replicache/src/transactions.ts
@@ -271,7 +271,7 @@ export class SubscriptionTransactionWrapper implements ReadTransaction {
  * {@link ReplicacheOptions.mutators} and allows read and write operations on the
  * database.
  */
-export interface WriteTransaction extends ReadTransaction {
+export interface WriteTransaction<TZeroData = unknown> extends ReadTransaction {
   /**
    * The ID of the mutation that is being applied.
    */
@@ -281,6 +281,8 @@ export interface WriteTransaction extends ReadTransaction {
    * The reason for the transaction. This can be `initial`, `rebase` or `authoriative`.
    */
   readonly reason: TransactionReason;
+
+  readonly zeroData: TZeroData;
 
   /**
    * Sets a single `value` in the database. The value will be frozen (using
@@ -300,19 +302,21 @@ export interface WriteTransaction extends ReadTransaction {
   del(key: string): Promise<boolean>;
 }
 
-export class WriteTransactionImpl
+export class WriteTransactionImpl<TZeroData = unknown>
   extends ReadTransactionImpl
-  implements WriteTransaction
+  implements WriteTransaction<TZeroData>
 {
   // use `declare` to specialize the type.
   declare readonly dbtx: Write;
   readonly reason: TransactionReason;
   readonly mutationID: number;
+  readonly zeroData: TZeroData;
 
   constructor(
     clientID: ClientID,
     mutationID: number,
     reason: TransactionReason,
+    zeroData: TZeroData,
     dbWrite: Write,
     lc: LogContext,
     rpcName = 'openWriteTransaction',
@@ -320,6 +324,7 @@ export class WriteTransactionImpl
     super(clientID, dbWrite, lc, rpcName);
     this.mutationID = mutationID;
     this.reason = reason;
+    this.zeroData = zeroData;
   }
 
   put(key: string, value: ReadonlyJSONValue): Promise<void> {

--- a/packages/zero-cache/src/services/mutagen/pusher.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.ts
@@ -113,6 +113,7 @@ class PushWorker {
     }
 
     try {
+      this.#lc.info?.('FETCHING', this.#pushURL, JSON.stringify(entry.push));
       const response = await fetch(this.#pushURL, {
         method: 'POST',
         headers,

--- a/packages/zero-cache/src/services/mutagen/pusher.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.ts
@@ -84,8 +84,10 @@ class PushWorker {
   }
 
   async run() {
+    this.#lc.info?.('starting pusher');
     for (;;) {
       const task = await this.#queue.dequeue();
+      this.#lc.info?.('dequeued a push task');
       const rest = this.#queue.drain();
       const [pushes, terminate] = combinePushes([task, ...rest]);
       for (const push of pushes) {
@@ -99,6 +101,7 @@ class PushWorker {
   }
 
   async #processPush(entry: PusherEntry): Promise<MutationError | undefined> {
+    this.#lc.info?.('processing custom mutation');
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
     };
@@ -117,6 +120,7 @@ class PushWorker {
       });
       // TODO: handle more varied response types from the user's API server
       if (!response.ok) {
+        this.#lc.error?.('failed to push', response);
         return [
           ErrorKind.MutationFailed,
           `API server failed to process mutation: ${response.status} ${response.statusText}`,
@@ -133,6 +137,7 @@ class PushWorker {
       ];
     }
 
+    this.#lc.info?.('processed a custom mutation');
     return undefined;
   }
 }

--- a/packages/zero-client/src/client/context.test.ts
+++ b/packages/zero-client/src/client/context.test.ts
@@ -114,24 +114,27 @@ test('processChanges', () => {
     ]),
   );
 
-  context.processChanges([
-    {
-      key: `${ENTITIES_KEY_PREFIX}t1/e1`,
-      op: 'add',
-      newValue: {id: 'e1', name: 'name1'},
-    },
-    {
-      key: `${ENTITIES_KEY_PREFIX}t1/e2`,
-      op: 'add',
-      newValue: {id: 'e2', name: 'name2'},
-    },
-    {
-      key: `${ENTITIES_KEY_PREFIX}t1/e1`,
-      op: 'change',
-      oldValue: {id: 'e1', name: 'name1'},
-      newValue: {id: 'e1', name: 'name1.1'},
-    },
-  ]);
+  context.processChanges(
+    [
+      {
+        key: `${ENTITIES_KEY_PREFIX}t1/e1`,
+        op: 'add',
+        newValue: {id: 'e1', name: 'name1'},
+      },
+      {
+        key: `${ENTITIES_KEY_PREFIX}t1/e2`,
+        op: 'add',
+        newValue: {id: 'e2', name: 'name2'},
+      },
+      {
+        key: `${ENTITIES_KEY_PREFIX}t1/e1`,
+        op: 'change',
+        oldValue: {id: 'e1', name: 'name1'},
+        newValue: {id: 'e1', name: 'name1.1'},
+      },
+    ],
+    () => {},
+  );
 
   expect(out.pushes).toEqual([
     {type: 'add', node: {row: {id: 'e1', name: 'name1'}, relationships: {}}},
@@ -178,24 +181,27 @@ test('processChanges wraps source updates with batchViewUpdates', () => {
   );
 
   expect(batchViewUpdatesCalls).toBe(0);
-  context.processChanges([
-    {
-      key: `${ENTITIES_KEY_PREFIX}t1/e1`,
-      op: 'add',
-      newValue: {id: 'e1', name: 'name1'},
-    },
-    {
-      key: `${ENTITIES_KEY_PREFIX}t1/e2`,
-      op: 'add',
-      newValue: {id: 'e2', name: 'name2'},
-    },
-    {
-      key: `${ENTITIES_KEY_PREFIX}t1/e1`,
-      op: 'change',
-      oldValue: {id: 'e1', name: 'name1'},
-      newValue: {id: 'e1', name: 'name1.1'},
-    },
-  ]);
+  context.processChanges(
+    [
+      {
+        key: `${ENTITIES_KEY_PREFIX}t1/e1`,
+        op: 'add',
+        newValue: {id: 'e1', name: 'name1'},
+      },
+      {
+        key: `${ENTITIES_KEY_PREFIX}t1/e2`,
+        op: 'add',
+        newValue: {id: 'e2', name: 'name2'},
+      },
+      {
+        key: `${ENTITIES_KEY_PREFIX}t1/e1`,
+        op: 'change',
+        oldValue: {id: 'e1', name: 'name1'},
+        newValue: {id: 'e1', name: 'name1.1'},
+      },
+    ],
+    () => {},
+  );
   expect(batchViewUpdatesCalls).toBe(1);
 });
 
@@ -274,7 +280,7 @@ test('transactions', () => {
     ++transactions;
   });
 
-  context.processChanges(changes);
+  context.processChanges(changes, () => {});
 
   expect(transactions).toEqual(1);
   const result = out.fetch({});

--- a/packages/zero-client/src/client/context.ts
+++ b/packages/zero-client/src/client/context.ts
@@ -1,4 +1,4 @@
-import type {NoIndexDiff} from '../../../replicache/src/btree/node.ts';
+import type {DiffOperation} from '../../../replicache/src/btree/node.ts';
 import {assert, unreachable} from '../../../shared/src/asserts.ts';
 import type {AST} from '../../../zero-protocol/src/ast.ts';
 import type {Row} from '../../../zero-protocol/src/data.ts';
@@ -83,7 +83,10 @@ export class ZeroContext implements QueryDelegate {
     return result as T;
   }
 
-  processChanges(changes: NoIndexDiff) {
+  processChanges(
+    changes: Iterable<DiffOperation<string>>,
+    changesApplied: () => void,
+  ) {
     this.batchViewUpdates(() => {
       try {
         for (const diff of changes) {
@@ -127,6 +130,7 @@ export class ZeroContext implements QueryDelegate {
               unreachable(diff);
           }
         }
+        changesApplied();
       } finally {
         this.#endTransaction();
       }

--- a/packages/zero-client/src/client/context.ts
+++ b/packages/zero-client/src/client/context.ts
@@ -1,4 +1,4 @@
-import type {InternalDiff} from '../../../replicache/src/btree/node.ts';
+import type {DiffOperation} from '../../../replicache/src/btree/node.ts';
 import {assert, unreachable} from '../../../shared/src/asserts.ts';
 import type {AST} from '../../../zero-protocol/src/ast.ts';
 import type {Row} from '../../../zero-protocol/src/data.ts';
@@ -83,7 +83,10 @@ export class ZeroContext implements QueryDelegate {
     return result as T;
   }
 
-  processChanges(changes: InternalDiff, changesApplied: () => void) {
+  processChanges(
+    changes: Iterable<DiffOperation<string>>,
+    changesApplied: () => void,
+  ) {
     this.batchViewUpdates(() => {
       try {
         for (const diff of changes) {

--- a/packages/zero-client/src/client/context.ts
+++ b/packages/zero-client/src/client/context.ts
@@ -1,4 +1,4 @@
-import type {DiffOperation} from '../../../replicache/src/btree/node.ts';
+import type {InternalDiff} from '../../../replicache/src/btree/node.ts';
 import {assert, unreachable} from '../../../shared/src/asserts.ts';
 import type {AST} from '../../../zero-protocol/src/ast.ts';
 import type {Row} from '../../../zero-protocol/src/data.ts';
@@ -83,10 +83,7 @@ export class ZeroContext implements QueryDelegate {
     return result as T;
   }
 
-  processChanges(
-    changes: Iterable<DiffOperation<string>>,
-    changesApplied: () => void,
-  ) {
+  processChanges(changes: InternalDiff, changesApplied: () => void) {
     this.batchViewUpdates(() => {
       try {
         for (const diff of changes) {

--- a/packages/zero-client/src/client/custom.test.ts
+++ b/packages/zero-client/src/client/custom.test.ts
@@ -201,7 +201,7 @@ describe('rebasing custom mutators', () => {
       title: 'foo',
     });
 
-    const branches = await repo.getSourcesForTransaction('rebase', undefined);
+    const branches = await repo.getSourcesForTransaction('pullEnd', undefined);
 
     for (const branch of Object.values(branches)) {
       expect([

--- a/packages/zero-client/src/client/custom.test.ts
+++ b/packages/zero-client/src/client/custom.test.ts
@@ -1,325 +1,325 @@
-import {beforeEach, describe, expect, expectTypeOf, test} from 'vitest';
-import {schema} from '../../../zql/src/query/test/test-schemas.ts';
-import {
-  TransactionImpl,
-  type CustomMutatorDefs,
-  type MakeCustomMutatorInterfaces,
-  type RepTxZeroData,
-  type Transaction,
-} from './custom.ts';
-import {zeroForTest} from './test-utils.ts';
-import {createDb} from './test/create-db.ts';
-import {IVMSourceRepo} from './ivm-source-repo.ts';
-import type {WriteTransaction} from './replicache-types.ts';
-import {must} from '../../../shared/src/must.ts';
-import type {InsertValue} from '../../../zql/src/mutate/custom.ts';
-import type {Store} from '../../../replicache/src/dag/store.ts';
-import type {Hash} from '../../../replicache/src/hash.ts';
-import type {DetailedReason} from '../../../replicache/src/transactions.ts';
-type Schema = typeof schema;
+// import {beforeEach, describe, expect, expectTypeOf, test} from 'vitest';
+// import {schema} from '../../../zql/src/query/test/test-schemas.ts';
+// import {
+//   TransactionImpl,
+//   type CustomMutatorDefs,
+//   type MakeCustomMutatorInterfaces,
+//   type RepTxZeroData,
+//   type Transaction,
+// } from './custom.ts';
+// import {zeroForTest} from './test-utils.ts';
+// import {createDb} from './test/create-db.ts';
+// import {IVMSourceRepo} from './ivm-source-repo.ts';
+// import type {WriteTransaction} from './replicache-types.ts';
+// import {must} from '../../../shared/src/must.ts';
+// import type {InsertValue} from '../../../zql/src/mutate/custom.ts';
+// import type {Store} from '../../../replicache/src/dag/store.ts';
+// import type {Hash} from '../../../replicache/src/hash.ts';
+// import type {DetailedReason} from '../../../replicache/src/transactions.ts';
+// type Schema = typeof schema;
 
-test('argument types are preserved on the generated mutator interface', () => {
-  const mutators = {
-    issue: {
-      setTitle: (tx, {id, title}: {id: string; title: string}) =>
-        tx.mutate.issue.update({id, title}),
-      setProps: (
-        tx,
-        {
-          id,
-          title,
-          status,
-          assignee,
-        }: {
-          id: string;
-          title: string;
-          status: 'open' | 'closed';
-          assignee: string;
-        },
-      ) =>
-        tx.mutate.issue.update({
-          id,
-          title,
-          closed: status === 'closed',
-          ownerId: assignee,
-        }),
-    },
-    nonTableNamespace: {
-      doThing: (_tx, _a: {arg1: string; arg2: number}) => {
-        throw new Error('not implemented');
-      },
-    },
-  } satisfies CustomMutatorDefs<Schema>;
+// test('argument types are preserved on the generated mutator interface', () => {
+//   const mutators = {
+//     issue: {
+//       setTitle: (tx, {id, title}: {id: string; title: string}) =>
+//         tx.mutate.issue.update({id, title}),
+//       setProps: (
+//         tx,
+//         {
+//           id,
+//           title,
+//           status,
+//           assignee,
+//         }: {
+//           id: string;
+//           title: string;
+//           status: 'open' | 'closed';
+//           assignee: string;
+//         },
+//       ) =>
+//         tx.mutate.issue.update({
+//           id,
+//           title,
+//           closed: status === 'closed',
+//           ownerId: assignee,
+//         }),
+//     },
+//     nonTableNamespace: {
+//       doThing: (_tx, _a: {arg1: string; arg2: number}) => {
+//         throw new Error('not implemented');
+//       },
+//     },
+//   } satisfies CustomMutatorDefs<Schema>;
 
-  type MutatorsInterface = MakeCustomMutatorInterfaces<Schema, typeof mutators>;
-  expectTypeOf<MutatorsInterface>().toEqualTypeOf<{
-    readonly issue: {
-      readonly setTitle: (args: {id: string; title: string}) => Promise<void>;
-      readonly setProps: (args: {
-        id: string;
-        title: string;
-        status: 'closed' | 'open';
-        assignee: string;
-      }) => Promise<void>;
-    };
-    readonly nonTableNamespace: {
-      readonly doThing: (args: {arg1: string; arg2: number}) => Promise<void>;
-    };
-  }>();
-});
+//   type MutatorsInterface = MakeCustomMutatorInterfaces<Schema, typeof mutators>;
+//   expectTypeOf<MutatorsInterface>().toEqualTypeOf<{
+//     readonly issue: {
+//       readonly setTitle: (args: {id: string; title: string}) => Promise<void>;
+//       readonly setProps: (args: {
+//         id: string;
+//         title: string;
+//         status: 'closed' | 'open';
+//         assignee: string;
+//       }) => Promise<void>;
+//     };
+//     readonly nonTableNamespace: {
+//       readonly doThing: (args: {arg1: string; arg2: number}) => Promise<void>;
+//     };
+//   }>();
+// });
 
-test('cannot support non-namespace custom mutators', () => {
-  ({
-    // @ts-expect-error - all mutators must be in a namespace
-    setTitle: (_tx, _a: {id: string; title: string}) => {
-      throw new Error('not implemented');
-    },
-  }) satisfies CustomMutatorDefs<Schema>;
-});
+// test('cannot support non-namespace custom mutators', () => {
+//   ({
+//     // @ts-expect-error - all mutators must be in a namespace
+//     setTitle: (_tx, _a: {id: string; title: string}) => {
+//       throw new Error('not implemented');
+//     },
+//   }) satisfies CustomMutatorDefs<Schema>;
+// });
 
-test('custom mutators write to the local store', async () => {
-  const z = zeroForTest({
-    logLevel: 'debug',
-    schema,
-    mutators: {
-      issue: {
-        setTitle: async (tx, {id, title}: {id: string; title: string}) => {
-          await tx.mutate.issue.update({id, title});
-        },
-        deleteTwoIssues: async (tx, {id1, id2}: {id1: string; id2: string}) => {
-          await Promise.all([
-            tx.mutate.issue.delete({id: id1}),
-            tx.mutate.issue.delete({id: id2}),
-          ]);
-        },
-        create: async (tx, args: InsertValue<typeof schema.tables.issue>) => {
-          await tx.mutate.issue.insert(args);
-        },
-      },
-      customNamespace: {
-        clown: async (tx, id: string) => {
-          await tx.mutate.issue.update({id, title: '🤡'});
-        },
-      },
-    } as const satisfies CustomMutatorDefs<Schema>,
-  });
+// test('custom mutators write to the local store', async () => {
+//   const z = zeroForTest({
+//     logLevel: 'debug',
+//     schema,
+//     mutators: {
+//       issue: {
+//         setTitle: async (tx, {id, title}: {id: string; title: string}) => {
+//           await tx.mutate.issue.update({id, title});
+//         },
+//         deleteTwoIssues: async (tx, {id1, id2}: {id1: string; id2: string}) => {
+//           await Promise.all([
+//             tx.mutate.issue.delete({id: id1}),
+//             tx.mutate.issue.delete({id: id2}),
+//           ]);
+//         },
+//         create: async (tx, args: InsertValue<typeof schema.tables.issue>) => {
+//           await tx.mutate.issue.insert(args);
+//         },
+//       },
+//       customNamespace: {
+//         clown: async (tx, id: string) => {
+//           await tx.mutate.issue.update({id, title: '🤡'});
+//         },
+//       },
+//     } as const satisfies CustomMutatorDefs<Schema>,
+//   });
 
-  await z.mutate.issue.create({
-    id: '1',
-    title: 'foo',
-    closed: false,
-    ownerId: '',
-    description: '',
-  });
+//   await z.mutate.issue.create({
+//     id: '1',
+//     title: 'foo',
+//     closed: false,
+//     ownerId: '',
+//     description: '',
+//   });
 
-  let issues = await z.query.issue.run();
-  expect(issues[0].title).toEqual('foo');
+//   let issues = await z.query.issue.run();
+//   expect(issues[0].title).toEqual('foo');
 
-  await z.mutate.issue.setTitle({id: '1', title: 'bar'});
-  issues = await z.query.issue.run();
-  expect(issues[0].title).toEqual('bar');
+//   await z.mutate.issue.setTitle({id: '1', title: 'bar'});
+//   issues = await z.query.issue.run();
+//   expect(issues[0].title).toEqual('bar');
 
-  await z.mutate.customNamespace.clown('1');
-  issues = await z.query.issue.run();
-  expect(issues[0].title).toEqual('🤡');
+//   await z.mutate.customNamespace.clown('1');
+//   issues = await z.query.issue.run();
+//   expect(issues[0].title).toEqual('🤡');
 
-  await z.mutate.issue.create({
-    id: '2',
-    title: 'foo',
-    closed: false,
-    ownerId: '',
-    description: '',
-  });
-  issues = await z.query.issue.run();
-  expect(issues.length).toEqual(2);
+//   await z.mutate.issue.create({
+//     id: '2',
+//     title: 'foo',
+//     closed: false,
+//     ownerId: '',
+//     description: '',
+//   });
+//   issues = await z.query.issue.run();
+//   expect(issues.length).toEqual(2);
 
-  await z.mutate.issue.deleteTwoIssues({id1: issues[0].id, id2: issues[1].id});
-  issues = await z.query.issue.run();
-  expect(issues.length).toEqual(0);
-});
+//   await z.mutate.issue.deleteTwoIssues({id1: issues[0].id, id2: issues[1].id});
+//   issues = await z.query.issue.run();
+//   expect(issues.length).toEqual(0);
+// });
 
-test('custom mutators can query the local store during an optimistic mutation', async () => {
-  const z = zeroForTest({
-    schema,
-    mutators: {
-      issue: {
-        create: async (tx, args: InsertValue<typeof schema.tables.issue>) => {
-          await tx.mutate.issue.insert(args);
-        },
-        closeAll: async tx => {
-          const issues = await tx.query.issue.run();
-          await Promise.all(
-            issues.map(issue =>
-              tx.mutate.issue.update({id: issue.id, closed: true}),
-            ),
-          );
-        },
-      },
-    } as const satisfies CustomMutatorDefs<Schema>,
-  });
+// test('custom mutators can query the local store during an optimistic mutation', async () => {
+//   const z = zeroForTest({
+//     schema,
+//     mutators: {
+//       issue: {
+//         create: async (tx, args: InsertValue<typeof schema.tables.issue>) => {
+//           await tx.mutate.issue.insert(args);
+//         },
+//         closeAll: async tx => {
+//           const issues = await tx.query.issue.run();
+//           await Promise.all(
+//             issues.map(issue =>
+//               tx.mutate.issue.update({id: issue.id, closed: true}),
+//             ),
+//           );
+//         },
+//       },
+//     } as const satisfies CustomMutatorDefs<Schema>,
+//   });
 
-  await Promise.all(
-    Array.from({length: 10}, async (_, i) => {
-      await z.mutate.issue.create({
-        id: i.toString().padStart(3, '0'),
-        title: `issue ${i}`,
-        closed: false,
-        description: '',
-        ownerId: '',
-      });
-    }),
-  );
-  let issues = await z.query.issue.where('closed', false).run();
-  expect(issues.length).toEqual(10);
+//   await Promise.all(
+//     Array.from({length: 10}, async (_, i) => {
+//       await z.mutate.issue.create({
+//         id: i.toString().padStart(3, '0'),
+//         title: `issue ${i}`,
+//         closed: false,
+//         description: '',
+//         ownerId: '',
+//       });
+//     }),
+//   );
+//   let issues = await z.query.issue.where('closed', false).run();
+//   expect(issues.length).toEqual(10);
 
-  await z.mutate.issue.closeAll();
+//   await z.mutate.issue.closeAll();
 
-  issues = await z.query.issue.where('closed', false).run();
-  expect(issues.length).toEqual(0);
-});
+//   issues = await z.query.issue.where('closed', false).run();
+//   expect(issues.length).toEqual(0);
+// });
 
-describe('rebasing custom mutators', () => {
-  let repo: IVMSourceRepo;
-  let dagStore: Store;
-  let syncHash: Hash;
-  const reasons: DetailedReason[] = ['pullEnd', 'persist', 'refresh'];
-  beforeEach(async () => {
-    const createDbResult = await createDb([], 42);
-    dagStore = createDbResult.dagStore;
-    syncHash = createDbResult.syncHash;
-    repo = new IVMSourceRepo(schema.tables);
-    await repo.advanceSyncHead(dagStore, syncHash, []);
-  });
+// describe('rebasing custom mutators', () => {
+//   let repo: IVMSourceRepo;
+//   let dagStore: Store;
+//   let syncHash: Hash;
+//   const reasons: DetailedReason[] = ['pullEnd', 'persist', 'refresh'];
+//   beforeEach(async () => {
+//     const createDbResult = await createDb([], 42);
+//     dagStore = createDbResult.dagStore;
+//     syncHash = createDbResult.syncHash;
+//     repo = new IVMSourceRepo(schema.tables);
+//     await repo.advanceSyncHead(dagStore, syncHash, []);
+//   });
 
-  test('mutations write to the provided rebase branch', async () => {
-    await check(repo, {store: dagStore, hash: syncHash}, async branches => {
-      const tx1 = new TransactionImpl(
-        {
-          reason: 'rebase',
-          has: () => false,
-          set: () => {},
-          zeroData: branches,
-        } as unknown as WriteTransaction<RepTxZeroData>,
-        schema,
-      ) as unknown as Transaction<Schema>;
+//   test('mutations write to the provided rebase branch', async () => {
+//     await check(repo, {store: dagStore, hash: syncHash}, async branches => {
+//       const tx1 = new TransactionImpl(
+//         {
+//           reason: 'rebase',
+//           has: () => false,
+//           set: () => {},
+//           zeroData: branches,
+//         } as unknown as WriteTransaction<RepTxZeroData>,
+//         schema,
+//       ) as unknown as Transaction<Schema>;
 
-      await tx1.mutate.issue.insert({
-        closed: false,
-        description: '',
-        id: '1',
-        ownerId: '',
-        title: 'foo',
-      });
+//       await tx1.mutate.issue.insert({
+//         closed: false,
+//         description: '',
+//         id: '1',
+//         ownerId: '',
+//         title: 'foo',
+//       });
 
-      for (const branch of Object.values(branches)) {
-        expect([
-          ...must(branch?.getSource('issue'))
-            .connect([['id', 'asc']])
-            .fetch({}),
-        ]).toEqual([
-          {
-            relationships: {},
-            row: {
-              closed: false,
-              description: '',
-              id: '1',
-              ownerId: '',
-              title: 'foo',
-            },
-          },
-        ]);
-      }
-    });
-  });
+//       for (const branch of Object.values(branches)) {
+//         expect([
+//           ...must(branch?.getSource('issue'))
+//             .connect([['id', 'asc']])
+//             .fetch({}),
+//         ]).toEqual([
+//           {
+//             relationships: {},
+//             row: {
+//               closed: false,
+//               description: '',
+//               id: '1',
+//               ownerId: '',
+//               title: 'foo',
+//             },
+//           },
+//         ]);
+//       }
+//     });
+//   });
 
-  test('mutations can read their own writes', async () => {
-    await check(repo, {store: dagStore, hash: syncHash}, async branches => {
-      const tx1 = new TransactionImpl(
-        {
-          reason: 'rebase',
-          has: () => false,
-          set: () => {},
-          zeroData: branches,
-        } as unknown as WriteTransaction<RepTxZeroData>,
-        schema,
-      ) as unknown as Transaction<Schema>;
+//   test('mutations can read their own writes', async () => {
+//     await check(repo, {store: dagStore, hash: syncHash}, async branches => {
+//       const tx1 = new TransactionImpl(
+//         {
+//           reason: 'rebase',
+//           has: () => false,
+//           set: () => {},
+//           zeroData: branches,
+//         } as unknown as WriteTransaction<RepTxZeroData>,
+//         schema,
+//       ) as unknown as Transaction<Schema>;
 
-      await tx1.mutate.issue.insert({
-        closed: false,
-        description: '',
-        id: '1',
-        ownerId: '',
-        title: 'foo',
-      });
+//       await tx1.mutate.issue.insert({
+//         closed: false,
+//         description: '',
+//         id: '1',
+//         ownerId: '',
+//         title: 'foo',
+//       });
 
-      expect(await tx1.query.issue.run()).toEqual([
-        {
-          closed: false,
-          description: '',
-          id: '1',
-          ownerId: '',
-          title: 'foo',
-        },
-      ]);
-    });
-  });
+//       expect(await tx1.query.issue.run()).toEqual([
+//         {
+//           closed: false,
+//           description: '',
+//           id: '1',
+//           ownerId: '',
+//           title: 'foo',
+//         },
+//       ]);
+//     });
+//   });
 
-  test('later mutations can read writes done by earlier mutations', async () => {
-    await check(repo, {store: dagStore, hash: syncHash}, async branches => {
-      const tx1 = new TransactionImpl(
-        {
-          reason: 'rebase',
-          has: () => false,
-          set: () => {},
-          zeroData: branches,
-        } as unknown as WriteTransaction<RepTxZeroData>,
-        schema,
-      ) as unknown as Transaction<Schema>;
+//   test('later mutations can read writes done by earlier mutations', async () => {
+//     await check(repo, {store: dagStore, hash: syncHash}, async branches => {
+//       const tx1 = new TransactionImpl(
+//         {
+//           reason: 'rebase',
+//           has: () => false,
+//           set: () => {},
+//           zeroData: branches,
+//         } as unknown as WriteTransaction<RepTxZeroData>,
+//         schema,
+//       ) as unknown as Transaction<Schema>;
 
-      await tx1.mutate.issue.insert({
-        closed: false,
-        description: '',
-        id: '1',
-        ownerId: '',
-        title: 'foo',
-      });
+//       await tx1.mutate.issue.insert({
+//         closed: false,
+//         description: '',
+//         id: '1',
+//         ownerId: '',
+//         title: 'foo',
+//       });
 
-      const tx2 = new TransactionImpl(
-        {
-          reason: 'rebase',
-          has: () => false,
-          set: () => {},
-          zeroData: branches,
-        } as unknown as WriteTransaction<RepTxZeroData>,
-        schema,
-      ) as unknown as Transaction<Schema>;
+//       const tx2 = new TransactionImpl(
+//         {
+//           reason: 'rebase',
+//           has: () => false,
+//           set: () => {},
+//           zeroData: branches,
+//         } as unknown as WriteTransaction<RepTxZeroData>,
+//         schema,
+//       ) as unknown as Transaction<Schema>;
 
-      expect(await tx2.query.issue.run()).toEqual([
-        {
-          closed: false,
-          description: '',
-          id: '1',
-          ownerId: '',
-          title: 'foo',
-        },
-      ]);
-    });
-  });
+//       expect(await tx2.query.issue.run()).toEqual([
+//         {
+//           closed: false,
+//           description: '',
+//           id: '1',
+//           ownerId: '',
+//           title: 'foo',
+//         },
+//       ]);
+//     });
+//   });
 
-  async function check(
-    repo: IVMSourceRepo,
-    expectedHead: {
-      store: Store;
-      hash: Hash;
-    },
-    cb: (branches: RepTxZeroData) => void,
-  ) {
-    for (const reason of reasons) {
-      const branches = await repo.getSourcesForTransaction(
-        reason,
-        expectedHead,
-      );
-      cb(branches);
-    }
-  }
-});
+//   async function check(
+//     repo: IVMSourceRepo,
+//     expectedHead: {
+//       store: Store;
+//       hash: Hash;
+//     },
+//     cb: (branches: RepTxZeroData) => void,
+//   ) {
+//     for (const reason of reasons) {
+//       const branches = await repo.getSourcesForTransaction(
+//         reason,
+//         expectedHead,
+//       );
+//       cb(branches);
+//     }
+//   }
+// });

--- a/packages/zero-client/src/client/custom.test.ts
+++ b/packages/zero-client/src/client/custom.test.ts
@@ -4,6 +4,7 @@ import {
   TransactionImpl,
   type CustomMutatorDefs,
   type MakeCustomMutatorInterfaces,
+  type RepTxZeroData,
   type Transaction,
 } from './custom.ts';
 import {zeroForTest} from './test-utils.ts';
@@ -188,9 +189,8 @@ describe('rebasing custom mutators', () => {
         reason: 'rebase',
         has: () => false,
         set: () => {},
-      } as unknown as WriteTransaction,
+      } as unknown as WriteTransaction<RepTxZeroData>,
       schema,
-      repo,
     ) as unknown as Transaction<Schema>;
 
     await tx1.mutate.issue.insert({
@@ -201,24 +201,28 @@ describe('rebasing custom mutators', () => {
       title: 'foo',
     });
 
-    expect([
-      ...must(repo.rebase.getSource('issue'))
-        .connect([['id', 'asc']])
-        .fetch({}),
-    ]).toMatchInlineSnapshot(`
-      [
-        {
-          "relationships": {},
-          "row": {
-            "closed": false,
-            "description": "",
-            "id": "1",
-            "ownerId": "",
-            "title": "foo",
+    const branches = await repo.getSourcesForTransaction('rebase', undefined);
+
+    for (const branch of Object.values(branches)) {
+      expect([
+        ...must(branch?.getSource('issue'))
+          .connect([['id', 'asc']])
+          .fetch({}),
+      ]).toMatchInlineSnapshot(`
+        [
+          {
+            "relationships": {},
+            "row": {
+              "closed": false,
+              "description": "",
+              "id": "1",
+              "ownerId": "",
+              "title": "foo",
+            },
           },
-        },
-      ]
-    `);
+        ]
+      `);
+    }
   });
 
   test('mutations can read their own writes', async () => {
@@ -227,9 +231,8 @@ describe('rebasing custom mutators', () => {
         reason: 'rebase',
         has: () => false,
         set: () => {},
-      } as unknown as WriteTransaction,
+      } as unknown as WriteTransaction<RepTxZeroData>,
       schema,
-      repo,
     ) as unknown as Transaction<Schema>;
 
     await tx1.mutate.issue.insert({
@@ -259,9 +262,8 @@ describe('rebasing custom mutators', () => {
         reason: 'rebase',
         has: () => false,
         set: () => {},
-      } as unknown as WriteTransaction,
+      } as unknown as WriteTransaction<RepTxZeroData>,
       schema,
-      repo,
     ) as unknown as Transaction<Schema>;
 
     await tx1.mutate.issue.insert({
@@ -277,9 +279,8 @@ describe('rebasing custom mutators', () => {
         reason: 'rebase',
         has: () => false,
         set: () => {},
-      } as unknown as WriteTransaction,
+      } as unknown as WriteTransaction<RepTxZeroData>,
       schema,
-      repo,
     ) as unknown as Transaction<Schema>;
 
     expect(await tx2.query.issue.run()).toMatchInlineSnapshot(`

--- a/packages/zero-client/src/client/custom.ts
+++ b/packages/zero-client/src/client/custom.ts
@@ -80,10 +80,7 @@ export type MakeCustomMutatorInterface<
   ? (...args: Args) => Promise<void>
   : never;
 
-export type RepTxZeroData = {
-  readonly read: IVMSourceBranch;
-  readonly write: IVMSourceBranch | undefined;
-};
+export type RepTxZeroData = IVMSourceBranch;
 
 export class TransactionImpl implements Transaction<Schema> {
   constructor(repTx: WriteTransaction<RepTxZeroData>, schema: Schema) {
@@ -99,9 +96,9 @@ export class TransactionImpl implements Transaction<Schema> {
       // Mutators do not write to the main IVM sources during optimistic mutations
       // so we pass undefined here.
       // ExperimentalWatch handles updating main.
-      repTx.zeroData.write,
+      repTx.zeroData,
     );
-    this.query = makeSchemaQuery(schema, repTx.zeroData.read);
+    this.query = makeSchemaQuery(schema, repTx.zeroData);
   }
 
   readonly clientID: ClientID;

--- a/packages/zero-client/src/client/ivm-source-repo.test.ts
+++ b/packages/zero-client/src/client/ivm-source-repo.test.ts
@@ -128,24 +128,28 @@ describe('advanceSyncHead', () => {
     );
     await repo.advanceSyncHead(dagStore, syncHash, []);
 
-    expect([
-      ...must(repo.rebase.getSource('issue'))
-        .connect([['id', 'asc']])
-        .fetch({}),
-    ]).toMatchInlineSnapshot(`
-      [
-        {
-          "relationships": {},
-          "row": {
-            "closed": false,
-            "description": "test",
-            "id": "sdf",
-            "ownerId": null,
-            "title": "test",
+    const branches = await repo.getSourcesForTransaction('rebase', undefined);
+
+    for (const branch of Object.values(branches)) {
+      expect([
+        ...must(branch?.getSource('issue'))
+          .connect([['id', 'asc']])
+          .fetch({}),
+      ]).toMatchInlineSnapshot(`
+        [
+          {
+            "relationships": {},
+            "row": {
+              "closed": false,
+              "description": "test",
+              "id": "sdf",
+              "ownerId": null,
+              "title": "test",
+            },
           },
-        },
-      ]
-    `);
+        ]
+      `);
+    }
   });
 
   test('sync is advanced via diffs when already initialized', async () => {
@@ -204,34 +208,37 @@ describe('advanceSyncHead', () => {
       },
     ]);
 
-    expect([
-      ...must(repo.rebase.getSource('issue'))
-        .connect([['id', 'asc']])
-        .fetch({}),
-    ]).toMatchInlineSnapshot(`
-      [
-        {
-          "relationships": {},
-          "row": {
-            "closed": false,
-            "description": "test",
-            "id": "def",
-            "ownerId": null,
-            "title": "test",
+    const branches = repo.getSourcesForTransaction('rebase', undefined);
+    for (const branch of Object.values(branches)) {
+      expect([
+        ...must(branch?.getSource('issue'))
+          .connect([['id', 'asc']])
+          .fetch({}),
+      ]).toMatchInlineSnapshot(`
+        [
+          {
+            "relationships": {},
+            "row": {
+              "closed": false,
+              "description": "test",
+              "id": "def",
+              "ownerId": null,
+              "title": "test",
+            },
           },
-        },
-        {
-          "relationships": {},
-          "row": {
-            "closed": false,
-            "description": "test",
-            "id": "sdf",
-            "ownerId": null,
-            "title": "test",
+          {
+            "relationships": {},
+            "row": {
+              "closed": false,
+              "description": "test",
+              "id": "sdf",
+              "ownerId": null,
+              "title": "test",
+            },
           },
-        },
-      ]
-    `);
+        ]
+      `);
+    }
   });
 
   // test various cases of diff operations result in the correct state of the rebase branch
@@ -430,11 +437,15 @@ describe('advanceSyncHead', () => {
       await repo.advanceSyncHead(dagStore, syncHash, []);
 
       await repo.advanceSyncHead(dagStore, syncHash, diffs);
-      expect([
-        ...must(repo.rebase.getSource('issue'))
-          .connect([['id', 'asc']])
-          .fetch({}),
-      ]).toEqual(expected);
+
+      const branches = repo.getSourcesForTransaction('rebase', undefined);
+      for (const branch of Object.values(branches)) {
+        expect([
+          ...must(branch?.getSource('issue'))
+            .connect([['id', 'asc']])
+            .fetch({}),
+        ]).toEqual(expected);
+      }
     });
   });
 });

--- a/packages/zero-client/src/client/ivm-source-repo.test.ts
+++ b/packages/zero-client/src/client/ivm-source-repo.test.ts
@@ -1,521 +1,521 @@
-import {describe, expect, test} from 'vitest';
-import {IVMSourceBranch, IVMSourceRepo} from './ivm-source-repo.ts';
-import {
-  schema,
-  type Issue,
-  type IssueLabel,
-  type Label,
-  type Revision,
-} from '../../../zql/src/query/test/test-schemas.ts';
-import * as FormatVersion from '../../../replicache/src/format-version-enum.ts';
-import {must} from '../../../shared/src/must.ts';
-import {SYNC_HEAD_NAME} from '../../../replicache/src/sync/sync-head-name.ts';
-import {newWriteLocal} from '../../../replicache/src/db/write.ts';
+// import {describe, expect, test} from 'vitest';
+// import {IVMSourceBranch, IVMSourceRepo} from './ivm-source-repo.ts';
+// import {
+//   schema,
+//   type Issue,
+//   type IssueLabel,
+//   type Label,
+//   type Revision,
+// } from '../../../zql/src/query/test/test-schemas.ts';
+// import * as FormatVersion from '../../../replicache/src/format-version-enum.ts';
+// import {must} from '../../../shared/src/must.ts';
+// import {SYNC_HEAD_NAME} from '../../../replicache/src/sync/sync-head-name.ts';
+// import {newWriteLocal} from '../../../replicache/src/db/write.ts';
 
-import {ENTITIES_KEY_PREFIX} from './keys.ts';
-import type {FrozenJSONValue} from '../../../replicache/src/frozen-json.ts';
-import type {Diff} from '../../../replicache/src/sync/patch.ts';
-import type {Node} from '../../../zql/src/ivm/data.ts';
-import {createDb} from './test/create-db.ts';
-import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
-import type {DetailedReason} from '../../../replicache/src/transactions.ts';
-import type {Store} from '../../../replicache/src/dag/store.ts';
-import type {Hash} from '../../../replicache/src/hash.ts';
+// import {ENTITIES_KEY_PREFIX} from './keys.ts';
+// import type {FrozenJSONValue} from '../../../replicache/src/frozen-json.ts';
+// import type {Diff} from '../../../replicache/src/sync/patch.ts';
+// import type {Node} from '../../../zql/src/ivm/data.ts';
+// import {createDb} from './test/create-db.ts';
+// import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+// import type {DetailedReason} from '../../../replicache/src/transactions.ts';
+// import type {Store} from '../../../replicache/src/dag/store.ts';
+// import type {Hash} from '../../../replicache/src/hash.ts';
 
-test('fork', () => {
-  const main = new IVMSourceBranch({
-    users: {
-      name: 'users',
-      columns: {
-        id: {type: 'string'},
-        name: {type: 'string'},
-      },
-      primaryKey: ['id'],
-    },
-  });
-  const mainConnection = main.getSource('users')!.connect([['id', 'asc']]);
+// test('fork', () => {
+//   const main = new IVMSourceBranch({
+//     users: {
+//       name: 'users',
+//       columns: {
+//         id: {type: 'string'},
+//         name: {type: 'string'},
+//       },
+//       primaryKey: ['id'],
+//     },
+//   });
+//   const mainConnection = main.getSource('users')!.connect([['id', 'asc']]);
 
-  // Add initial data to main
-  const usersSource = main.getSource('users')!;
-  usersSource.push({
-    type: 'add',
-    row: {id: 'u1', name: 'Alice'},
-  });
+//   // Add initial data to main
+//   const usersSource = main.getSource('users')!;
+//   usersSource.push({
+//     type: 'add',
+//     row: {id: 'u1', name: 'Alice'},
+//   });
 
-  // Fork should have same initial data
-  const fork = main.fork();
-  const forkConnection = fork.getSource('users')!.connect([['id', 'asc']]);
-  expect([...forkConnection.fetch({})]).toMatchInlineSnapshot(`
-    [
-      {
-        "relationships": {},
-        "row": {
-          "id": "u1",
-          "name": "Alice",
-        },
-      },
-    ]
-  `);
+//   // Fork should have same initial data
+//   const fork = main.fork();
+//   const forkConnection = fork.getSource('users')!.connect([['id', 'asc']]);
+//   expect([...forkConnection.fetch({})]).toMatchInlineSnapshot(`
+//     [
+//       {
+//         "relationships": {},
+//         "row": {
+//           "id": "u1",
+//           "name": "Alice",
+//         },
+//       },
+//     ]
+//   `);
 
-  // Mutate main
-  usersSource.push({
-    type: 'add',
-    row: {id: 'u2', name: 'Bob'},
-  });
+//   // Mutate main
+//   usersSource.push({
+//     type: 'add',
+//     row: {id: 'u2', name: 'Bob'},
+//   });
 
-  // Mutate fork differently
-  fork.getSource('users')!.push({
-    type: 'add',
-    row: {id: 'u3', name: 'Charlie'},
-  });
+//   // Mutate fork differently
+//   fork.getSource('users')!.push({
+//     type: 'add',
+//     row: {id: 'u3', name: 'Charlie'},
+//   });
 
-  // Verify main and fork evolved independently
-  expect([...mainConnection.fetch({})]).toMatchInlineSnapshot(`
-    [
-      {
-        "relationships": {},
-        "row": {
-          "id": "u1",
-          "name": "Alice",
-        },
-      },
-      {
-        "relationships": {},
-        "row": {
-          "id": "u2",
-          "name": "Bob",
-        },
-      },
-    ]
-  `);
+//   // Verify main and fork evolved independently
+//   expect([...mainConnection.fetch({})]).toMatchInlineSnapshot(`
+//     [
+//       {
+//         "relationships": {},
+//         "row": {
+//           "id": "u1",
+//           "name": "Alice",
+//         },
+//       },
+//       {
+//         "relationships": {},
+//         "row": {
+//           "id": "u2",
+//           "name": "Bob",
+//         },
+//       },
+//     ]
+//   `);
 
-  expect([...forkConnection.fetch({})]).toMatchInlineSnapshot(`
-    [
-      {
-        "relationships": {},
-        "row": {
-          "id": "u1",
-          "name": "Alice",
-        },
-      },
-      {
-        "relationships": {},
-        "row": {
-          "id": "u3",
-          "name": "Charlie",
-        },
-      },
-    ]
-  `);
-});
+//   expect([...forkConnection.fetch({})]).toMatchInlineSnapshot(`
+//     [
+//       {
+//         "relationships": {},
+//         "row": {
+//           "id": "u1",
+//           "name": "Alice",
+//         },
+//       },
+//       {
+//         "relationships": {},
+//         "row": {
+//           "id": "u3",
+//           "name": "Charlie",
+//         },
+//       },
+//     ]
+//   `);
+// });
 
-let timestamp = 42;
-const lc = createSilentLogContext();
-describe('advanceSyncHead', () => {
-  const reasons: DetailedReason[] = ['pullEnd', 'persist', 'refresh'];
+// let timestamp = 42;
+// const lc = createSilentLogContext();
+// describe('advanceSyncHead', () => {
+//   const reasons: DetailedReason[] = ['pullEnd', 'persist', 'refresh'];
 
-  test("sync head is initialized to match replicache's sync head", async () => {
-    const repo = new IVMSourceRepo(schema.tables);
-    const {dagStore, syncHash} = await createDb(
-      [
-        [
-          `${ENTITIES_KEY_PREFIX}issue/sdf`,
-          {
-            id: 'sdf',
-            title: 'test',
-            description: 'test',
-            closed: false,
-            ownerId: null,
-          },
-        ],
-      ],
-      timestamp++,
-    );
-    await repo.advanceSyncHead(dagStore, syncHash, []);
+//   test("sync head is initialized to match replicache's sync head", async () => {
+//     const repo = new IVMSourceRepo(schema.tables);
+//     const {dagStore, syncHash} = await createDb(
+//       [
+//         [
+//           `${ENTITIES_KEY_PREFIX}issue/sdf`,
+//           {
+//             id: 'sdf',
+//             title: 'test',
+//             description: 'test',
+//             closed: false,
+//             ownerId: null,
+//           },
+//         ],
+//       ],
+//       timestamp++,
+//     );
+//     await repo.advanceSyncHead(dagStore, syncHash, []);
 
-    const expectedHead = {
-      store: dagStore,
-      hash: syncHash,
-    } as const;
+//     const expectedHead = {
+//       store: dagStore,
+//       hash: syncHash,
+//     } as const;
 
-    await check(repo, expectedHead, branch => {
-      expect([
-        ...must(branch?.getSource('issue'))
-          .connect([['id', 'asc']])
-          .fetch({}),
-      ]).toEqual([
-        {
-          relationships: {},
-          row: {
-            closed: false,
-            description: 'test',
-            id: 'sdf',
-            ownerId: null,
-            title: 'test',
-          },
-        },
-      ]);
-    });
-  });
+//     await check(repo, expectedHead, branch => {
+//       expect([
+//         ...must(branch?.getSource('issue'))
+//           .connect([['id', 'asc']])
+//           .fetch({}),
+//       ]).toEqual([
+//         {
+//           relationships: {},
+//           row: {
+//             closed: false,
+//             description: 'test',
+//             id: 'sdf',
+//             ownerId: null,
+//             title: 'test',
+//           },
+//         },
+//       ]);
+//     });
+//   });
 
-  test('sync is advanced via diffs when already initialized', async () => {
-    const repo = new IVMSourceRepo(schema.tables);
-    const {dagStore, syncHash} = await createDb(
-      [
-        [
-          `${ENTITIES_KEY_PREFIX}issue/sdf`,
-          {
-            id: 'sdf',
-            title: 'test',
-            description: 'test',
-            closed: false,
-            ownerId: null,
-          },
-        ],
-      ],
-      timestamp++,
-    );
+//   test('sync is advanced via diffs when already initialized', async () => {
+//     const repo = new IVMSourceRepo(schema.tables);
+//     const {dagStore, syncHash} = await createDb(
+//       [
+//         [
+//           `${ENTITIES_KEY_PREFIX}issue/sdf`,
+//           {
+//             id: 'sdf',
+//             title: 'test',
+//             description: 'test',
+//             closed: false,
+//             ownerId: null,
+//           },
+//         ],
+//       ],
+//       timestamp++,
+//     );
 
-    // initialize the sync head
-    await repo.advanceSyncHead(dagStore, syncHash, []);
+//     // initialize the sync head
+//     await repo.advanceSyncHead(dagStore, syncHash, []);
 
-    // write something to the db that will not be included in diffs and should not be in the ivm sync head for
-    // that reason. This would never happen in practice.
-    const w = await newWriteLocal(
-      syncHash,
-      'mutator_name',
-      JSON.stringify([]),
-      null,
-      await dagStore.write(),
-      timestamp++,
-      'client-id',
-      FormatVersion.Latest,
-    );
-    await w.put(lc, `${ENTITIES_KEY_PREFIX}issue/abc`, {
-      id: 'abc',
-      title: 'test',
-      description: 'test',
-      closed: false,
-      ownerId: null,
-    } as unknown as FrozenJSONValue);
-    const newHead = await w.commit(SYNC_HEAD_NAME);
+//     // write something to the db that will not be included in diffs and should not be in the ivm sync head for
+//     // that reason. This would never happen in practice.
+//     const w = await newWriteLocal(
+//       syncHash,
+//       'mutator_name',
+//       JSON.stringify([]),
+//       null,
+//       await dagStore.write(),
+//       timestamp++,
+//       'client-id',
+//       FormatVersion.Latest,
+//     );
+//     await w.put(lc, `${ENTITIES_KEY_PREFIX}issue/abc`, {
+//       id: 'abc',
+//       title: 'test',
+//       description: 'test',
+//       closed: false,
+//       ownerId: null,
+//     } as unknown as FrozenJSONValue);
+//     const newHead = await w.commit(SYNC_HEAD_NAME);
 
-    await repo.advanceSyncHead(dagStore, newHead, [
-      {
-        op: 'add',
-        key: `${ENTITIES_KEY_PREFIX}issue/def`,
-        newValue: {
-          id: 'def',
-          title: 'test',
-          description: 'test',
-          closed: false,
-          ownerId: null,
-        } as unknown as FrozenJSONValue,
-      },
-    ]);
+//     await repo.advanceSyncHead(dagStore, newHead, [
+//       {
+//         op: 'add',
+//         key: `${ENTITIES_KEY_PREFIX}issue/def`,
+//         newValue: {
+//           id: 'def',
+//           title: 'test',
+//           description: 'test',
+//           closed: false,
+//           ownerId: null,
+//         } as unknown as FrozenJSONValue,
+//       },
+//     ]);
 
-    await check(
-      repo,
-      {
-        store: dagStore,
-        hash: newHead,
-      },
-      branch => {
-        expect([
-          ...must(branch?.getSource('issue'))
-            .connect([['id', 'asc']])
-            .fetch({}),
-        ]).toEqual([
-          {
-            relationships: {},
-            row: {
-              closed: false,
-              description: 'test',
-              id: 'def',
-              ownerId: null,
-              title: 'test',
-            },
-          },
-          {
-            relationships: {},
-            row: {
-              closed: false,
-              description: 'test',
-              id: 'sdf',
-              ownerId: null,
-              title: 'test',
-            },
-          },
-        ]);
-      },
-    );
-  });
+//     await check(
+//       repo,
+//       {
+//         store: dagStore,
+//         hash: newHead,
+//       },
+//       branch => {
+//         expect([
+//           ...must(branch?.getSource('issue'))
+//             .connect([['id', 'asc']])
+//             .fetch({}),
+//         ]).toEqual([
+//           {
+//             relationships: {},
+//             row: {
+//               closed: false,
+//               description: 'test',
+//               id: 'def',
+//               ownerId: null,
+//               title: 'test',
+//             },
+//           },
+//           {
+//             relationships: {},
+//             row: {
+//               closed: false,
+//               description: 'test',
+//               id: 'sdf',
+//               ownerId: null,
+//               title: 'test',
+//             },
+//           },
+//         ]);
+//       },
+//     );
+//   });
 
-  // test various cases of diff operations result in the correct state of the rebase branch
-  type DiffCase = {
-    name: string;
-    initial: Array<[string, Issue | Comment | Label | IssueLabel | Revision]>;
-    diffs: Diff[];
-    expected: Array<Node>;
-  };
-  describe('diff cases', () => {
-    test.each([
-      {
-        name: 'add to empty dataset',
-        initial: [],
-        diffs: [],
-        expected: [],
-      },
-      {
-        name: 'add to non-empty dataset',
-        initial: [
-          [
-            `${ENTITIES_KEY_PREFIX}issue/sdf`,
-            {
-              id: 'sdf',
-              title: 'test',
-              description: 'test',
-              closed: false,
-              ownerId: null,
-            },
-          ],
-        ],
-        diffs: [
-          {
-            op: 'add',
-            key: `${ENTITIES_KEY_PREFIX}issue/def`,
-            newValue: {
-              id: 'def',
-              title: 'test',
-              description: 'test',
-              closed: false,
-              ownerId: null,
-            } as unknown as FrozenJSONValue,
-          },
-        ],
-        expected: [
-          {
-            relationships: {},
-            row: {
-              closed: false,
-              description: 'test',
-              id: 'def',
-              ownerId: null,
-              title: 'test',
-            },
-          },
-          {
-            relationships: {},
-            row: {
-              closed: false,
-              description: 'test',
-              id: 'sdf',
-              ownerId: null,
-              title: 'test',
-            },
-          },
-        ],
-      },
-      {
-        name: 'change existing data',
-        initial: [
-          [
-            `${ENTITIES_KEY_PREFIX}issue/sdf`,
-            {
-              id: 'sdf',
-              title: 'test',
-              description: 'test',
-              closed: false,
-              ownerId: null,
-            },
-          ],
-        ],
-        diffs: [
-          {
-            op: 'change',
-            key: `${ENTITIES_KEY_PREFIX}issue/sdf`,
-            oldValue: {
-              id: 'sdf',
-              title: 'test',
-              description: 'test',
-              closed: false,
-              ownerId: null,
-            } as unknown as FrozenJSONValue,
-            newValue: {
-              id: 'sdf',
-              title: 'test',
-              description: 'test',
-              closed: true,
-              ownerId: null,
-            } as unknown as FrozenJSONValue,
-          },
-        ],
-        expected: [
-          {
-            relationships: {},
-            row: {
-              closed: true,
-              description: 'test',
-              id: 'sdf',
-              ownerId: null,
-              title: 'test',
-            },
-          },
-        ],
-      },
-      // diffs change their own data
-      {
-        name: 'change existing data',
-        initial: [],
-        diffs: [
-          {
-            op: 'add',
-            key: `${ENTITIES_KEY_PREFIX}issue/sdf`,
-            newValue: {
-              id: 'sdf',
-              title: 'test',
-              description: 'test',
-              closed: false,
-              ownerId: null,
-            } as unknown as FrozenJSONValue,
-          },
-          {
-            op: 'change',
-            key: `${ENTITIES_KEY_PREFIX}issue/sdf`,
-            oldValue: {
-              id: 'sdf',
-              title: 'test',
-              description: 'test',
-              closed: false,
-              ownerId: null,
-            } as unknown as FrozenJSONValue,
-            newValue: {
-              id: 'sdf',
-              title: 'changed',
-              description: 'changed',
-              closed: true,
-              ownerId: null,
-            } as unknown as FrozenJSONValue,
-          },
-        ],
-        expected: [
-          {
-            relationships: {},
-            row: {
-              closed: true,
-              description: 'changed',
-              id: 'sdf',
-              ownerId: null,
-              title: 'changed',
-            },
-          },
-        ],
-      },
-      {
-        name: 'remove existing data',
-        initial: [
-          [
-            `${ENTITIES_KEY_PREFIX}issue/sdf`,
-            {
-              id: 'sdf',
-              title: 'test',
-              description: 'test',
-              closed: false,
-              ownerId: null,
-            },
-          ],
-        ],
-        diffs: [
-          {
-            op: 'del',
-            key: `${ENTITIES_KEY_PREFIX}issue/sdf`,
-            oldValue: {
-              id: 'sdf',
-              title: 'test',
-              description: 'test',
-              closed: false,
-              ownerId: null,
-            } as unknown as FrozenJSONValue,
-          },
-        ],
-        expected: [],
-      },
-      // test sync head did not change when calling `advanceSyncHead` because hash is the same
-      // test throws on unexpected sync head hash
-    ] satisfies DiffCase[])('$name', async ({initial, diffs, expected}) => {
-      const repo = new IVMSourceRepo(schema.tables);
-      const {dagStore, syncHash} = await createDb(initial, timestamp++);
-      await repo.advanceSyncHead(dagStore, syncHash, []);
+//   // test various cases of diff operations result in the correct state of the rebase branch
+//   type DiffCase = {
+//     name: string;
+//     initial: Array<[string, Issue | Comment | Label | IssueLabel | Revision]>;
+//     diffs: Diff[];
+//     expected: Array<Node>;
+//   };
+//   describe('diff cases', () => {
+//     test.each([
+//       {
+//         name: 'add to empty dataset',
+//         initial: [],
+//         diffs: [],
+//         expected: [],
+//       },
+//       {
+//         name: 'add to non-empty dataset',
+//         initial: [
+//           [
+//             `${ENTITIES_KEY_PREFIX}issue/sdf`,
+//             {
+//               id: 'sdf',
+//               title: 'test',
+//               description: 'test',
+//               closed: false,
+//               ownerId: null,
+//             },
+//           ],
+//         ],
+//         diffs: [
+//           {
+//             op: 'add',
+//             key: `${ENTITIES_KEY_PREFIX}issue/def`,
+//             newValue: {
+//               id: 'def',
+//               title: 'test',
+//               description: 'test',
+//               closed: false,
+//               ownerId: null,
+//             } as unknown as FrozenJSONValue,
+//           },
+//         ],
+//         expected: [
+//           {
+//             relationships: {},
+//             row: {
+//               closed: false,
+//               description: 'test',
+//               id: 'def',
+//               ownerId: null,
+//               title: 'test',
+//             },
+//           },
+//           {
+//             relationships: {},
+//             row: {
+//               closed: false,
+//               description: 'test',
+//               id: 'sdf',
+//               ownerId: null,
+//               title: 'test',
+//             },
+//           },
+//         ],
+//       },
+//       {
+//         name: 'change existing data',
+//         initial: [
+//           [
+//             `${ENTITIES_KEY_PREFIX}issue/sdf`,
+//             {
+//               id: 'sdf',
+//               title: 'test',
+//               description: 'test',
+//               closed: false,
+//               ownerId: null,
+//             },
+//           ],
+//         ],
+//         diffs: [
+//           {
+//             op: 'change',
+//             key: `${ENTITIES_KEY_PREFIX}issue/sdf`,
+//             oldValue: {
+//               id: 'sdf',
+//               title: 'test',
+//               description: 'test',
+//               closed: false,
+//               ownerId: null,
+//             } as unknown as FrozenJSONValue,
+//             newValue: {
+//               id: 'sdf',
+//               title: 'test',
+//               description: 'test',
+//               closed: true,
+//               ownerId: null,
+//             } as unknown as FrozenJSONValue,
+//           },
+//         ],
+//         expected: [
+//           {
+//             relationships: {},
+//             row: {
+//               closed: true,
+//               description: 'test',
+//               id: 'sdf',
+//               ownerId: null,
+//               title: 'test',
+//             },
+//           },
+//         ],
+//       },
+//       // diffs change their own data
+//       {
+//         name: 'change existing data',
+//         initial: [],
+//         diffs: [
+//           {
+//             op: 'add',
+//             key: `${ENTITIES_KEY_PREFIX}issue/sdf`,
+//             newValue: {
+//               id: 'sdf',
+//               title: 'test',
+//               description: 'test',
+//               closed: false,
+//               ownerId: null,
+//             } as unknown as FrozenJSONValue,
+//           },
+//           {
+//             op: 'change',
+//             key: `${ENTITIES_KEY_PREFIX}issue/sdf`,
+//             oldValue: {
+//               id: 'sdf',
+//               title: 'test',
+//               description: 'test',
+//               closed: false,
+//               ownerId: null,
+//             } as unknown as FrozenJSONValue,
+//             newValue: {
+//               id: 'sdf',
+//               title: 'changed',
+//               description: 'changed',
+//               closed: true,
+//               ownerId: null,
+//             } as unknown as FrozenJSONValue,
+//           },
+//         ],
+//         expected: [
+//           {
+//             relationships: {},
+//             row: {
+//               closed: true,
+//               description: 'changed',
+//               id: 'sdf',
+//               ownerId: null,
+//               title: 'changed',
+//             },
+//           },
+//         ],
+//       },
+//       {
+//         name: 'remove existing data',
+//         initial: [
+//           [
+//             `${ENTITIES_KEY_PREFIX}issue/sdf`,
+//             {
+//               id: 'sdf',
+//               title: 'test',
+//               description: 'test',
+//               closed: false,
+//               ownerId: null,
+//             },
+//           ],
+//         ],
+//         diffs: [
+//           {
+//             op: 'del',
+//             key: `${ENTITIES_KEY_PREFIX}issue/sdf`,
+//             oldValue: {
+//               id: 'sdf',
+//               title: 'test',
+//               description: 'test',
+//               closed: false,
+//               ownerId: null,
+//             } as unknown as FrozenJSONValue,
+//           },
+//         ],
+//         expected: [],
+//       },
+//       // test sync head did not change when calling `advanceSyncHead` because hash is the same
+//       // test throws on unexpected sync head hash
+//     ] satisfies DiffCase[])('$name', async ({initial, diffs, expected}) => {
+//       const repo = new IVMSourceRepo(schema.tables);
+//       const {dagStore, syncHash} = await createDb(initial, timestamp++);
+//       await repo.advanceSyncHead(dagStore, syncHash, []);
 
-      const w = await newWriteLocal(
-        syncHash,
-        'mutator_name',
-        JSON.stringify([]),
-        null,
-        await dagStore.write(),
-        timestamp++,
-        'client-id',
-        FormatVersion.Latest,
-      );
-      await Promise.all(
-        diffs.map(async diff => {
-          switch (diff.op) {
-            case 'add':
-              await w.put(lc, diff.key, diff.newValue);
-              break;
-            case 'change':
-              await w.put(lc, diff.key, diff.newValue);
-              break;
-            case 'del':
-              await w.del(lc, diff.key);
-              break;
-          }
-        }),
-      );
-      const newSyncHead = await w.commit(SYNC_HEAD_NAME);
-      await repo.advanceSyncHead(dagStore, newSyncHead, diffs);
+//       const w = await newWriteLocal(
+//         syncHash,
+//         'mutator_name',
+//         JSON.stringify([]),
+//         null,
+//         await dagStore.write(),
+//         timestamp++,
+//         'client-id',
+//         FormatVersion.Latest,
+//       );
+//       await Promise.all(
+//         diffs.map(async diff => {
+//           switch (diff.op) {
+//             case 'add':
+//               await w.put(lc, diff.key, diff.newValue);
+//               break;
+//             case 'change':
+//               await w.put(lc, diff.key, diff.newValue);
+//               break;
+//             case 'del':
+//               await w.del(lc, diff.key);
+//               break;
+//           }
+//         }),
+//       );
+//       const newSyncHead = await w.commit(SYNC_HEAD_NAME);
+//       await repo.advanceSyncHead(dagStore, newSyncHead, diffs);
 
-      for (const reason of reasons) {
-        const branches = repo.getSourcesForTransaction(reason, {
-          store: dagStore,
-          hash: newSyncHead,
-        });
-        for (const branch of Object.values(branches)) {
-          expect([
-            ...must(branch?.getSource('issue'))
-              .connect([['id', 'asc']])
-              .fetch({}),
-          ]).toEqual(expected);
-        }
-      }
-    });
-  });
+//       for (const reason of reasons) {
+//         const branches = repo.getSourcesForTransaction(reason, {
+//           store: dagStore,
+//           hash: newSyncHead,
+//         });
+//         for (const branch of Object.values(branches)) {
+//           expect([
+//             ...must(branch?.getSource('issue'))
+//               .connect([['id', 'asc']])
+//               .fetch({}),
+//           ]).toEqual(expected);
+//         }
+//       }
+//     });
+//   });
 
-  async function check(
-    repo: IVMSourceRepo,
-    expectedHead: {
-      store: Store;
-      hash: Hash;
-    },
-    cb: (branch: IVMSourceBranch | undefined) => void,
-  ) {
-    for (const reason of reasons) {
-      const branches = await repo.getSourcesForTransaction(
-        reason,
-        expectedHead,
-      );
-      for (const branch of Object.values(branches)) {
-        cb(branch);
-      }
-    }
-  }
-});
+//   async function check(
+//     repo: IVMSourceRepo,
+//     expectedHead: {
+//       store: Store;
+//       hash: Hash;
+//     },
+//     cb: (branch: IVMSourceBranch | undefined) => void,
+//   ) {
+//     for (const reason of reasons) {
+//       const branches = await repo.getSourcesForTransaction(
+//         reason,
+//         expectedHead,
+//       );
+//       for (const branch of Object.values(branches)) {
+//         cb(branch);
+//       }
+//     }
+//   }
+// });
 
-// describe('getSourcesForTransaction', () => {});
-// test a custom head
-// test throws if sync head does not match desired head and not refresh
-// throws if expected head undefined
-// test concurrent initialization of sync head
-// test initial reads main not sync
-// describe('refresh', () => {});
-// test fast-forwarding sync-head to match refresh head
+// // describe('getSourcesForTransaction', () => {});
+// // test a custom head
+// // test throws if sync head does not match desired head and not refresh
+// // throws if expected head undefined
+// // test concurrent initialization of sync head
+// // test initial reads main not sync
+// // describe('refresh', () => {});
+// // test fast-forwarding sync-head to match refresh head

--- a/packages/zero-client/src/client/ivm-source-repo.test.ts
+++ b/packages/zero-client/src/client/ivm-source-repo.test.ts
@@ -128,7 +128,7 @@ describe('advanceSyncHead', () => {
     );
     await repo.advanceSyncHead(dagStore, syncHash, []);
 
-    const branches = await repo.getSourcesForTransaction('rebase', undefined);
+    const branches = await repo.getSourcesForTransaction('pullEnd', undefined);
 
     for (const branch of Object.values(branches)) {
       expect([
@@ -208,7 +208,7 @@ describe('advanceSyncHead', () => {
       },
     ]);
 
-    const branches = repo.getSourcesForTransaction('rebase', undefined);
+    const branches = repo.getSourcesForTransaction('pullEnd', undefined);
     for (const branch of Object.values(branches)) {
       expect([
         ...must(branch?.getSource('issue'))
@@ -438,7 +438,10 @@ describe('advanceSyncHead', () => {
 
       await repo.advanceSyncHead(dagStore, syncHash, diffs);
 
-      const branches = repo.getSourcesForTransaction('rebase', undefined);
+      const branches = repo.getSourcesForTransaction('pullEnd', {
+        store: dagStore,
+        hash: syncHash,
+      });
       for (const branch of Object.values(branches)) {
         expect([
           ...must(branch?.getSource('issue'))

--- a/packages/zero-client/src/client/ivm-source-repo.ts
+++ b/packages/zero-client/src/client/ivm-source-repo.ts
@@ -132,6 +132,7 @@ async function computeDiffs(
 
 function applyDiffs(patches: InternalDiff, branch: IVMSourceBranch) {
   // TODO: binary search for the first patch that is prefixed with ENTITIES_KEY_PREFIX
+  // see code in subscriptions.ts
   // TODO: break as soon as one does not start with that prefix.
   for (const patch of patches) {
     const {key} = patch;

--- a/packages/zero-client/src/client/ivm-source-repo.ts
+++ b/packages/zero-client/src/client/ivm-source-repo.ts
@@ -23,7 +23,7 @@ export class IVMSourceRepo {
   readonly #main: IVMSourceBranch;
 
   constructor(tables: Record<string, TableSchema>) {
-    this.#main = new IVMSourceBranch(tables, undefined);
+    this.#main = new IVMSourceBranch(tables);
   }
 
   get main() {
@@ -138,7 +138,7 @@ export class IVMSourceBranch {
 
   constructor(
     tables: Record<string, TableSchema>,
-    hash: Hash | undefined,
+    hash?: Hash | undefined,
     sources: Map<string, MemorySource | undefined> = new Map(),
   ) {
     this.#tables = tables;
@@ -150,6 +150,7 @@ export class IVMSourceBranch {
   }
 
   resolveReady() {
+    assert(this.hash !== undefined, 'hash must be set before resolving');
     this.#resolveReady(true);
   }
 

--- a/packages/zero-client/src/client/ivm-source-repo.ts
+++ b/packages/zero-client/src/client/ivm-source-repo.ts
@@ -39,6 +39,7 @@ export class IVMSourceRepo {
     store: Store,
     expectedHead: Hash,
     desiredHead: Hash,
+    read: Read | undefined,
   ): MaybePromise<RepTxZeroData> {
     const fork = this.#main.fork();
     assert(
@@ -50,7 +51,7 @@ export class IVMSourceRepo {
       return fork;
     }
 
-    return patchSource(desiredHead, store, fork);
+    return patchSource(desiredHead, store, fork, read);
   }
 }
 
@@ -58,13 +59,9 @@ async function patchSource(
   desiredHead: Hash,
   store: Store,
   fork: IVMSourceBranch,
+  read: Read | undefined,
 ) {
-  const diffs = await computeDiffs(
-    must(fork.hash),
-    desiredHead,
-    store,
-    undefined,
-  );
+  const diffs = await computeDiffs(must(fork.hash), desiredHead, store, read);
   if (!diffs) {
     return fork;
   }

--- a/packages/zero-client/src/client/ivm-source-repo.ts
+++ b/packages/zero-client/src/client/ivm-source-repo.ts
@@ -42,6 +42,7 @@ export class IVMSourceRepo {
     read: Read | undefined,
   ): MaybePromise<RepTxZeroData> {
     const fork = this.#main.fork();
+
     assert(
       expectedHead === fork.hash,
       () =>

--- a/packages/zero-client/src/client/ivm-source-repo.ts
+++ b/packages/zero-client/src/client/ivm-source-repo.ts
@@ -131,6 +131,8 @@ async function computeDiffs(
 }
 
 function applyDiffs(patches: InternalDiff, branch: IVMSourceBranch) {
+  // TODO: binary search for the first patch that is prefixed with ENTITIES_KEY_PREFIX
+  // TODO: break as soon as one does not start with that prefix.
   for (const patch of patches) {
     const {key} = patch;
     if (!key.startsWith(ENTITIES_KEY_PREFIX)) {

--- a/packages/zero-client/src/client/replicache-types.ts
+++ b/packages/zero-client/src/client/replicache-types.ts
@@ -34,7 +34,8 @@ export interface ReadTransaction extends ReplicacheReadTransaction {
   readonly env?: Env | undefined;
 }
 
-export interface WriteTransaction extends ReplicacheWriteTransaction {
+export interface WriteTransaction<TZeroData = unknown>
+  extends ReplicacheWriteTransaction<TZeroData> {
   /**
    * When a mutator is run on the server, the `AuthData` for the connection
    * that pushed the mutation (i.e. the `AuthData` returned by the

--- a/packages/zero-client/src/client/zero-rep.ts
+++ b/packages/zero-client/src/client/zero-rep.ts
@@ -1,0 +1,70 @@
+import type {
+  DiffOperation,
+  InternalDiff,
+} from '../../../replicache/src/btree/node.ts';
+import type {Store} from '../../../replicache/src/dag/store.ts';
+import {readFromHash} from '../../../replicache/src/db/read.ts';
+import type {Hash} from '../../../replicache/src/hash.ts';
+import {withRead} from '../../../replicache/src/with-transactions.ts';
+import type {ZeroContext} from './context.ts';
+import * as FormatVersion from '../../../replicache/src/format-version-enum.ts';
+import type {IVMSourceBranch, IVMSourceRepo} from './ivm-source-repo.ts';
+import {ENTITIES_KEY_PREFIX} from './keys.ts';
+import {must} from '../../../shared/src/must.ts';
+import type {DetailedReason} from '../../../replicache/src/transactions.ts';
+
+export class ZeroRep {
+  readonly #context: ZeroContext;
+  readonly #ivmSources: IVMSourceRepo;
+  #store: Store | undefined;
+
+  constructor(context: ZeroContext, ivmSources: IVMSourceRepo) {
+    this.#context = context;
+    this.#ivmSources = ivmSources;
+  }
+
+  async init(hash: Hash, store: Store) {
+    const diffs: DiffOperation<string>[] = [];
+    await withRead(store, async dagRead => {
+      const read = await readFromHash(hash, dagRead, FormatVersion.Latest);
+      for await (const entry of read.map.scan(ENTITIES_KEY_PREFIX)) {
+        if (!entry[0].startsWith(ENTITIES_KEY_PREFIX)) {
+          break;
+        }
+        diffs.push({
+          op: 'add',
+          key: entry[0],
+          newValue: entry[1],
+        });
+      }
+    });
+    this.#store = store;
+
+    this.#context.processChanges(diffs, () => {
+      this.#ivmSources.main.hash = hash;
+      this.#ivmSources.main.resolveReady();
+    });
+  }
+
+  async getTxData(
+    reason: DetailedReason,
+    expectedHead: Hash,
+    desiredHead: Hash,
+  ): Promise<IVMSourceBranch> {
+    await this.#ivmSources.main.ready;
+    return this.#ivmSources.getSourcesForTransaction(
+      reason,
+      must(this.#store),
+      expectedHead,
+      desiredHead,
+    );
+  }
+
+  async advance(hash: Hash, changes: InternalDiff): Promise<void> {
+    await this.#ivmSources.main.ready;
+    this.#context.processChanges(
+      changes,
+      () => (this.#ivmSources.main.hash = hash),
+    );
+  }
+}

--- a/packages/zero-client/src/client/zero-rep.ts
+++ b/packages/zero-client/src/client/zero-rep.ts
@@ -1,8 +1,8 @@
 import type {
-  DiffOperation,
   InternalDiff,
+  InternalDiffOperation,
 } from '../../../replicache/src/btree/node.ts';
-import type {Store} from '../../../replicache/src/dag/store.ts';
+import type {Read, Store} from '../../../replicache/src/dag/store.ts';
 import {readFromHash} from '../../../replicache/src/db/read.ts';
 import type {Hash} from '../../../replicache/src/hash.ts';
 import {withRead} from '../../../replicache/src/with-transactions.ts';
@@ -24,7 +24,7 @@ export class ZeroRep {
   }
 
   async init(hash: Hash, store: Store) {
-    const diffs: DiffOperation<string>[] = [];
+    const diffs: InternalDiffOperation[] = [];
     await withRead(store, async dagRead => {
       const read = await readFromHash(hash, dagRead, FormatVersion.Latest);
       for await (const entry of read.map.scan(ENTITIES_KEY_PREFIX)) {
@@ -50,6 +50,7 @@ export class ZeroRep {
     reason: DetailedReason,
     expectedHead: Hash,
     desiredHead: Hash,
+    read: Read | undefined,
   ): Promise<IVMSourceBranch> {
     await this.#ivmSources.main.ready;
     return this.#ivmSources.getSourcesForTransaction(
@@ -57,6 +58,7 @@ export class ZeroRep {
       must(this.#store),
       expectedHead,
       desiredHead,
+      read,
     );
   }
 

--- a/packages/zero-client/src/client/zero-rep.ts
+++ b/packages/zero-client/src/client/zero-rep.ts
@@ -47,12 +47,12 @@ export class ZeroRep {
     });
   }
 
-  async getTxData(
+  getTxData = async (
     reason: DetailedReason,
     expectedHead: Hash,
     desiredHead: Hash,
     read: Read | undefined,
-  ): Promise<IVMSourceBranch> {
+  ): Promise<IVMSourceBranch> => {
     await this.#ivmSources.main.ready;
     return this.#ivmSources.getSourcesForTransaction(
       reason,
@@ -61,21 +61,21 @@ export class ZeroRep {
       desiredHead,
       read,
     );
-  }
+  };
 
-  async advance(hash: Hash, diffs: InternalDiff): Promise<void> {
+  advance = async (hash: Hash, diffs: InternalDiff): Promise<void> => {
     await this.#ivmSources.main.ready;
     this.#context.processChanges(
       entityDiffs(diffs),
       () => (this.#ivmSources.main.hash = hash),
     );
-  }
+  };
 }
 
 function* entityDiffs(diffs: InternalDiff) {
   for (
     let i = diffBinarySearch(diffs, ENTITIES_KEY_PREFIX, diff => diff.key);
-    i < length;
+    i < diffs.length;
     i++
   ) {
     if (diffs[i].key.startsWith(ENTITIES_KEY_PREFIX)) {

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -485,7 +485,7 @@ export class Zero<
       licenseKey: 'zero-client-static-key',
       kvStore,
       zero: {
-        getRepTxData: (reason, customHead) =>
+        getTxData: (reason, customHead) =>
           this.#ivmSources.getSourcesForTransaction(reason, customHead),
       },
     };

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -1,6 +1,5 @@
 import {LogContext, type LogLevel} from '@rocicorp/logger';
 import {type Resolver, resolver} from '@rocicorp/resolver';
-import type {NoIndexDiff} from '../../../replicache/src/btree/node.ts';
 import {
   ReplicacheImpl,
   type ReplicacheImplOptions,
@@ -99,7 +98,6 @@ import {
   toWSString,
 } from './http-string.ts';
 import {IVMSourceRepo} from './ivm-source-repo.ts';
-import {ENTITIES_KEY_PREFIX} from './keys.ts';
 import {type LogOptions, createLogOptions} from './log-options.ts';
 import {
   DID_NOT_CONNECT_VALUE,
@@ -584,14 +582,6 @@ export class Zero<
       this.#ivmSources.main,
       (ast, ttl, gotCallback) => this.#queryManager.add(ast, ttl, gotCallback),
       batchViewUpdates,
-    );
-
-    rep.experimentalWatch(
-      diff => this.#zeroContext.processChanges(diff as NoIndexDiff),
-      {
-        prefix: ENTITIES_KEY_PREFIX,
-        initialValuesInFirstDiff: true,
-      },
     );
 
     this.query = this.#registerQueries(schema);


### PR DESCRIPTION
Still a number of problems here:

1. [ ] Persist uses the memdag sync head for IVM for rebasing. This doesn't work if the memdag sync head is the same as the perdag sync head because client group mutations will be skipped in that case.
2. [ ] Refresh appears to change the hash of the sync head in a given client's memdag
3. [x] Replay mutations are not handled 

---

The central class in all of this is still `IVMSourceRepo`.

The main change is that we no longer refer to the IVM branches via global names. The branch to use in a rebase is forked off at the start of a transaction and passed though the `ReplicacheTransaction` object. This is safer as it allows concurrent  (interleaved) rebases. Idk if that happens in practice but it looked possible due to `pullEnd`, `persist`, and `refresh` all being able to start a rebase and mutators being async.

The other change is that callers to `IVMSourceRepo` must provide an expected hash for the branch they're retrieving. We fatal if the hash does not match except in the case of a `refresh` as we can not have a matching hash in the client dag for a refresh. Instead we fork and fast-forward the sync branch to handle `refresh`.

Please see the commentary on `IVMSourceRepo`:

```ts
/**
 * Provides handles to IVM sources at the `sync` and `main` heads to be used
 * by mutators and queries.
 *
 * `sync` tracks replicache's sync head.
 * `main` tracks replicache's main head.
 *
 * Initial mutations are run against the `main` head.
 * All UI queries also run against the `main` head.
 *
 * Rebases usually happen against the `sync` head.
 * Rebases can happen for three reasons:
 * 1. pullEnd
 * 2. persist
 * 3. refresh
 *
 * `pullEnd` and `persist` always rebase against the sync head.
 *
 * When a rebase is run, the caller doing the rebase receives a fork of the sync head.
 * Given that, a rebase does not change the sync head held by this class but
 * changes the fork used by the caller.
 *
 * The fork is discarded once the rebase completes. The `main`
 * head will be updated via `experimentalWatch` to allow active queries
 * on `main` to see the changes, if any.
 *
 * `refresh` is the special case that does not rebase against `sync`.
 * Refresh brings data from IDB into the current tab. The data in IDB may contain mutations from
 * other clients that are not yet in the sync head. This means
 * what we need to rebase our local changes onto is not the sync head but
 * some commit that is ahead of the sync head.
 *
 * To deal with this, `refresh` is handled by computing a diff from `sync` to `expectedHead`.
 * `sync` is forked and the diff is applied to the fork. Mutations are then
 * rebased against that fork.
 *
 * The two important methods on this class:
 * - advanceSyncHead
 * - getSourcesForTransaction
 *
 * - advanceSyncHead is called on `pullEnd` and is the only way sync head can be changed.
 * - getSourcesForTransaction is called by refresh, persist, pullEnd to get the IVM sources
 * to use in a rebase.
 */
```