### PR TITLE
chore(zero-cache): include the IncomingMessage in the websocket receiver API

### DIFF
--- a/packages/zero-cache/src/types/websocket-handoff.test.ts
+++ b/packages/zero-cache/src/types/websocket-handoff.test.ts
@@ -47,9 +47,11 @@ describe('types/websocket-handoff', () => {
     installWebSocketReceiver(
       lc,
       wss,
-      (ws, payload) => {
+      (ws, payload, m) => {
         ws.on('message', msg => {
-          ws.send(`Received "${msg}" and payload ${JSON.stringify(payload)}`);
+          ws.send(
+            `Received "${msg}" and payload ${JSON.stringify(payload)} at ${m.url}`,
+          );
           ws.close();
         });
       },
@@ -57,12 +59,12 @@ describe('types/websocket-handoff', () => {
     );
 
     const {promise: reply, resolve} = resolver<RawData>();
-    const ws = new WebSocket(`ws://localhost:${port}/`);
+    const ws = new WebSocket(`ws://localhost:${port}/foobar`);
     ws.on('open', () => ws.send('hello'));
     ws.on('message', msg => resolve(msg));
 
     expect(String(await reply)).toBe(
-      'Received "hello" and payload {"foo":"boo"}',
+      'Received "hello" and payload {"foo":"boo"} at /foobar',
     );
   });
 

--- a/packages/zero-cache/src/types/websocket-handoff.ts
+++ b/packages/zero-cache/src/types/websocket-handoff.ts
@@ -31,7 +31,11 @@ export type WebSocketHandoff<P> = (
   onerror: (reason: unknown) => void,
 ) => HandoffSpec<P> | void;
 
-export type WebSocketReceiver<P> = (ws: WebSocket, payload: P) => void;
+export type WebSocketReceiver<P> = (
+  ws: WebSocket,
+  payload: P,
+  msg: IncomingMessageSubset,
+) => void;
 
 export type WebSocketHandoffHandler = (
   message: IncomingMessageSubset,
@@ -135,7 +139,7 @@ export function installWebSocketReceiver<P>(
       message as IncomingMessage,
       socket as Socket,
       Buffer.from(head),
-      ws => receive(ws, payload),
+      ws => receive(ws, payload, message),
     );
   });
 }


### PR DESCRIPTION
This will allow more flexible routing of websockets passed between workers. (To be used in an upcoming PR)