### PR TITLE
feat(zero-cache): auto-reset on an unsupported ADD COLUMN schema change

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/schema/published.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/published.pg-test.ts
@@ -85,7 +85,7 @@ describe('tables/published', () => {
         handle text DEFAULT null,
         address text[],
         boolean BOOL DEFAULT 'false',
-        int int8 DEFAULT 2147483647,
+        int int8 DEFAULT (2147483647 + 2),
         flt FLOAT8 DEFAULT 123.456,
         bigint int8 DEFAULT 2147483648,
         timez TIMESTAMPTZ[],
@@ -159,7 +159,7 @@ describe('tables/published', () => {
                 dataType: 'int8',
                 typeOID: 20,
                 notNull: false,
-                dflt: '2147483647',
+                dflt: '(2147483647 + 2)',
               },
               flt: {
                 pos: 6,


### PR DESCRIPTION
SQLite has limited constraints on what DEFAULT values it accepts when adding a column:

https://www.sqlite.org/lang_altertable.html#altertabaddcol

Detect when an added column violates those constraints and initiate an `--auto-reset` in response. (The alternative an status quo is replication getting stuck)

User reports:

https://discord.com/channels/830183651022471199/1346154873661554768/1346562509024530463

https://bugs.rocicorp.dev/issue/3359