### PR TITLE
chore(replicache, zero-client): fix worker test URL handling

### DIFF
--- a/packages/replicache/src/worker.test.ts
+++ b/packages/replicache/src/worker.test.ts
@@ -8,8 +8,11 @@ afterEach(async () => {
 });
 
 test('worker test', async () => {
-  const url = new URL('./worker-test.ts', import.meta.url);
-  const w = new Worker(url, {type: 'module'});
+  // Need to have the 'new URL' call inside `new Worker` for vite to
+  // correctly bundle the worker file.
+  const w = new Worker(new URL('./worker-test.ts', import.meta.url), {
+    type: 'module',
+  });
   const name = 'worker-test';
   dbsToDrop.add(name);
 

--- a/packages/zero-client/src/client/worker.test.ts
+++ b/packages/zero-client/src/client/worker.test.ts
@@ -2,8 +2,11 @@ import {expect, test} from 'vitest';
 import {sleep} from '../../../shared/src/sleep.ts';
 
 test('worker test', async () => {
-  const url = new URL('./worker-test.ts', import.meta.url);
-  const w = new Worker(url, {type: 'module'});
+  // Need to have the 'new URL' call inside `new Worker` for vite to
+  // correctly bundle the worker file.
+  const w = new Worker(new URL('./worker-test.ts', import.meta.url), {
+    type: 'module',
+  });
   // Wait for the worker "test harness" to be ready since it may have async
   // modules.
   await waitForReady(w);


### PR DESCRIPTION
To correctly have Vite bundle the worker files, the `new URL` call must be inside the `new Worker` constructor. This change ensures that the worker test files are correctly loaded in both the Replicache and Zero Client packages.

https://github.com/rocicorp/mono/pull/4587