### PR TITLE
chore: Switch back perf runner to self-hosted

### DIFF
--- a/.github/workflows/bencher-benchmarks-pr.yml
+++ b/.github/workflows/bencher-benchmarks-pr.yml
@@ -83,7 +83,7 @@ jobs:
 
     permissions:
       pull-requests: write
-    runs-on: ubuntu-24-arm64-perf
+    runs-on: self-hosted
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: rocicorp
@@ -111,7 +111,7 @@ jobs:
           npx tsx ../shared/src/tool/vitest-perf-json-to-bmf.ts |\
           bencher run \
           --project zero \
-          --testbed perf-runner \
+          --testbed self-hosted \
           --token '${{ secrets.BENCHER_API_TOKEN }}' \
           --adapter json \
           --github-actions '${{ secrets.GITHUB_TOKEN }}' \

--- a/.github/workflows/bencher-benchmarks.yml
+++ b/.github/workflows/bencher-benchmarks.yml
@@ -57,7 +57,7 @@ jobs:
     name: Perf
     permissions:
       checks: write
-    runs-on: ubuntu-24-arm64-perf
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -82,7 +82,7 @@ jobs:
           npx tsx ../shared/src/tool/vitest-perf-json-to-bmf.ts |\
           bencher run \
           --project zero \
-          --testbed perf-runner \
+          --testbed self-hosted \
           --token '${{ secrets.BENCHER_API_TOKEN }}' \
           --adapter json \
           --github-actions '${{ secrets.GITHUB_TOKEN }}' \

--- a/.github/workflows/perf-v2.js.yml
+++ b/.github/workflows/perf-v2.js.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   benchmark:
     name: Performance regression check
-    runs-on: ubuntu-24-arm64-perf
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Turns out the self hosted runner is more stable as seen in the screenshots

<img width="1442" height="847" alt="Screenshot 2025-08-21 at 09 29 22" src="https://github.com/user-attachments/assets/cbd01d48-c071-4ecd-b12f-4d175699c673" />

<img width="1413" height="866" alt="Screenshot 2025-08-21 at 09 34 22" src="https://github.com/user-attachments/assets/09020438-af1e-40c2-84a8-b2fbd9cbd7df" />


<img width="1412" height="856" alt="Screenshot 2025-08-21 at 09 34 51" src="https://github.com/user-attachments/assets/d056cd31-804c-4db8-9990-bbbf20209207" />
