### PR TITLE
chore(zero-pg): Adds a PostgresConnection adapter.

### DIFF
--- a/apps/zbugs/server/push-handler.ts
+++ b/apps/zbugs/server/push-handler.ts
@@ -1,45 +1,14 @@
-import {
-  PushProcessor,
-  type DBConnection,
-  type DBTransaction,
-  type Params,
-  type Row,
-} from '@rocicorp/zero/pg';
-import postgres, {type JSONValue} from 'postgres';
+import {PushProcessor, type Params} from '@rocicorp/zero/pg';
+import postgres from 'postgres';
 import {schema} from '../shared/schema.ts';
 import {createServerMutators, type PostCommitTask} from './server-mutators.ts';
 import type {ReadonlyJSONObject} from '@rocicorp/zero';
 import type {AuthData} from '../shared/auth.ts';
+import {connectionProvider} from '@rocicorp/zero/pg';
 
-class Connection implements DBConnection<postgres.TransactionSql> {
-  readonly #pg: postgres.Sql;
-  constructor(pg: postgres.Sql) {
-    this.#pg = pg;
-  }
-
-  query(sql: string, params: unknown[]): Promise<Row[]> {
-    return this.#pg.unsafe(sql, params as JSONValue[]);
-  }
-
-  transaction<T>(
-    fn: (tx: DBTransaction<postgres.TransactionSql>) => Promise<T>,
-  ): Promise<T> {
-    return this.#pg.begin(pgTx => fn(new Transaction(pgTx))) as Promise<T>;
-  }
-}
-
-class Transaction implements DBTransaction<postgres.TransactionSql> {
-  readonly wrappedTransaction: postgres.TransactionSql;
-  constructor(pgTx: postgres.TransactionSql) {
-    this.wrappedTransaction = pgTx;
-  }
-
-  query(sql: string, params: unknown[]): Promise<Row[]> {
-    return this.wrappedTransaction.unsafe(sql, params as JSONValue[]);
-  }
-}
-
-const mutatorSql = postgres(process.env.ZERO_UPSTREAM_DB as string);
+const provider = connectionProvider(
+  postgres(process.env.ZERO_UPSTREAM_DB as string),
+);
 
 export async function handlePush(
   authData: AuthData | undefined,
@@ -48,11 +17,7 @@ export async function handlePush(
 ) {
   const postCommitTasks: PostCommitTask[] = [];
   const mutators = createServerMutators(authData, postCommitTasks);
-  const processor = new PushProcessor(
-    schema,
-    () => new Connection(mutatorSql),
-    mutators,
-  );
+  const processor = new PushProcessor(schema, provider, mutators);
   const response = await processor.process(params, body);
   await Promise.all(postCommitTasks.map(task => task()));
   return response;

--- a/packages/zero-pg/src/mod.ts
+++ b/packages/zero-pg/src/mod.ts
@@ -7,4 +7,10 @@ export type {
   ConnectionProvider,
   Row,
 } from '../../zql/src/mutate/custom.ts';
+export {
+  connectionProvider,
+  Connection,
+  type PostgresSQL,
+  type PostgresTransaction,
+} from './postgres-connection.ts';
 export {type PushHandler, type Params, PushProcessor} from './web.ts';

--- a/packages/zero-pg/src/postgres-connection.ts
+++ b/packages/zero-pg/src/postgres-connection.ts
@@ -1,0 +1,65 @@
+import type {DBConnection, DBTransaction} from '../../zql/src/mutate/custom.ts';
+import type {JSONValue} from '../../shared/src/json.ts';
+import type {Row} from '../../zql/src/mutate/custom.ts';
+
+/**
+ * Subset of the postgres lib's `Transaction` interface that we use.
+ */
+export type PostgresTransaction = {
+  unsafe(sql: string, params: JSONValue[]): Promise<Row[]>;
+};
+
+/**
+ * Subset of the postgres lib's `SQL` interface that we use.
+ */
+export type PostgresSQL<Transaction extends PostgresTransaction> = {
+  unsafe(sql: string, params: JSONValue[]): Promise<Row[]>;
+  begin<T>(fn: (tx: Transaction) => Promise<T>): Promise<T>;
+};
+
+/**
+ * Adapts the `postgres` library to Zero's `DBConnection` interface.
+ * Note: we do this via Go-style structural interface dependencies rather than
+ * directly depending on the `postgres` library to eliminate chance of version
+ * conflicts with customer.
+ */
+export class Connection<
+  WrappedTransaction extends PostgresTransaction,
+  WrappedPostgres extends PostgresSQL<WrappedTransaction>,
+> implements DBConnection<WrappedTransaction>
+{
+  readonly #pg: WrappedPostgres;
+  constructor(pg: WrappedPostgres) {
+    this.#pg = pg;
+  }
+
+  query(sql: string, params: unknown[]): Promise<Row[]> {
+    return this.#pg.unsafe(sql, params as JSONValue[]);
+  }
+
+  transaction<T>(
+    fn: (tx: DBTransaction<WrappedTransaction>) => Promise<T>,
+  ): Promise<T> {
+    return this.#pg.begin(pgTx => fn(new Transaction(pgTx))) as Promise<T>;
+  }
+}
+
+class Transaction<WrappedTransaction extends PostgresTransaction>
+  implements DBTransaction<WrappedTransaction>
+{
+  readonly wrappedTransaction: WrappedTransaction;
+  constructor(pgTx: WrappedTransaction) {
+    this.wrappedTransaction = pgTx;
+  }
+
+  query(sql: string, params: unknown[]): Promise<Row[]> {
+    return this.wrappedTransaction.unsafe(sql, params as JSONValue[]);
+  }
+}
+
+export function connectionProvider<
+  WrappedTransaction extends PostgresTransaction,
+  WrappedPostgres extends PostgresSQL<WrappedTransaction>,
+>(pg: WrappedPostgres): () => Connection<WrappedTransaction, WrappedPostgres> {
+  return () => new Connection(pg);
+}


### PR DESCRIPTION
This way if user just wants to use postgres() they don't need to implement the adapter.