### PR TITLE
chore(zero-client): Doc dev server and JSDoc for zero

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,5 @@ test-results/
 debug-scratch.md
 
 repro/
+packages/zero/docs
+packages/zero-client/docs

--- a/package-lock.json
+++ b/package-lock.json
@@ -6098,15 +6098,17 @@
       "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig=="
     },
     "node_modules/@gerrit0/mini-shiki": {
-      "version": "1.27.2",
-      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-1.27.2.tgz",
-      "integrity": "sha512-GeWyHz8ao2gBiUW4OJnQDxXQnFgZQwwQk05t/CVVgNBN7/rK8XZ7xY6YhLVv9tH3VppWWmr9DCl3MwemB/i+Og==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.2.2.tgz",
+      "integrity": "sha512-vaZNGhGLKMY14HbF53xxHNgFO9Wz+t5lTlGNpl2N9xFiKQ0I5oIe0vKjU9dh7Nb3Dw6lZ7wqUE0ri+zcdpnK+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/engine-oniguruma": "^1.27.2",
-        "@shikijs/types": "^1.27.2",
-        "@shikijs/vscode-textmate": "^10.0.1"
+        "@shikijs/engine-oniguruma": "^3.2.1",
+        "@shikijs/langs": "^3.2.1",
+        "@shikijs/themes": "^3.2.1",
+        "@shikijs/types": "^3.2.1",
+        "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@google-cloud/precise-date": {
@@ -7730,31 +7732,51 @@
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.29.2.tgz",
-      "integrity": "sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.2.1.tgz",
+      "integrity": "sha512-wZZAkayEn6qu2+YjenEoFqj0OyQI64EWsNR6/71d1EkG4sxEOFooowKivsWPpaWNBu3sxAG+zPz5kzBL/SsreQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "1.29.2",
-        "@shikijs/vscode-textmate": "^10.0.1"
+        "@shikijs/types": "3.2.1",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.2.1.tgz",
+      "integrity": "sha512-If0iDHYRSGbihiA8+7uRsgb1er1Yj11pwpX1c6HLYnizDsKAw5iaT3JXj5ZpaimXSWky/IhxTm7C6nkiYVym+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.2.1"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.2.1.tgz",
+      "integrity": "sha512-k5DKJUT8IldBvAm8WcrDT5+7GA7se6lLksR+2E3SvyqGTyFMzU2F9Gb7rmD+t+Pga1MKrYFxDIeyWjMZWM6uBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.2.1"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.29.2.tgz",
-      "integrity": "sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.2.1.tgz",
+      "integrity": "sha512-/NTWAk4KE2M8uac0RhOsIhYQf4pdU0OywQuYDGIGAJ6Mjunxl2cGiuLkvu4HLCMn+OTTLRWkjZITp+aYJv60yA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/vscode-textmate": "^10.0.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
       }
     },
     "node_modules/@shikijs/vscode-textmate": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.1.tgz",
-      "integrity": "sha512-fTIQwLF+Qhuws31iw7Ncl1R3HUDtGwIipiJ9iU+UsDUwMhegFcQKQHd51nZjb7CArq0MvON8rbgCGQYWHUKAdg==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "dev": true,
       "license": "MIT"
     },
@@ -24849,39 +24871,40 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.27.6",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.27.6.tgz",
-      "integrity": "sha512-oBFRoh2Px6jFx366db0lLlihcalq/JzyCVp7Vaq1yphL/tbgx2e+bkpkCgJPunaPvPwoTOXSwasfklWHm7GfAw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.2.tgz",
+      "integrity": "sha512-9Giuv+eppFKnJ0oi+vxqLM817b/IrIsEMYgy3jj6zdvppAfDqV3d6DXL2vXUg2TnlL62V48th25Zf/tcQKAJdg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@gerrit0/mini-shiki": "^1.24.0",
+        "@gerrit0/mini-shiki": "^3.2.2",
         "lunr": "^2.3.9",
         "markdown-it": "^14.1.0",
         "minimatch": "^9.0.5",
-        "yaml": "^2.6.1"
+        "yaml": "^2.7.1"
       },
       "bin": {
         "typedoc": "bin/typedoc"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 18",
+        "pnpm": ">= 10"
       },
       "peerDependencies": {
-        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x"
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x"
       }
     },
     "node_modules/typedoc-plugin-markdown": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.4.1.tgz",
-      "integrity": "sha512-fx23nSCvewI9IR8lzIYtzDphETcgTDuxKcmHKGD4lo36oexC+B1k4NaCOY58Snqb4OlE8OXDAGVcQXYYuLRCNw==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.6.1.tgz",
+      "integrity": "sha512-SrJv9zkpCWdG1cvtWniFU6M7MkCZuheN2R3fuqDPF+O+PeZ8bzmfj1ju/BJwoPWIKyFJVPhK8Sg6tBrM1y+VoA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "typedoc": "0.27.x"
+        "typedoc": "0.28.x"
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {
@@ -26500,9 +26523,9 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
       "devOptional": true,
       "license": "ISC",
       "bin": {
@@ -26810,8 +26833,8 @@
         "@docusaurus/tsconfig": "3.7.0",
         "@docusaurus/types": "3.7.0",
         "docusaurus-plugin-typedoc": "^1.2.2",
-        "typedoc": "^0.27.6",
-        "typedoc-plugin-markdown": "^4.4.1",
+        "typedoc": "^0.28.2",
+        "typedoc-plugin-markdown": "^4.6.1",
         "typescript": "~5.8.2"
       },
       "engines": {
@@ -27206,13 +27229,47 @@
       "devDependencies": {
         "@rocicorp/eslint-config": "^0.7.0",
         "@rocicorp/prettier-config": "^0.3.0",
+        "chokidar": "^4.0.1",
         "datadog": "0.0.0",
         "esbuild": "^0.25.0",
         "playwright": "^1.51.0",
         "replicache": "15.2.1",
         "shared": "0.0.0",
+        "typedoc": "^0.28.2",
+        "typedoc-plugin-markdown": "^4.6.1",
         "typescript": "~5.8.2",
+        "ws": "^8.18.1",
         "zero-protocol": "0.0.0"
+      }
+    },
+    "packages/zero-client/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "packages/zero-client/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "packages/zero-client/node_modules/typescript": {
@@ -30807,14 +30864,16 @@
       "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig=="
     },
     "@gerrit0/mini-shiki": {
-      "version": "1.27.2",
-      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-1.27.2.tgz",
-      "integrity": "sha512-GeWyHz8ao2gBiUW4OJnQDxXQnFgZQwwQk05t/CVVgNBN7/rK8XZ7xY6YhLVv9tH3VppWWmr9DCl3MwemB/i+Og==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.2.2.tgz",
+      "integrity": "sha512-vaZNGhGLKMY14HbF53xxHNgFO9Wz+t5lTlGNpl2N9xFiKQ0I5oIe0vKjU9dh7Nb3Dw6lZ7wqUE0ri+zcdpnK+Q==",
       "dev": true,
       "requires": {
-        "@shikijs/engine-oniguruma": "^1.27.2",
-        "@shikijs/types": "^1.27.2",
-        "@shikijs/vscode-textmate": "^10.0.1"
+        "@shikijs/engine-oniguruma": "^3.2.1",
+        "@shikijs/langs": "^3.2.1",
+        "@shikijs/themes": "^3.2.1",
+        "@shikijs/types": "^3.2.1",
+        "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "@google-cloud/precise-date": {
@@ -31991,29 +32050,47 @@
       "requires": {}
     },
     "@shikijs/engine-oniguruma": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.29.2.tgz",
-      "integrity": "sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.2.1.tgz",
+      "integrity": "sha512-wZZAkayEn6qu2+YjenEoFqj0OyQI64EWsNR6/71d1EkG4sxEOFooowKivsWPpaWNBu3sxAG+zPz5kzBL/SsreQ==",
       "dev": true,
       "requires": {
-        "@shikijs/types": "1.29.2",
-        "@shikijs/vscode-textmate": "^10.0.1"
+        "@shikijs/types": "3.2.1",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "@shikijs/langs": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.2.1.tgz",
+      "integrity": "sha512-If0iDHYRSGbihiA8+7uRsgb1er1Yj11pwpX1c6HLYnizDsKAw5iaT3JXj5ZpaimXSWky/IhxTm7C6nkiYVym+A==",
+      "dev": true,
+      "requires": {
+        "@shikijs/types": "3.2.1"
+      }
+    },
+    "@shikijs/themes": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.2.1.tgz",
+      "integrity": "sha512-k5DKJUT8IldBvAm8WcrDT5+7GA7se6lLksR+2E3SvyqGTyFMzU2F9Gb7rmD+t+Pga1MKrYFxDIeyWjMZWM6uBQ==",
+      "dev": true,
+      "requires": {
+        "@shikijs/types": "3.2.1"
       }
     },
     "@shikijs/types": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.29.2.tgz",
-      "integrity": "sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.2.1.tgz",
+      "integrity": "sha512-/NTWAk4KE2M8uac0RhOsIhYQf4pdU0OywQuYDGIGAJ6Mjunxl2cGiuLkvu4HLCMn+OTTLRWkjZITp+aYJv60yA==",
       "dev": true,
       "requires": {
-        "@shikijs/vscode-textmate": "^10.0.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
       }
     },
     "@shikijs/vscode-textmate": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.1.tgz",
-      "integrity": "sha512-fTIQwLF+Qhuws31iw7Ncl1R3HUDtGwIipiJ9iU+UsDUwMhegFcQKQHd51nZjb7CArq0MvON8rbgCGQYWHUKAdg==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "dev": true
     },
     "@sideway/address": {
@@ -41790,8 +41867,8 @@
         "prism-react-renderer": "^2.4.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "typedoc": "^0.27.6",
-        "typedoc-plugin-markdown": "^4.4.1",
+        "typedoc": "^0.28.2",
+        "typedoc-plugin-markdown": "^4.6.1",
         "typescript": "~5.8.2"
       },
       "dependencies": {
@@ -43793,16 +43870,16 @@
       }
     },
     "typedoc": {
-      "version": "0.27.6",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.27.6.tgz",
-      "integrity": "sha512-oBFRoh2Px6jFx366db0lLlihcalq/JzyCVp7Vaq1yphL/tbgx2e+bkpkCgJPunaPvPwoTOXSwasfklWHm7GfAw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.2.tgz",
+      "integrity": "sha512-9Giuv+eppFKnJ0oi+vxqLM817b/IrIsEMYgy3jj6zdvppAfDqV3d6DXL2vXUg2TnlL62V48th25Zf/tcQKAJdg==",
       "dev": true,
       "requires": {
-        "@gerrit0/mini-shiki": "^1.24.0",
+        "@gerrit0/mini-shiki": "^3.2.2",
         "lunr": "^2.3.9",
         "markdown-it": "^14.1.0",
         "minimatch": "^9.0.5",
-        "yaml": "^2.6.1"
+        "yaml": "^2.7.1"
       },
       "dependencies": {
         "brace-expansion": {
@@ -43826,9 +43903,9 @@
       }
     },
     "typedoc-plugin-markdown": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.4.1.tgz",
-      "integrity": "sha512-fx23nSCvewI9IR8lzIYtzDphETcgTDuxKcmHKGD4lo36oexC+B1k4NaCOY58Snqb4OlE8OXDAGVcQXYYuLRCNw==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.6.1.tgz",
+      "integrity": "sha512-SrJv9zkpCWdG1cvtWniFU6M7MkCZuheN2R3fuqDPF+O+PeZ8bzmfj1ju/BJwoPWIKyFJVPhK8Sg6tBrM1y+VoA==",
       "dev": true,
       "requires": {}
     },
@@ -44776,9 +44853,9 @@
       "dev": true
     },
     "yaml": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
       "devOptional": true
     },
     "yargs": {
@@ -45099,15 +45176,34 @@
         "@rocicorp/logger": "^5.3.0",
         "@rocicorp/prettier-config": "^0.3.0",
         "@rocicorp/resolver": "^1.0.2",
+        "chokidar": "^4.0.1",
         "datadog": "0.0.0",
         "esbuild": "^0.25.0",
         "playwright": "^1.51.0",
         "replicache": "15.2.1",
         "shared": "0.0.0",
+        "typedoc": "^0.28.2",
+        "typedoc-plugin-markdown": "^4.6.1",
         "typescript": "~5.8.2",
+        "ws": "^8.18.1",
         "zero-protocol": "0.0.0"
       },
       "dependencies": {
+        "chokidar": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+          "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+          "dev": true,
+          "requires": {
+            "readdirp": "^4.0.1"
+          }
+        },
+        "readdirp": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+          "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+          "dev": true
+        },
         "typescript": {
           "version": "5.8.2",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",

--- a/packages/replicache-doc/package.json
+++ b/packages/replicache-doc/package.json
@@ -30,8 +30,8 @@
     "@docusaurus/tsconfig": "3.7.0",
     "@docusaurus/types": "3.7.0",
     "docusaurus-plugin-typedoc": "^1.2.2",
-    "typedoc": "^0.27.6",
-    "typedoc-plugin-markdown": "^4.4.1",
+    "typedoc": "^0.28.2",
+    "typedoc-plugin-markdown": "^4.6.1",
     "typescript": "~5.8.2"
   },
   "browserslist": {

--- a/packages/replicache/src/error-responses.ts
+++ b/packages/replicache/src/error-responses.ts
@@ -31,8 +31,7 @@ export function isClientStateNotFoundResponse(
 
 /**
  * The server endpoint may respond with a `VersionNotSupported` error if it does
- * not know how to handle the {@link pullVersion}, {@link pushVersion} or the
- * {@link schemaVersion}.
+ * not know how to handle the pull, push or schema version.
  */
 export type VersionNotSupportedResponse = {
   error: 'VersionNotSupported';

--- a/packages/replicache/src/kv/idb-store.ts
+++ b/packages/replicache/src/kv/idb-store.ts
@@ -202,9 +202,9 @@ function openDatabase(name: string): Promise<IDBDatabase> {
 }
 
 /**
- * This {@link Error} is thrown when we detect that the IndexedDB has been
- * removed. This does not normally happen but can happen during development if
- * the user has DevTools open and deletes the IndexedDB from there.
+ * This error is thrown when we detect that the IndexedDB has been removed. This
+ * does not normally happen but can happen during development if the user has
+ * DevTools open and deletes the IndexedDB from there.
  */
 export class IDBNotFoundError extends Error {
   name = 'IDBNotFoundError';

--- a/packages/replicache/src/kv/store.ts
+++ b/packages/replicache/src/kv/store.ts
@@ -1,5 +1,4 @@
 import type {ReadonlyJSONValue} from '../../../shared/src/json.ts';
-
 /**
  * Store defines a transactional key/value store that Replicache stores all data
  * within.
@@ -26,7 +25,7 @@ export interface Store {
  *
  * The name is used to identify the store. If the same name is used for multiple
  * stores, they should share the same data. It is also desirable to have these
- * stores share an {@link RWLock}.
+ * stores share an `RWLock`.
  *
  */
 export type CreateStore = (name: string) => Store;

--- a/packages/replicache/src/persist/collect-idb-databases.ts
+++ b/packages/replicache/src/persist/collect-idb-databases.ts
@@ -274,11 +274,10 @@ export type DropDatabaseOptions = {
 };
 
 /**
- * Deletes a single Replicache database.
- * @param dbName
- * @param createKVStore
+ * Drops the specified database.
+ * @param dbName The name of the database to drop.
+ * @param opts Options for dropping the database.
  */
-
 export async function dropDatabase(
   dbName: string,
   opts?: DropDatabaseOptions | undefined,

--- a/packages/zero-client/package.json
+++ b/packages/zero-client/package.json
@@ -13,7 +13,9 @@
     "bench": "vitest bench --run",
     "bench:watch": "vitest bench --watch",
     "check-types": "tsc",
-    "check-types:watch": "tsc --watch"
+    "check-types:watch": "tsc --watch",
+    "docs": "node --experimental-strip-types --no-warnings scripts/generate-docs.ts",
+    "docs:server": "node --experimental-strip-types --no-warnings scripts/generate-docs.ts --server"
   },
   "dependencies": {
     "@rocicorp/lock": "^1.0.4",
@@ -29,7 +31,11 @@
     "replicache": "15.2.1",
     "shared": "0.0.0",
     "typescript": "~5.8.2",
-    "zero-protocol": "0.0.0"
+    "zero-protocol": "0.0.0",
+    "typedoc": "^0.28.2",
+    "typedoc-plugin-markdown": "^4.6.1",
+    "chokidar": "^4.0.1",
+    "ws": "^8.18.1"
   },
   "eslintConfig": {
     "extends": "../../eslint-config.json"

--- a/packages/zero-client/scripts/generate-docs.ts
+++ b/packages/zero-client/scripts/generate-docs.ts
@@ -1,0 +1,266 @@
+/* eslint-disable no-console */
+import * as chokidar from 'chokidar';
+import {ChildProcess, execSync, spawn} from 'node:child_process';
+import * as fs from 'node:fs';
+import * as http from 'node:http';
+import * as path from 'node:path';
+import * as url from 'node:url';
+import {WebSocket, WebSocketServer} from 'ws';
+
+// Get the directory name using import.meta.url
+const dirname = url.fileURLToPath(new URL('.', import.meta.url));
+
+// Store TypeDoc process reference
+let typeDocProcess: ChildProcess | null = null;
+
+// Start TypeDoc in watch mode
+function startTypedocWatcher() {
+  // Create output directory if it doesn't exist
+  const outputDir = path.resolve(dirname, '../docs');
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, {recursive: true});
+  }
+
+  const entryPoint = path.resolve(dirname, '../src/mod.ts');
+
+  // Build the TypeDoc CLI command with --watch flag
+  const args = [
+    'typedoc',
+    entryPoint,
+    '--out',
+    outputDir,
+    '--name',
+    '@rocicorp/zero API Documentation',
+    '--excludePrivate',
+    '--excludeProtected',
+    '--watch', // Enable incremental watch mode
+    '--preserveWatchOutput',
+    '--logLevel',
+    'Warn',
+  ];
+
+  console.log(`Starting TypeDoc in watch mode: npx ${args.join(' ')}`);
+
+  // Run TypeDoc as a child process instead of using execSync
+  typeDocProcess = spawn('npx', args, {
+    cwd: path.resolve(dirname, '..'),
+    stdio: 'pipe', // Capture output
+  });
+
+  // Forward stdout/stderr with prefixes
+  typeDocProcess.stdout?.on('data', data => {
+    const output = data.toString().trim();
+    if (output) console.log(`[TypeDoc] ${output}`);
+  });
+
+  typeDocProcess.stderr?.on('data', data => {
+    const output = data.toString().trim();
+    if (output) console.error(`[TypeDoc] ${output}`);
+  });
+
+  typeDocProcess.on('close', code => {
+    console.log(`TypeDoc process exited with code ${code}`);
+    typeDocProcess = null;
+  });
+
+  return typeDocProcess;
+}
+
+// Generate docs once without watch mode
+function generateDocsOnce() {
+  // Create output directory if it doesn't exist
+  const outputDir = path.resolve(dirname, '../docs');
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, {recursive: true});
+  }
+
+  try {
+    const entryPoint = path.resolve(dirname, '../src/mod.ts');
+
+    // Build the TypeDoc CLI command
+    const command = [
+      'npx typedoc',
+      `"${entryPoint}"`,
+      `--out "${outputDir}"`,
+      '--name "Zero Client API Documentation"',
+      '--excludePrivate',
+      '--excludeProtected',
+    ].join(' ');
+
+    console.log(`Executing: ${command}`);
+
+    // Execute TypeDoc via CLI
+    execSync(command, {
+      stdio: 'inherit',
+      cwd: path.resolve(dirname, '..'),
+    });
+
+    // Verify files were created
+    const files = fs
+      .readdirSync(outputDir)
+      .filter(file => !file.startsWith('.'));
+
+    if (files.length === 0) {
+      throw new Error('No documentation files were generated');
+    }
+
+    console.log(`Documentation generated successfully at ${outputDir}`);
+    console.log(`Generated ${files.length} files`);
+    return 0;
+  } catch (error) {
+    console.error(
+      'Error generating documentation:',
+      error instanceof Error ? error.message : String(error),
+    );
+    return 1;
+  }
+}
+
+// Create a simple web server for the documentation
+function createServer(docsDir: string, port = 3000) {
+  const server = http.createServer((req, res) => {
+    // Add live reload script to HTML files
+    if (req.url === '/livereload.js') {
+      res.writeHead(200, {'Content-Type': 'text/javascript'});
+      res.end(`
+        const socket = new WebSocket('ws://localhost:${port + 1}');
+        socket.addEventListener('message', () => {
+          console.log('Reloading page...');
+          window.location.reload();
+        });
+      `);
+      return;
+    }
+
+    // Default to index.html for root path
+    let filePath = path.join(docsDir, req.url || '');
+    if (req.url === '/' || req.url === '') {
+      filePath = path.join(docsDir, 'index.html');
+    }
+
+    // Handle file serving
+    fs.readFile(filePath, (err, data) => {
+      if (err) {
+        if (err.code === 'ENOENT') {
+          res.writeHead(404);
+          res.end('File not found');
+        } else {
+          res.writeHead(500);
+          res.end('Server error');
+        }
+        return;
+      }
+
+      const ext = path.extname(filePath);
+      const contentType = getContentType(ext);
+      res.writeHead(200, {'Content-Type': contentType});
+
+      // Inject live reload script into HTML files
+      if (ext === '.html') {
+        const html = data.toString();
+        const injectedHtml = html.replace(
+          '</head>',
+          '<script src="/livereload.js"></script></head>',
+        );
+        res.end(injectedHtml);
+      } else {
+        res.end(data);
+      }
+    });
+  });
+
+  server.listen(port, () => {
+    console.log(`Documentation server running at http://localhost:${port}`);
+  });
+
+  return server;
+}
+
+// Define a custom WebSocket server type with our notifyClients method
+interface LiveReloadServer {
+  clients: Set<WebSocket>;
+  notifyClients: () => void;
+}
+
+// Create WebSocket server for live reload
+function createWebSocketServer(port = 3001): LiveReloadServer {
+  const wss = new WebSocketServer({port});
+
+  console.log(`WebSocket server for live reload running on port ${port}`);
+
+  return {
+    clients: wss.clients,
+    notifyClients: () => {
+      for (const client of wss.clients) {
+        if (client.readyState === WebSocket.OPEN) {
+          client.send('reload');
+        }
+      }
+    },
+  };
+}
+
+// Watch for changes to the docs directory to trigger browser reload
+function watchDocsForChanges(wsServer: LiveReloadServer) {
+  const docsDir = path.resolve(dirname, '../docs');
+
+  console.log('Setting up watcher for documentation output...');
+
+  // Watch generated HTML files for changes
+  const watcher = chokidar.watch(path.join(docsDir, '**/*.html'), {
+    ignoreInitial: true,
+    persistent: true,
+  });
+
+  // When docs are updated, notify clients to reload
+  watcher.on('change', () => {
+    wsServer.notifyClients();
+  });
+
+  return watcher;
+}
+
+function getContentType(ext: string) {
+  const contentTypes: Record<string, string> = {
+    '.html': 'text/html',
+    '.css': 'text/css',
+    '.js': 'text/javascript',
+    '.json': 'application/json',
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.svg': 'image/svg+xml',
+  };
+
+  return contentTypes[ext] || 'text/plain';
+}
+
+// Parse command line arguments
+const args = process.argv.slice(2);
+const runServer = args.includes('--server') || args.includes('-s');
+const watchMode = args.includes('--watch') || args.includes('-w') || runServer;
+
+// Run documentation generation based on mode
+if (watchMode) {
+  startTypedocWatcher();
+} else {
+  generateDocsOnce();
+}
+
+// Start server if requested
+if (runServer) {
+  const docsDir = path.resolve(dirname, '../docs');
+  const httpServer = createServer(docsDir);
+  const wsServer = createWebSocketServer();
+  const docsWatcher = watchDocsForChanges(wsServer);
+
+  // Handle termination
+  process.on('SIGINT', async () => {
+    console.log('Stopping servers and processes...');
+    if (typeDocProcess) {
+      typeDocProcess.kill();
+    }
+    httpServer.close();
+    await docsWatcher.close();
+    process.exit(0);
+  });
+}

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -24,6 +24,7 @@ import {
   getBrowserGlobal,
   mustGetBrowserGlobal,
 } from '../../../shared/src/browser-env.ts';
+import type {DeepMerge} from '../../../shared/src/deep-merge.ts';
 import {getDocumentVisibilityWatcher} from '../../../shared/src/document-visible.ts';
 import type {Enum} from '../../../shared/src/enum.ts';
 import {must} from '../../../shared/src/must.ts';
@@ -133,7 +134,6 @@ import {getServer} from './server-option.ts';
 import {version} from './version.ts';
 import {PokeHandler} from './zero-poke-handler.ts';
 import {ZeroRep} from './zero-rep.ts';
-import type {DeepMerge} from '../../../shared/src/deep-merge.ts';
 
 type ConnectionState = Enum<typeof ConnectionState>;
 type PingResult = Enum<typeof PingResult>;
@@ -1731,7 +1731,7 @@ export class Zero<
    * Starts a ping and waits for a pong.
    *
    * If it takes too long to get a pong we disconnect and this returns
-   * {@code PingResult.TimedOut}.
+   * {@linkcode PingResult.TimedOut}.
    */
   async #ping(
     l: LogContext,

--- a/packages/zero-client/src/mod.ts
+++ b/packages/zero-client/src/mod.ts
@@ -15,7 +15,6 @@ export {
 export {makeIDBName} from '../../replicache/src/replicache.ts';
 export type {ClientGroupID, ClientID} from '../../replicache/src/sync/ids.ts';
 export {TransactionClosedError} from '../../replicache/src/transaction-closed-error.ts';
-export type {UpdateNeededReason} from '../../replicache/src/types.ts';
 export type {
   JSONObject,
   JSONValue,
@@ -111,7 +110,19 @@ export type {
 export type {HumanReadable, Query, Row} from '../../zql/src/query/query.ts';
 export {DEFAULT_TTL, type TTL} from '../../zql/src/query/ttl.ts';
 export type {ResultType, TypedView} from '../../zql/src/query/typed-view.ts';
-export type {DBMutator, TableMutator} from './client/crud.ts';
-export type {CustomMutatorDefs, CustomMutatorImpl} from './client/custom.ts';
-export type {ZeroOptions} from './client/options.ts';
-export {Zero} from './client/zero.ts';
+export type {BatchMutator, DBMutator, TableMutator} from './client/crud.ts';
+export type {
+  CustomMutatorDefs,
+  CustomMutatorImpl,
+  MakeCustomMutatorInterface,
+  MakeCustomMutatorInterfaces,
+  PromiseWithServerResult,
+} from './client/custom.ts';
+export type {
+  Inspector,
+  Client as InspectorClient,
+  ClientGroup as InspectorClientGroup,
+  Query as InspectorQuery,
+} from './client/inspector/types.ts';
+export type {UpdateNeededReason, ZeroOptions} from './client/options.ts';
+export {Zero, type MakeEntityQueriesFromSchema} from './client/zero.ts';

--- a/packages/zql-integration-tests/package.json
+++ b/packages/zql-integration-tests/package.json
@@ -26,6 +26,5 @@
   "eslintConfig": {
     "extends": "../../eslint-config.json"
   },
-  "prettier": "@rocicorp/prettier-config",
-  "dependencies": {}
+  "prettier": "@rocicorp/prettier-config"
 }

--- a/packages/zql/src/ivm/operator.ts
+++ b/packages/zql/src/ivm/operator.ts
@@ -15,7 +15,7 @@ export interface Input {
 
   /**
    * Fetch data. May modify the data in place.
-   * Returns nodes sorted in order of {@linkcode SourceSchema.compareRows}.
+   * Returns nodes sorted in order of `SourceSchema.compareRows`.
    */
   fetch(req: FetchRequest): Stream<Node>;
 


### PR DESCRIPTION
This started as adding JSDoc to zero-client Query but ended up adding a simple doc server generated with Co-Pilot.

Usage

cd packages/zero-client
npm run docs:server

Then go ahead and open http://localhost:3000 in your browser.

Edit your JSDoc and see changes on save.