### PR TITLE
chore(zero-cache): some basic metrics

### DIFF
--- a/packages/zero-cache/src/server/logging.ts
+++ b/packages/zero-cache/src/server/logging.ts
@@ -16,32 +16,7 @@ export function createLogContext(
 ): LogContext {
   const logSink = createLogSink(log, includeOtel);
   const lc = createLogContextShared({log}, context, logSink);
-  process.on('unhandledRejection', async (err, promise) => {
-    lc.error?.('unhandledRejection', err);
-    if (err instanceof Error && err.name === 'PostgresError') {
-      const q = promise as any;
-      const isPostgresBug =
-        typeof q === 'object' &&
-        q !== null &&
-        (typeof q.cursorFn === 'function' ||
-          (Array.isArray(q.strings) &&
-            typeof q.strings[0] === 'string' &&
-            (q.strings[0].includes('transaction_read_only') ||
-              q.strings[0].includes('pg_catalog.pg_type'))));
-
-      if (isPostgresBug) {
-        return; // Prevent detached driver-level query promises from crashing the worker.
-      }
-    }
-    await logSink.flush?.();
-    process.exit(UNHANDLED_EXCEPTION_ERROR_CODE);
-  });
-
   process.on('uncaughtException', async (err, origin) => {
-    if (origin === 'unhandledRejection') {
-      // Node 15+ fallback, should be caught by the above hook.
-      return;
-    }
     lc.error?.(origin, err);
     await logSink.flush?.();
     process.exit(UNHANDLED_EXCEPTION_ERROR_CODE);

--- a/packages/zero-cache/src/server/logging.ts
+++ b/packages/zero-cache/src/server/logging.ts
@@ -16,7 +16,32 @@ export function createLogContext(
 ): LogContext {
   const logSink = createLogSink(log, includeOtel);
   const lc = createLogContextShared({log}, context, logSink);
+  process.on('unhandledRejection', async (err, promise) => {
+    lc.error?.('unhandledRejection', err);
+    if (err instanceof Error && err.name === 'PostgresError') {
+      const q = promise as any;
+      const isPostgresBug =
+        typeof q === 'object' &&
+        q !== null &&
+        (typeof q.cursorFn === 'function' ||
+          (Array.isArray(q.strings) &&
+            typeof q.strings[0] === 'string' &&
+            (q.strings[0].includes('transaction_read_only') ||
+              q.strings[0].includes('pg_catalog.pg_type'))));
+
+      if (isPostgresBug) {
+        return; // Prevent detached driver-level query promises from crashing the worker.
+      }
+    }
+    await logSink.flush?.();
+    process.exit(UNHANDLED_EXCEPTION_ERROR_CODE);
+  });
+
   process.on('uncaughtException', async (err, origin) => {
+    if (origin === 'unhandledRejection') {
+      // Node 15+ fallback, should be caught by the above hook.
+      return;
+    }
     lc.error?.(origin, err);
     await logSink.flush?.();
     process.exit(UNHANDLED_EXCEPTION_ERROR_CODE);

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -530,6 +530,7 @@ export class PipelineDriver {
               throw new ResetPipelinesSignal(
                 `Scalar subquery value changed for ${meta.ast.table}: ` +
                   `${String(resolvedValue)} -> ${String(newValue)}`,
+                'scalar-subquery',
               );
             }
             const streamer = this.#streamer;
@@ -783,6 +784,7 @@ export class PipelineDriver {
         `Advancement exceeded timeout at ${pos} of ${numChanges} changes ` +
           `after ${elapsed} ms. Advancement time limited based on total ` +
           `hydration time of ${totalHydrationTimeMs} ms.`,
+        'advancement-timeout',
       );
     }
     return advanceTimer.elapsedLap() > this.#yieldThresholdMs();

--- a/packages/zero-cache/src/services/view-syncer/snapshotter.ts
+++ b/packages/zero-cache/src/services/view-syncer/snapshotter.ts
@@ -255,11 +255,20 @@ export interface SnapshotDiff extends Iterable<Change> {
  * change or truncate is encountered, which result in aborting the
  * advancement and resetting / rehydrating the pipelines.
  */
+export type ResetPipelinesReason =
+  | 'advancement-timeout'
+  | 'scalar-subquery'
+  | 'schema-change'
+  | 'truncation'
+  | 'permissions-change';
+
 export class ResetPipelinesSignal extends Error {
   readonly name = 'ResetPipelinesSignal';
+  readonly reason: ResetPipelinesReason;
 
-  constructor(msg: string) {
+  constructor(msg: string, reason: ResetPipelinesReason) {
     super(msg);
+    this.reason = reason;
   }
 }
 
@@ -436,12 +445,14 @@ class Diff implements SnapshotDiff {
               // The current map of `TableSpec`s may not have the correct or complete information.
               throw new ResetPipelinesSignal(
                 `schema for table ${table} has changed`,
+                'schema-change',
               );
             }
             if (op === TRUNCATE_OP) {
               // Truncates are also processed by rehydrating pipelines at current.
               throw new ResetPipelinesSignal(
                 `table ${table} has been truncated`,
+                'truncation',
               );
             }
             const specs = this.#syncableTables.get(table);
@@ -508,6 +519,7 @@ class Diff implements SnapshotDiff {
                       prevValue.permissions !== nextValue.permissions,
                   ).hash
                 } => ${nextValue.hash}`,
+                'permissions-change',
               );
             }
 

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -374,9 +374,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     this.#lc.debug?.('about to acquire lock for cvr ', rid);
     const lockWaitStart = performance.now();
     return this.#lock.withLock(async () => {
-      this.#lockWaitTime.record(
-        (performance.now() - lockWaitStart) / 1000,
-      );
+      this.#lockWaitTime.record((performance.now() - lockWaitStart) / 1000);
       this.#lc.debug?.('acquired lock in #runInLockWithCVR ', rid);
       const lc = this.#lc.withContext('lock', rid);
       if (!this.#stateChanges.active) {

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -137,6 +137,9 @@ export interface ViewSyncer {
 
   // Connection context management is owned by the view syncer for disconnect cleanup.
   contextManager: ConnectionContextManager;
+
+  readonly queryCount: number;
+  readonly rowCount: number;
 }
 
 export type SyncContext = ConnectionSelector & {
@@ -295,6 +298,15 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     'query.transformation-no-ops',
     'Number of times query transformation resulted in no-op (hash unchanged)',
   );
+  readonly #lockWaitTime = getOrCreateHistogram('sync', 'lock-wait-time', {
+    description: 'Time spent waiting to acquire the ViewSyncer lock.',
+    unit: 's',
+  });
+  readonly #pipelineResets = getOrCreateCounter(
+    'sync',
+    'pipeline-resets',
+    'Number of pipeline resets',
+  );
 
   readonly #inspectorDelegate: InspectorDelegate;
 
@@ -360,7 +372,11 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   ): Promise<void> {
     const rid = randomID();
     this.#lc.debug?.('about to acquire lock for cvr ', rid);
+    const lockWaitStart = performance.now();
     return this.#lock.withLock(async () => {
+      this.#lockWaitTime.record(
+        (performance.now() - lockWaitStart) / 1000,
+      );
       this.#lc.debug?.('acquired lock in #runInLockWithCVR ', rid);
       const lc = this.#lc.withContext('lock', rid);
       if (!this.#stateChanges.active) {
@@ -468,6 +484,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
               return;
             }
             lc.info?.(`resetting pipelines: ${result.message}`);
+            this.#pipelineResets.add(1, {reason: result.reason});
             this.#pipelines.reset(clientSchema);
             this.#pipelinesSynced = false;
           }
@@ -539,6 +556,14 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
   #totalHydrationTimeMs(): number {
     return this.#pipelines.totalHydrationTimeMs();
+  }
+
+  get queryCount(): number {
+    return this.#pipelines.initialized() ? this.#pipelines.queries().size : 0;
+  }
+
+  get rowCount(): number {
+    return this.#cvrStore.rowCount;
   }
 
   #keepAliveUntil: number = 0;

--- a/packages/zero-cache/src/workers/syncer.test.ts
+++ b/packages/zero-cache/src/workers/syncer.test.ts
@@ -109,6 +109,8 @@ function makeFactories(
           inspect: vi.fn(),
           updateAuth: vi.fn(),
           keepalive: () => true,
+          queryCount: 0,
+          rowCount: 0,
           stop() {
             stopped.resolve();
             return stopped.promise;

--- a/packages/zero-cache/src/workers/syncer.ts
+++ b/packages/zero-cache/src/workers/syncer.ts
@@ -18,6 +18,7 @@ import {
   recordConnectionSuccess,
   setActiveClientGroupsGetter,
 } from '../server/anonymous-otel-start.ts';
+import {getOrCreateGauge} from '../observability/metrics.ts';
 import type {Mutagen} from '../services/mutagen/mutagen.ts';
 import type {Pusher} from '../services/mutagen/pusher.ts';
 import type {ReplicaState} from '../services/replicator/replicator.ts';
@@ -142,6 +143,36 @@ export class Syncer implements SingletonService {
     );
 
     setActiveClientGroupsGetter(() => this.#viewSyncers.size);
+
+    getOrCreateGauge(
+      'sync',
+      'active-client-groups',
+      'Number of active client groups',
+    ).addCallback(result => result.observe(this.#viewSyncers.size));
+
+    getOrCreateGauge(
+      'sync',
+      'queries',
+      'Active queries (pipelines) across all client groups',
+    ).addCallback(result => {
+      let total = 0;
+      for (const vs of this.#viewSyncers.getServices()) {
+        total += vs.queryCount;
+      }
+      result.observe(total);
+    });
+
+    getOrCreateGauge(
+      'sync',
+      'rows',
+      'Tracked rows across all client groups',
+    ).addCallback(result => {
+      let total = 0;
+      for (const vs of this.#viewSyncers.getServices()) {
+        total += vs.rowCount;
+      }
+      result.observe(total);
+    });
   }
 
   readonly #createConnection = async (ws: WebSocket, params: ConnectParams) => {


### PR DESCRIPTION
## Add zero-cache metrics

Adds five new OTel metrics to improve visibility into sync worker health:

1. **`zero.sync.active-client-groups`** (Observable Gauge) — Number of active `ViewSyncerService` instances in a syncer worker. Complements the existing anonymous telemetry gauge by routing through the standard OTel/Prometheus pipeline.

2. **`zero.sync.queries`** (Observable Gauge) — Active IVM pipelines across all client groups in a syncer worker.

3. **`zero.sync.rows`** (Observable Gauge) — CVR-tracked rows across all client groups in a syncer worker.

4. **`zero.sync.lock-wait-time`** (Histogram, seconds) — Time spent waiting to acquire the `ViewSyncerService` lock per operation.

5. **`zero.sync.pipeline-resets`** (Counter) — Count of pipeline resets with a `reason` attribute distinguishing: `advancement-timeout`, `scalar-subquery`, `schema-change`, `truncation`, `permissions-change`.

Per-worker averages (e.g. queries/client-group) can be derived in Grafana by dividing by `active-client-groups`. Cluster-wide aggregation is done by summing across instances.

Also adds a typed `ResetPipelinesReason` to `ResetPipelinesSignal` so reset causes are tracked structurally rather than by parsing error messages.
