### PR TITLE
feat(zero-cache)!: improved backup protocol and change-log cleanup logic

### DIFF
--- a/.github/workflows/sst-gigabugs-deploy.yml
+++ b/.github/workflows/sst-gigabugs-deploy.yml
@@ -2,7 +2,7 @@ name: Build and Deploy Gigabugs Zero-Cache AWS SST
 
 on:
   push:
-    branches: [darkgnotic/better-backup] # [gigabugs]
+    branches: [gigabugs]
 env:
   # Setting an environment variable with the value of a configuration variable
   ECR_IMAGE_ZERO_CACHE: zero-zgigabugs

--- a/.github/workflows/sst-gigabugs-deploy.yml
+++ b/.github/workflows/sst-gigabugs-deploy.yml
@@ -2,7 +2,7 @@ name: Build and Deploy Gigabugs Zero-Cache AWS SST
 
 on:
   push:
-    branches: [gigabugs]
+    branches: [darkgnotic/better-backup] # [gigabugs]
 env:
   # Setting an environment variable with the value of a configuration variable
   ECR_IMAGE_ZERO_CACHE: zero-zgigabugs

--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -256,8 +256,7 @@ test('zero-cache --help', () => {
                                                                                                                                                                    
      --litestream-executable string                              optional                                                                                          
        ZERO_LITESTREAM_EXECUTABLE env                                                                                                                              
-                                                                 Path to the litestream executable. This option has no effect if                                   
-                                                                 litestream-backup-url is unspecified.                                                             
+                                                                 Path to the litestream executable.                                                                
                                                                                                                                                                    
      --litestream-config-path string                             default: "./src/services/litestream/config.yml"                                                   
        ZERO_LITESTREAM_CONFIG_PATH env                                                                                                                             
@@ -275,7 +274,8 @@ test('zero-cache --help', () => {
      --litestream-backup-url string                              optional                                                                                          
        ZERO_LITESTREAM_BACKUP_URL env                                                                                                                              
                                                                  The location of the litestream backup, usually an s3:// URL.                                      
-                                                                 If set, the litestream-executable must also be specified.                                         
+                                                                 This is only consulted by the replication-manager.                                                
+                                                                 view-syncers receive this information from the replication-manager.                               
                                                                                                                                                                    
      --litestream-port number                                    optional                                                                                          
        ZERO_LITESTREAM_PORT env                                                                                                                                    
@@ -327,16 +327,6 @@ test('zero-cache --help', () => {
                                                                  the snapshot from the backup.                                                                     
                                                                                                                                                                    
                                                                  This requires a custom build of litestream (version 0.3.13+z0.0.1+).                              
-                                                                                                                                                                   
-     --litestream-restore-duration-ms-estimate number            optional                                                                                          
-       ZERO_LITESTREAM_RESTORE_DURATION_MS_ESTIMATE env                                                                                                            
-                                                                 The estimated time required to restore the replica from backup. This duration                     
-                                                                 is used to determine when it is safe to purge change long entries; the                            
-                                                                 change-streamer waits for at least this duration before purging changes                           
-                                                                 that have been successfully backed up.                                                            
-                                                                                                                                                                   
-                                                                 This can generally be left unspecified, as the server will compute the estimate                   
-                                                                 based on an actual restore, using the initial-sync time for bootstrapping.                        
                                                                                                                                                                    
      --storage-db-tmp-dir string                                 optional                                                                                          
        ZERO_STORAGE_DB_TMP_DIR env                                                                                                                                 

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -395,10 +395,7 @@ export const zeroOptions = {
   litestream: {
     executable: {
       type: v.string().optional(),
-      desc: [
-        `Path to the {bold litestream} executable. This option has no effect if`,
-        `{bold litestream-backup-url} is unspecified.`,
-      ],
+      desc: [`Path to the {bold litestream} executable.`],
     },
 
     configPath: {
@@ -429,7 +426,8 @@ export const zeroOptions = {
       type: v.string().optional(),
       desc: [
         `The location of the litestream backup, usually an {bold s3://} URL.`,
-        `If set, the {bold litestream-executable} must also be specified.`,
+        `This is only consulted by the {bold replication-manager}.`,
+        `{bold view-syncers} receive this information from the {bold replication-manager}.`,
       ],
     },
 
@@ -502,19 +500,6 @@ export const zeroOptions = {
         `the snapshot from the backup.`,
         ``,
         `This requires a custom build of litestream (version 0.3.13+z0.0.1+).`,
-      ],
-    },
-
-    restoreDurationMsEstimate: {
-      type: v.number().optional(),
-      desc: [
-        `The estimated time required to restore the replica from backup. This duration`,
-        `is used to determine when it is safe to purge change long entries; the`,
-        `{bold change-streamer} waits for at least this duration before purging changes`,
-        `that have been successfully backed up.`,
-        ``,
-        `This can generally be left unspecified, as the server will compute the estimate`,
-        `based on an actual restore, using the initial-sync time for bootstrapping.`,
       ],
     },
   },

--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -88,28 +88,14 @@ export default async function runWorker(
   const {
     taskID,
     changeStreamer: {mode: changeStreamerMode},
-    litestream: {backupURL, restoreDurationMsEstimate},
+    litestream,
   } = config;
-  const litestream = backupURL?.length;
   const runChangeStreamer = changeStreamerMode !== 'discover';
 
-  if (litestream) {
-    // For the replication-manager (i.e. authoritative replica), only attempt
-    // a restore once, allowing the backup to be absent.
-    // For view-syncers, attempt a restore for up to 10 times over 30 seconds.
+  let restoreStart = new Date();
+  if (litestream.backupURL || (litestream.executable && !runChangeStreamer)) {
     try {
-      const restoreElapsedMs = await restoreReplica(
-        lc,
-        config,
-        runChangeStreamer ? 1 : 10,
-        3000,
-      );
-      if (!restoreDurationMsEstimate && restoreElapsedMs) {
-        internalFlags.push(
-          '--litestream-restore-duration-ms-estimate',
-          String(restoreElapsedMs),
-        );
-      }
+      restoreStart = await restoreReplica(lc, config);
     } catch (e) {
       if (runChangeStreamer) {
         // If the restore failed, e.g. due to a corrupt backup, the
@@ -127,10 +113,12 @@ export default async function runWorker(
 
   const {promise: changeStreamerReady, resolve} = resolver();
   const changeStreamer = runChangeStreamer
-    ? loadWorker('./server/change-streamer.ts', 'supporting').once(
-        'message',
-        resolve,
-      )
+    ? loadWorker(
+        './server/change-streamer.ts',
+        'supporting',
+        undefined,
+        String(restoreStart.getTime()),
+      ).once('message', resolve)
     : (resolve() ?? undefined);
 
   if (numSyncers) {
@@ -147,7 +135,7 @@ export default async function runWorker(
   // file is present.
   await changeStreamerReady;
 
-  if (runChangeStreamer && litestream) {
+  if (runChangeStreamer && litestream.backupURL) {
     // Start a backup replicator and corresponding litestream backup process.
     const {promise: backupReady, resolve} = resolver();
     const mode: ReplicaFileMode = 'backup';
@@ -171,7 +159,7 @@ export default async function runWorker(
   const syncers: Worker[] = [];
   if (numSyncers) {
     const mode: ReplicaFileMode =
-      runChangeStreamer && litestream ? 'serving-copy' : 'serving';
+      runChangeStreamer && litestream.backupURL ? 'serving-copy' : 'serving';
     const replicator = loadWorker(
       './server/replicator.ts',
       'supporting',

--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -1,4 +1,4 @@
-import {pid} from 'node:process';
+import {pid} from 'process';
 import {assert} from '../../../shared/src/asserts.ts';
 import {must} from '../../../shared/src/must.ts';
 import * as v from '../../../shared/src/valita.ts';
@@ -10,7 +10,6 @@ import {
   ReplicatorService,
   type ReplicatorMode,
 } from '../services/replicator/replicator.ts';
-import {pgClient} from '../types/pg.ts';
 import {
   parentWorker,
   singleProcessMode,
@@ -42,14 +41,7 @@ export default async function runWorker(
 
   const shard = getShardConfig(config);
   const {taskID, change} = config;
-  // Create a pg client with a single short-lived connection for the purpose
-  // of change-streamer discovery (i.e. ChangeDB as DNS).
-  const changeDB = pgClient(lc, change.db, {
-    max: 1,
-    ['idle_timeout']: 15,
-    connection: {['application_name']: 'change-streamer-discovery'},
-  });
-  const changeStreamer = new ChangeStreamerHttpClient(lc, shard, changeDB);
+  const changeStreamer = new ChangeStreamerHttpClient(lc, shard, change.db);
 
   const replicator = new ReplicatorService(
     lc,

--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -1,4 +1,4 @@
-import {pid} from 'process';
+import {pid} from 'node:process';
 import {assert} from '../../../shared/src/asserts.ts';
 import {must} from '../../../shared/src/must.ts';
 import * as v from '../../../shared/src/valita.ts';

--- a/packages/zero-cache/src/server/worker-dispatcher.test.ts
+++ b/packages/zero-cache/src/server/worker-dispatcher.test.ts
@@ -68,6 +68,10 @@ test.each([
     {version: '3', worker: 'replication', action: 'changes'},
   ],
   [
+    '/replication/v3/snapshot?id=foobar',
+    {version: '3', worker: 'replication', action: 'snapshot'},
+  ],
+  [
     '/api/replication/v1/changes',
     {base: 'api', worker: 'replication', version: '1', action: 'changes'},
   ],

--- a/packages/zero-cache/src/services/change-streamer/backup-monitor.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/backup-monitor.test.ts
@@ -1,8 +1,11 @@
+import {resolver} from '@rocicorp/resolver';
 import nock from 'nock';
 import {beforeEach, describe, expect, test, vi} from 'vitest';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import {Subscription} from '../../types/subscription.ts';
 import {BackupMonitor} from './backup-monitor.ts';
 import type {ChangeStreamerService} from './change-streamer.ts';
+import type {SnapshotMessage} from './snapshot.ts';
 
 describe('change-streamer/backup-monitor', () => {
   const scheduled: string[] = [];
@@ -34,6 +37,7 @@ litestream_replica_validation_total{db="/tmp/zbugs-sync-replica.db",name="file",
 
     monitor = new BackupMonitor(
       lc,
+      's3://foo/bar',
       'http://localhost:4850/metrics',
       changeStreamer as unknown as ChangeStreamerService,
       100_000, // 100 seconds
@@ -47,68 +51,192 @@ litestream_replica_validation_total{db="/tmp/zbugs-sync-replica.db",name="file",
     return () => vi.useRealTimers();
   });
 
+  function getFirstMessage(
+    sub: Subscription<SnapshotMessage>,
+  ): Promise<SnapshotMessage> {
+    const {promise, resolve} = resolver<SnapshotMessage>();
+    void (async function () {
+      for await (const msg of sub) {
+        resolve(msg);
+        // To simulate an open connection, do not exit the loop.
+      }
+    })();
+    return promise;
+  }
+
   test('schedules overdue cleanup', async () => {
     setMetricsResponse('618ocqq8', '1.74545644476593e+09');
 
-    await monitor.checkMetrics();
+    await monitor.checkWatermarksAndScheduleCleanup();
 
-    vi.advanceTimersByTime(0);
     expect(scheduled).toEqual(['618ocqq8']);
   });
 
-  test('schedules new cleanup', async () => {
-    vi.setSystemTime(Date.UTC(2025, 3, 24));
+  test('schedules new cleanup at the right time', async () => {
+    const time = Date.UTC(2025, 3, 24);
+    vi.setSystemTime(time);
     const nowSeconds = (Date.now() / 1000).toPrecision(9);
     setMetricsResponse('618p0bw8', nowSeconds);
 
-    await monitor.checkMetrics();
+    await monitor.checkWatermarksAndScheduleCleanup();
 
-    vi.advanceTimersByTime(99_999);
+    vi.setSystemTime(time + 99_999);
+    await monitor.checkWatermarksAndScheduleCleanup();
     expect(scheduled).toEqual([]);
 
-    vi.advanceTimersByTime(1);
+    vi.setSystemTime(time + 100_000);
+    await monitor.checkWatermarksAndScheduleCleanup();
     expect(scheduled).toEqual(['618p0bw8']);
   });
 
-  test('skips redundant watermarks cleanup', async () => {
-    vi.setSystemTime(Date.UTC(2025, 3, 24));
-    const firstWatermarkTime = (Date.UTC(2025, 3, 23) / 1000).toPrecision(9);
-    setMetricsResponse('618ofzts', firstWatermarkTime);
+  test('drops obsolete watermarks', async () => {
+    const time = Date.UTC(2025, 3, 24);
+    vi.setSystemTime(time);
 
-    await monitor.checkMetrics();
-    vi.advanceTimersByTime(0);
-    expect(scheduled.pop()).toEqual('618ofzts');
+    const t1 = (Date.now() / 1000).toPrecision(9);
+    setMetricsResponse('618ocqq8', t1);
+    await monitor.checkWatermarksAndScheduleCleanup();
+    expect(scheduled).toEqual([]);
 
-    for (let i = 0; i < 5; i++) {
-      await monitor.checkMetrics();
-      vi.advanceTimersByTime(100);
-      expect(scheduled).toEqual([]);
-    }
+    vi.setSystemTime(time + 10_000);
+    const t2 = (Date.now() / 1000).toPrecision(9);
+    setMetricsResponse('618p0bw8', t2);
+    await monitor.checkWatermarksAndScheduleCleanup();
+    expect(scheduled).toEqual([]);
 
-    const secondWatermarkTime = ((Date.now() - 100_000) / 1000).toPrecision(9);
-    setMetricsResponse('618oko80', secondWatermarkTime);
+    vi.setSystemTime(time + 110_000);
+    await monitor.checkWatermarksAndScheduleCleanup();
+    expect(scheduled).toEqual(['618p0bw8']);
+  });
 
-    await monitor.checkMetrics();
-    vi.advanceTimersByTime(1);
-    expect(scheduled.pop()).toEqual('618oko80');
+  test('only keeps one reservation per id', async () => {
+    const sub1 = monitor.startSnapshotReservation('foo-bar');
+    expect(await getFirstMessage(sub1)).toEqual([
+      'status',
+      {
+        tag: 'status',
+        backupURL: 's3://foo/bar',
+      },
+    ]);
+    expect(sub1.active).toBe(true);
 
-    for (let i = 0; i < 5; i++) {
-      await monitor.checkMetrics();
-      vi.advanceTimersByTime(100);
-      expect(scheduled).toEqual([]);
-    }
+    const sub2 = monitor.startSnapshotReservation('bar-foo');
+    expect(await getFirstMessage(sub2)).toEqual([
+      'status',
+      {
+        tag: 'status',
+        backupURL: 's3://foo/bar',
+      },
+    ]);
+    expect(sub1.active).toBe(true);
+    expect(sub2.active).toBe(true);
 
-    const thirdWatermarkTime = ((Date.now() - 100_000) / 1000).toPrecision(9);
-    setMetricsResponse('618p0bw8', thirdWatermarkTime);
+    const sub3 = monitor.startSnapshotReservation('bar-foo');
+    expect(await getFirstMessage(sub3)).toEqual([
+      'status',
+      {
+        tag: 'status',
+        backupURL: 's3://foo/bar',
+      },
+    ]);
+    expect(sub1.active).toBe(true);
+    expect(sub2.active).toBe(false);
+    expect(sub3.active).toBe(true);
+  });
 
-    await monitor.checkMetrics();
-    vi.advanceTimersByTime(1);
-    expect(scheduled.pop()).toEqual('618p0bw8');
+  test('pauses cleanup during reservation', async () => {
+    const time = Date.UTC(2025, 3, 24);
+    vi.setSystemTime(time);
+    const nowSeconds = (Date.now() / 1000).toPrecision(9);
+    setMetricsResponse('618p0bw8', nowSeconds);
 
-    for (let i = 0; i < 5; i++) {
-      await monitor.checkMetrics();
-      vi.advanceTimersByTime(100);
-      expect(scheduled).toEqual([]);
-    }
+    await monitor.checkWatermarksAndScheduleCleanup();
+
+    const sub = monitor.startSnapshotReservation('foo-bar');
+    expect(await getFirstMessage(sub)).toEqual([
+      'status',
+      {
+        tag: 'status',
+        backupURL: 's3://foo/bar',
+      },
+    ]);
+
+    vi.setSystemTime(time + 100_000);
+    await monitor.checkWatermarksAndScheduleCleanup();
+    expect(scheduled).toEqual([]);
+
+    monitor.endReservation('foo-bar');
+    await monitor.checkWatermarksAndScheduleCleanup();
+    expect(scheduled).toEqual(['618p0bw8']);
+  });
+
+  test('extends cleanup delay due to reservation', async () => {
+    const time = Date.UTC(2025, 3, 24);
+    vi.setSystemTime(time);
+    const sub = monitor.startSnapshotReservation('boo-far');
+    expect(await getFirstMessage(sub)).toEqual([
+      'status',
+      {
+        tag: 'status',
+        backupURL: 's3://foo/bar',
+      },
+    ]);
+
+    vi.setSystemTime(time + 50_000);
+    const nowSeconds = (Date.now() / 1000).toPrecision(9);
+    setMetricsResponse('618p0bw8', nowSeconds);
+
+    await monitor.checkWatermarksAndScheduleCleanup();
+    expect(scheduled).toEqual([]);
+
+    vi.setSystemTime(time + 125_000); // Reservation was held of 125 secs.
+    monitor.endReservation('boo-far');
+    await monitor.checkWatermarksAndScheduleCleanup();
+    expect(scheduled).toEqual([]);
+
+    // No cleanup should be scheduled, even though 100 seconds passed,
+    // as the delay should have been increased to 125 seconds.
+    vi.setSystemTime(time + 174_999);
+    await monitor.checkWatermarksAndScheduleCleanup();
+    expect(scheduled).toEqual([]);
+
+    vi.setSystemTime(time + 175_000);
+    await monitor.checkWatermarksAndScheduleCleanup();
+    expect(scheduled).toEqual(['618p0bw8']);
+  });
+
+  test('does not extend cleanup delay on prematurely terminated reservation', async () => {
+    const time = Date.UTC(2025, 3, 24);
+    vi.setSystemTime(time);
+    const sub = monitor.startSnapshotReservation('boo-far');
+    expect(await getFirstMessage(sub)).toEqual([
+      'status',
+      {
+        tag: 'status',
+        backupURL: 's3://foo/bar',
+      },
+    ]);
+
+    vi.setSystemTime(time + 50_000);
+    const nowSeconds = (Date.now() / 1000).toPrecision(9);
+    setMetricsResponse('618p0bw8', nowSeconds);
+
+    await monitor.checkWatermarksAndScheduleCleanup();
+    expect(scheduled).toEqual([]);
+
+    // Hold the reservation for 125 secs but terminate unexpectedly.
+    // This should *not* result in increasing the cleanup delay.
+    vi.setSystemTime(time + 125_000);
+    sub.cancel();
+    await monitor.checkWatermarksAndScheduleCleanup();
+    expect(scheduled).toEqual([]);
+
+    vi.setSystemTime(time + 149_999);
+    await monitor.checkWatermarksAndScheduleCleanup();
+    expect(scheduled).toEqual([]);
+
+    vi.setSystemTime(time + 150_000); // delay should still be 100 secs
+    await monitor.checkWatermarksAndScheduleCleanup();
+    expect(scheduled).toEqual(['618p0bw8']);
   });
 });

--- a/packages/zero-cache/src/services/change-streamer/backup-monitor.ts
+++ b/packages/zero-cache/src/services/change-streamer/backup-monitor.ts
@@ -1,58 +1,85 @@
 import type {LogContext} from '@rocicorp/logger';
 import parsePrometheusTextFormat from 'parse-prometheus-text-format';
 import {promiseVoid} from '../../../../shared/src/resolved-promises.ts';
+import {Subscription} from '../../types/subscription.ts';
 import {RunningState} from '../running-state.ts';
 import type {Service} from '../service.ts';
 import type {ChangeStreamerService} from './change-streamer.ts';
+import type {SnapshotMessage} from './snapshot.ts';
 
 export const CHECK_INTERVAL_MS = 60 * 1000;
-const DEFAULT_CLEANUP_DELAY_MS = 60 * 1000;
+const MIN_CLEANUP_DELAY_MS = 30 * 1000;
 
-// The BackupMonitor polls the litestream "/metrics" endpoint to track the
-// watermark (label) value of the `litestream_replica_progress` gauge and
-// schedule cleanup of change log entries that can be purged as a result.
-//
-// See: https://github.com/rocicorp/litestream/pull/3
-//
-// Note that change log purging involves two time values:
-// 1. The time at which a watermark has been backed up by litestream
-// 2. The time it takes to restore the replica from the backup
-//
-// Namely, it is not safe to simply purge change log entries as soon as they
-// have been applied and backed up by litestream. Consider the case in which
-// litestream backs up new wal segments every minute, but it takes 5 minutes
-// to restore a replica: if a zero-cache starts restoring a replica at
-// minute 0, and new watermarks are replicated at minutes 1, 2, 3, 4, and 5,
-// purging changelog records as soon as those watermarks are replicated would
-// result in the zero-cache not being able to catch up from minute 0 once it
-// has finished restoring the replica.
-//
-// Consequently, cleanup is delayed by an interval equivalent to the time it
-// takes for the litestream restore, which is calculated by the runner (when
-// it performed the restore or the initial sync). In addition to this delay,
-// the ChangeStreamerService itself adds at least 30 seconds of padding before
-// purging records, ensuring all active subscribers are past the watermark
-// before purging preceding records.
+type Reservation = {
+  start: Date;
+  sub: Subscription<SnapshotMessage>;
+};
+
+/**
+ * The BackupMonitor polls the litestream "/metrics" endpoint to track the
+ * watermark (label) value of the `litestream_replica_progress` gauge and
+ * schedule cleanup of change log entries that can be purged as a result.
+ *
+ * See: https: *github.com/rocicorp/litestream/pull/3
+ *
+ * Namely, it is not safe to simply purge change log entries as soon as they
+ * have been applied and backed up by litestream. Consider the case in which
+ * litestream backs up new wal segments every minute, but it takes 5 minutes
+ * to restore a replica: if a zero-cache starts restoring a replica at
+ * minute 0, and new watermarks are replicated at minutes 1, 2, 3, 4, and 5,
+ * purging changelog records as soon as those watermarks are replicated would
+ * result in the zero-cache not being able to catch up from minute 0 once it
+ * has finished restoring the replica.
+ *
+ * The `/snapshot` reservation protocol is used to prevent premature change
+ * log cleanup:
+ * - Clients restoring a snapshot initiate a `/snapshot` request and hold that
+ *   request open while it restores its snapshot, prepares it, and
+ *   starts its subscription to the change stream. During this time, no
+ *   cleanups are scheduled.
+ * - When the subscription is started, the interval since the beginning of
+ *   of the reservation is tracked to increase the background cleanup delay
+ *   interval if needed. The reservation is ended (and request closed), and
+ *   cleanup scheduling is resumed with the current delay interval.
+ *
+ * Note that the reservation request is the primary mechanism by which
+ * premature change log cleanup is prevented. The cleanup delay interval is
+ * a secondary safeguard.
+ */
 export class BackupMonitor implements Service {
   readonly id = 'backup-monitor';
   readonly #lc: LogContext;
+  readonly #backupURL: string;
   readonly #metricsEndpoint: string;
   readonly #changeStreamer: ChangeStreamerService;
   readonly #state = new RunningState(this.id);
-  readonly #cleanupDelayMs: number;
-  readonly #cleanupTimers = new Map<string, NodeJS.Timeout>();
+
+  readonly #reservations = new Map<string, Reservation>();
+  readonly #watermarks = new Map<string, Date>();
+
+  #lastWatermark: string = '';
+  #cleanupDelayMs: number;
   #checkMetricsTimer: NodeJS.Timeout | undefined;
 
   constructor(
     lc: LogContext,
+    backupURL: string,
     metricsEndpoint: string,
     changeStreamer: ChangeStreamerService,
-    cleanupDelayMs: number | undefined,
+    initialCleanupDelayMs: number,
   ) {
     this.#lc = lc.withContext('component', this.id);
+    this.#backupURL = backupURL;
     this.#metricsEndpoint = metricsEndpoint;
     this.#changeStreamer = changeStreamer;
-    this.#cleanupDelayMs = cleanupDelayMs ?? DEFAULT_CLEANUP_DELAY_MS;
+    this.#cleanupDelayMs = Math.max(
+      initialCleanupDelayMs,
+      MIN_CLEANUP_DELAY_MS, // purely for peace of mind
+    );
+
+    this.#lc.info?.(
+      `backup monitor started ${initialCleanupDelayMs} ms after snapshot restore`,
+    );
   }
 
   run(): Promise<void> {
@@ -60,72 +87,126 @@ export class BackupMonitor implements Service {
       `monitoring backups at ${this.#metricsEndpoint} with ` +
         `${this.#cleanupDelayMs} ms cleanup delay`,
     );
-    this.#checkMetricsTimer = setInterval(this.checkMetrics, CHECK_INTERVAL_MS);
+    this.#checkMetricsTimer = setInterval(
+      this.checkWatermarksAndScheduleCleanup,
+      CHECK_INTERVAL_MS,
+    );
     return this.#state.stopped();
   }
 
+  startSnapshotReservation(taskID: string): Subscription<SnapshotMessage> {
+    this.#lc.info?.(`pausing change-log cleanup while ${taskID} snapshots`);
+    // In the case of retries, only track the last reservation.
+    this.#reservations.get(taskID)?.sub.cancel();
+
+    const sub = Subscription.create<SnapshotMessage>({
+      // If the reservation still exists when the connection closes
+      // (e.g. subscriber crashed), clean it up without updating the
+      // cleanup delay.
+      cleanup: () => this.endReservation(taskID, false),
+    });
+    this.#reservations.set(taskID, {start: new Date(), sub});
+    sub.push(['status', {tag: 'status', backupURL: this.#backupURL}]);
+    return sub;
+  }
+
+  endReservation(taskID: string, updateCleanupDelay = true) {
+    const res = this.#reservations.get(taskID);
+    if (res === undefined) {
+      return;
+    }
+    this.#reservations.delete(taskID);
+    const {start, sub} = res;
+    sub.cancel(); // closes the connection if still open
+
+    if (updateCleanupDelay) {
+      const duration = Date.now() - start.getTime();
+      this.#lc.info?.(`snapshot initialized by ${taskID} in ${duration} ms`);
+      if (duration > this.#cleanupDelayMs) {
+        this.#cleanupDelayMs = duration;
+        this.#lc.info?.(`increased cleanup delay to ${duration} ms`);
+      }
+    }
+  }
+
   // Exported for testing
-  readonly checkMetrics = async () => {
+  readonly checkWatermarksAndScheduleCleanup = async () => {
     try {
-      const resp = await fetch(this.#metricsEndpoint);
-      if (!resp.ok) {
-        this.#lc.warn?.(
-          `unable to fetch metrics at ${this.#metricsEndpoint}`,
-          await resp.text(),
-        );
-        return;
-      }
-      const families = parsePrometheusTextFormat(await resp.text());
-      for (const family of families) {
-        if (
-          family.type === 'GAUGE' &&
-          family.name === 'litestream_replica_progress'
-        ) {
-          for (const metric of family.metrics) {
-            const watermark = metric.labels?.watermark;
-            if (watermark && !this.#cleanupTimers.has(watermark)) {
-              const time = new Date(parseFloat(metric.value) * 1000);
-              const now = Date.now();
-              const cleanupAt = Math.max(
-                time.getTime() + this.#cleanupDelayMs,
-                now,
-              );
-              this.#lc.info?.(
-                `replicated watermark=${watermark} to ${metric.labels?.name}` +
-                  ` at ${time.toISOString()}. scheduling cleanup at ` +
-                  new Date(cleanupAt).toISOString() +
-                  ` (in ${cleanupAt - now} ms)`,
-              );
-              this.#cleanupTimers.set(
-                watermark,
-                setTimeout(() => {
-                  this.#changeStreamer.scheduleCleanup(watermark);
-                  // Clean up all previous watermarks, leaving the latest one in the
-                  // map to avoid redundant scheduling.
-                  for (const [key, timer] of this.#cleanupTimers.entries()) {
-                    if (key === watermark) {
-                      break;
-                    }
-                    this.#cleanupTimers.delete(key);
-                    clearTimeout(timer);
-                  }
-                }, cleanupAt - now),
-              );
-              this.#lc.debug?.('timers', [...this.#cleanupTimers.keys()]);
-            }
-          }
-        }
-      }
+      await this.#checkWatermarks();
     } catch (e) {
       this.#lc.warn?.(`unable to fetch metrics at ${this.#metricsEndpoint}`, e);
     }
+    try {
+      this.#scheduleCleanup();
+    } catch (e) {
+      this.#lc.warn?.(`error scheduling cleanup`, e);
+    }
   };
+
+  async #checkWatermarks() {
+    const resp = await fetch(this.#metricsEndpoint);
+    if (!resp.ok) {
+      this.#lc.warn?.(
+        `unable to fetch metrics at ${this.#metricsEndpoint}`,
+        await resp.text(),
+      );
+      return;
+    }
+    const families = parsePrometheusTextFormat(await resp.text());
+    for (const family of families) {
+      if (
+        family.type === 'GAUGE' &&
+        family.name === 'litestream_replica_progress'
+      ) {
+        for (const metric of family.metrics) {
+          const watermark = metric.labels?.watermark;
+          if (
+            watermark &&
+            watermark > this.#lastWatermark &&
+            !this.#watermarks.has(watermark)
+          ) {
+            const time = new Date(parseFloat(metric.value) * 1000);
+            this.#lc.info?.(
+              `replicated watermark=${watermark} to ${metric.labels?.name}` +
+                ` at ${time.toISOString()}.`,
+            );
+            this.#watermarks.set(watermark, time);
+          }
+        }
+      }
+    }
+  }
+
+  #scheduleCleanup() {
+    if (this.#reservations.size > 0) {
+      this.#lc.info?.(
+        `watermark cleanup paused for snapshot(s): ${[...this.#reservations.keys()]}`,
+      );
+      return;
+    }
+    const latestCleanupTime = Date.now() - this.#cleanupDelayMs;
+    let maxWatermark = '';
+    for (const [watermark, backupTime] of this.#watermarks.entries()) {
+      if (
+        backupTime.getTime() <= latestCleanupTime &&
+        watermark > maxWatermark
+      ) {
+        maxWatermark = watermark;
+      }
+    }
+    if (maxWatermark.length) {
+      this.#changeStreamer.scheduleCleanup(maxWatermark);
+      for (const watermark of this.#watermarks.keys()) {
+        if (watermark <= maxWatermark) {
+          this.#watermarks.delete(watermark);
+        }
+      }
+      this.#lastWatermark = maxWatermark;
+    }
+  }
 
   stop(): Promise<void> {
     clearInterval(this.#checkMetricsTimer);
-    for (const cleanupTimer of this.#cleanupTimers.values()) {
-      clearTimeout(cleanupTimer);
-    }
     this.#state.stop(this.#lc);
     return promiseVoid;
   }

--- a/packages/zero-cache/src/services/change-streamer/backup-monitor.ts
+++ b/packages/zero-cache/src/services/change-streamer/backup-monitor.ts
@@ -22,7 +22,7 @@ type Reservation = {
  *
  * See: https: *github.com/rocicorp/litestream/pull/3
  *
- * Namely, it is not safe to simply purge change log entries as soon as they
+ * Note that change log entries cannot simply be purged as soon as they
  * have been applied and backed up by litestream. Consider the case in which
  * litestream backs up new wal segments every minute, but it takes 5 minutes
  * to restore a replica: if a zero-cache starts restoring a replica at

--- a/packages/zero-cache/src/services/change-streamer/backup-monitor.ts
+++ b/packages/zero-cache/src/services/change-streamer/backup-monitor.ts
@@ -18,7 +18,7 @@ type Reservation = {
 /**
  * The BackupMonitor polls the litestream "/metrics" endpoint to track the
  * watermark (label) value of the `litestream_replica_progress` gauge and
- * schedule cleanup of change log entries that can be purged as a result.
+ * schedules cleanup of change log entries that can be purged as a result.
  *
  * See: https: *github.com/rocicorp/litestream/pull/3
  *

--- a/packages/zero-cache/src/services/change-streamer/backup-monitor.ts
+++ b/packages/zero-cache/src/services/change-streamer/backup-monitor.ts
@@ -207,6 +207,13 @@ export class BackupMonitor implements Service {
 
   stop(): Promise<void> {
     clearInterval(this.#checkMetricsTimer);
+    for (const {sub} of this.#reservations.values()) {
+      // Close any pending reservations. This commonly happens when a new
+      // replication-manager makes a `/snapshot` reservation on the existing
+      // replication-manager, and then shuts it down when it takes over the
+      // replication slot.
+      sub.cancel();
+    }
     this.#state.stop(this.#lc);
     return promiseVoid;
   }

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg-test.ts
@@ -116,6 +116,7 @@ describe('change-streamer/service', () => {
   test('immediate forwarding, transaction storage', async () => {
     const sub = await streamer.subscribe({
       protocolVersion: PROTOCOL_VERSION,
+      taskID: 'task-id',
       id: 'myid',
       mode: 'serving',
       watermark: '01',
@@ -188,6 +189,7 @@ describe('change-streamer/service', () => {
     // Subscribe to the original watermark.
     const sub = await streamer.subscribe({
       protocolVersion: PROTOCOL_VERSION,
+      taskID: 'task-id',
       id: 'myid',
       mode: 'serving',
       watermark: '01',
@@ -275,6 +277,7 @@ describe('change-streamer/service', () => {
     // Subscribe to the original watermark.
     const sub = await streamer.subscribe({
       protocolVersion: PROTOCOL_VERSION,
+      taskID: 'task-id',
       id: 'myid',
       mode: 'serving',
       watermark: '01',
@@ -351,6 +354,7 @@ describe('change-streamer/service', () => {
     // Subscribe to a watermark from "the future".
     const sub = await streamer.subscribe({
       protocolVersion: PROTOCOL_VERSION,
+      taskID: 'task-id',
       id: 'myid',
       mode: 'serving',
       watermark: '0b',
@@ -422,6 +426,7 @@ describe('change-streamer/service', () => {
   test('data types (forwarded and catchup)', async () => {
     const sub = await streamer.subscribe({
       protocolVersion: PROTOCOL_VERSION,
+      taskID: 'task-id',
       id: 'myid',
       mode: 'serving',
       watermark: '01',
@@ -487,6 +492,7 @@ describe('change-streamer/service', () => {
     // Also verify when loading from the Store as opposed to direct forwarding.
     const catchupSub = await streamer.subscribe({
       protocolVersion: PROTOCOL_VERSION,
+      taskID: 'task-id',
       id: 'myid2',
       mode: 'serving',
       watermark: '01',
@@ -537,6 +543,7 @@ describe('change-streamer/service', () => {
     const sub04 = drainToQueue(
       await streamer.subscribe({
         protocolVersion: PROTOCOL_VERSION,
+        taskID: 'task-id',
         id: 'myid1',
         mode: 'serving',
         watermark: '04',
@@ -549,6 +556,7 @@ describe('change-streamer/service', () => {
     const sub08 = drainToQueue(
       await streamer.subscribe({
         protocolVersion: PROTOCOL_VERSION,
+        taskID: 'task-id',
         id: 'myid1',
         mode: 'serving',
         watermark: '08',
@@ -561,6 +569,7 @@ describe('change-streamer/service', () => {
     const sub02 = drainToQueue(
       await streamer.subscribe({
         protocolVersion: PROTOCOL_VERSION,
+        taskID: 'task-id',
         id: 'myid1',
         mode: 'serving',
         watermark: '02',
@@ -592,6 +601,7 @@ describe('change-streamer/service', () => {
     // Start two subscribers: one at 06 and one at 04
     await streamer.subscribe({
       protocolVersion: PROTOCOL_VERSION,
+      taskID: 'task-id',
       id: 'myid1',
       mode: 'serving',
       watermark: '06',
@@ -601,6 +611,7 @@ describe('change-streamer/service', () => {
 
     const sub2 = await streamer.subscribe({
       protocolVersion: PROTOCOL_VERSION,
+      taskID: 'task-id',
       id: 'myid2',
       mode: 'serving',
       watermark: '04',
@@ -662,6 +673,7 @@ describe('change-streamer/service', () => {
     // New connections earlier than 06 should now be rejected.
     const sub3 = await streamer.subscribe({
       protocolVersion: PROTOCOL_VERSION,
+      taskID: 'task-id',
       id: 'myid2',
       mode: 'serving',
       watermark: '04',
@@ -682,6 +694,7 @@ describe('change-streamer/service', () => {
   test('wrong replica version', async () => {
     const sub = await streamer.subscribe({
       protocolVersion: PROTOCOL_VERSION,
+      taskID: 'task-id',
       id: 'myid1',
       mode: 'serving',
       watermark: '06',
@@ -897,6 +910,7 @@ describe('change-streamer/service', () => {
 
     const sub = await streamer.subscribe({
       protocolVersion: PROTOCOL_VERSION,
+      taskID: 'task-id',
       id: 'myid',
       mode: 'serving',
       watermark: '01',
@@ -1046,6 +1060,7 @@ describe('change-streamer/service', () => {
 
     void streamer.subscribe({
       protocolVersion: PROTOCOL_VERSION,
+      taskID: 'task-id',
       id: 'backup-id',
       mode: 'backup',
       watermark: '02', // Too early

--- a/packages/zero-cache/src/services/change-streamer/change-streamer.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer.ts
@@ -52,14 +52,22 @@ export interface ChangeStreamer {
 // v2: Adds the "status" message which is initially used to signal that the
 //     subscription is valid (i.e. starting at the requested watermark).
 //     Introduced in 0.19.
+// v3: Adds the "taskID" to the subscription context, and support for
+//     the BackupMonitor-mediated "/snapshot" request.
 
-export const PROTOCOL_VERSION = 2;
+export const PROTOCOL_VERSION = 3;
 
 export type SubscriberContext = {
   /**
    * The supported change-streamer protocol version.
    */
   protocolVersion: number;
+
+  /**
+   * Task ID. This is used to link the request with a preceding snapshot
+   * reservation.
+   */
+  taskID: string | null; // TODO: Make required when v3 is min.
 
   /**
    * Subscriber id. This is only used for debugging.

--- a/packages/zero-cache/src/services/change-streamer/snapshot.ts
+++ b/packages/zero-cache/src/services/change-streamer/snapshot.ts
@@ -1,0 +1,24 @@
+/**
+ * Definitions for the `snapshot` API, which serves the purpose of:
+ * - informing subscribers (i.e. view-syncers) of the (litestream)
+ *   backup location from which to restore a replica snapshot
+ * - preventing change-log cleanup while a snapshot restore is in
+ *   progress
+ * - tracking the approximate time it takes from the beginning of
+ *   snapshot "reservation" to the subsequent subscription, which
+ *   serves as the minimum interval to wait before cleaning up
+ *   backed up changes.
+ */
+
+import * as v from '../../../../shared/src/valita.ts';
+
+const statusSchema = v.object({
+  tag: v.literal('status'),
+  backupURL: v.string(),
+});
+
+const statusMessageSchema = v.tuple([v.literal('status'), statusSchema]);
+
+export const snapshotMessageSchema = v.union(statusMessageSchema);
+
+export type SnapshotMessage = v.Infer<typeof statusMessageSchema>;

--- a/packages/zero-cache/src/services/litestream/commands.ts
+++ b/packages/zero-cache/src/services/litestream/commands.ts
@@ -4,46 +4,50 @@ import {ChildProcess, spawn} from 'node:child_process';
 import {existsSync} from 'node:fs';
 import {must} from '../../../../shared/src/must.ts';
 import {sleep} from '../../../../shared/src/sleep.ts';
+import {assertNormalized} from '../../config/normalize.ts';
 import type {ZeroConfig} from '../../config/zero-config.ts';
+import {getShardConfig} from '../../types/shards.ts';
+import {ChangeStreamerHttpClient} from '../change-streamer/change-streamer-http.ts';
 
-type ZeroLitestreamConfig = Pick<
-  ZeroConfig,
-  'port' | 'log' | 'replica' | 'litestream'
->;
+// Retry for up to 3 minutes (60 times with 3 second delay).
+// Beyond that, let the container runner restart the task.
+const MAX_RETRIES = 20;
+const RETRY_INTERVAL_MS = 3000;
 
 /**
- * @returns The time in milliseconds it took for the successful restore
+ * @returns The time at which the last restore started
  *          (i.e. not counting failed attempts).
  */
 export async function restoreReplica(
   lc: LogContext,
-  config: ZeroLitestreamConfig,
-  maxRetries: number,
-  retryIntervalMs = 3000,
-): Promise<number | undefined> {
-  for (let i = 0; i < maxRetries; i++) {
+  config: ZeroConfig,
+): Promise<Date> {
+  const {changeStreamer} = config;
+
+  for (let i = 0; i < MAX_RETRIES; i++) {
     if (i > 0) {
       lc.info?.(
-        `replica not found. retrying in ${retryIntervalMs / 1000} seconds`,
+        `replica not found. retrying in ${RETRY_INTERVAL_MS / 1000} seconds`,
       );
-      await sleep(retryIntervalMs);
+      await sleep(RETRY_INTERVAL_MS);
     }
-    const start = Date.now();
-    const restored = await tryRestore(config);
+    const start = new Date();
+    const restored = await tryRestore(lc, config);
     if (restored) {
-      return Date.now() - start;
+      return start;
     }
-    if (maxRetries === 1) {
+    if (changeStreamer.mode === 'dedicated') {
       lc.info?.('no litestream backup found');
-      return undefined;
+      return start;
     }
   }
   throw new Error(`max attempts exceeded restoring replica`);
 }
 
 function getLitestream(
-  config: ZeroLitestreamConfig,
+  config: ZeroConfig,
   logLevelOverride?: LogLevel,
+  backupURLOverride?: string,
 ): {
   litestream: string;
   env: NodeJS.ProcessEnv;
@@ -70,7 +74,7 @@ function getLitestream(
     env: {
       ...process.env,
       ['ZERO_REPLICA_FILE']: config.replica.file,
-      ['ZERO_LITESTREAM_BACKUP_URL']: must(backupURL),
+      ['ZERO_LITESTREAM_BACKUP_URL']: must(backupURLOverride ?? backupURL),
       ['ZERO_LITESTREAM_MIN_CHECKPOINT_PAGE_COUNT']: String(
         minCheckpointPageCount,
       ),
@@ -91,9 +95,30 @@ function getLitestream(
   };
 }
 
-async function tryRestore(config: ZeroLitestreamConfig) {
-  // The log output for litestream restore is minimal. Include it all.
-  const {litestream, env} = getLitestream(config, 'debug');
+async function tryRestore(lc: LogContext, config: ZeroConfig) {
+  const {changeStreamer} = config;
+
+  // Fire off a snapshot reservation to the current replication-manager
+  // (if there is one).
+  const backupURL = reserveAndGetSnapshotLocation(lc, config);
+  let backupURLOverride: string | undefined;
+  if (changeStreamer.mode === 'discover') {
+    // The return value is required by view-syncers ...
+    backupURLOverride = await backupURL;
+    lc.info?.(`restoring backup from ${backupURLOverride}`);
+  } else {
+    // but it is also useful to pause change-log cleanup when a new
+    // replication-manager is starting up. In this case, the request is
+    // best-effort. In particular, there may not be a previous
+    // replication-manager running at all.
+    void backupURL.catch(e => lc.debug?.(e));
+  }
+
+  const {litestream, env} = getLitestream(
+    config,
+    'debug', // Include all output from `litestream restore`, as it's minimal.
+    backupURLOverride,
+  );
   const {
     restoreParallelism: parallelism,
     multipartConcurrency,
@@ -136,13 +161,50 @@ async function tryRestore(config: ZeroLitestreamConfig) {
   return existsSync(config.replica.file);
 }
 
-export function startReplicaBackupProcess(
-  config: ZeroLitestreamConfig,
-): ChildProcess {
+export function startReplicaBackupProcess(config: ZeroConfig): ChildProcess {
   const {litestream, env} = getLitestream(config);
   return spawn(litestream, ['replicate'], {
     env,
     stdio: 'inherit',
     windowsHide: true,
   });
+}
+
+async function reserveAndGetSnapshotLocation(
+  lc: LogContext,
+  config: ZeroConfig,
+) {
+  const {promise: backupURL, resolve, reject} = resolver<string>();
+  try {
+    assertNormalized(config);
+    const {taskID, change} = config;
+    const shardID = getShardConfig(config);
+
+    const changeStreamerClient = new ChangeStreamerHttpClient(
+      lc,
+      shardID,
+      change.db,
+    );
+
+    const sub = await changeStreamerClient.reserveSnapshot(taskID);
+
+    // Capture the value of the status message that the change-streamer
+    // (i.e. BackupMonitor) returns, and hold the connection open to
+    // "reserve" the snapshot and prevent change log cleanup.
+    //
+    // The change-streamer itself will close the connection when the
+    // subscription is started (or the reservation retried).
+    void (async function () {
+      try {
+        for await (const msg of sub) {
+          resolve(msg[1].backupURL);
+        }
+      } catch (e) {
+        reject(e);
+      }
+    })();
+  } catch (e) {
+    reject(e);
+  }
+  return backupURL;
 }

--- a/packages/zero-cache/src/services/litestream/commands.ts
+++ b/packages/zero-cache/src/services/litestream/commands.ts
@@ -11,7 +11,7 @@ import {ChangeStreamerHttpClient} from '../change-streamer/change-streamer-http.
 
 // Retry for up to 3 minutes (60 times with 3 second delay).
 // Beyond that, let the container runner restart the task.
-const MAX_RETRIES = 20;
+const MAX_RETRIES = 60;
 const RETRY_INTERVAL_MS = 3000;
 
 /**

--- a/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
@@ -24,6 +24,7 @@ import {initChangeLog} from './schema/change-log.ts';
 import {initReplicationState} from './schema/replication-state.ts';
 import {ReplicationMessages} from './test-utils.ts';
 
+const TASK_ID = 'task-id';
 const REPLICA_ID = 'incremental_sync_test_id';
 
 describe('replicator/incremental-sync', () => {
@@ -41,6 +42,7 @@ describe('replicator/incremental-sync', () => {
     downstream = Subscription.create();
     subscribeFn = vi.fn();
     syncer = new IncrementalSyncer(
+      TASK_ID,
       REPLICA_ID,
       {subscribe: subscribeFn.mockResolvedValue(downstream)},
       replica,
@@ -84,6 +86,7 @@ describe('replicator/incremental-sync', () => {
     await versionReady.next(); // Get the initial nextStateVersion.
     expect(subscribeFn.mock.calls[0][0]).toEqual({
       protocolVersion: PROTOCOL_VERSION,
+      taskID: 'task-id',
       id: 'incremental_sync_test_id',
       mode: 'serving',
       replicaVersion: '02',
@@ -237,6 +240,7 @@ describe('replicator/incremental-sync', () => {
 
     const {promise: hasRetried, resolve: retried} = resolver<true>();
     const syncer = new IncrementalSyncer(
+      TASK_ID,
       REPLICA_ID,
       {
         subscribe: vi
@@ -263,6 +267,7 @@ describe('replicator/incremental-sync', () => {
 
     const {promise: hasRetried, resolve: retried} = resolver<true>();
     const syncer = new IncrementalSyncer(
+      TASK_ID,
       REPLICA_ID,
       {
         subscribe: vi

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -1,6 +1,7 @@
 import type {LogContext} from '@rocicorp/logger';
 import {Database} from '../../../../zqlite/src/db.ts';
 import {StatementRunner} from '../../db/statements.ts';
+import instruments from '../../observability/view-syncer-instruments.ts';
 import type {Source} from '../../types/streams.ts';
 import {
   PROTOCOL_VERSION,
@@ -12,7 +13,6 @@ import {ChangeProcessor, type TransactionMode} from './change-processor.ts';
 import {Notifier} from './notifier.ts';
 import type {ReplicaState, ReplicatorMode} from './replicator.ts';
 import {getSubscriptionState} from './schema/replication-state.ts';
-import instruments from '../../observability/view-syncer-instruments.ts';
 
 /**
  * The {@link IncrementalSyncer} manages a logical replication stream from upstream,
@@ -21,6 +21,7 @@ import instruments from '../../observability/view-syncer-instruments.ts';
  * replication messages is done by the {@link ChangeProcessor}.
  */
 export class IncrementalSyncer {
+  readonly #taskID: string;
   readonly #id: string;
   readonly #changeStreamer: ChangeStreamer;
   readonly #replica: StatementRunner;
@@ -31,11 +32,13 @@ export class IncrementalSyncer {
   readonly #state = new RunningState('IncrementalSyncer');
 
   constructor(
+    taskID: string,
     id: string,
     changeStreamer: ChangeStreamer,
     replica: Database,
     mode: ReplicatorMode,
   ) {
+    this.#taskID = taskID;
     this.#id = id;
     this.#changeStreamer = changeStreamer;
     this.#replica = new StatementRunner(replica);
@@ -66,6 +69,7 @@ export class IncrementalSyncer {
       try {
         downstream = await this.#changeStreamer.subscribe({
           protocolVersion: PROTOCOL_VERSION,
+          taskID: this.#taskID,
           id: this.#id,
           mode: this.#mode,
           watermark,

--- a/packages/zero-cache/src/services/replicator/replicator.ts
+++ b/packages/zero-cache/src/services/replicator/replicator.ts
@@ -71,6 +71,7 @@ export class ReplicatorService implements Replicator, Service {
       .withContext('serviceID', this.id);
 
     this.#incrementalSyncer = new IncrementalSyncer(
+      taskID,
       `${taskID}/${id}`,
       changeStreamer,
       replica,

--- a/packages/zero-cache/src/types/streams.ts
+++ b/packages/zero-cache/src/types/streams.ts
@@ -362,7 +362,9 @@ class WebSocketCloser<T> {
   };
 
   #handleError = ({message, error}: ErrorEvent) => {
-    this.#lc.error?.('connection error', message, error);
+    if (this.#ws.readyState === this.#ws.OPEN) {
+      this.#lc.error?.('connection error', message, error);
+    }
     this.#connected.reject(error);
   };
 

--- a/prod/sst/sst.config.ts
+++ b/prod/sst/sst.config.ts
@@ -63,7 +63,6 @@ export default $config({
       ZERO_REPLICA_FILE: IS_EBS_STAGE
         ? '/data/sync-replica.db'
         : 'sync-replica.db',
-      ZERO_LITESTREAM_BACKUP_URL: $interpolate`s3://${replicationBucket.name}/backup/20250319-00`,
       ZERO_IMAGE_URL: process.env.ZERO_IMAGE_URL!,
       ZERO_APP_ID: process.env.ZERO_APP_ID || 'zero',
       PGCONNECT_TIMEOUT: '60', // scale-from-zero dbs need more than 30 seconds
@@ -170,6 +169,7 @@ export default $config({
       },
       environment: {
         ...commonEnv,
+        ZERO_LITESTREAM_BACKUP_URL: $interpolate`s3://${replicationBucket.name}/backup/20250319-00`,
         ZERO_CHANGE_MAX_CONNS: '3',
         ZERO_NUM_SYNC_WORKERS: '0',
       },


### PR DESCRIPTION
## ⚠️  Deployment notes

* The new `replication-manager` must be rolled out before `view-syncer`s are rolled out
* The `ZERO_LITESTREAM_BACKUP_URL` is no longer needed by `view-syncers`. 
  * Specifying it is fine but it will be ignored.
  * This means that initiating a resync (by updating the backup url) only requires updating the `replication-manager`. The `view-syncers` will pick this up and reset when signaled by the `replication-manager`; there is no need to update them manually.

## Feature

Better backup protocol and cleanup logic

This feature was inspired by @tantaman's idea for more reliably pausing change-log cleanup when a `litestream` restore is in progress: https://github.com/rocicorp/mono/pull/4263#discussion_r2060297645

* The `replication-manager` (i.e. `change-streamer`) exports a new `/snapshot` websocket handler used to "reserve" a snapshot.
* `view-syncers` make this request before restoring the replica from the backup. In particular, the `replication-manager` immediately sends a downstream message indicating the backup-url from which to restore. This obviates the need for the `view-syncers` to be configured with backup-url, replacing the previous config coordination point with a runtime protocol.
* The request is kept open while the replica is restored and prepared. While a "reservation" is in progress, the backup monitor refrains from scheduling any watermark cleanup.
* When the `view-syncer` finishes its restore and subscribes to the `change-streamer`, the corresponding reservation is closed. This allows the backup monitor to resume watermark cleanup scheduling.
* In addition, the duration for which the reservation lasted is used to increase the cleanup delay, if approprate, as a secondary precaution against premature change log cleanup.

### Miscellaneous cleanup

* The BackupMonitor implementation was simplified to perform all logic in a single `setInterval()` callback (previously there was a Timer for every watermark encountered).
* On each interval, the latest qualifying watermark is scheduled for cleanup. Earlier watermarks are discarded.
