### PR TITLE
Enable re-use of mutators on server with non-push endpoints

### DIFF
--- a/packages/zero-server/src/mod.ts
+++ b/packages/zero-server/src/mod.ts
@@ -4,3 +4,4 @@ export * from './push-processor.ts';
 export * from './custom.ts';
 export * from './zql-database.ts';
 export * from '../../zql/src/mutate/custom.ts';
+export * from './query.ts';

--- a/packages/zero-server/src/zql-database.ts
+++ b/packages/zero-server/src/zql-database.ts
@@ -26,8 +26,7 @@ import type {
 export class ZQLDatabase<S extends Schema, WrappedTransaction>
   implements Database<TransactionImpl<S, WrappedTransaction>>
 {
-  readonly #connection: DBConnection<WrappedTransaction>;
-
+  readonly connection: DBConnection<WrappedTransaction>;
   readonly #mutate: (
     dbTransaction: DBTransaction<WrappedTransaction>,
     serverSchema: ServerSchema,
@@ -39,7 +38,7 @@ export class ZQLDatabase<S extends Schema, WrappedTransaction>
   readonly #schema: S;
 
   constructor(connection: DBConnection<WrappedTransaction>, schema: S) {
-    this.#connection = connection;
+    this.connection = connection;
     this.#mutate = makeSchemaCRUD(schema);
     this.#query = makeSchemaQuery(schema);
     this.#schema = schema;
@@ -52,7 +51,7 @@ export class ZQLDatabase<S extends Schema, WrappedTransaction>
     ) => Promise<R>,
     transactionInput: TransactionProviderInput,
   ): Promise<R> {
-    return this.#connection.transaction(async dbTx => {
+    return this.connection.transaction(async dbTx => {
       const zeroTx = await makeServerTransaction(
         dbTx,
         transactionInput.clientID,


### PR DESCRIPTION
This PR enables re-using mutators using `PushProcessor`, e.g. to implement an API used by non-zero clients by exporting `makeSchemaQuery` and making `ZQLDatabase.connection` not private, like so:
```
import { db, DbTransaction } from "../drizzle";
import {
  Transaction,
  makeSchemaCRUD,
  makeSchemaQuery, // Not currently exported
  makeServerTransaction,
} from "@rocicorp/zero/server";
import { schema, Schema } from "./schema";
import { zeroNodePg } from "@rocicorp/zero/server/adapters/drizzle-pg";

export type ZeroTransaction = Transaction<Schema, DbTransaction>;

const mutate = makeSchemaCRUD(schema);
const query = makeSchemaQuery(schema);
export const zeroDb = zeroNodePg(schema, db);

const FAKE_CLIENT_ID = "";
const FAKE_MUTATION_ID = 0;

export function zeroTransaction<R>(
  func: (tx: ZeroTransaction) => Promise<R>
): Promise<R> {
   // connection is private
  return zeroDb.connection.transaction(async (dbTx) => {
    const zeroTx = await makeServerTransaction(
      dbTx,
      FAKE_CLIENT_ID,
      FAKE_MUTATION_ID,
      schema,
      mutate,
      query
    );
    return await func(zeroTx);
  });
}
```

From what I can tell, `makeServerTransaction` only requires `clientID` and `mutationID` to conform to the `TransactionBase` type and doesn't use them, so passing in fake values here seems fine but want to double check.

An alternative would be to add a new method on `ZQLDatabase` for this without needing to change the exports/property visibility, but not sure what a good name would be.