### PR TITLE
feat(zero): Limit TTL to 10 minutes

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.test.ts
@@ -1,5 +1,4 @@
 import {expect, test} from 'vitest';
-import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {getInactiveQueries, type CVR} from './cvr.ts';
 import type {ClientQueryRecord} from './schema/types.ts';
 
@@ -234,6 +233,5 @@ test.each([
   },
 ])('getInactiveQueries %o', ({clients, expected}) => {
   const cvr = makeCVR(clients);
-  const lc = createSilentLogContext();
-  expect(getInactiveQueries(lc, cvr)).toEqual(expected);
+  expect(getInactiveQueries(cvr)).toEqual(expected);
 });

--- a/packages/zero-cache/src/services/view-syncer/cvr.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.test.ts
@@ -1,4 +1,5 @@
 import {expect, test} from 'vitest';
+import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {getInactiveQueries, type CVR} from './cvr.ts';
 import type {ClientQueryRecord} from './schema/types.ts';
 
@@ -56,6 +57,8 @@ function makeCVR(clients: Record<string, QueryDef[]>): CVR {
   return cvr;
 }
 
+const minutes = (n: number) => n * 60 * 1000;
+
 test.each([
   {
     clients: {
@@ -95,8 +98,8 @@ test.each([
     },
     expected: [
       {hash: 'h2', ttl: 2000, inactivatedAt: 1000},
-      {hash: 'h1', ttl: -1, inactivatedAt: 1000},
-      {hash: 'h3', ttl: -1, inactivatedAt: 3000},
+      {hash: 'h1', ttl: minutes(10), inactivatedAt: 1000},
+      {hash: 'h3', ttl: minutes(10), inactivatedAt: 3000},
     ],
   },
   {
@@ -119,7 +122,7 @@ test.each([
     },
     expected: [
       {hash: 'h1', ttl: 1000, inactivatedAt: 1000},
-      {hash: 'h2', ttl: -1, inactivatedAt: 2000},
+      {hash: 'h2', ttl: minutes(10), inactivatedAt: 2000},
     ],
   },
 
@@ -194,7 +197,7 @@ test.each([
     },
     expected: [
       {hash: 'h1', ttl: 3000, inactivatedAt: 2000},
-      {hash: 'h2', ttl: -1, inactivatedAt: 4000},
+      {hash: 'h2', ttl: minutes(10), inactivatedAt: 4000},
     ],
   },
   {
@@ -209,8 +212,8 @@ test.each([
       ],
     },
     expected: [
-      {hash: 'h2', ttl: -1, inactivatedAt: 2000},
-      {hash: 'h1', ttl: -1, inactivatedAt: 3000},
+      {hash: 'h2', ttl: minutes(10), inactivatedAt: 2000},
+      {hash: 'h1', ttl: minutes(10), inactivatedAt: 3000},
     ],
   },
   {
@@ -226,10 +229,11 @@ test.each([
     },
     expected: [
       {hash: 'h2', ttl: 2000, inactivatedAt: 1000},
-      {hash: 'h1', ttl: -1, inactivatedAt: 2000},
+      {hash: 'h1', ttl: minutes(10), inactivatedAt: 2000},
     ],
   },
 ])('getInactiveQueries %o', ({clients, expected}) => {
   const cvr = makeCVR(clients);
-  expect(getInactiveQueries(cvr)).toEqual(expected);
+  const lc = createSilentLogContext();
+  expect(getInactiveQueries(lc, cvr)).toEqual(expected);
 });

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -330,12 +330,12 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
   /**
    * Returns non active queries in the order that we want to remove them.
    */
-  getInactiveQueries(lc: LogContext): {
+  getInactiveQueries(): {
     hash: string;
     inactivatedAt: number;
     ttl: number | undefined;
   }[] {
-    return getInactiveQueries(lc, this._cvr);
+    return getInactiveQueries(this._cvr);
   }
 
   deleteDesiredQueries(
@@ -873,10 +873,7 @@ function mergeRefCounts(
   return Object.values(merged).some(v => v > 0) ? merged : null;
 }
 
-export function getInactiveQueries(
-  lc: LogContext,
-  cvr: CVR,
-): {
+export function getInactiveQueries(cvr: CVR): {
   hash: string;
   inactivatedAt: number;
   ttl: number;
@@ -896,12 +893,12 @@ export function getInactiveQueries(
     }
     for (const clientState of Object.values(query.clientState)) {
       const {inactivatedAt, ttl} = clientState;
-      const clampedTTL = clampTTL(lc, ttl);
+      const clampedTTL = clampTTL(ttl);
       if (inactivatedAt !== undefined) {
         const existing = inactive.get(queryID);
         if (existing) {
           // Use the last eviction time.
-          const existingTTL = clampTTL(lc, existing.ttl);
+          const existingTTL = clampTTL(existing.ttl);
           if (
             existingTTL + existing.inactivatedAt <
             inactivatedAt + clampedTTL
@@ -929,11 +926,11 @@ export function getInactiveQueries(
   });
 }
 
-export function nextEvictionTime(lc: LogContext, cvr: CVR): number | undefined {
+export function nextEvictionTime(cvr: CVR): number | undefined {
   let next: number | undefined;
-  for (const {inactivatedAt, ttl} of getInactiveQueries(lc, cvr)) {
+  for (const {inactivatedAt, ttl} of getInactiveQueries(cvr)) {
     // We no longer support a TTL larger than 10 minutes. So, ttl < 0 means 10 minutes.
-    const clampedTTL = clampTTL(lc, ttl);
+    const clampedTTL = clampTTL(ttl);
     const expire = inactivatedAt + clampedTTL;
     if (next === undefined || expire < next) {
       next = expire;

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -14,7 +14,7 @@ import {
 import {stringCompare} from '../../../../shared/src/string-compare.ts';
 import type {AST} from '../../../../zero-protocol/src/ast.ts';
 import type {ClientSchema} from '../../../../zero-protocol/src/client-schema.ts';
-import {compareTTL} from '../../../../zql/src/query/ttl.ts';
+import {clampTTL, compareTTL} from '../../../../zql/src/query/ttl.ts';
 import * as counters from '../../observability/counters.ts';
 import * as histograms from '../../observability/histograms.ts';
 import {stringify, type JSONObject} from '../../types/bigint-json.ts';
@@ -330,12 +330,12 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
   /**
    * Returns non active queries in the order that we want to remove them.
    */
-  getInactiveQueries(): {
+  getInactiveQueries(lc: LogContext): {
     hash: string;
     inactivatedAt: number;
     ttl: number | undefined;
   }[] {
-    return getInactiveQueries(this._cvr);
+    return getInactiveQueries(lc, this._cvr);
   }
 
   deleteDesiredQueries(
@@ -873,11 +873,15 @@ function mergeRefCounts(
   return Object.values(merged).some(v => v > 0) ? merged : null;
 }
 
-export function getInactiveQueries(cvr: CVR): {
+export function getInactiveQueries(
+  lc: LogContext,
+  cvr: CVR,
+): {
   hash: string;
   inactivatedAt: number;
   ttl: number;
 }[] {
+  // We no longer support a TTL larger than 10 minutes.
   const inactive: Map<
     string,
     {
@@ -892,28 +896,24 @@ export function getInactiveQueries(cvr: CVR): {
     }
     for (const clientState of Object.values(query.clientState)) {
       const {inactivatedAt, ttl} = clientState;
+      const clampedTTL = clampTTL(lc, ttl);
       if (inactivatedAt !== undefined) {
         const existing = inactive.get(queryID);
         if (existing) {
-          // if one of them have no ttl, then we have no ttl
-          if (existing.ttl < 0 || ttl < 0) {
-            existing.ttl = -1;
-            existing.inactivatedAt = Math.max(
-              existing.inactivatedAt,
-              inactivatedAt,
-            );
-          } else {
-            // pick the one with the last expire
-            if (existing.inactivatedAt + existing.ttl < inactivatedAt + ttl) {
-              existing.inactivatedAt = inactivatedAt;
-              existing.ttl = ttl;
-            }
+          // Use the last eviction time.
+          const existingTTL = clampTTL(lc, existing.ttl);
+          if (
+            existingTTL + existing.inactivatedAt <
+            inactivatedAt + clampedTTL
+          ) {
+            existing.ttl = clampedTTL;
+            existing.inactivatedAt = inactivatedAt;
           }
         } else {
           inactive.set(queryID, {
             hash: queryID,
             inactivatedAt,
-            ttl,
+            ttl: clampedTTL,
           });
         }
       }
@@ -925,23 +925,16 @@ export function getInactiveQueries(cvr: CVR): {
     if (a.ttl === b.ttl) {
       return a.inactivatedAt - b.inactivatedAt;
     }
-    if (a.ttl < 0) {
-      return 1;
-    }
-    if (b.ttl < 0) {
-      return -1;
-    }
     return a.inactivatedAt + a.ttl - b.inactivatedAt - b.ttl;
   });
 }
 
-export function nextEvictionTime(cvr: CVR): number | undefined {
+export function nextEvictionTime(lc: LogContext, cvr: CVR): number | undefined {
   let next: number | undefined;
-  for (const {inactivatedAt, ttl} of getInactiveQueries(cvr)) {
-    if (ttl < 0) {
-      continue;
-    }
-    const expire = inactivatedAt + ttl;
+  for (const {inactivatedAt, ttl} of getInactiveQueries(lc, cvr)) {
+    // We no longer support a TTL larger than 10 minutes. So, ttl < 0 means 10 minutes.
+    const clampedTTL = clampTTL(lc, ttl);
+    const expire = inactivatedAt + clampedTTL;
     if (next === undefined || expire < next) {
       next = expire;
     }

--- a/packages/zero-cache/src/services/view-syncer/schema/types.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/types.ts
@@ -179,6 +179,9 @@ const clientStateSchema = v.object({
    * TTL, time to live in milliseconds. If the query is not updated within this
    * time. The time to live is the time after it has become inactive. Negative
    * values are treated as `'forever'`.
+   *
+   * We do clamp this to a maximum of 10 minutes, so that queries do not
+   * live for a very long time in the CVR.
    */
   ttl: v.number(),
 

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -34,6 +34,8 @@ import {
   transformAndHashQuery,
   type TransformedAndHashed,
 } from '../../auth/read-authorizer.ts';
+import {type ZeroConfig} from '../../config/zero-config.ts';
+import {CustomQueryTransformer} from '../../custom-queries/transform-query.ts';
 import * as counters from '../../observability/counters.ts';
 import * as histograms from '../../observability/histograms.ts';
 import {stringify} from '../../types/bigint-json.ts';
@@ -79,8 +81,6 @@ import {
   type RowID,
 } from './schema/types.ts';
 import {ResetPipelinesSignal} from './snapshotter.ts';
-import {CustomQueryTransformer} from '../../custom-queries/transform-query.ts';
-import {type ZeroConfig} from '../../config/zero-config.ts';
 
 export type TokenData = {
   readonly raw: string;
@@ -718,7 +718,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
   #scheduleExpireEviction(lc: LogContext, cvr: CVRSnapshot): void {
     // first see if there is any inactive query with a ttl.
-    const next = nextEvictionTime(cvr);
+    const next = nextEvictionTime(lc, cvr);
     if (next === undefined) {
       lc.debug?.('no inactive queries with ttl');
       // no inactive queries with a ttl. Cancel existing timeout if any.
@@ -1466,7 +1466,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         `Trying to evict inactive queries, rowCount: ${rowCountBeforeEvictions} > maxRowCount: ${this.maxRowCount}`,
       );
 
-      const inactiveQueries = getInactiveQueries(cvr);
+      const inactiveQueries = getInactiveQueries(lc, cvr);
       if (!inactiveQueries.length) {
         lc.debug?.('No inactive queries to evict');
         return;

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -718,7 +718,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
   #scheduleExpireEviction(lc: LogContext, cvr: CVRSnapshot): void {
     // first see if there is any inactive query with a ttl.
-    const next = nextEvictionTime(lc, cvr);
+    const next = nextEvictionTime(cvr);
     if (next === undefined) {
       lc.debug?.('no inactive queries with ttl');
       // no inactive queries with a ttl. Cancel existing timeout if any.
@@ -1466,7 +1466,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         `Trying to evict inactive queries, rowCount: ${rowCountBeforeEvictions} > maxRowCount: ${this.maxRowCount}`,
       );
 
-      const inactiveQueries = getInactiveQueries(lc, cvr);
+      const inactiveQueries = getInactiveQueries(cvr);
       if (!inactiveQueries.length) {
         lc.debug?.('No inactive queries to evict');
         return;

--- a/packages/zql/src/query/ttl.test.ts
+++ b/packages/zql/src/query/ttl.test.ts
@@ -64,22 +64,22 @@ test.each([
 });
 
 test.each([
-  ['none', 'none'],
-  ['forever', MAX_TTL],
+  ['none', 0],
+  ['forever', 10 * 60 * 1000, true],
   [0, 0],
-  [-1, MAX_TTL],
+  [-1, 10 * 60 * 1000, true],
   [1, 1],
   [1000, 1000],
-  [10 * 60 * 1000, MAX_TTL], // Exactly at the max TTL
-  [10 * 60 * 1000 + 1, MAX_TTL], // Just above the max TTL
-  ['1h', MAX_TTL], // Above max TTL in string format
-  ['1m', '1m'], // Below max TTL in string format
-] as const)('clampTTL(%o) === %o', (ttl, expected) => {
+  [10 * 60 * 1000, 10 * 60 * 1000], // Exactly at the max TTL
+  [10 * 60 * 1000 + 1, 10 * 60 * 1000, true], // Just above the max TTL
+  ['1h', 10 * 60 * 1000, true], // Above max TTL in string format
+  ['1m', 60 * 1000], // Below max TTL in string format
+] as const)('clampTTL(%o) === %o', (ttl, expected, expectError?) => {
   const mockLogContext = {
     warn: vi.fn(),
   } as unknown as LogContext;
   expect(clampTTL(mockLogContext, ttl)).toBe(expected);
-  if (expected === MAX_TTL) {
+  if (expectError) {
     expect(mockLogContext.warn).toHaveBeenCalledWith(
       `TTL (${ttl}) is too high, clamping to ${MAX_TTL}`,
     );

--- a/packages/zql/src/query/ttl.test.ts
+++ b/packages/zql/src/query/ttl.test.ts
@@ -1,5 +1,6 @@
-import {expect, test} from 'vitest';
-import {compareTTL, normalizeTTL, parseTTL} from './ttl.ts';
+import type {LogContext} from '@rocicorp/logger';
+import {expect, test, vi} from 'vitest';
+import {clampTTL, compareTTL, MAX_TTL, normalizeTTL, parseTTL} from './ttl.ts';
 
 test.each([
   ['none', 0],
@@ -60,4 +61,29 @@ test.each([
   [1.25 * 365 * 24 * 60 * 60 * 1000, '1.25y'],
 ] as const)('normalizeTTL(%o) === %o', (ttl, expected) => {
   expect(normalizeTTL(ttl)).toBe(expected);
+});
+
+test.each([
+  ['none', 'none'],
+  ['forever', MAX_TTL],
+  [0, 0],
+  [-1, MAX_TTL],
+  [1, 1],
+  [1000, 1000],
+  [10 * 60 * 1000, MAX_TTL], // Exactly at the max TTL
+  [10 * 60 * 1000 + 1, MAX_TTL], // Just above the max TTL
+  ['1h', MAX_TTL], // Above max TTL in string format
+  ['1m', '1m'], // Below max TTL in string format
+] as const)('clampTTL(%o) === %o', (ttl, expected) => {
+  const mockLogContext = {
+    warn: vi.fn(),
+  } as unknown as LogContext;
+  expect(clampTTL(mockLogContext, ttl)).toBe(expected);
+  if (expected === MAX_TTL) {
+    expect(mockLogContext.warn).toHaveBeenCalledWith(
+      `TTL (${ttl}) is too high, clamping to ${MAX_TTL}`,
+    );
+  } else {
+    expect(mockLogContext.warn).not.toHaveBeenCalled();
+  }
 });

--- a/packages/zql/src/query/ttl.test.ts
+++ b/packages/zql/src/query/ttl.test.ts
@@ -78,7 +78,7 @@ test.each([
   const mockLogContext = {
     warn: vi.fn(),
   } as unknown as LogContext;
-  expect(clampTTL(mockLogContext, ttl)).toBe(expected);
+  expect(clampTTL(ttl, mockLogContext)).toBe(expected);
   if (expectError) {
     expect(mockLogContext.warn).toHaveBeenCalledWith(
       `TTL (${ttl}) is too high, clamping to ${MAX_TTL}`,

--- a/packages/zql/src/query/ttl.ts
+++ b/packages/zql/src/query/ttl.ts
@@ -18,6 +18,8 @@ export type TTL = `${number}${TimeUnit}` | 'forever' | 'none' | number;
 
 export const DEFAULT_TTL: TTL = 'none';
 
+export const MAX_TTL: TTL = '10m';
+
 const multiplier = {
   s: 1000,
   m: 60 * 1000,
@@ -79,14 +81,12 @@ export function normalizeTTL(ttl: TTL): TTL {
   return (shortest.length < lengthOfNumber ? shortest : ttl) as TTL;
 }
 
-export const MAX_TTL: TTL = '10m';
-
-export function clampTTL(lc: LogContext, ttl: TTL): TTL {
+export function clampTTL(lc: LogContext, ttl: TTL): number {
   const parsedTTL = parseTTL(ttl);
-  if (parsedTTL === -1 || parsedTTL >= 10 * 60 * 1000) {
+  if (parsedTTL === -1 || parsedTTL > 10 * 60 * 1000) {
     // 10 minutes in milliseconds
     lc.warn?.(`TTL (${ttl}) is too high, clamping to ${MAX_TTL}`);
-    return MAX_TTL;
+    return parseTTL(MAX_TTL);
   }
-  return ttl;
+  return parsedTTL;
 }

--- a/packages/zql/src/query/ttl.ts
+++ b/packages/zql/src/query/ttl.ts
@@ -81,11 +81,11 @@ export function normalizeTTL(ttl: TTL): TTL {
   return (shortest.length < lengthOfNumber ? shortest : ttl) as TTL;
 }
 
-export function clampTTL(lc: LogContext, ttl: TTL): number {
+export function clampTTL(ttl: TTL, lc?: LogContext): number {
   const parsedTTL = parseTTL(ttl);
   if (parsedTTL === -1 || parsedTTL > 10 * 60 * 1000) {
     // 10 minutes in milliseconds
-    lc.warn?.(`TTL (${ttl}) is too high, clamping to ${MAX_TTL}`);
+    lc?.warn?.(`TTL (${ttl}) is too high, clamping to ${MAX_TTL}`);
     return parseTTL(MAX_TTL);
   }
   return parsedTTL;

--- a/packages/zql/src/query/ttl.ts
+++ b/packages/zql/src/query/ttl.ts
@@ -1,3 +1,5 @@
+import type {LogContext} from '@rocicorp/logger';
+
 export type TimeUnit = 's' | 'm' | 'h' | 'd' | 'y';
 
 /**
@@ -75,4 +77,16 @@ export function normalizeTTL(ttl: TTL): TTL {
   }
 
   return (shortest.length < lengthOfNumber ? shortest : ttl) as TTL;
+}
+
+export const MAX_TTL: TTL = '10m';
+
+export function clampTTL(lc: LogContext, ttl: TTL): TTL {
+  const parsedTTL = parseTTL(ttl);
+  if (parsedTTL === -1 || parsedTTL >= 10 * 60 * 1000) {
+    // 10 minutes in milliseconds
+    lc.warn?.(`TTL (${ttl}) is too high, clamping to ${MAX_TTL}`);
+    return MAX_TTL;
+  }
+  return ttl;
 }


### PR DESCRIPTION
If the TTL is set to "never" or a value greater than 10 minutes, we now
default it to 10 minutes. This is to prevent that queries are active for
too long, which can lead to performance issues and resource exhaustion.

This is dealt with on both the client and server. On the client we log
a warning and change the TTL. On the server we treat `-1` as 10 minutes so that old
existing queries will also expire.