### PR TITLE
chore(zero-cache): avoid sending the `columns` field in pg MessageRelations

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -50,7 +50,7 @@ import {
 import type {
   DataChange,
   Identifier,
-  MessageDelete,
+  MessageRelation,
 } from '../protocol/current/data.ts';
 import type {
   ChangeStreamData,
@@ -61,7 +61,7 @@ import {type InitialSyncOptions} from './initial-sync.ts';
 import type {
   Message,
   MessageMessage,
-  MessageRelation,
+  MessageRelation as PostgresRelation,
 } from './logical-replication/pgoutput.types.ts';
 import {subscribe} from './logical-replication/stream.ts';
 import {fromBigInt, toLexiVersion, type LSN} from './lsn.ts';
@@ -491,6 +491,13 @@ class ChangeMaker {
 
   // eslint-disable-next-line require-await
   async #makeChanges(msg: Message): Promise<ChangeStreamData[]> {
+    // Avoid sending the `columns` from the Postgres MessageRelation message.
+    // They are not used downstream and the message can be large.
+    function withoutColumns(relation: PostgresRelation): MessageRelation {
+      const {columns: _, ...rest} = relation;
+      return rest;
+    }
+
     switch (msg.tag) {
       case 'begin':
         return [
@@ -507,20 +514,39 @@ class ChangeMaker {
             `Invalid DELETE msg (missing key): ${stringify(msg)}`,
           );
         }
-        // https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html#PROTOCOL-LOGICALREP-MESSAGE-FORMATS-DELETE
         return [
-          ['data', msg.old ? {...msg, key: msg.old} : (msg as MessageDelete)],
+          [
+            'data',
+            {
+              ...msg,
+              relation: withoutColumns(msg.relation),
+              // https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html#PROTOCOL-LOGICALREP-MESSAGE-FORMATS-DELETE
+              key: must(msg.old ?? msg.key),
+            },
+          ],
         ];
       }
 
       case 'update': {
-        // https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html#PROTOCOL-LOGICALREP-MESSAGE-FORMATS-UPDATE
-        return [['data', msg.old ? {...msg, key: msg.old} : msg]];
+        return [
+          [
+            'data',
+            {
+              ...msg,
+              relation: withoutColumns(msg.relation),
+              // https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html#PROTOCOL-LOGICALREP-MESSAGE-FORMATS-UPDATE
+              key: msg.old ?? msg.key,
+            },
+          ],
+        ];
       }
 
       case 'insert':
+        return [['data', {...msg, relation: withoutColumns(msg.relation)}]];
       case 'truncate':
-        return [['data', msg]];
+        return [
+          ['data', {...msg, relations: msg.relations.map(withoutColumns)}],
+        ];
 
       case 'message':
         if (msg.prefix !== this.#shardPrefix) {
@@ -749,7 +775,7 @@ class ChangeMaker {
    * this mechanism cannot be used to reliably *replicate* schema changes.
    * However, they serve the purpose determining if schemas have changed.
    */
-  async #handleRelation(rel: MessageRelation): Promise<ChangeStreamData[]> {
+  async #handleRelation(rel: PostgresRelation): Promise<ChangeStreamData[]> {
     const {publications, ddlDetection} = this.#shardConfig;
     if (ddlDetection) {
       return [];
@@ -832,7 +858,7 @@ export function tablesDifferent(a: PublishedTableSpec, b: PublishedTableSpec) {
   );
 }
 
-export function relationDifferent(a: PublishedTableSpec, b: MessageRelation) {
+export function relationDifferent(a: PublishedTableSpec, b: PostgresRelation) {
   if (a.oid !== b.relationOid || a.schema !== b.schema || a.name !== b.name) {
     return true;
   }

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -491,13 +491,6 @@ class ChangeMaker {
 
   // eslint-disable-next-line require-await
   async #makeChanges(msg: Message): Promise<ChangeStreamData[]> {
-    // Avoid sending the `columns` from the Postgres MessageRelation message.
-    // They are not used downstream and the message can be large.
-    function withoutColumns(relation: PostgresRelation): MessageRelation {
-      const {columns: _, ...rest} = relation;
-      return rest;
-    }
-
     switch (msg.tag) {
       case 'begin':
         return [
@@ -914,6 +907,13 @@ function columnsByID(
     colsByID.set(spec.pos, {...spec, name});
   }
   return colsByID;
+}
+
+// Avoid sending the `columns` from the Postgres MessageRelation message.
+// They are not used downstream and the message can be large.
+function withoutColumns(relation: PostgresRelation): MessageRelation {
+  const {columns: _, ...rest} = relation;
+  return rest;
 }
 
 export class UnsupportedSchemaChangeError extends Error {


### PR DESCRIPTION
The `columns` field can be large for tables with many columns. They are not used downstream, so removing them from the change-stream can significantly reduce the amount of downstream I/O (i.e. change-db writes, change-streamer -> subscriber websocket)