### PR TITLE
fix(zero-cache): bump to new litestream with upload fix

### DIFF
--- a/packages/zero/Dockerfile
+++ b/packages/zero/Dockerfile
@@ -1,10 +1,10 @@
 FROM golang:1.23 AS litestream
 
 WORKDIR /src/
-RUN git clone --depth 1 --branch zero@v0.0.4 https://github.com/rocicorp/litestream.git
+RUN git clone --depth 1 --branch zero@v0.0.5 https://github.com/rocicorp/litestream.git
 WORKDIR /src/litestream/
 
-ARG LITESTREAM_VERSION=0.3.13+z0.0.4  # upstream version + zero version
+ARG LITESTREAM_VERSION=0.3.13+z0.0.5  # upstream version + zero version
 
 RUN --mount=type=cache,target=/root/.cache/go-build \
 	--mount=type=cache,target=/go/pkg \


### PR DESCRIPTION
Bump to new litestream version with the fix for large uploads:

https://github.com/rocicorp/litestream/pull/6

User report:

https://discord.com/channels/830183651022471199/1334697671021035590/1373130883489464342