### PR TITLE
fix(zql): error in `take` when bound node is edited

### DIFF
--- a/packages/zql-integration-tests/src/chinook/chinook.pg-test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook.pg-test.ts
@@ -540,11 +540,14 @@ describe(
             name: 'Order by nullable column',
             createQuery: q => q.customer.orderBy('company', 'desc').limit(10),
           },
-          // TODO: case below is broken.
-          // {
-          //   name: 'Order by nullable column (single row)',
-          //   createQuery: q => q.employee.orderBy('reportsTo', 'asc').limit(1),
-          // },
+          {
+            name: 'Order by column (single row)',
+            createQuery: q => q.employee.orderBy('firstName', 'asc').limit(1),
+          },
+          {
+            name: 'Order by nullable column (single row)',
+            createQuery: q => q.employee.orderBy('reportsTo', 'asc').limit(1),
+          },
           {
             name: 'Order by nullable column',
             createQuery: q => q.employee.orderBy('reportsTo', 'desc').limit(6),

--- a/packages/zql/src/ivm/take.ts
+++ b/packages/zql/src/ivm/take.ts
@@ -498,6 +498,12 @@ export class Take implements Operator {
         newBoundNode.row,
         maxBound,
       );
+      this.#withRowHiddenFromFetch(newBoundNode.row, () => {
+        this.#output.push({
+          type: 'remove',
+          node: change.oldNode,
+        });
+      });
       this.#output.push({
         type: 'add',
         node: newBoundNode,


### PR DESCRIPTION
When the bound node was edited to no longer be inside the window, take would not push a remove for that node.

Example:

```ts
const employees = new MemorySource([{
  id: 1,
  name: 'April',
}, {
  id: 2,
  name: 'BApril',
}]);

const view = z.employees.limit(1).orderBy('name', 'asc').materialize();

// view is:
[{
  id: 1,
  name: 'April',
}];

// now edit april
employees.push({
  type: 'edit',
  newRow: {
    id: 1,
    name: 'ZApril',
  },
  oldRow: {
    id: 1,
    name: 'April',
  }
});

// the view (before this fix) would be:
[{
  id: 1,
  name: 'April',
}, {
  id:2,
  name: 'BApril'
}];

// because only the `add` change for the node that fell into the window
// would be pushed.
// The `remove` change for the node to be ejected was not pushed.
```
