### PR TITLE
fix(zero-cache): start with smaller CVR purge sizes, make configurable

### DIFF
--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -122,6 +122,20 @@ test('zero-cache --help', () => {
                                                                    Note that garbage collection is an incremental, periodic process which does not                   
                                                                    necessarily purge all eligible CVRs immediately.                                                  
                                                                                                                                                                      
+     --cvr-garbage-collection-initial-interval-seconds number      default: 60                                                                                       
+       ZERO_CVR_GARBAGE_COLLECTION_INITIAL_INTERVAL_SECONDS env                                                                                                      
+                                                                   The initial interval at which to check and garbage collect inactive CVRs.                         
+                                                                   This interval is increased exponentially (up to 16 minutes) when there is                         
+                                                                   nothing to purge.                                                                                 
+                                                                                                                                                                     
+     --cvr-garbage-collection-initial-batch-size number            default: 25                                                                                       
+       ZERO_CVR_GARBAGE_COLLECTION_INITIAL_BATCH_SIZE env                                                                                                            
+                                                                   The initial number of CVRs to purge per garbage collection interval.                              
+                                                                   This number is increased linearly if the rate of new CVRs exceeds the rate of                     
+                                                                   purged CVRs, in order to reach a steady state.                                                    
+                                                                                                                                                                     
+                                                                   Setting this to 0 effectively disables CVR garbage collection.                                    
+                                                                                                                                                                     
      --query-hydration-stats boolean                               optional                                                                                          
        ZERO_QUERY_HYDRATION_STATS env                                                                                                                                
                                                                    Track and log the number of rows considered by query hydrations which                             

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -275,6 +275,26 @@ export const zeroOptions = {
         `necessarily purge all eligible CVRs immediately.`,
       ],
     },
+
+    garbageCollectionInitialIntervalSeconds: {
+      type: v.number().default(60),
+      desc: [
+        `The initial interval at which to check and garbage collect inactive CVRs.`,
+        `This interval is increased exponentially (up to 16 minutes) when there is`,
+        `nothing to purge.`,
+      ],
+    },
+
+    garbageCollectionInitialBatchSize: {
+      type: v.number().default(25),
+      desc: [
+        `The initial number of CVRs to purge per garbage collection interval.`,
+        `This number is increased linearly if the rate of new CVRs exceeds the rate of`,
+        `purged CVRs, in order to reach a steady state.`,
+        ``,
+        `Setting this to 0 effectively disables CVR garbage collection.`,
+      ],
+    },
   },
 
   queryHydrationStats: {

--- a/packages/zero-cache/src/server/reaper.ts
+++ b/packages/zero-cache/src/server/reaper.ts
@@ -38,12 +38,12 @@ export default async function runWorker(
   return runUntilKilled(
     lc,
     parent,
-    new CVRPurger(
-      lc,
-      cvrDB,
-      shard,
-      cvr.garbageCollectionInactivityThresholdHours * MS_PER_HOUR,
-    ),
+    new CVRPurger(lc, cvrDB, shard, {
+      inactivityThresholdMs:
+        cvr.garbageCollectionInactivityThresholdHours * MS_PER_HOUR,
+      initialBatchSize: cvr.garbageCollectionInitialBatchSize,
+      initialIntervalMs: cvr.garbageCollectionInitialIntervalSeconds * 1000,
+    }),
   );
 }
 

--- a/packages/zero-cache/src/services/view-syncer/cvr-purger.pg-test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-purger.pg-test.ts
@@ -91,7 +91,11 @@ describe('view-syncer/cvr', () => {
     cvrDb = await testDBs.create('cvr_purger_test_db');
     await cvrDb.begin(tx => setupCVRTables(lc, tx, SHARD));
 
-    purger = new CVRPurger(lc, cvrDb, SHARD, INACTIVITY_THRESHOLD_MS);
+    purger = new CVRPurger(lc, cvrDb, SHARD, {
+      inactivityThresholdMs: INACTIVITY_THRESHOLD_MS,
+      initialBatchSize: 25,
+      initialIntervalMs: 60000,
+    });
 
     for (const [clientGroupID, lastActive] of [
       ['new-1', Date.now()],


### PR DESCRIPTION
Default to a smaller CVR purge batch size (now 25 instead of 1000), and make CVR purging more generally configurable with two new options:
* `ZERO_CVR_GARBAGE_COLLECTION_INITIAL_BATCH_SIZE`
* `ZERO_CVR_GARBAGE_COLLECTION_INITIAL_INTERVAL_SECONDS`


Users should generally not need to tune these as the logic is adaptive, but they are made available in case tuning is desired. Notably, garbage collection can be disabled entirely by setting the batch size to 0.

The large initial batch size of 1000 can take a long time for apps with large CVRs, causing "returning" CVRs that are in the process of being purged in being locked out. (Detecting and responding to loading being-purged CVRs is forthcoming in a separate PR).

User report:

* https://discord.com/channels/830183651022471199/1288232858795769917/1414648438393536773