### PR TITLE
feat(zero-cache): eliminate quadratic writes/pokes (take 2)

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr-store.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.pg-test.ts
@@ -640,7 +640,7 @@ describe('view-syncer/cvr-store', () => {
             "lastActive": 1732320000000,
             "owner": "my-task",
             "replicaVersion": "01",
-            "version": "18w",
+            "version": "18m",
           },
         ]
       `);
@@ -654,7 +654,7 @@ describe('view-syncer/cvr-store', () => {
             Result [
               {
                 "clientGroupID": "my-cvr",
-                "version": "18w",
+                "version": "18m",
               },
             ]
           `);

--- a/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
@@ -931,11 +931,11 @@ describe('view-syncer/cvr', () => {
       {
         "clients": 2,
         "desires": 6,
-        "instances": 2,
+        "instances": 1,
         "queries": 7,
         "rows": 0,
         "rowsDeferred": 0,
-        "statements": 18,
+        "statements": 17,
       }
     `);
     expect(updated).toEqual({
@@ -1615,16 +1615,16 @@ describe('view-syncer/cvr', () => {
       Date.UTC(2024, 3, 23, 1),
     );
     expect(flushed).toMatchInlineSnapshot(`
-        {
-          "clients": 0,
-          "desires": 0,
-          "instances": 2,
-          "queries": 1,
-          "rows": 3,
-          "rowsDeferred": 0,
-          "statements": 5,
-        }
-      `);
+      {
+        "clients": 0,
+        "desires": 0,
+        "instances": 1,
+        "queries": 1,
+        "rows": 3,
+        "rowsDeferred": 0,
+        "statements": 4,
+      }
+    `);
 
     expect(
       await cvrStore.catchupConfigPatches(
@@ -2045,16 +2045,16 @@ describe('view-syncer/cvr', () => {
       Date.UTC(2024, 3, 23, 1),
     );
     expect(flushed).toMatchInlineSnapshot(`
-        {
-          "clients": 0,
-          "desires": 0,
-          "instances": 2,
-          "queries": 1,
-          "rows": 2,
-          "rowsDeferred": 0,
-          "statements": 5,
-        }
-      `);
+      {
+        "clients": 0,
+        "desires": 0,
+        "instances": 1,
+        "queries": 1,
+        "rows": 2,
+        "rowsDeferred": 0,
+        "statements": 4,
+      }
+    `);
 
     expect(
       await cvrStore.catchupConfigPatches(
@@ -2289,11 +2289,11 @@ describe('view-syncer/cvr', () => {
       {
         "clients": 0,
         "desires": 0,
-        "instances": 2,
+        "instances": 1,
         "queries": 1,
         "rows": 0,
         "rowsDeferred": 0,
-        "statements": 4,
+        "statements": 3,
       }
     `);
 
@@ -2612,11 +2612,11 @@ describe('view-syncer/cvr', () => {
       {
         "clients": 0,
         "desires": 0,
-        "instances": 2,
+        "instances": 1,
         "queries": 2,
         "rows": 2,
         "rowsDeferred": 0,
-        "statements": 6,
+        "statements": 5,
       }
     `);
 
@@ -3058,11 +3058,11 @@ describe('view-syncer/cvr', () => {
       {
         "clients": 0,
         "desires": 0,
-        "instances": 2,
+        "instances": 1,
         "queries": 1,
         "rows": 2,
         "rowsDeferred": 0,
-        "statements": 5,
+        "statements": 4,
       }
     `);
 
@@ -3917,11 +3917,11 @@ describe('view-syncer/cvr', () => {
       {
         "clients": 0,
         "desires": 0,
-        "instances": 2,
+        "instances": 1,
         "queries": 0,
         "rows": 6,
         "rowsDeferred": 0,
-        "statements": 6,
+        "statements": 5,
       }
     `);
 
@@ -4145,11 +4145,11 @@ describe('view-syncer/cvr', () => {
       {
         "clients": 0,
         "desires": 0,
-        "instances": 2,
+        "instances": 1,
         "queries": 0,
         "rows": 1,
         "rowsDeferred": 0,
-        "statements": 4,
+        "statements": 3,
       }
     `);
 
@@ -4354,22 +4354,12 @@ describe('view-syncer/cvr', () => {
     ] satisfies PatchToVersion[]);
 
     // Same last active day (no index change), but different hour.
-    const {cvr: updated, flushed} = await updater.flush(
+    const {flushed} = await updater.flush(
       lc,
       LAST_CONNECT,
       Date.UTC(2024, 3, 23, 1),
     );
-    expect(flushed).toMatchInlineSnapshot(`
-      {
-        "clients": 0,
-        "desires": 0,
-        "instances": 2,
-        "queries": 0,
-        "rows": 0,
-        "rowsDeferred": 0,
-        "statements": 3,
-      }
-    `);
+    expect(flushed).toBe(false);
 
     // Verify round tripping.
     const cvrStore2 = new CVRStore(
@@ -4381,19 +4371,15 @@ describe('view-syncer/cvr', () => {
       ON_FAILURE,
     );
     const reloaded = await cvrStore2.load(lc, LAST_CONNECT);
-    expect(reloaded).toEqual(updated);
+    expect(reloaded).toEqual(cvr);
 
     await expectState(db, {
       ...initialState,
       instances: [
         {
-          clientGroupID: 'abc123',
-          version: '1ba',
-          replicaVersion: '120',
-          lastActive: Date.UTC(2024, 3, 23, 1),
+          ...initialState.instances[0],
           owner: 'my-task',
           grantedAt: 1709251200000,
-          clientSchema: null,
         },
       ],
     });
@@ -5188,11 +5174,11 @@ describe('view-syncer/cvr', () => {
       {
         "clients": 1,
         "desires": 1,
-        "instances": 2,
+        "instances": 1,
         "queries": 1,
         "rows": 0,
         "rowsDeferred": 0,
-        "statements": 6,
+        "statements": 5,
       }
     `);
 

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -106,7 +106,6 @@ export class CVRUpdater {
   protected _setVersion(version: CVRVersion) {
     assert(cmpVersions(this._cvr.version, version) < 0);
     this._cvr.version = version;
-    this._cvrStore.putInstance(this._cvr);
     return version;
   }
 
@@ -132,11 +131,11 @@ export class CVRUpdater {
   }> {
     const start = Date.now();
 
+    this._cvr.lastActive = lastActive;
     const flushed = await this._cvrStore.flush(
       this._orig.version,
-      this._cvr.version,
+      this._cvr,
       lastConnectTime,
-      lastActive,
     );
 
     if (!flushed) {
@@ -146,7 +145,6 @@ export class CVRUpdater {
       `flushed cvr@${versionString(this._cvr.version)} ` +
         `${JSON.stringify(flushed)} in (${Date.now() - start} ms)`,
     );
-    this._cvr.lastActive = lastActive;
     return {cvr: this._cvr, flushed};
   }
 }

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -1953,60 +1953,6 @@ describe('view-syncer/service', () => {
       },
     ]);
 
-    expect(await nextPoke(client)).toMatchInlineSnapshot(`
-      [
-        [
-          "pokeStart",
-          {
-            "baseCookie": null,
-            "pokeID": "00:01",
-          },
-        ],
-        [
-          "pokePart",
-          {
-            "desiredQueriesPatches": {
-              "foo": [
-                {
-                  "ast": {
-                    "orderBy": [],
-                    "table": "issues",
-                    "where": {
-                      "left": {
-                        "name": "id",
-                        "type": "column",
-                      },
-                      "op": "IN",
-                      "right": {
-                        "type": "literal",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                      "type": "simple",
-                    },
-                  },
-                  "hash": "query-hash1",
-                  "op": "put",
-                },
-              ],
-            },
-            "pokeID": "00:01",
-          },
-        ],
-        [
-          "pokeEnd",
-          {
-            "cookie": "00:01",
-            "pokeID": "00:01",
-          },
-        ],
-      ]
-    `);
-
     // Make sure it's the SchemaVersionNotSupported error that gets
     // propagated, and not any error related to the bad query.
     const dequeuePromise = nextPoke(client);

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -1953,6 +1953,60 @@ describe('view-syncer/service', () => {
       },
     ]);
 
+    expect(await nextPoke(client)).toMatchInlineSnapshot(`
+      [
+        [
+          "pokeStart",
+          {
+            "baseCookie": null,
+            "pokeID": "00:01",
+          },
+        ],
+        [
+          "pokePart",
+          {
+            "desiredQueriesPatches": {
+              "foo": [
+                {
+                  "ast": {
+                    "orderBy": [],
+                    "table": "issues",
+                    "where": {
+                      "left": {
+                        "name": "id",
+                        "type": "column",
+                      },
+                      "op": "IN",
+                      "right": {
+                        "type": "literal",
+                        "value": [
+                          "1",
+                          "2",
+                          "3",
+                          "4",
+                        ],
+                      },
+                      "type": "simple",
+                    },
+                  },
+                  "hash": "query-hash1",
+                  "op": "put",
+                },
+              ],
+            },
+            "pokeID": "00:01",
+          },
+        ],
+        [
+          "pokeEnd",
+          {
+            "cookie": "00:01",
+            "pokeID": "00:01",
+          },
+        ],
+      ]
+    `);
+
     // Make sure it's the SchemaVersionNotSupported error that gets
     // propagated, and not any error related to the bad query.
     const dequeuePromise = nextPoke(client);
@@ -2066,6 +2120,7 @@ describe('view-syncer/service', () => {
       }),
     );
     stateChanges.push({state: 'version-ready'});
+    await expectNoPokes(client);
 
     // Then, a relevant change should bump the client from '01' directly to '123'.
     replicator.processTransaction(

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -871,17 +871,6 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       } else {
         await this.#catchupClients(lc, cvr);
       }
-
-      // If CVR was non-empty, then the CVR, database, and all clients
-      // should now be at the same version.
-      if (serverQueries.length > 0) {
-        const cvrVersion = must(this.#cvr).version;
-        const dbVersion = this.#pipelines.currentVersion();
-        assert(
-          cvrVersion.stateVersion === dbVersion,
-          `CVR@${versionString(cvrVersion)}" does not match DB@${dbVersion}`,
-        );
-      }
     });
   }
 


### PR DESCRIPTION
This builds on (and completes) the intent of #3736, which is to avoid flushing the CVR and sending pokes to clients for which an advancement did not result in any material changes.

The hole in the logic of the original PR was that an advancement is associated with a new version, and that version was eagerly set in the CVRUpdater, thus counting as a "material change" and bypassing the flush-skipping logic. The unit test also verified this incompletely by not properly waiting for the no-op change to propagate to the replica and view-syncer before committing the affecting change.

In this fix, the CVR update / put is delayed until checking for material changes (i.e. to the rows or query tables), correctly implementing the intent of the first PR. The test is also corrected to verify that the no empty pokes are sent.

User report: https://discord.com/channels/830183651022471199/1356104289184907334/1356354680518611208