### PR TITLE
Emit a warning if no IDB instead of hard crash.

### DIFF
--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -397,7 +397,6 @@ export class Zero<
       onUpdateNeeded,
       onClientStateNotFound,
       hiddenTabDisconnectDelay = DEFAULT_DISCONNECT_HIDDEN_DELAY_MS,
-      kvStore = 'idb',
       schema,
       batchViewUpdates = applyViewUpdates => applyViewUpdates(),
       maxRecentQueries = 0,
@@ -410,6 +409,17 @@ export class Zero<
       server,
       false /*options.enableAnalytics,*/, // Reenable analytics
     );
+
+    let {kvStore = 'idb'} = options as ZeroAdvancedOptions<S>;
+    if (kvStore === 'idb') {
+      if (!getBrowserGlobal('indexedDB')) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          'IndexedDB is not supported in this environment. Falling back to memory storage.',
+        );
+        kvStore = 'mem';
+      }
+    }
 
     if (hiddenTabDisconnectDelay < 0) {
       throw new Error(


### PR DESCRIPTION
This makes it consistent with what we do for `WebSocket` and makes it a little easier to use Zero in SSR environments.

Surprisingly commonly people don't even want to actually sync server-side they just want to be able to _isntantiate_ Zero server-side to avoid too much branching.

I'm not entirely sure this is a great idea, but at least it is consistent for now.