### PR TITLE
fix(zbugs): Minor fix for comment button jumping on responsive

### DIFF
--- a/apps/zbugs/src/index.css
+++ b/apps/zbugs/src/index.css
@@ -1099,6 +1099,7 @@ textarea.autoResize {
 
   button {
     flex-shrink: 0;
+    align-self: start;
   }
 
   .aside {


### PR DESCRIPTION
After testing the button was jumping a bit on responsive so here is a fix.