### PR TITLE
chore(zero-cache): support exporting subsets of otel exports

### DIFF
--- a/packages/otel/src/enabled.ts
+++ b/packages/otel/src/enabled.ts
@@ -1,0 +1,24 @@
+export function otelEnabled() {
+  return otelMetricsEnabled() || otelTracesEnabled() || otelLogsEnabled();
+}
+
+export function otelMetricsEnabled() {
+  return (
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT ||
+    process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
+  );
+}
+
+export function otelLogsEnabled() {
+  return (
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT ||
+    process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
+  );
+}
+
+export function otelTracesEnabled() {
+  return (
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT ||
+    process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+  );
+}

--- a/packages/zero-cache/src/server/logging.ts
+++ b/packages/zero-cache/src/server/logging.ts
@@ -4,13 +4,13 @@ import {
   type LogLevel,
   type LogSink,
 } from '@rocicorp/logger';
+import {otelLogsEnabled} from '../../../otel/src/enabled.ts';
 import {
   createLogContext as createLogContextShared,
   getLogSink,
   type LogConfig,
 } from '../../../shared/src/logging.ts';
 import {OtelLogSink} from './otel-log-sink.ts';
-import {otelLogsEnabled} from './otel-start.ts';
 
 export function createLogContext(
   {log}: {log: LogConfig},

--- a/packages/zero-cache/src/server/logging.ts
+++ b/packages/zero-cache/src/server/logging.ts
@@ -4,9 +4,13 @@ import {
   type LogLevel,
   type LogSink,
 } from '@rocicorp/logger';
-import {createLogContext as createLogContextShared} from '../../../shared/src/logging.ts';
+import {
+  createLogContext as createLogContextShared,
+  getLogSink,
+  type LogConfig,
+} from '../../../shared/src/logging.ts';
 import {OtelLogSink} from './otel-log-sink.ts';
-import {getLogSink, type LogConfig} from '../../../shared/src/logging.ts';
+import {otelLogsEnabled} from './otel-start.ts';
 
 export function createLogContext(
   {log}: {log: LogConfig},
@@ -17,7 +21,7 @@ export function createLogContext(
 
 function createLogSink(config: LogConfig): LogSink {
   const sink = getLogSink(config);
-  if (process.env.OTEL_EXPORTER_OTLP_ENDPOINT) {
+  if (otelLogsEnabled()) {
     const otelSink = new OtelLogSink();
     return new CompositeLogSink([otelSink, sink]);
   }

--- a/packages/zero-cache/src/server/otel-start.ts
+++ b/packages/zero-cache/src/server/otel-start.ts
@@ -20,6 +20,12 @@ import {
 import {PeriodicExportingMetricReader} from '@opentelemetry/sdk-metrics';
 import {NodeSDK} from '@opentelemetry/sdk-node';
 import {ATTR_SERVICE_VERSION} from '@opentelemetry/semantic-conventions';
+import {
+  otelEnabled,
+  otelLogsEnabled,
+  otelMetricsEnabled,
+  otelTracesEnabled,
+} from '../../../otel/src/enabled.ts';
 
 class OtelManager {
   static #instance: OtelManager;
@@ -102,31 +108,6 @@ class OtelManager {
       body: 'OpenTelemetry SDK started successfully',
     });
   }
-}
-
-export function otelEnabled() {
-  return otelMetricsEnabled() || otelTracesEnabled() || otelLogsEnabled();
-}
-
-export function otelMetricsEnabled() {
-  return (
-    process.env.OTEL_EXPORTER_OTLP_ENDPOINT ||
-    process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
-  );
-}
-
-export function otelLogsEnabled() {
-  return (
-    process.env.OTEL_EXPORTER_OTLP_ENDPOINT ||
-    process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
-  );
-}
-
-export function otelTracesEnabled() {
-  return (
-    process.env.OTEL_EXPORTER_OTLP_ENDPOINT ||
-    process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-  );
 }
 
 export const startOtelAuto = () => OtelManager.getInstance().startOtelAuto();


### PR DESCRIPTION
Modify the `otel-start` logic to support exporting subsets of otel traces, metrics, and logs by understanding the `OTEL_EXPORTER_OTLP_{METRICS,LOGS,TRACES}_ENDPOINT` environment variables.

Also fix the `server.version` attribute to reference the zero-version, rather than the instrumentation scope version (that's appropriate for annotating traces).