### PR TITLE
feat(zbugs): swap to custom mutators

### DIFF
--- a/apps/zbugs/api/push.ts
+++ b/apps/zbugs/api/push.ts
@@ -6,7 +6,8 @@ import {
   type Row,
 } from '@rocicorp/zero/pg';
 import postgres, {type JSONValue} from 'postgres';
-import {schema} from '../schema.ts';
+import {schema} from '../shared/schema.ts';
+import {createMutators} from '../shared/mutators.ts';
 
 class Connection implements DBConnection<postgres.TransactionSql> {
   readonly #pg: postgres.Sql;
@@ -40,6 +41,6 @@ const mutatorSql = postgres(process.env.ZERO_UPSTREAM_DB as string);
 
 export const pushHandler: PushHandler = createPushHandler({
   dbConnectionProvider: () => new Connection(mutatorSql),
-  mutators: {},
+  mutators: createMutators(process.env.VITE_PUBLIC_JWK as string),
   schema,
 });

--- a/apps/zbugs/api/tsconfig.json
+++ b/apps/zbugs/api/tsconfig.json
@@ -7,5 +7,5 @@
     },
     "declaration": true
   },
-  "include": [".", "../schema.ts"]
+  "include": [".", "../shared/*"]
 }

--- a/apps/zbugs/shared/mutators.ts
+++ b/apps/zbugs/shared/mutators.ts
@@ -1,0 +1,235 @@
+import {schema} from './schema.ts';
+import {must} from '../../../packages/shared/src/must.ts';
+import {assert} from '../../../packages/shared/src/asserts.ts';
+import type {UpdateValue, Transaction, CustomMutatorDefs} from '@rocicorp/zero';
+import type {JWK} from 'jose';
+import {Validators} from './validators.ts';
+
+type AddEmojiArgs = {
+  id: string;
+  unicode: string;
+  annotation: string;
+  subjectID: string;
+  creatorID: string;
+  created: number;
+};
+
+type CreateIssueArgs = {
+  id: string;
+  title: string;
+  description?: string;
+  created: number;
+  modified: number;
+};
+
+type AddCommentArgs = {
+  id: string;
+  issueID: string;
+  body: string;
+  created: number;
+};
+
+export function createMutators(publicJwk: string) {
+  // This `?? {}` is a workaround as the Vite build system ends up invoking
+  // `createMutators` via `configureServer` in `vite.config.ts`.
+  // On github CI we do not have access to the publicJwk, so we default to an empty object.
+  const v = new Validators(JSON.parse(publicJwk ?? '{}') as JWK);
+  return {
+    issue: {
+      async create(
+        tx,
+        {id, title, description, created, modified}: CreateIssueArgs,
+      ) {
+        const creatorID = must((await v.verifyToken(tx)).sub);
+
+        // See the "A Puzzle" heading in https://github.com/rocicorp/mono/pull/4035
+        if (tx.location === 'server') {
+          created = modified = Date.now();
+        }
+
+        await tx.mutate.issue.insert({
+          id,
+          title,
+          description: description ?? '',
+          created,
+          creatorID,
+          modified,
+          open: true,
+          visibility: 'public',
+        });
+      },
+
+      async update(
+        tx,
+        change: UpdateValue<typeof schema.tables.issue> & {modified: number},
+      ) {
+        await v.assertIsCreatorOrAdmin(tx, tx.query.issue, change.id);
+        await tx.mutate.issue.update({
+          ...change,
+          modified: tx.location === 'server' ? Date.now() : change.modified,
+        });
+      },
+
+      async delete(tx, id: string) {
+        await v.assertIsCreatorOrAdmin(tx, tx.query.issue, id);
+        await tx.mutate.issue.delete({id});
+      },
+
+      async addLabel(
+        tx,
+        {
+          issueID,
+          labelID,
+        }: {
+          issueID: string;
+          labelID: string;
+        },
+      ) {
+        await v.assertIsCreatorOrAdmin(tx, tx.query.issue, issueID);
+        await tx.mutate.issueLabel.insert({
+          issueID,
+          labelID,
+        });
+      },
+
+      async removeLabel(
+        tx,
+        {
+          issueID,
+          labelID,
+        }: {
+          issueID: string;
+          labelID: string;
+        },
+      ) {
+        await v.assertIsCreatorOrAdmin(tx, tx.query.issue, issueID);
+        await tx.mutate.issueLabel.delete({issueID, labelID});
+      },
+    },
+
+    emoji: {
+      async addToIssue(tx, args: AddEmojiArgs) {
+        await addEmoji(tx, 'issue', args);
+      },
+
+      async addToComment(tx, args: AddEmojiArgs) {
+        await addEmoji(tx, 'comment', args);
+      },
+
+      async remove(tx, id: string) {
+        await v.assertIsCreatorOrAdmin(tx, tx.query.emoji, id);
+        await tx.mutate.emoji.delete({id});
+      },
+    },
+
+    comment: {
+      async add(tx, {id, issueID, body, created}: AddCommentArgs) {
+        if (tx.location === 'server') {
+          created = Date.now();
+        }
+
+        const jwt = await v.verifyToken(tx);
+        const creatorID = must(jwt.sub);
+
+        await v.assertUserCanSeeIssue(tx, jwt, issueID);
+
+        await tx.mutate.comment.insert({
+          id,
+          issueID,
+          creatorID,
+          body,
+          created,
+        });
+      },
+
+      async edit(
+        tx,
+        {
+          id,
+          body,
+        }: {
+          id: string;
+          body: string;
+        },
+      ) {
+        await v.assertIsCreatorOrAdmin(tx, tx.query.comment, id);
+        await tx.mutate.comment.update({id, body});
+      },
+
+      async remove(tx, id: string) {
+        await v.assertIsCreatorOrAdmin(tx, tx.query.comment, id);
+        await tx.mutate.comment.delete({id});
+      },
+    },
+
+    label: {
+      async create(tx, {id, name}: {id: string; name: string}) {
+        const jwt = await v.verifyToken(tx);
+        assert(v.isAdmin(jwt), 'Only admins can create labels');
+        await tx.mutate.label.insert({id, name});
+      },
+
+      async createAndAddToIssue(
+        tx,
+        {
+          issueID,
+          labelID,
+          labelName,
+        }: {
+          labelID: string;
+          issueID: string;
+          labelName: string;
+        },
+      ) {
+        const jwt = await v.verifyToken(tx);
+        assert(v.isAdmin(jwt), 'Only admins can create labels');
+        await tx.mutate.label.insert({id: labelID, name: labelName});
+        await tx.mutate.issueLabel.insert({issueID, labelID});
+      },
+    },
+
+    viewState: {
+      async set(tx, {issueID, viewed}: {issueID: string; viewed: number}) {
+        const userID = must((await v.verifyToken(tx)).sub);
+        await tx.mutate.viewState.upsert({issueID, userID, viewed});
+      },
+    },
+
+    userPref: {
+      async set(tx, {key, value}: {key: string; value: string}) {
+        const userID = must((await v.verifyToken(tx)).sub);
+        await tx.mutate.userPref.upsert({key, value, userID});
+      },
+    },
+  } as const satisfies CustomMutatorDefs<typeof schema>;
+
+  async function addEmoji(
+    tx: Transaction<typeof schema, unknown>,
+    subjectType: 'issue' | 'comment',
+    {id, unicode, annotation, subjectID, creatorID, created}: AddEmojiArgs,
+  ) {
+    if (tx.location === 'server') {
+      created = Date.now();
+    }
+
+    const jwt = await v.verifyToken(tx);
+    creatorID = must(jwt.sub);
+
+    if (subjectType === 'issue') {
+      v.assertUserCanSeeIssue(tx, jwt, subjectID);
+    } else {
+      v.assertUserCanSeeComment(tx, jwt, subjectID);
+    }
+
+    await tx.mutate.emoji.insert({
+      id,
+      value: unicode,
+      annotation,
+      subjectID,
+      creatorID,
+      created,
+    });
+  }
+}
+
+export type Mutators = ReturnType<typeof createMutators>;

--- a/apps/zbugs/shared/schema.ts
+++ b/apps/zbugs/shared/schema.ts
@@ -3,6 +3,7 @@ import {
   boolean,
   createSchema,
   definePermissions,
+  enumeration,
   NOBODY_CAN,
   number,
   relationships,
@@ -20,7 +21,7 @@ const user = table('user')
     login: string(),
     name: string().optional(),
     avatar: string(),
-    role: string(),
+    role: enumeration<'user' | 'crew'>(),
   })
   .primaryKey('id');
 

--- a/apps/zbugs/shared/validators.ts
+++ b/apps/zbugs/shared/validators.ts
@@ -1,0 +1,89 @@
+import type {Query, Transaction} from '@rocicorp/zero';
+import {jwtVerify, type JWK, type JWTPayload} from 'jose';
+import type {schema} from './schema.ts';
+import {must} from '../../../packages/shared/src/must.ts';
+import {assert} from '../../../packages/shared/src/asserts.ts';
+
+export class Validators {
+  readonly #publicJwk: JWK;
+  readonly #tokenCache: Map<string, JWTPayload>;
+
+  constructor(publicJwk: JWK) {
+    this.#publicJwk = publicJwk;
+    this.#tokenCache = new Map();
+  }
+
+  async verifyToken(
+    tx: Transaction<typeof schema, unknown>,
+  ): Promise<JWTPayload> {
+    const token = tx.token;
+    assert(token, 'user must be logged in for this operation');
+    if (this.#tokenCache.size > 1000) {
+      let i = 0;
+      for (const key of this.#tokenCache.keys()) {
+        this.#tokenCache.delete(key);
+        ++i;
+        if (i > 100) {
+          break;
+        }
+      }
+    }
+    if (this.#tokenCache.has(token)) {
+      return this.#tokenCache.get(token) as JWTPayload;
+    }
+
+    const payload = (await jwtVerify(token, this.#publicJwk)).payload;
+    this.#tokenCache.set(token, payload);
+    return payload;
+  }
+
+  isAdmin(token: JWTPayload) {
+    return token.role === 'crew';
+  }
+
+  async assertIsCreatorOrAdmin(
+    tx: Transaction<typeof schema, unknown>,
+    query: Query<typeof schema, 'comment' | 'issue' | 'emoji'>,
+    id: string,
+  ) {
+    const jwt = await this.verifyToken(tx);
+    if (this.isAdmin(jwt)) {
+      return;
+    }
+    const creatorID = must(
+      await query.where('id', id).one().run(),
+      `entity ${id} does not exist`,
+    ).creatorID;
+    assert(
+      jwt.sub === creatorID,
+      `User ${jwt.sub} is not an admin or the creator of the target entity`,
+    );
+  }
+
+  async assertUserCanSeeIssue(
+    tx: Transaction<typeof schema, unknown>,
+    jwt: JWTPayload,
+    issueID: string,
+  ) {
+    const issue = must(await tx.query.issue.where('id', issueID).one().run());
+
+    assert(
+      issue.visibility === 'public' ||
+        jwt.sub === issue.creatorID ||
+        jwt.role === 'crew',
+      'User does not have permission to view this issue',
+    );
+  }
+
+  async assertUserCanSeeComment(
+    tx: Transaction<typeof schema, unknown>,
+    jwt: JWTPayload,
+    commentID: string,
+  ) {
+    const comment = must(
+      await tx.query.comment.where('id', commentID).one().run(),
+    );
+
+    await this.assertUserCanSeeIssue(tx, jwt, comment.issueID);
+  }
+}

--- a/apps/zbugs/src/comment-query.ts
+++ b/apps/zbugs/src/comment-query.ts
@@ -1,7 +1,11 @@
 import type {Zero} from '@rocicorp/zero';
-import type {IssueRow, Schema} from '../schema.ts';
+import type {IssueRow, Schema} from '../shared/schema.ts';
+import type {Mutators} from '../shared/mutators.ts';
 
-export function commentQuery(z: Zero<Schema>, displayed: IssueRow | undefined) {
+export function commentQuery(
+  z: Zero<Schema, Mutators>,
+  displayed: IssueRow | undefined,
+) {
   return z.query.comment
     .where('issueID', 'IS', displayed?.id ?? null)
     .related('creator')

--- a/apps/zbugs/src/components/avatar-image.tsx
+++ b/apps/zbugs/src/components/avatar-image.tsx
@@ -1,5 +1,5 @@
 import {memo, type ImgHTMLAttributes} from 'react';
-import type {UserRow} from '../../schema.ts';
+import type {UserRow} from '../../shared/schema.ts';
 import {avatarURLWithSize} from '../avatar-url-with-size.ts';
 
 interface AvatarImageProps extends ImgHTMLAttributes<HTMLImageElement> {

--- a/apps/zbugs/src/components/emoji-panel.tsx
+++ b/apps/zbugs/src/components/emoji-panel.tsx
@@ -11,7 +11,6 @@ import {
   useRole,
   useTransitionStatus,
 } from '@floating-ui/react';
-import {nanoid} from 'nanoid';
 import {
   forwardRef,
   memo,
@@ -32,6 +31,7 @@ import {ButtonWithLoginCheck} from './button-with-login-check.tsx';
 import {type ButtonProps} from './button.tsx';
 import {EmojiPicker} from './emoji-picker.tsx';
 import {EmojiPill} from './emoji-pill.tsx';
+import {nanoid} from 'nanoid';
 
 const loginMessage = 'You need to be logged in to modify emoji reactions.';
 
@@ -54,22 +54,26 @@ export const EmojiPanel = memo(
 
       const addEmoji = useCallback(
         (unicode: string, annotation: string) => {
-          const id = nanoid();
-          z.mutate.emoji.insert({
-            id,
-            value: unicode,
+          const args = {
+            id: nanoid(),
+            unicode,
             annotation,
             subjectID,
             creatorID: z.userID,
             created: Date.now(),
-          });
+          } as const;
+          if (commentID !== undefined) {
+            z.mutate.emoji.addToComment(args);
+          } else {
+            z.mutate.emoji.addToIssue(args);
+          }
         },
-        [subjectID, z],
+        [subjectID, commentID, z],
       );
 
       const removeEmoji = useCallback(
         (id: string) => {
-          z.mutate.emoji.delete({id});
+          z.mutate.emoji.remove(id);
         },
         [z],
       );

--- a/apps/zbugs/src/components/user-picker.tsx
+++ b/apps/zbugs/src/components/user-picker.tsx
@@ -2,7 +2,7 @@ import {type Row} from '@rocicorp/zero';
 import {useQuery} from '@rocicorp/zero/react';
 import {useEffect, useMemo, useState} from 'react';
 import {toSorted} from '../../../../packages/shared/src/to-sorted.ts';
-import {type Schema} from '../../schema.ts';
+import {type Schema} from '../../shared/schema.ts';
 import avatarIcon from '../assets/icons/avatar-default.svg';
 import {avatarURLWithSize} from '../avatar-url-with-size.ts';
 import {useZero} from '../hooks/use-zero.ts';

--- a/apps/zbugs/src/emoji-utils.test.ts
+++ b/apps/zbugs/src/emoji-utils.test.ts
@@ -16,7 +16,7 @@ function makeEmoji(userID: string, login: string): Emoji {
       login,
       avatar: 'avatar',
       name: 'James Holden',
-      role: 'admin',
+      role: 'crew',
     },
   };
 }

--- a/apps/zbugs/src/emoji-utils.ts
+++ b/apps/zbugs/src/emoji-utils.ts
@@ -1,6 +1,6 @@
 import type {Row} from '@rocicorp/zero';
 import {assert} from 'shared/src/asserts.js';
-import type {Schema} from '../schema.ts';
+import type {Schema} from '../shared/schema.ts';
 
 export type Emoji = Row<Schema['tables']['emoji']> & {
   readonly creator: Row<Schema['tables']['user']> | undefined;

--- a/apps/zbugs/src/hooks/use-user-pref.ts
+++ b/apps/zbugs/src/hooks/use-user-pref.ts
@@ -1,7 +1,8 @@
 import type {Zero} from '@rocicorp/zero';
 import {useQuery} from '@rocicorp/zero/react';
-import type {Schema} from '../../schema.ts';
+import type {Schema} from '../../shared/schema.ts';
 import {useZero} from './use-zero.ts';
+import type {Mutators} from '../../shared/mutators.ts';
 
 export function useUserPref(key: string): string | undefined {
   const z = useZero();
@@ -11,12 +12,12 @@ export function useUserPref(key: string): string | undefined {
 }
 
 export async function setUserPref(
-  z: Zero<Schema>,
+  z: Zero<Schema, Mutators>,
   key: string,
   value: string,
   mutate = z.mutate,
 ): Promise<void> {
-  await mutate.userPref.upsert({key, value, userID: z.userID});
+  await mutate.userPref.set({key, value});
 }
 
 export function useNumericPref(key: string, defaultValue: number): number {
@@ -25,7 +26,7 @@ export function useNumericPref(key: string, defaultValue: number): number {
 }
 
 export function setNumericPref(
-  z: Zero<Schema>,
+  z: Zero<Schema, Mutators>,
   key: string,
   value: number,
 ): Promise<void> {

--- a/apps/zbugs/src/hooks/use-zero.ts
+++ b/apps/zbugs/src/hooks/use-zero.ts
@@ -1,3 +1,4 @@
 import {createUseZero} from '@rocicorp/zero/react';
-import type {Schema} from '../../schema.ts';
-export const useZero = createUseZero<Schema>();
+import type {Schema} from '../../shared/schema.ts';
+import type {Mutators} from '../../shared/mutators.ts';
+export const useZero = createUseZero<Schema, Mutators>();

--- a/apps/zbugs/src/pages/issue/comment-composer.tsx
+++ b/apps/zbugs/src/pages/issue/comment-composer.tsx
@@ -1,10 +1,10 @@
-import {nanoid} from 'nanoid';
 import {useEffect, useState} from 'react';
 import {Button} from '../../components/button.tsx';
 import {useLogin} from '../../hooks/use-login.tsx';
 import {useZero} from '../../hooks/use-zero.ts';
 import {maxCommentLength} from '../../limits.ts';
 import {isCtrlEnter} from './is-ctrl-enter.ts';
+import {nanoid} from 'nanoid';
 
 export function CommentComposer({
   id,
@@ -23,10 +23,9 @@ export function CommentComposer({
   const save = () => {
     setCurrentBody(body ?? '');
     if (!id) {
-      z.mutate.comment.insert({
+      z.mutate.comment.add({
         id: nanoid(),
         issueID,
-        creatorID: z.userID,
         body: currentBody,
         created: Date.now(),
       });
@@ -34,7 +33,7 @@ export function CommentComposer({
       return;
     }
 
-    z.mutate.comment.update({id, body: currentBody});
+    z.mutate.comment.edit({id, body: currentBody});
     onDone?.();
   };
 

--- a/apps/zbugs/src/pages/issue/comment.tsx
+++ b/apps/zbugs/src/pages/issue/comment.tsx
@@ -42,7 +42,7 @@ export const Comment = memo(
     const isPermalinked = highlight || hash === permalink;
 
     const edit = () => setEditing(true);
-    const remove = () => z.mutate.comment.delete({id});
+    const remove = () => z.mutate.comment.remove(id);
 
     if (!comment) {
       return <div style={{height}}></div>;

--- a/apps/zbugs/src/pages/issue/issue-composer.tsx
+++ b/apps/zbugs/src/pages/issue/issue-composer.tsx
@@ -52,15 +52,12 @@ export function IssueComposer({isOpen, onDismiss}: Props) {
   const handleSubmit = () => {
     const id = nanoid();
 
-    z.mutate.issue.insert({
+    z.mutate.issue.create({
       id,
       title,
       description: description ?? '',
       created: Date.now(),
-      creatorID: z.userID,
       modified: Date.now(),
-      open: true,
-      visibility: 'public',
     });
     reset();
     onDismiss(id);

--- a/apps/zbugs/src/zero-setup.ts
+++ b/apps/zbugs/src/zero-setup.ts
@@ -1,5 +1,6 @@
 import {Zero} from '@rocicorp/zero';
-import {type Schema, schema} from '../schema.ts';
+import {type Schema, schema} from '../shared/schema.ts';
+import {createMutators, type Mutators} from '../shared/mutators.ts';
 import {Atom} from './atom.ts';
 import {clearJwt, getJwt, getRawJwt} from './jwt.ts';
 import {mark} from './perf-log.ts';
@@ -14,7 +15,7 @@ export type LoginState = {
   };
 };
 
-const zeroAtom = new Atom<Zero<Schema>>();
+const zeroAtom = new Atom<Zero<Schema, Mutators>>();
 const authAtom = new Atom<LoginState>();
 const jwt = getJwt();
 const encodedJwt = getRawJwt();
@@ -34,6 +35,7 @@ authAtom.onChange(auth => {
     logLevel: 'info',
     server: import.meta.env.VITE_PUBLIC_SERVER,
     userID: auth?.decoded?.sub ?? 'anon',
+    mutators: createMutators(import.meta.env.VITE_PUBLIC_JWK),
     auth: (error?: 'invalid-token') => {
       if (error === 'invalid-token') {
         clearJwt();
@@ -51,7 +53,7 @@ authAtom.onChange(auth => {
 
 let didPreload = false;
 
-export function preload(z: Zero<Schema>) {
+export function preload(z: Zero<Schema, Mutators>) {
   if (didPreload) {
     return;
   }
@@ -87,9 +89,9 @@ export function preload(z: Zero<Schema>) {
 }
 
 // To enable accessing zero in the devtools easily.
-function exposeDevHooks(z: Zero<Schema>) {
+function exposeDevHooks(z: Zero<Schema, Mutators>) {
   const casted = window as unknown as {
-    z?: Zero<Schema>;
+    z?: Zero<Schema, Mutators>;
   };
   casted.z = z;
 }

--- a/apps/zbugs/tsconfig.json
+++ b/apps/zbugs/tsconfig.json
@@ -10,5 +10,5 @@
     },
     "declaration": true
   },
-  "include": ["src", "schema.ts"]
+  "include": ["src", "shared/*"]
 }

--- a/packages/zero-client/src/client/custom.ts
+++ b/packages/zero-client/src/client/custom.ts
@@ -73,7 +73,7 @@ export type MakeCustomMutatorInterface<
   S extends Schema,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   F,
-> = F extends (tx: Transaction<S>, ...args: infer Args) => Promise<void>
+> = F extends (tx: ClientTransaction<S>, ...args: infer Args) => Promise<void>
   ? (...args: Args) => Promise<void>
   : never;
 

--- a/packages/zero-pg/src/custom.ts
+++ b/packages/zero-pg/src/custom.ts
@@ -1,4 +1,3 @@
-import type {ReadonlyJSONValue} from '../../shared/src/json.ts';
 import type {Schema} from '../../zero-schema/src/builder/schema-builder.ts';
 import type {TableSchema} from '../../zero-schema/src/table-schema.ts';
 import type {
@@ -8,12 +7,13 @@ import type {
   TransactionBase,
   ConnectionProvider,
   DBTransaction,
+  Transaction,
 } from '../../zql/src/mutate/custom.ts';
 import {PushProcessor, type PushHandler} from './web.ts';
 import {formatPg, sql} from '../../z2s/src/sql.ts';
 import type {ShardID} from '../../zero-cache/src/types/shards.ts';
 
-export interface Transaction<S extends Schema, TWrappedTransaction>
+interface ServerTransaction<S extends Schema, TWrappedTransaction>
   extends TransactionBase<S> {
   readonly location: 'server';
   readonly reason: 'authoritative';
@@ -31,9 +31,10 @@ export type CustomMutatorDefs<S extends Schema, TDBTransaction> = {
   };
 };
 
-export type CustomMutatorImpl<S extends Schema, TDBTransaction> = (
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type CustomMutatorImpl<S extends Schema, TDBTransaction, TArgs = any> = (
   tx: Transaction<S, TDBTransaction>,
-  args: ReadonlyJSONValue,
+  args: TArgs,
 ) => Promise<void>;
 
 type Options<
@@ -70,7 +71,7 @@ export function createPushHandler<
 }
 
 export class TransactionImpl<S extends Schema, TWrappedTransaction>
-  implements Transaction<S, TWrappedTransaction>
+  implements ServerTransaction<S, TWrappedTransaction>
 {
   readonly location = 'server';
   readonly reason = 'authoritative';

--- a/packages/zero-pg/src/query.ts
+++ b/packages/zero-pg/src/query.ts
@@ -92,12 +92,12 @@ export class Z2SQuery<
       sqlQuery.values,
     );
 
-    if (Array.isArray(result)) {
-      return result as HumanReadable<TReturn>;
-    }
-
     if (this.format.singular) {
       return first(result) as HumanReadable<TReturn>;
+    }
+
+    if (Array.isArray(result)) {
+      return result as HumanReadable<TReturn>;
     }
 
     return [...result] as HumanReadable<TReturn>;


### PR DESCRIPTION
We're ready to port zbugs to custom mutators.

Missing features:
- threading mutation errors from the api server back to the client
- adding an auth error type to the protocol so the api server can cause the token to be refreshed on the client

Bugs:
- `related` does not do type conversion in `z2s` (zql 2 sql). E.g., dates come back as strings rather than milliseconds when doing reads, which contain `related` calls, on the server via ZQL. This doesn't impact zbugs at the moment.


# A puzzle:

Setting `created` and `modified` for an issue in the custom mutator does indeed cause an i-loop until the API server responds.

The steps are as follows:
1. Mutation runs to create the issue
2. UI navigates to the issue page
3. `useQuery` runs to set up `j/k` queries
4. This writes a new query
5. This causes the server to poke
6. This causes a rebase of outstanding mutations
7. Rebasing the issue create mutation updates created and modified again
8. This updates the query for `j/k` since `start` takes in the `issue` row which has a new `created` and `modified` time.
9. This writes a new query
10. Back to step 5

https://github.com/user-attachments/assets/d5f6aa37-f4d7-4fdb-9662-3bae74080a28

# 🤔
- one option is to not rebase mutations if only queries change and no data changes. This doesn't fully prevent the issue, however. A query that returns data can cause this loop.
- memoize the input to the `j/k` queries based on `issue.id` so we ignore created/modified time changes
- definitely add some brakes if queries are cycling too fast, throw an error.

