### PR TITLE
fix(ttl): fix incorrect calculation of expired queries

### DIFF
--- a/packages/zero-cache/src/services/mutagen/pusher.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.ts
@@ -130,7 +130,7 @@ export class PusherService implements Service, Pusher {
     await sql`DELETE FROM ${upstreamSchema({
       appID: this.#config.app.id,
       shardNum: this.#config.shard.num,
-    })}.mutations WHERE "clientGroupID" = ${this.id} AND "clientID" = ${upToID.clientID} AND "mutationID" <= ${upToID}`;
+    })}.mutations WHERE "clientGroupID" = ${this.id} AND "clientID" = ${upToID.clientID} AND "mutationID" <= ${upToID.id}`;
   }
 
   ref() {

--- a/packages/zero-cache/src/services/view-syncer/cvr.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.test.ts
@@ -228,10 +228,7 @@ test.each([
         {hash: 'h2', ttl: -1, inactivatedAt: undefined},
       ],
     },
-    expected: [
-      {hash: 'h2', ttl: 2000, inactivatedAt: ttlClockFromNumber(1000)},
-      {hash: 'h1', ttl: minutes(10), inactivatedAt: ttlClockFromNumber(2000)},
-    ],
+    expected: [],
   },
 ])('getInactiveQueries %o', ({clients, expected}) => {
   const cvr = makeCVR(clients);


### PR DESCRIPTION
There are two paths the check if queries are expired:

1. `hasExpiredQueries` in view-syncer.ts
2. `getInactiveQueries` in cvr.ts

(1) only returns queries that are expired for all clients. (2) was returning queries if they were expired for 1 or more clients.

On reading, it appears that both paths should caluclate expiration the same way. The second path should not return a query as inactive if one of its client has not inactivated it.

It looks like this was addressed before here: https://github.com/rocicorp/mono/pull/3843 but it did not take into account the `undefined` case. Or I'm missing something.

before (re-schedules eviction every 50ms because it thinks a query is expired but it is not):

https://github.com/user-attachments/assets/42459a6a-2716-4a94-b843-53aa37475206

after (stable):

https://github.com/user-attachments/assets/e8893bd4-be06-4290-9016-7b46eb33ad65

