### PR TITLE
feat(zero): Add inspector metrics for query-update-server

### DIFF
--- a/packages/zero-cache/src/server/inspect-metrics-delegate.ts
+++ b/packages/zero-cache/src/server/inspect-metrics-delegate.ts
@@ -1,0 +1,61 @@
+import {assert} from '../../../shared/src/asserts.ts';
+import {mapValues} from '../../../shared/src/objects.ts';
+import {TDigest} from '../../../shared/src/tdigest.ts';
+import type {ServerMetrics as ServerMetricsJSON} from '../../../zero-protocol/src/inspect-down.ts';
+import {
+  isServerMetric,
+  type MetricMap,
+  type MetricsDelegate,
+} from '../../../zql/src/query/metrics-delegate.ts';
+
+/**
+ * Server-side metrics collected for queries during materialization and update.
+ * These metrics are reported via the inspector and complement client-side metrics.
+ */
+export type ServerMetrics = {
+  'query-materialization-server': TDigest;
+  'query-update-server': TDigest;
+};
+
+export class InspectMetricsDelegate implements MetricsDelegate {
+  readonly #globalMetrics: ServerMetrics = newMetrics();
+  readonly #perQueryServerMetrics = new Map<string, ServerMetrics>();
+
+  addMetric<K extends keyof MetricMap>(
+    metric: K,
+    value: number,
+    ...args: MetricMap[K]
+  ): void {
+    assert(isServerMetric(metric), `Invalid server metric: ${metric}`);
+    const queryID = args[0];
+
+    let serverMetrics = this.#perQueryServerMetrics.get(queryID);
+    if (!serverMetrics) {
+      serverMetrics = newMetrics();
+      this.#perQueryServerMetrics.set(queryID, serverMetrics);
+    }
+
+    serverMetrics[metric].add(value);
+    this.#globalMetrics[metric].add(value);
+  }
+
+  getMetricsJSONForQuery(queryID: string): ServerMetricsJSON | null {
+    const serverMetrics = this.#perQueryServerMetrics.get(queryID);
+    return serverMetrics ? mapValues(serverMetrics, v => v.toJSON()) : null;
+  }
+
+  getMetricsJSON() {
+    return mapValues(this.#globalMetrics, v => v.toJSON());
+  }
+
+  deleteMetricsForQuery(queryID: string): void {
+    this.#perQueryServerMetrics.delete(queryID);
+  }
+}
+
+function newMetrics(): ServerMetrics {
+  return {
+    'query-materialization-server': new TDigest(),
+    'query-update-server': new TDigest(),
+  };
+}

--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -28,6 +28,7 @@ import {Subscription} from '../types/subscription.ts';
 import {replicaFileModeSchema, replicaFileName} from '../workers/replicator.ts';
 import {Syncer} from '../workers/syncer.ts';
 import {startAnonymousTelemetry} from './anonymous-otel-start.ts';
+import {InspectMetricsDelegate} from './inspect-metrics-delegate.ts';
 import {createLogContext} from './logging.ts';
 import {startOtelAuto} from './otel-start.ts';
 
@@ -89,6 +90,7 @@ export default function runWorker(
       .withContext('clientGroupID', id)
       .withContext('instance', randomID());
     lc.debug?.(`creating view syncer`);
+    const inspectMetricsDelegate = new InspectMetricsDelegate();
     return new ViewSyncerService(
       config,
       logger,
@@ -104,10 +106,12 @@ export default function runWorker(
         shard,
         operatorStorage.createClientGroupStorage(id),
         id,
+        inspectMetricsDelegate,
       ),
       sub,
       drainCoordinator,
       config.log.slowHydrateThreshold,
+      inspectMetricsDelegate,
     );
   };
 

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -7,12 +7,20 @@ import type {ClientSchema} from '../../../../zero-protocol/src/client-schema.ts'
 import type {Row} from '../../../../zero-protocol/src/data.ts';
 import type {PrimaryKey} from '../../../../zero-protocol/src/primary-key.ts';
 import {buildPipeline} from '../../../../zql/src/builder/builder.ts';
+import {
+  Debug,
+  runtimeDebugFlags,
+} from '../../../../zql/src/builder/debug-delegate.ts';
 import type {Change} from '../../../../zql/src/ivm/change.ts';
 import type {Node} from '../../../../zql/src/ivm/data.ts';
 import type {Input, Storage} from '../../../../zql/src/ivm/operator.ts';
 import type {SourceSchema} from '../../../../zql/src/ivm/schema.ts';
-import type {Source, SourceChange} from '../../../../zql/src/ivm/source.ts';
-import {runtimeDebugFlags} from '../../../../zql/src/builder/debug-delegate.ts';
+import type {
+  Source,
+  SourceChange,
+  SourceInput,
+} from '../../../../zql/src/ivm/source.ts';
+import {MeasurePushOperator} from '../../../../zql/src/query/measure-push-operator.ts';
 import {TableSource} from '../../../../zqlite/src/table-source.ts';
 import {
   reloadPermissionsIfChanged,
@@ -22,6 +30,7 @@ import type {LogConfig} from '../../config/zero-config.ts';
 import {computeZqlSpecs} from '../../db/lite-tables.ts';
 import type {LiteAndZqlSpec, LiteTableSpec} from '../../db/specs.ts';
 import {getOrCreateHistogram} from '../../observability/metrics.ts';
+import type {InspectMetricsDelegate} from '../../server/inspect-metrics-delegate.ts';
 import type {RowKey} from '../../types/row-key.ts';
 import type {SchemaVersions} from '../../types/schema-versions.ts';
 import type {ShardID} from '../../types/shards.ts';
@@ -33,7 +42,6 @@ import {
   Snapshotter,
   type SnapshotDiff,
 } from './snapshotter.ts';
-import {Debug} from '../../../../zql/src/builder/debug-delegate.ts';
 
 export type RowAdd = {
   readonly type: 'add';
@@ -88,6 +96,7 @@ export class PipelineDriver {
       'Time to advance all queries for a given client group for in response to a single change.',
     unit: 's',
   });
+  readonly #inspectMetricsDelegate: InspectMetricsDelegate;
 
   constructor(
     lc: LogContext,
@@ -96,12 +105,14 @@ export class PipelineDriver {
     shardID: ShardID,
     storage: ClientGroupStorage,
     clientGroupID: string,
+    inspectMetricsDelegate: InspectMetricsDelegate,
   ) {
     this.#lc = lc.withContext('clientGroupID', clientGroupID);
     this.#snapshotter = snapshotter;
     this.#storage = storage;
     this.#shardID = shardID;
     this.#logConfig = logConfig;
+    this.#inspectMetricsDelegate = inspectMetricsDelegate;
   }
 
   /**
@@ -240,14 +251,14 @@ export class PipelineDriver {
   }
 
   /**
-   * Adds a pipeline for the query. The method will hydrated the query using
-   * the the driver's current snapshot of the database and return a stream
-   * of results. Henceforth, updates to the query will be returned when the
-   * driver is {@link advance}d. The query and its pipeline can be removed with
+   * Adds a pipeline for the query. The method will hydrate the query using the
+   * driver's current snapshot of the database and return a stream of results.
+   * Henceforth, updates to the query will be returned when the driver is
+   * {@link advance}d. The query and its pipeline can be removed with
    * {@link removeQuery()}.
    *
-   * If a query with an identical hash has already been added, this method
-   * is a no-op and no RowChanges are generated.
+   * If a query with an identical hash has already been added, this method is a
+   * no-op and no RowChanges are generated.
    *
    * @param timer The caller-controlled {@link Timer} used to determine the
    *        final hydration time. (The caller may pause and resume the timer
@@ -255,13 +266,14 @@ export class PipelineDriver {
    * @return The rows from the initial hydration of the query.
    */
   *addQuery(
-    hash: string,
+    transformationHash: string,
+    queryID: string,
     query: AST,
     timer: {totalElapsed: () => number},
   ): Iterable<RowChange> {
     assert(this.initialized());
-    if (this.#pipelines.has(hash)) {
-      this.#lc.info?.(`query ${hash} already added`, query);
+    if (this.#pipelines.has(transformationHash)) {
+      this.#lc.info?.(`query ${transformationHash} already added`, query);
       return;
     }
     const debugDelegate = runtimeDebugFlags.trackRowsVended
@@ -273,30 +285,36 @@ export class PipelineDriver {
         debug: debugDelegate,
         getSource: name => this.#getSource(name),
         createStorage: () => this.#createStorage(),
-        decorateSourceInput: input => input,
+        decorateSourceInput: (input: SourceInput, queryID: string): Input =>
+          new MeasurePushOperator(
+            input,
+            queryID,
+            this.#inspectMetricsDelegate,
+            'query-update-server',
+          ),
         decorateInput: input => input,
         addEdge() {},
         decorateFilterInput: input => input,
       },
-      hash,
+      queryID,
     );
     const schema = input.getSchema();
     input.setOutput({
       push: change => {
         const streamer = this.#streamer;
         assert(streamer, 'must #startAccumulating() before pushing changes');
-        streamer.accumulate(hash, schema, [change]);
+        streamer.accumulate(transformationHash, schema, [change]);
       },
     });
 
-    yield* hydrate(input, hash, this.#tableSpecs);
+    yield* hydrate(input, transformationHash, this.#tableSpecs);
 
     const hydrationTimeMs = timer.totalElapsed();
     if (runtimeDebugFlags.trackRowCountsVended) {
       if (hydrationTimeMs > this.#logConfig.slowHydrateThreshold) {
         let totalRowsConsidered = 0;
         const lc = this.#lc
-          .withContext('hash', hash)
+          .withContext('hash', transformationHash)
           .withContext('hydrationTimeMs', hydrationTimeMs);
         for (const tableName of this.#tables.keys()) {
           const entries = [
@@ -319,7 +337,7 @@ export class PipelineDriver {
     // Note: This hydrationTime is a wall-clock overestimate, as it does
     // not take time slicing into account. The view-syncer resets this
     // to a more precise processing-time measurement with setHydrationTime().
-    this.#pipelines.set(hash, {input, hydrationTimeMs});
+    this.#pipelines.set(transformationHash, {input, hydrationTimeMs});
   }
 
   /**

--- a/packages/zero-cache/src/services/view-syncer/view-syncer-test-util.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer-test-util.ts
@@ -27,6 +27,7 @@ import {
 import type {ExpressionBuilder} from '../../../../zql/src/query/expression.ts';
 import {Database} from '../../../../zqlite/src/db.ts';
 import type {ZeroConfig} from '../../config/zero-config.ts';
+import {InspectMetricsDelegate} from '../../server/inspect-metrics-delegate.ts';
 import {testDBs} from '../../test/db.ts';
 import {DbFile} from '../../test/lite.ts';
 import {upstreamSchema} from '../../types/shards.ts';
@@ -666,6 +667,7 @@ export async function setup(
   const operatorStorage = new DatabaseStorage(
     storageDB,
   ).createClientGroupStorage(serviceID);
+  const inspectMetricsDelegate = new InspectMetricsDelegate();
   const vs = new ViewSyncerService(
     {query: queryConfig},
     lc,
@@ -681,10 +683,12 @@ export async function setup(
       SHARD,
       operatorStorage,
       'view-syncer.pg-test.ts',
+      inspectMetricsDelegate,
     ),
     stateChanges,
     drainCoordinator,
     100,
+    inspectMetricsDelegate,
     undefined,
     setTimeoutFn,
   );

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -3501,4 +3501,51 @@ describe('view-syncer/service', () => {
       ]
     `);
   });
+
+  test('inspect metrics op returns server metrics', async () => {
+    const {queue: client} = connectWithQueueAndSource(SYNC_CONTEXT, [
+      {op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY},
+    ]);
+
+    // Wait for initial hydration to complete
+    await nextPoke(client);
+    stateChanges.push({state: 'version-ready'});
+    await nextPoke(client);
+
+    // Trigger query materializations to generate metrics
+    replicator.processTransaction(
+      'txn-1',
+      messages.insert('issues', {
+        id: 'test-issue',
+        title: 'Test Issue',
+        owner: '100',
+        big: 1000,
+        json: null,
+        parent: null,
+      }),
+    );
+    stateChanges.push({state: 'version-ready'});
+    await expectNoPokes(client);
+
+    // Now call the inspect method and expect it to send a response
+    const inspectId = 'test-metrics-inspect';
+
+    // Call inspect and wait for the response to come through the client queue
+    await vs.inspect(SYNC_CONTEXT, ['inspect', {op: 'metrics', id: inspectId}]);
+
+    const msg = await client.dequeue();
+    expect(msg).toMatchObject([
+      'inspect',
+      {
+        id: 'test-metrics-inspect',
+        op: 'metrics',
+        value: {
+          'query-materialization-server': expect.arrayContaining([
+            expect.any(Number),
+          ]),
+          'query-update-server': expect.arrayContaining([expect.any(Number)]),
+        },
+      },
+    ]);
+  });
 });

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -14,9 +14,7 @@ import {assert, unreachable} from '../../../../shared/src/asserts.ts';
 import {stringify} from '../../../../shared/src/bigint-json.ts';
 import {CustomKeyMap} from '../../../../shared/src/custom-key-map.ts';
 import {must} from '../../../../shared/src/must.ts';
-import {mapValues} from '../../../../shared/src/objects.ts';
 import {randInt} from '../../../../shared/src/rand.ts';
-import {TDigest} from '../../../../shared/src/tdigest.ts';
 import type {AST} from '../../../../zero-protocol/src/ast.ts';
 import type {ChangeDesiredQueriesMessage} from '../../../../zero-protocol/src/change-desired-queries.ts';
 import type {
@@ -42,6 +40,7 @@ import {
   getOrCreateHistogram,
   getOrCreateUpDownCounter,
 } from '../../observability/metrics.ts';
+import {InspectMetricsDelegate} from '../../server/inspect-metrics-delegate.ts';
 import {ErrorForClient, getLogLevel} from '../../types/error-for-client.ts';
 import type {PostgresDB} from '../../types/pg.ts';
 import {rowIDString, type RowKey} from '../../types/row-key.ts';
@@ -103,14 +102,6 @@ export type SyncContext = {
   readonly schemaVersion: number | null;
   readonly tokenData: TokenData | undefined;
   readonly httpCookie: string | undefined;
-};
-
-/**
- * Server-side metrics collected for queries during materialization.
- * These metrics are reported via the inspector and complement client-side metrics.
- */
-export type ServerMetrics = {
-  'query-materialization-server': TDigest;
 };
 
 const tracer = trace.getTracer('view-syncer', version);
@@ -249,12 +240,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     },
   );
 
-  // Store per-query server-side materialization metrics for inspector
-  readonly #perQueryServerMetrics = new Map<string, ServerMetrics>();
-
-  readonly #serverMetrics: ServerMetrics = {
-    'query-materialization-server': new TDigest(),
-  };
+  readonly #inspectMetricsDelegate: InspectMetricsDelegate;
 
   readonly #config: Pick<ZeroConfig, 'serverVersion'>;
 
@@ -270,6 +256,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     versionChanges: Subscription<ReplicaState>,
     drainCoordinator: DrainCoordinator,
     slowHydrateThreshold: number,
+    inspectMetricsDelegate: InspectMetricsDelegate,
     keepaliveMs = DEFAULT_KEEPALIVE_MS,
     setTimeoutFn: SetTimeout = setTimeout.bind(globalThis),
   ) {
@@ -284,6 +271,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     this.#drainCoordinator = drainCoordinator;
     this.#keepaliveMs = keepaliveMs;
     this.#slowHydrateThreshold = slowHydrateThreshold;
+    this.#inspectMetricsDelegate = inspectMetricsDelegate;
     this.#cvrStore = new CVRStore(
       lc,
       cvrDb,
@@ -1079,6 +1067,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           span.setAttribute('table', transformedAst.table);
           for (const _ of this.#pipelines.addQuery(
             transformationHash,
+            hash,
             transformedAst,
             timer.start(),
           )) {
@@ -1102,17 +1091,11 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   }
 
   #addQueryMaterializationServerMetric(queryID: string, elapsed: number) {
-    let perQueryMetrics = this.#perQueryServerMetrics.get(queryID);
-    if (!perQueryMetrics) {
-      this.#perQueryServerMetrics.set(
-        queryID,
-        (perQueryMetrics = {
-          'query-materialization-server': new TDigest(),
-        }),
-      );
-    }
-    perQueryMetrics['query-materialization-server'].add(elapsed);
-    this.#serverMetrics['query-materialization-server'].add(elapsed);
+    this.#inspectMetricsDelegate.addMetric(
+      'query-materialization-server',
+      elapsed,
+      queryID,
+    );
   }
 
   /**
@@ -1337,7 +1320,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       for (const q of removeQueries) {
         this.#pipelines.removeQuery(q.transformationHash);
         // Remove per-query server metrics when query is deleted
-        this.#perQueryServerMetrics.delete(q.id);
+        this.#inspectMetricsDelegate.deleteMetricsForQuery(q.id);
       }
       for (const hash of unhydrateQueries) {
         this.#pipelines.removeQuery(hash);
@@ -1345,7 +1328,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         const ids = hashToIDs.get(hash);
         if (ids) {
           for (const id of ids) {
-            this.#perQueryServerMetrics.delete(id);
+            this.#inspectMetricsDelegate.deleteMetricsForQuery(id);
           }
         }
       }
@@ -1365,7 +1348,12 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
             .withContext('transformationHash', q.transformationHash);
           lc.debug?.(`adding pipeline for query`, q.ast);
 
-          yield* pipelines.addQuery(q.transformationHash, q.ast, timer.start());
+          yield* pipelines.addQuery(
+            q.transformationHash,
+            q.id,
+            q.ast,
+            timer.start(),
+          );
           const elapsed = timer.stop();
           totalProcessTime += elapsed;
 
@@ -1712,20 +1700,12 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         );
 
         // Enhance query rows with server-side materialization metrics
-        const enhancedRows = queryRows.map(row => {
-          const serverMetrics = this.#perQueryServerMetrics.get(row.queryID);
-          const metrics = serverMetrics
-            ? {
-                'query-materialization-server':
-                  serverMetrics['query-materialization-server'].toJSON(),
-              }
-            : null;
-
-          return {
-            ...row,
-            metrics,
-          };
-        });
+        const enhancedRows = queryRows.map(row => ({
+          ...row,
+          metrics: this.#inspectMetricsDelegate.getMetricsJSONForQuery(
+            row.queryID,
+          ),
+        }));
 
         client.sendInspectResponse(lc, {
           op: 'queries',
@@ -1736,14 +1716,10 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       }
 
       case 'metrics': {
-        const serverMetrics = mapValues(this.#serverMetrics, metric =>
-          metric.toJSON(),
-        );
-
         client.sendInspectResponse(lc, {
           op: 'metrics',
           id: body.id,
-          value: serverMetrics,
+          value: this.#inspectMetricsDelegate.getMetricsJSON(),
         });
         break;
       }

--- a/packages/zero-client/src/client/context.ts
+++ b/packages/zero-client/src/client/context.ts
@@ -7,6 +7,7 @@ import type {FilterInput} from '../../../zql/src/ivm/filter-operators.ts';
 import {MemoryStorage} from '../../../zql/src/ivm/memory-storage.ts';
 import type {Input, Storage} from '../../../zql/src/ivm/operator.ts';
 import type {Source, SourceInput} from '../../../zql/src/ivm/source.ts';
+import {MeasurePushOperator} from '../../../zql/src/query/measure-push-operator.ts';
 import type {MetricsDelegate} from '../../../zql/src/query/metrics-delegate.ts';
 import type {
   CommitListener,
@@ -14,7 +15,6 @@ import type {
 } from '../../../zql/src/query/query-delegate.ts';
 import type {RunOptions} from '../../../zql/src/query/query.ts';
 import {type IVMSourceBranch} from './ivm-branch.ts';
-import {MeasurePushOperator} from './measure-push-operator.ts';
 import type {QueryManager} from './query-manager.ts';
 import type {ZeroLogContext} from './zero-log-context.ts';
 
@@ -100,7 +100,7 @@ export class ZeroContext implements QueryDelegate {
   }
 
   decorateSourceInput(input: SourceInput, queryID: string): Input {
-    return new MeasurePushOperator(input, queryID, this);
+    return new MeasurePushOperator(input, queryID, this, 'query-update-client');
   }
 
   addEdge() {}

--- a/packages/zero-client/src/client/inspector/inspector.test.ts
+++ b/packages/zero-client/src/client/inspector/inspector.test.ts
@@ -18,6 +18,7 @@ const emptyMetrics = {
   'query-materialization-end-to-end': new TDigest(),
   'query-materialization-server': new TDigest(),
   'query-update-client': new TDigest(),
+  'query-update-server': new TDigest(),
 };
 
 async function getMetrics<
@@ -48,6 +49,7 @@ async function getMetrics<
       id,
       value: metricsResponseValue ?? {
         'query-materialization-server': [1000],
+        'query-update-server': [1000],
       },
     },
   ]);
@@ -386,6 +388,9 @@ describe('query metrics', () => {
         "query-update-client": [
           1000,
         ],
+        "query-update-server": [
+          1000,
+        ],
       }
     `);
 
@@ -598,6 +603,7 @@ describe('query metrics', () => {
             ttl: 60_000,
             metrics: {
               'query-materialization-server': [1000, 1, 2],
+              'query-update-server': [100, 3, 4],
             },
           },
         ],
@@ -610,29 +616,34 @@ describe('query metrics', () => {
 
     const {metrics} = queries[0];
     expect(metrics).toMatchInlineSnapshot(`
-          {
-            "query-materialization-client": [
-              1000,
-              0,
-              1,
-            ],
-            "query-materialization-end-to-end": [
-              1000,
-              50,
-              1,
-            ],
-            "query-materialization-server": [
-              1000,
-              1,
-              2,
-            ],
-            "query-update-client": [
-              1000,
-              0,
-              1,
-            ],
-          }
-        `);
+      {
+        "query-materialization-client": [
+          1000,
+          0,
+          1,
+        ],
+        "query-materialization-end-to-end": [
+          1000,
+          50,
+          1,
+        ],
+        "query-materialization-server": [
+          1000,
+          1,
+          2,
+        ],
+        "query-update-client": [
+          1000,
+          0,
+          1,
+        ],
+        "query-update-server": [
+          100,
+          3,
+          4,
+        ],
+      }
+    `);
 
     view.destroy();
     await z.close();

--- a/packages/zero-client/src/client/inspector/inspector.ts
+++ b/packages/zero-client/src/client/inspector/inspector.ts
@@ -34,7 +34,6 @@ import type {
 import type {Schema} from '../../../../zero-schema/src/builder/schema-builder.ts';
 import type {
   ClientMetricMap,
-  MetricMap,
   ServerMetricMap,
 } from '../../../../zql/src/query/metrics-delegate.ts';
 import {normalizeTTL, type TTL} from '../../../../zql/src/query/ttl.ts';
@@ -53,7 +52,7 @@ type Rep = ReplicacheImpl<MutatorDefs>;
 type GetWebSocket = () => Promise<WebSocket>;
 
 type Metrics = {
-  readonly [K in keyof MetricMap]: ReadonlyTDigest;
+  readonly [K in keyof (ClientMetricMap & ServerMetricMap)]: ReadonlyTDigest;
 };
 
 type ClientMetrics = {
@@ -432,7 +431,7 @@ class Query implements QueryInterface {
 function mergeMetrics(
   clientMetrics: ClientMetrics | undefined,
   serverMetrics: ServerMetricsJSON | null | undefined,
-): Metrics {
+): ClientMetrics & ServerMetrics {
   return {
     ...(clientMetrics ?? newClientMetrics()),
     ...(serverMetrics
@@ -452,6 +451,7 @@ function newClientMetrics(): ClientMetrics {
 function newServerMetrics(): ServerMetrics {
   return {
     'query-materialization-server': new TDigest(),
+    'query-update-server': new TDigest(),
   };
 }
 

--- a/packages/zero-client/src/client/inspector/types.ts
+++ b/packages/zero-client/src/client/inspector/types.ts
@@ -13,6 +13,7 @@ export type Metrics = {
   'query-materialization-end-to-end': ReadonlyTDigest;
   'query-update-client': ReadonlyTDigest;
   'query-materialization-server': ReadonlyTDigest;
+  'query-update-server': ReadonlyTDigest;
 };
 
 export interface Inspector {

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -79,7 +79,11 @@ import {
   clientToServer,
 } from '../../../zero-schema/src/name-mapper.ts';
 import {customMutatorKey} from '../../../zql/src/mutate/custom.ts';
-import type {MetricMap} from '../../../zql/src/query/metrics-delegate.ts';
+import {
+  type ClientMetricMap,
+  type MetricMap,
+  isClientMetric,
+} from '../../../zql/src/query/metrics-delegate.ts';
 import type {QueryDelegate} from '../../../zql/src/query/query-delegate.ts';
 import {newQuery} from '../../../zql/src/query/query-impl.ts';
 import {
@@ -1956,18 +1960,12 @@ export class Zero<
     value: number,
     ...args: MetricMap[K]
   ) => void = (metric, value, ...args) => {
-    switch (metric) {
-      case 'query-materialization-client':
-      case 'query-materialization-end-to-end':
-      case 'query-update-client':
-        this.#queryManager.addMetric(metric, value, ...args);
-        break;
-      case 'query-materialization-server':
-        unreachable();
-      // eslint-disable-next-line no-fallthrough
-      default:
-        unreachable(metric);
-    }
+    assert(isClientMetric(metric), `Invalid metric: ${metric}`);
+    this.#queryManager.addMetric(
+      metric as keyof ClientMetricMap,
+      value,
+      ...(args as ClientMetricMap[keyof ClientMetricMap]),
+    );
   };
 }
 

--- a/packages/zero-protocol/src/ast.test.ts
+++ b/packages/zero-protocol/src/ast.test.ts
@@ -607,5 +607,5 @@ test('protocol version', () => {
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
   expect(hash).toEqual('1c228prd1v53r');
-  expect(PROTOCOL_VERSION).toEqual(27);
+  expect(PROTOCOL_VERSION).toEqual(28);
 });

--- a/packages/zero-protocol/src/inspect-down.ts
+++ b/packages/zero-protocol/src/inspect-down.ts
@@ -5,6 +5,7 @@ import {astSchema} from './ast.ts';
 
 const serverMetricsSchema = v.object({
   'query-materialization-server': tdigestSchema,
+  'query-update-server': tdigestSchema,
 });
 
 export type ServerMetrics = v.Infer<typeof serverMetricsSchema>;

--- a/packages/zero-protocol/src/protocol-version.test.ts
+++ b/packages/zero-protocol/src/protocol-version.test.ts
@@ -11,6 +11,6 @@ test('protocol version', () => {
   // If this test fails upstream or downstream schema has changed such that
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
-  expect(hash).toEqual('xn7buvgxr6mt');
-  expect(PROTOCOL_VERSION).toEqual(27);
+  expect(hash).toEqual('7hfvmalxghfc');
+  expect(PROTOCOL_VERSION).toEqual(28);
 });

--- a/packages/zero-protocol/src/protocol-version.ts
+++ b/packages/zero-protocol/src/protocol-version.ts
@@ -33,7 +33,8 @@ import {assert} from '../../shared/src/asserts.ts';
 // -- version 25 modifies `mutationsResults` to include `del` patches (0.22)
 // -- version 26 adds inspect/metrics and adds metrics to inspect/query (0.23)
 // -- version 27 adds inspect/version (0.23)
-export const PROTOCOL_VERSION = 27;
+// -- version 28 adds more inspect/metrics (0.23)
+export const PROTOCOL_VERSION = 28;
 
 /**
  * The minimum server-supported sync protocol version (i.e. the version

--- a/packages/zql/src/query/measure-push-operator.test.ts
+++ b/packages/zql/src/query/measure-push-operator.test.ts
@@ -24,6 +24,7 @@ describe('MeasurePushOperator', () => {
       mockInput,
       'test-query-id',
       mockMetricsDelegate,
+      'query-update-client',
     );
     const req = {} as FetchRequest;
 
@@ -49,6 +50,7 @@ describe('MeasurePushOperator', () => {
       mockInput,
       'test-query-id',
       mockMetricsDelegate,
+      'query-update-client',
     );
     const req = {} as FetchRequest;
 
@@ -75,6 +77,7 @@ describe('MeasurePushOperator', () => {
       mockInput,
       'test-query-id',
       mockMetricsDelegate,
+      'query-update-client',
     );
 
     const result = measurePushOperator.getSchema();
@@ -100,6 +103,7 @@ describe('MeasurePushOperator', () => {
       mockInput,
       'test-query-id',
       mockMetricsDelegate,
+      'query-update-client',
     );
 
     measurePushOperator.destroy();
@@ -128,6 +132,7 @@ describe('MeasurePushOperator', () => {
       mockInput,
       'test-query-id',
       mockMetricsDelegate,
+      'query-update-client',
     );
     measurePushOperator.setOutput(mockOutput);
 
@@ -169,6 +174,7 @@ describe('MeasurePushOperator', () => {
       mockInput,
       'test-query-id',
       mockMetricsDelegate,
+      'query-update-client',
     );
     measurePushOperator.setOutput(mockOutput);
 

--- a/packages/zql/src/query/measure-push-operator.test.ts
+++ b/packages/zql/src/query/measure-push-operator.test.ts
@@ -1,14 +1,10 @@
 import {describe, expect, test, vi} from 'vitest';
-import type {Change} from '../../../zql/src/ivm/change.ts';
-import type {Node} from '../../../zql/src/ivm/data.ts';
-import type {
-  FetchRequest,
-  Input,
-  Output,
-} from '../../../zql/src/ivm/operator.ts';
-import type {SourceSchema} from '../../../zql/src/ivm/schema.ts';
-import type {MetricsDelegate} from '../../../zql/src/query/metrics-delegate.ts';
+import type {Change} from '../ivm/change.ts';
+import type {Node} from '../ivm/data.ts';
+import type {FetchRequest, Input, Output} from '../ivm/operator.ts';
+import type {SourceSchema} from '../ivm/schema.ts';
 import {MeasurePushOperator} from './measure-push-operator.ts';
+import type {MetricsDelegate} from './metrics-delegate.ts';
 
 describe('MeasurePushOperator', () => {
   test('should pass through fetch calls', () => {

--- a/packages/zql/src/query/metrics-delegate.ts
+++ b/packages/zql/src/query/metrics-delegate.ts
@@ -8,6 +8,7 @@ export type ClientMetricMap = {
 
 export type ServerMetricMap = {
   'query-materialization-server': [queryID: string];
+  'query-update-server': [queryID: string];
 };
 
 export type MetricMap = ClientMetricMap & ServerMetricMap;
@@ -18,4 +19,16 @@ export interface MetricsDelegate {
     value: number,
     ...args: MetricMap[K]
   ): void;
+}
+
+export function isClientMetric(
+  metric: keyof MetricMap,
+): metric is keyof ClientMetricMap {
+  return metric.endsWith('-client') || metric.endsWith('-end-to-end');
+}
+
+export function isServerMetric(
+  metric: keyof MetricMap,
+): metric is keyof ServerMetricMap {
+  return metric.endsWith('-server');
 }


### PR DESCRIPTION
This PR adds inspector metrics for `query-update-server`, enabling measurement of update times per query (`queryID`) and globally across all updates. Metrics are collected via a `MeasurePush` operator in the IVM pipeline, similar to the client-side approach. Inspector responses now include these metrics. Also includes a test fix for metric integration.### Summary
Adds inspector metrics for `query-update-server`, allowing measurement of update times both per query (`queryID`) and globally.

### Changes
- Collects update time metrics via `MeasurePush` operator in the IVM pipeline (mirroring client-side).
- Inspector responses now include these new metrics.
