### PR TITLE
perf: remove eager expandNode from ArrayView

### DIFF
--- a/packages/zql/src/ivm/array-view.test.ts
+++ b/packages/zql/src/ivm/array-view.test.ts
@@ -154,23 +154,15 @@ test('single-format', () => {
 
   // trying to add another element should be an error
   // pipeline should have been configured with a limit of one
-  // With batched change application, the error is thrown when changes are applied
-  // (at flush() or .data access), not at push() time.
-  consume(ms.push({row: {a: 2, b: 'b'}, type: 'add'}));
-  expect(() => view.flush()).toThrow(
+  // Changes are applied immediately in push(), so the error is thrown at push time.
+  expect(() => consume(ms.push({row: {a: 2, b: 'b'}, type: 'add'}))).toThrow(
     "Singular relationship '' should not have multiple rows. You may need to declare this relationship with the `many` helper instead of the `one` helper in your schema.",
   );
 
   // Adding the same element is not an error in the ArrayView but it is an error
   // in the Source. This case is tested in view-apply-change.ts.
 
-  // Note: After the failed flush, the pending change is still there. Let's verify
-  // that accessing .data also throws (auto-flush safety net).
-  expect(() => view.data).toThrow(
-    "Singular relationship '' should not have multiple rows. You may need to declare this relationship with the `many` helper instead of the `one` helper in your schema.",
-  );
-
-  // The listener's data is still the old value since the flush failed
+  // The listener's data is still the old value since the push failed
   expect(data).toEqual({a: 1, b: 'a'});
   expect(callCount).toBe(1);
 

--- a/packages/zql/src/ivm/array-view.ts
+++ b/packages/zql/src/ivm/array-view.ts
@@ -1,59 +1,14 @@
 import {assert} from '../../../shared/src/asserts.ts';
 import type {Immutable} from '../../../shared/src/immutable.ts';
-import {mapValues} from '../../../shared/src/objects.ts';
 import {emptyArray} from '../../../shared/src/sentinels.ts';
 import type {ErroredQuery} from '../../../zero-protocol/src/custom-queries.ts';
 import type {TTL} from '../query/ttl.ts';
 import type {Listener, ResultType, TypedView} from '../query/typed-view.ts';
 import type {Change} from './change.ts';
-import type {Node} from './data.ts';
 import {skipYields, type Input, type Output} from './operator.ts';
 import type {SourceSchema} from './schema.ts';
-import {
-  applyChanges,
-  type ExpandedNode,
-  type ViewChange,
-} from './view-apply-change.ts';
+import {applyChange} from './view-apply-change.ts';
 import type {Entry, Format, View} from './view.ts';
-
-/**
- * Eagerly expand a Node's lazy relationship generators into arrays.
- * This captures the current state of the source at the moment of expansion.
- */
-function expandNode(node: Node): ExpandedNode {
-  return {
-    row: node.row,
-    relationships: mapValues(node.relationships, v =>
-      Array.from(skipYields(v()), expandNode),
-    ),
-  };
-}
-
-/**
- * Expand a Change by eagerly evaluating all lazy relationship generators.
- */
-function expandChange(change: Change): ViewChange {
-  switch (change.type) {
-    case 'add':
-    case 'remove':
-      return {type: change.type, node: expandNode(change.node)};
-    case 'edit':
-      return {
-        type: 'edit',
-        node: expandNode(change.node),
-        oldNode: expandNode(change.oldNode),
-      };
-    case 'child':
-      return {
-        type: 'child',
-        node: expandNode(change.node),
-        child: {
-          relationshipName: change.child.relationshipName,
-          change: expandChange(change.child.change),
-        },
-      };
-  }
-}
 
 /**
  * Implements a materialized view of the output of an operator.
@@ -82,9 +37,6 @@ export class ArrayView<V extends View> implements Output, TypedView<V> {
   #resultType: ResultType = 'unknown';
   #error: ErroredQuery | undefined;
   readonly #updateTTL: (ttl: TTL) => void;
-
-  // Pending changes buffered for batch application (O(N + K) optimization)
-  #pendingChanges: ViewChange[] = [];
 
   constructor(
     input: Input,
@@ -122,30 +74,7 @@ export class ArrayView<V extends View> implements Output, TypedView<V> {
   }
 
   get data() {
-    // Auto-flush for backwards compatibility. Recommended: push() then flush().
-    //
-    //   push(A) ──► buffer ──► push(B) ──► buffer ──► flush() ──► apply all
-    //                                                    │
-    //   Legacy code may read .data here ─────────────────┘ (before flush)
-    //                          │
-    //                          ▼
-    //   Without auto-flush: stale data (missing A, B)
-    //   With auto-flush:    current data (has A, B)
-    this.#applyPendingChanges();
     return this.#root[''] as V;
-  }
-
-  #applyPendingChanges() {
-    if (this.#pendingChanges.length > 0) {
-      this.#root = applyChanges(
-        this.#root,
-        this.#pendingChanges,
-        this.#schema,
-        '',
-        this.#format,
-      );
-      this.#pendingChanges = [];
-    }
   }
 
   addListener(listener: Listener<V>) {
@@ -175,12 +104,10 @@ export class ArrayView<V extends View> implements Output, TypedView<V> {
 
   #hydrate() {
     this.#dirty = true;
-    // During hydration, expand and apply nodes immediately
     for (const node of skipYields(this.#input.fetch({}))) {
-      const expanded = expandNode(node);
-      this.#root = applyChanges(
+      this.#root = applyChange(
         this.#root,
-        [{type: 'add', node: expanded}],
+        {type: 'add', node},
         this.#schema,
         '',
         this.#format,
@@ -191,11 +118,15 @@ export class ArrayView<V extends View> implements Output, TypedView<V> {
 
   push(change: Change) {
     this.#dirty = true;
-    // Eagerly expand the change to capture current source state.
-    // This is critical: lazy generators would see stale data if deferred.
-    // Buffer the change for batch application (O(N + K) optimization).
-    const expanded = expandChange(change);
-    this.#pendingChanges.push(expanded);
+    // Apply immediately to capture current source state. Lazy relationship
+    // thunks must be evaluated now, before subsequent pushes mutate the source.
+    this.#root = applyChange(
+      this.#root,
+      change,
+      this.#schema,
+      '',
+      this.#format,
+    );
     return emptyArray;
   }
 
@@ -204,8 +135,6 @@ export class ArrayView<V extends View> implements Output, TypedView<V> {
       return;
     }
     this.#dirty = false;
-    // Apply all pending changes in one batch (O(N + K) optimization)
-    this.#applyPendingChanges();
     this.#fireListeners();
   }
 


### PR DESCRIPTION
## Problem

PR #5462 introduced `expandNode`/`expandChange` to support change buffering in ArrayView. These functions eagerly materialize ALL relationship thunks recursively before passing nodes to `applyChange`. For queries with wide/deep relationships, this turned into the single most expensive operation in the IVM pipeline.

Profiled on a page with 45 parent rows, ~200 related rows per parent, and 135 IVM pipelines (3 queries per parent row), `expandNode` became the dominant cost at **60.7% inclusive time** (10,672ms), a **4.3x regression** over the pre-#5462 baseline.

The root cause: `expandNode` recursively calls `Array.from(skipYields(v()), expandNode)` on every relationship key of every node, eagerly walking entire relationship trees. Combined with `mapValues`/`mapEntries` object allocation and generator overhead through `skipYields`, this created O(tree_size * pipeline_count) work on every `push()` and `#hydrate()` call.

## Profiled numbers (Chrome DevTools, React DEV mode)

Test scenario: page rendering 45 parent rows with ~200 related rows each, 135 IVM pipelines (3 queries per parent row).

### Before (0.26-canary.8 with expandNode) vs After (this PR)

```
Metric                     Before          After           Change
-----------------------------------------------------------------------
Longest task               12,900ms        7,686ms         40% faster
Long tasks (>50ms)         11              6               45% fewer
```

### Function-level breakdown (inclusive time)

```
Function                   Before               After                Change
---------------------------------------------------------------------------------
expandNode                 10,672ms (60.7%)      53ms (0.3%)         ELIMINATED
mapValues/mapEntries       10,616ms (60.3%)      106ms (0.6%)        ELIMINATED
skipYields                  5,984ms (34.0%)      108ms (0.7%)        93% reduction
#pushChild                 11,895ms (67.6%)     6,792ms (44.9%)      43% reduction
filterPush                  5,789ms (32.9%)     2,085ms (13.8%)      64% reduction
compareUTF8                   402ms (2.3%)        121ms (0.8%)        70% reduction
GC                            776ms (4.4%)        848ms (5.6%)        similar
```

### Self-time (leaf functions)

```
Function                   Before               After
------------------------------------------------------
run (React DEV scheduler)  7,653ms (43.5%)      8,310ms (54.9%)   [constant, dev-only]
expandNode                 ~2,600ms (~15%)       negligible        ELIMINATED
skipYields                   450ms (2.6%)         108ms (0.7%)     76% reduction
compareUTF8                  402ms (2.3%)         121ms (0.8%)     70% reduction
#fetch                       530ms (3.0%)         189ms (1.2%)     64% reduction
```

### Production estimate

The `run` function (React DEV mode scheduler) accounts for ~48% of total time but disappears in production builds. Subtracting dev-only overhead:

- **Before (with expandNode):** ~6.5s estimated production blocking time
- **After (this PR):** ~2.5 to 3s estimated production blocking time
- Remaining time dominated by N+1 pipeline pattern (135 pipelines), not ArrayView

## Data flow: before vs after

```
BEFORE (0.26 with expandNode):
                                                              
  push(change) ──> expandChange(change)                       
                        |                                     
                        ├── expandNode(node)                  
                        |     ├── mapValues(relationships)    
                        |     |     ├── skipYields(thunk())   
                        |     |     ├── Array.from(...)       
                        |     |     └── expandNode (recurse)  x N children
                        |     └── { row, relationships }      
                        |                                     
                        ├── expandNode(oldNode)  [for edits]  
                        |     └── (same recursive walk)       
                        |                                     
                        └── ExpandedChange                    
                              |                               
                     buffer in #pendingChanges                
                              |                               
                     flush() ──> applyChanges(expanded)       
                                    └── getChildNodes(array)  


AFTER (this PR):

  push(change) ──> applyChange(root, change)
                        |
                        └── getChildNodes(node.relationships)
                              |
                              ├── if Array.isArray  ──> yield* array
                              └── else (thunk)      ──> yield* skipYields(thunk())
                                                        evaluated lazily,
                                                        only for relationships
                                                        that applyChange
                                                        actually touches
```

The key insight: `getChildNodes()` in `view-apply-change.ts` already handles both expanded arrays AND lazy thunks natively. It uses `Array.isArray(children)` to distinguish the two cases and evaluates thunks on demand. The eager `expandNode` was doing redundant work that `getChildNodes` would do anyway, but recursively across the ENTIRE tree instead of just the nodes being changed.

## Fix

Remove `expandNode`/`expandChange` and the change buffering (`#pendingChanges`, `#applyPendingChanges`, auto-flush in `.data`). Apply each change immediately in `push()` using the immutable `applyChange`, exactly as the original code did before #5462 but preserving the immutable return semantics that #5462 introduced.

This is safe because:

1. **Thunks evaluated at the right time.** `push()` evaluates thunks immediately while source state is current. No stale captures.
2. **`getChildNodes()` handles lazy thunks natively.** It uses `Array.isArray(children)` to distinguish expanded arrays from lazy generator thunks. No expansion needed.
3. **Listener contract preserved.** Listeners still only fire on `flush()`, so the push/flush batching contract is maintained.
4. **Immutable `applyChange` preserved.** Returns new Entry objects, preserves identity for unchanged nodes. `React.memo` / shallow comparison on view data still works correctly.

### Changes

- Remove `expandNode` and `expandChange` functions
- Remove `mapValues` import (only used by `expandNode`)
- Remove `ExpandedNode` type import (no longer needed in array-view)
- Remove change buffering (`#pendingChanges`, `#applyPendingChanges`, auto-flush in `.data`)
- Apply changes immediately via `this.#root = applyChange(...)` in `push()`
- Update test: singular format error now throws at push time, not flush time

## Test results

All **2,212 ZQL tests pass** across 132 test files (2 pre-existing skips unrelated to this change).

Follows up on #5462.
