### PR TITLE
chore(zero-cache): Refactor observability instruments

### DIFF
--- a/packages/zero-cache/src/observability/counters.ts
+++ b/packages/zero-cache/src/observability/counters.ts
@@ -1,0 +1,55 @@
+import {getMeter} from './view-syncer-instruments.ts';
+
+function createCounter(name: string, options: {description: string}) {
+  return getMeter().createCounter(name, {
+    description: options.description,
+  });
+}
+
+export function replicationEvents() {
+  return createCounter('replication-events', {
+    description: 'Number of replication events processed',
+  });
+}
+
+export function crudMutations() {
+  return createCounter('crud-mutations', {
+    description: 'Number of CRUD mutations processed',
+  });
+}
+
+export function customMutations() {
+  return createCounter('custom-mutations', {
+    description: 'Number of custom mutations processed',
+  });
+}
+
+export function pushes() {
+  return createCounter('pushes', {
+    description: 'Number of pushes processed by the pusher',
+  });
+}
+
+export function queryHydrations() {
+  return createCounter('query-hydrations', {
+    description: 'Number of query hydrations',
+  });
+}
+
+export function cvrRowsFlushed() {
+  return createCounter('cvr-rows-flushed', {
+    description: 'Number of rows flushed to all CVRs',
+  });
+}
+
+export function rowsPoked() {
+  return createCounter('rows-poked', {
+    description: 'Number of rows poked',
+  });
+}
+
+export function pokeTransactions() {
+  return createCounter('poke-transactions', {
+    description: 'Number of poke transactions (pokeStart,pokeEnd) pairs',
+  });
+}

--- a/packages/zero-cache/src/observability/histograms.ts
+++ b/packages/zero-cache/src/observability/histograms.ts
@@ -1,0 +1,60 @@
+import {getMeter} from './view-syncer-instruments.ts';
+
+function createHistogram(
+  name: string,
+  options: {description: string; unit?: string},
+) {
+  return getMeter().createHistogram(name, options);
+}
+
+export function wsMessageProcessingTime() {
+  return createHistogram('ws-message-processing-time', {
+    description:
+      'Time to process a websocket message. The `message.type` attribute is set in order to filter by message type.',
+    unit: 'milliseconds',
+  });
+}
+
+export function replicationEventProcessingTime() {
+  return createHistogram('replication-event-processing-time', {
+    description: 'Time to process a replication event.',
+    unit: 'milliseconds',
+  });
+}
+
+export function transactionAdvanceTime() {
+  return createHistogram('cg-advance-time', {
+    description:
+      'Time to advance all queries for a given client group after applying a new transaction to the replica.',
+    unit: 'milliseconds',
+  });
+}
+
+export function changeAdvanceTime() {
+  return createHistogram('change-advance-time', {
+    description:
+      'Time to advance all queries for a given client group for in response to a single change.',
+    unit: 'milliseconds',
+  });
+}
+
+export function cvrFlushTime() {
+  return createHistogram('cvr-flush-time', {
+    description: 'Time to flush a CVR transaction.',
+    unit: 'milliseconds',
+  });
+}
+
+export function pokeTime() {
+  return createHistogram('poke-flush-time', {
+    description: 'Time to poke to all clients.',
+    unit: 'milliseconds',
+  });
+}
+
+export function hydrationTime() {
+  return createHistogram('hydration-time', {
+    description: 'Time to hydrate a query.',
+    unit: 'milliseconds',
+  });
+}

--- a/packages/zero-cache/src/observability/up-down-counters.ts
+++ b/packages/zero-cache/src/observability/up-down-counters.ts
@@ -1,0 +1,49 @@
+import {getMeter} from './view-syncer-instruments.ts';
+
+function createUpDownCounter(name: string, options: {description: string}) {
+  return getMeter().createUpDownCounter(name, {
+    description: options.description,
+  });
+}
+
+export function activeConnections() {
+  return createUpDownCounter('active-connections', {
+    description: 'Number of active websocket connections',
+  });
+}
+
+export function activeQueries() {
+  return createUpDownCounter('active-queries', {
+    description: 'Number of active queries',
+  });
+}
+
+export function activeClients() {
+  return createUpDownCounter('active-clients', {
+    description: 'Number of active clients',
+  });
+}
+
+export function activeClientGroups() {
+  return createUpDownCounter('active-client-groups', {
+    description: 'Number of active client groups',
+  });
+}
+
+export function activeViewSyncerInstances() {
+  return createUpDownCounter('active-view-syncer-instances', {
+    description: 'Number of active view syncer instances',
+  });
+}
+
+export function activePusherInstances() {
+  return createUpDownCounter('active-pusher-instances', {
+    description: 'Number of active pusher instances',
+  });
+}
+
+export function activeIvmStorageInstances() {
+  return createUpDownCounter('active-ivm-storage-instances', {
+    description: 'Number of active ivm operator storage instances',
+  });
+}

--- a/packages/zero-cache/src/observability/view-syncer-instruments.ts
+++ b/packages/zero-cache/src/observability/view-syncer-instruments.ts
@@ -1,121 +1,12 @@
 import {metrics, type Meter} from '@opentelemetry/api';
 
+// intentional lazy initialization so it is not started before the SDK is started.
+
 let meter: Meter | undefined;
-function getMeter() {
+
+export function getMeter() {
   if (!meter) {
     meter = metrics.getMeter('view-syncer');
   }
   return meter;
 }
-
-// intentional lazy initialization so it is not started before the SDK is started.
-export default {
-  get counters() {
-    return {
-      replicationEvents: getMeter().createCounter('replication-events', {
-        description: 'Number of replication events processed',
-      }),
-      crudMutations: getMeter().createCounter('crud-mutations', {
-        description: 'Number of CRUD mutations processed',
-      }),
-      customMutations: getMeter().createCounter('custom-mutations', {
-        description: 'Number of custom mutations processed',
-      }),
-      pushes: getMeter().createCounter('pushes', {
-        description: 'Number of pushes processed by the pusher',
-      }),
-      queryHydrations: getMeter().createCounter('query-hydrations', {
-        description: 'Number of query hydrations',
-      }),
-      cvrRowsFlushed: getMeter().createCounter('cvr-rows-flushed', {
-        description: 'Number of rows flushed to all CVRs',
-      }),
-      rowsPoked: getMeter().createCounter('rows-poked', {
-        description: 'Number of rows poked',
-      }),
-      pokeTransactions: getMeter().createCounter('poke-transactions', {
-        description: 'Number of poke transactions (pokeStart,pokeEnd) pairs',
-      }),
-    };
-  },
-
-  get upDownCounters() {
-    return {
-      activeConnections: getMeter().createUpDownCounter('active-connections', {
-        description: 'Number of active websocket connections',
-      }),
-      activeQueries: getMeter().createUpDownCounter('active-queries', {
-        description: 'Number of active queries',
-      }),
-      activeClients: getMeter().createUpDownCounter('active-clients', {
-        description: 'Number of active clients',
-      }),
-      activeClientGroups: getMeter().createUpDownCounter(
-        'active-client-groups',
-        {
-          description: 'Number of active client groups',
-        },
-      ),
-      activeViewSyncerInstances: getMeter().createUpDownCounter(
-        'active-view-syncer-instances',
-        {
-          description: 'Number of active view syncer instances',
-        },
-      ),
-      activePusherInstances: getMeter().createUpDownCounter(
-        'active-pusher-instances',
-        {
-          description: 'Number of active pusher instances',
-        },
-      ),
-      activeIvmStorageInstances: getMeter().createUpDownCounter(
-        'active-ivm-storage-instances',
-        {
-          description: 'Number of active ivm operator storage instances',
-        },
-      ),
-    };
-  },
-
-  get histograms() {
-    return {
-      wsMessageProcessingTime: getMeter().createHistogram(
-        'ws-message-processing-time',
-        {
-          description:
-            'Time to process a websocket message. The `message.type` attribute is set in order to filter by message type.',
-          unit: 'milliseconds',
-        },
-      ),
-      replicationEventProcessingTime: getMeter().createHistogram(
-        'replication-event-processing-time',
-        {
-          description: 'Time to process a replication event.',
-          unit: 'milliseconds',
-        },
-      ),
-      transactionAdvanceTime: getMeter().createHistogram('cg-advance-time', {
-        description:
-          'Time to advance all queries for a given client group after applying a new transaction to the replica.',
-        unit: 'milliseconds',
-      }),
-      changeAdvanceTime: getMeter().createHistogram('change-advance-time', {
-        description:
-          'Time to advance all queries for a given client group for in response to a single change.',
-        unit: 'milliseconds',
-      }),
-      cvrFlushTime: getMeter().createHistogram('cvr-flush-time', {
-        description: 'Time to flush a CVR transaction.',
-        unit: 'milliseconds',
-      }),
-      pokeTime: getMeter().createHistogram('poke-flush-time', {
-        description: 'Time to poke to all clients.',
-        unit: 'milliseconds',
-      }),
-      hydrationTime: getMeter().createHistogram('hydration-time', {
-        description: 'Time to hydrate a query.',
-        unit: 'milliseconds',
-      }),
-    };
-  },
-};

--- a/packages/zero-cache/src/services/mutagen/mutagen.ts
+++ b/packages/zero-cache/src/services/mutagen/mutagen.ts
@@ -26,13 +26,13 @@ import {
 } from '../../auth/write-authorizer.ts';
 import {type ZeroConfig} from '../../config/zero-config.ts';
 import * as Mode from '../../db/mode-enum.ts';
+import * as counters from '../../observability/counters.ts';
 import {ErrorForClient} from '../../types/error-for-client.ts';
 import type {PostgresDB, PostgresTransaction} from '../../types/pg.ts';
 import {throwErrorForClientIfSchemaVersionNotSupported} from '../../types/schema-versions.ts';
 import {appSchema, upstreamSchema, type ShardID} from '../../types/shards.ts';
 import {SlidingWindowLimiter} from '../limiter/sliding-window-limiter.ts';
 import type {Service} from '../service.ts';
-import instruments from '../../observability/view-syncer-instruments.ts';
 
 // An error encountered processing a mutation.
 // Returned back to application for display to user.
@@ -102,7 +102,7 @@ export class MutagenService implements Mutagen, Service {
         'Rate limit exceeded',
       ]);
     }
-    instruments.counters.crudMutations.add(1, {
+    counters.crudMutations().add(1, {
       clientGroupID: this.id,
     });
     return processMutation(

--- a/packages/zero-cache/src/services/mutagen/pusher.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.ts
@@ -14,13 +14,13 @@ import {
   type PushResponse,
 } from '../../../../zero-protocol/src/push.ts';
 import {type ZeroConfig} from '../../config/zero-config.ts';
+import * as counters from '../../observability/counters.ts';
 import {ErrorForClient} from '../../types/error-for-client.ts';
 import {upstreamSchema} from '../../types/shards.ts';
 import type {Source} from '../../types/streams.ts';
 import {Subscription, type Result} from '../../types/subscription.ts';
 import type {HandlerResult, StreamResult} from '../../workers/connection.ts';
 import type {Service} from '../service.ts';
-import instruments from '../../observability/view-syncer-instruments.ts';
 
 type Fatal = {
   error: 'forClient';
@@ -314,10 +314,10 @@ class PushWorker {
   }
 
   async #processPush(entry: PusherEntry): Promise<PushResponse | Fatal> {
-    instruments.counters.customMutations.add(entry.push.mutations.length, {
+    counters.customMutations().add(entry.push.mutations.length, {
       clientGroupID: entry.push.clientGroupID,
     });
-    instruments.counters.pushes.add(1, {
+    counters.pushes().add(1, {
       clientGroupID: entry.push.clientGroupID,
     });
 

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -1,7 +1,7 @@
 import type {LogContext} from '@rocicorp/logger';
 import {Database} from '../../../../zqlite/src/db.ts';
 import {StatementRunner} from '../../db/statements.ts';
-import instruments from '../../observability/view-syncer-instruments.ts';
+import * as counters from '../../observability/counters.ts';
 import type {Source} from '../../types/streams.ts';
 import {
   PROTOCOL_VERSION,
@@ -80,7 +80,7 @@ export class IncrementalSyncer {
         unregister = this.#state.cancelOnStop(downstream);
 
         for await (const message of downstream) {
-          instruments.counters.replicationEvents.add(1);
+          counters.replicationEvents().add(1);
           switch (message[0]) {
             case 'status':
               // Used for checking if a replica can be caught up. Not

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -12,7 +12,8 @@ import {stringCompare} from '../../../../shared/src/string-compare.ts';
 import type {AST} from '../../../../zero-protocol/src/ast.ts';
 import type {ClientSchema} from '../../../../zero-protocol/src/client-schema.ts';
 import {compareTTL} from '../../../../zql/src/query/ttl.ts';
-import instruments from '../../observability/view-syncer-instruments.ts';
+import * as counters from '../../observability/counters.ts';
+import * as histograms from '../../observability/histograms.ts';
 import {stringify, type JSONObject} from '../../types/bigint-json.ts';
 import {ErrorForClient} from '../../types/error-for-client.ts';
 import type {LexiVersion} from '../../types/lexi-version.ts';
@@ -148,8 +149,8 @@ export class CVRUpdater {
       `flushed cvr@${versionString(this._cvr.version)} ` +
         `${JSON.stringify(flushed)} in (${elapsed} ms)`,
     );
-    instruments.counters.cvrRowsFlushed.add(flushed.rows);
-    instruments.histograms.cvrFlushTime.record(elapsed);
+    counters.cvrRowsFlushed().add(flushed.rows);
+    histograms.cvrFlushTime().record(elapsed);
     return {cvr: this._cvr, flushed};
   }
 }

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -24,6 +24,7 @@ import {
 import type {LogConfig} from '../../config/zero-config.ts';
 import {computeZqlSpecs} from '../../db/lite-tables.ts';
 import type {LiteAndZqlSpec, LiteTableSpec} from '../../db/specs.ts';
+import * as histograms from '../../observability/histograms.ts';
 import type {RowKey} from '../../types/row-key.ts';
 import type {SchemaVersions} from '../../types/schema-versions.ts';
 import type {ShardID} from '../../types/shards.ts';
@@ -35,7 +36,6 @@ import {
   Snapshotter,
   type SnapshotDiff,
 } from './snapshotter.ts';
-import instruments from '../../observability/view-syncer-instruments.ts';
 
 export type RowAdd = {
   readonly type: 'add';
@@ -445,7 +445,7 @@ export class PipelineDriver {
       }
 
       const elapsed = performance.now() - start;
-      instruments.histograms.changeAdvanceTime.record(elapsed, {
+      histograms.changeAdvanceTime().record(elapsed, {
         clientGroupID: this.#clientGroupID,
         table,
         type,

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -31,7 +31,8 @@ import type {
 } from '../../../../zero-protocol/src/inspect-up.ts';
 import type {Upstream} from '../../../../zero-protocol/src/up.ts';
 import {transformAndHashQuery} from '../../auth/read-authorizer.ts';
-import instruments from '../../observability/view-syncer-instruments.ts';
+import * as counters from '../../observability/counters.ts';
+import * as histograms from '../../observability/histograms.ts';
 import {stringify} from '../../types/bigint-json.ts';
 import {ErrorForClient, getLogLevel} from '../../types/error-for-client.ts';
 import type {PostgresDB} from '../../types/pg.ts';
@@ -817,12 +818,12 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       );
 
       const elapsed = Date.now() - start;
-      instruments.counters.queryHydrations.add(1, {
+      counters.queryHydrations().add(1, {
         clientGroupID: this.id,
         hash,
         transformationHash,
       });
-      instruments.histograms.hydrationTime.record(elapsed, {
+      histograms.hydrationTime().record(elapsed, {
         clientGroupID: this.id,
         hash,
         transformationHash,
@@ -1291,7 +1292,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       lc.info?.(
         `finished processing advancement of ${numChanges} changes (${elapsed} ms)`,
       );
-      instruments.histograms.transactionAdvanceTime.record(elapsed, {
+      histograms.transactionAdvanceTime().record(elapsed, {
         clientGroupID: this.id,
       });
       return 'success';


### PR DESCRIPTION
Structuring things as export default object prevents tree shaking

And with this refactor it becomes clear that we don't use the up-down counters. I'm leaving it in there for now.