### PR TITLE
chore(zero-protocol): bump min protocol to v6 and clean up obsolete code

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/client-handler.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.test.ts
@@ -7,7 +7,6 @@ import type {
   PokePartMessage,
   PokeStartMessage,
 } from '../../../../zero-protocol/src/poke.ts';
-import {PROTOCOL_VERSION} from '../../../../zero-protocol/src/protocol-version.ts';
 import type {JSONObject} from '../../types/bigint-json.ts';
 import {ErrorForClient} from '../../types/error-for-client.ts';
 import {Subscription} from '../../types/subscription.ts';
@@ -41,7 +40,6 @@ describe('view-syncer/client-handler', () => {
       'ws1',
       SHARD,
       '121',
-      PROTOCOL_VERSION,
       schemaVersion,
       subscription,
     );
@@ -70,7 +68,6 @@ describe('view-syncer/client-handler', () => {
         'pokeStart',
         {
           baseCookie: '121',
-          cookie: '123',
           pokeID: '123',
           schemaVersions: {
             maxSupportedVersion: 1,
@@ -89,7 +86,6 @@ describe('view-syncer/client-handler', () => {
         'pokeStart',
         {
           baseCookie: '123',
-          cookie: '129',
           pokeID: '129',
           schemaVersions: {
             maxSupportedVersion: 1,
@@ -130,7 +126,6 @@ describe('view-syncer/client-handler', () => {
         'ws1',
         SHARD,
         '121',
-        PROTOCOL_VERSION,
         schemaVersion,
         subscriptions[0],
       ),
@@ -142,7 +137,6 @@ describe('view-syncer/client-handler', () => {
         'ws2',
         SHARD,
         '120:01',
-        PROTOCOL_VERSION,
         schemaVersion,
         subscriptions[1],
       ),
@@ -154,7 +148,6 @@ describe('view-syncer/client-handler', () => {
         'ws3',
         SHARD,
         '11z',
-        PROTOCOL_VERSION,
         schemaVersion,
         subscriptions[2],
       ),
@@ -285,7 +278,7 @@ describe('view-syncer/client-handler', () => {
     expect(received[0]).toEqual([
       [
         'pokeStart',
-        {pokeID: '123', baseCookie: '121', cookie: '123', schemaVersions},
+        {pokeID: '123', baseCookie: '121', schemaVersions},
       ] satisfies PokeStartMessage,
       ['pokeEnd', {pokeID: '123', cookie: '123'}] satisfies PokeEndMessage,
     ]);
@@ -294,7 +287,7 @@ describe('view-syncer/client-handler', () => {
     expect(received[1]).toEqual([
       [
         'pokeStart',
-        {pokeID: '121', baseCookie: '120:01', cookie: '121', schemaVersions},
+        {pokeID: '121', baseCookie: '120:01', schemaVersions},
       ] satisfies PokeStartMessage,
       [
         'pokePart',
@@ -326,7 +319,7 @@ describe('view-syncer/client-handler', () => {
       // Second poke
       [
         'pokeStart',
-        {pokeID: '123', baseCookie: '121', cookie: '123', schemaVersions},
+        {pokeID: '123', baseCookie: '121', schemaVersions},
       ] satisfies PokeStartMessage,
       ['pokeEnd', {pokeID: '123', cookie: '123'}] satisfies PokeEndMessage,
     ]);
@@ -335,7 +328,7 @@ describe('view-syncer/client-handler', () => {
     expect(received[2]).toEqual([
       [
         'pokeStart',
-        {pokeID: '121', baseCookie: '11z', cookie: '121', schemaVersions},
+        {pokeID: '121', baseCookie: '11z', schemaVersions},
       ] satisfies PokeStartMessage,
       [
         'pokePart',
@@ -374,7 +367,7 @@ describe('view-syncer/client-handler', () => {
       // Second poke
       [
         'pokeStart',
-        {pokeID: '123', baseCookie: '121', cookie: '123', schemaVersions},
+        {pokeID: '123', baseCookie: '121', schemaVersions},
       ] satisfies PokeStartMessage,
       ['pokeEnd', {pokeID: '123', cookie: '123'}] satisfies PokeEndMessage,
     ]);
@@ -400,7 +393,6 @@ describe('view-syncer/client-handler', () => {
       'ws1',
       SHARD,
       '120',
-      PROTOCOL_VERSION,
       schemaVersion,
       subscription,
     );
@@ -463,7 +455,6 @@ describe('view-syncer/client-handler', () => {
         'ws1',
         SHARD,
         '121',
-        PROTOCOL_VERSION,
         schemaVersion,
         downstream,
       );

--- a/packages/zero-cache/src/services/view-syncer/cvr-store.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.pg-test.ts
@@ -395,7 +395,7 @@ describe('view-syncer/cvr-store', () => {
       );
     }
     await updater.received(lc, rows);
-    cvr = (await updater.flush(lc, true, CONNECT_TIME, now)).cvr;
+    cvr = (await updater.flush(lc, CONNECT_TIME, now)).cvr;
 
     expect(await db`SELECT * FROM "roze_1/cvr".instances`)
       .toMatchInlineSnapshot(`
@@ -450,7 +450,7 @@ describe('view-syncer/cvr-store', () => {
       );
     }
     await updater.received(lc, rows);
-    await updater.flush(lc, true, CONNECT_TIME, now);
+    await updater.flush(lc, CONNECT_TIME, now);
 
     expect(await db`SELECT * FROM "roze_1/cvr".instances`)
       .toMatchInlineSnapshot(`
@@ -534,7 +534,7 @@ describe('view-syncer/cvr-store', () => {
         );
       }
       await updater.received(lc, rows);
-      cvr = (await updater.flush(lc, true, CONNECT_TIME, now)).cvr;
+      cvr = (await updater.flush(lc, CONNECT_TIME, now)).cvr;
 
       // add a random sleep for varying the asynchronicity
       // between the CVR flush and the async row flush.
@@ -607,7 +607,7 @@ describe('view-syncer/cvr-store', () => {
         );
       }
       await updater.received(lc, rows);
-      cvr = (await updater.flush(lc, true, CONNECT_TIME, now)).cvr;
+      cvr = (await updater.flush(lc, CONNECT_TIME, now)).cvr;
 
       // add a random sleep for varying the asynchronicity
       // between the CVR flush and the async row flush.
@@ -628,7 +628,7 @@ describe('view-syncer/cvr-store', () => {
     // Empty rows.
     const rows = new CustomKeyMap<RowID, RowUpdate>(rowIDString);
     await updater.received(lc, rows);
-    await updater.flush(lc, true, CONNECT_TIME, now);
+    await updater.flush(lc, CONNECT_TIME, now);
 
     expect(await db`SELECT * FROM "roze_1/cvr".instances`)
       .toMatchInlineSnapshot(`
@@ -691,7 +691,7 @@ describe('view-syncer/cvr-store', () => {
       );
     }
     await updater.received(lc, rows);
-    cvr = (await updater.flush(lc, true, CONNECT_TIME, now)).cvr;
+    cvr = (await updater.flush(lc, CONNECT_TIME, now)).cvr;
 
     expect(await db`SELECT * FROM "roze_1/cvr".instances`)
       .toMatchInlineSnapshot(`

--- a/packages/zero-cache/src/services/view-syncer/cvr-store.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.ts
@@ -652,7 +652,6 @@ export class CVRStore {
   async #flush(
     expectedCurrentVersion: CVRVersion,
     newVersion: CVRVersion,
-    skipNoopFlushes: boolean,
     lastConnectTime: number,
     lastActive: number,
   ): Promise<CVRFlushStats | null> {
@@ -686,11 +685,7 @@ export class CVRStore {
         }
       }
     }
-    if (
-      skipNoopFlushes &&
-      this.#pendingRowRecordUpdates.size === 0 &&
-      this.#writes.size === 0
-    ) {
+    if (this.#pendingRowRecordUpdates.size === 0 && this.#writes.size === 0) {
       return null;
     }
     this.#setLastActive(lastActive);
@@ -757,7 +752,6 @@ export class CVRStore {
   async flush(
     expectedCurrentVersion: CVRVersion,
     newVersion: CVRVersion,
-    skipNoopFlushes: boolean,
     lastConnectTime: number,
     lastActive: number,
   ): Promise<CVRFlushStats | null> {
@@ -765,7 +759,6 @@ export class CVRStore {
       return await this.#flush(
         expectedCurrentVersion,
         newVersion,
-        skipNoopFlushes,
         lastConnectTime,
         lastActive,
       );

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -124,7 +124,6 @@ export class CVRUpdater {
 
   async flush(
     lc: LogContext,
-    skipNoopFlushes: boolean,
     lastConnectTime: number,
     lastActive = Date.now(),
   ): Promise<{
@@ -136,7 +135,6 @@ export class CVRUpdater {
     const flushed = await this._cvrStore.flush(
       this._orig.version,
       this._cvr.version,
-      skipNoopFlushes,
       lastConnectTime,
       lastActive,
     );
@@ -428,14 +426,9 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
     this._cvrStore.deleteClientGroup(clientGroupID);
   }
 
-  flush(
-    lc: LogContext,
-    skipNoopFlushes: boolean,
-    lastConnectTime: number,
-    lastActive = Date.now(),
-  ) {
+  flush(lc: LogContext, lastConnectTime: number, lastActive = Date.now()) {
     // TODO: Add cleanup of no-longer-desired got queries and constituent rows.
-    return super.flush(lc, skipNoopFlushes, lastConnectTime, lastActive);
+    return super.flush(lc, lastConnectTime, lastActive);
   }
 }
 

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -7,6 +7,7 @@ import {
   test,
   vi,
 } from 'vitest';
+import {testLogConfig} from '../../../../otel/src/test-log-config.ts';
 import {h128} from '../../../../shared/src/hash.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {Queue} from '../../../../shared/src/queue.ts';
@@ -72,7 +73,6 @@ import {PipelineDriver} from './pipeline-driver.ts';
 import {initViewSyncerSchema} from './schema/init.ts';
 import {Snapshotter} from './snapshotter.ts';
 import {pickToken, type SyncContext, ViewSyncerService} from './view-syncer.ts';
-import {testLogConfig} from '../../../../otel/src/test-log-config.ts';
 
 const APP_ID = 'this_app';
 const SHARD_NUM = 2;
@@ -765,7 +765,6 @@ describe('view-syncer/service', () => {
           "pokeStart",
           {
             "baseCookie": null,
-            "cookie": "00:01",
             "pokeID": "00:01",
           },
         ],
@@ -826,7 +825,6 @@ describe('view-syncer/service', () => {
           "pokeStart",
           {
             "baseCookie": "00:01",
-            "cookie": "01",
             "pokeID": "01",
             "schemaVersions": {
               "maxSupportedVersion": 3,
@@ -1412,7 +1410,6 @@ describe('view-syncer/service', () => {
           "pokeStart",
           {
             "baseCookie": null,
-            "cookie": "00:01",
             "pokeID": "00:01",
           },
         ],
@@ -1516,7 +1513,6 @@ describe('view-syncer/service', () => {
           "pokeStart",
           {
             "baseCookie": "00:01",
-            "cookie": "01",
             "pokeID": "01",
             "schemaVersions": {
               "maxSupportedVersion": 3,
@@ -1791,7 +1787,6 @@ describe('view-syncer/service', () => {
           "pokeStart",
           {
             "baseCookie": null,
-            "cookie": "00:01",
             "pokeID": "00:01",
           },
         ],
@@ -1869,7 +1864,6 @@ describe('view-syncer/service', () => {
           "pokeStart",
           {
             "baseCookie": null,
-            "cookie": "00:01",
             "pokeID": "00:01",
           },
         ],
@@ -1972,7 +1966,6 @@ describe('view-syncer/service', () => {
           "pokeStart",
           {
             "baseCookie": null,
-            "cookie": "00:01",
             "pokeID": "00:01",
           },
         ],
@@ -2045,7 +2038,6 @@ describe('view-syncer/service', () => {
         "pokeStart",
         {
           "baseCookie": "00:01",
-          "cookie": "01",
           "pokeID": "01",
           "schemaVersions": {
             "maxSupportedVersion": 3,
@@ -2086,7 +2078,6 @@ describe('view-syncer/service', () => {
           "pokeStart",
           {
             "baseCookie": "01",
-            "cookie": "123",
             "pokeID": "123",
             "schemaVersions": {
               "maxSupportedVersion": 3,
@@ -2228,7 +2219,6 @@ describe('view-syncer/service', () => {
           "pokeStart",
           {
             "baseCookie": "123",
-            "cookie": "124",
             "pokeID": "124",
             "schemaVersions": {
               "maxSupportedVersion": 3,
@@ -2368,7 +2358,6 @@ describe('view-syncer/service', () => {
           "pokeStart",
           {
             "baseCookie": null,
-            "cookie": "00:01",
             "pokeID": "00:01",
           },
         ],
@@ -2435,7 +2424,6 @@ describe('view-syncer/service', () => {
           "pokeStart",
           {
             "baseCookie": "00:01",
-            "cookie": "00:02",
             "pokeID": "00:02",
           },
         ],
@@ -2495,7 +2483,6 @@ describe('view-syncer/service', () => {
         "pokeStart",
         {
           "baseCookie": "00:02",
-          "cookie": "01",
           "pokeID": "01",
           "schemaVersions": {
             "maxSupportedVersion": 3,
@@ -2509,7 +2496,6 @@ describe('view-syncer/service', () => {
         "pokeStart",
         {
           "baseCookie": null,
-          "cookie": "01",
           "pokeID": "01",
           "schemaVersions": {
             "maxSupportedVersion": 3,
@@ -2555,7 +2541,6 @@ describe('view-syncer/service', () => {
           "pokeStart",
           {
             "baseCookie": "01",
-            "cookie": "123",
             "pokeID": "123",
             "schemaVersions": {
               "maxSupportedVersion": 3,
@@ -2611,7 +2596,6 @@ describe('view-syncer/service', () => {
           "pokeStart",
           {
             "baseCookie": null,
-            "cookie": "00:01",
             "pokeID": "00:01",
           },
         ],
@@ -2670,7 +2654,6 @@ describe('view-syncer/service', () => {
       'pokeStart',
       {
         baseCookie: '00:01',
-        cookie: '01',
         pokeID: '01',
         schemaVersions: {minSupportedVersion: 2, maxSupportedVersion: 3},
       },
@@ -2690,7 +2673,6 @@ describe('view-syncer/service', () => {
           "pokeStart",
           {
             "baseCookie": "01",
-            "cookie": "07",
             "pokeID": "07",
             "schemaVersions": {
               "maxSupportedVersion": 3,
@@ -2779,7 +2761,6 @@ describe('view-syncer/service', () => {
           "pokeStart",
           {
             "baseCookie": null,
-            "cookie": "00:01",
             "pokeID": "00:01",
           },
         ],
@@ -2838,7 +2819,6 @@ describe('view-syncer/service', () => {
       'pokeStart',
       {
         baseCookie: '00:01',
-        cookie: '01',
         pokeID: '01',
         schemaVersions: {minSupportedVersion: 2, maxSupportedVersion: 3},
       },
@@ -2865,7 +2845,6 @@ describe('view-syncer/service', () => {
           "pokeStart",
           {
             "baseCookie": null,
-            "cookie": "00:01",
             "pokeID": "00:01",
           },
         ],
@@ -2886,7 +2865,6 @@ describe('view-syncer/service', () => {
           "pokeStart",
           {
             "baseCookie": "00:01",
-            "cookie": "01",
             "pokeID": "01",
             "schemaVersions": {
               "maxSupportedVersion": 3,
@@ -2930,7 +2908,6 @@ describe('view-syncer/service', () => {
           "pokeStart",
           {
             "baseCookie": "01",
-            "cookie": "02",
             "pokeID": "02",
             "schemaVersions": {
               "maxSupportedVersion": 3,
@@ -2968,7 +2945,6 @@ describe('view-syncer/service', () => {
           "pokeStart",
           {
             "baseCookie": null,
-            "cookie": "00:01",
             "pokeID": "00:01",
           },
         ],
@@ -3093,7 +3069,6 @@ describe('view-syncer/service', () => {
           "pokeStart",
           {
             "baseCookie": "01",
-            "cookie": "123:01",
             "pokeID": "123:01",
             "schemaVersions": {
               "maxSupportedVersion": 3,
@@ -3180,7 +3155,6 @@ describe('view-syncer/service', () => {
           "pokeStart",
           {
             "baseCookie": "123",
-            "cookie": "123:01",
             "pokeID": "123:01",
           },
         ],
@@ -3245,7 +3219,6 @@ describe('view-syncer/service', () => {
     const preAdvancement = (await nextPoke(client1))[0][1] as PokeStartBody;
     expect(preAdvancement).toEqual({
       baseCookie: '00:01',
-      cookie: '01',
       pokeID: '01',
       schemaVersions: {minSupportedVersion: 2, maxSupportedVersion: 3},
     });
@@ -3277,7 +3250,6 @@ describe('view-syncer/service', () => {
           "pokeStart",
           {
             "baseCookie": null,
-            "cookie": "123:01",
             "pokeID": "123:01",
             "schemaVersions": {
               "maxSupportedVersion": 3,
@@ -3464,7 +3436,7 @@ describe('view-syncer/service', () => {
       await cvrStore.load(lc, Date.now()),
       '07',
       REPLICA_VERSION,
-    ).flush(lc, true, Date.now(), Date.now());
+    ).flush(lc, Date.now(), Date.now());
 
     // Connect the client.
     const client = connect(SYNC_CONTEXT, [
@@ -3505,7 +3477,6 @@ describe('view-syncer/service', () => {
           "pokeStart",
           {
             "baseCookie": null,
-            "cookie": "07:02",
             "pokeID": "07:02",
             "schemaVersions": {
               "maxSupportedVersion": 3,
@@ -3627,7 +3598,7 @@ describe('view-syncer/service', () => {
       await cvrStore.load(lc, Date.now()),
       '07',
       '1' + REPLICA_VERSION, // CVR is at a newer replica version.
-    ).flush(lc, true, Date.now(), Date.now());
+    ).flush(lc, Date.now(), Date.now());
 
     // Connect the client.
     const client = connect(SYNC_CONTEXT, [
@@ -3683,7 +3654,7 @@ describe('view-syncer/service', () => {
       await cvrStore.load(lc, Date.now()),
       '07',
       REPLICA_VERSION,
-    ).flush(lc, true, Date.now(), Date.now());
+    ).flush(lc, Date.now(), Date.now());
 
     // Connect the client with a base cookie from the future.
     const client = connect({...SYNC_CONTEXT, baseCookie: '08'}, [
@@ -3773,7 +3744,6 @@ describe('view-syncer/service', () => {
           "pokeStart",
           {
             "baseCookie": "01",
-            "cookie": "123",
             "pokeID": "123",
             "schemaVersions": {
               "maxSupportedVersion": 3,
@@ -6594,7 +6564,6 @@ describe('view-syncer/service', () => {
             "pokeStart",
             {
               "baseCookie": null,
-              "cookie": "00:01",
               "pokeID": "00:01",
             },
           ],
@@ -6894,7 +6863,6 @@ describe('view-syncer/service', () => {
             "pokeStart",
             {
               "baseCookie": "01",
-              "cookie": "123:04",
               "pokeID": "123:04",
               "schemaVersions": {
                 "maxSupportedVersion": 3,
@@ -7057,7 +7025,6 @@ describe('view-syncer/service', () => {
             "pokeStart",
             {
               "baseCookie": "123:02",
-              "cookie": "123:03",
               "pokeID": "123:03",
             },
           ],
@@ -7157,7 +7124,6 @@ describe('permissions', () => {
           "pokeStart",
           {
             "baseCookie": "00:01",
-            "cookie": "01",
             "pokeID": "01",
             "schemaVersions": {
               "maxSupportedVersion": 3,
@@ -7236,7 +7202,6 @@ describe('permissions', () => {
           "pokeStart",
           {
             "baseCookie": null,
-            "cookie": "01:02",
             "pokeID": "01:02",
             "schemaVersions": {
               "maxSupportedVersion": 3,
@@ -7425,7 +7390,6 @@ describe('permissions', () => {
           "pokeStart",
           {
             "baseCookie": "00:01",
-            "cookie": "01",
             "pokeID": "01",
             "schemaVersions": {
               "maxSupportedVersion": 3,
@@ -7522,7 +7486,6 @@ describe('permissions', () => {
           "pokeStart",
           {
             "baseCookie": "01",
-            "cookie": "05",
             "pokeID": "05",
             "schemaVersions": {
               "maxSupportedVersion": 3,
@@ -7610,7 +7573,6 @@ describe('permissions', () => {
           "pokeStart",
           {
             "baseCookie": "00:01",
-            "cookie": "01",
             "pokeID": "01",
             "schemaVersions": {
               "maxSupportedVersion": 3,
@@ -7675,7 +7637,6 @@ describe('permissions', () => {
           "pokeStart",
           {
             "baseCookie": "00:01",
-            "cookie": "01",
             "pokeID": "01",
             "schemaVersions": {
               "maxSupportedVersion": 3,

--- a/packages/zero-client/src/client/zero-poke-handler.test.ts
+++ b/packages/zero-client/src/client/zero-poke-handler.test.ts
@@ -794,7 +794,6 @@ suite('onPokeErrors', () => {
         pokeHandler.handlePokeStart({
           pokeID: 'poke1',
           baseCookie: '1',
-          cookie: '2',
           schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
         });
         pokeHandler.handlePokePart({pokeID: 'poke2'});
@@ -806,7 +805,6 @@ suite('onPokeErrors', () => {
         pokeHandler.handlePokeStart({
           pokeID: 'poke1',
           baseCookie: '1',
-          cookie: '2',
           schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
         });
         pokeHandler.handlePokeEnd({pokeID: 'poke2', cookie: '2'});
@@ -1145,7 +1143,6 @@ test('handlePoke returns the last mutation id change for this client from pokePa
   pokeHandler.handlePokeStart({
     pokeID: 'poke1',
     baseCookie: '1',
-    cookie: '2',
     schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
   });
   const lastMutationIDChangeForSelf0 = pokeHandler.handlePokePart({

--- a/packages/zero-protocol/src/poke.ts
+++ b/packages/zero-protocol/src/poke.ts
@@ -34,8 +34,6 @@ export const pokeStartBodySchema = v.object({
   // with initial cookie `null`, before the first request. So we have to be
   // able to send a base cookie with value `null` to match that state.
   baseCookie: nullableVersionSchema,
-  // Deprecated: Replaced by pokeEnd.cookie.
-  cookie: versionSchema.optional(),
   /**
    * This field is always set if the poke contains a `rowsPatch`.
    * It may be absent for patches that only update clients and queries.

--- a/packages/zero-protocol/src/protocol-version.test.ts
+++ b/packages/zero-protocol/src/protocol-version.test.ts
@@ -11,6 +11,6 @@ test('protocol version', () => {
   // If this test fails upstream or downstream schema has changed such that
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
-  expect(hash).toEqual('lyr40rg4ou26');
+  expect(hash).toEqual('18730x547v0tw');
   expect(PROTOCOL_VERSION).toEqual(7);
 });

--- a/packages/zero-protocol/src/protocol-version.ts
+++ b/packages/zero-protocol/src/protocol-version.ts
@@ -13,9 +13,9 @@ import {assert} from '../../shared/src/asserts.ts';
  * running the new code.
  */
 // History:
-// -- Version 5 adds support for `pokeEnd.cookie`.
-// -- Version 6 makes `pokeStart.cookie` optional.
-// -- Version 7 introduces the initConnection.clientSchema field.
+// -- Version 5 adds support for `pokeEnd.cookie`. (0.14)
+// -- Version 6 makes `pokeStart.cookie` optional. (0.16)
+// -- Version 7 introduces the initConnection.clientSchema field. (0.17)
 export const PROTOCOL_VERSION = 7;
 
 /**
@@ -28,16 +28,6 @@ export const PROTOCOL_VERSION = 7;
  * from protocol versions before `MIN_SERVER_SUPPORTED_PROTOCOL_VERSION` are
  * closed with a `VersionNotSupported` error.
  */
-export const MIN_SERVER_SUPPORTED_SYNC_PROTOCOL = 2;
+export const MIN_SERVER_SUPPORTED_SYNC_PROTOCOL = 6;
 
 assert(MIN_SERVER_SUPPORTED_SYNC_PROTOCOL < PROTOCOL_VERSION);
-
-/**
- * The minimum server-supported upstream permissions protocol version
- * (i.e. the `protocolVersion` stored with the compiled permissions JSON).
- * This should correspond to the last time the AST definition was
- * changed in a backwards-incompatible way.
- */
-export const MIN_SERVER_SUPPORTED_PERMISSIONS_PROTOCOL = 4;
-
-assert(MIN_SERVER_SUPPORTED_PERMISSIONS_PROTOCOL < PROTOCOL_VERSION);


### PR DESCRIPTION
Bumps to minimum supported `/sync/v.../connect` wire protocol version to `v6`, released in zero v0.16, which made the `pokeStart.cookie` optional and in favor of `pokeEnd.cookie`. (#3832)

With that minimum supported version, the `cookie` field can be removed from the `PokeStart` message and the server no longer sends it.

The logic which skips empty flushes (to avoid quadratic writes) is now also unconditional, since clients started supporting that protocol from v5. (#3735)