### PR TITLE
chore(zero-cache): revert split-health check behavior

### DIFF
--- a/packages/zero-cache/src/services/http-service.ts
+++ b/packages/zero-cache/src/services/http-service.ts
@@ -47,23 +47,13 @@ export class HttpService implements Service {
     return true;
   }
 
-  // start() is used in unit tests, or to start the HttpService early,
-  // before the ServiceRunner runs all of the services.
-  //
+  // start() is used in unit tests.
   // run() is the lifecycle method called by the ServiceRunner.
   async start(): Promise<string> {
-    this.#fastify.get('/', (_req, res) => {
-      if (this._respondToHealthCheck()) {
-        return res.send('OK');
-      }
-      return;
-    });
+    this.#fastify.get('/', (_req, res) => res.send('OK'));
     this.#fastify.get('/keepalive', ({headers}, res) => {
-      if (this._respondToKeepalive()) {
-        this.#heartbeatMonitor.onHeartbeat(headers);
-        return res.send('OK');
-      }
-      return;
+      this.#heartbeatMonitor.onHeartbeat(headers);
+      return res.send('OK');
     });
     await this.#init(this.#fastify);
     const address = await this.#fastify.listen({
@@ -75,10 +65,7 @@ export class HttpService implements Service {
   }
 
   async run(): Promise<void> {
-    // Check if start() was already called.
-    if (this.#fastify.addresses().length === 0) {
-      await this.start();
-    }
+    await this.start();
     await this.#state.stopped();
   }
 


### PR DESCRIPTION
Revert the behavior of announcing health at `/` early.

This was previously needed to allow the `replication-manager` to have an arbitrarily long startup time even if not monitored by an elastic load balancer.

The AWS docs for [`healthCheckGracePeriodSeconds`](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_definition_parameters.html#sd-networkconfiguration) have since been updated to indicate that it works for container health checks as well as ELB health checks.

> **healthCheckGracePeriodSeconds**
>
> The period of time, in seconds, that the Amazon ECS service scheduler ignores unhealthy Elastic Load Balancing, VPC Lattice, and container health checks after a task has first started. If you do not specify a health check grace period value, the default value of 0 is used. If you do not use any of the health checks, then healthCheckGracePeriodSeconds is unused.
>
> If your service's tasks take a while to start and respond, you can specify a health check grace period of up to 2,147,483,647 seconds (about 69 years). During that time, the Amazon ECS service scheduler ignores the health check status. This grace period can prevent the service scheduler from marking tasks as unhealthy and stopping them before they have time to come up.

Thus it is no longer necessary to special-case container health checks.