### PR TITLE
feat(zero-cache): non-disruptive resync

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -1,15 +1,19 @@
-import {PG_ADMIN_SHUTDOWN} from '@drdgvhbh/postgres-error-codes';
+import {
+  PG_ADMIN_SHUTDOWN,
+  PG_OBJECT_IN_USE,
+} from '@drdgvhbh/postgres-error-codes';
 import {LogContext} from '@rocicorp/logger';
 import postgres from 'postgres';
 import {AbortError} from '../../../../../shared/src/abort-error.ts';
-import {assert} from '../../../../../shared/src/asserts.ts';
 import {deepEqual} from '../../../../../shared/src/json.ts';
 import {must} from '../../../../../shared/src/must.ts';
+import {promiseVoid} from '../../../../../shared/src/resolved-promises.ts';
 import {
   equals,
   intersection,
   symmetricDifferences,
 } from '../../../../../shared/src/set-utils.ts';
+import {sleep} from '../../../../../shared/src/sleep.ts';
 import * as v from '../../../../../shared/src/valita.ts';
 import {Database} from '../../../../../zqlite/src/db.ts';
 import {mapPostgresToLiteColumn} from '../../../db/pg-to-lite.ts';
@@ -28,7 +32,11 @@ import {
   type LexiVersion,
 } from '../../../types/lexi-version.ts';
 import {pgClient, type PostgresDB} from '../../../types/pg.ts';
-import type {ShardConfig, ShardID} from '../../../types/shards.ts';
+import {
+  upstreamSchema,
+  type ShardConfig,
+  type ShardID,
+} from '../../../types/shards.ts';
 import type {Sink} from '../../../types/streams.ts';
 import {Subscription, type PendingResult} from '../../../types/subscription.ts';
 import type {
@@ -50,7 +58,7 @@ import type {
   ChangeStreamMessage,
   Data,
 } from '../protocol/current/downstream.ts';
-import {replicationSlot, type InitialSyncOptions} from './initial-sync.ts';
+import {type InitialSyncOptions} from './initial-sync.ts';
 import type {
   Message,
   MessageMessage,
@@ -63,9 +71,11 @@ import {updateShardSchema} from './schema/init.ts';
 import {getPublicationInfo, type PublishedSchema} from './schema/published.ts';
 import {
   getInternalShardConfig,
+  getReplicaAtVersion,
   internalPublicationPrefix,
   replicaIdentitiesForTablesWithoutPrimaryKeys,
   type InternalShardConfig,
+  type Replica,
 } from './schema/shard.ts';
 import {validate} from './schema/validation.ts';
 import {initSyncSchema} from './sync-schema.ts';
@@ -112,24 +122,24 @@ export async function initializePostgresChangeSource(
   // initial sync if not.
   const db = pgClient(lc, upstreamURI);
   try {
-    await checkAndUpdateUpstream(
+    const upstreamReplica = await checkAndUpdateUpstream(
       lc,
       db,
       shard,
       subscriptionState.replicaVersion,
     );
+
+    const changeSource = new PostgresChangeSource(
+      lc,
+      upstreamURI,
+      shard,
+      upstreamReplica,
+    );
+
+    return {subscriptionState, changeSource};
   } finally {
     await db.end();
   }
-
-  const changeSource = new PostgresChangeSource(
-    lc,
-    upstreamURI,
-    shard,
-    subscriptionState.replicaVersion,
-  );
-
-  return {subscriptionState, changeSource};
 }
 
 async function checkAndUpdateUpstream(
@@ -138,7 +148,16 @@ async function checkAndUpdateUpstream(
   shard: ShardConfig,
   replicaVersion: string,
 ) {
-  const slot = replicationSlot(shard);
+  // Perform any shard schema updates
+  await updateShardSchema(lc, db, shard, replicaVersion);
+
+  const upstreamReplica = await getReplicaAtVersion(db, shard, replicaVersion);
+  if (!upstreamReplica) {
+    throw new AutoResetSignal(
+      `No replication slot for replica at version ${replicaVersion}`,
+    );
+  }
+  const {slot} = upstreamReplica;
   const result = await db<{restartLSN: LSN | null}[]>`
   SELECT restart_lsn as "restartLSN" FROM pg_replication_slots WHERE slot_name = ${slot}`;
   if (result.length === 0) {
@@ -150,15 +169,7 @@ async function checkAndUpdateUpstream(
       `replication slot ${slot} has been invalidated for exceeding the max_slot_wal_keep_size`,
     );
   }
-  // Perform any shard schema updates
-  await updateShardSchema(lc, db, shard, replicaVersion);
-
-  const expected = await getInternalShardConfig(db, shard);
-  if (expected.replicaVersion !== replicaVersion) {
-    throw new AutoResetSignal(
-      `local replicaVersion ${replicaVersion} does not match upstream replicaVersion ${expected.replicaVersion}`,
-    );
-  }
+  return upstreamReplica;
 }
 
 /**
@@ -169,31 +180,35 @@ class PostgresChangeSource implements ChangeSource {
   readonly #lc: LogContext;
   readonly #upstreamUri: string;
   readonly #shard: ShardID;
-  readonly #replicaVersion: string;
+  readonly #replica: Replica;
 
   constructor(
     lc: LogContext,
     upstreamUri: string,
     shard: ShardID,
-    replicaVersion: string,
+    replica: Replica,
   ) {
     this.#lc = lc.withContext('component', 'change-source');
     this.#upstreamUri = upstreamUri;
     this.#shard = shard;
-    this.#replicaVersion = replicaVersion;
+    this.#replica = replica;
   }
 
   async startStream(clientWatermark: string): Promise<ChangeStream> {
     const db = pgClient(this.#lc, this.#upstreamUri);
-    const slot = replicationSlot(this.#shard);
+    const {slot} = this.#replica;
 
+    let cleanup = promiseVoid;
     try {
-      await this.#stopExistingReplicationSlotSubscriber(db, slot);
+      ({cleanup} = await this.#stopExistingReplicationSlotSubscribers(
+        db,
+        slot,
+      ));
       const config = await getInternalShardConfig(db, this.#shard);
       this.#lc.info?.(`starting replication stream@${slot}`);
       return await this.#startStream(db, slot, clientWatermark, config);
     } finally {
-      await db.end();
+      void cleanup.then(() => db.end());
     }
   }
 
@@ -221,6 +236,7 @@ class PostgresChangeSource implements ChangeSource {
       this.#lc,
       this.#shard,
       shardConfig,
+      this.#replica.initialSchema,
       this.#upstreamUri,
     );
 
@@ -244,7 +260,7 @@ class PostgresChangeSource implements ChangeSource {
 
     this.#lc.info?.(
       `started replication stream@${slot} from ${clientWatermark} (replicaVersion: ${
-        this.#replicaVersion
+        this.#replica.version
       })`,
     );
 
@@ -254,25 +270,73 @@ class PostgresChangeSource implements ChangeSource {
     };
   }
 
-  async #stopExistingReplicationSlotSubscriber(
+  /**
+   * Stops all replication slots associated with this shard, and returns
+   * a `cleanup` task that drops any slot other than the specified
+   * `slotToKeep`.
+   */
+  async #stopExistingReplicationSlotSubscribers(
     db: PostgresDB,
-    slot: string,
-  ): Promise<void> {
-    const result = await db<{pid: string | null}[]>`
-    SELECT pg_terminate_backend(active_pid), active_pid as pid
-      FROM pg_replication_slots WHERE slot_name = ${slot}`;
+    slotToKeep: string,
+  ): Promise<{cleanup: Promise<void>}> {
+    const replicasTable = `${upstreamSchema(this.#shard)}.replicas`;
+
+    const result = await db<{slot: string; pid: string | null}[]>`
+    SELECT slot, pg_terminate_backend(active_pid), active_pid as pid
+      FROM pg_replication_slots 
+      JOIN ${db(replicasTable)} ON slot_name = slot`;
     if (result.length === 0) {
       // Note: This should not happen as it is checked at initialization time,
       //       but it is technically possible for the replication slot to be
       //       dropped (e.g. manually).
       throw new AbortError(
-        `replication slot ${slot} is missing. Delete the replica and resync.`,
+        `replication slot ${slotToKeep} is missing. Delete the replica and resync.`,
       );
     }
-    const {pid} = result[0];
-    if (pid) {
-      this.#lc.info?.(`signaled subscriber ${pid} to shut down`);
+    // Clean up the replicas table.
+    await db`DELETE FROM ${db(replicasTable)} WHERE slot != ${slotToKeep}`;
+
+    const pids = result.filter(({pid}) => pid !== null).map(({pid}) => pid);
+    if (pids.length) {
+      this.#lc.info?.(`signaled subscriber ${pids} to shut down`);
     }
+    const otherSlots = result
+      .filter(({slot}) => slot !== slotToKeep)
+      .map(({slot}) => slot);
+    return {
+      cleanup: otherSlots.length
+        ? this.#dropReplicationSlots(db, otherSlots)
+        : promiseVoid,
+    };
+  }
+
+  async #dropReplicationSlots(db: PostgresDB, slots: string[]) {
+    this.#lc.info?.(`dropping other replication slot(s) ${slots}`);
+    for (let i = 0; i < 5; i++) {
+      try {
+        await db`
+          SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots
+            WHERE slot_name IN ${db(slots)}
+        `;
+        this.#lc.info?.(`successfully dropped ${slots}`);
+        return;
+      } catch (e) {
+        // error: replication slot "zero_slot_change_source_test_id" is active for PID 268
+        if (
+          e instanceof postgres.PostgresError &&
+          e.code === PG_OBJECT_IN_USE
+        ) {
+          // The freeing up of the replication slot is not transactional;
+          // sometimes it takes time for Postgres to consider the slot
+          // inactive.
+          this.#lc.debug?.(`attempt ${i + 1}: ${String(e)}`, e);
+        } else {
+          this.#lc.warn?.(`error dropping ${slots}`, e);
+        }
+        await sleep(1000);
+      }
+    }
+    this.#lc.warn?.(`maximum attempts exceeded dropping ${slots}`);
   }
 }
 
@@ -330,6 +394,7 @@ class ChangeMaker {
   readonly #lc: LogContext;
   readonly #shardPrefix: string;
   readonly #shardConfig: InternalShardConfig;
+  readonly #initialSchema: PublishedSchema;
   readonly #upstream: ShortLivedClient;
 
   #replicaIdentityTimer: NodeJS.Timeout | undefined;
@@ -339,12 +404,14 @@ class ChangeMaker {
     lc: LogContext,
     {appID, shardNum}: ShardID,
     shardConfig: InternalShardConfig,
+    initialSchema: PublishedSchema,
     upstreamURI: string,
   ) {
     this.#lc = lc;
     // Note: This matches the prefix used in pg_logical_emit_message() in pg/schema/ddl.ts.
     this.#shardPrefix = `${appID}/${shardNum}`;
     this.#shardConfig = shardConfig;
+    this.#initialSchema = initialSchema;
     this.#upstream = new ShortLivedClient(
       lc,
       upstreamURI,
@@ -646,23 +713,24 @@ class ChangeMaker {
    * However, they serve the purpose determining if schemas have changed.
    */
   async #handleRelation(rel: MessageRelation): Promise<ChangeStreamData[]> {
-    const {publications, ddlDetection, initialSchema} = this.#shardConfig;
+    const {publications, ddlDetection} = this.#shardConfig;
     if (ddlDetection) {
       return [];
     }
-    assert(initialSchema); // Written in initial-sync
     const currentSchema = await getPublicationInfo(
       this.#upstream.db,
       publications,
     );
-    if (schemasDifferent(initialSchema, currentSchema, this.#lc)) {
+    if (schemasDifferent(this.#initialSchema, currentSchema, this.#lc)) {
       throw new UnsupportedSchemaChangeError();
     }
     // Even if the currentSchema is equal to the initialSchema, the
     // MessageRelation itself must be checked to detect transient
     // schema changes within the transaction (e.g. adding and dropping
     // a table, or renaming a column and then renaming it back).
-    const orel = initialSchema.tables.find(t => t.oid === rel.relationOid);
+    const orel = this.#initialSchema.tables.find(
+      t => t.oid === rel.relationOid,
+    );
     if (!orel) {
       // Can happen if a table is created and then dropped in the same transaction.
       this.#lc.info?.(`relation not in initialSchema: ${stringify(rel)}`);

--- a/packages/zero-cache/src/services/change-source/pg/decommission.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/decommission.pg-test.ts
@@ -1,4 +1,4 @@
-import type {LogContext} from '@rocicorp/logger';
+import {LogContext} from '@rocicorp/logger';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
 import {Database} from '../../../../../zqlite/src/db.ts';
@@ -62,7 +62,7 @@ describe('decommission', () => {
     ]);
     expect(
       await upstream`SELECT slot_name FROM pg_replication_slots WHERE slot_name LIKE 'zeroout%'`.values(),
-    ).toEqual([['zeroout_13']]);
+    ).toMatchObject([[expect.stringMatching('zeroout_13_')]]);
     expect(
       await upstream`SELECT nspname FROM pg_namespace WHERE nspname LIKE 'zeroout%'`.values(),
     ).toEqual([['zeroout_13'], ['zeroout']]);

--- a/packages/zero-cache/src/services/change-source/pg/decommission.ts
+++ b/packages/zero-cache/src/services/change-source/pg/decommission.ts
@@ -12,18 +12,28 @@ export async function decommissionShard(
 
   lc.info?.(`Decommissioning zero shard ${shard}`);
   await db.begin(async tx => {
-    await tx.unsafe(dropShard(appID, shardID));
-    lc.debug?.(`Dropped upstream shard schema ${shard} and event triggers`);
-
+    // Kill the active_pid's on existing slots before altering publications,
+    // as deleting a publication associated with an existing subscriber causes
+    // weirdness; the active_pid becomes null and thus unable to be terminated.
     const slots = await tx<{pid: string | null}[]>`
     SELECT pg_terminate_backend(active_pid), active_pid as pid
-      FROM pg_replication_slots WHERE slot_name = ${shard}`;
+      FROM pg_replication_slots 
+      WHERE slot_name = ${shard} 
+         OR slot_name LIKE ${shard + '_%'}`;
     if (slots.length > 0) {
       if (slots[0].pid !== null) {
         lc.info?.(`signaled subscriber ${slots[0].pid} to shut down`);
       }
-      await tx`SELECT pg_drop_replication_slot(${shard})`;
-      lc.debug?.(`Dropped replication slot ${shard}`);
+      const dropped = await tx<{slotName: string}[]>`
+        SELECT pg_drop_replication_slot(slot_name), slot_name as "slotName"
+          FROM pg_replication_slots 
+          WHERE slot_name = ${shard} 
+             OR slot_name LIKE ${shard + '_%'}`;
+      lc.debug?.(
+        `Dropped replication slot(s) ${dropped.map(({slotName}) => slotName)}`,
+      );
+      await tx.unsafe(dropShard(appID, shardID));
+      lc.debug?.(`Dropped upstream shard schema ${shard} and event triggers`);
     }
   });
   lc.info?.(`Finished decommissioning zero shard ${shard}`);

--- a/packages/zero-cache/src/services/change-source/pg/decommission.ts
+++ b/packages/zero-cache/src/services/change-source/pg/decommission.ts
@@ -24,11 +24,13 @@ export async function decommissionShard(
       if (slots[0].pid !== null) {
         lc.info?.(`signaled subscriber ${slots[0].pid} to shut down`);
       }
+      // Escape underscores for the LIKE expression.
+      const slotExpression = `${appID}_${shardID}_%`.replaceAll('_', '\\_');
       const dropped = await tx<{slotName: string}[]>`
         SELECT pg_drop_replication_slot(slot_name), slot_name as "slotName"
           FROM pg_replication_slots 
           WHERE slot_name = ${shard} 
-             OR slot_name LIKE ${shard + '_%'}`;
+             OR slot_name LIKE ${slotExpression}`;
       lc.debug?.(
         `Dropped replication slot(s) ${dropped.map(({slotName}) => slotName)}`,
       );

--- a/packages/zero-cache/src/services/change-source/pg/schema/init.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.ts
@@ -1,5 +1,6 @@
 import type {LogContext} from '@rocicorp/logger';
 import {assert} from '../../../../../../shared/src/asserts.ts';
+import * as v from '../../../../../../shared/src/valita.ts';
 import {
   getVersionHistory,
   runSchemaMigrations,
@@ -10,19 +11,33 @@ import type {PostgresDB} from '../../../../types/pg.ts';
 import {upstreamSchema, type ShardConfig} from '../../../../types/shards.ts';
 import {AutoResetSignal} from '../../../change-streamer/schema/tables.ts';
 import {decommissionShard} from '../decommission.ts';
-import {dropShard, setupTablesAndReplication, setupTriggers} from './shard.ts';
+import {publishedSchema} from './published.ts';
+import {setupTablesAndReplication, setupTriggers} from './shard.ts';
 
 /**
  * Initializes a shard for initial sync.
  * This will drop any existing shard setup.
  */
-export async function initShardSchema(
+export async function ensureShardSchema(
   lc: LogContext,
   db: PostgresDB,
   shard: ShardConfig,
 ): Promise<void> {
-  await db.unsafe(dropShard(shard.appID, shard.shardNum));
-  return runShardMigrations(lc, db, shard);
+  const initialSetup: Migration = {
+    migrateSchema: (lc, tx) => setupTablesAndReplication(lc, tx, shard),
+    minSafeVersion: 1,
+  };
+  await runSchemaMigrations(
+    lc,
+    `upstream-shard-${shard.appID}`,
+    upstreamSchema(shard),
+    db,
+    initialSetup,
+    // The incremental migration of any existing replicas will be replaced by
+    // the incoming replica being synced, so the replicaVersion here is
+    // unnecessary.
+    getIncrementalMigrations(shard, 'obsolete'),
+  );
 }
 
 /**
@@ -34,32 +49,35 @@ export async function updateShardSchema(
   shard: ShardConfig,
   replicaVersion: string,
 ): Promise<void> {
-  const {appID, shardNum} = shard;
-  const versionHistory = await getVersionHistory(db, upstreamSchema(shard));
-  if (versionHistory === null) {
-    throw new AutoResetSignal(
-      `upstream shard ${appID}_${shardNum} is not initialized`,
-    );
-  }
-  await runShardMigrations(lc, db, shard, replicaVersion);
+  await runSchemaMigrations(
+    lc,
+    `upstream-shard-${shard.appID}`,
+    upstreamSchema(shard),
+    db,
+    {
+      // If the expected existing shard is absent, throw an
+      // AutoResetSignal to backtrack and initial sync.
+      migrateSchema: () => {
+        throw new AutoResetSignal(
+          `upstream shard ${upstreamSchema(shard)} is not initialized`,
+        );
+      },
+    },
+    getIncrementalMigrations(shard, replicaVersion),
+  );
 
   // The decommission check is run in updateShardSchema so that it happens
   // after initial sync, and not when the shard schema is initially set up.
   await decommissionLegacyShard(lc, db, shard);
 }
 
-async function runShardMigrations(
-  lc: LogContext,
-  db: PostgresDB,
+function getIncrementalMigrations(
   shard: ShardConfig,
   replicaVersion?: string,
-): Promise<void> {
-  const setupMigration: Migration = {
-    migrateSchema: (lc, tx) => setupTablesAndReplication(lc, tx, shard),
-    minSafeVersion: 1,
-  };
+): IncrementalMigrationMap {
+  const shardConfigTable = `${upstreamSchema(shard)}.shardConfig`;
 
-  const schemaVersionMigrationMap: IncrementalMigrationMap = {
+  return {
     4: {
       migrateSchema: () => {
         throw new AutoResetSignal('resetting to upgrade shard schema');
@@ -84,11 +102,9 @@ async function runShardMigrations(
         );
         await Promise.all([
           tx`
-          ALTER TABLE ${tx(upstreamSchema(shard))}."shardConfig" 
-            ADD "replicaVersion" TEXT`,
+          ALTER TABLE ${tx(shardConfigTable)} ADD "replicaVersion" TEXT`,
           tx`
-          UPDATE ${tx(upstreamSchema(shard))}."shardConfig" 
-            SET ${tx({replicaVersion})}`,
+          UPDATE ${tx(shardConfigTable)} SET ${tx({replicaVersion})}`,
         ]);
         lc.info?.(
           `Recorded replicaVersion ${replicaVersion} in upstream shardConfig`,
@@ -101,22 +117,54 @@ async function runShardMigrations(
     7: {
       migrateSchema: async (lc, tx) => {
         const [{publications}] = await tx<{publications: string[]}[]>`
-          SELECT publications FROM ${tx(upstreamSchema(shard))}."shardConfig"
-        `;
+          SELECT publications FROM ${tx(shardConfigTable)}`;
         await setupTriggers(lc, tx, {...shard, publications});
         lc.info?.(`Upgraded to v2 event triggers`);
       },
     },
-  };
 
-  await runSchemaMigrations(
-    lc,
-    `upstream-shard-${shard.appID}`,
-    upstreamSchema(shard),
-    db,
-    setupMigration,
-    schemaVersionMigrationMap,
-  );
+    // Adds support for non-disruptive resyncs, which tracks multiple
+    // replicas with different slot names.
+    8: {
+      migrateSchema: async (lc, tx) => {
+        const {appID, shardNum} = shard;
+
+        const legacyShardConfigSchema = v.object({
+          replicaVersion: v.string().nullable(),
+          initialSchema: publishedSchema.nullable(),
+        });
+        const result = await tx`
+          SELECT "replicaVersion", "initialSchema" FROM ${tx(shardConfigTable)}`;
+        assert(result.length === 1);
+        const {replicaVersion, initialSchema} = v.parse(
+          result[0],
+          legacyShardConfigSchema,
+          'passthrough',
+        );
+
+        await Promise.all([
+          tx`
+          CREATE TABLE ${tx(upstreamSchema(shard))}.replicas (
+            "slot"          TEXT PRIMARY KEY,
+            "version"       TEXT NOT NULL,
+            "initialSchema" JSON NOT NULL
+          );
+          `,
+          tx`
+          INSERT INTO ${tx(upstreamSchema(shard))}.replicas ${tx({
+            slot: `${appID}_${shardNum}`, // legacy slot name
+            version: replicaVersion,
+            initialSchema,
+          })}
+          `,
+          tx`
+          ALTER TABLE ${tx(shardConfigTable)} DROP "replicaVersion", DROP "initialSchema"
+          `,
+        ]);
+        lc.info?.(`Upgraded schema to support non-disruptive resyncs`);
+      },
+    },
+  };
 }
 
 export async function decommissionLegacyShard(

--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
@@ -22,6 +22,10 @@ export function internalPublicationPrefix({appID}: AppID) {
   return `_${appID}_`;
 }
 
+export function legacyReplicationSlot({appID, shardNum}: ShardID) {
+  return `${appID}_${shardNum}`;
+}
+
 export function replicationSlotPrefix(shard: ShardID) {
   const {appID, shardNum} = check(shard);
   return `${appID}_${shardNum}_`;

--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
@@ -7,7 +7,7 @@ import * as v from '../../../../../../shared/src/valita.ts';
 import {Default} from '../../../../db/postgres-replica-identity-enum.ts';
 import type {PostgresDB, PostgresTransaction} from '../../../../types/pg.ts';
 import type {AppID, ShardConfig, ShardID} from '../../../../types/shards.ts';
-import {appSchema, upstreamSchema} from '../../../../types/shards.ts';
+import {appSchema, check, upstreamSchema} from '../../../../types/shards.ts';
 import {id} from '../../../../types/sql.ts';
 import {createEventTriggerStatements} from './ddl.ts';
 import {
@@ -20,6 +20,15 @@ import {validate} from './validation.ts';
 
 export function internalPublicationPrefix({appID}: AppID) {
   return `_${appID}_`;
+}
+
+export function replicationSlotPrefix(shard: ShardID) {
+  const {appID, shardNum} = check(shard);
+  return `${appID}_${shardNum}_`;
+}
+
+export function newReplicationSlot(shard: ShardID) {
+  return replicationSlotPrefix(shard) + Date.now();
 }
 
 function defaultPublicationName(appID: string, shardID: string | number) {
@@ -114,21 +123,24 @@ export function shardSetup(
   CREATE TABLE ${shard}."${SHARD_CONFIG_TABLE}" (
     "publications"  TEXT[] NOT NULL,
     "ddlDetection"  BOOL NOT NULL,
-    "replicaVersion" TEXT,
-    "initialSchema" JSON,
 
     -- Ensure that there is only a single row in the table.
     "lock" BOOL PRIMARY KEY DEFAULT true CHECK (lock)
   );
 
-  INSERT INTO ${shard}."${SHARD_CONFIG_TABLE}" 
-    ("lock", "publications", "ddlDetection", "replicaVersion", "initialSchema")
-    VALUES (true, 
+  INSERT INTO ${shard}."${SHARD_CONFIG_TABLE}" (
+      "publications",
+      "ddlDetection" 
+    ) VALUES (
       ARRAY[${literal(pubs)}], 
-      false,  -- set in SAVEPOINT with triggerSetup() statements
-      null,   -- set in initial-sync at consistent_point LSN.
-      null    -- set in initial-sync at consistent_ponit LSN.
+      false  -- set in SAVEPOINT with triggerSetup() statements
     );
+
+  CREATE TABLE ${shard}.replicas (
+    "slot"          TEXT PRIMARY KEY,
+    "version"       TEXT NOT NULL,
+    "initialSchema" JSON NOT NULL
+  );
   `;
 }
 
@@ -146,11 +158,17 @@ export function dropShard(appID: string, shardID: string | number): string {
   `;
 }
 
+const replicaSchema = v.object({
+  slot: v.string(),
+  version: v.string(),
+  initialSchema: publishedSchema,
+});
+
+export type Replica = v.Infer<typeof replicaSchema>;
+
 const internalShardConfigSchema = v.object({
   publications: v.array(v.string()),
   ddlDetection: v.boolean(),
-  replicaVersion: v.string().nullable(),
-  initialSchema: publishedSchema.nullable(),
 });
 
 export type InternalShardConfig = v.Infer<typeof internalShardConfigSchema>;
@@ -167,18 +185,33 @@ function triggerSetup(shard: ShardConfig): string {
 }
 
 // Called in initial-sync to store the exact schema that was initially synced.
-export async function setInitialSchema(
+export async function addReplica(
   db: PostgresDB,
   shard: ShardID,
+  slot: string,
   replicaVersion: string,
   {tables, indexes}: PublishedSchema,
 ) {
   const schema = upstreamSchema(shard);
   const synced: PublishedSchema = {tables, indexes};
   await db`
-  UPDATE ${db(schema)}."shardConfig" 
-     SET "replicaVersion" = ${replicaVersion},
-          "initialSchema" = ${synced}`;
+    INSERT INTO ${db(schema)}.replicas ("slot", "version", "initialSchema")
+      VALUES (${slot}, ${replicaVersion}, ${synced})`;
+}
+
+export async function getReplicaAtVersion(
+  db: PostgresDB,
+  shard: ShardID,
+  replicaVersion: string,
+): Promise<Replica | null> {
+  const result = await db`
+    SELECT * FROM ${db(upstreamSchema(shard))}.replicas 
+      WHERE version = ${replicaVersion};
+  `;
+  if (result.length === 0) {
+    return null;
+  }
+  return v.parse(result[0], replicaSchema, 'passthrough');
 }
 
 export async function getInternalShardConfig(
@@ -186,7 +219,7 @@ export async function getInternalShardConfig(
   shard: ShardID,
 ): Promise<InternalShardConfig> {
   const result = await db`
-    SELECT "publications", "ddlDetection", "replicaVersion", "initialSchema"
+    SELECT "publications", "ddlDetection"
       FROM ${db(upstreamSchema(shard))}."shardConfig";
   `;
   assert(result.length === 1);

--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
@@ -31,6 +31,16 @@ export function replicationSlotPrefix(shard: ShardID) {
   return `${appID}_${shardNum}_`;
 }
 
+/**
+ * An expression used to match replication slots in the shard
+ * in a Postgres `LIKE` operator.
+ */
+export function replicationSlotExpression(shard: ShardID) {
+  // Underscores have a special meaning in LIKE values
+  // so they have to be escaped.
+  return `${replicationSlotPrefix(shard)}%`.replaceAll('_', '\\_');
+}
+
 export function newReplicationSlot(shard: ShardID) {
   return replicationSlotPrefix(shard) + Date.now();
 }

--- a/packages/zero-cache/src/services/change-source/pg/sync-schema.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/sync-schema.pg-test.ts
@@ -13,7 +13,7 @@ import {
   initDB as initLiteDB,
 } from '../../../test/lite.ts';
 import type {PostgresDB} from '../../../types/pg.ts';
-import {replicationSlotPrefix} from './schema/shard.ts';
+import {replicationSlotExpression} from './schema/shard.ts';
 import {initSyncSchema} from './sync-schema.ts';
 
 const APP_ID = 'zeroz';
@@ -149,7 +149,7 @@ describe('change-streamer/pg/sync-schema', () => {
 
         // Slot should still exist.
         const slots = await upstream`SELECT slot_name FROM pg_replication_slots 
-          WHERE slot_name LIKE ${replicationSlotPrefix(shard) + '_%'}`.values();
+          WHERE slot_name LIKE ${replicationSlotExpression(shard)}`.values();
         expect(slots).toHaveLength(1);
       },
       10000,

--- a/packages/zero-cache/src/services/change-source/pg/sync-schema.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/sync-schema.pg-test.ts
@@ -13,7 +13,7 @@ import {
   initDB as initLiteDB,
 } from '../../../test/lite.ts';
 import type {PostgresDB} from '../../../types/pg.ts';
-import {replicationSlot} from './initial-sync.ts';
+import {replicationSlotPrefix} from './schema/shard.ts';
 import {initSyncSchema} from './sync-schema.ts';
 
 const APP_ID = 'zeroz';
@@ -149,8 +149,8 @@ describe('change-streamer/pg/sync-schema', () => {
 
         // Slot should still exist.
         const slots = await upstream`SELECT slot_name FROM pg_replication_slots 
-          WHERE slot_name = ${replicationSlot(shard)}`.values();
-        expect(slots[0]).toEqual([replicationSlot(shard)]);
+          WHERE slot_name LIKE ${replicationSlotPrefix(shard) + '_%'}`.values();
+        expect(slots).toHaveLength(1);
       },
       10000,
     );

--- a/packages/zero-cache/src/types/shards.ts
+++ b/packages/zero-cache/src/types/shards.ts
@@ -47,7 +47,7 @@ export const ALLOWED_APP_ID_CHARACTERS = /^[a-z0-9_]+$/;
 export const INVALID_APP_ID_MESSAGE =
   'The App ID may only consist of lower-case letters, numbers, and the underscore character';
 
-function check(shard: ShardID): {appID: string; shardNum: number} {
+export function check(shard: ShardID): {appID: string; shardNum: number} {
   const {appID, shardNum} = shard;
   if (!ALLOWED_APP_ID_CHARACTERS.test(appID)) {
     throw new Error(INVALID_APP_ID_MESSAGE);


### PR DESCRIPTION
`zero-cache` previously used a constant replication slot named `{app-id}_{shard-num}`, requiring a previously synced `zero-cache` instance to be shut down (and the replication slot dropped and re-created) in order for the new `zero-cache` to perform initial sync. This can result in a lot of downtime when resyncing large databases.

With non-disruptive resync, an initial-syncing `zero-cache` creates a replication slot of the form `{app-id}_{shard-num}_{timestamp}` and records it in a `replicas` upstream table when initial-sync completes. This allows the old replication slot to continue servicing the old `zero-cache` while the new one performs initial-sync.

Once initial-sync is complete, all subscribers to any replication slot for the shard are shutdown, and all but the new replication slot are cleaned up. The new replica then begins its subscription on the new (and sole remaining) replication slot, resulting in a non-disruptive handoff similar to the usual replication-manager restart.