### PR TITLE
feat(zbugs): Add discord notifications.

### DIFF
--- a/apps/zbugs/README.md
+++ b/apps/zbugs/README.md
@@ -36,15 +36,6 @@ ZERO_UPSTREAM_DB = "postgresql://user:password@127.0.0.1:6434/postgres"
 # Where to send custom mutations
 ZERO_PUSH_URL = "http://localhost:5173/api/push"
 
-# A separate Postgres database we use to store CVRs. CVRs (client view records)
-# keep track of which clients have which data. This is how we know what diff to
-# send on reconnect. It can be same database as above, but it makes most sense
-# for it to be a separate "database" in the same postgres "cluster".
-ZERO_CVR_DB = "postgresql://user:password@127.0.0.1:6435/postgres"
-
-# Yet another Postgres database which we used to store a replication log.
-ZERO_CHANGE_DB = "postgresql://user:password@127.0.0.1:6435/postgres"
-
 # Place to store the SQLite data zero-cache maintains. This can be lost, but if
 # it is, zero-cache will have to re-replicate next time it starts up.
 ZERO_REPLICA_FILE = "/tmp/zbugs-sync-replica.db"
@@ -79,6 +70,10 @@ PRIVATE_JWK = ""
 VITE_PUBLIC_SERVER="http://localhost:4848"
 # See comment on `ZERO_AUTH_JWK`
 VITE_PUBLIC_JWK=''
+
+# Discord webhook to send notifications to. Not required. Notifications won't
+# be sent if absent.
+DISCORD_WEBHOOK_URL=''
 ```
 
 Then start the server:

--- a/apps/zbugs/api/discord.ts
+++ b/apps/zbugs/api/discord.ts
@@ -1,0 +1,36 @@
+export async function postToDiscord({
+  title,
+  message,
+  link,
+}: {
+  title: string;
+  message: string;
+  link: string;
+}) {
+  const content = `**${title}**\n${message}\n<${link}>`;
+  const url = process.env.DISCORD_WEBHOOK_URL;
+  if (!url) {
+    console.log('No discord URL, skipping posting message', content);
+    return;
+  }
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({content}),
+    });
+
+    if (Math.floor(response.status / 100) !== 2) {
+      console.error(
+        'Failed to post to Discord:',
+        response,
+        await response.text(),
+      );
+    }
+  } catch (e) {
+    console.error('Failed to post to Discord:', e);
+  }
+}

--- a/apps/zbugs/api/notify.ts
+++ b/apps/zbugs/api/notify.ts
@@ -1,0 +1,153 @@
+import {type Schema} from '../shared/schema.ts';
+import {type Validators} from '../shared/validators.ts';
+import {must} from '../../../packages/shared/src/must.ts';
+import {assert} from '../../../packages/shared/src/asserts.ts';
+import {type Transaction, type UpdateValue} from '@rocicorp/zero';
+import {postToDiscord} from './discord.ts';
+import {schema} from '../shared/schema.ts';
+
+type CreateIssueNotification = {
+  kind: 'create-issue';
+};
+
+type UpdateIssueNotification = {
+  kind: 'update-issue';
+  update: UpdateValue<typeof schema.tables.issue>;
+};
+
+type AddEmojiToIssueNotification = {
+  kind: 'add-emoji-to-issue';
+  emoji: string;
+};
+
+type AddEmojiToCommentNotification = {
+  kind: 'add-emoji-to-comment';
+  commentID: string;
+  emoji: string;
+};
+
+type AddCommentNotification = {
+  kind: 'add-comment';
+  commentID: string;
+  comment: string;
+};
+
+type EditCommentNotification = {
+  kind: 'edit-comment';
+  commentID: string;
+  comment: string;
+};
+
+type NotificationArgs = {issueID: string} & (
+  | CreateIssueNotification
+  | UpdateIssueNotification
+  | AddEmojiToIssueNotification
+  | AddEmojiToCommentNotification
+  | AddCommentNotification
+  | EditCommentNotification
+);
+
+export async function notify(
+  tx: Transaction<Schema>,
+  v: Validators,
+  args: NotificationArgs,
+) {
+  const {issueID, kind} = args;
+  const issue = await tx.query.issue.where('id', issueID).one().run();
+  assert(issue);
+
+  if (issue.visibility !== 'public') {
+    console.log('Skipping notification for private issue', issueID);
+    return;
+  }
+
+  const modifierUserID = must((await v.verifyToken(tx)).sub);
+  const modifierUser = await tx.query.user
+    .where('id', modifierUserID)
+    .one()
+    .run();
+  console.log('modifierUser', modifierUser);
+  assert(modifierUser);
+
+  switch (kind) {
+    case 'create-issue': {
+      await postToDiscord({
+        title: `${modifierUser.login} reported an issue`,
+        message: [issue.title, clip(issue.description ?? '')]
+          .filter(Boolean)
+          .join('\n'),
+        link: `https://bugs.rocicorp.dev/issue/${issue.shortID}`,
+      });
+      break;
+    }
+
+    case 'update-issue': {
+      const {update} = args;
+      if (update.open !== undefined) {
+        const title = `${modifierUser.login} ${
+          update.open ? 'reopened' : 'closed'
+        } an issue`;
+        await postToDiscord({
+          title,
+          message: issue.title,
+          link: `https://bugs.rocicorp.dev/issue/${issue.shortID}`,
+        });
+      } else {
+        await postToDiscord({
+          title: `${modifierUser.login} updated an issue`,
+          message: [issue.title, clip(issue.description ?? '')]
+            .filter(Boolean)
+            .join('\n'),
+          link: `https://bugs.rocicorp.dev/issue/${issue.shortID}`,
+        });
+      }
+      break;
+    }
+
+    case 'add-emoji-to-issue': {
+      const {emoji} = args;
+      await postToDiscord({
+        title: `${modifierUser.login} reacted to an issue`,
+        message: [issue.title, emoji].join('\n'),
+        link: `https://bugs.rocicorp.dev/issue/${issue.shortID}`,
+      });
+      break;
+    }
+
+    case 'add-emoji-to-comment': {
+      const {commentID, emoji} = args;
+      const comment = await tx.query.comment.where('id', commentID).one().run();
+      assert(comment);
+      await postToDiscord({
+        title: `${modifierUser.login} reacted to a comment`,
+        message: [clip(comment.body), emoji].filter(Boolean).join('\n'),
+        link: `https://bugs.rocicorp.dev/issue/${issue.shortID}`,
+      });
+      break;
+    }
+
+    case 'add-comment': {
+      const {commentID, comment} = args;
+      await postToDiscord({
+        title: `${modifierUser.login} commented on an issue`,
+        message: [issue.title, clip(comment)].join('\n'),
+        link: `https://bugs.rocicorp.dev/issue/${issue.shortID}#comment-${commentID}`,
+      });
+      break;
+    }
+
+    case 'edit-comment': {
+      const {commentID, comment} = args;
+      await postToDiscord({
+        title: `${modifierUser.login} edited a comment`,
+        message: [issue.title, clip(comment)].join('\n'),
+        link: `https://bugs.rocicorp.dev/issue/${issue.shortID}#comment-${commentID}`,
+      });
+      break;
+    }
+  }
+}
+
+function clip(s: string) {
+  return s.length > 255 ? s.slice(0, 255) + '...' : s;
+}

--- a/apps/zbugs/api/push-handler.ts
+++ b/apps/zbugs/api/push-handler.ts
@@ -7,7 +7,7 @@ import {
 } from '@rocicorp/zero/pg';
 import postgres, {type JSONValue} from 'postgres';
 import {schema} from '../shared/schema.ts';
-import {createMutators} from '../shared/mutators.ts';
+import {createServerMutators} from './server-mutators.ts';
 
 class Connection implements DBConnection<postgres.TransactionSql> {
   readonly #pg: postgres.Sql;
@@ -41,6 +41,6 @@ const mutatorSql = postgres(process.env.ZERO_UPSTREAM_DB as string);
 
 export const pushHandler: PushHandler = createPushHandler({
   dbConnectionProvider: () => new Connection(mutatorSql),
-  mutators: createMutators(process.env.VITE_PUBLIC_JWK as string),
+  mutators: createServerMutators(process.env.VITE_PUBLIC_JWK as string),
   schema,
 });

--- a/apps/zbugs/api/server-mutators.ts
+++ b/apps/zbugs/api/server-mutators.ts
@@ -1,0 +1,143 @@
+import {
+  createMutators,
+  type CreateIssueArgs,
+  type AddEmojiArgs,
+  type AddCommentArgs,
+} from '../shared/mutators.ts';
+import {type CustomMutatorDefs, type UpdateValue} from '@rocicorp/zero';
+import {schema} from '../shared/schema.ts';
+import type {JWK} from 'jose';
+import {Validators} from '../shared/validators.ts';
+import {notify} from './notify.ts';
+import {assert} from '../../../packages/shared/src/asserts.ts';
+
+export function createServerMutators(publicJwk: string) {
+  // This `?? {}` is a workaround as the Vite build system ends up invoking
+  // `createMutators` via `configureServer` in `vite.config.ts`.
+  // On github CI we do not have access to the publicJwk, so we default to an empty object.
+  const v = new Validators(JSON.parse(publicJwk ?? '{}') as JWK);
+  const mutators = createMutators(v);
+
+  return {
+    ...mutators,
+
+    issue: {
+      ...mutators.issue,
+
+      async create(tx, {id, title, description}: CreateIssueArgs) {
+        await mutators.issue.create(tx, {
+          id,
+          title,
+          description,
+          created: Date.now(),
+          modified: Date.now(),
+        });
+        void notify(tx, v, {kind: 'create-issue', issueID: id});
+      },
+
+      async update(tx, update: UpdateValue<typeof schema.tables.issue>) {
+        await mutators.issue.update(tx, {
+          ...update,
+          modified: Date.now(),
+        });
+        await notify(tx, v, {
+          kind: 'update-issue',
+          issueID: update.id,
+          update,
+        });
+      },
+
+      async addLabel(
+        tx,
+        {issueID, labelID}: {issueID: string; labelID: string},
+      ) {
+        await mutators.issue.addLabel(tx, {issueID, labelID});
+        await notify(tx, v, {
+          kind: 'update-issue',
+          issueID,
+          update: {id: issueID},
+        });
+      },
+
+      async removeLabel(
+        tx,
+        {issueID, labelID}: {issueID: string; labelID: string},
+      ) {
+        await mutators.issue.removeLabel(tx, {issueID, labelID});
+        await notify(tx, v, {
+          kind: 'update-issue',
+          issueID,
+          update: {id: issueID},
+        });
+      },
+    },
+
+    emoji: {
+      ...mutators.emoji,
+
+      async addToIssue(tx, args: AddEmojiArgs) {
+        await mutators.emoji.addToIssue(tx, {
+          ...args,
+          created: Date.now(),
+        });
+        await notify(tx, v, {
+          kind: 'add-emoji-to-issue',
+          issueID: args.subjectID,
+          emoji: args.unicode,
+        });
+      },
+
+      async addToComment(tx, args: AddEmojiArgs) {
+        await mutators.emoji.addToComment(tx, {
+          ...args,
+          created: Date.now(),
+        });
+
+        const comment = await tx.query.comment
+          .where('id', args.subjectID)
+          .one()
+          .run();
+        assert(comment);
+        await notify(tx, v, {
+          kind: 'add-emoji-to-comment',
+          issueID: comment.issueID,
+          commentID: args.subjectID,
+          emoji: args.unicode,
+        });
+      },
+    },
+
+    comment: {
+      ...mutators.comment,
+
+      async add(tx, {id, issueID, body}: AddCommentArgs) {
+        await mutators.comment.add(tx, {
+          id,
+          issueID,
+          body,
+          created: Date.now(),
+        });
+        await notify(tx, v, {
+          kind: 'add-comment',
+          issueID,
+          commentID: id,
+          comment: body,
+        });
+      },
+
+      async edit(tx, {id, body}: {id: string; body: string}) {
+        await mutators.comment.edit(tx, {id, body});
+
+        const comment = await tx.query.comment.where('id', id).one().run();
+        assert(comment);
+
+        await notify(tx, v, {
+          kind: 'edit-comment',
+          issueID: comment.issueID,
+          commentID: id,
+          comment: body,
+        });
+      },
+    },
+  } as const satisfies CustomMutatorDefs<typeof schema>;
+}

--- a/apps/zbugs/src/zero-setup.ts
+++ b/apps/zbugs/src/zero-setup.ts
@@ -5,6 +5,7 @@ import {Atom} from './atom.ts';
 import {clearJwt, getJwt, getRawJwt} from './jwt.ts';
 import {mark} from './perf-log.ts';
 import {CACHE_FOREVER} from './query-cache-policy.ts';
+import {Validators} from '../shared/validators.ts';
 
 export type LoginState = {
   encoded: string;
@@ -31,11 +32,14 @@ authAtom.value =
 authAtom.onChange(auth => {
   zeroAtom.value?.close();
   mark('creating new zero');
+  console.log('auth', auth);
   const z = new Zero({
     logLevel: 'info',
     server: import.meta.env.VITE_PUBLIC_SERVER,
     userID: auth?.decoded?.sub ?? 'anon',
-    mutators: createMutators(import.meta.env.VITE_PUBLIC_JWK),
+    mutators: createMutators(
+      new Validators(JSON.parse(import.meta.env.VITE_PUBLIC_JWK)),
+    ),
     auth: (error?: 'invalid-token') => {
       if (error === 'invalid-token') {
         clearJwt();

--- a/packages/zero-cache/src/auth/jwt.ts
+++ b/packages/zero-cache/src/auth/jwt.ts
@@ -41,13 +41,13 @@ export async function verifyToken(
   token: string,
   verifyOptions: JWTClaimVerificationOptions,
 ): Promise<JWTPayload> {
-  const numOptionsSet = [config.jwk, config.secret, config.jwksUrl].reduce(
-    (l, r) => l + (r !== undefined ? 1 : 0),
-    0,
+  const optionsSet = (['jwk', 'secret', 'jwksUrl'] as const).filter(
+    key => config[key] !== undefined,
   );
   assert(
-    numOptionsSet === 1,
-    'Exactly one of jwk, secret, or jwksUrl must be set in order to verify tokens',
+    optionsSet.length === 1,
+    'Exactly one of jwk, secret, or jwksUrl must be set in order to verify tokens but actually the following were set: ' +
+      JSON.stringify(optionsSet),
   );
 
   if (config.jwk !== undefined) {


### PR DESCRIPTION
There are a few issues here though:

1. We are awaiting on the notification within the PG tx :-|. I had to do this because the notification wasn't getting sent if I didn't. Need to figure out what's going on there.

2. I observed that if there was not a matching mutator name, the mutation retries forever. It should be silently skipped.

At the same time refactored how created/modified dates are set. This seems slightly nicer?