### PR TITLE
API polish for custom queries

### DIFF
--- a/apps/zbugs/api/index.ts
+++ b/apps/zbugs/api/index.ts
@@ -196,30 +196,26 @@ async function mutateHandler(
 fastify.post<{
   Querystring: Record<string, string>;
   Body: ReadonlyJSONValue;
-}>('/api/pull', getQueriesHandler);
-
-fastify.post<{
-  Querystring: Record<string, string>;
-  Body: ReadonlyJSONValue;
-}>('/api/get-queries', getQueriesHandler);
-
-async function getQueriesHandler(
-  request: FastifyRequest<{
-    Querystring: Record<string, string>;
-    Body: ReadonlyJSONValue;
-  }>,
-  reply: FastifyReply,
-) {
-  await withAuth(request, reply, async authData => {
-    reply.send(
-      await handleGetQueriesRequest(
-        (name, args) => ({query: getQuery(authData, name, args)}),
-        schema,
-        request.body,
-      ),
-    );
-  });
-}
+}>(
+  '/api/get-queries',
+  async (
+    request: FastifyRequest<{
+      Querystring: Record<string, string>;
+      Body: ReadonlyJSONValue;
+    }>,
+    reply: FastifyReply,
+  ) => {
+    await withAuth(request, reply, async authData => {
+      reply.send(
+        await handleGetQueriesRequest(
+          (name, args) => ({query: getQuery(authData, name, args)}),
+          schema,
+          request.body,
+        ),
+      );
+    });
+  },
+);
 
 fastify.post<{
   Body: {contentType: string};

--- a/apps/zbugs/shared/queries.ts
+++ b/apps/zbugs/shared/queries.ts
@@ -20,7 +20,7 @@ function applyIssuePermissions<TQuery extends Query<Schema, 'issue', any>>(
   ) as TQuery;
 }
 
-const idValidator = z.tuple([z.string()]).parse;
+const idValidator = z.tuple([z.string()]);
 const keyValidator = idValidator;
 
 const listContextParams = z.object({
@@ -41,11 +41,13 @@ const issueRowSort = z.object({
 });
 
 export const queries = {
-  allLabels: syncedQuery('allLabels', z.tuple([]).parse, () => builder.label),
+  allLabels: syncedQuery('allLabels', z.tuple([]), () => builder.label),
 
-  allIssues: syncedQuery('allIssues', z.tuple([]).parse, () => builder.issue),
+  allUsers: syncedQuery('allUsers', z.tuple([]), () => builder.user),
 
-  allUsers: syncedQuery('allUsers', z.tuple([]).parse, () => builder.user),
+  user: syncedQuery('user', idValidator, userID =>
+    builder.user.where('id', userID).one(),
+  ),
 
   issuePreload: syncedQueryWithContext(
     'issuePreload',
@@ -69,10 +71,6 @@ export const queries = {
       ),
   ),
 
-  user: syncedQuery('user', idValidator, userID =>
-    builder.user.where('id', userID).one(),
-  ),
-
   userPref: syncedQueryWithContext(
     'userPref',
     keyValidator,
@@ -89,7 +87,7 @@ export const queries = {
       z.boolean(),
       z.string().nullable(),
       z.enum(['crew', 'creators']).nullable(),
-    ]).parse,
+    ]),
     (disabled, login, filter) => {
       let q = builder.user;
       if (disabled && login) {
@@ -115,7 +113,7 @@ export const queries = {
       z.union([z.literal('shortID'), z.literal('id')]),
       z.string().or(z.number()),
       z.string(),
-    ]).parse,
+    ]),
     (auth: AuthData | undefined, idField, id, userID) =>
       applyIssuePermissions(
         builder.issue
@@ -148,7 +146,7 @@ export const queries = {
       listContextParams.nullable(),
       issueRowSort.nullable(),
       z.union([z.literal('next'), z.literal('prev')]),
-    ]).parse,
+    ]),
     (auth: AuthData | undefined, listContext, issue, dir) =>
       applyIssuePermissions(
         buildListQuery(listContext, issue, dir).one(),
@@ -158,7 +156,7 @@ export const queries = {
 
   issueList: syncedQueryWithContext(
     'issueList',
-    z.tuple([listContextParams, z.string(), z.number()]).parse,
+    z.tuple([listContextParams, z.string(), z.number()]),
     (auth: AuthData | undefined, listContext, userID, limit) =>
       applyIssuePermissions(
         buildListQuery(listContext, null, 'next')


### PR DESCRIPTION
This is basically accomplishing two things at a high level:

- Allow callers to treat the results of `syncedQuery` and `syncedQueryWithContext` generically
- Reduce number of concepts related to synced queries and clean up naming

Details:

* Get rid of the concept of "named query". This was confusing me because the thing we were calling a "named query" didn't actually have a name. It's just a function that returns a ZQL query.  Replace with `QueryFn` That ended up being useful to have defined.
* Get rid of separate withContext and withValidation functions. It was nice to have them decomposed, but all these types are gnarly and it's not worth the complexity. In practice, people only need to generalize for this validation case.
* Combine SyncedQuery and SyncedQueryWithContext type into just one type.
* With a huge amount of iteration and help from various AIs, found an incantation that can handle passing a union of contextful and contextless synced queries to withValidation.
* Allow passing object with parse method to validator arg