### PR TITLE
fix(zero-client): fixed types for connection API to not allow null

### DIFF
--- a/packages/zero-cache/src/auth/auth.test.ts
+++ b/packages/zero-cache/src/auth/auth.test.ts
@@ -87,6 +87,14 @@ describe('resolveAuth', () => {
     ).resolves.toEqual({type: 'opaque', raw: 'opaque-1'});
   });
 
+  test('reuses the existing opaque auth object when the token is unchanged', async () => {
+    const existingAuth = {type: 'opaque', raw: 'opaque-1'} as const;
+
+    await expect(
+      resolveAuth(lc, existingAuth, 'u1', 'opaque-1', undefined),
+    ).resolves.toBe(existingAuth);
+  });
+
   test('treats empty auth as unauthenticated when no prior auth exists', async () => {
     await expect(resolveAuth(lc, undefined, 'u1', '', undefined)).resolves.toBe(
       undefined,

--- a/packages/zero-cache/src/auth/auth.ts
+++ b/packages/zero-cache/src/auth/auth.ts
@@ -33,6 +33,16 @@ function isProvidedAuth(wireAuth: string | undefined): wireAuth is string {
   return wireAuth !== undefined && wireAuth !== '';
 }
 
+export function authEquals(a: Auth | undefined, b: Auth | undefined) {
+  if (a === b) {
+    return true;
+  }
+  if (!a || !b) {
+    return false;
+  }
+  return a.type === b.type && a.raw === b.raw;
+}
+
 /**
  * Resolves one auth snapshot transition without binding it to a client group.
  */
@@ -88,6 +98,11 @@ export async function resolveAuth(
           'Token type cannot change from JWT to opaque. Connections are pinned to a single token type.',
         origin: ErrorOrigin.ZeroCache,
       });
+    }
+
+    if (previousAuth?.type === 'opaque' && previousAuth.raw === wireAuth) {
+      lc.debug?.(`Opaque auth unchanged, reusing previous snapshot`);
+      return previousAuth;
     }
 
     lc.debug?.(`Updated auth with opaque token`);

--- a/packages/zero-cache/src/services/mutagen/pusher.test.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.test.ts
@@ -358,6 +358,29 @@ describe('combine pushes', () => {
     expect(pushes[0].push.mutations).toHaveLength(3);
   });
 
+  test('combines pushes when auth matches by value across snapshots', () => {
+    const first = makeEntry(makePush(1, 'client1'), {
+      clientID: 'client1',
+      wsID: 'ws1',
+      revision: 1,
+      auth: 'a',
+    });
+    const second = makeEntry(makePush(1, 'client1'), {
+      clientID: 'client1',
+      wsID: 'ws1',
+      revision: 1,
+      auth: 'a',
+    });
+
+    second.context.auth = {type: 'opaque', raw: 'a'};
+
+    const [pushes, terminate] = combinePushes([first, second]);
+
+    expect(pushes).toHaveLength(1);
+    expect(terminate).toBe(false);
+    expect(pushes[0].push.mutations).toHaveLength(2);
+  });
+
   test('handles multiple clients with multiple pushes', () => {
     const [pushes, terminate] = combinePushes([
       makeEntry(makePush(1, 'client1'), {clientID: 'client1', auth: 'a'}),

--- a/packages/zero-cache/src/services/mutagen/pusher.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.ts
@@ -20,7 +20,7 @@ import {
   type PushBody,
   type PushResponse,
 } from '../../../../zero-protocol/src/push.ts';
-import {isAuthErrorBody} from '../../auth/auth.ts';
+import {authEquals, isAuthErrorBody} from '../../auth/auth.ts';
 import {type ZeroConfig} from '../../config/zero-config.ts';
 import {fetchFromAPIServer} from '../../custom/fetch.ts';
 import {getOrCreateCounter} from '../../observability/metrics.ts';
@@ -628,7 +628,7 @@ function assertAreCompatiblePushes(left: PusherEntry, right: PusherEntry) {
     'revision must be the same for all pushes',
   );
   assert(
-    left.context.auth === right.context.auth,
+    authEquals(left.context.auth, right.context.auth),
     'auth must be the same for all pushes with the same clientID',
   );
   assert(

--- a/packages/zero-cache/src/services/view-syncer/connection-context-manager.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/connection-context-manager.test.ts
@@ -297,6 +297,9 @@ describe('ConnectionContextManager', () => {
     );
     register(manager, 'c1', 'ws1', 'user-1');
     validate(manager, 'c1', 'ws1');
+    const previousAuth = manager.mustGetConnectionContext(
+      selector('c1', 'ws1'),
+    ).auth;
 
     await expect(
       manager.updateAuth(selector('c1', 'ws1'), {auth: 'token-ws1'}),
@@ -312,6 +315,9 @@ describe('ConnectionContextManager', () => {
       wsID: 'ws1',
     });
     expect(manager.getGroupState().retransformAt).toBe(11_000);
+    expect(manager.mustGetConnectionContext(selector('c1', 'ws1')).auth).toBe(
+      previousAuth,
+    );
   });
 
   test('demotes only the connection whose auth materially changes', async () => {

--- a/packages/zero-cache/src/services/view-syncer/connection-context-manager.ts
+++ b/packages/zero-cache/src/services/view-syncer/connection-context-manager.ts
@@ -3,6 +3,7 @@ import type {InitConnectionBody} from '../../../../zero-protocol/src/connect.ts'
 import {ErrorKind} from '../../../../zero-protocol/src/error-kind.ts';
 import {ErrorOrigin} from '../../../../zero-protocol/src/error-origin.ts';
 import {
+  authEquals,
   resolveAuth,
   type Auth,
   type ValidateLegacyJWT,
@@ -667,16 +668,6 @@ export class ConnectionContextManagerImpl implements ConnectionContextManager {
       ? undefined
       : this.#now() + this.#revalidateIntervalMs;
   }
-}
-
-function authEquals(a: Auth | undefined, b: Auth | undefined) {
-  if (a === b) {
-    return true;
-  }
-  if (!a || !b) {
-    return false;
-  }
-  return a.type === b.type && a.raw === b.raw;
 }
 
 function snapshotConnection<T extends ConnectionContext | undefined>(

--- a/packages/zero-client/src/client/connection.ts
+++ b/packages/zero-client/src/client/connection.ts
@@ -90,26 +90,26 @@ export interface Connection {
    * Resumes the connection from a terminal state.
    *
    * If called when not in a terminal state, this method does nothing.
+   * To clear existing auth credentials, create a new Zero instance with `auth` omitted.
    *
    * @param opts - Optional connection options
    * @param opts.auth - Token to use for authentication. If provided, this overrides
    *                    the stored auth credential for this connection attempt.
-   *                    If `null` or `undefined`, the stored auth credential is cleared.
    * @returns A promise that resolves once the connection state has transitioned to connecting.
    */
-  connect(opts?: {auth: string | null | undefined}): Promise<void>;
+  connect(opts?: {auth: string}): Promise<void>;
 }
 
 export class ConnectionImpl implements Connection {
   readonly #connectionManager: ConnectionManager;
   readonly #lc: LogContext;
   readonly #source: ConnectionSource;
-  readonly #setAuth: (auth: string | null | undefined) => void;
+  readonly #setAuth: (auth: string) => void;
 
   constructor(
     connectionManager: ConnectionManager,
     lc: LogContext,
-    setAuth: (auth: string | null | undefined) => void,
+    setAuth: (auth: string) => void,
   ) {
     this.#connectionManager = connectionManager;
     this.#lc = lc;
@@ -121,7 +121,7 @@ export class ConnectionImpl implements Connection {
     return this.#source;
   }
 
-  async connect(opts?: {auth: string | null | undefined}): Promise<void> {
+  async connect(opts?: {auth: string}): Promise<void> {
     const lc = this.#lc.withContext('connect');
 
     if (opts && 'auth' in opts) {

--- a/packages/zero-client/src/client/options.ts
+++ b/packages/zero-client/src/client/options.ts
@@ -45,6 +45,9 @@ export type ZeroOptions<
    * The call to `connect` is handled automatically by the ZeroProvider component
    * for React and SolidJS when the `auth` prop changes.
    *
+   * Transitions between authenticated and logged-out states recreate the Zero
+   * instance instead.
+   *
    * When `auth` changes while connected, Zero refreshes server-side auth context
    * and re-transforms queries without reconnecting.
    *
@@ -57,15 +60,16 @@ export type ZeroOptions<
   /**
    * A unique identifier for the user.
    *
+   * Omit this, or set to `null`, for logged-out clients.
+   *
+   * This is passed to the query/mutate endpoints via an `X-User-ID` header and
+   * must be used to validate claimed user identity against the provided auth
+   * on the server (either token or cookie auth).
+   *
    * Each userID gets its own client-side storage so that the app can switch
    * between users without losing state.
-   *
-   * Omit this only for logged-out clients.
-   *
-   * This must match the `sub` claim of the `auth` token if
-   * `auth` is provided.
    */
-  userID?: string | undefined;
+  userID?: string | null | undefined;
 
   /**
    * Distinguishes the storage used by this Zero instance from that of other

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -480,7 +480,7 @@ export class Zero<
       });
     }
 
-    this.#checkAuthValid(userID, options.auth);
+    this.#checkAuthValid(userID ?? undefined, options.auth);
 
     const cacheURL = options.cacheURL ?? options.server;
     const server = getServer(cacheURL);
@@ -644,7 +644,7 @@ export class Zero<
       internalReplicacheImplMap.set(this, rep);
     }
     this.#server = server;
-    this.userID = userID;
+    this.userID = userID ?? undefined;
     this.#lc = lc.withContext('clientID', rep.clientID);
     this.#connection = new ConnectionImpl(
       this.#connectionManager,

--- a/packages/zero-react/src/zero-provider.test.tsx
+++ b/packages/zero-react/src/zero-provider.test.tsx
@@ -444,25 +444,36 @@ describe('ZeroProvider', () => {
       });
     });
 
-    test('calls connection.connect when null auth is provided and then changes', () => {
-      const mockZero = createMockZero();
+    test('recreates zero when auth changes from undefined to a value', () => {
+      const mockZero1 = createMockZero('client-1');
+      const mockZero2 = createMockZero('client-2');
       const ZeroMock = vi.mocked(ZeroConstructor);
-      ZeroMock.mockImplementation(function () {
-        return mockZero;
+      ZeroMock.mockImplementationOnce(function () {
+        return mockZero1;
+      }).mockImplementationOnce(function () {
+        return mockZero2;
       });
 
       const schema = {} as Schema;
+      let capturedZero: Zero<Schema> | undefined;
+
+      function TestComponent() {
+        capturedZero = useZero<Schema>();
+        return <div>test</div>;
+      }
 
       const root = renderWithRoot(
         <ZeroProvider
           cacheURL="https://example.com"
           schema={schema}
-          auth={null}
+          auth={undefined}
           userID="test-user"
         >
-          <div>test</div>
+          <TestComponent />
         </ZeroProvider>,
       );
+
+      expect(capturedZero).toBe(mockZero1);
 
       act(() => {
         root.render(
@@ -472,59 +483,81 @@ describe('ZeroProvider', () => {
             auth="token-new"
             userID="test-user"
           >
-            <div>test</div>
+            <TestComponent />
           </ZeroProvider>,
         );
       });
 
-      expect(mockZero.connection.connect).toHaveBeenCalledWith({
-        auth: 'token-new',
-      });
-      expect(mockZero.connection.connect).toHaveBeenCalledTimes(1);
-      expect(mockZero.close).not.toHaveBeenCalled();
+      expect(ZeroMock).toHaveBeenCalledTimes(2);
+      expect(ZeroMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          auth: 'token-new',
+        }),
+      );
+      expect(mockZero1.close).toHaveBeenCalledTimes(1);
+      expect(mockZero1.connection.connect).not.toHaveBeenCalled();
+      expect(mockZero2.connection.connect).not.toHaveBeenCalled();
+      expect(capturedZero).toBe(mockZero2);
 
       act(() => {
         root.unmount();
       });
     });
 
-    test('calls connection.connect when no auth value is provided and then changes', () => {
-      const mockZero = createMockZero();
+    test('recreates zero when auth changes from a value to undefined', () => {
+      const mockZero1 = createMockZero('client-1');
+      const mockZero2 = createMockZero('client-2');
       const ZeroMock = vi.mocked(ZeroConstructor);
-      ZeroMock.mockImplementation(function () {
-        return mockZero;
+      ZeroMock.mockImplementationOnce(function () {
+        return mockZero1;
+      }).mockImplementationOnce(function () {
+        return mockZero2;
       });
 
       const schema = {} as Schema;
+      let capturedZero: Zero<Schema> | undefined;
+
+      function TestComponent() {
+        capturedZero = useZero<Schema>();
+        return <div>test</div>;
+      }
 
       const root = renderWithRoot(
         <ZeroProvider
           cacheURL="https://example.com"
           schema={schema}
+          auth="token-initial"
           userID="test-user"
         >
-          <div>test</div>
+          <TestComponent />
         </ZeroProvider>,
       );
+
+      expect(capturedZero).toBe(mockZero1);
 
       act(() => {
         root.render(
           <ZeroProvider
             cacheURL="https://example.com"
             schema={schema}
-            auth="token-new"
+            auth={undefined}
             userID="test-user"
           >
-            <div>test</div>
+            <TestComponent />
           </ZeroProvider>,
         );
       });
 
-      expect(mockZero.connection.connect).toHaveBeenCalledWith({
-        auth: 'token-new',
-      });
-      expect(mockZero.connection.connect).toHaveBeenCalledTimes(1);
-      expect(mockZero.close).not.toHaveBeenCalled();
+      expect(ZeroMock).toHaveBeenCalledTimes(2);
+      expect(ZeroMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          auth: undefined,
+        }),
+      );
+      expect(mockZero1.close).toHaveBeenCalledTimes(1);
+      expect(mockZero1.connection.connect).not.toHaveBeenCalled();
+      expect(mockZero2.connection.connect).not.toHaveBeenCalled();
+      expect(capturedZero).toBe(mockZero2);
 
       act(() => {
         root.unmount();

--- a/packages/zero-react/src/zero-provider.tsx
+++ b/packages/zero-react/src/zero-provider.tsx
@@ -63,8 +63,6 @@ export type ZeroProviderProps<
   children: ReactNode;
 };
 
-const NO_AUTH_SET = Symbol();
-
 export function ZeroProvider<
   S extends BaseDefaultSchema = DefaultSchema,
   MD extends CustomMutatorDefs | undefined = undefined,
@@ -76,7 +74,8 @@ export function ZeroProvider<
     isExternalZero ? props.zero : undefined,
   );
 
-  const auth = 'auth' in props ? props.auth : NO_AUTH_SET;
+  const auth = 'auth' in props ? props.auth : undefined;
+  const hasAuth = typeof auth === 'string';
   const prevAuthRef = useRef<typeof auth>(auth);
 
   const keysWithoutAuth = useMemo(
@@ -100,6 +99,7 @@ export function ZeroProvider<
     }
 
     const z = new Zero(props);
+    prevAuthRef.current = auth;
     init?.(z);
     setZero(z);
 
@@ -109,18 +109,20 @@ export function ZeroProvider<
     };
     // we intentionally don't include auth in the dependency array
     // to avoid closing zero when auth changes
-  }, [init, ...keysWithoutAuth]);
+  }, [hasAuth, init, ...keysWithoutAuth]);
 
   useEffect(() => {
     if (!zero || isExternalZero) return;
 
-    const authChanged = auth !== prevAuthRef.current;
+    const prevAuth = prevAuthRef.current;
+    const authChanged = auth !== prevAuth;
 
     if (authChanged) {
       prevAuthRef.current = auth;
-      void zero.connection.connect({
-        auth: auth === NO_AUTH_SET ? undefined : auth,
-      });
+
+      if (typeof prevAuth === 'string' && typeof auth === 'string') {
+        void zero.connection.connect({auth});
+      }
     }
   }, [auth, zero]);
 

--- a/packages/zero-solid/src/use-zero.test.tsx
+++ b/packages/zero-solid/src/use-zero.test.tsx
@@ -345,10 +345,12 @@ describe('ZeroProvider', () => {
       expect(zero.connection.connect).not.toHaveBeenCalled();
     });
 
-    test('calls connection.connect when auth changes from undefined to a value', () => {
-      const zero = createMockZero();
-      ZeroMock.mockImplementation(function () {
-        return zero;
+    test('recreates zero when auth changes from undefined to a value', () => {
+      const zeros = [createMockZero('client-1'), createMockZero('client-2')];
+      const capturedOptions: ZeroOptions<Schema>[] = [];
+      ZeroMock.mockImplementation(function (options) {
+        capturedOptions.push(options as ZeroOptions<Schema>);
+        return zeros[capturedOptions.length - 1]!;
       });
 
       const schema = {} as Schema;
@@ -365,24 +367,29 @@ describe('ZeroProvider', () => {
         </ZeroProvider>
       );
 
-      renderHook(() => useZero<Schema>(), {
+      const {result} = renderHook(() => useZero<Schema>(), {
         initialProps: [],
         wrapper,
       });
 
+      expect(result()).toBe(zeros[0]);
+
       setAuth('token-new');
 
-      expect(zero.connection.connect).toHaveBeenCalledWith({
-        auth: 'token-new',
-      });
-      expect(zero.connection.connect).toHaveBeenCalledTimes(1);
-      expect(ZeroMock).toHaveBeenCalledTimes(1);
+      expect(ZeroMock).toHaveBeenCalledTimes(2);
+      expect(capturedOptions[1]?.auth).toBe('token-new');
+      expect(zeros[0].close).toHaveBeenCalledTimes(1);
+      expect(zeros[0].connection.connect).not.toHaveBeenCalled();
+      expect(zeros[1].connection.connect).not.toHaveBeenCalled();
+      expect(result()).toBe(zeros[1]);
     });
 
-    test('calls connection.connect with undefined when auth prop is changed to undefined', () => {
-      const zero = createMockZero();
-      ZeroMock.mockImplementation(function () {
-        return zero;
+    test('recreates zero when auth changes from a value to undefined', () => {
+      const zeros = [createMockZero('client-1'), createMockZero('client-2')];
+      const capturedOptions: ZeroOptions<Schema>[] = [];
+      ZeroMock.mockImplementation(function (options) {
+        capturedOptions.push(options as ZeroOptions<Schema>);
+        return zeros[capturedOptions.length - 1]!;
       });
 
       const schema = {} as Schema;
@@ -399,23 +406,21 @@ describe('ZeroProvider', () => {
         </ZeroProvider>
       );
 
-      renderHook(() => useZero<Schema>(), {
+      const {result} = renderHook(() => useZero<Schema>(), {
         initialProps: [],
         wrapper,
       });
 
+      expect(result()).toBe(zeros[0]);
+
       setAuth(undefined);
 
-      expect(zero.connection.connect).toHaveBeenCalledWith({auth: undefined});
-      expect(zero.connection.connect).toHaveBeenCalledTimes(1);
-      expect(ZeroMock).toHaveBeenCalledTimes(1);
-
-      zero.connection.connect.mockClear();
-
-      setAuth('token-new');
-
-      expect(zero.connection.connect).toHaveBeenCalledWith({auth: 'token-new'});
-      expect(zero.connection.connect).toHaveBeenCalledTimes(1);
+      expect(ZeroMock).toHaveBeenCalledTimes(2);
+      expect(capturedOptions[1]).not.toHaveProperty('auth');
+      expect(zeros[0].close).toHaveBeenCalledTimes(1);
+      expect(zeros[0].connection.connect).not.toHaveBeenCalled();
+      expect(zeros[1].connection.connect).not.toHaveBeenCalled();
+      expect(result()).toBe(zeros[1]);
     });
 
     test('does not call connection.connect when zero is provided externally and auth changes', () => {

--- a/packages/zero-solid/src/use-zero.ts
+++ b/packages/zero-solid/src/use-zero.ts
@@ -72,8 +72,6 @@ export function createUseZero<
   return () => useZero<S, MD, Context>();
 }
 
-const NO_AUTH_SET = Symbol();
-
 export function ZeroProvider<
   S extends BaseDefaultSchema = DefaultSchema,
   MD extends CustomMutatorDefs | undefined = undefined,
@@ -89,14 +87,22 @@ export function ZeroProvider<
     | ZeroOptions<S, MD, Context>
   ),
 ) {
+  let prevAuth = 'auth' in props ? props.auth : undefined;
+
+  const auth = createMemo(() => ('auth' in props ? props.auth : undefined));
+  const hasAuth = createMemo(() => typeof auth() === 'string');
+
   const zero = createMemo(() => {
     if ('zero' in props) {
       return props.zero;
     }
 
+    hasAuth();
+
     const [, options] = splitProps(props, ['children', 'auth']);
 
-    const authValue = untrack(() => props.auth);
+    const authValue = untrack(auth);
+    prevAuth = authValue;
     const createdZero = new Zero({
       ...options,
       ...(authValue !== undefined ? {auth: authValue} : {}),
@@ -107,13 +113,6 @@ export function ZeroProvider<
     return createdZero;
   });
 
-  const auth = createMemo<
-    typeof NO_AUTH_SET | ZeroOptions<S, MD, Context>['auth']
-  >(() => ('auth' in props ? props.auth : NO_AUTH_SET));
-
-  let prevAuth: typeof NO_AUTH_SET | ZeroOptions<S, MD, Context>['auth'] =
-    NO_AUTH_SET;
-
   createEffect(() => {
     const currentZero = zero();
     if (!currentZero || 'zero' in props) {
@@ -122,16 +121,13 @@ export function ZeroProvider<
 
     const currentAuth = auth();
 
-    if (prevAuth === NO_AUTH_SET) {
-      prevAuth = currentAuth;
-      return;
-    }
-
     if (currentAuth !== prevAuth) {
+      const previousAuth = prevAuth;
       prevAuth = currentAuth;
-      void currentZero.connection.connect({
-        auth: currentAuth === NO_AUTH_SET ? undefined : currentAuth,
-      });
+
+      if (typeof previousAuth === 'string' && typeof currentAuth === 'string') {
+        void currentZero.connection.connect({auth: currentAuth});
+      }
     }
   });
 


### PR DESCRIPTION
We previously allowed null/undefined for the Connection API, but this was not semantically correct, since a new Zero instance must be created under this condition. So this is removing the types which may confuse users.