### PR TITLE
feat(zql): added TTL to run

### DIFF
--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -793,7 +793,7 @@ export class QueryImpl<
       'run requires a query delegate to be set',
     );
     delegate.assertValidRunOptions(options);
-    const v: TypedView<HumanReadable<TReturn>> = this.materialize();
+    const v: TypedView<HumanReadable<TReturn>> = this.materialize(options?.ttl);
     if (options?.type === 'complete') {
       return new Promise(resolve => {
         v.addListener((data, type) => {

--- a/packages/zql/src/query/query.ts
+++ b/packages/zql/src/query/query.ts
@@ -422,8 +422,8 @@ export interface Query<
    * @param options Options to control the result type.
    * @param options.type The type of result to return.
    * @param options.ttl Time To Live. This is the amount of time to keep the rows
-   *                  associated with this query after {@linkcode cleanup} has
-   *                  been called.
+   *                  associated with this query after the returned promise has
+   *                  resolved.
    * @returns A promise resolving to the query result.
    *
    * @example
@@ -483,7 +483,7 @@ export type HumanReadableRecursive<T> = undefined extends T
  * By default, `run` uses `{type: 'unknown'}` to avoid waiting for the server.
  *
  * The `ttl` option is used to specify the time to live for the query. This is the amount of
- * time to keep the rows associated with this query after {@linkcode cleanup} has been called.
+ * time to keep the rows associated with this query after the promise has resolved.
  */
 export type RunOptions = {
   type: 'unknown' | 'complete';

--- a/packages/zql/src/query/query.ts
+++ b/packages/zql/src/query/query.ts
@@ -408,7 +408,8 @@ export interface Query<
 
   /**
    * Executes the query and returns the result once. The `options` parameter
-   * specifies whether to wait for complete results or return immediately.
+   * specifies whether to wait for complete results or return immediately,
+   * and the time to live for the query.
    *
    * - `{type: 'unknown'}`: Returns a snapshot of the data immediately.
    * - `{type: 'complete'}`: Waits for the latest, complete results from the server.
@@ -418,12 +419,16 @@ export interface Query<
    * `Query` implements `PromiseLike`, and calling `then` on it will invoke `run`
    * with the default behavior (`unknown`).
    *
-   * @param options Options to control the result type. Defaults to `{type: 'unknown'}`.
+   * @param options Options to control the result type.
+   * @param options.type The type of result to return.
+   * @param options.ttl Time To Live. This is the amount of time to keep the rows
+   *                  associated with this query after {@linkcode cleanup} has
+   *                  been called.
    * @returns A promise resolving to the query result.
    *
    * @example
    * ```js
-   * const result = await query.run({type: 'complete'});
+   * const result = await query.run({type: 'complete', ttl: '1m'});
    * ```
    */
   run(options?: RunOptions): Promise<HumanReadable<TReturn>>;
@@ -476,9 +481,13 @@ export type HumanReadableRecursive<T> = undefined extends T
  * this query you can preload it before calling run. See {@link preload}.
  *
  * By default, `run` uses `{type: 'unknown'}` to avoid waiting for the server.
+ *
+ * The `ttl` option is used to specify the time to live for the query. This is the amount of
+ * time to keep the rows associated with this query after {@linkcode cleanup} has been called.
  */
 export type RunOptions = {
   type: 'unknown' | 'complete';
+  ttl?: TTL;
 };
 
 export const DEFAULT_RUN_OPTIONS_UNKNOWN = {


### PR DESCRIPTION
This exposes TTL to `.run()`:

```tsx
zero.query.example
.where("slug", "=", params.exampleSlug)
.one()
.run({type:"complete", ttl: "1m"})
```

Related discord thread: https://discord.com/channels/830183651022471199/1391413459538673856