### PR TITLE
chore(zero): fix exports of adapters

### DIFF
--- a/packages/zero/package.json
+++ b/packages/zero/package.json
@@ -115,11 +115,11 @@
     },
     "./server/adapters/postgresjs": {
       "types": "./out/zero-server/src/adapters/postgres.d.ts",
-      "default": "./out/zero-server/src/adapters/postgresjs.js"
+      "default": "./out/zero/src/adapters/postgresjs.js"
     },
     "./server/adapters/drizzle-pg": {
       "types": "./out/zero-server/src/adapters/drizzle-pg.d.ts",
-      "default": "./out/zero-server/src/adapters/drizzle-pg.js"
+      "default": "./out/zero/src/adapters/drizzle-pg.js"
     },
     "./solid": {
       "types": "./out/zero-solid/src/mod.d.ts",

--- a/packages/zero/src/adapters/drizzle-pg.ts
+++ b/packages/zero/src/adapters/drizzle-pg.ts
@@ -1,0 +1,1 @@
+export * from '../../../zero-server/src/adapters/drizzle-pg.ts';

--- a/packages/zero/src/adapters/postgresjs.ts
+++ b/packages/zero/src/adapters/postgresjs.ts
@@ -1,0 +1,1 @@
+export * from '../../../zero-server/src/adapters/postgresjs.ts';

--- a/packages/zero/tsconfig.server.json
+++ b/packages/zero/tsconfig.server.json
@@ -6,6 +6,7 @@
   "include": [
     "src/server/*.ts",
     "src/server.ts",
+    "src/adapters/*.ts",
     "src/cli.ts",
     "src/build-schema.ts",
     "src/zero-cache-dev.ts",


### PR DESCRIPTION
drizzle adapter was not being built into the final zero package.