### PR TITLE
fix(zbugs): restore triggers missed in drizzle refactor

### DIFF
--- a/apps/zbugs/db/migrations/0000_init.sql
+++ b/apps/zbugs/db/migrations/0000_init.sql
@@ -93,6 +93,165 @@ CREATE INDEX "issue_open_modified_idx" ON "issue" USING btree ("open","modified"
 CREATE INDEX "issuelabel_issueid_idx" ON "issueLabel" USING btree ("issueID");--> statement-breakpoint
 CREATE UNIQUE INDEX "user_githubid_idx" ON "user" USING btree ("githubID");--> statement-breakpoint
 CREATE UNIQUE INDEX "user_login_idx" ON "user" USING btree ("login");
+
+----> BEGIN manual modification for triggers
+CREATE OR REPLACE FUNCTION update_modified_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.modified = (EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER issue_set_last_modified
+BEFORE INSERT OR UPDATE ON issue
+FOR EACH ROW
+EXECUTE FUNCTION update_modified_column();
+
+CREATE OR REPLACE FUNCTION issue_set_created_on_insert()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.created = (EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER issue_set_created_on_insert_trigger
+BEFORE INSERT ON issue
+FOR EACH ROW
+EXECUTE FUNCTION issue_set_created_on_insert();
+
+
+CREATE OR REPLACE FUNCTION update_issue_modified_time()
+RETURNS TRIGGER AS $$
+BEGIN
+    UPDATE issue
+    SET modified = EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000
+    WHERE id = NEW."issueID";
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER update_issue_modified_time_on_comment
+AFTER INSERT ON comment
+FOR EACH ROW
+EXECUTE FUNCTION update_issue_modified_time();
+
+CREATE OR REPLACE FUNCTION comment_set_created_on_insert()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.created = (EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER comment_set_created_on_insert_trigger
+BEFORE INSERT ON comment
+FOR EACH ROW
+EXECUTE FUNCTION comment_set_created_on_insert();
+
+CREATE OR REPLACE FUNCTION validate_comment_body_length()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.body IS NOT NULL THEN
+    -- The launch post has a special case maxlength of 1024 because trolls
+    IF NEW."issueID" = 'duuW9Nyj5cTNLlimp9Qje' AND LENGTH(NEW.body) > 1024 THEN
+      RAISE EXCEPTION 'Column value exceeds maximum allowed length of %', 1024;
+    END IF;
+    -- Length chosen because we have some old comments that are ~44KB.
+    IF LENGTH(NEW.body) > 64*1024 THEN
+      RAISE EXCEPTION 'Column value exceeds maximum allowed length of %', 64*1024;
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER check_comment_body_length
+BEFORE INSERT OR UPDATE ON comment
+FOR EACH ROW
+EXECUTE FUNCTION validate_comment_body_length();
+
+
+CREATE OR REPLACE FUNCTION emoji_check_subject_id()
+RETURNS TRIGGER AS $$
+BEGIN
+    -- Check if subjectID exists in the issue table
+    IF EXISTS (SELECT 1 FROM issue WHERE id = NEW."subjectID") THEN
+        NULL; -- Do nothing
+    ELSIF EXISTS (SELECT 1 FROM comment WHERE id = NEW."subjectID") THEN
+        NULL; -- Do nothing
+    ELSE
+        RAISE EXCEPTION 'id ''%'' does not exist in issue or comment', NEW."subjectID";
+    END IF;
+    
+    PERFORM update_issue_modified_on_emoji_change(NEW."subjectID");
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER emoji_check_subject_id_update_trigger
+BEFORE INSERT OR UPDATE ON emoji
+FOR EACH ROW
+EXECUTE FUNCTION emoji_check_subject_id();
+
+CREATE OR REPLACE FUNCTION emoji_set_created_on_insert()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.created = EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER emoji_set_created_on_insert_trigger
+BEFORE INSERT ON emoji
+FOR EACH ROW
+EXECUTE FUNCTION emoji_set_created_on_insert();
+
+-- Delete emoji when issue is deleted
+CREATE OR REPLACE FUNCTION delete_emoji_on_issue_delete()
+RETURNS TRIGGER AS $$
+BEGIN
+    DELETE FROM emoji WHERE "subjectID" = OLD.id;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER delete_emoji_on_issue_delete_trigger
+AFTER DELETE ON issue
+FOR EACH ROW
+EXECUTE FUNCTION delete_emoji_on_issue_delete();
+
+-- Delete emoji when comment is deleted
+CREATE OR REPLACE FUNCTION delete_emoji_on_comment_delete()
+RETURNS TRIGGER AS $$
+BEGIN
+    DELETE FROM emoji WHERE "subjectID" = OLD.id;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER delete_emoji_on_comment_delete_trigger
+AFTER DELETE ON comment
+FOR EACH ROW
+EXECUTE FUNCTION delete_emoji_on_comment_delete();
+
+-- When an emoji is added or deleted we find the issue and update the modified time
+CREATE OR REPLACE FUNCTION update_issue_modified_on_emoji_change("subjectID" VARCHAR)
+RETURNS VOID AS $$
+BEGIN
+    UPDATE issue
+    SET modified = EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000
+    FROM (
+        SELECT issue.id AS id
+        FROM issue JOIN comment ON issue.id=comment."issueID"
+        WHERE comment.id = "subjectID" OR issue.id = "subjectID"
+    ) AS subquery
+    WHERE issue.id = subquery.id;
+END;   
+$$ LANGUAGE plpgsql;
+----> END manual modification for triggers
 ----> BEGIN manual modification for publication
 CREATE PUBLICATION zero_zbugs
   FOR TABLE


### PR DESCRIPTION
Impacts local dbs.  Local dbs should be cleared with `docker compose down -v`, and then
```
npm run db-up
# in another tab
npm run db-migrate
npm run db-seed
```