### PR TITLE
chore(test): use `zpg` instead of manual compiler invocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,5 @@ debug-scratch.md
 repro/
 packages/zero/docs
 packages/zero-client/docs
+
+Chinook_PostgreSql.sql

--- a/packages/zero-pg/src/query.ts
+++ b/packages/zero-pg/src/query.ts
@@ -39,7 +39,7 @@ export function makeSchemaQuery<S extends Schema>(
         return target[prop];
       }
 
-      const q = new Z2SQuery(
+      const q = new ZPGQuery(
         schema,
         this.#serverSchema,
         prop,
@@ -59,7 +59,7 @@ export function makeSchemaQuery<S extends Schema>(
     ) as SchemaQuery<S>;
 }
 
-export class Z2SQuery<
+export class ZPGQuery<
   TSchema extends Schema,
   TTable extends keyof TSchema['tables'] & string,
   TReturn = PullRow<TTable, TSchema>,
@@ -99,8 +99,8 @@ export class Z2SQuery<
     tableName: TTable,
     ast: AST,
     format: Format,
-  ): Z2SQuery<TSchema, TTable, TReturn> {
-    return new Z2SQuery(
+  ): ZPGQuery<TSchema, TTable, TReturn> {
+    return new ZPGQuery(
       schema,
       this.#serverSchema,
       tableName,


### PR DESCRIPTION
`zpg` removes some manual steps when using the z2s compiler