### PR TITLE
chore(zero-cache): fix flake, skip obsolete

### DIFF
--- a/packages/zero-cache/src/db/transaction-pool.pg-test.ts
+++ b/packages/zero-cache/src/db/transaction-pool.pg-test.ts
@@ -185,7 +185,8 @@ describe('db/transaction-pool', () => {
     });
   });
 
-  test('pool resizing before run', async () => {
+  // TODO: Remove pool resizing functionality
+  test.skip('pool resizing before run', async () => {
     const pool = newTransactionPool(
       Mode.SERIALIZABLE,
       initTask,
@@ -218,7 +219,8 @@ describe('db/transaction-pool', () => {
     });
   });
 
-  test('pool resizing after run', async () => {
+  // TODO: Remove pool resizing functionality
+  test.skip('pool resizing after run', async () => {
     const pool = newTransactionPool(
       Mode.SERIALIZABLE,
       initTask,
@@ -281,151 +283,156 @@ describe('db/transaction-pool', () => {
     });
   });
 
-  test('pool resizing and idle/keepalive timeouts', {retry: 2}, async () => {
-    const pool = newTransactionPool(
-      Mode.SERIALIZABLE,
-      initTask,
-      cleanupTask,
-      2,
-      5,
-      {
-        forInitialWorkers: {
-          timeoutMs: 100,
-          task: keepaliveTask,
+  // TODO: Remove pool resizing functionality
+  test.skip(
+    'pool resizing and idle/keepalive timeouts',
+    {retry: 2},
+    async () => {
+      const pool = newTransactionPool(
+        Mode.SERIALIZABLE,
+        initTask,
+        cleanupTask,
+        2,
+        5,
+        {
+          forInitialWorkers: {
+            timeoutMs: 100,
+            task: keepaliveTask,
+          },
+          forExtraWorkers: {
+            timeoutMs: 50,
+            task: 'done',
+          },
         },
-        forExtraWorkers: {
-          timeoutMs: 50,
-          task: 'done',
-        },
-      },
-    );
+      );
 
-    const processing = new Queue<boolean>();
-    const canProceed = new Queue<boolean>();
+      const processing = new Queue<boolean>();
+      const canProceed = new Queue<boolean>();
 
-    const blockingTask =
-      (stmt: string) => async (tx: postgres.TransactionSql) => {
-        processing.enqueue(true);
-        await canProceed.dequeue();
-        return task(stmt)(tx);
-      };
+      const blockingTask =
+        (stmt: string) => async (tx: postgres.TransactionSql) => {
+          processing.enqueue(true);
+          await canProceed.dequeue();
+          return task(stmt)(tx);
+        };
 
-    pool.run(db);
+      pool.run(db);
 
-    void pool.process(blockingTask(`INSERT INTO foo (id) VALUES (1)`));
-    void pool.process(
-      blockingTask(`INSERT INTO foo (id, val) VALUES (6, 'foo')`),
-    );
+      void pool.process(blockingTask(`INSERT INTO foo (id) VALUES (1)`));
+      void pool.process(
+        blockingTask(`INSERT INTO foo (id, val) VALUES (6, 'foo')`),
+      );
 
-    for (let i = 0; i < 2; i++) {
-      await processing.dequeue();
-    }
+      for (let i = 0; i < 2; i++) {
+        await processing.dequeue();
+      }
 
-    void pool.process(blockingTask(`INSERT INTO foo (id) VALUES (3)`));
-    void pool.process(blockingTask(`INSERT INTO foo (id) VALUES (2)`));
-    void pool.process(
-      blockingTask(`INSERT INTO foo (id, val) VALUES (8, 'foo')`),
-    );
+      void pool.process(blockingTask(`INSERT INTO foo (id) VALUES (3)`));
+      void pool.process(blockingTask(`INSERT INTO foo (id) VALUES (2)`));
+      void pool.process(
+        blockingTask(`INSERT INTO foo (id, val) VALUES (8, 'foo')`),
+      );
 
-    // Ensure all tasks get a worker.
-    for (let i = 2; i < 5; i++) {
-      await processing.dequeue();
-    }
-    // Let all 5 tasks proceed.
-    for (let i = 0; i < 5; i++) {
-      canProceed.enqueue(true);
-    }
+      // Ensure all tasks get a worker.
+      for (let i = 2; i < 5; i++) {
+        await processing.dequeue();
+      }
+      // Let all 5 tasks proceed.
+      for (let i = 0; i < 5; i++) {
+        canProceed.enqueue(true);
+      }
 
-    // Let the extra workers hit their 50ms idle timeout.
-    await sleep(100);
+      // Let the extra workers hit their 50ms idle timeout.
+      await sleep(100);
 
-    await expectTables(db, {
-      ['public.cleaned']: [{id: 1}, {id: 2}, {id: 3}],
-      ['public.keepalive']: [],
-    });
+      await expectTables(db, {
+        ['public.cleaned']: [{id: 1}, {id: 2}, {id: 3}],
+        ['public.keepalive']: [],
+      });
 
-    // Repeat to spawn more workers.
-    void pool.process(blockingTask(`INSERT INTO foo (id) VALUES (10)`));
-    void pool.process(
-      blockingTask(`INSERT INTO foo (id, val) VALUES (60, 'foo')`),
-    );
+      // Repeat to spawn more workers.
+      void pool.process(blockingTask(`INSERT INTO foo (id) VALUES (10)`));
+      void pool.process(
+        blockingTask(`INSERT INTO foo (id, val) VALUES (60, 'foo')`),
+      );
 
-    for (let i = 0; i < 2; i++) {
-      await processing.dequeue();
-    }
+      for (let i = 0; i < 2; i++) {
+        await processing.dequeue();
+      }
 
-    void pool.process(blockingTask(`INSERT INTO foo (id) VALUES (30)`));
-    void pool.process(blockingTask(`INSERT INTO foo (id) VALUES (20)`));
-    void pool.process(
-      blockingTask(`INSERT INTO foo (id, val) VALUES (80, 'foo')`),
-    );
+      void pool.process(blockingTask(`INSERT INTO foo (id) VALUES (30)`));
+      void pool.process(blockingTask(`INSERT INTO foo (id) VALUES (20)`));
+      void pool.process(
+        blockingTask(`INSERT INTO foo (id, val) VALUES (80, 'foo')`),
+      );
 
-    for (let i = 2; i < 5; i++) {
-      await processing.dequeue();
-    }
+      for (let i = 2; i < 5; i++) {
+        await processing.dequeue();
+      }
 
-    // Let all 5 tasks proceed.
-    for (let i = 0; i < 5; i++) {
-      canProceed.enqueue(true);
-    }
+      // Let all 5 tasks proceed.
+      for (let i = 0; i < 5; i++) {
+        canProceed.enqueue(true);
+      }
 
-    // Let the new extra workers hit their 50ms idle timeout.
-    await sleep(100);
+      // Let the new extra workers hit their 50ms idle timeout.
+      await sleep(100);
 
-    await expectTables(db, {
-      ['public.cleaned']: [
-        {id: 1},
-        {id: 2},
-        {id: 3},
-        {id: 4},
-        {id: 5},
-        {id: 6},
-      ],
-      ['public.keepalive']: [],
-    });
+      await expectTables(db, {
+        ['public.cleaned']: [
+          {id: 1},
+          {id: 2},
+          {id: 3},
+          {id: 4},
+          {id: 5},
+          {id: 6},
+        ],
+        ['public.keepalive']: [],
+      });
 
-    // Let the initial workers hit their 100ms keepalive timeout.
-    await sleep(100);
+      // Let the initial workers hit their 100ms keepalive timeout.
+      await sleep(100);
 
-    pool.setDone();
-    await pool.done();
+      pool.setDone();
+      await pool.done();
 
-    await expectTables(db, {
-      ['public.foo']: [
-        {id: 1, val: null},
-        {id: 2, val: null},
-        {id: 3, val: null},
-        {id: 6, val: 'foo'},
-        {id: 8, val: 'foo'},
-        {id: 10, val: null},
-        {id: 20, val: null},
-        {id: 30, val: null},
-        {id: 60, val: 'foo'},
-        {id: 80, val: 'foo'},
-      ],
-      ['public.workers']: [
-        {id: 1},
-        {id: 2},
-        {id: 3},
-        {id: 4},
-        {id: 5},
-        {id: 6},
-        {id: 7},
-        {id: 8},
-      ],
-      ['public.keepalive']: [{id: 1}, {id: 2}],
-      ['public.cleaned']: [
-        {id: 1},
-        {id: 2},
-        {id: 3},
-        {id: 4},
-        {id: 5},
-        {id: 6},
-        {id: 7},
-        {id: 8},
-      ],
-    });
-  });
+      await expectTables(db, {
+        ['public.foo']: [
+          {id: 1, val: null},
+          {id: 2, val: null},
+          {id: 3, val: null},
+          {id: 6, val: 'foo'},
+          {id: 8, val: 'foo'},
+          {id: 10, val: null},
+          {id: 20, val: null},
+          {id: 30, val: null},
+          {id: 60, val: 'foo'},
+          {id: 80, val: 'foo'},
+        ],
+        ['public.workers']: [
+          {id: 1},
+          {id: 2},
+          {id: 3},
+          {id: 4},
+          {id: 5},
+          {id: 6},
+          {id: 7},
+          {id: 8},
+        ],
+        ['public.keepalive']: [{id: 1}, {id: 2}],
+        ['public.cleaned']: [
+          {id: 1},
+          {id: 2},
+          {id: 3},
+          {id: 4},
+          {id: 5},
+          {id: 6},
+          {id: 7},
+          {id: 8},
+        ],
+      });
+    },
+  );
 
   test('external failure before running', async () => {
     const pool = newTransactionPool(

--- a/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.pg-test.ts
@@ -419,8 +419,7 @@ describe('view-syncer/cvr', () => {
     );
   });
 
-  // Relies on an async homing signal (with no explicit flush, so allow retries)
-  test('load existing cvr', {retry: 3}, async () => {
+  test('load existing cvr', async () => {
     const initialState: DBState = {
       instances: [
         {
@@ -509,16 +508,19 @@ describe('view-syncer/cvr', () => {
       clientSchema: null,
     } satisfies CVRSnapshot);
 
-    await expectState(cvrDb, {
-      ...initialState,
-      instances: [
-        {
-          ...initialState.instances[0],
-          owner: 'my-task',
-          grantedAt: 1709251200000,
-        },
-      ],
-    });
+    // Relies on an async homing signal (with no explicit flush, so use waitFor)
+    await vi.waitFor(() =>
+      expectState(cvrDb, {
+        ...initialState,
+        instances: [
+          {
+            ...initialState.instances[0],
+            owner: 'my-task',
+            grantedAt: 1709251200000,
+          },
+        ],
+      }),
+    );
   });
 
   test('no update', async () => {


### PR DESCRIPTION
Use `vi.waitFor()` to deflake a cvr test.

Skip (flakey) transaction pool tests that cover unused functionality.