### PR TITLE
feat(zero-cache): improve replication performance for schema changes

### DIFF
--- a/packages/zero-cache/src/services/replicator/change-processor.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.test.ts
@@ -899,7 +899,7 @@ describe('replicator/incremental-sync', () => {
             stateVersion: '0e',
             table: 'foo',
             op: 'r',
-            rowKey: null,
+            rowKey: '',
           },
           {
             stateVersion: '0e',
@@ -985,13 +985,13 @@ describe('replicator/incremental-sync', () => {
             stateVersion: '0e',
             table: 'bar',
             op: 'r',
-            rowKey: null,
+            rowKey: '',
           },
           {
             stateVersion: '0e',
             table: 'foo',
             op: 'r',
-            rowKey: null,
+            rowKey: '',
           },
           {
             stateVersion: '0e',
@@ -1104,7 +1104,7 @@ describe('replicator/incremental-sync', () => {
             stateVersion: '0e',
             table: 'foo',
             op: 'r',
-            rowKey: null,
+            rowKey: '',
           },
           {
             stateVersion: '0e',
@@ -1185,7 +1185,7 @@ describe('replicator/incremental-sync', () => {
             stateVersion: '0e',
             table: 'foo',
             op: 'r',
-            rowKey: null,
+            rowKey: '',
           },
           {
             stateVersion: '0e',
@@ -1253,7 +1253,7 @@ describe('replicator/incremental-sync', () => {
             stateVersion: '0e',
             table: 'foo',
             op: 'r',
-            rowKey: null,
+            rowKey: '',
           },
           {
             stateVersion: '0e',
@@ -1335,7 +1335,7 @@ describe('replicator/incremental-sync', () => {
             stateVersion: '0e',
             table: 'foo',
             op: 'r',
-            rowKey: null,
+            rowKey: '',
           },
           {
             stateVersion: '0e',
@@ -1420,7 +1420,7 @@ describe('replicator/incremental-sync', () => {
             stateVersion: '0e',
             table: 'foo',
             op: 'r',
-            rowKey: null,
+            rowKey: '',
           },
           {
             stateVersion: '0e',
@@ -1503,7 +1503,7 @@ describe('replicator/incremental-sync', () => {
             stateVersion: '0e',
             table: 'foo',
             op: 'r',
-            rowKey: null,
+            rowKey: '',
           },
           {
             stateVersion: '0e',
@@ -1591,7 +1591,7 @@ describe('replicator/incremental-sync', () => {
             stateVersion: '0e',
             table: 'foo',
             op: 'r',
-            rowKey: null,
+            rowKey: '',
           },
           {
             stateVersion: '0e',
@@ -1675,7 +1675,7 @@ describe('replicator/incremental-sync', () => {
             stateVersion: '0e',
             table: 'foo',
             op: 'r',
-            rowKey: null,
+            rowKey: '',
           },
           {
             stateVersion: '0e',
@@ -1769,7 +1769,7 @@ describe('replicator/incremental-sync', () => {
             stateVersion: '0e',
             table: 'foo',
             op: 'r',
-            rowKey: null,
+            rowKey: '',
           },
           {
             stateVersion: '0e',
@@ -1836,7 +1836,7 @@ describe('replicator/incremental-sync', () => {
             stateVersion: '0e',
             table: 'foo',
             op: 'r',
-            rowKey: null,
+            rowKey: '',
           },
         ],
       },
@@ -1870,7 +1870,7 @@ describe('replicator/incremental-sync', () => {
             stateVersion: '0e',
             table: 'foo',
             op: 'r',
-            rowKey: null,
+            rowKey: '',
           },
         ],
       },
@@ -1972,7 +1972,7 @@ describe('replicator/incremental-sync', () => {
             stateVersion: '07',
             table: 'transaction',
             op: 'r',
-            rowKey: null,
+            rowKey: '',
           },
         ],
       },

--- a/packages/zero-cache/src/services/replicator/schema/change-log.test.ts
+++ b/packages/zero-cache/src/services/replicator/schema/change-log.test.ts
@@ -2,7 +2,7 @@ import {beforeEach, describe, expect, test} from 'vitest';
 import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
 import {Database} from '../../../../../zqlite/src/db.ts';
 import {StatementRunner} from '../../../db/statements.ts';
-import {expectTables} from '../../../test/lite.ts';
+import {expectTableExact} from '../../../test/lite.ts';
 import {
   initChangeLog,
   logDeleteOp,
@@ -20,6 +20,18 @@ describe('replicator/schema/change-log', () => {
     db = new StatementRunner(conn);
   });
 
+  function expectChangeLog(...entries: unknown[]) {
+    expectTableExact(
+      db.db,
+      '_zero.changeLog',
+      entries,
+      'number',
+      'stateVersion',
+      'table',
+      'rowKey',
+    );
+  }
+
   test('replicator/schema/change-log', () => {
     expect(logSetOp(db, '01', 'foo', {a: 1, b: 2})).toMatchInlineSnapshot(
       `"{"a":1,"b":2}"`,
@@ -34,27 +46,23 @@ describe('replicator/schema/change-log', () => {
       `"{"a":2,"b":3}"`,
     );
 
-    expectTables(db.db, {
-      ['_zero.changeLog']: [
-        {stateVersion: '01', table: 'bar', rowKey: '{"a":1,"b":2}', op: 's'},
-        {stateVersion: '01', table: 'bar', rowKey: '{"a":2,"b":3}', op: 's'},
-        {stateVersion: '01', table: 'foo', rowKey: '{"a":1,"b":2}', op: 's'},
-        {stateVersion: '01', table: 'foo', rowKey: '{"a":2,"b":3}', op: 's'},
-      ],
-    });
+    expectChangeLog(
+      {stateVersion: '01', table: 'bar', rowKey: '{"a":1,"b":2}', op: 's'},
+      {stateVersion: '01', table: 'bar', rowKey: '{"a":2,"b":3}', op: 's'},
+      {stateVersion: '01', table: 'foo', rowKey: '{"a":1,"b":2}', op: 's'},
+      {stateVersion: '01', table: 'foo', rowKey: '{"a":2,"b":3}', op: 's'},
+    );
 
     expect(logDeleteOp(db, '02', 'bar', {b: 3, a: 2})).toMatchInlineSnapshot(
       `"{"a":2,"b":3}"`,
     );
 
-    expectTables(db.db, {
-      ['_zero.changeLog']: [
-        {stateVersion: '01', table: 'bar', rowKey: '{"a":1,"b":2}', op: 's'},
-        {stateVersion: '01', table: 'foo', rowKey: '{"a":1,"b":2}', op: 's'},
-        {stateVersion: '01', table: 'foo', rowKey: '{"a":2,"b":3}', op: 's'},
-        {stateVersion: '02', table: 'bar', rowKey: '{"a":2,"b":3}', op: 'd'},
-      ],
-    });
+    expectChangeLog(
+      {stateVersion: '01', table: 'bar', rowKey: '{"a":1,"b":2}', op: 's'},
+      {stateVersion: '01', table: 'foo', rowKey: '{"a":1,"b":2}', op: 's'},
+      {stateVersion: '01', table: 'foo', rowKey: '{"a":2,"b":3}', op: 's'},
+      {stateVersion: '02', table: 'bar', rowKey: '{"a":2,"b":3}', op: 'd'},
+    );
 
     expect(logDeleteOp(db, '03', 'foo', {a: 2, b: 3})).toMatchInlineSnapshot(
       `"{"a":2,"b":3}"`,
@@ -67,14 +75,13 @@ describe('replicator/schema/change-log', () => {
       `"{"a":8,"b":9}"`,
     );
 
-    expectTables(db.db, {
-      ['_zero.changeLog']: [
-        {stateVersion: '01', table: 'bar', rowKey: '{"a":1,"b":2}', op: 's'},
-        {stateVersion: '02', table: 'bar', rowKey: '{"a":2,"b":3}', op: 'd'},
-        {stateVersion: '03', table: 'foo', rowKey: '', op: 't'},
-        {stateVersion: '03', table: 'foo', rowKey: '{"a":8,"b":9}', op: 's'},
-      ],
-    });
+    expectChangeLog(
+      {stateVersion: '01', table: 'bar', rowKey: '{"a":1,"b":2}', op: 's'},
+      {stateVersion: '01', table: 'foo', rowKey: '{"a":1,"b":2}', op: 's'},
+      {stateVersion: '02', table: 'bar', rowKey: '{"a":2,"b":3}', op: 'd'},
+      {stateVersion: '03', table: 'foo', rowKey: '', op: 't'},
+      {stateVersion: '03', table: 'foo', rowKey: '{"a":8,"b":9}', op: 's'},
+    );
 
     expect(logDeleteOp(db, '04', 'bar', {a: 1, b: 2})).toMatchInlineSnapshot(
       `"{"a":1,"b":2}"`,
@@ -87,46 +94,41 @@ describe('replicator/schema/change-log', () => {
       `"{"a":7,"b":9}"`,
     );
 
-    expectTables(db.db, {
-      ['_zero.changeLog']: [
-        {stateVersion: '03', table: 'foo', rowKey: '', op: 't'},
-        {stateVersion: '03', table: 'foo', rowKey: '{"a":8,"b":9}', op: 's'},
-        {stateVersion: '04', table: 'bar', rowKey: null, op: 'r'},
-        {stateVersion: '04', table: 'bar', rowKey: '{"a":7,"b":9}', op: 's'},
-      ],
-    });
+    expectChangeLog(
+      {stateVersion: '01', table: 'foo', rowKey: '{"a":1,"b":2}', op: 's'},
+      {stateVersion: '03', table: 'foo', rowKey: '', op: 't'},
+      {stateVersion: '03', table: 'foo', rowKey: '{"a":8,"b":9}', op: 's'},
+      {stateVersion: '04', table: 'bar', rowKey: '', op: 'r'},
+      {stateVersion: '04', table: 'bar', rowKey: '{"a":7,"b":9}', op: 's'},
+    );
 
-    // Test that table-wide ops preserve each other and reset always sort before truncates.
+    // The last table-wide op is the only one that persists.
     logTruncateOp(db, '05', 'baz');
     logResetOp(db, '05', 'baz');
     logResetOp(db, '05', 'baz');
     logResetOp(db, '05', 'baz');
 
-    expectTables(db.db, {
-      ['_zero.changeLog']: [
-        {stateVersion: '03', table: 'foo', rowKey: '', op: 't'},
-        {stateVersion: '03', table: 'foo', rowKey: '{"a":8,"b":9}', op: 's'},
-        {stateVersion: '04', table: 'bar', rowKey: null, op: 'r'},
-        {stateVersion: '04', table: 'bar', rowKey: '{"a":7,"b":9}', op: 's'},
-        {stateVersion: '05', table: 'baz', rowKey: null, op: 'r'},
-        {stateVersion: '05', table: 'baz', rowKey: '', op: 't'},
-      ],
-    });
+    expectChangeLog(
+      {stateVersion: '01', table: 'foo', rowKey: '{"a":1,"b":2}', op: 's'},
+      {stateVersion: '03', table: 'foo', rowKey: '', op: 't'},
+      {stateVersion: '03', table: 'foo', rowKey: '{"a":8,"b":9}', op: 's'},
+      {stateVersion: '04', table: 'bar', rowKey: '', op: 'r'},
+      {stateVersion: '04', table: 'bar', rowKey: '{"a":7,"b":9}', op: 's'},
+      {stateVersion: '05', table: 'baz', rowKey: '', op: 'r'},
+    );
 
     logResetOp(db, '06', 'baz');
     logResetOp(db, '06', 'baz');
     logTruncateOp(db, '06', 'baz');
     logTruncateOp(db, '06', 'baz');
 
-    expectTables(db.db, {
-      ['_zero.changeLog']: [
-        {stateVersion: '03', table: 'foo', rowKey: '', op: 't'},
-        {stateVersion: '03', table: 'foo', rowKey: '{"a":8,"b":9}', op: 's'},
-        {stateVersion: '04', table: 'bar', rowKey: null, op: 'r'},
-        {stateVersion: '04', table: 'bar', rowKey: '{"a":7,"b":9}', op: 's'},
-        {stateVersion: '06', table: 'baz', rowKey: null, op: 'r'},
-        {stateVersion: '06', table: 'baz', rowKey: '', op: 't'},
-      ],
-    });
+    expectChangeLog(
+      {stateVersion: '01', table: 'foo', rowKey: '{"a":1,"b":2}', op: 's'},
+      {stateVersion: '03', table: 'foo', rowKey: '', op: 't'},
+      {stateVersion: '03', table: 'foo', rowKey: '{"a":8,"b":9}', op: 's'},
+      {stateVersion: '04', table: 'bar', rowKey: '', op: 'r'},
+      {stateVersion: '04', table: 'bar', rowKey: '{"a":7,"b":9}', op: 's'},
+      {stateVersion: '06', table: 'baz', rowKey: '', op: 't'},
+    );
   });
 });

--- a/packages/zero-cache/src/test/lite.ts
+++ b/packages/zero-cache/src/test/lite.ts
@@ -45,6 +45,21 @@ export function initDB(
   });
 }
 
+export function expectTableExact(
+  db: Database,
+  table: string,
+  expectedRows: unknown[],
+  numberType: 'number' | 'bigint' = 'number',
+  ...orderBy: string[]
+) {
+  const ordering = orderBy.map(c => id(c)).join(', ');
+  const actual = db
+    .prepare(`SELECT * FROM ${id(table)} ORDER BY ${ordering}`)
+    .safeIntegers(numberType === 'bigint')
+    .all();
+  expect(actual).toEqual(expectedRows);
+}
+
 export function expectTables(
   db: Database,
   tables?: Record<string, unknown[]>,

--- a/packages/zero-cache/src/workers/replicator.ts
+++ b/packages/zero-cache/src/workers/replicator.ts
@@ -81,7 +81,7 @@ async function connect(
       // hydration), so it is fine for it to be empty at startup.
       replica.prepare('DELETE FROM "_zero.changeLog"').run();
       const t1 = performance.now();
-      lc.info?.(`Cleared _zero.changeeLog (${t1 - t0} ms)`);
+      lc.info?.(`Cleared _zero.changeLog (${t1 - t0} ms)`);
       replica.exec('VACUUM');
       recordEvent(replica, 'vacuum');
       replica.unsafeMode(false);

--- a/packages/zero-cache/src/workers/replicator.ts
+++ b/packages/zero-cache/src/workers/replicator.ts
@@ -38,7 +38,6 @@ async function connect(
   mode: ReplicaFileMode,
 ): Promise<Database> {
   const replica = new Database(lc, file);
-  const start = Date.now();
 
   // Perform any upgrades to the replica in case the backup is an
   // earlier version.
@@ -73,13 +72,21 @@ async function connect(
     const millisSinceLastEvent =
       Date.now() - (events.at(-1)?.timestamp.getTime() ?? 0);
     if (millisSinceLastEvent / MILLIS_PER_HOUR > vacuumIntervalHours) {
-      lc.info?.(`Performing maintenance VACUUM on ${file}`);
+      lc.info?.(`Performing maintenance cleanup on ${file}`);
+      const t0 = performance.now();
       replica.unsafeMode(true);
       replica.pragma('journal_mode = OFF');
+      // Clear the changeLog to reclaim as much space as possible. The
+      // changeLog is only used for IVM advancements (i.e. from an initial
+      // hydration), so it is fine for it to be empty at startup.
+      replica.prepare('DELETE FROM "_zero.changeLog"').run();
+      const t1 = performance.now();
+      lc.info?.(`Cleared _zero.changeeLog (${t1 - t0} ms)`);
       replica.exec('VACUUM');
       recordEvent(replica, 'vacuum');
       replica.unsafeMode(false);
-      lc.info?.(`VACUUM completed (${Date.now() - start} ms)`);
+      const t2 = performance.now();
+      lc.info?.(`VACUUM completed (${t2 - t1} ms)`);
     }
   }
 
@@ -92,6 +99,10 @@ async function connect(
   replica.pragma('busy_timeout = 30000');
 
   replica.pragma('optimize = 0x10002');
+  // Cap the running time of `PRAGMA optimize` calls that happen
+  // after replicating schema changes. 1000 is the limit recommended
+  // in https://sqlite.org/lang_analyze.html#approx
+  replica.pragma('analysis_limit = 1000');
   lc.info?.(`optimized ${file}`);
   return replica;
 }


### PR DESCRIPTION
Removes `O(table-size)` change log operations that were previously used to save space after a table-wide operation, such as truncating a table or replicating a schema change.

For schema changes over large tables, this ends up in a lot of SQLite I/O operations (i.e. `O(table-size)`) that can delay subsequent replication processing for many minutes, which on balance is not worth the space savings.

With this change, the changeLog cleanup is removed from the critical replication path, and instead moved to the maintenance vacuum task which happens at startup if configured, allowing the operation to be performed, if desired, without affecting availability.  

User report: https://discord.com/channels/830183651022471199/1354595802332401845/1356307016196296744