### PR TITLE
chore(zql): rename `makeSchemaQuery` to `query`

### DIFF
--- a/packages/zql/src/query/named.test.ts
+++ b/packages/zql/src/query/named.test.ts
@@ -4,7 +4,7 @@ import {
   hashOfAST,
   hashOfNameAndArgs,
 } from '../../../zero-protocol/src/query-hash.ts';
-import {makeSchemaQuery, query, type NamedQuery} from './named.ts';
+import {query, type NamedQuery} from './named.ts';
 import {ast, defaultFormat} from './query-impl.ts';
 import {StaticQuery} from './static-query.ts';
 import {schema} from './test/test-schemas.ts';
@@ -85,7 +85,7 @@ function check(named: NamedQuery<typeof schema, [string], any>) {
 }
 
 test('makeSchemaQuery', () => {
-  const builders = makeSchemaQuery(schema);
+  const builders = query(schema);
   const q1 = builders.issue.where('id', '123').nameAndArgs('myName', ['123']);
   expect(ast(q1)).toMatchInlineSnapshot(`
     {


### PR DESCRIPTION
to get a handle on the query builders one can now do:

```ts
const builders = query(schema);
builders.issue.where(...);
```

This is used for defining custom queries. Could also be used to remove the superfluous `useZero` in react components.

I did not stick the builder on schema mainly for practical considerations. It would increase the size of the schema type which we want to avoid given TypeScript's type size limits.