### PR TITLE
chore(zero-cache): define and handle `backfill` change messages

### DIFF
--- a/packages/zero-cache/src/services/change-source/protocol/version.test.ts
+++ b/packages/zero-cache/src/services/change-source/protocol/version.test.ts
@@ -37,9 +37,9 @@ test('protocol versions', () => {
   // Then update the version number of the `CHANGE_SOURCE_PATH`
   // in current and export it appropriately as the new version
   // in `mod.ts`.
-  t(current, '4zimue6d5cl1', '/changes/v0/stream');
+  t(current, '3o21eprg77jzi', '/changes/v0/stream');
   // During initial development, we use v0 as a non-stable
   // version (i.e. breaking change are allowed). Once the
   // protocol graduates to v1, versions must be stable.
-  t(v0, '4zimue6d5cl1', '/changes/v0/stream');
+  t(v0, '3o21eprg77jzi', '/changes/v0/stream');
 });

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.pg.test.ts
@@ -204,13 +204,13 @@ describe('change-streamer/http', () => {
       ],
       [
         // Change the error message as necessary
-        `Cannot service client at protocol v6. Supported protocols: [v1 ... v5]`,
+        `Cannot service client at protocol v7. Supported protocols: [v1 ... v6]`,
         `/replication/v${PROTOCOL_VERSION + 1}/changes` +
           `?id=foo&replicaVersion=bar&watermark=123&initial=true`,
       ],
       [
         // Change the error message as necessary
-        `Cannot service client at protocol v6. Supported protocols: [v1 ... v5]`,
+        `Cannot service client at protocol v7. Supported protocols: [v1 ... v6]`,
         `/replication/v${PROTOCOL_VERSION + 1}/snapshot` +
           `?id=foo&replicaVersion=bar&watermark=123&initial=true`,
       ],

--- a/packages/zero-cache/src/services/change-streamer/change-streamer.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer.ts
@@ -64,8 +64,10 @@ export interface ChangeStreamer {
 //   - Adds `metadata` to `create-table` message
 //   - Adds `tableMetadata` to `add-column` message
 //   - Adds `table-update-metadata` message
+// v6: v0.26
+//   - Adds support for `backfill` messages
 
-export const PROTOCOL_VERSION = 5;
+export const PROTOCOL_VERSION = 6;
 
 export type SubscriberContext = {
   /**

--- a/packages/zero-cache/src/services/replicator/change-processor.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.ts
@@ -821,7 +821,6 @@ class TransactionProcessor {
         skipped++;
         continue; // the row was deleted after the backfill snapshot
       }
-      const fullRow = {...row.row, [ZERO_VERSION_COLUMN_NAME]: watermark};
       const updates =
         rowOp?.op === SET_OP
           ? columns.filter(
@@ -840,7 +839,8 @@ class TransactionProcessor {
           ON CONFLICT (${rowKeyColsStr})
           DO UPDATE SET ${updateStmts.join(',')};
       `,
-        Object.values(fullRow),
+        ...Object.values(row.row),
+        watermark, // the _0_version for new rows (i.e. table backfill)
       );
       backfilled++;
     }

--- a/packages/zero-cache/src/services/replicator/change-processor.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.ts
@@ -40,6 +40,7 @@ import type {
   ColumnUpdate,
   IndexCreate,
   IndexDrop,
+  MessageBackfill,
   MessageCommit,
   MessageDelete,
   MessageInsert,
@@ -53,7 +54,7 @@ import type {
 } from '../change-source/protocol/current/data.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
 import type {ReplicatorMode} from './replicator.ts';
-import {ChangeLog} from './schema/change-log.ts';
+import {ChangeLog, DEL_OP, SET_OP} from './schema/change-log.ts';
 import {ColumnMetadataStore} from './schema/column-metadata.ts';
 import {
   ZERO_VERSION_COLUMN_NAME,
@@ -66,6 +67,7 @@ export type ChangeProcessorMode = ReplicatorMode | 'initial-sync';
 export type CommitResult = {
   watermark: string;
   schemaUpdated: boolean;
+  changeLogUpdated: boolean;
 };
 
 /**
@@ -221,8 +223,11 @@ export class ChangeProcessor {
       this.#currentTx = null;
 
       assert(watermark, 'watermark is required for commit messages');
-      const schemaUpdated = tx.processCommit(msg, watermark);
-      return {watermark, schemaUpdated};
+      const {schemaUpdated, changeLogUpdated} = tx.processCommit(
+        msg,
+        watermark,
+      );
+      return {watermark, schemaUpdated, changeLogUpdated};
     }
 
     if (msg.tag === 'rollback') {
@@ -271,6 +276,9 @@ export class ChangeProcessor {
       case 'drop-index':
         tx.processDropIndex(msg);
         break;
+      case 'backfill':
+        tx.processBackfill(msg);
+        break;
       default:
         unreachable(msg);
     }
@@ -314,6 +322,7 @@ class TransactionProcessor {
 
   #pos = 0;
   #schemaChanged = false;
+  #numChangeLogEntries = 0;
 
   constructor(
     lc: LogContext,
@@ -459,14 +468,11 @@ class TransactionProcessor {
   // https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html#PROTOCOL-LOGICALREP-MESSAGE-FORMATS-TUPLEDATA
   //
   // However, in certain cases an UPDATE may be received for a row that
-  // was not initially synced, such as when:
-  // (1) an existing table is added to the app's publication, or
-  // (2) a new sharding key is added to a shard during resharding.
+  // was not initially synced, such as when, an existing table is added
+  // to the app's publication.
   //
   // In order to facilitate "resumptive" replication, the logic falls back to
   // an INSERT if the update did not change any rows.
-  // TODO: Figure out a solution for resumptive replication of rows
-  //       with TOASTed values.
   processUpdate(update: MessageUpdate) {
     const table = liteTableName(update.relation);
     const tableSpec = this.#tableSpec(table);
@@ -537,6 +543,7 @@ class TransactionProcessor {
       this.#logTruncateOp(table);
     }
   }
+
   processCreateTable(create: TableCreate) {
     if (create.metadata) {
       this.#tableMetadata.set(create.spec, create.metadata);
@@ -554,7 +561,17 @@ class TransactionProcessor {
       );
     }
 
-    this.#logResetOp(table.name);
+    if (
+      Object.keys(create.backfill ?? {}).length ===
+      Object.keys(create.spec.columns).length
+    ) {
+      this.#reloadTableSpecs();
+    } else {
+      // Make the table visible immediately unless all of the columns are
+      // being backfilled. In the backfill case, the version bump will happen
+      // with the backfill is complete.
+      this.#logResetOp(table.name);
+    }
     this.#lc.info?.(create.tag, table.name);
   }
 
@@ -591,7 +608,13 @@ class TransactionProcessor {
     // Write to metadata table
     this.#columnMetadata.insert(table, name, msg.column.spec, msg.backfill);
 
-    this.#bumpVersions(table);
+    if (msg.backfill) {
+      this.#reloadTableSpecs();
+    } else {
+      // Make the new column visible immediately if it's not being backfilled.
+      // Otherwise, the version bump will happen with the backfill is complete.
+      this.#bumpVersions(table);
+    }
     this.#lc.info?.(msg.tag, table, msg.column);
   }
 
@@ -690,7 +713,17 @@ class TransactionProcessor {
 
     // indexes affect tables visibility (e.g. sync-ability is gated on
     // having a unique index), so reset pipelines to refresh table schemas.
-    this.#logResetOp(index.tableName);
+    // However, the reset is not necessary if the index is for a table
+    // that is not yet visible due to backfilling.
+    const tableSpec = must(this.#tableSpecs.get(index.tableName));
+    if (
+      (tableSpec.backfilling ?? []).length ===
+      Object.entries(tableSpec.columns).length - 1 // don't count _0_version
+    ) {
+      this.#reloadTableSpecs();
+    } else {
+      this.#logResetOp(index.tableName);
+    }
     this.#lc.info?.(create.tag, index.name);
   }
 
@@ -727,6 +760,7 @@ class TransactionProcessor {
         key,
         backfilledColumns,
       );
+      this.#numChangeLogEntries++;
     }
   }
 
@@ -736,12 +770,14 @@ class TransactionProcessor {
     // when writing columns that are being backfilled.
     if (this.#mode === 'serving' || backfilling?.length) {
       this.#changeLog.logDeleteOp(this.#version, this.#pos++, table, key);
+      this.#numChangeLogEntries++;
     }
   }
 
   #logTruncateOp(table: string) {
     if (this.#mode === 'serving') {
       this.#changeLog.logTruncateOp(this.#version, table);
+      this.#numChangeLogEntries++;
     }
   }
 
@@ -749,12 +785,96 @@ class TransactionProcessor {
     this.#schemaChanged = true;
     if (this.#mode === 'serving') {
       this.#changeLog.logResetOp(this.#version, table);
+      this.#numChangeLogEntries++;
     }
     this.#reloadTableSpecs();
   }
 
-  /** @returns `true` if the schema was updated. */
-  processCommit(commit: MessageCommit, watermark: string): boolean {
+  processBackfill({
+    relation,
+    watermark,
+    columns,
+    rowValues,
+    completed,
+  }: MessageBackfill) {
+    const tableName = liteTableName(relation);
+    const tableSpec = must(this.#tableSpecs.get(tableName));
+    const rowKeyCols = relation.rowKey.columns;
+    const cols = [...rowKeyCols, ...columns];
+
+    // Common parts of the INSERT sql statement.
+    const insertColsStr = [...cols, ZERO_VERSION_COLUMN_NAME].map(id).join(',');
+    const qMarks = Array.from({length: cols.length + 1}, () => '?').join(',');
+    const rowKeyColsStr = rowKeyCols.map(id).join(',');
+
+    let backfilled = 0;
+    let skipped = 0;
+    for (const v of rowValues) {
+      const row = liteRow(
+        Object.fromEntries(cols.map((c, i) => [c, v[i]])),
+        tableSpec,
+        this.#jsonFormat,
+      );
+      const rowKey = this.#getKey(row, {relation});
+      const rowOp = this.#changeLog.getLatestRowOp(tableName, rowKey);
+      if (rowOp?.op === DEL_OP && rowOp.stateVersion > watermark) {
+        skipped++;
+        continue; // the row was deleted after the backfill snapshot
+      }
+      const fullRow = {...row.row, [ZERO_VERSION_COLUMN_NAME]: watermark};
+      const updates =
+        rowOp?.op === SET_OP
+          ? columns.filter(
+              c => (rowOp.backfillingColumnVersions[c] ?? '') <= watermark,
+            )
+          : columns;
+      if (updates.length === 0) {
+        // row already has newer values for all backfilling columns.
+        skipped++;
+        continue;
+      }
+      const updateStmts = updates.map(col => `${id(col)}=excluded.${id(col)}`);
+      this.#db.run(
+        /*sql*/ `
+        INSERT INTO ${id(tableName)} (${insertColsStr}) VALUES (${qMarks})
+          ON CONFLICT (${rowKeyColsStr})
+          DO UPDATE SET ${updateStmts.join(',')};
+      `,
+        Object.values(fullRow),
+      );
+      backfilled++;
+    }
+
+    this.#lc.debug?.(
+      `backfilled ${backfilled} rows (skipped ${skipped}) into ${tableName}`,
+    );
+
+    if (completed) {
+      const columnMetadata = must(ColumnMetadataStore.getInstance(this.#db.db));
+      for (const col of cols) {
+        columnMetadata.clearBackfilling(tableName, col);
+      }
+      // Given that new columns are being exposed for every row in the table, bump the
+      // row version for all rows.
+      this.#bumpVersions(tableName);
+      this.#lc.info?.(`finished backfilling ${tableName}`);
+
+      // Note that there is no need to clear the backfillingColumnVersions values
+      // in the changeLog. It could theoretically be done for clarity but:
+      // (1) it could be non-trivial in terms of latency introduced and
+      // (2) the data must be preserved if _other_ columns are in the process
+      //     of being backfilled
+      //
+      // Thus, for speed and simplicity, the values are left as is. (Note that
+      // subsequent replicated changes to those rows will clear the values if
+      // no backfills are in progress).
+    }
+  }
+
+  processCommit(
+    commit: MessageCommit,
+    watermark: string,
+  ): {schemaUpdated: boolean; changeLogUpdated: boolean} {
     if (watermark !== this.#version) {
       throw new Error(
         `'commit' version ${watermark} does not match 'begin' version ${
@@ -779,7 +899,10 @@ class TransactionProcessor {
     const elapsedMs = Date.now() - this.#startMs;
     this.#lc.debug?.(`Committed tx@${this.#version} (${elapsedMs} ms)`);
 
-    return this.#schemaChanged;
+    return {
+      schemaUpdated: this.#schemaChanged,
+      changeLogUpdated: this.#numChangeLogEntries > 0,
+    };
   }
 
   abort(lc: LogContext) {

--- a/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
@@ -1,4 +1,4 @@
-import {LogContext} from '@rocicorp/logger';
+import type {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
 import {
   afterEach,

--- a/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
@@ -1,4 +1,4 @@
-import type {LogContext} from '@rocicorp/logger';
+import {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
 import {
   afterEach,
@@ -16,6 +16,7 @@ import {Database} from '../../../../zqlite/src/db.ts';
 import {initEventSinkForTesting} from '../../observability/events.ts';
 import {expectTables, initDB} from '../../test/lite.ts';
 import {Subscription} from '../../types/subscription.ts';
+import {orTimeoutWith} from '../../types/timeout.ts';
 import {
   PROTOCOL_VERSION,
   type Downstream,
@@ -510,6 +511,148 @@ describe('replicator/incremental-sync', () => {
         },
       ]
     `);
+  });
+
+  async function noNotification(
+    notification: Promise<IteratorResult<unknown>>,
+  ) {
+    expect(await orTimeoutWith(notification, 50, 'timed-out')).toBe(
+      'timed-out',
+    );
+  }
+
+  test('does not notify on incomplete backfills', async () => {
+    const issues = new ReplicationMessages({issues: ['issueID']});
+
+    initReplicationState(replica, ['zero_data'], '09');
+
+    initDB(
+      replica,
+      /*sql*/ `
+    CREATE TABLE issues(
+      issueID INTEGER PRIMARY KEY,
+      big INTEGER,
+      _0_version TEXT
+    );
+    CREATE UNIQUE INDEX issues_pkey ON issues ("issueID");
+
+    INSERT INTO issues ("issueID", big, _0_version) VALUES (1, 2, '100');
+    INSERT INTO issues ("issueID", big, _0_version) VALUES (2, 3, '100');
+      `,
+    );
+
+    void syncer.run(lc);
+    const notifications = syncer.subscribe();
+    const versionReady = notifications[Symbol.asyncIterator]();
+    await versionReady.next(); // Get the initial nextStateVersion.
+    expect(subscribeFn.mock.calls[0][0]).toEqual({
+      protocolVersion: PROTOCOL_VERSION,
+      taskID: 'task-id',
+      id: 'incremental_sync_test_id',
+      mode: 'serving',
+      replicaVersion: '09',
+      watermark: '09',
+      initial: true,
+    });
+
+    const next = versionReady.next();
+
+    for (const change of [
+      ['status', {tag: 'status'}],
+      ['begin', issues.begin(), {commitWatermark: '110'}],
+      [
+        'data',
+        issues.addColumn(
+          'issues',
+          'new_column',
+          {pos: 4, dataType: 'text'},
+          {backfill: {id: 123}},
+        ),
+      ],
+      ['commit', issues.commit(), {watermark: '110'}],
+      ['begin', issues.begin(), {commitWatermark: '110.01'}],
+      [
+        'data',
+        {
+          tag: 'backfill',
+          relation: {
+            schema: 'public',
+            name: 'issues',
+            rowKey: {columns: ['issueID']},
+          },
+          watermark: '110',
+          columns: ['new_column'],
+          rowValues: [[1, 'hello']],
+        },
+      ],
+      ['commit', issues.commit(), {watermark: '110.01'}],
+    ] satisfies Downstream[]) {
+      downstream.push(change);
+    }
+
+    // Ensure no notifications have been published.
+    await noNotification(next);
+
+    // And that row versions have not changed, even for backfilled rows.
+    const issuesDump = replica.prepare(/*sql*/ `SELECT * FROM issues`);
+    expect(issuesDump.all()).toEqual([
+      {
+        _0_version: '100',
+        big: 2,
+        issueID: 1,
+        new_column: 'hello',
+      },
+      {
+        _0_version: '100',
+        big: 3,
+        issueID: 2,
+        new_column: null,
+      },
+    ]);
+
+    // Complete the backfill.
+    for (const change of [
+      ['begin', issues.begin(), {commitWatermark: '110.02'}],
+      [
+        'data',
+        {
+          tag: 'backfill',
+          relation: {
+            schema: 'public',
+            name: 'issues',
+            rowKey: {columns: ['issueID']},
+          },
+          watermark: '110',
+          columns: ['new_column'],
+          rowValues: [[2, 'world']],
+          completed: true,
+        },
+      ],
+      ['commit', issues.commit(), {watermark: '110.02'}],
+    ] satisfies Downstream[]) {
+      downstream.push(change);
+    }
+
+    // Now there should be a notification.
+    expect(
+      await orTimeoutWith(next, 5000, new Error('timed-out')),
+    ).not.toBeInstanceOf(Error);
+
+    // And row versions should be bumped.
+    expect(issuesDump.all()).toEqual([
+      {
+        _0_version: '110.02',
+        big: 2,
+        issueID: 1,
+        new_column: 'hello',
+      },
+      {
+        _0_version: '110.02',
+        big: 3,
+        issueID: 2,
+        new_column: 'world',
+      },
+    ]);
   });
 
   test('retry on initial change-streamer connection failure', async () => {

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -114,7 +114,7 @@ export class IncrementalSyncer {
               if (result?.schemaUpdated) {
                 statusPublisher?.publish(lc, 'Replicating', 'Schema updated');
               }
-              if (result?.watermark) {
+              if (result?.watermark && result?.changeLogUpdated) {
                 void this.#notifier.notifySubscribers({state: 'version-ready'});
               }
               break;

--- a/packages/zero-cache/src/services/replicator/schema/change-log.test.ts
+++ b/packages/zero-cache/src/services/replicator/schema/change-log.test.ts
@@ -532,4 +532,28 @@ describe('replicator/schema/change-log', () => {
       backfillingColumnVersions: '{}',
     });
   });
+
+  test('getLatestRowOp', () => {
+    changeLog.logSetOp('123', 0, 'foo', {a: 1, b: 2}, ['c', 'b']);
+    changeLog.logSetOp('123', 1, 'bar', {b: 1, a: 2}, undefined);
+
+    expect(changeLog.getLatestRowOp('bar', {a: 3, b: 4})).toBeUndefined();
+    expect(changeLog.getLatestRowOp('foo', {b: 2, a: 1})).toEqual({
+      stateVersion: '123',
+      table: 'foo',
+      rowKey: '{"a":1,"b":2}',
+      op: 's',
+      backfillingColumnVersions: {
+        b: '123',
+        c: '123',
+      },
+    });
+    expect(changeLog.getLatestRowOp('bar', {a: 2, b: 1})).toEqual({
+      stateVersion: '123',
+      table: 'bar',
+      rowKey: '{"a":2,"b":1}',
+      op: 's',
+      backfillingColumnVersions: {},
+    });
+  });
 });


### PR DESCRIPTION
Defines a new `backfill` message in the change stream protocol, and implements the handling of them at the replication level, as specified in the [backfill algorithm](https://www.notion.so/replicache/Auto-backfill-Schema-Change-Replication-2cb3bed8954580ee8c92e3a730c38772?source=copy_link#2cc3bed89545801c9f74dd255c6ffdef).

Key points:
* The changeLog metadata tracked in https://github.com/rocicorp/mono/pull/5505 is used to determine which rows / column values to backfill, avoiding re-introducing deleted rows or overwriting columns from newer replicated updates.
* Care is taken not to change row versions during the backfill. In other words, no changes to any syncable columns should occur while the backfill is in progress.
* To avoid unnecessary IVM processing, no replica-changed notifications are sent if nothing has been added to the changeLog (e.g. transactions consisting only of backfill messages).
* A completed backfill is handled similarly to a schema change: all row versions in the table are bumped, and a reset signal is inserted into the changeLog so that pipelines are rehydrated.

Upcoming:
* change-source logic for producing backfill messages