### PR TITLE
fix(zql): O(logn) point queries

### DIFF
--- a/packages/zql-integration-tests/src/chinook/chinook.pg-test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook.pg-test.ts
@@ -26,7 +26,6 @@ test.each(
     {
       suiteName: 'compiler_chinook',
       pgContent,
-      only: 'In operator',
       zqlSchema: schema,
       setRawData: r => {
         data = r;
@@ -174,6 +173,22 @@ test.each(
             .limit(10),
       },
     ],
+    // primary key compare for each table
+    (() =>
+      tables.map(
+        table =>
+          ({
+            name: `${table} pk lookup`,
+            createQuery: q => {
+              const pk = schema.tables[table].primaryKey;
+              let ret = q[table] as AnyQuery;
+              for (const column of pk) {
+                ret = ret.where(column, '=', 1);
+              }
+              return ret;
+            },
+          }) as const,
+      ))(),
     // compare against primary key for each operator
     (() =>
       operators.map(

--- a/packages/zql/src/ivm/constraint.test.ts
+++ b/packages/zql/src/ivm/constraint.test.ts
@@ -1,0 +1,352 @@
+import {describe, test, expect} from 'vitest';
+import {
+  pullSimpleAndComponents,
+  primaryKeyConstraintFromFilters,
+} from './constraint.ts';
+import type {SimpleOperator} from '../../../zero-protocol/src/ast.ts';
+
+describe('constraint', () => {
+  describe('pullSimpleAndComponents', () => {
+    test.each([
+      {
+        name: 'pulls simple conditions from AND',
+        condition: {
+          type: 'and',
+          conditions: [
+            {
+              type: 'simple',
+              left: {type: 'column', name: 'id'},
+              op: '=',
+              right: {type: 'literal', value: 1},
+            },
+            {
+              type: 'simple',
+              left: {type: 'column', name: 'name'},
+              op: '=',
+              right: {type: 'literal', value: 'test'},
+            },
+          ],
+        } as const,
+        expected: [
+          {
+            type: 'simple',
+            left: {type: 'column', name: 'id'},
+            op: '=',
+            right: {type: 'literal', value: 1},
+          },
+          {
+            type: 'simple',
+            left: {type: 'column', name: 'name'},
+            op: '=',
+            right: {type: 'literal', value: 'test'},
+          },
+        ],
+      },
+      {
+        name: 'pulls from nested AND',
+        condition: {
+          type: 'and',
+          conditions: [
+            {
+              type: 'simple',
+              left: {type: 'column', name: 'id'},
+              op: '=',
+              right: {type: 'literal', value: 1},
+            },
+            {
+              type: 'and',
+              conditions: [
+                {
+                  type: 'simple',
+                  left: {type: 'column', name: 'name'},
+                  op: '=',
+                  right: {type: 'literal', value: 'test'},
+                },
+                {
+                  type: 'simple',
+                  left: {type: 'column', name: 'age'},
+                  op: '=',
+                  right: {type: 'literal', value: 30},
+                },
+              ],
+            },
+          ],
+        } as const,
+        expected: [
+          {
+            type: 'simple',
+            left: {type: 'column', name: 'id'},
+            op: '=',
+            right: {type: 'literal', value: 1},
+          },
+          {
+            type: 'simple',
+            left: {type: 'column', name: 'name'},
+            op: '=',
+            right: {type: 'literal', value: 'test'},
+          },
+          {
+            type: 'simple',
+            left: {type: 'column', name: 'age'},
+            op: '=',
+            right: {type: 'literal', value: 30},
+          },
+        ],
+      },
+      {
+        name: 'returns empty for OR at top level',
+        condition: {
+          type: 'or',
+          conditions: [
+            {
+              type: 'simple',
+              left: {type: 'column', name: 'id'},
+              op: '=',
+              right: {type: 'literal', value: 1},
+            },
+            {
+              type: 'simple',
+              left: {type: 'column', name: 'id'},
+              op: '=',
+              right: {type: 'literal', value: 2},
+            },
+          ],
+        } as const,
+        expected: [],
+      },
+      {
+        name: 'pulls from single condition OR',
+        condition: {
+          type: 'or',
+          conditions: [
+            {
+              type: 'simple',
+              left: {type: 'column', name: 'id'},
+              op: '=',
+              right: {type: 'literal', value: 1},
+            },
+          ],
+        } as const,
+        expected: [
+          {
+            type: 'simple',
+            left: {type: 'column', name: 'id'},
+            op: '=',
+            right: {type: 'literal', value: 1},
+          },
+        ],
+      },
+    ])('$name', ({condition, expected}) => {
+      const result = pullSimpleAndComponents(condition);
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('primaryKeyConstraintFromFilters', () => {
+    test.each([
+      {
+        name: 'returns undefined for no condition',
+        condition: undefined,
+        primary: ['id'] as const,
+        expected: undefined,
+      },
+      {
+        name: 'returns undefined for OR condition',
+        condition: {
+          type: 'or',
+          conditions: [
+            {
+              type: 'simple',
+              left: {type: 'column', name: 'id'},
+              op: '=',
+              right: {type: 'literal', value: 1},
+            },
+            {
+              type: 'simple',
+              left: {type: 'column', name: 'id'},
+              op: '=',
+              right: {type: 'literal', value: 2},
+            },
+          ],
+        } as const,
+        primary: ['id'] as const,
+        expected: undefined,
+      },
+      {
+        name: 'returns constraint for simple primary key lookup',
+        condition: {
+          type: 'simple',
+          left: {type: 'column', name: 'id'},
+          op: '=',
+          right: {type: 'literal', value: 1},
+        } as const,
+        primary: ['id'] as const,
+        expected: {id: 1},
+      },
+      {
+        name: 'returns constraint for composite primary key lookup',
+        condition: {
+          type: 'and',
+          conditions: [
+            {
+              type: 'simple',
+              left: {type: 'column', name: 'id'},
+              op: '=',
+              right: {type: 'literal', value: 1},
+            },
+            {
+              type: 'simple',
+              left: {type: 'column', name: 'tenant'},
+              op: '=',
+              right: {type: 'literal', value: 'test'},
+            },
+          ],
+        } as const,
+        primary: ['id', 'tenant'] as const,
+        expected: {id: 1, tenant: 'test'},
+      },
+      {
+        name: 'returns undefined for partial primary key',
+        condition: {
+          type: 'simple',
+          left: {type: 'column', name: 'id'},
+          op: '=',
+          right: {type: 'literal', value: 1},
+        } as const,
+        primary: ['id', 'tenant'] as const,
+        expected: undefined,
+      },
+      {
+        name: 'returns undefined for non-primary key columns',
+        condition: {
+          type: 'and',
+          conditions: [
+            {
+              type: 'simple',
+              left: {type: 'column', name: 'id'},
+              op: '=',
+              right: {type: 'literal', value: 1},
+            },
+            {
+              type: 'simple',
+              left: {type: 'column', name: 'name'},
+              op: '=',
+              right: {type: 'literal', value: 'test'},
+            },
+          ],
+        } as const,
+        primary: ['id'] as const,
+        expected: {id: 1},
+      },
+      {
+        name: 'handles nested AND conditions',
+        condition: {
+          type: 'and',
+          conditions: [
+            {
+              type: 'simple',
+              left: {type: 'column', name: 'id'},
+              op: '=',
+              right: {type: 'literal', value: 1},
+            },
+            {
+              type: 'and',
+              conditions: [
+                {
+                  type: 'simple',
+                  left: {type: 'column', name: 'tenant'},
+                  op: '=',
+                  right: {type: 'literal', value: 'test'},
+                },
+              ],
+            },
+          ],
+        } as const,
+        primary: ['id', 'tenant'] as const,
+        expected: {id: 1, tenant: 'test'},
+      },
+      {
+        name: 'handles nested AND with OR conditions',
+        condition: {
+          type: 'and',
+          conditions: [
+            {
+              type: 'simple',
+              left: {type: 'column', name: 'id'},
+              op: '=',
+              right: {type: 'literal', value: 1},
+            },
+            {
+              type: 'and',
+              conditions: [
+                {
+                  type: 'simple',
+                  left: {type: 'column', name: 'tenant'},
+                  op: '=',
+                  right: {type: 'literal', value: 'test'},
+                },
+                {
+                  type: 'or',
+                  conditions: [
+                    {
+                      type: 'simple',
+                      left: {type: 'column', name: 'status'},
+                      op: '=',
+                      right: {type: 'literal', value: 'active'},
+                    },
+                    {
+                      type: 'simple',
+                      left: {type: 'column', name: 'status'},
+                      op: '=',
+                      right: {type: 'literal', value: 'pending'},
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        } as const,
+        primary: ['id', 'tenant'] as const,
+        expected: {id: 1, tenant: 'test'},
+      },
+    ])('$name', ({condition, primary, expected}) => {
+      const result = primaryKeyConstraintFromFilters(condition, primary);
+      expect(result).toEqual(expected);
+    });
+  });
+});
+
+test('returns undefined for operators other than equality', () => {
+  const operators: SimpleOperator[] = [
+    '>',
+    '<',
+    '>=',
+    '<=',
+    '!=',
+    'LIKE',
+    'NOT LIKE',
+    'ILIKE',
+    'NOT ILIKE',
+    'IN',
+    'NOT IN',
+    'IS',
+    'IS NOT',
+  ];
+
+  for (const op of operators) {
+    const condition = {
+      type: 'simple',
+      left: {type: 'column', name: 'id'},
+      op,
+      right: {
+        type: 'literal',
+        value: op === 'IN' || op === 'NOT IN' ? [1, 2, 3] : 1,
+      },
+    } as const;
+
+    const primary = ['id'] as const;
+    const result = primaryKeyConstraintFromFilters(condition, primary);
+
+    expect(result).toBeUndefined();
+  }
+});

--- a/packages/zql/src/query/test/util.ts
+++ b/packages/zql/src/query/test/util.ts
@@ -1,11 +1,12 @@
 import type {Faker} from '@faker-js/faker';
 import type {ValueType} from '../../../../zero-schema/src/table-schema.ts';
 import type {Query} from '../query.ts';
+import type {Schema} from '../../../../zero-schema/src/builder/schema-builder.ts';
 
 export type Rng = () => number;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AnyQuery = Query<any, any, any>;
+export type AnyQuery = Query<Schema, string, any>;
 
 export function selectRandom<T>(rng: Rng, values: readonly T[]): T {
   return values[Math.floor(rng() * values.length)];


### PR DESCRIPTION
No more full table scans to do a point query by primary key on the client.


https://bugs.rocicorp.dev/issue/3793

Before:
![CleanShot 2025-05-05 at 20 53 33@2x](https://github.com/user-attachments/assets/0652f220-5e4b-4d66-ba0d-071414404a44)

After:
![CleanShot 2025-05-05 at 14 33 37](https://github.com/user-attachments/assets/f310a7bb-a339-4a4e-8238-05001a2faff7)
