### PR TITLE
chore(zero-cache): reduce flakiness in test

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/change-source.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.pg-test.ts
@@ -880,17 +880,17 @@ describe('change-source/pg', {timeout: 30000}, () => {
 
     changes2.cancel();
 
+    // Verify that the replica rows have been cleaned up.
+    const replicas2 = await upstream.unsafe(`
+      SELECT slot FROM "${APP_ID}_${SHARD_NUM}".replicas
+    `);
+    expect(replicas2).toEqual(replicas1.slice(1));
+
     // Verify that only one slot remains
     const slots2 = await upstream<{slot: string}[]>`
       SELECT slot_name as slot FROM pg_replication_slots
     `.values();
     expect(slots2).toEqual(slots1.slice(1));
-
-    // Verify that the replica rows have also been cleaned up.
-    const replicas2 = await upstream.unsafe(`
-      SELECT slot FROM "${APP_ID}_${SHARD_NUM}".replicas
-    `);
-    expect(replicas2).toEqual(replicas1.slice(1));
 
     anotherReplicaFile.delete();
   });

--- a/packages/zero-cache/src/services/change-source/pg/change-source.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.pg-test.ts
@@ -886,7 +886,9 @@ describe('change-source/pg', {timeout: 30000}, () => {
     `);
     expect(replicas2).toEqual(replicas1.slice(1));
 
-    // Verify that only one slot remains
+    // Verify that only one slot remains. (Add a sleep to reduce
+    // flakiness because the drop is non-transactional.)
+    await sleep(100);
     const slots2 = await upstream<{slot: string}[]>`
       SELECT slot_name as slot FROM pg_replication_slots
     `.values();


### PR DESCRIPTION
The dropping of a replication slot is non-transactional, and sometimes it takes a bit for pg to update the `pg_replication_slots` table.

Swap the order of the PG calls and add a `sleep()` to reduce false positive failures. 