### PR TITLE
nwip: I am not sure how to use suspense

### DIFF
--- a/apps/zbugs/src/components/maybe-suspend.tsx
+++ b/apps/zbugs/src/components/maybe-suspend.tsx
@@ -1,0 +1,26 @@
+import {Suspense} from 'react';
+
+export function MaybeSuspend({
+  children,
+  enabled,
+  onReveal,
+}: {
+  children: React.ReactNode;
+  enabled: boolean;
+  onReveal?: (() => void) | undefined;
+}) {
+  if (enabled) {
+    return (
+      <Suspense>
+        {children}
+        <Reveal on={onReveal} />
+      </Suspense>
+    );
+  }
+  return <>{children}</>;
+}
+
+function Reveal({on}: {on?: (() => void) | undefined}) {
+  on?.();
+  return null;
+}

--- a/apps/zbugs/src/pages/issue/issue-page.tsx
+++ b/apps/zbugs/src/pages/issue/issue-page.tsx
@@ -1,4 +1,4 @@
-import {useQuery} from '@rocicorp/zero/react';
+import {useQuery, useSuspenseQuery} from '@rocicorp/zero/react';
 import {useWindowVirtualizer, Virtualizer} from '@tanstack/react-virtual';
 import {nanoid} from 'nanoid';
 import {
@@ -80,7 +80,7 @@ function softNavigate(path: string, state?: ZbugsHistoryState) {
 
 const emojiToastShowDuration = 3_000;
 
-export function IssuePage({onReady}: {onReady: () => void}) {
+export function IssuePage() {
   const z = useZero();
   const params = useParams();
 
@@ -92,15 +92,10 @@ export function IssuePage({onReady}: {onReady: () => void}) {
   const zbugsHistoryState = useHistoryState<ZbugsHistoryState | undefined>();
   const listContext = zbugsHistoryState?.zbugsListContext;
 
-  const [issue, issueResult] = useQuery(
+  const [issue, issueResult] = useSuspenseQuery(
     issueDetail(login.loginState?.decoded, idField, id, z.userID),
-    CACHE_NAV,
+    {ttl: CACHE_NAV},
   );
-  useEffect(() => {
-    if (issue || issueResult.type === 'complete') {
-      onReady();
-    }
-  }, [issue, onReady, issueResult.type]);
 
   const isScrolling = useIsScrolling();
   const [displayed, setDisplayed] = useState(issue);
@@ -209,7 +204,7 @@ export function IssuePage({onReady}: {onReady: () => void}) {
   }
   const prevNextOptions = {
     enabled: listContext !== undefined && issueSnapshot !== undefined,
-    ...CACHE_NAV,
+    ttl: CACHE_NAV,
   } as const;
   // Don't need to send entire issue to server, just the sort columns plus PK.
   const start = displayed
@@ -258,7 +253,7 @@ export function IssuePage({onReady}: {onReady: () => void}) {
 
   const [allComments, allCommentsResult] = useQuery(
     commentQuery(z, displayed),
-    {enabled: displayAllComments && displayed !== undefined, ...CACHE_NAV},
+    {enabled: displayAllComments && displayed !== undefined, ttl: CACHE_NAV},
   );
 
   const [comments, hasOlderComments] = useMemo(() => {

--- a/apps/zbugs/src/query-cache-policy.ts
+++ b/apps/zbugs/src/query-cache-policy.ts
@@ -1,3 +1,3 @@
-export const CACHE_NONE = {ttl: 'none'} as const;
-export const CACHE_NAV = {ttl: '5m'} as const;
+export const CACHE_NONE = 'none' as const;
+export const CACHE_NAV = '5m' as const;
 export const CACHE_PRELOAD = CACHE_NAV;

--- a/apps/zbugs/src/root.tsx
+++ b/apps/zbugs/src/root.tsx
@@ -1,6 +1,5 @@
-import {ZeroInspector} from '@rocicorp/zero/react';
 import Cookies from 'js-cookie';
-import {useState} from 'react';
+import {createContext, useState} from 'react';
 import {Route, Switch} from 'wouter';
 import {Nav} from './components/nav.tsx';
 import {OnboardingModal} from './components/onboarding-modal.tsx';
@@ -9,44 +8,45 @@ import {ErrorPage} from './pages/error/error-page.tsx';
 import {IssuePage} from './pages/issue/issue-page.tsx';
 import {ListPage} from './pages/list/list-page.tsx';
 import {routes} from './routes.ts';
-import {useZero} from './hooks/use-zero.ts';
+import {MaybeSuspend} from './components/maybe-suspend.tsx';
+
+type InitialLoadState = 'loading' | 'complete';
+export const LoadContext = createContext<InitialLoadState>('loading');
 
 export function Root() {
-  const z = useZero();
-
-  const [contentReady, setContentReady] = useState(false);
   const [showOnboarding, setShowOnboarding] = useState(
     () => !Cookies.get('onboardingDismissed'),
   );
+
+  const [loadState, setLoadState] = useState<InitialLoadState>('loading');
 
   useSoftNav();
 
   return (
     <>
-      <div
-        className="app-container flex p-8"
-        style={{visibility: contentReady ? 'visible' : 'hidden'}}
+      <MaybeSuspend
+        enabled={loadState === 'loading'}
+        onReveal={() => setLoadState('complete')}
       >
-        <div className="primary-nav w-48 shrink-0 grow-0">
-          <Nav />
-        </div>
-        <div className="primary-content">
-          <Switch>
-            <Route path={routes.home}>
-              <ListPage onReady={() => setContentReady(true)} />
-            </Route>
-            <Route path={routes.issue}>
-              {params => (
-                <IssuePage
-                  key={params.id}
-                  onReady={() => setContentReady(true)}
-                />
-              )}
-            </Route>
-            <Route component={ErrorPage} />
-          </Switch>
-        </div>
-      </div>
+        <LoadContext.Provider value={loadState}>
+          <div className="app-container flex p-8">
+            <div className="primary-nav w-48 shrink-0 grow-0">
+              <Nav />
+            </div>
+            <div className="primary-content">
+              <Switch>
+                <Route path={routes.home}>
+                  <ListPage />
+                </Route>
+                <Route path={routes.issue}>
+                  {params => <IssuePage key={params.id} />}
+                </Route>
+                <Route component={ErrorPage} />
+              </Switch>
+            </div>
+          </div>
+        </LoadContext.Provider>
+      </MaybeSuspend>
       <OnboardingModal
         isOpen={showOnboarding}
         onDismiss={() => {
@@ -54,7 +54,6 @@ export function Root() {
           setShowOnboarding(false);
         }}
       />
-      {import.meta.env.DEV && <ZeroInspector zero={z} />}
     </>
   );
 }

--- a/apps/zbugs/src/zero-preload.ts
+++ b/apps/zbugs/src/zero-preload.ts
@@ -7,7 +7,7 @@ import type {AuthData} from '../shared/auth.ts';
 
 export function preload(auth: AuthData | undefined, z: Zero<Schema, Mutators>) {
   // Preload all issues and first 10 comments from each.
-  z.preload(queries.issuePreload(auth, z.userID), CACHE_PRELOAD);
-  z.preload(queries.allUsers(), CACHE_PRELOAD);
-  z.preload(queries.allLabels(), CACHE_PRELOAD);
+  // z.preload(queries.issuePreload(auth, z.userID), {ttl: CACHE_PRELOAD});
+  // z.preload(queries.allUsers(), {ttl: CACHE_PRELOAD});
+  // z.preload(queries.allLabels(), {ttl: CACHE_PRELOAD});
 }

--- a/packages/zero-react/src/use-query.tsx
+++ b/packages/zero-react/src/use-query.tsx
@@ -45,10 +45,11 @@ export type UseSuspenseQueryOptions = UseQueryOptions & {
    *   optimistic local results, or the query has completed loading from the
    *   server.
    * - 'complete': the query result type is 'complete'.
+   * - 'none': do not suspend.
    *
    * Default is 'non-empty'.
    */
-  suspendUntil?: 'complete' | 'non-empty';
+  suspendUntil?: 'complete' | 'non-empty' | 'none';
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion


### PR DESCRIPTION
Hey @lewisl9029 and @grgbkr I was playing with the new suspense support and it was not as glorious as I hoped. Maybe I just don't get the glory of Suspense though.

Here is how I had hoped to use it. Currently in zbugs, I have [manual logic](https://github.com/rocicorp/mono/pull/4830/files#diff-fe44d0a1725a1ac25dfedaf82dd420db12c23ecca73c7cb529c69341a8b51d06L83) to delay displaying any UI until the main content area query has completed. Then the entire UI comes up together. I had hoped suspense support would automate this in a cleaner way.

But it's surprisingly subtle!

Simply changing the content area queries to useSuspenseQuery and putting a `<Suspense>` around the content area doesn't do the trick. Because whenever a new query starts in the content area the entire page goes blank again, which is not what I want.

For example, if I let the app load, then type an obscure query in the search box, it causes a query to go to the server which causes a suspend. Because of suspense, the entire page goes blank again and flickers a loading state. But that's not what I want.

I only want the entire page to  go blank for the very *first* load. After that I don't actually want to use suspense at all. I just want the specific parts of the app waiting for load to go blank, like they do today. So like when you do a search in zbugs that cause a server load, the result table and result count UI should go blank but nothing else.

I realized don't actually know how to achieve this gracefully w/ suspense. I can blank the entire UI on first load by [conditionally wrapping](https://github.com/rocicorp/mono/pull/4830/files#diff-0efd385fff79d660eaddb6685e77217c217225a6c7c8322376ec5827fe02be6dR27) the entire content area in <Suspense>. But that means in the case when I don't wrap the content area I still need a suspense boundary somewhere or else I'll get errors.

My next thought was to wrap `<Suspense>` around, e.g., `<ListPage>`. But this doesn't work because `<ListPage>` also includes the search UI which shouldn't be disabled on second load. And I can't factor out the data table into a separate component that has a suspense around it because there is the matter of result count which uses the query result and is displayed outside the data table.

I [find myself wondering](https://github.com/rocicorp/mono/pull/4830/files#diff-9597c0281d1a51dac42b6c50666d911bc9fbdea3ae9ea97008a054f98926febcR88) what the purpose of this machinery is when what I had worked fine and was like 10 lines of code. The suspense code is much bigger and more complex and doesn't work yet!

In summary:

<img width="556" height="500" alt="image" src="https://github.com/user-attachments/assets/2a2e687d-ddff-423d-88b8-d4b016b9621b" />

... or am I misunderstanding how to use Suspense?