### PR TITLE
feat(zero-client): omit userID for logged-out clients

### DIFF
--- a/packages/zero-client/src/client/options.ts
+++ b/packages/zero-client/src/client/options.ts
@@ -55,15 +55,17 @@ export type ZeroOptions<
   auth?: string | null | undefined;
 
   /**
-   * A unique identifier for the user. Must be non-empty.
+   * A unique identifier for the user.
    *
    * Each userID gets its own client-side storage so that the app can switch
    * between users without losing state.
    *
+   * Omit this only for logged-out clients.
+   *
    * This must match the `sub` claim of the `auth` token if
    * `auth` is provided.
    */
-  userID: string;
+  userID?: string | undefined;
 
   /**
    * Distinguishes the storage used by this Zero instance from that of other

--- a/packages/zero-client/src/client/zero-idb.test.ts
+++ b/packages/zero-client/src/client/zero-idb.test.ts
@@ -3,7 +3,7 @@ import {hasMemStore} from '../../../replicache/src/kv/mem-store.ts';
 import {h64} from '../../../shared/src/hash.ts';
 import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import {string, table} from '../../../zero-schema/src/builder/table-builder.ts';
-import {Zero} from './zero.ts';
+import {LOGGED_OUT_STORAGE_USER_ID, Zero} from './zero.ts';
 
 const schema = createSchema({
   tables: [
@@ -156,4 +156,18 @@ test('delete closes and removes all databases for the same zero instance', async
 
   await zOther.close();
   await zOther.delete();
+});
+
+test('logged-out client uses a private storage sentinel for idb naming', async () => {
+  const zero = new Zero({
+    storageKey,
+    schema,
+    kvStore: 'mem',
+  });
+
+  expect(zero.idbName).toEqual(
+    `rep:zero-${LOGGED_OUT_STORAGE_USER_ID}-o92aeop6ci3f:7:49.32bj126fs2e3f`,
+  );
+
+  await zero.close();
 });

--- a/packages/zero-client/src/client/zero-stress-client-test.ts
+++ b/packages/zero-client/src/client/zero-stress-client-test.ts
@@ -7,7 +7,6 @@ import {Zero} from './zero.ts';
 
 const zeroStress = new Zero({
   schema: zeroStressSchema,
-  userID: 'anon',
   cacheURL: null,
   mutators,
 });

--- a/packages/zero-client/src/client/zero.auth.test.ts
+++ b/packages/zero-client/src/client/zero.auth.test.ts
@@ -44,7 +44,7 @@ test('connect({auth}) sends updateAuth set', async () => {
   expect(msg).toEqual(['updateAuth', {auth: 'next-token'}]);
 });
 
-test('sends updateAuth even when auth changes', async () => {
+test('sends updateAuth even when auth is unchanged', async () => {
   const z = zeroForTest({auth: 'test-auth'});
   await z.triggerConnected();
 
@@ -114,4 +114,58 @@ test('updated auth is sent once and reused for later reconnect handshakes', asyn
   await z.connection.connect();
   socket = await z.socket;
   expect(decodeSecProtocols(socket.protocol).authToken).toBe('token-2');
+});
+
+test('allows logged-out construction without a userID', async () => {
+  const z = zeroForTest({
+    auth: undefined,
+    userID: undefined,
+  });
+
+  expect(z.userID).toBeUndefined();
+
+  await z.close();
+});
+
+test.each([
+  ['', 'empty'],
+  ['anon', 'anon'],
+])(
+  'rejects constructing a logged-out client with legacy sentinel userID %p',
+  (userID, descriptor) => {
+    expect(() =>
+      zeroForTest({
+        auth: undefined,
+        userID,
+      }),
+    ).toThrow(
+      `ZeroOptions.userID should not be ${descriptor}. Omit it entirely for logged-out clients.`,
+    );
+  },
+);
+
+test('rejects constructing an authenticated client without a userID', () => {
+  expect(() =>
+    zeroForTest({
+      auth: 'auth-token',
+      userID: undefined,
+    }),
+  ).toThrow('ZeroOptions.userID is required when auth is set.');
+});
+
+test('connect({auth}) rejects on a logged-out client without a userID', async () => {
+  const z = zeroForTest({
+    auth: undefined,
+    userID: undefined,
+  });
+  await z.triggerConnected();
+
+  const socket = await z.socket;
+  socket.messages.length = 0;
+
+  await expect(z.connection.connect({auth: 'next-token'})).rejects.toThrow(
+    'ZeroOptions.userID is required when auth is set.',
+  );
+
+  await z.close();
 });

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -656,6 +656,17 @@ describe('createSocket', () => {
       expectedURL: `ws://example.com/sync/v${PROTOCOL_VERSION}/connect?clientID=clientID&clientGroupID=testClientGroupID&userID=userID&baseCookie=&ts=0&lmid=0&wsid=wsidx&profileID=${mockProfileID}`,
     },
     {
+      socketURL: 'ws://example.com/' as WSString,
+      baseCookie: null,
+      clientID: 'clientID',
+      userID: undefined,
+      auth: '',
+      lmid: 0,
+      debugPerf: false,
+      now: 0,
+      expectedURL: `ws://example.com/sync/v${PROTOCOL_VERSION}/connect?clientID=clientID&clientGroupID=testClientGroupID&baseCookie=&ts=0&lmid=0&wsid=wsidx&profileID=${mockProfileID}`,
+    },
+    {
       socketURL: 'ws://example.com/prefix' as WSString,
       baseCookie: null,
       clientID: 'clientID',
@@ -758,12 +769,12 @@ describe('createSocket', () => {
       socketURL: 'ws://example.com/' as WSString,
       baseCookie: null,
       clientID: 'clientID',
-      userID: 'userID',
+      userID: undefined,
       auth: '',
       lmid: 0,
       debugPerf: false,
       now: 456,
-      expectedURL: `ws://example.com/sync/v${PROTOCOL_VERSION}/connect?clientID=clientID&clientGroupID=testClientGroupID&userID=userID&baseCookie=&ts=456&lmid=0&wsid=wsidx&profileID=${mockProfileID}&reason=rehome&backoff=100&lastTask=foo%2Fbar%26baz`,
+      expectedURL: `ws://example.com/sync/v${PROTOCOL_VERSION}/connect?clientID=clientID&clientGroupID=testClientGroupID&baseCookie=&ts=456&lmid=0&wsid=wsidx&profileID=${mockProfileID}&reason=rehome&backoff=100&lastTask=foo%2Fbar%26baz`,
       additionalConnectParams: {
         reason: 'rehome',
         backoff: '100',
@@ -775,7 +786,7 @@ describe('createSocket', () => {
     socketURL: WSString;
     baseCookie: NullableVersion;
     clientID: string;
-    userID: string;
+    userID: string | undefined;
     auth: string | undefined;
     lmid: number;
     debugPerf: boolean;

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -256,6 +256,8 @@ const NULL_LAST_MUTATION_ID_SENT = {clientID: '', id: -1} as const;
 
 const DEFAULT_QUERY_CHANGE_THROTTLE_MS = 10;
 
+export const LOGGED_OUT_STORAGE_USER_ID = '__anonymous__';
+
 function convertOnUpdateNeededReason(
   reason: ReplicacheUpdateNeededReason,
 ): UpdateNeededReason {
@@ -330,7 +332,7 @@ export class Zero<
 
   readonly #rep: ReplicacheImpl<WithCRUD<MutatorDefs>>;
   readonly #server: HTTPString | null;
-  readonly userID: string;
+  readonly userID: string | undefined;
   readonly storageKey: string;
 
   readonly #lc: LogContext;
@@ -470,12 +472,16 @@ export class Zero<
       maxRecentQueries = 0,
       slowMaterializeThreshold = 5_000,
     } = options;
-    if (!userID) {
+
+    if (userID === '' || userID === 'anon') {
       throw new ClientError({
         kind: ClientErrorKind.Internal,
-        message: 'ZeroOptions.userID must not be empty.',
+        message: `ZeroOptions.userID should not be ${userID === '' ? 'empty' : userID}. Omit it entirely for logged-out clients.`,
       });
     }
+
+    this.#checkAuthValid(userID, options.auth);
+
     const cacheURL = options.cacheURL ?? options.server;
     const server = getServer(cacheURL);
     this.#enableAnalytics = shouldEnableAnalytics(
@@ -566,6 +572,9 @@ export class Zero<
       queryUrl: options.queryURL ?? options.getQueriesURL ?? '',
     });
     const hashedKey = h64(nameKey).toString(36);
+    // Logged-out clients still need a stable local storage namespace.
+    // This sentinel is only for IDB naming; logged-out connections omit userID on the wire.
+    const storageScopedUserID = userID ?? LOGGED_OUT_STORAGE_USER_ID;
 
     const replicacheOptions: ReplicacheOptions<WithCRUD<MutatorDefs>> = {
       // The schema stored in IDB is dependent upon both the ClientSchema
@@ -574,7 +583,7 @@ export class Zero<
       logLevel: logOptions.logLevel,
       logSinks: [logOptions.logSink],
       mutators: replicacheMutators,
-      name: `zero-${userID}-${hashedKey}`,
+      name: `zero-${storageScopedUserID}-${hashedKey}`,
       pusher: (req, reqID) => this.#pusher(req, reqID),
       puller: (req, reqID) => this.#puller(req, reqID),
       pushDelay: 0,
@@ -2252,6 +2261,8 @@ export class Zero<
    * @param auth - The authentication token to set.
    */
   #setAuth(auth: string | undefined | null): void {
+    this.#checkAuthValid(this.userID, auth);
+
     this.#rep.auth = toReplicacheAuthToken(auth);
 
     if (auth) {
@@ -2451,6 +2462,18 @@ export class Zero<
       ...(args as ClientMetricMap[keyof ClientMetricMap]),
     );
   };
+
+  #checkAuthValid(
+    userID: string | undefined,
+    auth: string | null | undefined,
+  ): void {
+    if (userID === undefined && auth) {
+      throw new ClientError({
+        kind: ClientErrorKind.Internal,
+        message: 'ZeroOptions.userID is required when auth is set.',
+      });
+    }
+  }
 }
 
 export class OnlineManager extends Subscribable<boolean> {
@@ -2478,7 +2501,7 @@ export async function createSocket(
   clientID: string,
   clientGroupID: string,
   clientSchema: ClientSchema,
-  userID: string,
+  userID: string | undefined,
   auth: string | undefined,
   lmid: number,
   wsid: string,
@@ -2572,7 +2595,7 @@ export async function createConnectionURL(
   socketOrigin: HTTPString | WSString,
   clientID: string,
   clientGroupID: string,
-  userID: string,
+  userID: string | undefined,
   baseCookie: string | null,
   lmid: number,
   wsid: string,
@@ -2587,7 +2610,9 @@ export async function createConnectionURL(
   const {searchParams} = url;
   searchParams.set('clientID', clientID);
   searchParams.set('clientGroupID', clientGroupID);
-  searchParams.set('userID', userID);
+  if (userID !== undefined) {
+    searchParams.set('userID', userID);
+  }
   searchParams.set('baseCookie', baseCookie === null ? '' : String(baseCookie));
   searchParams.set('ts', String(performance.now()));
   searchParams.set('lmid', String(lmid));


### PR DESCRIPTION
## Let logged-out `Zero` clients omit `userID`

Makes `userID` optional for logged-out clients, while still requiring it whenever `auth` is set. This is because we now send an `X-User-ID` header to the API, and the API should have a better representation of logged in/logged out than 'anon' or an empty string.

The semantics are now: on the API, if the header exists, the user is logged in, and this is a user ID. If the header doesn't exist, the user is not logged in.

- Stops sending the legacy `'anon'` / empty sentinel on connect URLs; logged-out connections now omit `userID` entirely, matching the new zero-cache auth contract.
- Keeps logged-out local storage stable by using a private storage-only sentinel for IDB naming.