### PR TITLE
Revert "feat(zero-client): Use admin password for inspector (#4825)"

### DIFF
--- a/packages/zero-cache/src/server/inspector-delegate.ts
+++ b/packages/zero-cache/src/server/inspector-delegate.ts
@@ -18,14 +18,6 @@ export type ServerMetrics = {
   'query-update-server': TDigest;
 };
 
-type ClientGroupID = string;
-
-/**
- * Set of authenticated client IDs. We keep this outside of the class to share this state
- * across all instances of the InspectorDelegate.
- */
-const authenticatedClientIDs = new Set<ClientGroupID>();
-
 export class InspectorDelegate implements MetricsDelegate {
   readonly #globalMetrics: ServerMetrics = newMetrics();
   readonly #perQueryServerMetrics = new Map<string, ServerMetrics>();
@@ -90,22 +82,6 @@ export class InspectorDelegate implements MetricsDelegate {
     }
     this.#queryIDToTransformationHash.set(queryID, transformationHash);
     this.#transformationASTs.set(transformationHash, ast);
-  }
-
-  /**
-   * Check if the client is authenticated. We only require authentication once
-   * per "worker".
-   */
-  isAuthenticated(clientGroupID: ClientGroupID): boolean {
-    return authenticatedClientIDs.has(clientGroupID);
-  }
-
-  setAuthenticated(clientGroupID: ClientGroupID): void {
-    authenticatedClientIDs.add(clientGroupID);
-  }
-
-  clearAuthenticated(clientGroupID: ClientGroupID) {
-    authenticatedClientIDs.delete(clientGroupID);
   }
 }
 

--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -90,7 +90,7 @@ export default function runWorker(
       .withContext('clientGroupID', id)
       .withContext('instance', randomID());
     lc.debug?.(`creating view syncer`);
-    const inspectorDelegate = new InspectorDelegate();
+    const inspectMetricsDelegate = new InspectorDelegate();
     return new ViewSyncerService(
       config,
       logger,
@@ -106,12 +106,12 @@ export default function runWorker(
         shard,
         operatorStorage.createClientGroupStorage(id),
         id,
-        inspectorDelegate,
+        inspectMetricsDelegate,
       ),
       sub,
       drainCoordinator,
       config.log.slowHydrateThreshold,
-      inspectorDelegate,
+      inspectMetricsDelegate,
     );
   };
 

--- a/packages/zero-cache/src/services/view-syncer/view-syncer-inspect.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer-inspect.pg-test.ts
@@ -5,7 +5,6 @@ import type {Downstream} from '../../../../zero-protocol/src/down.ts';
 import type {InspectDownMessage} from '../../../../zero-protocol/src/inspect-down.ts';
 import {PROTOCOL_VERSION} from '../../../../zero-protocol/src/protocol-version.ts';
 import type {UpQueriesPatch} from '../../../../zero-protocol/src/queries-patch.ts';
-import {InspectorDelegate} from '../../server/inspector-delegate.ts';
 import {type PgTest, test} from '../../test/db.ts';
 import {DbFile} from '../../test/lite.ts';
 import type {PostgresDB} from '../../types/pg.ts';
@@ -19,9 +18,7 @@ import {
   messages,
   nextPoke,
   permissionsAll,
-  serviceID,
   setup,
-  TEST_ADMIN_PASSWORD,
 } from './view-syncer-test-util.ts';
 import {type SyncContext, ViewSyncerService} from './view-syncer.ts';
 
@@ -54,8 +51,6 @@ describe('view-syncer/service', () => {
     httpCookie: undefined,
   };
 
-  let delegate: InspectorDelegate;
-
   beforeEach<PgTest>(async ({testDBs}) => {
     ({
       replicaDbFile,
@@ -66,10 +61,7 @@ describe('view-syncer/service', () => {
       viewSyncerDone,
       replicator,
       connectWithQueueAndSource,
-      inspectorDelegate: delegate,
     } = await setup(testDBs, 'view_syncer_inspect_test', permissionsAll));
-
-    delegate.setAuthenticated(serviceID);
 
     return async () => {
       vi.useRealTimers();
@@ -77,8 +69,6 @@ describe('view-syncer/service', () => {
       await viewSyncerDone;
       await testDBs.drop(cvrDB, upstreamDb);
       replicaDbFile.delete();
-
-      delegate.clearAuthenticated(serviceID);
     };
   });
 
@@ -207,83 +197,6 @@ describe('view-syncer/service', () => {
         id: 'test-version-inspect',
         op: 'version',
         value: expect.stringMatching(/^\d+\.\d+\.\d+$/),
-      },
-    ]);
-  });
-
-  test('not authenticated', async () => {
-    delegate.clearAuthenticated('9876');
-
-    const {queue: client} = connectWithQueueAndSource(SYNC_CONTEXT, []);
-
-    // Wait for initial hydration to complete
-    await nextPoke(client);
-    stateChanges.push({state: 'version-ready'});
-    await nextPoke(client);
-
-    await expectNoPokes(client);
-
-    const inspectId = 'test-version-inspect';
-
-    // Call inspect and wait for the response to come through the client queue
-    await vs.inspect(SYNC_CONTEXT, ['inspect', {op: 'version', id: inspectId}]);
-
-    const msg = await client.dequeue();
-
-    expect(msg).toEqual([
-      'inspect',
-      {
-        id: 'test-version-inspect',
-        op: 'authenticated',
-        value: false,
-      },
-    ]);
-  });
-
-  test('authenticate', async () => {
-    delegate.clearAuthenticated(serviceID);
-
-    const {queue: client} = connectWithQueueAndSource(SYNC_CONTEXT, []);
-
-    // Wait for initial hydration to complete
-    await nextPoke(client);
-    stateChanges.push({state: 'version-ready'});
-    await nextPoke(client);
-
-    await expectNoPokes(client);
-
-    const inspectId = 'test-version-inspect';
-
-    // Call inspect and wait for the response to come through the client queue
-    await vs.inspect(SYNC_CONTEXT, [
-      'inspect',
-      {op: 'authenticate', id: inspectId, value: 'wrong'},
-    ]);
-
-    let msg = await client.dequeue();
-
-    expect(msg).toEqual([
-      'inspect',
-      {
-        id: 'test-version-inspect',
-        op: 'authenticated',
-        value: false,
-      },
-    ]);
-
-    await vs.inspect(SYNC_CONTEXT, [
-      'inspect',
-      {op: 'authenticate', id: inspectId, value: TEST_ADMIN_PASSWORD},
-    ]);
-
-    msg = await client.dequeue();
-
-    expect(msg).toEqual([
-      'inspect',
-      {
-        id: 'test-version-inspect',
-        op: 'authenticated',
-        value: true,
       },
     ]);
   });

--- a/packages/zero-cache/src/services/view-syncer/view-syncer-test-util.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer-test-util.ts
@@ -544,8 +544,6 @@ async function expectDesired(
   return pokeParts;
 }
 
-export const TEST_ADMIN_PASSWORD = 'test-pwd';
-
 export async function setup(
   testDBs: TestDBs,
   testName: string,
@@ -670,9 +668,9 @@ export async function setup(
   const operatorStorage = new DatabaseStorage(
     storageDB,
   ).createClientGroupStorage(serviceID);
-  const inspectorDelegate = new InspectorDelegate();
+  const inspectMetricsDelegate = new InspectorDelegate();
   const vs = new ViewSyncerService(
-    {getQueries: queryConfig, adminPassword: TEST_ADMIN_PASSWORD},
+    {getQueries: queryConfig},
     lc,
     SHARD,
     TASK_ID,
@@ -686,12 +684,12 @@ export async function setup(
       SHARD,
       operatorStorage,
       'view-syncer.pg-test.ts',
-      inspectorDelegate,
+      inspectMetricsDelegate,
     ),
     stateChanges,
     drainCoordinator,
     100,
-    inspectorDelegate,
+    inspectMetricsDelegate,
     undefined,
     setTimeoutFn,
   );
@@ -752,7 +750,6 @@ export async function setup(
     connect,
     connectWithQueueAndSource,
     setTimeoutFn,
-    inspectorDelegate,
   };
 }
 

--- a/packages/zero-cache/src/services/view-syncer/view-syncer-ttl.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer-ttl.pg-test.ts
@@ -5,7 +5,6 @@ import {type ClientSchema} from '../../../../zero-protocol/src/client-schema.ts'
 import type {Downstream} from '../../../../zero-protocol/src/down.ts';
 import {PROTOCOL_VERSION} from '../../../../zero-protocol/src/protocol-version.ts';
 import type {UpQueriesPatch} from '../../../../zero-protocol/src/queries-patch.ts';
-import type {InspectorDelegate} from '../../server/inspector-delegate.ts';
 import {type PgTest, test} from '../../test/db.ts';
 import {DbFile} from '../../test/lite.ts';
 import type {PostgresDB} from '../../types/pg.ts';
@@ -60,7 +59,6 @@ let connectWithQueueAndSource: (
   source: Source<Downstream>;
 };
 let setTimeoutFn: Mock<typeof setTimeout>;
-let inspectorDelegate: InspectorDelegate;
 
 function callNextSetTimeout(delta: number, expectedDelay?: number) {
   // Sanity check that the system time is the mocked time.
@@ -98,13 +96,9 @@ beforeEach<PgTest>(async ({testDBs}) => {
     connect,
     connectWithQueueAndSource,
     setTimeoutFn,
-    inspectorDelegate,
   } = await setup(testDBs, 'view_syncer_ttl_test', permissionsAll));
-  inspectorDelegate.setAuthenticated(serviceID);
 
   return async () => {
-    inspectorDelegate.clearAuthenticated(serviceID);
-
     vi.useRealTimers();
     await vs.stop();
     await viewSyncerDone;

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg-test.ts
@@ -3997,4 +3997,51 @@ describe('view-syncer/service', () => {
       ]
     `);
   });
+
+  test('inspect metrics op returns server metrics', async () => {
+    const {queue: client} = connectWithQueueAndSource(SYNC_CONTEXT, [
+      {op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY},
+    ]);
+
+    // Wait for initial hydration to complete
+    await nextPoke(client);
+    stateChanges.push({state: 'version-ready'});
+    await nextPoke(client);
+
+    // Trigger query materializations to generate metrics
+    replicator.processTransaction(
+      'txn-1',
+      messages.insert('issues', {
+        id: 'test-issue',
+        title: 'Test Issue',
+        owner: '100',
+        big: 1000,
+        json: null,
+        parent: null,
+      }),
+    );
+    stateChanges.push({state: 'version-ready'});
+    await expectNoPokes(client);
+
+    // Now call the inspect method and expect it to send a response
+    const inspectId = 'test-metrics-inspect';
+
+    // Call inspect and wait for the response to come through the client queue
+    await vs.inspect(SYNC_CONTEXT, ['inspect', {op: 'metrics', id: inspectId}]);
+
+    const msg = await client.dequeue();
+    expect(msg).toMatchObject([
+      'inspect',
+      {
+        id: 'test-metrics-inspect',
+        op: 'metrics',
+        value: {
+          'query-materialization-server': expect.arrayContaining([
+            expect.any(Number),
+          ]),
+          'query-update-server': expect.arrayContaining([expect.any(Number)]),
+        },
+      },
+    ]);
+  });
 });

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -151,10 +151,7 @@ export const TTL_CLOCK_INTERVAL = 60_000;
  */
 export const TTL_TIMER_HYSTERESIS = 50; // ms
 
-type PartialZeroConfig = Pick<
-  ZeroConfig,
-  'getQueries' | 'serverVersion' | 'adminPassword'
->;
+type PartialZeroConfig = Pick<ZeroConfig, 'getQueries' | 'serverVersion'>;
 
 export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   readonly id: string;
@@ -247,7 +244,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
   readonly #inspectorDelegate: InspectorDelegate;
 
-  readonly #config: Pick<ZeroConfig, 'serverVersion' | 'adminPassword'>;
+  readonly #config: Pick<ZeroConfig, 'serverVersion'>;
 
   constructor(
     config: PartialZeroConfig,
@@ -1805,23 +1802,6 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   ): Promise<void> => {
     const client = must(this.#clients.get(clientID));
 
-    // Check if the client is already authenticated. We only authenticate the clientGroup
-    // once per "worker".
-    if (
-      body.op !== 'authenticate' &&
-      !this.#inspectorDelegate.isAuthenticated(this.id)
-    ) {
-      lc.info?.(
-        'Client not authenticated to access the inspector protocol. Sending authentication challenge',
-      );
-      client.sendInspectResponse(lc, {
-        op: 'authenticated',
-        id: body.id,
-        value: false,
-      });
-      return;
-    }
-
     switch (body.op) {
       case 'queries': {
         const queryRows = await this.#cvrStore.inspectQueries(
@@ -1864,24 +1844,6 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           value: getServerVersion(this.#config),
         });
         break;
-
-      case 'authenticate': {
-        const password = body.value;
-        const ok = password === this.#config.adminPassword;
-        if (ok) {
-          this.#inspectorDelegate.setAuthenticated(this.id);
-        } else {
-          this.#inspectorDelegate.clearAuthenticated(this.id);
-        }
-
-        client.sendInspectResponse(lc, {
-          op: 'authenticated',
-          id: body.id,
-          value: ok,
-        });
-
-        break;
-      }
 
       default:
         unreachable(body);

--- a/packages/zero-client/src/client/inspector/inspector.test.ts
+++ b/packages/zero-client/src/client/inspector/inspector.test.ts
@@ -137,7 +137,7 @@ test('client queries', async () => {
     (await z.socket).messages.length = 0;
     const p = inspector.client.queries();
     await Promise.resolve();
-    expect((await z.socket).jsonMessages).toEqual([
+    expect((await z.socket).messages.map(s => JSON.parse(s))).toEqual([
       [
         'inspect',
         {
@@ -662,8 +662,8 @@ test('server version', async () => {
   await z.socket;
   const p = inspector.serverVersion();
   await Promise.resolve();
-  expect((await z.socket).jsonMessages).toEqual([
-    ['inspect', {op: 'version', id: '000000000000000000000'}],
+  expect((await z.socket).messages).toEqual([
+    JSON.stringify(['inspect', {op: 'version', id: '000000000000000000000'}]),
   ]);
 
   await z.triggerMessage([
@@ -739,142 +739,4 @@ test('clientZQL', async () => {
 
   view.destroy();
   await z.close();
-});
-
-describe('authenticate', () => {
-  test('authenticate rpc dance', async () => {
-    const z = zeroForTest({schema});
-    await z.triggerConnected();
-    await Promise.resolve();
-    const inspector = await z.inspect();
-    vi.spyOn(Math, 'random').mockImplementation(() => 0.5);
-    await z.socket;
-    const p = inspector.serverVersion();
-    await Promise.resolve();
-    expect((await z.socket).jsonMessages).toEqual([
-      ['inspect', {op: 'version', id: '000000000000000000000'}],
-    ]);
-    (await z.socket).messages.length = 0;
-
-    vi.stubGlobal('prompt', () => 'test-user');
-
-    await z.triggerMessage([
-      'inspect',
-      {
-        op: 'authenticated',
-        id: '000000000000000000000',
-        value: false,
-      },
-    ] satisfies InspectDownMessage);
-
-    expect((await z.socket).jsonMessages).toEqual([
-      [
-        'inspect',
-        {op: 'authenticate', id: '000000000000000000000', value: 'test-user'},
-      ],
-    ]);
-    (await z.socket).messages.length = 0;
-
-    await z.triggerMessage([
-      'inspect',
-      {
-        op: 'authenticated',
-        id: '000000000000000000000',
-        value: true,
-      },
-    ] satisfies InspectDownMessage);
-    expect((await z.socket).jsonMessages).toEqual([
-      ['inspect', {op: 'version', id: '000000000000000000000'}],
-    ]);
-    (await z.socket).messages.length = 0;
-
-    await z.triggerMessage([
-      'inspect',
-      {
-        op: 'version',
-        id: '000000000000000000000',
-        value: '1.2.34',
-      },
-    ] satisfies InspectDownMessage);
-
-    expect(await p).toBe('1.2.34');
-
-    await z.close();
-  });
-
-  test('cancel prompt', async () => {
-    const z = zeroForTest({schema});
-    await z.triggerConnected();
-    await Promise.resolve();
-    const inspector = await z.inspect();
-    vi.spyOn(Math, 'random').mockImplementation(() => 0.5);
-    await z.socket;
-    const p = inspector.serverVersion();
-    await Promise.resolve();
-    expect((await z.socket).jsonMessages).toEqual([
-      ['inspect', {op: 'version', id: '000000000000000000000'}],
-    ]);
-    (await z.socket).messages.length = 0;
-
-    vi.stubGlobal('prompt', () => null);
-
-    await z.triggerMessage([
-      'inspect',
-      {
-        op: 'authenticated',
-        id: '000000000000000000000',
-        value: false,
-      },
-    ] satisfies InspectDownMessage);
-
-    await expect(p).rejects.toThrowError(`Authentication failed`);
-    await z.close();
-  });
-
-  test('wrong password rejects', async () => {
-    const z = zeroForTest({schema});
-    await z.triggerConnected();
-    await Promise.resolve();
-    const inspector = await z.inspect();
-    vi.spyOn(Math, 'random').mockImplementation(() => 0.5);
-    await z.socket;
-    const p = inspector.serverVersion();
-    await Promise.resolve();
-    expect((await z.socket).jsonMessages).toEqual([
-      ['inspect', {op: 'version', id: '000000000000000000000'}],
-    ]);
-    (await z.socket).messages.length = 0;
-
-    vi.stubGlobal('prompt', () => 'test-user');
-
-    await z.triggerMessage([
-      'inspect',
-      {
-        op: 'authenticated',
-        id: '000000000000000000000',
-        value: false,
-      },
-    ] satisfies InspectDownMessage);
-
-    expect((await z.socket).jsonMessages).toEqual([
-      [
-        'inspect',
-        {op: 'authenticate', id: '000000000000000000000', value: 'test-user'},
-      ],
-    ]);
-    (await z.socket).messages.length = 0;
-
-    await z.triggerMessage([
-      'inspect',
-      {
-        op: 'authenticated',
-        id: '000000000000000000000',
-        value: false,
-      },
-    ] satisfies InspectDownMessage);
-
-    await expect(p).rejects.toThrowError(`Authentication failed`);
-
-    await z.close();
-  });
 });

--- a/packages/zero-client/src/client/inspector/inspector.ts
+++ b/packages/zero-client/src/client/inspector/inspector.ts
@@ -19,7 +19,6 @@ import * as valita from '../../../../shared/src/valita.ts';
 import type {AST} from '../../../../zero-protocol/src/ast.ts';
 import type {Row} from '../../../../zero-protocol/src/data.ts';
 import {
-  inspectAuthenticatedDownSchema,
   inspectMetricsDownSchema,
   inspectQueriesDownSchema,
   inspectVersionDownSchema,
@@ -27,7 +26,11 @@ import {
   type InspectQueryRow,
   type ServerMetrics as ServerMetricsJSON,
 } from '../../../../zero-protocol/src/inspect-down.ts';
-import type {InspectUpBody} from '../../../../zero-protocol/src/inspect-up.ts';
+import type {
+  InspectQueriesUpBody,
+  InspectUpBody,
+  InspectUpMessage,
+} from '../../../../zero-protocol/src/inspect-up.ts';
 import type {Schema} from '../../../../zero-schema/src/builder/schema-builder.ts';
 import type {
   ClientMetricMap,
@@ -82,11 +85,6 @@ export async function newInspector(
     socket,
   );
 }
-
-// T extends forces T to be resolved
-type DistributiveOmit<T, K extends string> = T extends object
-  ? Omit<T, K>
-  : never;
 
 class Inspector implements InspectorInterface {
   readonly #rep: Rep;
@@ -152,11 +150,9 @@ class Inspector implements InspectorInterface {
   }
 }
 
-class UnauthenticatedError extends Error {}
-
-function rpcNoAuthTry<T extends InspectDownBody>(
+function rpc<T extends InspectDownBody>(
   socket: WebSocket,
-  arg: DistributiveOmit<InspectUpBody, 'id'>,
+  arg: Omit<InspectUpBody, 'id'>,
   downSchema: valita.Type<T>,
 ): Promise<T['value']> {
   return new Promise((resolve, reject) => {
@@ -172,53 +168,16 @@ function rpcNoAuthTry<T extends InspectDownBody>(
         if (res.ok) {
           resolve(res.value.value);
         } else {
-          // Check if we got un authenticated/false response
-          const authRes = valita.test(body, inspectAuthenticatedDownSchema);
-          if (authRes.ok) {
-            // Handle authenticated response
-            assert(
-              authRes.value.value === false,
-              'Expected unauthenticated response',
-            );
-            reject(new UnauthenticatedError());
-          }
-
           reject(res.error);
         }
         socket.removeEventListener('message', f);
       }
     };
     socket.addEventListener('message', f);
-    socket.send(JSON.stringify(['inspect', {...arg, id}]));
+    socket.send(
+      JSON.stringify(['inspect', {...arg, id}] satisfies InspectUpMessage),
+    );
   });
-}
-
-async function rpc<T extends InspectDownBody>(
-  socket: WebSocket,
-  arg: DistributiveOmit<InspectUpBody, 'id'>,
-  downSchema: valita.Type<T>,
-): Promise<T['value']> {
-  try {
-    return await rpcNoAuthTry(socket, arg, downSchema);
-  } catch (e) {
-    if (e instanceof UnauthenticatedError) {
-      const password = prompt('Enter password:');
-      if (password) {
-        // Do authenticate rpc
-        const authRes = await rpcNoAuthTry(
-          socket,
-          {op: 'authenticate', value: password},
-          inspectAuthenticatedDownSchema,
-        );
-        if (authRes) {
-          // If authentication is successful, retry the original RPC
-          return rpcNoAuthTry(socket, arg, downSchema);
-        }
-      }
-      throw new Error('Authentication failed');
-    }
-    throw e;
-  }
 }
 
 class Client implements ClientInterface {
@@ -252,7 +211,7 @@ class Client implements ClientInterface {
   async queries(): Promise<QueryInterface[]> {
     const rows: InspectQueryRow[] = await rpc(
       await this.#socket(),
-      {op: 'queries', clientID: this.id},
+      {op: 'queries', clientID: this.id} as InspectQueriesUpBody,
       inspectQueriesDownSchema,
     );
     return rows.map(row => new Query(row, this.#delegate));

--- a/packages/zero-client/src/client/test-utils.ts
+++ b/packages/zero-client/src/client/test-utils.ts
@@ -4,7 +4,6 @@ import {resolver} from '@rocicorp/resolver';
 import type {Store} from '../../../replicache/src/dag/store.ts';
 import {assert} from '../../../shared/src/asserts.ts';
 import type {Enum} from '../../../shared/src/enum.ts';
-import type {JSONValue} from '../../../shared/src/json.ts';
 import {TestLogSink} from '../../../shared/src/logging-test-utils.ts';
 import type {ConnectedMessage} from '../../../zero-protocol/src/connect.ts';
 import type {Downstream} from '../../../zero-protocol/src/down.ts';
@@ -68,10 +67,6 @@ export class MockSocket extends EventTarget {
     super();
     this.url = url;
     this.protocol = protocol;
-  }
-
-  get jsonMessages(): JSONValue[] {
-    return this.messages.map(message => JSON.parse(message));
   }
 
   send(message: string) {

--- a/packages/zero-protocol/src/ast.test.ts
+++ b/packages/zero-protocol/src/ast.test.ts
@@ -607,5 +607,5 @@ test('protocol version', () => {
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
   expect(hash).toEqual('1c228prd1v53r');
-  expect(PROTOCOL_VERSION).toBe(30);
+  expect(PROTOCOL_VERSION).toEqual(29);
 });

--- a/packages/zero-protocol/src/inspect-down.ts
+++ b/packages/zero-protocol/src/inspect-down.ts
@@ -53,20 +53,10 @@ export const inspectVersionDownSchema = inspectBaseDownSchema.extend({
   value: v.string(),
 });
 
-export const inspectAuthenticatedDownSchema = inspectBaseDownSchema.extend({
-  op: v.literal('authenticated'),
-  value: v.boolean(),
-});
-
-export type InspectAuthenticatedDown = v.Infer<
-  typeof inspectAuthenticatedDownSchema
->;
-
 export const inspectDownBodySchema = v.union(
   inspectQueriesDownSchema,
   inspectMetricsDownSchema,
   inspectVersionDownSchema,
-  inspectAuthenticatedDownSchema,
 );
 
 export const inspectDownMessageSchema = v.tuple([

--- a/packages/zero-protocol/src/inspect-up.ts
+++ b/packages/zero-protocol/src/inspect-up.ts
@@ -11,32 +11,23 @@ const inspectQueriesUpBodySchema = inspectUpBase.extend({
 
 export type InspectQueriesUpBody = v.Infer<typeof inspectQueriesUpBodySchema>;
 
-const inspectMetricsUpSchema = inspectUpBase.extend({
-  op: v.literal('metrics'),
+const inspectBasicUpSchema = inspectUpBase.extend({
+  op: v.literalUnion('metrics', 'version'),
 });
 
-export type InspectMetricsUpBody = v.Infer<typeof inspectMetricsUpSchema>;
+export type InspectMetricsUpBody = {
+  op: 'metrics';
+  id: string;
+};
 
-const inspectVersionUpSchema = inspectUpBase.extend({
-  op: v.literal('version'),
-});
-
-export type InspectVersionUpBody = v.Infer<typeof inspectVersionUpSchema>;
-
-export const inspectAuthenticateUpSchema = inspectUpBase.extend({
-  op: v.literal('authenticate'),
-  value: v.string(),
-});
-
-export type InspectAuthenticateUpBody = v.Infer<
-  typeof inspectAuthenticateUpSchema
->;
+export type InspectVersionUpBody = {
+  op: 'version';
+  id: string;
+};
 
 const inspectUpBodySchema = v.union(
   inspectQueriesUpBodySchema,
-  inspectMetricsUpSchema,
-  inspectVersionUpSchema,
-  inspectAuthenticateUpSchema,
+  inspectBasicUpSchema,
 );
 
 export const inspectUpMessageSchema = v.tuple([

--- a/packages/zero-protocol/src/protocol-version.test.ts
+++ b/packages/zero-protocol/src/protocol-version.test.ts
@@ -11,6 +11,6 @@ test('protocol version', () => {
   // If this test fails upstream or downstream schema has changed such that
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
-  expect(hash).toEqual('b8fxxa7v0iz0');
-  expect(PROTOCOL_VERSION).toBe(30);
+  expect(hash).toEqual('1pmjffpekmm4w');
+  expect(PROTOCOL_VERSION).toEqual(29);
 });

--- a/packages/zero-protocol/src/protocol-version.ts
+++ b/packages/zero-protocol/src/protocol-version.ts
@@ -35,8 +35,7 @@ import {assert} from '../../shared/src/asserts.ts';
 // -- version 27 adds inspect/version (0.23)
 // -- version 28 adds more inspect/metrics (0.23)
 // -- version 29 adds error responses for custom queries (0.23)
-// -- version 30 adds admin password authentication to inspector RPC calls (0.23)
-export const PROTOCOL_VERSION = 30;
+export const PROTOCOL_VERSION = 29;
 
 /**
  * The minimum server-supported sync protocol version (i.e. the version


### PR DESCRIPTION
I decided to revert this temporarily because it's such an important debug feature and I really think we need some way for it to be default-on. Let's talk about what we should do at next team meeting. Can imagine a number of options.

This reverts commit cc32e9efbf533d4ed2d2a5d5aebfcfe9b3233584.