### PR TITLE
chore(zql): test an arbitrary query string

### DIFF
--- a/packages/zql-integration-tests/src/chinook/check-zql-string.pg-test.ts
+++ b/packages/zql-integration-tests/src/chinook/check-zql-string.pg-test.ts
@@ -1,0 +1,48 @@
+import {bootstrap, runAndCompare} from '../helpers/runner.ts';
+import {getChinook} from './get-deps.ts';
+import {schema} from './schema.ts';
+import {test} from 'vitest';
+import '../helpers/comparePg.ts';
+import {defaultFormat} from '../../../zql/src/query/query-impl.ts';
+import type {AnyQuery} from '../../../zql/src/query/test/util.ts';
+import {StaticQuery} from '../../../zql/src/query/static-query.ts';
+import {staticToRunnable} from '../helpers/static.ts';
+
+const QUERY_STRING = `customer`;
+
+const pgContent = await getChinook();
+
+const harness = await bootstrap({
+  suiteName: 'frontend_analysis',
+  zqlSchema: schema,
+  pgContent,
+});
+
+const z = {
+  query: Object.fromEntries(
+    Object.entries(schema.tables).map(([name]) => [
+      name,
+      new StaticQuery(
+        schema,
+        name as keyof typeof schema.tables,
+        {table: name},
+        defaultFormat,
+      ),
+    ]),
+  ),
+};
+
+const f = new Function('z', `return z.query.${QUERY_STRING};`);
+const query: AnyQuery = f(z);
+
+test('manual zql string', async () => {
+  await runAndCompare(
+    schema,
+    staticToRunnable({
+      query,
+      schema,
+      harness,
+    }),
+    undefined,
+  );
+});

--- a/packages/zql-integration-tests/src/helpers/static.ts
+++ b/packages/zql-integration-tests/src/helpers/static.ts
@@ -1,0 +1,46 @@
+import type {Schema} from '../../../zero-schema/src/builder/schema-builder.ts';
+import {ast, QueryImpl} from '../../../zql/src/query/query-impl.ts';
+import type {AnyQuery} from '../../../zql/src/query/test/util.ts';
+import {type bootstrap} from './runner.ts';
+import {ZPGQuery} from '../../../zero-pg/src/query.ts';
+
+export function staticToRunnable<TSchema extends Schema>({
+  query,
+  schema,
+  harness,
+}: {
+  query: AnyQuery;
+  schema: TSchema;
+  harness: Awaited<ReturnType<typeof bootstrap>>;
+}) {
+  // reconstruct the generated query
+  // for zql, zqlite and pg
+  const zql = new QueryImpl(
+    harness.delegates.memory,
+    schema,
+    ast(query).table,
+    ast(query),
+    query.format,
+  );
+  const zqlite = new QueryImpl(
+    harness.delegates.sqlite,
+    schema,
+    ast(query).table,
+    ast(query),
+    query.format,
+  );
+  const pg = new ZPGQuery(
+    schema,
+    harness.delegates.pg.serverSchema,
+    ast(query).table,
+    harness.delegates.pg.transaction,
+    ast(query),
+    query.format,
+  );
+
+  return {
+    memory: zql,
+    pg,
+    sqlite: zqlite,
+  };
+}


### PR DESCRIPTION
Fuzz testing creates failing queries but debugging those failing queries can be hard.

Allow testing an arbitrary query string so we can iterate on debugging a failing query.

Usage:

1. replace `QUERY_STRING` with the failing query. E.g., `QUERY_STRING = 'customer.related("invoice")'`
2. `npm run test -- check-zql-string --project=zql-integration-tests/pg-17`