### PR TITLE
chore(zbugs): shortID is null optimistically

### DIFF
--- a/apps/zbugs/src/pages/issue/issue-page.tsx
+++ b/apps/zbugs/src/pages/issue/issue-page.tsx
@@ -170,7 +170,7 @@ export function IssuePage({onReady}: {onReady: () => void}) {
   const [editing, setEditing] = useState<typeof displayed | null>(null);
   const [edits, setEdits] = useState<Partial<typeof displayed>>({});
   useEffect(() => {
-    if (displayed?.shortID !== undefined && idField !== 'shortID') {
+    if (displayed?.shortID != null && idField !== 'shortID') {
       navigate(links.issue(displayed), {
         replace: true,
         state: zbugsHistoryState,


### PR DESCRIPTION
the comparison:

```ts
displayed?.shortID !== undefined
```

would cause a navigate loop since `shortID` gets set to `null` not `undefined` optimistically.

You can repro this error by using `zbugs` offline.

![CleanShot 2025-03-05 at 21 20 08@2x](https://github.com/user-attachments/assets/5c48067e-d73d-4da7-a59a-3d7fe376b78d)

Found when testing custom mutators e2e with an offline api server.