### PR TITLE
chore(zero-cache): reduce litestream backup size

### DIFF
--- a/packages/zero-cache/src/services/change-source/custom/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/custom/change-source.ts
@@ -152,7 +152,7 @@ export async function initialSync(
 
   const processor = new ChangeProcessor(
     new StatementRunner(tx),
-    'INITIAL-SYNC',
+    'initial-sync',
     (_, err) => {
       throw err;
     },

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -9,7 +9,7 @@ import {
   type Downstream,
 } from '../change-streamer/change-streamer.ts';
 import {RunningState} from '../running-state.ts';
-import {ChangeProcessor, type TransactionMode} from './change-processor.ts';
+import {ChangeProcessor} from './change-processor.ts';
 import {Notifier} from './notifier.ts';
 import {ReplicationStatusPublisher} from './replication-status.ts';
 import type {ReplicaState, ReplicatorMode} from './replicator.ts';
@@ -28,7 +28,6 @@ export class IncrementalSyncer {
   readonly #replica: StatementRunner;
   readonly #mode: ReplicatorMode;
   readonly #publishReplicationStatus: boolean;
-  readonly #txMode: TransactionMode;
   readonly #notifier: Notifier;
 
   readonly #state = new RunningState('IncrementalSyncer');
@@ -53,7 +52,6 @@ export class IncrementalSyncer {
     this.#replica = new StatementRunner(replica);
     this.#mode = mode;
     this.#publishReplicationStatus = publishReplicationStatus;
-    this.#txMode = mode === 'serving' ? 'CONCURRENT' : 'IMMEDIATE';
     this.#notifier = new Notifier();
   }
 
@@ -73,7 +71,7 @@ export class IncrementalSyncer {
       const {replicaVersion, watermark} = getSubscriptionState(this.#replica);
       const processor = new ChangeProcessor(
         this.#replica,
-        this.#txMode,
+        this.#mode,
         (lc: LogContext, err: unknown) => this.stop(lc, err),
       );
 

--- a/packages/zero-cache/src/services/replicator/test-utils.ts
+++ b/packages/zero-cache/src/services/replicator/test-utils.ts
@@ -56,7 +56,7 @@ export function createChangeProcessor(
     throw err;
   },
 ): ChangeProcessor {
-  return new ChangeProcessor(new StatementRunner(db), 'IMMEDIATE', failures);
+  return new ChangeProcessor(new StatementRunner(db), 'serving', failures);
 }
 
 export class ReplicationMessages<


### PR DESCRIPTION
Easy / significant optimization to reduce the amount of data backed up (and restored) by litestream.

Avoid writing `_zero.changeLog` entries in the `backup` replicator (i.e. the `replication-manager`), as that replica is never used for incremental catchup.

Only the `serving` replicator (e.g. `view-syncer` nodes or single-nodes) need the change log, and they only need change log entries from after the first restore, since all connections first start with a hydration.

Thus, by avoiding creating change log entries in the backup replicator, the change log is no longer backed up by (or restored from) litestream, reducing the amount of data transferred (and thus startup time).