### PR TITLE
test(zql): impl `push` tests for pg vs zql vs zqlite

### DIFF
--- a/packages/z2s/src/compiler.output.test.ts
+++ b/packages/z2s/src/compiler.output.test.ts
@@ -642,7 +642,7 @@ test('related w/o junction edge', () => {
   ).toMatchInlineSnapshot(`
     {
       "text": "SELECT (
-        SELECT array_agg(row_to_json("inner_owner")) FROM (SELECT * FROM "user"  WHERE ("issue"."owner_id" = "user"."id")  ) "inner_owner"
+        SELECT COALESCE(array_agg(row_to_json("inner_owner")) , ARRAY[]::json[]) FROM (SELECT * FROM "user"  WHERE ("issue"."owner_id" = "user"."id")  ) "inner_owner"
       ) as "owner",* FROM "issue"",
       "values": [],
     }

--- a/packages/z2s/src/compiler.ts
+++ b/packages/z2s/src/compiler.ts
@@ -106,9 +106,11 @@ function relationshipSubquery(
     ) as ${sql.ident(relationship.subquery.alias)}`;
   }
   return sql`(
-    SELECT ${format?.singular ? sql`` : sql`array_agg`}(row_to_json(${sql.ident(
-      `inner_${relationship.subquery.alias}`,
-    )})) FROM (${select(
+    SELECT ${
+      format?.singular ? sql`` : sql`COALESCE(array_agg`
+    }(row_to_json(${sql.ident(`inner_${relationship.subquery.alias}`)})) ${
+      format?.singular ? sql`` : sql`, ARRAY[]::json[])`
+    } FROM (${select(
       relationship.subquery,
       format,
       correlate(

--- a/packages/z2s/src/test/chinook/get-deps.ts
+++ b/packages/z2s/src/test/chinook/get-deps.ts
@@ -26,7 +26,9 @@ async function getChinook(fileName: string, url: string): Promise<string> {
   const content = (await response.text())
     .replaceAll('DROP DATABASE IF EXISTS chinook;', '')
     .replaceAll('CREATE DATABASE chinook;', '')
-    .replaceAll('\\c chinook;', '');
+    .replaceAll('\\c chinook;', '')
+    // disabled foreign key constraints as push tests do not respect an insertion order that would preserved them.
+    .replace(/ALTER TABLE.*?FOREIGN KEY.*?;/gs, '');
   await writeFile(fileName, content);
   return content;
 }


### PR DESCRIPTION
The tests that compare ZQL vs ZQLite vs PG output only tested hydration.

Add `push` tests that push:

- add
- remove

events into sources.

`edit` to come shortly.

---

The motivation to do this now is to support testing the tldraw fix so we can have the most confidence that it works in all environments.