### PR TITLE
chore(zero-cache): Make the TTL clock zero based

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr-store.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.ts
@@ -208,7 +208,7 @@ export class CVRStore {
       id,
       version: EMPTY_CVR_VERSION,
       lastActive: 0,
-      ttlClock: ttlClockFromNumber(0),
+      ttlClock: ttlClockFromNumber(0), // TTL clock starts at 0, not Date.now()
       replicaVersion: null,
       clients: {},
       queries: {},
@@ -254,7 +254,7 @@ export class CVRStore {
       this.putInstance({
         version: cvr.version,
         lastActive: 0,
-        ttlClock: ttlClockFromNumber(0),
+        ttlClock: ttlClockFromNumber(0), // TTL clock starts at 0 for new instances
         replicaVersion: null,
         clientSchema: null,
       });
@@ -390,7 +390,9 @@ export class CVRStore {
   }
 
   /**
-   * Updates the `ttlClock` of the CVR instance.
+   * Updates the `ttlClock` of the CVR instance. The ttlClock starts at 0 when
+   * the CVR instance is first created and increments based on elapsed time
+   * since the base time established by the ViewSyncerService.
    */
   async updateTTLClock(ttlClock: TTLClock, lastActive: number): Promise<void> {
     await this.#db`UPDATE ${this.#cvr('instances')}
@@ -400,9 +402,9 @@ export class CVRStore {
   }
 
   /**
-   *
-   * @returns This returns the current `ttlClock` of the CVR instance. If the
-   *          CVR has never been initialized for this client group, it returns
+   * @returns This returns the current `ttlClock` of the CVR instance. The ttlClock
+   *          represents elapsed time since the instance was created (starting from 0).
+   *          If the CVR has never been initialized for this client group, it returns
    *          `undefined`.
    */
   async getTTLClock(): Promise<TTLClock | undefined> {

--- a/packages/zero-cache/src/services/view-syncer/view-syncer-ttl.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer-ttl.pg-test.ts
@@ -134,7 +134,7 @@ describe('ttl', () => {
         SELECT "ttlClock", "lastActive"
         FROM "this_app_2/cvr".instances
         WHERE "clientGroupID" = ${serviceID}`;
-      expect(result[0].ttlClock).toBe(t0);
+      expect(result[0].ttlClock).toBe(0);
       expect(result[0].lastActive).toBe(t0);
 
       {
@@ -154,7 +154,7 @@ describe('ttl', () => {
           WHERE "clientGroupID" = ${serviceID}`;
         expect(result).toEqual([
           {
-            ttlClock: t1,
+            ttlClock: 500,
             lastActive: t1,
           },
         ]);
@@ -189,7 +189,7 @@ describe('ttl', () => {
         SELECT "ttlClock", "lastActive"
         FROM "this_app_2/cvr".instances
         WHERE "clientGroupID" = ${serviceID}`;
-      expect(result).toEqual([{ttlClock: t0, lastActive: t0}]);
+      expect(result).toEqual([{ttlClock: 0, lastActive: t0}]);
 
       vi.setSystemTime(Date.now() + 500);
       // Close the first connection.
@@ -201,7 +201,7 @@ describe('ttl', () => {
           SELECT "ttlClock", "lastActive"
           FROM "this_app_2/cvr".instances
           WHERE "clientGroupID" = ${serviceID}`;
-      expect(result).toEqual([{ttlClock: t0, lastActive: t0}]);
+      expect(result).toEqual([{ttlClock: 0, lastActive: t0}]);
 
       // Move time forward and close the second connection.
       vi.setSystemTime(Date.now() + 500);
@@ -215,7 +215,7 @@ describe('ttl', () => {
           SELECT "ttlClock", "lastActive"
           FROM "this_app_2/cvr".instances
           WHERE "clientGroupID" = ${serviceID}`;
-      expect(result).toEqual([{ttlClock: t2, lastActive: t2}]);
+      expect(result).toEqual([{ttlClock: 1010, lastActive: t2}]);
     });
 
     test('one client - disconnect and reconnect', async () => {
@@ -237,7 +237,7 @@ describe('ttl', () => {
         SELECT "ttlClock", "lastActive"
         FROM "this_app_2/cvr".instances
         WHERE "clientGroupID" = ${serviceID}`;
-      expect(result[0].ttlClock).toBe(t0);
+      expect(result[0].ttlClock).toBe(0);
       expect(result[0].lastActive).toBe(t0);
 
       // Disconnect.
@@ -250,7 +250,7 @@ describe('ttl', () => {
         SELECT "ttlClock", "lastActive"
         FROM "this_app_2/cvr".instances
         WHERE "clientGroupID" = ${serviceID}`;
-      expect(result[0].ttlClock).toBe(t1);
+      expect(result[0].ttlClock).toBe(500);
       expect(result[0].lastActive).toBe(t1);
 
       // Wait some time while disconnected (should not advance ttlClock).
@@ -270,7 +270,7 @@ describe('ttl', () => {
           SELECT "ttlClock", "lastActive"
           FROM "this_app_2/cvr".instances
           WHERE "clientGroupID" = ${serviceID}`;
-      expect(result[0].ttlClock).toBe(t1);
+      expect(result[0].ttlClock).toBe(500);
       expect(result[0].lastActive).toBe(t1);
 
       // Make a change.
@@ -291,7 +291,7 @@ describe('ttl', () => {
           SELECT "ttlClock", "lastActive"
           FROM "this_app_2/cvr".instances
           WHERE "clientGroupID" = ${serviceID}`;
-      expect(result[0].ttlClock).toBe(t1);
+      expect(result[0].ttlClock).toBe(500);
       expect(result[0].lastActive).toBe(t2);
     });
   });
@@ -333,7 +333,7 @@ describe('ttl', () => {
     `,
     ).toEqual([
       {
-        ttlClock: t2,
+        ttlClock: 10 * 60 * 1000,
         lastActive: t2,
       },
     ]);
@@ -356,7 +356,7 @@ describe('ttl', () => {
     `,
     ).toEqual([
       {
-        ttlClock: t2,
+        ttlClock: 10 * 60 * 1000,
         lastActive: t2,
       },
     ]);
@@ -372,7 +372,7 @@ describe('ttl', () => {
     `,
     ).toEqual([
       {
-        ttlClock: t2,
+        ttlClock: 10 * 60 * 1000,
         lastActive: t2,
       },
     ]);
@@ -391,7 +391,7 @@ describe('ttl', () => {
     `,
     ).toEqual([
       {
-        ttlClock: t2 + 300_000,
+        ttlClock: 10 * 60 * 1000 + 5 * 60 * 1000,
         lastActive: t3 + 300_000,
       },
     ]);
@@ -412,7 +412,7 @@ describe('ttl', () => {
     await nextPoke(client); // hydration
 
     // Advance 2 seconds, then inactivate the query.
-    const t1 = t0 + 2 * 1000;
+    const t1 = t0 + 2_000;
     vi.setSystemTime(t1);
     await inactivateQuery(vs, SYNC_CONTEXT, 'query-hash1');
     await nextPokeParts(client); // Should get a desiredQueriesPatches poke
@@ -426,7 +426,7 @@ describe('ttl', () => {
     `,
     ).toEqual([
       {
-        ttlClock: t1,
+        ttlClock: 2_000,
         lastActive: t1,
       },
     ]);
@@ -457,7 +457,7 @@ describe('ttl', () => {
     expect(desires).toEqual([
       {
         deleted: true,
-        inactivatedAt: t1,
+        inactivatedAt: 2_000,
       },
     ]);
 

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -508,18 +508,9 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         this.#ttlClockBase = now;
 
         // Get the TTL clock from the CVR store, or initialize it to now.
-        this.#readTTLClockFromCVR(now).catch(e => {
+        this.#readTTLClockFromCVR().catch(e => {
           lc.error?.('failed to read TTL clock', e);
         });
-
-        // this.#cvrStore
-        //   .getTTLClock()
-        //   .then(ttlClock => {
-        //     this.#ttlClock = ttlClock ?? ttlClockFromNumber(now);
-        //   })
-        //   .catch(e => {
-        //     this.#lc.error?.('failed to get TTL clock', e);
-        //   });
       }
 
       const newClient = new ClientHandler(
@@ -1045,14 +1036,14 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     }
   }
 
-  async #readTTLClockFromCVR(now: number): Promise<TTLClock> {
+  async #readTTLClockFromCVR(): Promise<TTLClock> {
     if (this.#ttlClockInitializedPromise) {
       return this.#ttlClockInitializedPromise;
     }
 
     this.#ttlClockInitializedPromise = this.#cvrStore
       .getTTLClock()
-      .then(t => t ?? ttlClockFromNumber(now));
+      .then(t => t ?? ttlClockFromNumber(0));
     return (this.#ttlClock = await this.#ttlClockInitializedPromise);
   }
 
@@ -1076,7 +1067,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       let ttlClock: TTLClock;
       if (!this.#hasTTLClock()) {
         // Fetch it from the CVR or initialize it to now.
-        ttlClock = await this.#readTTLClockFromCVR(now);
+        ttlClock = await this.#readTTLClockFromCVR();
       } else {
         ttlClock = this.#getTTLClock(now);
       }


### PR DESCRIPTION
This initialized the TTL clock to start at 0 instead of Date.now().

We still increment it the same way as before.