### PR TITLE
chore(z2s): test `.one` on primary key lookup

### DIFF
--- a/packages/zql-integration-tests/src/chinook/chinook.pg-test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook.pg-test.ts
@@ -35,6 +35,34 @@ test.each(
       {
         name: 'compare primary key',
         createQuery: q => q.track.where('id', '=', 2941),
+        manualVerification: [
+          {
+            albumId: 233,
+            bytes: 9800861,
+            composer: 'Adam Clayton, Bono, Larry Mullen, The Edge',
+            genreId: 1,
+            id: 2941,
+            mediaTypeId: 1,
+            milliseconds: 296280,
+            name: 'Walk On',
+            unitPrice: 0.99,
+          },
+        ],
+      },
+      {
+        name: 'compare primary key and use `one`',
+        createQuery: q => q.track.where('id', '=', 2941).one(),
+        manualVerification: {
+          albumId: 233,
+          bytes: 9800861,
+          composer: 'Adam Clayton, Bono, Larry Mullen, The Edge',
+          genreId: 1,
+          id: 2941,
+          mediaTypeId: 1,
+          milliseconds: 296280,
+          name: 'Walk On',
+          unitPrice: 0.99,
+        },
       },
       {
         name: 'where equality',

--- a/packages/zql-integration-tests/src/helpers/runner.ts
+++ b/packages/zql-integration-tests/src/helpers/runner.ts
@@ -291,7 +291,8 @@ export async function createVitests<TSchema extends Schema>(
   }: Options<TSchema>,
   ...testSpecs: (readonly {
     name: string;
-    createQuery: (q: Queries<TSchema>) => Query<TSchema, string>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    createQuery: (q: Queries<TSchema>) => Query<TSchema, string, any>;
     manualVerification?: unknown;
   }[])[]
 ) {


### PR DESCRIPTION
had a user report about something like this not working. Double checking.

https://github.com/AkshayPathak/zero-reproduction/blob/c024fe28a0099a10be7157646a03cf486aa4ca87/packages/zero/src/mutators.ts#L10