### PR TITLE
feat(zero-cache): support ALTER SCHEMA ddl changes

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg-test.ts
@@ -653,6 +653,62 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
       [],
     ],
     [
+      'rename schema',
+      'ALTER SCHEMA my RENAME TO your;',
+      [{tag: 'drop-index'}, {tag: 'rename-table'}, {tag: 'create-index'}],
+      {['your.bar']: []},
+      [
+        {
+          columns: {
+            ['_0_version']: {
+              characterMaximumLength: null,
+              dataType: 'TEXT',
+              dflt: null,
+              notNull: false,
+              pos: 2,
+            },
+            id: {
+              characterMaximumLength: null,
+              dataType: 'int8|NOT_NULL',
+              dflt: null,
+              notNull: false,
+              pos: 1,
+            },
+            handle: {
+              characterMaximumLength: null,
+              dataType: 'text|NOT_NULL',
+              dflt: null,
+              notNull: false,
+              pos: 3,
+            },
+            foo: {
+              characterMaximumLength: null,
+              dataType: 'text|NOT_NULL',
+              dflt: null,
+              notNull: false,
+              pos: 4,
+            },
+            boo: {
+              characterMaximumLength: null,
+              dataType: 'TEXT',
+              dflt: null,
+              notNull: false,
+              pos: 5,
+            },
+          },
+          name: 'your.bar',
+        },
+      ],
+      [
+        {
+          columns: {handle: 'ASC'},
+          name: 'your.bar_pkey',
+          tableName: 'your.bar',
+          unique: true,
+        },
+      ],
+    ],
+    [
       'add unpublished column',
       'ALTER TABLE foo ADD "newInt" INT4;',
       [], // no DDL event published
@@ -1264,11 +1320,7 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
     ) => {
       await upstream.unsafe(stmts);
       const transaction = await nextTransaction();
-      expect(transaction.length).toBe(changes.length);
-
-      transaction.forEach((change, i) => {
-        expect(change).toMatchObject(changes[i]);
-      });
+      expect(transaction).toMatchObject(changes);
 
       expectMatchingObjectsInTables(replica, expectedData, 'bigint');
 

--- a/packages/zero-cache/src/services/change-source/pg/decommission.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/decommission.pg-test.ts
@@ -58,6 +58,7 @@ describe('decommission', () => {
       ['zeroout_drop_table_13'],
       ['zeroout_drop_index_13'],
       ['zeroout_alter_publication_13'],
+      ['zeroout_alter_schema_13'],
     ]);
     expect(
       await upstream`SELECT slot_name FROM pg_replication_slots WHERE slot_name LIKE 'zeroout%'`.values(),

--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl.pg-test.ts
@@ -312,8 +312,8 @@ describe('change-source/tables/ddl', () => {
         version: 1,
         event: {
           tag: 'CREATE TABLE',
-          table: {schema: 'pub', name: 'bar'},
-        },
+          table: {schema: 'deprecated', name: 'deprecated'},
+        } as {tag: string},
         schema: {
           tables: inserted(DDL_START.schema.tables, 0, {
             oid: expect.any(Number),
@@ -397,8 +397,8 @@ describe('change-source/tables/ddl', () => {
         version: 1,
         event: {
           tag: 'CREATE INDEX',
-          index: {schema: 'pub', name: 'foo_name_index'},
-        },
+          index: {schema: 'deprecated', name: 'deprecated'},
+        } as {tag: string},
         schema: {
           tables: DDL_START.schema.tables,
           indexes: inserted(DDL_START.schema.indexes, 3, {
@@ -425,8 +425,8 @@ describe('change-source/tables/ddl', () => {
         version: 1,
         event: {
           tag: 'ALTER TABLE',
-          table: {schema: 'pub', name: 'food'},
-        },
+          table: {schema: 'deprecated', name: 'deprecated'},
+        } as {tag: string},
         schema: {
           tables: replaced(DDL_START.schema.tables, 1, 1, {
             oid: expect.any(Number),
@@ -505,8 +505,8 @@ describe('change-source/tables/ddl', () => {
         },
         event: {
           tag: 'ALTER TABLE',
-          table: {schema: 'pub', name: 'foo'},
-        },
+          table: {schema: 'deprecated', name: 'deprecated'},
+        } as {tag: string},
         type: 'ddlUpdate',
         version: 1,
         schema: {
@@ -575,8 +575,8 @@ describe('change-source/tables/ddl', () => {
         version: 1,
         event: {
           tag: 'ALTER TABLE',
-          table: {schema: 'pub', name: 'foo'},
-        },
+          table: {schema: 'deprecated', name: 'deprecated'},
+        } as {tag: string},
         schema: {
           indexes: DDL_START.schema.indexes,
           tables: replaced(DDL_START.schema.tables, 1, 1, {
@@ -637,8 +637,8 @@ describe('change-source/tables/ddl', () => {
         version: 1,
         event: {
           tag: 'ALTER TABLE',
-          table: {schema: 'pub', name: 'foo'},
-        },
+          table: {schema: 'deprecated', name: 'deprecated'},
+        } as {tag: string},
         schema: {
           indexes: DDL_START.schema.indexes,
           tables: replaced(DDL_START.schema.tables, 1, 1, {
@@ -691,8 +691,8 @@ describe('change-source/tables/ddl', () => {
         version: 1,
         event: {
           tag: 'ALTER TABLE',
-          table: {schema: 'pub', name: 'foo'},
-        },
+          table: {schema: 'deprecated', name: 'deprecated'},
+        } as {tag: string},
         schema: {
           tables: replaced(DDL_START.schema.tables, 1, 1, {
             oid: expect.any(Number),
@@ -764,8 +764,8 @@ describe('change-source/tables/ddl', () => {
         version: 1,
         event: {
           tag: 'ALTER TABLE',
-          table: {schema: 'pub', name: 'foo'},
-        },
+          table: {schema: 'deprecated', name: 'deprecated'},
+        } as {tag: string},
         schema: {
           tables: replaced(DDL_START.schema.tables, 1, 1, {
             oid: expect.any(Number),
@@ -1064,6 +1064,191 @@ describe('change-source/tables/ddl', () => {
               publications: {
                 ['zero_all']: {rowFilter: null}, // Now part of zero_all
               },
+            },
+          ],
+        },
+      },
+    ],
+    [
+      'alter schema',
+      `ALTER SCHEMA pub RENAME TO bup`,
+      {
+        context: {
+          query: 'ALTER SCHEMA pub RENAME TO bup',
+        },
+        type: 'ddlUpdate',
+        version: 1,
+        event: {tag: 'ALTER SCHEMA'},
+        schema: {
+          tables: [
+            {
+              oid: expect.any(Number),
+              schema: 'bup',
+              name: 'boo',
+              columns: {
+                description: {
+                  characterMaximumLength: null,
+                  dataType: 'text',
+                  typeOID: 25,
+                  dflt: null,
+                  notNull: false,
+                  pos: 3,
+                },
+                id: {
+                  characterMaximumLength: null,
+                  dataType: 'text',
+                  typeOID: 25,
+                  dflt: null,
+                  notNull: true,
+                  pos: 1,
+                },
+                name: {
+                  characterMaximumLength: null,
+                  dataType: 'text',
+                  typeOID: 25,
+                  dflt: null,
+                  notNull: false,
+                  pos: 2,
+                },
+              },
+              primaryKey: ['id'],
+              publications: {
+                ['zero_all']: {rowFilter: null},
+                ['zero_sum']: {rowFilter: null},
+              },
+            },
+            {
+              oid: expect.any(Number),
+              schema: 'bup',
+              name: 'foo',
+              columns: {
+                description: {
+                  characterMaximumLength: null,
+                  dataType: 'text',
+                  typeOID: 25,
+                  dflt: null,
+                  notNull: false,
+                  pos: 3,
+                },
+                id: {
+                  characterMaximumLength: null,
+                  dataType: 'text',
+                  typeOID: 25,
+                  dflt: null,
+                  notNull: true,
+                  pos: 1,
+                },
+                name: {
+                  characterMaximumLength: null,
+                  dataType: 'text',
+                  typeOID: 25,
+                  dflt: null,
+                  notNull: false,
+                  pos: 2,
+                },
+              },
+              primaryKey: ['id'],
+              publications: {
+                ['zero_all']: {rowFilter: null},
+                ['zero_sum']: {rowFilter: null},
+              },
+            },
+            {
+              oid: expect.any(Number),
+              schema: 'bup',
+              name: 'yoo',
+              columns: {
+                description: {
+                  characterMaximumLength: null,
+                  dataType: 'text',
+                  typeOID: 25,
+                  dflt: null,
+                  notNull: false,
+                  pos: 3,
+                },
+                id: {
+                  characterMaximumLength: null,
+                  dataType: 'text',
+                  typeOID: 25,
+                  dflt: null,
+                  notNull: true,
+                  pos: 1,
+                },
+                name: {
+                  characterMaximumLength: null,
+                  dataType: 'text',
+                  typeOID: 25,
+                  dflt: null,
+                  notNull: false,
+                  pos: 2,
+                },
+              },
+              primaryKey: ['id'],
+              publications: {['zero_all']: {rowFilter: null}},
+            },
+          ],
+          indexes: [
+            {
+              name: 'boo_name_key',
+              schema: 'bup',
+              tableName: 'boo',
+              columns: {name: 'ASC'},
+              unique: true,
+            },
+            {
+              name: 'boo_pkey',
+              schema: 'bup',
+              tableName: 'boo',
+              columns: {id: 'ASC'},
+              unique: true,
+            },
+            {
+              name: 'foo_custom_index',
+              schema: 'bup',
+              tableName: 'foo',
+              columns: {
+                description: 'ASC',
+                name: 'ASC',
+              },
+              unique: false,
+            },
+            {
+              name: 'foo_name_key',
+              schema: 'bup',
+              tableName: 'foo',
+              columns: {name: 'ASC'},
+              unique: true,
+            },
+            {
+              name: 'foo_pkey',
+              schema: 'bup',
+              tableName: 'foo',
+              columns: {id: 'ASC'},
+              unique: true,
+            },
+            {
+              name: 'yoo_custom_index',
+              schema: 'bup',
+              tableName: 'yoo',
+              columns: {
+                description: 'ASC',
+                name: 'ASC',
+              },
+              unique: false,
+            },
+            {
+              name: 'yoo_name_key',
+              schema: 'bup',
+              tableName: 'yoo',
+              columns: {name: 'ASC'},
+              unique: true,
+            },
+            {
+              name: 'yoo_pkey',
+              schema: 'bup',
+              tableName: 'yoo',
+              columns: {id: 'ASC'},
+              unique: true,
             },
           ],
         },

--- a/packages/zero-cache/src/services/change-source/pg/schema/init.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.pg-test.ts
@@ -14,8 +14,8 @@ const SHARD_NUM = 23;
 
 // Update as necessary.
 const CURRENT_SCHEMA_VERSIONS = {
-  dataVersion: 6,
-  schemaVersion: 6,
+  dataVersion: 7,
+  schemaVersion: 7,
   minSafeVersion: 1,
   lock: 'v',
 } as const;
@@ -110,7 +110,7 @@ describe('change-streamer/pg/schema/init', () => {
       },
     },
     {
-      name: 'v5 to v6',
+      name: 'v5 to v7',
       upstreamSetup: `
         CREATE SCHEMA ${APP_ID}_${SHARD_NUM};
         CREATE TABLE ${APP_ID}_${SHARD_NUM}."shardConfig" (
@@ -164,7 +164,10 @@ describe('change-streamer/pg/schema/init', () => {
           {
             appID: APP_ID,
             shardNum: SHARD_NUM,
-            publications: c.requestedPublications ?? [],
+            publications: c.requestedPublications ?? [
+              `_${APP_ID}_metadata_23`,
+              `_${APP_ID}_public_23`,
+            ],
           },
           '123',
         );

--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.pg-test.ts
@@ -75,6 +75,7 @@ describe('change-source/pg', () => {
       'zro_drop_table_0',
       'zro_drop_index_0',
       'zro_alter_publication_0',
+      'zro_alter_schema_0',
     ]);
   });
 

--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
@@ -255,6 +255,14 @@ export async function setupTablesAndReplication(
   const pubs = await getPublicationInfo(tx, allPublications);
   await replicaIdentitiesForTablesWithoutPrimaryKeys(pubs)?.apply(lc, tx);
 
+  await setupTriggers(lc, tx, shard);
+}
+
+export async function setupTriggers(
+  lc: LogContext,
+  tx: PostgresTransaction,
+  shard: ShardConfig,
+) {
   try {
     await tx.savepoint(sub => sub.unsafe(triggerSetup(shard)));
   } catch (e) {


### PR DESCRIPTION
Adds support for `ALTER SCHEMA ...` ddl changes, which essentially map to one or more table renames on the replica.

This is necessary to implement (one strategy of) non-disruptive resyncs, but is technically also a user-usable feature given that non-public schemas are supported.

Also clean up / simplify the trigger logic as it is now based on a simple diff. The new format deprecates the unused `table` and `index` fields and does not constrain the `tag` values, thus improving forwards compatibility.