### PR TITLE
chore(zero-cache): emit deprecation warnings for deprecated options

### DIFF
--- a/packages/analyze-query/src/bin-analyze.ts
+++ b/packages/analyze-query/src/bin-analyze.ts
@@ -1,10 +1,12 @@
 /* eslint-disable no-console */
-import '../../shared/src/dotenv.ts';
 import chalk from 'chalk';
 import fs from 'node:fs';
 import {astToZQL} from '../../ast-to-zql/src/ast-to-zql.ts';
 import {formatOutput} from '../../ast-to-zql/src/format.ts';
+import {logLevel, logOptions} from '../../otel/src/log-options.ts';
 import {testLogConfig} from '../../otel/src/test-log-config.ts';
+import {assert} from '../../shared/src/asserts.ts';
+import '../../shared/src/dotenv.ts';
 import {colorConsole, createLogContext} from '../../shared/src/logging.ts';
 import {must} from '../../shared/src/must.ts';
 import {parseOptions} from '../../shared/src/options.ts';
@@ -16,26 +18,31 @@ import {
   ZERO_ENV_VAR_PREFIX,
   zeroOptions,
 } from '../../zero-cache/src/config/zero-config.ts';
+import {computeZqlSpecs} from '../../zero-cache/src/db/lite-tables.ts';
 import {
   deployPermissionsOptions,
   loadSchemaAndPermissions,
 } from '../../zero-cache/src/scripts/permissions.ts';
-import {pgClient} from '../../zero-cache/src/types/pg.ts';
 import {hydrate} from '../../zero-cache/src/services/view-syncer/pipeline-driver.ts';
+import {pgClient} from '../../zero-cache/src/types/pg.ts';
 import {getShardID, upstreamSchema} from '../../zero-cache/src/types/shards.ts';
 import {
   mapAST,
   type AST,
   type CompoundKey,
 } from '../../zero-protocol/src/ast.ts';
+import type {Row} from '../../zero-protocol/src/data.ts';
+import {hashOfAST} from '../../zero-protocol/src/query-hash.ts';
 import type {Schema} from '../../zero-schema/src/builder/schema-builder.ts';
 import {
   clientToServer,
   serverToClient,
 } from '../../zero-schema/src/name-mapper.ts';
 import {buildPipeline} from '../../zql/src/builder/builder.ts';
+import type {FilterInput} from '../../zql/src/ivm/filter-operators.ts';
 import {MemoryStorage} from '../../zql/src/ivm/memory-storage.ts';
 import type {Input} from '../../zql/src/ivm/operator.ts';
+import type {QueryDelegate} from '../../zql/src/query/query-delegate.ts';
 import {completedAST, newQuery} from '../../zql/src/query/query-impl.ts';
 import {type PullRow, type Query} from '../../zql/src/query/query.ts';
 import {Database} from '../../zqlite/src/db.ts';
@@ -44,13 +51,6 @@ import {
   runtimeDebugStats,
 } from '../../zqlite/src/runtime-debug.ts';
 import {TableSource} from '../../zqlite/src/table-source.ts';
-import type {FilterInput} from '../../zql/src/ivm/filter-operators.ts';
-import {hashOfAST} from '../../zero-protocol/src/query-hash.ts';
-import {computeZqlSpecs} from '../../zero-cache/src/db/lite-tables.ts';
-import type {Row} from '../../zero-protocol/src/data.ts';
-import {assert} from '../../shared/src/asserts.ts';
-import type {QueryDelegate} from '../../zql/src/query/query-delegate.ts';
-import {logLevel, logOptions} from '../../otel/src/log-options.ts';
 
 const options = {
   schema: deployPermissionsOptions.schema,
@@ -133,14 +133,13 @@ const options = {
   },
 };
 
-const cfg = parseOptions(
-  options,
+const cfg = parseOptions(options, {
   // the command line parses drops all text after the first newline
   // so we need to replace newlines with spaces
   // before parsing
-  process.argv.slice(2).map(s => s.replaceAll('\n', ' ')),
-  ZERO_ENV_VAR_PREFIX,
-  [
+  argv: process.argv.slice(2).map(s => s.replaceAll('\n', ' ')),
+  envNamePrefix: ZERO_ENV_VAR_PREFIX,
+  description: [
     {
       header: 'analyze-query',
       content: `Analyze a ZQL query and show information about how it runs against a SQLite replica.
@@ -178,7 +177,7 @@ const cfg = parseOptions(
   `,
     },
   ],
-);
+});
 const config = {
   ...cfg,
   cvr: {

--- a/packages/analyze-query/src/bin-transform.ts
+++ b/packages/analyze-query/src/bin-transform.ts
@@ -1,6 +1,8 @@
 /* eslint-disable no-console */
-import '../../shared/src/dotenv.ts';
 import {consoleLogSink, LogContext} from '@rocicorp/logger';
+import {astToZQL} from '../../ast-to-zql/src/ast-to-zql.ts';
+import {formatOutput} from '../../ast-to-zql/src/format.ts';
+import '../../shared/src/dotenv.ts';
 import {must} from '../../shared/src/must.ts';
 import {parseOptions} from '../../shared/src/options.ts';
 import * as v from '../../shared/src/valita.ts';
@@ -10,11 +12,9 @@ import {
   shardOptions,
   ZERO_ENV_VAR_PREFIX,
 } from '../../zero-cache/src/config/zero-config.ts';
-import {pgClient} from '../../zero-cache/src/types/pg.ts';
 import {loadSchemaAndPermissions} from '../../zero-cache/src/scripts/permissions.ts';
+import {pgClient} from '../../zero-cache/src/types/pg.ts';
 import {getShardID, upstreamSchema} from '../../zero-cache/src/types/shards.ts';
-import {astToZQL} from '../../ast-to-zql/src/ast-to-zql.ts';
-import {formatOutput} from '../../ast-to-zql/src/format.ts';
 
 const options = {
   cvr: {db: v.string()},
@@ -30,11 +30,7 @@ const options = {
   },
 };
 
-const config = parseOptions(
-  options,
-  process.argv.slice(2),
-  ZERO_ENV_VAR_PREFIX,
-);
+const config = parseOptions(options, {envNamePrefix: ZERO_ENV_VAR_PREFIX});
 
 const lc = new LogContext('debug', {}, consoleLogSink);
 const {permissions} = await loadSchemaAndPermissions(config.schema);

--- a/packages/ast-to-zql/src/bin.ts
+++ b/packages/ast-to-zql/src/bin.ts
@@ -20,7 +20,7 @@ const options = {
   },
 };
 
-const config = parseOptions(options, process.argv.slice(2));
+const config = parseOptions(options);
 
 let schema: Schema | undefined;
 if (config.schema) {

--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -16,7 +16,13 @@ const exit = () => {
 test('zero-cache --help', () => {
   const logger = {info: vi.fn()};
   expect(() =>
-    parseOptions(zeroOptions, ['--help'], 'ZERO_', [], {}, logger, exit),
+    parseOptions(zeroOptions, {
+      argv: ['--help'],
+      envNamePrefix: 'ZERO_',
+      env: {},
+      logger,
+      exit,
+    }),
   ).toThrow(ExitAfterUsage);
   expect(logger.info).toHaveBeenCalled();
   expect(stripAnsi(logger.info.mock.calls[0][0])).toMatchInlineSnapshot(`
@@ -368,17 +374,15 @@ test.each([['has/slashes'], ['has-dashes'], ['has.dots']])(
   appID => {
     const logger = {info: vi.fn()};
     expect(() =>
-      parseOptionsAdvanced(
-        zeroOptions,
-        ['--app-id', appID],
-        'ZERO_',
-        [],
-        false, // allow unknown
-        true, // allow partial
-        {},
+      parseOptionsAdvanced(zeroOptions, {
+        argv: ['--app-id', appID],
+        envNamePrefix: 'ZERO_',
+        allowUnknown: false,
+        allowPartial: true,
+        env: {},
         logger,
         exit,
-      ),
+      }),
     ).toThrowError(INVALID_APP_ID_MESSAGE);
   },
 );
@@ -386,14 +390,12 @@ test.each([['has/slashes'], ['has-dashes'], ['has.dots']])(
 test.each([['isok'], ['has_underscores'], ['1'], ['123']])(
   '--app-id %s',
   appID => {
-    const {config} = parseOptionsAdvanced(
-      zeroOptions,
-      ['--app-id', appID],
-      'ZERO_',
-      [],
-      false,
-      true,
-    );
+    const {config} = parseOptionsAdvanced(zeroOptions, {
+      argv: ['--app-id', appID],
+      envNamePrefix: 'ZERO_',
+      allowUnknown: false,
+      allowPartial: true,
+    });
     expect(config.app.id).toBe(appID);
   },
 );
@@ -401,18 +403,16 @@ test.each([['isok'], ['has_underscores'], ['1'], ['123']])(
 test('--shard-id disallowed', () => {
   const logger = {info: vi.fn()};
   expect(() =>
-    parseOptionsAdvanced(
-      zeroOptions,
-      ['--shard-id', 'prod'],
-      'ZERO_',
-      [],
-      false, // allow unknown
-      true, // allow partial
-      {},
+    parseOptionsAdvanced(zeroOptions, {
+      argv: ['--shard-id', 'prod'],
+      envNamePrefix: 'ZERO_',
+      allowUnknown: false,
+      allowPartial: true,
+      env: {},
       logger,
       exit,
-    ),
+    }),
   ).toThrowErrorMatchingInlineSnapshot(
-    `[Error: ZERO_SHARD_ID is deprecated. Please use ZERO_APP_ID instead.]`,
+    `[Error: ZERO_SHARD_ID is no longer an option. Please use ZERO_APP_ID instead.]`,
   );
 });

--- a/packages/zero-cache/src/scripts/deploy-permissions.ts
+++ b/packages/zero-cache/src/scripts/deploy-permissions.ts
@@ -1,6 +1,7 @@
-import '../../../shared/src/dotenv.ts';
 import {writeFile} from 'node:fs/promises';
 import {ident as id, literal} from 'pg-format';
+import '../../../shared/src/dotenv.ts';
+import {colorConsole, createLogContext} from '../../../shared/src/logging.ts';
 import {parseOptions} from '../../../shared/src/options.ts';
 import {difference} from '../../../shared/src/set-utils.ts';
 import {mapCondition} from '../../../zero-protocol/src/ast.ts';
@@ -23,13 +24,11 @@ import {
   deployPermissionsOptions,
   loadSchemaAndPermissions,
 } from './permissions.ts';
-import {colorConsole, createLogContext} from '../../../shared/src/logging.ts';
 
-const config = parseOptions(
-  deployPermissionsOptions,
-  process.argv.slice(2),
-  ZERO_ENV_VAR_PREFIX,
-);
+const config = parseOptions(deployPermissionsOptions, {
+  argv: process.argv.slice(2),
+  envNamePrefix: ZERO_ENV_VAR_PREFIX,
+});
 
 const shard = getShardID(config);
 const app = appSchema(shard);
@@ -196,6 +195,9 @@ if (!ret) {
   } else {
     colorConsole.error(`No --output-file or --upstream-db specified`);
     // Shows the usage text.
-    parseOptions(deployPermissionsOptions, ['--help'], ZERO_ENV_VAR_PREFIX);
+    parseOptions(deployPermissionsOptions, {
+      argv: ['--help'],
+      envNamePrefix: ZERO_ENV_VAR_PREFIX,
+    });
   }
 }

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -31,7 +31,7 @@ export default async function runWorker(
   assert(args.length > 0, `parent startMs not specified`);
   const parentStartMs = parseInt(args[0]);
 
-  const config = getZeroConfig(env, args.slice(1));
+  const config = getZeroConfig({env, argv: args.slice(1)});
   assertNormalized(config);
   const {
     taskID,

--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -38,7 +38,7 @@ export default async function runWorker(
   env: NodeJS.ProcessEnv,
 ): Promise<void> {
   const startMs = Date.now();
-  const config = getZeroConfig(env);
+  const config = getZeroConfig({env});
   assertNormalized(config);
   const lc = createLogContext(config, {worker: 'dispatcher'});
 

--- a/packages/zero-cache/src/server/mutator.ts
+++ b/packages/zero-cache/src/server/mutator.ts
@@ -14,7 +14,7 @@ function runWorker(
   env: NodeJS.ProcessEnv,
   ...args: string[]
 ): Promise<void> {
-  const config = getZeroConfig(env, args.slice(1));
+  const config = getZeroConfig({env, argv: args.slice(1)});
   const lc = createLogContext(config, {worker: 'mutator'});
 
   // TODO: create `PusherFactory`

--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -31,7 +31,7 @@ export default async function runWorker(
   assert(args.length > 0, `replicator mode not specified`);
   const fileMode = v.parse(args[0], replicaFileModeSchema);
 
-  const config = getZeroConfig(env, args.slice(1));
+  const config = getZeroConfig({env, argv: args.slice(1)});
   assertNormalized(config);
   const mode: ReplicatorMode = fileMode === 'backup' ? 'backup' : 'serving';
   const workerName = `${mode}-replicator`;

--- a/packages/zero-cache/src/server/runner/run-worker.ts
+++ b/packages/zero-cache/src/server/runner/run-worker.ts
@@ -1,5 +1,5 @@
-import '../../../../shared/src/dotenv.ts';
 import {resolver, type Resolver} from '@rocicorp/resolver';
+import '../../../../shared/src/dotenv.ts';
 import {PROTOCOL_VERSION} from '../../../../zero-protocol/src/protocol-version.ts';
 import {normalizeZeroConfig} from '../../config/normalize.ts';
 import {getZeroConfig} from '../../config/zero-config.ts';
@@ -20,7 +20,9 @@ export async function runWorker(
   parent: Worker | null,
   env: NodeJS.ProcessEnv,
 ): Promise<void> {
-  const cfg = getZeroConfig(env);
+  // Note: This is top-level options parse, and the only time we emit
+  //       warnings for deprecated options.
+  const cfg = getZeroConfig({env, emitDeprecationWarnings: true});
   const lc = createLogContext(cfg, {worker: 'runner'});
 
   const defaultTaskID = await getTaskID(lc);

--- a/packages/zero-cache/src/server/runner/run-worker.ts
+++ b/packages/zero-cache/src/server/runner/run-worker.ts
@@ -20,8 +20,8 @@ export async function runWorker(
   parent: Worker | null,
   env: NodeJS.ProcessEnv,
 ): Promise<void> {
-  // Note: This is top-level options parse, and the only time we emit
-  //       warnings for deprecated options.
+  // Note: Deprecation warnings are only emitted at this top-level parse;
+  //       they are suppressed when parsed in subprocesses.
   const cfg = getZeroConfig({env, emitDeprecationWarnings: true});
   const lc = createLogContext(cfg, {worker: 'runner'});
 

--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -39,7 +39,7 @@ export default function runWorker(
   env: NodeJS.ProcessEnv,
   ...args: string[]
 ): Promise<void> {
-  const config = getZeroConfig(env, args.slice(1));
+  const config = getZeroConfig({env, argv: args.slice(1)});
   assertNormalized(config);
   startOtelAuto();
 

--- a/packages/zero/src/zero-cache-dev.ts
+++ b/packages/zero/src/zero-cache-dev.ts
@@ -1,17 +1,17 @@
 #!/usr/bin/env node
 /* eslint-disable no-console */
 
-import '../../shared/src/dotenv.ts';
 import {resolver} from '@rocicorp/resolver';
 import {watch} from 'chokidar';
 import {spawn, type ChildProcess} from 'node:child_process';
+import '../../shared/src/dotenv.ts';
+import {createLogContext} from '../../shared/src/logging.ts';
 import {parseOptionsAdvanced} from '../../shared/src/options.ts';
 import {
   ZERO_ENV_VAR_PREFIX,
   zeroOptions,
 } from '../../zero-cache/src/config/zero-config.ts';
 import {deployPermissionsOptions} from '../../zero-cache/src/scripts/permissions.ts';
-import {createLogContext} from '../../shared/src/logging.ts';
 
 const deployPermissionsScript = 'zero-deploy-permissions';
 const zeroCacheScript = 'zero-cache';
@@ -34,11 +34,11 @@ async function main() {
       ...deployPermissionsOptions,
       ...zeroOptions,
     },
-    process.argv.slice(2),
-    ZERO_ENV_VAR_PREFIX,
-    [],
-    false,
-    true, // allowPartial, required by server/runner/config.ts
+    {
+      envNamePrefix: ZERO_ENV_VAR_PREFIX,
+      // TODO: This may no longer be necessary since multi-tenant was removed.
+      allowPartial: true, // required by server/runner/config.ts
+    },
   );
 
   const lc = createLogContext(config);
@@ -51,19 +51,13 @@ async function main() {
 
   const {unknown: zeroCacheArgs} = parseOptionsAdvanced(
     deployPermissionsOptions,
-    process.argv.slice(2),
-    ZERO_ENV_VAR_PREFIX,
-    [],
-    true,
+    {envNamePrefix: ZERO_ENV_VAR_PREFIX, allowUnknown: true},
   );
 
-  const {unknown: deployPermissionsArgs} = parseOptionsAdvanced(
-    zeroOptions,
-    process.argv.slice(2),
-    ZERO_ENV_VAR_PREFIX,
-    [],
-    true,
-  );
+  const {unknown: deployPermissionsArgs} = parseOptionsAdvanced(zeroOptions, {
+    envNamePrefix: ZERO_ENV_VAR_PREFIX,
+    allowUnknown: true,
+  });
 
   const {path} = config.schema;
 

--- a/tools/client-simulator/src/main.ts
+++ b/tools/client-simulator/src/main.ts
@@ -1,4 +1,3 @@
-import '../../shared/src/dotenv.ts';
 import {consoleLogSink, LogContext} from '@rocicorp/logger';
 import {nanoid} from 'nanoid';
 import {pipeline, Writable} from 'node:stream';
@@ -8,6 +7,7 @@ import * as v from '../../../packages/shared/src/valita.ts';
 import {initConnectionMessageSchema} from '../../../packages/zero-protocol/src/connect.ts';
 import {downstreamSchema} from '../../../packages/zero-protocol/src/down.ts';
 import {PROTOCOL_VERSION} from '../../../packages/zero-protocol/src/protocol-version.ts';
+import '../../shared/src/dotenv.ts';
 import initConnectionJSON from './init-connection.json' with {type: 'json'};
 
 const options = {
@@ -22,8 +22,7 @@ function run() {
   const lc = new LogContext('debug', {}, consoleLogSink);
   const {viewSyncers, numConnections, millisBetweenMessages} = parseOptions(
     options,
-    process.argv.slice(2),
-    'ZERO_',
+    {envNamePrefix: 'ZERO_'},
   );
 
   const initConnectionMessage = v.parse(

--- a/tools/load-generator/src/main.ts
+++ b/tools/load-generator/src/main.ts
@@ -1,10 +1,10 @@
-import '../../shared/src/dotenv.ts';
 import {consoleLogSink, LogContext} from '@rocicorp/logger';
 import {nanoid} from 'nanoid/non-secure';
 import {ident as id, literal} from 'pg-format';
 import postgres from 'postgres';
 import {parseOptions} from '../../../packages/shared/src/options.ts';
 import * as v from '../../../packages/shared/src/valita.ts';
+import '../../shared/src/dotenv.ts';
 
 const options = {
   upstream: {
@@ -36,8 +36,7 @@ async function run() {
   const lc = new LogContext('debug', {}, consoleLogSink);
   const {upstream, insert, perturb, qps, maxConnections} = parseOptions(
     options,
-    process.argv.slice(2),
-    'ZERO_',
+    {envNamePrefix: 'ZERO_'},
   );
   const db = postgres(upstream.db, {
     max: Math.max(1, Math.min(maxConnections, qps / 10)),


### PR DESCRIPTION
Adds a `deprecated` field to Options definitions that emits a warning when the value is present:

<img width="468" alt="Screenshot 2025-07-09 at 11 29 25" src="https://github.com/user-attachments/assets/52442358-5abe-434d-9280-72930b420a08" />


Also (finally) changed the `parseOptions()` function to take an options object instead of a list of params.