### PR TITLE
chore(zero-client)!: Change run default to unknown

### DIFF
--- a/packages/analyze-query/src/bin-analyze.ts
+++ b/packages/analyze-query/src/bin-analyze.ts
@@ -37,11 +37,7 @@ import {
   newQuery,
   type QueryDelegate,
 } from '../../zql/src/query/query-impl.ts';
-import {
-  DEFAULT_RUN_OPTIONS_COMPLETE,
-  type PullRow,
-  type Query,
-} from '../../zql/src/query/query.ts';
+import {type PullRow, type Query} from '../../zql/src/query/query.ts';
 import {Database} from '../../zqlite/src/db.ts';
 import {
   runtimeDebugFlags,
@@ -168,9 +164,7 @@ const host: QueryDelegate = {
   batchViewUpdates<T>(applyViewUpdates: () => T): T {
     return applyViewUpdates();
   },
-  normalizeRunOptions(options) {
-    return options ?? DEFAULT_RUN_OPTIONS_COMPLETE;
-  },
+  assertValidRunOptions() {},
   defaultQueryComplete: true,
 };
 

--- a/packages/zero-cache/bench/benchmark.ts
+++ b/packages/zero-cache/bench/benchmark.ts
@@ -8,7 +8,6 @@ import {MemoryStorage} from '../../zql/src/ivm/memory-storage.ts';
 import type {Input} from '../../zql/src/ivm/operator.ts';
 import type {Source} from '../../zql/src/ivm/source.ts';
 import {newQuery, type QueryDelegate} from '../../zql/src/query/query-impl.ts';
-import {DEFAULT_RUN_OPTIONS_COMPLETE} from '../../zql/src/query/query.ts';
 import {Database} from '../../zqlite/src/db.ts';
 import {TableSource} from '../../zqlite/src/table-source.ts';
 import {computeZqlSpecs} from '../src/db/lite-tables.ts';
@@ -76,9 +75,7 @@ export function bench(opts: Options) {
     batchViewUpdates<T>(applyViewUpdates: () => T): T {
       return applyViewUpdates();
     },
-    normalizeRunOptions(options) {
-      return options ?? DEFAULT_RUN_OPTIONS_COMPLETE;
-    },
+    assertValidRunOptions() {},
     defaultQueryComplete: true,
   };
 

--- a/packages/zero-cache/src/auth/read-authorizer.query.test.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.query.test.ts
@@ -43,11 +43,7 @@ import {
   newQuery,
   type QueryDelegate,
 } from '../../../zql/src/query/query-impl.ts';
-import {
-  DEFAULT_RUN_OPTIONS_COMPLETE,
-  type Query,
-  type Row,
-} from '../../../zql/src/query/query.ts';
+import {type Query, type Row} from '../../../zql/src/query/query.ts';
 import {Database} from '../../../zqlite/src/db.ts';
 import {TableSource} from '../../../zqlite/src/table-source.ts';
 import type {ZeroConfig} from '../config/zero-config.ts';
@@ -541,9 +537,7 @@ beforeEach(() => {
     batchViewUpdates<T>(applyViewUpdates: () => T): T {
       return applyViewUpdates();
     },
-    normalizeRunOptions(options) {
-      return options ?? DEFAULT_RUN_OPTIONS_COMPLETE;
-    },
+    assertValidRunOptions() {},
     defaultQueryComplete: true,
   };
 

--- a/packages/zero-client/src/client/context.test.ts
+++ b/packages/zero-client/src/client/context.test.ts
@@ -9,10 +9,6 @@ import {Catch} from '../../../zql/src/ivm/catch.ts';
 import {Join} from '../../../zql/src/ivm/join.ts';
 import {MemorySource} from '../../../zql/src/ivm/memory-source.ts';
 import {MemoryStorage} from '../../../zql/src/ivm/memory-storage.ts';
-import {
-  DEFAULT_RUN_OPTIONS_COMPLETE,
-  type RunOptions,
-} from '../../../zql/src/query/query.ts';
 import {ZeroContext, type AddQuery, type UpdateQuery} from './context.ts';
 import {IVMSourceBranch} from './ivm-branch.ts';
 import {ENTITIES_KEY_PREFIX} from './keys.ts';
@@ -20,9 +16,7 @@ import {ENTITIES_KEY_PREFIX} from './keys.ts';
 const testBatchViewUpdates = (applyViewUpdates: () => void) =>
   applyViewUpdates();
 
-function normalizeRunOptions(options: RunOptions | undefined): RunOptions {
-  return options ?? DEFAULT_RUN_OPTIONS_COMPLETE;
-}
+function assertValidRunOptions(): void {}
 
 test('getSource', () => {
   const schema = createSchema({
@@ -49,7 +43,7 @@ test('getSource', () => {
     null as unknown as UpdateQuery,
     testBatchViewUpdates,
     5_000,
-    normalizeRunOptions,
+    assertValidRunOptions,
   );
 
   const source = context.getSource('users');
@@ -123,7 +117,7 @@ test('processChanges', () => {
     null as unknown as UpdateQuery,
     testBatchViewUpdates,
     5_000,
-    normalizeRunOptions,
+    assertValidRunOptions,
   );
   const out = new Catch(
     context.getSource('t1')!.connect([
@@ -190,7 +184,7 @@ test('processChanges wraps source updates with batchViewUpdates', () => {
     null as unknown as UpdateQuery,
     batchViewUpdates,
     5_000,
-    normalizeRunOptions,
+    assertValidRunOptions,
   );
   const out = new Catch(
     context.getSource('t1')!.connect([
@@ -246,7 +240,7 @@ test('transactions', () => {
     null as unknown as UpdateQuery,
     testBatchViewUpdates,
     5_000,
-    normalizeRunOptions,
+    assertValidRunOptions,
   );
   const servers = context.getSource('server')!;
   const flair = context.getSource('flair')!;
@@ -323,7 +317,7 @@ test('batchViewUpdates errors if applyViewUpdates is not called', () => {
     null as unknown as UpdateQuery,
     batchViewUpdates,
     5_000,
-    normalizeRunOptions,
+    assertValidRunOptions,
   );
 
   expect(batchViewUpdatesCalls).toEqual(0);
@@ -344,7 +338,7 @@ test('batchViewUpdates returns value', () => {
     null as unknown as UpdateQuery,
     batchViewUpdates,
     5_000,
-    normalizeRunOptions,
+    assertValidRunOptions,
   );
 
   expect(batchViewUpdatesCalls).toEqual(0);

--- a/packages/zero-client/src/client/context.ts
+++ b/packages/zero-client/src/client/context.ts
@@ -38,7 +38,7 @@ export class ZeroContext implements QueryDelegate {
 
   readonly #slowMaterializeThreshold: number;
   readonly #lc: LogContext;
-  readonly normalizeRunOptions: (options?: RunOptions) => RunOptions;
+  readonly assertValidRunOptions: (options?: RunOptions) => void;
 
   /**
    * Client-side queries start out as "unknown" and are then updated to
@@ -53,7 +53,7 @@ export class ZeroContext implements QueryDelegate {
     updateQuery: UpdateQuery,
     batchViewUpdates: (applyViewUpdates: () => void) => void,
     slowMaterializeThreshold: number,
-    normalizeRunOptions: (options?: RunOptions) => RunOptions,
+    assertValidRunOptions: (options?: RunOptions) => void,
   ) {
     this.#mainSources = mainSources;
     this.#addQuery = addQuery;
@@ -61,7 +61,7 @@ export class ZeroContext implements QueryDelegate {
     this.#batchViewUpdates = batchViewUpdates;
     this.#lc = lc;
     this.#slowMaterializeThreshold = slowMaterializeThreshold;
-    this.normalizeRunOptions = normalizeRunOptions;
+    this.assertValidRunOptions = assertValidRunOptions;
   }
 
   getSource(name: string): Source | undefined {

--- a/packages/zero-client/src/client/custom.test.ts
+++ b/packages/zero-client/src/client/custom.test.ts
@@ -107,7 +107,7 @@ test('supports mutators without a namespace', async () => {
     createdAt: 1743018138477,
   });
 
-  const issues = await z.query.issue.run({type: 'unknown'});
+  const issues = await z.query.issue;
   expect(issues[0].title).toEqual('no-namespace');
 });
 
@@ -370,7 +370,7 @@ describe('rebasing custom mutators', () => {
           create: async (tx, args: InsertValue<typeof schema.tables.issue>) => {
             await tx.mutate.issue.insert(args);
             // query main. The issue should not be there yet.
-            expect(await z.query.issue.run({type: 'unknown'})).length(0);
+            expect(await z.query.issue).length(0);
             // but it is in this tx
             expect(await tx.query.issue).length(1);
 

--- a/packages/zero-client/src/client/custom.ts
+++ b/packages/zero-client/src/client/custom.ts
@@ -22,11 +22,7 @@ import type {
   UpsertValue,
 } from '../../../zql/src/mutate/custom.ts';
 import {newQuery} from '../../../zql/src/query/query-impl.ts';
-import {
-  DEFAULT_RUN_OPTIONS_UNKNOWN,
-  type Query,
-  type RunOptions,
-} from '../../../zql/src/query/query.ts';
+import {type Query, type RunOptions} from '../../../zql/src/query/query.ts';
 import type {ClientID} from '../types/client-state.ts';
 import {ZeroContext} from './context.ts';
 import {deleteImpl, insertImpl, updateImpl, upsertImpl} from './crud.ts';
@@ -164,16 +160,12 @@ function makeSchemaCRUD<S extends Schema>(
   ) as SchemaCRUD<S>;
 }
 
-function normalizeRunOptions(options: RunOptions | undefined): RunOptions {
-  if (options === undefined) {
-    return DEFAULT_RUN_OPTIONS_UNKNOWN;
-  }
+function assertValidRunOptions(options: RunOptions | undefined): void {
   // TODO(arv): We should enforce this with the type system too.
   assert(
-    options.type !== 'complete',
+    options?.type !== 'complete',
     'Cannot wait for complete results in custom mutations',
   );
-  return options;
 }
 
 function makeSchemaQuery<S extends Schema>(
@@ -189,7 +181,7 @@ function makeSchemaQuery<S extends Schema>(
     () => {},
     applyViewUpdates => applyViewUpdates(),
     slowMaterializeThreshold,
-    normalizeRunOptions,
+    assertValidRunOptions,
   );
 
   return new Proxy(

--- a/packages/zero-client/src/client/zero.json.test.ts
+++ b/packages/zero-client/src/client/zero.json.test.ts
@@ -34,7 +34,7 @@ test('we can create rows with json columns and query those rows', async () => {
     artists: ['artist 2', 'artist 3'],
   });
 
-  const tracks = await z.query.track.run({type: 'unknown'});
+  const tracks = await z.query.track;
 
   expect(tracks).toEqual([
     {

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -79,11 +79,7 @@ import {
 } from '../../../zero-schema/src/name-mapper.ts';
 import {customMutatorKey} from '../../../zql/src/mutate/custom.ts';
 import {newQuery} from '../../../zql/src/query/query-impl.ts';
-import {
-  DEFAULT_RUN_OPTIONS_UNKNOWN,
-  type Query,
-  type RunOptions,
-} from '../../../zql/src/query/query.ts';
+import {type Query, type RunOptions} from '../../../zql/src/query/query.ts';
 import {nanoid} from '../util/nanoid.ts';
 import {send} from '../util/socket.ts';
 import * as ConnectionState from './connection-state-enum.ts';
@@ -542,7 +538,7 @@ export class Zero<
       (ast, ttl) => this.#queryManager.update(ast, ttl),
       batchViewUpdates,
       slowMaterializeThreshold,
-      normalizeRunOptions,
+      assertValidRunOptions,
     );
 
     const replicacheImplOptions: ReplicacheImplOptions = {
@@ -2004,6 +2000,4 @@ class TimedOutError extends Error {
 
 class CloseError extends Error {}
 
-function normalizeRunOptions(options?: RunOptions | undefined): RunOptions {
-  return options ?? DEFAULT_RUN_OPTIONS_UNKNOWN;
-}
+function assertValidRunOptions(_options?: RunOptions | undefined): void {}

--- a/packages/zql/src/query/query.ts
+++ b/packages/zql/src/query/query.ts
@@ -375,22 +375,20 @@ export interface Query<
    * Executes the query and returns the result once. The `options` parameter
    * specifies whether to wait for complete results or return immediately.
    *
-   * - `{type: 'complete'}`: Waits for the latest, complete results from the server.
    * - `{type: 'unknown'}`: Returns a snapshot of the data immediately.
+   * - `{type: 'complete'}`: Waits for the latest, complete results from the server.
    *
-   * By default, `run` waits for complete results. Inside a custom mutator, the
-   * default behavior is `{type: 'unknown'}`, and calling `run` with `{type: 'complete'}`
-   * is not allowed.
+   * By default, `run` uses `{type: 'unknown'}` to avoid waiting for the server.
    *
    * `Query` implements `PromiseLike`, and calling `then` on it will invoke `run`
-   * with the default behavior (waiting for complete results).
+   * with the default behavior (`unknown`).
    *
-   * @param options Options to control the result type. Defaults to `{type: 'complete'}`.
+   * @param options Options to control the result type. Defaults to `{type: 'unknown'}`.
    * @returns A promise resolving to the query result.
    *
    * @example
    * ```js
-   * const result = await query.run({type: 'unknown'});
+   * const result = await query.run({type: 'complete'});
    * ```
    */
   run(options?: RunOptions): Promise<HumanReadable<TReturn>>;
@@ -442,6 +440,7 @@ export type HumanReadableRecursive<T> = undefined extends T
  * have to wait for the server to return results. To ensure that we have the result for
  * this query you can preload it before calling run. See {@link preload}.
  *
+ * By default, `run` uses `{type: 'unknown'}` to avoid waiting for the server.
  */
 export type RunOptions = {
   type: 'unknown' | 'complete';

--- a/packages/zql/src/query/test/query-delegate.ts
+++ b/packages/zql/src/query/test/query-delegate.ts
@@ -12,7 +12,6 @@ import {
   type GotCallback,
   type QueryDelegate,
 } from '../query-impl.ts';
-import {DEFAULT_RUN_OPTIONS_COMPLETE, type RunOptions} from '../query.ts';
 import type {TTL} from '../ttl.ts';
 import {
   commentSchema,
@@ -46,9 +45,7 @@ export class QueryDelegateImpl implements QueryDelegate {
     this.callGot = callGot;
   }
 
-  normalizeRunOptions(options?: RunOptions): RunOptions {
-    return options ?? DEFAULT_RUN_OPTIONS_COMPLETE;
-  }
+  assertValidRunOptions(): void {}
 
   batchViewUpdates<T>(applyViewUpdates: () => T): T {
     return applyViewUpdates();

--- a/packages/zqlite/src/test/source-factory.ts
+++ b/packages/zqlite/src/test/source-factory.ts
@@ -18,7 +18,6 @@ import type {Input} from '../../../zql/src/ivm/operator.ts';
 import type {Source} from '../../../zql/src/ivm/source.ts';
 import type {SourceFactory} from '../../../zql/src/ivm/test/source-factory.ts';
 import type {QueryDelegate} from '../../../zql/src/query/query-impl.ts';
-import {DEFAULT_RUN_OPTIONS_COMPLETE} from '../../../zql/src/query/query.ts';
 import {Database} from '../db.ts';
 import {compile, sql} from '../internal/sql.ts';
 import {TableSource, toSQLiteTypeName} from '../table-source.ts';
@@ -179,9 +178,7 @@ export function newQueryDelegate(
     batchViewUpdates<T>(applyViewUpdates: () => T): T {
       return applyViewUpdates();
     },
-    normalizeRunOptions(options) {
-      return options ?? DEFAULT_RUN_OPTIONS_COMPLETE;
-    },
+    assertValidRunOptions() {},
     defaultQueryComplete: true,
   };
 }


### PR DESCRIPTION
BREAKING CHANGE -- This is a breaking change from a previous change but it restores the old 0.18 behavior of running the default query to unknown.

This simplifies the code since run always defaults to unknown now.

We still throw if you try to pass complete to a run inside a custom mutator.