### PR TITLE
chore(zero): Add metrics for client side update to query

### DIFF
--- a/packages/analyze-query/src/bin-analyze.ts
+++ b/packages/analyze-query/src/bin-analyze.ts
@@ -39,9 +39,7 @@ import {
   serverToClient,
 } from '../../zero-schema/src/name-mapper.ts';
 import {buildPipeline} from '../../zql/src/builder/builder.ts';
-import type {FilterInput} from '../../zql/src/ivm/filter-operators.ts';
 import {MemoryStorage} from '../../zql/src/ivm/memory-storage.ts';
-import type {Input} from '../../zql/src/ivm/operator.ts';
 import type {QueryDelegate} from '../../zql/src/query/query-delegate.ts';
 import {completedAST, newQuery} from '../../zql/src/query/query-impl.ts';
 import {type PullRow, type Query} from '../../zql/src/query/query.ts';
@@ -241,12 +239,9 @@ const host: QueryDelegate = {
     // TODO: table storage!!
     return new MemoryStorage();
   },
-  decorateInput(input: Input): Input {
-    return input;
-  },
-  decorateFilterInput(input: FilterInput): FilterInput {
-    return input;
-  },
+  decorateInput: input => input,
+  decorateSourceInput: input => input,
+  decorateFilterInput: input => input,
   addServerQuery() {
     return () => {};
   },
@@ -310,7 +305,7 @@ async function runAst(
   }
 
   const tableSpecs = computeZqlSpecs(lc, db);
-  const pipeline = buildPipeline(ast, host);
+  const pipeline = buildPipeline(ast, host, 'query-id');
 
   const start = performance.now();
 

--- a/packages/zero-cache/bench/benchmark.ts
+++ b/packages/zero-cache/bench/benchmark.ts
@@ -3,9 +3,7 @@
 import {testLogConfig} from '../../otel/src/test-log-config.ts';
 import {assert} from '../../shared/src/asserts.ts';
 import {createSilentLogContext} from '../../shared/src/logging-test-utils.ts';
-import type {FilterInput} from '../../zql/src/ivm/filter-operators.ts';
 import {MemoryStorage} from '../../zql/src/ivm/memory-storage.ts';
-import type {Input} from '../../zql/src/ivm/operator.ts';
 import type {Source} from '../../zql/src/ivm/source.ts';
 import type {QueryDelegate} from '../../zql/src/query/query-delegate.ts';
 import {newQuery} from '../../zql/src/query/query-impl.ts';
@@ -59,12 +57,9 @@ export function bench(opts: Options) {
       // TODO: table storage!!
       return new MemoryStorage();
     },
-    decorateInput(input: Input): Input {
-      return input;
-    },
-    decorateFilterInput(input: FilterInput): FilterInput {
-      return input;
-    },
+    decorateInput: input => input,
+    decorateSourceInput: input => input,
+    decorateFilterInput: input => input,
     addServerQuery() {
       return () => {};
     },

--- a/packages/zero-cache/src/auth/read-authorizer.query.test.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.query.test.ts
@@ -517,6 +517,7 @@ beforeEach(() => {
     },
     decorateInput: input => input,
     decorateFilterInput: input => input,
+    decorateSourceInput: input => input,
     addServerQuery() {
       return () => {};
     },
@@ -928,7 +929,7 @@ function runReadQueryWithPermissions(
       preMutationRow: undefined,
     },
   );
-  const pipeline = buildPipeline(updatedAst, queryDelegate);
+  const pipeline = buildPipeline(updatedAst, queryDelegate, 'query-id');
   const out = new Catch(pipeline);
   return out.fetch({});
 }

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -268,12 +268,17 @@ export class PipelineDriver {
       this.#lc.info?.(`query ${hash} already added`, query);
       return;
     }
-    const input = buildPipeline(query, {
-      getSource: name => this.#getSource(name),
-      createStorage: () => this.#createStorage(),
-      decorateInput: input => input,
-      decorateFilterInput: input => input,
-    });
+    const input = buildPipeline(
+      query,
+      {
+        getSource: name => this.#getSource(name),
+        createStorage: () => this.#createStorage(),
+        decorateSourceInput: input => input,
+        decorateInput: input => input,
+        decorateFilterInput: input => input,
+      },
+      hash,
+    );
     const schema = input.getSchema();
     input.setOutput({
       push: change => {

--- a/packages/zero-client/src/client/context.ts
+++ b/packages/zero-client/src/client/context.ts
@@ -6,7 +6,7 @@ import {ErrorKind} from '../../../zero-protocol/src/error-kind.ts';
 import type {FilterInput} from '../../../zql/src/ivm/filter-operators.ts';
 import {MemoryStorage} from '../../../zql/src/ivm/memory-storage.ts';
 import type {Input, Storage} from '../../../zql/src/ivm/operator.ts';
-import type {Source} from '../../../zql/src/ivm/source.ts';
+import type {Source, SourceInput} from '../../../zql/src/ivm/source.ts';
 import type {MetricsDelegate} from '../../../zql/src/query/metrics-delegate.ts';
 import type {
   CommitListener,
@@ -14,6 +14,7 @@ import type {
 } from '../../../zql/src/query/query-delegate.ts';
 import type {RunOptions} from '../../../zql/src/query/query.ts';
 import {type IVMSourceBranch} from './ivm-branch.ts';
+import {MeasurePushOperator} from './measure-push-operator.ts';
 import type {QueryManager} from './query-manager.ts';
 import type {ZeroLogContext} from './zero-log-context.ts';
 
@@ -96,6 +97,10 @@ export class ZeroContext implements QueryDelegate {
 
   decorateFilterInput(input: FilterInput): FilterInput {
     return input;
+  }
+
+  decorateSourceInput(input: SourceInput, queryID: string): Input {
+    return new MeasurePushOperator(input, queryID, this);
   }
 
   onTransactionCommit(cb: CommitListener): () => void {

--- a/packages/zero-client/src/client/inspector/inspector.ts
+++ b/packages/zero-client/src/client/inspector/inspector.ts
@@ -28,6 +28,7 @@ import type {
   InspectUpMessage,
 } from '../../../../zero-protocol/src/inspect-up.ts';
 import type {Schema} from '../../../../zero-schema/src/builder/schema-builder.ts';
+import type {MetricMap} from '../../../../zql/src/query/metrics-delegate.ts';
 import {normalizeTTL, type TTL} from '../../../../zql/src/query/ttl.ts';
 import {nanoid} from '../../util/nanoid.ts';
 import {ENTITIES_KEY_PREFIX} from '../keys.ts';
@@ -44,8 +45,7 @@ type Rep = ReplicacheImpl<MutatorDefs>;
 type GetWebSocket = () => Promise<WebSocket>;
 
 type Metrics = {
-  readonly 'query-materialization-client': ReadonlyTDigest;
-  readonly 'query-materialization-end-to-end': ReadonlyTDigest;
+  readonly [K in keyof MetricMap]: ReadonlyTDigest;
 };
 
 export interface InspectorMetricsDelegate {

--- a/packages/zero-client/src/client/inspector/types.ts
+++ b/packages/zero-client/src/client/inspector/types.ts
@@ -11,6 +11,7 @@ export interface GetInspector {
 export type Metrics = {
   'query-materialization-client': ReadonlyTDigest;
   'query-materialization-end-to-end': ReadonlyTDigest;
+  'query-update-client': ReadonlyTDigest;
 };
 
 export interface Inspector {

--- a/packages/zero-client/src/client/measure-push-operator.test.ts
+++ b/packages/zero-client/src/client/measure-push-operator.test.ts
@@ -1,0 +1,187 @@
+import {describe, expect, test, vi} from 'vitest';
+import type {Change} from '../../../zql/src/ivm/change.ts';
+import type {Node} from '../../../zql/src/ivm/data.ts';
+import type {
+  FetchRequest,
+  Input,
+  Output,
+} from '../../../zql/src/ivm/operator.ts';
+import type {SourceSchema} from '../../../zql/src/ivm/schema.ts';
+import type {MetricsDelegate} from '../../../zql/src/query/metrics-delegate.ts';
+import {MeasurePushOperator} from './measure-push-operator.ts';
+
+describe('MeasurePushOperator', () => {
+  test('should pass through fetch calls', () => {
+    const mockInput: Input = {
+      setOutput: vi.fn(),
+      fetch: vi.fn(() => []),
+      cleanup: vi.fn(() => []),
+      getSchema: vi.fn(() => ({}) as SourceSchema),
+      destroy: vi.fn(),
+    };
+
+    const mockMetricsDelegate: MetricsDelegate = {
+      addMetric: vi.fn(),
+    };
+
+    const measurePushOperator = new MeasurePushOperator(
+      mockInput,
+      'test-query-id',
+      mockMetricsDelegate,
+    );
+    const req = {} as FetchRequest;
+
+    measurePushOperator.fetch(req);
+
+    expect(mockInput.fetch).toHaveBeenCalledWith(req);
+  });
+
+  test('should pass through cleanup calls', () => {
+    const mockInput: Input = {
+      setOutput: vi.fn(),
+      fetch: vi.fn(() => []),
+      cleanup: vi.fn(() => []),
+      getSchema: vi.fn(() => ({}) as SourceSchema),
+      destroy: vi.fn(),
+    };
+
+    const mockMetricsDelegate: MetricsDelegate = {
+      addMetric: vi.fn(),
+    };
+
+    const measurePushOperator = new MeasurePushOperator(
+      mockInput,
+      'test-query-id',
+      mockMetricsDelegate,
+    );
+    const req = {} as FetchRequest;
+
+    measurePushOperator.cleanup(req);
+
+    expect(mockInput.cleanup).toHaveBeenCalledWith(req);
+  });
+
+  test('should pass through getSchema calls', () => {
+    const schema = {} as SourceSchema;
+    const mockInput: Input = {
+      setOutput: vi.fn(),
+      fetch: vi.fn(() => []),
+      cleanup: vi.fn(() => []),
+      getSchema: vi.fn(() => schema),
+      destroy: vi.fn(),
+    };
+
+    const mockMetricsDelegate: MetricsDelegate = {
+      addMetric: vi.fn(),
+    };
+
+    const measurePushOperator = new MeasurePushOperator(
+      mockInput,
+      'test-query-id',
+      mockMetricsDelegate,
+    );
+
+    const result = measurePushOperator.getSchema();
+
+    expect(result).toBe(schema);
+    expect(mockInput.getSchema).toHaveBeenCalled();
+  });
+
+  test('should pass through destroy calls', () => {
+    const mockInput: Input = {
+      setOutput: vi.fn(),
+      fetch: vi.fn(() => []),
+      cleanup: vi.fn(() => []),
+      getSchema: vi.fn(() => ({}) as SourceSchema),
+      destroy: vi.fn(),
+    };
+
+    const mockMetricsDelegate: MetricsDelegate = {
+      addMetric: vi.fn(),
+    };
+
+    const measurePushOperator = new MeasurePushOperator(
+      mockInput,
+      'test-query-id',
+      mockMetricsDelegate,
+    );
+
+    measurePushOperator.destroy();
+
+    expect(mockInput.destroy).toHaveBeenCalled();
+  });
+
+  test('should measure push timing and record metric', () => {
+    const mockInput: Input = {
+      setOutput: vi.fn(),
+      fetch: vi.fn(() => []),
+      cleanup: vi.fn(() => []),
+      getSchema: vi.fn(() => ({}) as SourceSchema),
+      destroy: vi.fn(),
+    };
+
+    const mockOutput: Output = {
+      push: vi.fn(),
+    };
+
+    const mockMetricsDelegate: MetricsDelegate = {
+      addMetric: vi.fn(),
+    };
+
+    const measurePushOperator = new MeasurePushOperator(
+      mockInput,
+      'test-query-id',
+      mockMetricsDelegate,
+    );
+    measurePushOperator.setOutput(mockOutput);
+
+    const change: Change = {
+      type: 'add',
+      node: {} as Node,
+    };
+
+    measurePushOperator.push(change);
+
+    expect(mockOutput.push).toHaveBeenCalledWith(change);
+    expect(mockMetricsDelegate.addMetric).toHaveBeenCalledWith(
+      'query-update-client',
+      expect.any(Number),
+      'test-query-id',
+    );
+  });
+
+  test('should not record metric when output.push throws', () => {
+    const mockInput: Input = {
+      setOutput: vi.fn(),
+      fetch: vi.fn(() => []),
+      cleanup: vi.fn(() => []),
+      getSchema: vi.fn(() => ({}) as SourceSchema),
+      destroy: vi.fn(),
+    };
+
+    const mockOutput: Output = {
+      push: vi.fn(() => {
+        throw new Error('Test error');
+      }),
+    };
+
+    const mockMetricsDelegate: MetricsDelegate = {
+      addMetric: vi.fn(),
+    };
+
+    const measurePushOperator = new MeasurePushOperator(
+      mockInput,
+      'test-query-id',
+      mockMetricsDelegate,
+    );
+    measurePushOperator.setOutput(mockOutput);
+
+    const change: Change = {
+      type: 'add',
+      node: {} as Node,
+    };
+
+    expect(() => measurePushOperator.push(change)).toThrow('Test error');
+    expect(mockMetricsDelegate.addMetric).not.toHaveBeenCalled();
+  });
+});

--- a/packages/zero-client/src/client/measure-push-operator.ts
+++ b/packages/zero-client/src/client/measure-push-operator.ts
@@ -1,0 +1,57 @@
+import type {Change} from '../../../zql/src/ivm/change.ts';
+import type {Node} from '../../../zql/src/ivm/data.ts';
+import {
+  throwOutput,
+  type FetchRequest,
+  type Input,
+  type Operator,
+  type Output,
+} from '../../../zql/src/ivm/operator.ts';
+import type {SourceSchema} from '../../../zql/src/ivm/schema.ts';
+import type {Stream} from '../../../zql/src/ivm/stream.ts';
+import type {MetricsDelegate} from '../../../zql/src/query/metrics-delegate.ts';
+
+export class MeasurePushOperator implements Operator {
+  readonly #input: Input;
+  readonly #queryID: string;
+  readonly #metricsDelegate: MetricsDelegate;
+
+  #output: Output = throwOutput;
+
+  constructor(input: Input, queryID: string, metricsDelegate: MetricsDelegate) {
+    this.#input = input;
+    this.#queryID = queryID;
+    this.#metricsDelegate = metricsDelegate;
+    input.setOutput(this);
+  }
+
+  setOutput(output: Output): void {
+    this.#output = output;
+  }
+
+  fetch(req: FetchRequest): Stream<Node> {
+    return this.#input.fetch(req);
+  }
+
+  cleanup(req: FetchRequest): Stream<Node> {
+    return this.#input.cleanup(req);
+  }
+
+  getSchema(): SourceSchema {
+    return this.#input.getSchema();
+  }
+
+  destroy(): void {
+    this.#input.destroy();
+  }
+
+  push(change: Change): void {
+    const startTime = performance.now();
+    this.#output.push(change);
+    this.#metricsDelegate.addMetric(
+      'query-update-client',
+      performance.now() - startTime,
+      this.#queryID,
+    );
+  }
+}

--- a/packages/zero-client/src/client/query-manager.ts
+++ b/packages/zero-client/src/client/query-manager.ts
@@ -69,6 +69,7 @@ export class QueryManager implements InspectorMetricsDelegate {
   readonly #metrics: Metric = {
     'query-materialization-client': new TDigest(),
     'query-materialization-end-to-end': new TDigest(),
+    'query-update-client': new TDigest(),
   };
   readonly #queryMetrics: Map<string, Metric> = new Map();
   readonly #slowMaterializeThreshold: number;
@@ -394,6 +395,10 @@ export class QueryManager implements InspectorMetricsDelegate {
     value: number,
     ...args: MetricMap[K]
   ): void {
+    // Only query metrics are tracked at this point.
+    // If this check fails then we need to add a runtime check.
+    metric satisfies `query-${string}`;
+
     // We track all materializations of queries as well as per
     // query materializations.
     this.#metrics[metric].add(value);
@@ -430,6 +435,7 @@ export class QueryManager implements InspectorMetricsDelegate {
       existing = {
         'query-materialization-client': new TDigest(),
         'query-materialization-end-to-end': new TDigest(),
+        'query-update-client': new TDigest(),
       };
       this.#queryMetrics.set(queryID, existing);
     }

--- a/packages/zero-client/src/client/query-manager.ts
+++ b/packages/zero-client/src/client/query-manager.ts
@@ -66,11 +66,7 @@ export class QueryManager implements InspectorMetricsDelegate {
   #pendingRemovals: Array<() => void> = [];
   #batchTimer: ReturnType<typeof setTimeout> | undefined;
   readonly #lc: ZeroLogContext;
-  readonly #metrics: Metric = {
-    'query-materialization-client': new TDigest(),
-    'query-materialization-end-to-end': new TDigest(),
-    'query-update-client': new TDigest(),
-  };
+  readonly #metrics: Metric = newMetrics();
   readonly #queryMetrics: Map<string, Metric> = new Map();
   readonly #slowMaterializeThreshold: number;
 
@@ -432,11 +428,7 @@ export class QueryManager implements InspectorMetricsDelegate {
     // The query manager manages metrics that are per query.
     let existing = this.#queryMetrics.get(queryID);
     if (!existing) {
-      existing = {
-        'query-materialization-client': new TDigest(),
-        'query-materialization-end-to-end': new TDigest(),
-        'query-update-client': new TDigest(),
-      };
+      existing = newMetrics();
       this.#queryMetrics.set(queryID, existing);
     }
     existing[metric].add(value);
@@ -445,4 +437,12 @@ export class QueryManager implements InspectorMetricsDelegate {
   getQueryMetrics(queryID: string): Metric | undefined {
     return this.#queryMetrics.get(queryID);
   }
+}
+
+function newMetrics(): Metric {
+  return {
+    'query-materialization-client': new TDigest(),
+    'query-materialization-end-to-end': new TDigest(),
+    'query-update-client': new TDigest(),
+  };
 }

--- a/packages/zql/src/builder/builder.test.ts
+++ b/packages/zql/src/builder/builder.test.ts
@@ -1,4 +1,6 @@
 import {expect, test} from 'vitest';
+import {testLogConfig} from '../../../otel/src/test-log-config.ts';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
 import type {AST, Disjunction} from '../../../zero-protocol/src/ast.ts';
 import {Catch} from '../ivm/catch.ts';
 import {createSource} from '../ivm/test/source-factory.ts';
@@ -7,8 +9,6 @@ import {
   buildPipeline,
   groupSubqueryConditions,
 } from './builder.ts';
-import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
-import {testLogConfig} from '../../../otel/src/test-log-config.ts';
 import {TestBuilderDelegate} from './test-builder-delegate.ts';
 
 const lc = createSilentLogContext();
@@ -78,6 +78,7 @@ test('source-only', () => {
         ],
       },
       delegate,
+      'query-id',
     ),
   );
 
@@ -180,6 +181,7 @@ test('filter', () => {
         },
       },
       delegate,
+      'query-id',
     ),
   );
 
@@ -277,6 +279,7 @@ test('self-join', () => {
         ],
       },
       delegate,
+      'query-id',
     ),
   );
 
@@ -576,6 +579,7 @@ test('self-join edit', () => {
         limit: 3,
       },
       delegate,
+      'query-id',
     ),
   );
 
@@ -790,6 +794,7 @@ test('multi-join', () => {
         ],
       },
       delegate,
+      'query-id',
     ),
   );
 
@@ -955,6 +960,7 @@ test('join with limit', () => {
         ],
       },
       delegate,
+      'query-id',
     ),
   );
 
@@ -1075,6 +1081,7 @@ test('skip', () => {
         start: {row: {id: 3}, exclusive: true},
       },
       delegate,
+      'query-id',
     ),
   );
 
@@ -1174,6 +1181,7 @@ test('exists junction', () => {
         },
       },
       delegate,
+      'query-id',
     ),
   );
 
@@ -1384,6 +1392,7 @@ test('duplicative exists junction', () => {
         },
       },
       delegate,
+      'query-id',
     ),
   );
 
@@ -1583,6 +1592,7 @@ test('exists junction with limit, remove row after limit, and last row', () => {
         },
       },
       delegate,
+      'query-id',
     ),
   );
 
@@ -1701,6 +1711,7 @@ test('exists self join', () => {
         limit: 2,
       },
       delegate,
+      'query-id',
     ),
   );
 
@@ -1878,6 +1889,7 @@ test('not exists self join', () => {
         },
       },
       delegate,
+      'query-id',
     ),
   );
 
@@ -2043,6 +2055,7 @@ test('empty or - nothing goes through', () => {
         },
       },
       delegate,
+      'query-id',
     ),
   );
 
@@ -2065,6 +2078,7 @@ test('empty and - everything goes through', () => {
         },
       },
       delegate,
+      'query-id',
     ),
   );
 
@@ -2108,6 +2122,7 @@ test('always false literal comparison - nothing goes through', () => {
         },
       },
       delegate,
+      'query-id',
     ),
   );
 
@@ -2138,6 +2153,7 @@ test('always true literal comparison - everything goes through', () => {
         },
       },
       delegate,
+      'query-id',
     ),
   );
 

--- a/packages/zql/src/builder/test-builder-delegate.ts
+++ b/packages/zql/src/builder/test-builder-delegate.ts
@@ -3,9 +3,9 @@ import type {JSONObject} from '../../../shared/src/json.ts';
 import type {AST} from '../../../zero-protocol/src/ast.ts';
 import type {FilterInput} from '../ivm/filter-operators.ts';
 import {MemoryStorage} from '../ivm/memory-storage.ts';
-import type {Storage, Input} from '../ivm/operator.ts';
+import type {Input, Storage} from '../ivm/operator.ts';
 import {FilterSnitch, Snitch, type SnitchMessage} from '../ivm/snitch.ts';
-import type {Source} from '../ivm/source.ts';
+import type {Source, SourceInput} from '../ivm/source.ts';
 import type {BuilderDelegate} from './builder.ts';
 
 export class TestBuilderDelegate implements BuilderDelegate {
@@ -53,6 +53,10 @@ export class TestBuilderDelegate implements BuilderDelegate {
       return input;
     }
     return new FilterSnitch(input, name, this.#log);
+  }
+
+  decorateSourceInput(input: SourceInput): Input {
+    return input;
   }
 
   clearLog() {

--- a/packages/zql/src/ivm/operator.ts
+++ b/packages/zql/src/ivm/operator.ts
@@ -2,7 +2,7 @@ import type {JSONValue} from '../../../shared/src/json.ts';
 import type {Row} from '../../../zero-protocol/src/data.ts';
 import type {Change} from './change.ts';
 import type {Constraint} from './constraint.ts';
-import {type Node} from './data.ts';
+import type {Node} from './data.ts';
 import type {SourceSchema} from './schema.ts';
 import type {Stream} from './stream.ts';
 

--- a/packages/zql/src/ivm/test/push-tests.ts
+++ b/packages/zql/src/ivm/test/push-tests.ts
@@ -67,7 +67,7 @@ export function runPushTest(t: PushTest) {
     );
 
     const builderDelegate = new TestBuilderDelegate(sources, true);
-    const pipeline = buildPipeline(t.ast, builderDelegate);
+    const pipeline = buildPipeline(t.ast, builderDelegate, 'query-id');
 
     const finalOutput = makeFinalOutput(pipeline);
 

--- a/packages/zql/src/query/metrics-delegate.ts
+++ b/packages/zql/src/query/metrics-delegate.ts
@@ -3,6 +3,7 @@ import type {AST} from '../../../zero-protocol/src/ast.ts';
 export type MetricMap = {
   'query-materialization-client': [queryID: string];
   'query-materialization-end-to-end': [queryID: string, ast: AST];
+  'query-update-client': [queryID: string];
 };
 
 export interface MetricsDelegate {

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -780,7 +780,7 @@ export class QueryImpl<
       ? delegate.addCustomQuery(this.customQueryID, ttl, gotCallback)
       : delegate.addServerQuery(ast, ttl, gotCallback);
 
-    const input = buildPipeline(ast, delegate);
+    const input = buildPipeline(ast, delegate, queryID);
 
     const view = delegate.batchViewUpdates(() =>
       (factory ?? arrayViewFactory)(

--- a/packages/zql/src/query/test/query-delegate.ts
+++ b/packages/zql/src/query/test/query-delegate.ts
@@ -9,7 +9,7 @@ import type {AST} from '../../../../zero-protocol/src/ast.ts';
 import type {FilterInput} from '../../ivm/filter-operators.ts';
 import {MemoryStorage} from '../../ivm/memory-storage.ts';
 import type {Input} from '../../ivm/operator.ts';
-import type {Source} from '../../ivm/source.ts';
+import type {Source, SourceInput} from '../../ivm/source.ts';
 import {createSource} from '../../ivm/test/source-factory.ts';
 import type {CustomQueryID} from '../named.ts';
 import type {
@@ -140,6 +140,10 @@ export class QueryDelegateImpl implements QueryDelegate {
 
   createStorage() {
     return new MemoryStorage();
+  }
+
+  decorateSourceInput(input: SourceInput): Input {
+    return input;
   }
 
   decorateInput(input: Input, _description: string): Input {

--- a/packages/zqlite/src/query-delegate.ts
+++ b/packages/zqlite/src/query-delegate.ts
@@ -1,10 +1,11 @@
 import type {LogContext} from '@rocicorp/logger';
 import type {LogConfig} from '../../otel/src/log-options.ts';
+import type {AST} from '../../zero-protocol/src/ast.ts';
 import type {Schema} from '../../zero-schema/src/builder/schema-builder.ts';
 import type {FilterInput} from '../../zql/src/ivm/filter-operators.ts';
 import {MemoryStorage} from '../../zql/src/ivm/memory-storage.ts';
 import type {Input} from '../../zql/src/ivm/operator.ts';
-import type {Source} from '../../zql/src/ivm/source.ts';
+import type {Source, SourceInput} from '../../zql/src/ivm/source.ts';
 import type {
   CommitListener,
   QueryDelegate,
@@ -40,6 +41,8 @@ export class QueryDelegateImpl implements QueryDelegate {
     };
   }
 
+  mapAst?: ((ast: AST) => AST) | undefined;
+
   getSource(tableName: string): Source {
     let source = this.#sources.get(tableName);
     if (source) {
@@ -65,18 +68,27 @@ export class QueryDelegateImpl implements QueryDelegate {
   createStorage() {
     return new MemoryStorage();
   }
+
+  decorateSourceInput(input: SourceInput): Input {
+    return input;
+  }
+
   decorateInput(input: Input): Input {
     return input;
   }
+
   decorateFilterInput(input: FilterInput): FilterInput {
     return input;
   }
+
   addServerQuery() {
     return () => {};
   }
+
   addCustomQuery() {
     return () => {};
   }
+
   updateServerQuery() {}
   updateCustomQuery() {}
   flushQueryChanges() {}

--- a/packages/zqlite/src/query-delegate.ts
+++ b/packages/zqlite/src/query-delegate.ts
@@ -1,6 +1,5 @@
 import type {LogContext} from '@rocicorp/logger';
 import type {LogConfig} from '../../otel/src/log-options.ts';
-import type {AST} from '../../zero-protocol/src/ast.ts';
 import type {Schema} from '../../zero-schema/src/builder/schema-builder.ts';
 import type {FilterInput} from '../../zql/src/ivm/filter-operators.ts';
 import {MemoryStorage} from '../../zql/src/ivm/memory-storage.ts';
@@ -40,8 +39,6 @@ export class QueryDelegateImpl implements QueryDelegate {
       slowRowThreshold: 0,
     };
   }
-
-  mapAst?: ((ast: AST) => AST) | undefined;
 
   getSource(tableName: string): Source {
     let source = this.#sources.get(tableName);

--- a/packages/zqlite/src/test/source-factory.ts
+++ b/packages/zqlite/src/test/source-factory.ts
@@ -16,7 +16,7 @@ import type {SchemaValue} from '../../../zero-schema/src/table-schema.ts';
 import type {FilterInput} from '../../../zql/src/ivm/filter-operators.ts';
 import {MemoryStorage} from '../../../zql/src/ivm/memory-storage.ts';
 import type {Input} from '../../../zql/src/ivm/operator.ts';
-import type {Source} from '../../../zql/src/ivm/source.ts';
+import type {Source, SourceInput} from '../../../zql/src/ivm/source.ts';
 import type {SourceFactory} from '../../../zql/src/ivm/test/source-factory.ts';
 import type {QueryDelegate} from '../../../zql/src/query/query-delegate.ts';
 import {Database} from '../db.ts';
@@ -164,6 +164,9 @@ export function newQueryDelegate(
 
     createStorage() {
       return new MemoryStorage();
+    },
+    decorateSourceInput(input: SourceInput): Input {
+      return input;
     },
     decorateInput(input: Input): Input {
       return input;


### PR DESCRIPTION
# Add Client-Side Query Update Time Metrics

## Summary
This PR adds metrics tracking for query update performance on the client side by measuring how long individual query updates take to propagate through the IVM pipeline.

## Problem
We could measure query materialization time but lacked visibility into query update performance, making it difficult to identify bottlenecks in the update pipeline.

## Solution
- **New `MeasurePushOperator`**: Wraps push operations to measure execution time and record `query-update-client` metrics
- **Enhanced `QueryDelegate`**: Added `decorateSourceInput` method to enable measurement decoration
- **Updated `buildPipeline`**: Now requires `queryID` parameter for proper query identification

## Inspector Integration
Metrics are exposed through existing inspector infrastructure via `getMetrics()` and `getQueryMetrics(queryID)`.
