### PR TITLE
chore(mutators): deal with extra properties in mutator responses

### DIFF
--- a/packages/zero-client/src/client/custom.ts
+++ b/packages/zero-client/src/client/custom.ts
@@ -142,6 +142,7 @@ export function makeReplicacheMutator<S extends Schema>(
 
     if (repTx.reason === 'initial') {
       const serverPromise = mutationTracker.trackMutation(repTx.mutationID);
+
       (
         clientPromise as PromiseMaybeWithServerResult<void, MutationResult>
       ).server = serverPromise;

--- a/packages/zero-client/src/client/mutation-tracker.ts
+++ b/packages/zero-client/src/client/mutation-tracker.ts
@@ -3,13 +3,12 @@ import type {
   MutationError,
   MutationID,
   MutationOk,
+  MutationResult,
   PushError,
   PushOk,
   PushResponse,
 } from '../../../zero-protocol/src/push.ts';
 import {assert} from '../../../shared/src/asserts.ts';
-
-type MutationResult = MutationOk | MutationError | PushError;
 
 /**
  * Tracks what pushes are in-flight and resolves promises when they're acked.

--- a/packages/zero-protocol/src/ast.test.ts
+++ b/packages/zero-protocol/src/ast.test.ts
@@ -607,5 +607,5 @@ test('protocol version', () => {
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
   expect(hash).toEqual('2zzy9s2lcdcms');
-  expect(PROTOCOL_VERSION).toEqual(9);
+  expect(PROTOCOL_VERSION).toEqual(10);
 });

--- a/packages/zero-protocol/src/protocol-version.test.ts
+++ b/packages/zero-protocol/src/protocol-version.test.ts
@@ -11,6 +11,6 @@ test('protocol version', () => {
   // If this test fails upstream or downstream schema has changed such that
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
-  expect(hash).toEqual('197n4i7n0dfho');
-  expect(PROTOCOL_VERSION).toEqual(9);
+  expect(hash).toEqual('t7u0oo1fhqzn');
+  expect(PROTOCOL_VERSION).toEqual(10);
 });

--- a/packages/zero-protocol/src/protocol-version.ts
+++ b/packages/zero-protocol/src/protocol-version.ts
@@ -17,7 +17,7 @@ import {assert} from '../../shared/src/asserts.ts';
 // -- Version 6 makes `pokeStart.cookie` optional. (0.16)
 // -- Version 7 introduces the initConnection.clientSchema field. (0.17)
 // -- Version 8 drops support for Version 5 (0.18).
-export const PROTOCOL_VERSION = 9;
+export const PROTOCOL_VERSION = 10;
 
 /**
  * The minimum server-supported sync protocol version (i.e. the version

--- a/packages/zero-protocol/src/push.ts
+++ b/packages/zero-protocol/src/push.ts
@@ -103,14 +103,20 @@ const mutationIDSchema = v.object({
 
 const appErrorSchema = v.object({
   error: v.literal('app'),
-  // the user can add any additional fields in their API server
+  // The user can return any additional data here
+  details: jsonSchema.optional(),
 });
 const zeroErrorSchema = v.object({
   error: v.literal('ooo-mutation'),
+  details: jsonSchema.optional(),
 });
 
-const mutationOkSchema = v.object({});
+const mutationOkSchema = v.object({
+  // The user can return any additional data here
+  data: jsonSchema.optional(),
+});
 const mutationErrorSchema = v.union(appErrorSchema, zeroErrorSchema);
+
 const mutationResultSchema = v.union(mutationOkSchema, mutationErrorSchema);
 const mutationResponseSchema = v.object({
   id: mutationIDSchema,


### PR DESCRIPTION
Adds a `JSON` field to `error` and `ok` responses to allow the user to return any sort of extra data required.