### PR TITLE
chore: Playwright CI caching

### DIFF
--- a/.github/workflows/bencher-benchmarks-pr.yml
+++ b/.github/workflows/bencher-benchmarks-pr.yml
@@ -119,9 +119,12 @@ jobs:
           key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
           restore-keys: |
             playwright-${{ runner.os }}-
-      - name: Install Playwright Deps
-        if: steps.cache-playwright.outputs.cache-hit != 'true'
+      - name: Install Playwright
+        if: steps.cache-playwright.outputs.cache-hit == 'false'
         run: npx playwright install --with-deps
+      - name: Install Playwright Deps
+        if: steps.cache-playwright.outputs.cache-hit == 'true'
+        run: npx playwright install-deps
 
       - name: Run benchmarks
         working-directory: packages/zero-client

--- a/.github/workflows/bencher-benchmarks.yml
+++ b/.github/workflows/bencher-benchmarks.yml
@@ -82,7 +82,7 @@ jobs:
 
       - run: npm ci
 
-      - name: Install Playwright Deps
+      - name: Install Playwright
         run: npx playwright install --with-deps
 
       - name: Run benchmarks

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -153,8 +153,11 @@ jobs:
           key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
           restore-keys: |
             playwright-${{ runner.os }}-
-      - name: Install Playwright Deps
-        if: steps.cache-playwright.outputs.cache-hit != 'true'
+      - name: Install Playwright
+        if: steps.cache-playwright.outputs.cache-hit == 'false'
         run: npx playwright install --with-deps
+      - name: Install Playwright Deps
+        if: steps.cache-playwright.outputs.cache-hit == 'true'
+        run: npx playwright install-deps
 
       - run: npm run test

--- a/.github/workflows/perf-smoke.yml
+++ b/.github/workflows/perf-smoke.yml
@@ -42,9 +42,12 @@ jobs:
           key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
           restore-keys: |
             playwright-${{ runner.os }}-
-      - name: Install Playwright Deps
-        if: steps.cache-playwright.outputs.cache-hit != 'true'
+      - name: Install Playwright
+        if: steps.cache-playwright.outputs.cache-hit == 'false'
         run: npx playwright install --with-deps
+      - name: Install Playwright Deps
+        if: steps.cache-playwright.outputs.cache-hit == 'true'
+        run: npx playwright install-deps
 
       - name: Run benchmark
         shell: bash

--- a/.github/workflows/perf-v2.js.yml
+++ b/.github/workflows/perf-v2.js.yml
@@ -34,16 +34,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
 
-      - name: Cache Playwright
-        id: cache-playwright
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            playwright-${{ runner.os }}-
-      - name: Install Playwright Deps
-        if: steps.cache-playwright.outputs.cache-hit != 'true'
+      - name: Install Playwright
         run: npx playwright install --with-deps
 
       - run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -19352,31 +19352,33 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.43.1.tgz",
-      "integrity": "sha512-V7SoH0ai2kNt1Md9E3Gwas5B9m8KR2GVvwZnAI6Pg0m3sh7UvgiYhRrhsziCmqMJNouPckiOhk8T+9bSAK0VIA==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.0.tgz",
+      "integrity": "sha512-442pTfGM0xxfCYxuBa/Pu6B2OqxqqaYq39JS8QDMGThUvIOCd6s0ANDog3uwA0cHavVlnTQzGCN7Id2YekDSXA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.43.1"
+        "playwright-core": "1.51.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.43.1.tgz",
-      "integrity": "sha512-EI36Mto2Vrx6VF7rm708qSnesVQKbxEWvPrfA1IPY6HgczBplDx7ENtx+K2n4kJ41sLLkuGfmb0ZLSSXlDhqPg==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.0.tgz",
+      "integrity": "sha512-x47yPE3Zwhlil7wlNU/iktF7t2r/URR3VLbH6EknJd/04Qc/PSJ0EY3CMXipmglLG+zyRxW6HNo2EGbKLHPWMg==",
+      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/plimit-lit": {
@@ -27157,7 +27159,7 @@
         "compare-utf8": "^0.1.1",
         "esbuild": "^0.25.0",
         "fetch-mock": "^9.11.0",
-        "playwright": "^1.43.1",
+        "playwright": "^1.51.0",
         "shared": "0.0.0",
         "sinon": "^13.0.1",
         "tsc-alias": "^1.8.10",
@@ -27230,7 +27232,7 @@
         "get-port": "^7.0.0",
         "hash-wasm": "^4.9.0",
         "idb": "^7.0.1",
-        "playwright": "^1.43.1",
+        "playwright": "^1.51.0",
         "replicache": "15.2.1",
         "shared": "0.0.0",
         "tsx": "^4.19.1",
@@ -27670,7 +27672,6 @@
         "@rocicorp/rails": "^0.10.0",
         "fast-check": "^3.18.0",
         "nanoid": "^5.1.2",
-        "playwright": "^1.43.1",
         "replicache": "15.2.1",
         "shared": "0.0.0",
         "typescript": "^5.7.3",
@@ -27744,7 +27745,6 @@
         "@rocicorp/prettier-config": "^0.2.0",
         "fast-check": "^3.18.0",
         "nanoid": "^5.1.2",
-        "playwright": "^1.43.1",
         "shared": "0.0.0",
         "typescript": "^5.7.3"
       }
@@ -40220,18 +40220,18 @@
       }
     },
     "playwright": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.43.1.tgz",
-      "integrity": "sha512-V7SoH0ai2kNt1Md9E3Gwas5B9m8KR2GVvwZnAI6Pg0m3sh7UvgiYhRrhsziCmqMJNouPckiOhk8T+9bSAK0VIA==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.0.tgz",
+      "integrity": "sha512-442pTfGM0xxfCYxuBa/Pu6B2OqxqqaYq39JS8QDMGThUvIOCd6s0ANDog3uwA0cHavVlnTQzGCN7Id2YekDSXA==",
       "requires": {
         "fsevents": "2.3.2",
-        "playwright-core": "1.43.1"
+        "playwright-core": "1.51.0"
       }
     },
     "playwright-core": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.43.1.tgz",
-      "integrity": "sha512-EI36Mto2Vrx6VF7rm708qSnesVQKbxEWvPrfA1IPY6HgczBplDx7ENtx+K2n4kJ41sLLkuGfmb0ZLSSXlDhqPg=="
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.0.tgz",
+      "integrity": "sha512-x47yPE3Zwhlil7wlNU/iktF7t2r/URR3VLbH6EknJd/04Qc/PSJ0EY3CMXipmglLG+zyRxW6HNo2EGbKLHPWMg=="
     },
     "plimit-lit": {
       "version": "1.6.1",
@@ -41959,7 +41959,7 @@
         "compare-utf8": "^0.1.1",
         "esbuild": "^0.25.0",
         "fetch-mock": "^9.11.0",
-        "playwright": "^1.43.1",
+        "playwright": "^1.51.0",
         "shared": "0.0.0",
         "sinon": "^13.0.1",
         "tsc-alias": "^1.8.10",
@@ -42020,7 +42020,7 @@
         "get-port": "^7.0.0",
         "hash-wasm": "^4.9.0",
         "idb": "^7.0.1",
-        "playwright": "^1.43.1",
+        "playwright": "^1.51.0",
         "replicache": "15.2.1",
         "shared": "0.0.0",
         "tsx": "^4.19.1",
@@ -45573,7 +45573,6 @@
         "compare-utf8": "^0.1.1",
         "fast-check": "^3.18.0",
         "nanoid": "^5.1.2",
-        "playwright": "^1.43.1",
         "replicache": "15.2.1",
         "shared": "0.0.0",
         "typescript": "^5.7.3",
@@ -45610,7 +45609,6 @@
         "fast-check": "^3.18.0",
         "nanoid": "^5.1.2",
         "pg-logical-replication": "^2.0.7",
-        "playwright": "^1.43.1",
         "shared": "0.0.0",
         "typescript": "^5.7.3",
         "zql": "0.0.0"

--- a/packages/replicache-perf/package.json
+++ b/packages/replicache-perf/package.json
@@ -21,7 +21,7 @@
     "get-port": "^7.0.0",
     "hash-wasm": "^4.9.0",
     "idb": "^7.0.1",
-    "playwright": "^1.43.1",
+    "playwright": "^1.51.0",
     "replicache": "15.2.1",
     "shared": "0.0.0",
     "tsx": "^4.19.1",

--- a/packages/replicache/package.json
+++ b/packages/replicache/package.json
@@ -35,7 +35,7 @@
     "compare-utf8": "^0.1.1",
     "esbuild": "^0.25.0",
     "fetch-mock": "^9.11.0",
-    "playwright": "^1.43.1",
+    "playwright": "^1.51.0",
     "shared": "0.0.0",
     "sinon": "^13.0.1",
     "tsc-alias": "^1.8.10",

--- a/packages/zql/package.json
+++ b/packages/zql/package.json
@@ -21,7 +21,6 @@
     "@rocicorp/rails": "^0.10.0",
     "fast-check": "^3.18.0",
     "nanoid": "^5.1.2",
-    "playwright": "^1.43.1",
     "replicache": "15.2.1",
     "shared": "0.0.0",
     "typescript": "^5.7.3",

--- a/packages/zqlite/package.json
+++ b/packages/zqlite/package.json
@@ -23,7 +23,6 @@
     "@rocicorp/prettier-config": "^0.2.0",
     "fast-check": "^3.18.0",
     "nanoid": "^5.1.2",
-    "playwright": "^1.43.1",
     "shared": "0.0.0",
     "typescript": "^5.7.3"
   },


### PR DESCRIPTION
The cache only caches the browser which are stored in `~/.cache/ms-playwright`. Playwright also needs system libraries. Even if we get a cache hit we need to ensure the libraries are installed.