### PR TITLE
feat(zero)!: drop `Schema` information from mutator return

### DIFF
--- a/apps/zbugs/server/server-mutators.ts
+++ b/apps/zbugs/server/server-mutators.ts
@@ -3,8 +3,9 @@ import {
   type CreateIssueArgs,
   type AddEmojiArgs,
   type AddCommentArgs,
+  type MutatorTx,
 } from '../shared/mutators.ts';
-import {type CustomMutatorDefs, type UpdateValue} from '@rocicorp/zero';
+import {type UpdateValue} from '@rocicorp/zero';
 import {schema} from '../shared/schema.ts';
 import {notify} from './notify.ts';
 import {assert} from '../../../packages/shared/src/asserts.ts';
@@ -24,7 +25,7 @@ export function createServerMutators(
     issue: {
       ...mutators.issue,
 
-      async create(tx, {id, title, description}: CreateIssueArgs) {
+      async create(tx: MutatorTx, {id, title, description}: CreateIssueArgs) {
         await mutators.issue.create(tx, {
           id,
           title,
@@ -41,7 +42,7 @@ export function createServerMutators(
       },
 
       async update(
-        tx,
+        tx: MutatorTx,
         args: {id: string} & UpdateValue<typeof schema.tables.issue>,
       ) {
         const oldIssue = await tx.query.issue.where('id', args.id).one();
@@ -74,7 +75,7 @@ export function createServerMutators(
       },
 
       async addLabel(
-        tx,
+        tx: MutatorTx,
         {issueID, labelID}: {issueID: string; labelID: string},
       ) {
         await mutators.issue.addLabel(tx, {issueID, labelID});
@@ -91,7 +92,7 @@ export function createServerMutators(
       },
 
       async removeLabel(
-        tx,
+        tx: MutatorTx,
         {issueID, labelID}: {issueID: string; labelID: string},
       ) {
         await mutators.issue.removeLabel(tx, {issueID, labelID});
@@ -111,7 +112,7 @@ export function createServerMutators(
     emoji: {
       ...mutators.emoji,
 
-      async addToIssue(tx, args: AddEmojiArgs) {
+      async addToIssue(tx: MutatorTx, args: AddEmojiArgs) {
         await mutators.emoji.addToIssue(tx, {
           ...args,
           created: Date.now(),
@@ -128,7 +129,7 @@ export function createServerMutators(
         );
       },
 
-      async addToComment(tx, args: AddEmojiArgs) {
+      async addToComment(tx: MutatorTx, args: AddEmojiArgs) {
         await mutators.emoji.addToComment(tx, {
           ...args,
           created: Date.now(),
@@ -155,7 +156,7 @@ export function createServerMutators(
     comment: {
       ...mutators.comment,
 
-      async add(tx, {id, issueID, body}: AddCommentArgs) {
+      async add(tx: MutatorTx, {id, issueID, body}: AddCommentArgs) {
         await mutators.comment.add(tx, {
           id,
           issueID,
@@ -175,7 +176,7 @@ export function createServerMutators(
         );
       },
 
-      async edit(tx, {id, body}: {id: string; body: string}) {
+      async edit(tx: MutatorTx, {id, body}: {id: string; body: string}) {
         await mutators.comment.edit(tx, {id, body});
 
         const comment = await tx.query.comment.where('id', id).one();
@@ -194,5 +195,5 @@ export function createServerMutators(
         );
       },
     },
-  } as const satisfies CustomMutatorDefs<typeof schema>;
+  } as const;
 }

--- a/packages/zero-client/src/client/custom.ts
+++ b/packages/zero-client/src/client/custom.ts
@@ -32,12 +32,14 @@ import type {ZeroLogContext} from './zero-log-context.ts';
 /**
  * The shape which a user's custom mutator definitions must conform to.
  */
-export type CustomMutatorDefs<S extends Schema> = {
+export type CustomMutatorDefs = {
   [namespaceOrKey: string]:
     | {
-        [key: string]: CustomMutatorImpl<S>;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        [key: string]: CustomMutatorImpl<any>;
       }
-    | CustomMutatorImpl<S>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    | CustomMutatorImpl<any>;
 };
 
 export type MutatorResult = {
@@ -62,7 +64,7 @@ export type CustomMutatorImpl<S extends Schema, TArgs = any> = (
  */
 export type MakeCustomMutatorInterfaces<
   S extends Schema,
-  MD extends CustomMutatorDefs<S>,
+  MD extends CustomMutatorDefs,
 > = {
   readonly [NamespaceOrName in keyof MD]: MD[NamespaceOrName] extends (
     tx: Transaction<S>,

--- a/packages/zero-client/src/client/options.ts
+++ b/packages/zero-client/src/client/options.ts
@@ -13,7 +13,7 @@ import {UpdateNeededReasonType} from './update-needed-reason-type.ts';
  */
 export interface ZeroOptions<
   S extends Schema,
-  MD extends CustomMutatorDefs<S> | undefined = undefined,
+  MD extends CustomMutatorDefs | undefined = undefined,
 > {
   /**
    * URL to the zero-cache. This can be a simple hostname, e.g.
@@ -235,7 +235,7 @@ export interface ZeroOptions<
  */
 export interface ZeroAdvancedOptions<
   S extends Schema,
-  MD extends CustomMutatorDefs<S> | undefined = undefined,
+  MD extends CustomMutatorDefs | undefined = undefined,
 > extends ZeroOptions<S, MD> {}
 
 export type UpdateNeededReason =

--- a/packages/zero-client/src/client/test-utils.ts
+++ b/packages/zero-client/src/client/test-utils.ts
@@ -82,7 +82,7 @@ export class MockSocket extends EventTarget {
 
 export class TestZero<
   const S extends Schema,
-  MD extends CustomMutatorDefs<S> | undefined = undefined,
+  MD extends CustomMutatorDefs | undefined = undefined,
 > extends Zero<S, MD> {
   pokeIDCounter = 0;
 
@@ -278,7 +278,7 @@ let testZeroCounter = 0;
 
 export function zeroForTest<
   const S extends Schema,
-  MD extends CustomMutatorDefs<S> | undefined = undefined,
+  MD extends CustomMutatorDefs | undefined = undefined,
 >(
   options: Partial<ZeroOptions<S, MD>> = {},
   errorOnUpdateNeeded = true,

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -69,6 +69,7 @@ import {
   PULL_TIMEOUT_MS,
   RUN_LOOP_INTERVAL_MS,
 } from './zero.ts';
+import type {Transaction} from '../../../zql/src/mutate/custom.ts';
 
 const startTime = 1678829450000;
 
@@ -812,7 +813,7 @@ describe('initConnection', () => {
 
   async function zeroForTestWithDeletedClients<
     const S extends Schema,
-    MD extends CustomMutatorDefs<S> = CustomMutatorDefs<S>,
+    MD extends CustomMutatorDefs = CustomMutatorDefs,
   >(
     options: Partial<ZeroOptions<S, MD>> & {
       deletedClients?: ClientID[] | undefined;
@@ -3320,10 +3321,10 @@ test('custom mutations get pushed', async () => {
     schema,
     mutators: {
       issues: {
-        foo: (tx, {foo}: {foo: number}) =>
+        foo: (tx: Transaction<typeof schema>, {foo}: {foo: number}) =>
           tx.mutate.issues.insert({id: foo.toString(), value: foo}),
       },
-    } as const satisfies CustomMutatorDefs<typeof schema>,
+    } as const,
   });
   await z.triggerConnected();
   const mockSocket = await z.socket;

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -174,10 +174,9 @@ interface TestZero {
   }) => LogOptions;
 }
 
-function asTestZero<
-  S extends Schema,
-  MD extends CustomMutatorDefs<S> | undefined,
->(z: Zero<S, MD>): TestZero {
+function asTestZero<S extends Schema, MD extends CustomMutatorDefs | undefined>(
+  z: Zero<S, MD>,
+): TestZero {
   return z as TestZero;
 }
 
@@ -272,7 +271,7 @@ type CloseCode = typeof CLOSE_CODE_NORMAL | typeof CLOSE_CODE_GOING_AWAY;
 
 export class Zero<
   const S extends Schema,
-  MD extends CustomMutatorDefs<S> | undefined = undefined,
+  MD extends CustomMutatorDefs | undefined = undefined,
 > {
   readonly version = version;
 
@@ -513,7 +512,7 @@ export class Zero<
             assertUnique(key);
             replicacheMutators[key] = makeReplicacheMutator(
               lc,
-              mutator as CustomMutatorImpl<S>,
+              mutator as CustomMutatorImpl<Schema>,
               schema,
               slowMaterializeThreshold,
             ) as () => MutatorReturn;
@@ -785,7 +784,7 @@ export class Zero<
    * await zero.mutate.issue.update({id: '1', title: 'Updated title'});
    * ```
    */
-  readonly mutate: MD extends CustomMutatorDefs<S>
+  readonly mutate: MD extends CustomMutatorDefs
     ? DeepMerge<DBMutator<S>, MakeCustomMutatorInterfaces<S, MD>>
     : DBMutator<S>;
 

--- a/packages/zero-pg/src/custom.test.ts
+++ b/packages/zero-pg/src/custom.test.ts
@@ -1,10 +1,9 @@
 import {expectTypeOf, test} from 'vitest';
 import type {CustomMutatorDefs} from './custom.ts';
 import type {CustomMutatorDefs as CustomMutatorClientDefs} from '../../zero-client/src/client/custom.ts';
-import type {Schema} from '../../zero-schema/src/builder/schema-builder.ts';
 
 test('server mutator type is compatible with client mutator type', () => {
-  expectTypeOf<CustomMutatorDefs<unknown>>().toExtend<
-    CustomMutatorClientDefs<Schema>
-  >();
+  expectTypeOf<
+    CustomMutatorDefs<unknown>
+  >().toExtend<CustomMutatorClientDefs>();
 });

--- a/packages/zero-react/src/use-zero.tsx
+++ b/packages/zero-react/src/use-zero.tsx
@@ -8,7 +8,7 @@ const ZeroContext = createContext<unknown | undefined>(undefined);
 
 export function useZero<
   S extends Schema,
-  MD extends CustomMutatorDefs<S> | undefined = undefined,
+  MD extends CustomMutatorDefs | undefined = undefined,
 >(): Zero<S, MD> {
   const zero = useContext(ZeroContext);
   if (zero === undefined) {
@@ -19,14 +19,14 @@ export function useZero<
 
 export function createUseZero<
   S extends Schema,
-  MD extends CustomMutatorDefs<S> | undefined = undefined,
+  MD extends CustomMutatorDefs | undefined = undefined,
 >() {
   return () => useZero<S, MD>();
 }
 
 export function ZeroProvider<
   S extends Schema,
-  MD extends CustomMutatorDefs<S> | undefined = undefined,
+  MD extends CustomMutatorDefs | undefined = undefined,
 >({children, zero}: {children: React.ReactNode; zero: Zero<S, MD>}) {
   return <ZeroContext.Provider value={zero}>{children}</ZeroContext.Provider>;
 }

--- a/packages/zero-solid/src/create-zero.ts
+++ b/packages/zero-solid/src/create-zero.ts
@@ -6,7 +6,7 @@ import {
   type ZeroOptions,
 } from '../../zero/src/zero.ts';
 
-export function createZero<S extends Schema, MD extends CustomMutatorDefs<S>>(
+export function createZero<S extends Schema, MD extends CustomMutatorDefs>(
   options: ZeroOptions<S, MD>,
 ): Zero<S, MD> {
   const opts = {


### PR DESCRIPTION
Solves "type too deep" errors.

https://discord.com/channels/830183651022471199/1375464099252666460/1375464102620565637

The type of the `tx` argument for `Mutators` does not need to be exposed to callers (it is only called internally by Zero). Drop it.

This does now require custom mutator definitions to explicitly type their transaction argument. Done here via `MutatorTx` in `zbugs`.