### PR TITLE
chore(zero-cache): add support for unparsed json values in the change stream

### DIFF
--- a/packages/zero-cache/src/integration/integration.pg-test.ts
+++ b/packages/zero-cache/src/integration/integration.pg-test.ts
@@ -735,7 +735,8 @@ describe('integration', {timeout: 30000}, () => {
         `.simple();
       } else {
         await streamCustomChanges([
-          ['begin', {tag: 'begin'}, {commitWatermark: '102'}],
+          // Unlike initial sync, this transaction uses JSON_STRINGIFIED.
+          ['begin', {tag: 'begin', json: 's'}, {commitWatermark: '102'}],
           [
             'data',
             {
@@ -749,10 +750,10 @@ describe('integration', {timeout: 30000}, () => {
                 id: 'voo',
                 ['far_id']: 'doo',
                 b: null,
-                j1: 'foo',
-                j2: false,
-                j3: 456.789,
-                j4: {bar: 'baz'},
+                j1: '"foo"',
+                j2: 'false',
+                j3: '456.789',
+                j4: '{"bar":"baz"}',
               },
             },
           ],
@@ -769,10 +770,10 @@ describe('integration', {timeout: 30000}, () => {
                 id: 'bar',
                 ['far_id']: 'not_baz',
                 b: true,
-                j1: {foo: 'bar\u0000'},
-                j2: true,
-                j3: 123,
-                j4: 'string',
+                j1: '{"foo":"bar\\u0000"}',
+                j2: 'true',
+                j3: '123',
+                j4: '"string"',
               },
               key: null,
             },

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
@@ -16,7 +16,11 @@ import {
 import type {IndexSpec, PublishedTableSpec} from '../../../db/specs.ts';
 import {importSnapshot, TransactionPool} from '../../../db/transaction-pool.ts';
 import type {LexiVersion} from '../../../types/lexi-version.ts';
-import {liteValues, type LiteValueType} from '../../../types/lite.ts';
+import {
+  JSON_STRINGIFIED,
+  liteValues,
+  type LiteValueType,
+} from '../../../types/lite.ts';
 import {liteTableName} from '../../../types/names.ts';
 import {pgClient, type PostgresDB} from '../../../types/pg.ts';
 import type {ShardConfig, ShardID} from '../../../types/shards.ts';
@@ -338,7 +342,7 @@ async function copy(
         const values: LiteValueType[] = [];
         for (let j = i; j < i + INSERT_BATCH_SIZE; j++) {
           values.push(
-            ...liteValues(rows[j], table, 'json-as-string'),
+            ...liteValues(rows[j], table, JSON_STRINGIFIED),
             initialVersion,
           );
         }
@@ -347,7 +351,7 @@ async function copy(
       // Remaining set of rows is < INSERT_BATCH_SIZE
       for (; i < rows.length; i++) {
         insertStmt.run([
-          ...liteValues(rows[i], table, 'json-as-string'),
+          ...liteValues(rows[i], table, JSON_STRINGIFIED),
           initialVersion,
         ]);
       }

--- a/packages/zero-cache/src/services/change-source/protocol/current/data.ts
+++ b/packages/zero-cache/src/services/change-source/protocol/current/data.ts
@@ -14,6 +14,17 @@ import type {Satisfies} from '../../../../types/satisfies.ts';
 
 export const beginSchema = v.object({
   tag: v.literal('begin'),
+  // The format of values of "json"-typed columns (e.g. "JSON" and "JSONB").
+  // - 'p' is for parsed JSON, which may include JSON values or JSON objects.
+  //   These values are parsed and stringified at every process boundary
+  //   between the change-source and the replica.
+  // - 's' is for stringified JSON. These values skip the parsing and
+  //   stringification, and are directly ferried to the replica as a JSON
+  //   string. For JSON values this improves performance by 20~25% in the
+  //   change-streamer and 25~30% in the replicator.
+  //
+  // If absent, the format is assumed to be 'p' (parsed JSON objects/values).
+  json: v.union(v.literal('p'), v.literal('s')).optional(),
 });
 
 export const commitSchema = v.object({

--- a/packages/zero-cache/src/services/change-source/protocol/version.test.ts
+++ b/packages/zero-cache/src/services/change-source/protocol/version.test.ts
@@ -38,9 +38,9 @@ test('protocol versions', () => {
   // Then update the version number of the `CHANGE_SOURCE_PATH`
   // in current and export it appropriately as the new version
   // in `mod.ts`.
-  t(current, '1c43bn5dzejyy', '/changes/v0/stream');
+  t(current, '3lxrltn74rwl7', '/changes/v0/stream');
   // During initial development, we use v0 as a non-stable
   // version (i.e. breaking change are allowed). Once the
   // protocol graduates to v1, versions must be stable.
-  t(v0, '1c43bn5dzejyy', '/changes/v0/stream');
+  t(v0, '3lxrltn74rwl7', '/changes/v0/stream');
 });

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.test.ts
@@ -21,6 +21,7 @@ import {
   ChangeStreamerHttpClient,
   ChangeStreamerHttpServer,
   getSubscriberContext,
+  PROTOCOL_VERSION,
 } from './change-streamer-http.ts';
 import type {Downstream, SubscriberContext} from './change-streamer.ts';
 
@@ -99,6 +100,12 @@ describe('change-streamer/http', () => {
       [
         'invalid querystring - missing watermark',
         `/api/replication/v0/changes?id=foo&replicaVersion=bar&initial=true`,
+      ],
+      [
+        // Change the error message as necessary
+        `Cannot service client at protocol v2. Supported protocols: [v0 ... v1]`,
+        `/api/replication/v${PROTOCOL_VERSION + 1}/changes` +
+          `?id=foo&replicaVersion=bar&watermark=123&initial=true`,
       ],
     ])('%s: %s', async (error, path) => {
       for (const baseURL of [serverURL, dispatcherURL]) {


### PR DESCRIPTION
This is the first step to adding support for unparsed JSON in the change stream, which is the equivalent of the optimization done for initial-sync (#3919), applied to incremental replication.

Avoiding JSON parsing and instead ferrying values directly as JSON strings from Postgres (through the change-streamer, to the replicator,) to the replica improves performance by 20 ~ 25% in the change-streamer and 25 ~ 30% in the replicator:
 
![parsed vs stringified JSON](https://github.com/user-attachments/assets/6327b669-ec33-4efb-8c83-b21716329507)

Rolling this out is a two-step process. 

1. In the first step (this PR), an option is introduced into the change protocol to declare, per transaction, the format of the JSON values in the comprising changes, and a client (i.e. view-syncer) supporting this protocol connects to the change-streamer at `v1`. The server (replication-manager), however, starts off supporting both `v0` and `v1`, and thus does not apply the operation, since `v0` clients do not handle it correctly.
2. In a subsequent rollout, the server (replication-manager) will stop supporting `v0`. With the guarantee that only `v1` clients can connect to the change stream, the replication-manager can safely configure its postgres client to skip the parsing of JSON/JSONB values and instead ferry them directly as strings through the various layers to the SQLite replica.

@cbnsndwch if your stack (replication-manager and view-syncers) is fully rolled out with this change, you can begin formatting your changes with stringified objects and `json: 's'` to get the performance gains.