### PR TITLE
chore(z2s): Don't use postgres.js type config in compiler test

### DIFF
--- a/packages/zero-cache/src/test/db.ts
+++ b/packages/zero-cache/src/test/db.ts
@@ -31,7 +31,11 @@ class TestDBs {
   });
   readonly #dbs: Record<string, postgres.Sql> = {};
 
-  async create(database: string, onNotice?: OnNoticeFn): Promise<PostgresDB> {
+  async create(
+    database: string,
+    onNotice?: OnNoticeFn,
+    useTypeConfig = true,
+  ): Promise<PostgresDB> {
     const exists = this.#dbs[database];
     if (exists !== undefined) {
       console.warn('dropping database', database);
@@ -53,7 +57,7 @@ class TestDBs {
         onNotice?.(n);
         defaultOnNotice(n);
       },
-      ...postgresTypeConfig(),
+      ...(useTypeConfig ? postgresTypeConfig() : {}),
     });
     this.#dbs[database] = db;
     return db;


### PR DESCRIPTION
Demonstrates that the sql generated by the z2s compiler is not dependent on these configured type conversions.