### PR TITLE
feat(analyze-query): add --output-vended-rows and --output-synced-rows options

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -277,9 +277,7 @@ export class PipelineDriver {
       },
     });
 
-    if (runtimeDebugFlags.trackRowsVended) {
-      runtimeDebugStats.resetRowsVended(this.#clientGroupID);
-    }
+    runtimeDebugStats.resetRowsVended(this.#clientGroupID);
 
     yield* hydrate(input, hash, this.#tableSpecs);
 
@@ -293,7 +291,8 @@ export class PipelineDriver {
         for (const tableName of this.#tables.keys()) {
           const entires = [
             ...(runtimeDebugStats
-              .getRowsVended(this.#clientGroupID)
+              .getVendedRowCounts()
+              .get(this.#clientGroupID)
               ?.get(tableName)
               ?.entries() ?? []),
           ];
@@ -305,8 +304,8 @@ export class PipelineDriver {
         }
         lc.info?.(`Total rows considered: ${totalRowsConsidered}`);
       }
-      runtimeDebugStats.resetRowsVended(this.#clientGroupID);
     }
+    runtimeDebugStats.resetRowsVended(this.#clientGroupID);
 
     // Note: This hydrationTime is a wall-clock overestimate, as it does
     // not take time slicing into account. The view-syncer resets this

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -282,7 +282,7 @@ export class PipelineDriver {
     yield* hydrate(input, hash, this.#tableSpecs);
 
     const hydrationTimeMs = timer.totalElapsed();
-    if (runtimeDebugFlags.trackRowsVended) {
+    if (runtimeDebugFlags.trackRowCountsVended) {
       if (hydrationTimeMs > 200) {
         let totalRowsConsidered = 0;
         const lc = this.#lc

--- a/packages/zqlite/src/table-source.ts
+++ b/packages/zqlite/src/table-source.ts
@@ -43,7 +43,7 @@ import type {Stream} from '../../zql/src/ivm/stream.ts';
 import {Database, Statement} from './db.ts';
 import {compile, format, sql} from './internal/sql.ts';
 import {StatementCache} from './internal/statement-cache.ts';
-import {runtimeDebugFlags, runtimeDebugStats} from './runtime-debug.ts';
+import {runtimeDebugStats} from './runtime-debug.ts';
 
 type Statements = {
   readonly cache: StatementCache;
@@ -321,10 +321,14 @@ export class TableSource implements Source {
         if (result.done) {
           break;
         }
-        if (runtimeDebugFlags.trackRowsVended) {
-          runtimeDebugStats.rowVended(this.#clientGroupID, this.#table, query);
-        }
-        yield fromSQLiteTypes(valueTypes, result.value);
+        const row = fromSQLiteTypes(valueTypes, result.value);
+        runtimeDebugStats.rowVended(
+          this.#clientGroupID,
+          this.#table,
+          query,
+          row,
+        );
+        yield row;
       } while (!result.done);
     } finally {
       rowIterator.return?.();


### PR DESCRIPTION
Default to false.

These are useful for understanding if a query is returning the expected results, and how the query is working.  

Output looks like

```
greg zero [grgbkr/analayze-debug]$ node out/analyze-query/src/bin-analyze.js --replica-file /tmp/zbugs-sync-replica.db   --schema-path='../../apps/zbugs/shared/schema.ts' --query='issue.related("comments").limit(5)' --apply-permissions --auth-data='{"userId":"user-123"}' --output-vended-rows --output-synced-rows
[MISSING_ENV_FILE] missing .env file (/Users/greg/github/mono/packages/zero/.env)
[MISSING_ENV_FILE] https://github.com/dotenvx/dotenvx/issues/484
[dotenvx@1.39.0] injecting env (0)


=== Query After Permissions: ===

issue
  .where(({ and, cmp, or }) =>
    or(
      and(cmp(null, "IS NOT", null), cmp(null, "crew")),
      cmp("visibility", "public"),
    ),
  )
  .related("comments", (q) => q.orderBy("id", "asc"))
  .orderBy("id", "asc")
  .limit(5)



=== Synced rows: ===

issue: [
  {
    id: '-Thbh2750u8nQUnsjkl2X',
    shortID: 1781,
    title: 'AST `field` should be split into `table` and `column` parts',
    open: false,
    modified: 1716564468000,
    created: 1715198543000,
    creatorID: 'tDY6IbKdVqbBlRBc3XMwF',
    assigneeID: null,
    description: 'All `fields` should be tuples of `table`, `column` -- https://github.com/rocicorp/mono/blob/main/packages/zql/src/ast/ast.ts#L19\n' +
      '\n' +
      'Right now we encode table + column via a dot in the string.',
    visibility: 'public'
  },
  {
    id: '-aHMbMcRa-52TSNraxxyB',
    shortID: 6,
    title: 'Move @rocicorp/licensing into this repo',
    open: true,
    modified: 1677093343000,
    created: 1676884917000,
    creatorID: 'nqYkxAGMnzk7Y5STjZryV',
    assigneeID: null,
    description: '`@rocicorp/licensing` is a private npm package and we need to pass in the NPM_TOKEN to the GitHub Actions runners. Moving this into the mono repo would simplify that.',
    visibility: 'public'
  },
  {
    id: '-f91Mdf0XQuX8XPPi9swV',
    shortID: 470,
    title: 'Remove allowUnconfirmedWrites option',
    open: true,
    modified: 1709537612000,
    created: 1681411313000,
    creatorID: 'nqYkxAGMnzk7Y5STjZryV',
    assigneeID: null,
    description: 'We should not expose this in the API. It is not safe?',
    visibility: 'public'
  },
  {
    id: '-guR4swz7EX7CeNnEQI3P',
    shortID: 25,
    title: 'ExperimentalKVStore: Move withRead/withWrite to Replicache',
    open: true,
    modified: 1677090671000,
    created: 1630665606000,
    creatorID: 'OeVnr1y5bEM_Yg06sUFtD',
    assigneeID: null,
    description: 'Why do clients have to implement this? It seems like given read(), write(), and release(), we can do this ourselves.',
    visibility: 'public'
  },
  {
    id: '-hS3eXkArDXIEBbRliAbq',
    shortID: 84,
    title: 'An error in persist prevents future persists from being scheduled',
    open: false,
    modified: 1677091441000,
    created: 1661304014000,
    creatorID: 'Gg4MskWt3M-ttzzlrJ9jn',
    assigneeID: null,
    description: 'In replicache.ts we have:\n' +
      '\n' +
      '```\n' +
      '  private _schedulePersist(): void {\n' +
      '    if (this._persistIsScheduled) {\n' +
      '      return;\n' +
      '    }\n' +
      '    this._persistIsScheduled = true;\n' +
      '    void (async () => {\n' +
      '      await requestIdle(PERSIST_TIMEOUT);\n' +
      '      await this._persist();\n' +
      '      this._persistIsScheduled = false;\n' +
      '    })();\n' +
      '  }\n' +
      '```\n' +
      '\n' +
      'If `this._persist()` throws an error `this._persistIsScheduled` is not reset to false, and no future persists will be scheduled.  `this._persistIsScheduled ` should be reset to false in a finally.\n' +
      '\n' +
      'Something like:\n' +
      '```\n' +
      '  private _schedulePersist(): void {\n' +
      '    if (this._persistIsScheduled) {\n' +
      '      return;\n' +
      '    }\n' +
      '    this._persistIsScheduled = true;\n' +
      '    void (async () => {\n' +
      '      await requestIdle(PERSIST_TIMEOUT);\n' +
      '      await this._persist();\n' +
      '    })().finally(() => (this._persistIsScheduled = false));\n' +
      '  }\n' +
      '\n' +
      '```\n' +
      '\n' +
      'We should add a test for this.\n' +
      '\n',
    visibility: 'public'
  }
]
comment: [
  {
    id: 'X4CJ85HxN582eGwydHr-m',
    issueID: '-Thbh2750u8nQUnsjkl2X',
    created: 1716564465000,
    body: 'fixed by https://github.com/rocicorp/mono/pull/1839',
    creatorID: 'tDY6IbKdVqbBlRBc3XMwF'
  },
  {
    id: 'pkZIT-tzMTVuUKEf3ScEv',
    issueID: '-f91Mdf0XQuX8XPPi9swV',
    created: 1684744555000,
    body: '@grgbkr I vaguely remember we consciously decided to leave this for some reason. Do you remember the details?',
    creatorID: 'OeVnr1y5bEM_Yg06sUFtD'
  },
  {
    id: 'KBFAzUD97ZDDkhc54QE_E',
    issueID: '-guR4swz7EX7CeNnEQI3P',
    created: 1630886399000,
    body: 'Yup. I was hoping we could only have, `withRead` and `withWrite` (and no `read`, `write` and `release`). I think it is still doable if I refactor transactions to remove some intermediate abstractions.',
    creatorID: 'nqYkxAGMnzk7Y5STjZryV'
  }
]
total synced rows: 8
=== Query Stats: ===

issue vended: {
  'SELECT "id","shortID","title","open","modified","created","creatorID","assigneeID","description","visibility" FROM "issue" WHERE ((? IS NOT ? AND ? = ?) OR "visibility" = ?) ORDER BY "id" asc': 5
}
comment vended: {
  'SELECT "id","issueID","created","body","creatorID" FROM "comment" WHERE "issueID" = ? AND TRUE ORDER BY "id" asc': 3
}
total rows considered: 8
time: 3.32ms ms
=== Vended Rows: ===

issue: {
  'SELECT "id","shortID","title","open","modified","created","creatorID","assigneeID","description","visibility" FROM "issue" WHERE ((? IS NOT ? AND ? = ?) OR "visibility" = ?) ORDER BY "id" asc': [
    {
      id: '-Thbh2750u8nQUnsjkl2X',
      shortID: 1781,
      title: 'AST `field` should be split into `table` and `column` parts',
      open: false,
      modified: 1716564468000,
      created: 1715198543000,
      creatorID: 'tDY6IbKdVqbBlRBc3XMwF',
      assigneeID: null,
      description: 'All `fields` should be tuples of `table`, `column` -- https://github.com/rocicorp/mono/blob/main/packages/zql/src/ast/ast.ts#L19\n' +
        '\n' +
        'Right now we encode table + column via a dot in the string.',
      visibility: 'public'
    },
    {
      id: '-aHMbMcRa-52TSNraxxyB',
      shortID: 6,
      title: 'Move @rocicorp/licensing into this repo',
      open: true,
      modified: 1677093343000,
      created: 1676884917000,
      creatorID: 'nqYkxAGMnzk7Y5STjZryV',
      assigneeID: null,
      description: '`@rocicorp/licensing` is a private npm package and we need to pass in the NPM_TOKEN to the GitHub Actions runners. Moving this into the mono repo would simplify that.',
      visibility: 'public'
    },
    {
      id: '-f91Mdf0XQuX8XPPi9swV',
      shortID: 470,
      title: 'Remove allowUnconfirmedWrites option',
      open: true,
      modified: 1709537612000,
      created: 1681411313000,
      creatorID: 'nqYkxAGMnzk7Y5STjZryV',
      assigneeID: null,
      description: 'We should not expose this in the API. It is not safe?',
      visibility: 'public'
    },
    {
      id: '-guR4swz7EX7CeNnEQI3P',
      shortID: 25,
      title: 'ExperimentalKVStore: Move withRead/withWrite to Replicache',
      open: true,
      modified: 1677090671000,
      created: 1630665606000,
      creatorID: 'OeVnr1y5bEM_Yg06sUFtD',
      assigneeID: null,
      description: 'Why do clients have to implement this? It seems like given read(), write(), and release(), we can do this ourselves.',
      visibility: 'public'
    },
    {
      id: '-hS3eXkArDXIEBbRliAbq',
      shortID: 84,
      title: 'An error in persist prevents future persists from being scheduled',
      open: false,
      modified: 1677091441000,
      created: 1661304014000,
      creatorID: 'Gg4MskWt3M-ttzzlrJ9jn',
      assigneeID: null,
      description: 'In replicache.ts we have:\n' +
        '\n' +
        '```\n' +
        '  private _schedulePersist(): void {\n' +
        '    if (this._persistIsScheduled) {\n' +
        '      return;\n' +
        '    }\n' +
        '    this._persistIsScheduled = true;\n' +
        '    void (async () => {\n' +
        '      await requestIdle(PERSIST_TIMEOUT);\n' +
        '      await this._persist();\n' +
        '      this._persistIsScheduled = false;\n' +
        '    })();\n' +
        '  }\n' +
        '```\n' +
        '\n' +
        'If `this._persist()` throws an error `this._persistIsScheduled` is not reset to false, and no future persists will be scheduled.  `this._persistIsScheduled ` should be reset to false in a finally.\n' +
        '\n' +
        'Something like:\n' +
        '```\n' +
        '  private _schedulePersist(): void {\n' +
        '    if (this._persistIsScheduled) {\n' +
        '      return;\n' +
        '    }\n' +
        '    this._persistIsScheduled = true;\n' +
        '    void (async () => {\n' +
        '      await requestIdle(PERSIST_TIMEOUT);\n' +
        '      await this._persist();\n' +
        '    })().finally(() => (this._persistIsScheduled = false));\n' +
        '  }\n' +
        '\n' +
        '```\n' +
        '\n' +
        'We should add a test for this.\n' +
        '\n',
      visibility: 'public'
    }
  ]
}
comment: {
  'SELECT "id","issueID","created","body","creatorID" FROM "comment" WHERE "issueID" = ? AND TRUE ORDER BY "id" asc': [
    {
      id: 'X4CJ85HxN582eGwydHr-m',
      issueID: '-Thbh2750u8nQUnsjkl2X',
      created: 1716564465000,
      body: 'fixed by https://github.com/rocicorp/mono/pull/1839',
      creatorID: 'tDY6IbKdVqbBlRBc3XMwF'
    },
    {
      id: 'pkZIT-tzMTVuUKEf3ScEv',
      issueID: '-f91Mdf0XQuX8XPPi9swV',
      created: 1684744555000,
      body: '@grgbkr I vaguely remember we consciously decided to leave this for some reason. Do you remember the details?',
      creatorID: 'OeVnr1y5bEM_Yg06sUFtD'
    },
    {
      id: 'KBFAzUD97ZDDkhc54QE_E',
      issueID: '-guR4swz7EX7CeNnEQI3P',
      created: 1630886399000,
      body: 'Yup. I was hoping we could only have, `withRead` and `withWrite` (and no `read`, `write` and `release`). I think it is still doable if I refactor transactions to remove some intermediate abstractions.',
      creatorID: 'nqYkxAGMnzk7Y5STjZryV'
    }
  ]
}


=== Query Plans: ===

query SELECT "id","shortID","title","open","modified","created","creatorID","assigneeID","description","visibility" FROM "issue" WHERE ((? IS NOT ? AND ? = ?) OR "visibility" = ?) ORDER BY "id" asc
SCAN issue USING INDEX issue_pkey


query SELECT "id","issueID","created","body","creatorID" FROM "comment" WHERE "issueID" = ? AND TRUE ORDER BY "id" asc
SEARCH comment USING INDEX comment_issueid_idx (issueID=?)
USE TEMP B-TREE FOR ORDER BY

```