### PR TITLE
fix(zero-cache): refuse or halt replication for unsupported replica identities

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -645,7 +645,7 @@ class ChangeMaker {
 
     // Validate the new table schemas
     for (const table of nextTbl.values()) {
-      validate(this.#lc, table);
+      validate(this.#lc, table, update.schema.indexes);
     }
 
     const [droppedIdx, createdIdx] = symmetricDifferences(prevIdx, nextIdx);

--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
@@ -375,7 +375,7 @@ export function validatePublications(
     }
   });
 
-  published.tables.forEach(table => validate(lc, table));
+  published.tables.forEach(table => validate(lc, table, published.indexes));
 }
 
 type ReplicaIdentities = {


### PR DESCRIPTION
User report:
* https://discord.com/channels/830183651022471199/1407339469077745664/1407548096308580454

Error at initial-sync, or halt incremental replication, when a table:
* has `REPLICA IDENTITY NOTHING`
* has `REPLICA IDENTITY INDEX` without an index ([which is equivalent to `NOTHING`](https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-REPLICA-IDENTITY))