### PR TITLE
chore(zero-cache): increase vitest timeouts, disable isolation

### DIFF
--- a/packages/zero-cache/vitest.config.ts
+++ b/packages/zero-cache/vitest.config.ts
@@ -23,6 +23,13 @@ export function configForVersion(version: number, url: string) {
         reporter: [['html'], ['clover', {file: 'coverage.xml'}]],
         include: ['src/**'],
       },
+      poolOptions: {
+        forks: {
+          isolate: false,
+        },
+      },
+      testTimeout: 20000,
+      hookTimeout: 20000,
     },
   });
 }


### PR DESCRIPTION
Disable vitest isolation so that a single worker can run multiple files. Increase default timeouts.