### PR TITLE
fix(zero-cache): fix keepalive algorithm to ensure postgres cleans up the wal

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.ts
+++ b/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.ts
@@ -52,7 +52,7 @@ export async function subscribe(
   // Postgres will send keepalives before timing out a wal_sender. It is possible that
   // these keepalives are not received if there is back-pressure in the replication
   // stream. To keep the connection alive, explicitly send keepalives if none have been
-  // sent within the last 90% of the wal_sender_timeout.
+  // sent within the last 75% of the wal_sender_timeout.
   //
   // https://www.postgresql.org/docs/current/runtime-config-replication.html#GUC-WAL-SENDER-TIMEOUT
   const [{walSenderTimeoutMs}] = await session<
@@ -60,7 +60,7 @@ export async function subscribe(
   >`SELECT EXTRACT(EPOCH FROM (setting || unit)::interval) * 1000 
         AS "walSenderTimeoutMs" FROM pg_settings
         WHERE name = 'wal_sender_timeout'`.simple();
-  const manualKeepaliveTimeout = Math.floor(walSenderTimeoutMs * 0.9);
+  const manualKeepaliveTimeout = Math.floor(walSenderTimeoutMs * 0.75);
   lc.info?.(
     `wal_sender_timeout: ${walSenderTimeoutMs}ms. ` +
       `Ensuring manual keepalives at least every ${manualKeepaliveTimeout}ms`,


### PR DESCRIPTION
Make the manual keepalive timeout parameterized by the `wal_sender_timeout` to avoid sending them too often.

This ensures that postgres will send it's periodic keepalive message with `shouldRespond: true` so that we properly ack the current lsn (if caught up with the replication stream).

User report:
* https://discord.com/channels/830183651022471199/1422663767791243294/1422735151959638016