### PR TITLE
chore(zero-cache): surface diagnostic otel messages to debug logs

### DIFF
--- a/packages/zero-cache/src/server/logging.ts
+++ b/packages/zero-cache/src/server/logging.ts
@@ -15,13 +15,18 @@ import {OtelLogSink} from './otel-log-sink.ts';
 export function createLogContext(
   {log}: {log: LogConfig},
   context: {worker: string},
+  includeOtel = true,
 ): LogContext {
-  return createLogContextShared({log}, context, createLogSink(log));
+  return createLogContextShared(
+    {log},
+    context,
+    createLogSink(log, includeOtel),
+  );
 }
 
-function createLogSink(config: LogConfig): LogSink {
+function createLogSink(config: LogConfig, includeOtel: boolean): LogSink {
   const sink = getLogSink(config);
-  if (otelLogsEnabled()) {
+  if (includeOtel && otelLogsEnabled()) {
     const otelSink = new OtelLogSink();
     return new CompositeLogSink([otelSink, sink]);
   }

--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -42,9 +42,9 @@ export default function runWorker(
 ): Promise<void> {
   const config = getZeroConfig({env, argv: args.slice(1)});
   assertNormalized(config);
-  startOtelAuto();
 
-  const lc = createLogContext(config, {worker: 'syncer'});
+  startOtelAuto(createLogContext(config, {worker: 'syncer'}, false));
+  const lc = createLogContext(config, {worker: 'syncer'}, true);
 
   assert(args.length > 0, `replicator mode not specified`);
   const fileMode = v.parse(args[0], replicaFileModeSchema);


### PR DESCRIPTION
Surface diagnostic messages from the otel client to the debug logs, which include otel usage warnings and export errors. The messages otherwise go into the ether.