### PR TITLE
chore(mutators): await pushed messages before failing the stream

### DIFF
--- a/packages/zero-cache/src/services/mutagen/pusher.test.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.test.ts
@@ -630,10 +630,11 @@ describe('pusher streaming', () => {
         ]
       `);
 
-      // The stream should fail with InvalidPush error
-      await expect(
-        result.stream[Symbol.asyncIterator]().next(),
-      ).rejects.toThrow('mutation was out of order');
+      // The stream should be completed after the OOO mutation
+      expect(await result.stream[Symbol.asyncIterator]().next()).toEqual({
+        done: true,
+        value: undefined,
+      });
     }
   });
 

--- a/packages/zero-client/src/client/mutation-tracker.test.ts
+++ b/packages/zero-client/src/client/mutation-tracker.test.ts
@@ -53,7 +53,7 @@ describe('MutationTracker', () => {
     });
   });
 
-  test('handles push errors', async () => {
+  test('does not resolve mutators for transient errors', async () => {
     const tracker = new MutationTracker();
     tracker.clientID = CLIENT_ID;
     const mutationPromise = tracker.trackMutation(1, []);
@@ -64,10 +64,13 @@ describe('MutationTracker', () => {
     };
 
     tracker.processPushResponse(response);
-    await expect(mutationPromise).rejects.toEqual({
-      error: 'unsupported-push-version',
-      mutationIDs: [{clientID: CLIENT_ID, id: 1}],
+    let called = false;
+    void mutationPromise.finally(() => {
+      called = true;
     });
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(tracker.size).toBe(1);
+    expect(called).toBe(false);
   });
 
   test('rejects mutations from other clients', () => {


### PR DESCRIPTION
If we've enqueued messages to the stream, wait for those messages to be consumed before closing the connection.

Previously a failure in a batch of mutations could cause the connection to close before the success responses ever got sent.

```
m1 : success
m2 : success
m3 : success
m4 : fail
```

^-- this would close the stream before responses to m1 -> m3 could be processed.