### PR TITLE
fix(mutators): assert provided columns actually exist

### DIFF
--- a/packages/zero-pg/src/custom.ts
+++ b/packages/zero-pg/src/custom.ts
@@ -18,6 +18,7 @@ import type {
   ServerTableSchema,
 } from '../../z2s/src/schema.ts';
 import {getServerSchema} from './schema.ts';
+import {assert} from '../../shared/src/asserts.ts';
 
 interface ServerTransaction<S extends Schema, TWrappedTransaction>
   extends TransactionBase<S> {
@@ -286,6 +287,10 @@ function origAndServerNamesFor(
 
 function serverNameFor(originalName: string, schema: TableSchema): string {
   const col = schema.columns[originalName];
+  assert(
+    col,
+    `Column ${originalName} was not found in the Zero schema for the table ${schema.name}`,
+  );
   return col.serverName ?? originalName;
 }
 

--- a/packages/zero-pg/src/push-processor.ts
+++ b/packages/zero-pg/src/push-processor.ts
@@ -166,12 +166,20 @@ export class PushProcessor<
         m,
         true,
       );
+
       if ('error' in ret.result) {
         this.#lc.error?.(
           `Error ${ret.result.error} processing mutation ${m.id} for client ${m.clientID}: ${ret.result.details}`,
+          e,
         );
         return ret;
       }
+
+      this.#lc.error?.(
+        `Unexpected error processing mutation ${m.id} for client ${m.clientID}`,
+        e,
+      );
+
       return {
         id: ret.id,
         result: {


### PR DESCRIPTION
User report: https://discord.com/channels/830183651022471199/1367519188851228758/1369351714884423721

some users are ending up with extra junk in the objects they pass to `insert` / `update`, causing exceptions.

They don't know what they're doing wrong since we do not output:
1. the bogus column
2. what table they're tring to access

