### PR TITLE
fix(zero-cache): fix incorrect shutdown under initial CPU load

### DIFF
--- a/packages/zero-cache/src/services/life-cycle.ts
+++ b/packages/zero-cache/src/services/life-cycle.ts
@@ -1,15 +1,15 @@
-import { LogContext } from '@rocicorp/logger'
-import { resolver } from '@rocicorp/resolver'
-import type { IncomingHttpHeaders } from 'node:http'
-import { pid } from 'node:process'
-import type { EventEmitter } from 'stream'
+import {LogContext} from '@rocicorp/logger';
+import {resolver} from '@rocicorp/resolver';
+import type {IncomingHttpHeaders} from 'node:http';
+import {pid} from 'node:process';
+import type {EventEmitter} from 'stream';
 import {
   singleProcessMode,
   type Subprocess,
   type Worker,
-} from '../types/processes.ts'
-import { RunningState } from './running-state.ts'
-import type { SingletonService } from './service.ts'
+} from '../types/processes.ts';
+import {RunningState} from './running-state.ts';
+import type {SingletonService} from './service.ts';
 
 /**
  * * `user-facing` workers serve external requests and are the first to
@@ -333,10 +333,10 @@ export class HeartbeatMonitor {
       const timeSinceLastHeartbeat = Date.now() - this.#lastHeartbeat;
       if (timeSinceLastHeartbeat >= this.#stopInterval) {
         this.#lc.info?.(
-        `last heartbeat received ${
-          timeSinceLastHeartbeat / 1000
-        } seconds ago. draining.`,
-      );
+          `last heartbeat received ${
+            timeSinceLastHeartbeat / 1000
+          } seconds ago. draining.`,
+        );
         process.kill(process.pid, GRACEFUL_SHUTDOWN[0]);
       }
     });

--- a/packages/zero-cache/src/services/life-cycle.ts
+++ b/packages/zero-cache/src/services/life-cycle.ts
@@ -325,9 +325,11 @@ export class HeartbeatMonitor {
     //   this.#lastHeartbeat. Downtime ensues.
     //
     // To avoid this, we push the check out to a phase of the event loop *after*
-    // I/O events are processed, using setImmediate(). This ensures we see
-    // a value for this.#lastHeartbeat that reflects any keepalive requests
-    // that came in during the current event loop turn.
+    // I/O events are processed, using setImmediate():
+    // https://nodejs.org/en/learn/asynchronous-work/event-loop-timers-and-nexttick#setimmediate-vs-settimeout
+    //
+    // This ensures we see a value for this.#lastHeartbeat that reflects
+    // any keepalive requests that came in during the current event loop turn.
     this.#checkImmediateTimer = setImmediate(() => {
       this.#checkImmediateTimer = undefined;
       const timeSinceLastHeartbeat = Date.now() - this.#lastHeartbeat;

--- a/packages/zero-cache/src/services/life-cycle.ts
+++ b/packages/zero-cache/src/services/life-cycle.ts
@@ -1,15 +1,15 @@
-import {LogContext} from '@rocicorp/logger';
-import {resolver} from '@rocicorp/resolver';
-import type {IncomingHttpHeaders} from 'node:http';
-import {pid} from 'node:process';
-import type {EventEmitter} from 'stream';
+import { LogContext } from '@rocicorp/logger'
+import { resolver } from '@rocicorp/resolver'
+import type { IncomingHttpHeaders } from 'node:http'
+import { pid } from 'node:process'
+import type { EventEmitter } from 'stream'
 import {
   singleProcessMode,
   type Subprocess,
   type Worker,
-} from '../types/processes.ts';
-import {RunningState} from './running-state.ts';
-import type {SingletonService} from './service.ts';
+} from '../types/processes.ts'
+import { RunningState } from './running-state.ts'
+import type { SingletonService } from './service.ts'
 
 /**
  * * `user-facing` workers serve external requests and are the first to
@@ -281,7 +281,8 @@ export class HeartbeatMonitor {
   readonly #stopInterval: number;
 
   #lc: LogContext;
-  #timer: NodeJS.Timeout | undefined;
+  #checkIntervalTimer: NodeJS.Timeout | undefined;
+  #checkImmediateTimer: NodeJS.Immediate | undefined;
   #lastHeartbeat = 0;
 
   constructor(lc: LogContext, stopInterval = DEFAULT_STOP_INTERVAL_MS) {
@@ -291,7 +292,7 @@ export class HeartbeatMonitor {
 
   onHeartbeat(reqHeaders: IncomingHttpHeaders) {
     this.#lastHeartbeat = Date.now();
-    if (this.#timer === undefined) {
+    if (this.#checkIntervalTimer === undefined) {
       this.#lc.info?.(
         `starting heartbeat monitor at ${
           this.#stopInterval / 1000
@@ -300,7 +301,7 @@ export class HeartbeatMonitor {
       );
       // e.g. check every 5 seconds to see if it's been over 20 seconds
       //      since the last heartbeat.
-      this.#timer = setInterval(
+      this.#checkIntervalTimer = setInterval(
         this.#checkStopInterval,
         this.#stopInterval / 4,
       );
@@ -308,18 +309,43 @@ export class HeartbeatMonitor {
   }
 
   #checkStopInterval = () => {
-    const timeSinceLastHeartbeat = Date.now() - this.#lastHeartbeat;
-    if (timeSinceLastHeartbeat >= this.#stopInterval) {
-      this.#lc.info?.(
+    // In the Node.js event loop, timers like setInterval and setTimeout
+    // run *before* I/O events coming from network sockets or file reads/writes.
+    // When this process gets starved of CPU resources for long periods of time,
+    // for example when other processes are monopolizing all available cores,
+    // pathological behavior can emerge:
+    // - keepalive network request comes in, but is queued in Node internals waiting
+    //   for time on the event loop
+    // - CPU is starved/monopolized by other processes for longer than the time
+    //   configured via this.#stopInterval
+    // - When CPU becomes available and the event loop wakes up, this stop interval
+    //   check is run *before* the keepalive request is processed. The value of
+    //   this.#lastHeartbeat is now very stale, and erroneously triggers a shutdown
+    //   even though keepalive requests were about to be processed and update
+    //   this.#lastHeartbeat. Downtime ensues.
+    //
+    // To avoid this, we push the check out to a phase of the event loop *after*
+    // I/O events are processed, using setImmediate(). This ensures we see
+    // a value for this.#lastHeartbeat that reflects any keepalive requests
+    // that came in during the current event loop turn.
+    this.#checkImmediateTimer = setImmediate(() => {
+      this.#checkImmediateTimer = undefined;
+      const timeSinceLastHeartbeat = Date.now() - this.#lastHeartbeat;
+      if (timeSinceLastHeartbeat >= this.#stopInterval) {
+        this.#lc.info?.(
         `last heartbeat received ${
           timeSinceLastHeartbeat / 1000
         } seconds ago. draining.`,
       );
-      process.kill(process.pid, GRACEFUL_SHUTDOWN[0]);
-    }
+        process.kill(process.pid, GRACEFUL_SHUTDOWN[0]);
+      }
+    });
   };
 
   stop() {
-    clearTimeout(this.#timer);
+    clearTimeout(this.#checkIntervalTimer);
+    if (this.#checkImmediateTimer) {
+      clearImmediate(this.#checkImmediateTimer);
+    }
   }
 }


### PR DESCRIPTION
Discord thread w/ original context: https://discord.com/channels/830183651022471199/1361448930058965023

Recently I ran into a pathological shutdown loop in prod, where my replication manager was doing an expensive operation against sqlite and then immediately shutting itself down, even though nothing seemed to actually be wrong. Because this expensive sqlite operation was being done as part of catching up to upstream on every node startup, it was infinitely looping through failed restarts. Logs revealed that shutdown was being triggered by HeartbeatMonitor, which believed it had not received a keepalive request from the load balancer recently. This seemed to be false — the LB was sending keepalives at the normal rate.

The theory at the time was that something was funky with the ordering of the timers and request handlers in the HeartbeatMonitor class, such that after the expensive operations completed the state got out of sync with reality and triggered an erroneous shutdown. To test this hypothesis we increased the replication manager's CPU cores from 2 to 8, in hopes that the process running the HeartbeatMonitor would have enough CPU cycles available to avoid getting into this corrupted state while other expensive work was happening. This did in fact solve the infinite shutdown loop and appears to have been directionally correct.

Looking more closely at how/why this could happen, it seems very likely that what we saw was due to the fact that I/O events are processed *after* timers in the Node.js event loop: https://nodejs.org/en/learn/asynchronous-work/event-loop-timers-and-nexttick

If true, the explanation for the behavior we saw during this incident would be that after CPU became available again, first the timer to check the stop interval fired (the "timers" phase), checked a very stale lastHeartbeat timestamp, and believed it was appropriate to shut down. This pre-empted the I/O event callbacks from the keepalive network request, which would have been processed in the later "poll" phase of the event loop and caused the lastHeartbeat timestamp to be bumped up to a much more recent time that would not have triggered a shutdown.

This change attempts to protect against that pathological case by wrapping interval checks with a `setImmediate`. When called in early phases of the event loop, `setImmediate` allegedly executes in the later `check` phase of the same turn, after all outstanding I/O events have been processed. This should in theory mean the ordering aligns with how we'd like this logic to behave.

cc @darkgnotic 