### PR TITLE
chore(z2s): bind from json packed args

### DIFF
--- a/packages/z2s/src/sql.test.ts
+++ b/packages/z2s/src/sql.test.ts
@@ -1,5 +1,5 @@
-import {expect, test} from 'vitest';
-import {formatPg, sql} from './sql.ts';
+import {describe, expect, test} from 'vitest';
+import {formatPg, formatPgJson, jsonPackArg, sql} from './sql.ts';
 
 test('identical values result in a single placeholder', () => {
   const userId = 1;
@@ -31,4 +31,52 @@ test('identical values result in a single placeholder', () => {
       ],
     }
   `);
+});
+
+describe('json arg packing', () => {
+  test('single arg', () => {
+    expect(
+      formatPgJson(
+        sql`SELECT * FROM "user" WHERE "id" = ${jsonPackArg('number', 1)} `,
+      ),
+    ).toMatchInlineSnapshot(`
+      {
+        "text": "SELECT * FROM "user" WHERE "id" = ($1->>0)::numeric",
+        "values": [
+          "[1]",
+        ],
+      }
+    `);
+  });
+
+  // identical values should only be encoded once
+  test('many equivalent args', () => {
+    expect(
+      formatPgJson(
+        sql`SELECT * FROM "user" WHERE "id" = ${jsonPackArg('number', 1)} OR "other_id" = ${jsonPackArg('number', 1)}`,
+      ),
+    ).toMatchInlineSnapshot(`
+      {
+        "text": "SELECT * FROM "user" WHERE "id" = ($1->>0)::numeric OR "other_id" = ($1->>0)::numeric",
+        "values": [
+          "[1]",
+        ],
+      }
+    `);
+  });
+
+  test('all types', () => {
+    expect(
+      formatPgJson(
+        sql`SELECT * FROM "foo" WHERE "a" = ${jsonPackArg('json', {})} OR "b" = ${jsonPackArg('number', 1)} OR "c" = ${jsonPackArg('string', 'str')} OR "d" = ${jsonPackArg('boolean', true)}`,
+      ),
+    ).toMatchInlineSnapshot(`
+      {
+        "text": "SELECT * FROM "foo" WHERE "a" = $1->0 OR "b" = ($1->>1)::numeric OR "c" = $1->>2 OR "d" = ($1->>3)::boolean",
+        "values": [
+          "[{},1,"str",true]",
+        ],
+      }
+    `);
+  });
 });


### PR DESCRIPTION
Allows us to control type conversion by JSON packing the arguments to the query then extracting from JSON where they're used.

example:
```ts
expect(
      formatPgJson(
        sql`SELECT * FROM "user" WHERE "id" = ${jsonPackArg('number', 1)} `,
      ),
    ).toMatchInlineSnapshot(`
      {
        "text": "SELECT * FROM "user" WHERE "id" = ($1->>0)::numeric",
        "values": [
          "[1]",
        ],
      }
    `);
```

