### PR TITLE
fix(zero-cache): ensure that the backfill-completed tx version is >= the backfill watermark

### DIFF
--- a/packages/zero-cache/src/services/change-source/common/backfill-manager.test.ts
+++ b/packages/zero-cache/src/services/change-source/common/backfill-manager.test.ts
@@ -77,6 +77,10 @@ describe('backfill-manager', () => {
     return c;
   }
 
+  async function expectChanges(changes: ChangeStreamMessage[]) {
+    expect(await drainChanges(changes.length)).toMatchObject(changes);
+  }
+
   test('backfill initiated by change-streamer request', async () => {
     testStreams.push([
       {
@@ -120,7 +124,7 @@ describe('backfill-manager', () => {
 
     changeStream.pushStatus(['status', {ack: false}, {watermark: '130'}]);
 
-    expect(await drainChanges(5)).toMatchObject([
+    await expectChanges([
       [
         'begin',
         {tag: 'begin', json: 'p', skipAck: true},
@@ -152,6 +156,12 @@ describe('backfill-manager', () => {
           watermark: '130',
         },
       ],
+      ['commit', {tag: 'commit'}, {watermark: '123.01'}],
+      [
+        'begin',
+        {tag: 'begin', json: 'p', skipAck: true},
+        {commitWatermark: '130'},
+      ],
       [
         'data',
         {
@@ -161,7 +171,7 @@ describe('backfill-manager', () => {
           watermark: '130',
         },
       ],
-      ['commit', {tag: 'commit'}, {watermark: '123.01'}],
+      ['commit', {tag: 'commit'}, {watermark: '130'}],
     ] satisfies ChangeStreamMessage[]);
 
     expect(backfillRequests).toMatchObject([
@@ -238,7 +248,7 @@ describe('backfill-manager', () => {
 
     changeStream.pushStatus(['status', {ack: false}, {watermark: '130'}]);
 
-    expect(await drainChanges(8)).toMatchObject([
+    await expectChanges([
       ['begin', {tag: 'begin'}, {commitWatermark: '125'}],
       [
         'data',
@@ -288,6 +298,8 @@ describe('backfill-manager', () => {
           watermark: '130',
         },
       ],
+      ['commit', {tag: 'commit'}, {watermark: '125.01'}],
+      ['begin', {tag: 'begin'}, {commitWatermark: '130'}],
       [
         'data',
         {
@@ -297,7 +309,7 @@ describe('backfill-manager', () => {
           watermark: '130',
         },
       ],
-      ['commit', {tag: 'commit'}, {watermark: '125.01'}],
+      ['commit', {tag: 'commit'}, {watermark: '130'}],
     ] satisfies ChangeStreamMessage[]);
 
     expect(backfillRequests).toMatchObject([
@@ -570,7 +582,7 @@ describe('backfill-manager', () => {
       [
         'begin',
         {tag: 'begin', json: 'p', skipAck: true},
-        {commitWatermark: '125.01'},
+        {commitWatermark: '130'},
       ],
       [
         'data',
@@ -585,7 +597,7 @@ describe('backfill-manager', () => {
           watermark: '130',
         },
       ],
-      ['commit', {tag: 'commit'}, {watermark: '125.01'}],
+      ['commit', {tag: 'commit'}, {watermark: '130'}],
     ] satisfies ChangeStreamMessage[]);
 
     expect(backfillRequests).toMatchObject([
@@ -658,7 +670,7 @@ describe('backfill-manager', () => {
 
     // The first request is canceled and only the changes from
     // the updated request are streamed.
-    expect(await drainChanges(6)).toMatchObject([
+    await expectChanges([
       ['begin', {tag: 'begin'}, {commitWatermark: '125'}],
       [
         'data',
@@ -669,11 +681,7 @@ describe('backfill-manager', () => {
         },
       ],
       ['commit', {tag: 'commit'}, {watermark: '125'}],
-      [
-        'begin',
-        {tag: 'begin', json: 'p', skipAck: true},
-        {commitWatermark: '125.01'},
-      ],
+      ['begin', {tag: 'begin'}, {commitWatermark: '130'}],
       [
         'data',
         {
@@ -687,7 +695,7 @@ describe('backfill-manager', () => {
           watermark: '130',
         },
       ],
-      ['commit', {tag: 'commit'}, {watermark: '125.01'}],
+      ['commit', {tag: 'commit'}, {watermark: '130'}],
     ] satisfies ChangeStreamMessage[]);
 
     expect(backfillRequests).toMatchObject([
@@ -766,7 +774,7 @@ describe('backfill-manager', () => {
 
     // The first request is canceled and only the changes from
     // the updated request are streamed.
-    expect(await drainChanges(6)).toMatchObject([
+    await expectChanges([
       ['begin', {tag: 'begin'}, {commitWatermark: '125'}],
       [
         'data',
@@ -777,11 +785,7 @@ describe('backfill-manager', () => {
         },
       ],
       ['commit', {tag: 'commit'}, {watermark: '125'}],
-      [
-        'begin',
-        {tag: 'begin', json: 'p', skipAck: true},
-        {commitWatermark: '125.01'},
-      ],
+      ['begin', {tag: 'begin'}, {commitWatermark: '130'}],
       [
         'data',
         {
@@ -795,7 +799,7 @@ describe('backfill-manager', () => {
           watermark: '130',
         },
       ],
-      ['commit', {tag: 'commit'}, {watermark: '125.01'}],
+      ['commit', {tag: 'commit'}, {watermark: '130'}],
     ] satisfies ChangeStreamMessage[]);
 
     expect(backfillRequests).toMatchObject([
@@ -876,7 +880,7 @@ describe('backfill-manager', () => {
 
     // The first request is canceled and only the changes from
     // the updated request are streamed.
-    expect(await drainChanges(6)).toMatchObject([
+    await expectChanges([
       ['begin', {tag: 'begin'}, {commitWatermark: '125'}],
       [
         'data',
@@ -888,11 +892,7 @@ describe('backfill-manager', () => {
         },
       ],
       ['commit', {tag: 'commit'}, {watermark: '125'}],
-      [
-        'begin',
-        {tag: 'begin', json: 'p', skipAck: true},
-        {commitWatermark: '125.01'},
-      ],
+      ['begin', {tag: 'begin'}, {commitWatermark: '130'}],
       [
         'data',
         {
@@ -906,7 +906,7 @@ describe('backfill-manager', () => {
           watermark: '130',
         },
       ],
-      ['commit', {tag: 'commit'}, {watermark: '125.01'}],
+      ['commit', {tag: 'commit'}, {watermark: '130'}],
     ] satisfies ChangeStreamMessage[]);
 
     expect(backfillRequests).toMatchObject([
@@ -1305,7 +1305,7 @@ describe('backfill-manager', () => {
     changeStream.release('140');
     changeStream.pushStatus(['status', {ack: false}, {watermark: '150'}]);
 
-    expect(await drainChanges(12)).toMatchObject([
+    await expectChanges([
       ['begin', {tag: 'begin'}, {commitWatermark: '140'}],
       [
         'data',
@@ -1378,6 +1378,8 @@ describe('backfill-manager', () => {
           ],
         },
       ],
+      ['commit', {tag: 'commit'}, {watermark: '140.02'}],
+      ['begin', {tag: 'begin'}, {commitWatermark: '150'}],
       [
         'data',
         {
@@ -1387,7 +1389,7 @@ describe('backfill-manager', () => {
           watermark: '150',
         },
       ],
-      ['commit', {tag: 'commit'}, {watermark: '140.02'}],
+      ['commit', {tag: 'commit'}, {watermark: '150'}],
     ] satisfies ChangeStreamMessage[]);
 
     expect(backfillRequests).toMatchObject([
@@ -1440,11 +1442,11 @@ describe('backfill-manager', () => {
 
     changeStream.pushStatus(['status', {ack: false}, {watermark: '130'}]);
 
-    expect(await drainChanges(3)).toMatchObject([
+    await expectChanges([
       [
         'begin',
         {tag: 'begin', json: 'p', skipAck: true},
-        {commitWatermark: '123.01'},
+        {commitWatermark: '130'},
       ],
       [
         'data',
@@ -1455,7 +1457,7 @@ describe('backfill-manager', () => {
           watermark: '130',
         },
       ],
-      ['commit', {tag: 'commit'}, {watermark: '123.01'}],
+      ['commit', {tag: 'commit'}, {watermark: '130'}],
     ] satisfies ChangeStreamMessage[]);
 
     expect(backfillRequests).toMatchObject([
@@ -1557,7 +1559,7 @@ describe('backfill-manager', () => {
 
     changeStream.pushStatus(['status', {ack: false}, {watermark: '188'}]);
 
-    expect(await drainChanges(4)).toMatchObject([
+    await expectChanges([
       [
         'begin',
         {tag: 'begin', json: 'p', skipAck: true},
@@ -1573,6 +1575,12 @@ describe('backfill-manager', () => {
           rowValues: [[1]],
         },
       ],
+      ['commit', {tag: 'commit'}, {watermark: '123.01'}],
+      [
+        'begin',
+        {tag: 'begin', json: 'p', skipAck: true},
+        {commitWatermark: '188'},
+      ],
       [
         'data',
         {
@@ -1582,7 +1590,7 @@ describe('backfill-manager', () => {
           watermark: '188',
         },
       ],
-      ['commit', {tag: 'commit'}, {watermark: '123.01'}],
+      ['commit', {tag: 'commit'}, {watermark: '188'}],
     ] satisfies ChangeStreamMessage[]);
 
     expect(backfillRequests).toMatchObject([
@@ -1915,7 +1923,7 @@ describe('backfill-manager', () => {
     await sleep(100);
     changeStream.pushStatus(['status', {ack: false}, {watermark: '130'}]);
 
-    expect(await drainChanges(6)).toMatchObject([
+    await expectChanges([
       [
         'begin',
         {tag: 'begin', json: 'p', skipAck: true},
@@ -1935,11 +1943,10 @@ describe('backfill-manager', () => {
         },
       ],
       ['commit', {tag: 'commit'}, {watermark: '123.01'}],
-
       [
         'begin',
         {tag: 'begin', json: 'p', skipAck: true},
-        {commitWatermark: '123.02'},
+        {commitWatermark: '130'},
       ],
       [
         'data',
@@ -1950,7 +1957,7 @@ describe('backfill-manager', () => {
           watermark: '130',
         },
       ],
-      ['commit', {tag: 'commit'}, {watermark: '123.02'}],
+      ['commit', {tag: 'commit'}, {watermark: '130'}],
     ] satisfies ChangeStreamMessage[]);
 
     expect(backfillRequests).toMatchObject([

--- a/packages/zero-cache/src/services/change-source/common/backfill-manager.ts
+++ b/packages/zero-cache/src/services/change-source/common/backfill-manager.ts
@@ -235,10 +235,19 @@ export class BackfillManager implements Cancelable, Listener {
       }
 
       const {major, minor = 0n} = stateVersionFromString(lastWatermark);
-      const tx = stateVersionToString({
+      let tx = stateVersionToString({
         major,
         minor: BigInt(minor) + 1n,
       });
+
+      if (msg.tag === 'backfill-completed' && tx < msg.watermark) {
+        // At this point it is ensured that #changeStreamReached() the
+        // msg.watermark. Given that guarantee, ensure that the version of the
+        // transaction containing the backfill-completed message is at least up
+        // to the backfill watermark, so that the final database state is never
+        // earlier than any of the versions of backfilled rows.
+        tx = msg.watermark;
+      }
 
       void changeStream.push([
         'begin',
@@ -262,10 +271,12 @@ export class BackfillManager implements Cancelable, Listener {
 
     for await (const msg of this.#backfillStreamer(state.request)) {
       // Before sending `backfill-completed`, the main replication stream
-      // may need to catch up.
+      // may need to catch up, and/or the current transaction may need to be
+      // committed to open a new transaction that's up to backfill watermark.
       const mustWaitBeforeFlush =
         msg.tag === 'backfill-completed' &&
-        this.#changeStreamReached(lc, msg.watermark);
+        (this.#changeStreamReached(lc, msg.watermark) ||
+          (backfillTx !== null && backfillTx < msg.watermark));
 
       // If necessary, yield the reservation to the main stream.
       if (

--- a/packages/zero-cache/src/services/change-source/common/backfill-manager.ts
+++ b/packages/zero-cache/src/services/change-source/common/backfill-manager.ts
@@ -241,7 +241,7 @@ export class BackfillManager implements Cancelable, Listener {
       });
 
       if (msg.tag === 'backfill-completed' && tx < msg.watermark) {
-        // At this point it must be the case that #changeStreamReached() the
+        // At this point it must be the case that the #changeStreamReached() the
         // backfill watermark. Given that guarantee, ensure that the version of the
         // transaction containing the backfill-completed message is at least up
         // to the backfill watermark, so that the final database state is never

--- a/packages/zero-cache/src/services/change-source/common/backfill-manager.ts
+++ b/packages/zero-cache/src/services/change-source/common/backfill-manager.ts
@@ -244,8 +244,8 @@ export class BackfillManager implements Cancelable, Listener {
         // At this point it must be the case that the #changeStreamReached() the
         // backfill watermark. Given that guarantee, ensure that the version of the
         // transaction containing the backfill-completed message is at least up
-        // to the backfill watermark, so that the final database state is never
-        // earlier than any of the versions of backfilled rows.
+        // to the backfill watermark, so that the final database state version is
+        // never earlier than the version of any backfilled rows.
         tx = msg.watermark;
       }
 

--- a/packages/zero-cache/src/services/change-source/common/backfill-manager.ts
+++ b/packages/zero-cache/src/services/change-source/common/backfill-manager.ts
@@ -241,8 +241,8 @@ export class BackfillManager implements Cancelable, Listener {
       });
 
       if (msg.tag === 'backfill-completed' && tx < msg.watermark) {
-        // At this point it is ensured that #changeStreamReached() the
-        // msg.watermark. Given that guarantee, ensure that the version of the
+        // At this point it must be the case that #changeStreamReached() the
+        // backfill watermark. Given that guarantee, ensure that the version of the
         // transaction containing the backfill-completed message is at least up
         // to the backfill watermark, so that the final database state is never
         // earlier than any of the versions of backfilled rows.

--- a/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg.test.ts
@@ -1614,8 +1614,8 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
               ['e', 'f'],
             ],
           },
-          {tag: 'backfill-completed'},
         ],
+        [{tag: 'backfill-completed'}],
         [
           {
             tag: 'backfill',
@@ -1624,8 +1624,8 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
               ['e', 'f'],
             ],
           },
-          {tag: 'backfill-completed'},
         ],
+        [{tag: 'backfill-completed'}],
       ],
       {
         existing: [


### PR DESCRIPTION
The BackfillManager already does the work for delaying the `backfill-completed` message until the replication-stream has reached or exceeded the backfill's snapshot LSN, as required by the backfill algorithm.

In addition to this, ensure that version of the final transaction containing the `backfill-completed` watermark is explicitly greater than or equal to the backfill watermark. Bumping the minor version of the latest committed change does not guarantee this, since there may not have been any committed changes since the backfill LSN (even if the replication stream's status messages have passed it). In such cases, the backfill LSN itself is used as the transaction version, which is safe since it has already been verified that the replication stream has passed that LSN.

Context:
* https://rocicorp.slack.com/archives/C0ABMK92H47/p1775589780500379 