### PR TITLE
chore(zero-cache,pg): test type conversion on write

### DIFF
--- a/packages/zero-pg/src/custom.pg-test.ts
+++ b/packages/zero-pg/src/custom.pg-test.ts
@@ -148,6 +148,29 @@ describe('makeSchemaCRUD', () => {
       ]);
     });
   });
+
+  test('convert types on write', async () => {
+    await pg.begin(async tx => {
+      const crud = crudProvider(new Transaction(tx));
+      await crud.needsConversion.insert({
+        id: '1',
+        date: new Date('2021-01-01').getTime(),
+        time: new Date('1970-01-01T12:34:56Z').getTime(),
+        numeric: 1.23,
+        bigint: 123,
+      });
+
+      await checkDb(tx, 'needsConversion', [
+        {
+          id: '1',
+          date: new Date('2021-01-01').getTime(),
+          time: new Date('1970-01-01T12:34:56Z').getTime(),
+          numeric: 1.23,
+          bigint: 123,
+        },
+      ]);
+    });
+  });
 });
 
 async function checkDb(pg: PostgresDB, table: string, expected: unknown[]) {

--- a/packages/zero-pg/src/test/schema.ts
+++ b/packages/zero-pg/src/test/schema.ts
@@ -32,6 +32,15 @@ export const schema = createSchema({
         c: string().optional(),
       })
       .primaryKey('a', 'b'),
+    table('needsConversion')
+      .columns({
+        id: string(),
+        date: number(),
+        time: number(),
+        numeric: number(),
+        bigint: number(),
+      })
+      .primaryKey('id'),
   ],
   relationships: [],
 });
@@ -55,7 +64,16 @@ CREATE TABLE "compoundPk" (
   b INTEGER,
   c TEXT,
   PRIMARY KEY (a, b)
-);`;
+);
+
+CREATE TABLE "needsConversion" (
+  id TEXT PRIMARY KEY,
+  date DATE,
+  time TIME,
+  numeric NUMERIC,
+  bigint BIGINT
+);
+`;
 
 export const seedDataSql = `
 INSERT INTO basic (id, a, b, c) VALUES ('1', 2, 'foo', true);


### PR DESCRIPTION
All of these tests fail. We need to convert types on write.

@darkgnotic  - the CRUD test failure surprised me because I know we have people inserting epochs into date columns.