### PR TITLE
feat(zero): drop `schema` from `tx` type

### DIFF
--- a/apps/zbugs/shared/mutators.ts
+++ b/apps/zbugs/shared/mutators.ts
@@ -1,6 +1,6 @@
 import {schema} from './schema.ts';
 import {assert} from '../../../packages/shared/src/asserts.ts';
-import type {UpdateValue, Transaction, CustomMutatorDefs} from '@rocicorp/zero';
+import type {UpdateValue, Transaction} from '@rocicorp/zero';
 import {
   assertIsCreatorOrAdmin,
   assertUserCanSeeIssue,
@@ -34,12 +34,13 @@ export type AddCommentArgs = {
 };
 
 export type NotificationType = 'subscribe' | 'unsubscribe';
+export type MutatorTx = Transaction<typeof schema>;
 
 export function createMutators(authData: AuthData | undefined) {
   return {
     issue: {
       async create(
-        tx,
+        tx: MutatorTx,
         {id, title, description, created, modified}: CreateIssueArgs,
       ) {
         assertIsLoggedIn(authData);
@@ -65,7 +66,7 @@ export function createMutators(authData: AuthData | undefined) {
       },
 
       async update(
-        tx,
+        tx: MutatorTx,
         change: UpdateValue<typeof schema.tables.issue> & {modified: number},
       ) {
         const oldIssue = await tx.query.issue.where('id', change.id).one();
@@ -102,13 +103,13 @@ export function createMutators(authData: AuthData | undefined) {
         }
       },
 
-      async delete(tx, id: string) {
+      async delete(tx: MutatorTx, id: string) {
         await assertIsCreatorOrAdmin(authData, tx.query.issue, id);
         await tx.mutate.issue.delete({id});
       },
 
       async addLabel(
-        tx,
+        tx: MutatorTx,
         {issueID, labelID}: {issueID: string; labelID: string},
       ) {
         await assertIsCreatorOrAdmin(authData, tx.query.issue, issueID);
@@ -116,7 +117,7 @@ export function createMutators(authData: AuthData | undefined) {
       },
 
       async removeLabel(
-        tx,
+        tx: MutatorTx,
         {issueID, labelID}: {issueID: string; labelID: string},
       ) {
         await assertIsCreatorOrAdmin(authData, tx.query.issue, issueID);
@@ -126,7 +127,7 @@ export function createMutators(authData: AuthData | undefined) {
 
     notification: {
       async update(
-        tx,
+        tx: MutatorTx,
         {
           issueID,
           subscribed,
@@ -146,22 +147,22 @@ export function createMutators(authData: AuthData | undefined) {
     },
 
     emoji: {
-      async addToIssue(tx, args: AddEmojiArgs) {
+      async addToIssue(tx: MutatorTx, args: AddEmojiArgs) {
         await addEmoji(tx, 'issue', args);
       },
 
-      async addToComment(tx, args: AddEmojiArgs) {
+      async addToComment(tx: MutatorTx, args: AddEmojiArgs) {
         await addEmoji(tx, 'comment', args);
       },
 
-      async remove(tx, id: string) {
+      async remove(tx: MutatorTx, id: string) {
         await assertIsCreatorOrAdmin(authData, tx.query.emoji, id);
         await tx.mutate.emoji.delete({id});
       },
     },
 
     comment: {
-      async add(tx, {id, issueID, body, created}: AddCommentArgs) {
+      async add(tx: MutatorTx, {id, issueID, body, created}: AddCommentArgs) {
         assertIsLoggedIn(authData);
         const creatorID = authData.sub;
 
@@ -177,25 +178,25 @@ export function createMutators(authData: AuthData | undefined) {
         });
       },
 
-      async edit(tx, {id, body}: {id: string; body: string}) {
+      async edit(tx: MutatorTx, {id, body}: {id: string; body: string}) {
         await assertIsCreatorOrAdmin(authData, tx.query.comment, id);
         await tx.mutate.comment.update({id, body});
       },
 
-      async remove(tx, id: string) {
+      async remove(tx: MutatorTx, id: string) {
         await assertIsCreatorOrAdmin(authData, tx.query.comment, id);
         await tx.mutate.comment.delete({id});
       },
     },
 
     label: {
-      async create(tx, {id, name}: {id: string; name: string}) {
+      async create(tx: MutatorTx, {id, name}: {id: string; name: string}) {
         assert(isAdmin(authData), 'Only admins can create labels');
         await tx.mutate.label.insert({id, name});
       },
 
       async createAndAddToIssue(
-        tx,
+        tx: MutatorTx,
         {
           issueID,
           labelID,
@@ -209,7 +210,10 @@ export function createMutators(authData: AuthData | undefined) {
     },
 
     viewState: {
-      async set(tx, {issueID, viewed}: {issueID: string; viewed: number}) {
+      async set(
+        tx: MutatorTx,
+        {issueID, viewed}: {issueID: string; viewed: number},
+      ) {
         assertIsLoggedIn(authData);
         const userID = authData.sub;
         await tx.mutate.viewState.upsert({issueID, userID, viewed});
@@ -217,13 +221,13 @@ export function createMutators(authData: AuthData | undefined) {
     },
 
     userPref: {
-      async set(tx, {key, value}: {key: string; value: string}) {
+      async set(tx: MutatorTx, {key, value}: {key: string; value: string}) {
         assertIsLoggedIn(authData);
         const userID = authData.sub;
         await tx.mutate.userPref.upsert({key, value, userID});
       },
     },
-  } as const satisfies CustomMutatorDefs<typeof schema>;
+  } as const;
 
   async function addEmoji(
     tx: Transaction<typeof schema, unknown>,

--- a/packages/zero-client/src/client/custom.ts
+++ b/packages/zero-client/src/client/custom.ts
@@ -32,15 +32,14 @@ import type {ZeroLogContext} from './zero-log-context.ts';
 /**
  * The shape which a user's custom mutator definitions must conform to.
  */
-export type CustomMutatorDefs<
-  S extends Schema,
-  TWrappedTransaction = unknown,
-> = {
+export type CustomMutatorDefs = {
   [namespaceOrKey: string]:
     | {
-        [key: string]: CustomMutatorImpl<S, TWrappedTransaction>;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        [key: string]: CustomMutatorImpl<any>;
       }
-    | CustomMutatorImpl<S, TWrappedTransaction>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    | CustomMutatorImpl<any>;
 };
 
 export type MutatorResult = {
@@ -69,8 +68,7 @@ export type CustomMutatorImpl<
  */
 export type MakeCustomMutatorInterfaces<
   S extends Schema,
-  MD extends CustomMutatorDefs<S, TWrappedTransaction>,
-  TWrappedTransaction = unknown,
+  MD extends CustomMutatorDefs,
 > = {
   readonly [NamespaceOrName in keyof MD]: MD[NamespaceOrName] extends (
     tx: Transaction<S>,

--- a/packages/zero-client/src/client/options.ts
+++ b/packages/zero-client/src/client/options.ts
@@ -16,8 +16,7 @@ import {UpdateNeededReasonType} from './update-needed-reason-type.ts';
  */
 export interface ZeroOptions<
   S extends Schema,
-  MD extends CustomMutatorDefs<S, TWrappedTransaction> | undefined = undefined,
-  TWrappedTransaction = unknown,
+  MD extends CustomMutatorDefs | undefined = undefined,
 > {
   /**
    * URL to the zero-cache. This can be a simple hostname, e.g.
@@ -258,9 +257,8 @@ export interface ZeroOptions<
  */
 export interface ZeroAdvancedOptions<
   S extends Schema,
-  MD extends CustomMutatorDefs<S, TWrappedTransaction> | undefined = undefined,
-  TWrappedTransaction = unknown,
-> extends ZeroOptions<S, MD, TWrappedTransaction> {}
+  MD extends CustomMutatorDefs | undefined = undefined,
+> extends ZeroOptions<S, MD> {}
 
 export type UpdateNeededReason =
   | {type: UpdateNeededReasonType.NewClientGroup}

--- a/packages/zero-client/src/client/test-utils.ts
+++ b/packages/zero-client/src/client/test-utils.ts
@@ -82,9 +82,8 @@ export class MockSocket extends EventTarget {
 
 export class TestZero<
   const S extends Schema,
-  MD extends CustomMutatorDefs<S, TWrappedTransaction> | undefined = undefined,
-  TWrappedTransaction = unknown,
-> extends Zero<S, MD, TWrappedTransaction> {
+  MD extends CustomMutatorDefs | undefined = undefined,
+> extends Zero<S, MD> {
   pokeIDCounter = 0;
 
   #connectionStateResolvers: Set<{
@@ -92,7 +91,7 @@ export class TestZero<
     resolve: (state: ConnectionState) => void;
   }> = new Set();
 
-  constructor(options: ZeroOptions<S, MD, TWrappedTransaction>) {
+  constructor(options: ZeroOptions<S, MD>) {
     super(options);
   }
 
@@ -279,12 +278,11 @@ let testZeroCounter = 0;
 
 export function zeroForTest<
   const S extends Schema,
-  MD extends CustomMutatorDefs<S, TWrappedTransaction> | undefined = undefined,
-  TWrappedTransaction = unknown,
+  MD extends CustomMutatorDefs | undefined = undefined,
 >(
-  options: Partial<ZeroOptions<S, MD, TWrappedTransaction>> = {},
+  options: Partial<ZeroOptions<S, MD>> = {},
   errorOnUpdateNeeded = true,
-): TestZero<S, MD, TWrappedTransaction> {
+): TestZero<S, MD> {
   // Special case kvStore. If not present we default to 'mem'. This allows
   // passing `undefined` to get the default behavior.
   const newOptions = {...options};
@@ -306,7 +304,7 @@ export function zeroForTest<
         }
       : undefined,
     ...newOptions,
-  } satisfies ZeroOptions<S, MD, TWrappedTransaction>);
+  } satisfies ZeroOptions<S, MD>);
 }
 
 export async function waitForUpstreamMessage(

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -43,6 +43,7 @@ import {
   table,
 } from '../../../zero-schema/src/builder/table-builder.ts';
 import {refCountSymbol} from '../../../zql/src/ivm/view-apply-change.ts';
+import type {Transaction} from '../../../zql/src/mutate/custom.ts';
 import {nanoid} from '../util/nanoid.ts';
 import * as ConnectionState from './connection-state-enum.ts';
 import type {CustomMutatorDefs} from './custom.ts';
@@ -920,7 +921,7 @@ describe('initConnection', () => {
 
   async function zeroForTestWithDeletedClients<
     const S extends Schema,
-    MD extends CustomMutatorDefs<S> = CustomMutatorDefs<S>,
+    MD extends CustomMutatorDefs = CustomMutatorDefs,
   >(
     options: Partial<ZeroOptions<S, MD>> & {
       deletedClients?: ClientID[] | undefined;
@@ -2797,10 +2798,10 @@ describe('Mutation responses poked down', () => {
       schema,
       mutators: {
         issues: {
-          foo: (tx, {foo}: {foo: number}) =>
+          foo: (tx: Transaction<typeof schema>, {foo}: {foo: number}) =>
             tx.mutate.issues.insert({id: foo.toString(), value: foo}),
         },
-      } as const satisfies CustomMutatorDefs<typeof schema>,
+      } as const,
     });
     await r.triggerConnected();
     expect(r.connectionState).toBe(ConnectionState.Connected);
@@ -3590,10 +3591,10 @@ test('custom mutations get pushed', async () => {
     schema,
     mutators: {
       issues: {
-        foo: (tx, {foo}: {foo: number}) =>
+        foo: (tx: Transaction<typeof schema>, {foo}: {foo: number}) =>
           tx.mutate.issues.insert({id: foo.toString(), value: foo}),
       },
-    } as const satisfies CustomMutatorDefs<typeof schema>,
+    } as const,
   });
   await z.triggerConnected();
   const mockSocket = await z.socket;

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -181,11 +181,9 @@ interface TestZero {
   }) => LogOptions;
 }
 
-function asTestZero<
-  S extends Schema,
-  MD extends CustomMutatorDefs<S, TWrappedTransaction> | undefined,
-  TWrappedTransaction = unknown,
->(z: Zero<S, MD, TWrappedTransaction>): TestZero {
+function asTestZero<S extends Schema, MD extends CustomMutatorDefs | undefined>(
+  z: Zero<S, MD>,
+): TestZero {
   return z as TestZero;
 }
 
@@ -282,8 +280,7 @@ type CloseCode = typeof CLOSE_CODE_NORMAL | typeof CLOSE_CODE_GOING_AWAY;
 
 export class Zero<
   const S extends Schema,
-  MD extends CustomMutatorDefs<S, TWrappedTransaction> | undefined = undefined,
-  TWrappedTransaction = unknown,
+  MD extends CustomMutatorDefs | undefined = undefined,
 > {
   readonly version = version;
 
@@ -401,7 +398,7 @@ export class Zero<
   // 2. client successfully connects
   #totalToConnectStart: number | undefined = undefined;
 
-  readonly #options: ZeroOptions<S, MD, TWrappedTransaction>;
+  readonly #options: ZeroOptions<S, MD>;
 
   readonly query: MakeEntityQueriesFromSchema<S>;
 
@@ -416,7 +413,7 @@ export class Zero<
   /**
    * Constructs a new Zero client.
    */
-  constructor(options: ZeroOptions<S, MD, TWrappedTransaction>) {
+  constructor(options: ZeroOptions<S, MD>) {
     const {
       userID,
       storageKey,
@@ -428,7 +425,7 @@ export class Zero<
       batchViewUpdates = applyViewUpdates => applyViewUpdates(),
       maxRecentQueries = 0,
       slowMaterializeThreshold = 5_000,
-    } = options as ZeroOptions<S, MD, TWrappedTransaction>;
+    } = options as ZeroOptions<S, MD>;
     if (!userID) {
       throw new Error('ZeroOptions.userID must not be empty.');
     }
@@ -438,7 +435,7 @@ export class Zero<
       false /*options.enableAnalytics,*/, // Reenable analytics
     );
 
-    let {kvStore = 'idb'} = options as ZeroOptions<S, MD, TWrappedTransaction>;
+    let {kvStore = 'idb'} = options as ZeroOptions<S, MD>;
     if (kvStore === 'idb') {
       if (!getBrowserGlobal('indexedDB')) {
         // eslint-disable-next-line no-console
@@ -862,11 +859,8 @@ export class Zero<
    * await zero.mutate.issue.update({id: '1', title: 'Updated title'});
    * ```
    */
-  readonly mutate: MD extends CustomMutatorDefs<S, TWrappedTransaction>
-    ? DeepMerge<
-        DBMutator<S>,
-        MakeCustomMutatorInterfaces<S, MD, TWrappedTransaction>
-      >
+  readonly mutate: MD extends CustomMutatorDefs
+    ? DeepMerge<DBMutator<S>, MakeCustomMutatorInterfaces<S, MD>>
     : DBMutator<S>;
 
   /**

--- a/packages/zero-react/src/components/inspector.tsx
+++ b/packages/zero-react/src/components/inspector.tsx
@@ -5,7 +5,7 @@ import {MarkIcon} from './mark-icon.tsx';
 
 export default function Inspector<
   S extends Schema,
-  MD extends CustomMutatorDefs<S> | undefined = undefined,
+  MD extends CustomMutatorDefs | undefined = undefined,
 >({zero, onClose}: {zero: Zero<S, MD>; onClose: () => void}) {
   return (
     <dialog

--- a/packages/zero-react/src/components/zero-inspector.tsx
+++ b/packages/zero-react/src/components/zero-inspector.tsx
@@ -9,7 +9,7 @@ const Inspector = lazy(() => import('./inspector.tsx'));
 
 export function ZeroInspector<
   S extends Schema,
-  MD extends CustomMutatorDefs<S> | undefined = undefined,
+  MD extends CustomMutatorDefs | undefined = undefined,
 >({zero}: {zero: Zero<S, MD>}): JSX.Element {
   const [show, setShow] = useState(false);
   return show ? (

--- a/packages/zero-react/src/zero-provider.tsx
+++ b/packages/zero-react/src/zero-provider.tsx
@@ -15,7 +15,7 @@ const ZeroContext = createContext<unknown | undefined>(undefined);
 
 export function useZero<
   S extends Schema,
-  MD extends CustomMutatorDefs<S> | undefined = undefined,
+  MD extends CustomMutatorDefs | undefined = undefined,
 >(): Zero<S, MD> {
   const zero = useContext(ZeroContext);
   if (zero === undefined) {
@@ -26,14 +26,14 @@ export function useZero<
 
 export function createUseZero<
   S extends Schema,
-  MD extends CustomMutatorDefs<S> | undefined = undefined,
+  MD extends CustomMutatorDefs | undefined = undefined,
 >() {
   return () => useZero<S, MD>();
 }
 
 export type ZeroProviderProps<
   S extends Schema,
-  MD extends CustomMutatorDefs<S> | undefined = undefined,
+  MD extends CustomMutatorDefs | undefined = undefined,
 > = (ZeroOptions<S, MD> | {zero: Zero<S, MD>}) & {
   init?: (zero: Zero<S, MD>) => void;
   children: ReactNode;
@@ -41,7 +41,7 @@ export type ZeroProviderProps<
 
 export function ZeroProvider<
   S extends Schema,
-  MD extends CustomMutatorDefs<S> | undefined = undefined,
+  MD extends CustomMutatorDefs | undefined = undefined,
 >({children, init, ...props}: ZeroProviderProps<S, MD>) {
   const [zero, setZero] = useState<Zero<S, MD> | undefined>(
     'zero' in props ? props.zero : undefined,

--- a/packages/zero-solid/src/use-zero.ts
+++ b/packages/zero-solid/src/use-zero.ts
@@ -20,7 +20,7 @@ const ZeroContext = createContext<Accessor<Zero<any, any>> | undefined>(
   undefined,
 );
 
-export function createZero<S extends Schema, MD extends CustomMutatorDefs<S>>(
+export function createZero<S extends Schema, MD extends CustomMutatorDefs>(
   options: ZeroOptions<S, MD>,
 ): Zero<S, MD> {
   const opts = {
@@ -32,7 +32,7 @@ export function createZero<S extends Schema, MD extends CustomMutatorDefs<S>>(
 
 export function useZero<
   S extends Schema,
-  MD extends CustomMutatorDefs<S> | undefined = undefined,
+  MD extends CustomMutatorDefs | undefined = undefined,
 >(): () => Zero<S, MD> {
   const zero = useContext(ZeroContext);
 
@@ -44,14 +44,14 @@ export function useZero<
 
 export function createUseZero<
   S extends Schema,
-  MD extends CustomMutatorDefs<S> | undefined = undefined,
+  MD extends CustomMutatorDefs | undefined = undefined,
 >() {
   return () => useZero<S, MD>();
 }
 
 export function ZeroProvider<
   S extends Schema,
-  MD extends CustomMutatorDefs<S> | undefined = undefined,
+  MD extends CustomMutatorDefs | undefined = undefined,
 >(
   props: {children: JSX.Element} & (
     | {


### PR DESCRIPTION
resurrects https://github.com/rocicorp/mono/pull/4449 to solve type depth issues.

users must now explicitly type their `Transaction` argument in their mutator definitions.