### PR TITLE
chore(zero-cache): use multipart config for litestream uploads

### DIFF
--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -300,18 +300,13 @@ test('zero-cache --help', () => {
      --litestream-multipart-concurrency number                   default: 48                                                                                       
        ZERO_LITESTREAM_MULTIPART_CONCURRENCY env                                                                                                                   
                                                                  The number of parts (of size --litestream-multipart-size bytes)                                   
-                                                                 to download in parallel when restoring the snapshot from the backup.                              
-                                                                                                                                                                   
-                                                                 This requires a custom build of litestream (version 0.3.13+z0.0.1+).                              
-                                                                 Set to 0 to disable.                                                                              
+                                                                 to upload or download in parallel when backing up or restoring the snapshot.                      
                                                                                                                                                                    
      --litestream-multipart-size number                          default: 16777216                                                                                 
        ZERO_LITESTREAM_MULTIPART_SIZE env                                                                                                                          
-                                                                 The size of each part when downloading the snapshot with --multipart-concurrency.                 
-                                                                 Multipart downloads require concurrency * size bytes of memory when restoring                     
-                                                                 the snapshot from the backup.                                                                     
-                                                                                                                                                                   
-                                                                 This requires a custom build of litestream (version 0.3.13+z0.0.1+).                              
+                                                                 The size of each part when uploading or downloading the snapshot with                             
+                                                                 --multipart-concurrency. Note that up to concurrency * size                                       
+                                                                 bytes of memory are used when backing up or restoring the snapshot.                               
                                                                                                                                                                    
      --storage-db-tmp-dir string                                 optional                                                                                          
        ZERO_STORAGE_DB_TMP_DIR env                                                                                                                                 

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -489,21 +489,16 @@ export const zeroOptions = {
       type: v.number().default(48),
       desc: [
         `The number of parts (of size {bold --litestream-multipart-size} bytes)`,
-        `to download in parallel when restoring the snapshot from the backup.`,
-        ``,
-        `This requires a custom build of litestream (version 0.3.13+z0.0.1+).`,
-        `Set to 0 to disable.`,
+        `to upload or download in parallel when backing up or restoring the snapshot.`,
       ],
     },
 
     multipartSize: {
       type: v.number().default(16 * 1024 * 1024),
       desc: [
-        `The size of each part when downloading the snapshot with {bold --multipart-concurrency}.`,
-        `Multipart downloads require {bold concurrency * size} bytes of memory when restoring`,
-        `the snapshot from the backup.`,
-        ``,
-        `This requires a custom build of litestream (version 0.3.13+z0.0.1+).`,
+        `The size of each part when uploading or downloading the snapshot with`,
+        `{bold --multipart-concurrency}. Note that up to {bold concurrency * size}`,
+        `bytes of memory are used when backing up or restoring the snapshot.`,
       ],
     },
   },

--- a/packages/zero-cache/src/services/litestream/config.yml
+++ b/packages/zero-cache/src/services/litestream/config.yml
@@ -9,6 +9,8 @@ dbs:
         retention: ${ZERO_LITESTREAM_SNAPSHOT_BACKUP_INTERVAL_MINUTES}m
         retention-check-interval: 1h
         sync-interval: ${ZERO_LITESTREAM_INCREMENTAL_BACKUP_INTERVAL_MINUTES}m
+        multipart-concurrency: ${ZERO_LITESTREAM_MULTIPART_CONCURRENCY}
+        multipart-size: ${ZERO_LITESTREAM_MULTIPART_SIZE}
 
 logging:
   level: ${ZERO_LITESTREAM_LOG_LEVEL}

--- a/packages/zero/Dockerfile
+++ b/packages/zero/Dockerfile
@@ -1,10 +1,10 @@
 FROM golang:1.23 AS litestream
 
 WORKDIR /src/
-RUN git clone --depth 1 --branch zero@v0.0.5 https://github.com/rocicorp/litestream.git
+RUN git clone --depth 1 --branch zero@v0.0.6 https://github.com/rocicorp/litestream.git
 WORKDIR /src/litestream/
 
-ARG LITESTREAM_VERSION=0.3.13+z0.0.5  # upstream version + zero version
+ARG LITESTREAM_VERSION=0.3.13+z0.0.6  # upstream version + zero version
 
 RUN --mount=type=cache,target=/root/.cache/go-build \
 	--mount=type=cache,target=/go/pkg \


### PR DESCRIPTION
Apply the `--multipart-concurrency` and `--multipart-size` options to litestream uploads as well as downloads, making the memory usage (and ideally, speed gains) symmetric for restores and backups.

This leverages a new feature in our litestream fork: https://github.com/rocicorp/litestream/pull/7