### PR TITLE
zero-cache: respect ZERO_CHANGE_STREAMER_QUEUE_SIZE_BACK_PRESSURE_THRESHOLD

### DIFF
--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -578,6 +578,17 @@ export const zeroOptions = {
         `throughput.`,
       ],
     },
+
+    queueSizeBackPressureThreshold: {
+      type: v.number().optional(),
+      desc: [
+        `Optional queued change count threshold for applying back pressure.`,
+        ``,
+        `If set, back pressure is applied when either the estimated queued bytes exceeds`,
+        `{bold backPressureLimitHeapProportion} threshold or the number of queued changes exceeds`,
+        `this threshold.`,
+      ],
+    },
   },
 
   taskID: {

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -42,6 +42,7 @@ export default async function runWorker(
       protocol,
       startupDelayMs,
       backPressureLimitHeapProportion,
+      queueSizeBackPressureThreshold,
     },
     upstream,
     change,
@@ -101,6 +102,7 @@ export default async function runWorker(
         subscriptionState,
         autoReset ?? false,
         backPressureLimitHeapProportion,
+        queueSizeBackPressureThreshold,
         setTimeout,
       );
       break;

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -61,11 +61,11 @@ describe('change-streamer/service', () => {
     acks = new Queue();
     setTimeoutFn = vi.fn();
 
-    streamer = await initializeStreamer(
-      lc,
-      shard,
-      'task-id',
-      'change.streamer:12345',
+	    streamer = await initializeStreamer(
+	      lc,
+	      shard,
+	      'task-id',
+	      'change.streamer:12345',
       'ws',
       sql,
       {
@@ -76,12 +76,11 @@ describe('change-streamer/service', () => {
             acks: {push: status => acks.enqueue(status)},
           }),
       },
-      replicaConfig,
-      true,
-      0.04,
-      undefined,
-      setTimeoutFn as unknown as typeof setTimeout,
-    );
+	      replicaConfig,
+	      true,
+	      0.04,
+	      setTimeoutFn as unknown as typeof setTimeout,
+	    );
     streamerDone = streamer.run();
 
     return async () => {
@@ -866,7 +865,6 @@ describe('change-streamer/service', () => {
 	      replicaConfig,
 	      true,
 	      0.04,
-	      undefined,
 	    );
     void streamer.run();
 
@@ -892,7 +890,6 @@ describe('change-streamer/service', () => {
 	      replicaConfig,
 	      true,
 	      0.04,
-	      undefined,
 	    );
     void streamer.run();
 
@@ -915,7 +912,6 @@ describe('change-streamer/service', () => {
 	      replicaConfig,
 	      true,
 	      0.04,
-	      undefined,
 	    );
     void streamer.run();
 
@@ -950,7 +946,6 @@ describe('change-streamer/service', () => {
 	      replicaConfig,
 	      true,
 	      0.04,
-	      undefined,
 	    );
     void streamer.run();
 
@@ -988,7 +983,6 @@ describe('change-streamer/service', () => {
 	      replicaConfig,
 	      true,
 	      0.04,
-	      undefined,
 	    );
     void streamer.run();
 
@@ -1060,7 +1054,6 @@ describe('change-streamer/service', () => {
 	      replicaConfig,
 	      true,
 	      0.04,
-	      undefined,
 	    );
     void streamer.run();
 

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -79,6 +79,7 @@ describe('change-streamer/service', () => {
       replicaConfig,
       true,
       0.04,
+      undefined,
       setTimeoutFn as unknown as typeof setTimeout,
     );
     streamerDone = streamer.run();
@@ -854,18 +855,19 @@ describe('change-streamer/service', () => {
           return resolver().promise;
         }),
     };
-    const streamer = await initializeStreamer(
-      lc,
-      shard,
-      'task-id',
-      'change.streamer:12345',
-      'ws',
-      sql,
-      source,
-      replicaConfig,
-      true,
-      0.04,
-    );
+	    const streamer = await initializeStreamer(
+	      lc,
+	      shard,
+	      'task-id',
+	      'change.streamer:12345',
+	      'ws',
+	      sql,
+	      source,
+	      replicaConfig,
+	      true,
+	      0.04,
+	      undefined,
+	    );
     void streamer.run();
 
     expect(await hasRetried).toBe(true);
@@ -879,18 +881,19 @@ describe('change-streamer/service', () => {
         return resolver().promise;
       }),
     };
-    let streamer = await initializeStreamer(
-      lc,
-      shard,
-      'task-id',
-      'change.streamer:12345',
+	    let streamer = await initializeStreamer(
+	      lc,
+	      shard,
+	      'task-id',
+	      'change.streamer:12345',
       'ws',
       sql,
       source,
-      replicaConfig,
-      true,
-      0.04,
-    );
+	      replicaConfig,
+	      true,
+	      0.04,
+	      undefined,
+	    );
     void streamer.run();
 
     expect(await requests.dequeue()).toBe(REPLICA_VERSION);
@@ -901,18 +904,19 @@ describe('change-streamer/service', () => {
       UPDATE "zoro_3/cdc"."replicationState" SET "lastWatermark" = '04';
     `.simple();
 
-    streamer = await initializeStreamer(
-      lc,
-      shard,
-      'task-id',
+	    streamer = await initializeStreamer(
+	      lc,
+	      shard,
+	      'task-id',
       'change.streamer:12345',
       'ws',
       sql,
       source,
-      replicaConfig,
-      true,
-      0.04,
-    );
+	      replicaConfig,
+	      true,
+	      0.04,
+	      undefined,
+	    );
     void streamer.run();
 
     expect(await requests.dequeue()).toBe('04');
@@ -935,18 +939,19 @@ describe('change-streamer/service', () => {
           return resolver().promise;
         }),
     };
-    const streamer = await initializeStreamer(
-      lc,
-      shard,
-      'task-id',
+	    const streamer = await initializeStreamer(
+	      lc,
+	      shard,
+	      'task-id',
       'change.streamer:12345',
       'ws',
       sql,
       source,
-      replicaConfig,
-      true,
-      0.04,
-    );
+	      replicaConfig,
+	      true,
+	      0.04,
+	      undefined,
+	    );
     void streamer.run();
 
     changes.fail(new Error('doh'));
@@ -972,18 +977,19 @@ describe('change-streamer/service', () => {
           return resolver().promise;
         }),
     };
-    const streamer = await initializeStreamer(
-      lc,
-      shard,
-      'task-id',
+	    const streamer = await initializeStreamer(
+	      lc,
+	      shard,
+	      'task-id',
       'change.streamer:54321',
       'ws',
       sql,
       source,
-      replicaConfig,
-      true,
-      0.04,
-    );
+	      replicaConfig,
+	      true,
+	      0.04,
+	      undefined,
+	    );
     void streamer.run();
 
     // Stream down a big (1MB) transaction, which should take time to commit.
@@ -1043,18 +1049,19 @@ describe('change-streamer/service', () => {
           }),
         ),
     };
-    const streamer = await initializeStreamer(
-      lc,
-      shard,
-      'task-id',
+	    const streamer = await initializeStreamer(
+	      lc,
+	      shard,
+	      'task-id',
       'change.streamer:54321',
       'ws',
       sql,
       source,
-      replicaConfig,
-      true,
-      0.04,
-    );
+	      replicaConfig,
+	      true,
+	      0.04,
+	      undefined,
+	    );
     void streamer.run();
 
     const sub = await streamer.subscribe({

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -56,6 +56,7 @@ export async function initializeStreamer(
   subscriptionState: SubscriptionState,
   autoReset: boolean,
   backPressureLimitHeapProportion: number,
+  queueSizeBackPressureThreshold: number | undefined,
   setTimeoutFn = setTimeout,
 ): Promise<ChangeStreamerService> {
   // Make sure the ChangeLog DB is set up.
@@ -80,6 +81,7 @@ export async function initializeStreamer(
     changeSource,
     autoReset,
     backPressureLimitHeapProportion,
+    queueSizeBackPressureThreshold,
     setTimeoutFn,
   );
 }
@@ -277,6 +279,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     source: ChangeSource,
     autoReset: boolean,
     backPressureLimitHeapProportion: number,
+    queueSizeBackPressureThreshold: number | undefined,
     setTimeoutFn = setTimeout,
   ) {
     this.id = `change-streamer`;
@@ -296,6 +299,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       consumed => this.#stream?.acks.push(['status', consumed[1], consumed[2]]),
       err => this.stop(err),
       backPressureLimitHeapProportion,
+      queueSizeBackPressureThreshold,
     );
     this.#forwarder = new Forwarder();
     this.#autoReset = autoReset;

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -45,6 +45,8 @@ import {
 } from './schema/tables.ts';
 import type {Subscriber} from './subscriber.ts';
 
+const BACK_PRESSURE_RELEASE_RATIO = 0.8;
+
 type SubscriberAndMode = {
   subscriber: Subscriber;
   mode: ReplicatorMode;
@@ -322,10 +324,12 @@ export class Storer implements Service {
 
   #maybeReleaseBackPressure() {
     const belowBytes =
-      this.#approximateQueuedBytes < this.#backPressureThresholdBytes * 0.8;
+      this.#approximateQueuedBytes <
+      this.#backPressureThresholdBytes * BACK_PRESSURE_RELEASE_RATIO;
     const belowQueueSize =
       this.#queueSizeBackPressureThreshold === undefined ||
-      this.#queue.size() < this.#queueSizeBackPressureThreshold * 0.8;
+      this.#queue.size() <
+        this.#queueSizeBackPressureThreshold * BACK_PRESSURE_RELEASE_RATIO;
     if (
       this.#readyForMore !== null &&
       // Wait for at least 20% of the threshold to free up.

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -323,16 +323,18 @@ export class Storer implements Service {
   }
 
   #maybeReleaseBackPressure() {
-    const belowBytes =
-      this.#approximateQueuedBytes <
-      this.#backPressureThresholdBytes * BACK_PRESSURE_RELEASE_RATIO;
+    const isBelowThreshold = (current: number, threshold: number) =>
+      current < threshold * BACK_PRESSURE_RELEASE_RATIO;
+    const belowBytes = isBelowThreshold(
+      this.#approximateQueuedBytes,
+      this.#backPressureThresholdBytes,
+    );
     const belowQueueSize =
       this.#queueSizeBackPressureThreshold === undefined ||
-      this.#queue.size() <
-        this.#queueSizeBackPressureThreshold * BACK_PRESSURE_RELEASE_RATIO;
+      isBelowThreshold(this.#queue.size(), this.#queueSizeBackPressureThreshold);
     if (
       this.#readyForMore !== null &&
-      // Wait for at least 20% of the threshold to free up.
+      // Wait for at least 20% of each configured threshold to free up.
       belowBytes &&
       belowQueueSize
     ) {

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -115,6 +115,7 @@ export class Storer implements Service {
   readonly #onFatal: (err: Error) => void;
   readonly #queue = new Queue<QueueEntry>();
   readonly #backPressureThresholdBytes: number;
+  readonly #queueSizeBackPressureThreshold: number | undefined;
 
   #approximateQueuedBytes = 0;
   #running = false;
@@ -130,6 +131,7 @@ export class Storer implements Service {
     onConsumed: (c: Commit | StatusMessage) => void,
     onFatal: (err: Error) => void,
     backPressureLimitHeapProportion: number,
+    queueSizeBackPressureThreshold: number | undefined,
   ) {
     this.#lc = lc.withContext('component', 'change-log');
     this.#shard = shard;
@@ -140,6 +142,7 @@ export class Storer implements Service {
     this.#replicaVersion = replicaVersion;
     this.#onConsumed = onConsumed;
     this.#onFatal = onFatal;
+    this.#queueSizeBackPressureThreshold = queueSizeBackPressureThreshold;
 
     const heapStats = getHeapStatistics();
     this.#backPressureThresholdBytes =
@@ -152,6 +155,12 @@ export class Storer implements Service {
         `to absorb upstream spikes`,
       {heapStats},
     );
+
+    if (this.#queueSizeBackPressureThreshold !== undefined) {
+      this.#lc.info?.(
+        `Queue size back pressure threshold set to ${this.#queueSizeBackPressureThreshold} queued changes`,
+      );
+    }
   }
 
   // For readability in SQL statements.
@@ -284,9 +293,14 @@ export class Storer implements Service {
     if (!this.#running) {
       return undefined;
     }
+    const overBytes =
+      this.#approximateQueuedBytes > this.#backPressureThresholdBytes;
+    const overQueueSize =
+      this.#queueSizeBackPressureThreshold !== undefined &&
+      this.#queue.size() > this.#queueSizeBackPressureThreshold;
     if (
       this.#readyForMore === null &&
-      this.#approximateQueuedBytes > this.#backPressureThresholdBytes
+      (overBytes || overQueueSize)
     ) {
       this.#lc.warn?.(
         `applying back pressure with ${this.#queue.size()} queued changes (~${(this.#approximateQueuedBytes / 1024 ** 2).toFixed(2)} MB)\n` +
@@ -307,10 +321,16 @@ export class Storer implements Service {
   }
 
   #maybeReleaseBackPressure() {
+    const belowBytes =
+      this.#approximateQueuedBytes < this.#backPressureThresholdBytes * 0.8;
+    const belowQueueSize =
+      this.#queueSizeBackPressureThreshold === undefined ||
+      this.#queue.size() < this.#queueSizeBackPressureThreshold * 0.8;
     if (
       this.#readyForMore !== null &&
       // Wait for at least 20% of the threshold to free up.
-      this.#approximateQueuedBytes < this.#backPressureThresholdBytes * 0.8
+      belowBytes &&
+      belowQueueSize
     ) {
       this.#lc.info?.(
         `releasing back pressure with ${this.#queue.size()} queued changes (~${(this.#approximateQueuedBytes / 1024 ** 2).toFixed(2)} MB)`,

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -45,6 +45,9 @@ import {
 } from './schema/tables.ts';
 import type {Subscriber} from './subscriber.ts';
 
+// Back pressure is applied when either the queued bytes threshold or the queued
+// change count threshold is exceeded, and released only after we fall below
+// both thresholds by a safety margin.
 const BACK_PRESSURE_RELEASE_RATIO = 0.8;
 
 type SubscriberAndMode = {
@@ -334,7 +337,6 @@ export class Storer implements Service {
       isBelowThreshold(this.#queue.size(), this.#queueSizeBackPressureThreshold);
     if (
       this.#readyForMore !== null &&
-      // Wait for at least 20% of each configured threshold to free up.
       belowBytes &&
       belowQueueSize
     ) {

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -326,15 +326,16 @@ export class Storer implements Service {
   }
 
   #maybeReleaseBackPressure() {
-    const isBelowThreshold = (current: number, threshold: number) =>
-      current < threshold * BACK_PRESSURE_RELEASE_RATIO;
-    const belowBytes = isBelowThreshold(
-      this.#approximateQueuedBytes,
-      this.#backPressureThresholdBytes,
-    );
+    const releaseBytesThreshold =
+      this.#backPressureThresholdBytes * BACK_PRESSURE_RELEASE_RATIO;
+    const releaseQueueSizeThreshold =
+      this.#queueSizeBackPressureThreshold === undefined
+        ? undefined
+        : this.#queueSizeBackPressureThreshold * BACK_PRESSURE_RELEASE_RATIO;
+    const belowBytes = this.#approximateQueuedBytes < releaseBytesThreshold;
     const belowQueueSize =
-      this.#queueSizeBackPressureThreshold === undefined ||
-      isBelowThreshold(this.#queue.size(), this.#queueSizeBackPressureThreshold);
+      releaseQueueSizeThreshold === undefined ||
+      this.#queue.size() < releaseQueueSizeThreshold;
     if (
       this.#readyForMore !== null &&
       belowBytes &&


### PR DESCRIPTION
Adds change streamer config option queueSizeBackPressureThreshold.

Env var: ZERO_CHANGE_STREAMER_QUEUE_SIZE_BACK_PRESSURE_THRESHOLD

Behavior: if set, the change streamer applies back pressure when either the existing heap based queued bytes threshold is exceeded or the queued change count exceeds this threshold. Release requires falling below both thresholds.