### PR TITLE
fix(zql): Fix ref count for edit in applyChange

### DIFF
--- a/packages/zql/src/ivm/view-apply-change.test.ts
+++ b/packages/zql/src/ivm/view-apply-change.test.ts
@@ -1024,5 +1024,647 @@ describe('applyChange', () => {
         }),
       ).toThrowError(new Error('node does not exist'));
     });
+
+    test('edit, singular: false', () => {
+      const refCountMap = new Map<Entry, number>();
+      const schema = {
+        tableName: 'event',
+        columns: {
+          id: {type: 'string'},
+          name: {type: 'string'},
+        },
+        primaryKey: ['id'],
+        sort: [['id', 'asc']],
+        system: 'client',
+        relationships: {},
+        isHidden: false,
+        compareRows: makeComparator([['id', 'asc']]),
+      } as const;
+      const root = {'': []};
+      const format = {
+        singular: false,
+        relationships: {},
+      };
+
+      const apply = (change: ViewChange) =>
+        applyChange(root, change, schema, '', format, refCountMap);
+
+      apply({
+        type: 'add',
+        node: {
+          row: {
+            id: '1',
+            name: 'Aaron',
+          },
+          relationships: {},
+        },
+      });
+      expect(root).toMatchInlineSnapshot(`
+        {
+          "": [
+            {
+              "id": "1",
+              "name": "Aaron",
+            },
+          ],
+        }
+      `);
+      expect(refCountMap).toMatchInlineSnapshot(`
+        Map {
+          {
+            "id": "1",
+            "name": "Aaron",
+          } => 1,
+        }
+      `);
+
+      apply({
+        type: 'edit',
+        oldNode: {
+          row: {
+            id: '1',
+            name: 'N/A',
+          },
+        },
+        node: {
+          row: {
+            id: '1',
+            name: 'Greg',
+          },
+        },
+      });
+      expect(root).toMatchInlineSnapshot(`
+        {
+          "": [
+            {
+              "id": "1",
+              "name": "Greg",
+            },
+          ],
+        }
+      `);
+      expect(refCountMap).toMatchInlineSnapshot(`
+        Map {
+          {
+            "id": "1",
+            "name": "Greg",
+          } => 1,
+        }
+      `);
+
+      for (let i = 0; i < 2; i++) {
+        apply({
+          type: 'add',
+          node: {
+            row: {
+              id: '1',
+              name: 'Aaron',
+            },
+            relationships: {},
+          },
+        });
+      }
+      expect(root).toMatchInlineSnapshot(`
+        {
+          "": [
+            {
+              "id": "1",
+              "name": "Aaron",
+            },
+          ],
+        }
+      `);
+      expect(refCountMap).toMatchInlineSnapshot(`
+        Map {
+          {
+            "id": "1",
+            "name": "Aaron",
+          } => 3,
+        }
+      `);
+
+      apply({
+        type: 'edit',
+        oldNode: {
+          row: {
+            id: '1',
+            name: 'Aaron',
+          },
+        },
+        node: {
+          row: {
+            id: '1',
+            name: 'Greg',
+          },
+        },
+      });
+      expect(root).toMatchInlineSnapshot(`
+        {
+          "": [
+            {
+              "id": "1",
+              "name": "Greg",
+            },
+          ],
+        }
+      `);
+      expect(refCountMap).toMatchInlineSnapshot(`
+        Map {
+          {
+            "id": "1",
+            "name": "Greg",
+          } => 3,
+        }
+      `);
+    });
+
+    test('edit primary key, singular: false', () => {
+      const refCountMap = new Map<Entry, number>();
+      const schema = {
+        tableName: 'event',
+        columns: {
+          id: {type: 'string'},
+          name: {type: 'string'},
+        },
+        primaryKey: ['id'],
+        sort: [['id', 'asc']],
+        system: 'client',
+        relationships: {},
+        isHidden: false,
+        compareRows: makeComparator([['id', 'asc']]),
+      } as const;
+      const root = {'': []};
+      const format = {
+        singular: false,
+        relationships: {},
+      };
+
+      const apply = (change: ViewChange) =>
+        applyChange(root, change, schema, '', format, refCountMap);
+
+      apply({
+        type: 'add',
+        node: {
+          row: {
+            id: '1',
+            name: 'Aaron',
+          },
+          relationships: {},
+        },
+      });
+      expect(root).toMatchInlineSnapshot(`
+        {
+          "": [
+            {
+              "id": "1",
+              "name": "Aaron",
+            },
+          ],
+        }
+      `);
+      expect(refCountMap).toMatchInlineSnapshot(`
+        Map {
+          {
+            "id": "1",
+            "name": "Aaron",
+          } => 1,
+        }
+      `);
+
+      apply({
+        type: 'edit',
+        oldNode: {
+          row: {
+            id: '1',
+            name: 'N/A',
+          },
+        },
+        node: {
+          row: {
+            id: '2',
+            name: 'Greg',
+          },
+        },
+      });
+      expect(root).toMatchInlineSnapshot(`
+        {
+          "": [
+            {
+              "id": "2",
+              "name": "Greg",
+            },
+          ],
+        }
+      `);
+      expect(refCountMap).toMatchInlineSnapshot(`
+        Map {
+          {
+            "id": "2",
+            "name": "Greg",
+          } => 1,
+        }
+      `);
+      apply({
+        type: 'remove',
+        node: {
+          row: {
+            id: '2',
+            name: 'Greg',
+          },
+          relationships: {},
+        },
+      });
+
+      for (let i = 0; i < 2; i++) {
+        apply({
+          type: 'add',
+          node: {
+            row: {
+              id: '1',
+              name: 'Aaron',
+            },
+            relationships: {},
+          },
+        });
+      }
+      expect(root).toMatchInlineSnapshot(`
+    {
+      "": [
+        {
+          "id": "1",
+          "name": "Aaron",
+        },
+      ],
+    }
+  `);
+
+      for (let i = 0; i < 2; i++) {
+        apply({
+          type: 'add',
+          node: {
+            row: {
+              id: '2',
+              name: 'Greg',
+            },
+            relationships: {},
+          },
+        });
+      }
+
+      expect(root).toMatchInlineSnapshot(`
+        {
+          "": [
+            {
+              "id": "1",
+              "name": "Aaron",
+            },
+            {
+              "id": "2",
+              "name": "Greg",
+            },
+          ],
+        }
+      `);
+      expect(refCountMap).toMatchInlineSnapshot(`
+        Map {
+          {
+            "id": "1",
+            "name": "Aaron",
+          } => 2,
+          {
+            "id": "2",
+            "name": "Greg",
+          } => 2,
+        }
+      `);
+
+      apply({
+        type: 'edit',
+        oldNode: {
+          row: {
+            id: '1',
+            name: 'Aaron',
+          },
+        },
+        node: {
+          row: {
+            id: '2',
+            name: 'Greg',
+          },
+        },
+      });
+      expect(root).toMatchInlineSnapshot(`
+        {
+          "": [
+            {
+              "id": "1",
+              "name": "Aaron",
+            },
+            {
+              "id": "2",
+              "name": "Greg",
+            },
+          ],
+        }
+      `);
+      expect(refCountMap).toMatchInlineSnapshot(`
+        Map {
+          {
+            "id": "1",
+            "name": "Aaron",
+          } => 1,
+          {
+            "id": "2",
+            "name": "Greg",
+          } => 3,
+        }
+      `);
+    });
+
+    test('edit, singular: true', () => {
+      const refCountMap = new Map<Entry, number>();
+      const schema = {
+        tableName: 'event',
+        columns: {
+          id: {type: 'string'},
+          name: {type: 'string'},
+        },
+        primaryKey: ['id'],
+        sort: [['id', 'asc']],
+        system: 'client',
+        relationships: {},
+        isHidden: false,
+        compareRows: makeComparator([['id', 'asc']]),
+      } as const;
+      const root = {'': undefined};
+      const format = {
+        singular: true,
+        relationships: {},
+      };
+
+      const apply = (change: ViewChange) =>
+        applyChange(root, change, schema, '', format, refCountMap);
+
+      apply({
+        type: 'add',
+        node: {
+          row: {
+            id: '1',
+            name: 'Aaron',
+          },
+          relationships: {},
+        },
+      });
+      expect(root).toMatchInlineSnapshot(`
+        {
+          "": {
+            "id": "1",
+            "name": "Aaron",
+          },
+        }
+      `);
+      expect(refCountMap).toMatchInlineSnapshot(`
+        Map {
+          {
+            "id": "1",
+            "name": "Aaron",
+          } => 1,
+        }
+      `);
+
+      apply({
+        type: 'edit',
+        oldNode: {
+          row: {
+            id: '1',
+            name: 'N/A',
+          },
+        },
+        node: {
+          row: {
+            id: '1',
+            name: 'Greg',
+          },
+        },
+      });
+      expect(root).toMatchInlineSnapshot(`
+        {
+          "": {
+            "id": "1",
+            "name": "Greg",
+          },
+        }
+      `);
+      expect(refCountMap).toMatchInlineSnapshot(`
+        Map {
+          {
+            "id": "1",
+            "name": "Greg",
+          } => 1,
+        }
+      `);
+
+      apply({
+        type: 'add',
+        node: {
+          row: {
+            id: '1',
+            name: 'Greg',
+          },
+          relationships: {},
+        },
+      });
+      expect(root).toMatchInlineSnapshot(`
+        {
+          "": {
+            "id": "1",
+            "name": "Greg",
+          },
+        }
+      `);
+      expect(refCountMap).toMatchInlineSnapshot(`
+        Map {
+          {
+            "id": "1",
+            "name": "Greg",
+          } => 2,
+        }
+      `);
+
+      apply({
+        type: 'edit',
+        oldNode: {
+          row: {
+            id: '2',
+            name: 'Greg',
+          },
+        },
+        node: {
+          row: {
+            id: '1',
+            name: 'Aaron',
+          },
+        },
+      });
+      expect(root).toMatchInlineSnapshot(`
+        {
+          "": {
+            "id": "1",
+            "name": "Aaron",
+          },
+        }
+      `);
+      expect(refCountMap).toMatchInlineSnapshot(`
+        Map {
+          {
+            "id": "1",
+            "name": "Aaron",
+          } => 2,
+        }
+      `);
+    });
+
+    test('edit primary key, singular: true', () => {
+      const refCountMap = new Map<Entry, number>();
+      const schema = {
+        tableName: 'event',
+        columns: {
+          id: {type: 'string'},
+          name: {type: 'string'},
+        },
+        primaryKey: ['id'],
+        sort: [['id', 'asc']],
+        system: 'client',
+        relationships: {},
+        isHidden: false,
+        compareRows: makeComparator([['id', 'asc']]),
+      } as const;
+      const root = {'': undefined};
+      const format = {
+        singular: true,
+        relationships: {},
+      };
+
+      const apply = (change: ViewChange) =>
+        applyChange(root, change, schema, '', format, refCountMap);
+
+      apply({
+        type: 'add',
+        node: {
+          row: {
+            id: '1',
+            name: 'Aaron',
+          },
+          relationships: {},
+        },
+      });
+      expect(root).toMatchInlineSnapshot(`
+        {
+          "": {
+            "id": "1",
+            "name": "Aaron",
+          },
+        }
+      `);
+      expect(refCountMap).toMatchInlineSnapshot(`
+        Map {
+          {
+            "id": "1",
+            "name": "Aaron",
+          } => 1,
+        }
+      `);
+
+      apply({
+        type: 'edit',
+        oldNode: {
+          row: {
+            id: '1',
+            name: 'N/A',
+          },
+        },
+        node: {
+          row: {
+            id: '2',
+            name: 'Greg',
+          },
+        },
+      });
+      expect(root).toMatchInlineSnapshot(`
+        {
+          "": {
+            "id": "2",
+            "name": "Greg",
+          },
+        }
+      `);
+      expect(refCountMap).toMatchInlineSnapshot(`
+        Map {
+          {
+            "id": "2",
+            "name": "Greg",
+          } => 1,
+        }
+      `);
+
+      apply({
+        type: 'add',
+        node: {
+          row: {
+            id: '2',
+            name: 'Greg',
+          },
+          relationships: {},
+        },
+      });
+      expect(root).toMatchInlineSnapshot(`
+        {
+          "": {
+            "id": "2",
+            "name": "Greg",
+          },
+        }
+      `);
+      expect(refCountMap).toMatchInlineSnapshot(`
+        Map {
+          {
+            "id": "2",
+            "name": "Greg",
+          } => 2,
+        }
+      `);
+
+      apply({
+        type: 'edit',
+        oldNode: {
+          row: {
+            id: '2',
+            name: 'Greg',
+          },
+        },
+        node: {
+          row: {
+            id: '1',
+            name: 'Aaron',
+          },
+        },
+      });
+      expect(root).toMatchInlineSnapshot(`
+        {
+          "": {
+            "id": "1",
+            "name": "Aaron",
+          },
+        }
+      `);
+      expect(refCountMap).toMatchInlineSnapshot(`
+        Map {
+          {
+            "id": "1",
+            "name": "Aaron",
+          } => 2,
+        }
+      `);
+    });
   });
 });

--- a/packages/zql/src/ivm/view-apply-change.ts
+++ b/packages/zql/src/ivm/view-apply-change.ts
@@ -301,27 +301,19 @@ export function applyChange(
               schema.compareRows,
             );
             let rc = 1;
-            let newEntry: Entry;
+            const newEntry = makeEntryPreserveRelationships(
+              change.node.row,
+              oldEntry,
+              format.relationships,
+            );
             let deleteCount = 0;
             if (found) {
-              // We changed a row to a row that already exists.
-              // The existing row should increase its ref count.
-              // We preserver the relationships of the existing row.
+              // We changed a row to a row that already exists. The existing row
+              // should increase its ref count.
               deleteCount = 1;
-              const oldEntry = view[pos];
-              rc = must(refCountMap.get(oldEntry)) + 1;
-              refCountMap.delete(oldEntry);
-              newEntry = makeEntryPreserveRelationships(
-                change.node.row,
-                oldEntry,
-                format.relationships,
-              );
-            } else {
-              newEntry = makeEntryPreserveRelationships(
-                change.node.row,
-                oldEntry,
-                format.relationships,
-              );
+              const existing = view[pos];
+              rc = must(refCountMap.get(existing)) + 1;
+              refCountMap.delete(existing);
             }
             // @ts-expect-error view is readonly
             view.splice(pos, deleteCount, newEntry);

--- a/packages/zql/src/ivm/view-apply-change.ts
+++ b/packages/zql/src/ivm/view-apply-change.ts
@@ -256,8 +256,8 @@ export function applyChange(
         // @ts-expect-error parentEntry is readonly
         parentEntry[relationship] = newEntry;
       } else {
-        const view = parentEntry[relationship] as EntryList | undefined;
-        assertArray(view);
+        const view = parentEntry[relationship];
+        assertEntryList(view);
         // If the order changed due to the edit, we need to remove and reinsert.
         if (schema.compareRows(change.oldNode.row, change.node.row) === 0) {
           const {pos, found} = binarySearch(
@@ -268,6 +268,7 @@ export function applyChange(
           assert(found, 'node does not exists');
           const rc = must(refCountMap.get(view[pos]));
           refCountMap.delete(view[pos]);
+          // @ts-expect-error view is readonly
           view[pos] = makeEntryPreserveRelationships(
             change.node.row,
             view[pos],
@@ -286,6 +287,7 @@ export function applyChange(
           const rc = must(refCountMap.get(oldEntry));
           if (rc === 1) {
             refCountMap.delete(oldEntry);
+            // @ts-expect-error view is readonly
             view.splice(pos, 1);
           } else {
             refCountMap.set(oldEntry, rc - 1);
@@ -321,6 +323,7 @@ export function applyChange(
                 format.relationships,
               );
             }
+            // @ts-expect-error view is readonly
             view.splice(pos, deleteCount, newEntry);
             refCountMap.set(newEntry, rc);
           }
@@ -372,4 +375,8 @@ function getChildEntryList(
   const view = parentEntry[relationship] as unknown;
   assertArray(view);
   return view as EntryList;
+}
+
+function assertEntryList(v: unknown): asserts v is EntryList {
+  assertArray(v);
 }

--- a/packages/zql/src/ivm/view-apply-change.ts
+++ b/packages/zql/src/ivm/view-apply-change.ts
@@ -244,11 +244,11 @@ export function applyChange(
     }
     case 'edit': {
       if (singular) {
-        assertObject(parentEntry[relationship]);
         const existing = parentEntry[relationship];
+        assertEntry(existing);
         const rc = must(refCountMap.get(existing));
         const newEntry = {
-          ...parentEntry[relationship],
+          ...existing,
           ...change.node.row,
         };
         refCountMap.set(newEntry, rc);
@@ -379,4 +379,8 @@ function getChildEntryList(
 
 function assertEntryList(v: unknown): asserts v is EntryList {
   assertArray(v);
+}
+
+function assertEntry(v: unknown): asserts v is Entry {
+  assertObject(v);
 }


### PR DESCRIPTION
The edit branch was incomplete.


### Singular

We replace the old object with the new object transferring the ref count.


### Not Singular

If we edit the value of a non primary column, we transfer the ref count to the new object.

If we edit the value of a primary column, we need to decrement the ref count of the old object and increment the ref count of the new object.
