### PR TITLE
feat(mutators)!: nest server result in client promise for custom muta…

### DIFF
--- a/packages/zero-client/src/client/test-utils.ts
+++ b/packages/zero-client/src/client/test-utils.ts
@@ -36,6 +36,10 @@ import {
   getInternalReplicacheImplForTesting,
   onSetConnectionStateSymbol,
 } from './zero.ts';
+import type {
+  PushResponse,
+  PushResponseMessage,
+} from '../../../zero-protocol/src/push.ts';
 
 type ConnectionState = Enum<typeof ConnectionState>;
 type ErrorKind = Enum<typeof ErrorKind>;
@@ -203,6 +207,11 @@ export class TestZero<
 
   triggerPullResponse(pullResponseBody: PullResponseBody): Promise<void> {
     const msg: PullResponseMessage = ['pull', pullResponseBody];
+    return this.triggerMessage(msg);
+  }
+
+  triggerPushResponse(pushResponseBody: PushResponse): Promise<void> {
+    const msg: PushResponseMessage = ['push-response', pushResponseBody];
     return this.triggerMessage(msg);
   }
 

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -16,6 +16,7 @@ import type {PullRequest} from '../../../replicache/src/sync/pull.ts';
 import type {PushRequest} from '../../../replicache/src/sync/push.ts';
 import type {
   MutatorDefs,
+  MutatorReturn,
   UpdateNeededReason as ReplicacheUpdateNeededReason,
 } from '../../../replicache/src/types.ts';
 import {assert, unreachable} from '../../../shared/src/asserts.ts';
@@ -477,7 +478,9 @@ export class Zero<
             mutatorOrMutators,
             schema,
             slowMaterializeThreshold,
-          );
+            // Replicache expects mutators to only be able to return JSON
+            // but Zero wraps the return with: `{server?: Promise<MutationResult>, client?: T}`
+          ) as () => MutatorReturn;
           continue;
         }
         if (typeof mutatorOrMutators === 'object') {
@@ -493,7 +496,7 @@ export class Zero<
               mutator as CustomMutatorImpl<S>,
               schema,
               slowMaterializeThreshold,
-            );
+            ) as () => MutatorReturn;
           }
           continue;
         }

--- a/packages/zero-protocol/src/push.ts
+++ b/packages/zero-protocol/src/push.ts
@@ -179,6 +179,7 @@ export type Mutation = v.Infer<typeof mutationSchema>;
 export type PushBody = v.Infer<typeof pushBodySchema>;
 export type PushMessage = v.Infer<typeof pushMessageSchema>;
 export type PushResponse = v.Infer<typeof pushResponseSchema>;
+export type PushResponseMessage = v.Infer<typeof pushResponseMessageSchema>;
 export type MutationResponse = v.Infer<typeof mutationResponseSchema>;
 export type MutationOk = v.Infer<typeof mutationOkSchema>;
 export type MutationError = v.Infer<typeof mutationErrorSchema>;


### PR DESCRIPTION
…tors

We cannot tack properties onto `Promise` since any `async` function above us in the stack will undo that change by wrapping the promise in a new one.

----

The change --

The return type for a custom mutator was:

```ts
Promise<void> & {server: Promise<MutationResult>}
```

Now it is:

```ts
Promise<{server?: Promise<MutationResult>}>
```