### PR TITLE
chore(zero): allow an array of urls for query/mutate

### DIFF
--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -42,10 +42,15 @@ test('zero-cache --help', () => {
                                                                  Note that this number must allow for at least one connection per                                  
                                                                  sync worker, or zero-cache will fail to start. See num-sync-workers                               
                                                                                                                                                                    
-     --push-url string                                           optional                                                                                          
+     --push-url string[]                                         optional                                                                                          
        ZERO_PUSH_URL env                                                                                                                                           
                                                                  DEPRECATED. Use query_url instead.                                                                
                                                                  The URL of the API server to which zero-cache will push mutations.                                
+                                                                                                                                                                   
+                                                                 * is allowed if you would like to allow the client to specify a subdomain to use.                 
+                                                                 e.g., *.example.com/api/mutate                                                                    
+                                                                 You can specify multiple URLs as well which the client can choose from.                           
+                                                                 e.g., ["https://api1.example.com/mutate", "https://api2.example.com/mutate"]                      
                                                                                                                                                                    
      --push-api-key string                                       optional                                                                                          
        ZERO_PUSH_API_KEY env                                                                                                                                       
@@ -57,10 +62,15 @@ test('zero-cache --help', () => {
                                                                  This is useful for passing authentication cookies to the API server.                              
                                                                  If false, cookies are not forwarded.                                                              
                                                                                                                                                                    
-     --mutate-url string                                         optional                                                                                          
+     --mutate-url string[]                                       optional                                                                                          
        ZERO_MUTATE_URL env                                                                                                                                         
                                                                                                                                                                    
                                                                  The URL of the API server to which zero-cache will push mutations.                                
+                                                                                                                                                                   
+                                                                 * is allowed if you would like to allow the client to specify a subdomain to use.                 
+                                                                 e.g., *.example.com/api/mutate                                                                    
+                                                                 You can specify multiple URLs as well which the client can choose from.                           
+                                                                 e.g., ["https://api1.example.com/mutate", "https://api2.example.com/mutate"]                      
                                                                                                                                                                    
      --mutate-api-key string                                     optional                                                                                          
        ZERO_MUTATE_API_KEY env                                                                                                                                     
@@ -72,10 +82,15 @@ test('zero-cache --help', () => {
                                                                  This is useful for passing authentication cookies to the API server.                              
                                                                  If false, cookies are not forwarded.                                                              
                                                                                                                                                                    
-     --query-url string                                          optional                                                                                          
+     --query-url string[]                                        optional                                                                                          
        ZERO_QUERY_URL env                                                                                                                                          
                                                                                                                                                                    
                                                                  The URL of the API server to which zero-cache will send named queries.                            
+                                                                                                                                                                   
+                                                                 * is allowed if you would like to allow the client to specify a subdomain to use.                 
+                                                                 e.g., *.example.com/api/mutate                                                                    
+                                                                 You can specify multiple URLs as well which the client can choose from.                           
+                                                                 e.g., ["https://api1.example.com/mutate", "https://api2.example.com/mutate"]                      
                                                                                                                                                                    
      --query-api-key string                                      optional                                                                                          
        ZERO_QUERY_API_KEY env                                                                                                                                      

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -159,10 +159,15 @@ const makeMutatorQueryOptions = (
   suffix: string,
 ) => ({
   url: {
-    type: v.string().optional(), // optional until we remove CRUD mutations
+    type: v.array(v.string()).optional(), // optional until we remove CRUD mutations
     desc: [
       replacement ? `DEPRECATED. Use ${replacement} instead.` : ``,
       `The URL of the API server to which zero-cache will ${suffix}.`,
+      ``,
+      `* is allowed if you would like to allow the client to specify a subdomain to use.`,
+      `e.g., *.example.com/api/mutate`,
+      `You can specify multiple URLs as well which the client can choose from.`,
+      `e.g., ["https://api1.example.com/mutate", "https://api2.example.com/mutate"]`,
     ],
   },
   apiKey: {

--- a/packages/zero-cache/src/custom-queries/transform-query.test.ts
+++ b/packages/zero-cache/src/custom-queries/transform-query.test.ts
@@ -133,7 +133,7 @@ describe('CustomQueryTransformer', () => {
 
     const transformer = new CustomQueryTransformer(
       {
-        url: pullUrl,
+        url: [pullUrl],
         forwardCookies: false,
       },
       mockShard,
@@ -180,7 +180,7 @@ describe('CustomQueryTransformer', () => {
 
     const transformer = new CustomQueryTransformer(
       {
-        url: pullUrl,
+        url: [pullUrl],
         forwardCookies: false,
       },
       mockShard,
@@ -210,7 +210,7 @@ describe('CustomQueryTransformer', () => {
 
     const transformer = new CustomQueryTransformer(
       {
-        url: pullUrl,
+        url: [pullUrl],
         forwardCookies: false,
       },
       mockShard,
@@ -234,7 +234,7 @@ describe('CustomQueryTransformer', () => {
 
     const transformer = new CustomQueryTransformer(
       {
-        url: pullUrl,
+        url: [pullUrl],
         forwardCookies: false,
       },
       mockShard,
@@ -259,7 +259,7 @@ describe('CustomQueryTransformer', () => {
 
     const transformer = new CustomQueryTransformer(
       {
-        url: pullUrl,
+        url: [pullUrl],
         forwardCookies: false,
       },
       mockShard,
@@ -290,7 +290,7 @@ describe('CustomQueryTransformer', () => {
 
     const transformer = new CustomQueryTransformer(
       {
-        url: pullUrl,
+        url: [pullUrl],
         forwardCookies: false,
       },
       mockShard,
@@ -337,7 +337,7 @@ describe('CustomQueryTransformer', () => {
 
     const transformer = new CustomQueryTransformer(
       {
-        url: pullUrl,
+        url: [pullUrl],
         forwardCookies: false,
       },
       mockShard,
@@ -387,7 +387,7 @@ describe('CustomQueryTransformer', () => {
 
     const transformer = new CustomQueryTransformer(
       {
-        url: pullUrl,
+        url: [pullUrl],
         forwardCookies: false,
       },
       mockShard,
@@ -424,7 +424,7 @@ describe('CustomQueryTransformer', () => {
 
     const transformer = new CustomQueryTransformer(
       {
-        url: pullUrl,
+        url: [pullUrl],
         forwardCookies: true,
       },
       mockShard,
@@ -468,7 +468,7 @@ describe('CustomQueryTransformer', () => {
 
     const transformer = new CustomQueryTransformer(
       {
-        url: pullUrl,
+        url: [pullUrl],
         forwardCookies: false,
       },
       mockShard,
@@ -508,7 +508,7 @@ describe('CustomQueryTransformer', () => {
 
     const transformer = new CustomQueryTransformer(
       {
-        url: pullUrl,
+        url: [pullUrl],
         forwardCookies: false,
       },
       mockShard,

--- a/packages/zero-cache/src/custom-queries/transform-query.ts
+++ b/packages/zero-cache/src/custom-queries/transform-query.ts
@@ -11,6 +11,7 @@ import type {ShardID} from '../types/shards.ts';
 import * as v from '../../../shared/src/valita.ts';
 import {hashOfAST} from '../../../zero-protocol/src/query-hash.ts';
 import {TimedCache} from '../../../shared/src/cache.ts';
+import {must} from '../../../shared/src/must.ts';
 
 type HttpError = {
   error: 'http';
@@ -36,13 +37,13 @@ export class CustomQueryTransformer {
   readonly #shard: ShardID;
   readonly #cache: TimedCache<TransformedAndHashed>;
   readonly #config: {
-    url: string;
+    url: string[];
     forwardCookies: boolean;
   };
 
   constructor(
     config: {
-      url: string;
+      url: string[];
       forwardCookies: boolean;
     },
     shard: ShardID,
@@ -86,7 +87,10 @@ export class CustomQueryTransformer {
     }
 
     const response = await fetchFromAPIServer(
-      this.#config.url,
+      must(
+        this.#config.url[0],
+        'A ZERO_QUERY_URL must be configured for custom queries',
+      ),
       this.#shard,
       headerOptions,
       undefined,

--- a/packages/zero-cache/src/services/mutagen/pusher.test.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.test.ts
@@ -296,7 +296,7 @@ describe('pusher service', () => {
     const pusher = new PusherService(
       config,
       {
-        url: 'http://example.com',
+        url: ['http://example.com'],
         forwardCookies: false,
       },
       lc,
@@ -319,7 +319,7 @@ describe('pusher service', () => {
     const pusher = new PusherService(
       config,
       {
-        url: 'http://example.com',
+        url: ['http://example.com'],
         apiKey: 'api-key',
         forwardCookies: false,
       },
@@ -352,7 +352,7 @@ describe('pusher service', () => {
     const pusher = new PusherService(
       config,
       {
-        url: 'http://example.com',
+        url: ['http://example.com'],
         apiKey: 'api-key',
         forwardCookies: false,
       },
@@ -383,7 +383,7 @@ describe('pusher service', () => {
     const pusher = new PusherService(
       config,
       {
-        url: 'http://example.com',
+        url: ['http://example.com'],
         apiKey: 'api-key',
         forwardCookies: false,
       },
@@ -433,7 +433,7 @@ describe('pusher service', () => {
     const pusher = new PusherService(
       config,
       {
-        url: 'http://example.com',
+        url: ['http://example.com'],
         apiKey: 'api-key',
         forwardCookies: false,
       },
@@ -459,7 +459,7 @@ describe('pusher service', () => {
     const pusher = new PusherService(
       config,
       {
-        url: 'http://example.com',
+        url: ['http://example.com'],
         apiKey: 'api-key',
         forwardCookies: true,
       },
@@ -485,7 +485,7 @@ describe('initConnection', () => {
     const pusher = new PusherService(
       config,
       {
-        url: 'http://example.com',
+        url: ['http://example.com'],
         apiKey: 'api-key',
         forwardCookies: false,
       },
@@ -502,7 +502,7 @@ describe('initConnection', () => {
     const pusher = new PusherService(
       config,
       {
-        url: 'http://example.com',
+        url: ['http://example.com'],
         apiKey: 'api-key',
         forwardCookies: false,
       },
@@ -520,7 +520,7 @@ describe('initConnection', () => {
     const pusher = new PusherService(
       config,
       {
-        url: 'http://example.com',
+        url: ['http://example.com'],
         apiKey: 'api-key',
         forwardCookies: false,
       },
@@ -547,7 +547,7 @@ describe('initConnection', () => {
     const pusher = new PusherService(
       config,
       {
-        url: 'http://example.com',
+        url: ['http://example.com'],
         apiKey: 'api-key',
         forwardCookies: false,
       },
@@ -594,7 +594,7 @@ describe('pusher streaming', () => {
     const pusher = new PusherService(
       config,
       {
-        url: 'http://example.com',
+        url: ['http://example.com'],
         apiKey: 'api-key',
         forwardCookies: false,
       },
@@ -631,7 +631,7 @@ describe('pusher streaming', () => {
     const pusher = new PusherService(
       config,
       {
-        url: 'http://example.com',
+        url: ['http://example.com'],
         apiKey: 'api-key',
         forwardCookies: false,
       },
@@ -715,7 +715,7 @@ describe('pusher streaming', () => {
     const pusher = new PusherService(
       config,
       {
-        url: 'http://example.com',
+        url: ['http://example.com'],
         apiKey: 'api-key',
         forwardCookies: false,
       },
@@ -775,7 +775,7 @@ describe('pusher streaming', () => {
     const pusher = new PusherService(
       config,
       {
-        url: 'http://example.com',
+        url: ['http://example.com'],
         apiKey: 'api-key',
         forwardCookies: false,
       },
@@ -809,7 +809,7 @@ describe('pusher streaming', () => {
     const pusher = new PusherService(
       config,
       {
-        url: 'http://example.com',
+        url: ['http://example.com'],
         apiKey: 'api-key',
         forwardCookies: false,
       },
@@ -834,7 +834,7 @@ describe('pusher streaming', () => {
     const pusher = new PusherService(
       config,
       {
-        url: 'http://example.com',
+        url: ['http://example.com'],
         apiKey: 'api-key',
         forwardCookies: false,
       },
@@ -877,7 +877,7 @@ describe('pusher streaming', () => {
     const pusher = new PusherService(
       config,
       {
-        url: 'http://example.com',
+        url: ['http://example.com'],
         apiKey: 'api-key',
         forwardCookies: false,
       },
@@ -936,7 +936,7 @@ describe('pusher streaming', () => {
     const pusher = new PusherService(
       config,
       {
-        url: 'http://example.com',
+        url: ['http://example.com'],
         apiKey: 'api-key',
         forwardCookies: false,
       },
@@ -965,7 +965,7 @@ describe('pusher streaming', () => {
     const pusher = new PusherService(
       config,
       {
-        url: 'http://example.com',
+        url: ['http://example.com'],
         apiKey: 'api-key',
         forwardCookies: false,
       },

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -111,7 +111,7 @@ const ON_FAILURE = (e: unknown) => {
 };
 
 const queryConfig: ZeroConfig['query'] = {
-  url: 'http://my-pull-endpoint.dev/api/zero/pull',
+  url: ['http://my-pull-endpoint.dev/api/zero/pull'],
   forwardCookies: true,
 };
 

--- a/packages/zero-cache/src/workers/syncer.test.ts
+++ b/packages/zero-cache/src/workers/syncer.test.ts
@@ -100,7 +100,7 @@ describe('cleanup', () => {
         const ret = new PusherService(
           {} as ZeroConfig,
           {
-            url: 'http://example.com',
+            url: ['http://example.com'],
             forwardCookies: false,
           },
           lc,
@@ -245,7 +245,7 @@ describe('connection telemetry', () => {
         const ret = new PusherService(
           {} as ZeroConfig,
           {
-            url: 'http://example.com',
+            url: ['http://example.com'],
             forwardCookies: false,
           },
           lc,


### PR DESCRIPTION
To support previews we'll need to support an array of possible mutate/query urls.

For this iteration, we just pick the first URL.

### For later iterations:

The client can send a URL to use. If that URL matches one in the list, it is used. If it does not match, an error is thrown.

For the final iteration, the URL can have a star in the subdomain position. E.g., `https://*.example.com` and the client can insert a subdomain.

After doing some testing, it looks like the existing `.env` format will correctly parse into a string array.

e.g.,
```
ZERO_PUSH_URL = 'http://example.com'
```

get parsed to:
```ts
{ url: ['http://example.com'] }
```

Given that, this is not a breaking change for our users.