### PR TITLE
chore(zero-cache): handle pathological change-source disconnects

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -313,7 +313,7 @@ class PostgresChangeSource implements ChangeSource {
     const slotExpression = replicationSlotExpression(this.#shard);
     const legacySlotName = legacyReplicationSlot(this.#shard);
 
-    // Note: slot_name <= slotToKeep uses a string compare of the millisecond
+    // Note: `slot_name <= slotToKeep` uses a string compare of the millisecond
     // timestamp, which works until it exceeds 13 digits (sometime in 2286).
     const result = await sql<{slot: string; pid: string | null}[]>`
     SELECT slot_name as slot, pg_terminate_backend(active_pid), active_pid as pid

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -298,9 +298,13 @@ class PostgresChangeSource implements ChangeSource {
   }
 
   /**
-   * Stops all replication slots associated with this shard, and returns
+   * Stops replication slots associated with this shard, and returns
    * a `cleanup` task that drops any slot other than the specified
    * `slotToKeep`.
+   *
+   * Note that replication slots created after `slotToKeep` (as indicated by
+   * the timestamp suffix) are preserved, as those are newly syncing replicas
+   * that will soon take over the slot.
    */
   async #stopExistingReplicationSlotSubscribers(
     sql: PostgresDB,
@@ -309,16 +313,18 @@ class PostgresChangeSource implements ChangeSource {
     const slotExpression = replicationSlotExpression(this.#shard);
     const legacySlotName = legacyReplicationSlot(this.#shard);
 
+    // Note: slot_name <= slotToKeep uses a string compare of the millisecond
+    // timestamp, which works until it exceeds 13 digits (sometime in 2286).
     const result = await sql<{slot: string; pid: string | null}[]>`
     SELECT slot_name as slot, pg_terminate_backend(active_pid), active_pid as pid
       FROM pg_replication_slots 
-      WHERE slot_name LIKE ${slotExpression} OR slot_name = ${legacySlotName}`;
+      WHERE (slot_name LIKE ${slotExpression} OR slot_name = ${legacySlotName})
+            AND slot_name <= ${slotToKeep}`;
     if (result.length === 0) {
-      // Note: This should not happen as it is checked at initialization time,
-      //       but it is technically possible for the replication slot to be
-      //       dropped (e.g. manually).
       throw new AbortError(
-        `replication slot ${slotToKeep} is missing. Delete the replica and resync.`,
+        `replication slot ${slotToKeep} is missing. A different ` +
+          `replication-manager should now be running on a new ` +
+          `replication slot.`,
       );
     }
     // Clean up the replicas table.


### PR DESCRIPTION
In the case of a stuck Postgres change-source, which has been observed with a Neon upstream (example logs below), 
the replication-manager will continually kill other replication slots, preventing a new resyncing instance from taking over (as its replication slot continually gets deleted by this looping change-streamer).

Change the replication slot logic to only stop-and-drop _new_ replication slots, which allows a newly syncing replication slot to eventually take over the problematic one.

```
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:02:58.007,INFO,change-streamer,change-streamer,retrying change-streamer in 25 ms,"{""level"":""INFO"",""worker"":""change-streamer"",""pid"":95,""component"":""change-streamer"",""code"":""CONNECTION_CLOSED"",""errno"":""CONNECTION_CLOSED"",""address"":[""ep-frosty-tree-a4ov7p1o.us-east-1.aws.neon.tech""],""port"":[5432],""name"":""Error"",""errorMsg"":""write CONNECTION_CLOSED ep-frosty-tree-a4ov7p1o.us-east-1.aws.neon.tech:5432"",""stack"":""Error: write CONNECTION_CLOSED ep-frosty-tree-a4ov7p1o.us-east-1.aws.neon.tech:5432\n    at TLSSocket.closed (file:///usr/local/lib/node_modules/@rocicorp/zero/node_modules/postgres/src/connection.js:438:57)\n    at TLSSocket.emit (node:events:530:35)\n    at node:net:343:12\n    at Socket.done (node:_tls_wrap:650:7)\n    at Object.onceWrapper (node:events:633:26)\n    at Socket.emit (node:events:530:35)\n    at TCP.<anonymous> (node:net:343:12)"",""message"":""retrying change-streamer in 25 ms""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:02:58.008,INFO,backup-replicator,replicator,aborting transaction 64rk0lig,"{""level"":""INFO"",""worker"":""backup-replicator"",""pid"":106,""component"":""replicator"",""serviceID"":""backup-replicator-106"",""message"":""aborting transaction 64rk0lig""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:02:58.122,INFO,change-streamer,change-source,starting replication stream@zeroshippercrm_0_1746149225902,"{""level"":""INFO"",""worker"":""change-streamer"",""pid"":95,""component"":""change-source"",""message"":""starting replication stream@zeroshippercrm_0_1746149225902""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:02:58.167,INFO,change-streamer,change-source,started replication stream@zeroshippercrm_0_1746149225902 from 64m27p08 (replicaVersion: 61qbmvug),"{""level"":""INFO"",""worker"":""change-streamer"",""pid"":95,""component"":""change-source"",""message"":""started replication stream@zeroshippercrm_0_1746149225902 from 64m27p08 (replicaVersion: 61qbmvug)""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:02:58.788,DEBUG,#1,,started worker,"{""level"":""DEBUG"",""worker"":""#1"",""pid"":95,""watermark"":""64rk0lig"",""message"":""started worker""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:03:09.050,DEBUG,change-streamer,change-source,closing idle upstream connection,"{""level"":""DEBUG"",""worker"":""change-streamer"",""pid"":95,""component"":""change-source"",""message"":""closing idle upstream connection""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:03:11.993,DEBUG,change-streamer,,rolling back transaction,"{""level"":""DEBUG"",""worker"":""change-streamer"",""pid"":95,""watermark"":""64rk0lig"",""name"":""RollbackSignal"",""message"":""rolling back transaction"",""errorMsg"":""rolling back transaction"",""stack"":""RollbackSignal: rolling back transaction\n    at TransactionPool.abort (file:///usr/local/lib/node_modules/@rocicorp/zero/out/zero-cache/src/db/transaction-pool.js:247:19)\n    at #processQueue (file:///usr/local/lib/node_modules/@rocicorp/zero/out/zero-cache/src/services/change-streamer/storer.js:186:33)\n    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at async Storer.run (file:///usr/local/lib/node_modules/@rocicorp/zero/out/zero-cache/src/services/change-streamer/storer.js:147:13)""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:04:23.188,DEBUG,change-streamer,,transaction pool done,"{""level"":""DEBUG"",""worker"":""change-streamer"",""pid"":95,""watermark"":""64rk0lig"",""message"":""transaction pool done""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:04:23.188,WARN,change-streamer,change-streamer,aborting interrupted transaction 64rk0lig,"{""level"":""WARN"",""worker"":""change-streamer"",""pid"":95,""component"":""change-streamer"",""message"":""aborting interrupted transaction 64rk0lig""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:04:23.188,INFO,change-streamer,change-streamer,retrying change-streamer in 25 ms,"{""level"":""INFO"",""worker"":""change-streamer"",""pid"":95,""component"":""change-streamer"",""code"":""CONNECTION_CLOSED"",""errno"":""CONNECTION_CLOSED"",""address"":[""ep-frosty-tree-a4ov7p1o.us-east-1.aws.neon.tech""],""port"":[5432],""name"":""Error"",""errorMsg"":""write CONNECTION_CLOSED ep-frosty-tree-a4ov7p1o.us-east-1.aws.neon.tech:5432"",""stack"":""Error: write CONNECTION_CLOSED ep-frosty-tree-a4ov7p1o.us-east-1.aws.neon.tech:5432\n    at TLSSocket.closed (file:///usr/local/lib/node_modules/@rocicorp/zero/node_modules/postgres/src/connection.js:438:57)\n    at TLSSocket.emit (node:events:530:35)\n    at node:net:343:12\n    at Socket.done (node:_tls_wrap:650:7)\n    at Object.onceWrapper (node:events:633:26)\n    at Socket.emit (node:events:530:35)\n    at TCP.<anonymous> (node:net:343:12)"",""message"":""retrying change-streamer in 25 ms""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:04:23.189,INFO,backup-replicator,replicator,aborting transaction 64rk0lig,"{""level"":""INFO"",""worker"":""backup-replicator"",""pid"":106,""component"":""replicator"",""serviceID"":""backup-replicator-106"",""message"":""aborting transaction 64rk0lig""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:04:23.263,INFO,change-streamer,change-source,starting replication stream@zeroshippercrm_0_1746149225902,"{""level"":""INFO"",""worker"":""change-streamer"",""pid"":95,""component"":""change-source"",""message"":""starting replication stream@zeroshippercrm_0_1746149225902""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:04:23.311,INFO,change-streamer,change-source,started replication stream@zeroshippercrm_0_1746149225902 from 64m27p08 (replicaVersion: 61qbmvug),"{""level"":""INFO"",""worker"":""change-streamer"",""pid"":95,""component"":""change-source"",""message"":""started replication stream@zeroshippercrm_0_1746149225902 from 64m27p08 (replicaVersion: 61qbmvug)""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:04:23.933,DEBUG,#1,,started worker,"{""level"":""DEBUG"",""worker"":""#1"",""pid"":95,""watermark"":""64rk0lig"",""message"":""started worker""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:04:34.223,DEBUG,change-streamer,change-source,closing idle upstream connection,"{""level"":""DEBUG"",""worker"":""change-streamer"",""pid"":95,""component"":""change-source"",""message"":""closing idle upstream connection""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:04:39.243,DEBUG,change-streamer,,rolling back transaction,"{""level"":""DEBUG"",""worker"":""change-streamer"",""pid"":95,""watermark"":""64rk0lig"",""name"":""RollbackSignal"",""message"":""rolling back transaction"",""errorMsg"":""rolling back transaction"",""stack"":""RollbackSignal: rolling back transaction\n    at TransactionPool.abort (file:///usr/local/lib/node_modules/@rocicorp/zero/out/zero-cache/src/db/transaction-pool.js:247:19)\n    at #processQueue (file:///usr/local/lib/node_modules/@rocicorp/zero/out/zero-cache/src/services/change-streamer/storer.js:186:33)\n    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at async Storer.run (file:///usr/local/lib/node_modules/@rocicorp/zero/out/zero-cache/src/services/change-streamer/storer.js:147:13)""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:05:58.886,DEBUG,change-streamer,,transaction pool done,"{""level"":""DEBUG"",""worker"":""change-streamer"",""pid"":95,""watermark"":""64rk0lig"",""message"":""transaction pool done""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:05:58.886,WARN,change-streamer,change-streamer,aborting interrupted transaction 64rk0lig,"{""level"":""WARN"",""worker"":""change-streamer"",""pid"":95,""component"":""change-streamer"",""message"":""aborting interrupted transaction 64rk0lig""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:05:58.886,INFO,change-streamer,change-streamer,retrying change-streamer in 25 ms,"{""level"":""INFO"",""worker"":""change-streamer"",""pid"":95,""component"":""change-streamer"",""code"":""CONNECTION_CLOSED"",""errno"":""CONNECTION_CLOSED"",""address"":[""ep-frosty-tree-a4ov7p1o.us-east-1.aws.neon.tech""],""port"":[5432],""name"":""Error"",""errorMsg"":""write CONNECTION_CLOSED ep-frosty-tree-a4ov7p1o.us-east-1.aws.neon.tech:5432"",""stack"":""Error: write CONNECTION_CLOSED ep-frosty-tree-a4ov7p1o.us-east-1.aws.neon.tech:5432\n    at TLSSocket.closed (file:///usr/local/lib/node_modules/@rocicorp/zero/node_modules/postgres/src/connection.js:438:57)\n    at TLSSocket.emit (node:events:530:35)\n    at node:net:343:12\n    at Socket.done (node:_tls_wrap:650:7)\n    at Object.onceWrapper (node:events:633:26)\n    at Socket.emit (node:events:530:35)\n    at TCP.<anonymous> (node:net:343:12)"",""message"":""retrying change-streamer in 25 ms""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:05:58.886,INFO,backup-replicator,replicator,aborting transaction 64rk0lig,"{""level"":""INFO"",""worker"":""backup-replicator"",""pid"":106,""component"":""replicator"",""serviceID"":""backup-replicator-106"",""message"":""aborting transaction 64rk0lig""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:05:59.055,INFO,change-streamer,change-source,starting replication stream@zeroshippercrm_0_1746149225902,"{""level"":""INFO"",""worker"":""change-streamer"",""pid"":95,""component"":""change-source"",""message"":""starting replication stream@zeroshippercrm_0_1746149225902""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:05:59.096,INFO,change-streamer,change-source,started replication stream@zeroshippercrm_0_1746149225902 from 64m27p08 (replicaVersion: 61qbmvug),"{""level"":""INFO"",""worker"":""change-streamer"",""pid"":95,""component"":""change-source"",""message"":""started replication stream@zeroshippercrm_0_1746149225902 from 64m27p08 (replicaVersion: 61qbmvug)""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:05:59.714,DEBUG,#1,,started worker,"{""level"":""DEBUG"",""worker"":""#1"",""pid"":95,""watermark"":""64rk0lig"",""message"":""started worker""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:06:09.979,DEBUG,change-streamer,change-source,closing idle upstream connection,"{""level"":""DEBUG"",""worker"":""change-streamer"",""pid"":95,""component"":""change-source"",""message"":""closing idle upstream connection""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:06:11.989,DEBUG,change-streamer,,rolling back transaction,"{""level"":""DEBUG"",""worker"":""change-streamer"",""pid"":95,""watermark"":""64rk0lig"",""name"":""RollbackSignal"",""message"":""rolling back transaction"",""errorMsg"":""rolling back transaction"",""stack"":""RollbackSignal: rolling back transaction\n    at TransactionPool.abort (file:///usr/local/lib/node_modules/@rocicorp/zero/out/zero-cache/src/db/transaction-pool.js:247:19)\n    at #processQueue (file:///usr/local/lib/node_modules/@rocicorp/zero/out/zero-cache/src/services/change-streamer/storer.js:186:33)\n    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at async Storer.run (file:///usr/local/lib/node_modules/@rocicorp/zero/out/zero-cache/src/services/change-streamer/storer.js:147:13)""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:07:14.212,DEBUG,change-streamer,,transaction pool done,"{""level"":""DEBUG"",""worker"":""change-streamer"",""pid"":95,""watermark"":""64rk0lig"",""message"":""transaction pool done""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:07:14.212,WARN,change-streamer,change-streamer,aborting interrupted transaction 64rk0lig,"{""level"":""WARN"",""worker"":""change-streamer"",""pid"":95,""component"":""change-streamer"",""message"":""aborting interrupted transaction 64rk0lig""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:07:14.212,INFO,change-streamer,change-streamer,retrying change-streamer in 25 ms,"{""level"":""INFO"",""worker"":""change-streamer"",""pid"":95,""component"":""change-streamer"",""code"":""CONNECTION_CLOSED"",""errno"":""CONNECTION_CLOSED"",""address"":[""ep-frosty-tree-a4ov7p1o.us-east-1.aws.neon.tech""],""port"":[5432],""name"":""Error"",""errorMsg"":""write CONNECTION_CLOSED ep-frosty-tree-a4ov7p1o.us-east-1.aws.neon.tech:5432"",""stack"":""Error: write CONNECTION_CLOSED ep-frosty-tree-a4ov7p1o.us-east-1.aws.neon.tech:5432\n    at TLSSocket.closed (file:///usr/local/lib/node_modules/@rocicorp/zero/node_modules/postgres/src/connection.js:438:57)\n    at TLSSocket.emit (node:events:530:35)\n    at node:net:343:12\n    at Socket.done (node:_tls_wrap:650:7)\n    at Object.onceWrapper (node:events:633:26)\n    at Socket.emit (node:events:530:35)\n    at TCP.<anonymous> (node:net:343:12)"",""message"":""retrying change-streamer in 25 ms""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:07:14.213,INFO,backup-replicator,replicator,aborting transaction 64rk0lig,"{""level"":""INFO"",""worker"":""backup-replicator"",""pid"":106,""component"":""replicator"",""serviceID"":""backup-replicator-106"",""message"":""aborting transaction 64rk0lig""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:07:14.456,INFO,change-streamer,change-source,starting replication stream@zeroshippercrm_0_1746149225902,"{""level"":""INFO"",""worker"":""change-streamer"",""pid"":95,""component"":""change-source"",""message"":""starting replication stream@zeroshippercrm_0_1746149225902""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:07:14.496,INFO,change-streamer,change-source,started replication stream@zeroshippercrm_0_1746149225902 from 64m27p08 (replicaVersion: 61qbmvug),"{""level"":""INFO"",""worker"":""change-streamer"",""pid"":95,""component"":""change-source"",""message"":""started replication stream@zeroshippercrm_0_1746149225902 from 64m27p08 (replicaVersion: 61qbmvug)""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:07:15.149,DEBUG,#1,,started worker,"{""level"":""DEBUG"",""worker"":""#1"",""pid"":95,""watermark"":""64rk0lig"",""message"":""started worker""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:07:25.362,DEBUG,change-streamer,change-source,closing idle upstream connection,"{""level"":""DEBUG"",""worker"":""change-streamer"",""pid"":95,""component"":""change-source"",""message"":""closing idle upstream connection""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:07:29.010,DEBUG,change-streamer,,rolling back transaction,"{""level"":""DEBUG"",""worker"":""change-streamer"",""pid"":95,""watermark"":""64rk0lig"",""name"":""RollbackSignal"",""message"":""rolling back transaction"",""errorMsg"":""rolling back transaction"",""stack"":""RollbackSignal: rolling back transaction\n    at TransactionPool.abort (file:///usr/local/lib/node_modules/@rocicorp/zero/out/zero-cache/src/db/transaction-pool.js:247:19)\n    at #processQueue (file:///usr/local/lib/node_modules/@rocicorp/zero/out/zero-cache/src/services/change-streamer/storer.js:186:33)\n    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at async Storer.run (file:///usr/local/lib/node_modules/@rocicorp/zero/out/zero-cache/src/services/change-streamer/storer.js:147:13)""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:08:09.606,DEBUG,change-streamer,,transaction pool done,"{""level"":""DEBUG"",""worker"":""change-streamer"",""pid"":95,""watermark"":""64rk0lig"",""message"":""transaction pool done""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:08:09.606,WARN,change-streamer,change-streamer,aborting interrupted transaction 64rk0lig,"{""level"":""WARN"",""worker"":""change-streamer"",""pid"":95,""component"":""change-streamer"",""message"":""aborting interrupted transaction 64rk0lig""}
",/service/replication-manager/abff0535675e4d3bbbd3d00313e12394
2025-05-03 18:08:09.607,INFO,change-streamer,change-streamer,retrying change-streamer in 25 ms,"{""level"":""INFO"",""worker"":""change-streamer"",""pid"":95,""component"":""change-streamer"",""code"":""CONNECTION_CLOSED"",""errno"":""CONNECTION_CLOSED"",""address"":[""ep-frosty-tree-a4ov7p1o.us-east-1.aws.neon.tech""],""port"":[5432],""name"":""Error"",""errorMsg"":""write CONNECTION_CLOSED ep-frosty-tree-a4ov7p1o.us-east-1.aws.neon.tech:5432"",""stack"":""Error: write CONNECTION_CLOSED ep-frosty-tree-a4ov7p1o.us-east-1.aws.neon.tech:5432\n    at TLSSocket.closed (file:///usr/local/lib/node_modules/@rocicorp/zero/node_modules/postgres/src/connection.js:438:57)\n    at TLSSocket.emit (node:events:530:35)\n    at node:net:343:12\n    at Socket.done (node:_tls_wrap:650:7)\n    at Object.onceWrapper (node:events:633:26)\n    at Socket.emit (node:events:530:35)\n    at TCP.<anonymous> (node:net:343:12)"",""message"":""retrying change-streamer in 25 ms""}
```
