### PR TITLE
chore(zero-cache): composite sink to keep console logs

### DIFF
--- a/packages/zero-cache/src/server/otel-log-sink.ts
+++ b/packages/zero-cache/src/server/otel-log-sink.ts
@@ -8,7 +8,7 @@ import {
 import type {Context, LogLevel, LogSink} from '@rocicorp/logger';
 import {errorOrObject} from './logging.ts';
 import {stringify} from '../types/bigint-json.ts';
-import {startOtel, type OtelEndpoints} from './start-otel.ts';
+import {startOtel, type OtelEndpoints} from './otel-start.ts';
 
 export class OtelLogSink implements LogSink {
   readonly #logger: Logger;
@@ -36,7 +36,7 @@ export class OtelLogSink implements LogSink {
 
     const payload: LogRecord = {
       severityNumber: toErrorNum(level),
-      severityText: level.toUpperCase(),
+      severityText: level,
       body: message,
       timestamp: Date.now() * 1_000_000, // nanoseconds
     };

--- a/packages/zero-cache/src/server/otel-start.ts
+++ b/packages/zero-cache/src/server/otel-start.ts
@@ -16,9 +16,7 @@ import {NoopMetricExporter} from '../../../otel/src/noop-metric-exporter.ts';
 import {version} from '../../../otel/src/version.ts';
 import {
   BatchLogRecordProcessor,
-  ConsoleLogRecordExporter,
   LoggerProvider,
-  SimpleLogRecordProcessor,
   type LogRecordProcessor,
 } from '@opentelemetry/sdk-logs';
 import {logs} from '@opentelemetry/api-logs';
@@ -51,15 +49,8 @@ export function startOtel(endpoints: OtelEndpoints) {
         url: endpoints.logCollector,
       }),
     );
-    const consoleProcessor = new SimpleLogRecordProcessor(
-      // TODO: we need to write a custom console log exporter to preserve
-      // our old format.
-      new ConsoleLogRecordExporter(),
-    );
     logRecordProcessors.push(processor);
-    logRecordProcessors.push(consoleProcessor);
     provider.addLogRecordProcessor(processor);
-    provider.addLogRecordProcessor(consoleProcessor);
     logs.setGlobalLoggerProvider(provider);
   }
 

--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -27,7 +27,7 @@ import {Subscription} from '../types/subscription.ts';
 import {replicaFileModeSchema, replicaFileName} from '../workers/replicator.ts';
 import {Syncer} from '../workers/syncer.ts';
 import {createLogContext} from './logging.ts';
-import {startOtel} from './start-otel.ts';
+import {startOtel} from './otel-start.ts';
 
 function randomID() {
   return randInt(1, Number.MAX_SAFE_INTEGER).toString(36);


### PR DESCRIPTION
We should still log to console even if the OTEL collector is up.

OTEL allows adding a console exporter but the log format is not the same as our prior format and would require some messaging to make it the same.

Seems easier to just do it this way.