### PR TITLE
fix(zero-cache): Fix too large timer exception

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -702,7 +702,9 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     lc.debug?.('Scheduling eviction timer to run in ', next - now, 'ms');
     this.#expiredQueriesTimer = this.#setTimeout(
       () => this.#runInLockWithCVR(this.#removeExpiredQueries),
-      next - now,
+      // If the expire time is too far in the future we will run it in an hour.
+      // At that point in time it will be rescheduled as needed again.
+      Math.min(next - now, 60 * 60 * 1000), // 1 hour
     );
   }
 


### PR DESCRIPTION
NodeJS timers have a maximum limit of 2^31-1 milliseconds, which is about 24.8 days. This commit fixes the issue by setting the timer to 1h which will then reschedule the expiration work again.

https://bugs.rocicorp.dev/issue/3645