### PR TITLE
chore(zero-cache): update custom change source test with new required tables

### DIFF
--- a/packages/zero-cache/src/services/change-source/custom/change-source.test.ts
+++ b/packages/zero-cache/src/services/change-source/custom/change-source.test.ts
@@ -137,6 +137,40 @@ describe('change-source/custom', () => {
         {
           tag: 'create-table',
           spec: {
+            schema: 'bongo_0',
+            name: 'mutations',
+            primaryKey: ['clientGroupID', 'clientID', 'mutationID'],
+            columns: {
+              clientGroupID: {pos: 0, dataType: 'text', notNull: true},
+              clientID: {pos: 1, dataType: 'text', notNull: true},
+              mutationID: {pos: 2, dataType: 'bigint', notNull: true},
+              mutation: {pos: 3, dataType: 'json'},
+            },
+          },
+        },
+      ],
+      [
+        'data',
+        {
+          tag: 'create-index',
+          spec: {
+            name: 'bongo_mutations_key',
+            schema: 'bongo_0',
+            tableName: 'mutations',
+            columns: {
+              clientGroupID: 'ASC',
+              clientID: 'ASC',
+              mutationID: 'ASC',
+            },
+            unique: true,
+          },
+        },
+      ],
+      [
+        'data',
+        {
+          tag: 'create-table',
+          spec: {
             schema: 'bongo',
             name: 'schemaVersions',
             primaryKey: ['lock'],

--- a/packages/zero-cache/src/services/change-source/custom/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/custom/change-source.ts
@@ -1,12 +1,12 @@
 import {LogContext} from '@rocicorp/logger';
 import {WebSocket} from 'ws';
 import {assert, unreachable} from '../../../../../shared/src/asserts.ts';
+import {stringify} from '../../../../../shared/src/bigint-json.ts';
 import {deepEqual} from '../../../../../shared/src/json.ts';
 import type {SchemaValue} from '../../../../../zero-schema/src/table-schema.ts';
 import {Database} from '../../../../../zqlite/src/db.ts';
 import {computeZqlSpecs} from '../../../db/lite-tables.ts';
 import {StatementRunner} from '../../../db/statements.ts';
-import {stringify} from '../../../../../shared/src/bigint-json.ts';
 import type {ShardConfig, ShardID} from '../../../types/shards.ts';
 import {stream} from '../../../types/streams.ts';
 import type {
@@ -220,6 +220,12 @@ function getRequiredTables({
       clientID: {type: 'string'},
       lastMutationID: {type: 'number'},
       userID: {type: 'string'},
+    },
+    [`${appID}_${shardNum}.mutations`]: {
+      clientGroupID: {type: 'string'},
+      clientID: {type: 'string'},
+      mutationID: {type: 'number'},
+      mutation: {type: 'json'},
     },
     [`${appID}.permissions`]: {
       permissions: {type: 'json'},


### PR DESCRIPTION
Updates the custom change-source test to document / reflect the new tables expected of custom upstreams, starting from: https://github.com/rocicorp/mono/pull/4650

Context: https://discord.com/channels/830183651022471199/1399802770223005857/1399805526748954694

@cbnsndwch 
@DAlperin 