### PR TITLE
fix(z2s): apply where to junction edges

### DIFF
--- a/packages/z2s/src/compiler.ts
+++ b/packages/z2s/src/compiler.ts
@@ -222,6 +222,7 @@ function relationshipSubquery(
         }),
       );
     }
+
     return sql`(
         SELECT ${toJSON(innerAlias, format?.singular)} FROM (SELECT ${sql.join(
           selectionSet,
@@ -234,22 +235,15 @@ function relationshipSubquery(
           })),
           relationship.correlation.childField,
         )(participatingTables[0].table)}) ${
-          relationship.subquery.where
-            ? sql`AND ${where(
-                spec,
-                relationship.subquery.where,
-                participatingTables[0].table,
-              )}`
+          nestedAst.where
+            ? sql`AND ${where(spec, nestedAst.where, lastTable)}`
             : sql``
-        } ${orderBy(
-          spec,
-          relationship.subquery.orderBy,
-          participatingTables[0].table,
-        )} ${
+        } ${orderBy(spec, nestedAst.orderBy, lastTable)} ${
           format?.singular ? limit(1) : limit(last(participatingTables)?.limit)
         } ) ${sql.ident(innerAlias)}
       ) as ${sql.ident(relationship.subquery.alias)}`;
   }
+
   return sql`(
       SELECT ${toJSON(innerAlias, format?.singular)} FROM (${select(
         spec,

--- a/packages/zql-integration-tests/src/chinook/chinook.pg-test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook.pg-test.ts
@@ -26,7 +26,6 @@ test.each(
     {
       suiteName: 'compiler_chinook',
       pgContent,
-      only: 'related with pk condition',
       zqlSchema: schema,
       setRawData: r => {
         data = r;
@@ -202,7 +201,7 @@ test.each(
             .limit(10),
       },
       {
-        name: 'Related with where',
+        name: 'Junction related with where',
         createQuery: q =>
           q.playlist
             .where('id', 17)
@@ -240,6 +239,61 @@ test.each(
           id: 1,
           name: 'AC/DC',
         },
+      },
+
+      {
+        name: 'Junction related with where, no limits',
+        createQuery: q =>
+          q.playlist.where('id', 17).related('tracks', t => t.where('id', 1)),
+        manualVerification: [
+          {
+            id: 17,
+            name: 'Heavy Metal Classic',
+            tracks: [
+              {
+                albumId: 1,
+                bytes: 11170334,
+                composer: 'Angus Young, Malcolm Young, Brian Johnson',
+                genreId: 1,
+                id: 1,
+                mediaTypeId: 1,
+                milliseconds: 343719,
+                name: 'For Those About To Rock (We Salute You)',
+                unitPrice: 0.99,
+              },
+            ],
+          },
+        ],
+      },
+      // zql and zqlite are currently unable to order over junction edges
+      // {
+      //   name: 'Junction related order by',
+      //   createQuery: q =>
+      //     q.playlist
+      //       .where('id', 17)
+      //       .related('tracks', t => t.orderBy('name', 'asc')),
+      // },
+      // zql and zqlite are currently unable to limit on junction edges
+      // {
+      //   name: 'Junction related order by with limit',
+      //   createQuery: q =>
+      //     q.playlist
+      //       .where('id', 17)
+      //       .related('tracks', t => t.orderBy('name', 'asc').limit(1)),
+      // },
+      {
+        name: 'Junction related where on non primary key',
+        createQuery: q =>
+          q.playlist
+            .where('id', 17)
+            .related('tracks', t => t.where('name', 'For Those About To Rock')),
+        manualVerification: [
+          {
+            id: 17,
+            name: 'Heavy Metal Classic',
+            tracks: [],
+          },
+        ],
       },
       {
         name: 'Permission check (via exists) against parent row',

--- a/packages/zql-integration-tests/src/helpers/runner.ts
+++ b/packages/zql-integration-tests/src/helpers/runner.ts
@@ -309,7 +309,7 @@ export async function createVitests<TSchema extends Schema>(
 
   return testSpecs
     .flat()
-    .filter(t => (only ? only.includes(t.name) : true))
+    .filter(t => (only ? t.name.includes(only) : true))
     .map(({name, createQuery, manualVerification}) => ({
       name,
       fn: makeTest(


### PR DESCRIPTION
junction edges were referring to the wrong ast to pull `where` conditions from in the compiled sql.

Next up:
- disable `limit` over junction edges in ZQL
- disable `orderBy` over junction edges in ZQL

Both of those things are not yet supported by ZQL.