### PR TITLE
chore(zql): fix chinook tests

### DIFF
--- a/packages/zero-protocol/src/ast.test.ts
+++ b/packages/zero-protocol/src/ast.test.ts
@@ -606,6 +606,6 @@ test('protocol version', () => {
   // If this test fails because the AST schema has changed such that
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
-  expect(hash).toEqual('2zzy9s2lcdcms');
+  expect(hash).toEqual('1c228prd1v53r');
   expect(PROTOCOL_VERSION).toEqual(16);
 });

--- a/packages/zero-protocol/src/ast.ts
+++ b/packages/zero-protocol/src/ast.ts
@@ -22,7 +22,7 @@ const orderingElementSchema = v.readonly(
 );
 
 export const orderingSchema = v.readonlyArray(orderingElementSchema);
-export type System = 'permissions' | 'client';
+export type System = 'permissions' | 'client' | 'test';
 
 export const primitiveSchema = v.union(
   v.string(),
@@ -173,7 +173,9 @@ const correlationSchema = v.readonlyObject({
 export const correlatedSubquerySchemaOmitSubquery = v.readonlyObject({
   correlation: correlationSchema,
   hidden: v.boolean().optional(),
-  system: v.union(v.literal('permissions'), v.literal('client')).optional(),
+  system: v
+    .union(v.literal('permissions'), v.literal('client'), v.literal('test'))
+    .optional(),
 });
 
 export const correlatedSubquerySchema: v.Type<CorrelatedSubquery> =

--- a/packages/zero-protocol/src/protocol-version.test.ts
+++ b/packages/zero-protocol/src/protocol-version.test.ts
@@ -11,6 +11,6 @@ test('protocol version', () => {
   // If this test fails upstream or downstream schema has changed such that
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
-  expect(hash).toEqual('gmhjpmamj2r4');
+  expect(hash).toEqual('3yg0w7bfg9f7');
   expect(PROTOCOL_VERSION).toEqual(16);
 });

--- a/packages/zql-integration-tests/src/helpers/runner.ts
+++ b/packages/zql-integration-tests/src/helpers/runner.ts
@@ -19,7 +19,7 @@ import type {DBTransaction} from '../../../zql/src/mutate/custom.ts';
 import {
   ast,
   defaultFormat,
-  newQuery,
+  QueryImpl,
   type QueryDelegate,
 } from '../../../zql/src/query/query-impl.ts';
 import type {Query} from '../../../zql/src/query/query.ts';
@@ -223,8 +223,22 @@ function makeQueries<TSchema extends Schema>(
       {table},
       defaultFormat,
     );
-    ret.memory[table] = newQuery(delegates.memory, schema, table);
-    ret.sqlite[table] = newQuery(delegates.sqlite, schema, table);
+    ret.memory[table] = new QueryImpl(
+      delegates.memory,
+      schema,
+      table,
+      {table},
+      defaultFormat,
+      'test',
+    );
+    ret.sqlite[table] = new QueryImpl(
+      delegates.sqlite,
+      schema,
+      table,
+      {table},
+      defaultFormat,
+      'test',
+    );
   });
 
   return ret as QueriesBySource<TSchema>;

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -609,6 +609,7 @@ export class QueryImpl<
   TReturn = PullRow<TTable, TSchema>,
 > extends AbstractQuery<TSchema, TTable, TReturn> {
   readonly #delegate: QueryDelegate;
+  readonly #system: System;
 
   constructor(
     delegate: QueryDelegate,
@@ -616,8 +617,10 @@ export class QueryImpl<
     tableName: TTable,
     ast: AST,
     format: Format,
+    system: System = 'client',
   ) {
-    super(schema, tableName, ast, format, 'client');
+    super(schema, tableName, ast, format, system);
+    this.#system = system;
     this.#delegate = delegate;
   }
 
@@ -635,7 +638,14 @@ export class QueryImpl<
     ast: AST,
     format: Format,
   ): QueryImpl<TSchema, TTable, TReturn> {
-    return new QueryImpl(this.#delegate, schema, tableName, ast, format);
+    return new QueryImpl(
+      this.#delegate,
+      schema,
+      tableName,
+      ast,
+      format,
+      this.#system,
+    );
   }
 
   materialize<T>(


### PR DESCRIPTION
`not(exists(` should be testable as it is used on the server.