### PR TITLE
chore(zero-cache): bump to litestream version with region fix

### DIFF
--- a/packages/zero/Dockerfile
+++ b/packages/zero/Dockerfile
@@ -1,10 +1,10 @@
 FROM golang:1.23 AS litestream
 
 WORKDIR /src/
-RUN git clone --depth 1 --branch zero@v0.0.2 https://github.com/rocicorp/litestream.git
+RUN git clone --depth 1 --branch zero@v0.0.3 https://github.com/rocicorp/litestream.git
 WORKDIR /src/litestream/
 
-ARG LITESTREAM_VERSION=0.3.13+z0.0.2  # upstream version + zero version
+ARG LITESTREAM_VERSION=0.3.13+z0.0.3  # upstream version + zero version
 
 RUN --mount=type=cache,target=/root/.cache/go-build \
 	--mount=type=cache,target=/go/pkg \


### PR DESCRIPTION
Bump to zero@v0.0.3 litestream which contains the fix (https://github.com/rocicorp/litestream/pull/4) for an unreleased bug (https://github.com/benbjohnson/litestream/issues/621).