### PR TITLE
feat!(zero-client): reject server mutator promise in all error cases

### DIFF
--- a/packages/zero-client/src/client/custom.test.ts
+++ b/packages/zero-client/src/client/custom.test.ts
@@ -462,7 +462,7 @@ describe('server results and keeping read queries', () => {
 
     await z.close();
 
-    expect(await close.server).toEqual({error: 'app'});
+    await expect(close.server).rejects.toEqual({error: 'app'});
   });
 
   test('changeDesiredQueries:remove is not sent while there are pending mutations', async () => {
@@ -571,7 +571,7 @@ describe('server results and keeping read queries', () => {
     messages.length = 0;
 
     await z.close();
-    expect(await close.server).toEqual({error: 'app'});
+    await expect(close.server).rejects.toEqual({error: 'app'});
   });
 });
 

--- a/packages/zero-client/src/client/custom.ts
+++ b/packages/zero-client/src/client/custom.ts
@@ -6,7 +6,7 @@ import {assert} from '../../../shared/src/asserts.ts';
 import type {ReadonlyJSONValue} from '../../../shared/src/json.ts';
 import {must} from '../../../shared/src/must.ts';
 import {emptyFunction} from '../../../shared/src/sentinels.ts';
-import type {MutationResult} from '../../../zero-protocol/src/push.ts';
+import type {MutationOk} from '../../../zero-protocol/src/push.ts';
 import type {Schema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import type {TableSchema} from '../../../zero-schema/src/table-schema.ts';
 import type {
@@ -41,7 +41,7 @@ export type CustomMutatorDefs<S extends Schema> = {
 };
 
 export type PromiseWithServerResult = Promise<void> & {
-  server: Promise<MutationResult>;
+  server: Promise<MutationOk>;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/zero-client/src/client/mutation-tracker.test.ts
+++ b/packages/zero-client/src/client/mutation-tracker.test.ts
@@ -50,7 +50,7 @@ describe('MutationTracker', () => {
     };
 
     tracker.processPushResponse(response);
-    expect(await serverPromise).toEqual({
+    await expect(serverPromise).rejects.toEqual({
       error: 'app',
       details: '',
     });
@@ -146,6 +146,10 @@ describe('MutationTracker', () => {
 
     const mutation2 = tracker.trackMutation();
     tracker.mutationIDAssigned(mutation2.ephemeralID, 2);
+
+    mutation2.serverPromise.catch(() => {
+      // expected
+    });
 
     const response: PushResponse = {
       mutations: [
@@ -261,6 +265,10 @@ describe('MutationTracker', () => {
     tracker.mutationIDAssigned(mutation3.ephemeralID, 3);
     const mutation4 = tracker.trackMutation();
     tracker.mutationIDAssigned(mutation4.ephemeralID, 4);
+
+    mutation4.serverPromise.catch(() => {
+      // expected
+    });
 
     tracker.processPushResponse({
       mutations: [


### PR DESCRIPTION
server errors used to resolve and client errors would reject.

now they both reject.