### PR TITLE
chore(zero-cache): make the pg connect timeout configurable via PGCONNECT_TIMEOUT

### DIFF
--- a/packages/zero-cache/src/types/pg.ts
+++ b/packages/zero-cache/src/types/pg.ts
@@ -3,6 +3,7 @@ import {OID} from '@postgresql-typed/oids';
 import {LogContext} from '@rocicorp/logger';
 import postgres, {type Notice, type PostgresType} from 'postgres';
 import {randInt} from '../../../shared/src/rand.ts';
+import type {ValueType} from '../../../zero-protocol/src/client-schema.ts';
 import {BigIntJSON, type JSONValue} from './bigint-json.ts';
 import {
   DATE,
@@ -12,7 +13,6 @@ import {
   TIMESTAMP,
   TIMESTAMPTZ,
 } from './pg-types.ts';
-import type {ValueType} from '../../../zero-protocol/src/client-schema.ts';
 
 const WITH_HH_MM_TIMEZONE = /[+-]\d\d:\d\d$/;
 const WITH_HH_TIMEZONE = /[+-]\d\d$/;
@@ -179,7 +179,6 @@ export function pgClient(
     ...postgresTypeConfig(jsonAsString),
     onnotice,
     ['max_lifetime']: maxLifetimeSeconds,
-    ['connect_timeout']: 60, // scale-from-zero dbs need more than 30 seconds
     ssl: ssl === 'disable' || ssl === 'false' ? false : (ssl as 'prefer'),
     ...options,
   });

--- a/prod/sst/sst.config.ts
+++ b/prod/sst/sst.config.ts
@@ -65,6 +65,7 @@ export default $config({
       ZERO_LITESTREAM_BACKUP_URL: $interpolate`s3://${replicationBucket.name}/backup/20250319-00`,
       ZERO_IMAGE_URL: process.env.ZERO_IMAGE_URL!,
       ZERO_APP_ID: process.env.ZERO_APP_ID || 'zero',
+      PGCONNECT_TIMEOUT: '60', // scale-from-zero dbs need more than 30 seconds
     };
 
     const ecsVolumeRole = IS_EBS_STAGE


### PR DESCRIPTION
Stop hardcoding the `connect_timeout` on the postgres.js client so that it can be dynamically configured via the `PGCONNECT_TIMEOUT` environment variable, as per https://github.com/porsager/postgres?tab=readme-ov-file#environmental-variables

