### PR TITLE
perf(zql): optimization for sparce/empty OR branches

### DIFF
--- a/packages/analyze-query/src/bin-analyze.ts
+++ b/packages/analyze-query/src/bin-analyze.ts
@@ -44,6 +44,7 @@ import {
   runtimeDebugStats,
 } from '../../zqlite/src/runtime-debug.ts';
 import {TableSource} from '../../zqlite/src/table-source.ts';
+import type {FilterInput} from '../../zql/src/ivm/filter-operators.ts';
 
 const options = {
   replicaFile: zeroOptions.replica.file,
@@ -178,6 +179,9 @@ const host: QueryDelegate = {
     return new MemoryStorage();
   },
   decorateInput(input: Input): Input {
+    return input;
+  },
+  decorateFilterInput(input: FilterInput): FilterInput {
     return input;
   },
   addServerQuery() {

--- a/packages/zero-cache/bench/benchmark.ts
+++ b/packages/zero-cache/bench/benchmark.ts
@@ -4,6 +4,7 @@ import {testLogConfig} from '../../otel/src/test-log-config.ts';
 import {assert} from '../../shared/src/asserts.ts';
 import {createSilentLogContext} from '../../shared/src/logging-test-utils.ts';
 import type {AST} from '../../zero-protocol/src/ast.ts';
+import type {FilterInput} from '../../zql/src/ivm/filter-operators.ts';
 import {MemoryStorage} from '../../zql/src/ivm/memory-storage.ts';
 import type {Input} from '../../zql/src/ivm/operator.ts';
 import type {Source} from '../../zql/src/ivm/source.ts';
@@ -62,6 +63,9 @@ export function bench(opts: Options) {
       return new MemoryStorage();
     },
     decorateInput(input: Input): Input {
+      return input;
+    },
+    decorateFilterInput(input: FilterInput): FilterInput {
       return input;
     },
     addServerQuery() {

--- a/packages/zero-cache/src/auth/read-authorizer.query.test.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.query.test.ts
@@ -49,6 +49,7 @@ import {TableSource} from '../../../zqlite/src/table-source.ts';
 import type {ZeroConfig} from '../config/zero-config.ts';
 import {transformQuery} from './read-authorizer.ts';
 import {WriteAuthorizerImpl} from './write-authorizer.ts';
+import type {FilterInput} from '../../../zql/src/ivm/filter-operators.ts';
 
 const zeroConfig = {
   log: testLogConfig,
@@ -524,6 +525,9 @@ beforeEach(() => {
       return new MemoryStorage();
     },
     decorateInput(input: Input): Input {
+      return input;
+    },
+    decorateFilterInput(input: FilterInput): FilterInput {
       return input;
     },
     addServerQuery() {

--- a/packages/zero-cache/src/auth/write-authorizer.ts
+++ b/packages/zero-cache/src/auth/write-authorizer.ts
@@ -101,6 +101,7 @@ export class WriteAuthorizerImpl implements WriteAuthorizer {
       getSource: name => this.#getSource(name),
       createStorage: () => cgStorage.createStorage(),
       decorateInput: input => input,
+      decorateFilterInput: input => input,
       mapAst: ast => ast,
     };
     this.#tableSpecs = computeZqlSpecs(this.#lc, replica);

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -266,6 +266,7 @@ export class PipelineDriver {
       getSource: name => this.#getSource(name),
       createStorage: () => this.#createStorage(),
       decorateInput: input => input,
+      decorateFilterInput: input => input,
       mapAst: ast => ast,
     });
     const schema = input.getSchema();

--- a/packages/zero-client/src/client/context.ts
+++ b/packages/zero-client/src/client/context.ts
@@ -3,6 +3,7 @@ import type {Hash} from '../../../replicache/src/hash.ts';
 import {assert} from '../../../shared/src/asserts.ts';
 import type {AST} from '../../../zero-protocol/src/ast.ts';
 import {ErrorKind} from '../../../zero-protocol/src/error-kind.ts';
+import type {FilterInput} from '../../../zql/src/ivm/filter-operators.ts';
 import {MemoryStorage} from '../../../zql/src/ivm/memory-storage.ts';
 import type {Input, Storage} from '../../../zql/src/ivm/operator.ts';
 import type {Source} from '../../../zql/src/ivm/source.ts';
@@ -107,6 +108,10 @@ export class ZeroContext implements QueryDelegate {
   }
 
   decorateInput(input: Input): Input {
+    return input;
+  }
+
+  decorateFilterInput(input: FilterInput): FilterInput {
     return input;
   }
 

--- a/packages/zql-benchmarks/src/chinook-hydration.bench.ts
+++ b/packages/zql-benchmarks/src/chinook-hydration.bench.ts
@@ -29,6 +29,27 @@ await runBenchmarks(
       createQuery: q => q.album.related('artist'),
     },
     {
+      name: 'OR with empty branch and limit',
+      createQuery: q =>
+        q.track
+          .where(({or, cmp}) =>
+            or(cmp('milliseconds', -1), cmp('mediaTypeId', 1)),
+          )
+          .limit(5),
+    },
+    {
+      name: 'OR with empty branch and limit with exists',
+      createQuery: q =>
+        q.track
+          .where(({or, cmp, exists}) =>
+            or(
+              cmp('milliseconds', -1),
+              exists('mediaType', q => q.where('id', 1)),
+            ),
+          )
+          .limit(5),
+    },
+    {
       name: 'all playlists',
       createQuery: q =>
         q.playlist.related('tracks', t =>

--- a/packages/zql-benchmarks/src/chinook-hydration.bench.ts
+++ b/packages/zql-benchmarks/src/chinook-hydration.bench.ts
@@ -29,6 +29,16 @@ await runBenchmarks(
       createQuery: q => q.album.related('artist'),
     },
     {
+      name: 'all playlists',
+      createQuery: q =>
+        q.playlist.related('tracks', t =>
+          t
+            .related('mediaType')
+            .related('genre')
+            .related('album', a => a.related('artist')),
+        ),
+    },
+    {
       name: 'OR with empty branch and limit',
       createQuery: q =>
         q.track
@@ -48,16 +58,6 @@ await runBenchmarks(
             ),
           )
           .limit(5),
-    },
-    {
-      name: 'all playlists',
-      createQuery: q =>
-        q.playlist.related('tracks', t =>
-          t
-            .related('mediaType')
-            .related('genre')
-            .related('album', a => a.related('artist')),
-        ),
     },
   ],
 );

--- a/packages/zql/src/builder/builder.ts
+++ b/packages/zql/src/builder/builder.ts
@@ -22,8 +22,7 @@ import {Exists} from '../ivm/exists.ts';
 import {FanIn} from '../ivm/fan-in.ts';
 import {FanOut} from '../ivm/fan-out.ts';
 import {
-  FilterEnd,
-  FilterStart,
+  buildFilterPipeline,
   type FilterInput,
 } from '../ivm/filter-operators.ts';
 import {Filter} from '../ivm/filter.ts';
@@ -242,10 +241,8 @@ function applyWhere(
   delegate: BuilderDelegate,
   name: string,
 ): Input {
-  const filterStart = new FilterStart(input);
-  return new FilterEnd(
-    filterStart,
-    applyFilter(filterStart, condition, delegate, name),
+  return buildFilterPipeline(input, filterInput =>
+    applyFilter(filterInput, condition, delegate, name),
   );
 }
 

--- a/packages/zql/src/builder/builder.ts
+++ b/packages/zql/src/builder/builder.ts
@@ -56,7 +56,9 @@ export interface BuilderDelegate {
    */
   createStorage(name: string): Storage;
 
-  decorateInput<I extends Input | FilterInput>(input: I, name: string): I;
+  decorateInput(input: Input, name: string): Input;
+
+  decorateFilterInput(input: FilterInput, name: string): FilterInput;
 
   /**
    * The AST is mapped on-the-wire between client and server names.
@@ -385,7 +387,7 @@ function applyCorrelatedSubqueryCondition(
 ): FilterInput {
   assert(condition.op === 'EXISTS' || condition.op === 'NOT EXISTS');
   const existsName = `${name}:exists(${condition.related.subquery.alias})`;
-  return delegate.decorateInput(
+  return delegate.decorateFilterInput(
     new Exists(
       input,
       delegate.createStorage(existsName),

--- a/packages/zql/src/builder/test-builder-delegate.ts
+++ b/packages/zql/src/builder/test-builder-delegate.ts
@@ -1,9 +1,10 @@
 import {assert} from '../../../shared/src/asserts.ts';
 import type {JSONObject} from '../../../shared/src/json.ts';
 import type {AST} from '../../../zero-protocol/src/ast.ts';
+import type {FilterInput} from '../ivm/filter-operators.ts';
 import {MemoryStorage} from '../ivm/memory-storage.ts';
 import type {Storage, Input} from '../ivm/operator.ts';
-import {Snitch, type SnitchMessage} from '../ivm/snitch.ts';
+import {FilterSnitch, Snitch, type SnitchMessage} from '../ivm/snitch.ts';
 import type {Source} from '../ivm/source.ts';
 import type {BuilderDelegate} from './builder.ts';
 
@@ -45,6 +46,13 @@ export class TestBuilderDelegate implements BuilderDelegate {
       return input;
     }
     return new Snitch(input, name, this.#log);
+  }
+
+  decorateFilterInput(input: FilterInput, name: string): FilterInput {
+    if (!this.#shouldLog) {
+      return input;
+    }
+    return new FilterSnitch(input, name, this.#log);
   }
 
   clearLog() {

--- a/packages/zql/src/ivm/exists.push.test.ts
+++ b/packages/zql/src/ivm/exists.push.test.ts
@@ -190,32 +190,21 @@ suite('EXISTS 1 to many', () => {
           ],
           [
             ":exists(issue)",
-            "fetch",
+            "filter",
             {
-              "constraint": undefined,
-              "reverse": true,
-              "start": {
-                "basis": "after",
-                "row": {
-                  "id": "c2",
-                  "issueID": "i1",
-                },
-              },
+              "id": "c2",
+              "issueID": "i1",
             },
+            "fetch",
           ],
           [
             ":exists(issue)",
-            "fetch",
+            "filter",
             {
-              "constraint": undefined,
-              "start": {
-                "basis": "at",
-                "row": {
-                  "id": "c2",
-                  "issueID": "i1",
-                },
-              },
+              "id": "c3",
+              "issueID": "i1",
             },
+            "fetch",
           ],
           [
             ":exists(issue)",
@@ -230,32 +219,21 @@ suite('EXISTS 1 to many', () => {
           ],
           [
             ":exists(issue)",
-            "fetch",
+            "filter",
             {
-              "constraint": undefined,
-              "reverse": true,
-              "start": {
-                "basis": "after",
-                "row": {
-                  "id": "c3",
-                  "issueID": "i1",
-                },
-              },
+              "id": "c3",
+              "issueID": "i1",
             },
+            "fetch",
           ],
           [
             ":exists(issue)",
-            "fetch",
+            "filter",
             {
-              "constraint": undefined,
-              "start": {
-                "basis": "at",
-                "row": {
-                  "id": "c3",
-                  "issueID": "i1",
-                },
-              },
+              "id": "c4",
+              "issueID": "i2",
             },
+            "fetch",
           ],
           [
             ":exists(issue)",
@@ -270,32 +248,12 @@ suite('EXISTS 1 to many', () => {
           ],
           [
             ":exists(issue)",
-            "fetch",
+            "filter",
             {
-              "constraint": undefined,
-              "reverse": true,
-              "start": {
-                "basis": "after",
-                "row": {
-                  "id": "c4",
-                  "issueID": "i2",
-                },
-              },
+              "id": "c4",
+              "issueID": "i2",
             },
-          ],
-          [
-            ":exists(issue)",
             "fetch",
-            {
-              "constraint": undefined,
-              "start": {
-                "basis": "at",
-                "row": {
-                  "id": "c4",
-                  "issueID": "i2",
-                },
-              },
-            },
           ],
         ]
       `);

--- a/packages/zql/src/ivm/exists.ts
+++ b/packages/zql/src/ivm/exists.ts
@@ -122,7 +122,9 @@ export class Exists implements Operator {
   }
 
   push(change: Change) {
-    this.#inPush = true;
+    this.#inPush = !(
+      change as unknown as {syntheticFetch?: boolean | undefined}
+    ).syntheticFetch;
     try {
       switch (change.type) {
         // add, remove and edit cannot change the size of the

--- a/packages/zql/src/ivm/exists.ts
+++ b/packages/zql/src/ivm/exists.ts
@@ -93,9 +93,12 @@ export class Exists implements FilterOperator {
     this.#output = output;
   }
 
-  filter(node: Node): void {
+  filter(node: Node, cleanup: boolean): void {
     if (this.#filter(node)) {
-      this.#output.filter(node);
+      this.#output.filter(node, cleanup);
+    }
+    if (cleanup) {
+      this.#delSize(node);
     }
   }
 

--- a/packages/zql/src/ivm/fan-in.ts
+++ b/packages/zql/src/ivm/fan-in.ts
@@ -55,8 +55,8 @@ export class FanIn implements FilterOperator {
     return this.#schema;
   }
 
-  filter(node: Node, _cleanup: boolean): void {
-    this.#accumulatedFilters.push(node);
+  filter(node: Node, cleanup: boolean): boolean {
+    return this.#output.filter(node, cleanup);
   }
 
   push(change: Change) {

--- a/packages/zql/src/ivm/fan-in.ts
+++ b/packages/zql/src/ivm/fan-in.ts
@@ -1,7 +1,7 @@
 import {assert} from '../../../shared/src/asserts.ts';
 import {must} from '../../../shared/src/must.ts';
 import type {Change} from './change.ts';
-import {drainStreams, type Node} from './data.ts';
+import {type Node} from './data.ts';
 import type {FanOut} from './fan-out.ts';
 import {
   throwFilterOutput,
@@ -30,7 +30,6 @@ export class FanIn implements FilterOperator {
   readonly #schema: SourceSchema;
   #output: FilterOutput = throwFilterOutput;
   #accumulatedPushes: Change[] = [];
-  #accumulatedFilters: Node[] = [];
 
   constructor(fanOut: FanOut, inputs: FilterInput[]) {
     this.#inputs = inputs;

--- a/packages/zql/src/ivm/fan-in.ts
+++ b/packages/zql/src/ivm/fan-in.ts
@@ -63,14 +63,6 @@ export class FanIn implements FilterOperator {
     this.#accumulatedPushes.push(change);
   }
 
-  fanOutDoneFilteringToAllBranches(node: Node, cleanup: boolean): void {
-    if (this.#accumulatedFilters.length) {
-      this.#output.filter(node, cleanup);
-    } else if (cleanup) {
-      drainStreams(node);
-    }
-  }
-
   fanOutDonePushingToAllBranches(fanOutChangeType: Change['type']) {
     if (this.#inputs.length === 0) {
       assert(

--- a/packages/zql/src/ivm/fan-out-fan-in.test.ts
+++ b/packages/zql/src/ivm/fan-out-fan-in.test.ts
@@ -11,7 +11,6 @@ import {
   FilterEnd,
   FilterStart,
 } from './filter-operators.ts';
-import {relationships} from '../../../zero-schema/src/builder/relationship-builder.ts';
 
 const lc = createSilentLogContext();
 

--- a/packages/zql/src/ivm/fan-out-fan-in.test.ts
+++ b/packages/zql/src/ivm/fan-out-fan-in.test.ts
@@ -6,6 +6,12 @@ import {Filter} from './filter.ts';
 import {createSource} from './test/source-factory.ts';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
 import {testLogConfig} from '../../../otel/src/test-log-config.ts';
+import {
+  buildFilterPipeline,
+  FilterEnd,
+  FilterStart,
+} from './filter-operators.ts';
+import {relationships} from '../../../zero-schema/src/builder/relationship-builder.ts';
 
 const lc = createSilentLogContext();
 
@@ -18,10 +24,12 @@ test('fan-out pushes along all paths', () => {
     ['a'],
   );
   const connector = s.connect([['a', 'asc']]);
-  const fanOut = new FanOut(connector);
-  const catch1 = new Catch(fanOut);
-  const catch2 = new Catch(fanOut);
-  const catch3 = new Catch(fanOut);
+
+  const filterStart = new FilterStart(connector);
+  const fanOut = new FanOut(filterStart);
+  const catch1 = new Catch(new FilterEnd(filterStart, fanOut));
+  const catch2 = new Catch(new FilterEnd(filterStart, fanOut));
+  const catch3 = new Catch(new FilterEnd(filterStart, fanOut));
 
   // dummy fan-in for invariant in fan-out
   const fanIn = new FanIn(fanOut, []);
@@ -147,14 +155,17 @@ test('fan-out,fan-in pairing does not duplicate pushes', () => {
     ['a'],
   );
   const connector = s.connect([['a', 'asc']]);
-  const fanOut = new FanOut(connector);
-  const filter1 = new Filter(fanOut, () => true);
-  const filter2 = new Filter(fanOut, () => true);
-  const filter3 = new Filter(fanOut, () => true);
+  const pipeline = buildFilterPipeline(connector, filterInput => {
+    const fanOut = new FanOut(filterInput);
+    const filter1 = new Filter(fanOut, () => true);
+    const filter2 = new Filter(fanOut, () => true);
+    const filter3 = new Filter(fanOut, () => true);
 
-  const fanIn = new FanIn(fanOut, [filter1, filter2, filter3]);
-  const out = new Catch(fanIn);
-  fanOut.setFanIn(fanIn);
+    const fanIn = new FanIn(fanOut, [filter1, filter2, filter3]);
+    fanOut.setFanIn(fanIn);
+    return fanIn;
+  });
+  const out = new Catch(pipeline);
 
   s.push({type: 'add', row: {a: 1, b: 'foo'}});
   s.push({type: 'add', row: {a: 2, b: 'foo'}});
@@ -214,15 +225,22 @@ test('fan-in fetch', () => {
     ['a', 'asc'],
     ['b', 'asc'],
   ]);
-  const fanOut = new FanOut(connector);
 
-  const filter1 = new Filter(fanOut, row => row.a === true);
-  const filter2 = new Filter(fanOut, row => row.b === true);
-  const filter3 = new Filter(fanOut, row => row.a === true && row.b === false); // duplicates a row of filter1
-  const filter4 = new Filter(fanOut, row => row.a === true && row.b === true); // duplicates a row of filter1 and filter2
+  const pipeline = buildFilterPipeline(connector, filterInput => {
+    const fanOut = new FanOut(filterInput);
 
-  const fanIn = new FanIn(fanOut, [filter1, filter2, filter3, filter4]);
-  const out = new Catch(fanIn);
+    const filter1 = new Filter(fanOut, row => row.a === true);
+    const filter2 = new Filter(fanOut, row => row.b === true);
+    const filter3 = new Filter(
+      fanOut,
+      row => row.a === true && row.b === false,
+    ); // duplicates a row of filter1
+    const filter4 = new Filter(fanOut, row => row.a === true && row.b === true); // duplicates a row of filter1 and filter2
+
+    return new FanIn(fanOut, [filter1, filter2, filter3, filter4]);
+  });
+
+  const out = new Catch(pipeline);
   const result = out.fetch();
   expect(result).toMatchInlineSnapshot(`
     [
@@ -251,7 +269,7 @@ test('fan-in fetch', () => {
   `);
 });
 
-test('cleanup called once per branch', () => {
+test('cleanup forwards too all branches', () => {
   const s = createSource(
     lc,
     testLogConfig,
@@ -259,18 +277,46 @@ test('cleanup called once per branch', () => {
     {a: {type: 'number'}, b: {type: 'string'}},
     ['a'],
   );
+  s.push({type: 'add', row: {a: 1, b: 'foo'}});
+
   const connector = s.connect([['a', 'asc']]);
-  const fanOut = new FanOut(connector);
-  const filter1 = new Filter(fanOut, () => true);
+  const filterStart = new FilterStart(connector);
+  const fanOut = new FanOut(filterStart);
+  const filter1 = new Filter(fanOut, () => false);
   const filter2 = new Filter(fanOut, () => true);
   const filter3 = new Filter(fanOut, () => true);
 
   const fanIn = new FanIn(fanOut, [filter1, filter2, filter3]);
-  const out = new Catch(fanIn);
+  fanOut.setFanIn(fanIn);
+  const out = new Catch(new FilterEnd(filterStart, fanIn));
 
-  const spy = vi.spyOn(connector, 'cleanup');
+  const filterSpy1 = vi.spyOn(filter1, 'filter');
+  const filterSpy2 = vi.spyOn(filter2, 'filter');
+  const filterSpy3 = vi.spyOn(filter2, 'filter');
 
-  out.cleanup();
+  const result = out.cleanup();
+  expect(result).toMatchInlineSnapshot(`
+    [
+      {
+        "relationships": {},
+        "row": {
+          "a": 1,
+          "b": "foo",
+        },
+      },
+    ]
+  `);
 
-  expect(spy).toHaveBeenCalledTimes(3);
+  expect(filterSpy1).toHaveBeenCalledExactlyOnceWith(
+    {relationships: {}, row: {a: 1, b: 'foo'}},
+    true,
+  );
+  expect(filterSpy2).toHaveBeenCalledExactlyOnceWith(
+    {relationships: {}, row: {a: 1, b: 'foo'}},
+    true,
+  );
+  expect(filterSpy3).toHaveBeenCalledExactlyOnceWith(
+    {relationships: {}, row: {a: 1, b: 'foo'}},
+    true,
+  );
 });

--- a/packages/zql/src/ivm/fan-out.ts
+++ b/packages/zql/src/ivm/fan-out.ts
@@ -48,13 +48,12 @@ export class FanOut implements FilterOperator {
   }
 
   filter(node: Node, cleanup: boolean): boolean {
+    let result = false;
+    // Forward to all outputs, don't short circuit.
     for (const output of this.#outputs) {
-      const result = output.filter(node, cleanup);
-      if (result) {
-        return true;
-      }
+      result = output.filter(node, cleanup) || result;
     }
-    return false;
+    return result;
   }
 
   push(change: Change) {

--- a/packages/zql/src/ivm/fan-out.ts
+++ b/packages/zql/src/ivm/fan-out.ts
@@ -2,7 +2,6 @@ import {must} from '../../../shared/src/must.ts';
 import type {Change} from './change.ts';
 import type {FanIn} from './fan-in.ts';
 import type {Node} from './data.ts';
-import type {Stream} from './stream.ts';
 import type {
   FilterInput,
   FilterOperator,
@@ -48,14 +47,14 @@ export class FanOut implements FilterOperator {
     return this.#input.getSchema();
   }
 
-  filter(node: Node, cleanup: boolean): void {
-    for (const out of this.#outputs) {
-      out.filter(node, cleanup);
+  filter(node: Node, cleanup: boolean): boolean {
+    for (const output of this.#outputs) {
+      const result = output.filter(node, cleanup);
+      if (result) {
+        return true;
+      }
     }
-    must(
-      this.#fanIn,
-      'fan-out must have a corresponding fan-in set!',
-    ).fanOutDoneFilteringToAllBranches(node, cleanup);
+    return false;
   }
 
   push(change: Change) {

--- a/packages/zql/src/ivm/fan-out.ts
+++ b/packages/zql/src/ivm/fan-out.ts
@@ -49,9 +49,13 @@ export class FanOut implements FilterOperator {
 
   filter(node: Node, cleanup: boolean): boolean {
     let result = false;
-    // Forward to all outputs, don't short circuit.
     for (const output of this.#outputs) {
       result = output.filter(node, cleanup) || result;
+      // Cleanup needs to be forwarded to all outputs, don't short circuit
+      // cleanup.  For non-cleanup we can short-circuit on first true.
+      if (!cleanup && result) {
+        return true;
+      }
     }
     return result;
   }

--- a/packages/zql/src/ivm/filter-operators.ts
+++ b/packages/zql/src/ivm/filter-operators.ts
@@ -63,7 +63,7 @@ export class FilterStart implements FilterInput, Output {
   }
 
   *cleanup(req: FetchRequest): Stream<Node> {
-    for (const node of this.#input.fetch(req)) {
+    for (const node of this.#input.cleanup(req)) {
       if (this.#output.filter(node, true)) {
         yield node;
       } else {
@@ -92,7 +92,7 @@ export class FilterEnd implements Input, FilterOutput {
   }
 
   *cleanup(req: FetchRequest): Stream<Node> {
-    for (const node of this.#start.fetch(req)) {
+    for (const node of this.#start.cleanup(req)) {
       yield node;
     }
   }
@@ -116,4 +116,12 @@ export class FilterEnd implements Input, FilterOutput {
   push(change: Change) {
     this.#output.push(change);
   }
+}
+
+export function buildFilterPipeline(
+  input: Input,
+  pipeline: (filterInput: FilterInput) => FilterInput,
+): Input {
+  const filterStart = new FilterStart(input);
+  return new FilterEnd(filterStart, pipeline(filterStart));
 }

--- a/packages/zql/src/ivm/filter-operators.ts
+++ b/packages/zql/src/ivm/filter-operators.ts
@@ -4,6 +4,25 @@ import type {Change} from './change.ts';
 import type {SourceSchema} from './schema.ts';
 import type {Stream} from './stream.ts';
 
+/**
+ * The `where` clause of a ZQL query is implemented using a sub-graph of
+ * `FilterOperators`.  This sub-graph starts with a `FilterStart` operator,
+ * that adapts from the normal `Operator` `Output`, to the
+ * `FilterOperator` `FilterInput`, and ends with a `FilterEnd` operator that
+ * adapts from a `FilterOperator` `FilterOutput` to a normal `Operator` `Input`.
+ * `FilterOperator'`s do not have `fetch` or `cleanup` instead they have a
+ * `filter(node: Node, cleanup: boolean): boolean` method.
+ * They also have `push` which is just like normal `Operator` push.
+ * Not having a `fetch` means these `FilterOperator`'s cannot modify
+ * `Node` `row`s or `relationship`s, but they shouldn't, they should just
+ * filter.
+ *
+ * This FilterOperator abstraction enable much more efficient processing of
+ * `fetch` for `where` clauses containing OR conditions.
+ *
+ * See https://github.com/rocicorp/mono/pull/4339
+ */
+
 export interface FilterInput extends InputBase {
   /** Tell the input where to send its output. */
   setFilterOutput(output: FilterOutput): void;

--- a/packages/zql/src/ivm/filter-operators.ts
+++ b/packages/zql/src/ivm/filter-operators.ts
@@ -17,7 +17,7 @@ import type {Stream} from './stream.ts';
  * `Node` `row`s or `relationship`s, but they shouldn't, they should just
  * filter.
  *
- * This FilterOperator abstraction enable much more efficient processing of
+ * This `FilterOperator` abstraction enables much more efficient processing of
  * `fetch` for `where` clauses containing OR conditions.
  *
  * See https://github.com/rocicorp/mono/pull/4339

--- a/packages/zql/src/ivm/filter-operators.ts
+++ b/packages/zql/src/ivm/filter-operators.ts
@@ -1,0 +1,102 @@
+import type {FetchRequest, Input, InputBase, Output} from './operator.ts';
+import {type Node} from './data.ts';
+import type {Change} from './change.ts';
+import type {SourceSchema} from './schema.ts';
+
+export interface FilterInput extends InputBase {
+  /** Tell the input where to send its output. */
+  setFilterOutput(output: FilterOutput): void;
+}
+
+export interface FilterOutput extends Output {
+  filter(node: Node): void;
+}
+
+export interface FilterOperator extends FilterInput, FilterOutput {}
+
+/**
+ * An implementation of FilterOutput that throws if pushed to. It is used as the
+ * initial value for for an operator's output before it is set.
+ */
+export const throwFilterOutput: FilterOutput = {
+  push(_change: Change): void {
+    throw new Error('Output not set');
+  },
+  filter(_node: Node): void {
+    throw new Error('Output not set');
+  },
+};
+
+export class FilterInputAdaptor implements FilterInput, Output {
+  readonly #input: Input;
+
+  #output: FilterOutput = throwFilterOutput;
+
+  constructor(input: Input) {
+    this.#input = input;
+    input.setOutput(this);
+  }
+
+  setFilterOutput(output: FilterOutput) {
+    this.#output = output;
+  }
+
+  destroy(): void {
+    this.#input.destroy();
+  }
+
+  getSchema(): SourceSchema {
+    return this.#input.getSchema();
+  }
+
+  fetch(req: FetchRequest) {
+    return this.#input.fetch(req);
+  }
+
+  cleanup(req: FetchRequest) {
+    return this.#input.cleanup(req);
+  }
+
+  push(change: Change) {
+    this.#output.push(change);
+  }
+}
+
+export class FilterOutputAdaptor implements Input, FilterOutput {
+  readonly #input: Input;
+
+  #output: Output = throwFilterOutput;
+
+  constructor(input: Input) {
+    this.#input = input;
+    input.setOutput(this);
+  }
+
+  filter(_node: Node) {
+    throw Error('Unexpected filter call.');
+  }
+
+  setOutput(output: Output) {
+    this.#output = output;
+  }
+
+  destroy(): void {
+    this.#input.destroy();
+  }
+
+  getSchema(): SourceSchema {
+    return this.#input.getSchema();
+  }
+
+  fetch(req: FetchRequest) {
+    return this.#input.fetch(req);
+  }
+
+  cleanup(req: FetchRequest) {
+    return this.#input.cleanup(req);
+  }
+
+  push(change: Change) {
+    this.#output.push(change);
+  }
+}

--- a/packages/zql/src/ivm/filter-operators.ts
+++ b/packages/zql/src/ivm/filter-operators.ts
@@ -2,6 +2,8 @@ import type {FetchRequest, Input, InputBase, Output} from './operator.ts';
 import {type Node} from './data.ts';
 import type {Change} from './change.ts';
 import type {SourceSchema} from './schema.ts';
+import type {Stream} from './stream.ts';
+import {assert} from '../../../shared/src/asserts.ts';
 
 export interface FilterInput extends InputBase {
   /** Tell the input where to send its output. */
@@ -9,7 +11,7 @@ export interface FilterInput extends InputBase {
 }
 
 export interface FilterOutput extends Output {
-  filter(node: Node): void;
+  filter(node: Node, cleanup: boolean): boolean;
 }
 
 export interface FilterOperator extends FilterInput, FilterOutput {}
@@ -22,15 +24,16 @@ export const throwFilterOutput: FilterOutput = {
   push(_change: Change): void {
     throw new Error('Output not set');
   },
-  filter(_node: Node): void {
+  filter(_node: Node, _cleanup: boolean): boolean {
     throw new Error('Output not set');
   },
 };
 
-export class FilterInputAdaptor implements FilterInput, Output {
+export class FilterStart implements FilterInput, Output {
   readonly #input: Input;
 
   #output: FilterOutput = throwFilterOutput;
+  #inFilterFetchOrCleanup = false;
 
   constructor(input: Input) {
     this.#input = input;
@@ -49,32 +52,52 @@ export class FilterInputAdaptor implements FilterInput, Output {
     return this.#input.getSchema();
   }
 
-  fetch(req: FetchRequest) {
-    return this.#input.fetch(req);
-  }
-
-  cleanup(req: FetchRequest) {
-    return this.#input.cleanup(req);
-  }
-
   push(change: Change) {
     this.#output.push(change);
   }
+
+  *filterFetchOrCleanup(req: FetchRequest, cleanup: boolean): Stream<Node> {
+    assert(!this.#inFilterFetchOrCleanup);
+    this.#inFilterFetchOrCleanup = true;
+    try {
+      for (const node of this.#input.fetch(req)) {
+        this.#output.filter(node, cleanup);
+        yield node;
+      }
+    } finally {
+      this.#inFilterFetchOrCleanup = false;
+    }
+  }
 }
 
-export class FilterOutputAdaptor implements Input, FilterOutput {
+export class FilterEnd implements Input, FilterOutput {
+  readonly #start: FilterStart;
   readonly #input: Input;
 
   #output: Output = throwFilterOutput;
+  #receivedNodeViaFilter: Node = undefined;
 
-  constructor(input: Input) {
+  constructor(start: FilterStart, input: Input) {
+    this.#start = start;
     this.#input = input;
     input.setOutput(this);
   }
 
-  filter(_node: Node) {
-    throw Error('Unexpected filter call.');
+  fetch(req: FetchRequest): Stream<Node> {
+    assert(this.#receivedNodeViaFilter === undefined);
+    for (const node of this.#start.filterFetch(req)) {
+      if (this.#receivedNodeViaFilter) {
+        assert(this.#receivedNodeViaFilter === node);
+        yield node;
+      }
+    }
   }
+
+  cleanup(req: FetchRequest): Stream<Node> {
+    throw new Error('Method not implemented.');
+  }
+
+  filter(node: Node, cleanup: boolean) {}
 
   setOutput(output: Output) {
     this.#output = output;
@@ -86,14 +109,6 @@ export class FilterOutputAdaptor implements Input, FilterOutput {
 
   getSchema(): SourceSchema {
     return this.#input.getSchema();
-  }
-
-  fetch(req: FetchRequest) {
-    return this.#input.fetch(req);
-  }
-
-  cleanup(req: FetchRequest) {
-    return this.#input.cleanup(req);
   }
 
   push(change: Change) {

--- a/packages/zql/src/ivm/filter-operators.ts
+++ b/packages/zql/src/ivm/filter-operators.ts
@@ -16,8 +16,9 @@ export interface FilterOutput extends Output {
 export interface FilterOperator extends FilterInput, FilterOutput {}
 
 /**
- * An implementation of FilterOutput that throws if pushed to. It is used as the
- * initial value for for an operator's output before it is set.
+ * An implementation of FilterOutput that throws if push or filter is called.
+ * It is used as the initial value for for an operator's output before it is
+ * set.
  */
 export const throwFilterOutput: FilterOutput = {
   push(_change: Change): void {

--- a/packages/zql/src/ivm/filter.test.ts
+++ b/packages/zql/src/ivm/filter.test.ts
@@ -4,6 +4,7 @@ import {Filter} from './filter.ts';
 import {createSource} from './test/source-factory.ts';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
 import {testLogConfig} from '../../../otel/src/test-log-config.ts';
+import {buildFilterPipeline} from './filter-operators.ts';
 
 const lc = createSilentLogContext();
 
@@ -20,7 +21,11 @@ test('basics', () => {
   ms.push({type: 'add', row: {a: 1, b: 'foo'}});
 
   const connector = ms.connect([['a', 'asc']]);
-  const filter = new Filter(connector, row => row.b === 'foo');
+  const filter = buildFilterPipeline(
+    connector,
+    filterInput => new Filter(filterInput, row => row.b === 'foo'),
+  );
+
   const out = new Catch(filter);
 
   expect(out.fetch()).toMatchInlineSnapshot(`
@@ -108,7 +113,10 @@ test('edit', () => {
   }
 
   const connector = ms.connect([['a', 'asc']]);
-  const filter = new Filter(connector, row => (row.x as number) % 2 === 0);
+  const filter = buildFilterPipeline(
+    connector,
+    filterInput => new Filter(filterInput, row => (row.x as number) % 2 === 0),
+  );
   const out = new Catch(filter);
 
   expect(out.fetch()).toMatchInlineSnapshot(`

--- a/packages/zql/src/ivm/filter.ts
+++ b/packages/zql/src/ivm/filter.ts
@@ -1,14 +1,15 @@
 import type {Row} from '../../../zero-protocol/src/data.ts';
 import type {Change} from './change.ts';
 import {drainStreams} from './data.ts';
-import {filterPush} from './filter-push.ts';
 import {
-  throwOutput,
-  type FetchRequest,
-  type Input,
-  type Operator,
-  type Output,
-} from './operator.ts';
+  throwFilterOutput,
+  type FilterInput,
+  type FilterOperator,
+  type FilterOutput,
+} from './filter-operators.ts';
+import {filterPush} from './filter-push.ts';
+import {type FetchRequest} from './operator.ts';
+import {type Node} from './data.ts';
 import type {SourceSchema} from './schema.ts';
 
 /**
@@ -16,19 +17,25 @@ import type {SourceSchema} from './schema.ts';
  *
  * The predicate must be pure.
  */
-export class Filter implements Operator {
-  readonly #input: Input;
+export class Filter implements FilterOperator {
+  readonly #input: FilterInput;
   readonly #predicate: (row: Row) => boolean;
 
-  #output: Output = throwOutput;
+  #output: FilterOutput = throwFilterOutput;
 
-  constructor(input: Input, predicate: (row: Row) => boolean) {
+  constructor(input: FilterInput, predicate: (row: Row) => boolean) {
     this.#input = input;
     this.#predicate = predicate;
-    input.setOutput(this);
+    input.setFilterOutput(this);
   }
 
-  setOutput(output: Output) {
+  filter(node: Node) {
+    if (this.#predicate(node.row)) {
+      this.#output.filter(node);
+    }
+  }
+
+  setFilterOutput(output: FilterOutput) {
     this.#output = output;
   }
 

--- a/packages/zql/src/ivm/join.fetch.test.ts
+++ b/packages/zql/src/ivm/join.fetch.test.ts
@@ -2253,7 +2253,7 @@ function fetchTest(t: FetchTest): FetchTestResults {
       for (let i = results.fetchMessages.length - 1; i >= 0; i--) {
         const [name, type, req] = results.fetchMessages[i];
         expect(type).toSatisfy(t => t === 'fetch' || t === 'cleanup');
-        assert(type !== 'push');
+        assert(type === 'fetch' || type === 'cleanup');
         if (!(req.constraint && seen.has(req.constraint))) {
           expectedMessages[i] = [name, 'cleanup', req];
         } else {

--- a/packages/zql/src/ivm/operator.ts
+++ b/packages/zql/src/ivm/operator.ts
@@ -14,6 +14,18 @@ export interface InputBase {
   getSchema(): SourceSchema;
 
   /**
+   * Completely destroy the input. Destroying an input
+   * causes it to call destroy on its upstreams, fully
+   * cleaning up a pipeline.
+   */
+  destroy(): void;
+}
+
+export interface Input extends InputBase {
+  /** Tell the input where to send its output. */
+  setOutput(output: Output): void;
+
+  /**
    * Fetch data. May modify the data in place.
    * Returns nodes sorted in order of `SourceSchema.compareRows`.
    */
@@ -31,18 +43,6 @@ export interface InputBase {
    * propagate the cleanup message through the graph.
    */
   cleanup(req: FetchRequest): Stream<Node>;
-
-  /**
-   * Completely destroy the input. Destroying an input
-   * causes it to call destroy on its upstreams, fully
-   * cleaning up a pipeline.
-   */
-  destroy(): void;
-}
-
-export interface Input extends InputBase {
-  /** Tell the input where to send its output. */
-  setOutput(output: Output): void;
 }
 
 export type FetchRequest = {

--- a/packages/zql/src/ivm/operator.ts
+++ b/packages/zql/src/ivm/operator.ts
@@ -9,7 +9,7 @@ import type {Stream} from './stream.ts';
 /**
  * Input to an operator.
  */
-export interface Input {
+export interface InputBase {
   /** The schema of the data this input returns. */
   getSchema(): SourceSchema;
 
@@ -32,15 +32,17 @@ export interface Input {
    */
   cleanup(req: FetchRequest): Stream<Node>;
 
-  /** Tell the input where to send its output. */
-  setOutput(output: Output): void;
-
   /**
    * Completely destroy the input. Destroying an input
    * causes it to call destroy on its upstreams, fully
    * cleaning up a pipeline.
    */
   destroy(): void;
+}
+
+export interface Input extends InputBase {
+  /** Tell the input where to send its output. */
+  setOutput(output: Output): void;
 }
 
 export type FetchRequest = {

--- a/packages/zql/src/query/test/query-delegate.ts
+++ b/packages/zql/src/query/test/query-delegate.ts
@@ -3,6 +3,7 @@ import {assert} from '../../../../shared/src/asserts.ts';
 import {deepEqual} from '../../../../shared/src/json.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import type {AST} from '../../../../zero-protocol/src/ast.ts';
+import type {FilterInput} from '../../ivm/filter-operators.ts';
 import {MemoryStorage} from '../../ivm/memory-storage.ts';
 import type {Input} from '../../ivm/operator.ts';
 import type {Source} from '../../ivm/source.ts';
@@ -107,6 +108,10 @@ export class QueryDelegateImpl implements QueryDelegate {
   }
 
   decorateInput(input: Input, _description: string): Input {
+    return input;
+  }
+
+  decorateFilterInput(input: FilterInput, _description: string): FilterInput {
     return input;
   }
 

--- a/packages/zqlite/src/test/source-factory.ts
+++ b/packages/zqlite/src/test/source-factory.ts
@@ -21,6 +21,7 @@ import type {QueryDelegate} from '../../../zql/src/query/query-impl.ts';
 import {Database} from '../db.ts';
 import {compile, sql} from '../internal/sql.ts';
 import {TableSource, toSQLiteTypeName} from '../table-source.ts';
+import type {FilterInput} from '../../../zql/src/ivm/filter-operators.ts';
 
 export const createSource: SourceFactory = (
   lc: LogContext,
@@ -165,6 +166,9 @@ export function newQueryDelegate(
       return new MemoryStorage();
     },
     decorateInput(input: Input): Input {
+      return input;
+    },
+    decorateFilterInput(input: FilterInput): FilterInput {
       return input;
     },
     addServerQuery() {


### PR DESCRIPTION
**Problem**
Fetching a pipeline with an OR is very inefficient if one or more branches are sparse or empty.  

This is because of how `FanIn` merges fetch `Stream`s.  It essentially uses merge-sort, asking each `Stream` for its next `Node `to determine the next `Node` in sort order.  A sparse or empty branch may process every (or nearly every) row in its source table to answer that its `Stream` is empty, even if another branch could satisfy the limit of the query processing far fewer rows.

For example lets say the condition of a query is `or(cmp('foo', 'bar'), and(cmp('fuzzy', 'wuzzy'), exists('baz')))`, where `cmp('foo', 'bar')` is always false but `and(cmp('fuzzy', 'wuzzy'), exists('baz'))` has many matches early in the sort order.  We need a complex query with exists, cause otherwise we have an optimization that will hoist the whole filter to the SqlLite query. We will fetch from SqlLite `or(cmp('foo', 'bar'), cmp('fuzzy', 'wuzzy'))`, which will effectively return  `cmp('fuzzy', 'wuzzy')`, since `cmp('foo', 'bar')` is always false. FanIn/FanOut will do this fetch for each branch of the or.  In order to merge in the right sort order it will ask for the next item from branch `cmp('foo', 'bar')`, and the next item from branch `and(cmp('fuzzy', 'wuzzy'), exists('baz'))`, to compare them. To get the next item from branch `cmp('fuzzy', 'wuzzy')`, we fetch `or(cmp('foo', 'bar'), cmp('fuzzy', 'wuzzy'))` from SqlLite which has many rows, but then the Filter operator for branch `cmp('fuzzy', 'wuzzy')` discards all the rows.  We effectively process all of `cmp('fuzzy', 'wuzzy')` (without respect to limit, so worst case the entire table) to answer that the next item for `cmp('foo', 'bar')` doesn't exist. 

There are two significant inefficiencies here:
1. a query to SqlLite is made per branch of OR.  Each query has to be broad enough to return all rows which may match any branch of the OR.
2. to correctly order/dedup the merged output of these branches, many more rows than necessary (in many case all rows of a table) are processed if one or more branch is empty/sparse.

**Solution**

Eliminate doing a query per branch.  Do a single query that is broad enough to return all rows which may match any branch of the OR.

Process the nodes returned from this single query in order, filtering them one at a time, eliminating the need to merge at all.

This is accomplished by introducing the new abstraction of a `FilterOperator`.  The `where` clause of a ZQL query is implemented using a sub-graph of `FilterOperators`.  This sub-graph starts with a `FilterStart` operator, that adapts from the normal `Operator` `Output`, to the `FilterOperator` `FilterInput`, and ends with a `FilterEnd` operator that adapts from a `FilterOperator` `FilterOutput` to a normal `Operator` `Input`.  `FilterOperator'`s do not have `fetch` or `cleanup` instead they have a `filter(node: Node, cleanup: boolean): boolean` method.  They also have `push` which is just like normal `Operator` push.  There are currently 4 `FilterOperator`s: `Filter`, `Exist`, `FanIn` and `FanOut`.    Not having a `fetch` means these `FilterOperator`'s cannot modify Node rows or relationships, but they shouldn't, they should just filter  This new abstraction allows much more efficient processing of `fetch` for an OR condition.  
_Fetch with a FilterOperator subgraph_
When a `FilterEnd` receives a fetch, it fetches from its corresponding `FilterStart` at the start of the `FilterOperator` subgraph, which fetches from it's `Input` (which is a normal `Operator`), it then asks its `FilterOutput` to filter each node, yielding to `FilterEnd` those Node's which pass the filter. 
_Push with a FilterOperator subgraph_
Push works as it does today.  `FilterStart` receives a push, which pushes to its `FilterOutput` which pushes to its `FilterOutput`(s) (maybe multiple, as `FanOut` can branch out pushes), until the push conditionally (it may be filtered out) reaches `FilterEnd`, which pushes it to it normal `Operator` `Output`.

Note this code structure can also support correctly and efficiently processing nested ORs (i.e. nested `FanIn` / `FanOut`), making it possible to not convert `where` conditions to DNF.


Perf impact on a 'OR with empty branch and limit with exists' scenario  using the chinook tracks data set yielded a 100x speed up.
```
 ✓  zql-benchmarks/pg-17  src/chinook-hydration.bench.ts > OR with empty branch and limit with exists 1816ms
     name           hz     min      max    mean     p75      p99     p995     p999     rme  samples
   · zql     29,029.27  0.0238   3.0766  0.0344  0.0268   0.0718   0.1245   2.1104  ±5.83%    14515  [35.78x] ⇑
     zql        811.28  1.0302   2.7010  1.2326  1.1540   2.5545   2.6407   2.7010  ±3.09%      406  (baseline)
   · zqlite  10,963.91  0.0690   2.9097  0.0912  0.0767   0.2030   1.7859   2.3478  ±4.99%     5482  [99.17x] ⇑
     zqlite     110.56  8.3685  10.5341  9.0450  9.7990  10.5341  10.5341  10.5341  ±1.80%       56  (baseline)
   · zpg        898.83  0.7937   4.8358  1.1126  1.1835   2.0152   2.6168   4.8358  ±2.44%      450  [1.21x] ⇑
     zpg        744.30  0.8805   6.7553  1.3435  1.3058   4.4409   5.4718   6.7553  ±5.07%      373  (baseline)
```