### PR TITLE
refactor(zql): move splitting of edits up to source

### DIFF
--- a/packages/zql/src/builder/builder.test.ts
+++ b/packages/zql/src/builder/builder.test.ts
@@ -684,6 +684,50 @@ test('self-join edit', () => {
               {
                 "relationships": {},
                 "row": {
+                  "id": 1,
+                  "name": "aaron",
+                  "recruiterID": null,
+                },
+              },
+            ],
+          },
+          "row": {
+            "id": 4,
+            "name": "matt",
+            "recruiterID": 1,
+          },
+        },
+        "type": "add",
+      },
+      {
+        "node": {
+          "relationships": {
+            "recruiter": [
+              {
+                "relationships": {},
+                "row": {
+                  "id": 1,
+                  "name": "aaron",
+                  "recruiterID": null,
+                },
+              },
+            ],
+          },
+          "row": {
+            "id": 4,
+            "name": "matt",
+            "recruiterID": 1,
+          },
+        },
+        "type": "remove",
+      },
+      {
+        "node": {
+          "relationships": {
+            "recruiter": [
+              {
+                "relationships": {},
+                "row": {
                   "id": 2,
                   "name": "erik",
                   "recruiterID": 1,

--- a/packages/zql/src/ivm/exists.ts
+++ b/packages/zql/src/ivm/exists.ts
@@ -76,7 +76,10 @@ export class Exists implements Operator {
     this.#relationshipName = relationshipName;
     this.#input.setOutput(this);
     this.#storage = storage as ExistsStorage;
-    assert(this.#input.getSchema().relationships[relationshipName]);
+    assert(
+      this.#input.getSchema().relationships[relationshipName],
+      `Input schema missing ${relationshipName}`,
+    );
     this.#not = type === 'NOT EXISTS';
     this.#parentJoinKey = parentJoinKey;
 

--- a/packages/zql/src/ivm/join.push.test.ts
+++ b/packages/zql/src/ivm/join.push.test.ts
@@ -1326,17 +1326,12 @@ suite('push one:many', () => {
             ".comments:source(comment)",
             "push",
             {
-              "oldRow": {
+              "row": {
                 "id": "c1",
                 "issueID": "i1",
                 "text": "comment 1",
               },
-              "row": {
-                "id": "c1",
-                "issueID": "i2",
-                "text": "comment 1.2",
-              },
-              "type": "edit",
+              "type": "remove",
             },
           ],
           [
@@ -1365,6 +1360,18 @@ suite('push one:many', () => {
                 "text": "issue 1",
               },
               "type": "child",
+            },
+          ],
+          [
+            ".comments:source(comment)",
+            "push",
+            {
+              "row": {
+                "id": "c1",
+                "issueID": "i2",
+                "text": "comment 1.2",
+              },
+              "type": "add",
             },
           ],
           [
@@ -1513,15 +1520,11 @@ suite('push one:many', () => {
             ":source(issue)",
             "push",
             {
-              "oldRow": {
+              "row": {
                 "id": "i1",
                 "text": "issue 1",
               },
-              "row": {
-                "id": "i3",
-                "text": "issue 1.3",
-              },
-              "type": "edit",
+              "type": "remove",
             },
           ],
           [
@@ -1542,6 +1545,17 @@ suite('push one:many', () => {
               "constraint": {
                 "issueID": "i1",
               },
+            },
+          ],
+          [
+            ":source(issue)",
+            "push",
+            {
+              "row": {
+                "id": "i3",
+                "text": "issue 1.3",
+              },
+              "type": "add",
             },
           ],
           [
@@ -2149,15 +2163,11 @@ suite('push many:one', () => {
             ".owner:source(user)",
             "push",
             {
-              "oldRow": {
+              "row": {
                 "id": "u2",
                 "text": "user 2",
               },
-              "row": {
-                "id": "u1",
-                "text": "user 1",
-              },
-              "type": "edit",
+              "type": "remove",
             },
           ],
           [
@@ -2167,6 +2177,17 @@ suite('push many:one', () => {
               "constraint": {
                 "ownerID": "u2",
               },
+            },
+          ],
+          [
+            ".owner:source(user)",
+            "push",
+            {
+              "row": {
+                "id": "u1",
+                "text": "user 1",
+              },
+              "type": "add",
             },
           ],
           [
@@ -2394,34 +2415,24 @@ suite('push many:one', () => {
             ".issues:source(issue)",
             "push",
             {
-              "oldRow": {
+              "row": {
                 "id": "i2",
                 "ownerID": "u2",
                 "text": "item 2",
               },
-              "row": {
-                "id": "i2",
-                "ownerID": "u1",
-                "text": "item 2",
-              },
-              "type": "edit",
+              "type": "remove",
             },
           ],
           [
             ".issues:join(comments)",
             "push",
             {
-              "oldRow": {
+              "row": {
                 "id": "i2",
                 "ownerID": "u2",
                 "text": "item 2",
               },
-              "row": {
-                "id": "i2",
-                "ownerID": "u1",
-                "text": "item 2",
-              },
-              "type": "edit",
+              "type": "remove",
             },
           ],
           [
@@ -2459,6 +2470,30 @@ suite('push many:one', () => {
               "constraint": {
                 "issueID": "i2",
               },
+            },
+          ],
+          [
+            ".issues:source(issue)",
+            "push",
+            {
+              "row": {
+                "id": "i2",
+                "ownerID": "u1",
+                "text": "item 2",
+              },
+              "type": "add",
+            },
+          ],
+          [
+            ".issues:join(comments)",
+            "push",
+            {
+              "row": {
+                "id": "i2",
+                "ownerID": "u1",
+                "text": "item 2",
+              },
+              "type": "add",
             },
           ],
           [
@@ -4218,38 +4253,26 @@ describe('edit assignee', () => {
           ":source(issue)",
           "push",
           {
-            "oldRow": {
+            "row": {
               "assigneeID": undefined,
               "creatorID": "u1",
               "issueID": "i1",
               "text": "first issue",
             },
-            "row": {
-              "assigneeID": "u1",
-              "creatorID": "u1",
-              "issueID": "i1",
-              "text": "first issue",
-            },
-            "type": "edit",
+            "type": "remove",
           },
         ],
         [
           ":join(creator)",
           "push",
           {
-            "oldRow": {
+            "row": {
               "assigneeID": undefined,
               "creatorID": "u1",
               "issueID": "i1",
               "text": "first issue",
             },
-            "row": {
-              "assigneeID": "u1",
-              "creatorID": "u1",
-              "issueID": "i1",
-              "text": "first issue",
-            },
-            "type": "edit",
+            "type": "remove",
           },
         ],
         [
@@ -4281,6 +4304,32 @@ describe('edit assignee', () => {
             "constraint": {
               "userID": undefined,
             },
+          },
+        ],
+        [
+          ":source(issue)",
+          "push",
+          {
+            "row": {
+              "assigneeID": "u1",
+              "creatorID": "u1",
+              "issueID": "i1",
+              "text": "first issue",
+            },
+            "type": "add",
+          },
+        ],
+        [
+          ":join(creator)",
+          "push",
+          {
+            "row": {
+              "assigneeID": "u1",
+              "creatorID": "u1",
+              "issueID": "i1",
+              "text": "first issue",
+            },
+            "type": "add",
           },
         ],
         [
@@ -4534,38 +4583,26 @@ describe('edit assignee', () => {
           ":source(issue)",
           "push",
           {
-            "oldRow": {
+            "row": {
               "assigneeID": undefined,
               "creatorID": "u1",
               "issueID": "i1",
               "text": "first issue",
             },
-            "row": {
-              "assigneeID": "u1",
-              "creatorID": "u1",
-              "issueID": "i1",
-              "text": "first issue",
-            },
-            "type": "edit",
+            "type": "remove",
           },
         ],
         [
           ":join(creator)",
           "push",
           {
-            "oldRow": {
+            "row": {
               "assigneeID": undefined,
               "creatorID": "u1",
               "issueID": "i1",
               "text": "first issue",
             },
-            "row": {
-              "assigneeID": "u1",
-              "creatorID": "u1",
-              "issueID": "i1",
-              "text": "first issue",
-            },
-            "type": "edit",
+            "type": "remove",
           },
         ],
         [
@@ -4597,6 +4634,32 @@ describe('edit assignee', () => {
             "constraint": {
               "userID": undefined,
             },
+          },
+        ],
+        [
+          ":source(issue)",
+          "push",
+          {
+            "row": {
+              "assigneeID": "u1",
+              "creatorID": "u1",
+              "issueID": "i1",
+              "text": "first issue",
+            },
+            "type": "add",
+          },
+        ],
+        [
+          ":join(creator)",
+          "push",
+          {
+            "row": {
+              "assigneeID": "u1",
+              "creatorID": "u1",
+              "issueID": "i1",
+              "text": "first issue",
+            },
+            "type": "add",
           },
         ],
         [
@@ -4809,38 +4872,26 @@ describe('edit assignee', () => {
           ":source(issue)",
           "push",
           {
-            "oldRow": {
+            "row": {
               "assigneeID": "u1",
               "creatorID": "u1",
               "issueID": "i1",
               "text": "first issue",
             },
-            "row": {
-              "assigneeID": undefined,
-              "creatorID": "u1",
-              "issueID": "i1",
-              "text": "first issue",
-            },
-            "type": "edit",
+            "type": "remove",
           },
         ],
         [
           ":join(creator)",
           "push",
           {
-            "oldRow": {
+            "row": {
               "assigneeID": "u1",
               "creatorID": "u1",
               "issueID": "i1",
               "text": "first issue",
             },
-            "row": {
-              "assigneeID": undefined,
-              "creatorID": "u1",
-              "issueID": "i1",
-              "text": "first issue",
-            },
-            "type": "edit",
+            "type": "remove",
           },
         ],
         [
@@ -4872,6 +4923,32 @@ describe('edit assignee', () => {
             "constraint": {
               "userID": "u1",
             },
+          },
+        ],
+        [
+          ":source(issue)",
+          "push",
+          {
+            "row": {
+              "assigneeID": undefined,
+              "creatorID": "u1",
+              "issueID": "i1",
+              "text": "first issue",
+            },
+            "type": "add",
+          },
+        ],
+        [
+          ":join(creator)",
+          "push",
+          {
+            "row": {
+              "assigneeID": undefined,
+              "creatorID": "u1",
+              "issueID": "i1",
+              "text": "first issue",
+            },
+            "type": "add",
           },
         ],
         [
@@ -5115,38 +5192,26 @@ describe('edit assignee', () => {
           ":source(issue)",
           "push",
           {
-            "oldRow": {
+            "row": {
               "assigneeID": "u1",
               "creatorID": "u1",
               "issueID": "i1",
               "text": "first issue",
             },
-            "row": {
-              "assigneeID": undefined,
-              "creatorID": "u1",
-              "issueID": "i1",
-              "text": "first issue",
-            },
-            "type": "edit",
+            "type": "remove",
           },
         ],
         [
           ":join(creator)",
           "push",
           {
-            "oldRow": {
+            "row": {
               "assigneeID": "u1",
               "creatorID": "u1",
               "issueID": "i1",
               "text": "first issue",
             },
-            "row": {
-              "assigneeID": undefined,
-              "creatorID": "u1",
-              "issueID": "i1",
-              "text": "first issue",
-            },
-            "type": "edit",
+            "type": "remove",
           },
         ],
         [
@@ -5178,6 +5243,32 @@ describe('edit assignee', () => {
             "constraint": {
               "userID": "u1",
             },
+          },
+        ],
+        [
+          ":source(issue)",
+          "push",
+          {
+            "row": {
+              "assigneeID": undefined,
+              "creatorID": "u1",
+              "issueID": "i1",
+              "text": "first issue",
+            },
+            "type": "add",
+          },
+        ],
+        [
+          ":join(creator)",
+          "push",
+          {
+            "row": {
+              "assigneeID": undefined,
+              "creatorID": "u1",
+              "issueID": "i1",
+              "text": "first issue",
+            },
+            "type": "add",
           },
         ],
         [

--- a/packages/zql/src/ivm/join.ts
+++ b/packages/zql/src/ivm/join.ts
@@ -3,7 +3,7 @@ import type {CompoundKey, System} from '../../../zero-protocol/src/ast.ts';
 import type {Row, Value} from '../../../zero-protocol/src/data.ts';
 import type {PrimaryKey} from '../../../zero-protocol/src/primary-key.ts';
 import type {Change, ChildChange} from './change.ts';
-import {compareValues, valuesEqual, type Node} from './data.ts';
+import {compareValues, type Node} from './data.ts';
 import {
   throwOutput,
   type FetchRequest,
@@ -168,11 +168,7 @@ export class Join implements Input {
             change.node.row,
             this.#parentKey,
           ),
-          `Parent edit must not change relationship. ${JSON.stringify(
-            change.oldNode.row,
-          )},  ${JSON.stringify(change.node.row)}, ${JSON.stringify(
-            this.#parentKey,
-          )}`,
+          `Parent edit must not change relationship.`,
         );
         this.#output.push({
           type: 'edit',

--- a/packages/zql/src/ivm/join.ts
+++ b/packages/zql/src/ivm/join.ts
@@ -3,7 +3,7 @@ import type {CompoundKey, System} from '../../../zero-protocol/src/ast.ts';
 import type {Row, Value} from '../../../zero-protocol/src/data.ts';
 import type {PrimaryKey} from '../../../zero-protocol/src/primary-key.ts';
 import type {Change, ChildChange} from './change.ts';
-import {valuesEqual, type Node} from './data.ts';
+import {compareValues, valuesEqual, type Node} from './data.ts';
 import {
   throwOutput,
   type FetchRequest,
@@ -168,7 +168,11 @@ export class Join implements Input {
             change.node.row,
             this.#parentKey,
           ),
-          'Parent edit must not change relationship.',
+          `Parent edit must not change relationship. ${JSON.stringify(
+            change.oldNode.row,
+          )},  ${JSON.stringify(change.node.row)}, ${JSON.stringify(
+            this.#parentKey,
+          )}`,
         );
         this.#output.push({
           type: 'edit',
@@ -334,7 +338,7 @@ export function makeStorageKey(
 
 function rowEqualsForCompoundKey(a: Row, b: Row, key: CompoundKey): boolean {
   for (let i = 0; i < key.length; i++) {
-    if (!valuesEqual(a[key[i]], b[key[i]])) {
+    if (compareValues(a[key[i]], b[key[i]]) !== 0) {
       return false;
     }
   }

--- a/packages/zql/src/ivm/source.ts
+++ b/packages/zql/src/ivm/source.ts
@@ -52,6 +52,9 @@ export interface Source {
    * @param sort The ordering of the rows. Source must return rows in this
    * order.
    * @param filters Filters to apply to the source.
+   * @param splitEditKeys If an edit change modifies the values of any of the
+   *   keys in splitEditKeys, the source should split the edit change into
+   *   a remove of the old row followed by an add of the new row.
    */
   connect(
     sort: Ordering,

--- a/packages/zql/src/ivm/source.ts
+++ b/packages/zql/src/ivm/source.ts
@@ -53,7 +53,11 @@ export interface Source {
    * order.
    * @param filters Filters to apply to the source.
    */
-  connect(sort: Ordering, filters?: Condition | undefined): SourceInput;
+  connect(
+    sort: Ordering,
+    filters?: Condition | undefined,
+    splitEditKeys?: Set<string> | undefined,
+  ): SourceInput;
 
   /**
    * Pushes a change into the source and into all connected outputs.

--- a/packages/zql/src/ivm/take.push.test.ts
+++ b/packages/zql/src/ivm/take.push.test.ts
@@ -4875,19 +4875,13 @@ suite('take with partition', () => {
               ".comments:source(comment)",
               "push",
               {
-                "oldRow": {
+                "row": {
                   "created": 100,
                   "id": "c1",
                   "issueID": "i1",
                   "text": "a",
                 },
-                "row": {
-                  "created": 100,
-                  "id": "c1",
-                  "issueID": "i2",
-                  "text": "a2",
-                },
-                "type": "edit",
+                "type": "remove",
               },
             ],
             [
@@ -5007,6 +5001,19 @@ suite('take with partition', () => {
                   "id": "i1",
                 },
                 "type": "child",
+              },
+            ],
+            [
+              ".comments:source(comment)",
+              "push",
+              {
+                "row": {
+                  "created": 100,
+                  "id": "c1",
+                  "issueID": "i2",
+                  "text": "a2",
+                },
+                "type": "add",
               },
             ],
             [

--- a/packages/zql/src/ivm/take.ts
+++ b/packages/zql/src/ivm/take.ts
@@ -382,30 +382,11 @@ export class Take implements Operator {
   }
 
   #pushEditChange(change: EditChange): void {
-    if (
-      this.#partitionKeyComparator &&
-      this.#partitionKeyComparator(change.oldNode.row, change.node.row) !== 0
-    ) {
-      // different partition key so fall back to remove/add.
-
-      // TODO: So in some cases these don't need to be transformed into a remove
-      // + add.
-      //
-      // If the oldRow was <= the bound of the old partition value, and the
-      // newRow is <= the bound of the new partition value, this can be sent as
-      // an edit, as the row is present in the output of this operator before
-      // and after applying this push.
-
-      this.push({
-        type: 'remove',
-        node: change.oldNode,
-      });
-      this.push({
-        type: 'add',
-        node: change.node,
-      });
-      return;
-    }
+    assert(
+      !this.#partitionKeyComparator ||
+        this.#partitionKeyComparator(change.oldNode.row, change.node.row) === 0,
+      'Unexpected change of partition key',
+    );
 
     const {takeState, takeStateKey, maxBound, constraint} =
       this.#getStateAndConstraint(change.oldNode.row);


### PR DESCRIPTION
This slightly simplifies take and join logic, but more importantly it avoids having to add fairly complex overlay logic in take and join to correctly handle split pushes.  Instead the overlay logic for edits split into a remove and add is centralized at the source layer.  

This is done by gathering the join keys and partition keys in builder and passing them to the source connection as a set called splitEditKeys.  If the an edit modifies the values of any of these keys, then the source will push it as a remove followed by an add instead of as an edit.

Added asserts in join and take ensuring no unexpected edits are received.