### PR TITLE
chore: Use es2022 in all packages

### DIFF
--- a/apps/zbugs/src/components/filter.tsx
+++ b/apps/zbugs/src/components/filter.tsx
@@ -1,6 +1,7 @@
 import {useQuery} from '@rocicorp/zero/react';
 import classNames from 'classnames';
 import {memo, useMemo, useState} from 'react';
+import {toSorted} from '../../../../packages/shared/src/to-sorted.ts';
 import labelIcon from '../assets/icons/label.svg';
 import {useZero} from '../hooks/use-zero.ts';
 import {Button} from './button.tsx';
@@ -23,7 +24,7 @@ export const Filter = memo(function Filter({onSelect}: Props) {
   const [unsortedLabels] = useQuery(z.query.label);
   // TODO: Support case-insensitive sorting in ZQL.
   const labels = useMemo(
-    () => unsortedLabels.toSorted((a, b) => a.name.localeCompare(b.name)),
+    () => toSorted(unsortedLabels, (a, b) => a.name.localeCompare(b.name)),
     [unsortedLabels],
   );
 

--- a/apps/zbugs/src/components/user-picker.tsx
+++ b/apps/zbugs/src/components/user-picker.tsx
@@ -1,6 +1,7 @@
 import {type Row} from '@rocicorp/zero';
 import {useQuery} from '@rocicorp/zero/react';
 import {useEffect, useMemo, useState} from 'react';
+import {toSorted} from '../../../../packages/shared/src/to-sorted.ts';
 import {type Schema} from '../../schema.ts';
 import avatarIcon from '../assets/icons/avatar-default.svg';
 import {avatarURLWithSize} from '../avatar-url-with-size.ts';
@@ -48,7 +49,7 @@ export function UserPicker({
   const [unsortedUsers] = useQuery(q);
   // TODO: Support case-insensitive sorting in ZQL.
   const users = useMemo(
-    () => unsortedUsers.toSorted((a, b) => a.login.localeCompare(b.login)),
+    () => toSorted(unsortedUsers, (a, b) => a.login.localeCompare(b.login)),
     [unsortedUsers],
   );
 

--- a/apps/zbugs/src/pages/issue/issue-page.tsx
+++ b/apps/zbugs/src/pages/issue/issue-page.tsx
@@ -20,6 +20,7 @@ import {toast, ToastContainer} from 'react-toastify';
 import {assert} from 'shared/src/asserts.js';
 import {useParams} from 'wouter';
 import {navigate, useHistoryState} from 'wouter/use-browser-location';
+import {findLastIndex} from '../../../../../packages/shared/src/find-last-index.ts';
 import {must} from '../../../../../packages/shared/src/must.ts';
 import {difference} from '../../../../../packages/shared/src/set-utils.ts';
 import type {CommentRow, IssueRow, Schema, UserRow} from '../../../schema.ts';
@@ -51,12 +52,12 @@ import {
 } from '../../limits.ts';
 import {LRUCache} from '../../lru-cache.ts';
 import {recordPageLoad} from '../../page-load-stats.ts';
+import {CACHE_AWHILE} from '../../query-cache-policy.ts';
 import {links, type ListContext, type ZbugsHistoryState} from '../../routes.ts';
 import {preload} from '../../zero-setup.ts';
 import {CommentComposer} from './comment-composer.tsx';
 import {Comment} from './comment.tsx';
 import {isCtrlEnter} from './is-ctrl-enter.ts';
-import {CACHE_AWHILE} from '../../query-cache-policy.ts';
 
 const emojiToastShowDuration = 3_000;
 
@@ -1038,7 +1039,7 @@ function useShowToastForNewComment(
     }
 
     for (const commentID of newCommentIDs) {
-      const index = comments.findLastIndex(c => c.id === commentID);
+      const index = findLastIndex(comments, c => c.id === commentID);
       if (index === -1) {
         continue;
       }

--- a/apps/zbugs/tsconfig.json
+++ b/apps/zbugs/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "jsx": "react-jsx",
     "baseUrl": "../../packages",
     "paths": {

--- a/packages/replicache-perf/tsconfig.json
+++ b/packages/replicache-perf/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "lib": ["DOM", "ES2022"]
+  },
   "include": ["src/**/*.ts", "src/**/*.js"]
 }

--- a/packages/shared/src/find-last-index.test.ts
+++ b/packages/shared/src/find-last-index.test.ts
@@ -1,0 +1,66 @@
+import {expect, test} from 'vitest';
+import data from '../tsconfig.json' with {type: 'json'};
+import {findLastIndex} from './find-last-index.ts';
+
+function getESLibVersion(libs: string[]): number {
+  const esVersion = libs.find(lib => lib.toLowerCase().startsWith('es'));
+  if (!esVersion) {
+    throw new Error('Could not find ES lib version');
+  }
+  return parseInt(esVersion.slice(2), 10);
+}
+
+test('lib < ES2023', () => {
+  // findLastIndex was added in ES2023
+
+  // sanity check that we are using es2022. If this starts failing then we can
+  // remove the findLastIndex and use the builtin.
+  expect(getESLibVersion(data.compilerOptions.lib)).toBeLessThan(2023);
+});
+
+test('finds the last element that satisfies the predicate', () => {
+  const array = [1, 2, 3, 4, 5];
+  const index = findLastIndex(array, num => num % 2 === 0);
+  expect(index).toBe(3);
+});
+
+test('returns -1 when no element satisfies the predicate', () => {
+  const array = [1, 3, 5, 7, 9];
+  const index = findLastIndex(array, num => num % 2 === 0);
+  expect(index).toBe(-1);
+});
+
+test('returns -1 for an empty array', () => {
+  const array: number[] = [];
+  const index = findLastIndex(array, () => true);
+  expect(index).toBe(-1);
+});
+
+test('finds the last occurrence of a value', () => {
+  const array = [1, 3, 5, 3, 1];
+  const index = findLastIndex(array, num => num === 3);
+  expect(index).toBe(3);
+});
+
+test('works with objects', () => {
+  const array = [
+    {id: 1, active: true},
+    {id: 2, active: false},
+    {id: 3, active: true},
+    {id: 4, active: false},
+  ];
+  const index = findLastIndex(array, obj => obj.active);
+  expect(index).toBe(2);
+});
+
+test('provides correct index to predicate function', () => {
+  const array = ['a', 'b', 'c', 'd'];
+  const receivedIndices: number[] = [];
+
+  findLastIndex(array, (_, index) => {
+    receivedIndices.unshift(index);
+    return false;
+  });
+
+  expect(receivedIndices).toEqual([0, 1, 2, 3]);
+});

--- a/packages/shared/src/find-last-index.ts
+++ b/packages/shared/src/find-last-index.ts
@@ -1,0 +1,14 @@
+// findLastIndex was added in ES2023
+
+export function findLastIndex<T>(
+  array: readonly T[],
+  predicate: (value: T, index: number) => boolean,
+): number {
+  let index = array.length;
+  while (index--) {
+    if (predicate(array[index], index)) {
+      return index;
+    }
+  }
+  return -1;
+}

--- a/packages/shared/src/has-own.test.ts
+++ b/packages/shared/src/has-own.test.ts
@@ -1,0 +1,18 @@
+import {expect, test} from 'vitest';
+import data from '../tsconfig.json' with {type: 'json'};
+
+function getESLibVersion(libs: string[]): number {
+  const esVersion = libs.find(lib => lib.toLowerCase().startsWith('es'));
+  if (!esVersion) {
+    throw new Error('Could not find ES lib version');
+  }
+  return parseInt(esVersion.slice(2), 10);
+}
+
+test('lib >= ES2021', () => {
+  // sanity check that we are using es2021. If this starts failing then we need
+  // to add the polyfill back
+  expect(getESLibVersion(data.compilerOptions.lib)).toBeGreaterThanOrEqual(
+    2021,
+  );
+});

--- a/packages/shared/src/has-own.ts
+++ b/packages/shared/src/has-own.ts
@@ -1,9 +1,2 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-const objectPrototypeHasOwnProperty = Object.prototype.hasOwnProperty;
-
-/**
- * Object.hasOwn polyfill
- */
-export const hasOwn: (object: any, key: PropertyKey) => boolean =
-  (Object as any).hasOwn ||
-  ((object, key) => objectPrototypeHasOwnProperty.call(object, key));
+// hasOwn was added in ES2022
+export const {hasOwn} = Object;

--- a/packages/shared/src/to-sorted.test.ts
+++ b/packages/shared/src/to-sorted.test.ts
@@ -1,0 +1,85 @@
+import {expect, test} from 'vitest';
+import data from '../tsconfig.json' with {type: 'json'};
+import {toSorted} from './to-sorted.ts';
+
+function getESLibVersion(libs: string[]): number {
+  const esVersion = libs.find(lib => lib.toLowerCase().startsWith('es'));
+  if (!esVersion) {
+    throw new Error('Could not find ES lib version');
+  }
+  return parseInt(esVersion.slice(2), 10);
+}
+
+test('lib < ES2023', () => {
+  // toSorted was added in ES2023
+
+  // sanity check that we are using es2022. If this starts failing then we can
+  // remove the toSorted and use the builtin.
+  expect(getESLibVersion(data.compilerOptions.lib)).toBeLessThan(2023);
+});
+
+test('sorts an array of numbers in ascending order', () => {
+  const array = [3, 1, 4, 1, 5, 9];
+  const sorted = toSorted(array, (a, b) => a - b);
+  expect(sorted).toEqual([1, 1, 3, 4, 5, 9]);
+  // Original array should not be modified
+  expect(array).toEqual([3, 1, 4, 1, 5, 9]);
+});
+
+test('sorts an array of numbers in descending order', () => {
+  const array = [3, 1, 4, 1, 5, 9];
+  const sorted = toSorted(array, (a, b) => b - a);
+  expect(sorted).toEqual([9, 5, 4, 3, 1, 1]);
+  expect(array).toEqual([3, 1, 4, 1, 5, 9]);
+});
+
+test('sorts an array of strings alphabetically', () => {
+  const array = ['banana', 'apple', 'cherry', 'date'];
+  const sorted = toSorted(array, (a, b) => a.localeCompare(b));
+  expect(sorted).toEqual(['apple', 'banana', 'cherry', 'date']);
+  expect(array).toEqual(['banana', 'apple', 'cherry', 'date']);
+});
+
+test('handles empty array', () => {
+  const array: number[] = [];
+  const sorted = toSorted(array, (a, b) => a - b);
+  expect(sorted).toEqual([]);
+  expect(array).toEqual([]);
+});
+
+test('works with array of objects', () => {
+  const array = [
+    {name: 'John', age: 30},
+    {name: 'Alice', age: 25},
+    {name: 'Bob', age: 40},
+  ];
+  const sorted = toSorted(array, (a, b) => a.age - b.age);
+  expect(sorted).toEqual([
+    {name: 'Alice', age: 25},
+    {name: 'John', age: 30},
+    {name: 'Bob', age: 40},
+  ]);
+  expect(array).toEqual([
+    {name: 'John', age: 30},
+    {name: 'Alice', age: 25},
+    {name: 'Bob', age: 40},
+  ]);
+});
+
+test('returns a new array instance', () => {
+  const array = [3, 1, 4];
+  const sorted = toSorted(array, (a, b) => a - b);
+  expect(sorted).not.toBe(array);
+});
+
+test('compare is optional', () => {
+  const array = ['c', 'a', 'd'];
+  const sorted = toSorted(array);
+  expect(sorted).toEqual(['a', 'c', 'd']);
+});
+
+test('compare is optional and uses funky default compare', () => {
+  const array = [33, 2, 111];
+  const sorted = toSorted(array);
+  expect(sorted).toEqual([111, 2, 33]);
+});

--- a/packages/shared/src/to-sorted.ts
+++ b/packages/shared/src/to-sorted.ts
@@ -1,0 +1,4 @@
+// toSorted was added in ES2023
+export function toSorted<T>(arr: T[], compare?: (a: T, b: T) => number) {
+  return [...arr].sort(compare);
+}

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "lib": ["DOM", "ES2022"]
+  },
   "include": ["src/**/*.ts", "src/**/*.js"]
 }

--- a/packages/zero-advanced/tsconfig.json
+++ b/packages/zero-advanced/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "lib": ["DOM", "ES2022"]
+  },
   "include": ["src"]
 }

--- a/packages/zero-react/tsconfig.json
+++ b/packages/zero-react/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "lib": ["DOM", "ES2022"],
     "jsx": "react-jsx"
   },
   "include": ["src"]

--- a/packages/zero-solid/tsconfig.json
+++ b/packages/zero-solid/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "lib": ["DOM", "ES2022"]
+  },
   "include": ["src"]
 }

--- a/tools/client-simulator/src/main.ts
+++ b/tools/client-simulator/src/main.ts
@@ -7,7 +7,7 @@ import * as v from '../../../packages/shared/src/valita.ts';
 import {initConnectionMessageSchema} from '../../../packages/zero-protocol/src/connect.ts';
 import {downstreamSchema} from '../../../packages/zero-protocol/src/down.ts';
 import {PROTOCOL_VERSION} from '../../../packages/zero-protocol/src/protocol-version.ts';
-import initConnectionJSON from './init-connection.json';
+import initConnectionJSON from './init-connection.json' with {type: 'json'};
 
 const options = {
   viewSyncers: {type: v.array(v.string())},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,13 @@
 {
   "compilerOptions": {
     "target": "es2022",
-    "module": "Node16",
+    "lib": ["ES2022"],
+    "module": "NodeNext",
     "verbatimModuleSyntax": true,
     "allowImportingTsExtensions": true,
     "rewriteRelativeImportExtensions": true,
     "esModuleInterop": true,
-    "moduleResolution": "Node16",
+    "moduleResolution": "NodeNext",
     "moduleDetection": "force",
     "strict": true,
     "exactOptionalPropertyTypes": true,

--- a/turbo.json
+++ b/turbo.json
@@ -36,9 +36,12 @@
       "outputs": [],
       "inputs": [
         "$TURBO_DEFAULT$",
+        "../zero-advanced/src/**/*.ts",
+        "../zero-cache/src/**/*.ts",
         "../zero-client/src/**/*.ts",
         "../zero-react/src/**/*.ts",
-        "../zero-cache/src/**/*.ts"
+        "../zero-schema/src/**/*.ts",
+        "../zero-solid/src/**/*.ts"
       ]
     }
   }


### PR DESCRIPTION
This changes zbugs to compile to es2022, and updates all packages to use
 es2022 lib. The latter is so that we do not end up using builtins that
 are not supported in es2022.