### PR TITLE
feat(zero-react): support for suspense via useSuspenseQuery

### DIFF
--- a/packages/zero-react/src/mod.ts
+++ b/packages/zero-react/src/mod.ts
@@ -11,6 +11,7 @@ export type {ResultType} from '../../zql/src/query/typed-view.ts';
 export {ZeroInspector} from './components/zero-inspector.tsx';
 export {
   useQuery,
+  useSuspenseQuery,
   type QueryResult,
   type QueryResultDetails,
   type UseQueryOptions,

--- a/packages/zero-react/src/use-query.tsx
+++ b/packages/zero-react/src/use-query.tsx
@@ -35,14 +35,7 @@ export type UseQueryOptions = {
   ttl?: TTL | undefined;
 };
 
-export type UseSuspenseQueryOptions = {
-  enabled?: boolean | undefined;
-  /**
-   * Time to live (TTL) in seconds. Controls how long query results are cached
-   * after the query is removed. During this time, Zero continues to sync the query.
-   * Default is 'never'.
-   */
-  ttl?: TTL | undefined;
+export type UseSuspenseQueryOptions = UseQueryOptions & {
   /**
    * Whether to suspend until the query is complete or until the query has non-empty data.
    * Default is 'complete'.


### PR DESCRIPTION
`useSuspenseQuery` takes the same options as useQuery, plus a new `'suspendUntil'` option.

```
  /**
   * Whether to suspend until:
   * - 'non-empty': the query has non-empty results (non-empty array or defined
   *   value for singular results) which may be of result type 'unknown'
   *   or the query result type is 'complete' (in which case results may be
   *   empty).  This is useful for suspending until there are non-empty
   *   optimistic local results, or the query has completed loading from the
   * server.
   * - 'complete': the query result type is 'complete'.
   *
   * Default is 'non-empty'.
   */
 ```
 
Based on @lewisl9029's contribution https://github.com/rocicorp/mono/pull/4747