### PR TITLE
chore(zero-cache): always run through the top-level dispatcher

### DIFF
--- a/packages/zero-cache/src/server/runner/config.test.ts
+++ b/packages/zero-cache/src/server/runner/config.test.ts
@@ -103,7 +103,7 @@ test('parse options', () => {
             },
             "host": "normalize.me",
             "id": "ten-boo",
-            "path": "/tenboo",
+            "path": "/tenboo/",
           },
           {
             "env": {
@@ -113,7 +113,7 @@ test('parse options', () => {
               "ZERO_REPLICA_FILE": "tenbar.db",
             },
             "id": "ten_bar",
-            "path": "/tenbar",
+            "path": "/tenbar/",
           },
           {
             "env": {
@@ -124,7 +124,7 @@ test('parse options', () => {
               "ZERO_UPSTREAM_DB": "overridden",
             },
             "id": "tenbaz-123",
-            "path": "/tenbaz",
+            "path": "/tenbaz/",
           },
         ],
         "upstream": {

--- a/packages/zero-cache/src/server/runner/config.ts
+++ b/packages/zero-cache/src/server/runner/config.ts
@@ -74,7 +74,8 @@ const tenantSchema = v.object({
       if (p.indexOf('/', 1) >= 0) {
         return v.err(`Only a single path component may be specified: ${p}`);
       }
-      return v.ok(p[0] === '/' ? p : '/' + p);
+      p = p[0] === '/' ? p : '/' + p;
+      return v.ok(p + '/'); // normalized to '/{path}/'
     })
     .optional(),
   env: zeroEnvSchema.partial().extend({

--- a/packages/zero-cache/src/server/runner/zero-dispatcher.ts
+++ b/packages/zero-cache/src/server/runner/zero-dispatcher.ts
@@ -1,18 +1,22 @@
 import type {LogContext} from '@rocicorp/logger';
+import {assert} from '../../../../shared/src/asserts.ts';
 import {installWebSocketHandoff} from '../../services/dispatcher/websocket-handoff.ts';
 import {HttpService, type Options} from '../../services/http-service.ts';
 import type {IncomingMessageSubset} from '../../types/http.ts';
 import type {Worker} from '../../types/processes.ts';
 
 type Tenant = {
+  // Note: The empty signifies the sole tenant. This can only be provided
+  //       internally, as ID's specified via --tenants-json are normalized to
+  //       be non-empty.
   id: string;
   host?: string | undefined;
   path?: string | undefined;
   worker: Worker;
 };
 
-export class TenantDispatcher extends HttpService {
-  readonly id = 'tenant-dispatcher';
+export class ZeroDispatcher extends HttpService {
+  readonly id = 'zero-dispatcher';
   readonly #tenants: Tenant[];
   readonly #runAsReplicationManager: boolean;
 
@@ -22,15 +26,16 @@ export class TenantDispatcher extends HttpService {
     tenants: Tenant[],
     opts: Options,
   ) {
-    super('tenant-dispatcher', lc, opts, fastify => {
+    super('zero-dispatcher', lc, opts, fastify => {
       installWebSocketHandoff(lc, req => this.#handoff(req), fastify.server);
     });
 
     this.#runAsReplicationManager = runAsReplicationManager;
     this.#tenants = tenants.filter(
       // Only tenants with a host or path can be dispatched to
-      // in the view-syncer.
-      t => runAsReplicationManager || t.host || t.path,
+      // in the view-syncer (with the exception of the single tenant
+      // case, signified by the empty id).
+      t => runAsReplicationManager || t.host || t.path || t.id.length === 0,
     );
   }
 
@@ -40,6 +45,11 @@ export class TenantDispatcher extends HttpService {
     const {pathname} = new URL(u ?? '', `http://${host}/`);
 
     for (const t of this.#tenants) {
+      if (t.id.length === 0) {
+        // sole tenant
+        assert(this.#tenants.length === 1);
+        return {payload: t.id, receiver: t.worker};
+      }
       if (this.#runAsReplicationManager) {
         // The replication-manager dispatches internally using the
         // tenant ID as the first path component
@@ -51,7 +61,7 @@ export class TenantDispatcher extends HttpService {
       if (t.host && t.host !== host) {
         continue;
       }
-      if (t.path && pathname !== t.path && !pathname.startsWith(t.path + '/')) {
+      if (t.path && !pathname.startsWith(t.path)) {
         continue;
       }
       this._lc.debug?.(`connecting ${host}${pathname} to ${t.id}`);


### PR DESCRIPTION
Rename the former `TenantDispatcher` to the `ZeroDispatcher` and always use it for dispatch to the zero-cache(s), even when there is only a single "tenant".

This will facilitate building top-level process management features that can apply to all scenarios.