### PR TITLE
fix(z2s): handle self join, not exists

### DIFF
--- a/packages/shared/src/arrays.ts
+++ b/packages/shared/src/arrays.ts
@@ -33,6 +33,13 @@ export function zip<T1, T2>(a1: readonly T1[], a2: readonly T2[]): [T1, T2][] {
   return result;
 }
 
+export function last<T>(arr: T[]): T | undefined {
+  if (arr.length === 0) {
+    return undefined;
+  }
+  return arr[arr.length - 1];
+}
+
 export function groupBy<T, K>(
   arr: readonly T[],
   keyFn: (el: T) => K,

--- a/packages/zero-pg/src/query.ts
+++ b/packages/zero-pg/src/query.ts
@@ -115,9 +115,9 @@ export class ZPGQuery<
       this.#query ??
       formatPgInternalConvert(
         compile(
-          this._completeAst(),
-          this.#schema.tables,
           this.#serverSchema,
+          this.#schema,
+          this._completeAst(),
           this.format,
         ),
       );

--- a/packages/zql-integration-tests/src/collate.pg-test.ts
+++ b/packages/zql-integration-tests/src/collate.pg-test.ts
@@ -342,7 +342,7 @@ async function runAsSQL(
   q: Query<Schema, 'item'>,
   runPgQuery: (query: string, args: unknown[]) => Promise<unknown[]>,
 ) {
-  const c = compile(completedAST(q), schema.tables, serverSchema);
+  const c = compile(serverSchema, schema, completedAST(q));
   const sqlQuery = formatPgInternalConvert(c);
   return extractZqlResult(
     await runPgQuery(sqlQuery.text, sqlQuery.values as JSONValue[]),

--- a/packages/zql-integration-tests/src/compiler-bigint.pg-test.ts
+++ b/packages/zql-integration-tests/src/compiler-bigint.pg-test.ts
@@ -211,7 +211,7 @@ describe('compiling ZQL to SQL', () => {
   ) {
     test('All bigints in safe Number range', async () => {
       const query = issueQuery.related('comments').limit(2);
-      const c = compile(completedAST(query), schema.tables, serverSchema);
+      const c = compile(serverSchema, schema, completedAST(query));
       const sqlQuery = formatPgInternalConvert(c);
       const pgResult = extractZqlResult(
         await runPgQuery(sqlQuery.text, sqlQuery.values as JSONValue[]),
@@ -258,7 +258,7 @@ describe('compiling ZQL to SQL', () => {
 
     test('bigint exceeds safe range', async () => {
       const query = issueQuery.related('comments');
-      const c = compile(completedAST(query), schema.tables, serverSchema);
+      const c = compile(serverSchema, schema, completedAST(query));
       const sqlQuery = formatPgInternalConvert(c);
       const result = await runPgQuery(
         sqlQuery.text,
@@ -276,7 +276,7 @@ describe('compiling ZQL to SQL', () => {
           .where('hash', '<', Number(Number.MAX_SAFE_INTEGER))
           .where('hash', '!=', Number(Number.MAX_SAFE_INTEGER - 3)),
       );
-      const c = compile(completedAST(query), schema.tables, serverSchema);
+      const c = compile(serverSchema, schema, completedAST(query));
       const sqlQuery = formatPgInternalConvert(c);
       const pgResult = extractZqlResult(
         await runPgQuery(sqlQuery.text, sqlQuery.values as JSONValue[]),
@@ -323,7 +323,7 @@ describe('compiling ZQL to SQL', () => {
       const q2 = issueQuery.related('comments', q =>
         q.where('hash', '=', Number.MAX_SAFE_INTEGER - 3),
       );
-      const c2 = compile(completedAST(q2), schema.tables, serverSchema);
+      const c2 = compile(serverSchema, schema, completedAST(q2));
       const sqlQuery2 = formatPgInternalConvert(c2);
       const pgResult2 = extractZqlResult(
         await runPgQuery(sqlQuery2.text, sqlQuery2.values as JSONValue[]),

--- a/packages/zql-integration-tests/src/helpers/runner.ts
+++ b/packages/zql-integration-tests/src/helpers/runner.ts
@@ -152,13 +152,9 @@ async function makeDatabases<TSchema extends Schema>(
   await Promise.all(
     Object.values(schema.tables).map(async table => {
       const sqlQuery = formatPgInternalConvert(
-        compile(
-          {
-            table: table.name,
-          },
-          schema.tables,
-          serverSchema,
-        ),
+        compile(serverSchema, schema, {
+          table: table.name,
+        }),
       );
       const rows = extractZqlResult(
         await pg.unsafe(sqlQuery.text, sqlQuery.values as JSONValue[]),


### PR DESCRIPTION
When server name mappings were added, the compiler got way out of hand. Fixing the `self join` bug would have made everything even more complicated because the fix required introducing aliasing for every table. This PR refactors the compiler so table and column mapping and aliasing only happen in a single place. Qualified column names are also passed everywhere via a `QualifiedColumn` structure so there is never confusion about what "string" a function is dealing with.

---

Two bugs were found when adding more tests to z2s:

1. `self join`
2. `not exists`

# Self Join

Self join failed because we did not auto-alias tables.

Before auto-aliasing we would generate this SQL:

```sql
SELECT (SELECT * FROM employee WHERE employee.reports_to = employee.id) as reports_to FROM employee;
```

which would return no results for the sub-select since the sub-query never references the outer-query.

With auto-aliasing we generate this instead:

```sql
SELECT (SELECT * FROM employee as employee_1 WHERE employee_1.reports_to = employee_0.id) as reports_to FROM employee as employee_0
```

which correctly compares the child to the parent.

# Not Exists

For not exists, `NOT EXISTS` forgot to apply the correlation. We pass the correlation to `NOT EXISTS` now.

