### PR TITLE
feat(zero-cache): restore the ZERO_CHANGE_STREAMER_URI option

### DIFF
--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -197,7 +197,7 @@ test('zero-cache --help', () => {
      --change-streamer-mode dedicated,discover                   default: "dedicated"                                                                              
        ZERO_CHANGE_STREAMER_MODE env                                                                                                                               
                                                                  As an alternative to ZERO_CHANGE_STREAMER_URI, the ZERO_CHANGE_STREAMER_MODE                      
-                                                                 can be set to discover to instruct the view-syncer to connect to the                              
+                                                                 can be set to "discover" to instruct the view-syncer to connect to the                            
                                                                  ip address registered by the replication-manager upon startup.                                    
                                                                                                                                                                    
                                                                  This may not work in all networking configurations, e.g. certain private                          

--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -187,16 +187,24 @@ test('zero-cache --help', () => {
        ZERO_PORT env                                                                                                                                               
                                                                  The port for sync connections.                                                                    
                                                                                                                                                                    
+     --change-streamer-uri string                                optional                                                                                          
+       ZERO_CHANGE_STREAMER_URI env                                                                                                                                
+                                                                 When set, connects to the change-streamer at the given URI.                                       
+                                                                 In a multi-node setup, this should be specified in view-syncer options,                           
+                                                                 pointing to the replication-manager URI, which runs a change-streamer                             
+                                                                 on port 4849.                                                                                     
+                                                                                                                                                                   
      --change-streamer-mode dedicated,discover                   default: "dedicated"                                                                              
        ZERO_CHANGE_STREAMER_MODE env                                                                                                                               
-                                                                 The mode for running or connecting to the change-streamer:                                        
-                                                                 * dedicated: runs the change-streamer and shuts down when another                                 
-                                                                       change-streamer takes over the replication slot. This is appropriate in a                   
-                                                                       single-node configuration, or for the replication-manager in a                              
-                                                                       multi-node configuration.                                                                   
-                                                                 * discover: connects to the change-streamer as internally advertised in the                       
-                                                                       change-db. This is appropriate for the view-syncers in a multi-node                         
-                                                                       configuration.                                                                              
+                                                                 As an alternative to ZERO_CHANGE_STREAMER_URI, the ZERO_CHANGE_STREAMER_MODE                      
+                                                                 can be set to discover to instruct the view-syncer to connect to the                              
+                                                                 ip address registered by the replication-manager upon startup.                                    
+                                                                                                                                                                   
+                                                                 This may not work in all networking configurations, e.g. certain private                          
+                                                                 networking or port forwarding configurations. Using the ZERO_CHANGE_STREAMER_URI                  
+                                                                 with an explicit routable hostname is recommended instead.                                        
+                                                                                                                                                                   
+                                                                 Note: This option is ignored if the ZERO_CHANGE_STREAMER_URI is set.                              
                                                                                                                                                                    
      --change-streamer-port number                               optional                                                                                          
        ZERO_CHANGE_STREAMER_PORT env                                                                                                                               
@@ -205,28 +213,6 @@ test('zero-cache --help', () => {
                                                                  runs in the same process tree in local development or a single-node configuration.                
                                                                                                                                                                    
                                                                  If unspecified, defaults to --port + 1.                                                           
-                                                                                                                                                                   
-     --change-streamer-address string                            optional                                                                                          
-       ZERO_CHANGE_STREAMER_ADDRESS env                                                                                                                            
-                                                                 The host:port for other processes to use when connecting to this                                  
-                                                                 change-streamer. When unspecified, the machine's IP address and the                               
-                                                                 --change-streamer-port will be advertised for discovery.                                          
-                                                                                                                                                                   
-                                                                 In most cases, the default behavior (unspecified) is sufficient, including in a                   
-                                                                 single-node configuration or a multi-node configuration with host/awsvpc networking               
-                                                                 (e.g. Fargate).                                                                                   
-                                                                                                                                                                   
-                                                                 For a multi-node configuration in which the process is unable to determine the                    
-                                                                 externally addressable port (e.g. a container running with bridge mode networking),               
-                                                                 the --change-streamer-address must be specified manually (e.g. a load balancer or                 
-                                                                 service discovery address).                                                                       
-                                                                                                                                                                   
-     --change-streamer-protocol ws,wss                           default: "ws"                                                                                     
-       ZERO_CHANGE_STREAMER_PROTOCOL env                                                                                                                           
-                                                                 The protocol for other processes to use when connecting to this                                   
-                                                                 change-streamer.                                                                                  
-                                                                                                                                                                   
-                                                                 If unspecified, defaults to ws.                                                                   
                                                                                                                                                                    
      --task-id string                                            optional                                                                                          
        ZERO_TASK_ID env                                                                                                                                            

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -317,17 +317,28 @@ export const zeroOptions = {
   },
 
   changeStreamer: {
+    uri: {
+      type: v.string().optional(),
+      desc: [
+        `When set, connects to the {bold change-streamer} at the given URI.`,
+        `In a multi-node setup, this should be specified in {bold view-syncer} options,`,
+        `pointing to the {bold replication-manager} URI, which runs a {bold change-streamer}`,
+        `on port 4849.`,
+      ],
+    },
+
     mode: {
       type: v.literalUnion('dedicated', 'discover').default('dedicated'),
       desc: [
-        `The mode for running or connecting to the change-streamer:`,
-        `* {bold dedicated}: runs the change-streamer and shuts down when another`,
-        `      change-streamer takes over the replication slot. This is appropriate in a `,
-        `      single-node configuration, or for the {bold replication-manager} in a `,
-        `      multi-node configuration.`,
-        `* {bold discover}: connects to the change-streamer as internally advertised in the`,
-        `      change-db. This is appropriate for the {bold view-syncers} in a multi-node `,
-        `      configuration.`,
+        `As an alternative to {bold ZERO_CHANGE_STREAMER_URI}, the {bold ZERO_CHANGE_STREAMER_MODE}`,
+        `can be set to {bold discover} to instruct the {bold view-syncer} to connect to the `,
+        `ip address registered by the {bold replication-manager} upon startup.`,
+        ``,
+        `This may not work in all networking configurations, e.g. certain private `,
+        `networking or port forwarding configurations. Using the {bold ZERO_CHANGE_STREAMER_URI}`,
+        `with an explicit routable hostname is recommended instead.`,
+        ``,
+        `Note: This option is ignored if the {bold ZERO_CHANGE_STREAMER_URI} is set.`,
       ],
     },
 
@@ -345,29 +356,19 @@ export const zeroOptions = {
     address: {
       type: v.string().optional(),
       desc: [
-        `The {bold host:port} for other processes to use when connecting to this `,
-        `change-streamer. When unspecified, the machine's IP address and the`,
-        `{bold --change-streamer-port} will be advertised for discovery.`,
-        ``,
-        `In most cases, the default behavior (unspecified) is sufficient, including in a`,
-        `single-node configuration or a multi-node configuration with host/awsvpc networking`,
-        `(e.g. Fargate).`,
-        ``,
-        `For a multi-node configuration in which the process is unable to determine the`,
-        `externally addressable port (e.g. a container running with {bold bridge} mode networking),`,
-        `the {bold --change-streamer-address} must be specified manually (e.g. a load balancer or`,
-        `service discovery address).`,
+        `DEPRECATED: Use the {bold ZERO_CHANGE_STREAMER_URI} when routing to`,
+        `a hostname.`,
       ],
+      hidden: true,
     },
 
     protocol: {
       type: v.literalUnion('ws', 'wss').default('ws'),
       desc: [
-        `The {bold protocol} for other processes to use when connecting to this `,
-        `change-streamer.`,
-        ``,
-        `If unspecified, defaults to ws.`,
+        `DEPRECATED: Use the {bold ZERO_CHANGE_STREAMER_URI} when routing to`,
+        `a hostname.`,
       ],
+      hidden: true,
     },
 
     discoveryInterfacePreferences: {
@@ -384,19 +385,6 @@ export const zeroOptions = {
       // More confusing than it's worth to advertise this. The default list should be
       // adjusted to make things work for all environments; it is controlled as a
       // hidden flag as an emergency to unblock people with outlier network configs.
-      hidden: true,
-    },
-
-    uri: {
-      type: v
-        .string()
-        .assert(() => {
-          throw new Error(
-            `ZERO_CHANGE_STREAMER_URI is deprecated. Please see notes for ` +
-              `ZERO_CHANGE_STREAMER_MODE: https://github.com/rocicorp/mono/pull/4335`,
-          );
-        })
-        .optional(),
       hidden: true,
     },
   },

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -331,7 +331,7 @@ export const zeroOptions = {
       type: v.literalUnion('dedicated', 'discover').default('dedicated'),
       desc: [
         `As an alternative to {bold ZERO_CHANGE_STREAMER_URI}, the {bold ZERO_CHANGE_STREAMER_MODE}`,
-        `can be set to {bold discover} to instruct the {bold view-syncer} to connect to the `,
+        `can be set to "{bold discover}" to instruct the {bold view-syncer} to connect to the `,
         `ip address registered by the {bold replication-manager} upon startup.`,
         ``,
         `This may not work in all networking configurations, e.g. certain private `,

--- a/packages/zero-cache/src/integration/integration.pg-test.ts
+++ b/packages/zero-cache/src/integration/integration.pg-test.ts
@@ -534,7 +534,26 @@ describe('integration', {timeout: 30000}, () => {
       undefined,
     ],
     [
-      'multi-node',
+      'multi-node (routed)',
+      'pg',
+      () => [
+        // The replication-manager must be started first for initial-sync
+        {
+          ...env,
+          ['ZERO_PORT']: `${port2}`,
+          ['ZERO_NUM_SYNC_WORKERS']: '0',
+        },
+        // startZero() will then copy to replicaDbFile2 for the view-syncer
+        {
+          ...env,
+          ['ZERO_CHANGE_STREAMER_URI']: `http://localhost:${port2 + 1}`,
+          ['ZERO_REPLICA_FILE']: replicaDbFile2.path,
+        },
+      ],
+      undefined,
+    ],
+    [
+      'multi-node (auto-discover)',
       'pg',
       () => [
         // The replication-manager must be started first for initial-sync
@@ -553,7 +572,27 @@ describe('integration', {timeout: 30000}, () => {
       undefined,
     ],
     [
-      'lazy view-syncer multi-node',
+      'lazy view-syncer multi-node (routed)',
+      'pg',
+      () => [
+        // The replication-manager must be started first for initial-sync
+        {
+          ...env,
+          ['ZERO_PORT']: `${port2}`,
+          ['ZERO_NUM_SYNC_WORKERS']: '0',
+        },
+        // startZero() will then copy to replicaDbFile2 for the view-syncer
+        {
+          ...env,
+          ['ZERO_CHANGE_STREAMER_URI']: `http://localhost:${port2 + 1}`,
+          ['ZERO_REPLICA_FILE']: replicaDbFile2.path,
+          ['ZERO_LAZY_STARTUP']: 'true',
+        },
+      ],
+      undefined,
+    ],
+    [
+      'lazy view-syncer multi-node (auto-discover)',
       'pg',
       () => [
         // The replication-manager must be started first for initial-sync

--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -87,10 +87,11 @@ export default async function runWorker(
   const shard = getShardID(config);
   const {
     taskID,
-    changeStreamer: {mode: changeStreamerMode},
+    changeStreamer: {mode: changeStreamerMode, uri: changeStreamerURI},
     litestream,
   } = config;
-  const runChangeStreamer = changeStreamerMode !== 'discover';
+  const runChangeStreamer =
+    changeStreamerMode === 'dedicated' && changeStreamerURI === undefined;
 
   let restoreStart = new Date();
   if (litestream.backupURL || (litestream.executable && !runChangeStreamer)) {

--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -40,8 +40,23 @@ export default async function runWorker(
   const replica = await setupReplica(lc, fileMode, config.replica);
 
   const shard = getShardConfig(config);
-  const {taskID, change} = config;
-  const changeStreamer = new ChangeStreamerHttpClient(lc, shard, change.db);
+  const {
+    taskID,
+    change,
+    changeStreamer: {
+      port,
+      mode: m,
+      uri: changeStreamerURI = m === 'dedicated'
+        ? `http://localhost:${port}/`
+        : undefined,
+    },
+  } = config;
+  const changeStreamer = new ChangeStreamerHttpClient(
+    lc,
+    shard,
+    change.db,
+    changeStreamerURI,
+  );
 
   const replicator = new ReplicatorService(
     lc,

--- a/packages/zero-cache/src/services/litestream/commands.ts
+++ b/packages/zero-cache/src/services/litestream/commands.ts
@@ -167,14 +167,18 @@ async function reserveAndGetSnapshotLocation(
   const {promise: backupURL, resolve, reject} = resolver<string>();
   try {
     assertNormalized(config);
-    const {taskID, change} = config;
+    const {
+      taskID,
+      change,
+      changeStreamer: {uri},
+    } = config;
     const shardID = getShardConfig(config);
 
     const changeStreamerClient = new ChangeStreamerHttpClient(
       lc,
       shardID,
       change.db,
-      undefined,
+      uri,
     );
 
     const sub = await changeStreamerClient.reserveSnapshot(taskID);

--- a/packages/zero-cache/src/services/litestream/commands.ts
+++ b/packages/zero-cache/src/services/litestream/commands.ts
@@ -174,6 +174,7 @@ async function reserveAndGetSnapshotLocation(
       lc,
       shardID,
       change.db,
+      undefined,
     );
 
     const sub = await changeStreamerClient.reserveSnapshot(taskID);

--- a/packages/zero-cache/src/services/litestream/commands.ts
+++ b/packages/zero-cache/src/services/litestream/commands.ts
@@ -167,18 +167,14 @@ async function reserveAndGetSnapshotLocation(
   const {promise: backupURL, resolve, reject} = resolver<string>();
   try {
     assertNormalized(config);
-    const {
-      taskID,
-      change,
-      changeStreamer: {uri},
-    } = config;
+    const {taskID, change, changeStreamer} = config;
     const shardID = getShardConfig(config);
 
     const changeStreamerClient = new ChangeStreamerHttpClient(
       lc,
       shardID,
       change.db,
-      uri,
+      changeStreamer.uri,
     );
 
     const sub = await changeStreamerClient.reserveSnapshot(taskID);

--- a/prod/sst/sst.config.ts
+++ b/prod/sst/sst.config.ts
@@ -211,7 +211,7 @@ export default $config({
       },
       environment: {
         ...commonEnv,
-        ZERO_CHANGE_STREAMER_MODE: 'discover',
+        ZERO_CHANGE_STREAMER_URI: replicationManager.url,
         ZERO_UPSTREAM_MAX_CONNS: '15',
         ZERO_CVR_MAX_CONNS: '160',
       },


### PR DESCRIPTION
Restore the `ZERO_CHANGE_STREAMER_URI` option and recommend it as the standard routing mechanism from the `view-syncer` to `replication-manager`.

Auto-discovery via `ZERO_CHANGE_STREAMER_MODE` is still supported but no longer the recommended configuration. An explicit routing component, while requiring additional setup on the developer's part, works for a wider range of production environments.

User report:
* https://discord.com/channels/830183651022471199/1389157062881050686/1389253989404512326
