### PR TITLE
chore(zero): split `runAst` out into its own function

### DIFF
--- a/packages/analyze-query/src/bin-analyze.ts
+++ b/packages/analyze-query/src/bin-analyze.ts
@@ -326,7 +326,15 @@ async function runHash(hash: string) {
   });
 }
 
+if (config.outputSyncedRows) {
+  colorConsole.log(chalk.blue.bold('=== Synced Rows: ===\n'));
+  for (const [table, rows] of Object.entries(result.syncedRows)) {
+    colorConsole.log(chalk.bold(table + ':'), rows);
+  }
+}
+
 colorConsole.log(chalk.blue.bold('=== Query Stats: ===\n'));
+colorConsole.log(chalk.bold('total synced rows:'), result.syncedRowCount);
 showStats();
 if (config.outputVendedRows) {
   colorConsole.log(chalk.blue.bold('=== Vended Rows: ===\n'));

--- a/packages/analyze-query/src/bin-analyze.ts
+++ b/packages/analyze-query/src/bin-analyze.ts
@@ -5,40 +5,30 @@ import {astToZQL} from '../../ast-to-zql/src/ast-to-zql.ts';
 import {formatOutput} from '../../ast-to-zql/src/format.ts';
 import {logLevel, logOptions} from '../../otel/src/log-options.ts';
 import {testLogConfig} from '../../otel/src/test-log-config.ts';
-import {assert} from '../../shared/src/asserts.ts';
 import '../../shared/src/dotenv.ts';
 import {colorConsole, createLogContext} from '../../shared/src/logging.ts';
 import {must} from '../../shared/src/must.ts';
 import {parseOptions} from '../../shared/src/options.ts';
 import * as v from '../../shared/src/valita.ts';
-import {transformAndHashQuery} from '../../zero-cache/src/auth/read-authorizer.ts';
 import {
   appOptions,
   shardOptions,
   ZERO_ENV_VAR_PREFIX,
   zeroOptions,
 } from '../../zero-cache/src/config/zero-config.ts';
-import {computeZqlSpecs} from '../../zero-cache/src/db/lite-tables.ts';
 import {
   deployPermissionsOptions,
   loadSchemaAndPermissions,
 } from '../../zero-cache/src/scripts/permissions.ts';
-import {hydrate} from '../../zero-cache/src/services/view-syncer/pipeline-driver.ts';
 import {pgClient} from '../../zero-cache/src/types/pg.ts';
 import {getShardID, upstreamSchema} from '../../zero-cache/src/types/shards.ts';
-import {
-  mapAST,
-  type AST,
-  type CompoundKey,
-} from '../../zero-protocol/src/ast.ts';
-import type {Row} from '../../zero-protocol/src/data.ts';
-import {hashOfAST} from '../../zero-protocol/src/query-hash.ts';
+import {type AST, type CompoundKey} from '../../zero-protocol/src/ast.ts';
 import type {Schema} from '../../zero-schema/src/builder/schema-builder.ts';
 import {
   clientToServer,
   serverToClient,
 } from '../../zero-schema/src/name-mapper.ts';
-import {buildPipeline} from '../../zql/src/builder/builder.ts';
+
 import {MemoryStorage} from '../../zql/src/ivm/memory-storage.ts';
 import type {QueryDelegate} from '../../zql/src/query/query-delegate.ts';
 import {completedAST, newQuery} from '../../zql/src/query/query-impl.ts';
@@ -47,6 +37,7 @@ import {Database} from '../../zqlite/src/db.ts';
 import {runtimeDebugFlags} from '../../zql/src/builder/debug-delegate.ts';
 import {TableSource} from '../../zqlite/src/table-source.ts';
 import {Debug} from '../../zql/src/builder/debug-delegate.ts';
+import {runAst, type RunResult} from './run-ast.ts';
 
 const options = {
   schema: deployPermissionsOptions.schema,
@@ -262,82 +253,29 @@ const host: QueryDelegate = {
   addMetric() {},
 };
 
-let start: number;
-let end: number;
+let result: RunResult;
 
 if (config.ast) {
   // the user likely has a transformed AST since the wire and storage formats are the transformed AST
-  [start, end] = await runAst(JSON.parse(config.ast), true);
+  result = await runAst(lc, JSON.parse(config.ast), true, {
+    applyPermissions: config.applyPermissions,
+    authData: config.authData,
+    clientToServerMapper,
+    permissions,
+    outputSyncedRows: config.outputSyncedRows,
+    db,
+    host,
+  });
 } else if (config.query) {
-  [start, end] = await runQuery(config.query);
+  result = await runQuery(config.query);
 } else if (config.hash) {
-  [start, end] = await runHash(config.hash);
+  result = await runHash(config.hash);
 } else {
   colorConsole.error('No query or AST or hash provided');
   process.exit(1);
 }
 
-async function runAst(
-  ast: AST,
-  isTransformed: boolean,
-): Promise<[number, number]> {
-  if (!isTransformed) {
-    // map the AST to server names if not already transformed
-    ast = mapAST(ast, clientToServerMapper);
-  }
-  if (config.applyPermissions) {
-    const authData = config.authData ? JSON.parse(config.authData) : {};
-    if (!config.authData) {
-      colorConsole.warn(
-        'No auth data provided. Permission rules will compare to `NULL` wherever an auth data field is referenced.',
-      );
-    }
-    ast = transformAndHashQuery(
-      lc,
-      clientGroupID,
-      ast,
-      permissions,
-      authData,
-      false,
-    ).transformedAst;
-    colorConsole.log(chalk.blue.bold('\n\n=== Query After Permissions: ===\n'));
-    colorConsole.log(await formatOutput(ast.table + astToZQL(ast)));
-  }
-
-  const tableSpecs = computeZqlSpecs(lc, db);
-  const pipeline = buildPipeline(ast, host, 'query-id');
-
-  const start = performance.now();
-
-  if (config.outputSyncedRows) {
-    colorConsole.log(chalk.blue.bold('\n\n=== Synced rows: ===\n'));
-  }
-  let syncedRowCount = 0;
-  const rowsByTable: Record<string, Row[]> = {};
-  for (const rowChange of hydrate(pipeline, hashOfAST(ast), tableSpecs)) {
-    assert(rowChange.type === 'add');
-    syncedRowCount++;
-    if (config.outputSyncedRows) {
-      let rows: Row[] = rowsByTable[rowChange.table];
-      if (!rows) {
-        rows = [];
-        rowsByTable[rowChange.table] = rows;
-      }
-      rows.push(rowChange.row);
-    }
-  }
-  if (config.outputSyncedRows) {
-    for (const [source, rows] of Object.entries(rowsByTable)) {
-      colorConsole.log(chalk.bold(`${source}:`), rows);
-    }
-    colorConsole.log(chalk.bold('total synced rows:'), syncedRowCount);
-  }
-
-  const end = performance.now();
-  return [start, end];
-}
-
-function runQuery(queryString: string): Promise<[number, number]> {
+function runQuery(queryString: string): Promise<RunResult> {
   const z = {
     query: Object.fromEntries(
       Object.entries(schema.tables).map(([name]) => [
@@ -351,7 +289,15 @@ function runQuery(queryString: string): Promise<[number, number]> {
   const q: Query<Schema, string, PullRow<string, Schema>> = f(z);
 
   const ast = completedAST(q);
-  return runAst(ast, false);
+  return runAst(lc, ast, false, {
+    applyPermissions: config.applyPermissions,
+    authData: config.authData,
+    clientToServerMapper,
+    permissions,
+    outputSyncedRows: config.outputSyncedRows,
+    db,
+    host,
+  });
 }
 
 async function runHash(hash: string) {
@@ -369,7 +315,15 @@ async function runHash(hash: string) {
   const ast = rows[0].clientAST as AST;
   colorConsole.log(await formatOutput(ast.table + astToZQL(ast)));
 
-  return runAst(ast, true);
+  return runAst(lc, ast, true, {
+    applyPermissions: config.applyPermissions,
+    authData: config.authData,
+    clientToServerMapper,
+    permissions,
+    outputSyncedRows: config.outputSyncedRows,
+    db,
+    host,
+  });
 }
 
 colorConsole.log(chalk.blue.bold('=== Query Stats: ===\n'));
@@ -410,7 +364,11 @@ function showStats() {
     chalk.bold('total rows considered:'),
     colorRowsConsidered(totalRowsConsidered),
   );
-  colorConsole.log(chalk.bold('time:'), colorTime(end - start), 'ms');
+  colorConsole.log(
+    chalk.bold('time:'),
+    colorTime(result.end - result.start),
+    'ms',
+  );
 }
 
 function explainQueries() {

--- a/packages/analyze-query/src/run-ast.ts
+++ b/packages/analyze-query/src/run-ast.ts
@@ -1,0 +1,110 @@
+import type {AST} from '../../zero-protocol/src/ast.ts';
+import {buildPipeline} from '../../zql/src/builder/builder.ts';
+import {hydrate} from '../../zero-cache/src/services/view-syncer/pipeline-driver.ts';
+import {transformAndHashQuery} from '../../zero-cache/src/auth/read-authorizer.ts';
+import {assert} from '../../shared/src/asserts.ts';
+import {computeZqlSpecs} from '../../zero-cache/src/db/lite-tables.ts';
+import type {Row} from '../../zero-protocol/src/data.ts';
+import {hashOfAST} from '../../zero-protocol/src/query-hash.ts';
+import {mapAST} from '../../zero-protocol/src/ast.ts';
+import type {NameMapper} from '../../zero-schema/src/name-mapper.ts';
+import {LogContext} from '@rocicorp/logger';
+import type {PermissionsConfig} from '../../zero-schema/src/compiled-permissions.ts';
+import {astToZQL} from '../../ast-to-zql/src/ast-to-zql.ts';
+import {formatOutput} from '../../ast-to-zql/src/format.ts';
+import type {Database} from '../../zqlite/src/db.ts';
+import type {QueryDelegate} from '../../zql/src/query/query-delegate.ts';
+import {must} from '../../shared/src/must.ts';
+import type {
+  RowCountsBySource,
+  RowsBySource,
+} from '../../zql/src/builder/debug-delegate.ts';
+
+export type RunResult = {
+  warnings: string[];
+  syncedRows: Record<string, Row[]>;
+  syncedRowCount: number;
+  start: number;
+  end: number;
+  afterPermissions: string | undefined;
+  vendedRowCounts: RowCountsBySource | undefined;
+  vendedRows: RowsBySource | undefined;
+};
+
+export async function runAst(
+  lc: LogContext,
+  ast: AST,
+  isTransformed: boolean,
+  options: {
+    applyPermissions: boolean;
+    authData: string | undefined;
+    clientToServerMapper: NameMapper | undefined;
+    permissions: PermissionsConfig;
+    outputSyncedRows: boolean;
+    db: Database;
+    host: QueryDelegate;
+  },
+): Promise<RunResult> {
+  const {clientToServerMapper, permissions, host, db} = options;
+  const result: RunResult = {
+    warnings: [],
+    syncedRows: {},
+    syncedRowCount: 0,
+    start: 0,
+    end: 0,
+    afterPermissions: undefined,
+    vendedRowCounts: host.debug?.getVendedRowCounts(),
+    vendedRows: host.debug?.getVendedRows(),
+  };
+
+  if (!isTransformed) {
+    // map the AST to server names if not already transformed
+    ast = mapAST(ast, must(clientToServerMapper));
+  }
+  if (options.applyPermissions) {
+    const authData = options.authData ? JSON.parse(options.authData) : {};
+    if (!options.authData) {
+      result.warnings.push(
+        'No auth data provided. Permission rules will compare to `NULL` wherever an auth data field is referenced.',
+      );
+    }
+    ast = transformAndHashQuery(
+      lc,
+      'clientGroupIDForAnalyze',
+      ast,
+      permissions,
+      authData,
+      false,
+    ).transformedAst;
+    result.afterPermissions = await formatOutput(ast.table + astToZQL(ast));
+  }
+
+  const tableSpecs = computeZqlSpecs(lc, db);
+  const pipeline = buildPipeline(ast, host, 'query-id');
+
+  const start = performance.now();
+
+  let syncedRowCount = 0;
+  const rowsByTable: Record<string, Row[]> = {};
+  for (const rowChange of hydrate(pipeline, hashOfAST(ast), tableSpecs)) {
+    assert(rowChange.type === 'add');
+    syncedRowCount++;
+    if (options.outputSyncedRows) {
+      let rows: Row[] = rowsByTable[rowChange.table];
+      if (!rows) {
+        rows = [];
+        rowsByTable[rowChange.table] = rows;
+      }
+      rows.push(rowChange.row);
+    }
+  }
+
+  const end = performance.now();
+  result.syncedRows = rowsByTable;
+  result.start = start;
+  result.end = end;
+  result.syncedRowCount = syncedRowCount;
+  result.vendedRowCounts = host.debug?.getVendedRowCounts();
+  result.vendedRows = host.debug?.getVendedRows();
+  return result;
+}

--- a/packages/zql/src/builder/debug-delegate.ts
+++ b/packages/zql/src/builder/debug-delegate.ts
@@ -7,8 +7,8 @@ export const runtimeDebugFlags = {
 
 type SourceName = string;
 type SQL = string;
-type RowCountsBySource = Map<SourceName, RowCountsByQuery>;
-type RowsBySource = Map<SourceName, RowsByQuery>;
+export type RowCountsBySource = Map<SourceName, RowCountsByQuery>;
+export type RowsBySource = Map<SourceName, RowsByQuery>;
 type RowCountsByQuery = Map<SQL, number>;
 type RowsByQuery = Map<SQL, Row[]>;
 


### PR DESCRIPTION
So we can call this from other places. Specifically the `queryz` endpoint to debug a query on a production server.