### PR TITLE
chore(load-harness): handle crashed processes and high qps

### DIFF
--- a/tools/load-generator/src/main.ts
+++ b/tools/load-generator/src/main.ts
@@ -19,16 +19,20 @@ const options = {
     ints: v.array(v.string()).optional(),
     jsonbs: v.array(v.string()).optional(),
   },
+
+  maxConnections: v.number().default(40),
 };
 
 async function run() {
   const lc = new LogContext('debug', {}, consoleLogSink);
-  const {upstream, perturb, qps} = parseOptions(
+  const {upstream, perturb, qps, maxConnections} = parseOptions(
     options,
     process.argv.slice(2),
     'ZERO_',
   );
-  const db = postgres(upstream.db, {max: Math.max(1, qps / 10)});
+  const db = postgres(upstream.db, {
+    max: Math.max(1, Math.min(qps / 10, maxConnections)),
+  });
 
   const assignments = [`${id(perturb.key)} = ${id(perturb.key)}`];
   perturb.bools?.forEach(col =>

--- a/tools/load-generator/src/main.ts
+++ b/tools/load-generator/src/main.ts
@@ -31,7 +31,7 @@ async function run() {
     'ZERO_',
   );
   const db = postgres(upstream.db, {
-    max: Math.max(1, Math.min(qps / 10, maxConnections)),
+    max: Math.max(1, Math.min(maxConnections, qps / 10)),
   });
 
   const assignments = [`${id(perturb.key)} = ${id(perturb.key)}`];

--- a/tools/process-tracker/src/main.ts
+++ b/tools/process-tracker/src/main.ts
@@ -59,11 +59,13 @@ async function run() {
   let i = 0;
   async function trackAndDisplay() {
     const stats = await pidusage(pids);
+    // Note: The pid may have crashed so `stats[pid]` should
+    //       be accessed with the `?.` operator.
     const line = pids
       .map(
         pid =>
-          `${stats[pid].cpu.toFixed(1)}%\t\t` +
-          `${Math.floor(stats[pid].memory / MB)}MB`,
+          `${(stats[pid]?.cpu ?? 0).toFixed(1)}%\t\t` +
+          `${Math.floor((stats[pid]?.memory ?? 0) / MB)}MB`,
       )
       .join('\t\t');
     process.stdout.write(`${CLEAR_LINE}${line}`);
@@ -72,7 +74,9 @@ async function run() {
       void file?.write(
         [
           new Date().toISOString(),
-          ...pids.map(pid => [stats[pid].cpu, stats[pid].memory]).flat(),
+          ...pids
+            .map(pid => [stats[pid]?.cpu ?? 0, stats[pid]?.memory ?? 0])
+            .flat(),
         ]
           .map(n => String(n))
           .join('\t') + '\n',


### PR DESCRIPTION
Cap the number of `load-generator` connections for handling high qps workloads, and make the `process-tracker` resilient to crashed processes.