### PR TITLE
chore(zero): error on no pull url, throw on missing table

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -968,6 +968,12 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         });
       }
 
+      if (customQueries.size > 0 && !this.#customQueryTransformer) {
+        lc.error?.(
+          'Custom/named queries were requested but no `pull.url` is configured for Zero Cache.',
+        );
+      }
+
       if (this.#customQueryTransformer && customQueries.size > 0) {
         const transformedCustomQueries =
           await this.#customQueryTransformer.transform(

--- a/packages/zero-pg/src/query.ts
+++ b/packages/zero-pg/src/query.ts
@@ -42,6 +42,10 @@ export function makeSchemaQuery<S extends Schema>(
         return target[prop];
       }
 
+      if (!(prop in schema.tables)) {
+        throw new Error(`Table ${prop} does not exist in schema`);
+      }
+
       const q = new ZPGQuery(
         schema,
         this.#serverSchema,


### PR DESCRIPTION
Some extra error reporting and invariants.

- if custom queries are received by zero-cache but no pull url is configured, log an errr
- if zero-pg receives a query for a table that is not in the schema, fatal