### PR TITLE
fix(z2s): NULLS FIRST vs NULLS LAST

### DIFF
--- a/packages/z2s/src/compiler.output.test.ts
+++ b/packages/z2s/src/compiler.output.test.ts
@@ -256,7 +256,7 @@ test('orderBy', () => {
     ),
   ).toMatchInlineSnapshot(`
     {
-      "text": "ORDER BY "user"."name" COLLATE "ucs_basic" ASC, "user"."age" DESC",
+      "text": "ORDER BY "user"."name" COLLATE "ucs_basic" ASC NULLS FIRST, "user"."age" DESC NULLS LAST",
       "values": [],
     }
   `);
@@ -277,7 +277,7 @@ test('orderBy', () => {
     ),
   ).toMatchInlineSnapshot(`
     {
-      "text": "ORDER BY "user"."name" COLLATE "ucs_basic" ASC, "user"."age" DESC, "user"."id" COLLATE "ucs_basic" ASC",
+      "text": "ORDER BY "user"."name" COLLATE "ucs_basic" ASC NULLS FIRST, "user"."age" DESC NULLS LAST, "user"."id" COLLATE "ucs_basic" ASC NULLS FIRST",
       "values": [],
     }
   `);

--- a/packages/z2s/src/compiler.ts
+++ b/packages/z2s/src/compiler.ts
@@ -154,11 +154,11 @@ export function orderBy(
           sql`${colIdent(spec.server, {
             table,
             zql: col,
-          })}${maybeCollate(serverColumnSchema)} ASC`
+          })}${maybeCollate(serverColumnSchema)} ASC NULLS FIRST`
         : sql`${colIdent(spec.server, {
             table,
             zql: col,
-          })}${maybeCollate(serverColumnSchema)} DESC`;
+          })}${maybeCollate(serverColumnSchema)} DESC NULLS LAST`;
     }),
     ', ',
   )}`;

--- a/packages/zql-integration-tests/src/chinook/check-zql-string.pg-test.ts
+++ b/packages/zql-integration-tests/src/chinook/check-zql-string.pg-test.ts
@@ -8,7 +8,9 @@ import type {AnyQuery} from '../../../zql/src/query/test/util.ts';
 import {StaticQuery} from '../../../zql/src/query/static-query.ts';
 import {staticToRunnable} from '../helpers/static.ts';
 
-const QUERY_STRING = `customer`;
+const QUERY_STRING = `customer
+  .orderBy('company', 'desc')
+  .limit(2)`;
 
 const pgContent = await getChinook();
 


### PR DESCRIPTION
SQLite and ZQL considers null to be smaller than all values. Postgres considers null to be larger than all values.

Modify postgres order-by to match sqlite.

Found by the fuzzer.