### PR TITLE
chore(zero-cache): reduce catchup batch size

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -393,7 +393,7 @@ export class Storer implements Service {
         for await (const entries of tx<ChangeEntry[]>`
           SELECT watermark, change FROM ${this.#cdc('changeLog')}
            WHERE watermark >= ${sub.watermark}
-           ORDER BY watermark, pos`.cursor(10000)) {
+           ORDER BY watermark, pos`.cursor(2000)) {
           for (const entry of entries) {
             if (entry.watermark === sub.watermark) {
               // This should be the first entry.


### PR DESCRIPTION
See if this addresses the liveness failures between the change-streamer and backup-replicator process during a large catchup.

User report:

https://discord.com/channels/830183651022471199/1370057107814088796/1370196000152752178