### PR TITLE
chore: Log a warning when auth token exceeds ZeroOptions.maxHeaderLength

### DIFF
--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -2014,7 +2014,9 @@ export async function createSocket(
     secProtocol = encodeSecProtocols(undefined, auth);
     if (secProtocol.length > maxHeaderLength) {
       lc.warn?.(
-        `Encoded auth token length (${secProtocol.length}) exceeds ZeroOptions.maxHeaderLength (${maxHeaderLength}). This may cause connection failures.',
+        `Encoded auth token length (${secProtocol.length}) exceeds ` +
+          `ZeroOptions.maxHeaderLength (${maxHeaderLength}). This may ` +
+          `cause connection failures.`,
       );
     }
     queriesPatch = undefined;


### PR DESCRIPTION
Motivated by a customer report in Discord https://discord.com/channels/830183651022471199/1386615648838488094/1387011719338917910