### PR TITLE
fix(zero-cache): handle resync after partial state drop

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.pg-test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.pg-test.ts
@@ -2310,6 +2310,10 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
       'missing metadata publication',
       `DROP PUBLICATION "_${APP_ID}_metadata_${SHARD_NUM}"`,
     ],
+    [
+      'dropped schema with vestigial publications',
+      `DROP SCHEMA "${APP_ID}_${SHARD_NUM}" CASCADE`,
+    ],
   ])('recover from corrupted state: %s', async (_name, corruption) => {
     const lc = createSilentLogContext();
     const sql = upstream;

--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
@@ -155,6 +155,7 @@ export function shardSetup(
   ${getClientsTableDefinition(shard)}
   ${getMutationsTableDefinition(shard)}
 
+  DROP PUBLICATION IF EXISTS ${id(metadataPublication)};
   CREATE PUBLICATION ${id(metadataPublication)}
     FOR TABLE ${app}."schemaVersions", ${app}."permissions", TABLE ${shard}."clients", ${shard}."mutations";
 
@@ -304,8 +305,8 @@ export async function setupTablesAndReplication(
       requested.appID,
       requested.shardNum,
     );
-    // Note: For re-syncing, this publication is dropped in dropShard(), so an existence
-    //       check is unnecessary.
+    await sql`
+      DROP PUBLICATION IF EXISTS ${sql(defaultPublication)}`;
     await sql`
       CREATE PUBLICATION ${sql(defaultPublication)} 
         FOR TABLES IN SCHEMA public


### PR DESCRIPTION
Handle a resync after the upstream schema is manually dropped with, e.g. with `DROP SCHEMA zero_0 CASCADE`;

Most methods encountering "corrupted" upstream / replica state will result in zero-cache [fully dropping the schema and all publications](https://github.com/rocicorp/mono/blob/e37b8c123db42612328127450d6c4479182f839f/packages/zero-cache/src/services/change-source/pg/schema/shard.ts#L185) before resyncing.

However, if the schema is manually dropped by the user, there can be a vestigial publication left over, which was preventing a resync from happening. Handle this case by dropping existing publications before (re-)creating them.

User report:
* https://discord.com/channels/830183651022471199/1407339469077745664/1407680089705156608