### PR TITLE
fix(z2s): return `undefined` for empty result set and `one` format

### DIFF
--- a/packages/z2s/src/collate.pg-test.ts
+++ b/packages/z2s/src/collate.pg-test.ts
@@ -193,7 +193,9 @@ describe('collation behavior', () => {
         (await nodePostgres.query(query, args as JSONValue[])).rows,
     );
   });
-  function t(runPgQuery: (query: string, args: unknown[]) => Promise<unknown>) {
+  function t(
+    runPgQuery: (query: string, args: unknown[]) => Promise<unknown[]>,
+  ) {
     async function testColumn(col: 'name' | 'size' | 'uuid') {
       const itemQuery = newQuery(queryDelegate, schema, 'item');
       const query = itemQuery.orderBy(col, 'asc');
@@ -347,7 +349,7 @@ describe('collation behavior', () => {
 
 async function runAsSQL(
   q: Query<Schema, 'item'>,
-  runPgQuery: (query: string, args: unknown[]) => Promise<unknown>,
+  runPgQuery: (query: string, args: unknown[]) => Promise<unknown[]>,
 ) {
   const c = compile(ast(q), schema.tables, serverSchema);
   const sqlQuery = formatPgInternalConvert(c);

--- a/packages/z2s/src/compiler-bigint.pg-test.ts
+++ b/packages/z2s/src/compiler-bigint.pg-test.ts
@@ -214,7 +214,9 @@ describe('compiling ZQL to SQL', () => {
         (await nodePostgres.query(query, args as JSONValue[])).rows,
     );
   });
-  function t(runPgQuery: (query: string, args: unknown[]) => Promise<unknown>) {
+  function t(
+    runPgQuery: (query: string, args: unknown[]) => Promise<unknown[]>,
+  ) {
     test('All bigints in safe Number range', async () => {
       const query = issueQuery.related('comments').limit(2);
       const c = compile(ast(query), schema.tables, serverSchema);

--- a/packages/z2s/src/compiler.pg-test.ts
+++ b/packages/z2s/src/compiler.pg-test.ts
@@ -236,7 +236,8 @@ afterAll(async () => {
   await nodePostgres.end();
 });
 
-function ast(q: Query<Schema, keyof Schema['tables']>) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function ast(q: Query<Schema, keyof Schema['tables'], any>) {
   return (q as QueryImpl<Schema, keyof Schema['tables']>)[completedAstSymbol];
 }
 
@@ -262,7 +263,9 @@ describe('compiling ZQL to SQL', () => {
         (await nodePostgres.query(query, args as JSONValue[])).rows,
     );
   });
-  function t(runPgQuery: (query: string, args: unknown[]) => Promise<unknown>) {
+  function t(
+    runPgQuery: (query: string, args: unknown[]) => Promise<unknown[]>,
+  ) {
     test('basic where clause', async () => {
       const query = issueQuery.where('title', '=', 'Test Issue 1');
       const c = compile(ast(query), schema.tables, serverSchema);

--- a/packages/z2s/src/compiler.ts
+++ b/packages/z2s/src/compiler.ts
@@ -39,7 +39,7 @@ type Tables = Record<string, TableSchema>;
 const ZQL_RESULT_KEY = 'zql_result';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function extractZqlResult(pgResult: any): JSONValue {
+export function extractZqlResult(pgResult: Array<any>): JSONValue {
   const bigIntJson: BigIntJSONValue = parseBigIntJson(
     pgResult[0][ZQL_RESULT_KEY],
   );

--- a/packages/zero-pg/src/query.pg-test.ts
+++ b/packages/zero-pg/src/query.pg-test.ts
@@ -52,4 +52,16 @@ describe('makeSchemaQuery', () => {
       expect(result).toEqual({id: '1', a: 2, b: 'foo', c: true});
     });
   });
+
+  test('select singular with no results', async () => {
+    await pg.begin(async tx => {
+      const transaciton = new Transaction(tx);
+      const query = queryProvider(
+        transaciton,
+        await getServerSchema(transaciton, schema),
+      );
+      const result = await query.basic.where('id', 'non-existent').one().run();
+      expect(result).toEqual(undefined);
+    });
+  });
 });

--- a/packages/zero-pg/src/query.ts
+++ b/packages/zero-pg/src/query.ts
@@ -122,10 +122,19 @@ export class Z2SQuery<
         ),
       );
     this.#query = sqlQuery;
-    const result = extractZqlResult(
-      await this.#dbTransaction.query(sqlQuery.text, sqlQuery.values),
+    const pgIterableResult = await this.#dbTransaction.query(
+      sqlQuery.text,
+      sqlQuery.values,
     );
-    return result as HumanReadable<TReturn>;
+
+    const pgArrayResult = Array.isArray(pgIterableResult)
+      ? pgIterableResult
+      : [...pgIterableResult];
+    if (pgArrayResult.length === 0 && this.format.singular) {
+      return undefined as unknown as HumanReadable<TReturn>;
+    }
+
+    return extractZqlResult(pgArrayResult) as HumanReadable<TReturn>;
   }
 
   preload(): {


### PR DESCRIPTION
https://bugs.rocicorp.dev/issue/3715