### PR TITLE
fix(zql): Do not allow NOT EXISTS in client queries

### DIFF
--- a/packages/zero-cache/src/auth/read-authorizer.test.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.test.ts
@@ -9,14 +9,9 @@ import {
   definePermissions,
 } from '../../../zero-schema/src/permissions.ts';
 import type {ExpressionBuilder} from '../../../zql/src/query/expression.ts';
-import {
-  ast,
-  newQuery,
-  type QueryDelegate,
-} from '../../../zql/src/query/query-impl.ts';
+import {ast} from '../../../zql/src/query/query-impl.ts';
+import {staticQuery} from '../../../zql/src/query/static-query.ts';
 import {transformQuery} from './read-authorizer.ts';
-
-const mockDelegate = {} as QueryDelegate;
 
 const lc = createSilentLogContext();
 
@@ -183,7 +178,7 @@ describe('unreadable tables', () => {
   ];
   test('top-level', () => {
     for (const tableName of unreadables) {
-      const query = newQuery(mockDelegate, schema, tableName);
+      const query = staticQuery(schema, tableName);
       expect(
         transformQuery(lc, ast(query), permissionRules, authData),
       ).toStrictEqual({
@@ -198,7 +193,7 @@ describe('unreadable tables', () => {
   });
 
   test('related', () => {
-    const query = newQuery(mockDelegate, schema, 'readable')
+    const query = staticQuery(schema, 'readable')
       .related('unreadable')
       .related('readable');
 
@@ -230,7 +225,7 @@ describe('unreadable tables', () => {
                   "type": "or",
                 },
               },
-              "system": "client",
+              "system": "permissions",
             },
             {
               "correlation": {
@@ -256,7 +251,7 @@ describe('unreadable tables', () => {
                   "type": "and",
                 },
               },
-              "system": "client",
+              "system": "permissions",
             },
           ],
           "table": "readable",
@@ -294,7 +289,7 @@ describe('unreadable tables', () => {
                   "type": "or",
                 },
               },
-              "system": "client",
+              "system": "permissions",
             },
             {
               "correlation": {
@@ -320,7 +315,7 @@ describe('unreadable tables', () => {
                   "type": "and",
                 },
               },
-              "system": "client",
+              "system": "permissions",
             },
           ],
           "table": "readable",
@@ -336,7 +331,7 @@ describe('unreadable tables', () => {
       transformQuery(
         lc,
         ast(
-          newQuery(mockDelegate, schema, 'readable').related('readable', q =>
+          staticQuery(schema, 'readable').related('readable', q =>
             q.related('readable', q => q.related('unreadable')),
           ),
         ),
@@ -406,7 +401,7 @@ describe('unreadable tables', () => {
                             "type": "or",
                           },
                         },
-                        "system": "client",
+                        "system": "permissions",
                       },
                     ],
                     "table": "readable",
@@ -415,7 +410,7 @@ describe('unreadable tables', () => {
                       "type": "and",
                     },
                   },
-                  "system": "client",
+                  "system": "permissions",
                 },
               ],
               "table": "readable",
@@ -424,7 +419,7 @@ describe('unreadable tables', () => {
                 "type": "and",
               },
             },
-            "system": "client",
+            "system": "permissions",
           },
         ],
         "table": "readable",
@@ -439,7 +434,7 @@ describe('unreadable tables', () => {
       transformQuery(
         lc,
         ast(
-          newQuery(mockDelegate, schema, 'readable').related('readable', q =>
+          staticQuery(schema, 'readable').related('readable', q =>
             q.related('readable', q => q.related('unreadable')),
           ),
         ),
@@ -509,7 +504,7 @@ describe('unreadable tables', () => {
                             "type": "or",
                           },
                         },
-                        "system": "client",
+                        "system": "permissions",
                       },
                     ],
                     "table": "readable",
@@ -518,7 +513,7 @@ describe('unreadable tables', () => {
                       "type": "and",
                     },
                   },
-                  "system": "client",
+                  "system": "permissions",
                 },
               ],
               "table": "readable",
@@ -527,7 +522,7 @@ describe('unreadable tables', () => {
                 "type": "and",
               },
             },
-            "system": "client",
+            "system": "permissions",
           },
         ],
         "table": "readable",
@@ -541,7 +536,7 @@ describe('unreadable tables', () => {
     expect(
       transformQuery(
         lc,
-        ast(newQuery(mockDelegate, schema, 'readable').related('unreadable')),
+        ast(staticQuery(schema, 'readable').related('unreadable')),
         permissionRules,
         authData,
       ),
@@ -572,7 +567,7 @@ describe('unreadable tables', () => {
                 "type": "or",
               },
             },
-            "system": "client",
+            "system": "permissions",
           },
         ],
         "table": "readable",
@@ -585,9 +580,7 @@ describe('unreadable tables', () => {
   });
 
   test('subqueries in conditions are replaced by `const true` or `const false` expressions', () => {
-    const query = newQuery(mockDelegate, schema, 'readable').whereExists(
-      'unreadable',
-    );
+    const query = staticQuery(schema, 'readable').whereExists('unreadable');
 
     // `unreadable` should be replaced by `false` condition.
     expect(transformQuery(lc, ast(query), permissionRules, undefined))
@@ -623,7 +616,7 @@ describe('unreadable tables', () => {
                       "type": "or",
                     },
                   },
-                  "system": "client",
+                  "system": "permissions",
                 },
                 "type": "correlatedSubquery",
               },
@@ -665,7 +658,7 @@ describe('unreadable tables', () => {
                       "type": "or",
                     },
                   },
-                  "system": "client",
+                  "system": "permissions",
                 },
                 "type": "correlatedSubquery",
               },
@@ -680,7 +673,7 @@ describe('unreadable tables', () => {
       transformQuery(
         lc,
         ast(
-          newQuery(mockDelegate, schema, 'readable').where(({not, exists}) =>
+          staticQuery(schema, 'readable').where(({not, exists}) =>
             not(exists('unreadable')),
           ),
         ),
@@ -719,7 +712,7 @@ describe('unreadable tables', () => {
                     "type": "or",
                   },
                 },
-                "system": "client",
+                "system": "permissions",
               },
               "type": "correlatedSubquery",
             },
@@ -732,7 +725,7 @@ describe('unreadable tables', () => {
       transformQuery(
         lc,
         ast(
-          newQuery(mockDelegate, schema, 'readable').where(({not, exists}) =>
+          staticQuery(schema, 'readable').where(({not, exists}) =>
             not(exists('unreadable')),
           ),
         ),
@@ -771,7 +764,7 @@ describe('unreadable tables', () => {
                     "type": "or",
                   },
                 },
-                "system": "client",
+                "system": "permissions",
               },
               "type": "correlatedSubquery",
             },
@@ -786,9 +779,8 @@ describe('unreadable tables', () => {
       transformQuery(
         lc,
         ast(
-          newQuery(mockDelegate, schema, 'readable').whereExists(
-            'readable',
-            q => q.whereExists('unreadable', q => q.where('id', '1')),
+          staticQuery(schema, 'readable').whereExists('readable', q =>
+            q.whereExists('unreadable', q => q.where('id', '1')),
           ),
         ),
         permissionRules,
@@ -849,7 +841,7 @@ describe('unreadable tables', () => {
                               "type": "or",
                             },
                           },
-                          "system": "client",
+                          "system": "permissions",
                         },
                         "type": "correlatedSubquery",
                       },
@@ -857,7 +849,7 @@ describe('unreadable tables', () => {
                     "type": "and",
                   },
                 },
-                "system": "client",
+                "system": "permissions",
               },
               "type": "correlatedSubquery",
             },
@@ -871,9 +863,8 @@ describe('unreadable tables', () => {
       transformQuery(
         lc,
         ast(
-          newQuery(mockDelegate, schema, 'readable').whereExists(
-            'readable',
-            q => q.whereExists('unreadable', q => q.where('id', '1')),
+          staticQuery(schema, 'readable').whereExists('readable', q =>
+            q.whereExists('unreadable', q => q.where('id', '1')),
           ),
         ),
         permissionRules,
@@ -934,7 +925,7 @@ describe('unreadable tables', () => {
                               "type": "or",
                             },
                           },
-                          "system": "client",
+                          "system": "permissions",
                         },
                         "type": "correlatedSubquery",
                       },
@@ -942,7 +933,7 @@ describe('unreadable tables', () => {
                     "type": "and",
                   },
                 },
-                "system": "client",
+                "system": "permissions",
               },
               "type": "correlatedSubquery",
             },
@@ -957,7 +948,7 @@ describe('unreadable tables', () => {
       transformQuery(
         lc,
         ast(
-          newQuery(mockDelegate, schema, 'readable')
+          staticQuery(schema, 'readable')
             .where(({not, exists}) => not(exists('unreadable')))
             .whereExists('readable'),
         ),
@@ -996,7 +987,7 @@ describe('unreadable tables', () => {
                     "type": "or",
                   },
                 },
-                "system": "client",
+                "system": "permissions",
               },
               "type": "correlatedSubquery",
             },
@@ -1026,7 +1017,7 @@ describe('unreadable tables', () => {
                     "type": "and",
                   },
                 },
-                "system": "client",
+                "system": "permissions",
               },
               "type": "correlatedSubquery",
             },
@@ -1040,7 +1031,7 @@ describe('unreadable tables', () => {
       transformQuery(
         lc,
         ast(
-          newQuery(mockDelegate, schema, 'readable')
+          staticQuery(schema, 'readable')
             .where(({not, exists}) => not(exists('unreadable')))
             .whereExists('readable'),
         ),
@@ -1079,7 +1070,7 @@ describe('unreadable tables', () => {
                     "type": "or",
                   },
                 },
-                "system": "client",
+                "system": "permissions",
               },
               "type": "correlatedSubquery",
             },
@@ -1109,7 +1100,7 @@ describe('unreadable tables', () => {
                     "type": "and",
                   },
                 },
-                "system": "client",
+                "system": "permissions",
               },
               "type": "correlatedSubquery",
             },
@@ -1125,7 +1116,7 @@ test('exists rules in permissions are tagged as the permissions system', () => {
   expect(
     transformQuery(
       lc,
-      ast(newQuery(mockDelegate, schema, 'readableThruUnreadable')),
+      ast(staticQuery(schema, 'readableThruUnreadable')),
       permissionRules,
       undefined,
     ),
@@ -1169,11 +1160,7 @@ test('exists rules in permissions are tagged as the permissions system', () => {
   expect(
     transformQuery(
       lc,
-      ast(
-        newQuery(mockDelegate, schema, 'readable').related(
-          'readableThruUnreadable',
-        ),
-      ),
+      ast(staticQuery(schema, 'readable').related('readableThruUnreadable')),
       permissionRules,
       undefined,
     ),
@@ -1230,7 +1217,7 @@ test('exists rules in permissions are tagged as the permissions system', () => {
               "type": "correlatedSubquery",
             },
           },
-          "system": "client",
+          "system": "permissions",
         },
       ],
       "table": "readable",
@@ -1248,7 +1235,7 @@ describe('admin readable', () => {
       transformQuery(
         lc,
         ast(
-          newQuery(mockDelegate, schema, 'adminReadable')
+          staticQuery(schema, 'adminReadable')
             .related('self1')
             .related('self2'),
         ),
@@ -1291,7 +1278,7 @@ describe('admin readable', () => {
                 "type": "simple",
               },
             },
-            "system": "client",
+            "system": "permissions",
           },
           {
             "correlation": {
@@ -1325,7 +1312,7 @@ describe('admin readable', () => {
                 "type": "simple",
               },
             },
-            "system": "client",
+            "system": "permissions",
           },
         ],
         "table": "adminReadable",
@@ -1349,7 +1336,7 @@ describe('admin readable', () => {
       transformQuery(
         lc,
         ast(
-          newQuery(mockDelegate, schema, 'adminReadable')
+          staticQuery(schema, 'adminReadable')
             .related('self1', q => q.where('id', '1'))
             .related('self2', q =>
               q.where('id', '2').related('self1', q => q.where('id', '3')),
@@ -1411,7 +1398,7 @@ describe('admin readable', () => {
                 "type": "and",
               },
             },
-            "system": "client",
+            "system": "permissions",
           },
           {
             "correlation": {
@@ -1480,7 +1467,7 @@ describe('admin readable', () => {
                       "type": "and",
                     },
                   },
-                  "system": "client",
+                  "system": "permissions",
                 },
               ],
               "table": "adminReadable",
@@ -1514,7 +1501,7 @@ describe('admin readable', () => {
                 "type": "and",
               },
             },
-            "system": "client",
+            "system": "permissions",
           },
         ],
         "table": "adminReadable",
@@ -1555,9 +1542,7 @@ describe('admin readable', () => {
     expect(
       transformQuery(
         lc,
-        ast(
-          newQuery(mockDelegate, schema, 'adminReadable').whereExists('self1'),
-        ),
+        ast(staticQuery(schema, 'adminReadable').whereExists('self1')),
         permissionRules,
         authData,
       ),
@@ -1601,7 +1586,7 @@ describe('admin readable', () => {
                     "type": "simple",
                   },
                 },
-                "system": "client",
+                "system": "permissions",
               },
               "type": "correlatedSubquery",
             },
@@ -1627,9 +1612,8 @@ describe('admin readable', () => {
       transformQuery(
         lc,
         ast(
-          newQuery(mockDelegate, schema, 'adminReadable').whereExists(
-            'self1',
-            q => q.where('id', '1'),
+          staticQuery(schema, 'adminReadable').whereExists('self1', q =>
+            q.where('id', '1'),
           ),
         ),
         permissionRules,
@@ -1692,7 +1676,7 @@ describe('admin readable', () => {
                     "type": "and",
                   },
                 },
-                "system": "client",
+                "system": "permissions",
               },
               "type": "correlatedSubquery",
             },
@@ -1718,9 +1702,8 @@ describe('admin readable', () => {
       transformQuery(
         lc,
         ast(
-          newQuery(mockDelegate, schema, 'adminReadable').whereExists(
-            'self1',
-            q => q.whereExists('self2'),
+          staticQuery(schema, 'adminReadable').whereExists('self1', q =>
+            q.whereExists('self2'),
           ),
         ),
         permissionRules,
@@ -1789,7 +1772,7 @@ describe('admin readable', () => {
                               "type": "simple",
                             },
                           },
-                          "system": "client",
+                          "system": "permissions",
                         },
                         "type": "correlatedSubquery",
                       },
@@ -1809,7 +1792,7 @@ describe('admin readable', () => {
                     "type": "and",
                   },
                 },
-                "system": "client",
+                "system": "permissions",
               },
               "type": "correlatedSubquery",
             },

--- a/packages/zero-pg/src/query.ts
+++ b/packages/zero-pg/src/query.ts
@@ -5,7 +5,11 @@ import type {AST} from '../../zero-protocol/src/ast.ts';
 import type {Schema} from '../../zero-schema/src/builder/schema-builder.ts';
 import type {Format} from '../../zql/src/ivm/view.ts';
 import type {DBTransaction, SchemaQuery} from '../../zql/src/mutate/custom.ts';
-import {AbstractQuery, defaultFormat} from '../../zql/src/query/query-impl.ts';
+import {
+  AbstractQuery,
+  defaultFormat,
+  newQuerySymbol,
+} from '../../zql/src/query/query-impl.ts';
 import type {HumanReadable, PullRow, Query} from '../../zql/src/query/query.ts';
 import type {TypedView} from '../../zql/src/query/typed-view.ts';
 
@@ -82,15 +86,13 @@ export class ZPGQuery<
     ast: AST,
     format: Format,
   ) {
-    super(schema, tableName, ast, format);
+    super(schema, tableName, ast, format, 'permissions');
     this.#dbTransaction = dbTransaction;
     this.#schema = schema;
     this.#serverSchema = serverSchema;
   }
 
-  protected readonly _system = 'permissions';
-
-  protected _newQuery<
+  protected [newQuerySymbol]<
     TSchema extends Schema,
     TTable extends keyof TSchema['tables'] & string,
     TReturn,

--- a/packages/zql/src/query/assert-no-not-exists.test.ts
+++ b/packages/zql/src/query/assert-no-not-exists.test.ts
@@ -1,0 +1,116 @@
+import {expect, test} from 'vitest';
+import type {Condition} from '../../../zero-protocol/src/ast.ts';
+import {assertNoNotExists} from './assert-no-not-exists.ts';
+
+test('throws an error when NOT EXISTS is used', () => {
+  const condition: Condition = {
+    type: 'correlatedSubquery',
+    op: 'NOT EXISTS',
+    related: {
+      correlation: {
+        parentField: ['id'],
+        childField: ['issue_id'],
+      },
+      subquery: {
+        table: 'comments',
+      },
+    },
+  };
+
+  expect(() => assertNoNotExists(condition)).toThrow(
+    'NOT EXISTS is not supported on the client',
+  );
+});
+
+test('does not throw for EXISTS', () => {
+  const condition: Condition = {
+    type: 'correlatedSubquery',
+    op: 'EXISTS',
+    related: {
+      correlation: {
+        parentField: ['id'],
+        childField: ['issue_id'],
+      },
+      subquery: {
+        table: 'comments',
+      },
+    },
+  };
+
+  expect(() => assertNoNotExists(condition)).not.toThrow();
+});
+
+test('checks nested conditions', () => {
+  const condition: Condition = {
+    type: 'and',
+    conditions: [
+      {
+        type: 'simple',
+        op: '=',
+        left: {type: 'column', name: 'status'},
+        right: {type: 'literal', value: 'open'},
+      },
+      {
+        type: 'or',
+        conditions: [
+          {
+            type: 'simple',
+            op: '>',
+            left: {type: 'column', name: 'priority'},
+            right: {type: 'literal', value: 3},
+          },
+          {
+            type: 'correlatedSubquery',
+            op: 'NOT EXISTS', // This should trigger the error
+            related: {
+              correlation: {
+                parentField: ['id'],
+                childField: ['task_id'],
+              },
+              subquery: {
+                table: 'comments',
+              },
+            },
+          },
+        ],
+      },
+    ],
+  };
+
+  expect(() => assertNoNotExists(condition)).toThrow(
+    'NOT EXISTS is not supported on the client',
+  );
+});
+
+test('checks subquery where conditions', () => {
+  const condition: Condition = {
+    type: 'correlatedSubquery',
+    op: 'EXISTS',
+    related: {
+      correlation: {
+        parentField: ['id'],
+        childField: ['issue_id'],
+      },
+      subquery: {
+        table: 'comments',
+        where: {
+          type: 'correlatedSubquery',
+          op: 'NOT EXISTS', // This should trigger the error
+          related: {
+            correlation: {
+              parentField: ['id'],
+              childField: ['comment_id'],
+            },
+            subquery: {
+              table: 'reactions',
+            },
+          },
+        },
+      },
+    },
+  };
+
+  expect(() => assertNoNotExists(condition)).toThrow(
+    'NOT EXISTS is not supported on the client',
+  );
+});

--- a/packages/zql/src/query/assert-no-not-exists.ts
+++ b/packages/zql/src/query/assert-no-not-exists.ts
@@ -1,0 +1,43 @@
+import {unreachable} from '../../../shared/src/asserts.ts';
+import type {Condition} from '../../../zero-protocol/src/ast.ts';
+
+/**
+ * Checks if a condition contains any NOT EXISTS operations.
+ *
+ * The client-side query engine cannot support NOT EXISTS operations because:
+ *
+ * 1. Zero only syncs a subset of data to the client, defined by the queries you use
+ * 2. On the client, we can't distinguish between a row not existing at all vs.
+ *    a row not being synced to the client
+ * 3. For NOT EXISTS to work correctly, we would need complete knowledge of what
+ *    doesn't exist, which is not reasonable with the partial sync model
+ *
+ * @param condition The condition to check
+ * @throws Error if the condition uses NOT EXISTS operator
+ */
+export function assertNoNotExists(condition: Condition): void {
+  switch (condition.type) {
+    case 'simple':
+      // Simple conditions don't use EXISTS/NOT EXISTS
+      return;
+
+    case 'correlatedSubquery':
+      if (condition.op === 'NOT EXISTS') {
+        throw new Error('NOT EXISTS is not supported on the client');
+      }
+      // Check if the subquery has a where condition
+      if (condition.related.subquery.where) {
+        assertNoNotExists(condition.related.subquery.where);
+      }
+      return;
+
+    case 'and':
+    case 'or':
+      for (const c of condition.conditions) {
+        assertNoNotExists(c);
+      }
+      return;
+    default:
+      unreachable(condition);
+  }
+}

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -122,6 +122,9 @@ export const SUBQ_PREFIX = 'zsubq_';
 
 export const defaultFormat = {singular: false, relationships: {}} as const;
 
+export const systemSymbol = Symbol();
+export const newQuerySymbol = Symbol();
+
 export abstract class AbstractQuery<
   TSchema extends Schema,
   TTable extends keyof TSchema['tables'] & string,
@@ -133,12 +136,20 @@ export abstract class AbstractQuery<
   readonly #ast: AST;
   readonly format: Format;
   #hash: string = '';
+  readonly #system: System;
 
-  constructor(schema: TSchema, tableName: TTable, ast: AST, format: Format) {
+  constructor(
+    schema: TSchema,
+    tableName: TTable,
+    ast: AST,
+    format: Format,
+    system: System,
+  ) {
     this.#schema = schema;
     this.#tableName = tableName;
     this.#ast = ast;
     this.format = format;
+    this.#system = system;
   }
 
   get [astSymbol](): AST {
@@ -152,10 +163,8 @@ export abstract class AbstractQuery<
     return this.#hash;
   }
 
-  protected abstract _system: System;
-
   // TODO(arv): Put this in the delegate?
-  protected abstract _newQuery<
+  protected abstract [newQuerySymbol]<
     TSchema extends Schema,
     TTable extends keyof TSchema['tables'] & string,
     TReturn,
@@ -167,7 +176,7 @@ export abstract class AbstractQuery<
   ): AbstractQuery<TSchema, TTable, TReturn>;
 
   one(): Query<TSchema, TTable, TReturn | undefined> {
-    return this._newQuery(
+    return this[newQuerySymbol](
       this.#schema,
       this.#tableName,
       {
@@ -200,7 +209,7 @@ export abstract class AbstractQuery<
     assert(related, 'Invalid relationship');
     if (isOneHop(related)) {
       const {destSchema, destField, sourceField, cardinality} = related[0];
-      let q: AnyQuery = this._newQuery(
+      let q: AnyQuery = this[newQuerySymbol](
         this.#schema,
         destSchema,
         {
@@ -229,7 +238,7 @@ export abstract class AbstractQuery<
         'The source and destination of a relationship must have the same number of fields',
       );
 
-      return this._newQuery(
+      return this[newQuerySymbol](
         this.#schema,
         this.#tableName,
         {
@@ -237,7 +246,7 @@ export abstract class AbstractQuery<
           related: [
             ...(this.#ast.related ?? []),
             {
-              system: this._system,
+              system: this.#system,
               correlation: {
                 parentField: sourceField,
                 childField: destField,
@@ -264,7 +273,7 @@ export abstract class AbstractQuery<
       const {destSchema} = secondRelation;
       const junctionSchema = firstRelation.destSchema;
       const sq = cb(
-        this._newQuery(
+        this[newQuerySymbol](
           this.#schema,
           destSchema,
           {
@@ -283,7 +292,7 @@ export abstract class AbstractQuery<
       assert(isCompoundKey(secondRelation.sourceField), 'Invalid relationship');
       assert(isCompoundKey(secondRelation.destField), 'Invalid relationship');
 
-      return this._newQuery(
+      return this[newQuerySymbol](
         this.#schema,
         this.#tableName,
         {
@@ -291,7 +300,7 @@ export abstract class AbstractQuery<
           related: [
             ...(this.#ast.related ?? []),
             {
-              system: this._system,
+              system: this.#system,
               correlation: {
                 parentField: firstRelation.sourceField,
                 childField: firstRelation.destField,
@@ -306,7 +315,7 @@ export abstract class AbstractQuery<
                 ),
                 related: [
                   {
-                    system: this._system,
+                    system: this.#system,
                     correlation: {
                       parentField: secondRelation.sourceField,
                       childField: secondRelation.destField,
@@ -358,7 +367,7 @@ export abstract class AbstractQuery<
       cond = and(existingWhere, cond);
     }
 
-    return this._newQuery(
+    return this[newQuerySymbol](
       this.#schema,
       this.#tableName,
       {
@@ -373,7 +382,7 @@ export abstract class AbstractQuery<
     row: Partial<PullRow<TTable, TSchema>>,
     opts?: {inclusive: boolean} | undefined,
   ): Query<TSchema, TTable, TReturn> {
-    return this._newQuery(
+    return this[newQuerySymbol](
       this.#schema,
       this.#tableName,
       {
@@ -395,7 +404,7 @@ export abstract class AbstractQuery<
       throw new Error('Limit must be an integer');
     }
 
-    return this._newQuery(
+    return this[newQuerySymbol](
       this.#schema,
       this.#tableName,
       {
@@ -410,7 +419,7 @@ export abstract class AbstractQuery<
     field: TSelector,
     direction: 'asc' | 'desc',
   ): Query<TSchema, TTable, TReturn> {
-    return this._newQuery(
+    return this[newQuerySymbol](
       this.#schema,
       this.#tableName,
       {
@@ -434,7 +443,7 @@ export abstract class AbstractQuery<
       assert(isCompoundKey(destField), 'Invalid relationship');
 
       const sq = cb(
-        this._newQuery(
+        this[newQuerySymbol](
           this.#schema,
           destSchema,
           {
@@ -447,7 +456,7 @@ export abstract class AbstractQuery<
       return {
         type: 'correlatedSubquery',
         related: {
-          system: this._system,
+          system: this.#system,
           correlation: {
             parentField: sourceField,
             childField: destField,
@@ -470,7 +479,7 @@ export abstract class AbstractQuery<
       const {destSchema} = secondRelation;
       const junctionSchema = firstRelation.destSchema;
       const queryToDest = cb(
-        this._newQuery(
+        this[newQuerySymbol](
           this.#schema,
           destSchema,
           {
@@ -484,7 +493,7 @@ export abstract class AbstractQuery<
       return {
         type: 'correlatedSubquery',
         related: {
-          system: this._system,
+          system: this.#system,
           correlation: {
             parentField: firstRelation.sourceField,
             childField: firstRelation.destField,
@@ -499,7 +508,7 @@ export abstract class AbstractQuery<
             where: {
               type: 'correlatedSubquery',
               related: {
-                system: this._system,
+                system: this.#system,
                 correlation: {
                   parentField: secondRelation.sourceField,
                   childField: secondRelation.destField,
@@ -600,17 +609,19 @@ export class QueryImpl<
     ast: AST,
     format: Format,
   ) {
-    super(schema, tableName, ast, format);
+    super(schema, tableName, ast, format, 'client');
     this.#delegate = delegate;
   }
-
-  protected readonly _system = 'client';
 
   get [completedAstSymbol](): AST {
     return this._completeAst();
   }
 
-  protected _newQuery<TSchema extends Schema, TTable extends string, TReturn>(
+  protected [newQuerySymbol]<
+    TSchema extends Schema,
+    TTable extends string,
+    TReturn,
+  >(
     schema: TSchema,
     tableName: TTable,
     ast: AST,

--- a/packages/zql/src/query/static-query.ts
+++ b/packages/zql/src/query/static-query.ts
@@ -2,7 +2,7 @@ import type {AST} from '../../../zero-protocol/src/ast.ts';
 import type {Schema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import type {Format} from '../ivm/view.ts';
 import {ExpressionBuilder} from './expression.ts';
-import {AbstractQuery, defaultFormat} from './query-impl.ts';
+import {AbstractQuery, defaultFormat, newQuerySymbol} from './query-impl.ts';
 import type {HumanReadable, PullRow, Query} from './query.ts';
 import type {TypedView} from './typed-view.ts';
 
@@ -31,9 +31,11 @@ export class StaticQuery<
     return new ExpressionBuilder(this._exists);
   }
 
-  protected readonly _system = 'permissions';
+  constructor(schema: TSchema, tableName: TTable, ast: AST, format: Format) {
+    super(schema, tableName, ast, format, 'permissions');
+  }
 
-  protected _newQuery<
+  protected [newQuerySymbol]<
     TSchema extends Schema,
     TTable extends keyof TSchema['tables'] & string,
     TReturn,


### PR DESCRIPTION
`NOT EXISTS` can't work reliably on client because:
- Zero only syncs a subset of data to the client
- Client can't distinguish between non-existent rows vs. non-synced rows
- Correct `NOT EXISTS` requires complete knowledge of data

Added `assertNoNotExists()` function to validate conditions and throw
errors when `NOT EXISTS` is used in client queries. Updated `query-impl.ts`
to check conditions after DNF conversion.

https://bugs.rocicorp.dev/issue/3438