### PR TITLE
fix(zero): zod/valita/whatever validator functions take a single arg

### DIFF
--- a/packages/zql/src/builder/builder.ts
+++ b/packages/zql/src/builder/builder.ts
@@ -97,7 +97,7 @@ export interface BuilderDelegate {
  *   }
  * }
  *
- * const input = buildPipeline(ast, myDelegate);
+ * const input = buildPipeline(ast, myDelegate, hash(ast));
  * const sink = new MySink(input);
  * ```
  */

--- a/packages/zql/src/query/named.ts
+++ b/packages/zql/src/query/named.ts
@@ -57,7 +57,7 @@ export type CustomQueryID = {
 };
 
 export type Validator<T extends ReadonlyArray<ReadonlyJSONValue>> = (
-  ...args: readonly unknown[]
+  args: readonly unknown[],
 ) => T | readonly [...T];
 
 /**
@@ -247,6 +247,7 @@ export function withValidation<
   | ValidatedSyncedQuery<TReturnQuery>
   | ValidatedSyncedQueryWithContext<TContext, TReturnQuery> {
   const {validator, takesContext} = fn;
+
   if (validator) {
     if (takesContext) {
       return ((context, ...args) =>
@@ -256,13 +257,13 @@ export function withValidation<
             ReadonlyArray<ReadonlyJSONValue>,
             TReturnQuery
           >
-        )(context, ...validator(...args))) as ValidatedSyncedQueryWithContext<
+        )(context, ...validator(args))) as ValidatedSyncedQueryWithContext<
         TContext,
         TReturnQuery
       >;
     }
     return ((...args) =>
-      fn(...validator(...args))) as ValidatedSyncedQuery<TReturnQuery>;
+      fn(...validator(args))) as ValidatedSyncedQuery<TReturnQuery>;
   }
 
   throw new Error(fn.name + ' does not have a validator defined');


### PR DESCRIPTION
```ts
const paramSchema = v.tuple([v.string(), v.number()]);
const def = syncedQueryWithContext(
  'myQuery',
  paramSchema.parse.bind(paramSchema),
  (ctx: object, ownerId, createdAt) => {
    expect(ctx).toEqual({});
    return builder.issue
      .where('ownerId', ownerId)
      .where('createdAt', '>', createdAt);
  },
);

let q = def({}, '123', 123);
expect(q.customQueryID).toEqual({
  name: 'myQuery',
  args: ['123', 123],
});

const validated = withValidation(def);
q = validated({}, '321', 321);
```

Some weird typing errors I need to work through when using withValidation(withContext( in zbugs -- https://github.com/rocicorp/mono/pull/4784