### PR TITLE
chore(zero-cache): check the protocol version on snapshot reservation requests

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.pg-test.ts
@@ -175,6 +175,12 @@ describe('change-streamer/http', () => {
         `/replication/v${PROTOCOL_VERSION + 1}/changes` +
           `?id=foo&replicaVersion=bar&watermark=123&initial=true`,
       ],
+      [
+        // Change the error message as necessary
+        `Cannot service client at protocol v4. Supported protocols: [v1 ... v3]`,
+        `/replication/v${PROTOCOL_VERSION + 1}/snapshot` +
+          `?id=foo&replicaVersion=bar&watermark=123&initial=true`,
+      ],
     ])('%s: %s', async (error, path) => {
       for (const address of [serverAddress, dispatcherAddress]) {
         const {promise: result, resolve} = resolver<unknown>();

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
@@ -7,7 +7,7 @@ import {must} from '../../../../shared/src/must.ts';
 import type {IncomingMessageSubset} from '../../types/http.ts';
 import {pgClient, type PostgresDB} from '../../types/pg.ts';
 import {type Worker} from '../../types/processes.ts';
-import type {ShardID} from '../../types/shards.ts';
+import {type ShardID} from '../../types/shards.ts';
 import {streamIn, streamOut, type Source} from '../../types/streams.ts';
 import {URLParams} from '../../types/url-params.ts';
 import {installWebSocketReceiver} from '../../types/websocket-handoff.ts';
@@ -101,6 +101,7 @@ export class ChangeStreamerHttpServer extends HttpService {
         req.url ?? '',
         req.headers.origin ?? 'http://localhost',
       );
+      checkProtocolVersion(url.pathname);
       const taskID = url.searchParams.get('taskID');
       if (!taskID) {
         throw new Error('Missing taskID in snapshot request');
@@ -194,7 +195,7 @@ type RequestHeaders = Pick<IncomingMessage, 'url' | 'headers'>;
 
 export function getSubscriberContext(req: RequestHeaders): SubscriberContext {
   const url = new URL(req.url ?? '', req.headers.origin ?? 'http://localhost');
-  const protocolVersion = checkPath(url.pathname);
+  const protocolVersion = checkProtocolVersion(url.pathname);
   const params = new URLParams(url);
 
   return {
@@ -208,7 +209,7 @@ export function getSubscriberContext(req: RequestHeaders): SubscriberContext {
   };
 }
 
-function checkPath(pathname: string): number {
+function checkProtocolVersion(pathname: string): number {
   const match = PATH_REGEX.exec(pathname);
   if (!match) {
     throw new Error(`invalid path: ${pathname}`);


### PR DESCRIPTION
Have the change-streamer (i.e. replication-manager) verify that the protocol version in the snapshot reservation url is within the support range of change-streamer protocol versions.

This allows the snapshot request to verify that the replication-manager will support the subsequent change stream request from the view-syncer, and be used in a subsequent PR to coordinate rollouts of replication-managers and view-syncers when the protocol changes.