### PR TITLE
feat(zero-cache): option to run the zero-cache lazily

### DIFF
--- a/packages/shared/src/options.ts
+++ b/packages/shared/src/options.ts
@@ -104,14 +104,13 @@ export type Group = Record<string, Option>;
 export type Options = Record<string, Group | Option>;
 
 /** Unwrap the Value type from an Option<V>. */
-type ValueOf<T extends Option> =
-  T extends v.Optional<infer V>
-    ? V | undefined
-    : T extends v.Type<infer V>
-      ? V
-      : T extends WrappedOptionType
-        ? ValueOf<T['type']>
-        : never;
+type ValueOf<T extends Option> = T extends v.Optional<infer V>
+  ? V | undefined
+  : T extends v.Type<infer V>
+  ? V
+  : T extends WrappedOptionType
+  ? ValueOf<T['type']>
+  : never;
 
 type Required =
   | RequiredOptionType
@@ -154,8 +153,8 @@ export type Config<O extends Options> = {
     : never]: O[P] extends Required
     ? ValueOf<O[P]>
     : O[P] extends Group
-      ? ConfigGroup<O[P]>
-      : never;
+    ? ConfigGroup<O[P]>
+    : never;
 } & {
   // Values for optional options are in optional fields.
   [P in keyof O as O[P] extends Optional ? P : never]?: O[P] extends Optional
@@ -342,8 +341,8 @@ export function parseOptionsAdvanced<T extends Options>(
       (required
         ? '{italic required}'
         : defaultValue !== undefined
-          ? `default: ${JSON.stringify(defaultValue)}`
-          : 'optional') + '\n',
+        ? `default: ${JSON.stringify(defaultValue)}`
+        : 'optional') + '\n',
     ];
     if (desc) {
       spec.push(...desc);
@@ -353,8 +352,8 @@ export function parseOptionsAdvanced<T extends Options>(
       literals.size
         ? String([...literals].map(l => `{underline ${l}}`))
         : multiple
-          ? `{underline ${terminalType}[]}`
-          : `{underline ${terminalType}}`,
+        ? `{underline ${terminalType}[]}`
+        : `{underline ${terminalType}}`,
       `  ${env} env`,
     ];
 
@@ -441,15 +440,8 @@ function valueParser(flagName: string, typeName: string) {
     switch (typeName) {
       case 'string':
         return input;
-      case 'boolean': {
-        const bool = input.toLowerCase();
-        if (['true', '1'].includes(bool)) {
-          return true;
-        } else if (['false', '0'].includes(bool)) {
-          return false;
-        }
-        throw new TypeError(`Invalid input for --${flagName}: "${input}"`);
-      }
+      case 'boolean':
+        return parseBoolean(flagName, input);
       case 'number': {
         const val = Number(input);
         if (Number.isNaN(val)) {
@@ -520,6 +512,16 @@ function parseArgs(
   }
 
   return [result, envObj, unknown] as const;
+}
+
+export function parseBoolean(flagName: string, input: string) {
+  const bool = input.toLowerCase();
+  if (['true', '1'].includes(bool)) {
+    return true;
+  } else if (['false', '0'].includes(bool)) {
+    return false;
+  }
+  throw new TypeError(`Invalid input for --${flagName}: "${input}"`);
 }
 
 function showUsage(

--- a/packages/shared/src/options.ts
+++ b/packages/shared/src/options.ts
@@ -104,13 +104,14 @@ export type Group = Record<string, Option>;
 export type Options = Record<string, Group | Option>;
 
 /** Unwrap the Value type from an Option<V>. */
-type ValueOf<T extends Option> = T extends v.Optional<infer V>
-  ? V | undefined
-  : T extends v.Type<infer V>
-  ? V
-  : T extends WrappedOptionType
-  ? ValueOf<T['type']>
-  : never;
+type ValueOf<T extends Option> =
+  T extends v.Optional<infer V>
+    ? V | undefined
+    : T extends v.Type<infer V>
+      ? V
+      : T extends WrappedOptionType
+        ? ValueOf<T['type']>
+        : never;
 
 type Required =
   | RequiredOptionType
@@ -153,8 +154,8 @@ export type Config<O extends Options> = {
     : never]: O[P] extends Required
     ? ValueOf<O[P]>
     : O[P] extends Group
-    ? ConfigGroup<O[P]>
-    : never;
+      ? ConfigGroup<O[P]>
+      : never;
 } & {
   // Values for optional options are in optional fields.
   [P in keyof O as O[P] extends Optional ? P : never]?: O[P] extends Optional
@@ -341,8 +342,8 @@ export function parseOptionsAdvanced<T extends Options>(
       (required
         ? '{italic required}'
         : defaultValue !== undefined
-        ? `default: ${JSON.stringify(defaultValue)}`
-        : 'optional') + '\n',
+          ? `default: ${JSON.stringify(defaultValue)}`
+          : 'optional') + '\n',
     ];
     if (desc) {
       spec.push(...desc);
@@ -352,8 +353,8 @@ export function parseOptionsAdvanced<T extends Options>(
       literals.size
         ? String([...literals].map(l => `{underline ${l}}`))
         : multiple
-        ? `{underline ${terminalType}[]}`
-        : `{underline ${terminalType}}`,
+          ? `{underline ${terminalType}[]}`
+          : `{underline ${terminalType}}`,
       `  ${env} env`,
     ];
 

--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -306,6 +306,7 @@ test('zero-cache --help', () => {
                                                                 the replication-manager (to know where to continue replication from). If the                      
                                                                 replication-manager has never run, there will be no replica file to restore, and                  
                                                                 the view-syncer will fail to start up, never connecting to the replication-manager.               
+                                                                                                                                                                  
                                                                 As such, it is not recommended to run a replication-manager lazily.                               
                                                                                                                                                                   
     "

--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -296,6 +296,18 @@ test('zero-cache --help', () => {
                                                                 Active queries, on the other hand, are never evicted and are allowed to use more                  
                                                                 rows than the limit.                                                                              
                                                                                                                                                                   
+     --run-lazily boolean                                       default: false                                                                                    
+       ZERO_RUN_LAZILY env                                                                                                                                        
+                                                                Delay starting the zero-cache processes until the first request.                                  
+                                                                                                                                                                  
+                                                                Note: This works as expected in single-node mode. While it is technically usable                  
+                                                                in a multi-node setup, there is a bootstrapping complication in that the                          
+                                                                view-syncer must first restore the replica from litestream before connecting to                   
+                                                                the replication-manager (to know where to continue replication from). If the                      
+                                                                replication-manager has never run, there will be no replica file to restore, and                  
+                                                                the view-syncer will fail to start up, never connecting to the replication-manager.               
+                                                                As such, it is not recommended to run a replication-manager lazily.                               
+                                                                                                                                                                  
     "
   `);
 });

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -480,6 +480,7 @@ export const zeroOptions = {
         'the replication-manager (to know where to continue replication from). If the',
         'replication-manager has never run, there will be no replica file to restore, and',
         'the view-syncer will fail to start up, never connecting to the replication-manager.',
+        '',
         'As such, it is not recommended to run a replication-manager lazily.',
       ],
     },

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -467,6 +467,23 @@ export const zeroOptions = {
       'rows than the limit.',
     ],
   },
+
+  run: {
+    lazily: {
+      type: v.boolean().default(false),
+      desc: [
+        'Delay starting the zero-cache processes until the first request.',
+        '',
+        'Note: This works as expected in single-node mode. While it is technically usable',
+        'in a multi-node setup, there is a bootstrapping complication in that the',
+        'view-syncer must first restore the replica from litestream before connecting to',
+        'the replication-manager (to know where to continue replication from). If the',
+        'replication-manager has never run, there will be no replica file to restore, and',
+        'the view-syncer will fail to start up, never connecting to the replication-manager.',
+        'As such, it is not recommended to run a replication-manager lazily.',
+      ],
+    },
+  },
 };
 
 export type ZeroConfig = Config<typeof zeroOptions>;

--- a/packages/zero-cache/src/integration/integration.pg-test.ts
+++ b/packages/zero-cache/src/integration/integration.pg-test.ts
@@ -527,6 +527,12 @@ describe('integration', {timeout: 30000}, () => {
     ['single-node standalone', 'pg', () => [env], undefined],
     ['replica identity full', 'pg', () => [env], 'FULL'],
     [
+      'lazy single-node standalone',
+      'pg',
+      () => [{...env, ['ZERO_RUN_LAZILY']: 'true'}],
+      undefined,
+    ],
+    [
       'single-node multi-tenant direct-dispatch',
       'pg',
       () => [
@@ -561,6 +567,27 @@ describe('integration', {timeout: 30000}, () => {
       undefined,
     ],
     [
+      'lazy single-node multi-tenant, double-dispatch',
+      'pg',
+      () => [
+        {
+          ['ZERO_PORT']: String(port),
+          ['ZERO_LOG_LEVEL']: LOG_LEVEL,
+          ['ZERO_TENANTS_JSON']: JSON.stringify({
+            tenants: [
+              {
+                id: 'tenant',
+                path: '/zero',
+                env: {...env, ['ZERO_PORT']: String(port + 3)},
+              },
+            ],
+          }),
+          ['ZERO_RUN_LAZILY']: 'true',
+        },
+      ],
+      undefined,
+    ],
+    [
       'multi-node standalone',
       'pg',
       () => [
@@ -575,6 +602,26 @@ describe('integration', {timeout: 30000}, () => {
           ...env,
           ['ZERO_CHANGE_STREAMER_URI']: `http://localhost:${port2 + 1}`,
           ['ZERO_REPLICA_FILE']: replicaDbFile2.path,
+        },
+      ],
+      undefined,
+    ],
+    [
+      'lazy view-syncer multi-node standalone',
+      'pg',
+      () => [
+        // The replication-manager must be started first for initial-sync
+        {
+          ...env,
+          ['ZERO_PORT']: `${port2}`,
+          ['ZERO_NUM_SYNC_WORKERS']: '0',
+        },
+        // startZero() will then copy to replicaDbFile2 for the view-syncer
+        {
+          ...env,
+          ['ZERO_CHANGE_STREAMER_URI']: `http://localhost:${port2 + 1}`,
+          ['ZERO_REPLICA_FILE']: replicaDbFile2.path,
+          ['ZERO_RUN_LAZILY']: 'true',
         },
       ],
       undefined,

--- a/packages/zero-cache/src/server/runner/config.test.ts
+++ b/packages/zero-cache/src/server/runner/config.test.ts
@@ -89,6 +89,9 @@ test('parse options', () => {
         "port": 4848,
         "push": {},
         "replica": {},
+        "run": {
+          "lazily": false,
+        },
         "shard": {
           "num": 0,
         },
@@ -154,6 +157,7 @@ test('parse options', () => {
         "ZERO_LOG_SLOW_ROW_THRESHOLD": "2",
         "ZERO_PER_USER_MUTATION_LIMIT_WINDOW_MS": "60000",
         "ZERO_PORT": "4848",
+        "ZERO_RUN_LAZILY": "false",
         "ZERO_SHARD_NUM": "0",
         "ZERO_TARGET_CLIENT_ROW_COUNT": "20000",
         "ZERO_TENANTS_JSON": "{"tenants":[{"id":"ten-boo","host":"Normalize.ME","path":"tenboo","env":{"ZERO_REPLICA_FILE":"tenboo.db","ZERO_CVR_DB":"foo","ZERO_CHANGE_DB":"foo","ZERO_APP_ID":"foo"}},{"id":"ten_bar","path":"/tenbar","env":{"ZERO_REPLICA_FILE":"tenbar.db","ZERO_CVR_DB":"bar","ZERO_CHANGE_DB":"bar","ZERO_APP_ID":"bar"}},{"id":"tenbaz-123","path":"/tenbaz","env":{"ZERO_REPLICA_FILE":"tenbar.db","ZERO_UPSTREAM_DB":"overridden","ZERO_CVR_DB":"baz","ZERO_CHANGE_DB":"baz","ZERO_APP_ID":"foo"}}]}",
@@ -540,6 +544,18 @@ test('zero-cache --help', () => {
                                                                 this limit, zero-cache will evict inactive queries in order of ttl-based expiration.              
                                                                 Active queries, on the other hand, are never evicted and are allowed to use more                  
                                                                 rows than the limit.                                                                              
+                                                                                                                                                                  
+     --run-lazily boolean                                       default: false                                                                                    
+       ZERO_RUN_LAZILY env                                                                                                                                        
+                                                                Delay starting the zero-cache processes until the first request.                                  
+                                                                                                                                                                  
+                                                                Note: This works as expected in single-node mode. While it is technically usable                  
+                                                                in a multi-node setup, there is a bootstrapping complication in that the                          
+                                                                view-syncer must first restore the replica from litestream before connecting to                   
+                                                                the replication-manager (to know where to continue replication from). If the                      
+                                                                replication-manager has never run, there will be no replica file to restore, and                  
+                                                                the view-syncer will fail to start up, never connecting to the replication-manager.               
+                                                                As such, it is not recommended to run a replication-manager lazily.                               
                                                                                                                                                                   
      --server-version string                                    optional                                                                                          
        ZERO_SERVER_VERSION env                                                                                                                                    

--- a/packages/zero-cache/src/server/runner/config.test.ts
+++ b/packages/zero-cache/src/server/runner/config.test.ts
@@ -555,6 +555,7 @@ test('zero-cache --help', () => {
                                                                 the replication-manager (to know where to continue replication from). If the                      
                                                                 replication-manager has never run, there will be no replica file to restore, and                  
                                                                 the view-syncer will fail to start up, never connecting to the replication-manager.               
+                                                                                                                                                                  
                                                                 As such, it is not recommended to run a replication-manager lazily.                               
                                                                                                                                                                   
      --server-version string                                    optional                                                                                          


### PR DESCRIPTION
### Feature

Adds a `--run-lazily` (or `ZERO_RUN_LAZILY`) option to delay starting the zero-cache processes until the receiving the first (websocket) request:

`--run-lazily` usage documentation:

```
        Delay starting the zero-cache processes until the first request.

        Note: This works as expected in single-node mode. While it is technically usable
        in a multi-node setup, there is a bootstrapping complication in that the
        view-syncer must first restore the replica from litestream before connecting to
        the replication-manager (to know where to continue replication from). If the
        replication-manager has never run, there will be no replica file to restore, and
        the view-syncer will fail to start up, never connecting to the replication-manager.

        As such, it is not recommended to run a replication-manager lazily.
```

User request: https://discord.com/channels/830183651022471199/1359461732518592532/1359836126885445662

### Implementation

* The websocket handoff framework was modified to allow the handoff logic to invoke a callback instead of immediately returning the Worker to dispatch the websocket to.
* The top-level runner now spawns a Worker on demand, upon the first call to `getWorker()`. 
* These Workers are spawned eagerly if the `--run-lazily` option is not set (i.e. to achieve the status quo) .
* Those that are not spawned eagerly are spawned upon the first call to `getWorker()`, which happens when receiving a request for that worker.