### PR TITLE
chore(z2s): more alias fixes

### DIFF
--- a/packages/z2s/src/compiler.output.test.ts
+++ b/packages/z2s/src/compiler.output.test.ts
@@ -87,7 +87,7 @@ test('limit', () => {
 
 test('orderBy', () => {
   const compiler = new Compiler(schema.tables);
-  expect(formatPg(compiler.orderBy([]))).toMatchInlineSnapshot(`
+  expect(formatPg(compiler.orderBy([], 'user'))).toMatchInlineSnapshot(`
     {
       "text": "ORDER BY",
       "values": [],
@@ -95,32 +95,38 @@ test('orderBy', () => {
   `);
   expect(
     formatPg(
-      compiler.orderBy([
-        ['name', 'asc'],
-        ['age', 'desc'],
-      ]),
+      compiler.orderBy(
+        [
+          ['name', 'asc'],
+          ['age', 'desc'],
+        ],
+        'user',
+      ),
     ),
   ).toMatchInlineSnapshot(`
     {
-      "text": "ORDER BY "name" ASC, "age" DESC",
+      "text": "ORDER BY "user"."name" ASC, "user"."age" DESC",
       "values": [],
     }
   `);
   expect(
     formatPg(
-      compiler.orderBy([
-        ['name', 'asc'],
-        ['age', 'desc'],
-        ['id', 'asc'],
-      ]),
+      compiler.orderBy(
+        [
+          ['name', 'asc'],
+          ['age', 'desc'],
+          ['id', 'asc'],
+        ],
+        'user',
+      ),
     ),
   ).toMatchInlineSnapshot(`
     {
-      "text": "ORDER BY "name" ASC, "age" DESC, "id" ASC",
+      "text": "ORDER BY "user"."name" ASC, "user"."age" DESC, "user"."id" ASC",
       "values": [],
     }
   `);
-  expect(formatPg(compiler.orderBy(undefined))).toMatchInlineSnapshot(`
+  expect(formatPg(compiler.orderBy(undefined, 'user'))).toMatchInlineSnapshot(`
     {
       "text": "",
       "values": [],
@@ -763,8 +769,8 @@ test('related thru junction edge', () => {
   ).toMatchInlineSnapshot(`
     {
       "text": "SELECT (
-            SELECT COALESCE(array_agg(row_to_json("inner_labels")) , ARRAY[]::json[]) FROM (SELECT "table_1".* FROM "issue_label" as "issueLabel" JOIN "label" as "table_1" ON "issueLabel"."label_id" = "table_1"."id" WHERE ("issue"."id" = "issueLabel"."issue_id")    ) "inner_labels"
-          ) as "labels","id","title","description","closed","ownerId" FROM "issue"",
+            SELECT COALESCE(array_agg(row_to_json("inner_labels")) , ARRAY[]::json[]) FROM (SELECT "table_1"."id","table_1"."name" FROM "issue_label" as "issueLabel" JOIN "label" as "table_1" ON "issueLabel"."label_id" = "table_1"."id" WHERE ("issue"."id" = "issueLabel"."issue_id")    ) "inner_labels"
+          ) as "labels","issue"."id","issue"."title","issue"."description","issue"."closed","issue"."ownerId" FROM "issue"",
       "values": [],
     }
   `);
@@ -793,8 +799,8 @@ test('related w/o junction edge', () => {
   ).toMatchInlineSnapshot(`
     {
       "text": "SELECT (
-          SELECT COALESCE(array_agg(row_to_json("inner_owner")) , ARRAY[]::json[]) FROM (SELECT "id","name","age" FROM "user"  WHERE ("issue"."ownerId" = "user"."id")  ) "inner_owner"
-        ) as "owner","id","title","description","closed","ownerId" FROM "issue"",
+          SELECT COALESCE(array_agg(row_to_json("inner_owner")) , ARRAY[]::json[]) FROM (SELECT "user"."id","user"."name","user"."age" FROM "user"  WHERE ("issue"."ownerId" = "user"."id")  ) "inner_owner"
+        ) as "owner","issue"."id","issue"."title","issue"."description","issue"."closed","issue"."ownerId" FROM "issue"",
       "values": [],
     }
   `);

--- a/packages/z2s/src/compiler.pg-test.ts
+++ b/packages/z2s/src/compiler.pg-test.ts
@@ -1,4 +1,4 @@
-import './test/nullish.ts';
+import './test/comparePg.ts';
 import {beforeAll} from 'vitest';
 import {getConnectionURI, testDBs} from '../../zero-cache/src/test/db.ts';
 import type {PostgresDB} from '../../zero-cache/src/types/pg.ts';
@@ -279,7 +279,7 @@ describe('compiling ZQL to SQL', () => {
     );
     expect(
       mapResultToClientNames(await query.run(), schema, 'issue'),
-    ).toEqualNullish(pgResult);
+    ).toEqualPg(pgResult);
   });
 
   test('1 to many foreign key relationship', async () => {
@@ -293,7 +293,7 @@ describe('compiling ZQL to SQL', () => {
     );
     expect(
       mapResultToClientNames(await query.run(), schema, 'issue'),
-    ).toEqualNullish(pgResult);
+    ).toEqualPg(pgResult);
   });
 
   test('junction relationship', async () => {
@@ -307,7 +307,7 @@ describe('compiling ZQL to SQL', () => {
     );
     expect(
       mapResultToClientNames(await query.run(), schema, 'issue'),
-    ).toEqualNullish(pgResult);
+    ).toEqualPg(pgResult);
   });
 
   test('nested related with where clauses', async () => {

--- a/packages/z2s/src/test/chinook/chinook.output.test.ts
+++ b/packages/z2s/src/test/chinook/chinook.output.test.ts
@@ -13,12 +13,12 @@ test('limited junction edge', () => {
   const q = staticQuery(schema, 'playlist').related('tracks', q => q.limit(10));
   expect(getSQL(q)).toMatchInlineSnapshot(`
     "SELECT (
-            SELECT COALESCE(array_agg(row_to_json("inner_tracks")) , ARRAY[]::json[]) FROM (SELECT "table_1".* FROM "playlist_track" JOIN "track" as "table_1" ON "playlist_track"."track_id" = "table_1"."track_id" WHERE ("playlist"."playlist_id" = "playlist_track"."playlist_id")  ORDER BY "playlist_id" ASC, "track_id" ASC LIMIT $1 ) "inner_tracks"
-          ) as "tracks","playlist_id","name" FROM "playlist"   ORDER BY "playlist_id" ASC"
+            SELECT COALESCE(array_agg(row_to_json("inner_tracks")) , ARRAY[]::json[]) FROM (SELECT "table_1"."track_id" as "id","table_1"."name","table_1"."album_id" as "albumId","table_1"."media_type_id" as "mediaTypeId","table_1"."genre_id" as "genreId","table_1"."composer","table_1"."milliseconds","table_1"."bytes","table_1"."unit_price" as "unitPrice" FROM "playlist_track" as "playlistTrack" JOIN "track" as "table_1" ON "playlistTrack"."track_id" = "table_1"."track_id" WHERE ("playlist"."playlist_id" = "playlistTrack"."playlist_id")  ORDER BY "playlistTrack"."playlist_id" ASC, "playlistTrack"."track_id" ASC LIMIT $1 ) "inner_tracks"
+          ) as "tracks","playlist"."playlist_id" as "id","playlist"."name" FROM "playlist"   ORDER BY "playlist"."playlist_id" ASC"
   `);
 });
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-explicit-any
 function getSQL(q: Query<any, any, any>) {
   return formatPg(compile(ast(q), schema.tables, format(q))).text;
 }

--- a/packages/z2s/src/test/chinook/schema.ts
+++ b/packages/z2s/src/test/chinook/schema.ts
@@ -11,191 +11,194 @@ import {
 // Table definitions
 const album = table('album')
   .columns({
-    album_id: number(),
+    id: number().from('album_id'),
     title: string(),
-    artist_id: number(),
+    artistId: number().from('artist_id'),
   })
-  .primaryKey('album_id');
+  .primaryKey('id');
 
 const artist = table('artist')
   .columns({
-    artist_id: number(),
+    id: number().from('artist_id'),
     name: string().optional(),
   })
-  .primaryKey('artist_id');
+  .primaryKey('id');
 
 const customer = table('customer')
   .columns({
-    customer_id: number(),
-    first_name: string(),
-    last_name: string(),
+    id: number().from('customer_id'),
+    firstName: string().from('first_name'),
+    lastName: string().from('last_name'),
     company: string().optional(),
     address: string().optional(),
     city: string().optional(),
     state: string().optional(),
     country: string().optional(),
-    postal_code: string().optional(),
+    postalCode: string().optional().from('postal_code'),
     phone: string().optional(),
     fax: string().optional(),
     email: string(),
-    support_rep_id: number().optional(),
+    supportRepId: number().optional().from('support_rep_id'),
   })
-  .primaryKey('customer_id');
+  .primaryKey('id');
 
 const employee = table('employee')
   .columns({
-    employee_id: number(),
-    last_name: string(),
-    first_name: string(),
+    id: number().from('employee_id'),
+    lastName: string().from('last_name'),
+    firstName: string().from('first_name'),
     title: string().optional(),
-    reports_to: number().optional(),
-    birth_date: number().optional(), // TIMESTAMP as number
-    hire_date: number().optional(), // TIMESTAMP as number
+    reportsTo: number().optional().from('reports_to'),
+    birthDate: number().optional().from('birth_date'),
+    hireDate: number().optional().from('hire_date'),
     address: string().optional(),
     city: string().optional(),
     state: string().optional(),
     country: string().optional(),
-    postal_code: string().optional(),
+    postalCode: string().optional().from('postal_code'),
     phone: string().optional(),
     fax: string().optional(),
     email: string().optional(),
   })
-  .primaryKey('employee_id');
+  .primaryKey('id');
 
 const genre = table('genre')
   .columns({
-    genre_id: number(),
+    id: number().from('genre_id'),
     name: string().optional(),
   })
-  .primaryKey('genre_id');
+  .primaryKey('id');
 
 const invoice = table('invoice')
   .columns({
-    invoice_id: number(),
-    customer_id: number(),
-    invoice_date: number(), // TIMESTAMP as number
-    billing_address: string().optional(),
-    billing_city: string().optional(),
-    billing_state: string().optional(),
-    billing_country: string().optional(),
-    billing_postal_code: string().optional(),
+    id: number().from('invoice_id'),
+    customerId: number().from('customer_id'),
+    invoiceDate: number().from('invoice_date'),
+    billingAddress: string().optional().from('billing_address'),
+    billingCity: string().optional().from('billing_city'),
+    billingState: string().optional().from('billing_state'),
+    billingCountry: string().optional().from('billing_country'),
+    billingPostalCode: string().optional().from('billing_postal_code'),
     total: number(),
   })
-  .primaryKey('invoice_id');
+  .primaryKey('id');
 
-const invoice_line = table('invoice_line')
+const invoiceLine = table('invoiceLine')
+  .from('invoice_line')
   .columns({
-    invoice_line_id: number(),
-    invoice_id: number(),
-    track_id: number(),
-    unit_price: number(),
+    id: number().from('invoice_line_id'),
+    invoiceId: number().from('invoice_id'),
+    trackId: number().from('track_id'),
+    unitPrice: number().from('unit_price'),
     quantity: number(),
   })
-  .primaryKey('invoice_line_id');
+  .primaryKey('id');
 
-const media_type = table('media_type')
+const mediaType = table('mediaType')
+  .from('media_type')
   .columns({
-    media_type_id: number(),
+    id: number().from('media_type_id'),
     name: string().optional(),
   })
-  .primaryKey('media_type_id');
+  .primaryKey('id');
 
 const playlist = table('playlist')
   .columns({
-    playlist_id: number(),
+    id: number().from('playlist_id'),
     name: string().optional(),
   })
-  .primaryKey('playlist_id');
+  .primaryKey('id');
 
-const playlist_track = table('playlist_track')
+const playlistTrack = table('playlistTrack')
+  .from('playlist_track')
   .columns({
-    playlist_id: number(),
-    track_id: number(),
+    playlistId: number().from('playlist_id'),
+    trackId: number().from('track_id'),
   })
-  .primaryKey('playlist_id', 'track_id');
+  .primaryKey('playlistId', 'trackId');
 
 const track = table('track')
   .columns({
-    track_id: number(),
+    id: number().from('track_id'),
     name: string(),
-    album_id: number().optional(),
-    media_type_id: number(),
-    genre_id: number().optional(),
+    albumId: number().optional().from('album_id'),
+    mediaTypeId: number().from('media_type_id'),
+    genreId: number().optional().from('genre_id'),
     composer: string().optional(),
     milliseconds: number(),
     bytes: number().optional(),
-    unit_price: number(),
+    unitPrice: number().from('unit_price'),
   })
-  .primaryKey('track_id');
+  .primaryKey('id');
 
 // Relationships
 const albumRelationships = relationships(album, ({one, many}) => ({
   artist: one({
-    sourceField: ['artist_id'],
-    destField: ['artist_id'],
+    sourceField: ['artistId'],
+    destField: ['id'],
     destSchema: artist,
   }),
   tracks: many({
-    sourceField: ['album_id'],
-    destField: ['album_id'],
+    sourceField: ['id'],
+    destField: ['albumId'],
     destSchema: track,
   }),
 }));
 
 const customerRelationships = relationships(customer, ({one}) => ({
   supportRep: one({
-    sourceField: ['support_rep_id'],
-    destField: ['employee_id'],
+    sourceField: ['supportRepId'],
+    destField: ['id'],
     destSchema: employee,
   }),
 }));
 
 const employeeRelationships = relationships(employee, ({one}) => ({
   reportsTo: one({
-    sourceField: ['reports_to'],
-    destField: ['employee_id'],
+    sourceField: ['reportsTo'],
+    destField: ['id'],
     destSchema: employee,
   }),
 }));
 
 const invoiceRelationships = relationships(invoice, ({one, many}) => ({
   customer: one({
-    sourceField: ['customer_id'],
-    destField: ['customer_id'],
+    sourceField: ['customerId'],
+    destField: ['id'],
     destSchema: customer,
   }),
   lines: many({
-    sourceField: ['invoice_id'],
-    destField: ['invoice_id'],
-    destSchema: invoice_line,
+    sourceField: ['id'],
+    destField: ['invoiceId'],
+    destSchema: invoiceLine,
   }),
 }));
 
 const trackRelationships = relationships(track, ({one, many}) => ({
   album: one({
-    sourceField: ['album_id'],
-    destField: ['album_id'],
+    sourceField: ['albumId'],
+    destField: ['id'],
     destSchema: album,
   }),
   genre: one({
-    sourceField: ['genre_id'],
-    destField: ['genre_id'],
+    sourceField: ['genreId'],
+    destField: ['id'],
     destSchema: genre,
   }),
   mediaType: one({
-    sourceField: ['media_type_id'],
-    destField: ['media_type_id'],
-    destSchema: media_type,
+    sourceField: ['mediaTypeId'],
+    destField: ['id'],
+    destSchema: mediaType,
   }),
   playlists: many(
     {
-      sourceField: ['track_id'],
-      destField: ['track_id'],
-      destSchema: playlist_track,
+      sourceField: ['id'],
+      destField: ['trackId'],
+      destSchema: playlistTrack,
     },
     {
-      sourceField: ['playlist_id'],
-      destField: ['playlist_id'],
+      sourceField: ['playlistId'],
+      destField: ['id'],
       destSchema: playlist,
     },
   ),
@@ -204,13 +207,13 @@ const trackRelationships = relationships(track, ({one, many}) => ({
 const playlistRelationships = relationships(playlist, ({many}) => ({
   tracks: many(
     {
-      sourceField: ['playlist_id'],
-      destField: ['playlist_id'],
-      destSchema: playlist_track,
+      sourceField: ['id'],
+      destField: ['playlistId'],
+      destSchema: playlistTrack,
     },
     {
-      sourceField: ['track_id'],
-      destField: ['track_id'],
+      sourceField: ['trackId'],
+      destField: ['id'],
       destSchema: track,
     },
   ),
@@ -224,10 +227,10 @@ export const schema = createSchema({
     employee,
     genre,
     invoice,
-    invoice_line,
-    media_type,
+    invoiceLine,
+    mediaType,
     playlist,
-    playlist_track,
+    playlistTrack,
     track,
   ],
   relationships: [

--- a/packages/z2s/src/test/comparePg.ts
+++ b/packages/z2s/src/test/comparePg.ts
@@ -2,14 +2,17 @@
 import {expect} from 'vitest';
 
 /**
- * `one` relationships will be returned by postgres as `null` vs zql will return them as `undefined`.
+ * This matcher has the downside of covering up errors where `null` is expected but `undefined` is returned.
+ *
+ *  `one` relationships will be returned by postgres as `null` vs zql will return them as `undefined`.
+ *
+ * This also removes the `Symbol(rc)` fields from the `received` ZQL view as `PG` will not set them.
  *
  * Maybe we should change this in zql. Til then...
  *
- * This matcher has the downside of covering up errors where `null` is expected but `undefined` is returned.
  */
 expect.extend({
-  toEqualNullish(received: any, expected: any) {
+  toEqualPg(received: any, expected: any) {
     const normalize = (obj: any): any => {
       if (obj === null || obj === undefined) {
         return null;
@@ -48,6 +51,6 @@ expect.extend({
 // You'll need to extend the Vitest types
 declare module 'vitest' {
   interface Assertion {
-    toEqualNullish(expected: any): void;
+    toEqualPg(expected: any): void;
   }
 }

--- a/packages/zqlite/src/test/source-factory.ts
+++ b/packages/zqlite/src/test/source-factory.ts
@@ -16,7 +16,11 @@ import {
   clientToServer,
   serverToClient,
 } from '../../../zero-schema/src/name-mapper.ts';
-import {mapAST, type AST} from '../../../zero-protocol/src/ast.ts';
+import {
+  mapAST,
+  type AST,
+  type CompoundKey,
+} from '../../../zero-protocol/src/ast.ts';
 
 export const createSource: SourceFactory = (
   lc: LogContext,
@@ -144,7 +148,9 @@ export function newQueryDelegate(
             v,
           ]),
         ),
-        tableSchema.primaryKey,
+        tableSchema.primaryKey.map(k =>
+          clientToServerMapper.columnName(clientTableName, k),
+        ) as unknown as CompoundKey,
       );
 
       sources.set(serverTableName, source);


### PR DESCRIPTION
Updates `chinook/schema.ts` to use different names for server and client names are snaked-cased. E.g., `track_id` => `trackId`

Also uncovered some z2s errors since Postgres does not allow using a column alias in `order by`, `on` or `where`.

E.g., we must do:

```sql
SELECT track_id as id FROM track WHERE track.track_id = 1
```

Not:

```sql
SELECT track_id as id FROM track WHERE track.id = 1
```