### PR TITLE
chore(zero-cache): handle socket closures during websocket handoff

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
@@ -45,6 +45,7 @@ export class ChangeStreamerHttpServer extends HttpService {
       fastify.get(TENANT_PATH_PATTERN, {websocket: true}, this.#subscribe);
 
       installWebSocketReceiver<SubscriberContext>(
+        lc,
         fastify.websocketServer,
         this.#handleSubscription,
         parent,

--- a/packages/zero-cache/src/services/dispatcher/websocket-handoff.test.ts
+++ b/packages/zero-cache/src/services/dispatcher/websocket-handoff.test.ts
@@ -14,6 +14,7 @@ describe('dispatcher/websocket-handoff', () => {
   let port: number;
   let server: Server;
   let wss: WebSocketServer;
+  const lc = createSilentLogContext();
 
   beforeAll(() => {
     port = randInt(10000, 20000);
@@ -35,7 +36,7 @@ describe('dispatcher/websocket-handoff', () => {
     const [parent, child] = inProcChannel();
 
     installWebSocketHandoff(
-      createSilentLogContext(),
+      lc,
       () => ({
         payload: {foo: 'boo'},
         receiver: child,
@@ -44,6 +45,7 @@ describe('dispatcher/websocket-handoff', () => {
     );
 
     installWebSocketReceiver(
+      lc,
       wss,
       (ws, payload) => {
         ws.on('message', msg => {
@@ -68,7 +70,7 @@ describe('dispatcher/websocket-handoff', () => {
     const [parent, child] = inProcChannel();
 
     installWebSocketHandoff(
-      createSilentLogContext(),
+      lc,
       (_, callback) =>
         callback({
           payload: {foo: 'boo'},
@@ -78,6 +80,7 @@ describe('dispatcher/websocket-handoff', () => {
     );
 
     installWebSocketReceiver(
+      lc,
       wss,
       (ws, payload) => {
         ws.on('message', msg => {
@@ -104,7 +107,7 @@ describe('dispatcher/websocket-handoff', () => {
 
     // server(grandParent) to parent
     installWebSocketHandoff(
-      createSilentLogContext(),
+      lc,
       () => ({
         payload: {foo: 'boo'},
         receiver: grandParent,
@@ -114,7 +117,7 @@ describe('dispatcher/websocket-handoff', () => {
 
     // parent to child
     installWebSocketHandoff(
-      createSilentLogContext(),
+      lc,
       () => ({
         payload: {foo: 'boo'},
         receiver: parent2,
@@ -124,6 +127,7 @@ describe('dispatcher/websocket-handoff', () => {
 
     // child receives socket
     installWebSocketReceiver(
+      lc,
       wss,
       (ws, payload) => {
         ws.on('message', msg => {
@@ -146,7 +150,7 @@ describe('dispatcher/websocket-handoff', () => {
 
   test('handoff error', async () => {
     installWebSocketHandoff(
-      createSilentLogContext(),
+      lc,
       () => {
         throw new Error('こんにちは' + 'あ'.repeat(150));
       },

--- a/packages/zero-cache/src/workers/syncer.ts
+++ b/packages/zero-cache/src/workers/syncer.ts
@@ -82,7 +82,12 @@ export class Syncer implements SingletonService {
     this.#parent = parent;
     this.#wss = new WebSocketServer({noServer: true});
 
-    installWebSocketReceiver(this.#wss, this.#createConnection, this.#parent);
+    installWebSocketReceiver(
+      lc,
+      this.#wss,
+      this.#createConnection,
+      this.#parent,
+    );
   }
 
   readonly #createConnection = async (ws: WebSocket, params: ConnectParams) => {


### PR DESCRIPTION
Discovered by the load harness. The socket handle is `undefined` if it was closed before is it handed off to the subprocess.

Failing to check this will otherwise crash the server.