### PR TITLE
fix(zql): handle `whereExists('x', q => q.limit(0))`

### DIFF
--- a/packages/zql-integration-tests/src/chinook/check-zql-string.pg-test.ts
+++ b/packages/zql-integration-tests/src/chinook/check-zql-string.pg-test.ts
@@ -8,14 +8,11 @@ import type {AnyQuery} from '../../../zql/src/query/test/util.ts';
 import {StaticQuery} from '../../../zql/src/query/static-query.ts';
 import {staticToRunnable} from '../helpers/static.ts';
 
-const QUERY_STRING = `employee
-  .related('reportsToEmployee')
-  .orderBy('city', 'desc')
-  .orderBy('reportsTo', 'desc')
-  .orderBy('fax', 'desc')
-  .orderBy('id', 'asc')
-  .orderBy('state', 'desc')
-  .limit(154)`;
+const QUERY_STRING = `track
+  .whereExists('invoiceLines', q =>
+    q
+      .limit(0),
+  ).limit(1)`;
 
 const pgContent = await getChinook();
 


### PR DESCRIPTION
```ts
foo.whereExists('x', q => q.limit(0))
```

should always evaluate to false.

```ts
foo.whereNotExists('x', q => q.limit(0))
```

should always evaluate to true.

Found by the fuzzer.