### PR TITLE
chore: Remove sinon and use vitest instead

### DIFF
--- a/eslint-config.json
+++ b/eslint-config.json
@@ -41,6 +41,10 @@
           {
             "group": ["**/*.test.ts", "**/*.test.tsx"],
             "message": "Do not import from test files."
+          },
+          {
+            "group": ["sinon"],
+            "message": "Use vi instead of sinon"
           }
         ],
         "paths": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -7811,50 +7811,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@sinonjs/commons": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
-      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
-      "dev": true,
-      "dependencies": {
-        "type-detect": "4.0.8"
-      }
-    },
-    "node_modules/@sinonjs/fake-timers": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
-      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^2.0.0"
-      }
-    },
-    "node_modules/@sinonjs/samsam": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.3.tgz",
-      "integrity": "sha512-nhOb2dWPeb1sd3IQXL/dVPnKHDOAFfvichtBf4xV00/rU1QbPCQqKMbvIheIjqwVjh7qIgf2AHTHi391yMOMpQ==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^1.6.0",
-        "lodash.get": "^4.4.2",
-        "type-detect": "^4.0.8"
-      }
-    },
-    "node_modules/@sinonjs/samsam/node_modules/@sinonjs/commons": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
-      "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
-      "dev": true,
-      "dependencies": {
-        "type-detect": "4.0.8"
-      }
-    },
-    "node_modules/@sinonjs/text-encoding": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
-      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
-      "dev": true
-    },
     "node_modules/@slorber/remark-comment": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@slorber/remark-comment/-/remark-comment-1.0.0.tgz",
@@ -8918,21 +8874,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
       "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg=="
-    },
-    "node_modules/@types/sinon": {
-      "version": "10.0.13",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.13.tgz",
-      "integrity": "sha512-UVjDqJblVNQYvVNUsj0PuYYw0ELRmgt1Nt5Vk0pT5f16ROGfcKJY8o1HVuMOJOpD727RrGB9EGvoaTQE5tgxZQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/sinonjs__fake-timers": "*"
-      }
-    },
-    "node_modules/@types/sinonjs__fake-timers": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
-      "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
-      "dev": true
     },
     "node_modules/@types/sockjs": {
       "version": "0.3.36",
@@ -12567,15 +12508,6 @@
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true
-    },
-    "node_modules/diff": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -16458,12 +16390,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/just-extend": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
-      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
-      "dev": true
-    },
     "node_modules/kasi": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/kasi/-/kasi-1.1.0.tgz",
@@ -16703,12 +16629,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
-      "dev": true
-    },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "node_modules/lodash.isequal": {
@@ -18388,28 +18308,6 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "license": "MIT"
-    },
-    "node_modules/nise": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
-      "integrity": "sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^2.0.0",
-        "@sinonjs/fake-timers": "^10.0.2",
-        "@sinonjs/text-encoding": "^0.7.1",
-        "just-extend": "^4.0.2",
-        "path-to-regexp": "^1.7.0"
-      }
-    },
-    "node_modules/nise/node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "dev": true,
-      "dependencies": {
-        "isarray": "0.0.1"
-      }
     },
     "node_modules/no-case": {
       "version": "3.0.4",
@@ -23126,42 +23024,6 @@
         "joi": "^17.6.4"
       }
     },
-    "node_modules/sinon": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-13.0.2.tgz",
-      "integrity": "sha512-KvOrztAVqzSJWMDoxM4vM+GPys1df2VBoXm+YciyB/OLMamfS3VXh3oGh5WtrAGSzrgczNWFFY22oKb7Fi5eeA==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^1.8.3",
-        "@sinonjs/fake-timers": "^9.1.2",
-        "@sinonjs/samsam": "^6.1.1",
-        "diff": "^5.0.0",
-        "nise": "^5.1.1",
-        "supports-color": "^7.2.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/sinon"
-      }
-    },
-    "node_modules/sinon/node_modules/@sinonjs/commons": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
-      "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
-      "dev": true,
-      "dependencies": {
-        "type-detect": "4.0.8"
-      }
-    },
-    "node_modules/sinon/node_modules/@sinonjs/fake-timers": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
-      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^1.7.0"
-      }
-    },
     "node_modules/sirv": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.1.tgz",
@@ -24926,15 +24788,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/type-fest": {
@@ -26882,7 +26735,6 @@
         "@rocicorp/eslint-config": "^0.7.0",
         "@rocicorp/prettier-config": "^0.3.0",
         "@types/command-line-usage": "^5.0.2",
-        "@types/sinon": "^10.0.11",
         "@vitest/runner": "3.0.8",
         "command-line-args": "^6.0.1",
         "command-line-usage": "^7.0.3",
@@ -26891,7 +26743,6 @@
         "fetch-mock": "^9.11.0",
         "playwright": "^1.51.0",
         "shared": "0.0.0",
-        "sinon": "^13.0.1",
         "typescript": "~5.8.2",
         "vitest": "3.0.8"
       }
@@ -27307,13 +27158,11 @@
       "devDependencies": {
         "@rocicorp/eslint-config": "^0.7.0",
         "@rocicorp/prettier-config": "^0.3.0",
-        "@types/sinon": "^10.0.11",
         "datadog": "0.0.0",
         "esbuild": "^0.25.0",
         "playwright": "^1.51.0",
         "replicache": "15.2.1",
         "shared": "0.0.0",
-        "sinon": "^13.0.1",
         "typescript": "~5.8.2",
         "zero-protocol": "0.0.0"
       }
@@ -32150,52 +31999,6 @@
       "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
       "dev": true
     },
-    "@sinonjs/commons": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
-      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
-      "dev": true,
-      "requires": {
-        "type-detect": "4.0.8"
-      }
-    },
-    "@sinonjs/fake-timers": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
-      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^2.0.0"
-      }
-    },
-    "@sinonjs/samsam": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.3.tgz",
-      "integrity": "sha512-nhOb2dWPeb1sd3IQXL/dVPnKHDOAFfvichtBf4xV00/rU1QbPCQqKMbvIheIjqwVjh7qIgf2AHTHi391yMOMpQ==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^1.6.0",
-        "lodash.get": "^4.4.2",
-        "type-detect": "^4.0.8"
-      },
-      "dependencies": {
-        "@sinonjs/commons": {
-          "version": "1.8.6",
-          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
-          "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
-          "dev": true,
-          "requires": {
-            "type-detect": "4.0.8"
-          }
-        }
-      }
-    },
-    "@sinonjs/text-encoding": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
-      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
-      "dev": true
-    },
     "@slorber/remark-comment": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@slorber/remark-comment/-/remark-comment-1.0.0.tgz",
@@ -32983,21 +32786,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
       "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg=="
-    },
-    "@types/sinon": {
-      "version": "10.0.13",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.13.tgz",
-      "integrity": "sha512-UVjDqJblVNQYvVNUsj0PuYYw0ELRmgt1Nt5Vk0pT5f16ROGfcKJY8o1HVuMOJOpD727RrGB9EGvoaTQE5tgxZQ==",
-      "dev": true,
-      "requires": {
-        "@types/sinonjs__fake-timers": "*"
-      }
-    },
-    "@types/sinonjs__fake-timers": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
-      "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
-      "dev": true
     },
     "@types/sockjs": {
       "version": "0.3.36",
@@ -35427,12 +35215,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-      "dev": true
-    },
-    "diff": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
       "dev": true
     },
     "dir-glob": {
@@ -38124,12 +37906,6 @@
         }
       }
     },
-    "just-extend": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
-      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
-      "dev": true
-    },
     "kasi": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/kasi/-/kasi-1.1.0.tgz",
@@ -38342,12 +38118,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
-      "dev": true
-    },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "lodash.isequal": {
@@ -39448,30 +39218,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
-    },
-    "nise": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
-      "integrity": "sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^2.0.0",
-        "@sinonjs/fake-timers": "^10.0.2",
-        "@sinonjs/text-encoding": "^0.7.1",
-        "just-extend": "^4.0.2",
-        "path-to-regexp": "^1.7.0"
-      },
-      "dependencies": {
-        "path-to-regexp": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-          "dev": true,
-          "requires": {
-            "isarray": "0.0.1"
-          }
-        }
-      }
     },
     "no-case": {
       "version": "3.0.4",
@@ -41927,7 +41673,6 @@
         "@rocicorp/prettier-config": "^0.3.0",
         "@rocicorp/resolver": "^1.0.2",
         "@types/command-line-usage": "^5.0.2",
-        "@types/sinon": "^10.0.11",
         "@vitest/runner": "3.0.8",
         "command-line-args": "^6.0.1",
         "command-line-usage": "^7.0.3",
@@ -41936,7 +41681,6 @@
         "fetch-mock": "^9.11.0",
         "playwright": "^1.51.0",
         "shared": "0.0.0",
-        "sinon": "^13.0.1",
         "typescript": "~5.8.2",
         "vitest": "3.0.8"
       },
@@ -42701,40 +42445,6 @@
         "@hapi/wreck": "^18.0.0",
         "debug": "^4.3.4",
         "joi": "^17.6.4"
-      }
-    },
-    "sinon": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-13.0.2.tgz",
-      "integrity": "sha512-KvOrztAVqzSJWMDoxM4vM+GPys1df2VBoXm+YciyB/OLMamfS3VXh3oGh5WtrAGSzrgczNWFFY22oKb7Fi5eeA==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^1.8.3",
-        "@sinonjs/fake-timers": "^9.1.2",
-        "@sinonjs/samsam": "^6.1.1",
-        "diff": "^5.0.0",
-        "nise": "^5.1.1",
-        "supports-color": "^7.2.0"
-      },
-      "dependencies": {
-        "@sinonjs/commons": {
-          "version": "1.8.6",
-          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
-          "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
-          "dev": true,
-          "requires": {
-            "type-detect": "4.0.8"
-          }
-        },
-        "@sinonjs/fake-timers": {
-          "version": "9.1.2",
-          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
-          "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
-          "dev": true,
-          "requires": {
-            "@sinonjs/commons": "^1.7.0"
-          }
-        }
       }
     },
     "sirv": {
@@ -43963,12 +43673,6 @@
       "requires": {
         "prelude-ls": "^1.2.1"
       }
-    },
-    "type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true
     },
     "type-fest": {
       "version": "0.20.2",
@@ -45314,13 +45018,11 @@
         "@rocicorp/logger": "^5.3.0",
         "@rocicorp/prettier-config": "^0.3.0",
         "@rocicorp/resolver": "^1.0.2",
-        "@types/sinon": "^10.0.11",
         "datadog": "0.0.0",
         "esbuild": "^0.25.0",
         "playwright": "^1.51.0",
         "replicache": "15.2.1",
         "shared": "0.0.0",
-        "sinon": "^13.0.1",
         "typescript": "~5.8.2",
         "zero-protocol": "0.0.0"
       },

--- a/packages/replicache/package.json
+++ b/packages/replicache/package.json
@@ -37,7 +37,6 @@
     "@rocicorp/eslint-config": "^0.7.0",
     "@rocicorp/prettier-config": "^0.3.0",
     "@types/command-line-usage": "^5.0.2",
-    "@types/sinon": "^10.0.11",
     "@vitest/runner": "3.0.8",
     "command-line-args": "^6.0.1",
     "command-line-usage": "^7.0.3",
@@ -46,7 +45,6 @@
     "fetch-mock": "^9.11.0",
     "playwright": "^1.51.0",
     "shared": "0.0.0",
-    "sinon": "^13.0.1",
     "typescript": "~5.8.2",
     "vitest": "3.0.8"
   },

--- a/packages/replicache/src/db/rebase.test.ts
+++ b/packages/replicache/src/db/rebase.test.ts
@@ -1,6 +1,5 @@
 import {LogContext} from '@rocicorp/logger';
-import sinon from 'sinon';
-import {afterEach, describe, expect, test} from 'vitest';
+import {afterEach, describe, expect, test, vi} from 'vitest';
 import {assert} from '../../../shared/src/asserts.ts';
 import type {Enum} from '../../../shared/src/enum.ts';
 import {BTreeRead} from '../btree/read.ts';
@@ -28,7 +27,7 @@ import {ChainBuilder} from './test-helpers.ts';
 type FormatVersion = Enum<typeof FormatVersion>;
 
 afterEach(() => {
-  sinon.restore();
+  vi.restoreAllMocks();
 });
 
 async function createMutationSequenceFixture() {
@@ -143,7 +142,7 @@ async function createMutationSequenceFixture() {
 
 async function createMissingMutatorFixture() {
   const formatVersion = FormatVersion.Latest;
-  const consoleErrorStub = sinon.stub(console, 'error');
+  const consoleErrorStub = vi.spyOn(console, 'error');
   const clientID = 'test_client_id';
   const store = new TestStore();
   const b = new ChainBuilder(store, undefined, formatVersion);
@@ -194,8 +193,8 @@ async function createMissingMutatorFixture() {
       expect(await btreeRead.get('foo')).to.equal('bar');
     },
     expectMissingMutatorErrorLog: () => {
-      expect(consoleErrorStub.callCount).to.equal(1);
-      const {args} = consoleErrorStub.getCall(0);
+      expect(consoleErrorStub).toBeCalledTimes(1);
+      const args = consoleErrorStub.mock.calls[0];
       expect(args[0]).to.equal(
         `Cannot rebase unknown mutator ${localCommit.meta.mutatorName}`,
       );

--- a/packages/replicache/src/kv/idb-store.test.ts
+++ b/packages/replicache/src/kv/idb-store.test.ts
@@ -1,5 +1,5 @@
-import * as sinon from 'sinon';
-import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+import {assert} from '../../../shared/src/asserts.ts';
 import {withRead, withWrite} from '../with-transactions.ts';
 import {dropIDBStoreWithMemFallback} from './idb-store-with-mem-fallback.ts';
 import {IDBNotFoundError, IDBStore} from './idb-store.ts';
@@ -49,10 +49,12 @@ describe('reopening IDB', () => {
     await dropIDBStoreWithMemFallback(name);
 
     // Use spy to get a hold of the request object and then the idb instance.
-    const openSpy = sinon.spy(indexedDB, 'open');
+    const openSpy = vi.spyOn(indexedDB, 'open');
 
     store = new IDBStore(name);
-    const req = openSpy.returnValues[0];
+    const result = openSpy.mock.results[0];
+    assert(result.type === 'return');
+    const req = result.value;
     idb = new Promise((resolve, reject) => {
       req.addEventListener('success', () => resolve(req.result));
       req.addEventListener('error', () => reject(req.error));
@@ -60,7 +62,7 @@ describe('reopening IDB', () => {
   });
 
   afterEach(() => {
-    sinon.restore();
+    vi.restoreAllMocks();
   });
 
   test('succeeds if IDB still exists', async () => {

--- a/packages/replicache/src/pending-mutation.test.ts
+++ b/packages/replicache/src/pending-mutation.test.ts
@@ -1,4 +1,4 @@
-import {expect, test} from 'vitest';
+import {expect, test, vi} from 'vitest';
 import type {JSONValue} from '../../shared/src/json.ts';
 import {
   initReplicacheTesting,
@@ -52,7 +52,7 @@ test('pending mutation', async () => {
   rep.pullURL = 'https://diff.com/pull';
   fetchMock.post(rep.pullURL, makePullResponseV1(clientID, 2, undefined, 1));
   rep.pullIgnorePromise();
-  await tickAFewTimes(100);
+  await tickAFewTimes(vi, 100);
   await rep.mutate.addData({a: 3});
   const addAMutation = {id: 3, name: 'addData', args: {a: 3}, clientID};
   expect(await rep.experimentalPendingMutations()).to.deep.equal([
@@ -62,7 +62,7 @@ test('pending mutation', async () => {
   fetchMock.reset();
   fetchMock.post(rep.pullURL, makePullResponseV1(clientID, 3, undefined, 2));
   rep.pullIgnorePromise();
-  await tickAFewTimes(100);
+  await tickAFewTimes(vi, 100);
   expect(await rep.experimentalPendingMutations()).to.deep.equal([]);
 });
 

--- a/packages/replicache/src/persist/client-group-gc.test.ts
+++ b/packages/replicache/src/persist/client-group-gc.test.ts
@@ -1,5 +1,4 @@
 import {LogContext} from '@rocicorp/logger';
-import {type SinonFakeTimers, useFakeTimers} from 'sinon';
 import {afterEach, beforeEach, expect, test, vi} from 'vitest';
 import {assertNotUndefined} from '../../../shared/src/asserts.ts';
 import type {Read} from '../dag/store.ts';
@@ -17,15 +16,14 @@ import {
 import {makeClientV6, setClientsForTesting} from './clients-test-helpers.ts';
 import type {OnClientsDeleted} from './clients.ts';
 
-let clock: SinonFakeTimers;
 const START_TIME = 0;
 const FIVE_MINS_IN_MS = 5 * 60 * 1000;
 beforeEach(() => {
-  clock = useFakeTimers(0);
+  vi.useFakeTimers({now: 0});
 });
 
 afterEach(() => {
-  clock.restore();
+  vi.restoreAllMocks();
 });
 
 function awaitLatestGCUpdate(): Promise<ClientGroupMap> {
@@ -123,7 +121,7 @@ test('initClientGroupGC starts 5 min interval that collects client groups that a
     expect(readClientGroupMap).to.deep.equal(clientGroupMap);
   });
 
-  await clock.tickAsync(FIVE_MINS_IN_MS);
+  await vi.advanceTimersByTimeAsync(FIVE_MINS_IN_MS);
   await awaitLatestGCUpdate();
 
   // client-group-1 is not collected because it is referred to by client1 and has pending mutations
@@ -154,7 +152,7 @@ test('initClientGroupGC starts 5 min interval that collects client groups that a
     'client-group-2': clientGroup2,
   });
 
-  await clock.tickAsync(FIVE_MINS_IN_MS);
+  await vi.advanceTimersByTimeAsync(FIVE_MINS_IN_MS);
   await awaitLatestGCUpdate();
 
   // client-group-1 is not collected because it has pending mutations
@@ -179,7 +177,7 @@ test('initClientGroupGC starts 5 min interval that collects client groups that a
     'client-group-2': clientGroup2,
   });
 
-  await clock.tickAsync(FIVE_MINS_IN_MS);
+  await vi.advanceTimersByTimeAsync(FIVE_MINS_IN_MS);
   await awaitLatestGCUpdate();
 
   // client-group-1 is collect because it is not referred to and has no pending mutations
@@ -199,7 +197,7 @@ test('initClientGroupGC starts 5 min interval that collects client groups that a
   // nothing collected yet because gc has not run yet
   await expectClientGroups(dagStore, {'client-group-2': clientGroup2});
 
-  await clock.tickAsync(FIVE_MINS_IN_MS);
+  await vi.advanceTimersByTimeAsync(FIVE_MINS_IN_MS);
   await awaitLatestGCUpdate();
 
   // client-group-2 is not collected because it is referred to by client3
@@ -211,7 +209,7 @@ test('initClientGroupGC starts 5 min interval that collects client groups that a
   // nothing collected yet because gc has not run yet
   await expectClientGroups(dagStore, {'client-group-2': clientGroup2});
 
-  await clock.tickAsync(FIVE_MINS_IN_MS);
+  await vi.advanceTimersByTimeAsync(FIVE_MINS_IN_MS);
   await awaitLatestGCUpdate();
 
   // client-group-2 is collected because it is not referred to and has pending mutations
@@ -297,7 +295,7 @@ test('initClientGroupGC starts 5 min interval that collects client groups that a
     expect(readClientGroupMap).to.deep.equal(clientGroupMap);
   });
 
-  await clock.tickAsync(FIVE_MINS_IN_MS);
+  await vi.advanceTimersByTimeAsync(FIVE_MINS_IN_MS);
   await awaitLatestGCUpdate();
 
   // client-group-1 is not collected because it is referred to by client1 and has pending mutations
@@ -325,7 +323,7 @@ test('initClientGroupGC starts 5 min interval that collects client groups that a
     'client-group-2': clientGroup2,
   });
 
-  await clock.tickAsync(FIVE_MINS_IN_MS);
+  await vi.advanceTimersByTimeAsync(FIVE_MINS_IN_MS);
   await awaitLatestGCUpdate();
 
   // client-group-1 is collected because we ignore pending mutations
@@ -347,7 +345,7 @@ test('initClientGroupGC starts 5 min interval that collects client groups that a
   // nothing collected yet because gc has not run yet
   await expectClientGroups(dagStore, {'client-group-2': clientGroup2});
 
-  await clock.tickAsync(FIVE_MINS_IN_MS);
+  await vi.advanceTimersByTimeAsync(FIVE_MINS_IN_MS);
   await awaitLatestGCUpdate();
 
   // client-group-2 is not collected because it is referred to by client3
@@ -359,7 +357,7 @@ test('initClientGroupGC starts 5 min interval that collects client groups that a
   // nothing collected yet because gc has not run yet
   await expectClientGroups(dagStore, {'client-group-2': clientGroup2});
 
-  await clock.tickAsync(FIVE_MINS_IN_MS);
+  await vi.advanceTimersByTimeAsync(FIVE_MINS_IN_MS);
   await awaitLatestGCUpdate();
 
   // client-group-2 is collected because it is not referred to and has pending mutations

--- a/packages/replicache/src/persist/collect-idb-databases.test.ts
+++ b/packages/replicache/src/persist/collect-idb-databases.test.ts
@@ -1,5 +1,4 @@
 import {LogContext} from '@rocicorp/logger';
-import {type SinonFakeTimers, useFakeTimers} from 'sinon';
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {assertNotUndefined} from '../../../shared/src/asserts.ts';
 import type {Store} from '../dag/store.ts';
@@ -29,14 +28,12 @@ import {
 import {makeClientGroupMap} from './test-utils.ts';
 
 describe('collectIDBDatabases', () => {
-  let clock: SinonFakeTimers;
-
   beforeEach(() => {
-    clock = useFakeTimers(0);
+    vi.useFakeTimers({now: 0});
   });
 
   afterEach(() => {
-    clock.restore();
+    vi.useRealTimers();
   });
 
   type Entries = [

--- a/packages/replicache/src/persist/idb-databases-store.test.ts
+++ b/packages/replicache/src/persist/idb-databases-store.test.ts
@@ -1,5 +1,4 @@
-import * as sinon from 'sinon';
-import {afterEach, expect, test} from 'vitest';
+import {afterEach, expect, test, vi} from 'vitest';
 import {TestMemStore} from '../kv/test-mem-store.ts';
 import {
   IDBDatabasesStore,
@@ -7,7 +6,7 @@ import {
 } from './idb-databases-store.ts';
 
 afterEach(() => {
-  sinon.restore();
+  vi.restoreAllMocks();
 });
 
 test('getDatabases with no existing record in db', async () => {
@@ -16,7 +15,7 @@ test('getDatabases with no existing record in db', async () => {
 });
 
 test('putDatabase with no existing record in db', async () => {
-  sinon.replace(Date, 'now', () => 1);
+  vi.setSystemTime(1);
 
   const store = new IDBDatabasesStore(_ => new TestMemStore());
   const testDB = {
@@ -34,8 +33,7 @@ test('putDatabase with no existing record in db', async () => {
 });
 
 test('putDatabase updates lastOpenedTimestampMS', async () => {
-  let now = 1;
-  sinon.replace(Date, 'now', () => now);
+  vi.setSystemTime(1);
 
   const store = new IDBDatabasesStore(_ => new TestMemStore());
   const testDB = {
@@ -51,7 +49,7 @@ test('putDatabase updates lastOpenedTimestampMS', async () => {
     testName: withLastOpenedTimestampMS(testDB, 1),
   });
 
-  now = 2;
+  vi.setSystemTime(2);
   expect(await store.putDatabase(testDB)).to.deep.equal({
     testName: withLastOpenedTimestampMS(testDB, 2),
   });
@@ -61,8 +59,7 @@ test('putDatabase updates lastOpenedTimestampMS', async () => {
 });
 
 test('putDatabase ignores passed in lastOpenedTimestampMS', async () => {
-  const now = 2;
-  sinon.replace(Date, 'now', () => now);
+  vi.setSystemTime(2);
 
   const store = new IDBDatabasesStore(_ => new TestMemStore());
   const testDB = {
@@ -91,8 +88,7 @@ function withLastOpenedTimestampMS(
 }
 
 test('putDatabase sequence', async () => {
-  let now = 1;
-  sinon.replace(Date, 'now', () => now);
+  vi.setSystemTime(1);
   const store = new IDBDatabasesStore(_ => new TestMemStore());
   const testDB1 = {
     name: 'testName1',
@@ -115,7 +111,7 @@ test('putDatabase sequence', async () => {
     schemaVersion: 'testSchemaVersion2',
   };
 
-  now = 2;
+  vi.setSystemTime(2);
 
   expect(await store.putDatabase(testDB2)).to.deep.equal({
     testName1: withLastOpenedTimestampMS(testDB1, 1),
@@ -136,8 +132,7 @@ test('close closes kv store', async () => {
 });
 
 test('clear', async () => {
-  let now = 1;
-  sinon.replace(Date, 'now', () => now);
+  vi.setSystemTime(1);
   const store = new IDBDatabasesStore(_ => new TestMemStore());
   const testDB1 = {
     name: 'testName1',
@@ -147,10 +142,10 @@ test('clear', async () => {
   };
 
   expect(await store.putDatabase(testDB1)).to.deep.equal({
-    testName1: withLastOpenedTimestampMS(testDB1, now),
+    testName1: withLastOpenedTimestampMS(testDB1, Date.now()),
   });
   expect(await store.getDatabases()).to.deep.equal({
-    testName1: withLastOpenedTimestampMS(testDB1, now),
+    testName1: withLastOpenedTimestampMS(testDB1, Date.now()),
   });
 
   await store.clearDatabases();
@@ -164,13 +159,13 @@ test('clear', async () => {
     schemaVersion: 'testSchemaVersion2',
   };
 
-  now = 2;
+  vi.setSystemTime(2);
 
   expect(await store.putDatabase(testDB2)).to.deep.equal({
-    testName2: withLastOpenedTimestampMS(testDB2, now),
+    testName2: withLastOpenedTimestampMS(testDB2, Date.now()),
   });
   expect(await store.getDatabases()).to.deep.equal({
-    testName2: withLastOpenedTimestampMS(testDB2, now),
+    testName2: withLastOpenedTimestampMS(testDB2, Date.now()),
   });
 });
 

--- a/packages/replicache/src/process-scheduler.test.ts
+++ b/packages/replicache/src/process-scheduler.test.ts
@@ -1,19 +1,17 @@
 import {resolver, type Resolver} from '@rocicorp/resolver';
-import sinon, {type SinonFakeTimers, useFakeTimers} from 'sinon';
-import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {AbortError} from '../../shared/src/abort-error.ts';
 import {ProcessScheduler} from './process-scheduler.ts';
 import {expectPromiseToReject} from './test-util.ts';
 
 describe('ProcessScheduler', () => {
-  let clock: SinonFakeTimers;
   beforeEach(() => {
-    clock = useFakeTimers();
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
-    clock.restore();
-    sinon.restore();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   async function aFewMicrotasks(num = 10) {
@@ -350,7 +348,7 @@ describe('ProcessScheduler', () => {
     const result2 = schedule();
     expect(result1).to.equal(result2);
     // make idle take 100 ms
-    await clock.tickAsync(100);
+    await vi.advanceTimersByTimeAsync(100);
     requestIdleResolvers[0].resolve();
     await aFewMicrotasks();
     expect(testProcessCallCount).to.equal(1);
@@ -361,7 +359,7 @@ describe('ProcessScheduler', () => {
     expect(result3).to.equal(result4);
     expect(testProcessCallCount).to.equal(1);
     // make process take 200ms
-    await clock.tickAsync(200);
+    await vi.advanceTimersByTimeAsync(200);
     testProcessResolvers[0].resolve();
     await aFewMicrotasks();
     expect(resolved).to.deep.equal([1, 2]);
@@ -374,7 +372,7 @@ describe('ProcessScheduler', () => {
     // schedule during second scheduled process throttle
     const result5 = schedule();
     expect(result4).to.equal(result5);
-    await clock.tickAsync(50);
+    await vi.advanceTimersByTimeAsync(50);
     await aFewMicrotasks();
     // now 250ms has elapsed
     expect(requestIdleCalls.length).to.equal(2);
@@ -393,7 +391,7 @@ describe('ProcessScheduler', () => {
     expect(result7).to.equal(result8);
     expect(testProcessCallCount).to.equal(2);
     // make second process run take 250ms
-    await clock.tickAsync(250);
+    await vi.advanceTimersByTimeAsync(250);
     testProcessResolvers[1].resolve();
     await aFewMicrotasks();
     expect(resolved).to.deep.equal([1, 2, 3, 4, 5, 6]);

--- a/packages/replicache/src/replicache-collect-idb-databases.test.ts
+++ b/packages/replicache/src/replicache-collect-idb-databases.test.ts
@@ -1,10 +1,6 @@
-import {expect, test} from 'vitest';
+import {expect, test, vi} from 'vitest';
 import {sleep} from '../../shared/src/sleep.ts';
-import {
-  clock,
-  initReplicacheTesting,
-  replicacheForTesting,
-} from './test-util.ts';
+import {initReplicacheTesting, replicacheForTesting} from './test-util.ts';
 
 initReplicacheTesting();
 
@@ -23,7 +19,7 @@ test('collect IDB databases', async () => {
 
   expect(await getDatabases()).to.deep.equal(['collect-idb-databases-1']);
 
-  await clock.tickAsync(ONE_MONTH);
+  await vi.advanceTimersByTimeAsync(ONE_MONTH);
 
   const rep2 = await replicacheForTesting('collect-idb-databases-2');
   await rep2.close();
@@ -33,15 +29,15 @@ test('collect IDB databases', async () => {
     'collect-idb-databases-2',
   ]);
 
-  await clock.tickAsync(12 * HOURS);
+  await vi.advanceTimersByTimeAsync(12 * HOURS);
 
   // Open one more database and keep it open long enough to trigger the collection.
   const rep3 = await replicacheForTesting('collect-idb-databases-3');
-  await clock.tickAsync(5 * MINUTES);
+  await vi.advanceTimersByTimeAsync(5 * MINUTES);
   await rep3.close();
 
   // Restore real timers and wait a few ms to let the idb state "flush"
-  clock.restore();
+  vi.useRealTimers();
   await sleep(500);
 
   expect(await getDatabases()).to.deep.equal([

--- a/packages/replicache/src/replicache-on-update-needed.test.ts
+++ b/packages/replicache/src/replicache-on-update-needed.test.ts
@@ -1,4 +1,4 @@
-import {describe, expect, test} from 'vitest';
+import {describe, expect, test, vi} from 'vitest';
 import {
   initReplicacheTesting,
   replicacheForTesting,
@@ -31,7 +31,7 @@ describe('onUpdateNeeded', () => {
       {useUniqueName: false},
     );
 
-    await tickAFewTimes();
+    await tickAFewTimes(vi);
 
     expect(onUpdateNeededReason).to.deep.equal({
       type: 'NewClientGroup',

--- a/packages/replicache/src/replicache-poke.test.ts
+++ b/packages/replicache/src/replicache-poke.test.ts
@@ -1,5 +1,4 @@
-import * as sinon from 'sinon';
-import {expect, test} from 'vitest';
+import {expect, test, vi} from 'vitest';
 import type {VersionNotSupportedResponse} from './error-responses.ts';
 import {
   addData,
@@ -148,7 +147,7 @@ test('overlapped pokes not supported', async () => {
 });
 
 test('Client group unknown on server', async () => {
-  const onClientStateNotFound = sinon.stub();
+  const onClientStateNotFound = vi.fn();
   const rep = await replicacheForTesting('client-group-unknown', {
     onClientStateNotFound,
   });
@@ -169,7 +168,7 @@ test('Client group unknown on server', async () => {
   }
 
   expect(err).undefined;
-  expect(onClientStateNotFound.callCount).equal(1);
+  expect(onClientStateNotFound).toHaveBeenCalledOnce();
   expect(rep.isClientGroupDisabled).true;
 });
 
@@ -184,7 +183,7 @@ test('Version not supported on server', async () => {
       disableAllBackgroundProcesses,
     );
 
-    const onUpdateNeededStub = (rep.onUpdateNeeded = sinon.stub());
+    const onUpdateNeededStub = (rep.onUpdateNeeded = vi.fn());
 
     const poke: Poke = {
       baseCookie: 123,
@@ -193,8 +192,8 @@ test('Version not supported on server', async () => {
 
     await rep.poke(poke);
 
-    expect(onUpdateNeededStub.callCount).to.equal(1);
-    expect(onUpdateNeededStub.lastCall.args).deep.equal([reason]);
+    expect(onUpdateNeededStub).toHaveBeenCalledOnce();
+    expect(onUpdateNeededStub.mock.calls[0]).toEqual([reason]);
   };
 
   await t({error: 'VersionNotSupported'}, {type: 'VersionNotSupported'});

--- a/packages/replicache/src/watch.test.ts
+++ b/packages/replicache/src/watch.test.ts
@@ -1,5 +1,4 @@
-import * as sinon from 'sinon';
-import {describe, expect, test} from 'vitest';
+import {describe, expect, test, vi} from 'vitest';
 import type {JSONValue} from '../../shared/src/json.ts';
 import {Queue} from '../../shared/src/queue.ts';
 import {
@@ -26,13 +25,13 @@ test('watch', async () => {
     },
   });
 
-  const spy = sinon.spy();
+  const spy = vi.fn();
   const unwatch = rep.experimentalWatch(spy);
 
   await rep.mutate.addData({a: 1, b: 2});
 
-  expect(spy.callCount).to.equal(1);
-  expect(spy.lastCall.args).to.deep.equal([
+  expect(spy).toHaveBeenCalledTimes(1);
+  expect(spy.mock.lastCall).to.deep.equal([
     [
       {
         op: 'add',
@@ -47,13 +46,13 @@ test('watch', async () => {
     ],
   ]);
 
-  spy.resetHistory();
+  spy.mockClear();
   await rep.mutate.addData({a: 1, b: 2});
-  expect(spy.callCount).to.equal(0);
+  expect(spy).toHaveBeenCalledTimes(0);
 
   await rep.mutate.addData({a: 11});
-  expect(spy.callCount).to.equal(1);
-  expect(spy.lastCall.args).to.deep.equal([
+  expect(spy).toHaveBeenCalledTimes(1);
+  expect(spy.mock.lastCall).to.deep.equal([
     [
       {
         op: 'change',
@@ -64,10 +63,10 @@ test('watch', async () => {
     ],
   ]);
 
-  spy.resetHistory();
+  spy.mockClear();
   await rep.mutate.del('b');
-  expect(spy.callCount).to.equal(1);
-  expect(spy.lastCall.args).to.deep.equal([
+  expect(spy).toHaveBeenCalledTimes(1);
+  expect(spy.mock.lastCall).to.deep.equal([
     [
       {
         op: 'del',
@@ -79,9 +78,9 @@ test('watch', async () => {
 
   unwatch();
 
-  spy.resetHistory();
+  spy.mockClear();
   await rep.mutate.addData({c: 6});
-  expect(spy.callCount).to.equal(0);
+  expect(spy).toHaveBeenCalledTimes(0);
 });
 
 test('watch with prefix', async () => {
@@ -92,13 +91,13 @@ test('watch with prefix', async () => {
     },
   });
 
-  const spy = sinon.spy();
+  const spy = vi.fn();
   const unwatch = rep.experimentalWatch(spy, {prefix: 'b'});
 
   await rep.mutate.addData({a: 1, b: 2});
 
-  expect(spy.callCount).to.equal(1);
-  expect(spy.lastCall.args).to.deep.equal([
+  expect(spy).toHaveBeenCalledTimes(1);
+  expect(spy.mock.lastCall).to.deep.equal([
     [
       {
         op: 'add',
@@ -108,16 +107,16 @@ test('watch with prefix', async () => {
     ],
   ]);
 
-  spy.resetHistory();
+  spy.mockClear();
   await rep.mutate.addData({a: 1, b: 2});
-  expect(spy.callCount).to.equal(0);
+  expect(spy).toHaveBeenCalledTimes(0);
 
   await rep.mutate.addData({a: 11});
-  expect(spy.callCount).to.equal(0);
+  expect(spy).toHaveBeenCalledTimes(0);
 
   await rep.mutate.addData({b: 3, b1: 4, c: 5});
-  expect(spy.callCount).to.equal(1);
-  expect(spy.lastCall.args).to.deep.equal([
+  expect(spy).toHaveBeenCalledTimes(1);
+  expect(spy.mock.lastCall).to.deep.equal([
     [
       {
         op: 'change',
@@ -133,10 +132,10 @@ test('watch with prefix', async () => {
     ],
   ]);
 
-  spy.resetHistory();
+  spy.mockClear();
   await rep.mutate.del('b');
-  expect(spy.callCount).to.equal(1);
-  expect(spy.lastCall.args).to.deep.equal([
+  expect(spy).toHaveBeenCalledTimes(1);
+  expect(spy.mock.lastCall).to.deep.equal([
     [
       {
         op: 'del',
@@ -148,9 +147,9 @@ test('watch with prefix', async () => {
 
   unwatch();
 
-  spy.resetHistory();
+  spy.mockClear();
   await rep.mutate.addData({b: 6});
-  expect(spy.callCount).to.equal(0);
+  expect(spy).toHaveBeenCalledTimes(0);
 });
 
 test('watch and initial callback with no data', async () => {
@@ -165,12 +164,12 @@ test('watch and initial callback with no data', async () => {
     disableAllBackgroundProcesses,
   );
 
-  const spy = sinon.spy();
+  const spy = vi.fn();
   const unwatch = rep.experimentalWatch(spy, {initialValuesInFirstDiff: true});
-  await tickAFewTimes();
-  expect(spy.callCount).to.equal(1);
-  expect(spy.lastCall.args).to.deep.equal([[]]);
-  spy.resetHistory();
+  await tickAFewTimes(vi);
+  expect(spy).toHaveBeenCalledTimes(1);
+  expect(spy.mock.lastCall).to.deep.equal([[]]);
+  spy.mockClear();
 
   unwatch();
 });
@@ -189,11 +188,11 @@ test('watch and initial callback with data', async () => {
 
   await rep.mutate.addData({a: 1, b: 2});
 
-  const spy = sinon.spy();
+  const spy = vi.fn();
   const unwatch = rep.experimentalWatch(spy, {initialValuesInFirstDiff: true});
-  await tickAFewTimes();
-  expect(spy.callCount).to.equal(1);
-  expect(spy.lastCall.args).to.deep.equal([
+  await tickAFewTimes(vi);
+  expect(spy).toHaveBeenCalledTimes(1);
+  expect(spy.mock.lastCall).to.deep.equal([
     [
       {
         op: 'add',
@@ -208,7 +207,7 @@ test('watch and initial callback with data', async () => {
     ],
   ]);
 
-  spy.resetHistory();
+  spy.mockClear();
 
   unwatch();
 });
@@ -221,23 +220,23 @@ test('watch with prefix and initial callback no data', async () => {
     },
   });
 
-  const spy = sinon.spy();
+  const spy = vi.fn();
   const unwatch = rep.experimentalWatch(spy, {
     prefix: 'b',
     initialValuesInFirstDiff: true,
   });
 
-  await tickAFewTimes();
+  await tickAFewTimes(vi);
 
   // Initial callback should always be called even with no data.
-  expect(spy.callCount).to.equal(1);
-  expect(spy.lastCall.args).to.deep.equal([[]]);
-  spy.resetHistory();
+  expect(spy).toHaveBeenCalledTimes(1);
+  expect(spy.mock.lastCall).to.deep.equal([[]]);
+  spy.mockClear();
 
   await rep.mutate.addData({a: 1, b: 2});
 
-  expect(spy.callCount).to.equal(1);
-  expect(spy.lastCall.args).to.deep.equal([
+  expect(spy).toHaveBeenCalledTimes(1);
+  expect(spy.mock.lastCall).to.deep.equal([
     [
       {
         op: 'add',
@@ -260,16 +259,16 @@ test('watch with prefix and initial callback and data', async () => {
 
   await rep.mutate.addData({a: 1, b: 2});
 
-  const spy = sinon.spy();
+  const spy = vi.fn();
   const unwatch = rep.experimentalWatch(spy, {
     prefix: 'b',
     initialValuesInFirstDiff: true,
   });
 
-  await tickAFewTimes();
+  await tickAFewTimes(vi);
 
-  expect(spy.callCount).to.equal(1);
-  expect(spy.lastCall.args).to.deep.equal([
+  expect(spy).toHaveBeenCalledTimes(1);
+  expect(spy.mock.lastCall).to.deep.equal([
     [
       {
         op: 'add',
@@ -291,17 +290,17 @@ test('watch on index', async () => {
     indexes: {id1: {jsonPointer: '/id'}},
   });
 
-  const spy = sinon.spy();
+  const spy = vi.fn();
   const unwatch = rep.experimentalWatch(spy, {
     indexName: 'id1',
   });
 
-  await tickAFewTimes();
+  await tickAFewTimes(vi);
 
   await rep.mutate.addData({a: {id: 'aaa'}, b: {id: 'bbb'}});
 
-  expect(spy.callCount).to.equal(1);
-  expect(spy.lastCall.args).to.deep.equal([
+  expect(spy).toHaveBeenCalledTimes(1);
+  expect(spy.mock.lastCall).to.deep.equal([
     [
       {
         op: 'add',
@@ -316,10 +315,10 @@ test('watch on index', async () => {
     ],
   ]);
 
-  spy.resetHistory();
+  spy.mockClear();
   await rep.mutate.addData({b: {id: 'bbb', more: 42}});
-  expect(spy.callCount).to.equal(1);
-  expect(spy.lastCall.args).to.deep.equal([
+  expect(spy).toHaveBeenCalledTimes(1);
+  expect(spy.mock.lastCall).to.deep.equal([
     [
       {
         op: 'change',
@@ -330,10 +329,10 @@ test('watch on index', async () => {
     ],
   ]);
 
-  spy.resetHistory();
+  spy.mockClear();
   await rep.mutate.del('a');
-  expect(spy.callCount).to.equal(1);
-  expect(spy.lastCall.args).to.deep.equal([
+  expect(spy).toHaveBeenCalledTimes(1);
+  expect(spy.mock.lastCall).to.deep.equal([
     [
       {
         op: 'del',
@@ -355,18 +354,18 @@ test('watch on index with prefix', async () => {
     indexes: {id1: {jsonPointer: '/id'}},
   });
 
-  const spy = sinon.spy();
+  const spy = vi.fn();
   const unwatch = rep.experimentalWatch(spy, {
     indexName: 'id1',
     prefix: 'b',
   });
 
-  await tickAFewTimes();
+  await tickAFewTimes(vi);
 
   await rep.mutate.addData({a: {id: 'aaa'}, b: {id: 'bbb'}});
 
-  expect(spy.callCount).to.equal(1);
-  expect(spy.lastCall.args).to.deep.equal([
+  expect(spy).toHaveBeenCalledTimes(1);
+  expect(spy.mock.lastCall).to.deep.equal([
     [
       {
         op: 'add',
@@ -376,10 +375,10 @@ test('watch on index with prefix', async () => {
     ],
   ]);
 
-  spy.resetHistory();
+  spy.mockClear();
   await rep.mutate.addData({b: {id: 'bbb', more: 42}});
-  expect(spy.callCount).to.equal(1);
-  expect(spy.lastCall.args).to.deep.equal([
+  expect(spy).toHaveBeenCalledTimes(1);
+  expect(spy.mock.lastCall).to.deep.equal([
     [
       {
         op: 'change',
@@ -390,10 +389,10 @@ test('watch on index with prefix', async () => {
     ],
   ]);
 
-  spy.resetHistory();
+  spy.mockClear();
   await rep.mutate.addData({a: {id: 'baa'}});
-  expect(spy.callCount).to.equal(1);
-  expect(spy.lastCall.args).to.deep.equal([
+  expect(spy).toHaveBeenCalledTimes(1);
+  expect(spy.mock.lastCall).to.deep.equal([
     [
       {
         op: 'add',
@@ -403,14 +402,14 @@ test('watch on index with prefix', async () => {
     ],
   ]);
 
-  spy.resetHistory();
+  spy.mockClear();
   await rep.mutate.addData({c: {id: 'abaa'}});
-  expect(spy.callCount).to.equal(0);
+  expect(spy).toHaveBeenCalledTimes(0);
 
-  spy.resetHistory();
+  spy.mockClear();
   await rep.mutate.del('b');
-  expect(spy.callCount).to.equal(1);
-  expect(spy.lastCall.args).to.deep.equal([
+  expect(spy).toHaveBeenCalledTimes(1);
+  expect(spy.mock.lastCall).to.deep.equal([
     [
       {
         op: 'del',
@@ -436,17 +435,17 @@ test('watch with index and initial callback with no data', async () => {
     disableAllBackgroundProcesses,
   );
 
-  const spy = sinon.spy();
+  const spy = vi.fn();
   const unwatch = rep.experimentalWatch(spy, {
     initialValuesInFirstDiff: true,
     indexName: 'id1',
   });
-  await tickAFewTimes();
+  await tickAFewTimes(vi);
 
   // Initial callback should always be called even with no data.
-  expect(spy.callCount).to.equal(1);
-  expect(spy.lastCall.args).to.deep.equal([[]]);
-  spy.resetHistory();
+  expect(spy).toHaveBeenCalledTimes(1);
+  expect(spy.mock.lastCall).to.deep.equal([[]]);
+  spy.mockClear();
 
   unwatch();
 });
@@ -462,14 +461,14 @@ test('watch and initial callback with data', async () => {
 
   await rep.mutate.addData({a: {id: 'aaa'}, b: {id: 'bbb'}});
 
-  const spy = sinon.spy();
+  const spy = vi.fn();
   const unwatch = rep.experimentalWatch(spy, {
     initialValuesInFirstDiff: true,
     indexName: 'id1',
   });
-  await tickAFewTimes();
-  expect(spy.callCount).to.equal(1);
-  expect(spy.lastCall.args).to.deep.equal([
+  await tickAFewTimes(vi);
+  expect(spy).toHaveBeenCalledTimes(1);
+  expect(spy.mock.lastCall).to.deep.equal([
     [
       {
         op: 'add',
@@ -498,17 +497,17 @@ test('watch with index and prefix and initial callback and data', async () => {
 
   await rep.mutate.addData({a: {id: 'aaa'}, b: {id: 'bbb'}});
 
-  const spy = sinon.spy();
+  const spy = vi.fn();
   const unwatch = rep.experimentalWatch(spy, {
     prefix: 'b',
     initialValuesInFirstDiff: true,
     indexName: 'id1',
   });
 
-  await tickAFewTimes();
+  await tickAFewTimes(vi);
 
-  expect(spy.callCount).to.equal(1);
-  expect(spy.lastCall.args).to.deep.equal([
+  expect(spy).toHaveBeenCalledTimes(1);
+  expect(spy.mock.lastCall).to.deep.equal([
     [
       {
         op: 'add',

--- a/packages/shared/src/browser-env.ts
+++ b/packages/shared/src/browser-env.ts
@@ -4,9 +4,25 @@
 
 type GlobalThis = typeof globalThis;
 
+const overrides = new Map<keyof GlobalThis, GlobalThis[keyof GlobalThis]>();
+
+export function overrideBrowserGlobal<T extends keyof GlobalThis>(
+  name: T,
+  value: GlobalThis[T],
+) {
+  overrides.set(name, value);
+}
+
+export function clearBrowserOverrides() {
+  overrides.clear();
+}
+
 export function getBrowserGlobal<T extends keyof GlobalThis>(
   name: T,
 ): GlobalThis[T] | undefined {
+  if (overrides.has(name)) {
+    return overrides.get(name);
+  }
   return globalThis[name];
 }
 
@@ -29,7 +45,7 @@ export function getBrowserGlobal<T extends keyof GlobalThis>(
 export function getBrowserGlobalMethod<T extends keyof GlobalThis>(
   name: T,
 ): GlobalThis[T] | undefined {
-  return globalThis[name]?.bind(globalThis);
+  return getBrowserGlobal(name)?.bind(globalThis);
 }
 
 export function mustGetBrowserGlobal<T extends keyof GlobalThis>(

--- a/packages/shared/src/sleep.test.ts
+++ b/packages/shared/src/sleep.test.ts
@@ -1,15 +1,10 @@
-import {type SinonFakeTimers, useFakeTimers} from 'sinon';
-import {afterEach, beforeEach, expect, test} from 'vitest';
+import {beforeEach, expect, test, vi} from 'vitest';
 import {AbortError} from './abort-error.ts';
 import {sleep, sleepWithAbort} from './sleep.ts';
 
-let clock: SinonFakeTimers;
 beforeEach(() => {
-  clock = useFakeTimers(0);
-});
-
-afterEach(() => {
-  clock.restore();
+  vi.useFakeTimers({now: 0});
+  return () => vi.useRealTimers();
 });
 
 test('sleep', async () => {
@@ -18,15 +13,15 @@ test('sleep', async () => {
     await sleep(100);
     callCount++;
   })();
-  await clock.tickAsync(99);
+  await vi.advanceTimersByTimeAsync(99);
   expect(Date.now()).toEqual(99);
   expect(callCount).toEqual(0);
 
-  await clock.tickAsync(1);
+  await vi.advanceTimersByTimeAsync(1);
   expect(callCount).toEqual(1);
   expect(Date.now()).toEqual(100);
 
-  await clock.tickAsync(100);
+  await vi.advanceTimersByTimeAsync(100);
   expect(callCount).toEqual(1);
   expect(Date.now()).toEqual(200);
 
@@ -49,10 +44,10 @@ test('sleep abort', async () => {
 
   expect(e).toBeInstanceOf(AbortError);
 
-  await clock.tickAsync(100);
+  await vi.advanceTimersByTimeAsync(100);
   expect(Date.now()).toEqual(100);
 
-  await clock.tickAsync(100);
+  await vi.advanceTimersByTimeAsync(100);
   expect(Date.now()).toEqual(200);
 });
 
@@ -68,18 +63,18 @@ test('sleepWithAbort', async () => {
     abortedResolved = true;
   });
 
-  await clock.tickAsync(50);
+  await vi.advanceTimersByTimeAsync(50);
   controller.abort();
   expect(okResolved).toEqual(false);
   expect(abortedResolved).toEqual(false);
   expect(Date.now()).toEqual(50);
 
-  await clock.tickAsync(0);
+  await vi.advanceTimersByTimeAsync(0);
   expect(okResolved).toEqual(false);
   expect(abortedResolved).toEqual(true);
   expect(Date.now()).toEqual(50);
 
-  await clock.tickAsync(50);
+  await vi.advanceTimersByTimeAsync(50);
   expect(okResolved).toEqual(false);
 });
 

--- a/packages/zero-client/package.json
+++ b/packages/zero-client/package.json
@@ -23,13 +23,11 @@
   "devDependencies": {
     "@rocicorp/eslint-config": "^0.7.0",
     "@rocicorp/prettier-config": "^0.3.0",
-    "@types/sinon": "^10.0.11",
     "datadog": "0.0.0",
     "esbuild": "^0.25.0",
     "playwright": "^1.51.0",
     "replicache": "15.2.1",
     "shared": "0.0.0",
-    "sinon": "^13.0.1",
     "typescript": "~5.8.2",
     "zero-protocol": "0.0.0"
   },

--- a/packages/zero-client/src/client/worker-test.ts
+++ b/packages/zero-client/src/client/worker-test.ts
@@ -1,6 +1,5 @@
 // This test file is loaded by worker.test.ts
 
-import sinon from 'sinon';
 import {assert} from '../../../shared/src/asserts.ts';
 import {deepEqual} from '../../../shared/src/json.ts';
 import {sleep} from '../../../shared/src/sleep.ts';
@@ -12,20 +11,19 @@ import {
 } from '../../../zero-schema/src/builder/table-builder.ts';
 import {MockSocket, zeroForTest} from './test-utils.ts';
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const {WebSocket} = globalThis;
+
 onmessage = async (e: MessageEvent) => {
   const {userID} = e.data;
   try {
-    sinon.replace(
-      globalThis,
-      'WebSocket',
-      MockSocket as unknown as typeof WebSocket,
-    );
+    globalThis.WebSocket = MockSocket as unknown as typeof WebSocket;
     await testBasics(userID);
     postMessage(undefined);
   } catch (ex) {
     postMessage(ex);
   } finally {
-    sinon.restore();
+    globalThis.WebSocket = WebSocket;
   }
 };
 


### PR DESCRIPTION
Our version of sinon was very old (v13 and sinon is at v20 now) and vitest provides the same functionality. This commit removes sinon and replaces it with vitest's mocking and spying capabilities. This should make our tests more consistent and easier to maintain.