### PR TITLE
chore: Remove tsc-alias

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18094,20 +18094,6 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/mylas": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/mylas/-/mylas-2.1.13.tgz",
-      "integrity": "sha512-+MrqnJRtxdF+xngFfUUkIMQrUUL0KsxbADUkn23Z/4ibGg192Q+z+CQyiYwvWTsYjJygmMR8+w3ZDa98Zh6ESg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/raouldeheer"
-      }
-    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -19195,19 +19181,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/plimit-lit": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/plimit-lit/-/plimit-lit-1.6.1.tgz",
-      "integrity": "sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "queue-lit": "^1.5.1"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/postcss": {
@@ -20835,16 +20808,6 @@
       "license": "MIT",
       "dependencies": {
         "inherits": "~2.0.3"
-      }
-    },
-    "node_modules/queue-lit": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/queue-lit/-/queue-lit-1.5.2.tgz",
-      "integrity": "sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/queue-microtask": {
@@ -24361,34 +24324,6 @@
         "node": ">=0.3.1"
       }
     },
-    "node_modules/tsc-alias": {
-      "version": "1.8.10",
-      "resolved": "https://registry.npmjs.org/tsc-alias/-/tsc-alias-1.8.10.tgz",
-      "integrity": "sha512-Ibv4KAWfFkFdKJxnWfVtdOmB0Zi1RJVxcbPGiCDsFpCQSsmpWyuzHG3rQyI5YkobWwxFPEyQfu1hdo4qLG2zPw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chokidar": "^3.5.3",
-        "commander": "^9.0.0",
-        "globby": "^11.0.4",
-        "mylas": "^2.1.9",
-        "normalize-path": "^3.0.0",
-        "plimit-lit": "^1.2.6"
-      },
-      "bin": {
-        "tsc-alias": "dist/bin/index.js"
-      }
-    },
-    "node_modules/tsc-alias/node_modules/commander": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || >=14"
-      }
-    },
     "node_modules/tsconfck": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.3.tgz",
@@ -26553,7 +26488,6 @@
         "playwright": "^1.51.0",
         "shared": "0.0.0",
         "sinon": "^13.0.1",
-        "tsc-alias": "^1.8.10",
         "typescript": "~5.8.2",
         "vitest": "3.0.8"
       }
@@ -26849,7 +26783,6 @@
         "@vitest/runner": "3.0.8",
         "esbuild": "^0.25.0",
         "replicache": "15.2.1",
-        "tsc-alias": "^1.8.10",
         "typescript": "~5.8.2",
         "vitest": "3.0.8"
       },
@@ -26975,7 +26908,6 @@
         "replicache": "15.2.1",
         "shared": "0.0.0",
         "sinon": "^13.0.1",
-        "tsc-alias": "^1.8.10",
         "typescript": "~5.8.2",
         "zero-protocol": "0.0.0"
       }
@@ -31480,7 +31412,6 @@
         "postgres": "^3.4.4",
         "replicache": "15.2.1",
         "semver": "^7.5.4",
-        "tsc-alias": "^1.8.10",
         "tsx": "^4.19.1",
         "typescript": "~5.8.2",
         "url-pattern": "^1.0.3",
@@ -38926,12 +38857,6 @@
       "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
       "dev": true
     },
-    "mylas": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/mylas/-/mylas-2.1.13.tgz",
-      "integrity": "sha512-+MrqnJRtxdF+xngFfUUkIMQrUUL0KsxbADUkn23Z/4ibGg192Q+z+CQyiYwvWTsYjJygmMR8+w3ZDa98Zh6ESg==",
-      "dev": true
-    },
     "mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -39669,15 +39594,6 @@
       "version": "1.51.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.0.tgz",
       "integrity": "sha512-x47yPE3Zwhlil7wlNU/iktF7t2r/URR3VLbH6EknJd/04Qc/PSJ0EY3CMXipmglLG+zyRxW6HNo2EGbKLHPWMg=="
-    },
-    "plimit-lit": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/plimit-lit/-/plimit-lit-1.6.1.tgz",
-      "integrity": "sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==",
-      "dev": true,
-      "requires": {
-        "queue-lit": "^1.5.1"
-      }
     },
     "postcss": {
       "version": "8.5.3",
@@ -40638,12 +40554,6 @@
         "inherits": "~2.0.3"
       }
     },
-    "queue-lit": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/queue-lit/-/queue-lit-1.5.2.tgz",
-      "integrity": "sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==",
-      "dev": true
-    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -41372,7 +41282,6 @@
         "playwright": "^1.51.0",
         "shared": "0.0.0",
         "sinon": "^13.0.1",
-        "tsc-alias": "^1.8.10",
         "typescript": "~5.8.2",
         "vitest": "3.0.8"
       },
@@ -43275,28 +43184,6 @@
         }
       }
     },
-    "tsc-alias": {
-      "version": "1.8.10",
-      "resolved": "https://registry.npmjs.org/tsc-alias/-/tsc-alias-1.8.10.tgz",
-      "integrity": "sha512-Ibv4KAWfFkFdKJxnWfVtdOmB0Zi1RJVxcbPGiCDsFpCQSsmpWyuzHG3rQyI5YkobWwxFPEyQfu1hdo4qLG2zPw==",
-      "dev": true,
-      "requires": {
-        "chokidar": "^3.5.3",
-        "commander": "^9.0.0",
-        "globby": "^11.0.4",
-        "mylas": "^2.1.9",
-        "normalize-path": "^3.0.0",
-        "plimit-lit": "^1.2.6"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "9.5.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-          "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-          "dev": true
-        }
-      }
-    },
     "tsconfck": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.3.tgz",
@@ -44771,7 +44658,6 @@
         "replicache": "15.2.1",
         "shared": "0.0.0",
         "sinon": "^13.0.1",
-        "tsc-alias": "^1.8.10",
         "typescript": "~5.8.2",
         "zero-protocol": "0.0.0"
       },

--- a/packages/replicache/package.json
+++ b/packages/replicache/package.json
@@ -21,7 +21,7 @@
     "check-types": "tsc && tsc --project tool/tsconfig.json",
     "check-types:watch": "tsc --watch",
     "lint": "eslint --ext .ts,.tsx,.js,.jsx src/",
-    "build": "rm -rf out && tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && npx tsx tool/build.ts",
+    "build": "rm -rf out && tsc -p tsconfig.build.json && npx tsx tool/build.ts",
     "build-bundle-sizes": "rm -rf out && npx tsx tool/build.ts --bundle-sizes",
     "prepack": "npm run lint && npm run test && npm run build && mv README.md README-org.md && mv README-external.md README.md",
     "postpack": "mv README.md README-external.md && mv README-org.md README.md",
@@ -47,7 +47,6 @@
     "playwright": "^1.51.0",
     "shared": "0.0.0",
     "sinon": "^13.0.1",
-    "tsc-alias": "^1.8.10",
     "typescript": "~5.8.2",
     "vitest": "3.0.8"
   },

--- a/packages/zero-client/package.json
+++ b/packages/zero-client/package.json
@@ -30,7 +30,6 @@
     "replicache": "15.2.1",
     "shared": "0.0.0",
     "sinon": "^13.0.1",
-    "tsc-alias": "^1.8.10",
     "typescript": "~5.8.2",
     "zero-protocol": "0.0.0"
   },

--- a/packages/zero/package.json
+++ b/packages/zero/package.json
@@ -15,8 +15,8 @@
   },
   "scripts": {
     "build": "rm -rf out && npm run build-server && npm run build-client",
-    "build-client": "tsc -p tsconfig.client.json && tsc-alias -p tsconfig.client.json && npx tsx tool/build.js",
-    "build-server": "tsc -p tsconfig.server.json && tsc-alias -p tsconfig.server.json && chmod +x out/zero/src/cli.js out/zero/src/build-schema.js out/zero/src/deploy-permissions.js out/zero/src/zero-cache-dev.js out/zero/src/ast-to-zql.js",
+    "build-client": "tsc -p tsconfig.client.json && npx tsx tool/build.js",
+    "build-server": "tsc -p tsconfig.server.json && chmod +x out/zero/src/cli.js out/zero/src/build-schema.js out/zero/src/deploy-permissions.js out/zero/src/zero-cache-dev.js out/zero/src/ast-to-zql.js",
     "check-types": "tsc",
     "check-types:watch": "tsc --watch",
     "format": "prettier --write .",
@@ -69,7 +69,6 @@
     "@vitest/runner": "3.0.8",
     "esbuild": "^0.25.0",
     "replicache": "15.2.1",
-    "tsc-alias": "^1.8.10",
     "typescript": "~5.8.2",
     "vitest": "3.0.8"
   },


### PR DESCRIPTION
It was not needed any more.

Verified by looking at the output files.