### PR TITLE
feat(zero-cache): forward cookies from request to API server (disabled by default)

### DIFF
--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -44,6 +44,14 @@ test('zero-cache --help', () => {
        ZERO_PUSH_API_KEY env                                                                                                                                       
                                                                  An optional secret used to authorize zero-cache to call the API server handling writes.           
                                                                                                                                                                    
+     --push-forward-cookies boolean                              default: false                                                                                    
+       ZERO_PUSH_FORWARD_COOKIES env                                                                                                                               
+                                                                 If true, zero-cache will forward cookies from the request to the push URL.                        
+                                                                 This is useful for passing authentication cookies to the API server.                              
+                                                                 If false, cookies are not forwarded.                                                              
+                                                                                                                                                                   
+                                                                 Note that this option is only relevant if the push-url is set.                                    
+                                                                                                                                                                   
      --pull-url string                                           optional                                                                                          
        ZERO_PULL_URL env                                                                                                                                           
                                                                  The URL of the API server to which zero-cache will send named queries.                            
@@ -51,6 +59,14 @@ test('zero-cache --help', () => {
      --pull-api-key string                                       optional                                                                                          
        ZERO_PULL_API_KEY env                                                                                                                                       
                                                                  An optional secret used to authorize zero-cache to call the API server handling reads.            
+                                                                                                                                                                   
+     --pull-forward-cookies boolean                              default: false                                                                                    
+       ZERO_PULL_FORWARD_COOKIES env                                                                                                                               
+                                                                 If true, zero-cache will forward cookies from the request to the pull URL.                        
+                                                                 This is useful for passing authentication cookies to the API server.                              
+                                                                 If false, cookies are not forwarded.                                                              
+                                                                                                                                                                   
+                                                                 Note that this option is only relevant if the pull-url is set.                                    
                                                                                                                                                                    
      --cvr-db string                                             optional                                                                                          
        ZERO_CVR_DB env                                                                                                                                             

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -208,6 +208,16 @@ export const zeroOptions = {
         `An optional secret used to authorize zero-cache to call the API server handling writes.`,
       ],
     },
+    forwardCookies: {
+      type: v.boolean().default(false),
+      desc: [
+        `If true, zero-cache will forward cookies from the request to the push URL.`,
+        `This is useful for passing authentication cookies to the API server.`,
+        `If false, cookies are not forwarded.`,
+        ``,
+        `Note that this option is only relevant if the {bold push-url} is set.`,
+      ],
+    },
   },
 
   pull: {
@@ -221,6 +231,16 @@ export const zeroOptions = {
       type: v.string().optional(),
       desc: [
         `An optional secret used to authorize zero-cache to call the API server handling reads.`,
+      ],
+    },
+    forwardCookies: {
+      type: v.boolean().default(false),
+      desc: [
+        `If true, zero-cache will forward cookies from the request to the pull URL.`,
+        `This is useful for passing authentication cookies to the API server.`,
+        `If false, cookies are not forwarded.`,
+        ``,
+        `Note that this option is only relevant if the {bold pull-url} is set.`,
       ],
     },
   },

--- a/packages/zero-cache/src/custom/fetch.ts
+++ b/packages/zero-cache/src/custom/fetch.ts
@@ -8,6 +8,7 @@ const reservedParams = ['schema', 'appID'];
 export type HeaderOptions = {
   apiKey?: string | undefined;
   token?: string | undefined;
+  cookie?: string | undefined;
 };
 
 export async function fetchFromAPIServer(
@@ -26,6 +27,9 @@ export async function fetchFromAPIServer(
   }
   if (headerOptions.token !== undefined) {
     headers['Authorization'] = `Bearer ${headerOptions.token}`;
+  }
+  if (headerOptions.cookie !== undefined) {
+    headers['Cookie'] = headerOptions.cookie;
   }
 
   const urlObj = new URL(url);

--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -125,10 +125,12 @@ export default function runWorker(
       : (id: string) =>
           new PusherService(
             config,
+            {
+              ...config.push,
+              url: must(config.push.url),
+            },
             lc.withContext('clientGroupID', id),
             id,
-            must(config.push.url),
-            config.push.apiKey,
           );
 
   const syncer = new Syncer(

--- a/packages/zero-cache/src/services/mutagen/pusher.test.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.test.ts
@@ -295,10 +295,12 @@ describe('pusher service', () => {
   test('the service can be stopped', async () => {
     const pusher = new PusherService(
       config,
+      {
+        url: 'http://example.com',
+        forwardCookies: false,
+      },
       lc,
       'cgid',
-      'http://exmaple.com',
-      undefined,
     );
     let shutDown = false;
     void pusher.run().then(() => {
@@ -316,10 +318,13 @@ describe('pusher service', () => {
 
     const pusher = new PusherService(
       config,
+      {
+        url: 'http://example.com',
+        apiKey: 'api-key',
+        forwardCookies: false,
+      },
       lc,
       'cgid',
-      'http://exmaple.com',
-      'api-key',
     );
     void pusher.run();
     pusher.initConnection(clientID, wsID, undefined);
@@ -346,10 +351,13 @@ describe('pusher service', () => {
 
     const pusher = new PusherService(
       config,
+      {
+        url: 'http://example.com',
+        apiKey: 'api-key',
+        forwardCookies: false,
+      },
       lc,
       'cgid',
-      'http://exmaple.com',
-      'api-key',
     );
     void pusher.run();
     pusher.initConnection(clientID, wsID, undefined);
@@ -359,7 +367,7 @@ describe('pusher service', () => {
     await pusher.stop();
 
     expect(fetch.mock.calls[0][0]).toMatchInlineSnapshot(
-      `"http://exmaple.com/?schema=zero_0&appID=zero"`,
+      `"http://example.com/?schema=zero_0&appID=zero"`,
     );
 
     fetch.mockReset();
@@ -374,10 +382,13 @@ describe('pusher service', () => {
 
     const pusher = new PusherService(
       config,
+      {
+        url: 'http://example.com',
+        apiKey: 'api-key',
+        forwardCookies: false,
+      },
       lc,
       'cgid',
-      'http://exmaple.com',
-      'api-key',
     );
 
     void pusher.run();
@@ -412,16 +423,74 @@ describe('pusher service', () => {
     expect(JSON.parse(fetch.mock.calls[1][1].body).mutations).toHaveLength(3);
     expect(fetch.mock.calls).toHaveLength(2);
   });
+
+  test('the service does not forward cookies if forwardCookies is false', async () => {
+    const fetch = (global.fetch = vi.fn());
+    fetch.mockResolvedValue({
+      ok: true,
+    });
+
+    const pusher = new PusherService(
+      config,
+      {
+        url: 'http://example.com',
+        apiKey: 'api-key',
+        forwardCookies: false,
+      },
+      lc,
+      'cgid',
+    );
+    void pusher.run();
+    pusher.initConnection(clientID, wsID, undefined);
+
+    pusher.enqueuePush(clientID, makePush(1), 'jwt', 'my-cookie');
+
+    await pusher.stop();
+
+    expect(fetch.mock.calls[0][1]?.headers).not.toHaveProperty('Cookie');
+  });
+
+  test('the service forwards cookies if forwardCookies is true', async () => {
+    const fetch = (global.fetch = vi.fn());
+    fetch.mockResolvedValue({
+      ok: true,
+    });
+
+    const pusher = new PusherService(
+      config,
+      {
+        url: 'http://example.com',
+        apiKey: 'api-key',
+        forwardCookies: true,
+      },
+      lc,
+      'cgid',
+    );
+    void pusher.run();
+    pusher.initConnection(clientID, wsID, undefined);
+
+    pusher.enqueuePush(clientID, makePush(1), 'jwt', 'my-cookie');
+
+    await pusher.stop();
+
+    expect(fetch.mock.calls[0][1]?.headers).toHaveProperty(
+      'Cookie',
+      'my-cookie',
+    );
+  });
 });
 
 describe('initConnection', () => {
   test('initConnection returns a stream', () => {
     const pusher = new PusherService(
       config,
+      {
+        url: 'http://example.com',
+        apiKey: 'api-key',
+        forwardCookies: false,
+      },
       lc,
       'cgid',
-      'http://example.com',
-      'api-key',
     );
     void pusher.run();
 
@@ -432,10 +501,13 @@ describe('initConnection', () => {
   test('initConnection throws if it was already called for the same clientID and wsID', () => {
     const pusher = new PusherService(
       config,
+      {
+        url: 'http://example.com',
+        apiKey: 'api-key',
+        forwardCookies: false,
+      },
       lc,
       'cgid',
-      'http://example.com',
-      'api-key',
     );
     void pusher.run();
     pusher.initConnection('c1', 'ws1', undefined);
@@ -447,10 +519,13 @@ describe('initConnection', () => {
   test('initConnection destroys prior stream for same client when wsID changes', async () => {
     const pusher = new PusherService(
       config,
+      {
+        url: 'http://example.com',
+        apiKey: 'api-key',
+        forwardCookies: false,
+      },
       lc,
       'cgid',
-      'http://example.com',
-      'api-key',
     );
     void pusher.run();
     const stream1 = pusher.initConnection('c1', 'ws1', undefined);
@@ -471,10 +546,13 @@ describe('initConnection', () => {
 
     const pusher = new PusherService(
       config,
+      {
+        url: 'http://example.com',
+        apiKey: 'api-key',
+        forwardCookies: false,
+      },
       lc,
       'cgid',
-      'http://example.com',
-      'api-key',
     );
     void pusher.run();
 
@@ -515,10 +593,13 @@ describe('pusher streaming', () => {
   test('returns ok for subsequent pushes from same client', () => {
     const pusher = new PusherService(
       config,
+      {
+        url: 'http://example.com',
+        apiKey: 'api-key',
+        forwardCookies: false,
+      },
       lc,
       'cgid',
-      'http://example.com',
-      'api-key',
     );
     void pusher.run();
 
@@ -549,10 +630,13 @@ describe('pusher streaming', () => {
 
     const pusher = new PusherService(
       config,
+      {
+        url: 'http://example.com',
+        apiKey: 'api-key',
+        forwardCookies: false,
+      },
       lc,
       'cgid',
-      'http://example.com',
-      'api-key',
     );
     void pusher.run();
     const stream1 = pusher.initConnection('client1', 'ws1', undefined);
@@ -630,10 +714,13 @@ describe('pusher streaming', () => {
 
     const pusher = new PusherService(
       config,
+      {
+        url: 'http://example.com',
+        apiKey: 'api-key',
+        forwardCookies: false,
+      },
       lc,
       'cgid',
-      'http://example.com',
-      'api-key',
     );
     void pusher.run();
     const stream1 = pusher.initConnection('client1', 'ws1', undefined);
@@ -687,10 +774,13 @@ describe('pusher streaming', () => {
 
     const pusher = new PusherService(
       config,
+      {
+        url: 'http://example.com',
+        apiKey: 'api-key',
+        forwardCookies: false,
+      },
       lc,
       'cgid',
-      'http://example.com',
-      'api-key',
     );
     void pusher.run();
     const stream = pusher.initConnection(clientID, wsID, undefined);
@@ -718,10 +808,13 @@ describe('pusher streaming', () => {
   test('cleanup removes client subscription', () => {
     const pusher = new PusherService(
       config,
+      {
+        url: 'http://example.com',
+        apiKey: 'api-key',
+        forwardCookies: false,
+      },
       lc,
       'cgid',
-      'http://example.com',
-      'api-key',
     );
     void pusher.run();
 
@@ -740,10 +833,13 @@ describe('pusher streaming', () => {
   test('new websocket for same client creates new downstream', async () => {
     const pusher = new PusherService(
       config,
+      {
+        url: 'http://example.com',
+        apiKey: 'api-key',
+        forwardCookies: false,
+      },
       lc,
       'cgid',
-      'http://example.com',
-      'api-key',
     );
     void pusher.run();
 
@@ -780,10 +876,13 @@ describe('pusher streaming', () => {
 
     const pusher = new PusherService(
       config,
+      {
+        url: 'http://example.com',
+        apiKey: 'api-key',
+        forwardCookies: false,
+      },
       lc,
       'cgid',
-      'http://example.com',
-      'api-key',
     );
     void pusher.run();
 
@@ -836,10 +935,13 @@ describe('pusher streaming', () => {
 
     const pusher = new PusherService(
       config,
+      {
+        url: 'http://example.com',
+        apiKey: 'api-key',
+        forwardCookies: false,
+      },
       lc,
       'cgid',
-      'http://example.com',
-      'api-key',
     );
     void pusher.run();
 
@@ -862,10 +964,13 @@ describe('pusher streaming', () => {
 
     const pusher = new PusherService(
       config,
+      {
+        url: 'http://example.com',
+        apiKey: 'api-key',
+        forwardCookies: false,
+      },
       lc,
       'cgid',
-      'http://example.com',
-      'api-key',
     );
     void pusher.run();
 

--- a/packages/zero-cache/src/services/mutagen/pusher.test.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.test.ts
@@ -42,11 +42,15 @@ describe('combine pushes', () => {
       {
         push: makePush(1),
         jwt: 'a',
+        httpCookie: undefined,
+
         clientID,
       },
       {
         push: makePush(1),
         jwt: 'a',
+        httpCookie: undefined,
+
         clientID,
       },
       undefined,
@@ -60,12 +64,16 @@ describe('combine pushes', () => {
       {
         push: makePush(1),
         jwt: 'a',
+        httpCookie: undefined,
+
         clientID,
       },
       undefined,
       {
         push: makePush(1),
         jwt: 'a',
+        httpCookie: undefined,
+
         clientID,
       },
     ]);
@@ -80,16 +88,19 @@ describe('combine pushes', () => {
       {
         push: makePush(1, 'client1'),
         jwt: 'a',
+        httpCookie: undefined,
         clientID: 'client1',
       },
       {
         push: makePush(2, 'client1'),
         jwt: 'a',
+        httpCookie: undefined,
         clientID: 'client1',
       },
       {
         push: makePush(1, 'client2'),
         jwt: 'b',
+        httpCookie: undefined,
         clientID: 'client2',
       },
     ]);
@@ -114,11 +125,13 @@ describe('combine pushes', () => {
         {
           push: makePush(1, 'client1'),
           jwt: 'a',
+          httpCookie: undefined,
           clientID: 'client1',
         },
         {
           push: makePush(2, 'client1'),
-          jwt: 'b', // Different JWT
+          jwt: 'b',
+          httpCookie: undefined, // Different JWT
           clientID: 'client1',
         },
       ]),
@@ -134,6 +147,7 @@ describe('combine pushes', () => {
             schemaVersion: 1,
           },
           jwt: 'a',
+          httpCookie: undefined,
           clientID: 'client1',
         },
         {
@@ -142,6 +156,7 @@ describe('combine pushes', () => {
             schemaVersion: 2, // Different schema version
           },
           jwt: 'a',
+          httpCookie: undefined,
           clientID: 'client1',
         },
       ]),
@@ -159,6 +174,7 @@ describe('combine pushes', () => {
             pushVersion: 1,
           },
           jwt: 'a',
+          httpCookie: undefined,
           clientID: 'client1',
         },
         {
@@ -167,6 +183,7 @@ describe('combine pushes', () => {
             pushVersion: 2, // Different push version
           },
           jwt: 'a',
+          httpCookie: undefined,
           clientID: 'client1',
         },
       ]),
@@ -184,6 +201,7 @@ describe('combine pushes', () => {
           pushVersion: 1,
         },
         jwt: 'a',
+        httpCookie: undefined,
         clientID: 'client1',
       },
       {
@@ -193,6 +211,7 @@ describe('combine pushes', () => {
           pushVersion: 1,
         },
         jwt: 'a',
+        httpCookie: undefined,
         clientID: 'client1',
       },
     ]);
@@ -207,21 +226,25 @@ describe('combine pushes', () => {
       {
         push: makePush(1, 'client1'),
         jwt: 'a',
+        httpCookie: undefined,
         clientID: 'client1',
       },
       {
         push: makePush(2, 'client2'),
         jwt: 'b',
+        httpCookie: undefined,
         clientID: 'client2',
       },
       {
         push: makePush(1, 'client1'),
         jwt: 'a',
+        httpCookie: undefined,
         clientID: 'client1',
       },
       {
         push: makePush(3, 'client2'),
         jwt: 'b',
+        httpCookie: undefined,
         clientID: 'client2',
       },
     ]);
@@ -243,16 +266,19 @@ describe('combine pushes', () => {
       {
         push: makePush(1, 'client1'),
         jwt: 'a',
+        httpCookie: undefined,
         clientID: 'client1',
       },
       {
         push: makePush(1, 'client2'),
         jwt: 'b',
+        httpCookie: undefined,
         clientID: 'client2',
       },
       {
         push: makePush(1, 'client1'),
         jwt: 'a',
+        httpCookie: undefined,
         clientID: 'client1',
       },
     ]);
@@ -298,7 +324,7 @@ describe('pusher service', () => {
     void pusher.run();
     pusher.initConnection(clientID, wsID, undefined);
 
-    pusher.enqueuePush(clientID, makePush(1), 'jwt');
+    pusher.enqueuePush(clientID, makePush(1), 'jwt', undefined);
 
     await pusher.stop();
 
@@ -328,7 +354,7 @@ describe('pusher service', () => {
     void pusher.run();
     pusher.initConnection(clientID, wsID, undefined);
 
-    pusher.enqueuePush(clientID, makePush(1), 'jwt');
+    pusher.enqueuePush(clientID, makePush(1), 'jwt', undefined);
 
     await pusher.stop();
 
@@ -356,7 +382,7 @@ describe('pusher service', () => {
 
     void pusher.run();
     pusher.initConnection(clientID, wsID, undefined);
-    pusher.enqueuePush(clientID, makePush(1), 'jwt');
+    pusher.enqueuePush(clientID, makePush(1), 'jwt', undefined);
     // release control of the loop so the push can be sent
     await Promise.resolve();
 
@@ -365,11 +391,11 @@ describe('pusher service', () => {
     expect(JSON.parse(fetch.mock.calls[0][1].body).mutations).toHaveLength(1);
 
     // We have not resolved the API server yet so these should stack up
-    pusher.enqueuePush(clientID, makePush(1), 'jwt');
+    pusher.enqueuePush(clientID, makePush(1), 'jwt', undefined);
     await Promise.resolve();
-    pusher.enqueuePush(clientID, makePush(1), 'jwt');
+    pusher.enqueuePush(clientID, makePush(1), 'jwt', undefined);
     await Promise.resolve();
-    pusher.enqueuePush(clientID, makePush(1), 'jwt');
+    pusher.enqueuePush(clientID, makePush(1), 'jwt', undefined);
     await Promise.resolve();
 
     // no new pushes sent yet since we are still waiting on the user's API server
@@ -457,7 +483,7 @@ describe('initConnection', () => {
     };
 
     pusher.initConnection(clientID, wsID, userPushParams);
-    pusher.enqueuePush(clientID, makePush(1), 'jwt');
+    pusher.enqueuePush(clientID, makePush(1), 'jwt', undefined);
 
     // Wait for the push to be processed
     await new Promise(resolve => setTimeout(resolve, 0));
@@ -497,8 +523,8 @@ describe('pusher streaming', () => {
     void pusher.run();
 
     pusher.initConnection(clientID, wsID, undefined);
-    pusher.enqueuePush(clientID, makePush(1), 'jwt');
-    const result = pusher.enqueuePush(clientID, makePush(1), 'jwt');
+    pusher.enqueuePush(clientID, makePush(1), 'jwt', undefined);
+    const result = pusher.enqueuePush(clientID, makePush(1), 'jwt', undefined);
     expect(result.type).toBe('ok');
   });
 
@@ -536,14 +562,14 @@ describe('pusher streaming', () => {
       ok: true,
       json: () => Promise.resolve(successResponse1),
     });
-    pusher.enqueuePush('client1', makePush(1, 'client1'), 'jwt');
+    pusher.enqueuePush('client1', makePush(1, 'client1'), 'jwt', undefined);
     await new Promise(resolve => setTimeout(resolve, 0));
 
     fetch.mockResolvedValue({
       ok: true,
       json: () => Promise.resolve(successResponse2),
     });
-    pusher.enqueuePush('client2', makePush(2, 'client2'), 'jwt');
+    pusher.enqueuePush('client2', makePush(2, 'client2'), 'jwt', undefined);
 
     const s1Messages: unknown[] = [];
     const s2Messages: unknown[] = [];
@@ -613,8 +639,8 @@ describe('pusher streaming', () => {
     const stream1 = pusher.initConnection('client1', 'ws1', undefined);
     const stream2 = pusher.initConnection('client2', 'ws2', undefined);
 
-    pusher.enqueuePush('client1', makePush(1, 'client1'), 'jwt');
-    pusher.enqueuePush('client2', makePush(1, 'client2'), 'jwt');
+    pusher.enqueuePush('client1', makePush(1, 'client1'), 'jwt', undefined);
+    pusher.enqueuePush('client2', makePush(1, 'client2'), 'jwt', undefined);
 
     const messages1: unknown[] = [];
     const messages2: unknown[] = [];
@@ -669,7 +695,7 @@ describe('pusher streaming', () => {
     void pusher.run();
     const stream = pusher.initConnection(clientID, wsID, undefined);
 
-    pusher.enqueuePush(clientID, makePush(1, clientID), 'jwt');
+    pusher.enqueuePush(clientID, makePush(1, clientID), 'jwt', undefined);
 
     const messages: unknown[] = [];
     for await (const msg of stream) {
@@ -701,7 +727,7 @@ describe('pusher streaming', () => {
 
     const stream1 = pusher.initConnection(clientID, 'ws1', undefined);
 
-    pusher.enqueuePush(clientID, makePush(1, clientID), 'jwt');
+    pusher.enqueuePush(clientID, makePush(1, clientID), 'jwt', undefined);
 
     stream1.cancel();
 
@@ -762,7 +788,7 @@ describe('pusher streaming', () => {
     void pusher.run();
 
     const stream = pusher.initConnection(clientID, 'ws1', undefined);
-    pusher.enqueuePush(clientID, makePush(2, clientID), 'jwt');
+    pusher.enqueuePush(clientID, makePush(2, clientID), 'jwt', undefined);
 
     const messages: unknown[] = [];
     for await (const msg of stream) {
@@ -818,7 +844,7 @@ describe('pusher streaming', () => {
     void pusher.run();
 
     const stream = pusher.initConnection(clientID, 'ws1', undefined);
-    pusher.enqueuePush(clientID, makePush(1, clientID), 'jwt');
+    pusher.enqueuePush(clientID, makePush(1, clientID), 'jwt', undefined);
 
     await expect(stream[Symbol.asyncIterator]().next()).rejects.toThrow(
       'unsupportedSchemaVersion',
@@ -844,7 +870,7 @@ describe('pusher streaming', () => {
     void pusher.run();
 
     const stream = pusher.initConnection(clientID, 'ws1', undefined);
-    pusher.enqueuePush(clientID, makePush(1, clientID), 'jwt');
+    pusher.enqueuePush(clientID, makePush(1, clientID), 'jwt', undefined);
 
     await expect(stream[Symbol.asyncIterator]().next()).rejects.toThrow(
       new ErrorForClient({

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -730,6 +730,7 @@ describe('view-syncer/service', () => {
     protocolVersion: PROTOCOL_VERSION,
     schemaVersion: 2,
     tokenData: undefined,
+    httpCookie: undefined,
   };
 
   beforeEach(async () => {
@@ -3255,6 +3256,7 @@ describe('view-syncer/service', () => {
         protocolVersion: PROTOCOL_VERSION,
         schemaVersion: 2,
         tokenData: undefined,
+        httpCookie: undefined,
       },
       [{op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY}],
     );
@@ -6689,6 +6691,7 @@ describe('view-syncer/service', () => {
           protocolVersion: PROTOCOL_VERSION,
           schemaVersion: 2,
           tokenData: undefined,
+          httpCookie: undefined,
         },
         [{op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY2}],
       );
@@ -6897,6 +6900,7 @@ describe('permissions', () => {
       raw: '',
       decoded: {sub: 'foo', role: 'user', iat: 0},
     },
+    httpCookie: undefined,
   };
 
   beforeEach(async () => {

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -112,6 +112,7 @@ const ON_FAILURE = (e: unknown) => {
 
 const pullConfig: ZeroConfig['pull'] = {
   url: 'http://my-pull-endpoint.dev/api/zero/pull',
+  forwardCookies: true,
 };
 
 const REPLICA_VERSION = '01';

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -94,6 +94,7 @@ export type SyncContext = {
   readonly protocolVersion: number;
   readonly schemaVersion: number | null;
   readonly tokenData: TokenData | undefined;
+  readonly httpCookie: string | undefined;
 };
 
 const tracer = trace.getTracer('view-syncer', version);
@@ -159,7 +160,10 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
   #cvr: CVRSnapshot | undefined;
   #pipelinesSynced = false;
+  // DEPRECATED: remove `authData` in favor of forwarding
+  // auth and cookie headers directly
   #authData: TokenData | undefined;
+  #httpCookie: string | undefined;
 
   /**
    * The {@linkcode maxRowCount} is used for the eviction of inactive queries.
@@ -426,11 +430,13 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   ): Source<Downstream> {
     this.#lc.debug?.('viewSyncer.initConnection');
     return startSpan(tracer, 'vs.initConnection', () => {
-      const {clientID, wsID, baseCookie, schemaVersion, tokenData} = ctx;
+      const {clientID, wsID, baseCookie, schemaVersion, tokenData, httpCookie} =
+        ctx;
       this.#authData = pickToken(this.#lc, this.#authData, tokenData);
       this.#lc.debug?.(
         `Picked auth token: ${JSON.stringify(this.#authData?.decoded)}`,
       );
+      this.#httpCookie = httpCookie;
 
       const lc = this.#lc
         .withContext('clientID', clientID)
@@ -819,6 +825,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           {
             apiKey: this.#pullConfig.apiKey,
             token: this.#authData?.raw,
+            cookie: this.#httpCookie,
           },
           customQueries,
         );
@@ -980,6 +987,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
             {
               apiKey: this.#pullConfig.apiKey,
               token: this.#authData?.raw,
+              cookie: this.#httpCookie,
             },
             customQueries.values(),
           );

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -221,7 +221,10 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
     if (pullConfig.url) {
       this.#customQueryTransformer = new CustomQueryTransformer(
-        pullConfig.url,
+        {
+          url: pullConfig.url,
+          forwardCookies: pullConfig.forwardCookies,
+        },
         shard,
       );
     }
@@ -825,7 +828,9 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           {
             apiKey: this.#pullConfig.apiKey,
             token: this.#authData?.raw,
-            cookie: this.#httpCookie,
+            cookie: this.#pullConfig.forwardCookies
+              ? this.#httpCookie
+              : undefined,
           },
           customQueries,
         );

--- a/packages/zero-cache/src/workers/connect-params.ts
+++ b/packages/zero-cache/src/workers/connect-params.ts
@@ -20,6 +20,7 @@ export type ConnectParams = {
   readonly auth: string | undefined;
   readonly userID: string;
   readonly initConnectionMsg: InitConnectionMessage | undefined;
+  readonly httpCookie: string | undefined;
 };
 
 export function getConnectParams(
@@ -65,6 +66,7 @@ export function getConnectParams(
         initConnectionMsg: initConnectionMessage,
         auth: authToken,
         userID,
+        httpCookie: headers.cookie,
       },
       error: null,
     };

--- a/packages/zero-cache/src/workers/syncer-ws-message-handler.ts
+++ b/packages/zero-cache/src/workers/syncer-ws-message-handler.ts
@@ -29,6 +29,9 @@ export class SyncerWsMessageHandler implements MessageHandler {
   readonly #clientGroupID: string;
   readonly #syncContext: SyncContext;
   readonly #pusher: Pusher | undefined;
+  // DEPRECATED: remove #token
+  // and forward auth and cookie headers that were
+  // sent with the push.
   readonly #token: string | undefined;
 
   constructor(
@@ -46,6 +49,7 @@ export class SyncerWsMessageHandler implements MessageHandler {
       baseCookie,
       protocolVersion,
       schemaVersion,
+      httpCookie,
     } = connectParams;
     this.#viewSyncer = viewSyncer;
     this.#mutagen = mutagen;
@@ -66,6 +70,7 @@ export class SyncerWsMessageHandler implements MessageHandler {
       protocolVersion,
       schemaVersion,
       tokenData,
+      httpCookie,
     };
   }
 
@@ -121,6 +126,7 @@ export class SyncerWsMessageHandler implements MessageHandler {
                   this.#syncContext.clientID,
                   msg[1],
                   this.#token,
+                  this.#syncContext.httpCookie,
                 ),
               ];
             }

--- a/packages/zero-cache/src/workers/syncer.test.ts
+++ b/packages/zero-cache/src/workers/syncer.test.ts
@@ -87,10 +87,12 @@ describe('cleanup', () => {
       id => {
         const ret = new PusherService(
           {} as ZeroConfig,
+          {
+            url: 'http://example.com',
+            forwardCookies: false,
+          },
           lc,
           id,
-          'http://example.com',
-          undefined,
         );
         pushers.push(ret);
         return ret;


### PR DESCRIPTION
Allows users to forward cookies sent from the browser to zero-cache along to their API server when calling push/pull.

This is configurable and disabled by default since it has security implications.