### PR TITLE
nwip: polish TTL in zbugs

### DIFF
--- a/apps/zbugs/src/pages/issue/issue-page.tsx
+++ b/apps/zbugs/src/pages/issue/issue-page.tsx
@@ -56,6 +56,7 @@ import {preload} from '../../zero-setup.ts';
 import {CommentComposer} from './comment-composer.tsx';
 import {Comment} from './comment.tsx';
 import {isCtrlEnter} from './is-ctrl-enter.ts';
+import {CACHE_AWHILE} from '../../query-cache-policy.ts';
 
 const emojiToastShowDuration = 3_000;
 
@@ -92,7 +93,7 @@ export function IssuePage({onReady}: {onReady: () => void}) {
     )
     .one();
 
-  const [issue, issueResult] = useQuery(q, {ttl: '1d'});
+  const [issue, issueResult] = useQuery(q, CACHE_AWHILE);
   useEffect(() => {
     if (issue) {
       onReady();
@@ -237,7 +238,7 @@ export function IssuePage({onReady}: {onReady: () => void}) {
 
   const [allComments, allCommentsResult] = useQuery(
     commentQuery(z, displayed),
-    {enabled: displayAllComments && displayed !== undefined, ttl: '1d'},
+    {enabled: displayAllComments && displayed !== undefined, ...CACHE_AWHILE},
   );
 
   const [comments, hasOlderComments] = useMemo(() => {

--- a/apps/zbugs/src/query-cache-policy.ts
+++ b/apps/zbugs/src/query-cache-policy.ts
@@ -1,0 +1,3 @@
+export const CACHE_NONE = {ttl: 'none'} as const;
+export const CACHE_AWHILE = {ttl: '1d'} as const;
+export const CACHE_FOREVER = {ttl: 'forever'} as const;

--- a/packages/zero-pg/src/query.ts
+++ b/packages/zero-pg/src/query.ts
@@ -109,4 +109,8 @@ export class Z2SQuery<
   materialize(): TypedView<HumanReadable<TReturn>> {
     throw new Error('Z2SQuery cannot be materialized');
   }
+
+  updateTTL(): void {
+    throw new Error('Z2SQuery cannot be materialized');
+  }
 }

--- a/packages/zero-react/src/use-query.tsx
+++ b/packages/zero-react/src/use-query.tsx
@@ -194,7 +194,9 @@ export class ViewStore {
 
     const hash = query.hash() + clientID;
     let existing = this.#views.get(hash);
-    if (!existing) {
+    if (existing) {
+      existing.updateTTL(ttl);
+    } else {
       existing = new ViewWrapper(
         query,
         ttl,
@@ -256,7 +258,7 @@ class ViewWrapper<
   readonly #query: AdvancedQuery<TSchema, TTable, TReturn>;
   #snapshot: QueryResult<TReturn>;
   #reactInternals: Set<() => void>;
-  readonly #ttl: TTL;
+  #ttl: TTL;
 
   constructor(
     query: AdvancedQuery<TSchema, TTable, TReturn>,
@@ -271,6 +273,10 @@ class ViewWrapper<
     this.#snapshot = getDefaultSnapshot(query.format.singular);
     this.#reactInternals = new Set();
     this.#materializeIfNeeded();
+  }
+
+  updateTTL(ttl: TTL) {
+    this.#query.updateTTL(ttl);
   }
 
   #onData = (

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -542,6 +542,7 @@ export abstract class AbstractQuery<
 
   abstract materialize(): TypedView<HumanReadable<TReturn>>;
   abstract materialize<T>(factory: ViewFactory<TSchema, TTable, TReturn, T>): T;
+  abstract updateTTL(ttl: TTL): void;
   abstract run(): Promise<HumanReadable<TReturn>>;
   abstract preload(): {
     cleanup: () => void;
@@ -630,6 +631,10 @@ export class QueryImpl<
     );
 
     return view as T;
+  }
+
+  updateTTL(ttl: TTL): void {
+    this.#delegate.addServerQuery(this._completeAst(), ttl);
   }
 
   run(): Promise<HumanReadable<TReturn>> {

--- a/packages/zql/src/query/query-internal.ts
+++ b/packages/zql/src/query/query-internal.ts
@@ -14,6 +14,7 @@ export interface AdvancedQuery<
     factory: ViewFactory<TSchema, TTable, TReturn, T>,
     ttl?: TTL,
   ): T;
+  updateTTL(ttl: TTL): void;
   get format(): Format;
   hash(): string;
 }

--- a/packages/zql/src/query/query.ts
+++ b/packages/zql/src/query/query.ts
@@ -188,6 +188,7 @@ export interface Query<
   one(): Query<TSchema, TTable, TReturn | undefined>;
 
   materialize(ttl?: number): TypedView<HumanReadable<TReturn>>;
+  updateTTL(ttl: number): void;
 
   run(): Promise<HumanReadable<TReturn>>;
 

--- a/packages/zql/src/query/static-query.ts
+++ b/packages/zql/src/query/static-query.ts
@@ -49,6 +49,10 @@ export class StaticQuery<
     throw new Error('StaticQuery cannot be materialized');
   }
 
+  updateTTL(): void {
+    throw new Error('StaticQuery cannot have TTL');
+  }
+
   run(): Promise<HumanReadable<TReturn>> {
     return Promise.reject(new Error('StaticQuery cannot be run'));
   }


### PR DESCRIPTION
I was testing the TTL stuff by polishing the usage in zbugs.

For the text entry I realized there was an elegant approach where I just test whether the in-memory text filter is different than the querystring one.

Since we debounce qs updates this would work perfectly ... except that useQuery ignores the call because the query didn't change only the TTL.

~Since there is a single view store per query across entire client, it's not just a matter of taking the new ttl if different - we really need to calculate the target expiration from the ttl and compare that, and only send the new ttl if different.~ Nevermind, I realized the TTL represents the time after going inactive, so comparing them directly is right.

Also it would be good to avoid tearing down the local view if possible. 