### PR TITLE
Revert "chore(zer-client): Send active clients on connect"

### DIFF
--- a/packages/zero-client/src/client/alive-clients-manager.test.ts
+++ b/packages/zero-client/src/client/alive-clients-manager.test.ts
@@ -7,9 +7,9 @@ import {
   type MockInstance,
 } from 'vitest';
 import {nanoid} from '../util/nanoid.ts';
-import {ActiveClientsManager} from './active-clients-manager.ts';
+import {AliveClientsManager} from './alive-clients-manager.ts';
 
-describe('ActiveClientManager with mocked locks', () => {
+describe('AliveClientManager with mocked locks', () => {
   let requestSpy: MockInstance<typeof navigator.locks.request>;
   let querySpy: MockInstance<typeof navigator.locks.query>;
 
@@ -24,39 +24,39 @@ describe('ActiveClientManager with mocked locks', () => {
 
   test('should call lockManager.request in the constructor', () => {
     const ac = new AbortController();
-    new ActiveClientsManager('group1', 'client1', ac.signal);
+    new AliveClientsManager('group1', 'client1', ac.signal);
 
     expect(requestSpy).toHaveBeenCalledWith(
-      'zero-active-clients/group1/client1',
+      'zero-alive/group1/client1',
       {signal: ac.signal},
       expect.any(Function),
     );
     ac.abort();
   });
 
-  test('should return active clients from held and pending locks', async () => {
+  test('should return alive clients from held and pending locks', async () => {
     const ac = new AbortController();
 
     querySpy.mockResolvedValue({
-      held: [{name: 'zero-active-clients/group1/client1'}],
-      pending: [{name: 'zero-active-clients/group1/client2'}],
+      held: [{name: 'zero-alive/group1/client1'}],
+      pending: [{name: 'zero-alive/group1/client2'}],
     });
 
-    const clientManager = new ActiveClientsManager(
+    const clientManager = new AliveClientsManager(
       'group1',
       'client1',
       ac.signal,
     );
-    const activeClients = await clientManager.getActiveClients();
+    const aliveClients = await clientManager.getAliveClients();
 
-    expect(activeClients).toEqual(new Set(['client1', 'client2']));
+    expect(aliveClients).toEqual(new Set(['client1', 'client2']));
     ac.abort();
   });
 
   test('should ignore invalid lock keys', async () => {
     const ac = new AbortController();
 
-    const clientManager = new ActiveClientsManager(
+    const clientManager = new AliveClientsManager(
       'group1',
       'client1',
       ac.signal,
@@ -65,19 +65,19 @@ describe('ActiveClientManager with mocked locks', () => {
     querySpy.mockResolvedValue({
       held: [{name: 'invalid-lock-key'}],
       pending: [
-        {name: 'zero-active-clients/group1/client1'},
-        {name: 'zero-active-clients/group1/client3'},
+        {name: 'zero-alive/group1/client1'},
+        {name: 'zero-alive/group1/client3'},
       ],
     });
 
-    const activeClients = await clientManager.getActiveClients();
+    const aliveClients = await clientManager.getAliveClients();
 
-    expect(activeClients).toEqual(new Set(['client1', 'client3']));
+    expect(aliveClients).toEqual(new Set(['client1', 'client3']));
     ac.abort();
   });
 });
 
-describe('ActiveClientManager without navigator', () => {
+describe('AliveClientManager without navigator', () => {
   beforeEach(() => {
     vi.stubGlobal('navigator', undefined);
     return () => {
@@ -87,14 +87,14 @@ describe('ActiveClientManager without navigator', () => {
 
   test('should return set with self if navigator is undefined', async () => {
     const ac = new AbortController();
-    const clientManager = new ActiveClientsManager(
+    const clientManager = new AliveClientsManager(
       'group1',
       'client1',
       ac.signal,
     );
-    const activeClients = await clientManager.getActiveClients();
+    const aliveClients = await clientManager.getAliveClients();
 
-    expect(activeClients).toEqual(new Set(['client1']));
+    expect(aliveClients).toEqual(new Set(['client1']));
     ac.abort();
   });
 
@@ -102,27 +102,27 @@ describe('ActiveClientManager without navigator', () => {
     const ac1 = new AbortController();
     const ac2 = new AbortController();
 
-    const clientManager1 = new ActiveClientsManager(
+    const clientManager1 = new AliveClientsManager(
       'group1',
       'client1',
       ac1.signal,
     );
-    const clientManager2 = new ActiveClientsManager(
+    const clientManager2 = new AliveClientsManager(
       'group1',
       'client2',
       ac2.signal,
     );
 
-    expect(await clientManager1.getActiveClients()).toEqual(
+    expect(await clientManager1.getAliveClients()).toEqual(
       new Set(['client1', 'client2']),
     );
-    expect(await clientManager2.getActiveClients()).toEqual(
+    expect(await clientManager2.getAliveClients()).toEqual(
       new Set(['client1', 'client2']),
     );
 
     ac1.abort();
 
-    expect(await clientManager2.getActiveClients()).toEqual(
+    expect(await clientManager2.getAliveClients()).toEqual(
       new Set(['client2']),
     );
 
@@ -130,7 +130,7 @@ describe('ActiveClientManager without navigator', () => {
   });
 });
 
-describe('ActiveClientManager with undefined locks', () => {
+describe('AliveClientManager with undefined locks', () => {
   let signal: AbortSignal;
   beforeEach(() => {
     const ac = new AbortController();
@@ -145,27 +145,27 @@ describe('ActiveClientManager with undefined locks', () => {
   test('should return set with self if navigator.locks is undefined', async () => {
     vi.stubGlobal('navigator', {locks: undefined});
 
-    const clientManager = new ActiveClientsManager('group1', 'client1', signal);
-    const activeClients = await clientManager.getActiveClients();
+    const clientManager = new AliveClientsManager('group1', 'client1', signal);
+    const aliveClients = await clientManager.getAliveClients();
 
-    expect(activeClients).toEqual(new Set(['client1']));
+    expect(aliveClients).toEqual(new Set(['client1']));
   });
 });
 
-describe('ActiveClientManager with real lock', () => {
+describe('AliveClientManager with real lock', () => {
   // Use nanoid for client groups so that tests do not interfere with each other.
 
   test('One manager', async () => {
     const ac = new AbortController();
     const clientGroupID = nanoid();
-    const clientManager = new ActiveClientsManager(
+    const clientManager = new AliveClientsManager(
       clientGroupID,
       'client1',
       ac.signal,
     );
-    const activeClients = await clientManager.getActiveClients();
+    const aliveClients = await clientManager.getAliveClients();
 
-    expect(activeClients).toEqual(new Set(['client1']));
+    expect(aliveClients).toEqual(new Set(['client1']));
 
     ac.abort();
   });
@@ -175,22 +175,22 @@ describe('ActiveClientManager with real lock', () => {
     const ac1 = new AbortController();
     const ac2 = new AbortController();
 
-    const clientManager1 = new ActiveClientsManager(
+    const clientManager1 = new AliveClientsManager(
       clientGroupID,
       'client1',
       ac1.signal,
     );
-    const clientManager2 = new ActiveClientsManager(
+    const clientManager2 = new AliveClientsManager(
       clientGroupID,
       'client2',
       ac2.signal,
     );
 
-    const activeClients1 = await clientManager1.getActiveClients();
-    const activeClients2 = await clientManager2.getActiveClients();
+    const aliveClients1 = await clientManager1.getAliveClients();
+    const aliveClients2 = await clientManager2.getAliveClients();
 
-    expect(activeClients1).toEqual(new Set(['client1', 'client2']));
-    expect(activeClients2).toEqual(new Set(['client1', 'client2']));
+    expect(aliveClients1).toEqual(new Set(['client1', 'client2']));
+    expect(aliveClients2).toEqual(new Set(['client1', 'client2']));
 
     ac1.abort();
     ac2.abort();
@@ -204,35 +204,35 @@ describe('ActiveClientManager with real lock', () => {
     const ac3 = new AbortController();
     const ac4 = new AbortController();
 
-    const clientManager1 = new ActiveClientsManager(
+    const clientManager1 = new AliveClientsManager(
       clientGroupID1,
       'client1',
       ac1.signal,
     );
-    const clientManager2 = new ActiveClientsManager(
+    const clientManager2 = new AliveClientsManager(
       clientGroupID1,
       'client2',
       ac1.signal,
     );
-    const clientManager3 = new ActiveClientsManager(
+    const clientManager3 = new AliveClientsManager(
       clientGroupID2,
       'client3',
       ac3.signal,
     );
-    const clientManager4 = new ActiveClientsManager(
+    const clientManager4 = new AliveClientsManager(
       clientGroupID2,
       'client4',
       ac4.signal,
     );
 
-    const activeClients1 = await clientManager1.getActiveClients();
-    const activeClients2 = await clientManager2.getActiveClients();
-    const activeClients3 = await clientManager3.getActiveClients();
-    const activeClients4 = await clientManager4.getActiveClients();
-    expect(activeClients1).toEqual(new Set(['client1', 'client2']));
-    expect(activeClients2).toEqual(new Set(['client1', 'client2']));
-    expect(activeClients3).toEqual(new Set(['client3', 'client4']));
-    expect(activeClients4).toEqual(new Set(['client3', 'client4']));
+    const aliveClients1 = await clientManager1.getAliveClients();
+    const aliveClients2 = await clientManager2.getAliveClients();
+    const aliveClients3 = await clientManager3.getAliveClients();
+    const aliveClients4 = await clientManager4.getAliveClients();
+    expect(aliveClients1).toEqual(new Set(['client1', 'client2']));
+    expect(aliveClients2).toEqual(new Set(['client1', 'client2']));
+    expect(aliveClients3).toEqual(new Set(['client3', 'client4']));
+    expect(aliveClients4).toEqual(new Set(['client3', 'client4']));
 
     ac1.abort();
     ac2.abort();
@@ -246,22 +246,22 @@ describe('ActiveClientManager with real lock', () => {
     const ac1 = new AbortController();
     const ac2 = new AbortController();
 
-    const clientManager1 = new ActiveClientsManager(
+    const clientManager1 = new AliveClientsManager(
       clientGroupID1,
       'client1',
       ac1.signal,
     );
-    const clientManager2 = new ActiveClientsManager(
+    const clientManager2 = new AliveClientsManager(
       clientGroupID2,
       'client2',
       ac2.signal,
     );
 
-    const activeClients1 = await clientManager1.getActiveClients();
-    const activeClients2 = await clientManager2.getActiveClients();
+    const aliveClients1 = await clientManager1.getAliveClients();
+    const aliveClients2 = await clientManager2.getAliveClients();
 
-    expect(activeClients1).toEqual(new Set(['client1']));
-    expect(activeClients2).toEqual(new Set(['client2']));
+    expect(aliveClients1).toEqual(new Set(['client1']));
+    expect(aliveClients2).toEqual(new Set(['client2']));
 
     ac1.abort();
     ac2.abort();
@@ -273,37 +273,37 @@ describe('ActiveClientManager with real lock', () => {
     const ac2 = new AbortController();
     const ac3 = new AbortController();
 
-    const clientManager1 = new ActiveClientsManager(
+    const clientManager1 = new AliveClientsManager(
       clientGroupID,
       'client1',
       ac1.signal,
     );
-    const clientManager2 = new ActiveClientsManager(
+    const clientManager2 = new AliveClientsManager(
       clientGroupID,
       'client2',
       ac2.signal,
     );
-    const clientManager3 = new ActiveClientsManager(
+    const clientManager3 = new AliveClientsManager(
       clientGroupID,
       'client3',
       ac3.signal,
     );
 
-    const activeClients1 = await clientManager1.getActiveClients();
-    const activeClients2 = await clientManager2.getActiveClients();
-    const activeClients3 = await clientManager3.getActiveClients();
+    const aliveClients1 = await clientManager1.getAliveClients();
+    const aliveClients2 = await clientManager2.getAliveClients();
+    const aliveClients3 = await clientManager3.getAliveClients();
 
-    expect(activeClients1).toEqual(new Set(['client1', 'client2', 'client3']));
-    expect(activeClients2).toEqual(new Set(['client1', 'client2', 'client3']));
-    expect(activeClients3).toEqual(new Set(['client1', 'client2', 'client3']));
+    expect(aliveClients1).toEqual(new Set(['client1', 'client2', 'client3']));
+    expect(aliveClients2).toEqual(new Set(['client1', 'client2', 'client3']));
+    expect(aliveClients3).toEqual(new Set(['client1', 'client2', 'client3']));
 
     ac1.abort();
 
-    const activeClientsAfterClose1 = await clientManager2.getActiveClients();
-    expect(activeClientsAfterClose1).toEqual(new Set(['client2', 'client3']));
+    const aliveClientsAfterClose1 = await clientManager2.getAliveClients();
+    expect(aliveClientsAfterClose1).toEqual(new Set(['client2', 'client3']));
 
-    const activeClientsAfterClose2 = await clientManager3.getActiveClients();
-    expect(activeClientsAfterClose2).toEqual(new Set(['client2', 'client3']));
+    const aliveClientsAfterClose2 = await clientManager3.getAliveClients();
+    expect(aliveClientsAfterClose2).toEqual(new Set(['client2', 'client3']));
 
     ac2.abort();
     ac3.abort();

--- a/packages/zero-client/src/client/alive-clients-manager.ts
+++ b/packages/zero-client/src/client/alive-clients-manager.ts
@@ -1,7 +1,7 @@
 import {resolver} from '@rocicorp/resolver';
 import {getBrowserGlobal} from '../../../shared/src/browser-env.ts';
 
-const lockKeyPrefix = 'zero-active-clients';
+const lockKeyPrefix = 'zero-alive';
 
 function toLockKey(clientGroupID: string, clientID: string): string {
   return `${lockKeyPrefix}/${clientGroupID}/${clientID}`;
@@ -28,7 +28,7 @@ function fromLockKey(
 const allMockLocks = new Set<{name: string}>();
 
 /**
- * A class that lists the active clients in a client group. It uses the
+ * A class that lists the alive clients in a client group. It uses the
  * `navigator.locks` API to manage locks for each client. The class is designed
  * to be used in a browser environment where the `navigator.locks` API is
  * available.
@@ -40,7 +40,7 @@ const allMockLocks = new Set<{name: string}>();
  * and `clientID`. Then the `query` method is used to get the list of all
  * clients that hold or are waiting for locks in the same client group.
  */
-export class ActiveClientsManager {
+export class AliveClientsManager {
   readonly clientGroupID: string;
   readonly clientID: string;
   readonly #resolver = resolver<void>();
@@ -78,14 +78,14 @@ export class ActiveClientsManager {
     );
   }
 
-  async getActiveClients(): Promise<Set<string>> {
-    const activeClients: Set<string> = new Set();
+  async getAliveClients(): Promise<Set<string>> {
+    const aliveClients: Set<string> = new Set();
 
     const add = (info: Iterable<{name?: string}> | undefined) => {
       for (const lock of info ?? []) {
         const client = fromLockKey(lock.name);
         if (client?.clientGroupID === this.clientGroupID) {
-          activeClients.add(client.clientID);
+          aliveClients.add(client.clientID);
         }
       }
     };
@@ -97,6 +97,6 @@ export class ActiveClientsManager {
       add(snapshot.held);
       add(snapshot.pending);
     }
-    return activeClients;
+    return aliveClients;
   }
 }

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -351,7 +351,6 @@ describe('createSocket', () => {
     now: number,
     expectedURL: string,
     additionalConnectParams?: Record<string, string>,
-    activeClients = new Set([clientID]),
   ) => {
     const clientSchema: ClientSchema = {
       tables: {
@@ -383,7 +382,6 @@ describe('createSocket', () => {
         undefined,
         1048 * 8,
         additionalConnectParams,
-        {getActiveClients: () => Promise.resolve(activeClients)},
       );
       expect(`${mockSocket.url}`).equal(expectedURL);
       expect(mockSocket.protocol).equal(
@@ -394,7 +392,6 @@ describe('createSocket', () => {
               desiredQueriesPatch: [],
               deleted: {clientIDs: ['old-deleted-client']},
               ...(baseCookie === null ? {clientSchema} : {}),
-              activeClients: [...activeClients],
             },
           ],
           auth,
@@ -421,7 +418,6 @@ describe('createSocket', () => {
         undefined,
         0, // do not put any extra information into headers
         additionalConnectParams,
-        {getActiveClients: () => Promise.resolve(activeClients)},
       );
       expect(`${mockSocket.url}`).equal(expectedURL);
       expect(mockSocket2.protocol).equal(encodeSecProtocols(undefined, auth));
@@ -771,37 +767,43 @@ describe('initConnection', () => {
         decodeSecProtocols(mockSocket.protocol).initConnectionMessage,
         initConnectionMessageSchema,
       ),
-    ).toEqual([
-      'initConnection',
-      {
-        activeClients: [r.clientID],
-        clientSchema: {
-          tables: {
-            e: {
-              columns: {
-                id: {
-                  type: 'string',
-                },
-                value: {
-                  type: 'string',
+    ).toMatchInlineSnapshot(`
+      [
+        "initConnection",
+        {
+          "clientSchema": {
+            "tables": {
+              "e": {
+                "columns": {
+                  "id": {
+                    "type": "string",
+                  },
+                  "value": {
+                    "type": "string",
+                  },
                 },
               },
             },
           },
-        },
-        desiredQueriesPatch: [
-          {
-            ast: {
-              orderBy: [['id', 'asc']],
-              table: 'e',
+          "desiredQueriesPatch": [
+            {
+              "ast": {
+                "orderBy": [
+                  [
+                    "id",
+                    "asc",
+                  ],
+                ],
+                "table": "e",
+              },
+              "hash": "29j3x0l4bxthp",
+              "op": "put",
+              "ttl": 0,
             },
-            hash: '29j3x0l4bxthp',
-            op: 'put',
-            ttl: 0,
-          },
-        ],
-      },
-    ]);
+          ],
+        },
+      ]
+    `);
 
     expect(mockSocket.messages.length).toEqual(0);
     await r.triggerConnected();
@@ -862,45 +864,52 @@ describe('initConnection', () => {
         decodeSecProtocols(mockSocket.protocol).initConnectionMessage,
         initConnectionMessageSchema,
       ),
-    ).toEqual([
-      'initConnection',
-      {
-        activeClients: [r.clientID],
-        clientSchema: {
-          tables: {
-            e: {
-              columns: {
-                id: {
-                  type: 'string',
-                },
-                value: {
-                  type: 'string',
+    ).toMatchInlineSnapshot(`
+      [
+        "initConnection",
+        {
+          "clientSchema": {
+            "tables": {
+              "e": {
+                "columns": {
+                  "id": {
+                    "type": "string",
+                  },
+                  "value": {
+                    "type": "string",
+                  },
                 },
               },
             },
           },
-        },
-        deleted: {
-          clientIDs: ['a'],
-        },
-        desiredQueriesPatch: [
-          {
-            ast: {
-              orderBy: [['id', 'asc']],
-              table: 'e',
-            },
-            hash: '29j3x0l4bxthp',
-            op: 'put',
-            ttl: 0,
+          "deleted": {
+            "clientIDs": [
+              "a",
+            ],
           },
-        ],
-      },
-    ]);
+          "desiredQueriesPatch": [
+            {
+              "ast": {
+                "orderBy": [
+                  [
+                    "id",
+                    "asc",
+                  ],
+                ],
+                "table": "e",
+              },
+              "hash": "29j3x0l4bxthp",
+              "op": "put",
+              "ttl": 0,
+            },
+          ],
+        },
+      ]
+    `);
 
     expect(mockSocket.messages.length).toEqual(0);
     await r.triggerConnected();
     expect(mockSocket.messages.length).toEqual(0);
-    await r.close();
   });
 
   test('sends desired queries patch in `initConnectionMessage` when the patch is over maxHeaderLength', async () => {
@@ -967,8 +976,6 @@ describe('initConnection', () => {
     view.addListener(() => {});
     await r.triggerConnected();
     expect(mockSocket.messages.length).toEqual(1);
-
-    await r.close();
   });
 
   test('sends desired queries patch in `initConnectionMessage` when the patch is over maxHeaderLength with deleted clients', async () => {
@@ -1088,7 +1095,6 @@ describe('initConnection', () => {
     ).toEqual([
       'initConnection',
       {
-        activeClients: [r.clientID],
         desiredQueriesPatch: [],
         clientSchema: {
           tables: {

--- a/packages/zero-protocol/src/ast.test.ts
+++ b/packages/zero-protocol/src/ast.test.ts
@@ -607,5 +607,5 @@ test('protocol version', () => {
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
   expect(hash).toEqual('1c228prd1v53r');
-  expect(PROTOCOL_VERSION).toEqual(19);
+  expect(PROTOCOL_VERSION).toEqual(18);
 });

--- a/packages/zero-protocol/src/connect.ts
+++ b/packages/zero-protocol/src/connect.ts
@@ -30,14 +30,6 @@ const initConnectionBodySchema = v.object({
   clientSchema: clientSchemaSchema.optional(),
   deleted: deleteClientsBodySchema.optional(),
   userPushParams: userPushParamsSchema.optional(),
-
-  /**
-   * `activeClients` is an optional array of client IDs that are currently active
-   * in the client group. This is used to inform the server about the clients
-   * that are currently active (aka running, aka alive), so it can inactive
-   * queries from inactive clients.
-   */
-  activeClients: v.array(v.string()).optional(),
 });
 
 export const initConnectionMessageSchema = v.tuple([

--- a/packages/zero-protocol/src/protocol-version.test.ts
+++ b/packages/zero-protocol/src/protocol-version.test.ts
@@ -11,6 +11,6 @@ test('protocol version', () => {
   // If this test fails upstream or downstream schema has changed such that
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
-  expect(hash).toEqual('1281atik6gm8m');
-  expect(PROTOCOL_VERSION).toEqual(19);
+  expect(hash).toEqual('3m0maejt4jhl3');
+  expect(PROTOCOL_VERSION).toEqual(18);
 });

--- a/packages/zero-protocol/src/protocol-version.ts
+++ b/packages/zero-protocol/src/protocol-version.ts
@@ -24,8 +24,7 @@ import {assert} from '../../shared/src/asserts.ts';
 // -- Version 16 adds a new error type (alreadyProcessed) to mutation responses
 // -- Version 17 deprecates `AST` in downstream query puts. It was never used anyway.
 // -- Version 18 adds `name` and `args` to the `queries-patch` protocol
-// -- Version 19 adds `activeClients` to the `initConnection` protocol
-export const PROTOCOL_VERSION = 19;
+export const PROTOCOL_VERSION = 18;
 
 /**
  * The minimum server-supported sync protocol version (i.e. the version


### PR DESCRIPTION
Reverts rocicorp/mono#4510

No need to have this incomplete feature in the release