### PR TITLE
feat(zql): rename custom query APIs

### DIFF
--- a/apps/zbugs/api/index.ts
+++ b/apps/zbugs/api/index.ts
@@ -1,26 +1,24 @@
 // https://vercel.com/templates/other/fastify-serverless-function
+import '@dotenvx/dotenvx/config';
 import cookie from '@fastify/cookie';
 import oauthPlugin, {type OAuth2Namespace} from '@fastify/oauth2';
 import {Octokit} from '@octokit/core';
-import '@dotenvx/dotenvx/config';
-import Fastify, {type FastifyReply, type FastifyRequest} from 'fastify';
-import {jwtVerify, SignJWT, type JWK} from 'jose';
-import {nanoid} from 'nanoid';
-import postgres from 'postgres';
-import {handlePush} from '../server/push-handler.ts';
-import {must} from '../../../packages/shared/src/must.ts';
-import assert from 'assert';
-import {authDataSchema, type AuthData} from '../shared/auth.ts';
 import type {ReadonlyJSONValue} from '@rocicorp/zero';
-import type {IncomingHttpHeaders} from 'http';
-import * as v from '../../../packages/shared/src/valita.ts';
 import {
   transformRequestMessageSchema,
   type TransformResponseMessage,
-  query,
 } from '@rocicorp/zero';
-
-import {schema} from '../shared/schema.ts';
+import assert from 'assert';
+import Fastify, {type FastifyReply, type FastifyRequest} from 'fastify';
+import type {IncomingHttpHeaders} from 'http';
+import {jwtVerify, SignJWT, type JWK} from 'jose';
+import {nanoid} from 'nanoid';
+import postgres from 'postgres';
+import {must} from '../../../packages/shared/src/must.ts';
+import * as v from '../../../packages/shared/src/valita.ts';
+import {handlePush} from '../server/push-handler.ts';
+import {authDataSchema, type AuthData} from '../shared/auth.ts';
+import {queries} from '../shared/schema.ts';
 
 declare module 'fastify' {
   interface FastifyInstance {
@@ -144,9 +142,7 @@ fastify.post<{
   reply.send(response);
 });
 
-const queryBuilders = query(schema);
-const emptyQuery = queryBuilders.issue.where(({or}) => or());
-
+const emptyQuery = queries.issue.where(({or}) => or());
 fastify.post<{
   Querystring: Record<string, string>;
   Body: ReadonlyJSONValue;

--- a/apps/zbugs/shared/schema.ts
+++ b/apps/zbugs/shared/schema.ts
@@ -10,7 +10,7 @@ import {
   table,
   type ExpressionBuilder,
   type Row,
-  query,
+  querify,
 } from '@rocicorp/zero';
 import type {AuthData, Role} from './auth.ts';
 
@@ -202,7 +202,7 @@ export type IssueRow = Row<typeof schema.tables.issue>;
 export type CommentRow = Row<typeof schema.tables.comment>;
 export type UserRow = Row<typeof schema.tables.user>;
 
-export const queries = query(schema);
+export const queries = querify(schema);
 
 export const permissions: ReturnType<typeof definePermissions> =
   definePermissions<AuthData, Schema>(schema, () => {

--- a/packages/zero-client/src/mod.ts
+++ b/packages/zero-client/src/mod.ts
@@ -118,7 +118,7 @@ export type {
   ExpressionFactory,
 } from '../../zql/src/query/expression.ts';
 export {
-  query,
+  querify,
   type CustomQueryID,
   type NamedQuery,
   type NamedQueryImpl,


### PR DESCRIPTION
- pulling core zero changes out of https://github.com/rocicorp/mono/pull/4491 

New names:
- querify(schema) - returns a the query builder for a schema
- namedQuery(name, fn) - names a query 

Mutators will likely become:
- mutator(name, fn);

I don't think they need to be called `namedMutator`s given there will be no concept of ad-hoc mutations. ad-hoc queries will likely still exist as a client-side only concept.