### PR TITLE
chore(zql-viz): Remove zql-viz build step.

### DIFF
--- a/apps/zql-viz/package.json
+++ b/apps/zql-viz/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "scripts": {
     "dev": "npx api-extractor run --local && vite",
-    "build": "npx api-extractor run --local && tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview"
   },


### PR DESCRIPTION
It's blocking create-canary.js from working and I can't figure out why.