### PR TITLE
Revert "chore(zql): `run` now needs an option for "complete" vs "unknown""

### DIFF
--- a/packages/zql-integration-tests/src/helpers/runner.ts
+++ b/packages/zql-integration-tests/src/helpers/runner.ts
@@ -252,9 +252,7 @@ function makeTest<TSchema extends Schema>(
       zqlSchema,
       ast(queries.sqlite).table,
     );
-    const memoryResult = await queries.memory.run({
-      type: 'complete',
-    });
+    const memoryResult = await queries.memory;
 
     expect(memoryResult).toEqualPg(pgResult);
     expect(sqliteResult).toEqualPg(pgResult);


### PR DESCRIPTION
Reverts rocicorp/mono#4267