### PR TITLE
chore(zero-cache): fix backup monitor logging

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/backup-monitor.ts
+++ b/packages/zero-cache/src/services/change-streamer/backup-monitor.ts
@@ -111,7 +111,7 @@ export class BackupMonitor implements Service {
                   }
                 }, cleanupAt - now),
               );
-              this.#lc.debug?.('timers', [...this.#cleanupTimers.entries()]);
+              this.#lc.debug?.('timers', [...this.#cleanupTimers.keys()]);
             }
           }
         }


### PR DESCRIPTION
Fixes a "circular object" error when trying to log the timeout objects.