### PR TITLE
fix(analyze-query): use replica based tablespecs TableSource schemas to match zero-cache behavior

### DIFF
--- a/packages/analyze-query/src/bin-analyze.ts
+++ b/packages/analyze-query/src/bin-analyze.ts
@@ -211,7 +211,7 @@ const host: QueryDelegate = {
       db,
       serverTableName,
       tableSpec.zqlSpec,
-      [primaryKey[0], ...primaryKey.slice(1)],
+      primaryKey,
     );
 
     sources.set(serverTableName, source);

--- a/packages/analyze-query/src/run-ast.ts
+++ b/packages/analyze-query/src/run-ast.ts
@@ -21,6 +21,7 @@ import type {
   RowCountsBySource,
   RowsBySource,
 } from '../../zql/src/builder/debug-delegate.ts';
+import type {LiteAndZqlSpec} from '../../zero-cache/src/db/specs.ts';
 
 export type RunResult = {
   warnings: string[];
@@ -45,6 +46,7 @@ export async function runAst(
     permissions?: PermissionsConfig | undefined;
     outputSyncedRows: boolean;
     db: Database;
+    tableSpecs: Map<string, LiteAndZqlSpec>;
     host: BuilderDelegate;
   },
 ): Promise<RunResult> {

--- a/packages/zero-cache/src/db/lite-tables.ts
+++ b/packages/zero-cache/src/db/lite-tables.ts
@@ -231,6 +231,22 @@ export function computeZqlSpecs(
   return tableSpecs;
 }
 
+export function mustGetTableSpec(
+  tableSpecs: Map<string, LiteAndZqlSpec>,
+  tableName: string,
+): LiteAndZqlSpec {
+  const tableSpec = tableSpecs.get(tableName);
+  if (!tableSpec) {
+    throw new Error(
+      `table '${tableName}' is not one of: ${[...tableSpecs.keys()]
+        .filter(t => !t.includes('.') && !t.startsWith('_litestream_'))
+        .sort()}. ` +
+        `Check the spelling and ensure that the table has a primary key.`,
+    );
+  }
+  return tableSpec;
+}
+
 // Deterministic comparator for favoring shorter row keys.
 function keyCmp(a: string[], b: string[]) {
   if (a.length !== b.length) {

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -27,7 +27,7 @@ import {
   type LoadedPermissions,
 } from '../../auth/load-permissions.ts';
 import type {LogConfig} from '../../config/zero-config.ts';
-import {computeZqlSpecs} from '../../db/lite-tables.ts';
+import {computeZqlSpecs, mustGetTableSpec} from '../../db/lite-tables.ts';
 import type {LiteAndZqlSpec, LiteTableSpec} from '../../db/specs.ts';
 import {getOrCreateHistogram} from '../../observability/metrics.ts';
 import type {InspectorDelegate} from '../../server/inspector-delegate.ts';
@@ -521,17 +521,8 @@ export class PipelineDriver {
       return source;
     }
 
-    const tableSpec = this.#tableSpecs.get(tableName);
-    if (!tableSpec) {
-      throw new Error(
-        `table '${tableName}' is not one of: ${[...this.#tableSpecs.keys()]
-          .filter(t => !t.includes('.') && !t.startsWith('_litestream_'))
-          .sort()}. ` +
-          `Check the spelling and ensure that the table has a primary key.`,
-      );
-    }
+    const tableSpec = mustGetTableSpec(this.#tableSpecs, tableName);
     const {primaryKey} = tableSpec.tableSpec;
-    assert(primaryKey?.length);
 
     const {db} = this.#snapshotter.current();
     source = new TableSource(

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -531,7 +531,7 @@ export class PipelineDriver {
       db.db,
       tableName,
       tableSpec.zqlSpec,
-      [primaryKey[0], ...primaryKey.slice(1)],
+      primaryKey,
     );
     this.#tables.set(tableName, source);
     this.#lc.debug?.(`created TableSource for ${tableName}`);


### PR DESCRIPTION
Another step towards making analyze-query's behavior more perfectly match zero-cache.

Without this change some queries that would succeed against zero-cache would fail with an exception with analyze-query.

In particular, if 
1. zero-cache determine that a column C should be part of a table T's primary key because it has a unique index on it
2. column C does not appear in schema.ts for table T

This caused queries involving the 'user' table of zbugs to fail, because of the `githubID` column, which has a unique index on it, but is not in schema.ts.
