### PR TITLE
chore(zql): stronger return type on custom queries

### DIFF
--- a/packages/zql/src/query/named.test.ts
+++ b/packages/zql/src/query/named.test.ts
@@ -9,11 +9,26 @@ import {
   hashOfNameAndArgs,
 } from '../../../zero-protocol/src/query-hash.ts';
 
+const tx = {
+  issue: new StaticQuery(schema, 'issue', {table: 'issue'}, defaultFormat),
+} as any;
 test('defining a named query', () => {
   const named = query(schema, 'issue', (tx, id: string) =>
     tx.issue.where('id', id),
   );
-  expectTypeOf(named).toEqualTypeOf<NamedQuery<typeof schema, [string]>>();
+  const q = named(tx, '123');
+  expectTypeOf<ReturnType<typeof q.run>>().toEqualTypeOf<
+    Promise<
+      {
+        readonly id: string;
+        readonly title: string;
+        readonly description: string;
+        readonly closed: boolean;
+        readonly ownerId: string | null;
+        readonly createdAt: number;
+      }[]
+    >
+  >();
   check(named);
 });
 
@@ -21,18 +36,24 @@ test('binding query to a schema', () => {
   const bound = query.bindTo(schema);
 
   const named = bound('issue', (tx, id: string) => tx.issue.where('id', id));
-
-  expectTypeOf(named).toEqualTypeOf<NamedQuery<typeof schema, [string]>>();
+  const q = named(tx, '123');
+  expectTypeOf<ReturnType<typeof q.run>>().toEqualTypeOf<
+    Promise<
+      {
+        readonly id: string;
+        readonly title: string;
+        readonly description: string;
+        readonly closed: boolean;
+        readonly ownerId: string | null;
+        readonly createdAt: number;
+      }[]
+    >
+  >();
   check(named);
 });
 
-function check(named: NamedQuery<typeof schema, [string]>) {
-  const r = named(
-    {
-      issue: new StaticQuery(schema, 'issue', {table: 'issue'}, defaultFormat),
-    } as any,
-    '123',
-  );
+function check(named: NamedQuery<typeof schema, [string], any>) {
+  const r = named(tx, '123');
 
   const id = r.customQueryID;
   expect(id?.name).toBe('issue');


### PR DESCRIPTION
The return type of a custom query needs to be threaded back through so callers know what data they're receiving.