### PR TITLE
fix(zero-cache): perform replica upgrades in view-syncer

### DIFF
--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -34,7 +34,7 @@ export default async function runWorker(
   const workerName = `${mode}-replicator`;
   const lc = createLogContext(config, {worker: workerName});
 
-  const replica = setupReplica(lc, fileMode, config.replica);
+  const replica = await setupReplica(lc, fileMode, config.replica);
 
   const changeStreamerPort = config.changeStreamerPort ?? config.port + 1;
   const changeStreamerURI =

--- a/packages/zero-cache/src/services/change-source/custom/sync-schema.ts
+++ b/packages/zero-cache/src/services/change-source/custom/sync-schema.ts
@@ -1,12 +1,6 @@
 import type {LogContext} from '@rocicorp/logger';
-
-import {
-  runSchemaMigrations,
-  type Migration,
-} from '../../../db/migration-lite.ts';
 import type {ShardConfig} from '../../../types/shards.ts';
-// TODO: Move this to a common location rather than depending on pg
-import {schemaVersionMigrationMap} from '../pg/sync-schema.ts';
+import {initReplica} from '../replica-schema.ts';
 import {initialSync} from './change-source.ts';
 
 export async function initSyncSchema(
@@ -16,16 +10,7 @@ export async function initSyncSchema(
   dbPath: string,
   upstreamURI: string,
 ): Promise<void> {
-  const setupMigration: Migration = {
-    migrateSchema: (log, tx) => initialSync(log, shard, tx, upstreamURI),
-    minSafeVersion: 1,
-  };
-
-  await runSchemaMigrations(
-    log,
-    debugName,
-    dbPath,
-    setupMigration,
-    schemaVersionMigrationMap,
+  await initReplica(log, debugName, dbPath, (log, tx) =>
+    initialSync(log, shard, tx, upstreamURI),
   );
 }

--- a/packages/zero-cache/src/services/change-source/custom/sync-schema.ts
+++ b/packages/zero-cache/src/services/change-source/custom/sync-schema.ts
@@ -2,10 +2,11 @@ import type {LogContext} from '@rocicorp/logger';
 
 import {
   runSchemaMigrations,
-  type IncrementalMigrationMap,
   type Migration,
 } from '../../../db/migration-lite.ts';
 import type {ShardConfig} from '../../../types/shards.ts';
+// TODO: Move this to a common location rather than depending on pg
+import {schemaVersionMigrationMap} from '../pg/sync-schema.ts';
 import {initialSync} from './change-source.ts';
 
 export async function initSyncSchema(
@@ -18,10 +19,6 @@ export async function initSyncSchema(
   const setupMigration: Migration = {
     migrateSchema: (log, tx) => initialSync(log, shard, tx, upstreamURI),
     minSafeVersion: 1,
-  };
-
-  const schemaVersionMigrationMap: IncrementalMigrationMap = {
-    1: setupMigration,
   };
 
   await runSchemaMigrations(

--- a/packages/zero-cache/src/services/change-source/pg/sync-schema.ts
+++ b/packages/zero-cache/src/services/change-source/pg/sync-schema.ts
@@ -1,36 +1,7 @@
 import type {LogContext} from '@rocicorp/logger';
-
-import {
-  runSchemaMigrations,
-  type IncrementalMigrationMap,
-  type Migration,
-} from '../../../db/migration-lite.ts';
 import type {ShardConfig} from '../../../types/shards.ts';
-import {AutoResetSignal} from '../../change-streamer/schema/tables.ts';
-import {
-  CREATE_RUNTIME_EVENTS_TABLE,
-  recordEvent,
-} from '../../replicator/schema/replication-state.ts';
+import {initReplica} from '../replica-schema.ts';
 import {initialSync, type InitialSyncOptions} from './initial-sync.ts';
-
-export const schemaVersionMigrationMap: IncrementalMigrationMap = {
-  // There's no incremental migration from v1. Just reset the replica.
-  4: {
-    migrateSchema: () => {
-      throw new AutoResetSignal('upgrading replica to new schema');
-    },
-    minSafeVersion: 3,
-  },
-
-  5: {
-    migrateSchema: (_, db) => {
-      db.exec(CREATE_RUNTIME_EVENTS_TABLE);
-    },
-    migrateData: (_, db) => {
-      recordEvent(db, 'upgrade');
-    },
-  },
-};
 
 export async function initSyncSchema(
   log: LogContext,
@@ -40,38 +11,7 @@ export async function initSyncSchema(
   upstreamURI: string,
   syncOptions: InitialSyncOptions,
 ): Promise<void> {
-  const setupMigration: Migration = {
-    migrateSchema: (log, tx) =>
-      initialSync(log, shard, tx, upstreamURI, syncOptions),
-    minSafeVersion: 1,
-  };
-
-  await runSchemaMigrations(
-    log,
-    debugName,
-    dbPath,
-    setupMigration,
-    schemaVersionMigrationMap,
-  );
-}
-
-export async function upgradeSyncSchema(
-  log: LogContext,
-  debugName: string,
-  dbPath: string,
-) {
-  await runSchemaMigrations(
-    log,
-    debugName,
-    dbPath,
-    // setupMigration should never be invoked
-    {
-      migrateSchema: () => {
-        throw new Error(
-          'This should only be called for already synced replicas',
-        );
-      },
-    },
-    schemaVersionMigrationMap,
+  await initReplica(log, debugName, dbPath, (log, tx) =>
+    initialSync(log, shard, tx, upstreamURI, syncOptions),
   );
 }

--- a/packages/zero-cache/src/services/change-source/pg/sync-schema.ts
+++ b/packages/zero-cache/src/services/change-source/pg/sync-schema.ts
@@ -13,7 +13,7 @@ import {
 } from '../../replicator/schema/replication-state.ts';
 import {initialSync, type InitialSyncOptions} from './initial-sync.ts';
 
-const schemaVersionMigrationMap: IncrementalMigrationMap = {
+export const schemaVersionMigrationMap: IncrementalMigrationMap = {
   // There's no incremental migration from v1. Just reset the replica.
   4: {
     migrateSchema: () => {

--- a/packages/zero-cache/src/services/change-source/replica-schema.ts
+++ b/packages/zero-cache/src/services/change-source/replica-schema.ts
@@ -1,0 +1,72 @@
+import type {LogContext} from '@rocicorp/logger';
+import type {Database} from '../../../../zqlite/src/db.ts';
+import {
+  runSchemaMigrations,
+  type IncrementalMigrationMap,
+  type Migration,
+} from '../../db/migration-lite.ts';
+import {AutoResetSignal} from '../change-streamer/schema/tables.ts';
+import {
+  CREATE_RUNTIME_EVENTS_TABLE,
+  recordEvent,
+} from '../replicator/schema/replication-state.ts';
+
+export async function initReplica(
+  log: LogContext,
+  debugName: string,
+  dbPath: string,
+  initialSync: (lc: LogContext, tx: Database) => Promise<void>,
+): Promise<void> {
+  const setupMigration: Migration = {
+    migrateSchema: (log, tx) => initialSync(log, tx),
+    minSafeVersion: 1,
+  };
+
+  await runSchemaMigrations(
+    log,
+    debugName,
+    dbPath,
+    setupMigration,
+    schemaVersionMigrationMap,
+  );
+}
+
+export async function upgradeReplica(
+  log: LogContext,
+  debugName: string,
+  dbPath: string,
+) {
+  await runSchemaMigrations(
+    log,
+    debugName,
+    dbPath,
+    // setupMigration should never be invoked
+    {
+      migrateSchema: () => {
+        throw new Error(
+          'This should only be called for already synced replicas',
+        );
+      },
+    },
+    schemaVersionMigrationMap,
+  );
+}
+
+export const schemaVersionMigrationMap: IncrementalMigrationMap = {
+  // There's no incremental migration from v1. Just reset the replica.
+  4: {
+    migrateSchema: () => {
+      throw new AutoResetSignal('upgrading replica to new schema');
+    },
+    minSafeVersion: 3,
+  },
+
+  5: {
+    migrateSchema: (_, db) => {
+      db.exec(CREATE_RUNTIME_EVENTS_TABLE);
+    },
+    migrateData: (_, db) => {
+      recordEvent(db, 'upgrade');
+    },
+  },
+};

--- a/packages/zero-cache/src/workers/replicator.ts
+++ b/packages/zero-cache/src/workers/replicator.ts
@@ -3,6 +3,7 @@ import * as v from '../../../shared/src/valita.ts';
 import {Database} from '../../../zqlite/src/db.ts';
 import type {ReplicaOptions} from '../config/zero-config.ts';
 import {deleteLiteDB} from '../db/delete-lite-db.ts';
+import {upgradeSyncSchema} from '../services/change-source/pg/sync-schema.ts';
 import {Notifier} from '../services/replicator/notifier.ts';
 import type {
   ReplicaState,
@@ -30,13 +31,18 @@ export function replicaFileName(replicaFile: string, mode: ReplicaFileMode) {
 const MILLIS_PER_HOUR = 1000 * 60 * 60;
 const MB = 1024 * 1024;
 
-function connect(
+async function connect(
   lc: LogContext,
   {file, vacuumIntervalHours}: ReplicaOptions,
   walMode: 'wal' | 'wal2',
-): Database {
+  mode: ReplicaFileMode,
+): Promise<Database> {
   const replica = new Database(lc, file);
   const start = Date.now();
+
+  // Perform any upgrades to the replica in case the backup is an
+  // earlier version.
+  await upgradeSyncSchema(lc, `${mode}-replica`, file);
 
   // Start by folding any (e.g. restored) WAL(2) files into the main db.
   replica.pragma('journal_mode = delete');
@@ -94,16 +100,16 @@ function connect(
   return replica;
 }
 
-export function setupReplica(
+export async function setupReplica(
   lc: LogContext,
   mode: ReplicaFileMode,
   replicaOptions: ReplicaOptions,
-): Database {
+): Promise<Database> {
   lc.info?.(`setting up ${mode} replica`);
 
   switch (mode) {
     case 'backup': {
-      const replica = connect(lc, replicaOptions, 'wal');
+      const replica = await connect(lc, replicaOptions, 'wal', mode);
       // https://litestream.io/tips/#disable-autocheckpoints-for-high-write-load-servers
       replica.pragma('wal_autocheckpoint = 0');
       return replica;
@@ -123,11 +129,11 @@ export function setupReplica(
       replica.close();
       lc.info?.(`finished copy (${Date.now() - start} ms)`);
 
-      return connect(lc, {...replicaOptions, file: copyLocation}, 'wal2');
+      return connect(lc, {...replicaOptions, file: copyLocation}, 'wal2', mode);
     }
 
     case 'serving':
-      return connect(lc, replicaOptions, 'wal2');
+      return connect(lc, replicaOptions, 'wal2', mode);
 
     default:
       throw new Error(`Invalid ReplicaMode ${mode}`);

--- a/packages/zero-cache/src/workers/replicator.ts
+++ b/packages/zero-cache/src/workers/replicator.ts
@@ -3,7 +3,7 @@ import * as v from '../../../shared/src/valita.ts';
 import {Database} from '../../../zqlite/src/db.ts';
 import type {ReplicaOptions} from '../config/zero-config.ts';
 import {deleteLiteDB} from '../db/delete-lite-db.ts';
-import {upgradeSyncSchema} from '../services/change-source/pg/sync-schema.ts';
+import {upgradeReplica} from '../services/change-source/replica-schema.ts';
 import {Notifier} from '../services/replicator/notifier.ts';
 import type {
   ReplicaState,
@@ -42,7 +42,7 @@ async function connect(
 
   // Perform any upgrades to the replica in case the backup is an
   // earlier version.
-  await upgradeSyncSchema(lc, `${mode}-replica`, file);
+  await upgradeReplica(lc, `${mode}-replica`, file);
 
   // Start by folding any (e.g. restored) WAL(2) files into the main db.
   replica.pragma('journal_mode = delete');


### PR DESCRIPTION
Perform post-initial-sync upgrades on a replica in the view-syncer, so that a new view-syncer can theoretically restore a backup from an old replication-manager.

User report: https://discord.com/channels/830183651022471199/1349521451169874012/1349923954474881026