### PR TITLE
chore: Only run relevant tests

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -59,7 +59,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: rocicorp
@@ -73,4 +73,10 @@ jobs:
       - run: npm ci
       - name: Install Playwright
         run: npx playwright install --with-deps
-      - run: npm run test
+      - name: Run tests
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            npm run test -- --changed origin/main
+          else
+            npm run test
+          fi

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "download-deps": "bash ./deps/download.sh",
     "build": "turbo run build",
     "dev": "turbo run dev",
-    "test": "turbo run --concurrency 1 test",
+    "test": "vitest run",
     "lint": "turbo run lint",
     "format": "turbo run format",
     "check-format": "turbo run check-format",

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,0 +1,3 @@
+import {defineWorkspace} from 'vitest/config';
+
+export default defineWorkspace(['packages/*', 'apps/*', 'tools/*']);


### PR DESCRIPTION
This changes how we run the JS tests on the CI.

We are no longer using turbo for this. Instead we use vitest workspaces.

Also, we use `--changed origin/main` to only run tests for the files that have changed.