### PR TITLE
feat(mutators): allow waiting for server results on the client

### DIFF
--- a/packages/zero-client/src/client/custom.test.ts
+++ b/packages/zero-client/src/client/custom.test.ts
@@ -4,6 +4,7 @@ import {
   TransactionImpl,
   type CustomMutatorDefs,
   type MakeCustomMutatorInterfaces,
+  type PromiseWithServerResult,
 } from './custom.ts';
 import {zeroForTest} from './test-utils.ts';
 import type {InsertValue, Transaction} from '../../../zql/src/mutate/custom.ts';
@@ -13,6 +14,7 @@ import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts'
 import type {WriteTransaction} from './replicache-types.ts';
 import {zeroData} from '../../../replicache/src/transactions.ts';
 import {must} from '../../../shared/src/must.ts';
+import type {MutationResult} from '../../../zero-protocol/src/push.ts';
 
 type Schema = typeof schema;
 
@@ -50,18 +52,25 @@ test('argument types are preserved on the generated mutator interface', () => {
   } satisfies CustomMutatorDefs<Schema>;
 
   type MutatorsInterface = MakeCustomMutatorInterfaces<Schema, typeof mutators>;
+
   expectTypeOf<MutatorsInterface>().toEqualTypeOf<{
     readonly issue: {
-      readonly setTitle: (args: {id: string; title: string}) => Promise<void>;
+      readonly setTitle: (args: {
+        id: string;
+        title: string;
+      }) => PromiseWithServerResult<void, MutationResult>;
       readonly setProps: (args: {
         id: string;
         title: string;
         status: 'closed' | 'open';
         assignee: string;
-      }) => Promise<void>;
+      }) => PromiseWithServerResult<void, MutationResult>;
     };
     readonly nonTableNamespace: {
-      readonly doThing: (args: {arg1: string; arg2: number}) => Promise<void>;
+      readonly doThing: (_a: {
+        arg1: string;
+        arg2: number;
+      }) => PromiseWithServerResult<void, MutationResult>;
     };
   }>();
 });

--- a/packages/zero-client/src/client/custom.ts
+++ b/packages/zero-client/src/client/custom.ts
@@ -62,7 +62,7 @@ export type MakeCustomMutatorInterfaces<
     tx: Transaction<S>,
     ...args: infer Args
   ) => Promise<void>
-    ? (...args: Args) => Promise<void>
+    ? (...args: Args) => PromiseWithServerResult<void, MutationResult>
     : {
         readonly [P in keyof MD[NamespaceOrName]]: MakeCustomMutatorInterface<
           S,
@@ -76,7 +76,7 @@ export type MakeCustomMutatorInterface<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   F,
 > = F extends (tx: ClientTransaction<S>, ...args: infer Args) => Promise<void>
-  ? (...args: Args) => Promise<void>
+  ? (...args: Args) => PromiseWithServerResult<void, MutationResult>
   : never;
 
 export class TransactionImpl<S extends Schema> implements ClientTransaction<S> {
@@ -122,7 +122,9 @@ type MaybeWithServerResult<T> = {
   server?: Promise<T>;
 };
 
-type PromiseWithServerResult<T, S> = Promise<T> & MaybeWithServerResult<S>;
+export type PromiseMaybeWithServerResult<T, S> = Promise<T> &
+  MaybeWithServerResult<S>;
+export type PromiseWithServerResult<T, S> = Promise<T> & {server: Promise<S>};
 
 export function makeReplicacheMutator<S extends Schema>(
   lc: LogContext,
@@ -134,14 +136,15 @@ export function makeReplicacheMutator<S extends Schema>(
   return (
     repTx: WriteTransaction,
     args: ReadonlyJSONValue,
-  ): PromiseWithServerResult<void, MutationResult> => {
+  ): PromiseMaybeWithServerResult<void, MutationResult> => {
     const tx = new TransactionImpl(lc, repTx, schema, slowMaterializeThreshold);
     const clientPromise = mutator(tx, args);
 
     if (repTx.reason === 'initial') {
       const serverPromise = mutationTracker.trackMutation(repTx.mutationID);
-      (clientPromise as PromiseWithServerResult<void, MutationResult>).server =
-        serverPromise;
+      (
+        clientPromise as PromiseMaybeWithServerResult<void, MutationResult>
+      ).server = serverPromise;
     }
 
     return clientPromise;

--- a/packages/zero-client/src/client/mutation-tracker.test.ts
+++ b/packages/zero-client/src/client/mutation-tracker.test.ts
@@ -1,6 +1,11 @@
 import {describe, test, expect} from 'vitest';
 import {MutationTracker} from './mutation-tracker.ts';
 import type {PushResponse} from '../../../zero-protocol/src/push.ts';
+import {makeReplicacheMutator} from './custom.ts';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
+import type {WriteTransaction} from './replicache-types.ts';
+import {zeroData} from '../../../replicache/src/transactions.ts';
 
 describe('MutationTracker', () => {
   const CLIENT_ID = 'test-client-1';
@@ -127,5 +132,55 @@ describe('MutationTracker', () => {
     const [result1, result2] = await Promise.all([mutation1, mutation2]);
     expect(result1).toBe(r1);
     expect(result2).toBe(r2);
+  });
+
+  test('mutation tracker size goes down each time a mutation is resolved or rejected', () => {
+    const tracker = new MutationTracker();
+    tracker.clientID = CLIENT_ID;
+    void tracker.trackMutation(1);
+    tracker.trackMutation(2).catch(() => {
+      // expected
+    });
+
+    const response: PushResponse = {
+      mutations: [
+        {
+          id: {clientID: CLIENT_ID, id: 1},
+          result: {},
+        },
+        {
+          id: {clientID: CLIENT_ID, id: 2},
+          result: {
+            error: 'app',
+          },
+        },
+      ],
+    };
+
+    tracker.processPushResponse(response);
+    expect(tracker.size).toBe(0);
+  });
+
+  test('mutations are not tracked on rebase', async () => {
+    const mt = new MutationTracker();
+    mt.clientID = CLIENT_ID;
+    const mutator = makeReplicacheMutator(
+      createSilentLogContext(),
+      mt,
+      async () => {},
+      createSchema({
+        tables: [],
+        relationships: [],
+      }),
+      0,
+    );
+
+    const tx = {
+      reason: 'rebase',
+      mutationID: 1,
+      [zeroData]: {},
+    };
+    await mutator(tx as unknown as WriteTransaction, {});
+    expect(mt.size).toBe(0);
   });
 });

--- a/packages/zero-client/src/client/mutation-tracker.test.ts
+++ b/packages/zero-client/src/client/mutation-tracker.test.ts
@@ -1,12 +1,13 @@
-import {describe, it, expect} from 'vitest';
+import {describe, test, expect} from 'vitest';
 import {MutationTracker} from './mutation-tracker.ts';
 import type {PushResponse} from '../../../zero-protocol/src/push.ts';
 
 describe('MutationTracker', () => {
   const CLIENT_ID = 'test-client-1';
 
-  it('tracks a mutation and resolves on success', async () => {
-    const tracker = new MutationTracker(CLIENT_ID);
+  test('tracks a mutation and resolves on success', async () => {
+    const tracker = new MutationTracker();
+    tracker.clientID = CLIENT_ID;
     const mutationPromise = tracker.trackMutation(1);
 
     const response: PushResponse = {
@@ -23,8 +24,9 @@ describe('MutationTracker', () => {
     expect(result).toEqual({});
   });
 
-  it('tracks a mutation and rejects on error', async () => {
-    const tracker = new MutationTracker(CLIENT_ID);
+  test('tracks a mutation and rejects on error', async () => {
+    const tracker = new MutationTracker();
+    tracker.clientID = CLIENT_ID;
     const mutationPromise = tracker.trackMutation(1);
 
     const response: PushResponse = {
@@ -46,8 +48,9 @@ describe('MutationTracker', () => {
     });
   });
 
-  it('handles push errors', async () => {
-    const tracker = new MutationTracker(CLIENT_ID);
+  test('handles push errors', async () => {
+    const tracker = new MutationTracker();
+    tracker.clientID = CLIENT_ID;
     const mutationPromise = tracker.trackMutation(1);
 
     const response: PushResponse = {
@@ -62,8 +65,9 @@ describe('MutationTracker', () => {
     });
   });
 
-  it('rejects mutation when explicitly rejected', async () => {
-    const tracker = new MutationTracker(CLIENT_ID);
+  test('rejects mutation when explicitly rejected', async () => {
+    const tracker = new MutationTracker();
+    tracker.clientID = CLIENT_ID;
     const mutationPromise = tracker.trackMutation(1);
 
     tracker.rejectMutation(1, new Error('Failed to send'));
@@ -71,8 +75,9 @@ describe('MutationTracker', () => {
     await expect(mutationPromise).rejects.toThrow('Failed to send');
   });
 
-  it('rejects mutations from other clients', () => {
-    const tracker = new MutationTracker(CLIENT_ID);
+  test('rejects mutations from other clients', () => {
+    const tracker = new MutationTracker();
+    tracker.clientID = CLIENT_ID;
     void tracker.trackMutation(1);
 
     const response: PushResponse = {
@@ -96,8 +101,9 @@ describe('MutationTracker', () => {
     );
   });
 
-  it('handles multiple concurrent mutations', async () => {
-    const tracker = new MutationTracker(CLIENT_ID);
+  test('handles multiple concurrent mutations', async () => {
+    const tracker = new MutationTracker();
+    tracker.clientID = CLIENT_ID;
     const mutation1 = tracker.trackMutation(1);
     const mutation2 = tracker.trackMutation(2);
 

--- a/packages/zero-client/src/client/mutation-tracker.ts
+++ b/packages/zero-client/src/client/mutation-tracker.ts
@@ -16,10 +16,13 @@ type MutationResult = MutationOk | MutationError | PushError;
  */
 export class MutationTracker {
   readonly #outstandingMutations: Map<number, Resolver<MutationResult>>;
-  readonly #clientID: string;
+  #clientID: string | undefined;
 
-  constructor(clientID: string) {
+  constructor() {
     this.#outstandingMutations = new Map();
+  }
+
+  set clientID(clientID: string) {
     this.#clientID = clientID;
   }
 
@@ -27,6 +30,7 @@ export class MutationTracker {
     assert(!this.#outstandingMutations.has(id));
     const mutationResolver = resolver<MutationResult>();
     this.#outstandingMutations.set(id, mutationResolver);
+    console.log('tracking, size:', this.#outstandingMutations.size);
     return mutationResolver.promise;
   }
 

--- a/packages/zero-client/src/client/mutation-tracker.ts
+++ b/packages/zero-client/src/client/mutation-tracker.ts
@@ -30,7 +30,6 @@ export class MutationTracker {
     assert(!this.#outstandingMutations.has(id));
     const mutationResolver = resolver<MutationResult>();
     this.#outstandingMutations.set(id, mutationResolver);
-    console.log('tracking, size:', this.#outstandingMutations.size);
     return mutationResolver.promise;
   }
 

--- a/packages/zero-client/src/client/mutation-tracker.ts
+++ b/packages/zero-client/src/client/mutation-tracker.ts
@@ -53,6 +53,10 @@ export class MutationTracker {
     }
   }
 
+  get size() {
+    return this.#outstandingMutations.size;
+  }
+
   #processPushError(error: PushError): void {
     const mids = error.mutationIDs;
 

--- a/packages/zero-protocol/src/push.ts
+++ b/packages/zero-protocol/src/push.ts
@@ -187,6 +187,7 @@ export type MutationError = v.Infer<typeof mutationErrorSchema>;
 export type PushError = v.Infer<typeof pushErrorSchema>;
 export type PushOk = v.Infer<typeof pushOkSchema>;
 export type MutationID = v.Infer<typeof mutationIDSchema>;
+export type MutationResult = v.Infer<typeof mutationResultSchema>;
 
 export function mapCRUD(
   arg: CRUDMutationArg,


### PR DESCRIPTION
Mutators now return a:

```ts
export type PromiseWithServerResult<T, S> = Promise<T> & {server: Promise<S>};
```

The `server` property allows waiting for authoritative results.


Usage looks like:

```ts
const close = z.mutate.issue.close();

// optionally await the local write
await close;


// optionally await/get/catch the server result
close.server.catch((e) => toast.showError(e));
```