### PR TITLE
feat(zero-pg): support async post-mutation tasks in PushProcessor

### DIFF
--- a/apps/zbugs/server/push-handler.ts
+++ b/apps/zbugs/server/push-handler.ts
@@ -5,7 +5,7 @@ import {
 } from '@rocicorp/zero/pg';
 import postgres from 'postgres';
 import {schema} from '../shared/schema.ts';
-import {createServerMutators, type PostCommitTask} from './server-mutators.ts';
+import {createServerMutators} from './server-mutators.ts';
 import type {AuthData} from '../shared/auth.ts';
 import type {ReadonlyJSONValue} from '@rocicorp/zero';
 
@@ -21,9 +21,7 @@ export async function handlePush(
   params: Record<string, string> | URLSearchParams,
   body: ReadonlyJSONValue,
 ) {
-  const postCommitTasks: PostCommitTask[] = [];
-  const mutators = createServerMutators(authData, postCommitTasks);
+  const mutators = createServerMutators(authData);
   const response = await processor.process(mutators, params, body);
-  await Promise.all(postCommitTasks.map(task => task()));
   return response;
 }

--- a/packages/zero-pg/src/push-processor.pg-test.ts
+++ b/packages/zero-pg/src/push-processor.pg-test.ts
@@ -1,13 +1,19 @@
 import {testDBs} from '../../zero-cache/src/test/db.ts';
-import {beforeEach, describe, expect, test} from 'vitest';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import type {PostgresDB} from '../../zero-cache/src/types/pg.ts';
 import {getClientsTableDefinition} from '../../zero-cache/src/services/change-source/pg/schema/shard.ts';
 
 import {PushProcessor} from './push-processor.ts';
 import {ZQLPostgresJSAdapter} from './zql-postgresjs-provider.ts';
 import type {PushBody} from '../../zero-protocol/src/push.ts';
-import {customMutatorKey} from '../../zql/src/mutate/custom.ts';
+import {
+  customMutatorKey,
+  type ServerTransaction,
+} from '../../zql/src/mutate/custom.ts';
 import {ZQLDatabaseProvider} from './zql-provider.ts';
+import type {CustomMutatorDefs} from './custom.ts';
+import {consoleLogSink} from '@rocicorp/logger';
+import {sleep} from '../../shared/src/sleep.ts';
 
 let pg: PostgresDB;
 const params = {
@@ -45,6 +51,32 @@ function makePush(
   };
 }
 
+function makePushBatch(
+  mutations: [mid: number, mutatorName: string][],
+): PushBody {
+  return {
+    pushVersion: 1,
+    clientGroupID: 'cgid',
+    requestID: 'rid',
+    schemaVersion: 1,
+    timestamp: 42,
+    mutations: mutations.map(([mid, mutatorName]) => ({
+      type: 'custom',
+      clientID: 'cid',
+      id: mid,
+      name: mutatorName,
+      timestamp: 42,
+      args: [],
+    })),
+  };
+}
+
+const schema = {
+  tables: {},
+  relationships: {},
+  version: 1,
+};
+
 const mutators = {
   foo: {
     bar: () => Promise.resolve(),
@@ -55,11 +87,7 @@ const mutators = {
 describe('out of order mutation', () => {
   test('first mutation is out of order', async () => {
     const processor = new PushProcessor(
-      new ZQLDatabaseProvider(new ZQLPostgresJSAdapter(pg), {
-        tables: {},
-        relationships: {},
-        version: 1,
-      }),
+      new ZQLDatabaseProvider(new ZQLPostgresJSAdapter(pg), schema),
     );
     const result = await processor.process(mutators, params, makePush(15));
 
@@ -83,11 +111,7 @@ describe('out of order mutation', () => {
 
   test('later mutations are out of order', async () => {
     const processor = new PushProcessor(
-      new ZQLDatabaseProvider(new ZQLPostgresJSAdapter(pg), {
-        tables: {},
-        relationships: {},
-        version: 1,
-      }),
+      new ZQLDatabaseProvider(new ZQLPostgresJSAdapter(pg), schema),
     );
 
     expect(await processor.process(mutators, params, makePush(1))).toEqual({
@@ -123,11 +147,7 @@ describe('out of order mutation', () => {
 
 test('first mutation', async () => {
   const processor = new PushProcessor(
-    new ZQLDatabaseProvider(new ZQLPostgresJSAdapter(pg), {
-      tables: {},
-      relationships: {},
-      version: 1,
-    }),
+    new ZQLDatabaseProvider(new ZQLPostgresJSAdapter(pg), schema),
   );
 
   expect(await processor.process(mutators, params, makePush(1))).toEqual({
@@ -147,11 +167,7 @@ test('first mutation', async () => {
 
 test('previously seen mutation', async () => {
   const processor = new PushProcessor(
-    new ZQLDatabaseProvider(new ZQLPostgresJSAdapter(pg), {
-      tables: {},
-      relationships: {},
-      version: 1,
-    }),
+    new ZQLDatabaseProvider(new ZQLPostgresJSAdapter(pg), schema),
   );
 
   await processor.process(mutators, params, makePush(1));
@@ -179,11 +195,7 @@ test('previously seen mutation', async () => {
 
 test('lmid still moves forward if the mutator implementation throws', async () => {
   const processor = new PushProcessor(
-    new ZQLDatabaseProvider(new ZQLPostgresJSAdapter(pg), {
-      tables: {},
-      relationships: {},
-      version: 1,
-    }),
+    new ZQLDatabaseProvider(new ZQLPostgresJSAdapter(pg), schema),
   );
 
   await processor.process(mutators, params, makePush(1));
@@ -212,11 +224,7 @@ test('lmid still moves forward if the mutator implementation throws', async () =
 
 test('mutators with and without namespaces', async () => {
   const processor = new PushProcessor(
-    new ZQLDatabaseProvider(new ZQLPostgresJSAdapter(pg), {
-      tables: {},
-      relationships: {},
-      version: 1,
-    }),
+    new ZQLDatabaseProvider(new ZQLPostgresJSAdapter(pg), schema),
   );
   const mutators = {
     namespaced: {
@@ -302,6 +310,209 @@ test('mutators with and without namespaces', async () => {
         `);
 
   await checkClientsTable(pg, 4);
+});
+
+describe('post commit tasks', () => {
+  let consoleErrorMock: ReturnType<typeof vi.spyOn>;
+  let mutators: CustomMutatorDefs<ServerTransaction<typeof schema, unknown>>;
+  let noErrorMock: ReturnType<typeof vi.fn>;
+  let taskErrorMock: ReturnType<typeof vi.fn>;
+  let mutationErrorMock: ReturnType<typeof vi.fn>;
+  let asyncResolutionMock: ReturnType<typeof vi.fn>;
+
+  let resolveAsyncResolution: (value: unknown) => void;
+
+  const taskException = new Error('post mutation task error');
+
+  beforeEach(() => {
+    consoleErrorMock = vi
+      .spyOn(consoleLogSink, 'log')
+      .mockImplementation(() => undefined);
+    noErrorMock = vi.fn().mockResolvedValue(undefined);
+    taskErrorMock = vi.fn().mockRejectedValue(taskException);
+    mutationErrorMock = vi.fn().mockResolvedValue(undefined);
+
+    asyncResolutionMock = vi.fn().mockImplementation(
+      () =>
+        new Promise(resolve => {
+          resolveAsyncResolution = resolve;
+        }),
+    );
+
+    mutators = {
+      postCommit: {
+        noError: tx => {
+          tx.after(noErrorMock);
+          return Promise.resolve();
+        },
+        taskError: tx => {
+          tx.after(taskErrorMock);
+          return Promise.resolve();
+        },
+        mutationError: tx => {
+          tx.after(mutationErrorMock);
+          return Promise.reject(new Error('mutator error'));
+        },
+        asyncResolution: tx => {
+          tx.after(asyncResolutionMock);
+          return Promise.resolve();
+        },
+      },
+    };
+  });
+
+  afterEach(() => {
+    consoleErrorMock.mockReset();
+  });
+
+  test('tasks execute if mutator succeeds', async () => {
+    const processor = new PushProcessor(
+      new ZQLDatabaseProvider(new ZQLPostgresJSAdapter(pg), schema),
+    );
+
+    await processor.process(
+      mutators,
+      params,
+      makePushBatch([
+        [1, customMutatorKey('postCommit', 'noError')],
+        [2, customMutatorKey('postCommit', 'taskError')],
+      ]),
+    );
+
+    expect(noErrorMock).toHaveBeenCalledTimes(1);
+    expect(taskErrorMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('tasks do not execute if mutator throws', async () => {
+    const processor = new PushProcessor(
+      new ZQLDatabaseProvider(new ZQLPostgresJSAdapter(pg), schema),
+    );
+
+    await processor.process(
+      mutators,
+      params,
+      makePushBatch([
+        [1, customMutatorKey('postCommit', 'noError')],
+        [2, customMutatorKey('postCommit', 'mutationError')],
+      ]),
+    );
+
+    expect(noErrorMock).toHaveBeenCalledTimes(1);
+    expect(mutationErrorMock).toHaveBeenCalledTimes(0);
+  });
+
+  test('tasks throws are sent to the logger', async () => {
+    const processor = new PushProcessor(
+      new ZQLDatabaseProvider(new ZQLPostgresJSAdapter(pg), schema),
+    );
+
+    await processor.process(
+      mutators,
+      params,
+      makePushBatch([
+        [1, customMutatorKey('postCommit', 'noError')],
+        [2, customMutatorKey('postCommit', 'taskError')],
+      ]),
+    );
+
+    expect(noErrorMock).toHaveBeenCalledTimes(1);
+    expect(taskErrorMock).toHaveBeenCalledTimes(1);
+
+    expect(consoleErrorMock).toHaveBeenCalledTimes(1);
+    expect(consoleErrorMock.mock.calls[0][0]).toEqual('error');
+    expect(consoleErrorMock.mock.calls[0][2]).toEqual(taskException);
+  });
+
+  test('.process() waits for tasks to settle by default', async () => {
+    const processor = new PushProcessor(
+      new ZQLDatabaseProvider(new ZQLPostgresJSAdapter(pg), schema),
+    );
+
+    const processPromise = processor.process(
+      mutators,
+      params,
+      makePushBatch([[1, customMutatorKey('postCommit', 'asyncResolution')]]),
+    );
+
+    let processCompleted = false;
+    void processPromise.then(() => {
+      processCompleted = true;
+    });
+
+    // Wait for the full mutation flow to complete w/ PG.
+    for (let i = 0; i < 10; i++) {
+      await sleep(10);
+    }
+
+    expect(asyncResolutionMock).toHaveBeenCalledTimes(1);
+    expect(processCompleted).toBe(false);
+
+    resolveAsyncResolution(undefined);
+
+    await sleep(1);
+
+    expect(processCompleted).toBe(true);
+  });
+
+  test('.process() does not wait for tasks to settle with async: true', async () => {
+    const processor = new PushProcessor(
+      new ZQLDatabaseProvider(new ZQLPostgresJSAdapter(pg), schema),
+      {async: true},
+    );
+
+    const processPromise = processor.process(
+      mutators,
+      params,
+      makePushBatch([[1, customMutatorKey('postCommit', 'asyncResolution')]]),
+    );
+
+    let processCompleted = false;
+    void processPromise.then(() => {
+      processCompleted = true;
+    });
+
+    // Wait for the full mutation flow to complete w/ PG.
+    for (let i = 0; i < 10; i++) {
+      await sleep(10);
+    }
+
+    expect(asyncResolutionMock).toHaveBeenCalledTimes(1);
+    expect(processCompleted).toBe(true);
+
+    // Test close() behavior
+    const closePromise = processor.close();
+    let closeCompleted = false;
+    void closePromise.then(() => {
+      closeCompleted = true;
+    });
+
+    // Close should not resolve while tasks are pending
+    await sleep(1);
+    expect(closeCompleted).toBe(false);
+
+    // Resolving the task should allow close() to complete
+    resolveAsyncResolution(undefined);
+    await sleep(1);
+    expect(closeCompleted).toBe(true);
+  });
+
+  test('.process() does not accept new mutations after close() is called', async () => {
+    const processor = new PushProcessor(
+      new ZQLDatabaseProvider(new ZQLPostgresJSAdapter(pg), schema),
+    );
+
+    void processor.close();
+
+    await expect(
+      processor.process(
+        mutators,
+        params,
+        makePushBatch([[1, customMutatorKey('postCommit', 'noError')]]),
+      ),
+    ).rejects.toThrow(
+      'PushProcessor has been closed and cannot process any more mutations',
+    );
+  });
 });
 
 async function checkClientsTable(

--- a/packages/zero-pg/src/zql-provider.ts
+++ b/packages/zero-pg/src/zql-provider.ts
@@ -53,6 +53,7 @@ export class ZQLDatabaseProvider<S extends Schema, WrappedTransaction>
         this.#schema,
         this.#mutate,
         this.#query,
+        transactionInput.after,
       );
 
       return callback(zeroTx, {

--- a/packages/zql/src/mutate/custom.ts
+++ b/packages/zql/src/mutate/custom.ts
@@ -38,6 +38,7 @@ export interface ServerTransaction<S extends Schema, TWrappedTransaction>
   readonly location: 'server';
   readonly reason: 'authoritative';
   readonly dbTransaction: DBTransaction<TWrappedTransaction>;
+  readonly after: (task: () => Promise<void>) => void;
 }
 
 /**


### PR DESCRIPTION
Discord thread with more context: https://discord.com/channels/830183651022471199/1363537428165558372

## Background
This adds first-class support to PushProcessor for executing async tasks transactionally with mutations — i.e. tasks are only run if a mutation succeeds. Tasks queued by failed mutations are skipped.

zbugs already had a `postCommitTasks` pattern written in userland, but it was not transactional. If a mutation's code threw or the database failed to commit, it would still execute the tasks. While this behavior is theoretically possible to build by inspecting the push response payload returned by `process()`, it seems more ergonomic to keep app devs out of the business of directly parsing push requests and responses for very common use cases. It's also likely that without first class support devs will end up re-building various versions of this, not all of which will be reliably transactional.

## tx.after()
PushProcessor now provides `DatabaseProvider` implementations with an `after` function, which can be used to enqueue async tasks for a given mutation. The ZQL `ServerTransaction` interface forwards this `after` function along as a top level field:
```typescript
tx.after(() =>
  postToDiscord({
    title: `${modifierUser.login} reported an issue`,
    message: [issue.title, clip(issue.description ?? '')]
      .filter(Boolean)
      .join('\n'),
    link: `https://bugs.rocicorp.dev/issue/${issue.shortID}`,
  }),
);
```

When a mutation successfully commits to the DB, the tasks it enqueued are committed to the set of tasks to be executed for the overall push request. When all the mutations in the push have been handled, all committed tasks are executed. If the promise returned by a task rejects, the exception is sent to the logger but does **not** fail the push request. Since the mutations for those tasks have already been committed and are making their way to the client via replication, it doesn't make sense to fail the push — work should continue to progress similar to other forms of mutation error.

## Async mode
The default behavior of `process()` is to wait for all post-commit tasks to settle before returning. This is necessary for serverless functions where responding to the push request will suspend the runtime immediately.

When running in a long-lived server process, the more common pattern is to execute async work after a response has been sent to the client, which can achieve higher throughput and lower latency for workloads where the async work takes a while to complete. For example if a post commit task in push A takes 3 seconds, a client might be have their mutations in push B queued up behind those tasks in zero-cache waiting for the push to respond before continuing.

This PR introduces an `async` configuration option which allows opt-in backgrounding of post commit tasks. In this mode `process()` returns immediately and tracks post commit tasks async.

To ensure background tasks are not interrupted, a new `close()` method is added which prevents new pushes from being processed and returns a promise that resolves when all in-flight tasks have settled. This method mimics the behavior of other libraries designed for long lived server processes, like `fastify.close()` or similar. It can be used in developers' existing graceful shutdown code alongside the other `close()`-style methods:

```typescript
const server = fastify()
const processor = new PushProcessor(/* connection/db details */, { async: true })

server.post(('/api/push', async function (request, reply) {
  return processor.process(/* mutators, etc. */)
})

await server.listen()

process.on('SIGTERM', async () => {
  await Promise.all([server.close(), processor.close()])
  process.exit(0)
})

```

This option could be used for backgrounding other async work in future changes, if desired.


## Future work
Some serverless runtimes like Vercel [support some form of `waitUntil`](https://vercel.com/changelog/waituntil-is-now-available-for-vercel-functions) or `after` function natively, which allows responses to return to clients while async work runs in the background. Other libraries check for the existence of these special globals in the runtime to automatically background async work. I believe it would be straightforward to do this in PushProcessor, running all post commit tasks for a push inside a `waitUntil` handler automatically even if the `async` flag is set to false.

