### PR TITLE
fix(z2s): junction relationship fixes

### DIFF
--- a/packages/z2s/src/compiler.output.test.ts
+++ b/packages/z2s/src/compiler.output.test.ts
@@ -986,7 +986,7 @@ test('related w/o junction edge', () => {
   ).toMatchInlineSnapshot(`
     {
       "text": "SELECT COALESCE(json_agg(row_to_json("root")), '[]'::json)::text as "zql_result" FROM (SELECT (
-          SELECT COALESCE(json_agg(row_to_json("inner_owner")) , '[]'::json) FROM (SELECT "user"."id","user"."name","user"."age" FROM "user"  WHERE ("issue"."ownerId" = "user"."id")  ) "inner_owner"
+          SELECT COALESCE(json_agg(row_to_json("inner_owner")), '[]'::json) FROM (SELECT "user"."id","user"."name","user"."age" FROM "user"  WHERE ("issue"."ownerId" = "user"."id")  ) "inner_owner"
         ) as "owner","issue"."id","issue"."title","issue"."description","issue"."closed","issue"."ownerId",EXTRACT(EPOCH FROM "issue"."created") * 1000 as "created" FROM "issue"    )"root"",
       "values": [],
     }

--- a/packages/z2s/src/compiler.ts
+++ b/packages/z2s/src/compiler.ts
@@ -224,9 +224,12 @@ export class Compiler {
     if (relationship.hidden) {
       const [join, lastAlias, lastLimit, lastTable] =
         this.makeJunctionJoin(relationship);
-      assert(relationship.subquery.related);
-      const nestedAst = relationship.subquery.related[0].subquery;
 
+      assert(
+        relationship.subquery.related,
+        'hidden relationship must be a junction',
+      );
+      const nestedAst = relationship.subquery.related[0].subquery;
       const selectionSet = this.related(
         nestedAst.related ?? [],
         format,

--- a/packages/z2s/src/compiler.ts
+++ b/packages/z2s/src/compiler.ts
@@ -202,12 +202,14 @@ export class Compiler {
     relationships: readonly CorrelatedSubquery[],
     format: Format | undefined,
     parentTable: string,
+    parentTableAlias?: string | undefined,
   ): SQLQuery[] {
     return relationships.map(relationship =>
       this.relationshipSubquery(
         relationship,
         format?.relationships[must(relationship.subquery.alias)],
         parentTable,
+        parentTableAlias,
       ),
     );
   }
@@ -216,30 +218,35 @@ export class Compiler {
     relationship: CorrelatedSubquery,
     format: Format | undefined,
     parentTable: string,
+    parentTableAlias?: string | undefined,
   ): SQLQuery {
+    const innerAlias = `inner_${relationship.subquery.alias}`;
     if (relationship.hidden) {
       const [join, lastAlias, lastLimit, lastTable] =
         this.makeJunctionJoin(relationship);
-      const lastClientColumns = Object.keys(this.#tables[lastTable].columns);
-      /**
-       * This aggregates the relationship subquery into an array of objects.
-       * This looks roughly like:
-       *
-       * SELECT COALESCE(json_agg(row_to_json("inner_owner")) , '[]'::json) FROM
-       * (SELECT mytable.col as client_col, mytable.col2 as client_col2 FROM mytable) inner_mytable
-       */
+      assert(relationship.subquery.related);
+      const nestedAst = relationship.subquery.related[0].subquery;
+
+      const selectionSet = this.related(
+        nestedAst.related ?? [],
+        format,
+        lastTable,
+        lastAlias,
+      );
+      const tableSchema = this.#tables[nestedAst.table];
+      for (const column of Object.keys(tableSchema.columns)) {
+        selectionSet.push(this.#selectCol(nestedAst.table, column, lastAlias));
+      }
       return sql`(
         SELECT ${this.#toJSON(
-          `inner_${relationship.subquery.alias}`,
+          innerAlias,
           format?.singular,
         )} FROM (SELECT ${sql.join(
-          lastClientColumns.map(
-            c => sql`${sql.ident(lastAlias)}.${this.#mapColumn(lastTable, c)}`,
-          ),
+          selectionSet,
           ',',
         )} FROM ${join} WHERE (${this.correlate(
           parentTable,
-          parentTable,
+          parentTableAlias ?? parentTable,
           relationship.correlation.parentField,
           relationship.subquery.table,
           relationship.subquery.table,
@@ -256,46 +263,55 @@ export class Compiler {
           relationship.subquery.table,
         )} ${
           format?.singular ? this.limit(1) : this.limit(lastLimit)
-        } ) ${sql.ident(`inner_${relationship.subquery.alias}`)}
+        } ) ${sql.ident(innerAlias)}
       ) as ${sql.ident(relationship.subquery.alias)}`;
     }
     return sql`(
-      SELECT ${
-        format?.singular ? sql`` : sql`COALESCE(json_agg`
-      }(row_to_json(${sql.ident(`inner_${relationship.subquery.alias}`)})) ${
-        format?.singular ? sql`` : sql`, '[]'::json)`
-      } FROM (${this.select(
+      SELECT ${this.#toJSON(innerAlias, format?.singular)} FROM (${this.select(
         relationship.subquery,
         format,
         this.correlate(
           parentTable,
-          parentTable,
+          parentTableAlias ?? parentTable,
           relationship.correlation.parentField,
           relationship.subquery.table,
           relationship.subquery.table,
           relationship.correlation.childField,
         ),
-      )}) ${sql.ident(`inner_${relationship.subquery.alias}`)}
+      )}) ${sql.ident(innerAlias)}
     ) as ${sql.ident(relationship.subquery.alias)}`;
   }
 
   pullTablesForJunction(
     relationship: CorrelatedSubquery,
-    tables: [string, Correlation, number | undefined][] = [],
-  ) {
+  ): [
+    [string, Correlation, number | undefined],
+    [string, Correlation, number | undefined],
+  ] {
+    const tables: [string, Correlation, number | undefined][] = [];
     tables.push([
       relationship.subquery.table,
       relationship.correlation,
       relationship.subquery.limit,
     ]);
     assert(
-      relationship.subquery.related?.length || 0 <= 1,
+      relationship.subquery.related?.length === 1,
       'Too many related tables for a junction edge',
     );
-    for (const subRelationship of relationship.subquery.related ?? []) {
-      this.pullTablesForJunction(subRelationship, tables);
-    }
-    return tables;
+    const otherRelationship = relationship.subquery.related[0];
+    assert(!otherRelationship.hidden);
+    return [
+      [
+        relationship.subquery.table,
+        relationship.correlation,
+        relationship.subquery.limit,
+      ],
+      [
+        otherRelationship.subquery.table,
+        otherRelationship.correlation,
+        otherRelationship.subquery.limit,
+      ],
+    ];
   }
 
   makeJunctionJoin(
@@ -590,7 +606,7 @@ export class Compiler {
     return sql.ident(mapped);
   }
 
-  #selectCol(table: string, column: string) {
+  #selectCol(table: string, column: string, tableAlias?: string | undefined) {
     const serverColumnSchema =
       this.#serverSchema[this.#nameMapper.tableName(table)][
         this.#nameMapper.columnName(table, column)
@@ -605,13 +621,13 @@ export class Compiler {
         serverType === 'timestamp with time zone')
     ) {
       return sql`EXTRACT(EPOCH FROM ${sql.ident(
-        table,
+        tableAlias ?? table,
       )}.${this.#mapColumnNoAlias(
         table,
         column,
       )}) * 1000 as ${sql.ident(column)}`;
     }
-    return sql`${sql.ident(table)}.${this.#mapColumn(table, column)}`;
+    return sql`${sql.ident(tableAlias ?? table)}.${this.#mapColumn(table, column)}`;
   }
 
   #toJSON(table: string, singular = false): SQLQuery {

--- a/packages/zql-integration-tests/src/compiler.pg-test.ts
+++ b/packages/zql-integration-tests/src/compiler.pg-test.ts
@@ -69,6 +69,137 @@ test.each(
         ],
       },
       {
+        name: 'related nested in junction related',
+        createQuery: q => q.label.related('issues', q => q.related('owner')),
+        manualVerification: [
+          {
+            id: 'label1',
+            issues: [
+              {
+                closed: true,
+                createdAt: 1743127752952,
+                description: 'Description for issue 1',
+                id: 'issue1',
+                owner: null,
+                ownerId: null,
+                title: 'Test Issue 1',
+              },
+              {
+                closed: true,
+                createdAt: 1742954952952,
+                description: 'Description for issue 3',
+                id: 'issue3',
+                owner: {
+                  id: 'user2',
+                  metadata: {
+                    altContacts: ['alt2@example.com'],
+                    email: 'user2@example.com',
+                    registrar: 'google',
+                  },
+                  name: 'User 2',
+                },
+                ownerId: 'user2',
+                title: 'Test Issue 3',
+              },
+            ],
+            name: 'Label 1',
+          },
+          {
+            id: 'label2',
+            issues: [
+              {
+                closed: true,
+                createdAt: 1743127752952,
+                description: 'Description for issue 1',
+                id: 'issue1',
+                owner: null,
+                ownerId: null,
+                title: 'Test Issue 1',
+              },
+              {
+                closed: false,
+                createdAt: 1743041352952,
+                description: 'Description for issue 2',
+                id: 'issue2',
+                owner: {
+                  id: 'user1',
+                  metadata: null,
+                  name: 'User 1',
+                },
+                ownerId: 'user1',
+                title: 'Test Issue 2',
+              },
+            ],
+            name: 'Label 2',
+          },
+        ],
+      },
+      {
+        name: 'related with filter nested in junction related',
+        createQuery: q =>
+          q.label.related('issues', q =>
+            q.related('comments', q => q.where('text', 'LIKE', '%2%')),
+          ),
+        manualVerification: [
+          {
+            id: 'label1',
+            issues: [
+              {
+                closed: true,
+                comments: [],
+                createdAt: 1743127752952,
+                description: 'Description for issue 1',
+                id: 'issue1',
+                ownerId: null,
+                title: 'Test Issue 1',
+              },
+              {
+                closed: true,
+                comments: [],
+                createdAt: 1742954952952,
+                description: 'Description for issue 3',
+                id: 'issue3',
+                ownerId: 'user2',
+                title: 'Test Issue 3',
+              },
+            ],
+            name: 'Label 1',
+          },
+          {
+            id: 'label2',
+            issues: [
+              {
+                closed: true,
+                comments: [],
+                createdAt: 1743127752952,
+                description: 'Description for issue 1',
+                id: 'issue1',
+                ownerId: null,
+                title: 'Test Issue 1',
+              },
+              {
+                closed: false,
+                comments: [
+                  {
+                    authorId: 'user2',
+                    createdAt: 1743041352952,
+                    id: 'comment2',
+                    issueId: 'issue2',
+                    text: 'Comment 2 text',
+                  },
+                ],
+                createdAt: 1743041352952,
+                description: 'Description for issue 2',
+                id: 'issue2',
+                ownerId: 'user1',
+                title: 'Test Issue 2',
+              },
+            ],
+            name: 'Label 2',
+          },
+        ],
+      },
+      {
         name: 'multiple where clauses',
         createQuery: q =>
           q.issue.where('closed', '=', false).where('ownerId', 'IS NOT', null),


### PR DESCRIPTION
Reported on discord: https://discord.com/channels/830183651022471199/1288232858795769917/1360371961141661936

Relationships nested in a junction relationship were not working correctly.

Additionally, `#selectCol` conversion logic for date and timestamp types were not being applied to columns of junction relationships. 