### PR TITLE
chore(zero-cache): fail the transaction pool fast(er)

### DIFF
--- a/packages/zero-cache/src/db/transaction-pool.ts
+++ b/packages/zero-cache/src/db/transaction-pool.ts
@@ -243,8 +243,9 @@ export class TransactionPool {
               task instanceof Error ||
               (task.task !== this.#init && this.#failure)
             ) {
-              lc.info?.(`aborting ${pending.length} statements`);
-              void Promise.allSettled(pending); // avoid unhandled rejections
+              void Promise.allSettled(pending).then(() =>
+                lc.info?.(`aborted ${pending.length} statements`),
+              ); // avoid unhandled rejections
               throw this.#failure ?? task;
             }
             await executeTask(task);

--- a/packages/zero-cache/src/db/transaction-pool.ts
+++ b/packages/zero-cache/src/db/transaction-pool.ts
@@ -243,7 +243,7 @@ export class TransactionPool {
               task instanceof Error ||
               (task.task !== this.#init && this.#failure)
             ) {
-              await Promise.allSettled(pending); // avoid unhandled rejections
+              void Promise.allSettled(pending); // avoid unhandled rejections
               throw this.#failure ?? task;
             }
             await executeTask(task);

--- a/packages/zero-cache/src/db/transaction-pool.ts
+++ b/packages/zero-cache/src/db/transaction-pool.ts
@@ -243,9 +243,10 @@ export class TransactionPool {
               task instanceof Error ||
               (task.task !== this.#init && this.#failure)
             ) {
+              // avoid unhandled rejections
               void Promise.allSettled(pending).then(() =>
                 lc.info?.(`aborted ${pending.length} statements`),
-              ); // avoid unhandled rejections
+              );
               throw this.#failure ?? task;
             }
             await executeTask(task);

--- a/packages/zero-cache/src/db/transaction-pool.ts
+++ b/packages/zero-cache/src/db/transaction-pool.ts
@@ -243,6 +243,7 @@ export class TransactionPool {
               task instanceof Error ||
               (task.task !== this.#init && this.#failure)
             ) {
+              lc.info?.(`aborting ${pending.length} statements`);
               void Promise.allSettled(pending); // avoid unhandled rejections
               throw this.#failure ?? task;
             }


### PR DESCRIPTION
Avoid awaiting the results of previously executed transactions if we are going to fail the transaction anyway.