### PR TITLE
chore(zql): disable fuzzer for now..

### DIFF
--- a/packages/zql-integration-tests/src/chinook/chinook-fuzz-hydration.pg-test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook-fuzz-hydration.pg-test.ts
@@ -4,7 +4,7 @@ import {en, Faker, generateMersenne53Randomizer} from '@faker-js/faker';
 import {bootstrap, runAndCompare} from '../helpers/runner.ts';
 import {getChinook} from './get-deps.ts';
 import {schema} from './schema.ts';
-import {test} from 'vitest';
+import {expect, test} from 'vitest';
 import {generateShrinkableQuery} from '../../../zql/src/query/test/query-gen.ts';
 import '../helpers/comparePg.ts';
 import {ast} from '../../../zql/src/query/query-impl.ts';
@@ -27,10 +27,14 @@ const harness = await bootstrap({
   pgContent,
 });
 
-test.each(Array.from({length: 100}, () => createCase()))(
+test.each(Array.from({length: 0}, () => createCase()))(
   'fuzz-hydration $seed',
   runCase,
 );
+
+test('sentinel', () => {
+  expect(true).toBe(true);
+});
 
 if (REPRO_SEED) {
   // eslint-disable-next-line no-only-tests/no-only-tests


### PR DESCRIPTION
Too many timeouts. This isn't great for running in CI. We'll need to come up with another plan.

Options:
a. limit the complexity of queries created in CI
b. disable in CI and run on a dedicated machine outside of CI
c. kick timeouts up to 30 seconds?