### PR TITLE
feat(zero-client)!: surface query transform errors to callers of `useQuery`

### DIFF
--- a/apps/zbugs/src/debug/query-users.tsx
+++ b/apps/zbugs/src/debug/query-users.tsx
@@ -6,6 +6,9 @@ export function QueryUsers() {
   if (details.type === 'unknown') {
     return <div>Loading...</div>;
   }
+  if (details.type === 'error') {
+    return <div>Error: {JSON.stringify(details.error?.details ?? null)}</div>;
+  }
   return (
     <div>
       Query Users Component

--- a/packages/zero-client/src/client/query-manager.test.ts
+++ b/packages/zero-client/src/client/query-manager.test.ts
@@ -28,12 +28,12 @@ import * as v from '../../../shared/src/valita.ts';
 import type {AST} from '../../../zero-protocol/src/ast.ts';
 import type {ChangeDesiredQueriesMessage} from '../../../zero-protocol/src/change-desired-queries.ts';
 import {upPutOpSchema} from '../../../zero-protocol/src/queries-patch.ts';
-import {hashOfNameAndArgs} from '../../../zero-protocol/src/query-hash.ts';
 import {schema} from '../../../zql/src/query/test/test-schemas.ts';
 import {MAX_TTL_MS, type TTL} from '../../../zql/src/query/ttl.ts';
 import {toGotQueriesKey} from './keys.ts';
 import {MutationTracker} from './mutation-tracker.ts';
 import {QueryManager} from './query-manager.ts';
+import {hashOfNameAndArgs} from '../../../zero-protocol/src/query-hash.ts';
 
 const slowMaterializeThreshold = Infinity; // Disable slow materialization logs for tests.
 
@@ -1599,6 +1599,117 @@ describe('queriesPatch with lastPatch', () => {
         op: 'del',
       },
     ]);
+  });
+});
+
+const stubAst: AST = {
+  table: 'issue',
+  orderBy: [['id', 'asc']],
+};
+
+describe('query transform errors', () => {
+  test('got is called with an error when a query fails to transform', () => {
+    const nameAndArgs = {name: 'custom1', args: []};
+    const nameAndArgs2 = {name: 'custom2', args: []};
+
+    const queryHash = hashOfNameAndArgs(nameAndArgs.name, nameAndArgs.args);
+    const experimentalWatch = createExperimentalWatchMock();
+    const send = vi.fn<(msg: ChangeDesiredQueriesMessage) => void>();
+    const maxRecentQueriesSize = 0;
+    const mutationTracker = new MutationTracker(lc, ackMutations);
+    const queryManager = new QueryManager(
+      lc,
+      mutationTracker,
+      'client1',
+      schema.tables,
+      send,
+      experimentalWatch,
+      maxRecentQueriesSize,
+      queryChangeThrottleMs,
+      slowMaterializeThreshold,
+    );
+
+    const gotCallback1 = vi.fn<(got: boolean | Error) => void>();
+    const gotCallback2 = vi.fn<(got: boolean | Error) => void>();
+    const gotCallback1Dupe = vi.fn<(got: boolean | Error) => void>();
+
+    queryManager.addCustom(stubAst, nameAndArgs, 0, gotCallback1);
+    // duplicate addition of same query
+    queryManager.addCustom(stubAst, nameAndArgs, 0, gotCallback1Dupe);
+    queryManager.addCustom(stubAst, nameAndArgs2, 0, gotCallback2);
+    queryManager.flushBatch();
+
+    function checkInitialGots(cb: Mock<(got: boolean | Error) => void>) {
+      expect(cb).toBeCalledTimes(1);
+      expect(cb).toBeCalledWith(false);
+    }
+
+    checkInitialGots(gotCallback1);
+    checkInitialGots(gotCallback1Dupe);
+    checkInitialGots(gotCallback2);
+
+    const err = {
+      details: 'injected failure',
+      error: 'app',
+      id: queryHash,
+      name: 'custom1',
+    } as const;
+
+    // set an error
+    queryManager.handleTransformErrors([err]);
+
+    function checkFinalGots(cb: Mock<(got: boolean | Error) => void>) {
+      expect(cb).toBeCalledTimes(2);
+      expect(cb).nthCalledWith(2, false, err);
+    }
+
+    checkFinalGots(gotCallback1);
+    checkFinalGots(gotCallback1Dupe);
+    // error does not notify unrelated queries
+    expect(gotCallback2).toHaveBeenCalledTimes(1);
+  });
+
+  test('errored queries are removed from the query manager', () => {
+    const nameAndArgs = {name: 'custom1', args: []};
+    const queryHash = hashOfNameAndArgs(nameAndArgs.name, nameAndArgs.args);
+
+    const experimentalWatch = createExperimentalWatchMock();
+    const send = vi.fn<(msg: ChangeDesiredQueriesMessage) => void>();
+    const maxRecentQueriesSize = 0;
+    const mutationTracker = new MutationTracker(lc, ackMutations);
+    const queryManager = new QueryManager(
+      lc,
+      mutationTracker,
+      'client1',
+      schema.tables,
+      send,
+      experimentalWatch,
+      maxRecentQueriesSize,
+      queryChangeThrottleMs,
+      slowMaterializeThreshold,
+    );
+    const gotCallback = vi.fn<(got: boolean | Error) => void>();
+
+    queryManager.addCustom(stubAst, nameAndArgs, 0, gotCallback);
+    queryManager.flushBatch();
+    expect(send).toBeCalledTimes(1);
+
+    // error it
+    queryManager.handleTransformErrors([
+      {
+        details: 'injected failure',
+        error: 'app',
+        id: queryHash,
+        name: 'custom1',
+      },
+    ]);
+
+    // add it again
+    queryManager.addCustom(stubAst, nameAndArgs, 0, gotCallback);
+    queryManager.flushBatch();
+
+    // check send is called again because the error removed the prior registration
+    expect(send).toBeCalledTimes(2);
   });
 });
 

--- a/packages/zero-client/src/client/query-manager.test.ts
+++ b/packages/zero-client/src/client/query-manager.test.ts
@@ -1668,49 +1668,6 @@ describe('query transform errors', () => {
     // error does not notify unrelated queries
     expect(gotCallback2).toHaveBeenCalledTimes(1);
   });
-
-  test('errored queries are removed from the query manager', () => {
-    const nameAndArgs = {name: 'custom1', args: []};
-    const queryHash = hashOfNameAndArgs(nameAndArgs.name, nameAndArgs.args);
-
-    const experimentalWatch = createExperimentalWatchMock();
-    const send = vi.fn<(msg: ChangeDesiredQueriesMessage) => void>();
-    const maxRecentQueriesSize = 0;
-    const mutationTracker = new MutationTracker(lc, ackMutations);
-    const queryManager = new QueryManager(
-      lc,
-      mutationTracker,
-      'client1',
-      schema.tables,
-      send,
-      experimentalWatch,
-      maxRecentQueriesSize,
-      queryChangeThrottleMs,
-      slowMaterializeThreshold,
-    );
-    const gotCallback = vi.fn<(got: boolean | Error) => void>();
-
-    queryManager.addCustom(stubAst, nameAndArgs, 0, gotCallback);
-    queryManager.flushBatch();
-    expect(send).toBeCalledTimes(1);
-
-    // error it
-    queryManager.handleTransformErrors([
-      {
-        details: 'injected failure',
-        error: 'app',
-        id: queryHash,
-        name: 'custom1',
-      },
-    ]);
-
-    // add it again
-    queryManager.addCustom(stubAst, nameAndArgs, 0, gotCallback);
-    queryManager.flushBatch();
-
-    // check send is called again because the error removed the prior registration
-    expect(send).toBeCalledTimes(2);
-  });
 });
 
 test('gotCallback, add same got callback twice', () => {

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -1070,7 +1070,7 @@ export class Zero<
         return this.#mutationTracker.processPushResponse(downMessage[1]);
 
       case 'transformError':
-        // this.#queryManager.handleTransformError();
+        this.#queryManager.handleTransformErrors(downMessage[1]);
         break;
 
       case 'inspect':

--- a/packages/zero-react/src/use-query.test.tsx
+++ b/packages/zero-react/src/use-query.test.tsx
@@ -369,7 +369,6 @@ describe('ViewStore', () => {
       cleanup();
     });
   });
-
 });
 
 describe('useSuspenseQuery', () => {
@@ -620,8 +619,8 @@ describe('useSuspenseQuery', () => {
         const [data, details] = useSuspenseQuery(q, {suspendUntil: 'complete'});
         return (
           <div>
-            {details.type === 'error' 
-              ? `Error: ${details.error?.queryName || 'Unknown error'}` 
+            {details.type === 'error'
+              ? `Error: ${details.error?.queryName || 'Unknown error'}`
               : JSON.stringify(data)}
           </div>
         );
@@ -638,14 +637,16 @@ describe('useSuspenseQuery', () => {
       await expect.poll(() => element.textContent).toBe('loading');
 
       const view = materializeSpy.mock.results[0].value as {
-        listeners: Set<(snap: unknown, resultType: ResultType, error?: ErroredQuery) => void>;
+        listeners: Set<
+          (snap: unknown, resultType: ResultType, error?: ErroredQuery) => void
+        >;
       };
 
-      const error: ErroredQuery = { 
+      const error: ErroredQuery = {
         error: 'app',
         id: 'test-error-1',
         name: 'Query failed',
-        details: { reason: 'Invalid syntax' }
+        details: {reason: 'Invalid syntax'},
       };
       view.listeners.forEach(cb => cb([], 'error', error));
       await expect.poll(() => element.textContent).toBe('Error: Query failed');
@@ -660,8 +661,8 @@ describe('useSuspenseQuery', () => {
         const [data, details] = useSuspenseQuery(q, {suspendUntil: 'complete'});
         return (
           <div>
-            {details.type === 'error' 
-              ? `Error: ${details.error?.queryName || 'Unknown error'}` 
+            {details.type === 'error'
+              ? `Error: ${details.error?.queryName || 'Unknown error'}`
               : JSON.stringify(data)}
           </div>
         );
@@ -678,14 +679,16 @@ describe('useSuspenseQuery', () => {
       await expect.poll(() => element.textContent).toBe('loading');
 
       const view = materializeSpy.mock.results[0].value as {
-        listeners: Set<(snap: unknown, resultType: ResultType, error?: ErroredQuery) => void>;
+        listeners: Set<
+          (snap: unknown, resultType: ResultType, error?: ErroredQuery) => void
+        >;
       };
 
       const error: ErroredQuery = {
         error: 'app',
         id: 'test-error-2',
         name: 'Query failed',
-        details: { reason: 'Invalid syntax' }
+        details: {reason: 'Invalid syntax'},
       };
       view.listeners.forEach(cb => cb(undefined, 'error', error));
       await expect.poll(() => element.textContent).toBe('Error: Query failed');
@@ -700,8 +703,8 @@ describe('useSuspenseQuery', () => {
         const [data, details] = useSuspenseQuery(q, {suspendUntil: 'partial'});
         return (
           <div>
-            {details.type === 'error' 
-              ? `Error: ${details.error?.queryName}` 
+            {details.type === 'error'
+              ? `Error: ${details.error?.queryName}`
               : `Data: ${JSON.stringify(data)}, Type: ${details.type}`}
           </div>
         );
@@ -718,7 +721,9 @@ describe('useSuspenseQuery', () => {
       await expect.poll(() => element.textContent).toBe('loading');
 
       const view = materializeSpy.mock.results[0].value as {
-        listeners: Set<(snap: unknown, resultType: ResultType, error?: ErroredQuery) => void>;
+        listeners: Set<
+          (snap: unknown, resultType: ResultType, error?: ErroredQuery) => void
+        >;
       };
 
       // First emit error
@@ -726,14 +731,18 @@ describe('useSuspenseQuery', () => {
         error: 'app',
         id: 'temp-failure',
         name: 'Temporary failure',
-        details: {}
+        details: {},
       };
       view.listeners.forEach(cb => cb([], 'error', error));
-      await expect.poll(() => element.textContent).toBe('Error: Temporary failure');
+      await expect
+        .poll(() => element.textContent)
+        .toBe('Error: Temporary failure');
 
       // Then emit success
       view.listeners.forEach(cb => cb([{a: 1}], 'complete'));
-      await expect.poll(() => element.textContent).toBe('Data: [{"a":1}], Type: complete');
+      await expect
+        .poll(() => element.textContent)
+        .toBe('Data: [{"a":1}], Type: complete');
     });
 
     test('query can return partial data with error state', async () => {
@@ -745,9 +754,8 @@ describe('useSuspenseQuery', () => {
         const [data, details] = useSuspenseQuery(q, {suspendUntil: 'partial'});
         return (
           <div>
-            Data: {JSON.stringify(data)}, 
-            Type: {details.type}, 
-            Error: {details.type === 'error' ? details.error?.queryName : 'none'}
+            Data: {JSON.stringify(data)}, Type: {details.type}, Error:{' '}
+            {details.type === 'error' ? details.error?.queryName : 'none'}
           </div>
         );
       }
@@ -763,17 +771,20 @@ describe('useSuspenseQuery', () => {
       await expect.poll(() => element.textContent).toBe('loading');
 
       const view = materializeSpy.mock.results[0].value as {
-        listeners: Set<(snap: unknown, resultType: ResultType, error?: ErroredQuery) => void>;
+        listeners: Set<
+          (snap: unknown, resultType: ResultType, error?: ErroredQuery) => void
+        >;
       };
 
       const error: ErroredQuery = {
         error: 'app',
         id: 'partial-failure',
         name: 'Partial failure',
-        details: { message: 'Some items failed' }
+        details: {message: 'Some items failed'},
       };
       view.listeners.forEach(cb => cb([{a: 1}], 'error', error));
-      await expect.poll(() => element.textContent)
+      await expect
+        .poll(() => element.textContent)
         .toBe('Data: [{"a":1}], Type: error, Error: Partial failure');
     });
 
@@ -786,8 +797,8 @@ describe('useSuspenseQuery', () => {
         const [data, details] = useSuspenseQuery(q, {suspendUntil: 'partial'});
         return (
           <div>
-            {details.type === 'error' 
-              ? `Error state: ${details.error?.queryName}` 
+            {details.type === 'error'
+              ? `Error state: ${details.error?.queryName}`
               : `Data: ${JSON.stringify(data)}`}
           </div>
         );
@@ -804,7 +815,9 @@ describe('useSuspenseQuery', () => {
       await expect.poll(() => element.textContent).toBe('loading');
 
       const view = materializeSpy.mock.results[0].value as {
-        listeners: Set<(snap: unknown, resultType: ResultType, error?: ErroredQuery) => void>;
+        listeners: Set<
+          (snap: unknown, resultType: ResultType, error?: ErroredQuery) => void
+        >;
       };
 
       // Emit error immediately
@@ -812,10 +825,12 @@ describe('useSuspenseQuery', () => {
         error: 'zero',
         id: 'immediate-error',
         name: 'Immediate error',
-        details: {}
+        details: {},
       };
       view.listeners.forEach(cb => cb([], 'error', error));
-      await expect.poll(() => element.textContent).toBe('Error state: Immediate error');
+      await expect
+        .poll(() => element.textContent)
+        .toBe('Error state: Immediate error');
     });
 
     test('HTTP error type is handled correctly', async () => {
@@ -828,7 +843,7 @@ describe('useSuspenseQuery', () => {
         return (
           <div>
             {details.type === 'error' && details.error?.type === 'http'
-              ? `HTTP Error: ${(details.error as any).status}` 
+              ? `HTTP Error: ${details.error.status}`
               : JSON.stringify(data)}
           </div>
         );
@@ -845,14 +860,18 @@ describe('useSuspenseQuery', () => {
       await expect.poll(() => element.textContent).toBe('loading');
 
       const view = materializeSpy.mock.results[0].value as {
-        listeners: Set<(snap: unknown, resultType: ResultType, error?: ErroredQuery) => void>;
+        listeners: Set<
+          (snap: unknown, resultType: ResultType, error?: ErroredQuery) => void
+        >;
       };
 
       const httpError: ErroredQuery = {
         error: 'http',
         status: 500,
-        message: 'Internal Server Error'
-      } as ErroredQuery;
+        id: 'q1',
+        name: 'q1',
+        details: 'Internal Server Error',
+      };
       view.listeners.forEach(cb => cb([], 'error', httpError));
       await expect.poll(() => element.textContent).toBe('HTTP Error: 500');
     });

--- a/packages/zero-react/src/use-query.test.tsx
+++ b/packages/zero-react/src/use-query.test.tsx
@@ -11,6 +11,7 @@ import {
 } from './use-query.tsx';
 import {ZeroProvider} from './zero-provider.tsx';
 import type {Zero} from '../../zero-client/src/client/zero.ts';
+import type {ErroredQuery} from '../../zero-protocol/src/custom-queries.ts';
 
 function newMockQuery(
   query: string,
@@ -368,6 +369,7 @@ describe('ViewStore', () => {
       cleanup();
     });
   });
+
 });
 
 describe('useSuspenseQuery', () => {
@@ -606,5 +608,253 @@ describe('useSuspenseQuery', () => {
 
     view.listeners.forEach(cb => cb(undefined, 'complete'));
     await expect.poll(() => element.textContent).toBe('singularUndefined');
+  });
+
+  describe('error handling', () => {
+    test('plural query returns error details when query fails', async () => {
+      const q = newMockQuery('query' + unique);
+      const zero = newMockZero('client' + unique);
+      const materializeSpy = vi.spyOn(zero, 'materialize');
+
+      function Comp() {
+        const [data, details] = useSuspenseQuery(q, {suspendUntil: 'complete'});
+        return (
+          <div>
+            {details.type === 'error' 
+              ? `Error: ${details.error?.queryName || 'Unknown error'}` 
+              : JSON.stringify(data)}
+          </div>
+        );
+      }
+
+      root.render(
+        <ZeroProvider zero={zero}>
+          <Suspense fallback={<>loading</>}>
+            <Comp />
+          </Suspense>
+        </ZeroProvider>,
+      );
+
+      await expect.poll(() => element.textContent).toBe('loading');
+
+      const view = materializeSpy.mock.results[0].value as {
+        listeners: Set<(snap: unknown, resultType: ResultType, error?: ErroredQuery) => void>;
+      };
+
+      const error: ErroredQuery = { 
+        error: 'app',
+        id: 'test-error-1',
+        name: 'Query failed',
+        details: { reason: 'Invalid syntax' }
+      };
+      view.listeners.forEach(cb => cb([], 'error', error));
+      await expect.poll(() => element.textContent).toBe('Error: Query failed');
+    });
+
+    test('singular query returns error details when query fails', async () => {
+      const q = newMockQuery('query' + unique, true);
+      const zero = newMockZero('client' + unique);
+      const materializeSpy = vi.spyOn(zero, 'materialize');
+
+      function Comp() {
+        const [data, details] = useSuspenseQuery(q, {suspendUntil: 'complete'});
+        return (
+          <div>
+            {details.type === 'error' 
+              ? `Error: ${details.error?.queryName || 'Unknown error'}` 
+              : JSON.stringify(data)}
+          </div>
+        );
+      }
+
+      root.render(
+        <ZeroProvider zero={zero}>
+          <Suspense fallback={<>loading</>}>
+            <Comp />
+          </Suspense>
+        </ZeroProvider>,
+      );
+
+      await expect.poll(() => element.textContent).toBe('loading');
+
+      const view = materializeSpy.mock.results[0].value as {
+        listeners: Set<(snap: unknown, resultType: ResultType, error?: ErroredQuery) => void>;
+      };
+
+      const error: ErroredQuery = {
+        error: 'app',
+        id: 'test-error-2',
+        name: 'Query failed',
+        details: { reason: 'Invalid syntax' }
+      };
+      view.listeners.forEach(cb => cb(undefined, 'error', error));
+      await expect.poll(() => element.textContent).toBe('Error: Query failed');
+    });
+
+    test('query transitions from error to success state', async () => {
+      const q = newMockQuery('query' + unique);
+      const zero = newMockZero('client' + unique);
+      const materializeSpy = vi.spyOn(zero, 'materialize');
+
+      function Comp() {
+        const [data, details] = useSuspenseQuery(q, {suspendUntil: 'partial'});
+        return (
+          <div>
+            {details.type === 'error' 
+              ? `Error: ${details.error?.queryName}` 
+              : `Data: ${JSON.stringify(data)}, Type: ${details.type}`}
+          </div>
+        );
+      }
+
+      root.render(
+        <ZeroProvider zero={zero}>
+          <Suspense fallback={<>loading</>}>
+            <Comp />
+          </Suspense>
+        </ZeroProvider>,
+      );
+
+      await expect.poll(() => element.textContent).toBe('loading');
+
+      const view = materializeSpy.mock.results[0].value as {
+        listeners: Set<(snap: unknown, resultType: ResultType, error?: ErroredQuery) => void>;
+      };
+
+      // First emit error
+      const error: ErroredQuery = {
+        error: 'app',
+        id: 'temp-failure',
+        name: 'Temporary failure',
+        details: {}
+      };
+      view.listeners.forEach(cb => cb([], 'error', error));
+      await expect.poll(() => element.textContent).toBe('Error: Temporary failure');
+
+      // Then emit success
+      view.listeners.forEach(cb => cb([{a: 1}], 'complete'));
+      await expect.poll(() => element.textContent).toBe('Data: [{"a":1}], Type: complete');
+    });
+
+    test('query can return partial data with error state', async () => {
+      const q = newMockQuery('query' + unique);
+      const zero = newMockZero('client' + unique);
+      const materializeSpy = vi.spyOn(zero, 'materialize');
+
+      function Comp() {
+        const [data, details] = useSuspenseQuery(q, {suspendUntil: 'partial'});
+        return (
+          <div>
+            Data: {JSON.stringify(data)}, 
+            Type: {details.type}, 
+            Error: {details.type === 'error' ? details.error?.queryName : 'none'}
+          </div>
+        );
+      }
+
+      root.render(
+        <ZeroProvider zero={zero}>
+          <Suspense fallback={<>loading</>}>
+            <Comp />
+          </Suspense>
+        </ZeroProvider>,
+      );
+
+      await expect.poll(() => element.textContent).toBe('loading');
+
+      const view = materializeSpy.mock.results[0].value as {
+        listeners: Set<(snap: unknown, resultType: ResultType, error?: ErroredQuery) => void>;
+      };
+
+      const error: ErroredQuery = {
+        error: 'app',
+        id: 'partial-failure',
+        name: 'Partial failure',
+        details: { message: 'Some items failed' }
+      };
+      view.listeners.forEach(cb => cb([{a: 1}], 'error', error));
+      await expect.poll(() => element.textContent)
+        .toBe('Data: [{"a":1}], Type: error, Error: Partial failure');
+    });
+
+    test('error state without suspense returns immediately', async () => {
+      const q = newMockQuery('query' + unique);
+      const zero = newMockZero('client' + unique);
+      const materializeSpy = vi.spyOn(zero, 'materialize');
+
+      function Comp() {
+        const [data, details] = useSuspenseQuery(q, {suspendUntil: 'partial'});
+        return (
+          <div>
+            {details.type === 'error' 
+              ? `Error state: ${details.error?.queryName}` 
+              : `Data: ${JSON.stringify(data)}`}
+          </div>
+        );
+      }
+
+      root.render(
+        <ZeroProvider zero={zero}>
+          <Suspense fallback={<>loading</>}>
+            <Comp />
+          </Suspense>
+        </ZeroProvider>,
+      );
+
+      await expect.poll(() => element.textContent).toBe('loading');
+
+      const view = materializeSpy.mock.results[0].value as {
+        listeners: Set<(snap: unknown, resultType: ResultType, error?: ErroredQuery) => void>;
+      };
+
+      // Emit error immediately
+      const error: ErroredQuery = {
+        error: 'zero',
+        id: 'immediate-error',
+        name: 'Immediate error',
+        details: {}
+      };
+      view.listeners.forEach(cb => cb([], 'error', error));
+      await expect.poll(() => element.textContent).toBe('Error state: Immediate error');
+    });
+
+    test('HTTP error type is handled correctly', async () => {
+      const q = newMockQuery('query' + unique);
+      const zero = newMockZero('client' + unique);
+      const materializeSpy = vi.spyOn(zero, 'materialize');
+
+      function Comp() {
+        const [data, details] = useSuspenseQuery(q, {suspendUntil: 'partial'});
+        return (
+          <div>
+            {details.type === 'error' && details.error?.type === 'http'
+              ? `HTTP Error: ${(details.error as any).status}` 
+              : JSON.stringify(data)}
+          </div>
+        );
+      }
+
+      root.render(
+        <ZeroProvider zero={zero}>
+          <Suspense fallback={<>loading</>}>
+            <Comp />
+          </Suspense>
+        </ZeroProvider>,
+      );
+
+      await expect.poll(() => element.textContent).toBe('loading');
+
+      const view = materializeSpy.mock.results[0].value as {
+        listeners: Set<(snap: unknown, resultType: ResultType, error?: ErroredQuery) => void>;
+      };
+
+      const httpError: ErroredQuery = {
+        error: 'http',
+        status: 500,
+        message: 'Internal Server Error'
+      } as ErroredQuery;
+      view.listeners.forEach(cb => cb([], 'error', httpError));
+      await expect.poll(() => element.textContent).toBe('HTTP Error: 500');
+    });
   });
 });

--- a/packages/zero-react/src/use-query.tsx
+++ b/packages/zero-react/src/use-query.tsx
@@ -11,10 +11,33 @@ import {type HumanReadable, type Query} from '../../zql/src/query/query.ts';
 import {DEFAULT_TTL_MS, type TTL} from '../../zql/src/query/ttl.ts';
 import type {ResultType, TypedView} from '../../zql/src/query/typed-view.ts';
 import {useZero} from './zero-provider.tsx';
+import type {ErroredQuery} from '../../zero-protocol/src/custom-queries.ts';
 
-export type QueryResultDetails = Readonly<{
-  type: ResultType;
-}>;
+export type QueryResultDetails = Readonly<
+  | {
+      type: 'complete';
+    }
+  | {
+      type: 'unknown';
+    }
+  | QueryErrorDetails
+>;
+
+type QueryErrorDetails = {
+  type: 'error';
+  error?:
+    | {
+        type: 'app';
+        queryName: string;
+        details: ReadonlyJSONValue;
+      }
+    | {
+        type: 'http';
+        queryName: string;
+        status: number;
+        details: ReadonlyJSONValue;
+      };
+};
 
 export type QueryResult<TReturn> = readonly [
   HumanReadable<TReturn>,
@@ -138,11 +161,14 @@ const disabledSubscriber = () => () => {};
 
 const resultTypeUnknown = {type: 'unknown'} as const;
 const resultTypeComplete = {type: 'complete'} as const;
+const resultTypeError = {type: 'error'} as const;
 
 const emptySnapshotSingularUnknown = [undefined, resultTypeUnknown] as const;
 const emptySnapshotSingularComplete = [undefined, resultTypeComplete] as const;
+const emptySnapshotSingularErrorUnknown = [undefined, resultTypeError] as const;
 const emptySnapshotPluralUnknown = [emptyArray, resultTypeUnknown] as const;
 const emptySnapshotPluralComplete = [emptyArray, resultTypeComplete] as const;
+const emptySnapshotErrorUnknown = [emptyArray, resultTypeError] as const;
 
 function getDefaultSnapshot<TReturn>(singular: boolean): QueryResult<TReturn> {
   return (
@@ -157,26 +183,66 @@ function getDefaultSnapshot<TReturn>(singular: boolean): QueryResult<TReturn> {
 function getSnapshot<TReturn>(
   singular: boolean,
   data: HumanReadable<TReturn>,
-  resultType: string,
+  resultType: ResultType,
+  error?: ErroredQuery | undefined,
 ): QueryResult<TReturn> {
   if (singular && data === undefined) {
-    return (resultType === 'complete'
-      ? emptySnapshotSingularComplete
-      : emptySnapshotSingularUnknown) as unknown as QueryResult<TReturn>;
+    switch (resultType) {
+      case 'error':
+        if (error) {
+          return [
+            undefined,
+            makeError(error),
+          ] as unknown as QueryResult<TReturn>;
+        }
+        return emptySnapshotSingularErrorUnknown as unknown as QueryResult<TReturn>;
+      case 'complete':
+        return emptySnapshotSingularComplete as unknown as QueryResult<TReturn>;
+      case 'unknown':
+        return emptySnapshotSingularUnknown as unknown as QueryResult<TReturn>;
+    }
   }
 
   if (!singular && (data as unknown[]).length === 0) {
-    return (
-      resultType === 'complete'
-        ? emptySnapshotPluralComplete
-        : emptySnapshotPluralUnknown
-    ) as QueryResult<TReturn>;
+    switch (resultType) {
+      case 'error':
+        if (error) {
+          break;
+        }
+        return emptySnapshotErrorUnknown as unknown as QueryResult<TReturn>;
+      case 'complete':
+        return emptySnapshotPluralComplete as unknown as QueryResult<TReturn>;
+      case 'unknown':
+        return emptySnapshotPluralUnknown as unknown as QueryResult<TReturn>;
+    }
   }
 
-  return [
-    data,
-    resultType === 'complete' ? resultTypeComplete : resultTypeUnknown,
-  ];
+  switch (resultType) {
+    case 'error':
+    case 'complete':
+      return [data, resultTypeComplete];
+    case 'unknown':
+      return [data, resultTypeUnknown];
+  }
+}
+
+function makeError(error: ErroredQuery): QueryErrorDetails {
+  return {
+    type: 'error',
+    error:
+      error.error === 'app' || error.error === 'zero'
+        ? {
+            type: 'app',
+            queryName: error.name,
+            details: error.details,
+          }
+        : {
+            type: 'http',
+            queryName: error.name,
+            status: error.status,
+            details: error.details,
+          },
+  };
 }
 
 declare const TESTING: boolean;
@@ -379,17 +445,29 @@ class ViewWrapper<
   #onData = (
     snap: Immutable<HumanReadable<TReturn>>,
     resultType: ResultType,
+    error?: ErroredQuery | undefined,
   ) => {
     const data =
       snap === undefined
         ? snap
         : (deepClone(snap as ReadonlyJSONValue) as HumanReadable<TReturn>);
-    this.#snapshot = getSnapshot(this.#format.singular, data, resultType);
+    this.#snapshot = getSnapshot(
+      this.#format.singular,
+      data,
+      resultType,
+      error,
+    );
     if (resultType === 'complete') {
       this.#complete = true;
       this.#completeResolver.resolve();
       this.#nonEmpty = true;
       this.#nonEmptyResolver.resolve();
+    }
+    if (resultType === 'error') {
+      this.#complete = true;
+      this.#completeResolver.reject(error);
+      this.#nonEmpty = true;
+      this.#nonEmptyResolver.reject(error);
     }
 
     if (

--- a/packages/zero-react/src/use-query.tsx
+++ b/packages/zero-react/src/use-query.tsx
@@ -207,7 +207,10 @@ function getSnapshot<TReturn>(
     switch (resultType) {
       case 'error':
         if (error) {
-          break;
+          return [
+            emptyArray,
+            makeError(error),
+          ] as unknown as QueryResult<TReturn>;
         }
         return emptySnapshotErrorUnknown as unknown as QueryResult<TReturn>;
       case 'complete':
@@ -219,6 +222,10 @@ function getSnapshot<TReturn>(
 
   switch (resultType) {
     case 'error':
+      if (error) {
+        return [data, makeError(error)];
+      }
+      return [data, resultTypeError];
     case 'complete':
       return [data, resultTypeComplete];
     case 'unknown':
@@ -457,17 +464,11 @@ class ViewWrapper<
       resultType,
       error,
     );
-    if (resultType === 'complete') {
+    if (resultType === 'complete' || resultType === 'error') {
       this.#complete = true;
       this.#completeResolver.resolve();
       this.#nonEmpty = true;
       this.#nonEmptyResolver.resolve();
-    }
-    if (resultType === 'error') {
-      this.#complete = true;
-      this.#completeResolver.reject(error);
-      this.#nonEmpty = true;
-      this.#nonEmptyResolver.reject(error);
     }
 
     if (

--- a/packages/zql/src/query/query-delegate.ts
+++ b/packages/zql/src/query/query-delegate.ts
@@ -6,9 +6,13 @@ import type {MetricsDelegate} from './metrics-delegate.ts';
 import type {CustomQueryID} from './named.ts';
 import type {Query, RunOptions} from './query.ts';
 import type {TTL} from './ttl.ts';
+import type {ErroredQuery} from '../../../zero-protocol/src/custom-queries.ts';
 
 export type CommitListener = () => void;
-export type GotCallback = (got: boolean) => void;
+export type GotCallback = (
+  got: boolean,
+  error?: ErroredQuery | undefined,
+) => void;
 
 export interface NewQueryDelegate {
   newQuery<

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -783,7 +783,13 @@ export class QueryImpl<
         : delegate.updateServerQuery(ast, newTTL);
     };
 
-    const gotCallback: GotCallback = got => {
+    const gotCallback: GotCallback = (got, error) => {
+      if (error) {
+        queryCompleteResolver.reject(error);
+        queryComplete = true;
+        return;
+      }
+
       if (got) {
         delegate.addMetric(
           'query-materialization-end-to-end',
@@ -847,6 +853,9 @@ export class QueryImpl<
           if (type === 'complete') {
             v.destroy();
             resolve(data as HumanReadable<TReturn>);
+          } else if (type === 'error') {
+            v.destroy();
+            resolve(Promise.reject(data));
           }
         });
       });

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -546,7 +546,7 @@ export abstract class AbstractQuery<
           defaultFormat,
           this.customQueryID,
           undefined,
-        ),
+        ) as AnyQuery,
       ) as unknown as QueryImpl<any, any>;
       return {
         type: 'correlatedSubquery',

--- a/packages/zql/src/query/typed-view.ts
+++ b/packages/zql/src/query/typed-view.ts
@@ -1,14 +1,19 @@
 import type {Immutable} from '../../../shared/src/immutable.ts';
+import type {ErroredQuery} from '../../../zero-protocol/src/custom-queries.ts';
 import type {TTL} from './ttl.ts';
 
-export type ResultType = 'unknown' | 'complete';
+export type ResultType = 'unknown' | 'complete' | 'error';
 
 /**
  * Called when the view changes. The received data should be considered
  * immutable. Caller must not modify it. Passed data is valid until next
  * time listener is called.
  */
-export type Listener<T> = (data: Immutable<T>, resultType: ResultType) => void;
+export type Listener<T> = (
+  data: Immutable<T>,
+  resultType: ResultType,
+  error?: ErroredQuery | undefined,
+) => void;
 
 export type TypedView<T> = {
   addListener(listener: Listener<T>): () => void;


### PR DESCRIPTION
```ts
const [data, details] = useQuery(...);

if (details.type === 'error') {
  // do something with result.error
}
```

Coming next is a way to let the user `retry` failed queries. E.g.,

```ts
datails.retry();
```

Might go with a shape more like TanStack's --

https://tanstack.com/query/v4/docs/framework/react/reference/useQuery

which would look like:

```ts
const [data, {type, error, retry}] = useQuery(...);
```