### PR TITLE
chore(zero): remove `ast` from downstream query patch messages [cust-queries]

### DIFF
--- a/packages/zero-cache/src/integration/integration.pg-test.ts
+++ b/packages/zero-cache/src/integration/integration.pg-test.ts
@@ -634,7 +634,7 @@ describe('integration', {timeout: 30000}, () => {
         {
           pokeID: '00:01',
           desiredQueriesPatches: {
-            def: [{op: 'put', hash: 'query-hash1', ast: FOO_QUERY}],
+            def: [{op: 'put', hash: 'query-hash1'}],
           },
         },
       ]);
@@ -652,7 +652,7 @@ describe('integration', {timeout: 30000}, () => {
         'pokePart',
         {
           pokeID: contentPokeID,
-          gotQueriesPatch: [{op: 'put', hash: 'query-hash1', ast: FOO_QUERY}],
+          gotQueriesPatch: [{op: 'put', hash: 'query-hash1'}],
           rowsPatch: [
             {
               op: 'put',
@@ -909,7 +909,7 @@ describe('integration', {timeout: 30000}, () => {
         {
           pokeID: WATERMARK_REGEX,
           desiredQueriesPatches: {
-            def: [{op: 'put', hash: 'query-hash2', ast: NOPK_QUERY}],
+            def: [{op: 'put', hash: 'query-hash2'}],
           },
         },
       ]);

--- a/packages/zero-cache/src/services/view-syncer/client-handler.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.test.ts
@@ -191,7 +191,6 @@ describe('view-syncer/client-handler', () => {
         op: 'put',
         id: 'foohash',
         clientID: 'foo',
-        ast: {table: 'issues'},
       },
     });
     await pokers.addPatch({
@@ -222,7 +221,6 @@ describe('view-syncer/client-handler', () => {
         type: 'query',
         op: 'put',
         id: 'bazhash',
-        ast: {table: 'labels'},
       },
     });
 
@@ -318,9 +316,7 @@ describe('view-syncer/client-handler', () => {
           desiredQueriesPatches: {
             foo: [{op: 'del', hash: 'barhash'}],
           },
-          gotQueriesPatch: [
-            {op: 'put', hash: 'bazhash', ast: {table: 'labels'}},
-          ],
+          gotQueriesPatch: [{op: 'put', hash: 'bazhash'}],
           rowsPatch: [
             {
               op: 'put',
@@ -361,13 +357,11 @@ describe('view-syncer/client-handler', () => {
           },
           desiredQueriesPatches: {
             foo: [
-              {op: 'put', hash: 'foohash', ast: {table: 'issues'}},
+              {op: 'put', hash: 'foohash'},
               {op: 'del', hash: 'barhash'},
             ],
           },
-          gotQueriesPatch: [
-            {op: 'put', hash: 'bazhash', ast: {table: 'labels'}},
-          ],
+          gotQueriesPatch: [{op: 'put', hash: 'bazhash'}],
           rowsPatch: [
             {
               op: 'put',

--- a/packages/zero-cache/src/services/view-syncer/client-handler.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.ts
@@ -7,7 +7,6 @@ import {
 import {promiseVoid} from '../../../../shared/src/resolved-promises.ts';
 import * as v from '../../../../shared/src/valita.ts';
 import type {Writable} from '../../../../shared/src/writable.ts';
-import type {AST} from '../../../../zero-protocol/src/ast.ts';
 import {rowSchema} from '../../../../zero-protocol/src/data.ts';
 import type {DeleteClientsBody} from '../../../../zero-protocol/src/delete-clients.ts';
 import type {Downstream} from '../../../../zero-protocol/src/down.ts';
@@ -53,7 +52,7 @@ export type DeleteRowPatch = {
 };
 
 export type RowPatch = PutRowPatch | DeleteRowPatch;
-export type ConfigPatch = DelQueryPatch | (PutQueryPatch & {ast: AST});
+export type ConfigPatch = DelQueryPatch | PutQueryPatch;
 
 export type Patch = ConfigPatch | RowPatch;
 
@@ -231,8 +230,7 @@ export class ClientHandler {
             ? ((body.desiredQueriesPatches ??= {})[patch.clientID] ??= [])
             : (body.gotQueriesPatch ??= []);
           if (op === 'put') {
-            const {ast} = patch;
-            patches.push({op, hash: patch.id, ast});
+            patches.push({op, hash: patch.id});
           } else {
             patches.push({op, hash: patch.id});
           }

--- a/packages/zero-cache/src/services/view-syncer/cvr-store.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.ts
@@ -10,7 +10,6 @@ import {
   deepEqual,
   type ReadonlyJSONValue,
 } from '../../../../shared/src/json.ts';
-import {must} from '../../../../shared/src/must.ts';
 import {sleep} from '../../../../shared/src/sleep.ts';
 import * as v from '../../../../shared/src/valita.ts';
 import {astSchema} from '../../../../zero-protocol/src/ast.ts';
@@ -594,14 +593,12 @@ export class CVRStore {
         ]),
       );
 
-      const ast = (id: string) => must(upToCVR.queries[id]).ast;
-
       const patches: PatchToVersion[] = [];
       for (const row of queryRows) {
         const {queryHash: id} = row;
         const patch: Patch = row.deleted
           ? {type: 'query', op: 'del', id}
-          : {type: 'query', op: 'put', id, ast: ast(id)};
+          : {type: 'query', op: 'put', id};
         const v = row.patchVersion;
         assert(v);
         patches.push({patch, toVersion: versionFromString(v)});
@@ -610,7 +607,7 @@ export class CVRStore {
         const {clientID, queryHash: id} = row;
         const patch: Patch = row.deleted
           ? {type: 'query', op: 'del', id, clientID}
-          : {type: 'query', op: 'put', id, clientID, ast: ast(id)};
+          : {type: 'query', op: 'put', id, clientID};
         patches.push({patch, toVersion: versionFromString(row.patchVersion)});
       }
 

--- a/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
@@ -834,39 +834,33 @@ describe('view-syncer/cvr', () => {
         {hash: 'threeHash', ast: {table: 'comments'}, ttl: undefined},
       ]),
     ).toMatchInlineSnapshot(`
-        [
-          {
-            "patch": {
-              "ast": {
-                "table": "users",
-              },
-              "clientID": "fooClient",
-              "id": "fourHash",
-              "op": "put",
-              "type": "query",
-            },
-            "toVersion": {
-              "minorVersion": 1,
-              "stateVersion": "1aa",
-            },
+      [
+        {
+          "patch": {
+            "clientID": "fooClient",
+            "id": "fourHash",
+            "op": "put",
+            "type": "query",
           },
-          {
-            "patch": {
-              "ast": {
-                "table": "comments",
-              },
-              "clientID": "fooClient",
-              "id": "threeHash",
-              "op": "put",
-              "type": "query",
-            },
-            "toVersion": {
-              "minorVersion": 1,
-              "stateVersion": "1aa",
-            },
+          "toVersion": {
+            "minorVersion": 1,
+            "stateVersion": "1aa",
           },
-        ]
-      `);
+        },
+        {
+          "patch": {
+            "clientID": "fooClient",
+            "id": "threeHash",
+            "op": "put",
+            "type": "query",
+          },
+          "toVersion": {
+            "minorVersion": 1,
+            "stateVersion": "1aa",
+          },
+        },
+      ]
+    `);
 
     // This adds a new barClient with desired queries.
     expect(
@@ -878,9 +872,6 @@ describe('view-syncer/cvr', () => {
       [
         {
           "patch": {
-            "ast": {
-              "table": "issues",
-            },
             "clientID": "barClient",
             "id": "oneHash",
             "op": "put",
@@ -893,9 +884,6 @@ describe('view-syncer/cvr', () => {
         },
         {
           "patch": {
-            "ast": {
-              "table": "comments",
-            },
             "clientID": "barClient",
             "id": "threeHash",
             "op": "put",
@@ -1239,9 +1227,6 @@ describe('view-syncer/cvr', () => {
       [
         {
           "patch": {
-            "ast": {
-              "table": "issues",
-            },
             "clientID": "fooClient",
             "id": "oneHash",
             "op": "put",
@@ -1525,9 +1510,6 @@ describe('view-syncer/cvr', () => {
       [
         {
           "patch": {
-            "ast": {
-              "table": "issues",
-            },
             "id": "oneHash",
             "op": "put",
             "type": "query",
@@ -1667,9 +1649,6 @@ describe('view-syncer/cvr', () => {
         },
         {
           "patch": {
-            "ast": {
-              "table": "issues",
-            },
             "clientID": "fooClient",
             "id": "oneHash",
             "op": "put",
@@ -2110,9 +2089,6 @@ describe('view-syncer/cvr', () => {
         },
         {
           "patch": {
-            "ast": {
-              "table": "issues",
-            },
             "id": "oneHash",
             "op": "put",
             "type": "query",
@@ -2124,9 +2100,6 @@ describe('view-syncer/cvr', () => {
         },
         {
           "patch": {
-            "ast": {
-              "table": "issues",
-            },
             "clientID": "fooClient",
             "id": "oneHash",
             "op": "put",
@@ -2687,9 +2660,6 @@ describe('view-syncer/cvr', () => {
         },
         {
           "patch": {
-            "ast": {
-              "table": "issues",
-            },
             "id": "oneHash",
             "op": "put",
             "type": "query",
@@ -2701,9 +2671,6 @@ describe('view-syncer/cvr', () => {
         },
         {
           "patch": {
-            "ast": {
-              "table": "issues",
-            },
             "id": "twoHash",
             "op": "put",
             "type": "query",
@@ -2715,9 +2682,6 @@ describe('view-syncer/cvr', () => {
         },
         {
           "patch": {
-            "ast": {
-              "table": "issues",
-            },
             "clientID": "fooClient",
             "id": "oneHash",
             "op": "put",
@@ -2730,9 +2694,6 @@ describe('view-syncer/cvr', () => {
         },
         {
           "patch": {
-            "ast": {
-              "table": "issues",
-            },
             "clientID": "fooClient",
             "id": "twoHash",
             "op": "put",
@@ -3671,9 +3632,6 @@ describe('view-syncer/cvr', () => {
         },
         {
           "patch": {
-            "ast": {
-              "table": "issues",
-            },
             "id": "oneHash",
             "op": "put",
             "type": "query",
@@ -3685,9 +3643,6 @@ describe('view-syncer/cvr', () => {
         },
         {
           "patch": {
-            "ast": {
-              "table": "issues",
-            },
             "id": "twoHash",
             "op": "put",
             "type": "query",
@@ -3699,9 +3654,6 @@ describe('view-syncer/cvr', () => {
         },
         {
           "patch": {
-            "ast": {
-              "table": "issues",
-            },
             "clientID": "fooClient",
             "id": "oneHash",
             "op": "put",
@@ -3714,9 +3666,6 @@ describe('view-syncer/cvr', () => {
         },
         {
           "patch": {
-            "ast": {
-              "table": "issues",
-            },
             "clientID": "fooClient",
             "id": "twoHash",
             "op": "put",
@@ -5675,9 +5624,6 @@ describe('view-syncer/cvr', () => {
         [
           {
             "patch": {
-              "ast": {
-                "table": "issues",
-              },
               "clientID": "fooClient",
               "id": "oneHash",
               "op": "put",

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -293,7 +293,7 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
       this._cvr.queries[id] = query;
       patches.push({
         toVersion: newVersion,
-        patch: {type: 'query', op: 'put', id, ast, clientID},
+        patch: {type: 'query', op: 'put', id, clientID},
       });
 
       this._cvrStore.putQuery(query);
@@ -585,7 +585,6 @@ export class CVRQueryDrivenUpdater extends CVRUpdater {
           type: 'query',
           op: 'put',
           id: query.id,
-          ast: query.ast,
         };
       }
 

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -23,7 +23,7 @@ import type {
   PokeStartBody,
 } from '../../../../zero-protocol/src/poke.ts';
 import {PROTOCOL_VERSION} from '../../../../zero-protocol/src/protocol-version.ts';
-import type {QueriesPatch} from '../../../../zero-protocol/src/queries-patch.ts';
+import type {UpQueriesPatch} from '../../../../zero-protocol/src/queries-patch.ts';
 import {relationships} from '../../../../zero-schema/src/builder/relationship-builder.ts';
 import {
   clientSchemaFrom,
@@ -574,7 +574,7 @@ async function setup(permissions: PermissionsConfig | undefined) {
 
   function connectWithQueueAndSource(
     ctx: SyncContext,
-    desiredQueriesPatch: QueriesPatch,
+    desiredQueriesPatch: UpQueriesPatch,
     clientSchema: ClientSchema = defaultClientSchema,
   ): {queue: Queue<Downstream>; source: Source<Downstream>} {
     const source = vs.initConnection(ctx, [
@@ -598,7 +598,7 @@ async function setup(permissions: PermissionsConfig | undefined) {
 
   function connect(
     ctx: SyncContext,
-    desiredQueriesPatch: QueriesPatch,
+    desiredQueriesPatch: UpQueriesPatch,
     clientSchema?: ClientSchema,
   ) {
     return connectWithQueueAndSource(ctx, desiredQueriesPatch, clientSchema)
@@ -688,12 +688,12 @@ describe('view-syncer/service', () => {
   let replicator: FakeReplicator;
   let connect: (
     ctx: SyncContext,
-    desiredQueriesPatch: QueriesPatch,
+    desiredQueriesPatch: UpQueriesPatch,
     clientSchema?: ClientSchema,
   ) => Queue<Downstream>;
   let connectWithQueueAndSource: (
     ctx: SyncContext,
-    desiredQueriesPatch: QueriesPatch,
+    desiredQueriesPatch: UpQueriesPatch,
     clientSchema?: ClientSchema,
   ) => {
     queue: Queue<Downstream>;
@@ -893,32 +893,6 @@ describe('view-syncer/service', () => {
             "desiredQueriesPatches": {
               "foo": [
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "issues",
-                    "where": {
-                      "left": {
-                        "name": "id",
-                        "type": "column",
-                      },
-                      "op": "IN",
-                      "right": {
-                        "type": "literal",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                      "type": "simple",
-                    },
-                  },
                   "hash": "query-hash1",
                   "op": "put",
                 },
@@ -956,32 +930,6 @@ describe('view-syncer/service', () => {
           {
             "gotQueriesPatch": [
               {
-                "ast": {
-                  "orderBy": [
-                    [
-                      "id",
-                      "asc",
-                    ],
-                  ],
-                  "table": "issues",
-                  "where": {
-                    "left": {
-                      "name": "id",
-                      "type": "column",
-                    },
-                    "op": "IN",
-                    "right": {
-                      "type": "literal",
-                      "value": [
-                        "1",
-                        "2",
-                        "3",
-                        "4",
-                      ],
-                    },
-                    "type": "simple",
-                  },
-                },
                 "hash": "query-hash1",
                 "op": "put",
               },
@@ -1538,75 +1486,14 @@ describe('view-syncer/service', () => {
             "desiredQueriesPatches": {
               "foo": [
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "issues",
-                    "where": {
-                      "left": {
-                        "name": "id",
-                        "type": "column",
-                      },
-                      "op": "IN",
-                      "right": {
-                        "type": "literal",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                      "type": "simple",
-                    },
-                  },
                   "hash": "query-hash1",
                   "op": "put",
                 },
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "issues",
-                    "where": {
-                      "left": {
-                        "name": "id",
-                        "type": "column",
-                      },
-                      "op": "IN",
-                      "right": {
-                        "type": "literal",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                      "type": "simple",
-                    },
-                  },
                   "hash": "query-hash1.1",
                   "op": "put",
                 },
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "issues",
-                  },
                   "hash": "query-hash2",
                   "op": "put",
                 },
@@ -1644,75 +1531,14 @@ describe('view-syncer/service', () => {
           {
             "gotQueriesPatch": [
               {
-                "ast": {
-                  "orderBy": [
-                    [
-                      "id",
-                      "asc",
-                    ],
-                  ],
-                  "table": "issues",
-                  "where": {
-                    "left": {
-                      "name": "id",
-                      "type": "column",
-                    },
-                    "op": "IN",
-                    "right": {
-                      "type": "literal",
-                      "value": [
-                        "1",
-                        "2",
-                        "3",
-                        "4",
-                      ],
-                    },
-                    "type": "simple",
-                  },
-                },
                 "hash": "query-hash1",
                 "op": "put",
               },
               {
-                "ast": {
-                  "orderBy": [
-                    [
-                      "id",
-                      "asc",
-                    ],
-                  ],
-                  "table": "issues",
-                  "where": {
-                    "left": {
-                      "name": "id",
-                      "type": "column",
-                    },
-                    "op": "IN",
-                    "right": {
-                      "type": "literal",
-                      "value": [
-                        "1",
-                        "2",
-                        "3",
-                        "4",
-                      ],
-                    },
-                    "type": "simple",
-                  },
-                },
                 "hash": "query-hash1.1",
                 "op": "put",
               },
               {
-                "ast": {
-                  "orderBy": [
-                    [
-                      "id",
-                      "asc",
-                    ],
-                  ],
-                  "table": "issues",
-                },
                 "hash": "query-hash2",
                 "op": "put",
               },
@@ -1915,32 +1741,6 @@ describe('view-syncer/service', () => {
             "desiredQueriesPatches": {
               "foo": [
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "issues",
-                    "where": {
-                      "left": {
-                        "name": "id",
-                        "type": "column",
-                      },
-                      "op": "IN",
-                      "right": {
-                        "type": "literal",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                      "type": "simple",
-                    },
-                  },
                   "hash": "query-hash1",
                   "op": "put",
                 },
@@ -1992,32 +1792,6 @@ describe('view-syncer/service', () => {
             "desiredQueriesPatches": {
               "foo": [
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "issues",
-                    "where": {
-                      "left": {
-                        "name": "id",
-                        "type": "column",
-                      },
-                      "op": "IN",
-                      "right": {
-                        "type": "literal",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                      "type": "simple",
-                    },
-                  },
                   "hash": "query-hash1",
                   "op": "put",
                 },
@@ -2102,45 +1876,10 @@ describe('view-syncer/service', () => {
             "desiredQueriesPatches": {
               "foo": [
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "issues",
-                    "where": {
-                      "left": {
-                        "name": "id",
-                        "type": "column",
-                      },
-                      "op": "IN",
-                      "right": {
-                        "type": "literal",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                      "type": "simple",
-                    },
-                  },
                   "hash": "query-hash1",
                   "op": "put",
                 },
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "issues",
-                  },
                   "hash": "query-hash2",
                   "op": "put",
                 },
@@ -2495,32 +2234,6 @@ describe('view-syncer/service', () => {
             "desiredQueriesPatches": {
               "foo": [
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "issues",
-                    "where": {
-                      "left": {
-                        "name": "id",
-                        "type": "column",
-                      },
-                      "op": "IN",
-                      "right": {
-                        "type": "literal",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                      "type": "simple",
-                    },
-                  },
                   "hash": "query-hash1",
                   "op": "put",
                 },
@@ -2561,32 +2274,6 @@ describe('view-syncer/service', () => {
             "desiredQueriesPatches": {
               "bar": [
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "issues",
-                    "where": {
-                      "left": {
-                        "name": "id",
-                        "type": "column",
-                      },
-                      "op": "IN",
-                      "right": {
-                        "type": "literal",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                      "type": "simple",
-                    },
-                  },
                   "hash": "query-hash1",
                   "op": "put",
                 },
@@ -2733,32 +2420,6 @@ describe('view-syncer/service', () => {
             "desiredQueriesPatches": {
               "foo": [
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "issues",
-                    "where": {
-                      "left": {
-                        "name": "id",
-                        "type": "column",
-                      },
-                      "op": "IN",
-                      "right": {
-                        "type": "literal",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                      "type": "simple",
-                    },
-                  },
                   "hash": "query-hash1",
                   "op": "put",
                 },
@@ -2898,32 +2559,6 @@ describe('view-syncer/service', () => {
             "desiredQueriesPatches": {
               "foo": [
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "issues",
-                    "where": {
-                      "left": {
-                        "name": "id",
-                        "type": "column",
-                      },
-                      "op": "IN",
-                      "right": {
-                        "type": "literal",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                      "type": "simple",
-                    },
-                  },
                   "hash": "query-hash1",
                   "op": "put",
                 },
@@ -3082,32 +2717,6 @@ describe('view-syncer/service', () => {
             "desiredQueriesPatches": {
               "foo": [
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "issues",
-                    "where": {
-                      "left": {
-                        "name": "id",
-                        "type": "column",
-                      },
-                      "op": "IN",
-                      "right": {
-                        "type": "literal",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                      "type": "simple",
-                    },
-                  },
                   "hash": "query-hash1",
                   "op": "put",
                 },
@@ -3210,32 +2819,6 @@ describe('view-syncer/service', () => {
             "desiredQueriesPatches": {
               "bar": [
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "issues",
-                    "where": {
-                      "left": {
-                        "name": "id",
-                        "type": "column",
-                      },
-                      "op": "IN",
-                      "right": {
-                        "type": "literal",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                      "type": "simple",
-                    },
-                  },
                   "hash": "query-hash1",
                   "op": "put",
                 },
@@ -3292,32 +2875,6 @@ describe('view-syncer/service', () => {
             "desiredQueriesPatches": {
               "bar": [
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "issues",
-                    "where": {
-                      "left": {
-                        "name": "id",
-                        "type": "column",
-                      },
-                      "op": "IN",
-                      "right": {
-                        "type": "literal",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                      "type": "simple",
-                    },
-                  },
                   "hash": "query-hash1",
                   "op": "put",
                 },
@@ -3391,64 +2948,12 @@ describe('view-syncer/service', () => {
             "desiredQueriesPatches": {
               "bar": [
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "issues",
-                    "where": {
-                      "left": {
-                        "name": "id",
-                        "type": "column",
-                      },
-                      "op": "IN",
-                      "right": {
-                        "type": "literal",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                      "type": "simple",
-                    },
-                  },
                   "hash": "query-hash1",
                   "op": "put",
                 },
               ],
               "foo": [
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "issues",
-                    "where": {
-                      "left": {
-                        "name": "id",
-                        "type": "column",
-                      },
-                      "op": "IN",
-                      "right": {
-                        "type": "literal",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                      "type": "simple",
-                    },
-                  },
                   "hash": "query-hash1",
                   "op": "put",
                 },
@@ -3456,32 +2961,6 @@ describe('view-syncer/service', () => {
             },
             "gotQueriesPatch": [
               {
-                "ast": {
-                  "orderBy": [
-                    [
-                      "id",
-                      "asc",
-                    ],
-                  ],
-                  "table": "issues",
-                  "where": {
-                    "left": {
-                      "name": "id",
-                      "type": "column",
-                    },
-                    "op": "IN",
-                    "right": {
-                      "type": "literal",
-                      "value": [
-                        "1",
-                        "2",
-                        "3",
-                        "4",
-                      ],
-                    },
-                    "type": "simple",
-                  },
-                },
                 "hash": "query-hash1",
                 "op": "put",
               },
@@ -3618,32 +3097,6 @@ describe('view-syncer/service', () => {
             "desiredQueriesPatches": {
               "foo": [
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "issues",
-                    "where": {
-                      "left": {
-                        "name": "id",
-                        "type": "column",
-                      },
-                      "op": "IN",
-                      "right": {
-                        "type": "literal",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                      "type": "simple",
-                    },
-                  },
                   "hash": "query-hash1",
                   "op": "put",
                 },
@@ -3651,32 +3104,6 @@ describe('view-syncer/service', () => {
             },
             "gotQueriesPatch": [
               {
-                "ast": {
-                  "orderBy": [
-                    [
-                      "id",
-                      "asc",
-                    ],
-                  ],
-                  "table": "issues",
-                  "where": {
-                    "left": {
-                      "name": "id",
-                      "type": "column",
-                    },
-                    "op": "IN",
-                    "right": {
-                      "type": "literal",
-                      "value": [
-                        "1",
-                        "2",
-                        "3",
-                        "4",
-                      ],
-                    },
-                    "type": "simple",
-                  },
-                },
                 "hash": "query-hash1",
                 "op": "put",
               },
@@ -4155,32 +3582,6 @@ describe('view-syncer/service', () => {
             "desiredQueriesPatches": {
               "foo": [
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "issues",
-                    "where": {
-                      "left": {
-                        "name": "id",
-                        "type": "column",
-                      },
-                      "op": "IN",
-                      "right": {
-                        "type": "literal",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                      "type": "simple",
-                    },
-                  },
                   "hash": "query-hash1",
                   "op": "put",
                 },
@@ -4196,32 +3597,6 @@ describe('view-syncer/service', () => {
           {
             "gotQueriesPatch": [
               {
-                "ast": {
-                  "orderBy": [
-                    [
-                      "id",
-                      "asc",
-                    ],
-                  ],
-                  "table": "issues",
-                  "where": {
-                    "left": {
-                      "name": "id",
-                      "type": "column",
-                    },
-                    "op": "IN",
-                    "right": {
-                      "type": "literal",
-                      "value": [
-                        "1",
-                        "2",
-                        "3",
-                        "4",
-                      ],
-                    },
-                    "type": "simple",
-                  },
-                },
                 "hash": "query-hash1",
                 "op": "put",
               },
@@ -4374,32 +3749,6 @@ describe('view-syncer/service', () => {
             "desiredQueriesPatches": {
               "foo": [
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "issues",
-                    "where": {
-                      "left": {
-                        "name": "id",
-                        "type": "column",
-                      },
-                      "op": "IN",
-                      "right": {
-                        "type": "literal",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                      "type": "simple",
-                    },
-                  },
                   "hash": "query-hash1",
                   "op": "put",
                 },
@@ -4415,32 +3764,6 @@ describe('view-syncer/service', () => {
           {
             "gotQueriesPatch": [
               {
-                "ast": {
-                  "orderBy": [
-                    [
-                      "id",
-                      "asc",
-                    ],
-                  ],
-                  "table": "issues",
-                  "where": {
-                    "left": {
-                      "name": "id",
-                      "type": "column",
-                    },
-                    "op": "IN",
-                    "right": {
-                      "type": "literal",
-                      "value": [
-                        "1",
-                        "2",
-                        "3",
-                        "4",
-                      ],
-                    },
-                    "type": "simple",
-                  },
-                },
                 "hash": "query-hash1",
                 "op": "put",
               },
@@ -4547,32 +3870,6 @@ describe('view-syncer/service', () => {
             "desiredQueriesPatches": {
               "foo": [
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "issues",
-                    "where": {
-                      "left": {
-                        "name": "id",
-                        "type": "column",
-                      },
-                      "op": "IN",
-                      "right": {
-                        "type": "literal",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                      "type": "simple",
-                    },
-                  },
                   "hash": "query-hash1",
                   "op": "put",
                 },
@@ -4675,32 +3972,6 @@ describe('view-syncer/service', () => {
             "desiredQueriesPatches": {
               "foo": [
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "issues",
-                    "where": {
-                      "left": {
-                        "name": "id",
-                        "type": "column",
-                      },
-                      "op": "IN",
-                      "right": {
-                        "type": "literal",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                      "type": "simple",
-                    },
-                  },
                   "hash": "query-hash1",
                   "op": "put",
                 },
@@ -4716,32 +3987,6 @@ describe('view-syncer/service', () => {
           {
             "gotQueriesPatch": [
               {
-                "ast": {
-                  "orderBy": [
-                    [
-                      "id",
-                      "asc",
-                    ],
-                  ],
-                  "table": "issues",
-                  "where": {
-                    "left": {
-                      "name": "id",
-                      "type": "column",
-                    },
-                    "op": "IN",
-                    "right": {
-                      "type": "literal",
-                      "value": [
-                        "1",
-                        "2",
-                        "3",
-                        "4",
-                      ],
-                    },
-                    "type": "simple",
-                  },
-                },
                 "hash": "query-hash1",
                 "op": "put",
               },
@@ -4819,32 +4064,6 @@ describe('view-syncer/service', () => {
             "desiredQueriesPatches": {
               "foo": [
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "issues",
-                    "where": {
-                      "left": {
-                        "name": "id",
-                        "type": "column",
-                      },
-                      "op": "IN",
-                      "right": {
-                        "type": "literal",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                      "type": "simple",
-                    },
-                  },
                   "hash": "query-hash1",
                   "op": "put",
                 },
@@ -4947,32 +4166,6 @@ describe('view-syncer/service', () => {
             "desiredQueriesPatches": {
               "foo": [
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "issues",
-                    "where": {
-                      "left": {
-                        "name": "id",
-                        "type": "column",
-                      },
-                      "op": "IN",
-                      "right": {
-                        "type": "literal",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                      "type": "simple",
-                    },
-                  },
                   "hash": "query-hash1",
                   "op": "put",
                 },
@@ -4988,32 +4181,6 @@ describe('view-syncer/service', () => {
           {
             "gotQueriesPatch": [
               {
-                "ast": {
-                  "orderBy": [
-                    [
-                      "id",
-                      "asc",
-                    ],
-                  ],
-                  "table": "issues",
-                  "where": {
-                    "left": {
-                      "name": "id",
-                      "type": "column",
-                    },
-                    "op": "IN",
-                    "right": {
-                      "type": "literal",
-                      "value": [
-                        "1",
-                        "2",
-                        "3",
-                        "4",
-                      ],
-                    },
-                    "type": "simple",
-                  },
-                },
                 "hash": "query-hash1",
                 "op": "put",
               },
@@ -5179,32 +4346,6 @@ describe('view-syncer/service', () => {
             "desiredQueriesPatches": {
               "foo": [
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "issues",
-                    "where": {
-                      "left": {
-                        "name": "id",
-                        "type": "column",
-                      },
-                      "op": "IN",
-                      "right": {
-                        "type": "literal",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                      "type": "simple",
-                    },
-                  },
                   "hash": "query-hash1",
                   "op": "put",
                 },
@@ -5220,32 +4361,6 @@ describe('view-syncer/service', () => {
           {
             "gotQueriesPatch": [
               {
-                "ast": {
-                  "orderBy": [
-                    [
-                      "id",
-                      "asc",
-                    ],
-                  ],
-                  "table": "issues",
-                  "where": {
-                    "left": {
-                      "name": "id",
-                      "type": "column",
-                    },
-                    "op": "IN",
-                    "right": {
-                      "type": "literal",
-                      "value": [
-                        "1",
-                        "2",
-                        "3",
-                        "4",
-                      ],
-                    },
-                    "type": "simple",
-                  },
-                },
                 "hash": "query-hash1",
                 "op": "put",
               },
@@ -5415,28 +4530,10 @@ describe('view-syncer/service', () => {
             "desiredQueriesPatches": {
               "foo": [
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "users",
-                  },
                   "hash": "user-query-hash",
                   "op": "put",
                 },
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "comments",
-                  },
                   "hash": "comment-query-hash",
                   "op": "put",
                 },
@@ -5452,28 +4549,10 @@ describe('view-syncer/service', () => {
           {
             "gotQueriesPatch": [
               {
-                "ast": {
-                  "orderBy": [
-                    [
-                      "id",
-                      "asc",
-                    ],
-                  ],
-                  "table": "users",
-                },
                 "hash": "user-query-hash",
                 "op": "put",
               },
               {
-                "ast": {
-                  "orderBy": [
-                    [
-                      "id",
-                      "asc",
-                    ],
-                  ],
-                  "table": "comments",
-                },
                 "hash": "comment-query-hash",
                 "op": "put",
               },
@@ -5647,58 +4726,14 @@ describe('view-syncer/service', () => {
             "desiredQueriesPatches": {
               "foo": [
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "users",
-                  },
                   "hash": "user-query-hash",
                   "op": "put",
                 },
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "comments",
-                  },
                   "hash": "comment-query-hash",
                   "op": "put",
                 },
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "issues",
-                    "where": {
-                      "left": {
-                        "name": "id",
-                        "type": "column",
-                      },
-                      "op": "IN",
-                      "right": {
-                        "type": "literal",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                      "type": "simple",
-                    },
-                  },
                   "hash": "issue-query-hash",
                   "op": "put",
                 },
@@ -5714,58 +4749,14 @@ describe('view-syncer/service', () => {
           {
             "gotQueriesPatch": [
               {
-                "ast": {
-                  "orderBy": [
-                    [
-                      "id",
-                      "asc",
-                    ],
-                  ],
-                  "table": "users",
-                },
                 "hash": "user-query-hash",
                 "op": "put",
               },
               {
-                "ast": {
-                  "orderBy": [
-                    [
-                      "id",
-                      "asc",
-                    ],
-                  ],
-                  "table": "comments",
-                },
                 "hash": "comment-query-hash",
                 "op": "put",
               },
               {
-                "ast": {
-                  "orderBy": [
-                    [
-                      "id",
-                      "asc",
-                    ],
-                  ],
-                  "table": "issues",
-                  "where": {
-                    "left": {
-                      "name": "id",
-                      "type": "column",
-                    },
-                    "op": "IN",
-                    "right": {
-                      "type": "literal",
-                      "value": [
-                        "1",
-                        "2",
-                        "3",
-                        "4",
-                      ],
-                    },
-                    "type": "simple",
-                  },
-                },
                 "hash": "issue-query-hash",
                 "op": "put",
               },
@@ -6042,58 +5033,14 @@ describe('view-syncer/service', () => {
             "desiredQueriesPatches": {
               "foo": [
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "users",
-                  },
                   "hash": "user-query-hash",
                   "op": "put",
                 },
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "comments",
-                  },
                   "hash": "comment-query-hash",
                   "op": "put",
                 },
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "issues",
-                    "where": {
-                      "left": {
-                        "name": "id",
-                        "type": "column",
-                      },
-                      "op": "IN",
-                      "right": {
-                        "type": "literal",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                      "type": "simple",
-                    },
-                  },
                   "hash": "issue-query-hash",
                   "op": "put",
                 },
@@ -6109,58 +5056,14 @@ describe('view-syncer/service', () => {
           {
             "gotQueriesPatch": [
               {
-                "ast": {
-                  "orderBy": [
-                    [
-                      "id",
-                      "asc",
-                    ],
-                  ],
-                  "table": "users",
-                },
                 "hash": "user-query-hash",
                 "op": "put",
               },
               {
-                "ast": {
-                  "orderBy": [
-                    [
-                      "id",
-                      "asc",
-                    ],
-                  ],
-                  "table": "comments",
-                },
                 "hash": "comment-query-hash",
                 "op": "put",
               },
               {
-                "ast": {
-                  "orderBy": [
-                    [
-                      "id",
-                      "asc",
-                    ],
-                  ],
-                  "table": "issues",
-                  "where": {
-                    "left": {
-                      "name": "id",
-                      "type": "column",
-                    },
-                    "op": "IN",
-                    "right": {
-                      "type": "literal",
-                      "value": [
-                        "1",
-                        "2",
-                        "3",
-                        "4",
-                      ],
-                    },
-                    "type": "simple",
-                  },
-                },
                 "hash": "issue-query-hash",
                 "op": "put",
               },
@@ -6391,28 +5294,10 @@ describe('view-syncer/service', () => {
             "desiredQueriesPatches": {
               "foo": [
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "users",
-                  },
                   "hash": "user-query-hash",
                   "op": "put",
                 },
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "comments",
-                  },
                   "hash": "comment-query-hash",
                   "op": "put",
                 },
@@ -6428,28 +5313,10 @@ describe('view-syncer/service', () => {
           {
             "gotQueriesPatch": [
               {
-                "ast": {
-                  "orderBy": [
-                    [
-                      "id",
-                      "asc",
-                    ],
-                  ],
-                  "table": "users",
-                },
                 "hash": "user-query-hash",
                 "op": "put",
               },
               {
-                "ast": {
-                  "orderBy": [
-                    [
-                      "id",
-                      "asc",
-                    ],
-                  ],
-                  "table": "comments",
-                },
                 "hash": "comment-query-hash",
                 "op": "put",
               },
@@ -6641,41 +5508,14 @@ describe('view-syncer/service', () => {
             "desiredQueriesPatches": {
               "foo": [
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "users",
-                  },
                   "hash": "user-query-hash",
                   "op": "put",
                 },
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "comments",
-                  },
                   "hash": "comment-query-hash",
                   "op": "put",
                 },
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "issues",
-                  },
                   "hash": "issue-query-hash",
                   "op": "put",
                 },
@@ -6691,41 +5531,14 @@ describe('view-syncer/service', () => {
           {
             "gotQueriesPatch": [
               {
-                "ast": {
-                  "orderBy": [
-                    [
-                      "id",
-                      "asc",
-                    ],
-                  ],
-                  "table": "users",
-                },
                 "hash": "user-query-hash",
                 "op": "put",
               },
               {
-                "ast": {
-                  "orderBy": [
-                    [
-                      "id",
-                      "asc",
-                    ],
-                  ],
-                  "table": "comments",
-                },
                 "hash": "comment-query-hash",
                 "op": "put",
               },
               {
-                "ast": {
-                  "orderBy": [
-                    [
-                      "id",
-                      "asc",
-                    ],
-                  ],
-                  "table": "issues",
-                },
                 "hash": "issue-query-hash",
                 "op": "put",
               },
@@ -7149,15 +5962,6 @@ describe('view-syncer/service', () => {
               "desiredQueriesPatches": {
                 "foo": [
                   {
-                    "ast": {
-                      "orderBy": [
-                        [
-                          "id",
-                          "asc",
-                        ],
-                      ],
-                      "table": "issues",
-                    },
                     "hash": "query-hash1",
                     "op": "put",
                   },
@@ -7185,15 +5989,6 @@ describe('view-syncer/service', () => {
           {
             "gotQueriesPatch": [
               {
-                "ast": {
-                  "orderBy": [
-                    [
-                      "id",
-                      "asc",
-                    ],
-                  ],
-                  "table": "issues",
-                },
                 "hash": "query-hash1",
                 "op": "put",
               },
@@ -7452,15 +6247,6 @@ describe('view-syncer/service', () => {
               "desiredQueriesPatches": {
                 "bar": [
                   {
-                    "ast": {
-                      "orderBy": [
-                        [
-                          "id",
-                          "asc",
-                        ],
-                      ],
-                      "table": "issues",
-                    },
                     "hash": "query-hash1",
                     "op": "put",
                   },
@@ -7474,15 +6260,6 @@ describe('view-syncer/service', () => {
               },
               "gotQueriesPatch": [
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "issues",
-                  },
                   "hash": "query-hash1",
                   "op": "put",
                 },
@@ -7610,15 +6387,6 @@ describe('view-syncer/service', () => {
               "desiredQueriesPatches": {
                 "bar": [
                   {
-                    "ast": {
-                      "orderBy": [
-                        [
-                          "id",
-                          "asc",
-                        ],
-                      ],
-                      "table": "issues",
-                    },
                     "hash": "query-hash1",
                     "op": "put",
                   },
@@ -7644,7 +6412,7 @@ describe('permissions', () => {
   let stateChanges: Subscription<ReplicaState>;
   let connect: (
     ctx: SyncContext,
-    desiredQueriesPatch: QueriesPatch,
+    desiredQueriesPatch: UpQueriesPatch,
   ) => Queue<Downstream>;
   let nextPoke: (client: Queue<Downstream>) => Promise<Downstream[]>;
   let replicaDbFile: DbFile;
@@ -7712,32 +6480,6 @@ describe('permissions', () => {
           {
             "gotQueriesPatch": [
               {
-                "ast": {
-                  "orderBy": [
-                    [
-                      "id",
-                      "asc",
-                    ],
-                  ],
-                  "table": "issues",
-                  "where": {
-                    "left": {
-                      "name": "id",
-                      "type": "column",
-                    },
-                    "op": "IN",
-                    "right": {
-                      "type": "literal",
-                      "value": [
-                        "1",
-                        "2",
-                        "3",
-                        "4",
-                      ],
-                    },
-                    "type": "simple",
-                  },
-                },
                 "hash": "query-hash1",
                 "op": "put",
               },
@@ -7791,64 +6533,12 @@ describe('permissions', () => {
             "desiredQueriesPatches": {
               "bar": [
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "issues",
-                    "where": {
-                      "left": {
-                        "name": "id",
-                        "type": "column",
-                      },
-                      "op": "IN",
-                      "right": {
-                        "type": "literal",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                      "type": "simple",
-                    },
-                  },
                   "hash": "query-hash1",
                   "op": "put",
                 },
               ],
               "foo": [
                 {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "issues",
-                    "where": {
-                      "left": {
-                        "name": "id",
-                        "type": "column",
-                      },
-                      "op": "IN",
-                      "right": {
-                        "type": "literal",
-                        "value": [
-                          "1",
-                          "2",
-                          "3",
-                          "4",
-                        ],
-                      },
-                      "type": "simple",
-                    },
-                  },
                   "hash": "query-hash1",
                   "op": "put",
                 },
@@ -7856,32 +6546,6 @@ describe('permissions', () => {
             },
             "gotQueriesPatch": [
               {
-                "ast": {
-                  "orderBy": [
-                    [
-                      "id",
-                      "asc",
-                    ],
-                  ],
-                  "table": "issues",
-                  "where": {
-                    "left": {
-                      "name": "id",
-                      "type": "column",
-                    },
-                    "op": "IN",
-                    "right": {
-                      "type": "literal",
-                      "value": [
-                        "1",
-                        "2",
-                        "3",
-                        "4",
-                      ],
-                    },
-                    "type": "simple",
-                  },
-                },
                 "hash": "query-hash1",
                 "op": "put",
               },
@@ -7978,32 +6642,6 @@ describe('permissions', () => {
           {
             "gotQueriesPatch": [
               {
-                "ast": {
-                  "orderBy": [
-                    [
-                      "id",
-                      "asc",
-                    ],
-                  ],
-                  "table": "issues",
-                  "where": {
-                    "left": {
-                      "name": "id",
-                      "type": "column",
-                    },
-                    "op": "IN",
-                    "right": {
-                      "type": "literal",
-                      "value": [
-                        "1",
-                        "2",
-                        "3",
-                        "4",
-                      ],
-                    },
-                    "type": "simple",
-                  },
-                },
                 "hash": "query-hash1",
                 "op": "put",
               },
@@ -8161,15 +6799,6 @@ describe('permissions', () => {
           {
             "gotQueriesPatch": [
               {
-                "ast": {
-                  "orderBy": [
-                    [
-                      "id",
-                      "asc",
-                    ],
-                  ],
-                  "table": "comments",
-                },
                 "hash": "query-hash1",
                 "op": "put",
               },
@@ -8225,15 +6854,6 @@ describe('permissions', () => {
           {
             "gotQueriesPatch": [
               {
-                "ast": {
-                  "orderBy": [
-                    [
-                      "id",
-                      "asc",
-                    ],
-                  ],
-                  "table": "comments",
-                },
                 "hash": "query-hash2",
                 "op": "put",
               },

--- a/packages/zero-client/src/client/query-manager.test.ts
+++ b/packages/zero-client/src/client/query-manager.test.ts
@@ -17,7 +17,7 @@ import type {ReadonlyJSONValue} from '../../../shared/src/json.ts';
 import * as v from '../../../shared/src/valita.ts';
 import type {AST} from '../../../zero-protocol/src/ast.ts';
 import type {ChangeDesiredQueriesMessage} from '../../../zero-protocol/src/change-desired-queries.ts';
-import {putOpSchema} from '../../../zero-protocol/src/queries-patch.ts';
+import {upPutOpSchema} from '../../../zero-protocol/src/queries-patch.ts';
 import {schema} from '../../../zql/src/query/test/test-schemas.ts';
 import type {TTL} from '../../../zql/src/query/ttl.ts';
 import {toGotQueriesKey} from './keys.ts';
@@ -743,7 +743,7 @@ describe('getQueriesPatch', () => {
       const patch = await queryManager.getQueriesPatch(testReadTransaction);
       expect(testReadTransaction.scanCalls).toEqual([{prefix: 'd/client1/'}]);
       const op = patch.get('1hydj1t7t5yv4');
-      v.assert(op, putOpSchema);
+      v.assert(op, upPutOpSchema);
       return op.ttl;
     }
 

--- a/packages/zero-client/src/client/query-manager.ts
+++ b/packages/zero-client/src/client/query-manager.ts
@@ -9,7 +9,7 @@ import {
   type AST,
 } from '../../../zero-protocol/src/ast.ts';
 import type {ChangeDesiredQueriesMessage} from '../../../zero-protocol/src/change-desired-queries.ts';
-import type {QueriesPatchOp} from '../../../zero-protocol/src/queries-patch.ts';
+import type {UpQueriesPatchOp} from '../../../zero-protocol/src/queries-patch.ts';
 import {
   clientToServer,
   type NameMapper,
@@ -118,14 +118,14 @@ export class QueryManager {
    */
   async getQueriesPatch(
     tx: ReadTransaction,
-    lastPatch?: Map<string, QueriesPatchOp> | undefined,
-  ): Promise<Map<string, QueriesPatchOp>> {
+    lastPatch?: Map<string, UpQueriesPatchOp> | undefined,
+  ): Promise<Map<string, UpQueriesPatchOp>> {
     const existingQueryHashes = new Set<string>();
     const prefix = desiredQueriesPrefixForClient(this.#clientID);
     for await (const key of tx.scan({prefix}).keys()) {
       existingQueryHashes.add(key.substring(prefix.length, key.length));
     }
-    const patch: Map<string, QueriesPatchOp> = new Map();
+    const patch: Map<string, UpQueriesPatchOp> = new Map();
     for (const hash of existingQueryHashes) {
       if (!this.#queries.has(hash)) {
         patch.set(hash, {op: 'del', hash});

--- a/packages/zero-client/src/client/test-utils.ts
+++ b/packages/zero-client/src/client/test-utils.ts
@@ -5,7 +5,6 @@ import type {Store} from '../../../replicache/src/dag/store.ts';
 import {assert} from '../../../shared/src/asserts.ts';
 import type {Enum} from '../../../shared/src/enum.ts';
 import {TestLogSink} from '../../../shared/src/logging-test-utils.ts';
-import {mapAST} from '../../../zero-protocol/src/ast.ts';
 import type {ConnectedMessage} from '../../../zero-protocol/src/connect.ts';
 import type {Downstream} from '../../../zero-protocol/src/down.ts';
 import {ErrorKind} from '../../../zero-protocol/src/error-kind.ts';
@@ -29,8 +28,6 @@ import type {
 } from '../../../zero-protocol/src/push.ts';
 import {upstreamSchema} from '../../../zero-protocol/src/up.ts';
 import type {Schema} from '../../../zero-schema/src/builder/schema-builder.ts';
-import {clientToServer} from '../../../zero-schema/src/name-mapper.ts';
-import {ast} from '../../../zql/src/query/query-impl.ts';
 import type {PullRow, Query} from '../../../zql/src/query/query.ts';
 import * as ConnectionState from './connection-state-enum.ts';
 import type {CustomMutatorDefs} from './custom.ts';
@@ -88,7 +85,6 @@ export class TestZero<
   MD extends CustomMutatorDefs<S> | undefined = undefined,
 > extends Zero<S, MD> {
   pokeIDCounter = 0;
-  readonly #schema: S;
 
   #connectionStateResolvers: Set<{
     state: ConnectionState;
@@ -97,7 +93,6 @@ export class TestZero<
 
   constructor(options: ZeroOptions<S, MD>) {
     super(options);
-    this.#schema = options.schema;
   }
 
   get perdag(): Store {
@@ -270,7 +265,6 @@ export class TestZero<
       gotQueriesPatch: [
         {
           op: 'put',
-          ast: mapAST(ast(q), clientToServer(this.#schema.tables)),
           hash: q.hash(),
         },
       ],

--- a/packages/zero-client/src/client/zero-poke-handler.test.ts
+++ b/packages/zero-client/src/client/zero-poke-handler.test.ts
@@ -9,7 +9,6 @@ import {
   test,
   vi,
 } from 'vitest';
-import type {AST} from '../../../zero-protocol/src/ast.ts';
 import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import {string, table} from '../../../zero-schema/src/builder/table-builder.ts';
 import {serverToClient} from '../../../zero-schema/src/name-mapper.ts';
@@ -1224,10 +1223,6 @@ test('mergePokes with all optionals defined', () => {
                 {
                   op: 'put',
                   hash: 'h1',
-                  ast: {
-                    table: 'issues',
-                    orderBy: [['issue_id', 'asc']],
-                  },
                 },
               ],
             },
@@ -1235,10 +1230,6 @@ test('mergePokes with all optionals defined', () => {
               {
                 op: 'put',
                 hash: 'h1',
-                ast: {
-                  table: 'issues',
-                  orderBy: [['issue_id', 'asc']],
-                },
               },
             ],
             rowsPatch: [
@@ -1266,10 +1257,6 @@ test('mergePokes with all optionals defined', () => {
                 {
                   op: 'put',
                   hash: 'h2',
-                  ast: {
-                    table: 'labels',
-                    orderBy: [['label_id', 'asc']],
-                  },
                 },
               ],
             },
@@ -1277,10 +1264,6 @@ test('mergePokes with all optionals defined', () => {
               {
                 op: 'put',
                 hash: 'h2',
-                ast: {
-                  table: 'labels',
-                  orderBy: [['label_id', 'asc']],
-                },
               },
             ],
             rowsPatch: [
@@ -1350,18 +1333,12 @@ test('mergePokes with all optionals defined', () => {
         {
           op: 'put',
           key: 'd/c1/h1',
-          value: {
-            table: 'issue',
-            orderBy: [['id', 'asc']],
-          },
+          value: null,
         },
         {
           op: 'put',
           key: 'g/h1',
-          value: {
-            table: 'issue',
-            orderBy: [['id', 'asc']],
-          },
+          value: null,
         },
         {
           op: 'put',
@@ -1377,18 +1354,12 @@ test('mergePokes with all optionals defined', () => {
         {
           op: 'put',
           key: 'd/c1/h2',
-          value: {
-            table: 'label',
-            orderBy: [['id', 'asc']],
-          },
+          value: null,
         },
         {
           op: 'put',
           key: 'g/h2',
-          value: {
-            table: 'label',
-            orderBy: [['id', 'asc']],
-          },
+          value: null,
         },
         {
           op: 'put',
@@ -1429,10 +1400,6 @@ test('mergePokes sparse', () => {
               {
                 op: 'put',
                 hash: 'h1',
-                ast: {
-                  table: 'issues',
-                  orderBy: [['issue_id', 'asc']],
-                },
               },
             ],
             rowsPatch: [
@@ -1459,10 +1426,6 @@ test('mergePokes sparse', () => {
                 {
                   op: 'put',
                   hash: 'h2',
-                  ast: {
-                    table: 'labels',
-                    orderBy: [['label_id', 'asc']],
-                  },
                 },
               ],
             },
@@ -1515,10 +1478,7 @@ test('mergePokes sparse', () => {
         {
           op: 'put',
           key: 'g/h1',
-          value: {
-            table: 'issue',
-            orderBy: [['id', 'asc']],
-          } satisfies AST,
+          value: null,
         },
         {
           op: 'put',
@@ -1534,10 +1494,7 @@ test('mergePokes sparse', () => {
         {
           op: 'put',
           key: 'd/c1/h2',
-          value: {
-            table: 'label',
-            orderBy: [['id', 'asc']],
-          },
+          value: null,
         },
         {
           op: 'del',

--- a/packages/zero-client/src/client/zero-poke-handler.ts
+++ b/packages/zero-client/src/client/zero-poke-handler.ts
@@ -7,7 +7,6 @@ import type {PatchOperation} from '../../../replicache/src/patch-operation.ts';
 import type {ClientID} from '../../../replicache/src/sync/ids.ts';
 import {getBrowserGlobalMethod} from '../../../shared/src/browser-env.ts';
 import type {JSONValue} from '../../../shared/src/json.ts';
-import {mapAST} from '../../../zero-protocol/src/ast.ts';
 import type {
   PokeEndBody,
   PokePartBody,
@@ -241,10 +240,8 @@ export function mergePokes(
         )) {
           mergedPatch.push(
             ...queriesPatch.map(op =>
-              queryPatchOpToReplicachePatchOp(
-                op,
-                hash => toDesiredQueriesKey(clientID, hash),
-                serverToClient,
+              queryPatchOpToReplicachePatchOp(op, hash =>
+                toDesiredQueriesKey(clientID, hash),
               ),
             ),
           );
@@ -253,11 +250,7 @@ export function mergePokes(
       if (pokePart.gotQueriesPatch) {
         mergedPatch.push(
           ...pokePart.gotQueriesPatch.map(op =>
-            queryPatchOpToReplicachePatchOp(
-              op,
-              toGotQueriesKey,
-              serverToClient,
-            ),
+            queryPatchOpToReplicachePatchOp(op, toGotQueriesKey),
           ),
         );
       }
@@ -283,7 +276,6 @@ export function mergePokes(
 function queryPatchOpToReplicachePatchOp(
   op: QueriesPatchOp,
   toKey: (hash: string) => string,
-  serverToClient: NameMapper,
 ): PatchOperation {
   switch (op.op) {
     case 'clear':
@@ -298,7 +290,7 @@ function queryPatchOpToReplicachePatchOp(
       return {
         op: 'put',
         key: toKey(op.hash),
-        value: mapAST(op.ast, serverToClient),
+        value: null,
       };
   }
 }

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -65,7 +65,7 @@ import type {
   PushMessage,
 } from '../../../zero-protocol/src/push.ts';
 import {CRUD_MUTATION_NAME, mapCRUD} from '../../../zero-protocol/src/push.ts';
-import type {QueriesPatchOp} from '../../../zero-protocol/src/queries-patch.ts';
+import type {UpQueriesPatchOp} from '../../../zero-protocol/src/queries-patch.ts';
 import type {Upstream} from '../../../zero-protocol/src/up.ts';
 import type {NullableVersion} from '../../../zero-protocol/src/version.ts';
 import {nullableVersionSchema} from '../../../zero-protocol/src/version.ts';
@@ -303,7 +303,7 @@ export class Zero<
    * If this is set to `undefined` that means no queries were sent inside the `sec-protocol` header
    * and an `initConnection` message must be sent to the server after receiving the `connected` message.
    */
-  #initConnectionQueries: Map<string, QueriesPatchOp> | undefined;
+  #initConnectionQueries: Map<string, UpQueriesPatchOp> | undefined;
 
   /**
    * We try to send the deleted clients and (client groups) as part of the
@@ -1904,7 +1904,7 @@ export async function createSocket(
 ): Promise<
   [
     WebSocket,
-    Map<string, QueriesPatchOp> | undefined,
+    Map<string, UpQueriesPatchOp> | undefined,
     DeleteClientsBody | undefined,
   ]
 > {
@@ -1943,7 +1943,7 @@ export async function createSocket(
   const queriesPatchP = rep.query(tx => queryManager.getQueriesPatch(tx));
   let deletedClients: DeleteClientsBody | undefined =
     await deleteClientsManager.getDeletedClients();
-  let queriesPatch: Map<string, QueriesPatchOp> | undefined =
+  let queriesPatch: Map<string, UpQueriesPatchOp> | undefined =
     await queriesPatchP;
 
   let secProtocol = encodeSecProtocols(

--- a/packages/zero-protocol/src/ast.test.ts
+++ b/packages/zero-protocol/src/ast.test.ts
@@ -607,5 +607,5 @@ test('protocol version', () => {
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
   expect(hash).toEqual('1c228prd1v53r');
-  expect(PROTOCOL_VERSION).toEqual(16);
+  expect(PROTOCOL_VERSION).toEqual(17);
 });

--- a/packages/zero-protocol/src/change-desired-queries.ts
+++ b/packages/zero-protocol/src/change-desired-queries.ts
@@ -1,8 +1,8 @@
 import * as v from '../../shared/src/valita.ts';
-import {queriesPatchSchema} from './queries-patch.ts';
+import {upQueriesPatchSchema} from './queries-patch.ts';
 
 const changeDesiredQueriesBodySchema = v.object({
-  desiredQueriesPatch: queriesPatchSchema,
+  desiredQueriesPatch: upQueriesPatchSchema,
 });
 
 export const changeDesiredQueriesMessageSchema = v.tuple([

--- a/packages/zero-protocol/src/connect.ts
+++ b/packages/zero-protocol/src/connect.ts
@@ -1,7 +1,7 @@
 import * as v from '../../shared/src/valita.ts';
 import {clientSchemaSchema} from './client-schema.ts';
 import {deleteClientsBodySchema} from './delete-clients.ts';
-import {queriesPatchSchema} from './queries-patch.ts';
+import {upQueriesPatchSchema} from './queries-patch.ts';
 
 /**
  * After opening a websocket the client waits for a `connected` message
@@ -26,7 +26,7 @@ const userPushParamsSchema = v.object({
 });
 
 const initConnectionBodySchema = v.object({
-  desiredQueriesPatch: queriesPatchSchema,
+  desiredQueriesPatch: upQueriesPatchSchema,
   clientSchema: clientSchemaSchema.optional(),
   deleted: deleteClientsBodySchema.optional(),
   userPushParams: userPushParamsSchema.optional(),

--- a/packages/zero-protocol/src/protocol-version.test.ts
+++ b/packages/zero-protocol/src/protocol-version.test.ts
@@ -11,6 +11,6 @@ test('protocol version', () => {
   // If this test fails upstream or downstream schema has changed such that
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
-  expect(hash).toEqual('3yg0w7bfg9f7');
-  expect(PROTOCOL_VERSION).toEqual(16);
+  expect(hash).toEqual('3mo9zwnqe0evw');
+  expect(PROTOCOL_VERSION).toEqual(17);
 });

--- a/packages/zero-protocol/src/protocol-version.ts
+++ b/packages/zero-protocol/src/protocol-version.ts
@@ -22,7 +22,8 @@ import {assert} from '../../shared/src/asserts.ts';
 // -- Version 14 removes 'timestamp' and 'date' types from the ClientSchema ValueType. (0.18)
 // -- Version 15 adds a `userPushParams` field to `initConnection`
 // -- Version 16 adds a new error type (alreadyProcessed) to mutation responses
-export const PROTOCOL_VERSION = 16;
+// -- Version 17 deprecates `AST` in downstream query puts. It was never used anyway.
+export const PROTOCOL_VERSION = 17;
 
 /**
  * The minimum server-supported sync protocol version (i.e. the version

--- a/packages/zero-protocol/src/queries-patch.ts
+++ b/packages/zero-protocol/src/queries-patch.ts
@@ -4,8 +4,14 @@ import {astSchema} from './ast.ts';
 export const putOpSchema = v.object({
   op: v.literal('put'),
   hash: v.string(),
-  ast: astSchema,
+  // Deprecated. The server does not need to poke the AST back down
+  // to the client.
+  ast: astSchema.optional(),
   ttl: v.number().optional(),
+});
+
+export const upPutOpSchema = putOpSchema.extend({
+  ast: astSchema,
 });
 
 const delOpSchema = v.object({
@@ -18,11 +24,15 @@ const clearOpSchema = v.object({
 });
 
 const patchOpSchema = v.union(putOpSchema, delOpSchema, clearOpSchema);
+const upPatchOpSchema = v.union(upPutOpSchema, delOpSchema, clearOpSchema);
 
 export const queriesPatchSchema = v.array(patchOpSchema);
+export const upQueriesPatchSchema = v.array(upPatchOpSchema);
 
 export type QueriesPutOp = v.Infer<typeof putOpSchema>;
 export type QueriesDelOp = v.Infer<typeof delOpSchema>;
 export type QueriesClearOp = v.Infer<typeof clearOpSchema>;
 export type QueriesPatchOp = v.Infer<typeof patchOpSchema>;
+export type UpQueriesPatchOp = v.Infer<typeof upPatchOpSchema>;
 export type QueriesPatch = v.Infer<typeof queriesPatchSchema>;
+export type UpQueriesPatch = v.Infer<typeof upQueriesPatchSchema>;


### PR DESCRIPTION
1. It is extra information that does not need to be sent
2. Custom queries will not send their AST to the client

**edit** -- double check this is safe given we do push some queries back up on reconnect which could have had their AST fields nuked via poke.