### PR TITLE
chore(zql): hydration benchmark harness

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -298,20 +298,6 @@
         "node": "^18 || >=20"
       }
     },
-    "apps/zbugs/node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "apps/zbugs/node_modules/vite-tsconfig-paths": {
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-5.1.4.tgz",
@@ -25093,11 +25079,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
-      "license": "Apache-2.0",
-      "peer": true,
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -26820,6 +26804,10 @@
       "resolved": "packages/zql",
       "link": true
     },
+    "node_modules/zql-benchmarks": {
+      "resolved": "packages/zql-benchmarks",
+      "link": true
+    },
     "node_modules/zql-integration-tests": {
       "resolved": "packages/zql-integration-tests",
       "link": true
@@ -26912,20 +26900,6 @@
         "replicache": "15.2.1",
         "typescript": "~5.8.2",
         "vitest": "3.0.8"
-      }
-    },
-    "packages/datadog/node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "packages/otel": {
@@ -27025,20 +26999,6 @@
       "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
       "license": "MIT"
     },
-    "packages/replicache-doc/node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "packages/replicache-perf": {
       "dependencies": {
         "@rocicorp/eslint-config": "^0.7.0",
@@ -27058,33 +27018,6 @@
         "typescript": "~5.8.2",
         "vite": "6.2.1",
         "xbytes": "^1.7.0"
-      }
-    },
-    "packages/replicache-perf/node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "packages/replicache/node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "packages/shared": {
@@ -27177,20 +27110,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/shared/node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "packages/z2s": {
@@ -27383,20 +27302,6 @@
         "node": "^18 || >=20"
       }
     },
-    "packages/zero-cache/node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "packages/zero-client": {
       "version": "0.0.0",
       "dependencies": {
@@ -27414,20 +27319,6 @@
         "shared": "0.0.0",
         "typescript": "~5.8.2",
         "zero-protocol": "0.0.0"
-      }
-    },
-    "packages/zero-client/node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "packages/zero-pg": {
@@ -27451,20 +27342,6 @@
         "@rocicorp/prettier-config": "^0.3.0",
         "shared": "0.0.0",
         "typescript": "~5.8.2"
-      }
-    },
-    "packages/zero-protocol/node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "packages/zero-react": {
@@ -27572,20 +27449,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "packages/zero/node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "packages/zql": {
       "version": "0.0.0",
       "dependencies": {
@@ -27607,7 +27470,7 @@
         "zod": "^3.21.4"
       }
     },
-    "packages/zql-integration-tests": {
+    "packages/zql-benchmarks": {
       "version": "0.0.0",
       "devDependencies": {
         "@rocicorp/eslint-config": "^0.7.0",
@@ -27617,17 +27480,14 @@
         "typescript": "~5.8.2"
       }
     },
-    "packages/zql-integration-tests/node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
+    "packages/zql-integration-tests": {
+      "version": "0.0.0",
+      "devDependencies": {
+        "@rocicorp/eslint-config": "^0.7.0",
+        "@rocicorp/prettier-config": "^0.3.0",
+        "@types/tmp": "^0.2.6",
+        "shared": "0.0.0",
+        "typescript": "~5.8.2"
       }
     },
     "packages/zql-to-sql": {
@@ -27678,20 +27538,6 @@
       },
       "engines": {
         "node": "^18 || >=20"
-      }
-    },
-    "packages/zql/node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "packages/zqlite": {
@@ -27780,20 +27626,6 @@
       },
       "engines": {
         "node": "^18 || >=20"
-      }
-    },
-    "packages/zqlite/node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "prod": {
@@ -32101,12 +31933,6 @@
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
           "integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA=="
-        },
-        "typescript": {
-          "version": "5.8.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-          "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-          "dev": true
         }
       }
     },
@@ -35402,14 +35228,6 @@
         "replicache": "15.2.1",
         "typescript": "~5.8.2",
         "vitest": "3.0.8"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "5.8.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-          "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-          "dev": true
-        }
       }
     },
     "date-fns": {
@@ -42116,14 +41934,6 @@
         "shared": "0.0.0",
         "typescript": "~5.8.2",
         "vitest": "3.0.8"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "5.8.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-          "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-          "dev": true
-        }
       }
     },
     "replicache-doc": {
@@ -42163,12 +41973,6 @@
           "version": "0.25.0",
           "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
           "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA=="
-        },
-        "typescript": {
-          "version": "5.8.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-          "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-          "dev": true
         }
       }
     },
@@ -42192,13 +41996,6 @@
         "typescript": "~5.8.2",
         "vite": "6.2.1",
         "xbytes": "^1.7.0"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "5.8.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-          "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ=="
-        }
       }
     },
     "require-directory": {
@@ -42746,12 +42543,6 @@
           "version": "4.30.0",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.30.0.tgz",
           "integrity": "sha512-G6zXWS1dLj6eagy6sVhOMQiLtJdxQBHIA9Z6HFUNLOlr6MFOgzV8wvmidtPONfPtEUv0uZsy77XJNzTAfwPDaA==",
-          "dev": true
-        },
-        "typescript": {
-          "version": "5.8.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-          "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
           "dev": true
         }
       }
@@ -44186,10 +43977,9 @@
       "requires": {}
     },
     "typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
-      "peer": true
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="
     },
     "typical": {
       "version": "7.2.0",
@@ -45349,12 +45139,6 @@
           "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.2.tgz",
           "integrity": "sha512-b+CiXQCNMUGe0Ri64S9SXFcP9hogjAJ2Rd6GdVxhPLRm7mhGaM7VgOvCAJ1ZshfHbqVDI3uqTI5C8/GaKuLI7g=="
         },
-        "typescript": {
-          "version": "5.8.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-          "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-          "dev": true
-        },
         "vite-tsconfig-paths": {
           "version": "5.1.4",
           "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-5.1.4.tgz",
@@ -45443,12 +45227,6 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.2.tgz",
           "integrity": "sha512-b+CiXQCNMUGe0Ri64S9SXFcP9hogjAJ2Rd6GdVxhPLRm7mhGaM7VgOvCAJ1ZshfHbqVDI3uqTI5C8/GaKuLI7g=="
-        },
-        "typescript": {
-          "version": "5.8.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-          "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-          "dev": true
         }
       }
     },
@@ -45467,14 +45245,6 @@
         "shared": "0.0.0",
         "typescript": "~5.8.2",
         "zero-protocol": "0.0.0"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "5.8.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-          "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-          "dev": true
-        }
       }
     },
     "zero-pg": {
@@ -45494,14 +45264,6 @@
         "@rocicorp/prettier-config": "^0.3.0",
         "shared": "0.0.0",
         "typescript": "~5.8.2"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "5.8.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-          "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-          "dev": true
-        }
       }
     },
     "zero-react": {
@@ -45583,13 +45345,17 @@
           "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.2.tgz",
           "integrity": "sha512-b+CiXQCNMUGe0Ri64S9SXFcP9hogjAJ2Rd6GdVxhPLRm7mhGaM7VgOvCAJ1ZshfHbqVDI3uqTI5C8/GaKuLI7g==",
           "dev": true
-        },
-        "typescript": {
-          "version": "5.8.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-          "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-          "dev": true
         }
+      }
+    },
+    "zql-benchmarks": {
+      "version": "file:packages/zql-benchmarks",
+      "requires": {
+        "@rocicorp/eslint-config": "^0.7.0",
+        "@rocicorp/prettier-config": "^0.3.0",
+        "@types/tmp": "^0.2.6",
+        "shared": "0.0.0",
+        "typescript": "~5.8.2"
       }
     },
     "zql-integration-tests": {
@@ -45600,14 +45366,6 @@
         "@types/tmp": "^0.2.6",
         "shared": "0.0.0",
         "typescript": "~5.8.2"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "5.8.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-          "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-          "dev": true
-        }
       }
     },
     "zqlite": {
@@ -45639,12 +45397,6 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.2.tgz",
           "integrity": "sha512-b+CiXQCNMUGe0Ri64S9SXFcP9hogjAJ2Rd6GdVxhPLRm7mhGaM7VgOvCAJ1ZshfHbqVDI3uqTI5C8/GaKuLI7g==",
-          "dev": true
-        },
-        "typescript": {
-          "version": "5.8.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-          "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
           "dev": true
         }
       }

--- a/packages/zql-benchmarks/package.json
+++ b/packages/zql-benchmarks/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "zql-benchmarks",
+  "description": "Benchmarks of ZQL, ZQLite, ZPG",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "format": "prettier --write .",
+    "check-format": "prettier --check .",
+    "check-types": "tsc",
+    "check-types:watch": "tsc --watch",
+    "build:bin": "tsc -p tsconfig.bin.json",
+    "lint": "eslint --ext .ts,.tsx,.js,.jsx src/",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "bench": "vitest bench",
+    "test-types": "vitest run --typecheck.only --no-browser.enabled",
+    "test-types:watch": "vitest watch --typecheck.only --no-browser.enabled"
+  },
+  "devDependencies": {
+    "@rocicorp/eslint-config": "^0.7.0",
+    "@rocicorp/prettier-config": "^0.3.0",
+    "@types/tmp": "^0.2.6",
+    "shared": "0.0.0",
+    "typescript": "~5.8.2"
+  },
+  "eslintConfig": {
+    "extends": "../../eslint-config.json"
+  },
+  "prettier": "@rocicorp/prettier-config"
+}

--- a/packages/zql-benchmarks/src/chinook.bench.ts
+++ b/packages/zql-benchmarks/src/chinook.bench.ts
@@ -1,0 +1,41 @@
+import {runHydrationBenchmarks} from '../../zql-integration-tests/src/helpers/runner.ts';
+import {getChinook} from '../../zql-integration-tests/src/chinook/get-deps.ts';
+import {schema} from '../../zql-integration-tests/src/chinook/schema.ts';
+
+const pgContent = await getChinook();
+
+await runHydrationBenchmarks(
+  {
+    suiteName: 'chinook_bench',
+    pgContent,
+    zqlSchema: schema,
+  },
+  [
+    {
+      name: '(table scan) select * from album',
+      createQuery: q => q.album,
+    },
+    {
+      name: '(pk lookup) select * from track where id = 3163',
+      createQuery: q => q.track.where('id', 3163),
+    },
+    {
+      name: '(secondary index lookup) select * from track where album_id = 248',
+      createQuery: q => q.track.where('albumId', 248),
+    },
+    {
+      name: 'scan with one depth related',
+      createQuery: q => q.album.related('artist'),
+    },
+    {
+      name: 'all playlists',
+      createQuery: q =>
+        q.playlist.related('tracks', t =>
+          t
+            .related('mediaType')
+            .related('genre')
+            .related('album', a => a.related('artist')),
+        ),
+    },
+  ],
+);

--- a/packages/zql-benchmarks/tsconfig.json
+++ b/packages/zql-benchmarks/tsconfig.json
@@ -4,5 +4,5 @@
     "lib": ["ESNext.Array", "ESNext", "DOM"],
     "outDir": "dist"
   },
-  "include": ["src/**/*.ts", "../zql-benchmarks/src/chinook.bench.ts"]
+  "include": ["src/**/*.ts"]
 }

--- a/packages/zql-benchmarks/vitest.config.pg-17.ts
+++ b/packages/zql-benchmarks/vitest.config.pg-17.ts
@@ -1,0 +1,3 @@
+import {configForVersion} from '../zero-cache/vitest.config.ts';
+
+export default configForVersion(17, import.meta.url);

--- a/packages/zql-benchmarks/vitest.config.ts
+++ b/packages/zql-benchmarks/vitest.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    workspace: ['vitest.config.*.ts'],
+  },
+});


### PR DESCRIPTION
Since I already created the integration test harness, might as well re-use it for benchmarks too.

- Benchmarks below run without this fix -- https://github.com/rocicorp/mono/pull/4327



![CleanShot 2025-05-05 at 21 50 14@2x](https://github.com/user-attachments/assets/239787e6-5d09-4357-8251-c4481921fa8c)


![CleanShot 2025-05-05 at 21 50 45@2x](https://github.com/user-attachments/assets/67672282-c825-44b1-a4f9-3638c950903a)
