### PR TITLE
chore(zero-cache): remove queries from `desired` if they fail to transform

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -1141,6 +1141,16 @@ describe('view-syncer/service', () => {
           [
             "pokePart",
             {
+              "gotQueriesPatch": [
+                {
+                  "hash": "custom-1",
+                  "op": "del",
+                },
+                {
+                  "hash": "custom-2",
+                  "op": "del",
+                },
+              ],
               "lastMutationIDChanges": {
                 "foo": 42,
               },
@@ -1206,6 +1216,16 @@ describe('view-syncer/service', () => {
           [
             "pokePart",
             {
+              "gotQueriesPatch": [
+                {
+                  "hash": "custom-1",
+                  "op": "del",
+                },
+                {
+                  "hash": "custom-2",
+                  "op": "del",
+                },
+              ],
               "lastMutationIDChanges": {
                 "foo": 42,
               },
@@ -1278,6 +1298,16 @@ describe('view-syncer/service', () => {
           [
             "pokePart",
             {
+              "gotQueriesPatch": [
+                {
+                  "hash": "custom-1",
+                  "op": "del",
+                },
+                {
+                  "hash": "custom-2",
+                  "op": "del",
+                },
+              ],
               "lastMutationIDChanges": {
                 "foo": 42,
               },
@@ -1347,6 +1377,10 @@ describe('view-syncer/service', () => {
                 {
                   "hash": "custom-2",
                   "op": "put",
+                },
+                {
+                  "hash": "custom-1",
+                  "op": "del",
                 },
               ],
               "lastMutationIDChanges": {


### PR DESCRIPTION
I was getting tons of API calls once I started forcing zbugs to fail transformation.

Makes sense because the queries are not removed from "desired" so we keep trying them.

If a query fails to transform, remove from desired.

We'll need to make a change on the client to track failure and not re-request unless explicitly re-requested (e.g., component unmount and re-mount or a `retry()` call).