### PR TITLE
chore(zero-cache): better handling of large upstream transactions

### DIFF
--- a/packages/zero-cache/src/db/transaction-pool.ts
+++ b/packages/zero-cache/src/db/transaction-pool.ts
@@ -199,11 +199,12 @@ export class TransactionPool {
                 ...result.stmts.map(stmt =>
                   stmt
                     .execute()
-                    .then(() =>
-                      lc.debug?.(
-                        `Executed statement (${Date.now() - start} ms)`,
-                        (stmt as unknown as Stmt).strings,
-                      ),
+                    .then(
+                      () =>
+                        lc.debug?.(
+                          `Executed statement (${Date.now() - start} ms)`,
+                          (stmt as unknown as Stmt).strings,
+                        ),
                     )
                     .catch(e => this.fail(e)),
                 ),

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -327,7 +327,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     while (this.#state.shouldRun()) {
       let err: unknown;
       try {
-        const startAfter = await this.#storer.getLastWatermark();
+        const startAfter = await this.#storer.getLastWatermarkToStartStream();
         const stream = await this.#source.startStream(startAfter);
         this.#stream = stream;
         this.#state.resetBackoff();

--- a/packages/zero-cache/src/services/life-cycle.ts
+++ b/packages/zero-cache/src/services/life-cycle.ts
@@ -102,8 +102,9 @@ export class ProcessManager {
     }
     this.#all.add(proc);
 
-    proc.on('error', err =>
-      this.#lc.error?.(`error from ${name} ${proc.pid}`, err),
+    proc.on(
+      'error',
+      err => this.#lc.error?.(`error from ${name} ${proc.pid}`, err),
     );
     proc.on('close', (code, signal) =>
       this.#onExit(code, signal, null, type, name, proc),

--- a/packages/zero-cache/src/services/replicator/change-processor.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.ts
@@ -131,8 +131,8 @@ export class ChangeProcessor {
         type === 'begin'
           ? downstream[2].commitWatermark
           : type === 'commit'
-            ? downstream[2].watermark
-            : undefined;
+          ? downstream[2].watermark
+          : undefined;
       return this.#processMessage(lc, message, watermark);
     } catch (e) {
       this.#fail(lc, e);

--- a/packages/zero-cache/src/services/runner.ts
+++ b/packages/zero-cache/src/services/runner.ts
@@ -34,11 +34,12 @@ export class ServiceRunner<S extends Service> {
     this.#instances.set(id, service);
     void service
       .run()
-      .catch(e =>
-        this.#lc.error?.(
-          `Error running ${service.constructor?.name} ${service.id}`,
-          e,
-        ),
+      .catch(
+        e =>
+          this.#lc.error?.(
+            `Error running ${service.constructor?.name} ${service.id}`,
+            e,
+          ),
       )
       .finally(() => {
         this.#instances.delete(id);

--- a/packages/zero-cache/src/services/view-syncer/schema/types.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/types.ts
@@ -52,14 +52,14 @@ export function cmpVersions(
   return a === null && b === null
     ? 0
     : a === null
-      ? -1
-      : b === null
-        ? 1
-        : a.stateVersion < b.stateVersion
-          ? -1
-          : a.stateVersion > b.stateVersion
-            ? 1
-            : (a.minorVersion ?? 0) - (b.minorVersion ?? 0);
+    ? -1
+    : b === null
+    ? 1
+    : a.stateVersion < b.stateVersion
+    ? -1
+    : a.stateVersion > b.stateVersion
+    ? 1
+    : (a.minorVersion ?? 0) - (b.minorVersion ?? 0);
 }
 
 export function versionToCookie(v: CVRVersion): string {


### PR DESCRIPTION
Fix two issues discovered while stress-testing the change-streamer with very large transactions.

1. If the replication stream disconnects, the change-streamer will loop around and reconnect. Before doing so, wait for any pending changes to flush to the change db in order to resume from the correct watermark. Otherwise, a duplicate key error can occur:

<img width="1276" alt="Screenshot 2025-03-21 at 19 30 56" src="https://github.com/user-attachments/assets/fc9ef8bc-c575-408a-9549-12932848a2c2" />

2. The replication stream may disconnect if the change-streamer is applying back pressure and thus not responding to the periodic keepalives from postgres. To signal to postgres that the subscriber is still alive, manually send keepalive responses if none have been sent for longer than postgres's 30-second keepalive interval. This prevents postgres from disconnecting when the replication-manager is busy processing messages.

<img width="1273" alt="Screenshot 2025-03-21 at 20 07 51" src="https://github.com/user-attachments/assets/337aea54-ecc3-458e-865e-45aed6dca108" />
