### PR TITLE
chore(zero): Rename analyze-query result fields for clarity

### DIFF
--- a/packages/analyze-query/src/bin-analyze.ts
+++ b/packages/analyze-query/src/bin-analyze.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import chalk from 'chalk';
 import fs from 'node:fs';
 import {astToZQL} from '../../ast-to-zql/src/ast-to-zql.ts';
@@ -355,10 +354,12 @@ for (const [query, plan] of Object.entries(plans)) {
 function showStats() {
   let totalRowsConsidered = 0;
   for (const source of sources.values()) {
-    const entries = Object.entries(
+    const values = Object.values(
       debug.getVendedRowCounts()?.[source.table] ?? {},
     );
-    totalRowsConsidered += entries.reduce((acc, entry) => acc + entry[1], 0);
+    for (const v of values) {
+      totalRowsConsidered += v;
+    }
     colorConsole.log(
       chalk.bold(source.table + ' vended:'),
       debug.getVendedRowCounts()?.[source.table] ?? {},

--- a/packages/analyze-query/src/run-ast.test.ts
+++ b/packages/analyze-query/src/run-ast.test.ts
@@ -84,15 +84,16 @@ test('runAst always returns vendedRowCounts regardless of vendedRows option', as
     {
       "afterPermissions": undefined,
       "end": 1011,
-      "start": 1010,
-      "syncedRowCount": 0,
-      "syncedRows": undefined,
-      "vendedRowCounts": {
+      "readRowCount": 2,
+      "readRowCountsByQuery": {
         "users": {
           "SELECT * FROM users": 2,
         },
       },
-      "vendedRows": undefined,
+      "readRows": undefined,
+      "start": 1010,
+      "syncedRowCount": 0,
+      "syncedRows": undefined,
       "warnings": [],
     }
   `);
@@ -110,15 +111,13 @@ test('runAst always returns vendedRowCounts regardless of vendedRows option', as
     {
       "afterPermissions": undefined,
       "end": 1021,
-      "start": 1020,
-      "syncedRowCount": 0,
-      "syncedRows": undefined,
-      "vendedRowCounts": {
+      "readRowCount": 2,
+      "readRowCountsByQuery": {
         "users": {
           "SELECT * FROM users": 2,
         },
       },
-      "vendedRows": {
+      "readRows": {
         "users": {
           "SELECT * FROM users": [
             {
@@ -132,6 +131,9 @@ test('runAst always returns vendedRowCounts regardless of vendedRows option', as
           ],
         },
       },
+      "start": 1020,
+      "syncedRowCount": 0,
+      "syncedRows": undefined,
       "warnings": [],
     }
   `);
@@ -149,15 +151,16 @@ test('runAst always returns vendedRowCounts regardless of vendedRows option', as
     {
       "afterPermissions": undefined,
       "end": 1031,
-      "start": 1030,
-      "syncedRowCount": 0,
-      "syncedRows": undefined,
-      "vendedRowCounts": {
+      "readRowCount": 2,
+      "readRowCountsByQuery": {
         "users": {
           "SELECT * FROM users": 2,
         },
       },
-      "vendedRows": undefined,
+      "readRows": undefined,
+      "start": 1030,
+      "syncedRowCount": 0,
+      "syncedRows": undefined,
       "warnings": [],
     }
   `);
@@ -185,11 +188,12 @@ test('runAst returns empty object for vendedRowCounts when no debug tracking', a
     {
       "afterPermissions": undefined,
       "end": 1011,
+      "readRowCount": 0,
+      "readRowCountsByQuery": {},
+      "readRows": undefined,
       "start": 1010,
       "syncedRowCount": 0,
       "syncedRows": undefined,
-      "vendedRowCounts": {},
-      "vendedRows": undefined,
       "warnings": [],
     }
   `);
@@ -217,15 +221,16 @@ test('runAst basic structure and functionality', async () => {
     {
       "afterPermissions": undefined,
       "end": 1011,
-      "start": 1010,
-      "syncedRowCount": 0,
-      "syncedRows": undefined,
-      "vendedRowCounts": {
+      "readRowCount": 2,
+      "readRowCountsByQuery": {
         "users": {
           "SELECT * FROM users": 2,
         },
       },
-      "vendedRows": undefined,
+      "readRows": undefined,
+      "start": 1010,
+      "syncedRowCount": 0,
+      "syncedRows": undefined,
       "warnings": [],
     }
   `);

--- a/packages/analyze-query/src/run-ast.ts
+++ b/packages/analyze-query/src/run-ast.ts
@@ -47,8 +47,9 @@ export async function runAst(
     start: 0,
     end: 0,
     afterPermissions: undefined,
-    vendedRowCounts: {},
-    vendedRows: undefined,
+    readRows: undefined,
+    readRowCountsByQuery: {},
+    readRowCount: undefined,
   };
 
   if (!isTransformed) {
@@ -117,10 +118,17 @@ export async function runAst(
 
   // Always include the count of synced and vended rows.
   result.syncedRowCount = syncedRowCount;
-  result.vendedRowCounts = host.debug?.getVendedRowCounts() ?? {};
+  result.readRowCountsByQuery = host.debug?.getVendedRowCounts() ?? {};
+  let readRowCount = 0;
+  for (const c of Object.values(result.readRowCountsByQuery)) {
+    for (const v of Object.values(c)) {
+      readRowCount += v;
+    }
+  }
+  result.readRowCount = readRowCount;
 
   if (options.vendedRows) {
-    result.vendedRows = host.debug?.getVendedRows();
+    result.readRows = host.debug?.getVendedRows();
   }
   return result;
 }

--- a/packages/zero-client/src/client/inspector/inspector.test.ts
+++ b/packages/zero-client/src/client/inspector/inspector.test.ts
@@ -822,7 +822,19 @@ describe('query analyze', () => {
           {id: '2', title: 'Another Issue'},
         ],
       },
-      vendedRowCounts: {
+      readRows: {
+        issues: {
+          'SELECT * FROM issues': [
+            {id: '1', title: 'Test Issue'},
+            {id: '2', title: 'Another Issue'},
+            {id: '3', title: 'Third Issue'},
+            {id: '4', title: 'Fourth Issue'},
+            {id: '5', title: 'Fifth Issue'},
+          ],
+        },
+      },
+      readRowCount: 5,
+      readRowCountsByQuery: {
         issues: {
           'SELECT * FROM issues': 5,
         },

--- a/packages/zero-protocol/src/analyze-query-result.ts
+++ b/packages/zero-protocol/src/analyze-query-result.ts
@@ -21,9 +21,14 @@ export const analyzeQueryResultSchema = v.object({
   start: v.number(),
   end: v.number(),
   afterPermissions: v.string().optional(),
+  /** @deprecated Use readRowCountsByQuery */
   vendedRowCounts: rowCountsBySourceSchema.optional(),
+  /** @deprecated Use readRows */
   vendedRows: rowsBySourceSchema.optional(),
   plans: v.record(v.array(v.string())).optional(),
+  readRows: rowsBySourceSchema.optional(),
+  readRowCountsByQuery: rowCountsBySourceSchema.optional(),
+  readRowCount: v.number().optional(),
 });
 
 export type AnalyzeQueryResult = v.Infer<typeof analyzeQueryResultSchema>;

--- a/packages/zero-protocol/src/ast.test.ts
+++ b/packages/zero-protocol/src/ast.test.ts
@@ -607,5 +607,5 @@ test('protocol version', () => {
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
   expect(hash).toEqual('q4ltbplgffre');
-  expect(PROTOCOL_VERSION).toBe(34);
+  expect(PROTOCOL_VERSION).toBe(35);
 });

--- a/packages/zero-protocol/src/protocol-version.test.ts
+++ b/packages/zero-protocol/src/protocol-version.test.ts
@@ -11,6 +11,6 @@ test('protocol version', () => {
   // If this test fails upstream or downstream schema has changed such that
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
-  expect(hash).toEqual('fmuscz1jx8zx');
-  expect(PROTOCOL_VERSION).toBe(34);
+  expect(hash).toEqual('pqdmjcokxkvg');
+  expect(PROTOCOL_VERSION).toBe(35);
 });

--- a/packages/zero-protocol/src/protocol-version.ts
+++ b/packages/zero-protocol/src/protocol-version.ts
@@ -40,7 +40,8 @@ import {assert} from '../../shared/src/asserts.ts';
 // -- version 32 adds analyze-query to the inspector RPC calls (0.24)
 // -- version 33 adds `flip` to CorrelatedSubquery (0.25)
 // -- version 34 moves `flip` from CorrelatedSubquery to CorrelatedSubqueryCondition (0.25)
-export const PROTOCOL_VERSION = 34;
+// -- version 35 adds `readRows`, `readRowCountsByQuery` and `readRowCount` to analyze-query result (0.25)
+export const PROTOCOL_VERSION = 35;
 
 /**
  * The minimum server-supported sync protocol version (i.e. the version


### PR DESCRIPTION
Renames fields in `AnalyzeQueryResult` to be more descriptive:

`vendedRowCounts` -> `readRowCountsByQuery`
`vendedRows` -> `readRows`
Added `readRowCount` for total rows read

Old fields are deprecated but still work for backward compatibility. Protocol version bumped to 35.

"Vended" was unclear - "read" better describes what these fields represent (rows read from the database during query execution).

Closes https://bugs.rocicorp.dev/p/zero/issue/4108