### PR TITLE
chore(zero-cache): remove readiness timeout

### DIFF
--- a/packages/zero-cache/src/db/transaction-pool.ts
+++ b/packages/zero-cache/src/db/transaction-pool.ts
@@ -199,11 +199,12 @@ export class TransactionPool {
                 ...result.stmts.map(stmt =>
                   stmt
                     .execute()
-                    .then(() =>
-                      lc.debug?.(
-                        `Executed statement (${Date.now() - start} ms)`,
-                        (stmt as unknown as Stmt).strings,
-                      ),
+                    .then(
+                      () =>
+                        lc.debug?.(
+                          `Executed statement (${Date.now() - start} ms)`,
+                          (stmt as unknown as Stmt).strings,
+                        ),
                     )
                     .catch(e => this.fail(e)),
                 ),

--- a/packages/zero-cache/src/server/multi/run-worker.ts
+++ b/packages/zero-cache/src/server/multi/run-worker.ts
@@ -4,7 +4,6 @@ import {PROTOCOL_VERSION} from '../../../../zero-protocol/src/protocol-version.t
 import {ProcessManager, runUntilKilled} from '../../services/life-cycle.ts';
 import type {Service} from '../../services/service.ts';
 import {childWorker, type Worker} from '../../types/processes.ts';
-import {orTimeout} from '../../types/timeout.ts';
 import {createLogContext} from '../logging.ts';
 import {getMultiZeroConfig} from './config.ts';
 import {getTaskID} from './runtime.ts';
@@ -85,11 +84,8 @@ export async function runWorker(
 
   const s = tenants.length > 1 ? 's' : '';
   lc.info?.(`waiting for zero-cache${s} to be ready ...`);
-  if ((await orTimeout(processes.allWorkersReady(), 60_000)) === 'timed-out') {
-    lc.info?.(`timed out waiting for readiness (${Date.now() - startMs} ms)`);
-  } else {
-    lc.info?.(`zero-cache${s} ready (${Date.now() - startMs} ms)`);
-  }
+  await processes.allWorkersReady();
+  lc.info?.(`zero-cache${s} ready (${Date.now() - startMs} ms)`);
 
   const mainServices: Service[] = [];
   if (multiMode) {

--- a/packages/zero-cache/src/services/replicator/change-processor.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.ts
@@ -131,8 +131,8 @@ export class ChangeProcessor {
         type === 'begin'
           ? downstream[2].commitWatermark
           : type === 'commit'
-            ? downstream[2].watermark
-            : undefined;
+          ? downstream[2].watermark
+          : undefined;
       return this.#processMessage(lc, message, watermark);
     } catch (e) {
       this.#fail(lc, e);

--- a/packages/zero-cache/src/services/runner.ts
+++ b/packages/zero-cache/src/services/runner.ts
@@ -34,11 +34,12 @@ export class ServiceRunner<S extends Service> {
     this.#instances.set(id, service);
     void service
       .run()
-      .catch(e =>
-        this.#lc.error?.(
-          `Error running ${service.constructor?.name} ${service.id}`,
-          e,
-        ),
+      .catch(
+        e =>
+          this.#lc.error?.(
+            `Error running ${service.constructor?.name} ${service.id}`,
+            e,
+          ),
       )
       .finally(() => {
         this.#instances.delete(id);

--- a/packages/zero-cache/src/services/view-syncer/schema/types.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/types.ts
@@ -52,14 +52,14 @@ export function cmpVersions(
   return a === null && b === null
     ? 0
     : a === null
-      ? -1
-      : b === null
-        ? 1
-        : a.stateVersion < b.stateVersion
-          ? -1
-          : a.stateVersion > b.stateVersion
-            ? 1
-            : (a.minorVersion ?? 0) - (b.minorVersion ?? 0);
+    ? -1
+    : b === null
+    ? 1
+    : a.stateVersion < b.stateVersion
+    ? -1
+    : a.stateVersion > b.stateVersion
+    ? 1
+    : (a.minorVersion ?? 0) - (b.minorVersion ?? 0);
 }
 
 export function versionToCookie(v: CVRVersion): string {


### PR DESCRIPTION
Remove the confusing readiness timeout at startup. Readiness can take arbitrarily long for large initial syncs, and should be handled by a production parameter such as `healthCheckGracePeriodSeconds`. There is no point in responding to health checks if the server is not fully ready.

Instead, periodically log which workers are still being awaited.