### PR TITLE
chore(zql): harness to benchmark pushes

### DIFF
--- a/packages/zql-benchmarks/src/chinook-hydration.bench.ts
+++ b/packages/zql-benchmarks/src/chinook-hydration.bench.ts
@@ -1,12 +1,13 @@
-import {runHydrationBenchmarks} from '../../zql-integration-tests/src/helpers/runner.ts';
+import {runBenchmarks} from '../../zql-integration-tests/src/helpers/runner.ts';
 import {getChinook} from '../../zql-integration-tests/src/chinook/get-deps.ts';
 import {schema} from '../../zql-integration-tests/src/chinook/schema.ts';
 
 const pgContent = await getChinook();
 
-await runHydrationBenchmarks(
+await runBenchmarks(
   {
     suiteName: 'chinook_bench',
+    type: 'hydration',
     pgContent,
     zqlSchema: schema,
   },

--- a/packages/zql-benchmarks/src/chinook-push.bench.ts
+++ b/packages/zql-benchmarks/src/chinook-push.bench.ts
@@ -1,0 +1,101 @@
+import {runBenchmarks} from '../../zql-integration-tests/src/helpers/runner.ts';
+import {getChinook} from '../../zql-integration-tests/src/chinook/get-deps.ts';
+import {schema} from '../../zql-integration-tests/src/chinook/schema.ts';
+import type {PullRow} from '../../zql/src/query/query.ts';
+
+const pgContent = await getChinook();
+
+function defaultTrack(id: number): PullRow<'track', typeof schema> {
+  return {
+    id,
+    name: `Track ${id}`,
+    albumId: 248,
+    mediaTypeId: 1,
+    genreId: 1,
+    composer: 'Composer',
+    milliseconds: 1000,
+    bytes: 1000,
+    unitPrice: 1.99,
+  };
+}
+
+await runBenchmarks(
+  {
+    suiteName: 'chinook_bench',
+    type: 'push',
+    pgContent,
+    zqlSchema: schema,
+  },
+  [
+    {
+      name: 'push into unlimited query',
+      createQuery: q => q.track,
+      generatePush: i => [
+        [
+          'track',
+          {
+            type: 'add',
+            row: defaultTrack(i + 10_000),
+          },
+        ],
+      ],
+    },
+    {
+      name: 'push into limited query, outside the bound',
+      createQuery: q => q.track.limit(100),
+      generatePush: i => [
+        [
+          'track',
+          {
+            type: 'add',
+            row: defaultTrack(i + 10_000),
+          },
+        ],
+      ],
+    },
+    {
+      name: 'push into limited query, inside the bound',
+      createQuery: q => q.track.limit(100),
+      generatePush: i => [
+        [
+          'track',
+          {
+            type: 'add',
+            row: defaultTrack(-1 * i),
+          },
+        ],
+      ],
+    },
+    // For some reason tinybench is not respecting limits on number of
+    // iterations and warmups to run. It is blowing past the track table size
+    // and removing all rows during test warmup.
+    // We should switch to https://github.com/evanwashere/mitata as
+    // tinybench also has bugs in `setup` and `teardown`: https://github.com/rocicorp/mono/pull/4313
+    // {
+    //   name: 'remove from limited query, outside the bound',
+    //   createQuery: q => q.track.limit(100),
+    //   generatePush: i => [
+    //     [
+    //       'track',
+    //       {
+    //         type: 'remove',
+    //         row: defaultTrack(i + 1_000),
+    //       },
+    //     ],
+    //   ],
+    // },
+    // {
+    //   name: 'remove from limited query, inside the bound',
+    //   createQuery: q => q.track.limit(100),
+    //   generatePush: i => [
+    //     [
+    //       'track',
+    //       {
+    //         type: 'remove',
+    //         row: defaultTrack(i + 1),
+    //       },
+    //     ],
+    //   ],
+    // },
+  ],
+);


### PR DESCRIPTION
Seemed most efficient for me to knock this out while I was in there.

![CleanShot 2025-05-06 at 10 44 02](https://github.com/user-attachments/assets/4231db04-3cc1-4030-8c1c-03c12d0b5fe2)

There are many more benchmarks to write but for another time.

Pushing into a limited query inside the bound is a 40% reduction in speed for zql but not zqlite... I wonder if the time to convert rows to server names via table mapper is dominating??? Seems odd.

`tinybench` seems riddled with bugs (it does not respect any warmup and iterations options, it includes setup and tear down time in its benchmark). Considering swapping to: https://github.com/evanwashere/mitata or opening PRs against tinybench.