### PR TITLE
chore(zero-cache): server side scaffolding for mutation responses [1/n]

### DIFF
--- a/packages/zero-cache/src/integration/integration.pg-test.ts
+++ b/packages/zero-cache/src/integration/integration.pg-test.ts
@@ -283,6 +283,40 @@ const INITIAL_CUSTOM_SETUP: ChangeStreamMessage[] = [
     {
       tag: 'create-table',
       spec: {
+        schema: '123_0',
+        name: 'mutations',
+        primaryKey: ['clientGroupID', 'clientID', 'mutationID'],
+        columns: {
+          clientGroupID: {pos: 0, dataType: 'text', notNull: true},
+          clientID: {pos: 1, dataType: 'text', notNull: true},
+          mutationID: {pos: 2, dataType: 'bigint', notNull: true},
+          mutation: {pos: 3, dataType: 'json'},
+        },
+      },
+    },
+  ],
+  [
+    'data',
+    {
+      tag: 'create-index',
+      spec: {
+        name: '123_mutations_key',
+        schema: '123_0',
+        tableName: 'mutations',
+        columns: {
+          clientGroupID: 'ASC',
+          clientID: 'ASC',
+          mutationID: 'ASC',
+        },
+        unique: true,
+      },
+    },
+  ],
+  [
+    'data',
+    {
+      tag: 'create-table',
+      spec: {
         schema: '123',
         name: 'schemaVersions',
         primaryKey: ['lock'],

--- a/packages/zero-cache/src/services/change-source/pg/schema/init.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.pg-test.ts
@@ -8,15 +8,16 @@ import {
 import {expectTablesToMatch, initDB, testDBs} from '../../../../test/db.ts';
 import type {PostgresDB} from '../../../../types/pg.ts';
 import {ensureShardSchema, updateShardSchema} from './init.ts';
-import {addReplica} from './shard.ts';
+import {addReplica, metadataPublicationName} from './shard.ts';
+import {id} from '../../../../types/sql.ts';
 
 const APP_ID = 'zappz';
 const SHARD_NUM = 23;
 
 // Update as necessary.
 const CURRENT_SCHEMA_VERSIONS = {
-  dataVersion: 9,
-  schemaVersion: 9,
+  dataVersion: 10,
+  schemaVersion: 10,
   minSafeVersion: 1,
   lock: 'v',
 } as const;
@@ -145,6 +146,11 @@ describe('change-streamer/pg/schema/init', () => {
             true,
             '{"tables":[],"indexes":[]}'
           );
+        CREATE TABLE ${APP_ID}_${SHARD_NUM}."schemaVersions" 
+            ("lock" BOOL PRIMARY KEY, "minSupportedVersion" INT4, "maxSupportedVersion" INT4);
+
+        CREATE PUBLICATION ${id(metadataPublicationName(APP_ID, SHARD_NUM))}
+            FOR TABLE ${APP_ID}_${SHARD_NUM}."schemaVersions";
   `,
       existingVersionHistory: {
         schemaVersion: 5,

--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.pg-test.ts
@@ -56,6 +56,7 @@ describe('change-source/pg', () => {
       [`_zro_metadata_0`, 'zro', 'schemaVersions', null],
       [`_zro_metadata_0`, 'zro', 'permissions', null],
       [`_zro_metadata_0`, `zro_0`, 'clients', null],
+      [`_zro_metadata_0`, `zro_0`, 'mutations', null],
       ['_zro_public_0', null, null, null],
     ]);
 
@@ -114,6 +115,7 @@ describe('change-source/pg', () => {
       [`_zro_metadata_0`, 'zro', 'schemaVersions', null],
       [`_zro_metadata_0`, 'zro', 'permissions', null],
       [`_zro_metadata_0`, `zro_0`, 'clients', null],
+      [`_zro_metadata_0`, `zro_0`, 'mutations', null],
       ['_zro_public_0', 'public', 'join_table', null],
     ]);
 
@@ -155,6 +157,7 @@ describe('change-source/pg', () => {
       [`_1_metadata_0`, '1', 'schemaVersions', null],
       [`_1_metadata_0`, '1', 'permissions', null],
       [`_1_metadata_0`, `1_0`, 'clients', null],
+      [`_1_metadata_0`, `1_0`, 'mutations', null],
       [`_1_public_0`, null, null, null],
     ]);
 
@@ -195,9 +198,11 @@ describe('change-source/pg', () => {
       [`_zro_metadata_0`, 'zro', 'schemaVersions', null],
       [`_zro_metadata_0`, 'zro', 'permissions', null],
       [`_zro_metadata_0`, `zro_0`, 'clients', null],
+      [`_zro_metadata_0`, `zro_0`, 'mutations', null],
       [`_zro_metadata_1`, 'zro', 'schemaVersions', null],
       [`_zro_metadata_1`, 'zro', 'permissions', null],
       [`_zro_metadata_1`, `zro_1`, 'clients', null],
+      [`_zro_metadata_1`, `zro_1`, 'mutations', null],
       ['_zro_public_0', null, null, null],
       ['_zro_public_1', null, null, null],
     ]);
@@ -288,6 +293,7 @@ describe('change-source/pg', () => {
       [`_zro_metadata_2`, 'zro', 'schemaVersions', null],
       [`_zro_metadata_2`, 'zro', 'permissions', null],
       [`_zro_metadata_2`, `zro_2`, 'clients', null],
+      [`_zro_metadata_2`, `zro_2`, 'mutations', null],
       ['zero_bar', 'far', 'bar', null],
       ['zero_foo', 'public', 'foo', '(id > 1000)'],
     ]);
@@ -330,6 +336,7 @@ describe('change-source/pg', () => {
       [`_supaneon_metadata_0`, 'supaneon', 'schemaVersions', null],
       [`_supaneon_metadata_0`, 'supaneon', 'permissions', null],
       [`_supaneon_metadata_0`, `supaneon_0`, 'clients', null],
+      ['_supaneon_metadata_0', 'supaneon_0', 'mutations', null],
       ['zero_foo', 'public', 'foo', null],
     ]);
 

--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
@@ -153,6 +153,7 @@ export function shardSetup(
   CREATE SCHEMA IF NOT EXISTS ${shard};
 
   ${getClientsTableDefinition(shard)}
+  ${getMutationsTableDefinition(shard)}
 
   CREATE PUBLICATION ${id(metadataPublication)}
     FOR TABLE ${app}."schemaVersions", ${app}."permissions", TABLE ${shard}."clients";

--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
@@ -156,7 +156,7 @@ export function shardSetup(
   ${getMutationsTableDefinition(shard)}
 
   CREATE PUBLICATION ${id(metadataPublication)}
-    FOR TABLE ${app}."schemaVersions", ${app}."permissions", TABLE ${shard}."clients";
+    FOR TABLE ${app}."schemaVersions", ${app}."permissions", TABLE ${shard}."clients", ${shard}."mutations";
 
   CREATE TABLE ${shard}."${SHARD_CONFIG_TABLE}" (
     "publications"  TEXT[] NOT NULL,

--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
@@ -49,7 +49,10 @@ function defaultPublicationName(appID: string, shardID: string | number) {
   return `_${appID}_public_${shardID}`;
 }
 
-function metadataPublicationName(appID: string, shardID: string | number) {
+export function metadataPublicationName(
+  appID: string,
+  shardID: string | number,
+) {
   return `_${appID}_metadata_${shardID}`;
 }
 
@@ -112,6 +115,25 @@ export function getClientsTableDefinition(schema: string) {
     "lastMutationID" BIGINT NOT NULL,
     "userID"         TEXT,
     PRIMARY KEY("clientGroupID", "clientID")
+  );`;
+}
+
+/**
+ * Tracks the results of mutations.
+ * 1. It is an error for the same mutation ID to be used twice.
+ * 2. The result is JSONB to allow for arbitrary results.
+ *
+ * The tables must be cleaned up as the clients
+ * receive the mutation responses and as clients are removed.
+ */
+export function getMutationsTableDefinition(schema: string) {
+  return /*sql*/ `
+  CREATE TABLE ${schema}."mutations" (
+    "clientGroupID"  TEXT NOT NULL,
+    "clientID"       TEXT NOT NULL,
+    "mutationID"     BIGINT NOT NULL,
+    "result"         JSON NOT NULL,
+    PRIMARY KEY("clientGroupID", "clientID", "mutationID")
   );`;
 }
 

--- a/packages/zero-cache/src/services/view-syncer/client-handler.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.ts
@@ -118,6 +118,7 @@ export class ClientHandler {
   readonly clientID: string;
   readonly wsID: string;
   readonly #zeroClientsTable: string;
+  readonly #zeroMutationsTable: string;
   readonly #lc: LogContext;
   readonly #downstream: Subscription<Downstream>;
   #baseVersion: NullableCVRVersion;
@@ -138,6 +139,7 @@ export class ClientHandler {
     this.clientID = clientID;
     this.wsID = wsID;
     this.#zeroClientsTable = `${upstreamSchema(shard)}.clients`;
+    this.#zeroMutationsTable = `${upstreamSchema(shard)}.mutations`;
     this.#lc = lc;
     this.#downstream = downstream;
     this.#baseVersion = cookieToVersion(baseCookie);
@@ -240,6 +242,8 @@ export class ClientHandler {
         case 'row':
           if (patch.id.table === this.#zeroClientsTable) {
             this.#updateLMIDs((body.lastMutationIDChanges ??= {}), patch);
+          } else if (patch.id.table === this.#zeroMutationsTable) {
+            // no-op for now
           } else {
             (body.rowsPatch ??= []).push(makeRowPatch(patch));
           }

--- a/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
@@ -1052,7 +1052,11 @@ describe('view-syncer/cvr', () => {
         },
         mutationResults: {
           ast: {
-            orderBy: [['mutationID', 'asc']],
+            orderBy: [
+              ['clientGroupID', 'asc'],
+              ['clientID', 'asc'],
+              ['mutationID', 'asc'],
+            ],
             schema: '',
             table: 'dapp_3.mutations',
             where: {
@@ -1253,7 +1257,11 @@ describe('view-syncer/cvr', () => {
         },
         {
           clientAST: {
-            orderBy: [['mutationID', 'asc']],
+            orderBy: [
+              ['clientGroupID', 'asc'],
+              ['clientID', 'asc'],
+              ['mutationID', 'asc'],
+            ],
             schema: '',
             table: `${APP_ID}_${SHARD_NUM}.mutations`,
             where: {

--- a/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
@@ -995,10 +995,10 @@ describe('view-syncer/cvr', () => {
         "clients": 2,
         "desires": 8,
         "instances": 1,
-        "queries": 9,
+        "queries": 10,
         "rows": 0,
         "rowsDeferred": 0,
-        "statements": 21,
+        "statements": 22,
       }
     `);
     expect(updated).toEqual({
@@ -1049,6 +1049,44 @@ describe('view-syncer/cvr', () => {
               ['clientID', 'asc'],
             ],
           },
+        },
+        mutationResults: {
+          ast: {
+            orderBy: [['mutationID', 'asc']],
+            schema: '',
+            table: 'dapp_3.mutations',
+            where: {
+              conditions: [
+                {
+                  left: {
+                    name: 'clientGroupID',
+                    type: 'column',
+                  },
+                  op: '=',
+                  right: {
+                    type: 'literal',
+                    value: 'abc123',
+                  },
+                  type: 'simple',
+                },
+                {
+                  left: {
+                    name: 'clientID',
+                    type: 'column',
+                  },
+                  op: '=',
+                  right: {
+                    type: 'literal',
+                    value: 'barClient',
+                  },
+                  type: 'simple',
+                },
+              ],
+              type: 'and',
+            },
+          },
+          id: 'mutationResults',
+          type: 'internal',
         },
         xCustomHash: {
           args: [],
@@ -1210,6 +1248,51 @@ describe('view-syncer/cvr', () => {
           internal: true,
           patchVersion: null,
           queryHash: 'lmids',
+          transformationHash: null,
+          transformationVersion: null,
+        },
+        {
+          clientAST: {
+            orderBy: [['mutationID', 'asc']],
+            schema: '',
+            table: `${APP_ID}_${SHARD_NUM}.mutations`,
+            where: {
+              conditions: [
+                {
+                  left: {
+                    name: 'clientGroupID',
+                    type: 'column',
+                  },
+                  op: '=',
+                  right: {
+                    type: 'literal',
+                    value: 'abc123',
+                  },
+                  type: 'simple',
+                },
+                {
+                  left: {
+                    name: 'clientID',
+                    type: 'column',
+                  },
+                  op: '=',
+                  right: {
+                    type: 'literal',
+                    value: 'barClient',
+                  },
+                  type: 'simple',
+                },
+              ],
+              type: 'and',
+            },
+          },
+          clientGroupID: 'abc123',
+          deleted: false,
+          internal: true,
+          patchVersion: null,
+          queryArgs: null,
+          queryHash: 'mutationResults',
+          queryName: null,
           transformationHash: null,
           transformationVersion: null,
         },

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -80,6 +80,7 @@ export type CVRSnapshot = {
 };
 
 const CLIENT_LMID_QUERY_ID = 'lmids';
+const CLIENT_MUTATION_RESULTS_QUERY_ID = 'mutationResults';
 
 function assertNotInternal(
   query: QueryRecord,
@@ -224,6 +225,52 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
       };
       this._cvr.queries[CLIENT_LMID_QUERY_ID] = lmidsQuery;
       this._cvrStore.putQuery(lmidsQuery);
+
+      const mutationResultsQuery: InternalQueryRecord = {
+        id: CLIENT_MUTATION_RESULTS_QUERY_ID,
+        type: 'internal',
+        ast: {
+          schema: '',
+          table: `${upstreamSchema(this.#shard)}.mutations`,
+          where: {
+            type: 'and',
+            conditions: [
+              {
+                type: 'simple',
+                left: {
+                  type: 'column',
+                  name: 'clientGroupID',
+                },
+                op: '=',
+                right: {
+                  type: 'literal',
+                  value: this._cvr.id,
+                },
+              },
+              {
+                type: 'simple',
+                left: {
+                  type: 'column',
+                  name: 'clientID',
+                },
+                op: '=',
+                right: {
+                  type: 'literal',
+                  value: id,
+                },
+              },
+            ],
+          },
+          orderBy: [
+            ['clientGroupID', 'asc'],
+            ['clientID', 'asc'],
+            ['mutationID', 'asc'],
+          ],
+        },
+      };
+      this._cvr.queries[CLIENT_MUTATION_RESULTS_QUERY_ID] =
+        mutationResultsQuery;
+      this._cvrStore.putQuery(mutationResultsQuery);
     }
     return client;
   }

--- a/packages/zero-cache/src/services/view-syncer/view-syncer-test-util.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer-test-util.ts
@@ -564,6 +564,14 @@ export async function setup(
     _0_version       TEXT NOT NULL,
     PRIMARY KEY ("clientGroupID", "clientID")
   );
+  CREATE TABLE "this_app_2.mutations" (
+    "clientGroupID"  TEXT,
+    "clientID"       TEXT,
+    "mutationID"     INTEGER,
+    "result"         TEXT,
+    _0_version       TEXT NOT NULL,
+    PRIMARY KEY ("clientGroupID", "clientID", "mutationID")
+  );
   CREATE TABLE "this_app.schemaVersions" (
     "lock"                INT PRIMARY KEY,
     "minSupportedVersion" INT,


### PR DESCRIPTION
- adds a table to track mutation responses to upstream
- adds an internal query to sync that table to zero-cache
- currently ignores those rows in client-handler 