### PR TITLE
fix(expo-sqlite): do not close a db we're trying to open

### DIFF
--- a/packages/replicache/src/expo/store.ts
+++ b/packages/replicache/src/expo/store.ts
@@ -4,65 +4,68 @@ import {
   type SQLiteBindParams,
 } from 'expo-sqlite';
 import {
+  safeFilename,
   SQLiteDatabaseManager,
   SQLiteStore,
   type SQLiteDatabaseManagerOptions,
 } from '../kv/sqlite-store.ts';
 import type {StoreProvider} from '../kv/store.ts';
 
-export const expoDbManagerInstance = new SQLiteDatabaseManager({
-  open: fileName => {
-    const db = openDatabaseSync(fileName);
-    let closed = false;
-
-    const close = () => {
-      if (!closed) {
-        db.closeSync();
-        closed = true;
-      }
-    };
-
-    return {
-      close,
-      destroy() {
-        close();
-        deleteDatabaseSync(fileName);
-      },
-      prepare(sql: string) {
-        const stmt = db.prepareSync(sql);
-        return {
-          run: (...params: unknown[]): void => {
-            stmt.executeSync(params as SQLiteBindParams);
-          },
-          all: <T>(...params: unknown[]): T[] => {
-            const result = stmt.executeSync(params as SQLiteBindParams);
-            return result.getAllSync() as unknown as T[];
-          },
-          finalize: () => stmt.finalizeSync(),
-        };
-      },
-    };
-  },
-});
-
 export function expoSQLiteStoreProvider(
-  opts?: Partial<Omit<SQLiteDatabaseManagerOptions, 'journalMode'>>,
+  opts?: Partial<SQLiteDatabaseManagerOptions>,
 ): StoreProvider {
   return {
-    create: (name: string) =>
-      new SQLiteStore(name, expoDbManagerInstance, {
+    create: (name: string) => {
+      const expoDbManagerInstance = new SQLiteDatabaseManager({
+        open: fileName => {
+          const db = openDatabaseSync(fileName);
+          let closed = false;
+
+          const close = () => {
+            if (!closed) {
+              db.closeSync();
+              closed = true;
+            }
+          };
+
+          return {
+            close,
+            destroy() {
+              close();
+              deleteDatabaseSync(fileName);
+            },
+            prepare(sql: string) {
+              const stmt = db.prepareSync(sql);
+              return {
+                run: (...params: unknown[]): void => {
+                  stmt.executeSync(params as SQLiteBindParams);
+                },
+                all: <T>(...params: unknown[]): T[] => {
+                  const result = stmt.executeSync(params as SQLiteBindParams);
+                  return result.getAllSync() as unknown as T[];
+                },
+                finalize: () => stmt.finalizeSync(),
+              };
+            },
+          };
+        },
+      });
+
+      return new SQLiteStore(name, expoDbManagerInstance, {
         // we default to 3 read connections for mobile devices
         readPoolSize: 3,
         busyTimeout: 200,
         synchronous: 'NORMAL',
         readUncommitted: false,
+        journalMode: 'WAL',
         ...opts,
-        // we override the journal mode to undefined because
-        // setting it to WAL causes hanging COMMITs on Expo
-        journalMode: undefined,
-      }),
+      });
+    },
+
     drop: (name: string) => {
-      expoDbManagerInstance.destroy(name);
+      // Note that we cannot drop a database if it is open.
+      // All connections must be closed before calling drop.
+      deleteDatabaseSync(safeFilename(name));
 
       return Promise.resolve();
     },

--- a/packages/replicache/src/kv/sqlite-store.ts
+++ b/packages/replicache/src/kv/sqlite-store.ts
@@ -354,7 +354,7 @@ export interface GenericSQLiteDatabaseManager {
 
 // we replace non-alphanumeric characters with underscores
 // because SQLite doesn't allow them in database names
-function safeFilename(name: string) {
+export function safeFilename(name: string) {
   return name.replace(/[^a-zA-Z0-9]/g, '_');
 }
 


### PR DESCRIPTION
The `SQLiteDatabaseManager` has a map of instances that it keys by database name. When someone tells the SQLiteDBManager to close a db by name, it looks up all connections that exist for that DB and closes them.

This was a problem when one Zero instance was being destroyed and another was being created. Both instances use the `replicache_dbs_v0` database so we could get into cases where a closing Zero would nuke the connections of an opening Zero. 

**Example:**

Zero Instance 1 would be closing.
Zero Instance 2 would be opening.

(note: zero.close is async but it is not / can not be awaited in useEffect in ZeroProvider)

The `replicache_dbs_v0` would be opened by Zero Instance 2. The close from Zero Instance 1 would come in.
The SQLiteDBManager would close all connections associated with `replicache_dbs_v0` which included Zero Instance 2's connections.

We would then fail when making any call to SQLite on that connection.

```
🟠 FunctionCallException: Calling the 'runSync' function has failed (at ExpoModulesCore/SyncFunctionDefinition.swift:137)
🟠 → Caused by: AccessClosedResourceException: Access to closed resource (at ExpoSQLite/SQLiteModule.swift:625)
```

This error does not show in the Expo logs but does show when:

a. running the app in xcode or
b. opening `Console.app` and selecting your simulator

<img width="1800" height="379" alt="CleanShot 2025-09-03 at 13 07 11" src="https://github.com/user-attachments/assets/94efd973-63da-490b-a209-6b883b4e22f2" />


---

The fix is to not have a single `SQLiteDBManager` but to create one for each Store. When the store is closed it then only closes its own connections to SQLite rather than the connections of other stores.

I tested this using the zslack app. Previously, after logging in w/ WAL mode and restarting the app, my channel list would be empty. Now it all works fine.

<img width="452" height="415" alt="CleanShot 2025-09-03 at 13 09 15" src="https://github.com/user-attachments/assets/af9c4aee-011a-4d7b-bf65-851498800ff0" />

<img width="459" height="954" alt="CleanShot 2025-09-03 at 13 09 26" src="https://github.com/user-attachments/assets/9ee51768-5977-4b70-8636-1fdbf3c923cc" />



https://rocicorp.slack.com/archives/C013XFG80JC/p1756914030938379