### PR TITLE
chore(zero-cache): more debug logs

### DIFF
--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -112,6 +112,7 @@ export default function runWorker(
       .withContext('component', 'view-syncer')
       .withContext('clientGroupID', id)
       .withContext('instance', randomID());
+    lc.debug?.(`creating view syncer`);
     return new ViewSyncerService(
       logger,
       shard,

--- a/packages/zero-cache/src/services/view-syncer/client-handler.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.ts
@@ -126,6 +126,7 @@ export class ClientHandler {
     schemaVersion: number | null,
     downstream: Subscription<Downstream>,
   ) {
+    lc.debug?.('new client handler');
     this.#clientGroupID = clientGroupID;
     this.clientID = clientID;
     this.wsID = wsID;

--- a/packages/zero-cache/src/workers/connection.ts
+++ b/packages/zero-cache/src/workers/connection.ts
@@ -98,6 +98,7 @@ export class Connection {
       .withContext('clientID', clientID)
       .withContext('clientGroupID', clientGroupID)
       .withContext('wsID', wsID);
+    this.#lc.debug?.('new connection');
     this.#onClose = onClose;
 
     this.#ws.addEventListener('close', this.#handleClose);

--- a/packages/zero-cache/src/workers/syncer.ts
+++ b/packages/zero-cache/src/workers/syncer.ts
@@ -91,9 +91,17 @@ export class Syncer implements SingletonService {
   }
 
   readonly #createConnection = async (ws: WebSocket, params: ConnectParams) => {
+    this.#lc.debug?.(
+      'creating connection',
+      params.clientGroupID,
+      params.clientID,
+    );
     const {clientID, clientGroupID, auth, userID} = params;
     const existing = this.#connections.get(clientID);
     if (existing) {
+      this.#lc.debug?.(
+        `client ${clientID} already connected, closing existing connection`,
+      );
       existing.close(`replaced by ${params.wsID}`);
     }
 
@@ -140,6 +148,11 @@ export class Syncer implements SingletonService {
 
     connection.init();
     if (params.initConnectionMsg) {
+      this.#lc.debug?.(
+        'handling init connection message from sec header',
+        params.clientGroupID,
+        params.clientID,
+      );
       await connection.handleInitConnection(
         JSON.stringify(params.initConnectionMsg),
       );


### PR DESCRIPTION
JB is hitting a case where a refresh of a tab never produces any logs at all. We're bailing out before we get to any logger calls, pokes, hydrations, etc.

Theories:
- an exception is thrown and swallowed
- `if (client?.wsID !== wsID) {` is always true causing us to early return
- we never acquire the cvr lock and thus never run `initConnection`


this adds more debug logs up the call stack to figure out where things break down.