### PR TITLE
chore(zql): add query name and args to builder interface

### DIFF
--- a/packages/analyze-query/src/bin-analyze.ts
+++ b/packages/analyze-query/src/bin-analyze.ts
@@ -206,6 +206,9 @@ const host: QueryDelegate = {
   addServerQuery() {
     return () => {};
   },
+  addCustomQuery() {
+    return () => {};
+  },
   updateServerQuery() {},
   onQueryMaterialized() {},
   onTransactionCommit() {

--- a/packages/zero-cache/bench/benchmark.ts
+++ b/packages/zero-cache/bench/benchmark.ts
@@ -67,6 +67,9 @@ export function bench(opts: Options) {
     addServerQuery() {
       return () => {};
     },
+    addCustomQuery() {
+      return () => {};
+    },
     updateServerQuery() {},
     onQueryMaterialized() {},
     onTransactionCommit() {

--- a/packages/zero-cache/src/auth/read-authorizer.query.test.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.query.test.ts
@@ -529,6 +529,9 @@ beforeEach(() => {
     addServerQuery() {
       return () => {};
     },
+    addCustomQuery() {
+      return () => {};
+    },
     updateServerQuery() {},
     onQueryMaterialized() {},
     onTransactionCommit() {

--- a/packages/zero-client/src/client/context.test.ts
+++ b/packages/zero-client/src/client/context.test.ts
@@ -9,7 +9,12 @@ import {Catch} from '../../../zql/src/ivm/catch.ts';
 import {Join} from '../../../zql/src/ivm/join.ts';
 import {MemorySource} from '../../../zql/src/ivm/memory-source.ts';
 import {MemoryStorage} from '../../../zql/src/ivm/memory-storage.ts';
-import {ZeroContext, type AddQuery, type UpdateQuery} from './context.ts';
+import {
+  ZeroContext,
+  type AddCustomQuery,
+  type AddQuery,
+  type UpdateQuery,
+} from './context.ts';
 import {IVMSourceBranch} from './ivm-branch.ts';
 import {ENTITIES_KEY_PREFIX} from './keys.ts';
 
@@ -40,6 +45,7 @@ test('getSource', () => {
     new LogContext('info'),
     new IVMSourceBranch(schema.tables),
     null as unknown as AddQuery,
+    null as unknown as AddCustomQuery,
     null as unknown as UpdateQuery,
     testBatchViewUpdates,
     5_000,
@@ -114,6 +120,7 @@ test('processChanges', () => {
     new LogContext('info'),
     new IVMSourceBranch(schema.tables),
     null as unknown as AddQuery,
+    null as unknown as AddCustomQuery,
     null as unknown as UpdateQuery,
     testBatchViewUpdates,
     5_000,
@@ -181,6 +188,7 @@ test('processChanges wraps source updates with batchViewUpdates', () => {
     new LogContext('info'),
     new IVMSourceBranch(schema.tables),
     null as unknown as AddQuery,
+    null as unknown as AddCustomQuery,
     null as unknown as UpdateQuery,
     batchViewUpdates,
     5_000,
@@ -237,6 +245,7 @@ test('transactions', () => {
     new LogContext('info'),
     new IVMSourceBranch(schema.tables),
     null as unknown as AddQuery,
+    null as unknown as AddCustomQuery,
     null as unknown as UpdateQuery,
     testBatchViewUpdates,
     5_000,
@@ -314,6 +323,7 @@ test('batchViewUpdates errors if applyViewUpdates is not called', () => {
     new LogContext('info'),
     new IVMSourceBranch(schema.tables),
     null as unknown as AddQuery,
+    null as unknown as AddCustomQuery,
     null as unknown as UpdateQuery,
     batchViewUpdates,
     5_000,
@@ -335,6 +345,7 @@ test('batchViewUpdates returns value', () => {
     new LogContext('info'),
     new IVMSourceBranch(schema.tables),
     null as unknown as AddQuery,
+    null as unknown as AddCustomQuery,
     null as unknown as UpdateQuery,
     batchViewUpdates,
     5_000,

--- a/packages/zero-client/src/client/custom.ts
+++ b/packages/zero-client/src/client/custom.ts
@@ -179,6 +179,7 @@ function makeSchemaQuery<S extends Schema>(
     lc,
     ivmBranch,
     () => emptyFunction,
+    () => emptyFunction,
     () => {},
     applyViewUpdates => applyViewUpdates(),
     slowMaterializeThreshold,

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -554,6 +554,8 @@ export class Zero<
       this.#ivmMain,
       (ast, ttl, gotCallback) =>
         this.#queryManager.addLegacy(ast, ttl, gotCallback),
+      (customQueryID, ttl, gotCallback) =>
+        this.#queryManager.addCustom(customQueryID, ttl, gotCallback),
       (ast, ttl) => this.#queryManager.update(ast, ttl),
       batchViewUpdates,
       slowMaterializeThreshold,

--- a/packages/zero-pg/src/query.ts
+++ b/packages/zero-pg/src/query.ts
@@ -86,7 +86,7 @@ export class ZPGQuery<
     ast: AST,
     format: Format,
   ) {
-    super(schema, tableName, ast, format, 'permissions');
+    super(schema, tableName, ast, format, 'permissions', undefined);
     this.#dbTransaction = dbTransaction;
     this.#schema = schema;
     this.#serverSchema = serverSchema;

--- a/packages/zql/src/query/named.ts
+++ b/packages/zql/src/query/named.ts
@@ -15,6 +15,11 @@ export type NamedQuery<
   query: Query<S, keyof S['tables'] & string>;
 };
 
+export type CustomQueryID = {
+  name: string;
+  args: ReadonlyArray<ReadonlyJSONValue>;
+};
+
 type NamedQueryFunc<
   S extends Schema,
   TArg extends ReadonlyArray<ReadonlyJSONValue> = ReadonlyJSONValue[],

--- a/packages/zql/src/query/named.ts
+++ b/packages/zql/src/query/named.ts
@@ -6,14 +6,7 @@ import type {Query} from './query.ts';
 export type NamedQuery<
   S extends Schema,
   TArg extends ReadonlyArray<ReadonlyJSONValue> = ReadonlyJSONValue[],
-> = (
-  tx: SchemaQuery<S>,
-  ...args: TArg
-) => {
-  name: string;
-  args: TArg;
-  query: Query<S, keyof S['tables'] & string>;
-};
+> = (tx: SchemaQuery<S>, ...args: TArg) => Query<S, keyof S['tables'] & string>;
 
 export type CustomQueryID = {
   name: string;
@@ -30,11 +23,7 @@ export function query<
   TArg extends ReadonlyArray<ReadonlyJSONValue> = ReadonlyJSONValue[],
 >(_s: S, name: string, fn: NamedQueryFunc<S, TArg>): NamedQuery<S, TArg> {
   return function queryWrapper(tx: SchemaQuery<S>, ...args: TArg) {
-    return {
-      name,
-      args,
-      query: fn(tx, ...args),
-    };
+    return fn(tx, ...args).nameAndArgs(name, args);
   };
 }
 

--- a/packages/zql/src/query/query-impl.query-kitchen-sink.test.ts
+++ b/packages/zql/src/query/query-impl.query-kitchen-sink.test.ts
@@ -334,6 +334,7 @@ describe('kitchen sink query', () => {
     expect(queryDelegate.addedServerQueries).toMatchInlineSnapshot(`
       [
         {
+          "args": undefined,
           "ast": {
             "limit": 6,
             "orderBy": [
@@ -511,6 +512,7 @@ describe('kitchen sink query', () => {
               "type": "and",
             },
           },
+          "name": undefined,
           "ttl": "none",
         },
       ]

--- a/packages/zql/src/query/query.ts
+++ b/packages/zql/src/query/query.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type {Expand, ExpandRecursive} from '../../../shared/src/expand.ts';
+import type {ReadonlyJSONValue} from '../../../shared/src/json.ts';
 import {type SimpleOperator} from '../../../zero-protocol/src/ast.ts';
 import type {Schema as ZeroSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import type {
@@ -149,8 +150,26 @@ export interface Query<
   /**
    * A string that uniquely identifies this query. This can be used to determine
    * if two queries are the same.
+   *
+   * The hash of a custom query, on the client, is the hash of its AST.
+   * The hash of a custom query, on the server, is the hash of its name and args.
+   *
+   * The first allows many client-side queries to be pinned to the same backend query.
+   * The second ensures we do not invoke a named query on the backend more than once for the same `name:arg` pairing.
+   *
+   * If the query.hash was of `name:args` then `useQuery` would de-dupe
+   * queries with divergent ASTs.
+   *
+   * QueryManager will hash based on `name:args` since it is speaking with
+   * the server which tracks queries by `name:args`.
    */
   hash(): string;
+  readonly customQueryID: CustomQueryID | undefined;
+
+  nameAndArgs(
+    name: string,
+    args: ReadonlyArray<ReadonlyJSONValue>,
+  ): Query<TSchema, TTable, TReturn>;
 
   /**
    * Related is used to add a related query to the current query. This is used
@@ -364,10 +383,7 @@ export interface Query<
    *            associated with this query after `TypedView.destroy`
    *            has been called.
    */
-  materialize(
-    ttl?: TTL,
-    customQueryID?: CustomQueryID | undefined,
-  ): TypedView<HumanReadable<TReturn>>;
+  materialize(ttl?: TTL): TypedView<HumanReadable<TReturn>>;
   /**
    * Creates a custom materialized view using a provided factory function. This
    * allows framework-specific bindings (like SolidJS, Vue, etc.) to create
@@ -385,7 +401,6 @@ export interface Query<
   materialize<T>(
     factory: ViewFactory<TSchema, TTable, TReturn, T>,
     ttl?: TTL,
-    customQueryID?: CustomQueryID | undefined,
   ): T;
 
   /**

--- a/packages/zql/src/query/query.ts
+++ b/packages/zql/src/query/query.ts
@@ -10,6 +10,7 @@ import type {
 } from '../../../zero-schema/src/table-schema.ts';
 import type {Format, ViewFactory} from '../ivm/view.ts';
 import type {ExpressionFactory, ParameterReference} from './expression.ts';
+import type {CustomQueryID} from './named.ts';
 import type {TTL} from './ttl.ts';
 import type {TypedView} from './typed-view.ts';
 
@@ -363,7 +364,10 @@ export interface Query<
    *            associated with this query after `TypedView.destroy`
    *            has been called.
    */
-  materialize(ttl?: TTL): TypedView<HumanReadable<TReturn>>;
+  materialize(
+    ttl?: TTL,
+    customQueryID?: CustomQueryID | undefined,
+  ): TypedView<HumanReadable<TReturn>>;
   /**
    * Creates a custom materialized view using a provided factory function. This
    * allows framework-specific bindings (like SolidJS, Vue, etc.) to create
@@ -381,6 +385,7 @@ export interface Query<
   materialize<T>(
     factory: ViewFactory<TSchema, TTable, TReturn, T>,
     ttl?: TTL,
+    customQueryID?: CustomQueryID | undefined,
   ): T;
 
   /**

--- a/packages/zql/src/query/static-query.ts
+++ b/packages/zql/src/query/static-query.ts
@@ -2,6 +2,7 @@ import type {AST} from '../../../zero-protocol/src/ast.ts';
 import type {Schema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import type {Format} from '../ivm/view.ts';
 import {ExpressionBuilder} from './expression.ts';
+import type {CustomQueryID} from './named.ts';
 import {AbstractQuery, defaultFormat, newQuerySymbol} from './query-impl.ts';
 import type {HumanReadable, PullRow, Query} from './query.ts';
 import type {TypedView} from './typed-view.ts';
@@ -36,9 +37,18 @@ export class StaticQuery<
     tableName: TTable,
     ast: AST,
     format: Format,
+    customQueryID?: CustomQueryID | undefined,
     currentJunction?: string | undefined,
   ) {
-    super(schema, tableName, ast, format, 'permissions', currentJunction);
+    super(
+      schema,
+      tableName,
+      ast,
+      format,
+      'permissions',
+      customQueryID,
+      currentJunction,
+    );
   }
 
   protected [newQuerySymbol]<
@@ -50,9 +60,17 @@ export class StaticQuery<
     tableName: TTable,
     ast: AST,
     format: Format,
+    customQueryID: CustomQueryID | undefined,
     currentJunction: string | undefined,
   ): StaticQuery<TSchema, TTable, TReturn> {
-    return new StaticQuery(schema, tableName, ast, format, currentJunction);
+    return new StaticQuery(
+      schema,
+      tableName,
+      ast,
+      format,
+      customQueryID,
+      currentJunction,
+    );
   }
 
   get ast() {

--- a/packages/zqlite/src/query-delegate.ts
+++ b/packages/zqlite/src/query-delegate.ts
@@ -74,6 +74,9 @@ export class QueryDelegateImpl implements QueryDelegate {
   addServerQuery() {
     return () => {};
   }
+  addCustomQuery() {
+    return () => {};
+  }
   updateServerQuery() {}
   onQueryMaterialized() {}
   onTransactionCommit(cb: CommitListener) {

--- a/packages/zqlite/src/test/source-factory.ts
+++ b/packages/zqlite/src/test/source-factory.ts
@@ -174,6 +174,9 @@ export function newQueryDelegate(
     addServerQuery() {
       return () => {};
     },
+    addCustomQuery() {
+      return () => {};
+    },
     updateServerQuery() {},
     onQueryMaterialized() {},
     onTransactionCommit() {


### PR DESCRIPTION
A custom query will have `name` and `args` filled in in addition to the AST.

- the AST is used for client execution
- name and args are sent to the server

The first commit in this PR is only kept around for historical interest / documentation of another approach.

