### PR TITLE
chore(mutators): add an `OutboundStream` for `pusher`

### DIFF
--- a/packages/shared/src/arrays.test.ts
+++ b/packages/shared/src/arrays.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, test} from 'vitest';
-import {defined} from './arrays.ts';
+import {defined, groupBy, zip} from './arrays.ts';
 
 describe('shared/arrays', () => {
   type Case = {
@@ -67,4 +67,103 @@ describe('shared/arrays', () => {
       }
     });
   }
+});
+
+describe('zip', () => {
+  test('zips empty arrays', () => {
+    expect(zip([], [])).toEqual([]);
+  });
+
+  test('zips arrays of equal length', () => {
+    expect(zip([1, 2, 3], ['a', 'b', 'c'])).toEqual([
+      [1, 'a'],
+      [2, 'b'],
+      [3, 'c'],
+    ]);
+  });
+
+  test('zips arrays with same elements', () => {
+    expect(zip([1, 1, 1], [2, 2, 2])).toEqual([
+      [1, 2],
+      [1, 2],
+      [1, 2],
+    ]);
+  });
+
+  test('throws on arrays of different length', () => {
+    expect(() => zip([1, 2], [1])).toThrow();
+    expect(() => zip([1], [1, 2])).toThrow();
+  });
+
+  test('preserves element references', () => {
+    const obj1 = {id: 1};
+    const obj2 = {id: 2};
+    const arr1 = [obj1];
+    const arr2 = [obj2];
+    const result = zip(arr1, arr2);
+    expect(result[0][0]).toBe(obj1);
+    expect(result[0][1]).toBe(obj2);
+  });
+});
+
+describe('groupBy', () => {
+  test('groups empty array', () => {
+    expect(groupBy([], x => x)).toEqual(new Map());
+  });
+
+  test('groups numbers by value', () => {
+    const input = [1, 2, 1, 3, 2, 1];
+    const result = groupBy(input, x => x);
+    expect(result.size).toBe(3);
+    expect(result.get(1)).toEqual([1, 1, 1]);
+    expect(result.get(2)).toEqual([2, 2]);
+    expect(result.get(3)).toEqual([3]);
+  });
+
+  test('groups objects by property', () => {
+    const input = [
+      {category: 'A', value: 1},
+      {category: 'B', value: 2},
+      {category: 'A', value: 3},
+      {category: 'C', value: 4},
+      {category: 'B', value: 5},
+    ];
+    const result = groupBy(input, x => x.category);
+
+    expect(result.size).toBe(3);
+    expect(result.get('A')).toEqual([
+      {category: 'A', value: 1},
+      {category: 'A', value: 3},
+    ]);
+    expect(result.get('B')).toEqual([
+      {category: 'B', value: 2},
+      {category: 'B', value: 5},
+    ]);
+    expect(result.get('C')).toEqual([{category: 'C', value: 4}]);
+  });
+
+  test('preserves element references', () => {
+    const obj1 = {id: 1, group: 'A'};
+    const obj2 = {id: 2, group: 'A'};
+    const input = [obj1, obj2];
+    const result = groupBy(input, x => x.group);
+    const groupA = result.get('A')!;
+    expect(groupA[0]).toBe(obj1);
+    expect(groupA[1]).toBe(obj2);
+  });
+
+  test('groups by computed values', () => {
+    const input = [1, 2, 3, 4, 5, 6];
+    const result = groupBy(input, x => (x % 2 === 0 ? 'even' : 'odd'));
+    expect(result.get('even')).toEqual([2, 4, 6]);
+    expect(result.get('odd')).toEqual([1, 3, 5]);
+  });
+
+  test('handles different key types', () => {
+    const input = ['a', 'bb', 'ccc', 'd', 'ee'];
+    const result = groupBy(input, x => x.length);
+    expect(result.get(1)).toEqual(['a', 'd']);
+    expect(result.get(2)).toEqual(['bb', 'ee']);
+    expect(result.get(3)).toEqual(['ccc']);
+  });
 });

--- a/packages/shared/src/arrays.ts
+++ b/packages/shared/src/arrays.ts
@@ -24,9 +24,9 @@ export function areEqual<T>(arr1: readonly T[], arr2: readonly T[]): boolean {
   return arr1.length === arr2.length && arr1.every((e, i) => e === arr2[i]);
 }
 
-export function zip<T>(a1: readonly T[], a2: readonly T[]): [T, T][] {
+export function zip<T1, T2>(a1: readonly T1[], a2: readonly T2[]): [T1, T2][] {
   assert(a1.length === a2.length);
-  const result: [T, T][] = [];
+  const result: [T1, T2][] = [];
   for (let i = 0; i < a1.length; i++) {
     result.push([a1[i], a2[i]]);
   }

--- a/packages/shared/src/arrays.ts
+++ b/packages/shared/src/arrays.ts
@@ -1,3 +1,5 @@
+import {assert} from './asserts.ts';
+
 /**
  * Returns `arr` as is if none of the elements are `undefined`.
  * Otherwise returns a new array with only defined elements in `arr`.
@@ -20,4 +22,30 @@ export function defined<T>(arr: (T | undefined)[]): T[] {
 
 export function areEqual<T>(arr1: readonly T[], arr2: readonly T[]): boolean {
   return arr1.length === arr2.length && arr1.every((e, i) => e === arr2[i]);
+}
+
+export function zip<T>(a1: readonly T[], a2: readonly T[]): [T, T][] {
+  assert(a1.length === a2.length);
+  const result: [T, T][] = [];
+  for (let i = 0; i < a1.length; i++) {
+    result.push([a1[i], a2[i]]);
+  }
+  return result;
+}
+
+export function groupBy<T, K>(
+  arr: readonly T[],
+  keyFn: (el: T) => K,
+): Map<K, T[]> {
+  const groups = new Map<K, T[]>();
+  for (const el of arr) {
+    const key = keyFn(el);
+    let group = groups.get(key);
+    if (group === undefined) {
+      group = [];
+      groups.set(key, group);
+    }
+    group.push(el);
+  }
+  return groups;
 }

--- a/packages/z2s/src/compiler.ts
+++ b/packages/z2s/src/compiler.ts
@@ -1,3 +1,4 @@
+import {zip} from '../../shared/src/arrays.ts';
 import {assert} from '../../shared/src/asserts.ts';
 import {must} from '../../shared/src/must.ts';
 import type {
@@ -396,13 +397,4 @@ export class Compiler {
     const mapped = this.#nameMapper.tableName(table);
     return sql.ident(mapped);
   }
-}
-
-function zip<T>(a1: readonly T[], a2: readonly T[]): [T, T][] {
-  assert(a1.length === a2.length);
-  const result: [T, T][] = [];
-  for (let i = 0; i < a1.length; i++) {
-    result.push([a1[i], a2[i]]);
-  }
-  return result;
 }

--- a/packages/zero-cache/src/services/mutagen/pusher.test.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.test.ts
@@ -19,7 +19,8 @@ const config = {
   },
 };
 
-const clientID = 'test';
+const clientID = 'test-cid';
+const wsID = 'test-wsid';
 describe('combine pushes', () => {
   test('empty array', () => {
     const [pushes, terminate] = combinePushes([]);
@@ -158,7 +159,7 @@ describe('pusher service', () => {
     );
     void pusher.run();
 
-    pusher.enqueuePush(clientID, makePush(1), 'jwt');
+    pusher.enqueuePush(clientID, wsID, makePush(1), 'jwt');
 
     await pusher.stop();
 
@@ -187,7 +188,7 @@ describe('pusher service', () => {
     );
     void pusher.run();
 
-    pusher.enqueuePush(clientID, makePush(1), 'jwt');
+    pusher.enqueuePush(clientID, wsID, makePush(1), 'jwt');
 
     await pusher.stop();
 
@@ -214,7 +215,7 @@ describe('pusher service', () => {
     );
 
     void pusher.run();
-    pusher.enqueuePush(clientID, makePush(1), 'jwt');
+    pusher.enqueuePush(clientID, wsID, makePush(1), 'jwt');
     // release control of the loop so the push can be sent
     await Promise.resolve();
 
@@ -223,11 +224,11 @@ describe('pusher service', () => {
     expect(JSON.parse(fetch.mock.calls[0][1].body).mutations).toHaveLength(1);
 
     // We have not resolved the API server yet so these should stack up
-    pusher.enqueuePush(clientID, makePush(1), 'jwt');
+    pusher.enqueuePush(clientID, wsID, makePush(1), 'jwt');
     await Promise.resolve();
-    pusher.enqueuePush(clientID, makePush(1), 'jwt');
+    pusher.enqueuePush(clientID, wsID, makePush(1), 'jwt');
     await Promise.resolve();
-    pusher.enqueuePush(clientID, makePush(1), 'jwt');
+    pusher.enqueuePush(clientID, wsID, makePush(1), 'jwt');
     await Promise.resolve();
 
     // no new pushes sent yet since we are still waiting on the user's API server
@@ -261,7 +262,7 @@ describe('pusher streaming', () => {
     );
     void pusher.run();
 
-    const result = pusher.enqueuePush(clientID, makePush(1), 'jwt');
+    const result = pusher.enqueuePush(clientID, wsID, makePush(1), 'jwt');
     expect(result.type).toBe('stream');
   });
 
@@ -275,25 +276,29 @@ describe('pusher streaming', () => {
     );
     void pusher.run();
 
-    pusher.enqueuePush(clientID, makePush(1), 'jwt');
-    const result = pusher.enqueuePush(clientID, makePush(1), 'jwt');
+    pusher.enqueuePush(clientID, wsID, makePush(1), 'jwt');
+    const result = pusher.enqueuePush(clientID, wsID, makePush(1), 'jwt');
     expect(result.type).toBe('ok');
   });
 
   test('streams successful push response to correct client', async () => {
     const fetch = (global.fetch = vi.fn());
-    const successResponse: PushResponse = {
+    const successResponse1: PushResponse = {
       mutations: [
         {
           id: {clientID: 'client1', id: 1},
-          result: {timestamp: 123, cookie: 'abc'},
+          result: {},
         },
       ],
     };
-    fetch.mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve(successResponse),
-    });
+    const successResponse2: PushResponse = {
+      mutations: [
+        {
+          id: {clientID: 'client2', id: 1},
+          result: {},
+        },
+      ],
+    };
 
     const pusher = new PusherService(
       config,
@@ -304,41 +309,85 @@ describe('pusher streaming', () => {
     );
     void pusher.run();
 
-    const result1 = pusher.enqueuePush('client1', makePush(1), 'jwt');
-    const result2 = pusher.enqueuePush('client2', makePush(1), 'jwt');
+    fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(successResponse1),
+    });
+    const result1 = pusher.enqueuePush(
+      'client1',
+      wsID,
+      makePush(1, 'client1'),
+      'jwt',
+    );
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(successResponse2),
+    });
+    const result2 = pusher.enqueuePush(
+      'client2',
+      wsID,
+      makePush(2, 'client2'),
+      'jwt',
+    );
 
     expect(result1.type).toBe('stream');
     expect(result2.type).toBe('stream');
 
-    if (result1.type === 'stream') {
-      const messages: unknown[] = [];
-      result1.stream.subscribe(msg => messages.push(msg));
+    if (result1.type === 'stream' && result2.type === 'stream') {
+      const s1Messages: unknown[] = [];
+      const s2Messages: unknown[] = [];
+      for await (const response of result1.stream) {
+        s1Messages.push(response);
+        break;
+      }
+      for await (const response of result2.stream) {
+        s2Messages.push(response);
+        break;
+      }
 
-      // Wait for push to be processed
-      await new Promise(resolve => setTimeout(resolve, 0));
-
-      expect(messages).toEqual([
+      expect(s1Messages).toMatchInlineSnapshot(`
         [
-          'push-response',
-          {
-            mutations: successResponse.mutations,
-          },
-        ],
-      ]);
+          [
+            "push-response",
+            {
+              "mutations": [
+                {
+                  "id": {
+                    "clientID": "client1",
+                    "id": 1,
+                  },
+                  "result": {},
+                },
+              ],
+            },
+          ],
+        ]
+      `);
+      expect(s2Messages).toMatchInlineSnapshot(`
+        [
+          [
+            "push-response",
+            {
+              "mutations": [
+                {
+                  "id": {
+                    "clientID": "client2",
+                    "id": 1,
+                  },
+                  "result": {},
+                },
+              ],
+            },
+          ],
+        ]
+      `);
     }
   });
 
   test('streams error response to affected clients', async () => {
     const fetch = (global.fetch = vi.fn());
-    const errorResponse: PushResponse = {
-      error: 'http',
-      status: 500,
-      details: 'Internal Server Error',
-      mutationIDs: [
-        {clientID: 'client1', id: 1},
-        {clientID: 'client2', id: 1},
-      ],
-    };
     fetch.mockResolvedValue({
       ok: false,
       status: 500,
@@ -354,8 +403,18 @@ describe('pusher streaming', () => {
     );
     void pusher.run();
 
-    const result1 = pusher.enqueuePush('client1', makePush(1), 'jwt');
-    const result2 = pusher.enqueuePush('client2', makePush(1), 'jwt');
+    const result1 = pusher.enqueuePush(
+      'client1',
+      wsID,
+      makePush(1, 'client1'),
+      'jwt',
+    );
+    const result2 = pusher.enqueuePush(
+      'client2',
+      wsID,
+      makePush(1, 'client2'),
+      'jwt',
+    );
 
     expect(result1.type).toBe('stream');
     expect(result2.type).toBe('stream');
@@ -363,11 +422,17 @@ describe('pusher streaming', () => {
     if (result1.type === 'stream' && result2.type === 'stream') {
       const messages1: unknown[] = [];
       const messages2: unknown[] = [];
-      result1.stream.subscribe(msg => messages1.push(msg));
-      result2.stream.subscribe(msg => messages2.push(msg));
-
       // Wait for push to be processed
       await new Promise(resolve => setTimeout(resolve, 0));
+
+      for await (const msg of result1.stream) {
+        messages1.push(msg);
+        break;
+      }
+      for await (const msg of result2.stream) {
+        messages2.push(msg);
+        break;
+      }
 
       expect(messages1).toEqual([
         [
@@ -388,7 +453,7 @@ describe('pusher streaming', () => {
             error: 'http',
             status: 500,
             details: 'Internal Server Error',
-            mutationIDs: [{clientID: 'client2', id: 1}],
+            mutationIDs: [{clientID: 'client2', id: 2}],
           },
         ],
       ]);
@@ -408,15 +473,20 @@ describe('pusher streaming', () => {
     );
     void pusher.run();
 
-    const result = pusher.enqueuePush(clientID, makePush(1), 'jwt');
+    const result = pusher.enqueuePush(
+      clientID,
+      wsID,
+      makePush(1, clientID),
+      'jwt',
+    );
     expect(result.type).toBe('stream');
 
     if (result.type === 'stream') {
       const messages: unknown[] = [];
-      result.stream.subscribe(msg => messages.push(msg));
-
-      // Wait for push to be processed
-      await new Promise(resolve => setTimeout(resolve, 0));
+      for await (const msg of result.stream) {
+        messages.push(msg);
+        break;
+      }
 
       expect(messages).toEqual([
         [
@@ -441,25 +511,75 @@ describe('pusher streaming', () => {
     );
     void pusher.run();
 
-    const result1 = pusher.enqueuePush(clientID, makePush(1), 'jwt');
+    const result1 = pusher.enqueuePush(
+      clientID,
+      wsID,
+      makePush(1, clientID),
+      'jwt',
+    );
     expect(result1.type).toBe('stream');
 
     if (result1.type === 'stream') {
-      result1.stream.cleanup();
+      result1.stream.cancel();
 
       // After cleanup, should get a new stream
-      const result2 = pusher.enqueuePush(clientID, makePush(1), 'jwt');
+      const result2 = pusher.enqueuePush(
+        clientID,
+        wsID,
+        makePush(1, clientID),
+        'jwt',
+      );
       expect(result2.type).toBe('stream');
+    }
+  });
+
+  test('new websocket for same client creates new downstream', async () => {
+    const pusher = new PusherService(
+      config,
+      lc,
+      'cgid',
+      'http://example.com',
+      'api-key',
+    );
+    void pusher.run();
+
+    const result1 = pusher.enqueuePush(
+      clientID,
+      wsID,
+      makePush(1, clientID),
+      'jwt',
+    );
+    expect(result1.type).toBe('stream');
+    const result2 = pusher.enqueuePush(
+      clientID,
+      'new-ws-id',
+      makePush(1, clientID),
+      'jwt',
+    );
+    expect(result2.type).toBe('stream');
+    if (result1.type === 'stream') {
+      // should not be iterable anymore as it is closed
+      const iterator = result1.stream[Symbol.asyncIterator]();
+      await expect(iterator.next()).resolves.toEqual({
+        done: true,
+        value: undefined,
+      });
     }
   });
 });
 
 let timestamp = 0;
 let id = 0;
-function makePush(numMutations: number): PushBody {
+
+beforeEach(() => {
+  timestamp = 0;
+  id = 0;
+});
+
+function makePush(numMutations: number, clientID?: string): PushBody {
   return {
     clientGroupID: 'cgid',
-    mutations: Array.from({length: numMutations}, makeMutation),
+    mutations: Array.from({length: numMutations}, () => makeMutation(clientID)),
     pushVersion: 1,
     requestID: 'rid',
     schemaVersion: 1,
@@ -467,11 +587,11 @@ function makePush(numMutations: number): PushBody {
   };
 }
 
-function makeMutation(): Mutation {
+function makeMutation(clientID?: string): Mutation {
   return {
     type: 'custom',
     args: [],
-    clientID: 'cid',
+    clientID: clientID ?? 'cid',
     id: ++id,
     name: 'n',
     timestamp: ++timestamp,

--- a/packages/zero-cache/src/services/mutagen/pusher.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.ts
@@ -1,15 +1,26 @@
 import type {LogContext} from '@rocicorp/logger';
 import {must} from '../../../../shared/src/must.ts';
 import {Queue} from '../../../../shared/src/queue.ts';
-import * as ErrorKind from '../../../../zero-protocol/src/error-kind-enum.ts';
-import type {PushBody} from '../../../../zero-protocol/src/push.ts';
+import * as v from '../../../../shared/src/valita.ts';
+import {
+  pushResponseSchema,
+  type PushBody,
+  type PushResponse,
+} from '../../../../zero-protocol/src/push.ts';
 import type {Service} from '../service.ts';
-import type {MutationError} from './mutagen.ts';
 import {type ZeroConfig} from '../../config/zero-config.ts';
 import {upstreamSchema} from '../../types/shards.ts';
+import type {HandlerResult} from '../../workers/connection.ts';
+import type {Downstream} from '../../../../zero-protocol/src/down.ts';
+import {Subscription} from '../../types/subscription.ts';
+import {groupBy} from '../../../../shared/src/arrays.ts';
 
 export interface Pusher {
-  enqueuePush(push: PushBody, jwt: string | undefined): void;
+  enqueuePush(
+    clientID: string,
+    push: PushBody,
+    jwt: string | undefined,
+  ): HandlerResult;
 }
 
 type Config = Pick<ZeroConfig, 'app' | 'shard'>;
@@ -27,7 +38,7 @@ type Config = Pick<ZeroConfig, 'app' | 'shard'>;
  * - Mutations for a given client are always sent in-order
  * - Mutations for different clients in the same group may be interleaved
  */
-export class PusherService implements Service {
+export class PusherService implements Service, Pusher {
   readonly id: string;
   readonly #pusher: PushWorker;
   readonly #queue: Queue<PusherEntryOrStop>;
@@ -45,8 +56,26 @@ export class PusherService implements Service {
     this.id = clientGroupID;
   }
 
-  enqueuePush(push: PushBody, jwt: string | undefined) {
+  enqueuePush(
+    clientID: string,
+    push: PushBody,
+    jwt: string | undefined,
+  ): HandlerResult {
+    const downstream: Subscription<Downstream> | undefined =
+      this.#pusher.maybeInitClient(clientID);
+
     this.#queue.enqueue({push, jwt});
+
+    if (downstream) {
+      return {
+        type: 'stream',
+        stream: downstream,
+      };
+    }
+
+    return {
+      type: 'ok',
+    };
   }
 
   run(): Promise<void> {
@@ -76,6 +105,7 @@ class PushWorker {
   readonly #queue: Queue<PusherEntryOrStop>;
   readonly #lc: LogContext;
   readonly #config: Config;
+  readonly #clients: Map<string, Subscription<Downstream>>;
 
   constructor(
     config: Config,
@@ -89,6 +119,20 @@ class PushWorker {
     this.#queue = queue;
     this.#lc = lc.withContext('component', 'pusher');
     this.#config = config;
+    this.#clients = new Map();
+  }
+
+  maybeInitClient(clientID: string) {
+    if (this.#clients.has(clientID)) {
+      return;
+    }
+    const downstream = Subscription.create<Downstream>({
+      cleanup: () => {
+        this.#clients.delete(clientID);
+      },
+    });
+    this.#clients.set(clientID, downstream);
+    return undefined;
   }
 
   async run() {
@@ -97,7 +141,8 @@ class PushWorker {
       const rest = this.#queue.drain();
       const [pushes, terminate] = combinePushes([task, ...rest]);
       for (const push of pushes) {
-        await this.#processPush(push);
+        const response = await this.#processPush(push);
+        this.#fanOutResponses(response);
       }
 
       if (terminate) {
@@ -106,7 +151,36 @@ class PushWorker {
     }
   }
 
-  async #processPush(entry: PusherEntry): Promise<MutationError | undefined> {
+  #fanOutResponses(response: PushResponse) {
+    if ('error' in response) {
+      const groupedMutationIDs = groupBy(
+        response.mutationIDs ?? [],
+        m => m.clientID,
+      );
+      for (const [clientID, mutationIDs] of groupedMutationIDs) {
+        const downstream = this.#clients.get(clientID);
+        if (downstream) {
+          downstream.push([
+            'push-response',
+            {
+              ...response,
+              mutationIDs,
+            },
+          ]);
+        }
+      }
+    } else {
+      const groupedMutations = groupBy(response.mutations, m => m.id.clientID);
+      for (const [clientID, mutations] of groupedMutations) {
+        const downstream = this.#clients.get(clientID);
+        if (downstream) {
+          downstream.push(['push-response', {mutations}]);
+        }
+      }
+    }
+  }
+
+  async #processPush(entry: PusherEntry): Promise<PushResponse> {
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
     };
@@ -132,25 +206,33 @@ class PushWorker {
         headers,
         body: JSON.stringify(entry.push),
       });
-      // TODO: handle more varied response types from the user's API server
       if (!response.ok) {
-        return [
-          ErrorKind.MutationFailed,
-          `API server failed to process mutation: ${response.status} ${response.statusText}`,
-        ];
+        return {
+          error: 'http',
+          status: response.status,
+          details: await response.text(),
+          mutationIDs: entry.push.mutations.map(m => ({
+            id: m.id,
+            clientID: m.clientID,
+          })),
+        };
       }
+
+      return v.parse(await response.json(), pushResponseSchema);
     } catch (e) {
       // We do not kill the pusher on error.
       // If the user's API server is down, the mutations will never be acknowledged
       // and the client will eventually retry.
       this.#lc.error?.('failed to push', e);
-      return [
-        ErrorKind.MutationFailed,
-        e instanceof Error ? e.message : 'unknown error',
-      ];
+      return {
+        error: 'zero-pusher',
+        details: String(e),
+        mutationIDs: entry.push.mutations.map(m => ({
+          id: m.id,
+          clientID: m.clientID,
+        })),
+      };
     }
-
-    return undefined;
   }
 }
 

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -417,6 +417,15 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         schemaVersion,
         downstream,
       );
+      // TODO: is it possible that there is a race here?
+      // That the client:
+      // 1. creates two websocket connections
+      // 2. closes the first one
+      // 3. due to network delay, the server receives the `initConnection` for the second connection first
+      // 4. then the server receives `initConnection` for the first connection, tearing down the second one here
+      //    (.get(clientID).close())
+      // 5. The server then receives the `closeConnection` for the first connection, closing all connections
+      //    it has to the client.
       this.#clients.get(clientID)?.close(`replaced by wsID: ${wsID}`);
       this.#clients.set(clientID, newClient);
 

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -417,15 +417,6 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         schemaVersion,
         downstream,
       );
-      // TODO: is it possible that there is a race here?
-      // That the client:
-      // 1. creates two websocket connections
-      // 2. closes the first one
-      // 3. due to network delay, the server receives the `initConnection` for the second connection first
-      // 4. then the server receives `initConnection` for the first connection, tearing down the second one here
-      //    (.get(clientID).close())
-      // 5. The server then receives the `closeConnection` for the first connection, closing all connections
-      //    it has to the client.
       this.#clients.get(clientID)?.close(`replaced by wsID: ${wsID}`);
       this.#clients.set(clientID, newClient);
 

--- a/packages/zero-cache/src/workers/syncer-ws-message-handler.ts
+++ b/packages/zero-cache/src/workers/syncer-ws-message-handler.ts
@@ -99,11 +99,14 @@ export class SyncerWsMessageHandler implements MessageHandler {
             }
 
             if (this.#pusher) {
-              this.#pusher.enqueuePush(msg[1], this.#token);
               // We do not call mutagen since if a pusher is set
               // the precludes crud mutators.
               // We'll be removing crud mutators when we release custom mutators.
-              return {type: 'ok'} satisfies HandlerResult;
+              return this.#pusher.enqueuePush(
+                this.#syncContext.clientID,
+                msg[1],
+                this.#token,
+              );
             }
 
             // Hold a connection-level lock while processing mutations so that:

--- a/packages/zero-cache/src/workers/syncer-ws-message-handler.ts
+++ b/packages/zero-cache/src/workers/syncer-ws-message-handler.ts
@@ -104,6 +104,7 @@ export class SyncerWsMessageHandler implements MessageHandler {
               // We'll be removing crud mutators when we release custom mutators.
               return this.#pusher.enqueuePush(
                 this.#syncContext.clientID,
+                this.#syncContext.wsID,
                 msg[1],
                 this.#token,
               );
@@ -152,6 +153,7 @@ export class SyncerWsMessageHandler implements MessageHandler {
         );
         return {
           type: 'stream',
+          source: 'viewSyncer',
           stream,
         };
       }

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -902,6 +902,11 @@ export class Zero<
           downMessage[1],
         );
 
+      case 'push-response':
+        // Ignored for now. Will be sent to the `mutation-tracker`
+        // in order to resolve mutation promises.
+        break;
+
       default:
         msgType satisfies never;
         rejectInvalidMessage();

--- a/packages/zero-protocol/src/ast.test.ts
+++ b/packages/zero-protocol/src/ast.test.ts
@@ -607,5 +607,5 @@ test('protocol version', () => {
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
   expect(hash).toEqual('2zzy9s2lcdcms');
-  expect(PROTOCOL_VERSION).toEqual(8);
+  expect(PROTOCOL_VERSION).toEqual(9);
 });

--- a/packages/zero-protocol/src/down.ts
+++ b/packages/zero-protocol/src/down.ts
@@ -9,6 +9,7 @@ import {
 } from './poke.ts';
 import {pongMessageSchema} from './pong.ts';
 import {pullResponseMessageSchema} from './pull.ts';
+import {pushResponseMessageSchema} from './push.ts';
 import {warmMessageSchema} from './warm.ts';
 
 export const downstreamSchema = v.union(
@@ -21,6 +22,7 @@ export const downstreamSchema = v.union(
   pokeEndMessageSchema,
   pullResponseMessageSchema,
   deleteClientsMessageSchema,
+  pushResponseMessageSchema,
 );
 
 export type Downstream = v.Infer<typeof downstreamSchema>;

--- a/packages/zero-protocol/src/protocol-version.test.ts
+++ b/packages/zero-protocol/src/protocol-version.test.ts
@@ -11,6 +11,6 @@ test('protocol version', () => {
   // If this test fails upstream or downstream schema has changed such that
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
-  expect(hash).toEqual('18730x547v0tw');
-  expect(PROTOCOL_VERSION).toEqual(8);
+  expect(hash).toEqual('kgpizwq3kw2o');
+  expect(PROTOCOL_VERSION).toEqual(9);
 });

--- a/packages/zero-protocol/src/protocol-version.ts
+++ b/packages/zero-protocol/src/protocol-version.ts
@@ -17,7 +17,7 @@ import {assert} from '../../shared/src/asserts.ts';
 // -- Version 6 makes `pokeStart.cookie` optional. (0.16)
 // -- Version 7 introduces the initConnection.clientSchema field. (0.17)
 // -- Version 8 drops support for Version 5 (0.18).
-export const PROTOCOL_VERSION = 8;
+export const PROTOCOL_VERSION = 9;
 
 /**
  * The minimum server-supported sync protocol version (i.e. the version

--- a/packages/zero-protocol/src/push.ts
+++ b/packages/zero-protocol/src/push.ts
@@ -96,7 +96,6 @@ export const pushBodySchema = v.object({
 });
 
 export const pushMessageSchema = v.tuple([v.literal('push'), pushBodySchema]);
-
 const mutationIDSchema = v.object({
   id: v.number(),
   clientID: v.string(),
@@ -104,14 +103,22 @@ const mutationIDSchema = v.object({
 
 const appErrorSchema = v.object({
   error: v.literal('app'),
-  details: v.string(),
+  // the user can add any additional fields in their API server
 });
 const zeroErrorSchema = v.object({
   error: v.literal('ooo-mutation'),
 });
+const tokenErrorSchema = v.object({
+  error: v.literal('token'),
+  // the user can add any additional fields in their API server
+});
 
 const mutationOkSchema = v.object({});
-const mutationErrorSchema = v.union(appErrorSchema, zeroErrorSchema);
+const mutationErrorSchema = v.union(
+  appErrorSchema,
+  zeroErrorSchema,
+  tokenErrorSchema,
+);
 const mutationResultSchema = v.union(mutationOkSchema, mutationErrorSchema);
 const mutationResponseSchema = v.object({
   id: mutationIDSchema,
@@ -136,13 +143,30 @@ const unsupportedSchemaVersionSchema = v.object({
   // were not processed by the server.
   mutationIDs: v.array(mutationIDSchema).optional(),
 });
+const httpErrorSchema = v.object({
+  error: v.literal('http'),
+  status: v.number(),
+  details: v.string(),
+  mutationIDs: v.array(mutationIDSchema).optional(),
+});
+const zeroPusherErrorSchema = v.object({
+  error: v.literal('zero-pusher'),
+  details: v.string(),
+  mutationIDs: v.array(mutationIDSchema).optional(),
+});
 
 const pushErrorSchema = v.union(
   unsupportedPushVersionSchema,
   unsupportedSchemaVersionSchema,
+  httpErrorSchema,
+  zeroPusherErrorSchema,
 );
 
 export const pushResponseSchema = v.union(pushOkSchema, pushErrorSchema);
+export const pushResponseMessageSchema = v.tuple([
+  v.literal('push-response'),
+  pushResponseSchema,
+]);
 
 export type InsertOp = v.Infer<typeof insertOpSchema>;
 export type UpsertOp = v.Infer<typeof upsertOpSchema>;


### PR DESCRIPTION
Just like `ViewSyncer` returns an `OutboundStream` which is proxied down to the client, follow the same pattern for passing mutation responses back to the client.

https://github.com/rocicorp/mono/blob/06697185aea4770c5aa7063e2f2012d0136ebe5f/packages/zero-cache/src/workers/connection.ts#L184-L192