### PR TITLE
perf(zql): fix V8 deopt in compareValues and compareBounds 

### DIFF
--- a/packages/shared/src/btree-set.bench.ts
+++ b/packages/shared/src/btree-set.bench.ts
@@ -105,3 +105,57 @@ describe('BTreeSet iterator next() in isolation', () => {
     use(sum);
   });
 });
+
+// Lookup and mutation benchmarks exercise internal node traversal,
+// triggering the BNode vs BNodeInternal shape polymorphism.
+describe('BTreeSet lookups', () => {
+  bench('has() hit', () => {
+    // Spread across the tree to exercise multiple internal nodes
+    use(tree.has(100));
+    use(tree.has(500));
+    use(tree.has(900));
+  });
+
+  bench('has() miss', () => {
+    use(tree.has(NUM_ENTRIES + 1));
+    use(tree.has(NUM_ENTRIES + 2));
+    use(tree.has(NUM_ENTRIES + 3));
+  });
+
+  bench('get() hit', () => {
+    use(tree.get(100));
+    use(tree.get(500));
+    use(tree.get(900));
+  });
+});
+
+describe('BTreeSet mutations', () => {
+  bench('add() then delete() single key', function* () {
+    // Setup: clone the tree so we don't corrupt the shared tree
+    const t = tree.clone();
+    yield () => {
+      t.add(NUM_ENTRIES + 1);
+      t.delete(NUM_ENTRIES + 1);
+    };
+  });
+
+  bench('add() 100 sequential keys', function* () {
+    yield () => {
+      const t = new BTreeSet<number>(numericComparator);
+      for (let i = 0; i < 100; i++) {
+        t.add(i);
+      }
+      use(t.size);
+    };
+  });
+
+  bench('add() 1000 sequential keys', function* () {
+    yield () => {
+      const t = new BTreeSet<number>(numericComparator);
+      for (let i = 0; i < NUM_ENTRIES; i++) {
+        t.add(i);
+      }
+      use(t.size);
+    };
+  });
+});

--- a/packages/zql-benchmarks/package.json
+++ b/packages/zql-benchmarks/package.json
@@ -14,6 +14,7 @@
     "test": "vitest run --silent=false --disable-console-intercept",
     "test:watch": "vitest watch",
     "bench": "vitest run --config vitest.config.bench.ts",
+    "bench:deopt": "vitest run --config vitest.config.bench.ts --execArgv=--trace-deopt",
     "bench:bmf": "BENCH_OUTPUT_FORMAT=json npm run bench 2>&1 | npx tsx ../shared/src/tool/mitata-json-to-bmf.ts",
     "bench:bmf:silent": "npm run bench:bmf --silent",
     "test-types": "vitest run --typecheck.only --no-browser.enabled",

--- a/packages/zql-benchmarks/src/memory-ivm-deopt.bench.ts
+++ b/packages/zql-benchmarks/src/memory-ivm-deopt.bench.ts
@@ -1,0 +1,397 @@
+/**
+ * In-memory ZQL IVM benchmarks for hot-path deopt analysis.
+ * Does NOT require postgres or SQLite - uses MemorySource only.
+ *
+ * Run:
+ *   npm --workspace=zql-benchmarks run bench -- memory-ivm-deopt
+ *
+ * Run with deopt tracing:
+ *   NODE_OPTIONS=--trace-deopt \
+ *     npm --workspace=zql-benchmarks run bench -- memory-ivm-deopt \
+ *     2>/tmp/deopt.log
+ *   grep '\[deopt' /tmp/deopt.log | grep -v node_modules | sort | uniq -c | sort -rn
+ */
+
+import {bench, describe} from '../../shared/src/bench.ts';
+import type {Row} from '../../zero-protocol/src/data.ts';
+import type {BuilderDelegate} from '../../zql/src/builder/builder.ts';
+import {Catch} from '../../zql/src/ivm/catch.ts';
+import {compareValues} from '../../zql/src/ivm/data.ts';
+import {buildFilterPipeline} from '../../zql/src/ivm/filter-operators.ts';
+import {Filter} from '../../zql/src/ivm/filter.ts';
+import {Join} from '../../zql/src/ivm/join.ts';
+import {MemorySource} from '../../zql/src/ivm/memory-source.ts';
+
+const noopDelegate = {addEdge() {}} as unknown as BuilderDelegate;
+
+// ---- Schema definitions ----
+
+const issueColumns = {
+  id: {type: 'string'} as const,
+  title: {type: 'string'} as const,
+  closed: {type: 'boolean'} as const,
+  ownerId: {type: 'string', optional: true} as const,
+  createdAt: {type: 'number'} as const,
+};
+
+const userColumns = {
+  id: {type: 'string'} as const,
+  name: {type: 'string'} as const,
+};
+
+// ---- Row generators ----
+
+function makeIssueRow(i: number): Row {
+  return {
+    id: `issue-${i}`,
+    title: `Issue ${i}`,
+    closed: i % 3 === 0,
+    ownerId: i % 5 === 0 ? null : `user-${i % 20}`,
+    createdAt: 1_000_000 + i,
+  };
+}
+
+function makeUserRow(i: number): Row {
+  return {id: `user-${i}`, name: `User ${i}`};
+}
+
+const ISSUE_COUNT = 1000;
+const USER_COUNT = 20;
+
+// ---- compareValues (hot path, deopt risk from polymorphism) ----
+
+describe('compareValues', () => {
+  const strs = ['apple', 'banana', 'cherry', 'date', 'elderberry'];
+  const nums = [1, 2, 3, 4, 5];
+
+  bench('compareValues(string, string)', () => {
+    for (let i = 0; i < strs.length; i++) {
+      for (let j = 0; j < strs.length; j++) {
+        compareValues(strs[i], strs[j]);
+      }
+    }
+  });
+
+  bench('compareValues(number, number)', () => {
+    for (let i = 0; i < nums.length; i++) {
+      for (let j = 0; j < nums.length; j++) {
+        compareValues(nums[i], nums[j]);
+      }
+    }
+  });
+
+  // Mixed types through the same call site — classic deopt trigger.
+  bench('compareValues(mixed: string/number/bool/null)', () => {
+    compareValues('a', 'b');
+    compareValues(1, 2);
+    compareValues(true, false);
+    compareValues(null, null);
+  });
+});
+
+// ---- MemorySource fetch ----
+
+describe('MemorySource fetch', () => {
+  bench(`scan ${ISSUE_COUNT} rows`, function* () {
+    const src = new MemorySource('issue', issueColumns, ['id']);
+    for (let i = 0; i < ISSUE_COUNT; i++) {
+      for (const _ of src.push({type: 'add', row: makeIssueRow(i)})) {
+        /* consume */
+      }
+    }
+    const conn = src.connect([
+      ['createdAt', 'asc'],
+      ['id', 'asc'],
+    ]);
+    const out = new Catch(conn);
+
+    yield () => {
+      out.fetch();
+    };
+  });
+});
+
+// ---- MemorySource push ----
+
+describe('MemorySource push', () => {
+  bench(`add/remove over ${ISSUE_COUNT} rows`, function* () {
+    const src = new MemorySource('issue', issueColumns, ['id']);
+    for (let i = 0; i < ISSUE_COUNT; i++) {
+      for (const _ of src.push({type: 'add', row: makeIssueRow(i)})) {
+        /* consume */
+      }
+    }
+    const conn = src.connect([
+      ['createdAt', 'asc'],
+      ['id', 'asc'],
+    ]);
+    new Catch(conn);
+
+    let idx = ISSUE_COUNT;
+    yield () => {
+      const row = makeIssueRow(idx++);
+      for (const _ of src.push({type: 'add', row})) {
+        /* consume */
+      }
+      for (const _ of src.push({type: 'remove', row})) {
+        /* consume */
+      }
+    };
+  });
+
+  bench(`edit over ${ISSUE_COUNT} rows`, function* () {
+    const src = new MemorySource('issue', issueColumns, ['id']);
+    const rows: Row[] = [];
+    for (let i = 0; i < ISSUE_COUNT; i++) {
+      const row = makeIssueRow(i);
+      rows.push(row);
+      for (const _ of src.push({type: 'add', row})) {
+        /* consume */
+      }
+    }
+    const conn = src.connect([
+      ['createdAt', 'asc'],
+      ['id', 'asc'],
+    ]);
+    new Catch(conn);
+
+    let idx = 0;
+    yield () => {
+      const oldRow = rows[idx % rows.length];
+      idx++;
+      const newRow = {...oldRow, title: `Updated ${idx}`};
+      for (const _ of src.push({type: 'edit', oldRow, row: newRow})) {
+        /* consume */
+      }
+      for (const _ of src.push({type: 'edit', oldRow: newRow, row: oldRow})) {
+        /* consume */
+      }
+    };
+  });
+});
+
+// ---- Filter ----
+
+describe('Filter', () => {
+  bench(`fetch open issues (${ISSUE_COUNT} total)`, function* () {
+    const src = new MemorySource('issue', issueColumns, ['id']);
+    for (let i = 0; i < ISSUE_COUNT; i++) {
+      for (const _ of src.push({type: 'add', row: makeIssueRow(i)})) {
+        /* consume */
+      }
+    }
+    const conn = src.connect([
+      ['createdAt', 'asc'],
+      ['id', 'asc'],
+    ]);
+    const filtered = buildFilterPipeline(
+      conn,
+      noopDelegate,
+      input => new Filter(input, row => row['closed'] === false),
+    );
+    const out = new Catch(filtered);
+
+    yield () => {
+      out.fetch();
+    };
+  });
+
+  bench('push add open issue (passes filter)', function* () {
+    const src = new MemorySource('issue', issueColumns, ['id']);
+    for (let i = 0; i < ISSUE_COUNT; i++) {
+      for (const _ of src.push({type: 'add', row: makeIssueRow(i)})) {
+        /* consume */
+      }
+    }
+    const conn = src.connect([
+      ['createdAt', 'asc'],
+      ['id', 'asc'],
+    ]);
+    const filtered = buildFilterPipeline(
+      conn,
+      noopDelegate,
+      input => new Filter(input, row => row['closed'] === false),
+    );
+    new Catch(filtered);
+
+    let idx = ISSUE_COUNT;
+    yield () => {
+      const row = makeIssueRow(idx++);
+      (row as Record<string, unknown>)['closed'] = false;
+      for (const _ of src.push({type: 'add', row})) {
+        /* consume */
+      }
+      for (const _ of src.push({type: 'remove', row})) {
+        /* consume */
+      }
+    };
+  });
+
+  bench('push add closed issue (filtered out)', function* () {
+    const src = new MemorySource('issue', issueColumns, ['id']);
+    for (let i = 0; i < ISSUE_COUNT; i++) {
+      for (const _ of src.push({type: 'add', row: makeIssueRow(i)})) {
+        /* consume */
+      }
+    }
+    const conn = src.connect([
+      ['createdAt', 'asc'],
+      ['id', 'asc'],
+    ]);
+    const filtered = buildFilterPipeline(
+      conn,
+      noopDelegate,
+      input => new Filter(input, row => row['closed'] === false),
+    );
+    new Catch(filtered);
+
+    let idx = ISSUE_COUNT;
+    yield () => {
+      const row = makeIssueRow(idx++);
+      (row as Record<string, unknown>)['closed'] = true;
+      for (const _ of src.push({type: 'add', row})) {
+        /* consume */
+      }
+      for (const _ of src.push({type: 'remove', row})) {
+        /* consume */
+      }
+    };
+  });
+});
+
+// ---- Join ----
+
+describe('Join', () => {
+  bench(`fetch ${ISSUE_COUNT} issues → ${USER_COUNT} users`, function* () {
+    const issueSrc = new MemorySource('issue', issueColumns, ['id']);
+    const userSrc = new MemorySource('user', userColumns, ['id']);
+
+    for (let i = 0; i < USER_COUNT; i++) {
+      for (const _ of userSrc.push({type: 'add', row: makeUserRow(i)})) {
+        /* consume */
+      }
+    }
+    for (let i = 0; i < ISSUE_COUNT; i++) {
+      for (const _ of issueSrc.push({type: 'add', row: makeIssueRow(i)})) {
+        /* consume */
+      }
+    }
+
+    const issueConn = issueSrc.connect([
+      ['createdAt', 'asc'],
+      ['id', 'asc'],
+    ]);
+    const userConn = userSrc.connect([['id', 'asc']]);
+    const join = new Join({
+      parent: issueConn,
+      child: userConn,
+      parentKey: ['ownerId'],
+      childKey: ['id'],
+      relationshipName: 'owner',
+      hidden: false,
+      system: 'client',
+    });
+    const out = new Catch(join);
+
+    yield () => {
+      out.fetch();
+    };
+  });
+
+  bench('push add/remove issue with owner', function* () {
+    const issueSrc = new MemorySource('issue', issueColumns, ['id']);
+    const userSrc = new MemorySource('user', userColumns, ['id']);
+
+    for (let i = 0; i < USER_COUNT; i++) {
+      for (const _ of userSrc.push({type: 'add', row: makeUserRow(i)})) {
+        /* consume */
+      }
+    }
+    for (let i = 0; i < ISSUE_COUNT; i++) {
+      for (const _ of issueSrc.push({type: 'add', row: makeIssueRow(i)})) {
+        /* consume */
+      }
+    }
+
+    const issueConn = issueSrc.connect([
+      ['createdAt', 'asc'],
+      ['id', 'asc'],
+    ]);
+    const userConn = userSrc.connect([['id', 'asc']]);
+    const join = new Join({
+      parent: issueConn,
+      child: userConn,
+      parentKey: ['ownerId'],
+      childKey: ['id'],
+      relationshipName: 'owner',
+      hidden: false,
+      system: 'client',
+    });
+    new Catch(join);
+    join.fetch({});
+
+    let idx = ISSUE_COUNT;
+    yield () => {
+      const row = makeIssueRow(idx++);
+      for (const _ of issueSrc.push({type: 'add', row})) {
+        /* consume */
+      }
+      for (const _ of issueSrc.push({type: 'remove', row})) {
+        /* consume */
+      }
+    };
+  });
+
+  bench('push edit issue title (non-key field)', function* () {
+    const issueSrc = new MemorySource('issue', issueColumns, ['id']);
+    const userSrc = new MemorySource('user', userColumns, ['id']);
+
+    for (let i = 0; i < USER_COUNT; i++) {
+      for (const _ of userSrc.push({type: 'add', row: makeUserRow(i)})) {
+        /* consume */
+      }
+    }
+    const issueRows: Row[] = [];
+    for (let i = 0; i < ISSUE_COUNT; i++) {
+      const row = makeIssueRow(i);
+      issueRows.push(row);
+      for (const _ of issueSrc.push({type: 'add', row})) {
+        /* consume */
+      }
+    }
+
+    const issueConn = issueSrc.connect([
+      ['createdAt', 'asc'],
+      ['id', 'asc'],
+    ]);
+    const userConn = userSrc.connect([['id', 'asc']]);
+    const join = new Join({
+      parent: issueConn,
+      child: userConn,
+      parentKey: ['ownerId'],
+      childKey: ['id'],
+      relationshipName: 'owner',
+      hidden: false,
+      system: 'client',
+    });
+    new Catch(join);
+    join.fetch({});
+
+    let idx = 0;
+    yield () => {
+      const oldRow = issueRows[idx % issueRows.length];
+      idx++;
+      const newRow = {...oldRow, title: `Updated ${idx}`};
+      for (const _ of issueSrc.push({type: 'edit', oldRow, row: newRow})) {
+        /* consume */
+      }
+      for (const _ of issueSrc.push({
+        type: 'edit',
+        oldRow: newRow,
+        row: oldRow,
+      })) {
+        /* consume */
+      }
+    };
+  });
+});

--- a/packages/zql-benchmarks/src/memory-ivm-deopt.bench.ts
+++ b/packages/zql-benchmarks/src/memory-ivm-deopt.bench.ts
@@ -5,11 +5,8 @@
  * Run:
  *   npm --workspace=zql-benchmarks run bench -- memory-ivm-deopt
  *
- * Run with deopt tracing:
- *   NODE_OPTIONS=--trace-deopt \
- *     npm --workspace=zql-benchmarks run bench -- memory-ivm-deopt \
- *     2>/tmp/deopt.log
- *   grep '\[deopt' /tmp/deopt.log | grep -v node_modules | sort | uniq -c | sort -rn
+ * Run with deopt tracing (output goes to stderr inline):
+ *   npm --workspace=zql-benchmarks run bench:deopt -- memory-ivm-deopt
  */
 
 import {bench, describe} from '../../shared/src/bench.ts';

--- a/packages/zql/src/ivm/data.test.ts
+++ b/packages/zql/src/ivm/data.test.ts
@@ -57,7 +57,9 @@ test('compareValues', () => {
       fc.boolean(),
       fc.oneof(fc.double(), fc.fullUnicodeString()),
       (b, v) => {
-        expect(() => compareValues(b, v)).toThrow('expected boolean');
+        expect(() => compareValues(b, v)).toThrow(
+          /Cannot compare values of different types: boolean and (number|string)/,
+        );
       },
     ),
   );
@@ -79,7 +81,9 @@ test('compareValues', () => {
       fc.double(),
       fc.oneof(fc.boolean(), fc.fullUnicodeString()),
       (n, v) => {
-        expect(() => compareValues(n, v)).toThrow('expected number');
+        expect(() => compareValues(n, v)).toThrow(
+          /Cannot compare values of different types: number and (boolean|string)/,
+        );
       },
     ),
   );
@@ -95,7 +99,9 @@ test('compareValues', () => {
       fc.fullUnicodeString(),
       fc.oneof(fc.boolean(), fc.double()),
       (s, v) => {
-        expect(() => compareValues(s, v)).toThrow('expected string');
+        expect(() => compareValues(s, v)).toThrow(
+          /Cannot compare values of different types: string and (boolean|number)/,
+        );
       },
     ),
   );

--- a/packages/zql/src/ivm/data.ts
+++ b/packages/zql/src/ivm/data.ts
@@ -1,9 +1,4 @@
 import {compareUTF8} from 'compare-utf8';
-import {
-  assertBoolean,
-  assertNumber,
-  assertString,
-} from '../../../shared/src/asserts.ts';
 import type {Ordering} from '../../../zero-protocol/src/ast.ts';
 import type {Row, Value} from '../../../zero-protocol/src/data.ts';
 import type {Stream} from './stream.ts';
@@ -35,28 +30,14 @@ export type Node = {
  * @returns < 0 if a < b, 0 if a === b, > 0 if a > b
  */
 export function compareValues(a: Value, b: Value): number {
-  a = normalizeUndefined(a);
-  b = normalizeUndefined(b);
+  a = a ?? null;
+  b = b ?? null;
 
   if (a === b) {
     return 0;
   }
-  if (a === null) {
-    return -1;
-  }
-  if (b === null) {
-    return 1;
-  }
-  if (typeof a === 'boolean') {
-    assertBoolean(b);
-    return a ? 1 : -1;
-  }
-  if (typeof a === 'number') {
-    assertNumber(b);
-    return a - b;
-  }
-  if (typeof a === 'string') {
-    assertString(b);
+
+  if (typeof a === 'string' && typeof b === 'string') {
     // We compare all strings in Zero as UTF-8. This is the default on SQLite
     // and we need to match it. See:
     // https://blog.replicache.dev/blog/replicache-11-adventures-in-text-encoding.
@@ -66,6 +47,29 @@ export function compareValues(a: Value, b: Value): number {
     //
     // https://www.sqlite.org/c3ref/create_collation.html
     return compareUTF8(a, b);
+  }
+
+  if (typeof a === 'number' && typeof b === 'number') {
+    return a - b;
+  }
+
+  if (typeof a === 'boolean' && typeof b === 'boolean') {
+    return a ? 1 : -1;
+  }
+
+  if (typeof a !== typeof b) {
+    throw new Error(
+      `Cannot compare values of different types: ${typeof a} and ${typeof b}`,
+    );
+  }
+
+  // check with null after since it is less likely to be the common case and we
+  // want to avoid the extra checks in that case
+  if (a === null) {
+    return -1;
+  }
+  if (b === null) {
+    return 1;
   }
   throw new Error(`Unsupported type: ${a}`);
 }

--- a/packages/zql/src/ivm/data.ts
+++ b/packages/zql/src/ivm/data.ts
@@ -57,12 +57,6 @@ export function compareValues(a: Value, b: Value): number {
     return a ? 1 : -1;
   }
 
-  if (typeof a !== typeof b) {
-    throw new Error(
-      `Cannot compare values of different types: ${typeof a} and ${typeof b}`,
-    );
-  }
-
   // check with null after since it is less likely to be the common case and we
   // want to avoid the extra checks in that case
   if (a === null) {
@@ -71,6 +65,13 @@ export function compareValues(a: Value, b: Value): number {
   if (b === null) {
     return 1;
   }
+
+  if (typeof a !== typeof b) {
+    throw new Error(
+      `Cannot compare values of different types: ${typeof a} and ${typeof b}`,
+    );
+  }
+
   throw new Error(`Unsupported type: ${a}`);
 }
 

--- a/packages/zql/src/ivm/memory-source.ts
+++ b/packages/zql/src/ivm/memory-source.ts
@@ -872,17 +872,15 @@ function compareBounds(a: Bound, b: Bound): number {
   if (a === b) {
     return 0;
   }
-  if (a === minValue) {
-    return -1;
+  // Use typeof to guard the Symbol sentinel checks first. This gives V8 a
+  // clear type discriminant so the common non-symbol path compiles as a
+  // specialised numeric/string fast-path without a Smi deopt when the
+  // minValue/maxValue sentinel symbols appear.
+  if (typeof a === 'symbol') {
+    return a === minValue ? -1 : 1;
   }
-  if (b === minValue) {
-    return 1;
-  }
-  if (a === maxValue) {
-    return 1;
-  }
-  if (b === maxValue) {
-    return -1;
+  if (typeof b === 'symbol') {
+    return b === minValue ? 1 : -1;
   }
   return compareValues(a, b);
 }

--- a/packages/zql/src/ivm/test/compare-rows-test.ts
+++ b/packages/zql/src/ivm/test/compare-rows-test.ts
@@ -75,7 +75,7 @@ export function compareRowsTest(
       order: [['a', 'asc']],
       r1: {a: 1},
       r2: {a: 'foo'},
-      expected: 'expected number',
+      expected: 'Cannot compare values of different types: number and string',
     },
   ];
 


### PR DESCRIPTION
## Problem

Running the IVM hot path under Node's `--trace-deopt` flag revealed two
deopt sites in the comparison code causing repeated bailouts from
Maglev/Turbofan back to the interpreter:

```sh
NODE_OPTIONS=--trace-deopt npm --workspace=zql-benchmarks run bench -- memory-ivm-deopt
```

**`compareValues`** — The original implementation narrowed the type of
`a` with `typeof` but then called assertion helpers (`assertBoolean`,
`assertNumber`, `assertString`) on `b` separately. These helpers
introduce additional call sites with mixed type feedback, preventing V8
from compiling a specialised fast path for the common string/number
cases.

**`compareBounds`** — The sentinel values `minValue`/`maxValue` are
Symbols. Checking `a === minValue` before knowing the type of `a` meant
that when a Symbol appeared, V8 deopted the integer/string fast path it
had compiled for the common case.

## Fix

**`compareValues`**: Check `typeof a === 'string' && typeof b ===
'string'` (and similarly for number/boolean) so each branch gives V8 a
clear monomorphic profile. The null sentinel check is moved after the
type checks since it is the less common case.

**`compareBounds`**: Guard with `typeof a === 'symbol'` first, giving
V8 a clear type discriminant so the non-symbol path stays compiled as a
numeric/string specialisation.

## Benchmarks

Measured with the new memory-ivm-deopt.bench.ts benchmark (2 runs
each, WIP vs. main):

| benchmark | main | WIP | speedup |
|---|---|---|---|
| `compareValues(string, string)` | 305 ns | 190 ns | **1.6×** |
| `compareValues(number, number)` | 286 ns | 125 ns | **2.3×** |
| `compareValues(mixed)` | 35 ns | 21 ns | **1.7×** |
| MemorySource push add/remove | 2.66 µs | 2.39 µs | **1.11×** |
| MemorySource push edit | 3.65 µs | 3.18 µs | **1.15×** |
| Join push add/remove | 4.22 µs | 3.83 µs | **1.10×** |
| Join push edit | 3.69 µs | 3.28 µs | **1.13×** |

The IVM operator improvements are a downstream effect of the faster
comparator. Fetch/scan paths are unchanged as expected since they do not
exercise the comparison hot path heavily.
