### PR TITLE
chore: fix create-canary

### DIFF
--- a/packages/zero/tool/create-canary.js
+++ b/packages/zero/tool/create-canary.js
@@ -193,12 +193,12 @@ try {
         {cwd: basePath('packages', 'zero')},
       );
     } catch (e) {
-      const wait = (i + 1) * 20;
-      console.error(
-        `Error building docker image, retrying in ${wait} seconds...`,
-      );
-      await new Promise(resolve => setTimeout(resolve, 10000));
-      continue;
+      if (i < 3) {
+        console.error(`Error building docker image, retrying in 10 seconds...`);
+        await new Promise(resolve => setTimeout(resolve, 10_000));
+        continue;
+      }
+      throw e;
     }
     break;
   }


### PR DESCRIPTION
It was reporting success even when docker push failed.