### PR TITLE
chore(mutators): `mutation-tracker` to track mutation status

### DIFF
--- a/packages/zero-client/src/client/custom.ts
+++ b/packages/zero-client/src/client/custom.ts
@@ -116,6 +116,8 @@ export class TransactionImpl<S extends Schema> implements ClientTransaction<S> {
   readonly token: string | undefined;
 }
 
+// TODO: wire into `PushResponseTracker` so we can give out promises for each mutation
+// when it is `initial`
 export function makeReplicacheMutator<S extends Schema>(
   lc: LogContext,
   mutator: CustomMutatorImpl<S>,

--- a/packages/zero-client/src/client/mutation-tracker.test.ts
+++ b/packages/zero-client/src/client/mutation-tracker.test.ts
@@ -1,0 +1,125 @@
+import {describe, it, expect} from 'vitest';
+import {MutationTracker} from './mutation-tracker.ts';
+import type {PushResponse} from '../../../zero-protocol/src/push.ts';
+
+describe('MutationTracker', () => {
+  const CLIENT_ID = 'test-client-1';
+
+  it('tracks a mutation and resolves on success', async () => {
+    const tracker = new MutationTracker(CLIENT_ID);
+    const mutationPromise = tracker.trackMutation(1);
+
+    const response: PushResponse = {
+      mutations: [
+        {
+          id: {clientID: CLIENT_ID, id: 1},
+          result: {},
+        },
+      ],
+    };
+
+    tracker.processPushResponse(response);
+    const result = await mutationPromise;
+    expect(result).toEqual({});
+  });
+
+  it('tracks a mutation and rejects on error', async () => {
+    const tracker = new MutationTracker(CLIENT_ID);
+    const mutationPromise = tracker.trackMutation(1);
+
+    const response: PushResponse = {
+      mutations: [
+        {
+          id: {clientID: CLIENT_ID, id: 1},
+          result: {
+            error: 'app',
+            details: '',
+          },
+        },
+      ],
+    };
+
+    tracker.processPushResponse(response);
+    await expect(mutationPromise).rejects.toEqual({
+      error: 'app',
+      details: '',
+    });
+  });
+
+  it('handles push errors', async () => {
+    const tracker = new MutationTracker(CLIENT_ID);
+    const mutationPromise = tracker.trackMutation(1);
+
+    const response: PushResponse = {
+      error: 'unsupported-push-version',
+      mutationIDs: [{clientID: CLIENT_ID, id: 1}],
+    };
+
+    tracker.processPushResponse(response);
+    await expect(mutationPromise).rejects.toEqual({
+      error: 'unsupported-push-version',
+      mutationIDs: [{clientID: CLIENT_ID, id: 1}],
+    });
+  });
+
+  it('rejects mutation when explicitly rejected', async () => {
+    const tracker = new MutationTracker(CLIENT_ID);
+    const mutationPromise = tracker.trackMutation(1);
+
+    tracker.rejectMutation(1, new Error('Failed to send'));
+
+    await expect(mutationPromise).rejects.toThrow('Failed to send');
+  });
+
+  it('rejects mutations from other clients', () => {
+    const tracker = new MutationTracker(CLIENT_ID);
+    void tracker.trackMutation(1);
+
+    const response: PushResponse = {
+      mutations: [
+        {
+          id: {clientID: 'other-client', id: 1},
+          result: {
+            error: 'app',
+            details: '',
+          },
+        },
+        {
+          id: {clientID: CLIENT_ID, id: 1},
+          result: {},
+        },
+      ],
+    };
+
+    expect(() => tracker.processPushResponse(response)).toThrow(
+      'received mutation for the wrong client',
+    );
+  });
+
+  it('handles multiple concurrent mutations', async () => {
+    const tracker = new MutationTracker(CLIENT_ID);
+    const mutation1 = tracker.trackMutation(1);
+    const mutation2 = tracker.trackMutation(2);
+
+    const r1 = {};
+    const r2 = {};
+    const response: PushResponse = {
+      mutations: [
+        {
+          id: {clientID: CLIENT_ID, id: 1},
+          result: r1,
+        },
+        {
+          id: {clientID: CLIENT_ID, id: 2},
+          result: r2,
+        },
+      ],
+    };
+
+    tracker.processPushResponse(response);
+
+    const [result1, result2] = await Promise.all([mutation1, mutation2]);
+    expect(result1).toBe(r1);
+    expect(result2).toBe(r2);
+  });
+});

--- a/packages/zero-client/src/client/mutation-tracker.ts
+++ b/packages/zero-client/src/client/mutation-tracker.ts
@@ -1,0 +1,100 @@
+import {resolver, type Resolver} from '@rocicorp/resolver';
+import type {
+  MutationError,
+  MutationID,
+  MutationOk,
+  PushError,
+  PushOk,
+  PushResponse,
+} from '../../../zero-protocol/src/push.ts';
+import {assert} from '../../../shared/src/asserts.ts';
+
+type MutationResult = MutationOk | MutationError | PushError;
+
+/**
+ * Tracks what pushes are in-flight and resolves promises when they're acked.
+ */
+export class MutationTracker {
+  readonly #outstandingMutations: Map<number, Resolver<MutationResult>>;
+  readonly #clientID: string;
+
+  constructor(clientID: string) {
+    this.#outstandingMutations = new Map();
+    this.#clientID = clientID;
+  }
+
+  trackMutation(id: number): Promise<MutationResult> {
+    assert(!this.#outstandingMutations.has(id));
+    const mutationResolver = resolver<MutationResult>();
+    this.#outstandingMutations.set(id, mutationResolver);
+    return mutationResolver.promise;
+  }
+
+  /**
+   * Called if the mutation is never able to be sent to the server
+   * and abandoned before persisted.
+   * In that case, we have no `pushResponse` to process.
+   */
+  rejectMutation(id: number, e: Error) {
+    const resolver = this.#outstandingMutations.get(id);
+    assert(resolver);
+    resolver.reject(e);
+    this.#outstandingMutations.delete(id);
+  }
+
+  processPushResponse(response: PushResponse): void {
+    if ('error' in response) {
+      this.#processPushError(response);
+    } else {
+      this.#processPushOk(response);
+    }
+  }
+
+  #processPushError(error: PushError): void {
+    const mids = error.mutationIDs;
+
+    // TODO: remove this check once the server always sends mutationIDs
+    if (!mids) {
+      return;
+    }
+
+    for (const mid of mids) {
+      this.#processMutationError(mid, error);
+    }
+  }
+
+  #processPushOk(ok: PushOk): void {
+    for (const mutation of ok.mutations) {
+      if ('error' in mutation.result) {
+        this.#processMutationError(mutation.id, mutation.result);
+      } else {
+        this.#processMutationOk(mutation.result, mutation.id);
+      }
+    }
+  }
+
+  #processMutationError(
+    mid: MutationID,
+    error: MutationError | Omit<PushError, 'mutationIDs'>,
+  ): void {
+    assert(
+      mid.clientID === this.#clientID,
+      'received mutation for the wrong client',
+    );
+    const resolver = this.#outstandingMutations.get(mid.id);
+    assert(resolver);
+    resolver.reject(error);
+    this.#outstandingMutations.delete(mid.id);
+  }
+
+  #processMutationOk(result: MutationOk, mid: MutationID): void {
+    assert(
+      mid.clientID === this.#clientID,
+      'received mutation for the wrong client',
+    );
+    const resolver = this.#outstandingMutations.get(mid.id);
+    assert(resolver);
+    resolver.resolve(result);
+    this.#outstandingMutations.delete(mid.id);
+  }
+}

--- a/packages/zero-protocol/src/push.ts
+++ b/packages/zero-protocol/src/push.ts
@@ -124,9 +124,17 @@ const pushOkSchema = v.object({
 
 const unsupportedPushVersionSchema = v.object({
   error: v.literal('unsupported-push-version'),
+  // optional for backwards compatibility
+  // This field is included so the client knows which mutations
+  // were not processed by the server.
+  mutationIDs: v.array(mutationIDSchema).optional(),
 });
 const unsupportedSchemaVersionSchema = v.object({
   error: v.literal('unsupported-schema-version'),
+  // optional for backwards compatibility
+  // This field is included so the client knows which mutations
+  // were not processed by the server.
+  mutationIDs: v.array(mutationIDSchema).optional(),
 });
 
 const pushErrorSchema = v.union(
@@ -150,6 +158,11 @@ export type PushBody = v.Infer<typeof pushBodySchema>;
 export type PushMessage = v.Infer<typeof pushMessageSchema>;
 export type PushResponse = v.Infer<typeof pushResponseSchema>;
 export type MutationResponse = v.Infer<typeof mutationResponseSchema>;
+export type MutationOk = v.Infer<typeof mutationOkSchema>;
+export type MutationError = v.Infer<typeof mutationErrorSchema>;
+export type PushError = v.Infer<typeof pushErrorSchema>;
+export type PushOk = v.Infer<typeof pushOkSchema>;
+export type MutationID = v.Infer<typeof mutationIDSchema>;
 
 export function mapCRUD(
   arg: CRUDMutationArg,


### PR DESCRIPTION
Start threading mutation results back to the client. This class tracks in-flight mutations on the client.

Next up:

1. Return a stream from `pusher`, on the server, to be proxied down to the client --

https://github.com/rocicorp/mono/blob/06697185aea4770c5aa7063e2f2012d0136ebe5f/packages/zero-cache/src/workers/connection.ts#L184-L192

2. Update `makeReplicacheMutator` so the mutator invokes the `mutation-tracker` on `initial` run of the mutation and that promise is returned to the caller

https://github.com/rocicorp/mono/blob/06697185aea4770c5aa7063e2f2012d0136ebe5f/packages/zero-client/src/client/custom.ts#L119-L129

3. Deal with client side edge cases: connection closed, connection not open.
   - Probably neither of these reject the mutation since they'll be retried in those cases.