### PR TITLE
feat(zero): WebSocket close beacon

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/client-handler.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.ts
@@ -268,6 +268,7 @@ export class ClientHandler {
   }
 
   sendDeleteClients(
+    lc: LogContext,
     deletedClientIDs: string[],
     deletedClientGroupIDs: string[],
   ): void {
@@ -278,6 +279,7 @@ export class ClientHandler {
     if (deletedClientGroupIDs.length > 0) {
       deleteClientsBody.clientGroupIDs = deletedClientGroupIDs;
     }
+    lc.debug?.('sending deleteClients', deleteClientsBody);
     this.#downstream.push(['deleteClients', deleteClientsBody]);
   }
 

--- a/packages/zero-cache/src/workers/syncer-ws-message-handler.ts
+++ b/packages/zero-cache/src/workers/syncer-ws-message-handler.ts
@@ -1,22 +1,22 @@
 import {trace} from '@opentelemetry/api';
 import {Lock} from '@rocicorp/lock';
+import type {LogContext} from '@rocicorp/logger';
+import type {JWTPayload} from 'jose';
+import {startAsyncSpan, startSpan} from '../../../otel/src/span.ts';
+import {version} from '../../../otel/src/version.ts';
+import {unreachable} from '../../../shared/src/asserts.ts';
+import * as ErrorKind from '../../../zero-protocol/src/error-kind-enum.ts';
+import type {ErrorBody} from '../../../zero-protocol/src/error.ts';
+import type {Upstream} from '../../../zero-protocol/src/up.ts';
+import type {ConnectParams} from '../services/dispatcher/connect-params.ts';
 import type {Mutagen} from '../services/mutagen/mutagen.ts';
+import type {Pusher} from '../services/mutagen/pusher.ts';
 import type {
   SyncContext,
   TokenData,
   ViewSyncer,
 } from '../services/view-syncer/view-syncer.ts';
 import type {HandlerResult, MessageHandler} from './connection.ts';
-import {version} from '../../../otel/src/version.ts';
-import * as ErrorKind from '../../../zero-protocol/src/error-kind-enum.ts';
-import type {Upstream} from '../../../zero-protocol/src/up.ts';
-import {startAsyncSpan, startSpan} from '../../../otel/src/span.ts';
-import {unreachable} from '../../../shared/src/asserts.ts';
-import type {LogContext} from '@rocicorp/logger';
-import type {JWTPayload} from 'jose';
-import type {ErrorBody} from '../../../zero-protocol/src/error.ts';
-import type {ConnectParams} from '../services/dispatcher/connect-params.ts';
-import type {Pusher} from '../services/mutagen/pusher.ts';
 
 const tracer = trace.getTracer('syncer-ws-server', version);
 
@@ -151,6 +151,12 @@ export class SyncerWsMessageHandler implements MessageHandler {
           stream,
         };
       }
+      case 'closeConnection':
+        await startAsyncSpan(tracer, 'connection.closeConnection', () =>
+          viewSyncer.closeConnection(this.#syncContext, msg),
+        );
+        break;
+
       default:
         unreachable(msgType);
     }

--- a/packages/zero-client/src/client/test-utils.ts
+++ b/packages/zero-client/src/client/test-utils.ts
@@ -25,6 +25,7 @@ import type {
 import {upstreamSchema} from '../../../zero-protocol/src/up.ts';
 import type {Schema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import * as ConnectionState from './connection-state-enum.ts';
+import type {CustomMutatorDefs} from './custom.ts';
 import type {LogOptions} from './log-options.ts';
 import type {ZeroOptions} from './options.ts';
 import {
@@ -35,7 +36,6 @@ import {
   getInternalReplicacheImplForTesting,
   onSetConnectionStateSymbol,
 } from './zero.ts';
-import type {CustomMutatorDefs} from './custom.ts';
 
 type ConnectionState = Enum<typeof ConnectionState>;
 type ErrorKind = Enum<typeof ErrorKind>;

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -1,7 +1,7 @@
 import {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
 import * as sinon from 'sinon';
-import {afterEach, beforeEach, describe, expect, suite, test, vi} from 'vitest';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {setDeletedClients} from '../../../replicache/src/deleted-clients.ts';
 import type {ReplicacheImpl} from '../../../replicache/src/replicache-impl.ts';
 import type {
@@ -343,7 +343,7 @@ const mockDeleteClientsManager = {
     }),
 } as unknown as DeleteClientsManager;
 
-suite('createSocket', () => {
+describe('createSocket', () => {
   const t = (
     socketURL: WSString,
     baseCookie: NullableVersion,
@@ -568,7 +568,7 @@ suite('createSocket', () => {
   );
 });
 
-suite('initConnection', () => {
+describe('initConnection', () => {
   test('not sent when connected message received but before ConnectionState.Connected', async () => {
     const r = zeroForTest();
     const mockSocket = await r.socket;
@@ -2189,7 +2189,7 @@ test('Constructing Zero with a negative hiddenTabDisconnectDelay option throws a
     );
 });
 
-suite('Disconnect on hide', () => {
+describe('Disconnect on hide', () => {
   type Case = {
     name: string;
     hiddenTabDisconnectDelay?: number | undefined;
@@ -2417,7 +2417,7 @@ test(ErrorKind.InvalidConnectionRequest, async () => {
   });
 });
 
-suite('Invalid Downstream message', () => {
+describe('Invalid Downstream message', () => {
   type Case = {
     name: string;
     duringPing: boolean;
@@ -2642,7 +2642,7 @@ test('the type of collection should be inferred from options with parse', () => 
   expect(commentQ).not.undefined;
 });
 
-suite('CRUD', () => {
+describe('CRUD', () => {
   const makeZero = () =>
     zeroForTest({
       schema: createSchema(1, {
@@ -2831,7 +2831,7 @@ suite('CRUD', () => {
   });
 });
 
-suite('CRUD with compound primary key', () => {
+describe('CRUD with compound primary key', () => {
   type Issue = {
     ids: string;
     idn: number;

--- a/packages/zero-protocol/src/close-connection.ts
+++ b/packages/zero-protocol/src/close-connection.ts
@@ -1,0 +1,23 @@
+import * as v from '../../shared/src/valita.ts';
+
+/**
+ * We do not use the body yet.
+ */
+export const closeConnectionBodySchema = v.array(v.unknown());
+
+/**
+ * This message gets sent as part of the close reason in the WebSocket close event.
+ * The close reason is a string, so we serialize this message to JSON.
+ 
+ * "The value must be no longer than 123 bytes (encoded in UTF-8)." -
+ * https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close#reason
+ */
+export const closeConnectionMessageSchema = v.tuple([
+  v.literal('closeConnection'),
+  closeConnectionBodySchema,
+]);
+
+export type CloseConnectionBody = v.Infer<typeof closeConnectionBodySchema>;
+export type CloseConnectionMessage = v.Infer<
+  typeof closeConnectionMessageSchema
+>;

--- a/packages/zero-protocol/src/up.ts
+++ b/packages/zero-protocol/src/up.ts
@@ -1,5 +1,6 @@
 import * as v from '../../shared/src/valita.ts';
 import {changeDesiredQueriesMessageSchema} from './change-desired-queries.ts';
+import {closeConnectionMessageSchema} from './close-connection.ts';
 import {initConnectionMessageSchema} from './connect.ts';
 import {deleteClientsMessageSchema} from './delete-clients.ts';
 import {pingMessageSchema} from './ping.ts';
@@ -13,6 +14,7 @@ export const upstreamSchema = v.union(
   changeDesiredQueriesMessageSchema,
   pullRequestMessageSchema,
   pushMessageSchema,
+  closeConnectionMessageSchema,
 );
 
 export type Upstream = v.Infer<typeof upstreamSchema>;


### PR DESCRIPTION
When Zero close is called we send a special close reason that is interpreted by the view syncer.

We send this close reason on pagehide when persisted is false. This websocket send goes through in unload when the tab is closed or reloaded. Different browsers deals with navigation differently.

https://replicache.notion.site/Close-Beacon-Yes-or-no-1ab3bed895458060bf8ad19603a2979f

In the view syncer, when we get this clean close we delete the client which means that it will no longer make queries desired by that client.