### PR TITLE
chore(mutators): pass schema and app-id to push endpoint

### DIFF
--- a/apps/zbugs/api/index.ts
+++ b/apps/zbugs/api/index.ts
@@ -108,11 +108,17 @@ fastify.get<{
     );
 });
 
-fastify.post('/api/push', async function (request, reply) {
+fastify.post<{
+  Querystring: {
+    schema: string;
+    appID: string;
+  };
+}>('/api/push', async function (request, reply) {
   const response = await pushHandler(
     {
       authorization: request.headers.authorization,
     },
+    request.query,
     request.body as ReadonlyJSONObject,
   );
   reply.send(response);

--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -146,6 +146,7 @@ export default function runWorker(
       ? undefined
       : (id: string) =>
           new PusherService(
+            config,
             lc.withContext('clientGroupID', id),
             id,
             must(config.push.url),

--- a/packages/zero-pg/src/custom.ts
+++ b/packages/zero-pg/src/custom.ts
@@ -56,18 +56,9 @@ export function createPushHandler<
   schema,
   dbConnectionProvider,
   mutators,
-  shardID,
 }: Options<S, TDBTransaction, MD>): PushHandler {
-  const processor = new PushProcessor(
-    shardID ?? {
-      appID: 'zero',
-      shardNum: 0,
-    },
-    schema,
-    dbConnectionProvider,
-    mutators,
-  );
-  return (headers, body) => processor.process(headers, body);
+  const processor = new PushProcessor(schema, dbConnectionProvider, mutators);
+  return (headers, params, body) => processor.process(headers, params, body);
 }
 
 export class TransactionImpl<S extends Schema, TWrappedTransaction>

--- a/packages/zero-pg/src/web.ts
+++ b/packages/zero-pg/src/web.ts
@@ -25,20 +25,24 @@ import {
 } from '../../zql/src/mutate/custom.ts';
 import {makeSchemaQuery} from './query.ts';
 import {assert} from '../../shared/src/asserts.ts';
-import {
-  upstreamSchema,
-  type ShardID,
-} from '../../zero-cache/src/types/shards.ts';
 import {formatPg} from '../../z2s/src/sql.ts';
 import {sql} from '../../z2s/src/sql.ts';
 import {MutationAlreadyProcessedError} from '../../zero-cache/src/services/mutagen/mutagen.ts';
 
 export type PushHandler = (
   headers: Headers,
+  params: Params,
   body: ReadonlyJSONObject,
 ) => Promise<PushResponse>;
 
-type Headers = {authorization?: string | undefined};
+type Headers = {
+  authorization?: string | undefined;
+};
+
+type Params = {
+  schema: string;
+  appID: string;
+};
 
 export class PushProcessor<
   S extends Schema,
@@ -48,17 +52,14 @@ export class PushProcessor<
   readonly #dbConnectionProvider: ConnectionProvider<TDBTransaction>;
   readonly #customMutatorDefs: MD;
   readonly #lc: LogContext;
-  readonly #shardID: ShardID;
   readonly #mutate: (dbTransaction: DBTransaction<unknown>) => SchemaCRUD<S>;
   readonly #query: (dbTransaction: DBTransaction<unknown>) => SchemaQuery<S>;
 
   constructor(
-    shardID: ShardID,
     schema: S,
     dbConnectionProvider: ConnectionProvider<TDBTransaction>,
     customMutatorDefs: MD,
   ) {
-    this.#shardID = shardID;
     this.#dbConnectionProvider = dbConnectionProvider;
     this.#customMutatorDefs = customMutatorDefs;
     this.#lc = createLogContext('info');
@@ -68,8 +69,16 @@ export class PushProcessor<
 
   async process(
     headers: Headers,
+    params: Params,
     body: ReadonlyJSONObject,
   ): Promise<PushResponse> {
+    // TODO: Remove this once zbugs zero-cache and api server are both up to date.
+    if (params.schema === undefined) {
+      params = {
+        schema: 'zero_0',
+        appID: 'zero',
+      };
+    }
     const req = v.parse(body, pushBodySchema);
     const connection = await this.#dbConnectionProvider();
 
@@ -81,7 +90,13 @@ export class PushProcessor<
 
     const responses: MutationResponse[] = [];
     for (const m of req.mutations) {
-      const res = await this.#processMutation(connection, headers, req, m);
+      const res = await this.#processMutation(
+        connection,
+        headers,
+        params,
+        req,
+        m,
+      );
       responses.push(res);
       if ('error' in res.result) {
         break;
@@ -96,6 +111,7 @@ export class PushProcessor<
   async #processMutation(
     dbConnection: DBConnection<TDBTransaction>,
     headers: Headers,
+    params: Params,
     req: PushBody,
     m: Mutation,
   ): Promise<MutationResponse> {
@@ -103,6 +119,7 @@ export class PushProcessor<
       return await this.#processMutationImpl(
         dbConnection,
         headers,
+        params,
         req,
         m,
         false,
@@ -135,6 +152,7 @@ export class PushProcessor<
       const ret = await this.#processMutationImpl(
         dbConnection,
         headers,
+        params,
         req,
         m,
         true,
@@ -158,6 +176,7 @@ export class PushProcessor<
   #processMutationImpl(
     dbConnection: DBConnection<TDBTransaction>,
     headers: Headers,
+    params: Params,
     req: PushBody,
     m: Mutation,
     errorMode: boolean,
@@ -171,7 +190,7 @@ export class PushProcessor<
     return dbConnection.transaction(async (dbTx): Promise<MutationResponse> => {
       await checkAndIncrementLastMutationID(
         dbTx,
-        this.#shardID,
+        params.schema,
         req.clientGroupID,
         m.clientID,
         m.id,
@@ -220,13 +239,13 @@ export class PushProcessor<
 
 async function checkAndIncrementLastMutationID(
   tx: DBTransaction<unknown>,
-  shard: ShardID,
+  schema: string,
   clientGroupID: string,
   clientID: string,
   receivedMutationID: number,
 ) {
   const formatted = formatPg(
-    sql`INSERT INTO ${sql.ident(upstreamSchema(shard))}.clients 
+    sql`INSERT INTO ${sql.ident(schema)}.clients 
     as current ("clientGroupID", "clientID", "lastMutationID")
         VALUES (${clientGroupID}, ${clientID}, ${1})
     ON CONFLICT ("clientGroupID", "clientID")


### PR DESCRIPTION
Placed them into the query string so a user can route based on `app_id`.