### PR TITLE
fix(zero): Inspector queries were broken

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr-store.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.pg-test.ts
@@ -927,8 +927,8 @@ describe('view-syncer/cvr-store', () => {
         VALUES('${CVR_ID}', 'bar', '{"table":"users"}', '02', 'bar-transformed', '01');
       
       -- Insert query 'baz' (tasks table with AST)
-      INSERT INTO "roze_1/cvr".queries ("clientGroupID", "queryHash", "clientAST", "patchVersion", "transformationHash", "transformationVersion")
-        VALUES('${CVR_ID}', 'baz', '{"table":"tasks"}', '03', 'baz-transformed', '01');
+      INSERT INTO "roze_1/cvr".queries ("clientGroupID", "queryHash", "clientAST", "patchVersion", "transformationHash", "transformationVersion", "queryName", "queryArgs")
+        VALUES('${CVR_ID}', 'baz', NULL, '03', 'baz-transformed', '01', 'named', '["arg1",1,true]');
       
       -- Client1 desires foo and bar
       INSERT INTO "roze_1/cvr".desires ("clientGroupID", "clientID", "queryHash", "patchVersion")
@@ -948,6 +948,7 @@ describe('view-syncer/cvr-store', () => {
     expect(allQueries).toMatchInlineSnapshot(`
       Result [
         {
+          "args": null,
           "ast": {
             "table": "users",
           },
@@ -955,11 +956,13 @@ describe('view-syncer/cvr-store', () => {
           "deleted": false,
           "got": true,
           "inactivatedAt": null,
+          "name": null,
           "queryID": "bar",
           "rowCount": 6,
           "ttl": -1,
         },
         {
+          "args": null,
           "ast": {
             "table": "issues",
           },
@@ -967,11 +970,13 @@ describe('view-syncer/cvr-store', () => {
           "deleted": false,
           "got": true,
           "inactivatedAt": null,
+          "name": null,
           "queryID": "foo",
           "rowCount": 6,
           "ttl": -1,
         },
         {
+          "args": null,
           "ast": {
             "table": "users",
           },
@@ -979,18 +984,23 @@ describe('view-syncer/cvr-store', () => {
           "deleted": false,
           "got": true,
           "inactivatedAt": 1728950400000,
+          "name": null,
           "queryID": "bar",
           "rowCount": 6,
           "ttl": -1,
         },
         {
-          "ast": {
-            "table": "tasks",
-          },
+          "args": [
+            "arg1",
+            1,
+            true,
+          ],
+          "ast": null,
           "clientID": "client2",
           "deleted": false,
           "got": true,
           "inactivatedAt": null,
+          "name": "named",
           "queryID": "baz",
           "rowCount": 0,
           "ttl": 7200,
@@ -1003,6 +1013,7 @@ describe('view-syncer/cvr-store', () => {
     expect(client1Queries).toMatchInlineSnapshot(`
       Result [
         {
+          "args": null,
           "ast": {
             "table": "users",
           },
@@ -1010,11 +1021,13 @@ describe('view-syncer/cvr-store', () => {
           "deleted": false,
           "got": true,
           "inactivatedAt": null,
+          "name": null,
           "queryID": "bar",
           "rowCount": 6,
           "ttl": -1,
         },
         {
+          "args": null,
           "ast": {
             "table": "issues",
           },
@@ -1022,6 +1035,7 @@ describe('view-syncer/cvr-store', () => {
           "deleted": false,
           "got": true,
           "inactivatedAt": null,
+          "name": null,
           "queryID": "foo",
           "rowCount": 6,
           "ttl": -1,
@@ -1034,6 +1048,7 @@ describe('view-syncer/cvr-store', () => {
     expect(client2Queries).toMatchInlineSnapshot(`
       Result [
         {
+          "args": null,
           "ast": {
             "table": "users",
           },
@@ -1041,18 +1056,23 @@ describe('view-syncer/cvr-store', () => {
           "deleted": false,
           "got": true,
           "inactivatedAt": 1728950400000,
+          "name": null,
           "queryID": "bar",
           "rowCount": 6,
           "ttl": -1,
         },
         {
-          "ast": {
-            "table": "tasks",
-          },
+          "args": [
+            "arg1",
+            1,
+            true,
+          ],
+          "ast": null,
           "clientID": "client2",
           "deleted": false,
           "got": true,
           "inactivatedAt": null,
+          "name": "named",
           "queryID": "baz",
           "rowCount": 0,
           "ttl": 7200,

--- a/packages/zero-cache/src/services/view-syncer/cvr-store.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.ts
@@ -839,19 +839,20 @@ export class CVRStore {
     try {
       return await reader.processReadTask(
         tx => tx<InspectQueryRow[]>`
-  SELECT
+  SELECT DISTINCT ON (d."clientID", d."queryHash")
     d."clientID",
     d."queryHash" AS "queryID",
     COALESCE((EXTRACT(EPOCH FROM d."ttl") * 1000)::double precision, -1) AS "ttl",
     (EXTRACT(EPOCH FROM d."inactivatedAt") * 1000)::double precision AS "inactivatedAt",
-    COUNT(r.*)::INT AS "rowCount",
+    (SELECT COUNT(*)::INT FROM ${this.#cvr('rows')} r 
+     WHERE r."clientGroupID" = d."clientGroupID" 
+     AND r."refCounts" ? d."queryHash") AS "rowCount",
     q."clientAST" AS "ast",
     (q."patchVersion" IS NOT NULL) AS "got",
-    COALESCE(d."deleted", FALSE) AS "deleted"
+    COALESCE(d."deleted", FALSE) AS "deleted",
+    q."queryName" AS "name",
+    q."queryArgs" AS "args"
   FROM ${this.#cvr('desires')} d
-  LEFT JOIN ${this.#cvr('rows')} r
-    ON r."clientGroupID" = d."clientGroupID"
-   AND r."refCounts" ? d."queryHash"
   LEFT JOIN ${this.#cvr('queries')} q
     ON q."clientGroupID" = d."clientGroupID"
    AND q."queryHash" = d."queryHash"
@@ -861,7 +862,6 @@ export class CVRStore {
       d."deleted" IS NOT DISTINCT FROM true AND
       (d."inactivatedAt" IS NOT NULL AND d."ttl" IS NOT NULL AND d."inactivatedAt" + d."ttl" <= now())
     )
-  GROUP BY d."clientID", d."queryHash", d."ttl", d."inactivatedAt", q."patchVersion", q."clientAST", d."deleted"
   ORDER BY d."clientID", d."queryHash"`,
       );
     } finally {

--- a/packages/zero-client/src/client/inspector/inspector.test.ts
+++ b/packages/zero-client/src/client/inspector/inspector.test.ts
@@ -115,6 +115,8 @@ test('client queries', async () => {
         clientID: z.clientID,
         queryID: '1',
         ast: {table: 'issue'},
+        name: null,
+        args: null,
         deleted: false,
         got: true,
         inactivatedAt: null,
@@ -126,6 +128,8 @@ test('client queries', async () => {
       {
         clientID: z.clientID,
         ast: {table: 'issue'},
+        name: null,
+        args: null,
         deleted: false,
         got: true,
         id: '1',
@@ -143,6 +147,8 @@ test('client queries', async () => {
         clientID: z.clientID,
         queryID: '1',
         ast: {table: 'issue'},
+        name: null,
+        args: null,
         deleted: false,
         got: true,
         inactivatedAt: d,
@@ -154,6 +160,8 @@ test('client queries', async () => {
       {
         clientID: z.clientID,
         ast: {table: 'issue'},
+        name: null,
+        args: null,
         deleted: false,
         got: true,
         id: '1',
@@ -217,6 +225,8 @@ test('clientGroup queries', async () => {
           clientID: z.clientID,
           queryID: '1',
           ast,
+          name: null,
+          args: null,
           deleted: false,
           got: true,
           inactivatedAt: null,
@@ -229,6 +239,8 @@ test('clientGroup queries', async () => {
   expect(await p).toEqual([
     {
       ast,
+      name: null,
+      args: null,
       clientID: z.clientID,
       deleted: false,
       got: true,

--- a/packages/zero-client/src/client/inspector/inspector.ts
+++ b/packages/zero-client/src/client/inspector/inspector.ts
@@ -283,14 +283,16 @@ async function clientsWithQueries(
 }
 
 class Query implements QueryInterface {
-  readonly ast: AST;
+  readonly ast: AST | null;
+  readonly name: string | null;
+  readonly args: ReadonlyArray<ReadonlyJSONValue> | null;
   readonly got: boolean;
   readonly ttl: TTL;
   readonly inactivatedAt: Date | null;
   readonly rowCount: number;
   readonly deleted: boolean;
   readonly id: string;
-  readonly zql: string;
+  readonly zql: string | null;
   readonly clientID: string;
 
   constructor(row: InspectQueryRow, _schema: Schema) {
@@ -303,9 +305,11 @@ class Query implements QueryInterface {
       row.inactivatedAt === null ? null : new Date(row.inactivatedAt);
     this.ttl = normalizeTTL(row.ttl);
     this.ast = row.ast;
+    this.name = row.name;
+    this.args = row.args;
     this.got = row.got;
     this.rowCount = row.rowCount;
     this.deleted = row.deleted;
-    this.zql = this.ast.table + astToZQL(this.ast);
+    this.zql = this.ast ? this.ast.table + astToZQL(this.ast) : null;
   }
 }

--- a/packages/zero-client/src/client/inspector/types.ts
+++ b/packages/zero-client/src/client/inspector/types.ts
@@ -30,7 +30,9 @@ export interface ClientGroup {
 }
 
 export interface Query {
-  readonly ast: AST;
+  readonly ast: AST | null;
+  readonly name: string | null;
+  readonly args: ReadonlyArray<ReadonlyJSONValue> | null;
   readonly clientID: string;
   readonly deleted: boolean;
   readonly got: boolean;
@@ -38,5 +40,5 @@ export interface Query {
   readonly inactivatedAt: Date | null;
   readonly rowCount: number;
   readonly ttl: TTL;
-  readonly zql: string;
+  readonly zql: string | null;
 }

--- a/packages/zero-protocol/src/ast.test.ts
+++ b/packages/zero-protocol/src/ast.test.ts
@@ -607,5 +607,5 @@ test('protocol version', () => {
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
   expect(hash).toEqual('1c228prd1v53r');
-  expect(PROTOCOL_VERSION).toEqual(19);
+  expect(PROTOCOL_VERSION).toEqual(20);
 });

--- a/packages/zero-protocol/src/inspect-down.ts
+++ b/packages/zero-protocol/src/inspect-down.ts
@@ -1,10 +1,16 @@
+import {jsonSchema} from '../../shared/src/json-schema.ts';
 import * as v from '../../shared/src/valita.ts';
 import {astSchema} from './ast.ts';
 
 const inspectQueryRowSchema = v.object({
   clientID: v.string(),
   queryID: v.string(),
-  ast: astSchema,
+  // null for custom queries
+  ast: astSchema.nullable(),
+  // not null for custom queries
+  name: v.string().nullable(),
+  // not null for custom queries
+  args: v.readonlyArray(jsonSchema).nullable(),
   got: v.boolean(),
   deleted: v.boolean(),
   ttl: v.number(),

--- a/packages/zero-protocol/src/protocol-version.test.ts
+++ b/packages/zero-protocol/src/protocol-version.test.ts
@@ -11,6 +11,6 @@ test('protocol version', () => {
   // If this test fails upstream or downstream schema has changed such that
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
-  expect(hash).toEqual('1281atik6gm8m');
-  expect(PROTOCOL_VERSION).toEqual(19);
+  expect(hash).toEqual('zhmq3two3zh4');
+  expect(PROTOCOL_VERSION).toEqual(20);
 });

--- a/packages/zero-protocol/src/protocol-version.ts
+++ b/packages/zero-protocol/src/protocol-version.ts
@@ -25,7 +25,8 @@ import {assert} from '../../shared/src/asserts.ts';
 // -- Version 17 deprecates `AST` in downstream query puts. It was never used anyway.
 // -- Version 18 adds `name` and `args` to the `queries-patch` protocol
 // -- Version 19 adds `activeClients` to the `initConnection` protocol
-export const PROTOCOL_VERSION = 19;
+// -- Version 20 changes inspector down message
+export const PROTOCOL_VERSION = 20;
 
 /**
  * The minimum server-supported sync protocol version (i.e. the version


### PR DESCRIPTION
When we added custom queries we changed the type of the ast column to nullable but the inspector code was not updated to handle that. This commit updates the inspector code to handle the nullable ast column as well as the name and args columns that were added when custom queries were added.