### PR TITLE
chore(vitest): allow `console.log` through

### DIFF
--- a/packages/shared/src/tool/vitest-config.ts
+++ b/packages/shared/src/tool/vitest-config.ts
@@ -35,7 +35,7 @@ export default {
       return undefined;
     },
     include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
-    silent: true,
+    silent: false,
     browser: {
       enabled: true,
       provider: 'playwright',


### PR DESCRIPTION
@arv  - is this ok to flip? 