### PR TITLE
fix(zero-cache): workaround the COPY hang bug in Windows

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
@@ -148,8 +148,8 @@ export async function initialSync(
     }
     const numWorkers =
       platform() === 'win32'
-        ? Math.max(tableCopyWorkers, numTables)
-        : tableCopyWorkers;
+        ? numTables
+        : Math.min(tableCopyWorkers, numTables);
 
     const copyPool = pgClient(
       lc,


### PR DESCRIPTION
The COPY hang bug that is fixed in Node v22+ for Linux/MacOS is still present in the latest version of Node on Windows.

User report: https://discord.com/channels/830183651022471199/1400629013105475634/1401009565931147267

Work around this for `win32` only, by running running enough copy workers (i.e. connections) for each table to have its own connection, and avoiding waiting for connections to close.