### PR TITLE
feat!(mutators): re-add types to `push-processor`

### DIFF
--- a/apps/zbugs/api/index.ts
+++ b/apps/zbugs/api/index.ts
@@ -11,6 +11,7 @@ import {handlePush} from '../server/push-handler.ts';
 import {must} from '../../../packages/shared/src/must.ts';
 import assert from 'assert';
 import {authDataSchema, type AuthData} from '../shared/auth.ts';
+import type {ReadonlyJSONValue} from '@rocicorp/zero';
 
 declare module 'fastify' {
   interface FastifyInstance {
@@ -110,7 +111,10 @@ fastify.get<{
     );
 });
 
-fastify.post('/api/push', async function (request, reply) {
+fastify.post<{
+  Querystring: Record<string, string>;
+  Body: ReadonlyJSONValue;
+}>('/api/push', async function (request, reply) {
   let {authorization} = request.headers;
   if (authorization !== undefined) {
     assert(authorization.toLowerCase().startsWith('bearer '));

--- a/apps/zbugs/server/push-handler.ts
+++ b/apps/zbugs/server/push-handler.ts
@@ -4,6 +4,7 @@ import {schema} from '../shared/schema.ts';
 import {createServerMutators, type PostCommitTask} from './server-mutators.ts';
 import type {AuthData} from '../shared/auth.ts';
 import {connectionProvider} from '@rocicorp/zero/pg';
+import type {ReadonlyJSONValue} from '@rocicorp/zero';
 
 const processor = new PushProcessor(
   schema,
@@ -12,8 +13,8 @@ const processor = new PushProcessor(
 
 export async function handlePush(
   authData: AuthData | undefined,
-  params: unknown,
-  body: unknown,
+  params: Record<string, string> | URLSearchParams,
+  body: ReadonlyJSONValue,
 ) {
   const postCommitTasks: PostCommitTask[] = [];
   const mutators = createServerMutators(authData, postCommitTasks);

--- a/packages/zero-pg/src/web.test.ts
+++ b/packages/zero-pg/src/web.test.ts
@@ -1,0 +1,82 @@
+import {describe, expect, test, vi} from 'vitest';
+import {PushProcessor} from './web.ts';
+import type {Schema} from '../../zero-schema/src/builder/schema-builder.ts';
+import type {CustomMutatorDefs} from './custom.ts';
+import type {DBConnection, DBTransaction} from '../../zql/src/mutate/custom.ts';
+import {type PushBody} from '../../zero-protocol/src/push.ts';
+import * as v from '../../shared/src/valita.ts';
+
+describe('PushProcessor', () => {
+  const body = {
+    pushVersion: 1,
+    requestID: 'test_request_id',
+    timestamp: 1234567890,
+    schemaVersion: 1,
+    clientGroupID: 'test_client_group',
+    mutations: [],
+  } satisfies PushBody;
+
+  const mockSchema = {
+    tables: {},
+    relationships: {},
+  } satisfies Schema;
+
+  const mockConnectionProvider = vi.fn().mockResolvedValue({
+    transaction: vi.fn().mockImplementation(callback => {
+      const mockTx = {} as DBTransaction<unknown>;
+      return callback(mockTx);
+    }),
+  } as unknown as DBConnection<unknown>);
+
+  // Mock mutators
+  const mockMutators = {} as CustomMutatorDefs<Schema, unknown>;
+
+  test('should accept Record<string, string> as params', async () => {
+    const processor = new PushProcessor(mockSchema, mockConnectionProvider);
+
+    const params: Record<string, string> = {
+      schema: 'test_schema',
+      appID: 'test_client_group',
+    };
+
+    const spy = vi.spyOn(v, 'parse');
+    await processor.process(mockMutators, params, body);
+
+    expect(spy.mock.calls[1][0]).toMatchInlineSnapshot(`
+      {
+        "appID": "test_client_group",
+        "schema": "test_schema",
+      }
+    `);
+  });
+
+  test('should accept URLSearchParams as params', async () => {
+    const processor = new PushProcessor(mockSchema, mockConnectionProvider);
+
+    const urlParams = new URLSearchParams();
+    urlParams.append('schema', 'test_schema');
+    urlParams.append('appID', 'test_client_group');
+
+    const spy = vi.spyOn(v, 'parse');
+    await processor.process(mockMutators, urlParams, body);
+
+    expect(spy.mock.calls[1][0]).toMatchInlineSnapshot(`
+      {
+        "appID": "test_client_group",
+        "schema": "test_schema",
+      }
+    `);
+  });
+
+  test('invalid params throw', async () => {
+    const processor = new PushProcessor(mockSchema, mockConnectionProvider);
+
+    const invalidParams: Record<string, string> = {
+      // Missing schema and clientGroupID
+    };
+
+    await expect(
+      processor.process(mockMutators, invalidParams, body),
+    ).rejects.toThrow('Missing property schema');
+  });
+});


### PR DESCRIPTION
Users do not know what types to provide and keep getting errors about missing properties.

https://bugs.rocicorp.dev/issue/3704?f=1&d=2
https://bugs.rocicorp.dev/issue/3711
https://discord.com/channels/830183651022471199/1357260393176895508/1357835830256734381

While not fully typed (as in, not asking for the exact shape of the query string and body) we at least now specify that the query params need to be a record or a URLSearchParams object. We also specify that the request body must be provided as JSON.