### PR TITLE
feat(zero-cache): protect zero-cache with client-side back-pressure

### DIFF
--- a/packages/zero-cache/src/services/mutagen/pusher.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.ts
@@ -257,7 +257,7 @@ class PushWorker {
         }
       }
     }
-    // Wait for results to get sent downstream go avoid queueing up
+    // Wait for results to be sent downstream to avoid queueing up
     // an arbitrary amount of responses in memory.
     await Promise.allSettled(pushed);
   }

--- a/packages/zero-cache/src/services/mutagen/pusher.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.ts
@@ -1,21 +1,21 @@
 import type {LogContext} from '@rocicorp/logger';
+import {groupBy} from '../../../../shared/src/arrays.ts';
 import {must} from '../../../../shared/src/must.ts';
 import {Queue} from '../../../../shared/src/queue.ts';
 import * as v from '../../../../shared/src/valita.ts';
+import type {Downstream} from '../../../../zero-protocol/src/down.ts';
+import * as ErrorKind from '../../../../zero-protocol/src/error-kind-enum.ts';
 import {
   pushResponseSchema,
   type PushBody,
   type PushResponse,
 } from '../../../../zero-protocol/src/push.ts';
-import type {Service} from '../service.ts';
 import {type ZeroConfig} from '../../config/zero-config.ts';
-import {upstreamSchema} from '../../types/shards.ts';
-import type {HandlerResult} from '../../workers/connection.ts';
-import type {Downstream} from '../../../../zero-protocol/src/down.ts';
-import {Subscription} from '../../types/subscription.ts';
-import {groupBy} from '../../../../shared/src/arrays.ts';
 import {ErrorForClient} from '../../types/error-for-client.ts';
-import * as ErrorKind from '../../../../zero-protocol/src/error-kind-enum.ts';
+import {upstreamSchema} from '../../types/shards.ts';
+import {Subscription, type Result} from '../../types/subscription.ts';
+import type {HandlerResult} from '../../workers/connection.ts';
+import type {Service} from '../service.ts';
 
 export interface Pusher {
   enqueuePush(
@@ -159,7 +159,7 @@ class PushWorker {
       const [pushes, terminate] = combinePushes([task, ...rest]);
       for (const push of pushes) {
         const response = await this.#processPush(push);
-        this.#fanOutResponses(response);
+        await this.#fanOutResponses(response);
       }
 
       if (terminate) {
@@ -178,7 +178,8 @@ class PushWorker {
    * Each client is on a different websocket connection though, so we need to fan out the response
    * to all the clients that were part of the push.
    */
-  #fanOutResponses(response: PushResponse) {
+  async #fanOutResponses(response: PushResponse) {
+    const pushed: Promise<Result>[] = [];
     if ('error' in response) {
       const groupedMutationIDs = groupBy(
         response.mutationIDs ?? [],
@@ -203,13 +204,15 @@ class PushWorker {
             }),
           );
         } else {
-          client[1].push([
-            'push-response',
-            {
-              ...response,
-              mutationIDs,
-            },
-          ]);
+          pushed.push(
+            client[1].push([
+              'push-response',
+              {
+                ...response,
+                mutationIDs,
+              },
+            ]).result,
+          );
         }
       }
     } else {
@@ -244,7 +247,9 @@ class PushWorker {
         const successes = failure ? mutations.slice(0, i) : mutations;
 
         if (successes.length > 0) {
-          client[1].push(['push-response', {mutations: successes}]);
+          pushed.push(
+            client[1].push(['push-response', {mutations: successes}]).result,
+          );
         }
 
         if (failure) {
@@ -252,6 +257,9 @@ class PushWorker {
         }
       }
     }
+    // Wait for results to get sent downstream go avoid queueing up
+    // an arbitrary amount of responses in memory.
+    await Promise.allSettled(pushed);
   }
 
   async #processPush(entry: PusherEntry): Promise<PushResponse> {

--- a/packages/zero-cache/src/workers/connection.ts
+++ b/packages/zero-cache/src/workers/connection.ts
@@ -1,6 +1,7 @@
 import type {LogContext} from '@rocicorp/logger';
+import {pipeline, Readable, Writable} from 'node:stream';
 import type {CloseEvent, Data, ErrorEvent} from 'ws';
-import WebSocket from 'ws';
+import WebSocket, {createWebSocketStream} from 'ws';
 import {assert} from '../../../shared/src/asserts.ts';
 import * as valita from '../../../shared/src/valita.ts';
 import {
@@ -11,7 +12,6 @@ import type {ConnectedMessage} from '../../../zero-protocol/src/connect.ts';
 import type {Downstream} from '../../../zero-protocol/src/down.ts';
 import * as ErrorKind from '../../../zero-protocol/src/error-kind-enum.ts';
 import {type ErrorBody} from '../../../zero-protocol/src/error.ts';
-import type {PongMessage} from '../../../zero-protocol/src/pong.ts';
 import {
   MIN_SERVER_SUPPORTED_SYNC_PROTOCOL,
   PROTOCOL_VERSION,
@@ -43,6 +43,15 @@ export interface MessageHandler {
   handleMessage(msg: Upstream): Promise<HandlerResult>;
 }
 
+// Ensures that a downstream message is sent at least every interval, sending a
+// 'pong' if necessary. This is set to be slightly longer than the client-side
+// PING_INTERVAL of 5 seconds, so that in the common case, 'pong's are sent in
+// response to client-initiated 'ping's. However, if the inbound stream is
+// backed up because a command is taking a long time to process, the pings
+// will be stuck in the queue (i.e. back-pressured), in which case pongs will
+// be manually sent to notify the client of server liveness.
+const DOWNSTREAM_MSG_INTERVAL_MS = 6_000;
+
 /**
  * Represents a connection between the client and server.
  *
@@ -58,6 +67,7 @@ export class Connection {
   readonly #lc: LogContext;
   readonly #onClose: () => void;
   readonly #messageHandler: MessageHandler;
+  readonly #downstreamMsgTimer: NodeJS.Timeout | undefined;
 
   #viewSyncerOutboundStream: Source<Downstream> | undefined;
   #pusherOutboundStream: Source<Downstream> | undefined;
@@ -84,9 +94,14 @@ export class Connection {
       .withContext('wsID', wsID);
     this.#onClose = onClose;
 
-    this.#ws.addEventListener('message', this.#handleMessage);
     this.#ws.addEventListener('close', this.#handleClose);
     this.#ws.addEventListener('error', this.#handleError);
+
+    this.#proxyInbound();
+    this.#downstreamMsgTimer = setInterval(
+      this.#maybeSendPong,
+      DOWNSTREAM_MSG_INTERVAL_MS / 2,
+    );
   }
 
   /**
@@ -114,7 +129,7 @@ export class Connection {
         'connected',
         {wsid: this.#wsID, timestamp: Date.now()},
       ];
-      send(this.#ws, connectedMessage);
+      this.send(connectedMessage, 'ignore-backpressure');
     }
   }
 
@@ -124,7 +139,6 @@ export class Connection {
     }
     this.#closed = true;
     this.#lc.info?.(`closing connection: ${reason}`, ...args);
-    this.#ws.removeEventListener('message', this.#handleMessage);
     this.#ws.removeEventListener('close', this.#handleClose);
     this.#ws.removeEventListener('error', this.#handleError);
     this.#viewSyncerOutboundStream?.cancel();
@@ -135,6 +149,7 @@ export class Connection {
     if (this.#ws.readyState !== this.#ws.CLOSED) {
       this.#ws.close();
     }
+    clearTimeout(this.#downstreamMsgTimer);
 
     // spin down services if we have
     // no more client connections for the client group?
@@ -167,7 +182,7 @@ export class Connection {
     try {
       const msgType = msg[0];
       if (msgType === 'ping') {
-        this.send(['pong', {}] satisfies PongMessage);
+        this.send(['pong', {}], 'ignore-backpressure');
         return;
       }
 
@@ -202,7 +217,7 @@ export class Connection {
             this.#pusherOutboundStream = result.stream;
             break;
         }
-        void this.#proxyOutbound(result.stream);
+        this.#proxyOutbound(result.stream);
         break;
       }
       case 'transient': {
@@ -238,15 +253,39 @@ export class Connection {
     this.#lc.error?.('WebSocket error event', e.message, e.error);
   };
 
-  async #proxyOutbound(outboundStream: Source<Downstream>) {
-    try {
-      for await (const outMsg of outboundStream) {
-        this.send(outMsg);
-      }
-      this.close('downstream closed by ViewSyncer');
-    } catch (e) {
-      this.#closeWithThrown(e);
-    }
+  #proxyInbound() {
+    pipeline(
+      createWebSocketStream(this.#ws),
+      new Writable({
+        write: (data, _encoding, callback) => {
+          this.#handleMessage({data}).then(() => callback(), callback);
+        },
+      }),
+      // The done callback is not used, as #handleClose and #handleError,
+      // configured on the underlying WebSocket, provide more complete
+      // information.
+      () => {},
+    );
+  }
+
+  #proxyOutbound(outboundStream: Source<Downstream>) {
+    // Note: createWebSocketStream() is avoided here in order to control
+    //       exception handling with #closeWithThrown(). If the Writable
+    //       from createWebSocketStream() were instead used, exceptions
+    //       from the outboundStream result in the Writable closing the
+    //       the websocket before the error message can be sent.
+    pipeline(
+      Readable.from(outboundStream),
+      new Writable({
+        objectMode: true,
+        write: (downstream: Downstream, _encoding, callback) =>
+          this.send(downstream, callback),
+      }),
+      e =>
+        e
+          ? this.#closeWithThrown(e)
+          : this.close(`downstream closed by ViewSyncer`),
+    );
   }
 
   #closeWithThrown(e: unknown) {
@@ -263,8 +302,21 @@ export class Connection {
     this.close(`client error: ${errorBody.kind}`, errorBody);
   }
 
-  send(data: Downstream) {
-    send(this.#ws, data);
+  #lastDownstreamMsgTime = Date.now();
+
+  #maybeSendPong = () => {
+    if (Date.now() - this.#lastDownstreamMsgTime > DOWNSTREAM_MSG_INTERVAL_MS) {
+      this.#lc.debug?.('manually sending pong');
+      this.send(['pong', {}], 'ignore-backpressure');
+    }
+  };
+
+  send(
+    data: Downstream,
+    callback: ((err?: Error | null) => void) | 'ignore-backpressure',
+  ) {
+    this.#lastDownstreamMsgTime = Date.now();
+    return send(this.#lc, this.#ws, data, callback);
   }
 
   sendError(errorBody: ErrorBody, thrown?: unknown) {
@@ -272,8 +324,22 @@ export class Connection {
   }
 }
 
-export function send(ws: WebSocket, data: Downstream) {
-  ws.send(JSON.stringify(data));
+function send(
+  lc: LogContext,
+  ws: WebSocket,
+  data: Downstream,
+  callback: ((err?: Error | null) => void) | 'ignore-backpressure',
+) {
+  if (ws.readyState === ws.OPEN) {
+    ws.send(
+      JSON.stringify(data),
+      callback === 'ignore-backpressure' ? undefined : callback,
+    );
+  } else {
+    lc.debug?.(`Dropping outbound message on ws (state: ${ws.readyState})`, {
+      dropped: data,
+    });
+  }
 }
 
 export function sendError(
@@ -285,5 +351,5 @@ export function sendError(
   lc = lc.withContext('errorKind', errorBody.kind);
   const logLevel = thrown ? getLogLevel(thrown) : 'info';
   lc[logLevel]?.('Sending error on WebSocket', errorBody, thrown ?? '');
-  send(ws, ['error', errorBody]);
+  send(lc, ws, ['error', errorBody], 'ignore-backpressure');
 }

--- a/packages/zero-cache/src/workers/connection.ts
+++ b/packages/zero-cache/src/workers/connection.ts
@@ -50,6 +50,10 @@ export interface MessageHandler {
 // backed up because a command is taking a long time to process, the pings
 // will be stuck in the queue (i.e. back-pressured), in which case pongs will
 // be manually sent to notify the client of server liveness.
+//
+// This is equivalent to what is done for Postgres keepalives on the
+// replication stream (which can similarly be back-pressured):
+// https://github.com/rocicorp/mono/blob/f98cb369a2dbb15650328859c732db358f187ef0/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.ts#L21
 const DOWNSTREAM_MSG_INTERVAL_MS = 6_000;
 
 /**


### PR DESCRIPTION
Use TCP backpressure to protect the zero-cache against memory blowup from either slow downstream connections or over-zealous upstream messages (e.g. DOS).

### Downstream

By simulating a large download (#4080) over a slow connection (#4076), the load harness is able to create a scenario in which a zero-cache (without downstream backpressure) crashes with an OOM.
  
![chart (4)](https://github.com/user-attachments/assets/5b836a0a-adb1-48be-b4ef-735ea8635454)

With back-pressure applied, the zero-cache eventually succeeds in the streaming the large download to the client:

![chart (5)](https://github.com/user-attachments/assets/5e4add9a-61e9-4031-9e39-f7a4feccb568)

This works by having IVM wait for downstream messages to be flushed to the connection before computing the next batch of data to be sent. For mutations, the Pusher similarly waits for responses to be sent before computing the next batch of results.

### Upstream

Upstream flow control is similarly enforced by only pulling messages from the connection after the previous messages have been processed (modulo an internal buffer in the TCP channel).

This works out of the box for the View Syncer as most commands block on being processed in the lock.

There is a TODO added to the Pusher to cap the size of the mutation queue to prevent memory blowup.
