### PR TITLE
chore(zero-cache): distinguish between intentional and unexpected non-graceful shutdowns

### DIFF
--- a/packages/zero-cache/src/services/life-cycle.test.ts
+++ b/packages/zero-cache/src/services/life-cycle.test.ts
@@ -83,100 +83,101 @@ describe('shutdown', () => {
     await Promise.all(all.map(w => w.running.promise));
   });
 
-  test.each([['SIGTERM'], ['SIGINT']])(
-    'graceful shutdown: %s',
-    async signal => {
-      proc.emit(signal);
+  test('graceful shutdown', async () => {
+    proc.emit('SIGTERM');
 
-      await syncer1.draining.promise;
-      await syncer2.draining.promise;
+    await syncer1.draining.promise;
+    await syncer2.draining.promise;
 
-      syncer1.finishDrain.resolve();
-      syncer2.finishDrain.resolve();
+    syncer1.finishDrain.resolve();
+    syncer2.finishDrain.resolve();
 
-      await changeStreamer.draining.promise;
-      await replicator.draining.promise;
+    await changeStreamer.draining.promise;
+    await replicator.draining.promise;
 
-      changeStreamer.finishDrain.resolve();
-      replicator.finishDrain.resolve();
+    changeStreamer.finishDrain.resolve();
+    replicator.finishDrain.resolve();
 
-      await Promise.all(all.map(w => w.stopped.promise));
+    await Promise.all(all.map(w => w.stopped.promise));
 
-      expect(events).toEqual([
-        'drain user-facing',
-        'drain user-facing',
-        'stop user-facing',
-        'stop user-facing',
-        'drain supporting',
-        'drain supporting',
-        'stop supporting',
-        'stop supporting',
-      ]);
-    },
-  );
+    expect(events).toEqual([
+      'drain user-facing',
+      'drain user-facing',
+      'stop user-facing',
+      'stop user-facing',
+      'drain supporting',
+      'drain supporting',
+      'stop supporting',
+      'stop supporting',
+    ]);
+  });
 
-  test.each([['SIGTERM'], ['SIGINT']])(
-    'error during graceful shutdown: %s',
-    async signal => {
-      proc.emit(signal);
+  test('error during graceful shutdown: %s', async () => {
+    proc.emit('SIGTERM');
 
-      await syncer1.draining.promise;
-      await syncer2.draining.promise;
+    await syncer1.draining.promise;
+    await syncer2.draining.promise;
 
-      syncer1.stopped.reject('doh');
-      syncer2.finishDrain.resolve();
+    syncer1.stopped.reject('doh');
+    syncer2.finishDrain.resolve();
 
-      await changeStreamer.draining.promise;
-      await replicator.draining.promise;
+    await changeStreamer.draining.promise;
+    await replicator.draining.promise;
 
-      changeStreamer.finishDrain.resolve();
-      replicator.finishDrain.resolve();
+    changeStreamer.finishDrain.resolve();
+    replicator.finishDrain.resolve();
 
-      await Promise.allSettled(all.map(w => w.stopped.promise));
+    await Promise.allSettled(all.map(w => w.stopped.promise));
 
-      expect(events).toEqual([
-        'drain user-facing',
-        'drain user-facing',
-        'stop user-facing',
-        'drain supporting',
-        'drain supporting',
-        'stop supporting',
-        'stop supporting',
-      ]);
-    },
-  );
+    expect(events).toEqual([
+      'drain user-facing',
+      'drain user-facing',
+      'stop user-facing',
+      'drain supporting',
+      'drain supporting',
+      'stop supporting',
+      'stop supporting',
+    ]);
+  });
 
-  test.each([['SIGTERM'], ['SIGINT']])(
-    'all error during graceful shutdown: %s',
-    async signal => {
-      proc.emit(signal);
+  test('all error during graceful shutdown: %s', async () => {
+    proc.emit('SIGTERM');
 
-      await syncer1.draining.promise;
-      await syncer2.draining.promise;
+    await syncer1.draining.promise;
+    await syncer2.draining.promise;
 
-      syncer1.stopped.reject('doh');
-      syncer2.stopped.reject('doh');
+    syncer1.stopped.reject('doh');
+    syncer2.stopped.reject('doh');
 
-      await changeStreamer.draining.promise;
-      await replicator.draining.promise;
+    await changeStreamer.draining.promise;
+    await replicator.draining.promise;
 
-      changeStreamer.finishDrain.resolve();
-      replicator.finishDrain.resolve();
+    changeStreamer.finishDrain.resolve();
+    replicator.finishDrain.resolve();
 
-      await Promise.allSettled(all.map(w => w.stopped.promise));
+    await Promise.allSettled(all.map(w => w.stopped.promise));
 
-      expect(events).toEqual([
-        'drain user-facing',
-        'drain user-facing',
-        'drain supporting',
-        'drain supporting',
-        'stop supporting',
-        'stop supporting',
-      ]);
-    },
-  );
+    expect(events).toEqual([
+      'drain user-facing',
+      'drain user-facing',
+      'drain supporting',
+      'drain supporting',
+      'stop supporting',
+      'stop supporting',
+    ]);
+  });
 
   test.each([
+    [
+      'SIGINT',
+      () => proc.emit('SIGINT'),
+      [
+        'stop supporting',
+        'stop supporting',
+        'stop user-facing',
+        'stop user-facing',
+      ],
+    ],
     [
       'SIGQUIT',
       () => proc.emit('SIGQUIT'),
@@ -224,30 +225,5 @@ describe('shutdown', () => {
 
     // sort() because order doesn't matter.
     expect(events.sort()).toEqual(expectedEvents.sort());
-  });
-
-  test('graceful shutdown with no user-facing workers', async () => {
-    proc = new EventEmitter();
-    processes = new ProcessManager(lc, proc);
-    const changeStreamer = startWorker('cs', 'supporting');
-    const replicator = startWorker('rep', 'supporting');
-    const all = [changeStreamer, replicator];
-
-    await Promise.all(all.map(w => w.running.promise));
-
-    void changeStreamer.stop();
-
-    await replicator.draining.promise;
-
-    replicator.finishDrain.resolve();
-
-    await replicator.stopped.promise;
-
-    lc.debug?.('expecting');
-    expect(events).toEqual([
-      'stop supporting',
-      'drain supporting',
-      'stop supporting',
-    ]);
   });
 });

--- a/packages/zero-cache/src/services/life-cycle.test.ts
+++ b/packages/zero-cache/src/services/life-cycle.test.ts
@@ -83,94 +83,103 @@ describe('shutdown', () => {
     await Promise.all(all.map(w => w.running.promise));
   });
 
-  test('graceful shutdown', async () => {
-    proc.emit('SIGTERM');
+  test.each([['SIGTERM'], ['SIGINT']])(
+    'graceful shutdown: %s',
+    async signal => {
+      proc.emit(signal);
 
-    await syncer1.draining.promise;
-    await syncer2.draining.promise;
+      await syncer1.draining.promise;
+      await syncer2.draining.promise;
 
-    syncer1.finishDrain.resolve();
-    syncer2.finishDrain.resolve();
+      syncer1.finishDrain.resolve();
+      syncer2.finishDrain.resolve();
 
-    await changeStreamer.draining.promise;
-    await replicator.draining.promise;
+      await changeStreamer.draining.promise;
+      await replicator.draining.promise;
 
-    changeStreamer.finishDrain.resolve();
-    replicator.finishDrain.resolve();
+      changeStreamer.finishDrain.resolve();
+      replicator.finishDrain.resolve();
 
-    await Promise.all(all.map(w => w.stopped.promise));
+      await Promise.all(all.map(w => w.stopped.promise));
 
-    expect(events).toEqual([
-      'drain user-facing',
-      'drain user-facing',
-      'stop user-facing',
-      'stop user-facing',
-      'drain supporting',
-      'drain supporting',
-      'stop supporting',
-      'stop supporting',
-    ]);
-  });
+      expect(events).toEqual([
+        'drain user-facing',
+        'drain user-facing',
+        'stop user-facing',
+        'stop user-facing',
+        'drain supporting',
+        'drain supporting',
+        'stop supporting',
+        'stop supporting',
+      ]);
+    },
+  );
 
-  test('error during graceful shutdown: %s', async () => {
-    proc.emit('SIGTERM');
+  test.each([['SIGTERM'], ['SIGINT']])(
+    'error during graceful shutdown: %s',
+    async signal => {
+      proc.emit(signal);
 
-    await syncer1.draining.promise;
-    await syncer2.draining.promise;
+      await syncer1.draining.promise;
+      await syncer2.draining.promise;
 
-    syncer1.stopped.reject('doh');
-    syncer2.finishDrain.resolve();
+      syncer1.stopped.reject('doh');
+      syncer2.finishDrain.resolve();
 
-    await changeStreamer.draining.promise;
-    await replicator.draining.promise;
+      await changeStreamer.draining.promise;
+      await replicator.draining.promise;
 
-    changeStreamer.finishDrain.resolve();
-    replicator.finishDrain.resolve();
+      changeStreamer.finishDrain.resolve();
+      replicator.finishDrain.resolve();
 
-    await Promise.allSettled(all.map(w => w.stopped.promise));
+      await Promise.allSettled(all.map(w => w.stopped.promise));
 
-    expect(events).toEqual([
-      'drain user-facing',
-      'drain user-facing',
-      'stop user-facing',
-      'drain supporting',
-      'drain supporting',
-      'stop supporting',
-      'stop supporting',
-    ]);
-  });
+      expect(events).toEqual([
+        'drain user-facing',
+        'drain user-facing',
+        'stop user-facing',
+        'drain supporting',
+        'drain supporting',
+        'stop supporting',
+        'stop supporting',
+      ]);
+    },
+  );
 
-  test('all error during graceful shutdown: %s', async () => {
-    proc.emit('SIGTERM');
+  test.each([['SIGTERM'], ['SIGINT']])(
+    'all error during graceful shutdown: %s',
+    async signal => {
+      proc.emit(signal);
 
-    await syncer1.draining.promise;
-    await syncer2.draining.promise;
+      await syncer1.draining.promise;
+      await syncer2.draining.promise;
 
-    syncer1.stopped.reject('doh');
-    syncer2.stopped.reject('doh');
+      syncer1.stopped.reject('doh');
+      syncer2.stopped.reject('doh');
 
-    await changeStreamer.draining.promise;
-    await replicator.draining.promise;
+      await changeStreamer.draining.promise;
+      await replicator.draining.promise;
 
-    changeStreamer.finishDrain.resolve();
-    replicator.finishDrain.resolve();
+      changeStreamer.finishDrain.resolve();
+      replicator.finishDrain.resolve();
 
-    await Promise.allSettled(all.map(w => w.stopped.promise));
+      await Promise.allSettled(all.map(w => w.stopped.promise));
 
-    expect(events).toEqual([
-      'drain user-facing',
-      'drain user-facing',
-      'drain supporting',
-      'drain supporting',
-      'stop supporting',
-      'stop supporting',
-    ]);
-  });
+      expect(events).toEqual([
+        'drain user-facing',
+        'drain user-facing',
+        'drain supporting',
+        'drain supporting',
+        'stop supporting',
+        'stop supporting',
+      ]);
+    },
+  );
 
   test.each([
     [
-      'SIGINT',
-      () => proc.emit('SIGINT'),
+      'SIGQUIT',
+      () => proc.emit('SIGQUIT'),
       [
         'stop supporting',
         'stop supporting',
@@ -179,8 +188,8 @@ describe('shutdown', () => {
       ],
     ],
     [
-      'SIGQUIT',
-      () => proc.emit('SIGQUIT'),
+      'SIGABRT',
+      () => proc.emit('SIGABRT'),
       [
         'stop supporting',
         'stop supporting',

--- a/packages/zero-cache/src/services/life-cycle.ts
+++ b/packages/zero-cache/src/services/life-cycle.ts
@@ -13,21 +13,21 @@ import type {SingletonService} from './service.ts';
 
 /**
  * * `user-facing` workers serve external requests and are the first to
- *   receive a `SIGTERM` signal for graceful shutdown.
+ *   receive a `SIGTERM` or `SIGINT` signal for graceful shutdown.
  *
  * * `supporting` workers support `user-facing` workers and are sent
  *   the `SIGTERM` signal only after all `user-facing` workers have
  *   exited.
  *
- * For other kill signals, such as `SIGINT` and `SIGQUIT`, all workers
- * are stopped without draining. `SIGINT` is used to represent an
- * intentional abort (for which draining is not beneficial), whereas
- * `SIGQUIT` is used for unexpected process exits.
+ * For other kill signals, such as `SIGQUIT` and `SIGABRT`, all workers
+ * are stopped without draining. `SIGQUIT` is used to represent an
+ * intentional shutdown (for which draining is not beneficial), whereas
+ * `SIGABRT` is used for unexpected process exits.
  */
 export type WorkerType = 'user-facing' | 'supporting';
 
-export const GRACEFUL_SHUTDOWN = ['SIGTERM'] as const;
-export const FORCEFUL_SHUTDOWN = ['SIGINT', 'SIGQUIT'] as const;
+export const GRACEFUL_SHUTDOWN = ['SIGTERM', 'SIGINT'] as const;
+export const FORCEFUL_SHUTDOWN = ['SIGABRT', 'SIGQUIT'] as const;
 
 // An internal error code used to indicate that a message has already been
 // logged at level ERRROR. When a process exits with this error code, the
@@ -37,7 +37,7 @@ export const UNHANDLED_EXCEPTION_ERROR_CODE = 13;
 // An internal error code used to indicate that the server should exit
 // without draining (e.g. due to a supporting worker get a signal to shut
 // down), but the exit is otherwise intentional.
-const INTENTIONAL_ABORT_ERROR_CODE = 14;
+const INTENTIONAL_SHUTDOWN_ERROR_CODE = 14;
 
 /**
  * Handles readiness, termination signals, and coordination of graceful
@@ -57,11 +57,11 @@ export class ProcessManager {
   constructor(lc: LogContext, proc: EventEmitter) {
     this.#lc = lc.withContext('component', 'process-manager');
 
-    // Propagate `SIGTERM` to all user-facing workers,
+    // Propagate `SIGTERM` and `SIGINT` to all user-facing workers,
     // initiating a graceful shutdown. The parent process will
     // exit once all user-facing workers have exited ...
     for (const signal of GRACEFUL_SHUTDOWN) {
-      proc.on(signal, () => this.#startDrain());
+      proc.on(signal, () => this.#startDrain(signal));
     }
 
     // ... which will result in sending `SIGTERM` to the remaining workers.
@@ -70,14 +70,14 @@ export class ProcessManager {
         this.#all,
         code === 0
           ? 'SIGTERM' // graceful, drained shutdown
-          : code === INTENTIONAL_ABORT_ERROR_CODE
-            ? 'SIGINT' // intentional abort without drain
-            : 'SIGQUIT', // unintentional shutdown, alertable error
+          : code === INTENTIONAL_SHUTDOWN_ERROR_CODE
+            ? 'SIGQUIT' // intentional abort without drain
+            : 'SIGABRT', // unintentional shutdown, alertable error
       ),
     );
 
     // For other (catchable) kill signals, exit with a non-zero error code
-    // to send a `SIGINT` (intentional shutdown) or `SIGQUIT` (unexpected
+    // to send a `SIGQUIT` (intentional shutdown) or `SIGABRT` (unexpected
     // shutdown) to all workers. For these signals, workers are stopped
     // immediately without draining, since there is no merit to slowly draining
     // when supporting workers have stopped.
@@ -85,7 +85,7 @@ export class ProcessManager {
     // The logic for handling these signals is in `runUntilKilled()`.
     for (const signal of FORCEFUL_SHUTDOWN) {
       proc.on(signal, () =>
-        this.#exit(signal === 'SIGINT' ? INTENTIONAL_ABORT_ERROR_CODE : -1),
+        this.#exit(signal === 'SIGQUIT' ? INTENTIONAL_SHUTDOWN_ERROR_CODE : -1),
       );
     }
 
@@ -107,13 +107,13 @@ export class ProcessManager {
     void this.#lc.flush().finally(() => this.#exitImpl(code));
   }
 
-  #startDrain() {
-    this.#lc.info?.(`initiating drain (SIGTERM)`);
+  #startDrain(signal: (typeof GRACEFUL_SHUTDOWN)[number]) {
+    this.#lc.info?.(`initiating drain (${signal})`);
     this.#drainStart = Date.now();
     if (this.#userFacing.size) {
-      this.#kill(this.#userFacing, 'SIGTERM');
+      this.#kill(this.#userFacing, signal);
     } else {
-      this.#kill(this.#all, 'SIGTERM');
+      this.#kill(this.#all, signal);
     }
   }
 
@@ -197,16 +197,18 @@ export class ProcessManager {
       // server should be shut down without draining, but it is otherwise not
       // considered an unexpected/alertable error.
       if (code === 0 && (this.#drainStart === 0 || this.#userFacing.size > 0)) {
-        code = INTENTIONAL_ABORT_ERROR_CODE;
+        code = INTENTIONAL_SHUTDOWN_ERROR_CODE;
       }
       const log =
-        code === 0 || code === INTENTIONAL_ABORT_ERROR_CODE ? 'info' : 'warn';
+        code === 0 || code === INTENTIONAL_SHUTDOWN_ERROR_CODE
+          ? 'info'
+          : 'warn';
       this.#lc[log]?.(`${name} (${pid}) exited with code (${code})`, err ?? '');
       return this.#exit(code);
     }
 
     const log =
-      code === 0 || code === INTENTIONAL_ABORT_ERROR_CODE
+      code === 0 || code === INTENTIONAL_SHUTDOWN_ERROR_CODE
         ? 'info'
         : this.#drainStart > 0 || code === UNHANDLED_EXCEPTION_ERROR_CODE
           ? 'warn'

--- a/packages/zero-cache/src/services/life-cycle.ts
+++ b/packages/zero-cache/src/services/life-cycle.ts
@@ -13,25 +13,31 @@ import type {SingletonService} from './service.ts';
 
 /**
  * * `user-facing` workers serve external requests and are the first to
- *   receive a `SIGTERM` or `SIGINT` signal for graceful shutdown.
+ *   receive a `SIGTERM` signal for graceful shutdown.
  *
  * * `supporting` workers support `user-facing` workers and are sent
  *   the `SIGTERM` signal only after all `user-facing` workers have
  *   exited.
  *
- * For other kill signals, such as `SIGQUIT`, all workers
- * are stopped without draining. Additionally, if any worker exits
- * unexpectedly, all workers sent an immediate `SIGQUIT` signal.
+ * For other kill signals, such as `SIGINT` and `SIGQUIT`, all workers
+ * are stopped without draining. `SIGINT` is used to represent an
+ * intentional abort (for which draining is not beneficial), whereas
+ * `SIGQUIT` is used for unexpected process exits.
  */
 export type WorkerType = 'user-facing' | 'supporting';
 
-export const GRACEFUL_SHUTDOWN = ['SIGTERM', 'SIGINT'] as const;
-export const FORCEFUL_SHUTDOWN = ['SIGQUIT'] as const;
+export const GRACEFUL_SHUTDOWN = ['SIGTERM'] as const;
+export const FORCEFUL_SHUTDOWN = ['SIGINT', 'SIGQUIT'] as const;
 
 // An internal error code used to indicate that a message has already been
 // logged at level ERRROR. When a process exits with this error code, the
 // parent process logs the exit at level WARN instead of ERROR.
 export const UNHANDLED_EXCEPTION_ERROR_CODE = 13;
+
+// An internal error code used to indicate that the server should exit
+// without draining (e.g. due to a supporting worker get a signal to shut
+// down), but the exit is otherwise intentional.
+const INTENTIONAL_ABORT_ERROR_CODE = 14;
 
 /**
  * Handles readiness, termination signals, and coordination of graceful
@@ -51,26 +57,36 @@ export class ProcessManager {
   constructor(lc: LogContext, proc: EventEmitter) {
     this.#lc = lc.withContext('component', 'process-manager');
 
-    // Propagate `SIGTERM` and `SIGINT` to all user-facing workers,
+    // Propagate `SIGTERM` to all user-facing workers,
     // initiating a graceful shutdown. The parent process will
     // exit once all user-facing workers have exited ...
     for (const signal of GRACEFUL_SHUTDOWN) {
-      proc.on(signal, () => this.#startDrain(signal));
+      proc.on(signal, () => this.#startDrain());
     }
 
     // ... which will result in sending `SIGTERM` to the remaining workers.
     proc.on('exit', code =>
       this.#kill(
         this.#all,
-        code === 0 ? GRACEFUL_SHUTDOWN[0] : FORCEFUL_SHUTDOWN[0],
+        code === 0
+          ? 'SIGTERM' // graceful, drained shutdown
+          : code === INTENTIONAL_ABORT_ERROR_CODE
+            ? 'SIGINT' // intentional abort without drain
+            : 'SIGQUIT', // unintentional shutdown, alertable error
       ),
     );
 
     // For other (catchable) kill signals, exit with a non-zero error code
-    // to send a `SIGQUIT` to all workers. For this signal, workers are
-    // stopped immediately without draining. See `runUntilKilled()`.
+    // to send a `SIGINT` (intentional shutdown) or `SIGQUIT` (unexpected
+    // shutdown) to all workers. For these signals, workers are stopped
+    // immediately without draining, since there is no merit to slowly draining
+    // when supporting workers have stopped.
+    //
+    // The logic for handling these signals is in `runUntilKilled()`.
     for (const signal of FORCEFUL_SHUTDOWN) {
-      proc.on(signal, () => this.#exit(-1));
+      proc.on(signal, () =>
+        this.#exit(signal === 'SIGINT' ? INTENTIONAL_ABORT_ERROR_CODE : -1),
+      );
     }
 
     this.#exitImpl = (code: number) => {
@@ -91,13 +107,13 @@ export class ProcessManager {
     void this.#lc.flush().finally(() => this.#exitImpl(code));
   }
 
-  #startDrain(signal: 'SIGTERM' | 'SIGINT' = 'SIGTERM') {
-    this.#lc.info?.(`initiating drain (${signal})`);
+  #startDrain() {
+    this.#lc.info?.(`initiating drain (SIGTERM)`);
     this.#drainStart = Date.now();
     if (this.#userFacing.size) {
-      this.#kill(this.#userFacing, signal);
+      this.#kill(this.#userFacing, 'SIGTERM');
     } else {
-      this.#kill(this.#all, signal);
+      this.#kill(this.#all, 'SIGTERM');
     }
   }
 
@@ -161,7 +177,7 @@ export class ProcessManager {
   #onExit(
     code: number,
     sig: NodeJS.Signals | null,
-    err: unknown | null,
+    err: unknown,
     type: WorkerType,
     name: string,
     worker: Subprocess | undefined,
@@ -175,25 +191,32 @@ export class ProcessManager {
     const pid = worker?.pid ?? process.pid;
 
     if (type === 'supporting') {
-      // The replication-manager has no user-facing workers.
-      // In this case, code === 0 shutdowns are not errors.
-      // Non-zero exits are warnings (not errors) since they're often transient issues.
-      const log = code === 0 && this.#userFacing.size === 0 ? 'info' : 'warn';
+      // Supporting workers like the replication-manager shut down without a
+      // drain signal when receiving protocol-specific instructions (like auto
+      // reset). In this case, a special error code is used to signal that the
+      // server should be shut down without draining, but it is otherwise not
+      // considered an unexpected/alertable error.
+      if (code === 0 && (this.#drainStart === 0 || this.#userFacing.size > 0)) {
+        code = INTENTIONAL_ABORT_ERROR_CODE;
+      }
+      const log =
+        code === 0 || code === INTENTIONAL_ABORT_ERROR_CODE ? 'info' : 'warn';
       this.#lc[log]?.(`${name} (${pid}) exited with code (${code})`, err ?? '');
-      return this.#exit(log === 'info' || code !== 0 ? code : -1);
+      return this.#exit(code);
     }
 
     const log =
-      this.#drainStart > 0 || code === UNHANDLED_EXCEPTION_ERROR_CODE
-        ? 'warn'
-        : 'error';
-    if (sig) {
-      this.#lc[log]?.(`${name} (${pid}) killed with (${sig})`, err ?? '');
-    } else if (code !== 0) {
-      this.#lc[log]?.(`${name} (${pid}) exited with code (${code})`, err ?? '');
-    } else {
-      this.#lc.info?.(`${name} (${pid}) exited with code (${code})`);
-    }
+      code === 0 || code === INTENTIONAL_ABORT_ERROR_CODE
+        ? 'info'
+        : this.#drainStart > 0 || code === UNHANDLED_EXCEPTION_ERROR_CODE
+          ? 'warn'
+          : 'error';
+    this.#lc[log]?.(
+      sig
+        ? `${name} (${pid}) killed with (${sig})`
+        : `${name} (${pid}) exited with code (${code})`,
+      err ?? '',
+    );
 
     // user-facing workers exited or finished draining.
     if (this.#userFacing.size === 0) {
@@ -207,9 +230,9 @@ export class ProcessManager {
       return this.#exit(0);
     }
 
-    // Exit only if not draining. If a user-facing worker exits unexpectedly
-    // during a drain, log a warning but let other user-facing workers drain.
-    if (log === 'error') {
+    if (this.#drainStart === 0) {
+      // If a user-facing worker exits without receiving a drain signal,
+      // shutdown the server.
       return this.#exit(code || -1);
     }
 

--- a/packages/zero-cache/src/services/life-cycle.ts
+++ b/packages/zero-cache/src/services/life-cycle.ts
@@ -27,7 +27,9 @@ import type {SingletonService} from './service.ts';
 export type WorkerType = 'user-facing' | 'supporting';
 
 export const GRACEFUL_SHUTDOWN = ['SIGTERM', 'SIGINT'] as const;
-export const FORCEFUL_SHUTDOWN = ['SIGABRT', 'SIGQUIT'] as const;
+export const FORCEFUL_SHUTDOWN = ['SIGQUIT', 'SIGABRT'] as const;
+
+type GracefulShutdownSignal = (typeof GRACEFUL_SHUTDOWN)[number];
 
 // An internal error code used to indicate that a message has already been
 // logged at level ERRROR. When a process exits with this error code, the
@@ -107,7 +109,7 @@ export class ProcessManager {
     void this.#lc.flush().finally(() => this.#exitImpl(code));
   }
 
-  #startDrain(signal: (typeof GRACEFUL_SHUTDOWN)[number]) {
+  #startDrain(signal: GracefulShutdownSignal) {
     this.#lc.info?.(`initiating drain (${signal})`);
     this.#drainStart = Date.now();
     if (this.#userFacing.size) {


### PR DESCRIPTION
Distinguish between intentional, protocol-driven shutdowns such as auto-reset or incompatible-replica-version, vs unexpected, error-driven shutdowns, by using `SIGQUIT` for the former and `SIGABRT` for the latter. 

The behavior is the same in that drains are skipped; the only difference is in the logging level for classification/alerting purposes.

The behavior for `SIGTERM` and `SIGINT` remain the same.

Context:
* https://rocicorp.slack.com/archives/C0ARW28F8KU/p1775749914957699