### PR TITLE
feat(zero-cache): avoid sending duplicate row patches

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -23,6 +23,7 @@ import {type CVRFlushStats, type CVRStore} from './cvr-store.ts';
 import {KeyColumns} from './key-columns.ts';
 import {
   cmpVersions,
+  maxVersion,
   oneAfter,
   versionString,
   type CVRVersion,
@@ -438,6 +439,11 @@ type Hash = string;
 export type Column = string;
 export type RefCounts = Record<Hash, number>;
 
+type RowPatchInfo = {
+  op: 'put' | 'del';
+  toVersion: CVRVersion;
+};
+
 /**
  * A {@link CVRQueryDrivenUpdater} is used for updating a CVR after making queries.
  * The caller should invoke:
@@ -458,6 +464,7 @@ export class CVRQueryDrivenUpdater extends CVRUpdater {
     rowIDString,
   );
   readonly #replacedRows = new CustomKeyMap<RowID, boolean>(rowIDString);
+  readonly #lastPatches = new CustomKeyMap<RowID, RowPatchInfo>(rowIDString);
 
   #existingRows: Promise<Iterable<RowRecord>> | undefined = undefined;
 
@@ -710,29 +717,42 @@ export class CVRQueryDrivenUpdater extends CVRUpdater {
         this._cvrStore.delRowRecord(id);
       }
 
+      // Dedupe against the lastPatch sent for the row, and ensure that
+      // toVersion never backtracks (lest it be undesirably filtered).
+      const lastPatch = this.#lastPatches.get(id);
+      const toVersion = maxVersion(patchVersion, lastPatch?.toVersion);
+
       if (merged === null) {
         // All refCounts have gone to zero, if row was previously synced
         // delete it.
         if (existing || previouslyReceived) {
+          // dedupe
+          if (lastPatch?.op !== 'del') {
+            patches.push({
+              patch: {
+                type: 'row',
+                op: 'del',
+                id,
+              },
+              toVersion,
+            });
+          }
+          this.#lastPatches.set(id, {op: 'del', toVersion});
+        }
+      } else if (contents) {
+        // dedupe
+        if (lastPatch?.op !== 'put') {
           patches.push({
             patch: {
               type: 'row',
-              op: 'del',
+              op: 'put',
               id,
+              contents,
             },
-            toVersion: patchVersion,
+            toVersion,
           });
         }
-      } else if (contents) {
-        patches.push({
-          patch: {
-            type: 'row',
-            op: 'put',
-            id,
-            contents,
-          },
-          toVersion: patchVersion,
-        });
+        this.#lastPatches.set(id, {op: 'put', toVersion});
       }
     }
     return patches;

--- a/packages/zero-cache/src/services/view-syncer/schema/types.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/types.ts
@@ -62,6 +62,10 @@ export function cmpVersions(
             : (a.minorVersion ?? 0) - (b.minorVersion ?? 0);
 }
 
+export function maxVersion(a: CVRVersion, b?: CVRVersion): CVRVersion {
+  return !b ? a : cmpVersions(b, a) > 0 ? b : a;
+}
+
 export function versionToCookie(v: CVRVersion): string {
   return versionString(v);
 }


### PR DESCRIPTION
1. Tracks the row patches that have been sent and avoids resending redundant patches. This may save significant bandwidth during hydrations for queries with lots of joins.
2. Fixes an edge case to accompany https://github.com/rocicorp/mono/pull/4282: when an existing row is deleted, it will result in a new `patchVersion`, but if it is subsequently re-added, the patchVersion in the CVR will be restored. In this case, however, the `toVersion` used for filtering downstream patches should not move backwards, or else it will be undesirably filtered. 