### PR TITLE
fix(zero-client): Queries containing non-latin queries break startup.

### DIFF
--- a/apps/zbugs/shared/queries.ts
+++ b/apps/zbugs/shared/queries.ts
@@ -96,7 +96,10 @@ export const prevNext = namedQuery(
   'prevNext',
   (
     listContext: ListContext['params'] | null,
-    issue: Row<Schema['tables']['issue']> | null,
+    issue: Pick<
+      Row<Schema['tables']['issue']>,
+      'id' | 'created' | 'modified'
+    > | null,
     dir: 'next' | 'prev',
   ) => buildListQuery(listContext, issue, dir).one(),
 );
@@ -112,7 +115,10 @@ export const issueList = namedQuery(
 
 function buildListQuery(
   listContext: ListContext['params'] | null,
-  start: Row<Schema['tables']['issue']> | null,
+  start: Pick<
+    Row<Schema['tables']['issue']>,
+    'id' | 'created' | 'modified'
+  > | null,
   dir: 'next' | 'prev',
 ) {
   if (!listContext) {

--- a/apps/zbugs/src/pages/issue/issue-page.tsx
+++ b/apps/zbugs/src/pages/issue/issue-page.tsx
@@ -201,8 +201,16 @@ export function IssuePage({onReady}: {onReady: () => void}) {
   const useQueryOptions = {
     enabled: listContext !== undefined && issueSnapshot !== undefined,
   } as const;
+  // Don't need to send entire issue to server, just the sort columns plus PK.
+  const start = displayed
+    ? {
+        id: displayed.id,
+        created: displayed.created,
+        modified: displayed.modified,
+      }
+    : null;
   const [next] = useQuery(
-    prevNext(listContext?.params ?? null, displayed ?? null, 'next'),
+    prevNext(listContext?.params ?? null, start, 'next'),
     useQueryOptions,
   );
   useKeypress('j', () => {
@@ -212,7 +220,7 @@ export function IssuePage({onReady}: {onReady: () => void}) {
   });
 
   const [prev] = useQuery(
-    prevNext(listContext?.params ?? null, displayed ?? null, 'prev'),
+    prevNext(listContext?.params ?? null, start, 'prev'),
     useQueryOptions,
   );
   useKeypress('k', () => {

--- a/packages/zero-protocol/src/connect.test.ts
+++ b/packages/zero-protocol/src/connect.test.ts
@@ -16,6 +16,7 @@ test('encode/decodeSecProtocols round-trip', () => {
                     {
                       op: fc.constant<'put'>('put'),
                       hash: fc.string(),
+                      data: fc.fullUnicodeString(),
                       ast: fc.constant({
                         table: 'table',
                       }),


### PR DESCRIPTION
Fixes https://bugs.rocicorp.dev/issue/4008

We encode queries registered early in startup in the sec protocols and they have to be URL-encoded. To save space we also base64 encode, but btoa doesn't support non-latin chars.

Queries can contain any arbitrary string so that means we need to encode these non-latin chars. So add another layer of encoding!