### PR TITLE
chore(zero-client): inspect should wait for connect

### DIFF
--- a/packages/zero-client/src/client/inspector/inspector.test.ts
+++ b/packages/zero-client/src/client/inspector/inspector.test.ts
@@ -86,6 +86,7 @@ test('client queries', async () => {
     vi.spyOn(Math, 'random').mockReturnValue(0.5);
     (await z.socket).messages.length = 0;
     const p = inspector.client.queries();
+    await Promise.resolve();
     expect((await z.socket).messages.map(s => JSON.parse(s))).toEqual([
       [
         'inspect',
@@ -199,9 +200,9 @@ test('clientGroup queries', async () => {
 
   vi.spyOn(Math, 'random').mockImplementation(() => 0.5);
   const inspector = await z.inspect();
-  const socket = await z.socket;
   const p = inspector.clientGroup.queries();
-  expect(socket.messages).toMatchInlineSnapshot(`
+  await Promise.resolve();
+  expect((await z.socket).messages).toMatchInlineSnapshot(`
     [
       "["inspect",{"op":"queries","id":"000000000000000000000"}]",
     ]

--- a/packages/zero-client/src/client/inspector/inspector.ts
+++ b/packages/zero-client/src/client/inspector/inspector.ts
@@ -40,7 +40,7 @@ import type {
 
 type Rep = ReplicacheImpl<MutatorDefs>;
 
-type GetWebSocket = () => WebSocket | undefined;
+type GetWebSocket = () => Promise<WebSocket>;
 
 export async function newInspector(
   rep: Rep,
@@ -86,11 +86,10 @@ class Inspector implements InspectorInterface {
 }
 
 function rpc<T extends InspectDownBody>(
-  socket: WebSocket | undefined,
+  socket: WebSocket,
   arg: Omit<InspectUpBody, 'id'>,
   downSchema: valita.Type<T>,
 ): Promise<T['value']> {
-  assert(socket, 'WebSocket not available');
   return new Promise((resolve, reject) => {
     const id = nanoid();
     const f = (ev: MessageEvent) => {
@@ -139,7 +138,7 @@ class Client implements ClientInterface {
 
   async queries(): Promise<QueryInterface[]> {
     const rows: InspectQueryRow[] = await rpc(
-      this.#socket(),
+      await this.#socket(),
       {op: 'queries', clientID: this.id} as InspectQueriesUpBody,
       inspectQueriesDownSchema,
     );
@@ -212,7 +211,7 @@ class ClientGroup implements ClientGroupInterface {
 
   async queries(): Promise<QueryInterface[]> {
     const rows: InspectQueryRow[] = await rpc(
-      this.#socket(),
+      await this.#socket(),
       {op: 'queries'},
       inspectQueriesDownSchema,
     );

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -1849,7 +1849,11 @@ export class Zero<
     // eslint-disable-next-line no-unused-labels
     BUNDLE_SIZE: {
       const m = await import('./inspector/inspector.ts');
-      return m.newInspector(this.#rep, this.#schema, () => this.#socket);
+      // Wait for the web socket to be available
+      return m.newInspector(this.#rep, this.#schema, async () => {
+        await this.#connectResolver.promise;
+        return this.#socket!;
+      });
     }
   }
 }


### PR DESCRIPTION
Inspect should be used lazily but if someone creates it eagerly then they can run into issues where zero is not yet connected.