### PR TITLE
fix(zero): deal with receiving many responses for the same mutation

### DIFF
--- a/packages/zero-pg/src/web.pg-test.ts
+++ b/packages/zero-pg/src/web.pg-test.ts
@@ -168,7 +168,11 @@ test('previously seen mutation', async () => {
           clientID: 'cid',
           id: 2,
         },
-        result: {},
+        result: {
+          error: 'alreadyProcessed',
+          details:
+            'Ignoring mutation from cid with ID 2 as it was already processed. Expected: 4',
+        },
       },
     ],
   });

--- a/packages/zero-pg/src/web.ts
+++ b/packages/zero-pg/src/web.ts
@@ -173,7 +173,10 @@ export class PushProcessor<
             clientID: m.clientID,
             id: m.id,
           },
-          result: {},
+          result: {
+            error: 'alreadyProcessed',
+            details: e.message,
+          },
         };
       }
 

--- a/packages/zero-protocol/src/ast.test.ts
+++ b/packages/zero-protocol/src/ast.test.ts
@@ -607,5 +607,5 @@ test('protocol version', () => {
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
   expect(hash).toEqual('2zzy9s2lcdcms');
-  expect(PROTOCOL_VERSION).toEqual(15);
+  expect(PROTOCOL_VERSION).toEqual(16);
 });

--- a/packages/zero-protocol/src/protocol-version.test.ts
+++ b/packages/zero-protocol/src/protocol-version.test.ts
@@ -11,6 +11,6 @@ test('protocol version', () => {
   // If this test fails upstream or downstream schema has changed such that
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
-  expect(hash).toEqual('733s0hg8uzrv');
-  expect(PROTOCOL_VERSION).toEqual(15);
+  expect(hash).toEqual('gmhjpmamj2r4');
+  expect(PROTOCOL_VERSION).toEqual(16);
 });

--- a/packages/zero-protocol/src/protocol-version.ts
+++ b/packages/zero-protocol/src/protocol-version.ts
@@ -21,7 +21,8 @@ import {assert} from '../../shared/src/asserts.ts';
 // -- Version 12 adds 'timestamp' and 'date' types to the ClientSchema ValueType. (not shipped, reversed by version 14)
 // -- Version 14 removes 'timestamp' and 'date' types from the ClientSchema ValueType. (0.18)
 // -- Version 15 adds a `userPushParams` field to `initConnection`
-export const PROTOCOL_VERSION = 15;
+// -- Version 16 adds a new error type (alreadyProcessed) to mutation responses
+export const PROTOCOL_VERSION = 16;
 
 /**
  * The minimum server-supported sync protocol version (i.e. the version

--- a/packages/zero-protocol/src/push.ts
+++ b/packages/zero-protocol/src/push.ts
@@ -110,7 +110,7 @@ const appErrorSchema = v.object({
   details: jsonSchema.optional(),
 });
 const zeroErrorSchema = v.object({
-  error: v.literal('oooMutation'),
+  error: v.union(v.literal('oooMutation'), v.literal('alreadyProcessed')),
   details: jsonSchema.optional(),
 });
 


### PR DESCRIPTION
Return "mutation already processed" as an error from the server. In mutation tracker, no longer throw if an ephemeral id is missing for a mutation that says it has already been processed.

![CleanShot 2025-04-22 at 16 36 00](https://github.com/user-attachments/assets/203e0027-d605-49fa-9572-4095f2a20c41)
