### PR TITLE
feat(mutators): allow custom headers and query string params

### DIFF
--- a/apps/zbugs/src/zero-setup.ts
+++ b/apps/zbugs/src/zero-setup.ts
@@ -34,6 +34,9 @@ authAtom.onChange(auth => {
     server: import.meta.env.VITE_PUBLIC_SERVER,
     userID: authData?.sub ?? 'anon',
     mutators: createMutators(authData),
+    push: {
+      url: 'http://localhost:5173/api/push?foo=bar',
+    },
     auth: (error?: 'invalid-token') => {
       if (error === 'invalid-token') {
         clearJwt();

--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -174,7 +174,7 @@ export default async function runWorker(
     syncers.forEach(syncer => handleSubscriptionsFrom(lc, syncer, notifier));
   }
   let mutator: Worker | undefined;
-  if (config.push.url !== undefined && clientConnectionBifurcated) {
+  if (clientConnectionBifurcated) {
     mutator = loadWorker('./server/mutator.ts', 'supporting', 'mutator');
   }
 

--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -143,17 +143,14 @@ export default function runWorker(
       config,
     );
 
-  const pusherFactory =
-    config.push.url === undefined
-      ? undefined
-      : (id: string) =>
-          new PusherService(
-            config,
-            lc.withContext('clientGroupID', id),
-            id,
-            must(config.push.url),
-            config.push.apiKey,
-          );
+  const pusherFactory = (id: string) =>
+    new PusherService(
+      config,
+      lc.withContext('clientGroupID', id),
+      id,
+      config.push.url,
+      config.push.apiKey,
+    );
 
   const syncer = new Syncer(
     lc,

--- a/packages/zero-cache/src/services/mutagen/pusher.test.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.test.ts
@@ -20,7 +20,7 @@ const config = {
 };
 
 const clientID = 'test-cid';
-const wsID = 'test-wsid';
+// const wsID = 'test-wsid';
 describe('combine pushes', () => {
   test('empty array', () => {
     const [pushes, terminate] = combinePushes([]);
@@ -33,14 +33,17 @@ describe('combine pushes', () => {
       {
         push: makePush(1),
         jwt: 'a',
+        clientID,
       },
       {
         push: makePush(1),
         jwt: 'a',
+        clientID,
       },
       {
         push: makePush(1),
         jwt: 'a',
+        clientID,
       },
     ]);
     expect(pushes).toHaveLength(1);
@@ -53,26 +56,32 @@ describe('combine pushes', () => {
       {
         push: makePush(1),
         jwt: 'a',
+        clientID,
       },
       {
         push: makePush(1),
         jwt: 'a',
+        clientID,
       },
       {
         push: makePush(1),
         jwt: 'c',
+        clientID,
       },
       {
         push: makePush(1),
         jwt: 'b',
+        clientID,
       },
       {
         push: makePush(1),
         jwt: 'b',
+        clientID,
       },
       {
         push: makePush(1),
         jwt: 'c',
+        clientID,
       },
     ]);
     expect(pushes).toHaveLength(4);
@@ -98,10 +107,12 @@ describe('combine pushes', () => {
       {
         push: makePush(1),
         jwt: 'a',
+        clientID,
       },
       {
         push: makePush(1),
         jwt: 'a',
+        clientID,
       },
       undefined,
     ]);
@@ -114,11 +125,13 @@ describe('combine pushes', () => {
       {
         push: makePush(1),
         jwt: 'a',
+        clientID,
       },
       undefined,
       {
         push: makePush(1),
         jwt: 'a',
+        clientID,
       },
     ]);
     expect(pushes).toHaveLength(1);
@@ -159,7 +172,7 @@ describe('pusher service', () => {
     );
     void pusher.run();
 
-    pusher.enqueuePush(clientID, wsID, makePush(1), 'jwt');
+    pusher.enqueuePush(clientID, makePush(1), 'jwt');
 
     await pusher.stop();
 
@@ -188,7 +201,7 @@ describe('pusher service', () => {
     );
     void pusher.run();
 
-    pusher.enqueuePush(clientID, wsID, makePush(1), 'jwt');
+    pusher.enqueuePush(clientID, makePush(1), 'jwt');
 
     await pusher.stop();
 
@@ -215,7 +228,7 @@ describe('pusher service', () => {
     );
 
     void pusher.run();
-    pusher.enqueuePush(clientID, wsID, makePush(1), 'jwt');
+    pusher.enqueuePush(clientID, makePush(1), 'jwt');
     // release control of the loop so the push can be sent
     await Promise.resolve();
 
@@ -224,11 +237,11 @@ describe('pusher service', () => {
     expect(JSON.parse(fetch.mock.calls[0][1].body).mutations).toHaveLength(1);
 
     // We have not resolved the API server yet so these should stack up
-    pusher.enqueuePush(clientID, wsID, makePush(1), 'jwt');
+    pusher.enqueuePush(clientID, makePush(1), 'jwt');
     await Promise.resolve();
-    pusher.enqueuePush(clientID, wsID, makePush(1), 'jwt');
+    pusher.enqueuePush(clientID, makePush(1), 'jwt');
     await Promise.resolve();
-    pusher.enqueuePush(clientID, wsID, makePush(1), 'jwt');
+    pusher.enqueuePush(clientID, makePush(1), 'jwt');
     await Promise.resolve();
 
     // no new pushes sent yet since we are still waiting on the user's API server
@@ -262,7 +275,7 @@ describe('pusher streaming', () => {
     );
     void pusher.run();
 
-    const result = pusher.enqueuePush(clientID, wsID, makePush(1), 'jwt');
+    const result = pusher.enqueuePush(clientID, makePush(1), 'jwt');
     expect(result.type).toBe('stream');
   });
 
@@ -276,8 +289,8 @@ describe('pusher streaming', () => {
     );
     void pusher.run();
 
-    pusher.enqueuePush(clientID, wsID, makePush(1), 'jwt');
-    const result = pusher.enqueuePush(clientID, wsID, makePush(1), 'jwt');
+    pusher.enqueuePush(clientID, makePush(1), 'jwt');
+    const result = pusher.enqueuePush(clientID, makePush(1), 'jwt');
     expect(result.type).toBe('ok');
   });
 
@@ -315,7 +328,6 @@ describe('pusher streaming', () => {
     });
     const result1 = pusher.enqueuePush(
       'client1',
-      wsID,
       makePush(1, 'client1'),
       'jwt',
     );
@@ -327,7 +339,6 @@ describe('pusher streaming', () => {
     });
     const result2 = pusher.enqueuePush(
       'client2',
-      wsID,
       makePush(2, 'client2'),
       'jwt',
     );
@@ -405,13 +416,11 @@ describe('pusher streaming', () => {
 
     const result1 = pusher.enqueuePush(
       'client1',
-      wsID,
       makePush(1, 'client1'),
       'jwt',
     );
     const result2 = pusher.enqueuePush(
       'client2',
-      wsID,
       makePush(1, 'client2'),
       'jwt',
     );
@@ -473,12 +482,7 @@ describe('pusher streaming', () => {
     );
     void pusher.run();
 
-    const result = pusher.enqueuePush(
-      clientID,
-      wsID,
-      makePush(1, clientID),
-      'jwt',
-    );
+    const result = pusher.enqueuePush(clientID, makePush(1, clientID), 'jwt');
     expect(result.type).toBe('stream');
 
     if (result.type === 'stream') {
@@ -511,12 +515,7 @@ describe('pusher streaming', () => {
     );
     void pusher.run();
 
-    const result1 = pusher.enqueuePush(
-      clientID,
-      wsID,
-      makePush(1, clientID),
-      'jwt',
-    );
+    const result1 = pusher.enqueuePush(clientID, makePush(1, clientID), 'jwt');
     expect(result1.type).toBe('stream');
 
     if (result1.type === 'stream') {
@@ -525,7 +524,6 @@ describe('pusher streaming', () => {
       // After cleanup, should get a new stream
       const result2 = pusher.enqueuePush(
         clientID,
-        wsID,
         makePush(1, clientID),
         'jwt',
       );
@@ -543,19 +541,9 @@ describe('pusher streaming', () => {
     );
     void pusher.run();
 
-    const result1 = pusher.enqueuePush(
-      clientID,
-      wsID,
-      makePush(1, clientID),
-      'jwt',
-    );
+    const result1 = pusher.enqueuePush(clientID, makePush(1, clientID), 'jwt');
     expect(result1.type).toBe('stream');
-    const result2 = pusher.enqueuePush(
-      clientID,
-      'new-ws-id',
-      makePush(1, clientID),
-      'jwt',
-    );
+    const result2 = pusher.enqueuePush(clientID, makePush(1, clientID), 'jwt');
     expect(result2.type).toBe('stream');
     if (result1.type === 'stream') {
       // should not be iterable anymore as it is closed
@@ -596,12 +584,7 @@ describe('pusher streaming', () => {
     );
     void pusher.run();
 
-    const result = pusher.enqueuePush(
-      clientID,
-      wsID,
-      makePush(2, clientID),
-      'jwt',
-    );
+    const result = pusher.enqueuePush(clientID, makePush(2, clientID), 'jwt');
     expect(result.type).toBe('stream');
 
     if (result.type === 'stream') {
@@ -659,12 +642,7 @@ describe('pusher streaming', () => {
     );
     void pusher.run();
 
-    const result = pusher.enqueuePush(
-      clientID,
-      wsID,
-      makePush(1, clientID),
-      'jwt',
-    );
+    const result = pusher.enqueuePush(clientID, makePush(1, clientID), 'jwt');
     expect(result.type).toBe('stream');
 
     if (result.type === 'stream') {

--- a/packages/zero-cache/src/services/mutagen/pusher.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.ts
@@ -14,7 +14,7 @@ import {type ZeroConfig} from '../../config/zero-config.ts';
 import {ErrorForClient} from '../../types/error-for-client.ts';
 import {upstreamSchema} from '../../types/shards.ts';
 import {Subscription, type Result} from '../../types/subscription.ts';
-import type {HandlerResult} from '../../workers/connection.ts';
+import type {HandlerResult, StreamResult} from '../../workers/connection.ts';
 import type {Service} from '../service.ts';
 import type {UserPushParams} from '../../../../zero-protocol/src/connect.ts';
 import type {Source} from '../../types/streams.ts';
@@ -85,7 +85,7 @@ export class PusherService implements Service, Pusher {
     clientID: string,
     push: PushBody,
     jwt: string | undefined,
-  ): HandlerResult {
+  ): Exclude<HandlerResult, StreamResult> {
     this.#queue.enqueue({push, jwt, clientID});
 
     return {
@@ -411,6 +411,7 @@ export function combinePushes(
           mutations: [],
         },
       };
+      ret.push(composite);
       for (const entry of entries) {
         assertAreCompatiblePushes(composite, entry);
         composite.push.mutations.push(...entry.push.mutations);

--- a/packages/zero-cache/src/workers/connection.ts
+++ b/packages/zero-cache/src/workers/connection.ts
@@ -40,7 +40,7 @@ export type HandlerResult =
     };
 
 export interface MessageHandler {
-  handleMessage(msg: Upstream): Promise<HandlerResult>;
+  handleMessage(msg: Upstream): Promise<HandlerResult[]>;
 }
 
 // Ensures that a downstream message is sent at least every interval, sending a
@@ -191,7 +191,9 @@ export class Connection {
       }
 
       const result = await this.#messageHandler.handleMessage(msg);
-      return this.#handleMessageResult(result);
+      for (const r of result) {
+        this.#handleMessageResult(r);
+      }
     } catch (e) {
       this.#closeWithThrown(e);
     }
@@ -247,7 +249,9 @@ export class Connection {
       }
 
       const result = await this.#messageHandler.handleMessage(msg);
-      this.#handleMessageResult(result);
+      for (const r of result) {
+        this.#handleMessageResult(r);
+      }
     }
 
     this.close('WebSocket close event', {code, reason, wasClean});

--- a/packages/zero-cache/src/workers/connection.ts
+++ b/packages/zero-cache/src/workers/connection.ts
@@ -33,11 +33,13 @@ export type HandlerResult =
       type: 'transient';
       errors: ErrorBody[];
     }
-  | {
-      type: 'stream';
-      source: 'viewSyncer' | 'pusher';
-      stream: Source<Downstream>;
-    };
+  | StreamResult;
+
+export type StreamResult = {
+  type: 'stream';
+  source: 'viewSyncer' | 'pusher';
+  stream: Source<Downstream>;
+};
 
 export interface MessageHandler {
   handleMessage(msg: Upstream): Promise<HandlerResult[]>;

--- a/packages/zero-cache/src/workers/syncer-ws-message-handler.ts
+++ b/packages/zero-cache/src/workers/syncer-ws-message-handler.ts
@@ -28,7 +28,7 @@ export class SyncerWsMessageHandler implements MessageHandler {
   readonly #authData: JWTPayload | undefined;
   readonly #clientGroupID: string;
   readonly #syncContext: SyncContext;
-  readonly #pusher: Pusher | undefined;
+  readonly #pusher: Pusher;
   readonly #token: string | undefined;
 
   constructor(
@@ -37,7 +37,7 @@ export class SyncerWsMessageHandler implements MessageHandler {
     tokenData: TokenData | undefined,
     viewSyncer: ViewSyncer,
     mutagen: Mutagen,
-    pusher: Pusher | undefined,
+    pusher: Pusher,
   ) {
     const {
       clientGroupID,
@@ -171,7 +171,12 @@ export class SyncerWsMessageHandler implements MessageHandler {
           },
         ];
 
-        if (this.#pusher) {
+        // Given we support both CRUD and Custom mutators,
+        // we do not initialize the `pusher` unless the user has opted
+        // into custom mutations. We detect that by checking
+        // if the pushURL has been set either in the config
+        // or by the connected zero-client.
+        if (this.#pusher.pushURL || msg[1].userPushParams?.url) {
           ret.push({
             type: 'stream',
             source: 'pusher',

--- a/packages/zero-cache/src/workers/syncer.ts
+++ b/packages/zero-cache/src/workers/syncer.ts
@@ -43,7 +43,7 @@ export class Syncer implements SingletonService {
   readonly #lc: LogContext;
   readonly #viewSyncers: ServiceRunner<ViewSyncer & ActivityBasedService>;
   readonly #mutagens: ServiceRunner<Mutagen & Service>;
-  readonly #pushers: ServiceRunner<Pusher & Service> | undefined;
+  readonly #pushers: ServiceRunner<Pusher & Service>;
   readonly #connections = new Map<string, Connection>();
   readonly #drainCoordinator = new DrainCoordinator();
   readonly #parent: Worker;
@@ -60,7 +60,7 @@ export class Syncer implements SingletonService {
       drainCoordinator: DrainCoordinator,
     ) => ViewSyncer & ActivityBasedService,
     mutagenFactory: (id: string) => Mutagen & Service,
-    pusherFactory: ((id: string) => Pusher & Service) | undefined,
+    pusherFactory: (id: string) => Pusher & Service,
     parent: Worker,
   ) {
     this.#authConfig = config.auth;
@@ -76,9 +76,7 @@ export class Syncer implements SingletonService {
       v => v.keepalive(),
     );
     this.#mutagens = new ServiceRunner(lc, mutagenFactory);
-    if (pusherFactory) {
-      this.#pushers = new ServiceRunner(lc, pusherFactory);
-    }
+    this.#pushers = new ServiceRunner(lc, pusherFactory);
     this.#parent = parent;
     this.#wss = new WebSocketServer({noServer: true});
 
@@ -128,7 +126,7 @@ export class Syncer implements SingletonService {
           : undefined,
         this.#viewSyncers.getService(clientGroupID),
         this.#mutagens.getService(clientGroupID),
-        this.#pushers?.getService(clientGroupID),
+        this.#pushers.getService(clientGroupID),
       ),
       () => {
         if (this.#connections.get(clientID) === connection) {

--- a/packages/zero-client/src/client/options.ts
+++ b/packages/zero-client/src/client/options.ts
@@ -91,11 +91,15 @@ export interface ZeroOptions<
    * your API server. If you would like specific headers to be available
    * to your API server when it receives a custom mutation, you can
    * specify them here.
+   *
+   * The push url may also be specified here rather than in
+   * the zero-cache config. This is useful if request params
+   * should be different for different clients.
    */
   pushParams?:
     | {
+        url?: string | undefined;
         headers?: Record<string, string> | undefined;
-        queryParams?: Record<string, string> | undefined;
       }
     | undefined;
 

--- a/packages/zero-client/src/client/options.ts
+++ b/packages/zero-client/src/client/options.ts
@@ -96,7 +96,7 @@ export interface ZeroOptions<
    * the zero-cache config. This is useful if request params
    * should be different for different clients.
    */
-  pushParams?:
+  push?:
     | {
         url?: string | undefined;
         headers?: Record<string, string> | undefined;

--- a/packages/zero-client/src/client/options.ts
+++ b/packages/zero-client/src/client/options.ts
@@ -77,7 +77,27 @@ export interface ZeroOptions<
    */
   schema: S;
 
-  mutators?: MD;
+  /**
+   * `mutators` is a map of custom mutator definitions. The keys are
+   * namespaces or names of the mutators. The values are the mutator
+   * implementations. Client side mutators must be idempotent as a
+   * mutation can be rebased multiple times when folding in authoritative
+   * changes from the server to the client.
+   */
+  mutators?: MD | undefined;
+
+  /**
+   * Custom mutations are pushed to zero-cache and then to
+   * your API server. If you would like specific headers to be available
+   * to your API server when it receives a custom mutation, you can
+   * specify them here.
+   */
+  pushParams?:
+    | {
+        headers?: Record<string, string> | undefined;
+        queryParams?: Record<string, string> | undefined;
+      }
+    | undefined;
 
   /**
    * `onOnlineChange` is called when the Zero instance's online status changes.

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -379,6 +379,7 @@ describe('createSocket', () => {
         'wsidx',
         debugPerf,
         new LogContext('error', undefined, new TestLogSink()),
+        undefined,
         1048 * 8,
         additionalConnectParams,
       );
@@ -414,6 +415,7 @@ describe('createSocket', () => {
         'wsidx',
         debugPerf,
         new LogContext('error', undefined, new TestLogSink()),
+        undefined,
         0, // do not put any extra information into headers
         additionalConnectParams,
       );

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -1077,7 +1077,7 @@ export class Zero<
           // The clientSchema only needs to be sent for the very first request.
           // Henceforth it is stored with the CVR and verified automatically.
           ...(this.#connectCookie === null ? {clientSchema} : {}),
-          userPushParams: this.#options.pushParams,
+          userPushParams: this.#options.push,
         },
       ]);
       this.#deletedClients = undefined;
@@ -1171,7 +1171,7 @@ export class Zero<
       wsid,
       this.#options.logLevel === 'debug',
       l,
-      this.#options.pushParams,
+      this.#options.push,
       this.#options.maxHeaderLength,
       additionalConnectParams,
     );

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -35,7 +35,10 @@ import type {Writable} from '../../../shared/src/writable.ts';
 import type {ChangeDesiredQueriesMessage} from '../../../zero-protocol/src/change-desired-queries.ts';
 import {type ClientSchema} from '../../../zero-protocol/src/client-schema.ts';
 import type {CloseConnectionMessage} from '../../../zero-protocol/src/close-connection.ts';
-import type {ConnectedMessage} from '../../../zero-protocol/src/connect.ts';
+import type {
+  ConnectedMessage,
+  UserPushParams,
+} from '../../../zero-protocol/src/connect.ts';
 import {encodeSecProtocols} from '../../../zero-protocol/src/connect.ts';
 import type {DeleteClientsBody} from '../../../zero-protocol/src/delete-clients.ts';
 import type {Downstream} from '../../../zero-protocol/src/down.ts';
@@ -1074,6 +1077,7 @@ export class Zero<
           // The clientSchema only needs to be sent for the very first request.
           // Henceforth it is stored with the CVR and verified automatically.
           ...(this.#connectCookie === null ? {clientSchema} : {}),
+          userPushParams: this.#options.pushParams,
         },
       ]);
       this.#deletedClients = undefined;
@@ -1167,6 +1171,7 @@ export class Zero<
       wsid,
       this.#options.logLevel === 'debug',
       l,
+      this.#options.pushParams,
       this.#options.maxHeaderLength,
       additionalConnectParams,
     );
@@ -1859,6 +1864,7 @@ export async function createSocket(
   wsid: string,
   debugPerf: boolean,
   lc: LogContext,
+  pushParams: UserPushParams | undefined,
   maxHeaderLength = 1024 * 8,
   additionalConnectParams?: Record<string, string> | undefined,
 ): Promise<
@@ -1915,6 +1921,7 @@ export async function createSocket(
         // The clientSchema only needs to be sent for the very first request.
         // Henceforth it is stored with the CVR and verified automatically.
         ...(baseCookie === null ? {clientSchema} : {}),
+        userPushParams: pushParams,
       },
     ],
     auth,

--- a/packages/zero-pg/src/web.ts
+++ b/packages/zero-pg/src/web.ts
@@ -103,7 +103,7 @@ export class PushProcessor<
     if (queryString instanceof URLSearchParams) {
       queryString = Object.fromEntries(queryString);
     }
-    const queryParams = v.parse(queryString, pushParamsSchema);
+    const queryParams = v.parse(queryString, pushParamsSchema, 'passthrough');
     const connection = await this.#dbConnectionProvider();
 
     if (req.pushVersion !== 1) {

--- a/packages/zero-protocol/src/ast.test.ts
+++ b/packages/zero-protocol/src/ast.test.ts
@@ -607,5 +607,5 @@ test('protocol version', () => {
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
   expect(hash).toEqual('2zzy9s2lcdcms');
-  expect(PROTOCOL_VERSION).toEqual(14);
+  expect(PROTOCOL_VERSION).toEqual(15);
 });

--- a/packages/zero-protocol/src/connect.ts
+++ b/packages/zero-protocol/src/connect.ts
@@ -21,10 +21,16 @@ export const connectedMessageSchema = v.tuple([
   connectedBodySchema,
 ]);
 
+const userPushParamsSchema = v.object({
+  headers: v.record(v.string()).optional(),
+  queryParams: v.record(v.string()).optional(),
+});
+
 const initConnectionBodySchema = v.object({
   desiredQueriesPatch: queriesPatchSchema,
   clientSchema: clientSchemaSchema.optional(),
   deleted: deleteClientsBodySchema.optional(),
+  userPushParams: userPushParamsSchema.optional(),
 });
 
 export const initConnectionMessageSchema = v.tuple([
@@ -34,6 +40,7 @@ export const initConnectionMessageSchema = v.tuple([
 
 export type ConnectedBody = v.Infer<typeof connectedBodySchema>;
 export type ConnectedMessage = v.Infer<typeof connectedMessageSchema>;
+export type UserPushParams = v.Infer<typeof userPushParamsSchema>;
 
 export type InitConnectionBody = v.Infer<typeof initConnectionBodySchema>;
 export type InitConnectionMessage = v.Infer<typeof initConnectionMessageSchema>;

--- a/packages/zero-protocol/src/connect.ts
+++ b/packages/zero-protocol/src/connect.ts
@@ -23,7 +23,7 @@ export const connectedMessageSchema = v.tuple([
 
 const userPushParamsSchema = v.object({
   headers: v.record(v.string()).optional(),
-  queryParams: v.record(v.string()).optional(),
+  url: v.string().optional(),
 });
 
 const initConnectionBodySchema = v.object({

--- a/packages/zero-protocol/src/protocol-version.test.ts
+++ b/packages/zero-protocol/src/protocol-version.test.ts
@@ -11,6 +11,6 @@ test('protocol version', () => {
   // If this test fails upstream or downstream schema has changed such that
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
-  expect(hash).toEqual('2m72557u8fqg0');
-  expect(PROTOCOL_VERSION).toEqual(14);
+  expect(hash).toEqual('2eow9wx5iksuy');
+  expect(PROTOCOL_VERSION).toEqual(15);
 });

--- a/packages/zero-protocol/src/protocol-version.ts
+++ b/packages/zero-protocol/src/protocol-version.ts
@@ -20,7 +20,7 @@ import {assert} from '../../shared/src/asserts.ts';
 // -- Version 11 adds inspect queries. (0.18)
 // -- Version 12 adds 'timestamp' and 'date' types to the ClientSchema ValueType. (not shipped, reversed by version 14)
 // -- Version 14 removes 'timestamp' and 'date' types from the ClientSchema ValueType. (0.18)
-export const PROTOCOL_VERSION = 14;
+export const PROTOCOL_VERSION = 15;
 
 /**
  * The minimum server-supported sync protocol version (i.e. the version


### PR DESCRIPTION
- We previously had no way to initialize the pusher service with custom parameters from the client. This adds an `initConnection` method to `pusher` and extra arguments to the `initConnection` protocol message. 
- Responses to `initConnection` previously could only return a single value but now we must return two: the pusher stream and the view syncer stream.
- The logic to determine if a user had opted into custom mutators was based around the presence of `pushURL` in the config but this can now come from the client itself.