### PR TITLE
fix: email sending

### DIFF
--- a/apps/zbugs/server/email.ts
+++ b/apps/zbugs/server/email.ts
@@ -1,6 +1,10 @@
 import {schema, type Schema} from '../shared/schema.ts';
 import {type Transaction, type Row} from '@rocicorp/zero';
 
+// From https://github.com/colinhacks/zod/blob/2c333e268c316deef829c736b8c46ec95ee03e39/packages/zod/src/v4/core/regexes.ts#L33C34-L35C102
+const emailRegex =
+  /^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9-]*\.)+[A-Za-z]{2,}$/;
+
 export async function sendEmail({
   tx,
   email,
@@ -32,6 +36,11 @@ export async function sendEmail({
     console.log(
       'Missing LOOPS_EMAIL_API_KEY or LOOPS_TRANSACTIONAL_ID Skipping Email',
     );
+    return;
+  }
+
+  if (!emailRegex.test(email)) {
+    console.log('Invalid email provided, skipping email', email);
     return;
   }
 


### PR DESCRIPTION
Some mutations are now failing when one of the emails in the mutation is invalid. This adds validation to email sending.