### PR TITLE
fix(zero-client): Large connection headers should not throw

### DIFF
--- a/packages/zero-protocol/src/connect.test.ts
+++ b/packages/zero-protocol/src/connect.test.ts
@@ -1,6 +1,10 @@
 import fc from 'fast-check';
 import {expect, test} from 'vitest';
-import {decodeSecProtocols, encodeSecProtocols} from './connect.ts';
+import {
+  decodeSecProtocols,
+  encodeSecProtocols,
+  type InitConnectionMessage,
+} from './connect.ts';
 
 test('encode/decodeSecProtocols round-trip', () => {
   fc.assert(
@@ -66,4 +70,16 @@ test('encode/decodeSecProtocols round-trip', () => {
       },
     ),
   );
+});
+
+test('encodeSecProtocol with too much data', () => {
+  // Creates a string that is too large for String.fromCharCode. This is different in different browsers.
+  const largeString = Array.from({length: 2 ** 20}, () => '\u{0}').join('');
+  const initConnectionMessage: InitConnectionMessage = [
+    'initConnection',
+    {desiredQueriesPatch: [{op: 'del', hash: largeString}]},
+  ];
+  expect(() =>
+    encodeSecProtocols(initConnectionMessage, 'authToken'),
+  ).not.toThrow();
 });

--- a/packages/zero-protocol/src/connect.ts
+++ b/packages/zero-protocol/src/connect.ts
@@ -71,7 +71,7 @@ export type InitConnectionMessage = v.Infer<typeof initConnectionMessageSchema>;
 export function encodeSecProtocols(
   initConnectionMessage: InitConnectionMessage | undefined,
   authToken: string | undefined,
-) {
+): string {
   const protocols = {
     initConnectionMessage,
     authToken,
@@ -81,7 +81,12 @@ export function encodeSecProtocols(
   // arbitrary unicode strings, so we need to encode the JSON as UTF-8 first.
   // Phew!
   const bytes = new TextEncoder().encode(JSON.stringify(protocols));
-  return encodeURIComponent(btoa(String.fromCharCode(...bytes)));
+
+  // Convert bytes to string without spreading all bytes as arguments
+  // to avoid "Maximum call stack size exceeded" error with large data
+  const s = Array.from(bytes, byte => String.fromCharCode(byte)).join('');
+
+  return encodeURIComponent(btoa(s));
 }
 
 export function decodeSecProtocols(secProtocol: string): {


### PR DESCRIPTION
We were using `String.fromCharCode(...s)` which throws on large strings.

However, it is very unlikely that Zero will work correctly if the auth token is this large (64k or something like that) since Web Socket Sec Protocol header is usually limited to 8/16KB.
