### PR TITLE
refactor(zql): extract query execution into separate run.ts module

### DIFF
--- a/packages/zero-solid/src/use-query.test.tsx
+++ b/packages/zero-solid/src/use-query.test.tsx
@@ -22,7 +22,8 @@ import {
 } from '../../zero/src/zero.ts';
 import {MemorySource} from '../../zql/src/ivm/memory-source.ts';
 import {idSymbol, refCountSymbol} from '../../zql/src/ivm/view-apply-change.ts';
-import {materialize, newQuery} from '../../zql/src/query/query-impl.ts';
+import {newQuery, type AnyQuery} from '../../zql/src/query/query-impl.ts';
+import {materializeQuery} from '../../zql/src/query/run.ts';
 import {QueryDelegateImpl} from '../../zql/src/query/test/query-delegate.ts';
 import {useQuery, type UseQueryOptions} from './use-query.ts';
 import {ZeroProvider} from './use-zero.ts';
@@ -72,7 +73,20 @@ function newMockZero(
       | undefined,
     maybeOptions?: MaterializeOptions | undefined,
   ) {
-    return materialize(query, queryDelegate, factoryOrOptions, maybeOptions);
+    if (typeof factoryOrOptions === 'function') {
+      return materializeQuery(
+        queryDelegate,
+        query as AnyQuery,
+        factoryOrOptions,
+        maybeOptions?.ttl,
+      );
+    }
+    return materializeQuery(
+      queryDelegate,
+      query as AnyQuery,
+      undefined,
+      factoryOrOptions?.ttl,
+    );
   }
   return {
     clientID,

--- a/packages/zql-integration-tests/src/v20-array-style.test.ts
+++ b/packages/zql-integration-tests/src/v20-array-style.test.ts
@@ -10,7 +10,7 @@ import {
   table,
 } from '../../zero-schema/src/builder/table-builder.ts';
 import {createBuilder} from '../../zql/src/query/named.ts';
-import {delegateSymbol} from '../../zql/src/query/query.ts';
+import {runQuery} from '../../zql/src/query/run.ts';
 
 test('reading from old array style tables', async () => {
   const lc = createSilentLogContext();
@@ -46,7 +46,7 @@ test('reading from old array style tables', async () => {
   const d = newQueryDelegate(lc, testLogConfig, sqlite, schema);
   const queries = createBuilder(schema);
 
-  const rows = await queries.bar[delegateSymbol](d).run();
+  const rows = await runQuery(d, queries.bar);
   expect(rows).toMatchInlineSnapshot(`
     [
       {

--- a/packages/zql/src/query/query.ts
+++ b/packages/zql/src/query/query.ts
@@ -12,7 +12,6 @@ import type {
 import type {Format, ViewFactory} from '../ivm/view.ts';
 import type {ExpressionFactory, ParameterReference} from './expression.ts';
 import type {CustomQueryID} from './named.ts';
-import type {QueryDelegate} from './query-delegate.ts';
 import type {TTL} from './ttl.ts';
 import type {TypedView} from './typed-view.ts';
 
@@ -36,7 +35,6 @@ type ArraySelectors<E extends TableSchema> = {
 
 export type QueryReturn<Q> = Q extends Query<any, any, infer R> ? R : never;
 export type QueryTable<Q> = Q extends Query<any, infer T, any> ? T : never;
-export const delegateSymbol = Symbol('delegate');
 
 export type GetFilterType<
   TSchema extends TableSchema,
@@ -170,13 +168,13 @@ export interface Query<
    */
   hash(): string;
   readonly ast: AST;
+  completedAST(): AST;
   readonly customQueryID: CustomQueryID | undefined;
 
   nameAndArgs(
     name: string,
     args: ReadonlyArray<ReadonlyJSONValue>,
   ): Query<TSchema, TTable, TReturn>;
-  [delegateSymbol](delegate: QueryDelegate): Query<TSchema, TTable, TReturn>;
 
   /**
    * Related is used to add a related query to the current query. This is used

--- a/packages/zql/src/query/run.ts
+++ b/packages/zql/src/query/run.ts
@@ -1,0 +1,212 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {resolver} from '@rocicorp/resolver';
+import {hashOfNameAndArgs} from '../../../zero-protocol/src/query-hash.ts';
+import type {Schema} from '../../../zero-schema/src/builder/schema-builder.ts';
+import {buildPipeline} from '../builder/builder.ts';
+import {ArrayView} from '../ivm/array-view.ts';
+import type {Input} from '../ivm/operator.ts';
+import type {Format, ViewFactory} from '../ivm/view.ts';
+import type {GotCallback, QueryDelegate} from './query-delegate.ts';
+import type {AbstractQuery} from './query-impl.ts';
+import {
+  type HumanReadable,
+  type PreloadOptions,
+  type Query,
+  type RunOptions,
+} from './query.ts';
+import {DEFAULT_PRELOAD_TTL_MS, DEFAULT_TTL_MS, type TTL} from './ttl.ts';
+import type {TypedView} from './typed-view.ts';
+
+export function runQuery<
+  TSchema extends Schema,
+  TTable extends string,
+  TReturn,
+>(
+  delegate: QueryDelegate,
+  query: Query<TSchema, TTable, TReturn>,
+  options?: RunOptions,
+): Promise<HumanReadable<TReturn>> {
+  delegate.assertValidRunOptions(options);
+
+  const v = materializeQuery(delegate, query, options?.ttl) as TypedView<
+    HumanReadable<TReturn>
+  >;
+
+  if (options?.type === 'complete') {
+    return new Promise(resolve => {
+      v.addListener((data, type) => {
+        if (type === 'complete') {
+          v.destroy();
+          resolve(data as HumanReadable<TReturn>);
+        } else if (type === 'error') {
+          v.destroy();
+          resolve(Promise.reject(data));
+        }
+      });
+    });
+  }
+
+  options?.type satisfies 'unknown' | undefined;
+
+  const ret = v.data;
+  v.destroy();
+  return Promise.resolve(ret);
+}
+
+export function materializeQuery<
+  TSchema extends Schema,
+  TTable extends string,
+  TReturn,
+  T,
+>(
+  delegate: QueryDelegate,
+  query: Query<TSchema, TTable, TReturn>,
+  factoryOrTTL?: ViewFactory<TSchema, TTable, TReturn, T> | TTL,
+  ttl: TTL = DEFAULT_TTL_MS,
+): T | TypedView<HumanReadable<TReturn>> {
+  let factory: ViewFactory<TSchema, TTable, TReturn, T> | undefined;
+  if (typeof factoryOrTTL === 'function') {
+    factory = factoryOrTTL;
+  } else {
+    ttl = factoryOrTTL ?? DEFAULT_TTL_MS;
+  }
+
+  const ast = query.completedAST();
+  const queryID = query.customQueryID
+    ? hashOfNameAndArgs(query.customQueryID.name, query.customQueryID.args)
+    : query.hash();
+  const queryCompleteResolver = resolver<true>();
+  let queryComplete = delegate.defaultQueryComplete;
+
+  const updateTTL = (newTTL: TTL) => {
+    query.customQueryID
+      ? delegate.updateCustomQuery(query.customQueryID, newTTL)
+      : delegate.updateServerQuery(ast, newTTL);
+  };
+
+  const gotCallback: GotCallback = (got, error) => {
+    if (error) {
+      queryCompleteResolver.reject(error);
+      queryComplete = true;
+      return;
+    }
+
+    if (got) {
+      delegate.addMetric(
+        'query-materialization-end-to-end',
+        performance.now() - t0,
+        queryID,
+        ast,
+      );
+      queryComplete = true;
+      queryCompleteResolver.resolve(true);
+    }
+  };
+
+  let removeCommitObserver: (() => void) | undefined;
+  const onDestroy = () => {
+    input.destroy();
+    removeCommitObserver?.();
+    removeAddedQuery();
+  };
+
+  const t0 = performance.now();
+
+  const removeAddedQuery = query.customQueryID
+    ? delegate.addCustomQuery(ast, query.customQueryID, ttl, gotCallback)
+    : delegate.addServerQuery(ast, ttl, gotCallback);
+
+  const input = buildPipeline(ast, delegate, queryID);
+
+  const view = delegate.batchViewUpdates(() =>
+    (factory ?? arrayViewFactory)(
+      query as AbstractQuery<TSchema, TTable, TReturn>,
+      input,
+      query.format,
+      onDestroy,
+      cb => {
+        removeCommitObserver = delegate.onTransactionCommit(cb);
+      },
+      queryComplete || queryCompleteResolver.promise,
+      updateTTL,
+    ),
+  );
+
+  delegate.addMetric(
+    'query-materialization-client',
+    performance.now() - t0,
+    queryID,
+  );
+
+  return view as T;
+}
+
+export function preloadQuery<
+  TSchema extends Schema,
+  TTable extends string,
+  TReturn,
+>(
+  delegate: QueryDelegate,
+  query: Query<TSchema, TTable, TReturn>,
+  options?: PreloadOptions,
+): {
+  cleanup: () => void;
+  complete: Promise<void>;
+} {
+  const ttl = options?.ttl ?? DEFAULT_PRELOAD_TTL_MS;
+  const ast = query.completedAST();
+  const {resolve, promise: complete} = resolver<void>();
+
+  if (query.customQueryID) {
+    const cleanup = delegate.addCustomQuery(
+      ast,
+      query.customQueryID,
+      ttl,
+      got => {
+        if (got) {
+          resolve();
+        }
+      },
+    );
+    return {
+      cleanup,
+      complete,
+    };
+  }
+
+  const cleanup = delegate.addServerQuery(ast, ttl, got => {
+    if (got) {
+      resolve();
+    }
+  });
+  return {
+    cleanup,
+    complete,
+  };
+}
+
+function arrayViewFactory<
+  TSchema extends Schema,
+  TTable extends string,
+  TReturn,
+>(
+  _query: AbstractQuery<TSchema, TTable, TReturn>,
+  input: Input,
+  format: Format,
+  onDestroy: () => void,
+  onTransactionCommit: (cb: () => void) => void,
+  queryComplete: true | Promise<true>,
+  updateTTL: (ttl: TTL) => void,
+): TypedView<HumanReadable<TReturn>> {
+  const v = new ArrayView<HumanReadable<TReturn>>(
+    input,
+    format,
+    queryComplete,
+    updateTTL,
+  );
+  v.onDestroy = onDestroy;
+  onTransactionCommit(() => {
+    v.flush();
+  });
+  return v;
+}


### PR DESCRIPTION
For discussion. At first I felt like this refactor was necessary but as I got to understand the code more, it seemed less-so. Basically what it does is move the 'execution methods' (run, preload, materialize) into separate bare functions and make the Query objects dumber.

There is no actual problem w/ current code however. @grgbkr do you see any value to this refactor?