### PR TITLE
chore(zero-protocol): bump protocol to v8 to safely drop support for v5

### DIFF
--- a/packages/zero-protocol/src/ast.test.ts
+++ b/packages/zero-protocol/src/ast.test.ts
@@ -607,5 +607,5 @@ test('protocol version', () => {
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
   expect(hash).toEqual('2zzy9s2lcdcms');
-  expect(PROTOCOL_VERSION).toEqual(7);
+  expect(PROTOCOL_VERSION).toEqual(8);
 });

--- a/packages/zero-protocol/src/protocol-version.test.ts
+++ b/packages/zero-protocol/src/protocol-version.test.ts
@@ -12,5 +12,5 @@ test('protocol version', () => {
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
   expect(hash).toEqual('18730x547v0tw');
-  expect(PROTOCOL_VERSION).toEqual(7);
+  expect(PROTOCOL_VERSION).toEqual(8);
 });

--- a/packages/zero-protocol/src/protocol-version.ts
+++ b/packages/zero-protocol/src/protocol-version.ts
@@ -16,7 +16,8 @@ import {assert} from '../../shared/src/asserts.ts';
 // -- Version 5 adds support for `pokeEnd.cookie`. (0.14)
 // -- Version 6 makes `pokeStart.cookie` optional. (0.16)
 // -- Version 7 introduces the initConnection.clientSchema field. (0.17)
-export const PROTOCOL_VERSION = 7;
+// -- Version 8 drops support for Version 5 (0.18).
+export const PROTOCOL_VERSION = 8;
 
 /**
  * The minimum server-supported sync protocol version (i.e. the version


### PR DESCRIPTION
This should have been together with #4005