### PR TITLE
feat(zero): write mutation results to upstream

### DIFF
--- a/apps/zbugs/server/server-mutators.ts
+++ b/apps/zbugs/server/server-mutators.ts
@@ -26,6 +26,7 @@ export function createServerMutators(
       ...mutators.issue,
 
       async create(tx, {id, title, description}: CreateIssueArgs) {
+        throw new Error('foo'); // This line is a placeholder for debugging purposes.
         await mutators.issue.create(tx, {
           id,
           title,

--- a/packages/replicache-doc/docs/reference/server-push.md
+++ b/packages/replicache-doc/docs/reference/server-push.md
@@ -64,7 +64,7 @@ When pushing we `POST` an HTTP request with a [JSON encoded body](/api#pushreque
 
 ```ts
 type PushRequest = {
-  pushVersion: 1;
+  pushVersion: 2;
   clientGroupID: string;
   mutations: Mutation[];
   profileID: string;

--- a/packages/replicache/src/mutation-recovery-test-helper.ts
+++ b/packages/replicache/src/mutation-recovery-test-helper.ts
@@ -15,7 +15,7 @@ import {IDBDatabasesStore} from './persist/idb-databases-store.ts';
 import {persistDD31} from './persist/persist.ts';
 import {makeIDBNameForTesting} from './replicache.ts';
 import type {ClientGroupID, ClientID} from './sync/ids.ts';
-import {PUSH_VERSION_DD31} from './sync/push.ts';
+import {PUSH_VERSION_ZERO} from './sync/push.ts';
 import {closeablesToClose, dbsToDrop} from './test-util.ts';
 import type {MutatorDefs} from './types.ts';
 
@@ -179,7 +179,7 @@ export function createPushRequestBodyDD31(
       args: localMeta.mutatorArgsJSON,
       timestamp: localMeta.timestamp,
     })),
-    pushVersion: PUSH_VERSION_DD31,
+    pushVersion: PUSH_VERSION_ZERO,
     schemaVersion,
   };
 }

--- a/packages/replicache/src/mutation-recovery.ts
+++ b/packages/replicache/src/mutation-recovery.ts
@@ -33,7 +33,7 @@ import type {PullResponseOKV1, PullResponseV1, Puller} from './puller.ts';
 import type {PushResponse, Pusher} from './pusher.ts';
 import type {ClientGroupID, ClientID} from './sync/ids.ts';
 import {beginPullV1} from './sync/pull.ts';
-import {PUSH_VERSION_DD31, push} from './sync/push.ts';
+import {PUSH_VERSION_ZERO, push} from './sync/push.ts';
 import {withRead, withWrite} from './with-transactions.ts';
 
 type FormatVersion = Enum<typeof FormatVersion>;
@@ -360,7 +360,7 @@ async function recoverMutationsOfClientGroupDD31(
             clientID,
             pusher,
             database.schemaVersion,
-            PUSH_VERSION_DD31,
+            PUSH_VERSION_ZERO,
           );
           return {
             result: pusherResult,

--- a/packages/replicache/src/replicache-impl.ts
+++ b/packages/replicache/src/replicache-impl.ts
@@ -103,7 +103,7 @@ import * as HandlePullResponseResultEnum from './sync/handle-pull-response-resul
 import type {ClientGroupID, ClientID} from './sync/ids.ts';
 import {PullError} from './sync/pull-error.ts';
 import {beginPullV1, handlePullResponseV1, maybeEndPull} from './sync/pull.ts';
-import {push, PUSH_VERSION_DD31} from './sync/push.ts';
+import {push, PUSH_VERSION_ZERO} from './sync/push.ts';
 import {newRequestID} from './sync/request-id.ts';
 import {SYNC_HEAD_NAME} from './sync/sync-head-name.ts';
 import {throwIfClosed} from './transaction-closed-error.ts';
@@ -997,7 +997,7 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}> {
               clientID,
               this.pusher,
               this.schemaVersion,
-              PUSH_VERSION_DD31,
+              PUSH_VERSION_ZERO,
             );
             return {
               result: pusherResult,

--- a/packages/replicache/src/replicache-mutation-recovery-dd31.test.ts
+++ b/packages/replicache/src/replicache-mutation-recovery-dd31.test.ts
@@ -23,7 +23,7 @@ import type {PushResponse} from './pusher.ts';
 import type {ClientID} from './sync/ids.ts';
 import {PULL_VERSION_DD31, type PullRequestV1} from './sync/pull.ts';
 import {
-  PUSH_VERSION_DD31,
+  PUSH_VERSION_ZERO,
   type PushRequestV1,
   assertPushRequestV1,
 } from './sync/push.ts';
@@ -208,7 +208,7 @@ describe('DD31', () => {
           timestamp: client2PendingLocalMetas[1].timestamp,
         },
       ],
-      pushVersion: PUSH_VERSION_DD31,
+      pushVersion: PUSH_VERSION_ZERO,
       schemaVersion: schemaVersionOfClientWPendingMutations,
     });
 
@@ -477,7 +477,7 @@ describe('DD31', () => {
           timestamp: client1PendingLocalMetas[1].timestamp,
         },
       ],
-      pushVersion: PUSH_VERSION_DD31,
+      pushVersion: PUSH_VERSION_ZERO,
       schemaVersion: schemaVersionOfClientWPendingMutations,
     });
 
@@ -1777,7 +1777,7 @@ describe('DD31', () => {
         },
       ],
       profileID,
-      pushVersion: PUSH_VERSION_DD31,
+      pushVersion: PUSH_VERSION_ZERO,
       schemaVersion: schemaVersion2,
     };
     expect(pushRequestJSONBodies).to.deep.equal([pushRequestBody1]);
@@ -1930,7 +1930,7 @@ describe('DD31', () => {
         },
       ],
       profileID,
-      pushVersion: PUSH_VERSION_DD31,
+      pushVersion: PUSH_VERSION_ZERO,
       schemaVersion: schemaVersion2,
     };
     expect(pushRequestJSONBodies).to.deep.equal([pushRequestBody1]);

--- a/packages/replicache/src/sync/push.test.ts
+++ b/packages/replicache/src/sync/push.test.ts
@@ -10,7 +10,7 @@ import type {Pusher, PusherResult} from '../pusher.ts';
 import {withRead, withWrite} from '../with-transactions.ts';
 import type {ClientGroupID} from './ids.ts';
 import {
-  PUSH_VERSION_DD31,
+  PUSH_VERSION_ZERO,
   type PushRequest,
   type PushRequestV1,
   push,
@@ -116,7 +116,7 @@ test('try push [DD31]', async () => {
             timestamp: 42,
           },
         ],
-        pushVersion: PUSH_VERSION_DD31,
+        pushVersion: PUSH_VERSION_ZERO,
         schemaVersion: pushSchemaVersion,
       },
       pushResult: 'ok',
@@ -152,7 +152,7 @@ test('try push [DD31]', async () => {
             timestamp: 42,
           },
         ],
-        pushVersion: PUSH_VERSION_DD31,
+        pushVersion: PUSH_VERSION_ZERO,
         schemaVersion: pushSchemaVersion,
       },
       pushResult: 'ok',
@@ -188,7 +188,7 @@ test('try push [DD31]', async () => {
             timestamp: 42,
           },
         ],
-        pushVersion: PUSH_VERSION_DD31,
+        pushVersion: PUSH_VERSION_ZERO,
         schemaVersion: pushSchemaVersion,
       },
       pushResult: {error: 'FetchNotOk(500)'},
@@ -225,7 +225,7 @@ test('try push [DD31]', async () => {
             timestamp: 42,
           },
         ],
-        pushVersion: PUSH_VERSION_DD31,
+        pushVersion: PUSH_VERSION_ZERO,
         schemaVersion: pushSchemaVersion,
       },
       pushResult: {error: 'FetchNotOk(500)'},
@@ -301,7 +301,7 @@ test('try push [DD31]', async () => {
       clientID,
       pusher,
       pushSchemaVersion,
-      PUSH_VERSION_DD31,
+      PUSH_VERSION_ZERO,
     );
 
     expect(pusherResult).to.deep.equal(c.expPusherResult, `name: ${c.name}`);

--- a/packages/replicache/src/sync/push.ts
+++ b/packages/replicache/src/sync/push.ts
@@ -57,7 +57,7 @@ const mutationV1Schema: valita.Type<MutationV1> = valita.readonlyObject({
  * endpoint](/reference/server-push).
  */
 export type PushRequestV1 = {
-  pushVersion: typeof PUSH_VERSION_ZERO;
+  pushVersion: typeof PUSH_VERSION_ZERO | typeof PUSH_VERSION_DD31;
   /**
    * `schemaVersion` can optionally be used to specify to the push endpoint
    * version information about the mutators the app is using (e.g., format of
@@ -71,7 +71,10 @@ export type PushRequestV1 = {
 };
 
 const pushRequestV1Schema = valita.object({
-  pushVersion: valita.literal(PUSH_VERSION_ZERO),
+  pushVersion: valita.union(
+    valita.literal(PUSH_VERSION_ZERO),
+    valita.literal(PUSH_VERSION_DD31),
+  ),
   schemaVersion: valita.string(),
   profileID: valita.string(),
   clientGroupID: clientGroupIDSchema,

--- a/packages/replicache/src/sync/push.ts
+++ b/packages/replicache/src/sync/push.ts
@@ -29,6 +29,7 @@ import {
 
 export const PUSH_VERSION_SDD = 0;
 export const PUSH_VERSION_DD31 = 1;
+export const PUSH_VERSION_ZERO = 2;
 
 /**
  * Mutation describes a single mutation done on the client.
@@ -56,7 +57,7 @@ const mutationV1Schema: valita.Type<MutationV1> = valita.readonlyObject({
  * endpoint](/reference/server-push).
  */
 export type PushRequestV1 = {
-  pushVersion: 1;
+  pushVersion: typeof PUSH_VERSION_ZERO;
   /**
    * `schemaVersion` can optionally be used to specify to the push endpoint
    * version information about the mutators the app is using (e.g., format of
@@ -70,7 +71,7 @@ export type PushRequestV1 = {
 };
 
 const pushRequestV1Schema = valita.object({
-  pushVersion: valita.literal(1),
+  pushVersion: valita.literal(PUSH_VERSION_ZERO),
   schemaVersion: valita.string(),
   profileID: valita.string(),
   clientGroupID: clientGroupIDSchema,
@@ -115,7 +116,10 @@ export async function push(
   _clientID: ClientID,
   pusher: Pusher,
   schemaVersion: string,
-  pushVersion: typeof PUSH_VERSION_SDD | typeof PUSH_VERSION_DD31,
+  pushVersion:
+    | typeof PUSH_VERSION_SDD
+    | typeof PUSH_VERSION_DD31
+    | typeof PUSH_VERSION_ZERO,
 ): Promise<PusherResult | undefined> {
   // Find pending commits between the base snapshot and the main head and push
   // them to the data layer.
@@ -136,7 +140,7 @@ export async function push(
   // want tail first (in mutation id order).
   pending.reverse();
 
-  assert(pushVersion === PUSH_VERSION_DD31);
+  assert(pushVersion === PUSH_VERSION_ZERO);
 
   const pushMutations: FrozenMutationV1[] = [];
   for (const commit of pending) {
@@ -151,7 +155,7 @@ export async function push(
     profileID,
     clientGroupID,
     mutations: pushMutations,
-    pushVersion: PUSH_VERSION_DD31,
+    pushVersion: PUSH_VERSION_ZERO,
     schemaVersion,
   };
 

--- a/packages/zero-cache/src/services/mutagen/pusher.test.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.test.ts
@@ -702,14 +702,14 @@ describe('pusher streaming', () => {
       ok: true,
       json: () => Promise.resolve(successResponse1),
     });
-    pusher.enqueuePush('client1', makePush(1, 'client1'), 'jwt', undefined);
+    pusher.enqueuePush('client1', makePush(1, 'client1', 1), 'jwt', undefined);
     await new Promise(resolve => setTimeout(resolve, 0));
 
     fetch.mockResolvedValue({
       ok: true,
       json: () => Promise.resolve(successResponse2),
     });
-    pusher.enqueuePush('client2', makePush(2, 'client2'), 'jwt', undefined);
+    pusher.enqueuePush('client2', makePush(2, 'client2', 1), 'jwt', undefined);
 
     const s1Messages: unknown[] = [];
     const s2Messages: unknown[] = [];
@@ -783,8 +783,8 @@ describe('pusher streaming', () => {
     const stream1 = pusher.initConnection('client1', 'ws1', undefined);
     const stream2 = pusher.initConnection('client2', 'ws2', undefined);
 
-    pusher.enqueuePush('client1', makePush(1, 'client1'), 'jwt', undefined);
-    pusher.enqueuePush('client2', makePush(1, 'client2'), 'jwt', undefined);
+    pusher.enqueuePush('client1', makePush(1, 'client1', 1), 'jwt', undefined);
+    pusher.enqueuePush('client2', makePush(1, 'client2', 1), 'jwt', undefined);
 
     const messages1: unknown[] = [];
     const messages2: unknown[] = [];
@@ -1057,11 +1057,15 @@ beforeEach(() => {
   id = 0;
 });
 
-function makePush(numMutations: number, clientID?: string): PushBody {
+function makePush(
+  numMutations: number,
+  clientID?: string,
+  pushVersion = 2,
+): PushBody {
   return {
     clientGroupID: 'cgid',
     mutations: Array.from({length: numMutations}, () => makeMutation(clientID)),
-    pushVersion: 2,
+    pushVersion,
     requestID: 'rid',
     schemaVersion: 1,
     timestamp: ++timestamp,
@@ -1078,3 +1082,7 @@ function makeMutation(clientID?: string): Mutation {
     timestamp: ++timestamp,
   } as const;
 }
+
+// TODO:
+// - test that new push versions do not fan out responses for mutation results
+// - test that both push versions do return error if the entire push fails

--- a/packages/zero-cache/src/services/mutagen/pusher.test.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.test.ts
@@ -173,7 +173,7 @@ describe('combine pushes', () => {
         {
           push: {
             ...makePush(1, 'client1'),
-            pushVersion: 1,
+            pushVersion: 2,
           },
           jwt: 'a',
           httpCookie: undefined,
@@ -182,7 +182,7 @@ describe('combine pushes', () => {
         {
           push: {
             ...makePush(2, 'client1'),
-            pushVersion: 2, // Different push version
+            pushVersion: 3, // Different push version
           },
           jwt: 'a',
           httpCookie: undefined,
@@ -200,7 +200,7 @@ describe('combine pushes', () => {
         push: {
           ...makePush(1, 'client1'),
           schemaVersion: 1,
-          pushVersion: 1,
+          pushVersion: 2,
         },
         jwt: 'a',
         httpCookie: undefined,
@@ -210,7 +210,7 @@ describe('combine pushes', () => {
         push: {
           ...makePush(2, 'client1'),
           schemaVersion: 1,
-          pushVersion: 1,
+          pushVersion: 2,
         },
         jwt: 'a',
         httpCookie: undefined,
@@ -1061,7 +1061,7 @@ function makePush(numMutations: number, clientID?: string): PushBody {
   return {
     clientGroupID: 'cgid',
     mutations: Array.from({length: numMutations}, () => makeMutation(clientID)),
-    pushVersion: 1,
+    pushVersion: 2,
     requestID: 'rid',
     schemaVersion: 1,
     timestamp: ++timestamp,

--- a/packages/zero-cache/src/services/mutagen/pusher.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.ts
@@ -128,10 +128,12 @@ export class PusherService implements Service, Pusher {
   async ackMutationResponses(upToID: MutationID) {
     // delete the relevant rows from the `mutations` table
     const sql = this.#upstream;
-    await sql`DELETE FROM ${upstreamSchema({
-      appID: this.#config.app.id,
-      shardNum: this.#config.shard.num,
-    })}.mutations WHERE "clientGroupID" = ${this.id} AND "clientID" = ${upToID.clientID} AND "mutationID" <= ${upToID.id}`;
+    await sql`DELETE FROM ${sql(
+      upstreamSchema({
+        appID: this.#config.app.id,
+        shardNum: this.#config.shard.num,
+      }),
+    )}.mutations WHERE "clientGroupID" = ${this.id} AND "clientID" = ${upToID.clientID} AND "mutationID" <= ${upToID.id}`;
   }
 
   ref() {

--- a/packages/zero-cache/src/services/mutagen/pusher.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.ts
@@ -258,7 +258,10 @@ class PushWorker {
       const [pushes, terminate] = combinePushes([task, ...rest]);
       for (const push of pushes) {
         const response = await this.#processPush(push);
-        await this.#fanOutResponses(response);
+        if (push.push.pushVersion !== PUSH_VERSION_ZERO) {
+          await this.#fanOutResponses(response);
+        }
+        // else: response will be sent via poke
       }
 
       if (terminate) {

--- a/packages/zero-cache/src/services/view-syncer/cvr-store.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.ts
@@ -25,7 +25,7 @@ import type {PostgresDB, PostgresTransaction} from '../../types/pg.ts';
 import {rowIDString} from '../../types/row-key.ts';
 import {cvrSchema, type ShardID} from '../../types/shards.ts';
 import type {Patch, PatchToVersion} from './client-handler.ts';
-import type {CVR, CVRSnapshot} from './cvr.ts';
+import {type CVR, type CVRSnapshot} from './cvr.ts';
 import {RowRecordCache} from './row-record-cache.ts';
 import {
   type ClientsRow,
@@ -552,7 +552,6 @@ export class CVRStore {
       write: tx =>
         tx`DELETE FROM ${this.#cvr('clients')} WHERE "clientID" = ${clientID}`,
     });
-    // TODO: delete mutations queries as they are per client.
   }
 
   deleteClientGroup(clientGroupID: string) {

--- a/packages/zero-cache/src/services/view-syncer/cvr-store.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.ts
@@ -552,6 +552,7 @@ export class CVRStore {
       write: tx =>
         tx`DELETE FROM ${this.#cvr('clients')} WHERE "clientID" = ${clientID}`,
     });
+    // TODO: delete mutations queries as they are per client.
   }
 
   deleteClientGroup(clientGroupID: string) {

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -77,7 +77,7 @@ export type CVRSnapshot = {
 };
 
 const CLIENT_LMID_QUERY_ID = 'lmids';
-const CLIENT_MUTATION_RESULTS_QUERY_ID_PREFIX = 'mutationResults_';
+export const CLIENT_MUTATION_RESULTS_QUERY_ID = 'mutationResults';
 
 function assertNotInternal(
   query: QueryRecord,
@@ -163,10 +163,9 @@ export class CVRUpdater {
 export function getMutationResultsQuery(
   upstreamSchema: string,
   clientGroupID: string,
-  clientID: string,
 ): InternalQueryRecord {
   return {
-    id: CLIENT_MUTATION_RESULTS_QUERY_ID_PREFIX + clientID,
+    id: CLIENT_MUTATION_RESULTS_QUERY_ID,
     type: 'internal',
     ast: {
       schema: '',
@@ -184,18 +183,6 @@ export function getMutationResultsQuery(
             right: {
               type: 'literal',
               value: clientGroupID,
-            },
-          },
-          {
-            type: 'simple',
-            left: {
-              type: 'column',
-              name: 'clientID',
-            },
-            op: '=',
-            right: {
-              type: 'literal',
-              value: clientID,
             },
           },
         ],
@@ -262,13 +249,10 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
       this._cvr.queries[CLIENT_LMID_QUERY_ID] = lmidsQuery;
       this._cvrStore.putQuery(lmidsQuery);
     }
-    if (
-      !this._cvr.queries[CLIENT_MUTATION_RESULTS_QUERY_ID_PREFIX + client.id]
-    ) {
+    if (!this._cvr.queries[CLIENT_MUTATION_RESULTS_QUERY_ID]) {
       const mutationResultsQuery = getMutationResultsQuery(
         upstreamSchema(this.#shard),
         this._cvr.id,
-        client.id,
       );
       this._cvr.queries[mutationResultsQuery.id] = mutationResultsQuery;
       this._cvrStore.putQuery(mutationResultsQuery);

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -77,7 +77,7 @@ export type CVRSnapshot = {
 };
 
 const CLIENT_LMID_QUERY_ID = 'lmids';
-const CLIENT_MUTATION_RESULTS_QUERY_ID = 'mutationResults';
+const CLIENT_MUTATION_RESULTS_QUERY_ID_PREFIX = 'mutationResults_';
 
 function assertNotInternal(
   query: QueryRecord,
@@ -166,7 +166,7 @@ export function getMutationResultsQuery(
   clientID: string,
 ): InternalQueryRecord {
   return {
-    id: CLIENT_MUTATION_RESULTS_QUERY_ID,
+    id: CLIENT_MUTATION_RESULTS_QUERY_ID_PREFIX + clientID,
     type: 'internal',
     ast: {
       schema: '',
@@ -261,14 +261,16 @@ export class CVRConfigDrivenUpdater extends CVRUpdater {
       };
       this._cvr.queries[CLIENT_LMID_QUERY_ID] = lmidsQuery;
       this._cvrStore.putQuery(lmidsQuery);
-
+    }
+    if (
+      !this._cvr.queries[CLIENT_MUTATION_RESULTS_QUERY_ID_PREFIX + client.id]
+    ) {
       const mutationResultsQuery = getMutationResultsQuery(
         upstreamSchema(this.#shard),
         this._cvr.id,
         client.id,
       );
-      this._cvr.queries[CLIENT_MUTATION_RESULTS_QUERY_ID] =
-        mutationResultsQuery;
+      this._cvr.queries[mutationResultsQuery.id] = mutationResultsQuery;
       this._cvrStore.putQuery(mutationResultsQuery);
     }
     return client;

--- a/packages/zero-client/src/client/mutation-tracker.test.ts
+++ b/packages/zero-client/src/client/mutation-tracker.test.ts
@@ -560,7 +560,7 @@ describe('MutationTracker', () => {
     ]);
   });
 
-  test('advancing lmid does not resolve mutations that are not in limbo', () => {
+  test('advancing lmid resolves all outstanding mutations less than the lmid', async () => {
     const tracker = new MutationTracker(lc, ackMutations);
     tracker.clientID = CLIENT_ID;
 
@@ -571,12 +571,14 @@ describe('MutationTracker', () => {
     const mutation3 = tracker.trackMutation();
     tracker.mutationIDAssigned(mutation3.ephemeralID, 3);
 
-    tracker.lmidAdvanced(5);
+    tracker.lmidAdvanced(3);
 
-    expect(tracker.size).toBe(3);
+    expect(tracker.size).toBe(0);
 
-    tracker.lmidAdvanced(8);
-
-    expect(tracker.size).toBe(3);
+    await Promise.all([
+      mutation1.serverPromise,
+      mutation2.serverPromise,
+      mutation3.serverPromise,
+    ]);
   });
 });

--- a/packages/zero-client/src/client/mutation-tracker.ts
+++ b/packages/zero-client/src/client/mutation-tracker.ts
@@ -104,7 +104,9 @@ export class MutationTracker {
     try {
       for (const patch of patches) {
         if (patch.mutation.id.clientID !== this.#clientID) {
-          throw new Error('received mutation for the wrong client');
+          // will it be poked to us tho?
+          // maybe not ever if it was poked via another client?
+          continue; // This mutation is not for this client.
         }
 
         // Since we only write responses for failed mutations,

--- a/packages/zero-client/src/client/zero-poke-handler.ts
+++ b/packages/zero-client/src/client/zero-poke-handler.ts
@@ -183,10 +183,12 @@ export class PokeHandler {
         this.#mutationTracker.processMutationResponses(
           merged.mutationResults ?? [],
         );
-        // Newer versions of zero-cache will send down `mutationResults`
-        // Old versions will not.
-        // The line below is for old versions.
-        // It is also a fail-safe if a mutation response is somehow lost.
+
+        // Whenever the `lmid` is moved forward, we also call the `mutationTracker`
+        // to resolve outstanding mutations.
+        // This is because we only write `error` results to the `mutations` table
+        // and not `ok` results. `ok` results are resolved by seeing the `lmid`
+        // advance.
         if (!('error' in merged.pullResponse)) {
           const lmid =
             merged.pullResponse.lastMutationIDChanges[this.#clientID];

--- a/packages/zero-client/src/client/zero-rate.test.ts
+++ b/packages/zero-client/src/client/zero-rate.test.ts
@@ -32,7 +32,7 @@ test('connection stays alive on rate limit error', async () => {
   const pushReq: PushRequest = {
     profileID: 'p1',
     clientGroupID: await z.clientGroupID,
-    pushVersion: 1,
+    pushVersion: 2,
     schemaVersion: '1',
     mutations: [
       {

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -1246,7 +1246,7 @@ test('pusher sends one mutation per push message', async () => {
       const pushReq: PushRequest = {
         profileID: 'p1',
         clientGroupID: clientGroupID ?? (await r.clientGroupID),
-        pushVersion: 1,
+        pushVersion: 2,
         schemaVersion: '1',
         mutations,
       };
@@ -1490,7 +1490,7 @@ test('pusher maps CRUD mutation names', async () => {
       const pushReq: PushRequest = {
         profileID: 'p1',
         clientGroupID: await r.clientGroupID,
-        pushVersion: 1,
+        pushVersion: 2,
         schemaVersion: '1',
         mutations: [
           {
@@ -1592,7 +1592,7 @@ test('pusher adjusts mutation timestamps to be unix timestamps', async () => {
   const pushReq: PushRequest = {
     profileID: 'p1',
     clientGroupID: await r.clientGroupID,
-    pushVersion: 1,
+    pushVersion: 2,
     schemaVersion: '1',
     mutations,
   };
@@ -2205,7 +2205,7 @@ test('pusher waits for connection', async () => {
     const pushReq: PushRequest = {
       profileID: 'p1',
       clientGroupID: await r.clientGroupID,
-      pushVersion: 1,
+      pushVersion: 2,
       schemaVersion: '1',
       mutations: [],
     };
@@ -3489,7 +3489,7 @@ test('custom mutations get pushed', async () => {
             args: [{foo: 42}],
           },
         ],
-        pushVersion: 1,
+        pushVersion: 2,
       },
     ],
     [
@@ -3507,7 +3507,7 @@ test('custom mutations get pushed', async () => {
             args: [{foo: 43}],
           },
         ],
-        pushVersion: 1,
+        pushVersion: 2,
       },
     ],
     [
@@ -3525,7 +3525,7 @@ test('custom mutations get pushed', async () => {
             args: [{foo: 44}],
           },
         ],
-        pushVersion: 1,
+        pushVersion: 2,
       },
     ],
     ['ping', {}],

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -1424,7 +1424,7 @@ export class Zero<
 
   async #pusher(req: PushRequest, requestID: string): Promise<PusherResult> {
     // The deprecation of pushVersion 0 predates zero-client
-    assert(req.pushVersion === 1);
+    assert(req.pushVersion === 2 || req.pushVersion === 1);
     // If we are connecting we wait until we are connected.
     await this.#connectResolver.promise;
     const lc = this.#lc.withContext('requestID', requestID);

--- a/packages/zero-server/src/push-processor.pg-test.ts
+++ b/packages/zero-server/src/push-processor.pg-test.ts
@@ -126,14 +126,8 @@ describe('out of order mutation', () => {
     });
 
     await checkClientsTable(pg, 1);
-    await checkMutationsTable(pg, [
-      {
-        clientGroupID: 'cgid',
-        clientID: 'cid',
-        mutationID: 1n,
-        result: {},
-      },
-    ]);
+    // only error responses are written
+    await checkMutationsTable(pg, []);
   });
 });
 
@@ -159,14 +153,8 @@ test('first mutation', async () => {
   });
 
   await checkClientsTable(pg, 1);
-  await checkMutationsTable(pg, [
-    {
-      clientGroupID: 'cgid',
-      clientID: 'cid',
-      mutationID: 1n,
-      result: {},
-    },
-  ]);
+  // only error responses are written
+  await checkMutationsTable(pg, []);
 });
 
 test('previously seen mutation', async () => {
@@ -199,26 +187,7 @@ test('previously seen mutation', async () => {
   });
 
   await checkClientsTable(pg, 3);
-  await checkMutationsTable(pg, [
-    {
-      clientGroupID: 'cgid',
-      clientID: 'cid',
-      mutationID: 1n,
-      result: {},
-    },
-    {
-      clientGroupID: 'cgid',
-      clientID: 'cid',
-      mutationID: 2n,
-      result: {},
-    },
-    {
-      clientGroupID: 'cgid',
-      clientID: 'cid',
-      mutationID: 3n,
-      result: {},
-    },
-  ]);
+  await checkMutationsTable(pg, []);
 });
 
 test('lmid still moves forward if the mutator implementation throws', async () => {
@@ -253,18 +222,6 @@ test('lmid still moves forward if the mutator implementation throws', async () =
   });
   await checkClientsTable(pg, 3);
   await checkMutationsTable(pg, [
-    {
-      clientGroupID: 'cgid',
-      clientID: 'cid',
-      mutationID: 1n,
-      result: {},
-    },
-    {
-      clientGroupID: 'cgid',
-      clientID: 'cid',
-      mutationID: 2n,
-      result: {},
-    },
     {
       clientGroupID: 'cgid',
       clientID: 'cid',
@@ -377,30 +334,6 @@ test('processes all mutations, even if all mutations have been seen before', asy
     await pg`select "clientGroupID", "clientID", "mutationID", "result" from "zero_0"."mutations" order by "mutationID"`,
   ).toMatchInlineSnapshot(`
     Result [
-      {
-        "clientGroupID": "cgid",
-        "clientID": "cid",
-        "mutationID": 1n,
-        "result": {},
-      },
-      {
-        "clientGroupID": "cgid",
-        "clientID": "cid",
-        "mutationID": 2n,
-        "result": {},
-      },
-      {
-        "clientGroupID": "cgid",
-        "clientID": "cid",
-        "mutationID": 3n,
-        "result": {},
-      },
-      {
-        "clientGroupID": "cgid",
-        "clientID": "cid",
-        "mutationID": 4n,
-        "result": {},
-      },
       {
         "clientGroupID": "cgid",
         "clientID": "cid",
@@ -616,20 +549,7 @@ test('stops processing mutations as soon as it hits an out of order mutation', a
     ],
   });
   await checkClientsTable(pg, 2);
-  await checkMutationsTable(pg, [
-    {
-      clientGroupID: 'cgid',
-      clientID: 'cid',
-      mutationID: 1n,
-      result: {},
-    },
-    {
-      clientGroupID: 'cgid',
-      clientID: 'cid',
-      mutationID: 2n,
-      result: {},
-    },
-  ]);
+  await checkMutationsTable(pg, []);
 });
 
 test('a mutation throws an app error then an ooo mutation error', async () => {
@@ -813,18 +733,6 @@ test('mutators with and without namespaces', async () => {
 
   await checkClientsTable(pg, 4);
   await checkMutationsTable(pg, [
-    {
-      clientGroupID: 'cgid',
-      clientID: 'cid',
-      mutationID: 1n,
-      result: {},
-    },
-    {
-      clientGroupID: 'cgid',
-      clientID: 'cid',
-      mutationID: 2n,
-      result: {},
-    },
     {
       clientGroupID: 'cgid',
       clientID: 'cid',

--- a/packages/zero-server/src/push-processor.pg-test.ts
+++ b/packages/zero-server/src/push-processor.pg-test.ts
@@ -35,7 +35,7 @@ function makePush(
   const mids = Array.isArray(mid) ? mid : [mid];
   const mutatorNames = Array.isArray(mutatorName) ? mutatorName : [mutatorName];
   return {
-    pushVersion: 1,
+    pushVersion: 2,
     clientGroupID: 'cgid',
     requestID: 'rid',
     schemaVersion: 1,

--- a/packages/zero-server/src/push-processor.test.ts
+++ b/packages/zero-server/src/push-processor.test.ts
@@ -9,7 +9,7 @@ import {ZQLDatabase} from './zql-database.ts';
 import type postgres from 'postgres';
 describe('PushProcessor', () => {
   const body = {
-    pushVersion: 1,
+    pushVersion: 2,
     requestID: 'test_request_id',
     timestamp: 1234567890,
     schemaVersion: 1,

--- a/packages/zero-server/src/push-processor.ts
+++ b/packages/zero-server/src/push-processor.ts
@@ -22,6 +22,7 @@ export type Params = v.Infer<typeof pushParamsSchema>;
 
 export interface TransactionProviderHooks {
   updateClientMutationID: () => Promise<{lastMutationID: number | bigint}>;
+  writeMutationResult: (result: MutationResponse) => Promise<void>;
 }
 
 export interface TransactionProviderInput {
@@ -139,7 +140,7 @@ export class PushProcessor<
           params,
           req,
           m,
-          caughtError !== undefined,
+          caughtError,
         );
 
         // The first time through we caught an error.
@@ -204,7 +205,7 @@ export class PushProcessor<
     params: Params,
     req: PushBody,
     m: Mutation,
-    errorMode: boolean,
+    caughtError: unknown,
   ): Promise<MutationResponse> {
     if (m.type === 'crud') {
       throw new Error(
@@ -221,17 +222,30 @@ export class PushProcessor<
           m.id,
         );
 
-        if (!errorMode) {
-          await this.#dispatchMutation(dbTx, mutators, m);
-        }
-
-        return {
+        const result = {
           id: {
             clientID: m.clientID,
             id: m.id,
           },
           result: {},
         };
+
+        // no caught error? Not in error mode.
+        if (caughtError === undefined) {
+          await this.#dispatchMutation(dbTx, mutators, m);
+          await transactionHooks.writeMutationResult({
+            id: {
+              clientID: m.clientID,
+              id: m.id,
+            },
+            result: {},
+          });
+        } else {
+          const appError = makeAppErrorResponse(m, caughtError);
+          await transactionHooks.writeMutationResult(appError);
+        }
+
+        return result;
       },
       {
         upstreamSchema: params.schema,

--- a/packages/zero-server/src/push-processor.ts
+++ b/packages/zero-server/src/push-processor.ts
@@ -235,15 +235,6 @@ export class PushProcessor<
         // no caught error? Not in error mode.
         if (caughtError === undefined) {
           await this.#dispatchMutation(dbTx, mutators, m);
-          if (req.pushVersion >= PUSH_VERSION_ZERO) {
-            await transactionHooks.writeMutationResult({
-              id: {
-                clientID: m.clientID,
-                id: m.id,
-              },
-              result: {},
-            });
-          }
         } else {
           const appError = makeAppErrorResponse(m, caughtError);
           if (req.pushVersion >= PUSH_VERSION_ZERO) {

--- a/packages/zero-server/src/zql-database.pg-test.ts
+++ b/packages/zero-server/src/zql-database.pg-test.ts
@@ -8,10 +8,6 @@ import type {PostgresDB} from '../../zero-cache/src/types/pg.ts';
 import {zeroPostgresJS} from './adapters/postgresjs.ts';
 
 let sql: PostgresDB;
-// let connection: PostgresJSConnection<{
-//   bigint: bigint;
-//   json: JSONValue;
-// }>;
 
 beforeEach(async () => {
   sql = await testDBs.create('zero-pg-web');

--- a/packages/zero-server/src/zql-database.pg-test.ts
+++ b/packages/zero-server/src/zql-database.pg-test.ts
@@ -1,0 +1,86 @@
+import {beforeEach, expect, test} from 'vitest';
+import {testDBs} from '../../zero-cache/src/test/db.ts';
+import {
+  getClientsTableDefinition,
+  getMutationsTableDefinition,
+} from '../../zero-cache/src/services/change-source/pg/schema/shard.ts';
+import type {PostgresDB} from '../../zero-cache/src/types/pg.ts';
+import {zeroPostgresJS} from './adapters/postgresjs.ts';
+
+let sql: PostgresDB;
+// let connection: PostgresJSConnection<{
+//   bigint: bigint;
+//   json: JSONValue;
+// }>;
+
+beforeEach(async () => {
+  sql = await testDBs.create('zero-pg-web');
+  await sql.unsafe(`
+    CREATE SCHEMA IF NOT EXISTS zero_0;
+    ${getClientsTableDefinition('zero_0')}
+    ${getMutationsTableDefinition('zero_0')}
+  `);
+});
+
+test('update client mutation ID', async () => {
+  const db = zeroPostgresJS(
+    {
+      relationships: {},
+      tables: {},
+    },
+    sql,
+  );
+
+  await db.transaction(
+    async (_tx, hooks) => {
+      await hooks.updateClientMutationID();
+    },
+    {
+      upstreamSchema: 'zero_0',
+      clientGroupID: 'cg1',
+      clientID: 'c1',
+      mutationID: 1,
+    },
+  );
+
+  // query for the mid
+  const result =
+    await sql`SELECT "lastMutationID" FROM zero_0.clients WHERE "clientGroupID" = 'cg1' AND "clientID" = 'c1'`;
+
+  // expect the mid to be 1
+  expect(result).toEqual([{lastMutationID: BigInt(1)}]);
+});
+
+test('write mutation result', async () => {
+  const db = zeroPostgresJS(
+    {
+      relationships: {},
+      tables: {},
+    },
+    sql,
+  );
+
+  await db.transaction(
+    async (_tx, hooks) => {
+      await hooks.writeMutationResult({
+        id: {
+          clientID: 'c1',
+          id: 1,
+        },
+        result: {data: {foo: 'bar'}},
+      });
+    },
+    {
+      upstreamSchema: 'zero_0',
+      clientGroupID: 'cg1',
+      clientID: 'c1',
+      mutationID: 1,
+    },
+  );
+
+  // query for the mutation result
+  const result =
+    await sql`SELECT "result" FROM zero_0.mutations WHERE "clientGroupID" = 'cg1' AND "clientID" = 'c1' AND "mutationID" = 1`;
+  // expect the result to match
+  expect(result).toEqual([{result: {data: {foo: 'bar'}}}]);
+});

--- a/packages/zero-server/src/zql-database.ts
+++ b/packages/zero-server/src/zql-database.ts
@@ -89,7 +89,9 @@ export class ZQLDatabase<S extends Schema, WrappedTransaction>
                 )}::text::json)`,
           );
 
+          console.log('Writing mutation result:', formatted);
           await dbTx.query(formatted.text, formatted.values);
+          console.log('done writing mutation result');
         },
       });
     });

--- a/packages/zero-server/src/zql-database.ts
+++ b/packages/zero-server/src/zql-database.ts
@@ -80,6 +80,17 @@ export class ZQLDatabase<S extends Schema, WrappedTransaction>
 
           return {lastMutationID};
         },
+        async writeMutationResult(result) {
+          const formatted = formatPg(
+            sql`INSERT INTO ${sql.ident(transactionInput.upstreamSchema)}.mutations
+                    ("clientGroupID", "clientID", "mutationID", "result")
+                VALUES (${transactionInput.clientGroupID}, ${result.id.clientID}, ${result.id.id}, ${JSON.stringify(
+                  result.result,
+                )}::text::json)`,
+          );
+
+          await dbTx.query(formatted.text, formatted.values);
+        },
       });
     });
   }


### PR DESCRIPTION
- Write error results to the upstream DB
- Resolves client side promises on `poke` of either:
  - error response
  - last mutation id

The mutation responses in a poke are processed first, resolving any mutations with a lmid less than the current mutation as `ok` then the mutation with the same lmid as whatever was present in the poke.

Once all mutation responses in the poke are processed, all remaining mutations <= lmid are resolved as ok.