### PR TITLE
feat(custom-mutators): re-work transaction types to allow code sharing

### DIFF
--- a/packages/zero-client/src/client/custom.test.ts
+++ b/packages/zero-client/src/client/custom.test.ts
@@ -4,14 +4,14 @@ import {
   TransactionImpl,
   type CustomMutatorDefs,
   type MakeCustomMutatorInterfaces,
-  type Transaction,
 } from './custom.ts';
 import {zeroForTest} from './test-utils.ts';
 import {createDb} from './test/create-db.ts';
 import {IVMSourceRepo} from './ivm-source-repo.ts';
 import type {WriteTransaction} from './replicache-types.ts';
 import {must} from '../../../shared/src/must.ts';
-import type {InsertValue} from '../../../zql/src/mutate/custom.ts';
+import type {InsertValue, Transaction} from '../../../zql/src/mutate/custom.ts';
+
 type Schema = typeof schema;
 
 test('argument types are preserved on the generated mutator interface', () => {

--- a/packages/zero-client/src/client/custom.ts
+++ b/packages/zero-client/src/client/custom.ts
@@ -10,25 +10,16 @@ import {newQuery} from '../../../zql/src/query/query-impl.ts';
 import type {Query} from '../../../zql/src/query/query.ts';
 import {ZeroContext} from './context.ts';
 import type {
+  ClientTransaction,
   DeleteID,
   InsertValue,
   SchemaCRUD,
   SchemaQuery,
   TableCRUD,
-  TransactionBase,
+  Transaction,
   UpdateValue,
   UpsertValue,
 } from '../../../zql/src/mutate/custom.ts';
-
-/**
- * An instance of this is passed to custom mutator implementations and
- * allows reading and writing to the database and IVM at the head
- * at which the mutator is being applied.
- */
-export interface Transaction<S extends Schema> extends TransactionBase<S> {
-  readonly location: 'client';
-  readonly reason: 'optimistic' | 'rebase';
-}
 
 /**
  * The shape which a user's custom mutator definitions must conform to.
@@ -80,7 +71,7 @@ export type MakeCustomMutatorInterface<
   ? (...args: Args) => Promise<void>
   : never;
 
-export class TransactionImpl implements Transaction<Schema> {
+export class TransactionImpl implements ClientTransaction<Schema> {
   constructor(
     repTx: WriteTransaction,
     schema: Schema,

--- a/packages/zero-client/src/mod.ts
+++ b/packages/zero-client/src/mod.ts
@@ -103,3 +103,7 @@ export type {
 } from '../../zql/src/mutate/custom.ts';
 export type {ZeroOptions} from './client/options.ts';
 export {Zero} from './client/zero.ts';
+export type {
+  ServerTransaction,
+  Transaction,
+} from '../../zql/src/mutate/custom.ts';

--- a/packages/zero-pg/src/custom.pg-test.ts
+++ b/packages/zero-pg/src/custom.pg-test.ts
@@ -3,10 +3,9 @@ import {testDBs} from '../../zero-cache/src/test/db.ts';
 import {beforeEach, describe, expect, test} from 'vitest';
 import type {PostgresDB} from '../../zero-cache/src/types/pg.ts';
 
-import type {DBTransaction} from './db.ts';
 import {makeSchemaCRUD} from './custom.ts';
 import {Transaction} from './test/util.ts';
-import type {SchemaCRUD} from '../../zql/src/mutate/custom.ts';
+import type {DBTransaction, SchemaCRUD} from '../../zql/src/mutate/custom.ts';
 import {schema, schemaSql} from './test/schema.ts';
 
 describe('makeSchemaCRUD', () => {

--- a/packages/zero-pg/src/custom.ts
+++ b/packages/zero-pg/src/custom.ts
@@ -6,8 +6,9 @@ import type {
   SchemaQuery,
   TableCRUD,
   TransactionBase,
+  ConnectionProvider,
+  DBTransaction,
 } from '../../zql/src/mutate/custom.ts';
-import type {ConnectionProvider, DBTransaction} from './db.ts';
 import {PushProcessor, type PushHandler} from './web.ts';
 import {formatPg, sql} from '../../z2s/src/sql.ts';
 

--- a/packages/zero-pg/src/db.ts
+++ b/packages/zero-pg/src/db.ts
@@ -1,36 +1,9 @@
 import type {Schema} from '../../zero-schema/src/builder/schema-builder.ts';
 import type {TransactionBase} from '../../zql/src/mutate/custom.ts';
-import type {MaybePromise} from '../../shared/src/types.ts';
 
 export interface ZeroTransaction<S extends Schema, TDBTransaction>
   extends TransactionBase<S> {
   readonly location: 'server';
   readonly reason: 'authoritative';
   readonly dbTransaction: TDBTransaction;
-}
-
-export interface Row {
-  [column: string]: unknown;
-}
-
-/**
- * A function that returns a connection to the database which
- * will be used by custom mutators.
- */
-export type ConnectionProvider<TWrappedTransaction> = () => MaybePromise<
-  DBConnection<TWrappedTransaction>
->;
-
-export interface DBConnection<TWrappedTransaction> extends Queryable {
-  transaction: <T>(
-    cb: (tx: DBTransaction<TWrappedTransaction>) => Promise<T>,
-  ) => Promise<T>;
-}
-
-export interface DBTransaction<T> extends Queryable {
-  readonly wrappedTransaction: T;
-}
-
-interface Queryable {
-  query: (query: string, args: unknown[]) => Promise<Iterable<Row>>;
 }

--- a/packages/zero-pg/src/mod.ts
+++ b/packages/zero-pg/src/mod.ts
@@ -1,10 +1,11 @@
 export {createPushHandler} from './custom.ts';
 export type {CustomMutatorDefs, CustomMutatorImpl} from './custom.ts';
-export type {Transaction} from './custom.ts';
 export type {
+  Transaction,
+  ServerTransaction,
   DBConnection,
   DBTransaction,
   ConnectionProvider,
   Row,
-} from './db.ts';
+} from '../../zql/src/mutate/custom.ts';
 export type {PushHandler} from './web.ts';

--- a/packages/zero-pg/src/query.pg-test.ts
+++ b/packages/zero-pg/src/query.pg-test.ts
@@ -1,11 +1,10 @@
 import {beforeEach, describe, expect, test} from 'vitest';
-import type {SchemaQuery} from '../../zql/src/mutate/custom.ts';
+import type {SchemaQuery, DBTransaction} from '../../zql/src/mutate/custom.ts';
 import type {PostgresDB} from '../../zero-cache/src/types/pg.ts';
 import {schema, schemaSql, seedDataSql} from './test/schema.ts';
 import {testDBs} from '../../zero-cache/src/test/db.ts';
 import {makeSchemaQuery} from './query.ts';
 import {Transaction} from './test/util.ts';
-import type {DBTransaction} from './db.ts';
 
 describe('makeSchemaQuery', () => {
   let pg: PostgresDB;

--- a/packages/zero-pg/src/query.ts
+++ b/packages/zero-pg/src/query.ts
@@ -1,14 +1,13 @@
 import {first} from '../../shared/src/iterables.ts';
 import {compile} from '../../z2s/src/compiler.ts';
 import {formatPg} from '../../z2s/src/sql.ts';
-import type {AST} from '../../zero-protocol/src/ast.ts';
 import type {Schema} from '../../zero-schema/src/builder/schema-builder.ts';
+import type {SchemaQuery, DBTransaction} from '../../zql/src/mutate/custom.ts';
+import type {AST} from '../../zero-protocol/src/ast.ts';
 import type {Format} from '../../zql/src/ivm/view.ts';
-import type {SchemaQuery} from '../../zql/src/mutate/custom.ts';
 import {AbstractQuery} from '../../zql/src/query/query-impl.ts';
 import type {HumanReadable, PullRow, Query} from '../../zql/src/query/query.ts';
 import type {TypedView} from '../../zql/src/query/typed-view.ts';
-import type {DBTransaction} from './db.ts';
 
 export function makeSchemaQuery<S extends Schema>(
   schema: S,

--- a/packages/zero-pg/src/test/util.ts
+++ b/packages/zero-pg/src/test/util.ts
@@ -1,4 +1,8 @@
-import type {DBConnection, DBTransaction, Row} from '../db.ts';
+import type {
+  DBConnection,
+  DBTransaction,
+  Row,
+} from '../../../zql/src/mutate/custom.ts';
 import type {JSONValue} from '../../../shared/src/json.ts';
 import type {
   PostgresDB,

--- a/packages/zero-pg/src/web.ts
+++ b/packages/zero-pg/src/web.ts
@@ -6,7 +6,6 @@ import type {
   PushResponse,
 } from '../../zero-protocol/src/push.ts';
 import type {Schema} from '../../zero-schema/src/builder/schema-builder.ts';
-import type {ConnectionProvider, DBConnection, DBTransaction} from './db.ts';
 import * as v from '../../shared/src/valita.ts';
 import {pushBodySchema} from '../../zero-protocol/src/push.ts';
 import {
@@ -21,6 +20,9 @@ import {
   splitMutatorKey,
   type SchemaCRUD,
   type SchemaQuery,
+  type ConnectionProvider,
+  type DBConnection,
+  type DBTransaction,
 } from '../../zql/src/mutate/custom.ts';
 import {makeSchemaQuery} from './query.ts';
 


### PR DESCRIPTION
Mutator code should be able to run on the client or server.

This:

1. Moves `ServerTransaction` types out of the `pg` library and into `ZQL` which is shared on client and server
2. Create a `type Transaction = ServerTransaction | ClientTransaction`

The latter type lets the transaction be correctly narrowed for mutators:

```ts
myMutator(tx: Transaction) {
  if (tx.location === 'server') {
    // `token` only exists on `tx` in the server.
    verifyToken(tx.token);
  }
}
```

Here is some example usage in zbugs:

https://github.com/rocicorp/mono/blob/eaed250073db4528e1506ff9671f47c9fe0645ac/apps/zbugs/mutators.ts