### PR TITLE
feat(zero-cache): added passthrough of auth (again)

### DIFF
--- a/packages/zero-cache/src/auth/jwt.test.ts
+++ b/packages/zero-cache/src/auth/jwt.test.ts
@@ -2,7 +2,7 @@ import {SignJWT, type JWTPayload} from 'jose';
 import {describe, expect, test} from 'vitest';
 import {must} from '../../../shared/src/must.ts';
 import type {AuthConfig} from '../config/zero-config.ts';
-import {createJwkPair, verifyToken} from './jwt.ts';
+import {createJwkPair, tokenConfigOptions, verifyToken} from './jwt.ts';
 
 describe('symmetric key', () => {
   const key = 'ab'.repeat(16);
@@ -30,28 +30,21 @@ describe('jwk', async () => {
   commonTests({jwk: JSON.stringify(publicJwk)}, makeToken);
 });
 
-test('too many or too few options set', async () => {
-  await expect(verifyToken({}, '', {})).rejects.toThrowError('Exactly one of');
-  await expect(
-    verifyToken(
-      {
-        secret: 'abc',
-        jwk: 'def',
-      },
-      '',
-      {},
-    ),
-  ).rejects.toThrowError('Exactly one of');
-  await expect(
-    verifyToken(
-      {
-        secret: 'abc',
-        jwksUrl: 'def',
-      },
-      '',
-      {},
-    ),
-  ).rejects.toThrowError('Exactly one of');
+test('token config options', async () => {
+  await expect(tokenConfigOptions({})).toEqual([]);
+  await expect(tokenConfigOptions({secret: 'abc'})).toEqual(['secret']);
+  await expect(tokenConfigOptions({jwk: 'def'})).toEqual(['jwk']);
+  await expect(tokenConfigOptions({jwksUrl: 'ghi'})).toEqual(['jwksUrl']);
+  await expect(tokenConfigOptions({jwksUrl: 'jkl', secret: 'mno'})).toEqual([
+    'secret',
+    'jwksUrl',
+  ]);
+});
+
+test('no options set', async () => {
+  await expect(verifyToken({}, '', {})).rejects.toThrowError(
+    'verifyToken was called but no auth options',
+  );
 });
 
 function commonTests(

--- a/packages/zero-cache/src/auth/jwt.ts
+++ b/packages/zero-cache/src/auth/jwt.ts
@@ -7,7 +7,6 @@ import {
   type KeyLike,
 } from 'jose';
 import type {AuthConfig} from '../config/zero-config.ts';
-import {assert} from '../../../shared/src/asserts.ts';
 import {exportJWK, generateKeyPair} from 'jose';
 
 export async function createJwkPair() {
@@ -36,20 +35,19 @@ function getRemoteKeyset(jwksUrl: string) {
   return remoteKeyset;
 }
 
+export const tokenConfigOptions = (config: AuthConfig) => {
+  const tokenOptions = (['jwk', 'secret', 'jwksUrl'] as const).filter(
+    key => config[key] !== undefined,
+  );
+
+  return tokenOptions;
+};
+
 export async function verifyToken(
   config: AuthConfig,
   token: string,
   verifyOptions: JWTClaimVerificationOptions,
 ): Promise<JWTPayload> {
-  const optionsSet = (['jwk', 'secret', 'jwksUrl'] as const).filter(
-    key => config[key] !== undefined,
-  );
-  assert(
-    optionsSet.length === 1,
-    'Exactly one of jwk, secret, or jwksUrl must be set in order to verify tokens but actually the following were set: ' +
-      JSON.stringify(optionsSet),
-  );
-
   if (config.jwk !== undefined) {
     return verifyTokenImpl(token, loadJwk(config.jwk), verifyOptions);
   }

--- a/packages/zero-cache/src/workers/syncer.test.ts
+++ b/packages/zero-cache/src/workers/syncer.test.ts
@@ -27,7 +27,11 @@ vi.mock('../server/anonymous-otel-start.ts', () => ({
 const mockDB = (() => {}) as unknown as PostgresDB;
 
 import {Syncer} from './syncer.ts';
-import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import * as jwt from '../auth/jwt.ts';
+import {
+  createSilentLogContext,
+  TestLogSink,
+} from '../../../shared/src/logging-test-utils.ts';
 import {
   recordConnectionSuccess,
   recordConnectionAttempted,
@@ -44,6 +48,7 @@ import os from 'node:os';
 import fs from 'node:fs/promises';
 import {Database} from '../../../zqlite/src/db.ts';
 import type {PostgresDB} from '../types/pg.ts';
+import {LogContext} from '@rocicorp/logger';
 
 const lc = createSilentLogContext();
 const tempDir = await fs.mkdtemp(
@@ -57,86 +62,116 @@ CREATE TABLE "test-app.permissions" (permissions, hash);
 INSERT INTO "test-app.permissions" (permissions, hash) VALUES (null, 'test-hash');
 `);
 
+// ------------------------------
+// Test helpers
+// ------------------------------
+
+const TEST_PARENT: any = {
+  onMessageType: () => {},
+  send: () => {},
+};
+
+function makeFactories(
+  lc: LogContext,
+  mutagensOut: MutagenService[],
+  pushersOut: PusherService[],
+) {
+  return {
+    viewSyncerFactory: (id: string) =>
+      ({
+        id,
+        keepalive: () => true,
+        stop() {
+          return Promise.resolve();
+        },
+        run() {
+          return Promise.resolve();
+        },
+      }) as ViewSyncer & ActivityBasedService,
+    mutagenFactory: (id: string) => {
+      const ret = new MutagenService(
+        lc,
+        {appID: 'test-app', shardNum: 0},
+        id,
+        {} as any,
+        {
+          replica: {file: tempFile},
+          perUserMutationLimit: {},
+        } as ZeroConfig,
+      );
+      mutagensOut.push(ret);
+      return ret;
+    },
+    pusherFactory: (id: string) => {
+      const ret = new PusherService(
+        mockDB,
+        {} as ZeroConfig,
+        {url: ['http://example.com'], forwardCookies: false},
+        lc,
+        id,
+      );
+      pushersOut.push(ret);
+      return ret;
+    },
+  } as const;
+}
+
+function setupSyncer(lc: LogContext, config: ZeroConfig) {
+  const mutagens: MutagenService[] = [];
+  const pushers: PusherService[] = [];
+  const {viewSyncerFactory, mutagenFactory, pusherFactory} = makeFactories(
+    lc,
+    mutagens,
+    pushers,
+  );
+  const syncer = new Syncer(
+    lc,
+    config,
+    viewSyncerFactory,
+    mutagenFactory,
+    pusherFactory,
+    TEST_PARENT,
+  );
+  return {syncer, mutagens, pushers};
+}
+
+const baseParams = {
+  clientGroupID: '1',
+  userID: 'anon',
+  wsID: '1',
+  protocolVersion: 21,
+};
+
+function makeParams(clientID: number, params: any = {}) {
+  return {
+    ...baseParams,
+    clientID: `${clientID}`,
+    ...params,
+  };
+}
+
+function openConnection(clientID: number, params: any = {}) {
+  const ws = new MockWebSocket() as unknown as WebSocket;
+  receiver(ws, makeParams(clientID, params), {} as any);
+  return ws;
+}
+
 describe('cleanup', () => {
   let syncer: Syncer;
   let mutagens: MutagenService[];
   let pushers: PusherService[];
   beforeEach(() => {
-    mutagens = [];
-    pushers = [];
-    syncer = new Syncer(
-      lc,
-      {} as ZeroConfig,
-      id =>
-        ({
-          id,
-          keepalive: () => true,
-          stop() {
-            return Promise.resolve();
-          },
-          run() {
-            return Promise.resolve();
-          },
-        }) as ViewSyncer & ActivityBasedService,
-      id => {
-        const ret = new MutagenService(
-          lc,
-          {
-            appID: 'test-app',
-            shardNum: 0,
-          },
-          id,
-          {} as any,
-          {
-            replica: {
-              file: tempFile,
-            },
-            perUserMutationLimit: {},
-          } as ZeroConfig,
-        );
-        mutagens.push(ret);
-        return ret;
-      },
-      id => {
-        const ret = new PusherService(
-          mockDB,
-          {} as ZeroConfig,
-          {
-            url: ['http://example.com'],
-            forwardCookies: false,
-          },
-          lc,
-          id,
-        );
-        pushers.push(ret);
-        return ret;
-      },
-      {
-        onMessageType: () => {},
-        send: () => {},
-      } as any,
-    );
+    const env = setupSyncer(lc, {} as ZeroConfig);
+    syncer = env.syncer;
+    mutagens = env.mutagens;
+    pushers = env.pushers;
   });
 
   afterEach(async () => {
     await syncer.stop();
   });
 
-  function newConnection(clientID: number) {
-    const ws = new MockWebSocket() as unknown as WebSocket;
-    receiver(
-      ws,
-      {
-        clientGroupID: '1',
-        clientID: `${clientID}`,
-        userID: 'anon',
-        wsID: '1',
-        protocolVersion: 21, // Valid protocol version (current PROTOCOL_VERSION)
-      },
-      {} as any,
-    );
-    return ws;
-  }
+  const newConnection = (clientID: number) => openConnection(clientID);
 
   test('bumps ref count when getting same service over and over', () => {
     const connections: WebSocket[] = [];
@@ -203,87 +238,19 @@ describe('cleanup', () => {
 
 describe('connection telemetry', () => {
   let syncer: Syncer;
-  let mutagens: MutagenService[];
-  let pushers: PusherService[];
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mutagens = [];
-    pushers = [];
-    syncer = new Syncer(
-      lc,
-      {} as ZeroConfig,
-      id =>
-        ({
-          id,
-          keepalive: () => true,
-          stop() {
-            return Promise.resolve();
-          },
-          run() {
-            return Promise.resolve();
-          },
-        }) as ViewSyncer & ActivityBasedService,
-      id => {
-        const ret = new MutagenService(
-          lc,
-          {
-            appID: 'test-app',
-            shardNum: 0,
-          },
-          id,
-          {} as any,
-          {
-            replica: {
-              file: tempFile,
-            },
-            perUserMutationLimit: {},
-          } as ZeroConfig,
-        );
-        mutagens.push(ret);
-        return ret;
-      },
-      id => {
-        const ret = new PusherService(
-          mockDB,
-          {} as ZeroConfig,
-          {
-            url: ['http://example.com'],
-            forwardCookies: false,
-          },
-          lc,
-          id,
-        );
-        pushers.push(ret);
-        return ret;
-      },
-      {
-        onMessageType: () => {},
-        send: () => {},
-      } as any,
-    );
+    const env = setupSyncer(lc, {} as ZeroConfig);
+    syncer = env.syncer;
   });
 
   afterEach(async () => {
     await syncer.stop();
   });
 
-  function newConnection(clientID: number, params: any = {}) {
-    const ws = new MockWebSocket() as unknown as WebSocket;
-    receiver(
-      ws,
-      {
-        clientGroupID: '1',
-        clientID: `${clientID}`,
-        userID: 'anon',
-        wsID: '1',
-        protocolVersion: 21, // Valid protocol version (current PROTOCOL_VERSION)
-        ...params,
-      },
-      {} as any,
-    );
-    return ws;
-  }
+  const newConnection = (clientID: number, params: any = {}) =>
+    openConnection(clientID, params);
 
   test('should record connection success for valid protocol version', () => {
     // Create a connection with valid protocol version
@@ -310,6 +277,162 @@ describe('connection telemetry', () => {
 
     // Should record connection attempts
     expect(vi.mocked(recordConnectionAttempted)).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('jwt auth validation', () => {
+  let syncer: Syncer;
+  let mutagens: MutagenService[];
+  let pushers: PusherService[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const env = setupSyncer(lc, {
+      auth: {
+        // Intentionally set multiple options to trigger the validation error
+        jwk: '{}',
+        secret: 'super-secret',
+      },
+    } as ZeroConfig);
+    syncer = env.syncer;
+    mutagens = env.mutagens;
+    pushers = env.pushers;
+  });
+
+  afterEach(async () => {
+    await syncer.stop();
+  });
+
+  test('fails when too many JWT options are set', async () => {
+    const ws = new MockWebSocket() as unknown as WebSocket;
+    await expect(
+      receiver(
+        ws,
+        {
+          clientGroupID: '1',
+          clientID: `1`,
+          userID: 'anon',
+          wsID: '1',
+          protocolVersion: 21,
+          auth: 'dummy-token',
+        },
+        {} as any,
+      ),
+    ).rejects.toThrow(/Exactly one of jwk, secret, or jwksUrl must be set/);
+
+    expect(vi.mocked(recordConnectionAttempted)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(recordConnectionSuccess)).not.toHaveBeenCalled();
+
+    // No services should be instantiated when auth validation fails early
+    expect(mutagens.length).toBe(0);
+    expect(pushers.length).toBe(0);
+  });
+});
+
+describe('jwt auth without options', () => {
+  let syncer: Syncer;
+  let logSink: TestLogSink;
+  let mutagens: MutagenService[];
+  let pushers: PusherService[];
+  let verifySpy: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    verifySpy = vi.spyOn(jwt, 'verifyToken');
+    mutagens = [];
+    pushers = [];
+    logSink = new TestLogSink();
+    const lc = new LogContext('debug', {}, logSink);
+    const env = setupSyncer(lc, {
+      // No auth options set; should not verify token
+      auth: {},
+      // set custom mutations & get queries to avoid token verification
+      mutate: {url: ['http://mutate.example.com']},
+      getQueries: {url: ['http://queries.example.com']},
+    } as ZeroConfig);
+    syncer = env.syncer;
+    mutagens = env.mutagens;
+    pushers = env.pushers;
+  });
+
+  afterEach(async () => {
+    await syncer.stop();
+  });
+
+  const newConnection = (clientID: number, params: any = {}) =>
+    openConnection(clientID, params);
+
+  test('succeeds when using mutations & get queries and skips verification', () => {
+    const ws = newConnection(1, {auth: 'dummy-token'});
+
+    expect(vi.mocked(recordConnectionAttempted)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(recordConnectionSuccess)).toHaveBeenCalledTimes(1);
+    expect(verifySpy).not.toHaveBeenCalled();
+
+    // Connection stays open and sends 'connected'
+    expect((ws as any).readyState).toBe(MockWebSocket.OPEN);
+    const messages = (ws as any).messages as string[];
+    expect(messages.length).toBeGreaterThan(0);
+    const first = JSON.parse(messages[0]);
+    expect(first[0]).toBe('connected');
+
+    // check that we logged a warning that the auth token must be manually verified by the user
+    expect(logSink.messages).toContainEqual([
+      'warn',
+      {},
+      [
+        'One of jwk, secret, or jwksUrl is not configured - the `authorization` header must be manually verified by the user',
+      ],
+    ]);
+
+    // Services should be instantiated for successful connection
+    expect(mutagens.length).toBe(1);
+    expect(pushers.length).toBe(1);
+  });
+});
+
+describe('jwt auth missing options and missing endpoints', () => {
+  let syncer: Syncer;
+  let mutagens: MutagenService[];
+  let pushers: PusherService[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const env = setupSyncer(lc, {
+      // No auth and no mutate/getQueries set; should assert on receiving auth
+      auth: {},
+    } as ZeroConfig);
+    syncer = env.syncer;
+    mutagens = env.mutagens;
+    pushers = env.pushers;
+  });
+
+  afterEach(async () => {
+    await syncer.stop();
+  });
+
+  test('fails when no JWT options and no custom endpoints are set', async () => {
+    const ws = new MockWebSocket() as unknown as WebSocket;
+    await expect(
+      receiver(
+        ws,
+        {
+          clientGroupID: '1',
+          clientID: `1`,
+          userID: 'anon',
+          wsID: '1',
+          protocolVersion: 21,
+          auth: 'dummy-token',
+        },
+        {} as any,
+      ),
+    ).rejects.toThrow(/Exactly one of jwk, secret, or jwksUrl must be set/);
+
+    expect(vi.mocked(recordConnectionAttempted)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(recordConnectionSuccess)).not.toHaveBeenCalled();
+
+    expect(mutagens.length).toBe(0);
+    expect(pushers.length).toBe(0);
   });
 });
 
@@ -355,7 +478,11 @@ class MockWebSocket {
       listener({code: 1000, reason: 'Test close', wasClean: true});
     }
   }
-  send() {}
+  // recorded outbound messages (stringified JSON)
+  messages: string[] = [];
+  send(data: string) {
+    this.messages.push(data);
+  }
   on(event: string, fn: (event: any) => void) {
     this.addEventListener(event, fn);
   }

--- a/packages/zero-cache/src/workers/syncer.ts
+++ b/packages/zero-cache/src/workers/syncer.ts
@@ -6,8 +6,8 @@ import {MessagePort} from 'node:worker_threads';
 import {WebSocketServer, type WebSocket} from 'ws';
 import {promiseVoid} from '../../../shared/src/resolved-promises.ts';
 import {ErrorKind} from '../../../zero-protocol/src/error-kind.ts';
-import {verifyToken} from '../auth/jwt.ts';
-import {type AuthConfig, type ZeroConfig} from '../config/zero-config.ts';
+import {tokenConfigOptions, verifyToken} from '../auth/jwt.ts';
+import {type ZeroConfig} from '../config/zero-config.ts';
 import type {Mutagen} from '../services/mutagen/mutagen.ts';
 import type {Pusher} from '../services/mutagen/pusher.ts';
 import type {ReplicaState} from '../services/replicator/replicator.ts';
@@ -31,6 +31,7 @@ import {
   recordConnectionAttempted,
   setActiveClientGroupsGetter,
 } from '../server/anonymous-otel-start.ts';
+import {assert} from '../../../shared/src/asserts.ts';
 
 export type SyncerWorkerData = {
   replicatorPort: MessagePort;
@@ -54,7 +55,7 @@ export class Syncer implements SingletonService {
   readonly #parent: Worker;
   readonly #wss: WebSocketServer;
   readonly #stopped = resolver();
-  readonly #authConfig: AuthConfig;
+  readonly #config: ZeroConfig;
 
   constructor(
     lc: LogContext,
@@ -68,7 +69,7 @@ export class Syncer implements SingletonService {
     pusherFactory: ((id: string) => Pusher & Service) | undefined,
     parent: Worker,
   ) {
-    this.#authConfig = config.auth;
+    this.#config = config;
     // Relays notifications from the parent thread subscription
     // to ViewSyncers within this thread.
     const notifier = createNotifierFrom(lc, parent);
@@ -115,25 +116,46 @@ export class Syncer implements SingletonService {
 
     let decodedToken: JWTPayload | undefined;
     if (auth) {
-      try {
-        decodedToken = await verifyToken(this.#authConfig, auth, {
-          subject: userID,
-        });
-        this.#lc.debug?.(
-          `Received auth token ${auth} for clientID ${clientID}, decoded: ${JSON.stringify(decodedToken)}`,
+      const tokenOptions = tokenConfigOptions(this.#config.auth);
+
+      const hasPushOrMutate =
+        this.#config?.push?.url !== undefined ||
+        this.#config?.mutate?.url !== undefined;
+      const hasGetQueries = this.#config?.getQueries?.url !== undefined;
+
+      // must either have one of the token options set or have custom mutations & queries enabled
+      assert(
+        tokenOptions.length === 1 || (hasPushOrMutate && hasGetQueries),
+        'Exactly one of jwk, secret, or jwksUrl must be set in order to verify tokens but actually the following were set: ' +
+          JSON.stringify(tokenOptions) +
+          '. You may also set both ZERO_MUTATE_URL and ZERO_GET_QUERIES_URL to enable custom mutations and queries without passing token verification options.',
+      );
+
+      if (tokenOptions.length > 0) {
+        try {
+          decodedToken = await verifyToken(this.#config.auth, auth, {
+            subject: userID,
+          });
+          this.#lc.debug?.(
+            `Received auth token ${auth} for clientID ${clientID}, decoded: ${JSON.stringify(decodedToken)}`,
+          );
+        } catch (e) {
+          sendError(
+            this.#lc,
+            ws,
+            {
+              kind: ErrorKind.AuthInvalidated,
+              message: `Failed to decode auth token: ${String(e)}`,
+            },
+            e,
+          );
+          ws.close(3000, 'Failed to decode JWT');
+          return;
+        }
+      } else {
+        this.#lc.warn?.(
+          `One of jwk, secret, or jwksUrl is not configured - the \`authorization\` header must be manually verified by the user`,
         );
-      } catch (e) {
-        sendError(
-          this.#lc,
-          ws,
-          {
-            kind: ErrorKind.AuthInvalidated,
-            message: `Failed to decode auth token: ${String(e)}`,
-          },
-          e,
-        );
-        ws.close(3000, 'Failed to decode JWT');
-        return;
       }
     } else {
       this.#lc.debug?.(`No auth token received for clientID ${clientID}`);
@@ -154,10 +176,11 @@ export class Syncer implements SingletonService {
         new SyncerWsMessageHandler(
           this.#lc,
           params,
-          auth !== undefined && decodedToken !== undefined
+          // auth is an empty string if the user is not authenticated
+          auth
             ? {
                 raw: auth,
-                decoded: decodedToken,
+                decoded: decodedToken ?? {},
               }
             : undefined,
           this.#viewSyncers.getService(clientGroupID),


### PR DESCRIPTION
This is a reapply of https://github.com/rocicorp/mono/pull/4793, with fixes for zbugs.

The `auth` config defaults to an empty string in Replicache here:
https://github.com/rocicorp/mono/blob/842c0d5e6f7f588b3f5cfe7ca3fc6fcbc1879c51/packages/replicache/src/replicache-impl.ts#L444-L447

So `auth` is never `undefined`. This [commit](https://github.com/rocicorp/mono/commit/d5642c1131cb730ab340b826433ac49659ff2e7c) fixes handling this.

---

Changes zero-cache to allow pass-through of a token passed to `auth` without validation if no JWT configs are set, and a mutate & get queries URL are defined. It will also print a warning to the user: `One of jwk, secret, or jwksUrl is not configured - the auth token must be manually verified by the user`.

On the client:

```tsx
import { expoClient } from "@better-auth/expo/client";
import { createAuthClient } from "better-auth/react";
import * as SecureStore from "expo-secure-store";

export const authClient = createAuthClient({
  baseURL: "http://localhost:3000",
  plugins: [
    expoClient({
      scheme: "hello-zero-expo",
      storagePrefix: "hello-zero-expo",
      storage: SecureStore,
    }),
  ],
});

new Zero({
  ...
  kvStore: expoSQLiteStoreProvider(),
  auth: authClient.getCookie(),
});
```

Server:

```tsx
app.use("*", async (c, next) => {
  const authHeader = c.req.raw.headers.get("Authorization");
  const cookie = authHeader?.split("Bearer ")[1];
  const newHeaders = new Headers(c.req.raw.headers);
  if (cookie) {
    newHeaders.set("Cookie", cookie);
  }
  
  const session = await auth.api.getSession({ headers: newHeaders });
  if (!session) {
    c.set("auth", null);
    return next();
  }
  c.set("auth", session);
  return next();
});
```

