### PR TITLE
fix(zero-cache): fix handling of column default value changes

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg-test.ts
@@ -520,6 +520,57 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
       ],
     ],
     [
+      'change column default and set not null',
+      `
+       ALTER TABLE my.bar ALTER login SET DEFAULT floor(10000 * random())::text;
+       ALTER TABLE my.bar ALTER login SET NOT NULL;`,
+      [{tag: 'update-column'}],
+      {['my.bar']: []},
+      [
+        {
+          columns: {
+            ['_0_version']: {
+              characterMaximumLength: null,
+              dataType: 'TEXT',
+              dflt: null,
+              notNull: false,
+              pos: 2,
+            },
+            id: {
+              characterMaximumLength: null,
+              dataType: 'int8|NOT_NULL',
+              dflt: null,
+              notNull: false,
+              pos: 1,
+            },
+            handle: {
+              characterMaximumLength: null,
+              dataType: 'text|NOT_NULL',
+              dflt: null,
+              notNull: false,
+              pos: 3,
+            },
+            login: {
+              characterMaximumLength: null,
+              dataType: 'varchar|NOT_NULL',
+              dflt: null, // defaults should be ignored for update-column
+              notNull: false,
+              pos: 4,
+            },
+          },
+          name: 'my.bar',
+        },
+      ],
+      [
+        {
+          name: 'my.bar_username_key',
+          tableName: 'my.bar',
+          columns: {login: 'ASC'},
+          unique: true,
+        },
+      ],
+    ],
+    [
       'drop column with index',
       'ALTER TABLE my.bar DROP login;',
       [{tag: 'drop-index'}, {tag: 'drop-column'}],

--- a/packages/zero-cache/src/services/replicator/change-processor.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.test.ts
@@ -1383,6 +1383,91 @@ describe('replicator/incremental-sync', () => {
       ],
     },
     {
+      name: 'change column default and nullability',
+      setup: `
+        CREATE TABLE foo(id INT8, nolz TEXT, _0_version TEXT);
+        CREATE UNIQUE INDEX foo_pkey ON foo (id ASC);
+        INSERT INTO foo(id, nolz, _0_version) VALUES (1, 'hel', '00');
+        INSERT INTO foo(id, nolz, _0_version) VALUES (2, 'low', '00');
+        INSERT INTO foo(id, nolz, _0_version) VALUES (3, 'orl', '00');
+      `,
+      downstream: [
+        ['begin', fooBarBaz.begin(), {commitWatermark: '0e'}],
+        ['data', fooBarBaz.update('foo', {id: 3, nolz: 'olrd'})],
+        [
+          'data',
+          fooBarBaz.updateColumn(
+            'foo',
+            {name: 'nolz', spec: {pos: 1, dataType: 'TEXT'}},
+            {
+              name: 'nolz',
+              spec: {pos: 1, dataType: 'TEXT', notNull: true, dflt: 'now()'},
+            },
+          ),
+        ],
+        ['data', fooBarBaz.insert('foo', {id: 4, nolz: 'yay'})],
+        ['commit', fooBarBaz.commit(), {watermark: '0e'}],
+      ],
+      data: {
+        foo: [
+          {id: 1n, nolz: 'hel', ['_0_version']: '0e'},
+          {id: 2n, nolz: 'low', ['_0_version']: '0e'},
+          {id: 3n, nolz: 'olrd', ['_0_version']: '0e'},
+          {id: 4n, nolz: 'yay', ['_0_version']: '0e'},
+        ],
+        ['_zero.changeLog']: [
+          {
+            stateVersion: '0e',
+            table: 'foo',
+            op: 'r',
+            rowKey: null,
+          },
+          {
+            stateVersion: '0e',
+            table: 'foo',
+            op: 's',
+            rowKey: '{"id":4}',
+          },
+        ],
+      },
+      tableSpecs: [
+        {
+          name: 'foo',
+          columns: {
+            id: {
+              characterMaximumLength: null,
+              dataType: 'INT8',
+              dflt: null,
+              notNull: false,
+              pos: 1,
+            },
+            nolz: {
+              characterMaximumLength: null,
+              dataType: 'TEXT|NOT_NULL',
+              dflt: null,
+              notNull: false,
+              pos: 3,
+            },
+            ['_0_version']: {
+              characterMaximumLength: null,
+              dataType: 'TEXT',
+              dflt: null,
+              notNull: false,
+              pos: 2,
+            },
+          },
+        },
+      ],
+      indexSpecs: [
+        {
+          name: 'foo_pkey',
+          tableName: 'foo',
+          columns: {id: 'ASC'},
+          unique: true,
+        },
+      ],
+    },
+    {
       name: 'rename indexed column',
       setup: `
         CREATE TABLE foo(id INT8, renameMe TEXT, _0_version TEXT);


### PR DESCRIPTION
Even though SQLite does not support non-constant defaults, zero can support _changes_ of column defaults to arbitrary expressions, e.g.

```sql
ALTER TABLE foo ALTER COLUMN bar SET DEFAULT now();
```

because changing a column's defaults in Postgres does not modify existing values.

https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-DESC-SET-DROP-DEFAULT

> The new default value will only apply in subsequent INSERT or UPDATE commands; it does not cause rows already in the table to change.

and so column values will continue to come through the replication stream.

This was handled correctly most of the time; the `change-streamer` ignores changes to column defaults. 

However, if a change to a column default was followed by a subsequent change that _is_ relevant to zero (e.g. a change to nullability), the default of the new column was incorrectly triggering an unsupported change error.

The update column logic in the replicator itself is now fixed to ignore defaults.