### PR TITLE
feat(zero-cache): scope auth to websocket connections

### DIFF
--- a/packages/zero-cache/src/auth/auth.ts
+++ b/packages/zero-cache/src/auth/auth.ts
@@ -7,6 +7,8 @@ import {
   ProtocolError,
   type ErrorBody,
 } from '../../../zero-protocol/src/error.ts';
+import {ErrorReason} from '../../../zero-protocol/src/error-reason.ts';
+import type {PushError} from '../../../zero-protocol/src/push.ts';
 
 /** @deprecated JWT auth is deprecated */
 export type JWTAuth = {
@@ -22,174 +24,86 @@ export type OpaqueAuth = {
 
 export type Auth = OpaqueAuth | JWTAuth;
 
-export interface AuthSession {
-  /** Update the auth session with a new userID and token from the client */
-  update(
-    userID: string,
-    wireAuth: string | undefined,
-  ): Promise<AuthUpdateResult>;
-
-  /** The revision of the auth state */
-  get revision(): number;
-
-  /** The auth state for the session */
-  get auth(): Auth | undefined;
-
-  /** Clear the auth session, removing any stored auth and allowing a new userID to be bound on the next update. */
-  clear(): void;
-}
-
-export type AuthUpdateResult =
-  | {
-      readonly ok: true;
-    }
-  | {
-      readonly ok: false;
-      readonly error: ErrorBody;
-    };
-
 export type ValidateLegacyJWT = (
   token: string,
-  ctx: {readonly userID: string},
+  ctx: {readonly userID: string | undefined},
 ) => Promise<JWTAuth>;
 
 function isProvidedAuth(wireAuth: string | undefined): wireAuth is string {
   return wireAuth !== undefined && wireAuth !== '';
 }
 
-function authEquals(a: Auth | null | undefined, b: Auth | null | undefined) {
-  if (a === b) {
-    return true;
-  }
-  if (!a || !b) {
-    return false;
-  }
-  return a.type === b.type && a.raw === b.raw;
-}
+/**
+ * Resolves one auth snapshot transition without binding it to a client group.
+ */
+export async function resolveAuth(
+  lc: LogContext,
+  previousAuth: Auth | undefined,
+  userID: string | undefined,
+  wireAuth: string | undefined,
+  validateLegacyJWT: ValidateLegacyJWT | undefined,
+): Promise<Auth | undefined> {
+  try {
+    const hasProvidedAuth = isProvidedAuth(wireAuth);
 
-export class AuthSessionImpl implements AuthSession {
-  readonly id: string;
-  readonly #lc: LogContext;
-  readonly #validateLegacyJWT: ValidateLegacyJWT | undefined;
-  #auth: Auth | undefined = undefined;
-  #boundUserID: string | undefined;
-  #revision = 0;
-
-  constructor(
-    lc: LogContext,
-    clientGroupID: string,
-    validateLegacyJWT: ValidateLegacyJWT | undefined,
-  ) {
-    this.id = clientGroupID;
-    this.#lc = lc;
-    this.#validateLegacyJWT = validateLegacyJWT;
-  }
-
-  get auth(): Auth | undefined {
-    return this.#auth;
-  }
-
-  get revision(): number {
-    return this.#revision;
-  }
-
-  clear(): void {
-    const lc = this.#lc.withContext(
-      'boundUserID',
-      this.#boundUserID ?? 'unknown',
-    );
-    lc.debug?.(`Clearing auth session`);
-    this.#auth = undefined;
-    this.#boundUserID = undefined;
-    this.#revision = 0;
-  }
-
-  async update(
-    userID: string,
-    wireAuth: string | undefined,
-  ): Promise<AuthUpdateResult> {
-    try {
-      const lc = this.#lc.withContext('newUserID', userID);
-
-      // check if the auth update is trying to change the bound userID for this client group
-      if (this.#boundUserID && this.#boundUserID !== userID) {
-        return {
-          ok: false,
-          error: {
-            kind: ErrorKind.Unauthorized,
-            message:
-              'Client groups are pinned to a single user. Connection userID does not match existing client group userID.',
-            origin: ErrorOrigin.ZeroCache,
-          },
-        };
-      }
-
-      const previousAuth = this.#auth;
-      const hasProvidedAuth = isProvidedAuth(wireAuth);
-      let nextAuth = previousAuth;
-
-      if (previousAuth) {
-        lc.debug?.(`Attempting to update auth from previous value`);
-      } else {
-        lc.debug?.(`Attempting to initialize auth`);
-      }
-
-      if (!hasProvidedAuth && previousAuth) {
-        return {
-          ok: false,
-          error: {
-            kind: ErrorKind.Unauthorized,
-            message:
-              'No token provided. An unauthenticated client cannot connect to an authenticated client group.',
-            origin: ErrorOrigin.ZeroCache,
-          },
-        };
-      }
-
-      if (!hasProvidedAuth) {
-        nextAuth = undefined;
-        lc.debug?.(`Cleared auth`);
-      } else if (this.#validateLegacyJWT !== undefined) {
-        const verifiedToken = await this.#validateLegacyJWT(wireAuth, {userID});
-        nextAuth = pickToken(this.#lc, this.#auth, verifiedToken);
-        lc.debug?.(`Updated auth with JWT`);
-      } else {
-        if (this.#auth?.type === 'jwt') {
-          throw new Error(
-            'Cannot change auth type from legacy to opaque token',
-          );
-        }
-        nextAuth = {
-          type: 'opaque',
-          raw: wireAuth,
-        };
-        lc.debug?.(`Updated auth with opaque token`);
-      }
-
-      this.#auth = nextAuth;
-      this.#boundUserID ??= userID;
-
-      if (!authEquals(previousAuth, nextAuth)) {
-        this.#revision++;
-      }
-    } catch (e) {
-      if (isProtocolError(e)) {
-        return {
-          ok: false,
-          error: e.errorBody,
-        };
-      }
-      return {
-        ok: false,
-        error: {
-          kind: ErrorKind.AuthInvalidated,
-          message: `Failed to decode auth token: ${String(e)}`,
-          origin: ErrorOrigin.ZeroCache,
-        },
-      };
+    if (previousAuth) {
+      lc.debug?.(`Attempting to update auth from previous value`);
+    } else {
+      lc.debug?.(`Attempting to initialize auth`);
     }
 
-    return {ok: true};
+    if (!hasProvidedAuth && previousAuth) {
+      throw new ProtocolError({
+        kind: ErrorKind.Unauthorized,
+        message:
+          'No token provided. An unauthenticated client cannot connect to an authenticated client group.',
+        origin: ErrorOrigin.ZeroCache,
+      });
+    }
+
+    if (!hasProvidedAuth) {
+      lc.debug?.(`Cleared auth`);
+      return undefined;
+    }
+
+    if (userID === undefined) {
+      throw new ProtocolError({
+        kind: ErrorKind.Unauthorized,
+        message: 'Authenticated connections require a userID.',
+        origin: ErrorOrigin.ZeroCache,
+      });
+    }
+
+    if (validateLegacyJWT !== undefined) {
+      const verifiedToken = await validateLegacyJWT(wireAuth, {userID});
+      const nextAuth = pickToken(lc, previousAuth, verifiedToken);
+      lc.debug?.(`Updated auth with JWT`);
+      return nextAuth;
+    }
+
+    if (previousAuth?.type === 'jwt') {
+      throw new ProtocolError({
+        kind: ErrorKind.Unauthorized,
+        message:
+          'Token type cannot change from JWT to opaque. Connections are pinned to a single token type.',
+        origin: ErrorOrigin.ZeroCache,
+      });
+    }
+
+    lc.debug?.(`Updated auth with opaque token`);
+    return {
+      type: 'opaque',
+      raw: wireAuth,
+    };
+  } catch (e) {
+    if (isProtocolError(e)) {
+      throw e;
+    }
+    throw new ProtocolError({
+      kind: ErrorKind.AuthInvalidated,
+      message: `Failed to decode auth token: ${String(e)}`,
+      origin: ErrorOrigin.ZeroCache,
+    });
   }
 }
 
@@ -277,4 +191,38 @@ export function pickToken(
       'No token provided. An unauthenticated client cannot connect to an authenticated client group.',
     origin: ErrorOrigin.ZeroCache,
   });
+}
+
+export function isAuthErrorBody(ex: unknown): ex is ErrorBody | PushError {
+  if (typeof ex !== 'object' || ex === null) {
+    return false;
+  }
+
+  if ('error' in ex) {
+    return (
+      ex.error === 'http' &&
+      'status' in ex &&
+      (ex.status === 401 || ex.status === 403)
+    );
+  }
+
+  if (!('kind' in ex)) {
+    return false;
+  }
+
+  if (
+    ex.kind === ErrorKind.AuthInvalidated ||
+    ex.kind === ErrorKind.Unauthorized
+  ) {
+    return true;
+  }
+
+  return (
+    (ex.kind === ErrorKind.PushFailed ||
+      ex.kind === ErrorKind.TransformFailed) &&
+    'reason' in ex &&
+    ex.reason === ErrorReason.HTTP &&
+    'status' in ex &&
+    (ex.status === 401 || ex.status === 403)
+  );
 }

--- a/packages/zero-cache/src/custom-queries/transform-query.ts
+++ b/packages/zero-cache/src/custom-queries/transform-query.ts
@@ -3,12 +3,13 @@ import type {LogContext} from '@rocicorp/logger';
 import {startAsyncSpan} from '../../../otel/src/span.ts';
 import {TimedCache} from '../../../shared/src/cache.ts';
 import {getErrorMessage} from '../../../shared/src/error.ts';
-import {must} from '../../../shared/src/must.ts';
+import {sortedEntries} from '../../../shared/src/sorted-entries.ts';
 import {
   transformResponseMessageSchema,
   type ErroredQuery,
   type TransformRequestBody,
   type TransformRequestMessage,
+  type TransformResponseBody,
 } from '../../../zero-protocol/src/custom-queries.ts';
 import {ErrorKind} from '../../../zero-protocol/src/error-kind.ts';
 import {ErrorOrigin} from '../../../zero-protocol/src/error-origin.ts';
@@ -19,15 +20,21 @@ import {
 } from '../../../zero-protocol/src/error.ts';
 import {hashOfAST} from '../../../zero-protocol/src/query-hash.ts';
 import type {TransformedAndHashed} from '../auth/read-authorizer.ts';
-import {
-  compileUrlPattern,
-  fetchFromAPIServer,
-  type HeaderOptions,
-} from '../custom/fetch.ts';
+import {fetchFromAPIServer} from '../custom/fetch.ts';
+import type {
+  ConnectionContext,
+  HeaderOptions,
+} from '../services/view-syncer/connection-context-manager.ts';
 import type {CustomQueryRecord} from '../services/view-syncer/schema/types.ts';
 import type {ShardID} from '../types/shards.ts';
 
 const tracer = trace.getTracer('custom-query-transformer');
+
+type TransformResponse = TransformResponseBody | TransformFailedBody;
+export type TransformAttempt = {
+  result: (TransformedAndHashed | ErroredQuery)[] | TransformFailedBody;
+  cached: boolean;
+};
 
 /**
  * Transforms a custom query by calling the user's API server.
@@ -46,53 +53,48 @@ const tracer = trace.getTracer('custom-query-transformer');
  * The ViewSyncer will call the API server 3-4 times with the exact same queries
  * if we do not cache requests.
  *
- * Caching is safe here because the cache key encodes both
- * the user's cookies and auth token. A user cannot see another user's
- * transformed queries unless they share the same token and cookies.
+ * Caching is safe here because the cache key encodes the effective request
+ * identity used for `/query`: auth, userID, forwarded cookies, origin,
+ * custom headers, target URL, and the query hash itself.
  */
 export class CustomQueryTransformer {
   readonly #shard: ShardID;
   readonly #cache: TimedCache<TransformedAndHashed>;
-  readonly #config: {
-    url: string[];
-    forwardCookies: boolean;
-  };
-  readonly #urlPatterns: URLPattern[];
   readonly #lc: LogContext;
 
-  constructor(
-    lc: LogContext,
-    config: {
-      url: string[];
-      forwardCookies: boolean;
-    },
-    shard: ShardID,
-  ) {
-    this.#config = config;
+  constructor(lc: LogContext, shard: ShardID) {
     this.#shard = shard;
     this.#lc = lc;
-    this.#urlPatterns = config.url.map(compileUrlPattern);
     this.#cache = new TimedCache(5000); // 5 seconds cache TTL
   }
 
+  /**
+   * Forces the empty `/query` validation request used by auth maintenance.
+   *
+   * This stays separate from `transform()` because `transform([], ...)`
+   * short-circuits locally and never hits the API server, while validation
+   * still needs to make the request so auth failures are surfaced.
+   * Successful validation is intentionally opaque because callers only care
+   * whether the request succeeded or failed.
+   */
+  async validate(
+    ctx: ConnectionContext,
+  ): Promise<TransformFailedBody | undefined> {
+    const response = await this.#requestTransform(ctx, [], 'validate');
+
+    return Array.isArray(response) ? undefined : response;
+  }
+
   async transform(
-    headerOptions: HeaderOptions,
+    ctx: ConnectionContext,
     queries: Iterable<CustomQueryRecord>,
-    userQueryURL: string | undefined,
-  ): Promise<(TransformedAndHashed | ErroredQuery)[] | TransformFailedBody> {
+  ): Promise<TransformAttempt> {
     const request: TransformRequestBody = [];
     const cachedResponses: TransformedAndHashed[] = [];
 
-    if (!this.#config.forwardCookies && headerOptions.cookie) {
-      headerOptions = {
-        ...headerOptions,
-        cookie: undefined, // remove cookies if not forwarded
-      };
-    }
-
     // split queries into cached and uncached
     for (const query of queries) {
-      const cacheKey = getCacheKey(headerOptions, query.id);
+      const cacheKey = getCacheKey(ctx, query.id);
       const cached = this.#cache.get(cacheKey);
       if (cached) {
         cachedResponses.push(cached);
@@ -105,11 +107,58 @@ export class CustomQueryTransformer {
       }
     }
 
+    let cached = true;
+
     if (request.length === 0) {
-      return cachedResponses;
+      return {
+        result: cachedResponses,
+        cached: true,
+      };
+    } else {
+      // we are hitting the server with at least one uncached query
+      cached = false;
     }
 
-    const queryIDs = request.map(r => r.id);
+    const response = await this.#requestTransform(ctx, request, 'transform');
+    if (!Array.isArray(response)) {
+      return {
+        result: response,
+        cached,
+      };
+    }
+
+    const newResponses = response.map(transformed => {
+      if ('error' in transformed) {
+        return transformed;
+      }
+      return {
+        id: transformed.id,
+        transformedAst: transformed.ast,
+        transformationHash: hashOfAST(transformed.ast),
+      } satisfies TransformedAndHashed;
+    });
+
+    for (const transformed of newResponses) {
+      if ('error' in transformed) {
+        // do not cache error responses
+        continue;
+      }
+      const cacheKey = getCacheKey(ctx, transformed.id);
+      this.#cache.set(cacheKey, transformed);
+    }
+
+    return {
+      result: newResponses.concat(cachedResponses),
+      cached,
+    };
+  }
+
+  async #requestTransform(
+    ctx: ConnectionContext,
+    request: TransformRequestBody,
+    operation: 'validate' | 'transform',
+  ): Promise<TransformResponse> {
+    const queryIDs = request.map(({id}) => id);
 
     try {
       const transformResponse = await startAsyncSpan(
@@ -120,43 +169,13 @@ export class CustomQueryTransformer {
             transformResponseMessageSchema,
             'transform',
             this.#lc,
-            userQueryURL ??
-              must(
-                this.#config.url[0],
-                'A ZERO_QUERY_URL must be configured for custom queries',
-              ),
-            this.#urlPatterns,
+            ctx,
             this.#shard,
-            headerOptions,
             ['transform', request] satisfies TransformRequestMessage,
           ),
       );
 
-      if (transformResponse[0] === 'transformFailed') {
-        return transformResponse[1];
-      }
-
-      const newResponses = transformResponse[1].map(transformed => {
-        if ('error' in transformed) {
-          return transformed;
-        }
-        return {
-          id: transformed.id,
-          transformedAst: transformed.ast,
-          transformationHash: hashOfAST(transformed.ast),
-        } satisfies TransformedAndHashed;
-      });
-
-      for (const transformed of newResponses) {
-        if ('error' in transformed) {
-          // do not cache error responses
-          continue;
-        }
-        const cacheKey = getCacheKey(headerOptions, transformed.id);
-        this.#cache.set(cacheKey, transformed);
-      }
-
-      return newResponses.concat(cachedResponses);
+      return transformResponse[1];
     } catch (e) {
       if (
         isProtocolError(e) &&
@@ -172,16 +191,45 @@ export class CustomQueryTransformer {
         kind: ErrorKind.TransformFailed,
         origin: ErrorOrigin.ZeroCache,
         reason: ErrorReason.Internal,
-        message: `Failed to transform queries: ${getErrorMessage(e)}`,
+        message: `Failed to ${operation} queries: ${getErrorMessage(e)}`,
         queryIDs,
       } as const satisfies TransformFailedBody;
     }
   }
 }
 
-function getCacheKey(headerOptions: HeaderOptions, queryID: string) {
+function getCacheKey(ctx: ConnectionContext, queryID: string) {
   // For custom queries, queryID is a hash of the name + args.
-  // the APIKey from headerOptions is static. Not needed for the cache key.
-  // The token is used to identify the user and should be included in the cache key.
-  return `${headerOptions.token}:${headerOptions.cookie}:${queryID}`;
+  // The apiKey is static for a given transformer instance.
+  return JSON.stringify({
+    queryID,
+    token: ctx.auth?.raw,
+    cookie: ctx.queryContext.headerOptions.cookie,
+    origin: ctx.queryContext.headerOptions.origin,
+    userID: ctx.userID,
+    url: ctx.queryContext.url,
+    customHeaders: normalizedForwardedHeaders(ctx.queryContext.headerOptions),
+  });
+}
+
+function normalizedForwardedHeaders(headerOptions: HeaderOptions) {
+  const {allowedClientHeaders, customHeaders} = headerOptions;
+  if (
+    !customHeaders ||
+    !allowedClientHeaders ||
+    allowedClientHeaders.length === 0
+  ) {
+    return undefined;
+  }
+
+  const allowedHeaders = new Set(
+    allowedClientHeaders.map(header => header.toLowerCase()),
+  );
+  const forwardedHeaders = sortedEntries(customHeaders).filter(([header]) =>
+    allowedHeaders.has(header.toLowerCase()),
+  );
+
+  return forwardedHeaders.length === 0
+    ? undefined
+    : JSON.stringify(forwardedHeaders);
 }

--- a/packages/zero-cache/src/custom/fetch.ts
+++ b/packages/zero-cache/src/custom/fetch.ts
@@ -12,6 +12,8 @@ import {isProtocolError} from '../../../zero-protocol/src/error.ts';
 import {ProtocolErrorWithLevel} from '../types/error-with-level.ts';
 import {upstreamSchema, type ShardID} from '../types/shards.ts';
 import {randInt} from '../../../shared/src/rand.ts';
+import type {ConnectionContext} from '../services/view-syncer/connection-context-manager.ts';
+import {must} from '../../../shared/src/must.ts';
 
 const reservedParams = ['schema', 'appID'];
 
@@ -33,15 +35,6 @@ export function compileUrlPattern(pattern: string): URLPattern {
     );
   }
 }
-
-export type HeaderOptions = {
-  apiKey?: string | undefined;
-  customHeaders?: Record<string, string> | undefined;
-  allowedClientHeaders?: readonly string[] | undefined;
-  token?: string | undefined;
-  cookie?: string | undefined;
-  origin?: string | undefined;
-};
 
 /**
  * Filters custom headers based on the allowed headers list.
@@ -98,20 +91,27 @@ export async function fetchFromAPIServer<TValidator extends Type>(
   validator: TValidator,
   source: 'push' | 'transform',
   lc: LogContext,
-  url: string,
-  allowedUrlPatterns: URLPattern[],
+  ctx: ConnectionContext,
   shard: ShardID,
-  headerOptions: HeaderOptions,
   body: ReadonlyJSONValue,
 ) {
   const fetchFromAPIServerID = randInt(1, Number.MAX_SAFE_INTEGER).toString(36);
-  lc = lc.withContext('fetchFromAPIServerID', fetchFromAPIServerID);
+  lc = lc
+    .withContext('fetchFromAPIServerID', fetchFromAPIServerID)
+    .withContext('source', source);
+
+  const fetchConfig = source === 'push' ? ctx.pushContext : ctx.queryContext;
+  const url = must(
+    fetchConfig.url,
+    `Fetch config for ${source} is missing URL`,
+  );
+  const headerOptions = fetchConfig.headerOptions;
 
   lc.debug?.('fetchFromAPIServer called', {
     url,
   });
 
-  if (!urlMatch(url, allowedUrlPatterns)) {
+  if (!urlMatch(url, fetchConfig.allowedUrlPatterns ?? [])) {
     throw new ProtocolErrorWithLevel(
       source === 'push'
         ? {
@@ -145,8 +145,11 @@ export async function fetchFromAPIServer<TValidator extends Type>(
       headerOptions.allowedClientHeaders,
     ),
   );
-  if (headerOptions.token) {
-    headers['Authorization'] = `Bearer ${headerOptions.token}`;
+  if (ctx.userID) {
+    headers['X-User-ID'] = ctx.userID;
+  }
+  if (ctx.auth?.raw) {
+    headers['Authorization'] = `Bearer ${ctx.auth.raw}`;
   }
   if (headerOptions.cookie) {
     headers['Cookie'] = headerOptions.cookie;

--- a/packages/zero-cache/src/server/inspector-delegate.ts
+++ b/packages/zero-cache/src/server/inspector-delegate.ts
@@ -12,7 +12,7 @@ import {
 } from '../../../zql/src/query/metrics-delegate.ts';
 import {isDevelopmentMode} from '../config/normalize.ts';
 import type {CustomQueryTransformer} from '../custom-queries/transform-query.ts';
-import type {HeaderOptions} from '../custom/fetch.ts';
+import type {ConnectionContext} from '../services/view-syncer/connection-context-manager.ts';
 import type {CustomQueryRecord} from '../services/view-syncer/schema/types.ts';
 import {ProtocolErrorWithLevel} from '../types/error-with-level.ts';
 
@@ -107,8 +107,7 @@ export class InspectorDelegate implements MetricsDelegate {
   async transformCustomQuery(
     name: string,
     args: readonly ReadonlyJSONValue[],
-    headerOptions: HeaderOptions,
-    userQueryURL: string | undefined,
+    ctx: ConnectionContext,
   ): Promise<AST> {
     assert(
       this.#customQueryTransformer,
@@ -127,17 +126,13 @@ export class InspectorDelegate implements MetricsDelegate {
       },
     ];
 
-    const results = await this.#customQueryTransformer.transform(
-      headerOptions,
-      queries,
-      userQueryURL,
-    );
+    const results = await this.#customQueryTransformer.transform(ctx, queries);
 
-    if ('kind' in results) {
-      throw new ProtocolErrorWithLevel(results, 'warn');
+    if ('kind' in results.result) {
+      throw new ProtocolErrorWithLevel(results.result, 'warn');
     }
 
-    const result = results[0];
+    const result = results.result[0];
     if (!result) {
       throw new Error('No transformation result returned');
     }

--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -8,7 +8,6 @@ import {randInt} from '../../../shared/src/rand.ts';
 import {promiseVoid} from '../../../shared/src/resolved-promises.ts';
 import * as v from '../../../shared/src/valita.ts';
 import {DatabaseStorage} from '../../../zqlite/src/database-storage.ts';
-import {AuthSessionImpl, type ValidateLegacyJWT} from '../auth/auth.ts';
 import type {NormalizedZeroConfig} from '../config/normalize.ts';
 import {getNormalizedZeroConfig} from '../config/zero-config.ts';
 import {CustomQueryTransformer} from '../custom-queries/transform-query.ts';
@@ -18,6 +17,10 @@ import {exitAfter, runUntilKilled} from '../services/life-cycle.ts';
 import {MutagenService} from '../services/mutagen/mutagen.ts';
 import {PusherService} from '../services/mutagen/pusher.ts';
 import type {ReplicaState} from '../services/replicator/replicator.ts';
+import {
+  type ConnectionContextManager,
+  ConnectionContextManagerImpl,
+} from '../services/view-syncer/connection-context-manager.ts';
 import type {DrainCoordinator} from '../services/view-syncer/drain-coordinator.ts';
 import {PipelineDriver} from '../services/view-syncer/pipeline-driver.ts';
 import {Snapshotter} from '../services/view-syncer/snapshotter.ts';
@@ -37,6 +40,9 @@ import {InspectorDelegate} from './inspector-delegate.ts';
 import {createLogContext} from './logging.ts';
 import {startOtelAuto} from './otel-start.ts';
 import {isPriorityOpRunning, runPriorityOp} from './priority-op.ts';
+import type {ValidateLegacyJWT} from '../auth/auth.ts';
+import {tokenConfigOptions, verifyToken} from '../auth/jwt.ts';
+import {ProtocolErrorWithLevel} from '../types/error-with-level.ts';
 
 function randomID() {
   return randInt(1, Number.MAX_SAFE_INTEGER).toString(36);
@@ -53,6 +59,8 @@ function getCustomQueryConfig(
 
   return {
     url: queryConfig.url,
+    apiKey: queryConfig.apiKey,
+    allowedClientHeaders: queryConfig.allowedClientHeaders,
     forwardCookies: queryConfig.forwardCookies ?? false,
   };
 }
@@ -107,26 +115,75 @@ export default function runWorker(
   );
 
   const shard = getShardID(config);
+  const customQueryConfig = getCustomQueryConfig(config);
+  const pushConfig =
+    config.push.url === undefined && config.mutate.url === undefined
+      ? undefined
+      : {
+          ...config.push,
+          ...config.mutate,
+          url: must(
+            config.push.url ?? config.mutate.url,
+            'No push or mutate URL configured',
+          ),
+        };
+
+  /** @deprecated used in JWT validation */
+  let validateLegacyJWT: ValidateLegacyJWT | undefined = undefined;
+
+  const tokenOptions = tokenConfigOptions(config.auth ?? {});
+  if (tokenOptions.length === 1) {
+    validateLegacyJWT = async (token, {userID}) => {
+      if (!userID) {
+        throw new ProtocolErrorWithLevel(
+          {
+            kind: 'Unauthorized',
+            message: 'UserID is required for JWT validation.',
+            origin: 'zeroCache',
+          },
+          'warn',
+        );
+      }
+
+      const decoded = await verifyToken(config.auth, token, {
+        subject: userID,
+        ...(config.auth?.issuer && {issuer: config.auth.issuer}),
+        ...(config.auth?.audience && {
+          audience: config.auth.audience,
+        }),
+      });
+      return {
+        type: 'jwt',
+        raw: token,
+        decoded,
+      };
+    };
+  }
 
   const viewSyncerFactory = (
     id: string,
     sub: Subscription<ReplicaState>,
     drainCoordinator: DrainCoordinator,
-    validateLegacyJWT: ValidateLegacyJWT | undefined,
   ) => {
     const logger = lc
       .withContext('component', 'view-syncer')
       .withContext('clientGroupID', id)
       .withContext('instance', randomID());
+
+    const customQueryTransformer =
+      customQueryConfig && new CustomQueryTransformer(logger, shard);
+    const contextManager = new ConnectionContextManagerImpl(
+      logger,
+      config.auth.revalidateIntervalSeconds,
+      config.auth.retransformIntervalSeconds,
+      customQueryConfig,
+      pushConfig,
+      validateLegacyJWT,
+    );
+
     lc.debug?.(
       `creating view syncer. Query Planner Enabled: ${config.enableQueryPlanner}`,
     );
-
-    // Create the custom query transformer if configured
-    const customQueryConfig = getCustomQueryConfig(config);
-    const customQueryTransformer =
-      customQueryConfig &&
-      new CustomQueryTransformer(logger, customQueryConfig, shard);
 
     const inspectorDelegate = new InspectorDelegate(customQueryTransformer);
 
@@ -135,12 +192,6 @@ export default function runWorker(
       2,
     );
     const normalYieldThresholdMs = Math.max(config.yieldThresholdMs, 2);
-
-    const authSession = new AuthSessionImpl(
-      logger.withContext('component', 'auth-session'),
-      id,
-      validateLegacyJWT,
-    );
 
     return new ViewSyncerService(
       config,
@@ -168,9 +219,9 @@ export default function runWorker(
       drainCoordinator,
       config.log.slowHydrateThreshold,
       inspectorDelegate,
+      contextManager,
       customQueryTransformer,
       runPriorityOp,
-      authSession,
     );
   };
 
@@ -189,21 +240,14 @@ export default function runWorker(
     : undefined;
 
   const pusherFactory =
-    config.push.url === undefined && config.mutate.url === undefined
+    pushConfig === undefined
       ? undefined
-      : (id: string) =>
+      : (id: string, contextManager: ConnectionContextManager) =>
           new PusherService(
             config,
-            {
-              ...config.push,
-              ...config.mutate,
-              url: must(
-                config.push.url ?? config.mutate.url,
-                'No push or mutate URL configured',
-              ),
-            },
             lc.withContext('clientGroupID', id),
             id,
+            contextManager,
           );
 
   const syncer = new Syncer(
@@ -213,6 +257,7 @@ export default function runWorker(
     mutagenFactory,
     pusherFactory,
     parent,
+    validateLegacyJWT,
   );
 
   startAnonymousTelemetry(lc, config);

--- a/packages/zero-cache/src/services/mutagen/pusher.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.ts
@@ -20,8 +20,9 @@ import {
   type PushBody,
   type PushResponse,
 } from '../../../../zero-protocol/src/push.ts';
+import {isAuthErrorBody} from '../../auth/auth.ts';
 import {type ZeroConfig} from '../../config/zero-config.ts';
-import {compileUrlPattern, fetchFromAPIServer} from '../../custom/fetch.ts';
+import {fetchFromAPIServer} from '../../custom/fetch.ts';
 import {getOrCreateCounter} from '../../observability/metrics.ts';
 import {recordMutation} from '../../server/anonymous-otel-start.ts';
 import {ProtocolErrorWithLevel} from '../../types/error-with-level.ts';
@@ -29,26 +30,23 @@ import type {Source} from '../../types/streams.ts';
 import {Subscription} from '../../types/subscription.ts';
 import type {HandlerResult, StreamResult} from '../../workers/connection.ts';
 import type {RefCountedService, Service} from '../service.ts';
+import type {
+  ConnectionContext,
+  ConnectionContextManager,
+  ConnectionSelector,
+} from '../view-syncer/connection-context-manager.ts';
 
 export interface Pusher extends RefCountedService {
-  readonly pushURL: string | undefined;
-
-  initConnection(
-    clientID: string,
-    wsID: string,
-    userPushURL: string | undefined,
-    userPushHeaders: Record<string, string> | undefined,
-    onAuthFailure?: () => void,
-  ): Source<Downstream>;
-  enqueuePush(
-    clientID: string,
-    push: PushBody,
-    auth: string | undefined,
-    httpCookie: string | undefined,
-    origin: string | undefined,
-  ): HandlerResult;
-  ackMutationResponses(upToID: MutationID): Promise<void>;
-  deleteClientMutations(clientIDs: string[]): Promise<void>;
+  initConnection(selector: ConnectionSelector): Source<Downstream>;
+  enqueuePush(selector: ConnectionSelector, push: PushBody): HandlerResult;
+  ackMutationResponses(
+    requester: ConnectionSelector,
+    upToID: MutationID,
+  ): Promise<void>;
+  deleteClientMutations(
+    requester: ConnectionSelector,
+    clientIDs: string[],
+  ): Promise<void>;
 }
 
 type Config = Pick<ZeroConfig, 'app' | 'shard'>;
@@ -68,78 +66,58 @@ type Config = Pick<ZeroConfig, 'app' | 'shard'>;
  */
 export class PusherService implements Service, Pusher {
   readonly id: string;
+  readonly #contextManager: ConnectionContextManager;
   readonly #pusher: PushWorker;
   readonly #queue: Queue<PusherEntryOrStop>;
-  readonly #pushConfig: ZeroConfig['push'] & {url: string[]};
   readonly #config: Config;
   readonly #lc: LogContext;
-  readonly #pushURLPatterns: URLPattern[];
   #stopped: Promise<void> | undefined;
   #refCount = 0;
   #isStopped = false;
 
   constructor(
     appConfig: Config,
-    pushConfig: ZeroConfig['push'] & {url: string[]},
     lc: LogContext,
     clientGroupID: string,
+    contextManager: ConnectionContextManager,
   ) {
+    this.#contextManager = contextManager;
     this.#config = appConfig;
     this.#lc = lc.withContext('component', 'pusherService');
-    this.#pushURLPatterns = pushConfig.url.map(compileUrlPattern);
     this.#queue = new Queue();
     this.#pusher = new PushWorker(
       appConfig,
       lc,
-      pushConfig.url,
-      pushConfig.apiKey,
-      pushConfig.allowedClientHeaders,
+      this.#contextManager,
       this.#queue,
     );
     this.id = clientGroupID;
-    this.#pushConfig = pushConfig;
   }
 
-  get pushURL(): string | undefined {
-    return this.#pusher.pushURLs[0];
-  }
-
-  initConnection(
-    clientID: string,
-    wsID: string,
-    userPushURL: string | undefined,
-    userPushHeaders: Record<string, string> | undefined,
-    onAuthFailure?: () => void,
-  ) {
-    return this.#pusher.initConnection(
-      clientID,
-      wsID,
-      userPushURL,
-      userPushHeaders,
-      onAuthFailure,
-    );
+  initConnection(selector: ConnectionSelector) {
+    return this.#pusher.initConnection(selector);
   }
 
   enqueuePush(
-    clientID: string,
+    selector: ConnectionSelector,
     push: PushBody,
-    auth: string | undefined,
-    httpCookie: string | undefined,
-    origin: string | undefined,
   ): Exclude<HandlerResult, StreamResult> {
-    if (!this.#pushConfig.forwardCookies) {
-      httpCookie = undefined; // remove cookies if not forwarded
-    }
-    this.#queue.enqueue({push, auth, clientID, httpCookie, origin});
+    this.#pusher.enqueuePush(
+      this.#contextManager.mustGetConnectionContext(selector),
+      push,
+    );
 
     return {
       type: 'ok',
     };
   }
 
-  async ackMutationResponses(upToID: MutationID) {
-    const url = this.#pusher.effectivePushURL;
-    if (!url) {
+  async ackMutationResponses(
+    requester: ConnectionSelector,
+    upToID: MutationID,
+  ): Promise<void> {
+    const ctx = this.#contextManager.getConnectionContext(requester);
+    if (!ctx?.pushContext?.url) {
       // No push URL configured, skip cleanup
       return;
     }
@@ -173,10 +151,8 @@ export class PusherService implements Service, Pusher {
         pushResponseSchema,
         'push',
         this.#lc,
-        url,
-        this.#pushURLPatterns,
+        ctx,
         {appID: this.#config.app.id, shardNum: this.#config.shard.num},
-        {apiKey: this.#pushConfig.apiKey},
         cleanupBody,
       );
     } catch (e) {
@@ -186,12 +162,16 @@ export class PusherService implements Service, Pusher {
     }
   }
 
-  async deleteClientMutations(clientIDs: string[]) {
+  async deleteClientMutations(
+    requester: ConnectionSelector,
+    clientIDs: string[],
+  ): Promise<void> {
     if (clientIDs.length === 0) {
       return;
     }
-    const url = this.#pusher.effectivePushURL;
-    if (!url) {
+
+    const ctx = this.#contextManager.getConnectionContext(requester);
+    if (!ctx?.pushContext?.url) {
       // No push URL configured, skip cleanup
       return;
     }
@@ -224,10 +204,8 @@ export class PusherService implements Service, Pusher {
         pushResponseSchema,
         'push',
         this.#lc,
-        url,
-        this.#pushURLPatterns,
+        ctx,
         {appID: this.#config.app.id, shardNum: this.#config.shard.num},
-        {apiKey: this.#pushConfig.apiKey},
         cleanupBody,
       );
     } catch (e) {
@@ -271,10 +249,7 @@ export class PusherService implements Service, Pusher {
 
 type PusherEntry = {
   push: PushBody;
-  auth: string | undefined;
-  httpCookie: string | undefined;
-  origin: string | undefined;
-  clientID: string;
+  context: ConnectionContext;
 };
 type PusherEntryOrStop = PusherEntry | 'stop';
 
@@ -283,23 +258,14 @@ type PusherEntryOrStop = PusherEntry | 'stop';
  * to the user's API server.
  */
 class PushWorker {
-  readonly #pushURLs: string[];
-  readonly #pushURLPatterns: URLPattern[];
-  readonly #apiKey: string | undefined;
-  readonly #allowedClientHeaders: readonly string[] | undefined;
+  readonly #contextManager: ConnectionContextManager;
   readonly #queue: Queue<PusherEntryOrStop>;
   readonly #lc: LogContext;
   readonly #config: Config;
   readonly #clients: Map<
     string,
-    {
-      wsID: string;
-      downstream: Subscription<Downstream>;
-      onAuthFailure: (() => void) | undefined;
-    }
+    {wsID: string; downstream: Subscription<Downstream>}
   >;
-  #userPushURL?: string | undefined;
-  #userPushHeaders?: Record<string, string> | undefined;
 
   readonly #customMutations = getOrCreateCounter(
     'mutation',
@@ -315,42 +281,23 @@ class PushWorker {
   constructor(
     config: Config,
     lc: LogContext,
-    pushURL: string[],
-    apiKey: string | undefined,
-    allowedClientHeaders: readonly string[] | undefined,
+    contextManager: ConnectionContextManager,
     queue: Queue<PusherEntryOrStop>,
   ) {
-    this.#pushURLs = pushURL;
     this.#lc = lc.withContext('component', 'pusher');
-    this.#pushURLPatterns = pushURL.map(compileUrlPattern);
-    this.#apiKey = apiKey;
-    this.#allowedClientHeaders = allowedClientHeaders;
+    this.#contextManager = contextManager;
     this.#queue = queue;
     this.#config = config;
     this.#clients = new Map();
-  }
-
-  get pushURLs() {
-    return this.#pushURLs;
-  }
-
-  get effectivePushURL(): string | undefined {
-    return this.#userPushURL ?? this.#pushURLs[0];
   }
 
   /**
    * Returns a new downstream stream if the clientID,wsID pair has not been seen before.
    * If a clientID already exists with a different wsID, that client's downstream is cancelled.
    */
-  initConnection(
-    clientID: string,
-    wsID: string,
-    userPushURL: string | undefined,
-    userPushHeaders: Record<string, string> | undefined,
-    onAuthFailure?: () => void,
-  ) {
-    const existing = this.#clients.get(clientID);
-    if (existing && existing.wsID === wsID) {
+  initConnection(selector: ConnectionSelector) {
+    const existing = this.#clients.get(selector.clientID);
+    if (existing && existing.wsID === selector.wsID) {
       // already initialized for this socket
       throw new Error('Connection was already initialized');
     }
@@ -360,32 +307,23 @@ class PushWorker {
       existing.downstream.cancel();
     }
 
-    // Handle client group level URL parameters
-    if (this.#userPushURL === undefined) {
-      // First client in the group - store its URL and headers
-      this.#userPushURL = userPushURL;
-      this.#userPushHeaders = userPushHeaders;
-    } else {
-      // Validate that subsequent clients have compatible parameters
-      if (this.#userPushURL !== userPushURL) {
-        this.#lc.warn?.(
-          'Client provided different mutate parameters than client group',
-          {
-            clientID,
-            clientURL: userPushURL,
-            clientGroupURL: this.#userPushURL,
-          },
-        );
-      }
-    }
-
     const downstream = Subscription.create<Downstream>({
       cleanup: () => {
-        this.#clients.delete(clientID);
+        this.#clients.delete(selector.clientID);
       },
     });
-    this.#clients.set(clientID, {wsID, downstream, onAuthFailure});
+    this.#clients.set(selector.clientID, {
+      wsID: selector.wsID,
+      downstream,
+    });
     return downstream;
+  }
+
+  enqueuePush(context: ConnectionContext, push: PushBody) {
+    this.#queue.enqueue({
+      push,
+      context,
+    });
   }
 
   async run() {
@@ -466,16 +404,8 @@ class PushWorker {
                   };
 
           this.#failDownstream(client.downstream, pushFailedBody);
-          if (isPushAuthFailure(pushFailedBody)) {
-            this.#lc.debug?.('Auth failure detected in push response');
-            client.onAuthFailure?.();
-          }
         } else if ('kind' in response) {
           this.#failDownstream(client.downstream, response);
-          if (isPushAuthFailure(response)) {
-            this.#lc.debug?.('Auth failure detected in push response');
-            client.onAuthFailure?.();
-          }
         } else {
           unreachable(response);
         }
@@ -546,9 +476,10 @@ class PushWorker {
     // Record custom mutations for telemetry
     recordMutation('custom', entry.push.mutations.length);
 
-    const url =
-      this.#userPushURL ??
-      must(this.#pushURLs[0], 'ZERO_MUTATE_URL is not set');
+    const url = must(
+      entry.context.pushContext.url,
+      'ZERO_MUTATE_URL is not set',
+    );
 
     this.#lc.debug?.(
       'pushing to',
@@ -566,32 +497,54 @@ class PushWorker {
         clientID: m.clientID,
       }));
 
-      return await fetchFromAPIServer(
+      const response = await fetchFromAPIServer(
         pushResponseSchema,
         'push',
         this.#lc,
-        url,
-        this.#pushURLPatterns,
+        entry.context,
         {
           appID: this.#config.app.id,
           shardNum: this.#config.shard.num,
         },
-        {
-          apiKey: this.#apiKey,
-          customHeaders: this.#userPushHeaders,
-          allowedClientHeaders: this.#allowedClientHeaders,
-          token: entry.auth,
-          cookie: entry.httpCookie,
-          origin: entry.origin,
-        },
         entry.push,
       );
+      if ('kind' in response || 'error' in response) {
+        if (isAuthErrorBody(response)) {
+          this.#lc.warn?.('Push auth failed; invalidating connection', {
+            clientID: entry.context.clientID,
+            response: 'kind' in response ? response.message : undefined,
+          });
+          this.#contextManager.failConnection(
+            entry.context,
+            entry.context.revision,
+          );
+        }
+        return response;
+      }
+      // A successful push also validates this connection's current auth snapshot.
+      // That lets later shared work reuse it without trusting stale credentials.
+      this.#contextManager.validateConnection(
+        entry.context,
+        entry.context.revision,
+      );
+      return response;
     } catch (e) {
       if (isProtocolError(e) && e.errorBody.kind === ErrorKind.PushFailed) {
-        return {
+        const response = {
           ...e.errorBody,
           mutationIDs,
         } as const satisfies PushFailedBody;
+        if (isAuthErrorBody(response)) {
+          this.#lc.warn?.('Push auth failed; invalidating connection', {
+            clientID: entry.context.clientID,
+            response: 'kind' in response ? response.message : undefined,
+          });
+          this.#contextManager.failConnection(
+            entry.context,
+            entry.context.revision,
+          );
+        }
+        return response;
       }
 
       return {
@@ -612,27 +565,20 @@ class PushWorker {
   }
 }
 
-function isPushAuthFailure(errorBody: PushFailedBody): boolean {
-  return (
-    errorBody.reason === ErrorReason.HTTP &&
-    (errorBody.status === 401 || errorBody.status === 403)
-  );
-}
-
 /**
- * Pushes for different clientIDs could theoretically be interleaved.
+ * Pushes for different clients, sockets, or auth revisions could be interleaved.
  *
- * In order to do efficient batching to the user's API server,
- * we collect all pushes for the same clientID into a single push.
+ * In order to batch safely, we only combine pushes from the same
+ * clientID/wsID/revision snapshot.
  */
 export function combinePushes(
   entries: readonly (PusherEntryOrStop | undefined)[],
 ): [PusherEntry[], boolean] {
-  const pushesByClientID = new Map<string, PusherEntry[]>();
+  const pushesByConnection = new Map<string, PusherEntry[]>();
 
   function collect() {
     const ret: PusherEntry[] = [];
-    for (const entries of pushesByClientID.values()) {
+    for (const entries of pushesByConnection.values()) {
       const composite: PusherEntry = {
         ...entries[0],
         push: {
@@ -654,12 +600,12 @@ export function combinePushes(
       return [collect(), true];
     }
 
-    const {clientID} = entry;
-    const existing = pushesByClientID.get(clientID);
+    const key = `${entry.context.clientID}:${entry.context.wsID}:${entry.context.revision}`;
+    const existing = pushesByConnection.get(key);
     if (existing) {
       existing.push(entry);
     } else {
-      pushesByClientID.set(clientID, [entry]);
+      pushesByConnection.set(key, [entry]);
     }
   }
 
@@ -670,11 +616,19 @@ export function combinePushes(
 // If they are not, we have a bug in the code somewhere.
 function assertAreCompatiblePushes(left: PusherEntry, right: PusherEntry) {
   assert(
-    left.clientID === right.clientID,
+    left.context.clientID === right.context.clientID,
     'clientID must be the same for all pushes',
   );
   assert(
-    left.auth === right.auth,
+    left.context.wsID === right.context.wsID,
+    'wsID must be the same for all pushes',
+  );
+  assert(
+    left.context.revision === right.context.revision,
+    'revision must be the same for all pushes',
+  );
+  assert(
+    left.context.auth === right.context.auth,
     'auth must be the same for all pushes with the same clientID',
   );
   assert(
@@ -686,11 +640,21 @@ function assertAreCompatiblePushes(left: PusherEntry, right: PusherEntry) {
     'pushVersion must be the same for all pushes with the same clientID',
   );
   assert(
-    left.httpCookie === right.httpCookie,
+    left.context.pushContext.headerOptions.cookie ===
+      right.context.pushContext.headerOptions.cookie,
     'httpCookie must be the same for all pushes with the same clientID',
   );
   assert(
-    left.origin === right.origin,
+    left.context.pushContext.headerOptions.origin ===
+      right.context.pushContext.headerOptions.origin,
     'origin must be the same for all pushes with the same clientID',
+  );
+  assert(
+    left.context.userID === right.context.userID,
+    'userID must be the same for all pushes with the same clientID',
+  );
+  assert(
+    left.context.pushContext.url === right.context.pushContext.url,
+    'userPushURL must be the same for all pushes with the same clientID',
   );
 }

--- a/packages/zero-cache/src/services/view-syncer/connection-context-manager.ts
+++ b/packages/zero-cache/src/services/view-syncer/connection-context-manager.ts
@@ -1,0 +1,742 @@
+import type {LogContext} from '@rocicorp/logger';
+import type {InitConnectionBody} from '../../../../zero-protocol/src/connect.ts';
+import {ErrorKind} from '../../../../zero-protocol/src/error-kind.ts';
+import {ErrorOrigin} from '../../../../zero-protocol/src/error-origin.ts';
+import {
+  resolveAuth,
+  type Auth,
+  type ValidateLegacyJWT,
+} from '../../auth/auth.ts';
+import {compileUrlPattern} from '../../custom/fetch.ts';
+import {ProtocolErrorWithLevel} from '../../types/error-with-level.ts';
+import type {ConnectParams} from '../../workers/connect-params.ts';
+import type {UpdateAuthBody} from '../../../../zero-protocol/src/update-auth.ts';
+import type {ZeroConfig} from '../../config/zero-config.ts';
+
+export type ConnectionState = 'provisional' | 'validated';
+
+/**
+ * Identifies one live websocket for a client slot.
+ */
+export type ConnectionSelector = {
+  readonly clientID: string;
+  readonly wsID: string;
+};
+
+type FetchConfig = ZeroConfig['query'];
+
+export type HeaderOptions = {
+  apiKey?: string | undefined;
+  customHeaders?: Record<string, string> | undefined;
+  allowedClientHeaders?: readonly string[] | undefined;
+  cookie?: string | undefined;
+  origin?: string | undefined;
+};
+
+export type ConnectionFetchContext = {
+  url: string | undefined;
+  allowedUrlPatterns: URLPattern[] | undefined;
+  headerOptions: HeaderOptions;
+};
+
+/**
+ * A snapshot of one live connection tracked by the manager.
+ *
+ * `revalidateAt` is only populated while the connection is `validated`.
+ */
+export type ConnectionContext = {
+  state: ConnectionState;
+
+  readonly clientID: string;
+  readonly wsID: string;
+  readonly userID: string | undefined;
+
+  auth: Auth | undefined;
+
+  readonly profileID: string | null;
+  readonly baseCookie: string | null;
+  readonly protocolVersion: number;
+
+  revision: number;
+
+  revalidateAt: number | undefined;
+
+  readonly insertionOrder: number;
+
+  readonly queryContext: ConnectionFetchContext;
+  readonly pushContext: ConnectionFetchContext;
+};
+
+/**
+ * Group-scoped auth state shared across the live connections.
+ *
+ * The background connection is the validated connection currently used for
+ * shared background work. Retransform happens on a group level, and uses
+ * the background connection's credential to refetch the latest queries.
+ *
+ * Since auth can be pinned to logged-out users, `userID` can be undefined
+ * even after validation.
+ */
+export type GroupAuthState = {
+  userID: string | undefined;
+  validated: boolean;
+
+  backgroundConnection: ConnectionSelector | undefined;
+  retransformAt: number | undefined;
+};
+
+export type ConnectionContextManager = {
+  registerConnection(
+    selector: ConnectionSelector,
+    connectParams: ConnectParams,
+    auth?: Auth,
+  ): Readonly<ConnectionContext>;
+
+  initConnection(
+    selector: ConnectionSelector,
+    body: InitConnectionBody,
+  ): Readonly<ConnectionContext>;
+
+  updateAuth(
+    selector: ConnectionSelector,
+    body: UpdateAuthBody,
+  ): Promise<Readonly<ConnectionContext>>;
+
+  validateConnection(
+    selector: ConnectionSelector,
+    revision: number,
+  ):
+    | Readonly<{
+        connection: ConnectionContext;
+        group: GroupAuthState;
+      }>
+    | undefined;
+
+  failConnection(
+    selector: ConnectionSelector,
+    revision: number,
+  ): Readonly<ConnectionContext> | undefined;
+  closeConnection(
+    selector: ConnectionSelector,
+  ): Readonly<ConnectionContext> | undefined;
+
+  markBackgroundRetransformSuccess(
+    selector: ConnectionSelector,
+    revision: number,
+  ): void;
+
+  getConnectionContext(
+    selector: ConnectionSelector,
+  ): Readonly<ConnectionContext> | undefined;
+  mustGetConnectionContext(
+    selector: ConnectionSelector,
+  ): Readonly<ConnectionContext>;
+
+  getBackgroundConnectionContext(): Readonly<ConnectionContext> | undefined;
+  mustGetBackgroundConnectionContext(): Readonly<ConnectionContext>;
+
+  getGroupState(): Readonly<GroupAuthState>;
+
+  planMaintenance(): {
+    dueRevalidations: Readonly<ConnectionContext>[];
+    dueRetransform: boolean;
+    earliestDeadlineAt: number | undefined;
+  };
+};
+
+/**
+ * State machine for the auth state of a single `ViewSyncerService`.
+ *
+ * Connections are registered as `provisional`, optionally backfilled with
+ * `initConnection` metadata, and then promoted to `validated` once their
+ * stored `userID` is confirmed as valid. The manager also tracks which
+ * validated connection currently serves as the group's background connection.
+ *
+ * This is intentionally side-effect free.
+ */
+export class ConnectionContextManagerImpl implements ConnectionContextManager {
+  readonly #lc: LogContext;
+
+  // The live connection records, keyed by clientID
+  readonly #connections = new Map<string, ConnectionContext>();
+  readonly #group: GroupAuthState = {
+    userID: undefined,
+    backgroundConnection: undefined,
+    retransformAt: undefined,
+    validated: false,
+  };
+
+  readonly #validateLegacyJWT: ValidateLegacyJWT | undefined;
+
+  readonly #now: () => number;
+  readonly #revalidateIntervalMs: number | undefined;
+  readonly #retransformIntervalMs: number | undefined;
+  readonly #queryConfig: FetchConfig | undefined;
+  readonly #pushConfig: FetchConfig | undefined;
+  #nextInsertionOrder = 0;
+
+  constructor(
+    lc: LogContext,
+    revalidateIntervalSeconds?: number,
+    retransformIntervalSeconds?: number,
+    queryConfig?: FetchConfig,
+    pushConfig?: FetchConfig,
+    validateLegacyJWT?: ValidateLegacyJWT,
+    now?: () => number,
+  ) {
+    this.#lc = lc;
+    this.#now = now ?? Date.now;
+    this.#revalidateIntervalMs =
+      revalidateIntervalSeconds === undefined
+        ? undefined
+        : revalidateIntervalSeconds * 1000;
+    this.#retransformIntervalMs =
+      retransformIntervalSeconds === undefined
+        ? undefined
+        : retransformIntervalSeconds * 1000;
+    this.#queryConfig = queryConfig;
+    this.#pushConfig = pushConfig;
+    this.#validateLegacyJWT = validateLegacyJWT;
+  }
+
+  /**
+   * Creates or replaces the live record for a websocket connection.
+   *
+   * Re-registering the same `clientID` drops the old socket record and starts
+   * the replacement back in `provisional` state.
+   */
+  registerConnection(
+    selector: ConnectionSelector,
+    connectParams: ConnectParams,
+    auth?: Auth,
+  ): Readonly<ConnectionContext> {
+    this.#removeConnection(selector);
+
+    const sharedHeaders = {
+      customHeaders: undefined,
+      token: auth?.raw,
+      origin: connectParams.origin,
+      userID: connectParams.userID,
+    };
+
+    const connection: ConnectionContext = {
+      state: 'provisional',
+
+      clientID: connectParams.clientID,
+      wsID: connectParams.wsID,
+      revision: 0,
+      userID: connectParams.userID,
+      auth,
+
+      profileID: connectParams.profileID,
+      baseCookie: connectParams.baseCookie,
+      protocolVersion: connectParams.protocolVersion,
+
+      revalidateAt: undefined,
+
+      queryContext: {
+        url: this.#queryConfig?.url?.[0],
+        allowedUrlPatterns: this.#queryConfig?.url?.map(compileUrlPattern),
+        headerOptions: {
+          ...sharedHeaders,
+          apiKey: this.#queryConfig?.apiKey,
+          allowedClientHeaders: this.#queryConfig?.allowedClientHeaders,
+          cookie: this.#queryConfig?.forwardCookies
+            ? connectParams.httpCookie
+            : undefined,
+        },
+      },
+      pushContext: {
+        url: this.#pushConfig?.url?.[0],
+        allowedUrlPatterns: this.#pushConfig?.url?.map(compileUrlPattern),
+        headerOptions: {
+          ...sharedHeaders,
+          apiKey: this.#pushConfig?.apiKey,
+          allowedClientHeaders: this.#pushConfig?.allowedClientHeaders,
+          cookie: this.#pushConfig?.forwardCookies
+            ? connectParams.httpCookie
+            : undefined,
+        },
+      },
+
+      insertionOrder: ++this.#nextInsertionOrder,
+    };
+    this.#connections.set(connection.clientID, connection);
+    this.#refreshBackgroundConnectionContext();
+    this.#updateBackgroundRetransformDeadline(false);
+    return snapshotConnection(connection);
+  }
+
+  /**
+   * Backfills `initConnection` data for sockets that were registered before the
+   * client could send its full init payload.
+   *
+   * This updates metadata only; it does not validate the connection.
+   */
+  initConnection(
+    selector: ConnectionSelector,
+    body: InitConnectionBody,
+  ): Readonly<ConnectionContext> {
+    const connection = this.#mustGetConnectionContext(selector);
+
+    if (body.userQueryURL) {
+      connection.queryContext.url = body.userQueryURL;
+    }
+    if (body.userQueryHeaders) {
+      connection.queryContext.headerOptions.customHeaders =
+        body.userQueryHeaders;
+    }
+    if (body.userPushURL) {
+      connection.pushContext.url = body.userPushURL;
+    }
+    if (body.userPushHeaders) {
+      connection.pushContext.headerOptions.customHeaders = body.userPushHeaders;
+    }
+
+    connection.revision++;
+    this.#demoteConnection(connection);
+
+    return snapshotConnection(connection);
+  }
+
+  /**
+   * A material auth change demotes the connection back to provisional until it
+   * is validated again.
+   */
+  async updateAuth(
+    selector: ConnectionSelector,
+    body: UpdateAuthBody,
+  ): Promise<Readonly<ConnectionContext>> {
+    const connection = this.#mustGetConnectionContext(selector);
+
+    const nextAuth = await resolveAuth(
+      this.#lc,
+      connection.auth,
+      connection.userID,
+      body.auth,
+      this.#validateLegacyJWT,
+    );
+
+    const authChanged = !authEquals(connection.auth, nextAuth);
+    connection.auth = nextAuth;
+    if (authChanged) {
+      connection.revision++;
+      this.#demoteConnection(connection);
+    }
+
+    return snapshotConnection(connection);
+  }
+
+  /**
+   * Validates one connection against the group's pinned `userID`.
+   *
+   * The first successful validation binds the group `userID`. Later
+   * validations must match it. Validation also refreshes the connection's
+   * revalidation deadline and may pick the connection as the group
+   * background connection if none is currently available. If the websocket is
+   * gone by the time async validation finishes, this becomes a no-op.
+   */
+  validateConnection(
+    selector: ConnectionSelector,
+    revision: number,
+  ):
+    | Readonly<{
+        connection: ConnectionContext;
+        group: GroupAuthState;
+      }>
+    | undefined {
+    const connection = this.#getConnectionContext(selector);
+    if (!connection) {
+      return undefined;
+    }
+
+    if (connection.revision !== revision) {
+      this.#lc.debug?.('Skipping validateConnection for stale revision', {
+        clientID: selector.clientID,
+        attemptedRevision: revision,
+        currentRevision: connection.revision,
+      });
+      return undefined;
+    }
+
+    if (this.#group.validated && this.#group.userID !== connection.userID) {
+      throw new ProtocolErrorWithLevel(
+        {
+          kind: ErrorKind.Unauthorized,
+          message:
+            'Client groups are pinned to a single userID. Connection userID does not match existing client group userID.',
+          origin: ErrorOrigin.ZeroCache,
+        },
+        'warn',
+      );
+    }
+
+    if (!this.#group.validated) {
+      this.#group.validated = true;
+      this.#group.userID = connection.userID;
+    }
+
+    connection.state = 'validated';
+    connection.revalidateAt = this.#nextRevalidateAt();
+    this.#refreshBackgroundConnectionContext(connection);
+    this.#updateBackgroundRetransformDeadline(false);
+
+    return {
+      connection: snapshotConnection(connection),
+      group: this.getGroupState(),
+    };
+  }
+
+  /** Removes one connection due to failed auth and updates all derived background/deadline state. */
+  failConnection(
+    selector: ConnectionSelector,
+    revision: number,
+  ): ConnectionContext | undefined {
+    return this.#removeConnection(selector, revision);
+  }
+
+  /** Removes one disconnected connection and updates all derived background/deadline state. */
+  closeConnection(selector: ConnectionSelector): ConnectionContext | undefined {
+    return this.#removeConnection(selector);
+  }
+
+  /**
+   * Records a successful background retransform. This starts a fresh interval
+   * from the manager clock when shared retransform is schedulable, or
+   * clears the deadline if it is not.
+   */
+  markBackgroundRetransformSuccess(
+    selector: ConnectionSelector,
+    revision: number,
+  ): void {
+    const backgroundConnection = this.#getBackgroundConnectionContext();
+    if (!backgroundConnection) {
+      return;
+    }
+    if (
+      selector !== undefined &&
+      (backgroundConnection.clientID !== selector.clientID ||
+        backgroundConnection.wsID !== selector.wsID ||
+        backgroundConnection.revision !== revision)
+    ) {
+      return;
+    }
+    this.#updateBackgroundRetransformDeadline(true);
+  }
+
+  /** Returns the current live record for a client slot, if any. */
+  getConnectionContext(
+    selector: ConnectionSelector,
+  ): Readonly<ConnectionContext> | undefined {
+    return snapshotConnection(this.#getConnectionContext(selector));
+  }
+
+  /** Returns the live record for one websocket or throws if it is unavailable. */
+  mustGetConnectionContext(
+    selector: ConnectionSelector,
+  ): Readonly<ConnectionContext> {
+    return snapshotConnection(this.#mustGetConnectionContext(selector));
+  }
+
+  /** Returns the current background connection, if one exists. */
+  getBackgroundConnectionContext(): Readonly<ConnectionContext> | undefined {
+    return snapshotConnection(this.#getBackgroundConnectionContext());
+  }
+
+  mustGetBackgroundConnectionContext(): Readonly<ConnectionContext> {
+    const backgroundConnection = this.#getBackgroundConnectionContext();
+    if (!backgroundConnection) {
+      throw new ProtocolErrorWithLevel(
+        {
+          kind: ErrorKind.InvalidConnectionRequest,
+          message:
+            'No validated connection is available for shared query work.',
+          origin: ErrorOrigin.ZeroCache,
+        },
+        'warn',
+      );
+    }
+    return backgroundConnection;
+  }
+
+  /** Returns the shared group auth state. */
+  getGroupState(): Readonly<GroupAuthState> {
+    return snapshotGroup(this.#group);
+  }
+
+  /**
+   * Reports which maintenance work is currently due.
+   *
+   * The result is a pure snapshot: callers decide which actions to run and
+   * when to wake up next. `earliestDeadlineAt` is the earliest outstanding
+   * maintenance deadline, including overdue work, so it may be less than or
+   * equal to the manager clock.
+   */
+  planMaintenance(): {
+    dueRevalidations: Readonly<ConnectionContext>[];
+    dueRetransform: boolean;
+    earliestDeadlineAt: number | undefined;
+  } {
+    const dueRevalidations: Readonly<ConnectionContext>[] = [];
+    const now = this.#now();
+    let earliestDeadlineAt = this.#group.retransformAt;
+
+    for (const connection of this.#connections.values()) {
+      if (
+        connection.state !== 'validated' ||
+        connection.revalidateAt === undefined
+      ) {
+        continue;
+      }
+      if (connection.revalidateAt <= now) {
+        dueRevalidations.push(snapshotConnection(connection));
+      }
+      earliestDeadlineAt = minDefined(
+        earliestDeadlineAt,
+        connection.revalidateAt,
+      );
+    }
+
+    return {
+      dueRevalidations: dueRevalidations.sort(compareByInsertionOrder),
+      dueRetransform:
+        this.#group.retransformAt !== undefined &&
+        this.#group.retransformAt <= now,
+      earliestDeadlineAt,
+    };
+  }
+
+  #removeConnection(
+    selector: ConnectionSelector,
+    revision?: number,
+  ): Readonly<ConnectionContext> | undefined {
+    const connection = this.#getConnectionContext(selector);
+
+    if (!connection) {
+      return undefined;
+    }
+
+    // If the revision has changed, we should not remove the connection
+    if (revision !== undefined && connection.revision !== revision) {
+      this.#lc.debug?.('Ignoring failConnection for stale revision', {
+        clientID: selector.clientID,
+        wsID: selector.wsID,
+        attemptedRevision: revision,
+        currentRevision: connection.revision,
+      });
+      return undefined;
+    }
+
+    const snapshot = snapshotConnection(connection);
+
+    this.#connections.delete(connection.clientID);
+    this.#refreshBackgroundConnectionContext();
+    this.#updateBackgroundRetransformDeadline(false);
+
+    return snapshot;
+  }
+
+  #demoteConnection(connection: ConnectionContext): void {
+    connection.state = 'provisional';
+    connection.revalidateAt = undefined;
+    this.#refreshBackgroundConnectionContext();
+    this.#updateBackgroundRetransformDeadline(false);
+  }
+
+  /**
+   * Keeps the background connection sticky while it remains validated.
+   *
+   * When a newly validated `preferred` connection is provided, it is promoted
+   * only if there is no current validated background connection. Otherwise the
+   * existing background connection stays in place until it disappears or is
+   * demoted, at which point the newest validated connection is selected.
+   */
+  #refreshBackgroundConnectionContext(preferred?: ConnectionContext): void {
+    if (preferred?.state === 'validated') {
+      const currentBackgroundConnection =
+        this.#getBackgroundConnectionContext();
+      if (
+        currentBackgroundConnection?.clientID === preferred.clientID &&
+        currentBackgroundConnection.wsID === preferred.wsID
+      ) {
+        return;
+      }
+      if (currentBackgroundConnection !== undefined) {
+        return;
+      }
+      this.#group.backgroundConnection = {
+        clientID: preferred.clientID,
+        wsID: preferred.wsID,
+      };
+      this.#lc.debug?.('Selected background connection for shared auth work', {
+        clientID: preferred.clientID,
+        wsID: preferred.wsID,
+        revision: preferred.revision,
+        reason: 'preferred-validated',
+      });
+      return;
+    }
+
+    const currentBackgroundConnection = this.#getBackgroundConnectionContext();
+    if (currentBackgroundConnection?.state === 'validated') {
+      return;
+    }
+
+    const nextBackgroundConnection = [...this.#connections.values()]
+      .filter(connection => connection.state === 'validated')
+      .sort(comparePreferredValidatedConnection)
+      .at(0);
+    this.#group.backgroundConnection = nextBackgroundConnection
+      ? {
+          clientID: nextBackgroundConnection.clientID,
+          wsID: nextBackgroundConnection.wsID,
+        }
+      : undefined;
+    if (nextBackgroundConnection) {
+      this.#lc.debug?.('Selected background connection for shared auth work', {
+        clientID: nextBackgroundConnection.clientID,
+        wsID: nextBackgroundConnection.wsID,
+        revision: nextBackgroundConnection.revision,
+        reason: 'fallback-validated',
+      });
+    }
+  }
+
+  #getBackgroundConnectionContext(): ConnectionContext | undefined {
+    const backgroundConnection = this.#group.backgroundConnection;
+    if (!backgroundConnection) {
+      return undefined;
+    }
+    return this.#getConnectionContext(backgroundConnection);
+  }
+
+  #getConnectionContext(
+    selector: ConnectionSelector,
+  ): ConnectionContext | undefined {
+    const connection = this.#connections.get(selector.clientID);
+    if (!connection) {
+      return undefined;
+    }
+    if (connection.wsID !== selector.wsID) {
+      return undefined;
+    }
+    return connection;
+  }
+
+  #mustGetConnectionContext(selector: ConnectionSelector): ConnectionContext {
+    const connection = this.#getConnectionContext(selector);
+
+    if (!connection) {
+      throw new ProtocolErrorWithLevel(
+        {
+          kind: ErrorKind.InvalidConnectionRequest,
+          message:
+            'Connection auth state was not available for this websocket.',
+          origin: ErrorOrigin.ZeroCache,
+        },
+        'warn',
+      );
+    }
+
+    return connection;
+  }
+
+  /**
+   * Keeps the group background retransform deadline coherent with current
+   * schedulability.
+   *
+   * When `reset` is false, this seeds a deadline only when shared retransform
+   * is now possible and no deadline exists yet, preserving any existing
+   * cadence. When `reset` is true, it starts a fresh interval from `#now()` if
+   * retransform is schedulable, or clears the deadline if it is not.
+   */
+  #updateBackgroundRetransformDeadline(reset: boolean) {
+    const backgroundConnection = this.#getBackgroundConnectionContext();
+    if (!backgroundConnection || this.#retransformIntervalMs === undefined) {
+      this.#group.retransformAt = undefined;
+      return;
+    }
+
+    if (reset || this.#group.retransformAt === undefined) {
+      this.#group.retransformAt = this.#now() + this.#retransformIntervalMs;
+    }
+  }
+
+  #nextRevalidateAt() {
+    return this.#revalidateIntervalMs === undefined
+      ? undefined
+      : this.#now() + this.#revalidateIntervalMs;
+  }
+}
+
+function authEquals(a: Auth | undefined, b: Auth | undefined) {
+  if (a === b) {
+    return true;
+  }
+  if (!a || !b) {
+    return false;
+  }
+  return a.type === b.type && a.raw === b.raw;
+}
+
+function snapshotConnection<T extends ConnectionContext | undefined>(
+  connection: T,
+): T extends undefined ? T | undefined : Readonly<T> {
+  if (!connection) {
+    return undefined as T extends undefined ? T | undefined : Readonly<T>;
+  }
+  return {
+    ...connection,
+    queryContext: {
+      ...connection.queryContext,
+      headerOptions: {
+        ...connection.queryContext.headerOptions,
+        customHeaders: connection.queryContext.headerOptions.customHeaders
+          ? {...connection.queryContext.headerOptions.customHeaders}
+          : undefined,
+      },
+    },
+    pushContext: {
+      ...connection.pushContext,
+      headerOptions: {
+        ...connection.pushContext.headerOptions,
+        customHeaders: connection.pushContext.headerOptions.customHeaders
+          ? {...connection.pushContext.headerOptions.customHeaders}
+          : undefined,
+      },
+    },
+  } as T extends undefined ? T | undefined : Readonly<T>;
+}
+
+function snapshotGroup(group: GroupAuthState): Readonly<GroupAuthState> {
+  return {
+    ...group,
+    backgroundConnection: group.backgroundConnection
+      ? {...group.backgroundConnection}
+      : undefined,
+  };
+}
+
+function compareByInsertionOrder(
+  a: Pick<ConnectionContext, 'insertionOrder' | 'wsID'>,
+  b: Pick<ConnectionContext, 'insertionOrder' | 'wsID'>,
+) {
+  return a.insertionOrder - b.insertionOrder || a.wsID.localeCompare(b.wsID);
+}
+
+function comparePreferredValidatedConnection(
+  a: Pick<ConnectionContext, 'insertionOrder' | 'wsID'>,
+  b: Pick<ConnectionContext, 'insertionOrder' | 'wsID'>,
+) {
+  return b.insertionOrder - a.insertionOrder || b.wsID.localeCompare(a.wsID);
+}
+
+function minDefined(a: number | undefined, b: number | undefined) {
+  if (a === undefined) {
+    return b;
+  }
+  if (b === undefined) {
+    return a;
+  }
+  return Math.min(a, b);
+}

--- a/packages/zero-cache/src/services/view-syncer/inspect-handler.ts
+++ b/packages/zero-cache/src/services/view-syncer/inspect-handler.ts
@@ -3,18 +3,17 @@ import {unreachable} from '../../../../shared/src/asserts.ts';
 import {must} from '../../../../shared/src/must.ts';
 import type {InspectUpBody} from '../../../../zero-protocol/src/inspect-up.ts';
 import {Database} from '../../../../zqlite/src/db.ts';
-import type {JWTAuth} from '../../auth/auth.ts';
 import {loadPermissions} from '../../auth/load-permissions.ts';
 import type {NormalizedZeroConfig} from '../../config/normalize.ts';
 import {
   getServerVersion,
   isAdminPasswordValid,
 } from '../../config/zero-config.ts';
-import type {HeaderOptions} from '../../custom/fetch.ts';
 import {StatementRunner} from '../../db/statements.ts';
 import type {InspectorDelegate} from '../../server/inspector-delegate.ts';
 import {analyzeQuery} from '../analyze.ts';
 import type {ClientHandler} from './client-handler.ts';
+import type {ConnectionContext} from './connection-context-manager.ts';
 import type {CVRStore} from './cvr-store.ts';
 import type {CVRSnapshot} from './cvr.ts';
 
@@ -27,9 +26,7 @@ export async function handleInspect(
   clientGroupID: string,
   cvrStore: CVRStore,
   config: NormalizedZeroConfig,
-  headerOptions: HeaderOptions,
-  userQueryURL: string | undefined,
-  auth: JWTAuth | undefined,
+  ctx: ConnectionContext,
 ): Promise<void> {
   // Check if the client is already authenticated. We only authenticate the clientGroup
   // once per "worker".
@@ -116,8 +113,7 @@ export async function handleInspect(
           ast = await inspectorDelegate.transformCustomQuery(
             body.name,
             body.args,
-            headerOptions,
-            userQueryURL,
+            ctx,
           );
           legacyQuery = false;
         }
@@ -150,7 +146,7 @@ export async function handleInspect(
           body.options?.syncedRows,
           body.options?.vendedRows,
           permissions,
-          auth,
+          ctx.auth?.type === 'jwt' ? ctx.auth : undefined,
           body.options?.joinPlans,
         );
         client.sendInspectResponse(lc, {

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -23,7 +23,6 @@ import type {DeleteClientsMessage} from '../../../../zero-protocol/src/delete-cl
 import type {Downstream} from '../../../../zero-protocol/src/down.ts';
 import {ErrorKind} from '../../../../zero-protocol/src/error-kind.ts';
 import {ErrorOrigin} from '../../../../zero-protocol/src/error-origin.ts';
-import {ErrorReason} from '../../../../zero-protocol/src/error-reason.ts';
 import {
   isProtocolError,
   ProtocolError,
@@ -35,15 +34,16 @@ import type {
 } from '../../../../zero-protocol/src/inspect-up.ts';
 import type {UpdateAuthMessage} from '../../../../zero-protocol/src/update-auth.ts';
 import {clampTTL, MAX_TTL_MS} from '../../../../zql/src/query/ttl.ts';
-import type {Auth, AuthSession, AuthUpdateResult} from '../../auth/auth.ts';
+import {isAuthErrorBody, type Auth} from '../../auth/auth.ts';
 import {
   transformAndHashQuery,
   type TransformedAndHashed,
 } from '../../auth/read-authorizer.ts';
 import type {NormalizedZeroConfig} from '../../config/normalize.ts';
-import type {ZeroConfig} from '../../config/zero-config.ts';
-import type {CustomQueryTransformer} from '../../custom-queries/transform-query.ts';
-import type {HeaderOptions} from '../../custom/fetch.ts';
+import type {
+  CustomQueryTransformer,
+  TransformAttempt,
+} from '../../custom-queries/transform-query.ts';
 import {
   getOrCreateCounter,
   getOrCreateHistogram,
@@ -53,6 +53,7 @@ import type {InspectorDelegate} from '../../server/inspector-delegate.ts';
 import {
   getLogLevel,
   ProtocolErrorWithLevel,
+  wrapWithProtocolError,
 } from '../../types/error-with-level.ts';
 import type {PostgresDB} from '../../types/pg.ts';
 import {rowIDString, type RowKey} from '../../types/row-key.ts';
@@ -69,6 +70,11 @@ import {
   type PokeHandler,
   type RowPatch,
 } from './client-handler.ts';
+import type {
+  ConnectionContext,
+  ConnectionContextManager,
+  ConnectionSelector,
+} from './connection-context-manager.ts';
 import {ClientNotFoundError, CVRStore} from './cvr-store.ts';
 import type {CVRUpdater} from './cvr.ts';
 import {
@@ -104,42 +110,44 @@ import {
   type TTLClock,
 } from './ttl-clock.ts';
 
-export type SyncContext = {
-  readonly clientID: string;
-  readonly wsID: string;
+const PROTOCOL_VERSION_ATTR = 'protocol.version';
+
+export interface ViewSyncer {
+  initConnection(
+    selector: ConnectionSelector,
+    initConnectionMessage: InitConnectionMessage,
+  ): Source<Downstream>;
+
+  changeDesiredQueries(
+    selector: ConnectionSelector,
+    msg: ChangeDesiredQueriesMessage,
+  ): Promise<void>;
+
+  deleteClients(
+    selector: ConnectionSelector,
+    msg: DeleteClientsMessage,
+  ): Promise<string[]>;
+
+  inspect(selector: ConnectionSelector, msg: InspectUpMessage): Promise<void>;
+  updateAuth(
+    selector: ConnectionSelector,
+    msg: UpdateAuthMessage,
+    authRevisionChanged: boolean,
+  ): Promise<void>;
+
+  // Connection context management is owned by the view syncer for disconnect cleanup.
+  contextManager: ConnectionContextManager;
+}
+
+export type SyncContext = ConnectionSelector & {
   readonly profileID: string | null;
   readonly baseCookie: string | null;
   readonly protocolVersion: number;
   readonly httpCookie: string | undefined;
   readonly origin: string | undefined;
-  readonly userID: string;
-};
-
-const PROTOCOL_VERSION_ATTR = 'protocol.version';
-
-export interface ViewSyncer {
-  initConnection(
-    ctx: SyncContext,
-    msg: InitConnectionMessage,
-  ): Source<Downstream>;
-
-  changeDesiredQueries(
-    ctx: SyncContext,
-    msg: ChangeDesiredQueriesMessage,
-  ): Promise<void>;
-
-  deleteClients(ctx: SyncContext, msg: DeleteClientsMessage): Promise<string[]>;
-
-  inspect(context: SyncContext, msg: InspectUpMessage): Promise<void>;
-
+  readonly userID: string | undefined;
   readonly auth: Auth | undefined;
-  initAuthSession(
-    userID: string,
-    wireAuth: string | undefined,
-  ): Promise<AuthUpdateResult>;
-  updateAuth(ctx: SyncContext, msg: UpdateAuthMessage): Promise<void>;
-  clearAuth(): void;
-}
+};
 
 const DEFAULT_KEEPALIVE_MS = 5_000;
 
@@ -171,6 +179,10 @@ type CustomQueryTransformMode = 'all' | 'missing';
 
 export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   readonly id: string;
+  // Centralized connection/group auth bookkeeping plus maintenance policy.
+  // Network validation still happens in ViewSyncerService.
+  readonly contextManager: ConnectionContextManager;
+
   readonly #shard: ShardID;
   readonly #lc: LogContext;
   readonly #pipelines: PipelineDriver;
@@ -178,11 +190,6 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   readonly #drainCoordinator: DrainCoordinator;
   readonly #keepaliveMs: number;
   readonly #slowHydrateThreshold: number;
-  readonly #queryConfig: ZeroConfig['query'];
-  readonly #authSession: AuthSession;
-
-  userQueryURL?: string | undefined;
-  userQueryHeaders?: Record<string, string> | undefined;
 
   // The ViewSyncerService is only started in response to a connection,
   // so #lastConnectTime is always initialized to now(). This is necessary
@@ -231,12 +238,8 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   #cvr: CVRSnapshot | undefined;
   #pipelinesSynced = false;
 
-  #httpCookie: string | undefined;
-  #origin: string | undefined;
-
-  #lastAuthRevision: number = 0;
-
   #expiredQueriesTimer: ReturnType<SetTimeout> | 0 = 0;
+  #authMaintenanceTimer: ReturnType<SetTimeout> | 0 = 0;
   readonly #setTimeout: SetTimeout;
   readonly #customQueryTransformer: CustomQueryTransformer | undefined;
 
@@ -314,21 +317,20 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     drainCoordinator: DrainCoordinator,
     slowHydrateThreshold: number,
     inspectorDelegate: InspectorDelegate,
+    contextManager: ConnectionContextManager,
     customQueryTransformer: CustomQueryTransformer | undefined,
     runPriorityOp: <T>(
       lc: LogContext,
       description: string,
       op: () => Promise<T>,
     ) => Promise<T>,
-    authSession: AuthSession,
     keepaliveMs = DEFAULT_KEEPALIVE_MS,
     setTimeoutFn: SetTimeout = setTimeout.bind(globalThis),
   ) {
-    const queryConfig = config.query?.url ? config.query : config.getQueries;
     this.#config = config;
     this.id = clientGroupID;
+    this.contextManager = contextManager;
     this.#shard = shard;
-    this.#queryConfig = queryConfig;
     this.#lc = lc;
     this.#pipelines = pipelineDriver;
     this.#stateChanges = versionChanges;
@@ -337,7 +339,6 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     this.#slowHydrateThreshold = slowHydrateThreshold;
     this.#inspectorDelegate = inspectorDelegate;
     this.#customQueryTransformer = customQueryTransformer;
-    this.#authSession = authSession;
     this.#cvrStore = new CVRStore(
       lc,
       cvrDb,
@@ -352,33 +353,6 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     this.#runPriorityOp = runPriorityOp;
     // Wait for the first connection to init.
     this.keepalive();
-  }
-
-  get auth(): Auth | undefined {
-    return this.#authSession.auth;
-  }
-
-  clearAuth(): void {
-    this.#authSession.clear();
-    this.#lastAuthRevision = 0;
-  }
-
-  initAuthSession(
-    userID: string,
-    wireAuth: string | undefined,
-  ): Promise<AuthUpdateResult> {
-    return this.#authSession.update(userID, wireAuth);
-  }
-
-  #getHeaderOptions(forwardCookie: boolean): HeaderOptions {
-    return {
-      apiKey: this.#queryConfig.apiKey,
-      customHeaders: this.userQueryHeaders,
-      allowedClientHeaders: this.#queryConfig.allowedClientHeaders,
-      token: this.#authSession.auth?.raw,
-      cookie: forwardCookie ? this.#httpCookie : undefined,
-      origin: this.#origin,
-    };
   }
 
   #runInLockWithCVR(
@@ -433,6 +407,12 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         // Clear cached state if an error is encountered.
         this.#cvr = undefined;
         throw e;
+      } finally {
+        // Lock-scoped work is where validated connections gain or lose
+        // schedulable auth-maintenance deadlines. Recompute the single wakeup
+        // after every locked operation; out-of-lock fail/close transitions only
+        // clear or relax deadlines, so a stale earlier wakeup is harmless.
+        this.#scheduleAuthMaintenance(lc);
       }
     });
   }
@@ -509,7 +489,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           // all the custom queries, this #syncQueryPipelineSet call
           // should retransform those that are missing from #pipelines, which
           // are those which errored or changed transform hash
-          await this.#syncQueryPipelineSet(lc, cvr, 'missing');
+          await this.#syncQueryPipelineSet(lc, cvr, 'missing', undefined);
           this.#pipelinesSynced = true;
         });
       }
@@ -547,7 +527,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       lc.debug?.('Queries have expired');
       // #syncQueryPipelineSet() will remove the expired queries.
       if (this.#pipelinesSynced) {
-        await this.#syncQueryPipelineSet(lc, cvr, 'missing');
+        await this.#syncQueryPipelineSet(lc, cvr, 'missing', undefined);
       }
     }
 
@@ -618,6 +598,11 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   }
 
   #deleteClientDueToDisconnect(clientID: string, client: ClientHandler) {
+    this.contextManager.closeConnection({
+      clientID,
+      wsID: client.wsID,
+    });
+
     // Note: It is okay to delete / cleanup clients without acquiring the lock.
     // In fact, it is important to do so in order to guarantee that idle cleanup
     // is performed in a timely manner, regardless of the amount of work
@@ -644,47 +629,87 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     this.#expiredQueriesTimer = 0;
   }
 
+  #stopAuthMaintenanceTimer() {
+    if (this.#authMaintenanceTimer !== 0) {
+      this.#lc.debug?.('Stopping auth maintenance timer');
+    }
+    clearTimeout(this.#authMaintenanceTimer);
+    this.#authMaintenanceTimer = 0;
+  }
+
+  /**
+   * Schedules the auth maintenance wakeup from coordinator-derived
+   * deadlines. The timer plumbing is intentionally separate from the actual
+   * revalidation/retransform work so future policy changes only need to update
+   * the maintenance workers, not the wakeup logic.
+   *
+   * This is intentionally cheap & idempotent, so it can be called frequently
+   * when upstream state might have changed.
+   */
+  #scheduleAuthMaintenance(lc: LogContext) {
+    this.#stopAuthMaintenanceTimer();
+
+    const plan = this.contextManager.planMaintenance();
+    if (plan.earliestDeadlineAt === undefined) {
+      lc.debug?.('No auth maintenance wakeup scheduled');
+      return;
+    }
+
+    const delay = Math.max(0, plan.earliestDeadlineAt - Date.now());
+    lc.debug?.(
+      `Scheduling auth maintenance timer at ${new Date(plan.earliestDeadlineAt).toISOString()}`,
+      {
+        delay,
+        earliestDeadlineAt: plan.earliestDeadlineAt,
+      },
+    );
+    this.#authMaintenanceTimer = this.#setTimeout(() => {
+      this.#authMaintenanceTimer = 0;
+      this.#runInLockWithCVR((lc, cvr) =>
+        this.#runAuthMaintenance(lc, cvr),
+      ).catch(e =>
+        // If an error occurs (e.g. ownership change), propagate the error
+        // to the main run() loop via the #stateChanges Subscription.
+        this.#stateChanges.fail(e),
+      );
+    }, delay);
+  }
+
+  async #runAuthMaintenance(lc: LogContext, _cvr: CVRSnapshot): Promise<void> {
+    const plan = this.contextManager.planMaintenance();
+    if (plan.dueRevalidations.length === 0 && !plan.dueRetransform) {
+      lc.debug?.('Auth maintenance woke up with no due work');
+      return;
+    }
+
+    lc.debug?.('Auth maintenance woke up with pending work', {
+      dueRevalidations: plan.dueRevalidations.length,
+      dueRetransform: plan.dueRetransform,
+    });
+
+    for (const connection of plan.dueRevalidations) {
+      await this.#validateConnection(connection);
+    }
+
+    // Revalidation can change which connection is safe for shared background work.
+    // Replan before deciding whether to run the group retransform.
+    const refreshedPlan = this.contextManager.planMaintenance();
+    if (refreshedPlan.dueRetransform) {
+      await this.#runBackgroundRetransform(lc);
+    }
+  }
+
   initConnection(
-    ctx: SyncContext,
+    selector: ConnectionSelector,
     initConnectionMessage: InitConnectionMessage,
   ): Source<Downstream> {
     this.#lc.debug?.('viewSyncer.initConnection');
     return startSpan(tracer, 'vs.initConnection', () => {
-      const {
-        clientID,
-        profileID,
-        wsID,
-        baseCookie,
-        httpCookie,
-        origin,
-        protocolVersion,
-      } = ctx;
-      this.#httpCookie = httpCookie;
-      this.#origin = origin;
-
-      // Handle custom query URL and headers
-      const [, {userQueryURL, userQueryHeaders}] = initConnectionMessage;
-      if (this.userQueryURL === undefined) {
-        // First client in the group - store its parameters
-        this.userQueryURL = userQueryURL;
-        this.userQueryHeaders = userQueryHeaders;
-      } else {
-        // Validate that subsequent clients have compatible parameters
-        if (this.userQueryURL !== userQueryURL) {
-          this.#lc.warn?.(
-            'Client provided different query parameters than client group',
-            {
-              clientID,
-              clientURL: userQueryURL,
-              clientGroupURL: this.userQueryURL,
-            },
-          );
-        }
-      }
+      const ctx = this.contextManager.mustGetConnectionContext(selector);
 
       const lc = this.#lc
-        .withContext('clientID', clientID)
-        .withContext('wsID', wsID);
+        .withContext('clientID', ctx.clientID)
+        .withContext('wsID', ctx.wsID);
 
       // Setup the downstream connection.
       const downstream = Subscription.create<Downstream>({
@@ -692,14 +717,14 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           err
             ? lc[getLogLevel(err)]?.(`client closed with error`, err)
             : lc.info?.('client closed');
-          this.#deleteClientDueToDisconnect(clientID, newClient);
+          this.#deleteClientDueToDisconnect(ctx.clientID, newClient);
           this.#activeClients.add(-1, {
-            [PROTOCOL_VERSION_ATTR]: protocolVersion,
+            [PROTOCOL_VERSION_ATTR]: ctx.protocolVersion,
           });
         },
       });
       this.#activeClients.add(1, {
-        [PROTOCOL_VERSION_ATTR]: protocolVersion,
+        [PROTOCOL_VERSION_ATTR]: ctx.protocolVersion,
       });
 
       if (this.#clients.size === 0) {
@@ -714,14 +739,14 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       const newClient = new ClientHandler(
         lc,
         this.id,
-        clientID,
-        wsID,
+        ctx.clientID,
+        ctx.wsID,
         this.#shard,
-        baseCookie,
+        ctx.baseCookie,
         downstream,
       );
-      this.#clients.get(clientID)?.close(`replaced by wsID: ${wsID}`);
-      this.#clients.set(clientID, newClient);
+      this.#clients.get(ctx.clientID)?.close(`replaced by wsID: ${ctx.wsID}`);
+      this.#clients.set(ctx.clientID, newClient);
 
       // Note: initConnection() must be synchronous so that `downstream` is
       // immediately returned to the caller (connection.ts). This ensures
@@ -743,6 +768,11 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
               'warn',
             );
           }
+          // Every new websocket must revalidate so shared maintenance always
+          // has a current validated connection to fall back to.
+          if (!(await this.#validateConnection(ctx))) {
+            return;
+          }
           await this.#handleConfigUpdate(
             lc,
             clientID,
@@ -753,7 +783,8 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
             // `cg${clientGroupID}`, as is done in the schema migration.
             // As clients update to the zero version with the profileID logic,
             // the value will be correspondingly in the CVR db.
-            profileID ?? `cg${this.id}`,
+            ctx.profileID ?? `cg${this.id}`,
+            ctx,
           );
           // this.#authData  and cvr (in particular cvr.clientSchema) have been
           // initialized, signal the run loop to run.
@@ -767,83 +798,84 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   }
 
   async changeDesiredQueries(
-    ctx: SyncContext,
+    selector: ConnectionSelector,
     msg: ChangeDesiredQueriesMessage,
   ): Promise<void> {
     await this.#runInLockForClient(
-      ctx,
+      selector,
       msg,
-      async (lc, clientID, msg: Partial<InitConnectionBody>, cvr) => {
-        let customQueryTransformMode: CustomQueryTransformMode = 'missing';
-        const currentAuthRevision = this.#authSession.revision;
-        if (this.#lastAuthRevision < currentAuthRevision) {
-          customQueryTransformMode = 'all';
-          lc.debug?.(
-            'Auth revision changed, setting customQueryTransformMode to all',
-          );
-        }
-
-        const result = await this.#handleConfigUpdate(
+      (lc, clientID, msg: Partial<InitConnectionBody>, cvr) =>
+        this.#handleConfigUpdate(
           lc,
           clientID,
           msg,
           cvr,
-          customQueryTransformMode,
-        );
+          'missing',
+          undefined,
+          this.contextManager.mustGetConnectionContext(selector),
+        ),
+    );
+  }
 
-        // commit the new revision after the config update is successful
-        if (customQueryTransformMode === 'all') {
-          this.#lastAuthRevision = currentAuthRevision;
+  async updateAuth(
+    selector: ConnectionSelector,
+    msg: UpdateAuthMessage,
+    authRevisionChanged: boolean,
+  ): Promise<void> {
+    await this.#runInLockForClient(
+      selector,
+      msg,
+      async (lc, clientID, _, cvr) => {
+        // Avoid revalidation and query re-transformation if the revision is the same
+        if (!authRevisionChanged) {
+          lc.debug?.('Auth unchanged, skipping query re-transformation');
+          return;
+        }
+        lc.debug?.('Auth changed, re-validating and re-transforming queries');
+
+        const connection =
+          this.contextManager.mustGetConnectionContext(selector);
+
+        // If pipelines are not yet synced, there is no transform request that
+        // can absorb validation, so validate immediately.
+        if (!this.#pipelinesSynced) {
+          if (!(await this.#validateConnection(connection))) {
+            return;
+          }
         }
 
-        return result;
+        // Re-transform all queries so auth-sensitive query expansion matches
+        // the newly validated credential.
+        return await this.#handleConfigUpdate(
+          lc,
+          clientID,
+          {}, // no config updates, but we want to trigger re-transformation of custom queries if auth changed
+          cvr,
+          'all',
+          undefined,
+          connection,
+        );
       },
     );
   }
 
-  async updateAuth(ctx: SyncContext, msg: UpdateAuthMessage): Promise<void> {
-    await this.#runInLockForClient(ctx, msg, async (lc, clientID, _, cvr) => {
-      // update auth and check if the revision has changed
-      // if it has, we need to re-transform all queries since the auth data may be used in the transformation
-      const authResult = await this.#authSession.update(
-        ctx.userID,
-        msg[1].auth,
-      );
-      if (!authResult.ok) {
-        throw new ProtocolErrorWithLevel(authResult.error, 'warn');
-      }
-      const currentAuthRevision = this.#authSession.revision;
-      if (this.#lastAuthRevision >= currentAuthRevision) {
-        lc.debug?.('Auth revision unchanged, skipping query re-transformation');
-        return;
-      } else {
-        lc.debug?.('Auth revision changed, re-transforming queries');
-      }
-
-      const result = await this.#handleConfigUpdate(
-        lc,
-        clientID,
-        {}, // no config updates, but we want to trigger re-transformation of custom queries if auth changed
-        cvr,
-        'all',
-      );
-
-      // commit the new revision after the config update is successful
-      this.#lastAuthRevision = currentAuthRevision;
-
-      return result;
-    });
-  }
-
   async deleteClients(
-    ctx: SyncContext,
+    selector: ConnectionSelector,
     msg: DeleteClientsMessage,
   ): Promise<string[]> {
     const deletedClientIDs = await this.#runInLockForClient(
-      ctx,
+      selector,
       [msg[0], {deleted: msg[1]}],
       (lc, clientID, msg: Partial<InitConnectionBody>, cvr) =>
-        this.#handleConfigUpdate(lc, clientID, msg, cvr, 'missing'),
+        this.#handleConfigUpdate(
+          lc,
+          clientID,
+          msg,
+          cvr,
+          'missing',
+          undefined,
+          this.contextManager.mustGetConnectionContext(selector),
+        ),
     );
     return deletedClientIDs ?? [];
   }
@@ -924,6 +956,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     cvr: CVRSnapshot,
     clientID: string,
     customQueryTransformMode: CustomQueryTransformMode,
+    ctx: ConnectionContext | undefined,
     fn: (updater: CVRConfigDrivenUpdater) => PatchToVersion[],
   ): Promise<CVRSnapshot> {
     const updater = new CVRConfigDrivenUpdater(
@@ -958,7 +991,12 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     }
 
     if (this.#pipelinesSynced) {
-      await this.#syncQueryPipelineSet(lc, this.#cvr, customQueryTransformMode);
+      await this.#syncQueryPipelineSet(
+        lc,
+        this.#cvr,
+        customQueryTransformMode,
+        ctx,
+      );
     }
 
     return this.#cvr;
@@ -969,7 +1007,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
    * optionally adding the `newClient` if supplied.
    */
   #runInLockForClient<B, R = void, M extends [cmd: string, B] = [string, B]>(
-    ctx: SyncContext,
+    selector: ConnectionSelector,
     msg: M,
     fn: (
       lc: LogContext,
@@ -980,7 +1018,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     newClient?: ClientHandler,
   ): Promise<R | undefined> {
     this.#lc.debug?.('viewSyncer.#runInLockForClient');
-    const {clientID, wsID} = ctx;
+    const {clientID, wsID} = selector;
     const [cmd, body] = msg;
 
     if (newClient || !this.#clients.has(clientID)) {
@@ -995,6 +1033,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         span.setAttribute('clientID', clientID);
         let client: ClientHandler | undefined;
         let result: R | undefined;
+        let ctx: ConnectionContext | undefined;
         try {
           await this.#runInLockWithCVR(async (lc, cvr) => {
             lc = lc
@@ -1010,6 +1049,8 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
               // Connections may have been drained or dropped due to an error.
               return;
             }
+
+            ctx = this.contextManager.getConnectionContext(selector);
 
             if (newClient) {
               assert(
@@ -1030,9 +1071,8 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
             .withContext('wsID', wsID)
             .withContext('cmd', cmd);
           lc[getLogLevel(e)]?.(`closing connection with error`, e);
-          if (isTransformAuthFailure(e)) {
-            lc.debug?.('Auth failure detected in transform response');
-            this.clearAuth();
+          if (ctx) {
+            this.contextManager.failConnection(selector, ctx.revision);
           }
           if (client) {
             // Ideally, propagate the exception to the client's downstream subscription ...
@@ -1069,7 +1109,8 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     }: Partial<InitConnectionBody>,
     cvr: CVRSnapshot,
     customQueryTransformMode: CustomQueryTransformMode,
-    profileID?: string,
+    profileID: string | undefined,
+    ctx: ConnectionContext,
   ) =>
     startAsyncSpan(tracer, 'vs.#handleConfigUpdate', async () => {
       const deletedClientIDs: string[] = [];
@@ -1080,6 +1121,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         cvr,
         clientID,
         customQueryTransformMode,
+        ctx,
         updater => {
           const {ttlClock} = cvr;
           const patches: PatchToVersion[] = [];
@@ -1282,6 +1324,8 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         'Custom/named queries were requested but no `ZERO_QUERY_URL` is configured for Zero Cache.',
       );
     }
+    const backgroundContext =
+      this.contextManager.mustGetBackgroundConnectionContext();
     const customQueryTransformer = this.#customQueryTransformer;
     if (customQueryTransformer && customQueries.size > 0) {
       // Always transform custom queries during initialization to ensure
@@ -1291,19 +1335,24 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         '#hydrateUnchangedQueries transforming custom queries',
         () =>
           customQueryTransformer.transform(
-            this.#getHeaderOptions(this.#queryConfig.forwardCookies),
+            backgroundContext,
             customQueries.values(),
-            this.userQueryURL,
           ),
       );
+      if (!transformedCustomQueries.cached) {
+        this.contextManager.validateConnection(
+          backgroundContext,
+          backgroundContext.revision,
+        );
+      }
 
       // Only process queries that successfully transformed and transformed to
       // the same transformationHash as in the CVR here.
       // Queries that failed to transform will be retransformed by
       // #syncQueryPipelineSet, if they fail again errors will be sent to
       // the client.
-      if (Array.isArray(transformedCustomQueries)) {
-        for (const q of transformedCustomQueries) {
+      if (Array.isArray(transformedCustomQueries.result)) {
+        for (const q of transformedCustomQueries.result) {
           if ('error' in q) {
             customErrorCount++;
           } else if (
@@ -1318,7 +1367,6 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     }
 
     for (const q of otherQueries) {
-      const auth = this.#authSession.auth;
       const transformed = transformAndHashQuery(
         lc,
         q.id,
@@ -1326,7 +1374,9 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         must(this.#pipelines.currentPermissions()).permissions ?? {
           tables: {},
         },
-        auth?.type === 'jwt' ? auth : undefined,
+        backgroundContext.auth?.type === 'jwt'
+          ? backgroundContext.auth
+          : undefined,
         q.type === 'internal',
       );
       if (transformed.transformationHash === q.transformationHash) {
@@ -1481,6 +1531,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     lc: LogContext,
     cvr: CVRSnapshot,
     customQueryTransformMode: CustomQueryTransformMode,
+    ctx: ConnectionContext | undefined,
   ) {
     return startAsyncSpan(tracer, 'vs.#syncQueryPipelineSet', async span => {
       span.setAttribute('clientGroupID', this.id);
@@ -1512,6 +1563,12 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         origQuery: QueryRecord;
         transformed: TransformedAndHashed;
       }[] = [];
+      // When a specific connection triggered this work, use its context.
+      // Only background/shared sync work falls back to the selected
+      // validated connection.
+      const resolvedContext =
+        ctx ?? this.contextManager.mustGetBackgroundConnectionContext();
+
       for (const [id, query] of cvrQueryEntires) {
         if (query.type === 'custom') {
           // This should always match, no?
@@ -1525,7 +1582,6 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       for (const {id, query: origQuery} of otherQueries) {
         // This should always match, no?
         assert(id === origQuery.id, 'query id mismatch');
-        const auth = this.#authSession.auth;
         const transformed = transformAndHashQuery(
           lc,
           origQuery.id,
@@ -1533,7 +1589,9 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           must(this.#pipelines.currentPermissions()).permissions ?? {
             tables: {},
           },
-          auth?.type === 'jwt' ? auth : undefined,
+          resolvedContext.auth?.type === 'jwt'
+            ? resolvedContext.auth
+            : undefined,
           origQuery.type === 'internal',
         );
         transformedQueries.push({
@@ -1563,29 +1621,35 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         // This ensures the user's API server validates authorization with the
         // current auth context.
         const transformStart = performance.now();
-        let transformedCustomQueries;
+        let transformedCustomQueries: TransformAttempt;
         try {
           transformedCustomQueries = await this.#runPriorityOp(
             lc,
             '#syncQueryPipelineSet transforming custom queries',
             () =>
               customQueryTransformer.transform(
-                this.#getHeaderOptions(true),
+                resolvedContext,
                 customQueriesToTransform,
-                this.userQueryURL,
               ),
           );
 
           // Check if transform failed entirely (HTTP error or server-side failure).
           // This should disconnect the client and keep existing pipelines intact.
-          if (
-            !Array.isArray(transformedCustomQueries) &&
-            transformedCustomQueries.kind === ErrorKind.TransformFailed
-          ) {
-            // TransformFailedBody indicates an HTTP or infrastructure error.
-            // Throw to disconnect the client without modifying pipelines.
-            throw new ProtocolErrorWithLevel(transformedCustomQueries, 'warn');
+          if ('kind' in transformedCustomQueries.result) {
+            throw new ProtocolErrorWithLevel(
+              transformedCustomQueries.result,
+              'warn',
+            );
           } else {
+            // If the transform wasn't cached, we mark the connection as validated.
+            // This also passes the revision to ensure that race conditions with auth
+            // don't validate stale credentials.
+            if (!transformedCustomQueries.cached) {
+              this.contextManager.validateConnection(
+                resolvedContext,
+                resolvedContext.revision,
+              );
+            }
             this.#queryTransformations.add(1, {result: 'success'});
           }
         } catch (e) {
@@ -1603,7 +1667,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         >();
         erroredQueryIDs = this.#processTransformedCustomQueries(
           lc,
-          transformedCustomQueries,
+          transformedCustomQueries.result,
           (q: TransformedAndHashed) => {
             const origQuery = customQueries.get(q.id);
             if (origQuery) {
@@ -2130,8 +2194,11 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     });
   }
 
-  async inspect(context: SyncContext, msg: InspectUpMessage): Promise<void> {
-    await this.#runInLockForClient(context, msg, this.#handleInspect);
+  async inspect(
+    selector: ConnectionSelector,
+    msg: InspectUpMessage,
+  ): Promise<void> {
+    await this.#runInLockForClient(selector, msg, this.#handleInspect);
   }
 
   // oxlint-disable-next-line require-await
@@ -2142,7 +2209,10 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     cvr: CVRSnapshot,
   ): Promise<void> => {
     const client = must(this.#clients.get(clientID));
-    const auth = this.#authSession.auth;
+    const ctx = this.contextManager.mustGetConnectionContext({
+      clientID,
+      wsID: client.wsID,
+    });
     return handleInspect(
       lc,
       body,
@@ -2152,11 +2222,106 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       this.id,
       this.#cvrStore,
       this.#config,
-      this.#getHeaderOptions(this.#queryConfig.forwardCookies ?? false),
-      this.userQueryURL,
-      auth?.type === 'jwt' ? auth : undefined,
+      ctx,
     );
   };
+
+  async #runBackgroundRetransform(lc: LogContext): Promise<void> {
+    const attemptRetransform = async (connection: ConnectionContext) => {
+      await this.#syncQueryPipelineSet(
+        lc,
+        must(this.#cvr, 'cvr missing during auth maintenance retransform'),
+        'all',
+        connection,
+      );
+      this.contextManager.markBackgroundRetransformSuccess(
+        {
+          clientID: connection.clientID,
+          wsID: connection.wsID,
+        },
+        connection.revision,
+      );
+    };
+
+    let backgroundConnection =
+      this.contextManager.getBackgroundConnectionContext();
+    if (!backgroundConnection) {
+      // The timer may have fired using an old deadline. If there is no longer a
+      // selected validated connection, shared background retransform is simply
+      // unschedulable until one exists again.
+      lc.debug?.('Skipping background retransform with no selected connection');
+      return;
+    }
+
+    for (;;) {
+      try {
+        await attemptRetransform(backgroundConnection);
+        return;
+      } catch (e) {
+        if (isProtocolError(e) && isAuthErrorBody(e.errorBody)) {
+          lc.warn?.(
+            'Background retransform auth failed; failing connection and searching for replacement',
+            {
+              clientID: backgroundConnection.clientID,
+              message: e.message,
+            },
+          );
+          this.#failMaintenanceConnection(backgroundConnection, e);
+        } else {
+          throw e;
+        }
+      }
+
+      const replacement = this.contextManager.getBackgroundConnectionContext();
+      if (!replacement) {
+        // The selected connection failed and nothing valid replaced it, so
+        // there is no credential left that can safely drive shared background
+        // reads.
+        lc.debug?.(
+          'No replacement connection available for background retransform',
+        );
+        return;
+      }
+
+      lc.debug?.(
+        'Retrying background retransform with replacement connection',
+        {
+          clientID: replacement.clientID,
+          wsID: replacement.wsID,
+        },
+      );
+      backgroundConnection = replacement;
+    }
+  }
+
+  async #validateConnection(ctx: ConnectionContext): Promise<boolean> {
+    try {
+      if (this.#customQueryTransformer) {
+        const validation = await this.#customQueryTransformer.validate(ctx);
+        if (validation !== undefined) {
+          throw new ProtocolErrorWithLevel(validation, 'warn');
+        }
+      }
+
+      this.contextManager.validateConnection(ctx, ctx.revision);
+      return true;
+    } catch (e) {
+      if (isProtocolError(e) && isAuthErrorBody(e.errorBody)) {
+        this.#failMaintenanceConnection(ctx, e);
+        return false;
+      }
+      throw e;
+    }
+  }
+
+  #failMaintenanceConnection(ctx: ConnectionContext, error: ProtocolError) {
+    const wrapped = wrapWithProtocolError(error);
+    this.contextManager.failConnection(ctx, ctx.revision);
+    const client = this.#clients.get(ctx.clientID);
+    if (client?.wsID === ctx.wsID) {
+      client.fail(wrapped);
+    }
+  }
 
   stop(): Promise<void> {
     this.#lc.info?.('stopping view syncer');
@@ -2166,10 +2331,9 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   }
 
   async #cleanup(err?: unknown) {
-    this.clearAuth();
-
     this.#stopTTLClockInterval();
     this.#stopExpireTimer();
+    this.#stopAuthMaintenanceTimer();
 
     for (const client of this.#clients.values()) {
       if (err) {
@@ -2246,18 +2410,6 @@ function checkClientAndCVRVersions(
       origin: ErrorOrigin.ZeroCache,
     });
   }
-}
-
-function isTransformAuthFailure(error: unknown): boolean {
-  if (!isProtocolError(error)) {
-    return false;
-  }
-
-  return (
-    error.errorBody.kind === ErrorKind.TransformFailed &&
-    error.errorBody.reason === ErrorReason.HTTP &&
-    (error.errorBody.status === 401 || error.errorBody.status === 403)
-  );
 }
 
 /**

--- a/packages/zero-cache/src/workers/connect-params.ts
+++ b/packages/zero-cache/src/workers/connect-params.ts
@@ -17,7 +17,7 @@ export type ConnectParams = {
   readonly wsID: string;
   readonly debugPerf: boolean;
   readonly auth: string | undefined;
-  readonly userID: string;
+  readonly userID: string | undefined;
   readonly initConnectionMsg: InitConnectionMessage | undefined;
   readonly httpCookie: string | undefined;
   readonly origin: string | undefined;
@@ -46,7 +46,7 @@ export function getConnectParams(
     const timestamp = params.getInteger('ts', true);
     const lmID = params.getInteger('lmid', true);
     const wsID = params.get('wsid', false) ?? '';
-    const userID = params.get('userID', false) ?? '';
+    const userID = params.get('userID', false) ?? undefined;
     const debugPerf = params.getBoolean('debugPerf');
     const {initConnectionMessage, authToken} = decodeSecProtocols(
       must(headers['sec-websocket-protocol']),

--- a/packages/zero-cache/src/workers/syncer-ws-message-handler.ts
+++ b/packages/zero-cache/src/workers/syncer-ws-message-handler.ts
@@ -11,9 +11,10 @@ import type {Upstream} from '../../../zero-protocol/src/up.ts';
 import type {Mutagen} from '../services/mutagen/mutagen.ts';
 import type {Pusher} from '../services/mutagen/pusher.ts';
 import {
-  type SyncContext,
-  type ViewSyncer,
-} from '../services/view-syncer/view-syncer.ts';
+  type ConnectionContextManager,
+  type ConnectionSelector,
+} from '../services/view-syncer/connection-context-manager.ts';
+import {type ViewSyncer} from '../services/view-syncer/view-syncer.ts';
 import type {ConnectParams} from './connect-params.ts';
 import type {HandlerResult, MessageHandler} from './connection.ts';
 
@@ -25,29 +26,22 @@ export class SyncerWsMessageHandler implements MessageHandler {
   readonly #mutationLock: Lock;
   readonly #lc: LogContext;
   readonly #clientGroupID: string;
-  readonly #syncContext: SyncContext;
+  readonly #connectionSelector: ConnectionSelector;
+  readonly #contextManager: ConnectionContextManager;
   readonly #pusher: Pusher | undefined;
 
   constructor(
     lc: LogContext,
     connectParams: ConnectParams,
+    contextManager: ConnectionContextManager,
     viewSyncer: ViewSyncer,
     mutagen: Mutagen | undefined,
     pusher: Pusher | undefined,
   ) {
-    const {
-      clientGroupID,
-      clientID,
-      profileID,
-      wsID,
-      baseCookie,
-      protocolVersion,
-      httpCookie,
-      origin,
-      userID,
-    } = connectParams;
+    const {clientGroupID, clientID, wsID} = connectParams;
     this.#viewSyncer = viewSyncer;
     this.#mutagen = mutagen;
+    this.#contextManager = contextManager;
     this.#mutationLock = new Lock();
     this.#lc = lc
       .withContext('connection')
@@ -56,15 +50,9 @@ export class SyncerWsMessageHandler implements MessageHandler {
       .withContext('wsID', wsID);
     this.#clientGroupID = clientGroupID;
     this.#pusher = pusher;
-    this.#syncContext = {
+    this.#connectionSelector = {
       clientID,
-      profileID,
       wsID,
-      baseCookie,
-      protocolVersion,
-      httpCookie,
-      origin,
-      userID,
     };
   }
 
@@ -84,7 +72,7 @@ export class SyncerWsMessageHandler implements MessageHandler {
           tracer,
           'connection.push',
           async () => {
-            const {clientGroupID, mutations, auth: pushAuth} = msg[1];
+            const {clientGroupID, mutations} = msg[1];
             if (clientGroupID !== this.#clientGroupID) {
               return [
                 {
@@ -98,14 +86,6 @@ export class SyncerWsMessageHandler implements MessageHandler {
                   },
                 } satisfies HandlerResult,
               ];
-            }
-
-            // for backwards compatibility, if the push contains auth, we update it
-            if (pushAuth) {
-              await viewSyncer.updateAuth(this.#syncContext, [
-                'updateAuth',
-                {auth: pushAuth},
-              ]);
             }
 
             if (mutations.length === 0) {
@@ -134,13 +114,7 @@ export class SyncerWsMessageHandler implements MessageHandler {
                 ];
               }
               return [
-                this.#pusher.enqueuePush(
-                  this.#syncContext.clientID,
-                  msg[1],
-                  viewSyncer.auth?.raw,
-                  this.#syncContext.httpCookie,
-                  this.#syncContext.origin,
-                ),
+                this.#pusher.enqueuePush(this.#connectionSelector, msg[1]),
               ];
             }
 
@@ -158,7 +132,9 @@ export class SyncerWsMessageHandler implements MessageHandler {
               ];
             }
 
-            const auth = viewSyncer.auth;
+            const auth = this.#contextManager.mustGetConnectionContext(
+              this.#connectionSelector,
+            ).auth;
             assert(
               auth?.type !== 'opaque',
               'Only JWT auth is supported for CRUD mutations',
@@ -194,32 +170,51 @@ export class SyncerWsMessageHandler implements MessageHandler {
       }
       case 'changeDesiredQueries':
         await startAsyncSpan(tracer, 'connection.changeDesiredQueries', () =>
-          viewSyncer.changeDesiredQueries(this.#syncContext, msg),
+          viewSyncer.changeDesiredQueries(this.#connectionSelector, msg),
         );
         break;
       case 'updateAuth':
         await startAsyncSpan(tracer, 'connection.updateAuth', async () => {
-          await viewSyncer.updateAuth(this.#syncContext, msg);
+          const initialConnection =
+            this.#contextManager.mustGetConnectionContext(
+              this.#connectionSelector,
+            );
+          const updatedConnection = await this.#contextManager.updateAuth(
+            this.#connectionSelector,
+            msg[1],
+          );
+          const authRevisionChanged =
+            updatedConnection.revision !== initialConnection.revision;
+
+          await viewSyncer.updateAuth(
+            this.#connectionSelector,
+            msg,
+            authRevisionChanged,
+          );
         });
         break;
       case 'deleteClients': {
         const deletedClientIDs = await startAsyncSpan(
           tracer,
           'connection.deleteClients',
-          () => viewSyncer.deleteClients(this.#syncContext, msg),
+          () => viewSyncer.deleteClients(this.#connectionSelector, msg),
         );
         if (this.#pusher && deletedClientIDs.length > 0) {
-          await this.#pusher.deleteClientMutations(deletedClientIDs);
+          await this.#pusher.deleteClientMutations(
+            this.#connectionSelector,
+            deletedClientIDs,
+          );
         }
         break;
       }
       case 'initConnection': {
+        this.#contextManager.initConnection(this.#connectionSelector, msg[1]);
         const ret: HandlerResult[] = [
           {
             type: 'stream',
             source: 'viewSyncer',
             stream: startSpan(tracer, 'connection.initConnection', () =>
-              viewSyncer.initConnection(this.#syncContext, msg),
+              viewSyncer.initConnection(this.#connectionSelector, msg),
             ),
           },
         ];
@@ -232,13 +227,7 @@ export class SyncerWsMessageHandler implements MessageHandler {
           ret.push({
             type: 'stream',
             source: 'pusher',
-            stream: this.#pusher.initConnection(
-              this.#syncContext.clientID,
-              this.#syncContext.wsID,
-              msg[1].userPushURL,
-              msg[1].userPushHeaders,
-              () => viewSyncer.clearAuth(),
-            ),
+            stream: this.#pusher.initConnection(this.#connectionSelector),
           });
         }
 
@@ -250,13 +239,16 @@ export class SyncerWsMessageHandler implements MessageHandler {
 
       case 'inspect':
         await startAsyncSpan(tracer, 'connection.inspect', () =>
-          viewSyncer.inspect(this.#syncContext, msg),
+          viewSyncer.inspect(this.#connectionSelector, msg),
         );
         break;
 
       case 'ackMutationResponses':
         if (this.#pusher) {
-          await this.#pusher.ackMutationResponses(msg[1]);
+          await this.#pusher.ackMutationResponses(
+            this.#connectionSelector,
+            msg[1],
+          );
         }
         break;
 

--- a/packages/zero-cache/src/workers/syncer.ts
+++ b/packages/zero-cache/src/workers/syncer.ts
@@ -4,8 +4,9 @@ import {pid} from 'node:process';
 import type {MessagePort} from 'node:worker_threads';
 import {WebSocketServer, type ServerOptions, type WebSocket} from 'ws';
 import {promiseVoid} from '../../../shared/src/resolved-promises.ts';
-import {type ValidateLegacyJWT} from '../auth/auth.ts';
-import {tokenConfigOptions, verifyToken} from '../auth/jwt.ts';
+import {isProtocolError} from '../../../zero-protocol/src/error.ts';
+import {resolveAuth, type Auth, type ValidateLegacyJWT} from '../auth/auth.ts';
+import {tokenConfigOptions} from '../auth/jwt.ts';
 import {type ZeroConfig} from '../config/zero-config.ts';
 import {
   recordConnectionAttempted,
@@ -21,6 +22,7 @@ import type {
   Service,
   SingletonService,
 } from '../services/service.ts';
+import type {ConnectionContextManager} from '../services/view-syncer/connection-context-manager.ts';
 import {DrainCoordinator} from '../services/view-syncer/drain-coordinator.ts';
 import type {ViewSyncer} from '../services/view-syncer/view-syncer.ts';
 import type {Worker} from '../types/processes.ts';
@@ -80,6 +82,7 @@ export class Syncer implements SingletonService {
   readonly #wss: WebSocketServer;
   readonly #stopped = resolver();
   readonly #config: ZeroConfig;
+  readonly #validateLegacyJWT: ValidateLegacyJWT | undefined;
 
   constructor(
     lc: LogContext,
@@ -88,13 +91,19 @@ export class Syncer implements SingletonService {
       id: string,
       sub: Subscription<ReplicaState>,
       drainCoordinator: DrainCoordinator,
-      validateLegacyJWT: ValidateLegacyJWT | undefined,
     ) => ViewSyncer & ActivityBasedService,
     mutagenFactory: ((id: string) => Mutagen & Service) | undefined,
-    pusherFactory: ((id: string) => Pusher & Service) | undefined,
+    pusherFactory:
+      | ((
+          id: string,
+          contextManager: ConnectionContextManager,
+        ) => Pusher & Service)
+      | undefined,
     parent: Worker,
+    validateLegacyJWT: ValidateLegacyJWT | undefined,
   ) {
     this.#config = config;
+    this.#validateLegacyJWT = validateLegacyJWT;
     // Relays notifications from the parent thread subscription
     // to ViewSyncers within this thread.
     const notifier = createNotifierFrom(lc, parent);
@@ -103,20 +112,19 @@ export class Syncer implements SingletonService {
     this.#lc = lc;
     this.#viewSyncers = new ServiceRunner(
       lc,
-      id =>
-        viewSyncerFactory(
-          id,
-          notifier.subscribe(),
-          this.#drainCoordinator,
-          this.#validateLegacyJWT(),
-        ),
+      id => viewSyncerFactory(id, notifier.subscribe(), this.#drainCoordinator),
       v => v.keepalive(),
     );
     if (mutagenFactory) {
       this.#mutagens = new ServiceRunner(lc, mutagenFactory, m => m.hasRefs());
     }
     if (pusherFactory) {
-      this.#pushers = new ServiceRunner(lc, pusherFactory, p => p.hasRefs());
+      this.#pushers = new ServiceRunner(
+        lc,
+        id =>
+          pusherFactory(id, this.#viewSyncers.getService(id).contextManager),
+        p => p.hasRefs(),
+      );
     }
     this.#parent = parent;
     this.#wss = new WebSocketServer(getWebSocketServerOptions(config));
@@ -163,16 +171,44 @@ export class Syncer implements SingletonService {
       }
     }
 
-    const viewSyncer = this.#viewSyncers.getService(clientGroupID);
+    let initialAuth: Auth | undefined;
 
     // Verify JWT BEFORE touching existing connections - prevents unauthenticated
-    // attackers from force-disconnecting legitimate users via DoS
-    const authResult = await viewSyncer.initAuthSession(userID, auth);
-    if (!authResult.ok) {
-      sendError(this.#lc, ws, authResult.error);
-      ws.close(3000, authResult.error.message);
-      return;
+    // attackers from force-disconnecting legitimate users via DoS.
+    // TODO(0xcadams): With opaque tokens, `resolveAuth()` only checks that the token is
+    // present and shaped consistently; the API server does the real auth later.
+    try {
+      initialAuth = await resolveAuth(
+        this.#lc
+          .withContext('clientGroupID', clientGroupID)
+          .withContext('clientID', clientID),
+        // no previous auth, since this is a new connection
+        undefined,
+        userID,
+        auth,
+        this.#validateLegacyJWT,
+      );
+    } catch (e) {
+      if (isProtocolError(e)) {
+        this.#lc.warn?.(
+          'Rejecting sync connection during initial auth resolution',
+          {
+            clientGroupID,
+            clientID,
+            userID,
+            hasProvidedAuth,
+            errorKind: e.message,
+          },
+        );
+        sendError(this.#lc, ws, e.errorBody);
+        ws.close(3000, e.errorBody.message);
+        return;
+      }
+      throw e;
     }
+
+    const viewSyncer = this.#viewSyncers.getService(clientGroupID);
+    const contextManager = viewSyncer.contextManager;
 
     // Only check for and close existing connections AFTER auth is validated
     const existing = this.#connections.get(clientID);
@@ -182,6 +218,12 @@ export class Syncer implements SingletonService {
       );
       existing.close(`replaced by ${params.wsID}`);
     }
+
+    contextManager.registerConnection(
+      {clientID, wsID: params.wsID},
+      params,
+      initialAuth,
+    );
 
     const mutagen = this.#mutagens?.getService(clientGroupID);
     const pusher = this.#pushers?.getService(clientGroupID);
@@ -198,11 +240,16 @@ export class Syncer implements SingletonService {
         new SyncerWsMessageHandler(
           this.#lc,
           params,
+          contextManager,
           viewSyncer,
           mutagen,
           pusher,
         ),
         () => {
+          contextManager.closeConnection({
+            clientID,
+            wsID: params.wsID,
+          });
           if (this.#connections.get(clientID) === connection) {
             this.#connections.delete(clientID);
           }
@@ -213,6 +260,7 @@ export class Syncer implements SingletonService {
         },
       );
     } catch (e) {
+      contextManager.closeConnection({clientID, wsID: params.wsID});
       mutagen?.unref();
       pusher?.unref();
       throw e;
@@ -269,28 +317,5 @@ export class Syncer implements SingletonService {
     this.#wss.close();
     this.#stopped.resolve();
     return promiseVoid;
-  }
-
-  /** @deprecated used in JWT validation */
-  #validateLegacyJWT(): ValidateLegacyJWT | undefined {
-    const tokenOptions = tokenConfigOptions(this.#config.auth ?? {});
-    if (tokenOptions.length !== 1) {
-      return undefined;
-    }
-
-    return async (token, {userID}) => {
-      const decoded = await verifyToken(this.#config.auth, token, {
-        subject: userID,
-        ...(this.#config.auth?.issuer && {issuer: this.#config.auth.issuer}),
-        ...(this.#config.auth?.audience && {
-          audience: this.#config.auth.audience,
-        }),
-      });
-      return {
-        type: 'jwt',
-        raw: token,
-        decoded,
-      };
-    };
   }
 }


### PR DESCRIPTION
## Move `zero-cache` auth to per-connection runtime state

This PR introduces `ConnectionContextManager`, which is core to the refactor: it's a state machine that manages the state of the connection, and provides helpers to share auth context across push and query.

- Replaces shared client-group auth session state with per-connection auth, query, and push context managed by `ConnectionContextManager`.
- Threads the connection auth snapshot through syncer, view-syncer, pusher, custom query transform, and inspect flows.
- Uses the originating connection's auth for connection-triggered work, and one validated background connection for shared query work.
- Adds runtime handling for provisional vs validated connections, auth revision checks, targeted auth failures, and scheduled revalidation/retransform work.