### PR TITLE
chore(zero-cache): create internal tables first

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
@@ -106,6 +106,9 @@ export async function initialSync(
     const {snapshot_name: snapshot, consistent_point: lsn} = slot;
     const initialVersion = toLexiVersion(lsn);
 
+    initReplicationState(tx, publications, initialVersion);
+    initChangeLog(tx);
+
     // Run up to MAX_WORKERS to copy of tables at the replication slot's snapshot.
     const start = Date.now();
     let numTables: number;
@@ -145,8 +148,6 @@ export async function initialSync(
 
     await addReplica(sql, shard, slotName, initialVersion, published);
 
-    initReplicationState(tx, publications, initialVersion);
-    initChangeLog(tx);
     lc.info?.(
       `Synced ${numRows.toLocaleString()} rows of ${numTables} tables in ${publications} up to ${lsn} (${
         Date.now() - start


### PR DESCRIPTION
Purely for debugging convenience, create the internal replica tables before creating the user tables. This results in them getting earlier pages in the `sqlite_schema` table and makes it easier to work with the sqlite internals.

This is also more consistent with how the replica is initialized for custom change sources.