### PR TITLE
chore(prod): run gigabugs-ebs with max IOPS

### DIFF
--- a/prod/sst/sst.config.ts
+++ b/prod/sst/sst.config.ts
@@ -131,9 +131,9 @@ export default $config({
               name: 'replication-data',
               managedEbsVolume: {
                 roleArn: ecsVolumeRole?.arn,
-                volumeType: 'io2',
+                volumeType: 'gp3',
                 sizeInGb: 20,
-                iops: 3000,
+                iops: 15000,
                 fileSystemType: 'ext4',
               },
             },
@@ -161,8 +161,8 @@ export default $config({
 
     const replicationManager = new sst.aws.Service(`replication-manager`, {
       cluster,
-      cpu: '2 vCPU',
-      memory: '8 GB',
+      cpu: IS_EBS_STAGE ? '16 vCPU' : '2 vCPU',
+      memory: IS_EBS_STAGE ? '32 GB' : '8 GB',
       image: commonEnv.ZERO_IMAGE_URL,
       link: [replicationBucket],
       health: {


### PR DESCRIPTION
Run gigabugs-ebs with 16 vCPU and 15000 IOPS on the ebs volume, the maximum performance achievable on Fargate as per https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ebs-fargate-performance-limits.html