### PR TITLE
chore(mutators): workaround for custom upstream

### DIFF
--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -96,7 +96,7 @@ export default function runWorker(
       config.taskID,
       id,
       cvrDB,
-      upstreamDB,
+      config.upstream.type === 'pg' ? upstreamDB : undefined,
       new PipelineDriver(
         logger,
         config.log,

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -244,7 +244,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     taskID: string,
     clientGroupID: string,
     cvrDb: PostgresDB,
-    upstreamDb: PostgresDB,
+    upstreamDb: PostgresDB | undefined,
     pipelineDriver: PipelineDriver,
     versionChanges: Subscription<ReplicaState>,
     drainCoordinator: DrainCoordinator,


### PR DESCRIPTION
The `zero_0.mutations` table is written by the API server in the mutator's transaction, with the exception of cleanup. Cleanup of mutations that the client has acknowledged receiving is done by zero-cache.

This is a problem since if the upstream is custom we cannot delete mutation results from it.

This PR is a temporary workaround to not break users with custom upstreams.

Alternatives:
1. Send a message to the API server when a mutation is acked, client is deleted or client group is deleted. 
2. Add more to the custom upstream interface and poke that. 
3. Have the API server clean the table on some interval given zero is not expected to run for prolonged periods offline.