### PR TITLE
chore(analyze-query): fix broken zeroing of query counts.

### DIFF
--- a/packages/zqlite/src/table-source.ts
+++ b/packages/zqlite/src/table-source.ts
@@ -278,11 +278,10 @@ export class TableSource implements Source {
 
       const comparator = makeComparator(sort, req.reverse);
 
-      runtimeDebugStats.rowVended(
+      runtimeDebugStats.initQuery(
         this.#clientGroupID,
         this.#table,
         sqlAndBindings.text,
-        undefined,
       );
 
       yield* generateWithStart(


### PR DESCRIPTION
It was zeroing everytime a particular query template was fetched, which we don't want, since we want cumulative rows for that particular query across multiple fetches.