### PR TITLE
feat(zero): Add support for StandardSchema to synced queries.

### DIFF
--- a/apps/zbugs/api/index.ts
+++ b/apps/zbugs/api/index.ts
@@ -213,7 +213,7 @@ async function getQueriesHandler(
   await withAuth(request, reply, async authData => {
     reply.send(
       await handleGetQueriesRequest(
-        (name, args) => ({query: getQuery(authData, name, args)}),
+        (name, args) => getQuery(authData, name, args),
         schema,
         request.body,
       ),

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,6 +78,7 @@
         "remark-gfm": "^4.0.0",
         "use-debounce": "^10.0.4",
         "usehooks-ts": "^3.1.0",
+        "valibot": "^1.1.0",
         "wouter": "^3.7.1",
         "zod": "^3.21.4"
       },
@@ -807,6 +808,23 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@ark/schema": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@ark/schema/-/schema-0.49.0.tgz",
+      "integrity": "sha512-GphZBLpW72iS0v4YkeUtV3YIno35Gimd7+ezbPO9GwEi9kzdUrPVjvf6aXSBAfHikaFc/9pqZOpv3pOXnC71tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ark/util": "0.49.0"
+      }
+    },
+    "node_modules/@ark/util": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@ark/util/-/util-0.49.0.tgz",
+      "integrity": "sha512-/BtnX7oCjNkxi2vi6y1399b+9xd1jnCrDYhZ61f0a+3X8x8DxlK52VgEEzyuC2UQMPACIfYrmHkhD3lGt2GaMA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@aws-crypto/crc32": {
       "version": "5.2.0",
@@ -16039,6 +16057,17 @@
       "license": "Apache-2.0",
       "dependencies": {
         "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/arktype": {
+      "version": "2.1.22",
+      "resolved": "https://registry.npmjs.org/arktype/-/arktype-2.1.22.tgz",
+      "integrity": "sha512-xdzl6WcAhrdahvRRnXaNwsipCgHuNoLobRqhiP8RjnfL9Gp947abGlo68GAIyLtxbD+MLzNyH2YR4kEqioMmYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ark/schema": "0.49.0",
+        "@ark/util": "0.49.0"
       }
     },
     "node_modules/array-back": {
@@ -35475,6 +35504,20 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
     },
+    "node_modules/valibot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.1.0.tgz",
+      "integrity": "sha512-Nk8lX30Qhu+9txPYTwM0cFlWLdPFsFr6LblzqIySfbZph9+BFsAHsNvHOymEviUepeIW6KFHzpX8TKhbptBXXw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/validate-html-nesting": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/validate-html-nesting/-/validate-html-nesting-1.2.3.tgz",
@@ -36825,9 +36868,10 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.23.8",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -38663,13 +38707,15 @@
         "@rocicorp/logger": "^5.4.0",
         "@rocicorp/prettier-config": "^0.3.0",
         "@rocicorp/rails": "^0.10.0",
+        "arktype": "^2.1.22",
         "fast-check": "^3.18.0",
         "nanoid": "^5.1.2",
         "replicache": "15.2.1",
         "shared": "0.0.0",
         "typescript": "~5.8.2",
+        "valibot": "^1.1.0",
         "zero-protocol": "0.0.0",
-        "zod": "^3.21.4"
+        "zod": "^3.25.76"
       }
     },
     "packages/zql-benchmarks": {
@@ -39125,6 +39171,21 @@
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
       }
+    },
+    "@ark/schema": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@ark/schema/-/schema-0.49.0.tgz",
+      "integrity": "sha512-GphZBLpW72iS0v4YkeUtV3YIno35Gimd7+ezbPO9GwEi9kzdUrPVjvf6aXSBAfHikaFc/9pqZOpv3pOXnC71tw==",
+      "dev": true,
+      "requires": {
+        "@ark/util": "0.49.0"
+      }
+    },
+    "@ark/util": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@ark/util/-/util-0.49.0.tgz",
+      "integrity": "sha512-/BtnX7oCjNkxi2vi6y1399b+9xd1jnCrDYhZ61f0a+3X8x8DxlK52VgEEzyuC2UQMPACIfYrmHkhD3lGt2GaMA==",
+      "dev": true
     },
     "@aws-crypto/crc32": {
       "version": "5.2.0",
@@ -49144,6 +49205,16 @@
       "dev": true,
       "requires": {
         "dequal": "^2.0.3"
+      }
+    },
+    "arktype": {
+      "version": "2.1.22",
+      "resolved": "https://registry.npmjs.org/arktype/-/arktype-2.1.22.tgz",
+      "integrity": "sha512-xdzl6WcAhrdahvRRnXaNwsipCgHuNoLobRqhiP8RjnfL9Gp947abGlo68GAIyLtxbD+MLzNyH2YR4kEqioMmYQ==",
+      "dev": true,
+      "requires": {
+        "@ark/schema": "0.49.0",
+        "@ark/util": "0.49.0"
       }
     },
     "array-back": {
@@ -62599,6 +62670,12 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
     },
+    "valibot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.1.0.tgz",
+      "integrity": "sha512-Nk8lX30Qhu+9txPYTwM0cFlWLdPFsFr6LblzqIySfbZph9+BFsAHsNvHOymEviUepeIW6KFHzpX8TKhbptBXXw==",
+      "requires": {}
+    },
     "validate-html-nesting": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/validate-html-nesting/-/validate-html-nesting-1.2.3.tgz",
@@ -63456,6 +63533,7 @@
         "universal-user-agent": "^7.0.2",
         "use-debounce": "^10.0.4",
         "usehooks-ts": "^3.1.0",
+        "valibot": "^1.1.0",
         "vite": "6.2.1",
         "vite-bundle-analyzer": "^0.17.3",
         "vite-plugin-svgr": "^4.3.0",
@@ -64138,9 +64216,9 @@
       }
     },
     "zod": {
-      "version": "3.23.8",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g=="
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
     },
     "zql": {
       "version": "file:packages/zql",
@@ -64151,14 +64229,16 @@
         "@rocicorp/prettier-config": "^0.3.0",
         "@rocicorp/rails": "^0.10.0",
         "@rocicorp/resolver": "^1.0.2",
+        "arktype": "^2.1.22",
         "compare-utf8": "^0.1.1",
         "fast-check": "^3.18.0",
         "nanoid": "^5.1.2",
         "replicache": "15.2.1",
         "shared": "0.0.0",
         "typescript": "~5.8.2",
+        "valibot": "^1.1.0",
         "zero-protocol": "0.0.0",
-        "zod": "^3.21.4"
+        "zod": "^3.25.76"
       },
       "dependencies": {
         "fast-check": {

--- a/packages/shared/src/standard-schema.ts
+++ b/packages/shared/src/standard-schema.ts
@@ -1,0 +1,68 @@
+/** The Standard Schema interface. */
+export interface StandardSchemaV1<Input = unknown, Output = Input> {
+  /** The Standard Schema properties. */
+  readonly '~standard': Props<Input, Output>;
+}
+
+/** The Standard Schema properties interface. */
+export interface Props<Input = unknown, Output = Input> {
+  /** The version number of the standard. */
+  readonly version: 1;
+  /** The vendor name of the schema library. */
+  readonly vendor: string;
+  /** Validates unknown input values. */
+  readonly validate: (
+    value: unknown,
+  ) => Result<Output> | Promise<Result<Output>>;
+  /** Inferred types associated with the schema. */
+  readonly types?: Types<Input, Output> | undefined;
+}
+
+/** The result interface of the validate function. */
+export type Result<Output> = SuccessResult<Output> | FailureResult;
+
+/** The result interface if validation succeeds. */
+export interface SuccessResult<Output> {
+  /** The typed output value. */
+  readonly value: Output;
+  /** The non-existent issues. */
+  readonly issues?: undefined;
+}
+
+/** The result interface if validation fails. */
+export interface FailureResult {
+  /** The issues of failed validation. */
+  readonly issues: ReadonlyArray<Issue>;
+}
+
+/** The issue interface of the failure output. */
+export interface Issue {
+  /** The error message of the issue. */
+  readonly message: string;
+  /** The path of the issue, if any. */
+  readonly path?: ReadonlyArray<PropertyKey | PathSegment> | undefined;
+}
+
+/** The path segment interface of the issue. */
+export interface PathSegment {
+  /** The key representing a path segment. */
+  readonly key: PropertyKey;
+}
+
+/** The Standard Schema types interface. */
+export interface Types<Input = unknown, Output = Input> {
+  /** The input type of the schema. */
+  readonly input: Input;
+  /** The output type of the schema. */
+  readonly output: Output;
+}
+
+/** Infers the input type of a Standard Schema. */
+export type InferInput<Schema extends StandardSchemaV1> = NonNullable<
+  Schema['~standard']['types']
+>['input'];
+
+/** Infers the output type of a Standard Schema. */
+export type InferOutput<Schema extends StandardSchemaV1> = NonNullable<
+  Schema['~standard']['types']
+>['output'];

--- a/packages/zql/package.json
+++ b/packages/zql/package.json
@@ -19,13 +19,15 @@
     "@rocicorp/logger": "^5.4.0",
     "@rocicorp/prettier-config": "^0.3.0",
     "@rocicorp/rails": "^0.10.0",
+    "arktype": "^2.1.22",
     "fast-check": "^3.18.0",
     "nanoid": "^5.1.2",
     "replicache": "15.2.1",
     "shared": "0.0.0",
     "typescript": "~5.8.2",
+    "valibot": "^1.1.0",
     "zero-protocol": "0.0.0",
-    "zod": "^3.21.4"
+    "zod": "^3.25.76"
   },
   "eslintConfig": {
     "extends": "../../eslint-config.json"

--- a/packages/zql/src/query/named.test.ts
+++ b/packages/zql/src/query/named.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import {expect, expectTypeOf, test} from 'vitest';
+import {expect, expectTypeOf, test, describe} from 'vitest';
 import {
   createBuilder,
   syncedQuery,
@@ -10,8 +10,11 @@ import {schema} from './test/test-schemas.ts';
 const builder = createBuilder(schema);
 import * as v from '../../../shared/src/valita.ts';
 import {ast} from './query-impl.ts';
+import * as valibot from 'valibot';
+import {type} from 'arktype';
+import * as z from 'zod';
 
-test('syncedQuery', () => {
+test('syncedQuery', async () => {
   const idArgs = v.tuple([v.string()]);
   const def = syncedQuery('myQuery', idArgs, (id: string) =>
     builder.issue.where('id', id),
@@ -58,13 +61,11 @@ test('syncedQuery', () => {
 
   const wv = withValidation(def);
   expect(wv.queryName).toEqual('myQuery');
-  expect(wv.parse).toBeDefined();
-  expect(wv.takesContext).toEqual(true);
-  expect(() => wv('ignored', 123)).toThrow(
+  await expect(() => wv('ignored', 123)).rejects.toThrow(
     'invalid_type at .0 (expected string)',
   );
 
-  const vq = wv('ignored', '123');
+  const vq = (await wv('ignored', '123')).query;
   expectTypeOf<ReturnType<typeof vq.run>>().toEqualTypeOf<
     Promise<
       {
@@ -101,7 +102,7 @@ test('syncedQuery', () => {
   });
 });
 
-test('syncedQueryWithContext', () => {
+test('syncedQueryWithContext', async () => {
   const idArgs = v.tuple([v.string()]);
   const def = syncedQueryWithContext(
     'myQuery',
@@ -168,13 +169,11 @@ test('syncedQueryWithContext', () => {
 
   const wv = withValidation(def);
   expect(wv.queryName).toEqual('myQuery');
-  expect(wv.parse).toBeDefined();
-  expect(wv.takesContext).toEqual(true);
-  expect(() => wv('ignored', 123)).toThrow(
+  await expect(() => wv('ignored', 123)).rejects.toThrow(
     'invalid_type at .0 (expected string)',
   );
 
-  const vq = wv('user1', '123');
+  const vq = (await wv('user1', '123')).query;
   expectTypeOf<ReturnType<typeof vq.run>>().toEqualTypeOf<
     Promise<
       {
@@ -250,4 +249,143 @@ test('makeSchemaQuery', () => {
       },
     }
   `);
+});
+
+describe('Schema compatibility (StandardSchemaV1 and HasParseFn)', () => {
+  const testCases = [
+    {
+      name: 'Valibot (StandardSchemaV1) with syncedQuery',
+      parser: valibot.tuple([valibot.string(), valibot.number()]),
+      validArgs: ['test', 123],
+      invalidArgs: [123, 'test'],
+      expectedError: 'Invalid type: Expected string but received 123',
+      queryFn: (arg1: string, arg2: number) =>
+        builder.issue.where('id', arg1).where('createdAt', '>', arg2),
+    },
+    {
+      name: 'Arktype (StandardSchemaV1) with syncedQuery',
+      parser: type(['string', 'number']),
+      validArgs: ['test', 456],
+      invalidArgs: ['test', 'not-a-number'],
+      expectedError: 'must be a number \\(was a string\\)',
+      queryFn: (arg1: string, arg2: number) =>
+        builder.issue.where('id', arg1).where('createdAt', '>', arg2),
+    },
+    {
+      name: 'Zod 3 (HasParseFn) with syncedQuery',
+      parser: z.tuple([z.string(), z.number()]),
+      validArgs: ['test', 789],
+      invalidArgs: [999, 'test'],
+      expectedError: 'Expected string, received number',
+      queryFn: (arg1: string, arg2: number) =>
+        builder.issue.where('id', arg1).where('createdAt', '>', arg2),
+    },
+  ];
+
+  testCases.forEach(
+    ({name, parser, validArgs, invalidArgs, expectedError, queryFn}) => {
+      test(name, async () => {
+        const def = syncedQuery('testQuery', parser as any, queryFn as any);
+
+        expect(def.queryName).toEqual('testQuery');
+        expect(def.parse).toBeDefined();
+        expect(def.takesContext).toEqual(false);
+
+        const q = def(...validArgs);
+        expect(q.customQueryID).toEqual({
+          name: 'testQuery',
+          args: validArgs,
+        });
+
+        const wv = withValidation(def);
+        expect(wv.queryName).toEqual('testQuery');
+
+        await expect(() => wv('ignored', ...invalidArgs)).rejects.toThrow(
+          new RegExp(expectedError),
+        );
+
+        const vq = (await wv('ignored', ...validArgs)).query;
+        expect(vq.customQueryID).toEqual({
+          name: 'testQuery',
+          args: validArgs,
+        });
+      });
+    },
+  );
+});
+
+describe('Schema compatibility (StandardSchemaV1 and HasParseFn) with context', () => {
+  const testCases = [
+    {
+      name: 'Valibot (StandardSchemaV1) with syncedQueryWithContext',
+      parser: valibot.tuple([valibot.string(), valibot.number()]),
+      validArgs: ['test', 789],
+      invalidArgs: [true, 789],
+      expectedError: 'Invalid type: Expected string but received true',
+      queryFn: (context: string, arg1: string, arg2: number) =>
+        builder.issue
+          .where('ownerId', context)
+          .where('id', arg1)
+          .where('createdAt', '>', arg2),
+    },
+    {
+      name: 'Arktype (StandardSchemaV1) with syncedQueryWithContext',
+      parser: type(['string', 'number']),
+      validArgs: ['test', 321],
+      invalidArgs: [null, 321],
+      expectedError: 'must be a string',
+      queryFn: (context: string, arg1: string, arg2: number) =>
+        builder.issue
+          .where('ownerId', context)
+          .where('id', arg1)
+          .where('createdAt', '>', arg2),
+    },
+    {
+      name: 'Zod 3 (HasParseFn) with syncedQueryWithContext',
+      parser: z.tuple([z.string(), z.number()]),
+      validArgs: ['test', 654],
+      invalidArgs: [false, 654],
+      expectedError: 'Expected string, received boolean',
+      queryFn: (context: string, arg1: string, arg2: number) =>
+        builder.issue
+          .where('ownerId', context)
+          .where('id', arg1)
+          .where('createdAt', '>', arg2),
+    },
+  ];
+
+  testCases.forEach(
+    ({name, parser, validArgs, invalidArgs, expectedError, queryFn}) => {
+      test(name, async () => {
+        const def = syncedQueryWithContext(
+          'testQueryWithContext',
+          parser as any,
+          queryFn as any,
+        );
+
+        expect(def.queryName).toEqual('testQueryWithContext');
+        expect(def.parse).toBeDefined();
+        expect(def.takesContext).toEqual(true);
+
+        const q = def('context1', ...validArgs);
+        expect(q.customQueryID).toEqual({
+          name: 'testQueryWithContext',
+          args: validArgs,
+        });
+
+        const wv = withValidation(def);
+        expect(wv.queryName).toEqual('testQueryWithContext');
+
+        await expect(() => wv('context1', ...invalidArgs)).rejects.toThrow(
+          new RegExp(expectedError),
+        );
+
+        const vq = (await wv('context1', ...validArgs)).query;
+        expect(vq.customQueryID).toEqual({
+          name: 'testQueryWithContext',
+          args: validArgs,
+        });
+      });
+    },
+  );
 });


### PR DESCRIPTION
This was surprisingly difficult because StandardSchema supports async validation. This meant that SyncedQuery needed to get forked into ValidatedQuery, but fortunately that didn't spiral too far.

The other crazy unfortunate collision was that the async validation means that `withValidation` becomes async. But the return value `withValidation` is a query. And queries themselves are promise-like. This means that when code that calls `withValidation` uses await, it will unwrap recursively because that's what await does.

The result is that awaiting the result of `withValidation` in order to return the query over the http response actually tries to run the query.

The one lucky break was that `handleGetQueriesRequest` actually wants {query: Q}, not Q as an input. So I was able to leverage that and have `withValidation` return that shape not a raw query. This stops the recursive unwrapping of promises from happening. I think the previous API was actually better, but it's the best I could think of.

We probably need to remove the ability to run queries directly, as we've now added zero.run and friends. But we cannot do that until we add tx.run. That will likely have usability impacts on reading data inside transactions.