### PR TITLE
chore(zero-event): add a generic "state" field to status events

### DIFF
--- a/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
@@ -248,87 +248,89 @@ describe('replicator/incremental-sync', () => {
         {
           "component": "replication",
           "description": "Replicating from 02",
-          "indexes": [
-            {
-              "columns": [
-                {
-                  "column": "bool",
-                  "dir": "ASC",
-                },
-                {
-                  "column": "issueID",
-                  "dir": "ASC",
-                },
-              ],
-              "table": "issues",
-              "unique": true,
-            },
-          ],
-          "replicaSize": 40960,
           "stage": "Replicating",
+          "state": {
+            "indexes": [
+              {
+                "columns": [
+                  {
+                    "column": "bool",
+                    "dir": "ASC",
+                  },
+                  {
+                    "column": "issueID",
+                    "dir": "ASC",
+                  },
+                ],
+                "table": "issues",
+                "unique": true,
+              },
+            ],
+            "replicaSize": 40960,
+            "tables": [
+              {
+                "columns": [
+                  {
+                    "clientType": "string",
+                    "column": "_0_version",
+                    "upstreamType": "TEXT",
+                  },
+                  {
+                    "clientType": "number",
+                    "column": "big",
+                    "upstreamType": "INTEGER",
+                  },
+                  {
+                    "clientType": "boolean",
+                    "column": "bool",
+                    "upstreamType": "BOOL",
+                  },
+                  {
+                    "clientType": null,
+                    "column": "bytes",
+                    "upstreamType": "bytesa",
+                  },
+                  {
+                    "clientType": "string",
+                    "column": "description",
+                    "upstreamType": "TEXT",
+                  },
+                  {
+                    "clientType": "number",
+                    "column": "flt",
+                    "upstreamType": "REAL",
+                  },
+                  {
+                    "clientType": "json",
+                    "column": "intArray",
+                    "upstreamType": "int4[]",
+                  },
+                  {
+                    "clientType": "number",
+                    "column": "issueID",
+                    "upstreamType": "INTEGER",
+                  },
+                  {
+                    "clientType": "json",
+                    "column": "json",
+                    "upstreamType": "JSON",
+                  },
+                  {
+                    "clientType": "json",
+                    "column": "json2",
+                    "upstreamType": "JSONB",
+                  },
+                  {
+                    "clientType": "number",
+                    "column": "time",
+                    "upstreamType": "TIMESTAMPTZ",
+                  },
+                ],
+                "table": "issues",
+              },
+            ],
+          },
           "status": "OK",
-          "tables": [
-            {
-              "columns": [
-                {
-                  "clientType": "string",
-                  "column": "_0_version",
-                  "upstreamType": "TEXT",
-                },
-                {
-                  "clientType": "number",
-                  "column": "big",
-                  "upstreamType": "INTEGER",
-                },
-                {
-                  "clientType": "boolean",
-                  "column": "bool",
-                  "upstreamType": "BOOL",
-                },
-                {
-                  "clientType": null,
-                  "column": "bytes",
-                  "upstreamType": "bytesa",
-                },
-                {
-                  "clientType": "string",
-                  "column": "description",
-                  "upstreamType": "TEXT",
-                },
-                {
-                  "clientType": "number",
-                  "column": "flt",
-                  "upstreamType": "REAL",
-                },
-                {
-                  "clientType": "json",
-                  "column": "intArray",
-                  "upstreamType": "int4[]",
-                },
-                {
-                  "clientType": "number",
-                  "column": "issueID",
-                  "upstreamType": "INTEGER",
-                },
-                {
-                  "clientType": "json",
-                  "column": "json",
-                  "upstreamType": "JSON",
-                },
-                {
-                  "clientType": "json",
-                  "column": "json2",
-                  "upstreamType": "JSONB",
-                },
-                {
-                  "clientType": "number",
-                  "column": "time",
-                  "upstreamType": "TIMESTAMPTZ",
-                },
-              ],
-              "table": "issues",
-            },
-          ],
           "time": "2025-08-14T01:02:03.000Z",
           "type": "zero/events/status/replication/v1",
         },
@@ -389,109 +391,113 @@ describe('replicator/incremental-sync', () => {
         {
           "component": "replication",
           "description": "Replicating from 09",
-          "indexes": [
-            {
-              "columns": [
-                {
-                  "column": "bool",
-                  "dir": "ASC",
-                },
-                {
-                  "column": "issueID",
-                  "dir": "ASC",
-                },
-              ],
-              "table": "issues",
-              "unique": true,
-            },
-          ],
-          "replicaSize": 40960,
           "stage": "Replicating",
+          "state": {
+            "indexes": [
+              {
+                "columns": [
+                  {
+                    "column": "bool",
+                    "dir": "ASC",
+                  },
+                  {
+                    "column": "issueID",
+                    "dir": "ASC",
+                  },
+                ],
+                "table": "issues",
+                "unique": true,
+              },
+            ],
+            "replicaSize": 40960,
+            "tables": [
+              {
+                "columns": [
+                  {
+                    "clientType": "string",
+                    "column": "_0_version",
+                    "upstreamType": "TEXT",
+                  },
+                  {
+                    "clientType": "number",
+                    "column": "big",
+                    "upstreamType": "INTEGER",
+                  },
+                  {
+                    "clientType": "boolean",
+                    "column": "bool",
+                    "upstreamType": "BOOL",
+                  },
+                  {
+                    "clientType": "number",
+                    "column": "issueID",
+                    "upstreamType": "INTEGER",
+                  },
+                ],
+                "table": "issues",
+              },
+            ],
+          },
           "status": "OK",
-          "tables": [
-            {
-              "columns": [
-                {
-                  "clientType": "string",
-                  "column": "_0_version",
-                  "upstreamType": "TEXT",
-                },
-                {
-                  "clientType": "number",
-                  "column": "big",
-                  "upstreamType": "INTEGER",
-                },
-                {
-                  "clientType": "boolean",
-                  "column": "bool",
-                  "upstreamType": "BOOL",
-                },
-                {
-                  "clientType": "number",
-                  "column": "issueID",
-                  "upstreamType": "INTEGER",
-                },
-              ],
-              "table": "issues",
-            },
-          ],
           "time": "2025-08-14T01:02:03.000Z",
           "type": "zero/events/status/replication/v1",
         },
         {
           "component": "replication",
           "description": "Schema updated",
-          "indexes": [
-            {
-              "columns": [
-                {
-                  "column": "bool",
-                  "dir": "ASC",
-                },
-                {
-                  "column": "issueID",
-                  "dir": "ASC",
-                },
-              ],
-              "table": "issues",
-              "unique": true,
-            },
-          ],
-          "replicaSize": 49152,
           "stage": "Replicating",
+          "state": {
+            "indexes": [
+              {
+                "columns": [
+                  {
+                    "column": "bool",
+                    "dir": "ASC",
+                  },
+                  {
+                    "column": "issueID",
+                    "dir": "ASC",
+                  },
+                ],
+                "table": "issues",
+                "unique": true,
+              },
+            ],
+            "replicaSize": 49152,
+            "tables": [
+              {
+                "columns": [
+                  {
+                    "clientType": "string",
+                    "column": "_0_version",
+                    "upstreamType": "TEXT",
+                  },
+                  {
+                    "clientType": "number",
+                    "column": "big",
+                    "upstreamType": "INTEGER",
+                  },
+                  {
+                    "clientType": "boolean",
+                    "column": "bool",
+                    "upstreamType": "BOOL",
+                  },
+                  {
+                    "clientType": "number",
+                    "column": "issueID",
+                    "upstreamType": "INTEGER",
+                  },
+                  {
+                    "clientType": "number",
+                    "column": "new_column",
+                    "upstreamType": "int8",
+                  },
+                ],
+                "table": "issues",
+              },
+            ],
+          },
           "status": "OK",
-          "tables": [
-            {
-              "columns": [
-                {
-                  "clientType": "string",
-                  "column": "_0_version",
-                  "upstreamType": "TEXT",
-                },
-                {
-                  "clientType": "number",
-                  "column": "big",
-                  "upstreamType": "INTEGER",
-                },
-                {
-                  "clientType": "boolean",
-                  "column": "bool",
-                  "upstreamType": "BOOL",
-                },
-                {
-                  "clientType": "number",
-                  "column": "issueID",
-                  "upstreamType": "INTEGER",
-                },
-                {
-                  "clientType": "number",
-                  "column": "new_column",
-                  "upstreamType": "int8",
-                },
-              ],
-              "table": "issues",
-            },
-          ],
           "time": "2025-08-14T01:02:03.000Z",
           "type": "zero/events/status/replication/v1",
         },

--- a/packages/zero-cache/src/services/replicator/replication-status.test.ts
+++ b/packages/zero-cache/src/services/replicator/replication-status.test.ts
@@ -35,67 +35,69 @@ describe('replicator/replication-status', () => {
       {
         "component": "replication",
         "description": "my description",
-        "indexes": [
-          {
-            "columns": [
-              {
-                "column": "c",
-                "dir": "DESC",
-              },
-              {
-                "column": "d",
-                "dir": "ASC",
-              },
-            ],
-            "table": "bar",
-            "unique": true,
-          },
-          {
-            "columns": [
-              {
-                "column": "a",
-                "dir": "DESC",
-              },
-            ],
-            "table": "foo",
-            "unique": true,
-          },
-        ],
-        "replicaSize": 20480,
         "stage": "Initializing",
+        "state": {
+          "indexes": [
+            {
+              "columns": [
+                {
+                  "column": "c",
+                  "dir": "DESC",
+                },
+                {
+                  "column": "d",
+                  "dir": "ASC",
+                },
+              ],
+              "table": "bar",
+              "unique": true,
+            },
+            {
+              "columns": [
+                {
+                  "column": "a",
+                  "dir": "DESC",
+                },
+              ],
+              "table": "foo",
+              "unique": true,
+            },
+          ],
+          "replicaSize": 20480,
+          "tables": [
+            {
+              "columns": [
+                {
+                  "clientType": "string",
+                  "column": "c",
+                  "upstreamType": "varchar",
+                },
+                {
+                  "clientType": "boolean",
+                  "column": "d",
+                  "upstreamType": "bool",
+                },
+              ],
+              "table": "bar",
+            },
+            {
+              "columns": [
+                {
+                  "clientType": "number",
+                  "column": "a",
+                  "upstreamType": "int",
+                },
+                {
+                  "clientType": "string",
+                  "column": "b",
+                  "upstreamType": "TEXT",
+                },
+              ],
+              "table": "foo",
+            },
+          ],
+        },
         "status": "OK",
-        "tables": [
-          {
-            "columns": [
-              {
-                "clientType": "string",
-                "column": "c",
-                "upstreamType": "varchar",
-              },
-              {
-                "clientType": "boolean",
-                "column": "d",
-                "upstreamType": "bool",
-              },
-            ],
-            "table": "bar",
-          },
-          {
-            "columns": [
-              {
-                "clientType": "number",
-                "column": "a",
-                "upstreamType": "int",
-              },
-              {
-                "clientType": "string",
-                "column": "b",
-                "upstreamType": "TEXT",
-              },
-            ],
-            "table": "foo",
-          },
-        ],
         "time": "2025-10-14T01:02:03.000Z",
         "type": "zero/events/status/replication/v1",
       }
@@ -124,67 +126,69 @@ describe('replicator/replication-status', () => {
       {
         "component": "replication",
         "description": undefined,
-        "indexes": [
-          {
-            "columns": [
-              {
-                "column": "c",
-                "dir": "DESC",
-              },
-              {
-                "column": "d",
-                "dir": "ASC",
-              },
-            ],
-            "table": "bar",
-            "unique": true,
-          },
-          {
-            "columns": [
-              {
-                "column": "a",
-                "dir": "DESC",
-              },
-            ],
-            "table": "foo",
-            "unique": true,
-          },
-        ],
-        "replicaSize": 20480,
         "stage": "Replicating",
+        "state": {
+          "indexes": [
+            {
+              "columns": [
+                {
+                  "column": "c",
+                  "dir": "DESC",
+                },
+                {
+                  "column": "d",
+                  "dir": "ASC",
+                },
+              ],
+              "table": "bar",
+              "unique": true,
+            },
+            {
+              "columns": [
+                {
+                  "column": "a",
+                  "dir": "DESC",
+                },
+              ],
+              "table": "foo",
+              "unique": true,
+            },
+          ],
+          "replicaSize": 20480,
+          "tables": [
+            {
+              "columns": [
+                {
+                  "clientType": "string",
+                  "column": "c",
+                  "upstreamType": "varchar",
+                },
+                {
+                  "clientType": "boolean",
+                  "column": "d",
+                  "upstreamType": "bool",
+                },
+              ],
+              "table": "bar",
+            },
+            {
+              "columns": [
+                {
+                  "clientType": "number",
+                  "column": "a",
+                  "upstreamType": "int",
+                },
+                {
+                  "clientType": "string",
+                  "column": "b",
+                  "upstreamType": "TEXT",
+                },
+              ],
+              "table": "foo",
+            },
+          ],
+        },
         "status": "OK",
-        "tables": [
-          {
-            "columns": [
-              {
-                "clientType": "string",
-                "column": "c",
-                "upstreamType": "varchar",
-              },
-              {
-                "clientType": "boolean",
-                "column": "d",
-                "upstreamType": "bool",
-              },
-            ],
-            "table": "bar",
-          },
-          {
-            "columns": [
-              {
-                "clientType": "number",
-                "column": "a",
-                "upstreamType": "int",
-              },
-              {
-                "clientType": "string",
-                "column": "b",
-                "upstreamType": "TEXT",
-              },
-            ],
-            "table": "foo",
-          },
-        ],
         "time": "2025-10-14T01:02:03.000Z",
         "type": "zero/events/status/replication/v1",
       }
@@ -210,38 +214,40 @@ describe('replicator/replication-status', () => {
       {
         "component": "replication",
         "description": "another description",
-        "indexes": [
-          {
-            "columns": [
-              {
-                "column": "a",
-                "dir": "DESC",
-              },
-            ],
-            "table": "foo",
-            "unique": true,
-          },
-        ],
-        "replicaSize": 12288,
         "stage": "Initializing",
+        "state": {
+          "indexes": [
+            {
+              "columns": [
+                {
+                  "column": "a",
+                  "dir": "DESC",
+                },
+              ],
+              "table": "foo",
+              "unique": true,
+            },
+          ],
+          "replicaSize": 12288,
+          "tables": [
+            {
+              "columns": [
+                {
+                  "clientType": "number",
+                  "column": "a",
+                  "upstreamType": "int",
+                },
+                {
+                  "clientType": null,
+                  "column": "not_synced",
+                  "upstreamType": "bytea",
+                },
+              ],
+              "table": "foo",
+            },
+          ],
+        },
         "status": "OK",
-        "tables": [
-          {
-            "columns": [
-              {
-                "clientType": "number",
-                "column": "a",
-                "upstreamType": "int",
-              },
-              {
-                "clientType": null,
-                "column": "not_synced",
-                "upstreamType": "bytea",
-              },
-            ],
-            "table": "foo",
-          },
-        ],
         "time": "2025-10-14T01:02:03.000Z",
         "type": "zero/events/status/replication/v1",
       }

--- a/packages/zero-cache/src/services/replicator/replication-status.ts
+++ b/packages/zero-cache/src/services/replicator/replication-status.ts
@@ -89,9 +89,11 @@ export function replicationStatusEvent(
       stage,
       description,
       time: now.toISOString(),
-      tables: getReplicatedTables(db),
-      indexes: getReplicatedIndexes(db),
-      replicaSize: getReplicaSize(db),
+      state: {
+        tables: getReplicatedTables(db),
+        indexes: getReplicatedIndexes(db),
+        replicaSize: getReplicaSize(db),
+      },
     };
   } catch (e) {
     lc.warn?.(`Unable to create full ReplicationStatusEvent`, e);
@@ -102,9 +104,11 @@ export function replicationStatusEvent(
       stage,
       description,
       time: now.toISOString(),
-      tables: [],
-      indexes: [],
-      replicaSize: 0,
+      state: {
+        tables: [],
+        indexes: [],
+        replicaSize: 0,
+      },
     };
   }
 }

--- a/packages/zero-events/src/status.ts
+++ b/packages/zero-events/src/status.ts
@@ -40,6 +40,9 @@ export const statusEventSchema = zeroEventSchema.extend({
    */
   description: v.string().optional(),
 
+  /** Structured data describing the state of the component. */
+  state: jsonObjectSchema.optional(),
+
   /** Error details should be supplied for an 'ERROR' status message. */
   errorDetails: jsonObjectSchema.optional(),
 });
@@ -76,6 +79,14 @@ const replicatedIndexSchema = v.object({
 
 export type ReplicatedIndex = v.Infer<typeof replicatedIndexSchema>;
 
+const replicationStateSchema = v.object({
+  tables: v.array(replicatedTableSchema),
+  indexes: v.array(replicatedIndexSchema),
+  replicaSize: v.number().optional(),
+});
+
+export type ReplicationState = v.Infer<typeof replicationStateSchema>;
+
 const replicationStageSchema = v.literalUnion(
   'Initializing',
   'Indexing',
@@ -92,10 +103,7 @@ export const replicationStatusEventSchema = statusEventSchema.extend({
   type: v.literal('zero/events/status/replication/v1'),
   component: v.literal('replication'),
   stage: replicationStageSchema,
-
-  tables: v.array(replicatedTableSchema),
-  indexes: v.array(replicatedIndexSchema),
-  replicaSize: v.number().optional(),
+  state: replicationStateSchema,
 });
 
 // CloudEvent type: "zero.status/replication/v1"


### PR DESCRIPTION
Add a `state` field to hold structured data describing the state of a `component` in a StatusEvent, and put the replication state (`tables`, `indexes`, `replicaSize`) in that field.

This will facilitate handling of component events in a generic manner.