### PR TITLE
chore(zql): factor out `push-accumulated`

### DIFF
--- a/packages/shared/src/sentinels.ts
+++ b/packages/shared/src/sentinels.ts
@@ -1,2 +1,6 @@
 export function emptyFunction() {}
 export const emptyObject = Object.freeze({});
+export const emptyArray = Object.freeze([]);
+export function identity<T>(x: T): T {
+  return x;
+}

--- a/packages/zql/src/ivm/fan-in.ts
+++ b/packages/zql/src/ivm/fan-in.ts
@@ -1,5 +1,5 @@
 import {assert} from '../../../shared/src/asserts.ts';
-import {must} from '../../../shared/src/must.ts';
+import {identity} from '../../../shared/src/sentinels.ts';
 import type {Change} from './change.ts';
 import {type Node} from './data.ts';
 import type {FanOut} from './fan-out.ts';
@@ -9,6 +9,7 @@ import {
   type FilterOperator,
   type FilterOutput,
 } from './filter-operators.ts';
+import {pushAccumulatedChanges} from './push-accumulated.ts';
 import type {SourceSchema} from './schema.ts';
 
 /**
@@ -71,133 +72,12 @@ export class FanIn implements FilterOperator {
       return;
     }
 
-    if (this.#accumulatedPushes.length === 0) {
-      // It is possible for no forks to pass along the push.
-      // E.g., if no filters match in any fork.
-      return;
-    }
-
-    // collapse down to a single change per type
-    const candidatesToPush = new Map<Change['type'], Change>();
-    for (const change of this.#accumulatedPushes) {
-      if (fanOutChangeType === 'child' && change.type !== 'child') {
-        assert(
-          candidatesToPush.has(change.type) === false,
-          () =>
-            `Fan-in:child expected at most one ${change.type} when fan-out is of type child`,
-        );
-      }
-      candidatesToPush.set(change.type, change);
-    }
-
-    this.#accumulatedPushes = [];
-
-    const types = [...candidatesToPush.keys()];
-    /**
-     * Based on the received `fanOutChangeType` only certain output types are valid.
-     *
-     * - remove must result in all removes
-     * - add must result in all adds
-     * - edit must result in add or removes or edits
-     * - child must result in a single add or single remove or many child changes
-     */
-    switch (fanOutChangeType) {
-      case 'remove':
-        assert(
-          types.length === 1 && types[0] === 'remove',
-          'Fan-in:remove expected all removes',
-        );
-        this.#output.push(must(candidatesToPush.get('remove')));
-        return;
-      case 'add':
-        assert(
-          types.length === 1 && types[0] === 'add',
-          'Fan-in:add expected all adds',
-        );
-        this.#output.push(must(candidatesToPush.get('add')));
-        return;
-      case 'edit': {
-        assert(
-          types.every(
-            type => type === 'add' || type === 'remove' || type === 'edit',
-          ),
-          'Fan-in:edit expected all adds, removes, or edits',
-        );
-        const addChange = candidatesToPush.get('add');
-        const removeChange = candidatesToPush.get('remove');
-        const editChange = candidatesToPush.get('edit');
-
-        // If an `edit` is present, it supersedes `add` and `remove`
-        // as it semantically represents both.
-        if (editChange) {
-          this.#output.push(editChange);
-          return;
-        }
-
-        // If `edit` didn't make it through but both `add` and `remove` did,
-        // convert back to an edit.
-        //
-        // When can this happen?
-        //
-        //  EDIT old: a=1, new: a=2
-        //            |
-        //          FanOut
-        //          /    \
-        //         a=1   a=2
-        //          |     |
-        //        remove  add
-        //          \     /
-        //           FanIn
-        //
-        // The left filter converts the edit into a remove.
-        // The right filter converts the edit into an add.
-        if (addChange && removeChange) {
-          this.#output.push({
-            type: 'edit',
-            node: addChange.node,
-            oldNode: removeChange.node,
-          } as const);
-          return;
-        }
-
-        this.#output.push(must(addChange ?? removeChange));
-        return;
-      }
-      case 'child': {
-        assert(
-          types.every(
-            type =>
-              type === 'add' || // exists can change child to add or remove
-              type === 'remove' || // exists can change child to add or remove
-              type === 'child', // other operators may preserve the child change
-          ),
-          'Fan-in:child expected all adds, removes, or children',
-        );
-        assert(
-          types.length <= 2,
-          'Fan-in:child expected at most 2 types on a child change from fan-out',
-        );
-
-        // If any branch preserved the original child change, that takes precedence over all other changes.
-        const childChange = candidatesToPush.get('child');
-        if (childChange) {
-          this.#output.push(childChange);
-          return;
-        }
-
-        const addChange = candidatesToPush.get('add');
-        const removeChange = candidatesToPush.get('remove');
-
-        assert(
-          addChange === undefined || removeChange === undefined,
-          'Fan-in:child expected either add or remove, not both',
-        );
-
-        this.#output.push(must(addChange ?? removeChange));
-        return;
-      }
-      default:
-        fanOutChangeType satisfies never;
-    }
+    pushAccumulatedChanges(
+      this.#accumulatedPushes,
+      this.#output,
+      fanOutChangeType,
+      identity,
+      identity,
+    );
   }
 }

--- a/packages/zql/src/ivm/push-accumulated.test.ts
+++ b/packages/zql/src/ivm/push-accumulated.test.ts
@@ -1,0 +1,676 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {expect, test, describe, beforeEach} from 'vitest';
+import {
+  pushAccumulatedChanges,
+  mergeRelationships,
+  makeAddEmptyRelationships,
+  mergeEmpty,
+} from './push-accumulated.js';
+import type {Change} from './change.js';
+import type {Output} from './operator.js';
+import type {SourceSchema} from './schema.js';
+import {identity} from '../../../shared/src/sentinels.ts';
+
+const mockChildChange: Change = {
+  type: 'child',
+  node: {row: {id: 1}, relationships: {}},
+  child: {
+    change: {
+      type: 'add',
+      node: {row: {id: 2}, relationships: {}},
+    },
+    relationshipName: 'child',
+  },
+};
+
+const mockSchema: SourceSchema = {
+  tableName: 'test',
+  columns: {},
+  primaryKey: ['id'],
+  relationships: {
+    rel1: {} as any,
+    rel2: {} as any,
+  },
+  compareRows: () => 0,
+  isHidden: false,
+  sort: [],
+  system: 'client',
+};
+
+describe('pushAccumulatedChanges', () => {
+  let output: Output;
+  let pushedChanges: Change[];
+
+  beforeEach(() => {
+    pushedChanges = [];
+    output = {
+      push: (change: Change) => {
+        pushedChanges.push(change);
+      },
+    } as Output;
+  });
+
+  describe('invariant: add coming in will only create adds coming out', () => {
+    test('single add change passes through', () => {
+      const accumulatedPushes: Change[] = [
+        {
+          type: 'add',
+          node: {row: {id: 1}, relationships: {}},
+        },
+      ];
+
+      pushAccumulatedChanges(
+        accumulatedPushes,
+        output,
+        'add',
+        mergeRelationships,
+        identity,
+      );
+
+      expect(pushedChanges).toHaveLength(1);
+      expect(pushedChanges[0]?.type).toBe('add');
+    });
+
+    test('multiple add changes collapse to single add', () => {
+      const accumulatedPushes: Change[] = [
+        {
+          type: 'add',
+          node: {row: {id: 1}, relationships: {rel1: () => []}},
+        },
+        {
+          type: 'add',
+          node: {row: {id: 1}, relationships: {rel2: () => []}},
+        },
+      ];
+
+      pushAccumulatedChanges(
+        accumulatedPushes,
+        output,
+        'add',
+        mergeRelationships,
+        identity,
+      );
+
+      expect(pushedChanges).toHaveLength(1);
+      expect(pushedChanges[0]?.type).toBe('add');
+      expect(Object.keys(pushedChanges[0]?.node?.relationships ?? {})).toEqual(
+        expect.arrayContaining(['rel1', 'rel2']),
+      );
+    });
+
+    test('no changes when all branches filter out add', () => {
+      const accumulatedPushes: Change[] = [];
+
+      pushAccumulatedChanges(
+        accumulatedPushes,
+        output,
+        'add',
+        mergeRelationships,
+        identity,
+      );
+
+      expect(pushedChanges).toHaveLength(0);
+    });
+  });
+
+  describe('invariant: remove coming in will only create removes coming out', () => {
+    test('single remove change passes through', () => {
+      const accumulatedPushes: Change[] = [
+        {
+          type: 'remove',
+          node: {row: {id: 1}, relationships: {}},
+        },
+      ];
+
+      pushAccumulatedChanges(
+        accumulatedPushes,
+        output,
+        'remove',
+        mergeRelationships,
+        identity,
+      );
+
+      expect(pushedChanges).toHaveLength(1);
+      expect(pushedChanges[0]?.type).toBe('remove');
+    });
+
+    test('multiple remove changes collapse to single remove', () => {
+      const accumulatedPushes: Change[] = [
+        {
+          type: 'remove',
+          node: {row: {id: 1}, relationships: {rel1: () => []}},
+        },
+        {
+          type: 'remove',
+          node: {row: {id: 1}, relationships: {rel2: () => []}},
+        },
+      ];
+
+      pushAccumulatedChanges(
+        accumulatedPushes,
+        output,
+        'remove',
+        mergeRelationships,
+        identity,
+      );
+
+      expect(pushedChanges).toHaveLength(1);
+      expect(pushedChanges[0]?.type).toBe('remove');
+      expect(Object.keys(pushedChanges[0]?.node?.relationships ?? {})).toEqual(
+        expect.arrayContaining(['rel1', 'rel2']),
+      );
+    });
+  });
+
+  describe('invariant: edit coming in can create adds, removes, and edits coming out', () => {
+    test('edit preserved as edit', () => {
+      const accumulatedPushes: Change[] = [
+        {
+          type: 'edit',
+          node: {row: {id: 1, value: 2}, relationships: {}},
+          oldNode: {row: {id: 1, value: 1}, relationships: {}},
+        },
+      ];
+
+      pushAccumulatedChanges(
+        accumulatedPushes,
+        output,
+        'edit',
+        mergeRelationships,
+        identity,
+      );
+
+      expect(pushedChanges).toHaveLength(1);
+      expect(pushedChanges[0]?.type).toBe('edit');
+    });
+
+    test('edit converted to add only', () => {
+      const accumulatedPushes: Change[] = [
+        {
+          type: 'add',
+          node: {row: {id: 1, value: 2}, relationships: {}},
+        },
+      ];
+
+      pushAccumulatedChanges(
+        accumulatedPushes,
+        output,
+        'edit',
+        mergeRelationships,
+        identity,
+      );
+
+      expect(pushedChanges).toHaveLength(1);
+      expect(pushedChanges[0]?.type).toBe('add');
+    });
+
+    test('edit converted to remove only', () => {
+      const accumulatedPushes: Change[] = [
+        {
+          type: 'remove',
+          node: {row: {id: 1, value: 1}, relationships: {}},
+        },
+      ];
+
+      pushAccumulatedChanges(
+        accumulatedPushes,
+        output,
+        'edit',
+        mergeRelationships,
+        identity,
+      );
+
+      expect(pushedChanges).toHaveLength(1);
+      expect(pushedChanges[0]?.type).toBe('remove');
+    });
+
+    test('edit split into add and remove recombines to edit', () => {
+      const accumulatedPushes: Change[] = [
+        {
+          type: 'add',
+          node: {row: {id: 1, value: 2}, relationships: {}},
+        },
+        {
+          type: 'remove',
+          node: {row: {id: 1, value: 1}, relationships: {}},
+        },
+      ];
+
+      pushAccumulatedChanges(
+        accumulatedPushes,
+        output,
+        'edit',
+        mergeRelationships,
+        identity,
+      );
+
+      expect(pushedChanges).toHaveLength(1);
+      expect(pushedChanges[0]?.type).toBe('edit');
+      expect(pushedChanges[0]).toEqual({
+        type: 'edit',
+        node: {row: {id: 1, value: 2}, relationships: {}},
+        oldNode: {row: {id: 1, value: 1}, relationships: {}},
+      });
+    });
+
+    test('edit supersedes add and remove when all three present', () => {
+      const accumulatedPushes: Change[] = [
+        {
+          type: 'edit',
+          node: {row: {id: 1, value: 3}, relationships: {editRel: () => []}},
+          oldNode: {row: {id: 1, value: 0}, relationships: {}},
+        },
+        {
+          type: 'add',
+          node: {row: {id: 1, value: 2}, relationships: {addRel: () => []}},
+        },
+        {
+          type: 'remove',
+          node: {row: {id: 1, value: 1}, relationships: {removeRel: () => []}},
+        },
+      ];
+
+      pushAccumulatedChanges(
+        accumulatedPushes,
+        output,
+        'edit',
+        mergeRelationships,
+        identity,
+      );
+
+      expect(pushedChanges).toHaveLength(1);
+      expect(pushedChanges[0]?.type).toBe('edit');
+      const editChange = pushedChanges[0] as Extract<Change, {type: 'edit'}>;
+      expect(Object.keys(editChange.node.relationships)).toEqual(
+        expect.arrayContaining(['editRel', 'addRel']),
+      );
+      expect(Object.keys(editChange.oldNode.relationships)).toEqual(
+        expect.arrayContaining(['removeRel']),
+      );
+    });
+  });
+
+  describe('invariant: child coming in can create adds, removes, and children coming out', () => {
+    test('child preserved as child takes precedence', () => {
+      const accumulatedPushes: Change[] = [mockChildChange];
+
+      pushAccumulatedChanges(
+        accumulatedPushes,
+        output,
+        'child',
+        mergeRelationships,
+        identity,
+      );
+
+      expect(pushedChanges).toHaveLength(1);
+      expect(pushedChanges[0]?.type).toBe('child');
+    });
+
+    test('child converted to add only', () => {
+      const accumulatedPushes: Change[] = [
+        {
+          type: 'add',
+          node: {row: {id: 1}, relationships: {}},
+        },
+      ];
+
+      pushAccumulatedChanges(
+        accumulatedPushes,
+        output,
+        'child',
+        mergeRelationships,
+        identity,
+      );
+
+      expect(pushedChanges).toHaveLength(1);
+      expect(pushedChanges[0]?.type).toBe('add');
+    });
+
+    test('child converted to remove only', () => {
+      const accumulatedPushes: Change[] = [
+        {
+          type: 'remove',
+          node: {row: {id: 1}, relationships: {}},
+        },
+      ];
+
+      pushAccumulatedChanges(
+        accumulatedPushes,
+        output,
+        'child',
+        mergeRelationships,
+        identity,
+      );
+
+      expect(pushedChanges).toHaveLength(1);
+      expect(pushedChanges[0]?.type).toBe('remove');
+    });
+
+    test('child takes precedence over add/remove when present', () => {
+      const accumulatedPushes: Change[] = [
+        mockChildChange,
+        {
+          type: 'add',
+          node: {row: {id: 1}, relationships: {}},
+        },
+      ];
+
+      pushAccumulatedChanges(
+        accumulatedPushes,
+        output,
+        'child',
+        mergeRelationships,
+        identity,
+      );
+
+      expect(pushedChanges).toHaveLength(1);
+      expect(pushedChanges[0]?.type).toBe('child');
+    });
+
+    test('child ensures at most one add or remove (not both)', () => {
+      // This should assert fail if both add and remove are present without child
+      const accumulatedPushes: Change[] = [
+        {
+          type: 'add',
+          node: {row: {id: 1}, relationships: {}},
+        },
+        {
+          type: 'remove',
+          node: {row: {id: 2}, relationships: {}},
+        },
+      ];
+
+      expect(() => {
+        pushAccumulatedChanges(
+          accumulatedPushes,
+          output,
+          'child',
+          mergeRelationships,
+          identity,
+        );
+      }).toThrow('Fan-in:child expected either add or remove, not both');
+    });
+  });
+});
+
+describe('mergeRelationships', () => {
+  test('merges relationships from add changes', () => {
+    const left: Change = {
+      type: 'add',
+      node: {row: {id: 1}, relationships: {rel1: () => []}},
+    };
+    const right: Change = {
+      type: 'add',
+      node: {row: {id: 1}, relationships: {rel2: () => []}},
+    };
+
+    const result = mergeRelationships(left, right);
+
+    expect(result.type).toBe('add');
+    expect(Object.keys(result.node.relationships)).toEqual(
+      expect.arrayContaining(['rel1', 'rel2']),
+    );
+  });
+
+  test('merges relationships from remove changes', () => {
+    const left: Change = {
+      type: 'remove',
+      node: {row: {id: 1}, relationships: {rel1: () => []}},
+    };
+    const right: Change = {
+      type: 'remove',
+      node: {row: {id: 1}, relationships: {rel2: () => []}},
+    };
+
+    const result = mergeRelationships(left, right);
+
+    expect(result.type).toBe('remove');
+    expect(Object.keys(result.node.relationships)).toEqual(
+      expect.arrayContaining(['rel1', 'rel2']),
+    );
+  });
+
+  test('merges relationships from edit changes', () => {
+    const left: Change = {
+      type: 'edit',
+      node: {row: {id: 1}, relationships: {rel1: () => []}},
+      oldNode: {row: {id: 1}, relationships: {oldRel1: () => []}},
+    };
+    const right: Change = {
+      type: 'edit',
+      node: {row: {id: 1}, relationships: {rel2: () => []}},
+      oldNode: {row: {id: 1}, relationships: {oldRel2: () => []}},
+    };
+
+    const result = mergeRelationships(left, right) as Extract<
+      Change,
+      {type: 'edit'}
+    >;
+
+    expect(result.type).toBe('edit');
+    expect(Object.keys(result.node.relationships)).toEqual(
+      expect.arrayContaining(['rel1', 'rel2']),
+    );
+    expect(Object.keys(result.oldNode.relationships)).toEqual(
+      expect.arrayContaining(['oldRel1', 'oldRel2']),
+    );
+  });
+
+  test('left takes precedence when same relationship exists', () => {
+    const rel1Left = () => [];
+    const rel1Right = () => [];
+
+    const left: Change = {
+      type: 'add',
+      node: {row: {id: 1}, relationships: {rel1: rel1Left}},
+    };
+    const right: Change = {
+      type: 'add',
+      node: {row: {id: 1}, relationships: {rel1: rel1Right}},
+    };
+
+    const result = mergeRelationships(left, right) as Extract<
+      Change,
+      {type: 'add'}
+    >;
+
+    expect(result.node.relationships.rel1).toBe(rel1Left);
+  });
+
+  test('merges edit with add', () => {
+    const left: Change = {
+      type: 'edit',
+      node: {row: {id: 1}, relationships: {editRel: () => []}},
+      oldNode: {row: {id: 1}, relationships: {}},
+    };
+    const right: Change = {
+      type: 'add',
+      node: {row: {id: 1}, relationships: {addRel: () => []}},
+    };
+
+    const result = mergeRelationships(left, right) as Extract<
+      Change,
+      {type: 'edit'}
+    >;
+
+    expect(result.type).toBe('edit');
+    expect(Object.keys(result.node.relationships)).toEqual(
+      expect.arrayContaining(['editRel', 'addRel']),
+    );
+  });
+
+  test('merges edit with remove', () => {
+    const left: Change = {
+      type: 'edit',
+      node: {row: {id: 1}, relationships: {}},
+      oldNode: {row: {id: 1}, relationships: {editOldRel: () => []}},
+    };
+    const right: Change = {
+      type: 'remove',
+      node: {row: {id: 1}, relationships: {removeRel: () => []}},
+    };
+
+    const result = mergeRelationships(left, right) as Extract<
+      Change,
+      {type: 'edit'}
+    >;
+
+    expect(result.type).toBe('edit');
+    expect(Object.keys(result.oldNode.relationships)).toEqual(
+      expect.arrayContaining(['editOldRel', 'removeRel']),
+    );
+  });
+});
+
+describe('makeAddEmptyRelationships', () => {
+  test('adds empty relationships for add change', () => {
+    const schema: SourceSchema = mockSchema;
+
+    const addEmptyRelationships = makeAddEmptyRelationships(schema);
+
+    const change: Change = {
+      type: 'add',
+      node: {row: {id: 1}, relationships: {}},
+    };
+
+    const result = addEmptyRelationships(change) as Extract<
+      Change,
+      {type: 'add'}
+    >;
+
+    expect(Object.keys(result.node.relationships)).toEqual(
+      expect.arrayContaining(['rel1', 'rel2']),
+    );
+    expect(result.node.relationships.rel1?.()).toEqual([]);
+    expect(result.node.relationships.rel2?.()).toEqual([]);
+  });
+
+  test('adds empty relationships for remove change', () => {
+    const schema: SourceSchema = mockSchema;
+
+    const addEmptyRelationships = makeAddEmptyRelationships(schema);
+
+    const change: Change = {
+      type: 'remove',
+      node: {row: {id: 1}, relationships: {}},
+    };
+
+    const result = addEmptyRelationships(change) as Extract<
+      Change,
+      {type: 'remove'}
+    >;
+
+    expect(Object.keys(result.node.relationships)).toEqual(
+      expect.arrayContaining(['rel1', 'rel2']),
+    );
+  });
+
+  test('adds empty relationships for edit change', () => {
+    const schema: SourceSchema = mockSchema;
+
+    const addEmptyRelationships = makeAddEmptyRelationships(schema);
+
+    const change: Change = {
+      type: 'edit',
+      node: {row: {id: 1}, relationships: {}},
+      oldNode: {row: {id: 1}, relationships: {}},
+    };
+
+    const result = addEmptyRelationships(change) as Extract<
+      Change,
+      {type: 'edit'}
+    >;
+
+    expect(Object.keys(result.node.relationships)).toEqual(
+      expect.arrayContaining(['rel1', 'rel2']),
+    );
+    expect(Object.keys(result.oldNode.relationships)).toEqual(
+      expect.arrayContaining(['rel1', 'rel2']),
+    );
+  });
+
+  test('preserves existing relationships', () => {
+    const schema: SourceSchema = mockSchema;
+
+    const addEmptyRelationships = makeAddEmptyRelationships(schema);
+
+    const existingRel = () => [{row: {id: 2}, relationships: {}}];
+    const change: Change = {
+      type: 'add',
+      node: {row: {id: 1}, relationships: {rel1: existingRel}},
+    };
+
+    const result = addEmptyRelationships(change) as Extract<
+      Change,
+      {type: 'add'}
+    >;
+
+    expect(result.node.relationships.rel1).toBe(existingRel);
+    expect(result.node.relationships.rel2?.()).toEqual([]);
+  });
+
+  test('does not modify child changes', () => {
+    const schema: SourceSchema = mockSchema;
+
+    const addEmptyRelationships = makeAddEmptyRelationships(schema);
+
+    const change: Change = mockChildChange;
+
+    const result = addEmptyRelationships(change);
+
+    expect(result).toBe(change);
+  });
+
+  test('returns unchanged when schema has no relationships', () => {
+    const schema: SourceSchema = {
+      tableName: 'test',
+      columns: {},
+      primaryKey: ['id'],
+      relationships: {},
+      compareRows: () => 0,
+      isHidden: false,
+      sort: [],
+      system: 'client',
+    };
+
+    const addEmptyRelationships = makeAddEmptyRelationships(schema);
+
+    const change: Change = {
+      type: 'add',
+      node: {row: {id: 1}, relationships: {}},
+    };
+
+    const result = addEmptyRelationships(change);
+
+    expect(result).toBe(change);
+  });
+});
+
+describe('mergeEmpty', () => {
+  test('adds empty streams for missing relationships', () => {
+    const relationships: Record<string, () => any[]> = {
+      existing: () => [{id: 1}],
+    };
+
+    mergeEmpty(relationships, ['existing', 'new1', 'new2']);
+
+    expect(Object.keys(relationships)).toEqual(
+      expect.arrayContaining(['existing', 'new1', 'new2']),
+    );
+    expect(relationships.existing()).toEqual([{id: 1}]);
+    expect(relationships.new1()).toEqual([]);
+    expect(relationships.new2()).toEqual([]);
+  });
+
+  test('does not overwrite existing relationships', () => {
+    const existingFn = () => [{id: 1}];
+    const relationships: Record<string, () => any[]> = {
+      rel1: existingFn,
+    };
+
+    mergeEmpty(relationships, ['rel1', 'rel2']);
+
+    expect(relationships.rel1).toBe(existingFn);
+    expect(relationships.rel2()).toEqual([]);
+  });
+});

--- a/packages/zql/src/ivm/push-accumulated.ts
+++ b/packages/zql/src/ivm/push-accumulated.ts
@@ -1,0 +1,395 @@
+import {assert, unreachable} from '../../../shared/src/asserts.ts';
+import {must} from '../../../shared/src/must.ts';
+import {emptyArray} from '../../../shared/src/sentinels.ts';
+import type {Change} from './change.ts';
+import type {Node} from './data.ts';
+import type {Output} from './operator.ts';
+import type {SourceSchema} from './schema.ts';
+import type {Stream} from './stream.ts';
+
+/**
+ * # pushAccumulatedChanges
+ *
+ * Pushes the changes that were accumulated by
+ * [fan-out, fan-in] or [ufo, ufi] sub-graphs.
+ *
+ * This function is called at the end of the sub-graph.
+ *
+ * The sub-graphs represents `OR`s.
+ *
+ * Changes that can enter the subgraphs:
+ * 1. child (due to exist joins being above the sub-graph)
+ * 2. add
+ * 3. remove
+ * 4. edit
+ *
+ * # Changes that can exit into `pushAccumulatedChanges`:
+ *
+ * ## Child
+ * If a `child` change enters a sub-graph, it will flow to all branches.
+ * Each branch will either:
+ * - preserve the `child` change
+ * - stop the `child` change (e.g., filter)
+ * - convert it to an `add` or `remove` (e.g., exists filter)
+ *
+ * ## Add
+ * If an `add` change enters a sub-graph, it will flow to all branches.
+ * Each branch will either:
+ * - preserve the `add` change
+ * - hide the change (e.g., filter)
+ *
+ * ## Remove
+ * If a `remove` change enters a sub-graph, it will flow to all branches.
+ * Each branch will either:
+ * - preserve the `remove` change
+ * - hide the change (e.g., filter)
+ *
+ * ## Edit
+ * If an `edit` change enters a sub-graph, it will flow to all branches.
+ * Each branch will either:
+ * - preserve the `edit` change
+ * - convert it to an `add` (e.g., filter where old didn't match but new does)
+ * - convert it to a `remove` (e.g., filter where old matched but new doesn't)
+ *
+ * This results in some invariants:
+ * - an add coming in will only create adds coming out
+ * - a remove coming in will only create removes coming out
+ * - an edit coming in can create adds, removes, and edits coming out
+ * - a child coming in can create adds, removes, and children coming out
+ *
+ * # Return of `pushAccumulatedChanges`
+ *
+ * This function will only push a single change.
+ * Given the above invariants, how is this possible?
+ *
+ * An add that becomes many `adds` results in a single add
+ * as the `add` is the same row across all adds. Branches do not change the row.
+ *
+ * A remove that becomes many `removes` results in a single remove
+ * for the same reason.
+ *
+ * If a child enters and exits, it takes precedence over all other changes.
+ * If a child enters and is converted only to add and remove it exits as an edit.
+ * If a child enters and is converted to only add or only remove, it exits as that change.
+ *
+ * If an edit enters and is converted to add and remove it exits as an edit.
+ * If an edit enters and is converted to only add or only remove, it exits as that change.
+ * If an edit enters and exits as edits only, it exits as a single edit.
+ */
+export function pushAccumulatedChanges(
+  accumulatedPushes: Change[],
+  output: Output,
+  fanOutChangeType: Change['type'],
+  mergeRelationships: (existing: Change, incoming: Change) => Change,
+  addEmptyRelationships: (change: Change) => Change,
+) {
+  if (accumulatedPushes.length === 0) {
+    // It is possible for no forks to pass along the push.
+    // E.g., if no filters match in any fork.
+    return;
+  }
+
+  // collapse down to a single change per type
+  const candidatesToPush = new Map<Change['type'], Change>();
+  for (const change of accumulatedPushes) {
+    if (fanOutChangeType === 'child' && change.type !== 'child') {
+      assert(
+        candidatesToPush.has(change.type) === false,
+        () =>
+          `Fan-in:child expected at most one ${change.type} when fan-out is of type child`,
+      );
+    }
+
+    const existing = candidatesToPush.get(change.type);
+    let mergedChange = change;
+    if (existing) {
+      // merge in relationships
+      mergedChange = mergeRelationships(existing, change);
+    }
+    candidatesToPush.set(change.type, mergedChange);
+  }
+
+  accumulatedPushes.length = 0;
+
+  const types = [...candidatesToPush.keys()];
+  /**
+   * Based on the received `fanOutChangeType` only certain output types are valid.
+   *
+   * - remove must result in all removes
+   * - add must result in all adds
+   * - edit must result in add or removes or edits
+   * - child must result in a single add or single remove or many child changes
+   *    - Single add or remove because the relationship will be unique to one exist check within the fan-out,fan-in sub-graph
+   *    - Many child changes because other operators may preserve the child change
+   */
+  switch (fanOutChangeType) {
+    case 'remove':
+      assert(
+        types.length === 1 && types[0] === 'remove',
+        'Fan-in:remove expected all removes',
+      );
+      output.push(addEmptyRelationships(must(candidatesToPush.get('remove'))));
+      return;
+    case 'add':
+      assert(
+        types.length === 1 && types[0] === 'add',
+        'Fan-in:add expected all adds',
+      );
+      output.push(addEmptyRelationships(must(candidatesToPush.get('add'))));
+      return;
+    case 'edit': {
+      assert(
+        types.every(
+          type => type === 'add' || type === 'remove' || type === 'edit',
+        ),
+        'Fan-in:edit expected all adds, removes, or edits',
+      );
+      const addChange = candidatesToPush.get('add');
+      const removeChange = candidatesToPush.get('remove');
+      let editChange = candidatesToPush.get('edit');
+
+      // If an `edit` is present, it supersedes `add` and `remove`
+      // as it semantically represents both.
+      if (editChange) {
+        if (addChange) {
+          editChange = mergeRelationships(editChange, addChange);
+        }
+        if (removeChange) {
+          editChange = mergeRelationships(editChange, removeChange);
+        }
+        output.push(addEmptyRelationships(editChange));
+        return;
+      }
+
+      // If `edit` didn't make it through but both `add` and `remove` did,
+      // convert back to an edit.
+      //
+      // When can this happen?
+      //
+      //  EDIT old: a=1, new: a=2
+      //            |
+      //          FanOut
+      //          /    \
+      //         a=1   a=2
+      //          |     |
+      //        remove  add
+      //          \     /
+      //           FanIn
+      //
+      // The left filter converts the edit into a remove.
+      // The right filter converts the edit into an add.
+      if (addChange && removeChange) {
+        output.push(
+          addEmptyRelationships({
+            type: 'edit',
+            node: addChange.node,
+            oldNode: removeChange.node,
+          } as const),
+        );
+        return;
+      }
+
+      output.push(addEmptyRelationships(must(addChange ?? removeChange)));
+      return;
+    }
+    case 'child': {
+      assert(
+        types.every(
+          type =>
+            type === 'add' || // exists can change child to add or remove
+            type === 'remove' || // exists can change child to add or remove
+            type === 'child', // other operators may preserve the child change
+        ),
+        'Fan-in:child expected all adds, removes, or children',
+      );
+      assert(
+        types.length <= 2,
+        'Fan-in:child expected at most 2 types on a child change from fan-out',
+      );
+
+      // If any branch preserved the original child change, that takes precedence over all other changes.
+      const childChange = candidatesToPush.get('child');
+      if (childChange) {
+        output.push(childChange);
+        return;
+      }
+
+      const addChange = candidatesToPush.get('add');
+      const removeChange = candidatesToPush.get('remove');
+
+      assert(
+        addChange === undefined || removeChange === undefined,
+        'Fan-in:child expected either add or remove, not both',
+      );
+
+      output.push(addEmptyRelationships(must(addChange ?? removeChange)));
+      return;
+    }
+    default:
+      fanOutChangeType satisfies never;
+  }
+}
+
+/**
+ * Puts relationships from `right` into `left` if they don't already exist in `left`.
+ */
+export function mergeRelationships(left: Change, right: Change): Change {
+  // change types will always match
+  // unless we have an edit on the left
+  // then the right could be edit, add, or remove
+  if (left.type === right.type) {
+    switch (left.type) {
+      case 'add': {
+        return {
+          type: 'add',
+          node: {
+            row: left.node.row,
+            relationships: {
+              ...right.node.relationships,
+              ...left.node.relationships,
+            },
+          },
+        };
+      }
+      case 'remove': {
+        return {
+          type: 'remove',
+          node: {
+            row: left.node.row,
+            relationships: {
+              ...right.node.relationships,
+              ...left.node.relationships,
+            },
+          },
+        };
+      }
+      case 'edit': {
+        assert(right.type === 'edit');
+        // merge edits into a single edit
+        return {
+          type: 'edit',
+          node: {
+            row: left.node.row,
+            relationships: {
+              ...right.node.relationships,
+              ...left.node.relationships,
+            },
+          },
+          oldNode: {
+            row: left.oldNode.row,
+            relationships: {
+              ...right.oldNode.relationships,
+              ...left.oldNode.relationships,
+            },
+          },
+        };
+      }
+    }
+  }
+
+  // left is always an edit here
+  assert(left.type === 'edit');
+  switch (right.type) {
+    case 'add': {
+      return {
+        type: 'edit',
+        node: {
+          ...left.node,
+          relationships: {
+            ...right.node.relationships,
+            ...left.node.relationships,
+          },
+        },
+        oldNode: left.oldNode,
+      };
+    }
+    case 'remove': {
+      return {
+        type: 'edit',
+        node: left.node,
+        oldNode: {
+          ...left.oldNode,
+          relationships: {
+            ...right.node.relationships,
+            ...left.oldNode.relationships,
+          },
+        },
+      };
+    }
+  }
+
+  unreachable();
+}
+
+export function makeAddEmptyRelationships(
+  schema: SourceSchema,
+): (change: Change) => Change {
+  return (change: Change): Change => {
+    if (Object.keys(schema.relationships).length === 0) {
+      return change;
+    }
+
+    switch (change.type) {
+      case 'add':
+      case 'remove': {
+        const ret = {
+          ...change,
+          node: {
+            ...change.node,
+            relationships: {
+              ...change.node.relationships,
+            },
+          },
+        };
+
+        mergeEmpty(ret.node.relationships, Object.keys(schema.relationships));
+
+        return ret;
+      }
+      case 'edit': {
+        const ret = {
+          ...change,
+          node: {
+            ...change.node,
+            relationships: {
+              ...change.node.relationships,
+            },
+          },
+          oldNode: {
+            ...change.oldNode,
+            relationships: {
+              ...change.oldNode.relationships,
+            },
+          },
+        };
+
+        mergeEmpty(ret.node.relationships, Object.keys(schema.relationships));
+        mergeEmpty(
+          ret.oldNode.relationships,
+          Object.keys(schema.relationships),
+        );
+
+        return ret;
+      }
+      case 'child':
+        return change; // children only have relationships along the path to the change
+    }
+  };
+}
+
+/**
+ * For each relationship in `schema` that does not exist
+ * in `relationships`, add it with an empty stream.
+ *
+ * This modifies the `relationships` object in place.
+ */
+export function mergeEmpty(
+  relationships: Record<string, () => Stream<Node>>,
+  relationshipNames: string[],
+) {
+  for (const relName of relationshipNames) {
+    if (relationships[relName] === undefined) {
+      relationships[relName] = () => emptyArray;
+    }
+  }
+}


### PR DESCRIPTION
`fan-in` and `union-fan-in` will do nearly identical things in push accumulated changes. Factor the code out.

The one big change is that `union-fan-in` will merge relationships. Added two arguments to handle relationship merging