### PR TITLE
chore(zero): update zero-sqlite3 version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12373,10 +12373,11 @@
       "link": true
     },
     "node_modules/@rocicorp/zero-sqlite3": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@rocicorp/zero-sqlite3/-/zero-sqlite3-1.0.8.tgz",
-      "integrity": "sha512-lWxHKeetYuqYHeM6G+r/1fyQ30JbyiP+IT23knLGowknkpZmdEMUN1453lRHPpvFASIWRwRmhKrUIFDwXHC/Dg==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@rocicorp/zero-sqlite3/-/zero-sqlite3-1.0.9.tgz",
+      "integrity": "sha512-xR+fGqQJjfxmaKmobVVsmerSc/JNpJG5hwOxoAdj/kPkax5n85iHeW/4D9ss+8frP9oI/3KzRcxZosTwPp3lYw==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -37693,7 +37694,7 @@
       "devDependencies": {
         "@op-engineering/op-sqlite": "^15.0.1",
         "@rocicorp/prettier-config": "^0.3.0",
-        "@rocicorp/zero-sqlite3": "^1.0.8",
+        "@rocicorp/zero-sqlite3": "^1.0.9",
         "@types/command-line-usage": "^5.0.2",
         "@vitest/runner": "3.2.4",
         "command-line-args": "^6.0.1",
@@ -37709,7 +37710,7 @@
       },
       "peerDependencies": {
         "@op-engineering/op-sqlite": "^15.0.1",
-        "@rocicorp/zero-sqlite3": "^1.0.8",
+        "@rocicorp/zero-sqlite3": "^1.0.9",
         "expo-sqlite": "^15.2.14"
       },
       "peerDependenciesMeta": {
@@ -38345,7 +38346,7 @@
         "@rocicorp/lock": "^1.0.4",
         "@rocicorp/logger": "^5.4.0",
         "@rocicorp/resolver": "^1.0.2",
-        "@rocicorp/zero-sqlite3": "^1.0.8",
+        "@rocicorp/zero-sqlite3": "^1.0.9",
         "@types/basic-auth": "^1.1.8",
         "basic-auth": "^2.0.1",
         "chalk": "^5.3.0",
@@ -38426,7 +38427,7 @@
         "@rocicorp/lock": "^1.0.4",
         "@rocicorp/logger": "^5.4.0",
         "@rocicorp/resolver": "^1.0.2",
-        "@rocicorp/zero-sqlite3": "^1.0.8",
+        "@rocicorp/zero-sqlite3": "^1.0.9",
         "@types/basic-auth": "^1.1.8",
         "basic-auth": "^2.0.1",
         "chalk": "^5.3.0",
@@ -39331,7 +39332,7 @@
         "@databases/escape-identifier": "^1.0.3",
         "@databases/sql": "^3.3.0",
         "@rocicorp/logger": "^5.4.0",
-        "@rocicorp/zero-sqlite3": "^1.0.8",
+        "@rocicorp/zero-sqlite3": "^1.0.9",
         "zql": "0.0.0"
       },
       "devDependencies": {
@@ -46950,7 +46951,7 @@
         "@rocicorp/logger": "^5.4.0",
         "@rocicorp/prettier-config": "^0.3.0",
         "@rocicorp/resolver": "^1.0.2",
-        "@rocicorp/zero-sqlite3": "^1.0.8",
+        "@rocicorp/zero-sqlite3": "^1.0.9",
         "@types/basic-auth": "^1.1.8",
         "@vitest/runner": "3.2.4",
         "basic-auth": "^2.0.1",
@@ -47030,9 +47031,9 @@
       }
     },
     "@rocicorp/zero-sqlite3": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@rocicorp/zero-sqlite3/-/zero-sqlite3-1.0.8.tgz",
-      "integrity": "sha512-lWxHKeetYuqYHeM6G+r/1fyQ30JbyiP+IT23knLGowknkpZmdEMUN1453lRHPpvFASIWRwRmhKrUIFDwXHC/Dg==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@rocicorp/zero-sqlite3/-/zero-sqlite3-1.0.9.tgz",
+      "integrity": "sha512-xR+fGqQJjfxmaKmobVVsmerSc/JNpJG5hwOxoAdj/kPkax5n85iHeW/4D9ss+8frP9oI/3KzRcxZosTwPp3lYw==",
       "requires": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -60468,7 +60469,7 @@
         "@rocicorp/logger": "^5.4.0",
         "@rocicorp/prettier-config": "^0.3.0",
         "@rocicorp/resolver": "^1.0.2",
-        "@rocicorp/zero-sqlite3": "^1.0.8",
+        "@rocicorp/zero-sqlite3": "^1.0.9",
         "@types/command-line-usage": "^5.0.2",
         "@vitest/runner": "3.2.4",
         "command-line-args": "^6.0.1",
@@ -64554,7 +64555,7 @@
         "@rocicorp/logger": "^5.4.0",
         "@rocicorp/prettier-config": "^0.3.0",
         "@rocicorp/resolver": "^1.0.2",
-        "@rocicorp/zero-sqlite3": "^1.0.8",
+        "@rocicorp/zero-sqlite3": "^1.0.9",
         "@testcontainers/postgresql": "^10.9.0",
         "@types/basic-auth": "^1.1.8",
         "@types/node": "^20.8.4",
@@ -65226,7 +65227,7 @@
         "@databases/sql": "^3.3.0",
         "@rocicorp/logger": "^5.4.0",
         "@rocicorp/prettier-config": "^0.3.0",
-        "@rocicorp/zero-sqlite3": "^1.0.8",
+        "@rocicorp/zero-sqlite3": "^1.0.9",
         "fast-check": "^3.18.0",
         "nanoid": "^5.1.2",
         "shared": "0.0.0",

--- a/packages/replicache/package.json
+++ b/packages/replicache/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@op-engineering/op-sqlite": "^15.0.1",
     "@rocicorp/prettier-config": "^0.3.0",
-    "@rocicorp/zero-sqlite3": "^1.0.8",
+    "@rocicorp/zero-sqlite3": "^1.0.9",
     "@types/command-line-usage": "^5.0.2",
     "@vitest/runner": "3.2.4",
     "command-line-args": "^6.0.1",
@@ -55,7 +55,7 @@
   "peerDependencies": {
     "expo-sqlite": "^15.2.14",
     "@op-engineering/op-sqlite": "^15.0.1",
-    "@rocicorp/zero-sqlite3": "^1.0.8"
+    "@rocicorp/zero-sqlite3": "^1.0.9"
   },
   "peerDependenciesMeta": {
     "expo-sqlite": {

--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -37,7 +37,7 @@
     "@rocicorp/lock": "^1.0.4",
     "@rocicorp/logger": "^5.4.0",
     "@rocicorp/resolver": "^1.0.2",
-    "@rocicorp/zero-sqlite3": "^1.0.8",
+    "@rocicorp/zero-sqlite3": "^1.0.9",
     "@types/basic-auth": "^1.1.8",
     "basic-auth": "^2.0.1",
     "chalk": "^5.3.0",

--- a/packages/zero/package.json
+++ b/packages/zero/package.json
@@ -47,7 +47,7 @@
     "@rocicorp/lock": "^1.0.4",
     "@rocicorp/logger": "^5.4.0",
     "@rocicorp/resolver": "^1.0.2",
-    "@rocicorp/zero-sqlite3": "^1.0.8",
+    "@rocicorp/zero-sqlite3": "^1.0.9",
     "@types/basic-auth": "^1.1.8",
     "basic-auth": "^2.0.1",
     "chalk": "^5.3.0",

--- a/packages/zqlite/package.json
+++ b/packages/zqlite/package.json
@@ -31,7 +31,7 @@
     "@databases/escape-identifier": "^1.0.3",
     "@databases/sql": "^3.3.0",
     "@rocicorp/logger": "^5.4.0",
-    "@rocicorp/zero-sqlite3": "^1.0.8",
+    "@rocicorp/zero-sqlite3": "^1.0.9",
     "zql": "0.0.0"
   }
 }


### PR DESCRIPTION
- updates to sqlite 3.50
- enables support for scanstat which we need for join planning