### PR TITLE
chore(zql): Fix missing NOT LIKE operators in type

### DIFF
--- a/packages/zql-integration-tests/src/chinook/chinook.pg-test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook.pg-test.ts
@@ -44,7 +44,7 @@ import {
   newQuery,
   type QueryDelegate,
 } from '../../../zql/src/query/query-impl.ts';
-import type {Operator, Query} from '../../../zql/src/query/query.ts';
+import type {Query} from '../../../zql/src/query/query.ts';
 import {QueryDelegateImpl as TestMemoryQueryDelegate} from '../../../zql/src/query/test/query-delegate.ts';
 import {Database} from '../../../zqlite/src/db.ts';
 import {
@@ -58,6 +58,7 @@ import {schema} from './schema.ts';
 // TODO: Ideally z2s wouldn't depend on zero-pg (even in tests).  These
 // chinook tests should move to their own package.
 import {getServerSchema} from '../../../zero-pg/src/schema.ts';
+import type {SimpleOperator} from '../../../zero-protocol/src/ast.ts';
 
 let pg: PostgresDB;
 let sqlite: Database;
@@ -256,7 +257,7 @@ function randomRowAndColumn(table: string) {
   return {randomRow, randomColumn};
 }
 
-function randomOperator(): Operator {
+function randomOperator(): SimpleOperator {
   const operators = ['=', '!=', '>', '>=', '<', '<='] as const;
   return operators[Math.floor(Math.random() * operators.length)];
 }

--- a/packages/zql/src/query/expression.ts
+++ b/packages/zql/src/query/expression.ts
@@ -5,6 +5,7 @@ import {
   type Condition,
   type LiteralValue,
   type Parameter,
+  type SimpleOperator,
 } from '../../../zero-protocol/src/ast.ts';
 import type {Schema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import type {
@@ -12,7 +13,6 @@ import type {
   DestTableName,
   GetFilterType,
   NoJsonSelector,
-  Operator,
   PullTableSchema,
   Query,
 } from './query.ts';
@@ -69,7 +69,7 @@ export class ExpressionBuilder<
 
   cmp<
     TSelector extends NoJsonSelector<PullTableSchema<TTable, TSchema>>,
-    TOperator extends Operator,
+    TOperator extends SimpleOperator,
   >(
     field: TSelector,
     op: TOperator,
@@ -85,7 +85,7 @@ export class ExpressionBuilder<
   ): Condition;
   cmp(
     field: string,
-    opOrValue: Operator | ParameterReference | LiteralValue,
+    opOrValue: SimpleOperator | ParameterReference | LiteralValue,
     value?: ParameterReference | LiteralValue,
   ): Condition {
     return cmp(field, opOrValue, value);
@@ -93,7 +93,7 @@ export class ExpressionBuilder<
 
   cmpLit(
     left: ParameterReference | LiteralValue,
-    op: Operator,
+    op: SimpleOperator,
     right: ParameterReference | LiteralValue,
   ): Condition {
     return {
@@ -178,15 +178,15 @@ export function not(expression: Condition): Condition {
 
 export function cmp(
   field: string,
-  opOrValue: Operator | ParameterReference | LiteralValue,
+  opOrValue: SimpleOperator | ParameterReference | LiteralValue,
   value?: ParameterReference | LiteralValue,
 ): Condition {
-  let op: Operator;
+  let op: SimpleOperator;
   if (value === undefined) {
     value = opOrValue;
     op = '=';
   } else {
-    op = opOrValue as Operator;
+    op = opOrValue as SimpleOperator;
   }
 
   return {

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -10,6 +10,7 @@ import type {
   Condition,
   Ordering,
   Parameter,
+  SimpleOperator,
   System,
 } from '../../../zero-protocol/src/ast.ts';
 import type {Row as IVMRow} from '../../../zero-protocol/src/data.ts';
@@ -33,7 +34,6 @@ import {
 import {
   type GetFilterType,
   type HumanReadable,
-  type Operator,
   type PreloadOptions,
   type PullRow,
   type Query,
@@ -316,7 +316,7 @@ export abstract class AbstractQuery<
 
   where(
     fieldOrExpressionFactory: string | ExpressionFactory<TSchema, TTable>,
-    opOrValue?: Operator | GetFilterType<any, any, any> | Parameter,
+    opOrValue?: SimpleOperator | GetFilterType<any, any, any> | Parameter,
     value?: GetFilterType<any, any, any> | Parameter,
   ): Query<TSchema, TTable, TReturn> {
     let cond: Condition;

--- a/packages/zql/src/query/query.ts
+++ b/packages/zql/src/query/query.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type {Expand, ExpandRecursive} from '../../../shared/src/expand.ts';
+import {type SimpleOperator} from '../../../zero-protocol/src/ast.ts';
 import type {Schema as ZeroSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import type {
   LastInTuple,
@@ -20,24 +21,10 @@ type JsonSelectors<E extends TableSchema> = {
   [K in keyof E['columns']]: E['columns'][K] extends {type: 'json'} ? K : never;
 }[keyof E['columns']];
 
-export type Operator =
-  | '='
-  | '!='
-  | '<'
-  | '<='
-  | '>'
-  | '>='
-  | 'IN'
-  | 'NOT IN'
-  | 'LIKE'
-  | 'ILIKE'
-  | 'IS'
-  | 'IS NOT';
-
 export type GetFilterType<
   TSchema extends TableSchema,
   TColumn extends keyof TSchema['columns'],
-  TOperator extends Operator,
+  TOperator extends SimpleOperator,
 > = TOperator extends 'IS' | 'IS NOT'
   ? // SchemaValueToTSType adds null if the type is optional, but we add null
     // no matter what for dx reasons. See:
@@ -241,7 +228,7 @@ export interface Query<
    */
   where<
     TSelector extends NoJsonSelector<PullTableSchema<TTable, TSchema>>,
-    TOperator extends Operator,
+    TOperator extends SimpleOperator,
   >(
     field: TSelector,
     op: TOperator,


### PR DESCRIPTION
By using the one from the protocol these now have a single source of truth.