### PR TITLE
fix(zero): fix race with mutation resolution

### DIFF
--- a/packages/zero-client/src/client/custom.test.ts
+++ b/packages/zero-client/src/client/custom.test.ts
@@ -523,6 +523,18 @@ describe('server results and keeping read queries', () => {
       ],
     });
 
+    // confirm the mutation
+    await z.triggerPokeStart({
+      pokeID: '1',
+      baseCookie: null,
+      schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
+    });
+    await z.triggerPokePart({
+      pokeID: '1',
+      lastMutationIDChanges: {[z.clientID]: 1},
+    });
+    await z.triggerPokeEnd({pokeID: '1', cookie: '1'});
+
     z.queryDelegate.flushQueryChanges();
 
     // mutation is no longer outstanding, query is removed.
@@ -558,6 +570,17 @@ describe('server results and keeping read queries', () => {
         },
       ],
     });
+
+    await z.triggerPokeStart({
+      pokeID: '2',
+      baseCookie: '1',
+      schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
+    });
+    await z.triggerPokePart({
+      pokeID: '2',
+      lastMutationIDChanges: {[z.clientID]: 2},
+    });
+    await z.triggerPokeEnd({pokeID: '2', cookie: '2'});
 
     z.queryDelegate.flushQueryChanges();
 

--- a/packages/zero-client/src/client/query-manager.ts
+++ b/packages/zero-client/src/client/query-manager.ts
@@ -82,7 +82,7 @@ export class QueryManager {
     this.#mutationTracker = mutationTracker;
     this.#queryChangeThrottleMs = queryChangeThrottleMs;
 
-    this.#mutationTracker.onAllMutationsConfirmed(() => {
+    this.#mutationTracker.onAllMutationsApplied(() => {
       if (this.#pendingRemovals.length === 0) {
         return;
       }

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -1373,6 +1373,7 @@ export class Zero<
   #handlePokeEnd(_lc: ZeroLogContext, pokeMessage: PokeEndMessage): void {
     this.#abortPingTimeout();
     this.#pokeHandler.handlePokeEnd(pokeMessage[1]);
+    this.#mutationTracker.lmidAdvanced(this.#lastMutationIDReceived);
   }
 
   #onPokeError(): void {


### PR DESCRIPTION
The big picture is that we should have gone with writing mutation responses to the database in the first place.

The specific problem --

A user's API server could return an error but have applied the mutations. In this case, the mutation tracker was assuming that the mutations were not applied and would wait for a retry to apply them.

The retry would never happen since the mutations were applied with the original request.

The fix is to mark error responses to pushes as being in an unknown or limbo state. When the lmid is advanced, we resolve limbo mutations whose lmid is less than or equal to the current lmid.

We do not resolve outstanding mutations on every lmid advance since we may receive the push response for those mutations. If we resolved on every lmid bump then we can miss application errors being returned in response to mutations.

The most correct fix is to write mutation responses to the DB and send them down with `poke`. This will make mutation promise resolution transactional with the syncing of the side-effects of the mutation.