### PR TITLE
fix(zero-solid): Fix issue with reused views

### DIFF
--- a/packages/shared/src/ref-count.test.ts
+++ b/packages/shared/src/ref-count.test.ts
@@ -1,0 +1,40 @@
+import {expect, test} from 'vitest';
+import {RefCount} from './ref-count.ts';
+
+test('inc increases reference count and returns true on first add', () => {
+  const rc = new RefCount();
+  const obj1 = {};
+  const obj2 = {};
+
+  // First addition should return true
+  expect(rc.inc(obj1)).toBe(true);
+
+  // Second addition should return false
+  expect(rc.inc(obj1)).toBe(false);
+
+  // Different object should return true on first add
+  expect(rc.inc(obj2)).toBe(true);
+});
+
+test('dec decreases reference count', () => {
+  const rc = new RefCount();
+  const obj = {};
+
+  // Add twice
+  rc.inc(obj);
+  rc.inc(obj);
+
+  // First decrease should return false (not removed)
+  expect(rc.dec(obj)).toBe(false);
+
+  // Second decrease should return true (removed)
+  expect(rc.dec(obj)).toBe(true);
+});
+
+test('dec throws when trying to decrease non-existent object', () => {
+  const rc = new RefCount();
+  const obj = {};
+
+  // Trying to decrease a non-existent object should throw
+  expect(() => rc.dec(obj)).toThrow();
+});

--- a/packages/shared/src/ref-count.ts
+++ b/packages/shared/src/ref-count.ts
@@ -1,0 +1,30 @@
+import {must} from './must.ts';
+
+/**
+ * This is a basic ref count implementation that uses a WeakMap to store the
+ * reference count for each value.
+ */
+export class RefCount<T extends WeakKey = WeakKey> {
+  readonly #map = new WeakMap<T, number>();
+
+  /**
+   * Returns true if the value was added.
+   */
+  inc(value: T): boolean {
+    const rc = this.#map.get(value) ?? 0;
+    this.#map.set(value, rc + 1);
+    return rc === 0;
+  }
+
+  /**
+   * Returns true if the value was removed.
+   */
+  dec(value: T): boolean {
+    const rc = must(this.#map.get(value));
+    if (rc === 1) {
+      return this.#map.delete(value);
+    }
+    this.#map.set(value, rc - 1);
+    return false;
+  }
+}


### PR DESCRIPTION
In 0.17 we started reusing views when the query is the same. This caused an issue where we ended up calling destroy on the view multiple times.

Now we keep a ref count on the view and only destroy it when the ref count reaches zero.