### PR TITLE
fix(zero-schema): handle explicit `from("public.table")` schema inputs

### DIFF
--- a/packages/zero-schema/src/builder/schema-builder.test.ts
+++ b/packages/zero-schema/src/builder/schema-builder.test.ts
@@ -505,7 +505,7 @@ test('alternate db names', () => {
   `);
 
   const foo = table('foo')
-    .from('fooz')
+    .from('public.fooz')
     .columns({
       bar: string().from('baz'),
       baz: string().from('boo'),

--- a/packages/zero-schema/src/builder/table-builder.ts
+++ b/packages/zero-schema/src/builder/table-builder.ts
@@ -68,7 +68,12 @@ export class TableBuilder<TShape extends TableSchema> {
   from<ServerName extends string>(serverName: ServerName) {
     return new TableBuilder<TShape>({
       ...this.#schema,
-      serverName,
+      // Strip the "public." schema if specific, as tables in the public
+      // schema are replicated without the schema prefix.
+      // See liteTableName() in zero-cache/src/types/names.ts
+      serverName: serverName.startsWith('public.')
+        ? serverName.substring('public.'.length)
+        : serverName,
     });
   }
 

--- a/packages/zero-schema/src/builder/table-builder.ts
+++ b/packages/zero-schema/src/builder/table-builder.ts
@@ -68,8 +68,8 @@ export class TableBuilder<TShape extends TableSchema> {
   from<ServerName extends string>(serverName: ServerName) {
     return new TableBuilder<TShape>({
       ...this.#schema,
-      // Strip the "public." schema if specific, as tables in the public
-      // schema are replicated without the schema prefix.
+      // Strip the "public." schema if specified, as tables in the upstream
+      // "public" schema are created without the schema prefix on the replica.
       // See liteTableName() in zero-cache/src/types/names.ts
       serverName: serverName.startsWith('public.')
         ? serverName.substring('public.'.length)


### PR DESCRIPTION
Correctly handle an explicit `public` schema by dropping it, to be in line with how the tables are named on the replica.

User report:
* https://discord.com/channels/830183651022471199/1288232858795769917/1386082154613575793
