### PR TITLE
chore(mutators): make auth token available on the client transactions

### DIFF
--- a/packages/replicache/src/replicache-impl.ts
+++ b/packages/replicache/src/replicache-impl.ts
@@ -215,7 +215,7 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}> {
   pushURL: string;
 
   /** The authorization token used when doing a push request. */
-  auth: string;
+  #auth: string;
 
   /** The name of the Replicache database. Populated by {@link ReplicacheOptions#name}. */
   readonly name: string;
@@ -239,6 +239,18 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}> {
    */
   get idbName(): string {
     return makeIDBName(this.name, this.schemaVersion);
+  }
+
+  set auth(auth: string) {
+    if (this.#zero) {
+      this.#zero.auth = auth;
+    }
+
+    this.#auth = auth;
+  }
+
+  get auth() {
+    return this.#auth;
   }
 
   /** The schema version of the data understood by this application. */
@@ -424,7 +436,7 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}> {
       onClientsDeleted = () => {},
     } = implOptions;
     this.#zero = implOptions.zero;
-    this.auth = auth ?? '';
+    this.#auth = auth ?? '';
     this.pullURL = pullURL;
     this.pushURL = pushURL;
     this.name = name;

--- a/packages/replicache/src/replicache-options.ts
+++ b/packages/replicache/src/replicache-options.ts
@@ -251,7 +251,10 @@ export interface ReplicacheOptions<MD extends MutatorDefs> {
  * `mutatorImpl` is a function that was created by Zero
  *
  */
-export interface ZeroTxData {}
+export interface ZeroTxData {
+  ivmSources: unknown;
+  token: string | undefined;
+}
 
 export type ZeroReadOptions = {
   openLazyRead?: Read | undefined;
@@ -263,6 +266,8 @@ export type ZeroReadOptions = {
  * Prevents us from creating any direct dependencies on Zero.
  */
 export interface ZeroOption {
+  auth: string;
+
   /**
    * Allow Zero to initialize its IVM state from the given hash and dag.
    */

--- a/packages/zero-client/src/client/custom.test.ts
+++ b/packages/zero-client/src/client/custom.test.ts
@@ -4,10 +4,9 @@ import {
   TransactionImpl,
   type CustomMutatorDefs,
   type MakeCustomMutatorInterfaces,
-  type Transaction,
 } from './custom.ts';
 import {zeroForTest} from './test-utils.ts';
-import type {InsertValue} from '../../../zql/src/mutate/custom.ts';
+import type {InsertValue, Transaction} from '../../../zql/src/mutate/custom.ts';
 import {IVMSourceBranch} from './ivm-branch.ts';
 import {createDb} from './test/create-db.ts';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
@@ -236,7 +235,9 @@ describe('rebasing custom mutators', () => {
         reason: 'rebase',
         has: () => false,
         set: () => {},
-        [zeroData]: branch,
+        [zeroData]: {
+          ivmSources: branch,
+        },
       } as unknown as WriteTransaction,
       schema,
       10,

--- a/packages/zql/src/mutate/custom.ts
+++ b/packages/zql/src/mutate/custom.ts
@@ -28,6 +28,7 @@ export interface TransactionBase<S extends Schema> {
 
   readonly mutate: SchemaCRUD<S>;
   readonly query: SchemaQuery<S>;
+  readonly token: string | undefined;
 }
 
 export type Transaction<S extends Schema, TWrappedTransaction = unknown> =
@@ -39,7 +40,17 @@ export interface ServerTransaction<S extends Schema, TWrappedTransaction>
   readonly location: 'server';
   readonly reason: 'authoritative';
   readonly dbTransaction: DBTransaction<TWrappedTransaction>;
-  readonly token: string | undefined;
+}
+
+/**
+ * An instance of this is passed to custom mutator implementations and
+ * allows reading and writing to the database and IVM at the head
+ * at which the mutator is being applied.
+ */
+export interface ClientTransaction<S extends Schema>
+  extends TransactionBase<S> {
+  readonly location: 'client';
+  readonly reason: 'optimistic' | 'rebase';
 }
 
 export interface Row {
@@ -66,17 +77,6 @@ export interface DBTransaction<T> extends Queryable {
 
 interface Queryable {
   query: (query: string, args: unknown[]) => Promise<Iterable<Row>>;
-}
-
-/**
- * An instance of this is passed to custom mutator implementations and
- * allows reading and writing to the database and IVM at the head
- * at which the mutator is being applied.
- */
-export interface ClientTransaction<S extends Schema>
-  extends TransactionBase<S> {
-  readonly location: 'client';
-  readonly reason: 'optimistic' | 'rebase';
 }
 
 export type SchemaCRUD<S extends Schema> = {


### PR DESCRIPTION
This reduces the amount of boilerplate we need to write by allowing the server and client to share more code.