### PR TITLE
chore(custom-queries): change from `internal: boolean` to `type:`

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr-store.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.pg-test.ts
@@ -801,6 +801,7 @@ describe('view-syncer/cvr-store', () => {
             "transformationVersion": {
               "stateVersion": "01",
             },
+            "type": "client",
           },
         },
         "replicaVersion": "01",

--- a/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
@@ -444,6 +444,7 @@ describe('view-syncer/cvr', () => {
       queries: {
         ['oneHash']: {
           id: 'oneHash',
+          type: 'client',
           ast: {table: 'issues'},
           transformationHash: 'twoHash',
           clientState: {
@@ -549,6 +550,7 @@ describe('view-syncer/cvr', () => {
       queries: {
         oneHash: {
           id: 'oneHash',
+          type: 'client',
           ast: {table: 'issues'},
           transformationHash: 'twoHash',
           clientState: {
@@ -777,6 +779,7 @@ describe('view-syncer/cvr', () => {
       queries: {
         oneHash: {
           id: 'oneHash',
+          type: 'client',
           ast: {table: 'issues'},
           transformationHash: 'twoHash',
           transformationVersion: undefined,
@@ -964,7 +967,7 @@ describe('view-syncer/cvr', () => {
       queries: {
         lmids: {
           id: 'lmids',
-          internal: true,
+          type: 'internal',
           ast: {
             table: `${APP_ID}_${SHARD_NUM}.clients`,
             schema: '',
@@ -988,6 +991,7 @@ describe('view-syncer/cvr', () => {
         },
         oneHash: {
           id: 'oneHash',
+          type: 'client',
           ast: {table: 'issues'},
           transformationHash: 'twoHash',
           transformationVersion: undefined,
@@ -1002,6 +1006,7 @@ describe('view-syncer/cvr', () => {
         },
         threeHash: {
           id: 'threeHash',
+          type: 'client',
           ast: {table: 'comments'},
           clientState: {
             barClient: {
@@ -1018,6 +1023,7 @@ describe('view-syncer/cvr', () => {
         },
         fourHash: {
           id: 'fourHash',
+          type: 'client',
           ast: {table: 'users'},
           clientState: {
             fooClient: {
@@ -1682,6 +1688,7 @@ describe('view-syncer/cvr', () => {
       queries: {
         oneHash: {
           id: 'oneHash',
+          type: 'client',
           ast: {table: 'issues'},
           clientState: {
             fooClient: {
@@ -2125,6 +2132,7 @@ describe('view-syncer/cvr', () => {
       queries: {
         oneHash: {
           id: 'oneHash',
+          type: 'client',
           ast: {table: 'issues'},
           clientState: {
             fooClient: {
@@ -2712,6 +2720,7 @@ describe('view-syncer/cvr', () => {
       queries: {
         oneHash: {
           id: 'oneHash',
+          type: 'client',
           ast: {table: 'issues'},
           clientState: {
             fooClient: {
@@ -2726,6 +2735,7 @@ describe('view-syncer/cvr', () => {
         },
         twoHash: {
           id: 'twoHash',
+          type: 'client',
           ast: {table: 'issues'},
           clientState: {
             fooClient: {
@@ -3429,6 +3439,7 @@ describe('view-syncer/cvr', () => {
             "transformationVersion": {
               "stateVersion": "1aa",
             },
+            "type": "client",
           },
           "twoHash": {
             "ast": {
@@ -3453,6 +3464,7 @@ describe('view-syncer/cvr', () => {
             "transformationVersion": {
               "stateVersion": "1aa",
             },
+            "type": "client",
           },
         },
         "replicaVersion": "120",
@@ -5096,6 +5108,7 @@ describe('view-syncer/cvr', () => {
               "patchVersion": undefined,
               "transformationHash": undefined,
               "transformationVersion": undefined,
+              "type": "client",
             },
           },
           "replicaVersion": "120",
@@ -5120,6 +5133,7 @@ describe('view-syncer/cvr', () => {
         lastActive: now,
         queries: {
           oneHash: {
+            type: 'client',
             ast: {
               table: 'issues',
             },
@@ -5241,6 +5255,7 @@ describe('view-syncer/cvr', () => {
               },
             },
           },
+          type: 'client',
           id: 'oneHash',
           patchVersion: undefined,
           transformationHash: undefined,
@@ -5257,6 +5272,7 @@ describe('view-syncer/cvr', () => {
           ast: {
             table: 'issues',
           },
+          type: 'client',
           clientState: {
             fooClient: {
               inactivatedAt: now,
@@ -5353,48 +5369,49 @@ describe('view-syncer/cvr', () => {
       );
       const cvr = await cvrStore.load(lc, LAST_CONNECT);
       expect(cvr).toMatchInlineSnapshot(`
-        {
-          "clientSchema": null,
-          "clients": {
-            "fooClient": {
-              "desiredQueryIDs": [
-                "oneHash",
-              ],
-              "id": "fooClient",
-            },
-          },
-          "id": "abc123",
-          "lastActive": 1742256000000,
-          "queries": {
-            "oneHash": {
-              "ast": {
-                "table": "issues",
+          {
+            "clientSchema": null,
+            "clients": {
+              "fooClient": {
+                "desiredQueryIDs": [
+                  "oneHash",
+                ],
+                "id": "fooClient",
               },
-              "clientState": {
-                "fooClient": {
-                  "inactivatedAt": undefined,
-                  "ttl": -1,
-                  "version": {
-                    "minorVersion": 1,
-                    "stateVersion": "1a9",
+            },
+            "id": "abc123",
+            "lastActive": 1742256000000,
+            "queries": {
+              "oneHash": {
+                "ast": {
+                  "table": "issues",
+                },
+                "clientState": {
+                  "fooClient": {
+                    "inactivatedAt": undefined,
+                    "ttl": -1,
+                    "version": {
+                      "minorVersion": 1,
+                      "stateVersion": "1a9",
+                    },
                   },
                 },
-              },
-              "id": "oneHash",
-              "patchVersion": undefined,
-              "transformationHash": "oneHashTransformed",
-              "transformationVersion": {
-                "minorVersion": 1,
-                "stateVersion": "1a9",
+                "id": "oneHash",
+                "patchVersion": undefined,
+                "transformationHash": "oneHashTransformed",
+                "transformationVersion": {
+                  "minorVersion": 1,
+                  "stateVersion": "1a9",
+                },
+                "type": "client",
               },
             },
-          },
-          "replicaVersion": "120",
-          "version": {
-            "stateVersion": "1aa",
-          },
-        }
-      `);
+            "replicaVersion": "120",
+            "version": {
+              "stateVersion": "1aa",
+            },
+          }
+        `);
 
       const updater = new CVRConfigDrivenUpdater(cvrStore, cvr, SHARD);
       expect(
@@ -5428,6 +5445,7 @@ describe('view-syncer/cvr', () => {
         lastActive: now,
         queries: {
           oneHash: {
+            type: 'client',
             ast: {
               table: 'issues',
             },
@@ -5709,68 +5727,69 @@ describe('view-syncer/cvr', () => {
       Date.now(),
     );
     expect(updated).toMatchInlineSnapshot(`
-      {
-        "clientSchema": null,
-        "clients": {
-          "client-a": {
-            "desiredQueryIDs": [
-              "oneHash",
-            ],
-            "id": "client-a",
-          },
-          "client-c": {
-            "desiredQueryIDs": [
-              "oneHash",
-            ],
-            "id": "client-c",
-          },
-        },
-        "id": "abc123",
-        "lastActive": 1709683200000,
-        "queries": {
-          "oneHash": {
-            "ast": {
-              "table": "issues",
+        {
+          "clientSchema": null,
+          "clients": {
+            "client-a": {
+              "desiredQueryIDs": [
+                "oneHash",
+              ],
+              "id": "client-a",
             },
-            "clientState": {
-              "client-a": {
-                "inactivatedAt": undefined,
-                "ttl": -1,
-                "version": {
-                  "minorVersion": 1,
-                  "stateVersion": "1a9",
-                },
-              },
-              "client-b": {
-                "inactivatedAt": 1709683200000,
-                "ttl": -1,
-                "version": {
-                  "minorVersion": 1,
-                  "stateVersion": "1aa",
-                },
-              },
-              "client-c": {
-                "inactivatedAt": undefined,
-                "ttl": -1,
-                "version": {
-                  "minorVersion": 1,
-                  "stateVersion": "1a9",
-                },
-              },
+            "client-c": {
+              "desiredQueryIDs": [
+                "oneHash",
+              ],
+              "id": "client-c",
             },
-            "id": "oneHash",
-            "patchVersion": undefined,
-            "transformationHash": undefined,
-            "transformationVersion": undefined,
           },
-        },
-        "replicaVersion": "120",
-        "version": {
-          "minorVersion": 1,
-          "stateVersion": "1aa",
-        },
-      }
-    `);
+          "id": "abc123",
+          "lastActive": 1709683200000,
+          "queries": {
+            "oneHash": {
+              "ast": {
+                "table": "issues",
+              },
+              "clientState": {
+                "client-a": {
+                  "inactivatedAt": undefined,
+                  "ttl": -1,
+                  "version": {
+                    "minorVersion": 1,
+                    "stateVersion": "1a9",
+                  },
+                },
+                "client-b": {
+                  "inactivatedAt": 1709683200000,
+                  "ttl": -1,
+                  "version": {
+                    "minorVersion": 1,
+                    "stateVersion": "1aa",
+                  },
+                },
+                "client-c": {
+                  "inactivatedAt": undefined,
+                  "ttl": -1,
+                  "version": {
+                    "minorVersion": 1,
+                    "stateVersion": "1a9",
+                  },
+                },
+              },
+              "id": "oneHash",
+              "patchVersion": undefined,
+              "transformationHash": undefined,
+              "transformationVersion": undefined,
+              "type": "client",
+            },
+          },
+          "replicaVersion": "120",
+          "version": {
+            "minorVersion": 1,
+            "stateVersion": "1aa",
+          },
+        }
+      `);
     expect(flushed).toMatchInlineSnapshot(`
       {
         "clients": 1,
@@ -6028,59 +6047,60 @@ describe('view-syncer/cvr', () => {
     const cvr = await cvrStore.load(lc, LAST_CONNECT);
 
     expect(cvr).toMatchInlineSnapshot(`
-      {
-        "clientSchema": null,
-        "clients": {
-          "client-a": {
-            "desiredQueryIDs": [
-              "oneHash",
-            ],
-            "id": "client-a",
-          },
-          "client-c": {
-            "desiredQueryIDs": [
-              "oneHash",
-            ],
-            "id": "client-c",
-          },
-        },
-        "id": "abc123",
-        "lastActive": 1713830400000,
-        "queries": {
-          "oneHash": {
-            "ast": {
-              "table": "issues",
+        {
+          "clientSchema": null,
+          "clients": {
+            "client-a": {
+              "desiredQueryIDs": [
+                "oneHash",
+              ],
+              "id": "client-a",
             },
-            "clientState": {
-              "client-a": {
-                "inactivatedAt": undefined,
-                "ttl": -1,
-                "version": {
-                  "minorVersion": 1,
-                  "stateVersion": "1a9",
+            "client-c": {
+              "desiredQueryIDs": [
+                "oneHash",
+              ],
+              "id": "client-c",
+            },
+          },
+          "id": "abc123",
+          "lastActive": 1713830400000,
+          "queries": {
+            "oneHash": {
+              "ast": {
+                "table": "issues",
+              },
+              "clientState": {
+                "client-a": {
+                  "inactivatedAt": undefined,
+                  "ttl": -1,
+                  "version": {
+                    "minorVersion": 1,
+                    "stateVersion": "1a9",
+                  },
+                },
+                "client-c": {
+                  "inactivatedAt": undefined,
+                  "ttl": -1,
+                  "version": {
+                    "minorVersion": 1,
+                    "stateVersion": "1a9",
+                  },
                 },
               },
-              "client-c": {
-                "inactivatedAt": undefined,
-                "ttl": -1,
-                "version": {
-                  "minorVersion": 1,
-                  "stateVersion": "1a9",
-                },
-              },
+              "id": "oneHash",
+              "patchVersion": undefined,
+              "transformationHash": undefined,
+              "transformationVersion": undefined,
+              "type": "client",
             },
-            "id": "oneHash",
-            "patchVersion": undefined,
-            "transformationHash": undefined,
-            "transformationVersion": undefined,
           },
-        },
-        "replicaVersion": "120",
-        "version": {
-          "stateVersion": "1aa",
-        },
-      }
-    `);
+          "replicaVersion": "120",
+          "version": {
+            "stateVersion": "1aa",
+          },
+        }
+      `);
 
     const updater = new CVRConfigDrivenUpdater(cvrStore, cvr, SHARD);
 
@@ -6242,59 +6262,60 @@ describe('view-syncer/cvr', () => {
     `);
 
     expect(updated).toMatchInlineSnapshot(`
-      {
-        "clientSchema": null,
-        "clients": {
-          "client-a": {
-            "desiredQueryIDs": [
-              "oneHash",
-            ],
-            "id": "client-a",
-          },
-          "client-c": {
-            "desiredQueryIDs": [
-              "oneHash",
-            ],
-            "id": "client-c",
-          },
-        },
-        "id": "abc123",
-        "lastActive": 1713834000000,
-        "queries": {
-          "oneHash": {
-            "ast": {
-              "table": "issues",
-            },
-            "clientState": {
-              "client-a": {
-                "inactivatedAt": undefined,
-                "ttl": -1,
-                "version": {
-                  "minorVersion": 1,
-                  "stateVersion": "1a9",
+              {
+                "clientSchema": null,
+                "clients": {
+                  "client-a": {
+                    "desiredQueryIDs": [
+                      "oneHash",
+                    ],
+                    "id": "client-a",
+                  },
+                  "client-c": {
+                    "desiredQueryIDs": [
+                      "oneHash",
+                    ],
+                    "id": "client-c",
+                  },
                 },
-              },
-              "client-c": {
-                "inactivatedAt": undefined,
-                "ttl": -1,
-                "version": {
-                  "minorVersion": 1,
-                  "stateVersion": "1a9",
+                "id": "abc123",
+                "lastActive": 1713834000000,
+                "queries": {
+                  "oneHash": {
+                    "ast": {
+                      "table": "issues",
+                    },
+                    "clientState": {
+                      "client-a": {
+                        "inactivatedAt": undefined,
+                        "ttl": -1,
+                        "version": {
+                          "minorVersion": 1,
+                          "stateVersion": "1a9",
+                        },
+                      },
+                      "client-c": {
+                        "inactivatedAt": undefined,
+                        "ttl": -1,
+                        "version": {
+                          "minorVersion": 1,
+                          "stateVersion": "1a9",
+                        },
+                      },
+                    },
+                    "id": "oneHash",
+                    "patchVersion": undefined,
+                    "transformationHash": undefined,
+                    "transformationVersion": undefined,
+                    "type": "client",
+                  },
                 },
-              },
-            },
-            "id": "oneHash",
-            "patchVersion": undefined,
-            "transformationHash": undefined,
-            "transformationVersion": undefined,
-          },
-        },
-        "replicaVersion": "120",
-        "version": {
-          "stateVersion": "1aa",
-        },
-      }
-    `);
+                "replicaVersion": "120",
+                "version": {
+                  "stateVersion": "1aa",
+                },
+              }
+            `);
 
     {
       const cvr = await cvrStore.load(lc, LAST_CONNECT);

--- a/packages/zero-cache/src/services/view-syncer/cvr.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.test.ts
@@ -35,6 +35,7 @@ function makeCVR(clients: Record<string, QueryDef[]>): CVR {
         ast: {
           table: 'issues',
         },
+        type: 'client',
         clientState: {},
         id: hash,
         patchVersion: undefined,

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -69,7 +69,7 @@ const CLIENT_LMID_QUERY_ID = 'lmids';
 function assertNotInternal(
   query: QueryRecord,
 ): asserts query is ClientQueryRecord {
-  if (query.internal) {
+  if (query.type === 'internal') {
     // This should never happen for behaving clients, as query ids should be hashes.
     throw new Error(`Query ID ${query.id} is reserved for internal use`);
   }
@@ -202,7 +202,7 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
             ['clientID', 'asc'],
           ],
         },
-        internal: true,
+        type: 'internal',
       };
       this._cvr.queries[CLIENT_LMID_QUERY_ID] = lmidsQuery;
       this._cvrStore.putQuery(lmidsQuery);
@@ -249,7 +249,7 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
         needed.add(hash);
         continue;
       }
-      if (query.internal) {
+      if (query.type === 'internal') {
         continue;
       }
 
@@ -277,6 +277,7 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
         this._cvr.queries[id] ??
         ({
           id,
+          type: 'client',
           ast,
           clientState: {},
         } satisfies ClientQueryRecord);
@@ -577,7 +578,7 @@ export class CVRQueryDrivenUpdater extends CVRUpdater {
     if (query.transformationHash !== transformationHash) {
       const transformationVersion = this._ensureNewVersion();
 
-      if (!query.internal && query.patchVersion === undefined) {
+      if (query.type !== 'internal' && query.patchVersion === undefined) {
         // client query: desired -> gotten
         query.patchVersion = transformationVersion;
         gotQueryPatch = {
@@ -877,7 +878,7 @@ export function getInactiveQueries(cvr: CVR): {
     }
   > = new Map();
   for (const [queryID, query] of Object.entries(cvr.queries)) {
-    if (query.internal) {
+    if (query.type === 'internal') {
       continue;
     }
     for (const clientState of Object.values(query.clientState)) {

--- a/packages/zero-cache/src/services/view-syncer/schema/types.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/types.ts
@@ -161,7 +161,7 @@ export const baseQueryRecordSchema = v.object({
  * size-based quota logic for client-requested queries.
  */
 export const internalQueryRecordSchema = baseQueryRecordSchema.extend({
-  internal: v.literal(true),
+  type: v.literal('internal'),
 });
 
 export type InternalQueryRecord = v.Infer<typeof internalQueryRecordSchema>;
@@ -189,7 +189,7 @@ const clientStateSchema = v.object({
 });
 
 export const clientQueryRecordSchema = baseQueryRecordSchema.extend({
-  internal: v.literal(false).optional(),
+  type: v.literal('client'),
 
   /**
    * The client state for this query, which includes the inactivatedAt, ttl and

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -784,6 +784,7 @@ describe('view-syncer/service', () => {
       queries: {
         'query-hash1': {
           ast: ISSUES_QUERY,
+          type: 'client',
           clientState: {foo: {version: {stateVersion: '00', minorVersion: 1}}},
           id: 'query-hash1',
         },
@@ -841,11 +842,12 @@ describe('view-syncer/service', () => {
       queries: {
         'lmids': {
           ast: EXPECTED_LMIDS_AST,
-          internal: true,
+          type: 'internal',
           id: 'lmids',
         },
         'query-hash1': {
           ast: ISSUES_QUERY,
+          type: 'client',
           clientState: {
             foo: {
               inactivatedAt,
@@ -857,6 +859,7 @@ describe('view-syncer/service', () => {
         },
         'query-hash2': {
           ast: USERS_QUERY,
+          type: 'client',
           clientState: {
             foo: {
               inactivatedAt: undefined,

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -769,7 +769,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     for (const [hash, query] of gotQueries) {
       const {ast, transformationHash} = query;
       if (
-        !query.internal &&
+        query.type !== 'internal' &&
         Object.values(query.clientState).every(
           ({inactivatedAt}) => inactivatedAt !== undefined,
         )
@@ -785,7 +785,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
             tables: {},
           },
           this.#authData,
-          query.internal,
+          query.type === 'internal',
         );
       if (newTransformationHash !== transformationHash) {
         continue; // Query results may have changed.
@@ -856,7 +856,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
             tables: {},
           },
           this.#authData,
-          q.internal,
+          q.type === 'internal',
         );
         const ids = hashToIDs.get(transformationHash);
         if (ids) {
@@ -1326,7 +1326,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         const {hash} = inactiveQuery;
         const q = cvr.queries[hash];
         assert(q, 'query not found in CVR');
-        assert(!q.internal, 'internal queries should not be evicted');
+        assert(q.type !== 'internal', 'internal queries should not be evicted');
 
         const rowCountBeforeCurrentEviction = this.#cvrStore.rowCount;
 
@@ -1532,11 +1532,9 @@ export function pickToken(
 
 function expired(
   now: number,
-  q:
-    | Pick<InternalQueryRecord, 'internal'>
-    | Pick<ClientQueryRecord, 'internal' | 'clientState'>,
+  q: InternalQueryRecord | ClientQueryRecord,
 ): boolean {
-  if (q.internal) {
+  if (q.type === 'internal') {
     return false;
   }
   const {clientState} = q;


### PR DESCRIPTION
We'll support both custom queries and legacy queries for some time. This means the query structure has three types:
1. internal
2. client
3. custom

change from 
```ts
internal: boolean
``` 
to
```ts
type: 'internal' | 'client' | /*coming soon: */'custom'
```
