### PR TITLE
chore(zero-cache): run a pg (container) per vite worker

### DIFF
--- a/packages/zero-cache/src/db/create.pg-test.ts
+++ b/packages/zero-cache/src/db/create.pg-test.ts
@@ -1,9 +1,9 @@
 import type postgres from 'postgres';
-import {afterAll, afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {beforeEach, describe, expect} from 'vitest';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
 import {Database} from '../../../zqlite/src/db.ts';
 import {getPublicationInfo} from '../services/change-source/pg/schema/published.ts';
-import {testDBs} from '../test/db.ts';
+import {type PgTest, test} from '../test/db.ts';
 import {createTableStatement} from './create.ts';
 import {listTables} from './lite-tables.ts';
 import {mapPostgresToLite} from './pg-to-lite.ts';
@@ -513,20 +513,14 @@ describe('tables/create', () => {
 
   describe('pg', () => {
     let db: postgres.Sql;
-    beforeEach(async () => {
+    beforeEach<PgTest>(async ({testDBs}) => {
       db = await testDBs.create('create_tables_test');
       await db`
       CREATE PUBLICATION zero_all FOR ALL TABLES;
       CREATE TYPE my_type AS ENUM ('foo', 'bar', 'baz');
       `.simple();
-    });
 
-    afterEach(async () => {
-      await testDBs.drop(db);
-    });
-
-    afterAll(async () => {
-      await testDBs.end();
+      return () => testDBs.drop(db);
     });
 
     test.each(cases)('$name', async c => {

--- a/packages/zero-cache/src/db/migration.pg-test.ts
+++ b/packages/zero-cache/src/db/migration.pg-test.ts
@@ -1,8 +1,8 @@
 import type {LogContext} from '@rocicorp/logger';
 import type postgres from 'postgres';
-import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {beforeEach, describe, expect} from 'vitest';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
-import {testDBs} from '../test/db.ts';
+import {type PgTest, test} from '../test/db.ts';
 import type {PostgresDB} from '../types/pg.ts';
 import {
   type IncrementalMigrationMap,
@@ -205,13 +205,11 @@ describe('db/migration', () => {
 
   let db: PostgresDB;
 
-  beforeEach(async () => {
+  beforeEach<PgTest>(async ({testDBs}) => {
     db = await testDBs.create('migration_test');
     await db`CREATE TABLE "MigrationHistory" (event TEXT)`;
-  });
 
-  afterEach(async () => {
-    await testDBs.drop(db);
+    return () => testDBs.drop(db);
   });
 
   for (const c of cases) {

--- a/packages/zero-cache/src/db/pg-copy.pg-test.ts
+++ b/packages/zero-cache/src/db/pg-copy.pg-test.ts
@@ -1,17 +1,17 @@
 /* eslint-disable no-irregular-whitespace */
 import {Readable, Writable} from 'node:stream';
 import {pipeline} from 'node:stream/promises';
-import {beforeEach, describe, expect, test} from 'vitest';
+import {beforeEach, describe, expect} from 'vitest';
 import type {JSONValue} from '../../../shared/src/json.ts';
 import {randInt} from '../../../shared/src/rand.ts';
-import {testDBs} from '../test/db.ts';
+import {type PgTest, test} from '../test/db.ts';
 import {type PostgresDB} from '../types/pg.ts';
 import {NULL_BYTE, TextTransform} from './pg-copy.ts';
 
 describe('pg-copy', () => {
   let sql: PostgresDB;
 
-  beforeEach(async () => {
+  beforeEach<PgTest>(async ({testDBs}) => {
     sql = await testDBs.create('pg_copy_test');
 
     await sql`
@@ -28,9 +28,7 @@ describe('pg-copy', () => {
         j text
       )`;
 
-    return async () => {
-      await testDBs.drop(sql);
-    };
+    return () => testDBs.drop(sql);
   });
 
   type Row = {

--- a/packages/zero-cache/src/db/queries.pg-test.ts
+++ b/packages/zero-cache/src/db/queries.pg-test.ts
@@ -1,5 +1,5 @@
-import {afterEach, beforeEach, describe, expect, test} from 'vitest';
-import {testDBs} from '../test/db.ts';
+import {beforeEach, describe, expect} from 'vitest';
+import {type PgTest, test} from '../test/db.ts';
 import {INT4, JSONB, TEXT} from '../types/pg-types.ts';
 import type {PostgresDB} from '../types/pg.ts';
 import type {RowKey} from '../types/row-key.ts';
@@ -8,12 +8,10 @@ import {lookupRowsWithKeys} from './queries.ts';
 describe('db/queries', () => {
   let db: PostgresDB;
 
-  beforeEach(async () => {
+  beforeEach<PgTest>(async ({testDBs}) => {
     db = await testDBs.create('db_queries_test');
-  });
 
-  afterEach(async () => {
-    await testDBs.drop(db);
+    return () => testDBs.drop(db);
   });
 
   test('lookupRowsWithKeys', async () => {

--- a/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg-test.ts
@@ -1,5 +1,6 @@
 import {LogContext} from '@rocicorp/logger';
 import {afterAll, beforeAll, describe, expect, test} from 'vitest';
+import {type JSONValue} from '../../../../../shared/src/bigint-json.ts';
 import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
 import {Queue} from '../../../../../shared/src/queue.ts';
 import type {Database} from '../../../../../zqlite/src/db.ts';
@@ -7,7 +8,6 @@ import {listIndexes, listTables} from '../../../db/lite-tables.ts';
 import type {LiteIndexSpec, LiteTableSpec} from '../../../db/specs.ts';
 import {getConnectionURI, testDBs} from '../../../test/db.ts';
 import {DbFile, expectMatchingObjectsInTables} from '../../../test/lite.ts';
-import {type JSONValue} from '../../../../../shared/src/bigint-json.ts';
 import type {PostgresDB} from '../../../types/pg.ts';
 import type {Source} from '../../../types/streams.ts';
 import type {ChangeProcessor} from '../../replicator/change-processor.ts';

--- a/packages/zero-cache/src/services/change-source/pg/change-source.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.pg-test.ts
@@ -1,7 +1,7 @@
 import {PG_OBJECT_IN_USE} from '@drdgvhbh/postgres-error-codes';
 import {LogContext} from '@rocicorp/logger';
 import {PostgresError} from 'postgres';
-import {beforeEach, describe, expect, test, vi} from 'vitest';
+import {beforeEach, describe, expect, vi} from 'vitest';
 import {AbortError} from '../../../../../shared/src/abort-error.ts';
 import {TestLogSink} from '../../../../../shared/src/logging-test-utils.ts';
 import {Queue} from '../../../../../shared/src/queue.ts';
@@ -11,7 +11,8 @@ import {StatementRunner} from '../../../db/statements.ts';
 import {
   dropReplicationSlots,
   getConnectionURI,
-  testDBs,
+  type PgTest,
+  test,
 } from '../../../test/db.ts';
 import {DbFile} from '../../../test/lite.ts';
 import {versionFromLexi, versionToLexi} from '../../../types/lexi-version.ts';
@@ -45,7 +46,7 @@ describe.skip('change-source/pg', {timeout: 30000, retry: 3}, () => {
   let source: ChangeSource;
   let streams: ChangeStream[];
 
-  beforeEach(async () => {
+  beforeEach<PgTest>(async ({testDBs}) => {
     streams = [];
     logSink = new TestLogSink();
     lc = new LogContext('error', {}, logSink);

--- a/packages/zero-cache/src/services/change-source/pg/decommission.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/decommission.pg-test.ts
@@ -1,8 +1,8 @@
 import {LogContext} from '@rocicorp/logger';
-import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {beforeEach, describe, expect} from 'vitest';
 import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
 import {Database} from '../../../../../zqlite/src/db.ts';
-import {getConnectionURI, initDB, testDBs} from '../../../test/db.ts';
+import {getConnectionURI, initDB, type PgTest, test} from '../../../test/db.ts';
 import type {PostgresDB} from '../../../types/pg.ts';
 import {decommissionShard} from './decommission.ts';
 import {initialSync} from './initial-sync.ts';
@@ -15,14 +15,12 @@ describe('decommission', () => {
   let upstream: PostgresDB;
   let replica: Database;
 
-  beforeEach(async () => {
+  beforeEach<PgTest>(async ({testDBs}) => {
     lc = createSilentLogContext();
     upstream = await testDBs.create('decommission_test');
     replica = new Database(lc, ':memory:');
-  });
 
-  afterEach(async () => {
-    await testDBs.drop(upstream);
+    return () => testDBs.drop(upstream);
   });
 
   test('decommission shard', async () => {

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.pg-test.ts
@@ -1,5 +1,5 @@
 import {nanoid} from 'nanoid/non-secure';
-import {beforeEach, describe, expect, test} from 'vitest';
+import {beforeEach, describe, expect} from 'vitest';
 import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
 import type {ZeroEvent} from '../../../../../zero-events/src/index.ts';
 import {Database} from '../../../../../zqlite/src/db.ts';
@@ -11,7 +11,7 @@ import type {
   PublishedTableSpec,
 } from '../../../db/specs.ts';
 import {initEventSinkForTesting} from '../../../observability/events.ts';
-import {getConnectionURI, initDB, testDBs} from '../../../test/db.ts';
+import {getConnectionURI, initDB, type PgTest, test} from '../../../test/db.ts';
 import {
   expectMatchingObjectsInTables,
   expectTables,
@@ -2142,11 +2142,10 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
 
   let upstream: PostgresDB;
 
-  beforeEach(async () => {
+  beforeEach<PgTest>(async ({testDBs}) => {
     upstream = await testDBs.create('initial_sync_upstream');
-    return async () => {
-      await testDBs.drop(upstream);
-    };
+
+    return () => testDBs.drop(upstream);
   });
 
   for (const c of cases) {

--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl.pg-test.ts
@@ -1,8 +1,8 @@
 import type postgres from 'postgres';
-import {beforeEach, describe, expect, test} from 'vitest';
+import {beforeEach, describe, expect} from 'vitest';
 import {createSilentLogContext} from '../../../../../../shared/src/logging-test-utils.ts';
 import {Queue} from '../../../../../../shared/src/queue.ts';
-import {testDBs} from '../../../../test/db.ts';
+import {type PgTest, test} from '../../../../test/db.ts';
 import type {PostgresDB} from '../../../../types/pg.ts';
 import type {
   Message,
@@ -25,7 +25,7 @@ describe('change-source/tables/ddl', () => {
   const APP_ID = 'zap';
   const SHARD_NUM = 0;
 
-  beforeEach(async () => {
+  beforeEach<PgTest>(async ({testDBs}) => {
     notices = new Queue();
     upstream = await testDBs.create('ddl_test_upstream', n =>
       notices.enqueue(n),

--- a/packages/zero-cache/src/services/change-source/pg/schema/init.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.pg-test.ts
@@ -1,15 +1,20 @@
 import {LogContext} from '@rocicorp/logger';
-import {afterEach, beforeEach, describe, test} from 'vitest';
+import {beforeEach, describe} from 'vitest';
 import {createSilentLogContext} from '../../../../../../shared/src/logging-test-utils.ts';
 import {
   createVersionHistoryTable,
   type VersionHistory,
 } from '../../../../db/migration.ts';
-import {expectTablesToMatch, initDB, testDBs} from '../../../../test/db.ts';
+import {
+  expectTablesToMatch,
+  initDB,
+  type PgTest,
+  test,
+} from '../../../../test/db.ts';
 import type {PostgresDB} from '../../../../types/pg.ts';
+import {id} from '../../../../types/sql.ts';
 import {ensureShardSchema, updateShardSchema} from './init.ts';
 import {addReplica, metadataPublicationName} from './shard.ts';
-import {id} from '../../../../types/sql.ts';
 
 const APP_ID = 'zappz';
 const SHARD_NUM = 23;
@@ -26,13 +31,11 @@ describe('change-streamer/pg/schema/init', () => {
   let lc: LogContext;
   let upstream: PostgresDB;
 
-  beforeEach(async () => {
+  beforeEach<PgTest>(async ({testDBs}) => {
     lc = createSilentLogContext();
     upstream = await testDBs.create('shard_schema_migration_upstream');
-  });
 
-  afterEach(async () => {
-    await testDBs.drop(upstream);
+    return () => testDBs.drop(upstream);
   });
 
   type Case = {

--- a/packages/zero-cache/src/services/change-source/pg/schema/published.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/published.pg-test.ts
@@ -1,17 +1,15 @@
 import type postgres from 'postgres';
-import {beforeEach, describe, expect, test} from 'vitest';
+import {beforeEach, describe, expect} from 'vitest';
 import * as PostgresTypeClass from '../../../../db/postgres-type-class-enum.ts';
-import {testDBs} from '../../../../test/db.ts';
-import {type PublicationInfo, getPublicationInfo} from './published.ts';
+import {test, type PgTest} from '../../../../test/db.ts';
+import {getPublicationInfo, type PublicationInfo} from './published.ts';
 
 describe('tables/published', () => {
   let db: postgres.Sql;
-  beforeEach(async () => {
+  beforeEach<PgTest>(async ({testDBs}) => {
     db = await testDBs.create('published_tables_test');
 
-    return async () => {
-      await testDBs.drop(db);
-    };
+    return () => testDBs.drop(db);
   });
 
   async function runAndExpectIndexes(

--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.pg-test.ts
@@ -1,8 +1,8 @@
 import {LogContext} from '@rocicorp/logger';
-import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {beforeEach, describe, expect} from 'vitest';
 import {TestLogSink} from '../../../../../../shared/src/logging-test-utils.ts';
 import {Index} from '../../../../db/postgres-replica-identity-enum.ts';
-import {expectTables, initDB, testDBs} from '../../../../test/db.ts';
+import {expectTables, initDB, type PgTest, test} from '../../../../test/db.ts';
 import type {PostgresDB} from '../../../../types/pg.ts';
 import {getPublicationInfo} from './published.ts';
 import {
@@ -18,15 +18,15 @@ describe('change-source/pg', () => {
   let lc: LogContext;
   let db: PostgresDB;
 
-  beforeEach(async () => {
+  beforeEach<PgTest>(async ({testDBs}) => {
     logSink = new TestLogSink();
     lc = new LogContext('warn', {}, logSink);
     db = await testDBs.create('zero_schema_test');
-  });
 
-  afterEach(async () => {
-    await testDBs.drop(db);
-    await testDBs.sql`RESET ROLE; DROP ROLE IF EXISTS supaneon`.simple();
+    return async () => {
+      await testDBs.drop(db);
+      await testDBs.sql`RESET ROLE; DROP ROLE IF EXISTS supaneon`.simple();
+    };
   });
 
   function publications() {

--- a/packages/zero-cache/src/services/change-source/pg/schema/validation.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/validation.pg-test.ts
@@ -1,6 +1,6 @@
-import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {beforeEach, describe, expect} from 'vitest';
 import {createSilentLogContext} from '../../../../../../shared/src/logging-test-utils.ts';
-import {initDB, testDBs} from '../../../../test/db.ts';
+import {initDB, type PgTest, test} from '../../../../test/db.ts';
 import type {PostgresDB} from '../../../../types/pg.ts';
 import {getPublicationInfo} from './published.ts';
 import {UnsupportedTableSchemaError, validate} from './validation.ts';
@@ -9,12 +9,10 @@ describe('change-source/pg', () => {
   const lc = createSilentLogContext();
   let db: PostgresDB;
 
-  beforeEach(async () => {
+  beforeEach<PgTest>(async ({testDBs}) => {
     db = await testDBs.create('zero_schema_validation_test');
-  });
 
-  afterEach(async () => {
-    await testDBs.drop(db);
+    return () => testDBs.drop(db);
   });
 
   type InvalidTableCase = {

--- a/packages/zero-cache/src/services/change-source/pg/sync-schema.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/sync-schema.pg-test.ts
@@ -1,10 +1,11 @@
-import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {beforeEach, describe, expect} from 'vitest';
 import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
 import {
   expectTables,
   getConnectionURI,
   initDB,
-  testDBs,
+  type PgTest,
+  test,
 } from '../../../test/db.ts';
 import {
   DbFile,
@@ -106,15 +107,16 @@ describe('change-streamer/pg/sync-schema', () => {
   let upstream: PostgresDB;
   let replicaFile: DbFile;
 
-  beforeEach(async () => {
+  beforeEach<PgTest>(async ({testDBs}) => {
     upstream = await testDBs.create('sync_schema_migration_upstream');
     replicaFile = new DbFile('sync_schema_migration_replica');
+
+    return async () => {
+      await testDBs.drop(upstream);
+      replicaFile.delete();
+    };
   });
 
-  afterEach(async () => {
-    await testDBs.drop(upstream);
-    replicaFile.delete();
-  }, 10000);
   const lc = createSilentLogContext();
 
   for (const c of cases) {

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.pg-test.ts
@@ -1,17 +1,10 @@
 import {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
 import Fastify from 'fastify';
-import {
-  beforeEach,
-  describe,
-  expect,
-  type MockedFunction,
-  test,
-  vi,
-} from 'vitest';
+import {beforeEach, describe, expect, type MockedFunction, vi} from 'vitest';
 import WebSocket from 'ws';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
-import {getConnectionURI, testDBs} from '../../test/db.ts';
+import {getConnectionURI, type PgTest, test} from '../../test/db.ts';
 import {type PostgresDB} from '../../types/pg.ts';
 import {inProcChannel} from '../../types/processes.ts';
 import {cdcSchema, type ShardID} from '../../types/shards.ts';
@@ -50,7 +43,7 @@ describe('change-streamer/http', () => {
   let connectionClosed: Promise<Downstream[]>;
   let changeStreamerClient: ChangeStreamerHttpClient;
 
-  beforeEach(async () => {
+  beforeEach<PgTest>(async ({testDBs}) => {
     lc = createSilentLogContext();
 
     changeDB = await testDBs.create('change_streamer_http_client');

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg-test.ts
@@ -1,15 +1,15 @@
 import {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
-import {beforeEach, describe, expect, test, vi, type Mock} from 'vitest';
+import {beforeEach, describe, expect, vi, type Mock} from 'vitest';
 import {AbortError} from '../../../../shared/src/abort-error.ts';
 import {assert} from '../../../../shared/src/asserts.ts';
+import {stringify} from '../../../../shared/src/bigint-json.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {Queue} from '../../../../shared/src/queue.ts';
 import {sleep} from '../../../../shared/src/sleep.ts';
 import {Database} from '../../../../zqlite/src/db.ts';
 import {StatementRunner} from '../../db/statements.ts';
-import {expectTables, testDBs} from '../../test/db.ts';
-import {stringify} from '../../../../shared/src/bigint-json.ts';
+import {expectTables, test, type PgTest} from '../../test/db.ts';
 import type {PostgresDB} from '../../types/pg.ts';
 import type {Source} from '../../types/streams.ts';
 import {Subscription, type Result} from '../../types/subscription.ts';
@@ -50,7 +50,7 @@ describe('change-streamer/service', () => {
   const REPLICA_VERSION = '01';
   const shard = {appID: 'zoro', shardNum: 3};
 
-  beforeEach(async () => {
+  beforeEach<PgTest>(async ({testDBs}) => {
     lc = createSilentLogContext();
 
     sql = await testDBs.create('change_streamer_test_change_db');

--- a/packages/zero-cache/src/services/change-streamer/schema/init.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/schema/init.pg-test.ts
@@ -1,6 +1,6 @@
-import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {beforeEach, describe, expect} from 'vitest';
 import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
-import {testDBs} from '../../../test/db.ts';
+import {type PgTest, test} from '../../../test/db.ts';
 import type {PostgresDB} from '../../../types/pg.ts';
 import {getLastWatermarkV2} from './init.ts';
 import {ensureReplicationConfig, setupCDCTables} from './tables.ts';
@@ -11,13 +11,11 @@ describe('change-streamer/schema/migration', () => {
   const lc = createSilentLogContext();
   let db: PostgresDB;
 
-  beforeEach(async () => {
+  beforeEach<PgTest>(async ({testDBs}) => {
     db = await testDBs.create('change_streamer_schema_migration');
     await db.begin(tx => setupCDCTables(lc, tx, shard));
-  });
 
-  afterEach(async () => {
-    await testDBs.drop(db);
+    return () => testDBs.drop(db);
   });
 
   test('getLastWatermarkV2', async () => {

--- a/packages/zero-cache/src/services/change-streamer/schema/tables.pg-test.ts
+++ b/packages/zero-cache/src/services/change-streamer/schema/tables.pg-test.ts
@@ -1,7 +1,7 @@
-import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {beforeEach, describe, expect} from 'vitest';
 import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
 import {Database} from '../../../../../zqlite/src/db.ts';
-import {expectTables, testDBs} from '../../../test/db.ts';
+import {expectTables, type PgTest, test} from '../../../test/db.ts';
 import type {PostgresDB} from '../../../types/pg.ts';
 import {initReplicationState} from '../../replicator/schema/replication-state.ts';
 import {
@@ -19,13 +19,11 @@ describe('change-streamer/schema/tables', () => {
   const SHARD_NUM = 8;
   const shard = {appID: APP_ID, shardNum: SHARD_NUM};
 
-  beforeEach(async () => {
+  beforeEach<PgTest>(async ({testDBs}) => {
     db = await testDBs.create('change_streamer_schema_tables');
     await db.begin(tx => setupCDCTables(lc, tx, shard));
-  });
 
-  afterEach(async () => {
-    await testDBs.drop(db);
+    return () => testDBs.drop(db);
   });
 
   test('ensureReplicationConfig', async () => {

--- a/packages/zero-cache/src/services/mutagen/mutagen.pg-test.ts
+++ b/packages/zero-cache/src/services/mutagen/mutagen.pg-test.ts
@@ -1,6 +1,6 @@
 import {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
-import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {beforeEach, describe, expect} from 'vitest';
 import {
   createSilentLogContext,
   TestLogSink,
@@ -14,7 +14,7 @@ import {
 } from '../../../../zero-protocol/src/push.ts';
 import type {WriteAuthorizer} from '../../auth/write-authorizer.ts';
 import * as Mode from '../../db/mode-enum.ts';
-import {expectTables, testDBs} from '../../test/db.ts';
+import {expectTables, type PgTest, test} from '../../test/db.ts';
 import type {PostgresDB} from '../../types/pg.ts';
 import {zeroSchema} from './mutagen-test-shared.ts';
 import {processMutation} from './mutagen.ts';
@@ -72,15 +72,13 @@ describe('processMutation', {timeout: 15000}, () => {
   let lc: LogContext;
   let db: PostgresDB;
 
-  beforeEach(async () => {
+  beforeEach<PgTest>(async ({testDBs}) => {
     lc = createSilentLogContext();
     db = await testDBs.create('db_mutagen_test');
     await createTables(db);
-  });
 
-  afterEach(async () => {
-    await testDBs.drop(db);
-  }, 15000);
+    return () => testDBs.drop(db);
+  });
 
   test('new client with no last mutation id', async () => {
     await expectTables(db, {

--- a/packages/zero-cache/src/services/view-syncer/cvr-purger.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-purger.pg-test.ts
@@ -1,8 +1,8 @@
 import {resolver} from '@rocicorp/resolver';
-import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {beforeEach, describe, expect} from 'vitest';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {DEFAULT_TTL_MS} from '../../../../zql/src/query/ttl.ts';
-import {testDBs} from '../../test/db.ts';
+import {test, type PgTest} from '../../test/db.ts';
 import type {PostgresDB} from '../../types/pg.ts';
 import {cvrSchema} from '../../types/shards.ts';
 import {CVRPurger} from './cvr-purger.ts';
@@ -87,7 +87,7 @@ describe('view-syncer/cvr', () => {
   let cvrDb: PostgresDB;
   let purger: CVRPurger;
 
-  beforeEach(async () => {
+  beforeEach<PgTest>(async ({testDBs}) => {
     cvrDb = await testDBs.create('cvr_purger_test_db');
     await cvrDb.begin(tx => setupCVRTables(lc, tx, SHARD));
 
@@ -156,10 +156,8 @@ describe('view-syncer/cvr', () => {
         ],
       });
     }
-  });
 
-  afterEach(async () => {
-    await testDBs.drop(cvrDb);
+    return () => testDBs.drop(cvrDb);
   });
 
   test('complete purge', async () => {

--- a/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
@@ -1,9 +1,9 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+import {beforeEach, describe, expect, vi} from 'vitest';
 import {unreachable} from '../../../../shared/src/asserts.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {sleep} from '../../../../shared/src/sleep.ts';
 import {DEFAULT_TTL_MS} from '../../../../zql/src/query/ttl.ts';
-import {testDBs} from '../../test/db.ts';
+import {type PgTest, test} from '../../test/db.ts';
 import type {PostgresDB} from '../../types/pg.ts';
 import {cvrSchema, upstreamSchema} from '../../types/shards.ts';
 import {id} from '../../types/sql.ts';
@@ -174,7 +174,7 @@ describe('view-syncer/cvr', () => {
     throw e;
   };
 
-  beforeEach(async () => {
+  beforeEach<PgTest>(async ({testDBs}) => {
     [cvrDb, upstreamDb] = await Promise.all([
       testDBs.create('cvr_test_db'),
       testDBs.create('upstream_test_db'),
@@ -189,10 +189,8 @@ describe('view-syncer/cvr', () => {
       `),
       ),
     ]);
-  });
 
-  afterEach(async () => {
-    await testDBs.drop(cvrDb);
+    return () => testDBs.drop(cvrDb, upstreamDb);
   });
 
   async function catchupRows(

--- a/packages/zero-cache/src/services/view-syncer/view-syncer-inspect.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer-inspect.pg-test.ts
@@ -1,10 +1,10 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+import {beforeEach, describe, expect, vi} from 'vitest';
 import {Queue} from '../../../../shared/src/queue.ts';
 import {type ClientSchema} from '../../../../zero-protocol/src/client-schema.ts';
 import type {Downstream} from '../../../../zero-protocol/src/down.ts';
 import {PROTOCOL_VERSION} from '../../../../zero-protocol/src/protocol-version.ts';
 import type {UpQueriesPatch} from '../../../../zero-protocol/src/queries-patch.ts';
-import {testDBs} from '../../test/db.ts';
+import {type PgTest, test} from '../../test/db.ts';
 import {DbFile} from '../../test/lite.ts';
 import type {PostgresDB} from '../../types/pg.ts';
 import type {Source} from '../../types/streams.ts';
@@ -24,6 +24,7 @@ import {type SyncContext, ViewSyncerService} from './view-syncer.ts';
 describe('view-syncer/service', () => {
   let replicaDbFile: DbFile;
   let cvrDB: PostgresDB;
+  let upstreamDb: PostgresDB;
   let stateChanges: Subscription<ReplicaState>;
 
   let vs: ViewSyncerService;
@@ -49,24 +50,25 @@ describe('view-syncer/service', () => {
     httpCookie: undefined,
   };
 
-  beforeEach(async () => {
+  beforeEach<PgTest>(async ({testDBs}) => {
     ({
       replicaDbFile,
       cvrDB,
+      upstreamDb,
       stateChanges,
       vs,
       viewSyncerDone,
       replicator,
       connectWithQueueAndSource,
-    } = await setup('view_syncer_inspect_test', permissionsAll));
-  });
+    } = await setup(testDBs, 'view_syncer_inspect_test', permissionsAll));
 
-  afterEach(async () => {
-    vi.useRealTimers();
-    await vs.stop();
-    await viewSyncerDone;
-    await testDBs.drop(cvrDB);
-    replicaDbFile.delete();
+    return async () => {
+      vi.useRealTimers();
+      await vs.stop();
+      await viewSyncerDone;
+      await testDBs.drop(cvrDB, upstreamDb);
+      replicaDbFile.delete();
+    };
   });
 
   test('inspect metrics op returns server metrics', async () => {

--- a/packages/zero-cache/src/services/view-syncer/view-syncer-test-util.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer-test-util.ts
@@ -28,7 +28,7 @@ import type {ExpressionBuilder} from '../../../../zql/src/query/expression.ts';
 import {Database} from '../../../../zqlite/src/db.ts';
 import type {ZeroConfig} from '../../config/zero-config.ts';
 import {InspectMetricsDelegate} from '../../server/inspect-metrics-delegate.ts';
-import {testDBs} from '../../test/db.ts';
+import {TestDBs} from '../../test/db.ts';
 import {DbFile} from '../../test/lite.ts';
 import {upstreamSchema} from '../../types/shards.ts';
 import {id} from '../../types/sql.ts';
@@ -545,6 +545,7 @@ async function expectDesired(
 }
 
 export async function setup(
+  testDBs: TestDBs,
   testName: string,
   permissions: PermissionsConfig | undefined,
 ) {

--- a/packages/zero-cache/src/types/pg.pg-test.ts
+++ b/packages/zero-cache/src/types/pg.pg-test.ts
@@ -1,6 +1,6 @@
 import type postgres from 'postgres';
-import {afterEach, beforeEach, describe, expect, test} from 'vitest';
-import {testDBs} from '../test/db.ts';
+import {beforeEach, describe, expect, test} from 'vitest';
+import {type PgTest, test as testPg} from '../test/db.ts';
 import {BYTEA, INT4, TEXT, VARCHAR} from './pg-types.ts';
 import {typeNameByOID} from './pg.ts';
 
@@ -20,7 +20,7 @@ describe('types/pg-types', () => {
 describe('types/pg', () => {
   let db: postgres.Sql<{bigint: bigint}>;
 
-  beforeEach(async () => {
+  beforeEach<PgTest>(async ({testDBs}) => {
     db = await testDBs.create('pg_types');
     await db.unsafe(`
     CREATE TABLE bigints(
@@ -42,13 +42,11 @@ describe('types/pg', () => {
       times time[]
     );
     `);
+
+    return () => testDBs.drop(db);
   });
 
-  afterEach(async () => {
-    await testDBs.drop(db);
-  });
-
-  test('bigints', async () => {
+  testPg('bigints', async () => {
     await db`INSERT INTO bigints ${db({big: 9007199254740993n})}`;
     expect((await db`SELECT * FROM bigints`)[0]).toEqual({
       big: 9007199254740993n,
@@ -72,7 +70,7 @@ describe('types/pg', () => {
     // });
   });
 
-  test.each([
+  testPg.each([
     ['January 8 04:05:06.123456 1999 PST', 915768306123.456, 915797106123.456],
     ['2004-10-19 10:23:54.654321+02', 1098181434654.321, 1098174234654.321],
     ['1999-01-08 04:05:06.987654 -8:00', 915768306987.654, 915797106987.654],
@@ -93,7 +91,7 @@ describe('types/pg', () => {
     });
   });
 
-  test.for([
+  testPg.for([
     // This one does not work... Maybe because of the timezone? Daylight saving?
     // ['January 8, 1999', Date.UTC(1999, 0, 8)],
 
@@ -110,7 +108,7 @@ describe('types/pg', () => {
     });
   });
 
-  test.for([
+  testPg.for([
     ['00:00', 0],
     ['09:15:32', 33332000],
     ['14:15:10.1234564', 51310123], // default precision of postgres is 6 fractional digits -> rounded down

--- a/packages/zero-cache/test/pg-container-setup.ts
+++ b/packages/zero-cache/test/pg-container-setup.ts
@@ -14,6 +14,8 @@ export function runPostgresContainer(image: string, timezone: string) {
 
     // Referenced by ./src/test/db.ts
     provide('pgConnectionString', container.getConnectionUri());
+    provide('pgImage', image);
+    provide('pgTimezone', timezone);
 
     return async () => {
       await container.stop();


### PR DESCRIPTION
For the zero-cache PG tests, run a pg container per vite worker (i.e. subprocess) rather than per project (e.g. pg-15, pg-16, pg-17), using the [Per Scope Test Context](https://vitest.dev/guide/test-context.html#per-scope-context-3-2-0) feature of vite.

The theory is that isolating PG access to a single thread / process will reduce "Invalid snapshot identifier" flakiness in the PG tests.