### PR TITLE
chore(zero): Change max sample size for perf benchmarks

### DIFF
--- a/.github/workflows/bencher-benchmarks-pr.yml
+++ b/.github/workflows/bencher-benchmarks-pr.yml
@@ -123,4 +123,5 @@ jobs:
           --threshold-measure throughput \
           --threshold-test t_test \
           --threshold-lower-boundary 0.90 \
+          --threshold-max-sample-size 10 \
           --err

--- a/.github/workflows/bencher-benchmarks.yml
+++ b/.github/workflows/bencher-benchmarks.yml
@@ -89,4 +89,5 @@ jobs:
           --threshold-measure throughput \
           --threshold-test t_test \
           --threshold-lower-boundary 0.90 \
+          --threshold-max-sample-size 10 \
           --err


### PR DESCRIPTION
By only looking at the last 10 samples the regressions should only by local.