### PR TITLE
feat(zero-client): log stack on close

### DIFF
--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -741,6 +741,8 @@ export class Zero<
   close(): Promise<void> {
     const lc = this.#lc.withContext('close');
 
+    lc.debug?.('Closing Zero instance. Stack:', new Error().stack);
+
     if (this.#connectionState !== ConnectionState.Disconnected) {
       this.#disconnect(lc, {
         client: 'ClientClosed',


### PR DESCRIPTION
The stack trace is now logged at debug level when the client is closed.

This allows associating errors that happens during close.

https://bugs.rocicorp.dev/issue/3598