### PR TITLE
fix(zql): use correct comparator for generateWithStart in MemorySource

### DIFF
--- a/packages/zql/src/ivm/constraint.ts
+++ b/packages/zql/src/ivm/constraint.ts
@@ -40,7 +40,7 @@ export function constraintMatchesPrimaryKey(
   constraintKeys.sort(stringCompare);
 
   for (let i = 0; i < constraintKeys.length; i++) {
-    if (constraintKeys[i][0] !== primary[i]) {
+    if (constraintKeys[i] !== primary[i]) {
       return false;
     }
   }

--- a/packages/zql/src/ivm/flipped-join.ts
+++ b/packages/zql/src/ivm/flipped-join.ts
@@ -113,7 +113,7 @@ export class FlippedJoin implements Input {
   *fetch(req: FetchRequest): Stream<Node> {
     const childNodes = [...this.#child.fetch({})];
     // FlippedJoin's split-push change overlay logic is largely
-    // the same as Join's, which the exception of remove.  For remove,
+    // the same as Join's with the exception of remove.  For remove,
     // the change is undone here, and then re-applied to parents with order
     // less than or equal to change.position below.  This is necessary
     // because if the removed node was the last related child, the

--- a/packages/zql/src/ivm/memory-source.ts
+++ b/packages/zql/src/ivm/memory-source.ts
@@ -329,6 +329,15 @@ export class MemorySource implements Source {
       this.#overlay,
       this.#splitEditOverlay,
       callingConnectionIndex,
+      // Use indexComparator, generateWithOverlayInner has a subtle dependency
+      // on this.  Since generateWithConstraint is done after
+      // generateWithOverlay, the generator consumed by generateWithOverlayInner
+      // does not end when the constraint stops matching and so the final
+      // check to yield an add overlay if not yet yielded is not reached.
+      // However, using the indexComparator the add overlay will be less than
+      // the first row that does not match the constraint, and so any
+      // not yet yielded add overlay will be yielded when the first row
+      // not matching the constraint is reached.
       indexComparator,
       conn.filters?.predicate,
     );

--- a/packages/zql/src/ivm/memory-source.ts
+++ b/packages/zql/src/ivm/memory-source.ts
@@ -284,7 +284,7 @@ export class MemorySource implements Source {
 
     const index = this.#getOrCreateIndex(indexSort, from);
     const {data, comparator: compare} = index;
-    const comparator = (r1: Row, r2: Row) =>
+    const indexComparator = (r1: Row, r2: Row) =>
       compare(r1, r2) * (req.reverse ? -1 : 1);
 
     const startAt = req.start?.row;
@@ -329,7 +329,7 @@ export class MemorySource implements Source {
       this.#overlay,
       this.#splitEditOverlay,
       callingConnectionIndex,
-      comparator,
+      indexComparator,
       conn.filters?.predicate,
     );
 

--- a/packages/zql/src/ivm/memory-source.ts
+++ b/packages/zql/src/ivm/memory-source.ts
@@ -251,7 +251,9 @@ export class MemorySource implements Source {
     const callingConnectionIndex = this.#connections.indexOf(from);
     assert(callingConnectionIndex !== -1, 'Output not found');
     const conn = this.#connections[callingConnectionIndex];
-    const {sort: requestedSort} = conn;
+    const {sort: requestedSort, compareRows} = conn;
+    const connectionComparator = (r1: Row, r2: Row) =>
+      compareRows(r1, r2) * (req.reverse ? -1 : 1);
 
     const pkConstraint = primaryKeyConstraintFromFilters(
       conn.filters?.condition,
@@ -332,7 +334,7 @@ export class MemorySource implements Source {
     );
 
     const withConstraint = generateWithConstraint(
-      generateWithStart(withOverlay, req.start, comparator),
+      generateWithStart(withOverlay, req.start, connectionComparator),
       // we use `req.constraint` and not `fetchOrPkConstraint` here because we need to
       // AND the constraint with what could have been the primary key constraint
       req.constraint,

--- a/packages/zql/src/ivm/source.test.ts
+++ b/packages/zql/src/ivm/source.test.ts
@@ -362,7 +362,7 @@ suite('fetch-with-constraint-and-start', () => {
           "relationships": {},
           "row": {
             "a": 5,
-            "b": "1000",
+            "b": "3000",
           },
         },
       ]

--- a/packages/zql/src/ivm/source.test.ts
+++ b/packages/zql/src/ivm/source.test.ts
@@ -339,6 +339,67 @@ suite('fetch-with-constraint-and-start', () => {
     });
   }
 
+  test('c1', () => {
+    expect(
+      t({
+        startData: [
+          {a: 1, b: '1000'},
+          {a: 2, b: '3000'},
+          {a: 3, b: '2000'},
+          {a: 5, b: '1000'},
+          {a: 6, b: '4000'},
+          {a: 7, b: '0000'},
+        ],
+        start: {
+          row: {a: 3, b: '2000'},
+          basis: 'at',
+        },
+        constraint: {b: '1000'},
+      }),
+    ).toMatchInlineSnapshot(`
+      [
+        {
+          "relationships": {},
+          "row": {
+            "a": 5,
+            "b": "1000",
+          },
+        },
+      ]
+    `);
+  });
+
+  test('c1 reverse', () => {
+    expect(
+      t({
+        startData: [
+          {a: 1, b: '1000'},
+          {a: 2, b: '3000'},
+          {a: 3, b: '2000'},
+          {a: 5, b: '1000'},
+          {a: 6, b: '4000'},
+          {a: 7, b: '0000'},
+        ],
+        start: {
+          row: {a: 3, b: '2000'},
+          basis: 'at',
+        },
+        constraint: {b: '1000'},
+        reverse: true,
+      }),
+    ).toMatchInlineSnapshot(`
+      [
+        {
+          "relationships": {},
+          "row": {
+            "a": 1,
+            "b": "1000",
+          },
+        },
+      ]
+    `);
+  });
+
   test('c2', () => {
     expect(
       t({

--- a/packages/zql/src/ivm/source.test.ts
+++ b/packages/zql/src/ivm/source.test.ts
@@ -342,6 +342,10 @@ suite('fetch-with-constraint-and-start', () => {
   test('c1', () => {
     expect(
       t({
+        columns: {
+          a: {type: 'number'},
+          b: {type: 'string'},
+        },
         startData: [
           {a: 1, b: '1000'},
           {a: 2, b: '3000'},
@@ -372,6 +376,10 @@ suite('fetch-with-constraint-and-start', () => {
   test('c1 reverse', () => {
     expect(
       t({
+        columns: {
+          a: {type: 'number'},
+          b: {type: 'string'},
+        },
         startData: [
           {a: 1, b: '1000'},
           {a: 2, b: '3000'},

--- a/packages/zql/src/ivm/source.test.ts
+++ b/packages/zql/src/ivm/source.test.ts
@@ -362,7 +362,7 @@ suite('fetch-with-constraint-and-start', () => {
           "relationships": {},
           "row": {
             "a": 5,
-            "b": "3000",
+            "b": "1000",
           },
         },
       ]


### PR DESCRIPTION
Pass the connectionComparator rather than the indexComparator to genereateWithStart.

To understand the bug consider this test case

```
  function t(c: {
    columns?: Record<string, SchemaValue> | undefined;
    startData: Row[];
    start: Start;
    constraint: Constraint;
    reverse?: boolean | undefined;
  }) {
    const sort = [['a', 'asc']] as const;
    const s = createSource(
      lc,
      testLogConfig,
      'table',
      c.columns ?? {
        a: {type: 'number'},
        b: {type: 'boolean'},
      },
      ['a'],
    );
    for (const row of c.startData) {
      s.push({type: 'add', row});
    }
    const out = new Catch(s.connect(sort));
    return out.fetch({
      constraint: c.constraint,
      start: c.start,
      reverse: c.reverse,
    });
  }

  test('c1', () => {
    expect(
      t({
        startData: [
          {a: 1, b: '1000'},
          {a: 2, b: '3000'},
          {a: 3, b: '2000'},
          {a: 5, b: '1000'},
          {a: 6, b: '4000'},
          {a: 7, b: '0000'},
        ],
        start: {
          row: {a: 3, b: '2000'},
          basis: 'at',
        },
        constraint: {b: '1000'},
      }),
    ).toMatchInlineSnapshot(`
      [
        {
          "relationships": {},
          "row": {
            "a": 5,
            "b": "1000",
          },
        },
      ]
    `);
  });
```

connectionComparator is [['a', 'asc']], 
while indexComparator is [['b', 'asc'], ['a', 'asc']]

So the index orders the rows like
          {a: 7, b: '0000'},       
          {a: 1, b: '1000'},
          {a: 5, b: '1000'},
          {a: 3, b: '2000'},
          {a: 2, b: '3000'},
          {a: 6, b: '4000'},

We start scanning the index from (this is the startAt passed to generateWithOverlay):
{ b: '1000', a: Symbol(min-value) }
this is because constraint: {b: '1000'}, and so we start from the cluster matching the constraint.

generateWithStart skips nodes until its comparator tells it the node.row is >= start (or > then if basis: 'after').

If we use indexComparator ([['b', 'asc'], ['a', 'asc']])
 {a: 1, b: '1000'} < {a: 3, b: '2000'} so generateWithStart skips it
 {a: 5, b: '1000'} < {a: 3, b: '2000'} so generateWithStart skips it 
 
no other rows match the constraint of 1000, so no rows are yielded, which is a mistake  {a: 5, b: '1000'}  should have been yielded.

If we use connectionComparator ([['a', 'asc']])
 {a: 1, b: '1000'} < {a: 3, b: '2000'} so generateWithStart skips it
 {a: 5, b: '1000'} > {a: 3, b: '2000'} so generateWithStart yields it 
 
 
