### PR TITLE
fix(zql): pk lookup on `related`: `related(x, q => q.where('id', y))`

### DIFF
--- a/packages/zql-integration-tests/src/chinook/chinook.pg-test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook.pg-test.ts
@@ -200,6 +200,69 @@ test.each(
             ])
             .limit(10),
       },
+      {
+        name: 'Related with where',
+        createQuery: q =>
+          q.playlist
+            .where('id', 17)
+            .related('tracks', t => t.where('id', 1).one()),
+        manualVerification: [
+          {
+            id: 17,
+            name: 'Heavy Metal Classic',
+            tracks: {
+              albumId: 1,
+              bytes: 11170334,
+              composer: 'Angus Young, Malcolm Young, Brian Johnson',
+              genreId: 1,
+              id: 1,
+              mediaTypeId: 1,
+              milliseconds: 343719,
+              name: 'For Those About To Rock (We Salute You)',
+              unitPrice: 0.99,
+            },
+          },
+        ],
+      },
+      {
+        name: 'Permission check (via exists) against parent row',
+        createQuery: q =>
+          q.invoice
+            .where('id', 1)
+            .where('customerId', 2)
+            .related('lines', t =>
+              t.whereExists('invoice', eb => eb.where('customerId', '=', 2)),
+            ),
+        manualVerification: [
+          {
+            billingAddress: 'Theodor-Heuss-Straße 34',
+            billingCity: 'Stuttgart',
+            billingCountry: 'Germany',
+            billingPostalCode: '70174',
+            billingState: null,
+            customerId: 2,
+            id: 1,
+            invoiceDate: 1609459200000,
+            lines: [
+              {
+                id: 1,
+                invoiceId: 1,
+                quantity: 1,
+                trackId: 2,
+                unitPrice: 0.99,
+              },
+              {
+                id: 2,
+                invoiceId: 1,
+                quantity: 1,
+                trackId: 4,
+                unitPrice: 0.99,
+              },
+            ],
+            total: 1.98,
+          },
+        ],
+      },
     ],
     // primary key compare for each table
     (() =>

--- a/packages/zql-integration-tests/src/chinook/schema.ts
+++ b/packages/zql-integration-tests/src/chinook/schema.ts
@@ -164,6 +164,18 @@ const invoiceLineRelationships = relationships(invoiceLine, ({one}) => ({
     destField: ['id'],
     destSchema: invoice,
   }),
+  customer: one(
+    {
+      sourceField: ['invoiceId'],
+      destField: ['id'],
+      destSchema: invoice,
+    },
+    {
+      sourceField: ['customerId'],
+      destField: ['id'],
+      destSchema: customer,
+    },
+  ),
 }));
 
 const customerRelationships = relationships(customer, ({one}) => ({


### PR DESCRIPTION
Primary key filters in `related` calls would fail and return no results.

```ts
z.issue.related(
  'comments',
  q => q.where('id', id)
);
```

`req.constraint` in memory source should have been replaced everywhere by the primary key constraint if/when it existed. This moves the primary key constraint definition up to the top of the function and replaces all references to `req.constraint`

---
# User Reports

- https://discord.com/channels/830183651022471199/1374349312888147968/1374349316902359132
- https://discord.com/channels/830183651022471199/1334350942304206919/1374073823934156861

---

These query forms pass in `chinook.pg-test.ts`. Figuring that out separately.