### PR TITLE
chore(zero): implement call to transform custom queries

### DIFF
--- a/packages/zero-cache/src/custom-queries/transform-query.test.ts
+++ b/packages/zero-cache/src/custom-queries/transform-query.test.ts
@@ -1,0 +1,252 @@
+import {
+  describe,
+  expect,
+  vi,
+  beforeEach,
+  type MockedFunction,
+  test,
+} from 'vitest';
+import {transformCustomQueries} from './transform-query.ts';
+import {fetchFromAPIServer} from '../custom/fetch.ts';
+import type {CustomQueryRecord} from '../services/view-syncer/schema/types.ts';
+import type {ShardID} from '../types/shards.ts';
+import type {TransformResponseMessage} from '../../../zero-protocol/src/custom-queries.ts';
+
+// Mock the fetchFromAPIServer function
+vi.mock('../custom/fetch.ts');
+const mockFetchFromAPIServer = fetchFromAPIServer as MockedFunction<
+  typeof fetchFromAPIServer
+>;
+
+describe('transformCustomQueries', () => {
+  const mockShard: ShardID = {
+    appID: 'test_app',
+    shardNum: 1,
+  };
+
+  const pullUrl = 'https://api.example.com/pull';
+  const headerOptions = {
+    apiKey: 'test-api-key',
+    token: 'test-token',
+  };
+
+  const mockQueries: CustomQueryRecord[] = [
+    {
+      id: 'query1',
+      type: 'custom',
+      name: 'getUserById',
+      args: [123],
+      clientState: {},
+    },
+    {
+      id: 'query2',
+      type: 'custom',
+      name: 'getPostsByUser',
+      args: ['user123', 10],
+      clientState: {},
+    },
+  ];
+
+  beforeEach(() => {
+    mockFetchFromAPIServer.mockReset();
+  });
+
+  test('should transform queries successfully and return TransformedAndHashed array', async () => {
+    const mockSuccessResponse = new Response(
+      JSON.stringify([
+        'transformed',
+        [
+          {
+            id: 'hash1',
+            name: 'getUserById',
+            ast: {
+              table: 'users',
+              where: {
+                type: 'simple',
+                op: '=',
+                left: {type: 'column', name: 'id'},
+                right: {type: 'literal', value: 123},
+              },
+            },
+          },
+          {
+            id: 'hash2',
+            name: 'getPostsByUser',
+            ast: {
+              table: 'posts',
+              where: {
+                type: 'simple',
+                op: '=',
+                left: {type: 'column', name: 'userId'},
+                right: {type: 'literal', value: 'user123'},
+              },
+            },
+          },
+        ],
+      ] satisfies TransformResponseMessage),
+      {status: 200},
+    );
+
+    mockFetchFromAPIServer.mockResolvedValue(mockSuccessResponse);
+
+    const result = await transformCustomQueries(
+      pullUrl,
+      mockShard,
+      headerOptions,
+      mockQueries,
+    );
+
+    // Verify the API was called correctly
+    expect(mockFetchFromAPIServer).toHaveBeenCalledWith(
+      pullUrl,
+      mockShard,
+      headerOptions,
+      undefined,
+      [
+        'transform',
+        [
+          {id: 'query1', name: 'getUserById', args: [123]},
+          {id: 'query2', name: 'getPostsByUser', args: ['user123', 10]},
+        ],
+      ],
+    );
+
+    // Verify the result
+    expect(result).toEqual([
+      {
+        query: {
+          table: 'users',
+          where: {
+            type: 'simple',
+            op: '=',
+            left: {type: 'column', name: 'id'},
+            right: {type: 'literal', value: 123},
+          },
+        },
+        hash: 'hash1',
+      },
+      {
+        query: {
+          table: 'posts',
+          where: {
+            type: 'simple',
+            op: '=',
+            left: {type: 'column', name: 'userId'},
+            right: {type: 'literal', value: 'user123'},
+          },
+        },
+        hash: 'hash2',
+      },
+    ]);
+  });
+
+  test('should handle errored queries in response', async () => {
+    const mockMixedResponse = new Response(
+      JSON.stringify([
+        'transformed',
+        [
+          {
+            id: 'hash1',
+            name: 'getUserById',
+            ast: {
+              table: 'users',
+              where: {
+                type: 'simple',
+                op: '=',
+                left: {type: 'column', name: 'id'},
+                right: {type: 'literal', value: 123},
+              },
+            },
+          },
+          {
+            error: 'app',
+            id: 'query2',
+            name: 'getPostsByUser',
+            details: 'Query syntax error',
+          },
+        ],
+      ] satisfies TransformResponseMessage),
+      {status: 200},
+    );
+
+    mockFetchFromAPIServer.mockResolvedValue(mockMixedResponse);
+
+    const result = await transformCustomQueries(
+      pullUrl,
+      mockShard,
+      headerOptions,
+      mockQueries,
+    );
+
+    expect(result).toEqual([
+      {
+        query: {
+          table: 'users',
+          where: {
+            type: 'simple',
+            op: '=',
+            left: {type: 'column', name: 'id'},
+            right: {type: 'literal', value: 123},
+          },
+        },
+        hash: 'hash1',
+      },
+      {
+        error: 'app',
+        id: 'query2',
+        name: 'getPostsByUser',
+        details: 'Query syntax error',
+      },
+    ]);
+  });
+
+  test('should return HttpError when fetch response is not ok', async () => {
+    const mockErrorResponse = new Response(
+      'Bad Request: Invalid query format',
+      {
+        status: 400,
+      },
+    );
+
+    mockFetchFromAPIServer.mockResolvedValue(mockErrorResponse);
+
+    const result = await transformCustomQueries(
+      pullUrl,
+      mockShard,
+      headerOptions,
+      mockQueries,
+    );
+
+    expect(result).toEqual({
+      error: 'http',
+      status: 400,
+      details: 'Bad Request: Invalid query format',
+    });
+  });
+
+  test('should handle empty queries array', async () => {
+    const mockSuccessResponse = new Response(
+      JSON.stringify(['transformed', []]),
+      {status: 200},
+    );
+
+    mockFetchFromAPIServer.mockResolvedValue(mockSuccessResponse);
+
+    const result = await transformCustomQueries(
+      pullUrl,
+      mockShard,
+      headerOptions,
+      [],
+    );
+
+    expect(mockFetchFromAPIServer).toHaveBeenCalledWith(
+      pullUrl,
+      mockShard,
+      headerOptions,
+      undefined,
+      ['transform', []],
+    );
+
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/zero-cache/src/custom-queries/transform-query.ts
+++ b/packages/zero-cache/src/custom-queries/transform-query.ts
@@ -1,0 +1,59 @@
+import type {TransformedAndHashed} from '../auth/read-authorizer.ts';
+import type {CustomQueryRecord} from '../services/view-syncer/schema/types.ts';
+import {
+  transformResponseMessageSchema,
+  type ErroredQuery,
+  type TransformRequestBody,
+  type TransformRequestMessage,
+} from '../../../zero-protocol/src/custom-queries.ts';
+import {fetchFromAPIServer, type HeaderOptions} from '../custom/fetch.ts';
+import type {ShardID} from '../types/shards.ts';
+import * as v from '../../../shared/src/valita.ts';
+
+type HttpError = {
+  error: 'http';
+  status: number;
+  details: string;
+};
+
+export async function transformCustomQueries(
+  pullUrl: string,
+  shard: ShardID,
+  headerOptions: HeaderOptions,
+  queries: CustomQueryRecord[],
+): Promise<(TransformedAndHashed | ErroredQuery)[] | HttpError> {
+  const request: TransformRequestBody = queries.map(query => ({
+    id: query.id,
+    name: query.name,
+    args: query.args,
+  }));
+
+  const response = await fetchFromAPIServer(
+    pullUrl,
+    shard,
+    headerOptions,
+    undefined,
+    ['transform', request] satisfies TransformRequestMessage,
+  );
+
+  if (!response.ok) {
+    return {
+      error: 'http',
+      status: response.status,
+      details: await response.text(),
+    };
+  }
+
+  const body = await response.json();
+  const msg = v.parse(body, transformResponseMessageSchema);
+
+  return msg[1].map(transformed => {
+    if ('error' in transformed) {
+      return transformed;
+    }
+    return {
+      query: transformed.ast,
+      hash: transformed.id,
+    } satisfies TransformedAndHashed;
+  });
+}

--- a/packages/zero-cache/src/custom/fetch.ts
+++ b/packages/zero-cache/src/custom/fetch.ts
@@ -5,7 +5,7 @@ import {ErrorForClient} from '../types/error-for-client.ts';
 import {ErrorKind} from '../../../zero-protocol/src/error-kind.ts';
 
 const reservedParams = ['schema', 'appID'];
-type HeaderOptions = {
+export type HeaderOptions = {
   apiKey?: string | undefined;
   token?: string | undefined;
 };

--- a/packages/zero-cache/src/services/view-syncer/schema/types.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/types.ts
@@ -1,3 +1,4 @@
+import {jsonSchema} from '../../../../../shared/src/json-schema.ts';
 import * as v from '../../../../../shared/src/valita.ts';
 import {astSchema} from '../../../../../zero-protocol/src/ast.ts';
 import {jsonValueSchema} from '../../../types/bigint-json.ts';
@@ -212,7 +213,7 @@ export type ClientQueryRecord = v.Infer<typeof clientQueryRecordSchema>;
 export const customQueryRecordSchema = externalQueryRecordSchema.extend({
   type: v.literal('custom'),
   name: v.string(),
-  args: jsonValueSchema,
+  args: v.readonly(v.array(jsonSchema)),
 });
 
 export type CustomQueryRecord = v.Infer<typeof customQueryRecordSchema>;

--- a/packages/zero-protocol/src/custom-queries.ts
+++ b/packages/zero-protocol/src/custom-queries.ts
@@ -6,9 +6,10 @@ export const transformRequestBodySchema = v.array(
   v.object({
     id: v.string(),
     name: v.string(),
-    args: v.array(jsonSchema),
+    args: v.readonly(v.array(jsonSchema)),
   }),
 );
+export type TransformRequestBody = v.Infer<typeof transformRequestBodySchema>;
 
 export const transformedQuerySchema = v.object({
   id: v.string(),
@@ -22,6 +23,7 @@ export const erroredQuerySchema = v.object({
   name: v.string(),
   details: jsonSchema,
 });
+export type ErroredQuery = v.Infer<typeof erroredQuerySchema>;
 
 export const transformResponseBodySchema = v.array(
   v.union(transformedQuerySchema, erroredQuerySchema),
@@ -31,7 +33,14 @@ export const transformRequestMessageSchema = v.tuple([
   v.literal('transform'),
   transformRequestBodySchema,
 ]);
+export type TransformRequestMessage = v.Infer<
+  typeof transformRequestMessageSchema
+>;
+
 export const transformResponseMessageSchema = v.tuple([
   v.literal('transformed'),
   transformResponseBodySchema,
 ]);
+export type TransformResponseMessage = v.Infer<
+  typeof transformResponseMessageSchema
+>;


### PR DESCRIPTION
The view-syncer will call this function whenever it encounters custom queries.

It'll try to batch those custom queries together for a single call to the API server.