### PR TITLE
chore(z2s): convert args internally via SQL in Mutagen

### DIFF
--- a/packages/z2s/src/sql.test.ts
+++ b/packages/z2s/src/sql.test.ts
@@ -41,9 +41,11 @@ describe('json arg packing', () => {
       ),
     ).toMatchInlineSnapshot(`
       {
-        "text": "SELECT * FROM "user" WHERE "id" = ($1->>0)::numeric",
+        "text": "SELECT * FROM "user" WHERE "id" = ($1::json->>0)::numeric",
         "values": [
-          "[1]",
+          [
+            1,
+          ],
         ],
       }
     `);
@@ -57,9 +59,11 @@ describe('json arg packing', () => {
       ),
     ).toMatchInlineSnapshot(`
       {
-        "text": "SELECT * FROM "user" WHERE "id" = ($1->>0)::numeric OR "other_id" = ($1->>0)::numeric",
+        "text": "SELECT * FROM "user" WHERE "id" = ($1::json->>0)::numeric OR "other_id" = ($1::json->>0)::numeric",
         "values": [
-          "[1]",
+          [
+            1,
+          ],
         ],
       }
     `);
@@ -72,9 +76,37 @@ describe('json arg packing', () => {
       ),
     ).toMatchInlineSnapshot(`
       {
-        "text": "SELECT * FROM "foo" WHERE "a" = $1->0 OR "b" = ($1->>1)::numeric OR "c" = $1->>2 OR "d" = ($1->>3)::boolean",
+        "text": "SELECT * FROM "foo" WHERE "a" = $1::json->0 OR "b" = ($1::json->>1)::numeric OR "c" = $1::json->>2 OR "d" = ($1::json->>3)::boolean",
         "values": [
-          "[{},1,"str",true]",
+          [
+            {},
+            1,
+            "str",
+            true,
+          ],
+        ],
+      }
+    `);
+  });
+
+  test('mapped and joined', () => {
+    const values = [1, 2, 3];
+    expect(
+      formatPgJson(
+        sql`SELECT * FROM "foo" WHERE "a" ${sql.join(
+          values.map(v => jsonPackArg('number', v)),
+          ' AND ',
+        )} `,
+      ),
+    ).toMatchInlineSnapshot(`
+      {
+        "text": "SELECT * FROM "foo" WHERE "a" ($1::json->>0)::numeric AND ($1::json->>1)::numeric AND ($1::json->>2)::numeric",
+        "values": [
+          [
+            1,
+            2,
+            3,
+          ],
         ],
       }
     `);

--- a/packages/z2s/src/sql.test.ts
+++ b/packages/z2s/src/sql.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, test} from 'vitest';
-import {formatPg, formatPgJson, jsonPackArg, sql} from './sql.ts';
+import {formatPg, formatPgInternalConvert, sqlConvertArg, sql} from './sql.ts';
 
 test('identical values result in a single placeholder', () => {
   const userId = 1;
@@ -36,16 +36,14 @@ test('identical values result in a single placeholder', () => {
 describe('json arg packing', () => {
   test('single arg', () => {
     expect(
-      formatPgJson(
-        sql`SELECT * FROM "user" WHERE "id" = ${jsonPackArg('number', 1)} `,
+      formatPgInternalConvert(
+        sql`SELECT * FROM "user" WHERE "id" = ${sqlConvertArg('number', 1)} `,
       ),
     ).toMatchInlineSnapshot(`
       {
-        "text": "SELECT * FROM "user" WHERE "id" = ($1::json->>0)::numeric",
+        "text": "SELECT * FROM "user" WHERE "id" = $1::text::numeric",
         "values": [
-          [
-            1,
-          ],
+          "1",
         ],
       }
     `);
@@ -54,16 +52,14 @@ describe('json arg packing', () => {
   // identical values should only be encoded once
   test('many equivalent args', () => {
     expect(
-      formatPgJson(
-        sql`SELECT * FROM "user" WHERE "id" = ${jsonPackArg('number', 1)} OR "other_id" = ${jsonPackArg('number', 1)}`,
+      formatPgInternalConvert(
+        sql`SELECT * FROM "user" WHERE "id" = ${sqlConvertArg('number', 1)} OR "other_id" = ${sqlConvertArg('number', 1)}`,
       ),
     ).toMatchInlineSnapshot(`
       {
-        "text": "SELECT * FROM "user" WHERE "id" = ($1::json->>0)::numeric OR "other_id" = ($1::json->>0)::numeric",
+        "text": "SELECT * FROM "user" WHERE "id" = $1::text::numeric OR "other_id" = $1::text::numeric",
         "values": [
-          [
-            1,
-          ],
+          "1",
         ],
       }
     `);
@@ -71,19 +67,17 @@ describe('json arg packing', () => {
 
   test('all types', () => {
     expect(
-      formatPgJson(
-        sql`SELECT * FROM "foo" WHERE "a" = ${jsonPackArg('json', {})} OR "b" = ${jsonPackArg('number', 1)} OR "c" = ${jsonPackArg('string', 'str')} OR "d" = ${jsonPackArg('boolean', true)}`,
+      formatPgInternalConvert(
+        sql`SELECT * FROM "foo" WHERE "a" = ${sqlConvertArg('json', {})} OR "b" = ${sqlConvertArg('number', 1)} OR "c" = ${sqlConvertArg('string', 'str')} OR "d" = ${sqlConvertArg('boolean', true)}`,
       ),
     ).toMatchInlineSnapshot(`
       {
-        "text": "SELECT * FROM "foo" WHERE "a" = $1::json->0 OR "b" = ($1::json->>1)::numeric OR "c" = $1::json->>2 OR "d" = ($1::json->>3)::boolean",
+        "text": "SELECT * FROM "foo" WHERE "a" = $1::text::jsonb OR "b" = $2::text::numeric OR "c" = $3::text OR "d" = $4::text::boolean",
         "values": [
-          [
-            {},
-            1,
-            "str",
-            true,
-          ],
+          "{}",
+          "1",
+          "str",
+          "true",
         ],
       }
     `);
@@ -92,21 +86,19 @@ describe('json arg packing', () => {
   test('mapped and joined', () => {
     const values = [1, 2, 3];
     expect(
-      formatPgJson(
+      formatPgInternalConvert(
         sql`SELECT * FROM "foo" WHERE "a" ${sql.join(
-          values.map(v => jsonPackArg('number', v)),
+          values.map(v => sqlConvertArg('number', v)),
           ' AND ',
         )} `,
       ),
     ).toMatchInlineSnapshot(`
       {
-        "text": "SELECT * FROM "foo" WHERE "a" ($1::json->>0)::numeric AND ($1::json->>1)::numeric AND ($1::json->>2)::numeric",
+        "text": "SELECT * FROM "foo" WHERE "a" $1::text::numeric AND $2::text::numeric AND $3::text::numeric",
         "values": [
-          [
-            1,
-            2,
-            3,
-          ],
+          "1",
+          "2",
+          "3",
         ],
       }
     `);

--- a/packages/z2s/src/sql.ts
+++ b/packages/z2s/src/sql.ts
@@ -13,11 +13,9 @@ export function formatPg(sql: SQLQuery) {
   return sql.format((items: readonly SQLItem[]) => formatFn(items, format));
 }
 
-export function formatPgJson(sql: SQLQuery) {
-  const format = new JsonPackedFormat(escapePostgresIdentifier);
-  return sql.format((items: readonly SQLItem[]) =>
-    formatFn(items, format, true),
-  );
+export function formatPgInternalConvert(sql: SQLQuery) {
+  const format = new SQLConvertFormat(escapePostgresIdentifier);
+  return sql.format((items: readonly SQLItem[]) => formatFn(items, format));
 }
 
 export function formatSqlite(sql: SQLQuery) {
@@ -25,25 +23,25 @@ export function formatSqlite(sql: SQLQuery) {
   return sql.format((items: readonly SQLItem[]) => formatFn(items, format));
 }
 
-const jsonPack = Symbol('fromJson');
-type JsonPackArg = {
-  [jsonPack]: true;
+const sqlConvert = Symbol('fromJson');
+type SqlConvertArg = {
+  [sqlConvert]: true;
   type: ValueType;
   value: unknown;
 };
-function isJsonPack(value: unknown): value is JsonPackArg {
-  return value !== null && typeof value === 'object' && jsonPack in value;
+function isSqlConvert(value: unknown): value is SqlConvertArg {
+  return value !== null && typeof value === 'object' && sqlConvert in value;
 }
 
-export function jsonPackArg<T extends ValueType>(
+export function sqlConvertArg<T extends ValueType>(
   type: T,
   value: TypeNameToTypeMap[T],
 ): SQLQuery {
-  return sql.value({[jsonPack]: true, type, value});
+  return sql.value({[sqlConvert]: true, type, value});
 }
 
-export function jsonPackArgUnsafe(type: ValueType, value: unknown): SQLQuery {
-  return sql.value({[jsonPack]: true, type, value});
+export function sqlConvertArgUnsafe(type: ValueType, value: unknown): SQLQuery {
+  return sql.value({[sqlConvert]: true, type, value});
 }
 
 class ReusingFormat implements FormatConfig {
@@ -66,7 +64,26 @@ class ReusingFormat implements FormatConfig {
   };
 }
 
-class JsonPackedFormat implements FormatConfig {
+function stringify(type: ValueType, x: unknown): string {
+  switch (type) {
+    case 'json':
+      return JSON.stringify(x);
+    case 'boolean':
+      return x ? 'true' : 'false';
+    case 'number':
+    case 'date':
+    case 'timestamp':
+      return (x as number).toString();
+    case 'string':
+      return x as string;
+    case 'null':
+      return 'null';
+    default:
+      unreachable(type);
+  }
+}
+
+class SQLConvertFormat implements FormatConfig {
   readonly #seen: Map<unknown, number> = new Map();
   readonly escapeIdentifier: (str: string) => string;
 
@@ -75,7 +92,7 @@ class JsonPackedFormat implements FormatConfig {
   }
 
   formatValue = (value: unknown) => {
-    assert(isJsonPack(value), 'JsonPackedFormat can only take JsonPackArgs.');
+    assert(isSqlConvert(value), 'JsonPackedFormat can only take JsonPackArgs.');
     const key = value.value;
     if (this.#seen.has(key)) {
       return {
@@ -86,23 +103,31 @@ class JsonPackedFormat implements FormatConfig {
     this.#seen.set(key, this.#seen.size + 1);
     return {
       placeholder: this.#createPlaceholder(this.#seen.size, value),
-      value: value.value,
+      value: stringify(value.type, value.value),
     };
   };
 
-  #createPlaceholder(index: number, value: JsonPackArg) {
+  #createPlaceholder(index: number, value: SqlConvertArg) {
+    // Ok, so what is with all the `::text` casts
+    // before the final cast?
+    // This is to force the statement to describe its arguments
+    // as being text. Without the text cast the args are described as
+    // being bool/json/numeric/whatever and the bindings try to coerce
+    // the inputs to those types.
     switch (value.type) {
       case 'json':
-        return `$1::json->${index - 1}`;
+        // We use JSONB since that can be used as a primary key type
+        // whereas JSON cannot. So JSONB covers more cases.
+        return `$${index}::text::jsonb`;
       case 'boolean':
-        return `($1::json->>${index - 1})::boolean`;
+        return `$${index}::text::boolean`;
       case 'number':
-        return `($1::json->>${index - 1})::numeric`;
+        return `$${index}::text::numeric`;
       case 'string':
-        return `$1::json->>${index - 1}`;
+        return `$${index}::text`;
       case 'date':
       case 'timestamp':
-        return `to_timestamp(($1::json->>${index - 1})::bigint / 1000) AT TIME ZONE 'UTC'`;
+        return `to_timestamp($${index}::text::bigint / 1000) AT TIME ZONE 'UTC'`;
       case 'null':
         throw new Error('unsupported type');
       default:
@@ -117,7 +142,6 @@ const PREVIOUSLY_SEEN_VALUE = Symbol('PREVIOUSLY_SEEN_VALUE');
 function formatFn(
   items: readonly SQLItem[],
   {escapeIdentifier, formatValue}: FormatConfig,
-  jsonPack: boolean = false,
 ): {
   text: string;
   values: unknown[];
@@ -177,6 +201,6 @@ function formatFn(
   }
   return {
     text: text.trim(),
-    values: jsonPack ? [values] : values,
+    values,
   };
 }

--- a/packages/zero-pg/src/test/schema.ts
+++ b/packages/zero-pg/src/test/schema.ts
@@ -1,9 +1,11 @@
 import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import {
   boolean,
+  date,
   number,
   string,
   table,
+  timestamp,
 } from '../../../zero-schema/src/builder/table-builder.ts';
 
 export const schema = createSchema({
@@ -32,6 +34,15 @@ export const schema = createSchema({
         c: string().optional(),
       })
       .primaryKey('a', 'b'),
+    table('dateTypes')
+      .columns({
+        ts: timestamp(),
+        tstz: timestamp(),
+        tswtz: timestamp(),
+        tswotz: timestamp(),
+        d: date(),
+      })
+      .primaryKey('ts'),
   ],
   relationships: [],
 });
@@ -55,10 +66,26 @@ CREATE TABLE "compoundPk" (
   b INTEGER,
   c TEXT,
   PRIMARY KEY (a, b)
-);`;
+);
+
+CREATE TABLE "dateTypes" (
+  "ts" TIMESTAMP,
+  "tstz" TIMESTAMPTZ,
+  "tswtz" TIMESTAMP WITH TIME ZONE,
+  "tswotz" TIMESTAMP WITHOUT TIME ZONE,
+  "d" DATE,
+  PRIMARY KEY ("ts")
+);
+`;
 
 export const seedDataSql = `
 INSERT INTO basic (id, a, b, c) VALUES ('1', 2, 'foo', true);
 INSERT INTO divergent_names (divergent_id, divergent_a, divergent_b, divergent_c) VALUES ('2', 3, 'bar', false);
 INSERT INTO "compoundPk" (a, b, c) VALUES ('a', 1, 'c');
+INSERT INTO "dateTypes" (ts, tstz, tswtz, tswotz) VALUES (
+  '2021-01-01 00:00:01',
+  '2022-02-02 00:00:02',
+  '2023-03-03 00:00:03',
+  '2024-04-04 00:00:04'
+);
 `;

--- a/packages/zero-pg/src/test/schema.ts
+++ b/packages/zero-pg/src/test/schema.ts
@@ -2,11 +2,21 @@ import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import {
   boolean,
   date,
+  json,
   number,
   string,
   table,
   timestamp,
 } from '../../../zero-schema/src/builder/table-builder.ts';
+
+const jsonCols = {
+  str: json<string>(),
+  num: json<number>(),
+  bool: json<boolean>(),
+  nil: json<null>(),
+  obj: json<{foo: string}>(),
+  arr: json<string[]>(),
+} as const;
 
 export const schema = createSchema({
   tables: [
@@ -43,6 +53,13 @@ export const schema = createSchema({
         d: date(),
       })
       .primaryKey('ts'),
+    table('jsonCases')
+      .columns({
+        ...jsonCols,
+        str: string(),
+      })
+      .primaryKey('str'),
+    table('jsonbCases').columns(jsonCols).primaryKey('str'),
   ],
   relationships: [],
 });
@@ -75,6 +92,26 @@ CREATE TABLE "dateTypes" (
   "tswotz" TIMESTAMP WITHOUT TIME ZONE,
   "d" DATE,
   PRIMARY KEY ("ts")
+);
+
+CREATE TABLE "jsonbCases" (
+  "str" JSONB,
+  "num" JSONB,
+  "bool" JSONB,
+  "nil" JSONB,
+  "obj" JSONB,
+  "arr" JSONB,
+  PRIMARY KEY ("str")
+);
+
+CREATE TABLE "jsonCases" (
+  "str" TEXT,
+  "num" JSON,
+  "bool" JSON,
+  "nil" JSON,
+  "obj" JSON,
+  "arr" JSON,
+  PRIMARY KEY ("str")
 );
 `;
 

--- a/packages/zero-schema/src/table-schema.ts
+++ b/packages/zero-schema/src/table-schema.ts
@@ -41,7 +41,7 @@ export type RelationshipsSchema = {
   readonly [name: string]: Relationship;
 };
 
-type TypeNameToTypeMap = {
+export type TypeNameToTypeMap = {
   string: string;
   number: number;
   boolean: boolean;


### PR DESCRIPTION
All args are now passed to sql queries as text. We then convert that text to the appropriate type. This is to bypass any specific type conversions a user may have installed that would not be compatible with Zero.


Mutagen can now write to timestamp columns.