### PR TITLE
feat: loosen mutator and query output type requirements

### DIFF
--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -904,7 +904,7 @@ export class Zero<
   preload<
     TTable extends keyof S['tables'] & string,
     TInput extends ReadonlyJSONValue | undefined,
-    TOutput extends ReadonlyJSONValue | undefined,
+    TOutput,
     TReturn,
   >(
     query: QueryOrQueryRequest<TTable, TInput, TOutput, S, TReturn, C>,
@@ -939,7 +939,7 @@ export class Zero<
   run<
     TTable extends keyof S['tables'] & string,
     TInput extends ReadonlyJSONValue | undefined,
-    TOutput extends ReadonlyJSONValue | undefined,
+    TOutput,
     TReturn,
   >(
     query: QueryOrQueryRequest<TTable, TInput, TOutput, S, TReturn, C>,
@@ -982,7 +982,7 @@ export class Zero<
   materialize<
     TTable extends keyof S['tables'] & string,
     TInput extends ReadonlyJSONValue | undefined,
-    TOutput extends ReadonlyJSONValue | undefined,
+    TOutput,
     TReturn,
   >(
     query: QueryOrQueryRequest<TTable, TInput, TOutput, S, TReturn, C>,
@@ -992,7 +992,7 @@ export class Zero<
     T,
     TTable extends keyof S['tables'] & string,
     TInput extends ReadonlyJSONValue | undefined,
-    TOutput extends ReadonlyJSONValue | undefined,
+    TOutput,
     TReturn,
   >(
     query: QueryOrQueryRequest<TTable, TInput, TOutput, S, TReturn, C>,
@@ -1003,7 +1003,7 @@ export class Zero<
     T,
     TTable extends keyof S['tables'] & string,
     TInput extends ReadonlyJSONValue | undefined,
-    TOutput extends ReadonlyJSONValue | undefined,
+    TOutput,
     TReturn,
   >(
     query: QueryOrQueryRequest<TTable, TInput, TOutput, S, TReturn, C>,

--- a/packages/zero-react/src/use-query.tsx
+++ b/packages/zero-react/src/use-query.tsx
@@ -81,7 +81,7 @@ const suspend: (p: Promise<unknown>) => void = reactUse
 export function useQuery<
   TTable extends keyof TSchema['tables'] & string,
   TInput extends ReadonlyJSONValue | undefined,
-  TOutput extends ReadonlyJSONValue | undefined,
+  TOutput,
   TSchema extends BaseDefaultSchema = DefaultSchema,
   TReturn = PullRow<TTable, TSchema>,
   TContext extends BaseDefaultContext = DefaultContext,
@@ -101,7 +101,7 @@ export function useQuery<
 export function useQuery<
   TTable extends keyof TSchema['tables'] & string,
   TInput extends ReadonlyJSONValue | undefined,
-  TOutput extends ReadonlyJSONValue | undefined,
+  TOutput,
   TSchema extends BaseDefaultSchema = DefaultSchema,
   TReturn = PullRow<TTable, TSchema>,
   TContext extends BaseDefaultContext = DefaultContext,
@@ -116,7 +116,7 @@ export function useQuery<
 export function useQuery<
   TTable extends keyof TSchema['tables'] & string,
   TInput extends ReadonlyJSONValue | undefined,
-  TOutput extends ReadonlyJSONValue | undefined,
+  TOutput,
   TSchema extends BaseDefaultSchema = DefaultSchema,
   TReturn = PullRow<TTable, TSchema>,
   TContext extends BaseDefaultContext = DefaultContext,
@@ -155,7 +155,7 @@ export function useQuery<
 export function useSuspenseQuery<
   TTable extends keyof TSchema['tables'] & string,
   TInput extends ReadonlyJSONValue | undefined,
-  TOutput extends ReadonlyJSONValue | undefined,
+  TOutput,
   TSchema extends BaseDefaultSchema = DefaultSchema,
   TReturn = PullRow<TTable, TSchema>,
   TContext extends BaseDefaultContext = DefaultContext,
@@ -175,7 +175,7 @@ export function useSuspenseQuery<
 export function useSuspenseQuery<
   TTable extends keyof TSchema['tables'] & string,
   TInput extends ReadonlyJSONValue | undefined,
-  TOutput extends ReadonlyJSONValue | undefined,
+  TOutput,
   TSchema extends BaseDefaultSchema = DefaultSchema,
   TReturn = PullRow<TTable, TSchema>,
   TContext extends BaseDefaultContext = DefaultContext,
@@ -190,7 +190,7 @@ export function useSuspenseQuery<
 export function useSuspenseQuery<
   TTable extends keyof TSchema['tables'] & string,
   TInput extends ReadonlyJSONValue | undefined,
-  TOutput extends ReadonlyJSONValue | undefined,
+  TOutput,
   TSchema extends BaseDefaultSchema = DefaultSchema,
   TReturn = PullRow<TTable, TSchema>,
   TContext extends BaseDefaultContext = DefaultContext,

--- a/packages/zero-solid/src/use-query.ts
+++ b/packages/zero-solid/src/use-query.ts
@@ -62,7 +62,7 @@ export type UseQueryOptions = {
 export function createQuery<
   TTable extends keyof TSchema['tables'] & string,
   TInput extends ReadonlyJSONValue | undefined,
-  TOutput extends ReadonlyJSONValue | undefined,
+  TOutput,
   TSchema extends BaseDefaultSchema = DefaultSchema,
   TReturn = PullRow<TTable, TSchema>,
   TContext extends BaseDefaultContext = DefaultContext,
@@ -79,7 +79,7 @@ export function createQuery<
 export function useQuery<
   TTable extends keyof TSchema['tables'] & string,
   TInput extends ReadonlyJSONValue | undefined,
-  TOutput extends ReadonlyJSONValue | undefined,
+  TOutput,
   TSchema extends BaseDefaultSchema = DefaultSchema,
   TReturn = PullRow<TTable, TSchema>,
   TContext extends BaseDefaultContext = DefaultContext,
@@ -94,7 +94,7 @@ export function useQuery<
 export function useQuery<
   TTable extends keyof TSchema['tables'] & string,
   TInput extends ReadonlyJSONValue | undefined,
-  TOutput extends ReadonlyJSONValue | undefined,
+  TOutput,
   TSchema extends BaseDefaultSchema = DefaultSchema,
   TReturn = PullRow<TTable, TSchema>,
   TContext extends BaseDefaultContext = DefaultContext,
@@ -110,7 +110,7 @@ export function useQuery<
 export function useQuery<
   TTable extends keyof TSchema['tables'] & string,
   TInput extends ReadonlyJSONValue | undefined,
-  TOutput extends ReadonlyJSONValue | undefined,
+  TOutput,
   TSchema extends BaseDefaultSchema = DefaultSchema,
   TReturn = PullRow<TTable, TSchema>,
   TContext extends BaseDefaultContext = DefaultContext,

--- a/packages/zql/src/mutate/mutator.ts
+++ b/packages/zql/src/mutate/mutator.ts
@@ -27,7 +27,7 @@ export type MutatorDefinitionTypes<
 
 export type MutatorDefinition<
   TInput extends ReadonlyJSONValue | undefined,
-  TOutput extends ReadonlyJSONValue | undefined,
+  TOutput,
   TContext = DefaultContext,
   TWrappedTransaction = DefaultWrappedTransaction,
 > = {
@@ -69,7 +69,7 @@ export function defineMutator<
 // Overload for validator
 export function defineMutator<
   TInput extends ReadonlyJSONValue | undefined = undefined,
-  TOutput extends ReadonlyJSONValue | undefined = TInput,
+  TOutput = TInput,
   TSchema extends Schema = DefaultSchema,
   TContext = DefaultContext,
   TWrappedTransaction = DefaultWrappedTransaction,
@@ -85,7 +85,7 @@ export function defineMutator<
 // Implementation
 export function defineMutator<
   TInput extends ReadonlyJSONValue | undefined = undefined,
-  TOutput extends ReadonlyJSONValue | undefined = TInput,
+  TOutput = TInput,
   TSchema extends Schema = DefaultSchema,
   TContext = DefaultContext,
   TWrappedTransaction = DefaultWrappedTransaction,
@@ -176,7 +176,7 @@ type TypedDefineMutator<
   // With validator
   <
     TInput extends ReadonlyJSONValue | undefined,
-    TOutput extends ReadonlyJSONValue | undefined,
+    TOutput,
   >(
     validator: StandardSchemaV1<TInput, TOutput>,
     mutator: MutatorDefinitionFunction<
@@ -188,7 +188,7 @@ type TypedDefineMutator<
 };
 
 export type MutatorDefinitionFunction<
-  TOutput extends ReadonlyJSONValue | undefined,
+  TOutput,
   TContext,
   TTransaction,
 > = (options: {

--- a/packages/zql/src/query/query-registry.ts
+++ b/packages/zql/src/query/query-registry.ts
@@ -42,7 +42,7 @@ export type CustomQueryTypes<
 export type CustomQuery<
   TTable extends keyof TSchema['tables'] & string,
   TInput extends ReadonlyJSONValue | undefined,
-  TOutput extends ReadonlyJSONValue | undefined = TInput,
+  TOutput = TInput,
   TSchema extends Schema = DefaultSchema,
   TReturn = PullRow<TTable, TSchema>,
   TContext = DefaultContext,
@@ -55,7 +55,7 @@ export type CustomQuery<
 type CustomQueryCallable<
   TTable extends keyof TSchema['tables'] & string,
   TInput extends ReadonlyJSONValue | undefined,
-  TOutput extends ReadonlyJSONValue | undefined,
+  TOutput,
   TSchema extends Schema,
   TReturn,
   TContext,
@@ -91,7 +91,7 @@ export function isQuery<S extends Schema>(
 export type QueryRequestTypes<
   TTable extends keyof TSchema['tables'] & string,
   TInput extends ReadonlyJSONValue | undefined,
-  TOutput extends ReadonlyJSONValue | undefined,
+  TOutput,
   TSchema extends Schema,
   TReturn,
   TContext,
@@ -107,7 +107,7 @@ export type QueryRequestTypes<
 export type QueryRequest<
   TTable extends keyof TSchema['tables'] & string,
   TInput extends ReadonlyJSONValue | undefined,
-  TOutput extends ReadonlyJSONValue | undefined,
+  TOutput,
   TSchema extends Schema,
   TReturn,
   TContext,
@@ -140,7 +140,7 @@ export type QueryRequest<
 export type QueryOrQueryRequest<
   TTable extends keyof TSchema['tables'] & string,
   TInput extends ReadonlyJSONValue | undefined,
-  TOutput extends ReadonlyJSONValue | undefined,
+  TOutput,
   TSchema extends Schema,
   TReturn,
   TContext,
@@ -158,7 +158,7 @@ export type QueryOrQueryRequest<
 export const addContextToQuery = <
   TTable extends keyof TSchema['tables'] & string,
   TInput extends ReadonlyJSONValue | undefined,
-  TOutput extends ReadonlyJSONValue | undefined,
+  TOutput,
   TSchema extends Schema,
   TReturn,
   TContext,
@@ -263,7 +263,7 @@ export type QueryDefinitionTypes<
 export type QueryDefinition<
   TTable extends string,
   TInput extends ReadonlyJSONValue | undefined,
-  TOutput extends ReadonlyJSONValue | undefined,
+  TOutput,
   TReturn,
   TContext = DefaultContext,
 > = {
@@ -291,7 +291,7 @@ export function isQueryDefinition(f: unknown): f is AnyQueryDefinition {
 
 export type QueryDefinitionFunction<
   TTable extends string,
-  TInput extends ReadonlyJSONValue | undefined,
+  TInput,
   TReturn,
   TContext,
 > = (options: {args: TInput; ctx: TContext}) => Query<TTable, Schema, TReturn>;
@@ -356,7 +356,7 @@ export function defineQuery<
 // Overload for validator parameter - Input and Output can be different
 export function defineQuery<
   TInput extends ReadonlyJSONValue | undefined,
-  TOutput extends ReadonlyJSONValue | undefined,
+  TOutput,
   TContext = DefaultContext,
   TSchema extends Schema = DefaultSchema,
   TTable extends keyof TSchema['tables'] & string = keyof TSchema['tables'] &
@@ -370,7 +370,7 @@ export function defineQuery<
 // Implementation
 export function defineQuery<
   TInput extends ReadonlyJSONValue | undefined,
-  TOutput extends ReadonlyJSONValue | undefined,
+  TOutput,
   TContext = DefaultContext,
   TSchema extends Schema = DefaultSchema,
   TTable extends keyof TSchema['tables'] & string = keyof TSchema['tables'] &
@@ -482,7 +482,7 @@ type TypedDefineQuery<TSchema extends Schema, TContext> = {
   // With validator
   <
     TInput extends ReadonlyJSONValue | undefined,
-    TOutput extends ReadonlyJSONValue | undefined,
+    TOutput,
     TReturn,
     TTable extends keyof TSchema['tables'] & string = keyof TSchema['tables'] &
       string,
@@ -499,7 +499,7 @@ type TypedDefineQuery<TSchema extends Schema, TContext> = {
 export function createQuery<
   TTable extends keyof TSchema['tables'] & string,
   TInput extends ReadonlyJSONValue | undefined,
-  TOutput extends ReadonlyJSONValue | undefined,
+  TOutput,
   TSchema extends Schema,
   TReturn,
   TContext,


### PR DESCRIPTION
This PR removes the output type requirements for queries and mutators.
Only the input has to be transported to the server and thus needs to be restricted to JSON values.
On the server however, there is no need to enforce this on the output type because there is no transport anymore.

Loosening the types allows the schemas to transform the data into types used on the server (e.g. `DateTime`).

**Discord Thread**
https://discord.com/channels/830183651022471199/1486770071425515734

In my short experience this is more useful on the server than on the client because zql still only accepts limited value types.
I've never used it in queries but it should work the same way?