### PR TITLE
chore(zero): update `named` to take an object

### DIFF
--- a/apps/zbugs/server/get-query.ts
+++ b/apps/zbugs/server/get-query.ts
@@ -1,6 +1,6 @@
 import type {NamedQuery, ReadonlyJSONValue} from '@rocicorp/zero';
 import * as serverQueries from '../server/server-queries.ts';
-import * as sharedQueries from '../shared/queries.ts';
+import {queries as sharedQueries} from '../shared/queries.ts';
 
 export function getQuery(
   context: serverQueries.ServerContext,

--- a/apps/zbugs/server/server-queries.ts
+++ b/apps/zbugs/server/server-queries.ts
@@ -2,12 +2,7 @@ import type {AnyQuery, ReadonlyJSONValue, Row} from '@rocicorp/zero';
 import type {Schema} from '../shared/schema.ts';
 import type {Role} from '../shared/auth.ts';
 import type {ListContext} from '../shared/queries.ts';
-import {
-  issuePreload as sharedIssuePreload,
-  prevNext as sharedPrevNext,
-  issueList as sharedIssueList,
-  issueDetail as sharedIssueDetail,
-} from '../shared/queries.ts';
+import {queries as sharedQueries} from '../shared/queries.ts';
 import {applyIssuePermissions} from './read-permissions.ts';
 
 export type ServerContext = {
@@ -20,7 +15,7 @@ export type ServerQuery = (
 ) => AnyQuery;
 
 export function issuePreload(c: ServerContext, userID: string) {
-  return applyIssuePermissions(sharedIssuePreload(userID), c.role);
+  return applyIssuePermissions(sharedQueries.issuePreload(userID), c.role);
 }
 
 export function prevNext(
@@ -29,7 +24,10 @@ export function prevNext(
   issue: Row<Schema['tables']['issue']> | null,
   dir: 'next' | 'prev',
 ) {
-  return applyIssuePermissions(sharedPrevNext(listContext, issue, dir), c.role);
+  return applyIssuePermissions(
+    sharedQueries.prevNext(listContext, issue, dir),
+    c.role,
+  );
 }
 
 export function issueList(
@@ -39,7 +37,7 @@ export function issueList(
   limit: number,
 ) {
   return applyIssuePermissions(
-    sharedIssueList(listContext, userID, limit),
+    sharedQueries.issueList(listContext, userID, limit),
     c.role,
   );
 }
@@ -50,5 +48,8 @@ export function issueDetail(
   id: string | number,
   userID: string,
 ) {
-  return applyIssuePermissions(sharedIssueDetail(idField, id, userID), c.role);
+  return applyIssuePermissions(
+    sharedQueries.issueDetail(idField, id, userID),
+    c.role,
+  );
 }

--- a/apps/zbugs/shared/queries.ts
+++ b/apps/zbugs/shared/queries.ts
@@ -2,36 +2,32 @@ import {escapeLike, named, type Row} from '@rocicorp/zero';
 import {builder, type Schema} from './schema.ts';
 import {INITIAL_COMMENT_LIMIT} from './consts.ts';
 
-export const allLabels = named('allLabels', () => builder.label);
-export const allUsers = named('allUsers', () => builder.user);
+export const queries = named({
+  allLabels: () => builder.label,
 
-export const issuePreload = named('issuePreload', (userID: string) =>
-  builder.issue
-    .related('labels')
-    .related('viewState', q => q.where('userID', userID))
-    .related('creator')
-    .related('assignee')
-    .related('emoji', emoji => emoji.related('creator'))
-    .related('comments', comments =>
-      comments
-        .related('creator')
-        .related('emoji', emoji => emoji.related('creator'))
-        .limit(10)
-        .orderBy('created', 'desc'),
-    ),
-);
+  allUsers: () => builder.user,
 
-export const user = named('user', (userID: string) =>
-  builder.user.where('id', userID).one(),
-);
+  issuePreload: (userID: string) =>
+    builder.issue
+      .related('labels')
+      .related('viewState', q => q.where('userID', userID))
+      .related('creator')
+      .related('assignee')
+      .related('emoji', emoji => emoji.related('creator'))
+      .related('comments', comments =>
+        comments
+          .related('creator')
+          .related('emoji', emoji => emoji.related('creator'))
+          .limit(10)
+          .orderBy('created', 'desc'),
+      ),
 
-export const userPref = named('userPref', (key: string, userID: string) =>
-  builder.userPref.where('key', key).where('userID', userID).one(),
-);
+  user: (userID: string) => builder.user.where('id', userID).one(),
 
-export const userPicker = named(
-  'userPicker',
-  (
+  userPref: (key: string, userID: string) =>
+    builder.userPref.where('key', key).where('userID', userID).one(),
+
+  userPicker: (
     disabled: boolean,
     login: string | null,
     filter: 'crew' | 'creators' | null,
@@ -52,11 +48,12 @@ export const userPicker = named(
     }
     return q;
   },
-);
 
-export const issueDetail = named(
-  'issueDetail',
-  (idField: 'shortID' | 'id', id: string | number, userID: string) =>
+  issueDetail: (
+    idField: 'shortID' | 'id',
+    id: string | number,
+    userID: string,
+  ) =>
     builder.issue
       .where(idField, id)
       .related('emoji', emoji => emoji.related('creator'))
@@ -76,7 +73,31 @@ export const issueDetail = named(
           .orderBy('id', 'desc'),
       )
       .one(),
-);
+
+  prevNext: (
+    listContext: ListContext['params'] | null,
+    issue: Pick<
+      Row<Schema['tables']['issue']>,
+      'id' | 'created' | 'modified'
+    > | null,
+    dir: 'next' | 'prev',
+  ) => buildListQuery(listContext, issue, dir).one(),
+
+  issueList: (
+    listContext: ListContext['params'],
+    userID: string,
+    limit: number,
+  ) =>
+    buildListQuery(listContext, null, 'next')
+      .limit(limit)
+      .related('viewState', q => q.where('userID', userID).one())
+      .related('labels'),
+
+  emojiChange: (subjectID: string) =>
+    builder.emoji
+      .where('subjectID', subjectID ?? '')
+      .related('creator', creator => creator.one()),
+});
 
 export type ListContext = {
   readonly href: string;
@@ -91,27 +112,6 @@ export type ListContext = {
     readonly sortDirection: 'asc' | 'desc';
   };
 };
-
-export const prevNext = named(
-  'prevNext',
-  (
-    listContext: ListContext['params'] | null,
-    issue: Pick<
-      Row<Schema['tables']['issue']>,
-      'id' | 'created' | 'modified'
-    > | null,
-    dir: 'next' | 'prev',
-  ) => buildListQuery(listContext, issue, dir).one(),
-);
-
-export const issueList = named(
-  'issueList',
-  (listContext: ListContext['params'], userID: string, limit: number) =>
-    buildListQuery(listContext, null, 'next')
-      .limit(limit)
-      .related('viewState', q => q.where('userID', userID).one())
-      .related('labels'),
-);
 
 function buildListQuery(
   listContext: ListContext['params'] | null,
@@ -165,9 +165,3 @@ function buildListQuery(
     ),
   );
 }
-
-export const emojiChange = named('emojiChange', (subjectID: string) =>
-  builder.emoji
-    .where('subjectID', subjectID ?? '')
-    .related('creator', creator => creator.one()),
-);

--- a/apps/zbugs/src/components/filter.tsx
+++ b/apps/zbugs/src/components/filter.tsx
@@ -6,7 +6,7 @@ import labelIcon from '../assets/icons/label.svg';
 import {Button} from './button.tsx';
 import {Combobox} from './combobox.tsx';
 import {UserPicker} from './user-picker.tsx';
-import {allLabels} from '../../shared/queries.ts';
+import {queries} from '../../shared/queries.ts';
 
 export type Selection =
   | {creator: string}
@@ -20,7 +20,7 @@ type Props = {
 export const Filter = memo(function Filter({onSelect}: Props) {
   const [isOpen, setIsOpen] = useState(false);
 
-  const [unsortedLabels] = useQuery(allLabels());
+  const [unsortedLabels] = useQuery(queries.allLabels());
   // TODO: Support case-insensitive sorting in ZQL.
   const labels = useMemo(
     () => toSorted(unsortedLabels, (a, b) => a.name.localeCompare(b.name)),

--- a/apps/zbugs/src/components/label-picker.tsx
+++ b/apps/zbugs/src/components/label-picker.tsx
@@ -4,7 +4,7 @@ import {useCallback, useRef, useState} from 'react';
 import {useClickOutside} from '../hooks/use-click-outside.ts';
 import {Button} from './button.tsx';
 import style from './label-picker.module.css';
-import {allLabels} from '../../shared/queries.ts';
+import {queries} from '../../shared/queries.ts';
 
 const focusInput = (input: HTMLInputElement | null) => {
   if (input) {
@@ -24,7 +24,7 @@ export function LabelPicker({
   onCreateNewLabel: (name: string) => void;
 }) {
   const [isOpen, setIsOpen] = useState(false);
-  const [labels] = useQuery(allLabels().orderBy('name', 'asc'));
+  const [labels] = useQuery(queries.allLabels().orderBy('name', 'asc'));
   const ref = useRef<HTMLDivElement>(null);
 
   useClickOutside(

--- a/apps/zbugs/src/components/nav.tsx
+++ b/apps/zbugs/src/components/nav.tsx
@@ -13,7 +13,7 @@ import {AvatarImage} from './avatar-image.tsx';
 import {ButtonWithLoginCheck} from './button-with-login-check.tsx';
 import {Button} from './button.tsx';
 import {Link} from './link.tsx';
-import {user as userQuery, type ListContext} from '../../shared/queries.ts';
+import {queries, type ListContext} from '../../shared/queries.ts';
 
 export const Nav = memo(() => {
   const search = useSearch();
@@ -25,7 +25,7 @@ export const Nav = memo(() => {
   const login = useLogin();
   const [isMobile, setIsMobile] = useState(false);
   const [showUserPanel, setShowUserPanel] = useState(false); // State to control visibility of user-panel-mobile
-  const [user] = useQuery(userQuery(login.loginState?.decoded.sub ?? ''));
+  const [user] = useQuery(queries.user(login.loginState?.decoded.sub ?? ''));
 
   const [showIssueModal, setShowIssueModal] = useState(false);
 

--- a/apps/zbugs/src/components/user-picker.tsx
+++ b/apps/zbugs/src/components/user-picker.tsx
@@ -6,7 +6,7 @@ import {type Schema} from '../../shared/schema.ts';
 import avatarIcon from '../assets/icons/avatar-default.svg';
 import {avatarURLWithSize} from '../avatar-url-with-size.ts';
 import {Combobox} from './combobox.tsx';
-import {userPicker} from '../../shared/queries.ts';
+import {queries} from '../../shared/queries.ts';
 
 type Props = {
   onSelect?: ((user: User | undefined) => void) | undefined;
@@ -30,7 +30,7 @@ export function UserPicker({
   filter = undefined,
 }: Props) {
   const [unsortedUsers] = useQuery(
-    userPicker(!!disabled, selected?.login ?? null, filter ?? null),
+    queries.userPicker(!!disabled, selected?.login ?? null, filter ?? null),
   );
   // TODO: Support case-insensitive sorting in ZQL.
   const users = useMemo(

--- a/apps/zbugs/src/hooks/use-can-edit.ts
+++ b/apps/zbugs/src/hooks/use-can-edit.ts
@@ -1,11 +1,13 @@
 import {useQuery} from '@rocicorp/zero/react';
 import {useLogin} from './use-login.tsx';
-import {user} from '../../shared/queries.ts';
+import {queries} from '../../shared/queries.ts';
 
 export function useCanEdit(ownerUserID: string | undefined): boolean {
   const login = useLogin();
   const currentUserID = login.loginState?.decoded.sub;
-  const [isCrew] = useQuery(user(currentUserID || '').where('role', 'crew'));
+  const [isCrew] = useQuery(
+    queries.user(currentUserID || '').where('role', 'crew'),
+  );
   return (
     import.meta.env.VITE_PUBLIC_SANDBOX ||
     isCrew ||

--- a/apps/zbugs/src/hooks/use-user-pref.ts
+++ b/apps/zbugs/src/hooks/use-user-pref.ts
@@ -3,11 +3,11 @@ import {useQuery} from '@rocicorp/zero/react';
 import {type Schema} from '../../shared/schema.ts';
 import {useZero} from './use-zero.ts';
 import type {Mutators} from '../../shared/mutators.ts';
-import {userPref} from '../../shared/queries.ts';
+import {queries} from '../../shared/queries.ts';
 
 export function useUserPref(key: string): string | undefined {
   const z = useZero();
-  const [pref] = useQuery(userPref(key, z.userID));
+  const [pref] = useQuery(queries.userPref(key, z.userID));
   return pref?.value;
 }
 

--- a/apps/zbugs/src/pages/issue/issue-page.tsx
+++ b/apps/zbugs/src/pages/issue/issue-page.tsx
@@ -59,9 +59,11 @@ import {links, type ZbugsHistoryState} from '../../routes.ts';
 import {CommentComposer} from './comment-composer.tsx';
 import {Comment} from './comment.tsx';
 import {isCtrlEnter} from './is-ctrl-enter.ts';
-import {emojiChange, issueDetail, prevNext} from '../../../shared/queries.ts';
+import {queries} from '../../../shared/queries.ts';
 import {INITIAL_COMMENT_LIMIT} from '../../../shared/consts.ts';
 import {preload} from '../../zero-preload.ts';
+
+const {emojiChange, issueDetail, prevNext} = queries;
 
 function softNavigate(path: string, state?: ZbugsHistoryState) {
   navigate(path, {state});

--- a/apps/zbugs/src/pages/list/list-page.tsx
+++ b/apps/zbugs/src/pages/list/list-page.tsx
@@ -27,7 +27,7 @@ import {recordPageLoad} from '../../page-load-stats.ts';
 import {mark} from '../../perf-log.ts';
 import {preload} from '../../zero-preload.ts';
 import {CACHE_AWHILE, CACHE_NONE} from '../../query-cache-policy.ts';
-import {issueList, type ListContext} from '../../../shared/queries.ts';
+import {queries, type ListContext} from '../../../shared/queries.ts';
 
 let firstRowRendered = false;
 const itemSize = 56;
@@ -60,7 +60,7 @@ export function ListPage({onReady}: {onReady: () => void}) {
 
   const pageSize = 20;
   const [limit, setLimit] = useState(pageSize);
-  const q = issueList(
+  const q = queries.issueList(
     {
       sortDirection,
       sortField,

--- a/apps/zbugs/src/zero-preload.ts
+++ b/apps/zbugs/src/zero-preload.ts
@@ -2,11 +2,11 @@ import {Zero} from '@rocicorp/zero';
 import {type Schema} from '../shared/schema.ts';
 import {type Mutators} from '../shared/mutators.ts';
 import {CACHE_FOREVER} from './query-cache-policy.ts';
-import {allLabels, allUsers, issuePreload} from '../shared/queries.ts';
+import {queries} from '../shared/queries.ts';
 
 export function preload(z: Zero<Schema, Mutators>) {
   // Preload all issues and first 10 comments from each.
-  z.preload(issuePreload(z.userID), CACHE_FOREVER);
-  z.preload(allUsers(), CACHE_FOREVER);
-  z.preload(allLabels(), CACHE_FOREVER);
+  z.preload(queries.issuePreload(z.userID), CACHE_FOREVER);
+  z.preload(queries.allUsers(), CACHE_FOREVER);
+  z.preload(queries.allLabels(), CACHE_FOREVER);
 }


### PR DESCRIPTION
To reduce repetition of a query's name.

Before:
```ts
export const foo = named('foo', () => ...)
```
after:
```ts
export queries = named({
  foo: () => ...
});
```