### PR TITLE
chore(zero-cache): rewrite logical replication on postgres.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27016,6 +27016,7 @@
       },
       "devDependencies": {
         "@faker-js/faker": "^9.6.0",
+        "@rocicorp/eslint-config": "^0.7.0",
         "@rocicorp/prettier-config": "^0.3.0",
         "@vitest/runner": "3.0.8",
         "vitest": "3.0.8"
@@ -27115,6 +27116,7 @@
         "@rocicorp/zero-sqlite3": "^1.0.4",
         "chalk": "^5.3.0",
         "compare-utf8": "^0.1.1",
+        "defu": "^6.1.4",
         "dotenv": "^16.4.5",
         "eventemitter3": "^5.0.1",
         "fastify": "^5.0.0",
@@ -44894,6 +44896,7 @@
         "@databases/escape-identifier": "^1.0.3",
         "@databases/sql": "^3.3.0",
         "@faker-js/faker": "^9.6.0",
+        "@rocicorp/eslint-config": "^0.7.0",
         "@rocicorp/prettier-config": "^0.3.0",
         "@vitest/runner": "3.0.8",
         "vitest": "3.0.8"
@@ -45120,6 +45123,7 @@
         "chalk": "^5.3.0",
         "compare-utf8": "^0.1.1",
         "concurrently": "^8.2.1",
+        "defu": "^6.1.4",
         "dotenv": "^16.4.5",
         "eventemitter3": "^5.0.1",
         "fastify": "^5.0.0",

--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -35,6 +35,7 @@
     "@rocicorp/zero-sqlite3": "^1.0.4",
     "chalk": "^5.3.0",
     "compare-utf8": "^0.1.1",
+    "defu": "^6.1.4",
     "dotenv": "^16.4.5",
     "eventemitter3": "^5.0.1",
     "fastify": "^5.0.0",

--- a/packages/zero-cache/src/services/change-source/pg/logical-replication/binary-reader.ts
+++ b/packages/zero-cache/src/services/change-source/pg/logical-replication/binary-reader.ts
@@ -1,0 +1,98 @@
+// Forked from https://github.com/kibae/pg-logical-replication/blob/c55abddc62eadd61bd38922037ecb7a1469fa8c3/src/output-plugins/pgoutput/binary-reader.ts
+/* eslint-disable */
+
+// should not use { fatal: true } because ErrorResponse can use invalid utf8 chars
+const textDecoder = new TextDecoder();
+
+// https://www.postgresql.org/docs/14/protocol-message-types.html
+export class BinaryReader {
+  _p = 0;
+  constructor(private _b: Uint8Array) {}
+
+  readUint8() {
+    this.checkSize(1);
+
+    return this._b[this._p++];
+  }
+
+  readInt16() {
+    this.checkSize(2);
+
+    return (this._b[this._p++] << 8) | this._b[this._p++];
+  }
+
+  readInt32() {
+    this.checkSize(4);
+
+    return (
+      (this._b[this._p++] << 24) |
+      (this._b[this._p++] << 16) |
+      (this._b[this._p++] << 8) |
+      this._b[this._p++]
+    );
+  }
+
+  readString() {
+    const endIdx = this._b.indexOf(0x00, this._p);
+
+    if (endIdx < 0) {
+      // TODO PgError.protocol_violation
+      throw Error('unexpected end of message');
+    }
+
+    const strBuf = this._b.subarray(this._p, endIdx);
+    this._p = endIdx + 1;
+
+    return this.decodeText(strBuf);
+  }
+
+  decodeText(strBuf: Uint8Array) {
+    return textDecoder.decode(strBuf);
+  }
+
+  read(n: number) {
+    this.checkSize(n);
+
+    return this._b.subarray(this._p, (this._p += n));
+  }
+
+  checkSize(n: number) {
+    if (this._b.length < this._p + n) {
+      // TODO PgError.protocol_violation
+      throw Error('unexpected end of message');
+    }
+  }
+
+  array<T>(length: number, fn: () => T): T[] {
+    return Array.from({length}, fn, this);
+  }
+
+  // replication helpers
+  readLsn() {
+    const h = this.readUint32();
+    const l = this.readUint32();
+
+    if (h === 0 && l === 0) {
+      return null;
+    }
+
+    return `${h.toString(16).padStart(8, '0')}/${l
+      .toString(16)
+      .padStart(8, '0')}`.toUpperCase();
+  }
+
+  readTime() {
+    // (POSTGRES_EPOCH_JDATE - UNIX_EPOCH_JDATE) * USECS_PER_DAY == 946684800000000
+    return this.readUint64() + BigInt('946684800000000');
+  }
+
+  readUint64() {
+    return (
+      (BigInt(this.readUint32()) << BigInt(32)) | BigInt(this.readUint32())
+    );
+  }
+
+  readUint32() {
+    return this.readInt32() >>> 0;
+  }
+}

--- a/packages/zero-cache/src/services/change-source/pg/logical-replication/pgoutput-parser.ts
+++ b/packages/zero-cache/src/services/change-source/pg/logical-replication/pgoutput-parser.ts
@@ -1,0 +1,334 @@
+// Forked from https://github.com/kibae/pg-logical-replication/blob/c55abddc62eadd61bd38922037ecb7a1469fa8c3/src/output-plugins/pgoutput/pgoutput-parser.ts
+/* eslint-disable */
+
+// https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html
+
+// Replaced by TypeParsers
+// import {types} from 'pg';
+
+export type TypeParser = (val: string) => unknown;
+
+import {BinaryReader} from './binary-reader.ts';
+import type {
+  Message,
+  MessageBegin,
+  MessageCommit,
+  MessageDelete,
+  MessageInsert,
+  MessageMessage,
+  MessageOrigin,
+  MessageRelation,
+  MessageTruncate,
+  MessageType,
+  MessageUpdate,
+  RelationColumn,
+} from './pgoutput.types.ts';
+
+export class PgoutputParser {
+  _typeCache = new Map<number, {typeSchema: string; typeName: string}>();
+  _relationCache = new Map<number, MessageRelation>();
+
+  // Replaces "pg-types" library.
+  #typeParsers: Record<number, TypeParser>;
+  constructor(typeParsers: Record<number, TypeParser>) {
+    this.#typeParsers = typeParsers;
+  }
+  #getTypeParser(typeOid: number): TypeParser {
+    // The absence of a TypeParser defaults to "noParse", mimicking
+    // the behavior in pg-types:
+    // https://github.com/brianc/node-pg-types/blob/5b26b826466cff4a9092b8c9e31960fe293ef3d9/index.js#L15
+    return this.#typeParsers[typeOid] ?? String;
+  }
+  // Replaced "pg-types" library.
+
+  public parse(buf: Buffer): Message {
+    const reader = new BinaryReader(buf);
+    const tag = reader.readUint8();
+
+    switch (tag) {
+      case 0x42 /*B*/:
+        return this.msgBegin(reader);
+      case 0x4f /*O*/:
+        return this.msgOrigin(reader);
+      case 0x59 /*Y*/:
+        return this.msgType(reader);
+      case 0x52 /*R*/:
+        return this.msgRelation(reader);
+      case 0x49 /*I*/:
+        return this.msgInsert(reader);
+      case 0x55 /*U*/:
+        return this.msgUpdate(reader);
+      case 0x44 /*D*/:
+        return this.msgDelete(reader);
+      case 0x54 /*T*/:
+        return this.msgTruncate(reader);
+      case 0x4d /*M*/:
+        return this.msgMessage(reader);
+      case 0x43 /*C*/:
+        return this.msgCommit(reader);
+      default:
+        throw Error('unknown pgoutput message');
+    }
+  }
+
+  private msgBegin(reader: BinaryReader): MessageBegin {
+    // TODO lsn can be null if origin sended
+    // https://github.com/postgres/postgres/blob/85c61ba8920ba73500e1518c63795982ee455d14/src/backend/replication/pgoutput/pgoutput.c#L409
+    // https://github.com/postgres/postgres/blob/27b77ecf9f4d5be211900eda54d8155ada50d696/src/include/replication/reorderbuffer.h#L275
+
+    return {
+      tag: 'begin',
+      commitLsn: reader.readLsn(),
+      commitTime: reader.readTime(),
+      xid: reader.readInt32(),
+    };
+  }
+
+  private msgOrigin(reader: BinaryReader): MessageOrigin {
+    return {
+      tag: 'origin',
+      originLsn: reader.readLsn(),
+      originName: reader.readString(),
+    };
+  }
+
+  private msgType(reader: BinaryReader): MessageType {
+    const typeOid = reader.readInt32();
+    const typeSchema = reader.readString();
+    const typeName = reader.readString();
+
+    // mem leak not likely to happen because amount of types is usually small
+    this._typeCache.set(typeOid, {typeSchema, typeName});
+
+    return {tag: 'type', typeOid, typeSchema, typeName};
+  }
+
+  private msgRelation(reader: BinaryReader): MessageRelation {
+    // lsn expected to be null
+    // https://github.com/postgres/postgres/blob/27b77ecf9f4d5be211900eda54d8155ada50d696/src/backend/replication/walsender.c#L1342
+    const relationOid = reader.readInt32();
+    const schema = reader.readString();
+    const name = reader.readString();
+    const replicaIdentity = this.readRelationReplicaIdentity(reader);
+    const columns = reader.array(reader.readInt16(), () =>
+      this.readRelationColumn(reader),
+    );
+    const keyColumns = columns.filter(it => it.flags & 0b1).map(it => it.name);
+
+    const msg: MessageRelation = {
+      tag: 'relation',
+      relationOid,
+      schema,
+      name,
+      replicaIdentity,
+      columns,
+      keyColumns,
+    };
+
+    // mem leak not likely to happen because amount of relations is usually small
+    this._relationCache.set(relationOid, msg);
+
+    return msg;
+  }
+
+  private readRelationReplicaIdentity(reader: BinaryReader) {
+    // https://www.postgresql.org/docs/14/catalog-pg-class.html
+    const ident = reader.readUint8();
+
+    switch (ident) {
+      case 0x64 /*d*/:
+        return 'default';
+      case 0x6e /*n*/:
+        return 'nothing';
+      case 0x66 /*f*/:
+        return 'full';
+      case 0x69 /*i*/:
+        return 'index';
+      default:
+        throw Error(`unknown replica identity ${String.fromCharCode(ident)}`);
+    }
+  }
+
+  private readRelationColumn(reader: BinaryReader): RelationColumn {
+    const flags = reader.readUint8();
+    const name = reader.readString();
+    const typeOid = reader.readInt32();
+    const typeMod = reader.readInt32();
+
+    return {
+      flags,
+      name,
+      typeOid,
+      typeMod,
+      typeSchema: null,
+      typeName: null, // TODO resolve builtin type names?
+      ...this._typeCache.get(typeOid),
+      // parser: types.getTypeParser(typeOid),
+      parser: this.#getTypeParser(typeOid),
+    };
+  }
+
+  private msgInsert(reader: BinaryReader): MessageInsert {
+    const relation = this._relationCache.get(reader.readInt32());
+
+    if (!relation) {
+      throw Error('missing relation');
+    }
+
+    reader.readUint8(); // consume the 'N' key
+
+    return {
+      tag: 'insert',
+      relation,
+      new: this.readTuple(reader, relation),
+    };
+  }
+
+  private msgUpdate(reader: BinaryReader): MessageUpdate {
+    const relation = this._relationCache.get(reader.readInt32());
+
+    if (!relation) {
+      throw Error('missing relation');
+    }
+
+    let key: Record<string, any> | null = null;
+    let old: Record<string, any> | null = null;
+    let new_: Record<string, any> | null = null;
+    const subMsgKey = reader.readUint8();
+
+    if (subMsgKey === 0x4b /*K*/) {
+      key = this.readKeyTuple(reader, relation);
+      reader.readUint8(); // consume the 'N' key
+      new_ = this.readTuple(reader, relation);
+    } else if (subMsgKey === 0x4f /*O*/) {
+      old = this.readTuple(reader, relation);
+      reader.readUint8(); // consume the 'N' key
+      new_ = this.readTuple(reader, relation, old);
+    } else if (subMsgKey === 0x4e /*N*/) {
+      new_ = this.readTuple(reader, relation);
+    } else {
+      throw Error(`unknown submessage key ${String.fromCharCode(subMsgKey)}`);
+    }
+
+    return {tag: 'update', relation, key, old, new: new_};
+  }
+
+  private msgDelete(reader: BinaryReader): MessageDelete {
+    const relation = this._relationCache.get(reader.readInt32());
+
+    if (!relation) {
+      throw Error('missing relation');
+    }
+
+    let key: Record<string, any> | null = null;
+    let old: Record<string, any> | null = null;
+    const subMsgKey = reader.readUint8();
+
+    if (subMsgKey === 0x4b /*K*/) {
+      key = this.readKeyTuple(reader, relation);
+    } else if (subMsgKey === 0x4f /*O*/) {
+      old = this.readTuple(reader, relation);
+    } else {
+      throw Error(`unknown submessage key ${String.fromCharCode(subMsgKey)}`);
+    }
+
+    return {tag: 'delete', relation, key, old};
+  }
+
+  private readKeyTuple(
+    reader: BinaryReader,
+    relation: MessageRelation,
+  ): Record<string, any> {
+    const tuple = this.readTuple(reader, relation);
+    const key = Object.create(null);
+
+    for (const k of relation.keyColumns) {
+      // If value is `null`, then it is definitely not part of key,
+      // because key cannot have nulls by documentation.
+      // And if we got `null` while reading keyOnly tuple,
+      // then it means that `null` is not actual value
+      // but placeholder of non-key column.
+      key[k] = tuple[k] === null ? undefined : tuple[k];
+    }
+
+    return key;
+  }
+
+  private readTuple(
+    reader: BinaryReader,
+    {columns}: MessageRelation,
+    unchangedToastFallback?: Record<string, any> | null,
+  ): Record<string, any> {
+    const nfields = reader.readInt16();
+    const tuple = Object.create(null);
+
+    for (let i = 0; i < nfields; i++) {
+      const {name, parser} = columns[i];
+      const kind = reader.readUint8();
+
+      switch (kind) {
+        case 0x62: // 'b' binary
+          const bsize = reader.readInt32();
+          const bval = reader.read(bsize);
+          // dont need to .slice() because new buffer
+          // is created for each replication chunk
+          tuple[name] = bval;
+          break;
+        case 0x74: // 't' text
+          const valsize = reader.readInt32();
+          const valbuf = reader.read(valsize);
+          const valtext = reader.decodeText(valbuf);
+          tuple[name] = parser(valtext);
+          break;
+        case 0x6e: // 'n' null
+          tuple[name] = null;
+          break;
+        case 0x75: // 'u' unchanged toast datum
+          tuple[name] = unchangedToastFallback?.[name];
+          break;
+        default:
+          throw Error(`unknown attribute kind ${String.fromCharCode(kind)}`);
+      }
+    }
+
+    return tuple;
+  }
+
+  private msgTruncate(reader: BinaryReader): MessageTruncate {
+    const nrels = reader.readInt32();
+    const flags = reader.readUint8();
+
+    return {
+      tag: 'truncate',
+      cascade: Boolean(flags & 0b1),
+      restartIdentity: Boolean(flags & 0b10),
+      relations: reader.array(
+        nrels,
+        () => this._relationCache.get(reader.readInt32()) as MessageRelation,
+      ),
+    };
+  }
+
+  private msgMessage(reader: BinaryReader): MessageMessage {
+    const flags = reader.readUint8();
+
+    return {
+      tag: 'message',
+      flags,
+      transactional: Boolean(flags & 0b1),
+      messageLsn: reader.readLsn(),
+      prefix: reader.readString(),
+      content: reader.read(reader.readInt32()),
+    };
+  }
+
+  private msgCommit(reader: BinaryReader): MessageCommit {
+    return {
+      tag: 'commit',
+      flags: reader.readUint8(), // reserved unused
+      commitLsn: reader.readLsn(), // should be the same as begin.commitLsn
+      commitEndLsn: reader.readLsn(),
+      commitTime: reader.readTime(),
+    };
+  }
+}

--- a/packages/zero-cache/src/services/change-source/pg/logical-replication/pgoutput.types.ts
+++ b/packages/zero-cache/src/services/change-source/pg/logical-replication/pgoutput.types.ts
@@ -1,0 +1,107 @@
+// Forked from https://github.com/kibae/pg-logical-replication/blob/c55abddc62eadd61bd38922037ecb7a1469fa8c3/src/output-plugins/pgoutput/pgoutput.types.ts
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// https://www.postgresql.org/docs/current/protocol-logical-replication.html#PROTOCOL-LOGICAL-REPLICATION-PARAMS
+
+// export interface Options {
+//   protoVersion: 1 | 2
+//   publicationNames: string[]
+//   messages?: boolean
+// }
+
+export type Message =
+  | MessageBegin
+  | MessageCommit
+  | MessageDelete
+  | MessageInsert
+  | MessageMessage
+  | MessageOrigin
+  | MessageRelation
+  | MessageTruncate
+  | MessageType
+  | MessageUpdate;
+
+export interface MessageBegin {
+  tag: 'begin';
+  commitLsn: string | null;
+  commitTime: bigint;
+  xid: number;
+}
+
+export interface MessageCommit {
+  tag: 'commit';
+  flags: number;
+  commitLsn: string | null;
+  commitEndLsn: string | null;
+  commitTime: bigint;
+}
+
+export interface MessageDelete {
+  tag: 'delete';
+  relation: MessageRelation;
+  key: Record<string, any> | null;
+  old: Record<string, any> | null;
+}
+
+export interface MessageInsert {
+  tag: 'insert';
+  relation: MessageRelation;
+  new: Record<string, any>;
+}
+
+export interface MessageMessage {
+  tag: 'message';
+  flags: number;
+  transactional: boolean;
+  messageLsn: string | null;
+  prefix: string;
+  content: Uint8Array;
+}
+
+export interface MessageOrigin {
+  tag: 'origin';
+  originLsn: string | null;
+  originName: string;
+}
+
+export interface MessageRelation {
+  tag: 'relation';
+  relationOid: number;
+  schema: string;
+  name: string;
+  replicaIdentity: 'default' | 'nothing' | 'full' | 'index';
+  columns: RelationColumn[];
+  keyColumns: string[];
+}
+
+export interface RelationColumn {
+  name: string;
+  flags: number;
+  typeOid: number;
+  typeMod: number;
+  typeSchema: string | null;
+  typeName: string | null;
+  parser: (raw: any) => any;
+}
+
+export interface MessageTruncate {
+  tag: 'truncate';
+  cascade: boolean;
+  restartIdentity: boolean;
+  relations: MessageRelation[];
+}
+
+export interface MessageType {
+  tag: 'type';
+  typeOid: number;
+  typeSchema: string;
+  typeName: string;
+}
+
+export interface MessageUpdate {
+  tag: 'update';
+  relation: MessageRelation;
+  key: Record<string, any> | null;
+  old: Record<string, any> | null;
+  new: Record<string, any>;
+}

--- a/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.pg-test.ts
@@ -1,0 +1,440 @@
+import {LogContext} from '@rocicorp/logger';
+import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {createSilentLogContext} from '../../../../../../shared/src/logging-test-utils.ts';
+import {must} from '../../../../../../shared/src/must.ts';
+import {Queue} from '../../../../../../shared/src/queue.ts';
+import {sleep} from '../../../../../../shared/src/sleep.ts';
+import {dropReplicationSlots, testDBs} from '../../../../test/db.ts';
+import type {PostgresDB} from '../../../../types/pg.ts';
+import type {Source} from '../../../../types/streams.ts';
+import {fromBigInt, toBigInt, type LSN} from '../lsn.ts';
+import type {MessageCommit} from './pgoutput.types.ts';
+import {subscribe, type StreamMessage} from './stream.ts';
+
+describe('pg/logic-replication', {timeout: 30000}, () => {
+  let lc: LogContext;
+  let db: PostgresDB;
+
+  const SLOT = 'logical_replication_stream_pg_test_slot';
+
+  beforeEach(async () => {
+    lc = createSilentLogContext();
+    db = await testDBs.create('logical_replication_stream_pg_test');
+
+    await db.unsafe(`
+    CREATE TABLE foo(
+      id TEXT CONSTRAINT foo_pk PRIMARY KEY,
+      int INT4,
+      big BIGINT,
+      flt FLOAT8,
+      bool BOOLEAN,
+      date DATE,
+      time TIMESTAMPTZ,
+      json JSON,
+      num NUMERIC,
+      ints INT4[],
+      times TIMESTAMPTZ[]
+    );
+    CREATE PUBLICATION foo_pub FOR TABLE foo;
+
+    CREATE SCHEMA IF NOT EXISTS my;
+    CREATE TABLE my.boo(
+      a TEXT PRIMARY KEY, b TEXT, c TEXT, d TEXT
+    );
+    CREATE PUBLICATION my_pub FOR TABLES IN SCHEMA my;`);
+
+    await db`SELECT pg_create_logical_replication_slot(${SLOT}, 'pgoutput');`;
+  });
+
+  afterEach(async () => {
+    await dropReplicationSlots(db);
+    await testDBs.drop(db);
+  });
+
+  function drainToQueue(sub: Source<StreamMessage>): Queue<StreamMessage[1]> {
+    const queue = new Queue<StreamMessage[1]>();
+    void (async () => {
+      try {
+        for await (const msg of sub) {
+          queue.enqueue(msg[1]);
+        }
+      } catch (e) {
+        queue.enqueueRejection(e);
+      }
+    })();
+    return queue;
+  }
+
+  async function expectMessages(queue: Queue<StreamMessage[1]>, count: number) {
+    const msgs: StreamMessage[1][] = [];
+    for (let i = 0; i < count; i++) {
+      msgs.push(await queue.dequeue());
+    }
+    return msgs;
+  }
+
+  async function expectConfirmedFlushLSN(lsn: LSN | null) {
+    const expected = fromBigInt(toBigInt(lsn ?? '0/0'));
+
+    // Since there's no reliable mechanism to wait for the ack to have
+    // been processed by postgres, add retries with sleeps in between.
+    const MAX_ATTEMPTS = 10;
+
+    for (let i = 0; i < MAX_ATTEMPTS; i++) {
+      const [{confirmed}] = await db<{confirmed: string}[]>`
+        SELECT confirmed_flush_lsn as confirmed FROM pg_replication_slots
+          WHERE slot_name = ${SLOT}`;
+      if (confirmed === expected) {
+        return;
+      }
+      if (i < MAX_ATTEMPTS - 1) {
+        await sleep(100);
+      } else {
+        expect(confirmed).toBe(expected);
+      }
+    }
+  }
+
+  test('logical replication messages', async () => {
+    const {messages} = await subscribe(lc, db, SLOT, ['foo_pub', 'my_pub'], 0n);
+    const msgs = drainToQueue(messages);
+
+    await db.unsafe(`
+    -- tag: "insert"
+    INSERT INTO foo (id, int, big, flt, bool, date, time, json, num, ints, times)
+      VALUES (
+        'bar', 
+        123, 
+        '123456789098765432'::bigint,
+        456.789,
+        true,
+        '2025-03-19',
+        '2019-01-12T00:30:35.381101032Z',
+        '{"zoo":"dar"}',
+        '12345.678909876',
+        ARRAY[1, 2, 3],
+        ARRAY['2019-01-12T00:30:35.654321'::timestamp, '2019-01-12T00:30:35.123456'::timestamp]
+        );
+
+    -- tag: "update"
+    UPDATE foo set bool = false;
+
+    -- tag: "delete"
+    DELETE FROM foo;
+    
+    -- multiple publication support
+    INSERT INTO my.boo(a, b, c, d) VALUES ('1', '2', '3', '4');
+
+    -- tag: "truncate"
+    TRUNCATE my.boo, foo;
+
+    -- tag: "message"
+    SELECT pg_logical_emit_message(true, 'foo/bar', 'baz');
+    `);
+
+    expect(await msgs.dequeue()).toMatchObject({tag: 'begin'});
+    expect(await msgs.dequeue()).toMatchObject({
+      tag: 'relation',
+      schema: 'public',
+      name: 'foo',
+      keyColumns: ['id'],
+      relationOid: expect.any(Number),
+      replicaIdentity: 'default',
+    });
+    expect(await msgs.dequeue()).toMatchObject({
+      tag: 'insert',
+      relation: {name: 'foo'},
+      new: {
+        big: 123456789098765432n,
+        bool: true,
+        date: 1742342400000,
+        flt: 456.789,
+        id: 'bar',
+        int: 123,
+        json: {zoo: 'dar'},
+        num: 12345.678909876,
+        time: 1547253035381.101,
+        ints: [1, 2, 3],
+        times: [1547253035654.321, 1547253035123.456],
+      },
+    });
+    expect(await msgs.dequeue()).toMatchObject({
+      tag: 'update',
+      relation: {name: 'foo'},
+      key: null,
+      new: {
+        big: 123456789098765432n,
+        bool: false,
+        date: 1742342400000,
+        flt: 456.789,
+        id: 'bar',
+        int: 123,
+        json: {zoo: 'dar'},
+        num: 12345.678909876,
+        time: 1547253035381.101,
+      },
+      old: null,
+    });
+    expect(await msgs.dequeue()).toMatchObject({
+      tag: 'delete',
+      relation: {name: 'foo'},
+      key: {id: 'bar'},
+      old: null,
+    });
+    expect(await msgs.dequeue()).toMatchObject({
+      tag: 'relation',
+      schema: 'my',
+      name: 'boo',
+      relationOid: expect.any(Number),
+      replicaIdentity: 'default',
+    });
+    expect(await msgs.dequeue()).toMatchObject({
+      tag: 'insert',
+      new: {a: '1', b: '2', c: '3', d: '4'},
+      relation: {name: 'boo'},
+    });
+    expect(await msgs.dequeue()).toMatchObject({
+      tag: 'relation',
+      schema: 'my',
+      name: 'boo',
+    });
+    expect(await msgs.dequeue()).toMatchObject({
+      tag: 'relation',
+      schema: 'public',
+      name: 'foo',
+    });
+    expect(await msgs.dequeue()).toMatchObject({
+      tag: 'truncate',
+      restartIdentity: false,
+      cascade: false,
+      relations: [
+        {
+          tag: 'relation',
+          schema: 'my',
+          name: 'boo',
+        },
+        {
+          tag: 'relation',
+          schema: 'public',
+          name: 'foo',
+        },
+      ],
+    });
+    expect(await msgs.dequeue()).toMatchObject({
+      tag: 'message',
+      prefix: 'foo/bar',
+      content: Buffer.from([98, 97, 122]), // 'b', 'a', 'z'
+      flags: 1,
+      transactional: true,
+    });
+    expect(await msgs.dequeue()).toMatchObject({tag: 'commit'});
+  });
+
+  test('acks', async () => {
+    const {messages, acks} = await subscribe(
+      lc,
+      db,
+      SLOT,
+      ['foo_pub', 'my_pub'],
+      0n,
+    );
+    const msgs = drainToQueue(messages);
+
+    await db.unsafe(`
+    INSERT INTO my.boo(a, b, c, d) VALUES ('1', '2', '3', '4');
+    `);
+
+    await db.unsafe(`
+      INSERT INTO my.boo(a, b, c, d) VALUES ('e', 'f', 'g', 'h');
+    `);
+
+    await db.unsafe(`
+      INSERT INTO my.boo(a, b, c, d) VALUES ('w', 'x', 'y', 'z');
+    `);
+
+    const [
+      begin1,
+      relation1,
+      insert1,
+      commit1,
+      begin2,
+      insert2,
+      commit2,
+      begin3,
+      insert3,
+      commit3,
+    ] = await expectMessages(msgs, 10);
+
+    expect(begin1.tag).toBe('begin');
+    expect(relation1.tag).toBe('relation');
+    expect(insert1.tag).toBe('insert');
+    expect(commit1.tag).toBe('commit');
+
+    expect(begin2.tag).toBe('begin');
+    expect(insert2.tag).toBe('insert');
+    expect(commit2.tag).toBe('commit');
+
+    expect(begin3.tag).toBe('begin');
+    expect(insert3.tag).toBe('insert');
+    expect(commit3.tag).toBe('commit');
+
+    for (const commit of [commit1, commit2, commit3] as MessageCommit[]) {
+      const lsn = toBigInt(must(commit.commitLsn));
+      acks.push(lsn);
+      await expectConfirmedFlushLSN(commit.commitLsn);
+    }
+  });
+
+  test('session resumption from confirmed flushes', async () => {
+    // Interleave commits from three different transactions.
+    const queue1 = new Queue<true>();
+    const queue2 = new Queue<true>();
+    const queue3 = new Queue<true>();
+
+    const tx1 = db.begin(async tx => {
+      queue2.enqueue(true);
+      await queue1.dequeue();
+      await tx`INSERT INTO foo(id) VALUES ('1');`;
+      queue2.enqueue(true);
+      await queue1.dequeue();
+      await tx`INSERT INTO foo(id) VALUES ('11');`;
+      queue2.enqueue(true);
+    });
+
+    await queue2.dequeue();
+    const tx2 = db.begin(async tx => {
+      queue3.enqueue(true);
+      await queue2.dequeue();
+      await tx`INSERT INTO foo(id) VALUES ('2');`;
+      queue3.enqueue(true);
+      await queue2.dequeue();
+      await tx`INSERT INTO foo(id) VALUES ('22');`;
+      queue3.enqueue(true);
+    });
+
+    await queue3.dequeue();
+    const tx3 = db.begin(async tx => {
+      queue1.enqueue(true);
+      await queue3.dequeue();
+      await tx`INSERT INTO foo(id) VALUES ('3');`;
+      queue1.enqueue(true);
+      await queue3.dequeue();
+      await tx`INSERT INTO foo(id) VALUES ('33');`;
+      queue1.enqueue(true);
+    });
+
+    await Promise.all([tx1, tx2, tx3]);
+
+    const sub1 = await subscribe(lc, db, SLOT, ['foo_pub', 'my_pub'], 0n);
+
+    const msgs1 = await expectMessages(drainToQueue(sub1.messages), 13);
+    expect(msgs1.map(({tag}) => tag)).toEqual([
+      'begin', // 0
+      'relation', // 1
+      'insert', // 2
+      'insert', // 3
+      'commit', // 4
+
+      'begin', // 5
+      'insert', // 6
+      'insert', // 7
+      'commit', // 8
+
+      'begin', // 9
+      'insert', // 10
+      'insert', // 11
+      'commit', // 12
+    ]);
+
+    expect(msgs1[2]).toMatchObject({
+      tag: 'insert',
+      new: {id: '1'},
+      relation: {
+        tag: 'relation',
+        name: 'foo',
+      },
+    });
+    expect(msgs1[3]).toMatchObject({
+      tag: 'insert',
+      new: {id: '11'},
+      relation: {
+        tag: 'relation',
+        name: 'foo',
+      },
+    });
+    const commit1 = msgs1[4] as MessageCommit;
+    const commit1Lsn = toBigInt(must(commit1.commitEndLsn));
+    sub1.acks.push(commit1Lsn);
+    sub1.messages.cancel();
+    await expectConfirmedFlushLSN(commit1.commitEndLsn);
+
+    // Sub2 should resume from the second transaction.
+    const sub2 = await subscribe(lc, db, SLOT, ['foo_pub', 'my_pub'], 0n);
+    const msgs2 = await expectMessages(drainToQueue(sub2.messages), 9);
+    expect(msgs2.map(({tag}) => tag)).toEqual([
+      'begin', // 0
+      'relation', // 1
+      'insert', // 2
+      'insert', // 3
+      'commit', // 4
+
+      'begin', // 5
+      'insert', // 6
+      'insert', // 7
+      'commit', // 8
+    ]);
+    expect(msgs2[2]).toMatchObject({
+      tag: 'insert',
+      new: {id: '2'},
+      relation: {
+        tag: 'relation',
+        name: 'foo',
+      },
+    });
+    expect(msgs2[3]).toMatchObject({
+      tag: 'insert',
+      new: {id: '22'},
+      relation: {
+        tag: 'relation',
+        name: 'foo',
+      },
+    });
+    const commit2 = msgs2[4] as MessageCommit;
+    const commit2Lsn = toBigInt(must(commit2.commitEndLsn));
+    sub2.acks.push(commit2Lsn);
+    sub2.messages.cancel();
+    await expectConfirmedFlushLSN(commit2.commitEndLsn);
+
+    // Sub3 should resume from the third transaction.
+    const sub3 = await subscribe(lc, db, SLOT, ['foo_pub', 'my_pub'], 0n);
+    const msgs3 = await expectMessages(drainToQueue(sub3.messages), 5);
+    expect(msgs3.map(({tag}) => tag)).toEqual([
+      'begin', // 0
+      'relation', // 1
+      'insert', // 2
+      'insert', // 3
+      'commit', // 4
+    ]);
+    expect(msgs3[2]).toMatchObject({
+      tag: 'insert',
+      new: {id: '3'},
+      relation: {
+        tag: 'relation',
+        name: 'foo',
+      },
+    });
+    expect(msgs3[3]).toMatchObject({
+      tag: 'insert',
+      new: {id: '33'},
+      relation: {
+        tag: 'relation',
+        name: 'foo',
+      },
+    });
+    const commit3 = msgs3[4] as MessageCommit;
+    const commit3Lsn = toBigInt(must(commit3.commitEndLsn));
+    sub3.acks.push(commit3Lsn);
+    sub3.messages.cancel();
+    await expectConfirmedFlushLSN(commit3.commitEndLsn);
+  });
+});

--- a/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.ts
+++ b/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.ts
@@ -1,0 +1,140 @@
+import type {LogContext} from '@rocicorp/logger';
+import {defu} from 'defu';
+import postgres, {type Options, type PostgresType} from 'postgres';
+import {assert} from '../../../../../../shared/src/asserts.ts';
+import {mapValues} from '../../../../../../shared/src/objects.ts';
+import {type PostgresDB} from '../../../../types/pg.ts';
+import {pipe, type Sink, type Source} from '../../../../types/streams.ts';
+import {Subscription} from '../../../../types/subscription.ts';
+import {fromBigInt} from '../lsn.ts';
+import {PgoutputParser} from './pgoutput-parser.ts';
+import type {Message} from './pgoutput.types.ts';
+
+// Arbitrary array type to test if the PostgresDB client has fetched types.
+const INT4_ARRAY_TYPE = 1007;
+
+export type StreamMessage = [lsn: bigint, Message | {tag: 'keepalive'}];
+
+export async function subscribe(
+  lc: LogContext,
+  db: PostgresDB,
+  slot: string,
+  publications: string[],
+  lsn: bigint,
+  applicationName = 'zero-replicator',
+): Promise<{messages: Source<StreamMessage>; acks: Sink<bigint>}> {
+  const session = postgres(
+    defu(
+      {
+        max: 1,
+        ['fetch_types']: false, // Necessary for the streaming protocol
+        ['idle_timeout']: null,
+        ['max_lifetime']: null as unknown as number,
+        connection: {
+          ['application_name']: applicationName,
+          replication: 'database', // https://www.postgresql.org/docs/current/protocol-replication.html
+        },
+      },
+      // ParsedOptions are technically compatible with Options, but happen
+      // to not be typed that way. The postgres.js author does an equivalent
+      // merge of ParsedOptions and Options here:
+      // https://github.com/porsager/postgres/blob/089214e85c23c90cf142d47fb30bd03f42874984/src/subscribe.js#L13
+      db.options as unknown as Options<Record<string, PostgresType>>,
+    ),
+  );
+
+  const lsnString = fromBigInt(lsn);
+  const stream = session
+    .unsafe(
+      `START_REPLICATION SLOT "${slot}" LOGICAL ${lsnString} (
+        proto_version '1', 
+        publication_names '${publications}',
+        messages 'true'
+      )`,
+    )
+    .execute();
+  const [readable, writable] = await Promise.all([
+    stream.readable(),
+    stream.writable(),
+  ]);
+  lc.debug?.(`started replication stream at ${slot} from ${lsnString}`);
+
+  const typeParsers = await getTypeParsers(lc, db);
+  const parser = new PgoutputParser(typeParsers);
+  const messages = Subscription.create<StreamMessage>({
+    cleanup: () => readable.destroyed || readable.destroy(),
+  });
+
+  pipe(readable, messages, buffer => parseStreamMessage(lc, buffer, parser));
+
+  return {
+    messages,
+    acks: {push: (lsn: bigint) => writable.write(makeAck(lsn))},
+  };
+}
+
+function parseStreamMessage(
+  lc: LogContext,
+  buffer: Buffer,
+  parser: PgoutputParser,
+): StreamMessage | null {
+  // https://www.postgresql.org/docs/current/protocol-replication.html#PROTOCOL-REPLICATION-XLOGDATA
+  if (buffer[0] !== 0x77 && buffer[0] !== 0x6b) {
+    lc.warn?.('Unknown message', buffer[0]);
+    return null;
+  }
+  const lsn = buffer.readBigUInt64BE(1);
+  return buffer[0] === 0x77 // XLogData
+    ? [lsn, parser.parse(buffer.subarray(25))]
+    : buffer.readInt8(17) // Primary keepalive message: shouldRespond
+    ? [lsn, {tag: 'keepalive'}]
+    : null;
+}
+
+// https://www.postgresql.org/docs/current/protocol-replication.html#PROTOCOL-REPLICATION-STANDBY-STATUS-UPDATE
+function makeAck(lsn: bigint): Buffer {
+  const microNow = BigInt(Date.now() - Date.UTC(2000, 0, 1)) * BigInt(1000);
+
+  const x = Buffer.alloc(34);
+  x[0] = 'r'.charCodeAt(0);
+  x.writeBigInt64BE(lsn, 1);
+  x.writeBigInt64BE(lsn, 9);
+  x.writeBigInt64BE(lsn, 17);
+  x.writeBigInt64BE(microNow, 25);
+  return x;
+}
+
+// postgres.js has default type parsers with user-defined overrides
+// configurable per-client (see `postgresTypeConfig` in types/pg.ts).
+//
+// From these, the postgres.js client will automatically derive parsers
+// for array versions of these types, provided that the client was
+// configured with `fetch_types: true` (which is the default).
+//
+// A replication session (with `database: replication`), however, does
+// not support this type fetching, so it is done on a connection from
+// a default client.
+async function getTypeParsers(lc: LogContext, db: PostgresDB) {
+  if (!db.options.parsers[INT4_ARRAY_TYPE]) {
+    assert(db.options.fetch_types, `Supplied db must fetch_types`);
+    lc.debug?.('fetching array types');
+
+    // Execute a query to ensure that fetchArrayTypes() gets executed:
+    // https://github.com/porsager/postgres/blob/089214e85c23c90cf142d47fb30bd03f42874984/src/connection.js#L536
+    await db`SELECT 1`.simple();
+    assert(
+      db.options.parsers[INT4_ARRAY_TYPE],
+      `array types not fetched ${Object.keys(db.options.parsers)}`,
+    );
+  }
+  return mapValues(db.options.parsers, parse => {
+    // The postgres.js library tags parsers for array types with an `array: true` field.
+    // https://github.com/porsager/postgres/blob/089214e85c23c90cf142d47fb30bd03f42874984/src/connection.js#L760
+    const isArrayType = (parse as unknown as {array?: boolean}).array;
+
+    // And then skips the first character when parsing the string,
+    // e.g. '{1,2,3}` it will parse `1,2,3}`.
+    // https://github.com/porsager/postgres/blob/089214e85c23c90cf142d47fb30bd03f42874984/src/connection.js#L496
+    return isArrayType ? (val: string) => parse(val.substring(1)) : parse;
+  });
+}

--- a/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.ts
+++ b/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.ts
@@ -10,9 +10,6 @@ import {fromBigInt} from '../lsn.ts';
 import {PgoutputParser} from './pgoutput-parser.ts';
 import type {Message} from './pgoutput.types.ts';
 
-// Arbitrary array type to test if the PostgresDB client has fetched types.
-const INT4_ARRAY_TYPE = 1007;
-
 export type StreamMessage = [lsn: bigint, Message | {tag: 'keepalive'}];
 
 export async function subscribe(
@@ -104,6 +101,9 @@ function makeAck(lsn: bigint): Buffer {
   return x;
 }
 
+// Arbitrary array type to test if the PostgresDB client has fetched types.
+const INT4_ARRAY_TYPE = 1007;
+
 // postgres.js has default type parsers with user-defined overrides
 // configurable per-client (see `postgresTypeConfig` in types/pg.ts).
 //
@@ -133,7 +133,7 @@ async function getTypeParsers(lc: LogContext, db: PostgresDB) {
     const isArrayType = (parse as unknown as {array?: boolean}).array;
 
     // And then skips the first character when parsing the string,
-    // e.g. '{1,2,3}` it will parse `1,2,3}`.
+    // e.g. an array parser will parse '{1,2,3}' from '1,2,3}'.
     // https://github.com/porsager/postgres/blob/089214e85c23c90cf142d47fb30bd03f42874984/src/connection.js#L496
     return isArrayType ? (val: string) => parse(val.substring(1)) : parse;
   });

--- a/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.ts
+++ b/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.ts
@@ -83,8 +83,8 @@ function parseStreamMessage(
   return buffer[0] === 0x77 // XLogData
     ? [lsn, parser.parse(buffer.subarray(25))]
     : buffer.readInt8(17) // Primary keepalive message: shouldRespond
-    ? [lsn, {tag: 'keepalive'}]
-    : null;
+      ? [lsn, {tag: 'keepalive'}]
+      : null;
 }
 
 // https://www.postgresql.org/docs/current/protocol-replication.html#PROTOCOL-REPLICATION-STANDBY-STATUS-UPDATE

--- a/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.ts
+++ b/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.ts
@@ -54,7 +54,6 @@ export async function subscribe(
     stream.readable(),
     stream.writable(),
   ]);
-  lc.debug?.(`started replication stream at ${slot} from ${lsnString}`);
 
   const typeParsers = await getTypeParsers(lc, db);
   const parser = new PgoutputParser(typeParsers);

--- a/packages/zero-cache/src/services/change-source/pg/lsn.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/lsn.test.ts
@@ -3,7 +3,13 @@ import {
   versionFromLexi,
   type LexiVersion,
 } from '../../../types/lexi-version.ts';
-import {fromLexiVersion, toLexiVersion, type LSN} from './lsn.ts';
+import {
+  fromBigInt,
+  fromLexiVersion,
+  toBigInt,
+  toLexiVersion,
+  type LSN,
+} from './lsn.ts';
 
 describe('lsn to/from LexiVersion', () => {
   type Case = [LSN, LexiVersion, bigint];
@@ -15,6 +21,8 @@ describe('lsn to/from LexiVersion', () => {
   ];
   test.each(cases)('convert(%s <=> %s)', (lsn, lexi, ver) => {
     expect(toLexiVersion(lsn)).toBe(lexi);
+    expect(toBigInt(lsn)).toBe(ver);
+    expect(fromBigInt(ver)).toBe(lsn);
     expect(versionFromLexi(lexi).toString()).toBe(ver.toString());
     expect(fromLexiVersion(lexi)).toBe(lsn);
   });

--- a/packages/zero-cache/src/services/change-source/pg/lsn.ts
+++ b/packages/zero-cache/src/services/change-source/pg/lsn.ts
@@ -20,17 +20,25 @@ export type LSN = string;
 
 export type RecordType = Change['tag'];
 
-export function toLexiVersion(lsn: LSN): LexiVersion {
+export function toBigInt(lsn: LSN): bigint {
   const parts = lsn.split('/');
   assert(parts.length === 2, `Malformed LSN: "${lsn}"`);
   const high = BigInt(`0x${parts[0]}`);
   const low = BigInt(`0x${parts[1]}`);
   const val = (high << 32n) + low;
-  return versionToLexi(val);
+  return val;
+}
+
+export function toLexiVersion(lsn: LSN): LexiVersion {
+  return versionToLexi(toBigInt(lsn));
 }
 
 export function fromLexiVersion(lexi: LexiVersion): LSN {
   const val = versionFromLexi(lexi);
+  return fromBigInt(val);
+}
+
+export function fromBigInt(val: bigint): LSN {
   const high = val >> 32n;
   const low = val & 0xffffffffn;
   return `${high.toString(16).toUpperCase()}/${low.toString(16).toUpperCase()}`;


### PR DESCRIPTION
This grafts the protocol parsing logic from [pg-logical-replication](https://github.com/kibae/pg-logical-replication/tree/main/src/output-plugins/pgoutput) onto a connection managed by a `postgres.js` client rather than a `pg` client.

The benefits of this rewrite include:
* **Better connection handling**: postgres.js supports an `ssl: prefer` option that automatically detects if ssl is supported. We currently have to mimic this on the `pg` client by trying SSL first and falling back to non-SSL
* **Flow control**: The new implementation uses the postgres.js `.readable()` API to pipeline the replication stream to the application's change Subscription, allowing the change-streamer to exert backpressure on the postgres. (This reuses the flow control mechanism for the websocket connection to custom change sources.)
* **Direct type parser configuration**: Type parsing is now directly configured instead of using the static `pg-types` library, avoiding library linkage mishaps that can arise in certain build environments (e.g. https://discord.com/channels/830183651022471199/1350643925836365917)

This PR only defines the new library. It will replace the status quo in a subsequent PR.