### PR TITLE
feat(zero-cache): protect the replication-manager with back pressure

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -367,6 +367,8 @@ class ChangeStreamerImpl implements ChangeStreamerService {
 
           if (type === 'commit') {
             watermark = null;
+            // After each transaction, allow storer to exert back pressure.
+            await this.#storer.readyForMore();
           }
         }
       } catch (e) {


### PR DESCRIPTION
Protect the `replication-manager` from being overwhelmed by a highly active replication stream by exerting back pressure from the change-streamer when the queued changes exceeds a threshold.

Currently this threshold is based on a simple count. It can later be improved to be memory-size based. This works for both postgres and custom change sources.

Loadtests confirm that a change-streamer without this protection eventually crashes, while the back-pressure-protected change-streamer continues humming along.

![chart (2)](https://github.com/user-attachments/assets/8bc80c8b-a550-4d21-9a66-8ca04d228a1d)

Without back-pressure:

<img width="1192" alt="Screenshot 2025-03-20 at 19 34 45" src="https://github.com/user-attachments/assets/931059a3-0b91-4930-abb9-2318fd1d3be3" />

With back-pressure:

<img width="1193" alt="Screenshot 2025-03-20 at 19 35 02" src="https://github.com/user-attachments/assets/379ef7ac-d4b9-468f-9d05-7a9146049752" />

