### PR TITLE
feat(zbugs): no need to call `useZero` to build queries in React

### DIFF
--- a/apps/zbugs/shared/schema.ts
+++ b/apps/zbugs/shared/schema.ts
@@ -10,6 +10,7 @@ import {
   table,
   type ExpressionBuilder,
   type Row,
+  query,
 } from '@rocicorp/zero';
 import type {AuthData, Role} from './auth.ts';
 
@@ -200,6 +201,8 @@ type TableName = keyof Schema['tables'];
 export type IssueRow = Row<typeof schema.tables.issue>;
 export type CommentRow = Row<typeof schema.tables.comment>;
 export type UserRow = Row<typeof schema.tables.user>;
+
+export const queries = query(schema);
 
 export const permissions: ReturnType<typeof definePermissions> =
   definePermissions<AuthData, Schema>(schema, () => {

--- a/apps/zbugs/src/components/filter.tsx
+++ b/apps/zbugs/src/components/filter.tsx
@@ -3,10 +3,10 @@ import classNames from 'classnames';
 import {memo, useMemo, useState} from 'react';
 import {toSorted} from '../../../../packages/shared/src/to-sorted.ts';
 import labelIcon from '../assets/icons/label.svg';
-import {useZero} from '../hooks/use-zero.ts';
 import {Button} from './button.tsx';
 import {Combobox} from './combobox.tsx';
 import {UserPicker} from './user-picker.tsx';
+import {queries} from '../../shared/schema.ts';
 
 export type Selection =
   | {creator: string}
@@ -18,10 +18,9 @@ type Props = {
 };
 
 export const Filter = memo(function Filter({onSelect}: Props) {
-  const z = useZero();
   const [isOpen, setIsOpen] = useState(false);
 
-  const [unsortedLabels] = useQuery(z.query.label);
+  const [unsortedLabels] = useQuery(queries.label);
   // TODO: Support case-insensitive sorting in ZQL.
   const labels = useMemo(
     () => toSorted(unsortedLabels, (a, b) => a.name.localeCompare(b.name)),

--- a/apps/zbugs/src/components/label-picker.tsx
+++ b/apps/zbugs/src/components/label-picker.tsx
@@ -2,9 +2,9 @@ import {useQuery} from '@rocicorp/zero/react';
 import classNames from 'classnames';
 import {useCallback, useRef, useState} from 'react';
 import {useClickOutside} from '../hooks/use-click-outside.ts';
-import {useZero} from '../hooks/use-zero.ts';
 import {Button} from './button.tsx';
 import style from './label-picker.module.css';
+import {queries} from '../../shared/schema.ts';
 
 const focusInput = (input: HTMLInputElement | null) => {
   if (input) {
@@ -24,8 +24,7 @@ export function LabelPicker({
   onCreateNewLabel: (name: string) => void;
 }) {
   const [isOpen, setIsOpen] = useState(false);
-  const z = useZero();
-  const [labels] = useQuery(z.query.label.orderBy('name', 'asc'));
+  const [labels] = useQuery(queries.label.orderBy('name', 'asc'));
   const ref = useRef<HTMLDivElement>(null);
 
   useClickOutside(

--- a/apps/zbugs/src/components/nav.tsx
+++ b/apps/zbugs/src/components/nav.tsx
@@ -7,7 +7,6 @@ import {useQuery} from 'zero-react/src/use-query.js';
 import logoURL from '../assets/images/logo.svg';
 import markURL from '../assets/images/mark.svg';
 import {useLogin} from '../hooks/use-login.tsx';
-import {useZero} from '../hooks/use-zero.ts';
 import {IssueComposer} from '../pages/issue/issue-composer.tsx';
 import {
   links,
@@ -19,6 +18,7 @@ import {AvatarImage} from './avatar-image.tsx';
 import {ButtonWithLoginCheck} from './button-with-login-check.tsx';
 import {Button} from './button.tsx';
 import {Link} from './link.tsx';
+import {queries} from '../../shared/schema.ts';
 
 export const Nav = memo(() => {
   const search = useSearch();
@@ -30,9 +30,8 @@ export const Nav = memo(() => {
   const login = useLogin();
   const [isMobile, setIsMobile] = useState(false);
   const [showUserPanel, setShowUserPanel] = useState(false); // State to control visibility of user-panel-mobile
-  const zero = useZero();
   const [user] = useQuery(
-    zero.query.user.where('id', login.loginState?.decoded.sub ?? '').one(),
+    queries.user.where('id', login.loginState?.decoded.sub ?? '').one(),
   );
 
   const [showIssueModal, setShowIssueModal] = useState(false);

--- a/apps/zbugs/src/components/user-picker.tsx
+++ b/apps/zbugs/src/components/user-picker.tsx
@@ -2,10 +2,9 @@ import {type Row} from '@rocicorp/zero';
 import {useQuery} from '@rocicorp/zero/react';
 import {useEffect, useMemo, useState} from 'react';
 import {toSorted} from '../../../../packages/shared/src/to-sorted.ts';
-import {type Schema} from '../../shared/schema.ts';
+import {queries, type Schema} from '../../shared/schema.ts';
 import avatarIcon from '../assets/icons/avatar-default.svg';
 import {avatarURLWithSize} from '../avatar-url-with-size.ts';
-import {useZero} from '../hooks/use-zero.ts';
 import {Combobox} from './combobox.tsx';
 
 type Props = {
@@ -29,9 +28,7 @@ export function UserPicker({
   allowNone = true,
   filter = undefined,
 }: Props) {
-  const z = useZero();
-
-  let q = z.query.user;
+  let q = queries.user;
   if (disabled && selected?.login) {
     q = q.where('login', selected.login);
   } else if (filter) {

--- a/apps/zbugs/src/hooks/use-can-edit.ts
+++ b/apps/zbugs/src/hooks/use-can-edit.ts
@@ -1,13 +1,12 @@
 import {useQuery} from '@rocicorp/zero/react';
 import {useLogin} from './use-login.tsx';
-import {useZero} from './use-zero.ts';
+import {queries} from '../../shared/schema.ts';
 
 export function useCanEdit(ownerUserID: string | undefined): boolean {
   const login = useLogin();
-  const z = useZero();
   const currentUserID = login.loginState?.decoded.sub;
   const [isCrew] = useQuery(
-    z.query.user
+    queries.user
       .where('id', currentUserID || '')
       .where('role', 'crew')
       .one(),

--- a/apps/zbugs/src/hooks/use-user-pref.ts
+++ b/apps/zbugs/src/hooks/use-user-pref.ts
@@ -1,12 +1,12 @@
 import type {Zero} from '@rocicorp/zero';
 import {useQuery} from '@rocicorp/zero/react';
-import type {Schema} from '../../shared/schema.ts';
+import {queries, type Schema} from '../../shared/schema.ts';
 import {useZero} from './use-zero.ts';
 import type {Mutators} from '../../shared/mutators.ts';
 
 export function useUserPref(key: string): string | undefined {
   const z = useZero();
-  const q = z.query.userPref.where('key', key).where('userID', z.userID).one();
+  const q = queries.userPref.where('key', key).where('userID', z.userID).one();
   const [pref] = useQuery(q);
   return pref?.value;
 }

--- a/apps/zbugs/src/pages/list/list-page.tsx
+++ b/apps/zbugs/src/pages/list/list-page.tsx
@@ -29,15 +29,16 @@ import {mark} from '../../perf-log.ts';
 import type {ListContext} from '../../routes.ts';
 import {preload} from '../../zero-setup.ts';
 import {CACHE_AWHILE, CACHE_NONE} from '../../query-cache-policy.ts';
+import {queries} from '../../../shared/schema.ts';
 
 let firstRowRendered = false;
 const itemSize = 56;
 
 export function ListPage({onReady}: {onReady: () => void}) {
-  const z = useZero();
   const login = useLogin();
   const search = useSearch();
   const qs = useMemo(() => new URLSearchParams(search), [search]);
+  const z = useZero();
 
   const status = qs.get('status')?.toLowerCase() ?? 'open';
   const creator = qs.get('creator') ?? undefined;
@@ -57,7 +58,7 @@ export function ListPage({onReady}: {onReady: () => void}) {
   const sortDirection =
     qs.get('sortDir')?.toLowerCase() === 'asc' ? 'asc' : 'desc';
 
-  let q = z.query.issue
+  let q = queries.issue
     .orderBy(sortField, sortDirection)
     .orderBy('id', sortDirection)
     .related('labels')

--- a/apps/zbugs/src/zero-setup.ts
+++ b/apps/zbugs/src/zero-setup.ts
@@ -1,5 +1,5 @@
 import {Zero} from '@rocicorp/zero';
-import {type Schema, schema} from '../shared/schema.ts';
+import {queries, type Schema, schema} from '../shared/schema.ts';
 import {createMutators, type Mutators} from '../shared/mutators.ts';
 import {Atom} from './atom.ts';
 import {clearJwt, getJwt, getRawJwt} from './jwt.ts';
@@ -59,23 +59,25 @@ export function preload(z: Zero<Schema, Mutators>) {
   didPreload = true;
 
   // Preload all issues and first 10 comments from each.
-  z.query.issue
-    .related('labels')
-    .related('viewState', q => q.where('userID', z.userID))
-    .related('creator')
-    .related('assignee')
-    .related('emoji', emoji => emoji.related('creator'))
-    .related('comments', comments =>
-      comments
-        .related('creator')
-        .related('emoji', emoji => emoji.related('creator'))
-        .limit(10)
-        .orderBy('created', 'desc'),
-    )
-    .preload(CACHE_FOREVER);
+  z.preload(
+    queries.issue
+      .related('labels')
+      .related('viewState', q => q.where('userID', z.userID))
+      .related('creator')
+      .related('assignee')
+      .related('emoji', emoji => emoji.related('creator'))
+      .related('comments', comments =>
+        comments
+          .related('creator')
+          .related('emoji', emoji => emoji.related('creator'))
+          .limit(10)
+          .orderBy('created', 'desc'),
+      ),
+    CACHE_FOREVER,
+  );
 
-  z.query.user.preload(CACHE_FOREVER);
-  z.query.label.preload(CACHE_FOREVER);
+  z.preload(queries.user, CACHE_FOREVER);
+  z.preload(queries.label, CACHE_FOREVER);
 }
 
 // To enable accessing zero in the devtools easily.

--- a/packages/zero-client/src/mod.ts
+++ b/packages/zero-client/src/mod.ts
@@ -106,6 +106,7 @@ export type {Entry, Format, View, ViewFactory} from '../../zql/src/ivm/view.ts';
 export type {
   DeleteID,
   InsertValue,
+  SchemaQuery,
   ServerTransaction,
   Transaction,
   UpdateValue,

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -817,7 +817,7 @@ export class QueryImpl<
     complete: Promise<void>;
   } {
     const delegate = must(
-      pullDelegate(options?.delegate ?? this._delegate),
+      this._delegate,
       'preload requires a query delegate to be set',
     );
     const {resolve, promise: complete} = resolver<void>();
@@ -836,21 +836,6 @@ export class QueryImpl<
       complete,
     };
   }
-}
-
-function pullDelegate(
-  delegate: PreloadOptions['delegate'],
-): QueryDelegate | undefined {
-  if (delegate === undefined) {
-    return undefined;
-  }
-  if (typeof delegate === 'function') {
-    return delegate();
-  }
-  if (typeof delegate === 'object' && 'queryDelegate' in delegate) {
-    return delegate.queryDelegate;
-  }
-  return delegate;
 }
 
 function addPrimaryKeys(

--- a/packages/zql/src/query/query.ts
+++ b/packages/zql/src/query/query.ts
@@ -172,6 +172,7 @@ export interface Query<
     name: string,
     args: ReadonlyArray<ReadonlyJSONValue>,
   ): Query<TSchema, TTable, TReturn>;
+  delegate(delegate: QueryDelegate): Query<TSchema, TTable, TReturn>;
 
   /**
    * Related is used to add a related query to the current query. This is used
@@ -448,11 +449,6 @@ export type PreloadOptions = {
    * this query after {@linkcode cleanup} has been called.
    */
   ttl?: TTL | undefined;
-  delegate?:
-    | QueryDelegate
-    | (() => QueryDelegate)
-    | {queryDelegate: QueryDelegate}
-    | undefined;
 };
 
 /**


### PR DESCRIPTION
trying this on for size before converting zbugs to custom queries.

Feels nice.
- less generics (<Schema, Mutators> being passed around
- slightly less to type (queries.issue vs z.query.issue)
- no `const z = useZero();` just to then `z.query.issue`
