### PR TITLE
Add backwards tuple test

### DIFF
--- a/packages/zero-protocol/src/custom-queries.test.ts
+++ b/packages/zero-protocol/src/custom-queries.test.ts
@@ -1,0 +1,19 @@
+import {expect, test} from 'vitest';
+import * as v from '../../shared/src/valita.ts';
+import {
+  transformResponseMessageSchema,
+  type TransformResponseMessage,
+} from './custom-queries.ts';
+
+test('transform response schema accepts a third tuple object like {userID}', () => {
+  const valid: TransformResponseMessage = ['transformed', []];
+
+  expect(() => v.parse(valid, transformResponseMessageSchema)).not.toThrow();
+
+  expect(() =>
+    v.parse(
+      ['transformed', [], {userID: 'user-123'}],
+      transformResponseMessageSchema,
+    ),
+  ).not.toThrow();
+});


### PR DESCRIPTION
## Summary
- add a Vitest case for `transformResponseMessageSchema`
- expect `['transformed', [], {userID: 'user-123'}]` to parse so the current backwards-compatibility break shows up clearly