### PR TITLE
feat(zero-cache): garbage collection of inactive CVRs

### DIFF
--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -27,390 +27,396 @@ test('zero-cache --help', () => {
   expect(logger.info).toHaveBeenCalled();
   expect(stripAnsi(logger.info.mock.calls[0][0])).toMatchInlineSnapshot(`
     "
-     --upstream-db string                                        required                                                                                          
-       ZERO_UPSTREAM_DB env                                                                                                                                        
-                                                                 The "upstream" authoritative postgres database.                                                   
-                                                                 In the future we will support other types of upstream besides PG.                                 
-                                                                                                                                                                   
-     --upstream-max-conns number                                 default: 20                                                                                       
-       ZERO_UPSTREAM_MAX_CONNS env                                                                                                                                 
-                                                                 The maximum number of connections to open to the upstream database                                
-                                                                 for committing mutations. This is divided evenly amongst sync workers.                            
-                                                                 In addition to this number, zero-cache uses one connection for the                                
-                                                                 replication stream.                                                                               
-                                                                                                                                                                   
-                                                                 Note that this number must allow for at least one connection per                                  
-                                                                 sync worker, or zero-cache will fail to start. See num-sync-workers                               
-                                                                                                                                                                   
-     --push-url string[]                                         optional                                                                                          
-       ZERO_PUSH_URL env                                                                                                                                           
-                                                                 DEPRECATED. Use mutate-url instead.                                                               
-                                                                 The URL of the API server to which zero-cache will push mutations.                                
-                                                                                                                                                                   
-                                                                 * is allowed if you would like to allow the client to specify a subdomain to use.                 
-                                                                 e.g., *.example.com/api/mutate                                                                    
-                                                                 You can specify multiple URLs as well which the client can choose from.                           
-                                                                 e.g., ["https://api1.example.com/mutate", "https://api2.example.com/mutate"]                      
-                                                                                                                                                                   
-     --push-api-key string                                       optional                                                                                          
-       ZERO_PUSH_API_KEY env                                                                                                                                       
-                                                                 An optional secret used to authorize zero-cache to call the API server handling writes.           
-                                                                                                                                                                   
-     --push-forward-cookies boolean                              default: false                                                                                    
-       ZERO_PUSH_FORWARD_COOKIES env                                                                                                                               
-                                                                 If true, zero-cache will forward cookies from the request.                                        
-                                                                 This is useful for passing authentication cookies to the API server.                              
-                                                                 If false, cookies are not forwarded.                                                              
-                                                                                                                                                                   
-     --mutate-url string[]                                       optional                                                                                          
-       ZERO_MUTATE_URL env                                                                                                                                         
-                                                                                                                                                                   
-                                                                 The URL of the API server to which zero-cache will push mutations.                                
-                                                                                                                                                                   
-                                                                 * is allowed if you would like to allow the client to specify a subdomain to use.                 
-                                                                 e.g., *.example.com/api/mutate                                                                    
-                                                                 You can specify multiple URLs as well which the client can choose from.                           
-                                                                 e.g., ["https://api1.example.com/mutate", "https://api2.example.com/mutate"]                      
-                                                                                                                                                                   
-     --mutate-api-key string                                     optional                                                                                          
-       ZERO_MUTATE_API_KEY env                                                                                                                                     
-                                                                 An optional secret used to authorize zero-cache to call the API server handling writes.           
-                                                                                                                                                                   
-     --mutate-forward-cookies boolean                            default: false                                                                                    
-       ZERO_MUTATE_FORWARD_COOKIES env                                                                                                                             
-                                                                 If true, zero-cache will forward cookies from the request.                                        
-                                                                 This is useful for passing authentication cookies to the API server.                              
-                                                                 If false, cookies are not forwarded.                                                              
-                                                                                                                                                                   
-     --query-url string[]                                        optional                                                                                          
-       ZERO_QUERY_URL env                                                                                                                                          
-                                                                                                                                                                   
-                                                                 The URL of the API server to which zero-cache will send named queries.                            
-                                                                                                                                                                   
-                                                                 * is allowed if you would like to allow the client to specify a subdomain to use.                 
-                                                                 e.g., *.example.com/api/mutate                                                                    
-                                                                 You can specify multiple URLs as well which the client can choose from.                           
-                                                                 e.g., ["https://api1.example.com/mutate", "https://api2.example.com/mutate"]                      
-                                                                                                                                                                   
-     --query-api-key string                                      optional                                                                                          
-       ZERO_QUERY_API_KEY env                                                                                                                                      
-                                                                 An optional secret used to authorize zero-cache to call the API server handling writes.           
-                                                                                                                                                                   
-     --query-forward-cookies boolean                             default: false                                                                                    
-       ZERO_QUERY_FORWARD_COOKIES env                                                                                                                              
-                                                                 If true, zero-cache will forward cookies from the request.                                        
-                                                                 This is useful for passing authentication cookies to the API server.                              
-                                                                 If false, cookies are not forwarded.                                                              
-                                                                                                                                                                   
-     --cvr-db string                                             optional                                                                                          
-       ZERO_CVR_DB env                                                                                                                                             
-                                                                 The Postgres database used to store CVRs. CVRs (client view records) keep track                   
-                                                                 of the data synced to clients in order to determine the diff to send on reconnect.                
-                                                                 If unspecified, the upstream-db will be used.                                                     
-                                                                                                                                                                   
-     --cvr-max-conns number                                      default: 30                                                                                       
-       ZERO_CVR_MAX_CONNS env                                                                                                                                      
-                                                                 The maximum number of connections to open to the CVR database.                                    
-                                                                 This is divided evenly amongst sync workers.                                                      
-                                                                                                                                                                   
-                                                                 Note that this number must allow for at least one connection per                                  
-                                                                 sync worker, or zero-cache will fail to start. See num-sync-workers                               
-                                                                                                                                                                   
-     --query-hydration-stats boolean                             optional                                                                                          
-       ZERO_QUERY_HYDRATION_STATS env                                                                                                                              
-                                                                 Track and log the number of rows considered by query hydrations which                             
-                                                                 take longer than log-slow-hydrate-threshold milliseconds.                                         
-                                                                 This is useful for debugging and performance tuning.                                              
-                                                                                                                                                                   
-     --change-db string                                          optional                                                                                          
-       ZERO_CHANGE_DB env                                                                                                                                          
-                                                                 The Postgres database used to store recent replication log entries, in order                      
-                                                                 to sync multiple view-syncers without requiring multiple replication slots on                     
-                                                                 the upstream database. If unspecified, the upstream-db will be used.                              
-                                                                                                                                                                   
-     --change-max-conns number                                   default: 5                                                                                        
-       ZERO_CHANGE_MAX_CONNS env                                                                                                                                   
-                                                                 The maximum number of connections to open to the change database.                                 
-                                                                 This is used by the change-streamer for catching up                                               
-                                                                 zero-cache replication subscriptions.                                                             
-                                                                                                                                                                   
-     --replica-file string                                       required                                                                                          
-       ZERO_REPLICA_FILE env                                                                                                                                       
-                                                                 File path to the SQLite replica that zero-cache maintains.                                        
-                                                                 This can be lost, but if it is, zero-cache will have to re-replicate next                         
-                                                                 time it starts up.                                                                                
-                                                                                                                                                                   
-     --replica-vacuum-interval-hours number                      optional                                                                                          
-       ZERO_REPLICA_VACUUM_INTERVAL_HOURS env                                                                                                                      
-                                                                 Performs a VACUUM at server startup if the specified number of hours has elapsed                  
-                                                                 since the last VACUUM (or initial-sync). The VACUUM operation is heavyweight                      
-                                                                 and requires double the size of the db in disk space. If unspecified, VACUUM                      
-                                                                 operations are not performed.                                                                     
-                                                                                                                                                                   
-     --log-level debug,info,warn,error                           default: "info"                                                                                   
-       ZERO_LOG_LEVEL env                                                                                                                                          
-                                                                                                                                                                   
-     --log-format text,json                                      default: "text"                                                                                   
-       ZERO_LOG_FORMAT env                                                                                                                                         
-                                                                 Use text for developer-friendly console logging                                                   
-                                                                 and json for consumption by structured-logging services                                           
-                                                                                                                                                                   
-     --log-slow-row-threshold number                             default: 2                                                                                        
-       ZERO_LOG_SLOW_ROW_THRESHOLD env                                                                                                                             
-                                                                 The number of ms a row must take to fetch from table-source before it is considered slow.         
-                                                                                                                                                                   
-     --log-slow-hydrate-threshold number                         default: 100                                                                                      
-       ZERO_LOG_SLOW_HYDRATE_THRESHOLD env                                                                                                                         
-                                                                 The number of milliseconds a query hydration must take to print a slow warning.                   
-                                                                                                                                                                   
-     --log-ivm-sampling number                                   default: 5000                                                                                     
-       ZERO_LOG_IVM_SAMPLING env                                                                                                                                   
-                                                                 How often to collect IVM metrics. 1 out of N requests will be sampled where N is this value.      
-                                                                                                                                                                   
-     --app-id string                                             default: "zero"                                                                                   
-       ZERO_APP_ID env                                                                                                                                             
-                                                                 Unique identifier for the app.                                                                    
-                                                                                                                                                                   
-                                                                 Multiple zero-cache apps can run on a single upstream database, each of which                     
-                                                                 is isolated from the others, with its own permissions, sharding (future feature),                 
-                                                                 and change/cvr databases.                                                                         
-                                                                                                                                                                   
-                                                                 The metadata of an app is stored in an upstream schema with the same name,                        
-                                                                 e.g. "zero", and the metadata for each app shard, e.g. client and mutation                        
-                                                                 ids, is stored in the "{app-id}_{#}" schema. (Currently there is only a single                    
-                                                                 "0" shard, but this will change with sharding).                                                   
-                                                                                                                                                                   
-                                                                 The CVR and Change data are managed in schemas named "{app-id}_{shard-num}/cvr"                   
-                                                                 and "{app-id}_{shard-num}/cdc", respectively, allowing multiple apps and shards                   
-                                                                 to share the same database instance (e.g. a Postgres "cluster") for CVR and Change management.    
-                                                                                                                                                                   
-                                                                 Due to constraints on replication slot names, an App ID may only consist of                       
-                                                                 lower-case letters, numbers, and the underscore character.                                        
-                                                                                                                                                                   
-                                                                 Note that this option is used by both zero-cache and zero-deploy-permissions.                     
-                                                                                                                                                                   
-     --app-publications string[]                                 default: []                                                                                       
-       ZERO_APP_PUBLICATIONS env                                                                                                                                   
-                                                                 Postgres PUBLICATIONs that define the tables and columns to                                       
-                                                                 replicate. Publication names may not begin with an underscore,                                    
-                                                                 as zero reserves that prefix for internal use.                                                    
-                                                                                                                                                                   
-                                                                 If unspecified, zero-cache will create and use an internal publication that                       
-                                                                 publishes all tables in the public schema, i.e.:                                                  
-                                                                                                                                                                   
-                                                                 CREATE PUBLICATION _{app-id}_public_0 FOR TABLES IN SCHEMA public;                                
-                                                                                                                                                                   
-                                                                 Note that changing the set of publications will result in resyncing the replica,                  
-                                                                 which may involve downtime (replication lag) while the new replica is initializing.               
-                                                                 To change the set of publications without disrupting an existing app, a new app                   
-                                                                 should be created.                                                                                
-                                                                                                                                                                   
-     --auth-jwk string                                           optional                                                                                          
-       ZERO_AUTH_JWK env                                                                                                                                           
-                                                                 A public key in JWK format used to verify JWTs. Only one of jwk, jwksUrl and secret may be set.   
-                                                                                                                                                                   
-     --auth-jwks-url string                                      optional                                                                                          
-       ZERO_AUTH_JWKS_URL env                                                                                                                                      
-                                                                 A URL that returns a JWK set used to verify JWTs. Only one of jwk, jwksUrl and secret may be set. 
-                                                                                                                                                                   
-     --auth-secret string                                        optional                                                                                          
-       ZERO_AUTH_SECRET env                                                                                                                                        
-                                                                 A symmetric key used to verify JWTs. Only one of jwk, jwksUrl and secret may be set.              
-                                                                                                                                                                   
-     --port number                                               default: 4848                                                                                     
-       ZERO_PORT env                                                                                                                                               
-                                                                 The port for sync connections.                                                                    
-                                                                                                                                                                   
-     --change-streamer-uri string                                optional                                                                                          
-       ZERO_CHANGE_STREAMER_URI env                                                                                                                                
-                                                                 When set, connects to the change-streamer at the given URI.                                       
-                                                                 In a multi-node setup, this should be specified in view-syncer options,                           
-                                                                 pointing to the replication-manager URI, which runs a change-streamer                             
-                                                                 on port 4849.                                                                                     
-                                                                                                                                                                   
-     --change-streamer-mode dedicated,discover                   default: "dedicated"                                                                              
-       ZERO_CHANGE_STREAMER_MODE env                                                                                                                               
-                                                                 As an alternative to ZERO_CHANGE_STREAMER_URI, the ZERO_CHANGE_STREAMER_MODE                      
-                                                                 can be set to "discover" to instruct the view-syncer to connect to the                            
-                                                                 ip address registered by the replication-manager upon startup.                                    
-                                                                                                                                                                   
-                                                                 This may not work in all networking configurations, e.g. certain private                          
-                                                                 networking or port forwarding configurations. Using the ZERO_CHANGE_STREAMER_URI                  
-                                                                 with an explicit routable hostname is recommended instead.                                        
-                                                                                                                                                                   
-                                                                 Note: This option is ignored if the ZERO_CHANGE_STREAMER_URI is set.                              
-                                                                                                                                                                   
-     --change-streamer-port number                               optional                                                                                          
-       ZERO_CHANGE_STREAMER_PORT env                                                                                                                               
-                                                                 The port on which the change-streamer runs. This is an internal                                   
-                                                                 protocol between the replication-manager and view-syncers, which                                  
-                                                                 runs in the same process tree in local development or a single-node configuration.                
-                                                                                                                                                                   
-                                                                 If unspecified, defaults to --port + 1.                                                           
-                                                                                                                                                                   
-     --task-id string                                            optional                                                                                          
-       ZERO_TASK_ID env                                                                                                                                            
-                                                                 Globally unique identifier for the zero-cache instance.                                           
-                                                                                                                                                                   
-                                                                 Setting this to a platform specific task identifier can be useful for debugging.                  
-                                                                 If unspecified, zero-cache will attempt to extract the TaskARN if run from within                 
-                                                                 an AWS ECS container, and otherwise use a random string.                                          
-                                                                                                                                                                   
-     --per-user-mutation-limit-max number                        optional                                                                                          
-       ZERO_PER_USER_MUTATION_LIMIT_MAX env                                                                                                                        
-                                                                 The maximum mutations per user within the specified windowMs.                                     
-                                                                 If unset, no rate limiting is enforced.                                                           
-                                                                                                                                                                   
-     --per-user-mutation-limit-window-ms number                  default: 60000                                                                                    
-       ZERO_PER_USER_MUTATION_LIMIT_WINDOW_MS env                                                                                                                  
-                                                                 The sliding window over which the perUserMutationLimitMax is enforced.                            
-                                                                                                                                                                   
-     --num-sync-workers number                                   optional                                                                                          
-       ZERO_NUM_SYNC_WORKERS env                                                                                                                                   
-                                                                 The number of processes to use for view syncing.                                                  
-                                                                 Leave this unset to use the maximum available parallelism.                                        
-                                                                 If set to 0, the server runs without sync workers, which is the                                   
-                                                                 configuration for running the replication-manager.                                                
-                                                                                                                                                                   
-     --auto-reset boolean                                        default: true                                                                                     
-       ZERO_AUTO_RESET env                                                                                                                                         
-                                                                 Automatically wipe and resync the replica when replication is halted.                             
-                                                                 This situation can occur for configurations in which the upstream database                        
-                                                                 provider prohibits event trigger creation, preventing the zero-cache from                         
-                                                                 being able to correctly replicate schema changes. For such configurations,                        
-                                                                 an upstream schema change will instead result in halting replication with an                      
-                                                                 error indicating that the replica needs to be reset.                                              
-                                                                                                                                                                   
-                                                                 When auto-reset is enabled, zero-cache will respond to such situations                            
-                                                                 by shutting down, and when restarted, resetting the replica and all synced                        
-                                                                 clients. This is a heavy-weight operation and can result in user-visible                          
-                                                                 slowness or downtime if compute resources are scarce.                                             
-                                                                                                                                                                   
-     --admin-password string                                     optional                                                                                          
-       ZERO_ADMIN_PASSWORD env                                                                                                                                     
-                                                                 A password used to administer zero-cache server, for example to access the                        
-                                                                 /statz endpoint.                                                                                  
-                                                                                                                                                                   
-     --litestream-executable string                              optional                                                                                          
-       ZERO_LITESTREAM_EXECUTABLE env                                                                                                                              
-                                                                 Path to the litestream executable.                                                                
-                                                                                                                                                                   
-     --litestream-config-path string                             default: "./src/services/litestream/config.yml"                                                   
-       ZERO_LITESTREAM_CONFIG_PATH env                                                                                                                             
-                                                                 Path to the litestream yaml config file. zero-cache will run this with its                        
-                                                                 environment variables, which can be referenced in the file via \${ENV}                             
-                                                                 substitution, for example:                                                                        
-                                                                 * ZERO_REPLICA_FILE for the db path                                                               
-                                                                 * ZERO_LITESTREAM_BACKUP_LOCATION for the db replica url                                          
-                                                                 * ZERO_LITESTREAM_LOG_LEVEL for the log level                                                     
-                                                                 * ZERO_LOG_FORMAT for the log type                                                                
-                                                                                                                                                                   
-     --litestream-log-level debug,info,warn,error                default: "warn"                                                                                   
-       ZERO_LITESTREAM_LOG_LEVEL env                                                                                                                               
-                                                                                                                                                                   
-     --litestream-backup-url string                              optional                                                                                          
-       ZERO_LITESTREAM_BACKUP_URL env                                                                                                                              
-                                                                 The location of the litestream backup, usually an s3:// URL.                                      
-                                                                 This is only consulted by the replication-manager.                                                
-                                                                 view-syncers receive this information from the replication-manager.                               
-                                                                                                                                                                   
-     --litestream-port number                                    optional                                                                                          
-       ZERO_LITESTREAM_PORT env                                                                                                                                    
-                                                                 Port on which litestream exports metrics, used to determine the replication                       
-                                                                 watermark up to which it is safe to purge change log records.                                     
-                                                                                                                                                                   
-                                                                 If unspecified, defaults to --port + 2.                                                           
-                                                                                                                                                                   
-     --litestream-checkpoint-threshold-mb number                 default: 40                                                                                       
-       ZERO_LITESTREAM_CHECKPOINT_THRESHOLD_MB env                                                                                                                 
-                                                                 The size of the WAL file at which to perform an SQlite checkpoint to apply                        
-                                                                 the writes in the WAL to the main database file. Each checkpoint creates                          
-                                                                 a new WAL segment file that will be backed up by litestream. Smaller thresholds                   
-                                                                 may improve read performance, at the expense of creating more files to download                   
-                                                                 when restoring the replica from the backup.                                                       
-                                                                                                                                                                   
-     --litestream-incremental-backup-interval-minutes number     default: 15                                                                                       
-       ZERO_LITESTREAM_INCREMENTAL_BACKUP_INTERVAL_MINUTES env                                                                                                     
-                                                                 The interval between incremental backups of the replica. Shorter intervals                        
-                                                                 reduce the amount of change history that needs to be replayed when catching                       
-                                                                 up a new view-syncer, at the expense of increasing the number of files needed                     
-                                                                 to download for the initial litestream restore.                                                   
-                                                                                                                                                                   
-     --litestream-snapshot-backup-interval-hours number          default: 12                                                                                       
-       ZERO_LITESTREAM_SNAPSHOT_BACKUP_INTERVAL_HOURS env                                                                                                          
-                                                                 The interval between snapshot backups of the replica. Snapshot backups                            
-                                                                 make a full copy of the database to a new litestream generation. This                             
-                                                                 improves restore time at the expense of bandwidth. Applications with a                            
-                                                                 large database and low write rate can increase this interval to reduce                            
-                                                                 network usage for backups (litestream defaults to 24 hours).                                      
-                                                                                                                                                                   
-     --litestream-restore-parallelism number                     default: 48                                                                                       
-       ZERO_LITESTREAM_RESTORE_PARALLELISM env                                                                                                                     
-                                                                 The number of WAL files to download in parallel when performing the                               
-                                                                 initial restore of the replica from the backup.                                                   
-                                                                                                                                                                   
-     --litestream-multipart-concurrency number                   default: 48                                                                                       
-       ZERO_LITESTREAM_MULTIPART_CONCURRENCY env                                                                                                                   
-                                                                 The number of parts (of size --litestream-multipart-size bytes)                                   
-                                                                 to upload or download in parallel when backing up or restoring the snapshot.                      
-                                                                                                                                                                   
-     --litestream-multipart-size number                          default: 16777216                                                                                 
-       ZERO_LITESTREAM_MULTIPART_SIZE env                                                                                                                          
-                                                                 The size of each part when uploading or downloading the snapshot with                             
-                                                                 --multipart-concurrency. Note that up to concurrency * size                                       
-                                                                 bytes of memory are used when backing up or restoring the snapshot.                               
-                                                                                                                                                                   
-     --storage-db-tmp-dir string                                 optional                                                                                          
-       ZERO_STORAGE_DB_TMP_DIR env                                                                                                                                 
-                                                                 tmp directory for IVM operator storage. Leave unset to use os.tmpdir()                            
-                                                                                                                                                                   
-     --initial-sync-table-copy-workers number                    default: 5                                                                                        
-       ZERO_INITIAL_SYNC_TABLE_COPY_WORKERS env                                                                                                                    
-                                                                 The number of parallel workers used to copy tables during initial sync.                           
-                                                                 Each worker uses a database connection and will buffer up to (approximately)                      
-                                                                 10 MB of table data in memory during initial sync. Increasing the number of                       
-                                                                 workers may improve initial sync speed; however, note that local disk throughput                  
-                                                                 (i.e. IOPS), upstream CPU, and network bandwidth may also be bottlenecks.                         
-                                                                                                                                                                   
-     --lazy-startup boolean                                      default: false                                                                                    
-       ZERO_LAZY_STARTUP env                                                                                                                                       
-                                                                 Delay starting the majority of zero-cache until first request.                                    
-                                                                                                                                                                   
-                                                                 This is mainly intended to avoid connecting to Postgres replication stream                        
-                                                                 until the first request is received, which can be useful i.e., for preview instances.             
-                                                                                                                                                                   
-                                                                 Currently only supported in single-node mode.                                                     
-                                                                                                                                                                   
-     --server-version string                                     optional                                                                                          
-       ZERO_SERVER_VERSION env                                                                                                                                     
-                                                                 The version string outputted to logs when the server starts up.                                   
-                                                                                                                                                                   
-     --enable-telemetry boolean                                  default: true                                                                                     
-       ZERO_ENABLE_TELEMETRY env                                                                                                                                   
-                                                                 Set to false to opt out of telemetry collection.                                                  
-                                                                                                                                                                   
-                                                                 This helps us improve Zero by collecting anonymous usage data.                                    
-                                                                 Setting the DO_NOT_TRACK environment variable also disables telemetry.                            
-                                                                                                                                                                   
-     --cloud-event-sink-env string                               optional                                                                                          
-       ZERO_CLOUD_EVENT_SINK_ENV env                                                                                                                               
-                                                                 ENV variable containing a URI to a CloudEvents sink. When set, ZeroEvents                         
-                                                                 will be published to the sink as the data field of CloudEvents.                                   
-                                                                 The source field of the CloudEvents will be set to the ZERO_TASK_ID,                              
-                                                                 along with any extension attributes specified by the ZERO_CLOUD_EVENT_EXTENSION_OVERRIDES_ENV.    
-                                                                                                                                                                   
-                                                                 This configuration is modeled to easily integrate with a knative K_SINK binding,                  
-                                                                 (i.e. https://github.com/knative/eventing/blob/main/docs/spec/sources.md#sinkbinding).            
-                                                                 However, any CloudEvents sink can be used.                                                        
-                                                                                                                                                                   
-     --cloud-event-extension-overrides-env string                optional                                                                                          
-       ZERO_CLOUD_EVENT_EXTENSION_OVERRIDES_ENV env                                                                                                                
-                                                                 ENV variable containing a JSON stringified object with an extensions field                        
-                                                                 containing attributes that should be added or overridden on outbound CloudEvents.                 
-                                                                                                                                                                   
-                                                                 This configuration is modeled to easily integrate with a knative K_CE_OVERRIDES binding,          
-                                                                 (i.e. https://github.com/knative/eventing/blob/main/docs/spec/sources.md#sinkbinding).            
-                                                                                                                                                                   
+     --upstream-db string                                          required                                                                                          
+       ZERO_UPSTREAM_DB env                                                                                                                                          
+                                                                   The "upstream" authoritative postgres database.                                                   
+                                                                   In the future we will support other types of upstream besides PG.                                 
+                                                                                                                                                                     
+     --upstream-max-conns number                                   default: 20                                                                                       
+       ZERO_UPSTREAM_MAX_CONNS env                                                                                                                                   
+                                                                   The maximum number of connections to open to the upstream database                                
+                                                                   for committing mutations. This is divided evenly amongst sync workers.                            
+                                                                   In addition to this number, zero-cache uses one connection for the                                
+                                                                   replication stream.                                                                               
+                                                                                                                                                                     
+                                                                   Note that this number must allow for at least one connection per                                  
+                                                                   sync worker, or zero-cache will fail to start. See num-sync-workers                               
+                                                                                                                                                                     
+     --push-url string[]                                           optional                                                                                          
+       ZERO_PUSH_URL env                                                                                                                                             
+                                                                   DEPRECATED. Use mutate-url instead.                                                               
+                                                                   The URL of the API server to which zero-cache will push mutations.                                
+                                                                                                                                                                     
+                                                                   * is allowed if you would like to allow the client to specify a subdomain to use.                 
+                                                                   e.g., *.example.com/api/mutate                                                                    
+                                                                   You can specify multiple URLs as well which the client can choose from.                           
+                                                                   e.g., ["https://api1.example.com/mutate", "https://api2.example.com/mutate"]                      
+                                                                                                                                                                     
+     --push-api-key string                                         optional                                                                                          
+       ZERO_PUSH_API_KEY env                                                                                                                                         
+                                                                   An optional secret used to authorize zero-cache to call the API server handling writes.           
+                                                                                                                                                                     
+     --push-forward-cookies boolean                                default: false                                                                                    
+       ZERO_PUSH_FORWARD_COOKIES env                                                                                                                                 
+                                                                   If true, zero-cache will forward cookies from the request.                                        
+                                                                   This is useful for passing authentication cookies to the API server.                              
+                                                                   If false, cookies are not forwarded.                                                              
+                                                                                                                                                                     
+     --mutate-url string[]                                         optional                                                                                          
+       ZERO_MUTATE_URL env                                                                                                                                           
+                                                                                                                                                                     
+                                                                   The URL of the API server to which zero-cache will push mutations.                                
+                                                                                                                                                                     
+                                                                   * is allowed if you would like to allow the client to specify a subdomain to use.                 
+                                                                   e.g., *.example.com/api/mutate                                                                    
+                                                                   You can specify multiple URLs as well which the client can choose from.                           
+                                                                   e.g., ["https://api1.example.com/mutate", "https://api2.example.com/mutate"]                      
+                                                                                                                                                                     
+     --mutate-api-key string                                       optional                                                                                          
+       ZERO_MUTATE_API_KEY env                                                                                                                                       
+                                                                   An optional secret used to authorize zero-cache to call the API server handling writes.           
+                                                                                                                                                                     
+     --mutate-forward-cookies boolean                              default: false                                                                                    
+       ZERO_MUTATE_FORWARD_COOKIES env                                                                                                                               
+                                                                   If true, zero-cache will forward cookies from the request.                                        
+                                                                   This is useful for passing authentication cookies to the API server.                              
+                                                                   If false, cookies are not forwarded.                                                              
+                                                                                                                                                                     
+     --query-url string[]                                          optional                                                                                          
+       ZERO_QUERY_URL env                                                                                                                                            
+                                                                                                                                                                     
+                                                                   The URL of the API server to which zero-cache will send named queries.                            
+                                                                                                                                                                     
+                                                                   * is allowed if you would like to allow the client to specify a subdomain to use.                 
+                                                                   e.g., *.example.com/api/mutate                                                                    
+                                                                   You can specify multiple URLs as well which the client can choose from.                           
+                                                                   e.g., ["https://api1.example.com/mutate", "https://api2.example.com/mutate"]                      
+                                                                                                                                                                     
+     --query-api-key string                                        optional                                                                                          
+       ZERO_QUERY_API_KEY env                                                                                                                                        
+                                                                   An optional secret used to authorize zero-cache to call the API server handling writes.           
+                                                                                                                                                                     
+     --query-forward-cookies boolean                               default: false                                                                                    
+       ZERO_QUERY_FORWARD_COOKIES env                                                                                                                                
+                                                                   If true, zero-cache will forward cookies from the request.                                        
+                                                                   This is useful for passing authentication cookies to the API server.                              
+                                                                   If false, cookies are not forwarded.                                                              
+                                                                                                                                                                     
+     --cvr-db string                                               optional                                                                                          
+       ZERO_CVR_DB env                                                                                                                                               
+                                                                   The Postgres database used to store CVRs. CVRs (client view records) keep track                   
+                                                                   of the data synced to clients in order to determine the diff to send on reconnect.                
+                                                                   If unspecified, the upstream-db will be used.                                                     
+                                                                                                                                                                     
+     --cvr-max-conns number                                        default: 30                                                                                       
+       ZERO_CVR_MAX_CONNS env                                                                                                                                        
+                                                                   The maximum number of connections to open to the CVR database.                                    
+                                                                   This is divided evenly amongst sync workers.                                                      
+                                                                                                                                                                     
+                                                                   Note that this number must allow for at least one connection per                                  
+                                                                   sync worker, or zero-cache will fail to start. See num-sync-workers                               
+                                                                                                                                                                     
+     --cvr-garbage-collection-inactivity-threshold-hours number    default: 48                                                                                       
+       ZERO_CVR_GARBAGE_COLLECTION_INACTIVITY_THRESHOLD_HOURS env                                                                                                    
+                                                                   The duration after which an inactive CVR is eligible for garbage collection.                      
+                                                                   Note that garbage collection is an incremental, periodic process which does not                   
+                                                                   necessarily purge all eligible CVRs immediately.                                                  
+                                                                                                                                                                     
+     --query-hydration-stats boolean                               optional                                                                                          
+       ZERO_QUERY_HYDRATION_STATS env                                                                                                                                
+                                                                   Track and log the number of rows considered by query hydrations which                             
+                                                                   take longer than log-slow-hydrate-threshold milliseconds.                                         
+                                                                   This is useful for debugging and performance tuning.                                              
+                                                                                                                                                                     
+     --change-db string                                            optional                                                                                          
+       ZERO_CHANGE_DB env                                                                                                                                            
+                                                                   The Postgres database used to store recent replication log entries, in order                      
+                                                                   to sync multiple view-syncers without requiring multiple replication slots on                     
+                                                                   the upstream database. If unspecified, the upstream-db will be used.                              
+                                                                                                                                                                     
+     --change-max-conns number                                     default: 5                                                                                        
+       ZERO_CHANGE_MAX_CONNS env                                                                                                                                     
+                                                                   The maximum number of connections to open to the change database.                                 
+                                                                   This is used by the change-streamer for catching up                                               
+                                                                   zero-cache replication subscriptions.                                                             
+                                                                                                                                                                     
+     --replica-file string                                         required                                                                                          
+       ZERO_REPLICA_FILE env                                                                                                                                         
+                                                                   File path to the SQLite replica that zero-cache maintains.                                        
+                                                                   This can be lost, but if it is, zero-cache will have to re-replicate next                         
+                                                                   time it starts up.                                                                                
+                                                                                                                                                                     
+     --replica-vacuum-interval-hours number                        optional                                                                                          
+       ZERO_REPLICA_VACUUM_INTERVAL_HOURS env                                                                                                                        
+                                                                   Performs a VACUUM at server startup if the specified number of hours has elapsed                  
+                                                                   since the last VACUUM (or initial-sync). The VACUUM operation is heavyweight                      
+                                                                   and requires double the size of the db in disk space. If unspecified, VACUUM                      
+                                                                   operations are not performed.                                                                     
+                                                                                                                                                                     
+     --log-level debug,info,warn,error                             default: "info"                                                                                   
+       ZERO_LOG_LEVEL env                                                                                                                                            
+                                                                                                                                                                     
+     --log-format text,json                                        default: "text"                                                                                   
+       ZERO_LOG_FORMAT env                                                                                                                                           
+                                                                   Use text for developer-friendly console logging                                                   
+                                                                   and json for consumption by structured-logging services                                           
+                                                                                                                                                                     
+     --log-slow-row-threshold number                               default: 2                                                                                        
+       ZERO_LOG_SLOW_ROW_THRESHOLD env                                                                                                                               
+                                                                   The number of ms a row must take to fetch from table-source before it is considered slow.         
+                                                                                                                                                                     
+     --log-slow-hydrate-threshold number                           default: 100                                                                                      
+       ZERO_LOG_SLOW_HYDRATE_THRESHOLD env                                                                                                                           
+                                                                   The number of milliseconds a query hydration must take to print a slow warning.                   
+                                                                                                                                                                     
+     --log-ivm-sampling number                                     default: 5000                                                                                     
+       ZERO_LOG_IVM_SAMPLING env                                                                                                                                     
+                                                                   How often to collect IVM metrics. 1 out of N requests will be sampled where N is this value.      
+                                                                                                                                                                     
+     --app-id string                                               default: "zero"                                                                                   
+       ZERO_APP_ID env                                                                                                                                               
+                                                                   Unique identifier for the app.                                                                    
+                                                                                                                                                                     
+                                                                   Multiple zero-cache apps can run on a single upstream database, each of which                     
+                                                                   is isolated from the others, with its own permissions, sharding (future feature),                 
+                                                                   and change/cvr databases.                                                                         
+                                                                                                                                                                     
+                                                                   The metadata of an app is stored in an upstream schema with the same name,                        
+                                                                   e.g. "zero", and the metadata for each app shard, e.g. client and mutation                        
+                                                                   ids, is stored in the "{app-id}_{#}" schema. (Currently there is only a single                    
+                                                                   "0" shard, but this will change with sharding).                                                   
+                                                                                                                                                                     
+                                                                   The CVR and Change data are managed in schemas named "{app-id}_{shard-num}/cvr"                   
+                                                                   and "{app-id}_{shard-num}/cdc", respectively, allowing multiple apps and shards                   
+                                                                   to share the same database instance (e.g. a Postgres "cluster") for CVR and Change management.    
+                                                                                                                                                                     
+                                                                   Due to constraints on replication slot names, an App ID may only consist of                       
+                                                                   lower-case letters, numbers, and the underscore character.                                        
+                                                                                                                                                                     
+                                                                   Note that this option is used by both zero-cache and zero-deploy-permissions.                     
+                                                                                                                                                                     
+     --app-publications string[]                                   default: []                                                                                       
+       ZERO_APP_PUBLICATIONS env                                                                                                                                     
+                                                                   Postgres PUBLICATIONs that define the tables and columns to                                       
+                                                                   replicate. Publication names may not begin with an underscore,                                    
+                                                                   as zero reserves that prefix for internal use.                                                    
+                                                                                                                                                                     
+                                                                   If unspecified, zero-cache will create and use an internal publication that                       
+                                                                   publishes all tables in the public schema, i.e.:                                                  
+                                                                                                                                                                     
+                                                                   CREATE PUBLICATION _{app-id}_public_0 FOR TABLES IN SCHEMA public;                                
+                                                                                                                                                                     
+                                                                   Note that changing the set of publications will result in resyncing the replica,                  
+                                                                   which may involve downtime (replication lag) while the new replica is initializing.               
+                                                                   To change the set of publications without disrupting an existing app, a new app                   
+                                                                   should be created.                                                                                
+                                                                                                                                                                     
+     --auth-jwk string                                             optional                                                                                          
+       ZERO_AUTH_JWK env                                                                                                                                             
+                                                                   A public key in JWK format used to verify JWTs. Only one of jwk, jwksUrl and secret may be set.   
+                                                                                                                                                                     
+     --auth-jwks-url string                                        optional                                                                                          
+       ZERO_AUTH_JWKS_URL env                                                                                                                                        
+                                                                   A URL that returns a JWK set used to verify JWTs. Only one of jwk, jwksUrl and secret may be set. 
+                                                                                                                                                                     
+     --auth-secret string                                          optional                                                                                          
+       ZERO_AUTH_SECRET env                                                                                                                                          
+                                                                   A symmetric key used to verify JWTs. Only one of jwk, jwksUrl and secret may be set.              
+                                                                                                                                                                     
+     --port number                                                 default: 4848                                                                                     
+       ZERO_PORT env                                                                                                                                                 
+                                                                   The port for sync connections.                                                                    
+                                                                                                                                                                     
+     --change-streamer-uri string                                  optional                                                                                          
+       ZERO_CHANGE_STREAMER_URI env                                                                                                                                  
+                                                                   When set, connects to the change-streamer at the given URI.                                       
+                                                                   In a multi-node setup, this should be specified in view-syncer options,                           
+                                                                   pointing to the replication-manager URI, which runs a change-streamer                             
+                                                                   on port 4849.                                                                                     
+                                                                                                                                                                     
+     --change-streamer-mode dedicated,discover                     default: "dedicated"                                                                              
+       ZERO_CHANGE_STREAMER_MODE env                                                                                                                                 
+                                                                   As an alternative to ZERO_CHANGE_STREAMER_URI, the ZERO_CHANGE_STREAMER_MODE                      
+                                                                   can be set to "discover" to instruct the view-syncer to connect to the                            
+                                                                   ip address registered by the replication-manager upon startup.                                    
+                                                                                                                                                                     
+                                                                   This may not work in all networking configurations, e.g. certain private                          
+                                                                   networking or port forwarding configurations. Using the ZERO_CHANGE_STREAMER_URI                  
+                                                                   with an explicit routable hostname is recommended instead.                                        
+                                                                                                                                                                     
+                                                                   Note: This option is ignored if the ZERO_CHANGE_STREAMER_URI is set.                              
+                                                                                                                                                                     
+     --change-streamer-port number                                 optional                                                                                          
+       ZERO_CHANGE_STREAMER_PORT env                                                                                                                                 
+                                                                   The port on which the change-streamer runs. This is an internal                                   
+                                                                   protocol between the replication-manager and view-syncers, which                                  
+                                                                   runs in the same process tree in local development or a single-node configuration.                
+                                                                                                                                                                     
+                                                                   If unspecified, defaults to --port + 1.                                                           
+                                                                                                                                                                     
+     --task-id string                                              optional                                                                                          
+       ZERO_TASK_ID env                                                                                                                                              
+                                                                   Globally unique identifier for the zero-cache instance.                                           
+                                                                                                                                                                     
+                                                                   Setting this to a platform specific task identifier can be useful for debugging.                  
+                                                                   If unspecified, zero-cache will attempt to extract the TaskARN if run from within                 
+                                                                   an AWS ECS container, and otherwise use a random string.                                          
+                                                                                                                                                                     
+     --per-user-mutation-limit-max number                          optional                                                                                          
+       ZERO_PER_USER_MUTATION_LIMIT_MAX env                                                                                                                          
+                                                                   The maximum mutations per user within the specified windowMs.                                     
+                                                                   If unset, no rate limiting is enforced.                                                           
+                                                                                                                                                                     
+     --per-user-mutation-limit-window-ms number                    default: 60000                                                                                    
+       ZERO_PER_USER_MUTATION_LIMIT_WINDOW_MS env                                                                                                                    
+                                                                   The sliding window over which the perUserMutationLimitMax is enforced.                            
+                                                                                                                                                                     
+     --num-sync-workers number                                     optional                                                                                          
+       ZERO_NUM_SYNC_WORKERS env                                                                                                                                     
+                                                                   The number of processes to use for view syncing.                                                  
+                                                                   Leave this unset to use the maximum available parallelism.                                        
+                                                                   If set to 0, the server runs without sync workers, which is the                                   
+                                                                   configuration for running the replication-manager.                                                
+                                                                                                                                                                     
+     --auto-reset boolean                                          default: true                                                                                     
+       ZERO_AUTO_RESET env                                                                                                                                           
+                                                                   Automatically wipe and resync the replica when replication is halted.                             
+                                                                   This situation can occur for configurations in which the upstream database                        
+                                                                   provider prohibits event trigger creation, preventing the zero-cache from                         
+                                                                   being able to correctly replicate schema changes. For such configurations,                        
+                                                                   an upstream schema change will instead result in halting replication with an                      
+                                                                   error indicating that the replica needs to be reset.                                              
+                                                                                                                                                                     
+                                                                   When auto-reset is enabled, zero-cache will respond to such situations                            
+                                                                   by shutting down, and when restarted, resetting the replica and all synced                        
+                                                                   clients. This is a heavy-weight operation and can result in user-visible                          
+                                                                   slowness or downtime if compute resources are scarce.                                             
+                                                                                                                                                                     
+     --admin-password string                                       optional                                                                                          
+       ZERO_ADMIN_PASSWORD env                                                                                                                                       
+                                                                   A password used to administer zero-cache server, for example to access the                        
+                                                                   /statz endpoint.                                                                                  
+                                                                                                                                                                     
+     --litestream-executable string                                optional                                                                                          
+       ZERO_LITESTREAM_EXECUTABLE env                                                                                                                                
+                                                                   Path to the litestream executable.                                                                
+                                                                                                                                                                     
+     --litestream-config-path string                               default: "./src/services/litestream/config.yml"                                                   
+       ZERO_LITESTREAM_CONFIG_PATH env                                                                                                                               
+                                                                   Path to the litestream yaml config file. zero-cache will run this with its                        
+                                                                   environment variables, which can be referenced in the file via \${ENV}                             
+                                                                   substitution, for example:                                                                        
+                                                                   * ZERO_REPLICA_FILE for the db path                                                               
+                                                                   * ZERO_LITESTREAM_BACKUP_LOCATION for the db replica url                                          
+                                                                   * ZERO_LITESTREAM_LOG_LEVEL for the log level                                                     
+                                                                   * ZERO_LOG_FORMAT for the log type                                                                
+                                                                                                                                                                     
+     --litestream-log-level debug,info,warn,error                  default: "warn"                                                                                   
+       ZERO_LITESTREAM_LOG_LEVEL env                                                                                                                                 
+                                                                                                                                                                     
+     --litestream-backup-url string                                optional                                                                                          
+       ZERO_LITESTREAM_BACKUP_URL env                                                                                                                                
+                                                                   The location of the litestream backup, usually an s3:// URL.                                      
+                                                                   This is only consulted by the replication-manager.                                                
+                                                                   view-syncers receive this information from the replication-manager.                               
+                                                                                                                                                                     
+     --litestream-port number                                      optional                                                                                          
+       ZERO_LITESTREAM_PORT env                                                                                                                                      
+                                                                   Port on which litestream exports metrics, used to determine the replication                       
+                                                                   watermark up to which it is safe to purge change log records.                                     
+                                                                                                                                                                     
+                                                                   If unspecified, defaults to --port + 2.                                                           
+                                                                                                                                                                     
+     --litestream-checkpoint-threshold-mb number                   default: 40                                                                                       
+       ZERO_LITESTREAM_CHECKPOINT_THRESHOLD_MB env                                                                                                                   
+                                                                   The size of the WAL file at which to perform an SQlite checkpoint to apply                        
+                                                                   the writes in the WAL to the main database file. Each checkpoint creates                          
+                                                                   a new WAL segment file that will be backed up by litestream. Smaller thresholds                   
+                                                                   may improve read performance, at the expense of creating more files to download                   
+                                                                   when restoring the replica from the backup.                                                       
+                                                                                                                                                                     
+     --litestream-incremental-backup-interval-minutes number       default: 15                                                                                       
+       ZERO_LITESTREAM_INCREMENTAL_BACKUP_INTERVAL_MINUTES env                                                                                                       
+                                                                   The interval between incremental backups of the replica. Shorter intervals                        
+                                                                   reduce the amount of change history that needs to be replayed when catching                       
+                                                                   up a new view-syncer, at the expense of increasing the number of files needed                     
+                                                                   to download for the initial litestream restore.                                                   
+                                                                                                                                                                     
+     --litestream-snapshot-backup-interval-hours number            default: 12                                                                                       
+       ZERO_LITESTREAM_SNAPSHOT_BACKUP_INTERVAL_HOURS env                                                                                                            
+                                                                   The interval between snapshot backups of the replica. Snapshot backups                            
+                                                                   make a full copy of the database to a new litestream generation. This                             
+                                                                   improves restore time at the expense of bandwidth. Applications with a                            
+                                                                   large database and low write rate can increase this interval to reduce                            
+                                                                   network usage for backups (litestream defaults to 24 hours).                                      
+                                                                                                                                                                     
+     --litestream-restore-parallelism number                       default: 48                                                                                       
+       ZERO_LITESTREAM_RESTORE_PARALLELISM env                                                                                                                       
+                                                                   The number of WAL files to download in parallel when performing the                               
+                                                                   initial restore of the replica from the backup.                                                   
+                                                                                                                                                                     
+     --litestream-multipart-concurrency number                     default: 48                                                                                       
+       ZERO_LITESTREAM_MULTIPART_CONCURRENCY env                                                                                                                     
+                                                                   The number of parts (of size --litestream-multipart-size bytes)                                   
+                                                                   to upload or download in parallel when backing up or restoring the snapshot.                      
+                                                                                                                                                                     
+     --litestream-multipart-size number                            default: 16777216                                                                                 
+       ZERO_LITESTREAM_MULTIPART_SIZE env                                                                                                                            
+                                                                   The size of each part when uploading or downloading the snapshot with                             
+                                                                   --multipart-concurrency. Note that up to concurrency * size                                       
+                                                                   bytes of memory are used when backing up or restoring the snapshot.                               
+                                                                                                                                                                     
+     --storage-db-tmp-dir string                                   optional                                                                                          
+       ZERO_STORAGE_DB_TMP_DIR env                                                                                                                                   
+                                                                   tmp directory for IVM operator storage. Leave unset to use os.tmpdir()                            
+                                                                                                                                                                     
+     --initial-sync-table-copy-workers number                      default: 5                                                                                        
+       ZERO_INITIAL_SYNC_TABLE_COPY_WORKERS env                                                                                                                      
+                                                                   The number of parallel workers used to copy tables during initial sync.                           
+                                                                   Each worker uses a database connection and will buffer up to (approximately)                      
+                                                                   10 MB of table data in memory during initial sync. Increasing the number of                       
+                                                                   workers may improve initial sync speed; however, note that local disk throughput                  
+                                                                   (i.e. IOPS), upstream CPU, and network bandwidth may also be bottlenecks.                         
+                                                                                                                                                                     
+     --lazy-startup boolean                                        default: false                                                                                    
+       ZERO_LAZY_STARTUP env                                                                                                                                         
+                                                                   Delay starting the majority of zero-cache until first request.                                    
+                                                                                                                                                                     
+                                                                   This is mainly intended to avoid connecting to Postgres replication stream                        
+                                                                   until the first request is received, which can be useful i.e., for preview instances.             
+                                                                                                                                                                     
+                                                                   Currently only supported in single-node mode.                                                     
+                                                                                                                                                                     
+     --server-version string                                       optional                                                                                          
+       ZERO_SERVER_VERSION env                                                                                                                                       
+                                                                   The version string outputted to logs when the server starts up.                                   
+                                                                                                                                                                     
+     --enable-telemetry boolean                                    default: true                                                                                     
+       ZERO_ENABLE_TELEMETRY env                                                                                                                                     
+                                                                   Set to false to opt out of telemetry collection.                                                  
+                                                                                                                                                                     
+                                                                   This helps us improve Zero by collecting anonymous usage data.                                    
+                                                                   Setting the DO_NOT_TRACK environment variable also disables telemetry.                            
+                                                                                                                                                                     
+     --cloud-event-sink-env string                                 optional                                                                                          
+       ZERO_CLOUD_EVENT_SINK_ENV env                                                                                                                                 
+                                                                   ENV variable containing a URI to a CloudEvents sink. When set, ZeroEvents                         
+                                                                   will be published to the sink as the data field of CloudEvents.                                   
+                                                                   The source field of the CloudEvents will be set to the ZERO_TASK_ID,                              
+                                                                   along with any extension attributes specified by the ZERO_CLOUD_EVENT_EXTENSION_OVERRIDES_ENV.    
+                                                                                                                                                                     
+                                                                   This configuration is modeled to easily integrate with a knative K_SINK binding,                  
+                                                                   (i.e. https://github.com/knative/eventing/blob/main/docs/spec/sources.md#sinkbinding).            
+                                                                   However, any CloudEvents sink can be used.                                                        
+                                                                                                                                                                     
+     --cloud-event-extension-overrides-env string                  optional                                                                                          
+       ZERO_CLOUD_EVENT_EXTENSION_OVERRIDES_ENV env                                                                                                                  
+                                                                   ENV variable containing a JSON stringified object with an extensions field                        
+                                                                   containing attributes that should be added or overridden on outbound CloudEvents.                 
+                                                                                                                                                                     
+                                                                   This configuration is modeled to easily integrate with a knative K_CE_OVERRIDES binding,          
+                                                                   (i.e. https://github.com/knative/eventing/blob/main/docs/spec/sources.md#sinkbinding).            
+                                                                                                                                                                     
     "
   `);
 });

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -266,6 +266,15 @@ export const zeroOptions = {
       type: v.number().optional(),
       hidden: true, // Passed from main thread to sync workers
     },
+
+    garbageCollectionInactivityThresholdHours: {
+      type: v.number().default(48),
+      desc: [
+        `The duration after which an inactive CVR is eligible for garbage collection.`,
+        `Note that garbage collection is an incremental, periodic process which does not`,
+        `necessarily purge all eligible CVRs immediately.`,
+      ],
+    },
   },
 
   queryHydrationStats: {

--- a/packages/zero-cache/src/server/reaper.ts
+++ b/packages/zero-cache/src/server/reaper.ts
@@ -1,0 +1,55 @@
+import {must} from '../../../shared/src/must.ts';
+import {getNormalizedZeroConfig} from '../config/zero-config.ts';
+import {initEventSink} from '../observability/events.ts';
+import {exitAfter, runUntilKilled} from '../services/life-cycle.ts';
+import {CVRPurger} from '../services/view-syncer/cvr-purger.ts';
+import {initViewSyncerSchema} from '../services/view-syncer/schema/init.ts';
+import {pgClient} from '../types/pg.ts';
+import {
+  parentWorker,
+  singleProcessMode,
+  type Worker,
+} from '../types/processes.ts';
+import {getShardID} from '../types/shards.ts';
+import {createLogContext} from './logging.ts';
+import {startOtelAuto} from './otel-start.ts';
+
+const MS_PER_HOUR = 1000 * 60 * 60;
+
+export default async function runWorker(
+  parent: Worker,
+  env: NodeJS.ProcessEnv,
+  ...argv: string[]
+): Promise<void> {
+  const config = getNormalizedZeroConfig({env, argv});
+
+  startOtelAuto(createLogContext(config, {worker: 'reaper'}, false));
+  const lc = createLogContext(config, {worker: 'reaper'}, true);
+  initEventSink(lc, config);
+
+  const {cvr} = config;
+  const shard = getShardID(config);
+  const cvrDB = pgClient(lc, cvr.db, {
+    connection: {['application_name']: `zero-sync-cvr-purger`},
+  });
+  await initViewSyncerSchema(lc, cvrDB, shard);
+  parent.send(['ready', {ready: true}]);
+
+  return runUntilKilled(
+    lc,
+    parent,
+    new CVRPurger(
+      lc,
+      cvrDB,
+      shard,
+      cvr.garbageCollectionInactivityThresholdHours * MS_PER_HOUR,
+    ),
+  );
+}
+
+// fork()
+if (!singleProcessMode()) {
+  void exitAfter(() =>
+    runWorker(must(parentWorker), process.env, ...process.argv.slice(2)),
+  );
+}

--- a/packages/zero-cache/src/services/running-state.ts
+++ b/packages/zero-cache/src/services/running-state.ts
@@ -105,6 +105,14 @@ export class RunningState {
   }
 
   /**
+   * Returns a promise that resolves after `ms` milliseconds or when
+   * the service is stopped.
+   */
+  async sleep(ms: number): Promise<void> {
+    await Promise.race(this.#sleep(ms, this.#controller.signal));
+  }
+
+  /**
    * Called to stop the service. After this is called, {@link shouldRun()}
    * will return `false` and the {@link stopped()} Promise will be resolved.
    */
@@ -139,7 +147,7 @@ export class RunningState {
     } else if (this.shouldRun()) {
       const log = delay < 1000 ? 'info' : delay < 5000 ? 'warn' : 'error';
       lc[log]?.(`retrying ${this.#serviceName} in ${delay} ms`, err);
-      await Promise.race(this.#sleep(delay, this.#controller.signal));
+      await this.sleep(delay);
     }
   }
 

--- a/packages/zero-cache/src/services/view-syncer/cvr-purger.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-purger.pg-test.ts
@@ -1,0 +1,330 @@
+import {resolver} from '@rocicorp/resolver';
+import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import {DEFAULT_TTL_MS} from '../../../../zql/src/query/ttl.ts';
+import {testDBs} from '../../test/db.ts';
+import type {PostgresDB} from '../../types/pg.ts';
+import {cvrSchema} from '../../types/shards.ts';
+import {CVRPurger} from './cvr-purger.ts';
+import {
+  setupCVRTables,
+  type ClientsRow,
+  type DesiresRow,
+  type InstancesRow,
+  type QueriesRow,
+  type RowsRow,
+  type RowsVersionRow,
+} from './schema/cvr.ts';
+import {ttlClockFromNumber} from './ttl-clock.ts';
+
+const APP_ID = 'zapp';
+const SHARD_NUM = 3;
+const SHARD = {appID: APP_ID, shardNum: SHARD_NUM};
+
+describe('view-syncer/cvr', () => {
+  type DBState = {
+    instances: (Partial<InstancesRow> &
+      Pick<
+        InstancesRow,
+        'clientGroupID' | 'version' | 'clientSchema' | 'ttlClock'
+      >)[];
+    clients: ClientsRow[];
+    queries: QueriesRow[];
+    desires: DesiresRow[];
+    rows: RowsRow[];
+    rowsVersion?: RowsVersionRow[];
+  };
+
+  function addDBState(db: PostgresDB, state: Partial<DBState>): Promise<void> {
+    return db.begin(async tx => {
+      const {instances, rowsVersion} = state;
+      if (instances && !rowsVersion) {
+        state = {
+          rowsVersion: instances.map(({clientGroupID, version}) => ({
+            clientGroupID,
+            version,
+          })),
+          ...state,
+        };
+      }
+
+      for (const [table, rows] of Object.entries(state)) {
+        for (const row of rows) {
+          await tx`INSERT INTO ${tx(`${cvrSchema(SHARD)}.` + table)} ${tx(
+            row,
+          )}`;
+        }
+      }
+    });
+  }
+
+  async function getAllState(db: PostgresDB): Promise<DBState> {
+    const [instances, clients, queries, desires, rows] = await Promise.all([
+      db`SELECT * FROM ${db('zapp_3/cvr.instances')}`,
+      db`SELECT * FROM ${db('zapp_3/cvr.clients')}`,
+      db`SELECT * FROM ${db('zapp_3/cvr.queries')}`,
+      db`SELECT * FROM ${db('zapp_3/cvr.desires')}`,
+      db`SELECT * FROM ${db('zapp_3/cvr.rows')}`,
+    ]);
+
+    desires.forEach(row => {
+      // expiresAt is deprecated. It is still in the db but we do not
+      // want it in the js objects.
+      delete row.expiresAt;
+    });
+    return {
+      instances,
+      clients,
+      queries,
+      desires,
+      rows,
+    } as unknown as DBState;
+  }
+
+  const INACTIVITY_THRESHOLD_MS = 1000 * 60 * 60 * 24;
+
+  const lc = createSilentLogContext();
+  let cvrDb: PostgresDB;
+  let purger: CVRPurger;
+
+  beforeEach(async () => {
+    cvrDb = await testDBs.create('cvr_purger_test_db');
+    await cvrDb.begin(tx => setupCVRTables(lc, tx, SHARD));
+
+    purger = new CVRPurger(lc, cvrDb, SHARD, INACTIVITY_THRESHOLD_MS);
+
+    for (const [clientGroupID, lastActive] of [
+      ['new-1', Date.now()],
+      ['old-1', Date.now() - INACTIVITY_THRESHOLD_MS - 1000],
+      ['new-2', Date.now() - INACTIVITY_THRESHOLD_MS / 2],
+      ['old-2', Date.UTC(2025, 4, 23)],
+      ['new-3', Date.now() - INACTIVITY_THRESHOLD_MS + 60000],
+      ['old-3', Date.UTC(2024, 3, 12)],
+    ] as [string, number][]) {
+      await addDBState(cvrDb, {
+        instances: [
+          {
+            clientGroupID,
+            version: '1aa',
+            replicaVersion: null,
+            lastActive,
+            ttlClock: ttlClockFromNumber(Date.UTC(2024, 3, 23)),
+            clientSchema: null,
+          },
+        ],
+        clients: [
+          {
+            clientGroupID,
+            clientID: 'fooClient',
+          },
+        ],
+        queries: [
+          {
+            clientGroupID,
+            queryArgs: null,
+            queryName: null,
+            queryHash: 'oneHash',
+            clientAST: {table: 'issues'},
+            transformationHash: null,
+            transformationVersion: null,
+            patchVersion: null,
+            internal: null,
+            deleted: null,
+          },
+        ],
+        desires: [
+          {
+            clientGroupID,
+            clientID: 'fooClient',
+            queryHash: 'oneHash',
+            patchVersion: '1a9:01',
+            deleted: null,
+            inactivatedAt: null,
+            ttl: DEFAULT_TTL_MS,
+          },
+        ],
+        rows: [
+          {
+            clientGroupID,
+            rowKey: {a: 'b'},
+            rowVersion: '03',
+            refCounts: {oneHash: 1},
+            patchVersion: '1a0',
+            schema: 'public',
+            table: 'issues',
+          },
+        ],
+      });
+    }
+  });
+
+  afterEach(async () => {
+    await testDBs.drop(cvrDb);
+  });
+
+  test('complete purge', async () => {
+    expect(await purger.purgeInactiveCVRs(1000)).toEqual({
+      purged: 3,
+      remaining: 0,
+    });
+    expect(await getAllState(cvrDb)).toMatchObject({
+      clients: [
+        {clientGroupID: 'new-1'},
+        {clientGroupID: 'new-2'},
+        {clientGroupID: 'new-3'},
+      ],
+      desires: [
+        {clientGroupID: 'new-1'},
+        {clientGroupID: 'new-2'},
+        {clientGroupID: 'new-3'},
+      ],
+      instances: [
+        {clientGroupID: 'new-1'},
+        {clientGroupID: 'new-2'},
+        {clientGroupID: 'new-3'},
+      ],
+      queries: [
+        {clientGroupID: 'new-1'},
+        {clientGroupID: 'new-2'},
+        {clientGroupID: 'new-3'},
+      ],
+      rows: [
+        {clientGroupID: 'new-1'},
+        {clientGroupID: 'new-2'},
+        {clientGroupID: 'new-3'},
+      ],
+    });
+  });
+
+  test('incremental purge', async () => {
+    expect(await purger.purgeInactiveCVRs(2)).toEqual({
+      purged: 2,
+      remaining: 1,
+    });
+    expect(await getAllState(cvrDb)).toMatchObject({
+      clients: [
+        {clientGroupID: 'new-1'},
+        {clientGroupID: 'old-1'},
+        {clientGroupID: 'new-2'},
+        {clientGroupID: 'new-3'},
+      ],
+      desires: [
+        {clientGroupID: 'new-1'},
+        {clientGroupID: 'old-1'},
+        {clientGroupID: 'new-2'},
+        {clientGroupID: 'new-3'},
+      ],
+      instances: [
+        {clientGroupID: 'new-1'},
+        {clientGroupID: 'old-1'},
+        {clientGroupID: 'new-2'},
+        {clientGroupID: 'new-3'},
+      ],
+      queries: [
+        {clientGroupID: 'new-1'},
+        {clientGroupID: 'old-1'},
+        {clientGroupID: 'new-2'},
+        {clientGroupID: 'new-3'},
+      ],
+      rows: [
+        {clientGroupID: 'new-1'},
+        {clientGroupID: 'old-1'},
+        {clientGroupID: 'new-2'},
+        {clientGroupID: 'new-3'},
+      ],
+    });
+
+    expect(await purger.purgeInactiveCVRs(2)).toEqual({
+      purged: 1,
+      remaining: 0,
+    });
+    expect(await getAllState(cvrDb)).toMatchObject({
+      clients: [
+        {clientGroupID: 'new-1'},
+        {clientGroupID: 'new-2'},
+        {clientGroupID: 'new-3'},
+      ],
+      desires: [
+        {clientGroupID: 'new-1'},
+        {clientGroupID: 'new-2'},
+        {clientGroupID: 'new-3'},
+      ],
+      instances: [
+        {clientGroupID: 'new-1'},
+        {clientGroupID: 'new-2'},
+        {clientGroupID: 'new-3'},
+      ],
+      queries: [
+        {clientGroupID: 'new-1'},
+        {clientGroupID: 'new-2'},
+        {clientGroupID: 'new-3'},
+      ],
+      rows: [
+        {clientGroupID: 'new-1'},
+        {clientGroupID: 'new-2'},
+        {clientGroupID: 'new-3'},
+      ],
+    });
+  });
+
+  test('purge succeeds if cvrs are locked', async () => {
+    const {promise: rowLocked, resolve: signalRowLocked} = resolver();
+    const {promise: canReleaseRowLock, resolve: releaseRowLock} = resolver();
+
+    // Simulate a concurrent view-syncer update of cvr "old-3", which otherwise
+    // looks eligible for purging.
+    void cvrDb.begin(async sql => {
+      await sql`
+        SELECT * FROM ${sql(cvrSchema(SHARD))}.instances
+          WHERE "clientGroupID" = 'old-3'
+          FOR UPDATE`;
+
+      signalRowLocked();
+
+      // Hold the FOR UPDATE row lock until the test calls releaseRowLock().
+      await canReleaseRowLock;
+    });
+
+    await rowLocked;
+
+    expect(await purger.purgeInactiveCVRs(1000)).toEqual({
+      purged: 2,
+      remaining: 1,
+    });
+    expect(await getAllState(cvrDb)).toMatchObject({
+      clients: [
+        {clientGroupID: 'new-1'},
+        {clientGroupID: 'new-2'},
+        {clientGroupID: 'new-3'},
+        {clientGroupID: 'old-3'},
+      ],
+      desires: [
+        {clientGroupID: 'new-1'},
+        {clientGroupID: 'new-2'},
+        {clientGroupID: 'new-3'},
+        {clientGroupID: 'old-3'},
+      ],
+      instances: [
+        {clientGroupID: 'new-1'},
+        {clientGroupID: 'new-2'},
+        {clientGroupID: 'new-3'},
+        {clientGroupID: 'old-3'},
+      ],
+      queries: [
+        {clientGroupID: 'new-1'},
+        {clientGroupID: 'new-2'},
+        {clientGroupID: 'new-3'},
+        {clientGroupID: 'old-3'},
+      ],
+      rows: [
+        {clientGroupID: 'new-1'},
+        {clientGroupID: 'new-2'},
+        {clientGroupID: 'new-3'},
+        {clientGroupID: 'old-3'},
+      ],
+    });
+
+    // Let the locking transaction complete.
+    releaseRowLock();
+  });
+});

--- a/packages/zero-cache/src/services/view-syncer/cvr-purger.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-purger.ts
@@ -1,0 +1,112 @@
+import type {LogContext} from '@rocicorp/logger';
+import {promiseVoid} from '../../../../shared/src/resolved-promises.ts';
+import type {PostgresDB} from '../../types/pg.ts';
+import {cvrSchema, type ShardID} from '../../types/shards.ts';
+import {RunningState} from '../running-state.ts';
+import type {Service} from '../service.ts';
+
+const MINUTE = 60 * 1000;
+const MIN_PURGE_INTERVAL_MS = MINUTE;
+const MAX_PURGE_INTERVAL_MS = 16 * MINUTE;
+const DEFAULT_CVRS_PER_PURGE = 1000;
+
+export class CVRPurger implements Service {
+  readonly id = 'reaper';
+
+  readonly #lc: LogContext;
+  readonly #db: PostgresDB;
+  readonly #schema: string;
+  readonly #inactivityThresholdMs: number;
+  readonly #state = new RunningState('reaper');
+
+  constructor(
+    lc: LogContext,
+    db: PostgresDB,
+    shard: ShardID,
+    inactivityThresholdMs: number,
+  ) {
+    this.#lc = lc;
+    this.#db = db;
+    this.#schema = cvrSchema(shard);
+    this.#inactivityThresholdMs = inactivityThresholdMs;
+  }
+
+  async run() {
+    let purgeable: number | undefined;
+    let maxCVRsPerPurge = DEFAULT_CVRS_PER_PURGE;
+    let purgeInterval = MIN_PURGE_INTERVAL_MS;
+
+    while (this.#state.shouldRun()) {
+      try {
+        const {purged, remaining} =
+          await this.purgeInactiveCVRs(maxCVRsPerPurge);
+
+        if (purgeable !== undefined && remaining > purgeable) {
+          // If the number of purgeable CVRs has grown even after the purge,
+          // increase the number purged per round to achieve a steady state.
+          maxCVRsPerPurge += DEFAULT_CVRS_PER_PURGE;
+          this.#lc.info?.(`increased CVRs per purge to ${maxCVRsPerPurge}`);
+        }
+        purgeable = remaining;
+
+        purgeInterval =
+          purgeable > 0
+            ? MIN_PURGE_INTERVAL_MS
+            : Math.min(purgeInterval * 2, MAX_PURGE_INTERVAL_MS);
+        this.#lc.info?.(
+          `purged ${purged} inactive CVRs. Next purge in ${purgeInterval} ms`,
+        );
+        await this.#state.sleep(purgeInterval);
+      } catch (e) {
+        this.#lc.warn?.(`error encountered while garbage collecting CVRs`, e);
+      }
+    }
+  }
+
+  // Exported for testing.
+  purgeInactiveCVRs(
+    maxCVRs: number,
+  ): Promise<{purged: number; remaining: number}> {
+    return this.#db.begin(async sql => {
+      const threshold = Date.now() - this.#inactivityThresholdMs;
+      // Implementation note: `FOR UPDATE` will prevent a syncer from
+      // concurrently updating the CVR, since the update also performs
+      // a `SELECT ... FOR UPDATE`, instead causing that update to
+      // fail, which will cause the client to create a new CVR.
+      //
+      // `SKIP LOCKED` will skip over CVRs that a syncer is already
+      // in the process of updating. In this manner, an in-progress
+      // update effectively excludes the CVR from the purge.
+      const ids = (
+        await sql<{clientGroupID: string}[]>`
+          SELECT "clientGroupID" FROM ${sql(this.#schema)}.instances
+            WHERE "lastActive" < ${threshold}
+            ORDER BY "lastActive" ASC
+            LIMIT ${maxCVRs}
+            FOR UPDATE SKIP LOCKED
+      `.values()
+      ).flat();
+
+      if (ids.length > 0) {
+        // Rows only need to be deleted from the "instances" and "rowsVersion" tables.
+        // Deletes will cascade through the other tables via foreign key references.
+        for (const table of ['instances', 'rowsVersion']) {
+          await sql`
+            DELETE FROM ${sql(this.#schema)}.${sql(table)} WHERE "clientGroupID" IN ${sql(ids)}`;
+        }
+      }
+
+      const [{remaining}] = await sql<[{remaining: bigint}]>`
+        SELECT COUNT(*) AS remaining FROM ${sql(this.#schema)}.instances
+          WHERE "lastActive" < ${threshold}
+      `;
+
+      return {purged: ids.length, remaining: Number(remaining)};
+    });
+  }
+
+  stop(): Promise<void> {
+    this.#state.stop(this.#lc);
+    return promiseVoid;
+  }
+}

--- a/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
@@ -6,6 +6,8 @@ import {DEFAULT_TTL_MS} from '../../../../zql/src/query/ttl.ts';
 import {testDBs} from '../../test/db.ts';
 import type {PostgresDB} from '../../types/pg.ts';
 import {cvrSchema, upstreamSchema} from '../../types/shards.ts';
+import {id} from '../../types/sql.ts';
+import {getMutationsTableDefinition} from '../change-source/pg/schema/shard.ts';
 import type {PatchToVersion} from './client-handler.ts';
 import {
   ConcurrentModificationException,
@@ -34,8 +36,6 @@ import {
 } from './schema/cvr.ts';
 import type {ClientQueryRecord, CVRVersion, RowID} from './schema/types.ts';
 import {ttlClockFromNumber} from './ttl-clock.ts';
-import {getMutationsTableDefinition} from '../change-source/pg/schema/shard.ts';
-import {id} from '../../types/sql.ts';
 
 const APP_ID = 'dapp';
 const SHARD_NUM = 3;
@@ -65,11 +65,11 @@ describe('view-syncer/cvr', () => {
       const {instances, rowsVersion, desires} = state;
       if (instances && !rowsVersion) {
         state = {
-          ...state,
           rowsVersion: instances.map(({clientGroupID, version}) => ({
             clientGroupID,
             version,
           })),
+          ...state,
         };
       }
 

--- a/packages/zero-cache/src/services/view-syncer/schema/init.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/init.ts
@@ -133,6 +133,31 @@ export async function initViewSyncerSchema(
     },
   };
 
+  const migratedV13ToV14: Migration = {
+    migrateSchema: async (_, sql) => {
+      await sql`
+        CREATE INDEX instances_last_active ON ${sql(schema)}.instances ("lastActive");
+      `;
+
+      // Update / add foreign key constraints to cascade deletes.
+      for (const [table, reference] of [
+        ['clients', 'instances'],
+        ['queries', 'instances'],
+        ['rows', 'rowsVersion'],
+      ] as [string, string][]) {
+        const constraint = sql(`fk_${table}_client_group`);
+        await sql`
+          ALTER TABLE ${sql(schema)}.${sql(table)} DROP CONSTRAINT IF EXISTS ${constraint}`;
+        await sql`
+          ALTER TABLE ${sql(schema)}.${sql(table)} ADD CONSTRAINT ${constraint}
+            FOREIGN KEY("clientGroupID")
+            REFERENCES ${sql(schema)}.${sql(reference)} ("clientGroupID")
+            ON DELETE CASCADE;
+        `;
+      }
+    },
+  };
+
   const schemaVersionMigrationMap: IncrementalMigrationMap = {
     2: migrateV1toV2,
     3: migrateV2ToV3,
@@ -154,6 +179,10 @@ export async function initViewSyncerSchema(
     12: migratedV11ToV12,
     // V13 adds instances."ttlClock"
     13: migratedV12ToV13,
+    // V14 adds an index on instances."lastActive" and a FK constraint
+    // from rows."clientGroupID" to rowsVersion."clientGroupID" for
+    // garbage collection
+    14: migratedV13ToV14,
   };
 
   await runSchemaMigrations(


### PR DESCRIPTION
### Feature

Adds a periodic process that incrementally purges cvrs that have not been accessed for more than `ZERO_CVR_GARBAGE_COLLECTION_INACTIVITY_THRESHOLD_HOURS`, which defaults to 48 hours.

### Mechanism

The `reaper` process purges up to 1000 cvrs per iteration, increasing the number if necessary to reach a steady state. Iterations happen every minute while there are remaining cvrs to purge, with the interval increasing exponentially up to 16 minutes when there are no cvrs to purge.

### Schema Migration

A backwards-compatible schema migration on the CVR db:
* creates an index over the existing `lastActive` column on the `instances` table
* configures all foreign key references to cascade deletes to simplify the purge implementation