### PR TITLE
chore(zero-protocol): flag when PROTOCOL_VERSION might need to be bumped

### DIFF
--- a/packages/zero-protocol/src/protocol-version.test.ts
+++ b/packages/zero-protocol/src/protocol-version.test.ts
@@ -1,0 +1,16 @@
+import {expect, test} from 'vitest';
+import {h64} from '../../shared/src/hash.ts';
+import {downstreamSchema} from './down.ts';
+import {PROTOCOL_VERSION} from './protocol-version.ts';
+import {upstreamSchema} from './up.ts';
+
+test('protocol version', () => {
+  const schemaJSON = JSON.stringify({upstreamSchema, downstreamSchema});
+  const hash = h64(schemaJSON).toString(36);
+
+  // If this test fails upstream or downstream schema has changed such that
+  // old code will not understand the new schema, bump the
+  // PROTOCOL_VERSION and update the expected values.
+  expect(hash).toEqual('1s66ur0ylpggf');
+  expect(PROTOCOL_VERSION).toEqual(6);
+});


### PR DESCRIPTION
This is similar to the analogous one in `ast.test.ts`