### PR TITLE
chore(bench): remove setup and teardown, invert metric

### DIFF
--- a/packages/shared/src/tool/vitest-perf-json-to-bmf.ts
+++ b/packages/shared/src/tool/vitest-perf-json-to-bmf.ts
@@ -166,10 +166,14 @@ function convertVitestToBMF(vitestOutput: VitestOutput): BMFMetric {
         const metricName = `${group.fullName} > ${benchmark.name}`;
 
         bmf[metricName] = {
+          // benchmark outputs are the time in milliseconds it took to run.
+          // If we want to convert to throughput, we need to divide 1000 by the time.
+          // This is the inverse of the time taken.
+          // So if it took 100ms to run, the throughput is 1000 / 100 = 10
           throughput: {
-            value: benchmark.mean,
-            ['lower_value']: benchmark.min,
-            ['upper_value']: benchmark.max,
+            value: 1000 / benchmark.mean,
+            ['lower_value']: 1000 / benchmark.min,
+            ['upper_value']: 1000 / benchmark.max,
           },
         };
       });

--- a/packages/zero-client/src/client/zero.bench.ts
+++ b/packages/zero-client/src/client/zero.bench.ts
@@ -26,77 +26,75 @@ const schema = {
   },
   relationships: {},
 } as const;
-type Schema = typeof schema;
 type UserRow = Row<typeof user>;
 
 const userID = 'test-user-id-' + Math.random();
 
-async function withZero(
-  f: (z: Zero<Schema>) => Promise<void>,
-  persist = false,
-): Promise<void> {
-  const z = new Zero({
-    schema,
-    server: null,
-    userID,
-    kvStore: 'idb',
-  });
-  await f(z);
-  if (persist) {
-    await getInternalReplicacheImplForTesting(z).persist();
-  }
-  await z.close();
-}
 const N = 1_000;
+
+const z = new Zero({
+  schema,
+  server: null,
+  userID,
+  kvStore: 'idb',
+});
+await z.mutateBatch(async m => {
+  for (let i = 0; i < N; i++) {
+    await m.user.insert({
+      a: i,
+      b: i,
+      c: i,
+      d: i,
+      e: i,
+      f: i,
+      g: i,
+      h: i,
+      i,
+      j: i,
+    });
+  }
+});
+await getInternalReplicacheImplForTesting(z).persist();
 
 describe('basics', () => {
   bench(
     `All ${N} rows x 10 columns (numbers)`,
-    () =>
-      withZero(async z => {
-        const {promise, resolve} = resolver<readonly UserRow[]>();
-        const m = z.query.user.materialize();
-        m.addListener(data => {
-          if (data.length === N) {
-            resolve(data as readonly UserRow[]);
-          }
-        });
-        const rows = await promise;
-        expect(rows.reduce((sum, row) => sum + row.a, 0)).toBe(
-          ((N - 1) / 2) * N,
-        );
-        m.destroy();
-      }),
+    async () => {
+      const {promise, resolve} = resolver<readonly UserRow[]>();
+      const m = z.query.user.materialize();
+      m.addListener(data => {
+        if (data.length === N) {
+          resolve(data as readonly UserRow[]);
+        }
+      });
+      const rows = await promise;
+      expect(rows.reduce((sum, row) => sum + row.a, 0)).toBe(((N - 1) / 2) * N);
+      m.destroy();
+    },
     {
       throws: true,
-      setup: () =>
-        withZero(async z => {
-          await z.mutateBatch(async m => {
-            for (let i = 0; i < N; i++) {
-              await m.user.insert({
-                a: i,
-                b: i,
-                c: i,
-                d: i,
-                e: i,
-                f: i,
-                g: i,
-                h: i,
-                i,
-                j: i,
-              });
-            }
-          });
-        }, true),
+    },
+  );
+});
 
-      teardown: () =>
-        withZero(async z => {
-          await z.mutateBatch(async m => {
-            for (let i = 0; i < N; i++) {
-              await m.user.delete({a: i});
-            }
-          });
-        }, true),
+describe('pk compare', () => {
+  bench(
+    `pk = N`,
+    async () => {
+      const {promise, resolve} = resolver<readonly UserRow[]>();
+      const value = N - 1;
+      const m = z.query.user.where('a', value).materialize();
+      m.addListener(data => {
+        if (data.length === 1) {
+          resolve(data as readonly UserRow[]);
+        }
+      });
+      const rows = await promise;
+      expect(rows[0].a).toBe(value);
+      m.destroy();
+    },
+    {
+      throws: true,
     },
   );
 });
@@ -104,51 +102,22 @@ describe('basics', () => {
 describe('with filter', () => {
   bench(
     `Lower rows ${N / 2} x 10 columns (numbers)`,
-    () =>
-      withZero(async z => {
-        const {promise, resolve} = resolver<readonly UserRow[]>();
-        const m = z.query.user.where('a', '<', N / 2).materialize();
-        m.addListener(data => {
-          if (data.length === N / 2) {
-            resolve(data as readonly UserRow[]);
-          }
-        });
-        const rows = await promise;
-        expect(rows.reduce((sum, row) => sum + row.a, 0)).toBe(
-          (((N / 2 - 1) / 2) * N) / 2,
-        );
-        m.destroy();
-      }),
+    async () => {
+      const {promise, resolve} = resolver<readonly UserRow[]>();
+      const m = z.query.user.where('a', '<', N / 2).materialize();
+      m.addListener(data => {
+        if (data.length === N / 2) {
+          resolve(data as readonly UserRow[]);
+        }
+      });
+      const rows = await promise;
+      expect(rows.reduce((sum, row) => sum + row.a, 0)).toBe(
+        (((N / 2 - 1) / 2) * N) / 2,
+      );
+      m.destroy();
+    },
     {
       throws: true,
-      setup: () =>
-        withZero(async z => {
-          await z.mutateBatch(async m => {
-            for (let i = 0; i < N; i++) {
-              await m.user.insert({
-                a: i,
-                b: i,
-                c: i,
-                d: i,
-                e: i,
-                f: i,
-                g: i,
-                h: i,
-                i,
-                j: i,
-              });
-            }
-          });
-        }, true),
-
-      teardown: () =>
-        withZero(async z => {
-          await z.mutateBatch(async m => {
-            for (let i = 0; i < N; i++) {
-              await m.user.delete({a: i});
-            }
-          });
-        }, true),
     },
   );
 });


### PR DESCRIPTION
For some reason `setup` time is contributing to the total benchmark time giving us bad results. Doing setup once results in 10x faster benchmarks as we're now only measuring the thing we intend to measure.

More importantly, the benchmarks now provide meaningful information when changing the value of `N`. Before, the time was dominated by setup time so it was hard to figure out how a query scaled as `N` changed.

Discovered this while investigating a user report: https://bugs.rocicorp.dev/issue/3793

Before:
![CleanShot 2025-05-02 at 13 08 46](https://github.com/user-attachments/assets/cc1b7c5c-9596-415c-b75f-468e85258583)


After:
![CleanShot 2025-05-02 at 13 07 19](https://github.com/user-attachments/assets/8ca8e364-7a00-4f7d-9500-c86f6c830580)


# Invert Metric
https://github.com/rocicorp/mono/pull/4313/commits/91c4058dd538b765f504a069f9f08042c37abe87

Bencher expects throughput (e.g., QPS). Vitest outputs a timing per run. Divide 1 second by time per run to get QPS.

