### PR TITLE
chore: Bencher perf boundaries

### DIFF
--- a/.github/workflows/bencher-benchmarks-pr.yml
+++ b/.github/workflows/bencher-benchmarks-pr.yml
@@ -123,6 +123,6 @@ jobs:
           --start-point-reset \
           --threshold-measure throughput \
           --threshold-test t_test \
-          --threshold-lower-boundary 0.70 \
+          --threshold-lower-boundary 0.9 \
           --threshold-max-sample-size 10 \
           --err

--- a/.github/workflows/bencher-benchmarks.yml
+++ b/.github/workflows/bencher-benchmarks.yml
@@ -89,6 +89,6 @@ jobs:
           --start-point main \
           --threshold-measure throughput \
           --threshold-test t_test \
-          --threshold-lower-boundary 0.70 \
+          --threshold-lower-boundary 0.9 \
           --threshold-max-sample-size 10 \
           --err


### PR DESCRIPTION
I misunderstood. Closer to 1 allows more noise