### PR TITLE
chore(zero-cache): fix test waiting too long

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr-store.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.pg-test.ts
@@ -210,7 +210,7 @@ describe('view-syncer/cvr-store', () => {
     // start a CVR load.
     const loading = store.load(lc, CONNECT_TIME);
 
-    await sleep(100);
+    await sleep(1);
 
     // Simulate catching up.
     await db`


### PR DESCRIPTION
The cvr store wait 10ms between catchup iteration in the test. waiting 100 always causes the test to break.

This also used to be 1 until today: https://github.com/rocicorp/mono/commit/0dba5a8e113082677ead4aea6152cbdc54e21b8b#diff-7621c17e965cf383b5af5b5e0d82f10b86a21879b173dcafe9fb86fdcfe84c42L213