### PR TITLE
chore(zbugs): Fixing nested checklists. New detail view typographic scale

### DIFF
--- a/apps/zbugs/src/components/markdown.tsx
+++ b/apps/zbugs/src/components/markdown.tsx
@@ -148,15 +148,45 @@ export const Markdown = memo(({children}: {children: string}) => {
         img: ({node: _node, ...props}) => <img {...props} />,
         li: ({children, ...props}) => {
           const isTask = props.className?.includes('task-list-item');
+          const nodes: React.ReactNode[] = React.Children.toArray(children);
+          let checkbox: React.ReactNode = null;
+          let label: React.ReactNode = null;
+          const rest: React.ReactNode[] = [];
+          let seenCheckbox = false;
+          for (let i = 0; i < nodes.length; i++) {
+            const node = nodes[i];
+            if (
+              !seenCheckbox &&
+              React.isValidElement(node) &&
+              node.type === 'input' &&
+              node.props.type === 'checkbox'
+            ) {
+              seenCheckbox = true;
+              checkbox = node;
+              continue;
+            } else if (label === null) {
+              const isWhitespace =
+                typeof node === 'string' && node.trim().length === 0;
+              if (!isWhitespace) {
+                label = node;
+                continue;
+              }
+            }
+            rest.push(node);
+          }
+
           if (isTask) {
-            const [first, ...rest] = React.Children.toArray(children);
             return (
               <li className="task-list-item">
-                <div className="task-line">{first}</div>
+                <div className="task-line">
+                  {checkbox && <>{checkbox}</>}
+                  {label && <>{label}</>}
+                </div>
                 {rest.length > 0 && <div className="task-children">{rest}</div>}
               </li>
             );
           }
+
           return <li {...props}>{children}</li>;
         },
       }}

--- a/apps/zbugs/src/components/markdown.tsx
+++ b/apps/zbugs/src/components/markdown.tsx
@@ -146,6 +146,19 @@ export const Markdown = memo(({children}: {children: string}) => {
         // Ensure no additional processing for <img> elements
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         img: ({node: _node, ...props}) => <img {...props} />,
+        li: ({children, ...props}) => {
+          const isTask = props.className?.includes('task-list-item');
+          if (isTask) {
+            const [first, ...rest] = React.Children.toArray(children);
+            return (
+              <li className="task-list-item">
+                <div className="task-line">{first}</div>
+                {rest.length > 0 && <div className="task-children">{rest}</div>}
+              </li>
+            );
+          }
+          return <li {...props}>{children}</li>;
+        },
       }}
     >
       {children}

--- a/apps/zbugs/src/index.css
+++ b/apps/zbugs/src/index.css
@@ -781,7 +781,7 @@ textarea.autoResize {
 }
 
 .issue-detail-title {
-  font-size: 2rem;
+  font-size: 3rem;
   font-weight: 800;
   margin: 1.5rem 0;
 }
@@ -997,7 +997,7 @@ textarea.autoResize {
     gap: 0.5rem;
   }
 
-  ul.contains-task-list li.task-list-item::before {
+  ul.contains-task-list li.task-list-item .task-line::before {
     content: '';
     display: inline-block;
     width: 1.25rem;
@@ -1085,17 +1085,20 @@ textarea.autoResize {
 
   /* Markdown: Headers */
   h1 {
-    font-size: 3rem;
+    font-size: 2.25rem;
+    margin-bottom: 1rem;
+    font-weight: 700;
   }
 
   h2 {
-    font-size: 2rem;
+    font-size: 1.6875rem;
+    font-weight: 700;
     margin: 3rem 0 1rem;
   }
 
   h3 {
     font-size: 1.25rem;
-    font-weight: 700;
+    font-weight: 600;
     margin: 2rem 0 1rem;
   }
 

--- a/apps/zbugs/src/index.css
+++ b/apps/zbugs/src/index.css
@@ -988,10 +988,13 @@ textarea.autoResize {
   }
 
   ul.contains-task-list li.task-list-item {
+    display: block;
+  }
+
+  ul.contains-task-list li.task-list-item > .task-line {
     display: flex;
     align-items: center;
-    gap: 0.1rem;
-    padding-left: 0;
+    gap: 0.5rem;
   }
 
   ul.contains-task-list li.task-list-item::before {


### PR DESCRIPTION
- Nested checklists now display properly.
- New typographical scale on detail view (Perfect fourths, 1.333)