### PR TITLE
fix(z2s): handle `limit(0)` against `singular` relationships

### DIFF
--- a/packages/z2s/src/compiler.output.test.ts
+++ b/packages/z2s/src/compiler.output.test.ts
@@ -187,7 +187,7 @@ beforeEach(() => {
 });
 
 test('limit', () => {
-  expect(formatPgInternalConvert(limit(10))).toMatchInlineSnapshot(`
+  expect(formatPgInternalConvert(limit(10, false))).toMatchInlineSnapshot(`
     {
       "text": "LIMIT $1::text::double precision",
       "values": [
@@ -195,7 +195,8 @@ test('limit', () => {
       ],
     }
   `);
-  expect(formatPgInternalConvert(limit(undefined))).toMatchInlineSnapshot(`
+  expect(formatPgInternalConvert(limit(undefined, undefined)))
+    .toMatchInlineSnapshot(`
     {
       "text": "",
       "values": [],

--- a/packages/z2s/src/compiler.ts
+++ b/packages/z2s/src/compiler.ts
@@ -119,10 +119,19 @@ function select(
     ${maybeWhere(ast.where)} ${where(spec, ast.where, table)}
     ${maybeWhere(correlate)} ${correlate ? correlate(table) : sql``}
     ${orderBy(spec, ast.orderBy, table)}
-    ${format?.singular ? limit(1) : limit(ast.limit)}`;
+    ${limit(ast.limit, format?.singular)}`;
 }
 
-export function limit(limit: number | undefined): SQLQuery {
+export function limit(
+  limit: number | undefined,
+  singular: boolean | undefined,
+): SQLQuery {
+  if (limit === 0) {
+    return sql`LIMIT 0`;
+  }
+  if (singular) {
+    return sql`LIMIT 1`;
+  }
   if (limit === undefined) {
     return sql``;
   }
@@ -238,9 +247,10 @@ function relationshipSubquery(
           nestedAst.where
             ? sql`AND ${where(spec, nestedAst.where, lastTable)}`
             : sql``
-        } ${orderBy(spec, nestedAst.orderBy, lastTable)} ${
-          format?.singular ? limit(1) : limit(last(participatingTables)?.limit)
-        } ) ${sql.ident(innerAlias)}
+        } ${orderBy(spec, nestedAst.orderBy, lastTable)} ${limit(
+          last(participatingTables)?.limit,
+          format?.singular,
+        )} ) ${sql.ident(innerAlias)}
       ) as ${sql.ident(relationship.subquery.alias)}`;
   }
 

--- a/packages/zql-integration-tests/src/chinook/check-zql-string.pg-test.ts
+++ b/packages/zql-integration-tests/src/chinook/check-zql-string.pg-test.ts
@@ -8,14 +8,14 @@ import type {AnyQuery} from '../../../zql/src/query/test/util.ts';
 import {StaticQuery} from '../../../zql/src/query/static-query.ts';
 import {staticToRunnable} from '../helpers/static.ts';
 
-const QUERY_STRING = `employee
-  .related('reportsToEmployee')
-  .orderBy('city', 'desc')
-  .orderBy('reportsTo', 'desc')
-  .orderBy('fax', 'desc')
-  .orderBy('id', 'asc')
-  .orderBy('state', 'desc')
-  .limit(154)`;
+const QUERY_STRING = `customer
+  .related('supportRep', q =>
+    q
+      .orderBy('postalCode', 'asc')
+      .orderBy('id', 'desc')
+      .orderBy('birthDate', 'asc')
+      .limit(0),
+  )`;
 
 const pgContent = await getChinook();
 


### PR DESCRIPTION
the compiler defaulted `singular` to `limit(1)` but `limit(0)` should take precedence here.

Found by the fuzzer.