### PR TITLE
feat(mutators): db connection does not need to be queryable

### DIFF
--- a/packages/zql/src/mutate/custom.ts
+++ b/packages/zql/src/mutate/custom.ts
@@ -55,7 +55,7 @@ export interface Row {
   [column: string]: unknown;
 }
 
-export interface DBConnection<TWrappedTransaction> extends Queryable {
+export interface DBConnection<TWrappedTransaction> {
   transaction: <T>(
     cb: (tx: DBTransaction<TWrappedTransaction>) => Promise<T>,
   ) => Promise<T>;


### PR DESCRIPTION
Mutators only ever query within a transaction. This simplifies the interface for our users slightly.