### PR TITLE
chore(zql): `run` now needs an option for "complete" vs "unknown"

### DIFF
--- a/packages/zql-integration-tests/src/helpers/runner.ts
+++ b/packages/zql-integration-tests/src/helpers/runner.ts
@@ -252,7 +252,9 @@ function makeTest<TSchema extends Schema>(
       zqlSchema,
       ast(queries.sqlite).table,
     );
-    const memoryResult = await queries.memory;
+    const memoryResult = await queries.memory.run({
+      type: 'complete',
+    });
 
     expect(memoryResult).toEqualPg(pgResult);
     expect(sqliteResult).toEqualPg(pgResult);


### PR DESCRIPTION
The default of `unknown` causes `run` to return no data in tests.

related: #4234