### PR TITLE
feat(zql): make queries thenable

### DIFF
--- a/apps/zbugs/server/notify.ts
+++ b/apps/zbugs/server/notify.ts
@@ -56,7 +56,7 @@ export async function notify(
   assertIsLoggedIn(authData);
 
   const {issueID, kind} = args;
-  const issue = await tx.query.issue.where('id', issueID).one().run();
+  const issue = await tx.query.issue.where('id', issueID).one();
   assert(issue);
 
   if (issue.visibility !== 'public') {
@@ -65,10 +65,7 @@ export async function notify(
   }
 
   const modifierUserID = authData.sub;
-  const modifierUser = await tx.query.user
-    .where('id', modifierUserID)
-    .one()
-    .run();
+  const modifierUser = await tx.query.user.where('id', modifierUserID).one();
   assert(modifierUser);
 
   switch (kind) {
@@ -126,7 +123,7 @@ export async function notify(
 
     case 'add-emoji-to-comment': {
       const {commentID, emoji} = args;
-      const comment = await tx.query.comment.where('id', commentID).one().run();
+      const comment = await tx.query.comment.where('id', commentID).one();
       assert(comment);
       postCommitTasks.push(() =>
         postToDiscord({

--- a/apps/zbugs/server/server-mutators.ts
+++ b/apps/zbugs/server/server-mutators.ts
@@ -120,8 +120,7 @@ export function createServerMutators(
 
         const comment = await tx.query.comment
           .where('id', args.subjectID)
-          .one()
-          .run();
+          .one();
         assert(comment);
         await notify(
           tx,
@@ -163,7 +162,7 @@ export function createServerMutators(
       async edit(tx, {id, body}: {id: string; body: string}) {
         await mutators.comment.edit(tx, {id, body});
 
-        const comment = await tx.query.comment.where('id', id).one().run();
+        const comment = await tx.query.comment.where('id', id).one();
         assert(comment);
 
         await notify(

--- a/apps/zbugs/shared/auth.ts
+++ b/apps/zbugs/shared/auth.ts
@@ -36,7 +36,7 @@ export async function assertIsCreatorOrAdmin(
     return;
   }
   const creatorID = must(
-    await query.where('id', id).one().run(),
+    await query.where('id', id).one(),
     `entity ${id} does not exist`,
   ).creatorID;
   assert(
@@ -50,7 +50,7 @@ export async function assertUserCanSeeIssue(
   authData: AuthData,
   issueID: string,
 ) {
-  const issue = must(await tx.query.issue.where('id', issueID).one().run());
+  const issue = must(await tx.query.issue.where('id', issueID).one());
 
   assert(
     issue.visibility === 'public' ||
@@ -65,9 +65,7 @@ export async function assertUserCanSeeComment(
   authData: AuthData,
   commentID: string,
 ) {
-  const comment = must(
-    await tx.query.comment.where('id', commentID).one().run(),
-  );
+  const comment = must(await tx.query.comment.where('id', commentID).one());
 
   await assertUserCanSeeIssue(tx, authData, comment.issueID);
 }

--- a/packages/analyze-query/src/bin-analyze.ts
+++ b/packages/analyze-query/src/bin-analyze.ts
@@ -154,7 +154,7 @@ async function runQuery(queryString: string): Promise<[number, number]> {
   const q: Query<Schema, string, PullRow<string, Schema>> = f(z);
 
   const start = performance.now();
-  await q.run();
+  await q;
   const end = performance.now();
   return [start, end];
 }

--- a/packages/z2s/src/compiler.pg-test.ts
+++ b/packages/z2s/src/compiler.pg-test.ts
@@ -273,11 +273,7 @@ describe('compiling ZQL to SQL', () => {
       const pgResult = extractZqlResult(
         await runPgQuery(sqlQuery.text, sqlQuery.values),
       );
-      const zqlResult = mapResultToClientNames(
-        await query.run(),
-        schema,
-        'issue',
-      );
+      const zqlResult = mapResultToClientNames(await query, schema, 'issue');
       expect(zqlResult).toEqualPg(pgResult);
       expect(zqlResult).toMatchInlineSnapshot(`
         [
@@ -303,11 +299,7 @@ describe('compiling ZQL to SQL', () => {
       const pgResult = extractZqlResult(
         await runPgQuery(sqlQuery.text, sqlQuery.values),
       );
-      const zqlResult = mapResultToClientNames(
-        await query.run(),
-        schema,
-        'issue',
-      );
+      const zqlResult = mapResultToClientNames(await query, schema, 'issue');
       expect(zqlResult).toEqualPg(pgResult);
       expect(zqlResult).toMatchInlineSnapshot(`
       [
@@ -333,11 +325,7 @@ describe('compiling ZQL to SQL', () => {
       const pgResult = extractZqlResult(
         await runPgQuery(sqlQuery.text, sqlQuery.values),
       );
-      const zqlResult = mapResultToClientNames(
-        await query.run(),
-        schema,
-        'issue',
-      );
+      const zqlResult = mapResultToClientNames(await query, schema, 'issue');
       expect(zqlResult).toEqualPg(pgResult);
       expect(zqlResult).toMatchInlineSnapshot(`[]`);
     });
@@ -350,11 +338,7 @@ describe('compiling ZQL to SQL', () => {
       const pgResult = extractZqlResult(
         await runPgQuery(sqlQuery.text, sqlQuery.values),
       );
-      const zqlResult = mapResultToClientNames(
-        await query.run(),
-        schema,
-        'issue',
-      );
+      const zqlResult = mapResultToClientNames(await query, schema, 'issue');
       expect(zqlResult).toEqualPg(pgResult);
       expect(zqlResult).toMatchInlineSnapshot(`
         [
@@ -394,11 +378,7 @@ describe('compiling ZQL to SQL', () => {
       const pgResult = extractZqlResult(
         await runPgQuery(sqlQuery.text, sqlQuery.values),
       );
-      const zqlResult = mapResultToClientNames(
-        await query.run(),
-        schema,
-        'issue',
-      );
+      const zqlResult = mapResultToClientNames(await query, schema, 'issue');
       expect(zqlResult).toEqualPg(pgResult);
       expect(zqlResult).toMatchInlineSnapshot(`
         [
@@ -455,11 +435,7 @@ describe('compiling ZQL to SQL', () => {
       const pgResult = extractZqlResult(
         await runPgQuery(sqlQuery.text, sqlQuery.values),
       );
-      const zqlResult = mapResultToClientNames(
-        await query.run(),
-        schema,
-        'issue',
-      );
+      const zqlResult = mapResultToClientNames(await query, schema, 'issue');
       expect(zqlResult).toEqualPg(pgResult);
       expect(zqlResult).toMatchInlineSnapshot(`
               [
@@ -547,11 +523,7 @@ describe('compiling ZQL to SQL', () => {
       const pgResult = extractZqlResult(
         await runPgQuery(sqlQuery.text, sqlQuery.values),
       );
-      const zqlResult = mapResultToClientNames(
-        await query.run(),
-        schema,
-        'issue',
-      );
+      const zqlResult = mapResultToClientNames(await query, schema, 'issue');
       expect(zqlResult).toEqualPg(pgResult);
       expect(zqlResult).toMatchInlineSnapshot(`
                         [
@@ -620,11 +592,7 @@ describe('compiling ZQL to SQL', () => {
       const pgResult = extractZqlResult(
         await runPgQuery(sqlQuery.text, sqlQuery.values),
       );
-      const zqlResult = mapResultToClientNames(
-        await query.run(),
-        schema,
-        'issue',
-      );
+      const zqlResult = mapResultToClientNames(await query, schema, 'issue');
       expect(zqlResult).toEqualPg(pgResult);
       expect(zqlResult).toMatchInlineSnapshot(`
         [
@@ -677,11 +645,7 @@ describe('compiling ZQL to SQL', () => {
       const pgResult = extractZqlResult(
         await runPgQuery(sqlQuery.text, sqlQuery.values),
       );
-      const zqlResult = mapResultToClientNames(
-        await query.run(),
-        schema,
-        'issue',
-      );
+      const zqlResult = mapResultToClientNames(await query, schema, 'issue');
       expect(zqlResult).toEqualPg(pgResult);
       expect(zqlResult).toMatchInlineSnapshot(`
         [

--- a/packages/zero-client/src/client/custom.test.ts
+++ b/packages/zero-client/src/client/custom.test.ts
@@ -106,7 +106,7 @@ test('supports mutators without a namespace', async () => {
     createdAt: 1743018138477,
   });
 
-  const issues = await z.query.issue.run();
+  const issues = await z.query.issue;
   expect(issues[0].title).toEqual('no-namespace');
 });
 
@@ -173,15 +173,15 @@ test('custom mutators write to the local store', async () => {
     createdAt: 1743018138477,
   });
 
-  let issues = await z.query.issue.run();
+  let issues = await z.query.issue;
   expect(issues[0].title).toEqual('foo');
 
   await z.mutate.issue.setTitle({id: '1', title: 'bar'});
-  issues = await z.query.issue.run();
+  issues = await z.query.issue;
   expect(issues[0].title).toEqual('bar');
 
   await z.mutate.customNamespace.clown('1');
-  issues = await z.query.issue.run();
+  issues = await z.query.issue;
   expect(issues[0].title).toEqual('🤡');
 
   await z.mutate.issue.create({
@@ -192,11 +192,11 @@ test('custom mutators write to the local store', async () => {
     description: '',
     createdAt: 1743018138477,
   });
-  issues = await z.query.issue.run();
+  issues = await z.query.issue;
   expect(issues.length).toEqual(2);
 
   await z.mutate.issue.deleteTwoIssues({id1: issues[0].id, id2: issues[1].id});
-  issues = await z.query.issue.run();
+  issues = await z.query.issue;
   expect(issues.length).toEqual(0);
 });
 
@@ -209,7 +209,7 @@ test('custom mutators can query the local store during an optimistic mutation', 
           await tx.mutate.issue.insert(args);
         },
         closeAll: async tx => {
-          const issues = await tx.query.issue.run();
+          const issues = await tx.query.issue;
           await Promise.all(
             issues.map(issue =>
               tx.mutate.issue.update({id: issue.id, closed: true}),
@@ -232,12 +232,12 @@ test('custom mutators can query the local store during an optimistic mutation', 
       });
     }),
   );
-  let issues = await z.query.issue.where('closed', false).run();
+  let issues = await z.query.issue.where('closed', false);
   expect(issues.length).toEqual(10);
 
   await z.mutate.issue.closeAll();
 
-  issues = await z.query.issue.where('closed', false).run();
+  issues = await z.query.issue.where('closed', false);
   expect(issues.length).toEqual(0);
 });
 
@@ -305,7 +305,7 @@ describe('rebasing custom mutators', () => {
           ) => {
             await tx.mutate.issue.insert(args);
             const readIssue = must(
-              await tx.query.issue.where('id', args.id).one().run(),
+              await tx.query.issue.where('id', args.id).one(),
             );
             await tx.mutate.issue.update({
               ...readIssue,
@@ -325,7 +325,7 @@ describe('rebasing custom mutators', () => {
       createdAt: 1743018138477,
     });
 
-    const issue = must(await z.query.issue.where('id', '1').one().run());
+    const issue = must(await z.query.issue.where('id', '1').one());
     expect(issue.title).toEqual('foo updated');
     expect(issue.description).toEqual('updated');
   });
@@ -339,9 +339,9 @@ describe('rebasing custom mutators', () => {
           create: async (tx, args: InsertValue<typeof schema.tables.issue>) => {
             await tx.mutate.issue.insert(args);
             // query main. The issue should not be there yet.
-            expect(await z.query.issue.run()).length(0);
+            expect(await z.query.issue).length(0);
             // but it is in this tx
-            expect(await tx.query.issue.run()).length(1);
+            expect(await tx.query.issue).length(1);
 
             mutationRun = true;
           },
@@ -447,11 +447,11 @@ describe('server results and keeping read queries', () => {
             tx,
             _args: InsertValue<typeof schema.tables.issue>,
           ) => {
-            await tx.query.issue.run();
+            await tx.query.issue;
           },
 
           close: async (tx, _args: object) => {
-            await tx.query.issue.limit(1).run();
+            await tx.query.issue.limit(1);
           },
         },
       } as const satisfies CustomMutatorDefs<Schema>,

--- a/packages/zero-pg/src/query.pg-test.ts
+++ b/packages/zero-pg/src/query.pg-test.ts
@@ -30,13 +30,13 @@ describe('makeSchemaQuery', () => {
         transaciton,
         await getServerSchema(transaciton, schema),
       );
-      const result = await query.basic.run();
+      const result = await query.basic;
       expect(result).toEqual([{id: '1', a: 2, b: 'foo', c: true}]);
 
-      const result2 = await query.names.run();
+      const result2 = await query.names;
       expect(result2).toEqual([{id: '2', a: 3, b: 'bar', c: false}]);
 
-      const result3 = await query.compoundPk.run();
+      const result3 = await query.compoundPk;
       expect(result3).toEqual([{a: 'a', b: 1, c: 'c'}]);
     });
   });
@@ -48,7 +48,7 @@ describe('makeSchemaQuery', () => {
         transaciton,
         await getServerSchema(transaciton, schema),
       );
-      const result = await query.basic.one().run();
+      const result = await query.basic.one();
       expect(result).toEqual({id: '1', a: 2, b: 'foo', c: true});
     });
   });
@@ -60,7 +60,7 @@ describe('makeSchemaQuery', () => {
         transaciton,
         await getServerSchema(transaciton, schema),
       );
-      const result = await query.basic.where('id', 'non-existent').one().run();
+      const result = await query.basic.where('id', 'non-existent').one();
       expect(result).toEqual(undefined);
     });
   });

--- a/packages/zero-schema/src/builder/schema-builder.test.ts
+++ b/packages/zero-schema/src/builder/schema-builder.test.ts
@@ -123,8 +123,7 @@ test('building a schema', async () => {
   const iq = mockQuery as unknown as Query<typeof schema, 'issue'>;
   const r = await q
     .related('recruiter', q => q.related('recruiter', q => q.one()).one())
-    .one()
-    .run();
+    .one();
   expectTypeOf<typeof r>().toEqualTypeOf<
     | {
         readonly id: string;
@@ -150,7 +149,7 @@ test('building a schema', async () => {
   >({} as any);
 
   // recruiter is a singular relationship
-  expectTypeOf(await q.related('recruiter').run()).toEqualTypeOf<
+  expectTypeOf(await q.related('recruiter')).toEqualTypeOf<
     {
       readonly id: string;
       readonly name: string;
@@ -166,7 +165,7 @@ test('building a schema', async () => {
   >();
 
   // recruiter is a singular relationship
-  expectTypeOf(await q.related('recruiter', q => q).run()).toEqualTypeOf<
+  expectTypeOf(await q.related('recruiter', q => q)).toEqualTypeOf<
     {
       readonly id: string;
       readonly name: string;
@@ -181,9 +180,9 @@ test('building a schema', async () => {
     }[]
   >();
 
-  const id1 = await iq
-    .related('owner', q => q.related('ownedIssues', q => q.where('id', '1')))
-    .run();
+  const id1 = await iq.related('owner', q =>
+    q.related('ownedIssues', q => q.where('id', '1')),
+  );
   expectTypeOf(id1).toEqualTypeOf<
     {
       readonly id: string;
@@ -204,7 +203,7 @@ test('building a schema', async () => {
     }[]
   >({} as never);
 
-  const id = await iq.related('labels').run();
+  const id = await iq.related('labels');
   expectTypeOf(id).toEqualTypeOf<
     {
       readonly id: string;
@@ -218,7 +217,7 @@ test('building a schema', async () => {
   >();
 
   const lq = mockQuery as unknown as Query<typeof schema, 'label'>;
-  const ld = await lq.related('issues').run();
+  const ld = await lq.related('issues');
   expectTypeOf(ld).toEqualTypeOf<
     {
       readonly id: number;

--- a/packages/zql-integration-tests/src/chinook/chinook.pg-test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook.pg-test.ts
@@ -135,7 +135,7 @@ beforeEach(async () => {
   await Promise.all(
     tables.map(async table => {
       const rows = mapResultToClientNames<Row[], typeof schema>(
-        await zqliteQueries[table].run(),
+        await zqliteQueries[table],
         schema,
         table,
       );
@@ -359,8 +359,8 @@ async function checkZqlAndSql(
   mustEditRows?: [table: string, row: Row][],
 ) {
   const pgResult = await runZqlAsSql(pg, zqliteQuery);
-  const zqliteResult = await zqliteQuery.run();
-  const zqlMemResult = await memoryQuery.run();
+  const zqliteResult = await zqliteQuery;
+  const zqlMemResult = await memoryQuery;
   const ast = (zqliteQuery as QueryImpl<Schema, any>)[astForTestingSymbol];
   // In failure output:
   // `-` is PG

--- a/packages/zql-integration-tests/src/collate.pg-test.ts
+++ b/packages/zql-integration-tests/src/collate.pg-test.ts
@@ -200,13 +200,9 @@ describe('collation behavior', () => {
       const itemQuery = newQuery(queryDelegate, schema, 'item');
       const query = itemQuery.orderBy(col, 'asc');
       const pgResult = await runAsSQL(query, runPgQuery);
-      const zqlResult = mapResultToClientNames(
-        await query.run(),
-        schema,
-        'item',
-      );
+      const zqlResult = mapResultToClientNames(await query, schema, 'item');
       const memoryItemQuery = newQuery(memoryQueryDelegate, schema, 'item');
-      const memoryResult = await memoryItemQuery.orderBy(col, 'asc').run();
+      const memoryResult = await memoryItemQuery.orderBy(col, 'asc');
       expect(zqlResult).toEqualPg(pgResult);
       expect(memoryResult).toEqualPg(pgResult);
 
@@ -220,9 +216,9 @@ describe('collation behavior', () => {
           .orderBy(col, 'asc');
       }
       for (let i = 0; i < memoryResult.length - 1; i++) {
-        const memResult = await makeQuery(memoryItemQuery, i).run();
+        const memResult = await makeQuery(memoryItemQuery, i);
         const zqlResult = mapResultToClientNames(
-          await makeQuery(itemQuery, i).run(),
+          await makeQuery(itemQuery, i),
           schema,
           'item',
         );

--- a/packages/zql-integration-tests/src/compiler-bigint.pg-test.ts
+++ b/packages/zql-integration-tests/src/compiler-bigint.pg-test.ts
@@ -224,11 +224,7 @@ describe('compiling ZQL to SQL', () => {
       const pgResult = extractZqlResult(
         await runPgQuery(sqlQuery.text, sqlQuery.values as JSONValue[]),
       );
-      const zqlResult = mapResultToClientNames(
-        await query.run(),
-        schema,
-        'issue',
-      );
+      const zqlResult = mapResultToClientNames(await query, schema, 'issue');
       expect(zqlResult).toEqualPg(pgResult);
       expect(zqlResult).toMatchInlineSnapshot(`
         [
@@ -293,11 +289,7 @@ describe('compiling ZQL to SQL', () => {
       const pgResult = extractZqlResult(
         await runPgQuery(sqlQuery.text, sqlQuery.values as JSONValue[]),
       );
-      const zqlResult = mapResultToClientNames(
-        await query.run(),
-        schema,
-        'issue',
-      );
+      const zqlResult = mapResultToClientNames(await query, schema, 'issue');
       expect(zqlResult).toEqualPg(pgResult);
       expect(zqlResult).toMatchInlineSnapshot(`
         [
@@ -344,11 +336,7 @@ describe('compiling ZQL to SQL', () => {
       const pgResult2 = extractZqlResult(
         await runPgQuery(sqlQuery2.text, sqlQuery2.values as JSONValue[]),
       );
-      const zqlResult2 = mapResultToClientNames(
-        await q2.run(),
-        schema,
-        'issue',
-      );
+      const zqlResult2 = mapResultToClientNames(await q2, schema, 'issue');
       expect(zqlResult2).toEqualPg(pgResult2);
       expect(zqlResult2).toMatchInlineSnapshot(`
         [

--- a/packages/zql/src/query/query-impl.query.test.ts
+++ b/packages/zql/src/query/query-impl.query.test.ts
@@ -636,7 +636,7 @@ describe('joins and filters', () => {
       .related('owner')
       .related('comments', q => q.related('author').related('revisions'))
       .where('id', '=', '0001');
-    const data = await query.run();
+    const data = await query;
     expect(data).toMatchInlineSnapshot(`
       [
         {
@@ -719,7 +719,7 @@ describe('joins and filters', () => {
     const query = newQuery(queryDelegate, schema, 'issue').related(
       'oneComment',
     );
-    const data = await query.run();
+    const data = await query;
     expect(data).toMatchInlineSnapshot(`
       [
         {
@@ -767,14 +767,14 @@ describe('joins and filters', () => {
 test('limit -1', () => {
   const queryDelegate = new QueryDelegateImpl();
   expect(() => {
-    newQuery(queryDelegate, schema, 'issue').limit(-1);
+    void newQuery(queryDelegate, schema, 'issue').limit(-1);
   }).toThrow('Limit must be non-negative');
 });
 
 test('non int limit', () => {
   const queryDelegate = new QueryDelegateImpl();
   expect(() => {
-    newQuery(queryDelegate, schema, 'issue').limit(1.5);
+    void newQuery(queryDelegate, schema, 'issue').limit(1.5);
   }).toThrow('Limit must be an integer');
 });
 
@@ -788,12 +788,13 @@ test('run', async () => {
     'issue 1',
   );
 
-  const singleFilterRows = await issueQuery1.run();
-  const doubleFilterRows = await issueQuery1.where('closed', '=', false).run();
-  const doubleFilterWithNoResultsRows = await issueQuery1
-    .where('closed', '=', true)
-    .run();
-
+  const singleFilterRows = await issueQuery1;
+  const doubleFilterRows = await issueQuery1.where('closed', '=', false);
+  const doubleFilterWithNoResultsRows = await issueQuery1.where(
+    'closed',
+    '=',
+    true,
+  );
   expect(singleFilterRows.map(r => r.id)).toEqual(['0001']);
   expect(doubleFilterRows.map(r => r.id)).toEqual(['0001']);
   expect(doubleFilterWithNoResultsRows).toEqual([]);
@@ -802,7 +803,7 @@ test('run', async () => {
     .related('labels')
     .related('owner')
     .related('comments');
-  const rows = await issueQuery2.run();
+  const rows = await issueQuery2;
   expect(rows).toMatchInlineSnapshot(`
     [
       {
@@ -917,7 +918,7 @@ test('json columns are returned as JS objects', async () => {
   const queryDelegate = new QueryDelegateImpl();
   addData(queryDelegate);
 
-  const rows = await newQuery(queryDelegate, schema, 'user').run();
+  const rows = await newQuery(queryDelegate, schema, 'user');
   expect(rows).toMatchInlineSnapshot(`
     [
       {
@@ -951,12 +952,9 @@ test('complex expression', async () => {
   const queryDelegate = new QueryDelegateImpl();
   addData(queryDelegate);
 
-  let rows = await newQuery(queryDelegate, schema, 'issue')
-    .where(({or, cmp}) =>
-      or(cmp('title', '=', 'issue 1'), cmp('title', '=', 'issue 2')),
-    )
-    .run();
-
+  let rows = await newQuery(queryDelegate, schema, 'issue').where(({or, cmp}) =>
+    or(cmp('title', '=', 'issue 1'), cmp('title', '=', 'issue 2')),
+  );
   expect(rows).toMatchInlineSnapshot(`
     [
       {
@@ -980,14 +978,13 @@ test('complex expression', async () => {
     ]
   `);
 
-  rows = await newQuery(queryDelegate, schema, 'issue')
-    .where(({and, cmp, or}) =>
+  rows = await newQuery(queryDelegate, schema, 'issue').where(
+    ({and, cmp, or}) =>
       and(
         cmp('ownerId', '=', '0001'),
         or(cmp('title', '=', 'issue 1'), cmp('title', '=', 'issue 2')),
       ),
-    )
-    .run();
+  );
 
   expect(rows).toMatchInlineSnapshot(`
     [
@@ -1008,10 +1005,11 @@ test('null compare', async () => {
   const queryDelegate = new QueryDelegateImpl();
   addData(queryDelegate);
 
-  let rows = await newQuery(queryDelegate, schema, 'issue')
-    .where('ownerId', 'IS', null)
-    .run();
-
+  let rows = await newQuery(queryDelegate, schema, 'issue').where(
+    'ownerId',
+    'IS',
+    null,
+  );
   expect(rows).toMatchInlineSnapshot(`
     [
       {
@@ -1026,9 +1024,11 @@ test('null compare', async () => {
     ]
   `);
 
-  rows = await newQuery(queryDelegate, schema, 'issue')
-    .where('ownerId', 'IS NOT', null)
-    .run();
+  rows = await newQuery(queryDelegate, schema, 'issue').where(
+    'ownerId',
+    'IS NOT',
+    null,
+  );
 
   expect(rows).toMatchInlineSnapshot(`
     [
@@ -1058,15 +1058,14 @@ test('literal filter', async () => {
   const queryDelegate = new QueryDelegateImpl();
   addData(queryDelegate);
 
-  let rows = await newQuery(queryDelegate, schema, 'issue')
-    .where(({cmpLit}) => cmpLit(true, '=', false))
-    .run();
-
+  let rows = await newQuery(queryDelegate, schema, 'issue').where(({cmpLit}) =>
+    cmpLit(true, '=', false),
+  );
   expect(rows).toEqual([]);
 
-  rows = await newQuery(queryDelegate, schema, 'issue')
-    .where(({cmpLit}) => cmpLit(true, '=', true))
-    .run();
+  rows = await newQuery(queryDelegate, schema, 'issue').where(({cmpLit}) =>
+    cmpLit(true, '=', true),
+  );
 
   expect(rows).toMatchInlineSnapshot(`
     [
@@ -1176,7 +1175,7 @@ test('join with compound keys', async () => {
     });
   }
 
-  const rows = await newQuery(queryDelegate, schema, 'a').related('b').run();
+  const rows = await newQuery(queryDelegate, schema, 'a').related('b');
 
   expect(rows).toMatchInlineSnapshot(`
     [

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -532,6 +532,13 @@ export abstract class AbstractQuery<
     return this.#completedAST;
   }
 
+  then<T1, T2 = never>(
+    onFulfilled?: (value: HumanReadable<TReturn>) => T1,
+    onRejected?: (reason: unknown) => T2,
+  ): Promise<T1 | T2> {
+    return this.run().then(onFulfilled, onRejected);
+  }
+
   abstract materialize(): TypedView<HumanReadable<TReturn>>;
   abstract materialize<T>(factory: ViewFactory<TSchema, TTable, TReturn, T>): T;
   abstract run(): Promise<HumanReadable<TReturn>>;

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -532,10 +532,16 @@ export abstract class AbstractQuery<
     return this.#completedAST;
   }
 
-  then<T1, T2 = never>(
-    onFulfilled?: (value: HumanReadable<TReturn>) => T1,
-    onRejected?: (reason: unknown) => T2,
-  ): Promise<T1 | T2> {
+  then<TResult1 = HumanReadable<TReturn>, TResult2 = never>(
+    onFulfilled?:
+      | ((value: HumanReadable<TReturn>) => TResult1 | PromiseLike<TResult1>)
+      | undefined
+      | null,
+    onRejected?:
+      | ((reason: any) => TResult2 | PromiseLike<TResult2>)
+      | undefined
+      | null,
+  ): PromiseLike<TResult1 | TResult2> {
     return this.run().then(onFulfilled, onRejected);
   }
 

--- a/packages/zql/src/query/query.test.ts
+++ b/packages/zql/src/query/query.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
 /* eslint-disable @typescript-eslint/ban-types */
 import {describe, expectTypeOf, test} from 'vitest';
 import type {ReadonlyJSONValue} from '../../../shared/src/json.ts';
@@ -227,7 +228,7 @@ describe('types', () => {
 
   test('simple select with enums', () => {
     const query = mockQuery as unknown as Query<Schema, 'testWithEnums'>;
-    expectTypeOf(query.run()).toMatchTypeOf<
+    expectTypeOf(query.run()).toExtend<
       Promise<
         ReadonlyArray<{
           s: string;

--- a/packages/zql/src/query/query.ts
+++ b/packages/zql/src/query/query.ts
@@ -200,6 +200,11 @@ export interface Query<
 
   run(): Promise<HumanReadable<TReturn>>;
 
+  then<T1, T2 = never>(
+    onFulfilled?: (value: HumanReadable<TReturn>) => T1,
+    onRejected?: (reason: unknown) => T2,
+  ): Promise<T1 | T2>;
+
   preload(options?: PreloadOptions): {
     cleanup: () => void;
     complete: Promise<void>;

--- a/packages/zqlite/src/query.test.ts
+++ b/packages/zqlite/src/query.test.ts
@@ -111,7 +111,7 @@ test('row type', () => {
 
 test('basic query', async () => {
   const query = newQuery(queryDelegate, schema, 'issue');
-  const data = mapResultToClientNames(await query.run(), schema, 'issue');
+  const data = mapResultToClientNames(await query, schema, 'issue');
   expect(data).toMatchInlineSnapshot(`
     [
       {
@@ -143,10 +143,11 @@ test('basic query', async () => {
 });
 
 test('null compare', async () => {
-  let rows = await newQuery(queryDelegate, schema, 'issue')
-    .where('ownerId', 'IS', null)
-    .run();
-
+  let rows = await newQuery(queryDelegate, schema, 'issue').where(
+    'ownerId',
+    'IS',
+    null,
+  );
   expect(mapResultToClientNames(rows, schema, 'issue')).toMatchInlineSnapshot(`
     [
       {
@@ -160,9 +161,11 @@ test('null compare', async () => {
     ]
   `);
 
-  rows = await newQuery(queryDelegate, schema, 'issue')
-    .where('ownerId', 'IS NOT', null)
-    .run();
+  rows = await newQuery(queryDelegate, schema, 'issue').where(
+    'ownerId',
+    'IS NOT',
+    null,
+  );
 
   expect(rows).toMatchInlineSnapshot(`
     [
@@ -192,7 +195,7 @@ test('or', async () => {
   const query = newQuery(queryDelegate, schema, 'issue').where(({or, cmp}) =>
     or(cmp('ownerId', '=', '0001'), cmp('ownerId', '=', '0002')),
   );
-  const data = mapResultToClientNames(await query.run(), schema, 'issue');
+  const data = mapResultToClientNames(await query, schema, 'issue');
   expect(data).toMatchInlineSnapshot(`
     [
       {
@@ -301,7 +304,7 @@ test('schema applied `one`', async () => {
     .related('owner')
     .related('comments', q => q.related('author').related('revisions'))
     .where('id', '=', '0001');
-  const data = mapResultToClientNames(await query.run(), schema, 'issue');
+  const data = mapResultToClientNames(await query, schema, 'issue');
   expect(data).toMatchInlineSnapshot(`
     [
       {


### PR DESCRIPTION
Users can now:

```ts
await z.query.issue.limit(5);
```

rather than

```ts
await z.query.issue.limit(5).run();
```