### PR TITLE
fix(zero-cache): use explicit deletes (instead of fk references) in cvr gc

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr-purger.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-purger.ts
@@ -106,11 +106,24 @@ export class CVRPurger implements Service {
       ).flat();
 
       if (ids.length > 0) {
-        // Rows only need to be deleted from the "instances" and "rowsVersion" tables.
-        // Deletes will cascade through the other tables via foreign key references.
-        for (const table of ['instances', 'rowsVersion']) {
-          await sql`
-            DELETE FROM ${sql(this.#schema)}.${sql(table)} WHERE "clientGroupID" IN ${sql(ids)}`;
+        // Explicitly delete rows from cvr tables from "bottom" up. Even
+        // though all tables eventually reference a ("top") ancestor row in the
+        // "instances" or "rowsVersion" tables, relying on foreign key
+        // cascading deletes can be suboptimal when the foreign key is not a
+        // prefix of the primary key (e.g. the "desires" foreign key reference
+        // to the "queries" table is not a prefix of the "desires" primary
+        // key).
+        for (const table of [
+          'desires',
+          'queries',
+          'clients',
+          'instances',
+          'rows',
+          'rowsVersion',
+        ]) {
+          void sql`
+            DELETE FROM ${sql(this.#schema)}.${sql(table)} 
+              WHERE "clientGroupID" IN ${sql(ids)}`.execute();
         }
       }
 


### PR DESCRIPTION
When purging rows from CVR tables, explicitly delete the rows from child tables up to parent tables, rather than only deleting rows in parent tables and relying on foreign key cascades.

For some tables (e.g. the "desires" table), the foreign key reference is not a prefix of the primary key, so a cascading delete from the parent table can result in a quadratic scan of a clientGroup's rows. 

Instead, explicitly deleting by clientGroupID ensures that it is linear.

User report:
* https://discord.com/channels/830183651022471199/1420477677227348105/1420478261875577036