### PR TITLE
chore(zero): Clarify warning when no serverURL supplied.

### DIFF
--- a/packages/shared/src/tool/vitest-config.ts
+++ b/packages/shared/src/tool/vitest-config.ts
@@ -10,7 +10,6 @@ const logSilenceMessages = [
   'REPLICACHE LICENSE NOT VALID',
   'enableAnalytics false',
   'no such entity',
-  'Zero starting up with no server URL',
   'PokeHandler clearing due to unexpected poke error',
   'Not indexing value',
   'Zero starting up with no server URL',

--- a/packages/zero-client/src/client/server-option.ts
+++ b/packages/zero-client/src/client/server-option.ts
@@ -68,8 +68,7 @@ export function getServer(
   if (server === undefined || server === null) {
     // eslint-disable-next-line no-console
     console.warn(
-      'Zero starting up with no server URL. This is supported for unit testing ' +
-        'and prototyping, but no data will be synced.',
+      'Zero starting up with no server URL. No data will be synced.',
     );
     return null;
   }


### PR DESCRIPTION
There are valid reasons in real apps to have no serverURL, e.g., trial users.