### PR TITLE
chore(shared): use fastest (for chrome/v8) strategies for object helpers

### DIFF
--- a/packages/shared/src/objects.ts
+++ b/packages/shared/src/objects.ts
@@ -1,39 +1,36 @@
 export function mapValues<T, U>(
   input: Record<string, T>,
-  mapper: (value: T, index: number) => U,
+  mapper: (value: T) => U,
 ): Record<string, U> {
-  const output: Record<string, U> = {};
-  let i = 0;
-  for (const key in input) {
-    output[key] = mapper(input[key], i++);
-  }
-  return output;
+  return mapEntries(input, (k, v) => [k, mapper(v)]);
 }
 
-/**
- * Note: Use {@link mapValues()} if you do not need to change the keys, as it
- *       is more efficient.
- */
 export function mapEntries<T, U>(
   input: Record<string, T>,
-  mapper: (key: string, val: T, index: number) => [key: string, val: U],
+  mapper: (key: string, val: T) => [key: string, val: U],
 ): Record<string, U> {
+  // Direct assignment is faster than Object.fromEntries()
+  // https://github.com/rocicorp/mono/pull/3927#issuecomment-2706059475
   const output: Record<string, U> = {};
-  let i = 0;
-  for (const key in input) {
-    const [k, v] = mapper(key, input[key], i++);
-    output[k] = v;
+
+  // In chrome Object.entries is faster than for-in (13x) or Object.keys (15x)
+  // https://gist.github.com/arv/1b4e113724f6a14e2d4742bcc760d1fa
+  for (const entry of Object.entries(input)) {
+    const mapped = mapper(entry[0], entry[1]);
+    output[mapped[0]] = mapped[1];
   }
   return output;
 }
 
-/**
- * Note: Use {@link mapValues()} (preferred) or {@link mapEntries()} if possible,
- *       as they are more efficient.
- */
 export function mapAllEntries<T, U>(
   input: Record<string, T>,
   mapper: (entries: [key: string, val: T][]) => [key: string, val: U][],
 ): Record<string, U> {
-  return Object.fromEntries(mapper(Object.entries(input)));
+  // Direct assignment is faster than Object.fromEntries()
+  // https://github.com/rocicorp/mono/pull/3927#issuecomment-2706059475
+  const output: Record<string, U> = {};
+  for (const mapped of mapper(Object.entries(input))) {
+    output[mapped[0]] = mapped[1];
+  }
+  return output;
 }


### PR DESCRIPTION
Based on benchmarks: https://gist.github.com/arv/1b4e113724f6a14e2d4742bcc760d1fa