### PR TITLE
chore(mutators): register read queries in mutators

### DIFF
--- a/packages/shared/src/sentinels.ts
+++ b/packages/shared/src/sentinels.ts
@@ -1,0 +1,1 @@
+export function emptyFunction() {}

--- a/packages/zero-client/src/client/custom.bench.ts
+++ b/packages/zero-client/src/client/custom.bench.ts
@@ -23,6 +23,7 @@ bench('big schema', () => {
       [zeroData]: {},
     } as unknown as WriteTransaction,
     schema,
+    [],
     0,
   );
 });

--- a/packages/zero-client/src/client/mutation-tracker.test.ts
+++ b/packages/zero-client/src/client/mutation-tracker.test.ts
@@ -13,7 +13,7 @@ describe('MutationTracker', () => {
   test('tracks a mutation and resolves on success', async () => {
     const tracker = new MutationTracker();
     tracker.clientID = CLIENT_ID;
-    const mutationPromise = tracker.trackMutation(1);
+    const mutationPromise = tracker.trackMutation(1, []);
 
     const response: PushResponse = {
       mutations: [
@@ -32,7 +32,7 @@ describe('MutationTracker', () => {
   test('tracks a mutation and rejects on error', async () => {
     const tracker = new MutationTracker();
     tracker.clientID = CLIENT_ID;
-    const mutationPromise = tracker.trackMutation(1);
+    const mutationPromise = tracker.trackMutation(1, []);
 
     const response: PushResponse = {
       mutations: [
@@ -56,7 +56,7 @@ describe('MutationTracker', () => {
   test('handles push errors', async () => {
     const tracker = new MutationTracker();
     tracker.clientID = CLIENT_ID;
-    const mutationPromise = tracker.trackMutation(1);
+    const mutationPromise = tracker.trackMutation(1, []);
 
     const response: PushResponse = {
       error: 'unsupported-push-version',
@@ -70,20 +70,10 @@ describe('MutationTracker', () => {
     });
   });
 
-  test('rejects mutation when explicitly rejected', async () => {
-    const tracker = new MutationTracker();
-    tracker.clientID = CLIENT_ID;
-    const mutationPromise = tracker.trackMutation(1);
-
-    tracker.rejectMutation(1, new Error('Failed to send'));
-
-    await expect(mutationPromise).rejects.toThrow('Failed to send');
-  });
-
   test('rejects mutations from other clients', () => {
     const tracker = new MutationTracker();
     tracker.clientID = CLIENT_ID;
-    void tracker.trackMutation(1);
+    void tracker.trackMutation(1, []);
 
     const response: PushResponse = {
       mutations: [
@@ -109,8 +99,8 @@ describe('MutationTracker', () => {
   test('handles multiple concurrent mutations', async () => {
     const tracker = new MutationTracker();
     tracker.clientID = CLIENT_ID;
-    const mutation1 = tracker.trackMutation(1);
-    const mutation2 = tracker.trackMutation(2);
+    const mutation1 = tracker.trackMutation(1, []);
+    const mutation2 = tracker.trackMutation(2, []);
 
     const r1 = {};
     const r2 = {};
@@ -137,8 +127,8 @@ describe('MutationTracker', () => {
   test('mutation tracker size goes down each time a mutation is resolved or rejected', () => {
     const tracker = new MutationTracker();
     tracker.clientID = CLIENT_ID;
-    void tracker.trackMutation(1);
-    tracker.trackMutation(2).catch(() => {
+    void tracker.trackMutation(1, []);
+    tracker.trackMutation(2, []).catch(() => {
       // expected
     });
 

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -623,6 +623,7 @@ export class Zero<
       rep.experimentalWatch.bind(rep),
       maxRecentQueries,
     );
+    this.#mutationTracker.setQueryManager(this.#queryManager);
     this.#clientToServer = clientToServer(schema.tables);
 
     this.#deleteClientsManager = new DeleteClientsManager(


### PR DESCRIPTION
Problem:


> if a user checks permissions on the client in a custom mutator, nothing prevents the queries that provided the permission data from being deregistered before the mutator is rebased.
>
> It’d be a weird interaction to:
>
> 1. Have the mutator succeed
> 2. Navigate to a new page
> 3. Have the mutator rebase and fail because the queries it used are gone



This implement's @arv's idea:

> That is a good point. We should keep queries in the mutators alive until mutator has been confirmed
>
> I don’t think we need to change ref counting… we just need to add the queries to the desired set when the mutator is run the first time and removed when the mutator is acknowledged

https://rocicorp.slack.com/archives/C013XFG80JC/p1742815429158529