### PR TITLE
fix(zql)!: throw if a relationship name matches a column name

### DIFF
--- a/packages/zero-schema/src/builder/schema-builder.ts
+++ b/packages/zero-schema/src/builder/schema-builder.ts
@@ -91,6 +91,11 @@ function checkRelationship(
   // TS should be able to check this for us but something is preventing it from happening.
   Object.entries(relationships).forEach(([name, rel]) => {
     let source = tables[tableName];
+    if (source.columns[name] !== undefined) {
+      throw new Error(
+        `Relationship "${tableName}"."${name}" cannot have the same name as the column "${name}" on the the table "${source.name}"`,
+      );
+    }
     rel.forEach(connection => {
       if (!tables[connection.destSchema]) {
         throw new Error(

--- a/packages/zql-integration-tests/src/chinook/check-zql-string.pg-test.ts
+++ b/packages/zql-integration-tests/src/chinook/check-zql-string.pg-test.ts
@@ -8,13 +8,14 @@ import type {AnyQuery} from '../../../zql/src/query/test/util.ts';
 import {StaticQuery} from '../../../zql/src/query/static-query.ts';
 import {staticToRunnable} from '../helpers/static.ts';
 
-const QUERY_STRING = `playlist
-  .where('id', 3)
-  .related('tracks', q =>
-    q
-      .related('invoiceLines')
-  )
-  .limit(1)`;
+const QUERY_STRING = `employee
+  .related('reportsToEmployee')
+  .orderBy('city', 'desc')
+  .orderBy('reportsTo', 'desc')
+  .orderBy('fax', 'desc')
+  .orderBy('id', 'asc')
+  .orderBy('state', 'desc')
+  .limit(154)`;
 
 const pgContent = await getChinook();
 

--- a/packages/zql-integration-tests/src/chinook/chinook.pg-test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook.pg-test.ts
@@ -79,7 +79,7 @@ test.each(
         name: '3 level related: customer -> supportRep -> reportsTo',
         createQuery: q =>
           q.invoice.related('customer', c =>
-            c.related('supportRep', r => r.related('reportsTo')),
+            c.related('supportRep', r => r.related('reportsToEmployee')),
           ),
       },
       {

--- a/packages/zql-integration-tests/src/chinook/schema.ts
+++ b/packages/zql-integration-tests/src/chinook/schema.ts
@@ -187,7 +187,7 @@ const customerRelationships = relationships(customer, ({one}) => ({
 }));
 
 const employeeRelationships = relationships(employee, ({one}) => ({
-  reportsTo: one({
+  reportsToEmployee: one({
     sourceField: ['reportsTo'],
     destField: ['id'],
     destSchema: employee,


### PR DESCRIPTION
If a relationship name matches a column name and we try to sort by that column, we end up trying to sort on the relationship iterable.

E.g.,

```ts
employee.related('reportsTo').orderBy('reportsTo', 'asc');
```

would fail

Found by the fuzzer.