### PR TITLE
feat: export astToZQL from @rocicorp/zero/ast-to-zql

### DIFF
--- a/packages/zero/package.json
+++ b/packages/zero/package.json
@@ -118,6 +118,10 @@
       "types": "./out/zero/src/zero.d.ts",
       "default": "./out/zero/src/zero.js"
     },
+    "./ast-to-zql": {
+      "types": "./out/ast-to-zql/src/ast-to-zql.d.ts",
+      "default": "./out/ast-to-zql/src/ast-to-zql.js"
+    },
     "./bindings": {
       "types": "./out/zero/src/bindings.d.ts",
       "default": "./out/zero/src/bindings.js"


### PR DESCRIPTION
## Summary

Adds `./ast-to-zql` to the `@rocicorp/zero` package `exports` map so consumers can import the `astToZQL` function directly:

```typescript
import { astToZQL } from "@rocicorp/zero/ast-to-zql";
```

## Motivation

We're building query plan regression tests that:
1. Extract the AST from actual ZQL query definitions via the `.ast` getter
2. Serialize the AST back to a ZQL string using `astToZQL`
3. Pass it to `analyze-query --query` to verify no table scans, proper index usage, etc.

This keeps our tests automatically in sync with our real query definitions — if a query changes, the test reflects it without manual string updates.

Currently we have to use a dynamic import hack to access the function since it's not in the `exports` map:

```typescript
const _require = createRequire(import.meta.url);
const zeroMainPath = _require.resolve("@rocicorp/zero");
const astToZqlModulePath = zeroMainPath.replace(
  /out\/zero\/src\/zero\.js$/,
  "out/ast-to-zql/src/ast-to-zql.js",
);
const _astToZqlModule = await import(astToZqlModulePath);
```

## Change

One-liner addition to `packages/zero/package.json` exports, following the existing `{ types, default }` pattern:

```json
"./ast-to-zql": {
  "types": "./out/ast-to-zql/src/ast-to-zql.d.ts",
  "default": "./out/ast-to-zql/src/ast-to-zql.js"
}
```

No new code — just exposing an existing internal module.