### PR TITLE
chore(mutators): close connection on fatal errors

### DIFF
--- a/packages/zero-protocol/src/protocol-version.test.ts
+++ b/packages/zero-protocol/src/protocol-version.test.ts
@@ -11,6 +11,6 @@ test('protocol version', () => {
   // If this test fails upstream or downstream schema has changed such that
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
-  expect(hash).toEqual('kgpizwq3kw2o');
+  expect(hash).toEqual('197n4i7n0dfho');
   expect(PROTOCOL_VERSION).toEqual(9);
 });

--- a/packages/zero-protocol/src/push.ts
+++ b/packages/zero-protocol/src/push.ts
@@ -108,17 +108,9 @@ const appErrorSchema = v.object({
 const zeroErrorSchema = v.object({
   error: v.literal('ooo-mutation'),
 });
-const tokenErrorSchema = v.object({
-  error: v.literal('token'),
-  // the user can add any additional fields in their API server
-});
 
 const mutationOkSchema = v.object({});
-const mutationErrorSchema = v.union(
-  appErrorSchema,
-  zeroErrorSchema,
-  tokenErrorSchema,
-);
+const mutationErrorSchema = v.union(appErrorSchema, zeroErrorSchema);
 const mutationResultSchema = v.union(mutationOkSchema, mutationErrorSchema);
 const mutationResponseSchema = v.object({
   id: mutationIDSchema,


### PR DESCRIPTION
Problem 1:
- custom mutators did not close the connection on `InvalidPush` errors (OOO mutation, bad push version).

Problem 2:
- custom mutators would resolve client promises for a mutation on `InvalidPush` errors. This was wrong since these mutations will be retried later. No longer resolve these promises. We do that by not sending a response for mutations that fail with `InvalidPush` errors and instead close the connection.


--- 

Removed 'token' error type as that is unused. Left protocol version unchanged since it was unused.
