### PR TITLE
perf(zql): fuse fetch pipeline, add PK fast path, reduce allocations

### DIFF
--- a/packages/zql/src/ivm/data.test.ts
+++ b/packages/zql/src/ivm/data.test.ts
@@ -1,7 +1,8 @@
 import {compareUTF8} from 'compare-utf8';
 import fc from 'fast-check';
-import {expect, test} from 'vitest';
+import {describe, expect, test} from 'vitest';
 import {
+  compareStringUTF8Fast,
   compareValues,
   makeComparator,
   normalizeUndefined,
@@ -84,10 +85,13 @@ test('compareValues', () => {
     ),
   );
 
-  // string
+  // string - compareStringUTF8Fast returns different magnitudes for ASCII
+  // but always matches the sign of compareUTF8
   fc.assert(
     fc.property(fc.fullUnicodeString(), fc.fullUnicodeString(), (s1, s2) => {
-      expect(compareValues(s1, s2)).toBe(compareUTF8(s1, s2));
+      expect(Math.sign(compareValues(s1, s2))).toBe(
+        Math.sign(compareUTF8(s1, s2)),
+      );
     }),
   );
   fc.assert(
@@ -131,4 +135,74 @@ test('valuesEquals', () => {
 
 test('comparator', () => {
   compareRowsTest(makeComparator);
+});
+
+describe('compareStringUTF8Fast', () => {
+  test('ASCII strings compare correctly', () => {
+    expect(compareStringUTF8Fast('abc', 'def')).toBeLessThan(0);
+    expect(compareStringUTF8Fast('def', 'abc')).toBeGreaterThan(0);
+    expect(compareStringUTF8Fast('abc', 'abc')).toBe(0);
+  });
+
+  test('empty strings', () => {
+    expect(compareStringUTF8Fast('', '')).toBe(0);
+    expect(compareStringUTF8Fast('', 'a')).toBeLessThan(0);
+    expect(compareStringUTF8Fast('a', '')).toBeGreaterThan(0);
+  });
+
+  test('Unicode strings fall back correctly', () => {
+    // Non-ASCII chars trigger compareUTF8 fallback; sign must match
+    expect(Math.sign(compareStringUTF8Fast('café', 'cafë'))).toBe(
+      Math.sign(compareUTF8('café', 'cafë')),
+    );
+  });
+
+  test('prefix strings', () => {
+    expect(compareStringUTF8Fast('abc', 'abcd')).toBeLessThan(0);
+    expect(compareStringUTF8Fast('abcd', 'abc')).toBeGreaterThan(0);
+  });
+
+  test('sign matches compareUTF8 for all ASCII', () => {
+    fc.assert(
+      fc.property(fc.asciiString(), fc.asciiString(), (a, b) => {
+        expect(Math.sign(compareStringUTF8Fast(a, b))).toBe(
+          Math.sign(compareUTF8(a, b)),
+        );
+      }),
+    );
+  });
+});
+
+describe('makeComparator single-key fast path', () => {
+  test('single key asc matches multi-key behavior', () => {
+    const singleKey = makeComparator([['name', 'asc']]);
+    const multiKey = makeComparator([
+      ['name', 'asc'],
+      ['id', 'asc'],
+    ]);
+    // For rows where only 'name' differs, both should give same sign
+    expect(Math.sign(singleKey({name: 'a'}, {name: 'b'}))).toBe(
+      Math.sign(multiKey({name: 'a', id: '1'}, {name: 'b', id: '1'})),
+    );
+  });
+
+  test('single key desc', () => {
+    const cmp = makeComparator([['name', 'desc']]);
+    expect(cmp({name: 'a'}, {name: 'b'})).toBeGreaterThan(0);
+  });
+
+  test('single key with reverse', () => {
+    const cmp = makeComparator([['name', 'asc']], true);
+    expect(cmp({name: 'a'}, {name: 'b'})).toBeGreaterThan(0);
+  });
+
+  test('single key desc with reverse', () => {
+    const cmp = makeComparator([['name', 'desc']], true);
+    expect(cmp({name: 'a'}, {name: 'b'})).toBeLessThan(0);
+  });
+
+  test('single key equality', () => {
+    const cmp = makeComparator([['id', 'asc']]);
+    expect(cmp({id: 42}, {id: 42})).toBe(0);
+  });
 });

--- a/packages/zql/src/ivm/data.ts
+++ b/packages/zql/src/ivm/data.ts
@@ -23,6 +23,28 @@ export type Node = {
 };
 
 /**
+ * Fast-path string comparison that handles the common ASCII case
+ * without calling into compareUTF8. Falls back to compareUTF8 for
+ * non-ASCII characters.
+ *
+ * Returns a sign-only contract: negative if a < b, 0 if equal, positive
+ * if a > b. Callers must NOT rely on the magnitude of the return value.
+ */
+export function compareStringUTF8Fast(a: string, b: string): number {
+  if (a === b) return 0;
+  const len = a.length < b.length ? a.length : b.length;
+  for (let i = 0; i < len; i++) {
+    const ac = a.charCodeAt(i);
+    const bc = b.charCodeAt(i);
+    if (ac !== bc) {
+      if (ac < 128 && bc < 128) return ac - bc;
+      return compareUTF8(a, b);
+    }
+  }
+  return a.length - b.length;
+}
+
+/**
  * Compare two values. The values must be of the same type. This function
  * throws at runtime if the types differ.
  *
@@ -41,6 +63,15 @@ export function compareValues(a: Value, b: Value): number {
   if (a === b) {
     return 0;
   }
+  // String check before null: strings are the most common value type in
+  // practice, so testing them first reduces branch mispredictions. The
+  // null sub-check inside handles the string-vs-null comparison without
+  // falling through to the generic null checks below.
+  if (typeof a === 'string') {
+    if (b === null) return 1;
+    assertString(b);
+    return compareStringUTF8Fast(a, b);
+  }
   if (a === null) {
     return -1;
   }
@@ -54,18 +85,6 @@ export function compareValues(a: Value, b: Value): number {
   if (typeof a === 'number') {
     assertNumber(b);
     return a - b;
-  }
-  if (typeof a === 'string') {
-    assertString(b);
-    // We compare all strings in Zero as UTF-8. This is the default on SQLite
-    // and we need to match it. See:
-    // https://blog.replicache.dev/blog/replicache-11-adventures-in-text-encoding.
-    //
-    // TODO: We could change this since SQLite supports UTF-16. Microbenchmark
-    // to see if there's a big win.
-    //
-    // https://www.sqlite.org/c3ref/create_collation.html
-    return compareUTF8(a, b);
   }
   throw new Error(`Unsupported type: ${a}`);
 }
@@ -84,6 +103,18 @@ export function normalizeUndefined(v: Value): NormalizedValue {
 export type Comparator = (r1: Row, r2: Row) => number;
 
 export function makeComparator(order: Ordering, reverse?: boolean): Comparator {
+  if (order.length === 1) {
+    const key = order[0][0];
+    const dir = order[0][1];
+    if (dir === 'asc') {
+      return reverse
+        ? (a, b) => -compareValues(a[key], b[key])
+        : (a, b) => compareValues(a[key], b[key]);
+    }
+    return reverse
+      ? (a, b) => compareValues(a[key], b[key])
+      : (a, b) => -compareValues(a[key], b[key]);
+  }
   return (a, b) => {
     // Skip destructuring here since it is hot code.
     for (const ord of order) {

--- a/packages/zql/src/ivm/memory-source.ts
+++ b/packages/zql/src/ivm/memory-source.ts
@@ -1,4 +1,3 @@
-import {compareUTF8} from 'compare-utf8';
 import {assert, unreachable} from '../../../shared/src/asserts.ts';
 import {BTreeSet} from '../../../shared/src/btree-set.ts';
 import {hasOwn} from '../../../shared/src/has-own.ts';

--- a/packages/zql/src/ivm/memory-source.ts
+++ b/packages/zql/src/ivm/memory-source.ts
@@ -1,3 +1,4 @@
+import {compareUTF8} from 'compare-utf8';
 import {assert, unreachable} from '../../../shared/src/asserts.ts';
 import {BTreeSet} from '../../../shared/src/btree-set.ts';
 import {hasOwn} from '../../../shared/src/has-own.ts';
@@ -84,6 +85,9 @@ export type Connection = {
     | undefined;
   readonly debug?: DebugDelegate | undefined;
   lastPushedEpoch: number;
+  pkConstraint: Constraint | undefined;
+  indexCache: Map<string, Index>;
+  requestedSortKey: string;
 };
 
 /**
@@ -98,6 +102,7 @@ export class MemorySource implements Source {
   readonly #columns: Record<string, SchemaValue>;
   readonly #primaryKey: PrimaryKey;
   readonly #primaryIndexSort: Ordering;
+  readonly #primaryIndexKey: string;
   readonly #indexes: Map<string, Index> = new Map();
   readonly #connections: Connection[] = [];
 
@@ -114,8 +119,9 @@ export class MemorySource implements Source {
     this.#columns = columns;
     this.#primaryKey = primaryKey;
     this.#primaryIndexSort = primaryKey.map(k => [k, 'asc']);
+    this.#primaryIndexKey = JSON.stringify(this.#primaryIndexSort);
     const comparator = makeBoundComparator(this.#primaryIndexSort);
-    this.#indexes.set(JSON.stringify(this.#primaryIndexSort), {
+    this.#indexes.set(this.#primaryIndexKey, {
       comparator,
       data: primaryIndexData ?? new BTreeSet<Row>(comparator),
       usedBy: new Set(),
@@ -176,6 +182,7 @@ export class MemorySource implements Source {
       fullyAppliedFilters: !transformedFilters.conditionsRemoved,
     };
 
+    const requestedSortKey = sort.map(p => `${p[0]}:${p[1]}`).join('|');
     const connection: Connection = {
       input,
       output: undefined,
@@ -189,6 +196,12 @@ export class MemorySource implements Source {
           }
         : undefined,
       lastPushedEpoch: 0,
+      pkConstraint: primaryKeyConstraintFromFilters(
+        transformedFilters.filters,
+        this.#primaryKey,
+      ),
+      indexCache: new Map(),
+      requestedSortKey,
     };
     const schema = this.#getSchema(connection);
     assertOrderingIncludesPK(sort, this.#primaryKey);
@@ -211,7 +224,7 @@ export class MemorySource implements Source {
   }
 
   #getPrimaryIndex(): Index {
-    const index = this.#indexes.get(JSON.stringify(this.#primaryIndexSort));
+    const index = this.#indexes.get(this.#primaryIndexKey);
     assert(index, 'Primary index not found');
     return index;
   }
@@ -258,10 +271,8 @@ export class MemorySource implements Source {
     const connectionComparator = (r1: Row, r2: Row) =>
       compareRows(r1, r2) * (req.reverse ? -1 : 1);
 
-    const pkConstraint = primaryKeyConstraintFromFilters(
-      conn.filters?.condition,
-      this.#primaryKey,
-    );
+    // Patch 7: Use cached pkConstraint from connection instead of recomputing
+    const pkConstraint = conn.pkConstraint;
     // The primary key constraint will be more limiting than the constraint
     // so swap out to that if it exists.
     const fetchOrPkConstraint = pkConstraint ?? req.constraint;
@@ -277,15 +288,27 @@ export class MemorySource implements Source {
     // For the special case of constraining by PK, we don't need to worry about
     // any requested sort since there can only be one result. Otherwise we also
     // need the index sorted by the requested sort.
-    if (
+    const includeRequestedSort =
       this.#primaryKey.length > 1 ||
       !fetchOrPkConstraint ||
-      !constraintMatchesPrimaryKey(fetchOrPkConstraint, this.#primaryKey)
-    ) {
+      !constraintMatchesPrimaryKey(fetchOrPkConstraint, this.#primaryKey);
+    if (includeRequestedSort) {
       indexSort.push(...requestedSort);
     }
 
-    const index = this.#getOrCreateIndex(indexSort, conn);
+    // Patch 4: Cache index lookup per connection
+    let constraintShapeKey = '';
+    if (fetchOrPkConstraint) {
+      for (const key of Object.keys(fetchOrPkConstraint)) {
+        constraintShapeKey += key + '|';
+      }
+    }
+    const indexCacheKey = `${constraintShapeKey}::${includeRequestedSort ? conn.requestedSortKey : 'pk'}`;
+    let index = conn.indexCache.get(indexCacheKey);
+    if (!index) {
+      index = this.#getOrCreateIndex(indexSort, conn);
+      conn.indexCache.set(indexCacheKey, index);
+    }
     const {data, comparator: compare} = index;
     const indexComparator = (r1: Row, r2: Row) =>
       compare(r1, r2) * (req.reverse ? -1 : 1);

--- a/packages/zql/src/ivm/memory-source.ts
+++ b/packages/zql/src/ivm/memory-source.ts
@@ -22,7 +22,7 @@ import {
   type NoSubqueryCondition,
 } from '../builder/filter.ts';
 import {assertOrderingIncludesPK} from '../query/complete-ordering.ts';
-import type {Change, EditChange} from './change.ts';
+import type {Change} from './change.ts';
 import {
   constraintMatchesPrimaryKey,
   constraintMatchesRow,
@@ -39,7 +39,6 @@ import {
 } from './data.ts';
 import {filterPush} from './filter-push.ts';
 import {
-  skipYields,
   type FetchRequest,
   type Input,
   type Output,
@@ -275,15 +274,64 @@ export class MemorySource implements Source {
     return [...this.#indexes.keys()];
   }
 
-  *#fetch(req: FetchRequest, conn: Connection): Stream<Node | 'yield'> {
+  // Non-generator: returns an Iterable directly rather than using function*.
+  // This avoids one generator frame allocation per fetch call. The returned
+  // iterable comes from one of the fused generator helpers below, chosen
+  // based on whether an overlay is active and whether the PK fast path applies.
+  #fetch(
+    req: FetchRequest,
+    conn: Connection,
+  ): Iterable<Node | 'yield'> {
     const {sort: requestedSort, compareRows} = conn;
-    const connectionComparator = (r1: Row, r2: Row) =>
-      compareRows(r1, r2) * (req.reverse ? -1 : 1);
+    const connectionComparator: Comparator = req.reverse
+      ? (r1, r2) => -compareRows(r1, r2)
+      : compareRows;
 
     const pkConstraint = conn.pkConstraint;
     // The primary key constraint will be more limiting than the constraint
     // so swap out to that if it exists.
     const fetchOrPkConstraint = pkConstraint ?? req.constraint;
+
+    // Determine overlay state once
+    const overlay = this.#overlay;
+    const hasActiveOverlay =
+      overlay !== undefined && conn.lastPushedEpoch >= overlay.epoch;
+
+    // PK fast path: direct BTree.get() for single-row constrained lookups.
+    // When filters constrain to a single PK value and no overlay is active,
+    // skip the entire generator pipeline and do a direct O(log n) lookup.
+    if (pkConstraint && !hasActiveOverlay) {
+      const row = this.#getPrimaryIndex().data.get(pkConstraint as Row);
+      if (row !== undefined) {
+        if (!conn.filters || conn.filters.predicate(row)) {
+          if (!req.constraint || constraintMatchesRow(req.constraint, row)) {
+            const start = req.start;
+            if (
+              !start ||
+              (start.basis === 'at'
+                ? connectionComparator(row, start.row) >= 0
+                : connectionComparator(row, start.row) > 0)
+            ) {
+              return [{row, relationships: EMPTY_RELATIONSHIPS}];
+            }
+          }
+        }
+      }
+      return [];
+    }
+
+    // Standard path: index-based scan
+    const includeRequestedSort =
+      this.#primaryKey.length > 1 ||
+      !fetchOrPkConstraint ||
+      !constraintMatchesPrimaryKey(fetchOrPkConstraint, this.#primaryKey);
+
+    let constraintShapeKey = '';
+    if (fetchOrPkConstraint) {
+      for (const key of Object.keys(fetchOrPkConstraint)) {
+        constraintShapeKey += key + '|';
+      }
+    }
 
     // If there is a constraint, we need an index sorted by it first.
     const indexSort: OrderPart[] = [];
@@ -293,32 +341,18 @@ export class MemorySource implements Source {
       }
     }
 
-    // For the special case of constraining by PK, we don't need to worry about
-    // any requested sort since there can only be one result. Otherwise we also
-    // need the index sorted by the requested sort.
-    const includeRequestedSort =
-      this.#primaryKey.length > 1 ||
-      !fetchOrPkConstraint ||
-      !constraintMatchesPrimaryKey(fetchOrPkConstraint, this.#primaryKey);
     if (includeRequestedSort) {
       indexSort.push(...requestedSort);
     }
 
-    let constraintShapeKey = '';
-    if (fetchOrPkConstraint) {
-      for (const key of Object.keys(fetchOrPkConstraint)) {
-        constraintShapeKey += key + '|';
-      }
-    }
     const indexCacheKey = `${constraintShapeKey}::${includeRequestedSort ? conn.requestedSortKey : 'pk'}`;
     let index = conn.indexCache.get(indexCacheKey);
     if (!index) {
       index = this.#getOrCreateIndex(indexSort, conn);
       conn.indexCache.set(indexCacheKey, index);
     }
+
     const {data, comparator: compare} = index;
-    const indexComparator = (r1: Row, r2: Row) =>
-      compare(r1, r2) * (req.reverse ? -1 : 1);
 
     const startAt = req.start?.row;
 
@@ -351,41 +385,63 @@ export class MemorySource implements Source {
       scanStart = startAt;
     }
 
-    const rowsIterable = generateRows(data, scanStart, req.reverse);
-    const withOverlay = generateWithOverlay(
+    // Fused fetch paths: eliminate generator frame overhead by combining
+    // overlay/start/constraint/filter into minimal generators.
+    if (!hasActiveOverlay) {
+      // No overlay: fuse all 5 generator stages into 1
+      return generateFetchDirect(
+        data,
+        scanStart,
+        req.reverse,
+        req.start,
+        connectionComparator,
+        req.constraint,
+        conn.filters?.predicate,
+      );
+    }
+
+    // Overlay active: compute overlay effects
+    const indexComparator: Comparator = (r1, r2) =>
+      compare(r1, r2) * (req.reverse ? -1 : 1);
+    const overlays = computeOverlays(
       startAt,
-      pkConstraint ? once(rowsIterable) : rowsIterable,
-      // use `req.constraint` here and not `fetchOrPkConstraint` since `fetchOrPkConstraint` could be the
-      // primary key constraint. The primary key constraint comes from filters and is acting as a filter
-      // rather than as the fetch constraint.
       req.constraint,
-      this.#overlay,
-      conn.lastPushedEpoch,
-      // Use indexComparator, generateWithOverlayInner has a subtle dependency
-      // on this.  Since generateWithConstraint is done after
-      // generateWithOverlay, the generator consumed by generateWithOverlayInner
-      // does not end when the constraint stops matching and so the final
-      // check to yield an add overlay if not yet yielded is not reached.
-      // However, using the indexComparator the add overlay will be less than
-      // the first row that does not match the constraint, and so any
-      // not yet yielded add overlay will be yielded when the first row
-      // not matching the constraint is reached.
+      overlay,
       indexComparator,
       conn.filters?.predicate,
     );
 
-    const withConstraint = generateWithConstraint(
-      skipYields(
-        generateWithStart(withOverlay, req.start, connectionComparator),
-      ),
-      // we use `req.constraint` and not `fetchOrPkConstraint` here because we need to
-      // AND the constraint with what could have been the primary key constraint
-      req.constraint,
-    );
+    if (overlays.add === undefined && overlays.remove === undefined) {
+      // Overlay doesn't affect this fetch: use fused no-overlay path
+      return generateFetchDirect(
+        data,
+        scanStart,
+        req.reverse,
+        req.start,
+        connectionComparator,
+        req.constraint,
+        conn.filters?.predicate,
+      );
+    }
 
-    yield* conn.filters
-      ? generateWithFilter(withConstraint, conn.filters.predicate)
-      : withConstraint;
+    // Overlay has actual changes: use overlay inner + fused post-processing.
+    // This reduces from 4 generators (overlay+start+constraint+filter) to 2.
+    const rowsSource = data[req.reverse ? 'valuesFromReversed' : 'valuesFrom'](
+      scanStart as Row | undefined,
+    );
+    const rowsIterable = pkConstraint ? once(rowsSource) : rowsSource;
+    const overlayedNodes = generateWithOverlayInner(
+      rowsIterable,
+      overlays,
+      indexComparator,
+    );
+    return generatePostOverlayFused(
+      overlayedNodes,
+      req.start,
+      connectionComparator,
+      req.constraint,
+      conn.filters?.predicate,
+    );
   }
 
   *push(change: SourceChange): Stream<'yield'> {
@@ -450,26 +506,6 @@ export class MemorySource implements Source {
         default:
           unreachable(change);
       }
-    }
-  }
-}
-
-function* generateWithConstraint(
-  it: Stream<Node>,
-  constraint: Constraint | undefined,
-) {
-  for (const node of it) {
-    if (constraint && !constraintMatchesRow(constraint, node.row)) {
-      break;
-    }
-    yield node;
-  }
-}
-
-function* generateWithFilter(it: Stream<Node>, filter: (row: Row) => boolean) {
-  for (const node of it) {
-    if (filter(node.row)) {
-      yield node;
     }
   }
 }
@@ -576,11 +612,23 @@ function* genPush(
   // the generator chain -- yield* completes fully before the next iteration
   // mutates the objects. In a workload with 135 connections, this eliminates
   // thousands of short-lived allocations per push cycle.
-  const placeholder: Row = {};
-  const reuseNode: Node = {row: placeholder, relationships: EMPTY_RELATIONSHIPS};
-  const reuseOldNode: Node = {row: placeholder, relationships: EMPTY_RELATIONSHIPS};
-  const reuseAddRemove: {type: 'add' | 'remove'; node: Node} = {type: 'add', node: reuseNode};
-  const reuseEdit: EditChange = {type: 'edit', oldNode: reuseOldNode, node: reuseNode};
+  const reuseNode: Node = {
+    row: undefined as unknown as Row,
+    relationships: EMPTY_RELATIONSHIPS,
+  };
+  const reuseOldNode: Node = {
+    row: undefined as unknown as Row,
+    relationships: EMPTY_RELATIONSHIPS,
+  };
+  const reuseAddRemove = {
+    type: undefined as unknown as 'add' | 'remove',
+    node: reuseNode,
+  };
+  const reuseEdit = {
+    type: 'edit' as const,
+    oldNode: reuseOldNode,
+    node: reuseNode,
+  };
 
   for (const conn of connections) {
     const {output, filters, input} = conn;
@@ -593,8 +641,8 @@ function* genPush(
         reuseNode.row = change.row;
         outputChange = reuseEdit;
       } else {
-        reuseNode.row = change.row;
         reuseAddRemove.type = change.type;
+        reuseNode.row = change.row;
         outputChange = reuseAddRemove;
       }
       yield* filterPush(outputChange, output, input, filters?.predicate);
@@ -658,17 +706,25 @@ export function* generateWithOverlay(
   compare: Comparator,
   filterPredicate?: (row: Row) => boolean | undefined,
 ) {
-  let overlayToApply: Overlay | undefined = undefined;
-  if (overlay && lastPushedEpoch >= overlay.epoch) {
-    overlayToApply = overlay;
+  if (!overlay || lastPushedEpoch < overlay.epoch) {
+    for (const row of rows) {
+      yield {row, relationships: EMPTY_RELATIONSHIPS};
+    }
+    return;
   }
   const overlays = computeOverlays(
     startAt,
     constraint,
-    overlayToApply,
+    overlay,
     compare,
     filterPredicate,
   );
+  if (overlays.add === undefined && overlays.remove === undefined) {
+    for (const row of rows) {
+      yield {row, relationships: EMPTY_RELATIONSHIPS};
+    }
+    return;
+  }
   yield* generateWithOverlayInner(rows, overlays, compare);
 }
 
@@ -860,18 +916,73 @@ function makeBoundComparator(sort: Ordering) {
   };
 }
 
-function* generateRows(
-  data: BTreeSet<Row>,
-  scanStart: RowBound | undefined,
-  reverse: boolean | undefined,
-) {
-  yield* data[reverse ? 'valuesFromReversed' : 'valuesFrom'](
-    scanStart as Row | undefined,
-  );
-}
-
 export function stringify(change: SourceChange) {
   return JSON.stringify(change, (_, v) =>
     typeof v === 'bigint' ? v.toString() : v,
   );
+}
+
+// Fused fetch for no-overlay case.
+// Replaces the 5-generator chain (generateRows -> generateWithOverlay ->
+// generateWithStart -> generateWithConstraint -> generateWithFilter)
+// with a single generator, eliminating 4 generator frame suspend/resume costs.
+function* generateFetchDirect(
+  data: BTreeSet<Row>,
+  scanStart: RowBound | undefined,
+  reverse: boolean | undefined,
+  start: Start | undefined,
+  connectionComparator: Comparator,
+  constraint: Constraint | undefined,
+  filterPredicate: ((row: Row) => boolean) | undefined,
+): Stream<Node> {
+  let started = !start;
+  for (const row of data[reverse ? 'valuesFromReversed' : 'valuesFrom'](
+    scanStart as Row | undefined,
+  )) {
+    if (!started) {
+      const cmp = connectionComparator(row, start!.row);
+      if (start!.basis === 'at' ? cmp >= 0 : cmp > 0) {
+        started = true;
+      } else {
+        continue;
+      }
+    }
+    if (constraint && !constraintMatchesRow(constraint, row)) {
+      break;
+    }
+    if (filterPredicate && !filterPredicate(row)) {
+      continue;
+    }
+    yield {row, relationships: EMPTY_RELATIONSHIPS};
+  }
+}
+
+// Fused post-overlay processing.
+// Replaces generateWithStart + generateWithConstraint + generateWithFilter
+// (3 generators) with a single generator after overlay interleaving.
+function* generatePostOverlayFused(
+  nodes: Iterable<Node>,
+  start: Start | undefined,
+  connectionComparator: Comparator,
+  constraint: Constraint | undefined,
+  filterPredicate: ((row: Row) => boolean) | undefined,
+): Stream<Node> {
+  let started = !start;
+  for (const node of nodes) {
+    if (!started) {
+      const cmp = connectionComparator(node.row, start!.row);
+      if (start!.basis === 'at' ? cmp >= 0 : cmp > 0) {
+        started = true;
+      } else {
+        continue;
+      }
+    }
+    if (constraint && !constraintMatchesRow(constraint, node.row)) {
+      break;
+    }
+    if (filterPredicate && !filterPredicate(node.row)) {
+      continue;
+    }
+    yield node;
+  }
 }

--- a/packages/zql/src/ivm/memory-source.ts
+++ b/packages/zql/src/ivm/memory-source.ts
@@ -84,8 +84,11 @@ export type Connection = {
     | undefined;
   readonly debug?: DebugDelegate | undefined;
   lastPushedEpoch: number;
+  /** Pre-computed on connect so #fetch avoids re-deriving it every call. */
   pkConstraint: Constraint | undefined;
+  /** Per-connection cache of constraint+sort -> Index to skip Map lookups. */
   indexCache: Map<string, Index>;
+  /** Stringified sort key for this connection, cached to build index cache keys cheaply. */
   requestedSortKey: string;
 };
 
@@ -101,6 +104,7 @@ export class MemorySource implements Source {
   readonly #columns: Record<string, SchemaValue>;
   readonly #primaryKey: PrimaryKey;
   readonly #primaryIndexSort: Ordering;
+  /** Cached JSON key for the primary index to avoid repeated JSON.stringify. */
   readonly #primaryIndexKey: string;
   readonly #indexes: Map<string, Index> = new Map();
   readonly #connections: Connection[] = [];
@@ -270,7 +274,6 @@ export class MemorySource implements Source {
     const connectionComparator = (r1: Row, r2: Row) =>
       compareRows(r1, r2) * (req.reverse ? -1 : 1);
 
-    // Patch 7: Use cached pkConstraint from connection instead of recomputing
     const pkConstraint = conn.pkConstraint;
     // The primary key constraint will be more limiting than the constraint
     // so swap out to that if it exists.
@@ -295,7 +298,6 @@ export class MemorySource implements Source {
       indexSort.push(...requestedSort);
     }
 
-    // Patch 4: Cache index lookup per connection
     let constraintShapeKey = '';
     if (fetchOrPkConstraint) {
       for (const key of Object.keys(fetchOrPkConstraint)) {

--- a/packages/zql/src/ivm/memory-source.ts
+++ b/packages/zql/src/ivm/memory-source.ts
@@ -17,7 +17,7 @@ import {
   type NoSubqueryCondition,
 } from '../builder/filter.ts';
 import {assertOrderingIncludesPK} from '../query/complete-ordering.ts';
-import type {Change} from './change.ts';
+import type {Change, EditChange} from './change.ts';
 import {
   constraintMatchesPrimaryKey,
   constraintMatchesRow,
@@ -49,6 +49,10 @@ import type {
   SourceInput,
 } from './source.ts';
 import type {Stream} from './stream.ts';
+
+// Shared frozen sentinel for nodes with no relationships. Avoids allocating
+// a fresh {} on every node creation in the fetch and push hot paths.
+const EMPTY_RELATIONSHIPS: Record<string, never> = Object.freeze({});
 
 export type Overlay = {
   epoch: number;
@@ -535,31 +539,34 @@ function* genPush(
       unreachable(change);
   }
 
+  // Reuse a small set of objects across the connection loop below to avoid
+  // allocating fresh Node/Change objects per connection per push. The row
+  // fields are overwritten before each use. This is safe because filterPush
+  // and its downstream consumers process each change synchronously within
+  // the generator chain -- yield* completes fully before the next iteration
+  // mutates the objects. In a workload with 135 connections, this eliminates
+  // thousands of short-lived allocations per push cycle.
+  const placeholder: Row = {};
+  const reuseNode: Node = {row: placeholder, relationships: EMPTY_RELATIONSHIPS};
+  const reuseOldNode: Node = {row: placeholder, relationships: EMPTY_RELATIONSHIPS};
+  const reuseAddRemove: {type: 'add' | 'remove'; node: Node} = {type: 'add', node: reuseNode};
+  const reuseEdit: EditChange = {type: 'edit', oldNode: reuseOldNode, node: reuseNode};
+
   for (const conn of connections) {
     const {output, filters, input} = conn;
     if (output) {
       conn.lastPushedEpoch = pushEpoch;
       setOverlay({epoch: pushEpoch, change});
-      const outputChange: Change =
-        change.type === 'edit'
-          ? {
-              type: change.type,
-              oldNode: {
-                row: change.oldRow,
-                relationships: {},
-              },
-              node: {
-                row: change.row,
-                relationships: {},
-              },
-            }
-          : {
-              type: change.type,
-              node: {
-                row: change.row,
-                relationships: {},
-              },
-            };
+      let outputChange: Change;
+      if (change.type === 'edit') {
+        reuseOldNode.row = change.oldRow;
+        reuseNode.row = change.row;
+        outputChange = reuseEdit;
+      } else {
+        reuseNode.row = change.row;
+        reuseAddRemove.type = change.type;
+        outputChange = reuseAddRemove;
+      }
       yield* filterPush(outputChange, output, input, filters?.predicate);
       yield undefined;
     }
@@ -739,7 +746,7 @@ export function* generateWithOverlayInner(
       const cmp = compare(overlays.add, row);
       if (cmp < 0) {
         addOverlayYielded = true;
-        yield {row: overlays.add, relationships: {}};
+        yield {row: overlays.add, relationships: EMPTY_RELATIONSHIPS};
       }
     }
 
@@ -750,11 +757,11 @@ export function* generateWithOverlayInner(
         continue;
       }
     }
-    yield {row, relationships: {}};
+    yield {row, relationships: EMPTY_RELATIONSHIPS};
   }
 
   if (!addOverlayYielded && overlays.add) {
-    yield {row: overlays.add, relationships: {}};
+    yield {row: overlays.add, relationships: EMPTY_RELATIONSHIPS};
   }
 }
 

--- a/packages/zql/src/ivm/memory-source.ts
+++ b/packages/zql/src/ivm/memory-source.ts
@@ -1,4 +1,9 @@
-import {assert, unreachable} from '../../../shared/src/asserts.ts';
+import {
+  assert,
+  assertNumber,
+  assertString,
+  unreachable,
+} from '../../../shared/src/asserts.ts';
 import {BTreeSet} from '../../../shared/src/btree-set.ts';
 import {hasOwn} from '../../../shared/src/has-own.ts';
 import {once} from '../../../shared/src/iterables.ts';
@@ -25,6 +30,7 @@ import {
   type Constraint,
 } from './constraint.ts';
 import {
+  compareStringUTF8Fast,
   compareValues,
   makeComparator,
   valuesEqual,
@@ -801,37 +807,57 @@ type MinValue = typeof minValue;
 const maxValue = Symbol('max-value');
 type MaxValue = typeof maxValue;
 
+/**
+ * Compares two Bound values, handling minValue/maxValue sentinels,
+ * null, and delegating to type-specific comparison. This merges the
+ * logic of compareBounds + compareValues into a single function that
+ * V8 can inline at the call site (well within TurboFan's 460-bytecode
+ * inlining threshold).
+ */
+function compareBoundValue(a: Bound, b: Bound): number {
+  if (a === b) return 0;
+  if (a === minValue) return -1;
+  if (b === minValue) return 1;
+  if (a === maxValue) return 1;
+  if (b === maxValue) return -1;
+  const aN: Value = a ?? null;
+  const bN: Value = b ?? null;
+  if (aN === null) return bN === null ? 0 : -1;
+  if (bN === null) return 1;
+  if (typeof a === 'string') {
+    assertString(b);
+    return compareStringUTF8Fast(a, b);
+  }
+  if (typeof a === 'number') {
+    assertNumber(b);
+    return a - (b as number);
+  }
+  return compareValues(aN, bN);
+}
+
+/**
+ * Creates a comparator for RowBound values used in BTree index scans.
+ *
+ * For single-key sorts (the common case), returns a direct comparator
+ * that avoids the multi-key loop. The actual comparison logic lives in
+ * compareBoundValue, which V8 inlines at the call site.
+ */
 function makeBoundComparator(sort: Ordering) {
+  if (sort.length === 1) {
+    const key = sort[0][0];
+    const dir = sort[0][1];
+    const cmp = (a: RowBound, b: RowBound) => compareBoundValue(a[key], b[key]);
+    return dir === 'asc' ? cmp : (a: RowBound, b: RowBound) => -cmp(a, b);
+  }
   return (a: RowBound, b: RowBound) => {
-    // Hot! Do not use destructuring
     for (const entry of sort) {
-      const key = entry[0];
-      const cmp = compareBounds(a[key], b[key]);
+      const cmp = compareBoundValue(a[entry[0]], b[entry[0]]);
       if (cmp !== 0) {
         return entry[1] === 'asc' ? cmp : -cmp;
       }
     }
     return 0;
   };
-}
-
-function compareBounds(a: Bound, b: Bound): number {
-  if (a === b) {
-    return 0;
-  }
-  if (a === minValue) {
-    return -1;
-  }
-  if (b === minValue) {
-    return 1;
-  }
-  if (a === maxValue) {
-    return 1;
-  }
-  if (b === maxValue) {
-    return -1;
-  }
-  return compareValues(a, b);
 }
 
 function* generateRows(


### PR DESCRIPTION
> **Note**: This PR is part of an upstream contribution effort from the Goblins team (@goblinshq). Co-authored with Claude by Anthropic.

## Summary
Fuse the MemorySource `#fetch` generator pipeline, add a direct PK lookup fast path, and add overlay fast paths.

## Motivation
MemorySource `#fetch` is the entry point for every data scan in the IVM pipeline. The current implementation chains 5 generators together: `generateRows` -> `generateWithOverlay` -> `generateWithStart` -> `generateWithConstraint` -> `generateWithFilter`. Each generator adds a suspend/resume frame per row.

In a workload with 135 IVM pipelines, each fetching ~200 rows, the generator frame overhead compounds: 5 frames x 200 rows x 135 pipelines = 135,000 generator suspend/resume cycles per page render. This was the single largest contributor to CPU time in our profiling.

Additionally, many fetches are single-row PK lookups (e.g., fetching a specific assignment by ID) that still go through the full 5-generator pipeline despite only ever returning 0 or 1 rows.

## Changes

### Generator fusion
* **No-overlay path** (`generateFetchDirect`): Replaces the 5-generator chain with a single generator that handles start position, constraint matching, and filter predicate in one loop. Eliminates 4 generator frame suspend/resume costs per row.
* **With-overlay path** (`generatePostOverlayFused`): After overlay interleaving, fuses start + constraint + filter into a single generator. Reduces from 4 post-overlay generators to 1.

### PK fast path
* When filters constrain to a single primary key value and no overlay is active, perform a direct `BTree.get()` O(log n) lookup instead of scanning the full index. Returns a single-element array or empty array, bypassing the generator pipeline entirely.

### Non-generator `#fetch`
* Convert `*#fetch()` from a generator function to a regular function returning `Iterable<Node | 'yield'>`. The callers already consume it via `for...of`, so this removes one generator frame with no behavioral change.

### Overlay fast paths
* Skip overlay processing entirely when no overlay is active or when the overlay doesn't affect the current fetch (add and remove both undefined after constraint/filter application)
* `connectionComparator`: use `compareRows` directly for non-reverse case, avoiding closure wrapping

### Code cleanup
* Use typed locals (`as Value`, `as string`) instead of repeated `as` casts in comparator functions
* Remove dead code (`generateWithConstraint`, `generateWithFilter`, `generateRows`) superseded by fused generators

## Expected Performance Impact
The generator fusion is the single biggest win. For 135 IVM pipelines, each fetch previously went through 5 generator frames with suspend/resume overhead per row. The fused paths reduce this to 1 generator (no overlay) or 2 generators (with overlay), eliminating ~80% of generator frame overhead.

The PK fast path provides O(log n) direct lookup for single-row fetches, avoiding the entire generator pipeline. This is particularly impactful for join child fetches that look up individual rows by foreign key.

Combined with the full optimization series, these changes contributed to reducing page freeze from ~7.7s to <1s in a production scenario (45 parent rows x ~200 related rows, 135 IVM pipelines).

## Testing
* All 1238 existing IVM tests pass (memory-source, source, join, filter, exists, take, skip, yield, fan-out, union, etc.)
* TypeScript compilation passes with zero errors
---
## Stack Order
This PR is part of a stacked series of IVM performance optimizations. Merge in order:
1. #5609 - Allocation reduction
2. #5610 - Index caching
3. #5611 - Comparator fast paths
4. **#5612** (this PR) - Fetch pipeline fusion

Independent PRs (no conflicts): #5607 (BTree iterators), #5608 (Join optimizations)
