### PR TITLE
fix(zql): fix potentially undefined format

### DIFF
--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -140,7 +140,7 @@ export abstract class AbstractQuery<
     schema: TSchema,
     table: TTable,
     ast: AST,
-    format: Format | undefined,
+    format: Format,
   ): AbstractQuery<TSchema, TTable, TReturn>;
 
   one(): Query<TSchema, TTable, TReturn | undefined> {
@@ -417,7 +417,7 @@ export abstract class AbstractQuery<
             table: destSchema,
             alias: `${SUBQ_PREFIX}${relationship}`,
           },
-          undefined,
+          defaultFormat,
         ),
       ) as unknown as QueryImpl<any, any>;
       return {
@@ -453,7 +453,7 @@ export abstract class AbstractQuery<
             table: destSchema,
             alias: `${SUBQ_PREFIX}${relationship}`,
           },
-          undefined,
+          defaultFormat,
         ),
       );
 


### PR DESCRIPTION
Bit unclear on why TypeScript didn't catch that the implementations of this abstract method did not except undefined for Format but the abstract signature did. 

Regression was introduced here https://github.com/rocicorp/mono/commit/19e5a333e8e43e4e50e8b46336939013d21c322b