### PR TITLE
chore(mutators): do not send the client `mutation-success` responses

### DIFF
--- a/packages/shared/src/sentinels.ts
+++ b/packages/shared/src/sentinels.ts
@@ -1,1 +1,2 @@
 export function emptyFunction() {}
+export const emptyObject = Object.freeze({});

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -1298,6 +1298,7 @@ export class Zero<
   #handlePokeEnd(_lc: LogContext, pokeMessage: PokeEndMessage): void {
     this.#abortPingTimeout();
     this.#pokeHandler.handlePokeEnd(pokeMessage[1]);
+    this.#mutationTracker.processPokeEnd(this.#lastMutationIDReceived);
   }
 
   #onPokeError(): void {


### PR DESCRIPTION
We do not want the client to think a mutation is completed on the server before the client has received the corresponding pokes from the server that contain the state changes of the mutation.

This updates `mutation-tracker` to only resolve mutations as successful when the lmid moves forward.

---

There is also a race for transient errors. A mutation that receives an `app` failure could be skipped and a new lmid poked down before the `push-response` is received. Looks like the only recourse we have is to write all mutation results to the DB.