### PR TITLE
fix(react): view caching race condition

### DIFF
--- a/packages/zero-react/src/use-query.tsx
+++ b/packages/zero-react/src/use-query.tsx
@@ -12,7 +12,6 @@ import {DEFAULT_TTL_MS, type TTL} from '../../zql/src/query/ttl.ts';
 import type {ResultType, TypedView} from '../../zql/src/query/typed-view.ts';
 import {useZero} from './zero-provider.tsx';
 import type {ErroredQuery} from '../../zero-protocol/src/custom-queries.ts';
-import {assert} from '../../shared/src/asserts.ts';
 
 export type QueryResultDetails = Readonly<
   | {


### PR DESCRIPTION
For some reason we were replacing the view in the view store when `onMaterialized` was called.

There's no need for this. All we need is a valid view in the view store which we have as soon as we create the view. Now we only remove from the map when a view is destroyed.

user report: https://discord.com/channels/830183651022471199/1415395645203812424/1415395649205305434

Trying on having Claude review changes as well.

# Claude Review


  Key Changes Made:

  1. Removed the onMaterialized callback entirely (lines 375-382 in the new version)
    - The ViewWrapper constructor no longer takes an onMaterialized parameter
    - The problematic error throw on line 385 is completely removed
    - The onDematerialized callback now directly deletes from the map
  2. Removed the #materializeIfNeeded call from onDematerialized (line 521)
    - The callback no longer tries to re-add the view to the store
  3. Added assertion in destroy() method (lines 540-543)
    - Ensures views are not destroyed while they still have listeners
  4. Refactored cleanup logic (lines 529-530)
    - Calls this.destroy() directly instead of inline cleanup

  Analysis:

  ✅ This SHOULD resolve the "View already exists" error because:

  1. Eliminates the race condition entirely - The error was thrown in the onMaterialized callback when checking if a
  different view already existed. By removing this callback and the check, the error can no longer occur.
  2. Simplifies the lifecycle - Views are now added to the store immediately when created (line 383) and removed when
  destroyed (line 381), with no intermediate re-registration step.
  3. Maintains single ownership - Each ViewWrapper is added to the store exactly once when created and removed exactly
  once when destroyed.

  ✅ Correctness appears maintained because:

  1. Reference counting still works - The #reactInternals Set still tracks all React listeners
  2. Cleanup timing preserved - The 10ms setTimeout delay for cleanup is maintained
  3. View reuse still works - Existing views are still returned and their TTL updated (lines 384-386)
  4. Assertion adds safety - The new assertion ensures views aren't destroyed while in use

  Potential Concerns:

  1. Strict Mode behavior - The original design with onMaterialized seemed intended to handle React Strict Mode's
  mount/unmount/remount cycle. The new approach should still work since:
    - The view stays in the store between rapid unmount/remount cycles
    - The 10ms delay gives time for remounting to occur
    - If a component remounts, it will find and reuse the existing ViewWrapper
  2. Memory management - Views might stay in the store slightly longer, but the cleanup mechanism via onDematerialized
  still ensures they're removed when truly unused.

  Conclusion: Yes, these changes should resolve the "View already exists" error while maintaining correctness. The
  simplified lifecycle eliminates the race condition that caused the error, and the core functionality of view
  management, reference counting, and cleanup remains intact.