### PR TITLE
chore(zbugs): swap to using a `jwk`

### DIFF
--- a/.github/workflows/sst-gigabugs-deploy.yml
+++ b/.github/workflows/sst-gigabugs-deploy.yml
@@ -73,7 +73,7 @@ jobs:
           ZERO_UPSTREAM_DB: ${{ secrets.GIGABUGS_ZERO_UPSTREAM_DB }}
           ZERO_CVR_DB: ${{ secrets.GIGABUGS_ZERO_CVR_DB }}
           ZERO_CHANGE_DB: ${{ secrets.GIGABUGS_ZERO_CHANGE_DB }}
-          ZERO_AUTH_SECRET: ${{ secrets.GIGABUGS_ZERO_JWT_SECRET }}
+          ZERO_AUTH_JWK: ${{ secrets.GIGABUGS_ZERO_AUTH_JWK }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ vars.AWS_DEFAULT_REGION }}
@@ -91,7 +91,7 @@ jobs:
           ZERO_UPSTREAM_DB: ${{ secrets.GIGABUGS_ZERO_UPSTREAM_DB }}
           ZERO_CVR_DB: ${{ secrets.GIGABUGS_ZERO_CVR_DB }}2
           ZERO_CHANGE_DB: ${{ secrets.GIGABUGS_ZERO_CHANGE_DB }}2
-          ZERO_AUTH_SECRET: ${{ secrets.GIGABUGS_ZERO_JWT_SECRET }}
+          ZERO_AUTH_JWK: ${{ secrets.GIGABUGS_ZERO_AUTH_JWK }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ vars.AWS_DEFAULT_REGION }}

--- a/.github/workflows/sst-prod-deploy.yml
+++ b/.github/workflows/sst-prod-deploy.yml
@@ -68,7 +68,7 @@ jobs:
           ZERO_UPSTREAM_DB: ${{ secrets.PROD_ZERO_UPSTREAM_DB }}
           ZERO_CVR_DB: ${{ secrets.PROD_ZERO_CVR_DB }}
           ZERO_CHANGE_DB: ${{ secrets.PROD_ZERO_CHANGE_DB }}
-          ZERO_AUTH_SECRET: ${{ secrets.PROD_ZERO_JWT_SECRET }}
+          ZERO_AUTH_JWK: ${{ secrets.PROD_ZERO_AUTH_JWK }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ vars.AWS_DEFAULT_REGION }}

--- a/.github/workflows/sst-sandbox-deploy.yml.disabled
+++ b/.github/workflows/sst-sandbox-deploy.yml.disabled
@@ -68,7 +68,7 @@ jobs:
           ZERO_UPSTREAM_DB: ${{ secrets.SANDBOX_ZERO_UPSTREAM_DB }}
           ZERO_CVR_DB: ${{ secrets.SANDBOX_ZERO_CVR_DB }}
           ZERO_CHANGE_DB: ${{ secrets.SANDBOX_ZERO_CHANGE_DB }}
-          ZERO_AUTH_SECRET: ${{ secrets.SANDBOX_ZERO_JWT_SECRET }}
+          ZERO_AUTH_JWK: ${{ secrets.SANDBOX_ZERO_AUTH_JWK }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ vars.AWS_DEFAULT_REGION }}

--- a/apps/zbugs/README.md
+++ b/apps/zbugs/README.md
@@ -54,7 +54,10 @@ ZERO_LOG_FORMAT = "text"
 # Secret used to sign and verify the JWT
 # Set this to something real if you intend to deploy
 # the app.
-ZERO_AUTH_JWK = "TODO"
+# You can create a JWK pair via `npm run create-keys`
+# The public key goes here and in `VITE_PUBLIC_JWK`.
+# Only the API server needs the private key.
+ZERO_AUTH_JWK='TODO'
 
 #### ZBugs API Server Variables ####
 
@@ -69,6 +72,7 @@ GITHUB_CLIENT_SECRET = ""
 
 #### Vite Variables ####
 VITE_PUBLIC_SERVER="http://localhost:4848"
+VITE_PUBLIC_JWK='TODO'
 ```
 
 Then start the server:

--- a/apps/zbugs/README.md
+++ b/apps/zbugs/README.md
@@ -54,7 +54,7 @@ ZERO_LOG_FORMAT = "text"
 # Secret used to sign and verify the JWT
 # Set this to something real if you intend to deploy
 # the app.
-ZERO_AUTH_SECRET = "my-localhost-testing-secret"
+ZERO_AUTH_JWK = "TODO"
 
 #### ZBugs API Server Variables ####
 

--- a/apps/zbugs/api/index.ts
+++ b/apps/zbugs/api/index.ts
@@ -19,8 +19,7 @@ declare module 'fastify' {
 
 const sql = postgres(process.env.ZERO_UPSTREAM_DB as string);
 type QueryParams = {redirect?: string | undefined};
-
-const privateJwk = JSON.parse(process.env.ZERO_AUTH_JWK as string) as JWK;
+let privateJwk: JWK | undefined;
 
 export const fastify = Fastify({
   logger: true,
@@ -53,6 +52,9 @@ fastify.register(oauthPlugin, {
 fastify.get<{
   Querystring: QueryParams;
 }>('/api/login/github/callback', async function (request, reply) {
+  if (!privateJwk) {
+    privateJwk = JSON.parse(process.env.PRIVATE_JWK as string) as JWK;
+  }
   const {token} =
     await this.githubOAuth2.getAccessTokenFromAuthorizationCodeFlow(request);
 

--- a/apps/zbugs/api/tsconfig.json
+++ b/apps/zbugs/api/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
-    "allowSyntheticDefaultImports": true,
     "baseUrl": "../../packages",
     "paths": {
       "@rocicorp/zero/pg": ["./zero/src/pg.ts"]

--- a/apps/zbugs/package.json
+++ b/apps/zbugs/package.json
@@ -18,6 +18,7 @@
     "transform-query": "tsx ../../packages/zero-cache/src/scripts/transform-query.ts",
     "run-query": "tsx ../../packages/zero-cache/src/scripts/run-query.ts",
     "run-query-brk": "tsx --inspect-brk ../../packages/zero-cache/src/scripts/run-query.ts",
+    "create-keys": "tsx ../../packages/zero-cache/src/scripts/create-jwk.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "analyze": "analyze -c vite.config.ts"

--- a/apps/zbugs/playwright/README.md
+++ b/apps/zbugs/playwright/README.md
@@ -1,6 +1,6 @@
 # Running playwright tests locally
 
-- Add ZERO_AUTH_SECRET="my-localhost-testing-secret" env
+- Add ZERO_AUTH_JWK="TODO" env
 - URL="http://localhost:5174" PERCENT_DIRECT=1 npx playwright test --ui
 
 TODO: You are supposed to be able to run in a real browser and debug by

--- a/apps/zbugs/playwright/README.md
+++ b/apps/zbugs/playwright/README.md
@@ -1,6 +1,6 @@
 # Running playwright tests locally
 
-- Add ZERO_AUTH_JWK="TODO" env
+- Add ZERO_AUTH_JWK. Set this to the public key that is output by `npm run create-keys` in `zbugs`
 - URL="http://localhost:5174" PERCENT_DIRECT=1 npx playwright test --ui
 
 TODO: You are supposed to be able to run in a real browser and debug by

--- a/packages/zero-cache/src/auth/jwt.test.ts
+++ b/packages/zero-cache/src/auth/jwt.test.ts
@@ -1,25 +1,8 @@
-import {exportJWK, generateKeyPair, SignJWT, type JWTPayload} from 'jose';
+import {SignJWT, type JWTPayload} from 'jose';
 import {describe, expect, test} from 'vitest';
 import {must} from '../../../shared/src/must.ts';
 import type {AuthConfig} from '../config/zero-config.ts';
-import {verifyToken} from './jwt.ts';
-
-async function generateJwkKeys() {
-  const {publicKey, privateKey} = await generateKeyPair('PS256');
-
-  const privateJwk = await exportJWK(privateKey);
-  const publicJwk = await exportJWK(publicKey);
-
-  privateJwk.kid = 'key-2024-001';
-  privateJwk.use = 'sig';
-  privateJwk.alg = 'PS256';
-
-  publicJwk.kid = privateJwk.kid;
-  publicJwk.use = privateJwk.use;
-  publicJwk.alg = privateJwk.alg;
-
-  return {privateJwk, publicJwk};
-}
+import {createJwkPair, verifyToken} from './jwt.ts';
 
 describe('symmetric key', () => {
   const key = 'ab'.repeat(16);
@@ -34,7 +17,7 @@ describe('symmetric key', () => {
 });
 
 describe('jwk', async () => {
-  const {privateJwk, publicJwk} = await generateJwkKeys();
+  const {privateJwk, publicJwk} = await createJwkPair();
   async function makeToken(tokenData: JWTPayload) {
     const token = await new SignJWT(tokenData)
       .setProtectedHeader({

--- a/packages/zero-cache/src/auth/jwt.ts
+++ b/packages/zero-cache/src/auth/jwt.ts
@@ -8,6 +8,24 @@ import {
 } from 'jose';
 import type {AuthConfig} from '../config/zero-config.ts';
 import {assert} from '../../../shared/src/asserts.ts';
+import {exportJWK, generateKeyPair} from 'jose';
+
+export async function createJwkPair() {
+  const {publicKey, privateKey} = await generateKeyPair('PS256');
+
+  const privateJwk = await exportJWK(privateKey);
+  const publicJwk = await exportJWK(publicKey);
+
+  privateJwk.kid = 'key-2024-001';
+  privateJwk.use = 'sig';
+  privateJwk.alg = 'PS256';
+
+  publicJwk.kid = privateJwk.kid;
+  publicJwk.use = privateJwk.use;
+  publicJwk.alg = privateJwk.alg;
+
+  return {privateJwk, publicJwk};
+}
 
 let remoteKeyset: ReturnType<typeof createRemoteJWKSet> | undefined;
 function getRemoteKeyset(jwksUrl: string) {

--- a/packages/zero-cache/src/scripts/create-jwk.ts
+++ b/packages/zero-cache/src/scripts/create-jwk.ts
@@ -1,0 +1,11 @@
+import chalk from 'chalk';
+import {createJwkPair} from '../auth/jwt.ts';
+
+const {privateJwk, publicJwk} = await createJwkPair();
+// eslint-disable-next-line no-console
+console.log(
+  chalk.red('PRIVATE KEY:\n\n'),
+  JSON.stringify(privateJwk),
+  chalk.green('\n\nPUBLIC KEY:\n\n'),
+  JSON.stringify(publicJwk),
+);

--- a/prod/sst/sst.config.ts
+++ b/prod/sst/sst.config.ts
@@ -58,7 +58,7 @@ export default $config({
       ZERO_UPSTREAM_DB: process.env.ZERO_UPSTREAM_DB!,
       ZERO_CVR_DB: process.env.ZERO_CVR_DB!,
       ZERO_CHANGE_DB: process.env.ZERO_CHANGE_DB!,
-      ZERO_AUTH_SECRET: process.env.ZERO_AUTH_SECRET!,
+      ZERO_AUTH_JWK: process.env.ZERO_AUTH_JWK!,
       AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID!,
       AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY!,
       ZERO_LOG_FORMAT: "json",


### PR DESCRIPTION
This will allow the client and server to share jwt verification code by relying on the public key for jwt verification.

Given that verification code can be shared, custom mutator definitions become much shorter

---

# Updating Your Local ZBugs

Add the following to your `.env` for local development:

```ini
PRIVATE_JWK='{"kty":"RSA","n":"6g6Jm7gd1CFEa57jTt1lsBTNdNNkixrGi8yUVTBOKitojBN-Hrf2GPC1vaR4MfMJnh6Exk8JRP4bs3cGuws3I4xpTR6N0jaBKYKOeFbOEmWavKAmZb92wRF2zKLX6K1_69IRnXOqsjvRngiz5utVH6ttKKYdnoOHQZGJGQuiKea9zApVtFafoh4NYBFEsncgvEdLJ1SwgfHnaRm6LzWDw8IvJc2iBqPKOZ7FNqlZnZnyzuBDlAcYDVLPBrc1J5TCsn_5jHsUo1oTXZnxuFT7OlzlzQj1ihHuGTNY-fEpBZBbwor1bZgByDHcjzmRFlItF_jJbC2kd0bGNwU1iHQaUw","e":"AQAB","d":"Dq5CwLBXuUqCOXiJ1r8u9aXDDU-FFZnkV43JcAkg81GDCTuKbvAoUNV9pht-09iOreBJgQwhZLZw6Qd6Ne6KKCynyN01wA2zJEtlbEmQO2SBbtC3bS0JNyrv7Kik1O9XqrmjvossFb8yyAV7uJbiNqOmASVfjjsUbMRteP4Fzzg50cIxfL9flkPD27rh389Uk-kfsvAZ-HiKjlaUqdWaBLsYYstOIX1LYWuOFmUiayMZDDtka2NBYupqLUFH3-VaFUQtLDaXCLa73dcRmbmlMeiCKhsP5jYuvjwZ9JraWQPvLFvIGwE4ABJ_FTB6U0zNmm-ul0LbQ9t4GRMMPxT3QQ","p":"97HBj555HfijgIs7Zc_1PVKG1cp9pBVyoQj7ojOGH_HG-fQrgcQpuTCSj-qnWj_q59phAOBxUjwM0Q4JZyts2u1AtFVZ2vrsX382G45ejFuDLrOysCTpA1W0rkdOyS3aC61w0k9nN53tVSri6f3o0-1qQG9n0Gz7bm7CyXq180k","q":"8ee27S2kmyKV5x967emoD41vMMVlEQnG6Zxp971EXZ0EmrZYFVUc2JFgRXNVEN6glUBymTfMcftikktVYkwLDTkGUmTQemLme93gAp8sZAVF6Bfuma4vVZrhDXd2WPV2h4hBTSBu4SsxEWrXuIv4B-veGkh-l5ZJ7x-AHl2MRLs","dp":"t1Z2XBTDt4B7nUDxlTmpX1t_fC1mdBaAA1w_zV5vz6NJUWf-8A0_iNjAExBwEOgwuq60kE6Q8nqKTg8ivJ-y8hUciJ6IZQLIBSOG7DykFSYDYoUWJTUc2CAPHdSgJ17t_yjA0pp9XvhhXGHjFamgNYWM2ObdI7QXIzWOrk1K8ik","dq":"vaonyp5WySu8zJHqGE9y7X6_B0Y9j7ZStydkDlHfIGbUDVmahl9NVp_lE47xy2BCF8OIFomhSl0HVBysvX1RzPRA-KkCrHKOs9-qm2OhsmpP_UGGWggwJLZibeSUbftHC8zRJl-fj_wFZNqYeKGFvvA4G_NrDf9PyKSyFxzRtbE","qi":"G228rybliZQv_0xeLDSzNCOp4eLgab95t1B8jAwQXuLvK-V2K8NrNJmBz25PCf8DnbxhbRrTISW_W-OH5j28HSo8AvMkUcoFEsFQDOFOctv1RAqj7E-IZyrBa2ndsK06K7muRRYDV93aPTAZiSqh1fJLAYqKYLf13t_Fmfy58yI","kid":"key-2024-001","use":"sig","alg":"PS256"}'

ZERO_AUTH_JWK='{"kty":"RSA","n":"6g6Jm7gd1CFEa57jTt1lsBTNdNNkixrGi8yUVTBOKitojBN-Hrf2GPC1vaR4MfMJnh6Exk8JRP4bs3cGuws3I4xpTR6N0jaBKYKOeFbOEmWavKAmZb92wRF2zKLX6K1_69IRnXOqsjvRngiz5utVH6ttKKYdnoOHQZGJGQuiKea9zApVtFafoh4NYBFEsncgvEdLJ1SwgfHnaRm6LzWDw8IvJc2iBqPKOZ7FNqlZnZnyzuBDlAcYDVLPBrc1J5TCsn_5jHsUo1oTXZnxuFT7OlzlzQj1ihHuGTNY-fEpBZBbwor1bZgByDHcjzmRFlItF_jJbC2kd0bGNwU1iHQaUw","e":"AQAB","kid":"key-2024-001","use":"sig","alg":"PS256"}'

VITE_PUBLIC_JWK=${ZERO_AUTH_JWK}
```

If you want to create your own keys you can run:

`npm run create-keys`

in the `zbugs` dir.

Obviously never use these keys in production since we've revealed the private key here.