### PR TITLE
feat(inspector): Add Logarithmic Histogram Support for Query Metrics

### DIFF
--- a/packages/shared/src/logarithmic-histogram.test.ts
+++ b/packages/shared/src/logarithmic-histogram.test.ts
@@ -1,0 +1,68 @@
+import {expect, test} from 'vitest';
+import {LogarithmicHistogram} from './histogram.ts';
+
+test('initializes correctly with default values', () => {
+  const h = new LogarithmicHistogram();
+  expect(h.counts.length).toBe(2); // underflow + one bucket
+  expect(h.counts.every(c => c === 0)).toBe(true);
+});
+
+test('adds values and resizes dynamically', () => {
+  const h = new LogarithmicHistogram();
+  h.add(0.5); // should go to underflow
+  h.add(0.9); // should go to underflow
+  h.add(4); // log2(4) + 1 === 3
+  h.add(4.1); // log2(4.1) + 1 === 3
+  h.add(1024);
+  expect(h.counts).toEqual(
+    new Uint32Array([2, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 1]),
+  );
+});
+
+test('calculates bucket ranges dynamically', () => {
+  const h = new LogarithmicHistogram();
+  h.add(1024); // Trigger resizing
+  const ranges = h.getBucketRanges();
+  expect(ranges.length).toBe(12); // Ensure ranges reflect resizing
+  expect(ranges[0]).toEqual([0, 1]);
+  expect(ranges[1]).toEqual([1, 2]);
+  expect(ranges[ranges.length - 1]).toEqual([1024, 2048]);
+});
+
+test('serializes and deserializes dynamically resized histogram', () => {
+  const original = new LogarithmicHistogram();
+  original.add(0.5);
+  original.add(4);
+  original.add(32);
+  original.add(1024); // Trigger resizing
+
+  const hex = original.toHexString();
+  const deserialized = LogarithmicHistogram.fromHexString(hex);
+
+  expect(deserialized.counts).toEqual(original.counts);
+  expect(deserialized.toHexString()).toBe(hex);
+});
+
+test('handles serialization of large counts', () => {
+  const hist = new LogarithmicHistogram();
+  // Add a large number to one bucket
+  for (let i = 0; i < 1_000_000; i++) {
+    hist.add(1);
+  }
+
+  const hex = hist.toHexString();
+  const deserialized = LogarithmicHistogram.fromHexString(hex);
+
+  expect(deserialized.counts).toEqual(hist.counts);
+});
+
+test('throws error on invalid hex string', () => {
+  expect(() => LogarithmicHistogram.fromHexString('invalid')).toThrow(
+    'Invalid hex string: invalid',
+  );
+});
+
+test('throws on negative values', () => {
+  const h = new LogarithmicHistogram();
+  expect(() => h.add(-1)).toThrow('Value must not be negative, got: -1');
+});

--- a/packages/shared/src/logarithmic-histogram.ts
+++ b/packages/shared/src/logarithmic-histogram.ts
@@ -1,0 +1,113 @@
+/**
+ * Histogram class for tracking the distribution of values in logarithmic buckets.
+ *
+ * This histogram divides a range of positive values into logarithmically-spaced buckets
+ * and counts how many values fall into each bucket. It's particularly useful for data
+ * that spans several orders of magnitude.
+ *
+ * Features:
+ * - Logarithmic bucketing for better representation of exponentially distributed data
+ * - Underflow and overflow buckets for values outside the specified range
+ * - Serialization to/from hex strings for persistence
+ * - Efficient storage using Uint32Array
+ *
+ * Example usage:
+ * ```js
+ * const hist = new Histogram(); // min=1
+ * hist.add(5);
+ * hist.add(250);
+ * console.log(hist.counts);
+ * ```
+ */
+export class LogarithmicHistogram {
+  /** Array holding counts for all buckets (including underflow at index 0) */
+  #counts = new Uint32Array(2); // Start with underflow and one bucket
+
+  /**
+   * Adds a value to the appropriate bucket in the histogram.
+   *
+   * @param value - The positive number to add to the histogram
+   * @throws Error if value is less than or equal to zero
+   */
+  add(value: number) {
+    if (value < 0) {
+      throw new Error(`Value must not be negative, got: ${value}`);
+    }
+    if (value < 1) {
+      this.#counts[0]++;
+      return;
+    }
+
+    const index = Math.floor(Math.log2(value)) + 1;
+
+    // Resize if index exceeds current array size
+    if (index >= this.#counts.length) {
+      const newCounts = new Uint32Array(index + 1);
+      newCounts.set(this.#counts);
+      this.#counts = newCounts;
+    }
+
+    this.#counts[index]++;
+  }
+
+  /**
+   * Returns a read-only view of the bucket counts.
+   *
+   * The first element (index 0) is the underflow bucket.
+   * All other are regular logarithmic buckets.
+   *
+   * @returns A read-only array of bucket counts
+   */
+  get counts(): Readonly<Uint32Array> {
+    return this.#counts;
+  }
+
+  /**
+   * Calculates and returns the value ranges for each bucket.
+   *
+   * @returns An array of tuples, each containing [min, max] for a bucket.
+   *          The first tuple represents the underflow bucket.
+   *          For regular buckets, the range is [min, max), where min is inclusive and max is exclusive.
+   */
+  getBucketRanges(): [number, number][] {
+    const ranges: [number, number][] = [[0, 1]];
+    for (let i = 1; i < this.#counts.length; i++) {
+      ranges.push([2 ** (i - 1), 2 ** i]);
+    }
+    return ranges;
+  }
+
+  /**
+   * Serializes the histogram data to a hex string.
+   *
+   * Each count is encoded as 8 hexadecimal characters (4 bytes).
+   *
+   * @returns A hex string representing the histogram data
+   */
+  toHexString(): string {
+    return Array.from(this.#counts, count =>
+      count.toString(16).padStart(8, '0'),
+    ).join('');
+  }
+
+  /**
+   * Creates a histogram from a serialized hex string.
+   *
+   * @param hex - The hex string representation of histogram counts
+   * @returns A new Histogram instance with the deserialized data
+   * @throws Error if the hex string format is invalid
+   */
+  static fromHexString(hex: string): LogarithmicHistogram {
+    const histogram = new LogarithmicHistogram();
+    const counts = new Uint32Array(hex.length / 8);
+    for (let i = 0; i < hex.length; i += 8) {
+      const n = parseInt(hex.slice(i, i + 8), 16);
+      if (isNaN(n)) {
+        throw new Error(`Invalid hex string: ${hex}`);
+      }
+      counts[i / 8] = n;
+    }
+    histogram.#counts = counts;
+    return histogram;
+  }
+}

--- a/packages/zero-client/src/client/inspector/inspector.test.ts
+++ b/packages/zero-client/src/client/inspector/inspector.test.ts
@@ -130,6 +130,7 @@ test('client queries', async () => {
         got: true,
         id: '1',
         inactivatedAt: null,
+        histograms: new Map(),
         rowCount: 10,
         ttl: '1m',
         zql: 'issue',
@@ -158,6 +159,7 @@ test('client queries', async () => {
         got: true,
         id: '1',
         inactivatedAt: new Date(d),
+        histograms: new Map(),
         rowCount: 10,
         ttl: '1m',
         zql: 'issue',
@@ -234,9 +236,90 @@ test('clientGroup queries', async () => {
       got: true,
       id: '1',
       inactivatedAt: null,
+      histograms: new Map(),
       rowCount: 10,
       ttl: '1m',
       zql: "issue.where(({cmp, or}) => or(cmp('id', '1'), cmp('id', '!=', '2')))",
     },
   ]);
+});
+
+test('histogram for materialization durations', async () => {
+  // The RPC uses our nanoid which uses Math.random
+  vi.spyOn(Math, 'random').mockReturnValue(0.5);
+
+  let now = 0;
+  vi.spyOn(performance, 'now').mockImplementation(() => now);
+  expect(performance.now()).toEqual(0);
+
+  const userID = nanoid();
+  const z = zeroForTest({userID, schema, kvStore: 'mem'});
+  await z.triggerConnected();
+
+  const inspector = await z.inspect();
+  expect(await inspector.clients()).toEqual([
+    {
+      clientGroup: {
+        id: await z.clientGroupID,
+      },
+      id: z.clientID,
+    },
+  ]);
+
+  await z.socket;
+
+  const ast: AST = {
+    orderBy: [['id', 'asc']],
+    table: 'issue',
+  };
+  const q = z.query.issue;
+  expect(q.ast).toEqual(ast);
+
+  const qp = q.run({type: 'complete'});
+  now += 4;
+  await z.markQueryAsGot(q);
+  await qp;
+
+  const hash = z.query.issue.hash();
+
+  const response = [
+    {
+      clientID: z.clientID,
+      queryID: hash,
+      ast,
+      deleted: false,
+      got: true,
+      inactivatedAt: null,
+      rowCount: 10,
+      ttl: 0,
+    },
+  ];
+
+  (await z.socket).messages.length = 0;
+  const p = inspector.client.queries();
+  await Promise.resolve();
+  expect((await z.socket).messages.map(s => JSON.parse(s))).toEqual([
+    [
+      'inspect',
+      {
+        op: 'queries',
+        clientID: z.clientID,
+        id: '000000000000000000000',
+      },
+    ],
+  ]);
+  await z.triggerMessage([
+    'inspect',
+    {
+      op: 'queries',
+      id: '000000000000000000000',
+      value: response,
+    },
+  ] satisfies InspectDownMessage);
+  const queries = await p;
+  expect(queries[0].histograms.get('materialize')?.counts).toEqual(
+    new Uint32Array([0, 0, 0, 1]),
+  );
+
+  expect(inspector.advanceHistogram.counts).toEqual(new Uint32Array([2, 0]));
 });

--- a/packages/zero-client/src/client/inspector/inspector.ts
+++ b/packages/zero-client/src/client/inspector/inspector.ts
@@ -13,6 +13,7 @@ import type {ReplicacheImpl} from '../../../../replicache/src/replicache-impl.ts
 import {withRead} from '../../../../replicache/src/with-transactions.ts';
 import {assert} from '../../../../shared/src/asserts.ts';
 import type {ReadonlyJSONValue} from '../../../../shared/src/json.ts';
+import type {LogarithmicHistogram} from '../../../../shared/src/logarithmic-histogram.ts';
 import * as valita from '../../../../shared/src/valita.ts';
 import type {AST} from '../../../../zero-protocol/src/ast.ts';
 import type {Row} from '../../../../zero-protocol/src/data.ts';
@@ -34,6 +35,8 @@ import type {MutatorDefs} from '../replicache-types.ts';
 import type {
   ClientGroup as ClientGroupInterface,
   Client as ClientInterface,
+  HistogramsDelegate,
+  HistogramsMap,
   Inspector as InspectorInterface,
   Query as QueryInterface,
 } from './types.ts';
@@ -44,11 +47,19 @@ type GetWebSocket = () => Promise<WebSocket>;
 
 export async function newInspector(
   rep: Rep,
+  histogramsDelegate: HistogramsDelegate,
   schema: Schema,
   socket: GetWebSocket,
 ): Promise<InspectorInterface> {
   const clientGroupID = await rep.clientGroupID;
-  return new Inspector(rep, schema, rep.clientID, clientGroupID, socket);
+  return new Inspector(
+    rep,
+    histogramsDelegate,
+    schema,
+    rep.clientID,
+    clientGroupID,
+    socket,
+  );
 }
 
 class Inspector implements InspectorInterface {
@@ -57,31 +68,57 @@ class Inspector implements InspectorInterface {
   readonly clientGroup: ClientGroup;
   readonly #schema: Schema;
   readonly socket: GetWebSocket;
+  readonly #histogramsDelegate: HistogramsDelegate;
 
   constructor(
     rep: ReplicacheImpl,
+    histogramsDelegate: HistogramsDelegate,
     schema: Schema,
     clientID: string,
     clientGroupID: string,
     socket: GetWebSocket,
   ) {
     this.#rep = rep;
+    this.#histogramsDelegate = histogramsDelegate;
     this.#schema = schema;
-    this.client = new Client(rep, schema, socket, clientID, clientGroupID);
+    this.client = new Client(
+      rep,
+      histogramsDelegate,
+      schema,
+      socket,
+      clientID,
+      clientGroupID,
+    );
     this.clientGroup = this.client.clientGroup;
     this.socket = socket;
   }
 
   clients(): Promise<ClientInterface[]> {
     return withDagRead(this.#rep, dagRead =>
-      clients(this.#rep, this.socket, this.#schema, dagRead),
+      clients(
+        this.#rep,
+        this.#histogramsDelegate,
+        this.socket,
+        this.#schema,
+        dagRead,
+      ),
     );
   }
 
   clientsWithQueries(): Promise<ClientInterface[]> {
     return withDagRead(this.#rep, dagRead =>
-      clientsWithQueries(this.#rep, this.socket, this.#schema, dagRead),
+      clientsWithQueries(
+        this.#rep,
+        this.#histogramsDelegate,
+        this.socket,
+        this.#schema,
+        dagRead,
+      ),
     );
+  }
+
+  get advanceHistogram(): LogarithmicHistogram {
+    return this.#histogramsDelegate.advanceHistogram;
   }
 }
 
@@ -121,19 +158,28 @@ class Client implements ClientInterface {
   readonly clientGroup: ClientGroup;
   readonly #schema: Schema;
   readonly #socket: GetWebSocket;
+  readonly #histogramsDelegate: HistogramsDelegate;
 
   constructor(
     rep: Rep,
+    histogramsDelegate: HistogramsDelegate,
     schema: Schema,
     socket: GetWebSocket,
     id: string,
     clientGroupID: string,
   ) {
     this.#rep = rep;
+    this.#histogramsDelegate = histogramsDelegate;
     this.#schema = schema;
     this.#socket = socket;
     this.id = id;
-    this.clientGroup = new ClientGroup(rep, socket, schema, clientGroupID);
+    this.clientGroup = new ClientGroup(
+      rep,
+      histogramsDelegate,
+      socket,
+      schema,
+      clientGroupID,
+    );
   }
 
   async queries(): Promise<QueryInterface[]> {
@@ -142,7 +188,9 @@ class Client implements ClientInterface {
       {op: 'queries', clientID: this.id} as InspectQueriesUpBody,
       inspectQueriesDownSchema,
     );
-    return rows.map(row => new Query(row, this.#schema));
+    return rows.map(
+      row => new Query(row, this.#histogramsDelegate, this.#schema),
+    );
   }
 
   map(): Promise<Map<string, ReadonlyJSONValue>> {
@@ -177,9 +225,17 @@ class ClientGroup implements ClientGroupInterface {
   readonly id: string;
   readonly #schema: Schema;
   readonly #socket: GetWebSocket;
+  #histogramsDelegate: HistogramsDelegate;
 
-  constructor(rep: Rep, socket: GetWebSocket, schema: Schema, id: string) {
+  constructor(
+    rep: Rep,
+    histogramsDelegate: HistogramsDelegate,
+    socket: GetWebSocket,
+    schema: Schema,
+    id: string,
+  ) {
     this.#rep = rep;
+    this.#histogramsDelegate = histogramsDelegate;
     this.#socket = socket;
     this.#schema = schema;
     this.id = id;
@@ -189,6 +245,7 @@ class ClientGroup implements ClientGroupInterface {
     return withDagRead(this.#rep, dagRead =>
       clients(
         this.#rep,
+        this.#histogramsDelegate,
         this.#socket,
         this.#schema,
         dagRead,
@@ -201,6 +258,7 @@ class ClientGroup implements ClientGroupInterface {
     return withDagRead(this.#rep, dagRead =>
       clientsWithQueries(
         this.#rep,
+        this.#histogramsDelegate,
         this.#socket,
         this.#schema,
         dagRead,
@@ -215,7 +273,9 @@ class ClientGroup implements ClientGroupInterface {
       {op: 'queries'},
       inspectQueriesDownSchema,
     );
-    return rows.map(row => new Query(row, this.#schema));
+    return rows.map(
+      row => new Query(row, this.#histogramsDelegate, this.#schema),
+    );
   }
 }
 
@@ -248,6 +308,7 @@ type MapEntry<T extends ReadonlyMap<any, any>> =
 
 async function clients(
   rep: Rep,
+  histogramsDelegate: HistogramsDelegate,
   socket: GetWebSocket,
   schema: Schema,
   dagRead: Read,
@@ -258,18 +319,33 @@ async function clients(
     .filter(predicate)
     .map(
       ([clientID, {clientGroupID}]) =>
-        new Client(rep, schema, socket, clientID, clientGroupID),
+        new Client(
+          rep,
+          histogramsDelegate,
+          schema,
+          socket,
+          clientID,
+          clientGroupID,
+        ),
     );
 }
 
 async function clientsWithQueries(
   rep: Rep,
+  histogramsDelegate: HistogramsDelegate,
   socket: GetWebSocket,
   schema: Schema,
   dagRead: Read,
   predicate: (entry: MapEntry<ClientMap>) => boolean = () => true,
 ): Promise<ClientInterface[]> {
-  const allClients = await clients(rep, socket, schema, dagRead, predicate);
+  const allClients = await clients(
+    rep,
+    histogramsDelegate,
+    socket,
+    schema,
+    dagRead,
+    predicate,
+  );
   const clientsWithQueries: ClientInterface[] = [];
   await Promise.all(
     allClients.map(async client => {
@@ -292,8 +368,13 @@ class Query implements QueryInterface {
   readonly id: string;
   readonly zql: string;
   readonly clientID: string;
+  readonly histograms: HistogramsMap;
 
-  constructor(row: InspectQueryRow, _schema: Schema) {
+  constructor(
+    row: InspectQueryRow,
+    histograms: HistogramsDelegate,
+    _schema: Schema,
+  ) {
     // Use own properties to make this more useful in dev tools. For example, in
     // Chrome dev tools, if you do console.table(queries) you'll see the
     // properties in the table, if these were getters you would not see them in the table.
@@ -307,5 +388,6 @@ class Query implements QueryInterface {
     this.rowCount = row.rowCount;
     this.deleted = row.deleted;
     this.zql = this.ast.table + astToZQL(this.ast);
+    this.histograms = histograms.queryHistograms(row.queryID);
   }
 }

--- a/packages/zero-client/src/client/inspector/types.ts
+++ b/packages/zero-client/src/client/inspector/types.ts
@@ -1,4 +1,5 @@
 import type {ReadonlyJSONValue} from '../../../../shared/src/json.ts';
+import type {LogarithmicHistogram} from '../../../../shared/src/logarithmic-histogram.ts';
 import type {AST} from '../../../../zero-protocol/src/ast.ts';
 import type {Row} from '../../../../zero-protocol/src/data.ts';
 import type {TTL} from '../../../../zql/src/query/ttl.ts';
@@ -12,6 +13,7 @@ export interface Inspector {
   readonly clientGroup: ClientGroup;
   clients(): Promise<Client[]>;
   clientsWithQueries(): Promise<Client[]>;
+  readonly advanceHistogram: LogarithmicHistogram;
 }
 
 export interface Client {
@@ -29,6 +31,13 @@ export interface ClientGroup {
   queries(): Promise<Query[]>;
 }
 
+export interface HistogramsDelegate {
+  readonly advanceHistogram: LogarithmicHistogram;
+  queryHistograms(hash: string): HistogramsMap;
+}
+
+export type HistogramsMap = ReadonlyMap<string, LogarithmicHistogram>;
+
 export interface Query {
   readonly ast: AST;
   readonly clientID: string;
@@ -39,4 +48,5 @@ export interface Query {
   readonly rowCount: number;
   readonly ttl: TTL;
   readonly zql: string;
+  readonly histograms: HistogramsMap;
 }

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -1879,10 +1879,15 @@ export class Zero<
     BUNDLE_SIZE: {
       const m = await import('./inspector/inspector.ts');
       // Wait for the web socket to be available
-      return m.newInspector(this.#rep, this.#schema, async () => {
-        await this.#connectResolver.promise;
-        return this.#socket!;
-      });
+      return m.newInspector(
+        this.#rep,
+        this.#zeroContext,
+        this.#schema,
+        async () => {
+          await this.#connectResolver.promise;
+          return this.#socket!;
+        },
+      );
     }
   }
 }

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -2,8 +2,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {resolver} from '@rocicorp/resolver';
 import {assert} from '../../../shared/src/asserts.ts';
+import type {ReadonlyJSONValue} from '../../../shared/src/json.ts';
+import {must} from '../../../shared/src/must.ts';
 import type {Writable} from '../../../shared/src/writable.ts';
-import {hashOfAST} from '../../../zero-protocol/src/query-hash.ts';
 import type {
   AST,
   CompoundKey,
@@ -14,6 +15,7 @@ import type {
   System,
 } from '../../../zero-protocol/src/ast.ts';
 import type {Row as IVMRow} from '../../../zero-protocol/src/data.ts';
+import {hashOfAST} from '../../../zero-protocol/src/query-hash.ts';
 import type {Schema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import {
   isOneHop,
@@ -21,6 +23,7 @@ import {
   type TableSchema,
 } from '../../../zero-schema/src/table-schema.ts';
 import {buildPipeline} from '../builder/builder.ts';
+import {NotImplementedError} from '../error.ts';
 import {ArrayView} from '../ivm/array-view.ts';
 import type {Input} from '../ivm/operator.ts';
 import type {Format, ViewFactory} from '../ivm/view.ts';
@@ -32,6 +35,8 @@ import {
   simplifyCondition,
   type ExpressionFactory,
 } from './expression.ts';
+import type {CustomQueryID} from './named.ts';
+import type {GotCallback, QueryDelegate} from './query-delegate.ts';
 import {
   type GetFilterType,
   type HumanReadable,
@@ -42,11 +47,6 @@ import {
 } from './query.ts';
 import {DEFAULT_TTL, type TTL} from './ttl.ts';
 import type {TypedView} from './typed-view.ts';
-import {NotImplementedError} from '../error.ts';
-import type {CustomQueryID} from './named.ts';
-import type {ReadonlyJSONValue} from '../../../shared/src/json.ts';
-import type {GotCallback, QueryDelegate} from './query-delegate.ts';
-import {must} from '../../../shared/src/must.ts';
 
 type AnyQuery = Query<Schema, string, any>;
 
@@ -733,7 +733,7 @@ export class QueryImpl<
       this._delegate,
       'materialize requires a query delegate to be set',
     );
-    const t0 = Date.now();
+    const t0 = performance.now();
     let factory: ViewFactory<TSchema, TTable, TReturn, T> | undefined;
     if (typeof factoryOrTTL === 'function') {
       factory = factoryOrTTL;
@@ -745,8 +745,7 @@ export class QueryImpl<
     let queryComplete = delegate.defaultQueryComplete;
     const gotCallback: GotCallback = got => {
       if (got) {
-        const t1 = Date.now();
-        delegate.onQueryMaterialized(this.hash(), ast, t1 - t0);
+        delegate.onQueryMaterialized(this.hash(), ast, performance.now() - t0);
         queryComplete = true;
         queryCompleteResolver.resolve(true);
       }


### PR DESCRIPTION
### Summary

This PR introduces support for measuring query performance metrics using logarithmic histograms. The following metrics are now tracked:

- **Materialization Time**: Measures the time taken to materialize each query, grouped by query hash.
- **Advance Time**: Measures the time taken to process changes during query updates.

### Testing

- Updated inspector tests to verify histogram data is correctly exposed for queries.