### PR TITLE
feat(zero): Inactive desired queries when deleting a client 

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr-store.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.ts
@@ -467,13 +467,11 @@ export class CVRStore {
   }
 
   deleteClient(clientID: string) {
-    for (const name of ['desires', 'clients'] as const) {
-      this.#writes.add({
-        stats: {[name]: 1},
-        write: tx =>
-          tx`DELETE FROM ${this.#cvr(name)} WHERE "clientID" = ${clientID}`,
-      });
-    }
+    this.#writes.add({
+      stats: {clients: 1},
+      write: tx =>
+        tx`DELETE FROM ${this.#cvr('clients')} WHERE "clientID" = ${clientID}`,
+    });
   }
 
   deleteClientGroup(clientGroupID: string) {

--- a/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
@@ -1,4 +1,4 @@
-import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {unreachable} from '../../../../shared/src/asserts.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {sleep} from '../../../../shared/src/sleep.ts';
@@ -4555,6 +4555,7 @@ describe('view-syncer/cvr', () => {
   });
 
   test('deleteClient', async () => {
+    vi.setSystemTime(Date.UTC(2024, 2, 6));
     const initialState: DBState = {
       instances: [
         {
@@ -4681,7 +4682,7 @@ describe('view-syncer/cvr', () => {
       lc,
       true,
       LAST_CONNECT,
-      Date.UTC(2024, 3, 23, 1),
+      Date.now(),
     );
     expect(updated).toMatchInlineSnapshot(`
       {
@@ -4700,7 +4701,7 @@ describe('view-syncer/cvr', () => {
           },
         },
         "id": "abc123",
-        "lastActive": 1713834000000,
+        "lastActive": 1709683200000,
         "queries": {
           "oneHash": {
             "ast": {
@@ -4713,6 +4714,14 @@ describe('view-syncer/cvr', () => {
                 "version": {
                   "minorVersion": 1,
                   "stateVersion": "1a9",
+                },
+              },
+              "client-b": {
+                "inactivatedAt": 1709683200000,
+                "ttl": undefined,
+                "version": {
+                  "minorVersion": 1,
+                  "stateVersion": "1aa",
                 },
               },
               "client-c": {
@@ -4740,12 +4749,12 @@ describe('view-syncer/cvr', () => {
     expect(flushed).toMatchInlineSnapshot(`
       {
         "clients": 1,
-        "desires": 2,
+        "desires": 1,
         "instances": 2,
         "queries": 1,
         "rows": 0,
         "rowsDeferred": 0,
-        "statements": 7,
+        "statements": 6,
       }
     `);
 
@@ -4784,12 +4793,21 @@ describe('view-syncer/cvr', () => {
             "queryHash": "oneHash",
             "ttl": null,
           },
+          {
+            "clientGroupID": "abc123",
+            "clientID": "client-b",
+            "deleted": true,
+            "inactivatedAt": 1709683200000,
+            "patchVersion": "1aa:01",
+            "queryHash": "oneHash",
+            "ttl": null,
+          },
         ],
         "instances": Result [
           {
             "clientGroupID": "abc123",
             "grantedAt": 1709251200000,
-            "lastActive": 1713834000000,
+            "lastActive": 1709683200000,
             "owner": "my-task",
             "replicaVersion": "120",
             "version": "1aa:01",
@@ -5067,6 +5085,15 @@ describe('view-syncer/cvr', () => {
           {
             "clientGroupID": "abc123",
             "clientID": "client-a",
+            "deleted": null,
+            "inactivatedAt": null,
+            "patchVersion": "1a9:01",
+            "queryHash": "oneHash",
+            "ttl": null,
+          },
+          {
+            "clientGroupID": "def456",
+            "clientID": "client-b",
             "deleted": null,
             "inactivatedAt": null,
             "patchVersion": "1a9:01",

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -387,8 +387,13 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
       return [];
     }
 
-    // When a client is deleted we remove the desired queries and the client itself.
-    const patches = this.deleteDesiredQueries(clientID, client.desiredQueryIDs);
+    // When a client is deleted we mark all of its desired queries as inactive.
+    // They will then be removed when the queries expire.
+    const patches = this.markDesiredQueriesAsInactive(
+      clientID,
+      client.desiredQueryIDs,
+      Date.now(),
+    );
     delete this._cvr.clients[clientID];
     this._cvrStore.deleteClient(clientID);
 

--- a/packages/zero-cache/src/services/view-syncer/schema/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/cvr.ts
@@ -157,10 +157,6 @@ CREATE TABLE ${schema(shard)}.desires (
 
   PRIMARY KEY ("clientGroupID", "clientID", "queryHash"),
 
-  CONSTRAINT fk_desires_client
-    FOREIGN KEY("clientGroupID", "clientID")
-    REFERENCES ${ident(cvrSchema(shard))}.clients("clientGroupID", "clientID"),
-
   CONSTRAINT fk_desires_query
     FOREIGN KEY("clientGroupID", "queryHash")
     REFERENCES ${ident(cvrSchema(shard))}.queries("clientGroupID", "queryHash")

--- a/packages/zero-cache/src/services/view-syncer/schema/init.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/init.ts
@@ -89,6 +89,14 @@ export async function initViewSyncerSchema(
     },
   };
 
+  const migrateV7ToV8: Migration = {
+    migrateSchema: async (_, tx) => {
+      await tx`ALTER TABLE ${tx(
+        schema,
+      )}."desires" DROP CONSTRAINT fk_desires_client`;
+    },
+  };
+
   const schemaVersionMigrationMap: IncrementalMigrationMap = {
     2: migrateV1toV2,
     3: migrateV2ToV3,
@@ -98,6 +106,7 @@ export async function initViewSyncerSchema(
     5: {minSafeVersion: 3},
     6: migrateV5ToV6,
     7: migrateV6ToV7,
+    8: migrateV7ToV8,
   };
 
   await runSchemaMigrations(

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -529,6 +529,9 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         client.sendDeleteClients(lc, [clientID], []);
       }
     }
+
+    this.#scheduleExpireEviction(lc, cvr);
+    await this.#evictInactiveQueries(lc, cvr);
   };
 
   /**

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -17,10 +17,7 @@ import {must} from '../../../../shared/src/must.ts';
 import {randInt} from '../../../../shared/src/rand.ts';
 import type {AST} from '../../../../zero-protocol/src/ast.ts';
 import type {ChangeDesiredQueriesMessage} from '../../../../zero-protocol/src/change-desired-queries.ts';
-import type {
-  CloseConnectionBody,
-  CloseConnectionMessage,
-} from '../../../../zero-protocol/src/close-connection.ts';
+import type {CloseConnectionMessage} from '../../../../zero-protocol/src/close-connection.ts';
 import type {
   InitConnectionBody,
   InitConnectionMessage,
@@ -515,28 +512,6 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
     return this.#cvr;
   }
-
-  readonly #closeConnection = async (
-    lc: LogContext,
-    clientID: string,
-    _body: CloseConnectionBody,
-    cvr: CVRSnapshot,
-  ): Promise<void> => {
-    lc.debug?.('closing connection');
-
-    await this.#updateCVRConfig(lc, cvr, updater =>
-      updater.deleteClient(clientID),
-    );
-
-    for (const client of this.#getClients()) {
-      if (client.clientID !== clientID) {
-        client.sendDeleteClients(lc, [clientID], []);
-      }
-    }
-
-    this.#scheduleExpireEviction(lc, cvr);
-    await this.#evictInactiveQueries(lc, cvr);
-  };
 
   /**
    * Runs the given `fn` to process the `msg` from within the `#lock`,


### PR DESCRIPTION
We used to delete the desired queries of a client when the client was
deleted. This was causing the queries and its rows to be removed from
the client group and when a client is re-added the rows had to be
fetched again.

Instead, when a client is deleted, we inactive the desired queries of
the deleted client. This way, the queries will use the ttl to determine
if the queries and its rows should be kept or removed.