### PR TITLE
fix(zero-cache): catch exceptions during handle-close

### DIFF
--- a/packages/zero-cache/src/workers/connection.ts
+++ b/packages/zero-cache/src/workers/connection.ts
@@ -253,9 +253,13 @@ export class Connection {
         return;
       }
 
-      const result = await this.#messageHandler.handleMessage(msg);
-      for (const r of result) {
-        this.#handleMessageResult(r);
+      try {
+        const result = await this.#messageHandler.handleMessage(msg);
+        for (const r of result) {
+          this.#handleMessageResult(r);
+        }
+      } catch (e) {
+        this.#lc.warn?.(`error while handling close connection`, e);
       }
     }
 


### PR DESCRIPTION
User report: 

https://discord.com/channels/830183651022471199/1367957671621296190/1367958626488160337

This may be the (other?) uncaught exception that can kill the server.