### PR TITLE
chore(zero-cache): narrow input type of createLogContext()

### DIFF
--- a/packages/zero-cache/src/server/logging.ts
+++ b/packages/zero-cache/src/server/logging.ts
@@ -6,9 +6,13 @@ import {
   type LogSink,
 } from '@rocicorp/logger';
 import {pid} from 'node:process';
-import {type LogConfig, type ZeroConfig} from '../config/zero-config.ts';
 import {stringify} from '../types/bigint-json.ts';
 import {OtelLogSink} from './otel-log-sink.ts';
+
+export type LogConfig = {
+  level: LogLevel;
+  format: 'text' | 'json';
+};
 
 function createLogSink(config: LogConfig): LogSink {
   const consoleSink =
@@ -21,15 +25,10 @@ function createLogSink(config: LogConfig): LogSink {
 }
 
 export function createLogContext(
-  config: Pick<ZeroConfig, 'log' | 'tenantID'>,
+  {log}: {log: LogConfig},
   context: {worker: string},
 ): LogContext {
-  const {log, tenantID: tid} = config;
-  const ctx = {
-    ...((tid ?? '').length ? {tid} : {}),
-    ...context,
-    pid,
-  };
+  const ctx = {...context, pid};
   const lc = new LogContext(log.level, ctx, createLogSink(log));
   // Emit a blank line to absorb random ANSI control code garbage that
   // for some reason gets prepended to the first log line in CloudWatch.


### PR DESCRIPTION
Also remove vestigial `tenantID` stuff.