### PR TITLE
!feat(zero-cache): farewell, schema version

### DIFF
--- a/apps/zbugs/schema.ts
+++ b/apps/zbugs/schema.ts
@@ -190,7 +190,7 @@ type AuthData = {
   role: 'crew' | 'user';
 };
 
-export const schema = createSchema(5, {
+export const schema = createSchema({
   tables: [user, issue, comment, label, issueLabel, viewState, emoji, userPref],
   relationships: [
     userRelationships,

--- a/packages/z2s/src/test/chinook/schema.ts
+++ b/packages/z2s/src/test/chinook/schema.ts
@@ -216,7 +216,7 @@ const playlistRelationships = relationships(playlist, ({many}) => ({
   ),
 }));
 
-export const schema = createSchema(1, {
+export const schema = createSchema({
   tables: [
     album,
     artist,

--- a/packages/z2s/src/test/schema-gen.test.ts
+++ b/packages/z2s/src/test/schema-gen.test.ts
@@ -283,7 +283,6 @@ test('stable generation', () => {
           ],
         },
       },
-      "version": 1,
     }
   `);
 });

--- a/packages/z2s/src/test/schema-gen.ts
+++ b/packages/z2s/src/test/schema-gen.ts
@@ -1,11 +1,11 @@
 import type {Faker} from '@faker-js/faker';
 import type {Schema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import type {
+  Relationship,
   RelationshipsSchema,
   SchemaValue,
   TableSchema,
 } from '../../../zero-schema/src/table-schema.ts';
-import type {Relationship} from '../../../zero-schema/src/table-schema.ts';
 import {generateUniqueValues, selectRandom, shuffle, type Rng} from './util.ts';
 
 const dbTypes = {
@@ -23,7 +23,6 @@ export function generateSchema(rng: Rng, faker: Faker): Schema {
   const relationships = generateRelationships(rng, tables);
 
   return {
-    version: 1,
     tables: Object.fromEntries(tables.map(table => [table.name, table])),
     relationships,
   };

--- a/packages/zero-cache/bench/schema.ts
+++ b/packages/zero-cache/bench/schema.ts
@@ -86,7 +86,7 @@ const commentRelationships = relationships(comment, connect => ({
   }),
 }));
 
-export const schema = createSchema(1, {
+export const schema = createSchema({
   tables: [member, issue, comment, label, issueLabel],
   relationships: [issueRelationships, commentRelationships],
 });

--- a/packages/zero-cache/src/auth/load-permissions.ts
+++ b/packages/zero-cache/src/auth/load-permissions.ts
@@ -78,7 +78,6 @@ export function getSchema(lc: LogContext, replica: Database): Schema {
     }),
   );
   return {
-    version: 1, // only used on the client-side
     tables,
     relationships: {}, // relationships are already denormalized in ASTs
   };

--- a/packages/zero-cache/src/auth/read-authorizer.query.test.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.query.test.ts
@@ -34,6 +34,7 @@ import {
 } from '../../../zql/src/builder/builder.ts';
 import {Catch, type CaughtNode} from '../../../zql/src/ivm/catch.ts';
 import {MemoryStorage} from '../../../zql/src/ivm/memory-storage.ts';
+import type {Input} from '../../../zql/src/ivm/operator.ts';
 import type {Source} from '../../../zql/src/ivm/source.ts';
 import type {ExpressionBuilder} from '../../../zql/src/query/expression.ts';
 import {
@@ -48,7 +49,6 @@ import {TableSource} from '../../../zqlite/src/table-source.ts';
 import type {LogConfig, ZeroConfig} from '../config/zero-config.ts';
 import {transformQuery} from './read-authorizer.ts';
 import {WriteAuthorizerImpl} from './write-authorizer.ts';
-import type {Input} from '../../../zql/src/ivm/operator.ts';
 
 const logConfig: LogConfig = {
   format: 'text',
@@ -283,7 +283,7 @@ type AuthData = {
   };
 };
 
-const schema = createSchema(1, {
+const schema = createSchema({
   tables: [
     user,
     issue,

--- a/packages/zero-cache/src/auth/read-authorizer.test.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.test.ts
@@ -114,7 +114,7 @@ const adminReadableRelationships = relationships(adminReadable, connect => ({
   }),
 }));
 
-const schema = createSchema(1, {
+const schema = createSchema({
   tables: [
     unreadable,
     unreadable2,

--- a/packages/zero-cache/src/integration/integration.pg-test.ts
+++ b/packages/zero-cache/src/integration/integration.pg-test.ts
@@ -63,7 +63,7 @@ const nopk = table('nopk')
   })
   .primaryKey('id');
 
-const schema = createSchema(1, {
+const schema = createSchema({
   tables: [foo, bar, nopk],
 });
 

--- a/packages/zero-cache/src/services/mutagen/mutagen.authz.pg-test.ts
+++ b/packages/zero-cache/src/services/mutagen/mutagen.authz.pg-test.ts
@@ -42,7 +42,6 @@ const APP_ID = 'fooz';
 const SHARD_NUM = 0;
 const SHARD = {appID: APP_ID, shardNum: SHARD_NUM};
 const CG_ID = 'abc';
-const TEST_SCHEMA_VERSION = 1;
 
 const sqlSchema = /* sql */ `
 CREATE TABLE "${APP_ID}.permissions" (
@@ -140,7 +139,7 @@ function createReplicaTables(db: Database) {
   db.exec(sqlSchema);
 }
 
-const schema = createSchema(TEST_SCHEMA_VERSION, {
+const schema = createSchema({
   tables: [
     table('user')
       .columns({
@@ -395,7 +394,7 @@ function procMutation(
       timestamp: Date.now(),
     },
     authorizer,
-    TEST_SCHEMA_VERSION,
+    undefined,
   );
 }
 

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -282,7 +282,7 @@ const users = table('users')
   })
   .primaryKey('id');
 
-const schema = createSchema(1, {
+const schema = createSchema({
   tables: [issues, comments, issueLabels, labels, users],
   relationships: [
     relationships(comments, connect => ({

--- a/packages/zero-client/src/client/context.test.ts
+++ b/packages/zero-client/src/client/context.test.ts
@@ -8,14 +8,14 @@ import {Join} from '../../../zql/src/ivm/join.ts';
 import {MemorySource} from '../../../zql/src/ivm/memory-source.ts';
 import {MemoryStorage} from '../../../zql/src/ivm/memory-storage.ts';
 import {type AddQuery, ZeroContext} from './context.ts';
-import {ENTITIES_KEY_PREFIX} from './keys.ts';
 import {IVMSourceBranch} from './ivm-branch.ts';
+import {ENTITIES_KEY_PREFIX} from './keys.ts';
 
 const testBatchViewUpdates = (applyViewUpdates: () => void) =>
   applyViewUpdates();
 
 test('getSource', () => {
-  const schema = createSchema(1, {
+  const schema = createSchema({
     tables: [
       table('users')
         .columns({
@@ -90,7 +90,7 @@ test('getSource', () => {
     }
   `);
 });
-const schema = createSchema(1, {
+const schema = createSchema({
   tables: [
     table('t1')
       .columns({
@@ -200,7 +200,7 @@ test('processChanges wraps source updates with batchViewUpdates', () => {
 });
 
 test('transactions', () => {
-  const schema = createSchema(1, {
+  const schema = createSchema({
     tables: [
       table('server')
         .columns({

--- a/packages/zero-client/src/client/test-utils.ts
+++ b/packages/zero-client/src/client/test-utils.ts
@@ -234,7 +234,7 @@ export function zeroForTest<
     newOptions.kvStore = 'mem';
   }
 
-  const schema = options.schema ?? ({version: 1, tables: {}} as S);
+  const schema = options.schema ?? ({tables: {}} as S);
 
   const r = new TestZero({
     server: 'https://example.com/',

--- a/packages/zero-client/src/client/worker-test.ts
+++ b/packages/zero-client/src/client/worker-test.ts
@@ -40,7 +40,7 @@ async function testBasics(userID: string) {
 
   const r = zeroForTest({
     userID,
-    schema: createSchema(1, {
+    schema: createSchema({
       tables: [
         table('e')
           .columns({

--- a/packages/zero-client/src/client/zero-junction.test.ts
+++ b/packages/zero-client/src/client/zero-junction.test.ts
@@ -42,7 +42,7 @@ test('Zero Junction', async () => {
     ),
   }));
 
-  const schema = createSchema(1, {
+  const schema = createSchema({
     tables: [eventSchema, athleteSchema, disciplineSchema, matchupSchema],
     relationships: [eventRelation],
   });

--- a/packages/zero-client/src/client/zero-poke-handler.test.ts
+++ b/packages/zero-client/src/client/zero-poke-handler.test.ts
@@ -30,7 +30,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-const schema = createSchema(1, {
+const schema = createSchema({
   tables: [
     table('issue')
       .from('issues')

--- a/packages/zero-client/src/client/zero-rate.test.ts
+++ b/packages/zero-client/src/client/zero-rate.test.ts
@@ -61,7 +61,7 @@ test('connection stays alive on rate limit error', async () => {
 
 test('a mutation after a rate limit error causes limited mutations to be resent', async () => {
   const z = zeroForTest({
-    schema: createSchema(1, {
+    schema: createSchema({
       tables: [
         table('issue')
           .columns({
@@ -104,7 +104,7 @@ test('a mutation after a rate limit error causes limited mutations to be resent'
 
 test('previously confirmed mutations are not resent after a rate limit error', async () => {
   const z = zeroForTest({
-    schema: createSchema(1, {
+    schema: createSchema({
       tables: [
         table('issue')
           .columns({

--- a/packages/zero-client/src/client/zero.json.test.ts
+++ b/packages/zero-client/src/client/zero.json.test.ts
@@ -9,7 +9,7 @@ import {zeroForTest} from './test-utils.ts';
 
 test('we can create rows with json columns and query those rows', async () => {
   const z = zeroForTest({
-    schema: createSchema(1, {
+    schema: createSchema({
       tables: [
         table('track')
           .columns({

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -97,7 +97,7 @@ test('onOnlineChange callback', async () => {
 
   const z = zeroForTest({
     logLevel: 'debug',
-    schema: createSchema(1, {
+    schema: createSchema({
       tables: [
         table('foo')
           .columns({
@@ -594,7 +594,7 @@ describe('initConnection', () => {
   test('sent when connected message received but before ConnectionState.Connected desired queries > maxHeaderLength', async () => {
     const r = zeroForTest({
       maxHeaderLength: 0,
-      schema: createSchema(1, {
+      schema: createSchema({
         tables: [
           table('abc')
             .columns({
@@ -642,7 +642,7 @@ describe('initConnection', () => {
     const r = await zeroForTestWithDeletedClients({
       maxHeaderLength: 0,
       deletedClients: ['a'],
-      schema: createSchema(1, {
+      schema: createSchema({
         tables: [
           table('def')
             .columns({
@@ -696,7 +696,7 @@ describe('initConnection', () => {
     const r = await zeroForTestWithDeletedClients({
       maxHeaderLength: 0,
       deletedClientGroups: ['a'],
-      schema: createSchema(1, {
+      schema: createSchema({
         tables: [
           table('ijk')
             .columns({
@@ -748,7 +748,7 @@ describe('initConnection', () => {
 
   test('sends desired queries patch in sec-protocol header', async () => {
     const r = zeroForTest({
-      schema: createSchema(1, {
+      schema: createSchema({
         tables: [
           table('e')
             .columns({
@@ -844,7 +844,7 @@ describe('initConnection', () => {
 
   test('sends desired queries patch in sec-protocol header with deletedClients', async () => {
     const r = await zeroForTestWithDeletedClients({
-      schema: createSchema(1, {
+      schema: createSchema({
         tables: [
           table('e')
             .columns({
@@ -918,7 +918,7 @@ describe('initConnection', () => {
   test('sends desired queries patch in `initConnectionMessage` when the patch is over maxHeaderLength', async () => {
     const r = zeroForTest({
       maxHeaderLength: 0,
-      schema: createSchema(1, {
+      schema: createSchema({
         tables: [
           table('e')
             .columns({
@@ -984,7 +984,7 @@ describe('initConnection', () => {
   test('sends desired queries patch in `initConnectionMessage` when the patch is over maxHeaderLength with deleted clients', async () => {
     const r = await zeroForTestWithDeletedClients({
       maxHeaderLength: 0,
-      schema: createSchema(1, {
+      schema: createSchema({
         tables: [
           table('e')
             .columns({
@@ -1055,7 +1055,7 @@ describe('initConnection', () => {
 
   test('sends changeDesiredQueries if new queries are added after initConnection but before connected', async () => {
     const r = zeroForTest({
-      schema: createSchema(1, {
+      schema: createSchema({
         tables: [
           table('e')
             .columns({
@@ -1123,7 +1123,7 @@ describe('initConnection', () => {
 
   test('changeDesiredQueries does not include queries sent with initConnection', async () => {
     const r = zeroForTest({
-      schema: createSchema(1, {
+      schema: createSchema({
         tables: [
           table('e')
             .columns({
@@ -1150,7 +1150,7 @@ describe('initConnection', () => {
 
   test('changeDesiredQueries does include removal of a query sent with initConnection if it was removed before `connected`', async () => {
     const r = zeroForTest({
-      schema: createSchema(1, {
+      schema: createSchema({
         tables: [
           table('e')
             .columns({
@@ -1424,7 +1424,7 @@ test('pusher maps CRUD mutation names', async () => {
     }[],
   ) => {
     const r = zeroForTest({
-      schema: createSchema(1, {
+      schema: createSchema({
         tables: [
           table('issue')
             .from('issues')
@@ -1714,7 +1714,7 @@ test('smokeTest', async () => {
     const serverOptions = c.enableServer ? {} : {server: null};
     const r = zeroForTest({
       ...serverOptions,
-      schema: createSchema(1, {
+      schema: createSchema({
         tables: [
           table('issues')
             .columns({
@@ -2639,7 +2639,7 @@ test('kvStore option', async () => {
       server: null,
       userID,
       kvStore,
-      schema: createSchema(1, {
+      schema: createSchema({
         tables: [
           table('e')
             .columns({
@@ -2737,7 +2737,7 @@ test('Zero close should stop timeout, close delayed', async () => {
 
 test('ensure we get the same query object back', () => {
   const z = zeroForTest({
-    schema: createSchema(1, {
+    schema: createSchema({
       tables: [
         table('issue')
           .columns({
@@ -2768,7 +2768,7 @@ test('ensure we get the same query object back', () => {
 
 test('the type of collection should be inferred from options with parse', () => {
   const r = zeroForTest({
-    schema: createSchema(1, {
+    schema: createSchema({
       tables: [
         table('issue')
           .columns({
@@ -2799,7 +2799,7 @@ test('the type of collection should be inferred from options with parse', () => 
 describe('CRUD', () => {
   const makeZero = () =>
     zeroForTest({
-      schema: createSchema(1, {
+      schema: createSchema({
         tables: [
           table('issue')
             .from('issues')
@@ -2967,7 +2967,7 @@ describe('CRUD', () => {
 
   test('do not expose _zero_crud', () => {
     const z = zeroForTest({
-      schema: createSchema(1, {
+      schema: createSchema({
         tables: [
           table('issue')
             .columns({
@@ -3000,7 +3000,7 @@ describe('CRUD with compound primary key', () => {
   };
   const makeZero = () =>
     zeroForTest({
-      schema: createSchema(1, {
+      schema: createSchema({
         tables: [
           table('issue')
             .columns({
@@ -3125,7 +3125,7 @@ describe('CRUD with compound primary key', () => {
 
 test('mutate is a function for batching', async () => {
   const z = zeroForTest({
-    schema: createSchema(1, {
+    schema: createSchema({
       tables: [
         table('issue')
           .columns({
@@ -3176,7 +3176,7 @@ test('mutate is a function for batching', async () => {
 });
 
 test('custom mutations get pushed', async () => {
-  const schema = createSchema(1, {
+  const schema = createSchema({
     tables: [
       table('issues').columns({id: string(), value: number()}).primaryKey('id'),
     ],
@@ -3270,7 +3270,7 @@ test('custom mutations get pushed', async () => {
 
 test('calling mutate on the non batch version should throw inside a batch', async () => {
   const z = zeroForTest({
-    schema: createSchema(1, {
+    schema: createSchema({
       tables: [
         table('issue')
           .columns({

--- a/packages/zero-pg/src/test/schema.ts
+++ b/packages/zero-pg/src/test/schema.ts
@@ -6,7 +6,7 @@ import {
   table,
 } from '../../../zero-schema/src/builder/table-builder.ts';
 
-export const schema = createSchema(1, {
+export const schema = createSchema({
   tables: [
     table('basic')
       .columns({

--- a/packages/zero-protocol/src/push.test.ts
+++ b/packages/zero-protocol/src/push.test.ts
@@ -8,7 +8,7 @@ import {
 import {clientToServer} from '../../zero-schema/src/name-mapper.ts';
 import {mapCRUD} from './push.ts';
 
-const schema = createSchema(1, {
+const schema = createSchema({
   tables: [
     table('issue')
       .from('issues')

--- a/packages/zero-schema/src/builder/schema-builder.test.ts
+++ b/packages/zero-schema/src/builder/schema-builder.test.ts
@@ -114,7 +114,7 @@ test('building a schema', async () => {
     ),
   }));
 
-  const schema = createSchema(1, {
+  const schema = createSchema({
     tables: [user, issue, issueLabel, label],
     relationships: [userRelationships, issueRelationships, labelRelationships],
   });
@@ -269,7 +269,7 @@ test('too many relationships', () => {
   const y = makeTable('y');
   const z = makeTable('z');
 
-  const schema = createSchema(1, {
+  const schema = createSchema({
     tables: [
       a,
       b,
@@ -566,7 +566,7 @@ test('schema with conflicting table names', () => {
   const bar = table('bar').columns({a: string()}).primaryKey('a');
 
   expect(() =>
-    createSchema(1, {tables: [foo, bar]}),
+    createSchema({tables: [foo, bar]}),
   ).toThrowErrorMatchingInlineSnapshot(
     `[Error: Multiple tables reference the name "bar"]`,
   );
@@ -576,7 +576,7 @@ test('schema with conflicting table names', () => {
 const stringify = (o: unknown) => JSON.stringify(o, null, 2);
 
 test('clientSchemaFrom', () => {
-  const schema = createSchema(1, {
+  const schema = createSchema({
     tables: [
       table('issue')
         .from('issues')

--- a/packages/zero-schema/src/builder/schema-builder.ts
+++ b/packages/zero-schema/src/builder/schema-builder.ts
@@ -14,7 +14,6 @@ import type {Relationships} from './relationship-builder.ts';
 import {type TableBuilderWithColumns} from './table-builder.ts';
 
 export type Schema = {
-  readonly version: number;
   readonly tables: {readonly [table: string]: TableSchema};
   readonly relationships: {readonly [table: string]: RelationshipsSchema};
 };
@@ -24,29 +23,16 @@ export type Schema = {
  * You can assign them to any value you like. E.g.,
  *
  * ```ts
- * createSchema(1, {rsdfgafg: table('users')...}, {sdfd: relationships(users, ...)})
+ * createSchema({rsdfgafg: table('users')...}, {sdfd: relationships(users, ...)})
  * ```
- *
- * @param version The version of the schema. Only needs to be incremented
- * when the backend Postgres schema moves forward in a way that is not
- * compatible with the frontend. As in, if:
- * 1. Columns are removed
- * 2. Optional columns are made required
- *
- * Adding columns, adding tables, adding relationships, making
- * required columns optional are all backwards compatible changes and
- * do not require bumping the schema version.
  */
 export function createSchema<
   const TTables extends readonly TableBuilderWithColumns<TableSchema>[],
   const TRelationships extends readonly Relationships[],
->(
-  version: number,
-  options: {
-    readonly tables: TTables;
-    readonly relationships?: TRelationships | undefined;
-  },
-): {
+>(options: {
+  readonly tables: TTables;
+  readonly relationships?: TRelationships | undefined;
+}): {
   version: number;
   tables: {
     readonly [K in TTables[number]['schema']['name']]: Extract<
@@ -93,7 +79,6 @@ export function createSchema<
   });
 
   return {
-    version,
     tables: retTables,
     relationships: retRelationships,
   } as any;

--- a/packages/zero-schema/src/name-mapper.test.ts
+++ b/packages/zero-schema/src/name-mapper.test.ts
@@ -3,7 +3,7 @@ import {createSchema} from './builder/schema-builder.ts';
 import {boolean, string, table} from './builder/table-builder.ts';
 import {clientToServer, serverToClient} from './name-mapper.ts';
 
-const schema = createSchema(1, {
+const schema = createSchema({
   tables: [
     table('issue')
       .from('issues')

--- a/packages/zero-schema/src/permissions.test.ts
+++ b/packages/zero-schema/src/permissions.test.ts
@@ -18,7 +18,7 @@ const userSchema = table('user')
   })
   .primaryKey('id');
 
-const schema = createSchema(1, {tables: [userSchema]});
+const schema = createSchema({tables: [userSchema]});
 
 type AuthData = {
   sub: string;

--- a/packages/zero-schema/src/schema-config.test.ts
+++ b/packages/zero-schema/src/schema-config.test.ts
@@ -19,7 +19,7 @@ test('round trip', async () => {
       destSchema: circular,
     }),
   }));
-  const schema = createSchema(1, {
+  const schema = createSchema({
     tables: [circular],
     relationships: [circularRelationships],
   });

--- a/packages/zero-schema/src/schema-config.ts
+++ b/packages/zero-schema/src/schema-config.ts
@@ -40,7 +40,6 @@ export const tableSchemaSchema: v.Type<TableSchema> = v.readonlyObject({
 });
 
 export const schemaSchema = v.readonlyObject({
-  version: v.number(),
   tables: v.record(tableSchemaSchema),
   relationships: v.record(v.record(relationshipSchema)),
 });

--- a/packages/zero-schema/src/schema.test.ts
+++ b/packages/zero-schema/src/schema.test.ts
@@ -4,7 +4,7 @@ import {createSchema} from './builder/schema-builder.ts';
 import {number, string, table} from './builder/table-builder.ts';
 
 test('Key name does not matter', () => {
-  const schema = createSchema(1, {
+  const schema = createSchema({
     tables: [table('bar').columns({id: string()}).primaryKey('id')],
   });
 
@@ -19,7 +19,7 @@ test('Key name does not matter', () => {
 
 test('Missing primary key is an error', () => {
   expect(() =>
-    createSchema(1, {tables: [table('foo').columns({id: string()})]}),
+    createSchema({tables: [table('foo').columns({id: string()})]}),
   ).toThrowErrorMatchingInlineSnapshot(
     `[Error: Table "foo" is missing a primary key]`,
   );
@@ -48,7 +48,7 @@ test('Missing table in direct relationship should throw', () => {
   }));
 
   expect(() =>
-    createSchema(1, {tables: [foo], relationships: [fooRelationships]}),
+    createSchema({tables: [foo], relationships: [fooRelationships]}),
   ).toThrowErrorMatchingInlineSnapshot(
     `[Error: For relationship "foo"."barRelation", destination table "bar" is missing in the schema]`,
   );
@@ -100,7 +100,7 @@ test('Missing table in junction relationship should throw', () => {
   }));
 
   expect(() =>
-    createSchema(1, {
+    createSchema({
       tables: [tableB, tableC],
       relationships: [tableBRelationships, tableCRelationships],
     }),
@@ -156,7 +156,7 @@ test('Missing column in direct relationship source should throw', () => {
   }));
 
   expect(() =>
-    createSchema(1, {tables: [bar, foo], relationships: [fooRelationships]}),
+    createSchema({tables: [bar, foo], relationships: [fooRelationships]}),
   ).toThrowErrorMatchingInlineSnapshot(
     `[Error: For relationship "foo"."barRelation", the source field "missing" is missing in the table schema "foo"]`,
   );
@@ -237,7 +237,7 @@ test('Missing column in junction relationship source should throw', () => {
   }));
 
   expect(() =>
-    createSchema(1, {
+    createSchema({
       tables: [tableA, tableB, junctionTable],
       relationships: [tableARelationships],
     }),

--- a/packages/zero-schema/src/table-schema.test.ts
+++ b/packages/zero-schema/src/table-schema.test.ts
@@ -59,7 +59,7 @@ test('relationship schema types', () => {
     ),
   }));
 
-  const schema = createSchema(1, {
+  const schema = createSchema({
     tables: [issueLabel, comment, label, issue],
     relationships: [issueRelationships],
   });

--- a/packages/zero-solid/src/solid-view.test.ts
+++ b/packages/zero-solid/src/solid-view.test.ts
@@ -2020,7 +2020,7 @@ test('queryComplete promise', async () => {
   expect(view.resultDetails).toEqual({type: 'complete'});
 });
 
-const schema = createSchema(1, {
+const schema = createSchema({
   tables: [
     table('test')
       .columns({

--- a/packages/zero-solid/src/use-query.test.ts
+++ b/packages/zero-solid/src/use-query.test.ts
@@ -9,7 +9,7 @@ import {QueryDelegateImpl} from '../../zql/src/query/test/query-delegate.ts';
 import {useQuery} from './use-query.ts';
 
 function setupTestEnvironment() {
-  const schema = createSchema(1, {
+  const schema = createSchema({
     tables: [
       table('table')
         .columns({

--- a/packages/zql/src/query/query-impl.query.test.ts
+++ b/packages/zql/src/query/query-impl.query.test.ts
@@ -1,5 +1,7 @@
 import {describe, expect, test} from 'vitest';
+import type {LogConfig} from '../../../otel/src/log-options.ts';
 import {deepClone} from '../../../shared/src/deep-clone.ts';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
 import {must} from '../../../shared/src/must.ts';
 import {relationships} from '../../../zero-schema/src/builder/relationship-builder.ts';
 import {
@@ -12,8 +14,6 @@ import {newQuery, type QueryDelegate, QueryImpl} from './query-impl.ts';
 import type {AdvancedQuery} from './query-internal.ts';
 import {QueryDelegateImpl} from './test/query-delegate.ts';
 import {schema} from './test/test-schemas.ts';
-import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
-import type {LogConfig} from '../../../otel/src/log-options.ts';
 
 /**
  * Some basic manual tests to get us started.
@@ -1017,7 +1017,7 @@ test('join with compound keys', async () => {
     }),
   }));
 
-  const schema = createSchema(1, {
+  const schema = createSchema({
     tables: [a, b],
     relationships: [aRelationships],
   });

--- a/packages/zql/src/query/query.test.ts
+++ b/packages/zql/src/query/query.test.ts
@@ -171,7 +171,7 @@ const testWithMoreRelationshipsRelationships = relationships(
   }),
 );
 
-const schema = createSchema(1, {
+const schema = createSchema({
   tables: [
     testSchema,
     testSchemaWithNulls,
@@ -657,7 +657,7 @@ describe('schema structure', () => {
       }),
     }));
 
-    const schema = createSchema(1, {
+    const schema = createSchema({
       tables: [comment, issue],
       relationships: [issueRelationships],
     });
@@ -703,7 +703,7 @@ describe('schema structure', () => {
       }),
     }));
 
-    const schema = createSchema(1, {
+    const schema = createSchema({
       tables: [issue, comment],
       relationships: [issueRelationships, commentRelationships],
     });

--- a/packages/zql/src/query/test/test-schemas.ts
+++ b/packages/zql/src/query/test/test-schemas.ts
@@ -146,7 +146,7 @@ const labelRelationships = relationships(label, ({many}) => ({
   ),
 }));
 
-export const schema = createSchema(1, {
+export const schema = createSchema({
   tables: [issue, user, comment, revision, label, issueLabel],
   relationships: [
     issueRelationships,


### PR DESCRIPTION
### ⚠️ Breaking Change

`createSchema()` no longer takes a version. The `schemaVersion` is no more.

> _ever pervasive_
> _so often misunderstood_
> _missed you will not be_

