### PR TITLE
feat(custom-mutators): maintain and fork ivm through pull, mutate, refresh

### DIFF
--- a/packages/replicache/src/db/write.ts
+++ b/packages/replicache/src/db/write.ts
@@ -177,13 +177,13 @@ export class Write extends Read {
   async commitWithDiffs(
     headName: string,
     diffConfig: DiffComputationConfig,
-  ): Promise<DiffsMap> {
+  ): Promise<[Hash, DiffsMap]> {
     const commit = this.putCommit();
     const diffMap = await this.#generateDiffs(diffConfig);
     const commitHash = (await commit).chunk.hash;
     await this.#dagWrite.setHead(headName, commitHash);
     await this.#dagWrite.commit();
-    return diffMap;
+    return [commitHash, diffMap];
   }
 
   async #generateDiffs(diffConfig: DiffComputationConfig): Promise<DiffsMap> {

--- a/packages/replicache/src/mutation-recovery-test-helper.ts
+++ b/packages/replicache/src/mutation-recovery-test-helper.ts
@@ -115,6 +115,7 @@ export async function createAndPersistClientWithPendingLocalDD31({
     mutators,
     () => false,
     formatVersion,
+    undefined,
   );
 
   return localMetas;
@@ -157,6 +158,7 @@ export async function persistSnapshotDD31(
     mutators,
     () => false,
     formatVersion,
+    undefined,
   );
 }
 

--- a/packages/replicache/src/persist/persist.test.ts
+++ b/packages/replicache/src/persist/persist.test.ts
@@ -932,6 +932,7 @@ async function setupPersistTest() {
       mutators,
       () => false,
       FormatVersion.Latest,
+      undefined,
       onGatherMemOnlyChunksForTest,
     );
     const persistedChunkHashes: Hash[] = [];

--- a/packages/replicache/src/persist/persist.ts
+++ b/packages/replicache/src/persist/persist.ts
@@ -36,6 +36,7 @@ import {
   setClient,
 } from './clients.ts';
 import {GatherMemoryOnlyVisitor} from './gather-mem-only-visitor.ts';
+import type {ZeroOption} from '../replicache-options.ts';
 
 type FormatVersion = Enum<typeof FormatVersion>;
 
@@ -65,6 +66,7 @@ export async function persistDD31(
   mutators: MutatorDefs,
   closed: () => boolean,
   formatVersion: FormatVersion,
+  _getZeroData: ZeroOption['getTxData'] | undefined,
   onGatherMemOnlyChunksForTest = () => Promise.resolve(),
 ): Promise<void> {
   if (closed()) {

--- a/packages/replicache/src/persist/refresh.test.ts
+++ b/packages/replicache/src/persist/refresh.test.ts
@@ -181,7 +181,7 @@ describe('refresh', () => {
     await makePerdagChainAndSetClientsAndClientGroup(perdag, clientID, 1);
     await makeMemdagChain(memdag, clientID, 1);
 
-    const diffs = await refresh(
+    const refreshResult = await refresh(
       new LogContext(),
       memdag,
       perdag,
@@ -190,9 +190,10 @@ describe('refresh', () => {
       testSubscriptionsManagerOptions,
       () => false,
       formatVersion,
+      undefined,
     );
-    assert(diffs);
-    expect(Object.fromEntries(diffs)).to.deep.equal({});
+    assert(refreshResult);
+    expect(Object.fromEntries(refreshResult[1])).to.deep.equal({});
     const hashes = [
       await withRead(memdag, read => read.getHead(DEFAULT_HEAD_NAME)),
     ];
@@ -230,7 +231,7 @@ describe('refresh', () => {
     });
     await makeMemdagChain(memdag, clientID, 1);
 
-    const diffs = await refresh(
+    const refreshResult = await refresh(
       new LogContext(),
       memdag,
       perdag,
@@ -239,13 +240,14 @@ describe('refresh', () => {
       testSubscriptionsManagerOptions,
       () => false,
       formatVersion,
+      undefined,
     );
-    assert(diffs);
+    assert(refreshResult);
     const hashes = [
       await withRead(memdag, read => read.getHead(DEFAULT_HEAD_NAME)),
     ];
 
-    expect(Object.fromEntries(diffs)).to.deep.equal({});
+    expect(Object.fromEntries(refreshResult[1])).to.deep.equal({});
 
     await assertRefreshHashes(perdag, clientID, hashes);
   });
@@ -266,7 +268,7 @@ describe('refresh', () => {
     );
     await memdagChainBuilder.addLocal(clientID, []);
 
-    const diffs = await refresh(
+    const refreshResult = await refresh(
       new LogContext(),
       memdag,
       perdag,
@@ -275,10 +277,11 @@ describe('refresh', () => {
       testSubscriptionsManagerOptions,
       () => false,
       formatVersion,
+      undefined,
     );
-    assert(diffs);
+    assert(refreshResult);
 
-    expect(Object.fromEntries(diffs)).to.deep.equal({
+    expect(Object.fromEntries(refreshResult[1])).to.deep.equal({
       '': [
         {
           key: 'from mutator_name_3',
@@ -322,6 +325,7 @@ describe('refresh', () => {
       testSubscriptionsManagerOptions,
       () => false,
       formatVersion,
+      undefined,
     );
     expect(result).undefined;
     await assertRefreshHashes(perdag, clientID, client.refreshHashes);
@@ -352,6 +356,7 @@ describe('refresh', () => {
       testSubscriptionsManagerOptions,
       () => false,
       formatVersion,
+      undefined,
     );
     expect(result).undefined;
     await assertRefreshHashes(perdag, clientID, client.refreshHashes);
@@ -374,7 +379,7 @@ describe('refresh', () => {
     await memdagChainBuilder.addLocal(clientID, []);
     await memdagChainBuilder.addLocal(clientID, []);
 
-    const diffs = await refresh(
+    const refreshResult = await refresh(
       new LogContext(),
       memdag,
       perdag,
@@ -383,9 +388,10 @@ describe('refresh', () => {
       testSubscriptionsManagerOptions,
       () => false,
       formatVersion,
+      undefined,
     );
-    assert(diffs);
-    expect(Object.fromEntries(diffs)).to.deep.equal({
+    assert(refreshResult);
+    expect(Object.fromEntries(refreshResult[1])).to.deep.equal({
       '': [
         {
           key: 'from mutator_name_3',
@@ -437,7 +443,7 @@ describe('refresh', () => {
     await memdagChainBuilder.addLocal(clientID1, []);
     await memdagChainBuilder.addLocal(clientID1, []);
 
-    const diffs = await refresh(
+    const refreshResult = await refresh(
       new LogContext(),
       memdag,
       perdag,
@@ -446,9 +452,10 @@ describe('refresh', () => {
       testSubscriptionsManagerOptions,
       () => false,
       formatVersion,
+      undefined,
     );
-    assert(diffs);
-    expect(Object.fromEntries(diffs)).to.deep.equal({
+    assert(refreshResult);
+    expect(Object.fromEntries(refreshResult[1])).to.deep.equal({
       '': [
         {
           key: 'from mutator_name_3',
@@ -511,6 +518,7 @@ describe('refresh', () => {
       testSubscriptionsManagerOptions,
       () => false,
       formatVersion,
+      undefined,
     );
     expect(result).undefined;
     await assertRefreshHashes(perdag, clientID, client.refreshHashes);
@@ -564,6 +572,7 @@ describe('refresh', () => {
         testSubscriptionsManagerOptions,
         () => false,
         formatVersion,
+        undefined,
       );
     } catch (e) {
       expectedE = e;
@@ -808,7 +817,7 @@ describe('refresh', () => {
       });
     }
 
-    const diffs = await refresh(
+    const refreshResult = await refresh(
       new LogContext(),
       memdag,
       perdag,
@@ -819,9 +828,10 @@ describe('refresh', () => {
       testSubscriptionsManagerOptions,
       () => false,
       formatVersion,
+      undefined,
     );
-    assert(diffs);
-    expect(Object.fromEntries(diffs)).to.deep.equal({
+    assert(refreshResult);
+    expect(Object.fromEntries(refreshResult[1])).to.deep.equal({
       '': [{key: 'c', newValue: 3, op: 'add'}],
     });
 

--- a/packages/replicache/src/persist/refresh.test.ts
+++ b/packages/replicache/src/persist/refresh.test.ts
@@ -193,7 +193,7 @@ describe('refresh', () => {
       undefined,
     );
     assert(refreshResult);
-    expect(Object.fromEntries(refreshResult[1])).to.deep.equal({});
+    expect(Object.fromEntries(refreshResult.diffs)).to.deep.equal({});
     const hashes = [
       await withRead(memdag, read => read.getHead(DEFAULT_HEAD_NAME)),
     ];
@@ -247,7 +247,7 @@ describe('refresh', () => {
       await withRead(memdag, read => read.getHead(DEFAULT_HEAD_NAME)),
     ];
 
-    expect(Object.fromEntries(refreshResult[1])).to.deep.equal({});
+    expect(Object.fromEntries(refreshResult.diffs)).to.deep.equal({});
 
     await assertRefreshHashes(perdag, clientID, hashes);
   });
@@ -281,7 +281,7 @@ describe('refresh', () => {
     );
     assert(refreshResult);
 
-    expect(Object.fromEntries(refreshResult[1])).to.deep.equal({
+    expect(Object.fromEntries(refreshResult.diffs)).to.deep.equal({
       '': [
         {
           key: 'from mutator_name_3',
@@ -391,7 +391,7 @@ describe('refresh', () => {
       undefined,
     );
     assert(refreshResult);
-    expect(Object.fromEntries(refreshResult[1])).to.deep.equal({
+    expect(Object.fromEntries(refreshResult.diffs)).to.deep.equal({
       '': [
         {
           key: 'from mutator_name_3',
@@ -455,7 +455,7 @@ describe('refresh', () => {
       undefined,
     );
     assert(refreshResult);
-    expect(Object.fromEntries(refreshResult[1])).to.deep.equal({
+    expect(Object.fromEntries(refreshResult.diffs)).to.deep.equal({
       '': [
         {
           key: 'from mutator_name_3',
@@ -831,7 +831,7 @@ describe('refresh', () => {
       undefined,
     );
     assert(refreshResult);
-    expect(Object.fromEntries(refreshResult[1])).to.deep.equal({
+    expect(Object.fromEntries(refreshResult.diffs)).to.deep.equal({
       '': [{key: 'c', newValue: 3, op: 'add'}],
     });
 

--- a/packages/replicache/src/persist/refresh.ts
+++ b/packages/replicache/src/persist/refresh.ts
@@ -304,6 +304,11 @@ export async function refresh(
     }
     return undefined;
   }
+
+  // Advance zero here before setting refresh hashes
+  // since we must advance before delegating control of the microtask
+  // loop.
+  zero?.advance(result.oldHead, result.newHead, result.diffs.get('') ?? []);
   await setRefreshHashes([result.newPerdagClientHeadHash]);
   return {
     oldHead: result.oldHead,

--- a/packages/replicache/src/replicache-impl.ts
+++ b/packages/replicache/src/replicache-impl.ts
@@ -1228,11 +1228,6 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}> {
       }
     }
     if (refreshResult !== undefined) {
-      this.#zero?.advance(
-        refreshResult.oldHead,
-        refreshResult.newHead,
-        refreshResult.diffs.get('') ?? [],
-      );
       await this.#subscriptions.fire(refreshResult.diffs);
     }
   }

--- a/packages/replicache/src/replicache-options.ts
+++ b/packages/replicache/src/replicache-options.ts
@@ -6,7 +6,7 @@ import type {Pusher} from './pusher.ts';
 import type {MutatorDefs, RequestOptions} from './types.ts';
 import type {Hash} from './hash.ts';
 import type {InternalDiff} from './btree/node.ts';
-import type {Store} from './dag/store.ts';
+import type {Read, Store} from './dag/store.ts';
 
 /**
  * The options passed to {@link Replicache}.
@@ -271,7 +271,16 @@ export type ZeroOption = {
    * The data returned by `getTxData` will be available on the Replicache transaction
    * object for use in Zero's mutators.
    */
-  getTxData(expectedHead: Hash, desiredHead: Hash): Promise<ZeroTxData>;
+  getTxData(
+    expectedHead: Hash,
+    desiredHead: Hash,
+    readOptions?:
+      | {
+          openLazyRead?: Read | undefined;
+          openLazySourceRead?: Read | undefined;
+        }
+      | undefined,
+  ): Promise<ZeroTxData>;
 
   /**
    * When Replicache's main head moves forward, Zero must advance its IVM state.

--- a/packages/replicache/src/replicache-options.ts
+++ b/packages/replicache/src/replicache-options.ts
@@ -281,7 +281,7 @@ export interface ZeroOption {
     reason: TransactionReason,
     desiredHead: Hash,
     readOptions?: ZeroReadOptions | undefined,
-  ): Promise<ZeroTxData>;
+  ): Promise<ZeroTxData> | undefined;
 
   /**
    * When Replicache's main head moves forward, Zero must advance its IVM state.

--- a/packages/replicache/src/replicache-options.ts
+++ b/packages/replicache/src/replicache-options.ts
@@ -7,6 +7,7 @@ import type {MutatorDefs, RequestOptions} from './types.ts';
 import type {Hash} from './hash.ts';
 import type {InternalDiff} from './btree/node.ts';
 import type {Read, Store} from './dag/store.ts';
+import type {TransactionReason} from './transactions.ts';
 
 /**
  * The options passed to {@link Replicache}.
@@ -253,11 +254,16 @@ export interface ReplicacheOptions<MD extends MutatorDefs> {
  */
 export interface ZeroTxData {}
 
+export type ZeroReadOptions = {
+  openLazyRead?: Read | undefined;
+  openLazySourceRead?: Read | undefined;
+};
+
 /**
  * Minimal interface that Replicache needs to communicate with Zero.
  * Prevents us from creating any direct dependencies on Zero.
  */
-export type ZeroOption = {
+export interface ZeroOption {
   /**
    * Allow Zero to initialize its IVM state from the given hash and dag.
    */
@@ -272,18 +278,13 @@ export type ZeroOption = {
    * object for use in Zero's mutators.
    */
   getTxData(
-    expectedHead: Hash,
+    reason: TransactionReason,
     desiredHead: Hash,
-    readOptions?:
-      | {
-          openLazyRead?: Read | undefined;
-          openLazySourceRead?: Read | undefined;
-        }
-      | undefined,
+    readOptions?: ZeroReadOptions | undefined,
   ): Promise<ZeroTxData>;
 
   /**
    * When Replicache's main head moves forward, Zero must advance its IVM state.
    */
-  advance(hash: Hash, changes: InternalDiff): Promise<void>;
-};
+  advance(expectedHash: Hash, newHash: Hash, changes: InternalDiff): void;
+}

--- a/packages/zero-client/src/client/context.test.ts
+++ b/packages/zero-client/src/client/context.test.ts
@@ -11,6 +11,7 @@ import {type AddQuery, ZeroContext} from './context.ts';
 import {IVMSourceBranch} from './ivm-branch.ts';
 import {ENTITIES_KEY_PREFIX} from './keys.ts';
 import {LogContext} from '@rocicorp/logger';
+import type {Hash} from '../../../replicache/src/hash.ts';
 
 const testBatchViewUpdates = (applyViewUpdates: () => void) =>
   applyViewUpdates();
@@ -119,7 +120,7 @@ test('processChanges', () => {
     ]),
   );
 
-  context.processChanges([
+  context.processChanges(undefined, 'ahash' as Hash, [
     {
       key: `${ENTITIES_KEY_PREFIX}t1/e1`,
       op: 'add',
@@ -185,7 +186,7 @@ test('processChanges wraps source updates with batchViewUpdates', () => {
   );
 
   expect(batchViewUpdatesCalls).toBe(0);
-  context.processChanges([
+  context.processChanges(undefined, 'ahash' as Hash, [
     {
       key: `${ENTITIES_KEY_PREFIX}t1/e1`,
       op: 'add',
@@ -283,7 +284,7 @@ test('transactions', () => {
     ++transactions;
   });
 
-  context.processChanges(changes);
+  context.processChanges(undefined, 'ahash' as Hash, changes);
 
   expect(transactions).toEqual(1);
   const result = out.fetch({});

--- a/packages/zero-client/src/client/custom.ts
+++ b/packages/zero-client/src/client/custom.ts
@@ -93,6 +93,11 @@ export class TransactionImpl implements Transaction<Schema> {
     this.mutate = makeSchemaCRUD(
       schema,
       repTx,
+      // CRUD operators should not mutate the IVM store directly
+      // for `initial`. The IVM store will be updated via calls to `advance`
+      // after the transaction has been committed to the Replicache b-tree.
+      // Mutating the IVM store in the mutator would cause us to synchronously
+      // notify listeners of IVM while we're inside of the Replicache DB transaction.
       repTx.reason === 'initial'
         ? undefined
         : (must(

--- a/packages/zero-client/src/client/custom.ts
+++ b/packages/zero-client/src/client/custom.ts
@@ -93,7 +93,12 @@ export class TransactionImpl implements Transaction<Schema> {
     this.mutate = makeSchemaCRUD(
       schema,
       repTx,
-      castedRepTx[zeroData] as undefined | IVMSourceBranch,
+      repTx.reason === 'initial'
+        ? undefined
+        : (must(
+            castedRepTx[zeroData],
+            'zero was not set on replicache internal options!',
+          ) as IVMSourceBranch),
     );
     this.query = {};
   }

--- a/packages/zero-client/src/client/ivm-branch.test.ts
+++ b/packages/zero-client/src/client/ivm-branch.test.ts
@@ -399,7 +399,7 @@ describe('forkToHead', () => {
       timestamp++,
     );
     await initFromStore(branch, syncHash, dagStore);
-    await branch.forkToHead(dagStore, syncHash);
+    await branch.forkToHead('rebase', dagStore, syncHash);
     expect([
       ...must(branch.getSource('issue'))
         .connect([['id', 'asc']])
@@ -444,7 +444,7 @@ describe('forkToHead', () => {
     } as unknown as FrozenJSONValue);
     const head = await w.commit(SYNC_HEAD_NAME);
 
-    const fork = await branch.forkToHead(dagStore, head);
+    const fork = await branch.forkToHead('rebase', dagStore, head);
     expect([
       ...must(fork.getSource('issue'))
         .connect([['id', 'asc']])
@@ -465,7 +465,7 @@ describe('forkToHead', () => {
     `);
 
     // can also re-wind the fork to the original head
-    const fork2 = await fork.forkToHead(dagStore, syncHash);
+    const fork2 = await fork.forkToHead('rebase', dagStore, syncHash);
     expect([
       ...must(fork2.getSource('issue'))
         .connect([['id', 'asc']])

--- a/packages/zero-client/src/client/ivm-branch.test.ts
+++ b/packages/zero-client/src/client/ivm-branch.test.ts
@@ -18,7 +18,6 @@ import type {Diff} from '../../../replicache/src/sync/patch.ts';
 import type {Node} from '../../../zql/src/ivm/data.ts';
 import {createDb} from './test/create-db.ts';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
-import type {Hash} from '../../../replicache/src/hash.ts';
 
 test('fork', () => {
   const main = new IVMSourceBranch({
@@ -382,17 +381,6 @@ describe('advance', () => {
 });
 
 describe('forkToHead', () => {
-  test('throws on hash mismatch', async () => {
-    const branch = new IVMSourceBranch(schema.tables);
-    const {dagStore, syncHash} = await createDb([], timestamp++);
-    await initFromStore(branch, syncHash, dagStore);
-    await expect(() =>
-      branch.forkToHead(dagStore, 'wrong-hash' as Hash, syncHash),
-    ).rejects.toThrow(
-      `Expected head must match the main head. Got: wrong-hash, expected: fake000000000000000002`,
-    );
-  });
-
   test('handles when desiredHead is the same as expectedHead', async () => {
     const branch = new IVMSourceBranch(schema.tables);
     const {dagStore, syncHash} = await createDb(
@@ -411,7 +399,7 @@ describe('forkToHead', () => {
       timestamp++,
     );
     await initFromStore(branch, syncHash, dagStore);
-    await branch.forkToHead(dagStore, syncHash, syncHash);
+    await branch.forkToHead(dagStore, syncHash);
     expect([
       ...must(branch.getSource('issue'))
         .connect([['id', 'asc']])
@@ -456,7 +444,7 @@ describe('forkToHead', () => {
     } as unknown as FrozenJSONValue);
     const head = await w.commit(SYNC_HEAD_NAME);
 
-    const fork = await branch.forkToHead(dagStore, syncHash, head);
+    const fork = await branch.forkToHead(dagStore, head);
     expect([
       ...must(fork.getSource('issue'))
         .connect([['id', 'asc']])
@@ -477,7 +465,7 @@ describe('forkToHead', () => {
     `);
 
     // can also re-wind the fork to the original head
-    const fork2 = await fork.forkToHead(dagStore, head, syncHash);
+    const fork2 = await fork.forkToHead(dagStore, syncHash);
     expect([
       ...must(fork2.getSource('issue'))
         .connect([['id', 'asc']])

--- a/packages/zero-client/src/client/zero-rate.test.ts
+++ b/packages/zero-client/src/client/zero-rate.test.ts
@@ -80,7 +80,7 @@ test('a mutation after a rate limit error causes limited mutations to be resent'
   await z.mutate.issue.insert({id: 'a', value: 1});
   await z.triggerError(ErrorKind.MutationRateLimited, 'Rate limit exceeded');
 
-  await 1;
+  await tickAFewTimes(clock, 0);
   expect(mockSocket.messages).to.have.lengthOf(1);
   expect(mockSocket.closed).toBe(false);
   expect(z.connectionState).eq(ConnectionState.Connected);

--- a/packages/zero-client/src/client/zero-rep.ts
+++ b/packages/zero-client/src/client/zero-rep.ts
@@ -1,0 +1,65 @@
+import type {
+  InternalDiff,
+  InternalDiffOperation,
+} from '../../../replicache/src/btree/node.ts';
+import {readFromHash} from '../../../replicache/src/db/read.ts';
+import type {Hash} from '../../../replicache/src/hash.ts';
+import {withRead} from '../../../replicache/src/with-transactions.ts';
+import type {ZeroContext} from './context.ts';
+import * as FormatVersion from '../../../replicache/src/format-version-enum.ts';
+import type {IVMSourceBranch} from './ivm-branch.ts';
+import {ENTITIES_KEY_PREFIX} from './keys.ts';
+import {must} from '../../../shared/src/must.ts';
+import type {LazyStore} from '../../../replicache/src/dag/lazy-store.ts';
+import type {
+  ZeroOption,
+  ZeroReadOptions,
+} from '../../../replicache/src/replicache-options.ts';
+import type {TransactionReason} from '../../../replicache/src/transactions.ts';
+
+export class ZeroRep implements ZeroOption {
+  readonly #context: ZeroContext;
+  readonly #ivmMain: IVMSourceBranch;
+  #store: LazyStore | undefined;
+
+  constructor(context: ZeroContext, ivmMain: IVMSourceBranch) {
+    this.#context = context;
+    this.#ivmMain = ivmMain;
+  }
+
+  async init(hash: Hash, store: LazyStore) {
+    const diffs: InternalDiffOperation[] = [];
+    await withRead(store, async dagRead => {
+      const read = await readFromHash(hash, dagRead, FormatVersion.Latest);
+      for await (const entry of read.map.scan(ENTITIES_KEY_PREFIX)) {
+        if (!entry[0].startsWith(ENTITIES_KEY_PREFIX)) {
+          break;
+        }
+        diffs.push({
+          op: 'add',
+          key: entry[0],
+          newValue: entry[1],
+        });
+      }
+    });
+    this.#store = store;
+
+    this.#context.processChanges(undefined, hash, diffs);
+  }
+
+  getTxData = (
+    reason: TransactionReason,
+    desiredHead: Hash,
+    readOptions?: ZeroReadOptions | undefined,
+  ): Promise<IVMSourceBranch> =>
+    this.#ivmMain.forkToHead(
+      reason,
+      must(this.#store),
+      desiredHead,
+      readOptions,
+    );
+
+  advance = (expectedHash: Hash, newHash: Hash, diffs: InternalDiff): void => {
+    this.#context.processChanges(expectedHash, newHash, diffs);
+  };
+}


### PR DESCRIPTION
Persist requires some more invasive changes and will be in a separate PR.

Calls to `advance` are the key thing to review. `advance` replaces our use of `experimentalWatch` to update the main IVM sources. The main difference from experimentalWatch is that `advance` sends in the expected hash we're advancing from and the hash we're advancing to. This allows `advance` to set an invariant that we always advance in order. The IVMBranch also keeps track of its current hash so it can compute diffs to use to patch forks in `forkToHead(hash)`.

I'm surprised we never ran into problems with `experimentalWatch` as I would imagine there would have been cases where a `refresh` diff against HEAD-1 jumps ahead of a `pullEnd` diff against HEAD-0 (due to awaits) or vice-versa.