### PR TITLE
wip: support undefined in where() and generally wherever null is accepted in queries

### DIFF
--- a/apps/zbugs/shared/auth.ts
+++ b/apps/zbugs/shared/auth.ts
@@ -7,7 +7,7 @@ import * as v from '../../../packages/shared/src/valita.ts';
 /** The contents of the zbugs JWT */
 export const authDataSchema = v.object({
   sub: v.string(),
-  role: v.union(v.literal('crew'), v.literal('user')),
+  role: v.union(v.literal('crew'), v.literal('user')).optional(),
   name: v.string(),
   iat: v.number(),
   exp: v.number(),

--- a/packages/zero-protocol/src/ast.ts
+++ b/packages/zero-protocol/src/ast.ts
@@ -287,6 +287,7 @@ export type LiteralValue =
   | number
   | boolean
   | null
+  | undefined
   | ReadonlyArray<string | number | boolean>;
 
 /**

--- a/packages/zql/src/query/query.test.ts
+++ b/packages/zql/src/query/query.test.ts
@@ -614,13 +614,10 @@ describe('types', () => {
     // @ts-expect-error - IN cannot compare with undefined.
     q1.where('s', 'IN', [undefined]);
 
-    // IS and IS NOT can always compare with null
+    // IS and IS NOT can always compare with null and undefined
     q1.where('s', 'IS', null);
     q1.where('s', 'IS NOT', null);
-
-    // @ts-expect-error - IS cannot compare with undefined
     q1.where('s', 'IS', undefined);
-    // @ts-expect-error - same with IS NOT
     q1.where('s', 'IS NOT', undefined);
 
     const q2 = mockQuery as unknown as Query<Schema, 'testWithNulls'>;
@@ -636,11 +633,7 @@ describe('types', () => {
 
     q2.where('s', 'IS', null);
     q2.where('s', 'IS NOT', null);
-
-    // @ts-expect-error - IS cannot compare with undefined, even when field is
-    // optional.
     q2.where('s', 'IS', undefined);
-    // @ts-expect-error - Same with IS NOT
     q2.where('s', 'IS NOT', undefined);
   });
 

--- a/packages/zql/src/query/query.ts
+++ b/packages/zql/src/query/query.ts
@@ -29,7 +29,7 @@ export type GetFilterType<
   ? // SchemaValueToTSType adds null if the type is optional, but we add null
     // no matter what for dx reasons. See:
     // https://github.com/rocicorp/mono/pull/3576#discussion_r1925792608
-    SchemaValueToTSType<TSchema['columns'][TColumn]> | null
+    SchemaValueToTSType<TSchema['columns'][TColumn]> | null | undefined
   : TOperator extends 'IN' | 'NOT IN'
     ? // We don't want to compare to null in where clauses because it causes
       // confusing results:


### PR DESCRIPTION
Started this trying to just accept them for `IS` filters, but realized may as well accept anywhere `null` is supported (which I guess is just `IS` but anyway doing the change at a lower level). But I'm not sure what the correct change for z2s is, or indeed if there are reasons not to do this.

@tantaman can you take over?