### PR TITLE
feat(zbugs): stop using anon user IDs

### DIFF
--- a/apps/zbugs/api/index.ts
+++ b/apps/zbugs/api/index.ts
@@ -132,10 +132,11 @@ async function withAuth<T extends {headers: IncomingHttpHeaders}>(
   request: T,
   reply: FastifyReply,
   handler: (authData: JWTData | undefined) => Promise<void>,
+  verifyUserID: boolean = true,
 ) {
   let authData: JWTData | undefined;
   try {
-    authData = await maybeVerifyAuth(request.headers);
+    authData = await maybeVerifyAuth(request.headers, verifyUserID);
   } catch (e) {
     if (e instanceof Error) {
       reply.status(401).send(e.message);
@@ -164,37 +165,28 @@ async function mutateHandler(
   }>,
   reply: FastifyReply,
 ) {
-  let jwtData: JWTData | undefined;
-  try {
-    jwtData = await maybeVerifyAuth(request.headers);
-  } catch (e) {
-    if (e instanceof Error) {
-      reply.status(401).send(e.message);
-      return;
-    }
-    throw e;
-  }
+  await withAuth(request, reply, async jwtData => {
+    const postCommitTasks: (() => Promise<void>)[] = [];
+    const mutators = createServerMutators(postCommitTasks);
 
-  const postCommitTasks: (() => Promise<void>)[] = [];
-  const mutators = createServerMutators(postCommitTasks);
+    const response = await handleMutateRequest(
+      dbProvider,
+      (transact, _mutation) =>
+        transact((tx, name, args) => {
+          const mutator = mustGetMutator(mutators, name);
+          return mutator.fn({tx, args, ctx: jwtData});
+        }),
+      request.query,
+      request.body,
+      'info',
+    );
 
-  const response = await handleMutateRequest(
-    dbProvider,
-    (transact, _mutation) =>
-      transact((tx, name, args) => {
-        const mutator = mustGetMutator(mutators, name);
-        return mutator.fn({tx, args, ctx: jwtData});
-      }),
-    request.query,
-    request.body,
-    'info',
-  );
+    // we don't yet handle errors here, since Loops emails return 429 very often
+    // and we don't want to block the mutation
+    await Promise.allSettled(postCommitTasks.map(task => task()));
 
-  // we don't yet handle errors here, since Loops emails return 429 very often
-  // and we don't want to block the mutation
-  await Promise.allSettled(postCommitTasks.map(task => task()));
-
-  reply.send(response);
+    reply.send(response);
+  });
 }
 
 // this endpoint was kept for backwards compatibility
@@ -233,23 +225,29 @@ async function queryHandler(
 fastify.post<{
   Body: {contentType: string};
 }>('/api/upload/presigned-url', async (request, reply) => {
-  await withAuth(request, reply, async authData => {
-    if (!authData) {
-      reply.status(401).send('Authentication required');
-      return;
-    }
-
-    try {
-      const result = await getPresignedUrl(request.body.contentType);
-      reply.send(result);
-    } catch (error) {
-      if (error instanceof Error) {
-        reply.status(500).send(error.message);
+  await withAuth(
+    request,
+    reply,
+    async authData => {
+      if (!authData) {
+        reply.status(401).send('Authentication required');
         return;
       }
-      reply.status(500).send('Failed to generate presigned URL');
-    }
-  });
+
+      try {
+        const result = await getPresignedUrl(request.body.contentType);
+        reply.send(result);
+      } catch (error) {
+        if (error instanceof Error) {
+          reply.status(500).send(error.message);
+          return;
+        }
+        reply.status(500).send('Failed to generate presigned URL');
+      }
+    },
+    // don't verify the user ID header since this is from the client
+    false,
+  );
 });
 
 fastify.get<{
@@ -301,6 +299,7 @@ fastify.get<{
 
 async function maybeVerifyAuth(
   headers: IncomingHttpHeaders,
+  verifyUserID: boolean,
 ): Promise<JWTData | undefined> {
   let {authorization} = headers;
   if (!authorization) {
@@ -318,9 +317,19 @@ async function maybeVerifyAuth(
     throw new Error('VITE_PUBLIC_JWK is not set');
   }
 
-  return jwtDataSchema.parse(
+  const jwtData = jwtDataSchema.parse(
     (await jwtVerify(authorization, JSON.parse(jwk))).payload,
   );
+
+  if (verifyUserID) {
+    const userIDFromHeader = headers['x-user-id'];
+
+    if (userIDFromHeader !== jwtData.sub) {
+      throw new Error(`X-User-ID must match the authenticated user`);
+    }
+  }
+
+  return jwtData;
 }
 
 export default async function handler(

--- a/apps/zbugs/shared/queries.ts
+++ b/apps/zbugs/shared/queries.ts
@@ -98,11 +98,9 @@ export const queries = defineQueries({
 
   issuePreloadV2: defineQuery(
     z.object({
-      userID: z.string(),
       projectName: z.string(),
     }),
-
-    ({ctx: auth, args: {userID, projectName}}) =>
+    ({ctx: auth, args: {projectName}}) =>
       applyIssuePermissions(
         builder.issue
           .whereExists(
@@ -111,7 +109,9 @@ export const queries = defineQueries({
             {scalar: true},
           )
           .related('labels')
-          .related('viewState', q => q.where('userID', userID))
+          .related('viewState', q =>
+            auth?.sub ? q.where('userID', auth.sub) : alwaysFalse(q),
+          )
           .related('creator')
           .related('assignee')
           .related('emoji', emoji => emoji.related('creator'))
@@ -181,10 +181,8 @@ export const queries = defineQueries({
     z.object({
       idField: z.union([z.literal('shortID'), z.literal('id')]),
       id: z.union([z.string(), z.number()]),
-      userID: z.string(),
     }),
-
-    ({args: {idField, id, userID}, ctx: auth}) =>
+    ({args: {idField, id}, ctx: auth}) =>
       applyIssuePermissions(
         builder.issue
           .where(idField, id)
@@ -193,9 +191,14 @@ export const queries = defineQueries({
           .related('creator')
           .related('assignee')
           .related('labels')
-          .related('notificationState', q => q.where('userID', userID))
+          .related('notificationState', q =>
+            auth?.sub ? q.where('userID', auth.sub) : alwaysFalse(q),
+          )
           .related('viewState', viewState =>
-            viewState.where('userID', userID).one(),
+            (auth?.sub
+              ? viewState.where('userID', auth.sub)
+              : alwaysFalse(viewState)
+            ).one(),
           )
           .related('comments', comments =>
             comments
@@ -214,15 +217,14 @@ export const queries = defineQueries({
   issueListV2: defineQuery(
     z.object({
       listContext: listContextParams,
-      userID: z.string(),
       limit: z.nullable(z.number()),
       start: z.nullable(issueRowSortSchema),
       dir: z.union([z.literal('forward'), z.literal('backward')]),
       inclusive: z.optional(z.boolean()),
     }),
 
-    ({ctx: auth, args: {listContext, userID, limit, start, dir, inclusive}}) =>
-      issueListV2(listContext, limit, userID, auth, start, dir, inclusive),
+    ({ctx: auth, args: {listContext, limit, start, dir, inclusive}}) =>
+      issueListV2(listContext, limit, auth?.sub, auth, start, dir, inclusive),
   ),
 
   /**
@@ -249,27 +251,6 @@ export const queries = defineQueries({
   // TODO(arv): Remove
 
   // The below queries are DEPRECATED
-  issuePreload: defineQuery(idValidator, ({ctx: auth, args: userID}) =>
-    applyIssuePermissions(
-      builder.issue
-        .related('labels')
-        .related('viewState', q => q.where('userID', userID))
-        .related('creator')
-        .related('assignee')
-        .related('emoji', emoji => emoji.related('creator'))
-        .related('comments', comments =>
-          comments
-            .related('creator')
-            .related('emoji', emoji => emoji.related('creator'))
-            .limit(10)
-            .orderBy('created', 'desc'),
-        )
-        .orderBy('modified', 'desc')
-        .orderBy('id', 'desc')
-        .limit(1000),
-      auth?.role,
-    ),
-  ),
   prevNext: defineQuery(
     z.object({
       listContext: z.nullable(listContextParams),
@@ -288,11 +269,10 @@ export const queries = defineQueries({
   issueList: defineQuery(
     z.object({
       listContext: listContextParams,
-      userID: z.string(),
       limit: z.number(),
     }),
-    ({ctx: auth, args: {listContext, userID, limit}}) =>
-      issueListV2(listContext, limit, userID, auth, null, 'forward', false),
+    ({ctx: auth, args: {listContext, limit}}) =>
+      issueListV2(listContext, limit, auth?.sub, auth, null, 'forward', false),
   ),
 
   userPicker: defineQuery(
@@ -334,7 +314,7 @@ export type ListContext = {
 function issueListV2(
   listContext: ListContextParams,
   limit: number | null,
-  userID: string,
+  userID: string | undefined,
   auth: AuthData | undefined,
   start: IssueRowSort | null,
   dir: 'forward' | 'backward',
@@ -355,7 +335,7 @@ export type ListQueryArgs = {
   issueQuery?: (typeof builder)['issue'] | undefined;
   listContext?: ListContext['params'] | undefined;
   project?: string | undefined;
-  userID?: string;
+  userID?: string | undefined;
   role?: Role | undefined;
   limit?: number | undefined;
   start?: IssueRowSort | undefined;

--- a/apps/zbugs/src/emoji-utils.test.ts
+++ b/apps/zbugs/src/emoji-utils.test.ts
@@ -135,7 +135,7 @@ test('formatEmojiCreatorList', () => {
   expect(
     formatEmojiCreatorList(
       Array.from({length: 55}, (_, i) => makeEmoji('id-' + i, 'user-' + i)),
-      'anon',
+      undefined,
     ),
   ).toBe(
     'user-0, user-1, user-2, user-3, user-4, user-5, user-6, user-7, user-8, user-9 and 45 others',

--- a/apps/zbugs/src/emoji-utils.ts
+++ b/apps/zbugs/src/emoji-utils.ts
@@ -7,7 +7,7 @@ export type Emoji = Row['emoji'] & {
 
 export function formatEmojiCreatorList(
   emojis: Emoji[],
-  currentUserID: string,
+  currentUserID: string | undefined,
 ): string {
   assert(emojis.length > 0, 'Expected at least one emoji');
   const names = emojis
@@ -39,7 +39,7 @@ export function formatEmojiCreatorList(
 
 export function formatEmojiTooltipText(
   emojis: Emoji[],
-  currentUserID: string,
+  currentUserID: string | undefined,
 ): string {
   const names = formatEmojiCreatorList(emojis, currentUserID);
   return `${names} reacted with ${emojis[0].annotation}`;
@@ -57,8 +57,11 @@ export function setSkinTone(emoji: string, skinTone: number): string {
 
 export function findEmojiForCreator(
   emojis: Emoji[],
-  userID: string,
+  userID: string | undefined,
 ): string | undefined {
+  if (userID === undefined) {
+    return undefined;
+  }
   for (const emoji of emojis) {
     if (emoji.creatorID === userID) {
       return emoji.id;

--- a/apps/zbugs/src/pages/issue/issue-page.tsx
+++ b/apps/zbugs/src/pages/issue/issue-page.tsx
@@ -91,7 +91,7 @@ export function IssuePage({onReady}: {onReady: () => void}) {
   }, [listContext]);
 
   const [issue, issueResult] = useQuery(
-    queries.issueDetail({idField, id: idValue, userID: z.userID}),
+    queries.issueDetail({idField, id: idValue}),
     CACHE_NAV,
   );
   useEffect(() => {
@@ -122,7 +122,7 @@ export function IssuePage({onReady}: {onReady: () => void}) {
   useEffect(() => {
     // only push viewed forward if the issue has been modified since the last viewing
     if (
-      z.userID !== 'anon' &&
+      z.userID !== undefined &&
       displayed &&
       displayed.modified > (displayed?.viewState?.viewed ?? 0)
     ) {
@@ -218,7 +218,6 @@ export function IssuePage({onReady}: {onReady: () => void}) {
   const [[next]] = useQuery(
     queries.issueListV2({
       listContext: listContextParams,
-      userID: z.userID,
       limit: 1,
       start,
       dir: 'forward',
@@ -237,7 +236,6 @@ export function IssuePage({onReady}: {onReady: () => void}) {
   const [[prev]] = useQuery(
     queries.issueListV2({
       listContext: listContextParams,
-      userID: z.userID,
       limit: 1,
       start,
       dir: 'backward',
@@ -741,7 +739,7 @@ export function IssuePage({onReady}: {onReady: () => void}) {
           </div>
         </div>
 
-        {z.userID === 'anon' ? (
+        {z.userID === undefined ? (
           <a href="/api/login/github" className="login-to-comment">
             Login to comment
           </a>
@@ -1093,13 +1091,12 @@ function useShowToastForNewComment(
 }
 
 export function IssueRedirect({onReady}: {onReady: () => void}) {
-  const z = useZero();
   const params = useParams();
 
   const {idField, idValue} = getID(params);
 
   const [issue, issueResult] = useQuery(
-    queries.issueDetail({idField, id: idValue, userID: z.userID}),
+    queries.issueDetail({idField, id: idValue}),
     CACHE_NAV,
   );
 

--- a/apps/zbugs/src/pages/list/list-page.tsx
+++ b/apps/zbugs/src/pages/list/list-page.tsx
@@ -189,7 +189,6 @@ export function ListPage({onReady}: {onReady: () => void}) {
     ) =>
       queries.issueListV2({
         listContext: listContextParams,
-        userID: z.userID,
         limit,
         start,
         dir,

--- a/apps/zbugs/src/zero-init.tsx
+++ b/apps/zbugs/src/zero-init.tsx
@@ -13,7 +13,7 @@ export function ZeroInit({children}: {children: ReactNode}) {
       ({
         schema,
         cacheURL: import.meta.env.VITE_PUBLIC_SERVER,
-        userID: login.loginState?.decoded?.sub ?? 'anon',
+        userID: login.loginState?.decoded?.sub,
         mutators,
         logLevel: 'info',
         // changing the auth token will cause ZeroProvider to call connection.connect

--- a/apps/zbugs/src/zero-preload.ts
+++ b/apps/zbugs/src/zero-preload.ts
@@ -4,10 +4,7 @@ import {CACHE_PRELOAD} from './query-cache-policy.ts';
 
 export function preload(z: Zero, projectName: string) {
   // Preload all issues and first 10 comments from each.
-  z.preload(
-    queries.issuePreloadV2({userID: z.userID, projectName}),
-    CACHE_PRELOAD,
-  );
+  z.preload(queries.issuePreloadV2({projectName}), CACHE_PRELOAD);
   z.preload(queries.allUsers(), CACHE_PRELOAD);
   z.preload(queries.allLabels(), CACHE_PRELOAD);
   z.preload(queries.allProjects(), CACHE_PRELOAD);


### PR DESCRIPTION
## Adopt the new auth model in zbugs

- Stops threading `userID` through preload, issue detail, and list queries; user-scoped relations now derive from authenticated query context (`auth.sub`) instead.
- Treats logged-out state as `undefined` instead of `'anon'`, updating app init, issue UI, list navigation, and emoji helpers to stop pretending there is an anonymous user.
- Keeps logged-out queries valid by returning no `viewState` or `notificationState` rows until a real authenticated user exists.
- Tightens server-side auth checks by requiring `X-User-ID` to match the JWT on server-driven requests, while leaving the direct client upload endpoint free to skip that header check.
- Aligns zbugs with the new zero-client and zero-cache contract so authenticated requests are keyed to real identity and logged-out requests no longer invent one.