### PR TITLE
chore(z2s): use a single placeholder for identical values

### DIFF
--- a/packages/z2s/src/sql.test.ts
+++ b/packages/z2s/src/sql.test.ts
@@ -1,0 +1,34 @@
+import {expect, test} from 'vitest';
+import {formatPg, sql} from './sql.ts';
+
+test('identical values result in a single placeholder', () => {
+  const userId = 1;
+  expect(
+    formatPg(
+      sql`SELECT * FROM "user" WHERE "id" = ${userId} AND "id" = ${userId}`,
+    ),
+  ).toMatchInlineSnapshot(`
+    {
+      "text": "SELECT * FROM "user" WHERE "id" = $1 AND "id" = $1",
+      "values": [
+        1,
+      ],
+    }
+  `);
+
+  const str = JSON.stringify({a: 1});
+  expect(
+    formatPg(
+      sql`SELECT * FROM "user" WHERE "meta1" = ${str} AND "id" = ${userId} OR "meta2" = ${str} OR "otherId" = ${userId} AND foo = ${''}`,
+    ),
+  ).toMatchInlineSnapshot(`
+    {
+      "text": "SELECT * FROM "user" WHERE "meta1" = $1 AND "id" = $2 OR "meta2" = $1 OR "otherId" = $2 AND foo = $3",
+      "values": [
+        "{"a":1}",
+        1,
+        "",
+      ],
+    }
+  `);
+});

--- a/packages/z2s/src/sql.ts
+++ b/packages/z2s/src/sql.ts
@@ -1,26 +1,102 @@
-import type {SQLQuery, FormatConfig} from '@databases/sql';
-import baseSql from '@databases/sql';
+import type {SQLQuery, FormatConfig, SQLItem} from '@databases/sql';
+import baseSql, {SQLItemType} from '@databases/sql';
 import {
   escapePostgresIdentifier,
   escapeSQLiteIdentifier,
 } from '@databases/escape-identifier';
 
-const pgFormat: FormatConfig = {
-  escapeIdentifier: str => escapePostgresIdentifier(str),
-  formatValue: (value, index) => ({placeholder: `$${index + 1}`, value}),
-};
-
-const sqliteFormat: FormatConfig = {
-  escapeIdentifier: str => escapeSQLiteIdentifier(str),
-  formatValue: value => ({placeholder: '?', value}),
-};
-
 export function formatPg(sql: SQLQuery) {
-  return sql.format(pgFormat);
+  const format = new ReusingFormat(escapePostgresIdentifier);
+  return sql.format((items: readonly SQLItem[]) => formatFn(items, format));
 }
 
 export function formatSqlite(sql: SQLQuery) {
-  return sql.format(sqliteFormat);
+  const format = new ReusingFormat(escapeSQLiteIdentifier);
+  return sql.format((items: readonly SQLItem[]) => formatFn(items, format));
+}
+
+class ReusingFormat implements FormatConfig {
+  readonly #seen: Map<unknown, number> = new Map();
+  readonly escapeIdentifier: (str: string) => string;
+
+  constructor(escapeIdentifier: (str: string) => string) {
+    this.escapeIdentifier = escapeIdentifier;
+  }
+
+  formatValue = (value: unknown) => {
+    if (this.#seen.has(value)) {
+      return {
+        placeholder: `$${this.#seen.get(value)}`,
+        value: PREVIOUSLY_SEEN_VALUE,
+      };
+    }
+    this.#seen.set(value, this.#seen.size + 1);
+    return {placeholder: `$${this.#seen.size}`, value};
+  };
 }
 
 export const sql = baseSql.default;
+
+const PREVIOUSLY_SEEN_VALUE = Symbol('PREVIOUSLY_SEEN_VALUE');
+function formatFn(
+  items: readonly SQLItem[],
+  {escapeIdentifier, formatValue}: FormatConfig,
+): {
+  text: string;
+  values: unknown[];
+} {
+  // Create an empty query object.
+  let text = '';
+  const values = [];
+
+  const localIdentifiers = new Map<unknown, string>();
+
+  for (const item of items) {
+    switch (item.type) {
+      // If this is just raw text, we add it directly to the query text.
+      case SQLItemType.RAW: {
+        text += item.text;
+        break;
+      }
+
+      // If we got a value SQL item, add a placeholder and add the value to our
+      // placeholder values array.
+      case SQLItemType.VALUE: {
+        const {placeholder, value} = formatValue(item.value, values.length);
+        text += placeholder;
+        if (value !== PREVIOUSLY_SEEN_VALUE) {
+          values.push(value);
+        }
+
+        break;
+      }
+
+      // If we got an identifier type, escape the strings and get a local
+      // identifier for non-string identifiers.
+      case SQLItemType.IDENTIFIER: {
+        text += item.names
+          .map((name): string => {
+            if (typeof name === 'string') return escapeIdentifier(name);
+
+            if (!localIdentifiers.has(name))
+              localIdentifiers.set(name, `__local_${localIdentifiers.size}__`);
+
+            return escapeIdentifier(localIdentifiers.get(name)!);
+          })
+          .join('.');
+        break;
+      }
+    }
+  }
+
+  if (text.trim()) {
+    const lines = text.split('\n');
+    const min = Math.min(
+      ...lines.filter(l => l.trim() !== '').map(l => /^\s*/.exec(l)![0].length),
+    );
+    if (min) {
+      text = lines.map(line => line.substr(min)).join('\n');
+    }
+  }
+  return {text: text.trim(), values};
+}

--- a/packages/z2s/src/test/chinook/chinook.pg-test.ts
+++ b/packages/z2s/src/test/chinook/chinook.pg-test.ts
@@ -142,9 +142,13 @@ beforeEach(async () => {
 });
 
 describe('basic select', () => {
-  test.each(tables.map(table => [table]))('select * from %s', async table => {
-    await checkZqlAndSql(pg, zqliteQueries[table], memoryQueries[table]);
-  });
+  test.each(tables.map(table => [table]))(
+    'select * from %s',
+    async table => {
+      await checkZqlAndSql(pg, zqliteQueries[table], memoryQueries[table]);
+    },
+    20_000,
+  );
 
   test.each(tables.map(table => [table]))(
     'select * from %s limit 100',

--- a/packages/z2s/vitest.config.ts
+++ b/packages/z2s/vitest.config.ts
@@ -1,4 +1,4 @@
-import {defineConfig} from 'vitest/config';
+import {defineConfig, mergeConfig} from 'vitest/config';
 import {
   configForCustomPg,
   configForNoPg,
@@ -13,6 +13,12 @@ export const workspace = [
   configForVersion(16, url),
   configForVersion(17, url),
   ...configForCustomPg(url),
-];
+].map(c =>
+  mergeConfig(c, {
+    test: {
+      testTimeout: 20_000,
+    },
+  }),
+);
 
-export default defineConfig({test: {workspace}});
+export default defineConfig({test: {workspace, testTimeout: 20_000}});


### PR DESCRIPTION
z2s is going to be sender a large JSON blob that contains all args.

We don't want to bind this JSON blob for each time it is referenced in the SQL but rather only a single time.

This adds a format function (mostly copied from the internal implementation here: https://github.com/ForbesLindesay/atdatabases/blob/cb1b783ad9aafd85461ef7f4b86160b94b717468/packages/sql/src/web.ts#L212) that de-dupes values and reuses placeholders.