### PR TITLE
feat(zero-client): Expose client materialize time in inspector

### DIFF
--- a/packages/analyze-query/src/bin-analyze.ts
+++ b/packages/analyze-query/src/bin-analyze.ts
@@ -265,6 +265,7 @@ const host: QueryDelegate = {
   flushQueryChanges() {},
   assertValidRunOptions() {},
   defaultQueryComplete: true,
+  addMetric() {},
 };
 
 let start: number;

--- a/packages/analyze-query/src/bin-analyze.ts
+++ b/packages/analyze-query/src/bin-analyze.ts
@@ -255,7 +255,6 @@ const host: QueryDelegate = {
   },
   updateServerQuery() {},
   updateCustomQuery() {},
-  onQueryMaterialized() {},
   onTransactionCommit() {
     return () => {};
   },

--- a/packages/shared/src/centroid.ts
+++ b/packages/shared/src/centroid.ts
@@ -28,13 +28,6 @@ export class Centroid {
 /** CentroidList is sorted by the mean of the centroid, ascending. */
 export type CentroidList = Centroid[];
 
-/** newCentroidList creates a priority queue for the centroids */
-export function newCentroidList(centroids: CentroidList): CentroidList {
-  const l: CentroidList = centroids.slice();
-  sortCentroidList(l);
-  return l;
-}
-
 export function sortCentroidList(centroids: CentroidList): void {
   centroids.sort((a, b) => a.mean - b.mean);
 }

--- a/packages/shared/src/tdigest.ts
+++ b/packages/shared/src/tdigest.ts
@@ -4,10 +4,16 @@
 import {binarySearch} from './binary-search.ts';
 import {Centroid, sortCentroidList, type CentroidList} from './centroid.ts';
 
+export interface ReadonlyTDigest {
+  readonly count: () => number;
+  readonly quantile: (q: number) => number;
+  readonly cdf: (x: number) => number;
+}
+
 // TDigest is a data structure for accurate on-line accumulation of
 // rank-based statistics such as quantiles and trimmed means.
 export class TDigest {
-  compression: number;
+  readonly compression: number;
 
   #maxProcessed: number;
   #maxUnprocessed: number;
@@ -36,15 +42,12 @@ export class TDigest {
     this.#max = -Number.MAX_VALUE;
   }
 
-  add(mean: number, weight: number) {
+  add(mean: number, weight: number = 1) {
     this.addCentroid(new Centroid(mean, weight));
   }
 
   /** AddCentroidList can quickly add multiple centroids. */
   addCentroidList(centroidList: CentroidList) {
-    // It's possible to optimize this by bulk-copying the slice, but this
-    // yields just a 1-2% speedup (most time is in process()), so not worth
-    // the complexity.
     for (const c of centroidList) {
       this.addCentroid(c);
     }

--- a/packages/zero-cache/bench/benchmark.ts
+++ b/packages/zero-cache/bench/benchmark.ts
@@ -73,7 +73,6 @@ export function bench(opts: Options) {
     },
     updateServerQuery() {},
     updateCustomQuery() {},
-    onQueryMaterialized() {},
     onTransactionCommit() {
       return () => {};
     },

--- a/packages/zero-cache/bench/benchmark.ts
+++ b/packages/zero-cache/bench/benchmark.ts
@@ -83,6 +83,7 @@ export function bench(opts: Options) {
     assertValidRunOptions() {},
     flushQueryChanges() {},
     defaultQueryComplete: true,
+    addMetric() {},
   };
 
   const issueQuery = newQuery(host, schema, 'issue');

--- a/packages/zero-cache/src/auth/read-authorizer.query.test.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.query.test.ts
@@ -34,9 +34,7 @@ import {
   buildPipeline,
 } from '../../../zql/src/builder/builder.ts';
 import {Catch, type CaughtNode} from '../../../zql/src/ivm/catch.ts';
-import type {FilterInput} from '../../../zql/src/ivm/filter-operators.ts';
 import {MemoryStorage} from '../../../zql/src/ivm/memory-storage.ts';
-import type {Input} from '../../../zql/src/ivm/operator.ts';
 import type {Source} from '../../../zql/src/ivm/source.ts';
 import type {ExpressionBuilder} from '../../../zql/src/query/expression.ts';
 import type {QueryDelegate} from '../../../zql/src/query/query-delegate.ts';
@@ -517,12 +515,8 @@ beforeEach(() => {
     createStorage() {
       return new MemoryStorage();
     },
-    decorateInput(input: Input): Input {
-      return input;
-    },
-    decorateFilterInput(input: FilterInput): FilterInput {
-      return input;
-    },
+    decorateInput: input => input,
+    decorateFilterInput: input => input,
     addServerQuery() {
       return () => {};
     },
@@ -531,7 +525,6 @@ beforeEach(() => {
     },
     updateServerQuery() {},
     updateCustomQuery() {},
-    onQueryMaterialized() {},
     onTransactionCommit() {
       return () => {};
     },

--- a/packages/zero-cache/src/auth/read-authorizer.query.test.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.query.test.ts
@@ -34,10 +34,12 @@ import {
   buildPipeline,
 } from '../../../zql/src/builder/builder.ts';
 import {Catch, type CaughtNode} from '../../../zql/src/ivm/catch.ts';
+import type {FilterInput} from '../../../zql/src/ivm/filter-operators.ts';
 import {MemoryStorage} from '../../../zql/src/ivm/memory-storage.ts';
 import type {Input} from '../../../zql/src/ivm/operator.ts';
 import type {Source} from '../../../zql/src/ivm/source.ts';
 import type {ExpressionBuilder} from '../../../zql/src/query/expression.ts';
+import type {QueryDelegate} from '../../../zql/src/query/query-delegate.ts';
 import {completedAST, newQuery} from '../../../zql/src/query/query-impl.ts';
 import {type Query, type Row} from '../../../zql/src/query/query.ts';
 import {Database} from '../../../zqlite/src/db.ts';
@@ -45,8 +47,6 @@ import {TableSource} from '../../../zqlite/src/table-source.ts';
 import type {ZeroConfig} from '../config/zero-config.ts';
 import {transformQuery} from './read-authorizer.ts';
 import {WriteAuthorizerImpl} from './write-authorizer.ts';
-import type {FilterInput} from '../../../zql/src/ivm/filter-operators.ts';
-import type {QueryDelegate} from '../../../zql/src/query/query-delegate.ts';
 
 const zeroConfig = {
   log: testLogConfig,
@@ -541,6 +541,7 @@ beforeEach(() => {
     assertValidRunOptions() {},
     flushQueryChanges() {},
     defaultQueryComplete: true,
+    addMetric() {},
   };
 
   for (const table of Object.values(schema.tables)) {

--- a/packages/zero-client/src/client/context.test.ts
+++ b/packages/zero-client/src/client/context.test.ts
@@ -53,7 +53,6 @@ test('getSource', () => {
     null as unknown as FlushQueryChanges,
     testBatchViewUpdates,
     () => {},
-    5_000,
     assertValidRunOptions,
   );
 
@@ -131,7 +130,6 @@ test('processChanges', () => {
     null as unknown as FlushQueryChanges,
     testBatchViewUpdates,
     () => {},
-    5_000,
     assertValidRunOptions,
   );
   const out = new Catch(
@@ -202,7 +200,6 @@ test('processChanges wraps source updates with batchViewUpdates', () => {
     null as unknown as FlushQueryChanges,
     batchViewUpdates,
     () => {},
-    5_000,
     assertValidRunOptions,
   );
   const out = new Catch(
@@ -262,7 +259,6 @@ test('transactions', () => {
     null as unknown as FlushQueryChanges,
     testBatchViewUpdates,
     () => {},
-    5_000,
     assertValidRunOptions,
   );
   const servers = context.getSource('server')!;
@@ -343,7 +339,6 @@ test('batchViewUpdates errors if applyViewUpdates is not called', () => {
     null as unknown as FlushQueryChanges,
     batchViewUpdates,
     () => {},
-    5_000,
     assertValidRunOptions,
   );
 
@@ -368,7 +363,6 @@ test('batchViewUpdates returns value', () => {
     null as unknown as FlushQueryChanges,
     batchViewUpdates,
     () => {},
-    5_000,
     assertValidRunOptions,
   );
 

--- a/packages/zero-client/src/client/context.test.ts
+++ b/packages/zero-client/src/client/context.test.ts
@@ -52,6 +52,7 @@ test('getSource', () => {
     null as unknown as UpdateCustomQuery,
     null as unknown as FlushQueryChanges,
     testBatchViewUpdates,
+    () => {},
     5_000,
     assertValidRunOptions,
   );
@@ -129,6 +130,7 @@ test('processChanges', () => {
     null as unknown as UpdateCustomQuery,
     null as unknown as FlushQueryChanges,
     testBatchViewUpdates,
+    () => {},
     5_000,
     assertValidRunOptions,
   );
@@ -199,6 +201,7 @@ test('processChanges wraps source updates with batchViewUpdates', () => {
     null as unknown as UpdateCustomQuery,
     null as unknown as FlushQueryChanges,
     batchViewUpdates,
+    () => {},
     5_000,
     assertValidRunOptions,
   );
@@ -258,6 +261,7 @@ test('transactions', () => {
     null as unknown as UpdateCustomQuery,
     null as unknown as FlushQueryChanges,
     testBatchViewUpdates,
+    () => {},
     5_000,
     assertValidRunOptions,
   );
@@ -338,6 +342,7 @@ test('batchViewUpdates errors if applyViewUpdates is not called', () => {
     null as unknown as UpdateCustomQuery,
     null as unknown as FlushQueryChanges,
     batchViewUpdates,
+    () => {},
     5_000,
     assertValidRunOptions,
   );
@@ -362,6 +367,7 @@ test('batchViewUpdates returns value', () => {
     null as unknown as UpdateCustomQuery,
     null as unknown as FlushQueryChanges,
     batchViewUpdates,
+    () => {},
     5_000,
     assertValidRunOptions,
   );

--- a/packages/zero-client/src/client/context.ts
+++ b/packages/zero-client/src/client/context.ts
@@ -7,14 +7,12 @@ import type {FilterInput} from '../../../zql/src/ivm/filter-operators.ts';
 import {MemoryStorage} from '../../../zql/src/ivm/memory-storage.ts';
 import type {Input, Storage} from '../../../zql/src/ivm/operator.ts';
 import type {Source} from '../../../zql/src/ivm/source.ts';
-import type {CustomQueryID} from '../../../zql/src/query/named.ts';
+import type {MetricsDelegate} from '../../../zql/src/query/metrics-delegate.ts';
 import type {
   CommitListener,
-  GotCallback,
   QueryDelegate,
 } from '../../../zql/src/query/query-delegate.ts';
 import type {RunOptions} from '../../../zql/src/query/query.ts';
-import type {TTL} from '../../../zql/src/query/ttl.ts';
 import {type IVMSourceBranch} from './ivm-branch.ts';
 import type {QueryManager} from './query-manager.ts';
 import type {ZeroLogContext} from './zero-log-context.ts';
@@ -37,11 +35,11 @@ export class ZeroContext implements QueryDelegate {
   // pipelines *synchronously* and the core Replicache infra is all async. So
   // that needs to be fixed.
   readonly #mainSources: IVMSourceBranch;
-  readonly #addQuery: AddQuery;
-  readonly #addCustomQuery: AddCustomQuery;
-  readonly #updateQuery: UpdateQuery;
-  readonly #updateCustomQuery: UpdateCustomQuery;
-  readonly #flushQueryChanges: () => void;
+  readonly addServerQuery: AddQuery;
+  readonly addCustomQuery: AddCustomQuery;
+  readonly updateServerQuery: UpdateQuery;
+  readonly updateCustomQuery: UpdateCustomQuery;
+  readonly flushQueryChanges: () => void;
   readonly #batchViewUpdates: (applyViewUpdates: () => void) => void;
   readonly #commitListeners: Set<CommitListener> = new Set();
 
@@ -55,6 +53,8 @@ export class ZeroContext implements QueryDelegate {
    */
   readonly defaultQueryComplete = false;
 
+  readonly addMetric: MetricsDelegate['addMetric'];
+
   constructor(
     lc: ZeroLogContext,
     mainSources: IVMSourceBranch,
@@ -64,52 +64,25 @@ export class ZeroContext implements QueryDelegate {
     updateCustomQuery: UpdateCustomQuery,
     flushQueryChanges: () => void,
     batchViewUpdates: (applyViewUpdates: () => void) => void,
+    addMetric: MetricsDelegate['addMetric'],
     slowMaterializeThreshold: number,
     assertValidRunOptions: (options?: RunOptions) => void,
   ) {
     this.#mainSources = mainSources;
-    this.#addQuery = addQuery;
-    this.#updateQuery = updateQuery;
-    this.#updateCustomQuery = updateCustomQuery;
+    this.addServerQuery = addQuery;
+    this.updateServerQuery = updateQuery;
+    this.updateCustomQuery = updateCustomQuery;
     this.#batchViewUpdates = batchViewUpdates;
     this.#lc = lc;
     this.#slowMaterializeThreshold = slowMaterializeThreshold;
     this.assertValidRunOptions = assertValidRunOptions;
-    this.#addCustomQuery = addCustomQuery;
-    this.#flushQueryChanges = flushQueryChanges;
+    this.addCustomQuery = addCustomQuery;
+    this.flushQueryChanges = flushQueryChanges;
+    this.addMetric = addMetric;
   }
 
   getSource(name: string): Source | undefined {
     return this.#mainSources.getSource(name);
-  }
-
-  addCustomQuery(
-    customQueryID: CustomQueryID,
-    ttl: TTL,
-    gotCallback?: GotCallback | undefined,
-  ): () => void {
-    return this.#addCustomQuery(
-      customQueryID.name,
-      customQueryID.args,
-      ttl,
-      gotCallback,
-    );
-  }
-
-  addServerQuery(ast: AST, ttl: TTL, gotCallback?: GotCallback | undefined) {
-    return this.#addQuery(ast, ttl, gotCallback);
-  }
-
-  updateServerQuery(ast: AST, ttl: TTL): void {
-    this.#updateQuery(ast, ttl);
-  }
-
-  updateCustomQuery(customQueryID: CustomQueryID, ttl: TTL): void {
-    this.#updateCustomQuery(customQueryID.name, customQueryID.args, ttl);
-  }
-
-  flushQueryChanges() {
-    this.#flushQueryChanges();
   }
 
   onQueryMaterialized(hash: string, ast: AST, duration: number): void {

--- a/packages/zero-client/src/client/custom.bench.ts
+++ b/packages/zero-client/src/client/custom.bench.ts
@@ -23,6 +23,5 @@ bench('big schema', () => {
       [zeroData]: {},
     } as unknown as WriteTransaction,
     schema,
-    0,
   );
 });

--- a/packages/zero-client/src/client/custom.test.ts
+++ b/packages/zero-client/src/client/custom.test.ts
@@ -10,7 +10,9 @@ import {
 import {zeroData} from '../../../replicache/src/transactions.ts';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
 import {must} from '../../../shared/src/must.ts';
+import {refCountSymbol} from '../../../zql/src/ivm/view-apply-change.ts';
 import type {InsertValue, Transaction} from '../../../zql/src/mutate/custom.ts';
+import type {Row} from '../../../zql/src/query/query.ts';
 import {schema} from '../../../zql/src/query/test/test-schemas.ts';
 import * as ConnectionState from './connection-state-enum.ts';
 import {
@@ -23,8 +25,6 @@ import type {WriteTransaction} from './replicache-types.ts';
 import {MockSocket, zeroForTest} from './test-utils.ts';
 import {createDb} from './test/create-db.ts';
 import {getInternalReplicacheImplForTesting} from './zero.ts';
-import type {Row} from '../../../zql/src/query/query.ts';
-import {refCountSymbol} from '../../../zql/src/ivm/view-apply-change.ts';
 
 type Schema = typeof schema;
 type MutatorTx = Transaction<Schema>;
@@ -275,7 +275,6 @@ describe('rebasing custom mutators', () => {
         },
       } as unknown as WriteTransaction,
       schema,
-      10,
     ) as unknown as Transaction<Schema>;
 
     await tx1.mutate.issue.insert({

--- a/packages/zero-client/src/client/custom.ts
+++ b/packages/zero-client/src/client/custom.ts
@@ -190,6 +190,7 @@ function makeSchemaQuery<S extends Schema>(
     emptyFunction,
     emptyFunction,
     applyViewUpdates => applyViewUpdates(),
+    emptyFunction,
     slowMaterializeThreshold,
     assertValidRunOptions,
   );

--- a/packages/zero-client/src/client/custom.ts
+++ b/packages/zero-client/src/client/custom.ts
@@ -92,12 +92,7 @@ export type MakeCustomMutatorInterface<
   : never;
 
 export class TransactionImpl<S extends Schema> implements ClientTransaction<S> {
-  constructor(
-    lc: ZeroLogContext,
-    repTx: WriteTransaction,
-    schema: S,
-    slowMaterializeThreshold: number,
-  ) {
+  constructor(lc: ZeroLogContext, repTx: WriteTransaction, schema: S) {
     const castedRepTx = repTx as WriteTransactionImpl;
     must(repTx.reason === 'initial' || repTx.reason === 'rebase');
     this.clientID = repTx.clientID;
@@ -116,7 +111,6 @@ export class TransactionImpl<S extends Schema> implements ClientTransaction<S> {
       lc,
       schema,
       txData.ivmSources as IVMSourceBranch,
-      slowMaterializeThreshold,
     );
     this.token = txData.token;
   }
@@ -134,13 +128,12 @@ export function makeReplicacheMutator<S extends Schema, TWrappedTransaction>(
   lc: ZeroLogContext,
   mutator: CustomMutatorImpl<S, TWrappedTransaction>,
   schema: S,
-  slowMaterializeThreshold: number,
 ) {
   return async (
     repTx: WriteTransaction,
     args: ReadonlyJSONValue,
   ): Promise<void> => {
-    const tx = new TransactionImpl(lc, repTx, schema, slowMaterializeThreshold);
+    const tx = new TransactionImpl(lc, repTx, schema);
     await mutator(tx, args);
   };
 }
@@ -179,7 +172,6 @@ function makeSchemaQuery<S extends Schema>(
   lc: ZeroLogContext,
   schema: S,
   ivmBranch: IVMSourceBranch,
-  slowMaterializeThreshold: number,
 ) {
   const context = new ZeroContext(
     lc,
@@ -191,7 +183,6 @@ function makeSchemaQuery<S extends Schema>(
     emptyFunction,
     applyViewUpdates => applyViewUpdates(),
     emptyFunction,
-    slowMaterializeThreshold,
     assertValidRunOptions,
   );
 

--- a/packages/zero-client/src/client/inspector/inspector.test.ts
+++ b/packages/zero-client/src/client/inspector/inspector.test.ts
@@ -1,4 +1,4 @@
-import {beforeEach, expect, test, vi} from 'vitest';
+import {beforeEach, describe, expect, test, vi} from 'vitest';
 import type {AST} from '../../../../zero-protocol/src/ast.ts';
 import type {
   InspectDownMessage,
@@ -137,6 +137,7 @@ test('client queries', async () => {
         rowCount: 10,
         ttl: '1m',
         zql: 'issue',
+        metrics: null,
       },
     ],
   );
@@ -169,6 +170,7 @@ test('client queries', async () => {
         rowCount: 10,
         ttl: '1m',
         zql: 'issue',
+        metrics: null,
       },
     ],
   );
@@ -249,6 +251,134 @@ test('clientGroup queries', async () => {
       rowCount: 10,
       ttl: '1m',
       zql: "issue.where(({cmp, or}) => or(cmp('id', '1'), cmp('id', '!=', '2')))",
+      metrics: null,
     },
   ]);
+});
+
+describe('query metrics', () => {
+  test('real query metrics integration', async () => {
+    const z = zeroForTest({schema});
+    await z.triggerConnected();
+
+    const issueQuery = z.query.issue;
+    await issueQuery.run();
+
+    const inspector = await z.inspect();
+    expect(inspector.metrics['query-materialization-client'].count()).toBe(1);
+    expect(
+      inspector.metrics['query-materialization-client'].quantile(0.5),
+    ).toBeGreaterThanOrEqual(0);
+    await z.close();
+  });
+
+  test('Attaching the metrics to the query', async () => {
+    const z = zeroForTest({schema});
+    await z.triggerConnected();
+
+    const issueQuery = z.query.issue.orderBy('id', 'desc');
+    const view = issueQuery.materialize();
+
+    vi.spyOn(Math, 'random').mockImplementation(() => 0.5);
+    const inspector = await z.inspect();
+    const p = inspector.client.queries();
+    await Promise.resolve();
+
+    // Simulate the server response with query data
+    await z.triggerMessage([
+      'inspect',
+      {
+        op: 'queries',
+        id: '000000000000000000000',
+        value: [
+          {
+            clientID: z.clientID,
+            queryID: issueQuery.hash(),
+            ast: {
+              table: 'issue',
+              orderBy: [['id', 'desc']],
+            },
+            name: null,
+            args: null,
+            deleted: false,
+            got: true,
+            inactivatedAt: null,
+            rowCount: 1,
+            ttl: 60_000,
+          },
+        ],
+      },
+    ] satisfies InspectDownMessage);
+
+    const queries = await p;
+    expect(queries).toHaveLength(1);
+    expect(issueQuery.hash()).toBe(queries[0].id);
+    const {metrics} = queries[0];
+
+    expect(metrics?.['query-materialization-client'].count()).toBe(1);
+    expect(
+      metrics?.['query-materialization-client'].quantile(0.5),
+    ).toBeGreaterThanOrEqual(0);
+
+    view.destroy();
+    await z.close();
+  });
+
+  test('metrics collection during query materialization', async () => {
+    const z = zeroForTest({schema});
+    await z.triggerConnected();
+
+    // Execute multiple queries to generate real metrics
+    const query1 = z.query.issue;
+    const query2 = z.query.issue.where('id', '1');
+
+    await query1.run();
+    await query2.run();
+
+    // Check that metrics were actually collected
+    const inspector = await z.inspect();
+
+    expect(inspector.metrics['query-materialization-client'].count()).toBe(2);
+
+    const digest = inspector.metrics['query-materialization-client'];
+    expect(digest.count()).toBe(2);
+
+    expect(digest.quantile(0.5)).toBeGreaterThanOrEqual(0);
+
+    await z.close();
+  });
+
+  test('query-specific metrics integration test', async () => {
+    const z = zeroForTest({schema});
+    await z.triggerConnected();
+
+    // Execute queries with different characteristics to test metrics collection
+    await z.query.issue.run(); // Simple table query
+    await z.query.issue.where('id', '1').run(); // Filtered query
+    await z.query.issue.where('id', '2').run(); // Another filtered query
+
+    // Test that the inspector can access the real metrics
+    const inspector = await z.inspect();
+
+    // Verify global metrics were collected
+    const globalMetrics = inspector.metrics['query-materialization-client'];
+    expect(globalMetrics.count()).toBe(3);
+
+    // Test that percentiles work with real data
+    const p50 = globalMetrics.quantile(0.5);
+    const p90 = globalMetrics.quantile(0.9);
+
+    expect(Number.isFinite(p50)).toBe(true);
+    expect(Number.isFinite(p90)).toBe(true);
+    expect(p50).toBeGreaterThanOrEqual(0);
+    expect(p90).toBeGreaterThanOrEqual(p50);
+
+    // Test CDF functionality
+    const cdf0 = globalMetrics.cdf(0);
+    const cdfMax = globalMetrics.cdf(Number.MAX_VALUE);
+    expect(cdf0).toBeGreaterThanOrEqual(0);
+    expect(cdfMax).toBe(1);
+
+    await z.close();
+  });
 });

--- a/packages/zero-client/src/client/inspector/inspector.test.ts
+++ b/packages/zero-client/src/client/inspector/inspector.test.ts
@@ -322,7 +322,9 @@ describe('query metrics', () => {
     expect(
       metrics?.['query-materialization-client'].quantile(0.5),
     ).toBeGreaterThanOrEqual(0);
-    expect(metrics?.['query-materialization-end-to-end'].count()).toBe(1);
+    await vi.waitFor(() => {
+      expect(metrics?.['query-materialization-end-to-end'].count()).toBe(1);
+    });
     expect(
       metrics?.['query-materialization-end-to-end'].quantile(0.5),
     ).toBeGreaterThanOrEqual(0);

--- a/packages/zero-client/src/client/inspector/inspector.ts
+++ b/packages/zero-client/src/client/inspector/inspector.ts
@@ -45,6 +45,7 @@ type GetWebSocket = () => Promise<WebSocket>;
 
 type Metrics = {
   readonly 'query-materialization-client': ReadonlyTDigest;
+  readonly 'query-materialization-end-to-end': ReadonlyTDigest;
 };
 
 export interface InspectorMetricsDelegate {

--- a/packages/zero-client/src/client/inspector/inspector.ts
+++ b/packages/zero-client/src/client/inspector/inspector.ts
@@ -13,6 +13,7 @@ import type {ReplicacheImpl} from '../../../../replicache/src/replicache-impl.ts
 import {withRead} from '../../../../replicache/src/with-transactions.ts';
 import {assert} from '../../../../shared/src/asserts.ts';
 import type {ReadonlyJSONValue} from '../../../../shared/src/json.ts';
+import {type ReadonlyTDigest} from '../../../../shared/src/tdigest.ts';
 import * as valita from '../../../../shared/src/valita.ts';
 import type {AST} from '../../../../zero-protocol/src/ast.ts';
 import type {Row} from '../../../../zero-protocol/src/data.ts';
@@ -42,13 +43,30 @@ type Rep = ReplicacheImpl<MutatorDefs>;
 
 type GetWebSocket = () => Promise<WebSocket>;
 
+type Metrics = {
+  readonly 'query-materialization-client': ReadonlyTDigest;
+};
+
+export interface InspectorMetricsDelegate {
+  getQueryMetrics(hash: string): Metrics | undefined;
+  readonly metrics: Metrics;
+}
+
 export async function newInspector(
   rep: Rep,
+  metricsDelegate: InspectorMetricsDelegate,
   schema: Schema,
   socket: GetWebSocket,
 ): Promise<InspectorInterface> {
   const clientGroupID = await rep.clientGroupID;
-  return new Inspector(rep, schema, rep.clientID, clientGroupID, socket);
+  return new Inspector(
+    rep,
+    metricsDelegate,
+    schema,
+    rep.clientID,
+    clientGroupID,
+    socket,
+  );
 }
 
 class Inspector implements InspectorInterface {
@@ -57,9 +75,11 @@ class Inspector implements InspectorInterface {
   readonly clientGroup: ClientGroup;
   readonly #schema: Schema;
   readonly socket: GetWebSocket;
+  readonly #metricsDelegate: InspectorMetricsDelegate;
 
   constructor(
     rep: ReplicacheImpl,
+    metricsDelegate: InspectorMetricsDelegate,
     schema: Schema,
     clientID: string,
     clientGroupID: string,
@@ -67,20 +87,44 @@ class Inspector implements InspectorInterface {
   ) {
     this.#rep = rep;
     this.#schema = schema;
-    this.client = new Client(rep, schema, socket, clientID, clientGroupID);
+    this.client = new Client(
+      rep,
+      metricsDelegate,
+      schema,
+      socket,
+      clientID,
+      clientGroupID,
+    );
     this.clientGroup = this.client.clientGroup;
     this.socket = socket;
+    this.#metricsDelegate = metricsDelegate;
+  }
+
+  get metrics(): Metrics {
+    return this.#metricsDelegate.metrics;
   }
 
   clients(): Promise<ClientInterface[]> {
     return withDagRead(this.#rep, dagRead =>
-      clients(this.#rep, this.socket, this.#schema, dagRead),
+      clients(
+        this.#rep,
+        this.#metricsDelegate,
+        this.socket,
+        this.#schema,
+        dagRead,
+      ),
     );
   }
 
   clientsWithQueries(): Promise<ClientInterface[]> {
     return withDagRead(this.#rep, dagRead =>
-      clientsWithQueries(this.#rep, this.socket, this.#schema, dagRead),
+      clientsWithQueries(
+        this.#rep,
+        this.#metricsDelegate,
+        this.socket,
+        this.#schema,
+        dagRead,
+      ),
     );
   }
 }
@@ -119,21 +163,28 @@ class Client implements ClientInterface {
   readonly #rep: Rep;
   readonly id: string;
   readonly clientGroup: ClientGroup;
-  readonly #schema: Schema;
   readonly #socket: GetWebSocket;
+  readonly #metricsDelegate: InspectorMetricsDelegate;
 
   constructor(
     rep: Rep,
+    metricsDelegate: InspectorMetricsDelegate,
     schema: Schema,
     socket: GetWebSocket,
     id: string,
     clientGroupID: string,
   ) {
     this.#rep = rep;
-    this.#schema = schema;
     this.#socket = socket;
     this.id = id;
-    this.clientGroup = new ClientGroup(rep, socket, schema, clientGroupID);
+    this.clientGroup = new ClientGroup(
+      rep,
+      metricsDelegate,
+      socket,
+      schema,
+      clientGroupID,
+    );
+    this.#metricsDelegate = metricsDelegate;
   }
 
   async queries(): Promise<QueryInterface[]> {
@@ -142,7 +193,7 @@ class Client implements ClientInterface {
       {op: 'queries', clientID: this.id} as InspectQueriesUpBody,
       inspectQueriesDownSchema,
     );
-    return rows.map(row => new Query(row, this.#schema));
+    return rows.map(row => new Query(row, this.#metricsDelegate));
   }
 
   map(): Promise<Map<string, ReadonlyJSONValue>> {
@@ -177,9 +228,17 @@ class ClientGroup implements ClientGroupInterface {
   readonly id: string;
   readonly #schema: Schema;
   readonly #socket: GetWebSocket;
+  readonly #metricsDelegate: InspectorMetricsDelegate;
 
-  constructor(rep: Rep, socket: GetWebSocket, schema: Schema, id: string) {
+  constructor(
+    rep: Rep,
+    metricsDelegate: InspectorMetricsDelegate,
+    socket: GetWebSocket,
+    schema: Schema,
+    id: string,
+  ) {
     this.#rep = rep;
+    this.#metricsDelegate = metricsDelegate;
     this.#socket = socket;
     this.#schema = schema;
     this.id = id;
@@ -189,6 +248,7 @@ class ClientGroup implements ClientGroupInterface {
     return withDagRead(this.#rep, dagRead =>
       clients(
         this.#rep,
+        this.#metricsDelegate,
         this.#socket,
         this.#schema,
         dagRead,
@@ -201,6 +261,7 @@ class ClientGroup implements ClientGroupInterface {
     return withDagRead(this.#rep, dagRead =>
       clientsWithQueries(
         this.#rep,
+        this.#metricsDelegate,
         this.#socket,
         this.#schema,
         dagRead,
@@ -215,7 +276,7 @@ class ClientGroup implements ClientGroupInterface {
       {op: 'queries'},
       inspectQueriesDownSchema,
     );
-    return rows.map(row => new Query(row, this.#schema));
+    return rows.map(row => new Query(row, this.#metricsDelegate));
   }
 }
 
@@ -248,6 +309,7 @@ type MapEntry<T extends ReadonlyMap<any, any>> =
 
 async function clients(
   rep: Rep,
+  metricsDelegate: InspectorMetricsDelegate,
   socket: GetWebSocket,
   schema: Schema,
   dagRead: Read,
@@ -258,18 +320,33 @@ async function clients(
     .filter(predicate)
     .map(
       ([clientID, {clientGroupID}]) =>
-        new Client(rep, schema, socket, clientID, clientGroupID),
+        new Client(
+          rep,
+          metricsDelegate,
+          schema,
+          socket,
+          clientID,
+          clientGroupID,
+        ),
     );
 }
 
 async function clientsWithQueries(
   rep: Rep,
+  metricsDelegate: InspectorMetricsDelegate,
   socket: GetWebSocket,
   schema: Schema,
   dagRead: Read,
   predicate: (entry: MapEntry<ClientMap>) => boolean = () => true,
 ): Promise<ClientInterface[]> {
-  const allClients = await clients(rep, socket, schema, dagRead, predicate);
+  const allClients = await clients(
+    rep,
+    metricsDelegate,
+    socket,
+    schema,
+    dagRead,
+    predicate,
+  );
   const clientsWithQueries: ClientInterface[] = [];
   await Promise.all(
     allClients.map(async client => {
@@ -294,22 +371,25 @@ class Query implements QueryInterface {
   readonly id: string;
   readonly zql: string | null;
   readonly clientID: string;
+  readonly metrics: Metrics | null;
 
-  constructor(row: InspectQueryRow, _schema: Schema) {
+  constructor(row: InspectQueryRow, metricsDelegate: InspectorMetricsDelegate) {
+    const {ast, queryID, inactivatedAt} = row;
     // Use own properties to make this more useful in dev tools. For example, in
     // Chrome dev tools, if you do console.table(queries) you'll see the
     // properties in the table, if these were getters you would not see them in the table.
     this.clientID = row.clientID;
-    this.id = row.queryID;
+    this.id = queryID;
     this.inactivatedAt =
-      row.inactivatedAt === null ? null : new Date(row.inactivatedAt);
+      inactivatedAt === null ? null : new Date(inactivatedAt);
     this.ttl = normalizeTTL(row.ttl);
-    this.ast = row.ast;
+    this.ast = ast;
     this.name = row.name;
     this.args = row.args;
     this.got = row.got;
     this.rowCount = row.rowCount;
     this.deleted = row.deleted;
-    this.zql = this.ast ? this.ast.table + astToZQL(this.ast) : null;
+    this.zql = ast ? ast.table + astToZQL(ast) : null;
+    this.metrics = metricsDelegate.getQueryMetrics(queryID) ?? null;
   }
 }

--- a/packages/zero-client/src/client/inspector/types.ts
+++ b/packages/zero-client/src/client/inspector/types.ts
@@ -1,4 +1,5 @@
 import type {ReadonlyJSONValue} from '../../../../shared/src/json.ts';
+import type {ReadonlyTDigest} from '../../../../shared/src/tdigest.ts';
 import type {AST} from '../../../../zero-protocol/src/ast.ts';
 import type {Row} from '../../../../zero-protocol/src/data.ts';
 import type {TTL} from '../../../../zql/src/query/ttl.ts';
@@ -7,11 +8,16 @@ export interface GetInspector {
   inspect(): Promise<Inspector>;
 }
 
+export type Metrics = {
+  'query-materialization-client': ReadonlyTDigest;
+};
+
 export interface Inspector {
   readonly client: Client;
   readonly clientGroup: ClientGroup;
   clients(): Promise<Client[]>;
   clientsWithQueries(): Promise<Client[]>;
+  readonly metrics: Metrics;
 }
 
 export interface Client {
@@ -41,4 +47,5 @@ export interface Query {
   readonly rowCount: number;
   readonly ttl: TTL;
   readonly zql: string | null;
+  readonly metrics: Metrics | null;
 }

--- a/packages/zero-client/src/client/inspector/types.ts
+++ b/packages/zero-client/src/client/inspector/types.ts
@@ -10,6 +10,7 @@ export interface GetInspector {
 
 export type Metrics = {
   'query-materialization-client': ReadonlyTDigest;
+  'query-materialization-end-to-end': ReadonlyTDigest;
 };
 
 export interface Inspector {

--- a/packages/zero-client/src/client/mutation-tracker.test.ts
+++ b/packages/zero-client/src/client/mutation-tracker.test.ts
@@ -1,18 +1,18 @@
-import {describe, test, expect, vi} from 'vitest';
-import {MutationTracker} from './mutation-tracker.ts';
-import type {PushResponse} from '../../../zero-protocol/src/push.ts';
-import {makeReplicacheMutator} from './custom.ts';
-import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
-import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
-import type {WriteTransaction} from './replicache-types.ts';
-import {zeroData} from '../../../replicache/src/transactions.ts';
-import type {MutationPatch} from '../../../zero-protocol/src/mutations-patch.ts';
+import {describe, expect, test, vi} from 'vitest';
 import type {
   DiffOperation,
   NoIndexDiff,
 } from '../../../replicache/src/btree/node.ts';
-import {toMutationResponseKey} from './keys.ts';
+import {zeroData} from '../../../replicache/src/transactions.ts';
 import {unreachable} from '../../../shared/src/asserts.ts';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import type {MutationPatch} from '../../../zero-protocol/src/mutations-patch.ts';
+import type {PushResponse} from '../../../zero-protocol/src/push.ts';
+import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
+import {makeReplicacheMutator} from './custom.ts';
+import {toMutationResponseKey} from './keys.ts';
+import {MutationTracker} from './mutation-tracker.ts';
+import type {WriteTransaction} from './replicache-types.ts';
 
 const lc = createSilentLogContext();
 
@@ -191,7 +191,6 @@ describe('MutationTracker', () => {
         tables: [],
         relationships: [],
       }),
-      0,
     );
 
     const tx = {

--- a/packages/zero-client/src/client/query-manager.test.ts
+++ b/packages/zero-client/src/client/query-manager.test.ts
@@ -1890,7 +1890,7 @@ describe('update clamps TTL correctly', () => {
     () => () => {},
     maxRecentQueriesSize,
     queryChangeThrottleMs,
-    Infinity,
+    slowMaterializeThreshold,
   );
 
   afterEach(() => {

--- a/packages/zero-client/src/client/query-manager.test.ts
+++ b/packages/zero-client/src/client/query-manager.test.ts
@@ -1911,11 +1911,11 @@ describe('update clamps TTL correctly', () => {
 
   test('updateCustom', () => {
     // Add a custom query with a specific TTL
-    queryManager.addCustom('customQuery', [1], '1m');
+    queryManager.addCustom({name: 'customQuery', args: [1]}, '1m');
     queryManager.flushBatch();
 
     // Update the query with a larger TTL
-    queryManager.updateCustom('customQuery', [1], '2m');
+    queryManager.updateCustom({name: 'customQuery', args: [1]}, '2m');
     queryManager.flushBatch();
 
     expect(send).toBeCalledTimes(2);
@@ -1972,11 +1972,14 @@ describe('update clamps TTL correctly', () => {
 
   test('updateCustom does not send when TTL is already at max', () => {
     // Add a custom query with max TTL
-    queryManager.addCustom('customQuery', [1], 'forever');
+    queryManager.addCustom({name: 'customQuery', args: [1]}, 'forever');
     queryManager.flushBatch();
 
     // Update the query with a larger TTL (should be no-op since already at max)
-    queryManager.updateCustom('customQuery', [1], MAX_TTL_MS + 1000);
+    queryManager.updateCustom(
+      {name: 'customQuery', args: [1]},
+      MAX_TTL_MS + 1000,
+    );
     queryManager.flushBatch();
 
     // Only one send should happen (the initial add)

--- a/packages/zero-client/src/client/query-manager.test.ts
+++ b/packages/zero-client/src/client/query-manager.test.ts
@@ -100,7 +100,7 @@ test('add and remove a custom query', () => {
     maxRecentQueriesSize,
     queryChangeThrottleMs,
   );
-  const rm1 = queryManager.addCustom('customQuery', [1], '1m');
+  const rm1 = queryManager.addCustom({name: 'customQuery', args: [1]}, '1m');
   queryManager.flushBatch();
   expect(send).toBeCalledTimes(1);
   expect(send).toBeCalledWith([
@@ -118,20 +118,20 @@ test('add and remove a custom query', () => {
     },
   ]);
 
-  const rm2 = queryManager.addCustom('customQuery', [1], '1m');
+  const rm2 = queryManager.addCustom({name: 'customQuery', args: [1]}, '1m');
   queryManager.flushBatch();
   expect(send).toBeCalledTimes(1);
 
   rm2();
   queryManager.flushBatch();
-  const rm3 = queryManager.addCustom('customQuery', [1], '1m');
+  const rm3 = queryManager.addCustom({name: 'customQuery', args: [1]}, '1m');
   queryManager.flushBatch();
   expect(send).toBeCalledTimes(1);
   rm1();
   queryManager.flushBatch();
   rm3();
   queryManager.flushBatch();
-  queryManager.addCustom('customQuery', [1], '1m');
+  queryManager.addCustom({name: 'customQuery', args: [1]}, '1m');
   queryManager.flushBatch();
   // once for del, another for put
   expect(send).toBeCalledTimes(3);
@@ -139,7 +139,7 @@ test('add and remove a custom query', () => {
   send.mockClear();
 
   // now update the custom query
-  queryManager.updateCustom('customQuery', [1], '2m');
+  queryManager.updateCustom({name: 'customQuery', args: [1]}, '2m');
   queryManager.flushBatch();
   // update event sent
   expect(send).toBeCalledTimes(1);
@@ -158,7 +158,7 @@ test('add and remove a custom query', () => {
     },
   ]);
 
-  queryManager.updateCustom('customQuery', [1], '1m');
+  queryManager.updateCustom({name: 'customQuery', args: [1]}, '1m');
   queryManager.flushBatch();
   // send not called with lower ttl
   expect(send).toBeCalledTimes(1);
@@ -1662,8 +1662,8 @@ test('batching multiple operations in same microtask', () => {
     {table: 'issue', orderBy: [['id', 'desc']]},
     'forever',
   );
-  queryManager.addCustom('customQuery1', [1], '1m');
-  queryManager.addCustom('customQuery2', [2], '1m');
+  queryManager.addCustom({name: 'customQuery1', args: [1]}, '1m');
+  queryManager.addCustom({name: 'customQuery2', args: [2]}, '1m');
 
   expect(send).toBeCalledTimes(0); // No calls yet
 
@@ -1790,7 +1790,7 @@ describe('Adding a query with TTL too large should warn', () => {
   test('addCustom', () => {
     // Test with TTL larger than MAX_TTL_MS (600,000ms = 10 minutes)
     const largeTTL = MAX_TTL_MS + 1; // 600,001ms
-    queryManager.addCustom('testQuery', ['arg1'], largeTTL);
+    queryManager.addCustom({name: 'testQuery', args: ['arg1']}, largeTTL);
     queryManager.flushBatch();
 
     expect(logSink.log).toHaveBeenCalledExactlyOnceWith(
@@ -1801,7 +1801,7 @@ describe('Adding a query with TTL too large should warn', () => {
 
     // Test with 'forever' TTL which should also warn
     logSink.log.mockClear();
-    queryManager.addCustom('testQuery2', ['arg2'], 'forever');
+    queryManager.addCustom({name: 'testQuery2', args: ['arg2']}, 'forever');
     queryManager.flushBatch();
 
     expect(logSink.log).toHaveBeenCalledExactlyOnceWith(
@@ -1812,7 +1812,7 @@ describe('Adding a query with TTL too large should warn', () => {
 
     // Test with valid TTL that should not warn
     logSink.log.mockClear();
-    queryManager.addCustom('testQuery3', ['arg3'], '5m');
+    queryManager.addCustom({name: 'testQuery3', args: ['arg3']}, '5m');
     queryManager.flushBatch();
 
     expect(logSink.log).not.toHaveBeenCalled();

--- a/packages/zero-client/src/client/query-manager.test.ts
+++ b/packages/zero-client/src/client/query-manager.test.ts
@@ -34,6 +34,8 @@ import {toGotQueriesKey} from './keys.ts';
 import {MutationTracker} from './mutation-tracker.ts';
 import {QueryManager} from './query-manager.ts';
 
+const slowMaterializeThreshold = Infinity; // Disable slow materialization logs for tests.
+
 function createExperimentalWatchMock() {
   return vi.fn();
 }
@@ -55,6 +57,7 @@ test('add', () => {
     () => () => {},
     maxRecentQueriesSize,
     queryChangeThrottleMs,
+    slowMaterializeThreshold,
   );
   const ast: AST = {
     table: 'issue',
@@ -99,6 +102,7 @@ test('add and remove a custom query', () => {
     () => () => {},
     maxRecentQueriesSize,
     queryChangeThrottleMs,
+    slowMaterializeThreshold,
   );
   const rm1 = queryManager.addCustom({name: 'customQuery', args: [1]}, '1m');
   queryManager.flushBatch();
@@ -177,6 +181,7 @@ test('add renamed fields', () => {
     () => () => {},
     maxRecentQueriesSize,
     queryChangeThrottleMs,
+    slowMaterializeThreshold,
   );
   const ast: AST = {
     table: 'issue',
@@ -353,6 +358,7 @@ test('remove, recent queries max size 0', () => {
     () => () => {},
     maxRecentQueriesSize,
     queryChangeThrottleMs,
+    slowMaterializeThreshold,
   );
   const ast: AST = {
     table: 'issue',
@@ -420,6 +426,7 @@ test('remove, max recent queries size 2', () => {
     () => () => {},
     maxRecentQueriesSize,
     queryChangeThrottleMs,
+    slowMaterializeThreshold,
   );
   const ast1: AST = {
     table: 'issue',
@@ -584,6 +591,7 @@ test('test add/remove/add/remove changes lru order max recent queries size 2', (
     () => () => {},
     maxRecentQueriesSize,
     queryChangeThrottleMs,
+    slowMaterializeThreshold,
   );
   const ast1: AST = {
     table: 'issue',
@@ -801,6 +809,7 @@ describe('getQueriesPatch', () => {
       () => () => {},
       maxRecentQueriesSize,
       queryChangeThrottleMs,
+      slowMaterializeThreshold,
     );
     // hash: 12hwg3ihkijhm
     const ast1: AST = {
@@ -863,6 +872,7 @@ describe('getQueriesPatch', () => {
         () => () => {},
         maxRecentQueriesSize,
         queryChangeThrottleMs,
+        slowMaterializeThreshold,
       );
     });
 
@@ -1064,6 +1074,7 @@ describe('getQueriesPatch', () => {
       () => () => {},
       maxRecentQueriesSize,
       queryChangeThrottleMs,
+      slowMaterializeThreshold,
     );
     const ast1: AST = {
       table: 'issue',
@@ -1183,6 +1194,7 @@ test('gotCallback, query already got', () => {
     experimentalWatch,
     maxRecentQueriesSize,
     queryChangeThrottleMs,
+    slowMaterializeThreshold,
   );
   expect(experimentalWatch).toBeCalledTimes(1);
   const watchCallback = experimentalWatch.mock.calls[0][0];
@@ -1253,6 +1265,7 @@ test('gotCallback, query got after add', () => {
     experimentalWatch,
     maxRecentQueriesSize,
     queryChangeThrottleMs,
+    slowMaterializeThreshold,
   );
   expect(experimentalWatch).toBeCalledTimes(1);
   const watchCallback = experimentalWatch.mock.calls[0][0];
@@ -1318,6 +1331,7 @@ test('gotCallback, query got after add then removed', () => {
     experimentalWatch,
     maxRecentQueriesSize,
     queryChangeThrottleMs,
+    slowMaterializeThreshold,
   );
   expect(experimentalWatch).toBeCalledTimes(1);
   const watchCallback = experimentalWatch.mock.calls[0][0];
@@ -1393,6 +1407,7 @@ test('gotCallback, query got after subscription removed', () => {
     experimentalWatch,
     maxRecentQueriesSize,
     queryChangeThrottleMs,
+    slowMaterializeThreshold,
   );
   expect(experimentalWatch).toBeCalledTimes(1);
   const watchCallback = experimentalWatch.mock.calls[0][0];
@@ -1472,6 +1487,7 @@ describe('queriesPatch with lastPatch', () => {
       () => () => {},
       maxRecentQueriesSize,
       queryChangeThrottleMs,
+      slowMaterializeThreshold,
     );
 
     queryManager.addLegacy(
@@ -1511,6 +1527,7 @@ describe('queriesPatch with lastPatch', () => {
       () => () => {},
       0,
       queryChangeThrottleMs,
+      slowMaterializeThreshold,
     );
 
     const clean = queryManager.addLegacy(
@@ -1584,6 +1601,7 @@ test('gotCallback, add same got callback twice', () => {
     experimentalWatch,
     maxRecentQueriesSize,
     queryChangeThrottleMs,
+    slowMaterializeThreshold,
   );
   expect(experimentalWatch).toBeCalledTimes(1);
   const watchCallback = experimentalWatch.mock.calls[0][0];
@@ -1654,6 +1672,7 @@ test('batching multiple operations in same microtask', () => {
     () => () => {},
     maxRecentQueriesSize,
     queryChangeThrottleMs,
+    slowMaterializeThreshold,
   );
 
   // Add multiple queries synchronously - should be batched
@@ -1704,6 +1723,7 @@ describe('query manager & mutator interaction', () => {
       () => () => {},
       0,
       queryChangeThrottleMs,
+      slowMaterializeThreshold,
     );
   });
 
@@ -1781,6 +1801,7 @@ describe('Adding a query with TTL too large should warn', () => {
     () => () => {},
     maxRecentQueriesSize,
     queryChangeThrottleMs,
+    slowMaterializeThreshold,
   );
 
   afterEach(() => {
@@ -1869,6 +1890,7 @@ describe('update clamps TTL correctly', () => {
     () => () => {},
     maxRecentQueriesSize,
     queryChangeThrottleMs,
+    Infinity,
   );
 
   afterEach(() => {

--- a/packages/zero-client/src/client/query-manager.ts
+++ b/packages/zero-client/src/client/query-manager.ts
@@ -396,9 +396,6 @@ export class QueryManager implements InspectorMetricsDelegate {
   ): void {
     // We track all materializations of queries as well as per
     // query materializations.
-    metric satisfies
-      | 'query-materialization-client'
-      | 'query-materialization-end-to-end';
     this.#metrics[metric].add(value);
 
     const queryID = args[0];

--- a/packages/zero-client/src/client/query-manager.ts
+++ b/packages/zero-client/src/client/query-manager.ts
@@ -378,12 +378,15 @@ export class QueryManager implements InspectorMetricsDelegate {
     }
   }
 
-  get metrics() {
+  /**
+   * Gets the aggregated metrics for all queries managed by this QueryManager.
+   */
+  get metrics(): Metric {
     return this.#metrics;
   }
 
   addMetric(metric: keyof MetricMap, value: number, queryID: string): void {
-    // We track of all materializations of queries as well as per
+    // We track all materializations of queries as well as per
     // query materializations.
     if (metric === 'query-materialization-client') {
       this.#metrics[metric].add(value);

--- a/packages/zero-client/src/client/query-manager.ts
+++ b/packages/zero-client/src/client/query-manager.ts
@@ -68,6 +68,7 @@ export class QueryManager implements InspectorMetricsDelegate {
   readonly #lc: ZeroLogContext;
   readonly #metrics: Metric = {
     'query-materialization-client': new TDigest(),
+    'query-materialization-end-to-end': new TDigest(),
   };
   readonly #queryMetrics: Map<string, Metric> = new Map();
 
@@ -388,15 +389,17 @@ export class QueryManager implements InspectorMetricsDelegate {
   addMetric(metric: keyof MetricMap, value: number, queryID: string): void {
     // We track all materializations of queries as well as per
     // query materializations.
-    if (metric === 'query-materialization-client') {
-      this.#metrics[metric].add(value);
-    }
+    metric satisfies
+      | 'query-materialization-client'
+      | 'query-materialization-end-to-end';
+    this.#metrics[metric].add(value);
 
     // The query manager manages metrics that are per query.
     let existing = this.#queryMetrics.get(queryID);
     if (!existing) {
       existing = {
         'query-materialization-client': new TDigest(),
+        'query-materialization-end-to-end': new TDigest(),
       };
       this.#queryMetrics.set(queryID, existing);
     }

--- a/packages/zero-client/src/client/query-materialization-metrics.test.ts
+++ b/packages/zero-client/src/client/query-materialization-metrics.test.ts
@@ -1,0 +1,640 @@
+import {LogContext} from '@rocicorp/logger';
+import {beforeEach, describe, expect, test, vi} from 'vitest';
+import type {AST, System} from '../../../zero-protocol/src/ast.ts';
+import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
+import {string, table} from '../../../zero-schema/src/builder/table-builder.ts';
+import {MemorySource} from '../../../zql/src/ivm/memory-source.ts';
+import type {MetricMap} from '../../../zql/src/query/metrics-delegate.ts';
+import type {CustomQueryID} from '../../../zql/src/query/named.ts';
+import {QueryImpl} from '../../../zql/src/query/query-impl.ts';
+import {
+  ZeroContext,
+  type AddCustomQuery,
+  type AddQuery,
+  type FlushQueryChanges,
+  type UpdateCustomQuery,
+  type UpdateQuery,
+} from './context.ts';
+import {IVMSourceBranch} from './ivm-branch.ts';
+
+const testBatchViewUpdates = (applyViewUpdates: () => void) =>
+  applyViewUpdates();
+
+function assertValidRunOptions(): void {}
+
+// Helper function to create sequential performance.now() mocks
+function mockPerformanceNow(times: number[]): void {
+  let callCount = 0;
+  vi.spyOn(performance, 'now').mockImplementation(() => {
+    const time = times[callCount] ?? 0;
+    callCount++;
+    return time;
+  });
+}
+
+// Helper function for simple timing scenarios (t0, client metric timing)
+function mockClientTiming(t0: number, clientTime: number): void {
+  mockPerformanceNow([t0, clientTime]);
+}
+
+// Helper function for end-to-end timing scenarios (t0, client metric, end-to-end timing)
+function mockEndToEndTiming(
+  t0: number,
+  clientTime: number,
+  endToEndTime: number,
+): void {
+  mockPerformanceNow([t0, clientTime, endToEndTime]);
+}
+
+// Helper function to create a standard query
+function createTestQuery(context: ZeroContext) {
+  const ast = {
+    table: 'users',
+    orderBy: [['id', 'asc'] as [string, 'asc' | 'desc']],
+  };
+
+  return new QueryImpl(
+    context,
+    schema,
+    ast.table as 'users',
+    ast,
+    {singular: false, relationships: {}},
+    'test' as System,
+    undefined,
+  );
+}
+
+const schema = createSchema({
+  tables: [
+    table('users')
+      .columns({
+        id: string(),
+        name: string(),
+      })
+      .primaryKey('id'),
+  ],
+});
+
+// Type for views returned by materialize
+interface MockView {
+  data?: unknown[];
+  destroy: () => void;
+}
+
+describe('query materialization metrics', () => {
+  let addMetricSpy: ReturnType<typeof vi.fn>;
+  let context: ZeroContext;
+  let gotCallback: ((got: boolean) => void) | undefined;
+  let addServerQuerySpy: ReturnType<typeof vi.fn>;
+  let addCustomQuerySpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+
+    addMetricSpy =
+      vi.fn<
+        <K extends keyof MetricMap>(
+          metric: K,
+          value: number,
+          ...args: MetricMap[K]
+        ) => void
+      >();
+
+    addServerQuerySpy = vi
+      .fn<
+        (ast: AST, ttl: number, callback?: (got: boolean) => void) => () => void
+      >()
+      .mockImplementation((_ast, _ttl, callback) => {
+        gotCallback = callback;
+        return () => {};
+      });
+
+    addCustomQuerySpy = vi
+      .fn<
+        (
+          customQueryID: CustomQueryID,
+          ttl: number,
+          callback?: (got: boolean) => void,
+        ) => () => void
+      >()
+      .mockImplementation((_customQueryID, _ttl, callback) => {
+        gotCallback = callback;
+        return () => {};
+      });
+
+    context = new ZeroContext(
+      new LogContext('info'),
+      new IVMSourceBranch(schema.tables),
+      addServerQuerySpy as unknown as AddQuery,
+      addCustomQuerySpy as unknown as AddCustomQuery,
+      (() => {}) as unknown as UpdateQuery,
+      (() => {}) as unknown as UpdateCustomQuery,
+      (() => {}) as unknown as FlushQueryChanges,
+      testBatchViewUpdates,
+      addMetricSpy,
+      assertValidRunOptions,
+    );
+  });
+
+  describe('query-materialization-client metric', () => {
+    test.each([
+      {
+        name: 'records client metric immediately when query is materialized',
+        t0: 100,
+        clientTime: 125,
+        expectedDelta: 25,
+        setup: () => createTestQuery(context),
+      },
+      {
+        name: 'records client metric for custom queries',
+        t0: 200,
+        clientTime: 235,
+        expectedDelta: 35,
+        setup: () => createTestQuery(context).nameAndArgs('getUsers', []),
+        additionalChecks: () => {
+          expect(addCustomQuerySpy).toHaveBeenCalledOnce();
+        },
+      },
+    ])('$name', ({t0, clientTime, expectedDelta, setup, additionalChecks}) => {
+      mockClientTiming(t0, clientTime);
+
+      const query = setup();
+      const view = query.materialize() as MockView;
+
+      additionalChecks?.();
+
+      expect(addMetricSpy).toHaveBeenCalledWith(
+        'query-materialization-client',
+        expectedDelta,
+        expect.any(String),
+      );
+
+      view.destroy();
+    });
+
+    test('records client metric with different timing for multiple queries', () => {
+      // Mock performance.now() for multiple client queries
+      mockPerformanceNow([
+        100,
+        120, // First query: t0=100, client=120 (20ms)
+        200,
+        230, // Second query: t0=200, client=230 (30ms)
+        300,
+        340, // Third query: t0=300, client=340 (40ms)
+      ]);
+
+      const queries = [];
+      const views = [];
+
+      // Create multiple queries
+      for (let i = 0; i < 3; i++) {
+        const query = createTestQuery(context);
+        queries.push(query);
+        views.push(query.materialize() as MockView);
+      }
+
+      // Verify all client metrics were recorded
+      const clientCalls = addMetricSpy.mock.calls.filter(
+        call => call[0] === 'query-materialization-client',
+      );
+      expect(clientCalls).toHaveLength(3);
+
+      // Verify the timing for each call
+      expect(clientCalls[0][1]).toBe(20); // 120-100=20ms
+      expect(clientCalls[1][1]).toBe(30); // 230-200=30ms
+      expect(clientCalls[2][1]).toBe(40); // 340-300=40ms
+
+      // Cleanup
+      views.forEach(view => view.destroy());
+    });
+
+    test('records client metric with custom view factory', () => {
+      // Mock performance.now() for view factory
+      mockClientTiming(250, 275);
+
+      const query = createTestQuery(context);
+
+      // Use custom view factory
+      const customViewFactory = () => ({
+        destroy() {},
+      });
+
+      const view = query.materialize(customViewFactory) as MockView;
+
+      // Should record client metric even with custom view factory
+      expect(addMetricSpy).toHaveBeenCalledWith(
+        'query-materialization-client',
+        25, // 275ms - 250ms = 25ms elapsed
+        expect.any(String),
+      );
+
+      view.destroy();
+    });
+
+    test('records precise timing with fractional milliseconds', () => {
+      // Test precision with fractional milliseconds
+      mockClientTiming(1000.123, 1025.789);
+
+      const query = createTestQuery(context);
+
+      const view = query.materialize() as MockView;
+
+      // Should capture precise timing (accounting for floating-point precision)
+      expect(addMetricSpy).toHaveBeenCalledWith(
+        'query-materialization-client',
+        expect.closeTo(25.666, 0.001), // 1025.789 - 1000.123 = 25.666ms
+        expect.any(String),
+      );
+
+      view.destroy();
+    });
+
+    test('records client metric', () => {
+      // Mock performance.now() for query
+      mockClientTiming(500, 545);
+
+      const query = createTestQuery(context);
+
+      const view = query.materialize() as MockView;
+
+      // Should record client metric
+      expect(addMetricSpy).toHaveBeenCalledWith(
+        'query-materialization-client',
+        45, // 545ms - 500ms = 45ms elapsed
+        expect.any(String),
+      );
+
+      view.destroy();
+    });
+  });
+
+  describe('query-materialization-end-to-end metric', () => {
+    test.each([
+      {
+        name: 'records end-to-end metric when server query completes',
+        t0: 150,
+        clientTime: 200,
+        serverTime: 300,
+        expectedDelta: 150,
+        setup: () => createTestQuery(context),
+        additionalChecks: () => {
+          expect(addServerQuerySpy).toHaveBeenCalledOnce();
+        },
+      },
+      {
+        name: 'records end-to-end metric when custom query completes',
+        t0: 250,
+        clientTime: 300,
+        serverTime: 400,
+        expectedDelta: 150,
+        setup: () => createTestQuery(context).nameAndArgs('getUsers', []),
+        additionalChecks: () => {
+          expect(addCustomQuerySpy).toHaveBeenCalledOnce();
+        },
+      },
+    ])(
+      '$name',
+      ({
+        t0,
+        clientTime,
+        serverTime,
+        expectedDelta,
+        setup,
+        additionalChecks,
+      }) => {
+        mockEndToEndTiming(t0, clientTime, serverTime);
+
+        const query = setup();
+        const view = query.materialize() as MockView;
+
+        additionalChecks?.();
+        expect(gotCallback).toBeDefined();
+
+        gotCallback!(true);
+
+        expect(addMetricSpy).toHaveBeenCalledWith(
+          'query-materialization-end-to-end',
+          expectedDelta,
+          expect.any(String),
+          expect.objectContaining({
+            table: 'users',
+            orderBy: expect.arrayContaining([['id', 'asc']]),
+          }),
+        );
+
+        view.destroy();
+      },
+    );
+
+    test('does not record end-to-end metric when server never responds', () => {
+      // Mock performance.now() for basic timing - only 2 calls expected (t0 and client metric)
+      mockClientTiming(150, 200);
+
+      const query = createTestQuery(context);
+
+      const view = query.materialize() as MockView;
+
+      // Never call gotCallback
+
+      // Verify that end-to-end metric was NOT recorded
+      const endToEndCalls = addMetricSpy.mock.calls.filter(
+        call => call[0] === 'query-materialization-end-to-end',
+      );
+      expect(endToEndCalls).toHaveLength(0);
+
+      view.destroy();
+    });
+
+    test('always records client-side metric regardless of server response', () => {
+      // Mock performance.now() for basic timing
+      mockClientTiming(100, 150);
+
+      const query = createTestQuery(context);
+
+      const view = query.materialize() as MockView;
+
+      // Client-side metric should be recorded immediately
+      expect(addMetricSpy).toHaveBeenCalledWith(
+        'query-materialization-client',
+        50, // 150ms - 100ms = 50ms
+        expect.any(String), // queryID
+      );
+
+      view.destroy();
+    });
+
+    test('records different timing for multiple queries', () => {
+      // Mock performance.now() calls:
+      // Query1: t0=200, client=250, end-to-end=400
+      // Query2: t0=300, client=350, end-to-end=500
+      mockPerformanceNow([
+        200,
+        250, // First query: t0=200, client=250
+        300,
+        350, // Second query: t0=300, client=350
+        400,
+        500, // End-to-end callbacks: first=400, second=500
+      ]);
+
+      // First query
+      const query1 = createTestQuery(context);
+
+      const view1 = query1.materialize() as MockView;
+      const firstGotCallback = gotCallback!;
+
+      // Second query
+      const query2 = createTestQuery(context);
+
+      const view2 = query2.materialize() as MockView;
+      const secondGotCallback = gotCallback!;
+
+      // First query completes
+      firstGotCallback(true);
+
+      // Second query completes later
+      secondGotCallback(true);
+
+      // Verify both metrics were recorded with correct timing
+      // Check that the metrics were called in the right order and with right parameters
+      const endToEndCalls = addMetricSpy.mock.calls.filter(
+        call => call[0] === 'query-materialization-end-to-end',
+      );
+
+      expect(endToEndCalls).toHaveLength(2);
+
+      expect(endToEndCalls[0]).toEqual([
+        'query-materialization-end-to-end',
+        200, // 400ms - 200ms = 200ms elapsed for first query
+        expect.any(String),
+        expect.objectContaining({
+          table: 'users',
+          orderBy: expect.arrayContaining([['id', 'asc']]),
+        }),
+      ]);
+
+      expect(endToEndCalls[1]).toEqual([
+        'query-materialization-end-to-end',
+        200, // 500ms - 300ms = 200ms elapsed for second query
+        expect.any(String),
+        expect.objectContaining({
+          table: 'users',
+          orderBy: expect.arrayContaining([['id', 'asc']]),
+        }),
+      ]);
+
+      view1.destroy();
+      view2.destroy();
+    });
+
+    test('handles server responding with false (query not available)', () => {
+      // Mock performance.now() for server failure scenario
+      mockClientTiming(150, 200);
+
+      const query = createTestQuery(context);
+
+      const view = query.materialize() as MockView;
+
+      // Server responds with false (query not available)
+      gotCallback!(false);
+
+      // Should not record end-to-end metric when server responds with false
+      const endToEndCalls = addMetricSpy.mock.calls.filter(
+        call => call[0] === 'query-materialization-end-to-end',
+      );
+      expect(endToEndCalls).toHaveLength(0);
+
+      view.destroy();
+    });
+
+    test('handles very fast server responses', () => {
+      // Mock performance.now() for very fast response (same time for t0 and callback)
+      mockEndToEndTiming(101, 102, 101);
+
+      const query = createTestQuery(context);
+
+      const view = query.materialize() as MockView;
+
+      // Server responds immediately
+      gotCallback!(true);
+
+      // Should record a very small time
+      expect(addMetricSpy).toHaveBeenCalledWith(
+        'query-materialization-end-to-end',
+        0, // 101 - 101 = 0ms
+        expect.any(String),
+        expect.objectContaining({
+          table: 'users',
+          orderBy: expect.arrayContaining([['id', 'asc']]),
+        }),
+      );
+
+      view.destroy();
+    });
+
+    test('measures time correctly with view factory', () => {
+      // Mock performance.now() for view factory timing
+      mockEndToEndTiming(150, 200, 300);
+
+      const query = createTestQuery(context);
+
+      // Use custom view factory
+      const customViewFactory = vi.fn().mockReturnValue({
+        destroy: vi.fn(),
+      });
+
+      const view = query.materialize(customViewFactory) as MockView;
+
+      gotCallback!(true);
+
+      // Should still record the metric correctly with custom factory
+      expect(addMetricSpy).toHaveBeenCalledWith(
+        'query-materialization-end-to-end',
+        150, // 300ms - 150ms = 150ms elapsed
+        expect.any(String),
+        expect.objectContaining({
+          table: 'users',
+          orderBy: expect.arrayContaining([['id', 'asc']]),
+        }),
+      );
+
+      view.destroy();
+    });
+
+    test('integration with real data flow', () => {
+      // Mock performance.now() to simulate proper timing
+      mockEndToEndTiming(150, 200, 300);
+
+      // Add some test data to the source
+      const source = context.getSource('users') as MemorySource;
+      source.push({type: 'add', row: {id: 'user1', name: 'John'}});
+      source.push({type: 'add', row: {id: 'user2', name: 'Jane'}});
+
+      const query = createTestQuery(context);
+
+      const view = query.materialize() as MockView & {data: unknown[]};
+
+      // Verify view has data - should be ordered by id ascending
+      expect(view.data).toHaveLength(2);
+      expect(view.data[0]).toEqual(
+        expect.objectContaining({id: 'user1', name: 'John'}),
+      );
+      expect(view.data[1]).toEqual(
+        expect.objectContaining({id: 'user2', name: 'Jane'}),
+      );
+
+      gotCallback!(true);
+
+      // Verify metrics were recorded
+      expect(addMetricSpy).toHaveBeenCalledWith(
+        'query-materialization-client',
+        50, // 200ms - 150ms = 50ms
+        expect.any(String),
+      );
+
+      expect(addMetricSpy).toHaveBeenCalledWith(
+        'query-materialization-end-to-end',
+        150, // 300ms - 150ms = 150ms elapsed
+        expect.any(String),
+        expect.objectContaining({
+          table: 'users',
+          orderBy: expect.arrayContaining([['id', 'asc']]),
+        }),
+      );
+
+      view.destroy();
+    });
+  });
+
+  describe('edge cases and error scenarios', () => {
+    let addMetricSpy: ReturnType<typeof vi.fn>;
+    let context: ZeroContext;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+
+      addMetricSpy = vi.fn();
+
+      context = new ZeroContext(
+        new LogContext('info'),
+        new IVMSourceBranch(schema.tables),
+        (() => () => {}) as unknown as AddQuery,
+        (() => () => {}) as unknown as AddCustomQuery,
+        (() => {}) as unknown as UpdateQuery,
+        (() => {}) as unknown as UpdateCustomQuery,
+        (() => {}) as unknown as FlushQueryChanges,
+        testBatchViewUpdates,
+        addMetricSpy,
+        assertValidRunOptions,
+      );
+    });
+
+    test('handles rapid materialization and destruction', () => {
+      // Mock performance.now() for multiple rapid queries
+      // Each query has 2 calls: t0 and client metric
+      // Return sequential times for each query
+      mockPerformanceNow([
+        100,
+        101, // Query 1: t0=100, client=101 (1ms)
+        101,
+        102, // Query 2: t0=101, client=102 (1ms)
+        102,
+        103, // Query 3: t0=102, client=103 (1ms)
+        103,
+        104, // Query 4: t0=103, client=104 (1ms)
+        104,
+        105, // Query 5: t0=104, client=105 (1ms)
+      ]);
+
+      for (let i = 0; i < 5; i++) {
+        const query = createTestQuery(context);
+
+        const view = query.materialize() as MockView;
+        view.destroy();
+      }
+
+      // Should record client metrics for all materializations
+      const clientCalls = addMetricSpy.mock.calls.filter(
+        call => call[0] === 'query-materialization-client',
+      );
+      expect(clientCalls).toHaveLength(5);
+    });
+
+    test('performance.now() timing precision', () => {
+      // Test that we're using performance.now() correctly
+      let mockTime = 1000.123; // fractional milliseconds
+
+      const performanceNowSpy = vi
+        .spyOn(performance, 'now')
+        .mockImplementation(() => mockTime);
+
+      const query = createTestQuery(context);
+
+      mockTime = 1050.456;
+      const view = query.materialize() as MockView;
+
+      // Should capture the precise timing
+      expect(performanceNowSpy).toHaveBeenCalled();
+
+      view.destroy();
+      performanceNowSpy.mockRestore();
+    });
+
+    test('metric with query structure', () => {
+      // Mock performance.now() for query
+      mockClientTiming(100, 150);
+
+      const query = createTestQuery(context);
+
+      const view = query.materialize() as MockView;
+
+      // Metrics should be recorded
+      expect(addMetricSpy).toHaveBeenCalledWith(
+        'query-materialization-client',
+        50, // 150ms - 100ms = 50ms
+        expect.any(String),
+      );
+
+      view.destroy();
+    });
+  });
+});

--- a/packages/zero-client/src/client/query-materialization-metrics.test.ts
+++ b/packages/zero-client/src/client/query-materialization-metrics.test.ts
@@ -51,12 +51,12 @@ function createTestQuery(context: ZeroContext) {
   const ast = {
     table: 'users',
     orderBy: [['id', 'asc'] as [string, 'asc' | 'desc']],
-  };
+  } as const;
 
   return new QueryImpl(
     context,
     schema,
-    ast.table as 'users',
+    ast.table,
     ast,
     {singular: false, relationships: {}},
     'test' as System,
@@ -318,7 +318,7 @@ describe('query materialization metrics', () => {
           expect.any(String),
           expect.objectContaining({
             table: 'users',
-            orderBy: expect.arrayContaining([['id', 'asc']]),
+            orderBy: [['id', 'asc']],
           }),
         );
 
@@ -408,7 +408,7 @@ describe('query materialization metrics', () => {
         expect.any(String),
         expect.objectContaining({
           table: 'users',
-          orderBy: expect.arrayContaining([['id', 'asc']]),
+          orderBy: [['id', 'asc']],
         }),
       ]);
 
@@ -418,7 +418,7 @@ describe('query materialization metrics', () => {
         expect.any(String),
         expect.objectContaining({
           table: 'users',
-          orderBy: expect.arrayContaining([['id', 'asc']]),
+          orderBy: [['id', 'asc']],
         }),
       ]);
 
@@ -464,7 +464,7 @@ describe('query materialization metrics', () => {
         expect.any(String),
         expect.objectContaining({
           table: 'users',
-          orderBy: expect.arrayContaining([['id', 'asc']]),
+          orderBy: [['id', 'asc']],
         }),
       );
 
@@ -493,7 +493,7 @@ describe('query materialization metrics', () => {
         expect.any(String),
         expect.objectContaining({
           table: 'users',
-          orderBy: expect.arrayContaining([['id', 'asc']]),
+          orderBy: [['id', 'asc']],
         }),
       );
 
@@ -537,7 +537,7 @@ describe('query materialization metrics', () => {
         expect.any(String),
         expect.objectContaining({
           table: 'users',
-          orderBy: expect.arrayContaining([['id', 'asc']]),
+          orderBy: [['id', 'asc']],
         }),
       );
 
@@ -617,24 +617,6 @@ describe('query materialization metrics', () => {
 
       view.destroy();
       performanceNowSpy.mockRestore();
-    });
-
-    test('metric with query structure', () => {
-      // Mock performance.now() for query
-      mockClientTiming(100, 150);
-
-      const query = createTestQuery(context);
-
-      const view = query.materialize() as MockView;
-
-      // Metrics should be recorded
-      expect(addMetricSpy).toHaveBeenCalledWith(
-        'query-materialization-client',
-        50, // 150ms - 100ms = 50ms
-        expect.any(String),
-      );
-
-      view.destroy();
     });
   });
 });

--- a/packages/zero-client/src/client/test-utils.ts
+++ b/packages/zero-client/src/client/test-utils.ts
@@ -233,6 +233,20 @@ export class TestZero<
     socket.dispatchEvent(new CloseEvent('close'));
   }
 
+  async triggerGotQueriesPatch(
+    q: Query<S, keyof S['tables'] & string>,
+  ): Promise<void> {
+    q.hash();
+    await this.triggerPoke(null, '1', {
+      gotQueriesPatch: [
+        {
+          op: 'put',
+          hash: q.hash(),
+        },
+      ],
+    });
+  }
+
   declare [exposedToTestingSymbol]: TestingContext;
 
   get pusher() {

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -30,6 +30,7 @@ import type {Enum} from '../../../shared/src/enum.ts';
 import {must} from '../../../shared/src/must.ts';
 import {navigator} from '../../../shared/src/navigator.ts';
 import {sleep, sleepWithAbort} from '../../../shared/src/sleep.ts';
+import {Subscribable} from '../../../shared/src/subscribable.ts';
 import * as valita from '../../../shared/src/valita.ts';
 import type {Writable} from '../../../shared/src/writable.ts';
 import {type ClientSchema} from '../../../zero-protocol/src/client-schema.ts';
@@ -146,7 +147,6 @@ import {version} from './version.ts';
 import {ZeroLogContext} from './zero-log-context.ts';
 import {PokeHandler} from './zero-poke-handler.ts';
 import {ZeroRep} from './zero-rep.ts';
-import {Subscribable} from '../../../shared/src/subscribable.ts';
 
 type ConnectionState = Enum<typeof ConnectionState>;
 type PingResult = Enum<typeof PingResult>;
@@ -1953,14 +1953,14 @@ export class Zero<
     }
   }
 
-  #addMetric: (
-    metric: keyof MetricMap,
+  #addMetric: <K extends keyof MetricMap>(
+    metric: K,
     value: number,
-    ...args: MetricMap[typeof metric]
+    ...args: MetricMap[K]
   ) => void = (metric, value, ...args) => {
-    function isQueryMetric(metric: string): metric is `query-${string}` {
-      return metric.startsWith('query-');
-    }
+    const isQueryMetric = (metric: string): metric is `query-${string}` =>
+      metric.startsWith('query-');
+
     if (isQueryMetric(metric)) {
       this.#queryManager.addMetric(metric, value, args[0]);
     } else {

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -515,7 +515,6 @@ export class Zero<
             lc,
             mutatorOrMutators,
             schema,
-            slowMaterializeThreshold,
             // Replicache expects mutators to only be able to return JSON
             // but Zero wraps the return with: `{server?: Promise<MutationResult>, client?: T}`
           ) as () => MutatorReturn;
@@ -532,7 +531,6 @@ export class Zero<
               lc,
               mutator as CustomMutatorImpl<S>,
               schema,
-              slowMaterializeThreshold,
             ) as () => MutatorReturn;
           }
           continue;
@@ -579,7 +577,6 @@ export class Zero<
       () => this.#queryManager.flushBatch(),
       batchViewUpdates,
       this.#addMetric,
-      slowMaterializeThreshold,
       assertValidRunOptions,
     );
     this.queryDelegate = this.#zeroContext;
@@ -691,6 +688,7 @@ export class Zero<
       rep.experimentalWatch.bind(rep),
       maxRecentQueries,
       options.queryChangeThrottleMs ?? DEFAULT_QUERY_CHANGE_THROTTLE_MS,
+      slowMaterializeThreshold,
     );
     this.#clientToServer = clientToServer(schema.tables);
 
@@ -1962,7 +1960,7 @@ export class Zero<
       metric.startsWith('query-');
 
     if (isQueryMetric(metric)) {
-      this.#queryManager.addMetric(metric, value, args[0]);
+      this.#queryManager.addMetric(metric, value, ...args);
     } else {
       unreachable(metric);
     }

--- a/packages/zql/src/query/metrics-delegate.ts
+++ b/packages/zql/src/query/metrics-delegate.ts
@@ -1,0 +1,11 @@
+export type MetricMap = {
+  'query-materialization-client': [queryID: string];
+};
+
+export interface MetricsDelegate {
+  addMetric<K extends keyof MetricMap>(
+    metric: K,
+    value: number,
+    ...args: MetricMap[K]
+  ): void;
+}

--- a/packages/zql/src/query/metrics-delegate.ts
+++ b/packages/zql/src/query/metrics-delegate.ts
@@ -1,5 +1,8 @@
+import type {AST} from '../../../zero-protocol/src/ast.ts';
+
 export type MetricMap = {
   'query-materialization-client': [queryID: string];
+  'query-materialization-end-to-end': [queryID: string, ast: AST];
 };
 
 export interface MetricsDelegate {

--- a/packages/zql/src/query/query-delegate.ts
+++ b/packages/zql/src/query/query-delegate.ts
@@ -2,6 +2,7 @@ import type {AST} from '../../../zero-protocol/src/ast.ts';
 import type {Schema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import type {BuilderDelegate} from '../builder/builder.ts';
 import type {Format} from '../ivm/view.ts';
+import type {MetricsDelegate} from './metrics-delegate.ts';
 import type {CustomQueryID} from './named.ts';
 import type {Query, RunOptions} from './query.ts';
 import type {TTL} from './ttl.ts';
@@ -22,7 +23,7 @@ export interface NewQueryDelegate {
   ): Query<TSchema, TTable, TReturn>;
 }
 
-export interface QueryDelegate extends BuilderDelegate {
+export interface QueryDelegate extends BuilderDelegate, MetricsDelegate {
   addServerQuery(
     ast: AST,
     ttl: TTL,
@@ -37,6 +38,11 @@ export interface QueryDelegate extends BuilderDelegate {
   updateCustomQuery(customQueryID: CustomQueryID, ttl: TTL): void;
   flushQueryChanges(): void;
   onTransactionCommit(cb: CommitListener): () => void;
+  /**
+   * batchViewUpdates is used to allow the view to batch multiple view updates together.
+   * Normally, `applyViewUpdates` is called directly but for some cases, SolidJS for example,
+   * the updates are wrapped in a batch to avoid multiple re-renders.
+   */
   batchViewUpdates<T>(applyViewUpdates: () => T): T;
   onQueryMaterialized(hash: string, ast: AST, duration: number): void;
 

--- a/packages/zql/src/query/query-delegate.ts
+++ b/packages/zql/src/query/query-delegate.ts
@@ -44,7 +44,6 @@ export interface QueryDelegate extends BuilderDelegate, MetricsDelegate {
    * the updates are wrapped in a batch to avoid multiple re-renders.
    */
   batchViewUpdates<T>(applyViewUpdates: () => T): T;
-  onQueryMaterialized(hash: string, ast: AST, duration: number): void;
 
   /**
    * Asserts that the `RunOptions` provided to the `run` method are supported in

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -766,12 +766,12 @@ export class QueryImpl<
     const onDestroy = () => {
       input.destroy();
       removeCommitObserver?.();
-      removeServerQuery();
+      removeAddedQuery();
     };
 
     const t0 = performance.now();
 
-    const removeServerQuery = this.customQueryID
+    const removeAddedQuery = this.customQueryID
       ? delegate.addCustomQuery(this.customQueryID, ttl, gotCallback)
       : delegate.addServerQuery(ast, ttl, gotCallback);
 

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -756,7 +756,12 @@ export class QueryImpl<
 
     const gotCallback: GotCallback = got => {
       if (got) {
-        delegate.onQueryMaterialized(this.hash(), ast, performance.now() - t0);
+        delegate.addMetric(
+          'query-materialization-end-to-end',
+          performance.now() - t0,
+          queryID,
+          ast,
+        );
         queryComplete = true;
         queryCompleteResolver.resolve(true);
       }

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -15,7 +15,10 @@ import type {
   System,
 } from '../../../zero-protocol/src/ast.ts';
 import type {Row as IVMRow} from '../../../zero-protocol/src/data.ts';
-import {hashOfAST} from '../../../zero-protocol/src/query-hash.ts';
+import {
+  hashOfAST,
+  hashOfNameAndArgs,
+} from '../../../zero-protocol/src/query-hash.ts';
 import type {Schema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import {
   isOneHop,
@@ -733,7 +736,6 @@ export class QueryImpl<
       this._delegate,
       'materialize requires a query delegate to be set',
     );
-    const t0 = Date.now();
     let factory: ViewFactory<TSchema, TTable, TReturn, T> | undefined;
     if (typeof factoryOrTTL === 'function') {
       factory = factoryOrTTL;
@@ -741,34 +743,39 @@ export class QueryImpl<
       ttl = factoryOrTTL ?? DEFAULT_TTL_MS;
     }
     const ast = this._completeAst();
+    const queryID = this.customQueryID
+      ? hashOfNameAndArgs(this.customQueryID.name, this.customQueryID.args)
+      : this.hash();
     const queryCompleteResolver = resolver<true>();
     let queryComplete = delegate.defaultQueryComplete;
-    const gotCallback: GotCallback = got => {
-      if (got) {
-        const t1 = Date.now();
-        delegate.onQueryMaterialized(this.hash(), ast, t1 - t0);
-        queryComplete = true;
-        queryCompleteResolver.resolve(true);
-      }
-    };
-    const removeServerQuery = this.customQueryID
-      ? delegate.addCustomQuery(this.customQueryID, ttl, gotCallback)
-      : delegate.addServerQuery(ast, ttl, gotCallback);
-
     const updateTTL = (newTTL: TTL) => {
       this.customQueryID
         ? delegate.updateCustomQuery(this.customQueryID, newTTL)
         : delegate.updateServerQuery(ast, newTTL);
     };
 
-    const input = buildPipeline(ast, delegate);
-    let removeCommitObserver: (() => void) | undefined;
+    const gotCallback: GotCallback = got => {
+      if (got) {
+        delegate.onQueryMaterialized(this.hash(), ast, performance.now() - t0);
+        queryComplete = true;
+        queryCompleteResolver.resolve(true);
+      }
+    };
 
+    let removeCommitObserver: (() => void) | undefined;
     const onDestroy = () => {
       input.destroy();
       removeCommitObserver?.();
       removeServerQuery();
     };
+
+    const t0 = performance.now();
+
+    const removeServerQuery = this.customQueryID
+      ? delegate.addCustomQuery(this.customQueryID, ttl, gotCallback)
+      : delegate.addServerQuery(ast, ttl, gotCallback);
+
+    const input = buildPipeline(ast, delegate);
 
     const view = delegate.batchViewUpdates(() =>
       (factory ?? arrayViewFactory)(
@@ -782,6 +789,12 @@ export class QueryImpl<
         queryComplete || queryCompleteResolver.promise,
         updateTTL,
       ),
+    );
+
+    delegate.addMetric(
+      'query-materialization-client',
+      performance.now() - t0,
+      queryID,
     );
 
     return view as T;

--- a/packages/zql/src/query/test/query-delegate.ts
+++ b/packages/zql/src/query/test/query-delegate.ts
@@ -158,6 +158,8 @@ export class QueryDelegateImpl implements QueryDelegate {
     }
     this.gotCallbacks.length = 0;
   }
+
+  addMetric() {}
 }
 
 function makeSources() {

--- a/packages/zql/src/query/test/query-delegate.ts
+++ b/packages/zql/src/query/test/query-delegate.ts
@@ -75,8 +75,6 @@ export class QueryDelegateImpl implements QueryDelegate {
     return ast;
   }
 
-  onQueryMaterialized() {}
-
   commit() {
     for (const listener of this.#commitListeners) {
       listener();

--- a/packages/zqlite/src/query-delegate.ts
+++ b/packages/zqlite/src/query-delegate.ts
@@ -1,16 +1,16 @@
 import type {LogContext} from '@rocicorp/logger';
-import type {Schema} from '../../zero-schema/src/builder/schema-builder.ts';
-import type {Database} from './db.ts';
-import type {Source} from '../../zql/src/ivm/source.ts';
-import {TableSource} from './table-source.ts';
 import type {LogConfig} from '../../otel/src/log-options.ts';
-import type {Input} from '../../zql/src/ivm/operator.ts';
-import {MemoryStorage} from '../../zql/src/ivm/memory-storage.ts';
+import type {Schema} from '../../zero-schema/src/builder/schema-builder.ts';
 import type {FilterInput} from '../../zql/src/ivm/filter-operators.ts';
+import {MemoryStorage} from '../../zql/src/ivm/memory-storage.ts';
+import type {Input} from '../../zql/src/ivm/operator.ts';
+import type {Source} from '../../zql/src/ivm/source.ts';
 import type {
   CommitListener,
   QueryDelegate,
 } from '../../zql/src/query/query-delegate.ts';
+import type {Database} from './db.ts';
+import {TableSource} from './table-source.ts';
 
 export class QueryDelegateImpl implements QueryDelegate {
   readonly #lc: LogContext;
@@ -95,4 +95,5 @@ export class QueryDelegateImpl implements QueryDelegate {
     return ret;
   }
   assertValidRunOptions() {}
+  addMetric() {}
 }

--- a/packages/zqlite/src/query-delegate.ts
+++ b/packages/zqlite/src/query-delegate.ts
@@ -80,7 +80,6 @@ export class QueryDelegateImpl implements QueryDelegate {
   updateServerQuery() {}
   updateCustomQuery() {}
   flushQueryChanges() {}
-  onQueryMaterialized() {}
   onTransactionCommit(cb: CommitListener) {
     this.#commitObservers.add(cb);
     return () => {

--- a/packages/zqlite/src/test/source-factory.ts
+++ b/packages/zqlite/src/test/source-factory.ts
@@ -13,15 +13,15 @@ import {
   serverToClient,
 } from '../../../zero-schema/src/name-mapper.ts';
 import type {SchemaValue} from '../../../zero-schema/src/table-schema.ts';
+import type {FilterInput} from '../../../zql/src/ivm/filter-operators.ts';
 import {MemoryStorage} from '../../../zql/src/ivm/memory-storage.ts';
 import type {Input} from '../../../zql/src/ivm/operator.ts';
 import type {Source} from '../../../zql/src/ivm/source.ts';
 import type {SourceFactory} from '../../../zql/src/ivm/test/source-factory.ts';
+import type {QueryDelegate} from '../../../zql/src/query/query-delegate.ts';
 import {Database} from '../db.ts';
 import {compile, sql} from '../internal/sql.ts';
 import {TableSource, toSQLiteTypeName} from '../table-source.ts';
-import type {FilterInput} from '../../../zql/src/ivm/filter-operators.ts';
-import type {QueryDelegate} from '../../../zql/src/query/query-delegate.ts';
 
 export const createSource: SourceFactory = (
   lc: LogContext,
@@ -189,5 +189,6 @@ export function newQueryDelegate(
     assertValidRunOptions() {},
     flushQueryChanges() {},
     defaultQueryComplete: true,
+    addMetric() {},
   };
 }

--- a/packages/zqlite/src/test/source-factory.ts
+++ b/packages/zqlite/src/test/source-factory.ts
@@ -179,7 +179,6 @@ export function newQueryDelegate(
     },
     updateServerQuery() {},
     updateCustomQuery() {},
-    onQueryMaterialized() {},
     onTransactionCommit() {
       return () => {};
     },


### PR DESCRIPTION
# Add metrics collection for query materialization performance

This PR introduces metrics collection to track query materialization performance in Zero, accessible through the Zero Inspector.

## What's New

- Automatically tracks query materialization time with zero performance overhead
- Collects client-side and end-to-end performance metrics using T-Digest for percentile calculations
- Adds `metrics` property to Inspector and Query objects for performance analysis

## Usage

### Global Performance Metrics
```typescript
const inspector = await zero.inspect();
const clientMetrics = inspector.metrics['query-materialization-client'];

console.log(`Total queries: ${clientMetrics.count()}`);
console.log(`P50 latency: ${clientMetrics.quantile(0.5)}ms`);
console.log(`P90 latency: ${clientMetrics.quantile(0.9)}ms`);
```

### Per-Query Analysis
```typescript
const queries = await inspector.client.queries();
const slowQueries = queries.filter(q => 
  q.metrics?.['query-materialization-client'].quantile(0.9) > 100
);
console.log(`Found ${slowQueries.length} queries with >100ms P90 latency`);
```

## Interface Changes

```typescript
interface Inspector {
  readonly metrics: Metrics;
  // ... existing properties
}

interface Query {
  readonly metrics: Metrics | null;
  // ... existing properties
}

type Metrics = {
  readonly 'query-materialization-client': ReadonlyTDigest;
  readonly 'query-materialization-end-to-end': ReadonlyTDigest;
};
```

Enables developers to identify performance bottlenecks and optimize slow queries in Zero applications.