### PR TITLE
feat(zero): `mutators` api to match `queries` api [1/n]

### DIFF
--- a/packages/zql/src/mutate/custom.test.ts
+++ b/packages/zql/src/mutate/custom.test.ts
@@ -1,0 +1,44 @@
+import {expectTypeOf, test} from 'vitest';
+import {mutators, type Transaction} from './custom.ts';
+import type {Schema} from '../query/test/test-schemas.ts';
+
+// Check the type gymnastics of the mutators function
+test('mutators function', async () => {
+  const m = mutators({
+    exampleMutator: async (
+      _tx: Transaction<Schema>,
+      _id: string,
+      _name: string,
+    ) => {},
+    otherMutator: async (
+      _tx: Transaction<Schema>,
+      _id: string,
+      _value: number,
+    ) => {},
+  });
+
+  const fakeTx = {} as Transaction<Schema>;
+  await m.exampleMutator(fakeTx, '1', 'example');
+  await m.otherMutator(fakeTx, '1', 42);
+
+  // @ts-expect-error - should not allow non-existent mutators
+  // to be called
+  m.foo();
+
+  // `Schema` name is used rather than the unrolled `Schema` type.
+  // This should prevent type depth issues.
+  // vs. the old z.mutate where the entire Schema type is expanded
+  // for each mutator.
+  expectTypeOf(m).toEqualTypeOf<{
+    exampleMutator: (
+      _tx: Transaction<Schema>,
+      _id: string,
+      _name: string,
+    ) => Promise<void>;
+    otherMutator: (
+      _tx: Transaction<Schema>,
+      _id: string,
+      _value: number,
+    ) => Promise<void>;
+  }>();
+});

--- a/packages/zql/src/query/named.ts
+++ b/packages/zql/src/query/named.ts
@@ -77,6 +77,31 @@ function contextualizedNamedQuery<TContext>(
   return ret;
 }
 
+/**
+ * Define queries. You can place as many or as few queries
+ * in a call to this function as desired. E.g.,
+ *
+ * ```ts
+ * const allQueries = queries({
+ *   q1: ...,
+ *   q2: ...,
+ *   q3: ...,
+ *   ...,
+ * });
+ *
+ * // or
+ *
+ * const q1 = queries({
+ *   q1: ...
+ * });
+ * const q2 = queries({
+ *  q2: ...
+ * });
+ * ```
+ *
+ * The idea being that you can split queries across files
+ * if desired.
+ */
 export function queries<
   TQueries extends {
     [K in keyof TQueries]: TQueries[K] extends NamedQuery<

--- a/packages/zql/src/query/test/test-schemas.ts
+++ b/packages/zql/src/query/test/test-schemas.ts
@@ -164,6 +164,7 @@ export const schemaOptions = {
 };
 
 export const schema = createSchema(schemaOptions);
+export type Schema = typeof schema;
 
 export const issueSchema = schema.tables.issue;
 export const commentSchema = schema.tables.comment;


### PR DESCRIPTION
custom queries are defined like:

```ts
const q = queries({ name: fn, name: fn, ... });
```

add function to allow mutators to be defined the same way:

```ts
const m = mutators({ name: fn, name: fn, ... });
```

This PR defines the base `mutators` function.

Next PR:

- Allow using mutators defined in this way on the client