### PR TITLE
feat(zero-cache): faster sync+startup with manual vacuum policy

### DIFF
--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -80,6 +80,13 @@ test('zero-cache --help', () => {
                                                                 This can be lost, but if it is, zero-cache will have to re-replicate next                         
                                                                 time it starts up.                                                                                
                                                                                                                                                                   
+     --replica-vacuum-interval-hours number                     optional                                                                                          
+       ZERO_REPLICA_VACUUM_INTERVAL_HOURS env                                                                                                                     
+                                                                Performs a VACUUM at server startup if the specified number of hours has elapsed                  
+                                                                since the last VACUUM (or initial-sync). The VACUUM operation is heavyweight                      
+                                                                and requires double the size of the db in disk space. If unspecified, VACUUM                      
+                                                                operations are not performed.                                                                     
+                                                                                                                                                                  
      --log-level debug,info,warn,error                          default: "info"                                                                                   
        ZERO_LOG_LEVEL env                                                                                                                                         
                                                                                                                                                                   

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -87,6 +87,29 @@ export const shardOptions = {
   },
 };
 
+const replicaOptions = {
+  file: {
+    type: v.string(),
+    desc: [
+      `File path to the SQLite replica that zero-cache maintains.`,
+      `This can be lost, but if it is, zero-cache will have to re-replicate next`,
+      `time it starts up.`,
+    ],
+  },
+
+  vacuumIntervalHours: {
+    type: v.number().optional(),
+    desc: [
+      `Performs a VACUUM at server startup if the specified number of hours has elapsed`,
+      `since the last VACUUM (or initial-sync). The VACUUM operation is heavyweight`,
+      `and requires double the size of the db in disk space. If unspecified, VACUUM`,
+      `operations are not performed.`,
+    ],
+  },
+};
+
+export type ReplicaOptions = Config<typeof replicaOptions>;
+
 const perUserMutationLimit = {
   max: {
     type: v.number().optional(),
@@ -238,16 +261,7 @@ export const zeroOptions = {
     },
   },
 
-  replica: {
-    file: {
-      type: v.string(),
-      desc: [
-        `File path to the SQLite replica that zero-cache maintains.`,
-        `This can be lost, but if it is, zero-cache will have to re-replicate next`,
-        `time it starts up.`,
-      ],
-    },
-  },
+  replica: replicaOptions,
 
   log: logOptions,
 

--- a/packages/zero-cache/src/server/multi/config.test.ts
+++ b/packages/zero-cache/src/server/multi/config.test.ts
@@ -321,6 +321,13 @@ test('zero-cache --help', () => {
                                                                 This can be lost, but if it is, zero-cache will have to re-replicate next                         
                                                                 time it starts up.                                                                                
                                                                                                                                                                   
+     --replica-vacuum-interval-hours number                     optional                                                                                          
+       ZERO_REPLICA_VACUUM_INTERVAL_HOURS env                                                                                                                     
+                                                                Performs a VACUUM at server startup if the specified number of hours has elapsed                  
+                                                                since the last VACUUM (or initial-sync). The VACUUM operation is heavyweight                      
+                                                                and requires double the size of the db in disk space. If unspecified, VACUUM                      
+                                                                operations are not performed.                                                                     
+                                                                                                                                                                  
      --log-level debug,info,warn,error                          default: "info"                                                                                   
        ZERO_LOG_LEVEL env                                                                                                                                         
                                                                                                                                                                   

--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -34,7 +34,7 @@ export default async function runWorker(
   const workerName = `${mode}-replicator`;
   const lc = createLogContext(config, {worker: workerName});
 
-  const replica = setupReplica(lc, fileMode, config.replica.file);
+  const replica = setupReplica(lc, fileMode, config.replica);
 
   const changeStreamerPort = config.changeStreamerPort ?? config.port + 1;
   const changeStreamerURI =

--- a/packages/zero-cache/src/services/change-source/pg/sync-schema.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/sync-schema.pg-test.ts
@@ -21,8 +21,8 @@ const SHARD_NUM = 9;
 
 // Update as necessary.
 const CURRENT_SCHEMA_VERSIONS = {
-  dataVersion: 4,
-  schemaVersion: 4,
+  dataVersion: 5,
+  schemaVersion: 5,
   minSafeVersion: 1,
   lock: 1, // Internal column, always 1
 };

--- a/packages/zero-cache/src/services/change-source/pg/sync-schema.ts
+++ b/packages/zero-cache/src/services/change-source/pg/sync-schema.ts
@@ -7,6 +7,10 @@ import {
 } from '../../../db/migration-lite.ts';
 import type {ShardConfig} from '../../../types/shards.ts';
 import {AutoResetSignal} from '../../change-streamer/schema/tables.ts';
+import {
+  CREATE_RUNTIME_EVENTS_TABLE,
+  recordEvent,
+} from '../../replicator/schema/replication-state.ts';
 import {initialSync, type InitialSyncOptions} from './initial-sync.ts';
 
 export async function initSyncSchema(
@@ -30,6 +34,15 @@ export async function initSyncSchema(
         throw new AutoResetSignal('upgrading replica to new schema');
       },
       minSafeVersion: 3,
+    },
+
+    5: {
+      migrateSchema: (_, db) => {
+        db.exec(CREATE_RUNTIME_EVENTS_TABLE);
+      },
+      migrateData: (_, db) => {
+        recordEvent(db, 'upgrade');
+      },
     },
   };
 

--- a/packages/zero-cache/src/services/replicator/schema/replication-state.ts
+++ b/packages/zero-cache/src/services/replicator/schema/replication-state.ts
@@ -11,6 +11,19 @@ import {StatementRunner} from '../../../db/statements.ts';
 
 export const ZERO_VERSION_COLUMN_NAME = '_0_version';
 
+export type RuntimeEvent = 'sync' | 'upgrade' | 'vacuum';
+
+// event     : The RuntimeEvent. Only one row per event is tracked.
+//             Inserting an event will REPLACE any row for the same event.
+// timestamp : SQLite timestamp string, e.g. "2024-04-12 11:37:46".
+//             Append a `Z` when parsing with `new Date(...)`;
+export const CREATE_RUNTIME_EVENTS_TABLE = `
+  CREATE TABLE "_zero.runtimeEvents" (
+    event TEXT PRIMARY KEY ON CONFLICT REPLACE,
+    timestamp TEXT NOT NULL DEFAULT (current_timestamp)
+  );
+`;
+
 const CREATE_REPLICATION_STATE_SCHEMA =
   // replicaVersion   : A value identifying the version at which the initial sync happened, i.e.
   //                    the version at which all rows were copied, and to `_0_version` was set.
@@ -35,7 +48,8 @@ const CREATE_REPLICATION_STATE_SCHEMA =
     stateVersion TEXT NOT NULL,
     lock INTEGER PRIMARY KEY DEFAULT 1 CHECK (lock=1)
   );
-  `;
+  ` +
+  CREATE_RUNTIME_EVENTS_TABLE;
 
 const stringArray = v.array(v.string());
 
@@ -75,6 +89,29 @@ export function initReplicationState(
     INSERT INTO "_zero.replicationState" (stateVersion) VALUES (?)
     `,
   ).run(watermark);
+  recordEvent(db, 'sync');
+}
+
+export function recordEvent(db: Database, event: RuntimeEvent) {
+  db.prepare(
+    `
+    INSERT INTO "_zero.runtimeEvents" (event) VALUES (?) 
+    `,
+  ).run(event);
+}
+
+export function getAscendingEvents(db: Database) {
+  const result = db
+    .prepare(
+      `SELECT event, timestamp FROM "_zero.runtimeEvents" 
+         ORDER BY timestamp ASC
+    `,
+    )
+    .all<{event: string; timestamp: string}>();
+  return result.map(({event, timestamp}) => ({
+    event,
+    timestamp: new Date(timestamp + 'Z'),
+  }));
 }
 
 export function getSubscriptionState(db: StatementRunner): SubscriptionState {


### PR DESCRIPTION
### Context

`VACUUM` is a heavyweight operation that takes:
* 150% the time it takes to copy rows in initial sync (on NVMe)
* 50% the time it takes to copy rows in initial sync (on EBS)

<img width="2440" alt="Screenshot 2025-03-01 at 11 26 38" src="https://github.com/user-attachments/assets/46ed66d5-a709-43f0-9545-53d34fd464c3" />

It is particularly unnecessary right after initial-sync, where fragmentation should be very low (and can be forced to 0 by limiting to a single table copy worker). Indexes in particular should be completely contiguous now that they are created post-copy (#3835)

VACUUM-ing on every server restart can also be considered a premature optimization, and without empirical evidence that VACUUM-ing is needed, it does not justify slowing down server startup, particularly for large databases.

### Feature

Automatic VACUUMs are replaced with manual policies. 
* The currently implemented policy is a periodic interval (defaulting to never). 
* We can consider adding more policies based on other heuristics later.

(For example, a developer can force a vacuum by setting the interval to 0 and restarting.)

### Other optimizations

During initial sync we can assume exclusive access to the db. These settings are thus enabled to maximize SQLite performance:
* `locking_mode = EXCLUSIVE`
* `journal_mode = OFF`
* `synchronous = OFF`  (pre-existing optimization)