### PR TITLE
chore(zero-pg): Few dx niceties for PushProcessor.

### DIFF
--- a/apps/zbugs/api/index.ts
+++ b/apps/zbugs/api/index.ts
@@ -8,7 +8,6 @@ import {jwtVerify, SignJWT, type JWK} from 'jose';
 import {nanoid} from 'nanoid';
 import postgres from 'postgres';
 import {handlePush} from '../server/push-handler.ts';
-import type {ReadonlyJSONObject} from '@rocicorp/zero';
 import {must} from '../../../packages/shared/src/must.ts';
 import assert from 'assert';
 import {authDataSchema, type AuthData} from '../shared/auth.ts';
@@ -111,12 +110,7 @@ fastify.get<{
     );
 });
 
-fastify.post<{
-  Querystring: {
-    schema: string;
-    appID: string;
-  };
-}>('/api/push', async function (request, reply) {
+fastify.post('/api/push', async function (request, reply) {
   let {authorization} = request.headers;
   if (authorization !== undefined) {
     assert(authorization.toLowerCase().startsWith('bearer '));
@@ -131,11 +125,7 @@ fastify.post<{
         )
       : undefined;
 
-  const response = await handlePush(
-    authData,
-    request.query,
-    request.body as ReadonlyJSONObject,
-  );
+  const response = await handlePush(authData, request.query, request.body);
   reply.send(response);
 });
 

--- a/apps/zbugs/server/push-handler.ts
+++ b/apps/zbugs/server/push-handler.ts
@@ -1,24 +1,23 @@
-import {PushProcessor, type Params} from '@rocicorp/zero/pg';
+import {PushProcessor} from '@rocicorp/zero/pg';
 import postgres from 'postgres';
 import {schema} from '../shared/schema.ts';
 import {createServerMutators, type PostCommitTask} from './server-mutators.ts';
-import type {ReadonlyJSONObject} from '@rocicorp/zero';
 import type {AuthData} from '../shared/auth.ts';
 import {connectionProvider} from '@rocicorp/zero/pg';
 
-const provider = connectionProvider(
-  postgres(process.env.ZERO_UPSTREAM_DB as string),
+const processor = new PushProcessor(
+  schema,
+  connectionProvider(postgres(process.env.ZERO_UPSTREAM_DB as string)),
 );
 
 export async function handlePush(
   authData: AuthData | undefined,
-  params: Params,
-  body: ReadonlyJSONObject,
+  params: unknown,
+  body: unknown,
 ) {
   const postCommitTasks: PostCommitTask[] = [];
   const mutators = createServerMutators(authData, postCommitTasks);
-  const processor = new PushProcessor(schema, provider, mutators);
-  const response = await processor.process(params, body);
+  const response = await processor.process(mutators, params, body);
   await Promise.all(postCommitTasks.map(task => task()));
   return response;
 }

--- a/packages/zero-pg/src/mod.ts
+++ b/packages/zero-pg/src/mod.ts
@@ -13,4 +13,4 @@ export {
   type PostgresSQL,
   type PostgresTransaction,
 } from './postgres-connection.ts';
-export {type PushHandler, type Params, PushProcessor} from './web.ts';
+export {PushProcessor} from './web.ts';

--- a/packages/zero-pg/src/web.pg-test.ts
+++ b/packages/zero-pg/src/web.pg-test.ts
@@ -60,9 +60,8 @@ describe('out of order mutation', () => {
         version: 1,
       },
       () => new Connection(pg),
-      mutators,
     );
-    const result = await processor.process(params, makePush(15));
+    const result = await processor.process(mutators, params, makePush(15));
 
     expect(result).toEqual({
       mutations: [
@@ -90,10 +89,9 @@ describe('out of order mutation', () => {
         version: 1,
       },
       () => new Connection(pg),
-      mutators,
     );
 
-    expect(await processor.process(params, makePush(1))).toEqual({
+    expect(await processor.process(mutators, params, makePush(1))).toEqual({
       mutations: [
         {
           id: {
@@ -105,7 +103,7 @@ describe('out of order mutation', () => {
       ],
     });
 
-    expect(await processor.process(params, makePush(3))).toEqual({
+    expect(await processor.process(mutators, params, makePush(3))).toEqual({
       mutations: [
         {
           id: {
@@ -132,10 +130,9 @@ test('first mutation', async () => {
       version: 1,
     },
     () => new Connection(pg),
-    mutators,
   );
 
-  expect(await processor.process(params, makePush(1))).toEqual({
+  expect(await processor.process(mutators, params, makePush(1))).toEqual({
     mutations: [
       {
         id: {
@@ -158,14 +155,13 @@ test('previously seen mutation', async () => {
       version: 1,
     },
     () => new Connection(pg),
-    mutators,
   );
 
-  await processor.process(params, makePush(1));
-  await processor.process(params, makePush(2));
-  await processor.process(params, makePush(3));
+  await processor.process(mutators, params, makePush(1));
+  await processor.process(mutators, params, makePush(2));
+  await processor.process(mutators, params, makePush(3));
 
-  expect(await processor.process(params, makePush(2))).toEqual({
+  expect(await processor.process(mutators, params, makePush(2))).toEqual({
     mutations: [
       {
         id: {
@@ -188,12 +184,12 @@ test('lmid still moves forward if the mutator implementation throws', async () =
       version: 1,
     },
     () => new Connection(pg),
-    mutators,
   );
 
-  await processor.process(params, makePush(1));
-  await processor.process(params, makePush(2));
+  await processor.process(mutators, params, makePush(1));
+  await processor.process(mutators, params, makePush(2));
   const result = await processor.process(
+    mutators,
     params,
     makePush(3, customMutatorKey('foo', 'baz')),
   );

--- a/packages/zero-protocol/src/push.ts
+++ b/packages/zero-protocol/src/push.ts
@@ -166,6 +166,14 @@ export const pushResponseMessageSchema = v.tuple([
   pushResponseSchema,
 ]);
 
+/**
+ * The schema for the querystring parameters of the custom push endpoint.
+ */
+export const pushParamsSchema = v.object({
+  schema: v.string(),
+  appID: v.string(),
+});
+
 export type InsertOp = v.Infer<typeof insertOpSchema>;
 export type UpsertOp = v.Infer<typeof upsertOpSchema>;
 export type UpdateOp = v.Infer<typeof updateOpSchema>;


### PR DESCRIPTION
* Make type of params and body unknown so user doesn't have to validate.
* Move mutators to arg of process() so PushProcessor can be shared.