### PR TITLE
fix(zero-cache): avoid crashing on busy-timeout

### DIFF
--- a/packages/zero-cache/src/workers/replicator.ts
+++ b/packages/zero-cache/src/workers/replicator.ts
@@ -86,14 +86,10 @@ async function connect(
   lc.info?.(`setting ${file} to ${walMode} mode`);
   replica.pragma(`journal_mode = ${walMode}`);
 
-  // Set a busy timeout at litestream's recommended 5 seconds:
-  // (https://litestream.io/tips/#busy-timeout).
-  //
-  // In the view-syncer (for which there is no litestream replicate
-  // process), this is still useful for handling the `PRAGMA optimize`
-  // call the sync workers, which results in occasional `ANALYZE` calls
-  // that may contend with each other and with the replicator for the lock.
-  replica.pragma('busy_timeout = 5000');
+  // The duration of the loop in which the replicator attempts
+  // to begin a transaction while litestream is performing a
+  // checkpoint.
+  replica.pragma('busy_timeout = 30000');
 
   replica.pragma('optimize = 0x10002');
   lc.info?.(`optimized ${file}`);


### PR DESCRIPTION
Avoid crashing the replicator when it is unable to obtain the SQLite lock. `litestream` can hold the lock for an arbitrary amount of time (e.g. when checkpointing a large commit), and crashing can cause corruption or inhibit forward progress.

Instead, retry indefinitely, in the same way that litestream retries its checkpointing indefinitely.

User report: https://discord.com/channels/830183651022471199/1354595802332401845/1354595877301260511