### PR TITLE
chore(zero-cache): CopyRunner substitute for TransactionPool

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/copy-runner.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/copy-runner.pg-test.ts
@@ -1,0 +1,107 @@
+import {nanoid} from 'nanoid/non-secure';
+import {Writable} from 'node:stream';
+import {pipeline} from 'node:stream/promises';
+import {beforeEach, describe, expect, test} from 'vitest';
+import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
+import {READONLY} from '../../../db/mode-enum.ts';
+import {TransactionPool} from '../../../db/transaction-pool.ts';
+import {getConnectionURI, testDBs} from '../../../test/db.ts';
+import {
+  pgClient,
+  type PostgresDB,
+  type PostgresTransaction,
+} from '../../../types/pg.ts';
+import {orTimeout} from '../../../types/timeout.ts';
+import {CopyRunner} from './copy-runner.ts';
+
+describe('copy-runner', () => {
+  const lc = createSilentLogContext();
+  let sql: PostgresDB;
+
+  beforeEach(async ctx => {
+    sql = await testDBs.create(`copy_runner_${ctx.task.name}`);
+    const setup = Array.from({length: NUM_TABLES}, (_, i) =>
+      [
+        // This is a carefully crafted test that hits a bug in Postgres in which
+        // the database stops responding to commands after a certain type/sequence
+        // of COPY streams.
+        //
+        // The following conditions appear to be necessary to trigger the bug:
+        // - Sufficient table data streamed from the COPY (hence the 400 rows and `b` column)
+        // - A randomly ordered primary key column (the `a` column)
+        // - More tables than copy workers, to exercise post-COPY commands (hence the 10 tables).
+        //
+        // A failure manifests as a "Test timed out" error as Postgres becomes unresponsive.
+        `CREATE TABLE t${i} (a TEXT PRIMARY KEY, b TEXT, val INT);`,
+        ...Array.from(
+          {length: 400},
+          (_, r) =>
+            `INSERT INTO t${i} (a, b, val) VALUES ('${nanoid()}', '0000000000000000', ${r});`,
+        ),
+      ].join('\n'),
+    ).join('\n');
+    await sql.unsafe(setup);
+
+    return async () => {
+      await orTimeout(testDBs.drop(sql), 1000);
+    };
+  });
+
+  async function doCopy(tx: PostgresTransaction, i: number) {
+    let bytesReceived = 0;
+    const stream = await tx.unsafe(`COPY t${i} TO STDOUT`);
+    await pipeline(
+      stream,
+      new Writable({
+        write(chunk, _encoding, callback) {
+          bytesReceived += chunk.length;
+          callback();
+        },
+      }),
+    );
+    return bytesReceived;
+  }
+
+  const NUM_TABLES = 10;
+  const NUM_COPIERS = 3;
+
+  test('copy_runner', async () => {
+    const copyRunner = new CopyRunner(
+      lc,
+      () => pgClient(lc, getConnectionURI(sql)),
+      NUM_COPIERS,
+      undefined,
+    );
+
+    const results = await Promise.all(
+      Array.from({length: NUM_TABLES}, (_, i) => i).map(i =>
+        copyRunner.run(tx => doCopy(tx, i)),
+      ),
+    );
+    expect(results).toEqual(Array.from({length: NUM_TABLES}, () => 17090));
+    copyRunner.close();
+  });
+
+  // This is a meta-test to verify that the database setup in
+  // beforeEach() successfully triggers the Postgres hang in the
+  // connection-reusing TransactionPool.
+  test('transaction_pool', async () => {
+    const pool = new TransactionPool(
+      lc,
+      READONLY,
+      undefined,
+      undefined,
+      NUM_COPIERS,
+    );
+    pool.run(sql);
+
+    for (let table = 0; table < NUM_TABLES; table++) {
+      void pool.processReadTask(tx => doCopy(tx, table));
+    }
+    pool.setDone();
+
+    // If this succeeds, then the test setup did not successfully
+    // reproduce the conditions that make Postgres hang.
+    expect(await orTimeout(pool.done(), 2000)).toBe('timed-out');
+  });
+});

--- a/packages/zero-cache/src/services/change-source/pg/copy-runner.ts
+++ b/packages/zero-cache/src/services/change-source/pg/copy-runner.ts
@@ -1,0 +1,132 @@
+import type {LogContext} from '@rocicorp/logger';
+import {resolver, type Resolver} from '@rocicorp/resolver';
+import {Queue} from '../../../../../shared/src/queue.ts';
+import {READONLY} from '../../../db/mode-enum.ts';
+import type {PostgresDB, PostgresTransaction} from '../../../types/pg.ts';
+import {orTimeoutWith} from '../../../types/timeout.ts';
+
+const CONNECTION_REUSE_TIMEOUT = 100;
+const TIMED_OUT = {};
+
+type Task<T> = {
+  copy: (tx: PostgresTransaction, lc: LogContext) => Promise<T>;
+  result: Resolver<T>;
+};
+
+/**
+ * The CopyRunner is designed to run a single `COPY` command within a
+ * READ ONLY transaction, optionally at a specific SNAPSHOT, and reuse
+ * the connection if it is healthy.
+ *
+ * This works around a bug in Postgres in which the database stops
+ * responding to commands after a certain type / sequence of COPY
+ * streams.
+ */
+export class CopyRunner {
+  readonly #lc: LogContext;
+  readonly #connect: () => PostgresDB;
+  readonly #snapshotID: string | undefined;
+  readonly #workQueue = new Queue<Task<unknown> | 'done'>();
+  readonly #numWorkers: number;
+  readonly #pool: {db: PostgresDB; connID: number}[] = [];
+
+  #connID = 0;
+
+  constructor(
+    lc: LogContext,
+    connect: () => PostgresDB,
+    maxActive: number,
+    snapshotID: string | undefined,
+  ) {
+    this.#lc = lc.withContext('component', 'copy-runner');
+    this.#connect = connect;
+    this.#numWorkers = maxActive;
+    this.#snapshotID = snapshotID;
+
+    for (let i = 0; i < this.#numWorkers; i++) {
+      void this.#runWorker();
+    }
+  }
+
+  /**
+   * Runs the given `copy` logic when a connection is available,
+   * ensuring that at most `maxActive` copy commands are running
+   * at a given time.
+   */
+  run<T>(
+    copy: (tx: PostgresTransaction, lc: LogContext) => Promise<T>,
+  ): Promise<T> {
+    const result = resolver<T>();
+    this.#workQueue.enqueue({copy, result: result as Resolver<unknown>});
+    return result.promise;
+  }
+
+  async #runWorker(): Promise<void> {
+    for (;;) {
+      const task = await this.#workQueue.dequeue();
+      if (task === 'done') {
+        break;
+      }
+      // The task is awaited to ensure that only one COPY is running at a time
+      // for each worker. However, errors do not need to be handled in this
+      // loop as they are propagated to the caller of run().
+      await this.#run(task).catch(() => {});
+    }
+  }
+
+  #run(task: Task<unknown>): Promise<unknown> {
+    const {db, connID} = this.#getConnection();
+    const lc = this.#lc.withContext('conn', connID.toString());
+
+    const {copy, result} = task;
+    const txDone = db.begin(READONLY, tx => {
+      if (this.#snapshotID) {
+        void tx.unsafe(`SET TRANSACTION SNAPSHOT '${this.#snapshotID}'`);
+      }
+      return copy(tx, lc).then(result.resolve, result.reject);
+    });
+
+    function closeConnection() {
+      void db.end().catch(e => lc.warn?.(`error closing connection`, e));
+    }
+
+    // If the transaction successfully completes, the `COMMIT` succeeded
+    // and the connection is healthy, so the connection can be reused.
+    // If the transaction does not complete within a timeout, it is considered
+    // hung and the connection is closed.
+    void orTimeoutWith(txDone, CONNECTION_REUSE_TIMEOUT, TIMED_OUT).then(
+      done =>
+        done === TIMED_OUT ? closeConnection() : this.#pool.push({db, connID}),
+      closeConnection,
+    );
+
+    return result.promise;
+  }
+
+  #getConnection(): {db: PostgresDB; connID: number} {
+    const reusable = this.#pool.pop();
+    if (reusable) {
+      this.#lc.debug?.(`reusing connection ${reusable.connID}`);
+      return reusable;
+    }
+    const connID = ++this.#connID;
+    this.#lc.debug?.(`establishing connection ${connID}`);
+    return {db: this.#connect(), connID};
+  }
+
+  close() {
+    for (let i = 0; i < this.#numWorkers; i++) {
+      this.#workQueue.enqueue('done');
+    }
+    this.#pool.forEach(
+      ({db, connID}) =>
+        void db
+          .end()
+          .catch(e =>
+            this.#lc
+              .withContext('conn', connID.toString())
+              .warn?.(`error closing connection`, e),
+          ),
+    );
+  }
+}


### PR DESCRIPTION
CopyRunner is a special-case "drop-in" replacement for TransactionPool specifically intended for running a single `COPY` command and either reusing or discarding the connection based on whether it is healthy after the copy.

This works around a bug in Postgres in which certain types / sequences of `COPY` commands cause it to be unresponsive on the connection after it completes.

The unit test recreates the Postgres hang issue on the TransactionPool, and verifies that the CopyRunner successfully processes the same logic.