### PR TITLE
chore(zero): update litestream and node

### DIFF
--- a/packages/zero/Dockerfile
+++ b/packages/zero/Dockerfile
@@ -1,16 +1,16 @@
 FROM golang:1.23 AS litestream
 
 WORKDIR /src/
-RUN git clone --depth 1 --branch zero@v0.0.3 https://github.com/rocicorp/litestream.git
+RUN git clone --depth 1 --branch zero@v0.0.4 https://github.com/rocicorp/litestream.git
 WORKDIR /src/litestream/
 
-ARG LITESTREAM_VERSION=0.3.13+z0.0.3  # upstream version + zero version
+ARG LITESTREAM_VERSION=0.3.13+z0.0.4  # upstream version + zero version
 
 RUN --mount=type=cache,target=/root/.cache/go-build \
 	--mount=type=cache,target=/go/pkg \
 	go build -ldflags "-s -w -X 'main.Version=${LITESTREAM_VERSION}' -extldflags '-static'" -tags osusergo,netgo,sqlite_omit_load_extension -o /usr/local/bin/litestream ./cmd/litestream
 
-FROM node:22.11.0-alpine3.20
+FROM node:22.15.0-alpine3.20
 
 ARG ZERO_VERSION
 


### PR DESCRIPTION
node:22.15.0 fixes 3 high severity vulnerabilities in node:22.11.0

New litestream version contains a [minor fix](https://github.com/rocicorp/litestream/pull/5) (that didn't affect zero).