### PR TITLE
chore(zero-client): Basic styling of the password prompt

### DIFF
--- a/packages/zero-client/src/client/inspector/inspector.ts
+++ b/packages/zero-client/src/client/inspector/inspector.ts
@@ -1,6 +1,5 @@
 import type {ClientGroup} from './client-group.ts';
 import {Client} from './client.ts';
-import {createHTMLPasswordPrompt} from './html-dialog-prompt.ts';
 import type {
   ExtendedInspectorDelegate,
   InspectorDelegate,
@@ -55,6 +54,3 @@ export class Inspector {
     return (await this.#delegate.lazy).serverVersion(this.#delegate);
   }
 }
-
-// @ts-expect-error hack
-globalThis.createHTMLPasswordPrompt = createHTMLPasswordPrompt;


### PR DESCRIPTION
When using `await zero.inspect.client.queries()` we prompt for a password.

This styles that dialog a little bit.