### PR TITLE
chore(z2s): call TestQueryDelegate correctly

### DIFF
--- a/packages/zql-integration-tests/src/chinook/chinook.pg-test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook.pg-test.ts
@@ -126,7 +126,7 @@ beforeEach(async () => {
   );
 
   zqliteQueryDelegate = newQueryDelegate(lc, testLogConfig, sqlite, schema);
-  memoryQueryDelegate = new TestMemoryQueryDelegate(memorySources);
+  memoryQueryDelegate = new TestMemoryQueryDelegate({sources: memorySources});
 
   tables.forEach(table => {
     zqliteQueries[table] = newQuery(zqliteQueryDelegate, schema, table) as any;

--- a/packages/zql-integration-tests/src/collate.pg-test.ts
+++ b/packages/zql-integration-tests/src/collate.pg-test.ts
@@ -134,7 +134,7 @@ beforeAll(async () => {
 
   // Set up memory query
   const memorySources = makeMemorySources();
-  memoryQueryDelegate = new TestMemoryQueryDelegate(memorySources);
+  memoryQueryDelegate = new TestMemoryQueryDelegate({sources: memorySources});
 
   // Initialize memory sources with test data
   for (const row of testData.item) {

--- a/packages/zql-integration-tests/src/helpers/runner.ts
+++ b/packages/zql-integration-tests/src/helpers/runner.ts
@@ -158,7 +158,7 @@ async function makeDelegates<TSchema extends Schema>(
       serverSchema,
     },
     sqlite: newQueryDelegate(lc, testLogConfig, dbs.sqlite, schema),
-    memory: new TestMemoryQueryDelegate(dbs.memory),
+    memory: new TestMemoryQueryDelegate({sources: dbs.memory}),
   };
 }
 


### PR DESCRIPTION
TS didn't catch this surprisingly.