### PR TITLE
chore(zql): named/custom query wrapper

### DIFF
--- a/packages/zql/src/query/named.test.ts
+++ b/packages/zql/src/query/named.test.ts
@@ -1,0 +1,52 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {expect, expectTypeOf, test} from 'vitest';
+import {schema} from './test/test-schemas.ts';
+import {query, type NamedQuery} from './named.ts';
+import {StaticQuery} from './static-query.ts';
+import {ast, defaultFormat} from './query-impl.ts';
+
+test('defining a named query', () => {
+  const named = query(schema, 'issue', (tx, id: string) =>
+    tx.issue.where('id', id),
+  );
+  expectTypeOf(named).toEqualTypeOf<NamedQuery<typeof schema, [string]>>();
+  check(named);
+});
+
+test('binding query to a schema', () => {
+  const bound = query.bindTo(schema);
+
+  const named = bound('issue', (tx, id: string) => tx.issue.where('id', id));
+
+  expectTypeOf(named).toEqualTypeOf<NamedQuery<typeof schema, [string]>>();
+  check(named);
+});
+
+function check(named: NamedQuery<typeof schema, [string]>) {
+  const r = named(
+    {
+      issue: new StaticQuery(schema, 'issue', {table: 'issue'}, defaultFormat),
+    } as any,
+    '123',
+  );
+
+  expect(r.name).toBe('issue');
+  expect(r.args).toEqual(['123']);
+  expect(ast(r.query)).toMatchInlineSnapshot(`
+    {
+      "table": "issue",
+      "where": {
+        "left": {
+          "name": "id",
+          "type": "column",
+        },
+        "op": "=",
+        "right": {
+          "type": "literal",
+          "value": "123",
+        },
+        "type": "simple",
+      },
+    }
+  `);
+}

--- a/packages/zql/src/query/named.ts
+++ b/packages/zql/src/query/named.ts
@@ -1,0 +1,42 @@
+import type {ReadonlyJSONValue} from '../../../shared/src/json.ts';
+import type {Schema} from '../../../zero-schema/src/builder/schema-builder.ts';
+import type {SchemaQuery} from '../mutate/custom.ts';
+import type {Query} from './query.ts';
+
+export type NamedQuery<
+  S extends Schema,
+  TArg extends ReadonlyArray<ReadonlyJSONValue> = ReadonlyJSONValue[],
+> = (
+  tx: SchemaQuery<S>,
+  ...args: TArg
+) => {
+  name: string;
+  args: TArg;
+  query: Query<S, keyof S['tables'] & string>;
+};
+
+type NamedQueryFunc<
+  S extends Schema,
+  TArg extends ReadonlyArray<ReadonlyJSONValue> = ReadonlyJSONValue[],
+> = (tx: SchemaQuery<S>, ...arg: TArg) => Query<S, keyof S['tables'] & string>;
+
+export function query<
+  S extends Schema,
+  TArg extends ReadonlyArray<ReadonlyJSONValue> = ReadonlyJSONValue[],
+>(_s: S, name: string, fn: NamedQueryFunc<S, TArg>): NamedQuery<S, TArg> {
+  return function queryWrapper(tx: SchemaQuery<S>, ...args: TArg) {
+    return {
+      name,
+      args,
+      query: fn(tx, ...args),
+    };
+  };
+}
+
+query.bindTo =
+  <S extends Schema>(s: S) =>
+  <TArg extends ReadonlyArray<ReadonlyJSONValue> = ReadonlyJSONValue[]>(
+    name: string,
+    fn: NamedQueryFunc<S, TArg>,
+  ): NamedQuery<S, TArg> =>
+    query(s, name, fn);


### PR DESCRIPTION
```ts
const q = query.bindTo(schema);

q('issue', (tx, id: string) => tx.issue.where('id', id));

// or

query(schema, 'issue', (tx, id: string) => tx.issue.where('id', id));
```

The API is expected to evolve as I start using it in zbugs and other places.