### PR TITLE
chore(zero-cache): include tip for syncing tables from non-public schemas

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/client-schema.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-schema.test.ts
@@ -111,6 +111,27 @@ describe('client schemas', () => {
     checkClientSchema(SHARD_ID, clientSchema, tableSpecs, fullTables);
   });
 
+  test('missing tables with non-public schema', () => {
+    expect(() =>
+      checkClientSchema(
+        SHARD_ID,
+        {
+          tables: {
+            ['yyy.zzz']: {
+              columns: {
+                id: {type: 'string'},
+              },
+            },
+          },
+        },
+        tableSpecs,
+        fullTables,
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: {"kind":"SchemaVersionNotSupported","message":"The \\"yyy.zzz\\" table does not exist or is not one of the replicated tables: \\"bar\\",\\"foo\\". Note that zero does not sync tables from non-public schemas by default. Make sure you have defined a custom ZERO_APP_PUBLICATION to sync tables from non-public schemas."}]`,
+    );
+  });
+
   test('missing tables, missing columns', () => {
     expect(() =>
       checkClientSchema(

--- a/packages/zero-cache/src/services/view-syncer/client-schema.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-schema.ts
@@ -37,9 +37,15 @@ export function checkClientSchema(
         .sort()
         .map(t => `"${t}"`)
         .join(',');
+      const schemaTip =
+        missing.includes('.') && !syncedTables.includes('.')
+          ? ` Note that zero does not sync tables from non-public schemas ` +
+            `by default. Make sure you have defined a custom ` +
+            `ZERO_APP_PUBLICATION to sync tables from non-public schemas.`
+          : '';
       errors.push(
         `The "${missing}" table does not exist or is not ` +
-          `one of the replicated tables: ${syncedTables}.`,
+          `one of the replicated tables: ${syncedTables}.${schemaTip}`,
       );
     }
   }


### PR DESCRIPTION
Include a tip on how to sync non-public schemas is the missing table is from a non-public schema.

https://discord.com/channels/830183651022471199/1288232858795769917/1352746725777084517