### PR TITLE
fix(analyze-query): replace newlines with spaces in args for `bin-analyze.ts`

### DIFF
--- a/packages/analyze-query/src/bin-analyze.ts
+++ b/packages/analyze-query/src/bin-analyze.ts
@@ -117,7 +117,14 @@ const options = {
 };
 
 const config = normalizeZeroConfig(
-  parseOptions(options, process.argv.slice(2), ZERO_ENV_VAR_PREFIX),
+  parseOptions(
+    options,
+    // the command line parses drops all text after the first newline
+    // so we need to replace newlines with spaces
+    // before parsing
+    process.argv.slice(2).map(s => s.replaceAll('\n', ' ')),
+    ZERO_ENV_VAR_PREFIX,
+  ),
 );
 
 runtimeDebugFlags.trackRowsVended = true;


### PR DESCRIPTION
This definitely used to work but the command line parser is dropping any text after a newline. I tracked this down to being a bug inside the `commandLineArgs` library.

I did not see any options to enable multiline args.