### PR TITLE
fix(zero-cache): fix ordering of columns in replicated indexes

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.pg-test.ts
@@ -643,8 +643,8 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
         },
         {
           columns: {
-            issueID: 'ASC',
             orgID: 'ASC',
+            issueID: 'ASC',
           },
           name: 'issues_pkey',
           schema: 'public',
@@ -1382,8 +1382,8 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
         },
         {
           columns: {
-            issueID: 'ASC',
             orgID: 'ASC',
+            issueID: 'ASC',
           },
           name: 'issues_pkey',
           schema: 'public',
@@ -1778,9 +1778,14 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
           new Set(c.resultingPublications),
         );
 
-        const syncedIndices = listIndexes(replica);
-        expect(syncedIndices).toEqual(
-          c.replicatedIndexes.map(idx => mapPostgresToLiteIndex(idx)),
+        const syncedIndexes = listIndexes(replica);
+        // Test stringified indexes to verify field ordering.
+        expect(JSON.stringify(syncedIndexes, null, 2)).toEqual(
+          JSON.stringify(
+            c.replicatedIndexes.map(idx => mapPostgresToLiteIndex(idx)),
+            null,
+            2,
+          ),
         );
 
         expectMatchingObjectsInTables(replica, c.replicatedData, 'bigint');

--- a/packages/zero-cache/src/services/change-source/pg/schema/init.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.pg-test.ts
@@ -15,8 +15,8 @@ const SHARD_NUM = 23;
 
 // Update as necessary.
 const CURRENT_SCHEMA_VERSIONS = {
-  dataVersion: 8,
-  schemaVersion: 8,
+  dataVersion: 9,
+  schemaVersion: 9,
   minSafeVersion: 1,
   lock: 'v',
 } as const;

--- a/packages/zero-cache/src/services/change-source/pg/schema/init.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.ts
@@ -165,6 +165,18 @@ function getIncrementalMigrations(
         lc.info?.(`Upgraded schema to support non-disruptive resyncs`);
       },
     },
+
+    // Fixes field ordering of compound indexes. This incremental migration
+    // only fixes indexes resulting from new schema changes. A full resync is
+    // required to fix existing indexes.
+    9: {
+      migrateSchema: async (lc, sql) => {
+        const [{publications}] = await sql<{publications: string[]}[]>`
+          SELECT publications FROM ${sql(shardConfigTable)}`;
+        await setupTriggers(lc, sql, {...shard, publications});
+        lc.info?.(`Upgraded DDL event triggers`);
+      },
+    },
   };
 }
 

--- a/packages/zero-cache/src/services/change-source/pg/schema/published.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/published.pg-test.ts
@@ -1,425 +1,400 @@
 import type postgres from 'postgres';
-import {afterEach, beforeEach, describe, expect, test} from 'vitest';
-import {assert} from '../../../../../../shared/src/asserts.ts';
+import {beforeEach, describe, expect, test} from 'vitest';
 import * as PostgresTypeClass from '../../../../db/postgres-type-class-enum.ts';
 import {testDBs} from '../../../../test/db.ts';
 import {type PublicationInfo, getPublicationInfo} from './published.ts';
 
 describe('tables/published', () => {
-  type Case = {
-    name: string;
-    setupQuery: string;
-    expectedResult?: PublicationInfo;
-    expectedError?: string;
-  };
+  let db: postgres.Sql;
+  beforeEach(async () => {
+    db = await testDBs.create('published_tables_test');
 
-  const cases: Case[] = [
-    {
-      name: 'zero.clients',
-      setupQuery: `
+    return async () => {
+      await testDBs.drop(db);
+    };
+  });
+
+  async function runAndExpectIndexes(
+    setupQuery: string,
+    expectedResult: Omit<PublicationInfo, 'indexes'>,
+  ) {
+    await db.unsafe(setupQuery);
+
+    const tables = await getPublicationInfo(
+      db,
+      expectedResult.publications.map(p => p.pubname),
+    );
+    expect(tables).toMatchObject(expectedResult);
+    for (const t of tables.tables) {
+      expect(t.columns.excluded).toBeUndefined();
+    }
+    // Return an expectation on the stringified indexes to preserve field
+    // ordering, which is used to define the order of the indexed columns.
+    return expect(JSON.stringify(tables.indexes, null, 2));
+  }
+
+  async function runAndExpectError(setupQuery: string) {
+    await db.unsafe(setupQuery);
+
+    try {
+      await getPublicationInfo(db, [
+        'zero_all',
+        'zero_data',
+        'zero_one',
+        'zero_two',
+        'zero_keys',
+        '_zero_meta',
+        'zero_tables',
+      ]);
+      throw Error('expected error');
+    } catch (e) {
+      return expect(e);
+    }
+  }
+
+  test('zero.clients', async () => {
+    (
+      await runAndExpectIndexes(
+        `
       CREATE SCHEMA zero;
       CREATE PUBLICATION zero_all FOR TABLES IN SCHEMA zero;
       CREATE TABLE zero.clients (
         "clientID" VARCHAR (180) PRIMARY KEY,
         "lastMutationID" BIGINT
-      );
-      `,
-      expectedResult: {
-        publications: [
-          {
-            pubname: 'zero_all',
-            pubinsert: true,
-            pubupdate: true,
-            pubdelete: true,
-            pubtruncate: true,
-          },
-        ],
-        tables: [
-          {
-            oid: expect.any(Number),
-            schema: 'zero',
-            name: 'clients',
-            replicaIdentity: 'd',
-            columns: {
-              clientID: {
-                pos: 1,
-                dataType: 'varchar',
-                typeOID: 1043,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: 180,
-                notNull: true,
-                dflt: null,
-              },
-              lastMutationID: {
-                pos: 2,
-                dataType: 'int8',
-                typeOID: 20,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: false,
-                dflt: null,
-              },
+      );`,
+        {
+          publications: [
+            {
+              pubname: 'zero_all',
+              pubinsert: true,
+              pubupdate: true,
+              pubdelete: true,
+              pubtruncate: true,
             },
-            primaryKey: ['clientID'],
-            publications: {['zero_all']: {rowFilter: null}},
-          },
-        ],
-        indexes: [
-          {
-            name: 'clients_pkey',
-            schema: 'zero',
-            tableName: 'clients',
-            columns: {clientID: 'ASC'},
-            unique: true,
-          },
-        ],
-      },
-    },
-    {
-      name: 'types and array types',
-      setupQuery: `
-      CREATE TYPE DAY_OF_WEEK AS ENUM ('Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun');
-      CREATE SCHEMA test;
-      CREATE TABLE test.users (
-        user_id INTEGER PRIMARY KEY,
-        handle text DEFAULT null,
-        address text[],
-        boolean BOOL DEFAULT 'false',
-        int int8 DEFAULT (2147483647 + 2),
-        flt FLOAT8 DEFAULT 123.456,
-        bigint int8 DEFAULT 2147483648,
-        timez TIMESTAMPTZ[],
-        bigint_array BIGINT[],
-        bool_array BOOL[] DEFAULT '{true,false}',
-        real_array REAL[],
-        int_array INTEGER[],
-        json_val JSONB,
-        day DAY_OF_WEEK,
-        excluded INTEGER GENERATED ALWAYS AS (user_id + 1) STORED
-      );
-      CREATE PUBLICATION zero_data FOR TABLE test.users;
-      `,
-      expectedResult: {
-        publications: [
-          {
-            pubname: 'zero_data',
-            pubinsert: true,
-            pubupdate: true,
-            pubdelete: true,
-            pubtruncate: true,
-          },
-        ],
-        tables: [
-          {
-            oid: expect.any(Number),
-            schema: 'test',
-            name: 'users',
-            replicaIdentity: 'd',
-            columns: {
-              ['user_id']: {
-                pos: 1,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: true,
-                dflt: null,
+          ],
+          tables: [
+            {
+              oid: expect.any(Number),
+              schema: 'zero',
+              name: 'clients',
+              replicaIdentity: 'd',
+              columns: {
+                clientID: {
+                  pos: 1,
+                  dataType: 'varchar',
+                  typeOID: 1043,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: 180,
+                  notNull: true,
+                  dflt: null,
+                },
+                lastMutationID: {
+                  pos: 2,
+                  dataType: 'int8',
+                  typeOID: 20,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: false,
+                  dflt: null,
+                },
               },
-              handle: {
-                pos: 2,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                dataType: 'text',
-                typeOID: 25,
-                notNull: false,
-                dflt: null,
-              },
-              address: {
-                pos: 3,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                dataType: 'text[]',
-                typeOID: 1009,
-                notNull: false,
-                dflt: null,
-              },
-              boolean: {
-                pos: 4,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                dataType: 'bool',
-                typeOID: 16,
-                notNull: false,
-                dflt: 'false',
-              },
-              int: {
-                pos: 5,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                dataType: 'int8',
-                typeOID: 20,
-                notNull: false,
-                dflt: '(2147483647 + 2)',
-              },
-              flt: {
-                pos: 6,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                dataType: 'float8',
-                typeOID: 701,
-                notNull: false,
-                dflt: '123.456',
-              },
-              bigint: {
-                pos: 7,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                dataType: 'int8',
-                typeOID: 20,
-                notNull: false,
-                dflt: "'2147483648'::bigint",
-              },
-              timez: {
-                pos: 8,
-                dataType: 'timestamptz[]',
-                typeOID: 1185,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: false,
-                dflt: null,
-              },
-              ['bigint_array']: {
-                pos: 9,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                dataType: 'int8[]',
-                typeOID: 1016,
-                notNull: false,
-                dflt: null,
-              },
-              ['bool_array']: {
-                pos: 10,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                dataType: 'bool[]',
-                typeOID: 1000,
-                notNull: false,
-                dflt: "'{t,f}'::boolean[]",
-              },
-              ['real_array']: {
-                pos: 11,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                dataType: 'float4[]',
-                typeOID: 1021,
-                notNull: false,
-                dflt: null,
-              },
-              ['int_array']: {
-                pos: 12,
-                dataType: 'int4[]',
-                typeOID: 1007,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: false,
-                dflt: null,
-              },
-              ['json_val']: {
-                pos: 13,
-                dataType: 'jsonb',
-                typeOID: 3802,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: false,
-                dflt: null,
-              },
-              ['day']: {
-                pos: 14,
-                dataType: 'day_of_week',
-                typeOID: expect.any(Number),
-                pgTypeClass: PostgresTypeClass.Enum,
-                characterMaximumLength: null,
-                notNull: false,
-                dflt: null,
-              },
+              primaryKey: ['clientID'],
+              publications: {['zero_all']: {rowFilter: null}},
             },
-            primaryKey: ['user_id'],
-            publications: {['zero_data']: {rowFilter: null}},
-          },
-        ],
-        indexes: [
-          {
-            schema: 'test',
-            tableName: 'users',
-            name: 'users_pkey',
-            columns: {['user_id']: 'ASC'},
-            unique: true,
-            isReplicaIdentity: false,
-            isImmediate: true,
-          },
-        ],
-      },
-    },
-    {
-      name: 'row filter',
-      setupQuery: `
-      CREATE SCHEMA test;
-      CREATE TABLE test.users (
-        user_id INTEGER PRIMARY KEY,
-        org_id INTEGER,
-        handle text
-      );
-      CREATE PUBLICATION zero_data FOR TABLE test.users WHERE (org_id = 123);
-      `,
-      expectedResult: {
-        publications: [
-          {
-            pubname: 'zero_data',
-            pubinsert: true,
-            pubupdate: true,
-            pubdelete: true,
-            pubtruncate: true,
-          },
-        ],
-        tables: [
-          {
-            oid: expect.any(Number),
-            schema: 'test',
-            name: 'users',
-            replicaIdentity: 'd',
-            columns: {
-              ['user_id']: {
-                pos: 1,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: true,
-                dflt: null,
-              },
-              ['org_id']: {
-                pos: 2,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: false,
-                dflt: null,
-              },
-              handle: {
-                pos: 3,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                dataType: 'text',
-                typeOID: 25,
-                notNull: false,
-                dflt: null,
-              },
+          ],
+        },
+      )
+    ).toMatchInlineSnapshot(`
+      "[
+        {
+          "schema": "zero",
+          "tableName": "clients",
+          "name": "clients_pkey",
+          "unique": true,
+          "isReplicaIdentity": false,
+          "isImmediate": true,
+          "columns": {
+            "clientID": "ASC"
+          }
+        }
+      ]"
+    `);
+  });
+
+  test('types and array types', async () => {
+    (
+      await runAndExpectIndexes(
+        `
+        CREATE TYPE DAY_OF_WEEK AS ENUM ('Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun');
+        CREATE SCHEMA test;
+        CREATE TABLE test.users (
+          user_id INTEGER PRIMARY KEY,
+          handle text DEFAULT null,
+          address text[],
+          boolean BOOL DEFAULT 'false',
+          int int8 DEFAULT (2147483647 + 2),
+          flt FLOAT8 DEFAULT 123.456,
+          bigint int8 DEFAULT 2147483648,
+          timez TIMESTAMPTZ[],
+          bigint_array BIGINT[],
+          bool_array BOOL[] DEFAULT '{true,false}',
+          real_array REAL[],
+          int_array INTEGER[],
+          json_val JSONB,
+          day DAY_OF_WEEK,
+          excluded INTEGER GENERATED ALWAYS AS (user_id + 1) STORED
+        );
+        CREATE PUBLICATION zero_data FOR TABLE test.users;`,
+        {
+          publications: [
+            {
+              pubname: 'zero_data',
+              pubinsert: true,
+              pubupdate: true,
+              pubdelete: true,
+              pubtruncate: true,
             },
-            primaryKey: ['user_id'],
-            publications: {['zero_data']: {rowFilter: '(org_id = 123)'}},
-          },
-        ],
-        indexes: [
-          {
-            schema: 'test',
-            tableName: 'users',
-            name: 'users_pkey',
-            columns: {['user_id']: 'ASC'},
-            unique: true,
-            isReplicaIdentity: false,
-            isImmediate: true,
-          },
-        ],
-      },
-    },
-    {
-      name: 'multiple row filters',
-      setupQuery: `
+          ],
+          tables: [
+            {
+              oid: expect.any(Number),
+              schema: 'test',
+              name: 'users',
+              replicaIdentity: 'd',
+              columns: {
+                ['user_id']: {
+                  pos: 1,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: true,
+                  dflt: null,
+                },
+                handle: {
+                  pos: 2,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  dataType: 'text',
+                  typeOID: 25,
+                  notNull: false,
+                  dflt: null,
+                },
+                address: {
+                  pos: 3,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  dataType: 'text[]',
+                  typeOID: 1009,
+                  notNull: false,
+                  dflt: null,
+                },
+                boolean: {
+                  pos: 4,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  dataType: 'bool',
+                  typeOID: 16,
+                  notNull: false,
+                  dflt: 'false',
+                },
+                int: {
+                  pos: 5,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  dataType: 'int8',
+                  typeOID: 20,
+                  notNull: false,
+                  dflt: '(2147483647 + 2)',
+                },
+                flt: {
+                  pos: 6,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  dataType: 'float8',
+                  typeOID: 701,
+                  notNull: false,
+                  dflt: '123.456',
+                },
+                bigint: {
+                  pos: 7,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  dataType: 'int8',
+                  typeOID: 20,
+                  notNull: false,
+                  dflt: "'2147483648'::bigint",
+                },
+                timez: {
+                  pos: 8,
+                  dataType: 'timestamptz[]',
+                  typeOID: 1185,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: false,
+                  dflt: null,
+                },
+                ['bigint_array']: {
+                  pos: 9,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  dataType: 'int8[]',
+                  typeOID: 1016,
+                  notNull: false,
+                  dflt: null,
+                },
+                ['bool_array']: {
+                  pos: 10,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  dataType: 'bool[]',
+                  typeOID: 1000,
+                  notNull: false,
+                  dflt: "'{t,f}'::boolean[]",
+                },
+                ['real_array']: {
+                  pos: 11,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  dataType: 'float4[]',
+                  typeOID: 1021,
+                  notNull: false,
+                  dflt: null,
+                },
+                ['int_array']: {
+                  pos: 12,
+                  dataType: 'int4[]',
+                  typeOID: 1007,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: false,
+                  dflt: null,
+                },
+                ['json_val']: {
+                  pos: 13,
+                  dataType: 'jsonb',
+                  typeOID: 3802,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: false,
+                  dflt: null,
+                },
+                ['day']: {
+                  pos: 14,
+                  dataType: 'day_of_week',
+                  typeOID: expect.any(Number),
+                  pgTypeClass: PostgresTypeClass.Enum,
+                  characterMaximumLength: null,
+                  notNull: false,
+                  dflt: null,
+                },
+              },
+              primaryKey: ['user_id'],
+              publications: {['zero_data']: {rowFilter: null}},
+            },
+          ],
+        },
+      )
+    ).toMatchInlineSnapshot(`
+      "[
+        {
+          "schema": "test",
+          "tableName": "users",
+          "name": "users_pkey",
+          "unique": true,
+          "isReplicaIdentity": false,
+          "isImmediate": true,
+          "columns": {
+            "user_id": "ASC"
+          }
+        }
+      ]"
+    `);
+  });
+
+  test('row filter', async () => {
+    (
+      await runAndExpectIndexes(
+        `
       CREATE SCHEMA test;
       CREATE TABLE test.users (
         user_id INTEGER PRIMARY KEY,
         org_id INTEGER,
         handle text
       );
-      CREATE PUBLICATION zero_one FOR TABLE test.users WHERE (org_id = 123);
-      CREATE PUBLICATION zero_two FOR TABLE test.users (org_id, handle, user_id) WHERE (org_id = 456);
-      `,
-      expectedResult: {
-        publications: [
-          {
-            pubname: 'zero_one',
-            pubinsert: true,
-            pubupdate: true,
-            pubdelete: true,
-            pubtruncate: true,
-          },
-          {
-            pubname: 'zero_two',
-            pubinsert: true,
-            pubupdate: true,
-            pubdelete: true,
-            pubtruncate: true,
-          },
-        ],
-        tables: [
-          {
-            oid: expect.any(Number),
-            schema: 'test',
-            name: 'users',
-            replicaIdentity: 'd',
-            columns: {
-              ['user_id']: {
-                pos: 1,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: true,
-                dflt: null,
-              },
-              ['org_id']: {
-                pos: 2,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: false,
-                dflt: null,
-              },
-              handle: {
-                pos: 3,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                dataType: 'text',
-                typeOID: 25,
-                notNull: false,
-                dflt: null,
-              },
+      CREATE PUBLICATION zero_data FOR TABLE test.users WHERE (org_id = 123);`,
+        {
+          publications: [
+            {
+              pubname: 'zero_data',
+              pubinsert: true,
+              pubupdate: true,
+              pubdelete: true,
+              pubtruncate: true,
             },
-            primaryKey: ['user_id'],
-            publications: {
-              ['zero_one']: {rowFilter: '(org_id = 123)'},
-              ['zero_two']: {rowFilter: '(org_id = 456)'},
+          ],
+          tables: [
+            {
+              oid: expect.any(Number),
+              schema: 'test',
+              name: 'users',
+              replicaIdentity: 'd',
+              columns: {
+                ['user_id']: {
+                  pos: 1,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: true,
+                  dflt: null,
+                },
+                ['org_id']: {
+                  pos: 2,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: false,
+                  dflt: null,
+                },
+                handle: {
+                  pos: 3,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  dataType: 'text',
+                  typeOID: 25,
+                  notNull: false,
+                  dflt: null,
+                },
+              },
+              primaryKey: ['user_id'],
+              publications: {['zero_data']: {rowFilter: '(org_id = 123)'}},
             },
-          },
-        ],
-        indexes: [
-          {
-            schema: 'test',
-            tableName: 'users',
-            name: 'users_pkey',
-            columns: {['user_id']: 'ASC'},
-            unique: true,
-            isReplicaIdentity: false,
-            isImmediate: true,
-          },
-        ],
-      },
-    },
-    {
-      name: 'multiple row filters with unconditional',
-      setupQuery: `
+          ],
+        },
+      )
+    ).toMatchInlineSnapshot(`
+      "[
+        {
+          "schema": "test",
+          "tableName": "users",
+          "name": "users_pkey",
+          "unique": true,
+          "isReplicaIdentity": false,
+          "isImmediate": true,
+          "columns": {
+            "user_id": "ASC"
+          }
+        }
+      ]"
+    `);
+  });
+
+  test('multple row filters', async () => {
+    (
+      await runAndExpectIndexes(
+        `
       CREATE SCHEMA test;
       CREATE TABLE test.users (
         user_id INTEGER PRIMARY KEY,
@@ -427,83 +402,89 @@ describe('tables/published', () => {
         handle text
       );
       CREATE PUBLICATION zero_one FOR TABLE test.users WHERE (org_id = 123);
-      CREATE PUBLICATION zero_two FOR TABLE test.users (org_id, handle, user_id);
-      `,
-      expectedResult: {
-        publications: [
-          {
-            pubname: 'zero_one',
-            pubinsert: true,
-            pubupdate: true,
-            pubdelete: true,
-            pubtruncate: true,
-          },
-          {
-            pubname: 'zero_two',
-            pubinsert: true,
-            pubupdate: true,
-            pubdelete: true,
-            pubtruncate: true,
-          },
-        ],
-        tables: [
-          {
-            oid: expect.any(Number),
-            schema: 'test',
-            name: 'users',
-            replicaIdentity: 'd',
-            columns: {
-              ['user_id']: {
-                pos: 1,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: true,
-                dflt: null,
+      CREATE PUBLICATION zero_two FOR TABLE test.users (org_id, handle, user_id) WHERE (org_id = 456);`,
+        {
+          publications: [
+            {
+              pubname: 'zero_one',
+              pubinsert: true,
+              pubupdate: true,
+              pubdelete: true,
+              pubtruncate: true,
+            },
+            {
+              pubname: 'zero_two',
+              pubinsert: true,
+              pubupdate: true,
+              pubdelete: true,
+              pubtruncate: true,
+            },
+          ],
+          tables: [
+            {
+              oid: expect.any(Number),
+              schema: 'test',
+              name: 'users',
+              replicaIdentity: 'd',
+              columns: {
+                ['user_id']: {
+                  pos: 1,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: true,
+                  dflt: null,
+                },
+                ['org_id']: {
+                  pos: 2,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: false,
+                  dflt: null,
+                },
+                handle: {
+                  pos: 3,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  dataType: 'text',
+                  typeOID: 25,
+                  notNull: false,
+                  dflt: null,
+                },
               },
-              ['org_id']: {
-                pos: 2,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: false,
-                dflt: null,
-              },
-              handle: {
-                pos: 3,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                dataType: 'text',
-                typeOID: 25,
-                notNull: false,
-                dflt: null,
+              primaryKey: ['user_id'],
+              publications: {
+                ['zero_one']: {rowFilter: '(org_id = 123)'},
+                ['zero_two']: {rowFilter: '(org_id = 456)'},
               },
             },
-            primaryKey: ['user_id'],
-            publications: {
-              ['zero_one']: {rowFilter: '(org_id = 123)'},
-              ['zero_two']: {rowFilter: null},
-            },
-          },
-        ],
-        indexes: [
-          {
-            schema: 'test',
-            tableName: 'users',
-            name: 'users_pkey',
-            columns: {['user_id']: 'ASC'},
-            unique: true,
-            isReplicaIdentity: false,
-            isImmediate: true,
-          },
-        ],
-      },
-    },
-    {
-      name: 'multiple row filters with conflicting columns',
-      setupQuery: `
+          ],
+        },
+      )
+    ).toMatchInlineSnapshot(`
+      "[
+        {
+          "schema": "test",
+          "tableName": "users",
+          "name": "users_pkey",
+          "unique": true,
+          "isReplicaIdentity": false,
+          "isImmediate": true,
+          "columns": {
+            "user_id": "ASC"
+          }
+        }
+      ]"
+    `);
+  });
+
+  test('multiple row filters with unconditional', async () => {
+    (
+      await runAndExpectIndexes(
+        `
       CREATE SCHEMA test;
       CREATE TABLE test.users (
         user_id INTEGER PRIMARY KEY,
@@ -511,14 +492,105 @@ describe('tables/published', () => {
         handle text
       );
       CREATE PUBLICATION zero_one FOR TABLE test.users WHERE (org_id = 123);
-      CREATE PUBLICATION zero_two FOR TABLE test.users (org_id, user_id);
-      `,
-      expectedError:
-        'Error: Table users is exported with different columns: [user_id,org_id,handle] vs [user_id,org_id]',
-    },
-    {
-      name: 'column subset',
-      setupQuery: `
+      CREATE PUBLICATION zero_two FOR TABLE test.users (org_id, handle, user_id);`,
+        {
+          publications: [
+            {
+              pubname: 'zero_one',
+              pubinsert: true,
+              pubupdate: true,
+              pubdelete: true,
+              pubtruncate: true,
+            },
+            {
+              pubname: 'zero_two',
+              pubinsert: true,
+              pubupdate: true,
+              pubdelete: true,
+              pubtruncate: true,
+            },
+          ],
+          tables: [
+            {
+              oid: expect.any(Number),
+              schema: 'test',
+              name: 'users',
+              replicaIdentity: 'd',
+              columns: {
+                ['user_id']: {
+                  pos: 1,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: true,
+                  dflt: null,
+                },
+                ['org_id']: {
+                  pos: 2,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: false,
+                  dflt: null,
+                },
+                handle: {
+                  pos: 3,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  dataType: 'text',
+                  typeOID: 25,
+                  notNull: false,
+                  dflt: null,
+                },
+              },
+              primaryKey: ['user_id'],
+              publications: {
+                ['zero_one']: {rowFilter: '(org_id = 123)'},
+                ['zero_two']: {rowFilter: null},
+              },
+            },
+          ],
+        },
+      )
+    ).toMatchInlineSnapshot(`
+      "[
+        {
+          "schema": "test",
+          "tableName": "users",
+          "name": "users_pkey",
+          "unique": true,
+          "isReplicaIdentity": false,
+          "isImmediate": true,
+          "columns": {
+            "user_id": "ASC"
+          }
+        }
+      ]"
+    `);
+  });
+
+  test('multiple row filters with conflicting columns', async () => {
+    (
+      await runAndExpectError(`
+      CREATE SCHEMA test;
+      CREATE TABLE test.users (
+        user_id INTEGER PRIMARY KEY,
+        org_id INTEGER,
+        handle text
+      );
+      CREATE PUBLICATION zero_one FOR TABLE test.users WHERE (org_id = 123);
+      CREATE PUBLICATION zero_two FOR TABLE test.users (org_id, user_id);`)
+    ).toMatchInlineSnapshot(
+      `[Error: Table users is exported with different columns: [user_id,org_id,handle] vs [user_id,org_id]]`,
+    );
+  });
+
+  test('column subset', async () => {
+    (
+      await runAndExpectIndexes(
+        `
       CREATE SCHEMA test;
       CREATE TABLE test.users (
         user_id INTEGER PRIMARY KEY,
@@ -530,82 +602,88 @@ describe('tables/published', () => {
         int_array INTEGER[],
         json_val JSONB
       );
-      CREATE PUBLICATION zero_data FOR TABLE test.users (user_id, timez, int_array, json_val);
-      `,
-      expectedResult: {
-        publications: [
-          {
-            pubname: 'zero_data',
-            pubinsert: true,
-            pubupdate: true,
-            pubdelete: true,
-            pubtruncate: true,
-          },
-        ],
-        tables: [
-          {
-            oid: expect.any(Number),
-            schema: 'test',
-            name: 'users',
-            replicaIdentity: 'd',
-            columns: {
-              ['user_id']: {
-                pos: 1,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: true,
-                dflt: null,
-              },
-              ['timez']: {
-                pos: 3,
-                dataType: 'timestamptz',
-                typeOID: 1184,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: false,
-                dflt: null,
-              },
-              ['int_array']: {
-                pos: 7,
-                dataType: 'int4[]',
-                typeOID: 1007,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: false,
-                dflt: null,
-              },
-              ['json_val']: {
-                pos: 8,
-                dataType: 'jsonb',
-                typeOID: 3802,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: false,
-                dflt: null,
-              },
+      CREATE PUBLICATION zero_data FOR TABLE test.users (user_id, timez, int_array, json_val);`,
+        {
+          publications: [
+            {
+              pubname: 'zero_data',
+              pubinsert: true,
+              pubupdate: true,
+              pubdelete: true,
+              pubtruncate: true,
             },
-            primaryKey: ['user_id'],
-            publications: {['zero_data']: {rowFilter: null}},
-          },
-        ],
-        indexes: [
-          {
-            schema: 'test',
-            tableName: 'users',
-            name: 'users_pkey',
-            columns: {['user_id']: 'ASC'},
-            unique: true,
-            isReplicaIdentity: false,
-            isImmediate: true,
-          },
-        ],
-      },
-    },
-    {
-      name: 'primary key columns',
-      setupQuery: `
+          ],
+          tables: [
+            {
+              oid: expect.any(Number),
+              schema: 'test',
+              name: 'users',
+              replicaIdentity: 'd',
+              columns: {
+                ['user_id']: {
+                  pos: 1,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: true,
+                  dflt: null,
+                },
+                ['timez']: {
+                  pos: 3,
+                  dataType: 'timestamptz',
+                  typeOID: 1184,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: false,
+                  dflt: null,
+                },
+                ['int_array']: {
+                  pos: 7,
+                  dataType: 'int4[]',
+                  typeOID: 1007,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: false,
+                  dflt: null,
+                },
+                ['json_val']: {
+                  pos: 8,
+                  dataType: 'jsonb',
+                  typeOID: 3802,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: false,
+                  dflt: null,
+                },
+              },
+              primaryKey: ['user_id'],
+              publications: {['zero_data']: {rowFilter: null}},
+            },
+          ],
+        },
+      )
+    ).toMatchInlineSnapshot(`
+      "[
+        {
+          "schema": "test",
+          "tableName": "users",
+          "name": "users_pkey",
+          "unique": true,
+          "isReplicaIdentity": false,
+          "isImmediate": true,
+          "columns": {
+            "user_id": "ASC"
+          }
+        }
+      ]"
+    `);
+  });
+
+  test('primary key columns', async () => {
+    (
+      await runAndExpectIndexes(
+        `
       CREATE SCHEMA test;
       CREATE TABLE test.issues (
         issue_id INTEGER,
@@ -614,82 +692,90 @@ describe('tables/published', () => {
         component_id INTEGER,
         PRIMARY KEY (org_id, component_id, issue_id)
       );
-      CREATE PUBLICATION zero_keys FOR ALL TABLES;
-      `,
-      expectedResult: {
-        publications: [
-          {
-            pubname: 'zero_keys',
-            pubinsert: true,
-            pubupdate: true,
-            pubdelete: true,
-            pubtruncate: true,
-          },
-        ],
-        tables: [
-          {
-            oid: expect.any(Number),
-            schema: 'test',
-            name: 'issues',
-            replicaIdentity: 'd',
-            columns: {
-              ['issue_id']: {
-                pos: 1,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: true,
-                dflt: null,
-              },
-              ['description']: {
-                pos: 2,
-                dataType: 'text',
-                typeOID: 25,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: false,
-                dflt: null,
-              },
-              ['org_id']: {
-                pos: 3,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: true,
-                dflt: null,
-              },
-              ['component_id']: {
-                pos: 4,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: true,
-                dflt: null,
-              },
+      CREATE PUBLICATION zero_keys FOR ALL TABLES;`,
+        {
+          publications: [
+            {
+              pubname: 'zero_keys',
+              pubinsert: true,
+              pubupdate: true,
+              pubdelete: true,
+              pubtruncate: true,
             },
-            primaryKey: ['org_id', 'component_id', 'issue_id'],
-            publications: {['zero_keys']: {rowFilter: null}},
-          },
-        ],
-        indexes: [
-          {
-            schema: 'test',
-            tableName: 'issues',
-            name: 'issues_pkey',
-            columns: {['issue_id']: 'ASC'},
-            unique: true,
-            isReplicaIdentity: false,
-            isImmediate: true,
-          },
-        ],
-      },
-    },
-    {
-      name: 'multiple schemas',
-      setupQuery: `
+          ],
+          tables: [
+            {
+              oid: expect.any(Number),
+              schema: 'test',
+              name: 'issues',
+              replicaIdentity: 'd',
+              columns: {
+                ['issue_id']: {
+                  pos: 1,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: true,
+                  dflt: null,
+                },
+                ['description']: {
+                  pos: 2,
+                  dataType: 'text',
+                  typeOID: 25,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: false,
+                  dflt: null,
+                },
+                ['org_id']: {
+                  pos: 3,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: true,
+                  dflt: null,
+                },
+                ['component_id']: {
+                  pos: 4,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: true,
+                  dflt: null,
+                },
+              },
+              primaryKey: ['org_id', 'component_id', 'issue_id'],
+              publications: {['zero_keys']: {rowFilter: null}},
+            },
+          ],
+        },
+      )
+    ).toMatchInlineSnapshot(`
+      "[
+        {
+          "schema": "test",
+          "tableName": "issues",
+          "name": "issues_pkey",
+          "unique": true,
+          "isReplicaIdentity": false,
+          "isImmediate": true,
+          "columns": {
+            "org_id": "ASC",
+            "component_id": "ASC",
+            "issue_id": "ASC"
+          }
+        }
+      ]"
+    `);
+  });
+
+  test('multiple schemas', async () => {
+    (
+      await runAndExpectIndexes(
+        `
       CREATE SCHEMA test;
       CREATE TABLE test.issues (
         issue_id INTEGER,
@@ -711,166 +797,174 @@ describe('tables/published', () => {
       CREATE TABLE zero.clients (
         "clientID" VARCHAR (180) PRIMARY KEY,
         "lastMutationID" BIGINT
-      );
-      `,
-      expectedResult: {
-        publications: [
-          {
-            pubname: '_zero_meta',
-            pubinsert: true,
-            pubupdate: true,
-            pubdelete: true,
-            pubtruncate: true,
-          },
-          {
-            pubname: 'zero_tables',
-            pubinsert: true,
-            pubupdate: true,
-            pubdelete: true,
-            pubtruncate: true,
-          },
-        ],
-        tables: [
-          {
-            oid: expect.any(Number),
-            schema: 'test',
-            name: 'issues',
-            replicaIdentity: 'd',
-            columns: {
-              ['issue_id']: {
-                pos: 1,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: true,
-                dflt: null,
-              },
-              ['description']: {
-                pos: 2,
-                dataType: 'text',
-                typeOID: 25,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: false,
-                dflt: null,
-              },
-              ['org_id']: {
-                pos: 3,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: true,
-                dflt: null,
-              },
-              ['component_id']: {
-                pos: 4,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: true,
-                dflt: null,
-              },
+      );`,
+        {
+          publications: [
+            {
+              pubname: '_zero_meta',
+              pubinsert: true,
+              pubupdate: true,
+              pubdelete: true,
+              pubtruncate: true,
             },
-            primaryKey: ['org_id', 'component_id', 'issue_id'],
-            publications: {['zero_tables']: {rowFilter: null}},
-          },
-          {
-            oid: expect.any(Number),
-            schema: 'test',
-            name: 'users',
-            columns: {
-              ['user_id']: {
-                pos: 1,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: true,
-                dflt: null,
-              },
-              ['handle']: {
-                pos: 3,
-                dataType: 'text',
-                typeOID: 25,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: false,
-                dflt: "'foo'::text",
-              },
+            {
+              pubname: 'zero_tables',
+              pubinsert: true,
+              pubupdate: true,
+              pubdelete: true,
+              pubtruncate: true,
             },
-            primaryKey: ['user_id'],
-            publications: {['zero_tables']: {rowFilter: null}},
-          },
-          {
-            oid: expect.any(Number),
-            schema: 'zero',
-            name: 'clients',
-            replicaIdentity: 'd',
-            columns: {
-              clientID: {
-                pos: 1,
-                dataType: 'varchar',
-                typeOID: 1043,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: 180,
-                notNull: true,
-                dflt: null,
+          ],
+          tables: [
+            {
+              oid: expect.any(Number),
+              schema: 'test',
+              name: 'issues',
+              replicaIdentity: 'd',
+              columns: {
+                ['issue_id']: {
+                  pos: 1,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: true,
+                  dflt: null,
+                },
+                ['description']: {
+                  pos: 2,
+                  dataType: 'text',
+                  typeOID: 25,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: false,
+                  dflt: null,
+                },
+                ['org_id']: {
+                  pos: 3,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: true,
+                  dflt: null,
+                },
+                ['component_id']: {
+                  pos: 4,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: true,
+                  dflt: null,
+                },
               },
-              lastMutationID: {
-                pos: 2,
-                dataType: 'int8',
-                typeOID: 20,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: false,
-                dflt: null,
+              primaryKey: ['org_id', 'component_id', 'issue_id'],
+              publications: {['zero_tables']: {rowFilter: null}},
+            },
+            {
+              oid: expect.any(Number),
+              schema: 'test',
+              name: 'users',
+              columns: {
+                ['user_id']: {
+                  pos: 1,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: true,
+                  dflt: null,
+                },
+                ['handle']: {
+                  pos: 3,
+                  dataType: 'text',
+                  typeOID: 25,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: false,
+                  dflt: "'foo'::text",
+                },
               },
+              primaryKey: ['user_id'],
+              publications: {['zero_tables']: {rowFilter: null}},
             },
-            primaryKey: ['clientID'],
-            publications: {['_zero_meta']: {rowFilter: null}},
-          },
-        ],
-        indexes: [
-          {
-            schema: 'test',
-            tableName: 'issues',
-            name: 'issues_pkey',
-            columns: {
-              ['component_id']: 'ASC',
-              ['issue_id']: 'ASC',
-              ['org_id']: 'ASC',
+            {
+              oid: expect.any(Number),
+              schema: 'zero',
+              name: 'clients',
+              replicaIdentity: 'd',
+              columns: {
+                clientID: {
+                  pos: 1,
+                  dataType: 'varchar',
+                  typeOID: 1043,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: 180,
+                  notNull: true,
+                  dflt: null,
+                },
+                lastMutationID: {
+                  pos: 2,
+                  dataType: 'int8',
+                  typeOID: 20,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: false,
+                  dflt: null,
+                },
+              },
+              primaryKey: ['clientID'],
+              publications: {['_zero_meta']: {rowFilter: null}},
             },
-            unique: true,
-            isReplicaIdentity: false,
-            isImmediate: true,
-          },
-          {
-            schema: 'test',
-            tableName: 'users',
-            name: 'users_pkey',
-            columns: {['user_id']: 'ASC'},
-            unique: true,
-            isReplicaIdentity: false,
-            isImmediate: true,
-          },
-          {
-            schema: 'zero',
-            tableName: 'clients',
-            name: 'clients_pkey',
-            columns: {clientID: 'ASC'},
-            unique: true,
-            isReplicaIdentity: false,
-            isImmediate: true,
-          },
-        ],
-      },
-    },
-    {
-      name: 'indexes',
-      setupQuery: `
+          ],
+        },
+      )
+    ).toMatchInlineSnapshot(`
+      "[
+        {
+          "schema": "test",
+          "tableName": "issues",
+          "name": "issues_pkey",
+          "unique": true,
+          "isReplicaIdentity": false,
+          "isImmediate": true,
+          "columns": {
+            "org_id": "ASC",
+            "component_id": "ASC",
+            "issue_id": "ASC"
+          }
+        },
+        {
+          "schema": "test",
+          "tableName": "users",
+          "name": "users_pkey",
+          "unique": true,
+          "isReplicaIdentity": false,
+          "isImmediate": true,
+          "columns": {
+            "user_id": "ASC"
+          }
+        },
+        {
+          "schema": "zero",
+          "tableName": "clients",
+          "name": "clients_pkey",
+          "unique": true,
+          "isReplicaIdentity": false,
+          "isImmediate": true,
+          "columns": {
+            "clientID": "ASC"
+          }
+        }
+      ]"
+    `);
+  });
+
+  test('indexes that INCLUDE generated', async () => {
+    (
+      await runAndExpectIndexes(
+        `
       CREATE SCHEMA test;
       CREATE TABLE test.issues (
         issue_id INTEGER PRIMARY KEY,
@@ -883,101 +977,111 @@ describe('tables/published', () => {
       -- columns are ignored by the replica.
       CREATE INDEX issues_component_id ON test.issues (component_id) INCLUDE (stored);
       CREATE PUBLICATION zero_data FOR TABLE test.issues;
-      CREATE PUBLICATION zero_two FOR TABLE test.issues;
-      `,
-      expectedResult: {
-        publications: [
-          {
-            pubname: 'zero_data',
-            pubinsert: true,
-            pubupdate: true,
-            pubdelete: true,
-            pubtruncate: true,
-          },
-          {
-            pubname: 'zero_two',
-            pubinsert: true,
-            pubupdate: true,
-            pubdelete: true,
-            pubtruncate: true,
-          },
-        ],
-        tables: [
-          {
-            oid: expect.any(Number),
-            schema: 'test',
-            name: 'issues',
-            replicaIdentity: 'd',
-            columns: {
-              ['issue_id']: {
-                pos: 1,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: true,
-                dflt: null,
+      CREATE PUBLICATION zero_two FOR TABLE test.issues;`,
+        {
+          publications: [
+            {
+              pubname: 'zero_data',
+              pubinsert: true,
+              pubupdate: true,
+              pubdelete: true,
+              pubtruncate: true,
+            },
+            {
+              pubname: 'zero_two',
+              pubinsert: true,
+              pubupdate: true,
+              pubdelete: true,
+              pubtruncate: true,
+            },
+          ],
+          tables: [
+            {
+              oid: expect.any(Number),
+              schema: 'test',
+              name: 'issues',
+              replicaIdentity: 'd',
+              columns: {
+                ['issue_id']: {
+                  pos: 1,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: true,
+                  dflt: null,
+                },
+                ['org_id']: {
+                  pos: 2,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: false,
+                  dflt: null,
+                },
+                ['component_id']: {
+                  pos: 3,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: false,
+                  dflt: null,
+                },
               },
-              ['org_id']: {
-                pos: 2,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: false,
-                dflt: null,
-              },
-              ['component_id']: {
-                pos: 3,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: false,
-                dflt: null,
+              primaryKey: ['issue_id'],
+              publications: {
+                ['zero_data']: {rowFilter: null},
+                ['zero_two']: {rowFilter: null},
               },
             },
-            primaryKey: ['issue_id'],
-            publications: {
-              ['zero_data']: {rowFilter: null},
-              ['zero_two']: {rowFilter: null},
-            },
-          },
-        ],
-        indexes: [
-          {
-            schema: 'test',
-            tableName: 'issues',
-            name: 'issues_component_id',
-            columns: {['component_id']: 'ASC'},
-            unique: false,
-            isReplicaIdentity: false,
-            isImmediate: true,
-          },
-          {
-            schema: 'test',
-            tableName: 'issues',
-            name: 'issues_org_id',
-            columns: {['org_id']: 'ASC'},
-            unique: false,
-            isReplicaIdentity: false,
-            isImmediate: true,
-          },
-          {
-            schema: 'test',
-            tableName: 'issues',
-            name: 'issues_pkey',
-            columns: {['issue_id']: 'ASC'},
-            unique: true,
-            isReplicaIdentity: false,
-            isImmediate: true,
-          },
-        ],
-      },
-    },
-    {
-      name: 'unique indexes',
-      setupQuery: `
+          ],
+        },
+      )
+    ).toMatchInlineSnapshot(`
+      "[
+        {
+          "schema": "test",
+          "tableName": "issues",
+          "name": "issues_component_id",
+          "unique": false,
+          "isReplicaIdentity": false,
+          "isImmediate": true,
+          "columns": {
+            "component_id": "ASC"
+          }
+        },
+        {
+          "schema": "test",
+          "tableName": "issues",
+          "name": "issues_org_id",
+          "unique": false,
+          "isReplicaIdentity": false,
+          "isImmediate": true,
+          "columns": {
+            "org_id": "ASC"
+          }
+        },
+        {
+          "schema": "test",
+          "tableName": "issues",
+          "name": "issues_pkey",
+          "unique": true,
+          "isReplicaIdentity": false,
+          "isImmediate": true,
+          "columns": {
+            "issue_id": "ASC"
+          }
+        }
+      ]"
+    `);
+  });
+
+  test('unique indexes', async () => {
+    (
+      await runAndExpectIndexes(
+        `
       CREATE SCHEMA test;
       CREATE TABLE test.issues (
         issue_id INTEGER PRIMARY KEY,
@@ -985,91 +1089,101 @@ describe('tables/published', () => {
         component_id INTEGER
       );
       CREATE UNIQUE INDEX issues_component_id ON test.issues (component_id);
-      CREATE PUBLICATION zero_data FOR TABLE test.issues;
-      `,
-      expectedResult: {
-        publications: [
-          {
-            pubname: 'zero_data',
-            pubinsert: true,
-            pubupdate: true,
-            pubdelete: true,
-            pubtruncate: true,
-          },
-        ],
-        tables: [
-          {
-            oid: expect.any(Number),
-            schema: 'test',
-            name: 'issues',
-            replicaIdentity: 'd',
-            columns: {
-              ['issue_id']: {
-                pos: 1,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: true,
-                dflt: null,
-              },
-              ['org_id']: {
-                pos: 2,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: false,
-                dflt: null,
-              },
-              ['component_id']: {
-                pos: 3,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: false,
-                dflt: null,
-              },
+      CREATE PUBLICATION zero_data FOR TABLE test.issues;`,
+        {
+          publications: [
+            {
+              pubname: 'zero_data',
+              pubinsert: true,
+              pubupdate: true,
+              pubdelete: true,
+              pubtruncate: true,
             },
-            primaryKey: ['issue_id'],
-            publications: {['zero_data']: {rowFilter: null}},
-          },
-        ],
-        indexes: [
-          {
-            schema: 'test',
-            tableName: 'issues',
-            name: 'issues_component_id',
-            columns: {['component_id']: 'ASC'},
-            unique: true,
-            isReplicaIdentity: false,
-            isImmediate: true,
-          },
-          {
-            schema: 'test',
-            tableName: 'issues',
-            name: 'issues_org_id_key',
-            columns: {['org_id']: 'ASC'},
-            unique: true,
-            isReplicaIdentity: false,
-            isImmediate: true,
-          },
-          {
-            schema: 'test',
-            tableName: 'issues',
-            name: 'issues_pkey',
-            columns: {['issue_id']: 'ASC'},
-            unique: true,
-            isReplicaIdentity: false,
-            isImmediate: true,
-          },
-        ],
-      },
-    },
-    {
-      name: 'replica identity index',
-      setupQuery: `
+          ],
+          tables: [
+            {
+              oid: expect.any(Number),
+              schema: 'test',
+              name: 'issues',
+              replicaIdentity: 'd',
+              columns: {
+                ['issue_id']: {
+                  pos: 1,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: true,
+                  dflt: null,
+                },
+                ['org_id']: {
+                  pos: 2,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: false,
+                  dflt: null,
+                },
+                ['component_id']: {
+                  pos: 3,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: false,
+                  dflt: null,
+                },
+              },
+              primaryKey: ['issue_id'],
+              publications: {['zero_data']: {rowFilter: null}},
+            },
+          ],
+        },
+      )
+    ).toMatchInlineSnapshot(`
+      "[
+        {
+          "schema": "test",
+          "tableName": "issues",
+          "name": "issues_component_id",
+          "unique": true,
+          "isReplicaIdentity": false,
+          "isImmediate": true,
+          "columns": {
+            "component_id": "ASC"
+          }
+        },
+        {
+          "schema": "test",
+          "tableName": "issues",
+          "name": "issues_org_id_key",
+          "unique": true,
+          "isReplicaIdentity": false,
+          "isImmediate": true,
+          "columns": {
+            "org_id": "ASC"
+          }
+        },
+        {
+          "schema": "test",
+          "tableName": "issues",
+          "name": "issues_pkey",
+          "unique": true,
+          "isReplicaIdentity": false,
+          "isImmediate": true,
+          "columns": {
+            "issue_id": "ASC"
+          }
+        }
+      ]"
+    `);
+  });
+
+  test('replica identity index', async () => {
+    (
+      await runAndExpectIndexes(
+        `
       CREATE SCHEMA test;
       CREATE TABLE test.issues (
         issue_id INTEGER NOT NULL,
@@ -1078,76 +1192,80 @@ describe('tables/published', () => {
       );
       CREATE UNIQUE INDEX issues_key_idx ON test.issues (org_id, issue_id);
       ALTER TABLE test.issues REPLICA IDENTITY USING INDEX issues_key_idx;
-      CREATE PUBLICATION zero_data FOR TABLE test.issues;
-      `,
-      expectedResult: {
-        publications: [
-          {
-            pubname: 'zero_data',
-            pubinsert: true,
-            pubupdate: true,
-            pubdelete: true,
-            pubtruncate: true,
-          },
-        ],
-        tables: [
-          {
-            oid: expect.any(Number),
-            schema: 'test',
-            name: 'issues',
-            replicaIdentity: 'i',
-            columns: {
-              ['issue_id']: {
-                pos: 1,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: true,
-                dflt: null,
-              },
-              ['org_id']: {
-                pos: 2,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: true,
-                dflt: null,
-              },
-              ['component_id']: {
-                pos: 3,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: false,
-                dflt: null,
-              },
+      CREATE PUBLICATION zero_data FOR TABLE test.issues;`,
+        {
+          publications: [
+            {
+              pubname: 'zero_data',
+              pubinsert: true,
+              pubupdate: true,
+              pubdelete: true,
+              pubtruncate: true,
             },
-            primaryKey: [],
-            publications: {['zero_data']: {rowFilter: null}},
-          },
-        ],
-        indexes: [
-          {
-            schema: 'test',
-            tableName: 'issues',
-            name: 'issues_key_idx',
-            columns: {
-              ['org_id']: 'ASC',
-              ['issue_id']: 'ASC',
+          ],
+          tables: [
+            {
+              oid: expect.any(Number),
+              schema: 'test',
+              name: 'issues',
+              replicaIdentity: 'i',
+              columns: {
+                ['issue_id']: {
+                  pos: 1,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: true,
+                  dflt: null,
+                },
+                ['org_id']: {
+                  pos: 2,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: true,
+                  dflt: null,
+                },
+                ['component_id']: {
+                  pos: 3,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: false,
+                  dflt: null,
+                },
+              },
+              primaryKey: [],
+              publications: {['zero_data']: {rowFilter: null}},
             },
-            unique: true,
-            isReplicaIdentity: true,
-            isImmediate: true,
-          },
-        ],
-      },
-    },
-    {
-      name: 'compound indexes',
-      setupQuery: `
+          ],
+        },
+      )
+    ).toMatchInlineSnapshot(`
+      "[
+        {
+          "schema": "test",
+          "tableName": "issues",
+          "name": "issues_key_idx",
+          "unique": true,
+          "isReplicaIdentity": true,
+          "isImmediate": true,
+          "columns": {
+            "org_id": "ASC",
+            "issue_id": "ASC"
+          }
+        }
+      ]"
+    `);
+  });
+
+  test('compound indexes', async () => {
+    (
+      await runAndExpectIndexes(
+        `
       CREATE SCHEMA test;
       CREATE TABLE test.foo (
         id INTEGER PRIMARY KEY,
@@ -1157,107 +1275,113 @@ describe('tables/published', () => {
       CREATE INDEX foo_a_b ON test.foo (a ASC, b DESC);
       CREATE INDEX foo_b_a ON test.foo (b DESC, a DESC);
       CREATE PUBLICATION zero_data FOR TABLE test.foo;
-      CREATE PUBLICATION zero_two FOR TABLE test.foo;
-      `,
-      expectedResult: {
-        publications: [
-          {
-            pubname: 'zero_data',
-            pubinsert: true,
-            pubupdate: true,
-            pubdelete: true,
-            pubtruncate: true,
-          },
-          {
-            pubname: 'zero_two',
-            pubinsert: true,
-            pubupdate: true,
-            pubdelete: true,
-            pubtruncate: true,
-          },
-        ],
-        tables: [
-          {
-            oid: expect.any(Number),
-            schema: 'test',
-            name: 'foo',
-            replicaIdentity: 'd',
-            columns: {
-              ['id']: {
-                pos: 1,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: true,
-                dflt: null,
+      CREATE PUBLICATION zero_two FOR TABLE test.foo;`,
+        {
+          publications: [
+            {
+              pubname: 'zero_data',
+              pubinsert: true,
+              pubupdate: true,
+              pubdelete: true,
+              pubtruncate: true,
+            },
+            {
+              pubname: 'zero_two',
+              pubinsert: true,
+              pubupdate: true,
+              pubdelete: true,
+              pubtruncate: true,
+            },
+          ],
+          tables: [
+            {
+              oid: expect.any(Number),
+              schema: 'test',
+              name: 'foo',
+              replicaIdentity: 'd',
+              columns: {
+                ['id']: {
+                  pos: 1,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: true,
+                  dflt: null,
+                },
+                ['a']: {
+                  pos: 2,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: false,
+                  dflt: null,
+                },
+                [PostgresTypeClass.Base]: {
+                  pos: 3,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: false,
+                  dflt: null,
+                },
               },
-              ['a']: {
-                pos: 2,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: false,
-                dflt: null,
-              },
-              [PostgresTypeClass.Base]: {
-                pos: 3,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: false,
-                dflt: null,
+              primaryKey: ['id'],
+              publications: {
+                ['zero_data']: {rowFilter: null},
+                ['zero_two']: {rowFilter: null},
               },
             },
-            primaryKey: ['id'],
-            publications: {
-              ['zero_data']: {rowFilter: null},
-              ['zero_two']: {rowFilter: null},
-            },
-          },
-        ],
-        indexes: [
-          {
-            schema: 'test',
-            tableName: 'foo',
-            name: 'foo_a_b',
-            columns: {
-              a: 'ASC',
-              b: 'DESC',
-            },
-            unique: false,
-            isReplicaIdentity: false,
-            isImmediate: true,
-          },
-          {
-            schema: 'test',
-            tableName: 'foo',
-            name: 'foo_b_a',
-            columns: {
-              b: 'DESC',
-              a: 'DESC',
-            },
-            unique: false,
-            isReplicaIdentity: false,
-            isImmediate: true,
-          },
-          {
-            schema: 'test',
-            tableName: 'foo',
-            name: 'foo_pkey',
-            columns: {id: 'ASC'},
-            unique: true,
-            isReplicaIdentity: false,
-            isImmediate: true,
-          },
-        ],
-      },
-    },
-    {
-      name: 'ignores irrelevant indexes',
-      setupQuery: `
+          ],
+        },
+      )
+    ).toMatchInlineSnapshot(`
+      "[
+        {
+          "schema": "test",
+          "tableName": "foo",
+          "name": "foo_a_b",
+          "unique": false,
+          "isReplicaIdentity": false,
+          "isImmediate": true,
+          "columns": {
+            "a": "ASC",
+            "b": "DESC"
+          }
+        },
+        {
+          "schema": "test",
+          "tableName": "foo",
+          "name": "foo_b_a",
+          "unique": false,
+          "isReplicaIdentity": false,
+          "isImmediate": true,
+          "columns": {
+            "b": "DESC",
+            "a": "DESC"
+          }
+        },
+        {
+          "schema": "test",
+          "tableName": "foo",
+          "name": "foo_pkey",
+          "unique": true,
+          "isReplicaIdentity": false,
+          "isImmediate": true,
+          "columns": {
+            "id": "ASC"
+          }
+        }
+      ]"
+    `);
+  });
+
+  test('ignores irrelevant indexes', async () => {
+    (
+      await runAndExpectIndexes(
+        `
       CREATE SCHEMA test;
       CREATE TABLE test.issues (
         issue_id INTEGER PRIMARY KEY,
@@ -1273,101 +1397,109 @@ describe('tables/published', () => {
       CREATE INDEX partial_idx ON test.issues (component_id) WHERE org_id > 1000;
       CREATE INDEX idx_with_gen ON test.issues (issue_id, org_id, component_id, excluded);
       CREATE INDEX birthday_idx ON test.users (user_id, birthday);
-      CREATE PUBLICATION zero_data FOR TABLE test.issues, TABLE test.users (user_id);
-      `,
-      expectedResult: {
-        publications: [
-          {
-            pubname: 'zero_data',
-            pubinsert: true,
-            pubupdate: true,
-            pubdelete: true,
-            pubtruncate: true,
-          },
-        ],
-        tables: [
-          {
-            oid: expect.any(Number),
-            schema: 'test',
-            name: 'issues',
-            replicaIdentity: 'd',
-            columns: {
-              ['issue_id']: {
-                pos: 1,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: true,
-                dflt: null,
-              },
-              ['org_id']: {
-                pos: 2,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: false,
-                dflt: null,
-              },
-              ['component_id']: {
-                pos: 3,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: false,
-                dflt: null,
-              },
+      CREATE PUBLICATION zero_data FOR TABLE test.issues, TABLE test.users (user_id);`,
+        {
+          publications: [
+            {
+              pubname: 'zero_data',
+              pubinsert: true,
+              pubupdate: true,
+              pubdelete: true,
+              pubtruncate: true,
             },
-            primaryKey: ['issue_id'],
-            publications: {['zero_data']: {rowFilter: null}},
-          },
-          {
-            oid: expect.any(Number),
-            schema: 'test',
-            name: 'users',
-            replicaIdentity: 'd',
-            columns: {
-              ['user_id']: {
-                pos: 1,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: true,
-                dflt: null,
+          ],
+          tables: [
+            {
+              oid: expect.any(Number),
+              schema: 'test',
+              name: 'issues',
+              replicaIdentity: 'd',
+              columns: {
+                ['issue_id']: {
+                  pos: 1,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: true,
+                  dflt: null,
+                },
+                ['org_id']: {
+                  pos: 2,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: false,
+                  dflt: null,
+                },
+                ['component_id']: {
+                  pos: 3,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: false,
+                  dflt: null,
+                },
               },
+              primaryKey: ['issue_id'],
+              publications: {['zero_data']: {rowFilter: null}},
             },
-            primaryKey: ['user_id'],
-            publications: {['zero_data']: {rowFilter: null}},
-          },
-        ],
-        indexes: [
-          {
-            schema: 'test',
-            tableName: 'issues',
-            name: 'issues_pkey',
-            columns: {['issue_id']: 'ASC'},
-            unique: true,
-            isReplicaIdentity: false,
-            isImmediate: true,
-          },
-          {
-            schema: 'test',
-            tableName: 'users',
-            name: 'users_pkey',
-            columns: {['user_id']: 'ASC'},
-            unique: true,
-            isReplicaIdentity: false,
-            isImmediate: true,
-          },
-        ],
-      },
-    },
-    {
-      name: 'indices after column rename',
-      setupQuery: `
+            {
+              oid: expect.any(Number),
+              schema: 'test',
+              name: 'users',
+              replicaIdentity: 'd',
+              columns: {
+                ['user_id']: {
+                  pos: 1,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: true,
+                  dflt: null,
+                },
+              },
+              primaryKey: ['user_id'],
+              publications: {['zero_data']: {rowFilter: null}},
+            },
+          ],
+        },
+      )
+    ).toMatchInlineSnapshot(`
+      "[
+        {
+          "schema": "test",
+          "tableName": "issues",
+          "name": "issues_pkey",
+          "unique": true,
+          "isReplicaIdentity": false,
+          "isImmediate": true,
+          "columns": {
+            "issue_id": "ASC"
+          }
+        },
+        {
+          "schema": "test",
+          "tableName": "users",
+          "name": "users_pkey",
+          "unique": true,
+          "isReplicaIdentity": false,
+          "isImmediate": true,
+          "columns": {
+            "user_id": "ASC"
+          }
+        }
+      ]"
+    `);
+  });
+
+  test('indices after column rename', async () => {
+    (
+      await runAndExpectIndexes(
+        `
       CREATE SCHEMA test;
       CREATE TABLE test.foo (
         id INTEGER PRIMARY KEY,
@@ -1379,136 +1511,96 @@ describe('tables/published', () => {
       CREATE PUBLICATION zero_data FOR TABLE test.foo;
 
       ALTER TABLE test.foo RENAME a to az;
-      ALTER TABLE test.foo RENAME b to bz;
-      `,
-      expectedResult: {
-        publications: [
-          {
-            pubname: 'zero_data',
-            pubinsert: true,
-            pubupdate: true,
-            pubdelete: true,
-            pubtruncate: true,
-          },
-        ],
-        tables: [
-          {
-            oid: expect.any(Number),
-            schema: 'test',
-            name: 'foo',
-            replicaIdentity: 'd',
-            columns: {
-              ['id']: {
-                pos: 1,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: true,
-                dflt: null,
-              },
-              ['az']: {
-                pos: 2,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: false,
-                dflt: null,
-              },
-              ['bz']: {
-                pos: 3,
-                dataType: 'int4',
-                typeOID: 23,
-                pgTypeClass: PostgresTypeClass.Base,
-                characterMaximumLength: null,
-                notNull: false,
-                dflt: null,
-              },
+      ALTER TABLE test.foo RENAME b to bz;`,
+        {
+          publications: [
+            {
+              pubname: 'zero_data',
+              pubinsert: true,
+              pubupdate: true,
+              pubdelete: true,
+              pubtruncate: true,
             },
-            primaryKey: ['id'],
-            publications: {['zero_data']: {rowFilter: null}},
-          },
-        ],
-        indexes: [
-          {
-            schema: 'test',
-            tableName: 'foo',
-            name: 'foo_a_b',
-            columns: {
-              az: 'ASC',
-              bz: 'ASC',
+          ],
+          tables: [
+            {
+              oid: expect.any(Number),
+              schema: 'test',
+              name: 'foo',
+              replicaIdentity: 'd',
+              columns: {
+                ['id']: {
+                  pos: 1,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: true,
+                  dflt: null,
+                },
+                ['az']: {
+                  pos: 2,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: false,
+                  dflt: null,
+                },
+                ['bz']: {
+                  pos: 3,
+                  dataType: 'int4',
+                  typeOID: 23,
+                  pgTypeClass: PostgresTypeClass.Base,
+                  characterMaximumLength: null,
+                  notNull: false,
+                  dflt: null,
+                },
+              },
+              primaryKey: ['id'],
+              publications: {['zero_data']: {rowFilter: null}},
             },
-            unique: false,
-            isReplicaIdentity: false,
-            isImmediate: true,
-          },
-          {
-            schema: 'test',
-            tableName: 'foo',
-            name: 'foo_b_a',
-            columns: {
-              bz: 'DESC',
-              az: 'DESC',
-            },
-            unique: false,
-            isReplicaIdentity: false,
-            isImmediate: true,
-          },
-          {
-            schema: 'test',
-            tableName: 'foo',
-            name: 'foo_pkey',
-            columns: {id: 'ASC'},
-            unique: true,
-            isReplicaIdentity: false,
-            isImmediate: true,
-          },
-        ],
-      },
-    },
-  ];
-
-  let db: postgres.Sql;
-  beforeEach(async () => {
-    db = await testDBs.create('published_tables_test');
-  });
-
-  afterEach(async () => {
-    await testDBs.drop(db);
-  });
-
-  for (const c of cases) {
-    test(c.name, async () => {
-      await db.unsafe(c.setupQuery);
-
-      try {
-        const tables = await getPublicationInfo(
-          db,
-          c.expectedResult
-            ? c.expectedResult.publications.map(p => p.pubname)
-            : [
-                'zero_all',
-                'zero_data',
-                'zero_one',
-                'zero_two',
-                'zero_keys',
-                '_zero_meta',
-                'zero_tables',
-              ],
-        );
-        assert(c.expectedResult);
-        expect(tables).toMatchObject(c.expectedResult);
-        for (const t of tables.tables) {
-          expect(t.columns.excluded).toBeUndefined();
+          ],
+        },
+      )
+    ).toMatchInlineSnapshot(`
+      "[
+        {
+          "schema": "test",
+          "tableName": "foo",
+          "name": "foo_a_b",
+          "unique": false,
+          "isReplicaIdentity": false,
+          "isImmediate": true,
+          "columns": {
+            "az": "ASC",
+            "bz": "ASC"
+          }
+        },
+        {
+          "schema": "test",
+          "tableName": "foo",
+          "name": "foo_b_a",
+          "unique": false,
+          "isReplicaIdentity": false,
+          "isImmediate": true,
+          "columns": {
+            "bz": "DESC",
+            "az": "DESC"
+          }
+        },
+        {
+          "schema": "test",
+          "tableName": "foo",
+          "name": "foo_pkey",
+          "unique": true,
+          "isReplicaIdentity": false,
+          "isImmediate": true,
+          "columns": {
+            "id": "ASC"
+          }
         }
-      } catch (e) {
-        if (c.expectedError) {
-          expect(c.expectedError).toMatch(String(e));
-        } else {
-          throw e;
-        }
-      }
-    });
-  }
+      ]"
+    `);
+  });
 });

--- a/packages/zero-cache/src/services/change-source/pg/schema/published.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/published.ts
@@ -127,7 +127,8 @@ export function indexDefinitionsQuery(publications: readonly string[]) {
     ) as indexed ON true
     JOIN LATERAL (
       SELECT pg_attribute.attname as name, col.index_pos as pos
-        FROM UNNEST(pg_index.indkey) WITH ORDINALITY as col(table_pos, index_pos)
+        FROM UNNEST( (pg_index.indkey::smallint[])[:pg_index.indnkeyatts - 1] ) 
+          WITH ORDINALITY as col(table_pos, index_pos)
         JOIN pg_attribute ON attrelid = pg_index.indrelid AND attnum = col.table_pos
     ) AS index_column ON true
     LEFT JOIN pg_constraint ON pg_constraint.conindid = pc.oid
@@ -150,7 +151,7 @@ export function indexDefinitionsQuery(publications: readonly string[]) {
       'unique', "unique",
       'isReplicaIdentity', "isReplicaIdentity",
       'isImmediate', "isImmediate",
-      'columns', json_object_agg(DISTINCT "col", "dir")
+      'columns', json_object_agg("col", "dir")
     ) AS index FROM indexed_columns 
       GROUP BY "schema", "tableName", "name", "unique", "isReplicaIdentity", "isImmediate")
 


### PR DESCRIPTION
User report:

https://discord.com/channels/830183651022471199/1370898291721506876/1371170647241265293

Fixes replicated indexes to respect the column ordering of the upstream index.

Tangential: Also corrects the logic that excludes `INCLUDE`d (i.e. stored but not indexed) columns. 

### ⚠️ NOTE

To fully apply this fix, a resync is required. 

A resync is thus recommended for any app with compound indexes (including primary keys).