### PR TITLE
feat(replicache): add `zeroOption` to allow Zero to hook into Replicache events

### DIFF
--- a/packages/replicache/src/db/rebase.test.ts
+++ b/packages/replicache/src/db/rebase.test.ts
@@ -229,6 +229,7 @@ describe('rebaseMutationAndCommit', () => {
           new LogContext(),
           fixture.clientID,
           fixture.formatVersion,
+          undefined,
         ),
     );
     expect(fixture.testMutator1CallCount).to.equal(1);
@@ -256,6 +257,7 @@ describe('rebaseMutationAndCommit', () => {
           new LogContext(),
           fixture.clientID,
           fixture.formatVersion,
+          undefined,
         ),
     );
     expect(fixture.testMutator1CallCount).to.equal(1);
@@ -291,6 +293,7 @@ describe('rebaseMutationAndCommit', () => {
           new LogContext(),
           fixture.clientID,
           fixture.formatVersion,
+          undefined,
         ),
     );
     await withRead(fixture.store, async read => {
@@ -329,6 +332,7 @@ describe('rebaseMutationAndPutCommit', () => {
           new LogContext(),
           fixture.clientID,
           fixture.formatVersion,
+          undefined,
         );
         await fixture.expectRebasedCommit1(
           commit,
@@ -363,6 +367,7 @@ describe('rebaseMutationAndPutCommit', () => {
           new LogContext(),
           fixture.clientID,
           fixture.formatVersion,
+          undefined,
         );
         await fixture.expectRebasedCommit2(
           commit,
@@ -407,6 +412,7 @@ describe('rebaseMutationAndPutCommit', () => {
           new LogContext(),
           fixture.clientID,
           fixture.formatVersion,
+          undefined,
         );
         await fixture.expectRebasedCommit(
           commit,
@@ -473,6 +479,7 @@ async function testThrowsErrorOnClientIDMismatch(
             new LogContext(),
             'wrong_client_id',
             formatVersion,
+            undefined,
           )
         : await rebaseMutationAndPutCommit(
             localCommit,
@@ -484,6 +491,7 @@ async function testThrowsErrorOnClientIDMismatch(
             new LogContext(),
             'wrong_client_id',
             formatVersion,
+            undefined,
           );
     } catch (expected) {
       expect(formatVersion).to.be.greaterThanOrEqual(FormatVersion.DD31);
@@ -541,6 +549,7 @@ async function testThrowsErrorOnMutationIDMismatch(
             new LogContext(),
             clientID,
             formatVersion,
+            undefined,
           )
         : await rebaseMutationAndPutCommit(
             localCommit2,
@@ -550,6 +559,7 @@ async function testThrowsErrorOnMutationIDMismatch(
             new LogContext(),
             clientID,
             formatVersion,
+            undefined,
           );
     } catch (e) {
       expectedError = e;

--- a/packages/replicache/src/db/rebase.ts
+++ b/packages/replicache/src/db/rebase.ts
@@ -17,6 +17,7 @@ import {
   isLocalMetaDD31,
 } from './commit.ts';
 import {Write, newWriteLocal} from './write.ts';
+import type {ZeroTxData} from '../replicache-options.ts';
 
 type FormatVersion = Enum<typeof FormatVersion>;
 
@@ -28,6 +29,7 @@ async function rebaseMutation(
   lc: LogContext,
   mutationClientID: ClientID,
   formatVersion: FormatVersion,
+  zeroData: ZeroTxData | undefined,
 ): Promise<Write> {
   const localMeta = mutation.meta;
   const name = localMeta.mutatorName;
@@ -87,6 +89,7 @@ async function rebaseMutation(
     mutationClientID,
     await dbWrite.getMutationID(),
     'rebase',
+    zeroData,
     dbWrite,
     lc,
   );
@@ -104,6 +107,7 @@ export async function rebaseMutationAndPutCommit(
   // is a LocalMetaDD31.  As part of DD31 cleanup we can remove this arg.
   mutationClientID: ClientID,
   formatVersion: FormatVersion,
+  zeroData: ZeroTxData | undefined,
 ): Promise<Commit<Meta>> {
   const tx = await rebaseMutation(
     mutation,
@@ -113,6 +117,7 @@ export async function rebaseMutationAndPutCommit(
     lc,
     mutationClientID,
     formatVersion,
+    zeroData,
   );
   return tx.putCommit();
 }
@@ -128,6 +133,7 @@ export async function rebaseMutationAndCommit(
   // is a LocalMetaDD31.  As part of DD31 cleanup we can remove this arg.
   mutationClientID: ClientID,
   formatVersion: FormatVersion,
+  zeroData: ZeroTxData | undefined,
 ): Promise<Hash> {
   const dbWrite = await rebaseMutation(
     mutation,
@@ -137,6 +143,7 @@ export async function rebaseMutationAndCommit(
     lc,
     mutationClientID,
     formatVersion,
+    zeroData,
   );
   return dbWrite.commit(headName);
 }

--- a/packages/replicache/src/persist/persist.ts
+++ b/packages/replicache/src/persist/persist.ts
@@ -276,6 +276,7 @@ async function rebase(
           lc,
           meta.clientID,
           formatVersion,
+          undefined,
         )
       ).chunk.hash;
     }

--- a/packages/replicache/src/persist/refresh.ts
+++ b/packages/replicache/src/persist/refresh.ts
@@ -240,6 +240,7 @@ export async function refresh(
               lc,
               newMemdagMutations[i].meta.clientID,
               formatVersion,
+              undefined,
             )
           ).chunk.hash;
         }

--- a/packages/replicache/src/replicache-impl.ts
+++ b/packages/replicache/src/replicache-impl.ts
@@ -780,6 +780,7 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}> {
             lc,
             isLocalMetaDD31(meta) ? meta.clientID : clientID,
             FormatVersion.Latest,
+            undefined,
           ),
         );
       }
@@ -1481,6 +1482,7 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}> {
           clientID,
           await dbWrite.getMutationID(),
           'initial',
+          undefined,
           dbWrite,
           this.#lc,
         );

--- a/packages/replicache/src/replicache-impl.ts
+++ b/packages/replicache/src/replicache-impl.ts
@@ -76,7 +76,7 @@ import {refresh} from './persist/refresh.ts';
 import {ProcessScheduler} from './process-scheduler.ts';
 import type {Puller} from './puller.ts';
 import {type Pusher, PushError} from './pusher.ts';
-import type {ReplicacheOptions} from './replicache-options.ts';
+import type {ReplicacheOptions, ZeroOption} from './replicache-options.ts';
 import {
   getKVStoreProvider,
   httpStatusUnauthorized,
@@ -197,6 +197,13 @@ export interface ReplicacheImplOptions {
    * Callback for when Replicache has deleted clients.
    */
   onClientsDeleted?: OnClientsDeleted | undefined;
+
+  /**
+   * Internal option used by Zero.
+   * Replicache will call this to and, if zero is enabled, will
+   * invoke various hooks to allow Zero the keep IVM in sync with Replicache's b-trees.
+   */
+  zero?: ZeroOption | undefined;
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-types

--- a/packages/replicache/src/replicache-options.ts
+++ b/packages/replicache/src/replicache-options.ts
@@ -15,7 +15,7 @@ import type {Store} from './dag/store.ts';
 
 export interface ReplicacheOptions<
   MD extends MutatorDefs,
-  TZeroData = unknown,
+  TZeroData extends ZeroTxData = ZeroTxData,
 > {
   /**
    * This is the URL to the server endpoint dealing with the push updates. See
@@ -239,11 +239,13 @@ export interface ReplicacheOptions<
   zero?: ZeroOption<TZeroData> | undefined;
 }
 
+export interface ZeroTxData {}
+
 /**
  * Minimal interface that Replicache needs to communicate with Zero.
  * Prevents us from creating any direct dependencies on Zero.
  */
-export type ZeroOption<T> = {
+export type ZeroOption<T extends ZeroTxData> = {
   /**
    * Allow Zero to initialize its IVM state from the given hash and store.
    */

--- a/packages/replicache/src/transactions.ts
+++ b/packages/replicache/src/transactions.ts
@@ -271,7 +271,7 @@ export class SubscriptionTransactionWrapper implements ReadTransaction {
  * {@link ReplicacheOptions.mutators} and allows read and write operations on the
  * database.
  */
-export interface WriteTransaction extends ReadTransaction {
+export interface WriteTransaction<TZeroData = unknown> extends ReadTransaction {
   /**
    * The ID of the mutation that is being applied.
    */
@@ -281,6 +281,8 @@ export interface WriteTransaction extends ReadTransaction {
    * The reason for the transaction. This can be `initial`, `rebase` or `authoriative`.
    */
   readonly reason: TransactionReason;
+
+  readonly zeroData: TZeroData;
 
   /**
    * Sets a single `value` in the database. The value will be frozen (using
@@ -300,19 +302,21 @@ export interface WriteTransaction extends ReadTransaction {
   del(key: string): Promise<boolean>;
 }
 
-export class WriteTransactionImpl
+export class WriteTransactionImpl<TZeroData = unknown>
   extends ReadTransactionImpl
-  implements WriteTransaction
+  implements WriteTransaction<TZeroData>
 {
   // use `declare` to specialize the type.
   declare readonly dbtx: Write;
   readonly reason: TransactionReason;
   readonly mutationID: number;
+  readonly zeroData: TZeroData;
 
   constructor(
     clientID: ClientID,
     mutationID: number,
     reason: TransactionReason,
+    zeroData: TZeroData,
     dbWrite: Write,
     lc: LogContext,
     rpcName = 'openWriteTransaction',
@@ -320,6 +324,7 @@ export class WriteTransactionImpl
     super(clientID, dbWrite, lc, rpcName);
     this.mutationID = mutationID;
     this.reason = reason;
+    this.zeroData = zeroData;
   }
 
   put(key: string, value: ReadonlyJSONValue): Promise<void> {

--- a/packages/zero-client/src/client/replicache-types.ts
+++ b/packages/zero-client/src/client/replicache-types.ts
@@ -1,4 +1,3 @@
-import type {ZeroTxData} from '../../../replicache/src/replicache-options.ts';
 import type {
   ReadTransaction as ReplicacheReadTransaction,
   WriteTransaction as ReplicacheWriteTransaction,
@@ -35,8 +34,7 @@ export interface ReadTransaction extends ReplicacheReadTransaction {
   readonly env?: Env | undefined;
 }
 
-export interface WriteTransaction<T extends ZeroTxData = ZeroTxData>
-  extends ReplicacheWriteTransaction<T> {
+export interface WriteTransaction extends ReplicacheWriteTransaction {
   /**
    * When a mutator is run on the server, the `AuthData` for the connection
    * that pushed the mutation (i.e. the `AuthData` returned by the

--- a/packages/zero-client/src/client/replicache-types.ts
+++ b/packages/zero-client/src/client/replicache-types.ts
@@ -1,3 +1,4 @@
+import type {ZeroTxData} from '../../../replicache/src/replicache-options.ts';
 import type {
   ReadTransaction as ReplicacheReadTransaction,
   WriteTransaction as ReplicacheWriteTransaction,
@@ -34,7 +35,8 @@ export interface ReadTransaction extends ReplicacheReadTransaction {
   readonly env?: Env | undefined;
 }
 
-export interface WriteTransaction extends ReplicacheWriteTransaction {
+export interface WriteTransaction<T extends ZeroTxData = ZeroTxData>
+  extends ReplicacheWriteTransaction<T> {
   /**
    * When a mutator is run on the server, the `AuthData` for the connection
    * that pushed the mutation (i.e. the `AuthData` returned by the

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -130,6 +130,8 @@ import {
 import {getServer} from './server-option.ts';
 import {version} from './version.ts';
 import {PokeHandler} from './zero-poke-handler.ts';
+import type {WriteTransaction} from './replicache-types.ts';
+import type {ReadonlyJSONValue} from '../../../shared/src/json.ts';
 
 type ConnectionState = Enum<typeof ConnectionState>;
 type PingResult = Enum<typeof PingResult>;
@@ -454,7 +456,10 @@ export class Zero<
         mutatorsForNamespace as Record<string, CustomMutatorImpl<Schema>>,
       )) {
         (replicacheMutators as MutatorDefs)[customMutatorKey(namespace, name)] =
-          makeReplicacheMutator(mutator, schema);
+          makeReplicacheMutator(mutator, schema) as (
+            repTx: WriteTransaction,
+            args: ReadonlyJSONValue,
+          ) => Promise<void>;
       }
     }
 


### PR DESCRIPTION
 zeroOption is a minimal interface that Replicache will call when:
  
  - pullEnd
  - persist
  - refresh
  - mutate
  
happen. Replicache will invoke
  
- `advance` whenever it's main head moves forward.
- `getTxData` to fork IVM sources whenever it needs to rebase
- `init` on construction to populate the IVM sources

Invoking the above three methods in `persist.ts`, `refresh.ts`, `replicache-impl.ts::mutate`, `replicache-impl.ts::maybeEndPull` will happen in the next PR.