### PR TITLE
chore(zero-protocol): add vitest config

### DIFF
--- a/packages/zero-protocol/vitest.config.ts
+++ b/packages/zero-protocol/vitest.config.ts
@@ -1,0 +1,1 @@
+export {default} from '../shared/src/tool/vitest-config.ts';


### PR DESCRIPTION
It was missing making npm run test not work from the packages/zero-protocol directory.