### PR TITLE
chore(zqlite,z2s): map to/from server names in z2s

### DIFF
--- a/packages/z2s/src/compiler.ts
+++ b/packages/z2s/src/compiler.ts
@@ -12,9 +12,13 @@ import {
   type CorrelatedSubquery,
   type SimpleCondition,
 } from '../../zero-protocol/src/ast.ts';
+import {clientToServer, NameMapper} from '../../zero-schema/src/name-mapper.ts';
+import type {TableSchema} from '../../zero-schema/src/table-schema.ts';
 import type {Format} from '../../zql/src/ivm/view.ts';
 import {sql} from './sql.ts';
 import type {SQLQuery} from '@databases/sql';
+
+type Tables = Record<string, TableSchema>;
 
 /**
  * Compiles to the Postgres dialect of SQL
@@ -23,277 +27,344 @@ import type {SQLQuery} from '@databases/sql';
  * - IN is changed to ANY to allow binding array literals
  * - subqueries are aggregated using PG's `array_agg` and `row_to_json` functions
  */
-export function compile(ast: AST, format?: Format | undefined) {
-  return select(ast, format, undefined);
+export function compile(ast: AST, tables: Tables, format?: Format | undefined) {
+  const compiler = new Compiler(tables);
+  return compiler.compile(ast, format);
 }
 
-export function select(
-  ast: AST,
-  format: Format | undefined,
-  correlation: SQLQuery | undefined,
-) {
-  const selectionSet = related(ast.related ?? [], format, ast.table);
-  selectionSet.push(sql`*`);
-  return sql`SELECT ${sql.join(selectionSet, ',')} FROM ${sql.ident(
-    ast.table,
-  )} ${ast.where ? sql`WHERE ${where(ast.where, ast.table)}` : sql``} ${
-    correlation
-      ? sql`${ast.where ? sql`AND` : sql`WHERE`} (${correlation})`
-      : sql``
-  } ${orderBy(ast.orderBy)} ${format?.singular ? limit(1) : limit(ast.limit)}`;
-}
+export class Compiler {
+  readonly #tables: Tables;
+  readonly #nameMapper: NameMapper;
 
-export function orderBy(orderBy: Ordering | undefined): SQLQuery {
-  if (!orderBy) {
-    return sql``;
+  constructor(tables: Tables) {
+    this.#tables = tables;
+    this.#nameMapper = clientToServer(tables);
   }
-  return sql`ORDER BY ${sql.join(
-    orderBy.map(([col, dir]) =>
-      dir === 'asc' ? sql`${sql.ident(col)} ASC` : sql`${sql.ident(col)} DESC`,
-    ),
-    ', ',
-  )}`;
-}
 
-export function limit(limit: number | undefined): SQLQuery {
-  if (!limit) {
-    return sql``;
+  compile(ast: AST, format?: Format | undefined) {
+    return this.select(ast, format, undefined);
   }
-  return sql`LIMIT ${sql.value(limit)}`;
-}
 
-export function related(
-  relationships: readonly CorrelatedSubquery[],
-  format: Format | undefined,
-  parentTable: string,
-): SQLQuery[] {
-  return relationships.map(relationship =>
-    relationshipSubquery(
-      relationship,
-      format?.relationships[must(relationship.subquery.alias)],
-      parentTable,
-    ),
-  );
-}
+  select(
+    ast: AST,
+    format: Format | undefined,
+    correlation: SQLQuery | undefined,
+  ) {
+    const selectionSet = this.related(ast.related ?? [], format, ast.table);
+    const table = this.#tables[ast.table];
+    for (const column of Object.keys(table.columns)) {
+      selectionSet.push(this.#mapColumn(ast.table, column));
+    }
+    return sql`SELECT ${sql.join(selectionSet, ',')} FROM ${this.#mapTable(
+      ast.table,
+    )} ${ast.where ? sql`WHERE ${this.where(ast.where, ast.table)}` : sql``} ${
+      correlation
+        ? sql`${ast.where ? sql`AND` : sql`WHERE`} (${correlation})`
+        : sql``
+    } ${this.orderBy(ast.orderBy)} ${
+      format?.singular ? this.limit(1) : this.limit(ast.limit)
+    }`;
+  }
 
-function relationshipSubquery(
-  relationship: CorrelatedSubquery,
-  format: Format | undefined,
-  parentTable: string,
-) {
-  if (relationship.hidden) {
-    const [join, lastAlias, lastLimit] = makeJunctionJoin(relationship);
+  orderBy(orderBy: Ordering | undefined): SQLQuery {
+    if (!orderBy) {
+      return sql``;
+    }
+    return sql`ORDER BY ${sql.join(
+      orderBy.map(([col, dir]) =>
+        dir === 'asc'
+          ? sql`${sql.ident(col)} ASC`
+          : sql`${sql.ident(col)} DESC`,
+      ),
+      ', ',
+    )}`;
+  }
+
+  limit(limit: number | undefined): SQLQuery {
+    if (!limit) {
+      return sql``;
+    }
+    return sql`LIMIT ${sql.value(limit)}`;
+  }
+
+  related(
+    relationships: readonly CorrelatedSubquery[],
+    format: Format | undefined,
+    parentTable: string,
+  ): SQLQuery[] {
+    return relationships.map(relationship =>
+      this.relationshipSubquery(
+        relationship,
+        format?.relationships[must(relationship.subquery.alias)],
+        parentTable,
+      ),
+    );
+  }
+
+  relationshipSubquery(
+    relationship: CorrelatedSubquery,
+    format: Format | undefined,
+    parentTable: string,
+  ) {
+    if (relationship.hidden) {
+      const [join, lastAlias, lastLimit] = this.makeJunctionJoin(relationship);
+      return sql`(
+        SELECT ${
+          format?.singular ? sql`` : sql`COALESCE(array_agg`
+        }(row_to_json(${sql.ident(`inner_${relationship.subquery.alias}`)})) ${
+          format?.singular ? sql`` : sql`, ARRAY[]::json[])`
+        } FROM (SELECT ${sql.ident(
+          lastAlias,
+        )}.* FROM ${join} WHERE (${this.correlate(
+          parentTable,
+          parentTable,
+          relationship.correlation.parentField,
+          relationship.subquery.table,
+          relationship.subquery.table,
+          relationship.correlation.childField,
+        )}) ${
+          relationship.subquery.where
+            ? sql`AND ${this.where(
+                relationship.subquery.where,
+                relationship.subquery.table,
+              )}`
+            : sql``
+        } ${this.orderBy(relationship.subquery.orderBy)} ${
+          format?.singular ? this.limit(1) : this.limit(lastLimit)
+        } ) ${sql.ident(`inner_${relationship.subquery.alias}`)}
+      ) as ${sql.ident(relationship.subquery.alias)}`;
+    }
     return sql`(
       SELECT ${
         format?.singular ? sql`` : sql`COALESCE(array_agg`
       }(row_to_json(${sql.ident(`inner_${relationship.subquery.alias}`)})) ${
         format?.singular ? sql`` : sql`, ARRAY[]::json[])`
-      } FROM (SELECT ${sql.ident(lastAlias)}.* FROM ${join} WHERE (${correlate(
-        parentTable,
-        relationship.correlation.parentField,
-        relationship.subquery.table,
-        relationship.correlation.childField,
-      )}) ${
-        relationship.subquery.where
-          ? sql`AND ${where(
-              relationship.subquery.where,
-              relationship.subquery.table,
-            )}`
-          : sql``
-      } ${orderBy(relationship.subquery.orderBy)} ${
-        format?.singular ? limit(1) : limit(lastLimit)
-      } ) ${sql.ident(`inner_${relationship.subquery.alias}`)}
+      } FROM (${this.select(
+        relationship.subquery,
+        format,
+        this.correlate(
+          parentTable,
+          parentTable,
+          relationship.correlation.parentField,
+          relationship.subquery.table,
+          relationship.subquery.table,
+          relationship.correlation.childField,
+        ),
+      )}) ${sql.ident(`inner_${relationship.subquery.alias}`)}
     ) as ${sql.ident(relationship.subquery.alias)}`;
   }
-  return sql`(
-    SELECT ${
-      format?.singular ? sql`` : sql`COALESCE(array_agg`
-    }(row_to_json(${sql.ident(`inner_${relationship.subquery.alias}`)})) ${
-      format?.singular ? sql`` : sql`, ARRAY[]::json[])`
-    } FROM (${select(
-      relationship.subquery,
-      format,
-      correlate(
-        parentTable,
-        relationship.correlation.parentField,
-        relationship.subquery.table,
-        relationship.correlation.childField,
+
+  pullTablesForJunction(
+    relationship: CorrelatedSubquery,
+    tables: [string, Correlation, number | undefined][] = [],
+  ) {
+    tables.push([
+      relationship.subquery.table,
+      relationship.correlation,
+      relationship.subquery.limit,
+    ]);
+    assert(
+      relationship.subquery.related?.length || 0 <= 1,
+      'Too many related tables for a junction edge',
+    );
+    for (const subRelationship of relationship.subquery.related ?? []) {
+      this.pullTablesForJunction(subRelationship, tables);
+    }
+    return tables;
+  }
+
+  makeJunctionJoin(
+    relationship: CorrelatedSubquery,
+  ): [join: SQLQuery, lastAlis: string, lastLimit: number | undefined] {
+    const participatingTables = this.pullTablesForJunction(relationship);
+    const ret: SQLQuery[] = [];
+
+    function alias(index: number) {
+      if (index === 0) {
+        return participatingTables[0][0];
+      }
+      return `table_${index}`;
+    }
+
+    for (const [table, _correlation] of participatingTables) {
+      if (ret.length === 0) {
+        ret.push(this.#mapTable(table));
+        continue;
+      }
+      ret.push(
+        sql` JOIN ${this.#mapTableNoAlias(table)} as ${sql.ident(
+          alias(ret.length),
+        )} ON ${this.correlate(
+          participatingTables[ret.length - 1][0],
+          alias(ret.length - 1),
+          participatingTables[ret.length][1].parentField,
+          participatingTables[ret.length][0],
+          alias(ret.length),
+          participatingTables[ret.length][1].childField,
+        )}`,
+      );
+    }
+
+    return [
+      sql.join(ret, ''),
+      alias(ret.length - 1),
+      participatingTables[participatingTables.length - 1][2],
+    ] as const;
+  }
+
+  where(condition: Condition | undefined, table: string): SQLQuery {
+    if (!condition) {
+      return sql``;
+    }
+
+    switch (condition.type) {
+      case 'and':
+        return sql`(${sql.join(
+          condition.conditions.map(c => this.where(c, table)),
+          ' AND ',
+        )})`;
+      case 'or':
+        return sql`(${sql.join(
+          condition.conditions.map(c => this.where(c, table)),
+          ' OR ',
+        )})`;
+      case 'correlatedSubquery':
+        return this.exists(condition, table);
+      case 'simple':
+        return this.simple(condition, table);
+    }
+  }
+
+  simple(condition: SimpleCondition, table: string): SQLQuery {
+    switch (condition.op) {
+      case '!=':
+      case '<':
+      case '<=':
+      case '=':
+      case '>':
+      case '>=':
+      case 'ILIKE':
+      case 'LIKE':
+      case 'NOT ILIKE':
+      case 'NOT LIKE':
+        return sql`${this.valuePosition(
+          condition.left,
+          table,
+        )} ${sql.__dangerous__rawValue(condition.op)} ${this.valuePosition(
+          condition.right,
+          table,
+        )}`;
+      case 'NOT IN':
+      case 'IN':
+        return this.any(condition, table);
+      case 'IS':
+      case 'IS NOT':
+        return this.distinctFrom(condition, table);
+    }
+  }
+
+  distinctFrom(condition: SimpleCondition, table: string): SQLQuery {
+    return sql`${this.valuePosition(condition.left, table)} ${
+      condition.op === 'IS' ? sql`IS NOT DISTINCT FROM` : sql`IS DISTINCT FROM`
+    } ${this.valuePosition(condition.right, table)}`;
+  }
+
+  any(condition: SimpleCondition, table: string): SQLQuery {
+    return sql`${this.valuePosition(condition.left, table)} ${
+      condition.op === 'IN' ? sql`= ANY` : sql`!= ANY`
+    } (${this.valuePosition(condition.right, table)})`;
+  }
+
+  valuePosition(value: ValuePosition, table: string): SQLQuery {
+    switch (value.type) {
+      case 'column':
+        return this.#mapColumnNoAlias(table, value.name);
+      case 'literal':
+        return sql.value(value.value);
+      case 'static':
+        throw new Error(
+          'Static parameters must be bound to a value before compiling to SQL',
+        );
+    }
+  }
+
+  exists(
+    condition: CorrelatedSubqueryCondition,
+    parentTable: string,
+  ): SQLQuery {
+    switch (condition.op) {
+      case 'EXISTS':
+        return sql`EXISTS (${this.select(
+          condition.related.subquery,
+          undefined,
+          this.correlate(
+            parentTable,
+            parentTable,
+            condition.related.correlation.parentField,
+            condition.related.subquery.table,
+            condition.related.subquery.table,
+            condition.related.correlation.childField,
+          ),
+        )})`;
+      case 'NOT EXISTS':
+        return sql`NOT EXISTS (${this.select(
+          condition.related.subquery,
+          undefined,
+          undefined,
+        )})`;
+    }
+  }
+
+  correlate(
+    parentTable: string,
+    parentTableAlias: string,
+    parentColumns: readonly string[],
+    childTable: string,
+    childTableAlias: string,
+    childColumns: readonly string[],
+  ) {
+    return sql.join(
+      zip(parentColumns, childColumns).map(
+        ([parentColumn, childColumn]) =>
+          sql`${sql.ident(parentTableAlias)}.${this.#mapColumnNoAlias(
+            parentTable,
+            parentColumn,
+          )} = ${sql.ident(childTableAlias)}.${this.#mapColumnNoAlias(
+            childTable,
+            childColumn,
+          )}`,
       ),
-    )}) ${sql.ident(`inner_${relationship.subquery.alias}`)}
-  ) as ${sql.ident(relationship.subquery.alias)}`;
-}
-
-export function pullTablesForJunction(
-  relationship: CorrelatedSubquery,
-  tables: [string, Correlation, number | undefined][] = [],
-) {
-  tables.push([
-    relationship.subquery.table,
-    relationship.correlation,
-    relationship.subquery.limit,
-  ]);
-  assert(
-    relationship.subquery.related?.length || 0 <= 1,
-    'Too many related tables for a junction edge',
-  );
-  for (const subRelationship of relationship.subquery.related ?? []) {
-    pullTablesForJunction(subRelationship, tables);
-  }
-  return tables;
-}
-
-export function makeJunctionJoin(
-  relationship: CorrelatedSubquery,
-): [join: SQLQuery, lastAlis: string, lastLimit: number | undefined] {
-  const participatingTables = pullTablesForJunction(relationship);
-  const ret: SQLQuery[] = [];
-
-  function alias(index: number) {
-    if (index === 0) {
-      return participatingTables[0][0];
-    }
-    return `table_${index}`;
-  }
-
-  for (const [table, _correlation] of participatingTables) {
-    if (ret.length === 0) {
-      ret.push(sql.ident(table));
-      continue;
-    }
-    ret.push(
-      sql` JOIN ${sql.ident(table)} as ${sql.ident(
-        alias(ret.length),
-      )} ON ${correlate(
-        alias(ret.length - 1),
-        participatingTables[ret.length][1].parentField,
-        alias(ret.length),
-        participatingTables[ret.length][1].childField,
-      )}`,
+      ' AND ',
     );
   }
 
-  return [
-    sql.join(ret, ''),
-    alias(ret.length - 1),
-    participatingTables[participatingTables.length - 1][2],
-  ] as const;
-}
+  #mapColumn(table: string, column: string) {
+    const mapped = this.#nameMapper.columnName(table, column);
+    if (mapped === column) {
+      return sql.ident(column);
+    }
 
-export function where(
-  condition: Condition | undefined,
-  parentTable: string,
-): SQLQuery {
-  if (!condition) {
-    return sql``;
+    return sql`${sql.ident(mapped)} as ${sql.ident(column)}`;
   }
 
-  switch (condition.type) {
-    case 'and':
-      return sql`(${sql.join(
-        condition.conditions.map(c => where(c, parentTable)),
-        ' AND ',
-      )})`;
-    case 'or':
-      return sql`(${sql.join(
-        condition.conditions.map(c => where(c, parentTable)),
-        ' OR ',
-      )})`;
-    case 'correlatedSubquery':
-      return exists(condition, parentTable);
-    case 'simple':
-      return simple(condition);
+  #mapColumnNoAlias(table: string, column: string) {
+    const mapped = this.#nameMapper.columnName(table, column);
+    return sql.ident(mapped);
   }
-}
 
-export function simple(condition: SimpleCondition): SQLQuery {
-  switch (condition.op) {
-    case '!=':
-    case '<':
-    case '<=':
-    case '=':
-    case '>':
-    case '>=':
-    case 'ILIKE':
-    case 'LIKE':
-    case 'NOT ILIKE':
-    case 'NOT LIKE':
-      return sql`${valuePosition(condition.left)} ${sql.__dangerous__rawValue(
-        condition.op,
-      )} ${valuePosition(condition.right)}`;
-    case 'NOT IN':
-    case 'IN':
-      return any(condition);
-    case 'IS':
-    case 'IS NOT':
-      return distinctFrom(condition);
+  #mapTable(table: string) {
+    const mapped = this.#nameMapper.tableName(table);
+    if (mapped === table) {
+      return sql.ident(table);
+    }
+
+    return sql`${sql.ident(mapped)} as ${sql.ident(table)}`;
   }
-}
 
-export function distinctFrom(condition: SimpleCondition): SQLQuery {
-  return sql`${valuePosition(condition.left)} ${
-    condition.op === 'IS' ? sql`IS NOT DISTINCT FROM` : sql`IS DISTINCT FROM`
-  } ${valuePosition(condition.right)}`;
-}
-
-export function any(condition: SimpleCondition): SQLQuery {
-  return sql`${valuePosition(condition.left)} ${
-    condition.op === 'IN' ? sql`= ANY` : sql`!= ANY`
-  } (${valuePosition(condition.right)})`;
-}
-
-export function valuePosition(value: ValuePosition): SQLQuery {
-  switch (value.type) {
-    case 'column':
-      return sql.ident(value.name);
-    case 'literal':
-      return sql.value(value.value);
-    case 'static':
-      throw new Error(
-        'Static parameters must be bound to a value before compiling to SQL',
-      );
+  #mapTableNoAlias(table: string) {
+    const mapped = this.#nameMapper.tableName(table);
+    return sql.ident(mapped);
   }
-}
-
-export function exists(
-  condition: CorrelatedSubqueryCondition,
-  parentTable: string,
-): SQLQuery {
-  switch (condition.op) {
-    case 'EXISTS':
-      return sql`EXISTS (${select(
-        condition.related.subquery,
-        undefined,
-        correlate(
-          parentTable,
-          condition.related.correlation.parentField,
-          condition.related.subquery.table,
-          condition.related.correlation.childField,
-        ),
-      )})`;
-    case 'NOT EXISTS':
-      return sql`NOT EXISTS (${select(
-        condition.related.subquery,
-        undefined,
-        undefined,
-      )})`;
-  }
-}
-
-export function correlate(
-  parentTable: string,
-  parentColumns: readonly string[],
-  childTable: string,
-  childColumns: readonly string[],
-) {
-  return sql.join(
-    zip(parentColumns, childColumns).map(
-      ([parentColumn, childColumn]) =>
-        sql`${sql.ident(parentTable)}.${sql.ident(parentColumn)} = ${sql.ident(
-          childTable,
-        )}.${sql.ident(childColumn)}`,
-    ),
-    ' AND ',
-  );
 }
 
 function zip<T>(a1: readonly T[], a2: readonly T[]): [T, T][] {

--- a/packages/z2s/src/test/chinook/chinook.output.test.ts
+++ b/packages/z2s/src/test/chinook/chinook.output.test.ts
@@ -13,14 +13,14 @@ test('limited junction edge', () => {
   const q = staticQuery(schema, 'playlist').related('tracks', q => q.limit(10));
   expect(getSQL(q)).toMatchInlineSnapshot(`
     "SELECT (
-          SELECT COALESCE(array_agg(row_to_json("inner_tracks")) , ARRAY[]::json[]) FROM (SELECT "table_1".* FROM "playlist_track" JOIN "track" as "table_1" ON "playlist_track"."track_id" = "table_1"."track_id" WHERE ("playlist"."playlist_id" = "playlist_track"."playlist_id")  ORDER BY "playlist_id" ASC, "track_id" ASC LIMIT $1 ) "inner_tracks"
-        ) as "tracks",* FROM "playlist"   ORDER BY "playlist_id" ASC"
+            SELECT COALESCE(array_agg(row_to_json("inner_tracks")) , ARRAY[]::json[]) FROM (SELECT "table_1".* FROM "playlist_track" JOIN "track" as "table_1" ON "playlist_track"."track_id" = "table_1"."track_id" WHERE ("playlist"."playlist_id" = "playlist_track"."playlist_id")  ORDER BY "playlist_id" ASC, "track_id" ASC LIMIT $1 ) "inner_tracks"
+          ) as "tracks","playlist_id","name" FROM "playlist"   ORDER BY "playlist_id" ASC"
   `);
 });
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function getSQL(q: Query<any, any, any>) {
-  return formatPg(compile(ast(q), format(q))).text;
+  return formatPg(compile(ast(q), schema.tables, format(q))).text;
 }
 
 function ast(q: Query<Schema, keyof Schema['tables']>) {

--- a/packages/zero-cache/bench/benchmark.ts
+++ b/packages/zero-cache/bench/benchmark.ts
@@ -3,6 +3,7 @@
 import {testLogConfig} from '../../otel/src/test-log-config.ts';
 import {assert} from '../../shared/src/asserts.ts';
 import {createSilentLogContext} from '../../shared/src/logging-test-utils.ts';
+import type {AST} from '../../zero-protocol/src/ast.ts';
 import {MemoryStorage} from '../../zql/src/ivm/memory-storage.ts';
 import type {Input} from '../../zql/src/ivm/operator.ts';
 import type {Source} from '../../zql/src/ivm/source.ts';
@@ -25,6 +26,9 @@ export function bench(opts: Options) {
   const sources = new Map<string, Source>();
   const tableSpecs = computeZqlSpecs(lc, db);
   const host: QueryDelegate = {
+    mapAst(ast: AST): AST {
+      return ast;
+    },
     getSource: (name: string) => {
       let source = sources.get(name);
       if (source) {

--- a/packages/zero-cache/src/auth/read-authorizer.query.test.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.query.test.ts
@@ -486,6 +486,10 @@ beforeEach(() => {
 
   const sources = new Map<string, Source>();
   queryDelegate = {
+    mapAst(ast) {
+      return ast;
+    },
+
     getSource: (name: string) => {
       let source = sources.get(name);
       if (source) {

--- a/packages/zero-cache/src/auth/write-authorizer.ts
+++ b/packages/zero-cache/src/auth/write-authorizer.ts
@@ -101,6 +101,7 @@ export class WriteAuthorizerImpl implements WriteAuthorizer {
       getSource: name => this.#getSource(name),
       createStorage: () => cgStorage.createStorage(),
       decorateInput: input => input,
+      mapAst: ast => ast,
     };
     this.#tableSpecs = computeZqlSpecs(this.#lc, replica);
     this.#statementRunner = new StatementRunner(replica);

--- a/packages/zero-cache/src/scripts/run-query.ts
+++ b/packages/zero-cache/src/scripts/run-query.ts
@@ -54,6 +54,9 @@ const db = new Database(lc, config.replicaFile);
 const schema = getSchema(lc, db);
 const sources = new Map<string, TableSource>();
 const host: QueryDelegate = {
+  mapAst(ast: AST): AST {
+    return ast;
+  },
   getSource: (name: string) => {
     let source = sources.get(name);
     if (source) {

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -252,6 +252,7 @@ export class PipelineDriver {
       getSource: name => this.#getSource(name),
       createStorage: () => this.#createStorage(),
       decorateInput: input => input,
+      mapAst: ast => ast,
     });
     const schema = input.getSchema();
     input.setOutput({

--- a/packages/zero-client/src/client/context.ts
+++ b/packages/zero-client/src/client/context.ts
@@ -88,6 +88,10 @@ export class ZeroContext implements QueryDelegate {
     }
   }
 
+  mapAst(ast: AST): AST {
+    return ast;
+  }
+
   createStorage(): Storage {
     return new MemoryStorage();
   }

--- a/packages/zero-pg/src/query.ts
+++ b/packages/zero-pg/src/query.ts
@@ -47,6 +47,7 @@ export class Z2SQuery<
   TReturn = PullRow<TTable, TSchema>,
 > extends AbstractQuery<TSchema, TTable, TReturn> {
   readonly #dbTransaction: DBTransaction<unknown>;
+  readonly #schema: TSchema;
   #query:
     | {
         text: string;
@@ -63,6 +64,7 @@ export class Z2SQuery<
   ) {
     super(schema, tableName, ast, format);
     this.#dbTransaction = dbTransaction;
+    this.#schema = schema;
   }
 
   protected readonly _system = 'permissions';
@@ -82,7 +84,8 @@ export class Z2SQuery<
 
   async run(): Promise<HumanReadable<TReturn>> {
     const sqlQuery =
-      this.#query ?? formatPg(compile(this._completeAst(), this.format));
+      this.#query ??
+      formatPg(compile(this._completeAst(), this.#schema.tables, this.format));
     this.#query = sqlQuery;
     const result = await this.#dbTransaction.query(
       sqlQuery.text,

--- a/packages/zql/src/builder/builder.ts
+++ b/packages/zql/src/builder/builder.ts
@@ -53,6 +53,14 @@ export interface BuilderDelegate {
   createStorage(name: string): Storage;
 
   decorateInput(input: Input, name: string): Input;
+
+  /**
+   * The AST is mapped on-the-wire between client and server names.
+   *
+   * There is no "wire" for zqlite tests so this function is provided
+   * to allow tests to remap the AST.
+   */
+  mapAst(ast: AST): AST;
 }
 
 /**
@@ -80,7 +88,7 @@ export interface BuilderDelegate {
  * ```
  */
 export function buildPipeline(ast: AST, delegate: BuilderDelegate): Input {
-  return buildPipelineInternal(ast, delegate, '');
+  return buildPipelineInternal(delegate.mapAst(ast), delegate, '');
 }
 
 export function bindStaticParameters(

--- a/packages/zql/src/builder/test-builder-delegate.ts
+++ b/packages/zql/src/builder/test-builder-delegate.ts
@@ -1,5 +1,6 @@
 import {assert} from '../../../shared/src/asserts.ts';
 import type {JSONObject} from '../../../shared/src/json.ts';
+import type {AST} from '../../../zero-protocol/src/ast.ts';
 import {MemoryStorage} from '../ivm/memory-storage.ts';
 import type {Storage, Input} from '../ivm/operator.ts';
 import {Snitch, type SnitchMessage} from '../ivm/snitch.ts';
@@ -26,6 +27,10 @@ export class TestBuilderDelegate implements BuilderDelegate {
       `Missing source ${tableName}`,
     );
     return this.#sources[tableName];
+  }
+
+  mapAst(ast: AST): AST {
+    return ast;
   }
 
   createStorage(name: string): Storage {

--- a/packages/zql/src/query/test/query-delegate.ts
+++ b/packages/zql/src/query/test/query-delegate.ts
@@ -47,6 +47,10 @@ export class QueryDelegateImpl implements QueryDelegate {
     };
   }
 
+  mapAst(ast: AST): AST {
+    return ast;
+  }
+
   onQueryMaterialized() {}
 
   commit() {

--- a/packages/zql/src/query/test/test-schemas.ts
+++ b/packages/zql/src/query/test/test-schemas.ts
@@ -172,24 +172,24 @@ export type Revision = Row<typeof revisionSchema>;
 export type User = Row<typeof userSchema>;
 
 export const createTableSQL = /*sql*/ `
-CREATE TABLE IF NOT EXISTS "issue" (
+CREATE TABLE IF NOT EXISTS "issues" (
   "id" TEXT PRIMARY KEY,
   "title" TEXT NOT NULL,
   "description" TEXT NOT NULL,
   "closed" BOOLEAN NOT NULL,
-  "ownerId" TEXT
+  "owner_id" TEXT
 );
 
-CREATE TABLE IF NOT EXISTS "user" (
+CREATE TABLE IF NOT EXISTS "users" (
   "id" TEXT PRIMARY KEY,
   "name" TEXT NOT NULL,
   "metadata" JSONB
 );
 
-CREATE TABLE IF NOT EXISTS "comment" (
+CREATE TABLE IF NOT EXISTS "comments" (
   "id" TEXT PRIMARY KEY,
   "authorId" TEXT NOT NULL,
-  "issueId" TEXT NOT NULL,
+  "issue_id" TEXT NOT NULL,
   "text" TEXT NOT NULL,
   "createdAt" BIGINT NOT NULL
 );

--- a/packages/zqlite/src/query.test.ts
+++ b/packages/zqlite/src/query.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import {beforeEach, expect, expectTypeOf, test} from 'vitest';
 import {createSilentLogContext} from '../../shared/src/logging-test-utils.ts';
 import {must} from '../../shared/src/must.ts';
@@ -49,7 +50,7 @@ beforeEach(() => {
       title: 'issue 1',
       description: 'description 1',
       closed: false,
-      ownerId: '0001',
+      owner_id: '0001',
     },
   });
   issueSource.push({
@@ -59,7 +60,7 @@ beforeEach(() => {
       title: 'issue 2',
       description: 'description 2',
       closed: false,
-      ownerId: '0002',
+      owner_id: '0002',
     },
   });
   issueSource.push({
@@ -69,7 +70,7 @@ beforeEach(() => {
       title: 'issue 3',
       description: 'description 3',
       closed: false,
-      ownerId: null,
+      owner_id: null,
     },
   });
 
@@ -266,7 +267,7 @@ test('schema applied `one`', async () => {
     row: {
       id: '0001',
       authorId: '0001',
-      issueId: '0001',
+      issue_id: '0001',
       text: 'comment 1',
       createdAt: 1,
     },
@@ -276,7 +277,7 @@ test('schema applied `one`', async () => {
     row: {
       id: '0002',
       authorId: '0002',
-      issueId: '0001',
+      issue_id: '0001',
       text: 'comment 2',
       createdAt: 2,
     },

--- a/packages/zqlite/src/test/source-factory.ts
+++ b/packages/zqlite/src/test/source-factory.ts
@@ -13,6 +13,7 @@ import {Database} from '../db.ts';
 import {compile, sql} from '../internal/sql.ts';
 import {TableSource, toSQLiteTypeName} from '../table-source.ts';
 import {clientToServer} from '../../../zero-schema/src/name-mapper.ts';
+import {mapAST, type AST} from '../../../zero-protocol/src/ast.ts';
 
 export const createSource: SourceFactory = (
   lc: LogContext,
@@ -96,6 +97,10 @@ export function newQueryDelegate(
 
       sources.set(serverTableName, source);
       return source;
+    },
+
+    mapAst(ast: AST): AST {
+      return mapAST(ast, mapper);
     },
 
     createStorage() {


### PR DESCRIPTION
z2s needs to understand how to map to/from server names as `pg` will be using server names for its columns and tables. `z2s.compile` now takes the schema as a parameter so it can map names as it builds queries.

The `z2s` test suite is an integration test that:

1. Creates a PG DB
2. Uses `initialSync` to create a replica

Due to (2), that replica will be using server names so this PR also adds support for server names in zqlite tests. This more faithfully reproduces our production setup.