### PR TITLE
chore(zero-cache): fix add-then-remove edge case

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr-store.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.ts
@@ -334,9 +334,10 @@ export class CVRStore {
    *       {@link putRowRecord()} with `refCounts: null` in order to properly
    *       produce the appropriate delete patch when catching up old clients.
    *
-   * This `delRowRecord()` method, on the other hand, is only used when a
-   * row record is being *replaced* by another RowRecord, which currently
-   * only happens when the columns of the row key change.
+   * This `delRowRecord()` method, on the other hand, is only used:
+   * - when a row record is being *replaced* by another RowRecord, which currently
+   *   only happens when the columns of the row key change
+   * - for "canceling" the put of a row that was not in the CVR in the first place.
    */
   delRowRecord(id: RowID): void {
     this.#pendingRowRecordUpdates.set(id, null);


### PR DESCRIPTION
Fix an edge case that was discovered in a stress test, whereby a row that was not previously in the CVR was added during an IVM advancement, and then removed in a different batch (of 10,000 rows).
