### PR TITLE
Fix type hints with `enableLegacyMutators: false`

### DIFF
--- a/apps/zbugs/shared/schema.ts
+++ b/apps/zbugs/shared/schema.ts
@@ -215,6 +215,8 @@ export const schema = createSchema({
     issueLabelRelationships,
     emojiRelationships,
   ],
+  enableLegacyMutators: false,
+  enableLegacyQueries: false,
 });
 
 export type Schema = typeof schema;

--- a/apps/zbugs/src/pages/issue/issue-page.tsx
+++ b/apps/zbugs/src/pages/issue/issue-page.tsx
@@ -110,39 +110,6 @@ export function IssuePage({onReady}: {onReady: () => void}) {
     }
   }, [issue, isScrolling, displayed]);
 
-  if (import.meta.env.DEV) {
-    // exposes a function to dev console to create comments.
-    // useful for testing displayed above, and other things.
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useEffect(() => {
-      (window as unknown as Record<string, unknown>).autocomment = (
-        count = 1,
-        repeat = true,
-      ) => {
-        const mut = () => {
-          z.mutateBatch(m => {
-            for (let i = 0; i < count; i++) {
-              const id = nanoid();
-              m.comment.insert({
-                id,
-                issueID: displayed?.id ?? '',
-                body: `autocomment ${id}`,
-                created: Date.now(),
-                creatorID: z.userID,
-              });
-            }
-          });
-        };
-
-        if (repeat) {
-          setInterval(mut, 5_000);
-        } else {
-          mut();
-        }
-      };
-    });
-  }
-
   useEffect(() => {
     if (issueResult.type === 'complete') {
       recordPageLoad('issue-page');

--- a/packages/zero-client/src/client/crud.ts
+++ b/packages/zero-client/src/client/crud.ts
@@ -58,9 +58,12 @@ export type TableMutator<S extends TableSchema> = {
   delete: (id: DeleteID<S>) => Promise<void>;
 };
 
-export type DBMutator<S extends Schema> = {
-  [K in keyof S['tables']]: TableMutator<S['tables'][K]>;
-};
+export type DBMutator<S extends Schema> =
+  S['enableLegacyMutators'] extends false
+    ? {} // eslint-disable-line @typescript-eslint/ban-types -- {} is needed here for intersection type identity
+    : {
+        [K in keyof S['tables']]: TableMutator<S['tables'][K]>;
+      };
 
 export type BatchMutator<S extends Schema> = <R>(
   body: (m: DBMutator<S>) => MaybePromise<R>,

--- a/packages/zero-client/src/client/custom.test.ts
+++ b/packages/zero-client/src/client/custom.test.ts
@@ -800,11 +800,14 @@ test('warns when awaiting the promise directly', async () => {
 
 test('trying to use crud mutators throws if `enableLegacyMutators` is set to false', async () => {
   const z = zeroForTest({
-    schema,
-    enableLegacyMutators: false,
+    schema: {
+      ...schema,
+      enableLegacyMutators: false,
+    },
   });
 
   await expect(
+    // @ts-expect-error - Testing runtime behavior when legacy mutators are disabled
     z.mutate.issue.insert({
       id: '1',
       title: 'foo',
@@ -850,8 +853,10 @@ test('crud mutators work if `enableLegacyMutators` is set to true (or not set)',
 test('unnamed queries do not get registered with the query manager if `enableLegacyQueries` is set to false', async () => {
   const addLegacySpy = vi.spyOn(QueryManager.prototype, 'addLegacy');
   const z = zeroForTest({
-    schema,
-    enableLegacyQueries: false,
+    schema: {
+      ...schema,
+      enableLegacyQueries: false,
+    },
   });
 
   // mock the QueryManager class

--- a/packages/zero-client/src/client/options.ts
+++ b/packages/zero-client/src/client/options.ts
@@ -55,22 +55,6 @@ export interface ZeroOptions<
     | undefined;
 
   /**
-   * Enables legacy query support.
-   * When this is true, old-style queries that do not require server side implementations will be enabled.
-   * This will flip to false in the future and what we currently call "custom queries" will become "queries" and
-   * the only option for reading data.
-   */
-  enableLegacyQueries?: boolean | undefined;
-
-  /**
-   * Enables legacy mutator support.
-   * When this is true, old-style mutations that do not require server side implementations will be enabled.
-   * This will flip to false in the future and what we currently call "custom mutations" will become "mutations" and
-   * the only option for writing data.
-   */
-  enableLegacyMutators?: boolean | undefined;
-
-  /**
    * A unique identifier for the user. Must be non-empty.
    *
    * Each userID gets its own client-side storage so that the app can switch

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -484,7 +484,7 @@ export class Zero<
     });
     const logOptions = this.#logOptions;
 
-    const {enableLegacyMutators = true, enableLegacyQueries = true} = options;
+    const {enableLegacyMutators = true, enableLegacyQueries = true} = schema;
 
     const replicacheMutators: MutatorDefs & {
       [CRUD_MUTATION_NAME]: CRUDMutator;
@@ -930,7 +930,9 @@ export class Zero<
    * ```
    */
   readonly mutate: MD extends CustomMutatorDefs
-    ? DeepMerge<DBMutator<S>, MakeCustomMutatorInterfaces<S, MD>>
+    ? S['enableLegacyMutators'] extends false
+      ? MakeCustomMutatorInterfaces<S, MD>
+      : DeepMerge<DBMutator<S>, MakeCustomMutatorInterfaces<S, MD>>
     : DBMutator<S>;
 
   /**

--- a/packages/zero-client/src/client/zero.type.test.ts
+++ b/packages/zero-client/src/client/zero.type.test.ts
@@ -1,6 +1,7 @@
 import {expect, expectTypeOf, test} from 'vitest';
 import {zeroForTest} from './test-utils.ts';
 import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
+import type {DBMutator} from './crud.ts';
 
 import {
   number,
@@ -10,6 +11,7 @@ import {
 import {createBuilder} from '../../../zql/src/query/named.ts';
 import type {ImmutableArray} from '../../../shared/src/immutable.ts';
 import {refCountSymbol} from '../../../zql/src/ivm/view-apply-change.ts';
+import type {Transaction} from '../../../zql/src/mutate/custom.ts';
 
 test('run', async () => {
   const schema = createSchema({
@@ -77,4 +79,183 @@ test('materialize', async () => {
   });
 
   expect(gotData).toEqual([{id: 'a', value: 1, [refCountSymbol]: 1}]);
+});
+
+test('legacy mutators enabled - CRUD methods available in types', () => {
+  const schema = createSchema({
+    tables: [
+      table('issues')
+        .columns({
+          id: string(),
+          title: string(),
+        })
+        .primaryKey('id'),
+    ],
+    enableLegacyMutators: true,
+  });
+
+  const z = zeroForTest({schema});
+
+  // Verify CRUD methods exist in types
+  expectTypeOf(z.mutate.issues.insert).toBeFunction();
+  expectTypeOf(z.mutate.issues.update).toBeFunction();
+  expectTypeOf(z.mutate.issues.delete).toBeFunction();
+  expectTypeOf(z.mutate.issues.upsert).toBeFunction();
+
+  // Verify return types are Promise<void>
+  expectTypeOf(
+    z.mutate.issues.insert({id: 'test', title: 'test'}),
+  ).toEqualTypeOf<Promise<void>>();
+  expectTypeOf(z.mutate.issues.update({id: 'test'})).toEqualTypeOf<
+    Promise<void>
+  >();
+  expectTypeOf(z.mutate.issues.delete({id: 'test'})).toEqualTypeOf<
+    Promise<void>
+  >();
+});
+
+test('legacy mutators disabled - table mutators do not exist', () => {
+  const schema = createSchema({
+    tables: [
+      table('issues')
+        .columns({
+          id: string(),
+          title: string(),
+        })
+        .primaryKey('id'),
+    ],
+    enableLegacyMutators: false,
+  });
+
+  // Verify runtime value
+  expect(schema.enableLegacyMutators).toBe(false);
+
+  const z = zeroForTest({schema});
+
+  // Type test: DBMutator should be empty when enableLegacyMutators is false
+  type TestDBMutator = DBMutator<typeof schema>;
+  expectTypeOf<TestDBMutator>().toEqualTypeOf<{}>(); // eslint-disable-line @typescript-eslint/ban-types
+
+  // Verify table mutators do not exist when legacy mutators disabled
+  expectTypeOf(z.mutate).toEqualTypeOf<{}>(); // eslint-disable-line @typescript-eslint/ban-types
+
+  // @ts-expect-error - issues table should not exist when legacy mutators disabled
+  z.mutate.issues;
+});
+
+test('legacy mutators undefined - defaults to enabled', () => {
+  const schema = createSchema({
+    tables: [
+      table('issues')
+        .columns({
+          id: string(),
+          title: string(),
+        })
+        .primaryKey('id'),
+    ],
+    // enableLegacyMutators not specified - should default to true
+  });
+
+  const z = zeroForTest({schema});
+
+  // Should have CRUD methods by default
+  expectTypeOf(z.mutate.issues.insert).toBeFunction();
+  expectTypeOf(z.mutate.issues.update).toBeFunction();
+  expectTypeOf(z.mutate.issues.delete).toBeFunction();
+  expectTypeOf(z.mutate.issues.upsert).toBeFunction();
+});
+
+test('CRUD and custom mutators work together with enableLegacyMutators: true', async () => {
+  const schema = createSchema({
+    tables: [
+      table('issues')
+        .columns({
+          id: string(),
+          title: string(),
+          status: string(),
+        })
+        .primaryKey('id'),
+    ],
+    enableLegacyMutators: true,
+  });
+
+  const z = zeroForTest({
+    schema,
+    mutators: {
+      issue: {
+        // Custom mutator that uses CRUD internally
+        closeIssue: async (
+          tx: Transaction<typeof schema>,
+          {id}: {id: string},
+        ) => {
+          // eslint-disable-line @typescript-eslint/no-explicit-any
+          await tx.mutate.issues.update({id, status: 'closed'});
+        },
+        // Another custom mutator
+        createAndClose: async (
+          tx: any, // eslint-disable-line @typescript-eslint/no-explicit-any
+          {id, title}: {id: string; title: string},
+        ) => {
+          await tx.mutate.issues.insert({id, title, status: 'open'});
+          await tx.mutate.issues.update({id, status: 'closed'});
+        },
+      },
+    },
+  });
+
+  // Type-level: Verify both CRUD and custom mutators are available
+  expectTypeOf(z.mutate.issues.insert).toBeFunction();
+  expectTypeOf(z.mutate.issues.update).toBeFunction();
+  expectTypeOf(z.mutate.issues.delete).toBeFunction();
+  expectTypeOf(z.mutate.issue.closeIssue).toBeFunction();
+  expectTypeOf(z.mutate.issue.createAndClose).toBeFunction();
+
+  // Runtime: Verify both work
+  await z.mutate.issues.insert({id: '1', title: 'Test Issue', status: 'open'});
+  await z.mutate.issue.closeIssue({id: '1'});
+
+  const issues = await z.query.issues.where('id', '1').one();
+  expect(issues?.status).toBe('closed');
+});
+
+test('Custom mutators still work when enableLegacyMutators: false', async () => {
+  const schema = createSchema({
+    tables: [
+      table('issues')
+        .columns({
+          id: string(),
+          title: string(),
+          status: string(),
+        })
+        .primaryKey('id'),
+    ],
+    enableLegacyMutators: false,
+  });
+
+  const z = zeroForTest({
+    schema,
+    mutators: {
+      issue: {
+        // Custom mutator that doesn't rely on CRUD
+        customCreate: (
+          _tx: Transaction<typeof schema>,
+          {id, title}: {id: string; title: string},
+        ) => {
+          // eslint-disable-line @typescript-eslint/no-explicit-any
+          // In real usage, this would use server-side implementation
+          void id;
+          void title;
+          return Promise.resolve();
+        },
+      },
+    },
+  });
+
+  // Type-level: Verify table mutators are NOT available but custom mutators ARE
+  // @ts-expect-error - issues table should not exist when legacy mutators disabled
+  z.mutate.issues;
+  expectTypeOf(z.mutate.issue.customCreate).toBeFunction();
+
+  // Runtime: Verify custom mutator can be called
+  await z.mutate.issue.customCreate({id: '1', title: 'Test'});
 });

--- a/packages/zero-schema/src/builder/schema-builder.ts
+++ b/packages/zero-schema/src/builder/schema-builder.ts
@@ -16,6 +16,22 @@ import {type TableBuilderWithColumns} from './table-builder.ts';
 export type Schema = {
   readonly tables: {readonly [table: string]: TableSchema};
   readonly relationships: {readonly [table: string]: RelationshipsSchema};
+  /**
+   * Enables legacy query support.
+   * When this is true, old-style queries that do not require server side implementations will be enabled.
+   * This will flip to false in the future and what we currently call "custom queries" will become "queries" and
+   * the only option for reading data.
+   * The default is true, but will flip to false in the future.
+   */
+  readonly enableLegacyQueries?: boolean | undefined;
+  /**
+   * Enables legacy mutator support.
+   * When this is true, old-style mutations that do not require server side implementations will be enabled.
+   * This will flip to false in the future and what we currently call "custom mutations" will become "mutations" and
+   * the only option for writing data.
+   * The default is true, but will flip to false in the future.
+   */
+  readonly enableLegacyMutators?: boolean | undefined;
 };
 
 /**
@@ -29,9 +45,15 @@ export type Schema = {
 export function createSchema<
   const TTables extends readonly TableBuilderWithColumns<TableSchema>[],
   const TRelationships extends readonly Relationships[],
+  const TEnableLegacyQueries extends boolean | undefined,
+  const TEnableLegacyMutators extends boolean | undefined,
 >(options: {
   readonly tables: TTables;
   readonly relationships?: TRelationships | undefined;
+  /** @see Schema.enableLegacyQueries */
+  readonly enableLegacyQueries?: TEnableLegacyQueries | undefined;
+  /** @see Schema.enableLegacyMutators */
+  readonly enableLegacyMutators?: TEnableLegacyMutators | undefined;
 }): {
   tables: {
     readonly [K in TTables[number]['schema']['name']]: Extract<
@@ -45,6 +67,8 @@ export function createSchema<
       {name: K}
     >['relationships'];
   };
+  enableLegacyQueries: TEnableLegacyQueries;
+  enableLegacyMutators: TEnableLegacyMutators;
 } {
   const retTables: Record<string, TableSchema> = {};
   const retRelationships: Record<string, Record<string, Relationship>> = {};
@@ -80,6 +104,8 @@ export function createSchema<
   return {
     tables: retTables,
     relationships: retRelationships,
+    enableLegacyQueries: options.enableLegacyQueries,
+    enableLegacyMutators: options.enableLegacyMutators,
   } as any;
 }
 

--- a/packages/zero-schema/src/schema-config.ts
+++ b/packages/zero-schema/src/schema-config.ts
@@ -42,6 +42,8 @@ export const tableSchemaSchema: v.Type<TableSchema> = v.readonlyObject({
 export const schemaSchema = v.readonlyObject({
   tables: v.record(tableSchemaSchema),
   relationships: v.record(v.record(relationshipSchema)),
+  enableLegacyQueries: v.boolean().optional(),
+  enableLegacyMutators: v.boolean().optional(),
 });
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
We recently added `enableLegacyMutators` and `enableLegacyQueries`. They disable the relevant features at runtime. But they don't affect the mutators types.

This changes how they are implemented to disable the types too.

I considered putting `enableLegacyMutators` in mutators.ts, which at first seems reasonable, but alas all fields of the mutators object are reflected into namespaces in the API so there's no place for us to put it. This seems fine, anyway this flag is not long for the world.