### PR TITLE
chore(zql): migrate benchmarks to mitata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18229,6 +18229,11 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mitata": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/mitata/-/mitata-1.0.34.tgz",
+      "integrity": "sha512-Mc3zrtNBKIMeHSCQ0XqRLo1vbdIx1wvFV9c8NJAiyho6AjNfMY8bVhbS12bwciUdd1t4rj8099CH3N3NFahaUA=="
+    },
     "node_modules/mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
@@ -27472,6 +27477,9 @@
     },
     "packages/zql-benchmarks": {
       "version": "0.0.0",
+      "dependencies": {
+        "mitata": "^1.0.34"
+      },
       "devDependencies": {
         "@rocicorp/eslint-config": "^0.7.0",
         "@rocicorp/prettier-config": "^0.3.0",
@@ -39293,6 +39301,11 @@
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "dev": true
     },
+    "mitata": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/mitata/-/mitata-1.0.34.tgz",
+      "integrity": "sha512-Mc3zrtNBKIMeHSCQ0XqRLo1vbdIx1wvFV9c8NJAiyho6AjNfMY8bVhbS12bwciUdd1t4rj8099CH3N3NFahaUA=="
+    },
     "mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
@@ -45354,6 +45367,7 @@
         "@rocicorp/eslint-config": "^0.7.0",
         "@rocicorp/prettier-config": "^0.3.0",
         "@types/tmp": "^0.2.6",
+        "mitata": "^1.0.34",
         "shared": "0.0.0",
         "typescript": "~5.8.2"
       }

--- a/packages/zql-benchmarks/package.json
+++ b/packages/zql-benchmarks/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint --ext .ts,.tsx,.js,.jsx src/",
     "test": "vitest run",
     "test:watch": "vitest watch",
-    "bench": "vitest bench",
+    "bench": "vitest bench --run --silent=false --disable-console-intercept",
     "test-types": "vitest run --typecheck.only --no-browser.enabled",
     "test-types:watch": "vitest watch --typecheck.only --no-browser.enabled"
   },
@@ -27,5 +27,8 @@
   "eslintConfig": {
     "extends": "../../eslint-config.json"
   },
-  "prettier": "@rocicorp/prettier-config"
+  "prettier": "@rocicorp/prettier-config",
+  "dependencies": {
+    "mitata": "^1.0.34"
+  }
 }


### PR DESCRIPTION
problems with tinybench:
- setup/teardown methods do not work
- params to tune warmup and test iterations do not work

mitata seems more robust and it gives us insights into GC and CPU cycles.

Notes to self:
- We should change the benchmarks to allow comparing different queries rather than comparing zql vs zqlite vs pg perf.
- We should bump counters for fetch calls and print those too
- We should warn if a fetch does not use an index in zqlite

![CleanShot 2025-05-14 at 12 10 21](https://github.com/user-attachments/assets/2c330031-5460-4bb8-942c-bb834eff86d2)


