### PR TITLE
chore(zero): wire client and server together for mutation results  [2/n]

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/client-handler.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.ts
@@ -251,7 +251,6 @@ export class ClientHandler {
                 mutationRowSchema,
                 'passthrough',
               );
-              console.log('MUTATION RESULT', row.result);
               patches.push({
                 op: 'put',
                 // TODO: is this not already parsed?

--- a/packages/zero-client/src/client/custom.test.ts
+++ b/packages/zero-client/src/client/custom.test.ts
@@ -29,23 +29,6 @@ import {refCountSymbol} from '../../../zql/src/ivm/view-apply-change.ts';
 
 type Schema = typeof schema;
 
-// beforeEach(() => {
-//   let frameId = 0;
-
-//   vi.stubGlobal(
-//     'requestAnimationFrame',
-//     vi.fn(callback => {
-//       frameId++;
-//       setTimeout(() => callback(performance.now()), 0);
-//       return frameId;
-//     }),
-//   );
-// });
-
-// afterEach(() => {
-//   vi.unstubAllGlobals();
-// });
-
 test('argument types are preserved on the generated mutator interface', () => {
   const mutators = {
     issue: {

--- a/packages/zero-client/src/client/mutation-tracker.ts
+++ b/packages/zero-client/src/client/mutation-tracker.ts
@@ -14,6 +14,7 @@ import type {
   PushResponse,
 } from '../../../zero-protocol/src/push.ts';
 import type {ZeroLogContext} from './zero-log-context.ts';
+import type {MutationPatch} from '../../../zero-protocol/src/mutations-patch.ts';
 
 type ErrorType =
   | MutationError
@@ -96,6 +97,23 @@ export class MutationTracker {
     const entry = this.#outstandingMutations.get(id);
     if (entry) {
       this.#settleMutation(id, entry, 'reject', e);
+    }
+  }
+
+  /**
+   * Used when zero-cache pokes down mutation results.
+   */
+  processMutationResponses(patches: MutationPatch[]) {
+    for (const patch of patches) {
+      if (patch.mutation.id.clientID !== this.#clientID) {
+        continue; // Mutation for a different client. We will not have its promise.
+      }
+
+      if ('error' in patch.mutation.result) {
+        this.#processMutationError(patch.mutation.id, patch.mutation.result);
+      } else {
+        this.#processMutationOk(patch.mutation.id, patch.mutation.result);
+      }
     }
   }
 
@@ -274,7 +292,7 @@ export class MutationTracker {
       if ('error' in mutation.result) {
         this.#processMutationError(mutation.id, mutation.result);
       } else {
-        this.#processMutationOk(mutation.result, mutation.id);
+        this.#processMutationOk(mutation.id, mutation.result);
       }
     }
   }
@@ -315,7 +333,7 @@ export class MutationTracker {
     this.#settleMutation(ephemeralID, entry, 'reject', error);
   }
 
-  #processMutationOk(result: MutationOk, mid: MutationID): void {
+  #processMutationOk(mid: MutationID, result: MutationOk): void {
     assert(
       mid.clientID === this.#clientID,
       'received mutation for the wrong client',

--- a/packages/zero-client/src/client/mutation-tracker.ts
+++ b/packages/zero-client/src/client/mutation-tracker.ts
@@ -208,6 +208,7 @@ export class MutationTracker {
     if (lastMutationID === this.#currentMutationID) {
       return;
     }
+
     try {
       this.#currentMutationID = lastMutationID;
       this.#resolveLimboMutations(lastMutationID);

--- a/packages/zero-client/src/client/zero-poke-handler.test.ts
+++ b/packages/zero-client/src/client/zero-poke-handler.test.ts
@@ -4,6 +4,7 @@ import {
   type MockInstance,
   afterEach,
   beforeEach,
+  describe,
   expect,
   suite,
   test,
@@ -14,21 +15,12 @@ import {string, table} from '../../../zero-schema/src/builder/table-builder.ts';
 import {serverToClient} from '../../../zero-schema/src/name-mapper.ts';
 import {PokeHandler, mergePokes} from './zero-poke-handler.ts';
 import {MutationTracker} from './mutation-tracker.ts';
+import type {MutationPatch} from '../../../zero-protocol/src/mutations-patch.ts';
 
 let rafStub: MockInstance<(cb: FrameRequestCallback) => number>;
 // The FrameRequestCallback in PokeHandler does not use
 // its time argument, so use an arbitrary constant for it in tests.
 const UNUSED_RAF_ARG = 10;
-
-beforeEach(() => {
-  rafStub = vi
-    .spyOn(globalThis, 'requestAnimationFrame')
-    .mockImplementation(() => 0);
-});
-
-afterEach(() => {
-  vi.restoreAllMocks();
-});
 
 const schema = createSchema({
   tables: [
@@ -49,138 +41,39 @@ const schema = createSchema({
   ],
 });
 
-test('completed poke plays on first raf', async () => {
-  const onPokeErrorStub = vi.fn();
-  const replicachePokeStub = vi.fn();
-  const clientID = 'c1';
-  const logContext = new LogContext('error');
-  const pokeHandler = new PokeHandler(
-    replicachePokeStub,
-    onPokeErrorStub,
-    clientID,
-    schema,
-    logContext,
-    new MutationTracker(logContext),
-  );
-  expect(rafStub).toHaveBeenCalledTimes(0);
-
-  pokeHandler.handlePokeStart({
-    pokeID: 'poke1',
-    baseCookie: '1',
-    schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
-  });
-  pokeHandler.handlePokePart({
-    pokeID: 'poke1',
-    lastMutationIDChanges: {
-      c1: 1,
-      c2: 2,
-    },
-    rowsPatch: [
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {
-          ['issue_id']: 'issue1',
-          title: 'foo1',
-          description: 'columns not in client schema pass through',
-        },
-      },
-    ],
-  });
-  pokeHandler.handlePokePart({
-    pokeID: 'poke1',
-    lastMutationIDChanges: {
-      c1: 2,
-    },
-    rowsPatch: [
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue1', title: 'foo2'},
-      },
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue2', title: 'bar1'},
-      },
-    ],
+describe('poke handler', () => {
+  beforeEach(() => {
+    rafStub = vi
+      .spyOn(globalThis, 'requestAnimationFrame')
+      .mockImplementation(() => 0);
   });
 
-  expect(rafStub).toHaveBeenCalledTimes(0);
-
-  pokeHandler.handlePokeEnd({pokeID: 'poke1', cookie: '2'});
-
-  expect(rafStub).toHaveBeenCalledTimes(1);
-  expect(replicachePokeStub).toHaveBeenCalledTimes(0);
-
-  const rafCallback0 = rafStub.mock.calls[0][0];
-  await rafCallback0(UNUSED_RAF_ARG);
-
-  expect(replicachePokeStub).toHaveBeenCalledTimes(1);
-  const replicachePoke0 = replicachePokeStub.mock.calls[0][0];
-  expect(replicachePoke0).to.deep.equal({
-    baseCookie: '1',
-    pullResponse: {
-      cookie: '2',
-      lastMutationIDChanges: {
-        c1: 2,
-        c2: 2,
-      },
-      patch: [
-        {
-          op: 'put',
-          key: 'e/issue/issue1',
-          value: {
-            id: 'issue1',
-            title: 'foo1',
-            description: 'columns not in client schema pass through',
-          },
-        },
-        {
-          op: 'put',
-          key: 'e/issue/issue1',
-          value: {id: 'issue1', title: 'foo2'},
-        },
-        {
-          op: 'put',
-          key: 'e/issue/issue2',
-          value: {id: 'issue2', title: 'bar1'},
-        },
-      ],
-    },
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
-  expect(rafStub).toHaveBeenCalledTimes(2);
+  test('completed poke plays on first raf', async () => {
+    const onPokeErrorStub = vi.fn();
+    const replicachePokeStub = vi.fn();
+    const clientID = 'c1';
+    const logContext = new LogContext('error');
+    const pokeHandler = new PokeHandler(
+      replicachePokeStub,
+      onPokeErrorStub,
+      clientID,
+      schema,
+      logContext,
+      new MutationTracker(logContext),
+    );
+    expect(rafStub).toHaveBeenCalledTimes(0);
 
-  const rafCallback1 = rafStub.mock.calls[1][0];
-  await rafCallback1(UNUSED_RAF_ARG);
-  expect(replicachePokeStub).toHaveBeenCalledTimes(1);
-  expect(rafStub).toHaveBeenCalledTimes(2);
-});
-
-test('canceled poke is not applied', async () => {
-  const onPokeErrorStub = vi.fn();
-  const replicachePokeStub = vi.fn();
-  const clientID = 'c1';
-  const logContext = new LogContext('error');
-  const pokeHandler = new PokeHandler(
-    replicachePokeStub,
-    onPokeErrorStub,
-    clientID,
-    schema,
-    logContext,
-    new MutationTracker(logContext),
-  );
-  expect(rafStub).toHaveBeenCalledTimes(0);
-
-  const pokeStartAndParts = (pokeID: string) => {
     pokeHandler.handlePokeStart({
-      pokeID,
+      pokeID: 'poke1',
       baseCookie: '1',
       schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
     });
     pokeHandler.handlePokePart({
-      pokeID,
+      pokeID: 'poke1',
       lastMutationIDChanges: {
         c1: 1,
         c2: 2,
@@ -189,12 +82,16 @@ test('canceled poke is not applied', async () => {
         {
           op: 'put',
           tableName: 'issues',
-          value: {['issue_id']: 'issue1', title: 'foo1'},
+          value: {
+            ['issue_id']: 'issue1',
+            title: 'foo1',
+            description: 'columns not in client schema pass through',
+          },
         },
       ],
     });
     pokeHandler.handlePokePart({
-      pokeID,
+      pokeID: 'poke1',
       lastMutationIDChanges: {
         c1: 2,
       },
@@ -211,1319 +108,1119 @@ test('canceled poke is not applied', async () => {
         },
       ],
     });
-  };
-  pokeStartAndParts('poke1');
 
-  expect(rafStub).toHaveBeenCalledTimes(0);
+    expect(rafStub).toHaveBeenCalledTimes(0);
 
-  pokeHandler.handlePokeEnd({pokeID: 'poke1', cookie: '', cancel: true});
+    pokeHandler.handlePokeEnd({pokeID: 'poke1', cookie: '2'});
 
-  // raf is not scheduled because poke was canceled;
-  expect(rafStub).toHaveBeenCalledTimes(0);
-  expect(replicachePokeStub).toHaveBeenCalledTimes(0);
+    expect(rafStub).toHaveBeenCalledTimes(1);
+    expect(replicachePokeStub).toHaveBeenCalledTimes(0);
 
-  // now test receiving a poke after the canceled poke
-  pokeStartAndParts('poke2');
+    const rafCallback0 = rafStub.mock.calls[0][0];
+    await rafCallback0(UNUSED_RAF_ARG);
 
-  expect(rafStub).toHaveBeenCalledTimes(0);
-
-  pokeHandler.handlePokeEnd({pokeID: 'poke2', cookie: '2'});
-
-  expect(rafStub).toHaveBeenCalledTimes(1);
-  expect(replicachePokeStub).toHaveBeenCalledTimes(0);
-
-  const rafCallback0 = rafStub.mock.calls[0][0];
-  await rafCallback0(UNUSED_RAF_ARG);
-
-  expect(replicachePokeStub).toHaveBeenCalledTimes(1);
-  const replicachePoke0 = replicachePokeStub.mock.calls[0][0];
-  expect(replicachePoke0).to.deep.equal({
-    baseCookie: '1',
-    pullResponse: {
-      cookie: '2',
-      lastMutationIDChanges: {
-        c1: 2,
-        c2: 2,
-      },
-      patch: [
-        {
-          op: 'put',
-          key: 'e/issue/issue1',
-          value: {id: 'issue1', title: 'foo1'},
+    expect(replicachePokeStub).toHaveBeenCalledTimes(1);
+    const replicachePoke0 = replicachePokeStub.mock.calls[0][0];
+    expect(replicachePoke0).to.deep.equal({
+      baseCookie: '1',
+      pullResponse: {
+        cookie: '2',
+        lastMutationIDChanges: {
+          c1: 2,
+          c2: 2,
         },
-        {
-          op: 'put',
-          key: 'e/issue/issue1',
-          value: {id: 'issue1', title: 'foo2'},
-        },
-        {
-          op: 'put',
-          key: 'e/issue/issue2',
-          value: {id: 'issue2', title: 'bar1'},
-        },
-      ],
-    },
-  });
-
-  expect(rafStub).toHaveBeenCalledTimes(2);
-
-  const rafCallback1 = rafStub.mock.calls[1][0];
-  await rafCallback1(UNUSED_RAF_ARG);
-  expect(replicachePokeStub).toHaveBeenCalledTimes(1);
-  expect(rafStub).toHaveBeenCalledTimes(2);
-});
-
-test('multiple pokes received before raf callback are merged', async () => {
-  const onPokeErrorStub = vi.fn();
-  const replicachePokeStub = vi.fn();
-  const clientID = 'c1';
-  const logContext = new LogContext('error');
-  const pokeHandler = new PokeHandler(
-    replicachePokeStub,
-    onPokeErrorStub,
-    clientID,
-    schema,
-    logContext,
-    new MutationTracker(logContext),
-  );
-
-  expect(rafStub).toHaveBeenCalledTimes(0);
-
-  pokeHandler.handlePokeStart({
-    pokeID: 'poke1',
-    baseCookie: '1',
-    schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
-  });
-  pokeHandler.handlePokePart({
-    pokeID: 'poke1',
-    lastMutationIDChanges: {
-      c1: 1,
-      c2: 2,
-    },
-    rowsPatch: [
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue1', title: 'foo1'},
+        patch: [
+          {
+            op: 'put',
+            key: 'e/issue/issue1',
+            value: {
+              id: 'issue1',
+              title: 'foo1',
+              description: 'columns not in client schema pass through',
+            },
+          },
+          {
+            op: 'put',
+            key: 'e/issue/issue1',
+            value: {id: 'issue1', title: 'foo2'},
+          },
+          {
+            op: 'put',
+            key: 'e/issue/issue2',
+            value: {id: 'issue2', title: 'bar1'},
+          },
+        ],
       },
-    ],
-  });
-  pokeHandler.handlePokePart({
-    pokeID: 'poke1',
-    lastMutationIDChanges: {
-      c1: 2,
-    },
-    rowsPatch: [
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue1', title: 'foo2'},
-      },
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue2', title: 'bar1'},
-      },
-    ],
-  });
-
-  expect(rafStub).toHaveBeenCalledTimes(0);
-  pokeHandler.handlePokeEnd({pokeID: 'poke1', cookie: '2'});
-
-  expect(rafStub).toHaveBeenCalledTimes(1);
-  expect(replicachePokeStub).toHaveBeenCalledTimes(0);
-
-  pokeHandler.handlePokeStart({
-    pokeID: 'poke2',
-    baseCookie: '2',
-    schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
-  });
-  pokeHandler.handlePokePart({
-    pokeID: 'poke2',
-    lastMutationIDChanges: {
-      c1: 3,
-    },
-    rowsPatch: [
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue3', title: 'baz1'},
-      },
-    ],
-  });
-  pokeHandler.handlePokePart({
-    pokeID: 'poke2',
-    lastMutationIDChanges: {
-      c3: 1,
-    },
-    rowsPatch: [
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue2', title: 'bar2'},
-      },
-    ],
-  });
-
-  expect(rafStub).toHaveBeenCalledTimes(1);
-
-  pokeHandler.handlePokeEnd({pokeID: 'poke2', cookie: '3'});
-
-  expect(rafStub).toHaveBeenCalledTimes(1);
-  expect(replicachePokeStub).toHaveBeenCalledTimes(0);
-
-  const rafCallback0 = rafStub.mock.calls[0][0];
-  await rafCallback0(UNUSED_RAF_ARG);
-
-  expect(replicachePokeStub).toHaveBeenCalledTimes(1);
-  const replicachePoke0 = replicachePokeStub.mock.calls[0][0];
-  expect(replicachePoke0).to.deep.equal({
-    baseCookie: '1',
-    pullResponse: {
-      cookie: '3',
-      lastMutationIDChanges: {
-        c1: 3,
-        c2: 2,
-        c3: 1,
-      },
-      patch: [
-        {
-          op: 'put',
-          key: 'e/issue/issue1',
-          value: {id: 'issue1', title: 'foo1'},
-        },
-        {
-          op: 'put',
-          key: 'e/issue/issue1',
-          value: {id: 'issue1', title: 'foo2'},
-        },
-        {
-          op: 'put',
-          key: 'e/issue/issue2',
-          value: {id: 'issue2', title: 'bar1'},
-        },
-        {
-          op: 'put',
-          key: 'e/issue/issue3',
-          value: {id: 'issue3', title: 'baz1'},
-        },
-        {
-          op: 'put',
-          key: 'e/issue/issue2',
-          value: {id: 'issue2', title: 'bar2'},
-        },
-      ],
-    },
-  });
-
-  expect(rafStub).toHaveBeenCalledTimes(2);
-
-  const rafCallback1 = rafStub.mock.calls[1][0];
-  await rafCallback1(UNUSED_RAF_ARG);
-  expect(replicachePokeStub).toHaveBeenCalledTimes(1);
-  expect(rafStub).toHaveBeenCalledTimes(2);
-});
-
-test('multiple pokes received before raf callback are merged, canceled pokes are not merged', async () => {
-  const onPokeErrorStub = vi.fn();
-  const replicachePokeStub = vi.fn();
-  const clientID = 'c1';
-  const logContext = new LogContext('error');
-  const pokeHandler = new PokeHandler(
-    replicachePokeStub,
-    onPokeErrorStub,
-    clientID,
-    schema,
-    logContext,
-    new MutationTracker(logContext),
-  );
-
-  expect(rafStub).toHaveBeenCalledTimes(0);
-
-  pokeHandler.handlePokeStart({
-    pokeID: 'poke1',
-    baseCookie: '1',
-    schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
-  });
-  pokeHandler.handlePokePart({
-    pokeID: 'poke1',
-    lastMutationIDChanges: {
-      c1: 1,
-      c2: 2,
-    },
-    rowsPatch: [
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue1', title: 'foo1'},
-      },
-    ],
-  });
-  pokeHandler.handlePokePart({
-    pokeID: 'poke1',
-    lastMutationIDChanges: {
-      c1: 2,
-    },
-    rowsPatch: [
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue1', title: 'foo2'},
-      },
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue2', title: 'bar1'},
-      },
-    ],
-  });
-
-  expect(rafStub).toHaveBeenCalledTimes(0);
-  pokeHandler.handlePokeEnd({pokeID: 'poke1', cookie: '2'});
-
-  expect(rafStub).toHaveBeenCalledTimes(1);
-  expect(replicachePokeStub).toHaveBeenCalledTimes(0);
-
-  pokeHandler.handlePokeStart({
-    pokeID: 'poke2',
-    baseCookie: '2',
-    schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
-  });
-  pokeHandler.handlePokePart({
-    pokeID: 'poke2',
-    lastMutationIDChanges: {
-      c1: 3,
-    },
-    rowsPatch: [
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue3', title: 'baz1'},
-      },
-    ],
-  });
-  pokeHandler.handlePokePart({
-    pokeID: 'poke2',
-    lastMutationIDChanges: {
-      c3: 1,
-    },
-    rowsPatch: [
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue2', title: 'bar2'},
-      },
-    ],
-  });
-
-  expect(rafStub).toHaveBeenCalledTimes(1);
-
-  pokeHandler.handlePokeEnd({pokeID: 'poke2', cookie: '', cancel: true});
-
-  expect(rafStub).toHaveBeenCalledTimes(1);
-  expect(replicachePokeStub).toHaveBeenCalledTimes(0);
-
-  pokeHandler.handlePokeStart({
-    pokeID: 'poke3',
-    baseCookie: '2',
-    schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
-  });
-  pokeHandler.handlePokePart({
-    pokeID: 'poke3',
-    lastMutationIDChanges: {
-      c1: 3,
-    },
-    rowsPatch: [
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue4', title: 'baz2'},
-      },
-    ],
-  });
-
-  expect(rafStub).toHaveBeenCalledTimes(1);
-
-  pokeHandler.handlePokeEnd({pokeID: 'poke3', cookie: '3'});
-
-  const rafCallback0 = rafStub.mock.calls[0][0];
-  await rafCallback0(UNUSED_RAF_ARG);
-
-  expect(replicachePokeStub).toHaveBeenCalledTimes(1);
-  const replicachePoke0 = replicachePokeStub.mock.calls[0][0];
-  expect(replicachePoke0).to.deep.equal({
-    baseCookie: '1',
-    pullResponse: {
-      cookie: '3',
-      lastMutationIDChanges: {
-        c1: 3,
-        c2: 2,
-        // Not included because corresponding poke was canceled
-        // c3: 1,
-      },
-      patch: [
-        {
-          op: 'put',
-          key: 'e/issue/issue1',
-          value: {id: 'issue1', title: 'foo1'},
-        },
-        {
-          op: 'put',
-          key: 'e/issue/issue1',
-          value: {id: 'issue1', title: 'foo2'},
-        },
-        {
-          op: 'put',
-          key: 'e/issue/issue2',
-          value: {id: 'issue2', title: 'bar1'},
-        },
-        // Following not included because corresponding poke was canceled
-        // {
-        //   op: 'put',
-        //   key: 'e/issue/issue3',
-        //   value: {id: 'issue3', title: 'baz1'},
-        // },
-        // {
-        //   op: 'put',
-        //   key: 'e/issue/issue2',
-        //   value: {id: 'issue2', title: 'bar2'},
-        // },
-        // non-canceled poke after canceled poke is merged
-        {
-          op: 'put',
-          key: 'e/issue/issue4',
-          value: {id: 'issue4', title: 'baz2'},
-        },
-      ],
-    },
-  });
-
-  expect(rafStub).toHaveBeenCalledTimes(2);
-
-  const rafCallback1 = rafStub.mock.calls[1][0];
-  await rafCallback1(UNUSED_RAF_ARG);
-  expect(replicachePokeStub).toHaveBeenCalledTimes(1);
-  expect(rafStub).toHaveBeenCalledTimes(2);
-});
-
-test('playback over series of rafs', async () => {
-  const onPokeErrorStub = vi.fn();
-  const replicachePokeStub = vi.fn();
-  const clientID = 'c1';
-  const logContext = new LogContext('error');
-  const pokeHandler = new PokeHandler(
-    replicachePokeStub,
-    onPokeErrorStub,
-    clientID,
-    schema,
-    logContext,
-    new MutationTracker(logContext),
-  );
-
-  expect(rafStub).toHaveBeenCalledTimes(0);
-
-  pokeHandler.handlePokeStart({
-    pokeID: 'poke1',
-    baseCookie: '1',
-    schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
-  });
-  pokeHandler.handlePokePart({
-    pokeID: 'poke1',
-    lastMutationIDChanges: {
-      c1: 1,
-      c2: 2,
-    },
-    rowsPatch: [
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue1', title: 'foo1'},
-      },
-    ],
-  });
-  pokeHandler.handlePokePart({
-    pokeID: 'poke1',
-    lastMutationIDChanges: {
-      c1: 2,
-    },
-    rowsPatch: [
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue1', title: 'foo2'},
-      },
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue2', title: 'bar1'},
-      },
-    ],
-  });
-
-  expect(rafStub).toHaveBeenCalledTimes(0);
-  pokeHandler.handlePokeEnd({pokeID: 'poke1', cookie: '2'});
-
-  expect(rafStub).toHaveBeenCalledTimes(1);
-  expect(replicachePokeStub).toHaveBeenCalledTimes(0);
-
-  const rafCallback0 = rafStub.mock.calls[0][0];
-  await rafCallback0(UNUSED_RAF_ARG);
-
-  expect(replicachePokeStub).toHaveBeenCalledTimes(1);
-  const replicachePoke0 = replicachePokeStub.mock.calls[0][0];
-  expect(replicachePoke0).to.deep.equal({
-    baseCookie: '1',
-    pullResponse: {
-      cookie: '2',
-      lastMutationIDChanges: {
-        c1: 2,
-        c2: 2,
-      },
-      patch: [
-        {
-          op: 'put',
-          key: 'e/issue/issue1',
-          value: {id: 'issue1', title: 'foo1'},
-        },
-        {
-          op: 'put',
-          key: 'e/issue/issue1',
-          value: {id: 'issue1', title: 'foo2'},
-        },
-        {
-          op: 'put',
-          key: 'e/issue/issue2',
-          value: {id: 'issue2', title: 'bar1'},
-        },
-      ],
-    },
-  });
-
-  expect(rafStub).toHaveBeenCalledTimes(2);
-
-  pokeHandler.handlePokeStart({
-    pokeID: 'poke2',
-    baseCookie: '2',
-    schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
-  });
-  pokeHandler.handlePokePart({
-    pokeID: 'poke2',
-    lastMutationIDChanges: {
-      c1: 3,
-    },
-    rowsPatch: [
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue3', title: 'baz1'},
-      },
-    ],
-  });
-  pokeHandler.handlePokePart({
-    pokeID: 'poke2',
-    lastMutationIDChanges: {
-      c3: 1,
-    },
-    rowsPatch: [
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue2', title: 'bar2'},
-      },
-    ],
-  });
-
-  expect(rafStub).toHaveBeenCalledTimes(2);
-
-  pokeHandler.handlePokeEnd({pokeID: 'poke2', cookie: '3'});
-
-  expect(rafStub).toHaveBeenCalledTimes(2);
-  expect(replicachePokeStub).toHaveBeenCalledTimes(1);
-
-  const rafCallback1 = rafStub.mock.calls[1][0];
-  await rafCallback1(UNUSED_RAF_ARG);
-
-  expect(replicachePokeStub).toHaveBeenCalledTimes(2);
-  const replicachePoke1 = replicachePokeStub.mock.calls[1][0];
-  expect(replicachePoke1).to.deep.equal({
-    baseCookie: '2',
-    pullResponse: {
-      cookie: '3',
-      lastMutationIDChanges: {
-        c1: 3,
-        c3: 1,
-      },
-      patch: [
-        {
-          op: 'put',
-          key: 'e/issue/issue3',
-          value: {id: 'issue3', title: 'baz1'},
-        },
-        {
-          op: 'put',
-          key: 'e/issue/issue2',
-          value: {id: 'issue2', title: 'bar2'},
-        },
-      ],
-    },
-  });
-
-  expect(rafStub).toHaveBeenCalledTimes(3);
-
-  const rafCallback2 = rafStub.mock.calls[2][0];
-  await rafCallback2(UNUSED_RAF_ARG);
-  expect(replicachePokeStub).toHaveBeenCalledTimes(2);
-  expect(rafStub).toHaveBeenCalledTimes(3);
-});
-
-suite('onPokeErrors', () => {
-  const cases: {
-    name: string;
-    causeError: (pokeHandler: PokeHandler) => void;
-  }[] = [
-    {
-      name: 'pokePart before pokeStart',
-      causeError: pokeHandler => {
-        pokeHandler.handlePokePart({pokeID: 'poke1'});
-      },
-    },
-    {
-      name: 'pokeEnd before pokeStart',
-      causeError: pokeHandler => {
-        pokeHandler.handlePokeEnd({pokeID: 'poke1', cookie: '2'});
-      },
-    },
-    {
-      name: 'pokePart with wrong pokeID',
-      causeError: pokeHandler => {
-        pokeHandler.handlePokeStart({
-          pokeID: 'poke1',
-          baseCookie: '1',
-          schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
-        });
-        pokeHandler.handlePokePart({pokeID: 'poke2'});
-      },
-    },
-    {
-      name: 'pokeEnd with wrong pokeID',
-      causeError: pokeHandler => {
-        pokeHandler.handlePokeStart({
-          pokeID: 'poke1',
-          baseCookie: '1',
-          schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
-        });
-        pokeHandler.handlePokeEnd({pokeID: 'poke2', cookie: '2'});
-      },
-    },
-  ];
-  for (const c of cases) {
-    test(c.name, () => {
-      const onPokeErrorStub = vi.fn();
-      const replicachePokeStub = vi.fn();
-      const clientID = 'c1';
-      const logContext = new LogContext('error');
-      const pokeHandler = new PokeHandler(
-        replicachePokeStub,
-        onPokeErrorStub,
-        clientID,
-        schema,
-        logContext,
-        new MutationTracker(logContext),
-      );
-
-      expect(onPokeErrorStub).toHaveBeenCalledTimes(0);
-      c.causeError(pokeHandler);
-      expect(onPokeErrorStub).toHaveBeenCalledTimes(1);
     });
-  }
-});
 
-test('replicachePoke throwing error calls onPokeError and clears', async () => {
-  const onPokeErrorStub = vi.fn();
-  const replicachePokeStub = vi.fn();
-  const clientID = 'c1';
-  const logContext = new LogContext('error');
-  const pokeHandler = new PokeHandler(
-    replicachePokeStub,
-    onPokeErrorStub,
-    clientID,
-    schema,
-    logContext,
-    new MutationTracker(logContext),
-  );
-  expect(rafStub).toHaveBeenCalledTimes(0);
+    expect(rafStub).toHaveBeenCalledTimes(2);
 
-  pokeHandler.handlePokeStart({
-    pokeID: 'poke1',
-    baseCookie: '1',
-    schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
-  });
-  pokeHandler.handlePokePart({
-    pokeID: 'poke1',
-    lastMutationIDChanges: {
-      c1: 1,
-      c2: 2,
-    },
-    rowsPatch: [
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue1', title: 'foo1'},
-      },
-    ],
-  });
-  pokeHandler.handlePokePart({
-    pokeID: 'poke1',
-    lastMutationIDChanges: {
-      c1: 2,
-    },
-    rowsPatch: [
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue1', title: 'foo2'},
-      },
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue2', title: 'bar1'},
-      },
-    ],
+    const rafCallback1 = rafStub.mock.calls[1][0];
+    await rafCallback1(UNUSED_RAF_ARG);
+    expect(replicachePokeStub).toHaveBeenCalledTimes(1);
+    expect(rafStub).toHaveBeenCalledTimes(2);
   });
 
-  expect(rafStub).toHaveBeenCalledTimes(0);
+  test('canceled poke is not applied', async () => {
+    const onPokeErrorStub = vi.fn();
+    const replicachePokeStub = vi.fn();
+    const clientID = 'c1';
+    const logContext = new LogContext('error');
+    const pokeHandler = new PokeHandler(
+      replicachePokeStub,
+      onPokeErrorStub,
+      clientID,
+      schema,
+      logContext,
+      new MutationTracker(logContext),
+    );
+    expect(rafStub).toHaveBeenCalledTimes(0);
 
-  pokeHandler.handlePokeEnd({pokeID: 'poke1', cookie: '2'});
-
-  expect(rafStub).toHaveBeenCalledTimes(1);
-  expect(replicachePokeStub).toHaveBeenCalledTimes(0);
-
-  const {promise, reject} = resolver();
-  replicachePokeStub.mockReturnValue(promise);
-  expect(onPokeErrorStub).toHaveBeenCalledTimes(0);
-
-  const rafCallback0 = rafStub.mock.calls[0][0];
-  const rafCallback0Result = rafCallback0(UNUSED_RAF_ARG);
-
-  expect(onPokeErrorStub).toHaveBeenCalledTimes(0);
-
-  pokeHandler.handlePokeStart({
-    pokeID: 'poke2',
-    baseCookie: '2',
-    schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
-  });
-  pokeHandler.handlePokePart({
-    pokeID: 'poke2',
-    lastMutationIDChanges: {
-      c1: 3,
-    },
-    rowsPatch: [
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue3', title: 'baz1'},
-      },
-    ],
-  });
-  pokeHandler.handlePokeEnd({
-    pokeID: 'poke2',
-    cookie: '3',
-  });
-
-  reject('error in poke');
-  await rafCallback0Result;
-
-  expect(replicachePokeStub).toHaveBeenCalledTimes(1);
-  expect(rafStub).toHaveBeenCalledTimes(2);
-
-  expect(onPokeErrorStub).toHaveBeenCalledTimes(1);
-
-  const rafCallback1 = rafStub.mock.calls[1][0];
-  await rafCallback1(UNUSED_RAF_ARG);
-  // poke 2 cleared so replicachePokeStub not called
-  expect(replicachePokeStub).toHaveBeenCalledTimes(1);
-  expect(rafStub).toHaveBeenCalledTimes(2);
-});
-
-test('cookie gap during mergePoke calls onPokeError and clears', async () => {
-  const onPokeErrorStub = vi.fn();
-  const replicachePokeStub = vi.fn();
-  const clientID = 'c1';
-  const logContext = new LogContext('error');
-  const pokeHandler = new PokeHandler(
-    replicachePokeStub,
-    onPokeErrorStub,
-    clientID,
-    schema,
-    logContext,
-    new MutationTracker(logContext),
-  );
-  expect(rafStub).toHaveBeenCalledTimes(0);
-
-  pokeHandler.handlePokeStart({
-    pokeID: 'poke1',
-    baseCookie: '1',
-    schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
-  });
-  pokeHandler.handlePokePart({
-    pokeID: 'poke1',
-    lastMutationIDChanges: {
-      c1: 1,
-      c2: 2,
-    },
-    rowsPatch: [
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue1', title: 'foo1'},
-      },
-    ],
-  });
-  pokeHandler.handlePokePart({
-    pokeID: 'poke1',
-    lastMutationIDChanges: {
-      c1: 2,
-    },
-    rowsPatch: [
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue1', title: 'foo2'},
-      },
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue2', title: 'bar1'},
-      },
-    ],
-  });
-
-  expect(rafStub).toHaveBeenCalledTimes(0);
-
-  pokeHandler.handlePokeEnd({pokeID: 'poke1', cookie: '2'});
-
-  expect(rafStub).toHaveBeenCalledTimes(1);
-  expect(replicachePokeStub).toHaveBeenCalledTimes(0);
-
-  pokeHandler.handlePokeStart({
-    pokeID: 'poke2',
-    baseCookie: '3', // gap, should be 2
-    schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
-  });
-  pokeHandler.handlePokePart({
-    pokeID: 'poke2',
-    lastMutationIDChanges: {
-      c1: 2,
-    },
-  });
-
-  pokeHandler.handlePokeEnd({pokeID: 'poke2', cookie: '4'});
-
-  expect(rafStub).toHaveBeenCalledTimes(1);
-  expect(replicachePokeStub).toHaveBeenCalledTimes(0);
-
-  expect(onPokeErrorStub).toHaveBeenCalledTimes(0);
-
-  const rafCallback0 = rafStub.mock.calls[0][0];
-  const rafCallback0Result = rafCallback0(UNUSED_RAF_ARG);
-
-  expect(onPokeErrorStub).toHaveBeenCalledTimes(0);
-
-  pokeHandler.handlePokeStart({
-    pokeID: 'poke3',
-    baseCookie: '4',
-    schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
-  });
-  pokeHandler.handlePokePart({
-    pokeID: 'poke3',
-    lastMutationIDChanges: {
-      c1: 3,
-    },
-    rowsPatch: [
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue3', title: 'baz1'},
-      },
-    ],
-  });
-  pokeHandler.handlePokeEnd({
-    pokeID: 'poke3',
-    cookie: '5',
-  });
-  await rafCallback0Result;
-
-  // not called because error is in merge before call
-  expect(replicachePokeStub).toHaveBeenCalledTimes(0);
-  expect(rafStub).toHaveBeenCalledTimes(2);
-
-  expect(onPokeErrorStub).toHaveBeenCalledTimes(1);
-
-  const rafCallback1 = rafStub.mock.calls[1][0];
-  await rafCallback1(UNUSED_RAF_ARG);
-  // poke 3 cleared so replicachePokeStub not called
-  expect(replicachePokeStub).toHaveBeenCalledTimes(0);
-  expect(rafStub).toHaveBeenCalledTimes(2);
-});
-
-test('onDisconnect clears pending pokes', async () => {
-  const onPokeErrorStub = vi.fn();
-  const replicachePokeStub = vi.fn();
-  const clientID = 'c1';
-  const logContext = new LogContext('error');
-  const pokeHandler = new PokeHandler(
-    replicachePokeStub,
-    onPokeErrorStub,
-    clientID,
-    schema,
-    logContext,
-    new MutationTracker(logContext),
-  );
-  expect(rafStub).toHaveBeenCalledTimes(0);
-
-  pokeHandler.handlePokeStart({
-    pokeID: 'poke1',
-    baseCookie: '1',
-    schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
-  });
-  pokeHandler.handlePokePart({
-    pokeID: 'poke1',
-    lastMutationIDChanges: {
-      c1: 1,
-      c2: 2,
-    },
-    rowsPatch: [
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue1', title: 'foo1'},
-      },
-    ],
-  });
-  pokeHandler.handlePokePart({
-    pokeID: 'poke1',
-    lastMutationIDChanges: {
-      c1: 2,
-    },
-    rowsPatch: [
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue1', title: 'foo2'},
-      },
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue2', title: 'bar1'},
-      },
-    ],
-  });
-
-  expect(rafStub).toHaveBeenCalledTimes(0);
-
-  pokeHandler.handlePokeEnd({pokeID: 'poke1', cookie: '2'});
-
-  expect(rafStub).toHaveBeenCalledTimes(1);
-  expect(replicachePokeStub).toHaveBeenCalledTimes(0);
-
-  pokeHandler.handleDisconnect();
-
-  const rafCallback0 = rafStub.mock.calls[0][0];
-  await rafCallback0(UNUSED_RAF_ARG);
-
-  expect(replicachePokeStub).toHaveBeenCalledTimes(0);
-  expect(rafStub).toHaveBeenCalledTimes(1);
-});
-
-test('handlePoke returns the last mutation id change for this client from pokePart or undefined if none or error', () => {
-  const onPokeErrorStub = vi.fn();
-  const replicachePokeStub = vi.fn();
-  const clientID = 'c1';
-  const logContext = new LogContext('error');
-  const pokeHandler = new PokeHandler(
-    replicachePokeStub,
-    onPokeErrorStub,
-    clientID,
-    schema,
-    logContext,
-    new MutationTracker(logContext),
-  );
-  expect(rafStub).toHaveBeenCalledTimes(0);
-
-  pokeHandler.handlePokeStart({
-    pokeID: 'poke1',
-    baseCookie: '1',
-    schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
-  });
-  const lastMutationIDChangeForSelf0 = pokeHandler.handlePokePart({
-    pokeID: 'poke1',
-    lastMutationIDChanges: {
-      c1: 4,
-      c2: 2,
-    },
-    rowsPatch: [
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue1', title: 'foo1'},
-      },
-    ],
-  });
-  expect(lastMutationIDChangeForSelf0).equals(4);
-  const lastMutationIDChangeForSelf1 = pokeHandler.handlePokePart({
-    pokeID: 'poke1',
-    lastMutationIDChanges: {
-      c2: 3,
-    },
-    rowsPatch: [
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue1', title: 'foo2'},
-      },
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue2', title: 'bar1'},
-      },
-    ],
-  });
-  expect(lastMutationIDChangeForSelf1).to.be.undefined;
-  // error wrong pokeID
-  const lastMutationIDChangeForSelf2 = pokeHandler.handlePokePart({
-    pokeID: 'poke2',
-    lastMutationIDChanges: {
-      c1: 5,
-    },
-    rowsPatch: [
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue1', title: 'foo2'},
-      },
-      {
-        op: 'put',
-        tableName: 'issues',
-        value: {['issue_id']: 'issue2', title: 'bar1'},
-      },
-    ],
-  });
-  expect(lastMutationIDChangeForSelf2).to.be.undefined;
-});
-
-test('mergePokes with empty array returns undefined', () => {
-  const merged = mergePokes([], schema, serverToClient(schema.tables));
-  expect(merged).to.be.undefined;
-});
-
-test('mergePokes with all optionals defined', () => {
-  const result = mergePokes(
-    [
-      {
-        pokeStart: {
-          pokeID: 'poke1',
-          baseCookie: '3',
-          schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
+    const pokeStartAndParts = (pokeID: string) => {
+      pokeHandler.handlePokeStart({
+        pokeID,
+        baseCookie: '1',
+        schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
+      });
+      pokeHandler.handlePokePart({
+        pokeID,
+        lastMutationIDChanges: {
+          c1: 1,
+          c2: 2,
         },
-        parts: [
+        rowsPatch: [
           {
-            pokeID: 'poke1',
-            lastMutationIDChanges: {c1: 1, c2: 2},
-            desiredQueriesPatches: {
-              c1: [
-                {
-                  op: 'put',
-                  hash: 'h1',
-                },
-              ],
-            },
-            gotQueriesPatch: [
-              {
-                op: 'put',
-                hash: 'h1',
-              },
-            ],
-            rowsPatch: [
-              {
-                op: 'put',
-                tableName: 'issues',
-
-                value: {['issue_id']: 'issue1', title: 'foo1'},
-              },
-              {
-                op: 'update',
-                tableName: 'issues',
-                id: {['issue_id']: 'issue2'},
-                merge: {['issue_id']: 'issue2', title: 'bar1'},
-                constrain: ['issue_id', 'title'],
-              },
-            ],
-          },
-
-          {
-            pokeID: 'poke1',
-            lastMutationIDChanges: {c2: 3, c3: 4},
-            desiredQueriesPatches: {
-              c1: [
-                {
-                  op: 'put',
-                  hash: 'h2',
-                },
-              ],
-            },
-            gotQueriesPatch: [
-              {
-                op: 'put',
-                hash: 'h2',
-              },
-            ],
-            rowsPatch: [
-              {
-                op: 'put',
-                tableName: 'issues',
-                value: {['issue_id']: 'issue3', title: 'baz1'},
-              },
-            ],
+            op: 'put',
+            tableName: 'issues',
+            value: {['issue_id']: 'issue1', title: 'foo1'},
           },
         ],
-        pokeEnd: {
-          pokeID: 'poke1',
-          cookie: '4',
+      });
+      pokeHandler.handlePokePart({
+        pokeID,
+        lastMutationIDChanges: {
+          c1: 2,
         },
-      },
-      {
-        pokeStart: {
-          pokeID: 'poke2',
-          baseCookie: '4',
-          schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
-        },
-        parts: [
+        rowsPatch: [
           {
-            pokeID: 'poke2',
-            lastMutationIDChanges: {c4: 3},
-            desiredQueriesPatches: {
-              c1: [
-                {
-                  op: 'del',
-                  hash: 'h1',
-                },
-              ],
-            },
-            gotQueriesPatch: [
-              {
-                op: 'del',
-                hash: 'h1',
-              },
-            ],
-            rowsPatch: [
-              {op: 'del', tableName: 'issues', id: {['issue_id']: 'issue3'}},
-            ],
+            op: 'put',
+            tableName: 'issues',
+            value: {['issue_id']: 'issue1', title: 'foo2'},
+          },
+          {
+            op: 'put',
+            tableName: 'issues',
+            value: {['issue_id']: 'issue2', title: 'bar1'},
           },
         ],
-        pokeEnd: {
-          pokeID: 'poke2',
-          cookie: '5',
-        },
-      },
-    ],
-    schema,
-    serverToClient(schema.tables),
-  );
+      });
+    };
+    pokeStartAndParts('poke1');
 
-  expect(result).toEqual({
-    baseCookie: '3',
-    pullResponse: {
-      cookie: '5',
-      lastMutationIDChanges: {
-        c1: 1,
-        c2: 3,
-        c3: 4,
-        c4: 3,
+    expect(rafStub).toHaveBeenCalledTimes(0);
+
+    pokeHandler.handlePokeEnd({pokeID: 'poke1', cookie: '', cancel: true});
+
+    // raf is not scheduled because poke was canceled;
+    expect(rafStub).toHaveBeenCalledTimes(0);
+    expect(replicachePokeStub).toHaveBeenCalledTimes(0);
+
+    // now test receiving a poke after the canceled poke
+    pokeStartAndParts('poke2');
+
+    expect(rafStub).toHaveBeenCalledTimes(0);
+
+    pokeHandler.handlePokeEnd({pokeID: 'poke2', cookie: '2'});
+
+    expect(rafStub).toHaveBeenCalledTimes(1);
+    expect(replicachePokeStub).toHaveBeenCalledTimes(0);
+
+    const rafCallback0 = rafStub.mock.calls[0][0];
+    await rafCallback0(UNUSED_RAF_ARG);
+
+    expect(replicachePokeStub).toHaveBeenCalledTimes(1);
+    const replicachePoke0 = replicachePokeStub.mock.calls[0][0];
+    expect(replicachePoke0).to.deep.equal({
+      baseCookie: '1',
+      pullResponse: {
+        cookie: '2',
+        lastMutationIDChanges: {
+          c1: 2,
+          c2: 2,
+        },
+        patch: [
+          {
+            op: 'put',
+            key: 'e/issue/issue1',
+            value: {id: 'issue1', title: 'foo1'},
+          },
+          {
+            op: 'put',
+            key: 'e/issue/issue1',
+            value: {id: 'issue1', title: 'foo2'},
+          },
+          {
+            op: 'put',
+            key: 'e/issue/issue2',
+            value: {id: 'issue2', title: 'bar1'},
+          },
+        ],
       },
-      patch: [
-        {
-          op: 'put',
-          key: 'd/c1/h1',
-          value: null,
-        },
-        {
-          op: 'put',
-          key: 'g/h1',
-          value: null,
-        },
-        {
-          op: 'put',
-          key: 'e/issue/issue1',
-          value: {id: 'issue1', title: 'foo1'},
-        },
-        {
-          op: 'update',
-          key: 'e/issue/issue2',
-          merge: {id: 'issue2', title: 'bar1'},
-          constrain: ['id', 'title'],
-        },
-        {
-          op: 'put',
-          key: 'd/c1/h2',
-          value: null,
-        },
-        {
-          op: 'put',
-          key: 'g/h2',
-          value: null,
-        },
-        {
-          op: 'put',
-          key: 'e/issue/issue3',
-          value: {id: 'issue3', title: 'baz1'},
-        },
-        {
-          op: 'del',
-          key: 'd/c1/h1',
-        },
-        {
-          op: 'del',
-          key: 'g/h1',
-        },
-        {
-          op: 'del',
-          key: 'e/issue/issue3',
-        },
-      ],
-    },
+    });
+
+    expect(rafStub).toHaveBeenCalledTimes(2);
+
+    const rafCallback1 = rafStub.mock.calls[1][0];
+    await rafCallback1(UNUSED_RAF_ARG);
+    expect(replicachePokeStub).toHaveBeenCalledTimes(1);
+    expect(rafStub).toHaveBeenCalledTimes(2);
   });
-});
 
-test('mergePokes sparse', () => {
-  const result = mergePokes(
-    [
-      {
-        pokeStart: {
-          pokeID: 'poke1',
-          baseCookie: '3',
-          schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
-        },
-        parts: [
-          {
-            pokeID: 'poke1',
-            lastMutationIDChanges: {c1: 1, c2: 2},
-            gotQueriesPatch: [
-              {
-                op: 'put',
-                hash: 'h1',
-              },
-            ],
-            rowsPatch: [
-              {
-                op: 'put',
-                tableName: 'issues',
+  test('multiple pokes received before raf callback are merged', async () => {
+    const onPokeErrorStub = vi.fn();
+    const replicachePokeStub = vi.fn();
+    const clientID = 'c1';
+    const logContext = new LogContext('error');
+    const pokeHandler = new PokeHandler(
+      replicachePokeStub,
+      onPokeErrorStub,
+      clientID,
+      schema,
+      logContext,
+      new MutationTracker(logContext),
+    );
 
-                value: {['issue_id']: 'issue1', title: 'foo1'},
-              },
-              {
-                op: 'update',
-                tableName: 'issues',
-                id: {['issue_id']: 'issue2'},
-                merge: {['issue_id']: 'issue2', title: 'bar1'},
-                constrain: ['issue_id', 'title'],
-              },
-            ],
-          },
+    expect(rafStub).toHaveBeenCalledTimes(0);
 
-          {
-            pokeID: 'poke1',
-            desiredQueriesPatches: {
-              c1: [
-                {
-                  op: 'put',
-                  hash: 'h2',
-                },
-              ],
-            },
-          },
-        ],
-        pokeEnd: {
-          pokeID: 'poke1',
-          cookie: '4',
-        },
-      },
-      {
-        pokeStart: {
-          pokeID: 'poke2',
-          baseCookie: '4',
-          schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
-        },
-        parts: [
-          {
-            pokeID: 'poke2',
-            desiredQueriesPatches: {
-              c1: [
-                {
-                  op: 'del',
-                  hash: 'h1',
-                },
-              ],
-            },
-            rowsPatch: [
-              {op: 'del', tableName: 'issues', id: {['issue_id']: 'issue3'}},
-            ],
-          },
-        ],
-        pokeEnd: {
-          pokeID: 'poke2',
-          cookie: '5',
-        },
-      },
-    ],
-    schema,
-    serverToClient(schema.tables),
-  );
-  expect(result).toEqual({
-    baseCookie: '3',
-    pullResponse: {
+    pokeHandler.handlePokeStart({
+      pokeID: 'poke1',
+      baseCookie: '1',
+      schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
+    });
+    pokeHandler.handlePokePart({
+      pokeID: 'poke1',
       lastMutationIDChanges: {
         c1: 1,
         c2: 2,
       },
-      patch: [
+      rowsPatch: [
         {
           op: 'put',
-          key: 'g/h1',
-          value: null,
-        },
-        {
-          op: 'put',
-          key: 'e/issue/issue1',
-          value: {id: 'issue1', title: 'foo1'},
-        },
-        {
-          op: 'update',
-          key: 'e/issue/issue2',
-          merge: {id: 'issue2', title: 'bar1'},
-          constrain: ['id', 'title'],
-        },
-        {
-          op: 'put',
-          key: 'd/c1/h2',
-          value: null,
-        },
-        {
-          op: 'del',
-          key: 'd/c1/h1',
-        },
-        {
-          op: 'del',
-          key: 'e/issue/issue3',
+          tableName: 'issues',
+          value: {['issue_id']: 'issue1', title: 'foo1'},
         },
       ],
-      cookie: '5',
-    },
-  });
-});
+    });
+    pokeHandler.handlePokePart({
+      pokeID: 'poke1',
+      lastMutationIDChanges: {
+        c1: 2,
+      },
+      rowsPatch: [
+        {
+          op: 'put',
+          tableName: 'issues',
+          value: {['issue_id']: 'issue1', title: 'foo2'},
+        },
+        {
+          op: 'put',
+          tableName: 'issues',
+          value: {['issue_id']: 'issue2', title: 'bar1'},
+        },
+      ],
+    });
 
-test('mergePokes throws error on cookie gaps', () => {
-  expect(() => {
-    mergePokes(
+    expect(rafStub).toHaveBeenCalledTimes(0);
+    pokeHandler.handlePokeEnd({pokeID: 'poke1', cookie: '2'});
+
+    expect(rafStub).toHaveBeenCalledTimes(1);
+    expect(replicachePokeStub).toHaveBeenCalledTimes(0);
+
+    pokeHandler.handlePokeStart({
+      pokeID: 'poke2',
+      baseCookie: '2',
+      schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
+    });
+    pokeHandler.handlePokePart({
+      pokeID: 'poke2',
+      lastMutationIDChanges: {
+        c1: 3,
+      },
+      rowsPatch: [
+        {
+          op: 'put',
+          tableName: 'issues',
+          value: {['issue_id']: 'issue3', title: 'baz1'},
+        },
+      ],
+    });
+    pokeHandler.handlePokePart({
+      pokeID: 'poke2',
+      lastMutationIDChanges: {
+        c3: 1,
+      },
+      rowsPatch: [
+        {
+          op: 'put',
+          tableName: 'issues',
+          value: {['issue_id']: 'issue2', title: 'bar2'},
+        },
+      ],
+    });
+
+    expect(rafStub).toHaveBeenCalledTimes(1);
+
+    pokeHandler.handlePokeEnd({pokeID: 'poke2', cookie: '3'});
+
+    expect(rafStub).toHaveBeenCalledTimes(1);
+    expect(replicachePokeStub).toHaveBeenCalledTimes(0);
+
+    const rafCallback0 = rafStub.mock.calls[0][0];
+    await rafCallback0(UNUSED_RAF_ARG);
+
+    expect(replicachePokeStub).toHaveBeenCalledTimes(1);
+    const replicachePoke0 = replicachePokeStub.mock.calls[0][0];
+    expect(replicachePoke0).to.deep.equal({
+      baseCookie: '1',
+      pullResponse: {
+        cookie: '3',
+        lastMutationIDChanges: {
+          c1: 3,
+          c2: 2,
+          c3: 1,
+        },
+        patch: [
+          {
+            op: 'put',
+            key: 'e/issue/issue1',
+            value: {id: 'issue1', title: 'foo1'},
+          },
+          {
+            op: 'put',
+            key: 'e/issue/issue1',
+            value: {id: 'issue1', title: 'foo2'},
+          },
+          {
+            op: 'put',
+            key: 'e/issue/issue2',
+            value: {id: 'issue2', title: 'bar1'},
+          },
+          {
+            op: 'put',
+            key: 'e/issue/issue3',
+            value: {id: 'issue3', title: 'baz1'},
+          },
+          {
+            op: 'put',
+            key: 'e/issue/issue2',
+            value: {id: 'issue2', title: 'bar2'},
+          },
+        ],
+      },
+    });
+
+    expect(rafStub).toHaveBeenCalledTimes(2);
+
+    const rafCallback1 = rafStub.mock.calls[1][0];
+    await rafCallback1(UNUSED_RAF_ARG);
+    expect(replicachePokeStub).toHaveBeenCalledTimes(1);
+    expect(rafStub).toHaveBeenCalledTimes(2);
+  });
+
+  test('multiple pokes received before raf callback are merged, canceled pokes are not merged', async () => {
+    const onPokeErrorStub = vi.fn();
+    const replicachePokeStub = vi.fn();
+    const clientID = 'c1';
+    const logContext = new LogContext('error');
+    const pokeHandler = new PokeHandler(
+      replicachePokeStub,
+      onPokeErrorStub,
+      clientID,
+      schema,
+      logContext,
+      new MutationTracker(logContext),
+    );
+
+    expect(rafStub).toHaveBeenCalledTimes(0);
+
+    pokeHandler.handlePokeStart({
+      pokeID: 'poke1',
+      baseCookie: '1',
+      schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
+    });
+    pokeHandler.handlePokePart({
+      pokeID: 'poke1',
+      lastMutationIDChanges: {
+        c1: 1,
+        c2: 2,
+      },
+      rowsPatch: [
+        {
+          op: 'put',
+          tableName: 'issues',
+          value: {['issue_id']: 'issue1', title: 'foo1'},
+        },
+      ],
+    });
+    pokeHandler.handlePokePart({
+      pokeID: 'poke1',
+      lastMutationIDChanges: {
+        c1: 2,
+      },
+      rowsPatch: [
+        {
+          op: 'put',
+          tableName: 'issues',
+          value: {['issue_id']: 'issue1', title: 'foo2'},
+        },
+        {
+          op: 'put',
+          tableName: 'issues',
+          value: {['issue_id']: 'issue2', title: 'bar1'},
+        },
+      ],
+    });
+
+    expect(rafStub).toHaveBeenCalledTimes(0);
+    pokeHandler.handlePokeEnd({pokeID: 'poke1', cookie: '2'});
+
+    expect(rafStub).toHaveBeenCalledTimes(1);
+    expect(replicachePokeStub).toHaveBeenCalledTimes(0);
+
+    pokeHandler.handlePokeStart({
+      pokeID: 'poke2',
+      baseCookie: '2',
+      schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
+    });
+    pokeHandler.handlePokePart({
+      pokeID: 'poke2',
+      lastMutationIDChanges: {
+        c1: 3,
+      },
+      rowsPatch: [
+        {
+          op: 'put',
+          tableName: 'issues',
+          value: {['issue_id']: 'issue3', title: 'baz1'},
+        },
+      ],
+    });
+    pokeHandler.handlePokePart({
+      pokeID: 'poke2',
+      lastMutationIDChanges: {
+        c3: 1,
+      },
+      rowsPatch: [
+        {
+          op: 'put',
+          tableName: 'issues',
+          value: {['issue_id']: 'issue2', title: 'bar2'},
+        },
+      ],
+    });
+
+    expect(rafStub).toHaveBeenCalledTimes(1);
+
+    pokeHandler.handlePokeEnd({pokeID: 'poke2', cookie: '', cancel: true});
+
+    expect(rafStub).toHaveBeenCalledTimes(1);
+    expect(replicachePokeStub).toHaveBeenCalledTimes(0);
+
+    pokeHandler.handlePokeStart({
+      pokeID: 'poke3',
+      baseCookie: '2',
+      schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
+    });
+    pokeHandler.handlePokePart({
+      pokeID: 'poke3',
+      lastMutationIDChanges: {
+        c1: 3,
+      },
+      rowsPatch: [
+        {
+          op: 'put',
+          tableName: 'issues',
+          value: {['issue_id']: 'issue4', title: 'baz2'},
+        },
+      ],
+    });
+
+    expect(rafStub).toHaveBeenCalledTimes(1);
+
+    pokeHandler.handlePokeEnd({pokeID: 'poke3', cookie: '3'});
+
+    const rafCallback0 = rafStub.mock.calls[0][0];
+    await rafCallback0(UNUSED_RAF_ARG);
+
+    expect(replicachePokeStub).toHaveBeenCalledTimes(1);
+    const replicachePoke0 = replicachePokeStub.mock.calls[0][0];
+    expect(replicachePoke0).to.deep.equal({
+      baseCookie: '1',
+      pullResponse: {
+        cookie: '3',
+        lastMutationIDChanges: {
+          c1: 3,
+          c2: 2,
+          // Not included because corresponding poke was canceled
+          // c3: 1,
+        },
+        patch: [
+          {
+            op: 'put',
+            key: 'e/issue/issue1',
+            value: {id: 'issue1', title: 'foo1'},
+          },
+          {
+            op: 'put',
+            key: 'e/issue/issue1',
+            value: {id: 'issue1', title: 'foo2'},
+          },
+          {
+            op: 'put',
+            key: 'e/issue/issue2',
+            value: {id: 'issue2', title: 'bar1'},
+          },
+          // Following not included because corresponding poke was canceled
+          // {
+          //   op: 'put',
+          //   key: 'e/issue/issue3',
+          //   value: {id: 'issue3', title: 'baz1'},
+          // },
+          // {
+          //   op: 'put',
+          //   key: 'e/issue/issue2',
+          //   value: {id: 'issue2', title: 'bar2'},
+          // },
+          // non-canceled poke after canceled poke is merged
+          {
+            op: 'put',
+            key: 'e/issue/issue4',
+            value: {id: 'issue4', title: 'baz2'},
+          },
+        ],
+      },
+    });
+
+    expect(rafStub).toHaveBeenCalledTimes(2);
+
+    const rafCallback1 = rafStub.mock.calls[1][0];
+    await rafCallback1(UNUSED_RAF_ARG);
+    expect(replicachePokeStub).toHaveBeenCalledTimes(1);
+    expect(rafStub).toHaveBeenCalledTimes(2);
+  });
+
+  test('playback over series of rafs', async () => {
+    const onPokeErrorStub = vi.fn();
+    const replicachePokeStub = vi.fn();
+    const clientID = 'c1';
+    const logContext = new LogContext('error');
+    const pokeHandler = new PokeHandler(
+      replicachePokeStub,
+      onPokeErrorStub,
+      clientID,
+      schema,
+      logContext,
+      new MutationTracker(logContext),
+    );
+
+    expect(rafStub).toHaveBeenCalledTimes(0);
+
+    pokeHandler.handlePokeStart({
+      pokeID: 'poke1',
+      baseCookie: '1',
+      schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
+    });
+    pokeHandler.handlePokePart({
+      pokeID: 'poke1',
+      lastMutationIDChanges: {
+        c1: 1,
+        c2: 2,
+      },
+      rowsPatch: [
+        {
+          op: 'put',
+          tableName: 'issues',
+          value: {['issue_id']: 'issue1', title: 'foo1'},
+        },
+      ],
+    });
+    pokeHandler.handlePokePart({
+      pokeID: 'poke1',
+      lastMutationIDChanges: {
+        c1: 2,
+      },
+      rowsPatch: [
+        {
+          op: 'put',
+          tableName: 'issues',
+          value: {['issue_id']: 'issue1', title: 'foo2'},
+        },
+        {
+          op: 'put',
+          tableName: 'issues',
+          value: {['issue_id']: 'issue2', title: 'bar1'},
+        },
+      ],
+    });
+
+    expect(rafStub).toHaveBeenCalledTimes(0);
+    pokeHandler.handlePokeEnd({pokeID: 'poke1', cookie: '2'});
+
+    expect(rafStub).toHaveBeenCalledTimes(1);
+    expect(replicachePokeStub).toHaveBeenCalledTimes(0);
+
+    const rafCallback0 = rafStub.mock.calls[0][0];
+    await rafCallback0(UNUSED_RAF_ARG);
+
+    expect(replicachePokeStub).toHaveBeenCalledTimes(1);
+    const replicachePoke0 = replicachePokeStub.mock.calls[0][0];
+    expect(replicachePoke0).to.deep.equal({
+      baseCookie: '1',
+      pullResponse: {
+        cookie: '2',
+        lastMutationIDChanges: {
+          c1: 2,
+          c2: 2,
+        },
+        patch: [
+          {
+            op: 'put',
+            key: 'e/issue/issue1',
+            value: {id: 'issue1', title: 'foo1'},
+          },
+          {
+            op: 'put',
+            key: 'e/issue/issue1',
+            value: {id: 'issue1', title: 'foo2'},
+          },
+          {
+            op: 'put',
+            key: 'e/issue/issue2',
+            value: {id: 'issue2', title: 'bar1'},
+          },
+        ],
+      },
+    });
+
+    expect(rafStub).toHaveBeenCalledTimes(2);
+
+    pokeHandler.handlePokeStart({
+      pokeID: 'poke2',
+      baseCookie: '2',
+      schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
+    });
+    pokeHandler.handlePokePart({
+      pokeID: 'poke2',
+      lastMutationIDChanges: {
+        c1: 3,
+      },
+      rowsPatch: [
+        {
+          op: 'put',
+          tableName: 'issues',
+          value: {['issue_id']: 'issue3', title: 'baz1'},
+        },
+      ],
+    });
+    pokeHandler.handlePokePart({
+      pokeID: 'poke2',
+      lastMutationIDChanges: {
+        c3: 1,
+      },
+      rowsPatch: [
+        {
+          op: 'put',
+          tableName: 'issues',
+          value: {['issue_id']: 'issue2', title: 'bar2'},
+        },
+      ],
+    });
+
+    expect(rafStub).toHaveBeenCalledTimes(2);
+
+    pokeHandler.handlePokeEnd({pokeID: 'poke2', cookie: '3'});
+
+    expect(rafStub).toHaveBeenCalledTimes(2);
+    expect(replicachePokeStub).toHaveBeenCalledTimes(1);
+
+    const rafCallback1 = rafStub.mock.calls[1][0];
+    await rafCallback1(UNUSED_RAF_ARG);
+
+    expect(replicachePokeStub).toHaveBeenCalledTimes(2);
+    const replicachePoke1 = replicachePokeStub.mock.calls[1][0];
+    expect(replicachePoke1).to.deep.equal({
+      baseCookie: '2',
+      pullResponse: {
+        cookie: '3',
+        lastMutationIDChanges: {
+          c1: 3,
+          c3: 1,
+        },
+        patch: [
+          {
+            op: 'put',
+            key: 'e/issue/issue3',
+            value: {id: 'issue3', title: 'baz1'},
+          },
+          {
+            op: 'put',
+            key: 'e/issue/issue2',
+            value: {id: 'issue2', title: 'bar2'},
+          },
+        ],
+      },
+    });
+
+    expect(rafStub).toHaveBeenCalledTimes(3);
+
+    const rafCallback2 = rafStub.mock.calls[2][0];
+    await rafCallback2(UNUSED_RAF_ARG);
+    expect(replicachePokeStub).toHaveBeenCalledTimes(2);
+    expect(rafStub).toHaveBeenCalledTimes(3);
+  });
+
+  suite('onPokeErrors', () => {
+    const cases: {
+      name: string;
+      causeError: (pokeHandler: PokeHandler) => void;
+    }[] = [
+      {
+        name: 'pokePart before pokeStart',
+        causeError: pokeHandler => {
+          pokeHandler.handlePokePart({pokeID: 'poke1'});
+        },
+      },
+      {
+        name: 'pokeEnd before pokeStart',
+        causeError: pokeHandler => {
+          pokeHandler.handlePokeEnd({pokeID: 'poke1', cookie: '2'});
+        },
+      },
+      {
+        name: 'pokePart with wrong pokeID',
+        causeError: pokeHandler => {
+          pokeHandler.handlePokeStart({
+            pokeID: 'poke1',
+            baseCookie: '1',
+            schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
+          });
+          pokeHandler.handlePokePart({pokeID: 'poke2'});
+        },
+      },
+      {
+        name: 'pokeEnd with wrong pokeID',
+        causeError: pokeHandler => {
+          pokeHandler.handlePokeStart({
+            pokeID: 'poke1',
+            baseCookie: '1',
+            schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
+          });
+          pokeHandler.handlePokeEnd({pokeID: 'poke2', cookie: '2'});
+        },
+      },
+    ];
+    for (const c of cases) {
+      test(c.name, () => {
+        const onPokeErrorStub = vi.fn();
+        const replicachePokeStub = vi.fn();
+        const clientID = 'c1';
+        const logContext = new LogContext('error');
+        const pokeHandler = new PokeHandler(
+          replicachePokeStub,
+          onPokeErrorStub,
+          clientID,
+          schema,
+          logContext,
+          new MutationTracker(logContext),
+        );
+
+        expect(onPokeErrorStub).toHaveBeenCalledTimes(0);
+        c.causeError(pokeHandler);
+        expect(onPokeErrorStub).toHaveBeenCalledTimes(1);
+      });
+    }
+  });
+
+  test('replicachePoke throwing error calls onPokeError and clears', async () => {
+    const onPokeErrorStub = vi.fn();
+    const replicachePokeStub = vi.fn();
+    const clientID = 'c1';
+    const logContext = new LogContext('error');
+    const pokeHandler = new PokeHandler(
+      replicachePokeStub,
+      onPokeErrorStub,
+      clientID,
+      schema,
+      logContext,
+      new MutationTracker(logContext),
+    );
+    expect(rafStub).toHaveBeenCalledTimes(0);
+
+    pokeHandler.handlePokeStart({
+      pokeID: 'poke1',
+      baseCookie: '1',
+      schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
+    });
+    pokeHandler.handlePokePart({
+      pokeID: 'poke1',
+      lastMutationIDChanges: {
+        c1: 1,
+        c2: 2,
+      },
+      rowsPatch: [
+        {
+          op: 'put',
+          tableName: 'issues',
+          value: {['issue_id']: 'issue1', title: 'foo1'},
+        },
+      ],
+    });
+    pokeHandler.handlePokePart({
+      pokeID: 'poke1',
+      lastMutationIDChanges: {
+        c1: 2,
+      },
+      rowsPatch: [
+        {
+          op: 'put',
+          tableName: 'issues',
+          value: {['issue_id']: 'issue1', title: 'foo2'},
+        },
+        {
+          op: 'put',
+          tableName: 'issues',
+          value: {['issue_id']: 'issue2', title: 'bar1'},
+        },
+      ],
+    });
+
+    expect(rafStub).toHaveBeenCalledTimes(0);
+
+    pokeHandler.handlePokeEnd({pokeID: 'poke1', cookie: '2'});
+
+    expect(rafStub).toHaveBeenCalledTimes(1);
+    expect(replicachePokeStub).toHaveBeenCalledTimes(0);
+
+    const {promise, reject} = resolver();
+    replicachePokeStub.mockReturnValue(promise);
+    expect(onPokeErrorStub).toHaveBeenCalledTimes(0);
+
+    const rafCallback0 = rafStub.mock.calls[0][0];
+    const rafCallback0Result = rafCallback0(UNUSED_RAF_ARG);
+
+    expect(onPokeErrorStub).toHaveBeenCalledTimes(0);
+
+    pokeHandler.handlePokeStart({
+      pokeID: 'poke2',
+      baseCookie: '2',
+      schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
+    });
+    pokeHandler.handlePokePart({
+      pokeID: 'poke2',
+      lastMutationIDChanges: {
+        c1: 3,
+      },
+      rowsPatch: [
+        {
+          op: 'put',
+          tableName: 'issues',
+          value: {['issue_id']: 'issue3', title: 'baz1'},
+        },
+      ],
+    });
+    pokeHandler.handlePokeEnd({
+      pokeID: 'poke2',
+      cookie: '3',
+    });
+
+    reject('error in poke');
+    await rafCallback0Result;
+
+    expect(replicachePokeStub).toHaveBeenCalledTimes(1);
+    expect(rafStub).toHaveBeenCalledTimes(2);
+
+    expect(onPokeErrorStub).toHaveBeenCalledTimes(1);
+
+    const rafCallback1 = rafStub.mock.calls[1][0];
+    await rafCallback1(UNUSED_RAF_ARG);
+    // poke 2 cleared so replicachePokeStub not called
+    expect(replicachePokeStub).toHaveBeenCalledTimes(1);
+    expect(rafStub).toHaveBeenCalledTimes(2);
+  });
+
+  test('cookie gap during mergePoke calls onPokeError and clears', async () => {
+    const onPokeErrorStub = vi.fn();
+    const replicachePokeStub = vi.fn();
+    const clientID = 'c1';
+    const logContext = new LogContext('error');
+    const pokeHandler = new PokeHandler(
+      replicachePokeStub,
+      onPokeErrorStub,
+      clientID,
+      schema,
+      logContext,
+      new MutationTracker(logContext),
+    );
+    expect(rafStub).toHaveBeenCalledTimes(0);
+
+    pokeHandler.handlePokeStart({
+      pokeID: 'poke1',
+      baseCookie: '1',
+      schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
+    });
+    pokeHandler.handlePokePart({
+      pokeID: 'poke1',
+      lastMutationIDChanges: {
+        c1: 1,
+        c2: 2,
+      },
+      rowsPatch: [
+        {
+          op: 'put',
+          tableName: 'issues',
+          value: {['issue_id']: 'issue1', title: 'foo1'},
+        },
+      ],
+    });
+    pokeHandler.handlePokePart({
+      pokeID: 'poke1',
+      lastMutationIDChanges: {
+        c1: 2,
+      },
+      rowsPatch: [
+        {
+          op: 'put',
+          tableName: 'issues',
+          value: {['issue_id']: 'issue1', title: 'foo2'},
+        },
+        {
+          op: 'put',
+          tableName: 'issues',
+          value: {['issue_id']: 'issue2', title: 'bar1'},
+        },
+      ],
+    });
+
+    expect(rafStub).toHaveBeenCalledTimes(0);
+
+    pokeHandler.handlePokeEnd({pokeID: 'poke1', cookie: '2'});
+
+    expect(rafStub).toHaveBeenCalledTimes(1);
+    expect(replicachePokeStub).toHaveBeenCalledTimes(0);
+
+    pokeHandler.handlePokeStart({
+      pokeID: 'poke2',
+      baseCookie: '3', // gap, should be 2
+      schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
+    });
+    pokeHandler.handlePokePart({
+      pokeID: 'poke2',
+      lastMutationIDChanges: {
+        c1: 2,
+      },
+    });
+
+    pokeHandler.handlePokeEnd({pokeID: 'poke2', cookie: '4'});
+
+    expect(rafStub).toHaveBeenCalledTimes(1);
+    expect(replicachePokeStub).toHaveBeenCalledTimes(0);
+
+    expect(onPokeErrorStub).toHaveBeenCalledTimes(0);
+
+    const rafCallback0 = rafStub.mock.calls[0][0];
+    const rafCallback0Result = rafCallback0(UNUSED_RAF_ARG);
+
+    expect(onPokeErrorStub).toHaveBeenCalledTimes(0);
+
+    pokeHandler.handlePokeStart({
+      pokeID: 'poke3',
+      baseCookie: '4',
+      schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
+    });
+    pokeHandler.handlePokePart({
+      pokeID: 'poke3',
+      lastMutationIDChanges: {
+        c1: 3,
+      },
+      rowsPatch: [
+        {
+          op: 'put',
+          tableName: 'issues',
+          value: {['issue_id']: 'issue3', title: 'baz1'},
+        },
+      ],
+    });
+    pokeHandler.handlePokeEnd({
+      pokeID: 'poke3',
+      cookie: '5',
+    });
+    await rafCallback0Result;
+
+    // not called because error is in merge before call
+    expect(replicachePokeStub).toHaveBeenCalledTimes(0);
+    expect(rafStub).toHaveBeenCalledTimes(2);
+
+    expect(onPokeErrorStub).toHaveBeenCalledTimes(1);
+
+    const rafCallback1 = rafStub.mock.calls[1][0];
+    await rafCallback1(UNUSED_RAF_ARG);
+    // poke 3 cleared so replicachePokeStub not called
+    expect(replicachePokeStub).toHaveBeenCalledTimes(0);
+    expect(rafStub).toHaveBeenCalledTimes(2);
+  });
+
+  test('onDisconnect clears pending pokes', async () => {
+    const onPokeErrorStub = vi.fn();
+    const replicachePokeStub = vi.fn();
+    const clientID = 'c1';
+    const logContext = new LogContext('error');
+    const pokeHandler = new PokeHandler(
+      replicachePokeStub,
+      onPokeErrorStub,
+      clientID,
+      schema,
+      logContext,
+      new MutationTracker(logContext),
+    );
+    expect(rafStub).toHaveBeenCalledTimes(0);
+
+    pokeHandler.handlePokeStart({
+      pokeID: 'poke1',
+      baseCookie: '1',
+      schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
+    });
+    pokeHandler.handlePokePart({
+      pokeID: 'poke1',
+      lastMutationIDChanges: {
+        c1: 1,
+        c2: 2,
+      },
+      rowsPatch: [
+        {
+          op: 'put',
+          tableName: 'issues',
+          value: {['issue_id']: 'issue1', title: 'foo1'},
+        },
+      ],
+    });
+    pokeHandler.handlePokePart({
+      pokeID: 'poke1',
+      lastMutationIDChanges: {
+        c1: 2,
+      },
+      rowsPatch: [
+        {
+          op: 'put',
+          tableName: 'issues',
+          value: {['issue_id']: 'issue1', title: 'foo2'},
+        },
+        {
+          op: 'put',
+          tableName: 'issues',
+          value: {['issue_id']: 'issue2', title: 'bar1'},
+        },
+      ],
+    });
+
+    expect(rafStub).toHaveBeenCalledTimes(0);
+
+    pokeHandler.handlePokeEnd({pokeID: 'poke1', cookie: '2'});
+
+    expect(rafStub).toHaveBeenCalledTimes(1);
+    expect(replicachePokeStub).toHaveBeenCalledTimes(0);
+
+    pokeHandler.handleDisconnect();
+
+    const rafCallback0 = rafStub.mock.calls[0][0];
+    await rafCallback0(UNUSED_RAF_ARG);
+
+    expect(replicachePokeStub).toHaveBeenCalledTimes(0);
+    expect(rafStub).toHaveBeenCalledTimes(1);
+  });
+
+  test('handlePoke returns the last mutation id change for this client from pokePart or undefined if none or error', () => {
+    const onPokeErrorStub = vi.fn();
+    const replicachePokeStub = vi.fn();
+    const clientID = 'c1';
+    const logContext = new LogContext('error');
+    const pokeHandler = new PokeHandler(
+      replicachePokeStub,
+      onPokeErrorStub,
+      clientID,
+      schema,
+      logContext,
+      new MutationTracker(logContext),
+    );
+    expect(rafStub).toHaveBeenCalledTimes(0);
+
+    pokeHandler.handlePokeStart({
+      pokeID: 'poke1',
+      baseCookie: '1',
+      schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
+    });
+    const lastMutationIDChangeForSelf0 = pokeHandler.handlePokePart({
+      pokeID: 'poke1',
+      lastMutationIDChanges: {
+        c1: 4,
+        c2: 2,
+      },
+      rowsPatch: [
+        {
+          op: 'put',
+          tableName: 'issues',
+          value: {['issue_id']: 'issue1', title: 'foo1'},
+        },
+      ],
+    });
+    expect(lastMutationIDChangeForSelf0).equals(4);
+    const lastMutationIDChangeForSelf1 = pokeHandler.handlePokePart({
+      pokeID: 'poke1',
+      lastMutationIDChanges: {
+        c2: 3,
+      },
+      rowsPatch: [
+        {
+          op: 'put',
+          tableName: 'issues',
+          value: {['issue_id']: 'issue1', title: 'foo2'},
+        },
+        {
+          op: 'put',
+          tableName: 'issues',
+          value: {['issue_id']: 'issue2', title: 'bar1'},
+        },
+      ],
+    });
+    expect(lastMutationIDChangeForSelf1).to.be.undefined;
+    // error wrong pokeID
+    const lastMutationIDChangeForSelf2 = pokeHandler.handlePokePart({
+      pokeID: 'poke2',
+      lastMutationIDChanges: {
+        c1: 5,
+      },
+      rowsPatch: [
+        {
+          op: 'put',
+          tableName: 'issues',
+          value: {['issue_id']: 'issue1', title: 'foo2'},
+        },
+        {
+          op: 'put',
+          tableName: 'issues',
+          value: {['issue_id']: 'issue2', title: 'bar1'},
+        },
+      ],
+    });
+    expect(lastMutationIDChangeForSelf2).to.be.undefined;
+  });
+
+  test('mergePokes with empty array returns undefined', () => {
+    const merged = mergePokes([], schema, serverToClient(schema.tables));
+    expect(merged).to.be.undefined;
+  });
+
+  test('mergePokes with all optionals defined', () => {
+    const result = mergePokes(
       [
         {
           pokeStart: {
@@ -1535,6 +1232,61 @@ test('mergePokes throws error on cookie gaps', () => {
             {
               pokeID: 'poke1',
               lastMutationIDChanges: {c1: 1, c2: 2},
+              desiredQueriesPatches: {
+                c1: [
+                  {
+                    op: 'put',
+                    hash: 'h1',
+                  },
+                ],
+              },
+              gotQueriesPatch: [
+                {
+                  op: 'put',
+                  hash: 'h1',
+                },
+              ],
+              rowsPatch: [
+                {
+                  op: 'put',
+                  tableName: 'issues',
+
+                  value: {['issue_id']: 'issue1', title: 'foo1'},
+                },
+                {
+                  op: 'update',
+                  tableName: 'issues',
+                  id: {['issue_id']: 'issue2'},
+                  merge: {['issue_id']: 'issue2', title: 'bar1'},
+                  constrain: ['issue_id', 'title'],
+                },
+              ],
+            },
+
+            {
+              pokeID: 'poke1',
+              lastMutationIDChanges: {c2: 3, c3: 4},
+              desiredQueriesPatches: {
+                c1: [
+                  {
+                    op: 'put',
+                    hash: 'h2',
+                  },
+                ],
+              },
+              gotQueriesPatch: [
+                {
+                  op: 'put',
+                  hash: 'h2',
+                },
+              ],
+              rowsPatch: [
+                {
+                  op: 'put',
+                  tableName: 'issues',
+                  value: {['issue_id']: 'issue3', title: 'baz1'},
+                },
+              ],
             },
           ],
           pokeEnd: {
@@ -1545,23 +1297,402 @@ test('mergePokes throws error on cookie gaps', () => {
         {
           pokeStart: {
             pokeID: 'poke2',
-            baseCookie: '5', // gap, should be 4
+            baseCookie: '4',
             schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
           },
           parts: [
             {
               pokeID: 'poke2',
               lastMutationIDChanges: {c4: 3},
+              desiredQueriesPatches: {
+                c1: [
+                  {
+                    op: 'del',
+                    hash: 'h1',
+                  },
+                ],
+              },
+              gotQueriesPatch: [
+                {
+                  op: 'del',
+                  hash: 'h1',
+                },
+              ],
+              rowsPatch: [
+                {op: 'del', tableName: 'issues', id: {['issue_id']: 'issue3'}},
+              ],
             },
           ],
           pokeEnd: {
             pokeID: 'poke2',
-            cookie: '6',
+            cookie: '5',
           },
         },
       ],
       schema,
       serverToClient(schema.tables),
     );
-  }).to.throw();
+
+    expect(result).toEqual({
+      baseCookie: '3',
+      pullResponse: {
+        cookie: '5',
+        lastMutationIDChanges: {
+          c1: 1,
+          c2: 3,
+          c3: 4,
+          c4: 3,
+        },
+        patch: [
+          {
+            op: 'put',
+            key: 'd/c1/h1',
+            value: null,
+          },
+          {
+            op: 'put',
+            key: 'g/h1',
+            value: null,
+          },
+          {
+            op: 'put',
+            key: 'e/issue/issue1',
+            value: {id: 'issue1', title: 'foo1'},
+          },
+          {
+            op: 'update',
+            key: 'e/issue/issue2',
+            merge: {id: 'issue2', title: 'bar1'},
+            constrain: ['id', 'title'],
+          },
+          {
+            op: 'put',
+            key: 'd/c1/h2',
+            value: null,
+          },
+          {
+            op: 'put',
+            key: 'g/h2',
+            value: null,
+          },
+          {
+            op: 'put',
+            key: 'e/issue/issue3',
+            value: {id: 'issue3', title: 'baz1'},
+          },
+          {
+            op: 'del',
+            key: 'd/c1/h1',
+          },
+          {
+            op: 'del',
+            key: 'g/h1',
+          },
+          {
+            op: 'del',
+            key: 'e/issue/issue3',
+          },
+        ],
+      },
+    });
+  });
+
+  test('mergePokes sparse', () => {
+    const result = mergePokes(
+      [
+        {
+          pokeStart: {
+            pokeID: 'poke1',
+            baseCookie: '3',
+            schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
+          },
+          parts: [
+            {
+              pokeID: 'poke1',
+              lastMutationIDChanges: {c1: 1, c2: 2},
+              gotQueriesPatch: [
+                {
+                  op: 'put',
+                  hash: 'h1',
+                },
+              ],
+              rowsPatch: [
+                {
+                  op: 'put',
+                  tableName: 'issues',
+
+                  value: {['issue_id']: 'issue1', title: 'foo1'},
+                },
+                {
+                  op: 'update',
+                  tableName: 'issues',
+                  id: {['issue_id']: 'issue2'},
+                  merge: {['issue_id']: 'issue2', title: 'bar1'},
+                  constrain: ['issue_id', 'title'],
+                },
+              ],
+            },
+
+            {
+              pokeID: 'poke1',
+              desiredQueriesPatches: {
+                c1: [
+                  {
+                    op: 'put',
+                    hash: 'h2',
+                  },
+                ],
+              },
+            },
+          ],
+          pokeEnd: {
+            pokeID: 'poke1',
+            cookie: '4',
+          },
+        },
+        {
+          pokeStart: {
+            pokeID: 'poke2',
+            baseCookie: '4',
+            schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
+          },
+          parts: [
+            {
+              pokeID: 'poke2',
+              desiredQueriesPatches: {
+                c1: [
+                  {
+                    op: 'del',
+                    hash: 'h1',
+                  },
+                ],
+              },
+              rowsPatch: [
+                {op: 'del', tableName: 'issues', id: {['issue_id']: 'issue3'}},
+              ],
+            },
+          ],
+          pokeEnd: {
+            pokeID: 'poke2',
+            cookie: '5',
+          },
+        },
+      ],
+      schema,
+      serverToClient(schema.tables),
+    );
+    expect(result).toEqual({
+      baseCookie: '3',
+      pullResponse: {
+        lastMutationIDChanges: {
+          c1: 1,
+          c2: 2,
+        },
+        patch: [
+          {
+            op: 'put',
+            key: 'g/h1',
+            value: null,
+          },
+          {
+            op: 'put',
+            key: 'e/issue/issue1',
+            value: {id: 'issue1', title: 'foo1'},
+          },
+          {
+            op: 'update',
+            key: 'e/issue/issue2',
+            merge: {id: 'issue2', title: 'bar1'},
+            constrain: ['id', 'title'],
+          },
+          {
+            op: 'put',
+            key: 'd/c1/h2',
+            value: null,
+          },
+          {
+            op: 'del',
+            key: 'd/c1/h1',
+          },
+          {
+            op: 'del',
+            key: 'e/issue/issue3',
+          },
+        ],
+        cookie: '5',
+      },
+    });
+  });
+
+  test('mergePokes throws error on cookie gaps', () => {
+    expect(() => {
+      mergePokes(
+        [
+          {
+            pokeStart: {
+              pokeID: 'poke1',
+              baseCookie: '3',
+              schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
+            },
+            parts: [
+              {
+                pokeID: 'poke1',
+                lastMutationIDChanges: {c1: 1, c2: 2},
+              },
+            ],
+            pokeEnd: {
+              pokeID: 'poke1',
+              cookie: '4',
+            },
+          },
+          {
+            pokeStart: {
+              pokeID: 'poke2',
+              baseCookie: '5', // gap, should be 4
+              schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
+            },
+            parts: [
+              {
+                pokeID: 'poke2',
+                lastMutationIDChanges: {c4: 3},
+              },
+            ],
+            pokeEnd: {
+              pokeID: 'poke2',
+              cookie: '6',
+            },
+          },
+        ],
+        schema,
+        serverToClient(schema.tables),
+      );
+    }).to.throw();
+  });
+});
+
+describe('mutation tracker interactions', () => {
+  beforeEach(() => {
+    rafStub = vi
+      .spyOn(globalThis, 'requestAnimationFrame')
+      .mockImplementation(c => {
+        setTimeout(() => {
+          c(UNUSED_RAF_ARG);
+        }, 0);
+        return 1;
+      });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("poke handler advances mutation tracker's lmid", async () => {
+    const onPokeErrorStub = vi.fn();
+    const replicachePokeStub = vi.fn();
+    const clientID = 'c1';
+    const logContext = new LogContext('error');
+    const tracker = new MutationTracker(logContext);
+    const spy = vi.spyOn(tracker, 'lmidAdvanced');
+    tracker.clientID = clientID;
+    const pokeHandler = new PokeHandler(
+      replicachePokeStub,
+      onPokeErrorStub,
+      clientID,
+      schema,
+      logContext,
+      tracker,
+    );
+
+    let id = 0;
+    function doPoke(mids: Record<string, number> | undefined) {
+      ++id;
+      pokeHandler.handlePokeStart({
+        pokeID: 'poke' + id,
+        baseCookie: '1',
+        schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
+      });
+      pokeHandler.handlePokePart({
+        pokeID: 'poke' + id,
+        lastMutationIDChanges: mids,
+      });
+      pokeHandler.handlePokeEnd({pokeID: 'poke' + id, cookie: '2'});
+    }
+
+    doPoke(undefined);
+    expect(spy).not.toHaveBeenCalled();
+
+    doPoke({c2: 2});
+    expect(spy).not.toHaveBeenCalled();
+
+    doPoke({c1: 2, c2: 3, c3: 4});
+    await vi.waitFor(() => {
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(2);
+    });
+  });
+
+  test('poke handler calls `processMutationResponses`', async () => {
+    const onPokeErrorStub = vi.fn();
+    const replicachePokeStub = vi.fn();
+    const clientID = 'c1';
+    const logContext = new LogContext('error');
+    const tracker = new MutationTracker(logContext);
+    const spy = vi.spyOn(tracker, 'processMutationResponses');
+    tracker.clientID = clientID;
+    const pokeHandler = new PokeHandler(
+      replicachePokeStub,
+      onPokeErrorStub,
+      clientID,
+      schema,
+      logContext,
+      tracker,
+    );
+
+    let id = 0;
+    function doPoke(
+      mids: Record<string, number> | undefined,
+      mutationsPatch: MutationPatch[] | undefined,
+    ) {
+      ++id;
+      pokeHandler.handlePokeStart({
+        pokeID: 'poke' + id,
+        baseCookie: '1',
+        schemaVersions: {minSupportedVersion: 1, maxSupportedVersion: 1},
+      });
+      pokeHandler.handlePokePart({
+        pokeID: 'poke' + id,
+        lastMutationIDChanges: mids,
+        mutationsPatch,
+      });
+      pokeHandler.handlePokeEnd({pokeID: 'poke' + id, cookie: '2'});
+    }
+
+    doPoke(undefined, undefined);
+    expect(spy).not.toHaveBeenCalled();
+
+    doPoke({c2: 2}, undefined);
+    expect(spy).not.toHaveBeenCalled();
+
+    doPoke({c2: 2}, [
+      {
+        mutation: {
+          id: {id: 1, clientID: 'c1'},
+          result: {},
+        },
+        op: 'put',
+      },
+    ]);
+    await vi.waitFor(() => {
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith([
+        {
+          mutation: {
+            id: {id: 1, clientID: 'c1'},
+            result: {},
+          },
+          op: 'put',
+        },
+      ]);
+    });
+  });
 });

--- a/packages/zero-client/src/client/zero-poke-handler.test.ts
+++ b/packages/zero-client/src/client/zero-poke-handler.test.ts
@@ -13,6 +13,7 @@ import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import {string, table} from '../../../zero-schema/src/builder/table-builder.ts';
 import {serverToClient} from '../../../zero-schema/src/name-mapper.ts';
 import {PokeHandler, mergePokes} from './zero-poke-handler.ts';
+import {MutationTracker} from './mutation-tracker.ts';
 
 let rafStub: MockInstance<(cb: FrameRequestCallback) => number>;
 // The FrameRequestCallback in PokeHandler does not use
@@ -59,6 +60,7 @@ test('completed poke plays on first raf', async () => {
     clientID,
     schema,
     logContext,
+    new MutationTracker(logContext),
   );
   expect(rafStub).toHaveBeenCalledTimes(0);
 
@@ -167,6 +169,7 @@ test('canceled poke is not applied', async () => {
     clientID,
     schema,
     logContext,
+    new MutationTracker(logContext),
   );
   expect(rafStub).toHaveBeenCalledTimes(0);
 
@@ -281,6 +284,7 @@ test('multiple pokes received before raf callback are merged', async () => {
     clientID,
     schema,
     logContext,
+    new MutationTracker(logContext),
   );
 
   expect(rafStub).toHaveBeenCalledTimes(0);
@@ -431,6 +435,7 @@ test('multiple pokes received before raf callback are merged, canceled pokes are
     clientID,
     schema,
     logContext,
+    new MutationTracker(logContext),
   );
 
   expect(rafStub).toHaveBeenCalledTimes(0);
@@ -612,6 +617,7 @@ test('playback over series of rafs', async () => {
     clientID,
     schema,
     logContext,
+    new MutationTracker(logContext),
   );
 
   expect(rafStub).toHaveBeenCalledTimes(0);
@@ -822,6 +828,7 @@ suite('onPokeErrors', () => {
         clientID,
         schema,
         logContext,
+        new MutationTracker(logContext),
       );
 
       expect(onPokeErrorStub).toHaveBeenCalledTimes(0);
@@ -842,6 +849,7 @@ test('replicachePoke throwing error calls onPokeError and clears', async () => {
     clientID,
     schema,
     logContext,
+    new MutationTracker(logContext),
   );
   expect(rafStub).toHaveBeenCalledTimes(0);
 
@@ -948,6 +956,7 @@ test('cookie gap during mergePoke calls onPokeError and clears', async () => {
     clientID,
     schema,
     logContext,
+    new MutationTracker(logContext),
   );
   expect(rafStub).toHaveBeenCalledTimes(0);
 
@@ -1068,6 +1077,7 @@ test('onDisconnect clears pending pokes', async () => {
     clientID,
     schema,
     logContext,
+    new MutationTracker(logContext),
   );
   expect(rafStub).toHaveBeenCalledTimes(0);
 
@@ -1136,6 +1146,7 @@ test('handlePoke returns the last mutation id change for this client from pokePa
     clientID,
     schema,
     logContext,
+    new MutationTracker(logContext),
   );
   expect(rafStub).toHaveBeenCalledTimes(0);
 

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -710,6 +710,7 @@ export class Zero<
       rep.clientID,
       schema,
       this.#lc,
+      this.#mutationTracker,
     );
 
     this.#visibilityWatcher = getDocumentVisibilityWatcher(
@@ -1376,7 +1377,6 @@ export class Zero<
   #handlePokeEnd(_lc: ZeroLogContext, pokeMessage: PokeEndMessage): void {
     this.#abortPingTimeout();
     this.#pokeHandler.handlePokeEnd(pokeMessage[1]);
-    this.#mutationTracker.lmidAdvanced(this.#lastMutationIDReceived);
   }
 
   #onPokeError(): void {

--- a/packages/zero-protocol/src/ast.test.ts
+++ b/packages/zero-protocol/src/ast.test.ts
@@ -607,5 +607,5 @@ test('protocol version', () => {
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
   expect(hash).toEqual('1c228prd1v53r');
-  expect(PROTOCOL_VERSION).toEqual(22);
+  expect(PROTOCOL_VERSION).toEqual(23);
 });

--- a/packages/zero-protocol/src/mutations-patch.ts
+++ b/packages/zero-protocol/src/mutations-patch.ts
@@ -1,0 +1,15 @@
+import * as v from '../../shared/src/valita.ts';
+import {mutationIDSchema, mutationResponseSchema} from './push.ts';
+
+export const putOpSchema = v.object({
+  op: v.literal('put'),
+  mutation: mutationResponseSchema,
+});
+
+export const delOpSchema = v.object({
+  op: v.literal('del'),
+  mutationID: mutationIDSchema,
+});
+
+const patchOpSchema = v.union(putOpSchema, delOpSchema);
+export const mutationsPatchSchema = v.array(patchOpSchema);

--- a/packages/zero-protocol/src/mutations-patch.ts
+++ b/packages/zero-protocol/src/mutations-patch.ts
@@ -1,15 +1,10 @@
 import * as v from '../../shared/src/valita.ts';
-import {mutationIDSchema, mutationResponseSchema} from './push.ts';
+import {mutationResponseSchema} from './push.ts';
 
 export const putOpSchema = v.object({
   op: v.literal('put'),
   mutation: mutationResponseSchema,
 });
 
-export const delOpSchema = v.object({
-  op: v.literal('del'),
-  mutationID: mutationIDSchema,
-});
-
-const patchOpSchema = v.union(putOpSchema, delOpSchema);
+const patchOpSchema = putOpSchema;
 export const mutationsPatchSchema = v.array(patchOpSchema);

--- a/packages/zero-protocol/src/mutations-patch.ts
+++ b/packages/zero-protocol/src/mutations-patch.ts
@@ -8,3 +8,4 @@ export const putOpSchema = v.object({
 
 const patchOpSchema = putOpSchema;
 export const mutationsPatchSchema = v.array(patchOpSchema);
+export type MutationPatch = v.Infer<typeof patchOpSchema>;

--- a/packages/zero-protocol/src/mutations-patch.ts
+++ b/packages/zero-protocol/src/mutations-patch.ts
@@ -1,6 +1,13 @@
 import * as v from '../../shared/src/valita.ts';
 import {mutationResponseSchema} from './push.ts';
 
+/**
+ * Mutation results are stored ephemerally in the client
+ * hence why we only have the `put` operation.
+ *
+ * On put the mutation promise is resolved/rejected
+ * and reference released.
+ */
 export const putOpSchema = v.object({
   op: v.literal('put'),
   mutation: mutationResponseSchema,

--- a/packages/zero-protocol/src/poke.ts
+++ b/packages/zero-protocol/src/poke.ts
@@ -1,4 +1,5 @@
 import * as v from '../../shared/src/valita.ts';
+import {mutationsPatchSchema} from './mutations-patch.ts';
 import {queriesPatchSchema} from './queries-patch.ts';
 import {rowsPatchSchema} from './row-patch.ts';
 import {nullableVersionSchema, versionSchema} from './version.ts';
@@ -58,6 +59,8 @@ export const pokePartBodySchema = v.object({
   gotQueriesPatch: queriesPatchSchema.optional(),
   // Patches to the rows set.
   rowsPatch: rowsPatchSchema.optional(),
+  // Mutation results patch
+  mutationsPatch: mutationsPatchSchema.optional(),
 });
 
 export const pokeEndBodySchema = v.object({

--- a/packages/zero-protocol/src/protocol-version.test.ts
+++ b/packages/zero-protocol/src/protocol-version.test.ts
@@ -11,6 +11,6 @@ test('protocol version', () => {
   // If this test fails upstream or downstream schema has changed such that
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
-  expect(hash).toEqual('33g5lnxheg618');
-  expect(PROTOCOL_VERSION).toEqual(22);
+  expect(hash).toEqual('qpif75ntdfus');
+  expect(PROTOCOL_VERSION).toEqual(23);
 });

--- a/packages/zero-protocol/src/protocol-version.ts
+++ b/packages/zero-protocol/src/protocol-version.ts
@@ -28,7 +28,8 @@ import {assert} from '../../shared/src/asserts.ts';
 // -- Version 20 changes inspector down message (0.22)
 // -- Version 21 removes `AST` in downstream query puts which was deprecated in Version 17, removes support for versions < 18 (0.22)
 // -- Version 22 adds an optional 'userQueryParams' field to `initConnection` (0.22)
-export const PROTOCOL_VERSION = 22;
+// -- Version 23 add `mutationResults` to poke (0.22)
+export const PROTOCOL_VERSION = 23;
 
 /**
  * The minimum server-supported sync protocol version (i.e. the version

--- a/packages/zero-protocol/src/push.ts
+++ b/packages/zero-protocol/src/push.ts
@@ -120,7 +120,11 @@ const mutationOkSchema = v.object({
 });
 const mutationErrorSchema = v.union(appErrorSchema, zeroErrorSchema);
 
-const mutationResultSchema = v.union(mutationOkSchema, mutationErrorSchema);
+export const mutationResultSchema = v.union(
+  mutationOkSchema,
+  mutationErrorSchema,
+);
+
 export const mutationResponseSchema = v.object({
   id: mutationIDSchema,
   result: mutationResultSchema,

--- a/packages/zero-protocol/src/push.ts
+++ b/packages/zero-protocol/src/push.ts
@@ -99,7 +99,7 @@ export const pushBodySchema = v.object({
 });
 
 export const pushMessageSchema = v.tuple([v.literal('push'), pushBodySchema]);
-const mutationIDSchema = v.object({
+export const mutationIDSchema = v.object({
   id: v.number(),
   clientID: v.string(),
 });
@@ -121,7 +121,7 @@ const mutationOkSchema = v.object({
 const mutationErrorSchema = v.union(appErrorSchema, zeroErrorSchema);
 
 const mutationResultSchema = v.union(mutationOkSchema, mutationErrorSchema);
-const mutationResponseSchema = v.object({
+export const mutationResponseSchema = v.object({
   id: mutationIDSchema,
   result: mutationResultSchema,
 });


### PR DESCRIPTION
Add to the `poke` protocol so updates to the `mutations` table can be poked down to the client.

On poke end, the client uses the merged poke result to resolve mutation promises. This happens after Replicache has been updated so a user can issue a read after their promise resolves and get the latest state.