### PR TITLE
fix(zero-cache): include and validate the client's primaryKey

### DIFF
--- a/packages/zero-cache/src/db/lite-tables.test.ts
+++ b/packages/zero-cache/src/db/lite-tables.test.ts
@@ -334,6 +334,11 @@ describe('computeZqlSpec', () => {
       [
         {
           "tableSpec": {
+            "allKeys": [
+              [
+                "b",
+              ],
+            ],
             "columns": {
               "a": {
                 "characterMaximumLength": null,
@@ -405,6 +410,11 @@ describe('computeZqlSpec', () => {
       [
         {
           "tableSpec": {
+            "allKeys": [
+              [
+                "b",
+              ],
+            ],
             "columns": {
               "a": {
                 "characterMaximumLength": null,
@@ -455,6 +465,13 @@ describe('computeZqlSpec', () => {
       [
         {
           "tableSpec": {
+            "allKeys": [
+              [
+                "a",
+                "b",
+                "d",
+              ],
+            ],
             "columns": {
               "a": {
                 "characterMaximumLength": null,
@@ -520,6 +537,13 @@ describe('computeZqlSpec', () => {
       [
         {
           "tableSpec": {
+            "allKeys": [
+              [
+                "a",
+                "b",
+                "d",
+              ],
+            ],
             "columns": {
               "a": {
                 "characterMaximumLength": null,
@@ -595,6 +619,13 @@ describe('computeZqlSpec', () => {
       [
         {
           "tableSpec": {
+            "allKeys": [
+              [
+                "a",
+                "c",
+                "d",
+              ],
+            ],
             "columns": {
               "a": {
                 "characterMaximumLength": null,
@@ -671,6 +702,15 @@ describe('computeZqlSpec', () => {
       [
         {
           "tableSpec": {
+            "allKeys": [
+              [
+                "b",
+              ],
+              [
+                "a",
+                "c",
+              ],
+            ],
             "columns": {
               "a": {
                 "characterMaximumLength": null,
@@ -745,6 +785,15 @@ describe('computeZqlSpec', () => {
       [
         {
           "tableSpec": {
+            "allKeys": [
+              [
+                "c",
+              ],
+              [
+                "b",
+                "d",
+              ],
+            ],
             "columns": {
               "a": {
                 "characterMaximumLength": null,
@@ -826,6 +875,17 @@ describe('computeZqlSpec', () => {
       [
         {
           "tableSpec": {
+            "allKeys": [
+              [
+                "id",
+              ],
+              [
+                "name",
+              ],
+              [
+                "order",
+              ],
+            ],
             "columns": {
               "createdAt": {
                 "characterMaximumLength": null,

--- a/packages/zero-cache/src/db/lite-tables.ts
+++ b/packages/zero-cache/src/db/lite-tables.ts
@@ -216,6 +216,7 @@ export function computeZqlSpecs(
       // See row-key.ts: normalizedKeyOrder()
       primaryKey: v.parse(primaryKey.sort(), primaryKeySchema),
       unionKey: v.parse(unionKey.sort(), primaryKeySchema),
+      allKeys: keys.map(key => v.parse(key.sort(), primaryKeySchema)),
     };
 
     tableSpecs.set(tableSpec.name, {

--- a/packages/zero-cache/src/db/specs.ts
+++ b/packages/zero-cache/src/db/specs.ts
@@ -78,6 +78,12 @@ export type LiteTableSpecWithKeys = Omit<LiteTableSpec, 'primaryKey'> & {
    * can serve as a key.
    */
   unionKey: PrimaryKey;
+
+  /**
+   * All keys associated with a unique index over non-null
+   * columns, i.e. suitable as a primary key.
+   */
+  allKeys: PrimaryKey[];
 };
 
 export type LiteAndZqlSpec = {

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -735,6 +735,9 @@ describe('initConnection', () => {
                         "type": "string",
                       },
                     },
+                    "primaryKey": [
+                      "id",
+                    ],
                   },
                 },
               },
@@ -770,32 +773,35 @@ describe('initConnection', () => {
     mockSocket.onUpstream(msg => {
       expect(valita.parse(JSON.parse(msg), initConnectionMessageSchema))
         .toMatchInlineSnapshot(`
-          [
-            "initConnection",
-            {
-              "clientSchema": {
-                "tables": {
-                  "def": {
-                    "columns": {
-                      "id": {
-                        "type": "string",
-                      },
-                      "value": {
-                        "type": "string",
-                      },
-                    },
+      [
+        "initConnection",
+        {
+          "clientSchema": {
+            "tables": {
+              "def": {
+                "columns": {
+                  "id": {
+                    "type": "string",
+                  },
+                  "value": {
+                    "type": "string",
                   },
                 },
-              },
-              "deleted": {
-                "clientIDs": [
-                  "a",
+                "primaryKey": [
+                  "id",
                 ],
               },
-              "desiredQueriesPatch": [],
             },
-          ]
-        `);
+          },
+          "deleted": {
+            "clientIDs": [
+              "a",
+            ],
+          },
+          "desiredQueriesPatch": [],
+        },
+      ]
+    `);
       expect(r.connectionState).toEqual(ConnectionState.Connecting);
     });
 
@@ -824,32 +830,35 @@ describe('initConnection', () => {
     mockSocket.onUpstream(msg => {
       expect(valita.parse(JSON.parse(msg), initConnectionMessageSchema))
         .toMatchInlineSnapshot(`
-          [
-            "initConnection",
-            {
-              "clientSchema": {
-                "tables": {
-                  "ijk": {
-                    "columns": {
-                      "id": {
-                        "type": "string",
-                      },
-                      "value": {
-                        "type": "string",
-                      },
+        [
+          "initConnection",
+          {
+            "clientSchema": {
+              "tables": {
+                "ijk": {
+                  "columns": {
+                    "id": {
+                      "type": "string",
+                    },
+                    "value": {
+                      "type": "string",
                     },
                   },
+                  "primaryKey": [
+                    "id",
+                  ],
                 },
               },
-              "deleted": {
-                "clientGroupIDs": [
-                  "a",
-                ],
-              },
-              "desiredQueriesPatch": [],
             },
-          ]
-        `);
+            "deleted": {
+              "clientGroupIDs": [
+                "a",
+              ],
+            },
+            "desiredQueriesPatch": [],
+          },
+        ]
+      `);
       expect(r.connectionState).toEqual(ConnectionState.Connecting);
     });
 
@@ -897,6 +906,7 @@ describe('initConnection', () => {
                   type: 'string',
                 },
               },
+              primaryKey: ['id'],
             },
           },
         },
@@ -988,6 +998,7 @@ describe('initConnection', () => {
                   type: 'string',
                 },
               },
+              primaryKey: ['id'],
             },
           },
         },
@@ -1033,42 +1044,45 @@ describe('initConnection', () => {
     mockSocket.onUpstream(msg => {
       expect(valita.parse(JSON.parse(msg), initConnectionMessageSchema))
         .toMatchInlineSnapshot(`
-          [
-            "initConnection",
-            {
-              "clientSchema": {
-                "tables": {
-                  "e": {
-                    "columns": {
-                      "id": {
-                        "type": "string",
-                      },
-                      "value": {
-                        "type": "string",
+              [
+                "initConnection",
+                {
+                  "clientSchema": {
+                    "tables": {
+                      "e": {
+                        "columns": {
+                          "id": {
+                            "type": "string",
+                          },
+                          "value": {
+                            "type": "string",
+                          },
+                        },
+                        "primaryKey": [
+                          "id",
+                        ],
                       },
                     },
                   },
+                  "desiredQueriesPatch": [
+                    {
+                      "ast": {
+                        "orderBy": [
+                          [
+                            "id",
+                            "asc",
+                          ],
+                        ],
+                        "table": "e",
+                      },
+                      "hash": "29j3x0l4bxthp",
+                      "op": "put",
+                      "ttl": 300000,
+                    },
+                  ],
                 },
-              },
-              "desiredQueriesPatch": [
-                {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
-                      ],
-                    ],
-                    "table": "e",
-                  },
-                  "hash": "29j3x0l4bxthp",
-                  "op": "put",
-                  "ttl": 300000,
-                },
-              ],
-            },
-          ]
-        `);
+              ]
+            `);
 
       expect(r.connectionState).toEqual(ConnectionState.Connecting);
     });
@@ -1102,47 +1116,50 @@ describe('initConnection', () => {
     mockSocket.onUpstream(msg => {
       expect(valita.parse(JSON.parse(msg), initConnectionMessageSchema))
         .toMatchInlineSnapshot(`
-          [
-            "initConnection",
-            {
-              "clientSchema": {
-                "tables": {
-                  "e": {
-                    "columns": {
-                      "id": {
-                        "type": "string",
-                      },
-                      "value": {
-                        "type": "string",
+                [
+                  "initConnection",
+                  {
+                    "clientSchema": {
+                      "tables": {
+                        "e": {
+                          "columns": {
+                            "id": {
+                              "type": "string",
+                            },
+                            "value": {
+                              "type": "string",
+                            },
+                          },
+                          "primaryKey": [
+                            "id",
+                          ],
+                        },
                       },
                     },
-                  },
-                },
-              },
-              "deleted": {
-                "clientIDs": [
-                  "a",
-                ],
-              },
-              "desiredQueriesPatch": [
-                {
-                  "ast": {
-                    "orderBy": [
-                      [
-                        "id",
-                        "asc",
+                    "deleted": {
+                      "clientIDs": [
+                        "a",
                       ],
+                    },
+                    "desiredQueriesPatch": [
+                      {
+                        "ast": {
+                          "orderBy": [
+                            [
+                              "id",
+                              "asc",
+                            ],
+                          ],
+                          "table": "e",
+                        },
+                        "hash": "29j3x0l4bxthp",
+                        "op": "put",
+                        "ttl": 300000,
+                      },
                     ],
-                    "table": "e",
                   },
-                  "hash": "29j3x0l4bxthp",
-                  "op": "put",
-                  "ttl": 300000,
-                },
-              ],
-            },
-          ]
-        `);
+                ]
+              `);
 
       expect(r.connectionState).toEqual(ConnectionState.Connecting);
     });
@@ -1208,6 +1225,7 @@ describe('initConnection', () => {
                 id: {type: 'string'},
                 value: {type: 'string'},
               },
+              primaryKey: ['id'],
             },
           },
         },

--- a/packages/zero-protocol/src/ast.test.ts
+++ b/packages/zero-protocol/src/ast.test.ts
@@ -607,5 +607,5 @@ test('protocol version', () => {
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
   expect(hash).toEqual('1c228prd1v53r');
-  expect(PROTOCOL_VERSION).toEqual(29);
+  expect(PROTOCOL_VERSION).toEqual(30);
 });

--- a/packages/zero-protocol/src/client-schema.test.ts
+++ b/packages/zero-protocol/src/client-schema.test.ts
@@ -12,6 +12,7 @@ test('normalize', () => {
           z: {type: 'number'},
           y: {type: 'string'},
         },
+        primaryKey: ['z', 'y'],
       },
       d: {
         columns: {
@@ -19,6 +20,7 @@ test('normalize', () => {
           a: {type: 'null'},
           b: {type: 'json'},
         },
+        primaryKey: ['b'],
       },
       g: {
         columns: {
@@ -26,6 +28,7 @@ test('normalize', () => {
           k: {type: 'string'},
           j: {type: 'json'},
         },
+        primaryKey: ['k', 'i'],
       },
     },
   };
@@ -41,7 +44,11 @@ test('normalize', () => {
             "z": {
               "type": "number"
             }
-          }
+          },
+          "primaryKey": [
+            "y",
+            "z"
+          ]
         },
         "d": {
           "columns": {
@@ -54,7 +61,10 @@ test('normalize', () => {
             "v": {
               "type": "null"
             }
-          }
+          },
+          "primaryKey": [
+            "b"
+          ]
         },
         "g": {
           "columns": {
@@ -67,7 +77,11 @@ test('normalize', () => {
             "k": {
               "type": "string"
             }
-          }
+          },
+          "primaryKey": [
+            "i",
+            "k"
+          ]
         }
       }
     }"

--- a/packages/zero-protocol/src/protocol-version.test.ts
+++ b/packages/zero-protocol/src/protocol-version.test.ts
@@ -11,6 +11,6 @@ test('protocol version', () => {
   // If this test fails upstream or downstream schema has changed such that
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
-  expect(hash).toEqual('1pmjffpekmm4w');
-  expect(PROTOCOL_VERSION).toEqual(29);
+  expect(hash).toEqual('by6x3866cbh9');
+  expect(PROTOCOL_VERSION).toEqual(30);
 });

--- a/packages/zero-protocol/src/protocol-version.ts
+++ b/packages/zero-protocol/src/protocol-version.ts
@@ -35,7 +35,8 @@ import {assert} from '../../shared/src/asserts.ts';
 // -- version 27 adds inspect/version (0.23)
 // -- version 28 adds more inspect/metrics (0.23)
 // -- version 29 adds error responses for custom queries (0.23)
-export const PROTOCOL_VERSION = 29;
+// -- version 30 adds an optional primaryKey to the ClientSchema (0.24)
+export const PROTOCOL_VERSION = 30;
 
 /**
  * The minimum server-supported sync protocol version (i.e. the version

--- a/packages/zero-schema/src/builder/schema-builder.test.ts
+++ b/packages/zero-schema/src/builder/schema-builder.test.ts
@@ -619,7 +619,10 @@ test('clientSchemaFrom', () => {
               "the_issue_id": {
                 "type": "string"
               }
-            }
+            },
+            "primaryKey": [
+              "id"
+            ]
           },
           "issues": {
             "columns": {
@@ -638,7 +641,10 @@ test('clientSchemaFrom', () => {
               "title": {
                 "type": "string"
               }
-            }
+            },
+            "primaryKey": [
+              "id"
+            ]
           },
           "noMappings": {
             "columns": {
@@ -648,11 +654,14 @@ test('clientSchemaFrom', () => {
               "id": {
                 "type": "string"
               }
-            }
+            },
+            "primaryKey": [
+              "id"
+            ]
           }
         }
       },
-      "hash": "qw9u2r398f0z"
+      "hash": "3kmklq8wg87j5"
     }"
   `);
 });
@@ -698,11 +707,14 @@ test('array column', () => {
               "stringArray": {
                 "type": "json"
               }
-            }
+            },
+            "primaryKey": [
+              "id"
+            ]
           }
         }
       },
-      "hash": "qeez7tx1u29h"
+      "hash": "39k26n5eek28e"
     }"
   `);
 });

--- a/packages/zero-schema/src/builder/schema-builder.ts
+++ b/packages/zero-schema/src/builder/schema-builder.ts
@@ -143,16 +143,20 @@ export function clientSchemaFrom(schema: Schema): {
   hash: string;
 } {
   const client = {
-    tables: mapEntries(schema.tables, (name, {serverName, columns}) => [
-      serverName ?? name,
-      {
-        columns: mapEntries(columns, (name, {serverName, type}) => [
-          serverName ?? name,
-          {type},
-        ]),
-      },
-    ]),
-  };
+    tables: mapEntries(
+      schema.tables,
+      (name, {serverName, columns, primaryKey}) => [
+        serverName ?? name,
+        {
+          columns: mapEntries(columns, (name, {serverName, type}) => [
+            serverName ?? name,
+            {type},
+          ]),
+          primaryKey: [...primaryKey],
+        },
+      ],
+    ),
+  } satisfies ClientSchema;
   const clientSchema = normalizeClientSchema(client);
   const hash = h64(JSON.stringify(clientSchema)).toString(36);
   return {clientSchema, hash};


### PR DESCRIPTION
Include the `primaryKey` from the client's schema in the `ClientSchema` message validated by the zero-cache (and used as part of the IDB hash).

The zero-cache will validate that the `primaryKey` corresponds to an upstream index over non-null columns (order agnostic).

Note that in order to be backwards compatible with old client versions, the `primaryKey` field is optional, and can be made non-optional when bumping the min-supported protocol version to 30+