### PR TITLE
chore(z2s): run z2s compiler tests again postgres.js and node-postgres

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8701,11 +8701,85 @@
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
       "license": "MIT"
     },
+    "node_modules/@types/pg": {
+      "version": "8.11.11",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.11.tgz",
+      "integrity": "sha512-kGT1qKM8wJQ5qlawUrEkXgvMSXoV213KfMGXcwfDwUIfUHXqXYXOfS1nE1LINRJVVVx5wCm70XnFlMHaIcQAfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^4.0.1"
+      }
+    },
     "node_modules/@types/pg-format": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/pg-format/-/pg-format-1.0.5.tgz",
       "integrity": "sha512-i+oEEJEC+1I3XAhgqtVp45Faj8MBbV0Aoq4rHsHD7avgLjyDkaWKObd514g0Q/DOUkdxU0P4CQ0iq2KR4SoJcw==",
       "dev": true
+    },
+    "node_modules/@types/pg/node_modules/pg-types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.0.2.tgz",
+      "integrity": "sha512-cRL3JpS3lKMGsKaWndugWQoLOCoP+Cic8oseVcbr0qhPzYD5DWXK+RZ9LY9wxRf7RQia4SCwQlXk0q6FCPrVng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "pg-numeric": "1.0.2",
+        "postgres-array": "~3.0.1",
+        "postgres-bytea": "~3.0.0",
+        "postgres-date": "~2.1.0",
+        "postgres-interval": "^3.0.0",
+        "postgres-range": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-array": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.4.tgz",
+      "integrity": "sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-bytea": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
+      "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "obuf": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-date": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.1.0.tgz",
+      "integrity": "sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-interval": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
+      "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/@types/pidusage": {
       "version": "2.0.5",
@@ -19100,6 +19174,49 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/pg": {
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.14.1.tgz",
+      "integrity": "sha512-0TdbqfjwIun9Fm/r89oB7RFQ0bLgduAhiIqIXOsyKoiC/L54DbuAAzIEN/9Op0f1Po9X7iCPXGoa/Ah+2aI8Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.7.0",
+        "pg-pool": "^3.8.0",
+        "pg-protocol": "^1.8.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.1.1"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.1.1.tgz",
+      "integrity": "sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.7.0.tgz",
+      "integrity": "sha512-PI2W9mv53rXJQEOb8xNR8lH7Hr+EKa6oJa38zsK0S/ky2er16ios1wLKhZyxzD7jUReiWokc9WK5nxSnC7W1TA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pg-format": {
       "name": "pg-format-fix",
       "version": "1.0.5",
@@ -19107,6 +19224,70 @@
       "integrity": "sha512-HcXVy9Zk4kn87P0+U9XSxGtenNyknbPB87NreixSBk0lYJy89u+d/zQbS+f/aTTxABQ/B6FH1KdBB5EsGzRS2w==",
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-numeric": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
+      "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.8.0.tgz",
+      "integrity": "sha512-VBw3jiVm6ZOdLBTIcXLNdSotb6Iy3uOCwDGFAksZCXmi10nyRvnP2v3jl4d+IsLYRyXf6o9hIm/ZtUzlByNUdw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.8.0.tgz",
+      "integrity": "sha512-jvuYlEkL03NRvOoyoRktBK7+qU5kOvlAwvmrH8sr3wbLrOdVWsRxQfz8mMy9sZFsqJ1hEWNfdWKI4SAmoL+j7g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
       }
     },
     "node_modules/picocolors": {
@@ -20583,6 +20764,56 @@
         "type": "individual",
         "url": "https://github.com/sponsors/porsager"
       }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-range": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.4.tgz",
+      "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prebuild-install": {
       "version": "7.1.2",
@@ -26387,6 +26618,16 @@
         "xml-js": "bin/cli.js"
       }
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -26886,7 +27127,9 @@
         "@faker-js/faker": "^9.6.0",
         "@rocicorp/eslint-config": "^0.7.0",
         "@rocicorp/prettier-config": "^0.3.0",
+        "@types/pg": "^8.11.11",
         "@vitest/runner": "3.0.8",
+        "pg": "^8.14.1",
         "vitest": "3.0.8"
       }
     },
@@ -32558,6 +32801,61 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="
+    },
+    "@types/pg": {
+      "version": "8.11.11",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.11.tgz",
+      "integrity": "sha512-kGT1qKM8wJQ5qlawUrEkXgvMSXoV213KfMGXcwfDwUIfUHXqXYXOfS1nE1LINRJVVVx5wCm70XnFlMHaIcQAfw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^4.0.1"
+      },
+      "dependencies": {
+        "pg-types": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.0.2.tgz",
+          "integrity": "sha512-cRL3JpS3lKMGsKaWndugWQoLOCoP+Cic8oseVcbr0qhPzYD5DWXK+RZ9LY9wxRf7RQia4SCwQlXk0q6FCPrVng==",
+          "dev": true,
+          "requires": {
+            "pg-int8": "1.0.1",
+            "pg-numeric": "1.0.2",
+            "postgres-array": "~3.0.1",
+            "postgres-bytea": "~3.0.0",
+            "postgres-date": "~2.1.0",
+            "postgres-interval": "^3.0.0",
+            "postgres-range": "^1.1.1"
+          }
+        },
+        "postgres-array": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.4.tgz",
+          "integrity": "sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==",
+          "dev": true
+        },
+        "postgres-bytea": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
+          "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
+          "dev": true,
+          "requires": {
+            "obuf": "~1.1.2"
+          }
+        },
+        "postgres-date": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.1.0.tgz",
+          "integrity": "sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==",
+          "dev": true
+        },
+        "postgres-interval": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
+          "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
+          "dev": true
+        }
+      }
     },
     "@types/pg-format": {
       "version": "1.0.5",
@@ -39685,10 +39983,84 @@
       "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
       "dev": true
     },
+    "pg": {
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.14.1.tgz",
+      "integrity": "sha512-0TdbqfjwIun9Fm/r89oB7RFQ0bLgduAhiIqIXOsyKoiC/L54DbuAAzIEN/9Op0f1Po9X7iCPXGoa/Ah+2aI8Xw==",
+      "dev": true,
+      "requires": {
+        "pg-cloudflare": "^1.1.1",
+        "pg-connection-string": "^2.7.0",
+        "pg-pool": "^3.8.0",
+        "pg-protocol": "^1.8.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      }
+    },
+    "pg-cloudflare": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.1.1.tgz",
+      "integrity": "sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==",
+      "dev": true,
+      "optional": true
+    },
+    "pg-connection-string": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.7.0.tgz",
+      "integrity": "sha512-PI2W9mv53rXJQEOb8xNR8lH7Hr+EKa6oJa38zsK0S/ky2er16ios1wLKhZyxzD7jUReiWokc9WK5nxSnC7W1TA==",
+      "dev": true
+    },
     "pg-format": {
       "version": "npm:pg-format-fix@1.0.5",
       "resolved": "https://registry.npmjs.org/pg-format-fix/-/pg-format-fix-1.0.5.tgz",
       "integrity": "sha512-HcXVy9Zk4kn87P0+U9XSxGtenNyknbPB87NreixSBk0lYJy89u+d/zQbS+f/aTTxABQ/B6FH1KdBB5EsGzRS2w=="
+    },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true
+    },
+    "pg-numeric": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
+      "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
+      "dev": true
+    },
+    "pg-pool": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.8.0.tgz",
+      "integrity": "sha512-VBw3jiVm6ZOdLBTIcXLNdSotb6Iy3uOCwDGFAksZCXmi10nyRvnP2v3jl4d+IsLYRyXf6o9hIm/ZtUzlByNUdw==",
+      "dev": true,
+      "requires": {}
+    },
+    "pg-protocol": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.8.0.tgz",
+      "integrity": "sha512-jvuYlEkL03NRvOoyoRktBK7+qU5kOvlAwvmrH8sr3wbLrOdVWsRxQfz8mMy9sZFsqJ1hEWNfdWKI4SAmoL+j7g==",
+      "dev": true
+    },
+    "pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "requires": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      }
+    },
+    "pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dev": true,
+      "requires": {
+        "split2": "^4.1.0"
+      }
     },
     "picocolors": {
       "version": "1.1.1",
@@ -40521,6 +40893,39 @@
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.4.tgz",
       "integrity": "sha512-IbyN+9KslkqcXa8AO9fxpk97PA4pzewvpi2B3Dwy9u4zpV32QicaEdgmF3eSQUzdRk7ttDHQejNgAEr4XoeH4A=="
+    },
+    "postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true
+    },
+    "postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "dev": true
+    },
+    "postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true
+    },
+    "postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "requires": {
+        "xtend": "^4.0.0"
+      }
+    },
+    "postgres-range": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.4.tgz",
+      "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==",
+      "dev": true
     },
     "prebuild-install": {
       "version": "7.1.2",
@@ -44568,6 +44973,12 @@
         "sax": "^1.2.4"
       }
     },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true
+    },
     "y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -44631,7 +45042,9 @@
         "@faker-js/faker": "^9.6.0",
         "@rocicorp/eslint-config": "^0.7.0",
         "@rocicorp/prettier-config": "^0.3.0",
+        "@types/pg": "^8.11.11",
         "@vitest/runner": "3.0.8",
+        "pg": "^8.14.1",
         "vitest": "3.0.8"
       }
     },

--- a/packages/z2s/package.json
+++ b/packages/z2s/package.json
@@ -21,7 +21,9 @@
     "@faker-js/faker": "^9.6.0",
     "@rocicorp/eslint-config": "^0.7.0",
     "@rocicorp/prettier-config": "^0.3.0",
+    "@types/pg": "^8.11.11",
     "@vitest/runner": "3.0.8",
+    "pg": "^8.14.1",
     "vitest": "3.0.8"
   },
   "eslintConfig": {

--- a/packages/z2s/src/compiler-bigint.pg-test.ts
+++ b/packages/z2s/src/compiler-bigint.pg-test.ts
@@ -1,4 +1,4 @@
-import {beforeAll, describe, expect, test} from 'vitest';
+import {afterAll, beforeAll, describe, expect, test} from 'vitest';
 import {testLogConfig} from '../../otel/src/test-log-config.ts';
 import type {JSONValue} from '../../shared/src/json.ts';
 import {createSilentLogContext} from '../../shared/src/logging-test-utils.ts';
@@ -29,10 +29,14 @@ import {
   table,
 } from '../../zero-schema/src/builder/table-builder.ts';
 import {relationships} from '../../zero-schema/src/builder/relationship-builder.ts';
+import {Client} from 'pg';
 
 const lc = createSilentLogContext();
 
+const DB_NAME = 'compiler-bigint';
+
 let pg: PostgresDB;
+let nodePostgres: Client;
 let sqlite: Database;
 
 export const createTableSQL = /*sql*/ `
@@ -80,7 +84,7 @@ type Schema = typeof schema;
 let issueQuery: Query<Schema, 'issue'>;
 
 beforeAll(async () => {
-  pg = await testDBs.create('compiler', undefined, false);
+  pg = await testDBs.create(DB_NAME, undefined, false);
   await pg.unsafe(createTableSQL);
   sqlite = new Database(lc, ':memory:');
   const testData = {
@@ -154,6 +158,20 @@ beforeAll(async () => {
       .map(row => fromSQLiteTypes(schema.tables.comment.columns, row))
       .map(mapHash),
   ).toEqual(testData.comment);
+
+  const {host, port, user, pass} = pg.options;
+  nodePostgres = new Client({
+    user,
+    host: host[0],
+    port: port[0],
+    password: pass ?? undefined,
+    database: DB_NAME,
+  });
+  await nodePostgres.connect();
+});
+
+afterAll(() => {
+  nodePostgres.end();
 });
 
 function mapHash(commentRow: Record<string, unknown>) {
@@ -171,63 +189,79 @@ function ast(q: Query<Schema, keyof Schema['tables']>) {
 }
 
 describe('compiling ZQL to SQL', () => {
-  test('All bigints in safe Number range', async () => {
-    const query = issueQuery.related('comments').limit(2);
-    const c = compile(ast(query), schema.tables);
-    const sqlQuery = formatPg(c);
-    const pgResult = extractZqlResult(
-      await pg.unsafe(sqlQuery.text, sqlQuery.values as JSONValue[]),
-    );
-    expect(
-      mapResultToClientNames(await query.run(), schema, 'issue'),
-    ).toEqualPg(pgResult);
-    expect(pgResult).toMatchInlineSnapshot(`
-      [
-        {
-          "comments": [
-            {
-              "hash": 9007199254740987,
-              "id": "comment1",
-              "issueId": "issue1",
-            },
-            {
-              "hash": 9007199254740988,
-              "id": "comment2",
-              "issueId": "issue1",
-            },
-          ],
-          "id": "issue1",
-          "title": "Test Issue 1",
-        },
-        {
-          "comments": [
-            {
-              "hash": 9007199254740989,
-              "id": "comment3",
-              "issueId": "issue2",
-            },
-            {
-              "hash": 9007199254740990,
-              "id": "comment4",
-              "issueId": "issue2",
-            },
-          ],
-          "id": "issue2",
-          "title": "Test Issue 2",
-        },
-      ]
-    `);
-  });
-  test('bigint exceeds safe range', async () => {
-    const query = issueQuery.related('comments');
-    const c = compile(ast(query), schema.tables);
-    const sqlQuery = formatPg(c);
-    const result = await pg.unsafe(
-      sqlQuery.text,
-      sqlQuery.values as JSONValue[],
-    );
-    expect(() => extractZqlResult(result)).toThrowErrorMatchingInlineSnapshot(
-      `[Error: Value exceeds safe Number range. [2]['comments'][1]['hash'] = 9007199254740992]`,
+  describe('postgres.js', () => {
+    t((query: string, args: unknown[]) =>
+      pg.unsafe(query, args as JSONValue[]),
     );
   });
+  describe('node-postgres', () => {
+    t(
+      async (query: string, args: unknown[]) =>
+        (await nodePostgres.query(query, args as JSONValue[])).rows,
+    );
+  });
+  function t(runPgQuery: (query: string, args: unknown[]) => Promise<unknown>) {
+    test('All bigints in safe Number range', async () => {
+      const query = issueQuery.related('comments').limit(2);
+      const c = compile(ast(query), schema.tables);
+      const sqlQuery = formatPg(c);
+      const pgResult = extractZqlResult(
+        await runPgQuery(sqlQuery.text, sqlQuery.values as JSONValue[]),
+      );
+      const zqlResult = mapResultToClientNames(
+        await query.run(),
+        schema,
+        'issue',
+      );
+      expect(zqlResult).toEqualPg(pgResult);
+      expect(zqlResult).toMatchInlineSnapshot(`
+        [
+          {
+            "comments": [
+              {
+                "hash": 9007199254740987,
+                "id": "comment1",
+                "issueId": "issue1",
+              },
+              {
+                "hash": 9007199254740988,
+                "id": "comment2",
+                "issueId": "issue1",
+              },
+            ],
+            "id": "issue1",
+            "title": "Test Issue 1",
+          },
+          {
+            "comments": [
+              {
+                "hash": 9007199254740989,
+                "id": "comment3",
+                "issueId": "issue2",
+              },
+              {
+                "hash": 9007199254740990,
+                "id": "comment4",
+                "issueId": "issue2",
+              },
+            ],
+            "id": "issue2",
+            "title": "Test Issue 2",
+          },
+        ]
+      `);
+    });
+    test('bigint exceeds safe range', async () => {
+      const query = issueQuery.related('comments');
+      const c = compile(ast(query), schema.tables);
+      const sqlQuery = formatPg(c);
+      const result = await runPgQuery(
+        sqlQuery.text,
+        sqlQuery.values as JSONValue[],
+      );
+      expect(() => extractZqlResult(result)).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Value exceeds safe Number range. [2]['comments'][1]['hash'] = 9007199254740992]`,
+      );
+    });
+  }
 });

--- a/packages/z2s/src/compiler-bigint.pg-test.ts
+++ b/packages/z2s/src/compiler-bigint.pg-test.ts
@@ -170,8 +170,8 @@ beforeAll(async () => {
   await nodePostgres.connect();
 });
 
-afterAll(() => {
-  nodePostgres.end();
+afterAll(async () => {
+  await nodePostgres.end();
 });
 
 function mapHash(commentRow: Record<string, unknown>) {

--- a/packages/z2s/src/compiler.pg-test.ts
+++ b/packages/z2s/src/compiler.pg-test.ts
@@ -1,4 +1,4 @@
-import {beforeAll, describe, expect, test} from 'vitest';
+import {afterAll, beforeAll, describe, expect, test} from 'vitest';
 import {testLogConfig} from '../../otel/src/test-log-config.ts';
 import type {JSONValue} from '../../shared/src/json.ts';
 import {createSilentLogContext} from '../../shared/src/logging-test-utils.ts';
@@ -22,11 +22,16 @@ import {
 } from '../../zqlite/src/test/source-factory.ts';
 import {compile, extractZqlResult} from './compiler.ts';
 import {formatPg} from './sql.ts';
+import {Client} from 'pg';
 import './test/comparePg.ts';
 
 const lc = createSilentLogContext();
 
+const BASE_TIMESTAMP = 1743127752952;
+const DB_NAME = 'compiler';
+
 let pg: PostgresDB;
+let nodePostgres: Client;
 let sqlite: Database;
 type Schema = typeof schema;
 
@@ -37,7 +42,7 @@ let issueQuery: Query<Schema, 'issue'>;
  * These test will likely be deprecated.
  */
 beforeAll(async () => {
-  pg = await testDBs.create('compiler', undefined, false);
+  pg = await testDBs.create(DB_NAME, undefined, false);
   await pg.unsafe(createTableSQL);
   sqlite = new Database(lc, ':memory:');
   const testData = {
@@ -47,7 +52,7 @@ beforeAll(async () => {
       description: `Description for issue ${i + 1}`,
       closed: i % 2 === 0,
       ownerId: i === 0 ? null : `user${i}`,
-      createdAt: new Date(Date.now() - i * 86400000).getTime(),
+      createdAt: new Date(BASE_TIMESTAMP - i * 86400000).getTime(),
     })),
     user: Array.from({length: 3}, (_, i) => ({
       id: `user${i + 1}`,
@@ -61,12 +66,12 @@ beforeAll(async () => {
               altContacts: [`alt${i + 1}@example.com`],
             },
     })),
-    comment: Array.from({length: 4}, (_, i) => ({
+    comment: Array.from({length: 6}, (_, i) => ({
       id: `comment${i + 1}`,
       authorId: `user${(i % 3) + 1}`,
       issueId: `issue${(i % 3) + 1}`,
       text: `Comment ${i + 1} text`,
-      createdAt: new Date(Date.now() - i * 86400000).getTime(),
+      createdAt: new Date(BASE_TIMESTAMP - i * 86400000).getTime(),
     })),
     issueLabel: Array.from({length: 4}, (_, i) => ({
       issueId: `issue${(i % 3) + 1}`,
@@ -198,6 +203,20 @@ beforeAll(async () => {
     labelLiteRows.map(row => fromSQLiteTypes(schema.tables.label.columns, row)),
   ).toEqual(testData.label);
   expect(revisionLiteRows).toEqual(testData.revision);
+
+  const {host, port, user, pass} = pg.options;
+  nodePostgres = new Client({
+    user,
+    host: host[0],
+    port: port[0],
+    password: pass ?? undefined,
+    database: DB_NAME,
+  });
+  await nodePostgres.connect();
+});
+
+afterAll(() => {
+  nodePostgres.end();
 });
 
 function ast(q: Query<Schema, keyof Schema['tables']>) {
@@ -215,118 +234,483 @@ function createdAtToMillis(row: Record<string, unknown>) {
 }
 
 describe('compiling ZQL to SQL', () => {
-  test('basic where clause', async () => {
-    const query = issueQuery.where('title', '=', 'issue 1');
-    const c = compile(ast(query), schema.tables);
-    const sqlQuery = formatPg(c);
-    const pgResult = extractZqlResult(
-      await pg.unsafe(sqlQuery.text, sqlQuery.values as JSONValue[]),
-    );
-    expect(mapResultToClientNames(await query.run(), schema, 'issue')).toEqual(
-      pgResult,
+  describe('postgres.js', () => {
+    t((query: string, args: unknown[]) =>
+      pg.unsafe(query, args as JSONValue[]),
     );
   });
-
-  test('multiple where clauses', async () => {
-    const query = issueQuery
-      .where('closed', '=', false)
-      .where('ownerId', 'IS NOT', null);
-    const sqlQuery = formatPg(compile(ast(query), schema.tables));
-    const pgResult = extractZqlResult(
-      await pg.unsafe(sqlQuery.text, sqlQuery.values as JSONValue[]),
+  describe('node-postgres', () => {
+    t(
+      async (query: string, args: unknown[]) =>
+        (await nodePostgres.query(query, args as JSONValue[])).rows,
     );
-    expect(
-      mapResultToClientNames(await query.run(), schema, 'issue'),
-    ).toEqualPg(pgResult);
   });
-
-  test('whereExists with related table', async () => {
-    const query = issueQuery.whereExists('labels', q =>
-      q.where('name', '=', 'bug'),
-    );
-    const sqlQuery = formatPg(compile(ast(query), schema.tables));
-    const pgResult = extractZqlResult(
-      await pg.unsafe(sqlQuery.text, sqlQuery.values as JSONValue[]),
-    );
-    expect(
-      mapResultToClientNames(await query.run(), schema, 'issue'),
-    ).toEqualPg(pgResult);
-  });
-
-  test('order by and limit', async () => {
-    const query = issueQuery.orderBy('title', 'desc').limit(5);
-    const sqlQuery = formatPg(compile(ast(query), schema.tables));
-    const pgResult = extractZqlResult(
-      await pg.unsafe(sqlQuery.text, sqlQuery.values as JSONValue[]),
-    );
-    expect(
-      mapResultToClientNames(await query.run(), schema, 'issue'),
-    ).toEqualPg(pgResult);
-  });
-
-  test('1 to 1 foreign key relationship', async () => {
-    const query = issueQuery.related('owner');
-    const sqlQuery = formatPg(compile(ast(query), schema.tables, query.format));
-    const pgResult = extractZqlResult(
-      await pg.unsafe(sqlQuery.text, sqlQuery.values as JSONValue[]),
-    );
-    expect(
-      mapResultToClientNames(await query.run(), schema, 'issue'),
-    ).toEqualPg(pgResult);
-  });
-
-  test('1 to many foreign key relationship', async () => {
-    const query = issueQuery.related('comments');
-    const sqlQuery = formatPg(compile(ast(query), schema.tables, query.format));
-    const pgResult = extractZqlResult(
-      await pg.unsafe(sqlQuery.text, sqlQuery.values as JSONValue[]),
-    );
-    expect(
-      mapResultToClientNames(await query.run(), schema, 'issue'),
-    ).toEqualPg(pgResult);
-  });
-
-  test('junction relationship', async () => {
-    const query = issueQuery.related('labels');
-    const sqlQuery = formatPg(compile(ast(query), schema.tables, query.format));
-    const pgResult = extractZqlResult(
-      await pg.unsafe(sqlQuery.text, sqlQuery.values as JSONValue[]),
-    );
-    expect(
-      mapResultToClientNames(await query.run(), schema, 'issue'),
-    ).toEqualPg(pgResult);
-  });
-
-  test('nested related with where clauses', async () => {
-    const query = issueQuery
-      .where('closed', '=', false)
-      .related('comments', q =>
-        q.where('createdAt', '>', 1000).related('author'),
+  function t(runPgQuery: (query: string, args: unknown[]) => Promise<unknown>) {
+    test('basic where clause', async () => {
+      const query = issueQuery.where('title', '=', 'Test Issue 1');
+      const c = compile(ast(query), schema.tables);
+      const sqlQuery = formatPg(c);
+      const pgResult = extractZqlResult(
+        await runPgQuery(sqlQuery.text, sqlQuery.values),
       );
-    const sqlQuery = formatPg(compile(ast(query), schema.tables, query.format));
-    const pgResult = extractZqlResult(
-      await pg.unsafe(sqlQuery.text, sqlQuery.values as JSONValue[]),
-    );
-    expect(
-      mapResultToClientNames(await query.run(), schema, 'issue'),
-    ).toEqualPg(pgResult);
-  });
+      const zqlResult = mapResultToClientNames(
+        await query.run(),
+        schema,
+        'issue',
+      );
+      expect(zqlResult).toEqualPg(pgResult);
+      expect(zqlResult).toMatchInlineSnapshot(`
+        [
+          {
+            "closed": true,
+            "createdAt": 1743127752952,
+            "description": "Description for issue 1",
+            "id": "issue1",
+            "ownerId": null,
+            "title": "Test Issue 1",
+          },
+        ]
+      `);
+    });
 
-  test('complex query combining multiple features', async () => {
-    const query = issueQuery
-      .where('closed', '=', false)
-      .whereExists('labels', q => q.where('name', 'IN', ['Label 1', 'Label 2']))
-      .related('owner')
-      .related('comments', q =>
-        q.orderBy('createdAt', 'desc').limit(3).related('author'),
-      )
-      .orderBy('title', 'asc');
-    const sqlQuery = formatPg(compile(ast(query), schema.tables, query.format));
-    const pgResult = extractZqlResult(
-      await pg.unsafe(sqlQuery.text, sqlQuery.values as JSONValue[]),
-    );
-    expect(
-      mapResultToClientNames(await query.run(), schema, 'issue'),
-    ).toEqualPg(pgResult);
-  });
+    test('multiple where clauses', async () => {
+      const query = issueQuery
+        .where('closed', '=', false)
+        .where('ownerId', 'IS NOT', null);
+      const sqlQuery = formatPg(compile(ast(query), schema.tables));
+      const pgResult = extractZqlResult(
+        await runPgQuery(sqlQuery.text, sqlQuery.values),
+      );
+      const zqlResult = mapResultToClientNames(
+        await query.run(),
+        schema,
+        'issue',
+      );
+      expect(zqlResult).toEqualPg(pgResult);
+      expect(zqlResult).toMatchInlineSnapshot(`
+      [
+        {
+          "closed": false,
+          "createdAt": 1743041352952,
+          "description": "Description for issue 2",
+          "id": "issue2",
+          "ownerId": "user1",
+          "title": "Test Issue 2",
+        },
+      ]
+    `);
+    });
+
+    test('whereExists with related table', async () => {
+      const query = issueQuery.whereExists('labels', q =>
+        q.where('name', '=', 'bug'),
+      );
+      const sqlQuery = formatPg(compile(ast(query), schema.tables));
+      const pgResult = extractZqlResult(
+        await runPgQuery(sqlQuery.text, sqlQuery.values),
+      );
+      const zqlResult = mapResultToClientNames(
+        await query.run(),
+        schema,
+        'issue',
+      );
+      expect(zqlResult).toEqualPg(pgResult);
+      expect(zqlResult).toMatchInlineSnapshot(`[]`);
+    });
+
+    test('order by and limit', async () => {
+      const query = issueQuery.orderBy('title', 'desc').limit(5);
+      const sqlQuery = formatPg(compile(ast(query), schema.tables));
+      const pgResult = extractZqlResult(
+        await runPgQuery(sqlQuery.text, sqlQuery.values),
+      );
+      const zqlResult = mapResultToClientNames(
+        await query.run(),
+        schema,
+        'issue',
+      );
+      expect(zqlResult).toEqualPg(pgResult);
+      expect(zqlResult).toMatchInlineSnapshot(`
+        [
+          {
+            "closed": true,
+            "createdAt": 1742954952952,
+            "description": "Description for issue 3",
+            "id": "issue3",
+            "ownerId": "user2",
+            "title": "Test Issue 3",
+          },
+          {
+            "closed": false,
+            "createdAt": 1743041352952,
+            "description": "Description for issue 2",
+            "id": "issue2",
+            "ownerId": "user1",
+            "title": "Test Issue 2",
+          },
+          {
+            "closed": true,
+            "createdAt": 1743127752952,
+            "description": "Description for issue 1",
+            "id": "issue1",
+            "ownerId": null,
+            "title": "Test Issue 1",
+          },
+        ]
+      `);
+    });
+
+    test('1 to 1 foreign key relationship', async () => {
+      const query = issueQuery.related('owner');
+      const sqlQuery = formatPg(
+        compile(ast(query), schema.tables, query.format),
+      );
+      const pgResult = extractZqlResult(
+        await runPgQuery(sqlQuery.text, sqlQuery.values),
+      );
+      const zqlResult = mapResultToClientNames(
+        await query.run(),
+        schema,
+        'issue',
+      );
+      expect(zqlResult).toEqualPg(pgResult);
+      expect(zqlResult).toMatchInlineSnapshot(`
+        [
+          {
+            "closed": true,
+            "createdAt": 1743127752952,
+            "description": "Description for issue 1",
+            "id": "issue1",
+            "owner": undefined,
+            "ownerId": null,
+            "title": "Test Issue 1",
+          },
+          {
+            "closed": false,
+            "createdAt": 1743041352952,
+            "description": "Description for issue 2",
+            "id": "issue2",
+            "owner": {
+              "id": "user1",
+              "metadata": null,
+              "name": "User 1",
+            },
+            "ownerId": "user1",
+            "title": "Test Issue 2",
+          },
+          {
+            "closed": true,
+            "createdAt": 1742954952952,
+            "description": "Description for issue 3",
+            "id": "issue3",
+            "owner": {
+              "id": "user2",
+              "metadata": {
+                "altContacts": [
+                  "alt2@example.com",
+                ],
+                "email": "user2@example.com",
+                "registrar": "google",
+              },
+              "name": "User 2",
+            },
+            "ownerId": "user2",
+            "title": "Test Issue 3",
+          },
+        ]
+      `);
+    });
+
+    test('1 to many foreign key relationship', async () => {
+      const query = issueQuery.related('comments');
+      const sqlQuery = formatPg(
+        compile(ast(query), schema.tables, query.format),
+      );
+      const pgResult = extractZqlResult(
+        await runPgQuery(sqlQuery.text, sqlQuery.values),
+      );
+      const zqlResult = mapResultToClientNames(
+        await query.run(),
+        schema,
+        'issue',
+      );
+      expect(zqlResult).toEqualPg(pgResult);
+      expect(zqlResult).toMatchInlineSnapshot(`
+              [
+                {
+                  "closed": true,
+                  "comments": [
+                    {
+                      "authorId": "user1",
+                      "createdAt": 1743127752952,
+                      "id": "comment1",
+                      "issueId": "issue1",
+                      "text": "Comment 1 text",
+                    },
+                    {
+                      "authorId": "user1",
+                      "createdAt": 1742868552952,
+                      "id": "comment4",
+                      "issueId": "issue1",
+                      "text": "Comment 4 text",
+                    },
+                  ],
+                  "createdAt": 1743127752952,
+                  "description": "Description for issue 1",
+                  "id": "issue1",
+                  "ownerId": null,
+                  "title": "Test Issue 1",
+                },
+                {
+                  "closed": false,
+                  "comments": [
+                    {
+                      "authorId": "user2",
+                      "createdAt": 1743041352952,
+                      "id": "comment2",
+                      "issueId": "issue2",
+                      "text": "Comment 2 text",
+                    },
+                    {
+                      "authorId": "user2",
+                      "createdAt": 1742782152952,
+                      "id": "comment5",
+                      "issueId": "issue2",
+                      "text": "Comment 5 text",
+                    },
+                  ],
+                  "createdAt": 1743041352952,
+                  "description": "Description for issue 2",
+                  "id": "issue2",
+                  "ownerId": "user1",
+                  "title": "Test Issue 2",
+                },
+                {
+                  "closed": true,
+                  "comments": [
+                    {
+                      "authorId": "user3",
+                      "createdAt": 1742954952952,
+                      "id": "comment3",
+                      "issueId": "issue3",
+                      "text": "Comment 3 text",
+                    },
+                    {
+                      "authorId": "user3",
+                      "createdAt": 1742695752952,
+                      "id": "comment6",
+                      "issueId": "issue3",
+                      "text": "Comment 6 text",
+                    },
+                  ],
+                  "createdAt": 1742954952952,
+                  "description": "Description for issue 3",
+                  "id": "issue3",
+                  "ownerId": "user2",
+                  "title": "Test Issue 3",
+                },
+              ]
+            `);
+    });
+
+    test('junction relationship', async () => {
+      const query = issueQuery.related('labels');
+      const sqlQuery = formatPg(
+        compile(ast(query), schema.tables, query.format),
+      );
+      const pgResult = extractZqlResult(
+        await runPgQuery(sqlQuery.text, sqlQuery.values),
+      );
+      const zqlResult = mapResultToClientNames(
+        await query.run(),
+        schema,
+        'issue',
+      );
+      expect(zqlResult).toEqualPg(pgResult);
+      expect(zqlResult).toMatchInlineSnapshot(`
+                        [
+                          {
+                            "closed": true,
+                            "createdAt": 1743127752952,
+                            "description": "Description for issue 1",
+                            "id": "issue1",
+                            "labels": [
+                              {
+                                "id": "label1",
+                                "name": "Label 1",
+                              },
+                              {
+                                "id": "label2",
+                                "name": "Label 2",
+                              },
+                            ],
+                            "ownerId": null,
+                            "title": "Test Issue 1",
+                          },
+                          {
+                            "closed": false,
+                            "createdAt": 1743041352952,
+                            "description": "Description for issue 2",
+                            "id": "issue2",
+                            "labels": [
+                              {
+                                "id": "label2",
+                                "name": "Label 2",
+                              },
+                            ],
+                            "ownerId": "user1",
+                            "title": "Test Issue 2",
+                          },
+                          {
+                            "closed": true,
+                            "createdAt": 1742954952952,
+                            "description": "Description for issue 3",
+                            "id": "issue3",
+                            "labels": [
+                              {
+                                "id": "label1",
+                                "name": "Label 1",
+                              },
+                            ],
+                            "ownerId": "user2",
+                            "title": "Test Issue 3",
+                          },
+                        ]
+                      `);
+    });
+
+    test('nested related with where clauses', async () => {
+      // TODO Change to filter comments on createdAt once
+      // timestamp params are supported.
+      const query = issueQuery
+        .where('closed', '=', false)
+        .related('comments', q =>
+          q.where('text', 'ILIKE', '%2%').related('author'),
+        );
+      const sqlQuery = formatPg(
+        compile(ast(query), schema.tables, query.format),
+      );
+      const pgResult = extractZqlResult(
+        await runPgQuery(sqlQuery.text, sqlQuery.values),
+      );
+      const zqlResult = mapResultToClientNames(
+        await query.run(),
+        schema,
+        'issue',
+      );
+      expect(zqlResult).toEqualPg(pgResult);
+      expect(zqlResult).toMatchInlineSnapshot(`
+        [
+          {
+            "closed": false,
+            "comments": [
+              {
+                "author": {
+                  "id": "user2",
+                  "metadata": {
+                    "altContacts": [
+                      "alt2@example.com",
+                    ],
+                    "email": "user2@example.com",
+                    "registrar": "google",
+                  },
+                  "name": "User 2",
+                },
+                "authorId": "user2",
+                "createdAt": 1743041352952,
+                "id": "comment2",
+                "issueId": "issue2",
+                "text": "Comment 2 text",
+              },
+            ],
+            "createdAt": 1743041352952,
+            "description": "Description for issue 2",
+            "id": "issue2",
+            "ownerId": "user1",
+            "title": "Test Issue 2",
+          },
+        ]
+      `);
+    });
+
+    test('complex query combining multiple features', async () => {
+      const query = issueQuery
+        .where('closed', '=', false)
+        .whereExists('labels', q =>
+          q.where('name', 'IN', ['Label 1', 'Label 2']),
+        )
+        .related('owner')
+        .related('comments', q =>
+          q.orderBy('createdAt', 'desc').limit(3).related('author'),
+        )
+        .orderBy('title', 'asc');
+      const sqlQuery = formatPg(
+        compile(ast(query), schema.tables, query.format),
+      );
+      const pgResult = extractZqlResult(
+        await runPgQuery(sqlQuery.text, sqlQuery.values),
+      );
+      const zqlResult = mapResultToClientNames(
+        await query.run(),
+        schema,
+        'issue',
+      );
+      expect(zqlResult).toEqualPg(pgResult);
+      expect(zqlResult).toMatchInlineSnapshot(`
+        [
+          {
+            "closed": false,
+            "comments": [
+              {
+                "author": {
+                  "id": "user2",
+                  "metadata": {
+                    "altContacts": [
+                      "alt2@example.com",
+                    ],
+                    "email": "user2@example.com",
+                    "registrar": "google",
+                  },
+                  "name": "User 2",
+                },
+                "authorId": "user2",
+                "createdAt": 1743041352952,
+                "id": "comment2",
+                "issueId": "issue2",
+                "text": "Comment 2 text",
+              },
+              {
+                "author": {
+                  "id": "user2",
+                  "metadata": {
+                    "altContacts": [
+                      "alt2@example.com",
+                    ],
+                    "email": "user2@example.com",
+                    "registrar": "google",
+                  },
+                  "name": "User 2",
+                },
+                "authorId": "user2",
+                "createdAt": 1742782152952,
+                "id": "comment5",
+                "issueId": "issue2",
+                "text": "Comment 5 text",
+              },
+            ],
+            "createdAt": 1743041352952,
+            "description": "Description for issue 2",
+            "id": "issue2",
+            "owner": {
+              "id": "user1",
+              "metadata": null,
+              "name": "User 1",
+            },
+            "ownerId": "user1",
+            "title": "Test Issue 2",
+          },
+        ]
+      `);
+    });
+  }
 });

--- a/packages/z2s/src/compiler.pg-test.ts
+++ b/packages/z2s/src/compiler.pg-test.ts
@@ -215,8 +215,8 @@ beforeAll(async () => {
   await nodePostgres.connect();
 });
 
-afterAll(() => {
-  nodePostgres.end();
+afterAll(async () => {
+  await nodePostgres.end();
 });
 
 function ast(q: Query<Schema, keyof Schema['tables']>) {


### PR DESCRIPTION
It should be possible to extend this approach to the chinook tests as well.