### PR TITLE
chore(zero-client): Build zero with '@databases/sql/web'

### DIFF
--- a/packages/zero/tool/build.ts
+++ b/packages/zero/tool/build.ts
@@ -116,6 +116,10 @@ async function buildZeroClient() {
     dropLabels,
     outdir: basePath('out'),
     entryPoints,
+    alias: {
+      '@databases/sql': '@databases/sql/web',
+    },
+    mainFields: ['module', 'browser', 'main'],
   });
   if (metafile) {
     await writeFile(basePath('out/meta.json'), JSON.stringify(result.metafile));


### PR DESCRIPTION
Since '@databases/sql' references `node:fs` which causes headaches when people are bundling.