### PR TITLE
chore(zql): fuzz zql hydration

### DIFF
--- a/packages/zql-integration-tests/src/chinook/chinook-fuzz-hydration.pg-test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook-fuzz-hydration.pg-test.ts
@@ -1,0 +1,106 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {en, Faker, generateMersenne53Randomizer} from '@faker-js/faker';
+import {bootstrap, runAndCompare} from '../helpers/runner.ts';
+import {getChinook} from './get-deps.ts';
+import {schema} from './schema.ts';
+import {test} from 'vitest';
+import {generateQuery} from '../../../zql/src/query/test/query-gen.ts';
+import '../helpers/comparePg.ts';
+import {ast, QueryImpl} from '../../../zql/src/query/query-impl.ts';
+import {ZPGQuery} from '../../../zero-pg/src/query.ts';
+import type {AnyQuery} from '../../../zql/src/query/test/util.ts';
+import {astToZQL} from '../../../ast-to-zql/src/ast-to-zql.ts';
+import {formatOutput} from '../../../ast-to-zql/src/format.ts';
+
+const pgContent = await getChinook();
+
+// Set this to reproduce a specific failure.
+const REPRO_SEED = undefined;
+
+const harness = await bootstrap({
+  suiteName: 'frontend_analysis',
+  zqlSchema: schema,
+  pgContent,
+});
+
+test.each(Array.from({length: 30}, () => createCase()))(
+  'fuzz-hydration $seed',
+  runCase,
+);
+
+if (REPRO_SEED) {
+  // eslint-disable-next-line no-only-tests/no-only-tests
+  test.only('repro', async () => {
+    const {query} = createCase(REPRO_SEED);
+    // eslint-disable-next-line no-console
+    console.log(
+      'ZQL',
+      await formatOutput(ast(query).table + astToZQL(ast(query))),
+    );
+    await runCase({query, seed: REPRO_SEED});
+  });
+}
+
+function createCase(seed?: number | undefined) {
+  seed = seed ?? Date.now() ^ (Math.random() * 0x100000000);
+  const randomizer = generateMersenne53Randomizer(seed);
+  const rng = () => randomizer.next();
+  const faker = new Faker({
+    locale: en,
+    randomizer,
+  });
+  return {
+    seed,
+    query: generateQuery(
+      schema,
+      {},
+      rng,
+      faker,
+      harness.delegates.pg.serverSchema,
+    ),
+  };
+}
+
+async function runCase({query, seed}: {query: AnyQuery; seed: number}) {
+  // reconstruct the generated query
+  // for zql, zqlite and pg
+  const zql = new QueryImpl(
+    harness.delegates.memory,
+    schema,
+    ast(query).table as keyof typeof schema.tables,
+    ast(query),
+    query.format,
+  );
+  const zqlite = new QueryImpl(
+    harness.delegates.sqlite,
+    schema,
+    ast(query).table as keyof typeof schema.tables,
+    ast(query),
+    query.format,
+  );
+  const pg = new ZPGQuery(
+    schema,
+    harness.delegates.pg.serverSchema,
+    ast(query).table as keyof typeof schema.tables,
+    harness.delegates.pg.transaction,
+    ast(query),
+    query.format,
+  );
+
+  try {
+    await runAndCompare(
+      schema,
+      {
+        memory: zql,
+        pg,
+        sqlite: zqlite,
+      },
+      undefined,
+    );
+  } catch (e) {
+    if (seed === REPRO_SEED) {
+      throw e;
+    }
+    throw new Error('mismatch. repro seed: ' + seed);
+  }
+}

--- a/packages/zql-integration-tests/src/chinook/chinook.pg-test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook.pg-test.ts
@@ -10,7 +10,7 @@ import type {SimpleOperator} from '../../../zero-protocol/src/ast.ts';
 import type {PullRow} from '../../../zql/src/query/query.ts';
 
 // Junction edges do not correctly handle limits in ZQL
-const brokenRelationshipLimits = ['tracks'];
+const brokenRelationshipLimits = ['tracks', 'customer', 'playlists'];
 
 const pgContent = await getChinook();
 const tables = Object.keys(schema.tables) as Array<keyof typeof schema.tables>;

--- a/packages/zql-integration-tests/src/helpers/data-gen.ts
+++ b/packages/zql-integration-tests/src/helpers/data-gen.ts
@@ -89,14 +89,16 @@ export function generateData(
   return ret;
 }
 
-function getDataForType(faker: Faker, rng: Rng, column: ColumnInfo) {
+export function getDataForType(faker: Faker, rng: Rng, column: ColumnInfo) {
   if (column.optional) {
     if (rng() < 0.1) {
       return null;
     }
   }
 
-  switch (column.pgType) {
+  // remove the length of the type e.g., char(10) -> char
+  const type = column.pgType.replace(/\(.*\)/, '');
+  switch (type) {
     case 'smallint':
     case 'int2':
       return faker.number.int({min: -32768, max: 32767});

--- a/packages/zql-integration-tests/src/helpers/runner.ts
+++ b/packages/zql-integration-tests/src/helpers/runner.ts
@@ -636,28 +636,36 @@ function makeTest<TSchema extends Schema>(
         memory: createQuery(queryBuilders.memory),
       };
 
-      const pgResult = await queries.pg;
-      // Might we worth being able to configure ZQLite to return client vs server names
-      const sqliteResult = mapResultToClientNames(
-        await queries.sqlite,
-        zqlSchema,
-        ast(queries.sqlite).table,
-      );
-      const memoryResult = await queries.memory;
-
-      // - is PG
-      // + is SQLite / Memory
-      expect(memoryResult).toEqualPg(pgResult);
-      expect(sqliteResult).toEqualPg(pgResult);
-      if (manualVerification) {
-        expect(manualVerification).toEqualPg(pgResult);
-      }
+      await runAndCompare(zqlSchema, queries, manualVerification);
 
       if (pushEvery > 0) {
         await checkPush(zqlSchema, delegates, queries, pushEvery);
       }
     });
   };
+}
+
+export async function runAndCompare(
+  zqlSchema: Schema,
+  queries: QueryInstances,
+  manualVerification: unknown,
+) {
+  const pgResult = await queries.pg;
+  // Might we worth being able to configure ZQLite to return client vs server names
+  const sqliteResult = mapResultToClientNames(
+    await queries.sqlite,
+    zqlSchema,
+    ast(queries.sqlite).table,
+  );
+  const memoryResult = await queries.memory;
+
+  // - is PG
+  // + is SQLite / Memory
+  expect(memoryResult).toEqualPg(pgResult);
+  expect(sqliteResult).toEqualPg(pgResult);
+  if (manualVerification) {
+    expect(manualVerification).toEqualPg(pgResult);
+  }
 }
 
 async function checkPush(

--- a/packages/zql/src/query/test/query-gen.ts
+++ b/packages/zql/src/query/test/query-gen.ts
@@ -11,6 +11,8 @@ import {
   type Rng,
 } from './util.ts';
 import {NotImplementedError} from '../../error.ts';
+import type {ServerSchema} from '../../../../z2s/src/schema.ts';
+import {getDataForType} from '../../../../zql-integration-tests/src/helpers/data-gen.ts';
 export type Dataset = {
   [table: string]: Row[];
 };
@@ -20,9 +22,16 @@ export function generateQuery(
   data: Dataset,
   rng: Rng,
   faker: Faker,
+  serverSchema?: ServerSchema | undefined,
 ): AnyQuery {
-  const rootTable = selectRandom(rng, Object.keys(schema.tables));
-  return augmentQuery(schema, data, rng, faker, staticQuery(schema, rootTable));
+  return augmentQuery(
+    schema,
+    data,
+    rng,
+    faker,
+    staticQuery(schema, selectRandom(rng, Object.keys(schema.tables))),
+    serverSchema,
+  );
 }
 
 const maxDepth = 10;
@@ -32,6 +41,7 @@ function augmentQuery(
   rng: Rng,
   faker: Faker,
   query: AnyQuery,
+  serverSchema?: ServerSchema | undefined,
   depth = 0,
   inExists = false,
 ) {
@@ -113,11 +123,30 @@ function augmentQuery(
       if (!operator) {
         continue;
       }
+
+      let detailedType: string | undefined;
+      if (serverSchema) {
+        const tableName = ast(query).table;
+        const serverTable = schema.tables[tableName].serverName ?? tableName;
+        const serverColumn =
+          schema.tables[tableName].columns[columnName].serverName ?? columnName;
+
+        detailedType = serverSchema[serverTable]?.[serverColumn]?.type;
+      }
+
       const value =
         // TODO: all these constants should be tunable.
         rng() > 0.1 && tableData && tableData.length > 0
           ? selectRandom(rng, tableData)[columnName]
-          : randomValueForType(rng, faker, column.type, column.optional);
+          : detailedType
+            ? getDataForType(faker, rng, {
+                optional: !!column.optional,
+                pgType: detailedType,
+                isEnum: false,
+                isPrimaryKey: false,
+                name: columnName,
+              })
+            : randomValueForType(rng, faker, column.type, column.optional);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       query = query.where(columnName as any, operator, value);
     }
@@ -131,7 +160,9 @@ function augmentQuery(
       return query;
     }
 
-    const relationships = Object.keys(schema.relationships[ast(query).table]);
+    const relationships = Object.keys(
+      schema.relationships[ast(query).table] ?? {},
+    );
     const relationshipsToAdd = Math.floor(rng() * 4);
     if (relationshipsToAdd === 0) {
       return query;
@@ -143,7 +174,16 @@ function augmentQuery(
     );
     relationshipsToAddNames.forEach(relationshipName => {
       query = query.related(relationshipName, q =>
-        augmentQuery(schema, data, rng, faker, q, depth + 1, inExists),
+        augmentQuery(
+          schema,
+          data,
+          rng,
+          faker,
+          q,
+          serverSchema,
+          depth + 1,
+          inExists,
+        ),
       );
     });
 
@@ -156,7 +196,9 @@ function augmentQuery(
       return query;
     }
 
-    const relationships = Object.keys(schema.relationships[ast(query).table]);
+    const relationships = Object.keys(
+      schema.relationships[ast(query).table] ?? {},
+    );
     const existsToAdd = Math.floor(rng() * 4);
     if (existsToAdd === 0) {
       return query;
@@ -168,13 +210,31 @@ function augmentQuery(
         query = query.where(({not, exists}) =>
           not(
             exists(relationshipName, q =>
-              augmentQuery(schema, data, rng, faker, q, depth + 1, true),
+              augmentQuery(
+                schema,
+                data,
+                rng,
+                faker,
+                q,
+                serverSchema,
+                depth + 1,
+                true,
+              ),
             ),
           ),
         );
       } else {
         query = query.whereExists(relationshipName, q =>
-          augmentQuery(schema, data, rng, faker, q, depth + 1, true),
+          augmentQuery(
+            schema,
+            data,
+            rng,
+            faker,
+            q,
+            serverSchema,
+            depth + 1,
+            true,
+          ),
         );
       }
     });


### PR DESCRIPTION
Running

```
npm run test -- chinook-fuzz --project=zql-integration-tests/pg-17 --silent=false
```

Will use the query generator to generate 30 random queries and run them all through zql, zqlite, z2s and compare their output against one another.

Failures will print the seed that caused the failure (`mismatch. repro seed: xxxx`). You can then run with a specific seed which will print the query that was used and the data that was fetched.

![CleanShot 2025-05-20 at 20 06 41@2x](https://github.com/user-attachments/assets/c761fbaa-b29a-4196-8150-6311b36fd69f)


Running with seed `733566003` shows this query fails:

```ts
employee
  .where(({exists, not}) =>
    not(
      exists('reportsTo', q =>
        q
          .where(({exists, not}) =>
            not(
              exists('reportsTo', q =>
                q
                  .orderBy('birthDate', 'desc')
                  .orderBy('postalCode', 'desc')
                  .orderBy('firstName', 'asc')
                  .orderBy('id', 'asc')
                  .limit(81),
              ),
            ),
          )
          .orderBy('country', 'desc')
          .orderBy('reportsTo', 'desc')
          .orderBy('phone', 'asc')
          .orderBy('postalCode', 'desc')
          .orderBy('state', 'desc')
          .orderBy('city', 'desc')
          .orderBy('id', 'asc')
          .limit(115),
      ),
    ),
  )
  .where('email', '!=', 'orHBPJKMq0')
  .where('address', '!=', '55UsGyHXNH')
  .where('email', '!=', 'qBupKFnPFJ')
  .orderBy('reportsTo', 'asc')
  .orderBy('email', 'asc')
  .orderBy('title', 'desc')
  .limit(35)
```

1. Next is a shrink step to simplify the query form to the smallest thing that still fails.
2. Once the tests are stable enough, run continuously