### PR TITLE
fix(zero-cache): improve "no permissions message" with --app-id flag

### DIFF
--- a/packages/zero-cache/src/auth/load-permissions.ts
+++ b/packages/zero-cache/src/auth/load-permissions.ts
@@ -25,10 +25,11 @@ export function loadPermissions(
     `SELECT permissions, hash FROM "${appID}.permissions"`,
   );
   if (permissions === null) {
+    const appIDFlag = appID === 'zero' ? '' : ` --app-id=${appID}`;
     lc.warn?.(
       `\n\n\n` +
         `No upstream permissions deployed.\n` +
-        `Run 'npx zero-deploy-permissions' to enforce permissions.` +
+        `Run 'npx zero-deploy-permissions${appIDFlag}' to enforce permissions.` +
         `\n\n\n`,
     );
     return {permissions, hash: null};


### PR DESCRIPTION
User report: https://discord.com/channels/830183651022471199/1288232858795769917/1353875570211029052