### PR TITLE
chore(z2s): cache random operator generation

### DIFF
--- a/packages/zql-integration-tests/src/chinook/chinook.pg-test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook.pg-test.ts
@@ -135,17 +135,21 @@ test.each(
       // n-ary or
       (() => {
         const n = 5;
-        let cached: Array<Rrc<'artist'>> | undefined;
+        let cached:
+          | {rowsAndColumns: Array<Rrc<'artist'>>; operators: SimpleOperator[]}
+          | undefined;
         const rrc = () =>
           cached ??
-          (cached = Array.from({length: n}, () =>
-            randomRowAndColumn('artist'),
-          ));
+          (cached = {
+            rowsAndColumns: Array.from({length: n}, () =>
+              randomRowAndColumn('artist'),
+            ),
+            operators: Array.from({length: n}, () => randomOperator()),
+          });
         return {
           name: 'n-branches',
           createQuery: q => {
-            const rowsAndColumns = rrc();
-            const operators = Array.from({length: n}, () => randomOperator());
+            const {rowsAndColumns, operators} = rrc();
             return q.artist.where(({or, cmp}) =>
               or(
                 ...rowsAndColumns.map(({randomRow, randomColumn}, i) =>


### PR DESCRIPTION
We were getting a different random operator for each backend (pg, sqlite, memory)