### PR TITLE
feat(zero-cache): re-auth on 401s returned by the user's push endpoint

### DIFF
--- a/apps/zbugs/api/index.ts
+++ b/apps/zbugs/api/index.ts
@@ -122,12 +122,21 @@ fastify.post<{
   }
 
   const jwk = process.env.VITE_PUBLIC_JWK;
-  const authData: AuthData | undefined =
-    jwk && authorization
-      ? authDataSchema.parse(
-          (await jwtVerify(authorization, JSON.parse(jwk))).payload,
-        )
-      : undefined;
+  let authData: AuthData | undefined;
+  try {
+    authData =
+      jwk && authorization
+        ? authDataSchema.parse(
+            (await jwtVerify(authorization, JSON.parse(jwk))).payload,
+          )
+        : undefined;
+  } catch (e) {
+    if (e instanceof Error) {
+      reply.status(401).send(e.message);
+      return;
+    }
+    throw e;
+  }
 
   const response = await handlePush(authData, request.query, request.body);
   reply.send(response);


### PR DESCRIPTION
If the user's API server returns a 401 we will close the websocket connection with an `AuthInvalidated` error.

This forces the `auth` callback to be called on the client and the ws to be reconnected.

We currently do not have a way to update the JWT without tearing down and restarting the WS connection. That seems like a good future improvement, however. If we do that, we could also skip re-hydration of queries that do not use the modified fields of the JWT.