### PR TITLE
chore(api-viz): disable api-viz again.

### DIFF
--- a/apps/zql-viz/package.json
+++ b/apps/zql-viz/package.json
@@ -5,9 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "npx api-extractor run --local && vite",
-    "build": "npx api-extractor run --local && vite build",
-    "preview": "vite preview",
-    "check-types": "tsc --noEmit"
+    "preview": "vite preview"
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",


### PR DESCRIPTION
It got re-enabled in https://github.com/rocicorp/mono/pull/4837 - i think accidentally.