### PR TITLE
fix(zero-cache): support "resumptive" replication

### DIFF
--- a/packages/zero-cache/src/integration/integration.pg-test.ts
+++ b/packages/zero-cache/src/integration/integration.pg-test.ts
@@ -768,6 +768,11 @@ describe('integration', {timeout: 30000}, () => {
               new: {
                 id: 'bar',
                 ['far_id']: 'not_baz',
+                b: true,
+                j1: {foo: 'bar\u0000'},
+                j2: true,
+                j3: 123,
+                j4: 'string',
               },
               key: null,
             },

--- a/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg-test.ts
@@ -1139,6 +1139,112 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
       ],
       [],
     ],
+    [
+      'resumptive replication',
+      `
+      CREATE TABLE existing (a TEXT PRIMARY KEY, b TEXT);
+      INSERT INTO existing (a, b) VALUES ('c', 'd');
+      INSERT INTO existing (a, b) VALUES ('e', 'f');
+
+      CREATE TABLE existing_full (a TEXT PRIMARY KEY, b TEXT);
+      ALTER TABLE existing_full REPLICA IDENTITY FULL;
+      INSERT INTO existing_full (a, b) VALUES ('c', 'd');
+      INSERT INTO existing_full (a, b) VALUES ('e', 'f');
+
+      ALTER PUBLICATION zero_some_public ADD TABLE existing;
+      ALTER PUBLICATION zero_some_public ADD TABLE existing_full;
+      UPDATE existing SET a = a;
+      UPDATE existing_full SET a = a;
+      `,
+      [
+        {tag: 'create-table'},
+        {tag: 'create-index'},
+        {tag: 'create-table'},
+        {tag: 'create-index'},
+        {tag: 'update'},
+        {tag: 'update'},
+        {tag: 'update'},
+        {tag: 'update'},
+      ],
+      {
+        existing: [
+          {a: 'c', b: 'd'},
+          {a: 'e', b: 'f'},
+        ],
+        ['existing_full']: [
+          {a: 'c', b: 'd'},
+          {a: 'e', b: 'f'},
+        ],
+      },
+      [
+        {
+          name: 'existing',
+          columns: {
+            a: {
+              characterMaximumLength: null,
+              dataType: 'text|NOT_NULL',
+              dflt: null,
+              notNull: false,
+              pos: 1,
+            },
+            b: {
+              characterMaximumLength: null,
+              dataType: 'TEXT',
+              dflt: null,
+              notNull: false,
+              pos: 2,
+            },
+            ['_0_version']: {
+              characterMaximumLength: null,
+              dataType: 'TEXT',
+              dflt: null,
+              notNull: false,
+              pos: 3,
+            },
+          },
+        },
+        {
+          name: 'existing_full',
+          columns: {
+            a: {
+              characterMaximumLength: null,
+              dataType: 'text|NOT_NULL',
+              dflt: null,
+              notNull: false,
+              pos: 1,
+            },
+            b: {
+              characterMaximumLength: null,
+              dataType: 'TEXT',
+              dflt: null,
+              notNull: false,
+              pos: 2,
+            },
+            ['_0_version']: {
+              characterMaximumLength: null,
+              dataType: 'TEXT',
+              dflt: null,
+              notNull: false,
+              pos: 3,
+            },
+          },
+        },
+      ],
+      [
+        {
+          columns: {a: 'ASC'},
+          name: 'existing_pkey',
+          tableName: 'existing',
+          unique: true,
+        },
+        {
+          columns: {a: 'ASC'},
+          name: 'existing_full_pkey',
+          tableName: 'existing_full',
+          unique: true,
+        },
+      ],
+    ],
   ] satisfies [
     name: string,
     statements: string,

--- a/packages/zero-cache/src/services/change-source/protocol/current/data.ts
+++ b/packages/zero-cache/src/services/change-source/protocol/current/data.ts
@@ -56,9 +56,12 @@ export const insertSchema = v.object({
 export const updateSchema = v.object({
   tag: v.literal('update'),
   relation: relationSchema,
-  // key is present if the update changed the key of the row, or if the
+  // `key` is present if the update changed the key of the row, or if the
   // table's replicaIdentity === 'full'
   key: rowSchema.nullable(),
+  // `new` is the full row (and not just the updated columns). This is
+  // necessary for "catchup" replication scenarios such as adding tables
+  // to a publication, or resharding.
   new: rowSchema,
 });
 

--- a/packages/zero-cache/src/services/replicator/schema/change-log.test.ts
+++ b/packages/zero-cache/src/services/replicator/schema/change-log.test.ts
@@ -1,4 +1,4 @@
-import {beforeEach, describe, test} from 'vitest';
+import {beforeEach, describe, expect, test} from 'vitest';
 import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
 import {Database} from '../../../../../zqlite/src/db.ts';
 import {StatementRunner} from '../../../db/statements.ts';
@@ -21,10 +21,18 @@ describe('replicator/schema/change-log', () => {
   });
 
   test('replicator/schema/change-log', () => {
-    logSetOp(db, '01', 'foo', {a: 1, b: 2});
-    logSetOp(db, '01', 'foo', {b: 3, a: 2}); // Note: rowKey JSON should have sorted keys
-    logSetOp(db, '01', 'bar', {b: 2, a: 1}); // Note: rowKey JSON should have sorted keys
-    logSetOp(db, '01', 'bar', {a: 2, b: 3});
+    expect(logSetOp(db, '01', 'foo', {a: 1, b: 2})).toMatchInlineSnapshot(
+      `"{"a":1,"b":2}"`,
+    );
+    expect(logSetOp(db, '01', 'foo', {b: 3, a: 2})).toMatchInlineSnapshot(
+      `"{"a":2,"b":3}"`,
+    );
+    expect(logSetOp(db, '01', 'bar', {b: 2, a: 1})).toMatchInlineSnapshot(
+      `"{"a":1,"b":2}"`,
+    );
+    expect(logSetOp(db, '01', 'bar', {a: 2, b: 3})).toMatchInlineSnapshot(
+      `"{"a":2,"b":3}"`,
+    );
 
     expectTables(db.db, {
       ['_zero.changeLog']: [
@@ -35,7 +43,9 @@ describe('replicator/schema/change-log', () => {
       ],
     });
 
-    logDeleteOp(db, '02', 'bar', {a: 2, b: 3});
+    expect(logDeleteOp(db, '02', 'bar', {b: 3, a: 2})).toMatchInlineSnapshot(
+      `"{"a":2,"b":3}"`,
+    );
 
     expectTables(db.db, {
       ['_zero.changeLog']: [
@@ -46,10 +56,16 @@ describe('replicator/schema/change-log', () => {
       ],
     });
 
-    logDeleteOp(db, '03', 'foo', {a: 2, b: 3});
-    logSetOp(db, '03', 'foo', {b: 4, a: 5});
+    expect(logDeleteOp(db, '03', 'foo', {a: 2, b: 3})).toMatchInlineSnapshot(
+      `"{"a":2,"b":3}"`,
+    );
+    expect(logSetOp(db, '03', 'foo', {b: 4, a: 5})).toMatchInlineSnapshot(
+      `"{"a":5,"b":4}"`,
+    );
     logTruncateOp(db, '03', 'foo'); // Clears all "foo" log entries, including the previous two.
-    logSetOp(db, '03', 'foo', {b: 9, a: 8});
+    expect(logSetOp(db, '03', 'foo', {b: 9, a: 8})).toMatchInlineSnapshot(
+      `"{"a":8,"b":9}"`,
+    );
 
     expectTables(db.db, {
       ['_zero.changeLog']: [
@@ -60,10 +76,16 @@ describe('replicator/schema/change-log', () => {
       ],
     });
 
-    logDeleteOp(db, '04', 'bar', {a: 1, b: 2});
-    logSetOp(db, '04', 'bar', {b: 3, a: 2});
+    expect(logDeleteOp(db, '04', 'bar', {a: 1, b: 2})).toMatchInlineSnapshot(
+      `"{"a":1,"b":2}"`,
+    );
+    expect(logSetOp(db, '04', 'bar', {b: 3, a: 2})).toMatchInlineSnapshot(
+      `"{"a":2,"b":3}"`,
+    );
     logResetOp(db, '04', 'bar'); // Clears all "bar" log entries, including the previous two.
-    logSetOp(db, '04', 'bar', {b: 9, a: 7});
+    expect(logSetOp(db, '04', 'bar', {b: 9, a: 7})).toMatchInlineSnapshot(
+      `"{"a":7,"b":9}"`,
+    );
 
     expectTables(db.db, {
       ['_zero.changeLog']: [

--- a/packages/zero-cache/src/services/replicator/schema/change-log.ts
+++ b/packages/zero-cache/src/services/replicator/schema/change-log.ts
@@ -97,8 +97,8 @@ export function logSetOp(
   version: LexiVersion,
   table: string,
   row: LiteRowKey,
-) {
-  logRowOp(db, version, table, row, SET_OP);
+): string {
+  return logRowOp(db, version, table, row, SET_OP);
 }
 
 export function logDeleteOp(
@@ -106,8 +106,8 @@ export function logDeleteOp(
   version: LexiVersion,
   table: string,
   row: LiteRowKey,
-) {
-  logRowOp(db, version, table, row, DEL_OP);
+): string {
+  return logRowOp(db, version, table, row, DEL_OP);
 }
 
 function logRowOp(
@@ -116,7 +116,7 @@ function logRowOp(
   table: string,
   row: LiteRowKey,
   op: string,
-) {
+): string {
   const rowKey = stringify(normalizedKeyOrder(row));
   db.run(
     `
@@ -127,6 +127,7 @@ function logRowOp(
     `,
     {version, table, rowKey, op},
   );
+  return rowKey;
 }
 export function logTruncateOp(
   db: StatementRunner,

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -527,7 +527,7 @@ describe('view-syncer/pipeline-driver', () => {
 
     replicator.processTransaction(
       '134',
-      messages.update('comments', {id: '22', issueID: '3'}),
+      messages.update('comments', {id: '22', issueID: '3', upvotes: 20000}),
     );
 
     expect([...pipelines.advance().changes]).toMatchInlineSnapshot(`
@@ -560,7 +560,7 @@ describe('view-syncer/pipeline-driver', () => {
 
     replicator.processTransaction(
       '135',
-      messages.update('comments', {id: '22', upvotes: 10}),
+      messages.update('comments', {id: '22', issueID: '3', upvotes: 10}),
     );
 
     expect([...pipelines.advance().changes]).toMatchInlineSnapshot(`

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -2438,6 +2438,7 @@ describe('view-syncer/service', () => {
       appMessages.update('schemaVersions', {
         lock: true,
         minSupportedVersion: 3,
+        maxSupportedVersion: 3,
       }),
     );
 


### PR DESCRIPTION
Support introducing rows that were not originally synced to the replica during initial sync via `UPDATE` operations. This is termed "resumptive replication" and is used for operations in which new tables/rows are introduced into the replica after initial sync, including:
* when altering a publication to include new tables or columns
* [resharding](https://www.notion.so/replicache/Zero-Sharding-1903bed89545803a9345dffc1e781048?pvs=4#1913bed8954580458202fb378ffffaba) (future feature)

In such operations, the rows in the new tables are "touched" with an innocuous update to push the data through the replication stream, e.g.

```sql
BEGIN;
ALTER PUBLICATION my_zero_pub ADD TABLE my_table;
UPDATE my_table SET id = id;
COMMIT;
```

User report: https://discord.com/channels/830183651022471199/1344646746407698483

### Note

This codifies the requirement that the `update` messages in the ChangeSource protocol contain the *full* contents of the updated row, and not just the updated values. This is how the Postgres Change Source already works, but it was not documented for the general (i.e. custom) change source protocol.  (@cbnsndwch)

This is now documented, and unit tests updated to reflect the codified requirement.

