### PR TITLE
chore(zero-protocol): bump protocol version to 20

### DIFF
--- a/packages/zero-protocol/src/ast.test.ts
+++ b/packages/zero-protocol/src/ast.test.ts
@@ -607,5 +607,5 @@ test('protocol version', () => {
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
   expect(hash).toEqual('1c228prd1v53r');
-  expect(PROTOCOL_VERSION).toEqual(19);
+  expect(PROTOCOL_VERSION).toEqual(20);
 });

--- a/packages/zero-protocol/src/protocol-version.test.ts
+++ b/packages/zero-protocol/src/protocol-version.test.ts
@@ -12,5 +12,5 @@ test('protocol version', () => {
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
   expect(hash).toEqual('1281atik6gm8m');
-  expect(PROTOCOL_VERSION).toEqual(19);
+  expect(PROTOCOL_VERSION).toEqual(20);
 });

--- a/packages/zero-protocol/src/protocol-version.ts
+++ b/packages/zero-protocol/src/protocol-version.ts
@@ -25,7 +25,8 @@ import {assert} from '../../shared/src/asserts.ts';
 // -- Version 17 deprecates `AST` in downstream query puts. It was never used anyway.
 // -- Version 18 adds `name` and `args` to the `queries-patch` protocol
 // -- Version 19 adds `activeClients` to the `initConnection` protocol
-export const PROTOCOL_VERSION = 19;
+// -- Version 20 version 19 was reverted... causing deployment issues
+export const PROTOCOL_VERSION = 20;
 
 /**
  * The minimum server-supported sync protocol version (i.e. the version


### PR DESCRIPTION
19 was reverted and bumping to 20 to fix build issues