### PR TITLE
feat(zero): Allow customization of mutate and get-queries URLs on the client

### DIFF
--- a/packages/zero-cache/src/custom-queries/transform-query.test.ts
+++ b/packages/zero-cache/src/custom-queries/transform-query.test.ts
@@ -7,6 +7,7 @@ import {
   type MockedFunction,
   test,
 } from 'vitest';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
 import {CustomQueryTransformer} from './transform-query.ts';
 import {fetchFromAPIServer} from '../custom/fetch.ts';
 import type {CustomQueryRecord} from '../services/view-syncer/schema/types.ts';
@@ -28,6 +29,7 @@ describe('CustomQueryTransformer', () => {
     appID: 'test_app',
     shardNum: 1,
   };
+  const lc = createSilentLogContext();
 
   const pullUrl = 'https://api.example.com/pull';
   const headerOptions = {
@@ -132,6 +134,7 @@ describe('CustomQueryTransformer', () => {
     mockFetchFromAPIServer.mockResolvedValue(mockSuccessResponse);
 
     const transformer = new CustomQueryTransformer(
+      lc,
       {
         url: [pullUrl],
         forwardCookies: false,
@@ -146,6 +149,7 @@ describe('CustomQueryTransformer', () => {
 
     // Verify the API was called correctly
     expect(mockFetchFromAPIServer).toHaveBeenCalledWith(
+      lc,
       pullUrl,
       [pullUrl],
       mockShard,
@@ -184,6 +188,7 @@ describe('CustomQueryTransformer', () => {
     mockFetchFromAPIServer.mockResolvedValue(mockMixedResponse);
 
     const transformer = new CustomQueryTransformer(
+      lc,
       {
         url: [pullUrl],
         forwardCookies: false,
@@ -218,6 +223,7 @@ describe('CustomQueryTransformer', () => {
     mockFetchFromAPIServer.mockResolvedValue(mockErrorResponse);
 
     const transformer = new CustomQueryTransformer(
+      lc,
       {
         url: [pullUrl],
         forwardCookies: false,
@@ -257,6 +263,7 @@ describe('CustomQueryTransformer', () => {
     mockFetchFromAPIServer.mockResolvedValue(mockSuccessResponse);
 
     const transformer = new CustomQueryTransformer(
+      lc,
       {
         url: [pullUrl],
         forwardCookies: false,
@@ -282,6 +289,7 @@ describe('CustomQueryTransformer', () => {
     mockFetchFromAPIServer.mockResolvedValue(mockSuccessResponse());
 
     const transformer = new CustomQueryTransformer(
+      lc,
       {
         url: [pullUrl],
         forwardCookies: false,
@@ -317,6 +325,7 @@ describe('CustomQueryTransformer', () => {
     mockFetchFromAPIServer.mockResolvedValue(mockSuccessResponse());
 
     const transformer = new CustomQueryTransformer(
+      lc,
       {
         url: [pullUrl],
         forwardCookies: false,
@@ -364,6 +373,7 @@ describe('CustomQueryTransformer', () => {
       .mockResolvedValueOnce(mockResponse2());
 
     const transformer = new CustomQueryTransformer(
+      lc,
       {
         url: [pullUrl],
         forwardCookies: false,
@@ -375,6 +385,7 @@ describe('CustomQueryTransformer', () => {
     await transformer.transform(headerOptions, [mockQueries[0]], undefined);
     expect(mockFetchFromAPIServer).toHaveBeenCalledTimes(1);
     expect(mockFetchFromAPIServer).toHaveBeenLastCalledWith(
+      lc,
       'https://api.example.com/pull',
       ['https://api.example.com/pull'],
       mockShard,
@@ -391,6 +402,7 @@ describe('CustomQueryTransformer', () => {
     );
     expect(mockFetchFromAPIServer).toHaveBeenCalledTimes(2);
     expect(mockFetchFromAPIServer).toHaveBeenLastCalledWith(
+      lc,
       pullUrl,
       [pullUrl],
       mockShard,
@@ -420,6 +432,7 @@ describe('CustomQueryTransformer', () => {
     mockFetchFromAPIServer.mockResolvedValue(mockSuccessResponse());
 
     const transformer = new CustomQueryTransformer(
+      lc,
       {
         url: [pullUrl],
         forwardCookies: false,
@@ -435,6 +448,7 @@ describe('CustomQueryTransformer', () => {
     );
 
     expect(mockFetchFromAPIServer).toHaveBeenCalledWith(
+      lc,
       pullUrl,
       [pullUrl],
       mockShard,
@@ -459,6 +473,7 @@ describe('CustomQueryTransformer', () => {
     mockFetchFromAPIServer.mockResolvedValue(mockSuccessResponse());
 
     const transformer = new CustomQueryTransformer(
+      lc,
       {
         url: [pullUrl],
         forwardCookies: true,
@@ -474,6 +489,7 @@ describe('CustomQueryTransformer', () => {
     );
 
     expect(mockFetchFromAPIServer).toHaveBeenCalledWith(
+      lc,
       pullUrl,
       [pullUrl],
       mockShard,
@@ -505,6 +521,7 @@ describe('CustomQueryTransformer', () => {
     mockFetchFromAPIServer.mockResolvedValue(mockErrorResponse());
 
     const transformer = new CustomQueryTransformer(
+      lc,
       {
         url: [pullUrl],
         forwardCookies: false,
@@ -547,6 +564,7 @@ describe('CustomQueryTransformer', () => {
     mockFetchFromAPIServer.mockResolvedValue(mockSuccessResponse());
 
     const transformer = new CustomQueryTransformer(
+      lc,
       {
         url: [pullUrl],
         forwardCookies: false,
@@ -593,6 +611,7 @@ describe('CustomQueryTransformer', () => {
     mockFetchFromAPIServer.mockResolvedValue(mockSuccessResponse());
 
     const transformer = new CustomQueryTransformer(
+      lc,
       {
         url: [defaultUrl, customUrl],
         forwardCookies: false,
@@ -613,6 +632,7 @@ describe('CustomQueryTransformer', () => {
 
     // Verify custom URL was used instead of default
     expect(mockFetchFromAPIServer).toHaveBeenCalledWith(
+      lc,
       customUrl,
       [defaultUrl, customUrl],
       mockShard,
@@ -637,6 +657,7 @@ describe('CustomQueryTransformer', () => {
     mockFetchFromAPIServer.mockResolvedValue(mockSuccessResponse());
 
     const transformer = new CustomQueryTransformer(
+      lc,
       {
         url: [pullUrl],
         forwardCookies: false,
@@ -656,6 +677,7 @@ describe('CustomQueryTransformer', () => {
 
     // Verify query parameters were passed
     expect(mockFetchFromAPIServer).toHaveBeenCalledWith(
+      lc,
       pullUrl,
       [pullUrl],
       mockShard,
@@ -681,6 +703,7 @@ describe('CustomQueryTransformer', () => {
     mockFetchFromAPIServer.mockResolvedValue(mockSuccessResponse());
 
     const transformer = new CustomQueryTransformer(
+      lc,
       {
         url: [defaultUrl, customUrl],
         forwardCookies: false,
@@ -701,6 +724,7 @@ describe('CustomQueryTransformer', () => {
 
     // Verify both custom URL and query parameters were used
     expect(mockFetchFromAPIServer).toHaveBeenCalledWith(
+      lc,
       customUrl,
       [defaultUrl, customUrl],
       mockShard,
@@ -725,6 +749,7 @@ describe('CustomQueryTransformer', () => {
     mockFetchFromAPIServer.mockResolvedValue(mockSuccessResponse());
 
     const transformer = new CustomQueryTransformer(
+      lc,
       {
         url: [defaultUrl],
         forwardCookies: false,
@@ -736,6 +761,7 @@ describe('CustomQueryTransformer', () => {
 
     // Verify default URL and undefined queryParams were used
     expect(mockFetchFromAPIServer).toHaveBeenCalledWith(
+      lc,
       defaultUrl,
       [defaultUrl],
       mockShard,
@@ -756,6 +782,7 @@ describe('CustomQueryTransformer', () => {
     );
 
     const transformer = new CustomQueryTransformer(
+      lc,
       {
         url: [allowedUrl],
         forwardCookies: false,
@@ -786,6 +813,7 @@ describe('CustomQueryTransformer', () => {
 
     // Verify the disallowed URL was attempted to be used
     expect(mockFetchFromAPIServer).toHaveBeenCalledWith(
+      lc,
       disallowedUrl,
       [allowedUrl],
       mockShard,

--- a/packages/zero-cache/src/custom-queries/transform-query.test.ts
+++ b/packages/zero-cache/src/custom-queries/transform-query.test.ts
@@ -138,7 +138,11 @@ describe('CustomQueryTransformer', () => {
       },
       mockShard,
     );
-    const result = await transformer.transform(headerOptions, mockQueries);
+    const result = await transformer.transform(
+      headerOptions,
+      mockQueries,
+      undefined,
+    );
 
     // Verify the API was called correctly
     expect(mockFetchFromAPIServer).toHaveBeenCalledWith(
@@ -186,7 +190,11 @@ describe('CustomQueryTransformer', () => {
       },
       mockShard,
     );
-    const result = await transformer.transform(headerOptions, mockQueries);
+    const result = await transformer.transform(
+      headerOptions,
+      mockQueries,
+      undefined,
+    );
 
     expect(result).toEqual([
       transformResults[0],
@@ -216,7 +224,11 @@ describe('CustomQueryTransformer', () => {
       },
       mockShard,
     );
-    const result = await transformer.transform(headerOptions, mockQueries);
+    const result = await transformer.transform(
+      headerOptions,
+      mockQueries,
+      undefined,
+    );
 
     expect(result).toEqual([
       {
@@ -251,7 +263,7 @@ describe('CustomQueryTransformer', () => {
       },
       mockShard,
     );
-    const result = await transformer.transform(headerOptions, []);
+    const result = await transformer.transform(headerOptions, [], undefined);
 
     expect(mockFetchFromAPIServer).not.toHaveBeenCalled();
     expect(result).toEqual([]);
@@ -278,12 +290,16 @@ describe('CustomQueryTransformer', () => {
     );
 
     // First call - should fetch
-    await transformer.transform(headerOptions, [mockQueries[0]]);
+    await transformer.transform(headerOptions, [mockQueries[0]], undefined);
     expect(mockFetchFromAPIServer).toHaveBeenCalledTimes(1);
 
     // Second call with same query - should use cache, not fetch
     mockFetchFromAPIServer.mockResolvedValue(mockSuccessResponse());
-    const result = await transformer.transform(headerOptions, [mockQueries[0]]);
+    const result = await transformer.transform(
+      headerOptions,
+      [mockQueries[0]],
+      undefined,
+    );
     expect(mockFetchFromAPIServer).toHaveBeenCalledTimes(1); // Still only called once
     expect(result).toEqual([transformResults[0]]);
   });
@@ -309,18 +325,18 @@ describe('CustomQueryTransformer', () => {
     );
 
     // First call
-    await transformer.transform(headerOptions, [mockQueries[0]]);
+    await transformer.transform(headerOptions, [mockQueries[0]], undefined);
     expect(mockFetchFromAPIServer).toHaveBeenCalledTimes(1);
 
     // Advance time by 4 seconds - should still use cache
     vi.advanceTimersByTime(4000);
-    await transformer.transform(headerOptions, [mockQueries[0]]);
+    await transformer.transform(headerOptions, [mockQueries[0]], undefined);
     expect(mockFetchFromAPIServer).toHaveBeenCalledTimes(1);
 
     // Advance time by 2 more seconds (6 total) - cache should expire, fetch again
     vi.advanceTimersByTime(2000);
     mockFetchFromAPIServer.mockResolvedValue(mockSuccessResponse());
-    await transformer.transform(headerOptions, [mockQueries[0]]);
+    await transformer.transform(headerOptions, [mockQueries[0]], undefined);
     expect(mockFetchFromAPIServer).toHaveBeenCalledTimes(2);
   });
 
@@ -356,7 +372,7 @@ describe('CustomQueryTransformer', () => {
     );
 
     // Cache first query
-    await transformer.transform(headerOptions, [mockQueries[0]]);
+    await transformer.transform(headerOptions, [mockQueries[0]], undefined);
     expect(mockFetchFromAPIServer).toHaveBeenCalledTimes(1);
     expect(mockFetchFromAPIServer).toHaveBeenLastCalledWith(
       'https://api.example.com/pull',
@@ -368,7 +384,11 @@ describe('CustomQueryTransformer', () => {
     );
 
     // Now call with both queries - only second should be fetched
-    const result = await transformer.transform(headerOptions, mockQueries);
+    const result = await transformer.transform(
+      headerOptions,
+      mockQueries,
+      undefined,
+    );
     expect(mockFetchFromAPIServer).toHaveBeenCalledTimes(2);
     expect(mockFetchFromAPIServer).toHaveBeenLastCalledWith(
       pullUrl,
@@ -411,6 +431,7 @@ describe('CustomQueryTransformer', () => {
     const result = await transformer.transform(
       {...headerOptions, cookie: 'test-cookie'},
       [mockQueries[0]],
+      undefined,
     );
 
     expect(mockFetchFromAPIServer).toHaveBeenCalledWith(
@@ -449,6 +470,7 @@ describe('CustomQueryTransformer', () => {
     const result = await transformer.transform(
       {...headerOptions, cookie: 'test-cookie'},
       [mockQueries[0]],
+      undefined,
     );
 
     expect(mockFetchFromAPIServer).toHaveBeenCalledWith(
@@ -491,9 +513,11 @@ describe('CustomQueryTransformer', () => {
     );
 
     // First call - should fetch and get error
-    const result1 = await transformer.transform(headerOptions, [
-      mockQueries[0],
-    ]);
+    const result1 = await transformer.transform(
+      headerOptions,
+      [mockQueries[0]],
+      undefined,
+    );
     expect(mockFetchFromAPIServer).toHaveBeenCalledTimes(1);
     expect(result1).toEqual([
       {
@@ -506,7 +530,7 @@ describe('CustomQueryTransformer', () => {
 
     // Second call - should fetch again because errors are not cached
     mockFetchFromAPIServer.mockResolvedValue(mockErrorResponse());
-    await transformer.transform(headerOptions, [mockQueries[0]]);
+    await transformer.transform(headerOptions, [mockQueries[0]], undefined);
     expect(mockFetchFromAPIServer).toHaveBeenCalledTimes(2);
   });
 
@@ -535,17 +559,21 @@ describe('CustomQueryTransformer', () => {
     };
 
     // Cache with first header options
-    await transformer.transform(headerOptions, [mockQueries[0]]);
+    await transformer.transform(headerOptions, [mockQueries[0]], undefined);
     expect(mockFetchFromAPIServer).toHaveBeenCalledTimes(1);
 
     // Call with different header options - should fetch again due to different cache key
     mockFetchFromAPIServer.mockResolvedValue(mockSuccessResponse());
-    await transformer.transform(differentHeaderOptions, [mockQueries[0]]);
+    await transformer.transform(
+      differentHeaderOptions,
+      [mockQueries[0]],
+      undefined,
+    );
     expect(mockFetchFromAPIServer).toHaveBeenCalledTimes(2);
 
     // Call again with original header options - should use cache
     mockFetchFromAPIServer.mockResolvedValue(mockSuccessResponse());
-    await transformer.transform(headerOptions, [mockQueries[0]]);
+    await transformer.transform(headerOptions, [mockQueries[0]], undefined);
     expect(mockFetchFromAPIServer).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/zero-cache/src/custom-queries/transform-query.test.ts
+++ b/packages/zero-cache/src/custom-queries/transform-query.test.ts
@@ -616,11 +616,7 @@ describe('CustomQueryTransformer', () => {
 
     const userQueryURL = customUrl;
 
-    await transformer.transform(
-      headerOptions,
-      [mockQueries[0]],
-      userQueryURL,
-    );
+    await transformer.transform(headerOptions, [mockQueries[0]], userQueryURL);
 
     // Verify custom URL was used instead of default
     expect(mockFetchFromAPIServer).toHaveBeenCalledWith(

--- a/packages/zero-cache/src/custom-queries/transform-query.ts
+++ b/packages/zero-cache/src/custom-queries/transform-query.ts
@@ -6,6 +6,7 @@ import {
   type TransformRequestBody,
   type TransformRequestMessage,
 } from '../../../zero-protocol/src/custom-queries.ts';
+import type {UserQueryParams} from '../../../zero-protocol/src/connect.ts';
 import {fetchFromAPIServer, type HeaderOptions} from '../custom/fetch.ts';
 import type {ShardID} from '../types/shards.ts';
 import * as v from '../../../shared/src/valita.ts';
@@ -56,6 +57,7 @@ export class CustomQueryTransformer {
   async transform(
     headerOptions: HeaderOptions,
     queries: Iterable<CustomQueryRecord>,
+    userQueryParams: UserQueryParams | undefined,
   ): Promise<(TransformedAndHashed | ErroredQuery)[]> {
     const request: TransformRequestBody = [];
     const cachedResponses: TransformedAndHashed[] = [];
@@ -89,14 +91,15 @@ export class CustomQueryTransformer {
     let response: Response | undefined;
     try {
       response = await fetchFromAPIServer(
-        must(
-          this.#config.url[0],
-          'A ZERO_GET_QUERIES_URL must be configured for custom queries',
-        ),
+        userQueryParams?.url ??
+          must(
+            this.#config.url[0],
+            'A ZERO_GET_QUERIES_URL must be configured for custom queries',
+          ),
         this.#config.url,
         this.#shard,
         headerOptions,
-        undefined,
+        userQueryParams?.queryParams,
         ['transform', request] satisfies TransformRequestMessage,
       );
     } catch (e) {

--- a/packages/zero-cache/src/custom-queries/transform-query.ts
+++ b/packages/zero-cache/src/custom-queries/transform-query.ts
@@ -1,3 +1,4 @@
+import type {LogContext} from '@rocicorp/logger';
 import type {TransformedAndHashed} from '../auth/read-authorizer.ts';
 import type {CustomQueryRecord} from '../services/view-syncer/schema/types.ts';
 import {
@@ -41,8 +42,10 @@ export class CustomQueryTransformer {
     url: string[];
     forwardCookies: boolean;
   };
+  readonly #lc: LogContext;
 
   constructor(
+    lc: LogContext,
     config: {
       url: string[];
       forwardCookies: boolean;
@@ -51,6 +54,7 @@ export class CustomQueryTransformer {
   ) {
     this.#config = config;
     this.#shard = shard;
+    this.#lc = lc;
     this.#cache = new TimedCache(5000); // 5 seconds cache TTL
   }
 
@@ -91,6 +95,7 @@ export class CustomQueryTransformer {
     let response: Response | undefined;
     try {
       response = await fetchFromAPIServer(
+        this.#lc,
         userQueryParams?.url ??
           must(
             this.#config.url[0],

--- a/packages/zero-cache/src/custom-queries/transform-query.ts
+++ b/packages/zero-cache/src/custom-queries/transform-query.ts
@@ -7,7 +7,6 @@ import {
   type TransformRequestBody,
   type TransformRequestMessage,
 } from '../../../zero-protocol/src/custom-queries.ts';
-import type {UserQueryParams} from '../../../zero-protocol/src/connect.ts';
 import {fetchFromAPIServer, type HeaderOptions} from '../custom/fetch.ts';
 import type {ShardID} from '../types/shards.ts';
 import * as v from '../../../shared/src/valita.ts';
@@ -61,7 +60,7 @@ export class CustomQueryTransformer {
   async transform(
     headerOptions: HeaderOptions,
     queries: Iterable<CustomQueryRecord>,
-    userQueryParams: UserQueryParams | undefined,
+    userQueryURL: string | undefined,
   ): Promise<(TransformedAndHashed | ErroredQuery)[]> {
     const request: TransformRequestBody = [];
     const cachedResponses: TransformedAndHashed[] = [];
@@ -96,7 +95,7 @@ export class CustomQueryTransformer {
     try {
       response = await fetchFromAPIServer(
         this.#lc,
-        userQueryParams?.url ??
+        userQueryURL ??
           must(
             this.#config.url[0],
             'A ZERO_GET_QUERIES_URL must be configured for custom queries',
@@ -104,7 +103,6 @@ export class CustomQueryTransformer {
         this.#config.url,
         this.#shard,
         headerOptions,
-        userQueryParams?.queryParams,
         ['transform', request] satisfies TransformRequestMessage,
       );
     } catch (e) {

--- a/packages/zero-cache/src/custom/fetch.test.ts
+++ b/packages/zero-cache/src/custom/fetch.test.ts
@@ -6,6 +6,7 @@ import {
   type MockedFunction,
   test,
 } from 'vitest';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
 import {fetchFromAPIServer, urlMatch} from './fetch.ts';
 import {ErrorForClient} from '../types/error-for-client.ts';
 import {ErrorKind} from '../../../zero-protocol/src/error-kind.ts';
@@ -20,6 +21,7 @@ describe('fetchFromAPIServer', () => {
     appID: 'test_app',
     shardNum: 1,
   };
+  const lc = createSilentLogContext();
 
   const baseUrl = 'https://api.example.com/endpoint';
   const headerOptions = {
@@ -43,6 +45,7 @@ describe('fetchFromAPIServer', () => {
     mockFetch.mockResolvedValue(mockResponse);
 
     await fetchFromAPIServer(
+      lc,
       baseUrl,
       [baseUrl],
       mockShard,
@@ -71,6 +74,7 @@ describe('fetchFromAPIServer', () => {
     mockFetch.mockResolvedValue(mockResponse);
 
     await fetchFromAPIServer(
+      lc,
       baseUrl,
       [baseUrl],
       mockShard,
@@ -94,6 +98,7 @@ describe('fetchFromAPIServer', () => {
     mockFetch.mockResolvedValue(mockResponse);
 
     await fetchFromAPIServer(
+      lc,
       baseUrl,
       [baseUrl],
       mockShard,
@@ -118,6 +123,7 @@ describe('fetchFromAPIServer', () => {
     mockFetch.mockResolvedValue(mockResponse);
 
     await fetchFromAPIServer(
+      lc,
       baseUrl,
       [baseUrl],
       mockShard,
@@ -139,6 +145,7 @@ describe('fetchFromAPIServer', () => {
     mockFetch.mockResolvedValue(mockResponse);
 
     await fetchFromAPIServer(
+      lc,
       baseUrl,
       [baseUrl],
       mockShard,
@@ -159,6 +166,7 @@ describe('fetchFromAPIServer', () => {
     mockFetch.mockResolvedValue(mockResponse);
 
     await fetchFromAPIServer(
+      lc,
       baseUrl,
       [baseUrl],
       mockShard,
@@ -180,6 +188,7 @@ describe('fetchFromAPIServer', () => {
     const urlWithParams = 'https://api.example.com/endpoint?existing=param';
 
     await fetchFromAPIServer(
+      lc,
       urlWithParams,
       [baseUrl],
       mockShard,
@@ -201,6 +210,7 @@ describe('fetchFromAPIServer', () => {
 
     await expect(
       fetchFromAPIServer(
+        lc,
         urlWithReserved,
         [baseUrl],
         mockShard,
@@ -218,6 +228,7 @@ describe('fetchFromAPIServer', () => {
 
     await expect(
       fetchFromAPIServer(
+        lc,
         urlWithReserved,
         [baseUrl],
         mockShard,
@@ -235,6 +246,7 @@ describe('fetchFromAPIServer', () => {
 
     await expect(
       fetchFromAPIServer(
+        lc,
         baseUrl,
         [baseUrl],
         mockShard,
@@ -252,6 +264,7 @@ describe('fetchFromAPIServer', () => {
 
     await expect(
       fetchFromAPIServer(
+        lc,
         baseUrl,
         [baseUrl],
         mockShard,
@@ -271,6 +284,7 @@ describe('fetchFromAPIServer', () => {
     mockFetch.mockResolvedValue(mockResponse);
 
     const result = await fetchFromAPIServer(
+      lc,
       baseUrl,
       [baseUrl],
       mockShard,
@@ -290,7 +304,7 @@ describe('fetchFromAPIServer', () => {
     mockFetch.mockResolvedValueOnce(mockResponse1);
 
     await expect(
-      fetchFromAPIServer(baseUrl, [baseUrl], mockShard, {}, undefined, body),
+      fetchFromAPIServer(lc, baseUrl, [baseUrl], mockShard, {}, undefined, body),
     ).rejects.toThrow(ErrorForClient);
 
     // Second call - test the error details
@@ -299,6 +313,7 @@ describe('fetchFromAPIServer', () => {
 
     try {
       await fetchFromAPIServer(
+        lc,
         baseUrl,
         [baseUrl],
         mockShard,
@@ -319,6 +334,7 @@ describe('fetchFromAPIServer', () => {
     mockFetch.mockResolvedValue(mockResponse);
 
     const result = await fetchFromAPIServer(
+      lc,
       baseUrl,
       [baseUrl],
       mockShard,
@@ -335,6 +351,7 @@ describe('fetchFromAPIServer', () => {
     mockFetch.mockResolvedValue(mockResponse);
 
     await fetchFromAPIServer(
+      lc,
       baseUrl,
       [baseUrl],
       mockShard,
@@ -361,6 +378,7 @@ describe('fetchFromAPIServer', () => {
     };
 
     await fetchFromAPIServer(
+      lc,
       baseUrl,
       [baseUrl],
       mockShard,

--- a/packages/zero-cache/src/custom/fetch.test.ts
+++ b/packages/zero-cache/src/custom/fetch.test.ts
@@ -28,10 +28,6 @@ describe('fetchFromAPIServer', () => {
     apiKey: 'test-api-key',
     token: 'test-token',
   };
-  const queryParams = {
-    param1: 'value1',
-    param2: 'value2',
-  };
   const body = {test: 'data'};
 
   beforeEach(() => {
@@ -50,7 +46,6 @@ describe('fetchFromAPIServer', () => {
       [baseUrl],
       mockShard,
       headerOptions,
-      queryParams,
       body,
     );
 
@@ -79,7 +74,6 @@ describe('fetchFromAPIServer', () => {
       [baseUrl],
       mockShard,
       {apiKey: 'my-key'},
-      undefined,
       body,
     );
 
@@ -103,7 +97,6 @@ describe('fetchFromAPIServer', () => {
       [baseUrl],
       mockShard,
       {token: 'my-token'},
-      undefined,
       body,
     );
 
@@ -128,7 +121,6 @@ describe('fetchFromAPIServer', () => {
       [baseUrl],
       mockShard,
       {},
-      undefined,
       body,
     );
 
@@ -138,27 +130,6 @@ describe('fetchFromAPIServer', () => {
     expect(headers).not.toHaveProperty('X-Api-Key');
     expect(headers).not.toHaveProperty('Authorization');
     expect(headers).toHaveProperty('Content-Type', 'application/json');
-  });
-
-  test('should append query parameters to URL', async () => {
-    const mockResponse = new Response('{}', {status: 200});
-    mockFetch.mockResolvedValue(mockResponse);
-
-    await fetchFromAPIServer(
-      lc,
-      baseUrl,
-      [baseUrl],
-      mockShard,
-      {},
-      queryParams,
-      body,
-    );
-
-    const calledUrl = mockFetch.mock.calls[0][0] as string;
-    const url = new URL(calledUrl);
-
-    expect(url.searchParams.get('param1')).toBe('value1');
-    expect(url.searchParams.get('param2')).toBe('value2');
   });
 
   test('should append required schema and appID parameters', async () => {
@@ -171,7 +142,6 @@ describe('fetchFromAPIServer', () => {
       [baseUrl],
       mockShard,
       {},
-      undefined,
       body,
     );
 
@@ -180,29 +150,6 @@ describe('fetchFromAPIServer', () => {
 
     expect(url.searchParams.get('schema')).toBe('test_app_1');
     expect(url.searchParams.get('appID')).toBe('test_app');
-  });
-
-  test('should handle URLs that already have query parameters', async () => {
-    const mockResponse = new Response('{}', {status: 200});
-    mockFetch.mockResolvedValue(mockResponse);
-    const urlWithParams = 'https://api.example.com/endpoint?existing=param';
-
-    await fetchFromAPIServer(
-      lc,
-      urlWithParams,
-      [baseUrl],
-      mockShard,
-      {},
-      queryParams,
-      body,
-    );
-
-    const calledUrl = mockFetch.mock.calls[0][0] as string;
-    const url = new URL(calledUrl);
-
-    expect(url.searchParams.get('existing')).toBe('param');
-    expect(url.searchParams.get('param1')).toBe('value1');
-    expect(url.searchParams.get('schema')).toBe('test_app_1');
   });
 
   test('should throw an error if URL contains reserved parameter "schema"', async () => {
@@ -215,7 +162,6 @@ describe('fetchFromAPIServer', () => {
         [baseUrl],
         mockShard,
         {},
-        undefined,
         body,
       ),
     ).rejects.toThrow(
@@ -233,43 +179,6 @@ describe('fetchFromAPIServer', () => {
         [baseUrl],
         mockShard,
         {},
-        undefined,
-        body,
-      ),
-    ).rejects.toThrow(
-      'The push URL cannot contain the reserved query param "appID"',
-    );
-  });
-
-  test('should throw an error if query params contain reserved parameter "schema"', async () => {
-    const reservedQueryParams = {schema: 'reserved'};
-
-    await expect(
-      fetchFromAPIServer(
-        lc,
-        baseUrl,
-        [baseUrl],
-        mockShard,
-        {},
-        reservedQueryParams,
-        body,
-      ),
-    ).rejects.toThrow(
-      'The push URL cannot contain the reserved query param "schema"',
-    );
-  });
-
-  test('should throw an error if query params contain reserved parameter "appID"', async () => {
-    const reservedQueryParams = {appID: 'reserved'};
-
-    await expect(
-      fetchFromAPIServer(
-        lc,
-        baseUrl,
-        [baseUrl],
-        mockShard,
-        {},
-        reservedQueryParams,
         body,
       ),
     ).rejects.toThrow(
@@ -289,7 +198,6 @@ describe('fetchFromAPIServer', () => {
       [baseUrl],
       mockShard,
       {},
-      undefined,
       body,
     );
 
@@ -304,7 +212,7 @@ describe('fetchFromAPIServer', () => {
     mockFetch.mockResolvedValueOnce(mockResponse1);
 
     await expect(
-      fetchFromAPIServer(lc, baseUrl, [baseUrl], mockShard, {}, undefined, body),
+      fetchFromAPIServer(lc, baseUrl, [baseUrl], mockShard, {}, body),
     ).rejects.toThrow(ErrorForClient);
 
     // Second call - test the error details
@@ -318,7 +226,6 @@ describe('fetchFromAPIServer', () => {
         [baseUrl],
         mockShard,
         {},
-        undefined,
         body,
       );
     } catch (error) {
@@ -339,32 +246,10 @@ describe('fetchFromAPIServer', () => {
       [baseUrl],
       mockShard,
       {},
-      undefined,
       body,
     );
 
     expect(result).toBe(mockResponse);
-  });
-
-  test('should handle empty query params', async () => {
-    const mockResponse = new Response('{}', {status: 200});
-    mockFetch.mockResolvedValue(mockResponse);
-
-    await fetchFromAPIServer(
-      lc,
-      baseUrl,
-      [baseUrl],
-      mockShard,
-      {},
-      undefined,
-      body,
-    );
-
-    const calledUrl = mockFetch.mock.calls[0][0] as string;
-    const url = new URL(calledUrl);
-
-    expect(url.searchParams.get('schema')).toBe('test_app_1');
-    expect(url.searchParams.get('appID')).toBe('test_app');
   });
 
   test('should stringify body as JSON', async () => {
@@ -383,7 +268,6 @@ describe('fetchFromAPIServer', () => {
       [baseUrl],
       mockShard,
       {},
-      undefined,
       complexBody,
     );
 

--- a/packages/zero-cache/src/custom/fetch.test.ts
+++ b/packages/zero-cache/src/custom/fetch.test.ts
@@ -115,14 +115,7 @@ describe('fetchFromAPIServer', () => {
     const mockResponse = new Response('{}', {status: 200});
     mockFetch.mockResolvedValue(mockResponse);
 
-    await fetchFromAPIServer(
-      lc,
-      baseUrl,
-      [baseUrl],
-      mockShard,
-      {},
-      body,
-    );
+    await fetchFromAPIServer(lc, baseUrl, [baseUrl], mockShard, {}, body);
 
     const callArgs = mockFetch.mock.calls[0];
     const headers = callArgs[1]?.headers as Record<string, string>;
@@ -136,14 +129,7 @@ describe('fetchFromAPIServer', () => {
     const mockResponse = new Response('{}', {status: 200});
     mockFetch.mockResolvedValue(mockResponse);
 
-    await fetchFromAPIServer(
-      lc,
-      baseUrl,
-      [baseUrl],
-      mockShard,
-      {},
-      body,
-    );
+    await fetchFromAPIServer(lc, baseUrl, [baseUrl], mockShard, {}, body);
 
     const calledUrl = mockFetch.mock.calls[0][0] as string;
     const url = new URL(calledUrl);
@@ -156,14 +142,7 @@ describe('fetchFromAPIServer', () => {
     const urlWithReserved = 'https://api.example.com/endpoint?schema=reserved';
 
     await expect(
-      fetchFromAPIServer(
-        lc,
-        urlWithReserved,
-        [baseUrl],
-        mockShard,
-        {},
-        body,
-      ),
+      fetchFromAPIServer(lc, urlWithReserved, [baseUrl], mockShard, {}, body),
     ).rejects.toThrow(
       'The push URL cannot contain the reserved query param "schema"',
     );
@@ -173,14 +152,7 @@ describe('fetchFromAPIServer', () => {
     const urlWithReserved = 'https://api.example.com/endpoint?appID=reserved';
 
     await expect(
-      fetchFromAPIServer(
-        lc,
-        urlWithReserved,
-        [baseUrl],
-        mockShard,
-        {},
-        body,
-      ),
+      fetchFromAPIServer(lc, urlWithReserved, [baseUrl], mockShard, {}, body),
     ).rejects.toThrow(
       'The push URL cannot contain the reserved query param "appID"',
     );
@@ -220,14 +192,7 @@ describe('fetchFromAPIServer', () => {
     mockFetch.mockResolvedValueOnce(mockResponse2);
 
     try {
-      await fetchFromAPIServer(
-        lc,
-        baseUrl,
-        [baseUrl],
-        mockShard,
-        {},
-        body,
-      );
+      await fetchFromAPIServer(lc, baseUrl, [baseUrl], mockShard, {}, body);
     } catch (error) {
       expect(error).toBeInstanceOf(ErrorForClient);
       const errorForClient = error as ErrorForClient;

--- a/packages/zero-cache/src/custom/fetch.ts
+++ b/packages/zero-cache/src/custom/fetch.ts
@@ -18,13 +18,11 @@ export async function fetchFromAPIServer(
   allowedUrls: string[],
   shard: ShardID,
   headerOptions: HeaderOptions,
-  queryParams: Record<string, string> | undefined,
   body: ReadonlyJSONValue,
 ) {
   lc.info?.('fetchFromAPIServer called', {
     url,
     allowedUrls,
-    queryParams,
   });
   
   if (!urlMatch(url, allowedUrls)) {
@@ -48,9 +46,6 @@ export async function fetchFromAPIServer(
 
   const urlObj = new URL(url);
   const params = new URLSearchParams(urlObj.search);
-  for (const [key, value] of Object.entries(queryParams ?? {})) {
-    params.append(key, value);
-  }
 
   for (const reserved of reservedParams) {
     assert(

--- a/packages/zero-cache/src/custom/fetch.ts
+++ b/packages/zero-cache/src/custom/fetch.ts
@@ -1,3 +1,4 @@
+import type {LogContext} from '@rocicorp/logger';
 import {assert} from '../../../shared/src/asserts.ts';
 import {upstreamSchema, type ShardID} from '../types/shards.ts';
 import type {ReadonlyJSONValue} from '../../../shared/src/json.ts';
@@ -12,6 +13,7 @@ export type HeaderOptions = {
 };
 
 export async function fetchFromAPIServer(
+  lc: LogContext,
   url: string,
   allowedUrls: string[],
   shard: ShardID,
@@ -19,6 +21,12 @@ export async function fetchFromAPIServer(
   queryParams: Record<string, string> | undefined,
   body: ReadonlyJSONValue,
 ) {
+  lc.info?.('fetchFromAPIServer called', {
+    url,
+    allowedUrls,
+    queryParams,
+  });
+  
   if (!urlMatch(url, allowedUrls)) {
     throw new Error(
       `URL "${url}" is not allowed by the ZERO_MUTATE/GET_QUERIES_URL configuration`,
@@ -55,7 +63,11 @@ export async function fetchFromAPIServer(
   params.append('appID', shard.appID);
 
   urlObj.search = params.toString();
-  const response = await fetch(urlObj.toString(), {
+  
+  const finalUrl = urlObj.toString();
+  lc.info?.('Executing fetch', {finalUrl});
+  
+  const response = await fetch(finalUrl, {
     method: 'POST',
     headers,
     body: JSON.stringify(body),

--- a/packages/zero-cache/src/custom/fetch.ts
+++ b/packages/zero-cache/src/custom/fetch.ts
@@ -24,7 +24,7 @@ export async function fetchFromAPIServer(
     url,
     allowedUrls,
   });
-  
+
   if (!urlMatch(url, allowedUrls)) {
     throw new Error(
       `URL "${url}" is not allowed by the ZERO_MUTATE/GET_QUERIES_URL configuration`,
@@ -58,10 +58,10 @@ export async function fetchFromAPIServer(
   params.append('appID', shard.appID);
 
   urlObj.search = params.toString();
-  
+
   const finalUrl = urlObj.toString();
   lc.info?.('Executing fetch', {finalUrl});
-  
+
   const response = await fetch(finalUrl, {
     method: 'POST',
     headers,
@@ -103,10 +103,7 @@ export async function fetchFromAPIServer(
  * - "https://*.*.example.com" does not match "https://api.example.com" (only one subdomain)
  */
 export function urlMatch(url: string, allowedUrls: string[]): boolean {
-  assert(
-    url.includes('*') === false,
-    'Client provided URLs may not include `*`',
-  );
+  assert(url.includes('*') === false, 'URL to fetch may not include `*`');
   // ignore query parameters in the URL
   url = url.split('?')[0];
 

--- a/packages/zero-cache/src/services/mutagen/pusher.test.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.test.ts
@@ -594,7 +594,6 @@ describe('initConnection', () => {
     });
   });
 
-
   test('uses client custom URL when userParams.url is provided', async () => {
     const fetch = (global.fetch = vi.fn());
     fetch.mockResolvedValue({
@@ -624,7 +623,7 @@ describe('initConnection', () => {
 
     // Verify custom URL was used instead of default
     expect(fetch.mock.calls[0][0]).toEqual(
-      'http://custom.com/push?schema=zero_0&appID=zero'
+      'http://custom.com/push?schema=zero_0&appID=zero',
     );
 
     await pusher.stop();
@@ -657,7 +656,7 @@ describe('initConnection', () => {
 
     // Verify default URL was used
     expect(fetch.mock.calls[0][0]).toEqual(
-      'http://default.com/?schema=zero_0&appID=zero'
+      'http://default.com/?schema=zero_0&appID=zero',
     );
 
     await pusher.stop();
@@ -676,7 +675,11 @@ describe('initConnection', () => {
       'cgid',
     );
     void pusher.run();
-    const stream = pusher.initConnection(clientID, wsID, 'http://malicious.com/endpoint');
+    const stream = pusher.initConnection(
+      clientID,
+      wsID,
+      'http://malicious.com/endpoint',
+    );
 
     pusher.enqueuePush(clientID, makePush(1, clientID), 'jwt', undefined);
 
@@ -691,7 +694,9 @@ describe('initConnection', () => {
         'pushResponse',
         {
           error: 'zeroPusher',
-          details: expect.stringContaining('URL "http://malicious.com/endpoint" is not allowed by the ZERO_MUTATE/GET_QUERIES_URL configuration'),
+          details: expect.stringContaining(
+            'URL "http://malicious.com/endpoint" is not allowed by the ZERO_MUTATE/GET_QUERIES_URL configuration',
+          ),
           mutationIDs: [{clientID, id: 1}],
         },
       ],

--- a/packages/zero-cache/src/services/mutagen/pusher.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.ts
@@ -374,9 +374,22 @@ class PushWorker {
     // Record custom mutations for telemetry
     recordMutation('custom', entry.push.mutations.length);
 
+    const client = must(this.#clients.get(entry.clientID), 'unknown clientID');
+    const url =
+      client.userParams?.url ??
+      must(this.#pushURLs[0], 'ZERO_MUTATE_URL is not set');
+
+    this.#lc.debug?.(
+      'pushing to',
+      url,
+      'with',
+      entry.push.mutations.length,
+      'mutations',
+    );
+
     try {
       const response = await fetchFromAPIServer(
-        must(this.#pushURLs[0], 'ZERO_MUTATE_URL is not set'),
+        url,
         this.#pushURLs,
         {
           appID: this.#config.app.id,
@@ -387,7 +400,7 @@ class PushWorker {
           token: entry.jwt,
           cookie: entry.httpCookie,
         },
-        this.#clients.get(entry.clientID)?.userParams?.queryParams,
+        client?.userParams?.queryParams,
         entry.push,
       );
 

--- a/packages/zero-cache/src/services/mutagen/pusher.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.ts
@@ -408,6 +408,7 @@ class PushWorker {
 
     try {
       const response = await fetchFromAPIServer(
+        this.#lc,
         url,
         this.#pushURLs,
         {

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -291,6 +291,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
     if (pullConfig.url) {
       this.#customQueryTransformer = new CustomQueryTransformer(
+        this.#lc,
         {
           url: pullConfig.url,
           forwardCookies: pullConfig.forwardCookies,

--- a/packages/zero-cache/src/workers/syncer-ws-message-handler.ts
+++ b/packages/zero-cache/src/workers/syncer-ws-message-handler.ts
@@ -188,7 +188,7 @@ export class SyncerWsMessageHandler implements MessageHandler {
             stream: this.#pusher.initConnection(
               this.#syncContext.clientID,
               this.#syncContext.wsID,
-              msg[1].userPushParams,
+              msg[1].userPushURL,
             ),
           });
         }

--- a/packages/zero-client/src/client/options.ts
+++ b/packages/zero-client/src/client/options.ts
@@ -111,9 +111,9 @@ export interface ZeroOptions<
    *
    * DEPRECATED: Use `userMutateParams` instead.
    */
-  push?: UserMutateParams;
-  mutate?: UserMutateParams;
-  query?: UserQueryParams;
+  push?: UserMutateParams | undefined;
+  mutate?: UserMutateParams | undefined;
+  query?: UserQueryParams | undefined;
 
   /**
    * `onOnlineChange` is called when the Zero instance's online status changes.

--- a/packages/zero-client/src/client/options.ts
+++ b/packages/zero-client/src/client/options.ts
@@ -2,10 +2,6 @@ import type {LogLevel} from '@rocicorp/logger';
 import type {StoreProvider} from '../../../replicache/src/kv/store.ts';
 import type {MaybePromise} from '../../../shared/src/types.ts';
 import * as v from '../../../shared/src/valita.ts';
-import type {
-  UserMutateParams,
-  UserQueryParams,
-} from '../../../zero-protocol/src/connect.ts';
 import type {Schema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import type {CustomMutatorDefs} from './custom.ts';
 import type {OnError} from './on-error.ts';
@@ -102,18 +98,16 @@ export interface ZeroOptions<
   mutators?: MD | undefined;
 
   /**
-   * Custom mutations are pushed to zero-cache and then to
-   * your API server.
-   *
-   * push.queryParams can be used to augment the URL
-   * used to connect to your API server so it includes
-   * variables in the query string.
-   *
-   * DEPRECATED: Use `userMutateParams` instead.
+   * Custom URL for mutation requests sent to your API server.
+   * If not provided, uses the default configured in zero-cache.
    */
-  push?: UserMutateParams | undefined;
-  mutate?: UserMutateParams | undefined;
-  query?: UserQueryParams | undefined;
+  mutateURL?: string | undefined;
+
+  /**
+   * Custom URL for query requests sent to your API server.
+   * If not provided, uses the default configured in zero-cache.
+   */
+  getQueriesURL?: string | undefined;
 
   /**
    * `onOnlineChange` is called when the Zero instance's online status changes.

--- a/packages/zero-client/src/client/zero-idbname.test.ts
+++ b/packages/zero-client/src/client/zero-idbname.test.ts
@@ -24,22 +24,22 @@ test('idbName generation with URL configuration', async () => {
     {
       name: 'basic mutate and query URLs',
       config: {
-        mutate: {url: 'https://example.com/mutate'},
-        query: {url: 'https://example.com/query'},
+        mutateURL: 'https://example.com/mutate',
+        getQueriesURL: 'https://example.com/query',
       },
     },
     {
       name: 'different mutate URL',
       config: {
-        mutate: {url: 'https://different.com/mutate'},
-        query: {url: 'https://example.com/query'},
+        mutateURL: 'https://different.com/mutate',
+        getQueriesURL: 'https://example.com/query',
       },
     },
     {
       name: 'different query URL',
       config: {
-        mutate: {url: 'https://example.com/mutate'},
-        query: {url: 'https://different.com/query'},
+        mutateURL: 'https://example.com/mutate',
+        getQueriesURL: 'https://different.com/query',
       },
     },
     {
@@ -47,55 +47,22 @@ test('idbName generation with URL configuration', async () => {
       config: {},
     },
     {
-      name: 'legacy push parameter',
+      name: 'only mutate URL provided',
       config: {
-        push: {url: 'https://example.com/mutate'},
-        query: {url: 'https://example.com/query'},
+        mutateURL: 'https://example.com/mutate',
       },
     },
     {
-      name: 'mutate takes precedence over push',
+      name: 'only query URL provided',
       config: {
-        push: {url: 'https://push.com/mutate'},
-        mutate: {url: 'https://mutate.com/mutate'},
-        query: {url: 'https://example.com/query'},
-      },
-    },
-    {
-      name: 'explicit undefined parameters',
-      config: {
-        mutate: undefined,
-        query: undefined,
-      },
-    },
-    {
-      name: 'with mutate query parameters',
-      config: {
-        mutate: {
-          url: 'https://example.com/mutate',
-          queryParams: {apiKey: 'test123', version: 'v2'},
-        },
-        query: {url: 'https://example.com/query'},
-      },
-    },
-    {
-      name: 'with query parameters for both mutate and query',
-      config: {
-        mutate: {
-          url: 'https://example.com/mutate',
-          queryParams: {apiKey: 'mutate123'},
-        },
-        query: {
-          url: 'https://example.com/query',
-          queryParams: {apiKey: 'query456', format: 'json'},
-        },
+        getQueriesURL: 'https://example.com/query',
       },
     },
     {
       name: 'different storage key produces different hash',
       config: {
-        mutate: {url: 'https://example.com/mutate'},
-        query: {url: 'https://example.com/query'},
+        mutateURL: 'https://example.com/mutate',
+        getQueriesURL: 'https://example.com/query',
       },
       storageKey: 'different-storage-key',
     },
@@ -115,14 +82,8 @@ test('idbName generation with URL configuration', async () => {
     const expectedName = `rep:zero-${userID}-${h64(
       JSON.stringify({
         storageKey: testStorageKey,
-        mutateUrl:
-          testCase.config.mutate?.url ?? testCase.config.push?.url ?? '',
-        queryUrl: testCase.config.query?.url ?? '',
-        mutateQueryParams:
-          testCase.config.mutate?.queryParams ??
-          testCase.config.push?.queryParams ??
-          {},
-        queryQueryParams: testCase.config.query?.queryParams ?? {},
+        mutateUrl: testCase.config.mutateURL ?? '',
+        queryUrl: testCase.config.getQueriesURL ?? '',
       }),
     ).toString(36)}`;
 

--- a/packages/zero-client/src/client/zero-idbname.test.ts
+++ b/packages/zero-client/src/client/zero-idbname.test.ts
@@ -124,7 +124,7 @@ test('idbName generation with URL configuration', async () => {
           {},
         queryQueryParams: testCase.config.query?.queryParams ?? {},
       }),
-    ).toString()}`;
+    ).toString(36)}`;
 
     // The idbName should start with the expected prefix
     expect(zero.idbName, `Test case: ${testCase.name}`).toMatch(

--- a/packages/zero-client/src/client/zero-idbname.test.ts
+++ b/packages/zero-client/src/client/zero-idbname.test.ts
@@ -1,0 +1,136 @@
+import {expect, test} from 'vitest';
+import {h64} from '../../../shared/src/hash.ts';
+import {Zero} from './zero.ts';
+import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
+import {string, table} from '../../../zero-schema/src/builder/table-builder.ts';
+
+const schema = createSchema({
+  tables: [
+    table('foo')
+      .columns({
+        id: string(),
+        value: string(),
+      })
+      .primaryKey('id'),
+  ],
+});
+
+const userID = 'test-user';
+const storageKey = 'test-storage';
+
+test('idbName generation with URL configuration', async () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const testCases: any[] = [
+    {
+      name: 'basic mutate and query URLs',
+      config: {
+        mutate: {url: 'https://example.com/mutate'},
+        query: {url: 'https://example.com/query'},
+      },
+    },
+    {
+      name: 'different mutate URL',
+      config: {
+        mutate: {url: 'https://different.com/mutate'},
+        query: {url: 'https://example.com/query'},
+      },
+    },
+    {
+      name: 'different query URL',
+      config: {
+        mutate: {url: 'https://example.com/mutate'},
+        query: {url: 'https://different.com/query'},
+      },
+    },
+    {
+      name: 'no URLs provided',
+      config: {},
+    },
+    {
+      name: 'legacy push parameter',
+      config: {
+        push: {url: 'https://example.com/mutate'},
+        query: {url: 'https://example.com/query'},
+      },
+    },
+    {
+      name: 'mutate takes precedence over push',
+      config: {
+        push: {url: 'https://push.com/mutate'},
+        mutate: {url: 'https://mutate.com/mutate'},
+        query: {url: 'https://example.com/query'},
+      },
+    },
+    {
+      name: 'explicit undefined parameters',
+      config: {
+        mutate: undefined,
+        query: undefined,
+      },
+    },
+    {
+      name: 'with mutate query parameters',
+      config: {
+        mutate: {
+          url: 'https://example.com/mutate',
+          queryParams: {apiKey: 'test123', version: 'v2'},
+        },
+        query: {url: 'https://example.com/query'},
+      },
+    },
+    {
+      name: 'with query parameters for both mutate and query',
+      config: {
+        mutate: {
+          url: 'https://example.com/mutate',
+          queryParams: {apiKey: 'mutate123'},
+        },
+        query: {
+          url: 'https://example.com/query',
+          queryParams: {apiKey: 'query456', format: 'json'},
+        },
+      },
+    },
+    {
+      name: 'different storage key produces different hash',
+      config: {
+        mutate: {url: 'https://example.com/mutate'},
+        query: {url: 'https://example.com/query'},
+      },
+      storageKey: 'different-storage-key',
+    },
+  ];
+
+  for (const testCase of testCases) {
+    const testStorageKey = testCase.storageKey ?? storageKey;
+    const zero = new Zero({
+      userID,
+      storageKey: testStorageKey,
+      schema,
+      kvStore: 'mem',
+      ...testCase.config,
+    });
+
+    // Calculate the expected name from the config
+    const expectedName = `rep:zero-${userID}-${h64(
+      JSON.stringify({
+        storageKey: testStorageKey,
+        mutateUrl:
+          testCase.config.mutate?.url ?? testCase.config.push?.url ?? '',
+        queryUrl: testCase.config.query?.url ?? '',
+        mutateQueryParams:
+          testCase.config.mutate?.queryParams ??
+          testCase.config.push?.queryParams ??
+          {},
+        queryQueryParams: testCase.config.query?.queryParams ?? {},
+      }),
+    ).toString()}`;
+
+    // The idbName should start with the expected prefix
+    expect(zero.idbName, `Test case: ${testCase.name}`).toMatch(
+      new RegExp(`^${expectedName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`),
+    );
+
+    await zero.close();
+  }
+});

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -35,11 +35,7 @@ import {Subscribable} from '../../../shared/src/subscribable.ts';
 import * as valita from '../../../shared/src/valita.ts';
 import type {Writable} from '../../../shared/src/writable.ts';
 import {type ClientSchema} from '../../../zero-protocol/src/client-schema.ts';
-import type {
-  ConnectedMessage,
-  UserMutateParams,
-  UserQueryParams,
-} from '../../../zero-protocol/src/connect.ts';
+import type {ConnectedMessage} from '../../../zero-protocol/src/connect.ts';
 import {encodeSecProtocols} from '../../../zero-protocol/src/connect.ts';
 import type {DeleteClientsBody} from '../../../zero-protocol/src/delete-clients.ts';
 import type {Downstream} from '../../../zero-protocol/src/down.ts';
@@ -570,11 +566,8 @@ export class Zero<
     // Create a hash that includes storage key, URL configuration, and query parameters
     const nameKey = JSON.stringify({
       storageKey: this.storageKey,
-      mutateUrl: options.mutate?.url ?? options.push?.url ?? '',
-      queryUrl: options.query?.url ?? '',
-      mutateQueryParams:
-        options.mutate?.queryParams ?? options.push?.queryParams ?? {},
-      queryQueryParams: options.query?.queryParams ?? {},
+      mutateUrl: options.mutateURL ?? '',
+      queryUrl: options.getQueriesURL ?? '',
     });
     const hashedKey = h64(nameKey).toString(36);
 
@@ -1254,8 +1247,8 @@ export class Zero<
           // The clientSchema only needs to be sent for the very first request.
           // Henceforth it is stored with the CVR and verified automatically.
           ...(this.#connectCookie === null ? {clientSchema} : {}),
-          userPushParams: this.#options.mutate ?? this.#options.push,
-          userQueryParams: this.#options.query,
+          userPushURL: this.#options.mutateURL,
+          userQueryURL: this.#options.getQueriesURL,
         },
       ]);
       this.#deletedClients = undefined;
@@ -1350,8 +1343,8 @@ export class Zero<
       wsid,
       this.#options.logLevel === 'debug',
       lc,
-      this.#options.mutate ?? this.#options.push,
-      this.#options.query,
+      this.#options.mutateURL,
+      this.#options.getQueriesURL,
       this.#options.maxHeaderLength,
       additionalConnectParams,
       await this.#activeClientsManager,
@@ -2083,8 +2076,8 @@ export async function createSocket(
   wsid: string,
   debugPerf: boolean,
   lc: ZeroLogContext,
-  userPushParams: UserMutateParams | undefined,
-  userQueryParams: UserQueryParams | undefined,
+  userPushURL: string | undefined,
+  userQueryURL: string | undefined,
   maxHeaderLength = 1024 * 8,
   additionalConnectParams: Record<string, string> | undefined,
   activeClientsManager: Pick<ActiveClientsManager, 'activeClients'>,
@@ -2143,8 +2136,8 @@ export async function createSocket(
         // The clientSchema only needs to be sent for the very first request.
         // Henceforth it is stored with the CVR and verified automatically.
         ...(baseCookie === null ? {clientSchema} : {}),
-        userPushParams,
-        userQueryParams,
+        userPushURL,
+        userQueryURL,
         activeClients: [...activeClients],
       },
     ],

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -576,7 +576,7 @@ export class Zero<
         options.mutate?.queryParams ?? options.push?.queryParams ?? {},
       queryQueryParams: options.query?.queryParams ?? {},
     });
-    const hashedKey = h64(nameKey).toString();
+    const hashedKey = h64(nameKey).toString(36);
 
     const replicacheOptions: ReplicacheOptions<WithCRUD<MutatorDefs>> = {
       // The schema stored in IDB is dependent upon both the ClientSchema

--- a/packages/zero-protocol/src/connect.ts
+++ b/packages/zero-protocol/src/connect.ts
@@ -21,30 +21,14 @@ export const connectedMessageSchema = v.tuple([
   connectedBodySchema,
 ]);
 
-const userQueryMutateParamsSchema = v.object({
-  /**
-   * A client driven URL to send queries or mutations to.
-   * This URL must match one of the URLs set in the zero config.
-   *
-   * E.g., Given the following environment variable:
-   * ZERO_GET_QUERIES_URL=[https://*.example.com/query]
-   *
-   * Then this URL could be:
-   * https://myapp.example.com/query
-   */
-  url: v.string().optional(),
-  // The query string to use for query or mutation calls.
-  queryParams: v.record(v.string()).optional(),
-});
-
 const initConnectionBodySchema = v.object({
   desiredQueriesPatch: upQueriesPatchSchema,
   clientSchema: clientSchemaSchema.optional(),
   deleted: deleteClientsBodySchema.optional(),
   // parameters to configure the mutate endpoint
-  userPushParams: userQueryMutateParamsSchema.optional(),
+  userPushURL: v.string().optional(),
   // parameters to configure the query endpoint
-  userQueryParams: userQueryMutateParamsSchema.optional(),
+  userQueryURL: v.string().optional(),
 
   /**
    * `activeClients` is an optional array of client IDs that are currently active
@@ -62,9 +46,6 @@ export const initConnectionMessageSchema = v.tuple([
 
 export type ConnectedBody = v.Infer<typeof connectedBodySchema>;
 export type ConnectedMessage = v.Infer<typeof connectedMessageSchema>;
-export type UserMutateParams = v.Infer<typeof userQueryMutateParamsSchema>;
-export type UserQueryParams = v.Infer<typeof userQueryMutateParamsSchema>;
-
 export type InitConnectionBody = v.Infer<typeof initConnectionBodySchema>;
 export type InitConnectionMessage = v.Infer<typeof initConnectionMessageSchema>;
 

--- a/packages/zero-protocol/src/protocol-version.test.ts
+++ b/packages/zero-protocol/src/protocol-version.test.ts
@@ -11,6 +11,6 @@ test('protocol version', () => {
   // If this test fails upstream or downstream schema has changed such that
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
-  expect(hash).toEqual('by6x3866cbh9');
+  expect(hash).toEqual('3ebq2sj0qmcvv');
   expect(PROTOCOL_VERSION).toEqual(30);
 });


### PR DESCRIPTION
This PR allows users to customize the `mutate` and `get-queries` URLs on the client.

This functionality was always envisioned but it was broken in the current build and therefore not documented. 

The `mutate` version just wasn't wired up. But the `get-queries` version had a more fundamental problem: `get-queries` happens on behalf of a client-group, not a client. But we are configuring a client with the constructor param. So it was possible for `zero-cache` to get into a situation where it's doing a GET query fetch, but there are multiple clients having different values for the GET query customization URL. 

To fix this on the client, we incorporated the mutate URL, and the get-queries URL into the IDB name. The result is that changing these URLs gives a zero client a different client group ID. 

On the server, we simplified the communication and storage of these two URLs to be a single value in both the transform service, the pusher, and the view syncer because these services are all one-to-one with client groups. 

We also simplified the API and removed the ability to customize the query strings because by exposing the ability to customize the entire URL, we no longer need that and we removed all the supporting code that supported customizing the query strings. 

New unit tests were added where necessary, but I also tested manually that the functionality works in zbugs. 

Please review this PR carefully as it's a significant change and was implemented with the help of Claude Code. 