### PR TITLE
chore(zero-cache): rename TransformedAndHashed fields

### DIFF
--- a/packages/analyze-query/src/bin-analyze.ts
+++ b/packages/analyze-query/src/bin-analyze.ts
@@ -230,7 +230,13 @@ async function runAst(
         ),
       );
     }
-    ast = transformAndHashQuery(lc, ast, permissions, authData, false).query;
+    ast = transformAndHashQuery(
+      lc,
+      ast,
+      permissions,
+      authData,
+      false,
+    ).transformedAst;
     console.log(chalk.blue.bold('\n\n=== Query After Permissions: ===\n'));
     console.log(await formatOutput(ast.table + astToZQL(ast)));
   }

--- a/packages/analyze-query/src/bin-transform.ts
+++ b/packages/analyze-query/src/bin-transform.ts
@@ -53,7 +53,7 @@ const queryAst = transformAndHashQuery(
   permissions,
   {},
   rows[0].internal,
-).query;
+).transformedAst;
 
 console.log('\n=== AST ===\n');
 console.log(JSON.stringify(queryAst, null, 2));

--- a/packages/zero-cache/src/auth/read-authorizer.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.ts
@@ -8,8 +8,8 @@ import type {LogContext} from '@rocicorp/logger';
 import {simplifyCondition} from '../../../zql/src/query/expression.ts';
 
 export type TransformedAndHashed = {
-  query: AST;
-  hash: string;
+  transformedAst: AST;
+  transformationHash: string;
 };
 /**
  * Adds permission rules to the given query so it only returns rows that the
@@ -31,8 +31,8 @@ export function transformAndHashQuery(
     ? query // application permissions do not apply to internal queries
     : transformQuery(lc, query, permissionRules, authData);
   return {
-    query: transformed,
-    hash: hashOfAST(transformed),
+    transformedAst: transformed,
+    transformationHash: hashOfAST(transformed),
   };
 }
 

--- a/packages/zero-cache/src/custom-queries/transform-query.test.ts
+++ b/packages/zero-cache/src/custom-queries/transform-query.test.ts
@@ -114,7 +114,7 @@ describe('transformCustomQueries', () => {
     // Verify the result
     expect(result).toEqual([
       {
-        query: {
+        transformedAst: {
           table: 'users',
           where: {
             type: 'simple',
@@ -123,10 +123,10 @@ describe('transformCustomQueries', () => {
             right: {type: 'literal', value: 123},
           },
         },
-        hash: 'hash1',
+        transformationHash: '2q4jya9umt1i2',
       },
       {
-        query: {
+        transformedAst: {
           table: 'posts',
           where: {
             type: 'simple',
@@ -135,7 +135,7 @@ describe('transformCustomQueries', () => {
             right: {type: 'literal', value: 'user123'},
           },
         },
-        hash: 'hash2',
+        transformationHash: 'ofy7rz1vol9y',
       },
     ]);
   });
@@ -180,7 +180,7 @@ describe('transformCustomQueries', () => {
 
     expect(result).toEqual([
       {
-        query: {
+        transformedAst: {
           table: 'users',
           where: {
             type: 'simple',
@@ -189,7 +189,7 @@ describe('transformCustomQueries', () => {
             right: {type: 'literal', value: 123},
           },
         },
-        hash: 'hash1',
+        transformationHash: '2q4jya9umt1i2',
       },
       {
         error: 'app',

--- a/packages/zero-cache/src/custom-queries/transform-query.ts
+++ b/packages/zero-cache/src/custom-queries/transform-query.ts
@@ -9,6 +9,7 @@ import {
 import {fetchFromAPIServer, type HeaderOptions} from '../custom/fetch.ts';
 import type {ShardID} from '../types/shards.ts';
 import * as v from '../../../shared/src/valita.ts';
+import {hashOfAST} from '../../../zero-protocol/src/ast-hash.ts';
 
 type HttpError = {
   error: 'http';
@@ -52,8 +53,8 @@ export async function transformCustomQueries(
       return transformed;
     }
     return {
-      query: transformed.ast,
-      hash: transformed.id,
+      transformedAst: transformed.ast,
+      transformationHash: hashOfAST(transformed.ast),
     } satisfies TransformedAndHashed;
   });
 }

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -780,7 +780,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         continue; // No longer desired.
       }
 
-      const {query: transformedAst, hash: newTransformationHash} =
+      const {transformedAst, transformationHash: newTransformationHash} =
         transformAndHashQuery(
           lc,
           ast,
@@ -856,7 +856,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           q.type !== 'custom',
           'custom queries are not yet supported in syncQueryPipelineSet',
         );
-        const {query: ast, hash: transformationHash} = transformAndHashQuery(
+        const {transformedAst: ast, transformationHash} = transformAndHashQuery(
           lc,
           q.ast,
           must(this.#pipelines.currentPermissions()).permissions ?? {


### PR DESCRIPTION
We use the name `ast` instead of `query` in the view syncer. Also be clear about which hash this is as future versions of the code will include the original hash in the response as well.