### PR TITLE
chore(prod): fix ebs volume

### DIFF
--- a/prod/sst/sst.config.ts
+++ b/prod/sst/sst.config.ts
@@ -132,7 +132,7 @@ export default $config({
               managedEbsVolume: {
                 roleArn: ecsVolumeRole?.arn,
                 volumeType: 'gp3',
-                sizeInGb: 20,
+                sizeInGb: 30,
                 iops: 15000,
                 fileSystemType: 'ext4',
               },

--- a/prod/sst/sst.config.ts
+++ b/prod/sst/sst.config.ts
@@ -132,6 +132,7 @@ export default $config({
               managedEbsVolume: {
                 roleArn: ecsVolumeRole?.arn,
                 volumeType: 'gp3',
+                // Note: The maximum allowed IOPS/GB ratio is 500.
                 sizeInGb: 30,
                 iops: 15000,
                 fileSystemType: 'ext4',


### PR DESCRIPTION
At 20 gb and 15000 IOPS, AWS fails with:

```
Encountered 'InvalidParameterValue' error from AmazonEC2: "Iops to volume size ratio of 750.000000 is too high; maximum is 500"
```

Bumping to 30 gb to achieve the maximum allowed ratio of 500.