### PR TITLE
chore(zero-cache): fix flaky test

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -1953,11 +1953,19 @@ describe('view-syncer/service', () => {
       },
     ]);
 
+    let err;
+    try {
+      // Depending on the ordering of events, the error can happen on
+      // the first or second poke.
+      await nextPoke(client);
+      await nextPoke(client);
+    } catch (e) {
+      err = e;
+    }
     // Make sure it's the SchemaVersionNotSupported error that gets
     // propagated, and not any error related to the bad query.
-    const dequeuePromise = nextPoke(client);
-    await expect(dequeuePromise).rejects.toBeInstanceOf(ErrorForClient);
-    await expect(dequeuePromise).rejects.toHaveProperty('errorBody', {
+    expect(err).toBeInstanceOf(ErrorForClient);
+    expect((err as ErrorForClient).errorBody).toEqual({
       kind: ErrorKind.SchemaVersionNotSupported,
       message:
         'Schema version 1 is not in range of supported schema versions [2, 3].',


### PR DESCRIPTION
Fix a test that verifies an error condition that can happen in either of two pokes, depending on the order in which things get processed in the view-syncer.