### PR TITLE
fix(zbugs): fix vercel routing

### DIFF
--- a/apps/zbugs/vercel.json
+++ b/apps/zbugs/vercel.json
@@ -8,5 +8,9 @@
       "source": "/issue/(.*)",
       "destination": "/index.html"
     }
+        {
+      "source": "/p/(.*)",
+      "destination": "/index.html"
+    }
   ]
 }


### PR DESCRIPTION
Vercel config does not account for new paths in https://github.com/rocicorp/mono/commit/7b247c52ddbf81309351bb6c06153bf77bb5702c