### PR TITLE
chore(mutators): re-throw unknown errors that were caught in error mode

### DIFF
--- a/packages/zero-pg/src/push-processor.ts
+++ b/packages/zero-pg/src/push-processor.ts
@@ -183,9 +183,11 @@ export class PushProcessor<
         }
 
         // We threw an error while running in error mode.
-        // Return the new error.
+        // Re-throw the error and stop processing any further
+        // mutations as all subsequent mutations will fail by being
+        // out of order.
         if (caughtError !== undefined) {
-          return makeAppErrorResponse(m, e);
+          throw e;
         }
 
         caughtError = e;


### PR DESCRIPTION
If we catch an error in error mode (that is not OoO or MutationAlreadyProcessed) we should re-throw and stop processing mutations.

The previous code was also technically correct but would run mutations that could not possibly pass. The reason is that if we fail in error mode (with something other than MutationAlreadyProcessed) then all subsequent mutations will fail with OutOfOrderMutation or with the same (db down, bad password, whatever) error the current mutation failed with.

Might as well bail early rather than trying the remaining mutations.