### PR TITLE
chore(zero-cache): Rename (swap) Sender and Receiver process interfaces

### DIFF
--- a/packages/zero-cache/src/server/runner/zero-dispatcher.ts
+++ b/packages/zero-cache/src/server/runner/zero-dispatcher.ts
@@ -1,5 +1,6 @@
 import type {LogContext} from '@rocicorp/logger';
 import type {NormalizedZeroConfig} from '../../config/normalize.ts';
+import {handleHeapzRequest} from '../../services/heapz.ts';
 import {HttpService, type Options} from '../../services/http-service.ts';
 import {handleStatzRequest} from '../../services/statz.ts';
 import type {IncomingMessageSubset} from '../../types/http.ts';
@@ -8,7 +9,6 @@ import {
   installWebSocketHandoff,
   type HandoffSpec,
 } from '../../types/websocket-handoff.ts';
-import {handleHeapzRequest} from '../../services/heapz.ts';
 
 export class ZeroDispatcher extends HttpService {
   readonly id = 'zero-dispatcher';
@@ -38,7 +38,7 @@ export class ZeroDispatcher extends HttpService {
     onError: (error: unknown) => void,
   ) => {
     void this.#getWorker().then(
-      receiver => dispatch({payload: 'unused', receiver}),
+      sender => dispatch({payload: 'unused', sender}),
       onError,
     );
   };

--- a/packages/zero-cache/src/server/worker-dispatcher.ts
+++ b/packages/zero-cache/src/server/worker-dispatcher.ts
@@ -48,7 +48,7 @@ export class WorkerDispatcher implements Service {
         mutator !== undefined,
         'Received a push for a custom mutation but no `push.url` was configured.',
       );
-      return {payload: connectParams(req), receiver: mutator};
+      return {payload: connectParams(req), sender: mutator};
     };
 
     const handleSync = (req: IncomingMessageSubset) => {
@@ -64,7 +64,7 @@ export class WorkerDispatcher implements Service {
       const syncer = h32(taskID + '/' + clientGroupID) % syncers.length;
 
       lc.debug?.(`connecting ${clientGroupID} to syncer ${syncer}`);
-      return {payload: params, receiver: syncers[syncer]};
+      return {payload: params, sender: syncers[syncer]};
     };
 
     const handleChangeStream = (req: IncomingMessageSubset) => {
@@ -90,7 +90,7 @@ export class WorkerDispatcher implements Service {
 
       return {
         payload: path.action,
-        receiver: changeStreamer,
+        sender: changeStreamer,
       };
     };
 

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.pg-test.ts
@@ -74,7 +74,7 @@ describe('change-streamer/http', () => {
     snapshotFn = vi.fn();
     endReservationFn = vi.fn();
 
-    const [parent, receiver] = inProcChannel();
+    const [parent, sender] = inProcChannel();
 
     const dispatcher = Fastify();
     installWebSocketHandoff(
@@ -82,7 +82,7 @@ describe('change-streamer/http', () => {
       req => {
         const {pathname} = new URL(req.url ?? '', 'http://unused/');
         const action = pathname.substring(pathname.lastIndexOf('/') + 1);
-        return {payload: action, receiver};
+        return {payload: action, sender};
       },
       dispatcher.server,
     );

--- a/packages/zero-cache/src/types/websocket-handoff.test.ts
+++ b/packages/zero-cache/src/types/websocket-handoff.test.ts
@@ -39,7 +39,7 @@ describe('types/websocket-handoff', () => {
       lc,
       () => ({
         payload: {foo: 'boo'},
-        receiver: child,
+        sender: child,
       }),
       server,
     );
@@ -76,7 +76,7 @@ describe('types/websocket-handoff', () => {
       (_, callback) =>
         callback({
           payload: {foo: 'boo'},
-          receiver: child,
+          sender: child,
         }),
       server,
     );
@@ -112,7 +112,7 @@ describe('types/websocket-handoff', () => {
       lc,
       () => ({
         payload: {foo: 'boo'},
-        receiver: grandParent,
+        sender: grandParent,
       }),
       server,
     );
@@ -122,7 +122,7 @@ describe('types/websocket-handoff', () => {
       lc,
       () => ({
         payload: {foo: 'boo'},
-        receiver: parent2,
+        sender: parent2,
       }),
       parent1,
     );


### PR DESCRIPTION
The previous naming was intended to represent the destination process, i.e. you call "send()" on the receiving process. 

But this is kind of confusing.

The new naming is more intuitive: Sender.send() and Receiver.onMessage().