### PR TITLE
feat(mutators): prevent query removal while there are pending mutations

### DIFF
--- a/packages/zero-client/src/client/custom.bench.ts
+++ b/packages/zero-client/src/client/custom.bench.ts
@@ -23,7 +23,6 @@ bench('big schema', () => {
       [zeroData]: {},
     } as unknown as WriteTransaction,
     schema,
-    [],
     0,
   );
 });

--- a/packages/zero-client/src/client/mutation-tracker.ts
+++ b/packages/zero-client/src/client/mutation-tracker.ts
@@ -9,9 +9,6 @@ import type {
   PushResponse,
 } from '../../../zero-protocol/src/push.ts';
 import {assert} from '../../../shared/src/asserts.ts';
-import type {AST} from '../../../zero-protocol/src/ast.ts';
-import type {QueryManager} from './query-manager.ts';
-import {must} from '../../../shared/src/must.ts';
 import {emptyObject} from '../../../shared/src/sentinels.ts';
 
 const transientPushErrorTypes: PushError['error'][] = [
@@ -31,45 +28,26 @@ export class MutationTracker {
   readonly #outstandingMutations: Map<
     number,
     {
-      removeQueries: () => void;
       resolver: Resolver<MutationResult>;
     }
   >;
-  #queryManager: QueryManager | undefined;
+  readonly #allMutationsConfirmedListeners: Set<() => void>;
   #clientID: string | undefined;
 
   constructor() {
     this.#outstandingMutations = new Map();
-  }
-
-  setQueryManager(queryManager: QueryManager) {
-    this.#queryManager = queryManager;
+    this.#allMutationsConfirmedListeners = new Set();
   }
 
   set clientID(clientID: string) {
     this.#clientID = clientID;
   }
 
-  trackMutation(
-    id: number,
-    // We also register the queries used by the mutation with the server
-    // so the mutator does not lose the data it requires when rebasing.
-    readQueries: readonly AST[],
-  ): Promise<MutationResult> {
+  trackMutation(id: number): Promise<MutationResult> {
     assert(!this.#outstandingMutations.has(id));
     const mutationResolver = resolver<MutationResult>();
 
-    const cleanupCallbacks: (() => void)[] = [];
-    for (const query of readQueries) {
-      cleanupCallbacks.push(
-        must(
-          this.#queryManager,
-          'query manager was not set on the mutation-tracker',
-        ).add(query, 0),
-      );
-    }
     this.#outstandingMutations.set(id, {
-      removeQueries: () => cleanupCallbacks.forEach(cb => cb()),
       resolver: mutationResolver,
     });
     return mutationResolver.promise;
@@ -107,9 +85,7 @@ export class MutationTracker {
   onConnected(lastMutationID: number) {
     for (const [id, entry] of this.#outstandingMutations) {
       if (id <= lastMutationID) {
-        entry.removeQueries();
-        entry.resolver.resolve(emptyObject);
-        this.#outstandingMutations.delete(id);
+        this.#settleMutation(id, entry, 'resolve', emptyObject);
       } else {
         // the map is in insertion order which is in mutation ID order
         // so it is safe to break.
@@ -161,9 +137,7 @@ export class MutationTracker {
     );
     const entry = this.#outstandingMutations.get(mid.id);
     assert(entry);
-    entry.removeQueries();
-    entry.resolver.reject(error);
-    this.#outstandingMutations.delete(mid.id);
+    this.#settleMutation(mid.id, entry, 'reject', error);
   }
 
   #processMutationOk(result: MutationOk, mid: MutationID): void {
@@ -173,8 +147,41 @@ export class MutationTracker {
     );
     const entry = this.#outstandingMutations.get(mid.id);
     assert(entry);
-    entry.removeQueries();
-    entry.resolver.resolve(result);
-    this.#outstandingMutations.delete(mid.id);
+    this.#settleMutation(mid.id, entry, 'resolve', result);
+  }
+
+  #settleMutation(
+    mutationID: number,
+    entry: {
+      resolver: Resolver<MutationResult>;
+    },
+    type: 'resolve' | 'reject',
+    result: MutationOk | MutationError | Omit<PushError, 'mutationIDs'>,
+  ): void {
+    switch (type) {
+      case 'resolve':
+        assert(!('error' in result));
+        entry.resolver.resolve(result);
+        break;
+      case 'reject':
+        assert('error' in result);
+        entry.resolver.reject(result);
+        break;
+    }
+
+    const removed = this.#outstandingMutations.delete(mutationID);
+    if (removed && this.#outstandingMutations.size === 0) {
+      this.#notifyAllMutationsConfirmedListeners();
+    }
+  }
+
+  onAllMutationsConfirmed(listener: () => void): void {
+    this.#allMutationsConfirmedListeners.add(listener);
+  }
+
+  #notifyAllMutationsConfirmedListeners() {
+    for (const listener of this.#allMutationsConfirmedListeners) {
+      listener();
+    }
   }
 }

--- a/packages/zero-client/src/client/query-manager.test.ts
+++ b/packages/zero-client/src/client/query-manager.test.ts
@@ -22,6 +22,7 @@ import {schema} from '../../../zql/src/query/test/test-schemas.ts';
 import type {TTL} from '../../../zql/src/query/ttl.ts';
 import {toGotQueriesKey} from './keys.ts';
 import {QueryManager} from './query-manager.ts';
+import {MutationTracker} from './mutation-tracker.ts';
 
 function createExperimentalWatchMock() {
   return vi.fn();
@@ -30,7 +31,9 @@ function createExperimentalWatchMock() {
 test('add', () => {
   const send = vi.fn<(arg: ChangeDesiredQueriesMessage) => void>();
   const maxRecentQueriesSize = 0;
+  const mutationTracker = new MutationTracker();
   const queryManager = new QueryManager(
+    mutationTracker,
     'client1',
     schema.tables,
     send,
@@ -68,7 +71,9 @@ test('add', () => {
 test('add renamed fields', () => {
   const send = vi.fn<(arg: ChangeDesiredQueriesMessage) => void>();
   const maxRecentQueriesSize = 0;
+  const mutationTracker = new MutationTracker();
   const queryManager = new QueryManager(
+    mutationTracker,
     'client1',
     schema.tables,
     send,
@@ -237,7 +242,9 @@ test('add renamed fields', () => {
 test('remove, recent queries max size 0', () => {
   const send = vi.fn<(arg: ChangeDesiredQueriesMessage) => void>();
   const maxRecentQueriesSize = 0;
+  const mutationTracker = new MutationTracker();
   const queryManager = new QueryManager(
+    mutationTracker,
     'client1',
     schema.tables,
     send,
@@ -295,7 +302,9 @@ test('remove, recent queries max size 0', () => {
 test('remove, max recent queries size 2', () => {
   const send = vi.fn<(arg: ChangeDesiredQueriesMessage) => void>();
   const maxRecentQueriesSize = 2;
+  const mutationTracker = new MutationTracker();
   const queryManager = new QueryManager(
+    mutationTracker,
     'client1',
     schema.tables,
     send,
@@ -445,7 +454,9 @@ test('remove, max recent queries size 2', () => {
 test('test add/remove/add/remove changes lru order max recent queries size 2', () => {
   const send = vi.fn<(arg: ChangeDesiredQueriesMessage) => void>();
   const maxRecentQueriesSize = 2;
+  const mutationTracker = new MutationTracker();
   const queryManager = new QueryManager(
+    mutationTracker,
     'client1',
     schema.tables,
     send,
@@ -648,7 +659,9 @@ describe('getQueriesPatch', () => {
   test('basics', async () => {
     const send = vi.fn<(arg: ChangeDesiredQueriesMessage) => void>();
     const maxRecentQueriesSize = 0;
+    const mutationTracker = new MutationTracker();
     const queryManager = new QueryManager(
+      mutationTracker,
       'client1',
       schema.tables,
       send,
@@ -704,7 +717,9 @@ describe('getQueriesPatch', () => {
     beforeEach(() => {
       send = vi.fn<(arg: ChangeDesiredQueriesMessage) => void>();
       const maxRecentQueriesSize = 0;
+      const mutationTracker = new MutationTracker();
       queryManager = new QueryManager(
+        mutationTracker,
         'client1',
         schema.tables,
         send,
@@ -892,7 +907,9 @@ describe('getQueriesPatch', () => {
   test('getQueriesPatch includes recent queries in desired', async () => {
     const send = vi.fn<(arg: ChangeDesiredQueriesMessage) => void>();
     const maxRecentQueriesSize = 2;
+    const mutationTracker = new MutationTracker();
     const queryManager = new QueryManager(
+      mutationTracker,
       'client1',
       schema.tables,
       send,
@@ -995,7 +1012,9 @@ test('gotCallback, query already got', () => {
   const send = vi.fn<(msg: ChangeDesiredQueriesMessage) => void>();
 
   const maxRecentQueriesSize = 0;
+  const mutationTracker = new MutationTracker();
   const queryManager = new QueryManager(
+    mutationTracker,
     'client1',
     schema.tables,
     send,
@@ -1059,7 +1078,9 @@ test('gotCallback, query got after add', () => {
   const experimentalWatch = createExperimentalWatchMock();
   const send = vi.fn<(msg: ChangeDesiredQueriesMessage) => void>();
   const maxRecentQueriesSize = 0;
+  const mutationTracker = new MutationTracker();
   const queryManager = new QueryManager(
+    mutationTracker,
     'client1',
     schema.tables,
     send,
@@ -1119,7 +1140,9 @@ test('gotCallback, query got after add then removed', () => {
   const experimentalWatch = createExperimentalWatchMock();
   const send = vi.fn<(msg: ChangeDesiredQueriesMessage) => void>();
   const maxRecentQueriesSize = 0;
+  const mutationTracker = new MutationTracker();
   const queryManager = new QueryManager(
+    mutationTracker,
     'client1',
     schema.tables,
     send,
@@ -1189,7 +1212,9 @@ test('gotCallback, query got after subscription removed', () => {
   const experimentalWatch = createExperimentalWatchMock();
   const send = vi.fn<(q: ChangeDesiredQueriesMessage) => void>();
   const maxRecentQueriesSize = 0;
+  const mutationTracker = new MutationTracker();
   const queryManager = new QueryManager(
+    mutationTracker,
     'client1',
     schema.tables,
     send,
@@ -1262,7 +1287,9 @@ describe('queriesPatch with lastPatch', () => {
       () => false,
     );
     const maxRecentQueriesSize = 0;
+    const mutationTracker = new MutationTracker();
     const queryManager = new QueryManager(
+      mutationTracker,
       'client1',
       schema.tables,
       send,
@@ -1297,7 +1324,9 @@ describe('queriesPatch with lastPatch', () => {
     const send = vi.fn<(arg: ChangeDesiredQueriesMessage) => boolean>(
       () => false,
     );
+    const mutationTracker = new MutationTracker();
     const queryManager = new QueryManager(
+      mutationTracker,
       'client1',
       schema.tables,
       send,
@@ -1366,7 +1395,9 @@ test('gotCallback, add same got callback twice', () => {
   const experimentalWatch = createExperimentalWatchMock();
   const send = vi.fn<(msg: ChangeDesiredQueriesMessage) => void>();
   const maxRecentQueriesSize = 0;
+  const mutationTracker = new MutationTracker();
   const queryManager = new QueryManager(
+    mutationTracker,
     'client1',
     schema.tables,
     send,
@@ -1425,4 +1456,71 @@ test('gotCallback, add same got callback twice', () => {
 
   rem1();
   rem2();
+});
+
+describe('query manager & mutator interaction', () => {
+  let send: (msg: ChangeDesiredQueriesMessage) => void;
+  let mutationTracker: MutationTracker;
+  let queryManager: QueryManager;
+  const ast1: AST = {
+    table: 'issue',
+    orderBy: [['id', 'asc']],
+  };
+  const ast2: AST = {
+    table: 'issue',
+    limit: 1,
+    orderBy: [['id', 'desc']],
+  };
+
+  beforeEach(() => {
+    send = vi.fn<(msg: ChangeDesiredQueriesMessage) => void>();
+    mutationTracker = new MutationTracker();
+    queryManager = new QueryManager(
+      mutationTracker,
+      'client1',
+      schema.tables,
+      send,
+      () => () => {},
+      0,
+    );
+  });
+
+  test('queries are not removed while there are pending mutations', () => {
+    const remove = queryManager.add(ast1, 0);
+    expect(send).toBeCalledTimes(1);
+
+    void mutationTracker.trackMutation(1);
+
+    // try to remove the query
+    remove();
+
+    // query was not removed
+    expect(send).toBeCalledTimes(1);
+  });
+
+  test('queued queries are removed once the pending mutation count goes to 0', () => {
+    const remove1 = queryManager.add(ast1, 0);
+    const remove2 = queryManager.add(ast2, 0);
+    // once for each add
+    expect(send).toBeCalledTimes(2);
+
+    void mutationTracker.trackMutation(1);
+    remove1();
+    remove2();
+
+    expect(send).toBeCalledTimes(2);
+    mutationTracker.onConnected(1);
+    // send was called for each removed query that was queued
+    expect(send).toBeCalledTimes(4);
+  });
+
+  test('queries are removed immediately if there are no pending mutations', () => {
+    const remove1 = queryManager.add(ast1, 0);
+    const remove2 = queryManager.add(ast2, 0);
+    expect(send).toBeCalledTimes(2);
+    remove1();
+    expect(send).toBeCalledTimes(3);
+    remove2();
+    expect(send).toBeCalledTimes(4);
+  });
 });

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -618,13 +618,13 @@ export class Zero<
     this.mutateBatch = mutateBatch;
 
     this.#queryManager = new QueryManager(
+      this.#mutationTracker,
       rep.clientID,
       schema.tables,
       msg => this.#sendChangeDesiredQueries(msg),
       rep.experimentalWatch.bind(rep),
       maxRecentQueries,
     );
-    this.#mutationTracker.setQueryManager(this.#queryManager);
     this.#clientToServer = clientToServer(schema.tables);
 
     this.#deleteClientsManager = new DeleteClientsManager(


### PR DESCRIPTION
This goes back to the problem of having different data on `initial` run of the mutator than in a rebase.

The original idea was to register any read queries that are used in the mutator. 

That is less stable and less easily understood than freezing the active query set so queries cannot be removed until all outstanding mutations are committed. This approach will also cause less query churn on the backend.