### PR TITLE
feat(zero-cache): send pings to check and signal websocket liveness

### DIFF
--- a/packages/zero-cache/src/types/ws.ts
+++ b/packages/zero-cache/src/types/ws.ts
@@ -22,3 +22,59 @@ export function closeWithError(
   // https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close#reason
   ws.close(code, elide(errMsg, 123));
 }
+
+export function sendPingsForLiveness(
+  lc: LogContext,
+  ws: WebSocket,
+  intervalMs: number,
+) {
+  let alive = true;
+  ws.on('pong', () => (alive = true));
+
+  let heartbeatTimer: NodeJS.Timeout | undefined;
+  function startHeartBeats() {
+    heartbeatTimer = setInterval(() => {
+      if (!alive) {
+        lc.warn?.(
+          `socket@${ws.url} did not respond to heartbeat. Terminating...`,
+        );
+        ws.terminate();
+        return;
+      }
+
+      alive = false;
+      ws.ping();
+    }, intervalMs);
+  }
+
+  if (ws.readyState === ws.CONNECTING) {
+    ws.on('open', () => startHeartBeats());
+  } else if (ws.readyState === ws.OPEN) {
+    startHeartBeats();
+  }
+
+  ws.once('close', () => clearInterval(heartbeatTimer));
+}
+
+export function expectPingsForLiveness(
+  lc: LogContext,
+  ws: WebSocket,
+  intervalMs: number,
+  timeoutBufferMs = 3_000,
+) {
+  let missedPingTimer: NodeJS.Timeout | undefined;
+
+  function expectNextPing() {
+    clearTimeout(missedPingTimer);
+
+    missedPingTimer = setTimeout(() => {
+      lc.warn?.(`socket@${ws.url} did not send heartbeat. Terminating...`);
+      ws.terminate();
+    }, intervalMs + timeoutBufferMs);
+  }
+
+  ws.on('ping', expectNextPing);
+  ws.on('close', () => clearTimeout(missedPingTimer));
+
+  expectNextPing();
+}

--- a/packages/zero-cache/src/types/ws.ts
+++ b/packages/zero-cache/src/types/ws.ts
@@ -48,7 +48,7 @@ export function sendPingsForLiveness(
   }
 
   if (ws.readyState === ws.CONNECTING) {
-    ws.on('open', () => startHeartBeats());
+    ws.once('open', () => startHeartBeats());
   } else if (ws.readyState === ws.OPEN) {
     startHeartBeats();
   }
@@ -74,7 +74,7 @@ export function expectPingsForLiveness(
   }
 
   ws.on('ping', expectNextPing);
-  ws.on('close', () => clearTimeout(missedPingTimer));
+  ws.once('close', () => clearTimeout(missedPingTimer));
 
   expectNextPing();
 }


### PR DESCRIPTION
Send pings at 30 second intervals to keep websockets alive in the face of connection idle timeouts (which defaults to 60 seconds on AWS).

Also use them to determine liveness, closing connections if not.

This is used both for the replicator <-> change-streamer connection and for custom change sources.

User report: https://discord.com/channels/830183651022471199/1357355649905987635/1357392133815931122