### PR TITLE
fix(zero-cache): fix race condition that can orphan closed outbound streams

### DIFF
--- a/packages/zero-cache/src/workers/connection.ts
+++ b/packages/zero-cache/src/workers/connection.ts
@@ -285,6 +285,10 @@ export class Connection {
     //       from createWebSocketStream() were instead used, exceptions
     //       from the outboundStream result in the Writable closing the
     //       the websocket before the error message can be sent.
+    this.#ws
+      .once('error', () => outboundStream.cancel())
+      .once('close', () => outboundStream.cancel());
+
     pipeline(
       Readable.from(outboundStream),
       new Writable({


### PR DESCRIPTION
Add explicit handlers for the 'error' and 'close' events when proxying outbound streams. This covers a race condition in which the stream is closed while the proxying is being set up, resulting in the connection being marked as `#closed` before the outbound stream is stored as a member variable, and thus preventing the underlying subscription from getting the `cancel()` call.