### PR TITLE
chore(zero-cache): fix otel duplicate registration errors

### DIFF
--- a/packages/zero-cache/src/server/otel-start.ts
+++ b/packages/zero-cache/src/server/otel-start.ts
@@ -1,6 +1,6 @@
 import {diag} from '@opentelemetry/api';
 import {logs} from '@opentelemetry/api-logs';
-import * as autoInstrumentationsModule from '@opentelemetry/auto-instrumentations-node';
+import {getNodeAutoInstrumentations} from '@opentelemetry/auto-instrumentations-node';
 import type {Instrumentation} from '@opentelemetry/instrumentation';
 import {resourceFromAttributes} from '@opentelemetry/resources';
 import {NodeSDK} from '@opentelemetry/sdk-node';
@@ -56,8 +56,7 @@ class OtelManager {
     // Lazy load the auto-instrumentations module
     // avoid MODULE_NOT_FOUND errors in environments where it's not being used
     if (!this.#autoInstrumentations) {
-      this.#autoInstrumentations =
-        autoInstrumentationsModule.getNodeAutoInstrumentations();
+      this.#autoInstrumentations = getNodeAutoInstrumentations();
     }
     // Set defaults to be backwards compatible with the previously
     // hard-coded exporters

--- a/packages/zero/Dockerfile
+++ b/packages/zero/Dockerfile
@@ -44,10 +44,7 @@ ENV ZERO_LITESTREAM_CONFIG_PATH=/etc/litestream.yml
 ENV ZERO_LOG_FORMAT=json
 ENV ZERO_SERVER_VERSION=${ZERO_VERSION}
 ENV ZERO_IN_CONTAINER=1
-# Install OpenTelemetry instrumentation
-ENV NODE_PATH=/usr/local/lib/node_modules
-RUN npm install -g @opentelemetry/auto-instrumentations-node
 
 EXPOSE 4848 4849
 ENTRYPOINT ["/bin/sh", "-c"]
-CMD ["NODE_OPTIONS='--require=@opentelemetry/auto-instrumentations-node/register' npx zero-cache"]
+CMD ["npx zero-cache"]

--- a/packages/zero/src/zero-cache-dev.ts
+++ b/packages/zero/src/zero-cache-dev.ts
@@ -119,12 +119,6 @@ async function main() {
         // But let the developer override any of these dev defaults.
         ...process.env,
       };
-      if (process.env.OTEL_EXPORTER_OTLP_ENDPOINT) {
-        lc.info?.('Starting OpenTelemetry auto instrumentation.');
-        env['NODE_OPTIONS'] =
-          (env['NODE_OPTIONS'] || '') +
-          ' --require @opentelemetry/auto-instrumentations-node/register';
-      }
       zeroCacheProcess = spawn(zeroCacheScript, zeroCacheArgs || [], {
         env,
         stdio: 'inherit',


### PR DESCRIPTION
The [fix to surface otel diagnostic messages](https://github.com/rocicorp/mono/pull/4670) to the Logger revealed existing errors of the form:

```
Error: @opentelemetry/api: Attempted duplicate registration of API: {trace,context,propagation}
```

<img width="1013" height="468" alt="Screenshot 2025-08-02 at 15 25 09" src="https://github.com/user-attachments/assets/5923b3b9-da10-499d-987d-a2bd2261c89e" />

This is due to the duplicate registration of the otel libraries:
* first by`--require=@opentelemetry/auto-instrumentations-node/register`
* then explicitly in [`otel-start.ts`](https://github.com/rocicorp/mono/blob/a1a46d6c0b793ad21978cf3360d2dcea9a418bc1/packages/zero-cache/src/server/otel-start.ts#L71) 

Remove the former and rely on the latter, which affords additional options such as setting the `service.version` attribute.