### PR TITLE
chore(zero): persist mutator responses into replicache

### DIFF
--- a/packages/zero-cache/src/services/mutagen/pusher.test.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.test.ts
@@ -493,7 +493,7 @@ describe('pusher service', () => {
       ok: true,
     });
 
-    const mockDB = vi.fn() as unknown as PostgresDB;
+    const mockDB = vi.fn(x => ({ident: x})) as unknown as PostgresDB;
     const pusher = new PusherService(
       mockDB,
       config,
@@ -514,7 +514,9 @@ describe('pusher service', () => {
 
     await pusher.stop();
 
-    expect(mockDB).toHaveBeenCalledWith(
+    expect(mockDB).toHaveBeenNthCalledWith(1, 'zero_0');
+    expect(mockDB).toHaveBeenNthCalledWith(
+      2,
       [
         'DELETE FROM ',
         '.mutations WHERE "clientGroupID" = ',
@@ -522,7 +524,9 @@ describe('pusher service', () => {
         ' AND "mutationID" <= ',
         '',
       ],
-      'zero_0',
+      {
+        ident: 'zero_0',
+      },
       'cgid',
       'test-client',
       42,

--- a/packages/zero-cache/src/services/mutagen/pusher.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.ts
@@ -127,10 +127,12 @@ export class PusherService implements Service, Pusher {
   async ackMutationResponses(upToID: MutationID) {
     // delete the relevant rows from the `mutations` table
     const sql = this.#upstream;
-    await sql`DELETE FROM ${upstreamSchema({
-      appID: this.#config.app.id,
-      shardNum: this.#config.shard.num,
-    })}.mutations WHERE "clientGroupID" = ${this.id} AND "clientID" = ${upToID.clientID} AND "mutationID" <= ${upToID.id}`;
+    await sql`DELETE FROM ${sql(
+      upstreamSchema({
+        appID: this.#config.app.id,
+        shardNum: this.#config.shard.num,
+      }),
+    )}.mutations WHERE "clientGroupID" = ${this.id} AND "clientID" = ${upToID.clientID} AND "mutationID" <= ${upToID.id}`;
   }
 
   ref() {

--- a/packages/zero-cache/src/services/view-syncer/client-handler.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.test.ts
@@ -586,7 +586,15 @@ describe('view-syncer/client-handler', () => {
           [
             "pokePart",
             {
-              "mutationsPatch": [],
+              "mutationsPatch": [
+                {
+                  "id": {
+                    "clientID": "boo",
+                    "id": 123,
+                  },
+                  "op": "del",
+                },
+              ],
               "pokeID": "123",
             },
           ],

--- a/packages/zero-cache/src/services/view-syncer/client-handler.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.ts
@@ -1,5 +1,5 @@
 import type {LogContext} from '@rocicorp/logger';
-import {unreachable} from '../../../../shared/src/asserts.ts';
+import {assert, unreachable} from '../../../../shared/src/asserts.ts';
 import type {JSONObject} from '../../../../shared/src/bigint-json.ts';
 import {
   assertJSONValue,
@@ -278,7 +278,16 @@ export class ClientHandler {
                 },
               });
             } else {
-              // no need to deal with `del` as the mutation results are ephemeral on the client.
+              const {clientID, mutationID} = patch.id.rowKey;
+              assert(typeof clientID === 'string');
+              assert(typeof mutationID === 'bigint');
+              patches.push({
+                op: 'del',
+                id: {
+                  clientID,
+                  id: Number(mutationID),
+                },
+              });
             }
           } else {
             (body.rowsPatch ??= []).push(makeRowPatch(patch));

--- a/packages/zero-client/src/client/keys.test.ts
+++ b/packages/zero-client/src/client/keys.test.ts
@@ -4,7 +4,10 @@ import type {
   PrimaryKey,
   PrimaryKeyValueRecord,
 } from '../../../zero-protocol/src/primary-key.ts';
-import {toPrimaryKeyString as toPrimaryKeyStringImpl} from './keys.ts';
+import {
+  toPrimaryKeyString as toPrimaryKeyStringImpl,
+  toMutationResponseKey,
+} from './keys.ts';
 
 test('toPrimaryKeyString', () => {
   function toPrimaryKeyString(
@@ -148,4 +151,25 @@ test('no clashes - multiple pk', () => {
       },
     ),
   );
+});
+
+test('toMutationResponseKey', () => {
+  expect(
+    toMutationResponseKey({
+      clientID: 'cid',
+      id: 1,
+    }),
+  ).toBe('m/cid/1');
+  expect(
+    toMutationResponseKey({
+      clientID: 'cid',
+      id: 2,
+    }),
+  ).toBe('m/cid/2');
+  expect(
+    toMutationResponseKey({
+      clientID: 'cid2',
+      id: 1,
+    }),
+  ).toBe('m/cid2/1');
 });

--- a/packages/zero-client/src/client/keys.ts
+++ b/packages/zero-client/src/client/keys.ts
@@ -3,10 +3,12 @@ import * as v from '../../../shared/src/valita.ts';
 import type {CompoundKey} from '../../../zero-protocol/src/ast.ts';
 import type {Row} from '../../../zero-protocol/src/data.ts';
 import {primaryKeyValueSchema} from '../../../zero-protocol/src/primary-key.ts';
+import type {MutationID} from '../../../zero-protocol/src/push.ts';
 
 export const DESIRED_QUERIES_KEY_PREFIX = 'd/';
 export const GOT_QUERIES_KEY_PREFIX = 'g/';
 export const ENTITIES_KEY_PREFIX = 'e/';
+export const MUTATIONS_KEY_PREFIX = 'm/';
 
 export function toDesiredQueriesKey(clientID: string, hash: string): string {
   return DESIRED_QUERIES_KEY_PREFIX + clientID + '/' + hash;
@@ -18,6 +20,10 @@ export function desiredQueriesPrefixForClient(clientID: string): string {
 
 export function toGotQueriesKey(hash: string): string {
   return GOT_QUERIES_KEY_PREFIX + hash;
+}
+
+export function toMutationResponseKey(mid: MutationID): string {
+  return MUTATIONS_KEY_PREFIX + mid.clientID + '/' + mid.id;
 }
 
 export function toPrimaryKeyString(

--- a/packages/zero-client/src/client/mutation-tracker.test.ts
+++ b/packages/zero-client/src/client/mutation-tracker.test.ts
@@ -7,17 +7,24 @@ import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import type {WriteTransaction} from './replicache-types.ts';
 import {zeroData} from '../../../replicache/src/transactions.ts';
 import type {MutationPatch} from '../../../zero-protocol/src/mutations-patch.ts';
+import type {
+  DiffOperation,
+  NoIndexDiff,
+} from '../../../replicache/src/btree/node.ts';
+import {toMutationResponseKey} from './keys.ts';
+import {unreachable} from '../../../shared/src/asserts.ts';
 
 const lc = createSilentLogContext();
 
 const ackMutations = () => {};
+const watch = () => () => {};
 
 describe('MutationTracker', () => {
   const CLIENT_ID = 'test-client-1';
 
   test('tracks a mutation and resolves on success', async () => {
     const tracker = new MutationTracker(lc, ackMutations);
-    tracker.clientID = CLIENT_ID;
+    tracker.setClientIDAndWatch(CLIENT_ID, watch);
     const {ephemeralID, serverPromise} = tracker.trackMutation();
     tracker.mutationIDAssigned(ephemeralID, 1);
 
@@ -37,7 +44,7 @@ describe('MutationTracker', () => {
 
   test('tracks a mutation and resolves with error on error', async () => {
     const tracker = new MutationTracker(lc, ackMutations);
-    tracker.clientID = CLIENT_ID;
+    tracker.setClientIDAndWatch(CLIENT_ID, watch);
     const {serverPromise, ephemeralID} = tracker.trackMutation();
     tracker.mutationIDAssigned(ephemeralID, 1);
 
@@ -62,7 +69,7 @@ describe('MutationTracker', () => {
 
   test('does not resolve mutators for transient errors', async () => {
     const tracker = new MutationTracker(lc, ackMutations);
-    tracker.clientID = CLIENT_ID;
+    tracker.setClientIDAndWatch(CLIENT_ID, watch);
     const {ephemeralID, serverPromise} = tracker.trackMutation();
     tracker.mutationIDAssigned(ephemeralID, 1);
 
@@ -83,7 +90,7 @@ describe('MutationTracker', () => {
 
   test('rejects mutations from other clients', () => {
     const tracker = new MutationTracker(lc, ackMutations);
-    tracker.clientID = CLIENT_ID;
+    tracker.setClientIDAndWatch(CLIENT_ID, watch);
     const mutation = tracker.trackMutation();
     tracker.mutationIDAssigned(mutation.ephemeralID, 1);
 
@@ -110,7 +117,7 @@ describe('MutationTracker', () => {
 
   test('handles multiple concurrent mutations', async () => {
     const tracker = new MutationTracker(lc, ackMutations);
-    tracker.clientID = CLIENT_ID;
+    tracker.setClientIDAndWatch(CLIENT_ID, watch);
     const mutation1 = tracker.trackMutation();
     const mutation2 = tracker.trackMutation();
 
@@ -144,7 +151,7 @@ describe('MutationTracker', () => {
 
   test('mutation tracker size goes down each time a mutation is resolved or rejected', () => {
     const tracker = new MutationTracker(lc, ackMutations);
-    tracker.clientID = CLIENT_ID;
+    tracker.setClientIDAndWatch(CLIENT_ID, watch);
     const mutation1 = tracker.trackMutation();
     tracker.mutationIDAssigned(mutation1.ephemeralID, 1);
 
@@ -176,7 +183,7 @@ describe('MutationTracker', () => {
 
   test('mutations are not tracked on rebase', async () => {
     const mt = new MutationTracker(lc, ackMutations);
-    mt.clientID = CLIENT_ID;
+    mt.setClientIDAndWatch(CLIENT_ID, watch);
     const mutator = makeReplicacheMutator(
       createSilentLogContext(),
       async () => {},
@@ -196,10 +203,37 @@ describe('MutationTracker', () => {
     expect(mt.size).toBe(0);
   });
 
+  function mutationPatchToDiffOp(p: MutationPatch): DiffOperation<string> {
+    switch (p.op) {
+      case 'put':
+        return {
+          op: 'add',
+          key: toMutationResponseKey(p.mutation.id),
+          newValue: p.mutation.result,
+        };
+      case 'del':
+        return {
+          op: 'del',
+          key: toMutationResponseKey(p.id),
+          oldValue: null, // fine for tests
+        };
+      default:
+        unreachable();
+    }
+  }
+
   test('mutation responses, received via poke, are processed', async () => {
     const ackMutations = vi.fn();
+
+    let cb: ((diffs: NoIndexDiff) => void) | undefined;
+    const watch = (wcb: (diffs: NoIndexDiff) => void) => {
+      cb = wcb;
+      return () => {
+        cb = undefined;
+      };
+    };
     const tracker = new MutationTracker(lc, ackMutations);
-    tracker.clientID = CLIENT_ID;
+    tracker.setClientIDAndWatch(CLIENT_ID, watch);
 
     const mutation1 = tracker.trackMutation();
     tracker.mutationIDAssigned(mutation1.ephemeralID, 1);
@@ -223,19 +257,26 @@ describe('MutationTracker', () => {
       },
     ];
 
-    tracker.processMutationResponses(patches);
-    expect(ackMutations).toHaveBeenCalledOnce();
-    expect(ackMutations).toHaveBeenCalledWith({clientID: CLIENT_ID, id: 2});
+    // process mutations
+    cb!(patches.map(p => mutationPatchToDiffOp(p)));
 
     await expect(mutation1.serverPromise).resolves.toEqual({});
     await expect(mutation2.serverPromise).rejects.toEqual({
       error: 'app',
     });
+
+    tracker.lmidAdvanced(2);
+
+    expect(ackMutations).toHaveBeenCalledOnce();
+    expect(ackMutations).toHaveBeenCalledWith({
+      clientID: CLIENT_ID,
+      id: 2,
+    });
   });
 
   test('tracked mutations are resolved on reconnect', async () => {
     const tracker = new MutationTracker(lc, ackMutations);
-    tracker.clientID = CLIENT_ID;
+    tracker.setClientIDAndWatch(CLIENT_ID, watch);
 
     const mutation1 = tracker.trackMutation();
     tracker.mutationIDAssigned(mutation1.ephemeralID, 1);
@@ -265,7 +306,7 @@ describe('MutationTracker', () => {
 
   test('notified whenever the outstanding mutation count goes to 0', () => {
     const tracker = new MutationTracker(lc, ackMutations);
-    tracker.clientID = CLIENT_ID;
+    tracker.setClientIDAndWatch(CLIENT_ID, watch);
 
     let callCount = 0;
     tracker.onAllMutationsApplied(() => {
@@ -361,7 +402,7 @@ describe('MutationTracker', () => {
 
   test('mutations can be rejected before a mutation id is assigned', async () => {
     const tracker = new MutationTracker(lc, ackMutations);
-    tracker.clientID = CLIENT_ID;
+    tracker.setClientIDAndWatch(CLIENT_ID, watch);
 
     const {ephemeralID, serverPromise} = tracker.trackMutation();
     tracker.rejectMutation(ephemeralID, new Error('test error'));
@@ -379,7 +420,7 @@ describe('MutationTracker', () => {
 
   test('trying to resolve a mutation with an a unassigned ephemeral id throws', () => {
     const tracker = new MutationTracker(lc, ackMutations);
-    tracker.clientID = CLIENT_ID;
+    tracker.setClientIDAndWatch(CLIENT_ID, watch);
 
     tracker.trackMutation();
     const response: PushResponse = {
@@ -397,7 +438,7 @@ describe('MutationTracker', () => {
 
   test('resolve a mutation a second time with "already processed" error', () => {
     const tracker = new MutationTracker(lc, ackMutations);
-    tracker.clientID = CLIENT_ID;
+    tracker.setClientIDAndWatch(CLIENT_ID, watch);
 
     const {ephemeralID} = tracker.trackMutation();
     tracker.mutationIDAssigned(ephemeralID, 1);
@@ -447,7 +488,7 @@ describe('MutationTracker', () => {
 
   test('advancing lmid past outstanding lmid notifies "all mutations applied" listeners', () => {
     const tracker = new MutationTracker(lc, ackMutations);
-    tracker.clientID = CLIENT_ID;
+    tracker.setClientIDAndWatch(CLIENT_ID, watch);
 
     const listener = vi.fn();
     tracker.onAllMutationsApplied(listener);
@@ -469,7 +510,7 @@ describe('MutationTracker', () => {
 
   test('advancing lmid clears limbo mutations up to that lmid', async () => {
     const tracker = new MutationTracker(lc, ackMutations);
-    tracker.clientID = CLIENT_ID;
+    tracker.setClientIDAndWatch(CLIENT_ID, watch);
 
     const mutation1 = tracker.trackMutation();
     tracker.mutationIDAssigned(mutation1.ephemeralID, 1);
@@ -507,7 +548,7 @@ describe('MutationTracker', () => {
 
   test('failed push causes mutations to resolve that are under the current lmid', async () => {
     const tracker = new MutationTracker(lc, ackMutations);
-    tracker.clientID = CLIENT_ID;
+    tracker.setClientIDAndWatch(CLIENT_ID, watch);
 
     const mutation1 = tracker.trackMutation();
     tracker.mutationIDAssigned(mutation1.ephemeralID, 1);
@@ -540,7 +581,7 @@ describe('MutationTracker', () => {
 
   test('reconnecting puts outstanding mutations in limbo', async () => {
     const tracker = new MutationTracker(lc, ackMutations);
-    tracker.clientID = CLIENT_ID;
+    tracker.setClientIDAndWatch(CLIENT_ID, watch);
 
     const mutation1 = tracker.trackMutation();
     tracker.mutationIDAssigned(mutation1.ephemeralID, 3);
@@ -562,7 +603,7 @@ describe('MutationTracker', () => {
 
   test('advancing lmid does not resolve mutations that are not in limbo', () => {
     const tracker = new MutationTracker(lc, ackMutations);
-    tracker.clientID = CLIENT_ID;
+    tracker.setClientIDAndWatch(CLIENT_ID, watch);
 
     const mutation1 = tracker.trackMutation();
     tracker.mutationIDAssigned(mutation1.ephemeralID, 1);

--- a/packages/zero-client/src/client/mutation-tracker.test.ts
+++ b/packages/zero-client/src/client/mutation-tracker.test.ts
@@ -601,7 +601,7 @@ describe('MutationTracker', () => {
     ]);
   });
 
-  test('advancing lmid does not resolve mutations that are not in limbo', () => {
+  test('advancing lmid does resolve all mutations before that lmid', () => {
     const tracker = new MutationTracker(lc, ackMutations);
     tracker.setClientIDAndWatch(CLIENT_ID, watch);
 
@@ -614,10 +614,6 @@ describe('MutationTracker', () => {
 
     tracker.lmidAdvanced(5);
 
-    expect(tracker.size).toBe(3);
-
-    tracker.lmidAdvanced(8);
-
-    expect(tracker.size).toBe(3);
+    expect(tracker.size).toBe(0);
   });
 });

--- a/packages/zero-client/src/client/mutation-tracker.ts
+++ b/packages/zero-client/src/client/mutation-tracker.ts
@@ -27,13 +27,6 @@ type ErrorType =
   | Error
   | unknown;
 
-const completeFailureTypes: PushError['error'][] = [
-  // These should never actually be received as they cause the websocket
-  // connection to be closed.
-  'unsupportedPushVersion',
-  'unsupportedSchemaVersion',
-];
-
 let currentEphemeralID = 0;
 function nextEphemeralID(): EphemeralID {
   return ++currentEphemeralID as EphemeralID;
@@ -53,12 +46,7 @@ export class MutationTracker {
   readonly #ephemeralIDsByMutationID: Map<number, EphemeralID>;
   readonly #allMutationsAppliedListeners: Set<() => void>;
   readonly #lc: ZeroLogContext;
-  readonly #limboMutations: Set<EphemeralID>;
 
-  // This is only used in the new code path that processes
-  // mutation responses that arrive via the `poke` protocol.
-  // The old code path will be removed in the release after
-  // the one containing mutation-responses-via-poke.
   readonly #ackMutations: (upTo: MutationID) => void;
   #clientID: string | undefined;
   #largestOutstandingMutationID: number;
@@ -69,7 +57,6 @@ export class MutationTracker {
     this.#outstandingMutations = new Map();
     this.#ephemeralIDsByMutationID = new Map();
     this.#allMutationsAppliedListeners = new Set();
-    this.#limboMutations = new Set();
     this.#largestOutstandingMutationID = 0;
     this.#currentMutationID = 0;
     this.#ackMutations = ackMutations;
@@ -130,6 +117,7 @@ export class MutationTracker {
    */
   #processMutationResponses(diffs: NoIndexDiff): void {
     const clientID = must(this.#clientID);
+    let largestLmid = 0;
     for (const diff of diffs) {
       const mutationID = Number(
         diff.key.slice(MUTATIONS_KEY_PREFIX.length + clientID.length + 1),
@@ -138,6 +126,7 @@ export class MutationTracker {
         !isNaN(mutationID),
         `MutationTracker received a diff with an invalid mutation ID: ${diff.key}`,
       );
+      largestLmid = Math.max(largestLmid, mutationID);
       switch (diff.op) {
         case 'add': {
           const result = v.parse(diff.newValue, mutationResultSchema);
@@ -154,6 +143,13 @@ export class MutationTracker {
           throw new Error('MutationTracker does not expect change operations');
       }
     }
+
+    if (largestLmid > 0) {
+      this.#ackMutations({
+        clientID: must(this.#clientID),
+        id: largestLmid,
+      });
+    }
   }
 
   processPushResponse(response: PushResponse): void {
@@ -162,13 +158,15 @@ export class MutationTracker {
         'Received an error response when pushing mutations',
         response,
       );
-      this.#processPushError(response);
     } else {
       this.#processPushOk(response);
     }
   }
 
   /**
+   * DEPRECATED: to be removed when we switch to fully driving
+   * mutation resolution via poke.
+   *
    * When we reconnect to zero-cache, we resolve all outstanding mutations
    * whose ID is less than or equal to the lastMutationID.
    *
@@ -201,16 +199,6 @@ export class MutationTracker {
       }
     }
 
-    for (const [id, entry] of this.#outstandingMutations) {
-      if (entry.mutationID && entry.mutationID > lastMutationID) {
-        // We don't know the state of these mutations.
-        // They could have been applied by the server
-        // or not since we sent them before the connection was lost.
-        // Adding to `limbo` will cause them to be resolved
-        // when the next lmid bump is received.
-        this.#limboMutations.add(id);
-      }
-    }
     this.lmidAdvanced(lastMutationID);
   }
 
@@ -218,26 +206,8 @@ export class MutationTracker {
    * lmid advance will:
    * 1. notify "allMutationsApplied" listeners if the lastMutationID
    *    is greater than or equal to the largest outstanding mutation ID.
-   * 2. resolve all limbo mutations whose mutation ID is less than or equal to
+   * 2. resolve all mutations whose mutation ID is less than or equal to
    *    the lastMutationID.
-   *
-   * We only resolve "limbo mutations" since we want to give the mutation
-   * responses a chance to be received. `poke` and `pushResponse` are non transactional
-   * so they race.
-   *
-   * E.g., a `push` may call the api server which:
-   * writes to PG, replicates to zero-cache, then pokes the lmid down before the
-   * push response is sent.
-   *
-   * The only fix for this would be to have mutation responses be written to the database
-   * and sent down through the poke protocol.
-   *
-   * The artifact the user sees is that promise resolutions for mutations is not transactional
-   * with the update to synced data.
-   *
-   * It was a mistake to not just write the mutation responses to the database
-   * in the first place as this route ends up being more complicated
-   * and less reliable.
    */
   lmidAdvanced(lastMutationID: number): void {
     assert(
@@ -250,11 +220,7 @@ export class MutationTracker {
 
     try {
       this.#currentMutationID = lastMutationID;
-      this.#resolveLimboMutations(lastMutationID);
-      this.#ackMutations({
-        clientID: must(this.#clientID),
-        id: lastMutationID,
-      });
+      this.#resolveMutations(lastMutationID);
     } finally {
       if (lastMutationID >= this.#largestOutstandingMutationID) {
         // this is very important otherwise we hang query de-registration
@@ -267,66 +233,14 @@ export class MutationTracker {
     return this.#outstandingMutations.size;
   }
 
-  /**
-   * Push errors fall into two categories:
-   * - Those where we know the mutations were not applied
-   * - Those where we do not know the state of the mutations.
-   *
-   * The first category includes errors like "unsupportedPushVersion"
-   * and "unsupportedSchemaVersion". The mutations were never applied in those cases.
-   *
-   * The second category includes errors like "http" errors. E.g., a 500 on the user's
-   * API server or a network error.
-   *
-   * The mutations may have been applied by the API server but we never
-   * received the response.
-   *
-   * In this latter case, we must mark the mutations as being in limbo.
-   * This allows us to resolve them when we receive the next
-   * lmid bump if their lmids are lesser.
-   */
-  #processPushError(error: PushError): void {
-    if (completeFailureTypes.includes(error.error)) {
-      return;
-    }
-
-    const mids = error.mutationIDs;
-    // TODO: remove this check once the server always sends mutationIDs
-    if (!mids) {
-      return;
-    }
-
-    // If the push request failed then we do not know the state of the mutations that were
-    // included in that request.
-    // Maybe they were applied. Whatever happened, we've lost the response.
-    // Given that, we mark them as "in limbo."
-    for (const mid of mids) {
-      const ephemeralID = this.#ephemeralIDsByMutationID.get(mid.id);
-      if (ephemeralID) {
-        // if the lmid has already moved past the mutations we can settle them.
-        if (mid.id <= this.#currentMutationID) {
-          const entry = this.#outstandingMutations.get(ephemeralID);
-          if (entry) {
-            this.#settleMutation(ephemeralID, entry, 'resolve', emptyObject);
-          }
-          continue;
-        }
-        // otherwise put in limbo and wait for next lmid bump
-        this.#limboMutations.add(ephemeralID);
-      }
-    }
-  }
-
-  #resolveLimboMutations(lastMutationID: number): void {
-    for (const id of this.#limboMutations) {
-      const entry = this.#outstandingMutations.get(id);
-      if (!entry || !entry.mutationID) {
-        this.#limboMutations.delete(id);
-        continue;
-      }
-      if (entry.mutationID <= lastMutationID) {
-        this.#limboMutations.delete(id);
+  #resolveMutations(upTo: number): void {
+    // We resolve all mutations whose mutation ID is less than or equal to
+    // the upTo mutation ID.
+    for (const [id, entry] of this.#outstandingMutations) {
+      if (entry.mutationID && entry.mutationID <= upTo) {
         this.#settleMutation(id, entry, 'resolve', emptyObject);
+      } else {
+        break; // the map is in insertion order which is in mutation ID order
       }
     }
   }
@@ -424,7 +338,6 @@ export class MutationTracker {
     if (entry.mutationID) {
       this.#ephemeralIDsByMutationID.delete(entry.mutationID);
     }
-    this.#limboMutations.delete(ephemeralID);
   }
 
   /**

--- a/packages/zero-client/src/client/query-manager.test.ts
+++ b/packages/zero-client/src/client/query-manager.test.ts
@@ -1694,6 +1694,7 @@ describe('query manager & mutator interaction', () => {
   beforeEach(() => {
     send = vi.fn<(msg: ChangeDesiredQueriesMessage) => void>();
     mutationTracker = new MutationTracker(lc, ackMutations);
+    mutationTracker.setClientIDAndWatch('cid', () => () => {});
     queryManager = new QueryManager(
       lc,
       mutationTracker,

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -602,7 +602,10 @@ export class Zero<
     this.#server = server;
     this.userID = userID;
     this.#lc = lc.withContext('clientID', rep.clientID);
-    this.#mutationTracker.clientID = rep.clientID;
+    this.#mutationTracker.setClientIDAndWatch(
+      rep.clientID,
+      rep.experimentalWatch.bind(rep),
+    );
 
     this.#activeClientsManager = makeActiveClientsManager(
       rep.clientGroupID,

--- a/packages/zero-protocol/src/ast.test.ts
+++ b/packages/zero-protocol/src/ast.test.ts
@@ -607,5 +607,5 @@ test('protocol version', () => {
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
   expect(hash).toEqual('1c228prd1v53r');
-  expect(PROTOCOL_VERSION).toEqual(24);
+  expect(PROTOCOL_VERSION).toEqual(25);
 });

--- a/packages/zero-protocol/src/mutations-patch.ts
+++ b/packages/zero-protocol/src/mutations-patch.ts
@@ -1,5 +1,5 @@
 import * as v from '../../shared/src/valita.ts';
-import {mutationResponseSchema} from './push.ts';
+import {mutationIDSchema, mutationResponseSchema} from './push.ts';
 
 /**
  * Mutation results are stored ephemerally in the client
@@ -12,7 +12,11 @@ export const putOpSchema = v.object({
   op: v.literal('put'),
   mutation: mutationResponseSchema,
 });
+export const delOpSchema = v.object({
+  op: v.literal('del'),
+  id: mutationIDSchema,
+});
 
-const patchOpSchema = putOpSchema;
+const patchOpSchema = v.union(putOpSchema, delOpSchema);
 export const mutationsPatchSchema = v.array(patchOpSchema);
 export type MutationPatch = v.Infer<typeof patchOpSchema>;

--- a/packages/zero-protocol/src/protocol-version.test.ts
+++ b/packages/zero-protocol/src/protocol-version.test.ts
@@ -11,6 +11,6 @@ test('protocol version', () => {
   // If this test fails upstream or downstream schema has changed such that
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
-  expect(hash).toEqual('39mik5bjlwfjr');
-  expect(PROTOCOL_VERSION).toEqual(24);
+  expect(hash).toEqual('3pblce4hlmptt');
+  expect(PROTOCOL_VERSION).toEqual(25);
 });

--- a/packages/zero-protocol/src/protocol-version.ts
+++ b/packages/zero-protocol/src/protocol-version.ts
@@ -29,8 +29,9 @@ import {assert} from '../../shared/src/asserts.ts';
 // -- Version 21 removes `AST` in downstream query puts which was deprecated in Version 17, removes support for versions < 18 (0.22)
 // -- Version 22 adds an optional 'userQueryParams' field to `initConnection` (0.22)
 // -- Version 23 add `mutationResults` to poke (0.22)
-// -- Version 24 adds `ackMutationResults` to poke (0.22).
-export const PROTOCOL_VERSION = 24;
+// -- Version 24 adds `ackMutationResults` to upstream (0.22).
+// -- version 25 modifies `mutationsResults` to include `del` patches (0.22)
+export const PROTOCOL_VERSION = 25;
 
 /**
  * The minimum server-supported sync protocol version (i.e. the version


### PR DESCRIPTION
We need to persist mutator responses since:

1. Two clients can connect
2. Client A disconnects
3. Client B syncs Client A's mutations
4. Server pokes down results
5. Client B syncs to IBD
6. Client A refreshes from IDB
7. Client A comes online
8. Client A will not receive pokes for its mutations since they were already synced for the client group

Client A can only get its response if the mutation results are persisted to replicache.