### PR TITLE
feat(zero-cache): added passthrough of auth

### DIFF
--- a/packages/zero-cache/src/auth/jwt.test.ts
+++ b/packages/zero-cache/src/auth/jwt.test.ts
@@ -2,7 +2,7 @@ import {SignJWT, type JWTPayload} from 'jose';
 import {describe, expect, test} from 'vitest';
 import {must} from '../../../shared/src/must.ts';
 import type {AuthConfig} from '../config/zero-config.ts';
-import {createJwkPair, verifyToken} from './jwt.ts';
+import {createJwkPair, tokenConfigOptions, verifyToken} from './jwt.ts';
 
 describe('symmetric key', () => {
   const key = 'ab'.repeat(16);
@@ -30,28 +30,21 @@ describe('jwk', async () => {
   commonTests({jwk: JSON.stringify(publicJwk)}, makeToken);
 });
 
-test('too many or too few options set', async () => {
-  await expect(verifyToken({}, '', {})).rejects.toThrowError('Exactly one of');
-  await expect(
-    verifyToken(
-      {
-        secret: 'abc',
-        jwk: 'def',
-      },
-      '',
-      {},
-    ),
-  ).rejects.toThrowError('Exactly one of');
-  await expect(
-    verifyToken(
-      {
-        secret: 'abc',
-        jwksUrl: 'def',
-      },
-      '',
-      {},
-    ),
-  ).rejects.toThrowError('Exactly one of');
+test('token config options', async () => {
+  await expect(tokenConfigOptions({})).toEqual([]);
+  await expect(tokenConfigOptions({secret: 'abc'})).toEqual(['secret']);
+  await expect(tokenConfigOptions({jwk: 'def'})).toEqual(['jwk']);
+  await expect(tokenConfigOptions({jwksUrl: 'ghi'})).toEqual(['jwksUrl']);
+  await expect(tokenConfigOptions({jwksUrl: 'jkl', secret: 'mno'})).toEqual([
+    'secret',
+    'jwksUrl',
+  ]);
+});
+
+test('no options set', async () => {
+  await expect(verifyToken({}, '', {})).rejects.toThrowError(
+    'verifyToken was called but no auth options',
+  );
 });
 
 function commonTests(

--- a/packages/zero-cache/src/auth/jwt.ts
+++ b/packages/zero-cache/src/auth/jwt.ts
@@ -7,7 +7,6 @@ import {
   type KeyLike,
 } from 'jose';
 import type {AuthConfig} from '../config/zero-config.ts';
-import {assert} from '../../../shared/src/asserts.ts';
 import {exportJWK, generateKeyPair} from 'jose';
 
 export async function createJwkPair() {
@@ -36,20 +35,19 @@ function getRemoteKeyset(jwksUrl: string) {
   return remoteKeyset;
 }
 
+export const tokenConfigOptions = (config: AuthConfig) => {
+  const tokenOptions = (['jwk', 'secret', 'jwksUrl'] as const).filter(
+    key => config[key] !== undefined,
+  );
+
+  return tokenOptions;
+};
+
 export async function verifyToken(
   config: AuthConfig,
   token: string,
   verifyOptions: JWTClaimVerificationOptions,
 ): Promise<JWTPayload> {
-  const optionsSet = (['jwk', 'secret', 'jwksUrl'] as const).filter(
-    key => config[key] !== undefined,
-  );
-  assert(
-    optionsSet.length === 1,
-    'Exactly one of jwk, secret, or jwksUrl must be set in order to verify tokens but actually the following were set: ' +
-      JSON.stringify(optionsSet),
-  );
-
   if (config.jwk !== undefined) {
     return verifyTokenImpl(token, loadJwk(config.jwk), verifyOptions);
   }

--- a/packages/zero-cache/src/workers/syncer.ts
+++ b/packages/zero-cache/src/workers/syncer.ts
@@ -167,10 +167,10 @@ export class Syncer implements SingletonService {
         new SyncerWsMessageHandler(
           this.#lc,
           params,
-          auth !== undefined && decodedToken !== undefined
+          auth !== undefined
             ? {
                 raw: auth,
-                decoded: decodedToken,
+                decoded: decodedToken ?? {},
               }
             : undefined,
           this.#viewSyncers.getService(clientGroupID),


### PR DESCRIPTION
Changes zero-cache to allow pass-through of a token passed to `auth` without validation if no JWT configs are set. It will also print a warning to the user: `One of jwk, secret, or jwksUrl is not configured - the auth token must be manually verified by the user`.

On the client:

```tsx
import { expoClient } from "@better-auth/expo/client";
import { createAuthClient } from "better-auth/react";
import * as SecureStore from "expo-secure-store";

export const authClient = createAuthClient({
  baseURL: "http://localhost:3000",
  plugins: [
    expoClient({
      scheme: "hello-zero-expo",
      storagePrefix: "hello-zero-expo",
      storage: SecureStore,
    }),
  ],
});

new Zero({
  ...
  kvStore: expoSQLiteStoreProvider(),
  auth: authClient.getCookie(),
});
```

Server:

```tsx
app.use("*", async (c, next) => {
  const authHeader = c.req.raw.headers.get("Authorization");
  const cookie = authHeader?.split("Bearer ")[1];
  const newHeaders = new Headers(c.req.raw.headers);
  if (cookie) {
    newHeaders.set("Cookie", cookie);
  }
  
  const session = await auth.api.getSession({ headers: newHeaders });
  if (!session) {
    c.set("auth", null);
    return next();
  }
  c.set("auth", session);
  return next();
});
```


