### PR TITLE
chore(zero-cache): fix view-syncer-inspect test

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/view-syncer-inspect.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer-inspect.pg-test.ts
@@ -58,7 +58,7 @@ describe('view-syncer/service', () => {
       viewSyncerDone,
       replicator,
       connectWithQueueAndSource,
-    } = await setup('view_syncer_service_test', permissionsAll));
+    } = await setup('view_syncer_inspect_test', permissionsAll));
   });
 
   afterEach(async () => {


### PR DESCRIPTION
Test db's need a unique name.

<img width="625" height="125" alt="Screenshot 2025-08-15 at 20 31 31" src="https://github.com/user-attachments/assets/7493a199-003f-4f34-ad6c-d8d02aea4cfb" />
