### PR TITLE
chore(zero-cache): reenable change-source.pg tests

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/change-source.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.pg-test.ts
@@ -36,7 +36,7 @@ import {dropEventTriggerStatements} from './schema/ddl.ts';
 const APP_ID = '23';
 const SHARD_NUM = 1;
 
-describe.skip('change-source/pg', {timeout: 30000, retry: 3}, () => {
+describe('change-source/pg', {timeout: 30000, retry: 3}, () => {
   let logSink: TestLogSink;
   let lc: LogContext;
   let upstream: PostgresDB;
@@ -50,12 +50,8 @@ describe.skip('change-source/pg', {timeout: 30000, retry: 3}, () => {
     streams = [];
     logSink = new TestLogSink();
     lc = new LogContext('error', {}, logSink);
-    upstream = await testDBs.create(
-      'change_source_pg_test_upstream_' + Math.random().toString(36).slice(2),
-    );
-    replicaDbFile = new DbFile(
-      'change_source_pg_test_replica_' + Math.random().toString(36).slice(2),
-    );
+    upstream = await testDBs.create('change_source_pg_test_upstream');
+    replicaDbFile = new DbFile('change_source_pg_test_replica');
 
     upstreamURI = getConnectionURI(upstream);
     await upstream.unsafe(`


### PR DESCRIPTION
Snapshot flakiness was fixed with https://github.com/rocicorp/mono/pull/4767