### PR TITLE
feat(zero-cache): support replication of tables with REPLICA IDENTITY FULL

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg-test.ts
@@ -1101,7 +1101,6 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
         {
           tag: 'insert',
           relation: {
-            tag: 'relation',
             schema: 'public',
             name: 'nopk',
             replicaIdentity: 'default',

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -495,17 +495,23 @@ class ChangeMaker {
         ];
 
       case 'delete': {
-        const key = msg.key ?? msg.old;
-        if (!key) {
+        if (!(msg.key ?? msg.old)) {
           throw new Error(
             `Invalid DELETE msg (missing key): ${stringify(msg)}`,
           );
         }
-        return [['data', msg.key ? (msg as MessageDelete) : {...msg, key}]];
+        // https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html#PROTOCOL-LOGICALREP-MESSAGE-FORMATS-DELETE
+        return [
+          ['data', msg.old ? {...msg, key: msg.old} : (msg as MessageDelete)],
+        ];
+      }
+
+      case 'update': {
+        // https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html#PROTOCOL-LOGICALREP-MESSAGE-FORMATS-UPDATE
+        return [['data', msg.old ? {...msg, key: msg.old} : msg]];
       }
 
       case 'insert':
-      case 'update':
       case 'truncate':
         return [['data', msg]];
 

--- a/packages/zero-cache/src/services/change-source/protocol/current/data.ts
+++ b/packages/zero-cache/src/services/change-source/protocol/current/data.ts
@@ -29,8 +29,12 @@ export const relationSchema = v.object({
   name: v.string(),
   keyColumns: v.array(v.string()),
 
-  // Deprecated tags will be removed in a later release.
-  tag: v.literal('relation').optional(),
+  // PG-specific. When replicaIdentity is 'full':
+  // * `keyColumns` contain all of the columns in the table.
+  // * the `key` of the Delete and Update messages represent the full row.
+  //
+  // It is the replicator's responsibility must convert these to an
+  // appropriate lookup key.
   replicaIdentity: v
     .union(
       v.literal('default'),
@@ -39,6 +43,9 @@ export const relationSchema = v.object({
       v.literal('index'),
     )
     .optional(),
+
+  // Deprecated tags will be removed in a later release.
+  tag: v.literal('relation').optional(),
 });
 
 export const rowSchema = v.record(jsonValueSchema);
@@ -52,14 +59,16 @@ export const insertSchema = v.object({
 export const updateSchema = v.object({
   tag: v.literal('update'),
   relation: relationSchema,
+  // key is present if the update changed the key of the row, or if the
+  // table's replicaIdentity === 'full'
   key: rowSchema.nullable(),
-  old: rowSchema.nullable(),
   new: rowSchema,
 });
 
 export const deleteSchema = v.object({
   tag: v.literal('delete'),
   relation: relationSchema,
+  // key is the full row if replicaIdentity === 'full'
   key: rowSchema,
 });
 

--- a/packages/zero-cache/src/services/change-source/protocol/current/data.ts
+++ b/packages/zero-cache/src/services/change-source/protocol/current/data.ts
@@ -43,9 +43,6 @@ export const relationSchema = v.object({
       v.literal('index'),
     )
     .optional(),
-
-  // Deprecated tags will be removed in a later release.
-  tag: v.literal('relation').optional(),
 });
 
 export const rowSchema = v.record(jsonValueSchema);

--- a/packages/zero-cache/src/services/change-source/protocol/current/data.ts
+++ b/packages/zero-cache/src/services/change-source/protocol/current/data.ts
@@ -33,8 +33,8 @@ export const relationSchema = v.object({
   // * `keyColumns` contain all of the columns in the table.
   // * the `key` of the Delete and Update messages represent the full row.
   //
-  // It is the replicator's responsibility must convert these to an
-  // appropriate lookup key.
+  // The replicator handles these tables by extracting a row key from
+  // the full row based on the table's PRIMARY KEY or UNIQUE INDEX.
   replicaIdentity: v
     .union(
       v.literal('default'),

--- a/packages/zero-cache/src/services/change-source/protocol/version.test.ts
+++ b/packages/zero-cache/src/services/change-source/protocol/version.test.ts
@@ -38,9 +38,9 @@ test('protocol versions', () => {
   // Then update the version number of the `CHANGE_SOURCE_PATH`
   // in current and export it appropriately as the new version
   // in `mod.ts`.
-  t(current, '2tm3p58pictgp', '/changes/v0/stream');
+  t(current, '1c43bn5dzejyy', '/changes/v0/stream');
   // During initial development, we use v0 as a non-stable
   // version (i.e. breaking change are allowed). Once the
   // protocol graduates to v1, versions must be stable.
-  t(v0, '2tm3p58pictgp', '/changes/v0/stream');
+  t(v0, '1c43bn5dzejyy', '/changes/v0/stream');
 });

--- a/packages/zero-cache/src/services/change-source/protocol/version.test.ts
+++ b/packages/zero-cache/src/services/change-source/protocol/version.test.ts
@@ -38,9 +38,9 @@ test('protocol versions', () => {
   // Then update the version number of the `CHANGE_SOURCE_PATH`
   // in current and export it appropriately as the new version
   // in `mod.ts`.
-  t(current, '268ode0tvphut', '/changes/v0/stream');
+  t(current, '2tm3p58pictgp', '/changes/v0/stream');
   // During initial development, we use v0 as a non-stable
   // version (i.e. breaking change are allowed). Once the
   // protocol graduates to v1, versions must be stable.
-  t(v0, '268ode0tvphut', '/changes/v0/stream');
+  t(v0, '2tm3p58pictgp', '/changes/v0/stream');
 });

--- a/packages/zero-cache/src/services/replicator/test-utils.ts
+++ b/packages/zero-cache/src/services/replicator/test-utils.ts
@@ -64,14 +64,18 @@ export class ReplicationMessages<
 > {
   readonly #tables = new Map<string, MessageRelation>();
 
-  constructor(tablesAndKeys: TablesAndKeys, schema = 'public') {
+  constructor(
+    tablesAndKeys: TablesAndKeys,
+    schema = 'public',
+    replicaIdentity: 'default' | 'full' = 'default',
+  ) {
     for (const [table, k] of Object.entries(tablesAndKeys)) {
       const keys = typeof k === 'string' ? [k] : [...k];
       const relation = {
         tag: 'relation',
         schema,
         name: table,
-        replicaIdentity: 'default',
+        replicaIdentity,
         keyColumns: keys,
       } as const;
       this.#tables.set(table, relation);
@@ -105,7 +109,6 @@ export class ReplicationMessages<
       relation: this.#relationOrFail(table),
       new: row,
       key: oldKey ?? null,
-      old: null,
     };
   }
 

--- a/packages/zero-cache/src/types/lite.test.ts
+++ b/packages/zero-cache/src/types/lite.test.ts
@@ -115,12 +115,13 @@ describe('types/lite', () => {
       },
     ],
   ])('liteRow: %s', (input, output, table) => {
-    const lite = liteRow(input, table);
+    const {row: lite, numCols} = liteRow(input, table);
     if (output) {
       expect(lite).toEqual(output);
     } else {
       expect(lite).toBe(input); // toBe => identity (i.e. no copy)
     }
+    expect(numCols).toBe(Object.keys(input).length);
   });
 
   test('values', () => {

--- a/packages/zero-cache/src/types/lite.ts
+++ b/packages/zero-cache/src/types/lite.ts
@@ -41,7 +41,7 @@ export function liteRow(
     }
   }
   if (!copyNeeded) {
-    return {row: row as unknown as LiteRow, numCols: numCols};
+    return {row: row as unknown as LiteRow, numCols};
   }
   // Slow path for when a conversion is needed.
   numCols = 0;
@@ -50,7 +50,7 @@ export function liteRow(
     numCols++;
     converted[key] = liteValue(row[key], columnType(key, table));
   }
-  return {row: converted, numCols: numCols};
+  return {row: converted, numCols};
 }
 
 export function liteValues(

--- a/packages/zero-cache/src/types/lite.ts
+++ b/packages/zero-cache/src/types/lite.ts
@@ -24,9 +24,15 @@ function columnType(col: string, table: LiteTableSpec) {
  * Creates a LiteRow from the supplied RowValue. A copy of the `row`
  * is made only if a value conversion is performed.
  */
-export function liteRow(row: RowValue, table: LiteTableSpec): LiteRow {
+export function liteRow(
+  row: RowValue,
+  table: LiteTableSpec,
+): {row: LiteRow; numCols: number} {
   let copyNeeded = false;
+  let numCols = 0;
+
   for (const key in row) {
+    numCols++;
     const val = row[key];
     const liteVal = liteValue(val, columnType(key, table));
     if (val !== liteVal) {
@@ -35,15 +41,16 @@ export function liteRow(row: RowValue, table: LiteTableSpec): LiteRow {
     }
   }
   if (!copyNeeded) {
-    return row as unknown as LiteRow;
+    return {row: row as unknown as LiteRow, numCols: numCols};
   }
   // Slow path for when a conversion is needed.
-  return Object.fromEntries(
-    Object.entries(row).map(([key, val]) => [
-      key,
-      liteValue(val, columnType(key, table)),
-    ]),
-  );
+  numCols = 0;
+  const converted: Record<string, LiteValueType> = {};
+  for (const key in row) {
+    numCols++;
+    converted[key] = liteValue(row[key], columnType(key, table));
+  }
+  return {row: converted, numCols: numCols};
 }
 
 export function liteValues(


### PR DESCRIPTION
When a table is configured with `REPLICA IDENTITY FULL`, the full rows are sent as the "keys", and all of the columns are considered the "keyColumns". 

However, these rows/columns cannot safely be used as keys because they may contain `NULL` values.

To handle these replication messages, create keys from the full rows using the primary key / unique index information from the replicated table schema.

User request: https://discord.com/channels/830183651022471199/1288232858795769917/1347172642507063368