### PR TITLE
test: re-render identity preservation tests for ArrayView + React

### DIFF
--- a/packages/zero-react/src/rerender.test.tsx
+++ b/packages/zero-react/src/rerender.test.tsx
@@ -68,27 +68,31 @@ describe('Snapshot identity', () => {
   beforeEach(() => { vi.useFakeTimers(); });
   afterEach(() => { vi.useRealTimers(); });
 
+  //   getSnapshot()  -->  ref1
+  //   getSnapshot()  -->  ref1  (same, no data change)
+  //   listener([row])
+  //   getSnapshot()  -->  ref2  (new, data changed)
+  //   getSnapshot()  -->  ref2  (same, no further change)
   test('getSnapshot returns same reference without data changes, new reference after', () => {
     const viewStore = new ViewStore();
     const {view, zero, cleanup} = createView(viewStore, 'identity');
 
-    // Same ref before data
     expect(view.getSnapshot()).toBe(view.getSnapshot());
 
-    // Push data
     getListeners(zero).forEach(cb => cb([{id: '1'}], 'unknown'));
     const withData = view.getSnapshot();
 
-    // Same ref after data (no further changes)
     expect(view.getSnapshot()).toBe(withData);
 
-    // New ref after new data
     getListeners(zero).forEach(cb => cb([{id: '1'}, {id: '2'}], 'unknown'));
     expect(view.getSnapshot()).not.toBe(withData);
 
     cleanup();
   });
 
+  //   getSnapshot()  -->  [[], {type:'unknown'}]  (sentinel A)
+  //   listener([])
+  //   getSnapshot()  -->  [[], {type:'unknown'}]  (sentinel A, same ref)
   test('empty snapshots use sentinel objects (no spurious re-renders)', () => {
     const viewStore = new ViewStore();
     const {view, zero, cleanup} = createView(viewStore, 'sentinel');
@@ -97,10 +101,8 @@ describe('Snapshot identity', () => {
     getListeners(zero).forEach(cb => cb([], 'unknown'));
     const empty2 = view.getSnapshot();
 
-    // Same sentinel reference for repeated empty data
     expect(empty1).toBe(empty2);
 
-    // Singular empty sentinel
     const qSingular = newMockQuery('singular', true);
     const zeroSingular = newMockZero('client-singular');
     const singular = viewStore.getView(zeroSingular, qSingular, true, 'forever');
@@ -114,6 +116,11 @@ describe('Snapshot identity', () => {
     cleanupSingular();
   });
 
+  //   listener([row1, row2])  -->  snap1 = [row1, row2]
+  //   listener([row1, row2'])  -->  snap2 = [row1, row2']
+  //
+  //   snap2[0]:  same ref as row1 (unchanged)
+  //   snap2[1]:  row2' (new ref, changed)
   test('row identity preserved in snapshot: unchanged rows keep same reference', () => {
     const viewStore = new ViewStore();
     const {view, zero, cleanup} = createView(viewStore, 'row-identity');
@@ -123,7 +130,6 @@ describe('Snapshot identity', () => {
     const row2 = {id: '2', name: 'Bob'};
     listeners.forEach(cb => cb([row1, row2], 'unknown'));
 
-    // Update only row2, keep row1 as same object
     const row2Updated = {id: '2', name: 'Bob Updated'};
     listeners.forEach(cb => cb([row1, row2Updated], 'unknown'));
 
@@ -135,10 +141,14 @@ describe('Snapshot identity', () => {
   });
 });
 
-describe('No data flash (data→empty→data)', () => {
+describe('No data flash (data to empty to data)', () => {
   beforeEach(() => { vi.useFakeTimers(); });
   afterEach(() => { vi.useRealTimers(); });
 
+  //   listener([row1])         -->  snap = [row1]   (has data)
+  //   listener([row1, row2])   -->  snap = [row1, row2]
+  //
+  //   At no point should snap become [] between these two updates.
   test('snapshot never goes empty between data updates', () => {
     const viewStore = new ViewStore();
     const {view, zero, cleanup} = createView(viewStore, 'flash');
@@ -152,7 +162,6 @@ describe('No data flash (data→empty→data)', () => {
     listeners.forEach(cb => cb([{id: '1'}], 'unknown'));
     listeners.forEach(cb => cb([{id: '1'}, {id: '2'}], 'unknown'));
 
-    // After first data, no snapshot should ever be empty
     let hadData = false;
     for (const len of snapshots) {
       if ((len as number) > 0) hadData = true;
@@ -162,6 +171,10 @@ describe('No data flash (data→empty→data)', () => {
     cleanup();
   });
 
+  //   listener([row])  -->  snap = [row]
+  //   unsubscribe
+  //   ... 15ms (past 10ms cleanup timeout) ...
+  //   getSnapshot()  -->  snap = [row]  (stale data preserved, not empty)
   test('stale snapshot preserved after view destroy (no empty flash on remount)', () => {
     const viewStore = new ViewStore();
     const {view, zero, cleanup} = createView(viewStore, 'destroy-flash');
@@ -170,10 +183,34 @@ describe('No data flash (data→empty→data)', () => {
     expect((view.getSnapshot()[0] as unknown[]).length).toBe(1);
 
     cleanup();
-    vi.advanceTimersByTime(15); // past 10ms cleanup timeout
+    vi.advanceTimersByTime(15);
 
-    // Stale snapshot still has data, not empty
     expect((view.getSnapshot()[0] as unknown[]).length).toBe(1);
+  });
+
+  //   listener([row])   -->  snap = [row]
+  //   listener([])       -->  snap = []     (legitimate empty)
+  //   listener([row2])  -->  snap = [row2]
+  //
+  //   Verifies that transitioning through empty is visible (not masked)
+  //   when the server genuinely returns empty then non-empty.
+  test('legitimate empty transition is visible (not masked)', () => {
+    const viewStore = new ViewStore();
+    const {view, zero, cleanup} = createView(viewStore, 'legit-empty');
+    const listeners = getListeners(zero);
+
+    const lengths: number[] = [];
+    view.subscribeReactInternals(() => {
+      lengths.push((view.getSnapshot()[0] as unknown[]).length);
+    });
+
+    listeners.forEach(cb => cb([{id: '1'}], 'unknown'));
+    listeners.forEach(cb => cb([], 'complete'));
+    listeners.forEach(cb => cb([{id: '2'}], 'complete'));
+
+    expect(lengths).toEqual([1, 0, 1]);
+
+    cleanup();
   });
 });
 
@@ -195,6 +232,13 @@ describe('React.memo child render counting', () => {
     document.body.removeChild(element);
   });
 
+  //   Parent (useQuery)
+  //     |
+  //     +-- ChildRow(row1)  React.memo  <-- same ref, skip re-render
+  //     +-- ChildRow(row2)  React.memo  <-- new ref, re-renders
+  //
+  //   listener([row1, row2])    -->  both children render
+  //   listener([row1, row2'])   -->  only row2 child re-renders
   test('only the changed row child re-renders; unchanged rows skip', async () => {
     const viewStore = new ViewStore();
     const q = newMockQuery(`react-memo-${unique}`);
@@ -225,7 +269,6 @@ describe('React.memo child render counting', () => {
     root.render(<Parent />);
     await expect.poll(() => parentRenders.current).toBeGreaterThanOrEqual(1);
 
-    // Push initial data
     const row1 = {id: '1', name: 'Alice'};
     const row2 = {id: '2', name: 'Bob'};
     getListeners(zero).forEach(cb => cb([row1, row2], 'unknown'));
@@ -235,16 +278,12 @@ describe('React.memo child render counting', () => {
     const rendersAfterData = parentRenders.current;
     const child1After = childRenders['1'] ?? 0;
 
-    // Update only row2, keep row1 as same reference
     getListeners(zero).forEach(cb => cb([row1, {id: '2', name: 'Bob Updated'}], 'unknown'));
 
     await expect.poll(() => element.querySelector('[data-testid="row-2"]')?.textContent).toBe('Bob Updated');
 
-    // Parent re-renders (new snapshot tuple)
     expect(parentRenders.current).toBeGreaterThan(rendersAfterData);
-    // Unchanged row1 child does NOT re-render
     expect(childRenders['1']).toBe(child1After);
-    // Changed row2 child DOES re-render
     expect(childRenders['2']).toBeGreaterThan(1);
   });
 });

--- a/packages/zero-react/src/rerender.test.tsx
+++ b/packages/zero-react/src/rerender.test.tsx
@@ -1,0 +1,258 @@
+import React, {memo, useSyncExternalStore} from 'react';
+import {createRoot, type Root} from 'react-dom/client';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+import {queryInternalsTag, type QueryImpl} from './bindings.ts';
+import {ViewStore} from './use-query.tsx';
+import type {
+  ErroredQuery,
+  Query,
+  ResultType,
+  Schema,
+  Zero,
+} from './zero.ts';
+
+// ─── Test helpers ───────────────────────────────────────────────────────────
+
+function newMockQuery(query: string, singular = false): Query<string, Schema> {
+  return {
+    [queryInternalsTag]: true,
+    hash: () => query,
+    format: {singular},
+  } as unknown as QueryImpl<string, Schema>;
+}
+
+type MockView = {
+  listeners: Set<
+    (data: unknown, resultType: ResultType, error?: ErroredQuery) => void
+  >;
+  addListener(
+    cb: (data: unknown, resultType: ResultType, error?: ErroredQuery) => void,
+  ): () => void;
+  destroy(): void;
+  updateTTL(): void;
+};
+
+function newView(): MockView {
+  return {
+    listeners: new Set(),
+    addListener(cb) {
+      this.listeners.add(cb);
+      return () => { this.listeners.delete(cb); };
+    },
+    destroy() { this.listeners.clear(); },
+    updateTTL() {},
+  };
+}
+
+function newMockZero(clientID: string): Zero<Schema, undefined, unknown> {
+  const view = newView();
+  return {
+    clientID,
+    materialize: vi.fn().mockImplementation(() => view),
+  } as unknown as Zero<Schema, undefined, unknown>;
+}
+
+function getListeners(zero: Zero<Schema, undefined, unknown>, index = 0) {
+  const result = vi.mocked(zero.materialize).mock.results[index]?.value as MockView | undefined;
+  if (!result) throw new Error('materialize was not called');
+  return result.listeners;
+}
+
+function createView(viewStore: ViewStore, suffix: string) {
+  const q = newMockQuery(`q-${suffix}`);
+  const zero = newMockZero(`client-${suffix}`);
+  const view = viewStore.getView(zero, q, true, 'forever');
+  const cleanup = view.subscribeReactInternals(() => {});
+  return {view, zero, q, cleanup};
+}
+
+// ─── Snapshot identity ──────────────────────────────────────────────────────
+
+describe('Snapshot identity', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  test('getSnapshot returns same reference without data changes, new reference after', () => {
+    const viewStore = new ViewStore();
+    const {view, zero, cleanup} = createView(viewStore, 'identity');
+
+    // Same ref before data
+    expect(view.getSnapshot()).toBe(view.getSnapshot());
+
+    // Push data
+    getListeners(zero).forEach(cb => cb([{id: '1'}], 'unknown'));
+    const withData = view.getSnapshot();
+
+    // Same ref after data (no further changes)
+    expect(view.getSnapshot()).toBe(withData);
+
+    // New ref after new data
+    getListeners(zero).forEach(cb => cb([{id: '1'}, {id: '2'}], 'unknown'));
+    expect(view.getSnapshot()).not.toBe(withData);
+
+    cleanup();
+  });
+
+  test('empty snapshots use sentinel objects (no spurious re-renders)', () => {
+    const viewStore = new ViewStore();
+    const {view, zero, cleanup} = createView(viewStore, 'sentinel');
+
+    const empty1 = view.getSnapshot();
+    getListeners(zero).forEach(cb => cb([], 'unknown'));
+    const empty2 = view.getSnapshot();
+
+    // Same sentinel reference for repeated empty data
+    expect(empty1).toBe(empty2);
+
+    // Singular empty sentinel
+    const qSingular = newMockQuery('singular', true);
+    const zeroSingular = newMockZero('client-singular');
+    const singular = viewStore.getView(zeroSingular, qSingular, true, 'forever');
+    const cleanupSingular = singular.subscribeReactInternals(() => {});
+
+    const s1 = singular.getSnapshot();
+    getListeners(zeroSingular).forEach(cb => cb(undefined, 'unknown'));
+    expect(singular.getSnapshot()).toBe(s1);
+
+    cleanup();
+    cleanupSingular();
+  });
+
+  test('row identity preserved in snapshot: unchanged rows keep same reference', () => {
+    const viewStore = new ViewStore();
+    const {view, zero, cleanup} = createView(viewStore, 'row-identity');
+    const listeners = getListeners(zero);
+
+    const row1 = {id: '1', name: 'Alice'};
+    const row2 = {id: '2', name: 'Bob'};
+    listeners.forEach(cb => cb([row1, row2], 'unknown'));
+
+    // Update only row2, keep row1 as same object
+    const row2Updated = {id: '2', name: 'Bob Updated'};
+    listeners.forEach(cb => cb([row1, row2Updated], 'unknown'));
+
+    const data = view.getSnapshot()[0] as Array<{id: string; name: string}>;
+    expect(data[0]).toBe(row1);
+    expect(data[1]).toBe(row2Updated);
+
+    cleanup();
+  });
+});
+
+// ─── Data flash prevention ──────────────────────────────────────────────────
+
+describe('No data flash (data→empty→data)', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  test('snapshot never goes empty between data updates', () => {
+    const viewStore = new ViewStore();
+    const {view, zero, cleanup} = createView(viewStore, 'flash');
+    const listeners = getListeners(zero);
+
+    const snapshots: unknown[] = [];
+    view.subscribeReactInternals(() => {
+      snapshots.push((view.getSnapshot()[0] as unknown[]).length);
+    });
+
+    listeners.forEach(cb => cb([{id: '1'}], 'unknown'));
+    listeners.forEach(cb => cb([{id: '1'}, {id: '2'}], 'unknown'));
+
+    // After first data, no snapshot should ever be empty
+    let hadData = false;
+    for (const len of snapshots) {
+      if ((len as number) > 0) hadData = true;
+      if (hadData) expect(len).toBeGreaterThan(0);
+    }
+
+    cleanup();
+  });
+
+  test('stale snapshot preserved after view destroy (no empty flash on remount)', () => {
+    const viewStore = new ViewStore();
+    const {view, zero, cleanup} = createView(viewStore, 'destroy-flash');
+
+    getListeners(zero).forEach(cb => cb([{id: '1'}], 'complete'));
+    expect((view.getSnapshot()[0] as unknown[]).length).toBe(1);
+
+    cleanup();
+    vi.advanceTimersByTime(15); // past 10ms cleanup timeout
+
+    // Stale snapshot still has data, not empty
+    expect((view.getSnapshot()[0] as unknown[]).length).toBe(1);
+  });
+});
+
+// ─── React.memo render counting ─────────────────────────────────────────────
+
+describe('React.memo child render counting', () => {
+  let root: Root;
+  let element: HTMLDivElement;
+  let unique = 0;
+
+  beforeEach(() => {
+    vi.useRealTimers();
+    element = document.createElement('div');
+    document.body.appendChild(element);
+    root = createRoot(element);
+    unique++;
+  });
+
+  afterEach(() => {
+    root.unmount();
+    document.body.removeChild(element);
+  });
+
+  test('only the changed row child re-renders; unchanged rows skip', async () => {
+    const viewStore = new ViewStore();
+    const q = newMockQuery(`react-memo-${unique}`);
+    const zero = newMockZero(`client-memo-${unique}`);
+    const parentRenders = {current: 0};
+    const childRenders: Record<string, number> = {};
+
+    type Row = {id: string; name: string};
+
+    const ChildRow = memo(function ChildRow({row}: {row: Row}) {
+      childRenders[row.id] = (childRenders[row.id] ?? 0) + 1;
+      return <div data-testid={`row-${row.id}`}>{row.name}</div>;
+    });
+
+    function Parent() {
+      const viewRef = viewStore.getView(zero, q, true, 'forever');
+      const [data] = useSyncExternalStore(
+        viewRef.subscribeReactInternals,
+        viewRef.getSnapshot,
+        viewRef.getSnapshot,
+      );
+      parentRenders.current++;
+      return (
+        <div>{((data ?? []) as Row[]).map(row => <ChildRow key={row.id} row={row} />)}</div>
+      );
+    }
+
+    root.render(<Parent />);
+    await expect.poll(() => parentRenders.current).toBeGreaterThanOrEqual(1);
+
+    // Push initial data
+    const row1 = {id: '1', name: 'Alice'};
+    const row2 = {id: '2', name: 'Bob'};
+    getListeners(zero).forEach(cb => cb([row1, row2], 'unknown'));
+
+    await expect.poll(() => element.querySelector('[data-testid="row-1"]')?.textContent).toBe('Alice');
+
+    const rendersAfterData = parentRenders.current;
+    const child1After = childRenders['1'] ?? 0;
+
+    // Update only row2, keep row1 as same reference
+    getListeners(zero).forEach(cb => cb([row1, {id: '2', name: 'Bob Updated'}], 'unknown'));
+
+    await expect.poll(() => element.querySelector('[data-testid="row-2"]')?.textContent).toBe('Bob Updated');
+
+    // Parent re-renders (new snapshot tuple)
+    expect(parentRenders.current).toBeGreaterThan(rendersAfterData);
+    // Unchanged row1 child does NOT re-render
+    expect(childRenders['1']).toBe(child1After);
+    // Changed row2 child DOES re-render
+    expect(childRenders['2']).toBeGreaterThan(1);
+  });
+});

--- a/packages/zero-react/src/rerender.test.tsx
+++ b/packages/zero-react/src/rerender.test.tsx
@@ -1,6 +1,10 @@
 import React, {memo, useSyncExternalStore} from 'react';
 import {createRoot, type Root} from 'react-dom/client';
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+import {consume} from '../../zql/src/ivm/stream.ts';
+import {newQuery} from '../../zql/src/query/query-impl.ts';
+import {QueryDelegateImpl} from '../../zql/src/query/test/query-delegate.ts';
+import {schema} from '../../zql/src/query/test/test-schemas.ts';
 import {queryInternalsTag, type QueryImpl} from './bindings.ts';
 import {ViewStore} from './use-query.tsx';
 import type {
@@ -285,5 +289,124 @@ describe('React.memo child render counting', () => {
     expect(parentRenders.current).toBeGreaterThan(rendersAfterData);
     expect(childRenders['1']).toBe(child1After);
     expect(childRenders['2']).toBeGreaterThan(1);
+  });
+});
+
+//   issue1 ─── owner:Alice        edit comment1       issue1' ─── owner:Alice (same ref)
+//           ├── comment1            ──────────►               ├── comment1' (new ref)
+//           └── comment2                                      └── comment2 (same ref)
+//   issue2 ─── owner:Bob                               issue2 (same ref, unrelated)
+//           └── comment3                                     └── comment3 (same ref)
+//
+//   <IssueRow issue={issue1}>  re-renders (descendant changed)
+//   <IssueRow issue={issue2}>  skips (React.memo, same ref)
+describe('End-to-end: real IVM pipeline to React.memo', () => {
+  let root: Root;
+  let element: HTMLDivElement;
+
+  beforeEach(() => {
+    vi.useRealTimers();
+    element = document.createElement('div');
+    document.body.appendChild(element);
+    root = createRoot(element);
+  });
+
+  afterEach(() => {
+    root.unmount();
+    document.body.removeChild(element);
+  });
+
+  test('editing a comment only re-renders the parent issue, not unrelated issues', async () => {
+    const queryDelegate = new QueryDelegateImpl();
+    const userSource = queryDelegate.getSource('user');
+    const issueSource = queryDelegate.getSource('issue');
+    const commentSource = queryDelegate.getSource('comment');
+
+    consume(userSource.push({type: 'add', row: {id: 'u1', name: 'Alice', metadata: null}}));
+    consume(userSource.push({type: 'add', row: {id: 'u2', name: 'Bob', metadata: null}}));
+    consume(issueSource.push({type: 'add', row: {id: 'i1', title: 'Bug', description: 'd1', closed: false, ownerId: 'u1', createdAt: 1}}));
+    consume(issueSource.push({type: 'add', row: {id: 'i2', title: 'Feature', description: 'd2', closed: false, ownerId: 'u2', createdAt: 2}}));
+    consume(commentSource.push({type: 'add', row: {id: 'c1', authorId: 'u1', issueId: 'i1', text: 'first', createdAt: 1}}));
+    consume(commentSource.push({type: 'add', row: {id: 'c2', authorId: 'u2', issueId: 'i1', text: 'second', createdAt: 2}}));
+    consume(commentSource.push({type: 'add', row: {id: 'c3', authorId: 'u2', issueId: 'i2', text: 'third', createdAt: 3}}));
+
+    const issueQuery = newQuery(schema, 'issue')
+      .related('owner')
+      .related('comments');
+
+    const view = queryDelegate.materialize(issueQuery);
+
+    // Wire the real TypedView to useSyncExternalStore
+    type IssueRow = {id: string; title: string; comments: Array<{id: string; text: string}>; owner: {name: string} | undefined};
+    let snapshot: unknown[] = [];
+    const subscribers = new Set<() => void>();
+    view.addListener(data => {
+      snapshot = data as unknown[];
+      for (const cb of subscribers) cb();
+    });
+    const subscribe = (cb: () => void) => {
+      subscribers.add(cb);
+      return () => { subscribers.delete(cb); };
+    };
+    const getSnapshot = () => snapshot;
+
+    const issueRenders: Record<string, number> = {};
+
+    const IssueRowComponent = memo(function IssueRowComponent({issue}: {issue: IssueRow}) {
+      issueRenders[issue.id] = (issueRenders[issue.id] ?? 0) + 1;
+      const commentTexts = issue.comments.map(c => c.text).join(', ');
+      return (
+        <div data-testid={`issue-${issue.id}`}>
+          {issue.title} by {issue.owner?.name}: [{commentTexts}]
+        </div>
+      );
+    });
+
+    function IssueList() {
+      const issues = useSyncExternalStore(subscribe, getSnapshot, getSnapshot) as IssueRow[];
+      return (
+        <div>
+          {issues.map(issue => (
+            <IssueRowComponent key={issue.id} issue={issue} />
+          ))}
+        </div>
+      );
+    }
+
+    root.render(<IssueList />);
+
+    // Wait for hydration render
+    await expect
+      .poll(() => element.querySelector('[data-testid="issue-i1"]')?.textContent)
+      .toContain('Bug');
+    await expect
+      .poll(() => element.querySelector('[data-testid="issue-i2"]')?.textContent)
+      .toContain('Feature');
+
+    const issue1RendersAfterHydration = issueRenders['i1'] ?? 0;
+    const issue2RendersAfterHydration = issueRenders['i2'] ?? 0;
+    expect(issue1RendersAfterHydration).toBeGreaterThanOrEqual(1);
+    expect(issue2RendersAfterHydration).toBeGreaterThanOrEqual(1);
+
+    // Edit comment1's text via the real source
+    consume(commentSource.push({
+      type: 'edit',
+      oldRow: {id: 'c1', authorId: 'u1', issueId: 'i1', text: 'first', createdAt: 1},
+      row: {id: 'c1', authorId: 'u1', issueId: 'i1', text: 'first-EDITED', createdAt: 1},
+    }));
+    queryDelegate.commit();
+
+    // Wait for the edit to appear in the DOM
+    await expect
+      .poll(() => element.querySelector('[data-testid="issue-i1"]')?.textContent)
+      .toContain('first-EDITED');
+
+    // issue1's component MUST have re-rendered (its comment changed)
+    expect(issueRenders['i1']).toBeGreaterThan(issue1RendersAfterHydration);
+
+    // issue2's component must NOT have re-rendered (unrelated, React.memo skips)
+    expect(issueRenders['i2']).toBe(issue2RendersAfterHydration);
+
+    view.destroy();
   });
 });

--- a/packages/zero-react/src/rerender.test.tsx
+++ b/packages/zero-react/src/rerender.test.tsx
@@ -15,57 +15,59 @@ import type {
   Zero,
 } from './zero.ts';
 
-function newMockQuery(query: string, singular = false): Query<string, Schema> {
-  return {
-    [queryInternalsTag]: true,
-    hash: () => query,
-    format: {singular},
-  } as unknown as QueryImpl<string, Schema>;
-}
+type Listener = (data: unknown, resultType: ResultType, error?: ErroredQuery) => void;
 
 type MockView = {
-  listeners: Set<
-    (data: unknown, resultType: ResultType, error?: ErroredQuery) => void
-  >;
-  addListener(
-    cb: (data: unknown, resultType: ResultType, error?: ErroredQuery) => void,
-  ): () => void;
+  listeners: Set<Listener>;
+  addListener(cb: Listener): () => void;
   destroy(): void;
   updateTTL(): void;
 };
 
-function newView(): MockView {
+function newMockQuery(hash: string, singular = false): Query<string, Schema> {
   return {
-    listeners: new Set(),
-    addListener(cb) {
-      this.listeners.add(cb);
-      return () => { this.listeners.delete(cb); };
-    },
-    destroy() { this.listeners.clear(); },
-    updateTTL() {},
-  };
+    [queryInternalsTag]: true,
+    hash: () => hash,
+    format: {singular},
+  } as unknown as QueryImpl<string, Schema>;
 }
 
 function newMockZero(clientID: string): Zero<Schema, undefined, unknown> {
-  const view = newView();
   return {
     clientID,
-    materialize: vi.fn().mockImplementation(() => view),
+    materialize: vi.fn().mockImplementation(() => ({
+      listeners: new Set(),
+      addListener(cb: Listener) {
+        this.listeners.add(cb);
+        return () => { this.listeners.delete(cb); };
+      },
+      destroy() { this.listeners.clear(); },
+      updateTTL() {},
+    } satisfies MockView)),
   } as unknown as Zero<Schema, undefined, unknown>;
 }
 
-function getListeners(zero: Zero<Schema, undefined, unknown>, index = 0) {
-  const result = vi.mocked(zero.materialize).mock.results[index]?.value as MockView | undefined;
-  if (!result) throw new Error('materialize was not called');
-  return result.listeners;
+function emit(zero: Zero<Schema, undefined, unknown>, data: unknown, resultType: ResultType = 'unknown') {
+  const mock = vi.mocked(zero.materialize).mock.results[0]?.value as MockView | undefined;
+  if (!mock) throw new Error('materialize not called');
+  mock.listeners.forEach(cb => cb(data, resultType));
 }
 
-function createView(viewStore: ViewStore, suffix: string) {
-  const q = newMockQuery(`q-${suffix}`);
-  const zero = newMockZero(`client-${suffix}`);
-  const view = viewStore.getView(zero, q, true, 'forever');
+function mockViewStore(suffix: string) {
+  const viewStore = new ViewStore();
+  const query = newMockQuery(`q-${suffix}`);
+  const zero = newMockZero(`c-${suffix}`);
+  const view = viewStore.getView(zero, query, true, 'forever');
   const cleanup = view.subscribeReactInternals(() => {});
-  return {view, zero, q, cleanup};
+  return {view, zero, cleanup};
+}
+
+function snapData(view: {getSnapshot: () => readonly [unknown, ...unknown[]]}) {
+  return view.getSnapshot()[0];
+}
+
+function snapLength(view: {getSnapshot: () => readonly [unknown, ...unknown[]]}) {
+  return (snapData(view) as unknown[]).length;
 }
 
 describe('Snapshot identity', () => {
@@ -74,70 +76,63 @@ describe('Snapshot identity', () => {
 
   //   getSnapshot()  -->  ref1
   //   getSnapshot()  -->  ref1  (same, no data change)
-  //   listener([row])
+  //   emit([row])
   //   getSnapshot()  -->  ref2  (new, data changed)
   //   getSnapshot()  -->  ref2  (same, no further change)
-  test('getSnapshot returns same reference without data changes, new reference after', () => {
-    const viewStore = new ViewStore();
-    const {view, zero, cleanup} = createView(viewStore, 'identity');
+  test('same reference without changes, new reference after data', () => {
+    const {view, zero, cleanup} = mockViewStore('identity');
 
     expect(view.getSnapshot()).toBe(view.getSnapshot());
 
-    getListeners(zero).forEach(cb => cb([{id: '1'}], 'unknown'));
+    emit(zero, [{id: '1'}]);
     const withData = view.getSnapshot();
-
     expect(view.getSnapshot()).toBe(withData);
 
-    getListeners(zero).forEach(cb => cb([{id: '1'}, {id: '2'}], 'unknown'));
+    emit(zero, [{id: '1'}, {id: '2'}]);
     expect(view.getSnapshot()).not.toBe(withData);
 
     cleanup();
   });
 
   //   getSnapshot()  -->  [[], {type:'unknown'}]  (sentinel A)
-  //   listener([])
+  //   emit([])
   //   getSnapshot()  -->  [[], {type:'unknown'}]  (sentinel A, same ref)
   test('empty snapshots use sentinel objects (no spurious re-renders)', () => {
-    const viewStore = new ViewStore();
-    const {view, zero, cleanup} = createView(viewStore, 'sentinel');
+    const {view, zero, cleanup} = mockViewStore('sentinel');
 
     const empty1 = view.getSnapshot();
-    getListeners(zero).forEach(cb => cb([], 'unknown'));
-    const empty2 = view.getSnapshot();
-
-    expect(empty1).toBe(empty2);
+    emit(zero, []);
+    expect(view.getSnapshot()).toBe(empty1);
 
     const qSingular = newMockQuery('singular', true);
-    const zeroSingular = newMockZero('client-singular');
+    const zeroSingular = newMockZero('c-singular');
+    const viewStore = new ViewStore();
     const singular = viewStore.getView(zeroSingular, qSingular, true, 'forever');
     const cleanupSingular = singular.subscribeReactInternals(() => {});
 
     const s1 = singular.getSnapshot();
-    getListeners(zeroSingular).forEach(cb => cb(undefined, 'unknown'));
+    emit(zeroSingular, undefined);
     expect(singular.getSnapshot()).toBe(s1);
 
     cleanup();
     cleanupSingular();
   });
 
-  //   listener([row1, row2])  -->  snap1 = [row1, row2]
-  //   listener([row1, row2'])  -->  snap2 = [row1, row2']
+  //   emit([row1, row2])    -->  snap1
+  //   emit([row1, row2'])   -->  snap2
   //
   //   snap2[0]:  same ref as row1 (unchanged)
   //   snap2[1]:  row2' (new ref, changed)
-  test('row identity preserved in snapshot: unchanged rows keep same reference', () => {
-    const viewStore = new ViewStore();
-    const {view, zero, cleanup} = createView(viewStore, 'row-identity');
-    const listeners = getListeners(zero);
+  test('unchanged rows keep same reference in snapshot', () => {
+    const {view, zero, cleanup} = mockViewStore('row-id');
 
     const row1 = {id: '1', name: 'Alice'};
-    const row2 = {id: '2', name: 'Bob'};
-    listeners.forEach(cb => cb([row1, row2], 'unknown'));
+    emit(zero, [row1, {id: '2', name: 'Bob'}]);
 
     const row2Updated = {id: '2', name: 'Bob Updated'};
-    listeners.forEach(cb => cb([row1, row2Updated], 'unknown'));
+    emit(zero, [row1, row2Updated]);
 
-    const data = view.getSnapshot()[0] as Array<{id: string; name: string}>;
+    const data = snapData(view) as Array<{id: string; name: string}>;
     expect(data[0]).toBe(row1);
     expect(data[1]).toBe(row2Updated);
 
@@ -149,68 +144,54 @@ describe('No data flash (data to empty to data)', () => {
   beforeEach(() => { vi.useFakeTimers(); });
   afterEach(() => { vi.useRealTimers(); });
 
-  //   listener([row1])         -->  snap = [row1]   (has data)
-  //   listener([row1, row2])   -->  snap = [row1, row2]
-  //
+  //   emit([row1])         -->  snap has data
+  //   emit([row1, row2])   -->  snap still has data
   //   At no point should snap become [] between these two updates.
   test('snapshot never goes empty between data updates', () => {
-    const viewStore = new ViewStore();
-    const {view, zero, cleanup} = createView(viewStore, 'flash');
-    const listeners = getListeners(zero);
+    const {view, zero, cleanup} = mockViewStore('flash');
 
-    const snapshots: unknown[] = [];
-    view.subscribeReactInternals(() => {
-      snapshots.push((view.getSnapshot()[0] as unknown[]).length);
-    });
+    const lengths: number[] = [];
+    view.subscribeReactInternals(() => { lengths.push(snapLength(view)); });
 
-    listeners.forEach(cb => cb([{id: '1'}], 'unknown'));
-    listeners.forEach(cb => cb([{id: '1'}, {id: '2'}], 'unknown'));
+    emit(zero, [{id: '1'}]);
+    emit(zero, [{id: '1'}, {id: '2'}]);
 
     let hadData = false;
-    for (const len of snapshots) {
-      if ((len as number) > 0) hadData = true;
+    for (const len of lengths) {
+      if (len > 0) hadData = true;
       if (hadData) expect(len).toBeGreaterThan(0);
     }
 
     cleanup();
   });
 
-  //   listener([row])  -->  snap = [row]
-  //   unsubscribe
-  //   ... 15ms (past 10ms cleanup timeout) ...
-  //   getSnapshot()  -->  snap = [row]  (stale data preserved, not empty)
-  test('stale snapshot preserved after view destroy (no empty flash on remount)', () => {
-    const viewStore = new ViewStore();
-    const {view, zero, cleanup} = createView(viewStore, 'destroy-flash');
+  //   emit([row])  -->  snap has data
+  //   unsubscribe + 15ms  -->  view destroyed
+  //   getSnapshot()  -->  snap still has data (stale, not empty)
+  test('stale snapshot preserved after view destroy', () => {
+    const {view, zero, cleanup} = mockViewStore('destroy');
 
-    getListeners(zero).forEach(cb => cb([{id: '1'}], 'complete'));
-    expect((view.getSnapshot()[0] as unknown[]).length).toBe(1);
+    emit(zero, [{id: '1'}], 'complete');
+    expect(snapLength(view)).toBe(1);
 
     cleanup();
     vi.advanceTimersByTime(15);
 
-    expect((view.getSnapshot()[0] as unknown[]).length).toBe(1);
+    expect(snapLength(view)).toBe(1);
   });
 
-  //   listener([row])   -->  snap = [row]
-  //   listener([])       -->  snap = []     (legitimate empty)
-  //   listener([row2])  -->  snap = [row2]
-  //
-  //   Verifies that transitioning through empty is visible (not masked)
-  //   when the server genuinely returns empty then non-empty.
+  //   emit([row])   -->  [1]
+  //   emit([])      -->  [0]  (legitimate empty)
+  //   emit([row2])  -->  [1]
   test('legitimate empty transition is visible (not masked)', () => {
-    const viewStore = new ViewStore();
-    const {view, zero, cleanup} = createView(viewStore, 'legit-empty');
-    const listeners = getListeners(zero);
+    const {view, zero, cleanup} = mockViewStore('legit-empty');
 
     const lengths: number[] = [];
-    view.subscribeReactInternals(() => {
-      lengths.push((view.getSnapshot()[0] as unknown[]).length);
-    });
+    view.subscribeReactInternals(() => { lengths.push(snapLength(view)); });
 
-    listeners.forEach(cb => cb([{id: '1'}], 'unknown'));
-    listeners.forEach(cb => cb([], 'complete'));
-    listeners.forEach(cb => cb([{id: '2'}], 'complete'));
+    emit(zero, [{id: '1'}]);
+    emit(zero, [], 'complete');
+    emit(zero, [{id: '2'}], 'complete');
 
     expect(lengths).toEqual([1, 0, 1]);
 
@@ -218,38 +199,33 @@ describe('No data flash (data to empty to data)', () => {
   });
 });
 
-describe('React.memo child render counting', () => {
+describe('React.memo render counting', () => {
   let root: Root;
   let element: HTMLDivElement;
-  let unique = 0;
+  const cleanups: Array<() => void> = [];
 
   beforeEach(() => {
     vi.useRealTimers();
     element = document.createElement('div');
     document.body.appendChild(element);
     root = createRoot(element);
-    unique++;
   });
 
   afterEach(() => {
+    for (const fn of cleanups) fn();
+    cleanups.length = 0;
     root.unmount();
     document.body.removeChild(element);
   });
 
-  //   Parent (useQuery)
-  //     |
-  //     +-- ChildRow(row1)  React.memo  <-- same ref, skip re-render
+  //   Parent (useSyncExternalStore)
+  //     +-- ChildRow(row1)  React.memo  <-- same ref, skip
   //     +-- ChildRow(row2)  React.memo  <-- new ref, re-renders
-  //
-  //   listener([row1, row2])    -->  both children render
-  //   listener([row1, row2'])   -->  only row2 child re-renders
-  test('only the changed row child re-renders; unchanged rows skip', async () => {
-    const viewStore = new ViewStore();
-    const q = newMockQuery(`react-memo-${unique}`);
-    const zero = newMockZero(`client-memo-${unique}`);
+  test('mock view: only the changed row child re-renders', async () => {
+    const {view: viewRef, zero} = mockViewStore('memo');
+
     const parentRenders = {current: 0};
     const childRenders: Record<string, number> = {};
-
     type Row = {id: string; name: string};
 
     const ChildRow = memo(function ChildRow({row}: {row: Row}) {
@@ -258,7 +234,6 @@ describe('React.memo child render counting', () => {
     });
 
     function Parent() {
-      const viewRef = viewStore.getView(zero, q, true, 'forever');
       const [data] = useSyncExternalStore(
         viewRef.subscribeReactInternals,
         viewRef.getSnapshot,
@@ -274,52 +249,29 @@ describe('React.memo child render counting', () => {
     await expect.poll(() => parentRenders.current).toBeGreaterThanOrEqual(1);
 
     const row1 = {id: '1', name: 'Alice'};
-    const row2 = {id: '2', name: 'Bob'};
-    getListeners(zero).forEach(cb => cb([row1, row2], 'unknown'));
+    emit(zero, [row1, {id: '2', name: 'Bob'}]);
 
     await expect.poll(() => element.querySelector('[data-testid="row-1"]')?.textContent).toBe('Alice');
-
     const rendersAfterData = parentRenders.current;
     const child1After = childRenders['1'] ?? 0;
 
-    getListeners(zero).forEach(cb => cb([row1, {id: '2', name: 'Bob Updated'}], 'unknown'));
+    emit(zero, [row1, {id: '2', name: 'Bob Updated'}]);
 
     await expect.poll(() => element.querySelector('[data-testid="row-2"]')?.textContent).toBe('Bob Updated');
-
     expect(parentRenders.current).toBeGreaterThan(rendersAfterData);
     expect(childRenders['1']).toBe(child1After);
     expect(childRenders['2']).toBeGreaterThan(1);
   });
-});
 
-//   issue1 ─── owner:Alice        edit comment1       issue1' ─── owner:Alice (same ref)
-//           ├── comment1            ──────────►               ├── comment1' (new ref)
-//           └── comment2                                      └── comment2 (same ref)
-//   issue2 ─── owner:Bob                               issue2 (same ref, unrelated)
-//           └── comment3                                     └── comment3 (same ref)
-//
-//   <IssueRow issue={issue1}>  re-renders (descendant changed)
-//   <IssueRow issue={issue2}>  skips (React.memo, same ref)
-describe('End-to-end: real IVM pipeline to React.memo', () => {
-  let root: Root;
-  let element: HTMLDivElement;
-  let viewToCleanup: {destroy(): void} | undefined;
-
-  beforeEach(() => {
-    vi.useRealTimers();
-    element = document.createElement('div');
-    document.body.appendChild(element);
-    root = createRoot(element);
-  });
-
-  afterEach(() => {
-    viewToCleanup?.destroy();
-    viewToCleanup = undefined;
-    root.unmount();
-    document.body.removeChild(element);
-  });
-
-  test('editing a comment only re-renders the parent issue, not unrelated issues', async () => {
+  //   issue1 ─── owner:Alice        edit comment1       issue1' ─── owner:Alice (same ref)
+  //           ├── comment1            ──────────►               ├── comment1' (new ref)
+  //           └── comment2                                      └── comment2 (same ref)
+  //   issue2 ─── owner:Bob                               issue2 (same ref, unrelated)
+  //           └── comment3                                     └── comment3 (same ref)
+  //
+  //   <IssueRow issue={issue1}>  re-renders (descendant changed)
+  //   <IssueRow issue={issue2}>  skips (React.memo, same ref)
+  test('real IVM pipeline: editing a comment only re-renders the parent issue', async () => {
     const queryDelegate = new QueryDelegateImpl({callGot: true});
     const userSource = queryDelegate.getSource('user');
     const issueSource = queryDelegate.getSource('issue');
@@ -333,14 +285,11 @@ describe('End-to-end: real IVM pipeline to React.memo', () => {
     consume(commentSource.push({type: 'add', row: {id: 'c2', authorId: 'u2', issueId: 'i1', text: 'second', createdAt: 2}}));
     consume(commentSource.push({type: 'add', row: {id: 'c3', authorId: 'u2', issueId: 'i2', text: 'third', createdAt: 3}}));
 
-    const issueQuery = newQuery(schema, 'issue')
-      .related('owner')
-      .related('comments');
+    const view = queryDelegate.materialize(
+      newQuery(schema, 'issue').related('owner').related('comments'),
+    );
+    cleanups.push(() => view.destroy());
 
-    const view = queryDelegate.materialize(issueQuery);
-    viewToCleanup = view;
-
-    // Wire the real TypedView to useSyncExternalStore
     type IssueRow = {id: string; title: string; comments: Array<{id: string; text: string}>; owner: {name: string} | undefined};
     let snapshot: unknown[] = [];
     const subscribers = new Set<() => void>();
@@ -348,17 +297,14 @@ describe('End-to-end: real IVM pipeline to React.memo', () => {
       snapshot = data as unknown[];
       for (const cb of subscribers) cb();
     });
-    const subscribe = (cb: () => void) => {
-      subscribers.add(cb);
-      return () => { subscribers.delete(cb); };
-    };
+    const subscribe = (cb: () => void) => { subscribers.add(cb); return () => { subscribers.delete(cb); }; };
     const getSnapshot = () => snapshot;
 
     const issueRenders: Record<string, number> = {};
 
     const IssueRowComponent = memo(function IssueRowComponent({issue}: {issue: IssueRow}) {
       issueRenders[issue.id] = (issueRenders[issue.id] ?? 0) + 1;
-      const commentTexts = issue.comments.map(c => c.text).join(', ');
+      const commentTexts = issue.comments.map(comment => comment.text).join(', ');
       return (
         <div data-testid={`issue-${issue.id}`}>
           {issue.title} by {issue.owner?.name}: [{commentTexts}]
@@ -370,29 +316,21 @@ describe('End-to-end: real IVM pipeline to React.memo', () => {
       const issues = useSyncExternalStore(subscribe, getSnapshot, getSnapshot) as IssueRow[];
       return (
         <div>
-          {issues.map(issue => (
-            <IssueRowComponent key={issue.id} issue={issue} />
-          ))}
+          {issues.map(issue => <IssueRowComponent key={issue.id} issue={issue} />)}
         </div>
       );
     }
 
     root.render(<IssueList />);
 
-    // Wait for hydration render
-    await expect
-      .poll(() => element.querySelector('[data-testid="issue-i1"]')?.textContent)
-      .toContain('Bug');
-    await expect
-      .poll(() => element.querySelector('[data-testid="issue-i2"]')?.textContent)
-      .toContain('Feature');
+    await expect.poll(() => element.querySelector('[data-testid="issue-i1"]')?.textContent).toContain('Bug');
+    await expect.poll(() => element.querySelector('[data-testid="issue-i2"]')?.textContent).toContain('Feature');
 
-    const issue1RendersAfterHydration = issueRenders['i1'] ?? 0;
-    const issue2RendersAfterHydration = issueRenders['i2'] ?? 0;
-    expect(issue1RendersAfterHydration).toBeGreaterThanOrEqual(1);
-    expect(issue2RendersAfterHydration).toBeGreaterThanOrEqual(1);
+    const issue1After = issueRenders['i1'] ?? 0;
+    const issue2After = issueRenders['i2'] ?? 0;
+    expect(issue1After).toBeGreaterThanOrEqual(1);
+    expect(issue2After).toBeGreaterThanOrEqual(1);
 
-    // Edit comment1's text via the real source
     consume(commentSource.push({
       type: 'edit',
       oldRow: {id: 'c1', authorId: 'u1', issueId: 'i1', text: 'first', createdAt: 1},
@@ -400,15 +338,9 @@ describe('End-to-end: real IVM pipeline to React.memo', () => {
     }));
     queryDelegate.commit();
 
-    // Wait for the edit to appear in the DOM
-    await expect
-      .poll(() => element.querySelector('[data-testid="issue-i1"]')?.textContent)
-      .toContain('first-EDITED');
+    await expect.poll(() => element.querySelector('[data-testid="issue-i1"]')?.textContent).toContain('first-EDITED');
 
-    // issue1's component MUST have re-rendered (its comment changed)
-    expect(issueRenders['i1']).toBeGreaterThan(issue1RendersAfterHydration);
-
-    // issue2's component must NOT have re-rendered (unrelated, React.memo skips)
-    expect(issueRenders['i2']).toBe(issue2RendersAfterHydration);
+    expect(issueRenders['i1']).toBeGreaterThan(issue1After);
+    expect(issueRenders['i2']).toBe(issue2After);
   });
 });

--- a/packages/zero-react/src/rerender.test.tsx
+++ b/packages/zero-react/src/rerender.test.tsx
@@ -11,8 +11,6 @@ import type {
   Zero,
 } from './zero.ts';
 
-// ─── Test helpers ───────────────────────────────────────────────────────────
-
 function newMockQuery(query: string, singular = false): Query<string, Schema> {
   return {
     [queryInternalsTag]: true,
@@ -65,8 +63,6 @@ function createView(viewStore: ViewStore, suffix: string) {
   const cleanup = view.subscribeReactInternals(() => {});
   return {view, zero, q, cleanup};
 }
-
-// ─── Snapshot identity ──────────────────────────────────────────────────────
 
 describe('Snapshot identity', () => {
   beforeEach(() => { vi.useFakeTimers(); });
@@ -139,8 +135,6 @@ describe('Snapshot identity', () => {
   });
 });
 
-// ─── Data flash prevention ──────────────────────────────────────────────────
-
 describe('No data flash (data→empty→data)', () => {
   beforeEach(() => { vi.useFakeTimers(); });
   afterEach(() => { vi.useRealTimers(); });
@@ -182,8 +176,6 @@ describe('No data flash (data→empty→data)', () => {
     expect((view.getSnapshot()[0] as unknown[]).length).toBe(1);
   });
 });
-
-// ─── React.memo render counting ─────────────────────────────────────────────
 
 describe('React.memo child render counting', () => {
   let root: Root;

--- a/packages/zero-react/src/rerender.test.tsx
+++ b/packages/zero-react/src/rerender.test.tsx
@@ -303,6 +303,7 @@ describe('React.memo child render counting', () => {
 describe('End-to-end: real IVM pipeline to React.memo', () => {
   let root: Root;
   let element: HTMLDivElement;
+  let viewToCleanup: {destroy(): void} | undefined;
 
   beforeEach(() => {
     vi.useRealTimers();
@@ -312,12 +313,14 @@ describe('End-to-end: real IVM pipeline to React.memo', () => {
   });
 
   afterEach(() => {
+    viewToCleanup?.destroy();
+    viewToCleanup = undefined;
     root.unmount();
     document.body.removeChild(element);
   });
 
   test('editing a comment only re-renders the parent issue, not unrelated issues', async () => {
-    const queryDelegate = new QueryDelegateImpl();
+    const queryDelegate = new QueryDelegateImpl({callGot: true});
     const userSource = queryDelegate.getSource('user');
     const issueSource = queryDelegate.getSource('issue');
     const commentSource = queryDelegate.getSource('comment');
@@ -335,6 +338,7 @@ describe('End-to-end: real IVM pipeline to React.memo', () => {
       .related('comments');
 
     const view = queryDelegate.materialize(issueQuery);
+    viewToCleanup = view;
 
     // Wire the real TypedView to useSyncExternalStore
     type IssueRow = {id: string; title: string; comments: Array<{id: string; text: string}>; owner: {name: string} | undefined};
@@ -406,7 +410,5 @@ describe('End-to-end: real IVM pipeline to React.memo', () => {
 
     // issue2's component must NOT have re-rendered (unrelated, React.memo skips)
     expect(issueRenders['i2']).toBe(issue2RendersAfterHydration);
-
-    view.destroy();
   });
 });

--- a/packages/zql/src/ivm/array-view-rerender.test.ts
+++ b/packages/zql/src/ivm/array-view-rerender.test.ts
@@ -80,6 +80,12 @@ function parentChildJoin(parentInput: Input, childInput: Input) {
   });
 }
 
+type ParentEntry = {
+  id: number;
+  name: string;
+  children: ChildRow[];
+};
+
 function parentChildView(join: Input) {
   const view = new ArrayView(
     join,
@@ -90,20 +96,20 @@ function parentChildView(join: Input) {
     true,
     () => {},
   );
-  type ParentEntry = {
-    id: number;
-    name: string;
-    children: ChildRow[];
-  };
   let data: unknown[] = [];
   view.addListener(entries => {
     assertArray(entries);
     data = [...entries];
   });
-  return {view, getData: () => data, asParent: (i: number) => data[i] as ParentEntry};
+  return {view, getData: () => data, asParent: (idx: number) => data[idx] as ParentEntry};
 }
 
 describe('ArrayView: flat list identity preservation', () => {
+  //   [A, B, C]  --edit B-->  [A, B', C]
+  //    |     |                  |      |
+  //    same  same               same   same
+  //          |                         |
+  //       different              new ref (edited)
   test('edit: unchanged siblings keep reference, edited row gets new reference', () => {
     const ms = flatSource([
       {id: 1, text: 'A'},
@@ -122,6 +128,9 @@ describe('ArrayView: flat list identity preservation', () => {
     expect(getData()[2]).toBe(refC);
   });
 
+  //   [A, B]  --add C-->  [A, B, C]
+  //    |  |                 |  |
+  //   same same            same same
   test('add: existing rows keep reference', () => {
     const ms = flatSource([{id: 1, text: 'A'}, {id: 2, text: 'B'}]);
     const {view, getData} = flatView(ms);
@@ -135,6 +144,9 @@ describe('ArrayView: flat list identity preservation', () => {
     expect(getData()).toHaveLength(3);
   });
 
+  //   [A, B, C]  --remove B-->  [A, C]
+  //    |     |                    |  |
+  //   same  same                 same same
   test('remove: remaining rows keep reference', () => {
     const ms = flatSource([
       {id: 1, text: 'A'},
@@ -152,6 +164,11 @@ describe('ArrayView: flat list identity preservation', () => {
     expect(getData()[1]).toBe(refC);
   });
 
+  //   [A, B, C]  --edit B, add D-->  [A, B', C, D]
+  //    |     |                         |      |
+  //   same  same                      same   same
+  //          |                               |
+  //       new ref                         new ref
   test('multiple pushes before single flush preserve identity correctly', () => {
     const ms = flatSource([
       {id: 1, text: 'A'},
@@ -159,13 +176,14 @@ describe('ArrayView: flat list identity preservation', () => {
       {id: 3, text: 'C'},
     ]);
     const {view, getData} = flatView(ms);
-    const [refA, , refC] = getData();
+    const [refA, refB, refC] = getData();
 
     consume(ms.push({type: 'edit', oldRow: {id: 2, text: 'B'}, row: {id: 2, text: 'B-edited'}}));
     consume(ms.push({type: 'add', row: {id: 4, text: 'D'}}));
     view.flush();
 
     expect(getData()[0]).toBe(refA);
+    expect(getData()[1]).not.toBe(refB);
     expect(getData()[1]).toEqual(expect.objectContaining({id: 2, text: 'B-edited'}));
     expect(getData()[2]).toBe(refC);
     expect(getData()).toHaveLength(4);
@@ -173,6 +191,16 @@ describe('ArrayView: flat list identity preservation', () => {
 });
 
 describe('ArrayView: child changes bubble new references up to ancestors', () => {
+  //   parent1 ─┬─ [child1, child2]     edit child1     parent1' ─┬─ [child1', child2]
+  //            │                         ────────►                │
+  //   parent2 ─┴─ [child3]                              parent2  ─┴─ [child3]
+  //                                                      same ref       same ref
+  //
+  //   parent1:  new ref (descendant changed)
+  //   child1:   new ref (edited)
+  //   child2:   same ref (unchanged)
+  //   parent2:  same ref (unrelated)
+  //   child3:   same ref (unrelated)
   test('child edit gives parent a new reference; unrelated parent keeps reference', () => {
     const {parentSource, childSource} = parentChildSources(
       [{id: 1, name: 'parent1'}, {id: 2, name: 'parent2'}],
@@ -202,24 +230,21 @@ describe('ArrayView: child changes bubble new references up to ancestors', () =>
     }));
     view.flush();
 
-    // Parent1 MUST have new ref (descendant changed)
     expect(getData()[0]).not.toBe(refParent1);
-    // Children array MUST have new ref
     expect(asParent(0).children).not.toBe(refChildrenArray);
-    // Edited child MUST have new ref
     expect(asParent(0).children[0]).not.toBe(refChild1);
     expect(asParent(0).children[0]).toEqual(
       expect.objectContaining({id: 10, text: 'child1-edited'}),
     );
-
-    // Unchanged sibling child keeps ref
     expect(asParent(0).children[1]).toBe(refChild2);
-    // Unrelated parent2 keeps ref
     expect(getData()[1]).toBe(refParent2);
-    // Unrelated child3 keeps ref
     expect(asParent(1).children[0]).toBe(refChild3);
   });
 
+  //   parent1 ─── [child1]     add child2     parent1' ─── [child1, child2]
+  //                              ────────►
+  //   parent1:  new ref (children changed)
+  //   child1:   same ref (unchanged)
   test('child add gives parent a new reference; existing children keep reference', () => {
     const {parentSource, childSource} = parentChildSources(
       [{id: 1, name: 'parent1'}],
@@ -242,6 +267,10 @@ describe('ArrayView: child changes bubble new references up to ancestors', () =>
     expect(asParent(0).children[0]).toBe(refChild1);
   });
 
+  //   parent1 ─── [child1, child2]     remove child1     parent1' ─── [child2]
+  //                                      ────────────►
+  //   parent1:  new ref (children changed)
+  //   child2:   same ref (unchanged)
   test('child remove gives parent a new reference; remaining children keep reference', () => {
     const {parentSource, childSource} = parentChildSources(
       [{id: 1, name: 'parent1'}],
@@ -267,8 +296,13 @@ describe('ArrayView: child changes bubble new references up to ancestors', () =>
     expect(asParent(0).children[0]).toBe(refChild2);
   });
 
+  //   gp1 ─── p1 ─┬─ c1       edit c1       gp1' ─── p1' ─┬─ c1'
+  //                └─ c2        ──────►                      └─ c2  (same ref)
+  //   gp2                                     gp2  (same ref)
+  //
+  //   gp1: new ref    p1: new ref    c1: new ref (edited)
+  //   gp2: same ref                  c2: same ref (unchanged)
   test('grandchild edit bubbles new reference through all 3 levels', () => {
-    // grandparent → parent → child (3-level chained Join)
     const gpSource = createSource(
       lc, testLogConfig, 'grandparents',
       {id: {type: 'number'}, name: {type: 'string'}}, ['id'],
@@ -307,10 +341,21 @@ describe('ArrayView: child changes bubble new references up to ancestors', () =>
       system: 'client',
     });
 
-    type GpEntry = {id: number; name: string; parents: Array<{id: number; children: Array<{id: number; text: string}>}>};
+    type ChildEntry = {id: number; pId: number; text: string};
+    type MidEntry = {id: number; gpId: number; name: string; children: ChildEntry[]};
+    type GpEntry = {id: number; name: string; parents: MidEntry[]};
+
     const view = new ArrayView(
       gpJoin,
-      {singular: false, relationships: {parents: {singular: false, relationships: {children: {singular: false, relationships: {}}}}}},
+      {
+        singular: false,
+        relationships: {
+          parents: {
+            singular: false,
+            relationships: {children: {singular: false, relationships: {}}},
+          },
+        },
+      },
       true,
       () => {},
     );
@@ -336,19 +381,80 @@ describe('ArrayView: child changes bubble new references up to ancestors', () =>
 
     const newGp1 = data[0] as GpEntry;
 
-    // Entire ancestor chain gets new references
     expect(data[0]).not.toBe(refGp1);
     expect(newGp1.parents[0]).not.toBe(refP1);
     expect(newGp1.parents[0].children[0]).not.toBe(refC1);
     expect(newGp1.parents[0].children[0]).toEqual(expect.objectContaining({text: 'c1-EDITED'}));
-
-    // Unchanged nodes keep references
     expect(newGp1.parents[0].children[1]).toBe(refC2);
     expect(data[1]).toBe(refGp2);
+  });
+
+  //   parent1 ─── child(.one())       edit child       parent1' ─── child'(.one())
+  //                                     ────────►
+  //   parent1: new ref (singular child changed)
+  //   child:   new ref (edited)
+  test('singular relationship: child edit gives parent a new reference', () => {
+    const parentSource = createSource(
+      lc, testLogConfig, 'parents',
+      {id: {type: 'number'}, name: {type: 'string'}}, ['id'],
+    );
+    const childSource = createSource(
+      lc, testLogConfig, 'children',
+      {id: {type: 'number'}, parentId: {type: 'number'}, text: {type: 'string'}}, ['id'],
+    );
+
+    consume(parentSource.push({type: 'add', row: {id: 1, name: 'parent1'}}));
+    consume(childSource.push({type: 'add', row: {id: 10, parentId: 1, text: 'only-child'}}));
+
+    const join = new Join({
+      parent: parentSource.connect([['id', 'asc']]),
+      child: childSource.connect([['id', 'asc']]),
+      parentKey: ['id'],
+      childKey: ['parentId'],
+      relationshipName: 'child',
+      hidden: false,
+      system: 'client',
+    });
+
+    const view = new ArrayView(
+      join,
+      {
+        singular: false,
+        relationships: {child: {singular: true, relationships: {}}},
+      },
+      true,
+      () => {},
+    );
+
+    type SingularParent = {id: number; name: string; child: ChildRow | undefined};
+
+    let data: unknown[] = [];
+    view.addListener(entries => {
+      assertArray(entries);
+      data = [...entries];
+    });
+
+    const refParent = data[0];
+    const parent = data[0] as SingularParent;
+    const refChild = parent.child;
+    expect(refChild).toEqual(expect.objectContaining({id: 10, text: 'only-child'}));
+
+    consume(childSource.push({
+      type: 'edit',
+      oldRow: {id: 10, parentId: 1, text: 'only-child'},
+      row: {id: 10, parentId: 1, text: 'only-child-EDITED'},
+    }));
+    view.flush();
+
+    const newParent = data[0] as SingularParent;
+    expect(data[0]).not.toBe(refParent);
+    expect(newParent.child).not.toBe(refChild);
+    expect(newParent.child).toEqual(expect.objectContaining({text: 'only-child-EDITED'}));
   });
 });
 
 describe('ArrayView: flush and data behavior', () => {
+  //   push(A), push(B), push(C), push(D), push(E)  -->  flush()  -->  listener fires ONCE
   test('listener fires exactly once per flush, not per push', () => {
     const ms = flatSource([{id: 1, text: 'A'}]);
     const {view} = flatView(ms);
@@ -357,8 +463,8 @@ describe('ArrayView: flush and data behavior', () => {
     view.addListener(() => { callCount++; });
     expect(callCount).toBe(1);
 
-    for (let i = 2; i <= 6; i++) {
-      consume(ms.push({type: 'add', row: {id: i, text: String(i)}}));
+    for (let idx = 2; idx <= 6; idx++) {
+      consume(ms.push({type: 'add', row: {id: idx, text: String(idx)}}));
     }
     expect(callCount).toBe(1);
 
@@ -366,6 +472,7 @@ describe('ArrayView: flush and data behavior', () => {
     expect(callCount).toBe(2);
   });
 
+  //   push(add B)  -->  view.data  -->  [A, B] (no flush needed)
   test('.data reflects changes immediately without flush (no buffering)', () => {
     const ms = flatSource([{id: 1, text: 'A'}]);
     const {view} = flatView(ms);

--- a/packages/zql/src/ivm/array-view-rerender.test.ts
+++ b/packages/zql/src/ivm/array-view-rerender.test.ts
@@ -1,0 +1,390 @@
+import {describe, expect, test} from 'vitest';
+import {testLogConfig} from '../../../otel/src/test-log-config.ts';
+import {assertArray} from '../../../shared/src/asserts.ts';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import {ArrayView} from './array-view.ts';
+import type {Input} from './operator.ts';
+import {Join} from './join.ts';
+import {consume} from './stream.ts';
+import {createSource} from './test/source-factory.ts';
+
+const lc = createSilentLogContext();
+
+// Shared helpers to eliminate boilerplate across tests.
+
+function flatSource(rows: Array<{id: number; text: string}>) {
+  const ms = createSource(
+    lc,
+    testLogConfig,
+    'items',
+    {id: {type: 'number'}, text: {type: 'string'}},
+    ['id'],
+  );
+  for (const row of rows) {
+    consume(ms.push({type: 'add', row}));
+  }
+  return ms;
+}
+
+function flatView(ms: ReturnType<typeof flatSource>) {
+  const view = new ArrayView(
+    ms.connect([['id', 'asc']]),
+    {singular: false, relationships: {}},
+    true,
+    () => {},
+  );
+  let data: unknown[] = [];
+  view.addListener(entries => {
+    assertArray(entries);
+    data = [...entries];
+  });
+  return {view, getData: () => data};
+}
+
+type ChildRow = {id: number; parentId: number; text: string};
+
+function parentChildSources(
+  parents: Array<{id: number; name: string}>,
+  children: ChildRow[],
+) {
+  const parentSource = createSource(
+    lc,
+    testLogConfig,
+    'parents',
+    {id: {type: 'number'}, name: {type: 'string'}},
+    ['id'],
+  );
+  const childSource = createSource(
+    lc,
+    testLogConfig,
+    'children',
+    {id: {type: 'number'}, parentId: {type: 'number'}, text: {type: 'string'}},
+    ['id'],
+  );
+  for (const row of parents) {
+    consume(parentSource.push({type: 'add', row}));
+  }
+  for (const row of children) {
+    consume(childSource.push({type: 'add', row}));
+  }
+  return {parentSource, childSource};
+}
+
+function parentChildJoin(parentInput: Input, childInput: Input) {
+  return new Join({
+    parent: parentInput,
+    child: childInput,
+    parentKey: ['id'],
+    childKey: ['parentId'],
+    relationshipName: 'children',
+    hidden: false,
+    system: 'client',
+  });
+}
+
+function parentChildView(join: Input) {
+  const view = new ArrayView(
+    join,
+    {
+      singular: false,
+      relationships: {children: {singular: false, relationships: {}}},
+    },
+    true,
+    () => {},
+  );
+  type ParentEntry = {
+    id: number;
+    name: string;
+    children: ChildRow[];
+  };
+  let data: unknown[] = [];
+  view.addListener(entries => {
+    assertArray(entries);
+    data = [...entries];
+  });
+  return {view, getData: () => data, asParent: (i: number) => data[i] as ParentEntry};
+}
+
+// ─── Flat list identity ─────────────────────────────────────────────────────
+
+describe('ArrayView: flat list identity preservation', () => {
+  test('edit: unchanged siblings keep reference, edited row gets new reference', () => {
+    const ms = flatSource([
+      {id: 1, text: 'A'},
+      {id: 2, text: 'B'},
+      {id: 3, text: 'C'},
+    ]);
+    const {view, getData} = flatView(ms);
+    const [refA, refB, refC] = getData();
+
+    consume(ms.push({type: 'edit', oldRow: {id: 2, text: 'B'}, row: {id: 2, text: 'B-edited'}}));
+    view.flush();
+
+    expect(getData()[0]).toBe(refA);
+    expect(getData()[1]).not.toBe(refB);
+    expect(getData()[1]).toEqual(expect.objectContaining({id: 2, text: 'B-edited'}));
+    expect(getData()[2]).toBe(refC);
+  });
+
+  test('add: existing rows keep reference', () => {
+    const ms = flatSource([{id: 1, text: 'A'}, {id: 2, text: 'B'}]);
+    const {view, getData} = flatView(ms);
+    const [refA, refB] = getData();
+
+    consume(ms.push({type: 'add', row: {id: 3, text: 'C'}}));
+    view.flush();
+
+    expect(getData()[0]).toBe(refA);
+    expect(getData()[1]).toBe(refB);
+    expect(getData()).toHaveLength(3);
+  });
+
+  test('remove: remaining rows keep reference', () => {
+    const ms = flatSource([
+      {id: 1, text: 'A'},
+      {id: 2, text: 'B'},
+      {id: 3, text: 'C'},
+    ]);
+    const {view, getData} = flatView(ms);
+    const [refA, , refC] = getData();
+
+    consume(ms.push({type: 'remove', row: {id: 2, text: 'B'}}));
+    view.flush();
+
+    expect(getData()).toHaveLength(2);
+    expect(getData()[0]).toBe(refA);
+    expect(getData()[1]).toBe(refC);
+  });
+
+  test('multiple pushes before single flush preserve identity correctly', () => {
+    const ms = flatSource([
+      {id: 1, text: 'A'},
+      {id: 2, text: 'B'},
+      {id: 3, text: 'C'},
+    ]);
+    const {view, getData} = flatView(ms);
+    const [refA, , refC] = getData();
+
+    consume(ms.push({type: 'edit', oldRow: {id: 2, text: 'B'}, row: {id: 2, text: 'B-edited'}}));
+    consume(ms.push({type: 'add', row: {id: 4, text: 'D'}}));
+    view.flush();
+
+    expect(getData()[0]).toBe(refA);
+    expect(getData()[1]).toEqual(expect.objectContaining({id: 2, text: 'B-edited'}));
+    expect(getData()[2]).toBe(refC);
+    expect(getData()).toHaveLength(4);
+  });
+});
+
+// ─── Relationship change propagation ────────────────────────────────────────
+// The immutability optimization preserves identity for UNCHANGED nodes.
+// These tests verify the other direction: when a descendant changes, ancestors
+// MUST get new references so React re-renders them.
+
+describe('ArrayView: child changes bubble new references up to ancestors', () => {
+  test('child edit gives parent a new reference; unrelated parent keeps reference', () => {
+    const {parentSource, childSource} = parentChildSources(
+      [{id: 1, name: 'parent1'}, {id: 2, name: 'parent2'}],
+      [
+        {id: 10, parentId: 1, text: 'child1'},
+        {id: 11, parentId: 1, text: 'child2'},
+        {id: 12, parentId: 2, text: 'child3'},
+      ],
+    );
+    const join = parentChildJoin(
+      parentSource.connect([['id', 'asc']]),
+      childSource.connect([['id', 'asc']]),
+    );
+    const {view, getData, asParent} = parentChildView(join);
+
+    const refParent1 = getData()[0];
+    const refParent2 = getData()[1];
+    const refChild1 = asParent(0).children[0];
+    const refChild2 = asParent(0).children[1];
+    const refChild3 = asParent(1).children[0];
+    const refChildrenArray = asParent(0).children;
+
+    consume(childSource.push({
+      type: 'edit',
+      oldRow: {id: 10, parentId: 1, text: 'child1'},
+      row: {id: 10, parentId: 1, text: 'child1-edited'},
+    }));
+    view.flush();
+
+    // Parent1 MUST have new ref (descendant changed)
+    expect(getData()[0]).not.toBe(refParent1);
+    // Children array MUST have new ref
+    expect(asParent(0).children).not.toBe(refChildrenArray);
+    // Edited child MUST have new ref
+    expect(asParent(0).children[0]).not.toBe(refChild1);
+    expect(asParent(0).children[0]).toEqual(
+      expect.objectContaining({id: 10, text: 'child1-edited'}),
+    );
+
+    // Unchanged sibling child keeps ref
+    expect(asParent(0).children[1]).toBe(refChild2);
+    // Unrelated parent2 keeps ref
+    expect(getData()[1]).toBe(refParent2);
+    // Unrelated child3 keeps ref
+    expect(asParent(1).children[0]).toBe(refChild3);
+  });
+
+  test('child add gives parent a new reference; existing children keep reference', () => {
+    const {parentSource, childSource} = parentChildSources(
+      [{id: 1, name: 'parent1'}],
+      [{id: 10, parentId: 1, text: 'child1'}],
+    );
+    const join = parentChildJoin(
+      parentSource.connect([['id', 'asc']]),
+      childSource.connect([['id', 'asc']]),
+    );
+    const {view, getData, asParent} = parentChildView(join);
+
+    const refParent = getData()[0];
+    const refChild1 = asParent(0).children[0];
+
+    consume(childSource.push({type: 'add', row: {id: 11, parentId: 1, text: 'child2'}}));
+    view.flush();
+
+    expect(getData()[0]).not.toBe(refParent);
+    expect(asParent(0).children).toHaveLength(2);
+    expect(asParent(0).children[0]).toBe(refChild1);
+  });
+
+  test('child remove gives parent a new reference; remaining children keep reference', () => {
+    const {parentSource, childSource} = parentChildSources(
+      [{id: 1, name: 'parent1'}],
+      [
+        {id: 10, parentId: 1, text: 'child1'},
+        {id: 11, parentId: 1, text: 'child2'},
+      ],
+    );
+    const join = parentChildJoin(
+      parentSource.connect([['id', 'asc']]),
+      childSource.connect([['id', 'asc']]),
+    );
+    const {view, getData, asParent} = parentChildView(join);
+
+    const refParent = getData()[0];
+    const refChild2 = asParent(0).children[1];
+
+    consume(childSource.push({type: 'remove', row: {id: 10, parentId: 1, text: 'child1'}}));
+    view.flush();
+
+    expect(getData()[0]).not.toBe(refParent);
+    expect(asParent(0).children).toHaveLength(1);
+    expect(asParent(0).children[0]).toBe(refChild2);
+  });
+
+  test('grandchild edit bubbles new reference through all 3 levels', () => {
+    // grandparent → parent → child (3-level chained Join)
+    const gpSource = createSource(
+      lc, testLogConfig, 'grandparents',
+      {id: {type: 'number'}, name: {type: 'string'}}, ['id'],
+    );
+    const pSource = createSource(
+      lc, testLogConfig, 'parents',
+      {id: {type: 'number'}, gpId: {type: 'number'}, name: {type: 'string'}}, ['id'],
+    );
+    const cSource = createSource(
+      lc, testLogConfig, 'children',
+      {id: {type: 'number'}, pId: {type: 'number'}, text: {type: 'string'}}, ['id'],
+    );
+
+    consume(gpSource.push({type: 'add', row: {id: 1, name: 'gp1'}}));
+    consume(gpSource.push({type: 'add', row: {id: 2, name: 'gp2'}}));
+    consume(pSource.push({type: 'add', row: {id: 10, gpId: 1, name: 'p1'}}));
+    consume(cSource.push({type: 'add', row: {id: 100, pId: 10, text: 'c1'}}));
+    consume(cSource.push({type: 'add', row: {id: 101, pId: 10, text: 'c2'}}));
+
+    const pcJoin = new Join({
+      parent: pSource.connect([['id', 'asc']]),
+      child: cSource.connect([['id', 'asc']]),
+      parentKey: ['id'],
+      childKey: ['pId'],
+      relationshipName: 'children',
+      hidden: false,
+      system: 'client',
+    });
+    const gpJoin = new Join({
+      parent: gpSource.connect([['id', 'asc']]),
+      child: pcJoin,
+      parentKey: ['id'],
+      childKey: ['gpId'],
+      relationshipName: 'parents',
+      hidden: false,
+      system: 'client',
+    });
+
+    type GpEntry = {id: number; name: string; parents: Array<{id: number; children: Array<{id: number; text: string}>}>};
+    const view = new ArrayView(
+      gpJoin,
+      {singular: false, relationships: {parents: {singular: false, relationships: {children: {singular: false, relationships: {}}}}}},
+      true,
+      () => {},
+    );
+    let data: unknown[] = [];
+    view.addListener(entries => {
+      assertArray(entries);
+      data = [...entries];
+    });
+
+    const refGp1 = data[0];
+    const refGp2 = data[1];
+    const gp1 = data[0] as GpEntry;
+    const refP1 = gp1.parents[0];
+    const refC1 = gp1.parents[0].children[0];
+    const refC2 = gp1.parents[0].children[1];
+
+    consume(cSource.push({
+      type: 'edit',
+      oldRow: {id: 100, pId: 10, text: 'c1'},
+      row: {id: 100, pId: 10, text: 'c1-EDITED'},
+    }));
+    view.flush();
+
+    const newGp1 = data[0] as GpEntry;
+
+    // Entire ancestor chain gets new references
+    expect(data[0]).not.toBe(refGp1);
+    expect(newGp1.parents[0]).not.toBe(refP1);
+    expect(newGp1.parents[0].children[0]).not.toBe(refC1);
+    expect(newGp1.parents[0].children[0]).toEqual(expect.objectContaining({text: 'c1-EDITED'}));
+
+    // Unchanged nodes keep references
+    expect(newGp1.parents[0].children[1]).toBe(refC2);
+    expect(data[1]).toBe(refGp2);
+  });
+});
+
+// ─── ArrayView behavior ─────────────────────────────────────────────────────
+
+describe('ArrayView: flush and data behavior', () => {
+  test('listener fires exactly once per flush, not per push', () => {
+    const ms = flatSource([{id: 1, text: 'A'}]);
+    const {view} = flatView(ms);
+
+    let callCount = 0;
+    view.addListener(() => { callCount++; });
+    expect(callCount).toBe(1);
+
+    for (let i = 2; i <= 6; i++) {
+      consume(ms.push({type: 'add', row: {id: i, text: String(i)}}));
+    }
+    expect(callCount).toBe(1);
+
+    view.flush();
+    expect(callCount).toBe(2);
+  });
+
+  test('.data reflects changes immediately without flush (no buffering)', () => {
+    const ms = flatSource([{id: 1, text: 'A'}]);
+    const {view} = flatView(ms);
+
+    consume(ms.push({type: 'add', row: {id: 2, text: 'B'}}));
+
+    assertArray(view.data);
+    expect(view.data).toHaveLength(2);
+    expect(view.data[1]).toEqual(expect.objectContaining({id: 2, text: 'B'}));
+  });
+});

--- a/packages/zql/src/ivm/array-view-rerender.test.ts
+++ b/packages/zql/src/ivm/array-view-rerender.test.ts
@@ -10,8 +10,6 @@ import {createSource} from './test/source-factory.ts';
 
 const lc = createSilentLogContext();
 
-// Shared helpers to eliminate boilerplate across tests.
-
 function flatSource(rows: Array<{id: number; text: string}>) {
   const ms = createSource(
     lc,
@@ -105,8 +103,6 @@ function parentChildView(join: Input) {
   return {view, getData: () => data, asParent: (i: number) => data[i] as ParentEntry};
 }
 
-// ─── Flat list identity ─────────────────────────────────────────────────────
-
 describe('ArrayView: flat list identity preservation', () => {
   test('edit: unchanged siblings keep reference, edited row gets new reference', () => {
     const ms = flatSource([
@@ -175,11 +171,6 @@ describe('ArrayView: flat list identity preservation', () => {
     expect(getData()).toHaveLength(4);
   });
 });
-
-// ─── Relationship change propagation ────────────────────────────────────────
-// The immutability optimization preserves identity for UNCHANGED nodes.
-// These tests verify the other direction: when a descendant changes, ancestors
-// MUST get new references so React re-renders them.
 
 describe('ArrayView: child changes bubble new references up to ancestors', () => {
   test('child edit gives parent a new reference; unrelated parent keeps reference', () => {
@@ -356,8 +347,6 @@ describe('ArrayView: child changes bubble new references up to ancestors', () =>
     expect(data[1]).toBe(refGp2);
   });
 });
-
-// ─── ArrayView behavior ─────────────────────────────────────────────────────
 
 describe('ArrayView: flush and data behavior', () => {
   test('listener fires exactly once per flush, not per push', () => {


### PR DESCRIPTION
## Summary

Adds tests verifying that the immutable `applyChange` pipeline preserves object identity for unchanged nodes (enabling `React.memo`) while correctly bubbling new references up for changed descendants.

**6 of these tests fail on `main`. This is intentional.** They document a regression introduced by `expandNode` in the change buffering PR. PR #5605 fixes all failures by removing `expandNode`. **Merge both PRs together.**

## Test results on `main`

### :red_circle: Failing: identity broken by `expandNode` eager materialization

`expandNode` recursively calls `Array.from(skipYields(thunk()), expandNode)` on every relationship, creating **new objects for every node in the tree** on every push. This destroys reference identity for all relationship data, meaning `React.memo` can never skip re-renders for components receiving rows with relationships.

| Test | Failure |
|---|---|
| flat edit: sibling identity | `expandNode` allocates new objects for all nodes, not just the edited one |
| child edit bubbles to parent | Eager expansion breaks the identity chain: parent, children array, and sibling child all get new refs when they shouldn't |
| child add bubbles to parent | Same: expansion allocates new relationship arrays |
| child remove bubbles to parent | Same |
| grandchild edit bubbles 3 levels | Same: entire tree gets new objects regardless of what changed |
| singular relationship: child edit | Same: `.one()` relationship child gets new ref from expansion |

### :green_circle: Passing: no relationship expansion involved

| Test | What it verifies |
|---|---|
| flat add: existing rows keep reference | No relationships, so `expandNode` doesn't interfere |
| flat remove: remaining rows keep reference | Same |
| multiple pushes before flush | Flat list only |
| listener fires once per flush | Behavioral, not identity |
| .data reflects changes immediately | Behavioral |

### :green_circle: Passing: React layer (ViewWrapper, not ArrayView)

These use mock views, so they test the `ViewWrapper`/`useSyncExternalStore` contract independently of the IVM pipeline.

| Test | What it verifies |
|---|---|
| getSnapshot returns same ref without changes | `useSyncExternalStore` contract: no spurious re-renders |
| empty snapshots use sentinel objects | Predefined empty tuples prevent re-renders from new empty arrays |
| row identity preserved in snapshot | ViewWrapper passes through row references from the view |
| snapshot never goes empty between updates | No data flash between successive data pushes |
| stale snapshot preserved after destroy | No empty flash on strict mode remount |
| legitimate empty transition is visible | Server genuinely returns empty then data: transition is not masked |
| React.memo: only changed row re-renders (mock) | Parent re-renders, unchanged `React.memo` child skips |

### :green_circle: Passing: end-to-end integration (real IVM to React.memo)

Uses `QueryDelegateImpl` with the test schema (`issue` → `owner`, `comments`) to build a real `Source` → `Join` → `ArrayView` pipeline, wires it directly to `useSyncExternalStore`, renders `React.memo` components, then edits a comment and verifies only the affected issue's component re-renders.

```
issue1 ─── owner:Alice        edit comment1       issue1' ─── owner:Alice (same ref)
        ├── comment1            ──────────►               ├── comment1' (new ref)
        └── comment2                                      └── comment2 (same ref)
issue2 ─── owner:Bob                               issue2 (same ref, unrelated)
        └── comment3                                     └── comment3 (same ref)

<IssueRow issue={issue1}>  re-renders (descendant changed)
<IssueRow issue={issue2}>  skips (React.memo, same ref)
```

| Test | What it verifies |
|---|---|
| editing a comment only re-renders the parent issue | Full chain: Source push → ArrayView applyChange → identity preservation → useSyncExternalStore → React.memo skip for unrelated rows |

## Test plan

- [x] All 30 tests pass on `fix/remove-eager-expand-node` branch (#5605)
- [x] 6 tests correctly fail on `main` (documenting the regression)
- [x] Existing `array-view.test.ts` and `view-apply-change.test.ts` still pass