### PR TITLE
chore: Add test:watch and check-types:watch to root

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,12 @@
     "build": "turbo run build",
     "dev": "turbo run dev",
     "test": "vitest run",
+    "test:watch": "vitest",
     "lint": "turbo run lint",
     "format": "turbo run format",
     "check-format": "turbo run check-format",
     "check-types": "turbo run check-types",
+    "check-types:watch": "turbo watch check-types",
     "build-ci": "npm install && turbo run build",
     "start-zero-cache": "cd packages/zero-cache && npm run start"
   },


### PR DESCRIPTION
You can now run `npm run test:watch` and `npm run check-types:watch` from the mono root and it will do the right thing. to watch for changes and re-run tests and type checks.