### PR TITLE
feat(zero-cache): make threshold for query-hydration-stats configurable

### DIFF
--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -68,7 +68,8 @@ test('zero-cache --help', () => {
                                                                                                                                                                    
      --query-hydration-stats boolean                             optional                                                                                          
        ZERO_QUERY_HYDRATION_STATS env                                                                                                                              
-                                                                 Track and log the number of rows considered by each query in the system.                          
+                                                                 Track and log the number of rows considered by query hydrations which                             
+                                                                 take longer than log-slow-hydrate-threshold milliseconds.                                         
                                                                  This is useful for debugging and performance tuning.                                              
                                                                                                                                                                    
      --change-db string                                          optional                                                                                          

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -255,7 +255,8 @@ export const zeroOptions = {
   queryHydrationStats: {
     type: v.boolean().optional(),
     desc: [
-      `Track and log the number of rows considered by each query in the system.`,
+      `Track and log the number of rows considered by query hydrations which`,
+      `take longer than {bold log-slow-hydrate-threshold} milliseconds.`,
       `This is useful for debugging and performance tuning.`,
     ],
   },

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -283,7 +283,7 @@ export class PipelineDriver {
 
     const hydrationTimeMs = timer.totalElapsed();
     if (runtimeDebugFlags.trackRowCountsVended) {
-      if (hydrationTimeMs > 200) {
+      if (hydrationTimeMs > this.#logConfig.slowHydrateThreshold) {
         let totalRowsConsidered = 0;
         const lc = this.#lc
           .withContext('hash', hash)


### PR DESCRIPTION
Use existing flag log-slow-hydrate-threshold as the threshold for query-hydration-stats rather than hardcoded 200ms.