### PR TITLE
fix(zero-cache): bound advancement processing and wal(2) growth

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -372,8 +372,9 @@ export class PipelineDriver {
     // total hydration time to make it through half of the advancement.
     // This serves as both a circuit breaker for very large transactions,
     // as well as a bound on the amount of time the previous connection locks
-    // the inactive WAL file (which prevents WAL2 from switching back to it
-    // when the current WAL is over the size limit).
+    // the inactive WAL file (as the lock prevents WAL2 from switching to the
+    // free WAL when the current one is over the size limit, which can make
+    // the WAL grow continuously and compound slowness).
     //
     // Note: 1/2 is a conservative estimate policy. A lower proportion would
     // flag slowness sooner, at the expense of larger estimation error.

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -30,7 +30,12 @@ import type {ShardID} from '../../types/shards.ts';
 import {getSubscriptionState} from '../replicator/schema/replication-state.ts';
 import {checkClientSchema} from './client-schema.ts';
 import type {ClientGroupStorage} from './database-storage.ts';
-import {Snapshotter, type SnapshotDiff} from './snapshotter.ts';
+import {
+  ResetPipelinesSignal,
+  Snapshotter,
+  type SnapshotDiff,
+} from './snapshotter.ts';
+import type {Timer} from './view-syncer.ts';
 
 export type RowAdd = {
   readonly type: 'add';
@@ -343,11 +348,15 @@ export class PipelineDriver {
   /**
    * Advances to the new head of the database.
    *
+   * @param timer The caller-controlled {@link Timer} that will be used to
+   *        measure the progress of the advancement and abort with a
+   *        ResetPipelinesSignal if it is estimated to take longer than
+   *        a hydration at `curr`.
    * @return The resulting row changes for all added queries. Note that the
    *         `changes` must be iterated over in their entirety in order to
    *         advance the database snapshot.
    */
-  advance(): {
+  advance(timer: Timer): {
     version: string;
     numChanges: number;
     changes: Iterable<RowChange>;
@@ -357,42 +366,69 @@ export class PipelineDriver {
     const {prev, curr, changes} = diff;
     this.#lc.debug?.(`${prev.version} => ${curr.version}: ${changes} changes`);
 
+    const totalHydrationTimeMs = this.totalHydrationTimeMs();
+
+    function checkProgress(pos: number) {
+      // Check every 10 changes
+      if (pos % 10 === 0) {
+        const elapsed = timer.totalElapsed();
+        if (elapsed > totalHydrationTimeMs / 2 && pos < changes / 2) {
+          throw new ResetPipelinesSignal(
+            `advancement exceeded timeout at ${pos} of ${changes} changes (${elapsed} ms)`,
+          );
+        }
+      }
+    }
+
     return {
       version: curr.version,
       numChanges: changes,
-      changes: this.#advance(diff),
+      changes: this.#advance(
+        diff,
+        // Somewhat arbitrary: only check progress if there are at least 10
+        // changes.
+        changes >= 10 ? checkProgress : () => {},
+      ),
     };
   }
 
-  *#advance(diff: SnapshotDiff): Iterable<RowChange> {
+  *#advance(
+    diff: SnapshotDiff,
+    onChange: (pos: number) => void,
+  ): Iterable<RowChange> {
+    let pos = 0;
     for (const {table, prevValue, nextValue, rowKey} of diff) {
-      if (prevValue && nextValue) {
-        // Rows are ultimately referred to by the union key (in #streamNodes())
-        // so an update is represented as an `edit` if and only if the
-        // unionKey-based row keys are the same in prevValue and nextValue.
-        const {unionKey} = must(this.#tableSpecs.get(table)).tableSpec;
-        if (
-          Object.keys(rowKey).length === unionKey.length ||
-          deepEqual(
-            getRowKey(unionKey, prevValue as Row) as JSONValue,
-            getRowKey(unionKey, nextValue as Row) as JSONValue,
-          )
-        ) {
-          yield* this.#push(table, {
-            type: 'edit',
-            row: nextValue as Row,
-            oldRow: prevValue as Row,
-          });
-          continue;
+      try {
+        if (prevValue && nextValue) {
+          // Rows are ultimately referred to by the union key (in #streamNodes())
+          // so an update is represented as an `edit` if and only if the
+          // unionKey-based row keys are the same in prevValue and nextValue.
+          const {unionKey} = must(this.#tableSpecs.get(table)).tableSpec;
+          if (
+            Object.keys(rowKey).length === unionKey.length ||
+            deepEqual(
+              getRowKey(unionKey, prevValue as Row) as JSONValue,
+              getRowKey(unionKey, nextValue as Row) as JSONValue,
+            )
+          ) {
+            yield* this.#push(table, {
+              type: 'edit',
+              row: nextValue as Row,
+              oldRow: prevValue as Row,
+            });
+            continue;
+          }
+          // If the unionKey-based row keys differed, they will be
+          // represented as a remove of the old key and an add of the new key.
         }
-        // If the unionKey-based row keys differed, they will be
-        // represented as a remove of the old key and an add of the new key.
-      }
-      if (prevValue) {
-        yield* this.#push(table, {type: 'remove', row: prevValue as Row});
-      }
-      if (nextValue) {
-        yield* this.#push(table, {type: 'add', row: nextValue as Row});
+        if (prevValue) {
+          yield* this.#push(table, {type: 'remove', row: prevValue as Row});
+        }
+        if (nextValue) {
+          yield* this.#push(table, {type: 'add', row: nextValue as Row});
+        }
+      } finally {
+        onChange(++pos);
       }
     }
 

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -35,7 +35,6 @@ import {
   Snapshotter,
   type SnapshotDiff,
 } from './snapshotter.ts';
-import type {Timer} from './view-syncer.ts';
 
 export type RowAdd = {
   readonly type: 'add';

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -356,7 +356,7 @@ export class PipelineDriver {
    *         `changes` must be iterated over in their entirety in order to
    *         advance the database snapshot.
    */
-  advance(timer: Timer): {
+  advance(timer: {totalElapsed: () => number}): {
     version: string;
     numChanges: number;
     changes: Iterable<RowChange>;
@@ -381,7 +381,7 @@ export class PipelineDriver {
       // Check every 10 changes
       if (pos % 10 === 0) {
         const elapsed = timer.totalElapsed();
-        if (elapsed > totalHydrationTimeMs / 2 && pos < changes / 2) {
+        if (elapsed > totalHydrationTimeMs / 2 && pos <= changes / 2) {
           throw new ResetPipelinesSignal(
             `advancement exceeded timeout at ${pos} of ${changes} changes (${elapsed} ms)`,
           );
@@ -394,9 +394,9 @@ export class PipelineDriver {
       numChanges: changes,
       changes: this.#advance(
         diff,
-        // Somewhat arbitrary: only check progress if there are at least 10
-        // changes.
-        changes >= 10 ? checkProgress : () => {},
+        // Somewhat arbitrary: only check progress if there are at least 20
+        // changes (Note that the first check doesn't happen until 10 changes).
+        changes >= 20 ? checkProgress : () => {},
       ),
     };
   }


### PR DESCRIPTION
User report: https://discord.com/channels/830183651022471199/1358875333243179039/1359565864273186939

### Summary

Bound the time allowed to process an incremental advancement.
* If it takes more than half of the total hydration time to get through half of the advancement, abort and hydrate at the head of the database.

### Effect

This solves two problems:

* Bounds the time it takes to handle very large transactions; no need to go through all changes incrementally when re-running the queries is probably faster.
* Avoids runaway wal growth that can happen due to an old transaction holding a lock on the inactive wal file.

### Explanation

In [wal2 mode](https://sqlite.org/cgi/src/doc/wal2/doc/wal2.md), writes alternate between two wal files to allow for increased concurrency between readers and writers. However, it can only checkpoint and reuse the inactive wal file if there are no readers holding a lock on it. Until that inactive wal file is free, the active wal file continues being used to store new writes.

With advancement processing, two transactions are used. A `current` transaction to look up new values, and a `previous` transaction to look up previous values, as well as replay the effect of each incremental change for the IVM pipeline.

This `previous` transaction is what can lock the inactive wal file. In a pathological case of a slow advancement amidst a high transaction rate, the wal file grows in an unbounded fashion:

<img width="629" alt="Screenshot 2025-04-11 at 19 18 41" src="https://github.com/user-attachments/assets/fd52f82f-0313-4656-8b49-25f9b6768d16" />

This problem compounds. A large wal file makes reads slow, which makes the advancement(s) slow, thereby never allowing the lock on the inactive wal file to be released. This results in creating a large store of work that occupies the CPU long after upstream transactions have stopped.

Short-circuiting long advancements has the effect of bounding the lifetime of old transactions, thereby guaranteeing that inactive wal files are eventually checkpointed and reused:


<img width="659" alt="Screenshot 2025-04-11 at 23 34 13" src="https://github.com/user-attachments/assets/ee7eb2b5-ed00-4be0-b5f9-204ae3bf4a08" />

Simulation via the load harness confirms that with the previous behavior, 5 minutes of changes created a ~27 minute backlog of work, whereas the with the new behavior the view-syncer is able to keep up.

![backlog-fix](https://github.com/user-attachments/assets/02815c23-e3d2-44fc-9fdb-cd97b95e0d8d)

