### PR TITLE
chore(zero): Add activeClients to initConnection

### DIFF
--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -2355,7 +2355,7 @@ test('server ahead', async () => {
   );
   // There are a lot of timers that get scheduled before the reload timer
   // for dropping the database. TODO: Make this more robust.
-  for (let i = 0; i < 8; i++) {
+  for (let i = 0; i < 10; i++) {
     await vi.advanceTimersToNextTimerAsync();
   }
   await promise;

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -385,6 +385,7 @@ describe('createSocket', () => {
     now: number,
     expectedURL: string,
     additionalConnectParams?: Record<string, string>,
+    activeClients = new Set([clientID]),
   ) => {
     const clientSchema: ClientSchema = {
       tables: {
@@ -416,6 +417,9 @@ describe('createSocket', () => {
         undefined,
         1048 * 8,
         additionalConnectParams,
+        Promise.resolve({
+          getActiveClients: () => Promise.resolve(activeClients),
+        }),
       );
       expect(`${mockSocket.url}`).equal(expectedURL);
       expect(mockSocket.protocol).equal(
@@ -426,6 +430,7 @@ describe('createSocket', () => {
               desiredQueriesPatch: [],
               deleted: {clientIDs: ['old-deleted-client']},
               ...(baseCookie === null ? {clientSchema} : {}),
+              activeClients: [...activeClients],
             },
           ],
           auth,
@@ -452,6 +457,9 @@ describe('createSocket', () => {
         undefined,
         0, // do not put any extra information into headers
         additionalConnectParams,
+        Promise.resolve({
+          getActiveClients: () => Promise.resolve(activeClients),
+        }),
       );
       expect(`${mockSocket.url}`).equal(expectedURL);
       expect(mockSocket2.protocol).equal(encodeSecProtocols(undefined, auth));
@@ -801,43 +809,37 @@ describe('initConnection', () => {
         decodeSecProtocols(mockSocket.protocol).initConnectionMessage,
         initConnectionMessageSchema,
       ),
-    ).toMatchInlineSnapshot(`
-      [
-        "initConnection",
-        {
-          "clientSchema": {
-            "tables": {
-              "e": {
-                "columns": {
-                  "id": {
-                    "type": "string",
-                  },
-                  "value": {
-                    "type": "string",
-                  },
+    ).toEqual([
+      'initConnection',
+      {
+        activeClients: [r.clientID],
+        clientSchema: {
+          tables: {
+            e: {
+              columns: {
+                id: {
+                  type: 'string',
+                },
+                value: {
+                  type: 'string',
                 },
               },
             },
           },
-          "desiredQueriesPatch": [
-            {
-              "ast": {
-                "orderBy": [
-                  [
-                    "id",
-                    "asc",
-                  ],
-                ],
-                "table": "e",
-              },
-              "hash": "29j3x0l4bxthp",
-              "op": "put",
-              "ttl": 0,
-            },
-          ],
         },
-      ]
-    `);
+        desiredQueriesPatch: [
+          {
+            ast: {
+              orderBy: [['id', 'asc']],
+              table: 'e',
+            },
+            hash: '29j3x0l4bxthp',
+            op: 'put',
+            ttl: 0,
+          },
+        ],
+      },
+    ]);
 
     expect(mockSocket.messages.length).toEqual(0);
     await r.triggerConnected();
@@ -898,52 +900,45 @@ describe('initConnection', () => {
         decodeSecProtocols(mockSocket.protocol).initConnectionMessage,
         initConnectionMessageSchema,
       ),
-    ).toMatchInlineSnapshot(`
-      [
-        "initConnection",
-        {
-          "clientSchema": {
-            "tables": {
-              "e": {
-                "columns": {
-                  "id": {
-                    "type": "string",
-                  },
-                  "value": {
-                    "type": "string",
-                  },
+    ).toEqual([
+      'initConnection',
+      {
+        activeClients: [r.clientID],
+        clientSchema: {
+          tables: {
+            e: {
+              columns: {
+                id: {
+                  type: 'string',
+                },
+                value: {
+                  type: 'string',
                 },
               },
             },
           },
-          "deleted": {
-            "clientIDs": [
-              "a",
-            ],
-          },
-          "desiredQueriesPatch": [
-            {
-              "ast": {
-                "orderBy": [
-                  [
-                    "id",
-                    "asc",
-                  ],
-                ],
-                "table": "e",
-              },
-              "hash": "29j3x0l4bxthp",
-              "op": "put",
-              "ttl": 0,
-            },
-          ],
         },
-      ]
-    `);
+        deleted: {
+          clientIDs: ['a'],
+        },
+        desiredQueriesPatch: [
+          {
+            ast: {
+              orderBy: [['id', 'asc']],
+              table: 'e',
+            },
+            hash: '29j3x0l4bxthp',
+            op: 'put',
+            ttl: 0,
+          },
+        ],
+      },
+    ]);
 
     expect(mockSocket.messages.length).toEqual(0);
     await r.triggerConnected();
     expect(mockSocket.messages.length).toEqual(0);
+    await r.close();
   });
 
   test('sends desired queries patch in `initConnectionMessage` when the patch is over maxHeaderLength', async () => {
@@ -1010,6 +1005,8 @@ describe('initConnection', () => {
     view.addListener(() => {});
     await r.triggerConnected();
     expect(mockSocket.messages.length).toEqual(1);
+
+    await r.close();
   });
 
   test('sends desired queries patch in `initConnectionMessage` when the patch is over maxHeaderLength with deleted clients', async () => {
@@ -1129,6 +1126,7 @@ describe('initConnection', () => {
     ).toEqual([
       'initConnection',
       {
+        activeClients: [r.clientID],
         desiredQueriesPatch: [],
         clientSchema: {
           tables: {

--- a/packages/zero-protocol/src/ast.test.ts
+++ b/packages/zero-protocol/src/ast.test.ts
@@ -607,5 +607,5 @@ test('protocol version', () => {
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
   expect(hash).toEqual('1c228prd1v53r');
-  expect(PROTOCOL_VERSION).toEqual(18);
+  expect(PROTOCOL_VERSION).toEqual(19);
 });

--- a/packages/zero-protocol/src/connect.ts
+++ b/packages/zero-protocol/src/connect.ts
@@ -30,6 +30,14 @@ const initConnectionBodySchema = v.object({
   clientSchema: clientSchemaSchema.optional(),
   deleted: deleteClientsBodySchema.optional(),
   userPushParams: userPushParamsSchema.optional(),
+
+  /**
+   * `activeClients` is an optional array of client IDs that are currently active
+   * in the client group. This is used to inform the server about the clients
+   * that are currently active (aka running, aka alive), so it can inactive
+   * queries from inactive clients.
+   */
+  activeClients: v.array(v.string()).optional(),
 });
 
 export const initConnectionMessageSchema = v.tuple([

--- a/packages/zero-protocol/src/protocol-version.test.ts
+++ b/packages/zero-protocol/src/protocol-version.test.ts
@@ -11,6 +11,6 @@ test('protocol version', () => {
   // If this test fails upstream or downstream schema has changed such that
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
-  expect(hash).toEqual('3m0maejt4jhl3');
-  expect(PROTOCOL_VERSION).toEqual(18);
+  expect(hash).toEqual('1281atik6gm8m');
+  expect(PROTOCOL_VERSION).toEqual(19);
 });

--- a/packages/zero-protocol/src/protocol-version.ts
+++ b/packages/zero-protocol/src/protocol-version.ts
@@ -24,7 +24,8 @@ import {assert} from '../../shared/src/asserts.ts';
 // -- Version 16 adds a new error type (alreadyProcessed) to mutation responses
 // -- Version 17 deprecates `AST` in downstream query puts. It was never used anyway.
 // -- Version 18 adds `name` and `args` to the `queries-patch` protocol
-export const PROTOCOL_VERSION = 18;
+// -- Version 19 adds `activeClients` to the `initConnection` protocol
+export const PROTOCOL_VERSION = 19;
 
 /**
  * The minimum server-supported sync protocol version (i.e. the version


### PR DESCRIPTION
This is a revert of the revert:

Revert "Revert "chore(zer-client): Send active clients on connect (#4510)" (#4522)"

This reverts commit 789b8dcad91ba5ac6e930b838c53a8d432b56cea.

The ActiveClientsManager changed to an async class, so we need the construction changed slightly.