### PR TITLE
chore(zero-cache): wait for copiers to close before closing replication

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
@@ -219,9 +219,13 @@ export async function initialSync(
       );
     } finally {
       copiers.setDone();
-      // Workaround a Node bug in Windows in which certain COPY streams result
-      // in hanging the connection, which causes this await to never resolve.
-      void copyPool.end().catch(e => lc.warn?.(`Error closing copyPool`, e));
+      if (platform() === 'win32') {
+        // Workaround a Node bug in Windows in which certain COPY streams result
+        // in hanging the connection, which causes this await to never resolve.
+        void copyPool.end().catch(e => lc.warn?.(`Error closing copyPool`, e));
+      } else {
+        await copyPool.end();
+      }
     }
   } catch (e) {
     // If initial-sync did not succeed, make a best effort to drop the


### PR DESCRIPTION
This should correctly fix the initial snapshot issue by ensuring that all copy workers start up (and set their snapshots) before the replication session is closed.

Keep the no-wait workaround for win32 only (to address the COPY hang bug in Node win32).