### PR TITLE
chore(load-harness): simulate slow connections in the client-simulator

### DIFF
--- a/tools/client-simulator/src/main.ts
+++ b/tools/client-simulator/src/main.ts
@@ -1,7 +1,8 @@
 import {consoleLogSink, LogContext} from '@rocicorp/logger';
 import 'dotenv/config';
 import {nanoid} from 'nanoid';
-import WebSocket from 'ws';
+import {pipeline, Writable} from 'node:stream';
+import WebSocket, {createWebSocketStream} from 'ws';
 import {parseOptions} from '../../../packages/shared/src/options.ts';
 import * as v from '../../../packages/shared/src/valita.ts';
 import {initConnectionMessageSchema} from '../../../packages/zero-protocol/src/connect.ts';
@@ -14,12 +15,12 @@ const options = {
 
   numConnections: {type: v.number().default(1)},
 
-  schemaVersion: {type: v.number().default(5)},
+  millisBetweenMessages: {type: v.number().optional()},
 };
 
 function run() {
   const lc = new LogContext('debug', {}, consoleLogSink);
-  const {viewSyncers, numConnections, schemaVersion} = parseOptions(
+  const {viewSyncers, numConnections, millisBetweenMessages} = parseOptions(
     options,
     process.argv.slice(2),
     'ZERO_',
@@ -31,13 +32,13 @@ function run() {
   );
 
   let pokesReceived = 0;
+  let msgsReceived = 0;
   const clients: WebSocket[] = [];
   for (const vs of viewSyncers) {
     for (let i = 0; i < numConnections; i++) {
       const params = new URLSearchParams({
         clientGroupID: nanoid(10),
         clientID: nanoid(10),
-        schemaVersion: String(schemaVersion),
         baseCookie: '',
         ts: String(performance.now()),
         lmid: '1',
@@ -48,26 +49,50 @@ function run() {
         encodeURIComponent(btoa(JSON.stringify({initConnectionMessage}))),
       );
       lc.debug?.(`connecting to ${url}`);
-      ws.on('error', err => lc.error?.(err));
-      ws.on('open', () => lc.debug?.(`connected`));
-      ws.addEventListener('message', ({data}) => {
-        const message = v.parse(JSON.parse(data.toString()), downstreamSchema);
-        switch (message[0]) {
-          case 'error':
-            lc.error?.(message);
-            break;
-          case 'pokeEnd':
-            pokesReceived++;
-            break;
-        }
-      });
+      const stream = createWebSocketStream(ws);
+      stream.on('error', err => lc.error?.(err));
+      stream.on('open', () => lc.debug?.(`connected`));
+      stream.on('close', () => lc.debug?.(`connection to ${url} closed`));
+      pipeline(
+        stream,
+        new Writable({
+          write: (data, _encoding, callback) => {
+            try {
+              const message = v.parse(
+                JSON.parse(data.toString()),
+                downstreamSchema,
+              );
+              const type = message[0];
+              msgsReceived++;
+              switch (type) {
+                case 'error':
+                  lc.error?.(message);
+                  break;
+                case 'pokeEnd':
+                  pokesReceived++;
+                  break;
+              }
+              if (millisBetweenMessages === undefined) {
+                callback();
+              } else {
+                setTimeout(callback, millisBetweenMessages);
+              }
+            } catch (err) {
+              callback(err instanceof Error ? err : new Error(String(err)));
+            }
+          },
+        }),
+        () => {},
+      );
       clients.push(ws);
     }
   }
 
   lc.info?.('');
   function logStatus() {
-    process.stdout.write(`\rPOKES: ${pokesReceived}`);
+    process.stdout.write(
+      `\rPOKES:\t${pokesReceived}\tMESSAGES:\t${msgsReceived}`,
+    );
   }
   const statusUpdater = setInterval(logStatus, 1000);
 


### PR DESCRIPTION
Add a `--millis-between-messages` option to the client simulator to simulate slow connections using tcp back pressure.