### PR TITLE
chore: log statement_timeout

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr-purger.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-purger.ts
@@ -50,6 +50,11 @@ export class CVRPurger implements Service {
       );
       // Do nothing and just wait to be stopped.
       await this.#state.stopped();
+    } else {
+      this.#lc.info?.(
+        `running cvr-purger with`,
+        await this.#db`SHOW statement_timeout`,
+      );
     }
 
     while (this.#state.shouldRun()) {


### PR DESCRIPTION
Log `SHOW statement_timeout` to help investigate when cvr gc results in postgres timeouts