### PR TITLE
chore(zql)!: Deprecate Query updateTTL

### DIFF
--- a/packages/ast-to-zql/src/ast-to-zql.test.ts
+++ b/packages/ast-to-zql/src/ast-to-zql.test.ts
@@ -1,10 +1,10 @@
 import {en, Faker, generateMersenne53Randomizer} from '@faker-js/faker';
 import {expect, test} from 'vitest';
 import {type AST} from '../../zero-protocol/src/ast.ts';
+import {ast} from '../../zql/src/query/query-impl.ts';
 import {staticQuery} from '../../zql/src/query/static-query.ts';
 import {generateQuery} from '../../zql/src/query/test/query-gen.ts';
 import {generateSchema} from '../../zql/src/query/test/schema-gen.ts';
-import {ast} from '../../zql/src/query/test/util.ts';
 import {astToZQL} from './ast-to-zql.ts';
 
 test('simple table selection', () => {

--- a/packages/ast-to-zql/src/ast-to-zql.ts
+++ b/packages/ast-to-zql/src/ast-to-zql.ts
@@ -21,7 +21,7 @@ import {SUBQ_PREFIX} from '../../zql/src/query/query-impl.ts';
  *
  * @example
  * ```
- * const ast = query.issue.where('id', '=', 123)[astForTestingSymbol];
+ * const ast = query.issue.where('id', '=', 123)[astSymbol];
  * console.log(astToZQL(ast)); // outputs: .where('id', '=', 123)
  * ```
  */

--- a/packages/zero-cache/src/auth/read-authorizer.query.test.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.query.test.ts
@@ -39,9 +39,8 @@ import type {Input} from '../../../zql/src/ivm/operator.ts';
 import type {Source} from '../../../zql/src/ivm/source.ts';
 import type {ExpressionBuilder} from '../../../zql/src/query/expression.ts';
 import {
-  completedAstSymbol,
+  completedAST,
   newQuery,
-  QueryImpl,
   type QueryDelegate,
 } from '../../../zql/src/query/query-impl.ts';
 import type {Query, Row} from '../../../zql/src/query/query.ts';
@@ -915,16 +914,17 @@ describe('issue permissions', () => {
   });
 });
 
-function ast(q: Query<ZeroSchema, string>) {
-  return (q as QueryImpl<ZeroSchema, string>)[completedAstSymbol];
-}
-
 function runReadQueryWithPermissions(
   authData: AuthData,
   query: Query<ZeroSchema, string>,
 ) {
   const updatedAst = bindStaticParameters(
-    transformQuery(new LogContext('debug'), ast(query), permissions, authData),
+    transformQuery(
+      new LogContext('debug'),
+      completedAST(query),
+      permissions,
+      authData,
+    ),
     {
       authData,
       preMutationRow: undefined,

--- a/packages/zero-cache/src/auth/read-authorizer.test.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.test.ts
@@ -2,7 +2,6 @@ import {describe, expect, test} from 'vitest';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
 import {must} from '../../../shared/src/must.ts';
 import {relationships} from '../../../zero-schema/src/builder/relationship-builder.ts';
-import type {Schema as ZeroSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import {string, table} from '../../../zero-schema/src/builder/table-builder.ts';
 import {
@@ -11,21 +10,15 @@ import {
 } from '../../../zero-schema/src/permissions.ts';
 import type {ExpressionBuilder} from '../../../zql/src/query/expression.ts';
 import {
-  astForTestingSymbol,
+  ast,
   newQuery,
-  QueryImpl,
   type QueryDelegate,
 } from '../../../zql/src/query/query-impl.ts';
-import type {Query} from '../../../zql/src/query/query.ts';
 import {transformQuery} from './read-authorizer.ts';
 
 const mockDelegate = {} as QueryDelegate;
 
 const lc = createSilentLogContext();
-
-function ast(q: Query<ZeroSchema, string>) {
-  return (q as QueryImpl<ZeroSchema, string>)[astForTestingSymbol];
-}
 
 const unreadable = table('unreadable')
   .columns({

--- a/packages/zero-pg/src/query.ts
+++ b/packages/zero-pg/src/query.ts
@@ -7,7 +7,6 @@ import type {Format} from '../../zql/src/ivm/view.ts';
 import type {DBTransaction, SchemaQuery} from '../../zql/src/mutate/custom.ts';
 import {AbstractQuery, defaultFormat} from '../../zql/src/query/query-impl.ts';
 import type {HumanReadable, PullRow, Query} from '../../zql/src/query/query.ts';
-import type {TTL} from '../../zql/src/query/ttl.ts';
 import type {TypedView} from '../../zql/src/query/typed-view.ts';
 
 export function makeSchemaQuery<S extends Schema>(
@@ -147,9 +146,5 @@ export class ZPGQuery<
 
   materialize(): TypedView<HumanReadable<TReturn>> {
     throw new Error('Z2SQuery cannot be materialized');
-  }
-
-  updateTTL(_ttl: TTL): void {
-    throw new Error('Z2SQuery cannot have a TTL');
   }
 }

--- a/packages/zero-solid/src/solid-view.test.ts
+++ b/packages/zero-solid/src/solid-view.test.ts
@@ -45,6 +45,7 @@ test('basics', () => {
     format,
     onDestroy,
     queryComplete,
+    () => {},
   );
 
   const state0 = [
@@ -105,6 +106,7 @@ test('single-format', () => {
     {singular: true, relationships: {}},
     () => {},
     true,
+    () => {},
   );
 
   const state0 = {a: 1, b: 'a', [refCountSymbol]: 1};
@@ -151,6 +153,7 @@ test('hydrate-empty', () => {
     format,
     onDestroy,
     queryComplete,
+    () => {},
   );
 
   expect(view.data).toEqual([]);
@@ -212,6 +215,7 @@ test('tree', () => {
     },
     () => {},
     true,
+    () => {},
   );
 
   const state0 = [
@@ -528,6 +532,7 @@ test('tree-single', () => {
     },
     () => {},
     true,
+    () => {},
   );
 
   const state0 = {
@@ -646,6 +651,7 @@ test('collapse', () => {
     },
     () => {},
     true,
+    () => {},
   );
 
   const state0: unknown[] = [];
@@ -1141,6 +1147,7 @@ test('collapse-single', () => {
     },
     () => {},
     true,
+    () => {},
   );
 
   const state0: unknown[] = [];
@@ -1220,6 +1227,7 @@ test('basic with edit pushes', () => {
     {singular: false, relationships: {}},
     () => {},
     true,
+    () => {},
   );
 
   const state0 = [
@@ -1302,6 +1310,7 @@ test('tree edit', () => {
     },
     () => {},
     true,
+    () => {},
   );
 
   const state0 = [
@@ -1520,6 +1529,7 @@ test('edit to change the order', () => {
     {singular: false, relationships: {}},
     () => {},
     true,
+    () => {},
   );
 
   const state0 = [
@@ -1631,6 +1641,7 @@ test('edit to preserve relationships', () => {
     },
     () => {},
     true,
+    () => {},
   );
 
   const state0: unknown[] = [];
@@ -1835,6 +1846,7 @@ test('edit leaf', () => {
     },
     () => {},
     true,
+    () => {},
   );
 
   const state0: unknown[] = [];
@@ -2086,6 +2098,7 @@ test('queryComplete promise', async () => {
     {singular: false, relationships: {}},
     () => {},
     queryCompleteResolver.promise,
+    () => {},
   );
 
   expect(view.data).toMatchInlineSnapshot(`
@@ -2148,6 +2161,7 @@ test('factory', () => {
     onDestroy,
     onTransactionCommit,
     true,
+    () => {},
   );
 
   expect(onTransactionCommit).toHaveBeenCalledTimes(1);

--- a/packages/zero-solid/src/use-query.ts
+++ b/packages/zero-solid/src/use-query.ts
@@ -66,7 +66,7 @@ function getView<
     view = query.materialize(solidViewFactory, ttl);
     views.set(query, view);
   } else {
-    query.updateTTL(ttl);
+    view.updateTTL(ttl);
   }
   viewRefCount.inc(view);
   return view as SolidView<HumanReadable<TReturn>>;

--- a/packages/zql/src/ivm/array-view.test.ts
+++ b/packages/zql/src/ivm/array-view.test.ts
@@ -32,6 +32,9 @@ test('basics', () => {
       ['b', 'asc'],
       ['a', 'asc'],
     ]),
+    {singular: false, relationships: {}},
+    true,
+    () => {},
   );
 
   let callCount = 0;
@@ -132,6 +135,8 @@ test('single-format', () => {
       ['a', 'asc'],
     ]),
     {singular: true, relationships: {}},
+    true,
+    () => {},
   );
 
   let callCount = 0;
@@ -180,6 +185,9 @@ test('hydrate-empty', () => {
       ['b', 'asc'],
       ['a', 'asc'],
     ]),
+    {singular: false, relationships: {}},
+    true,
+    () => {},
   );
 
   let callCount = 0;
@@ -236,10 +244,15 @@ test('tree', () => {
     system: 'client',
   });
 
-  const view = new ArrayView(join, {
-    singular: false,
-    relationships: {children: {singular: false, relationships: {}}},
-  });
+  const view = new ArrayView(
+    join,
+    {
+      singular: false,
+      relationships: {children: {singular: false, relationships: {}}},
+    },
+    true,
+    () => {},
+  );
   let data: unknown[] = [];
   view.addListener(entries => {
     assertArray(entries);
@@ -548,10 +561,15 @@ test('tree-single', () => {
     system: 'client',
   });
 
-  const view = new ArrayView(join, {
-    singular: true,
-    relationships: {child: {singular: true, relationships: {}}},
-  });
+  const view = new ArrayView(
+    join,
+    {
+      singular: true,
+      relationships: {child: {singular: true, relationships: {}}},
+    },
+    true,
+    () => {},
+  );
   let data: unknown;
   view.addListener(d => {
     data = structuredClone(d);
@@ -650,10 +668,15 @@ test('collapse', () => {
     setOutput() {},
   };
 
-  const view = new ArrayView(input, {
-    singular: false,
-    relationships: {labels: {singular: false, relationships: {}}},
-  });
+  const view = new ArrayView(
+    input,
+    {
+      singular: false,
+      relationships: {labels: {singular: false, relationships: {}}},
+    },
+    true,
+    () => {},
+  );
   let data: unknown[] = [];
   view.addListener(entries => {
     assertArray(entries);
@@ -1132,10 +1155,15 @@ test('collapse-single', () => {
     },
   };
 
-  const view = new ArrayView(input, {
-    singular: false,
-    relationships: {labels: {singular: true, relationships: {}}},
-  });
+  const view = new ArrayView(
+    input,
+    {
+      singular: false,
+      relationships: {labels: {singular: true, relationships: {}}},
+    },
+    true,
+    () => {},
+  );
   let data: unknown;
   view.addListener(d => {
     data = structuredClone(d);
@@ -1200,7 +1228,12 @@ test('basic with edit pushes', () => {
   ms.push({row: {a: 1, b: 'a'}, type: 'add'});
   ms.push({row: {a: 2, b: 'b'}, type: 'add'});
 
-  const view = new ArrayView(ms.connect([['a', 'asc']]));
+  const view = new ArrayView(
+    ms.connect([['a', 'asc']]),
+    {singular: false, relationships: {}},
+    true,
+    () => {},
+  );
 
   let callCount = 0;
   let data: unknown[] = [];
@@ -1310,10 +1343,15 @@ test('tree edit', () => {
     system: 'client',
   });
 
-  const view = new ArrayView(join, {
-    singular: false,
-    relationships: {children: {singular: false, relationships: {}}},
-  });
+  const view = new ArrayView(
+    join,
+    {
+      singular: false,
+      relationships: {children: {singular: false, relationships: {}}},
+    },
+    true,
+    () => {},
+  );
   let data: unknown[] = [];
   view.addListener(entries => {
     assertArray(entries);
@@ -1450,7 +1488,12 @@ test('edit to change the order', () => {
     ms.push({row, type: 'add'});
   }
 
-  const view = new ArrayView(ms.connect([['a', 'asc']]));
+  const view = new ArrayView(
+    ms.connect([['a', 'asc']]),
+    {singular: false, relationships: {}},
+    true,
+    () => {},
+  );
   let data: unknown[] = [];
   view.addListener(entries => {
     assertArray(entries);
@@ -1597,10 +1640,15 @@ test('edit to preserve relationships', () => {
     },
   };
 
-  const view = new ArrayView(input, {
-    singular: false,
-    relationships: {labels: {singular: false, relationships: {}}},
-  });
+  const view = new ArrayView(
+    input,
+    {
+      singular: false,
+      relationships: {labels: {singular: false, relationships: {}}},
+    },
+    true,
+    () => void 0,
+  );
   view.push({
     type: 'add',
     node: {

--- a/packages/zql/src/ivm/array-view.ts
+++ b/packages/zql/src/ivm/array-view.ts
@@ -1,5 +1,6 @@
 import {assert} from '../../../shared/src/asserts.ts';
 import type {Immutable} from '../../../shared/src/immutable.ts';
+import type {TTL} from '../query/ttl.ts';
 import type {Listener, TypedView} from '../query/typed-view.ts';
 import type {Change} from './change.ts';
 import type {Input, Output} from './operator.ts';
@@ -32,15 +33,18 @@ export class ArrayView<V extends View> implements Output, TypedView<V> {
 
   #dirty = false;
   #complete = false;
+  readonly #updateTTL: (ttl: TTL) => void;
 
   constructor(
     input: Input,
-    format: Format = {singular: false, relationships: {}},
-    queryComplete: true | Promise<true> = true,
+    format: Format, // = {singular: false, relationships: {}},
+    queryComplete: true | Promise<true>, // = true,
+    updateTTL: (ttl: TTL) => void,
   ) {
     this.#input = input;
     this.#schema = input.getSchema();
     this.#format = format;
+    this.#updateTTL = updateTTL;
     this.#root = {'': format.singular ? undefined : []};
     input.setOutput(this);
 
@@ -112,5 +116,9 @@ export class ArrayView<V extends View> implements Output, TypedView<V> {
     }
     this.#dirty = false;
     this.#fireListeners();
+  }
+
+  updateTTL(ttl: TTL) {
+    this.#updateTTL(ttl);
   }
 }

--- a/packages/zql/src/ivm/test/push-tests.ts
+++ b/packages/zql/src/ivm/test/push-tests.ts
@@ -1,19 +1,19 @@
 import {expect} from 'vitest';
+import {testLogConfig} from '../../../../otel/src/test-log-config.ts';
+import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {must} from '../../../../shared/src/must.ts';
 import type {AST} from '../../../../zero-protocol/src/ast.ts';
 import type {Row} from '../../../../zero-protocol/src/data.ts';
 import type {PrimaryKey} from '../../../../zero-protocol/src/primary-key.ts';
 import type {SchemaValue} from '../../../../zero-schema/src/table-schema.ts';
+import {buildPipeline} from '../../builder/builder.ts';
+import {TestBuilderDelegate} from '../../builder/test-builder-delegate.ts';
 import {ArrayView} from '../array-view.ts';
 import {Catch} from '../catch.ts';
 import type {Input} from '../operator.ts';
 import type {Source, SourceChange} from '../source.ts';
 import type {Format} from '../view.ts';
 import {createSource} from './source-factory.ts';
-import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
-import {TestBuilderDelegate} from '../../builder/test-builder-delegate.ts';
-import {buildPipeline} from '../../builder/builder.ts';
-import {testLogConfig} from '../../../../otel/src/test-log-config.ts';
 
 const lc = createSilentLogContext();
 
@@ -100,7 +100,7 @@ export function runPushTest(t: PushTest) {
     finalOutput: view,
     actualStorage: actualStorage2,
   } = innerTest(j => {
-    const view = new ArrayView(j, t.format);
+    const view = new ArrayView(j, t.format, true, () => {});
     data = view.data;
     return view;
   });

--- a/packages/zql/src/ivm/view.ts
+++ b/packages/zql/src/ivm/view.ts
@@ -1,6 +1,7 @@
 import type {Value} from '../../../zero-protocol/src/data.ts';
 import type {Schema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import type {Query} from '../query/query.ts';
+import type {TTL} from '../query/ttl.ts';
 import type {Input} from './operator.ts';
 
 export type View = EntryList | Entry | undefined;
@@ -24,4 +25,5 @@ export type ViewFactory<
   onDestroy: () => void,
   onTransactionCommit: (cb: () => void) => void,
   queryComplete: true | Promise<true>,
+  updateTTL: (ttl: TTL) => void,
 ) => T;

--- a/packages/zql/src/query/query-impl.ast.test.ts
+++ b/packages/zql/src/query/query-impl.ast.test.ts
@@ -1,20 +1,9 @@
 import {describe, expect, test} from 'vitest';
-import type {Schema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import type {ExpressionFactory} from './expression.ts';
-import {
-  astForTestingSymbol,
-  newQuery,
-  QueryImpl,
-  type QueryDelegate,
-} from './query-impl.ts';
-import type {Query} from './query.ts';
+import {ast, newQuery, type QueryDelegate} from './query-impl.ts';
 import {schema} from './test/test-schemas.ts';
 
 const mockDelegate = {} as QueryDelegate;
-
-function ast(q: Query<Schema, string>) {
-  return (q as QueryImpl<Schema, string>)[astForTestingSymbol];
-}
 
 describe('building the AST', () => {
   test('creates a new query', () => {

--- a/packages/zql/src/query/query.ts
+++ b/packages/zql/src/query/query.ts
@@ -142,8 +142,11 @@ export interface Query<
   TTable extends keyof TSchema['tables'] & string,
   TReturn = PullRow<TTable, TSchema>,
 > extends PromiseLike<HumanReadable<TReturn>> {
-  // TODO(arv): This does not really belong here. It is used by materialize to
-  // determine the format of the view. Maybe make it part of materialize?
+  /**
+   * Format is used to specify the shape of the query results. This is used by
+   * {@linkcode one} and it also describes the shape when using
+   * {@linkcode related}.
+   */
   readonly format: Format;
 
   /**
@@ -151,11 +154,6 @@ export interface Query<
    * if two queries are the same.
    */
   hash(): string;
-
-  // TODO(arv): This API sucks! Everything else is either read only or returns a new query... this one on the other hand
-  // finds the underlying query manager and tells the server about the new TTL.
-  // A better API would be to have a way to get the QueryManager and then call a method on it to update the TTL.
-  updateTTL(ttl: TTL): void;
 
   /**
    * Related is used to add a related query to the current query. This is used

--- a/packages/zql/src/query/static-query.ts
+++ b/packages/zql/src/query/static-query.ts
@@ -4,7 +4,6 @@ import type {Format} from '../ivm/view.ts';
 import {ExpressionBuilder} from './expression.ts';
 import {AbstractQuery, defaultFormat} from './query-impl.ts';
 import type {HumanReadable, PullRow, Query} from './query.ts';
-import type {TTL} from './ttl.ts';
 import type {TypedView} from './typed-view.ts';
 
 export function staticQuery<
@@ -64,9 +63,5 @@ export class StaticQuery<
     complete: Promise<void>;
   } {
     throw new Error('StaticQuery cannot be preloaded');
-  }
-
-  updateTTL(_ttl: TTL): void {
-    throw new Error('StaticQuery cannot have a TTL');
   }
 }

--- a/packages/zql/src/query/test/query-gen.ts
+++ b/packages/zql/src/query/test/query-gen.ts
@@ -1,9 +1,9 @@
 import type {Faker} from '@faker-js/faker';
 import type {Schema} from '../../../../zero-schema/src/builder/schema-builder.ts';
+import {ast} from '../query-impl.ts';
 import {staticQuery} from '../static-query.ts';
 import type {Row} from '../../../../zero-protocol/src/data.ts';
 import {
-  ast,
   randomValueForType,
   selectRandom,
   shuffle,

--- a/packages/zql/src/query/test/util.ts
+++ b/packages/zql/src/query/test/util.ts
@@ -1,17 +1,11 @@
 import type {Faker} from '@faker-js/faker';
 import type {ValueType} from '../../../../zero-schema/src/table-schema.ts';
-import {AbstractQuery, astForTestingSymbol} from '../query-impl.ts';
 import type {Query} from '../query.ts';
 
 export type Rng = () => number;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyQuery = Query<any, any, any>;
-
-export function ast(query: AnyQuery) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return (query as AbstractQuery<any, any>)[astForTestingSymbol];
-}
 
 export function selectRandom<T>(rng: Rng, values: readonly T[]): T {
   return values[Math.floor(rng() * values.length)];

--- a/packages/zql/src/query/typed-view.ts
+++ b/packages/zql/src/query/typed-view.ts
@@ -1,4 +1,5 @@
 import type {Immutable} from '../../../shared/src/immutable.ts';
+import type {TTL} from './ttl.ts';
 
 export type ResultType = 'unknown' | 'complete';
 
@@ -12,5 +13,6 @@ export type Listener<T> = (data: Immutable<T>, resultType: ResultType) => void;
 export type TypedView<T> = {
   addListener(listener: Listener<T>): () => void;
   destroy(): void;
+  updateTTL(ttl: TTL): void;
   readonly data: T;
 };


### PR DESCRIPTION
BREAKING CHANGE. Bindings need to be updated.

Instead of hanging this of off the Query we add it to the View that materialize returns. This allows us to remove the updateTTL method from the Query interface and the QueryImpl class.