### PR TITLE
fix(zero-cache): resync when publications are missing

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/change-source.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.pg-test.ts
@@ -923,4 +923,20 @@ describe('change-source/pg', {timeout: 30000}, () => {
       `[AutoResetSignal: Requested publications [zero_different_publication] do not match configured publications: [zero_foo,zero_zero]]`,
     );
   });
+
+  test('AutoReset on missing publications', async () => {
+    await startReplication();
+    await upstream`DROP PUBLICATION zero_foo`;
+
+    let err;
+    try {
+      await startReplication();
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(AutoResetSignal);
+    expect(err).toMatchInlineSnapshot(
+      `[AutoResetSignal: Upstream publications [zero_zero,_23_metadata_1] do not contain all subscribed publications [_23_metadata_1,zero_foo,zero_zero]]`,
+    );
+  });
 });

--- a/packages/zero-cache/src/services/change-source/pg/schema/init.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.ts
@@ -19,8 +19,7 @@ import {
 } from './shard.ts';
 
 /**
- * Initializes a shard for initial sync.
- * This will drop any existing shard setup.
+ * Ensures that a shard is set up for initial sync.
  */
 export async function ensureShardSchema(
   lc: LogContext,


### PR DESCRIPTION
Recover from upstream corruption that stopped being detected when resyncs were made to be non-disruptive.

Extra checks are performed before initial sync and replication subscription to ensure that the expected publications still exist upstream. If they are missing, a full (disruptive) resync is used to recover.

User report: https://discord.com/channels/830183651022471199/1358765533545369842/1359925435902726336