### PR TITLE
feat(zero): custom mutator api that matches custom queries

### DIFF
--- a/packages/zero-pg/src/mod.ts
+++ b/packages/zero-pg/src/mod.ts
@@ -18,9 +18,4 @@ export {
   type PostgresJSClient,
   type PostgresJSTransaction,
 } from './postgresjs-connection.ts';
-export {
-  PushProcessor,
-  type Database,
-  type TransactionProviderInput,
-  type TransactionProviderHooks,
-} from './push-processor.ts';
+export {PushProcessor} from './push-processor.ts';

--- a/packages/zero-pg/src/push-processor.pg-test.ts
+++ b/packages/zero-pg/src/push-processor.pg-test.ts
@@ -2,14 +2,14 @@ import {testDBs} from '../../zero-cache/src/test/db.ts';
 import {beforeEach, describe, expect, test} from 'vitest';
 import type {PostgresDB} from '../../zero-cache/src/types/pg.ts';
 import {getClientsTableDefinition} from '../../zero-cache/src/services/change-source/pg/schema/shard.ts';
-
-import {OutOfOrderMutation, PushProcessor} from './push-processor.ts';
 import {PostgresJSConnection} from './postgresjs-connection.ts';
 import type {PushBody} from '../../zero-protocol/src/push.ts';
 import {customMutatorKey} from '../../zql/src/mutate/custom.ts';
 import {ZQLDatabase} from './zql-database.ts';
 import {zip} from '../../shared/src/arrays.ts';
 import {MutationAlreadyProcessedError} from '../../zero-cache/src/services/mutagen/mutagen.ts';
+import {OutOfOrderMutation} from '../../zero-server/src/process-mutations.ts';
+import {PushProcessor} from './push-processor.ts';
 
 let pg: PostgresDB;
 const params = {

--- a/packages/zero-pg/src/push-processor.ts
+++ b/packages/zero-pg/src/push-processor.ts
@@ -1,59 +1,31 @@
-import {LogContext, type LogLevel} from '@rocicorp/logger';
+import {type LogLevel} from '@rocicorp/logger';
 import {assert} from '../../shared/src/asserts.ts';
 import type {ReadonlyJSONValue} from '../../shared/src/json.ts';
-import * as v from '../../shared/src/valita.ts';
-import {MutationAlreadyProcessedError} from '../../zero-cache/src/services/mutagen/mutagen.ts';
 import {
-  pushBodySchema,
-  pushParamsSchema,
-  type Mutation,
+  type CustomMutation,
   type MutationResponse,
-  type PushBody,
   type PushResponse,
 } from '../../zero-protocol/src/push.ts';
 import {splitMutatorKey} from '../../zql/src/mutate/custom.ts';
-import {createLogContext} from './logging.ts';
 import type {CustomMutatorDefs} from './custom.ts';
-
-export type Params = v.Infer<typeof pushParamsSchema>;
-
-// TODO: This file should move to @rocicorp/zero/server. It is not specific to
-// Postgres.
-
-export interface TransactionProviderHooks {
-  updateClientMutationID: () => Promise<{lastMutationID: number | bigint}>;
-}
-
-export interface TransactionProviderInput {
-  upstreamSchema: string;
-  clientGroupID: string;
-  clientID: string;
-  mutationID: number;
-}
-
-/**
- * Defines the abstract interface for a database that PushProcessor can execute
- * transactions against.
- */
-export interface Database<T> {
-  transaction: <R>(
-    callback: (tx: T, transactionHooks: TransactionProviderHooks) => Promise<R>,
-    transactionInput: TransactionProviderInput,
-  ) => Promise<R>;
-}
-
-type ExtractTransactionType<D> = D extends Database<infer T> ? T : never;
+import {
+  type ExtractTransactionType,
+  type Database,
+  processMutations,
+  type TransactFn,
+} from '../../zero-server/src/process-mutations.ts';
+import {must} from '../../shared/src/must.ts';
 
 export class PushProcessor<
   D extends Database<ExtractTransactionType<D>>,
   MD extends CustomMutatorDefs<ExtractTransactionType<D>>,
 > {
   readonly #dbProvider: D;
-  readonly #lc: LogContext;
+  readonly #logLevel;
 
   constructor(dbProvider: D, logLevel: LogLevel = 'info') {
     this.#dbProvider = dbProvider;
-    this.#lc = createLogContext(logLevel).withContext('PushProcessor');
+    this.#logLevel = logLevel;
   }
 
   /**
@@ -67,7 +39,7 @@ export class PushProcessor<
    * @param queryString the query string from the request sent by zero-cache. This will include zero's postgres schema name and appID.
    * @param body the body of the request sent by zero-cache as a JSON object.
    */
-  async process(
+  process(
     mutators: MD,
     queryString: URLSearchParams | Record<string, string>,
     body: ReadonlyJSONValue,
@@ -79,182 +51,53 @@ export class PushProcessor<
    * @param mutators the custom mutators for the application
    * @param request A `Request` object.
    */
-  async process(mutators: MD, request: Request): Promise<PushResponse>;
-  async process(
+  process(mutators: MD, request: Request): Promise<PushResponse>;
+  process(
     mutators: MD,
     queryOrQueryString: Request | URLSearchParams | Record<string, string>,
     body?: ReadonlyJSONValue,
   ): Promise<PushResponse> {
-    let queryString: URLSearchParams | Record<string, string>;
     if (queryOrQueryString instanceof Request) {
-      const url = new URL(queryOrQueryString.url);
-      queryString = url.searchParams;
-      body = await queryOrQueryString.json();
-    } else {
-      queryString = queryOrQueryString;
-    }
-    const req = v.parse(body, pushBodySchema);
-    if (queryString instanceof URLSearchParams) {
-      queryString = Object.fromEntries(queryString);
-    }
-    const queryParams = v.parse(queryString, pushParamsSchema, 'passthrough');
-
-    if (req.pushVersion !== 1) {
-      this.#lc.error?.(
-        `Unsupported push version ${req.pushVersion} for clientGroupID ${req.clientGroupID}`,
-      );
-      return {
-        error: 'unsupportedPushVersion',
-      };
-    }
-
-    const responses: MutationResponse[] = [];
-    for (const m of req.mutations) {
-      const res = await this.#processMutation(mutators, queryParams, req, m);
-      responses.push(res);
-
-      // we only break if we encounter an out-of-order mutation.
-      // otherwise we continue processing the rest of the mutations.
-      if ('error' in res.result && res.result.error === 'oooMutation') {
-        break;
-      }
-    }
-
-    return {
-      mutations: responses,
-    };
-  }
-
-  async #processMutation(
-    mutators: MD,
-    params: Params,
-    req: PushBody,
-    m: Mutation,
-  ): Promise<MutationResponse> {
-    let caughtError: unknown = undefined;
-    for (;;) {
-      try {
-        const ret = await this.#processMutationImpl(
-          mutators,
-          params,
-          req,
-          m,
-          caughtError !== undefined,
-        );
-
-        // The first time through we caught an error.
-        // We want to report that error as it was an application
-        // level error.
-        if (caughtError !== undefined) {
-          this.#lc.warn?.(
-            `Mutation ${m.id} for client ${m.clientID} was retried after an error: ${caughtError}`,
-          );
-          return makeAppErrorResponse(m, caughtError);
-        }
-
-        return ret;
-      } catch (e) {
-        if (e instanceof OutOfOrderMutation) {
-          this.#lc.error?.(e);
-          return {
-            id: {
-              clientID: m.clientID,
-              id: m.id,
-            },
-            result: {
-              error: 'oooMutation',
-              details: e.message,
-            },
-          };
-        }
-
-        if (e instanceof MutationAlreadyProcessedError) {
-          this.#lc.warn?.(e);
-          return {
-            id: {
-              clientID: m.clientID,
-              id: m.id,
-            },
-            result: {
-              error: 'alreadyProcessed',
-              details: e.message,
-            },
-          };
-        }
-
-        // We threw an error while running in error mode.
-        // Re-throw the error and stop processing any further
-        // mutations as all subsequent mutations will fail by being
-        // out of order.
-        if (caughtError !== undefined) {
-          throw e;
-        }
-
-        caughtError = e;
-        this.#lc.error?.(
-          `Unexpected error processing mutation ${m.id} for client ${m.clientID}`,
-          e,
-        );
-      }
-    }
-  }
-
-  #processMutationImpl(
-    mutators: MD,
-    params: Params,
-    req: PushBody,
-    m: Mutation,
-    errorMode: boolean,
-  ): Promise<MutationResponse> {
-    if (m.type === 'crud') {
-      throw new Error(
-        'crud mutators are deprecated in favor of custom mutators.',
+      return processMutations(
+        (transact, mutations) =>
+          this.#processMutation(mutators, transact, mutations),
+        queryOrQueryString,
+        this.#logLevel,
       );
     }
+    return processMutations(
+      (transact, mutation) =>
+        this.#processMutation(mutators, transact, mutation),
+      queryOrQueryString,
+      must(body),
+      this.#logLevel,
+    );
+  }
 
-    return this.#dbProvider.transaction(
-      async (dbTx, transactionHooks): Promise<MutationResponse> => {
-        await this.#checkAndIncrementLastMutationID(
-          this.#lc,
-          transactionHooks,
-          m.clientID,
-          m.id,
-        );
-
-        if (!errorMode) {
-          await this.#dispatchMutation(dbTx, mutators, m);
-        }
-
-        return {
-          id: {
-            clientID: m.clientID,
-            id: m.id,
-          },
-          result: {},
-        };
-      },
-      {
-        upstreamSchema: params.schema,
-        clientGroupID: req.clientGroupID,
-        clientID: m.clientID,
-        mutationID: m.id,
-      },
+  #processMutation(
+    mutators: MD,
+    transact: TransactFn,
+    _mutation: CustomMutation,
+  ): Promise<MutationResponse> {
+    return transact(this.#dbProvider, (tx, name, args) =>
+      this.#dispatchMutation(mutators, tx, name, args),
     );
   }
 
   #dispatchMutation(
-    dbTx: ExtractTransactionType<D>,
     mutators: MD,
-    m: Mutation,
+    dbTx: ExtractTransactionType<D>,
+    key: string,
+    args: ReadonlyJSONValue,
   ): Promise<void> {
-    const [namespace, name] = splitMutatorKey(m.name);
+    const [namespace, name] = splitMutatorKey(key);
     if (name === undefined) {
       const mutator = mutators[namespace];
       assert(
         typeof mutator === 'function',
-        () => `could not find mutator ${m.name}`,
+        () => `could not find mutator ${key}`,
       );
-      return mutator(dbTx, m.args[0]);
+      return mutator(dbTx, args);
     }
 
     const mutatorGroup = mutators[namespace];
@@ -265,62 +108,8 @@ export class PushProcessor<
     const mutator = mutatorGroup[name];
     assert(
       typeof mutator === 'function',
-      () => `could not find mutator ${m.name}`,
+      () => `could not find mutator ${key}`,
     );
-    return mutator(dbTx, m.args[0]);
+    return mutator(dbTx, args);
   }
-
-  async #checkAndIncrementLastMutationID(
-    lc: LogContext,
-    transactionHooks: TransactionProviderHooks,
-    clientID: string,
-    receivedMutationID: number,
-  ) {
-    lc.debug?.(`Incrementing LMID. Received: ${receivedMutationID}`);
-
-    const {lastMutationID} = await transactionHooks.updateClientMutationID();
-
-    if (receivedMutationID < lastMutationID) {
-      throw new MutationAlreadyProcessedError(
-        clientID,
-        receivedMutationID,
-        lastMutationID,
-      );
-    } else if (receivedMutationID > lastMutationID) {
-      throw new OutOfOrderMutation(
-        clientID,
-        receivedMutationID,
-        lastMutationID,
-      );
-    }
-    lc.debug?.(
-      `Incremented LMID. Received: ${receivedMutationID}. New: ${lastMutationID}`,
-    );
-  }
-}
-
-export class OutOfOrderMutation extends Error {
-  constructor(
-    clientID: string,
-    receivedMutationID: number,
-    lastMutationID: number | bigint,
-  ) {
-    super(
-      `Client ${clientID} sent mutation ID ${receivedMutationID} but expected ${lastMutationID}`,
-    );
-  }
-}
-
-function makeAppErrorResponse(m: Mutation, e: unknown): MutationResponse {
-  return {
-    id: {
-      clientID: m.clientID,
-      id: m.id,
-    },
-    result: {
-      error: 'app',
-      details:
-        e instanceof Error ? e.message : 'exception was not of type `Error`',
-    },
-  };
 }

--- a/packages/zero-pg/src/zql-database.ts
+++ b/packages/zero-pg/src/zql-database.ts
@@ -1,9 +1,4 @@
 import type {
-  Database,
-  TransactionProviderHooks,
-  TransactionProviderInput,
-} from './push-processor.ts';
-import type {
   DBConnection,
   DBTransaction,
   SchemaCRUD,
@@ -15,6 +10,11 @@ import {makeSchemaQuery} from './query.ts';
 import {makeSchemaCRUD, TransactionImpl} from './custom.ts';
 import type {Schema} from '../../zero-schema/src/builder/schema-builder.ts';
 import {makeServerTransaction} from './custom.ts';
+import type {
+  Database,
+  TransactionProviderHooks,
+  TransactionProviderInput,
+} from '../../zero-server/src/process-mutations.ts';
 
 /**
  * Implements a Database for use with PushProcessor that is backed by Postgres.

--- a/packages/zero-server/src/logging.ts
+++ b/packages/zero-server/src/logging.ts
@@ -1,0 +1,5 @@
+import {LogContext, consoleLogSink, type LogLevel} from '@rocicorp/logger';
+
+export function createLogContext(level: LogLevel): LogContext {
+  return new LogContext(level, {}, consoleLogSink);
+}

--- a/packages/zero-server/src/mod.ts
+++ b/packages/zero-server/src/mod.ts
@@ -1,1 +1,2 @@
-export * from './queries/process-queries.ts';
+export * from './process-queries.ts';
+export * from './process-mutations.ts';

--- a/packages/zero-server/src/process-mutations.ts
+++ b/packages/zero-server/src/process-mutations.ts
@@ -1,0 +1,310 @@
+import type {ReadonlyJSONValue} from '../../shared/src/json.ts';
+import {
+  pushBodySchema,
+  pushParamsSchema,
+  type CustomMutation,
+  type Mutation,
+  type MutationResponse,
+  type PushBody,
+  type PushResponse,
+} from '../../zero-protocol/src/push.ts';
+import * as v from '../../shared/src/valita.ts';
+import {MutationAlreadyProcessedError} from '../../zero-cache/src/services/mutagen/mutagen.ts';
+import {createLogContext} from './logging.ts';
+import type {LogContext, LogLevel} from '@rocicorp/logger';
+import {assert} from '../../shared/src/asserts.ts';
+
+export interface TransactionProviderHooks {
+  updateClientMutationID: () => Promise<{lastMutationID: number | bigint}>;
+}
+
+export interface TransactionProviderInput {
+  upstreamSchema: string;
+  clientGroupID: string;
+  clientID: string;
+  mutationID: number;
+}
+
+/**
+ * Defines the abstract interface for a database that PushProcessor can execute
+ * transactions against.
+ */
+export interface Database<T> {
+  transaction: <R>(
+    callback: (tx: T, transactionHooks: TransactionProviderHooks) => Promise<R>,
+    transactionInput: TransactionProviderInput,
+  ) => Promise<R>;
+}
+
+export type ExtractTransactionType<D> = D extends Database<infer T> ? T : never;
+export type Params = v.Infer<typeof pushParamsSchema>;
+
+export type TransactFn = <D extends Database<ExtractTransactionType<D>>>(
+  dbProvider: D,
+  cb: TransactFnCallback<D>,
+) => Promise<MutationResponse>;
+
+export type TransactFnCallback<D extends Database<ExtractTransactionType<D>>> =
+  (
+    tx: ExtractTransactionType<D>,
+    mutatorName: string,
+    mutatorArgs: ReadonlyJSONValue,
+  ) => Promise<void>;
+
+export type Parsed = {
+  transact: TransactFn;
+  mutations: CustomMutation[];
+};
+
+/**
+ * Call `cb` for each mutation in the request.
+ * The callback is called sequentially for each mutation.
+ * If a mutation is out of order, the processing will stop and an error will be returned.
+ * If a mutation has already been processed, it will be skipped and the processing will continue.
+ * If a mutation receives an application error, it will be skipped, the error will be returned to the client, and processing will continue.
+ */
+export function processMutations(
+  cb: (
+    transact: TransactFn,
+    mutation: CustomMutation,
+  ) => Promise<MutationResponse>,
+  queryString: URLSearchParams | Record<string, string>,
+  body: ReadonlyJSONValue,
+  logLevel?: LogLevel | undefined,
+): Promise<PushResponse>;
+export function processMutations(
+  cb: (
+    transact: TransactFn,
+    mutation: CustomMutation,
+  ) => Promise<MutationResponse>,
+  request: Request,
+  logLevel?: LogLevel | undefined,
+): Promise<PushResponse>;
+export async function processMutations(
+  cb: (
+    transact: TransactFn,
+    mutation: CustomMutation,
+  ) => Promise<MutationResponse>,
+  queryOrQueryString: Request | URLSearchParams | Record<string, string>,
+  body?: ReadonlyJSONValue | LogLevel,
+  logLevel?: LogLevel | undefined,
+): Promise<PushResponse> {
+  if (logLevel === undefined) {
+    if (queryOrQueryString instanceof Request && typeof body === 'string') {
+      logLevel = body as LogLevel;
+    } else {
+      logLevel = 'info';
+    }
+  }
+
+  let queryString: URLSearchParams | Record<string, string>;
+  if (queryOrQueryString instanceof Request) {
+    const url = new URL(queryOrQueryString.url);
+    queryString = url.searchParams;
+
+    body = await queryOrQueryString.json();
+  } else {
+    queryString = queryOrQueryString;
+  }
+  const req = v.parse(body, pushBodySchema);
+  if (queryString instanceof URLSearchParams) {
+    queryString = Object.fromEntries(queryString);
+  }
+  const queryParams = v.parse(queryString, pushParamsSchema, 'passthrough');
+
+  if (req.pushVersion !== 1) {
+    return {
+      error: 'unsupportedPushVersion',
+    };
+  }
+
+  const transactor = new Transactor(req, queryParams, logLevel);
+
+  const responses: MutationResponse[] = [];
+  for (const m of req.mutations) {
+    assert(m.type === 'custom', 'Expected custom mutation');
+
+    const res = await cb(
+      (dbProvider, innerCb) => transactor.transact(dbProvider, m, innerCb),
+      m,
+    );
+    responses.push(res);
+
+    // We only stop processing if the mutation is out of order.
+    // If the mutation has already been processed or if it returns an application error,
+    // we continue processing the next mutation.
+    if ('error' in res.result && res.result.error === 'oooMutation') {
+      break;
+    }
+  }
+
+  return {
+    mutations: responses,
+  };
+}
+
+class Transactor {
+  readonly #req: PushBody;
+  readonly #params: Params;
+  readonly #lc: LogContext;
+
+  constructor(req: PushBody, params: Params, logLevel: LogLevel) {
+    this.#req = req;
+    this.#params = params;
+    this.#lc = createLogContext(logLevel).withContext('PushProcessor');
+  }
+
+  transact = async <D extends Database<ExtractTransactionType<D>>>(
+    dbProvider: D,
+    mutation: CustomMutation,
+    cb: TransactFnCallback<D>,
+  ): Promise<MutationResponse> => {
+    let caughtError: unknown = undefined;
+    for (;;) {
+      try {
+        const ret = await this.#transactImpl(
+          dbProvider,
+          mutation,
+          cb,
+          caughtError !== undefined,
+        );
+        // The first time through we caught an error.
+        // We want to report that error as it was an application
+        // level error.
+        if (caughtError !== undefined) {
+          this.#lc.warn?.(
+            `Mutation ${mutation.id} for client ${mutation.clientID} was retried after an error: ${caughtError}`,
+          );
+          return makeAppErrorResponse(mutation, caughtError);
+        }
+
+        return ret;
+      } catch (e) {
+        if (e instanceof OutOfOrderMutation) {
+          this.#lc.error?.(e);
+          return {
+            id: {
+              clientID: mutation.clientID,
+              id: mutation.id,
+            },
+            result: {
+              error: 'oooMutation',
+              details: e.message,
+            },
+          };
+        }
+
+        if (e instanceof MutationAlreadyProcessedError) {
+          this.#lc.warn?.(e);
+          return {
+            id: {
+              clientID: mutation.clientID,
+              id: mutation.id,
+            },
+            result: {
+              error: 'alreadyProcessed',
+              details: e.message,
+            },
+          };
+        }
+
+        // We threw an error while running in error mode.
+        // Re-throw the error and stop processing any further
+        // mutations as all subsequent mutations will fail by being
+        // out of order.
+        if (caughtError !== undefined) {
+          throw e;
+        }
+
+        caughtError = e;
+        this.#lc.error?.(
+          `Unexpected error processing mutation ${mutation.id} for client ${mutation.clientID}`,
+          e,
+        );
+      }
+    }
+  };
+
+  #transactImpl<D extends Database<ExtractTransactionType<D>>>(
+    dbProvider: D,
+    mutation: CustomMutation,
+    cb: TransactFnCallback<D>,
+    errorMode: boolean,
+  ): Promise<MutationResponse> {
+    return dbProvider.transaction(
+      async (dbTx, transactionHooks) => {
+        await this.#checkAndIncrementLastMutationID(
+          transactionHooks,
+          mutation.clientID,
+          mutation.id,
+        );
+
+        if (!errorMode) {
+          await cb(dbTx, mutation.name, mutation.args[0]);
+        }
+
+        return {
+          id: {
+            clientID: mutation.clientID,
+            id: mutation.id,
+          },
+          result: {},
+        };
+      },
+      {
+        upstreamSchema: this.#params.schema,
+        clientGroupID: this.#req.clientGroupID,
+        clientID: mutation.clientID,
+        mutationID: mutation.id,
+      },
+    );
+  }
+
+  async #checkAndIncrementLastMutationID(
+    transactionHooks: TransactionProviderHooks,
+    clientID: string,
+    receivedMutationID: number,
+  ) {
+    const {lastMutationID} = await transactionHooks.updateClientMutationID();
+
+    if (receivedMutationID < lastMutationID) {
+      throw new MutationAlreadyProcessedError(
+        clientID,
+        receivedMutationID,
+        lastMutationID,
+      );
+    } else if (receivedMutationID > lastMutationID) {
+      throw new OutOfOrderMutation(
+        clientID,
+        receivedMutationID,
+        lastMutationID,
+      );
+    }
+  }
+}
+
+export class OutOfOrderMutation extends Error {
+  constructor(
+    clientID: string,
+    receivedMutationID: number,
+    lastMutationID: number | bigint,
+  ) {
+    super(
+      `Client ${clientID} sent mutation ID ${receivedMutationID} but expected ${lastMutationID}`,
+    );
+  }
+}
+
+function makeAppErrorResponse(m: Mutation, e: unknown): MutationResponse {
+  return {
+    id: {
+      clientID: m.clientID,
+      id: m.id,
+    },
+    result: {
+      error: 'app',
+      details:
+        e instanceof Error ? e.message : 'exception was not of type `Error`',
+    },
+  };
+}

--- a/packages/zero-server/src/process-queries.ts
+++ b/packages/zero-server/src/process-queries.ts
@@ -1,13 +1,13 @@
-import type {ReadonlyJSONValue} from '../../../shared/src/json.ts';
-import {type AnyQuery} from '../../../zql/src/query/query-impl.ts';
-import * as v from '../../../shared/src/valita.ts';
+import type {ReadonlyJSONValue} from '../../shared/src/json.ts';
+import {type AnyQuery} from '../../zql/src/query/query-impl.ts';
+import * as v from '../../shared/src/valita.ts';
 import {
   transformRequestMessageSchema,
   type TransformResponseMessage,
-} from '../../../zero-protocol/src/custom-queries.ts';
-import type {Schema} from '../../../zero-schema/src/builder/schema-builder.ts';
-import {clientToServer} from '../../../zero-schema/src/name-mapper.ts';
-import {mapAST} from '../../../zero-protocol/src/ast.ts';
+} from '../../zero-protocol/src/custom-queries.ts';
+import type {Schema} from '../../zero-schema/src/builder/schema-builder.ts';
+import {clientToServer} from '../../zero-schema/src/name-mapper.ts';
+import {mapAST} from '../../zero-protocol/src/ast.ts';
 
 /**
  * Invokes the callback `cb` for each query in the request or JSON body.

--- a/packages/zql/src/mutate/named.ts
+++ b/packages/zql/src/mutate/named.ts
@@ -1,0 +1,49 @@
+import type {ReadonlyJSONValue} from '../../../shared/src/json.ts';
+import {must} from '../../../shared/src/must.ts';
+import type {Schema} from '../../../zero-schema/src/builder/schema-builder.ts';
+import type {Transaction} from './custom.ts';
+
+export const mutatorsSymbol = Symbol('mutators');
+
+export type NamedMutatorImpl<
+  S extends Schema,
+  TArg extends
+    ReadonlyArray<ReadonlyJSONValue> = ReadonlyArray<ReadonlyJSONValue>,
+> = (tx: Transaction<S>, ...args: TArg) => Promise<void>;
+
+export type MutatorMap = Record<
+  string,
+  (...args: ReadonlyArray<ReadonlyJSONValue>) => Promise<void>
+>;
+
+export type MutatorProvider = {
+  [mutatorsSymbol]: MutatorMap;
+};
+
+export type NamedMutator<
+  S extends Schema,
+  TArg extends
+    ReadonlyArray<ReadonlyJSONValue> = ReadonlyArray<ReadonlyJSONValue>,
+> = {
+  (tx: Transaction<S> | MutatorProvider, ...args: TArg): Promise<void>;
+  mutatorName: string;
+};
+
+export function mutator<
+  S extends Schema,
+  TArg extends ReadonlyArray<ReadonlyJSONValue>,
+>(name: string, fn: NamedMutatorImpl<S, TArg>): NamedMutator<S, TArg> {
+  const ret = (tx: Transaction<S> | MutatorProvider, ...args: TArg) => {
+    if (typeof tx === 'object' && mutatorsSymbol in tx) {
+      // If we have a mutator provider, we get the mutator from it.
+      const mutator = must(tx[mutatorsSymbol][name]);
+      return mutator(...args);
+    }
+
+    // Otherwise, we assume it's a transaction and call the function directly.
+    return fn(tx as Transaction<S>, ...args);
+  };
+
+  ret.mutatorName = name;
+  return ret as NamedMutator<S, TArg>;
+}


### PR DESCRIPTION
This is the backend (push-processor) API. Frontend is currently unchanged.

The old API still exists and is implemented by calling the new API.