### PR TITLE
fix(zero): do not load a module that loads zero-sqlite3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ WARP.md
 *.db-wal
 
 1gb
+bun.lock

--- a/packages/zero-cache/src/services/mutagen/error.ts
+++ b/packages/zero-cache/src/services/mutagen/error.ts
@@ -1,0 +1,10 @@
+import {assert} from '../../../../shared/src/asserts.ts';
+
+export class MutationAlreadyProcessedError extends Error {
+  constructor(clientID: string, received: number, actual: number | bigint) {
+    super(
+      `Ignoring mutation from ${clientID} with ID ${received} as it was already processed. Expected: ${actual}`,
+    );
+    assert(received < actual);
+  }
+}

--- a/packages/zero-cache/src/services/mutagen/mutagen.ts
+++ b/packages/zero-cache/src/services/mutagen/mutagen.ts
@@ -34,6 +34,7 @@ import {throwErrorForClientIfSchemaVersionNotSupported} from '../../types/schema
 import {appSchema, upstreamSchema, type ShardID} from '../../types/shards.ts';
 import {SlidingWindowLimiter} from '../limiter/sliding-window-limiter.ts';
 import type {RefCountedService, Service} from '../service.ts';
+import {MutationAlreadyProcessedError} from './error.ts';
 
 // An error encountered processing a mutation.
 // Returned back to application for display to user.
@@ -476,15 +477,6 @@ async function checkSchemaVersionAndIncrementLastMutationID(
       schemaVersion,
       supportedVersionRange[0],
     );
-  }
-}
-
-export class MutationAlreadyProcessedError extends Error {
-  constructor(clientID: string, received: number, actual: number | bigint) {
-    super(
-      `Ignoring mutation from ${clientID} with ID ${received} as it was already processed. Expected: ${actual}`,
-    );
-    assert(received < actual);
   }
 }
 

--- a/packages/zero-server/src/process-mutations.ts
+++ b/packages/zero-server/src/process-mutations.ts
@@ -9,7 +9,7 @@ import {
   type PushResponse,
 } from '../../zero-protocol/src/push.ts';
 import * as v from '../../shared/src/valita.ts';
-import {MutationAlreadyProcessedError} from '../../zero-cache/src/services/mutagen/mutagen.ts';
+import {MutationAlreadyProcessedError} from '../../zero-cache/src/services/mutagen/error.ts';
 import {createLogContext} from './logging.ts';
 import type {LogContext, LogLevel} from '@rocicorp/logger';
 import {assert} from '../../shared/src/asserts.ts';

--- a/packages/zero-server/src/push-processor.pg-test.ts
+++ b/packages/zero-server/src/push-processor.pg-test.ts
@@ -12,7 +12,7 @@ import type {MutationResult, PushBody} from '../../zero-protocol/src/push.ts';
 import {customMutatorKey} from '../../zql/src/mutate/custom.ts';
 import {ZQLDatabase} from './zql-database.ts';
 import {zip} from '../../shared/src/arrays.ts';
-import {MutationAlreadyProcessedError} from '../../zero-cache/src/services/mutagen/mutagen.ts';
+import {MutationAlreadyProcessedError} from '../../zero-cache/src/services/mutagen/error.ts';
 import {OutOfOrderMutation} from './process-mutations.ts';
 
 let pg: PostgresDB;


### PR DESCRIPTION
Bun users would get errors when including `@rocicorp/zero/server` because it would import an error from mutagen which imported zero-sqlite3.

My 2 cents: we should create and enforce explicit package boundaries (making it impossible to zero/server to import from zero-cache) but its a bit late to claw that one back.

https://discord.com/channels/830183651022471199/1425144484337025104/1425144488287801556