### PR TITLE
chore(zql): allow static queries to be converted to runnable queries

### DIFF
--- a/packages/zql-integration-tests/src/chinook/check-zql-string.pg-test.ts
+++ b/packages/zql-integration-tests/src/chinook/check-zql-string.pg-test.ts
@@ -4,7 +4,7 @@ import {schema} from './schema.ts';
 import {test} from 'vitest';
 import '../helpers/comparePg.ts';
 import {defaultFormat} from '../../../zql/src/query/query-impl.ts';
-import type {AnyQuery} from '../../../zql/src/query/test/util.ts';
+import type {AnyStaticQuery} from '../../../zql/src/query/test/util.ts';
 import {StaticQuery} from '../../../zql/src/query/static-query.ts';
 import {staticToRunnable} from '../helpers/static.ts';
 
@@ -37,7 +37,7 @@ const z = {
 };
 
 const f = new Function('z', `return z.query.${QUERY_STRING};`);
-const query: AnyQuery = f(z);
+const query: AnyStaticQuery = f(z);
 
 test('manual zql string', async () => {
   await runAndCompare(

--- a/packages/zql-integration-tests/src/chinook/chinook-fuzz-hydration.pg-test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook-fuzz-hydration.pg-test.ts
@@ -8,7 +8,10 @@ import {test} from 'vitest';
 import {generateShrinkableQuery} from '../../../zql/src/query/test/query-gen.ts';
 import '../helpers/comparePg.ts';
 import {ast} from '../../../zql/src/query/query-impl.ts';
-import type {AnyQuery} from '../../../zql/src/query/test/util.ts';
+import type {
+  AnyQuery,
+  AnyStaticQuery,
+} from '../../../zql/src/query/test/util.ts';
 import {astToZQL} from '../../../ast-to-zql/src/ast-to-zql.ts';
 import {formatOutput} from '../../../ast-to-zql/src/format.ts';
 import {staticToRunnable} from '../helpers/static.ts';
@@ -71,7 +74,7 @@ async function runCase({
     await runAndCompare(
       schema,
       staticToRunnable({
-        query: query[0],
+        query: query[0] as AnyStaticQuery,
         schema,
         harness,
       }),
@@ -99,7 +102,7 @@ async function shrink(generations: AnyQuery[], seed: number) {
       await runAndCompare(
         schema,
         staticToRunnable({
-          query: generations[mid],
+          query: generations[mid] as AnyStaticQuery,
           schema,
           harness,
         }),

--- a/packages/zql-integration-tests/src/helpers/static.ts
+++ b/packages/zql-integration-tests/src/helpers/static.ts
@@ -1,6 +1,6 @@
 import type {Schema} from '../../../zero-schema/src/builder/schema-builder.ts';
-import {ast, QueryImpl} from '../../../zql/src/query/query-impl.ts';
-import type {AnyQuery} from '../../../zql/src/query/test/util.ts';
+import {ast} from '../../../zql/src/query/query-impl.ts';
+import type {AnyStaticQuery} from '../../../zql/src/query/test/util.ts';
 import {type bootstrap} from './runner.ts';
 import {ZPGQuery} from '../../../zero-pg/src/query.ts';
 
@@ -9,26 +9,14 @@ export function staticToRunnable<TSchema extends Schema>({
   schema,
   harness,
 }: {
-  query: AnyQuery;
+  query: AnyStaticQuery;
   schema: TSchema;
   harness: Awaited<ReturnType<typeof bootstrap>>;
 }) {
   // reconstruct the generated query
   // for zql, zqlite and pg
-  const zql = new QueryImpl(
-    harness.delegates.memory,
-    schema,
-    ast(query).table,
-    ast(query),
-    query.format,
-  );
-  const zqlite = new QueryImpl(
-    harness.delegates.sqlite,
-    schema,
-    ast(query).table,
-    ast(query),
-    query.format,
-  );
+  const zql = query.asRunnable(harness.delegates.memory);
+  const zqlite = query.asRunnable(harness.delegates.sqlite);
   const pg = new ZPGQuery(
     schema,
     harness.delegates.pg.serverSchema,

--- a/packages/zql/src/query/static-query.ts
+++ b/packages/zql/src/query/static-query.ts
@@ -1,9 +1,15 @@
-import type {AST} from '../../../zero-protocol/src/ast.ts';
+import type {AST, System} from '../../../zero-protocol/src/ast.ts';
 import type {Schema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import type {Format} from '../ivm/view.ts';
 import {ExpressionBuilder} from './expression.ts';
 import type {CustomQueryID} from './named.ts';
-import {AbstractQuery, defaultFormat, newQuerySymbol} from './query-impl.ts';
+import {
+  AbstractQuery,
+  defaultFormat,
+  newQuerySymbol,
+  QueryImpl,
+  type QueryDelegate,
+} from './query-impl.ts';
 import type {HumanReadable, PullRow, Query} from './query.ts';
 import type {TypedView} from './typed-view.ts';
 
@@ -28,15 +34,12 @@ export class StaticQuery<
   TTable extends keyof TSchema['tables'] & string,
   TReturn = PullRow<TTable, TSchema>,
 > extends AbstractQuery<TSchema, TTable, TReturn> {
-  expressionBuilder() {
-    return new ExpressionBuilder(this._exists);
-  }
-
   constructor(
     schema: TSchema,
     tableName: TTable,
     ast: AST,
     format: Format,
+    system: System = 'permissions',
     customQueryID?: CustomQueryID | undefined,
     currentJunction?: string | undefined,
   ) {
@@ -45,10 +48,14 @@ export class StaticQuery<
       tableName,
       ast,
       format,
-      'permissions',
+      system,
       customQueryID,
       currentJunction,
     );
+  }
+
+  expressionBuilder() {
+    return new ExpressionBuilder(this._exists);
   }
 
   protected [newQuerySymbol]<
@@ -68,8 +75,25 @@ export class StaticQuery<
       tableName,
       ast,
       format,
+      this._system,
       customQueryID,
       currentJunction,
+    );
+  }
+
+  // TODO: we should refactor `ZPGQuery` to use a `QueryDelegate` as well
+  // so we can remove `ZPGQuery` and call `asRunnable` on `StaticQuery`
+  // with the postgres delegate.
+  asRunnable(delegate: QueryDelegate): Query<TSchema, TTable, TReturn> {
+    return new QueryImpl(
+      delegate,
+      this._schema,
+      this._tableName,
+      this._ast,
+      this.format,
+      this._system,
+      this.customQueryID,
+      this._currentJunction,
     );
   }
 

--- a/packages/zql/src/query/test/util.ts
+++ b/packages/zql/src/query/test/util.ts
@@ -2,11 +2,14 @@ import type {Faker} from '@faker-js/faker';
 import type {ValueType} from '../../../../zero-schema/src/table-schema.ts';
 import type {Query} from '../query.ts';
 import type {Schema} from '../../../../zero-schema/src/builder/schema-builder.ts';
+import type {StaticQuery} from '../static-query.ts';
 
 export type Rng = () => number;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyQuery = Query<Schema, string, any>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AnyStaticQuery = StaticQuery<Schema, string, any>;
 
 export function selectRandom<T>(rng: Rng, values: readonly T[]): T {
   return values[Math.floor(rng() * values.length)];


### PR DESCRIPTION
This will allow building queries without first having access to a Zero instance.

E.g., a user can define queries by only referencing their schema and then run those queries later by binding them to a delegate on the client or server.

```ts
const q = schema.query;
const issues = q.issue;
const issueOne = q.issue.where('id', 1);

// inside the useQuery hook we would call `asRunnable`
issueOne.asRunnable(z).materialize();
```