### PR TITLE
chore(zbugs): roll litestream folder

### DIFF
--- a/prod/sst/sst.config.ts
+++ b/prod/sst/sst.config.ts
@@ -176,7 +176,7 @@ export default $config({
       environment: {
         ...commonEnv,
         ZERO_LOG_LEVEL: 'debug',
-        ZERO_LITESTREAM_BACKUP_URL: $interpolate`s3://${replicationBucket.name}/backup/20250609-01`,
+        ZERO_LITESTREAM_BACKUP_URL: $interpolate`s3://${replicationBucket.name}/backup/20250616-00`,
         ZERO_INITIAL_SYNC_PROFILE_COPY: 'true',
         ZERO_CHANGE_MAX_CONNS: '3',
         ZERO_NUM_SYNC_WORKERS: '0',


### PR DESCRIPTION
Since we've switched to custom queries, all the existing `forever` preloads will still be cached and running too.

Nuke them by forcing a re-sync of all clients.

@cesara - this will force a reset of the CVR db too, correct?