### PR TITLE
chore(zero): do not transform custom queries more than once

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -683,7 +683,52 @@ describe('view-syncer/pipeline-driver', () => {
         startTimer(),
       ),
     ];
-    expect(pipelines.addedQueries()).toEqual(new Set(['hash1']));
+    expect(pipelines.addedQueries()).toMatchInlineSnapshot(`
+      [
+        Set {
+          "hash1",
+        },
+        Map {
+          "queryID1" => [
+            {
+              "transformationHash": "hash1",
+              "transformedAst": {
+                "orderBy": [
+                  [
+                    "id",
+                    "desc",
+                  ],
+                ],
+                "related": [
+                  {
+                    "correlation": {
+                      "childField": [
+                        "issueID",
+                      ],
+                      "parentField": [
+                        "id",
+                      ],
+                    },
+                    "subquery": {
+                      "alias": "comments",
+                      "orderBy": [
+                        [
+                          "id",
+                          "desc",
+                        ],
+                      ],
+                      "table": "comments",
+                    },
+                    "system": "client",
+                  },
+                ],
+                "table": "issues",
+              },
+            },
+          ],
+        },
+      ]
+    `);
 
     replicator.processTransaction(
       '134',
@@ -693,7 +738,7 @@ describe('view-syncer/pipeline-driver', () => {
     pipelines.advanceWithoutDiff();
     pipelines.reset(null);
 
-    expect(pipelines.addedQueries()).toEqual(new Set());
+    expect(pipelines.addedQueries()).toEqual([new Set(), new Map()]);
 
     // The newColumn should be reflected after a reset.
     expect([
@@ -1506,9 +1551,54 @@ describe('view-syncer/pipeline-driver', () => {
       ),
     ];
 
-    expect([...pipelines.addedQueries()]).toEqual(['hash1']);
+    expect([...pipelines.addedQueries()]).toMatchInlineSnapshot(`
+      [
+        Set {
+          "hash1",
+        },
+        Map {
+          "queryID1" => [
+            {
+              "transformationHash": "hash1",
+              "transformedAst": {
+                "orderBy": [
+                  [
+                    "id",
+                    "desc",
+                  ],
+                ],
+                "related": [
+                  {
+                    "correlation": {
+                      "childField": [
+                        "issueID",
+                      ],
+                      "parentField": [
+                        "id",
+                      ],
+                    },
+                    "subquery": {
+                      "alias": "comments",
+                      "orderBy": [
+                        [
+                          "id",
+                          "desc",
+                        ],
+                      ],
+                      "table": "comments",
+                    },
+                    "system": "client",
+                  },
+                ],
+                "table": "issues",
+              },
+            },
+          ],
+        },
+      ]
+    `);
     pipelines.removeQuery('hash1');
-    expect([...pipelines.addedQueries()]).toEqual([]);
+    expect([...pipelines.addedQueries()]).toEqual([new Set(), new Map()]);
 
     replicator.processTransaction(
       '134',

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -72,6 +72,9 @@ export type RowChange = RowAdd | RowRemove | RowEdit;
 type Pipeline = {
   readonly input: Input;
   readonly hydrationTimeMs: number;
+  readonly originalHash: string;
+  readonly transformedAst: AST; // Optional, only set after hydration
+  readonly transformationHash: string; // The hash of the transformed AST
 };
 
 /**
@@ -79,6 +82,9 @@ type Pipeline = {
  */
 export class PipelineDriver {
   readonly #tables = new Map<string, TableSource>();
+  // We probs need the original query hash
+  // so we can decide not to re-transform a custom query
+  // that is already hydrated.
   readonly #pipelines = new Map<string, Pipeline>();
 
   readonly #lc: LogContext;
@@ -238,8 +244,32 @@ export class PipelineDriver {
   }
 
   /** @return The Set of query hashes for all added queries. */
-  addedQueries(): Set<string> {
-    return new Set(this.#pipelines.keys());
+  addedQueries(): [
+    transformationHashes: Set<string>,
+    byOriginalHash: Map<
+      string,
+      {
+        transformationHash: string;
+        transformedAst: AST;
+      }[]
+    >,
+  ] {
+    const byOriginalHash = new Map<
+      string,
+      {transformationHash: string; transformedAst: AST}[]
+    >();
+    for (const pipeline of this.#pipelines.values()) {
+      const {originalHash, transformedAst, transformationHash} = pipeline;
+
+      if (!byOriginalHash.has(originalHash)) {
+        byOriginalHash.set(originalHash, []);
+      }
+      byOriginalHash.get(originalHash)!.push({
+        transformationHash,
+        transformedAst,
+      });
+    }
+    return [new Set(this.#pipelines.keys()), byOriginalHash];
   }
 
   totalHydrationTimeMs(): number {
@@ -336,7 +366,13 @@ export class PipelineDriver {
     // Note: This hydrationTime is a wall-clock overestimate, as it does
     // not take time slicing into account. The view-syncer resets this
     // to a more precise processing-time measurement with setHydrationTime().
-    this.#pipelines.set(transformationHash, {input, hydrationTimeMs});
+    this.#pipelines.set(transformationHash, {
+      input,
+      hydrationTimeMs,
+      originalHash: queryID,
+      transformedAst: query,
+      transformationHash,
+    });
   }
 
   /**


### PR DESCRIPTION
Calling the API server every single time we sync pipelines or add a custom query that has already been transformed can cause unexpected behavior on the client.

The issue is that once a client has `gotten` a query, a re-transform on the server could flip it into an `error` state due to the user's API server not responding or returning an error. We should not re-transform queries that are already running.

This PR updates `view-syncer` to not transform a custom query if the pipeline driver is already running that query.

The PR takes a minimally invasive approach by acting as if the transformation call was made when a query, with the same id, is already running.

I don't understand how often `syncQueryPipelineSet` is called (but it shouldn't matter with the approach taken here). Would appreciate some insight on that.

--
We'll eventually prefix the custom query id with client id so each client will cause a transform of its own query requests.