### PR TITLE
chore(zero-cache): put all dbs in utc for now

### DIFF
--- a/packages/zero-cache/test/pg-17.ts
+++ b/packages/zero-cache/test/pg-17.ts
@@ -1,3 +1,3 @@
 import {runPostgresContainer} from './pg-container-setup';
 
-export default runPostgresContainer('postgres:17.0-alpine3.20', 'UTC+1');
+export default runPostgresContainer('postgres:17.0-alpine3.20', 'UTC');


### PR DESCRIPTION
We need to make a few fixes to existing tests before we can incorporate this change.

Some fixes in progress: https://github.com/rocicorp/mono/compare/mlaw/test-fix?expand=1