### PR TITLE
chore(zer-client): Send active clients on connect

### DIFF
--- a/packages/zero-client/src/client/active-clients-manager.ts
+++ b/packages/zero-client/src/client/active-clients-manager.ts
@@ -1,7 +1,7 @@
 import {resolver} from '@rocicorp/resolver';
 import {getBrowserGlobal} from '../../../shared/src/browser-env.ts';
 
-const lockKeyPrefix = 'zero-alive';
+const lockKeyPrefix = 'zero-active-clients';
 
 function toLockKey(clientGroupID: string, clientID: string): string {
   return `${lockKeyPrefix}/${clientGroupID}/${clientID}`;
@@ -28,7 +28,7 @@ function fromLockKey(
 const allMockLocks = new Set<{name: string}>();
 
 /**
- * A class that lists the alive clients in a client group. It uses the
+ * A class that lists the active clients in a client group. It uses the
  * `navigator.locks` API to manage locks for each client. The class is designed
  * to be used in a browser environment where the `navigator.locks` API is
  * available.
@@ -40,7 +40,7 @@ const allMockLocks = new Set<{name: string}>();
  * and `clientID`. Then the `query` method is used to get the list of all
  * clients that hold or are waiting for locks in the same client group.
  */
-export class AliveClientsManager {
+export class ActiveClientsManager {
   readonly clientGroupID: string;
   readonly clientID: string;
   readonly #resolver = resolver<void>();
@@ -78,14 +78,14 @@ export class AliveClientsManager {
     );
   }
 
-  async getAliveClients(): Promise<Set<string>> {
-    const aliveClients: Set<string> = new Set();
+  async getActiveClients(): Promise<Set<string>> {
+    const activeClients: Set<string> = new Set();
 
     const add = (info: Iterable<{name?: string}> | undefined) => {
       for (const lock of info ?? []) {
         const client = fromLockKey(lock.name);
         if (client?.clientGroupID === this.clientGroupID) {
-          aliveClients.add(client.clientID);
+          activeClients.add(client.clientID);
         }
       }
     };
@@ -97,6 +97,6 @@ export class AliveClientsManager {
       add(snapshot.held);
       add(snapshot.pending);
     }
-    return aliveClients;
+    return activeClients;
   }
 }

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -383,7 +383,7 @@ describe('createSocket', () => {
         undefined,
         1048 * 8,
         additionalConnectParams,
-        {getAliveClients: () => Promise.resolve(activeClients)},
+        {getActiveClients: () => Promise.resolve(activeClients)},
       );
       expect(`${mockSocket.url}`).equal(expectedURL);
       expect(mockSocket.protocol).equal(
@@ -421,7 +421,7 @@ describe('createSocket', () => {
         undefined,
         0, // do not put any extra information into headers
         additionalConnectParams,
-        {getAliveClients: () => Promise.resolve(activeClients)},
+        {getActiveClients: () => Promise.resolve(activeClients)},
       );
       expect(`${mockSocket.url}`).equal(expectedURL);
       expect(mockSocket2.protocol).equal(encodeSecProtocols(undefined, auth));

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -351,6 +351,7 @@ describe('createSocket', () => {
     now: number,
     expectedURL: string,
     additionalConnectParams?: Record<string, string>,
+    activeClients = new Set([clientID]),
   ) => {
     const clientSchema: ClientSchema = {
       tables: {
@@ -382,6 +383,7 @@ describe('createSocket', () => {
         undefined,
         1048 * 8,
         additionalConnectParams,
+        {getAliveClients: () => Promise.resolve(activeClients)},
       );
       expect(`${mockSocket.url}`).equal(expectedURL);
       expect(mockSocket.protocol).equal(
@@ -392,6 +394,7 @@ describe('createSocket', () => {
               desiredQueriesPatch: [],
               deleted: {clientIDs: ['old-deleted-client']},
               ...(baseCookie === null ? {clientSchema} : {}),
+              activeClients: [...activeClients],
             },
           ],
           auth,
@@ -418,6 +421,7 @@ describe('createSocket', () => {
         undefined,
         0, // do not put any extra information into headers
         additionalConnectParams,
+        {getAliveClients: () => Promise.resolve(activeClients)},
       );
       expect(`${mockSocket.url}`).equal(expectedURL);
       expect(mockSocket2.protocol).equal(encodeSecProtocols(undefined, auth));
@@ -767,43 +771,37 @@ describe('initConnection', () => {
         decodeSecProtocols(mockSocket.protocol).initConnectionMessage,
         initConnectionMessageSchema,
       ),
-    ).toMatchInlineSnapshot(`
-      [
-        "initConnection",
-        {
-          "clientSchema": {
-            "tables": {
-              "e": {
-                "columns": {
-                  "id": {
-                    "type": "string",
-                  },
-                  "value": {
-                    "type": "string",
-                  },
+    ).toEqual([
+      'initConnection',
+      {
+        activeClients: [r.clientID],
+        clientSchema: {
+          tables: {
+            e: {
+              columns: {
+                id: {
+                  type: 'string',
+                },
+                value: {
+                  type: 'string',
                 },
               },
             },
           },
-          "desiredQueriesPatch": [
-            {
-              "ast": {
-                "orderBy": [
-                  [
-                    "id",
-                    "asc",
-                  ],
-                ],
-                "table": "e",
-              },
-              "hash": "29j3x0l4bxthp",
-              "op": "put",
-              "ttl": 0,
-            },
-          ],
         },
-      ]
-    `);
+        desiredQueriesPatch: [
+          {
+            ast: {
+              orderBy: [['id', 'asc']],
+              table: 'e',
+            },
+            hash: '29j3x0l4bxthp',
+            op: 'put',
+            ttl: 0,
+          },
+        ],
+      },
+    ]);
 
     expect(mockSocket.messages.length).toEqual(0);
     await r.triggerConnected();
@@ -864,52 +862,45 @@ describe('initConnection', () => {
         decodeSecProtocols(mockSocket.protocol).initConnectionMessage,
         initConnectionMessageSchema,
       ),
-    ).toMatchInlineSnapshot(`
-      [
-        "initConnection",
-        {
-          "clientSchema": {
-            "tables": {
-              "e": {
-                "columns": {
-                  "id": {
-                    "type": "string",
-                  },
-                  "value": {
-                    "type": "string",
-                  },
+    ).toEqual([
+      'initConnection',
+      {
+        activeClients: [r.clientID],
+        clientSchema: {
+          tables: {
+            e: {
+              columns: {
+                id: {
+                  type: 'string',
+                },
+                value: {
+                  type: 'string',
                 },
               },
             },
           },
-          "deleted": {
-            "clientIDs": [
-              "a",
-            ],
-          },
-          "desiredQueriesPatch": [
-            {
-              "ast": {
-                "orderBy": [
-                  [
-                    "id",
-                    "asc",
-                  ],
-                ],
-                "table": "e",
-              },
-              "hash": "29j3x0l4bxthp",
-              "op": "put",
-              "ttl": 0,
-            },
-          ],
         },
-      ]
-    `);
+        deleted: {
+          clientIDs: ['a'],
+        },
+        desiredQueriesPatch: [
+          {
+            ast: {
+              orderBy: [['id', 'asc']],
+              table: 'e',
+            },
+            hash: '29j3x0l4bxthp',
+            op: 'put',
+            ttl: 0,
+          },
+        ],
+      },
+    ]);
 
     expect(mockSocket.messages.length).toEqual(0);
     await r.triggerConnected();
     expect(mockSocket.messages.length).toEqual(0);
+    await r.close();
   });
 
   test('sends desired queries patch in `initConnectionMessage` when the patch is over maxHeaderLength', async () => {
@@ -976,6 +967,8 @@ describe('initConnection', () => {
     view.addListener(() => {});
     await r.triggerConnected();
     expect(mockSocket.messages.length).toEqual(1);
+
+    await r.close();
   });
 
   test('sends desired queries patch in `initConnectionMessage` when the patch is over maxHeaderLength with deleted clients', async () => {
@@ -1095,6 +1088,7 @@ describe('initConnection', () => {
     ).toEqual([
       'initConnection',
       {
+        activeClients: [r.clientID],
         desiredQueriesPatch: [],
         clientSchema: {
           tables: {

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -86,6 +86,7 @@ import {
 } from '../../../zql/src/query/query.ts';
 import {nanoid} from '../util/nanoid.ts';
 import {send} from '../util/socket.ts';
+import {AliveClientsManager} from './alive-clients-manager.ts';
 import * as ConnectionState from './connection-state-enum.ts';
 import {ZeroContext} from './context.ts';
 import {
@@ -370,6 +371,7 @@ export class Zero<
 
   // We use an accessor pair to allow the subclass to override the setter.
   #connectionState: ConnectionState = ConnectionState.Disconnected;
+  #aliveClientsManager: AliveClientsManager | undefined;
 
   #setConnectionState(state: ConnectionState) {
     if (state === this.#connectionState) {
@@ -593,6 +595,14 @@ export class Zero<
     this.userID = userID;
     this.#lc = lc.withContext('clientID', rep.clientID);
     this.#mutationTracker.clientID = rep.clientID;
+
+    void rep.clientGroupID.then(clientGroupID => {
+      this.#aliveClientsManager = new AliveClientsManager(
+        clientGroupID,
+        rep.clientID,
+        this.#closeAbortController.signal,
+      );
+    });
 
     const onUpdateNeededCallback = (
       reason: UpdateNeededReason,
@@ -1217,6 +1227,7 @@ export class Zero<
       this.#options.push,
       this.#options.maxHeaderLength,
       additionalConnectParams,
+      this.#aliveClientsManager,
     );
 
     if (this.closed) {
@@ -1914,7 +1925,8 @@ export async function createSocket(
   lc: ZeroLogContext,
   userPushParams: UserPushParams | undefined,
   maxHeaderLength = 1024 * 8,
-  additionalConnectParams?: Record<string, string> | undefined,
+  additionalConnectParams: Record<string, string> | undefined,
+  aliveClientsManager: Pick<AliveClientsManager, 'getAliveClients'> | undefined,
 ): Promise<
   [
     WebSocket,
@@ -1960,6 +1972,8 @@ export async function createSocket(
   let queriesPatch: Map<string, UpQueriesPatchOp> | undefined =
     await queriesPatchP;
 
+  const activeClients = await aliveClientsManager?.getAliveClients();
+
   let secProtocol = encodeSecProtocols(
     [
       'initConnection',
@@ -1970,6 +1984,7 @@ export async function createSocket(
         // Henceforth it is stored with the CVR and verified automatically.
         ...(baseCookie === null ? {clientSchema} : {}),
         userPushParams,
+        activeClients: activeClients && [...activeClients],
       },
     ],
     auth,

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -1927,7 +1927,7 @@ export async function createSocket(
   maxHeaderLength = 1024 * 8,
   additionalConnectParams: Record<string, string> | undefined,
   aliveClientsManager:
-    | Pick<ActiveClientsManager, 'getAliveClients'>
+    | Pick<ActiveClientsManager, 'getActiveClients'>
     | undefined,
 ): Promise<
   [

--- a/packages/zero-protocol/src/ast.test.ts
+++ b/packages/zero-protocol/src/ast.test.ts
@@ -607,5 +607,5 @@ test('protocol version', () => {
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
   expect(hash).toEqual('1c228prd1v53r');
-  expect(PROTOCOL_VERSION).toEqual(18);
+  expect(PROTOCOL_VERSION).toEqual(19);
 });

--- a/packages/zero-protocol/src/connect.ts
+++ b/packages/zero-protocol/src/connect.ts
@@ -30,6 +30,14 @@ const initConnectionBodySchema = v.object({
   clientSchema: clientSchemaSchema.optional(),
   deleted: deleteClientsBodySchema.optional(),
   userPushParams: userPushParamsSchema.optional(),
+
+  /**
+   * `activeClients` is an optional array of client IDs that are currently active
+   * in the client group. This is used to inform the server about the clients
+   * that are currently active (aka running, aka alive), so it can inactive
+   * queries from inactive clients.
+   */
+  activeClients: v.array(v.string()).optional(),
 });
 
 export const initConnectionMessageSchema = v.tuple([

--- a/packages/zero-protocol/src/protocol-version.test.ts
+++ b/packages/zero-protocol/src/protocol-version.test.ts
@@ -11,6 +11,6 @@ test('protocol version', () => {
   // If this test fails upstream or downstream schema has changed such that
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
-  expect(hash).toEqual('3m0maejt4jhl3');
-  expect(PROTOCOL_VERSION).toEqual(18);
+  expect(hash).toEqual('1281atik6gm8m');
+  expect(PROTOCOL_VERSION).toEqual(19);
 });

--- a/packages/zero-protocol/src/protocol-version.ts
+++ b/packages/zero-protocol/src/protocol-version.ts
@@ -24,7 +24,8 @@ import {assert} from '../../shared/src/asserts.ts';
 // -- Version 16 adds a new error type (alreadyProcessed) to mutation responses
 // -- Version 17 deprecates `AST` in downstream query puts. It was never used anyway.
 // -- Version 18 adds `name` and `args` to the `queries-patch` protocol
-export const PROTOCOL_VERSION = 18;
+// -- Version 19 adds `activeClients` to the `initConnection` protocol
+export const PROTOCOL_VERSION = 19;
 
 /**
  * The minimum server-supported sync protocol version (i.e. the version


### PR DESCRIPTION
This sends the active clients on connect.

The active clients will later be used to determine what desired queries can be inactivated