### PR TITLE
Fix issue with timestamps and `timestamptz` data types

### DIFF
--- a/packages/z2s/src/compiler.output.test.ts
+++ b/packages/z2s/src/compiler.output.test.ts
@@ -280,7 +280,7 @@ test('compile with timestamp (with timezone)', () => {
     ),
   ).toMatchInlineSnapshot(`
     {
-      "text": "SELECT COALESCE(json_agg(row_to_json("root")), '[]'::json)::text as "zql_result" FROM (SELECT "timestampsTable"."id","timestampsTable"."timestampWithTz",EXTRACT(EPOCH FROM "timestampsTable"."timestampWithoutTz"::timestamp AT TIME ZONE 'UTC') * 1000 as "timestampWithoutTz" FROM "timestampsTable" WHERE "timestampWithTz" = $1::text::timestampz   )"root"",
+      "text": "SELECT COALESCE(json_agg(row_to_json("root")), '[]'::json)::text as "zql_result" FROM (SELECT "timestampsTable"."id","timestampsTable"."timestampWithTz",EXTRACT(EPOCH FROM "timestampsTable"."timestampWithoutTz") * 1000 as "timestampWithoutTz" FROM "timestampsTable" WHERE "timestampWithTz" = $1::text::timestampz   )"root"",
       "values": [
         ""abc"",
       ],
@@ -305,7 +305,7 @@ test('compile with timestamp (without timezone)', () => {
     ),
   ).toMatchInlineSnapshot(`
     {
-      "text": "SELECT COALESCE(json_agg(row_to_json("root")), '[]'::json)::text as "zql_result" FROM (SELECT "timestampsTable"."id","timestampsTable"."timestampWithTz",EXTRACT(EPOCH FROM "timestampsTable"."timestampWithoutTz"::timestamp AT TIME ZONE 'UTC') * 1000 as "timestampWithoutTz" FROM "timestampsTable" WHERE "timestampWithoutTz" = to_timestamp($1::text::bigint / 1000.0) AT TIME ZONE 'UTC'   )"root"",
+      "text": "SELECT COALESCE(json_agg(row_to_json("root")), '[]'::json)::text as "zql_result" FROM (SELECT "timestampsTable"."id","timestampsTable"."timestampWithTz",EXTRACT(EPOCH FROM "timestampsTable"."timestampWithoutTz") * 1000 as "timestampWithoutTz" FROM "timestampsTable" WHERE "timestampWithoutTz" = to_timestamp($1::text::bigint / 1000.0) AT TIME ZONE 'UTC'   )"root"",
       "values": [
         ""abc"",
       ],
@@ -957,7 +957,7 @@ test('related thru junction edge', () => {
     {
       "text": "SELECT COALESCE(json_agg(row_to_json("root")), '[]'::json)::text as "zql_result" FROM (SELECT (
             SELECT COALESCE(json_agg(row_to_json("inner_labels")), '[]'::json) FROM (SELECT "table_1"."id","table_1"."name" FROM "issue_label" as "issueLabel" JOIN "label" as "table_1" ON "issueLabel"."label_id" = "table_1"."id" WHERE ("issue"."id" = "issueLabel"."issue_id")    ) "inner_labels"
-          ) as "labels","issue"."id","issue"."title","issue"."description","issue"."closed","issue"."ownerId",EXTRACT(EPOCH FROM "issue"."created"::timestamp AT TIME ZONE 'UTC') * 1000 as "created" FROM "issue"    )"root"",
+          ) as "labels","issue"."id","issue"."title","issue"."description","issue"."closed","issue"."ownerId",EXTRACT(EPOCH FROM "issue"."created") * 1000 as "created" FROM "issue"    )"root"",
       "values": [],
     }
   `);
@@ -987,7 +987,7 @@ test('related w/o junction edge', () => {
     {
       "text": "SELECT COALESCE(json_agg(row_to_json("root")), '[]'::json)::text as "zql_result" FROM (SELECT (
           SELECT COALESCE(json_agg(row_to_json("inner_owner")) , '[]'::json) FROM (SELECT "user"."id","user"."name","user"."age" FROM "user"  WHERE ("issue"."ownerId" = "user"."id")  ) "inner_owner"
-        ) as "owner","issue"."id","issue"."title","issue"."description","issue"."closed","issue"."ownerId",EXTRACT(EPOCH FROM "issue"."created"::timestamp AT TIME ZONE 'UTC') * 1000 as "created" FROM "issue"    )"root"",
+        ) as "owner","issue"."id","issue"."title","issue"."description","issue"."closed","issue"."ownerId",EXTRACT(EPOCH FROM "issue"."created") * 1000 as "created" FROM "issue"    )"root"",
       "values": [],
     }
   `);

--- a/packages/z2s/src/compiler.output.test.ts
+++ b/packages/z2s/src/compiler.output.test.ts
@@ -73,6 +73,14 @@ const enumTable = table('enumTable')
   })
   .primaryKey('id');
 
+const timestampsTable = table('timestampsTable')
+  .columns({
+    id: string(),
+    timestampWithTz: number(),
+    timestampWithoutTz: number(),
+  })
+  .primaryKey('id');
+
 const alternateUser = table('alternate_user')
   .from('alternate_schema.user')
   .columns({
@@ -91,6 +99,7 @@ const schema = createSchema({
     parentTable,
     childTable,
     enumTable,
+    timestampsTable,
     alternateUser,
   ],
 });
@@ -129,6 +138,11 @@ const serverSchema: ServerSchema = {
   'enumTable': {
     id: {type: 'text', isEnum: false},
     status: {type: 'statusEnum', isEnum: true},
+  },
+  'timestampsTable': {
+    id: {type: 'text', isEnum: false},
+    timestampWithoutTz: {type: 'timestamp', isEnum: false},
+    timestampWithTz: {type: 'timestampz', isEnum: false},
   },
   'alternate_schema.user': {
     id: {type: 'text', isEnum: false},
@@ -244,6 +258,56 @@ test('compile with enum', () => {
       "text": "SELECT COALESCE(json_agg(row_to_json("root")), '[]'::json)::text as "zql_result" FROM (SELECT "enumTable"."id","enumTable"."status" FROM "enumTable" WHERE "status"::text = $1::text COLLATE "ucs_basic"   )"root"",
       "values": [
         "active",
+      ],
+    }
+  `);
+});
+
+test('compile with timestamp (with timezone)', () => {
+  const compiler = new Compiler(schema.tables, serverSchema);
+  expect(
+    formatPgInternalConvert(
+      compiler.compile({
+        table: 'timestampsTable',
+        related: [],
+        where: {
+          type: 'simple',
+          op: '=',
+          left: {type: 'column', name: 'timestampWithTz'},
+          right: {type: 'literal', value: 'abc'},
+        },
+      }),
+    ),
+  ).toMatchInlineSnapshot(`
+    {
+      "text": "SELECT COALESCE(json_agg(row_to_json("root")), '[]'::json)::text as "zql_result" FROM (SELECT "timestampsTable"."id","timestampsTable"."timestampWithTz","timestampsTable"."timestampWithoutTz" FROM "timestampsTable" WHERE "timestampWithTz" = $1::text::timestampz   )"root"",
+      "values": [
+        ""abc"",
+      ],
+    }
+  `);
+});
+
+test('compile with timestamp (without timezone)', () => {
+  const compiler = new Compiler(schema.tables, serverSchema);
+  expect(
+    formatPgInternalConvert(
+      compiler.compile({
+        table: 'timestampsTable',
+        related: [],
+        where: {
+          type: 'simple',
+          op: '=',
+          left: {type: 'column', name: 'timestampWithoutTz'},
+          right: {type: 'literal', value: 'abc'},
+        },
+      }),
+    ),
+  ).toMatchInlineSnapshot(`
+    {
+      "text": "SELECT COALESCE(json_agg(row_to_json("root")), '[]'::json)::text as "zql_result" FROM (SELECT "timestampsTable"."id","timestampsTable"."timestampWithTz","timestampsTable"."timestampWithoutTz" FROM "timestampsTable" WHERE "timestampWithoutTz" = to_timestamp($1::text::bigint / 1000.0) AT TIME ZONE 'UTC'   )"root"",
+      "values": [
+        ""abc"",
       ],
     }
   `);
@@ -893,7 +957,7 @@ test('related thru junction edge', () => {
     {
       "text": "SELECT COALESCE(json_agg(row_to_json("root")), '[]'::json)::text as "zql_result" FROM (SELECT (
             SELECT COALESCE(json_agg(row_to_json("inner_labels")), '[]'::json) FROM (SELECT "table_1"."id","table_1"."name" FROM "issue_label" as "issueLabel" JOIN "label" as "table_1" ON "issueLabel"."label_id" = "table_1"."id" WHERE ("issue"."id" = "issueLabel"."issue_id")    ) "inner_labels"
-          ) as "labels","issue"."id","issue"."title","issue"."description","issue"."closed","issue"."ownerId",EXTRACT(EPOCH FROM "issue"."created"::timestamp AT TIME ZONE 'UTC') * 1000 as "created" FROM "issue"    )"root"",
+          ) as "labels","issue"."id","issue"."title","issue"."description","issue"."closed","issue"."ownerId","issue"."created" FROM "issue"    )"root"",
       "values": [],
     }
   `);
@@ -923,7 +987,7 @@ test('related w/o junction edge', () => {
     {
       "text": "SELECT COALESCE(json_agg(row_to_json("root")), '[]'::json)::text as "zql_result" FROM (SELECT (
           SELECT COALESCE(json_agg(row_to_json("inner_owner")) , '[]'::json) FROM (SELECT "user"."id","user"."name","user"."age" FROM "user"  WHERE ("issue"."ownerId" = "user"."id")  ) "inner_owner"
-        ) as "owner","issue"."id","issue"."title","issue"."description","issue"."closed","issue"."ownerId",EXTRACT(EPOCH FROM "issue"."created"::timestamp AT TIME ZONE 'UTC') * 1000 as "created" FROM "issue"    )"root"",
+        ) as "owner","issue"."id","issue"."title","issue"."description","issue"."closed","issue"."ownerId","issue"."created" FROM "issue"    )"root"",
       "values": [],
     }
   `);

--- a/packages/z2s/src/compiler.output.test.ts
+++ b/packages/z2s/src/compiler.output.test.ts
@@ -280,7 +280,7 @@ test('compile with timestamp (with timezone)', () => {
     ),
   ).toMatchInlineSnapshot(`
     {
-      "text": "SELECT COALESCE(json_agg(row_to_json("root")), '[]'::json)::text as "zql_result" FROM (SELECT "timestampsTable"."id","timestampsTable"."timestampWithTz","timestampsTable"."timestampWithoutTz" FROM "timestampsTable" WHERE "timestampWithTz" = $1::text::timestampz   )"root"",
+      "text": "SELECT COALESCE(json_agg(row_to_json("root")), '[]'::json)::text as "zql_result" FROM (SELECT "timestampsTable"."id","timestampsTable"."timestampWithTz",EXTRACT(EPOCH FROM "timestampsTable"."timestampWithoutTz"::timestamp AT TIME ZONE 'UTC') * 1000 as "timestampWithoutTz" FROM "timestampsTable" WHERE "timestampWithTz" = $1::text::timestampz   )"root"",
       "values": [
         ""abc"",
       ],
@@ -305,7 +305,7 @@ test('compile with timestamp (without timezone)', () => {
     ),
   ).toMatchInlineSnapshot(`
     {
-      "text": "SELECT COALESCE(json_agg(row_to_json("root")), '[]'::json)::text as "zql_result" FROM (SELECT "timestampsTable"."id","timestampsTable"."timestampWithTz","timestampsTable"."timestampWithoutTz" FROM "timestampsTable" WHERE "timestampWithoutTz" = to_timestamp($1::text::bigint / 1000.0) AT TIME ZONE 'UTC'   )"root"",
+      "text": "SELECT COALESCE(json_agg(row_to_json("root")), '[]'::json)::text as "zql_result" FROM (SELECT "timestampsTable"."id","timestampsTable"."timestampWithTz",EXTRACT(EPOCH FROM "timestampsTable"."timestampWithoutTz"::timestamp AT TIME ZONE 'UTC') * 1000 as "timestampWithoutTz" FROM "timestampsTable" WHERE "timestampWithoutTz" = to_timestamp($1::text::bigint / 1000.0) AT TIME ZONE 'UTC'   )"root"",
       "values": [
         ""abc"",
       ],
@@ -957,7 +957,7 @@ test('related thru junction edge', () => {
     {
       "text": "SELECT COALESCE(json_agg(row_to_json("root")), '[]'::json)::text as "zql_result" FROM (SELECT (
             SELECT COALESCE(json_agg(row_to_json("inner_labels")), '[]'::json) FROM (SELECT "table_1"."id","table_1"."name" FROM "issue_label" as "issueLabel" JOIN "label" as "table_1" ON "issueLabel"."label_id" = "table_1"."id" WHERE ("issue"."id" = "issueLabel"."issue_id")    ) "inner_labels"
-          ) as "labels","issue"."id","issue"."title","issue"."description","issue"."closed","issue"."ownerId","issue"."created" FROM "issue"    )"root"",
+          ) as "labels","issue"."id","issue"."title","issue"."description","issue"."closed","issue"."ownerId",EXTRACT(EPOCH FROM "issue"."created"::timestamp AT TIME ZONE 'UTC') * 1000 as "created" FROM "issue"    )"root"",
       "values": [],
     }
   `);
@@ -987,7 +987,7 @@ test('related w/o junction edge', () => {
     {
       "text": "SELECT COALESCE(json_agg(row_to_json("root")), '[]'::json)::text as "zql_result" FROM (SELECT (
           SELECT COALESCE(json_agg(row_to_json("inner_owner")) , '[]'::json) FROM (SELECT "user"."id","user"."name","user"."age" FROM "user"  WHERE ("issue"."ownerId" = "user"."id")  ) "inner_owner"
-        ) as "owner","issue"."id","issue"."title","issue"."description","issue"."closed","issue"."ownerId","issue"."created" FROM "issue"    )"root"",
+        ) as "owner","issue"."id","issue"."title","issue"."description","issue"."closed","issue"."ownerId",EXTRACT(EPOCH FROM "issue"."created"::timestamp AT TIME ZONE 'UTC') * 1000 as "created" FROM "issue"    )"root"",
       "values": [],
     }
   `);

--- a/packages/z2s/src/compiler.output.test.ts
+++ b/packages/z2s/src/compiler.output.test.ts
@@ -142,7 +142,7 @@ const serverSchema: ServerSchema = {
   'timestampsTable': {
     id: {type: 'text', isEnum: false},
     timestampWithoutTz: {type: 'timestamp', isEnum: false},
-    timestampWithTz: {type: 'timestampz', isEnum: false},
+    timestampWithTz: {type: 'timestamptz', isEnum: false},
   },
   'alternate_schema.user': {
     id: {type: 'text', isEnum: false},
@@ -280,7 +280,7 @@ test('compile with timestamp (with timezone)', () => {
     ),
   ).toMatchInlineSnapshot(`
     {
-      "text": "SELECT COALESCE(json_agg(row_to_json("root")), '[]'::json)::text as "zql_result" FROM (SELECT "timestampsTable"."id","timestampsTable"."timestampWithTz",EXTRACT(EPOCH FROM "timestampsTable"."timestampWithoutTz") * 1000 as "timestampWithoutTz" FROM "timestampsTable" WHERE "timestampWithTz" = $1::text::timestampz   )"root"",
+      "text": "SELECT COALESCE(json_agg(row_to_json("root")), '[]'::json)::text as "zql_result" FROM (SELECT "timestampsTable"."id",EXTRACT(EPOCH FROM "timestampsTable"."timestampWithTz") * 1000 as "timestampWithTz",EXTRACT(EPOCH FROM "timestampsTable"."timestampWithoutTz") * 1000 as "timestampWithoutTz" FROM "timestampsTable" WHERE "timestampWithTz" = to_timestamp($1::text::bigint / 1000.0)   )"root"",
       "values": [
         ""abc"",
       ],
@@ -305,7 +305,7 @@ test('compile with timestamp (without timezone)', () => {
     ),
   ).toMatchInlineSnapshot(`
     {
-      "text": "SELECT COALESCE(json_agg(row_to_json("root")), '[]'::json)::text as "zql_result" FROM (SELECT "timestampsTable"."id","timestampsTable"."timestampWithTz",EXTRACT(EPOCH FROM "timestampsTable"."timestampWithoutTz") * 1000 as "timestampWithoutTz" FROM "timestampsTable" WHERE "timestampWithoutTz" = to_timestamp($1::text::bigint / 1000.0) AT TIME ZONE 'UTC'   )"root"",
+      "text": "SELECT COALESCE(json_agg(row_to_json("root")), '[]'::json)::text as "zql_result" FROM (SELECT "timestampsTable"."id",EXTRACT(EPOCH FROM "timestampsTable"."timestampWithTz") * 1000 as "timestampWithTz",EXTRACT(EPOCH FROM "timestampsTable"."timestampWithoutTz") * 1000 as "timestampWithoutTz" FROM "timestampsTable" WHERE "timestampWithoutTz" = to_timestamp($1::text::bigint / 1000.0) AT TIME ZONE 'UTC'   )"root"",
       "values": [
         ""abc"",
       ],

--- a/packages/z2s/src/compiler.ts
+++ b/packages/z2s/src/compiler.ts
@@ -596,29 +596,20 @@ export class Compiler {
         this.#nameMapper.columnName(table, column)
       ];
     const serverType = serverColumnSchema.type;
-    if (!serverColumnSchema.isEnum) {
-      if (
-        serverType === 'date' ||
+    if (
+      !serverColumnSchema.isEnum &&
+      (serverType === 'date' ||
         serverType === 'timestamp' ||
-        serverType === 'timestamp without time zone'
-      ) {
-        return sql`EXTRACT(EPOCH FROM ${sql.ident(
-          table,
-        )}.${this.#mapColumnNoAlias(
-          table,
-          column,
-        )}) * 1000 as ${sql.ident(column)}`;
-      } else if (
+        serverType === 'timestamp without time zone' ||
         serverType === 'timestamptz' ||
-        serverType === 'timestamp with time zone'
-      ) {
-        return sql`EXTRACT(EPOCH FROM ${sql.ident(
-          table,
-        )}.${this.#mapColumnNoAlias(
-          table,
-          column,
-        )}) * 1000 as ${sql.ident(column)}`;
-      }
+        serverType === 'timestamp with time zone')
+    ) {
+      return sql`EXTRACT(EPOCH FROM ${sql.ident(
+        table,
+      )}.${this.#mapColumnNoAlias(
+        table,
+        column,
+      )}) * 1000 as ${sql.ident(column)}`;
     }
     return sql`${sql.ident(table)}.${this.#mapColumn(table, column)}`;
   }

--- a/packages/z2s/src/compiler.ts
+++ b/packages/z2s/src/compiler.ts
@@ -596,20 +596,29 @@ export class Compiler {
         this.#nameMapper.columnName(table, column)
       ];
     const serverType = serverColumnSchema.type;
-    if (
-      !serverColumnSchema.isEnum &&
-      (serverType === 'date' ||
+    if (serverColumnSchema.isEnum) {
+      if (
+        serverType === 'date' ||
         serverType === 'timestamp' ||
+        serverType === 'timestamp without time zone'
+      ) {
+        return sql`EXTRACT(EPOCH FROM ${sql.ident(
+          table,
+        )}.${this.#mapColumnNoAlias(
+          table,
+          column,
+        )}::timestamp AT TIME ZONE 'UTC') * 1000 as ${sql.ident(column)}`;
+      } else if (
         serverType === 'timestamptz' ||
-        serverType === 'timestamp with time zone' ||
-        serverType === 'timestamp without time zone')
-    ) {
-      return sql`EXTRACT(EPOCH FROM ${sql.ident(
-        table,
-      )}.${this.#mapColumnNoAlias(
-        table,
-        column,
-      )}::timestamp AT TIME ZONE 'UTC') * 1000 as ${sql.ident(column)}`;
+        serverType === 'timestamp with time zone'
+      ) {
+        return sql`EXTRACT(EPOCH FROM ${sql.ident(
+          table,
+        )}.${this.#mapColumnNoAlias(
+          table,
+          column,
+        )}::timestamp) * 1000 as ${sql.ident(column)}`;
+      }
     }
     return sql`${sql.ident(table)}.${this.#mapColumn(table, column)}`;
   }

--- a/packages/z2s/src/compiler.ts
+++ b/packages/z2s/src/compiler.ts
@@ -607,7 +607,7 @@ export class Compiler {
         )}.${this.#mapColumnNoAlias(
           table,
           column,
-        )}::timestamp AT TIME ZONE 'UTC') * 1000 as ${sql.ident(column)}`;
+        )}) * 1000 as ${sql.ident(column)}`;
       } else if (
         serverType === 'timestamptz' ||
         serverType === 'timestamp with time zone'

--- a/packages/z2s/src/compiler.ts
+++ b/packages/z2s/src/compiler.ts
@@ -617,7 +617,7 @@ export class Compiler {
         )}.${this.#mapColumnNoAlias(
           table,
           column,
-        )}::timestamp) * 1000 as ${sql.ident(column)}`;
+        )}) * 1000 as ${sql.ident(column)}`;
       }
     }
     return sql`${sql.ident(table)}.${this.#mapColumn(table, column)}`;

--- a/packages/z2s/src/compiler.ts
+++ b/packages/z2s/src/compiler.ts
@@ -596,7 +596,7 @@ export class Compiler {
         this.#nameMapper.columnName(table, column)
       ];
     const serverType = serverColumnSchema.type;
-    if (serverColumnSchema.isEnum) {
+    if (!serverColumnSchema.isEnum) {
       if (
         serverType === 'date' ||
         serverType === 'timestamp' ||

--- a/packages/z2s/src/sql.test.ts
+++ b/packages/z2s/src/sql.test.ts
@@ -148,12 +148,28 @@ describe('string arg packing', () => {
           'ENUM_KEY',
           false,
           true,
+        )} OR "timestamp" = ${sqlConvertColumnArg(
+          {
+            isEnum: false,
+            type: 'timestamp',
+          },
+          'abc',
+          false,
+          true,
+        )} OR "timestampz" = ${sqlConvertColumnArg(
+          {
+            isEnum: false,
+            type: 'timestamptz',
+          },
+          'abc',
+          false,
+          true,
         )}`,
       ),
     ).toMatchInlineSnapshot(`
       {
         "text": "SELECT * FROM "foo" WHERE "jsonb" = $1::text::jsonb OR "numeric" = $2::text::numeric
-              OR "str" = $3::text COLLATE "ucs_basic" OR "boolean" = $4::text::boolean OR "uuid"::text = $5::text COLLATE "ucs_basic" OR "enum"::text = $6::text COLLATE "ucs_basic"",
+              OR "str" = $3::text COLLATE "ucs_basic" OR "boolean" = $4::text::boolean OR "uuid"::text = $5::text COLLATE "ucs_basic" OR "enum"::text = $6::text COLLATE "ucs_basic" OR "timestamp" = to_timestamp($7::text::bigint / 1000.0) AT TIME ZONE 'UTC' OR "timestampz" = to_timestamp($7::text::bigint / 1000.0)",
         "values": [
           "{}",
           "1",
@@ -161,6 +177,7 @@ describe('string arg packing', () => {
           "true",
           "8f1dceb2-b3dd-46cf-9deb-460e9d87541c",
           "ENUM_KEY",
+          ""abc"",
         ],
       }
     `);

--- a/packages/z2s/src/sql.ts
+++ b/packages/z2s/src/sql.ts
@@ -194,10 +194,11 @@ class SQLConvertFormat implements FormatConfig {
       switch (arg.type) {
         case 'date':
         case 'timestamp':
-        case 'timestamptz':
-        case 'timestamp with time zone':
         case 'timestamp without time zone':
           return `to_timestamp($${index}::text::bigint / 1000.0) AT TIME ZONE 'UTC'`;
+        case 'timestamptz':
+        case 'timestamp with time zone':
+          return `to_timestamp($${index}::text::bigint / 1000.0)`;
         case 'text':
           return `$${index}::text${collate}`;
         case 'bpchar':


### PR DESCRIPTION
Currently if you have a `timestamptz` column, and the server timezone is `Europe/London`, when a timestamp is written it's an hour out 😱, because they query ends up being

```sql
INSERT INTO "table" ("id","createdAt") VALUES ($1::text::character varying, to_timestamp($2::text::bigint / 1000.0) AT TIME ZONE 'UTC')
```

where
- `to_timestamp($2::text::bigint / 1000.0)` returns a timestamp with timezone, where the timezone is `Europe/London`
- `AT TIME ZONE 'UTC'` then converts it to a timestamp without the timezone, representing the time in UTC
- Then the insert happens into the column that does want a timezone. It interprets the timestamp as being a timestamp in `Europe/London`, not `UTC`, and therefore it ends up being an hour out

So in this PR I've adjusted it so that if the column is a `timestamptz` we don't convert it to a timezoneless timestamp in UTC. If the column is a `timestamp`, then we do ensure it's converted to UTC (although I wonder if this is the right thing to do?)

I've done a quick test in our app and this fixes it, but not 100% sure if this is correct

### Some queries I ran when debugging this
```sql
select to_timestamp(1::text::bigint / 1000.0);
--> 1970-01-01 01:00:00.001+01
```

```sql
select to_timestamp(1::text::bigint / 1000.0) AT TIME ZONE 'UTC';
--> 1970-01-01 00:00:00.001
```