### PR TITLE
fix(zero-solid): fix useQuery ref count

### DIFF
--- a/packages/zero-solid/src/use-query.test.ts
+++ b/packages/zero-solid/src/use-query.test.ts
@@ -1,6 +1,6 @@
 import {renderHook, testEffect} from '@solidjs/testing-library';
 import {createEffect, createRoot, createSignal} from 'solid-js';
-import {expect, test, vi} from 'vitest';
+import {expect, test, vi, type MockInstance} from 'vitest';
 import {must} from '../../shared/src/must.ts';
 import {
   createSchema,
@@ -10,6 +10,7 @@ import {
   type TTL,
 } from '../../zero/src/zero.ts';
 import {MemorySource} from '../../zql/src/ivm/memory-source.ts';
+import type {SourceInput} from '../../zql/src/ivm/source.ts';
 import {refCountSymbol} from '../../zql/src/ivm/view-apply-change.ts';
 import {newQuery} from '../../zql/src/query/query-impl.ts';
 import {QueryDelegateImpl} from '../../zql/src/query/test/query-delegate.ts';
@@ -168,27 +169,37 @@ test('useQuery deps change testEffect', () => {
   );
 });
 
-test('useQuery shared view should only be destroyed once', () => {
-  createRoot(dispose => {
-    const {ms, tableQuery} = setupTestEnvironment();
-    const connectSpy = vi.spyOn(ms, 'connect');
+test('useQuery shared view should only be destroyed once', async () => {
+  const {ms, tableQuery} = setupTestEnvironment();
+  const query = tableQuery.where('a', 1);
+  const connectSpy = vi.spyOn(ms, 'connect');
+  let destroySpy!: MockInstance<SourceInput['destroy']>;
 
-    const query = tableQuery.where('a', 1);
-    const [rows1] = useQuery(() => query);
-    const [rows2] = useQuery(() => query);
+  for (let i = 0; i < 2; i++) {
+    createRoot(dispose => {
+      const [rows1] = useQuery(() => query);
+      const [rows2] = useQuery(() => query);
 
-    expect(connectSpy).toHaveBeenCalledTimes(1);
-    // connect returns a SourceInput
+      expect(connectSpy).toHaveBeenCalledTimes(1);
 
-    expect(rows1()).toEqual([{a: 1, b: 'a', [refCountSymbol]: 1}]);
-    expect(rows2()).toEqual([{a: 1, b: 'a', [refCountSymbol]: 1}]);
+      expect(rows1()).toEqual([{a: 1, b: 'a', [refCountSymbol]: 1}]);
+      expect(rows2()).toEqual([{a: 1, b: 'a', [refCountSymbol]: 1}]);
 
-    expect(connectSpy).toHaveBeenCalledTimes(1);
-    const sourceInput = connectSpy.mock.results[0].value;
-    const destroySpy = vi.spyOn(sourceInput, 'destroy');
+      expect(connectSpy).toHaveBeenCalledTimes(1);
+      // connect returns a SourceInput
+      const sourceInput = connectSpy.mock.results[0].value;
+      destroySpy = vi.spyOn(sourceInput, 'destroy');
 
-    dispose();
+      dispose();
+    });
+
+    // We destroy the view on the next tick to prevent tearing it down and
+    // recreating it when a dependency changes.
+    await 1;
 
     expect(destroySpy).toHaveBeenCalledTimes(1);
-  });
+
+    connectSpy.mockClear();
+    destroySpy.mockReset();
+  }
 });


### PR DESCRIPTION
We were using the ref count to determine when to destroy the materialized view but we were not clearing the cached view so we end up using the destroyed view.