### PR TITLE
given plan, apply flips

### DIFF
--- a/packages/zql/src/planner/flip.test.ts
+++ b/packages/zql/src/planner/flip.test.ts
@@ -1,0 +1,146 @@
+import {describe, test, expect, beforeEach} from 'vitest';
+import {
+  flipJoins,
+  isJoin,
+  type VirtualConnection,
+  type VirtualJoin,
+  type VirtualNode,
+} from './flip.ts';
+
+function resetFlips(n: VirtualNode) {
+  if (isJoin(n)) {
+    n.flip = undefined;
+    resetFlips(n.left);
+    resetFlips(n.right);
+  }
+}
+
+function collectDecisionsPreorder(n: VirtualNode): Array<[number, boolean]> {
+  const out: Array<[number, boolean]> = [];
+  (function dfs(x: VirtualNode) {
+    if (!isJoin(x)) return;
+    out.push([x.id, !!x.flip]);
+    dfs(x.left);
+    dfs(x.right);
+  })(n);
+  return out;
+}
+
+// ---------- build the exact tree from your image ----------
+// Leaves
+const issue: VirtualConnection = {id: 1, name: 'issue'};
+const project: VirtualConnection = {id: 2, name: 'project'};
+const member: VirtualConnection = {id: 3, name: 'project_member'};
+const creator: VirtualConnection = {id: 4, name: 'creator'};
+
+// J1 = project ⋈ project_member
+const J1: VirtualJoin = {
+  id: 101,
+  name: 'project⋈project_member',
+  left: project,
+  right: member,
+};
+
+// J2 = issue ⋈ (project⋈project_member)
+const J2: VirtualJoin = {
+  id: 102,
+  name: 'issue⋈(project⋈project_member)',
+  left: issue,
+  right: J1,
+};
+
+// J3 = (issue⋈(project⋈project_member)) ⋈ creator
+const J3: VirtualJoin = {
+  id: 103,
+  name: '(issue⋈(project⋈project_member))⋈creator',
+  left: J2,
+  right: creator,
+};
+
+// convenience
+const idMap = {J1: 101, J2: 102, J3: 103};
+
+// ---------- plans ----------
+const P = {
+  base: [issue, project, member, creator], // issue, project, project_member, creator
+  creatorFirst: [creator, issue, project, member], // creator, issue, project, project_member
+  rightBlock: [project, member, issue, creator], // project, project_member, issue, creator
+  swapInner: [issue, member, project, creator], // issue, project_member, project, creator
+  bothRight: [member, project, issue, creator], // project_member, project, issue, creator
+  rightThenAll: [creator, project, member, issue], // creator, project, project_member, issue
+  allFlipped: [creator, member, project, issue], // creator, project_member, project, issue
+  impossible: [project, issue, member, creator], // interleaves J2's sides -> impossible
+};
+
+// ---------- expectations per plan ----------
+// decisions are returned/collected in preorder: [J3, J2, J1]
+const E = {
+  base: [
+    [idMap.J3, false],
+    [idMap.J2, false],
+    [idMap.J1, false],
+  ],
+  creatorFirst: [
+    [idMap.J3, true],
+    [idMap.J2, false],
+    [idMap.J1, false],
+  ],
+  rightBlock: [
+    [idMap.J3, false],
+    [idMap.J2, true],
+    [idMap.J1, false],
+  ],
+  swapInner: [
+    [idMap.J3, false],
+    [idMap.J2, false],
+    [idMap.J1, true],
+  ],
+  bothRight: [
+    [idMap.J3, false],
+    [idMap.J2, true],
+    [idMap.J1, true],
+  ],
+  rightThenAll: [
+    [idMap.J3, true],
+    [idMap.J2, true],
+    [idMap.J1, false],
+  ],
+  allFlipped: [
+    [idMap.J3, true],
+    [idMap.J2, true],
+    [idMap.J1, true],
+  ],
+} satisfies Record<string, Array<[number, boolean]>>;
+
+// ---------- run tests ----------
+describe('flipJoins', () => {
+  beforeEach(() => {
+    resetFlips(J3);
+  });
+
+  test.each([
+    ['base', P.base, E.base],
+    ['creatorFirst', P.creatorFirst, E.creatorFirst],
+    ['rightBlock', P.rightBlock, E.rightBlock],
+    ['swapInner', P.swapInner, E.swapInner],
+    ['bothRight', P.bothRight, E.bothRight],
+    ['rightThenAll', P.rightThenAll, E.rightThenAll],
+    ['allFlipped', P.allFlipped, E.allFlipped],
+  ] as const)('%s', (name, plan, expected) => {
+    const decisions = flipJoins(J3, plan);
+    const decided = collectDecisionsPreorder(J3); // confirm mutation order == returned
+
+    expect(decisions).toEqual(expected);
+    expect(decided).toEqual(expected);
+
+    // spot-check actual flags
+    const byId = new Map(decided);
+    expect(byId.get(idMap.J3)).toBe(expected[0][1]);
+    expect(byId.get(idMap.J2)).toBe(expected[1][1]);
+    expect(byId.get(idMap.J1)).toBe(expected[2][1]);
+  });
+
+  test('impossible plan throws', () => {
+    expect(() => flipJoins(J3, P.impossible)).toThrow();
+  });
+});

--- a/packages/zql/src/planner/flip.ts
+++ b/packages/zql/src/planner/flip.ts
@@ -1,0 +1,106 @@
+export type VirtualNode = VirtualJoin | VirtualConnection;
+
+export type VirtualJoin = {
+  id: number;
+  name: string;
+  left: VirtualNode;
+  right: VirtualNode;
+  flip?: boolean | undefined;
+};
+
+export type VirtualConnection = {
+  id: number;
+  name: string;
+};
+
+export function isJoin(node: VirtualNode): node is VirtualJoin {
+  return (node as VirtualJoin).left !== undefined;
+}
+
+/** Build a map from node -> set of leaf ids in its subtree */
+function buildLeafSets(root: VirtualNode) {
+  const memo = new Map<VirtualNode, Set<number>>();
+  const dfs = (n: VirtualNode): Set<number> => {
+    if (memo.has(n)) return memo.get(n)!;
+    let s: Set<number>;
+    if (isJoin(n)) {
+      const L = dfs(n.left);
+      const R = dfs(n.right);
+      s = new Set([...L, ...R]);
+    } else {
+      s = new Set([n.id]);
+    }
+    memo.set(n, s);
+    return s;
+  };
+  dfs(root);
+  return memo;
+}
+
+type FlipDecision = [id: number, flip: boolean];
+
+/**
+ * Decide which joins must be flipped to realize `plan` (list of connection ids).
+ * Mutates `flip` on the joins; also returns the decisions.
+ * Throws if no flip configuration can yield the plan.
+ */
+export function flipJoins(bottom: VirtualJoin, planConns: VirtualConnection[]) {
+  const plan = planConns.map(c => c.id);
+  const leafSets = buildLeafSets(bottom);
+
+  // Sanity: plan must be exactly the leaves under the root
+  const allLeaves = leafSets.get(bottom)!;
+  if (plan.length !== allLeaves.size || plan.some(id => !allLeaves.has(id))) {
+    throw new Error("Plan doesn't match the tree's leaves");
+  }
+
+  const decisions: FlipDecision[] = [];
+
+  function solve(node: VirtualNode, subseq: number[]) {
+    if (!isJoin(node)) {
+      if (subseq.length !== 1 || subseq[0] !== node.id) {
+        throw new Error(`Impossible: expected leaf ${node.id} here`);
+      }
+      return;
+    }
+
+    const Lset = leafSets.get(node.left)!;
+    const Rset = leafSets.get(node.right)!;
+
+    // Split this subtree's subsequence into left/right (preserve order)
+    const leftSeq: number[] = [];
+    const rightSeq: number[] = [];
+    for (const id of subseq) {
+      if (Lset.has(id)) leftSeq.push(id);
+      else if (Rset.has(id)) rightSeq.push(id);
+      else throw new Error(`Unknown id ${id} in subtree of ${node.id}`);
+    }
+
+    // Determine which side appears first in this subsequence
+    const first = subseq[0];
+    const firstIsLeft = Lset.has(first);
+    const flip = !firstIsLeft;
+
+    // Enforce “contiguous block” constraint: at most one side switch.
+    const expected = flip
+      ? [...rightSeq, ...leftSeq]
+      : [...leftSeq, ...rightSeq];
+    for (let i = 0; i < subseq.length; i++) {
+      if (subseq[i] !== expected[i]) {
+        throw new Error(
+          `Impossible order at join ${node.id}: leaves from left/right are interleaved`,
+        );
+      }
+    }
+
+    decisions.push([node.id, flip]);
+    node.flip = flip;
+
+    // Recurse into children
+    solve(node.left, leftSeq);
+    solve(node.right, rightSeq);
+  }
+
+  solve(bottom, plan);
+  return decisions;
+}


### PR DESCRIPTION
This is the "flipper" that flips join nodes after we've arrived at a plan.

The planner is still just a doc: https://www.notion.so/replicache/Simple-Flip-2713bed8954580dba401f6bb362252cf

The planner-via-flip only has access to 2^(n-1) possible plans vs the complete n! search space.