### PR TITLE
feat(zero-client): 100x speedup: lazy creation of queries and crud for mutators

### DIFF
--- a/packages/z2s/src/test/schema-gen.ts
+++ b/packages/z2s/src/test/schema-gen.ts
@@ -15,10 +15,14 @@ const dbTypes = {
   json: ['jsonb', 'json'],
 } as const;
 
-export function generateSchema(rng: Rng, faker: Faker): Schema {
+export function generateSchema(
+  rng: Rng,
+  faker: Faker,
+  numTables?: number,
+): Schema {
   const tables = generateUniqueValues(
     faker.word.noun,
-    Math.floor(rng() * 10) + 1,
+    numTables ?? Math.floor(rng() * 10) + 1,
   ).map(name => generateTable(name, rng, faker));
   const relationships = generateRelationships(rng, tables);
 

--- a/packages/zero-client/src/client/context.ts
+++ b/packages/zero-client/src/client/context.ts
@@ -133,10 +133,7 @@ export class ZeroContext implements QueryDelegate {
         // We should not fatal the inner-workings of Zero due to the user's application
         // code throwing an error.
         // Hence we wrap notifications in a try-catch block.
-        this.lc?.error?.(
-          'Failed notifying a commit listener of IVM updates',
-          e,
-        );
+        this.lc.error?.('Failed notifying a commit listener of IVM updates', e);
       }
     }
   }

--- a/packages/zero-client/src/client/custom.bench.ts
+++ b/packages/zero-client/src/client/custom.bench.ts
@@ -1,0 +1,28 @@
+import {en, Faker, generateMersenne53Randomizer} from '@faker-js/faker';
+import {bench} from 'vitest';
+import {generateSchema} from '../../../z2s/src/test/schema-gen.ts';
+import {TransactionImpl} from './custom.ts';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import type {WriteTransaction} from './replicache-types.ts';
+import {zeroData} from '../../../replicache/src/transactions.ts';
+
+const rng = generateMersenne53Randomizer(400);
+const schema = generateSchema(
+  () => rng.next(),
+  new Faker({
+    locale: en,
+    randomizer: rng,
+  }),
+  200,
+);
+
+bench('big schema', () => {
+  new TransactionImpl(
+    createSilentLogContext(),
+    {
+      [zeroData]: {},
+    } as unknown as WriteTransaction,
+    schema,
+    0,
+  );
+});

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -454,6 +454,7 @@ export class Zero<
     };
     this.#ivmMain = new IVMSourceBranch(schema.tables);
 
+    const lc = new LogContext(logOptions.logLevel, {}, logOptions.logSink);
     for (const [namespace, mutatorsForNamespace] of Object.entries(
       options.mutators ?? {},
     )) {
@@ -461,7 +462,12 @@ export class Zero<
         mutatorsForNamespace as Record<string, CustomMutatorImpl<Schema>>,
       )) {
         (replicacheMutators as MutatorDefs)[customMutatorKey(namespace, name)] =
-          makeReplicacheMutator(mutator, schema) as (
+          makeReplicacheMutator(
+            lc,
+            mutator,
+            schema,
+            slowMaterializeThreshold,
+          ) as (
             repTx: WriteTransaction,
             args: ReadonlyJSONValue,
           ) => Promise<void>;
@@ -492,7 +498,6 @@ export class Zero<
       kvStore,
     };
 
-    const lc = new LogContext(logOptions.logLevel, {}, logOptions.logSink);
     this.#zeroContext = new ZeroContext(
       lc,
       this.#ivmMain,


### PR DESCRIPTION
When users have really large schemas it gets expensive to create all the `schemCRUD` and `schemaQuery` objects up-front.

# Before:
![CleanShot 2025-03-11 at 14 46 50](https://github.com/user-attachments/assets/fadf6ebb-945b-40c3-8784-4312604ac0ba)


# After:
![CleanShot 2025-03-11 at 14 47 01](https://github.com/user-attachments/assets/a9512239-7939-4113-a53e-a98a4f289218)
