### PR TITLE
perf(zql): reduce allocations with frozen sentinel and object reuse

### DIFF
--- a/packages/zql/src/ivm/memory-source.ts
+++ b/packages/zql/src/ivm/memory-source.ts
@@ -17,7 +17,7 @@ import {
   type NoSubqueryCondition,
 } from '../builder/filter.ts';
 import {assertOrderingIncludesPK} from '../query/complete-ordering.ts';
-import type {Change} from './change.ts';
+import type {Change, EditChange} from './change.ts';
 import {
   constraintMatchesPrimaryKey,
   constraintMatchesRow,
@@ -49,6 +49,10 @@ import type {
   SourceInput,
 } from './source.ts';
 import type {Stream} from './stream.ts';
+
+// Shared frozen sentinel for nodes with no relationships. Avoids allocating
+// a fresh {} on every node creation in the fetch and push hot paths.
+const EMPTY_RELATIONSHIPS: Record<string, never> = Object.freeze({});
 
 export type Overlay = {
   epoch: number;
@@ -535,31 +539,34 @@ function* genPush(
       unreachable(change);
   }
 
+  // Reuse a small set of objects across the connection loop below to avoid
+  // allocating fresh Node/Change objects per connection per push. The row
+  // fields are overwritten before each use. This is safe because filterPush
+  // and its downstream consumers process each change synchronously within
+  // the generator chain -- yield* completes fully before the next iteration
+  // mutates the objects. In a workload with 135 connections, this eliminates
+  // thousands of short-lived allocations per push cycle.
+  const placeholder: Row = {};
+  const reuseNode: Node = {row: placeholder, relationships: EMPTY_RELATIONSHIPS};
+  const reuseOldNode: Node = {row: placeholder, relationships: EMPTY_RELATIONSHIPS};
+  const reuseAddRemove: {type: 'add' | 'remove'; node: Node} = {type: 'add', node: reuseNode};
+  const reuseEdit: EditChange = {type: 'edit', oldNode: reuseOldNode, node: reuseNode};
+
   for (const conn of connections) {
     const {output, filters, input} = conn;
     if (output) {
       conn.lastPushedEpoch = pushEpoch;
       setOverlay({epoch: pushEpoch, change});
-      const outputChange: Change =
-        change.type === 'edit'
-          ? {
-              type: change.type,
-              oldNode: {
-                row: change.oldRow,
-                relationships: {},
-              },
-              node: {
-                row: change.row,
-                relationships: {},
-              },
-            }
-          : {
-              type: change.type,
-              node: {
-                row: change.row,
-                relationships: {},
-              },
-            };
+      let outputChange: Change;
+      if (change.type === 'edit') {
+        reuseOldNode.row = change.oldRow;
+        reuseNode.row = change.row;
+        outputChange = reuseEdit;
+      } else {
+        reuseNode.row = change.row;
+        reuseAddRemove.type = change.type;
+        outputChange = reuseAddRemove;
+      }
       yield* filterPush(outputChange, output, input, filters?.predicate);
       yield undefined;
     }
@@ -739,7 +746,7 @@ export function* generateWithOverlayInner(
       const cmp = compare(overlays.add, row);
       if (cmp < 0) {
         addOverlayYielded = true;
-        yield {row: overlays.add, relationships: {}};
+        yield {row: overlays.add, relationships: EMPTY_RELATIONSHIPS};
       }
     }
 
@@ -750,11 +757,11 @@ export function* generateWithOverlayInner(
         continue;
       }
     }
-    yield {row, relationships: {}};
+    yield {row, relationships: EMPTY_RELATIONSHIPS};
   }
 
   if (!addOverlayYielded && overlays.add) {
-    yield {row: overlays.add, relationships: {}};
+    yield {row: overlays.add, relationships: EMPTY_RELATIONSHIPS};
   }
 }
 


### PR DESCRIPTION
> **Note**: This PR is part of an upstream contribution effort from the Goblins team (@goblinshq). Co-authored with Claude by Anthropic.

## Summary
Reduce GC pressure on the IVM push hot path with two allocation optimizations.

## Motivation
During IVM push operations, every source change is propagated to all connected pipelines. For each connection, the current code creates fresh `Node` and `Change` objects with new `relationships: {}` literals. In a workload with 135 IVM pipelines processing ~200 row changes, this creates thousands of short-lived objects per push cycle, increasing GC pressure and pause time.

Similarly, `generateWithOverlayInner` creates `{row, relationships: {}}` node objects for every row during fetch, adding more allocation overhead on the fetch hot path.

## Changes
* Add `EMPTY_RELATIONSHIPS` frozen sentinel at module scope, replacing per-node `{}` allocation in `generateWithOverlayInner` (3 sites) and `genPush` (via reuse objects)
* Pre-allocate reusable `Change` objects in `genPush` (`reuseNode`, `reuseOldNode`, `reuseAddRemove`, `reuseEdit`) and mutate `row` fields before yielding, instead of creating new objects per connection per push

## Safety
Object reuse in `genPush` is safe because `filterPush` consumers are synchronous within the generator chain. Each `yield* filterPush(...)` completes fully before the next loop iteration mutates the reused objects. There is no concurrent access.

## Expected Performance Impact
For 135 IVM pipelines each processing ~200 rows, this eliminates thousands of short-lived `{}` and `Change` object allocations per push cycle. The frozen sentinel also enables V8 to share the same hidden class across all nodes, improving inline cache hit rates for downstream consumers that read `node.relationships`.

## Testing
* All 56 existing memory-source tests pass
* All 154 existing source tests pass
---
## Stack Order
This PR is part of a stacked series of IVM performance optimizations. Merge in order:
1. **#5609** (this PR) - Allocation reduction
2. #5610 - Index caching
3. #5611 - Comparator fast paths
4. #5612 - Fetch pipeline fusion

Independent PRs (no conflicts): #5607 (BTree iterators), #5608 (Join optimizations)
