### PR TITLE
feat(custom-mutators): patch IVM sources in `persist.ts`, allow providing a `sourceRead` to `LazyRead`

### DIFF
--- a/packages/replicache/src/persist/persist.ts
+++ b/packages/replicache/src/persist/persist.ts
@@ -145,9 +145,7 @@ export async function persistDD31(
 
   let memdagBaseSnapshotPersisted = false;
   const zeroDataForMemdagBaseSnapshot =
-    getZeroData === undefined
-      ? undefined
-      : await getZeroData('rebase', memdagBaseSnapshot.chunk.hash);
+    getZeroData && (await getZeroData('rebase', memdagBaseSnapshot.chunk.hash));
 
   await withWrite(perdag, async perdagWrite => {
     const [mainClientGroup, latestPerdagMainClientGroupHeadCommit] =
@@ -224,11 +222,10 @@ export async function persistDD31(
     let zeroDataForPerdagHeadCommit: ZeroTxData | undefined;
     if (!memdagBaseSnapshotPersisted) {
       zeroDataForPerdagHeadCommit =
-        getZeroData === undefined
-          ? undefined
-          : await getZeroData('rebase', newMainClientGroupHeadHash, {
-              openLazySourceRead: perdagWrite,
-            });
+        getZeroData &&
+        (await getZeroData('rebase', newMainClientGroupHeadHash, {
+          openLazySourceRead: perdagWrite,
+        }));
     }
 
     // rebase new memdag mutations onto perdag

--- a/packages/zero-client/src/client/test/create-db.ts
+++ b/packages/zero-client/src/client/test/create-db.ts
@@ -12,6 +12,7 @@ import {SYNC_HEAD_NAME} from '../../../../replicache/src/sync/sync-head-name.ts'
 import * as FormatVersion from '../../../../replicache/src/format-version-enum.ts';
 import {newWriteLocal} from '../../../../replicache/src/db/write.ts';
 import type {FrozenJSONValue} from '../../../../replicache/src/frozen-json.ts';
+import type {LazyStore} from '../../../../replicache/src/dag/lazy-store.ts';
 
 const lc = createSilentLogContext();
 export async function createDb(
@@ -45,5 +46,5 @@ export async function createDb(
   );
   const syncHash = await w.commit(SYNC_HEAD_NAME);
 
-  return {dagStore, syncHash};
+  return {dagStore: dagStore as unknown as LazyStore, syncHash};
 }


### PR DESCRIPTION
# Problem:

Persist.ts persists the mutations from the current client onto the perdag. Mutations can do reads so we need to create IVM sources at the same head we'll be rebasing onto.

To get IVM into the right state, we diff from `ivmMain.hash` to `perdagHead.hash`.

When doing this diff, `perdagHead` is not loaded into the memdag yet so `LazyStore` must do a "source read" against the persistent store. See below "_getSourceRead()":

https://github.com/rocicorp/mono/blob/148b1608c353e49c934cf6edd26950eeafb03bc3/packages/replicache/src/dag/lazy-store.ts#L249-L254

The problem with this is that we already have a write transaction open against the persistent store when going to do the diff.

https://github.com/rocicorp/mono/blob/148b1608c353e49c934cf6edd26950eeafb03bc3/packages/replicache/src/persist/persist.ts#L145-L154

When the LazyStore tries to load the `perdagHead` from the persistent store, it opens a new IDB read transaction which completes on the next tick of the event loop. Because of this releasing of the event loop, the outer write transaction closes and all further writes fail.

```ts
persist.perdagWriteTx {
   ivm.computeDiff {
     lazyStore.getSourceRead {
        await openIdbReadTransaction // at this point `persist.perdadgWriteTx` auto-commits
     }
   }

   // all code that write to the perdag after this point fails due to the auto-commit of the write tx.
}
```

The simplest solution to this problem (implemented here) seems to be to pass a `sourceRead` to `LazyRead`. If `sourceRead` is provided, `lazyRead` uses that when it needs to fall back rather than trying to open a new transaction.