### PR TITLE
chore(zero): Add analyze to inspector query

### DIFF
--- a/packages/analyze-query/package.json
+++ b/packages/analyze-query/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "check-types": "tsc",
+    "check-types:watch": "tsc --watch",
     "format": "prettier --write .",
     "check-format": "prettier --check .",
     "lint": "eslint --ext .ts,.tsx,.js,.jsx src/"

--- a/packages/analyze-query/src/explain-queries.ts
+++ b/packages/analyze-query/src/explain-queries.ts
@@ -1,4 +1,4 @@
-import type {RowCountsBySource} from '../../zql/src/builder/debug-delegate.ts';
+import type {RowCountsBySource} from '../../zero-protocol/src/analyze-query-result.ts';
 import type {Database} from '../../zqlite/src/db.ts';
 
 export function explainQueries(counts: RowCountsBySource, db: Database) {

--- a/packages/zero-cache/src/server/inspector-delegate.ts
+++ b/packages/zero-cache/src/server/inspector-delegate.ts
@@ -98,10 +98,7 @@ export class InspectorDelegate implements MetricsDelegate {
    * per "worker".
    */
   isAuthenticated(clientGroupID: ClientGroupID): boolean {
-    if (isDevelopmentMode()) {
-      return true;
-    }
-    return authenticatedClientIDs.has(clientGroupID);
+    return isDevelopmentMode() || authenticatedClientIDs.has(clientGroupID);
   }
 
   setAuthenticated(clientGroupID: ClientGroupID): void {

--- a/packages/zero-cache/src/services/analyze.test.ts
+++ b/packages/zero-cache/src/services/analyze.test.ts
@@ -1,0 +1,390 @@
+import {beforeEach, describe, expect, test, vi} from 'vitest';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import type {AnalyzeQueryResult} from '../../../zero-protocol/src/analyze-query-result.ts';
+import type {AST} from '../../../zero-protocol/src/ast.ts';
+import type {NormalizedZeroConfig} from '../config/normalize.ts';
+import {analyzeQuery} from './analyze.ts';
+
+// Mock the runAst function
+vi.mock('../../../analyze-query/src/run-ast.ts', () => ({
+  runAst: vi.fn(),
+}));
+
+// Mock the explainQueries function
+vi.mock('../../../analyze-query/src/explain-queries.ts', () => ({
+  explainQueries: vi.fn(),
+}));
+
+// Mock Database
+vi.mock('../../../zqlite/src/db.ts', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  Database: vi.fn().mockImplementation(() => ({})),
+}));
+
+// Mock computeZqlSpecs
+vi.mock('../db/lite-tables.ts', () => ({
+  computeZqlSpecs: vi.fn(),
+  mustGetTableSpec: vi.fn(),
+}));
+
+// Mock MemoryStorage
+vi.mock('../../../zql/src/ivm/memory-storage.ts', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  MemoryStorage: vi.fn(),
+}));
+
+// Mock TableSource
+vi.mock('../../../zqlite/src/table-source.ts', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  TableSource: vi.fn(),
+}));
+
+// Mock Debug
+vi.mock('../../../zql/src/builder/debug-delegate.ts', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  Debug: vi.fn(),
+}));
+
+describe('analyzeQuery', () => {
+  const lc = createSilentLogContext();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const mockConfig: NormalizedZeroConfig = {
+    replica: {
+      file: '/path/to/replica.db',
+    },
+    log: {
+      level: 'error',
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+
+  const simpleAST: AST = {
+    table: 'users',
+  };
+
+  test('analyzes basic query with default options', async () => {
+    const {runAst} = await import('../../../analyze-query/src/run-ast.ts');
+    const {explainQueries} = await import(
+      '../../../analyze-query/src/explain-queries.ts'
+    );
+
+    const mockResult: AnalyzeQueryResult = {
+      warnings: [],
+      syncedRowCount: 5,
+      start: 1000,
+      end: 1050,
+      vendedRowCounts: {
+        users: {
+          'SELECT * FROM users': 5,
+        },
+      },
+    };
+
+    const mockPlans = {
+      'SELECT * FROM users': ['SCAN users'],
+    };
+
+    vi.mocked(runAst).mockResolvedValue(mockResult);
+    vi.mocked(explainQueries).mockReturnValue(mockPlans);
+
+    const result = await analyzeQuery(lc, mockConfig, simpleAST);
+
+    expect(runAst).toHaveBeenCalledWith(
+      lc,
+      simpleAST,
+      true, // isTransformed
+      expect.objectContaining({
+        applyPermissions: false,
+        syncedRows: true,
+        vendedRows: false,
+        db: expect.any(Object),
+        tableSpecs: expect.any(Map),
+        host: expect.objectContaining({
+          debug: expect.any(Object),
+          getSource: expect.any(Function),
+          createStorage: expect.any(Function),
+          decorateSourceInput: expect.any(Function),
+          decorateInput: expect.any(Function),
+          addEdge: expect.any(Function),
+          decorateFilterInput: expect.any(Function),
+        }),
+      }),
+    );
+
+    expect(explainQueries).toHaveBeenCalledWith(
+      mockResult.vendedRowCounts,
+      expect.any(Object),
+    );
+
+    expect(result).toEqual({
+      ...mockResult,
+      plans: mockPlans,
+    });
+  });
+
+  test('analyzes query with custom options', async () => {
+    const {runAst} = await import('../../../analyze-query/src/run-ast.ts');
+    const {explainQueries} = await import(
+      '../../../analyze-query/src/explain-queries.ts'
+    );
+
+    const mockResult: AnalyzeQueryResult = {
+      warnings: ['Custom warning'],
+      syncedRowCount: 3,
+      start: 2000,
+      end: 2100,
+      vendedRowCounts: {},
+    };
+
+    vi.mocked(runAst).mockResolvedValue(mockResult);
+    vi.mocked(explainQueries).mockReturnValue({});
+
+    const result = await analyzeQuery(lc, mockConfig, simpleAST, {
+      syncedRows: false,
+      vendedRows: true,
+    });
+
+    expect(runAst).toHaveBeenCalledWith(
+      lc,
+      simpleAST,
+      true,
+      expect.objectContaining({
+        syncedRows: false,
+        vendedRows: true,
+      }),
+    );
+
+    expect(result).toEqual({
+      ...mockResult,
+      plans: {},
+    });
+  });
+
+  test('handles query with complex AST', async () => {
+    const {runAst} = await import('../../../analyze-query/src/run-ast.ts');
+
+    const complexAST: AST = {
+      table: 'users',
+      where: {
+        type: 'simple',
+        left: {type: 'column', name: 'active'},
+        op: '=',
+        right: {type: 'literal', value: true},
+      },
+      orderBy: [['name', 'asc']],
+      limit: 10,
+    };
+
+    const mockResult: AnalyzeQueryResult = {
+      warnings: [],
+      syncedRowCount: 10,
+      start: 1500,
+      end: 1600,
+      vendedRowCounts: {
+        users: {
+          'SELECT * FROM users WHERE active = ? ORDER BY name LIMIT ?': 10,
+        },
+      },
+    };
+
+    vi.mocked(runAst).mockResolvedValue(mockResult);
+
+    const result = await analyzeQuery(lc, mockConfig, complexAST);
+
+    expect(runAst).toHaveBeenCalledWith(
+      lc,
+      complexAST,
+      true,
+      expect.any(Object),
+    );
+    expect(result.syncedRowCount).toBe(10);
+  });
+
+  test('handles query with no vended row counts', async () => {
+    const {runAst} = await import('../../../analyze-query/src/run-ast.ts');
+    const {explainQueries} = await import(
+      '../../../analyze-query/src/explain-queries.ts'
+    );
+
+    const mockResult: AnalyzeQueryResult = {
+      warnings: [],
+      syncedRowCount: 0,
+      start: 1000,
+      end: 1010,
+      vendedRowCounts: undefined,
+    };
+
+    vi.mocked(runAst).mockResolvedValue(mockResult);
+    vi.mocked(explainQueries).mockReturnValue({});
+
+    const result = await analyzeQuery(lc, mockConfig, simpleAST);
+
+    expect(explainQueries).toHaveBeenCalledWith({}, expect.any(Object));
+    expect(result.plans).toEqual({});
+  });
+
+  test('handles empty vended row counts', async () => {
+    const {runAst} = await import('../../../analyze-query/src/run-ast.ts');
+    const {explainQueries} = await import(
+      '../../../analyze-query/src/explain-queries.ts'
+    );
+
+    const mockResult: AnalyzeQueryResult = {
+      warnings: [],
+      syncedRowCount: 0,
+      start: 1000,
+      end: 1010,
+      vendedRowCounts: {},
+    };
+
+    vi.mocked(runAst).mockResolvedValue(mockResult);
+    vi.mocked(explainQueries).mockReturnValue({});
+
+    const result = await analyzeQuery(lc, mockConfig, simpleAST);
+
+    expect(explainQueries).toHaveBeenCalledWith({}, expect.any(Object));
+    expect(result.plans).toEqual({});
+  });
+
+  test('propagates errors from runAst', async () => {
+    const {runAst} = await import('../../../analyze-query/src/run-ast.ts');
+
+    const error = new Error('Query analysis failed');
+    vi.mocked(runAst).mockRejectedValue(error);
+
+    await expect(analyzeQuery(lc, mockConfig, simpleAST)).rejects.toThrow(
+      'Query analysis failed',
+    );
+  });
+
+  test('creates proper host delegate with getSource function', async () => {
+    const {runAst} = await import('../../../analyze-query/src/run-ast.ts');
+    const {mustGetTableSpec} = await import('../db/lite-tables.ts');
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    const {TableSource} = await import('../../../zqlite/src/table-source.ts');
+
+    const mockTableSpec = {
+      tableSpec: {primaryKey: ['id']},
+      zqlSpec: {},
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(mustGetTableSpec).mockReturnValue(mockTableSpec as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(TableSource).mockImplementation(() => ({}) as any);
+
+    const mockResult: AnalyzeQueryResult = {
+      warnings: [],
+      syncedRowCount: 0,
+      start: 1000,
+      end: 1010,
+    };
+
+    vi.mocked(runAst).mockResolvedValue(mockResult);
+
+    await analyzeQuery(lc, mockConfig, simpleAST);
+
+    // Verify that runAst was called with a host that has the expected functions
+    const hostArg = vi.mocked(runAst).mock.calls[0][3].host;
+
+    expect(typeof hostArg.getSource).toBe('function');
+    expect(typeof hostArg.createStorage).toBe('function');
+    expect(typeof hostArg.decorateSourceInput).toBe('function');
+    expect(typeof hostArg.decorateInput).toBe('function');
+    expect(typeof hostArg.addEdge).toBe('function');
+    expect(typeof hostArg.decorateFilterInput).toBe('function');
+    expect(hostArg.debug).toBeDefined();
+
+    // Test the getSource function
+    const tableName = 'test_table';
+    hostArg.getSource(tableName);
+
+    expect(mustGetTableSpec).toHaveBeenCalledWith(expect.any(Map), tableName);
+    expect(TableSource).toHaveBeenCalledWith(
+      lc,
+      mockConfig.log,
+      expect.any(Object), // db
+      tableName,
+      mockTableSpec.zqlSpec,
+      mockTableSpec.tableSpec.primaryKey,
+    );
+  });
+
+  test('caches table sources in host delegate', async () => {
+    const {runAst} = await import('../../../analyze-query/src/run-ast.ts');
+    const {explainQueries} = await import(
+      '../../../analyze-query/src/explain-queries.ts'
+    );
+    const {mustGetTableSpec} = await import('../db/lite-tables.ts');
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    const {TableSource} = await import('../../../zqlite/src/table-source.ts');
+
+    const mockTableSpec = {
+      tableSpec: {primaryKey: ['id']},
+      zqlSpec: {},
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mockTableSource = {id: 'mock-table-source'} as any;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(mustGetTableSpec).mockReturnValue(mockTableSpec as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(TableSource).mockImplementation(() => mockTableSource as any);
+    vi.mocked(explainQueries).mockReturnValue({});
+
+    const mockResult: AnalyzeQueryResult = {
+      warnings: [],
+      syncedRowCount: 0,
+      start: 1000,
+      end: 1010,
+    };
+
+    vi.mocked(runAst).mockResolvedValue(mockResult);
+
+    await analyzeQuery(lc, mockConfig, simpleAST);
+
+    const hostArg = vi.mocked(runAst).mock.calls[0][3].host;
+
+    // Call getSource twice with the same table name
+    const tableName = 'test_table';
+    const source1 = hostArg.getSource(tableName);
+    const source2 = hostArg.getSource(tableName);
+
+    // Should return the same cached instance
+    expect(source1).toBe(source2);
+    expect(source1).toBe(mockTableSource);
+
+    // TableSource constructor should only be called once
+    expect(TableSource).toHaveBeenCalledTimes(1);
+  });
+
+  test('passes through all analyze options correctly', async () => {
+    const {runAst} = await import('../../../analyze-query/src/run-ast.ts');
+
+    const options = {
+      syncedRows: false,
+      vendedRows: true,
+    };
+
+    vi.mocked(runAst).mockResolvedValue({
+      warnings: [],
+      syncedRowCount: 0,
+      start: 1000,
+      end: 1010,
+    });
+
+    await analyzeQuery(lc, mockConfig, simpleAST, options);
+
+    expect(runAst).toHaveBeenCalledWith(
+      lc,
+      simpleAST,
+      true,
+      expect.objectContaining(options),
+    );
+  });
+});

--- a/packages/zero-cache/src/services/view-syncer/view-syncer-test-util.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer-test-util.ts
@@ -25,7 +25,12 @@ import {
   definePermissions,
 } from '../../../../zero-schema/src/permissions.ts';
 import type {ExpressionBuilder} from '../../../../zql/src/query/expression.ts';
+import {
+  CREATE_STORAGE_TABLE,
+  DatabaseStorage,
+} from '../../../../zqlite/src/database-storage.ts';
 import {Database} from '../../../../zqlite/src/db.ts';
+import type {NormalizedZeroConfig} from '../../config/normalize.ts';
 import type {ZeroConfig} from '../../config/zero-config.ts';
 import {InspectorDelegate} from '../../server/inspector-delegate.ts';
 import {TestDBs} from '../../test/db.ts';
@@ -39,10 +44,6 @@ import type {ReplicaState} from '../replicator/replicator.ts';
 import {initChangeLog} from '../replicator/schema/change-log.ts';
 import {initReplicationState} from '../replicator/schema/replication-state.ts';
 import {fakeReplicator, ReplicationMessages} from '../replicator/test-utils.ts';
-import {
-  CREATE_STORAGE_TABLE,
-  DatabaseStorage,
-} from '../../../../zqlite/src/database-storage.ts';
 import {DrainCoordinator} from './drain-coordinator.ts';
 import {PipelineDriver} from './pipeline-driver.ts';
 import {initViewSyncerSchema} from './schema/init.ts';
@@ -675,7 +676,10 @@ export async function setup(
   ).createClientGroupStorage(serviceID);
   const inspectorDelegate = new InspectorDelegate();
   const vs = new ViewSyncerService(
-    {getQueries: queryConfig, adminPassword: TEST_ADMIN_PASSWORD},
+    {
+      getQueries: queryConfig,
+      adminPassword: TEST_ADMIN_PASSWORD,
+    } as NormalizedZeroConfig,
     lc,
     SHARD,
     TASK_ID,

--- a/packages/zero-client/src/client/inspector/inspector.ts
+++ b/packages/zero-client/src/client/inspector/inspector.ts
@@ -29,7 +29,10 @@ import {
   type InspectQueryRow,
   type ServerMetrics as ServerMetricsJSON,
 } from '../../../../zero-protocol/src/inspect-down.ts';
-import type {InspectUpBody} from '../../../../zero-protocol/src/inspect-up.ts';
+import type {
+  AnalyzeQueryOptions,
+  InspectUpBody,
+} from '../../../../zero-protocol/src/inspect-up.ts';
 import type {Schema} from '../../../../zero-schema/src/builder/schema-builder.ts';
 import type {
   ClientMetricMap,
@@ -40,7 +43,6 @@ import {nanoid} from '../../util/nanoid.ts';
 import {ENTITIES_KEY_PREFIX} from '../keys.ts';
 import type {MutatorDefs} from '../replicache-types.ts';
 import type {
-  AnalyzeQueryOptions,
   ClientGroup as ClientGroupInterface,
   Client as ClientInterface,
   Inspector as InspectorInterface,

--- a/packages/zero-client/src/client/inspector/inspector.ts
+++ b/packages/zero-client/src/client/inspector/inspector.ts
@@ -16,9 +16,11 @@ import type {ReadonlyJSONValue} from '../../../../shared/src/json.ts';
 import {mapValues} from '../../../../shared/src/objects.ts';
 import {TDigest, type ReadonlyTDigest} from '../../../../shared/src/tdigest.ts';
 import * as valita from '../../../../shared/src/valita.ts';
+import type {AnalyzeQueryResult} from '../../../../zero-protocol/src/analyze-query-result.ts';
 import type {AST} from '../../../../zero-protocol/src/ast.ts';
 import type {Row} from '../../../../zero-protocol/src/data.ts';
 import {
+  inspectAnalyzeQueryDownSchema,
   inspectAuthenticatedDownSchema,
   inspectMetricsDownSchema,
   inspectQueriesDownSchema,
@@ -38,6 +40,7 @@ import {nanoid} from '../../util/nanoid.ts';
 import {ENTITIES_KEY_PREFIX} from '../keys.ts';
 import type {MutatorDefs} from '../replicache-types.ts';
 import type {
+  AnalyzeQueryOptions,
   ClientGroup as ClientGroupInterface,
   Client as ClientInterface,
   Inspector as InspectorInterface,
@@ -255,7 +258,7 @@ class Client implements ClientInterface {
       {op: 'queries', clientID: this.id},
       inspectQueriesDownSchema,
     );
-    return rows.map(row => new Query(row, this.#delegate));
+    return rows.map(row => new Query(row, this.#delegate, this.#socket));
   }
 
   map(): Promise<Map<string, ReadonlyJSONValue>> {
@@ -338,7 +341,7 @@ class ClientGroup implements ClientGroupInterface {
       {op: 'queries'},
       inspectQueriesDownSchema,
     );
-    return rows.map(row => new Query(row, this.#delegate));
+    return rows.map(row => new Query(row, this.#delegate, this.#socket));
   }
 }
 
@@ -415,6 +418,8 @@ async function clientsWithQueries(
 }
 
 class Query implements QueryInterface {
+  readonly #socket: GetWebSocket;
+
   readonly name: string | null;
   readonly args: ReadonlyArray<ReadonlyJSONValue> | null;
   readonly got: boolean;
@@ -427,8 +432,15 @@ class Query implements QueryInterface {
   readonly metrics: Metrics | null;
   readonly clientZQL: string | null;
   readonly serverZQL: string | null;
+  readonly #serverAST: AST | null;
 
-  constructor(row: InspectQueryRow, delegate: InspectorDelegate) {
+  constructor(
+    row: InspectQueryRow,
+    delegate: InspectorDelegate,
+    socket: GetWebSocket,
+  ) {
+    this.#socket = socket;
+
     const {ast, queryID, inactivatedAt} = row;
     // Use own properties to make this more useful in dev tools. For example, in
     // Chrome dev tools, if you do console.table(queries) you'll see the
@@ -443,6 +455,7 @@ class Query implements QueryInterface {
     this.got = row.got;
     this.rowCount = row.rowCount;
     this.deleted = row.deleted;
+    this.#serverAST = ast;
     this.serverZQL = ast ? ast.table + astToZQL(ast) : null;
     const clientAST = delegate.getAST(queryID);
     this.clientZQL = clientAST ? clientAST.table + astToZQL(clientAST) : null;
@@ -452,6 +465,19 @@ class Query implements QueryInterface {
     const serverMetrics = row.metrics;
 
     this.metrics = mergeMetrics(clientMetrics, serverMetrics);
+  }
+
+  async analyze(options?: AnalyzeQueryOptions): Promise<AnalyzeQueryResult> {
+    assert(this.#serverAST, 'No server AST available for this query');
+    return rpc(
+      await this.#socket(),
+      {
+        op: 'analyze-query',
+        value: this.#serverAST,
+        options,
+      },
+      inspectAnalyzeQueryDownSchema,
+    );
   }
 }
 

--- a/packages/zero-client/src/client/inspector/types.ts
+++ b/packages/zero-client/src/client/inspector/types.ts
@@ -1,6 +1,8 @@
 import type {ReadonlyJSONValue} from '../../../../shared/src/json.ts';
 import type {ReadonlyTDigest} from '../../../../shared/src/tdigest.ts';
+import type {AnalyzeQueryResult} from '../../../../zero-protocol/src/analyze-query-result.ts';
 import type {Row} from '../../../../zero-protocol/src/data.ts';
+import type {AnalyzeQueryOptions} from '../../../../zero-protocol/src/inspect-up.ts';
 import type {TTL} from '../../../../zql/src/query/ttl.ts';
 
 export interface GetInspector {
@@ -52,4 +54,6 @@ export interface Query {
   readonly clientZQL: string | null;
   readonly serverZQL: string | null;
   readonly metrics: Metrics | null;
+
+  analyze(options?: AnalyzeQueryOptions): Promise<AnalyzeQueryResult>;
 }

--- a/packages/zero-protocol/src/analyze-query-result.test.ts
+++ b/packages/zero-protocol/src/analyze-query-result.test.ts
@@ -1,0 +1,276 @@
+import {describe, expect, test} from 'vitest';
+import * as valita from '../../shared/src/valita.ts';
+import {
+  analyzeQueryResultSchema,
+  rowCountsByQuerySchema,
+  rowCountsBySourceSchema,
+  rowsByQuerySchema,
+  rowsBySourceSchema,
+  type AnalyzeQueryResult,
+  type RowCountsByQuery,
+  type RowCountsBySource,
+  type RowsByQuery,
+  type RowsBySource,
+} from './analyze-query-result.ts';
+
+describe('analyze-query-result schemas', () => {
+  describe('rowCountsByQuerySchema', () => {
+    test('validates valid row counts by query', () => {
+      const valid: RowCountsByQuery = {
+        'SELECT * FROM users': 5,
+        'SELECT * FROM posts WHERE user_id = ?': 12,
+      };
+
+      expect(() => valita.parse(valid, rowCountsByQuerySchema)).not.toThrow();
+      expect(valita.parse(valid, rowCountsByQuerySchema)).toEqual(valid);
+    });
+
+    test('rejects invalid row counts', () => {
+      const invalid = {
+        'SELECT * FROM users': 'not-a-number',
+      };
+
+      expect(() => valita.parse(invalid, rowCountsByQuerySchema)).toThrow();
+    });
+
+    test('handles empty object', () => {
+      const empty: RowCountsByQuery = {};
+      expect(() => valita.parse(empty, rowCountsByQuerySchema)).not.toThrow();
+    });
+  });
+
+  describe('rowCountsBySourceSchema', () => {
+    test('validates valid row counts by source', () => {
+      const valid: RowCountsBySource = {
+        users: {
+          'SELECT * FROM users': 5,
+          'SELECT * FROM users WHERE id = ?': 1,
+        },
+        posts: {
+          'SELECT * FROM posts': 100,
+        },
+      };
+
+      expect(() => valita.parse(valid, rowCountsBySourceSchema)).not.toThrow();
+      expect(valita.parse(valid, rowCountsBySourceSchema)).toEqual(valid);
+    });
+
+    test('handles nested empty objects', () => {
+      const valid: RowCountsBySource = {
+        users: {},
+        posts: {},
+      };
+
+      expect(() => valita.parse(valid, rowCountsBySourceSchema)).not.toThrow();
+    });
+  });
+
+  describe('rowsByQuerySchema', () => {
+    test('validates valid rows by query', () => {
+      const valid: RowsByQuery = {
+        'SELECT * FROM users': [
+          {id: 1, name: 'Alice'},
+          {id: 2, name: 'Bob'},
+        ],
+        'SELECT * FROM posts': [{id: 1, title: 'Post 1', ['user_id']: 1}],
+      };
+
+      expect(() => valita.parse(valid, rowsByQuerySchema)).not.toThrow();
+      expect(valita.parse(valid, rowsByQuerySchema)).toEqual(valid);
+    });
+
+    test('handles empty arrays', () => {
+      const valid: RowsByQuery = {
+        'SELECT * FROM empty_table': [],
+      };
+
+      expect(() => valita.parse(valid, rowsByQuerySchema)).not.toThrow();
+    });
+  });
+
+  describe('rowsBySourceSchema', () => {
+    test('validates valid rows by source', () => {
+      const valid: RowsBySource = {
+        users: {
+          'SELECT * FROM users': [
+            {id: 1, name: 'Alice'},
+            {id: 2, name: 'Bob'},
+          ],
+        },
+        posts: {
+          'SELECT * FROM posts': [{id: 1, title: 'Post 1', ['user_id']: 1}],
+        },
+      };
+
+      expect(() => valita.parse(valid, rowsBySourceSchema)).not.toThrow();
+      expect(valita.parse(valid, rowsBySourceSchema)).toEqual(valid);
+    });
+  });
+
+  describe('analyzeQueryResultSchema', () => {
+    test('validates minimal valid result', () => {
+      const minimal: AnalyzeQueryResult = {
+        warnings: [],
+        syncedRowCount: 0,
+        start: 1000,
+        end: 1100,
+      };
+
+      expect(() =>
+        valita.parse(minimal, analyzeQueryResultSchema),
+      ).not.toThrow();
+      expect(valita.parse(minimal, analyzeQueryResultSchema)).toEqual(minimal);
+    });
+
+    test('validates complete result with all optional fields', () => {
+      const complete: AnalyzeQueryResult = {
+        warnings: ['No auth data provided'],
+        syncedRows: {
+          users: [{id: 1, name: 'Alice'}],
+          posts: [{id: 1, title: 'Post 1'}],
+        },
+        syncedRowCount: 2,
+        start: 1000,
+        end: 1150,
+        afterPermissions: "users.where('id', 1)",
+        vendedRowCounts: {
+          users: {
+            'SELECT * FROM users WHERE id = ?': 1,
+          },
+        },
+        vendedRows: {
+          users: {
+            'SELECT * FROM users WHERE id = ?': [{id: 1, name: 'Alice'}],
+          },
+        },
+        plans: {
+          'SELECT * FROM users WHERE id = ?': [
+            'SEARCH users USING INDEX idx_users_id (id=?)',
+          ],
+        },
+      };
+
+      expect(() =>
+        valita.parse(complete, analyzeQueryResultSchema),
+      ).not.toThrow();
+      expect(valita.parse(complete, analyzeQueryResultSchema)).toEqual(
+        complete,
+      );
+    });
+
+    test('validates result with warnings', () => {
+      const withWarnings: AnalyzeQueryResult = {
+        warnings: [
+          'No auth data provided. Permission rules will compare to `NULL` wherever an auth data field is referenced.',
+          'Query may be slow due to lack of indexes',
+        ],
+        syncedRowCount: 5,
+        start: 1000,
+        end: 1200,
+      };
+
+      expect(() =>
+        valita.parse(withWarnings, analyzeQueryResultSchema),
+      ).not.toThrow();
+    });
+
+    test('rejects invalid result with missing required fields', () => {
+      const invalid = {
+        warnings: [],
+        // missing syncedRowCount, start, end
+      };
+
+      expect(() => valita.parse(invalid, analyzeQueryResultSchema)).toThrow();
+    });
+
+    test('rejects invalid result with wrong types', () => {
+      const invalid = {
+        warnings: 'not-an-array',
+        syncedRowCount: 'not-a-number',
+        start: 1000,
+        end: 1100,
+      };
+
+      expect(() => valita.parse(invalid, analyzeQueryResultSchema)).toThrow();
+    });
+
+    test('validates result with zero timing', () => {
+      const zeroTiming: AnalyzeQueryResult = {
+        warnings: [],
+        syncedRowCount: 0,
+        start: 0,
+        end: 0,
+      };
+
+      expect(() =>
+        valita.parse(zeroTiming, analyzeQueryResultSchema),
+      ).not.toThrow();
+    });
+
+    test('validates result with complex query plans', () => {
+      const withPlans: AnalyzeQueryResult = {
+        warnings: [],
+        syncedRowCount: 10,
+        start: 1000,
+        end: 1050,
+        plans: {
+          'SELECT * FROM users u JOIN posts p ON u.id = p.user_id': [
+            'SCAN posts AS p',
+            'SEARCH users AS u USING INDEX idx_users_id (id=?)',
+          ],
+          'SELECT COUNT(*) FROM comments': ['SCAN comments'],
+        },
+      };
+
+      expect(() =>
+        valita.parse(withPlans, analyzeQueryResultSchema),
+      ).not.toThrow();
+    });
+  });
+
+  describe('edge cases', () => {
+    test('handles large row counts', () => {
+      const largeCount: AnalyzeQueryResult = {
+        warnings: [],
+        syncedRowCount: Number.MAX_SAFE_INTEGER,
+        start: 1000,
+        end: 2000,
+      };
+
+      expect(() =>
+        valita.parse(largeCount, analyzeQueryResultSchema),
+      ).not.toThrow();
+    });
+
+    test('handles negative timing (edge case)', () => {
+      const negativeTiming: AnalyzeQueryResult = {
+        warnings: [],
+        syncedRowCount: 0,
+        start: 1000,
+        end: 500, // end before start
+      };
+
+      // Schema should still validate even if timing doesn't make sense
+      expect(() =>
+        valita.parse(negativeTiming, analyzeQueryResultSchema),
+      ).not.toThrow();
+    });
+
+    test('handles empty nested objects', () => {
+      const emptyNested: AnalyzeQueryResult = {
+        warnings: [],
+        syncedRows: {},
+        syncedRowCount: 0,
+        start: 1000,
+        end: 1100,
+        vendedRowCounts: {},
+        vendedRows: {},
+        plans: {},
+      };
+
+      expect(() =>
+        valita.parse(emptyNested, analyzeQueryResultSchema),
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/zero-protocol/src/analyze-query-result.ts
+++ b/packages/zero-protocol/src/analyze-query-result.ts
@@ -1,0 +1,29 @@
+import * as v from '../../shared/src/valita.ts';
+
+import {rowSchema} from './data.ts';
+
+export const rowCountsByQuerySchema = v.record(v.number());
+export type RowCountsByQuery = v.Infer<typeof rowCountsByQuerySchema>;
+
+export const rowCountsBySourceSchema = v.record(rowCountsByQuerySchema);
+export type RowCountsBySource = v.Infer<typeof rowCountsBySourceSchema>;
+
+export const rowsByQuerySchema = v.record(v.array(rowSchema));
+export type RowsByQuery = v.Infer<typeof rowsByQuerySchema>;
+
+export const rowsBySourceSchema = v.record(rowsByQuerySchema);
+export type RowsBySource = v.Infer<typeof rowsBySourceSchema>;
+
+export const analyzeQueryResultSchema = v.object({
+  warnings: v.array(v.string()),
+  syncedRows: v.record(v.array(rowSchema)).optional(),
+  syncedRowCount: v.number(),
+  start: v.number(),
+  end: v.number(),
+  afterPermissions: v.string().optional(),
+  vendedRowCounts: rowCountsBySourceSchema.optional(),
+  vendedRows: rowsBySourceSchema.optional(),
+  plans: v.record(v.array(v.string())).optional(),
+});
+
+export type AnalyzeQueryResult = v.Infer<typeof analyzeQueryResultSchema>;

--- a/packages/zero-protocol/src/ast.test.ts
+++ b/packages/zero-protocol/src/ast.test.ts
@@ -607,5 +607,5 @@ test('protocol version', () => {
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
   expect(hash).toEqual('1c228prd1v53r');
-  expect(PROTOCOL_VERSION).toBe(31);
+  expect(PROTOCOL_VERSION).toBe(32);
 });

--- a/packages/zero-protocol/src/inspect-down.ts
+++ b/packages/zero-protocol/src/inspect-down.ts
@@ -1,6 +1,7 @@
 import {jsonSchema} from '../../shared/src/json-schema.ts';
 import {tdigestSchema} from '../../shared/src/tdigest-schema.ts';
 import * as v from '../../shared/src/valita.ts';
+import {analyzeQueryResultSchema} from './analyze-query-result.ts';
 import {astSchema} from './ast.ts';
 
 const serverMetricsSchema = v.object({
@@ -62,11 +63,21 @@ export type InspectAuthenticatedDown = v.Infer<
   typeof inspectAuthenticatedDownSchema
 >;
 
+export const inspectAnalyzeQueryDownSchema = inspectBaseDownSchema.extend({
+  op: v.literal('analyze-query'),
+  value: analyzeQueryResultSchema,
+});
+
+export type InspectAnalyzeQueryDown = v.Infer<
+  typeof inspectAnalyzeQueryDownSchema
+>;
+
 export const inspectDownBodySchema = v.union(
   inspectQueriesDownSchema,
   inspectMetricsDownSchema,
   inspectVersionDownSchema,
   inspectAuthenticatedDownSchema,
+  inspectAnalyzeQueryDownSchema,
 );
 
 export const inspectDownMessageSchema = v.tuple([

--- a/packages/zero-protocol/src/inspect-up.ts
+++ b/packages/zero-protocol/src/inspect-up.ts
@@ -1,4 +1,5 @@
 import * as v from '../../shared/src/valita.ts';
+import {astSchema} from './ast.ts';
 
 const inspectUpBase = v.object({
   id: v.string(),
@@ -32,11 +33,29 @@ export type InspectAuthenticateUpBody = v.Infer<
   typeof inspectAuthenticateUpSchema
 >;
 
+const analyzeQueryOptionsSchema = v.object({
+  vendedRows: v.boolean().optional(),
+  syncedRows: v.boolean().optional(),
+});
+
+export type AnalyzeQueryOptions = v.Infer<typeof analyzeQueryOptionsSchema>;
+
+export const inspectAnalyzeQueryUpSchema = inspectUpBase.extend({
+  op: v.literal('analyze-query'),
+  value: astSchema,
+  options: analyzeQueryOptionsSchema.optional(),
+});
+
+export type InspectAnalyzeQueryUpBody = v.Infer<
+  typeof inspectAnalyzeQueryUpSchema
+>;
+
 const inspectUpBodySchema = v.union(
   inspectQueriesUpBodySchema,
   inspectMetricsUpSchema,
   inspectVersionUpSchema,
   inspectAuthenticateUpSchema,
+  inspectAnalyzeQueryUpSchema,
 );
 
 export const inspectUpMessageSchema = v.tuple([

--- a/packages/zero-protocol/src/protocol-version.test.ts
+++ b/packages/zero-protocol/src/protocol-version.test.ts
@@ -11,6 +11,6 @@ test('protocol version', () => {
   // If this test fails upstream or downstream schema has changed such that
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
-  expect(hash).toBe('29dy0pj406bur');
-  expect(PROTOCOL_VERSION).toBe(31);
+  expect(hash).toEqual('2w9hr74j7pvnw');
+  expect(PROTOCOL_VERSION).toBe(32);
 });

--- a/packages/zero-protocol/src/protocol-version.ts
+++ b/packages/zero-protocol/src/protocol-version.ts
@@ -37,7 +37,8 @@ import {assert} from '../../shared/src/asserts.ts';
 // -- version 29 adds error responses for custom queries (0.23)
 // -- version 30 adds an optional primaryKey to the ClientSchema (0.24)
 // -- version 31 adds admin password authentication to inspector RPC calls (0.24)
-export const PROTOCOL_VERSION = 31;
+// -- version 32 adds analyze-query to the inspector RPC calls (0.24)
+export const PROTOCOL_VERSION = 32;
 
 /**
  * The minimum server-supported sync protocol version (i.e. the version

--- a/packages/zql/src/builder/debug-delegate.ts
+++ b/packages/zql/src/builder/debug-delegate.ts
@@ -1,4 +1,10 @@
-import type {Row} from '../../../zero-protocol/src/data.ts';
+import type {
+  RowCountsByQuery,
+  RowCountsBySource,
+  RowsByQuery,
+  RowsBySource,
+} from '../../../zero-protocol/src/analyze-query-result.ts';
+import {type Row} from '../../../zero-protocol/src/data.ts';
 
 export const runtimeDebugFlags = {
   trackRowCountsVended: false,
@@ -7,10 +13,6 @@ export const runtimeDebugFlags = {
 
 type SourceName = string;
 type SQL = string;
-export type RowCountsBySource = Record<SourceName, RowCountsByQuery>;
-export type RowsBySource = Record<SourceName, RowsByQuery>;
-type RowCountsByQuery = Record<SQL, number>;
-type RowsByQuery = Record<SQL, Row[]>;
 
 export interface DebugDelegate {
   initQuery(table: SourceName, query: SQL): void;


### PR DESCRIPTION
Add Query Analyse to Inspector
---

This PR adds a new `analyze()` method to Query objects in the Zero inspector, enabling detailed performance analysis of queries.

This uses the server side AST to analyze the query.

What's New
---

- **Query.analyze() method**: New async method that returns query analysis including timing, row counts, execution plans, and warnings
- **Server-side analysis**: New `analyzeQuery()` service function that leverages the existing `analyze-query` package
- **Protocol support**: Extended inspect protocol with `analyze-query` RPC (protocol version 32)
- **Development mode**: Inspector authentication bypassed in dev mode for easier debugging

Usage
---

```typescript
const inspector = await zero.inspect();
const query = await inspector.client.queries()[0];

const result = await query.analyze({
  syncedRows: true,   // Include synced row data
  vendedRows: true    // Include database access data
});

console.log({
  timing: `${result.end - result.start}ms`,
  rowCount: result.syncedRowCount,
  plans: result.plans,
  warnings: result.warnings
});
```
