### PR TITLE
chore(zero): check URL against whitelist in `fetchFromAPIServer`

### DIFF
--- a/packages/zero-cache/src/custom-queries/transform-query.test.ts
+++ b/packages/zero-cache/src/custom-queries/transform-query.test.ts
@@ -143,6 +143,7 @@ describe('CustomQueryTransformer', () => {
     // Verify the API was called correctly
     expect(mockFetchFromAPIServer).toHaveBeenCalledWith(
       pullUrl,
+      [pullUrl],
       mockShard,
       headerOptions,
       undefined,
@@ -348,6 +349,7 @@ describe('CustomQueryTransformer', () => {
     expect(mockFetchFromAPIServer).toHaveBeenCalledTimes(1);
     expect(mockFetchFromAPIServer).toHaveBeenLastCalledWith(
       'https://api.example.com/pull',
+      ['https://api.example.com/pull'],
       mockShard,
       headerOptions,
       undefined,
@@ -359,6 +361,7 @@ describe('CustomQueryTransformer', () => {
     expect(mockFetchFromAPIServer).toHaveBeenCalledTimes(2);
     expect(mockFetchFromAPIServer).toHaveBeenLastCalledWith(
       pullUrl,
+      [pullUrl],
       mockShard,
       headerOptions,
       undefined,
@@ -401,6 +404,7 @@ describe('CustomQueryTransformer', () => {
 
     expect(mockFetchFromAPIServer).toHaveBeenCalledWith(
       pullUrl,
+      [pullUrl],
       mockShard,
       headerOptions, // Cookies should not be forwarded
       undefined,
@@ -438,6 +442,7 @@ describe('CustomQueryTransformer', () => {
 
     expect(mockFetchFromAPIServer).toHaveBeenCalledWith(
       pullUrl,
+      [pullUrl],
       mockShard,
       {...headerOptions, cookie: 'test-cookie'}, // Cookies should be forwarded
       undefined,

--- a/packages/zero-cache/src/custom-queries/transform-query.ts
+++ b/packages/zero-cache/src/custom-queries/transform-query.ts
@@ -91,6 +91,7 @@ export class CustomQueryTransformer {
         this.#config.url[0],
         'A ZERO_QUERY_URL must be configured for custom queries',
       ),
+      this.#config.url,
       this.#shard,
       headerOptions,
       undefined,

--- a/packages/zero-cache/src/custom/fetch.test.ts
+++ b/packages/zero-cache/src/custom/fetch.test.ts
@@ -6,7 +6,7 @@ import {
   type MockedFunction,
   test,
 } from 'vitest';
-import {fetchFromAPIServer} from './fetch.ts';
+import {fetchFromAPIServer, urlMatch} from './fetch.ts';
 import {ErrorForClient} from '../types/error-for-client.ts';
 import {ErrorKind} from '../../../zero-protocol/src/error-kind.ts';
 import type {ShardID} from '../types/shards.ts';
@@ -44,6 +44,7 @@ describe('fetchFromAPIServer', () => {
 
     await fetchFromAPIServer(
       baseUrl,
+      [baseUrl],
       mockShard,
       headerOptions,
       queryParams,
@@ -71,6 +72,7 @@ describe('fetchFromAPIServer', () => {
 
     await fetchFromAPIServer(
       baseUrl,
+      [baseUrl],
       mockShard,
       {apiKey: 'my-key'},
       undefined,
@@ -93,6 +95,7 @@ describe('fetchFromAPIServer', () => {
 
     await fetchFromAPIServer(
       baseUrl,
+      [baseUrl],
       mockShard,
       {token: 'my-token'},
       undefined,
@@ -114,7 +117,14 @@ describe('fetchFromAPIServer', () => {
     const mockResponse = new Response('{}', {status: 200});
     mockFetch.mockResolvedValue(mockResponse);
 
-    await fetchFromAPIServer(baseUrl, mockShard, {}, undefined, body);
+    await fetchFromAPIServer(
+      baseUrl,
+      [baseUrl],
+      mockShard,
+      {},
+      undefined,
+      body,
+    );
 
     const callArgs = mockFetch.mock.calls[0];
     const headers = callArgs[1]?.headers as Record<string, string>;
@@ -128,7 +138,14 @@ describe('fetchFromAPIServer', () => {
     const mockResponse = new Response('{}', {status: 200});
     mockFetch.mockResolvedValue(mockResponse);
 
-    await fetchFromAPIServer(baseUrl, mockShard, {}, queryParams, body);
+    await fetchFromAPIServer(
+      baseUrl,
+      [baseUrl],
+      mockShard,
+      {},
+      queryParams,
+      body,
+    );
 
     const calledUrl = mockFetch.mock.calls[0][0] as string;
     const url = new URL(calledUrl);
@@ -141,7 +158,14 @@ describe('fetchFromAPIServer', () => {
     const mockResponse = new Response('{}', {status: 200});
     mockFetch.mockResolvedValue(mockResponse);
 
-    await fetchFromAPIServer(baseUrl, mockShard, {}, undefined, body);
+    await fetchFromAPIServer(
+      baseUrl,
+      [baseUrl],
+      mockShard,
+      {},
+      undefined,
+      body,
+    );
 
     const calledUrl = mockFetch.mock.calls[0][0] as string;
     const url = new URL(calledUrl);
@@ -155,7 +179,14 @@ describe('fetchFromAPIServer', () => {
     mockFetch.mockResolvedValue(mockResponse);
     const urlWithParams = 'https://api.example.com/endpoint?existing=param';
 
-    await fetchFromAPIServer(urlWithParams, mockShard, {}, queryParams, body);
+    await fetchFromAPIServer(
+      urlWithParams,
+      [baseUrl],
+      mockShard,
+      {},
+      queryParams,
+      body,
+    );
 
     const calledUrl = mockFetch.mock.calls[0][0] as string;
     const url = new URL(calledUrl);
@@ -169,7 +200,14 @@ describe('fetchFromAPIServer', () => {
     const urlWithReserved = 'https://api.example.com/endpoint?schema=reserved';
 
     await expect(
-      fetchFromAPIServer(urlWithReserved, mockShard, {}, undefined, body),
+      fetchFromAPIServer(
+        urlWithReserved,
+        [baseUrl],
+        mockShard,
+        {},
+        undefined,
+        body,
+      ),
     ).rejects.toThrow(
       'The push URL cannot contain the reserved query param "schema"',
     );
@@ -179,7 +217,14 @@ describe('fetchFromAPIServer', () => {
     const urlWithReserved = 'https://api.example.com/endpoint?appID=reserved';
 
     await expect(
-      fetchFromAPIServer(urlWithReserved, mockShard, {}, undefined, body),
+      fetchFromAPIServer(
+        urlWithReserved,
+        [baseUrl],
+        mockShard,
+        {},
+        undefined,
+        body,
+      ),
     ).rejects.toThrow(
       'The push URL cannot contain the reserved query param "appID"',
     );
@@ -189,7 +234,14 @@ describe('fetchFromAPIServer', () => {
     const reservedQueryParams = {schema: 'reserved'};
 
     await expect(
-      fetchFromAPIServer(baseUrl, mockShard, {}, reservedQueryParams, body),
+      fetchFromAPIServer(
+        baseUrl,
+        [baseUrl],
+        mockShard,
+        {},
+        reservedQueryParams,
+        body,
+      ),
     ).rejects.toThrow(
       'The push URL cannot contain the reserved query param "schema"',
     );
@@ -199,7 +251,14 @@ describe('fetchFromAPIServer', () => {
     const reservedQueryParams = {appID: 'reserved'};
 
     await expect(
-      fetchFromAPIServer(baseUrl, mockShard, {}, reservedQueryParams, body),
+      fetchFromAPIServer(
+        baseUrl,
+        [baseUrl],
+        mockShard,
+        {},
+        reservedQueryParams,
+        body,
+      ),
     ).rejects.toThrow(
       'The push URL cannot contain the reserved query param "appID"',
     );
@@ -213,6 +272,7 @@ describe('fetchFromAPIServer', () => {
 
     const result = await fetchFromAPIServer(
       baseUrl,
+      [baseUrl],
       mockShard,
       {},
       undefined,
@@ -230,7 +290,7 @@ describe('fetchFromAPIServer', () => {
     mockFetch.mockResolvedValueOnce(mockResponse1);
 
     await expect(
-      fetchFromAPIServer(baseUrl, mockShard, {}, undefined, body),
+      fetchFromAPIServer(baseUrl, [baseUrl], mockShard, {}, undefined, body),
     ).rejects.toThrow(ErrorForClient);
 
     // Second call - test the error details
@@ -238,7 +298,14 @@ describe('fetchFromAPIServer', () => {
     mockFetch.mockResolvedValueOnce(mockResponse2);
 
     try {
-      await fetchFromAPIServer(baseUrl, mockShard, {}, undefined, body);
+      await fetchFromAPIServer(
+        baseUrl,
+        [baseUrl],
+        mockShard,
+        {},
+        undefined,
+        body,
+      );
     } catch (error) {
       expect(error).toBeInstanceOf(ErrorForClient);
       const errorForClient = error as ErrorForClient;
@@ -253,6 +320,7 @@ describe('fetchFromAPIServer', () => {
 
     const result = await fetchFromAPIServer(
       baseUrl,
+      [baseUrl],
       mockShard,
       {},
       undefined,
@@ -266,7 +334,14 @@ describe('fetchFromAPIServer', () => {
     const mockResponse = new Response('{}', {status: 200});
     mockFetch.mockResolvedValue(mockResponse);
 
-    await fetchFromAPIServer(baseUrl, mockShard, {}, undefined, body);
+    await fetchFromAPIServer(
+      baseUrl,
+      [baseUrl],
+      mockShard,
+      {},
+      undefined,
+      body,
+    );
 
     const calledUrl = mockFetch.mock.calls[0][0] as string;
     const url = new URL(calledUrl);
@@ -285,7 +360,14 @@ describe('fetchFromAPIServer', () => {
       },
     };
 
-    await fetchFromAPIServer(baseUrl, mockShard, {}, undefined, complexBody);
+    await fetchFromAPIServer(
+      baseUrl,
+      [baseUrl],
+      mockShard,
+      {},
+      undefined,
+      complexBody,
+    );
 
     expect(mockFetch).toHaveBeenCalledWith(
       expect.any(String),
@@ -293,5 +375,105 @@ describe('fetchFromAPIServer', () => {
         body: JSON.stringify(complexBody),
       }),
     );
+  });
+});
+
+describe('urlMatch', () => {
+  test('should return true for matching URLs', () => {
+    expect(
+      urlMatch('https://api.example.com/endpoint', [
+        'https://api.example.com/endpoint',
+      ]),
+    ).toBe(true);
+
+    expect(
+      urlMatch('https://api.example.com/endpoint', [
+        'https://*.example.com/endpoint',
+      ]),
+    ).toBe(true);
+
+    expect(
+      urlMatch('https://api.v1.example.com/endpoint', [
+        'https://*.*.example.com/endpoint',
+      ]),
+    ).toBe(true);
+
+    expect(
+      urlMatch('https://api.example.com/endpoint?existing=param', [
+        'https://api.example.com/endpoint',
+      ]),
+    ).toBe(true);
+
+    expect(
+      urlMatch('https://api.example.com/endpoint?existing=param', [
+        'https://api.example.com/endpoint?other=param',
+      ]),
+    ).toBe(true);
+  });
+
+  test('should return false for non-matching URLs', () => {
+    expect(
+      urlMatch('https://api.example.com/other-endpoint', [
+        'https://api.example.com/endpoint',
+      ]),
+    ).toBe(false);
+
+    expect(
+      urlMatch('https://another-domain.com/endpoint', [
+        'https://api.example.com/endpoint',
+      ]),
+    ).toBe(false);
+
+    // Wildcard with no subdomain
+    expect(
+      urlMatch('https://example.com/endpoint', [
+        'https://*.example.com/endpoint',
+      ]),
+    ).toBe(false);
+
+    // Wildcard with trailing path
+    expect(
+      urlMatch('https://api.example.com/endpoint/path', [
+        'https://*.example.com/endpoint',
+      ]),
+    ).toBe(false);
+
+    // Wrong number of subdomains for wildcard
+    expect(
+      urlMatch('https://api.example.com/endpoint', [
+        'https://*.*.example.com/endpoint',
+      ]),
+    ).toBe(false);
+
+    // wildcards can only match subdomains, not paths or anything else
+    expect(
+      urlMatch('https://api.example.com/endpoint', [
+        'https://*example.com/endpoint',
+      ]),
+    ).toBe(false);
+    expect(
+      urlMatch('https://example.com/endpoint', [
+        'https://*example.com/endpoint',
+      ]),
+    ).toBe(false);
+    expect(
+      urlMatch('https://apiexample.com/endpoint', [
+        'https://*example.com/endpoint',
+      ]),
+    ).toBe(false);
+    expect(() =>
+      urlMatch('https://*example.com/endpoint', [
+        'https://*example.com/endpoint',
+      ]),
+    ).toThrow();
+    expect(
+      urlMatch('https://api.example.com/endpoint', [
+        'https://api.example.com/*',
+      ]),
+    ).toBe(false);
+  });
+
+  test('should handle empty allowed URLs array', () => {
+    expect(urlMatch('https://api.example.com/endpoint', [])).toBe(false);
   });
 });

--- a/packages/zero-cache/src/custom/fetch.ts
+++ b/packages/zero-cache/src/custom/fetch.ts
@@ -13,11 +13,17 @@ export type HeaderOptions = {
 
 export async function fetchFromAPIServer(
   url: string,
+  allowedUrls: string[],
   shard: ShardID,
   headerOptions: HeaderOptions,
   queryParams: Record<string, string> | undefined,
   body: ReadonlyJSONValue,
 ) {
+  if (!urlMatch(url, allowedUrls)) {
+    throw new Error(
+      `URL "${url}" is not allowed by the ZERO_MUTATE/QUERY_URL configuration`,
+    );
+  }
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
   };
@@ -75,4 +81,65 @@ export async function fetchFromAPIServer(
   }
 
   return response;
+}
+
+/**
+ * Returns true if:
+ * 1. the url is an exact match with one of the allowedUrls
+ * 2. an "allowedUrl" has a wildcard for a subdomain, e.g. "https://*.example.com" and the url matches that pattern
+ *
+ * Valid wildcard patterns:
+ * - "https://*.example.com" matches "https://api.example.com" and "https://www.example.com"
+ * - "https://*.example.com" does not match "https://example.com" (no subdomain)
+ * - "https://*.example.com" does not match "https://api.example.com/path" (no trailing path)
+ * - "https://*.*.example.com" matches "https://api.v1.example.com" and "https://www.v2.example.com"
+ * - "https://*.*.example.com" does not match "https://api.example.com" (only one subdomain)
+ */
+export function urlMatch(url: string, allowedUrls: string[]): boolean {
+  assert(
+    url.includes('*') === false,
+    'Client provided URLs may not include `*`',
+  );
+  // ignore query parameters in the URL
+  url = url.split('?')[0];
+
+  for (let allowedUrl of allowedUrls) {
+    // ignore query parameters in the allowed URL
+    allowedUrl = allowedUrl.split('?')[0];
+    if (url === allowedUrl) {
+      return true; // exact match
+    }
+
+    const parts = allowedUrl.split('*');
+
+    if (parts.length === 1) {
+      continue; // no wildcard, already checked above
+    }
+
+    let currentStr = url;
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      if (!currentStr.startsWith(part)) {
+        break;
+      }
+
+      currentStr = currentStr.slice(part.length);
+      if (currentStr === '' && i < parts.length - 1) {
+        // if we reach the end of the string but still have more parts to match, it's not a match
+        break;
+      } else if (currentStr === '' && i === parts.length - 1) {
+        // if we reach the end of the string and this is the last part, it's a match
+        return true;
+      }
+
+      // consume the rest of the string up to a .
+      const nextDotIndex = currentStr.indexOf('.');
+      if (nextDotIndex === -1) {
+        // no dot? then the wildcard rules don't apply, so we can stop checking
+        break;
+      }
+      currentStr = currentStr.slice(nextDotIndex);
+    }
+  }
+  return false;
 }

--- a/packages/zero-cache/src/services/mutagen/pusher.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.ts
@@ -363,6 +363,7 @@ class PushWorker {
     try {
       const response = await fetchFromAPIServer(
         must(this.#pushURLs[0], 'ZERO_MUTATE_URL is not set'),
+        this.#pushURLs,
         {
           appID: this.#config.app.id,
           shardNum: this.#config.shard.num,


### PR DESCRIPTION
To support previews we need to check a dynamic URL provided by the client against a static URL whitelist provided by the zero config.

Rules:
1. Query parameters are ignored
2. Strings that exactly match (after removing query params) are allowed
3. A wildcard may be present in the static set. Each wildcard matches a single subdomain. A wildcard must be followed by a `.`


Valid wildcard patterns:
- "https://\*.example.com" matches "https://api.example.com" and "https://www.example.com"
- "https://\*.example.com" does not match "https://example.com" (no subdomain)
- "https://\*.example.com" does not match "https://api.example.com/path" (no trailing path)
- "https://\*.\*.example.com" matches "https://api.v1.example.com" and "https://www.v2.example.com"
- "https://\*.\*.example.com" does not match "https://api.example.com" (only one subdomain)