### PR TITLE
chore(zero-cache): allow custom change source to force an auto-reset in initial sync

### DIFF
--- a/packages/zero-cache/src/services/change-source/custom/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/custom/change-source.ts
@@ -185,6 +185,7 @@ export async function initialSync(
 
       case 'status':
         break; // Ignored
+      // @ts-expect-error: falls through if the tag is not 'reset-required
       case 'control': {
         const {tag, message} = change[1];
         if (tag === 'reset-required') {
@@ -192,10 +193,8 @@ export async function initialSync(
             message ?? 'auto-reset signaled by change source',
           );
         }
-        throw new Error(
-          `unexpected message during initial-sync: ${stringify(change)}`,
-        );
       }
+      // falls through
       case 'rollback':
         throw new Error(
           `unexpected message during initial-sync: ${stringify(change)}`,

--- a/packages/zero-cache/src/services/change-source/custom/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/custom/change-source.ts
@@ -13,7 +13,10 @@ import type {
   ChangeSource,
   ChangeStream,
 } from '../../change-streamer/change-streamer-service.ts';
-import {type ReplicationConfig} from '../../change-streamer/schema/tables.ts';
+import {
+  AutoResetSignal,
+  type ReplicationConfig,
+} from '../../change-streamer/schema/tables.ts';
 import {ChangeProcessor} from '../../replicator/change-processor.ts';
 import {initChangeLog} from '../../replicator/schema/change-log.ts';
 import {
@@ -182,7 +185,17 @@ export async function initialSync(
 
       case 'status':
         break; // Ignored
-      case 'control':
+      case 'control': {
+        const {tag, message} = change[1];
+        if (tag === 'reset-required') {
+          throw new AutoResetSignal(
+            message ?? 'auto-reset signaled by change source',
+          );
+        }
+        throw new Error(
+          `unexpected message during initial-sync: ${stringify(change)}`,
+        );
+      }
       case 'rollback':
         throw new Error(
           `unexpected message during initial-sync: ${stringify(change)}`,

--- a/packages/zero-cache/src/services/change-source/protocol/current/control.ts
+++ b/packages/zero-cache/src/services/change-source/protocol/current/control.ts
@@ -14,4 +14,7 @@ import * as v from '../../../../../../shared/src/valita.ts';
  * This signal should only be used in well advertised scenarios, and is not suitable
  * as a common occurrence in production.
  */
-export const resetRequiredSchema = v.object({tag: v.literal('reset-required')});
+export const resetRequiredSchema = v.object({
+  tag: v.literal('reset-required'),
+  message: v.string().optional(),
+});

--- a/packages/zero-cache/src/services/change-source/protocol/version.test.ts
+++ b/packages/zero-cache/src/services/change-source/protocol/version.test.ts
@@ -38,9 +38,9 @@ test('protocol versions', () => {
   // Then update the version number of the `CHANGE_SOURCE_PATH`
   // in current and export it appropriately as the new version
   // in `mod.ts`.
-  t(current, '3lxrltn74rwl7', '/changes/v0/stream');
+  t(current, '2v7p7445ss8ce', '/changes/v0/stream');
   // During initial development, we use v0 as a non-stable
   // version (i.e. breaking change are allowed). Once the
   // protocol graduates to v1, versions must be stable.
-  t(v0, '3lxrltn74rwl7', '/changes/v0/stream');
+  t(v0, '2v7p7445ss8ce', '/changes/v0/stream');
 });


### PR DESCRIPTION
Handle the change-source protocol message:

```js
 ['control', {tag: 'reset-required', message: ...}]
```

during initial sync of custom change sources, responding by auto-resetting and running initial sync from scratch.

User request: https://discord.com/channels/830183651022471199/1356728897085112411/1359618257983766609

@cbnsndwch 

@DAlperin 