### PR TITLE
fix(zero-pg): zero receives args as an array

### DIFF
--- a/packages/zero-pg/src/web.ts
+++ b/packages/zero-pg/src/web.ts
@@ -209,6 +209,6 @@ export class PushProcessor<
     );
 
     const [namespace, name] = splitMutatorKey(m.name);
-    return this.#customMutatorDefs[namespace][name](zeroTx, m.args);
+    return this.#customMutatorDefs[namespace][name](zeroTx, m.args[0]);
   }
 }


### PR DESCRIPTION
Zero wraps the args in an array. This was done to make it easier to transition to support varags to mutators but we have not done that yet.