### PR TITLE
chore(zero-cache): refuse to start if deprecated option is found

### DIFF
--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -342,6 +342,19 @@ export const zeroOptions = {
       // hidden flag as an emergency to unblock people with outlier network configs.
       hidden: true,
     },
+
+    uri: {
+      type: v
+        .string()
+        .assert(() => {
+          throw new Error(
+            `ZERO_CHANGE_STREAMER_URI is deprecated. Please see notes for ` +
+              `ZERO_CHANGE_STREAMER_MODE: https://github.com/rocicorp/mono/pull/4335`,
+          );
+        })
+        .optional(),
+      hidden: true,
+    },
   },
 
   taskID: {


### PR DESCRIPTION
Ensure that users don't accidentally run servers with the old flags, as it would unintentionally result in running a replication-manager in a view-syncer node.