### PR TITLE
feat(zero)!: remove `then` from `Query`

### DIFF
--- a/apps/zbugs/server/notify.ts
+++ b/apps/zbugs/server/notify.ts
@@ -57,11 +57,14 @@ export async function notify(
   assertIsLoggedIn(authData);
 
   const {issueID, kind} = args;
-  const issue = await tx.query.issue.where('id', issueID).one();
+  const issue = await tx.query.issue.where('id', issueID).one().run();
   assert(issue);
 
   const modifierUserID = authData.sub;
-  const modifierUser = await tx.query.user.where('id', modifierUserID).one();
+  const modifierUser = await tx.query.user
+    .where('id', modifierUserID)
+    .one()
+    .run();
   assert(modifierUser);
 
   // include the actor only for the initial `create-issue` action
@@ -143,7 +146,8 @@ export async function notify(
         } else {
           const newAssignee = await tx.query.user
             .where('id', update.assigneeID)
-            .one();
+            .one()
+            .run();
           if (newAssignee) {
             changes.push(`Assignee changed to ${newAssignee.login}`);
           }
@@ -185,7 +189,7 @@ export async function notify(
 
     case 'add-emoji-to-comment': {
       const {commentID, emoji} = args;
-      const comment = await tx.query.comment.where('id', commentID).one();
+      const comment = await tx.query.comment.where('id', commentID).one().run();
       assert(comment);
 
       await sendNotifications({

--- a/apps/zbugs/server/server-mutators.ts
+++ b/apps/zbugs/server/server-mutators.ts
@@ -135,7 +135,8 @@ export function createServerMutators(
 
         const comment = await tx.query.comment
           .where('id', args.subjectID)
-          .one();
+          .one()
+          .run();
         assert(comment);
         assert(tx.location === 'server');
         await notify(
@@ -179,7 +180,7 @@ export function createServerMutators(
       async edit(tx: MutatorTx, {id, body}: {id: string; body: string}) {
         await mutators.comment.edit(tx, {id, body});
 
-        const comment = await tx.query.comment.where('id', id).one();
+        const comment = await tx.query.comment.where('id', id).one().run();
         assert(comment);
 
         assert(tx.location === 'server');

--- a/apps/zbugs/shared/auth.ts
+++ b/apps/zbugs/shared/auth.ts
@@ -39,7 +39,7 @@ export async function assertIsCreatorOrAdmin(
     return;
   }
   const creatorID = must(
-    await query.where('id', id).one(),
+    await query.where('id', id).one().run(),
     `entity ${id} does not exist`,
   ).creatorID;
   assert(
@@ -53,8 +53,8 @@ export async function assertUserCanSeeIssue(
   userID: string,
   issueID: string,
 ) {
-  const issue = must(await tx.query.issue.where('id', issueID).one());
-  const user = must(await tx.query.user.where('id', userID).one());
+  const issue = must(await tx.query.issue.where('id', issueID).one().run());
+  const user = must(await tx.query.user.where('id', userID).one().run());
 
   assert(
     issue.visibility === 'public' ||
@@ -69,7 +69,9 @@ export async function assertUserCanSeeComment(
   userID: string,
   commentID: string,
 ) {
-  const comment = must(await tx.query.comment.where('id', commentID).one());
+  const comment = must(
+    await tx.query.comment.where('id', commentID).one().run(),
+  );
 
   await assertUserCanSeeIssue(tx, userID, comment.issueID);
 }

--- a/apps/zbugs/shared/mutators.ts
+++ b/apps/zbugs/shared/mutators.ts
@@ -69,7 +69,10 @@ export function createMutators(authData: AuthData | undefined) {
         tx: MutatorTx,
         change: UpdateValue<typeof schema.tables.issue> & {modified: number},
       ) {
-        const oldIssue = await tx.query.issue.where('id', change.id).one();
+        const oldIssue = await tx.query.issue
+          .where('id', change.id)
+          .one()
+          .run();
         assert(oldIssue);
 
         await assertIsCreatorOrAdmin(authData, tx.query.issue, change.id);

--- a/packages/zero-client/src/client/zero.json.test.ts
+++ b/packages/zero-client/src/client/zero.json.test.ts
@@ -34,7 +34,7 @@ test('we can create rows with json columns and query those rows', async () => {
     artists: ['artist 2', 'artist 3'],
   });
 
-  const tracks = await z.query.track;
+  const tracks = await z.query.track.run();
 
   expect(tracks).toEqual([
     {

--- a/packages/zero-client/src/client/zero.type.test.ts
+++ b/packages/zero-client/src/client/zero.type.test.ts
@@ -214,7 +214,7 @@ test('CRUD and custom mutators work together with enableLegacyMutators: true', a
   await z.mutate.issues.insert({id: '1', title: 'Test Issue', status: 'open'});
   await z.mutate.issue.closeIssue({id: '1'});
 
-  const issues = await z.query.issues.where('id', '1').one();
+  const issues = await z.query.issues.where('id', '1').one().run();
   expect(issues?.status).toBe('closed');
 });
 

--- a/packages/zero-schema/src/builder/schema-builder.test.ts
+++ b/packages/zero-schema/src/builder/schema-builder.test.ts
@@ -123,7 +123,8 @@ test('building a schema', async () => {
   const iq = mockQuery as unknown as Query<typeof schema, 'issue'>;
   const r = await q
     .related('recruiter', q => q.related('recruiter', q => q.one()).one())
-    .one();
+    .one()
+    .run();
   expectTypeOf<typeof r>().toEqualTypeOf<
     | {
         readonly id: string;
@@ -149,7 +150,7 @@ test('building a schema', async () => {
   >({} as any);
 
   // recruiter is a singular relationship
-  expectTypeOf(await q.related('recruiter')).toEqualTypeOf<
+  expectTypeOf(await q.related('recruiter').run()).toEqualTypeOf<
     {
       readonly id: string;
       readonly name: string;
@@ -165,7 +166,7 @@ test('building a schema', async () => {
   >();
 
   // recruiter is a singular relationship
-  expectTypeOf(await q.related('recruiter', q => q)).toEqualTypeOf<
+  expectTypeOf(await q.related('recruiter', q => q).run()).toEqualTypeOf<
     {
       readonly id: string;
       readonly name: string;
@@ -180,9 +181,9 @@ test('building a schema', async () => {
     }[]
   >();
 
-  const id1 = await iq.related('owner', q =>
-    q.related('ownedIssues', q => q.where('id', '1')),
-  );
+  const id1 = await iq
+    .related('owner', q => q.related('ownedIssues', q => q.where('id', '1')))
+    .run();
   expectTypeOf(id1).toEqualTypeOf<
     {
       readonly id: string;
@@ -203,7 +204,7 @@ test('building a schema', async () => {
     }[]
   >({} as never);
 
-  const id = await iq.related('labels');
+  const id = await iq.related('labels').run();
   expectTypeOf(id).toEqualTypeOf<
     {
       readonly id: string;
@@ -217,7 +218,7 @@ test('building a schema', async () => {
   >();
 
   const lq = mockQuery as unknown as Query<typeof schema, 'label'>;
-  const ld = await lq.related('issues');
+  const ld = await lq.related('issues').run();
   expectTypeOf(ld).toEqualTypeOf<
     {
       readonly id: number;

--- a/packages/zero-server/src/query.pg-test.ts
+++ b/packages/zero-server/src/query.pg-test.ts
@@ -30,13 +30,13 @@ describe('makeSchemaQuery', () => {
         transaciton,
         await getServerSchema(transaciton, schema),
       );
-      const result = await query.basic;
+      const result = await query.basic.run();
       expect(result).toEqual([{id: '1', a: 2, b: 'foo', c: true}]);
 
-      const result2 = await query.names;
+      const result2 = await query.names.run();
       expect(result2).toEqual([{id: '2', a: 3, b: 'bar', c: false}]);
 
-      const result3 = await query.compoundPk;
+      const result3 = await query.compoundPk.run();
       expect(result3).toEqual([{a: 'a', b: 1, c: 'c'}]);
     });
   });
@@ -48,7 +48,7 @@ describe('makeSchemaQuery', () => {
         transaciton,
         await getServerSchema(transaciton, schema),
       );
-      const result = await query.basic.one();
+      const result = await query.basic.one().run();
       expect(result).toEqual({id: '1', a: 2, b: 'foo', c: true});
     });
   });
@@ -60,7 +60,7 @@ describe('makeSchemaQuery', () => {
         transaciton,
         await getServerSchema(transaciton, schema),
       );
-      const result = await query.basic.where('id', 'non-existent').one();
+      const result = await query.basic.where('id', 'non-existent').one().run();
       expect(result).toEqual(undefined);
     });
   });

--- a/packages/zql-integration-tests/src/chinook/chinook.pg-test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook.pg-test.ts
@@ -32,6 +32,7 @@ describe(
         {
           suiteName: 'compiler_chinook',
           pgContent,
+          only: 'compare primary key',
           zqlSchema: schema,
           setRawData: r => {
             data = r;

--- a/packages/zql-integration-tests/src/collate.pg-test.ts
+++ b/packages/zql-integration-tests/src/collate.pg-test.ts
@@ -192,9 +192,13 @@ describe('collation behavior', () => {
       const itemQuery = newQuery(queryDelegate, schema, 'item');
       const query = itemQuery.orderBy(col, 'asc');
       const pgResult = await runAsSQL(query, runPgQuery);
-      const zqlResult = mapResultToClientNames(await query, schema, 'item');
+      const zqlResult = mapResultToClientNames(
+        await query.run(),
+        schema,
+        'item',
+      );
       const memoryItemQuery = newQuery(memoryQueryDelegate, schema, 'item');
-      const memoryResult = await memoryItemQuery.orderBy(col, 'asc');
+      const memoryResult = await memoryItemQuery.orderBy(col, 'asc').run();
       expect(zqlResult).toEqualPg(pgResult);
       expect(memoryResult).toEqualPg(pgResult);
 
@@ -208,9 +212,9 @@ describe('collation behavior', () => {
           .orderBy(col, 'asc');
       }
       for (let i = 0; i < memoryResult.length - 1; i++) {
-        const memResult = await makeQuery(memoryItemQuery, i);
+        const memResult = await makeQuery(memoryItemQuery, i).run();
         const zqlResult = mapResultToClientNames(
-          await makeQuery(itemQuery, i),
+          await makeQuery(itemQuery, i).run(),
           schema,
           'item',
         );

--- a/packages/zql-integration-tests/src/compiler-bigint.pg-test.ts
+++ b/packages/zql-integration-tests/src/compiler-bigint.pg-test.ts
@@ -211,7 +211,11 @@ describe('compiling ZQL to SQL', () => {
       const pgResult = extractZqlResult(
         await runPgQuery(sqlQuery.text, sqlQuery.values as JSONValue[]),
       );
-      const zqlResult = mapResultToClientNames(await query, schema, 'issue');
+      const zqlResult = mapResultToClientNames(
+        await query.run(),
+        schema,
+        'issue',
+      );
       expect(zqlResult).toEqualPg(pgResult);
       expect(zqlResult).toMatchInlineSnapshot(`
         [
@@ -276,7 +280,11 @@ describe('compiling ZQL to SQL', () => {
       const pgResult = extractZqlResult(
         await runPgQuery(sqlQuery.text, sqlQuery.values as JSONValue[]),
       );
-      const zqlResult = mapResultToClientNames(await query, schema, 'issue');
+      const zqlResult = mapResultToClientNames(
+        await query.run(),
+        schema,
+        'issue',
+      );
       expect(zqlResult).toEqualPg(pgResult);
       expect(zqlResult).toMatchInlineSnapshot(`
         [
@@ -323,7 +331,11 @@ describe('compiling ZQL to SQL', () => {
       const pgResult2 = extractZqlResult(
         await runPgQuery(sqlQuery2.text, sqlQuery2.values as JSONValue[]),
       );
-      const zqlResult2 = mapResultToClientNames(await q2, schema, 'issue');
+      const zqlResult2 = mapResultToClientNames(
+        await q2.run(),
+        schema,
+        'issue',
+      );
       expect(zqlResult2).toEqualPg(pgResult2);
       expect(zqlResult2).toMatchInlineSnapshot(`
         [

--- a/packages/zql-integration-tests/src/compiler-types-with-args.pg-test.ts
+++ b/packages/zql-integration-tests/src/compiler-types-with-args.pg-test.ts
@@ -205,7 +205,11 @@ describe('compiling ZQL to SQL', () => {
       const pgResult = extractZqlResult(
         await runPgQuery(sqlQuery.text, sqlQuery.values as JSONValue[]),
       );
-      const zqlResult = mapResultToClientNames(await query, schema, 'issue');
+      const zqlResult = mapResultToClientNames(
+        await query.run(),
+        schema,
+        'issue',
+      );
       expect(zqlResult).toEqualPg(pgResult);
       expect(zqlResult).toMatchInlineSnapshot(`
         [
@@ -276,7 +280,11 @@ describe('compiling ZQL to SQL', () => {
       const pgResult = extractZqlResult(
         await runPgQuery(sqlQuery.text, sqlQuery.values as JSONValue[]),
       );
-      const zqlResult = mapResultToClientNames(await query, schema, 'issue');
+      const zqlResult = mapResultToClientNames(
+        await query.run(),
+        schema,
+        'issue',
+      );
       expect(zqlResult).toEqualPg(pgResult);
       expect(zqlResult).toMatchInlineSnapshot(`
               [
@@ -332,7 +340,11 @@ describe('compiling ZQL to SQL', () => {
       const pgResult = extractZqlResult(
         await runPgQuery(sqlQuery.text, sqlQuery.values as JSONValue[]),
       );
-      const zqlResult = mapResultToClientNames(await query, schema, 'issue');
+      const zqlResult = mapResultToClientNames(
+        await query.run(),
+        schema,
+        'issue',
+      );
       expect(zqlResult).toEqualPg(pgResult);
       expect(zqlResult).toMatchInlineSnapshot(`
       [
@@ -369,7 +381,11 @@ describe('compiling ZQL to SQL', () => {
       const pgResult2 = extractZqlResult(
         await runPgQuery(sqlQuery2.text, sqlQuery2.values as JSONValue[]),
       );
-      const zqlResult2 = mapResultToClientNames(await q2, schema, 'issue');
+      const zqlResult2 = mapResultToClientNames(
+        await q2.run(),
+        schema,
+        'issue',
+      );
       expect(zqlResult2).toEqualPg(pgResult2);
       expect(zqlResult2).toMatchInlineSnapshot(`
               [
@@ -411,7 +427,11 @@ describe('compiling ZQL to SQL', () => {
       const pgResult = extractZqlResult(
         await runPgQuery(sqlQuery.text, sqlQuery.values as JSONValue[]),
       );
-      const zqlResult = mapResultToClientNames(await query, schema, 'issue');
+      const zqlResult = mapResultToClientNames(
+        await query.run(),
+        schema,
+        'issue',
+      );
       expect(zqlResult).toEqualPg(pgResult);
       expect(zqlResult).toMatchInlineSnapshot(`
               [
@@ -448,7 +468,11 @@ describe('compiling ZQL to SQL', () => {
       const pgResult2 = extractZqlResult(
         await runPgQuery(sqlQuery2.text, sqlQuery2.values as JSONValue[]),
       );
-      const zqlResult2 = mapResultToClientNames(await q2, schema, 'issue');
+      const zqlResult2 = mapResultToClientNames(
+        await q2.run(),
+        schema,
+        'issue',
+      );
       expect(zqlResult2).toEqualPg(pgResult2);
       expect(zqlResult2).toMatchInlineSnapshot(`
               [

--- a/packages/zql-integration-tests/src/helpers/runner.ts
+++ b/packages/zql-integration-tests/src/helpers/runner.ts
@@ -666,14 +666,14 @@ export async function runAndCompare(
   queries: QueryInstances,
   manualVerification: unknown,
 ) {
-  const pgResult = await queries.pg;
+  const pgResult = await queries.pg.run();
   // Might we worth being able to configure ZQLite to return client vs server names
   const sqliteResult = mapResultToClientNames(
-    await queries.sqlite,
+    await queries.sqlite.run(),
     zqlSchema,
     ast(queries.sqlite).table,
   );
-  const memoryResult = await queries.memory;
+  const memoryResult = await queries.memory.run();
 
   // - is PG
   // + is SQLite / Memory
@@ -856,7 +856,7 @@ async function checkRemove(
     });
 
     // pg cannot be materialized.
-    const pgResult = await queries.pg;
+    const pgResult = await queries.pg.run();
     expect(
       mapResultToClientNames(
         zqliteMaterialized.data,
@@ -907,7 +907,7 @@ async function checkAddBack(
       row,
     });
 
-    const pgResult = await queries.pg;
+    const pgResult = await queries.pg.run();
     expect(
       mapResultToClientNames(
         zqliteMaterialized.data,
@@ -988,7 +988,7 @@ async function checkEditToRandom(
       row: editedRow,
     });
 
-    const pgResult = await queries.pg;
+    const pgResult = await queries.pg.run();
     expect(
       mapResultToClientNames(
         zqliteMaterialized.data,
@@ -1063,7 +1063,7 @@ async function checkEditToMatch(
       row: original,
     });
 
-    const pgResult = await queries.pg;
+    const pgResult = await queries.pg.run();
     expect(
       mapResultToClientNames(
         zqliteMaterialized.data,

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -667,19 +667,6 @@ export abstract class AbstractQuery<
     return this.#completedAST;
   }
 
-  then<TResult1 = HumanReadable<TReturn>, TResult2 = never>(
-    onFulfilled?:
-      | ((value: HumanReadable<TReturn>) => TResult1 | PromiseLike<TResult1>)
-      | undefined
-      | null,
-    onRejected?:
-      | ((reason: any) => TResult2 | PromiseLike<TResult2>)
-      | undefined
-      | null,
-  ): PromiseLike<TResult1 | TResult2> {
-    return this.run().then(onFulfilled, onRejected);
-  }
-
   abstract materialize(
     ttl?: TTL | undefined,
   ): TypedView<HumanReadable<TReturn>>;

--- a/packages/zql/src/query/query.ts
+++ b/packages/zql/src/query/query.ts
@@ -144,7 +144,7 @@ export interface Query<
   TSchema extends ZeroSchema,
   TTable extends keyof TSchema['tables'] & string,
   TReturn = PullRow<TTable, TSchema>,
-> extends PromiseLike<HumanReadable<TReturn>> {
+> {
   /**
    * Format is used to specify the shape of the query results. This is used by
    * {@linkcode one} and it also describes the shape when using

--- a/packages/zqlite/src/query.test.ts
+++ b/packages/zqlite/src/query.test.ts
@@ -112,7 +112,7 @@ test('row type', () => {
 
 test('basic query', async () => {
   const query = newQuery(queryDelegate, schema, 'issue');
-  const data = mapResultToClientNames(await query, schema, 'issue');
+  const data = mapResultToClientNames(await query.run(), schema, 'issue');
   expect(data).toMatchInlineSnapshot(`
     [
       {
@@ -144,11 +144,9 @@ test('basic query', async () => {
 });
 
 test('null compare', async () => {
-  let rows = await newQuery(queryDelegate, schema, 'issue').where(
-    'ownerId',
-    'IS',
-    null,
-  );
+  let rows = await newQuery(queryDelegate, schema, 'issue')
+    .where('ownerId', 'IS', null)
+    .run();
   expect(mapResultToClientNames(rows, schema, 'issue')).toMatchInlineSnapshot(`
     [
       {
@@ -162,11 +160,9 @@ test('null compare', async () => {
     ]
   `);
 
-  rows = await newQuery(queryDelegate, schema, 'issue').where(
-    'ownerId',
-    'IS NOT',
-    null,
-  );
+  rows = await newQuery(queryDelegate, schema, 'issue')
+    .where('ownerId', 'IS NOT', null)
+    .run();
 
   expect(rows).toMatchInlineSnapshot(`
     [
@@ -196,7 +192,7 @@ test('or', async () => {
   const query = newQuery(queryDelegate, schema, 'issue').where(({or, cmp}) =>
     or(cmp('ownerId', '=', '0001'), cmp('ownerId', '=', '0002')),
   );
-  const data = mapResultToClientNames(await query, schema, 'issue');
+  const data = mapResultToClientNames(await query.run(), schema, 'issue');
   expect(data).toMatchInlineSnapshot(`
     [
       {
@@ -305,7 +301,7 @@ test('schema applied `one`', async () => {
     .related('owner')
     .related('comments', q => q.related('author').related('revisions'))
     .where('id', '=', '0001');
-  const data = mapResultToClientNames(await query, schema, 'issue');
+  const data = mapResultToClientNames(await query.run(), schema, 'issue');
   expect(data).toMatchInlineSnapshot(`
     [
       {


### PR DESCRIPTION
Remove `then`.

Having a `runnableQuery` will be a bit problematic as it will require duplicating the `Query` interface as each `limit, where, related, etc.` call must return `RunnableQuery` rather than `Query`.