### PR TITLE
chore(zql): add a manual benchmark utility

### DIFF
--- a/packages/zql-benchmarks/package.json
+++ b/packages/zql-benchmarks/package.json
@@ -13,6 +13,7 @@
     "lint": "eslint --ext .ts,.tsx,.js,.jsx src/",
     "test": "vitest run --silent=false --disable-console-intercept",
     "test:watch": "vitest watch",
+    "bench": "vitest bench --disable-console-intercept --run",
     "bench:bmf": "BENCH_OUTPUT_FORMAT=json vitest bench --run --silent=false --disable-console-intercept 2>&1 | npx tsx ../shared/src/tool/mitata-json-to-bmf.ts",
     "bench:bmf:silent": "npm run bench:bmf --silent",
     "test-types": "vitest run --typecheck.only --no-browser.enabled",

--- a/packages/zql-benchmarks/src/chinook-manual-cases.bench.ts
+++ b/packages/zql-benchmarks/src/chinook-manual-cases.bench.ts
@@ -1,0 +1,35 @@
+import {bootstrap} from '../../zql-integration-tests/src/helpers/runner.ts';
+import {getChinook} from '../../zql-integration-tests/src/chinook/get-deps.ts';
+import {schema} from '../../zql-integration-tests/src/chinook/schema.ts';
+import {bench, run, summary} from 'mitata';
+import {expect, test} from 'vitest';
+
+const pgContent = await getChinook();
+
+const {queries} = await bootstrap({
+  suiteName: 'chinook_bench_exists',
+  zqlSchema: schema,
+  pgContent,
+});
+
+// Demonstration of how to compare two different query styles
+summary(() => {
+  bench('tracks with artist name : flipped', async () => {
+    await queries.sqlite.artist
+      .where('name', 'AC/DC')
+      .related('albums', a => a.related('tracks'));
+  });
+
+  bench('tracks with artist name : not flipped', async () => {
+    await queries.sqlite.track.whereExists('album', a =>
+      a.whereExists('artist', ar => ar.where('name', 'AC/DC')),
+    );
+  });
+});
+
+await run();
+
+// here so we can run with a vitest and get all the pg setup goodness
+test('noop', () => {
+  expect(true).toBe(true);
+});


### PR DESCRIPTION
Util to easily compare performance of query forms. Added a manual join flip case for demonstration.

Any benchmarks placed inside a `summary` block will be compared against one another

<img width="890" height="401" alt="CleanShot 2025-09-05 at 11 23 18" src="https://github.com/user-attachments/assets/d7f0a1df-0561-491d-84c9-08f55a95f37b" />


This'll be used to investigate various changes to memory storage, table storage, etc.