### PR TITLE
feat(mutators)!: move `sever` promise up a level

### DIFF
--- a/packages/replicache/src/replicache-options.ts
+++ b/packages/replicache/src/replicache-options.ts
@@ -261,6 +261,14 @@ export type ZeroReadOptions = {
   openLazySourceRead?: Read | undefined;
 };
 
+declare const idTag: unique symbol;
+export type EphemeralID = number & {[idTag]: true};
+
+export type MutationTrackingData = {
+  ephemeralID: EphemeralID;
+  serverPromise: Promise<unknown>;
+};
+
 /**
  * Minimal interface that Replicache needs to communicate with Zero.
  * Prevents us from creating any direct dependencies on Zero.
@@ -290,4 +298,8 @@ export interface ZeroOption {
    * When Replicache's main head moves forward, Zero must advance its IVM state.
    */
   advance(expectedHash: Hash, newHash: Hash, changes: InternalDiff): void;
+
+  trackMutation(): MutationTrackingData;
+  mutationIDAssigned(ephemeralID: EphemeralID, mutationID: number): void;
+  rejectMutation(ephemeralID: EphemeralID, ex: unknown): void;
 }

--- a/packages/zero-client/src/client/query-manager.test.ts
+++ b/packages/zero-client/src/client/query-manager.test.ts
@@ -1491,12 +1491,13 @@ describe('query manager & mutator interaction', () => {
     const remove = queryManager.add(ast1, 0);
     expect(send).toBeCalledTimes(1);
 
-    void mutationTracker.trackMutation(1);
+    const {ephemeralID} = mutationTracker.trackMutation();
+    mutationTracker.mutationIDAssigned(ephemeralID, 1);
 
     // try to remove the query
     remove();
 
-    // query was not removed
+    // query was not removed, just have the `add` send
     expect(send).toBeCalledTimes(1);
   });
 
@@ -1506,11 +1507,15 @@ describe('query manager & mutator interaction', () => {
     // once for each add
     expect(send).toBeCalledTimes(2);
 
-    void mutationTracker.trackMutation(1);
+    const {ephemeralID} = mutationTracker.trackMutation();
+    mutationTracker.mutationIDAssigned(ephemeralID, 1);
+
     remove1();
     remove2();
 
+    // send is still stuck at 2 -- no remove calls went through
     expect(send).toBeCalledTimes(2);
+
     mutationTracker.onConnected(1);
     // send was called for each removed query that was queued
     expect(send).toBeCalledTimes(4);

--- a/packages/zero-client/src/client/zero-rep.ts
+++ b/packages/zero-client/src/client/zero-rep.ts
@@ -12,9 +12,12 @@ import {ENTITIES_KEY_PREFIX} from './keys.ts';
 import {must} from '../../../shared/src/must.ts';
 import type {LazyStore} from '../../../replicache/src/dag/lazy-store.ts';
 import type {
+  EphemeralID,
+  MutationTrackingData,
   ZeroOption,
   ZeroReadOptions,
 } from '../../../replicache/src/replicache-options.ts';
+import type {MutationTracker} from './mutation-tracker.ts';
 
 type TxData = {
   ivmSources: IVMSourceBranch;
@@ -25,6 +28,7 @@ export class ZeroRep implements ZeroOption {
   readonly #context: ZeroContext;
   readonly #ivmMain: IVMSourceBranch;
   readonly #customMutatorsEnabled: boolean;
+  readonly #mutationTracker: MutationTracker;
   #store: LazyStore | undefined;
   #auth: string | undefined;
 
@@ -32,10 +36,12 @@ export class ZeroRep implements ZeroOption {
     context: ZeroContext,
     ivmMain: IVMSourceBranch,
     customMutatorsEnabled: boolean,
+    mutationTracker: MutationTracker,
   ) {
     this.#context = context;
     this.#ivmMain = ivmMain;
     this.#customMutatorsEnabled = customMutatorsEnabled;
+    this.#mutationTracker = mutationTracker;
   }
 
   set auth(auth: string) {
@@ -88,4 +94,14 @@ export class ZeroRep implements ZeroOption {
   advance = (expectedHash: Hash, newHash: Hash, diffs: InternalDiff): void => {
     this.#context.processChanges(expectedHash, newHash, diffs);
   };
+
+  trackMutation(): MutationTrackingData {
+    return this.#mutationTracker.trackMutation();
+  }
+  mutationIDAssigned(ephemeralID: EphemeralID, mutationID: number): void {
+    this.#mutationTracker.mutationIDAssigned(ephemeralID, mutationID);
+  }
+  rejectMutation(ephemeralID: EphemeralID, ex: unknown): void {
+    this.#mutationTracker.rejectMutation(ephemeralID, ex);
+  }
 }

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -475,7 +475,6 @@ export class Zero<
           assertUnique(key);
           replicacheMutators[key] = makeReplicacheMutator(
             lc,
-            this.#mutationTracker,
             mutatorOrMutators,
             schema,
             slowMaterializeThreshold,
@@ -493,7 +492,6 @@ export class Zero<
             assertUnique(key);
             replicacheMutators[key] = makeReplicacheMutator(
               lc,
-              this.#mutationTracker,
               mutator as CustomMutatorImpl<S>,
               schema,
               slowMaterializeThreshold,
@@ -549,6 +547,7 @@ export class Zero<
         this.#zeroContext,
         this.#ivmMain,
         options.mutators !== undefined,
+        this.#mutationTracker,
       ),
     };
 

--- a/packages/zero-protocol/src/push.ts
+++ b/packages/zero-protocol/src/push.ts
@@ -5,6 +5,9 @@ import {rowSchema} from './data.ts';
 import * as MutationType from './mutation-type-enum.ts';
 import {primaryKeySchema, primaryKeyValueRecordSchema} from './primary-key.ts';
 
+// NOTE! If you change this name you must also change the
+// string in `replicache-impl.ts` But CRUD mutators are being
+// deleted soon so this should not happen.
 export const CRUD_MUTATION_NAME = '_zero_crud';
 
 /**


### PR DESCRIPTION
Nobody was a fan of:

```ts
type Result = Promise<{
  server: Promise<MutationResult>
}>
```

Refactor things so we can do:

```ts
type Result = Promise<void> & {server: Promise<MutationResult>}
```

Or, if we add 1 more layer of wrapping in Zero, we can do:

```ts
type Result = {client: Promise<void>, server: Promise<void>};
```

although it seems more appropriate to return the "thing that should be awaited" as a top level promise.

Why was this so hard to pull off? Because the mutator implementation is buried deep within an async callstack and each async function will wrap its result in a promise automatically. We also needed information about the `mutationID`, in order to create the server promise, which can only be gotten from deep inside the call stack from `withWrite`.


Example of the issue:
```ts
// Custom mutator impl. is async because:
// 1. We need to share code with server which would have async ZQL calls in the mutator
// 2. Could call to async APIs in browser
const createIssue = async (): Promise<void> => { ... };

// basic structure of replicache-impl::#mutate
async #mutate(mutatorImpl) {
  await pendingNotifications;
  return withWrite(dag, async write => {
    const tx = new WriteTransaction(write.getMutationID())
    
    // `result` is the promise returned by `createIssue`, unwrapped
    const result = await mutatorImpl();
    
    // but it is re-wrapped into a promise on return
    // due to #mutate being an async fn
    return result;
  })
  
  // We returned `withWrite` above (a promise).
  // Could we have awaited it? Sure, but the return
  // would be re-wrapped in a promise again.
  // Resulting back again in `Promise<{server: Promise<MutatorResult>}>`
  
  // Could we make this function not async?
  // Yes, but `promise.then` re-wraps too.
}
```

Because `mutationID` comes from `withWrite` we couldn't do something trivial like:

```ts
// zero.ts
const wrappedMutator = (args) => {
  const server = trackMutation();
  const result = mutator(args);
  return {
    client: result,
    server,
  };
};
```
