### PR TITLE
fix(ast-to-zql): remove extraneous paren

### DIFF
--- a/packages/ast-to-zql/src/ast-to-zql.test.ts
+++ b/packages/ast-to-zql/src/ast-to-zql.test.ts
@@ -471,7 +471,7 @@ test('EXISTS with order', () => {
   };
 
   expect(astToZQL(ast)).toMatchInlineSnapshot(
-    `".whereExists('recruiter', q => q.where('y', '>', 0))).orderBy('id', 'asc')"`,
+    `".whereExists('recruiter', q => q.where('y', '>', 0)).orderBy('id', 'asc')"`,
   );
 });
 

--- a/packages/ast-to-zql/src/ast-to-zql.ts
+++ b/packages/ast-to-zql/src/ast-to-zql.ts
@@ -166,7 +166,7 @@ function transformExistsCondition(
     if (prefix === '.where') {
       return `.whereExists('${relationship}', q => q${astToZQL(
         related.subquery,
-      )}))`;
+      )})`;
     }
     prefix satisfies 'cmp';
     args.add('exists');


### PR DESCRIPTION
# JSON

```json
{
  "limit": 50,
  "table": "email_message",
  "where": {
    "type": "and",
    "conditions": [
      {
        "op": "EXISTS",
        "type": "correlatedSubquery",
        "related": {
          "system": "client",
          "subquery": {
            "alias": "zsubq_member_states",
            "table": "email_message_member_state",
            "where": {
              "type": "and",
              "conditions": [
                {
                  "op": "=",
                  "left": {
                    "name": "direction",
                    "type": "column"
                  },
                  "type": "simple",
                  "right": {
                    "type": "literal",
                    "value": "OUTBOUND"
                  }
                },
                {
                  "type": "simple",
                  "left": {
                    "type": "column",
                    "name": "workspace_id"
                  },
                  "right": {
                    "type": "literal",
                    "value": null
                  },
                  "op": "="
                }
              ]
            },
            "orderBy": [
              [
                "id",
                "asc"
              ]
            ]
          },
          "correlation": {
            "childField": [
              "message_id"
            ],
            "parentField": [
              "id"
            ]
          }
        }
      },
      {
        "type": "simple",
        "left": {
          "type": "column",
          "name": "workspace_id"
        },
        "right": {
          "type": "literal",
          "value": null
        },
        "op": "="
      }
    ]
  },
  "orderBy": [
    [
      "id",
      "asc"
    ]
  ]
}
```

# Before

```
cat json | npx ast-to-zql
Warning: Unable to format output with prettier: SyntaxError: ';' expected. (1:137)
> 1 | query.email_message.whereExists('member_states', q => q.where('direction', 'OUTBOUND').where('workspace_id', null).orderBy('id', 'asc'))).where('workspace_id', null).orderBy('id', 'asc').limit(50)
```


# After

```
cat json | npx ast-to-zql
query.email_message
  .whereExists('member_states', q =>
    q
      .where('direction', 'OUTBOUND')
      .where('workspace_id', null)
      .orderBy('id', 'asc'),
  )
  .where('workspace_id', null)
  .orderBy('id', 'asc')
  .limit(50)
```