### PR TITLE
Put db in `UTC+1` for integration tests

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr-store.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.pg-test.ts
@@ -47,7 +47,7 @@ describe('view-syncer/cvr-store', () => {
     await db.begin(tx => setupCVRTables(lc, tx, SHARD));
     await db.unsafe(`
     INSERT INTO "roze_1/cvr".instances ("clientGroupID", version, "lastActive", "replicaVersion")
-      VALUES('${CVR_ID}', '03', '2024-09-04', '01');
+      VALUES('${CVR_ID}', '03', '2024-09-04T00:00:00Z', '01');
     INSERT INTO "roze_1/cvr".queries ("clientGroupID", "queryHash", "clientAST", 
                              "patchVersion", "transformationHash", "transformationVersion")
       VALUES('${CVR_ID}', 'foo', '{"table":"issues"}', '01', 'foo-transformed', '01');
@@ -754,7 +754,7 @@ describe('view-syncer/cvr-store', () => {
       INSERT INTO "roze_1/cvr".desires ("clientGroupID", "clientID", "queryHash", "patchVersion")
         VALUES('${CVR_ID}', 'client1', 'foo', '01');
       INSERT INTO "roze_1/cvr".desires ("clientGroupID", "clientID", "queryHash", "patchVersion", "ttl", "inactivatedAt")
-        VALUES('${CVR_ID}', 'missing-client', 'foo', '01', '3600', '2025-03-10');
+        VALUES('${CVR_ID}', 'missing-client', 'foo', '01', '3600', '2025-03-10T00:00:00Z');
     `);
 
     const cvr = await store.load(lc, CONNECT_TIME);
@@ -838,7 +838,7 @@ describe('view-syncer/cvr-store', () => {
       INSERT INTO "roze_1/cvr".desires ("clientGroupID", "clientID", "queryHash", "patchVersion", "ttl")
         VALUES('${CVR_ID}', 'client2', 'baz', '03', INTERVAL '7200 milliseconds');
       INSERT INTO "roze_1/cvr".desires ("clientGroupID", "clientID", "queryHash", "patchVersion", "inactivatedAt")
-        VALUES('${CVR_ID}', 'client2', 'bar', '02', '2024-10-15');
+        VALUES('${CVR_ID}', 'client2', 'bar', '02', '2024-10-15T00:00:00Z');
     `);
 
     // Test inspectQueries with no clientID (should return all queries)

--- a/packages/zero-cache/test/pg-15.ts
+++ b/packages/zero-cache/test/pg-15.ts
@@ -1,3 +1,3 @@
 import {runPostgresContainer} from './pg-container-setup';
 
-export default runPostgresContainer('postgres:15.8-alpine3.20');
+export default runPostgresContainer('postgres:15.8-alpine3.20', 'UTC');

--- a/packages/zero-cache/test/pg-16.ts
+++ b/packages/zero-cache/test/pg-16.ts
@@ -1,3 +1,3 @@
 import {runPostgresContainer} from './pg-container-setup';
 
-export default runPostgresContainer('postgres:16.4-alpine3.20');
+export default runPostgresContainer('postgres:16.4-alpine3.20', 'UTC');

--- a/packages/zero-cache/test/pg-17.ts
+++ b/packages/zero-cache/test/pg-17.ts
@@ -1,3 +1,3 @@
 import {runPostgresContainer} from './pg-container-setup';
 
-export default runPostgresContainer('postgres:17.0-alpine3.20');
+export default runPostgresContainer('postgres:17.0-alpine3.20', 'UTC+1');

--- a/packages/zero-cache/test/pg-container-setup.ts
+++ b/packages/zero-cache/test/pg-container-setup.ts
@@ -1,6 +1,6 @@
 import {PostgreSqlContainer} from '@testcontainers/postgresql';
 
-export function runPostgresContainer(image: string) {
+export function runPostgresContainer(image: string, timezone: string) {
   return async ({provide}) => {
     const container = await new PostgreSqlContainer(image)
       .withCommand([
@@ -8,7 +8,7 @@ export function runPostgresContainer(image: string) {
         '-c',
         'wal_level=logical',
         '-c',
-        'timezone=UTC+1',
+        `timezone=${timezone}`,
       ])
       .start();
 

--- a/packages/zero-cache/test/pg-container-setup.ts
+++ b/packages/zero-cache/test/pg-container-setup.ts
@@ -3,7 +3,13 @@ import {PostgreSqlContainer} from '@testcontainers/postgresql';
 export function runPostgresContainer(image: string) {
   return async ({provide}) => {
     const container = await new PostgreSqlContainer(image)
-      .withCommand(['postgres', '-c', 'wal_level=logical'])
+      .withCommand([
+        'postgres',
+        '-c',
+        'wal_level=logical',
+        '-c',
+        'timezone=UTC+1',
+      ])
       .start();
 
     // Referenced by ./src/test/db.ts

--- a/packages/zql-integration-tests/src/discord-repro.pg-test.ts
+++ b/packages/zql-integration-tests/src/discord-repro.pg-test.ts
@@ -29,7 +29,7 @@ beforeAll(async () => {
 
   await pg.unsafe(/*sql*/ `
     INSERT INTO "issues" ("id", "title", "description", "closed", "owner_id", "createdAt") VALUES (
-      'issue1', 'Test Issue 1', 'Description for issue 1', false, 'user1', TIMESTAMP '2001-02-16 20:38:40'
+      'issue1', 'Test Issue 1', 'Description for issue 1', false, 'user1', TIMESTAMPTZ '2001-02-16T20:38:40.000Z'
     );
 
     INSERT INTO "users" ("id", "name") VALUES (

--- a/packages/zql/src/query/test/test-schemas.ts
+++ b/packages/zql/src/query/test/test-schemas.ts
@@ -184,7 +184,7 @@ CREATE TABLE IF NOT EXISTS "issues" (
   "description" TEXT NOT NULL,
   "closed" BOOLEAN NOT NULL,
   "owner_id" TEXT,
-  "createdAt" TIMESTAMP NOT NULL
+  "createdAt" TIMESTAMPTZ NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS "users" (
@@ -198,6 +198,7 @@ CREATE TABLE IF NOT EXISTS "comments" (
   "authorId" TEXT NOT NULL,
   "issue_id" TEXT NOT NULL,
   "text" TEXT NOT NULL,
+  -- not TIMESTAMPTZ so that we're checking both TIMESTAMP and TIMESTAMPTZ behaviour
   "createdAt" TIMESTAMP NOT NULL
 );
 


### PR DESCRIPTION
Followup for https://github.com/rocicorp/mono/pull/4216

I tested (`zql-integration-tests`) with the patch in the above PR reverted and things broke, so this adds some coverage