### PR TITLE
fix(zql): When using one in the relation we should add a limit 1

### DIFF
--- a/packages/zero-schema/src/table-schema.ts
+++ b/packages/zero-schema/src/table-schema.ts
@@ -114,16 +114,14 @@ export function atLeastOne<T>(arr: readonly T[]): AtLeastOne<T> {
   return arr as AtLeastOne<T>;
 }
 
-export function isOneHop(r: Relationship) {
+export function isOneHop(r: Relationship): r is readonly [Connection] {
   return r.length === 1;
 }
 
-export function isTwoHop(r: Relationship) {
+export function isTwoHop(
+  r: Relationship,
+): r is readonly [Connection, Connection] {
   return r.length === 2;
-}
-
-export function isManyHop(r: Relationship) {
-  return !isOneHop(r);
 }
 
 export type Opaque<BaseType, BrandType = unknown> = BaseType & {

--- a/packages/zero-schema/vitest.config.ts
+++ b/packages/zero-schema/vitest.config.ts
@@ -1,0 +1,13 @@
+import {defineConfig, mergeConfig} from 'vitest/config';
+import config from '../shared/src/tool/vitest-config.ts';
+
+export default mergeConfig(
+  config,
+  defineConfig({
+    test: {
+      browser: {
+        enabled: false,
+      },
+    },
+  }),
+);

--- a/packages/zql/src/query/query-impl.ast.test.ts
+++ b/packages/zql/src/query/query-impl.ast.test.ts
@@ -195,6 +195,7 @@ describe('building the AST', () => {
             },
             "subquery": {
               "alias": "owner",
+              "limit": 1,
               "orderBy": [
                 [
                   "id",
@@ -291,6 +292,7 @@ describe('building the AST', () => {
             },
             "subquery": {
               "alias": "owner",
+              "limit": 1,
               "orderBy": [
                 [
                   "id",
@@ -401,6 +403,7 @@ describe('building the AST', () => {
             },
             "subquery": {
               "alias": "owner",
+              "limit": 1,
               "orderBy": [
                 [
                   "id",
@@ -2052,5 +2055,28 @@ describe('exists', () => {
         },
       }
     `);
+  });
+});
+
+test('one in schema should imply limit 1 in the ast', () => {
+  const issueQuery = newQuery(mockDelegate, schema, 'issue');
+  const q1 = issueQuery.related('owner');
+  const q2 = issueQuery.related('comments');
+
+  expect(ast(q1)).toMatchObject({
+    table: 'issue',
+    related: [
+      {
+        subquery: {limit: 1, table: 'user'},
+      },
+    ],
+  });
+  expect(ast(q2)).toMatchObject({
+    table: 'issue',
+    related: [
+      {
+        subquery: expect.toSatisfy(sq => !('limit' in sq)),
+      },
+    ],
   });
 });

--- a/packages/zql/src/query/query-impl.query-kitchen-sink.test.ts
+++ b/packages/zql/src/query/query-impl.query-kitchen-sink.test.ts
@@ -358,6 +358,7 @@ describe('kitchen sink query', () => {
                 },
                 "subquery": {
                   "alias": "owner",
+                  "limit": 1,
                   "orderBy": [
                     [
                       "id",

--- a/packages/zql/src/query/query-impl.query.test.ts
+++ b/packages/zql/src/query/query-impl.query.test.ts
@@ -711,6 +711,57 @@ describe('joins and filters', () => {
       ]
     `);
   });
+
+  test('schema applied one but really many', async () => {
+    const queryDelegate = new QueryDelegateImpl();
+    addData(queryDelegate);
+
+    const query = newQuery(queryDelegate, schema, 'issue').related(
+      'oneComment',
+    );
+    const data = await query.run();
+    expect(data).toMatchInlineSnapshot(`
+      [
+        {
+          "closed": false,
+          "createdAt": 1,
+          "description": "description 1",
+          "id": "0001",
+          "oneComment": {
+            "authorId": "0001",
+            "createdAt": 1,
+            "id": "0001",
+            "issueId": "0001",
+            "text": "comment 1",
+            Symbol(rc): 1,
+          },
+          "ownerId": "0001",
+          "title": "issue 1",
+          Symbol(rc): 1,
+        },
+        {
+          "closed": false,
+          "createdAt": 2,
+          "description": "description 2",
+          "id": "0002",
+          "oneComment": undefined,
+          "ownerId": "0002",
+          "title": "issue 2",
+          Symbol(rc): 1,
+        },
+        {
+          "closed": false,
+          "createdAt": 3,
+          "description": "description 3",
+          "id": "0003",
+          "oneComment": undefined,
+          "ownerId": null,
+          "title": "issue 3",
+          Symbol(rc): 1,
+        },
+      ]
+    `);
+  });
 });
 
 test('limit -1', () => {

--- a/packages/zql/src/query/test/test-schemas.ts
+++ b/packages/zql/src/query/test/test-schemas.ts
@@ -79,6 +79,11 @@ const issueRelationships = relationships(issue, ({one, many}) => ({
     destField: ['issueId'],
     destSchema: comment,
   }),
+  oneComment: one({
+    sourceField: ['id'],
+    destField: ['issueId'],
+    destSchema: comment,
+  }),
   labels: many(
     {
       sourceField: ['id'],


### PR DESCRIPTION
This adds a limit 1 to the query when using one in the relation. This is fixes an issue where we end up sending multiple rows down where only one is expected.