### PR TITLE
fix(zql): return after first row for point queries (60x speedup)

### DIFF
--- a/packages/shared/src/iterables.ts
+++ b/packages/shared/src/iterables.ts
@@ -35,6 +35,15 @@ export function first<T>(stream: Iterable<T>): T | undefined {
   return value;
 }
 
+export function* once<T>(stream: Iterable<T>): Iterable<T> {
+  const it = stream[Symbol.iterator]();
+  const {value} = it.next();
+  if (value !== undefined) {
+    yield value;
+  }
+  it.return?.();
+}
+
 // TODO(arv): Use ES2024 Iterable.from when available
 // https://github.com/tc39/proposal-iterator-helpers
 

--- a/packages/zql/src/ivm/memory-source.ts
+++ b/packages/zql/src/ivm/memory-source.ts
@@ -44,6 +44,7 @@ import type {
   SourceInput,
 } from './source.ts';
 import type {Stream} from './stream.ts';
+import {once} from '../../../shared/src/iterables.ts';
 
 export type Overlay = {
   outputIndex: number;
@@ -313,9 +314,10 @@ export class MemorySource implements Source {
       scanStart = startAt;
     }
 
+    const rowsIterable = generateRows(data, scanStart, req.reverse);
     const withOverlay = generateWithOverlay(
       startAt,
-      generateRows(data, scanStart, req.reverse),
+      pkConstraint ? once(rowsIterable) : rowsIterable,
       req.constraint,
       this.#overlay,
       this.#splitEditOverlay,


### PR DESCRIPTION
**60x faster** (of course this depends on the size of the collection. ~3,500 rows in this case)

![CleanShot 2025-05-14 at 19 39 13](https://github.com/user-attachments/assets/b88d69a7-b789-48ad-a06b-2ac6a2262a25)


Before:
![CleanShot 2025-05-14 at 19 38 32](https://github.com/user-attachments/assets/85e137c3-6e56-424e-a701-783d838a7b4a)


After:
![CleanShot 2025-05-14 at 19 37 07](https://github.com/user-attachments/assets/0f304c2d-4873-454d-bab1-0cbad7fa97bb)
