### PR TITLE
feat(replicache): Export sqlite kv store symbols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,7 @@ Chinook_PostgreSql.sql
 WARP.md
 *.db-shm
 *.db-wal
+
+# We output files outside of out to make old React Native / Metro happy
+packages/replicache/expo
+packages/replicache/sqlite

--- a/packages/replicache/package.json
+++ b/packages/replicache/package.json
@@ -77,11 +77,17 @@
     },
     "./expo": {
       "types": "./out/replicache/src/expo.d.ts",
-      "default": "./out/expo.js"
+      "default": "./expo/index.js"
+    },
+    "./sqlite": {
+      "types": "./out/replicache/src/sqlite.d.ts",
+      "default": "./sqlite/index.js"
     }
   },
   "files": [
     "out",
+    "expo",
+    "sqlite",
     "!*.tsbuildinfo"
   ],
   "eslintConfig": {

--- a/packages/replicache/src/kv/sqlite-store.ts
+++ b/packages/replicache/src/kv/sqlite-store.ts
@@ -289,7 +289,7 @@ class SQLiteStoreRWBase {
   }
 }
 
-export class SQLiteStoreRead extends SQLiteStoreRWBase implements Read {
+class SQLiteStoreRead extends SQLiteStoreRWBase implements Read {
   constructor(
     preparedStatements: SQLitePreparedStatements,
     release: () => void,
@@ -308,7 +308,7 @@ export class SQLiteStoreRead extends SQLiteStoreRWBase implements Read {
   }
 }
 
-export class SQLiteStoreWrite extends SQLiteStoreRWBase implements Write {
+class SQLiteStoreWrite extends SQLiteStoreRWBase implements Write {
   #committed = false;
 
   constructor(

--- a/packages/replicache/src/sqlite.ts
+++ b/packages/replicache/src/sqlite.ts
@@ -1,0 +1,16 @@
+export {
+  SQLiteDatabaseManager,
+  SQLiteStore,
+  type GenericSQLiteDatabaseManager,
+  type PreparedStatement,
+  type SQLiteDatabase,
+  type SQLiteDatabaseManagerOptions,
+} from './kv/sqlite-store.ts';
+export type {
+  CreateStore as CreateKVStore,
+  DropStore as DropKVStore,
+  Read as KVRead,
+  Store as KVStore,
+  StoreProvider as KVStoreProvider,
+  Write as KVWrite,
+} from './kv/store.ts';

--- a/packages/replicache/tool/build.ts
+++ b/packages/replicache/tool/build.ts
@@ -30,12 +30,13 @@ async function buildReplicache(options: BuildOptions) {
   const {ext, mode, external, ...restOfOptions} = options;
   const outfile = basePath('out', 'replicache.' + ext);
   const entryPoints = {
-    replicache: basePath('src', 'mod.ts'),
+    'out/replicache': basePath('src', 'mod.ts'),
     ...(forBundleSizeDashboard
       ? {}
       : {
-          impl: basePath('src', 'impl.ts'),
-          expo: basePath('src', 'expo.ts'),
+          'out/impl': basePath('src', 'impl.ts'),
+          'expo/index': basePath('src', 'expo.ts'),
+          'sqlite/index': basePath('src', 'sqlite.ts'),
         }),
   };
   const result = await esbuild.build({
@@ -48,9 +49,10 @@ async function buildReplicache(options: BuildOptions) {
     // Use neutral to remove the automatic define for process.env.NODE_ENV
     platform: 'neutral',
     define,
-    outdir: basePath('out'),
+    outdir: basePath('.'),
     entryPoints,
     outExtension: {'.js': `.${ext}`},
+    chunkNames: 'out/chunks/[hash]',
   });
   if (metafile) {
     await writeFile(outfile + '.meta.json', JSON.stringify(result.metafile));

--- a/packages/replicache/tsconfig.build.json
+++ b/packages/replicache/tsconfig.build.json
@@ -5,5 +5,5 @@
     "emitDeclarationOnly": true,
     "outDir": "out"
   },
-  "include": ["src/mod.ts", "src/impl.ts", "src/expo.ts"]
+  "include": ["src/mod.ts", "src/impl.ts", "src/expo.ts", "src/sqlite.ts"]
 }


### PR DESCRIPTION
This allows creating a KV Store provider for different SQLite implementations. For example using `op-sqlite` in React Native.:

```ts
import { open, type Scalar } from "@op-engineering/op-sqlite";
import {
  SQLiteDatabaseManager,
  SQLiteStore,
  type KVStore,
  type KVStoreProvider,
} from "replicache/sqlite";

const dbManager = new SQLiteDatabaseManager({
  open(fileName: string) {
    const database = open({ name: fileName });
    return {
      close() {
        database.close();
      },
      destroy() {
        database.delete();
      },
      prepare(sql: string) {
        // OP-SQLite does not support sync execute on prepared statements.

        return {
          run(...params: unknown[]) {
            database.executeSync(sql, params as Scalar[]);
          },
          all<T>(...params: unknown[]): T[] {
            const result = database.executeSync(sql, params as Scalar[]);
            return result.rows as T[];
          },
          finalize() {},
        };
      },
    };
  },
});

export const provider: KVStoreProvider = {
  create(name): KVStore {
    return new SQLiteStore(name, dbManager, {
      readPoolSize: 2,
      busyTimeout: 5000,
      journalMode: "WAL",
      synchronous: "NORMAL",
    });
  },
  async drop(name): Promise<void> {
    dbManager.destroy(name);
  },
};
```