### PR TITLE
chore(zero): thread query transform errors down to client

### DIFF
--- a/packages/zero-cache/src/custom-queries/transform-query.test.ts
+++ b/packages/zero-cache/src/custom-queries/transform-query.test.ts
@@ -218,11 +218,22 @@ describe('CustomQueryTransformer', () => {
     );
     const result = await transformer.transform(headerOptions, mockQueries);
 
-    expect(result).toEqual({
-      error: 'http',
-      status: 400,
-      details: 'Bad Request: Invalid query format',
-    });
+    expect(result).toEqual([
+      {
+        details: 'Bad Request: Invalid query format',
+        error: 'http',
+        id: 'query1',
+        name: 'getUserById',
+        status: 400,
+      },
+      {
+        details: 'Bad Request: Invalid query format',
+        error: 'http',
+        id: 'query2',
+        name: 'getPostsByUser',
+        status: 400,
+      },
+    ]);
   });
 
   test('should handle empty queries array', async () => {

--- a/packages/zero-cache/src/custom-queries/transform-query.ts
+++ b/packages/zero-cache/src/custom-queries/transform-query.ts
@@ -56,7 +56,7 @@ export class CustomQueryTransformer {
   async transform(
     headerOptions: HeaderOptions,
     queries: Iterable<CustomQueryRecord>,
-  ): Promise<(TransformedAndHashed | ErroredQuery)[] | HttpError> {
+  ): Promise<(TransformedAndHashed | ErroredQuery)[]> {
     const request: TransformRequestBody = [];
     const cachedResponses: TransformedAndHashed[] = [];
 
@@ -86,24 +86,37 @@ export class CustomQueryTransformer {
       return cachedResponses;
     }
 
-    const response = await fetchFromAPIServer(
-      must(
-        this.#config.url[0],
-        'A ZERO_QUERY_URL must be configured for custom queries',
-      ),
-      this.#config.url,
-      this.#shard,
-      headerOptions,
-      undefined,
-      ['transform', request] satisfies TransformRequestMessage,
-    );
+    let response: Response | undefined;
+    try {
+      response = await fetchFromAPIServer(
+        must(
+          this.#config.url[0],
+          'A ZERO_QUERY_URL must be configured for custom queries',
+        ),
+        this.#config.url,
+        this.#shard,
+        headerOptions,
+        undefined,
+        ['transform', request] satisfies TransformRequestMessage,
+      );
+    } catch (e) {
+      return request.map(r => ({
+        error: 'zero',
+        details: e instanceof Error ? e.message : String(e),
+        id: r.id,
+        name: r.name,
+      }));
+    }
 
     if (!response.ok) {
-      return {
+      const details = await response.text();
+      return request.map(r => ({
         error: 'http',
         status: response.status,
-        details: await response.text(),
-      };
+        details,
+        id: r.id,
+        name: r.name,
+      }));
     }
 
     const body = await response.json();

--- a/packages/zero-cache/src/custom-queries/transform-query.ts
+++ b/packages/zero-cache/src/custom-queries/transform-query.ts
@@ -13,7 +13,7 @@ import {hashOfAST} from '../../../zero-protocol/src/query-hash.ts';
 import {TimedCache} from '../../../shared/src/cache.ts';
 import {must} from '../../../shared/src/must.ts';
 
-type HttpError = {
+export type HttpError = {
   error: 'http';
   status: number;
   details: string;

--- a/packages/zero-cache/src/services/view-syncer/client-handler.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.ts
@@ -370,8 +370,8 @@ export class ClientHandler {
     await this.#push(['deleteClients', deleteClientsBody]);
   }
 
-  sendQueryTransformError(_error: ErroredQuery) {
-    // stubbed
+  sendQueryTransformErrors(errors: ErroredQuery[]) {
+    void this.#push(['transformError', errors]);
   }
 
   sendInspectResponse(lc: LogContext, response: InspectDownBody): void {

--- a/packages/zero-cache/src/services/view-syncer/client-handler.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.ts
@@ -41,6 +41,7 @@ import {
   type PutQueryPatch,
   type RowID,
 } from './schema/types.ts';
+import type {ErroredQuery} from '../../../../zero-protocol/src/custom-queries.ts';
 
 export type PutRowPatch = {
   type: 'row';
@@ -367,6 +368,10 @@ export class ClientHandler {
     }
     lc.debug?.('sending deleteClients', deleteClientsBody);
     await this.#push(['deleteClients', deleteClientsBody]);
+  }
+
+  sendQueryTransformError(_error: ErroredQuery) {
+    // stubbed
   }
 
   sendInspectResponse(lc: LogContext, response: InspectDownBody): void {

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -997,6 +997,10 @@ export class Zero<
       case 'pushResponse':
         return this.#mutationTracker.processPushResponse(downMessage[1]);
 
+      case 'transformError':
+        // this.#queryManager.handleTransformError();
+        break;
+
       case 'inspect':
         // ignore at this layer.
         break;

--- a/packages/zero-protocol/src/ast.test.ts
+++ b/packages/zero-protocol/src/ast.test.ts
@@ -607,5 +607,5 @@ test('protocol version', () => {
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
   expect(hash).toEqual('1c228prd1v53r');
-  expect(PROTOCOL_VERSION).toEqual(28);
+  expect(PROTOCOL_VERSION).toEqual(29);
 });

--- a/packages/zero-protocol/src/custom-queries.ts
+++ b/packages/zero-protocol/src/custom-queries.ts
@@ -17,13 +17,28 @@ export const transformedQuerySchema = v.object({
   ast: astSchema,
 });
 
-export const erroredQuerySchema = v.object({
+export const appQueryErrorSchema = v.object({
   error: v.literal('app'),
   id: v.string(),
   name: v.string(),
   details: jsonSchema,
 });
+
+export const httpQueryErrorSchema = v.object({
+  error: v.literal('http'),
+  id: v.string(),
+  name: v.string(),
+  status: v.number(),
+  details: jsonSchema,
+});
+
+export const erroredQuerySchema = v.union(
+  appQueryErrorSchema,
+  httpQueryErrorSchema,
+);
 export type ErroredQuery = v.Infer<typeof erroredQuerySchema>;
+export type AppQueryError = v.Infer<typeof appQueryErrorSchema>;
+export type HttpQueryError = v.Infer<typeof httpQueryErrorSchema>;
 
 export const transformResponseBodySchema = v.array(
   v.union(transformedQuerySchema, erroredQuerySchema),

--- a/packages/zero-protocol/src/custom-queries.ts
+++ b/packages/zero-protocol/src/custom-queries.ts
@@ -24,6 +24,13 @@ export const appQueryErrorSchema = v.object({
   details: jsonSchema,
 });
 
+export const zeroErrorSchema = v.object({
+  error: v.literal('zero'),
+  id: v.string(),
+  name: v.string(),
+  details: jsonSchema,
+});
+
 export const httpQueryErrorSchema = v.object({
   error: v.literal('http'),
   id: v.string(),
@@ -35,6 +42,7 @@ export const httpQueryErrorSchema = v.object({
 export const erroredQuerySchema = v.union(
   appQueryErrorSchema,
   httpQueryErrorSchema,
+  zeroErrorSchema,
 );
 export type ErroredQuery = v.Infer<typeof erroredQuerySchema>;
 export type AppQueryError = v.Infer<typeof appQueryErrorSchema>;
@@ -52,6 +60,11 @@ export const transformRequestMessageSchema = v.tuple([
 export type TransformRequestMessage = v.Infer<
   typeof transformRequestMessageSchema
 >;
+export const transformErrorMessageSchema = v.tuple([
+  v.literal('transformError'),
+  v.array(erroredQuerySchema),
+]);
+export type TransformErrorMessage = v.Infer<typeof transformErrorMessageSchema>;
 
 export const transformResponseMessageSchema = v.tuple([
   v.literal('transformed'),

--- a/packages/zero-protocol/src/down.ts
+++ b/packages/zero-protocol/src/down.ts
@@ -1,5 +1,6 @@
 import * as v from '../../shared/src/valita.ts';
 import {connectedMessageSchema} from './connect.ts';
+import {transformErrorMessageSchema} from './custom-queries.ts';
 import {deleteClientsMessageSchema} from './delete-clients.ts';
 import {errorMessageSchema} from './error.ts';
 import {inspectDownMessageSchema} from './inspect-down.ts';
@@ -23,6 +24,7 @@ export const downstreamSchema = v.union(
   deleteClientsMessageSchema,
   pushResponseMessageSchema,
   inspectDownMessageSchema,
+  transformErrorMessageSchema,
 );
 
 export type Downstream = v.Infer<typeof downstreamSchema>;

--- a/packages/zero-protocol/src/protocol-version.test.ts
+++ b/packages/zero-protocol/src/protocol-version.test.ts
@@ -11,6 +11,6 @@ test('protocol version', () => {
   // If this test fails upstream or downstream schema has changed such that
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
-  expect(hash).toEqual('7hfvmalxghfc');
-  expect(PROTOCOL_VERSION).toEqual(28);
+  expect(hash).toEqual('1pmjffpekmm4w');
+  expect(PROTOCOL_VERSION).toEqual(29);
 });

--- a/packages/zero-protocol/src/protocol-version.ts
+++ b/packages/zero-protocol/src/protocol-version.ts
@@ -34,7 +34,8 @@ import {assert} from '../../shared/src/asserts.ts';
 // -- version 26 adds inspect/metrics and adds metrics to inspect/query (0.23)
 // -- version 27 adds inspect/version (0.23)
 // -- version 28 adds more inspect/metrics (0.23)
-export const PROTOCOL_VERSION = 28;
+// -- version 29 adds error responses for custom queries (0.23)
+export const PROTOCOL_VERSION = 29;
 
 /**
  * The minimum server-supported sync protocol version (i.e. the version

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -55,7 +55,7 @@ export type AnyQuery = Query<Schema, string, any>;
 
 const astSymbol = Symbol();
 
-export function ast(query: Query<Schema, string, any>): AST {
+export function ast(query: AnyQuery): AST {
   return (query as AbstractQuery<Schema, string>)[astSymbol];
 }
 
@@ -243,7 +243,7 @@ export abstract class AbstractQuery<
         },
         this.customQueryID,
         undefined,
-      );
+      ) as AnyQuery;
       if (cardinality === 'one') {
         q = q.one();
       }


### PR DESCRIPTION
If we get an error transforming a custom query, send that error back down to the client.