### PR TITLE
feat(zero)!: Add options to Query run

### DIFF
--- a/packages/analyze-query/src/bin-analyze.ts
+++ b/packages/analyze-query/src/bin-analyze.ts
@@ -171,6 +171,7 @@ const host: QueryDelegate = {
   normalizeRunOptions(options) {
     return options ?? DEFAULT_RUN_OPTIONS_COMPLETE;
   },
+  defaultQueryComplete: true,
 };
 
 let start: number;

--- a/packages/analyze-query/src/bin-analyze.ts
+++ b/packages/analyze-query/src/bin-analyze.ts
@@ -1,10 +1,14 @@
 /* eslint-disable no-console */
 import '@dotenvx/dotenvx/config';
 import chalk from 'chalk';
+import {astToZQL} from '../../ast-to-zql/src/ast-to-zql.ts';
+import {formatOutput} from '../../ast-to-zql/src/format.ts';
 import {testLogConfig} from '../../otel/src/test-log-config.ts';
 import {createSilentLogContext} from '../../shared/src/logging-test-utils.ts';
+import {must} from '../../shared/src/must.ts';
 import {parseOptions} from '../../shared/src/options.ts';
 import * as v from '../../shared/src/valita.ts';
+import {transformAndHashQuery} from '../../zero-cache/src/auth/read-authorizer.ts';
 import {
   appOptions,
   shardOptions,
@@ -12,6 +16,8 @@ import {
   zeroOptions,
 } from '../../zero-cache/src/config/zero-config.ts';
 import {loadSchemaAndPermissions} from '../../zero-cache/src/scripts/permissions.ts';
+import {pgClient} from '../../zero-cache/src/types/pg.ts';
+import {getShardID, upstreamSchema} from '../../zero-cache/src/types/shards.ts';
 import {
   mapAST,
   type AST,
@@ -31,19 +37,17 @@ import {
   newQuery,
   type QueryDelegate,
 } from '../../zql/src/query/query-impl.ts';
-import type {PullRow, Query} from '../../zql/src/query/query.ts';
+import {
+  DEFAULT_RUN_OPTIONS_COMPLETE,
+  type PullRow,
+  type Query,
+} from '../../zql/src/query/query.ts';
 import {Database} from '../../zqlite/src/db.ts';
 import {
   runtimeDebugFlags,
   runtimeDebugStats,
 } from '../../zqlite/src/runtime-debug.ts';
 import {TableSource} from '../../zqlite/src/table-source.ts';
-import {transformAndHashQuery} from '../../zero-cache/src/auth/read-authorizer.ts';
-import {astToZQL} from '../../ast-to-zql/src/ast-to-zql.ts';
-import {pgClient} from '../../zero-cache/src/types/pg.ts';
-import {getShardID, upstreamSchema} from '../../zero-cache/src/types/shards.ts';
-import {must} from '../../shared/src/must.ts';
-import {formatOutput} from '../../ast-to-zql/src/format.ts';
 
 const options = {
   replicaFile: zeroOptions.replica.file,
@@ -163,6 +167,9 @@ const host: QueryDelegate = {
   },
   batchViewUpdates<T>(applyViewUpdates: () => T): T {
     return applyViewUpdates();
+  },
+  normalizeRunOptions(options) {
+    return options ?? DEFAULT_RUN_OPTIONS_COMPLETE;
   },
 };
 

--- a/packages/zero-cache/bench/benchmark.ts
+++ b/packages/zero-cache/bench/benchmark.ts
@@ -8,6 +8,7 @@ import {MemoryStorage} from '../../zql/src/ivm/memory-storage.ts';
 import type {Input} from '../../zql/src/ivm/operator.ts';
 import type {Source} from '../../zql/src/ivm/source.ts';
 import {newQuery, type QueryDelegate} from '../../zql/src/query/query-impl.ts';
+import {DEFAULT_RUN_OPTIONS_COMPLETE} from '../../zql/src/query/query.ts';
 import {Database} from '../../zqlite/src/db.ts';
 import {TableSource} from '../../zqlite/src/table-source.ts';
 import {computeZqlSpecs} from '../src/db/lite-tables.ts';
@@ -74,6 +75,9 @@ export function bench(opts: Options) {
     },
     batchViewUpdates<T>(applyViewUpdates: () => T): T {
       return applyViewUpdates();
+    },
+    normalizeRunOptions(options) {
+      return options ?? DEFAULT_RUN_OPTIONS_COMPLETE;
     },
   };
 

--- a/packages/zero-cache/bench/benchmark.ts
+++ b/packages/zero-cache/bench/benchmark.ts
@@ -79,6 +79,7 @@ export function bench(opts: Options) {
     normalizeRunOptions(options) {
       return options ?? DEFAULT_RUN_OPTIONS_COMPLETE;
     },
+    defaultQueryComplete: true,
   };
 
   const issueQuery = newQuery(host, schema, 'issue');

--- a/packages/zero-cache/src/auth/read-authorizer.query.test.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.query.test.ts
@@ -43,7 +43,11 @@ import {
   newQuery,
   type QueryDelegate,
 } from '../../../zql/src/query/query-impl.ts';
-import type {Query, Row} from '../../../zql/src/query/query.ts';
+import {
+  DEFAULT_RUN_OPTIONS_COMPLETE,
+  type Query,
+  type Row,
+} from '../../../zql/src/query/query.ts';
 import {Database} from '../../../zqlite/src/db.ts';
 import {TableSource} from '../../../zqlite/src/table-source.ts';
 import type {ZeroConfig} from '../config/zero-config.ts';
@@ -536,6 +540,9 @@ beforeEach(() => {
     },
     batchViewUpdates<T>(applyViewUpdates: () => T): T {
       return applyViewUpdates();
+    },
+    normalizeRunOptions(options) {
+      return options ?? DEFAULT_RUN_OPTIONS_COMPLETE;
     },
   };
 

--- a/packages/zero-cache/src/auth/read-authorizer.query.test.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.query.test.ts
@@ -544,6 +544,7 @@ beforeEach(() => {
     normalizeRunOptions(options) {
       return options ?? DEFAULT_RUN_OPTIONS_COMPLETE;
     },
+    defaultQueryComplete: true,
   };
 
   for (const table of Object.values(schema.tables)) {

--- a/packages/zero-client/src/client/context.test.ts
+++ b/packages/zero-client/src/client/context.test.ts
@@ -9,12 +9,20 @@ import {Catch} from '../../../zql/src/ivm/catch.ts';
 import {Join} from '../../../zql/src/ivm/join.ts';
 import {MemorySource} from '../../../zql/src/ivm/memory-source.ts';
 import {MemoryStorage} from '../../../zql/src/ivm/memory-storage.ts';
+import {
+  DEFAULT_RUN_OPTIONS_COMPLETE,
+  type RunOptions,
+} from '../../../zql/src/query/query.ts';
 import {ZeroContext, type AddQuery, type UpdateQuery} from './context.ts';
 import {IVMSourceBranch} from './ivm-branch.ts';
 import {ENTITIES_KEY_PREFIX} from './keys.ts';
 
 const testBatchViewUpdates = (applyViewUpdates: () => void) =>
   applyViewUpdates();
+
+function normalizeRunOptions(options: RunOptions | undefined): RunOptions {
+  return options ?? DEFAULT_RUN_OPTIONS_COMPLETE;
+}
 
 test('getSource', () => {
   const schema = createSchema({
@@ -41,6 +49,7 @@ test('getSource', () => {
     null as unknown as UpdateQuery,
     testBatchViewUpdates,
     5_000,
+    normalizeRunOptions,
   );
 
   const source = context.getSource('users');
@@ -114,6 +123,7 @@ test('processChanges', () => {
     null as unknown as UpdateQuery,
     testBatchViewUpdates,
     5_000,
+    normalizeRunOptions,
   );
   const out = new Catch(
     context.getSource('t1')!.connect([
@@ -180,6 +190,7 @@ test('processChanges wraps source updates with batchViewUpdates', () => {
     null as unknown as UpdateQuery,
     batchViewUpdates,
     5_000,
+    normalizeRunOptions,
   );
   const out = new Catch(
     context.getSource('t1')!.connect([
@@ -235,6 +246,7 @@ test('transactions', () => {
     null as unknown as UpdateQuery,
     testBatchViewUpdates,
     5_000,
+    normalizeRunOptions,
   );
   const servers = context.getSource('server')!;
   const flair = context.getSource('flair')!;
@@ -311,6 +323,7 @@ test('batchViewUpdates errors if applyViewUpdates is not called', () => {
     null as unknown as UpdateQuery,
     batchViewUpdates,
     5_000,
+    normalizeRunOptions,
   );
 
   expect(batchViewUpdatesCalls).toEqual(0);
@@ -331,6 +344,7 @@ test('batchViewUpdates returns value', () => {
     null as unknown as UpdateQuery,
     batchViewUpdates,
     5_000,
+    normalizeRunOptions,
   );
 
   expect(batchViewUpdatesCalls).toEqual(0);

--- a/packages/zero-client/src/client/context.ts
+++ b/packages/zero-client/src/client/context.ts
@@ -10,8 +10,8 @@ import type {
   CommitListener,
   GotCallback,
   QueryDelegate,
-  RunOptions,
 } from '../../../zql/src/query/query-impl.ts';
+import type {RunOptions} from '../../../zql/src/query/query.ts';
 import type {TTL} from '../../../zql/src/query/ttl.ts';
 import {type IVMSourceBranch} from './ivm-branch.ts';
 import type {QueryManager} from './query-manager.ts';

--- a/packages/zero-client/src/client/context.ts
+++ b/packages/zero-client/src/client/context.ts
@@ -41,6 +41,12 @@ export class ZeroContext implements QueryDelegate {
   readonly staticQueryParameters = undefined;
   readonly normalizeRunOptions: (options?: RunOptions) => RunOptions;
 
+  /**
+   * Client-side queries start out as "unknown" and are then updated to
+   * "complete" once the server has sent back the query result.
+   */
+  readonly defaultQueryComplete = false;
+
   constructor(
     lc: LogContext,
     mainSources: IVMSourceBranch,

--- a/packages/zero-client/src/client/context.ts
+++ b/packages/zero-client/src/client/context.ts
@@ -10,6 +10,7 @@ import type {
   CommitListener,
   GotCallback,
   QueryDelegate,
+  RunOptions,
 } from '../../../zql/src/query/query-impl.ts';
 import type {TTL} from '../../../zql/src/query/ttl.ts';
 import {type IVMSourceBranch} from './ivm-branch.ts';
@@ -38,6 +39,7 @@ export class ZeroContext implements QueryDelegate {
   readonly slowMaterializeThreshold: number;
   readonly lc: LogContext;
   readonly staticQueryParameters = undefined;
+  readonly normalizeRunOptions: (options?: RunOptions) => RunOptions;
 
   constructor(
     lc: LogContext,
@@ -46,6 +48,7 @@ export class ZeroContext implements QueryDelegate {
     updateQuery: UpdateQuery,
     batchViewUpdates: (applyViewUpdates: () => void) => void,
     slowMaterializeThreshold: number,
+    normalizeRunOptions: (options?: RunOptions) => RunOptions,
   ) {
     this.#mainSources = mainSources;
     this.#addQuery = addQuery;
@@ -53,6 +56,7 @@ export class ZeroContext implements QueryDelegate {
     this.#batchViewUpdates = batchViewUpdates;
     this.lc = lc;
     this.slowMaterializeThreshold = slowMaterializeThreshold;
+    this.normalizeRunOptions = normalizeRunOptions;
   }
 
   getSource(name: string): Source | undefined {

--- a/packages/zero-client/src/client/zero.json.test.ts
+++ b/packages/zero-client/src/client/zero.json.test.ts
@@ -34,7 +34,7 @@ test('we can create rows with json columns and query those rows', async () => {
     artists: ['artist 2', 'artist 3'],
   });
 
-  const tracks = await z.query.track.run();
+  const tracks = await z.query.track.run({type: 'unknown'});
 
   expect(tracks).toEqual([
     {

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -79,7 +79,11 @@ import {
 } from '../../../zero-schema/src/name-mapper.ts';
 import {customMutatorKey} from '../../../zql/src/mutate/custom.ts';
 import {newQuery} from '../../../zql/src/query/query-impl.ts';
-import type {Query} from '../../../zql/src/query/query.ts';
+import {
+  DEFAULT_RUN_OPTIONS_COMPLETE,
+  type Query,
+  type RunOptions,
+} from '../../../zql/src/query/query.ts';
 import {nanoid} from '../util/nanoid.ts';
 import {send} from '../util/socket.ts';
 import * as ConnectionState from './connection-state-enum.ts';
@@ -538,6 +542,7 @@ export class Zero<
       (ast, ttl) => this.#queryManager.update(ast, ttl),
       batchViewUpdates,
       slowMaterializeThreshold,
+      normalizeRunOptions,
     );
 
     const replicacheImplOptions: ReplicacheImplOptions = {
@@ -1998,3 +2003,7 @@ class TimedOutError extends Error {
 }
 
 class CloseError extends Error {}
+
+function normalizeRunOptions(options?: RunOptions | undefined): RunOptions {
+  return options ?? DEFAULT_RUN_OPTIONS_COMPLETE;
+}

--- a/packages/zero-client/src/mod.ts
+++ b/packages/zero-client/src/mod.ts
@@ -107,7 +107,12 @@ export type {
   ExpressionBuilder,
   ExpressionFactory,
 } from '../../zql/src/query/expression.ts';
-export type {HumanReadable, Query, Row} from '../../zql/src/query/query.ts';
+export type {
+  HumanReadable,
+  Query,
+  Row,
+  RunOptions,
+} from '../../zql/src/query/query.ts';
 export {DEFAULT_TTL, type TTL} from '../../zql/src/query/ttl.ts';
 export type {ResultType, TypedView} from '../../zql/src/query/typed-view.ts';
 export type {BatchMutator, DBMutator, TableMutator} from './client/crud.ts';

--- a/packages/zero-solid/src/create-query.test.ts
+++ b/packages/zero-solid/src/create-query.test.ts
@@ -36,7 +36,7 @@ function setupTestEnvironment() {
   ms.push({row: {a: 1, b: 'a'}, type: 'add'});
   ms.push({row: {a: 2, b: 'b'}, type: 'add'});
 
-  const queryDelegate = new QueryDelegateImpl({table: ms});
+  const queryDelegate = new QueryDelegateImpl({sources: {table: ms}});
   const tableQuery = newQuery(queryDelegate, schema, 'table');
 
   return {ms, tableQuery, queryDelegate};

--- a/packages/zql/src/ivm/array-view.ts
+++ b/packages/zql/src/ivm/array-view.ts
@@ -37,8 +37,8 @@ export class ArrayView<V extends View> implements Output, TypedView<V> {
 
   constructor(
     input: Input,
-    format: Format, // = {singular: false, relationships: {}},
-    queryComplete: true | Promise<true>, // = true,
+    format: Format,
+    queryComplete: true | Promise<true>,
     updateTTL: (ttl: TTL) => void,
   ) {
     this.#input = input;

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -37,6 +37,7 @@ import {
   type PreloadOptions,
   type PullRow,
   type Query,
+  type RunOptions,
 } from './query.ts';
 import {DEFAULT_TTL, type TTL} from './ttl.ts';
 import type {TypedView} from './typed-view.ts';
@@ -60,22 +61,23 @@ export function newQuery<
   return new QueryImpl(delegate, schema, table, {table}, defaultFormat);
 }
 
-function newQueryWithDetails<
-  TSchema extends Schema,
-  TTable extends keyof TSchema['tables'] & string,
-  TReturn,
->(
-  delegate: QueryDelegate,
-  schema: TSchema,
-  tableName: TTable,
-  ast: AST,
-  format: Format,
-): QueryImpl<TSchema, TTable, TReturn> {
-  return new QueryImpl(delegate, schema, tableName, ast, format);
+export type CommitListener = () => void;
+
+export type GotCallback = (got: boolean) => void;
+
+export interface NewQueryDelegate {
+  newQuery<
+    TSchema extends Schema,
+    TTable extends keyof TSchema['tables'] & string,
+    TReturn,
+  >(
+    schema: TSchema,
+    table: TTable,
+    ast: AST,
+    format: Format,
+  ): Query<TSchema, TTable, TReturn>;
 }
 
-export type CommitListener = () => void;
-export type GotCallback = (got: boolean) => void;
 export interface QueryDelegate extends BuilderDelegate {
   addServerQuery(
     ast: AST,
@@ -86,6 +88,14 @@ export interface QueryDelegate extends BuilderDelegate {
   onTransactionCommit(cb: CommitListener): () => void;
   batchViewUpdates<T>(applyViewUpdates: () => T): T;
   onQueryMaterialized(hash: string, ast: AST, duration: number): void;
+
+  /**
+   * `run` defaults to wait for `complete` (aka got) results. But in custom mutators
+   * we default to `unknown` to avoid waiting for the server.
+   *
+   * Inside a custom mutator it is an error to call run with `{resultType: 'complete'}`.
+   */
+  normalizeRunOptions(options?: RunOptions): RunOptions;
 }
 
 export function staticParam(
@@ -136,6 +146,7 @@ export abstract class AbstractQuery<
 
   protected abstract _system: System;
 
+  // TODO(arv): Put this in the delegate?
   protected abstract _newQuery<
     TSchema extends Schema,
     TTable extends keyof TSchema['tables'] & string,
@@ -161,6 +172,7 @@ export abstract class AbstractQuery<
       },
     );
   }
+
   whereExists(
     relationship: string,
     cb?: (q: AnyQuery) => AnyQuery,
@@ -552,7 +564,7 @@ export abstract class AbstractQuery<
   abstract materialize(): TypedView<HumanReadable<TReturn>>;
   abstract materialize<T>(factory: ViewFactory<TSchema, TTable, TReturn, T>): T;
 
-  abstract run(): Promise<HumanReadable<TReturn>>;
+  abstract run(options?: RunOptions): Promise<HumanReadable<TReturn>>;
 
   abstract preload(): {
     cleanup: () => void;
@@ -596,7 +608,7 @@ export class QueryImpl<
     ast: AST,
     format: Format,
   ): QueryImpl<TSchema, TTable, TReturn> {
-    return newQueryWithDetails(this.#delegate, schema, tableName, ast, format);
+    return new QueryImpl(this.#delegate, schema, tableName, ast, format);
   }
 
   materialize<T>(
@@ -652,11 +664,24 @@ export class QueryImpl<
     return view as T;
   }
 
-  run(): Promise<HumanReadable<TReturn>> {
+  run(options?: RunOptions): Promise<HumanReadable<TReturn>> {
+    const opt = this.#delegate.normalizeRunOptions(options);
     const v: TypedView<HumanReadable<TReturn>> = this.materialize();
-    const ret = v.data;
-    v.destroy();
-    return Promise.resolve(ret);
+    if (opt.type === 'unknown') {
+      const ret = v.data;
+      v.destroy();
+      return Promise.resolve(ret);
+    }
+
+    opt.type satisfies 'complete';
+    return new Promise(resolve => {
+      v.addListener((data, type) => {
+        if (type === 'complete') {
+          v.destroy();
+          resolve(data as HumanReadable<TReturn>);
+        }
+      });
+    });
   }
 
   preload(options?: PreloadOptions): {

--- a/packages/zql/src/query/query.ts
+++ b/packages/zql/src/query/query.ts
@@ -372,9 +372,26 @@ export interface Query<
   ): T;
 
   /**
-   * Executes the query and returns the results. This is a 1-shot query that
-   * returns the results immediately. It is equivalent to calling `then` on the
-   * query.
+   * Executes the query and returns the result once. The `options` parameter
+   * specifies whether to wait for complete results or return immediately.
+   *
+   * - `{type: 'complete'}`: Waits for the latest, complete results from the server.
+   * - `{type: 'unknown'}`: Returns a snapshot of the data immediately.
+   *
+   * By default, `run` waits for complete results. Inside a custom mutator, the
+   * default behavior is `{type: 'unknown'}`, and calling `run` with `{type: 'complete'}`
+   * is not allowed.
+   *
+   * `Query` implements `PromiseLike`, and calling `then` on it will invoke `run`
+   * with the default behavior (waiting for complete results).
+   *
+   * @param options Options to control the result type. Defaults to `{type: 'complete'}`.
+   * @returns A promise resolving to the query result.
+   *
+   * @example
+   * ```js
+   * const result = await query.run({type: 'unknown'});
+   * ```
    */
   run(options?: RunOptions): Promise<HumanReadable<TReturn>>;
 

--- a/packages/zql/src/query/query.ts
+++ b/packages/zql/src/query/query.ts
@@ -376,7 +376,7 @@ export interface Query<
    * returns the results immediately. It is equivalent to calling `then` on the
    * query.
    */
-  run(): Promise<HumanReadable<TReturn>>;
+  run(options?: RunOptions): Promise<HumanReadable<TReturn>>;
 
   /**
    * Preload loads the data into the clients cache without keeping it in memory.
@@ -413,3 +413,27 @@ export type HumanReadable<T> = undefined extends T ? Expand<T> : Expand<T>[];
 export type HumanReadableRecursive<T> = undefined extends T
   ? ExpandRecursive<T>
   : ExpandRecursive<T>[];
+
+/**
+ * The kind of results we want to wait for when using {@linkcode run} on {@linkcode Query}.
+ *
+ * `unknown` means we don't want to wait for the server to return results. The result is a
+ * snapshot of the data at the time the query was run.
+ *
+ * `complete` means we want to ensure that we have the latest result from the server. The
+ * result is a complete and up-to-date view of the data. In some cases this means that we
+ * have to wait for the server to return results. To ensure that we have the result for
+ * this query you can preload it before calling run. See {@link preload}.
+ *
+ */
+export type RunOptions = {
+  type: 'unknown' | 'complete';
+};
+
+export const DEFAULT_RUN_OPTIONS_UNKNOWN = {
+  type: 'unknown',
+} as const;
+
+export const DEFAULT_RUN_OPTIONS_COMPLETE = {
+  type: 'complete',
+} as const;

--- a/packages/zql/src/query/test/query-delegate.ts
+++ b/packages/zql/src/query/test/query-delegate.ts
@@ -33,6 +33,7 @@ export class QueryDelegateImpl implements QueryDelegate {
   readonly gotCallbacks: (GotCallback | undefined)[] = [];
   synchronouslyCallNextGotCallback = false;
   callGot = false;
+  readonly defaultQueryComplete = false;
 
   constructor({
     sources = makeSources(),

--- a/packages/zql/src/query/test/query-delegate.ts
+++ b/packages/zql/src/query/test/query-delegate.ts
@@ -7,11 +7,12 @@ import {MemoryStorage} from '../../ivm/memory-storage.ts';
 import type {Input} from '../../ivm/operator.ts';
 import type {Source} from '../../ivm/source.ts';
 import {createSource} from '../../ivm/test/source-factory.ts';
-import type {
-  CommitListener,
-  GotCallback,
-  QueryDelegate,
+import {
+  type CommitListener,
+  type GotCallback,
+  type QueryDelegate,
 } from '../query-impl.ts';
+import {DEFAULT_RUN_OPTIONS_COMPLETE, type RunOptions} from '../query.ts';
 import type {TTL} from '../ttl.ts';
 import {
   commentSchema,
@@ -31,9 +32,21 @@ export class QueryDelegateImpl implements QueryDelegate {
   readonly addedServerQueries: {ast: AST; ttl: TTL}[] = [];
   readonly gotCallbacks: (GotCallback | undefined)[] = [];
   synchronouslyCallNextGotCallback = false;
+  callGot = false;
 
-  constructor(sources?: Record<string, Source>) {
-    this.#sources = sources ?? makeSources();
+  constructor({
+    sources = makeSources(),
+    callGot = false,
+  }: {
+    sources?: Record<string, Source> | undefined;
+    callGot?: boolean | undefined;
+  } = {}) {
+    this.#sources = sources;
+    this.callGot = callGot;
+  }
+
+  normalizeRunOptions(options?: RunOptions): RunOptions {
+    return options ?? DEFAULT_RUN_OPTIONS_COMPLETE;
   }
 
   batchViewUpdates<T>(applyViewUpdates: () => T): T {
@@ -66,9 +79,15 @@ export class QueryDelegateImpl implements QueryDelegate {
   ): () => void {
     this.addedServerQueries.push({ast, ttl});
     this.gotCallbacks.push(gotCallback);
-    if (this.synchronouslyCallNextGotCallback) {
-      this.synchronouslyCallNextGotCallback = false;
-      gotCallback?.(true);
+    if (this.callGot) {
+      void Promise.resolve().then(() => {
+        gotCallback?.(true);
+      });
+    } else {
+      if (this.synchronouslyCallNextGotCallback) {
+        this.synchronouslyCallNextGotCallback = false;
+        gotCallback?.(true);
+      }
     }
     return () => {};
   }
@@ -91,6 +110,13 @@ export class QueryDelegateImpl implements QueryDelegate {
 
   decorateInput(input: Input, _description: string): Input {
     return input;
+  }
+
+  callAllGotCallbacks() {
+    for (const gotCallback of this.gotCallbacks) {
+      gotCallback?.(true);
+    }
+    this.gotCallbacks.length = 0;
   }
 }
 

--- a/packages/zqlite/src/test/source-factory.ts
+++ b/packages/zqlite/src/test/source-factory.ts
@@ -1,26 +1,27 @@
 import type {LogContext} from '@rocicorp/logger';
 import type {LogConfig} from '../../../otel/src/log-options.ts';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import {
+  mapAST,
+  type AST,
+  type CompoundKey,
+} from '../../../zero-protocol/src/ast.ts';
 import type {PrimaryKey} from '../../../zero-protocol/src/primary-key.ts';
 import type {Schema} from '../../../zero-schema/src/builder/schema-builder.ts';
+import {
+  clientToServer,
+  serverToClient,
+} from '../../../zero-schema/src/name-mapper.ts';
 import type {SchemaValue} from '../../../zero-schema/src/table-schema.ts';
 import {MemoryStorage} from '../../../zql/src/ivm/memory-storage.ts';
 import type {Input} from '../../../zql/src/ivm/operator.ts';
 import type {Source} from '../../../zql/src/ivm/source.ts';
 import type {SourceFactory} from '../../../zql/src/ivm/test/source-factory.ts';
 import type {QueryDelegate} from '../../../zql/src/query/query-impl.ts';
+import {DEFAULT_RUN_OPTIONS_COMPLETE} from '../../../zql/src/query/query.ts';
 import {Database} from '../db.ts';
 import {compile, sql} from '../internal/sql.ts';
 import {TableSource, toSQLiteTypeName} from '../table-source.ts';
-import {
-  clientToServer,
-  serverToClient,
-} from '../../../zero-schema/src/name-mapper.ts';
-import {
-  mapAST,
-  type AST,
-  type CompoundKey,
-} from '../../../zero-protocol/src/ast.ts';
 
 export const createSource: SourceFactory = (
   lc: LogContext,
@@ -177,6 +178,9 @@ export function newQueryDelegate(
     },
     batchViewUpdates<T>(applyViewUpdates: () => T): T {
       return applyViewUpdates();
+    },
+    normalizeRunOptions(options) {
+      return options ?? DEFAULT_RUN_OPTIONS_COMPLETE;
     },
   };
 }

--- a/packages/zqlite/src/test/source-factory.ts
+++ b/packages/zqlite/src/test/source-factory.ts
@@ -182,5 +182,6 @@ export function newQueryDelegate(
     normalizeRunOptions(options) {
       return options ?? DEFAULT_RUN_OPTIONS_COMPLETE;
     },
+    defaultQueryComplete: true,
   };
 }


### PR DESCRIPTION
BREAKING CHANGE!

```ts
type RunOptions = {
  type: 'complete' | 'unknown';
}

interface Query<...> {
  ...
  run(options?: RunOptions): Promise<...>;
}
```

Defaults to `complete` for all queries except for the query used inside
custom mutations which defaults to `unknown`.

This is breaking because the `run` method of the `Query` class now waits
for `complete` results by default. This can lead to the promise returned
never resolving if the `server` is not set (or we are offline).

Another gotcha is that if you call run with `unknown` you get both
unknown and complete results but there is no way to tell which is
which.