### PR TITLE
fix(zero-cache): add flow control for large change DB transactions

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -357,8 +357,12 @@ class ChangeStreamerImpl implements ChangeStreamerService {
 
           if (type === 'commit') {
             watermark = null;
-            // After each transaction, allow storer to exert back pressure.
-            await this.#storer.readyForMore();
+          }
+
+          // Allow the storer to exert back pressure.
+          const readyForMore = this.#storer.readyForMore();
+          if (readyForMore) {
+            await readyForMore;
           }
         }
       } catch (e) {


### PR DESCRIPTION
Respond to back pressure from the change db for very large transactions by awaiting (the execution of) every 10,000th statement. This builds off of the new Promise API for Transaction Pool writes in https://github.com/rocicorp/mono/pull/4367.

This was verified in a stress test that performs a 2M row update. Previously this would result in crashing the replication-manager with an OOM, and now it successfully process the transaction as quickly as the change-db is able to store the changes.

User report:

https://discord.com/channels/830183651022471199/1370057107814088796/1370245009219260599