### PR TITLE
chore(zero-cache): debugging around lock acquisition in the view syncer

### DIFF
--- a/packages/zero-cache/src/lock.test.ts
+++ b/packages/zero-cache/src/lock.test.ts
@@ -1,0 +1,277 @@
+import {expect} from 'chai';
+import {RWLock} from './lock.js';
+import {afterEach, beforeEach, test, vi} from 'vitest';
+
+/**
+ * Creates a promise that resolves after [[ms]] milliseconds. Note that if you
+ * pass in `0` no `setTimeout` is used and the promise resolves immediately. In
+ * other words no macro task is used in that case.
+ */
+function sleep(ms: number): Promise<void> {
+  if (ms === 0) {
+    return Promise.resolve();
+  }
+
+  return new Promise(resolve => {
+    setTimeout(() => resolve(), ms);
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+test('Multiple reads', async () => {
+  const lock = new RWLock();
+
+  const log: string[] = [];
+
+  const r1: Promise<number> = (async () => {
+    const release = await lock.read();
+    log.push('r1');
+    release();
+    return 1;
+  })();
+
+  const r2: Promise<number> = (async () => {
+    const release = await lock.read();
+    log.push('r2');
+    release();
+    return 2;
+  })();
+  const r3: Promise<void> = (async () => {
+    const release = await lock.read();
+    log.push('r3');
+    release();
+  })();
+
+  const [v1, v2, v3] = await Promise.all([r1, r2, r3]);
+  expect(v1).to.equal(1);
+  expect(v2).to.equal(2);
+  expect(v3).to.equal(undefined);
+  expect(log).to.deep.equal(['r1', 'r2', 'r3']);
+});
+
+test('Multiple reads with sleep', async () => {
+  const lock = new RWLock();
+
+  const log: string[] = [];
+
+  const r1: Promise<number> = (async () => {
+    const release = await lock.read();
+    await sleep(6);
+    log.push('r1');
+    release();
+    return 1;
+  })();
+  const r2: Promise<number> = (async () => {
+    const release = await lock.read();
+    await sleep(4);
+    log.push('r2');
+    release();
+    return 2;
+  })();
+  const r3: Promise<void> = (async () => {
+    const release = await lock.read();
+    await sleep(2);
+    log.push('r3');
+    release();
+  })();
+
+  await vi.runAllTimersAsync();
+
+  const [v1, v2, v3] = await Promise.all([r1, r2, r3]);
+  expect(v1).to.equal(1);
+  expect(v2).to.equal(2);
+  expect(v3).to.equal(undefined);
+
+  expect(log).to.deep.equal(['r3', 'r2', 'r1']);
+});
+
+test('Multiple write', async () => {
+  const lock = new RWLock();
+
+  const log: string[] = [];
+
+  const w1: Promise<number> = (async () => {
+    const release = await lock.write();
+    log.push('w1a');
+    await sleep(6);
+    log.push('w1b');
+    release();
+    return 1;
+  })();
+  const w2: Promise<number> = (async () => {
+    const release = await lock.write();
+    log.push('w2a');
+    await sleep(4);
+    log.push('w2b');
+    release();
+    return 2;
+  })();
+  const w3: Promise<void> = (async () => {
+    const release = await lock.write();
+    log.push('w3a');
+    await sleep(2);
+    log.push('w3b');
+    release();
+  })();
+
+  await vi.runAllTimersAsync();
+
+  const [v1, v2, v3] = await Promise.all([w1, w2, w3]);
+  expect(v1).to.equal(1);
+  expect(v2).to.equal(2);
+  expect(v3).to.equal(undefined);
+
+  expect(log).to.deep.equal(['w1a', 'w1b', 'w2a', 'w2b', 'w3a', 'w3b']);
+});
+
+test('Write then read', async () => {
+  const lock = new RWLock();
+
+  const log: string[] = [];
+
+  const w1: Promise<number> = (async () => {
+    const release = await lock.write();
+    log.push('w1a');
+    await sleep(6);
+    log.push('w1b');
+    release();
+    return 1;
+  })();
+  const r2: Promise<number> = (async () => {
+    const release = await lock.read();
+    log.push('r2a');
+    await sleep(4);
+    log.push('r2b');
+    release();
+    return 2;
+  })();
+  const r3: Promise<void> = (async () => {
+    const release = await lock.read();
+    log.push('r3a');
+    await sleep(2);
+    log.push('r3b');
+    release();
+  })();
+
+  await vi.runAllTimersAsync();
+
+  const [v1, v2, v3] = await Promise.all([w1, r2, r3]);
+  expect(v1).to.equal(1);
+  expect(v2).to.equal(2);
+  expect(v3).to.equal(undefined);
+
+  expect(log).to.deep.equal(['w1a', 'w1b', 'r2a', 'r3a', 'r3b', 'r2b']);
+});
+
+test('Reads then writes', async () => {
+  const lock = new RWLock();
+
+  const log: string[] = [];
+
+  const r1: Promise<number> = (async () => {
+    const release = await lock.read();
+    log.push('r1a');
+    await sleep(8);
+    log.push('r1b');
+    release();
+    return 1;
+  })();
+  const r2: Promise<number> = (async () => {
+    const release = await lock.read();
+    log.push('r2a');
+    await sleep(6);
+    log.push('r2b');
+    release();
+    return 2;
+  })();
+  const w3: Promise<void> = (async () => {
+    const release = await lock.write();
+    log.push('w3a');
+    await sleep(4);
+    log.push('w3b');
+    release();
+  })();
+  const w4: Promise<number> = (async () => {
+    const release = await lock.write();
+    log.push('w4a');
+    await sleep(2);
+    log.push('w4b');
+    release();
+    return 4;
+  })();
+
+  await vi.runAllTimersAsync();
+
+  const [v1, v2, v3, v4] = await Promise.all([r1, r2, w3, w4]);
+  expect(v1).to.equal(1);
+  expect(v2).to.equal(2);
+  expect(v3).to.equal(undefined);
+  expect(v4).to.equal(4);
+
+  expect(log).to.deep.equal([
+    'r1a',
+    'r2a',
+    'r2b',
+    'r1b',
+    'w3a',
+    'w3b',
+    'w4a',
+    'w4b',
+  ]);
+});
+
+test('Reads then writes (withRead)', async () => {
+  const lock = new RWLock();
+
+  const log: string[] = [];
+
+  const r1: Promise<number> = lock.withRead(async () => {
+    log.push('r1a');
+    await sleep(8);
+    log.push('r1b');
+    return 1;
+  });
+  const r2: Promise<number> = lock.withRead(async () => {
+    log.push('r2a');
+    await sleep(6);
+    log.push('r2b');
+    return 2;
+  });
+  const w3: Promise<void> = lock.withWrite(async () => {
+    log.push('w3a');
+    await sleep(4);
+    log.push('w3b');
+  });
+  const w4: Promise<number> = lock.withWrite(async () => {
+    log.push('w4a');
+    await sleep(2);
+    log.push('w4b');
+    return 4;
+  });
+
+  await vi.runAllTimersAsync();
+
+  const [v1, v2, v3, v4] = await Promise.all([r1, r2, w3, w4]);
+  expect(v1).to.equal(1);
+  expect(v2).to.equal(2);
+  expect(v3).to.equal(undefined);
+  expect(v4).to.equal(4);
+
+  expect(log).to.deep.equal([
+    'r1a',
+    'r2a',
+    'r2b',
+    'r1b',
+    'w3a',
+    'w3b',
+    'w4a',
+    'w4b',
+  ]);
+});

--- a/packages/zero-cache/src/lock.test.ts
+++ b/packages/zero-cache/src/lock.test.ts
@@ -294,20 +294,42 @@ test('poll status', async () => {
         "warn",
         {
           "component": "lock",
-          "id": 0,
+          "id": 6,
         },
         [
           "Lock is taking too long to resolve. It may be stuck.",
+          "Error: Lock acquisition stack
+        at Lock.lock (/Users/mlaw/workspace/mono/packages/zero-cache/src/lock.ts:25:30)
+        at Lock.withLock (/Users/mlaw/workspace/mono/packages/zero-cache/src/lock.ts:47:21)
+        at /Users/mlaw/workspace/mono/packages/zero-cache/src/lock.test.ts:287:28
+        at file:///Users/mlaw/workspace/mono/node_modules/@vitest/runner/dist/index.js:174:14
+        at file:///Users/mlaw/workspace/mono/node_modules/@vitest/runner/dist/index.js:563:28
+        at file:///Users/mlaw/workspace/mono/node_modules/@vitest/runner/dist/index.js:61:24
+        at new Promise (<anonymous>)
+        at runWithTimeout (file:///Users/mlaw/workspace/mono/node_modules/@vitest/runner/dist/index.js:41:12)
+        at runTest (file:///Users/mlaw/workspace/mono/node_modules/@vitest/runner/dist/index.js:1149:17)
+        at runSuite (file:///Users/mlaw/workspace/mono/node_modules/@vitest/runner/dist/index.js:1303:15)",
         ],
       ],
       [
         "warn",
         {
           "component": "lock",
-          "id": 0,
+          "id": 6,
         },
         [
           "Lock is taking too long to resolve. It may be stuck.",
+          "Error: Lock acquisition stack
+        at Lock.lock (/Users/mlaw/workspace/mono/packages/zero-cache/src/lock.ts:25:30)
+        at Lock.withLock (/Users/mlaw/workspace/mono/packages/zero-cache/src/lock.ts:47:21)
+        at /Users/mlaw/workspace/mono/packages/zero-cache/src/lock.test.ts:287:28
+        at file:///Users/mlaw/workspace/mono/node_modules/@vitest/runner/dist/index.js:174:14
+        at file:///Users/mlaw/workspace/mono/node_modules/@vitest/runner/dist/index.js:563:28
+        at file:///Users/mlaw/workspace/mono/node_modules/@vitest/runner/dist/index.js:61:24
+        at new Promise (<anonymous>)
+        at runWithTimeout (file:///Users/mlaw/workspace/mono/node_modules/@vitest/runner/dist/index.js:41:12)
+        at runTest (file:///Users/mlaw/workspace/mono/node_modules/@vitest/runner/dist/index.js:1149:17)
+        at runSuite (file:///Users/mlaw/workspace/mono/node_modules/@vitest/runner/dist/index.js:1303:15)",
         ],
       ],
     ]

--- a/packages/zero-cache/src/lock.test.ts
+++ b/packages/zero-cache/src/lock.test.ts
@@ -288,50 +288,24 @@ test('poll status', async () => {
 
   await vi.runAllTimersAsync();
   await lockPromise;
-  expect(testLogSink.messages).toMatchInlineSnapshot(`
+  expect(
+    testLogSink.messages.map(m => [m[0], m[1], [m[2][0], m[2][1]]]),
+  ).toEqual([
     [
-      [
-        "warn",
-        {
-          "component": "lock",
-          "id": 6,
-        },
-        [
-          "Lock is taking too long to resolve. It may be stuck.",
-          "Error: Lock acquisition stack
-        at Lock.lock (/Users/mlaw/workspace/mono/packages/zero-cache/src/lock.ts:25:30)
-        at Lock.withLock (/Users/mlaw/workspace/mono/packages/zero-cache/src/lock.ts:47:21)
-        at /Users/mlaw/workspace/mono/packages/zero-cache/src/lock.test.ts:287:28
-        at file:///Users/mlaw/workspace/mono/node_modules/@vitest/runner/dist/index.js:174:14
-        at file:///Users/mlaw/workspace/mono/node_modules/@vitest/runner/dist/index.js:563:28
-        at file:///Users/mlaw/workspace/mono/node_modules/@vitest/runner/dist/index.js:61:24
-        at new Promise (<anonymous>)
-        at runWithTimeout (file:///Users/mlaw/workspace/mono/node_modules/@vitest/runner/dist/index.js:41:12)
-        at runTest (file:///Users/mlaw/workspace/mono/node_modules/@vitest/runner/dist/index.js:1149:17)
-        at runSuite (file:///Users/mlaw/workspace/mono/node_modules/@vitest/runner/dist/index.js:1303:15)",
-        ],
-      ],
-      [
-        "warn",
-        {
-          "component": "lock",
-          "id": 6,
-        },
-        [
-          "Lock is taking too long to resolve. It may be stuck.",
-          "Error: Lock acquisition stack
-        at Lock.lock (/Users/mlaw/workspace/mono/packages/zero-cache/src/lock.ts:25:30)
-        at Lock.withLock (/Users/mlaw/workspace/mono/packages/zero-cache/src/lock.ts:47:21)
-        at /Users/mlaw/workspace/mono/packages/zero-cache/src/lock.test.ts:287:28
-        at file:///Users/mlaw/workspace/mono/node_modules/@vitest/runner/dist/index.js:174:14
-        at file:///Users/mlaw/workspace/mono/node_modules/@vitest/runner/dist/index.js:563:28
-        at file:///Users/mlaw/workspace/mono/node_modules/@vitest/runner/dist/index.js:61:24
-        at new Promise (<anonymous>)
-        at runWithTimeout (file:///Users/mlaw/workspace/mono/node_modules/@vitest/runner/dist/index.js:41:12)
-        at runTest (file:///Users/mlaw/workspace/mono/node_modules/@vitest/runner/dist/index.js:1149:17)
-        at runSuite (file:///Users/mlaw/workspace/mono/node_modules/@vitest/runner/dist/index.js:1303:15)",
-        ],
-      ],
-    ]
-  `);
+      'warn',
+      {
+        component: 'lock',
+        id: 6,
+      },
+      ['Lock is taking too long to resolve. It may be stuck. Waiting on:', ''],
+    ],
+    [
+      'warn',
+      {
+        component: 'lock',
+        id: 6,
+      },
+      ['Lock is taking too long to resolve. It may be stuck. Waiting on:', ''],
+    ],
+  ]);
 });

--- a/packages/zero-cache/src/lock.ts
+++ b/packages/zero-cache/src/lock.ts
@@ -1,0 +1,63 @@
+import {resolver} from '@rocicorp/resolver';
+
+export class Lock {
+  private _lockP: Promise<void> | null = null;
+
+  async lock(): Promise<() => void> {
+    const previous = this._lockP;
+    const {promise, resolve} = resolver();
+    this._lockP = promise;
+    await previous;
+    return resolve;
+  }
+
+  withLock<R>(f: () => R | Promise<R>): Promise<R> {
+    return run(this.lock(), f);
+  }
+}
+
+export class RWLock {
+  private _lock = new Lock();
+  private _writeP: Promise<void> | null = null;
+  private _readP: Promise<void>[] = [];
+
+  read(): Promise<() => void> {
+    return this._lock.withLock(async () => {
+      await this._writeP;
+      const {promise, resolve} = resolver();
+      this._readP.push(promise);
+      return resolve;
+    });
+  }
+
+  withRead<R>(f: () => R | Promise<R>): Promise<R> {
+    return run(this.read(), f);
+  }
+
+  write(): Promise<() => void> {
+    return this._lock.withLock(async () => {
+      await this._writeP;
+      await Promise.all(this._readP);
+      const {promise, resolve} = resolver();
+      this._writeP = promise;
+      this._readP = [];
+      return resolve;
+    });
+  }
+
+  withWrite<R>(f: () => R | Promise<R>): Promise<R> {
+    return run(this.write(), f);
+  }
+}
+
+async function run<R>(
+  p: Promise<() => void>,
+  f: () => R | Promise<R>,
+): Promise<R> {
+  const release = await p;
+  try {
+    return await f();
+  } finally {
+    release();
+  }
+}


### PR DESCRIPTION
- prints if we're stuck waiting on a lock for more than 1 second
- emits the stack track of the stuck acquirer
- prints the name of the task in front of the acquirer that is blocking it