### PR TITLE
chore: Update TypeScript version constraints to use tilde for consist…

### DIFF
--- a/.syncpackrc
+++ b/.syncpackrc
@@ -1,0 +1,9 @@
+{
+  "semverGroups": [
+    {
+      "range": "~",
+      "dependencies": ["typescript"],
+      "packages": ["**"]
+    }
+  ]
+}

--- a/apps/zbugs/package.json
+++ b/apps/zbugs/package.json
@@ -73,7 +73,7 @@
     "rehype-video": "^2.3.0",
     "tailwindcss": "^3.0.23",
     "tsx": "^4.19.1",
-    "typescript": "^5.7.3",
+    "typescript": "~5.7.3",
     "universal-user-agent": "^7.0.2",
     "vite": "6.2.1",
     "vite-bundle-analyzer": "^0.17.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
         "rehype-video": "^2.3.0",
         "tailwindcss": "^3.0.23",
         "tsx": "^4.19.1",
-        "typescript": "^5.7.3",
+        "typescript": "~5.7.3",
         "universal-user-agent": "^7.0.2",
         "vite": "6.2.1",
         "vite-bundle-analyzer": "^0.17.3",
@@ -27114,7 +27114,7 @@
         "@rocicorp/prettier-config": "^0.2.0",
         "@vitest/runner": "3.0.8",
         "replicache": "15.2.1",
-        "typescript": "^5.7.3",
+        "typescript": "~5.7.3",
         "vitest": "3.0.8"
       }
     },
@@ -27161,7 +27161,7 @@
         "shared": "0.0.0",
         "sinon": "^13.0.1",
         "tsc-alias": "^1.8.10",
-        "typescript": "^5.7.3",
+        "typescript": "~5.7.3",
         "vitest": "3.0.8"
       }
     },
@@ -27234,7 +27234,7 @@
         "replicache": "15.2.1",
         "shared": "0.0.0",
         "tsx": "^4.19.1",
-        "typescript": "^5.7.3",
+        "typescript": "~5.7.3",
         "vite": "6.2.1",
         "xbytes": "^1.7.0"
       }
@@ -27264,7 +27264,7 @@
         "fast-check": "^3.18.0",
         "package-up": "^5.0.0",
         "type-fest": "^4.30.0",
-        "typescript": "^5.7.3",
+        "typescript": "~5.7.3",
         "vitest": "3.0.8"
       }
     },
@@ -27401,7 +27401,7 @@
         "esbuild": "^0.25.0",
         "replicache": "15.2.1",
         "tsc-alias": "^1.8.10",
-        "typescript": "^5.7.3",
+        "typescript": "~5.7.3",
         "vitest": "3.0.8"
       },
       "engines": {
@@ -27464,7 +27464,7 @@
         "@vitest/runner": "3.0.8",
         "concurrently": "^8.2.1",
         "shared": "0.0.0",
-        "typescript": "^5.7.3",
+        "typescript": "~5.7.3",
         "vitest": "3.0.8"
       }
     },
@@ -27522,7 +27522,7 @@
         "shared": "0.0.0",
         "sinon": "^13.0.1",
         "tsc-alias": "^1.8.10",
-        "typescript": "^5.7.3",
+        "typescript": "~5.7.3",
         "zero-protocol": "0.0.0"
       }
     },
@@ -27673,7 +27673,7 @@
         "playwright": "^1.43.1",
         "replicache": "15.2.1",
         "shared": "0.0.0",
-        "typescript": "^5.7.3",
+        "typescript": "~5.7.3",
         "zero-protocol": "0.0.0",
         "zod": "^3.21.4"
       }
@@ -27772,7 +27772,7 @@
         "@rocicorp/logger": "^5.3.0",
         "@rocicorp/prettier-config": "^0.2.0",
         "@vitest/runner": "3.0.8",
-        "typescript": "^5.7.3",
+        "typescript": "~5.7.3",
         "vitest": "3.0.8"
       }
     },
@@ -31926,7 +31926,7 @@
         "semver": "^7.5.4",
         "tsc-alias": "^1.8.10",
         "tsx": "^4.19.1",
-        "typescript": "^5.7.3",
+        "typescript": "~5.7.3",
         "url-pattern": "^1.0.3",
         "vitest": "3.0.8",
         "ws": "^8.18.1"
@@ -35252,7 +35252,7 @@
         "@rocicorp/prettier-config": "^0.2.0",
         "@vitest/runner": "3.0.8",
         "replicache": "15.2.1",
-        "typescript": "^5.7.3",
+        "typescript": "~5.7.3",
         "vitest": "3.0.8"
       }
     },
@@ -41963,7 +41963,7 @@
         "shared": "0.0.0",
         "sinon": "^13.0.1",
         "tsc-alias": "^1.8.10",
-        "typescript": "^5.7.3",
+        "typescript": "~5.7.3",
         "vitest": "3.0.8"
       }
     },
@@ -42024,7 +42024,7 @@
         "replicache": "15.2.1",
         "shared": "0.0.0",
         "tsx": "^4.19.1",
-        "typescript": "^5.7.3",
+        "typescript": "~5.7.3",
         "vite": "6.2.1",
         "xbytes": "^1.7.0"
       }
@@ -42538,7 +42538,7 @@
         "package-up": "^5.0.0",
         "semver": "^7.5.4",
         "type-fest": "^4.30.0",
-        "typescript": "^5.7.3",
+        "typescript": "~5.7.3",
         "vitest": "3.0.8"
       },
       "dependencies": {
@@ -45279,7 +45279,7 @@
         "remark-gfm": "^4.0.0",
         "tailwindcss": "^3.0.23",
         "tsx": "^4.19.1",
-        "typescript": "^5.7.3",
+        "typescript": "~5.7.3",
         "universal-user-agent": "^7.0.2",
         "use-debounce": "^10.0.4",
         "usehooks-ts": "^3.1.0",
@@ -45458,7 +45458,7 @@
         "postgres-array": "^3.0.2",
         "shared": "0.0.0",
         "tsx": "^4.19.1",
-        "typescript": "^5.7.3",
+        "typescript": "~5.7.3",
         "url-pattern": "^1.0.3",
         "vitest": "3.0.8",
         "ws": "^8.18.1",
@@ -45499,7 +45499,7 @@
         "shared": "0.0.0",
         "sinon": "^13.0.1",
         "tsc-alias": "^1.8.10",
-        "typescript": "^5.7.3",
+        "typescript": "~5.7.3",
         "zero-protocol": "0.0.0"
       }
     },
@@ -45576,7 +45576,7 @@
         "playwright": "^1.43.1",
         "replicache": "15.2.1",
         "shared": "0.0.0",
-        "typescript": "^5.7.3",
+        "typescript": "~5.7.3",
         "zero-protocol": "0.0.0",
         "zod": "^3.21.4"
       },
@@ -45640,7 +45640,7 @@
         "@rocicorp/logger": "^5.3.0",
         "@rocicorp/prettier-config": "^0.2.0",
         "@vitest/runner": "3.0.8",
-        "typescript": "^5.7.3",
+        "typescript": "~5.7.3",
         "vitest": "3.0.8",
         "zql": "0.0.0",
         "zqlite": "0.0.0"

--- a/packages/datadog/package.json
+++ b/packages/datadog/package.json
@@ -10,7 +10,7 @@
     "@rocicorp/prettier-config": "^0.2.0",
     "@vitest/runner": "3.0.8",
     "replicache": "15.2.1",
-    "typescript": "^5.7.3",
+    "typescript": "~5.7.3",
     "vitest": "3.0.8"
   },
   "scripts": {

--- a/packages/replicache-doc/package.json
+++ b/packages/replicache-doc/package.json
@@ -32,7 +32,7 @@
     "docusaurus-plugin-typedoc": "^1.2.2",
     "typedoc": "^0.27.6",
     "typedoc-plugin-markdown": "^4.4.1",
-    "typescript": "^5.7.3"
+    "typescript": "~5.7.3"
   },
   "browserslist": {
     "production": [

--- a/packages/replicache-perf/package.json
+++ b/packages/replicache-perf/package.json
@@ -25,7 +25,7 @@
     "replicache": "15.2.1",
     "shared": "0.0.0",
     "tsx": "^4.19.1",
-    "typescript": "^5.7.3",
+    "typescript": "~5.7.3",
     "vite": "6.2.1",
     "xbytes": "^1.7.0"
   },

--- a/packages/replicache/package.json
+++ b/packages/replicache/package.json
@@ -39,7 +39,7 @@
     "shared": "0.0.0",
     "sinon": "^13.0.1",
     "tsc-alias": "^1.8.10",
-    "typescript": "^5.7.3",
+    "typescript": "~5.7.3",
     "vitest": "3.0.8"
   },
   "type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -35,7 +35,7 @@
     "fast-check": "^3.18.0",
     "package-up": "^5.0.0",
     "type-fest": "^4.30.0",
-    "typescript": "^5.7.3",
+    "typescript": "~5.7.3",
     "vitest": "3.0.8"
   },
   "eslintConfig": {

--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -66,7 +66,7 @@
     "@vitest/runner": "3.0.8",
     "concurrently": "^8.2.1",
     "shared": "0.0.0",
-    "typescript": "^5.7.3",
+    "typescript": "~5.7.3",
     "vitest": "3.0.8"
   },
   "eslintConfig": {

--- a/packages/zero-client/package.json
+++ b/packages/zero-client/package.json
@@ -30,7 +30,7 @@
     "shared": "0.0.0",
     "sinon": "^13.0.1",
     "tsc-alias": "^1.8.10",
-    "typescript": "^5.7.3",
+    "typescript": "~5.7.3",
     "zero-protocol": "0.0.0"
   },
   "eslintConfig": {

--- a/packages/zero-protocol/package.json
+++ b/packages/zero-protocol/package.json
@@ -19,7 +19,7 @@
     "@rocicorp/eslint-config": "^0.7.0",
     "@rocicorp/prettier-config": "^0.2.0",
     "shared": "0.0.0",
-    "typescript": "^5.7.3"
+    "typescript": "~5.7.3"
   },
   "eslintConfig": {
     "extends": "../../eslint-config.json"

--- a/packages/zero/package.json
+++ b/packages/zero/package.json
@@ -62,7 +62,7 @@
     "esbuild": "^0.25.0",
     "replicache": "15.2.1",
     "tsc-alias": "^1.8.10",
-    "typescript": "^5.7.3",
+    "typescript": "~5.7.3",
     "vitest": "3.0.8"
   },
   "type": "module",

--- a/packages/zql/package.json
+++ b/packages/zql/package.json
@@ -24,7 +24,7 @@
     "playwright": "^1.43.1",
     "replicache": "15.2.1",
     "shared": "0.0.0",
-    "typescript": "^5.7.3",
+    "typescript": "~5.7.3",
     "zero-protocol": "0.0.0",
     "zod": "^3.21.4"
   },

--- a/packages/zqlite-zql-test/package.json
+++ b/packages/zqlite-zql-test/package.json
@@ -18,7 +18,7 @@
     "@rocicorp/logger": "^5.3.0",
     "@rocicorp/prettier-config": "^0.2.0",
     "@vitest/runner": "3.0.8",
-    "typescript": "^5.7.3",
+    "typescript": "~5.7.3",
     "vitest": "3.0.8"
   },
   "eslintConfig": {

--- a/packages/zqlite/package.json
+++ b/packages/zqlite/package.json
@@ -25,7 +25,7 @@
     "nanoid": "^5.1.2",
     "playwright": "^1.43.1",
     "shared": "0.0.0",
-    "typescript": "^5.7.3"
+    "typescript": "~5.7.3"
   },
   "eslintConfig": {
     "extends": "../../eslint-config.json"


### PR DESCRIPTION
…ency

When using ^5.7.3 it allows 5.8.x. Since TS does not follow semver we can end up with an incompatible version. This change updates all TypeScript version constraints to use tilde for consistency.