### PR TITLE
chore(zero-cache): consolidate config normalization logic into one place

### DIFF
--- a/packages/analyze-query/src/bin-analyze.ts
+++ b/packages/analyze-query/src/bin-analyze.ts
@@ -11,7 +11,6 @@ import * as v from '../../shared/src/valita.ts';
 import {transformAndHashQuery} from '../../zero-cache/src/auth/read-authorizer.ts';
 import {
   appOptions,
-  normalizeZeroConfig,
   shardOptions,
   ZERO_ENV_VAR_PREFIX,
   zeroOptions,
@@ -116,16 +115,21 @@ const options = {
   ) as unknown as typeof zeroOptions.upstream,
 };
 
-const config = normalizeZeroConfig(
-  parseOptions(
-    options,
-    // the command line parses drops all text after the first newline
-    // so we need to replace newlines with spaces
-    // before parsing
-    process.argv.slice(2).map(s => s.replaceAll('\n', ' ')),
-    ZERO_ENV_VAR_PREFIX,
-  ),
+const cfg = parseOptions(
+  options,
+  // the command line parses drops all text after the first newline
+  // so we need to replace newlines with spaces
+  // before parsing
+  process.argv.slice(2).map(s => s.replaceAll('\n', ' ')),
+  ZERO_ENV_VAR_PREFIX,
 );
+const config = {
+  ...cfg,
+  cvr: {
+    ...cfg.cvr,
+    db: cfg.cvr.db ?? cfg.upstream.db,
+  },
+};
 
 runtimeDebugFlags.trackRowsVended = true;
 

--- a/packages/zero-cache/src/config/network.ts
+++ b/packages/zero-cache/src/config/network.ts
@@ -1,0 +1,33 @@
+import type {LogContext} from '@rocicorp/logger';
+import {networkInterfaces} from 'os';
+
+function isLinkLocal(addr: string) {
+  return addr.startsWith('169.254.') || addr.startsWith('fe80::');
+}
+
+export function getHostIp(lc: LogContext) {
+  const interfaces = networkInterfaces();
+  const sorted = Object.values(networkInterfaces())
+    .flat()
+    .filter(val => val !== undefined)
+    .sort((a, b) => {
+      if (a.internal !== b.internal) {
+        // Prefer non-internal addresses.
+        return a.internal ? 1 : -1;
+      }
+      if (isLinkLocal(a.address) !== isLinkLocal(b.address)) {
+        // Prefer non link-local addresses
+        return isLinkLocal(a.address) ? 1 : -1;
+      }
+      if (a.family !== b.family) {
+        // Prefer IPv4.
+        return a.family === 'IPv4' ? -1 : 1;
+      }
+      // arbitrary
+      return a.address.localeCompare(b.address);
+    });
+
+  const preferred = sorted[0].address;
+  lc.info?.(`network interfaces`, {preferred, sorted, interfaces});
+  return preferred;
+}

--- a/packages/zero-cache/src/config/normalize.ts
+++ b/packages/zero-cache/src/config/normalize.ts
@@ -1,0 +1,93 @@
+import type {LogContext} from '@rocicorp/logger';
+import {nanoid} from 'nanoid';
+import {assert} from '../../../shared/src/asserts.ts';
+import {getHostIp} from './network.ts';
+import type {ZeroConfig} from './zero-config.ts';
+
+/** {@link ZeroConfig} with defaults set per option documentation. */
+export type NormalizedZeroConfig = ZeroConfig & {
+  taskID: string;
+  changeStreamerPort: number;
+  change: {
+    db: string;
+  };
+  cvr: {
+    db: string;
+  };
+  litestream: {
+    port: number;
+  };
+};
+
+export function assertNormalized(
+  config: ZeroConfig,
+): asserts config is NormalizedZeroConfig {
+  assert(config.taskID, 'missing --task-id');
+  assert(config.changeStreamerPort, 'missing --change-streamer-port');
+  assert(config.litestream.port, 'missing --litestream-port');
+  assert(config.change.db, 'missing --change-db');
+  assert(config.cvr.db, 'missing --cvr-db');
+}
+
+/**
+ * Normalizes the parsed `config` by setting defaults from the environment
+ * or from other options as documented. When defaults are applied, the
+ * corresponding `env` variable is updated so that the settings are propagated
+ * to spawned child workers. Child workers can then call
+ * {@link assertNormalized} to verify that the expected defaults have been set.
+ */
+export function normalizeZeroConfig(
+  lc: LogContext,
+  config: ZeroConfig,
+  env: NodeJS.ProcessEnv,
+  defaultTaskID?: string,
+): NormalizedZeroConfig {
+  if (!config.taskID) {
+    const taskID = defaultTaskID ?? nanoid();
+    config.taskID = taskID;
+    env['ZERO_TASK_ID'] = taskID;
+  }
+  if (!config.changeStreamerPort) {
+    const port = config.port + 1;
+    config.changeStreamerPort = port;
+    env['ZERO_CHANGE_STREAMER_PORT'] = String(port);
+  }
+  if (!config.litestream.port) {
+    const port = config.port + 2;
+    config.litestream.port = port;
+    env['ZERO_LITESTREAM_PORT'] = String(port);
+  }
+
+  if (!config.change.db) {
+    config.change.db = config.upstream.db;
+    env['ZERO_CHANGE_DB'] = config.upstream.db;
+  }
+  if (!config.cvr.db) {
+    config.cvr.db = config.upstream.db;
+    env['ZERO_CVR_DB'] = config.upstream.db;
+  }
+
+  const hostIP = getHostIp(lc); // TODO: This will be used for change-streamer discovery.
+  lc.info?.(`runtime env: taskID=${config.taskID}, hostIP=${hostIP}`);
+
+  return {
+    ...config,
+    taskID: config.taskID,
+    changeStreamerPort: config.changeStreamerPort,
+
+    litestream: {
+      ...config.litestream,
+      port: config.litestream.port,
+    },
+
+    change: {
+      ...config.change,
+      db: config.change.db,
+    },
+
+    cvr: {
+      ...config.cvr,
+      db: config.cvr.db,
+    },
+  };
+}

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -539,7 +539,7 @@ export const zeroOptions = {
   },
 };
 
-export type ZeroConfig = ReturnType<typeof getZeroConfig>;
+export type ZeroConfig = Config<typeof zeroOptions>;
 
 export const ZERO_ENV_VAR_PREFIX = 'ZERO_';
 
@@ -556,34 +556,5 @@ export function getZeroConfig(
       runtimeDebugFlags.trackRowsVended = true;
     }
   }
-
-  return normalizeZeroConfig(loadedConfig);
-}
-
-export function normalizeZeroConfig<
-  T extends {
-    cvr: {
-      db?: string | undefined;
-    };
-    change?:
-      | {
-          db?: string | undefined;
-        }
-      | undefined;
-    upstream: {
-      db: string;
-    };
-  },
->(config: T) {
-  return {
-    ...config,
-    cvr: {
-      ...config.cvr,
-      db: config.cvr.db ?? config.upstream.db,
-    },
-    change: {
-      ...config.change,
-      db: config.change?.db ?? config.upstream.db,
-    },
-  };
+  return loadedConfig;
 }

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -1,6 +1,7 @@
 import {assert} from '../../../shared/src/asserts.ts';
 import {must} from '../../../shared/src/must.ts';
 import {DatabaseInitError} from '../../../zqlite/src/db.ts';
+import {assertNormalized} from '../config/normalize.ts';
 import {getZeroConfig} from '../config/zero-config.ts';
 import {deleteLiteDB} from '../db/delete-lite-db.ts';
 import {warmupConnections} from '../db/warmup.ts';
@@ -27,9 +28,10 @@ export default async function runWorker(
   env: NodeJS.ProcessEnv,
 ): Promise<void> {
   const config = getZeroConfig(env);
+  assertNormalized(config);
   const {
     taskID,
-    changeStreamerPort: port = config.port + 1,
+    changeStreamerPort: port,
     upstream,
     change,
     replica,
@@ -39,7 +41,7 @@ export default async function runWorker(
   const lc = createLogContext(config, {worker: 'change-streamer'});
 
   // Kick off DB connection warmup in the background.
-  const changeDB = pgClient(lc, change.db ?? upstream.db, {
+  const changeDB = pgClient(lc, change.db, {
     max: change.maxConns,
     connection: {['application_name']: 'zero-change-streamer'},
   });

--- a/packages/zero-cache/src/server/runner/zero-dispatcher.ts
+++ b/packages/zero-cache/src/server/runner/zero-dispatcher.ts
@@ -1,5 +1,5 @@
 import type {LogContext} from '@rocicorp/logger';
-import type {ZeroConfig} from '../../config/zero-config.ts';
+import type {NormalizedZeroConfig} from '../../config/normalize.ts';
 import {HttpService, type Options} from '../../services/http-service.ts';
 import {handleStatzRequest} from '../../services/statz.ts';
 import type {IncomingMessageSubset} from '../../types/http.ts';
@@ -14,7 +14,7 @@ export class ZeroDispatcher extends HttpService {
   readonly #getWorker: () => Promise<Worker>;
 
   constructor(
-    config: ZeroConfig,
+    config: NormalizedZeroConfig,
     lc: LogContext,
     opts: Options,
     getWorker: () => Promise<Worker>,

--- a/packages/zero-cache/src/services/statz.ts
+++ b/packages/zero-cache/src/services/statz.ts
@@ -1,15 +1,15 @@
+import auth from 'basic-auth';
+import type {FastifyReply, FastifyRequest} from 'fastify';
+import fs from 'fs';
+import os from 'os';
+import type {Writable} from 'stream';
 import {astToZQL} from '../../../ast-to-zql/src/ast-to-zql.ts';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
-import {type ZeroConfig} from '../config/zero-config.ts';
-import {getShardID, upstreamSchema} from '../types/shards.ts';
-import {pgClient} from '../types/pg.ts';
-import type {Writable} from 'stream';
-import {BigIntJSON} from '../types/bigint-json.ts';
-import os from 'os';
-import fs from 'fs';
-import type {FastifyReply, FastifyRequest} from 'fastify';
 import {Database} from '../../../zqlite/src/db.ts';
-import auth from 'basic-auth';
+import type {NormalizedZeroConfig as ZeroConfig} from '../config/normalize.ts';
+import {BigIntJSON} from '../types/bigint-json.ts';
+import {pgClient} from '../types/pg.ts';
+import {getShardID, upstreamSchema} from '../types/shards.ts';
 
 const lc = createSilentLogContext();
 


### PR DESCRIPTION
(with the exception of `bin-analyze`  😉 )

Also adds network interface lookup which will be used for change-streamer discovery. Currently it is simply logged for analysis of interface names in different runtimes.