### PR TITLE
fix(zql): pk constraint is a filter, not the constraint

### DIFF
--- a/packages/zql-integration-tests/src/chinook/chinook.pg-test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook.pg-test.ts
@@ -26,6 +26,7 @@ test.each(
     {
       suiteName: 'compiler_chinook',
       pgContent,
+      only: 'related with pk condition',
       zqlSchema: schema,
       setRawData: r => {
         data = r;
@@ -223,6 +224,22 @@ test.each(
             },
           },
         ],
+      },
+      {
+        name: 'related with pk condition',
+        createQuery: q =>
+          q.artist.related('albums', a => a.where('id', '=', 1)).one(),
+        manualVerification: {
+          albums: [
+            {
+              artistId: 1,
+              id: 1,
+              title: 'For Those About To Rock We Salute You',
+            },
+          ],
+          id: 1,
+          name: 'AC/DC',
+        },
       },
       {
         name: 'Permission check (via exists) against parent row',

--- a/packages/zql-integration-tests/src/helpers/runner.ts
+++ b/packages/zql-integration-tests/src/helpers/runner.ts
@@ -795,6 +795,7 @@ async function checkRemove(
     const rows = must(queryRows.get(table));
     const rowIndex = Math.floor(Math.random() * rows.length);
     const row = must(rows[rowIndex]);
+
     rows.splice(rowIndex, 1);
 
     if (rows.length === 0) {

--- a/packages/zql/src/query/query-impl.query.test.ts
+++ b/packages/zql/src/query/query-impl.query.test.ts
@@ -1097,24 +1097,6 @@ describe('pk lookup optimization', () => {
           "title": "issue 1",
           Symbol(rc): 1,
         },
-        {
-          "closed": false,
-          "createdAt": 2,
-          "description": "description 2",
-          "id": "0002",
-          "ownerId": "0002",
-          "title": "issue 2",
-          Symbol(rc): 1,
-        },
-        {
-          "closed": false,
-          "createdAt": 3,
-          "description": "description 3",
-          "id": "0003",
-          "ownerId": null,
-          "title": "issue 3",
-          Symbol(rc): 1,
-        },
       ]
     `);
   });


### PR DESCRIPTION
The primary key constraint that we build from the connection's filters should not take the place of `req.constraint` everywhere.

The reason is that the primary key constraint must be ANDED with the fetch constraint. 

Example:

An album node could `fetch(constrating: artistID = 2)`. The connection may have a primary key filter on it `artistID = 1` but it would be wrong to return that artist since it was not `artistID = 2`.

---

I was able to get the chinook test to fail with this query pattern which uncovered the push bug since `chinook.pg-test.ts` tests add, remove and edit pushes.