### PR TITLE
refactor(zql): Change the `Change` type to tuple

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34752,7 +34752,8 @@
         "shared": "0.0.0",
         "solid-js": "^1.9.4",
         "vite-plugin-solid": "^2.11.11",
-        "zero-client": "0.0.0"
+        "zero-client": "0.0.0",
+        "zql": "0.0.0"
       },
       "peerDependencies": {
         "solid-js": "^1.9.4"

--- a/packages/analyze-query/src/run-ast.test.ts
+++ b/packages/analyze-query/src/run-ast.test.ts
@@ -10,6 +10,7 @@ import type {AST} from '../../zero-protocol/src/ast.ts';
 import type {ClientSchema} from '../../zero-protocol/src/client-schema.ts';
 import type {BuilderDelegate} from '../../zql/src/builder/builder.ts';
 import {Debug} from '../../zql/src/builder/debug-delegate.ts';
+import {ChangeType} from '../../zql/src/ivm/change-type.ts';
 import {Database} from '../../zqlite/src/db.ts';
 
 const minimalClientSchema: ClientSchema = {tables: {}};
@@ -296,7 +297,7 @@ test('runAst counts only unique synced rows, skips duplicates', async () => {
   vi.mocked(hydrate).mockImplementation(function* () {
     // First unique row from users table
     yield {
-      type: 'add',
+      type: ChangeType.ADD,
       table: 'users',
       queryID: 'test-query-id',
       rowKey: {id: 1},
@@ -305,7 +306,7 @@ test('runAst counts only unique synced rows, skips duplicates', async () => {
 
     // Second unique row from users table
     yield {
-      type: 'add',
+      type: ChangeType.ADD,
       table: 'users',
       queryID: 'test-query-id',
       rowKey: {id: 2},
@@ -314,7 +315,7 @@ test('runAst counts only unique synced rows, skips duplicates', async () => {
 
     // Duplicate of first row (same table + row content)
     yield {
-      type: 'add',
+      type: ChangeType.ADD,
       table: 'users',
       queryID: 'test-query-id',
       rowKey: {id: 1},
@@ -323,7 +324,7 @@ test('runAst counts only unique synced rows, skips duplicates', async () => {
 
     // Unique row from different table
     yield {
-      type: 'add',
+      type: ChangeType.ADD,
       table: 'posts',
       queryID: 'test-query-id',
       rowKey: {id: 1},
@@ -332,7 +333,7 @@ test('runAst counts only unique synced rows, skips duplicates', async () => {
 
     // Duplicate of the posts row
     yield {
-      type: 'add',
+      type: ChangeType.ADD,
       table: 'posts',
       queryID: 'test-query-id',
       rowKey: {id: 1},
@@ -341,7 +342,7 @@ test('runAst counts only unique synced rows, skips duplicates', async () => {
 
     // Another unique row from users (different content)
     yield {
-      type: 'add',
+      type: ChangeType.ADD,
       table: 'users',
       queryID: 'test-query-id',
       rowKey: {id: 3},
@@ -396,7 +397,7 @@ test('runAst handles case where all synced rows are duplicates', async () => {
 
     // Same row yielded multiple times
     yield {
-      type: 'add',
+      type: ChangeType.ADD,
       table: 'users',
       queryID: 'test-query-id',
       rowKey: {id: 1},
@@ -404,7 +405,7 @@ test('runAst handles case where all synced rows are duplicates', async () => {
     };
 
     yield {
-      type: 'add',
+      type: ChangeType.ADD,
       table: 'users',
       queryID: 'test-query-id',
       rowKey: {id: 1},
@@ -412,7 +413,7 @@ test('runAst handles case where all synced rows are duplicates', async () => {
     };
 
     yield {
-      type: 'add',
+      type: ChangeType.ADD,
       table: 'users',
       queryID: 'test-query-id',
       rowKey: {id: 1},

--- a/packages/shared/src/bench.ts
+++ b/packages/shared/src/bench.ts
@@ -25,6 +25,7 @@ type MeasureFn = Parameters<typeof measure>[0];
 const defaultMeasureOptions: MeasureOptions = {
   min_cpu_time: 2e9, // 2 seconds
   min_samples: 50,
+  inner_gc: true,
 };
 
 type BenchResult = {name: string; stats: Stats};

--- a/packages/shared/src/bench.ts
+++ b/packages/shared/src/bench.ts
@@ -25,7 +25,7 @@ type MeasureFn = Parameters<typeof measure>[0];
 const defaultMeasureOptions: MeasureOptions = {
   min_cpu_time: 2e9, // 2 seconds
   min_samples: 50,
-  inner_gc: true,
+  gc: true,
 };
 
 type BenchResult = {name: string; stats: Stats};

--- a/packages/zero-cache/src/auth/read-authorizer.query.test.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.query.test.ts
@@ -30,7 +30,7 @@ import {
   buildPipeline,
 } from '../../../zql/src/builder/builder.ts';
 import {Catch, type CaughtNode} from '../../../zql/src/ivm/catch.ts';
-import type {Source} from '../../../zql/src/ivm/source.ts';
+import {type Source, makeSourceChangeAdd} from '../../../zql/src/ivm/source.ts';
 import {consume} from '../../../zql/src/ivm/stream.ts';
 import type {ExpressionBuilder} from '../../../zql/src/query/expression.ts';
 import {QueryDelegateBase} from '../../../zql/src/query/query-delegate-base.ts';
@@ -588,84 +588,44 @@ test('cannot create an issue with the wrong creatorId, even if admin', async () 
 
 function addUser(user: Row<Schema['tables']['user']>) {
   const userSource = must(queryDelegate.getSource('user'));
-  consume(
-    userSource.push({
-      type: 'add',
-      row: user,
-    }),
-  );
+  consume(userSource.push(makeSourceChangeAdd(user)));
 }
 
 function addProject(project: Row<Schema['tables']['project']>) {
   const projectSource = must(queryDelegate.getSource('project'));
-  consume(
-    projectSource.push({
-      type: 'add',
-      row: project,
-    }),
-  );
+  consume(projectSource.push(makeSourceChangeAdd(project)));
 }
 
 function addProjectMember(
   projectMember: Row<Schema['tables']['projectMember']>,
 ) {
   const projectMemberSource = must(queryDelegate.getSource('projectMember'));
-  consume(
-    projectMemberSource.push({
-      type: 'add',
-      row: projectMember,
-    }),
-  );
+  consume(projectMemberSource.push(makeSourceChangeAdd(projectMember)));
 }
 
 function addIssue(issue: Row<Schema['tables']['issue']>) {
   const issueSource = must(queryDelegate.getSource('issue'));
-  consume(
-    issueSource.push({
-      type: 'add',
-      row: issue,
-    }),
-  );
+  consume(issueSource.push(makeSourceChangeAdd(issue)));
 }
 
 function addComment(comment: Row<Schema['tables']['comment']>) {
   const commentSource = must(queryDelegate.getSource('comment'));
-  consume(
-    commentSource.push({
-      type: 'add',
-      row: comment,
-    }),
-  );
+  consume(commentSource.push(makeSourceChangeAdd(comment)));
 }
 
 function addLabel(label: Row<Schema['tables']['label']>) {
   const labelSource = must(queryDelegate.getSource('label'));
-  consume(
-    labelSource.push({
-      type: 'add',
-      row: label,
-    }),
-  );
+  consume(labelSource.push(makeSourceChangeAdd(label)));
 }
 
 function addIssueLabel(issueLabel: Row<Schema['tables']['issueLabel']>) {
   const issueLabelSource = must(queryDelegate.getSource('issueLabel'));
-  consume(
-    issueLabelSource.push({
-      type: 'add',
-      row: issueLabel,
-    }),
-  );
+  consume(issueLabelSource.push(makeSourceChangeAdd(issueLabel)));
 }
 
 function addViewState(viewState: Row<Schema['tables']['viewState']>) {
   const viewStateSource = must(queryDelegate.getSource('viewState'));
-  consume(
-    viewStateSource.push({
-      type: 'add',
-      row: viewState,
-    }),
-  );
+  consume(viewStateSource.push(makeSourceChangeAdd(viewState)));
 }
 
 test('cannot create an issue unless you are a project member', async () => {

--- a/packages/zero-cache/src/auth/write-authorizer.ts
+++ b/packages/zero-cache/src/auth/write-authorizer.ts
@@ -46,6 +46,11 @@ import type {LiteAndZqlSpec} from '../db/specs.ts';
 import {StatementRunner} from '../db/statements.ts';
 import {mapLiteDataTypeToZqlSchemaValue} from '../types/lite.ts';
 import {
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+  makeSourceChangeRemove,
+} from '../../../zql/src/ivm/source.ts';
+import {
   getSchema,
   reloadPermissionsIfChanged,
   type LoadedPermissions,
@@ -165,12 +170,7 @@ export class WriteAuthorizerImpl implements WriteAuthorizer {
         const source = this.#getSource(op.tableName);
         switch (op.op) {
           case 'insert': {
-            consume(
-              source.push({
-                type: 'add',
-                row: op.value,
-              }),
-            );
+            consume(source.push(makeSourceChangeAdd(op.value)));
             break;
           }
           // TODO(mlaw): what if someone updates the same thing twice?
@@ -180,20 +180,17 @@ export class WriteAuthorizerImpl implements WriteAuthorizer {
           // pushed in.
           case 'update': {
             consume(
-              source.push({
-                type: 'edit',
-                oldRow: this.#requirePreMutationRow(op),
-                row: op.value,
-              }),
+              source.push(
+                makeSourceChangeEdit(op.value, this.#requirePreMutationRow(op)),
+              ),
             );
             break;
           }
           case 'delete': {
             consume(
-              source.push({
-                type: 'remove',
-                row: this.#requirePreMutationRow(op),
-              }),
+              source.push(
+                makeSourceChangeRemove(this.#requirePreMutationRow(op)),
+              ),
             );
             break;
           }

--- a/packages/zero-cache/src/auth/write-authorizer.ts
+++ b/packages/zero-cache/src/auth/write-authorizer.ts
@@ -25,6 +25,11 @@ import {
   bindStaticParameters,
   buildPipeline,
 } from '../../../zql/src/builder/builder.ts';
+import {
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+  makeSourceChangeRemove,
+} from '../../../zql/src/ivm/source.ts';
 import {consume} from '../../../zql/src/ivm/stream.ts';
 import {simplifyCondition} from '../../../zql/src/query/expression.ts';
 import {asQueryInternals} from '../../../zql/src/query/query-internals.ts';
@@ -45,11 +50,6 @@ import {computeZqlSpecs} from '../db/lite-tables.ts';
 import type {LiteAndZqlSpec} from '../db/specs.ts';
 import {StatementRunner} from '../db/statements.ts';
 import {mapLiteDataTypeToZqlSchemaValue} from '../types/lite.ts';
-import {
-  makeSourceChangeAdd,
-  makeSourceChangeEdit,
-  makeSourceChangeRemove,
-} from '../../../zql/src/ivm/source.ts';
 import {
   getSchema,
   reloadPermissionsIfChanged,

--- a/packages/zero-cache/src/services/run-ast.ts
+++ b/packages/zero-cache/src/services/run-ast.ts
@@ -18,6 +18,7 @@ import {
   buildPipeline,
   type BuilderDelegate,
 } from '../../../zql/src/builder/builder.ts';
+import {ChangeType} from '../../../zql/src/ivm/change-type.ts';
 import type {Node} from '../../../zql/src/ivm/data.ts';
 import {skipYields} from '../../../zql/src/ivm/operator.ts';
 import type {ConnectionCostModel} from '../../../zql/src/planner/planner-connection.ts';
@@ -138,7 +139,10 @@ export async function runAst(
       await yieldProcess();
       continue;
     }
-    assert(rowChange.type === 'add', 'Hydration only handles add row changes');
+    assert(
+      rowChange.type === ChangeType.ADD,
+      'Hydration only handles add row changes',
+    );
 
     // yield to other tasks to avoid blocking for too long
     if (syncedRowCount % 10 === 0) {

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -465,7 +465,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "3",
           },
           "table": "issues",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "queryID1",
@@ -478,7 +478,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "2",
           },
           "table": "issues",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "queryID1",
@@ -492,7 +492,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "22",
           },
           "table": "comments",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "queryID1",
@@ -506,7 +506,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "21",
           },
           "table": "comments",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "queryID1",
@@ -520,7 +520,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "20",
           },
           "table": "comments",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "queryID1",
@@ -533,7 +533,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "1",
           },
           "table": "issues",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "queryID1",
@@ -547,7 +547,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "10",
           },
           "table": "comments",
-          "type": "add",
+          "type": 0,
         },
       ]
     `);
@@ -573,7 +573,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "3",
           },
           "table": "issues",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "queryID1",
@@ -586,7 +586,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "2",
           },
           "table": "issues",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "queryID1",
@@ -600,7 +600,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "22",
           },
           "table": "comments",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "queryID1",
@@ -614,7 +614,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "21",
           },
           "table": "comments",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "queryID1",
@@ -628,7 +628,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "20",
           },
           "table": "comments",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "queryID1",
@@ -641,7 +641,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "1",
           },
           "table": "issues",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "queryID1",
@@ -655,7 +655,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "10",
           },
           "table": "comments",
-          "type": "add",
+          "type": 0,
         },
       ]
     `);
@@ -698,7 +698,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "31",
           },
           "table": "comments",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "queryID1",
@@ -711,7 +711,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "4",
           },
           "table": "issues",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "queryID1",
@@ -725,7 +725,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "41",
           },
           "table": "comments",
-          "type": "add",
+          "type": 0,
         },
       ]
     `);
@@ -757,7 +757,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "1",
           },
           "table": "issues",
-          "type": "remove",
+          "type": 1,
         },
         {
           "queryID": "queryID1",
@@ -766,7 +766,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "10",
           },
           "table": "comments",
-          "type": "remove",
+          "type": 1,
         },
         {
           "queryID": "queryID1",
@@ -775,7 +775,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "21",
           },
           "table": "comments",
-          "type": "remove",
+          "type": 1,
         },
       ]
     `);
@@ -822,7 +822,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "22",
           },
           "table": "comments",
-          "type": "remove",
+          "type": 1,
         },
         {
           "queryID": "queryID1",
@@ -836,7 +836,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "22",
           },
           "table": "comments",
-          "type": "add",
+          "type": 0,
         },
       ]
     `);
@@ -860,7 +860,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "22",
           },
           "table": "comments",
-          "type": "edit",
+          "type": 3,
         },
       ]
     `);
@@ -996,7 +996,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "3",
           },
           "table": "issues",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "queryID1",
@@ -1010,7 +1010,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "2",
           },
           "table": "issues",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "queryID1",
@@ -1024,7 +1024,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "22",
           },
           "table": "comments",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "queryID1",
@@ -1038,7 +1038,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "21",
           },
           "table": "comments",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "queryID1",
@@ -1052,7 +1052,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "20",
           },
           "table": "comments",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "queryID1",
@@ -1066,7 +1066,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "1",
           },
           "table": "issues",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "queryID1",
@@ -1080,7 +1080,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "10",
           },
           "table": "comments",
-          "type": "add",
+          "type": 0,
         },
       ]
     `);
@@ -1103,7 +1103,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "foo",
           },
           "table": "uniques",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "queryID1",
@@ -1116,7 +1116,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "boo",
           },
           "table": "uniques",
-          "type": "add",
+          "type": 0,
         },
       ]
     `);
@@ -1144,7 +1144,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "boo",
           },
           "table": "uniques",
-          "type": "edit",
+          "type": 3,
         },
       ]
     `);
@@ -1167,7 +1167,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "foo",
           },
           "table": "uniques",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "queryID1",
@@ -1180,7 +1180,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "boo",
           },
           "table": "uniques",
-          "type": "add",
+          "type": 0,
         },
       ]
     `);
@@ -1201,7 +1201,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "foo",
           },
           "table": "uniques",
-          "type": "remove",
+          "type": 1,
         },
         {
           "queryID": "queryID1",
@@ -1214,7 +1214,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "baz",
           },
           "table": "uniques",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "queryID1",
@@ -1227,7 +1227,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "foo",
           },
           "table": "uniques",
-          "type": "add",
+          "type": 0,
         },
       ]
     `);
@@ -1262,7 +1262,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "1",
           },
           "table": "issues",
-          "type": "remove",
+          "type": 1,
         },
         {
           "queryID": "queryID",
@@ -1272,7 +1272,7 @@ describe('view-syncer/pipeline-driver', () => {
             "labelID": "1",
           },
           "table": "issueLabels",
-          "type": "remove",
+          "type": 1,
         },
         {
           "queryID": "queryID",
@@ -1281,7 +1281,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "1",
           },
           "table": "labels",
-          "type": "remove",
+          "type": 1,
         },
       ]
     `);
@@ -1310,7 +1310,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "1",
           },
           "table": "issues",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "querySubsetSchemaExists",
@@ -1324,7 +1324,7 @@ describe('view-syncer/pipeline-driver', () => {
             "legacyID": "1-1",
           },
           "table": "issueLabels",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "querySubsetSchemaExists",
@@ -1337,7 +1337,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "1",
           },
           "table": "labels",
-          "type": "add",
+          "type": 0,
         },
       ]
     `);
@@ -1365,7 +1365,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "1",
           },
           "table": "issues",
-          "type": "add",
+          "type": 0,
         },
       ]
     `);
@@ -1390,7 +1390,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "1",
           },
           "table": "issues",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "queryID",
@@ -1405,7 +1405,7 @@ describe('view-syncer/pipeline-driver', () => {
             "labelID": "1",
           },
           "table": "issueLabels",
-          "type": "add",
+          "type": 0,
         },
       ]
     `);
@@ -1538,7 +1538,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "2",
           },
           "table": "issues",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "queryID1",
@@ -1553,7 +1553,7 @@ describe('view-syncer/pipeline-driver', () => {
             "labelID": "1",
           },
           "table": "issueLabels",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "queryID1",
@@ -1566,7 +1566,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "1",
           },
           "table": "labels",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "queryID1",
@@ -1581,7 +1581,7 @@ describe('view-syncer/pipeline-driver', () => {
             "labelID": "1",
           },
           "table": "issueLabels",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "queryID1",
@@ -1594,7 +1594,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "1",
           },
           "table": "labels",
-          "type": "add",
+          "type": 0,
         },
       ]
     `);
@@ -1617,7 +1617,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "2",
           },
           "table": "issues",
-          "type": "remove",
+          "type": 1,
         },
         {
           "queryID": "queryID1",
@@ -1627,7 +1627,7 @@ describe('view-syncer/pipeline-driver', () => {
             "labelID": "1",
           },
           "table": "issueLabels",
-          "type": "remove",
+          "type": 1,
         },
         {
           "queryID": "queryID1",
@@ -1636,7 +1636,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "1",
           },
           "table": "labels",
-          "type": "remove",
+          "type": 1,
         },
         {
           "queryID": "queryID1",
@@ -1646,7 +1646,7 @@ describe('view-syncer/pipeline-driver', () => {
             "labelID": "1",
           },
           "table": "issueLabels",
-          "type": "remove",
+          "type": 1,
         },
         {
           "queryID": "queryID1",
@@ -1655,7 +1655,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "1",
           },
           "table": "labels",
-          "type": "remove",
+          "type": 1,
         },
       ]
     `);
@@ -1792,7 +1792,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "4",
           },
           "table": "issues",
-          "type": "add",
+          "type": 0,
         },
       ]
     `);
@@ -1816,7 +1816,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "41",
           },
           "table": "comments",
-          "type": "add",
+          "type": 0,
         },
       ]
     `);
@@ -1832,7 +1832,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "4",
           },
           "table": "issues",
-          "type": "remove",
+          "type": 1,
         },
         {
           "queryID": "queryID1",
@@ -1841,7 +1841,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "41",
           },
           "table": "comments",
-          "type": "remove",
+          "type": 1,
         },
       ]
     `);
@@ -1930,7 +1930,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "1",
           },
           "table": "issues",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "queryScalar",
@@ -1944,7 +1944,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "10",
           },
           "table": "comments",
-          "type": "add",
+          "type": 0,
         },
       ]
     `);
@@ -1983,7 +1983,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "1",
           },
           "table": "issues",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "queryScalarSubsetSchema",
@@ -1997,7 +1997,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "10",
           },
           "table": "comments",
-          "type": "add",
+          "type": 0,
         },
       ]
     `);
@@ -2100,7 +2100,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "1",
           },
           "table": "issues",
-          "type": "add",
+          "type": 0,
         },
         {
           "queryID": "queryScalarAnd",
@@ -2114,7 +2114,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "10",
           },
           "table": "comments",
-          "type": "add",
+          "type": 0,
         },
       ]
     `);
@@ -2175,7 +2175,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "1",
           },
           "table": "issues",
-          "type": "edit",
+          "type": 3,
         },
       ]
     `);
@@ -2212,7 +2212,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "10",
           },
           "table": "comments",
-          "type": "edit",
+          "type": 3,
         },
       ]
     `);
@@ -2274,7 +2274,7 @@ describe('view-syncer/pipeline-driver', () => {
             "id": "10",
           },
           "table": "comments",
-          "type": "edit",
+          "type": 3,
         },
       ]
     `);

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -21,10 +21,13 @@ import {
   type Storage,
 } from '../../../../zql/src/ivm/operator.ts';
 import type {SourceSchema} from '../../../../zql/src/ivm/schema.ts';
-import type {
-  Source,
-  SourceChange,
-  SourceInput,
+import {
+  type Source,
+  type SourceChange,
+  type SourceInput,
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+  makeSourceChangeRemove,
 } from '../../../../zql/src/ivm/source.ts';
 import type {ConnectionCostModel} from '../../../../zql/src/planner/planner-connection.ts';
 import {MeasurePushOperator} from '../../../../zql/src/query/measure-push-operator.ts';
@@ -669,24 +672,23 @@ export class PipelineDriver {
               if (nextValue) {
                 this.#conflictRowsDeleted.add(1);
               }
-              yield* this.#push(tableSource, {
-                type: 'remove',
-                row: prevValue,
-              });
+              yield* this.#push(
+                tableSource,
+                makeSourceChangeRemove(prevValue as Row),
+              );
             }
           }
           if (nextValue) {
             if (editOldRow) {
-              yield* this.#push(tableSource, {
-                type: 'edit',
-                row: nextValue,
-                oldRow: editOldRow,
-              });
+              yield* this.#push(
+                tableSource,
+                makeSourceChangeEdit(nextValue as Row, editOldRow),
+              );
             } else {
-              yield* this.#push(tableSource, {
-                type: 'add',
-                row: nextValue,
-              });
+              yield* this.#push(
+                tableSource,
+                makeSourceChangeAdd(nextValue as Row),
+              );
             }
           }
         } finally {

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -58,29 +58,19 @@ import {checkClientSchema} from './client-schema.ts';
 import type {Snapshotter} from './snapshotter.ts';
 import {ResetPipelinesSignal, type SnapshotDiff} from './snapshotter.ts';
 
-export type RowAdd = {
-  readonly type: 'add';
+type RowOp<Op extends Omit<ChangeType, ChangeType.CHILD>> = {
+  readonly type: Op;
   readonly queryID: string;
   readonly table: string;
   readonly rowKey: Row;
   readonly row: Row;
 };
 
-export type RowRemove = {
-  readonly type: 'remove';
-  readonly queryID: string;
-  readonly table: string;
-  readonly rowKey: Row;
-  readonly row: undefined;
-};
+export type RowAdd = RowOp<ChangeType.ADD>;
 
-export type RowEdit = {
-  readonly type: 'edit';
-  readonly queryID: string;
-  readonly table: string;
-  readonly rowKey: Row;
-  readonly row: Row;
-};
+export type RowRemove = RowOp<ChangeType.REMOVE>;
+
+export type RowEdit = RowOp<ChangeType.EDIT>;
 
 export type RowChange = RowAdd | RowRemove | RowEdit;
 
@@ -476,7 +466,7 @@ export class PipelineDriver {
       for (const {table, row} of companionRows) {
         const primaryKey = mustGetPrimaryKey(this.#primaryKeys, table);
         yield {
-          type: 'add',
+          type: ChangeType.ADD,
           queryID,
           table,
           rowKey: getRowKey(primaryKey, row),
@@ -882,19 +872,16 @@ class Streamer {
         yield change;
         continue;
       }
-      switch (change[ChangeIndex.TYPE]) {
+      const type = change[ChangeIndex.TYPE];
+      switch (type) {
+        case ChangeType.REMOVE:
         case ChangeType.ADD: {
-          yield* this.#streamNodes(queryID, schema, 'add', () => [
+          yield* this.#streamNodes(queryID, schema, type, () => [
             change[ChangeIndex.NODE],
           ]);
           break;
         }
-        case ChangeType.REMOVE: {
-          yield* this.#streamNodes(queryID, schema, 'remove', () => [
-            change[ChangeIndex.NODE],
-          ]);
-          break;
-        }
+
         case ChangeType.CHILD: {
           const child = change[ChangeIndex.CHILD_DATA];
           const childSchema = must(
@@ -905,7 +892,7 @@ class Streamer {
           break;
         }
         case ChangeType.EDIT:
-          yield* this.#streamNodes(queryID, schema, 'edit', () => [
+          yield* this.#streamNodes(queryID, schema, type, () => [
             {row: change[ChangeIndex.NODE].row, relationships: {}},
           ]);
           break;
@@ -918,7 +905,7 @@ class Streamer {
   *#streamNodes(
     queryID: string,
     schema: SourceSchema,
-    op: 'add' | 'remove' | 'edit',
+    op: ChangeType.ADD | ChangeType.REMOVE | ChangeType.EDIT,
     nodes: () => Iterable<Node | 'yield'>,
   ): Iterable<RowChange | 'yield'> {
     const {tableName: table, system} = schema;
@@ -940,7 +927,7 @@ class Streamer {
       const {relationships} = node;
       let {row} = node;
       const rowKey = getRowKey(primaryKey, row);
-      if (op !== 'remove') {
+      if (op !== ChangeType.REMOVE) {
         const rowVersion = row[ZERO_VERSION_COLUMN_NAME];
         if (
           typeof rowVersion === 'string' &&
@@ -955,7 +942,7 @@ class Streamer {
         queryID,
         table,
         rowKey,
-        row: op === 'remove' ? undefined : row,
+        row: op === ChangeType.REMOVE ? undefined : row,
       } as RowChange;
 
       for (const [relationship, children] of Object.entries(relationships)) {

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -11,6 +11,8 @@ import {
   Debug,
   runtimeDebugFlags,
 } from '../../../../zql/src/builder/debug-delegate.ts';
+import {ChangeIndex} from '../../../../zql/src/ivm/change-index.ts';
+import {ChangeType} from '../../../../zql/src/ivm/change-type.ts';
 import type {Change} from '../../../../zql/src/ivm/change.ts';
 import type {Node} from '../../../../zql/src/ivm/data.ts';
 import {
@@ -514,16 +516,17 @@ export class PipelineDriver {
         companionInput.setOutput({
           push: (change: Change) => {
             let newValue: LiteralValue | null | undefined;
-            switch (change.type) {
-              case 'add':
-              case 'edit':
+            switch (change[ChangeIndex.TYPE]) {
+              case ChangeType.ADD:
+              case ChangeType.EDIT:
                 newValue =
-                  (change.node.row[childField] as LiteralValue) ?? null;
+                  (change[ChangeIndex.NODE].row[childField] as LiteralValue) ??
+                  null;
                 break;
-              case 'remove':
+              case ChangeType.REMOVE:
                 newValue = undefined;
                 break;
-              case 'child':
+              case ChangeType.CHILD:
                 return [];
             }
             if (!scalarValuesEqual(newValue, resolvedValue)) {
@@ -879,16 +882,21 @@ class Streamer {
         yield change;
         continue;
       }
-      const {type} = change;
-
-      switch (type) {
-        case 'add':
-        case 'remove': {
-          yield* this.#streamNodes(queryID, schema, type, () => [change.node]);
+      switch (change[ChangeIndex.TYPE]) {
+        case ChangeType.ADD: {
+          yield* this.#streamNodes(queryID, schema, 'add', () => [
+            change[ChangeIndex.NODE],
+          ]);
           break;
         }
-        case 'child': {
-          const {child} = change;
+        case ChangeType.REMOVE: {
+          yield* this.#streamNodes(queryID, schema, 'remove', () => [
+            change[ChangeIndex.NODE],
+          ]);
+          break;
+        }
+        case ChangeType.CHILD: {
+          const child = change[ChangeIndex.CHILD_DATA];
           const childSchema = must(
             schema.relationships[child.relationshipName],
           );
@@ -896,13 +904,13 @@ class Streamer {
           yield* this.#streamChanges(queryID, childSchema, [child.change]);
           break;
         }
-        case 'edit':
-          yield* this.#streamNodes(queryID, schema, type, () => [
-            {row: change.node.row, relationships: {}},
+        case ChangeType.EDIT:
+          yield* this.#streamNodes(queryID, schema, 'edit', () => [
+            {row: change[ChangeIndex.NODE].row, relationships: {}},
           ]);
           break;
         default:
-          unreachable(type);
+          unreachable(change[ChangeIndex.TYPE]);
       }
     }
   }
@@ -964,7 +972,7 @@ function* toAdds(nodes: Iterable<Node | 'yield'>): Iterable<Change | 'yield'> {
       yield node;
       continue;
     }
-    yield {type: 'add', node};
+    yield [ChangeType.ADD, node, null];
   }
 }
 

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -33,6 +33,7 @@ import type {
   InspectUpMessage,
 } from '../../../../zero-protocol/src/inspect-up.ts';
 import type {UpdateAuthMessage} from '../../../../zero-protocol/src/update-auth.ts';
+import {ChangeType} from '../../../../zql/src/ivm/change-type.ts';
 import {clampTTL, MAX_TTL_MS} from '../../../../zql/src/query/ttl.ts';
 import {isAuthErrorBody, type Auth} from '../../auth/auth.ts';
 import {
@@ -2133,15 +2134,15 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
             parsedRow.contents = contents;
           };
           switch (type) {
-            case 'add':
+            case ChangeType.ADD:
               updateVersion(row);
               parsedRow.refCounts[queryID]++;
               break;
-            case 'edit':
+            case ChangeType.EDIT:
               updateVersion(row);
               // No update to refCounts.
               break;
-            case 'remove':
+            case ChangeType.REMOVE:
               parsedRow.refCounts[queryID]--;
               break;
             default:

--- a/packages/zero-client/src/client/context.test.ts
+++ b/packages/zero-client/src/client/context.test.ts
@@ -18,7 +18,6 @@ import {
 } from './context.ts';
 import {IVMSourceBranch} from './ivm-branch.ts';
 import {ENTITIES_KEY_PREFIX} from './keys.ts';
-
 const testBatchViewUpdates = (applyViewUpdates: () => void) =>
   applyViewUpdates();
 
@@ -166,8 +165,8 @@ test('processChanges', () => {
     {type: 'add', node: {row: {id: 'e2', name: 'name2'}, relationships: {}}},
     {
       type: 'edit',
-      oldRow: {id: 'e1', name: 'name1'},
       row: {id: 'e1', name: 'name1.1'},
+      oldRow: {id: 'e1', name: 'name1'},
     },
   ]);
 
@@ -188,8 +187,8 @@ test('processChanges wraps source updates with batchViewUpdates', () => {
       {type: 'add', node: {row: {id: 'e2', name: 'name2'}, relationships: {}}},
       {
         type: 'edit',
-        oldRow: {id: 'e1', name: 'name1'},
         row: {id: 'e1', name: 'name1.1'},
+        oldRow: {id: 'e1', name: 'name1'},
       },
     ]);
   };

--- a/packages/zero-client/src/client/crud-impl.ts
+++ b/packages/zero-client/src/client/crud-impl.ts
@@ -13,6 +13,11 @@ import {consume} from '../../../zql/src/ivm/stream.ts';
 import type {IVMSourceBranch} from './ivm-branch.ts';
 import {toPrimaryKeyString} from './keys.ts';
 import type {WriteTransaction} from './replicache-types.ts';
+import {
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+  makeSourceChangeRemove,
+} from '../../../zql/src/ivm/source.ts';
 export type {TableMutator} from '../../../zql/src/mutate/crud.ts';
 
 function defaultOptionalFieldsToNull(
@@ -47,10 +52,9 @@ export async function insert(
     await tx.set(key, val);
     if (ivmBranch) {
       consume(
-        must(ivmBranch.getSource(arg.tableName)).push({
-          type: 'add',
-          row: arg.value,
-        }),
+        must(ivmBranch.getSource(arg.tableName)).push(
+          makeSourceChangeAdd(arg.value),
+        ),
       );
     }
   }
@@ -99,11 +103,9 @@ export async function update(
   await tx.set(key, next);
   if (ivmBranch) {
     consume(
-      must(ivmBranch.getSource(arg.tableName)).push({
-        type: 'edit',
-        oldRow: prev as Row,
-        row: next,
-      }),
+      must(ivmBranch.getSource(arg.tableName)).push(
+        makeSourceChangeEdit(next, prev as Row),
+      ),
     );
   }
 }
@@ -126,10 +128,9 @@ async function deleteImpl(
   await tx.del(key);
   if (ivmBranch) {
     consume(
-      must(ivmBranch.getSource(arg.tableName)).push({
-        type: 'remove',
-        row: prev as Row,
-      }),
+      must(ivmBranch.getSource(arg.tableName)).push(
+        makeSourceChangeRemove(prev as Row),
+      ),
     );
   }
 }

--- a/packages/zero-client/src/client/crud-impl.ts
+++ b/packages/zero-client/src/client/crud-impl.ts
@@ -9,15 +9,15 @@ import {
 } from '../../../zero-protocol/src/push.ts';
 import type {TableSchema} from '../../../zero-schema/src/table-schema.ts';
 import type {Schema} from '../../../zero-types/src/schema.ts';
-import {consume} from '../../../zql/src/ivm/stream.ts';
-import type {IVMSourceBranch} from './ivm-branch.ts';
-import {toPrimaryKeyString} from './keys.ts';
-import type {WriteTransaction} from './replicache-types.ts';
 import {
   makeSourceChangeAdd,
   makeSourceChangeEdit,
   makeSourceChangeRemove,
 } from '../../../zql/src/ivm/source.ts';
+import {consume} from '../../../zql/src/ivm/stream.ts';
+import type {IVMSourceBranch} from './ivm-branch.ts';
+import {toPrimaryKeyString} from './keys.ts';
+import type {WriteTransaction} from './replicache-types.ts';
 export type {TableMutator} from '../../../zql/src/mutate/crud.ts';
 
 function defaultOptionalFieldsToNull(

--- a/packages/zero-client/src/client/ivm-branch.test.ts
+++ b/packages/zero-client/src/client/ivm-branch.test.ts
@@ -20,6 +20,7 @@ import {consume} from '../../../zql/src/ivm/stream.ts';
 import {ENTITIES_KEY_PREFIX} from './keys.ts';
 import {createDb} from './test/create-db.ts';
 
+import {makeSourceChangeAdd} from '../../../zql/src/ivm/source.ts';
 test('fork', () => {
   const main = new IVMSourceBranch({
     users: {
@@ -35,12 +36,7 @@ test('fork', () => {
 
   // Add initial data to main
   const usersSource = main.getSource('users')!;
-  consume(
-    usersSource.push({
-      type: 'add',
-      row: {id: 'u1', name: 'Alice'},
-    }),
-  );
+  consume(usersSource.push(makeSourceChangeAdd({id: 'u1', name: 'Alice'})));
 
   // Fork should have same initial data
   const fork = main.fork();
@@ -58,19 +54,13 @@ test('fork', () => {
   `);
 
   // Mutate main
-  consume(
-    usersSource.push({
-      type: 'add',
-      row: {id: 'u2', name: 'Bob'},
-    }),
-  );
+  consume(usersSource.push(makeSourceChangeAdd({id: 'u2', name: 'Bob'})));
 
   // Mutate fork differently
   consume(
-    fork.getSource('users')!.push({
-      type: 'add',
-      row: {id: 'u3', name: 'Charlie'},
-    }),
+    fork
+      .getSource('users')!
+      .push(makeSourceChangeAdd({id: 'u3', name: 'Charlie'})),
   );
 
   // Verify main and fork evolved independently

--- a/packages/zero-client/src/client/ivm-branch.ts
+++ b/packages/zero-client/src/client/ivm-branch.ts
@@ -22,6 +22,11 @@ import {MemorySource} from '../../../zql/src/ivm/memory-source.ts';
 import {consume} from '../../../zql/src/ivm/stream.ts';
 import {ENTITIES_KEY_PREFIX, sourceNameFromKey} from './keys.ts';
 
+import {
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+  makeSourceChangeRemove,
+} from '../../../zql/src/ivm/source.ts';
 /**
  * Replicache needs to rebase mutations onto different
  * commits of it's b-tree. These mutations can have reads
@@ -214,28 +219,16 @@ function applyDiffs(diffs: NoIndexDiff, branch: IVMSourceBranch) {
     const source = must(branch.getSource(name));
     switch (diff.op) {
       case 'del':
-        consume(
-          source.push({
-            type: 'remove',
-            row: diff.oldValue as Row,
-          }),
-        );
+        consume(source.push(makeSourceChangeRemove(diff.oldValue as Row)));
         break;
       case 'add':
-        consume(
-          source.push({
-            type: 'add',
-            row: diff.newValue as Row,
-          }),
-        );
+        consume(source.push(makeSourceChangeAdd(diff.newValue as Row)));
         break;
       case 'change':
         consume(
-          source.push({
-            type: 'edit',
-            row: diff.newValue as Row,
-            oldRow: diff.oldValue as Row,
-          }),
+          source.push(
+            makeSourceChangeEdit(diff.newValue as Row, diff.oldValue as Row),
+          ),
         );
         break;
     }

--- a/packages/zero-client/src/client/query-materialization-metrics.test.ts
+++ b/packages/zero-client/src/client/query-materialization-metrics.test.ts
@@ -20,6 +20,7 @@ import {
 } from './context.ts';
 import {IVMSourceBranch} from './ivm-branch.ts';
 
+import {makeSourceChangeAdd} from '../../../zql/src/ivm/source.ts';
 const testBatchViewUpdates = (applyViewUpdates: () => void) =>
   applyViewUpdates();
 
@@ -505,8 +506,8 @@ describe('query materialization metrics', () => {
 
       // Add some test data to the source
       const source = queryDelegate.getSource('users') as MemorySource;
-      consume(source.push({type: 'add', row: {id: 'user1', name: 'John'}}));
-      consume(source.push({type: 'add', row: {id: 'user2', name: 'Jane'}}));
+      consume(source.push(makeSourceChangeAdd({id: 'user1', name: 'John'})));
+      consume(source.push(makeSourceChangeAdd({id: 'user2', name: 'Jane'})));
 
       const query = createTestQuery();
 

--- a/packages/zero-solid/package.json
+++ b/packages/zero-solid/package.json
@@ -27,7 +27,8 @@
     "shared": "0.0.0",
     "solid-js": "^1.9.4",
     "vite-plugin-solid": "^2.11.11",
-    "zero-client": "0.0.0"
+    "zero-client": "0.0.0",
+    "zql": "0.0.0"
   },
   "peerDependencies": {
     "solid-js": "^1.9.4"

--- a/packages/zero-solid/src/solid-view.test.ts
+++ b/packages/zero-solid/src/solid-view.test.ts
@@ -16,6 +16,11 @@ import {MemorySource} from '../../zql/src/ivm/memory-source.ts';
 import {MemoryStorage} from '../../zql/src/ivm/memory-storage.ts';
 import type {Input} from '../../zql/src/ivm/operator.ts';
 import type {SourceSchema} from '../../zql/src/ivm/schema.ts';
+import {
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+  makeSourceChangeRemove,
+} from '../../zql/src/ivm/source.ts';
 import {consume} from '../../zql/src/ivm/stream.ts';
 import {Take} from '../../zql/src/ivm/take.ts';
 import {createSource} from '../../zql/src/ivm/test/source-factory.ts';
@@ -39,8 +44,8 @@ test('basics', () => {
     {a: {type: 'number'}, b: {type: 'string'}},
     ['a'],
   );
-  consume(ms.push({row: {a: 1, b: 'a'}, type: 'add'}));
-  consume(ms.push({row: {a: 2, b: 'b'}, type: 'add'}));
+  consume(ms.push(makeSourceChangeAdd({a: 1, b: 'a'})));
+  consume(ms.push(makeSourceChangeAdd({a: 2, b: 'b'})));
 
   let commit: () => void = () => {};
   const onTransactionCommit = (cb: () => void): void => {
@@ -79,7 +84,7 @@ test('basics', () => {
 
   expect(state[1]).toEqual({type: 'complete'});
 
-  consume(ms.push({row: {a: 3, b: 'c'}, type: 'add'}));
+  consume(ms.push(makeSourceChangeAdd({a: 3, b: 'c'})));
   expect(data()).toEqual(data0);
   commit();
 
@@ -90,8 +95,8 @@ test('basics', () => {
   ];
   expect(data()).toEqual(data1);
 
-  consume(ms.push({row: {a: 2, b: 'b'}, type: 'remove'}));
-  consume(ms.push({row: {a: 1, b: 'a'}, type: 'remove'}));
+  consume(ms.push(makeSourceChangeRemove({a: 2, b: 'b'})));
+  consume(ms.push(makeSourceChangeRemove({a: 1, b: 'a'})));
 
   expect(data()).toEqual(data1);
   commit();
@@ -99,7 +104,7 @@ test('basics', () => {
   const data2 = [{a: 3, b: 'c', [refCountSymbol]: 1, [idSymbol]: '3'}];
   expect(data()).toEqual(data2);
 
-  consume(ms.push({row: {a: 3, b: 'c'}, type: 'remove'}));
+  consume(ms.push(makeSourceChangeRemove({a: 3, b: 'c'})));
 
   expect(data()).toEqual(data2);
   commit();
@@ -113,7 +118,7 @@ test('single-format', () => {
     {a: {type: 'number'}, b: {type: 'string'}},
     ['a'],
   );
-  consume(ms.push({row: {a: 1, b: 'a'}, type: 'add'}));
+  consume(ms.push(makeSourceChangeAdd({a: 1, b: 'a'})));
 
   let commit: () => void = () => {};
   const onTransactionCommit = (cb: () => void): void => {
@@ -148,7 +153,7 @@ test('single-format', () => {
   // trying to add another element should be an error
   // pipeline should have been configured with a limit of one
   expect(() => {
-    consume(ms.push({row: {a: 2, b: 'b'}, type: 'add'}));
+    consume(ms.push(makeSourceChangeAdd({a: 2, b: 'b'})));
     commit();
   }).toThrow(
     "Singular relationship '' should not have multiple rows. You may need to declare this relationship with the `many` helper instead of the `one` helper in your schema.",
@@ -157,7 +162,7 @@ test('single-format', () => {
   // Adding the same element is not an error in the ArrayView but it is an error
   // in the Source. This case is tested in view-apply-change.ts.
 
-  consume(ms.push({row: {a: 1, b: 'a'}, type: 'remove'}));
+  consume(ms.push(makeSourceChangeRemove({a: 1, b: 'a'})));
   expect(data()).toEqual(data0);
   commit();
 
@@ -210,30 +215,10 @@ test('tree', () => {
     {id: {type: 'number'}, name: {type: 'string'}, childID: {type: 'number'}},
     ['id'],
   );
-  consume(
-    ms.push({
-      type: 'add',
-      row: {id: 1, name: 'foo', childID: 2},
-    }),
-  );
-  consume(
-    ms.push({
-      type: 'add',
-      row: {id: 2, name: 'foobar', childID: null},
-    }),
-  );
-  consume(
-    ms.push({
-      type: 'add',
-      row: {id: 3, name: 'mon', childID: 4},
-    }),
-  );
-  consume(
-    ms.push({
-      type: 'add',
-      row: {id: 4, name: 'monkey', childID: null},
-    }),
-  );
+  consume(ms.push(makeSourceChangeAdd({id: 1, name: 'foo', childID: 2})));
+  consume(ms.push(makeSourceChangeAdd({id: 2, name: 'foobar', childID: null})));
+  consume(ms.push(makeSourceChangeAdd({id: 3, name: 'mon', childID: 4})));
+  consume(ms.push(makeSourceChangeAdd({id: 4, name: 'monkey', childID: null})));
 
   const join = new Join({
     parent: ms.connect([
@@ -331,7 +316,7 @@ test('tree', () => {
   expect(data()).toEqual(data0);
 
   // add parent with child
-  consume(ms.push({type: 'add', row: {id: 5, name: 'chocolate', childID: 2}}));
+  consume(ms.push(makeSourceChangeAdd({id: 5, name: 'chocolate', childID: 2})));
   expect(data()).toEqual(data0);
   commit();
   const data1 = [
@@ -404,7 +389,7 @@ test('tree', () => {
 
   // remove parent with child
   consume(
-    ms.push({type: 'remove', row: {id: 5, name: 'chocolate', childID: 2}}),
+    ms.push(makeSourceChangeRemove({id: 5, name: 'chocolate', childID: 2})),
   );
   expect(data()).toEqual(data1);
   commit();
@@ -462,14 +447,13 @@ test('tree', () => {
 
   // remove just child
   consume(
-    ms.push({
-      type: 'remove',
-      row: {
+    ms.push(
+      makeSourceChangeRemove({
         id: 2,
         name: 'foobar',
         childID: null,
-      },
-    }),
+      }),
+    ),
   );
   expect(data()).toEqual(data2);
   commit();
@@ -511,14 +495,13 @@ test('tree', () => {
 
   // add child
   consume(
-    ms.push({
-      type: 'add',
-      row: {
+    ms.push(
+      makeSourceChangeAdd({
         id: 2,
         name: 'foobaz',
         childID: null,
-      },
-    }),
+      }),
+    ),
   );
   expect(data()).toEqual(data3);
   commit();
@@ -582,18 +565,8 @@ test('tree-single', () => {
     {id: {type: 'number'}, name: {type: 'string'}, childID: {type: 'number'}},
     ['id'],
   );
-  consume(
-    ms.push({
-      type: 'add',
-      row: {id: 1, name: 'foo', childID: 2},
-    }),
-  );
-  consume(
-    ms.push({
-      type: 'add',
-      row: {id: 2, name: 'foobar', childID: null},
-    }),
-  );
+  consume(ms.push(makeSourceChangeAdd({id: 1, name: 'foo', childID: 2})));
+  consume(ms.push(makeSourceChangeAdd({id: 2, name: 'foobar', childID: null})));
 
   const take = new Take(
     ms.connect([
@@ -662,10 +635,7 @@ test('tree-single', () => {
 
   // remove the child
   consume(
-    ms.push({
-      type: 'remove',
-      row: {id: 2, name: 'foobar', childID: null},
-    }),
+    ms.push(makeSourceChangeRemove({id: 2, name: 'foobar', childID: null})),
   );
 
   expect(data()).toEqual(data0);
@@ -682,12 +652,7 @@ test('tree-single', () => {
   expect(data()).toEqual(data1);
 
   // remove the parent
-  consume(
-    ms.push({
-      type: 'remove',
-      row: {id: 1, name: 'foo', childID: 2},
-    }),
-  );
+  consume(ms.push(makeSourceChangeRemove({id: 1, name: 'foo', childID: 2})));
 
   expect(data()).toEqual(data1);
   commit();
@@ -1350,8 +1315,8 @@ test('basic with edit pushes', () => {
     {id: {type: 'number'}, b: {type: 'string'}},
     ['id'],
   );
-  consume(ms.push({row: {id: 1, b: 'a'}, type: 'add'}));
-  consume(ms.push({row: {id: 2, b: 'b'}, type: 'add'}));
+  consume(ms.push(makeSourceChangeAdd({id: 1, b: 'a'})));
+  consume(ms.push(makeSourceChangeAdd({id: 2, b: 'b'})));
 
   let commit: () => void = () => {};
   const onTransactionCommit = (cb: () => void): void => {
@@ -1383,9 +1348,7 @@ test('basic with edit pushes', () => {
   ];
   expect(data()).toEqual(data0);
 
-  consume(
-    ms.push({type: 'edit', row: {id: 2, b: 'b2'}, oldRow: {id: 2, b: 'b'}}),
-  );
+  consume(ms.push(makeSourceChangeEdit({id: 2, b: 'b2'}, {id: 2, b: 'b'})));
 
   expect(data()).toEqual(data0);
   commit();
@@ -1396,9 +1359,7 @@ test('basic with edit pushes', () => {
   ];
   expect(data()).toEqual(data1);
 
-  consume(
-    ms.push({type: 'edit', row: {id: 3, b: 'b3'}, oldRow: {id: 2, b: 'b2'}}),
-  );
+  consume(ms.push(makeSourceChangeEdit({id: 3, b: 'b3'}, {id: 2, b: 'b2'})));
 
   expect(data()).toEqual(data1);
   commit();
@@ -1416,8 +1377,8 @@ test('edit trigger reactivity at the column level', () => {
     {a: {type: 'number'}, b: {type: 'string'}},
     ['a'],
   );
-  consume(ms.push({row: {a: 1, b: 'a'}, type: 'add'}));
-  consume(ms.push({row: {a: 2, b: 'b'}, type: 'add'}));
+  consume(ms.push(makeSourceChangeAdd({a: 1, b: 'a'})));
+  consume(ms.push(makeSourceChangeAdd({a: 2, b: 'b'})));
 
   let commit: () => void = () => {};
   const onTransactionCommit = (cb: () => void): void => {
@@ -1496,9 +1457,7 @@ test('edit trigger reactivity at the column level', () => {
 
   clearLog();
 
-  consume(
-    ms.push({type: 'edit', row: {a: 2, b: 'b2'}, oldRow: {a: 2, b: 'b'}}),
-  );
+  consume(ms.push(makeSourceChangeEdit({a: 2, b: 'b2'}, {a: 2, b: 'b'})));
 
   expect(data()).toEqual(data0);
   commit();
@@ -1517,9 +1476,7 @@ test('edit trigger reactivity at the column level', () => {
 
   clearLog();
 
-  consume(
-    ms.push({type: 'edit', row: {a: 3, b: 'b3'}, oldRow: {a: 2, b: 'b2'}}),
-  );
+  consume(ms.push(makeSourceChangeEdit({a: 3, b: 'b3'}, {a: 2, b: 'b2'})));
 
   expect(data()).toEqual(data1);
   commit();
@@ -1537,9 +1494,7 @@ test('edit trigger reactivity at the column level', () => {
 
   clearLog();
 
-  consume(
-    ms.push({type: 'edit', row: {a: 0, b: 'b3'}, oldRow: {a: 3, b: 'b3'}}),
-  );
+  consume(ms.push(makeSourceChangeEdit({a: 0, b: 'b3'}, {a: 3, b: 'b3'})));
 
   expect(data()).toEqual(data2);
   commit();
@@ -1579,7 +1534,7 @@ test('tree edit', () => {
     {id: 3, name: 'mon', data: 'c', childID: 4},
     {id: 4, name: 'monkey', data: 'd', childID: null},
   ] as const) {
-    consume(ms.push({type: 'add', row}));
+    consume(ms.push(makeSourceChangeAdd(row)));
   }
 
   const join = new Join({
@@ -1685,11 +1640,12 @@ test('tree edit', () => {
 
   // Edit root
   consume(
-    ms.push({
-      type: 'edit',
-      oldRow: {id: 1, name: 'foo', data: 'a', childID: 2},
-      row: {id: 1, name: 'foo', data: 'a2', childID: 2},
-    }),
+    ms.push(
+      makeSourceChangeEdit(
+        {id: 1, name: 'foo', data: 'a2', childID: 2},
+        {id: 1, name: 'foo', data: 'a', childID: 2},
+      ),
+    ),
   );
 
   expect(data()).toEqual(data0);
@@ -1755,21 +1711,22 @@ test('tree edit', () => {
 
   // Edit leaf
   consume(
-    ms.push({
-      type: 'edit',
-      oldRow: {
-        id: 4,
-        name: 'monkey',
-        data: 'd',
-        childID: null,
-      },
-      row: {
-        id: 4,
-        name: 'monkey',
-        data: 'd2',
-        childID: null,
-      },
-    }),
+    ms.push(
+      makeSourceChangeEdit(
+        {
+          id: 4,
+          name: 'monkey',
+          data: 'd2',
+          childID: null,
+        },
+        {
+          id: 4,
+          name: 'monkey',
+          data: 'd',
+          childID: null,
+        },
+      ),
+    ),
   );
 
   expect(data()).toEqual(data1);
@@ -1849,7 +1806,7 @@ test('edit to change the order', () => {
     {a: 20, b: 'b'},
     {a: 30, b: 'c'},
   ] as const) {
-    consume(ms.push({row, type: 'add'}));
+    consume(ms.push(makeSourceChangeAdd(row)));
   }
 
   let commit: () => void = () => {};
@@ -1883,13 +1840,7 @@ test('edit to change the order', () => {
   ];
   expect(data()).toEqual(data0);
 
-  consume(
-    ms.push({
-      type: 'edit',
-      oldRow: {a: 20, b: 'b'},
-      row: {a: 5, b: 'b2'},
-    }),
-  );
+  consume(ms.push(makeSourceChangeEdit({a: 5, b: 'b2'}, {a: 20, b: 'b'})));
 
   expect(data()).toEqual(data0);
   commit();
@@ -1901,13 +1852,7 @@ test('edit to change the order', () => {
   ];
   expect(data()).toEqual(data1);
 
-  consume(
-    ms.push({
-      type: 'edit',
-      oldRow: {a: 5, b: 'b2'},
-      row: {a: 4, b: 'b3'},
-    }),
-  );
+  consume(ms.push(makeSourceChangeEdit({a: 4, b: 'b3'}, {a: 5, b: 'b2'})));
 
   expect(data()).toEqual(data1);
   commit();
@@ -1919,13 +1864,7 @@ test('edit to change the order', () => {
   ];
   expect(data()).toEqual(data2);
 
-  consume(
-    ms.push({
-      type: 'edit',
-      oldRow: {a: 4, b: 'b3'},
-      row: {a: 20, b: 'b4'},
-    }),
-  );
+  consume(ms.push(makeSourceChangeEdit({a: 20, b: 'b4'}, {a: 4, b: 'b3'})));
 
   expect(data()).toEqual(data2);
   commit();
@@ -2452,8 +2391,8 @@ test('queryComplete promise', async () => {
     {a: {type: 'number'}, b: {type: 'string'}},
     ['a'],
   );
-  consume(ms.push({row: {a: 1, b: 'a'}, type: 'add'}));
-  consume(ms.push({row: {a: 2, b: 'b'}, type: 'add'}));
+  consume(ms.push(makeSourceChangeAdd({a: 1, b: 'a'})));
+  consume(ms.push(makeSourceChangeAdd({a: 2, b: 'b'})));
 
   const queryCompleteResolver = resolver<true>();
 
@@ -2528,8 +2467,8 @@ test('factory', () => {
     {a: {type: 'number'}, b: {type: 'string'}},
     ['a'],
   );
-  ms.push({row: {a: 1, b: 'a'}, type: 'add'});
-  ms.push({row: {a: 2, b: 'b'}, type: 'add'});
+  ms.push(makeSourceChangeAdd({a: 1, b: 'a'}));
+  ms.push(makeSourceChangeAdd({a: 2, b: 'b'}));
 
   const onDestroy = vi.fn();
   const onTransactionCommit = vi.fn();

--- a/packages/zero-solid/src/solid-view.test.ts
+++ b/packages/zero-solid/src/solid-view.test.ts
@@ -5,6 +5,12 @@ import {expect, test, vi} from 'vitest';
 import {testLogConfig} from '../../otel/src/test-log-config.ts';
 import {createSilentLogContext} from '../../shared/src/logging-test-utils.ts';
 import {stringCompare} from '../../shared/src/string-compare.ts';
+import {
+  makeAddChange,
+  makeChildChange,
+  makeEditChange,
+  makeRemoveChange,
+} from '../../zql/src/ivm/change.ts';
 import {Join} from '../../zql/src/ivm/join.ts';
 import {MemorySource} from '../../zql/src/ivm/memory-source.ts';
 import {MemoryStorage} from '../../zql/src/ivm/memory-storage.ts';
@@ -806,12 +812,7 @@ test('collapse', () => {
     },
   } as const;
 
-  consume(
-    view.push({
-      type: 'add',
-      ...changeSansType,
-    }),
-  );
+  consume(view.push(makeAddChange(changeSansType.node)));
   expect(data()).toEqual(data0);
   commit();
 
@@ -833,84 +834,72 @@ test('collapse', () => {
   ];
   expect(data()).toEqual(data1);
 
-  consume(
-    view.push({
-      type: 'remove',
-      ...changeSansType,
-    }),
-  );
+  consume(view.push(makeRemoveChange(changeSansType.node)));
   expect(data()).toEqual(data1);
   commit();
 
   const data2: unknown[] = [];
   expect(data()).toEqual(data2);
 
-  consume(
-    view.push({
-      type: 'add',
-      ...changeSansType,
-    }),
-  );
+  consume(view.push(makeAddChange(changeSansType.node)));
   // no commit
 
   expect(data()).toEqual(data2);
 
   consume(
-    view.push({
-      type: 'child',
-      node: {
-        row: {
-          id: 1,
-          name: 'issue',
-        },
-        relationships: {
-          labels: () => [
-            {
-              row: {
-                id: 1,
-                issueId: 1,
-                labelId: 1,
-                extra: 'a',
-              },
-              relationships: {
-                labels: () => [
-                  {
-                    row: {
-                      id: 1,
-                      name: 'label',
+    view.push(
+      makeChildChange(
+        {
+          row: {
+            id: 1,
+            name: 'issue',
+          },
+          relationships: {
+            labels: () => [
+              {
+                row: {
+                  id: 1,
+                  issueId: 1,
+                  labelId: 1,
+                  extra: 'a',
+                },
+                relationships: {
+                  labels: () => [
+                    {
+                      row: {
+                        id: 1,
+                        name: 'label',
+                      },
+                      relationships: {},
                     },
-                    relationships: {},
-                  },
-                ],
+                  ],
+                },
               },
-            },
-            {
-              row: {
-                id: 2,
-                issueId: 1,
-                labelId: 2,
-                extra: 'b',
-              },
-              relationships: {
-                labels: () => [
-                  {
-                    row: {
-                      id: 2,
-                      name: 'label2',
+              {
+                row: {
+                  id: 2,
+                  issueId: 1,
+                  labelId: 2,
+                  extra: 'b',
+                },
+                relationships: {
+                  labels: () => [
+                    {
+                      row: {
+                        id: 2,
+                        name: 'label2',
+                      },
+                      relationships: {},
                     },
-                    relationships: {},
-                  },
-                ],
+                  ],
+                },
               },
-            },
-          ],
+            ],
+          },
         },
-      },
-      child: {
-        relationshipName: 'labels',
-        change: {
-          type: 'add',
-          node: {
+        {
+          relationshipName: 'labels',
+          change: makeAddChange({
             row: {
               id: 2,
               issueId: 1,
@@ -928,10 +917,10 @@ test('collapse', () => {
                 },
               ],
             },
-          },
+          }),
         },
-      },
-    }),
+      ),
+    ),
   );
 
   expect(data()).toEqual(data2);
@@ -963,34 +952,59 @@ test('collapse', () => {
 
   // edit the hidden row
   consume(
-    view.push({
-      type: 'child',
-      node: {
-        row: {
-          id: 1,
-          name: 'issue',
-        },
-        relationships: {
-          labels: () => [
-            {
-              row: {
-                id: 1,
-                issueId: 1,
-                labelId: 1,
-                extra: 'a',
-              },
-              relationships: {
-                labels: () => [
-                  {
-                    row: {
-                      id: 1,
-                      name: 'label',
+    view.push(
+      makeChildChange(
+        {
+          row: {
+            id: 1,
+            name: 'issue',
+          },
+          relationships: {
+            labels: () => [
+              {
+                row: {
+                  id: 1,
+                  issueId: 1,
+                  labelId: 1,
+                  extra: 'a',
+                },
+                relationships: {
+                  labels: () => [
+                    {
+                      row: {
+                        id: 1,
+                        name: 'label',
+                      },
+                      relationships: {},
                     },
-                    relationships: {},
-                  },
-                ],
+                  ],
+                },
               },
-            },
+              {
+                row: {
+                  id: 2,
+                  issueId: 1,
+                  labelId: 2,
+                  extra: 'b2',
+                },
+                relationships: {
+                  labels: () => [
+                    {
+                      row: {
+                        id: 2,
+                        name: 'label2',
+                      },
+                      relationships: {},
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+        {
+          relationshipName: 'labels',
+          change: makeEditChange(
             {
               row: {
                 id: 2,
@@ -1010,54 +1024,29 @@ test('collapse', () => {
                 ],
               },
             },
-          ],
-        },
-      },
-      child: {
-        relationshipName: 'labels',
-        change: {
-          type: 'edit',
-          oldNode: {
-            row: {
-              id: 2,
-              issueId: 1,
-              labelId: 2,
-              extra: 'b',
-            },
-            relationships: {
-              labels: () => [
-                {
-                  row: {
-                    id: 2,
-                    name: 'label2',
+            {
+              row: {
+                id: 2,
+                issueId: 1,
+                labelId: 2,
+                extra: 'b',
+              },
+              relationships: {
+                labels: () => [
+                  {
+                    row: {
+                      id: 2,
+                      name: 'label2',
+                    },
+                    relationships: {},
                   },
-                  relationships: {},
-                },
-              ],
+                ],
+              },
             },
-          },
-          node: {
-            row: {
-              id: 2,
-              issueId: 1,
-              labelId: 2,
-              extra: 'b2',
-            },
-            relationships: {
-              labels: () => [
-                {
-                  row: {
-                    id: 2,
-                    name: 'label2',
-                  },
-                  relationships: {},
-                },
-              ],
-            },
-          },
+          ),
         },
-      },
-    }),
+      ),
+    ),
   );
   expect(data()).toEqual(data3);
   commit();
@@ -1088,34 +1077,59 @@ test('collapse', () => {
 
   // edit the leaf
   consume(
-    view.push({
-      type: 'child',
-      node: {
-        row: {
-          id: 1,
-          name: 'issue',
-        },
-        relationships: {
-          labels: () => [
-            {
-              row: {
-                id: 1,
-                issueId: 1,
-                labelId: 1,
-                extra: 'a',
-              },
-              relationships: {
-                labels: () => [
-                  {
-                    row: {
-                      id: 1,
-                      name: 'label',
+    view.push(
+      makeChildChange(
+        {
+          row: {
+            id: 1,
+            name: 'issue',
+          },
+          relationships: {
+            labels: () => [
+              {
+                row: {
+                  id: 1,
+                  issueId: 1,
+                  labelId: 1,
+                  extra: 'a',
+                },
+                relationships: {
+                  labels: () => [
+                    {
+                      row: {
+                        id: 1,
+                        name: 'label',
+                      },
+                      relationships: {},
                     },
-                    relationships: {},
-                  },
-                ],
+                  ],
+                },
               },
-            },
+              {
+                row: {
+                  id: 2,
+                  issueId: 1,
+                  labelId: 2,
+                  extra: 'b2',
+                },
+                relationships: {
+                  labels: () => [
+                    {
+                      row: {
+                        id: 2,
+                        name: 'label2x',
+                      },
+                      relationships: {},
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+        {
+          relationshipName: 'labels',
+          change: makeChildChange(
             {
               row: {
                 id: 2,
@@ -1135,22 +1149,9 @@ test('collapse', () => {
                 ],
               },
             },
-          ],
-        },
-      },
-      child: {
-        relationshipName: 'labels',
-        change: {
-          type: 'child',
-          node: {
-            row: {
-              id: 2,
-              issueId: 1,
-              labelId: 2,
-              extra: 'b2',
-            },
-            relationships: {
-              labels: () => [
+            {
+              relationshipName: 'labels',
+              change: makeEditChange(
                 {
                   row: {
                     id: 2,
@@ -1158,32 +1159,19 @@ test('collapse', () => {
                   },
                   relationships: {},
                 },
-              ],
-            },
-          },
-          child: {
-            relationshipName: 'labels',
-            change: {
-              type: 'edit',
-              oldNode: {
-                row: {
-                  id: 2,
-                  name: 'label2',
+                {
+                  row: {
+                    id: 2,
+                    name: 'label2',
+                  },
+                  relationships: {},
                 },
-                relationships: {},
-              },
-              node: {
-                row: {
-                  id: 2,
-                  name: 'label2x',
-                },
-                relationships: {},
-              },
+              ),
             },
-          },
+          ),
         },
-      },
-    }),
+      ),
+    ),
   );
   expect(data()).toEqual(state4);
   commit();
@@ -1333,12 +1321,7 @@ test('collapse-single', () => {
       },
     },
   } as const;
-  consume(
-    view.push({
-      type: 'add',
-      ...changeSansType,
-    }),
-  );
+  consume(view.push(makeAddChange(changeSansType.node)));
 
   expect(data()).toEqual(data0);
   commit();
@@ -2021,9 +2004,8 @@ test('edit to preserve relationships', () => {
   const data0: unknown[] = [];
   expect(data()).toEqual(data0);
 
-  view.push({
-    type: 'add',
-    node: {
+  view.push(
+    makeAddChange({
       row: {id: 1, title: 'issue1'},
       relationships: {
         labels: () => [
@@ -2033,14 +2015,13 @@ test('edit to preserve relationships', () => {
           },
         ],
       },
-    },
-  });
+    }),
+  );
 
   expect(data()).toEqual(data0);
 
-  view.push({
-    type: 'add',
-    node: {
+  view.push(
+    makeAddChange({
       row: {id: 2, title: 'issue2'},
       relationships: {
         labels: () => [
@@ -2050,8 +2031,8 @@ test('edit to preserve relationships', () => {
           },
         ],
       },
-    },
-  });
+    }),
+  );
 
   expect(data()).toEqual(data0);
   commit();
@@ -2087,14 +2068,12 @@ test('edit to preserve relationships', () => {
   ];
   expect(data()).toEqual(data1);
 
-  view.push({
-    type: 'edit',
-    oldNode: {
-      row: {id: 1, title: 'issue1'},
-      relationships: {},
-    },
-    node: {row: {id: 1, title: 'issue1 changed'}, relationships: {}},
-  });
+  view.push(
+    makeEditChange(
+      {row: {id: 1, title: 'issue1 changed'}, relationships: {}},
+      {row: {id: 1, title: 'issue1'}, relationships: {}},
+    ),
+  );
 
   expect(data()).toEqual(data1);
   commit();
@@ -2132,11 +2111,12 @@ test('edit to preserve relationships', () => {
   expect(data()).toEqual(data2);
 
   // And now edit to change order
-  view.push({
-    type: 'edit',
-    oldNode: {row: {id: 1, title: 'issue1 changed'}, relationships: {}},
-    node: {row: {id: 3, title: 'issue1 is now issue3'}, relationships: {}},
-  });
+  view.push(
+    makeEditChange(
+      {row: {id: 3, title: 'issue1 is now issue3'}, relationships: {}},
+      {row: {id: 1, title: 'issue1 changed'}, relationships: {}},
+    ),
+  );
 
   expect(data()).toEqual(data2);
   commit();
@@ -2267,10 +2247,7 @@ test('edit leaf', () => {
     },
   } as const;
 
-  view.push({
-    type: 'add',
-    ...changeSansType,
-  });
+  view.push(makeAddChange(changeSansType.node));
   expect(data()).toEqual(data0);
   commit();
 
@@ -2294,59 +2271,51 @@ test('edit leaf', () => {
   ];
   expect(data()).toEqual(data1);
 
-  view.push({
-    type: 'remove',
-    ...changeSansType,
-  });
+  view.push(makeRemoveChange(changeSansType.node));
   expect(data()).toEqual(data1);
   commit();
 
   const data2: unknown[] = [];
   expect(data()).toEqual(data2);
 
-  view.push({
-    type: 'add',
-    ...changeSansType,
-  });
+  view.push(makeAddChange(changeSansType.node));
   // no commit
 
   expect(data()).toEqual(data2);
 
-  view.push({
-    type: 'child',
-    node: {
-      row: {
-        id: 1,
-        name: 'issue',
-      },
-      relationships: {
-        labels: () => [
-          {
-            row: {
-              id: 1,
-              issueId: 1,
-              labelId: 1,
-              extra: 'a',
+  view.push(
+    makeChildChange(
+      {
+        row: {
+          id: 1,
+          name: 'issue',
+        },
+        relationships: {
+          labels: () => [
+            {
+              row: {
+                id: 1,
+                issueId: 1,
+                labelId: 1,
+                extra: 'a',
+              },
+              relationships: {},
             },
-            relationships: {},
-          },
-          {
-            row: {
-              id: 2,
-              issueId: 1,
-              labelId: 2,
-              extra: 'b',
+            {
+              row: {
+                id: 2,
+                issueId: 1,
+                labelId: 2,
+                extra: 'b',
+              },
+              relationships: {},
             },
-            relationships: {},
-          },
-        ],
+          ],
+        },
       },
-    },
-    child: {
-      relationshipName: 'labels',
-      change: {
-        type: 'add',
-        node: {
+      {
+        relationshipName: 'labels',
+        change: makeAddChange({
           row: {
             id: 2,
             issueId: 1,
@@ -2354,10 +2323,10 @@ test('edit leaf', () => {
             extra: 'b',
           },
           relationships: {},
-        },
+        }),
       },
-    },
-  });
+    ),
+  );
 
   expect(data()).toEqual(data2);
   commit();
@@ -2391,24 +2360,39 @@ test('edit leaf', () => {
   expect(data()).toEqual(data3);
 
   // edit leaf
-  view.push({
-    type: 'child',
-    node: {
-      row: {
-        id: 1,
-        name: 'issue',
-      },
-      relationships: {
-        labels: () => [
-          {
-            row: {
-              id: 1,
-              issueId: 1,
-              labelId: 1,
-              extra: 'a',
+  view.push(
+    makeChildChange(
+      {
+        row: {
+          id: 1,
+          name: 'issue',
+        },
+        relationships: {
+          labels: () => [
+            {
+              row: {
+                id: 1,
+                issueId: 1,
+                labelId: 1,
+                extra: 'a',
+              },
+              relationships: {},
             },
-            relationships: {},
-          },
+            {
+              row: {
+                id: 2,
+                issueId: 1,
+                labelId: 2,
+                extra: 'b2',
+              },
+              relationships: {},
+            },
+          ],
+        },
+      },
+      {
+        relationshipName: 'labels',
+        change: makeEditChange(
           {
             row: {
               id: 2,
@@ -2418,34 +2402,19 @@ test('edit leaf', () => {
             },
             relationships: {},
           },
-        ],
-      },
-    },
-    child: {
-      relationshipName: 'labels',
-      change: {
-        type: 'edit',
-        oldNode: {
-          row: {
-            id: 2,
-            issueId: 1,
-            labelId: 2,
-            extra: 'b',
+          {
+            row: {
+              id: 2,
+              issueId: 1,
+              labelId: 2,
+              extra: 'b',
+            },
+            relationships: {},
           },
-          relationships: {},
-        },
-        node: {
-          row: {
-            id: 2,
-            issueId: 1,
-            labelId: 2,
-            extra: 'b2',
-          },
-          relationships: {},
-        },
+        ),
       },
-    },
-  });
+    ),
+  );
   expect(data()).toEqual(data3);
   commit();
 

--- a/packages/zero-solid/src/solid-view.ts
+++ b/packages/zero-solid/src/solid-view.ts
@@ -1,5 +1,7 @@
 import {produce, reconcile, type SetStoreFunction} from 'solid-js/store';
 import {emptyArray} from '../../shared/src/sentinels.ts';
+import {ChangeIndex} from '../../zql/src/ivm/change-index.ts';
+import {ChangeType} from '../../zql/src/ivm/change-type.ts';
 import {
   applyChange,
   idSymbol,
@@ -156,7 +158,10 @@ export class SolidView implements Output {
     // using produce at the end of the transaction but read the relationships
     // now as they are only valid to read when the push is received.
     if (this.#builderRoot) {
-      this.#applyChangeToRoot(change, this.#builderRoot);
+      this.#applyChangeToRoot(
+        materializeRelationships(change),
+        this.#builderRoot,
+      );
     } else {
       this.#pendingChanges.push(materializeRelationships(change));
     }
@@ -207,25 +212,33 @@ export class SolidView implements Output {
 }
 
 function materializeRelationships(change: Change): ViewChange {
-  switch (change.type) {
-    case 'add':
-      return {type: 'add', node: materializeNodeRelationships(change.node)};
-    case 'remove':
-      return {type: 'remove', node: materializeNodeRelationships(change.node)};
-    case 'child':
+  switch (change[ChangeIndex.TYPE]) {
+    case ChangeType.ADD:
+      return {
+        type: 'add',
+        node: materializeNodeRelationships(change[ChangeIndex.NODE]),
+      };
+    case ChangeType.REMOVE:
+      return {
+        type: 'remove',
+        node: materializeNodeRelationships(change[ChangeIndex.NODE]),
+      };
+    case ChangeType.CHILD:
       return {
         type: 'child',
-        node: {row: change.node.row},
+        node: {row: change[ChangeIndex.NODE].row},
         child: {
-          relationshipName: change.child.relationshipName,
-          change: materializeRelationships(change.child.change),
+          relationshipName: change[ChangeIndex.CHILD_DATA].relationshipName,
+          change: materializeRelationships(
+            change[ChangeIndex.CHILD_DATA].change,
+          ),
         },
       };
-    case 'edit':
+    case ChangeType.EDIT:
       return {
         type: 'edit',
-        node: {row: change.node.row},
-        oldNode: {row: change.oldNode.row},
+        node: {row: change[ChangeIndex.NODE].row},
+        oldNode: {row: change[ChangeIndex.OLD_NODE].row},
       };
   }
 }

--- a/packages/zero-solid/src/use-query.test.tsx
+++ b/packages/zero-solid/src/use-query.test.tsx
@@ -21,6 +21,10 @@ import {
 import {useQuery, type QueryResult, type UseQueryOptions} from './use-query.ts';
 import {ZeroProvider} from './use-zero.ts';
 import {
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+} from '../../zql/src/ivm/source.ts';
+import {
   createSchema,
   number,
   relationships,
@@ -52,8 +56,8 @@ function setupTestEnvironment() {
     schema.tables.table.columns,
     schema.tables.table.primaryKey,
   );
-  consume(ms.push({row: {a: 1, b: 'a'}, type: 'add'}));
-  consume(ms.push({row: {a: 2, b: 'b'}, type: 'add'}));
+  consume(ms.push(makeSourceChangeAdd({a: 1, b: 'a'})));
+  consume(ms.push(makeSourceChangeAdd({a: 2, b: 'b'})));
 
   const queryDelegate = new QueryDelegateImpl({sources: {table: ms}});
   const tableQuery = newQuery(schema, 'table');
@@ -138,7 +142,7 @@ test('useQuery', async () => {
   must(queryDelegate.gotCallbacks[0])(true);
   await Promise.resolve();
 
-  consume(ms.push({row: {a: 3, b: 'c'}, type: 'add'}));
+  consume(ms.push(makeSourceChangeAdd({a: 3, b: 'c'})));
   queryDelegate.commit();
 
   expect(rows()).toEqual([
@@ -400,10 +404,10 @@ test('useQuery query deps change, reconcile minimizes reactive updates, tree', a
     schema.tables.comment.columns,
     schema.tables.comment.primaryKey,
   );
-  consume(issueSource.push({row: {id: 'i1'}, type: 'add'}));
-  consume(issueSource.push({row: {id: 'i2'}, type: 'add'}));
-  consume(commentSource.push({row: {id: 'c1', issueID: 'i1'}, type: 'add'}));
-  consume(commentSource.push({row: {id: 'c2', issueID: 'i1'}, type: 'add'}));
+  consume(issueSource.push(makeSourceChangeAdd({id: 'i1'})));
+  consume(issueSource.push(makeSourceChangeAdd({id: 'i2'})));
+  consume(commentSource.push(makeSourceChangeAdd({id: 'c1', issueID: 'i1'})));
+  consume(commentSource.push(makeSourceChangeAdd({id: 'c2', issueID: 'i1'})));
 
   const queryDelegate = new QueryDelegateImpl({
     sources: {issue: issueSource, comment: commentSource},
@@ -691,9 +695,7 @@ test('useQuery query deps change testEffect', () => {
         expect(rows()).toEqual([
           {a: 1, b: 'a', [refCountSymbol]: 1, [idSymbol]: '1'},
         ]);
-        consume(
-          ms.push({type: 'edit', oldRow: {a: 1, b: 'a'}, row: {a: 1, b: 'a2'}}),
-        );
+        consume(ms.push(makeSourceChangeEdit({a: 1, b: 'a2'}, {a: 1, b: 'a'})));
         queryDelegate.commit();
       } else if (run === 1) {
         expect(rows()).toEqual([

--- a/packages/zero-solid/src/use-query.test.tsx
+++ b/packages/zero-solid/src/use-query.test.tsx
@@ -8,6 +8,10 @@ import {
 } from 'solid-js';
 import {afterEach, describe, expect, expectTypeOf, test, vi} from 'vitest';
 import {MemorySource} from '../../zql/src/ivm/memory-source.ts';
+import {
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+} from '../../zql/src/ivm/source.ts';
 import {QueryDelegateImpl} from '../../zql/src/query/test/query-delegate.ts';
 import {
   assert,
@@ -20,10 +24,6 @@ import {
 } from './bindings.ts';
 import {useQuery, type QueryResult, type UseQueryOptions} from './use-query.ts';
 import {ZeroProvider} from './use-zero.ts';
-import {
-  makeSourceChangeAdd,
-  makeSourceChangeEdit,
-} from '../../zql/src/ivm/source.ts';
 import {
   createSchema,
   number,

--- a/packages/zql-benchmarks/src/chinook-push.bench.ts
+++ b/packages/zql-benchmarks/src/chinook-push.bench.ts
@@ -9,6 +9,10 @@ import {
 } from '../../zql-integration-tests/src/helpers/runner.ts';
 import type {PullRow} from '../../zql/src/query/query.ts';
 
+import {
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+} from '../../zql/src/ivm/source.ts';
 const pgContent = await getChinook();
 
 function defaultTrack(id: number): PullRow<'track', typeof schema> {
@@ -41,40 +45,20 @@ await runBenchmarks(
       name: 'push into unlimited query',
       createQuery: q => q.track,
       generatePush: i => [
-        [
-          'track',
-          {
-            type: 'add',
-            row: defaultTrack(i + 10_000),
-          },
-        ],
+        ['track', makeSourceChangeAdd(defaultTrack(i + 10_000))],
       ],
     },
     {
       name: 'push into limited query, outside the bound',
       createQuery: q => q.track.limit(100),
       generatePush: i => [
-        [
-          'track',
-          {
-            type: 'add',
-            row: defaultTrack(i + 10_000),
-          },
-        ],
+        ['track', makeSourceChangeAdd(defaultTrack(i + 10_000))],
       ],
     },
     {
       name: 'push into limited query, inside the bound',
       createQuery: q => q.track.limit(100),
-      generatePush: i => [
-        [
-          'track',
-          {
-            type: 'add',
-            row: defaultTrack(-1 * i),
-          },
-        ],
-      ],
+      generatePush: i => [['track', makeSourceChangeAdd(defaultTrack(-1 * i))]],
     },
     {
       name: 'edit for limited query, outside the bound',
@@ -135,10 +119,6 @@ function makeEdit() {
       [column]: value,
     };
     currentValues.set(key, newRow);
-    return {
-      type: 'edit',
-      oldRow: row,
-      row: newRow,
-    } as const;
+    return makeSourceChangeEdit(newRow, row);
   };
 }

--- a/packages/zql-benchmarks/src/frontend-analysis.pg.test.ts
+++ b/packages/zql-benchmarks/src/frontend-analysis.pg.test.ts
@@ -4,10 +4,10 @@ import {expect, test} from 'vitest';
 import type {JSONValue} from '../../shared/src/json.ts';
 import {must} from '../../shared/src/must.ts';
 import type {Row} from '../../zero-protocol/src/data.ts';
-import {makeSourceChangeEdit} from '../../zql/src/ivm/source.ts';
 import {getChinook} from '../../zql-integration-tests/src/chinook/get-deps.ts';
 import {schema} from '../../zql-integration-tests/src/chinook/schema.ts';
 import {bootstrap} from '../../zql-integration-tests/src/helpers/runner.ts';
+import {makeSourceChangeEdit} from '../../zql/src/ivm/source.ts';
 import type {AnyQuery} from '../../zql/src/query/query.ts';
 
 const pgContent = await getChinook();

--- a/packages/zql-benchmarks/src/frontend-analysis.pg.test.ts
+++ b/packages/zql-benchmarks/src/frontend-analysis.pg.test.ts
@@ -4,6 +4,7 @@ import {expect, test} from 'vitest';
 import type {JSONValue} from '../../shared/src/json.ts';
 import {must} from '../../shared/src/must.ts';
 import type {Row} from '../../zero-protocol/src/data.ts';
+import {makeSourceChangeEdit} from '../../zql/src/ivm/source.ts';
 import {getChinook} from '../../zql-integration-tests/src/chinook/get-deps.ts';
 import {schema} from '../../zql-integration-tests/src/chinook/schema.ts';
 import {bootstrap} from '../../zql-integration-tests/src/helpers/runner.ts';
@@ -372,11 +373,7 @@ function makeEdit() {
       [column]: value,
     };
     currentValues.set(key, newRow);
-    return {
-      type: 'edit',
-      oldRow: row,
-      row: newRow,
-    } as const;
+    return makeSourceChangeEdit(newRow, row);
   };
 }
 

--- a/packages/zql-benchmarks/src/ivm-memory.bench.ts
+++ b/packages/zql-benchmarks/src/ivm-memory.bench.ts
@@ -15,6 +15,10 @@ import {MemorySource} from '../../zql/src/ivm/memory-source.ts';
 import {QueryDelegateImpl} from '../../zql/src/query/test/query-delegate.ts';
 import {builder, schema} from './schema.ts';
 
+import {
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+} from '../../zql/src/ivm/source.ts';
 // ---- Data sizes -------------------------------------------------------------
 // Keep small to run fast; increase for more stable results.
 
@@ -39,7 +43,7 @@ function makeSources() {
   }
 
   function add(tableName: string, row: Row) {
-    for (const _ of sources[tableName].push({type: 'add', row})) {
+    for (const _ of sources[tableName].push(makeSourceChangeAdd(row))) {
       /* consume */
     }
   }
@@ -183,7 +187,7 @@ describe('push', () => {
         description: 'Pushed issue',
         visibility: 'public',
       };
-      for (const _ of sources['issue'].push({type: 'add', row})) {
+      for (const _ of sources['issue'].push(makeSourceChangeAdd(row))) {
         /* consume */
       }
     };
@@ -209,7 +213,7 @@ describe('push', () => {
         description: 'Pushed issue',
         visibility: 'public',
       };
-      for (const _ of sources['issue'].push({type: 'add', row})) {
+      for (const _ of sources['issue'].push(makeSourceChangeAdd(row))) {
         /* consume */
       }
     };
@@ -226,19 +230,15 @@ describe('push', () => {
       const idx = editCount % NUM_ISSUES;
       const oldRow = issues[idx];
       const newRow = {...oldRow, title: `Edited ${editCount++}`};
-      for (const _ of sources['issue'].push({
-        type: 'edit',
-        oldRow: oldRow as Row,
-        row: newRow,
-      })) {
+      for (const _ of sources['issue'].push(
+        makeSourceChangeEdit(newRow, oldRow as Row),
+      )) {
         /* consume */
       }
       // restore
-      for (const _ of sources['issue'].push({
-        type: 'edit',
-        oldRow: newRow,
-        row: oldRow as Row,
-      })) {
+      for (const _ of sources['issue'].push(
+        makeSourceChangeEdit(oldRow as Row, newRow),
+      )) {
         /* consume */
       }
     };
@@ -258,7 +258,7 @@ describe('push', () => {
         body: 'A new comment',
         creatorID: 'user-0',
       };
-      for (const _ of sources['comment'].push({type: 'add', row})) {
+      for (const _ of sources['comment'].push(makeSourceChangeAdd(row))) {
         /* consume */
       }
     };
@@ -285,7 +285,7 @@ describe('push', () => {
         description: 'Front of list',
         visibility: 'public',
       };
-      for (const _ of sources['issue'].push({type: 'add', row})) {
+      for (const _ of sources['issue'].push(makeSourceChangeAdd(row))) {
         /* consume */
       }
     };
@@ -312,7 +312,7 @@ describe('push', () => {
         description: 'End of list',
         visibility: 'public',
       };
-      for (const _ of sources['issue'].push({type: 'add', row})) {
+      for (const _ of sources['issue'].push(makeSourceChangeAdd(row))) {
         /* consume */
       }
     };

--- a/packages/zql-benchmarks/src/memory-ivm-deopt.bench.ts
+++ b/packages/zql-benchmarks/src/memory-ivm-deopt.bench.ts
@@ -19,6 +19,11 @@ import {Filter} from '../../zql/src/ivm/filter.ts';
 import {Join} from '../../zql/src/ivm/join.ts';
 import {MemorySource} from '../../zql/src/ivm/memory-source.ts';
 
+import {
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+  makeSourceChangeRemove,
+} from '../../zql/src/ivm/source.ts';
 const noopDelegate = {addEdge() {}} as unknown as BuilderDelegate;
 
 // ---- Schema definitions ----
@@ -92,7 +97,7 @@ describe('MemorySource fetch', () => {
   bench(`scan ${ISSUE_COUNT} rows, sort 1 key`, function* () {
     const src = new MemorySource('issue', issueColumns, ['id']);
     for (let i = 0; i < ISSUE_COUNT; i++) {
-      for (const _ of src.push({type: 'add', row: makeIssueRow(i)})) {
+      for (const _ of src.push(makeSourceChangeAdd(makeIssueRow(i)))) {
         /* consume */
       }
     }
@@ -107,7 +112,7 @@ describe('MemorySource fetch', () => {
   bench(`scan ${ISSUE_COUNT} rows, sort 2 keys`, function* () {
     const src = new MemorySource('issue', issueColumns, ['id']);
     for (let i = 0; i < ISSUE_COUNT; i++) {
-      for (const _ of src.push({type: 'add', row: makeIssueRow(i)})) {
+      for (const _ of src.push(makeSourceChangeAdd(makeIssueRow(i)))) {
         /* consume */
       }
     }
@@ -125,7 +130,7 @@ describe('MemorySource fetch', () => {
   bench(`scan ${ISSUE_COUNT} rows, sort 4 keys`, function* () {
     const src = new MemorySource('issue', issueColumns, ['id']);
     for (let i = 0; i < ISSUE_COUNT; i++) {
-      for (const _ of src.push({type: 'add', row: makeIssueRow(i)})) {
+      for (const _ of src.push(makeSourceChangeAdd(makeIssueRow(i)))) {
         /* consume */
       }
     }
@@ -149,7 +154,7 @@ describe('MemorySource push', () => {
   bench(`add/remove over ${ISSUE_COUNT} rows, sort 1 key`, function* () {
     const src = new MemorySource('issue', issueColumns, ['id']);
     for (let i = 0; i < ISSUE_COUNT; i++) {
-      for (const _ of src.push({type: 'add', row: makeIssueRow(i)})) {
+      for (const _ of src.push(makeSourceChangeAdd(makeIssueRow(i)))) {
         /* consume */
       }
     }
@@ -159,10 +164,10 @@ describe('MemorySource push', () => {
     let idx = ISSUE_COUNT;
     yield () => {
       const row = makeIssueRow(idx++);
-      for (const _ of src.push({type: 'add', row})) {
+      for (const _ of src.push(makeSourceChangeAdd(row))) {
         /* consume */
       }
-      for (const _ of src.push({type: 'remove', row})) {
+      for (const _ of src.push(makeSourceChangeRemove(row))) {
         /* consume */
       }
     };
@@ -171,7 +176,7 @@ describe('MemorySource push', () => {
   bench(`add/remove over ${ISSUE_COUNT} rows, sort 2 keys`, function* () {
     const src = new MemorySource('issue', issueColumns, ['id']);
     for (let i = 0; i < ISSUE_COUNT; i++) {
-      for (const _ of src.push({type: 'add', row: makeIssueRow(i)})) {
+      for (const _ of src.push(makeSourceChangeAdd(makeIssueRow(i)))) {
         /* consume */
       }
     }
@@ -184,10 +189,10 @@ describe('MemorySource push', () => {
     let idx = ISSUE_COUNT;
     yield () => {
       const row = makeIssueRow(idx++);
-      for (const _ of src.push({type: 'add', row})) {
+      for (const _ of src.push(makeSourceChangeAdd(row))) {
         /* consume */
       }
-      for (const _ of src.push({type: 'remove', row})) {
+      for (const _ of src.push(makeSourceChangeRemove(row))) {
         /* consume */
       }
     };
@@ -196,7 +201,7 @@ describe('MemorySource push', () => {
   bench(`add/remove over ${ISSUE_COUNT} rows, sort 4 keys`, function* () {
     const src = new MemorySource('issue', issueColumns, ['id']);
     for (let i = 0; i < ISSUE_COUNT; i++) {
-      for (const _ of src.push({type: 'add', row: makeIssueRow(i)})) {
+      for (const _ of src.push(makeSourceChangeAdd(makeIssueRow(i)))) {
         /* consume */
       }
     }
@@ -211,10 +216,10 @@ describe('MemorySource push', () => {
     let idx = ISSUE_COUNT;
     yield () => {
       const row = makeIssueRow(idx++);
-      for (const _ of src.push({type: 'add', row})) {
+      for (const _ of src.push(makeSourceChangeAdd(row))) {
         /* consume */
       }
-      for (const _ of src.push({type: 'remove', row})) {
+      for (const _ of src.push(makeSourceChangeRemove(row))) {
         /* consume */
       }
     };
@@ -226,7 +231,7 @@ describe('MemorySource push', () => {
     for (let i = 0; i < ISSUE_COUNT; i++) {
       const row = makeIssueRow(i);
       rows.push(row);
-      for (const _ of src.push({type: 'add', row})) {
+      for (const _ of src.push(makeSourceChangeAdd(row))) {
         /* consume */
       }
     }
@@ -238,10 +243,10 @@ describe('MemorySource push', () => {
       const oldRow = rows[idx % rows.length];
       idx++;
       const newRow = {...oldRow, title: `Updated ${idx}`};
-      for (const _ of src.push({type: 'edit', oldRow, row: newRow})) {
+      for (const _ of src.push(makeSourceChangeEdit(newRow, oldRow))) {
         /* consume */
       }
-      for (const _ of src.push({type: 'edit', oldRow: newRow, row: oldRow})) {
+      for (const _ of src.push(makeSourceChangeEdit(oldRow, newRow))) {
         /* consume */
       }
     };
@@ -253,7 +258,7 @@ describe('MemorySource push', () => {
     for (let i = 0; i < ISSUE_COUNT; i++) {
       const row = makeIssueRow(i);
       rows.push(row);
-      for (const _ of src.push({type: 'add', row})) {
+      for (const _ of src.push(makeSourceChangeAdd(row))) {
         /* consume */
       }
     }
@@ -268,10 +273,10 @@ describe('MemorySource push', () => {
       const oldRow = rows[idx % rows.length];
       idx++;
       const newRow = {...oldRow, title: `Updated ${idx}`};
-      for (const _ of src.push({type: 'edit', oldRow, row: newRow})) {
+      for (const _ of src.push(makeSourceChangeEdit(newRow, oldRow))) {
         /* consume */
       }
-      for (const _ of src.push({type: 'edit', oldRow: newRow, row: oldRow})) {
+      for (const _ of src.push(makeSourceChangeEdit(oldRow, newRow))) {
         /* consume */
       }
     };
@@ -283,7 +288,7 @@ describe('MemorySource push', () => {
     for (let i = 0; i < ISSUE_COUNT; i++) {
       const row = makeIssueRow(i);
       rows.push(row);
-      for (const _ of src.push({type: 'add', row})) {
+      for (const _ of src.push(makeSourceChangeAdd(row))) {
         /* consume */
       }
     }
@@ -300,10 +305,10 @@ describe('MemorySource push', () => {
       const oldRow = rows[idx % rows.length];
       idx++;
       const newRow = {...oldRow, title: `Updated ${idx}`};
-      for (const _ of src.push({type: 'edit', oldRow, row: newRow})) {
+      for (const _ of src.push(makeSourceChangeEdit(newRow, oldRow))) {
         /* consume */
       }
-      for (const _ of src.push({type: 'edit', oldRow: newRow, row: oldRow})) {
+      for (const _ of src.push(makeSourceChangeEdit(oldRow, newRow))) {
         /* consume */
       }
     };
@@ -316,7 +321,7 @@ describe('Filter', () => {
   bench(`fetch open issues (${ISSUE_COUNT} total)`, function* () {
     const src = new MemorySource('issue', issueColumns, ['id']);
     for (let i = 0; i < ISSUE_COUNT; i++) {
-      for (const _ of src.push({type: 'add', row: makeIssueRow(i)})) {
+      for (const _ of src.push(makeSourceChangeAdd(makeIssueRow(i)))) {
         /* consume */
       }
     }
@@ -339,7 +344,7 @@ describe('Filter', () => {
   bench('push add open issue (passes filter)', function* () {
     const src = new MemorySource('issue', issueColumns, ['id']);
     for (let i = 0; i < ISSUE_COUNT; i++) {
-      for (const _ of src.push({type: 'add', row: makeIssueRow(i)})) {
+      for (const _ of src.push(makeSourceChangeAdd(makeIssueRow(i)))) {
         /* consume */
       }
     }
@@ -358,10 +363,10 @@ describe('Filter', () => {
     yield () => {
       const row = makeIssueRow(idx++);
       (row as Record<string, unknown>)['closed'] = false;
-      for (const _ of src.push({type: 'add', row})) {
+      for (const _ of src.push(makeSourceChangeAdd(row))) {
         /* consume */
       }
-      for (const _ of src.push({type: 'remove', row})) {
+      for (const _ of src.push(makeSourceChangeRemove(row))) {
         /* consume */
       }
     };
@@ -370,7 +375,7 @@ describe('Filter', () => {
   bench('push add closed issue (filtered out)', function* () {
     const src = new MemorySource('issue', issueColumns, ['id']);
     for (let i = 0; i < ISSUE_COUNT; i++) {
-      for (const _ of src.push({type: 'add', row: makeIssueRow(i)})) {
+      for (const _ of src.push(makeSourceChangeAdd(makeIssueRow(i)))) {
         /* consume */
       }
     }
@@ -389,10 +394,10 @@ describe('Filter', () => {
     yield () => {
       const row = makeIssueRow(idx++);
       (row as Record<string, unknown>)['closed'] = true;
-      for (const _ of src.push({type: 'add', row})) {
+      for (const _ of src.push(makeSourceChangeAdd(row))) {
         /* consume */
       }
-      for (const _ of src.push({type: 'remove', row})) {
+      for (const _ of src.push(makeSourceChangeRemove(row))) {
         /* consume */
       }
     };
@@ -407,12 +412,12 @@ describe('Join', () => {
     const userSrc = new MemorySource('user', userColumns, ['id']);
 
     for (let i = 0; i < USER_COUNT; i++) {
-      for (const _ of userSrc.push({type: 'add', row: makeUserRow(i)})) {
+      for (const _ of userSrc.push(makeSourceChangeAdd(makeUserRow(i)))) {
         /* consume */
       }
     }
     for (let i = 0; i < ISSUE_COUNT; i++) {
-      for (const _ of issueSrc.push({type: 'add', row: makeIssueRow(i)})) {
+      for (const _ of issueSrc.push(makeSourceChangeAdd(makeIssueRow(i)))) {
         /* consume */
       }
     }
@@ -443,12 +448,12 @@ describe('Join', () => {
     const userSrc = new MemorySource('user', userColumns, ['id']);
 
     for (let i = 0; i < USER_COUNT; i++) {
-      for (const _ of userSrc.push({type: 'add', row: makeUserRow(i)})) {
+      for (const _ of userSrc.push(makeSourceChangeAdd(makeUserRow(i)))) {
         /* consume */
       }
     }
     for (let i = 0; i < ISSUE_COUNT; i++) {
-      for (const _ of issueSrc.push({type: 'add', row: makeIssueRow(i)})) {
+      for (const _ of issueSrc.push(makeSourceChangeAdd(makeIssueRow(i)))) {
         /* consume */
       }
     }
@@ -473,10 +478,10 @@ describe('Join', () => {
     let idx = ISSUE_COUNT;
     yield () => {
       const row = makeIssueRow(idx++);
-      for (const _ of issueSrc.push({type: 'add', row})) {
+      for (const _ of issueSrc.push(makeSourceChangeAdd(row))) {
         /* consume */
       }
-      for (const _ of issueSrc.push({type: 'remove', row})) {
+      for (const _ of issueSrc.push(makeSourceChangeRemove(row))) {
         /* consume */
       }
     };
@@ -487,7 +492,7 @@ describe('Join', () => {
     const userSrc = new MemorySource('user', userColumns, ['id']);
 
     for (let i = 0; i < USER_COUNT; i++) {
-      for (const _ of userSrc.push({type: 'add', row: makeUserRow(i)})) {
+      for (const _ of userSrc.push(makeSourceChangeAdd(makeUserRow(i)))) {
         /* consume */
       }
     }
@@ -495,7 +500,7 @@ describe('Join', () => {
     for (let i = 0; i < ISSUE_COUNT; i++) {
       const row = makeIssueRow(i);
       issueRows.push(row);
-      for (const _ of issueSrc.push({type: 'add', row})) {
+      for (const _ of issueSrc.push(makeSourceChangeAdd(row))) {
         /* consume */
       }
     }
@@ -522,14 +527,10 @@ describe('Join', () => {
       const oldRow = issueRows[idx % issueRows.length];
       idx++;
       const newRow = {...oldRow, title: `Updated ${idx}`};
-      for (const _ of issueSrc.push({type: 'edit', oldRow, row: newRow})) {
+      for (const _ of issueSrc.push(makeSourceChangeEdit(newRow, oldRow))) {
         /* consume */
       }
-      for (const _ of issueSrc.push({
-        type: 'edit',
-        oldRow: newRow,
-        row: oldRow,
-      })) {
+      for (const _ of issueSrc.push(makeSourceChangeEdit(oldRow, newRow))) {
         /* consume */
       }
     };

--- a/packages/zql-benchmarks/vitest.config.bench.ts
+++ b/packages/zql-benchmarks/vitest.config.bench.ts
@@ -1,7 +1,16 @@
 import {mergeConfig} from 'vitest/config';
 import {benchConfig} from '../shared/src/tool/vitest-config.ts';
+import {ChangeIndex} from '../zql/src/ivm/change-index.ts';
+import {ChangeType} from '../zql/src/ivm/change-type.ts';
 
 export default mergeConfig(benchConfig, {
+  define: {
+    // These are hot and in benchmarks Vitest doesn't do a good job of inlining
+    // them, so we inline them ourselves here.
+    ...defineFromEnum('ChangeType', ChangeType),
+    ...defineFromEnum('ChangeIndex', ChangeIndex),
+  },
+
   test: {
     name: 'zql-benchmarks/bench',
     globalSetup: ['../zero-cache/test/pg-17.ts'],
@@ -11,3 +20,18 @@ export default mergeConfig(benchConfig, {
     passWithNoTests: true,
   },
 });
+
+function defineFromEnum<Name extends string, E extends {[key: string]: number}>(
+  name: Name,
+  enumObj: E,
+): {
+  [K in keyof E as `${Name}.${string & K}`]: `${E[K]}`;
+} {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(enumObj)) {
+    result[`${name}.${key}`] = `${value}`;
+  }
+  return result as {
+    [K in keyof E as `${Name}.${string & K}`]: `${E[K]}`;
+  };
+}

--- a/packages/zql-benchmarks/vitest.config.bench.ts
+++ b/packages/zql-benchmarks/vitest.config.bench.ts
@@ -2,6 +2,7 @@ import {mergeConfig} from 'vitest/config';
 import {benchConfig} from '../shared/src/tool/vitest-config.ts';
 import {ChangeIndex} from '../zql/src/ivm/change-index.ts';
 import {ChangeType} from '../zql/src/ivm/change-type.ts';
+import {SourceChangeIndex} from '../zql/src/ivm/source-change-index.ts';
 
 export default mergeConfig(benchConfig, {
   define: {
@@ -9,6 +10,7 @@ export default mergeConfig(benchConfig, {
     // them, so we inline them ourselves here.
     ...defineFromEnum('ChangeType', ChangeType),
     ...defineFromEnum('ChangeIndex', ChangeIndex),
+    ...defineFromEnum('SourceChangeIndex', SourceChangeIndex),
   },
 
   test: {

--- a/packages/zql-integration-tests/src/cap.pg.test.ts
+++ b/packages/zql-integration-tests/src/cap.pg.test.ts
@@ -14,6 +14,10 @@ import {createTableSQL, schema} from '../../zql/src/query/test/test-schemas.ts';
 import {Database} from '../../zqlite/src/db.ts';
 import {newQueryDelegate} from '../../zqlite/src/test/source-factory.ts';
 
+import {
+  makeSourceChangeAdd,
+  makeSourceChangeRemove,
+} from '../../zql/src/ivm/source.ts';
 const lc = createSilentLogContext();
 
 let pg: PostgresDB;
@@ -101,16 +105,15 @@ test('add comment to commentless issue → issue appears', () => {
   const view = queryDelegate.materialize(q);
 
   consume(
-    must(queryDelegate.getSource('comments')).push({
-      type: 'add',
-      row: {
+    must(queryDelegate.getSource('comments')).push(
+      makeSourceChangeAdd({
         id: 'c1a',
         authorId: 'user1',
         issue_id: 'issue1',
         text: 'Comment 1a',
         createdAt: 1100000000000,
-      },
-    }),
+      }),
+    ),
   );
 
   const data = view.data as ReadonlyArray<{readonly id: string}>;
@@ -125,16 +128,15 @@ test('add beyond cap limit → issue stays, related shows all', () => {
 
   // issue3 had 3 comments (at cap). Add a 4th.
   consume(
-    must(queryDelegate.getSource('comments')).push({
-      type: 'add',
-      row: {
+    must(queryDelegate.getSource('comments')).push(
+      makeSourceChangeAdd({
         id: 'c3d',
         authorId: 'user1',
         issue_id: 'issue3',
         text: 'Comment 3d',
         createdAt: 1100000001000,
-      },
-    }),
+      }),
+    ),
   );
 
   const data = view.data as ReadonlyArray<{
@@ -156,16 +158,15 @@ test('remove tracked comment with overflow → issue stays', () => {
 
   // issue4 has 5 comments. Remove c4a (tracked by cap). Cap refills from overflow.
   consume(
-    must(queryDelegate.getSource('comments')).push({
-      type: 'remove',
-      row: {
+    must(queryDelegate.getSource('comments')).push(
+      makeSourceChangeRemove({
         id: 'c4a',
         authorId: 'user1',
         issue_id: 'issue4',
         text: 'Comment 4a',
         createdAt: 1015027200000,
-      },
-    }),
+      }),
+    ),
   );
 
   const data = view.data as ReadonlyArray<{readonly id: string}>;
@@ -180,16 +181,15 @@ test('remove untracked overflow comment → issue stays', () => {
 
   // Remove c4e (overflow, not tracked by cap)
   consume(
-    must(queryDelegate.getSource('comments')).push({
-      type: 'remove',
-      row: {
+    must(queryDelegate.getSource('comments')).push(
+      makeSourceChangeRemove({
         id: 'c4e',
         authorId: 'user1',
         issue_id: 'issue4',
         text: 'Comment 4e',
         createdAt: 1015372800000,
-      },
-    }),
+      }),
+    ),
   );
 
   const data = view.data as ReadonlyArray<{readonly id: string}>;
@@ -204,16 +204,15 @@ test('remove only comment → issue disappears', () => {
 
   // Remove c1a from issue1 (the only comment, added in test 2)
   consume(
-    must(queryDelegate.getSource('comments')).push({
-      type: 'remove',
-      row: {
+    must(queryDelegate.getSource('comments')).push(
+      makeSourceChangeRemove({
         id: 'c1a',
         authorId: 'user1',
         issue_id: 'issue1',
         text: 'Comment 1a',
         createdAt: 1100000000000,
-      },
-    }),
+      }),
+    ),
   );
 
   const data = view.data as ReadonlyArray<{readonly id: string}>;
@@ -227,16 +226,15 @@ test('re-add comment → issue reappears', () => {
   const view = queryDelegate.materialize(q);
 
   consume(
-    must(queryDelegate.getSource('comments')).push({
-      type: 'add',
-      row: {
+    must(queryDelegate.getSource('comments')).push(
+      makeSourceChangeAdd({
         id: 'c1b',
         authorId: 'user1',
         issue_id: 'issue1',
         text: 'Comment 1b',
         createdAt: 1100000002000,
-      },
-    }),
+      }),
+    ),
   );
 
   const data = view.data as ReadonlyArray<{readonly id: string}>;
@@ -303,7 +301,7 @@ test('join-level unordered overlay — remove comment triggers overlay for multi
 
   const source = must(queryDelegate.getSource('comments'));
   for (const row of commentsToRemove) {
-    consume(source.push({type: 'remove', row}));
+    consume(source.push(makeSourceChangeRemove(row)));
     expect(view.data).toEqual(queryDelegate.materialize(q).data);
   }
 });

--- a/packages/zql-integration-tests/src/child-merge.pg.test.ts
+++ b/packages/zql-integration-tests/src/child-merge.pg.test.ts
@@ -6,6 +6,7 @@ import {must} from '../../shared/src/must.ts';
 import {initialSync} from '../../zero-cache/src/services/change-source/pg/initial-sync.ts';
 import {getConnectionURI, testDBs} from '../../zero-cache/src/test/db.ts';
 import type {PostgresDB} from '../../zero-cache/src/types/pg.ts';
+import {makeSourceChangeAdd} from '../../zql/src/ivm/source.ts';
 import {consume} from '../../zql/src/ivm/stream.ts';
 import type {QueryDelegate} from '../../zql/src/query/query-delegate.ts';
 import {newQuery} from '../../zql/src/query/query-impl.ts';
@@ -130,16 +131,15 @@ test('child change merging with flipped exists before OR containing flipped exis
   // Both FlippedJoins for 'labels' preserve it (they just flip and forward child changes)
   // Both child changes need to be merged in UnionFanIn
   consume(
-    must(queryDelegate.getSource('comments')).push({
-      type: 'add',
-      row: {
+    must(queryDelegate.getSource('comments')).push(
+      makeSourceChangeAdd({
         id: 'comment2',
         authorId: 'user1',
         issue_id: 'issue1',
         text: 'New comment',
         createdAt: 1100000000000,
-      },
-    }),
+      }),
+    ),
   );
 
   // Verify the view still has the issue

--- a/packages/zql-integration-tests/src/collate.pg.test.ts
+++ b/packages/zql-integration-tests/src/collate.pg.test.ts
@@ -44,6 +44,7 @@ import {
 import './helpers/comparePg.ts';
 import {fillPgAndSync} from './helpers/setup.ts';
 
+import {makeSourceChangeAdd} from '../../zql/src/ivm/source.ts';
 const lc = createSilentLogContext();
 
 const DB_NAME = 'collate-test';
@@ -151,12 +152,7 @@ beforeAll(async () => {
 
   // Initialize memory sources with test data
   for (const row of testData.item) {
-    consume(
-      memorySources.item.push({
-        type: 'add',
-        row,
-      }),
-    );
+    consume(memorySources.item.push(makeSourceChangeAdd(row)));
   }
 
   // Check that PG, SQLite, and test data are in sync

--- a/packages/zql-integration-tests/src/discord-repro.pg.test.ts
+++ b/packages/zql-integration-tests/src/discord-repro.pg.test.ts
@@ -6,6 +6,7 @@ import {must} from '../../shared/src/must.ts';
 import {initialSync} from '../../zero-cache/src/services/change-source/pg/initial-sync.ts';
 import {getConnectionURI, testDBs} from '../../zero-cache/src/test/db.ts';
 import type {PostgresDB} from '../../zero-cache/src/types/pg.ts';
+import {makeSourceChangeEdit} from '../../zql/src/ivm/source.ts';
 import {consume} from '../../zql/src/ivm/stream.ts';
 import type {QueryDelegate} from '../../zql/src/query/query-delegate.ts';
 import {newQuery} from '../../zql/src/query/query-impl.ts';
@@ -109,25 +110,26 @@ test('discord report https://discord.com/channels/830183651022471199/13475501749
     `);
 
   consume(
-    must(queryDelegate.getSource('issues')).push({
-      type: 'edit',
-      oldRow: {
-        id: 'issue1',
-        title: 'Test Issue 1',
-        description: 'Description for issue 1',
-        closed: false,
-        owner_id: 'user1',
-        createdAt: 982355920000,
-      },
-      row: {
-        id: 'issue1',
-        title: 'Test Issue 1',
-        description: 'Description for issue 1',
-        closed: true,
-        owner_id: 'user1',
-        createdAt: 982355920000,
-      },
-    }),
+    must(queryDelegate.getSource('issues')).push(
+      makeSourceChangeEdit(
+        {
+          id: 'issue1',
+          title: 'Test Issue 1',
+          description: 'Description for issue 1',
+          closed: true,
+          owner_id: 'user1',
+          createdAt: 982355920000,
+        },
+        {
+          id: 'issue1',
+          title: 'Test Issue 1',
+          description: 'Description for issue 1',
+          closed: false,
+          owner_id: 'user1',
+          createdAt: 982355920000,
+        },
+      ),
+    ),
   );
 
   expect(view.data).toEqual(queryDelegate.materialize(q).data);

--- a/packages/zql-integration-tests/src/helpers/runner.ts
+++ b/packages/zql-integration-tests/src/helpers/runner.ts
@@ -28,6 +28,7 @@ import {getServerSchema} from '../../../zero-server/src/schema.ts';
 import {Transaction} from '../../../zero-server/src/test/util.ts';
 import type {Schema} from '../../../zero-types/src/schema.ts';
 import type {ServerSchema} from '../../../zero-types/src/server-schema.ts';
+import {ChangeType} from '../../../zql/src/ivm/change-type.ts';
 import type {Change} from '../../../zql/src/ivm/change.ts';
 import type {Node} from '../../../zql/src/ivm/data.ts';
 import {
@@ -37,7 +38,14 @@ import {
 import {MemorySource} from '../../../zql/src/ivm/memory-source.ts';
 import {skipYields} from '../../../zql/src/ivm/operator.ts';
 import type {SourceSchema} from '../../../zql/src/ivm/schema.ts';
-import type {Source, SourceChange} from '../../../zql/src/ivm/source.ts';
+import {SourceChangeIndex} from '../../../zql/src/ivm/source-change-index.ts';
+import {
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+  makeSourceChangeRemove,
+  type Source,
+  type SourceChange,
+} from '../../../zql/src/ivm/source.ts';
 import {consume} from '../../../zql/src/ivm/stream.ts';
 import type {DBTransaction} from '../../../zql/src/mutate/custom.ts';
 import {QueryDelegateBase} from '../../../zql/src/query/query-delegate-base.ts';
@@ -168,12 +176,7 @@ async function makeDatabases<TSchema extends Schema>(
       ) as Row[];
       raw.set(table.name, rows);
       for (const row of rows) {
-        consume(
-          memory[table.name].push({
-            type: 'add',
-            row,
-          }),
-        );
+        consume(memory[table.name].push(makeSourceChangeAdd(row)));
       }
     }),
   );
@@ -498,31 +501,34 @@ function benchPush(
       let sourceGetter;
       if (type === 'zqlite') {
         changes = changes.map(([source, change]): [string, SourceChange] => {
-          switch (change.type) {
-            case 'add':
+          const changeType = change[SourceChangeIndex.TYPE];
+          const changeRow = change[SourceChangeIndex.ROW];
+          switch (changeType) {
+            case ChangeType.ADD:
               return [
                 source,
-                {
-                  ...change,
-                  row: mapRow(change.row, source, delegates.mapper),
-                },
+                makeSourceChangeAdd(
+                  mapRow(changeRow, source, delegates.mapper),
+                ),
               ];
-            case 'edit':
+            case ChangeType.EDIT:
               return [
                 source,
-                {
-                  ...change,
-                  oldRow: mapRow(change.oldRow, source, delegates.mapper),
-                  row: mapRow(change.row, source, delegates.mapper),
-                },
+                makeSourceChangeEdit(
+                  mapRow(changeRow, source, delegates.mapper),
+                  mapRow(
+                    change[SourceChangeIndex.OLD_ROW]!,
+                    source,
+                    delegates.mapper,
+                  ),
+                ),
               ];
-            case 'remove':
+            case ChangeType.REMOVE:
               return [
                 source,
-                {
-                  ...change,
-                  row: mapRow(change.row, source, delegates.mapper),
-                },
+                makeSourceChangeRemove(
+                  mapRow(changeRow, source, delegates.mapper),
+                ),
               ];
           }
         });
@@ -785,16 +791,12 @@ async function checkRemove(
     await serverTx.mutate[table].delete(row);
 
     consume(
-      must(delegates.sqlite.getSource(delegates.mapper.tableName(table))).push({
-        type: 'remove',
-        row: mappedRow,
-      }),
+      must(delegates.sqlite.getSource(delegates.mapper.tableName(table))).push(
+        makeSourceChangeRemove(mappedRow),
+      ),
     );
     consume(
-      must(delegates.memory.getSource(table)).push({
-        type: 'remove',
-        row,
-      }),
+      must(delegates.memory.getSource(table)).push(makeSourceChangeRemove(row)),
     );
 
     // pg cannot be materialized.
@@ -843,16 +845,12 @@ async function checkAddBack(
     await serverTx.mutate[table].insert(row);
 
     consume(
-      must(delegates.sqlite.getSource(delegates.mapper.tableName(table))).push({
-        type: 'add',
-        row: mappedRow,
-      }),
+      must(delegates.sqlite.getSource(delegates.mapper.tableName(table))).push(
+        makeSourceChangeAdd(mappedRow),
+      ),
     );
     consume(
-      must(delegates.memory.getSource(table)).push({
-        type: 'add',
-        row,
-      }),
+      must(delegates.memory.getSource(table)).push(makeSourceChangeAdd(row)),
     );
 
     const pgResult = await delegates.pg.run(query);
@@ -928,18 +926,14 @@ async function checkEditToRandom(
 
     await serverTx.mutate[table].update(editedRow);
     consume(
-      must(delegates.sqlite.getSource(delegates.mapper.tableName(table))).push({
-        type: 'edit',
-        oldRow: mappedRow,
-        row: mappedEditedRow,
-      }),
+      must(delegates.sqlite.getSource(delegates.mapper.tableName(table))).push(
+        makeSourceChangeEdit(mappedEditedRow, mappedRow),
+      ),
     );
     consume(
-      must(delegates.memory.getSource(table)).push({
-        type: 'edit',
-        oldRow: row,
-        row: editedRow,
-      }),
+      must(delegates.memory.getSource(table)).push(
+        makeSourceChangeEdit(editedRow, row),
+      ),
     );
 
     const pgResult = await delegates.pg.run(query);
@@ -1009,18 +1003,14 @@ async function checkEditToMatch(
     await serverTx.mutate[table].update(original);
 
     consume(
-      must(delegates.sqlite.getSource(delegates.mapper.tableName(table))).push({
-        type: 'edit',
-        oldRow: mappedEdited,
-        row: mappedOriginal,
-      }),
+      must(delegates.sqlite.getSource(delegates.mapper.tableName(table))).push(
+        makeSourceChangeEdit(mappedOriginal, mappedEdited),
+      ),
     );
     consume(
-      must(delegates.memory.getSource(table)).push({
-        type: 'edit',
-        oldRow: edited,
-        row: original,
-      }),
+      must(delegates.memory.getSource(table)).push(
+        makeSourceChangeEdit(original, edited),
+      ),
     );
 
     const pgResult = await delegates.pg.run(query);

--- a/packages/zql/src/builder/builder.test.ts
+++ b/packages/zql/src/builder/builder.test.ts
@@ -21,6 +21,11 @@ import {
 } from './builder.ts';
 import {TestBuilderDelegate} from './test-builder-delegate.ts';
 
+import {
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+  makeSourceChangeRemove,
+} from '../ivm/source.ts';
 const lc = createSilentLogContext();
 
 export function testBuilderDelegate() {
@@ -36,25 +41,25 @@ export function testBuilderDelegate() {
     ['id'],
   );
   consume(
-    users.push({type: 'add', row: {id: 1, name: 'aaron', recruiterID: null}}),
+    users.push(makeSourceChangeAdd({id: 1, name: 'aaron', recruiterID: null})),
   );
   consume(
-    users.push({type: 'add', row: {id: 2, name: 'erik', recruiterID: 1}}),
+    users.push(makeSourceChangeAdd({id: 2, name: 'erik', recruiterID: 1})),
   );
   consume(
-    users.push({type: 'add', row: {id: 3, name: 'greg', recruiterID: 1}}),
+    users.push(makeSourceChangeAdd({id: 3, name: 'greg', recruiterID: 1})),
   );
   consume(
-    users.push({type: 'add', row: {id: 4, name: 'matt', recruiterID: 1}}),
+    users.push(makeSourceChangeAdd({id: 4, name: 'matt', recruiterID: 1})),
   );
   consume(
-    users.push({type: 'add', row: {id: 5, name: 'cesar', recruiterID: 3}}),
+    users.push(makeSourceChangeAdd({id: 5, name: 'cesar', recruiterID: 3})),
   );
   consume(
-    users.push({type: 'add', row: {id: 6, name: 'darick', recruiterID: 3}}),
+    users.push(makeSourceChangeAdd({id: 6, name: 'darick', recruiterID: 3})),
   );
   consume(
-    users.push({type: 'add', row: {id: 7, name: 'alex', recruiterID: 1}}),
+    users.push(makeSourceChangeAdd({id: 7, name: 'alex', recruiterID: 1})),
   );
 
   const states = createSource(
@@ -64,11 +69,11 @@ export function testBuilderDelegate() {
     {code: {type: 'string'}},
     ['code'],
   );
-  consume(states.push({type: 'add', row: {code: 'CA'}}));
-  consume(states.push({type: 'add', row: {code: 'HI'}}));
-  consume(states.push({type: 'add', row: {code: 'AZ'}}));
-  consume(states.push({type: 'add', row: {code: 'MD'}}));
-  consume(states.push({type: 'add', row: {code: 'GA'}}));
+  consume(states.push(makeSourceChangeAdd({code: 'CA'})));
+  consume(states.push(makeSourceChangeAdd({code: 'HI'})));
+  consume(states.push(makeSourceChangeAdd({code: 'AZ'})));
+  consume(states.push(makeSourceChangeAdd({code: 'MD'})));
+  consume(states.push(makeSourceChangeAdd({code: 'GA'})));
 
   const userStates = createSource(
     lc,
@@ -77,13 +82,13 @@ export function testBuilderDelegate() {
     {userID: {type: 'number'}, stateCode: {type: 'string'}},
     ['userID', 'stateCode'],
   );
-  consume(userStates.push({type: 'add', row: {userID: 1, stateCode: 'HI'}}));
-  consume(userStates.push({type: 'add', row: {userID: 3, stateCode: 'AZ'}}));
-  consume(userStates.push({type: 'add', row: {userID: 3, stateCode: 'CA'}}));
-  consume(userStates.push({type: 'add', row: {userID: 4, stateCode: 'MD'}}));
-  consume(userStates.push({type: 'add', row: {userID: 5, stateCode: 'AZ'}}));
-  consume(userStates.push({type: 'add', row: {userID: 6, stateCode: 'CA'}}));
-  consume(userStates.push({type: 'add', row: {userID: 7, stateCode: 'GA'}}));
+  consume(userStates.push(makeSourceChangeAdd({userID: 1, stateCode: 'HI'})));
+  consume(userStates.push(makeSourceChangeAdd({userID: 3, stateCode: 'AZ'})));
+  consume(userStates.push(makeSourceChangeAdd({userID: 3, stateCode: 'CA'})));
+  consume(userStates.push(makeSourceChangeAdd({userID: 4, stateCode: 'MD'})));
+  consume(userStates.push(makeSourceChangeAdd({userID: 5, stateCode: 'AZ'})));
+  consume(userStates.push(makeSourceChangeAdd({userID: 6, stateCode: 'CA'})));
+  consume(userStates.push(makeSourceChangeAdd({userID: 7, stateCode: 'GA'})));
 
   const sources = {users, userStates, states};
 
@@ -167,7 +172,7 @@ test('source-only', () => {
     ]
   `);
 
-  consume(sources.users.push({type: 'add', row: {id: 8, name: 'sam'}}));
+  consume(sources.users.push(makeSourceChangeAdd({id: 8, name: 'sam'})));
   expect(sink.pushes).toMatchInlineSnapshot(`
     [
       {
@@ -254,9 +259,9 @@ test('filter', () => {
     ]
   `);
 
-  consume(sources.users.push({type: 'add', row: {id: 8, name: 'sam'}}));
-  consume(sources.users.push({type: 'add', row: {id: 9, name: 'abby'}}));
-  consume(sources.users.push({type: 'remove', row: {id: 8, name: 'sam'}}));
+  consume(sources.users.push(makeSourceChangeAdd({id: 8, name: 'sam'})));
+  consume(sources.users.push(makeSourceChangeAdd({id: 9, name: 'abby'})));
+  consume(sources.users.push(makeSourceChangeRemove({id: 8, name: 'sam'})));
   expect(sink.pushes).toMatchInlineSnapshot(`
     [
       {
@@ -437,28 +442,24 @@ test('self-join', () => {
   `);
 
   consume(
-    sources.users.push({
-      type: 'add',
-      row: {id: 8, name: 'sam', recruiterID: 2},
-    }),
+    sources.users.push(
+      makeSourceChangeAdd({id: 8, name: 'sam', recruiterID: 2}),
+    ),
   );
   consume(
-    sources.users.push({
-      type: 'add',
-      row: {id: 9, name: 'abby', recruiterID: 8},
-    }),
+    sources.users.push(
+      makeSourceChangeAdd({id: 9, name: 'abby', recruiterID: 8}),
+    ),
   );
   consume(
-    sources.users.push({
-      type: 'remove',
-      row: {id: 8, name: 'sam', recruiterID: 2},
-    }),
+    sources.users.push(
+      makeSourceChangeRemove({id: 8, name: 'sam', recruiterID: 2}),
+    ),
   );
   consume(
-    sources.users.push({
-      type: 'add',
-      row: {id: 8, name: 'sam', recruiterID: 3},
-    }),
+    sources.users.push(
+      makeSourceChangeAdd({id: 8, name: 'sam', recruiterID: 3}),
+    ),
   );
 
   expect(sink.pushes).toMatchInlineSnapshot(`
@@ -679,19 +680,20 @@ test('self-join edit', () => {
 
   // or was greg recruited by erik
   consume(
-    sources.users.push({
-      type: 'edit',
-      oldRow: {
-        id: 3,
-        name: 'greg',
-        recruiterID: 1,
-      },
-      row: {
-        id: 3,
-        name: 'greg',
-        recruiterID: 2,
-      },
-    }),
+    sources.users.push(
+      makeSourceChangeEdit(
+        {
+          id: 3,
+          name: 'greg',
+          recruiterID: 2,
+        },
+        {
+          id: 3,
+          name: 'greg',
+          recruiterID: 1,
+        },
+      ),
+    ),
   );
 
   expect(sink.pushes).toMatchInlineSnapshot(`
@@ -927,7 +929,7 @@ test('multi-join', () => {
   `);
 
   consume(
-    sources.userStates.push({type: 'add', row: {userID: 2, stateCode: 'HI'}}),
+    sources.userStates.push(makeSourceChangeAdd({userID: 2, stateCode: 'HI'})),
   );
 
   expect(sink.pushes).toMatchInlineSnapshot(`
@@ -1079,7 +1081,7 @@ test('join with limit', () => {
   `);
 
   consume(
-    sources.userStates.push({type: 'add', row: {userID: 2, stateCode: 'HI'}}),
+    sources.userStates.push(makeSourceChangeAdd({userID: 2, stateCode: 'HI'})),
   );
 
   expect(sink.pushes).toMatchInlineSnapshot(`
@@ -1169,7 +1171,7 @@ test('skip', () => {
     ]
   `);
 
-  consume(sources.users.push({type: 'add', row: {id: 8, name: 'sam'}}));
+  consume(sources.users.push(makeSourceChangeAdd({id: 8, name: 'sam'})));
   expect(sink.pushes).toMatchInlineSnapshot(`
     [
       {
@@ -1309,7 +1311,7 @@ test('exists junction', () => {
 
   // erik moves to hawaii
   consume(
-    sources.userStates.push({type: 'add', row: {userID: 2, stateCode: 'HI'}}),
+    sources.userStates.push(makeSourceChangeAdd({userID: 2, stateCode: 'HI'})),
   );
 
   expect(sink.pushes).toMatchInlineSnapshot(`
@@ -1520,7 +1522,7 @@ test('duplicative exists junction', () => {
 
   // erik moves to hawaii
   consume(
-    sources.userStates.push({type: 'add', row: {userID: 2, stateCode: 'HI'}}),
+    sources.userStates.push(makeSourceChangeAdd({userID: 2, stateCode: 'HI'})),
   );
 
   expect(sink.pushes).toMatchInlineSnapshot(`
@@ -1724,20 +1726,18 @@ test('exists junction with limit, remove row after limit, and last row', () => {
 
   // row after limit
   consume(
-    sources.users.push({
-      type: 'remove',
-      row: {id: 4, name: 'matt', recruiterID: 1},
-    }),
+    sources.users.push(
+      makeSourceChangeRemove({id: 4, name: 'matt', recruiterID: 1}),
+    ),
   );
 
   expect(sink.pushes).toMatchInlineSnapshot(`[]`);
 
   // last row, also after limit
   consume(
-    sources.users.push({
-      type: 'remove',
-      row: {id: 7, name: 'alex', recruiterID: 1},
-    }),
+    sources.users.push(
+      makeSourceChangeRemove({id: 7, name: 'alex', recruiterID: 1}),
+    ),
   );
 
   expect(sink.pushes).toMatchInlineSnapshot(`[]`);
@@ -1815,19 +1815,20 @@ test('exists self join', () => {
 
   // or was greg recruited by erik
   consume(
-    sources.users.push({
-      type: 'edit',
-      oldRow: {
-        id: 3,
-        name: 'greg',
-        recruiterID: 1,
-      },
-      row: {
-        id: 3,
-        name: 'greg',
-        recruiterID: 2,
-      },
-    }),
+    sources.users.push(
+      makeSourceChangeEdit(
+        {
+          id: 3,
+          name: 'greg',
+          recruiterID: 2,
+        },
+        {
+          id: 3,
+          name: 'greg',
+          recruiterID: 1,
+        },
+      ),
+    ),
   );
 
   expect(sink.pushes).toMatchInlineSnapshot(`
@@ -2092,19 +2093,20 @@ test('not exists self join', () => {
 
   // aaron recruited himself
   consume(
-    sources.users.push({
-      type: 'edit',
-      oldRow: {
-        id: 1,
-        name: 'aaron',
-        recruiterID: null,
-      },
-      row: {
-        id: 1,
-        name: 'aaron',
-        recruiterID: 1,
-      },
-    }),
+    sources.users.push(
+      makeSourceChangeEdit(
+        {
+          id: 1,
+          name: 'aaron',
+          recruiterID: 1,
+        },
+        {
+          id: 1,
+          name: 'aaron',
+          recruiterID: null,
+        },
+      ),
+    ),
   );
 
   expect(sink.pushes).toMatchInlineSnapshot(`
@@ -2375,7 +2377,7 @@ test('empty or - nothing goes through', () => {
 
   expect(sink.fetch()).toMatchInlineSnapshot(`[]`);
 
-  consume(sources.users.push({type: 'add', row: {id: 8, name: 'sam'}}));
+  consume(sources.users.push(makeSourceChangeAdd({id: 8, name: 'sam'})));
   expect(sink.pushes).toMatchInlineSnapshot(`[]`);
 });
 
@@ -2398,7 +2400,7 @@ test('empty and - everything goes through', () => {
 
   expect(sink.fetch().length).toEqual(7);
 
-  consume(sources.users.push({type: 'add', row: {id: 8, name: 'sam'}}));
+  consume(sources.users.push(makeSourceChangeAdd({id: 8, name: 'sam'})));
   expect(sink.pushes).toMatchInlineSnapshot(`
     [
       {
@@ -2442,7 +2444,7 @@ test('always false literal comparison - nothing goes through', () => {
 
   expect(sink.fetch()).toMatchInlineSnapshot(`[]`);
 
-  consume(sources.users.push({type: 'add', row: {id: 8, name: 'sam'}}));
+  consume(sources.users.push(makeSourceChangeAdd({id: 8, name: 'sam'})));
   expect(sink.pushes).toMatchInlineSnapshot(`[]`);
 });
 
@@ -2532,7 +2534,7 @@ test('always true literal comparison - everything goes through', () => {
     ]
   `);
 
-  consume(sources.users.push({type: 'add', row: {id: 8, name: 'sam'}}));
+  consume(sources.users.push(makeSourceChangeAdd({id: 8, name: 'sam'})));
   expect(sink.pushes).toMatchInlineSnapshot(`
     [
       {
@@ -2941,20 +2943,14 @@ test('duplicate relationship alias uses last-writer-wins', () => {
   // Verify push also works correctly - only the filtered relationship exists
   // Add a userState that doesn't match the filter - should not propagate
   consume(
-    sources.userStates.push({
-      type: 'add',
-      row: {userID: 1, stateCode: 'NY'},
-    }),
+    sources.userStates.push(makeSourceChangeAdd({userID: 1, stateCode: 'NY'})),
   );
   // No push should be received (filtered out)
   expect(sink.pushes).toEqual([]);
 
   // Add a userState that matches the filter - should propagate
   consume(
-    sources.userStates.push({
-      type: 'add',
-      row: {userID: 1, stateCode: 'CA'},
-    }),
+    sources.userStates.push(makeSourceChangeAdd({userID: 1, stateCode: 'CA'})),
   );
   expect(sink.pushes.length).toBe(1);
   expect(sink.pushes[0].type).toBe('child');

--- a/packages/zql/src/ivm/array-view.test.ts
+++ b/packages/zql/src/ivm/array-view.test.ts
@@ -11,6 +11,12 @@ import {TestBuilderDelegate} from '../builder/test-builder-delegate.ts';
 import type {ResultType} from '../query/typed-view.ts';
 import {ArrayView} from './array-view.ts';
 import type {Change} from './change.ts';
+import {
+  makeAddChange,
+  makeChildChange,
+  makeEditChange,
+  makeRemoveChange,
+} from './change.ts';
 import {Join} from './join.ts';
 import {MemoryStorage} from './memory-storage.ts';
 import type {Input} from './operator.ts';
@@ -736,12 +742,7 @@ test('collapse', () => {
       },
     },
   } as const;
-  consume(
-    view.push({
-      type: 'add',
-      ...changeSansType,
-    }),
-  );
+  consume(view.push(makeAddChange(changeSansType.node)));
   view.flush();
 
   expect(data).toMatchInlineSnapshot(`
@@ -761,81 +762,69 @@ test('collapse', () => {
     ]
   `);
 
-  consume(
-    view.push({
-      type: 'remove',
-      ...changeSansType,
-    }),
-  );
+  consume(view.push(makeRemoveChange(changeSansType.node)));
   view.flush();
 
   expect(data).toMatchInlineSnapshot(`[]`);
 
-  consume(
-    view.push({
-      type: 'add',
-      ...changeSansType,
-    }),
-  );
+  consume(view.push(makeAddChange(changeSansType.node)));
   // no commit
   expect(data).toMatchInlineSnapshot(`[]`);
 
   consume(
-    view.push({
-      type: 'child',
-      node: {
-        row: {
-          id: 1,
-          name: 'issue',
-        },
-        relationships: {
-          labels: () => [
-            {
-              row: {
-                id: 1,
-                issueId: 1,
-                labelId: 1,
-                extra: 'a',
-              },
-              relationships: {
-                labels: () => [
-                  {
-                    row: {
-                      id: 1,
-                      name: 'label',
+    view.push(
+      makeChildChange(
+        {
+          row: {
+            id: 1,
+            name: 'issue',
+          },
+          relationships: {
+            labels: () => [
+              {
+                row: {
+                  id: 1,
+                  issueId: 1,
+                  labelId: 1,
+                  extra: 'a',
+                },
+                relationships: {
+                  labels: () => [
+                    {
+                      row: {
+                        id: 1,
+                        name: 'label',
+                      },
+                      relationships: {},
                     },
-                    relationships: {},
-                  },
-                ],
+                  ],
+                },
               },
-            },
-            {
-              row: {
-                id: 2,
-                issueId: 1,
-                labelId: 2,
-                extra: 'b',
-              },
-              relationships: {
-                labels: () => [
-                  {
-                    row: {
-                      id: 2,
-                      name: 'label2',
+              {
+                row: {
+                  id: 2,
+                  issueId: 1,
+                  labelId: 2,
+                  extra: 'b',
+                },
+                relationships: {
+                  labels: () => [
+                    {
+                      row: {
+                        id: 2,
+                        name: 'label2',
+                      },
+                      relationships: {},
                     },
-                    relationships: {},
-                  },
-                ],
+                  ],
+                },
               },
-            },
-          ],
+            ],
+          },
         },
-      },
-      child: {
-        relationshipName: 'labels',
-        change: {
-          type: 'add',
-          node: {
+        {
+          relationshipName: 'labels',
+          change: makeAddChange({
             row: {
               id: 2,
               issueId: 1,
@@ -853,10 +842,10 @@ test('collapse', () => {
                 },
               ],
             },
-          },
+          }),
         },
-      },
-    }),
+      ),
+    ),
   );
   view.flush();
 
@@ -884,34 +873,59 @@ test('collapse', () => {
 
   // edit the hidden row
   consume(
-    view.push({
-      type: 'child',
-      node: {
-        row: {
-          id: 1,
-          name: 'issue',
-        },
-        relationships: {
-          labels: () => [
-            {
-              row: {
-                id: 1,
-                issueId: 1,
-                labelId: 1,
-                extra: 'a',
-              },
-              relationships: {
-                labels: () => [
-                  {
-                    row: {
-                      id: 1,
-                      name: 'label',
+    view.push(
+      makeChildChange(
+        {
+          row: {
+            id: 1,
+            name: 'issue',
+          },
+          relationships: {
+            labels: () => [
+              {
+                row: {
+                  id: 1,
+                  issueId: 1,
+                  labelId: 1,
+                  extra: 'a',
+                },
+                relationships: {
+                  labels: () => [
+                    {
+                      row: {
+                        id: 1,
+                        name: 'label',
+                      },
+                      relationships: {},
                     },
-                    relationships: {},
-                  },
-                ],
+                  ],
+                },
               },
-            },
+              {
+                row: {
+                  id: 2,
+                  issueId: 1,
+                  labelId: 2,
+                  extra: 'b2',
+                },
+                relationships: {
+                  labels: () => [
+                    {
+                      row: {
+                        id: 2,
+                        name: 'label2',
+                      },
+                      relationships: {},
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+        {
+          relationshipName: 'labels',
+          change: makeEditChange(
             {
               row: {
                 id: 2,
@@ -931,54 +945,29 @@ test('collapse', () => {
                 ],
               },
             },
-          ],
-        },
-      },
-      child: {
-        relationshipName: 'labels',
-        change: {
-          type: 'edit',
-          oldNode: {
-            row: {
-              id: 2,
-              issueId: 1,
-              labelId: 2,
-              extra: 'b',
-            },
-            relationships: {
-              labels: () => [
-                {
-                  row: {
-                    id: 2,
-                    name: 'label2',
+            {
+              row: {
+                id: 2,
+                issueId: 1,
+                labelId: 2,
+                extra: 'b',
+              },
+              relationships: {
+                labels: () => [
+                  {
+                    row: {
+                      id: 2,
+                      name: 'label2',
+                    },
+                    relationships: {},
                   },
-                  relationships: {},
-                },
-              ],
+                ],
+              },
             },
-          },
-          node: {
-            row: {
-              id: 2,
-              issueId: 1,
-              labelId: 2,
-              extra: 'b2',
-            },
-            relationships: {
-              labels: () => [
-                {
-                  row: {
-                    id: 2,
-                    name: 'label2',
-                  },
-                  relationships: {},
-                },
-              ],
-            },
-          },
+          ),
         },
-      },
-    }),
+      ),
+    ),
   );
   view.flush();
 
@@ -1006,34 +995,59 @@ test('collapse', () => {
 
   // edit the leaf
   consume(
-    view.push({
-      type: 'child',
-      node: {
-        row: {
-          id: 1,
-          name: 'issue',
-        },
-        relationships: {
-          labels: () => [
-            {
-              row: {
-                id: 1,
-                issueId: 1,
-                labelId: 1,
-                extra: 'a',
-              },
-              relationships: {
-                labels: () => [
-                  {
-                    row: {
-                      id: 1,
-                      name: 'label',
+    view.push(
+      makeChildChange(
+        {
+          row: {
+            id: 1,
+            name: 'issue',
+          },
+          relationships: {
+            labels: () => [
+              {
+                row: {
+                  id: 1,
+                  issueId: 1,
+                  labelId: 1,
+                  extra: 'a',
+                },
+                relationships: {
+                  labels: () => [
+                    {
+                      row: {
+                        id: 1,
+                        name: 'label',
+                      },
+                      relationships: {},
                     },
-                    relationships: {},
-                  },
-                ],
+                  ],
+                },
               },
-            },
+              {
+                row: {
+                  id: 2,
+                  issueId: 1,
+                  labelId: 2,
+                  extra: 'b2',
+                },
+                relationships: {
+                  labels: () => [
+                    {
+                      row: {
+                        id: 2,
+                        name: 'label2x',
+                      },
+                      relationships: {},
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+        {
+          relationshipName: 'labels',
+          change: makeChildChange(
             {
               row: {
                 id: 2,
@@ -1053,22 +1067,9 @@ test('collapse', () => {
                 ],
               },
             },
-          ],
-        },
-      },
-      child: {
-        relationshipName: 'labels',
-        change: {
-          type: 'child',
-          node: {
-            row: {
-              id: 2,
-              issueId: 1,
-              labelId: 2,
-              extra: 'b2',
-            },
-            relationships: {
-              labels: () => [
+            {
+              relationshipName: 'labels',
+              change: makeEditChange(
                 {
                   row: {
                     id: 2,
@@ -1076,32 +1077,19 @@ test('collapse', () => {
                   },
                   relationships: {},
                 },
-              ],
-            },
-          },
-          child: {
-            relationshipName: 'labels',
-            change: {
-              type: 'edit',
-              oldNode: {
-                row: {
-                  id: 2,
-                  name: 'label2',
+                {
+                  row: {
+                    id: 2,
+                    name: 'label2',
+                  },
+                  relationships: {},
                 },
-                relationships: {},
-              },
-              node: {
-                row: {
-                  id: 2,
-                  name: 'label2x',
-                },
-                relationships: {},
-              },
+              ),
             },
-          },
+          ),
         },
-      },
-    }),
+      ),
+    ),
   );
   view.flush();
 
@@ -1230,12 +1218,7 @@ test('collapse-single', () => {
       },
     },
   } as const;
-  consume(
-    view.push({
-      type: 'add',
-      ...changeSansType,
-    }),
-  );
+  consume(view.push(makeAddChange(changeSansType.node)));
   view.flush();
 
   expect(data).toEqual([
@@ -1691,9 +1674,8 @@ test('edit to preserve relationships', () => {
     () => void 0,
   );
   consume(
-    view.push({
-      type: 'add',
-      node: {
+    view.push(
+      makeAddChange({
         row: {id: 1, title: 'issue1'},
         relationships: {
           labels: () => [
@@ -1703,13 +1685,12 @@ test('edit to preserve relationships', () => {
             },
           ],
         },
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    view.push({
-      type: 'add',
-      node: {
+    view.push(
+      makeAddChange({
         row: {id: 2, title: 'issue2'},
         relationships: {
           labels: () => [
@@ -1719,8 +1700,8 @@ test('edit to preserve relationships', () => {
             },
           ],
         },
-      },
-    }),
+      }),
+    ),
   );
   let data: unknown[] = [];
   view.addListener(entries => {
@@ -1758,14 +1739,15 @@ test('edit to preserve relationships', () => {
   `);
 
   consume(
-    view.push({
-      type: 'edit',
-      oldNode: {
-        row: {id: 1, title: 'issue1'},
-        relationships: {},
-      },
-      node: {row: {id: 1, title: 'issue1 changed'}, relationships: {}},
-    }),
+    view.push(
+      makeEditChange(
+        {row: {id: 1, title: 'issue1 changed'}, relationships: {}},
+        {
+          row: {id: 1, title: 'issue1'},
+          relationships: {},
+        },
+      ),
+    ),
   );
   view.flush();
   expect(data).toMatchInlineSnapshot(`
@@ -1799,11 +1781,12 @@ test('edit to preserve relationships', () => {
 
   // And now edit to change order
   consume(
-    view.push({
-      type: 'edit',
-      oldNode: {row: {id: 1, title: 'issue1 changed'}, relationships: {}},
-      node: {row: {id: 3, title: 'issue1 is now issue3'}, relationships: {}},
-    }),
+    view.push(
+      makeEditChange(
+        {row: {id: 3, title: 'issue1 is now issue3'}, relationships: {}},
+        {row: {id: 1, title: 'issue1 changed'}, relationships: {}},
+      ),
+    ),
   );
   view.flush();
   expect(data).toMatchInlineSnapshot(`

--- a/packages/zql/src/ivm/array-view.test.ts
+++ b/packages/zql/src/ivm/array-view.test.ts
@@ -21,6 +21,11 @@ import {Join} from './join.ts';
 import {MemoryStorage} from './memory-storage.ts';
 import type {Input} from './operator.ts';
 import type {SourceSchema} from './schema.ts';
+import {
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+  makeSourceChangeRemove,
+} from './source.ts';
 import {consume} from './stream.ts';
 import {Take} from './take.ts';
 import {createSource} from './test/source-factory.ts';
@@ -36,8 +41,8 @@ test('basics', () => {
     {a: {type: 'number'}, b: {type: 'string'}},
     ['a'],
   );
-  consume(ms.push({row: {a: 1, b: 'a'}, type: 'add'}));
-  consume(ms.push({row: {a: 2, b: 'b'}, type: 'add'}));
+  consume(ms.push(makeSourceChangeAdd({a: 1, b: 'a'})));
+  consume(ms.push(makeSourceChangeAdd({a: 2, b: 'b'})));
 
   const view = new ArrayView(
     ms.connect([
@@ -73,7 +78,7 @@ test('basics', () => {
 
   expect(callCount).toBe(1);
 
-  consume(ms.push({row: {a: 3, b: 'c'}, type: 'add'}));
+  consume(ms.push(makeSourceChangeAdd({a: 3, b: 'c'})));
 
   // We don't get called until flush.
   expect(callCount).toBe(1);
@@ -98,9 +103,9 @@ test('basics', () => {
     },
   ]);
 
-  consume(ms.push({row: {a: 2, b: 'b'}, type: 'remove'}));
+  consume(ms.push(makeSourceChangeRemove({a: 2, b: 'b'})));
   expect(callCount).toBe(2);
-  consume(ms.push({row: {a: 1, b: 'a'}, type: 'remove'}));
+  consume(ms.push(makeSourceChangeRemove({a: 1, b: 'a'})));
   expect(callCount).toBe(2);
 
   view.flush();
@@ -114,7 +119,7 @@ test('basics', () => {
   ]);
 
   unlisten();
-  consume(ms.push({row: {a: 3, b: 'c'}, type: 'remove'}));
+  consume(ms.push(makeSourceChangeRemove({a: 3, b: 'c'})));
   expect(callCount).toBe(3);
 
   view.flush();
@@ -138,7 +143,7 @@ test('single-format', () => {
     {a: {type: 'number'}, b: {type: 'string'}},
     ['a'],
   );
-  consume(ms.push({row: {a: 1, b: 'a'}, type: 'add'}));
+  consume(ms.push(makeSourceChangeAdd({a: 1, b: 'a'})));
 
   const view = new ArrayView(
     ms.connect([
@@ -162,14 +167,14 @@ test('single-format', () => {
 
   // trying to add another element should be an error
   // pipeline should have been configured with a limit of one
-  expect(() => consume(ms.push({row: {a: 2, b: 'b'}, type: 'add'}))).toThrow(
+  expect(() => consume(ms.push(makeSourceChangeAdd({a: 2, b: 'b'})))).toThrow(
     "Singular relationship '' should not have multiple rows. You may need to declare this relationship with the `many` helper instead of the `one` helper in your schema.",
   );
 
   // Adding the same element is not an error in the ArrayView but it is an error
   // in the Source. This case is tested in view-apply-change.ts.
 
-  consume(ms.push({row: {a: 1, b: 'a'}, type: 'remove'}));
+  consume(ms.push(makeSourceChangeRemove({a: 1, b: 'a'})));
 
   // no call until flush
   expect(data).toEqual({a: 1, b: 'a'});
@@ -221,30 +226,10 @@ test('tree', () => {
     {id: {type: 'number'}, name: {type: 'string'}, childID: {type: 'number'}},
     ['id'],
   );
-  consume(
-    ms.push({
-      type: 'add',
-      row: {id: 1, name: 'foo', childID: 2},
-    }),
-  );
-  consume(
-    ms.push({
-      type: 'add',
-      row: {id: 2, name: 'foobar', childID: null},
-    }),
-  );
-  consume(
-    ms.push({
-      type: 'add',
-      row: {id: 3, name: 'mon', childID: 4},
-    }),
-  );
-  consume(
-    ms.push({
-      type: 'add',
-      row: {id: 4, name: 'monkey', childID: null},
-    }),
-  );
+  consume(ms.push(makeSourceChangeAdd({id: 1, name: 'foo', childID: 2})));
+  consume(ms.push(makeSourceChangeAdd({id: 2, name: 'foobar', childID: null})));
+  consume(ms.push(makeSourceChangeAdd({id: 3, name: 'mon', childID: 4})));
+  consume(ms.push(makeSourceChangeAdd({id: 4, name: 'monkey', childID: null})));
 
   const join = new Join({
     parent: ms.connect([
@@ -325,7 +310,7 @@ test('tree', () => {
   `);
 
   // add parent with child
-  consume(ms.push({type: 'add', row: {id: 5, name: 'chocolate', childID: 2}}));
+  consume(ms.push(makeSourceChangeAdd({id: 5, name: 'chocolate', childID: 2})));
   view.flush();
   expect(data).toMatchInlineSnapshot(`
     [
@@ -390,7 +375,7 @@ test('tree', () => {
 
   // remove parent with child
   consume(
-    ms.push({type: 'remove', row: {id: 5, name: 'chocolate', childID: 2}}),
+    ms.push(makeSourceChangeRemove({id: 5, name: 'chocolate', childID: 2})),
   );
   view.flush();
   expect(data).toMatchInlineSnapshot(`
@@ -442,14 +427,13 @@ test('tree', () => {
 
   // remove just child
   consume(
-    ms.push({
-      type: 'remove',
-      row: {
+    ms.push(
+      makeSourceChangeRemove({
         id: 2,
         name: 'foobar',
         childID: null,
-      },
-    }),
+      }),
+    ),
   );
   view.flush();
   expect(data).toMatchInlineSnapshot(`
@@ -487,14 +471,13 @@ test('tree', () => {
 
   // add child
   consume(
-    ms.push({
-      type: 'add',
-      row: {
+    ms.push(
+      makeSourceChangeAdd({
         id: 2,
         name: 'foobaz',
         childID: null,
-      },
-    }),
+      }),
+    ),
   );
   view.flush();
   expect(data).toMatchInlineSnapshot(`
@@ -553,18 +536,8 @@ test('tree-single', () => {
     {id: {type: 'number'}, name: {type: 'string'}, childID: {type: 'number'}},
     ['id'],
   );
-  consume(
-    ms.push({
-      type: 'add',
-      row: {id: 1, name: 'foo', childID: 2},
-    }),
-  );
-  consume(
-    ms.push({
-      type: 'add',
-      row: {id: 2, name: 'foobar', childID: null},
-    }),
-  );
+  consume(ms.push(makeSourceChangeAdd({id: 1, name: 'foo', childID: 2})));
+  consume(ms.push(makeSourceChangeAdd({id: 2, name: 'foobar', childID: null})));
 
   const take = new Take(
     ms.connect([
@@ -615,10 +588,7 @@ test('tree-single', () => {
 
   // remove the child
   consume(
-    ms.push({
-      type: 'remove',
-      row: {id: 2, name: 'foobar', childID: null},
-    }),
+    ms.push(makeSourceChangeRemove({id: 2, name: 'foobar', childID: null})),
   );
   view.flush();
 
@@ -630,12 +600,7 @@ test('tree-single', () => {
   });
 
   // remove the parent
-  consume(
-    ms.push({
-      type: 'remove',
-      row: {id: 1, name: 'foo', childID: 2},
-    }),
-  );
+  consume(ms.push(makeSourceChangeRemove({id: 1, name: 'foo', childID: 2})));
   view.flush();
   expect(data).toEqual(undefined);
 });
@@ -1241,8 +1206,8 @@ test('basic with edit pushes', () => {
     {a: {type: 'number'}, b: {type: 'string'}},
     ['a'],
   );
-  consume(ms.push({row: {a: 1, b: 'a'}, type: 'add'}));
-  consume(ms.push({row: {a: 2, b: 'b'}, type: 'add'}));
+  consume(ms.push(makeSourceChangeAdd({a: 1, b: 'a'})));
+  consume(ms.push(makeSourceChangeAdd({a: 2, b: 'b'})));
 
   const view = new ArrayView(
     ms.connect([['a', 'asc']]),
@@ -1276,9 +1241,7 @@ test('basic with edit pushes', () => {
 
   expect(callCount).toBe(1);
 
-  consume(
-    ms.push({type: 'edit', row: {a: 2, b: 'b2'}, oldRow: {a: 2, b: 'b'}}),
-  );
+  consume(ms.push(makeSourceChangeEdit({a: 2, b: 'b2'}, {a: 2, b: 'b'})));
 
   // We don't get called until flush.
   expect(callCount).toBe(1);
@@ -1300,9 +1263,7 @@ test('basic with edit pushes', () => {
     ]
   `);
 
-  consume(
-    ms.push({type: 'edit', row: {a: 3, b: 'b3'}, oldRow: {a: 2, b: 'b2'}}),
-  );
+  consume(ms.push(makeSourceChangeEdit({a: 3, b: 'b3'}, {a: 2, b: 'b2'})));
 
   view.flush();
   expect(callCount).toBe(3);
@@ -1343,7 +1304,7 @@ test('tree edit', () => {
     {id: 3, name: 'mon', data: 'c', childID: 4},
     {id: 4, name: 'monkey', data: 'd', childID: null},
   ] as const) {
-    consume(ms.push({type: 'add', row}));
+    consume(ms.push(makeSourceChangeAdd(row)));
   }
 
   const join = new Join({
@@ -1432,11 +1393,12 @@ test('tree edit', () => {
 
   // Edit root
   consume(
-    ms.push({
-      type: 'edit',
-      oldRow: {id: 1, name: 'foo', data: 'a', childID: 2},
-      row: {id: 1, name: 'foo', data: 'a2', childID: 2},
-    }),
+    ms.push(
+      makeSourceChangeEdit(
+        {id: 1, name: 'foo', data: 'a2', childID: 2},
+        {id: 1, name: 'foo', data: 'a', childID: 2},
+      ),
+    ),
   );
   view.flush();
   expect(data).toMatchInlineSnapshot(`
@@ -1506,7 +1468,7 @@ test('edit to change the order', () => {
     {a: 20, b: 'b'},
     {a: 30, b: 'c'},
   ] as const) {
-    consume(ms.push({row, type: 'add'}));
+    consume(ms.push(makeSourceChangeAdd(row)));
   }
 
   const view = new ArrayView(
@@ -1541,13 +1503,7 @@ test('edit to change the order', () => {
     ]
   `);
 
-  consume(
-    ms.push({
-      type: 'edit',
-      oldRow: {a: 20, b: 'b'},
-      row: {a: 5, b: 'b2'},
-    }),
-  );
+  consume(ms.push(makeSourceChangeEdit({a: 5, b: 'b2'}, {a: 20, b: 'b'})));
   view.flush();
   expect(data).toMatchInlineSnapshot(`
     [
@@ -1569,13 +1525,7 @@ test('edit to change the order', () => {
     ]
   `);
 
-  consume(
-    ms.push({
-      type: 'edit',
-      oldRow: {a: 5, b: 'b2'},
-      row: {a: 4, b: 'b3'},
-    }),
-  );
+  consume(ms.push(makeSourceChangeEdit({a: 4, b: 'b3'}, {a: 5, b: 'b2'})));
 
   view.flush();
   expect(data).toMatchInlineSnapshot(`
@@ -1598,13 +1548,7 @@ test('edit to change the order', () => {
     ]
   `);
 
-  consume(
-    ms.push({
-      type: 'edit',
-      oldRow: {a: 4, b: 'b3'},
-      row: {a: 20, b: 'b4'},
-    }),
-  );
+  consume(ms.push(makeSourceChangeEdit({a: 20, b: 'b4'}, {a: 4, b: 'b3'})));
   view.flush();
   expect(data).toMatchInlineSnapshot(`
     [
@@ -1827,8 +1771,8 @@ test('listeners receive error when queryComplete rejects - plural', async () => 
     {a: {type: 'number'}, b: {type: 'string'}},
     ['a'],
   );
-  consume(ms.push({row: {a: 1, b: 'a'}, type: 'add'}));
-  consume(ms.push({row: {a: 2, b: 'b'}, type: 'add'}));
+  consume(ms.push(makeSourceChangeAdd({a: 1, b: 'a'})));
+  consume(ms.push(makeSourceChangeAdd({a: 2, b: 'b'})));
 
   const testError: ErroredQuery = {
     error: 'app',
@@ -1885,7 +1829,7 @@ test('listeners receive error when queryComplete rejects - singular', async () =
     {a: {type: 'number'}, b: {type: 'string'}},
     ['a'],
   );
-  consume(ms.push({row: {a: 1, b: 'a'}, type: 'add'}));
+  consume(ms.push(makeSourceChangeAdd({a: 1, b: 'a'})));
 
   const testError: ErroredQuery = {
     error: 'parse',
@@ -1935,7 +1879,7 @@ test('all listeners receive error when queryComplete rejects', async () => {
     {a: {type: 'number'}, b: {type: 'string'}},
     ['a'],
   );
-  consume(ms.push({row: {a: 1, b: 'a'}, type: 'add'}));
+  consume(ms.push(makeSourceChangeAdd({a: 1, b: 'a'})));
 
   const testError: ErroredQuery = {
     error: 'parse',
@@ -1990,7 +1934,7 @@ test('listeners added after error still receive error state', async () => {
     {a: {type: 'number'}, b: {type: 'string'}},
     ['a'],
   );
-  consume(ms.push({row: {a: 1, b: 'a'}, type: 'add'}));
+  consume(ms.push(makeSourceChangeAdd({a: 1, b: 'a'})));
 
   const testError: ErroredQuery = {
     error: 'app',
@@ -2033,7 +1977,7 @@ test('error state persists through flush operations', async () => {
     {a: {type: 'number'}, b: {type: 'string'}},
     ['a'],
   );
-  consume(ms.push({row: {a: 1, b: 'a'}, type: 'add'}));
+  consume(ms.push(makeSourceChangeAdd({a: 1, b: 'a'})));
 
   const testError: ErroredQuery = {
     error: 'app',
@@ -2065,7 +2009,7 @@ test('error state persists through flush operations', async () => {
   const callsAfterError = callCount;
 
   // Add more data and flush
-  consume(ms.push({row: {a: 2, b: 'b'}, type: 'add'}));
+  consume(ms.push(makeSourceChangeAdd({a: 2, b: 'b'})));
   view.flush();
 
   // Should still be in error state
@@ -2103,12 +2047,15 @@ test('duplicate relationship alias uses last-writer-wins', () => {
 
   // Add user AND cjc BEFORE pipeline
   // The cjc has job_id='other-job', which won't match the filter 'target-job'
-  consume(users.push({type: 'add', row: {id: 'user-1', name: 'Test User'}}));
+  consume(users.push(makeSourceChangeAdd({id: 'user-1', name: 'Test User'})));
   consume(
-    candidateJobConnections.push({
-      type: 'add',
-      row: {id: 'cjc-1', candidate_id: 'user-1', job_id: 'other-job'},
-    }),
+    candidateJobConnections.push(
+      makeSourceChangeAdd({
+        id: 'cjc-1',
+        candidate_id: 'user-1',
+        job_id: 'other-job',
+      }),
+    ),
   );
 
   const sources = {users, candidate_job_connections: candidateJobConnections};
@@ -2186,10 +2133,13 @@ test('duplicate relationship alias uses last-writer-wins', () => {
   // and the filtered source connection filters out the remove (predicate fails)
   expect(() => {
     consume(
-      candidateJobConnections.push({
-        type: 'remove',
-        row: {id: 'cjc-1', candidate_id: 'user-1', job_id: 'other-job'},
-      }),
+      candidateJobConnections.push(
+        makeSourceChangeRemove({
+          id: 'cjc-1',
+          candidate_id: 'user-1',
+          job_id: 'other-job',
+        }),
+      ),
     );
     view.flush();
   }).not.toThrow();
@@ -2216,12 +2166,15 @@ test('unique relationship aliases work correctly', () => {
     ['id'],
   );
 
-  consume(users.push({type: 'add', row: {id: 'user-1', name: 'Test User'}}));
+  consume(users.push(makeSourceChangeAdd({id: 'user-1', name: 'Test User'})));
   consume(
-    candidateJobConnections.push({
-      type: 'add',
-      row: {id: 'cjc-1', candidate_id: 'user-1', job_id: 'other-job'},
-    }),
+    candidateJobConnections.push(
+      makeSourceChangeAdd({
+        id: 'cjc-1',
+        candidate_id: 'user-1',
+        job_id: 'other-job',
+      }),
+    ),
   );
 
   const sources = {users, candidate_job_connections: candidateJobConnections};
@@ -2299,10 +2252,13 @@ test('unique relationship aliases work correctly', () => {
   // Delete should work fine with unique aliases
   expect(() => {
     consume(
-      candidateJobConnections.push({
-        type: 'remove',
-        row: {id: 'cjc-1', candidate_id: 'user-1', job_id: 'other-job'},
-      }),
+      candidateJobConnections.push(
+        makeSourceChangeRemove({
+          id: 'cjc-1',
+          candidate_id: 'user-1',
+          job_id: 'other-job',
+        }),
+      ),
     );
     view.flush();
   }).not.toThrow();

--- a/packages/zql/src/ivm/array-view.ts
+++ b/packages/zql/src/ivm/array-view.ts
@@ -4,11 +4,37 @@ import {emptyArray} from '../../../shared/src/sentinels.ts';
 import type {ErroredQuery} from '../../../zero-protocol/src/custom-queries.ts';
 import type {TTL} from '../query/ttl.ts';
 import type {Listener, ResultType, TypedView} from '../query/typed-view.ts';
+import {ChangeIndex} from './change-index.ts';
+import {ChangeType} from './change-type.ts';
 import type {Change} from './change.ts';
 import {skipYields, type Input, type Output} from './operator.ts';
 import type {SourceSchema} from './schema.ts';
-import {applyChange} from './view-apply-change.ts';
+import {applyChange, type ViewChange} from './view-apply-change.ts';
 import type {Entry, Format, View} from './view.ts';
+
+function changeToViewChange(change: Change): ViewChange {
+  switch (change[ChangeIndex.TYPE]) {
+    case ChangeType.ADD:
+      return {type: 'add', node: change[ChangeIndex.NODE]};
+    case ChangeType.REMOVE:
+      return {type: 'remove', node: change[ChangeIndex.NODE]};
+    case ChangeType.CHILD:
+      return {
+        type: 'child',
+        node: change[ChangeIndex.NODE],
+        child: {
+          relationshipName: change[ChangeIndex.CHILD_DATA].relationshipName,
+          change: changeToViewChange(change[ChangeIndex.CHILD_DATA].change),
+        },
+      };
+    case ChangeType.EDIT:
+      return {
+        type: 'edit',
+        node: change[ChangeIndex.NODE],
+        oldNode: change[ChangeIndex.OLD_NODE],
+      };
+  }
+}
 
 /**
  * Implements a materialized view of the output of an operator.
@@ -116,7 +142,13 @@ export class ArrayView<V extends View> implements Output, TypedView<V> {
 
   push(change: Change) {
     this.#dirty = true;
-    applyChange(this.#root, change, this.#schema, '', this.#format);
+    applyChange(
+      this.#root,
+      changeToViewChange(change),
+      this.#schema,
+      '',
+      this.#format,
+    );
     return emptyArray;
   }
 

--- a/packages/zql/src/ivm/cap.push.test.ts
+++ b/packages/zql/src/ivm/cap.push.test.ts
@@ -14,6 +14,11 @@ import {
 import {createSource} from './test/source-factory.ts';
 import type {Format} from './view.ts';
 
+import {
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+  makeSourceChangeRemove,
+} from './source.ts';
 describe('Cap push - basic behavior', () => {
   const sources: Sources = {
     issue: {
@@ -72,13 +77,7 @@ describe('Cap push - basic behavior', () => {
       ast,
       format,
       pushes: [
-        [
-          'comment',
-          {
-            type: 'add',
-            row: {id: 'c2', issueID: 'i1', text: 'c2'},
-          },
-        ],
+        ['comment', makeSourceChangeAdd({id: 'c2', issueID: 'i1', text: 'c2'})],
       ],
     });
 
@@ -151,13 +150,7 @@ describe('Cap push - basic behavior', () => {
       ast,
       format,
       pushes: [
-        [
-          'comment',
-          {
-            type: 'add',
-            row: {id: 'c4', issueID: 'i1', text: 'c4'},
-          },
-        ],
+        ['comment', makeSourceChangeAdd({id: 'c4', issueID: 'i1', text: 'c4'})],
       ],
     });
 
@@ -215,10 +208,7 @@ describe('Cap push - basic behavior', () => {
       pushes: [
         [
           'comment',
-          {
-            type: 'remove',
-            row: {id: 'c2', issueID: 'i1', text: 'c2'},
-          },
+          makeSourceChangeRemove({id: 'c2', issueID: 'i1', text: 'c2'}),
         ],
       ],
     });
@@ -320,10 +310,7 @@ describe('Cap push - basic behavior', () => {
       pushes: [
         [
           'comment',
-          {
-            type: 'remove',
-            row: {id: 'c1', issueID: 'i1', text: 'c1'},
-          },
+          makeSourceChangeRemove({id: 'c1', issueID: 'i1', text: 'c1'}),
         ],
       ],
     });
@@ -389,10 +376,7 @@ describe('Cap push - basic behavior', () => {
       pushes: [
         [
           'comment',
-          {
-            type: 'remove',
-            row: {id: 'c1', issueID: 'i1', text: 'c1'},
-          },
+          makeSourceChangeRemove({id: 'c1', issueID: 'i1', text: 'c1'}),
         ],
       ],
     });
@@ -447,10 +431,7 @@ describe('Cap push - basic behavior', () => {
       pushes: [
         [
           'comment',
-          {
-            type: 'remove',
-            row: {id: 'c4', issueID: 'i1', text: 'c4'},
-          },
+          makeSourceChangeRemove({id: 'c4', issueID: 'i1', text: 'c4'}),
         ],
       ],
     });
@@ -507,11 +488,10 @@ describe('Cap push - basic behavior', () => {
       pushes: [
         [
           'comment',
-          {
-            type: 'edit',
-            oldRow: {id: 'c1', issueID: 'i1', text: 'c1'},
-            row: {id: 'c1', issueID: 'i1', text: 'c1 updated'},
-          },
+          makeSourceChangeEdit(
+            {id: 'c1', issueID: 'i1', text: 'c1 updated'},
+            {id: 'c1', issueID: 'i1', text: 'c1'},
+          ),
         ],
       ],
     });
@@ -639,13 +619,7 @@ describe('Cap push - unordered overlay in join', () => {
       ast,
       format,
       pushes: [
-        [
-          'child',
-          {
-            type: 'remove',
-            row: {id: 'x1', group: 'g1', text: 'x1'},
-          },
-        ],
+        ['child', makeSourceChangeRemove({id: 'x1', group: 'g1', text: 'x1'})],
       ],
     });
 
@@ -819,7 +793,7 @@ describe('Cap limit 0', () => {
         {id: {type: 'string'}, group: {type: 'string'}},
         ['id'],
       );
-      consume(source.push({type: 'add', row: {id: '1', group: 'g1'}}));
+      consume(source.push(makeSourceChangeAdd({id: '1', group: 'g1'})));
 
       const storage = new MemoryStorage();
       const cap = new Cap(

--- a/packages/zql/src/ivm/cap.ts
+++ b/packages/zql/src/ivm/cap.ts
@@ -1,7 +1,9 @@
 import {assert} from '../../../shared/src/asserts.ts';
 import type {Row, Value} from '../../../zero-protocol/src/data.ts';
 import type {PrimaryKey} from '../../../zero-protocol/src/primary-key.ts';
-import {type Change, type EditChange} from './change.ts';
+import {ChangeIndex} from './change-index.ts';
+import {ChangeType} from './change-type.ts';
+import {makeAddChange, type Change, type EditChange} from './change.ts';
 import type {Constraint} from './constraint.ts';
 import type {Comparator, Node} from './data.ts';
 import {
@@ -193,20 +195,23 @@ export class Cap implements Operator {
   }
 
   *push(change: Change): Stream<'yield'> {
-    if (change.type === 'edit') {
+    if (change[ChangeIndex.TYPE] === ChangeType.EDIT) {
       yield* this.#pushEditChange(change);
       return;
     }
 
-    const capStateKey = getCapStateKey(this.#partitionKey, change.node.row);
+    const capStateKey = getCapStateKey(
+      this.#partitionKey,
+      change[ChangeIndex.NODE].row,
+    );
     const capState = this.#storage.get(capStateKey);
     if (!capState) {
       return;
     }
 
-    const pk = serializePK(change.node.row, this.#primaryKey);
+    const pk = serializePK(change[ChangeIndex.NODE].row, this.#primaryKey);
 
-    if (change.type === 'add') {
+    if (change[ChangeIndex.TYPE] === ChangeType.ADD) {
       if (capState.size < this.#limit) {
         const pks = [...capState.pks, pk];
         this.#storage.set(capStateKey, {size: capState.size + 1, pks});
@@ -215,7 +220,7 @@ export class Cap implements Operator {
       }
       // Full — drop
       return;
-    } else if (change.type === 'remove') {
+    } else if (change[ChangeIndex.TYPE] === ChangeType.REMOVE) {
       const pkIndex = capState.pks.indexOf(pk);
       if (pkIndex === -1) {
         // Not in our set — drop
@@ -231,7 +236,9 @@ export class Cap implements Operator {
       const pkSet = new Set(pks);
       const constraint = this.#partitionKey
         ? (Object.fromEntries(
-            this.#partitionKey.map(key => [key, change.node.row[key]] as const),
+            this.#partitionKey.map(
+              key => [key, change[ChangeIndex.NODE].row[key]] as const,
+            ),
           ) as Constraint)
         : undefined;
 
@@ -257,12 +264,12 @@ export class Cap implements Operator {
         const replacementPK = serializePK(replacement.row, this.#primaryKey);
         pks.push(replacementPK);
         this.#storage.set(capStateKey, {size: newSize + 1, pks});
-        yield* this.#output.push({type: 'add', node: replacement}, this);
+        yield* this.#output.push(makeAddChange(replacement), this);
       } else {
         this.#storage.set(capStateKey, {size: newSize, pks});
         yield* this.#output.push(change, this);
       }
-    } else if (change.type === 'child') {
+    } else if (change[ChangeIndex.TYPE] === ChangeType.CHILD) {
       const pkSet = new Set(capState.pks);
       if (pkSet.has(pk)) {
         yield* this.#output.push(change, this);
@@ -273,20 +280,29 @@ export class Cap implements Operator {
   *#pushEditChange(change: EditChange): Stream<'yield'> {
     assert(
       !this.#partitionKeyComparator ||
-        this.#partitionKeyComparator(change.oldNode.row, change.node.row) === 0,
+        this.#partitionKeyComparator(
+          change[ChangeIndex.OLD_NODE].row,
+          change[ChangeIndex.NODE].row,
+        ) === 0,
       'Unexpected change of partition key',
     );
-    const capStateKey = getCapStateKey(this.#partitionKey, change.oldNode.row);
+    const capStateKey = getCapStateKey(
+      this.#partitionKey,
+      change[ChangeIndex.OLD_NODE].row,
+    );
     const capState = this.#storage.get(capStateKey);
     if (!capState) {
       return;
     }
 
-    const oldPK = serializePK(change.oldNode.row, this.#primaryKey);
+    const oldPK = serializePK(
+      change[ChangeIndex.OLD_NODE].row,
+      this.#primaryKey,
+    );
     const pkSet = new Set(capState.pks);
     if (pkSet.has(oldPK)) {
       // Update the PK in our set if it changed
-      const newPK = serializePK(change.node.row, this.#primaryKey);
+      const newPK = serializePK(change[ChangeIndex.NODE].row, this.#primaryKey);
       if (oldPK !== newPK) {
         const pks = capState.pks.map(p => (p === oldPK ? newPK : p));
         this.#storage.set(capStateKey, {size: capState.size, pks});

--- a/packages/zql/src/ivm/catch.ts
+++ b/packages/zql/src/ivm/catch.ts
@@ -1,6 +1,8 @@
 import {unreachable} from '../../../shared/src/asserts.ts';
 import {emptyArray} from '../../../shared/src/sentinels.ts';
 import type {Row} from '../../../zero-protocol/src/data.ts';
+import {ChangeIndex} from './change-index.ts';
+import {ChangeType} from './change-type.ts';
 import type {Change} from './change.ts';
 import type {Node} from './data.ts';
 import {type FetchRequest, type Input, type Output} from './operator.ts';
@@ -88,26 +90,30 @@ export class Catch implements Output {
 }
 
 export function expandChange(change: Change): CaughtChange {
-  switch (change.type) {
-    case 'add':
-    case 'remove':
+  switch (change[ChangeIndex.TYPE]) {
+    case ChangeType.ADD:
       return {
-        ...change,
-        node: expandNode(change.node),
+        type: 'add',
+        node: expandNode(change[ChangeIndex.NODE]),
       };
-    case 'edit':
+    case ChangeType.REMOVE:
+      return {
+        type: 'remove',
+        node: expandNode(change[ChangeIndex.NODE]),
+      };
+    case ChangeType.EDIT:
       return {
         type: 'edit',
-        oldRow: change.oldNode.row,
-        row: change.node.row,
+        oldRow: change[ChangeIndex.OLD_NODE].row,
+        row: change[ChangeIndex.NODE].row,
       };
-    case 'child':
+    case ChangeType.CHILD:
       return {
         type: 'child',
-        row: change.node.row,
+        row: change[ChangeIndex.NODE].row,
         child: {
-          ...change.child,
-          change: expandChange(change.child.change),
+          ...change[ChangeIndex.CHILD_DATA],
+          change: expandChange(change[ChangeIndex.CHILD_DATA].change),
         },
       };
     default:

--- a/packages/zql/src/ivm/change-index-enum.ts
+++ b/packages/zql/src/ivm/change-index-enum.ts
@@ -1,0 +1,9 @@
+export const TYPE = 0;
+export const NODE = 1;
+export const OLD_NODE = 2;
+export const CHILD_DATA = 2;
+
+export type TYPE = typeof TYPE;
+export type NODE = typeof NODE;
+export type OLD_NODE = typeof OLD_NODE;
+export type CHILD_DATA = typeof CHILD_DATA;

--- a/packages/zql/src/ivm/change-index.ts
+++ b/packages/zql/src/ivm/change-index.ts
@@ -1,0 +1,5 @@
+import type {Enum} from '../../../shared/src/enum.ts';
+import * as ChangeIndexEnum from './change-index-enum.ts';
+
+export {ChangeIndexEnum as ChangeIndex};
+export type ChangeIndex = Enum<typeof ChangeIndexEnum>;

--- a/packages/zql/src/ivm/change-type-enum.ts
+++ b/packages/zql/src/ivm/change-type-enum.ts
@@ -1,0 +1,9 @@
+export const ADD = 0;
+export const REMOVE = 1;
+export const CHILD = 2;
+export const EDIT = 3;
+
+export type ADD = typeof ADD;
+export type REMOVE = typeof REMOVE;
+export type CHILD = typeof CHILD;
+export type EDIT = typeof EDIT;

--- a/packages/zql/src/ivm/change-type.ts
+++ b/packages/zql/src/ivm/change-type.ts
@@ -1,0 +1,5 @@
+import type {Enum} from '../../../shared/src/enum.ts';
+import * as ChangeTypeEnum from './change-type-enum.ts';
+
+export {ChangeTypeEnum as ChangeType};
+export type ChangeType = Enum<typeof ChangeTypeEnum>;

--- a/packages/zql/src/ivm/change.ts
+++ b/packages/zql/src/ivm/change.ts
@@ -1,40 +1,36 @@
-import type {Node} from './data.ts';
+import { ChangeType } from './change-type.ts';
+import type { Node } from './data.ts';
+
+/**
+ * The `child` payload carried by a {@linkcode ChildChange}.
+ */
+export type ChildData = {
+  relationshipName: string;
+  change: Change;
+};
 
 export type Change = AddChange | RemoveChange | ChildChange | EditChange;
-export type ChangeType = Change['type'];
-
-// TODO: We should change these to classes to achieve monomorphic dispatch.
-// or add some runtime asserts that the order of the keys is always the same.
 
 /**
  * Represents a node (and all its children) getting added to the result.
  */
-export type AddChange = {
-  type: 'add';
-  node: Node;
-};
+export type AddChange = [type: ChangeType.ADD, node: Node, extra: null];
 
 /**
  * Represents a node (and all its children) getting removed from the result.
  */
-export type RemoveChange = {
-  type: 'remove';
-  node: Node;
-};
+export type RemoveChange = [type: ChangeType.REMOVE, node: Node, extra: null];
 
 /**
  * The node's row is unchanged, but one of its descendants has changed.
  * The node's relationships will reflect the change, `child` specifies the
  * specific descendant change.
  */
-export type ChildChange = {
-  type: 'child';
-  node: Node;
-  child: {
-    relationshipName: string;
-    change: Change;
-  };
-};
+export type ChildChange = [
+  type: ChangeType.CHILD,
+  node: Node,
+  child: ChildData,
+];
 
 /**
  * The row changed (in a way that the {@linkcode Source} determines). Most
@@ -58,8 +54,22 @@ export type ChildChange = {
  * the add.  This cleanup could be done if we move to multi-use Streams
  * for relationships.
  */
-export type EditChange = {
-  type: 'edit';
-  node: Node;
-  oldNode: Node;
-};
+export type EditChange = [type: ChangeType.EDIT, node: Node, oldNode: Node];
+
+// Factory functions — prefer these over constructing tuple literals directly.
+
+export function makeAddChange(node: Node): AddChange {
+  return [ChangeType.ADD, node, null];
+}
+
+export function makeRemoveChange(node: Node): RemoveChange {
+  return [ChangeType.REMOVE, node, null];
+}
+
+export function makeChildChange(node: Node, child: ChildData): ChildChange {
+  return [ChangeType.CHILD, node, child];
+}
+
+export function makeEditChange(node: Node, oldNode: Node): EditChange {
+  return [ChangeType.EDIT, node, oldNode];
+}

--- a/packages/zql/src/ivm/change.ts
+++ b/packages/zql/src/ivm/change.ts
@@ -1,5 +1,5 @@
-import { ChangeType } from './change-type.ts';
-import type { Node } from './data.ts';
+import {ChangeType} from './change-type.ts';
+import type {Node} from './data.ts';
 
 /**
  * The `child` payload carried by a {@linkcode ChildChange}.

--- a/packages/zql/src/ivm/destroy.test.ts
+++ b/packages/zql/src/ivm/destroy.test.ts
@@ -11,6 +11,7 @@ import {Snitch} from './snitch.ts';
 import {consume} from './stream.ts';
 import {createSource} from './test/source-factory.ts';
 
+import {makeSourceChangeAdd} from './source.ts';
 const lc = createSilentLogContext();
 
 test('destroy source connections', () => {
@@ -27,42 +28,35 @@ test('destroy source connections', () => {
   const snitch1 = new Snitch(connection1, 'snitch1');
   const snitch2 = new Snitch(connection2, 'snitch2');
 
-  const msg1 = {
-    type: 'add',
-    row: {a: 3},
-  } as const;
+  const msg1 = makeSourceChangeAdd({a: 3});
   consume(ms.push(msg1));
 
-  expect(snitch1.log).toEqual([['snitch1', 'push', msg1]]);
-  expect(snitch2.log).toEqual([['snitch2', 'push', msg1]]);
+  const record1 = {type: 'add', row: {a: 3}};
+  expect(snitch1.log).toEqual([['snitch1', 'push', record1]]);
+  expect(snitch2.log).toEqual([['snitch2', 'push', record1]]);
 
   snitch1.destroy();
 
-  const msg2 = {
-    type: 'add',
-    row: {a: 2},
-  } as const;
+  const msg2 = makeSourceChangeAdd({a: 2});
   consume(ms.push(msg2));
 
   // snitch1 was destroyed. No new events should
   // be received.
-  expect(snitch1.log).toEqual([['snitch1', 'push', msg1]]);
+  const record2 = {type: 'add', row: {a: 2}};
+  expect(snitch1.log).toEqual([['snitch1', 'push', record1]]);
   // snitch 2 is a separate connection and should not
   // have been destroyed
   expect(snitch2.log).toEqual([
-    ['snitch2', 'push', msg1],
-    ['snitch2', 'push', msg2],
+    ['snitch2', 'push', record1],
+    ['snitch2', 'push', record2],
   ]);
 
   snitch2.destroy();
-  const msg3 = {
-    type: 'add',
-    row: {a: 1},
-  } as const;
+  const msg3 = makeSourceChangeAdd({a: 1});
   consume(ms.push(msg3));
   expect(snitch2.log).toEqual([
-    ['snitch2', 'push', msg1],
-    ['snitch2', 'push', msg2],
+    ['snitch2', 'push', record1],
+    ['snitch2', 'push', record2],
   ]);
 });
 
@@ -93,7 +87,7 @@ test('destroy a pipeline that has forking', () => {
 
   const out = new Catch(pipeline);
 
-  consume(ms.push({type: 'add', row: {a: 1, b: 'foo'}}));
+  consume(ms.push(makeSourceChangeAdd({a: 1, b: 'foo'})));
 
   const expected = [
     {
@@ -110,7 +104,7 @@ test('destroy a pipeline that has forking', () => {
   expect(out.pushes).toEqual(expected);
 
   out.destroy();
-  consume(ms.push({type: 'add', row: {a: 2, b: 'foo'}}));
+  consume(ms.push(makeSourceChangeAdd({a: 2, b: 'foo'})));
 
   // The pipeline was destroyed. No new events should
   // be received.

--- a/packages/zql/src/ivm/exists.fetch.test.ts
+++ b/packages/zql/src/ivm/exists.fetch.test.ts
@@ -17,6 +17,7 @@ import {Snitch, type SnitchMessage} from './snitch.ts';
 import {consume} from './stream.ts';
 import {createSource} from './test/source-factory.ts';
 
+import {makeSourceChangeAdd} from './source.ts';
 const base = {
   columns: [
     {id: {type: 'string'}},
@@ -1564,7 +1565,7 @@ function fetchTest(t: FetchTest, reverse: boolean = false): FetchTestResults {
       t.primaryKeys[i],
     );
     for (const row of rows) {
-      consume(source.push({type: 'add', row}));
+      consume(source.push(makeSourceChangeAdd(row)));
     }
     const snitch = new Snitch(source.connect(ordering), String(i), log);
     return {

--- a/packages/zql/src/ivm/exists.flip.push.test.ts
+++ b/packages/zql/src/ivm/exists.flip.push.test.ts
@@ -7,6 +7,11 @@ import {
 } from './test/fetch-and-push-tests.ts';
 import type {Format} from './view.ts';
 
+import {
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+  makeSourceChangeRemove,
+} from './source.ts';
 const sources: Sources = {
   issue: {
     columns: {
@@ -147,15 +152,7 @@ suite('EXISTS 1 to many', () => {
       sourceContents,
       ast,
       format,
-      pushes: [
-        [
-          'issue',
-          {
-            type: 'remove',
-            row: {id: 'i1', title: 'issue 1'},
-          },
-        ],
-      ],
+      pushes: [['issue', makeSourceChangeRemove({id: 'i1', title: 'issue 1'})]],
     });
 
     expect(data).toMatchInlineSnapshot(`
@@ -633,15 +630,7 @@ suite('EXISTS', () => {
       sources,
       sourceContents,
       ast,
-      pushes: [
-        [
-          'issue',
-          {
-            type: 'add',
-            row: {id: 'i5', text: 'fifth issue'},
-          },
-        ],
-      ],
+      pushes: [['issue', makeSourceChangeAdd({id: 'i5', text: 'fifth issue'})]],
       format,
     });
 
@@ -697,18 +686,9 @@ suite('EXISTS', () => {
       pushes: [
         [
           'comment',
-          {
-            type: 'add',
-            row: {id: 'c4', issueID: 'i5', text: 'i2 c54 text'},
-          },
+          makeSourceChangeAdd({id: 'c4', issueID: 'i5', text: 'i2 c54 text'}),
         ],
-        [
-          'issue',
-          {
-            type: 'add',
-            row: {id: 'i5', text: 'fifth issue'},
-          },
-        ],
+        ['issue', makeSourceChangeAdd({id: 'i5', text: 'fifth issue'})],
       ],
       format,
     });
@@ -813,13 +793,7 @@ suite('EXISTS', () => {
       sourceContents,
       ast,
       pushes: [
-        [
-          'issue',
-          {
-            type: 'remove',
-            row: {id: 'i2', text: 'first issue'},
-          },
-        ],
+        ['issue', makeSourceChangeRemove({id: 'i2', text: 'first issue'})],
       ],
       format,
     });
@@ -874,13 +848,7 @@ suite('EXISTS', () => {
       sourceContents,
       ast,
       pushes: [
-        [
-          'issue',
-          {
-            type: 'remove',
-            row: {id: 'i1', text: 'first issue'},
-          },
-        ],
+        ['issue', makeSourceChangeRemove({id: 'i1', text: 'first issue'})],
       ],
       format,
     });
@@ -961,11 +929,10 @@ suite('EXISTS', () => {
       pushes: [
         [
           'issue',
-          {
-            type: 'edit',
-            oldRow: {id: 'i2', text: 'second issue'},
-            row: {id: 'i2', text: 'second issue v2'},
-          },
+          makeSourceChangeEdit(
+            {id: 'i2', text: 'second issue v2'},
+            {id: 'i2', text: 'second issue'},
+          ),
         ],
       ],
       format,
@@ -1023,11 +990,10 @@ suite('EXISTS', () => {
       pushes: [
         [
           'issue',
-          {
-            type: 'edit',
-            oldRow: {id: 'i1', text: 'first issue'},
-            row: {id: 'i1', text: 'first issue v2'},
-          },
+          makeSourceChangeEdit(
+            {id: 'i1', text: 'first issue v2'},
+            {id: 'i1', text: 'first issue'},
+          ),
         ],
       ],
       format,
@@ -1116,10 +1082,7 @@ suite('EXISTS', () => {
       pushes: [
         [
           'comment',
-          {
-            type: 'add',
-            row: {id: 'c4', issueID: 'i2', text: 'i2 c4 text'},
-          },
+          makeSourceChangeAdd({id: 'c4', issueID: 'i2', text: 'i2 c4 text'}),
         ],
       ],
       format,
@@ -1227,10 +1190,7 @@ suite('EXISTS', () => {
       pushes: [
         [
           'comment',
-          {
-            type: 'add',
-            row: {id: 'c4', issueID: 'i1', text: 'i1 c4 text'},
-          },
+          makeSourceChangeAdd({id: 'c4', issueID: 'i1', text: 'i1 c4 text'}),
         ],
       ],
       format,
@@ -1339,10 +1299,7 @@ suite('EXISTS', () => {
       pushes: [
         [
           'comment',
-          {
-            type: 'remove',
-            row: {id: 'c1', issueID: 'i1', text: 'i1 c1 text'},
-          },
+          makeSourceChangeRemove({id: 'c1', issueID: 'i1', text: 'i1 c1 text'}),
         ],
       ],
       format,
@@ -1424,10 +1381,7 @@ suite('EXISTS', () => {
       pushes: [
         [
           'comment',
-          {
-            type: 'remove',
-            row: {id: 'c3', issueID: 'i3', text: 'i3 c3 text'},
-          },
+          makeSourceChangeRemove({id: 'c3', issueID: 'i3', text: 'i3 c3 text'}),
         ],
       ],
       format,
@@ -1524,11 +1478,10 @@ suite('EXISTS', () => {
       pushes: [
         [
           'comment',
-          {
-            type: 'edit',
-            oldRow: {id: 'c3', issueID: 'i3', text: 'i3 c3 text'},
-            row: {id: 'c3', issueID: 'i3', text: 'i3 c3 text v2'},
-          },
+          makeSourceChangeEdit(
+            {id: 'c3', issueID: 'i3', text: 'i3 c3 text v2'},
+            {id: 'c3', issueID: 'i3', text: 'i3 c3 text'},
+          ),
         ],
       ],
       format,
@@ -1638,11 +1591,10 @@ suite('EXISTS', () => {
       pushes: [
         [
           'comment',
-          {
-            type: 'edit',
-            oldRow: {id: 'c1', issueID: 'i1', text: 'i1 c1 text'},
-            row: {id: 'c1', issueID: 'i2', text: 'i2 c1 text'},
-          },
+          makeSourceChangeEdit(
+            {id: 'c1', issueID: 'i2', text: 'i2 c1 text'},
+            {id: 'c1', issueID: 'i1', text: 'i1 c1 text'},
+          ),
         ],
       ],
       format,

--- a/packages/zql/src/ivm/exists.push.test.ts
+++ b/packages/zql/src/ivm/exists.push.test.ts
@@ -7,6 +7,11 @@ import {
 } from './test/fetch-and-push-tests.ts';
 import type {Format} from './view.ts';
 
+import {
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+  makeSourceChangeRemove,
+} from './source.ts';
 const sources: Sources = {
   issue: {
     columns: {
@@ -138,15 +143,7 @@ suite('EXISTS 1 to many', () => {
       sourceContents,
       ast,
       format,
-      pushes: [
-        [
-          'issue',
-          {
-            type: 'remove',
-            row: {id: 'i1', title: 'issue 1'},
-          },
-        ],
-      ],
+      pushes: [['issue', makeSourceChangeRemove({id: 'i1', title: 'issue 1'})]],
     });
 
     expect(data).toMatchInlineSnapshot(`
@@ -452,15 +449,7 @@ suite('EXISTS', () => {
       sources,
       sourceContents,
       ast,
-      pushes: [
-        [
-          'issue',
-          {
-            type: 'add',
-            row: {id: 'i5', text: 'fifth issue'},
-          },
-        ],
-      ],
+      pushes: [['issue', makeSourceChangeAdd({id: 'i5', text: 'fifth issue'})]],
       format,
     });
 
@@ -520,18 +509,9 @@ suite('EXISTS', () => {
       pushes: [
         [
           'comment',
-          {
-            type: 'add',
-            row: {id: 'c4', issueID: 'i5', text: 'i2 c54 text'},
-          },
+          makeSourceChangeAdd({id: 'c4', issueID: 'i5', text: 'i2 c54 text'}),
         ],
-        [
-          'issue',
-          {
-            type: 'add',
-            row: {id: 'i5', text: 'fifth issue'},
-          },
-        ],
+        ['issue', makeSourceChangeAdd({id: 'i5', text: 'fifth issue'})],
       ],
       format,
     });
@@ -640,13 +620,7 @@ suite('EXISTS', () => {
       sourceContents,
       ast,
       pushes: [
-        [
-          'issue',
-          {
-            type: 'remove',
-            row: {id: 'i2', text: 'first issue'},
-          },
-        ],
+        ['issue', makeSourceChangeRemove({id: 'i2', text: 'first issue'})],
       ],
       format,
     });
@@ -705,13 +679,7 @@ suite('EXISTS', () => {
       sourceContents,
       ast,
       pushes: [
-        [
-          'issue',
-          {
-            type: 'remove',
-            row: {id: 'i1', text: 'first issue'},
-          },
-        ],
+        ['issue', makeSourceChangeRemove({id: 'i1', text: 'first issue'})],
       ],
       format,
     });
@@ -797,11 +765,10 @@ suite('EXISTS', () => {
       pushes: [
         [
           'issue',
-          {
-            type: 'edit',
-            oldRow: {id: 'i2', text: 'second issue'},
-            row: {id: 'i2', text: 'second issue v2'},
-          },
+          makeSourceChangeEdit(
+            {id: 'i2', text: 'second issue v2'},
+            {id: 'i2', text: 'second issue'},
+          ),
         ],
       ],
       format,
@@ -863,11 +830,10 @@ suite('EXISTS', () => {
       pushes: [
         [
           'issue',
-          {
-            type: 'edit',
-            oldRow: {id: 'i1', text: 'first issue'},
-            row: {id: 'i1', text: 'first issue v2'},
-          },
+          makeSourceChangeEdit(
+            {id: 'i1', text: 'first issue v2'},
+            {id: 'i1', text: 'first issue'},
+          ),
         ],
       ],
       format,
@@ -960,10 +926,7 @@ suite('EXISTS', () => {
       pushes: [
         [
           'comment',
-          {
-            type: 'add',
-            row: {id: 'c4', issueID: 'i2', text: 'i2 c4 text'},
-          },
+          makeSourceChangeAdd({id: 'c4', issueID: 'i2', text: 'i2 c4 text'}),
         ],
       ],
       format,
@@ -1075,10 +1038,7 @@ suite('EXISTS', () => {
       pushes: [
         [
           'comment',
-          {
-            type: 'add',
-            row: {id: 'c4', issueID: 'i1', text: 'i1 c4 text'},
-          },
+          makeSourceChangeAdd({id: 'c4', issueID: 'i1', text: 'i1 c4 text'}),
         ],
       ],
       format,
@@ -1191,10 +1151,7 @@ suite('EXISTS', () => {
       pushes: [
         [
           'comment',
-          {
-            type: 'remove',
-            row: {id: 'c1', issueID: 'i1', text: 'i1 c1 text'},
-          },
+          makeSourceChangeRemove({id: 'c1', issueID: 'i1', text: 'i1 c1 text'}),
         ],
       ],
       format,
@@ -1280,10 +1237,7 @@ suite('EXISTS', () => {
       pushes: [
         [
           'comment',
-          {
-            type: 'remove',
-            row: {id: 'c3', issueID: 'i3', text: 'i3 c3 text'},
-          },
+          makeSourceChangeRemove({id: 'c3', issueID: 'i3', text: 'i3 c3 text'}),
         ],
       ],
       format,
@@ -1384,11 +1338,10 @@ suite('EXISTS', () => {
       pushes: [
         [
           'comment',
-          {
-            type: 'edit',
-            oldRow: {id: 'c3', issueID: 'i3', text: 'i3 c3 text'},
-            row: {id: 'c3', issueID: 'i3', text: 'i3 c3 text v2'},
-          },
+          makeSourceChangeEdit(
+            {id: 'c3', issueID: 'i3', text: 'i3 c3 text v2'},
+            {id: 'c3', issueID: 'i3', text: 'i3 c3 text'},
+          ),
         ],
       ],
       format,
@@ -1502,11 +1455,10 @@ suite('EXISTS', () => {
       pushes: [
         [
           'comment',
-          {
-            type: 'edit',
-            oldRow: {id: 'c1', issueID: 'i1', text: 'i1 c1 text'},
-            row: {id: 'c1', issueID: 'i2', text: 'i2 c1 text'},
-          },
+          makeSourceChangeEdit(
+            {id: 'c1', issueID: 'i2', text: 'i2 c1 text'},
+            {id: 'c1', issueID: 'i1', text: 'i1 c1 text'},
+          ),
         ],
       ],
       format,
@@ -1658,15 +1610,7 @@ suite('NOT EXISTS', () => {
       sources,
       sourceContents,
       ast,
-      pushes: [
-        [
-          'issue',
-          {
-            type: 'add',
-            row: {id: 'i5', text: 'fifth issue'},
-          },
-        ],
-      ],
+      pushes: [['issue', makeSourceChangeAdd({id: 'i5', text: 'fifth issue'})]],
       format,
       enableNotExists: true,
     });
@@ -1741,18 +1685,9 @@ suite('NOT EXISTS', () => {
       pushes: [
         [
           'comment',
-          {
-            type: 'add',
-            row: {id: 'c4', issueID: 'i5', text: 'i2 c54 text'},
-          },
+          makeSourceChangeAdd({id: 'c4', issueID: 'i5', text: 'i2 c54 text'}),
         ],
-        [
-          'issue',
-          {
-            type: 'add',
-            row: {id: 'i5', text: 'fifth issue'},
-          },
-        ],
+        ['issue', makeSourceChangeAdd({id: 'i5', text: 'fifth issue'})],
       ],
       format,
       enableNotExists: true,
@@ -1792,13 +1727,7 @@ suite('NOT EXISTS', () => {
       sourceContents,
       ast,
       pushes: [
-        [
-          'issue',
-          {
-            type: 'remove',
-            row: {id: 'i2', text: 'first issue'},
-          },
-        ],
+        ['issue', makeSourceChangeRemove({id: 'i2', text: 'first issue'})],
       ],
       format,
       enableNotExists: true,
@@ -1861,13 +1790,7 @@ suite('NOT EXISTS', () => {
       sourceContents,
       ast,
       pushes: [
-        [
-          'issue',
-          {
-            type: 'remove',
-            row: {id: 'i1', text: 'first issue'},
-          },
-        ],
+        ['issue', makeSourceChangeRemove({id: 'i1', text: 'first issue'})],
       ],
       format,
       enableNotExists: true,
@@ -1910,11 +1833,10 @@ suite('NOT EXISTS', () => {
       pushes: [
         [
           'issue',
-          {
-            type: 'edit',
-            oldRow: {id: 'i2', text: 'second issue'},
-            row: {id: 'i2', text: 'second issue v2'},
-          },
+          makeSourceChangeEdit(
+            {id: 'i2', text: 'second issue v2'},
+            {id: 'i2', text: 'second issue'},
+          ),
         ],
       ],
       format,
@@ -1988,11 +1910,10 @@ suite('NOT EXISTS', () => {
       pushes: [
         [
           'issue',
-          {
-            type: 'edit',
-            oldRow: {id: 'i1', text: 'first issue'},
-            row: {id: 'i1', text: 'first issue v2'},
-          },
+          makeSourceChangeEdit(
+            {id: 'i1', text: 'first issue v2'},
+            {id: 'i1', text: 'first issue'},
+          ),
         ],
       ],
       format,
@@ -2035,10 +1956,7 @@ suite('NOT EXISTS', () => {
       pushes: [
         [
           'comment',
-          {
-            type: 'add',
-            row: {id: 'c4', issueID: 'i2', text: 'i2 c4 text'},
-          },
+          makeSourceChangeAdd({id: 'c4', issueID: 'i2', text: 'i2 c4 text'}),
         ],
       ],
       format,
@@ -2103,10 +2021,7 @@ suite('NOT EXISTS', () => {
       pushes: [
         [
           'comment',
-          {
-            type: 'add',
-            row: {id: 'c4', issueID: 'i1', text: 'i1 c4 text'},
-          },
+          makeSourceChangeAdd({id: 'c4', issueID: 'i1', text: 'i1 c4 text'}),
         ],
       ],
       format,
@@ -2149,10 +2064,7 @@ suite('NOT EXISTS', () => {
       pushes: [
         [
           'comment',
-          {
-            type: 'remove',
-            row: {id: 'c1', issueID: 'i1', text: 'i1 c1 text'},
-          },
+          makeSourceChangeRemove({id: 'c1', issueID: 'i1', text: 'i1 c1 text'}),
         ],
       ],
       format,
@@ -2229,10 +2141,7 @@ suite('NOT EXISTS', () => {
       pushes: [
         [
           'comment',
-          {
-            type: 'remove',
-            row: {id: 'c3', issueID: 'i3', text: 'i3 c3 text'},
-          },
+          makeSourceChangeRemove({id: 'c3', issueID: 'i3', text: 'i3 c3 text'}),
         ],
       ],
       format,
@@ -2275,11 +2184,10 @@ suite('NOT EXISTS', () => {
       pushes: [
         [
           'comment',
-          {
-            type: 'edit',
-            oldRow: {id: 'c3', issueID: 'i3', text: 'i3 c3 text'},
-            row: {id: 'c3', issueID: 'i3', text: 'i3 c3 text v2'},
-          },
+          makeSourceChangeEdit(
+            {id: 'c3', issueID: 'i3', text: 'i3 c3 text v2'},
+            {id: 'c3', issueID: 'i3', text: 'i3 c3 text'},
+          ),
         ],
       ],
       format,
@@ -2322,11 +2230,10 @@ suite('NOT EXISTS', () => {
       pushes: [
         [
           'comment',
-          {
-            type: 'edit',
-            oldRow: {id: 'c1', issueID: 'i1', text: 'i1 c1 text'},
-            row: {id: 'c1', issueID: 'i2', text: 'i2 c1 text'},
-          },
+          makeSourceChangeEdit(
+            {id: 'c1', issueID: 'i2', text: 'i2 c1 text'},
+            {id: 'c1', issueID: 'i1', text: 'i1 c1 text'},
+          ),
         ],
       ],
       format,

--- a/packages/zql/src/ivm/exists.ts
+++ b/packages/zql/src/ivm/exists.ts
@@ -1,7 +1,9 @@
 import {areEqual} from '../../../shared/src/arrays.ts';
 import {assert, unreachable} from '../../../shared/src/asserts.ts';
 import type {CompoundKey} from '../../../zero-protocol/src/ast.ts';
-import {type Change} from './change.ts';
+import {ChangeIndex} from './change-index.ts';
+import {ChangeType} from './change-type.ts';
+import {makeAddChange, makeRemoveChange, type Change} from './change.ts';
 import {normalizeUndefined, type Node, type NormalizedValue} from './data.ts';
 import {
   throwFilterOutput,
@@ -108,31 +110,34 @@ export class Exists implements FilterOperator {
     assert(!this.#inPush, 'Unexpected re-entrancy');
     this.#inPush = true;
     try {
-      switch (change.type) {
+      switch (change[ChangeIndex.TYPE]) {
         // add, remove and edit cannot change the size of the
         // this.#relationshipName relationship, so simply #pushWithFilter
-        case 'add':
-        case 'edit':
-        case 'remove': {
+        case ChangeType.ADD:
+        case ChangeType.EDIT:
+        case ChangeType.REMOVE: {
           yield* this.#pushWithFilter(change);
           return;
         }
-        case 'child':
+        case ChangeType.CHILD:
           // Only add and remove child changes for the
           // this.#relationshipName relationship, can change the size
           // of the this.#relationshipName relationship, for other
           // child changes simply #pushWithFilter
           if (
-            change.child.relationshipName !== this.#relationshipName ||
-            change.child.change.type === 'edit' ||
-            change.child.change.type === 'child'
+            change[ChangeIndex.CHILD_DATA].relationshipName !==
+              this.#relationshipName ||
+            change[ChangeIndex.CHILD_DATA].change[ChangeIndex.TYPE] ===
+              ChangeType.EDIT ||
+            change[ChangeIndex.CHILD_DATA].change[ChangeIndex.TYPE] ===
+              ChangeType.CHILD
           ) {
             yield* this.#pushWithFilter(change);
             return;
           }
-          switch (change.child.change.type) {
-            case 'add': {
-              const size = yield* this.#fetchSize(change.node);
+          switch (change[ChangeIndex.CHILD_DATA].change[ChangeIndex.TYPE]) {
+            case ChangeType.ADD: {
+              const size = yield* this.#fetchSize(change[ChangeIndex.NODE]);
               if (size === 1) {
                 if (this.#not) {
                   // Since the add child change currently being processed is not
@@ -140,24 +145,18 @@ export class Exists implements FilterOperator {
                   // the remove being pushed to output (since the child has
                   // never been added to the output).
                   yield* this.#output.push(
-                    {
-                      type: 'remove',
-                      node: {
-                        row: change.node.row,
-                        relationships: {
-                          ...change.node.relationships,
-                          [this.#relationshipName]: () => [],
-                        },
+                    makeRemoveChange({
+                      row: change[ChangeIndex.NODE].row,
+                      relationships: {
+                        ...change[ChangeIndex.NODE].relationships,
+                        [this.#relationshipName]: () => [],
                       },
-                    },
+                    }),
                     this,
                   );
                 } else {
                   yield* this.#output.push(
-                    {
-                      type: 'add',
-                      node: change.node,
-                    },
+                    makeAddChange(change[ChangeIndex.NODE]),
                     this,
                   );
                 }
@@ -166,15 +165,12 @@ export class Exists implements FilterOperator {
               }
               return;
             }
-            case 'remove': {
-              const size = yield* this.#fetchSize(change.node);
+            case ChangeType.REMOVE: {
+              const size = yield* this.#fetchSize(change[ChangeIndex.NODE]);
               if (size === 0) {
                 if (this.#not) {
                   yield* this.#output.push(
-                    {
-                      type: 'add',
-                      node: change.node,
-                    },
+                    makeAddChange(change[ChangeIndex.NODE]),
                     this,
                   );
                 } else {
@@ -182,18 +178,17 @@ export class Exists implements FilterOperator {
                   // not pushed to output, the removed child needs to be added to
                   // the remove being pushed to output.
                   yield* this.#output.push(
-                    {
-                      type: 'remove',
-                      node: {
-                        row: change.node.row,
-                        relationships: {
-                          ...change.node.relationships,
-                          [this.#relationshipName]: () => [
-                            change.child.change.node,
+                    makeRemoveChange({
+                      row: change[ChangeIndex.NODE].row,
+                      relationships: {
+                        ...change[ChangeIndex.NODE].relationships,
+                        [this.#relationshipName]: () => [
+                          change[ChangeIndex.CHILD_DATA].change[
+                            ChangeIndex.NODE
                           ],
-                        },
+                        ],
                       },
-                    },
+                    }),
                     this,
                   );
                 }
@@ -238,7 +233,7 @@ export class Exists implements FilterOperator {
    * Pushes a change if this.#filter is true for its row.
    */
   *#pushWithFilter(change: Change, exists?: boolean): Stream<'yield'> {
-    if (yield* this.#filter(change.node, exists)) {
+    if (yield* this.#filter(change[ChangeIndex.NODE], exists)) {
       yield* this.#output.push(change, this);
     }
   }

--- a/packages/zql/src/ivm/fan-in.ts
+++ b/packages/zql/src/ivm/fan-in.ts
@@ -1,6 +1,7 @@
 import {assert} from '../../../shared/src/asserts.ts';
 import {emptyArray, identity} from '../../../shared/src/sentinels.ts';
-import type {Change} from './change.ts';
+import type {ChangeType} from './change-type.ts';
+import {type Change} from './change.ts';
 import {type Node} from './data.ts';
 import type {FanOut} from './fan-out.ts';
 import {
@@ -72,7 +73,7 @@ export class FanIn implements FilterOperator {
     return emptyArray;
   }
 
-  *fanOutDonePushingToAllBranches(fanOutChangeType: Change['type']) {
+  *fanOutDonePushingToAllBranches(fanOutChangeType: ChangeType) {
     if (this.#inputs.length === 0) {
       assert(
         this.#accumulatedPushes.length === 0,

--- a/packages/zql/src/ivm/fan-out-fan-in.test.ts
+++ b/packages/zql/src/ivm/fan-out-fan-in.test.ts
@@ -14,6 +14,11 @@ import {Filter} from './filter.ts';
 import {consume} from './stream.ts';
 import {createSource} from './test/source-factory.ts';
 
+import {
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+  makeSourceChangeRemove,
+} from './source.ts';
 const lc = createSilentLogContext();
 const mockDelegate = {
   addEdge() {},
@@ -39,11 +44,9 @@ test('fan-out pushes along all paths', () => {
   const fanIn = new FanIn(fanOut, []);
   fanOut.setFanIn(fanIn);
 
-  consume(s.push({type: 'add', row: {a: 1, b: 'foo'}}));
-  consume(
-    s.push({type: 'edit', oldRow: {a: 1, b: 'foo'}, row: {a: 1, b: 'bar'}}),
-  );
-  consume(s.push({type: 'remove', row: {a: 1, b: 'bar'}}));
+  consume(s.push(makeSourceChangeAdd({a: 1, b: 'foo'})));
+  consume(s.push(makeSourceChangeEdit({a: 1, b: 'bar'}, {a: 1, b: 'foo'})));
+  consume(s.push(makeSourceChangeRemove({a: 1, b: 'bar'})));
 
   expect(catch1.pushes).toMatchInlineSnapshot(`
     [
@@ -173,9 +176,9 @@ test('fan-out,fan-in pairing does not duplicate pushes', () => {
   });
   const out = new Catch(pipeline);
 
-  consume(s.push({type: 'add', row: {a: 1, b: 'foo'}}));
-  consume(s.push({type: 'add', row: {a: 2, b: 'foo'}}));
-  consume(s.push({type: 'add', row: {a: 3, b: 'foo'}}));
+  consume(s.push(makeSourceChangeAdd({a: 1, b: 'foo'})));
+  consume(s.push(makeSourceChangeAdd({a: 2, b: 'foo'})));
+  consume(s.push(makeSourceChangeAdd({a: 3, b: 'foo'})));
 
   expect(out.pushes).toMatchInlineSnapshot(`
     [
@@ -222,10 +225,10 @@ test('fan-in fetch', () => {
     ['a', 'b'],
   );
 
-  consume(s.push({type: 'add', row: {a: false, b: false}}));
-  consume(s.push({type: 'add', row: {a: false, b: true}}));
-  consume(s.push({type: 'add', row: {a: true, b: false}}));
-  consume(s.push({type: 'add', row: {a: true, b: true}}));
+  consume(s.push(makeSourceChangeAdd({a: false, b: false})));
+  consume(s.push(makeSourceChangeAdd({a: false, b: true})));
+  consume(s.push(makeSourceChangeAdd({a: true, b: false})));
+  consume(s.push(makeSourceChangeAdd({a: true, b: true})));
 
   const connector = s.connect([
     ['a', 'asc'],

--- a/packages/zql/src/ivm/fan-out.ts
+++ b/packages/zql/src/ivm/fan-out.ts
@@ -1,4 +1,5 @@
 import {must} from '../../../shared/src/must.ts';
+import {ChangeIndex} from './change-index.ts';
 import type {Change} from './change.ts';
 import type {Node} from './data.ts';
 import type {FanIn} from './fan-in.ts';
@@ -77,6 +78,6 @@ export class FanOut implements FilterOperator {
     yield* must(
       this.#fanIn,
       'fan-out must have a corresponding fan-in set!',
-    ).fanOutDonePushingToAllBranches(change.type);
+    ).fanOutDonePushingToAllBranches(change[ChangeIndex.TYPE]);
   }
 }

--- a/packages/zql/src/ivm/filter-push.ts
+++ b/packages/zql/src/ivm/filter-push.ts
@@ -1,5 +1,7 @@
 import {unreachable} from '../../../shared/src/asserts.ts';
 import type {Row} from '../../../zero-protocol/src/data.ts';
+import {ChangeIndex} from './change-index.ts';
+import {ChangeType} from './change-type.ts';
 import type {Change} from './change.ts';
 import {maybeSplitAndPushEditChange} from './maybe-split-and-push-edit-change.ts';
 import type {InputBase, Output} from './operator.ts';
@@ -15,19 +17,19 @@ export function* filterPush(
     yield* output.push(change, pusher);
     return;
   }
-  switch (change.type) {
-    case 'add':
-    case 'remove':
-      if (predicate(change.node.row)) {
+  switch (change[ChangeIndex.TYPE]) {
+    case ChangeType.ADD:
+    case ChangeType.REMOVE:
+      if (predicate(change[ChangeIndex.NODE].row)) {
         yield* output.push(change, pusher);
       }
       break;
-    case 'child':
-      if (predicate(change.node.row)) {
+    case ChangeType.CHILD:
+      if (predicate(change[ChangeIndex.NODE].row)) {
         yield* output.push(change, pusher);
       }
       break;
-    case 'edit':
+    case ChangeType.EDIT:
       yield* maybeSplitAndPushEditChange(change, predicate, output, pusher);
       break;
     default:

--- a/packages/zql/src/ivm/filter.test.ts
+++ b/packages/zql/src/ivm/filter.test.ts
@@ -8,6 +8,11 @@ import {Filter} from './filter.ts';
 import {consume} from './stream.ts';
 import {createSource} from './test/source-factory.ts';
 
+import {
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+  makeSourceChangeRemove,
+} from './source.ts';
 const lc = createSilentLogContext();
 const mockDelegate = {
   addEdge() {},
@@ -21,9 +26,9 @@ test('basics', () => {
     {a: {type: 'number'}, b: {type: 'string'}},
     ['a'],
   );
-  consume(ms.push({type: 'add', row: {a: 3, b: 'foo'}}));
-  consume(ms.push({type: 'add', row: {a: 2, b: 'bar'}}));
-  consume(ms.push({type: 'add', row: {a: 1, b: 'foo'}}));
+  consume(ms.push(makeSourceChangeAdd({a: 3, b: 'foo'})));
+  consume(ms.push(makeSourceChangeAdd({a: 2, b: 'bar'})));
+  consume(ms.push(makeSourceChangeAdd({a: 1, b: 'foo'})));
 
   const connector = ms.connect([['a', 'asc']]);
   const filter = buildFilterPipeline(
@@ -52,10 +57,10 @@ test('basics', () => {
       },
     ]
   `);
-  consume(ms.push({type: 'add', row: {a: 4, b: 'bar'}}));
-  consume(ms.push({type: 'add', row: {a: 5, b: 'foo'}}));
-  consume(ms.push({type: 'remove', row: {a: 3, b: 'foo'}}));
-  consume(ms.push({type: 'remove', row: {a: 2, b: 'bar'}}));
+  consume(ms.push(makeSourceChangeAdd({a: 4, b: 'bar'})));
+  consume(ms.push(makeSourceChangeAdd({a: 5, b: 'foo'})));
+  consume(ms.push(makeSourceChangeRemove({a: 3, b: 'foo'})));
+  consume(ms.push(makeSourceChangeRemove({a: 2, b: 'bar'})));
 
   expect(out.pushes).toMatchInlineSnapshot(`
     [
@@ -96,7 +101,7 @@ test('edit', () => {
     {a: 2, x: 2},
     {a: 3, x: 3},
   ]) {
-    consume(ms.push({type: 'add', row}));
+    consume(ms.push(makeSourceChangeAdd(row)));
   }
 
   const connector = ms.connect([['a', 'asc']]);
@@ -119,8 +124,8 @@ test('edit', () => {
     ]
   `);
 
-  consume(ms.push({type: 'add', row: {a: 4, x: 4}}));
-  consume(ms.push({type: 'edit', oldRow: {a: 3, x: 3}, row: {a: 3, x: 6}}));
+  consume(ms.push(makeSourceChangeAdd({a: 4, x: 4})));
+  consume(ms.push(makeSourceChangeEdit({a: 3, x: 6}, {a: 3, x: 3})));
 
   expect(out.pushes).toMatchInlineSnapshot(`
     [
@@ -173,7 +178,7 @@ test('edit', () => {
   `);
 
   out.pushes.length = 0;
-  consume(ms.push({type: 'edit', oldRow: {a: 3, x: 6}, row: {a: 3, x: 5}}));
+  consume(ms.push(makeSourceChangeEdit({a: 3, x: 5}, {a: 3, x: 6})));
   expect(out.pushes).toMatchInlineSnapshot(`
     [
       {
@@ -208,7 +213,7 @@ test('edit', () => {
   `);
 
   out.pushes.length = 0;
-  consume(ms.push({type: 'edit', oldRow: {a: 3, x: 5}, row: {a: 3, x: 7}}));
+  consume(ms.push(makeSourceChangeEdit({a: 3, x: 7}, {a: 3, x: 5})));
   expect(out.pushes).toMatchInlineSnapshot(`[]`);
   expect(out.fetch({})).toMatchInlineSnapshot(`
     [
@@ -230,7 +235,7 @@ test('edit', () => {
   `);
 
   out.pushes.length = 0;
-  consume(ms.push({type: 'edit', oldRow: {a: 2, x: 2}, row: {a: 2, x: 4}}));
+  consume(ms.push(makeSourceChangeEdit({a: 2, x: 4}, {a: 2, x: 2})));
   expect(out.pushes).toMatchInlineSnapshot(`
     [
       {

--- a/packages/zql/src/ivm/flipped-join.fetch.test.ts
+++ b/packages/zql/src/ivm/flipped-join.fetch.test.ts
@@ -13,6 +13,7 @@ import {Snitch, type SnitchMessage} from './snitch.ts';
 import {consume} from './stream.ts';
 import {createSource} from './test/source-factory.ts';
 
+import {makeSourceChangeAdd} from './source.ts';
 /**
  * These tests are based on join.fetch.test.ts.  Uses same cases.
  * Most of the data snapshots are the same expect for when
@@ -1917,7 +1918,7 @@ function fetchTest(t: FetchTest): FetchTestResults {
       t.primaryKeys[i],
     );
     for (const row of rows) {
-      consume(source.push({type: 'add', row}));
+      consume(source.push(makeSourceChangeAdd(row)));
     }
     const snitch = new Snitch(source.connect(ordering), String(i), log);
     return {

--- a/packages/zql/src/ivm/flipped-join.push.test.ts
+++ b/packages/zql/src/ivm/flipped-join.push.test.ts
@@ -7,6 +7,11 @@ import {
 } from './test/fetch-and-push-tests.ts';
 import type {Format} from './view.ts';
 
+import {
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+  makeSourceChangeRemove,
+} from './source.ts';
 /**
  * These tests are based on join.push.test.ts.  Uses same cases.
  * Most of the data snapshots are the same expect for when
@@ -70,7 +75,7 @@ suite('push one:many', () => {
       },
       ast,
       format,
-      pushes: [['issue', {type: 'remove', row: {id: 'i1'}}]],
+      pushes: [['issue', makeSourceChangeRemove({id: 'i1'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -110,7 +115,7 @@ suite('push one:many', () => {
       },
       ast,
       format,
-      pushes: [['comment', {type: 'remove', row: {id: 'c1', issueID: 'i1'}}]],
+      pushes: [['comment', makeSourceChangeRemove({id: 'c1', issueID: 'i1'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -151,7 +156,7 @@ suite('push one:many', () => {
       },
       ast,
       format,
-      pushes: [['issue', {type: 'add', row: {id: 'i1'}}]],
+      pushes: [['issue', makeSourceChangeAdd({id: 'i1'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -249,7 +254,7 @@ suite('push one:many', () => {
       },
       ast,
       format,
-      pushes: [['issue', {type: 'add', row: {id: 'i1'}}]],
+      pushes: [['issue', makeSourceChangeAdd({id: 'i1'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -356,7 +361,7 @@ suite('push one:many', () => {
       },
       ast,
       format,
-      pushes: [['issue', {type: 'add', row: {id: 'i2'}}]],
+      pushes: [['issue', makeSourceChangeAdd({id: 'i2'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -396,7 +401,7 @@ suite('push one:many', () => {
       },
       ast,
       format,
-      pushes: [['comment', {type: 'add', row: {id: 'c1', issueID: 'i1'}}]],
+      pushes: [['comment', makeSourceChangeAdd({id: 'c1', issueID: 'i1'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -492,7 +497,7 @@ suite('push one:many', () => {
       },
       ast,
       format,
-      pushes: [['comment', {type: 'add', row: {id: 'c1', issueID: 'i2'}}]],
+      pushes: [['comment', makeSourceChangeAdd({id: 'c1', issueID: 'i2'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -533,7 +538,7 @@ suite('push one:many', () => {
       },
       ast,
       format,
-      pushes: [['issue', {type: 'remove', row: {id: 'i1'}}]],
+      pushes: [['issue', makeSourceChangeRemove({id: 'i1'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -617,7 +622,7 @@ suite('push one:many', () => {
       },
       ast,
       format,
-      pushes: [['issue', {type: 'remove', row: {id: 'i1'}}]],
+      pushes: [['issue', makeSourceChangeRemove({id: 'i1'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -706,11 +711,11 @@ suite('push one:many', () => {
       ast,
       format,
       pushes: [
-        ['issue', {type: 'add', row: {id: 'i1'}}],
-        ['comment', {type: 'add', row: {id: 'c1', issueID: 'i1'}}],
-        ['comment', {type: 'add', row: {id: 'c2', issueID: 'i1'}}],
-        ['comment', {type: 'remove', row: {id: 'c1', issueID: 'i1'}}],
-        ['issue', {type: 'remove', row: {id: 'i1'}}],
+        ['issue', makeSourceChangeAdd({id: 'i1'})],
+        ['comment', makeSourceChangeAdd({id: 'c1', issueID: 'i1'})],
+        ['comment', makeSourceChangeAdd({id: 'c2', issueID: 'i1'})],
+        ['comment', makeSourceChangeRemove({id: 'c1', issueID: 'i1'})],
+        ['issue', makeSourceChangeRemove({id: 'i1'})],
       ],
     });
 
@@ -1024,11 +1029,10 @@ suite('push one:many', () => {
         pushes: [
           [
             'issue',
-            {
-              type: 'edit',
-              oldRow: {id: 'i1', text: 'issue 1'},
-              row: {id: 'i1', text: 'issue 1 edited'},
-            },
+            makeSourceChangeEdit(
+              {id: 'i1', text: 'issue 1 edited'},
+              {id: 'i1', text: 'issue 1'},
+            ),
           ],
         ],
       });
@@ -1132,11 +1136,10 @@ suite('push one:many', () => {
         pushes: [
           [
             'comment',
-            {
-              type: 'edit',
-              oldRow: {id: 'c1', issueID: 'i1', text: 'comment 1'},
-              row: {id: 'c1', issueID: 'i1', text: 'comment 1 edited'},
-            },
+            makeSourceChangeEdit(
+              {id: 'c1', issueID: 'i1', text: 'comment 1 edited'},
+              {id: 'c1', issueID: 'i1', text: 'comment 1'},
+            ),
           ],
         ],
       });
@@ -1266,11 +1269,10 @@ suite('push one:many', () => {
         pushes: [
           [
             'comment',
-            {
-              type: 'edit',
-              oldRow: {id: 'c1', issueID: 'i1', text: 'comment 1'},
-              row: {id: 'c1', issueID: 'i2', text: 'comment 1.2'},
-            },
+            makeSourceChangeEdit(
+              {id: 'c1', issueID: 'i2', text: 'comment 1.2'},
+              {id: 'c1', issueID: 'i1', text: 'comment 1'},
+            ),
           ],
         ],
       });
@@ -1467,11 +1469,10 @@ suite('push one:many', () => {
         pushes: [
           [
             'issue',
-            {
-              type: 'edit',
-              oldRow: {id: 'i1', text: 'issue 1'},
-              row: {id: 'i3', text: 'issue 1.3'},
-            },
+            makeSourceChangeEdit(
+              {id: 'i3', text: 'issue 1.3'},
+              {id: 'i1', text: 'issue 1'},
+            ),
           ],
         ],
       });
@@ -1696,7 +1697,7 @@ suite('push many:one', () => {
       },
       ast,
       format,
-      pushes: [['issue', {type: 'add', row: {id: 'i1', ownerID: 'u1'}}]],
+      pushes: [['issue', makeSourceChangeAdd({id: 'i1', ownerID: 'u1'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -1791,7 +1792,7 @@ suite('push many:one', () => {
       },
       ast,
       format,
-      pushes: [['issue', {type: 'add', row: {id: 'i1', ownerID: 'u2'}}]],
+      pushes: [['issue', makeSourceChangeAdd({id: 'i1', ownerID: 'u2'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -1832,7 +1833,7 @@ suite('push many:one', () => {
       },
       ast,
       format,
-      pushes: [['user', {type: 'add', row: {id: 'u1'}}]],
+      pushes: [['user', makeSourceChangeAdd({id: 'u1'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -1929,7 +1930,7 @@ suite('push many:one', () => {
       },
       ast,
       format,
-      pushes: [['user', {type: 'add', row: {id: 'u1'}}]],
+      pushes: [['user', makeSourceChangeAdd({id: 'u1'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -2095,11 +2096,10 @@ suite('push many:one', () => {
         pushes: [
           [
             'user',
-            {
-              type: 'edit',
-              row: {id: 'u1', text: 'user 1'},
-              oldRow: {id: 'u2', text: 'user 2'},
-            },
+            makeSourceChangeEdit(
+              {id: 'u1', text: 'user 1'},
+              {id: 'u2', text: 'user 2'},
+            ),
           ],
         ],
       });
@@ -2354,11 +2354,10 @@ suite('push many:one', () => {
         pushes: [
           [
             'issue',
-            {
-              type: 'edit',
-              row: {id: 'i2', ownerID: 'u1', text: 'item 2'},
-              oldRow: {id: 'i2', ownerID: 'u2', text: 'item 2'},
-            },
+            makeSourceChangeEdit(
+              {id: 'i2', ownerID: 'u1', text: 'item 2'},
+              {id: 'i2', ownerID: 'u2', text: 'item 2'},
+            ),
           ],
         ],
       });
@@ -2689,11 +2688,10 @@ suite('push many:one', () => {
         pushes: [
           [
             'user',
-            {
-              type: 'edit',
-              row: {id: 'u2', text: 'user 2 changed'},
-              oldRow: {id: 'u2', text: 'user 2'},
-            },
+            makeSourceChangeEdit(
+              {id: 'u2', text: 'user 2 changed'},
+              {id: 'u2', text: 'user 2'},
+            ),
           ],
         ],
       });
@@ -2746,11 +2744,10 @@ suite('push many:one', () => {
         pushes: [
           [
             'user',
-            {
-              type: 'edit',
-              row: {id: 'u1', text: 'user 1 changed'},
-              oldRow: {id: 'u1', text: 'user 1'},
-            },
+            makeSourceChangeEdit(
+              {id: 'u1', text: 'user 1 changed'},
+              {id: 'u1', text: 'user 1'},
+            ),
           ],
         ],
       });
@@ -2990,7 +2987,7 @@ suite('push one:many:many', () => {
       },
       ast,
       format,
-      pushes: [['revision', {type: 'add', row: {id: 'r1', commentID: 'c1'}}]],
+      pushes: [['revision', makeSourceChangeAdd({id: 'r1', commentID: 'c1'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -3148,7 +3145,7 @@ suite('push one:many:many', () => {
       },
       ast,
       format,
-      pushes: [['comment', {type: 'add', row: {id: 'c1', issueID: 'i1'}}]],
+      pushes: [['comment', makeSourceChangeAdd({id: 'c1', issueID: 'i1'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -3306,7 +3303,7 @@ suite('push one:many:many', () => {
       },
       ast,
       format,
-      pushes: [['issue', {type: 'add', row: {id: 'i1'}}]],
+      pushes: [['issue', makeSourceChangeAdd({id: 'i1'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -3449,7 +3446,7 @@ suite('push one:many:many', () => {
       },
       ast,
       format,
-      pushes: [['issue', {type: 'remove', row: {id: 'i1'}}]],
+      pushes: [['issue', makeSourceChangeRemove({id: 'i1'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -3649,7 +3646,7 @@ suite('push one:many:one', () => {
       },
       ast,
       format,
-      pushes: [['label', {type: 'add', row: {id: 'l1'}}]],
+      pushes: [['label', makeSourceChangeAdd({id: 'l1'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -3803,7 +3800,7 @@ suite('push one:many:one', () => {
       ast,
       format,
       pushes: [
-        ['issueLabel', {type: 'add', row: {issueID: 'i1', labelID: 'l1'}}],
+        ['issueLabel', makeSourceChangeAdd({issueID: 'i1', labelID: 'l1'})],
       ],
     });
 
@@ -3961,7 +3958,7 @@ suite('push one:many:one', () => {
       },
       ast,
       format,
-      pushes: [['label', {type: 'add', row: {id: 'l1'}}]],
+      pushes: [['label', makeSourceChangeAdd({id: 'l1'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -4315,21 +4312,20 @@ describe('edit assignee', () => {
       pushes: [
         [
           'issue',
-          {
-            type: 'edit',
-            oldRow: {
-              issueID: 'i1',
-              text: 'first issue',
-              assigneeID: undefined,
-              creatorID: 'u1',
-            },
-            row: {
+          makeSourceChangeEdit(
+            {
               issueID: 'i1',
               text: 'first issue',
               assigneeID: 'u1',
               creatorID: 'u1',
             },
-          },
+            {
+              issueID: 'i1',
+              text: 'first issue',
+              assigneeID: undefined,
+              creatorID: 'u1',
+            },
+          ),
         ],
       ],
       format,
@@ -4621,21 +4617,20 @@ describe('edit assignee', () => {
       pushes: [
         [
           'issue',
-          {
-            type: 'edit',
-            oldRow: {
-              issueID: 'i1',
-              text: 'first issue',
-              assigneeID: undefined,
-              creatorID: 'u1',
-            },
-            row: {
+          makeSourceChangeEdit(
+            {
               issueID: 'i1',
               text: 'first issue',
               assigneeID: 'u1',
               creatorID: 'u1',
             },
-          },
+            {
+              issueID: 'i1',
+              text: 'first issue',
+              assigneeID: undefined,
+              creatorID: 'u1',
+            },
+          ),
         ],
       ],
       format,
@@ -4899,21 +4894,20 @@ describe('edit assignee', () => {
       pushes: [
         [
           'issue',
-          {
-            type: 'edit',
-            oldRow: {
-              issueID: 'i1',
-              text: 'first issue',
-              assigneeID: 'u1',
-              creatorID: 'u1',
-            },
-            row: {
+          makeSourceChangeEdit(
+            {
               issueID: 'i1',
               text: 'first issue',
               assigneeID: undefined,
               creatorID: 'u1',
             },
-          },
+            {
+              issueID: 'i1',
+              text: 'first issue',
+              assigneeID: 'u1',
+              creatorID: 'u1',
+            },
+          ),
         ],
       ],
       format,
@@ -5185,21 +5179,20 @@ describe('edit assignee', () => {
       pushes: [
         [
           'issue',
-          {
-            type: 'edit',
-            oldRow: {
-              issueID: 'i1',
-              text: 'first issue',
-              assigneeID: 'u1',
-              creatorID: 'u1',
-            },
-            row: {
+          makeSourceChangeEdit(
+            {
               issueID: 'i1',
               text: 'first issue',
               assigneeID: undefined,
               creatorID: 'u1',
             },
-          },
+            {
+              issueID: 'i1',
+              text: 'first issue',
+              assigneeID: 'u1',
+              creatorID: 'u1',
+            },
+          ),
         ],
       ],
       format,
@@ -5483,20 +5476,8 @@ describe('joins with compound join keys', () => {
       sourceContents,
       ast,
       pushes: [
-        [
-          'a',
-          {
-            type: 'add',
-            row: {id: 2, a1: 7, a2: 8, a3: 9},
-          },
-        ],
-        [
-          'b',
-          {
-            type: 'add',
-            row: {id: 2, b1: 8, b2: 7, b3: 9},
-          },
-        ],
+        ['a', makeSourceChangeAdd({id: 2, a1: 7, a2: 8, a3: 9})],
+        ['b', makeSourceChangeAdd({id: 2, b1: 8, b2: 7, b3: 9})],
       ],
       format,
     });
@@ -5668,11 +5649,10 @@ describe('joins with compound join keys', () => {
       pushes: [
         [
           'a',
-          {
-            type: 'edit',
-            oldRow: {id: 0, a1: 1, a2: 2, a3: 3},
-            row: {id: 0, a1: 1, a2: 2, a3: 33},
-          },
+          makeSourceChangeEdit(
+            {id: 0, a1: 1, a2: 2, a3: 33},
+            {id: 0, a1: 1, a2: 2, a3: 3},
+          ),
         ],
       ],
       format,
@@ -5856,7 +5836,7 @@ suite('test overlay on many:one pushes', () => {
       },
       ast,
       format,
-      pushes: [['user', {type: 'add', row: {id: 'u1', name: 'Aaron'}}]],
+      pushes: [['user', makeSourceChangeAdd({id: 'u1', name: 'Aaron'})]],
       fetchOnPush: true,
     });
 
@@ -6160,7 +6140,7 @@ suite('test overlay on many:one pushes', () => {
       },
       ast,
       format,
-      pushes: [['user', {type: 'remove', row: {id: 'u1', name: 'Aaron'}}]],
+      pushes: [['user', makeSourceChangeRemove({id: 'u1', name: 'Aaron'})]],
       fetchOnPush: true,
     });
 
@@ -6436,11 +6416,10 @@ suite('test overlay on many:one pushes', () => {
       pushes: [
         [
           'user',
-          {
-            type: 'edit',
-            oldRow: {id: 'u1', name: 'Aaron'},
-            row: {id: 'u1', name: 'Boogs'},
-          },
+          makeSourceChangeEdit(
+            {id: 'u1', name: 'Boogs'},
+            {id: 'u1', name: 'Aaron'},
+          ),
         ],
       ],
       fetchOnPush: true,
@@ -6852,11 +6831,10 @@ suite('test overlay on many:one pushes', () => {
       pushes: [
         [
           'state',
-          {
-            type: 'edit',
-            oldRow: {id: 's0', name: 'Hawaii'},
-            row: {id: 's0', name: 'HI'},
-          },
+          makeSourceChangeEdit(
+            {id: 's0', name: 'HI'},
+            {id: 's0', name: 'Hawaii'},
+          ),
         ],
       ],
       fetchOnPush: true,
@@ -7634,7 +7612,9 @@ suite('test overlay on many:many (no junction) pushes', () => {
       },
       ast,
       format,
-      pushes: [['user', {type: 'add', row: {id: 'u2', name: 'Aaron', num: 2}}]],
+      pushes: [
+        ['user', makeSourceChangeAdd({id: 'u2', name: 'Aaron', num: 2})],
+      ],
       fetchOnPush: true,
     });
 
@@ -8068,7 +8048,7 @@ suite('test overlay on many:many (no junction) pushes', () => {
       ast,
       format,
       pushes: [
-        ['user', {type: 'remove', row: {id: 'u2', name: 'Aaron', num: 2}}],
+        ['user', makeSourceChangeRemove({id: 'u2', name: 'Aaron', num: 2})],
       ],
       fetchOnPush: true,
     });
@@ -8477,11 +8457,10 @@ suite('test overlay on many:many (no junction) pushes', () => {
       pushes: [
         [
           'user',
-          {
-            type: 'edit',
-            oldRow: {id: 'u2', name: 'Aaron', num: 2},
-            row: {id: 'u2', name: 'Aaron', num: 5},
-          },
+          makeSourceChangeEdit(
+            {id: 'u2', name: 'Aaron', num: 5},
+            {id: 'u2', name: 'Aaron', num: 2},
+          ),
         ],
       ],
       fetchOnPush: true,
@@ -9014,11 +8993,10 @@ suite('test overlay on many:many (no junction) pushes', () => {
       pushes: [
         [
           'state',
-          {
-            type: 'edit',
-            oldRow: {id: 's0', name: 'Hawaii'},
-            row: {id: 's0', name: 'HI'},
-          },
+          makeSourceChangeEdit(
+            {id: 's0', name: 'HI'},
+            {id: 's0', name: 'Hawaii'},
+          ),
         ],
       ],
       fetchOnPush: true,

--- a/packages/zql/src/ivm/flipped-join.sibling.test.ts
+++ b/packages/zql/src/ivm/flipped-join.sibling.test.ts
@@ -10,7 +10,12 @@ import {Catch, type CaughtChange} from './catch.ts';
 import {FlippedJoin} from './flipped-join.ts';
 import type {Input} from './operator.ts';
 import {Snitch, type SnitchMessage} from './snitch.ts';
-import type {SourceChange} from './source.ts';
+import {
+  type SourceChange,
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+  makeSourceChangeRemove,
+} from './source.ts';
 import {consume} from './stream.ts';
 import {createSource} from './test/source-factory.ts';
 
@@ -62,7 +67,7 @@ suite('sibling relationships tests with issues, comments, and owners', () => {
         ],
         [{id: 'o1'}, {id: 'o2'}],
       ],
-      pushes: [[0, {type: 'add', row: {id: 'i3', ownerId: 'o2'}}]],
+      pushes: [[0, makeSourceChangeAdd({id: 'i3', ownerId: 'o2'})]],
     });
     expect(log).toMatchInlineSnapshot(`
       [
@@ -117,7 +122,7 @@ suite('sibling relationships tests with issues, comments, and owners', () => {
         ],
         [{id: 'o1'}],
       ],
-      pushes: [[2, {type: 'add', row: {id: 'o2'}}]],
+      pushes: [[2, makeSourceChangeAdd({id: 'o2'})]],
     });
     expect(log).toMatchInlineSnapshot(`
       [
@@ -304,7 +309,7 @@ suite('sibling relationships tests with issues, comments, and owners', () => {
         ],
         [{id: 'o1'}, {id: 'o2'}],
       ],
-      pushes: [[1, {type: 'add', row: {id: 'c5', issueId: 'i1'}}]],
+      pushes: [[1, makeSourceChangeAdd({id: 'c5', issueId: 'i1'})]],
     });
     expect(log).toMatchInlineSnapshot(`
       [
@@ -420,7 +425,7 @@ suite('sibling relationships tests with issues, comments, and owners', () => {
         ],
         [{id: 'o1'}, {id: 'o2'}],
       ],
-      pushes: [[2, {type: 'remove', row: {id: 'o2'}}]],
+      pushes: [[2, makeSourceChangeRemove({id: 'o2'})]],
     });
     expect(log).toMatchInlineSnapshot(`
       [
@@ -607,7 +612,7 @@ suite('sibling relationships tests with issues, comments, and owners', () => {
         ],
         [{id: 'o1'}, {id: 'o2'}],
       ],
-      pushes: [[1, {type: 'remove', row: {id: 'c4', issueId: 'i2'}}]],
+      pushes: [[1, makeSourceChangeRemove({id: 'c4', issueId: 'i2'})]],
     });
     expect(log).toMatchInlineSnapshot(`
       [
@@ -749,11 +754,10 @@ suite('sibling relationships tests with issues, comments, and owners', () => {
         pushes: [
           [
             0,
-            {
-              type: 'edit',
-              oldRow: {id: 'i1', ownerId: 'o1', text: 'issue 1'},
-              row: {id: 'i1', ownerId: 'o1', text: 'issue 1 changed'},
-            },
+            makeSourceChangeEdit(
+              {id: 'i1', ownerId: 'o1', text: 'issue 1 changed'},
+              {id: 'i1', ownerId: 'o1', text: 'issue 1'},
+            ),
           ],
         ],
       });
@@ -841,11 +845,10 @@ suite('sibling relationships tests with issues, comments, and owners', () => {
         pushes: [
           [
             1,
-            {
-              type: 'edit',
-              oldRow: {id: 'c4', issueId: 'i2', text: 'comment 4'},
-              row: {id: 'c4', issueId: 'i2', text: 'comment 4 changed'},
-            },
+            makeSourceChangeEdit(
+              {id: 'c4', issueId: 'i2', text: 'comment 4 changed'},
+              {id: 'c4', issueId: 'i2', text: 'comment 4'},
+            ),
           ],
         ],
       });
@@ -944,11 +947,10 @@ suite('sibling relationships tests with issues, comments, and owners', () => {
         pushes: [
           [
             2,
-            {
-              type: 'edit',
-              oldRow: {id: 'o2', text: 'owner 2'},
-              row: {id: 'o2', text: 'owner 2 changed'},
-            },
+            makeSourceChangeEdit(
+              {id: 'o2', text: 'owner 2 changed'},
+              {id: 'o2', text: 'owner 2'},
+            ),
           ],
         ],
       });
@@ -1115,7 +1117,7 @@ function pushSiblingTest(t: PushTestSibling): PushTestSiblingResults {
       t.primaryKeys[i],
     );
     for (const row of rows) {
-      consume(source.push({type: 'add', row}));
+      consume(source.push(makeSourceChangeAdd(row)));
     }
     const snitch = new Snitch(source.connect(ordering), String(i), log, [
       'fetch',

--- a/packages/zql/src/ivm/flipped-join.ts
+++ b/packages/zql/src/ivm/flipped-join.ts
@@ -3,7 +3,15 @@ import {binarySearch} from '../../../shared/src/binary-search.ts';
 import {emptyArray} from '../../../shared/src/sentinels.ts';
 import type {CompoundKey, System} from '../../../zero-protocol/src/ast.ts';
 import type {Value} from '../../../zero-protocol/src/data.ts';
-import type {Change} from './change.ts';
+import {ChangeIndex} from './change-index.ts';
+import {ChangeType} from './change-type.ts';
+import {
+  makeAddChange,
+  makeChildChange,
+  makeEditChange,
+  makeRemoveChange,
+  type Change,
+} from './change.ts';
 import {constraintsAreCompatible} from './constraint.ts';
 import type {Node} from './data.ts';
 import {
@@ -147,8 +155,11 @@ export class FlippedJoin implements Input {
     // related parents with position greater than change.position
     // (which should not yet have the node removed), would not even
     // be fetched here, and would be absent from the output all together.
-    if (this.#inprogressChildChange?.change.type === 'remove') {
-      const removedNode = this.#inprogressChildChange.change.node;
+    if (
+      this.#inprogressChildChange?.change[ChangeIndex.TYPE] ===
+      ChangeType.REMOVE
+    ) {
+      const removedNode = this.#inprogressChildChange.change[ChangeIndex.NODE];
       const compare = this.#child.getSchema().compareRows;
       const insertPos = binarySearch(childNodes.length, i =>
         compare(removedNode.row, childNodes[i].row),
@@ -241,7 +252,7 @@ export class FlippedJoin implements Input {
           this.#inprogressChildChange &&
           this.#inprogressChildChange.position &&
           isJoinMatch(
-            this.#inprogressChildChange.change.node.row,
+            this.#inprogressChildChange.change[ChangeIndex.NODE].row,
             this.#childKey,
             minParentNode.row,
             this.#parentKey,
@@ -254,12 +265,16 @@ export class FlippedJoin implements Input {
                 minParentNode.row,
                 this.#inprogressChildChange.position,
               ) <= 0;
-          if (this.#inprogressChildChange.change.type === 'remove') {
+          if (
+            this.#inprogressChildChange.change[ChangeIndex.TYPE] ===
+            ChangeType.REMOVE
+          ) {
             if (hasInprogressChildChangeBeenPushedForMinParentNode) {
               // Remove form relatedChildNodes since the removed child
               // was inserted into childNodes above.
               overlaidRelatedChildNodes = relatedChildNodes.filter(
-                n => n !== this.#inprogressChildChange?.change.node,
+                n =>
+                  n !== this.#inprogressChildChange?.change[ChangeIndex.NODE],
               );
             }
           } else if (!hasInprogressChildChangeBeenPushedForMinParentNode) {
@@ -310,16 +325,16 @@ export class FlippedJoin implements Input {
   }
 
   *#pushChild(change: Change): Stream<'yield'> {
-    switch (change.type) {
-      case 'add':
-      case 'remove':
+    switch (change[ChangeIndex.TYPE]) {
+      case ChangeType.ADD:
+      case ChangeType.REMOVE:
         yield* this.#pushChildChange(change);
         break;
-      case 'edit': {
+      case ChangeType.EDIT: {
         assert(
           rowEqualsForCompoundKey(
-            change.oldNode.row,
-            change.node.row,
+            change[ChangeIndex.OLD_NODE].row,
+            change[ChangeIndex.NODE].row,
             this.#childKey,
           ),
           `Child edit must not change relationship.`,
@@ -327,7 +342,7 @@ export class FlippedJoin implements Input {
         yield* this.#pushChildChange(change, true);
         break;
       }
-      case 'child':
+      case ChangeType.CHILD:
         yield* this.#pushChildChange(change, true);
         break;
     }
@@ -340,7 +355,7 @@ export class FlippedJoin implements Input {
     };
     try {
       const constraint = buildJoinConstraint(
-        change.node.row,
+        change[ChangeIndex.NODE].row,
         this.#childKey,
         this.#parentKey,
       );
@@ -373,7 +388,7 @@ export class FlippedJoin implements Input {
             if (
               this.#child
                 .getSchema()
-                .compareRows(childNode.row, change.node.row) !== 0
+                .compareRows(childNode.row, change[ChangeIndex.NODE].row) !== 0
             ) {
               exists = true;
               break;
@@ -382,34 +397,33 @@ export class FlippedJoin implements Input {
         }
         if (exists) {
           yield* this.#output.push(
-            {
-              type: 'child',
-              node: {
+            makeChildChange(
+              {
                 ...parentNode,
                 relationships: {
                   ...parentNode.relationships,
                   [this.#relationshipName]: childNodeStream,
                 },
               },
-              child: {
+              {
                 relationshipName: this.#relationshipName,
                 change,
               },
-            },
+            ),
             this,
           );
         } else {
-          yield* this.#output.push(
-            {
-              ...change,
-              node: {
-                ...parentNode,
-                relationships: {
-                  ...parentNode.relationships,
-                  [this.#relationshipName]: () => [change.node],
-                },
-              },
+          const newNode = {
+            ...parentNode,
+            relationships: {
+              ...parentNode.relationships,
+              [this.#relationshipName]: () => [change[ChangeIndex.NODE]],
             },
+          };
+          yield* this.#output.push(
+            change[ChangeIndex.TYPE] === ChangeType.ADD
+              ? makeAddChange(newNode)
+              : makeRemoveChange(newNode),
             this,
           );
         }
@@ -439,7 +453,7 @@ export class FlippedJoin implements Input {
 
     // If no related child don't push as this is an inner join.
     let hasRelatedChild = false;
-    for (const node of childNodeStream(change.node)()) {
+    for (const node of childNodeStream(change[ChangeIndex.NODE])()) {
       if (node === 'yield') {
         yield 'yield';
         continue;
@@ -452,34 +466,43 @@ export class FlippedJoin implements Input {
       return;
     }
 
-    switch (change.type) {
-      case 'add':
-      case 'remove':
-      case 'child': {
+    switch (change[ChangeIndex.TYPE]) {
+      case ChangeType.ADD:
         yield* this.#output.push(
-          {
-            ...change,
-            node: flip(change.node),
-          },
+          makeAddChange(flip(change[ChangeIndex.NODE])),
+          this,
+        );
+        break;
+      case ChangeType.REMOVE:
+        yield* this.#output.push(
+          makeRemoveChange(flip(change[ChangeIndex.NODE])),
+          this,
+        );
+        break;
+      case ChangeType.CHILD: {
+        yield* this.#output.push(
+          makeChildChange(
+            flip(change[ChangeIndex.NODE]),
+            change[ChangeIndex.CHILD_DATA],
+          ),
           this,
         );
         break;
       }
-      case 'edit': {
+      case ChangeType.EDIT: {
         assert(
           rowEqualsForCompoundKey(
-            change.oldNode.row,
-            change.node.row,
+            change[ChangeIndex.OLD_NODE].row,
+            change[ChangeIndex.NODE].row,
             this.#parentKey,
           ),
           `Parent edit must not change relationship.`,
         );
         yield* this.#output.push(
-          {
-            type: 'edit',
-            oldNode: flip(change.oldNode),
-            node: flip(change.node),
-          },
+          makeEditChange(
+            flip(change[ChangeIndex.NODE]),
+            flip(change[ChangeIndex.OLD_NODE]),
+          ),
           this,
         );
         break;

--- a/packages/zql/src/ivm/join-utils.test.ts
+++ b/packages/zql/src/ivm/join-utils.test.ts
@@ -1,13 +1,19 @@
 import {describe, expect, test} from 'vitest';
 import type {Row} from '../../../zero-protocol/src/data.ts';
 import type {Change} from './change.ts';
+import {
+  makeAddChange,
+  makeChildChange,
+  makeEditChange,
+  makeRemoveChange,
+} from './change.ts';
 import type {Node} from './data.ts';
 import {
-  generateWithOverlayUnordered,
-  generateWithOverlayNoYieldUnordered,
-  rowEqualsForCompoundKey,
-  isJoinMatch,
   buildJoinConstraint,
+  generateWithOverlayNoYieldUnordered,
+  generateWithOverlayUnordered,
+  isJoinMatch,
+  rowEqualsForCompoundKey,
 } from './join-utils.ts';
 import type {SourceSchema} from './schema.ts';
 import type {Stream} from './stream.ts';
@@ -47,7 +53,7 @@ describe('generateWithOverlayUnordered', () => {
         makeNode({id: 1}),
         makeNode({id: 2}),
       ];
-      const overlay: Change = {type: 'remove', node: makeNode({id: 3})};
+      const overlay: Change = makeRemoveChange(makeNode({id: 3}));
 
       const result = collectRows(
         generateWithOverlayUnordered(stream, overlay, schema),
@@ -57,7 +63,7 @@ describe('generateWithOverlayUnordered', () => {
 
     test('does not assert when overlay node is not in stream', () => {
       const stream: Stream<Node | 'yield'> = [];
-      const overlay: Change = {type: 'remove', node: makeNode({id: 99})};
+      const overlay: Change = makeRemoveChange(makeNode({id: 99}));
 
       const result = collectRows(
         generateWithOverlayUnordered(stream, overlay, schema),
@@ -73,7 +79,7 @@ describe('generateWithOverlayUnordered', () => {
         makeNode({id: 2}),
         makeNode({id: 3}),
       ];
-      const overlay: Change = {type: 'add', node: makeNode({id: 2})};
+      const overlay: Change = makeAddChange(makeNode({id: 2}));
 
       const result = collectRows(
         generateWithOverlayUnordered(stream, overlay, schema),
@@ -83,7 +89,7 @@ describe('generateWithOverlayUnordered', () => {
 
     test('asserts if no matching node found in stream', () => {
       const stream: Stream<Node | 'yield'> = [makeNode({id: 1})];
-      const overlay: Change = {type: 'add', node: makeNode({id: 99})};
+      const overlay: Change = makeAddChange(makeNode({id: 99}));
 
       expect(() =>
         collectNodes(generateWithOverlayUnordered(stream, overlay, schema)),
@@ -99,11 +105,10 @@ describe('generateWithOverlayUnordered', () => {
         makeNode({id: 1}),
         makeNode({id: 2, val: 'new'}),
       ];
-      const overlay: Change = {
-        type: 'edit',
-        node: makeNode({id: 2, val: 'new'}),
-        oldNode: makeNode({id: 2, val: 'old'}),
-      };
+      const overlay: Change = makeEditChange(
+        makeNode({id: 2, val: 'new'}),
+        makeNode({id: 2, val: 'old'}),
+      );
 
       const result = collectRows(
         generateWithOverlayUnordered(stream, overlay, schema),
@@ -113,11 +118,10 @@ describe('generateWithOverlayUnordered', () => {
 
     test('asserts if no matching node found in stream', () => {
       const stream: Stream<Node | 'yield'> = [makeNode({id: 1})];
-      const overlay: Change = {
-        type: 'edit',
-        node: makeNode({id: 99}),
-        oldNode: makeNode({id: 99}),
-      };
+      const overlay: Change = makeEditChange(
+        makeNode({id: 99}),
+        makeNode({id: 99}),
+      );
 
       expect(() =>
         collectNodes(generateWithOverlayUnordered(stream, overlay, schema)),
@@ -148,15 +152,11 @@ describe('generateWithOverlayUnordered', () => {
         },
       ];
 
-      const childChange: Change = {type: 'add', node: makeNode({cid: 'c'})};
-      const overlay: Change = {
-        type: 'child',
-        node: makeNode({id: 2}),
-        child: {
-          relationshipName: 'items',
-          change: childChange,
-        },
-      };
+      const childChange: Change = makeAddChange(makeNode({cid: 'c'}));
+      const overlay: Change = makeChildChange(makeNode({id: 2}), {
+        relationshipName: 'items',
+        change: childChange,
+      });
 
       const result = collectNodes(
         generateWithOverlayUnordered(stream, overlay, schemaWithRel),
@@ -178,14 +178,10 @@ describe('generateWithOverlayUnordered', () => {
       };
 
       const stream: Stream<Node | 'yield'> = [makeNode({id: 1})];
-      const overlay: Change = {
-        type: 'child',
-        node: makeNode({id: 99}),
-        child: {
-          relationshipName: 'items',
-          change: {type: 'add', node: makeNode({cid: 'c'})},
-        },
-      };
+      const overlay: Change = makeChildChange(makeNode({id: 99}), {
+        relationshipName: 'items',
+        change: makeAddChange(makeNode({cid: 'c'})),
+      });
 
       expect(() =>
         collectNodes(
@@ -206,10 +202,7 @@ describe('generateWithOverlayUnordered', () => {
         makeNode({a: 1, b: 2, val: 'y'}),
         makeNode({a: 2, b: 1, val: 'z'}),
       ];
-      const overlay: Change = {
-        type: 'add',
-        node: makeNode({a: 1, b: 2}),
-      };
+      const overlay: Change = makeAddChange(makeNode({a: 1, b: 2}));
 
       const result = collectRows(
         generateWithOverlayUnordered(stream, overlay, compoundSchema),
@@ -226,10 +219,7 @@ describe('generateWithOverlayUnordered', () => {
         makeNode({a: 1, b: 2}),
       ];
       // Matches a=1 but b differs
-      const overlay: Change = {
-        type: 'add',
-        node: makeNode({a: 1, b: 3}),
-      };
+      const overlay: Change = makeAddChange(makeNode({a: 1, b: 3}));
 
       expect(() =>
         collectNodes(
@@ -250,7 +240,7 @@ describe('generateWithOverlayUnordered', () => {
         'yield' as const,
         makeNode({id: 3}),
       ];
-      const overlay: Change = {type: 'add', node: makeNode({id: 2})};
+      const overlay: Change = makeAddChange(makeNode({id: 2}));
 
       const result = collectNodes(
         generateWithOverlayUnordered(stream, overlay, schema),
@@ -274,7 +264,7 @@ describe('generateWithOverlayNoYieldUnordered', () => {
       yield makeNode({id: 2});
       yield makeNode({id: 3});
     }
-    const overlay: Change = {type: 'add', node: makeNode({id: 2})};
+    const overlay: Change = makeAddChange(makeNode({id: 2}));
 
     const result = [
       ...generateWithOverlayNoYieldUnordered(stream(), overlay, schema),

--- a/packages/zql/src/ivm/join-utils.ts
+++ b/packages/zql/src/ivm/join-utils.ts
@@ -1,6 +1,8 @@
 import {assert} from '../../../shared/src/asserts.ts';
 import type {CompoundKey} from '../../../zero-protocol/src/ast.ts';
 import type {Row, Value} from '../../../zero-protocol/src/data.ts';
+import {ChangeIndex} from './change-index.ts';
+import {ChangeType} from './change-type.ts';
 import type {Change} from './change.ts';
 import {compareValues, valuesEqual, type Node} from './data.ts';
 import type {SourceSchema} from './schema.ts';
@@ -34,35 +36,37 @@ export function* generateWithOverlay(
     }
     let yieldNode = true;
     if (!applied) {
-      switch (overlay.type) {
-        case 'add': {
-          if (schema.compareRows(overlay.node.row, node.row) === 0) {
+      switch (overlay[ChangeIndex.TYPE]) {
+        case ChangeType.ADD: {
+          if (
+            schema.compareRows(overlay[ChangeIndex.NODE].row, node.row) === 0
+          ) {
             applied = true;
             yieldNode = false;
           }
           break;
         }
-        case 'remove': {
-          if (schema.compareRows(overlay.node.row, node.row) < 0) {
+        case ChangeType.REMOVE: {
+          if (schema.compareRows(overlay[ChangeIndex.NODE].row, node.row) < 0) {
             applied = true;
-            yield overlay.node;
+            yield overlay[ChangeIndex.NODE];
           }
           break;
         }
-        case 'edit': {
+        case ChangeType.EDIT: {
           if (
             !editOldApplied &&
-            schema.compareRows(overlay.oldNode.row, node.row) < 0
+            schema.compareRows(overlay[ChangeIndex.OLD_NODE].row, node.row) < 0
           ) {
             editOldApplied = true;
             if (editNewApplied) {
               applied = true;
             }
-            yield overlay.oldNode;
+            yield overlay[ChangeIndex.OLD_NODE];
           }
           if (
             !editNewApplied &&
-            schema.compareRows(overlay.node.row, node.row) === 0
+            schema.compareRows(overlay[ChangeIndex.NODE].row, node.row) === 0
           ) {
             editNewApplied = true;
             if (editOldApplied) {
@@ -72,18 +76,24 @@ export function* generateWithOverlay(
           }
           break;
         }
-        case 'child': {
-          if (schema.compareRows(overlay.node.row, node.row) === 0) {
+        case ChangeType.CHILD: {
+          if (
+            schema.compareRows(overlay[ChangeIndex.NODE].row, node.row) === 0
+          ) {
             applied = true;
             yield {
               row: node.row,
               relationships: {
                 ...node.relationships,
-                [overlay.child.relationshipName]: () =>
+                [overlay[ChangeIndex.CHILD_DATA].relationshipName]: () =>
                   generateWithOverlay(
-                    node.relationships[overlay.child.relationshipName](),
-                    overlay.child.change,
-                    schema.relationships[overlay.child.relationshipName],
+                    node.relationships[
+                      overlay[ChangeIndex.CHILD_DATA].relationshipName
+                    ](),
+                    overlay[ChangeIndex.CHILD_DATA].change,
+                    schema.relationships[
+                      overlay[ChangeIndex.CHILD_DATA].relationshipName
+                    ],
                   ),
               },
             };
@@ -98,17 +108,17 @@ export function* generateWithOverlay(
     }
   }
   if (!applied) {
-    if (overlay.type === 'remove') {
+    if (overlay[ChangeIndex.TYPE] === ChangeType.REMOVE) {
       applied = true;
-      yield overlay.node;
-    } else if (overlay.type === 'edit') {
+      yield overlay[ChangeIndex.NODE];
+    } else if (overlay[ChangeIndex.TYPE] === ChangeType.EDIT) {
       assert(
         editNewApplied,
         'edit overlay: new node must be applied before old node',
       );
       editOldApplied = true;
       applied = true;
-      yield overlay.oldNode;
+      yield overlay[ChangeIndex.OLD_NODE];
     }
   }
 
@@ -132,10 +142,10 @@ export function* generateWithOverlayUnordered(
   schema: SourceSchema,
 ): Stream<Node | 'yield'> {
   // Eager inject
-  if (overlay.type === 'remove') {
-    yield overlay.node;
-  } else if (overlay.type === 'edit') {
-    yield overlay.oldNode;
+  if (overlay[ChangeIndex.TYPE] === ChangeType.REMOVE) {
+    yield overlay[ChangeIndex.NODE];
+  } else if (overlay[ChangeIndex.TYPE] === ChangeType.EDIT) {
+    yield overlay[ChangeIndex.OLD_NODE];
   }
 
   // Stream with inline suppress
@@ -146,28 +156,43 @@ export function* generateWithOverlayUnordered(
       continue;
     }
     if (!suppressed) {
-      if (overlay.type === 'add' || overlay.type === 'edit') {
+      if (
+        overlay[ChangeIndex.TYPE] === ChangeType.ADD ||
+        overlay[ChangeIndex.TYPE] === ChangeType.EDIT
+      ) {
         if (
-          rowEqualsForCompoundKey(overlay.node.row, node.row, schema.primaryKey)
+          rowEqualsForCompoundKey(
+            overlay[ChangeIndex.NODE].row,
+            node.row,
+            schema.primaryKey,
+          )
         ) {
           suppressed = true;
           continue;
         }
       }
-      if (overlay.type === 'child') {
+      if (overlay[ChangeIndex.TYPE] === ChangeType.CHILD) {
         if (
-          rowEqualsForCompoundKey(overlay.node.row, node.row, schema.primaryKey)
+          rowEqualsForCompoundKey(
+            overlay[ChangeIndex.NODE].row,
+            node.row,
+            schema.primaryKey,
+          )
         ) {
           suppressed = true;
           yield {
             row: node.row,
             relationships: {
               ...node.relationships,
-              [overlay.child.relationshipName]: () =>
+              [overlay[ChangeIndex.CHILD_DATA].relationshipName]: () =>
                 generateWithOverlay(
-                  node.relationships[overlay.child.relationshipName](),
-                  overlay.child.change,
-                  schema.relationships[overlay.child.relationshipName],
+                  node.relationships[
+                    overlay[ChangeIndex.CHILD_DATA].relationshipName
+                  ](),
+                  overlay[ChangeIndex.CHILD_DATA].change,
+                  schema.relationships[
+                    overlay[ChangeIndex.CHILD_DATA].relationshipName
+                  ],
                 ),
             },
           };
@@ -178,7 +203,7 @@ export function* generateWithOverlayUnordered(
     yield node;
   }
   assert(
-    suppressed || overlay.type === 'remove',
+    suppressed || overlay[ChangeIndex.TYPE] === ChangeType.REMOVE,
     'overlayGenerator: overlay was never applied to any fetched node',
   );
 }

--- a/packages/zql/src/ivm/join.fetch.test.ts
+++ b/packages/zql/src/ivm/join.fetch.test.ts
@@ -15,6 +15,7 @@ import {Snitch, type SnitchMessage} from './snitch.ts';
 import {consume} from './stream.ts';
 import {createSource} from './test/source-factory.ts';
 
+import {makeSourceChangeAdd} from './source.ts';
 const lc = createSilentLogContext();
 
 suite('fetch one:many', () => {
@@ -2084,7 +2085,7 @@ function fetchTest(t: FetchTest): FetchTestResults {
       t.primaryKeys[i],
     );
     for (const row of rows) {
-      consume(source.push({type: 'add', row}));
+      consume(source.push(makeSourceChangeAdd(row)));
     }
     const snitch = new Snitch(source.connect(ordering), String(i), log);
     return {

--- a/packages/zql/src/ivm/join.push.test.ts
+++ b/packages/zql/src/ivm/join.push.test.ts
@@ -7,6 +7,11 @@ import {
 } from './test/fetch-and-push-tests.ts';
 import type {Format} from './view.ts';
 
+import {
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+  makeSourceChangeRemove,
+} from './source.ts';
 suite('push one:many', () => {
   const sources: Sources = {
     issue: {
@@ -59,7 +64,7 @@ suite('push one:many', () => {
       },
       ast,
       format,
-      pushes: [['issue', {type: 'remove', row: {id: 'i1'}}]],
+      pushes: [['issue', makeSourceChangeRemove({id: 'i1'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -123,7 +128,7 @@ suite('push one:many', () => {
       },
       ast,
       format,
-      pushes: [['comment', {type: 'remove', row: {id: 'c1', issueID: 'i1'}}]],
+      pushes: [['comment', makeSourceChangeRemove({id: 'c1', issueID: 'i1'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -164,7 +169,7 @@ suite('push one:many', () => {
       },
       ast,
       format,
-      pushes: [['issue', {type: 'add', row: {id: 'i1'}}]],
+      pushes: [['issue', makeSourceChangeAdd({id: 'i1'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -253,7 +258,7 @@ suite('push one:many', () => {
       },
       ast,
       format,
-      pushes: [['issue', {type: 'add', row: {id: 'i1'}}]],
+      pushes: [['issue', makeSourceChangeAdd({id: 'i1'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -351,7 +356,7 @@ suite('push one:many', () => {
       },
       ast,
       format,
-      pushes: [['issue', {type: 'add', row: {id: 'i2'}}]],
+      pushes: [['issue', makeSourceChangeAdd({id: 'i2'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -423,7 +428,7 @@ suite('push one:many', () => {
       },
       ast,
       format,
-      pushes: [['comment', {type: 'add', row: {id: 'c1', issueID: 'i1'}}]],
+      pushes: [['comment', makeSourceChangeAdd({id: 'c1', issueID: 'i1'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -517,7 +522,7 @@ suite('push one:many', () => {
       },
       ast,
       format,
-      pushes: [['comment', {type: 'add', row: {id: 'c1', issueID: 'i2'}}]],
+      pushes: [['comment', makeSourceChangeAdd({id: 'c1', issueID: 'i2'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -566,7 +571,7 @@ suite('push one:many', () => {
       },
       ast,
       format,
-      pushes: [['issue', {type: 'remove', row: {id: 'i1'}}]],
+      pushes: [['issue', makeSourceChangeRemove({id: 'i1'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -641,7 +646,7 @@ suite('push one:many', () => {
       },
       ast,
       format,
-      pushes: [['issue', {type: 'remove', row: {id: 'i1'}}]],
+      pushes: [['issue', makeSourceChangeRemove({id: 'i1'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -721,11 +726,11 @@ suite('push one:many', () => {
       ast,
       format,
       pushes: [
-        ['issue', {type: 'add', row: {id: 'i1'}}],
-        ['comment', {type: 'add', row: {id: 'c1', issueID: 'i1'}}],
-        ['comment', {type: 'add', row: {id: 'c2', issueID: 'i1'}}],
-        ['comment', {type: 'remove', row: {id: 'c1', issueID: 'i1'}}],
-        ['issue', {type: 'remove', row: {id: 'i1'}}],
+        ['issue', makeSourceChangeAdd({id: 'i1'})],
+        ['comment', makeSourceChangeAdd({id: 'c1', issueID: 'i1'})],
+        ['comment', makeSourceChangeAdd({id: 'c2', issueID: 'i1'})],
+        ['comment', makeSourceChangeRemove({id: 'c1', issueID: 'i1'})],
+        ['issue', makeSourceChangeRemove({id: 'i1'})],
       ],
     });
 
@@ -1031,11 +1036,10 @@ suite('push one:many', () => {
         pushes: [
           [
             'issue',
-            {
-              type: 'edit',
-              oldRow: {id: 'i1', text: 'issue 1'},
-              row: {id: 'i1', text: 'issue 1 edited'},
-            },
+            makeSourceChangeEdit(
+              {id: 'i1', text: 'issue 1 edited'},
+              {id: 'i1', text: 'issue 1'},
+            ),
           ],
         ],
       });
@@ -1130,11 +1134,10 @@ suite('push one:many', () => {
         pushes: [
           [
             'comment',
-            {
-              type: 'edit',
-              oldRow: {id: 'c1', issueID: 'i1', text: 'comment 1'},
-              row: {id: 'c1', issueID: 'i1', text: 'comment 1 edited'},
-            },
+            makeSourceChangeEdit(
+              {id: 'c1', issueID: 'i1', text: 'comment 1 edited'},
+              {id: 'c1', issueID: 'i1', text: 'comment 1'},
+            ),
           ],
         ],
       });
@@ -1264,11 +1267,10 @@ suite('push one:many', () => {
         pushes: [
           [
             'comment',
-            {
-              type: 'edit',
-              oldRow: {id: 'c1', issueID: 'i1', text: 'comment 1'},
-              row: {id: 'c1', issueID: 'i2', text: 'comment 1.2'},
-            },
+            makeSourceChangeEdit(
+              {id: 'c1', issueID: 'i2', text: 'comment 1.2'},
+              {id: 'c1', issueID: 'i1', text: 'comment 1'},
+            ),
           ],
         ],
       });
@@ -1455,11 +1457,10 @@ suite('push one:many', () => {
         pushes: [
           [
             'issue',
-            {
-              type: 'edit',
-              oldRow: {id: 'i1', text: 'issue 1'},
-              row: {id: 'i3', text: 'issue 1.3'},
-            },
+            makeSourceChangeEdit(
+              {id: 'i3', text: 'issue 1.3'},
+              {id: 'i1', text: 'issue 1'},
+            ),
           ],
         ],
       });
@@ -1663,7 +1664,7 @@ suite('push many:one', () => {
       },
       ast,
       format,
-      pushes: [['issue', {type: 'add', row: {id: 'i1', ownerID: 'u1'}}]],
+      pushes: [['issue', makeSourceChangeAdd({id: 'i1', ownerID: 'u1'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -1749,7 +1750,7 @@ suite('push many:one', () => {
       },
       ast,
       format,
-      pushes: [['issue', {type: 'add', row: {id: 'i1', ownerID: 'u2'}}]],
+      pushes: [['issue', makeSourceChangeAdd({id: 'i1', ownerID: 'u2'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -1825,7 +1826,7 @@ suite('push many:one', () => {
       },
       ast,
       format,
-      pushes: [['user', {type: 'add', row: {id: 'u1'}}]],
+      pushes: [['user', makeSourceChangeAdd({id: 'u1'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -1919,7 +1920,7 @@ suite('push many:one', () => {
       },
       ast,
       format,
-      pushes: [['user', {type: 'add', row: {id: 'u1'}}]],
+      pushes: [['user', makeSourceChangeAdd({id: 'u1'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -2079,11 +2080,10 @@ suite('push many:one', () => {
         pushes: [
           [
             'user',
-            {
-              type: 'edit',
-              row: {id: 'u1', text: 'user 1'},
-              oldRow: {id: 'u2', text: 'user 2'},
-            },
+            makeSourceChangeEdit(
+              {id: 'u1', text: 'user 1'},
+              {id: 'u2', text: 'user 2'},
+            ),
           ],
         ],
       });
@@ -2328,11 +2328,10 @@ suite('push many:one', () => {
         pushes: [
           [
             'issue',
-            {
-              type: 'edit',
-              row: {id: 'i2', ownerID: 'u1', text: 'item 2'},
-              oldRow: {id: 'i2', ownerID: 'u2', text: 'item 2'},
-            },
+            makeSourceChangeEdit(
+              {id: 'i2', ownerID: 'u1', text: 'item 2'},
+              {id: 'i2', ownerID: 'u2', text: 'item 2'},
+            ),
           ],
         ],
       });
@@ -2591,11 +2590,10 @@ suite('push many:one', () => {
         pushes: [
           [
             'user',
-            {
-              type: 'edit',
-              row: {id: 'u2', text: 'user 2 changed'},
-              oldRow: {id: 'u2', text: 'user 2'},
-            },
+            makeSourceChangeEdit(
+              {id: 'u2', text: 'user 2 changed'},
+              {id: 'u2', text: 'user 2'},
+            ),
           ],
         ],
       });
@@ -2665,11 +2663,10 @@ suite('push many:one', () => {
         pushes: [
           [
             'user',
-            {
-              type: 'edit',
-              row: {id: 'u1', text: 'user 1 changed'},
-              oldRow: {id: 'u1', text: 'user 1'},
-            },
+            makeSourceChangeEdit(
+              {id: 'u1', text: 'user 1 changed'},
+              {id: 'u1', text: 'user 1'},
+            ),
           ],
         ],
       });
@@ -2903,7 +2900,7 @@ suite('push one:many:many', () => {
       },
       ast,
       format,
-      pushes: [['revision', {type: 'add', row: {id: 'r1', commentID: 'c1'}}]],
+      pushes: [['revision', makeSourceChangeAdd({id: 'r1', commentID: 'c1'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -3049,7 +3046,7 @@ suite('push one:many:many', () => {
       },
       ast,
       format,
-      pushes: [['comment', {type: 'add', row: {id: 'c1', issueID: 'i1'}}]],
+      pushes: [['comment', makeSourceChangeAdd({id: 'c1', issueID: 'i1'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -3181,7 +3178,7 @@ suite('push one:many:many', () => {
       },
       ast,
       format,
-      pushes: [['issue', {type: 'add', row: {id: 'i1'}}]],
+      pushes: [['issue', makeSourceChangeAdd({id: 'i1'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -3303,7 +3300,7 @@ suite('push one:many:many', () => {
       },
       ast,
       format,
-      pushes: [['issue', {type: 'remove', row: {id: 'i1'}}]],
+      pushes: [['issue', makeSourceChangeRemove({id: 'i1'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -3476,7 +3473,7 @@ suite('push one:many:one', () => {
       },
       ast,
       format,
-      pushes: [['label', {type: 'add', row: {id: 'l1'}}]],
+      pushes: [['label', makeSourceChangeAdd({id: 'l1'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -3616,7 +3613,7 @@ suite('push one:many:one', () => {
       ast,
       format,
       pushes: [
-        ['issueLabel', {type: 'add', row: {issueID: 'i1', labelID: 'l1'}}],
+        ['issueLabel', makeSourceChangeAdd({issueID: 'i1', labelID: 'l1'})],
       ],
     });
 
@@ -3748,7 +3745,7 @@ suite('push one:many:one', () => {
       },
       ast,
       format,
-      pushes: [['label', {type: 'add', row: {id: 'l1'}}]],
+      pushes: [['label', makeSourceChangeAdd({id: 'l1'})]],
     });
 
     expect(log).toMatchInlineSnapshot(`
@@ -4061,21 +4058,20 @@ describe('edit assignee', () => {
       pushes: [
         [
           'issue',
-          {
-            type: 'edit',
-            oldRow: {
-              issueID: 'i1',
-              text: 'first issue',
-              assigneeID: undefined,
-              creatorID: 'u1',
-            },
-            row: {
+          makeSourceChangeEdit(
+            {
               issueID: 'i1',
               text: 'first issue',
               assigneeID: 'u1',
               creatorID: 'u1',
             },
-          },
+            {
+              issueID: 'i1',
+              text: 'first issue',
+              assigneeID: undefined,
+              creatorID: 'u1',
+            },
+          ),
         ],
       ],
       format,
@@ -4372,21 +4368,20 @@ describe('edit assignee', () => {
       pushes: [
         [
           'issue',
-          {
-            type: 'edit',
-            oldRow: {
-              issueID: 'i1',
-              text: 'first issue',
-              assigneeID: undefined,
-              creatorID: 'u1',
-            },
-            row: {
+          makeSourceChangeEdit(
+            {
               issueID: 'i1',
               text: 'first issue',
               assigneeID: 'u1',
               creatorID: 'u1',
             },
-          },
+            {
+              issueID: 'i1',
+              text: 'first issue',
+              assigneeID: undefined,
+              creatorID: 'u1',
+            },
+          ),
         ],
       ],
       format,
@@ -4677,21 +4672,20 @@ describe('edit assignee', () => {
       pushes: [
         [
           'issue',
-          {
-            type: 'edit',
-            oldRow: {
-              issueID: 'i1',
-              text: 'first issue',
-              assigneeID: 'u1',
-              creatorID: 'u1',
-            },
-            row: {
+          makeSourceChangeEdit(
+            {
               issueID: 'i1',
               text: 'first issue',
               assigneeID: undefined,
               creatorID: 'u1',
             },
-          },
+            {
+              issueID: 'i1',
+              text: 'first issue',
+              assigneeID: 'u1',
+              creatorID: 'u1',
+            },
+          ),
         ],
       ],
       format,
@@ -4983,21 +4977,20 @@ describe('edit assignee', () => {
       pushes: [
         [
           'issue',
-          {
-            type: 'edit',
-            oldRow: {
-              issueID: 'i1',
-              text: 'first issue',
-              assigneeID: 'u1',
-              creatorID: 'u1',
-            },
-            row: {
+          makeSourceChangeEdit(
+            {
               issueID: 'i1',
               text: 'first issue',
               assigneeID: undefined,
               creatorID: 'u1',
             },
-          },
+            {
+              issueID: 'i1',
+              text: 'first issue',
+              assigneeID: 'u1',
+              creatorID: 'u1',
+            },
+          ),
         ],
       ],
       format,
@@ -5327,20 +5320,8 @@ describe('joins with compound join keys', () => {
       sourceContents,
       ast,
       pushes: [
-        [
-          'a',
-          {
-            type: 'add',
-            row: {id: 2, a1: 7, a2: 8, a3: 9},
-          },
-        ],
-        [
-          'b',
-          {
-            type: 'add',
-            row: {id: 2, b1: 8, b2: 7, b3: 9},
-          },
-        ],
+        ['a', makeSourceChangeAdd({id: 2, a1: 7, a2: 8, a3: 9})],
+        ['b', makeSourceChangeAdd({id: 2, b1: 8, b2: 7, b3: 9})],
       ],
       format,
     });
@@ -5538,11 +5519,10 @@ describe('joins with compound join keys', () => {
       pushes: [
         [
           'a',
-          {
-            type: 'edit',
-            oldRow: {id: 0, a1: 1, a2: 2, a3: 3},
-            row: {id: 0, a1: 1, a2: 2, a3: 33},
-          },
+          makeSourceChangeEdit(
+            {id: 0, a1: 1, a2: 2, a3: 33},
+            {id: 0, a1: 1, a2: 2, a3: 3},
+          ),
         ],
       ],
       format,
@@ -5713,7 +5693,7 @@ suite('test overlay on many:one pushes', () => {
       },
       ast,
       format,
-      pushes: [['user', {type: 'add', row: {id: 'u1', name: 'Aaron'}}]],
+      pushes: [['user', makeSourceChangeAdd({id: 'u1', name: 'Aaron'})]],
       fetchOnPush: true,
     });
 
@@ -6022,7 +6002,7 @@ suite('test overlay on many:one pushes', () => {
       },
       ast,
       format,
-      pushes: [['user', {type: 'remove', row: {id: 'u1', name: 'Aaron'}}]],
+      pushes: [['user', makeSourceChangeRemove({id: 'u1', name: 'Aaron'})]],
       fetchOnPush: true,
     });
 
@@ -6310,11 +6290,10 @@ suite('test overlay on many:one pushes', () => {
       pushes: [
         [
           'user',
-          {
-            type: 'edit',
-            oldRow: {id: 'u1', name: 'Aaron'},
-            row: {id: 'u1', name: 'Boogs'},
-          },
+          makeSourceChangeEdit(
+            {id: 'u1', name: 'Boogs'},
+            {id: 'u1', name: 'Aaron'},
+          ),
         ],
       ],
       fetchOnPush: true,
@@ -6720,11 +6699,10 @@ suite('test overlay on many:one pushes', () => {
       pushes: [
         [
           'state',
-          {
-            type: 'edit',
-            oldRow: {id: 's0', name: 'Hawaii'},
-            row: {id: 's0', name: 'HI'},
-          },
+          makeSourceChangeEdit(
+            {id: 's0', name: 'HI'},
+            {id: 's0', name: 'Hawaii'},
+          ),
         ],
       ],
       fetchOnPush: true,
@@ -7499,7 +7477,9 @@ suite('test overlay on many:many (no junction) pushes', () => {
       },
       ast,
       format,
-      pushes: [['user', {type: 'add', row: {id: 'u2', name: 'Aaron', num: 2}}]],
+      pushes: [
+        ['user', makeSourceChangeAdd({id: 'u2', name: 'Aaron', num: 2})],
+      ],
       fetchOnPush: true,
     });
 
@@ -7924,7 +7904,7 @@ suite('test overlay on many:many (no junction) pushes', () => {
       ast,
       format,
       pushes: [
-        ['user', {type: 'remove', row: {id: 'u2', name: 'Aaron', num: 2}}],
+        ['user', makeSourceChangeRemove({id: 'u2', name: 'Aaron', num: 2})],
       ],
       fetchOnPush: true,
     });
@@ -8324,11 +8304,10 @@ suite('test overlay on many:many (no junction) pushes', () => {
       pushes: [
         [
           'user',
-          {
-            type: 'edit',
-            oldRow: {id: 'u2', name: 'Aaron', num: 2},
-            row: {id: 'u2', name: 'Aaron', num: 5},
-          },
+          makeSourceChangeEdit(
+            {id: 'u2', name: 'Aaron', num: 5},
+            {id: 'u2', name: 'Aaron', num: 2},
+          ),
         ],
       ],
       fetchOnPush: true,
@@ -8854,11 +8833,10 @@ suite('test overlay on many:many (no junction) pushes', () => {
       pushes: [
         [
           'state',
-          {
-            type: 'edit',
-            oldRow: {id: 's0', name: 'Hawaii'},
-            row: {id: 's0', name: 'HI'},
-          },
+          makeSourceChangeEdit(
+            {id: 's0', name: 'HI'},
+            {id: 's0', name: 'Hawaii'},
+          ),
         ],
       ],
       fetchOnPush: true,

--- a/packages/zql/src/ivm/join.sibling.test.ts
+++ b/packages/zql/src/ivm/join.sibling.test.ts
@@ -10,7 +10,12 @@ import {Catch, type CaughtChange} from './catch.ts';
 import {Join} from './join.ts';
 import type {Input} from './operator.ts';
 import {Snitch, type SnitchMessage} from './snitch.ts';
-import type {SourceChange} from './source.ts';
+import {
+  type SourceChange,
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+  makeSourceChangeRemove,
+} from './source.ts';
 import {consume} from './stream.ts';
 import {createSource} from './test/source-factory.ts';
 
@@ -54,7 +59,7 @@ suite('sibling relationships tests with issues, comments, and owners', () => {
         ],
         [{id: 'o1'}, {id: 'o2'}],
       ],
-      pushes: [[0, {type: 'add', row: {id: 'i3', ownerId: 'o2'}}]],
+      pushes: [[0, makeSourceChangeAdd({id: 'i3', ownerId: 'o2'})]],
     });
     expect(log).toMatchInlineSnapshot(`
       [
@@ -151,7 +156,7 @@ suite('sibling relationships tests with issues, comments, and owners', () => {
         ],
         [{id: 'o1'}],
       ],
-      pushes: [[2, {type: 'add', row: {id: 'o2'}}]],
+      pushes: [[2, makeSourceChangeAdd({id: 'o2'})]],
     });
     expect(log).toMatchInlineSnapshot(`
       [
@@ -227,7 +232,7 @@ suite('sibling relationships tests with issues, comments, and owners', () => {
         ],
         [{id: 'o1'}, {id: 'o2'}],
       ],
-      pushes: [[1, {type: 'add', row: {id: 'c5', issueId: 'i1'}}]],
+      pushes: [[1, makeSourceChangeAdd({id: 'c5', issueId: 'i1'})]],
     });
     expect(log).toMatchInlineSnapshot(`
       [
@@ -305,7 +310,7 @@ suite('sibling relationships tests with issues, comments, and owners', () => {
         ],
         [{id: 'o1'}, {id: 'o2'}],
       ],
-      pushes: [[2, {type: 'remove', row: {id: 'o2'}}]],
+      pushes: [[2, makeSourceChangeRemove({id: 'o2'})]],
     });
     expect(log).toMatchInlineSnapshot(`
       [
@@ -381,7 +386,7 @@ suite('sibling relationships tests with issues, comments, and owners', () => {
         ],
         [{id: 'o1'}, {id: 'o2'}],
       ],
-      pushes: [[1, {type: 'remove', row: {id: 'c4', issueId: 'i2'}}]],
+      pushes: [[1, makeSourceChangeRemove({id: 'c4', issueId: 'i2'})]],
     });
     expect(log).toMatchInlineSnapshot(`
       [
@@ -485,11 +490,10 @@ suite('sibling relationships tests with issues, comments, and owners', () => {
         pushes: [
           [
             0,
-            {
-              type: 'edit',
-              oldRow: {id: 'i1', ownerId: 'o1', text: 'issue 1'},
-              row: {id: 'i1', ownerId: 'o1', text: 'issue 1 changed'},
-            },
+            makeSourceChangeEdit(
+              {id: 'i1', ownerId: 'o1', text: 'issue 1 changed'},
+              {id: 'i1', ownerId: 'o1', text: 'issue 1'},
+            ),
           ],
         ],
       });
@@ -539,11 +543,10 @@ suite('sibling relationships tests with issues, comments, and owners', () => {
         pushes: [
           [
             1,
-            {
-              type: 'edit',
-              oldRow: {id: 'c4', issueId: 'i2', text: 'comment 4'},
-              row: {id: 'c4', issueId: 'i2', text: 'comment 4 changed'},
-            },
+            makeSourceChangeEdit(
+              {id: 'c4', issueId: 'i2', text: 'comment 4 changed'},
+              {id: 'c4', issueId: 'i2', text: 'comment 4'},
+            ),
           ],
         ],
       });
@@ -623,11 +626,10 @@ suite('sibling relationships tests with issues, comments, and owners', () => {
         pushes: [
           [
             2,
-            {
-              type: 'edit',
-              oldRow: {id: 'o2', text: 'owner 2'},
-              row: {id: 'o2', text: 'owner 2 changed'},
-            },
+            makeSourceChangeEdit(
+              {id: 'o2', text: 'owner 2 changed'},
+              {id: 'o2', text: 'owner 2'},
+            ),
           ],
         ],
       });
@@ -718,7 +720,7 @@ function pushSiblingTest(t: PushTestSibling): PushTestSiblingResults {
       t.primaryKeys[i],
     );
     for (const row of rows) {
-      consume(source.push({type: 'add', row}));
+      consume(source.push(makeSourceChangeAdd(row)));
     }
     const snitch = new Snitch(source.connect(ordering), String(i), log, [
       'fetch',

--- a/packages/zql/src/ivm/join.ts
+++ b/packages/zql/src/ivm/join.ts
@@ -1,7 +1,15 @@
 import {assert, unreachable} from '../../../shared/src/asserts.ts';
 import type {CompoundKey, System} from '../../../zero-protocol/src/ast.ts';
 import type {Row} from '../../../zero-protocol/src/data.ts';
-import type {Change, ChildChange} from './change.ts';
+import {ChangeIndex} from './change-index.ts';
+import {ChangeType} from './change-type.ts';
+import {
+  makeAddChange,
+  makeChildChange,
+  makeEditChange,
+  makeRemoveChange,
+  type Change,
+} from './change.ts';
 import type {Node} from './data.ts';
 import {
   buildJoinConstraint,
@@ -119,66 +127,62 @@ export class Join implements Input {
   }
 
   *#pushParent(change: Change): Stream<'yield'> {
-    switch (change.type) {
-      case 'add':
+    switch (change[ChangeIndex.TYPE]) {
+      case ChangeType.ADD:
         yield* this.#output.push(
-          {
-            type: 'add',
-            node: this.#processParentNode(
-              change.node.row,
-              change.node.relationships,
+          makeAddChange(
+            this.#processParentNode(
+              change[ChangeIndex.NODE].row,
+              change[ChangeIndex.NODE].relationships,
             ),
-          },
+          ),
           this,
         );
         break;
-      case 'remove':
+      case ChangeType.REMOVE:
         yield* this.#output.push(
-          {
-            type: 'remove',
-            node: this.#processParentNode(
-              change.node.row,
-              change.node.relationships,
+          makeRemoveChange(
+            this.#processParentNode(
+              change[ChangeIndex.NODE].row,
+              change[ChangeIndex.NODE].relationships,
             ),
-          },
+          ),
           this,
         );
         break;
-      case 'child':
+      case ChangeType.CHILD:
         yield* this.#output.push(
-          {
-            type: 'child',
-            node: this.#processParentNode(
-              change.node.row,
-              change.node.relationships,
+          makeChildChange(
+            this.#processParentNode(
+              change[ChangeIndex.NODE].row,
+              change[ChangeIndex.NODE].relationships,
             ),
-            child: change.child,
-          },
+            change[ChangeIndex.CHILD_DATA],
+          ),
           this,
         );
         break;
-      case 'edit': {
+      case ChangeType.EDIT: {
         // Assert the edit could not change the relationship.
         assert(
           rowEqualsForCompoundKey(
-            change.oldNode.row,
-            change.node.row,
+            change[ChangeIndex.OLD_NODE].row,
+            change[ChangeIndex.NODE].row,
             this.#parentKey,
           ),
           `Parent edit must not change relationship.`,
         );
         yield* this.#output.push(
-          {
-            type: 'edit',
-            oldNode: this.#processParentNode(
-              change.oldNode.row,
-              change.oldNode.relationships,
+          makeEditChange(
+            this.#processParentNode(
+              change[ChangeIndex.NODE].row,
+              change[ChangeIndex.NODE].relationships,
             ),
-            node: this.#processParentNode(
-              change.node.row,
-              change.node.relationships,
+            this.#processParentNode(
+              change[ChangeIndex.OLD_NODE].row,
+              change[ChangeIndex.OLD_NODE].relationships,
             ),
-          },
+          ),
           this,
         );
         break;
@@ -189,17 +193,17 @@ export class Join implements Input {
   }
 
   *#pushChild(change: Change): Stream<'yield'> {
-    switch (change.type) {
-      case 'add':
-      case 'remove':
-        yield* this.#pushChildChange(change.node.row, change);
+    switch (change[ChangeIndex.TYPE]) {
+      case ChangeType.ADD:
+      case ChangeType.REMOVE:
+        yield* this.#pushChildChange(change[ChangeIndex.NODE].row, change);
         break;
-      case 'child':
-        yield* this.#pushChildChange(change.node.row, change);
+      case ChangeType.CHILD:
+        yield* this.#pushChildChange(change[ChangeIndex.NODE].row, change);
         break;
-      case 'edit': {
-        const childRow = change.node.row;
-        const oldChildRow = change.oldNode.row;
+      case ChangeType.EDIT: {
+        const childRow = change[ChangeIndex.NODE].row;
+        const oldChildRow = change[ChangeIndex.OLD_NODE].row;
         // Assert the edit could not change the relationship.
         assert(
           rowEqualsForCompoundKey(oldChildRow, childRow, this.#childKey),
@@ -233,17 +237,13 @@ export class Join implements Input {
           continue;
         }
         this.#inprogressChildChange.position = parentNode.row;
-        const childChange: ChildChange = {
-          type: 'child',
-          node: this.#processParentNode(
-            parentNode.row,
-            parentNode.relationships,
-          ),
-          child: {
+        const childChange = makeChildChange(
+          this.#processParentNode(parentNode.row, parentNode.relationships),
+          {
             relationshipName: this.#relationshipName,
             change,
           },
-        };
+        );
         yield* this.#output.push(childChange, this);
       }
     } finally {
@@ -268,7 +268,7 @@ export class Join implements Input {
         isJoinMatch(
           parentNodeRow,
           this.#parentKey,
-          this.#inprogressChildChange.change.node.row,
+          this.#inprogressChildChange.change[ChangeIndex.NODE].row,
           this.#childKey,
         ) &&
         this.#inprogressChildChange.position &&

--- a/packages/zql/src/ivm/maybe-split-and-push-edit-change.ts
+++ b/packages/zql/src/ivm/maybe-split-and-push-edit-change.ts
@@ -1,5 +1,6 @@
 import type {Row} from '../../../zero-protocol/src/data.ts';
-import type {EditChange} from './change.ts';
+import {ChangeIndex} from './change-index.ts';
+import {makeAddChange, makeRemoveChange, type EditChange} from './change.ts';
 import type {InputBase, Output} from './operator.ts';
 
 /**
@@ -13,26 +14,14 @@ export function* maybeSplitAndPushEditChange(
   output: Output,
   pusher: InputBase,
 ) {
-  const oldWasPresent = predicate(change.oldNode.row);
-  const newIsPresent = predicate(change.node.row);
+  const oldWasPresent = predicate(change[ChangeIndex.OLD_NODE].row);
+  const newIsPresent = predicate(change[ChangeIndex.NODE].row);
 
   if (oldWasPresent && newIsPresent) {
     yield* output.push(change, pusher);
   } else if (oldWasPresent && !newIsPresent) {
-    yield* output.push(
-      {
-        type: 'remove',
-        node: change.oldNode,
-      },
-      pusher,
-    );
+    yield* output.push(makeRemoveChange(change[ChangeIndex.OLD_NODE]), pusher);
   } else if (!oldWasPresent && newIsPresent) {
-    yield* output.push(
-      {
-        type: 'add',
-        node: change.node,
-      },
-      pusher,
-    );
+    yield* output.push(makeAddChange(change[ChangeIndex.NODE]), pusher);
   }
 }

--- a/packages/zql/src/ivm/memory-source.test.ts
+++ b/packages/zql/src/ivm/memory-source.test.ts
@@ -20,6 +20,11 @@ import {consume} from './stream.ts';
 import {compareRowsTest} from './test/compare-rows-test.ts';
 import {createSource} from './test/source-factory.ts';
 
+import {
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+  makeSourceChangeRemove,
+} from './source.ts';
 const lc = createSilentLogContext();
 
 test('schema', () => {
@@ -134,22 +139,18 @@ test('push edit change', () => {
     ['a'],
   );
 
-  consume(
-    ms.push({
-      type: 'add',
-      row: {a: 'a', b: 'b', c: 'c'},
-    }),
-  );
+  consume(ms.push(makeSourceChangeAdd({a: 'a', b: 'b', c: 'c'})));
 
   const conn = ms.connect([['a', 'asc']]);
   const c = new Catch(conn);
 
   consume(
-    ms.push({
-      type: 'edit',
-      oldRow: {a: 'a', b: 'b', c: 'c'},
-      row: {a: 'a', b: 'b2', c: 'c2'},
-    }),
+    ms.push(
+      makeSourceChangeEdit(
+        {a: 'a', b: 'b2', c: 'c2'},
+        {a: 'a', b: 'b', c: 'c'},
+      ),
+    ),
   );
   expect(c.pushes).toMatchInlineSnapshot(`
     [
@@ -193,12 +194,7 @@ test('fetch during push edit change', () => {
     ['a'],
   );
 
-  consume(
-    ms.push({
-      type: 'add',
-      row: {a: 'a', b: 'b', c: 'c'},
-    }),
-  );
+  consume(ms.push(makeSourceChangeAdd({a: 'a', b: 'b', c: 'c'})));
 
   const conn = ms.connect([['a', 'asc']]);
   let fetchDuringPush = undefined;
@@ -219,11 +215,12 @@ test('fetch during push edit change', () => {
   });
 
   consume(
-    ms.push({
-      type: 'edit',
-      oldRow: {a: 'a', b: 'b', c: 'c'},
-      row: {a: 'a', b: 'b2', c: 'c2'},
-    }),
+    ms.push(
+      makeSourceChangeEdit(
+        {a: 'a', b: 'b2', c: 'c2'},
+        {a: 'a', b: 'b', c: 'c'},
+      ),
+    ),
   );
   expect(fetchDuringPush).toMatchInlineSnapshot(`
     [
@@ -645,7 +642,7 @@ describe('generateWithOverlayUnordered', () => {
   test('Epoch gating — overlay skipped when lastPushedEpoch < overlay.epoch', () => {
     const overlay = {
       epoch: 5,
-      change: {type: 'add' as const, row: {id: 4, s: 'd', n: 44}},
+      change: makeSourceChangeAdd({id: 4, s: 'd', n: 44}),
     };
     const actual = Array.from(
       generateWithOverlayUnordered(rows, undefined, overlay, 4, pk),
@@ -657,7 +654,7 @@ describe('generateWithOverlayUnordered', () => {
   test('Epoch gating — overlay applied when lastPushedEpoch >= overlay.epoch', () => {
     const overlay = {
       epoch: 5,
-      change: {type: 'add' as const, row: {id: 4, s: 'd', n: 44}},
+      change: makeSourceChangeAdd({id: 4, s: 'd', n: 44}),
     };
     const actual = Array.from(
       generateWithOverlayUnordered(rows, undefined, overlay, 5, pk),
@@ -669,7 +666,7 @@ describe('generateWithOverlayUnordered', () => {
   test('Constraint filtering — overlay filtered out by constraint', () => {
     const overlay = {
       epoch: 1,
-      change: {type: 'add' as const, row: {id: 4, s: 'd', n: 44}},
+      change: makeSourceChangeAdd({id: 4, s: 'd', n: 44}),
     };
     const actual = Array.from(
       generateWithOverlayUnordered(rows, {s: 'a'}, overlay, 1, pk),
@@ -681,7 +678,7 @@ describe('generateWithOverlayUnordered', () => {
   test('Filter predicate — overlay filtered out by predicate', () => {
     const overlay = {
       epoch: 1,
-      change: {type: 'add' as const, row: {id: 4, s: 'd', n: 44}},
+      change: makeSourceChangeAdd({id: 4, s: 'd', n: 44}),
     };
     const actual = Array.from(
       generateWithOverlayUnordered(
@@ -700,7 +697,7 @@ describe('generateWithOverlayUnordered', () => {
   test('Add change type', () => {
     const overlay = {
       epoch: 1,
-      change: {type: 'add' as const, row: {id: 4, s: 'd', n: 44}},
+      change: makeSourceChangeAdd({id: 4, s: 'd', n: 44}),
     };
     const actual = Array.from(
       generateWithOverlayUnordered(rows, undefined, overlay, 1, pk),
@@ -712,7 +709,7 @@ describe('generateWithOverlayUnordered', () => {
   test('Remove change type', () => {
     const overlay = {
       epoch: 1,
-      change: {type: 'remove' as const, row: {id: 2, s: 'b', n: 22}},
+      change: makeSourceChangeRemove({id: 2, s: 'b', n: 22}),
     };
     const actual = Array.from(
       generateWithOverlayUnordered(rows, undefined, overlay, 1, pk),
@@ -724,11 +721,10 @@ describe('generateWithOverlayUnordered', () => {
   test('Edit change type', () => {
     const overlay = {
       epoch: 1,
-      change: {
-        type: 'edit' as const,
-        row: {id: 2, s: 'b2', n: 225},
-        oldRow: {id: 2, s: 'b', n: 22},
-      },
+      change: makeSourceChangeEdit(
+        {id: 2, s: 'b2', n: 225},
+        {id: 2, s: 'b', n: 22},
+      ),
     };
     const actual = Array.from(
       generateWithOverlayUnordered(rows, undefined, overlay, 1, pk),

--- a/packages/zql/src/ivm/memory-source.test.ts
+++ b/packages/zql/src/ivm/memory-source.test.ts
@@ -5,6 +5,8 @@ import {emptyArray} from '../../../shared/src/sentinels.ts';
 import type {Ordering} from '../../../zero-protocol/src/ast.ts';
 import type {Row} from '../../../zero-protocol/src/data.ts';
 import {Catch} from './catch.ts';
+import {ChangeIndex} from './change-index.ts';
+import {ChangeType} from './change-type.ts';
 import type {Change} from './change.ts';
 import {
   generateWithOverlayInner,
@@ -202,10 +204,14 @@ test('fetch during push edit change', () => {
   let fetchDuringPush = undefined;
   conn.setOutput({
     push(change: Change) {
-      expect(change).toEqual({
-        type: 'edit',
-        oldNode: {row: {a: 'a', b: 'b', c: 'c'}, relationships: {}},
-        node: {row: {a: 'a', b: 'b2', c: 'c2'}, relationships: {}},
+      expect(change[ChangeIndex.TYPE]).toBe(ChangeType.EDIT);
+      expect(change[ChangeIndex.NODE]).toEqual({
+        row: {a: 'a', b: 'b2', c: 'c2'},
+        relationships: {},
+      });
+      expect(change[ChangeIndex.OLD_NODE]).toEqual({
+        row: {a: 'a', b: 'b', c: 'c'},
+        relationships: {},
       });
       fetchDuringPush = [...conn.fetch({})];
       return emptyArray;

--- a/packages/zql/src/ivm/memory-source.ts
+++ b/packages/zql/src/ivm/memory-source.ts
@@ -18,6 +18,7 @@ import {
   type NoSubqueryCondition,
 } from '../builder/filter.ts';
 import {assertOrderingIncludesPK} from '../query/complete-ordering.ts';
+import {ChangeType} from './change-type.ts';
 import type {Change} from './change.ts';
 import {makeAddChange, makeEditChange, makeRemoveChange} from './change.ts';
 import {
@@ -42,6 +43,7 @@ import {
   type Start,
 } from './operator.ts';
 import type {SourceSchema} from './schema.ts';
+import {SourceChangeIndex} from './source-change-index.ts';
 import type {
   Source,
   SourceChange,
@@ -50,6 +52,7 @@ import type {
   SourceChangeRemove,
   SourceInput,
 } from './source.ts';
+import {makeSourceChangeAdd, makeSourceChangeRemove} from './source.ts';
 import type {Stream} from './stream.ts';
 
 export type Overlay = {
@@ -391,9 +394,9 @@ export class MemorySource implements Source {
 
   #writeChange(change: SourceChange) {
     for (const {data} of this.#indexes.values()) {
-      switch (change.type) {
-        case 'add': {
-          const added = data.add(change.row);
+      switch (change[SourceChangeIndex.TYPE]) {
+        case ChangeType.ADD: {
+          const added = data.add(change[SourceChangeIndex.ROW]);
           // must succeed since we checked has() above.
           assert(
             added,
@@ -401,8 +404,8 @@ export class MemorySource implements Source {
           );
           break;
         }
-        case 'remove': {
-          const removed = data.delete(change.row);
+        case ChangeType.REMOVE: {
+          const removed = data.delete(change[SourceChangeIndex.ROW]);
           // must succeed since we checked has() above.
           assert(
             removed,
@@ -410,18 +413,18 @@ export class MemorySource implements Source {
           );
           break;
         }
-        case 'edit': {
+        case ChangeType.EDIT: {
           // TODO: We could see if the PK (form the index tree's perspective)
           // changed and if not we could use set.
           // We cannot just do `set` with the new value since the `oldRow` might
           // not map to the same entry as the new `row` in the index btree.
-          const removed = data.delete(change.oldRow);
+          const removed = data.delete(change[SourceChangeIndex.OLD_ROW]);
           // must succeed since we checked has() above.
           assert(
             removed,
             'MemorySource: edit remove must succeed since row existence was already checked',
           );
-          data.add(change.row);
+          data.add(change[SourceChangeIndex.ROW]);
           break;
         }
         default:
@@ -460,11 +463,16 @@ export function* genPushAndWriteWithSplitEdit(
   getNextEpoch: () => number,
 ) {
   let shouldSplitEdit = false;
-  if (change.type === 'edit') {
+  if (change[SourceChangeIndex.TYPE] === ChangeType.EDIT) {
     for (const {splitEditKeys} of connections) {
       if (splitEditKeys) {
         for (const key of splitEditKeys) {
-          if (!valuesEqual(change.row[key], change.oldRow[key])) {
+          if (
+            !valuesEqual(
+              change[SourceChangeIndex.ROW][key],
+              change[SourceChangeIndex.OLD_ROW][key],
+            )
+          ) {
             shouldSplitEdit = true;
             break;
           }
@@ -473,13 +481,10 @@ export function* genPushAndWriteWithSplitEdit(
     }
   }
 
-  if (change.type === 'edit' && shouldSplitEdit) {
+  if (change[SourceChangeIndex.TYPE] === ChangeType.EDIT && shouldSplitEdit) {
     yield* genPushAndWrite(
       connections,
-      {
-        type: 'remove',
-        row: change.oldRow,
-      },
+      makeSourceChangeRemove(change[SourceChangeIndex.OLD_ROW]),
       exists,
       setOverlay,
       writeChange,
@@ -487,10 +492,7 @@ export function* genPushAndWriteWithSplitEdit(
     );
     yield* genPushAndWrite(
       connections,
-      {
-        type: 'add',
-        row: change.row,
-      },
+      makeSourceChangeAdd(change[SourceChangeIndex.ROW]),
       exists,
       setOverlay,
       writeChange,
@@ -529,18 +531,24 @@ function* genPush(
   setOverlay: (o: Overlay | undefined) => void,
   pushEpoch: number,
 ) {
-  switch (change.type) {
-    case 'add':
+  switch (change[SourceChangeIndex.TYPE]) {
+    case ChangeType.ADD:
       assert(
-        !exists(change.row),
+        !exists(change[SourceChangeIndex.ROW]),
         () => `Row already exists ${stringify(change)}`,
       );
       break;
-    case 'remove':
-      assert(exists(change.row), () => `Row not found ${stringify(change)}`);
+    case ChangeType.REMOVE:
+      assert(
+        exists(change[SourceChangeIndex.ROW]),
+        () => `Row not found ${stringify(change)}`,
+      );
       break;
-    case 'edit':
-      assert(exists(change.oldRow), () => `Row not found ${stringify(change)}`);
+    case ChangeType.EDIT:
+      assert(
+        exists(change[SourceChangeIndex.OLD_ROW]),
+        () => `Row not found ${stringify(change)}`,
+      );
       break;
     default:
       unreachable(change);
@@ -552,14 +560,20 @@ function* genPush(
       conn.lastPushedEpoch = pushEpoch;
       setOverlay({epoch: pushEpoch, change});
       const outputChange: Change =
-        change.type === 'edit'
+        change[SourceChangeIndex.TYPE] === ChangeType.EDIT
           ? makeEditChange(
-              {row: change.row, relationships: {}},
-              {row: change.oldRow, relationships: {}},
+              {row: change[SourceChangeIndex.ROW], relationships: {}},
+              {row: change[SourceChangeIndex.OLD_ROW], relationships: {}},
             )
-          : change.type === 'add'
-            ? makeAddChange({row: change.row, relationships: {}})
-            : makeRemoveChange({row: change.row, relationships: {}});
+          : change[SourceChangeIndex.TYPE] === ChangeType.ADD
+            ? makeAddChange({
+                row: change[SourceChangeIndex.ROW],
+                relationships: {},
+              })
+            : makeRemoveChange({
+                row: change[SourceChangeIndex.ROW],
+                relationships: {},
+              });
       yield* filterPush(outputChange, output, input, filters?.predicate);
       yield undefined;
     }
@@ -646,23 +660,23 @@ function computeOverlays(
     add: undefined,
     remove: undefined,
   };
-  switch (overlay?.change.type) {
-    case 'add':
+  switch (overlay?.change[SourceChangeIndex.TYPE]) {
+    case ChangeType.ADD:
       overlays = {
-        add: overlay.change.row,
+        add: overlay.change[SourceChangeIndex.ROW],
         remove: undefined,
       };
       break;
-    case 'remove':
+    case ChangeType.REMOVE:
       overlays = {
         add: undefined,
-        remove: overlay.change.row,
+        remove: overlay.change[SourceChangeIndex.ROW],
       };
       break;
-    case 'edit':
+    case ChangeType.EDIT:
       overlays = {
-        add: overlay.change.row,
-        remove: overlay.change.oldRow,
+        add: overlay.change[SourceChangeIndex.ROW],
+        remove: overlay.change[SourceChangeIndex.OLD_ROW],
       };
       break;
   }
@@ -776,17 +790,23 @@ export function* generateWithOverlayUnordered(
     overlayToApply = overlay;
   }
   let overlays: Overlays = {add: undefined, remove: undefined};
-  switch (overlayToApply?.change.type) {
-    case 'add':
-      overlays = {add: overlayToApply.change.row, remove: undefined};
-      break;
-    case 'remove':
-      overlays = {add: undefined, remove: overlayToApply.change.row};
-      break;
-    case 'edit':
+  switch (overlayToApply?.change[SourceChangeIndex.TYPE]) {
+    case ChangeType.ADD:
       overlays = {
-        add: overlayToApply.change.row,
-        remove: overlayToApply.change.oldRow,
+        add: overlayToApply.change[SourceChangeIndex.ROW],
+        remove: undefined,
+      };
+      break;
+    case ChangeType.REMOVE:
+      overlays = {
+        add: undefined,
+        remove: overlayToApply.change[SourceChangeIndex.ROW],
+      };
+      break;
+    case ChangeType.EDIT:
+      overlays = {
+        add: overlayToApply.change[SourceChangeIndex.ROW],
+        remove: overlayToApply.change[SourceChangeIndex.OLD_ROW],
       };
       break;
   }

--- a/packages/zql/src/ivm/memory-source.ts
+++ b/packages/zql/src/ivm/memory-source.ts
@@ -19,6 +19,7 @@ import {
 } from '../builder/filter.ts';
 import {assertOrderingIncludesPK} from '../query/complete-ordering.ts';
 import type {Change} from './change.ts';
+import {makeAddChange, makeEditChange, makeRemoveChange} from './change.ts';
 import {
   constraintMatchesPrimaryKey,
   constraintMatchesRow,
@@ -552,24 +553,13 @@ function* genPush(
       setOverlay({epoch: pushEpoch, change});
       const outputChange: Change =
         change.type === 'edit'
-          ? {
-              type: change.type,
-              oldNode: {
-                row: change.oldRow,
-                relationships: {},
-              },
-              node: {
-                row: change.row,
-                relationships: {},
-              },
-            }
-          : {
-              type: change.type,
-              node: {
-                row: change.row,
-                relationships: {},
-              },
-            };
+          ? makeEditChange(
+              {row: change.row, relationships: {}},
+              {row: change.oldRow, relationships: {}},
+            )
+          : change.type === 'add'
+            ? makeAddChange({row: change.row, relationships: {}})
+            : makeRemoveChange({row: change.row, relationships: {}});
       yield* filterPush(outputChange, output, input, filters?.predicate);
       yield undefined;
     }

--- a/packages/zql/src/ivm/push-accumulated.test.ts
+++ b/packages/zql/src/ivm/push-accumulated.test.ts
@@ -1,13 +1,24 @@
 /* oxlint-disable @typescript-eslint/no-explicit-any */
 import {beforeEach, describe, expect, test} from 'vitest';
 import {emptyArray, identity} from '../../../shared/src/sentinels.ts';
-import type {Change} from './change.js';
+import {ChangeIndex} from './change-index.js';
+import {ChangeType} from './change-type.js';
+import {
+  makeAddChange,
+  makeChildChange,
+  makeEditChange,
+  makeRemoveChange,
+  type AddChange,
+  type Change,
+  type EditChange,
+  type RemoveChange,
+} from './change.js';
 import type {InputBase, Output} from './operator.js';
 import {
+  pushAccumulatedChanges as genPushAccumulatedChanges,
   makeAddEmptyRelationships,
   mergeEmpty,
   mergeRelationships,
-  pushAccumulatedChanges as genPushAccumulatedChanges,
 } from './push-accumulated.js';
 import type {SourceSchema} from './schema.js';
 
@@ -20,7 +31,7 @@ function pushAccumulatedChanges(
   accumulatedPushes: Change[],
   output: Output,
   pusher: InputBase,
-  fanOutChangeType: Change['type'],
+  fanOutChangeType: ChangeType,
   mergeRelationships: (existing: Change, incoming: Change) => Change,
   addEmptyRelationships: (change: Change) => Change,
 ) {
@@ -36,17 +47,13 @@ function pushAccumulatedChanges(
   ];
 }
 
-const mockChildChange: Change = {
-  type: 'child',
-  node: {row: {id: 1}, relationships: {}},
-  child: {
-    change: {
-      type: 'add',
-      node: {row: {id: 2}, relationships: {}},
-    },
+const mockChildChange: Change = makeChildChange(
+  {row: {id: 1}, relationships: {}},
+  {
+    change: makeAddChange({row: {id: 2}, relationships: {}}),
     relationshipName: 'child',
   },
-};
+);
 
 const mockSchema: SourceSchema = {
   tableName: 'test',
@@ -79,51 +86,42 @@ describe('pushAccumulatedChanges', () => {
   describe('invariant: add coming in will only create adds coming out', () => {
     test('single add change passes through', () => {
       const accumulatedPushes: Change[] = [
-        {
-          type: 'add',
-          node: {row: {id: 1}, relationships: {}},
-        },
+        makeAddChange({row: {id: 1}, relationships: {}}),
       ];
 
       pushAccumulatedChanges(
         accumulatedPushes,
         output,
         mockPusher,
-        'add',
+        ChangeType.ADD,
         mergeRelationships,
         identity,
       );
 
       expect(pushedChanges).toHaveLength(1);
-      expect(pushedChanges[0]?.type).toBe('add');
+      expect(pushedChanges[0]?.[ChangeIndex.TYPE]).toBe(ChangeType.ADD);
     });
 
     test('multiple add changes collapse to single add', () => {
       const accumulatedPushes: Change[] = [
-        {
-          type: 'add',
-          node: {row: {id: 1}, relationships: {rel1: () => []}},
-        },
-        {
-          type: 'add',
-          node: {row: {id: 1}, relationships: {rel2: () => []}},
-        },
+        makeAddChange({row: {id: 1}, relationships: {rel1: () => []}}),
+        makeAddChange({row: {id: 1}, relationships: {rel2: () => []}}),
       ];
 
       pushAccumulatedChanges(
         accumulatedPushes,
         output,
         mockPusher,
-        'add',
+        ChangeType.ADD,
         mergeRelationships,
         identity,
       );
 
       expect(pushedChanges).toHaveLength(1);
-      expect(pushedChanges[0]?.type).toBe('add');
-      expect(Object.keys(pushedChanges[0]?.node?.relationships ?? {})).toEqual(
-        expect.arrayContaining(['rel1', 'rel2']),
-      );
+      expect(pushedChanges[0]?.[ChangeIndex.TYPE]).toBe(ChangeType.ADD);
+      expect(
+        Object.keys(pushedChanges[0]?.[ChangeIndex.NODE]?.relationships ?? {}),
+      ).toEqual(expect.arrayContaining(['rel1', 'rel2']));
     });
 
     test('no changes when all branches filter out add', () => {
@@ -133,7 +131,7 @@ describe('pushAccumulatedChanges', () => {
         accumulatedPushes,
         output,
         mockPusher,
-        'add',
+        ChangeType.ADD,
         mergeRelationships,
         identity,
       );
@@ -145,184 +143,162 @@ describe('pushAccumulatedChanges', () => {
   describe('invariant: remove coming in will only create removes coming out', () => {
     test('single remove change passes through', () => {
       const accumulatedPushes: Change[] = [
-        {
-          type: 'remove',
-          node: {row: {id: 1}, relationships: {}},
-        },
+        makeRemoveChange({row: {id: 1}, relationships: {}}),
       ];
 
       pushAccumulatedChanges(
         accumulatedPushes,
         output,
         mockPusher,
-        'remove',
+        ChangeType.REMOVE,
         mergeRelationships,
         identity,
       );
 
       expect(pushedChanges).toHaveLength(1);
-      expect(pushedChanges[0]?.type).toBe('remove');
+      expect(pushedChanges[0]?.[ChangeIndex.TYPE]).toBe(ChangeType.REMOVE);
     });
 
     test('multiple remove changes collapse to single remove', () => {
       const accumulatedPushes: Change[] = [
-        {
-          type: 'remove',
-          node: {row: {id: 1}, relationships: {rel1: () => []}},
-        },
-        {
-          type: 'remove',
-          node: {row: {id: 1}, relationships: {rel2: () => []}},
-        },
+        makeRemoveChange({row: {id: 1}, relationships: {rel1: () => []}}),
+        makeRemoveChange({row: {id: 1}, relationships: {rel2: () => []}}),
       ];
 
       pushAccumulatedChanges(
         accumulatedPushes,
         output,
         mockPusher,
-        'remove',
+        ChangeType.REMOVE,
         mergeRelationships,
         identity,
       );
 
       expect(pushedChanges).toHaveLength(1);
-      expect(pushedChanges[0]?.type).toBe('remove');
-      expect(Object.keys(pushedChanges[0]?.node?.relationships ?? {})).toEqual(
-        expect.arrayContaining(['rel1', 'rel2']),
-      );
+      expect(pushedChanges[0]?.[ChangeIndex.TYPE]).toBe(ChangeType.REMOVE);
+      expect(
+        Object.keys(pushedChanges[0]?.[ChangeIndex.NODE]?.relationships ?? {}),
+      ).toEqual(expect.arrayContaining(['rel1', 'rel2']));
     });
   });
 
   describe('invariant: edit coming in can create adds, removes, and edits coming out', () => {
     test('edit preserved as edit', () => {
       const accumulatedPushes: Change[] = [
-        {
-          type: 'edit',
-          node: {row: {id: 1, value: 2}, relationships: {}},
-          oldNode: {row: {id: 1, value: 1}, relationships: {}},
-        },
+        makeEditChange(
+          {row: {id: 1, value: 2}, relationships: {}},
+          {row: {id: 1, value: 1}, relationships: {}},
+        ),
       ];
 
       pushAccumulatedChanges(
         accumulatedPushes,
         output,
         mockPusher,
-        'edit',
+        ChangeType.EDIT,
         mergeRelationships,
         identity,
       );
 
       expect(pushedChanges).toHaveLength(1);
-      expect(pushedChanges[0]?.type).toBe('edit');
+      expect(pushedChanges[0]?.[ChangeIndex.TYPE]).toBe(ChangeType.EDIT);
     });
 
     test('edit converted to add only', () => {
       const accumulatedPushes: Change[] = [
-        {
-          type: 'add',
-          node: {row: {id: 1, value: 2}, relationships: {}},
-        },
+        makeAddChange({row: {id: 1, value: 2}, relationships: {}}),
       ];
 
       pushAccumulatedChanges(
         accumulatedPushes,
         output,
         mockPusher,
-        'edit',
+        ChangeType.EDIT,
         mergeRelationships,
         identity,
       );
 
       expect(pushedChanges).toHaveLength(1);
-      expect(pushedChanges[0]?.type).toBe('add');
+      expect(pushedChanges[0]?.[ChangeIndex.TYPE]).toBe(ChangeType.ADD);
     });
 
     test('edit converted to remove only', () => {
       const accumulatedPushes: Change[] = [
-        {
-          type: 'remove',
-          node: {row: {id: 1, value: 1}, relationships: {}},
-        },
+        makeRemoveChange({row: {id: 1, value: 1}, relationships: {}}),
       ];
 
       pushAccumulatedChanges(
         accumulatedPushes,
         output,
         mockPusher,
-        'edit',
+        ChangeType.EDIT,
         mergeRelationships,
         identity,
       );
 
       expect(pushedChanges).toHaveLength(1);
-      expect(pushedChanges[0]?.type).toBe('remove');
+      expect(pushedChanges[0]?.[ChangeIndex.TYPE]).toBe(ChangeType.REMOVE);
     });
 
     test('edit split into add and remove recombines to edit', () => {
       const accumulatedPushes: Change[] = [
-        {
-          type: 'add',
-          node: {row: {id: 1, value: 2}, relationships: {}},
-        },
-        {
-          type: 'remove',
-          node: {row: {id: 1, value: 1}, relationships: {}},
-        },
+        makeAddChange({row: {id: 1, value: 2}, relationships: {}}),
+        makeRemoveChange({row: {id: 1, value: 1}, relationships: {}}),
       ];
 
       pushAccumulatedChanges(
         accumulatedPushes,
         output,
         mockPusher,
-        'edit',
+        ChangeType.EDIT,
         mergeRelationships,
         identity,
       );
 
       expect(pushedChanges).toHaveLength(1);
-      expect(pushedChanges[0]?.type).toBe('edit');
-      expect(pushedChanges[0]).toEqual({
-        type: 'edit',
-        node: {row: {id: 1, value: 2}, relationships: {}},
-        oldNode: {row: {id: 1, value: 1}, relationships: {}},
-      });
+      expect(pushedChanges[0]?.[ChangeIndex.TYPE]).toBe(ChangeType.EDIT);
+      expect(pushedChanges[0]).toEqual(
+        makeEditChange(
+          {row: {id: 1, value: 2}, relationships: {}},
+          {row: {id: 1, value: 1}, relationships: {}},
+        ),
+      );
     });
 
     test('edit supersedes add and remove when all three present', () => {
       const accumulatedPushes: Change[] = [
-        {
-          type: 'edit',
-          node: {row: {id: 1, value: 3}, relationships: {editRel: () => []}},
-          oldNode: {row: {id: 1, value: 0}, relationships: {}},
-        },
-        {
-          type: 'add',
-          node: {row: {id: 1, value: 2}, relationships: {addRel: () => []}},
-        },
-        {
-          type: 'remove',
-          node: {row: {id: 1, value: 1}, relationships: {removeRel: () => []}},
-        },
+        makeEditChange(
+          {row: {id: 1, value: 3}, relationships: {editRel: () => []}},
+          {row: {id: 1, value: 0}, relationships: {}},
+        ),
+        makeAddChange({
+          row: {id: 1, value: 2},
+          relationships: {addRel: () => []},
+        }),
+        makeRemoveChange({
+          row: {id: 1, value: 1},
+          relationships: {removeRel: () => []},
+        }),
       ];
 
       pushAccumulatedChanges(
         accumulatedPushes,
         output,
         mockPusher,
-        'edit',
+        ChangeType.EDIT,
         mergeRelationships,
         identity,
       );
 
       expect(pushedChanges).toHaveLength(1);
-      expect(pushedChanges[0]?.type).toBe('edit');
-      const editChange = pushedChanges[0] as Extract<Change, {type: 'edit'}>;
-      expect(Object.keys(editChange.node.relationships)).toEqual(
+      expect(pushedChanges[0]?.[ChangeIndex.TYPE]).toBe(ChangeType.EDIT);
+      const editChange = pushedChanges[0] as EditChange;
+      expect(Object.keys(editChange[ChangeIndex.NODE].relationships)).toEqual(
         expect.arrayContaining(['editRel', 'addRel']),
       );
-      expect(Object.keys(editChange.oldNode.relationships)).toEqual(
-        expect.arrayContaining(['removeRel']),
-      );
+      expect(
+        Object.keys(editChange[ChangeIndex.OLD_NODE].relationships),
+      ).toEqual(expect.arrayContaining(['removeRel']));
     });
   });
 
@@ -334,90 +310,75 @@ describe('pushAccumulatedChanges', () => {
         accumulatedPushes,
         output,
         mockPusher,
-        'child',
+        ChangeType.CHILD,
         mergeRelationships,
         identity,
       );
 
       expect(pushedChanges).toHaveLength(1);
-      expect(pushedChanges[0]?.type).toBe('child');
+      expect(pushedChanges[0]?.[ChangeIndex.TYPE]).toBe(ChangeType.CHILD);
     });
 
     test('child converted to add only', () => {
       const accumulatedPushes: Change[] = [
-        {
-          type: 'add',
-          node: {row: {id: 1}, relationships: {}},
-        },
+        makeAddChange({row: {id: 1}, relationships: {}}),
       ];
 
       pushAccumulatedChanges(
         accumulatedPushes,
         output,
         mockPusher,
-        'child',
+        ChangeType.CHILD,
         mergeRelationships,
         identity,
       );
 
       expect(pushedChanges).toHaveLength(1);
-      expect(pushedChanges[0]?.type).toBe('add');
+      expect(pushedChanges[0]?.[ChangeIndex.TYPE]).toBe(ChangeType.ADD);
     });
 
     test('child converted to remove only', () => {
       const accumulatedPushes: Change[] = [
-        {
-          type: 'remove',
-          node: {row: {id: 1}, relationships: {}},
-        },
+        makeRemoveChange({row: {id: 1}, relationships: {}}),
       ];
 
       pushAccumulatedChanges(
         accumulatedPushes,
         output,
         mockPusher,
-        'child',
+        ChangeType.CHILD,
         mergeRelationships,
         identity,
       );
 
       expect(pushedChanges).toHaveLength(1);
-      expect(pushedChanges[0]?.type).toBe('remove');
+      expect(pushedChanges[0]?.[ChangeIndex.TYPE]).toBe(ChangeType.REMOVE);
     });
 
     test('child takes precedence over add/remove when present', () => {
       const accumulatedPushes: Change[] = [
         mockChildChange,
-        {
-          type: 'add',
-          node: {row: {id: 1}, relationships: {}},
-        },
+        makeAddChange({row: {id: 1}, relationships: {}}),
       ];
 
       pushAccumulatedChanges(
         accumulatedPushes,
         output,
         mockPusher,
-        'child',
+        ChangeType.CHILD,
         mergeRelationships,
         identity,
       );
 
       expect(pushedChanges).toHaveLength(1);
-      expect(pushedChanges[0]?.type).toBe('child');
+      expect(pushedChanges[0]?.[ChangeIndex.TYPE]).toBe(ChangeType.CHILD);
     });
 
     test('child ensures at most one add or remove (not both)', () => {
       // This should assert fail if both add and remove are present without child
       const accumulatedPushes: Change[] = [
-        {
-          type: 'add',
-          node: {row: {id: 1}, relationships: {}},
-        },
-        {
-          type: 'remove',
-          node: {row: {id: 2}, relationships: {}},
-        },
+        makeAddChange({row: {id: 1}, relationships: {}}),
+        makeRemoveChange({row: {id: 2}, relationships: {}}),
       ];
 
       expect(() => {
@@ -425,7 +386,7 @@ describe('pushAccumulatedChanges', () => {
           accumulatedPushes,
           output,
           mockPusher,
-          'child',
+          ChangeType.CHILD,
           mergeRelationships,
           identity,
         );
@@ -436,63 +397,58 @@ describe('pushAccumulatedChanges', () => {
 
 describe('mergeRelationships', () => {
   test('merges relationships from add changes', () => {
-    const left: Change = {
-      type: 'add',
-      node: {row: {id: 1}, relationships: {rel1: () => []}},
-    };
-    const right: Change = {
-      type: 'add',
-      node: {row: {id: 1}, relationships: {rel2: () => []}},
-    };
+    const left: Change = makeAddChange({
+      row: {id: 1},
+      relationships: {rel1: () => []},
+    });
+    const right: Change = makeAddChange({
+      row: {id: 1},
+      relationships: {rel2: () => []},
+    });
 
     const result = mergeRelationships(left, right);
 
-    expect(result.type).toBe('add');
-    expect(Object.keys(result.node.relationships)).toEqual(
+    expect(result[ChangeIndex.TYPE]).toBe(ChangeType.ADD);
+    expect(Object.keys(result[ChangeIndex.NODE].relationships)).toEqual(
       expect.arrayContaining(['rel1', 'rel2']),
     );
   });
 
   test('merges relationships from remove changes', () => {
-    const left: Change = {
-      type: 'remove',
-      node: {row: {id: 1}, relationships: {rel1: () => []}},
-    };
-    const right: Change = {
-      type: 'remove',
-      node: {row: {id: 1}, relationships: {rel2: () => []}},
-    };
+    const left: Change = makeRemoveChange({
+      row: {id: 1},
+      relationships: {rel1: () => []},
+    });
+    const right: Change = makeRemoveChange({
+      row: {id: 1},
+      relationships: {rel2: () => []},
+    });
 
     const result = mergeRelationships(left, right);
 
-    expect(result.type).toBe('remove');
-    expect(Object.keys(result.node.relationships)).toEqual(
+    expect(result[ChangeIndex.TYPE]).toBe(ChangeType.REMOVE);
+    expect(Object.keys(result[ChangeIndex.NODE].relationships)).toEqual(
       expect.arrayContaining(['rel1', 'rel2']),
     );
   });
 
   test('merges relationships from edit changes', () => {
-    const left: Change = {
-      type: 'edit',
-      node: {row: {id: 1}, relationships: {rel1: () => []}},
-      oldNode: {row: {id: 1}, relationships: {oldRel1: () => []}},
-    };
-    const right: Change = {
-      type: 'edit',
-      node: {row: {id: 1}, relationships: {rel2: () => []}},
-      oldNode: {row: {id: 1}, relationships: {oldRel2: () => []}},
-    };
+    const left: Change = makeEditChange(
+      {row: {id: 1}, relationships: {rel1: () => []}},
+      {row: {id: 1}, relationships: {oldRel1: () => []}},
+    );
+    const right: Change = makeEditChange(
+      {row: {id: 1}, relationships: {rel2: () => []}},
+      {row: {id: 1}, relationships: {oldRel2: () => []}},
+    );
 
-    const result = mergeRelationships(left, right) as Extract<
-      Change,
-      {type: 'edit'}
-    >;
+    const result = mergeRelationships(left, right) as EditChange;
 
-    expect(result.type).toBe('edit');
-    expect(Object.keys(result.node.relationships)).toEqual(
+    expect(result[ChangeIndex.TYPE]).toBe(ChangeType.EDIT);
+    expect(Object.keys(result[ChangeIndex.NODE].relationships)).toEqual(
       expect.arrayContaining(['rel1', 'rel2']),
     );
-    expect(Object.keys(result.oldNode.relationships)).toEqual(
+    expect(Object.keys(result[ChangeIndex.OLD_NODE].relationships)).toEqual(
       expect.arrayContaining(['oldRel1', 'oldRel2']),
     );
   });
@@ -501,87 +457,74 @@ describe('mergeRelationships', () => {
     const rel1Left = () => [];
     const rel1Right = () => [];
 
-    const left: Change = {
-      type: 'add',
-      node: {row: {id: 1}, relationships: {rel1: rel1Left}},
-    };
-    const right: Change = {
-      type: 'add',
-      node: {row: {id: 1}, relationships: {rel1: rel1Right}},
-    };
+    const left: Change = makeAddChange({
+      row: {id: 1},
+      relationships: {rel1: rel1Left},
+    });
+    const right: Change = makeAddChange({
+      row: {id: 1},
+      relationships: {rel1: rel1Right},
+    });
 
-    const result = mergeRelationships(left, right) as Extract<
-      Change,
-      {type: 'add'}
-    >;
+    const result = mergeRelationships(left, right) as AddChange;
 
-    expect(result.node.relationships.rel1).toBe(rel1Left);
+    expect(result[ChangeIndex.NODE].relationships.rel1).toBe(rel1Left);
   });
 
   test('merges edit with add', () => {
-    const left: Change = {
-      type: 'edit',
-      node: {row: {id: 1}, relationships: {editRel: () => []}},
-      oldNode: {row: {id: 1}, relationships: {}},
-    };
-    const right: Change = {
-      type: 'add',
-      node: {row: {id: 1}, relationships: {addRel: () => []}},
-    };
+    const left: Change = makeEditChange(
+      {row: {id: 1}, relationships: {editRel: () => []}},
+      {row: {id: 1}, relationships: {}},
+    );
+    const right: Change = makeAddChange({
+      row: {id: 1},
+      relationships: {addRel: () => []},
+    });
 
-    const result = mergeRelationships(left, right) as Extract<
-      Change,
-      {type: 'edit'}
-    >;
+    const result = mergeRelationships(left, right) as EditChange;
 
-    expect(result.type).toBe('edit');
-    expect(Object.keys(result.node.relationships)).toEqual(
+    expect(result[ChangeIndex.TYPE]).toBe(ChangeType.EDIT);
+    expect(Object.keys(result[ChangeIndex.NODE].relationships)).toEqual(
       expect.arrayContaining(['editRel', 'addRel']),
     );
   });
 
   test('merges edit with remove', () => {
-    const left: Change = {
-      type: 'edit',
-      node: {row: {id: 1}, relationships: {}},
-      oldNode: {row: {id: 1}, relationships: {editOldRel: () => []}},
-    };
-    const right: Change = {
-      type: 'remove',
-      node: {row: {id: 1}, relationships: {removeRel: () => []}},
-    };
+    const left: Change = makeEditChange(
+      {row: {id: 1}, relationships: {}},
+      {row: {id: 1}, relationships: {editOldRel: () => []}},
+    );
+    const right: Change = makeRemoveChange({
+      row: {id: 1},
+      relationships: {removeRel: () => []},
+    });
 
-    const result = mergeRelationships(left, right) as Extract<
-      Change,
-      {type: 'edit'}
-    >;
+    const result = mergeRelationships(left, right) as EditChange;
 
-    expect(result.type).toBe('edit');
-    expect(Object.keys(result.oldNode.relationships)).toEqual(
+    expect(result[ChangeIndex.TYPE]).toBe(ChangeType.EDIT);
+    expect(Object.keys(result[ChangeIndex.OLD_NODE].relationships)).toEqual(
       expect.arrayContaining(['editOldRel', 'removeRel']),
     );
   });
 
   test('merges relationships from child changes', () => {
     const childInfo = {
-      change: {type: 'add' as const, node: {row: {id: 2}, relationships: {}}},
+      change: makeAddChange({row: {id: 2}, relationships: {}}),
       relationshipName: 'childRel',
     };
-    const left: Change = {
-      type: 'child',
-      node: {row: {id: 1}, relationships: {rel1: () => []}},
-      child: childInfo,
-    };
-    const right: Change = {
-      type: 'child',
-      node: {row: {id: 1}, relationships: {rel2: () => []}},
-      child: childInfo,
-    };
+    const left: Change = makeChildChange(
+      {row: {id: 1}, relationships: {rel1: () => []}},
+      childInfo,
+    );
+    const right: Change = makeChildChange(
+      {row: {id: 1}, relationships: {rel2: () => []}},
+      childInfo,
+    );
 
     const result = mergeRelationships(left, right);
 
-    expect(result.type).toBe('child');
-    expect(Object.keys(result.node.relationships)).toEqual(
+    expect(result[ChangeIndex.TYPE]).toBe(ChangeType.CHILD);
+    expect(Object.keys(result[ChangeIndex.NODE].relationships)).toEqual(
       expect.arrayContaining(['rel1', 'rel2']),
     );
   });
@@ -593,21 +536,15 @@ describe('makeAddEmptyRelationships', () => {
 
     const addEmptyRelationships = makeAddEmptyRelationships(schema);
 
-    const change: Change = {
-      type: 'add',
-      node: {row: {id: 1}, relationships: {}},
-    };
+    const change: Change = makeAddChange({row: {id: 1}, relationships: {}});
 
-    const result = addEmptyRelationships(change) as Extract<
-      Change,
-      {type: 'add'}
-    >;
+    const result = addEmptyRelationships(change) as AddChange;
 
-    expect(Object.keys(result.node.relationships)).toEqual(
+    expect(Object.keys(result[ChangeIndex.NODE].relationships)).toEqual(
       expect.arrayContaining(['rel1', 'rel2']),
     );
-    expect(result.node.relationships.rel1?.()).toEqual([]);
-    expect(result.node.relationships.rel2?.()).toEqual([]);
+    expect(result[ChangeIndex.NODE].relationships.rel1?.()).toEqual([]);
+    expect(result[ChangeIndex.NODE].relationships.rel2?.()).toEqual([]);
   });
 
   test('adds empty relationships for remove change', () => {
@@ -615,17 +552,11 @@ describe('makeAddEmptyRelationships', () => {
 
     const addEmptyRelationships = makeAddEmptyRelationships(schema);
 
-    const change: Change = {
-      type: 'remove',
-      node: {row: {id: 1}, relationships: {}},
-    };
+    const change: Change = makeRemoveChange({row: {id: 1}, relationships: {}});
 
-    const result = addEmptyRelationships(change) as Extract<
-      Change,
-      {type: 'remove'}
-    >;
+    const result = addEmptyRelationships(change) as RemoveChange;
 
-    expect(Object.keys(result.node.relationships)).toEqual(
+    expect(Object.keys(result[ChangeIndex.NODE].relationships)).toEqual(
       expect.arrayContaining(['rel1', 'rel2']),
     );
   });
@@ -635,21 +566,17 @@ describe('makeAddEmptyRelationships', () => {
 
     const addEmptyRelationships = makeAddEmptyRelationships(schema);
 
-    const change: Change = {
-      type: 'edit',
-      node: {row: {id: 1}, relationships: {}},
-      oldNode: {row: {id: 1}, relationships: {}},
-    };
+    const change: Change = makeEditChange(
+      {row: {id: 1}, relationships: {}},
+      {row: {id: 1}, relationships: {}},
+    );
 
-    const result = addEmptyRelationships(change) as Extract<
-      Change,
-      {type: 'edit'}
-    >;
+    const result = addEmptyRelationships(change) as EditChange;
 
-    expect(Object.keys(result.node.relationships)).toEqual(
+    expect(Object.keys(result[ChangeIndex.NODE].relationships)).toEqual(
       expect.arrayContaining(['rel1', 'rel2']),
     );
-    expect(Object.keys(result.oldNode.relationships)).toEqual(
+    expect(Object.keys(result[ChangeIndex.OLD_NODE].relationships)).toEqual(
       expect.arrayContaining(['rel1', 'rel2']),
     );
   });
@@ -660,18 +587,15 @@ describe('makeAddEmptyRelationships', () => {
     const addEmptyRelationships = makeAddEmptyRelationships(schema);
 
     const existingRel = () => [{row: {id: 2}, relationships: {}}];
-    const change: Change = {
-      type: 'add',
-      node: {row: {id: 1}, relationships: {rel1: existingRel}},
-    };
+    const change: Change = makeAddChange({
+      row: {id: 1},
+      relationships: {rel1: existingRel},
+    });
 
-    const result = addEmptyRelationships(change) as Extract<
-      Change,
-      {type: 'add'}
-    >;
+    const result = addEmptyRelationships(change) as AddChange;
 
-    expect(result.node.relationships.rel1).toBe(existingRel);
-    expect(result.node.relationships.rel2?.()).toEqual([]);
+    expect(result[ChangeIndex.NODE].relationships.rel1).toBe(existingRel);
+    expect(result[ChangeIndex.NODE].relationships.rel2?.()).toEqual([]);
   });
 
   test('does not modify child changes', () => {
@@ -700,10 +624,7 @@ describe('makeAddEmptyRelationships', () => {
 
     const addEmptyRelationships = makeAddEmptyRelationships(schema);
 
-    const change: Change = {
-      type: 'add',
-      node: {row: {id: 1}, relationships: {}},
-    };
+    const change: Change = makeAddChange({row: {id: 1}, relationships: {}});
 
     const result = addEmptyRelationships(change);
 

--- a/packages/zql/src/ivm/push-accumulated.ts
+++ b/packages/zql/src/ivm/push-accumulated.ts
@@ -1,7 +1,15 @@
 import {assert, unreachable} from '../../../shared/src/asserts.ts';
 import {must} from '../../../shared/src/must.ts';
 import {emptyArray} from '../../../shared/src/sentinels.ts';
-import type {Change} from './change.ts';
+import {ChangeIndex} from './change-index.ts';
+import {ChangeType} from './change-type.ts';
+import {
+  makeAddChange,
+  makeChildChange,
+  makeEditChange,
+  makeRemoveChange,
+  type Change,
+} from './change.ts';
 import type {Node} from './data.ts';
 import type {InputBase, Output} from './operator.ts';
 import type {SourceSchema} from './schema.ts';
@@ -80,7 +88,7 @@ export function* pushAccumulatedChanges(
   accumulatedPushes: Change[],
   output: Output,
   pusher: InputBase,
-  fanOutChangeType: Change['type'],
+  fanOutChangeType: ChangeType,
   mergeRelationships: (existing: Change, incoming: Change) => Change,
   addEmptyRelationships: (change: Change) => Change,
 ): Stream<'yield'> {
@@ -91,23 +99,26 @@ export function* pushAccumulatedChanges(
   }
 
   // collapse down to a single change per type
-  const candidatesToPush = new Map<Change['type'], Change>();
+  const candidatesToPush = new Map<ChangeType, Change>();
   for (const change of accumulatedPushes) {
-    if (fanOutChangeType === 'child' && change.type !== 'child') {
+    if (
+      fanOutChangeType === ChangeType.CHILD &&
+      change[ChangeIndex.TYPE] !== ChangeType.CHILD
+    ) {
       assert(
-        candidatesToPush.has(change.type) === false,
+        candidatesToPush.has(change[ChangeIndex.TYPE]) === false,
         () =>
-          `Fan-in:child expected at most one ${change.type} when fan-out is of type child`,
+          `Fan-in:child expected at most one ${change[ChangeIndex.TYPE]} when fan-out is of type child`,
       );
     }
 
-    const existing = candidatesToPush.get(change.type);
+    const existing = candidatesToPush.get(change[ChangeIndex.TYPE]);
     let mergedChange = change;
     if (existing) {
       // merge in relationships
       mergedChange = mergeRelationships(existing, change);
     }
-    candidatesToPush.set(change.type, mergedChange);
+    candidatesToPush.set(change[ChangeIndex.TYPE], mergedChange);
   }
 
   accumulatedPushes.length = 0;
@@ -124,36 +135,39 @@ export function* pushAccumulatedChanges(
    *    - Many child changes because other operators may preserve the child change
    */
   switch (fanOutChangeType) {
-    case 'remove':
+    case ChangeType.REMOVE:
       assert(
-        types.length === 1 && types[0] === 'remove',
+        types.length === 1 && types[0] === ChangeType.REMOVE,
         'Fan-in:remove expected all removes',
       );
       yield* output.push(
-        addEmptyRelationships(must(candidatesToPush.get('remove'))),
+        addEmptyRelationships(must(candidatesToPush.get(ChangeType.REMOVE))),
         pusher,
       );
       return;
-    case 'add':
+    case ChangeType.ADD:
       assert(
-        types.length === 1 && types[0] === 'add',
+        types.length === 1 && types[0] === ChangeType.ADD,
         'Fan-in:add expected all adds',
       );
       yield* output.push(
-        addEmptyRelationships(must(candidatesToPush.get('add'))),
+        addEmptyRelationships(must(candidatesToPush.get(ChangeType.ADD))),
         pusher,
       );
       return;
-    case 'edit': {
+    case ChangeType.EDIT: {
       assert(
         types.every(
-          type => type === 'add' || type === 'remove' || type === 'edit',
+          type =>
+            type === ChangeType.ADD ||
+            type === ChangeType.REMOVE ||
+            type === ChangeType.EDIT,
         ),
         'Fan-in:edit expected all adds, removes, or edits',
       );
-      const addChange = candidatesToPush.get('add');
-      const removeChange = candidatesToPush.get('remove');
-      let editChange = candidatesToPush.get('edit');
+      const addChange = candidatesToPush.get(ChangeType.ADD);
+      const removeChange = candidatesToPush.get(ChangeType.REMOVE);
+      let editChange = candidatesToPush.get(ChangeType.EDIT);
 
       // If an `edit` is present, it supersedes `add` and `remove`
       // as it semantically represents both.
@@ -187,11 +201,12 @@ export function* pushAccumulatedChanges(
       // The right filter converts the edit into an add.
       if (addChange && removeChange) {
         yield* output.push(
-          addEmptyRelationships({
-            type: 'edit',
-            node: addChange.node,
-            oldNode: removeChange.node,
-          } as const),
+          addEmptyRelationships(
+            makeEditChange(
+              addChange[ChangeIndex.NODE],
+              removeChange[ChangeIndex.NODE],
+            ),
+          ),
           pusher,
         );
         return;
@@ -203,13 +218,13 @@ export function* pushAccumulatedChanges(
       );
       return;
     }
-    case 'child': {
+    case ChangeType.CHILD: {
       assert(
         types.every(
           type =>
-            type === 'add' || // exists can change child to add or remove
-            type === 'remove' || // exists can change child to add or remove
-            type === 'child', // other operators may preserve the child change
+            type === ChangeType.ADD || // exists can change child to add or remove
+            type === ChangeType.REMOVE || // exists can change child to add or remove
+            type === ChangeType.CHILD, // other operators may preserve the child change
         ),
         'Fan-in:child expected all adds, removes, or children',
       );
@@ -219,14 +234,14 @@ export function* pushAccumulatedChanges(
       );
 
       // If any branch preserved the original child change, that takes precedence over all other changes.
-      const childChange = candidatesToPush.get('child');
+      const childChange = candidatesToPush.get(ChangeType.CHILD);
       if (childChange) {
         yield* output.push(childChange, pusher);
         return;
       }
 
-      const addChange = candidatesToPush.get('add');
-      const removeChange = candidatesToPush.get('remove');
+      const addChange = candidatesToPush.get(ChangeType.ADD);
+      const removeChange = candidatesToPush.get(ChangeType.REMOVE);
 
       assert(
         addChange === undefined || removeChange === undefined,
@@ -251,113 +266,100 @@ export function mergeRelationships(left: Change, right: Change): Change {
   // change types will always match
   // unless we have an edit on the left
   // then the right could be edit, add, or remove
-  if (left.type === right.type) {
-    switch (left.type) {
-      case 'add': {
-        return {
-          type: 'add',
-          node: {
-            row: left.node.row,
-            relationships: {
-              ...right.node.relationships,
-              ...left.node.relationships,
-            },
+  if (left[ChangeIndex.TYPE] === right[ChangeIndex.TYPE]) {
+    switch (left[ChangeIndex.TYPE]) {
+      case ChangeType.ADD: {
+        return makeAddChange({
+          row: left[ChangeIndex.NODE].row,
+          relationships: {
+            ...right[ChangeIndex.NODE].relationships,
+            ...left[ChangeIndex.NODE].relationships,
           },
-        };
+        });
       }
-      case 'remove': {
-        return {
-          type: 'remove',
-          node: {
-            row: left.node.row,
-            relationships: {
-              ...right.node.relationships,
-              ...left.node.relationships,
-            },
+      case ChangeType.REMOVE: {
+        return makeRemoveChange({
+          row: left[ChangeIndex.NODE].row,
+          relationships: {
+            ...right[ChangeIndex.NODE].relationships,
+            ...left[ChangeIndex.NODE].relationships,
           },
-        };
+        });
       }
-      case 'edit': {
+      case ChangeType.EDIT: {
         assert(
-          right.type === 'edit',
+          right[ChangeIndex.TYPE] === ChangeType.EDIT,
           () =>
-            `mergeRelationships: when left.type is edit and types match, right.type must be edit, got ${right.type}`,
+            `mergeRelationships: when left.type is edit and types match, right.type must be edit, got ${right[ChangeIndex.TYPE]}`,
         );
         // merge edits into a single edit
-        return {
-          type: 'edit',
-          node: {
-            row: left.node.row,
+        return makeEditChange(
+          {
+            row: left[ChangeIndex.NODE].row,
             relationships: {
-              ...right.node.relationships,
-              ...left.node.relationships,
+              ...right[ChangeIndex.NODE].relationships,
+              ...left[ChangeIndex.NODE].relationships,
             },
           },
-          oldNode: {
-            row: left.oldNode.row,
+          {
+            row: left[ChangeIndex.OLD_NODE].row,
             relationships: {
-              ...right.oldNode.relationships,
-              ...left.oldNode.relationships,
+              ...right[ChangeIndex.OLD_NODE].relationships,
+              ...left[ChangeIndex.OLD_NODE].relationships,
             },
           },
-        };
+        );
       }
-      case 'child': {
+      case ChangeType.CHILD: {
         // Multiple branches may preserve the same child change, each adding
         // different relationships. Merge the relationships, keeping the child
         // (which should be identical across branches).
         assert(
-          right.type === 'child',
+          right[ChangeIndex.TYPE] === ChangeType.CHILD,
           () =>
-            `mergeRelationships: when left.type is child and types match, right.type must be child, got ${right.type}`,
+            `mergeRelationships: when left.type is child and types match, right.type must be child, got ${right[ChangeIndex.TYPE]}`,
         );
-        return {
-          type: 'child',
-          node: {
-            row: left.node.row,
+        return makeChildChange(
+          {
+            row: left[ChangeIndex.NODE].row,
             relationships: {
-              ...right.node.relationships,
-              ...left.node.relationships,
+              ...right[ChangeIndex.NODE].relationships,
+              ...left[ChangeIndex.NODE].relationships,
             },
           },
-          child: left.child,
-        };
+          left[ChangeIndex.CHILD_DATA],
+        );
       }
     }
   }
 
   // left is always an edit here
   assert(
-    left.type === 'edit',
+    left[ChangeIndex.TYPE] === ChangeType.EDIT,
     () =>
-      `mergeRelationships: when types differ, left.type must be edit, got left.type=${left.type}, right.type=${right.type}`,
+      `mergeRelationships: when types differ, left.type must be edit, got left.type=${left[ChangeIndex.TYPE]}, right.type=${right[ChangeIndex.TYPE]}`,
   );
-  switch (right.type) {
-    case 'add': {
-      return {
-        type: 'edit',
-        node: {
-          ...left.node,
+  switch (right[ChangeIndex.TYPE]) {
+    case ChangeType.ADD: {
+      return makeEditChange(
+        {
+          ...left[ChangeIndex.NODE],
           relationships: {
-            ...right.node.relationships,
-            ...left.node.relationships,
+            ...right[ChangeIndex.NODE].relationships,
+            ...left[ChangeIndex.NODE].relationships,
           },
         },
-        oldNode: left.oldNode,
-      };
+        left[ChangeIndex.OLD_NODE],
+      );
     }
-    case 'remove': {
-      return {
-        type: 'edit',
-        node: left.node,
-        oldNode: {
-          ...left.oldNode,
-          relationships: {
-            ...right.node.relationships,
-            ...left.oldNode.relationships,
-          },
+    case ChangeType.REMOVE: {
+      return makeEditChange(left[ChangeIndex.NODE], {
+        ...left[ChangeIndex.OLD_NODE],
+        relationships: {
+          ...right[ChangeIndex.NODE].relationships,
+          ...left[ChangeIndex.OLD_NODE].relationships,
         },
-      };
+      });
     }
   }
 
@@ -372,49 +374,39 @@ export function makeAddEmptyRelationships(
       return change;
     }
 
-    switch (change.type) {
-      case 'add':
-      case 'remove': {
-        const ret = {
-          ...change,
-          node: {
-            ...change.node,
-            relationships: {
-              ...change.node.relationships,
-            },
-          },
-        };
-
-        mergeEmpty(ret.node.relationships, Object.keys(schema.relationships));
-
-        return ret;
+    switch (change[ChangeIndex.TYPE]) {
+      case ChangeType.ADD: {
+        const relationships = {...change[ChangeIndex.NODE].relationships};
+        mergeEmpty(relationships, Object.keys(schema.relationships));
+        return makeAddChange({
+          row: change[ChangeIndex.NODE].row,
+          relationships,
+        });
       }
-      case 'edit': {
-        const ret = {
-          ...change,
-          node: {
-            ...change.node,
-            relationships: {
-              ...change.node.relationships,
-            },
-          },
-          oldNode: {
-            ...change.oldNode,
-            relationships: {
-              ...change.oldNode.relationships,
-            },
-          },
+      case ChangeType.REMOVE: {
+        const relationships = {...change[ChangeIndex.NODE].relationships};
+        mergeEmpty(relationships, Object.keys(schema.relationships));
+        return makeRemoveChange({
+          row: change[ChangeIndex.NODE].row,
+          relationships,
+        });
+      }
+      case ChangeType.EDIT: {
+        const nodeRelationships = {...change[ChangeIndex.NODE].relationships};
+        const oldNodeRelationships = {
+          ...change[ChangeIndex.OLD_NODE].relationships,
         };
-
-        mergeEmpty(ret.node.relationships, Object.keys(schema.relationships));
-        mergeEmpty(
-          ret.oldNode.relationships,
-          Object.keys(schema.relationships),
+        mergeEmpty(nodeRelationships, Object.keys(schema.relationships));
+        mergeEmpty(oldNodeRelationships, Object.keys(schema.relationships));
+        return makeEditChange(
+          {row: change[ChangeIndex.NODE].row, relationships: nodeRelationships},
+          {
+            row: change[ChangeIndex.OLD_NODE].row,
+            relationships: oldNodeRelationships,
+          },
         );
-
-        return ret;
       }
-      case 'child':
+      case ChangeType.CHILD:
         return change; // children only have relationships along the path to the change
     }
   };

--- a/packages/zql/src/ivm/skip.test.ts
+++ b/packages/zql/src/ivm/skip.test.ts
@@ -4,7 +4,11 @@ import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts'
 import {Catch} from './catch.ts';
 import type {FetchRequest} from './operator.ts';
 import {type Bound, Skip} from './skip.ts';
-import type {SourceChange} from './source.ts';
+import {
+  type SourceChange,
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+} from './source.ts';
 import {consume} from './stream.ts';
 import {createSource} from './test/source-factory.ts';
 
@@ -25,46 +29,39 @@ suite('fetch', () => {
     );
 
     consume(
-      ms.push({
-        type: 'add',
-        row: {id: 1, name: 'Aaron', startDate: '2019-06-18'},
-      }),
+      ms.push(
+        makeSourceChangeAdd({id: 1, name: 'Aaron', startDate: '2019-06-18'}),
+      ),
     );
     consume(
-      ms.push({
-        type: 'add',
-        row: {id: 2, name: 'Erik', startDate: '2020-08-01'},
-      }),
+      ms.push(
+        makeSourceChangeAdd({id: 2, name: 'Erik', startDate: '2020-08-01'}),
+      ),
     );
     consume(
-      ms.push({
-        type: 'add',
-        row: {id: 3, name: 'Greg', startDate: '2021-12-07'},
-      }),
+      ms.push(
+        makeSourceChangeAdd({id: 3, name: 'Greg', startDate: '2021-12-07'}),
+      ),
     );
     consume(
-      ms.push({
-        type: 'add',
-        row: {id: 4, name: 'Cesar', startDate: '2022-12-01'},
-      }),
+      ms.push(
+        makeSourceChangeAdd({id: 4, name: 'Cesar', startDate: '2022-12-01'}),
+      ),
     );
     consume(
-      ms.push({
-        type: 'add',
-        row: {id: 5, name: 'Alex', startDate: '2023-04-01'},
-      }),
+      ms.push(
+        makeSourceChangeAdd({id: 5, name: 'Alex', startDate: '2023-04-01'}),
+      ),
     );
     consume(
-      ms.push({
-        type: 'add',
-        row: {id: 6, name: 'Darick', startDate: '2023-09-01'},
-      }),
+      ms.push(
+        makeSourceChangeAdd({id: 6, name: 'Darick', startDate: '2023-09-01'}),
+      ),
     );
     consume(
-      ms.push({
-        type: 'add',
-        row: {id: 7, name: 'Matt', startDate: '2024-06-01'},
-      }),
+      ms.push(
+        makeSourceChangeAdd({id: 7, name: 'Matt', startDate: '2024-06-01'}),
+      ),
     );
 
     const conn = ms.connect([
@@ -926,7 +923,7 @@ suite('push', () => {
     expect(
       t({
         skipBound: {row: {id: 1, date: '2014-01-24'}, exclusive: false},
-        pushes: [{type: 'add', row: {id: 1, date: '2014-01-23'}}],
+        pushes: [makeSourceChangeAdd({id: 1, date: '2014-01-23'})],
       }),
     ).toMatchInlineSnapshot(`[]`);
   });
@@ -935,7 +932,7 @@ suite('push', () => {
     expect(
       t({
         skipBound: {row: {id: 1, date: '2014-01-24'}, exclusive: false},
-        pushes: [{type: 'add', row: {id: 2, date: '2014-01-23'}}],
+        pushes: [makeSourceChangeAdd({id: 2, date: '2014-01-23'})],
       }),
     ).toMatchInlineSnapshot(`[]`);
   });
@@ -944,7 +941,7 @@ suite('push', () => {
     expect(
       t({
         skipBound: {row: {id: 1, date: '2014-01-24'}, exclusive: false},
-        pushes: [{type: 'add', row: {id: 1, date: '2014-01-24'}}],
+        pushes: [makeSourceChangeAdd({id: 1, date: '2014-01-24'})],
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -966,7 +963,7 @@ suite('push', () => {
     expect(
       t({
         skipBound: {row: {id: 1, date: '2014-01-24'}, exclusive: false},
-        pushes: [{type: 'add', row: {id: 2, date: '2014-01-24'}}],
+        pushes: [makeSourceChangeAdd({id: 2, date: '2014-01-24'})],
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -988,7 +985,7 @@ suite('push', () => {
     expect(
       t({
         skipBound: {row: {id: 1, date: '2014-01-24'}, exclusive: false},
-        pushes: [{type: 'add', row: {id: 1, date: '2014-01-25'}}],
+        pushes: [makeSourceChangeAdd({id: 1, date: '2014-01-25'})],
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1010,7 +1007,7 @@ suite('push', () => {
     expect(
       t({
         skipBound: {row: {id: 1, date: '2014-01-24'}, exclusive: false},
-        pushes: [{type: 'add', row: {id: 2, date: '2014-01-25'}}],
+        pushes: [makeSourceChangeAdd({id: 2, date: '2014-01-25'})],
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1032,7 +1029,7 @@ suite('push', () => {
     expect(
       t({
         skipBound: {row: {id: 1, date: '2014-01-24'}, exclusive: true},
-        pushes: [{type: 'add', row: {id: 1, date: '2014-01-23'}}],
+        pushes: [makeSourceChangeAdd({id: 1, date: '2014-01-23'})],
       }),
     ).toMatchInlineSnapshot(`[]`);
   });
@@ -1041,7 +1038,7 @@ suite('push', () => {
     expect(
       t({
         skipBound: {row: {id: 1, date: '2014-01-24'}, exclusive: true},
-        pushes: [{type: 'add', row: {id: 2, date: '2014-01-23'}}],
+        pushes: [makeSourceChangeAdd({id: 2, date: '2014-01-23'})],
       }),
     ).toMatchInlineSnapshot(`[]`);
   });
@@ -1050,7 +1047,7 @@ suite('push', () => {
     expect(
       t({
         skipBound: {row: {id: 1, date: '2014-01-24'}, exclusive: true},
-        pushes: [{type: 'add', row: {id: 1, date: '2014-01-24'}}],
+        pushes: [makeSourceChangeAdd({id: 1, date: '2014-01-24'})],
       }),
     ).toMatchInlineSnapshot(`[]`);
   });
@@ -1059,7 +1056,7 @@ suite('push', () => {
     expect(
       t({
         skipBound: {row: {id: 1, date: '2014-01-24'}, exclusive: true},
-        pushes: [{type: 'add', row: {id: 2, date: '2014-01-24'}}],
+        pushes: [makeSourceChangeAdd({id: 2, date: '2014-01-24'})],
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1081,7 +1078,7 @@ suite('push', () => {
     expect(
       t({
         skipBound: {row: {id: 1, date: '2014-01-24'}, exclusive: true},
-        pushes: [{type: 'add', row: {id: 1, date: '2014-01-25'}}],
+        pushes: [makeSourceChangeAdd({id: 1, date: '2014-01-25'})],
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1103,7 +1100,7 @@ suite('push', () => {
     expect(
       t({
         skipBound: {row: {id: 1, date: '2014-01-24'}, exclusive: true},
-        pushes: [{type: 'add', row: {id: 2, date: '2014-01-25'}}],
+        pushes: [makeSourceChangeAdd({id: 2, date: '2014-01-25'})],
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1126,12 +1123,11 @@ suite('push', () => {
       t({
         skipBound: {row: {id: 1, date: '2014-01-24'}, exclusive: false},
         pushes: [
-          {type: 'add', row: {id: 1, date: '2014-01-22'}},
-          {
-            type: 'edit',
-            oldRow: {id: 1, date: '2014-01-22'},
-            row: {id: 1, date: '2014-01-23'},
-          },
+          makeSourceChangeAdd({id: 1, date: '2014-01-22'}),
+          makeSourceChangeEdit(
+            {id: 1, date: '2014-01-23'},
+            {id: 1, date: '2014-01-22'},
+          ),
         ],
       }),
     ).toMatchInlineSnapshot(`[]`);
@@ -1142,12 +1138,11 @@ suite('push', () => {
       t({
         skipBound: {row: {id: 1, date: '2014-01-24'}, exclusive: false},
         pushes: [
-          {type: 'add', row: {id: 1, date: '2014-01-24', x: 1}},
-          {
-            type: 'edit',
-            oldRow: {id: 1, date: '2014-01-24', x: 1},
-            row: {id: 1, date: '2014-01-24', x: 2},
-          },
+          makeSourceChangeAdd({id: 1, date: '2014-01-24', x: 1}),
+          makeSourceChangeEdit(
+            {id: 1, date: '2014-01-24', x: 2},
+            {id: 1, date: '2014-01-24', x: 1},
+          ),
         ],
       }),
     ).toMatchInlineSnapshot(`
@@ -1185,12 +1180,11 @@ suite('push', () => {
       t({
         skipBound: {row: {id: 1, date: '2014-01-24'}, exclusive: true},
         pushes: [
-          {type: 'add', row: {id: 1, date: '2014-01-24', x: 1}},
-          {
-            type: 'edit',
-            oldRow: {id: 1, date: '2014-01-24', x: 1},
-            row: {id: 1, date: '2014-01-24', x: 2},
-          },
+          makeSourceChangeAdd({id: 1, date: '2014-01-24', x: 1}),
+          makeSourceChangeEdit(
+            {id: 1, date: '2014-01-24', x: 2},
+            {id: 1, date: '2014-01-24', x: 1},
+          ),
         ],
       }),
     ).toMatchInlineSnapshot(`[]`);
@@ -1201,12 +1195,11 @@ suite('push', () => {
       t({
         skipBound: {row: {id: 1, date: '2014-01-24'}, exclusive: true},
         pushes: [
-          {type: 'add', row: {id: 1, date: '2014-01-25'}},
-          {
-            type: 'edit',
-            oldRow: {id: 1, date: '2014-01-25'},
-            row: {id: 1, date: '2014-01-26'},
-          },
+          makeSourceChangeAdd({id: 1, date: '2014-01-25'}),
+          makeSourceChangeEdit(
+            {id: 1, date: '2014-01-26'},
+            {id: 1, date: '2014-01-25'},
+          ),
         ],
       }),
     ).toMatchInlineSnapshot(`
@@ -1241,12 +1234,11 @@ suite('push', () => {
       t({
         skipBound: {row: {id: 1, date: '2014-01-24'}, exclusive: true},
         pushes: [
-          {type: 'add', row: {id: 1, date: '2014-01-23'}},
-          {
-            type: 'edit',
-            oldRow: {id: 1, date: '2014-01-23'},
-            row: {id: 1, date: '2014-01-25'},
-          },
+          makeSourceChangeAdd({id: 1, date: '2014-01-23'}),
+          makeSourceChangeEdit(
+            {id: 1, date: '2014-01-25'},
+            {id: 1, date: '2014-01-23'},
+          ),
         ],
       }),
     ).toMatchInlineSnapshot(`
@@ -1270,12 +1262,11 @@ suite('push', () => {
       t({
         skipBound: {row: {id: 1, date: '2014-01-24'}, exclusive: true},
         pushes: [
-          {type: 'add', row: {id: 1, date: '2014-01-25'}},
-          {
-            type: 'edit',
-            oldRow: {id: 1, date: '2014-01-25'},
-            row: {id: 1, date: '2014-01-23'},
-          },
+          makeSourceChangeAdd({id: 1, date: '2014-01-25'}),
+          makeSourceChangeEdit(
+            {id: 1, date: '2014-01-23'},
+            {id: 1, date: '2014-01-25'},
+          ),
         ],
       }),
     ).toMatchInlineSnapshot(`

--- a/packages/zql/src/ivm/skip.ts
+++ b/packages/zql/src/ivm/skip.ts
@@ -1,6 +1,13 @@
 import {assert} from '../../../shared/src/asserts.ts';
 import type {Row} from '../../../zero-protocol/src/data.ts';
-import type {AddChange, Change, ChildChange, RemoveChange} from './change.ts';
+import {ChangeIndex} from './change-index.ts';
+import {ChangeType} from './change-type.ts';
+import {
+  type AddChange,
+  type Change,
+  type ChildChange,
+  type RemoveChange,
+} from './change.ts';
 import type {Comparator, Node} from './data.ts';
 import {maybeSplitAndPushEditChange} from './maybe-split-and-push-edit-change.ts';
 import {
@@ -80,7 +87,7 @@ export class Skip implements Operator {
 
   *push(change: Change): Stream<'yield'> {
     const shouldBePresent = (row: Row) => this.#shouldBePresent(row);
-    if (change.type === 'edit') {
+    if (change[ChangeIndex.TYPE] === ChangeType.EDIT) {
       yield* maybeSplitAndPushEditChange(
         change,
         shouldBePresent,
@@ -92,7 +99,7 @@ export class Skip implements Operator {
 
     change satisfies AddChange | RemoveChange | ChildChange;
 
-    if (shouldBePresent(change.node.row)) {
+    if (shouldBePresent(change[ChangeIndex.NODE].row)) {
       yield* this.#output.push(change, this);
     }
   }

--- a/packages/zql/src/ivm/snitch.ts
+++ b/packages/zql/src/ivm/snitch.ts
@@ -1,5 +1,7 @@
 import {assert, unreachable} from '../../../shared/src/asserts.ts';
 import type {Row} from '../../../zero-protocol/src/data.ts';
+import {ChangeIndex} from './change-index.ts';
+import {ChangeType} from './change-type.ts';
 import type {Change} from './change.ts';
 import type {Node} from './data.ts';
 import type {
@@ -90,21 +92,22 @@ export class Snitch implements Operator {
 }
 
 function toChangeRecord(change: Change): ChangeRecord {
-  switch (change.type) {
-    case 'add':
-    case 'remove':
-      return {type: change.type, row: change.node.row};
-    case 'edit':
+  switch (change[ChangeIndex.TYPE]) {
+    case ChangeType.ADD:
+      return {type: 'add', row: change[ChangeIndex.NODE].row};
+    case ChangeType.REMOVE:
+      return {type: 'remove', row: change[ChangeIndex.NODE].row};
+    case ChangeType.EDIT:
       return {
-        type: change.type,
-        row: change.node.row,
-        oldRow: change.oldNode.row,
+        type: 'edit',
+        row: change[ChangeIndex.NODE].row,
+        oldRow: change[ChangeIndex.OLD_NODE].row,
       };
-    case 'child':
+    case ChangeType.CHILD:
       return {
         type: 'child',
-        row: change.node.row,
-        child: toChangeRecord(change.child.change),
+        row: change[ChangeIndex.NODE].row,
+        child: toChangeRecord(change[ChangeIndex.CHILD_DATA].change),
       };
     default:
       unreachable(change);

--- a/packages/zql/src/ivm/source-change-index-enum.ts
+++ b/packages/zql/src/ivm/source-change-index-enum.ts
@@ -1,0 +1,7 @@
+export const TYPE = 0;
+export const ROW = 1;
+export const OLD_ROW = 2;
+
+export type TYPE = typeof TYPE;
+export type ROW = typeof ROW;
+export type OLD_ROW = typeof OLD_ROW;

--- a/packages/zql/src/ivm/source-change-index.ts
+++ b/packages/zql/src/ivm/source-change-index.ts
@@ -1,0 +1,5 @@
+import type {Enum} from '../../../shared/src/enum.ts';
+import * as SourceChangeIndexEnum from './source-change-index-enum.ts';
+
+export {SourceChangeIndexEnum as SourceChangeIndex};
+export type SourceChangeIndex = Enum<typeof SourceChangeIndexEnum>;

--- a/packages/zql/src/ivm/source.test.ts
+++ b/packages/zql/src/ivm/source.test.ts
@@ -8,9 +8,16 @@ import type {
 import type {Row} from '../../../zero-protocol/src/data.ts';
 import type {SchemaValue} from '../../../zero-schema/src/table-schema.ts';
 import {Catch, expandNode, type CaughtNode} from './catch.ts';
+import {ChangeType} from './change-type.ts';
 import type {Constraint} from './constraint.ts';
 import type {FetchRequest, Input, Output, Start} from './operator.ts';
-import type {SourceChange} from './source.ts';
+import {SourceChangeIndex} from './source-change-index.ts';
+import {
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+  makeSourceChangeRemove,
+  type SourceChange,
+} from './source.ts';
 import {consume} from './stream.ts';
 import {createSource} from './test/source-factory.ts';
 
@@ -25,9 +32,14 @@ function asNodes(rows: Row[]) {
 
 function asChanges(sc: SourceChange[]) {
   return sc.map(c => ({
-    type: c.type,
+    type:
+      c[SourceChangeIndex.TYPE] === ChangeType.ADD
+        ? 'add'
+        : c[SourceChangeIndex.TYPE] === ChangeType.REMOVE
+          ? 'remove'
+          : 'edit',
     node: {
-      row: c.row,
+      row: c[SourceChangeIndex.ROW],
       relationships: {},
     },
   }));
@@ -62,18 +74,18 @@ test('simple-fetch', () => {
   const out = new Catch(s.connect(sort));
   expect(out.fetch()).toEqual([]);
 
-  consume(s.push({type: 'add', row: {a: 3}}));
+  consume(s.push(makeSourceChangeAdd({a: 3})));
   expect(out.fetch()).toEqual(asNodes([{a: 3}]));
 
-  consume(s.push({type: 'add', row: {a: 1}}));
-  consume(s.push({type: 'add', row: {a: 2}}));
+  consume(s.push(makeSourceChangeAdd({a: 1})));
+  consume(s.push(makeSourceChangeAdd({a: 2})));
   expect(out.fetch()).toEqual(asNodes([{a: 1}, {a: 2}, {a: 3}]));
 
-  consume(s.push({type: 'remove', row: {a: 1}}));
+  consume(s.push(makeSourceChangeRemove({a: 1})));
   expect(out.fetch()).toEqual(asNodes([{a: 2}, {a: 3}]));
 
-  consume(s.push({type: 'remove', row: {a: 2}}));
-  consume(s.push({type: 'remove', row: {a: 3}}));
+  consume(s.push(makeSourceChangeRemove({a: 2})));
+  consume(s.push(makeSourceChangeRemove({a: 3})));
   expect(out.fetch()).toEqual([]);
 });
 
@@ -116,9 +128,9 @@ test('fetch-with-constraint', () => {
     ['a'],
   );
   const out = new Catch(s.connect(sort));
-  consume(s.push({type: 'add', row: {a: 3, b: true, c: 1, d: null}}));
-  consume(s.push({type: 'add', row: {a: 1, b: true, c: 2, d: null}}));
-  consume(s.push({type: 'add', row: {a: 2, b: false, c: null, d: null}}));
+  consume(s.push(makeSourceChangeAdd({a: 3, b: true, c: 1, d: null})));
+  consume(s.push(makeSourceChangeAdd({a: 1, b: true, c: 2, d: null})));
+  consume(s.push(makeSourceChangeAdd({a: 2, b: false, c: null, d: null})));
 
   expect(out.fetch({constraint: {b: true}})).toEqual(
     asNodes([
@@ -177,8 +189,8 @@ test('fetch-start', () => {
     asNodes([]),
   );
 
-  consume(s.push({type: 'add', row: {a: 2}}));
-  consume(s.push({type: 'add', row: {a: 3}}));
+  consume(s.push(makeSourceChangeAdd({a: 2})));
+  consume(s.push(makeSourceChangeAdd({a: 3})));
   expect(out.fetch({start: {row: {a: 2}, basis: 'at'}})).toEqual(
     asNodes([{a: 2}, {a: 3}]),
   );
@@ -193,7 +205,7 @@ test('fetch-start', () => {
     asNodes([]),
   );
 
-  consume(s.push({type: 'remove', row: {a: 3}}));
+  consume(s.push(makeSourceChangeRemove({a: 3})));
   expect(out.fetch({start: {row: {a: 2}, basis: 'at'}})).toEqual(
     asNodes([{a: 2}]),
   );
@@ -222,8 +234,8 @@ test('fetch-start reverse', () => {
     out.fetch({start: {row: {a: 2}, basis: 'after'}, reverse: true}),
   ).toEqual(asNodes([]));
 
-  consume(s.push({type: 'add', row: {a: 2}}));
-  consume(s.push({type: 'add', row: {a: 3}}));
+  consume(s.push(makeSourceChangeAdd({a: 2})));
+  consume(s.push(makeSourceChangeAdd({a: 3})));
   expect(out.fetch({start: {row: {a: 2}, basis: 'at'}, reverse: true})).toEqual(
     asNodes([{a: 2}]),
   );
@@ -238,7 +250,7 @@ test('fetch-start reverse', () => {
     out.fetch({start: {row: {a: 3}, basis: 'after'}, reverse: true}),
   ).toEqual(asNodes([{a: 2}]));
 
-  consume(s.push({type: 'remove', row: {a: 3}}));
+  consume(s.push(makeSourceChangeRemove({a: 3})));
   expect(out.fetch({start: {row: {a: 2}, basis: 'at'}, reverse: true})).toEqual(
     asNodes([{a: 2}]),
   );
@@ -267,7 +279,7 @@ suite('fetch-with-constraint-and-start', () => {
       ['a'],
     );
     for (const row of c.startData) {
-      consume(s.push({type: 'add', row}));
+      consume(s.push(makeSourceChangeAdd(row)));
     }
     const out = new Catch(s.connect(sort));
     return out.fetch({
@@ -596,42 +608,39 @@ test('push', () => {
 
   expect(out.pushes).toEqual([]);
 
-  consume(s.push({type: 'add', row: {a: 2}}));
-  expect(out.pushes).toEqual(asChanges([{type: 'add', row: {a: 2}}]));
+  consume(s.push(makeSourceChangeAdd({a: 2})));
+  expect(out.pushes).toEqual(asChanges([makeSourceChangeAdd({a: 2})]));
 
-  consume(s.push({type: 'add', row: {a: 1}}));
+  consume(s.push(makeSourceChangeAdd({a: 1})));
   expect(out.pushes).toEqual(
-    asChanges([
-      {type: 'add', row: {a: 2}},
-      {type: 'add', row: {a: 1}},
-    ]),
+    asChanges([makeSourceChangeAdd({a: 2}), makeSourceChangeAdd({a: 1})]),
   );
 
-  consume(s.push({type: 'remove', row: {a: 1}}));
-  consume(s.push({type: 'remove', row: {a: 2}}));
+  consume(s.push(makeSourceChangeRemove({a: 1})));
+  consume(s.push(makeSourceChangeRemove({a: 2})));
   expect(out.pushes).toEqual(
     asChanges([
-      {type: 'add', row: {a: 2}},
-      {type: 'add', row: {a: 1}},
-      {type: 'remove', row: {a: 1}},
-      {type: 'remove', row: {a: 2}},
+      makeSourceChangeAdd({a: 2}),
+      makeSourceChangeAdd({a: 1}),
+      makeSourceChangeRemove({a: 1}),
+      makeSourceChangeRemove({a: 2}),
     ]),
   );
 
   // Remove row that isn't there
   out.reset();
-  expect(() => consume(s.push({type: 'remove', row: {a: 1}}))).toThrow(
+  expect(() => consume(s.push(makeSourceChangeRemove({a: 1})))).toThrow(
     'Row not found',
   );
   expect(out.pushes).toEqual(asChanges([]));
 
   // Add row twice
-  consume(s.push({type: 'add', row: {a: 1}}));
-  expect(out.pushes).toEqual(asChanges([{type: 'add', row: {a: 1}}]));
-  expect(() => consume(s.push({type: 'add', row: {a: 1}}))).toThrow(
+  consume(s.push(makeSourceChangeAdd({a: 1})));
+  expect(out.pushes).toEqual(asChanges([makeSourceChangeAdd({a: 1})]));
+  expect(() => consume(s.push(makeSourceChangeAdd({a: 1})))).toThrow(
     'Row already exists',
   );
-  expect(out.pushes).toEqual(asChanges([{type: 'add', row: {a: 1}}]));
+  expect(out.pushes).toEqual(asChanges([makeSourceChangeAdd({a: 1})]));
 });
 
 test('overlay-source-isolation', () => {
@@ -661,7 +670,7 @@ test('overlay-source-isolation', () => {
   o2.onPush = fetchAll;
   o3.onPush = fetchAll;
 
-  consume(s.push({type: 'add', row: {a: 2}}));
+  consume(s.push(makeSourceChangeAdd({a: 2})));
   expect(o1.fetches).toEqual([
     asNodes([{a: 2}]),
     asNodes([{a: 2}]),
@@ -708,17 +717,15 @@ test('overlay-source-isolation with split edit', () => {
   o2.onPush = fetchAll;
   o3.onPush = fetchAll;
 
-  consume(s.push({type: 'add', row: {a: 2, b: 'foo', c: 1}}));
-  consume(s.push({type: 'add', row: {a: 3, b: 'bar', c: 1}}));
+  consume(s.push(makeSourceChangeAdd({a: 2, b: 'foo', c: 1})));
+  consume(s.push(makeSourceChangeAdd({a: 3, b: 'bar', c: 1})));
 
   clearAll();
 
   consume(
-    s.push({
-      type: 'edit',
-      oldRow: {a: 2, b: 'foo', c: 1},
-      row: {a: 2, b: 'foo2', c: 1},
-    }),
+    s.push(
+      makeSourceChangeEdit({a: 2, b: 'foo2', c: 1}, {a: 2, b: 'foo', c: 1}),
+    ),
   );
 
   // o2 needs edit split, edit is split for all connections,
@@ -997,11 +1004,9 @@ test('overlay-source-isolation with split edit', () => {
   clearAll();
 
   consume(
-    s.push({
-      type: 'edit',
-      oldRow: {a: 3, b: 'bar', c: 1},
-      row: {a: 3, b: 'bar', c: 2},
-    }),
+    s.push(
+      makeSourceChangeEdit({a: 3, b: 'bar', c: 2}, {a: 3, b: 'bar', c: 1}),
+    ),
   );
 
   // o2 and o3 need edit split, edit is split for all connections,
@@ -1288,7 +1293,7 @@ suite('overlay-vs-fetch-start', () => {
       'a',
     ]);
     for (const row of c.startData) {
-      consume(s.push({type: 'add', row}));
+      consume(s.push(makeSourceChangeAdd(row)));
     }
     const out = new OverlaySpy(s.connect(sort));
     out.onPush = () =>
@@ -1314,7 +1319,7 @@ suite('overlay-vs-fetch-start', () => {
           row: {a: 2},
           basis: 'at',
         },
-        change: {type: 'add', row: {a: 1}},
+        change: makeSourceChangeAdd({a: 1}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1345,7 +1350,7 @@ suite('overlay-vs-fetch-start', () => {
           basis: 'at',
         },
         reverse: true,
-        change: {type: 'add', row: {a: 1}},
+        change: makeSourceChangeAdd({a: 1}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1375,7 +1380,7 @@ suite('overlay-vs-fetch-start', () => {
           row: {a: 2},
           basis: 'at',
         },
-        change: {type: 'add', row: {a: 3}},
+        change: makeSourceChangeAdd({a: 3}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1412,7 +1417,7 @@ suite('overlay-vs-fetch-start', () => {
           basis: 'at',
         },
         reverse: true,
-        change: {type: 'add', row: {a: 3}},
+        change: makeSourceChangeAdd({a: 3}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1436,7 +1441,7 @@ suite('overlay-vs-fetch-start', () => {
           row: {a: 2},
           basis: 'at',
         },
-        change: {type: 'add', row: {a: 5}},
+        change: makeSourceChangeAdd({a: 5}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1473,7 +1478,7 @@ suite('overlay-vs-fetch-start', () => {
           basis: 'at',
         },
         reverse: true,
-        change: {type: 'add', row: {a: 5}},
+        change: makeSourceChangeAdd({a: 5}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1497,7 +1502,7 @@ suite('overlay-vs-fetch-start', () => {
           row: {a: 2},
           basis: 'after',
         },
-        change: {type: 'add', row: {a: 1}},
+        change: makeSourceChangeAdd({a: 1}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1522,7 +1527,7 @@ suite('overlay-vs-fetch-start', () => {
           basis: 'after',
         },
         reverse: true,
-        change: {type: 'add', row: {a: 1}},
+        change: makeSourceChangeAdd({a: 1}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1546,7 +1551,7 @@ suite('overlay-vs-fetch-start', () => {
           row: {a: 2},
           basis: 'after',
         },
-        change: {type: 'add', row: {a: 3}},
+        change: makeSourceChangeAdd({a: 3}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1577,7 +1582,7 @@ suite('overlay-vs-fetch-start', () => {
           basis: 'after',
         },
         reverse: true,
-        change: {type: 'add', row: {a: 3}},
+        change: makeSourceChangeAdd({a: 3}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1594,7 +1599,7 @@ suite('overlay-vs-fetch-start', () => {
           row: {a: 2},
           basis: 'after',
         },
-        change: {type: 'add', row: {a: 5}},
+        change: makeSourceChangeAdd({a: 5}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1625,7 +1630,7 @@ suite('overlay-vs-fetch-start', () => {
           basis: 'after',
         },
         reverse: true,
-        change: {type: 'add', row: {a: 5}},
+        change: makeSourceChangeAdd({a: 5}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1642,7 +1647,7 @@ suite('overlay-vs-fetch-start', () => {
           row: {a: 4},
           basis: 'after',
         },
-        change: {type: 'add', row: {a: 3}},
+        change: makeSourceChangeAdd({a: 3}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1660,7 +1665,7 @@ suite('overlay-vs-fetch-start', () => {
           basis: 'after',
         },
         reverse: true,
-        change: {type: 'add', row: {a: 3}},
+        change: makeSourceChangeAdd({a: 3}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1690,7 +1695,7 @@ suite('overlay-vs-fetch-start', () => {
           row: {a: 4},
           basis: 'after',
         },
-        change: {type: 'add', row: {a: 5}},
+        change: makeSourceChangeAdd({a: 5}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1715,7 +1720,7 @@ suite('overlay-vs-fetch-start', () => {
           basis: 'after',
         },
         reverse: true,
-        change: {type: 'add', row: {a: 5}},
+        change: makeSourceChangeAdd({a: 5}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1739,7 +1744,7 @@ suite('overlay-vs-fetch-start', () => {
           row: {a: 2},
           basis: 'at',
         },
-        change: {type: 'remove', row: {a: 2}},
+        change: makeSourceChangeRemove({a: 2}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1764,7 +1769,7 @@ suite('overlay-vs-fetch-start', () => {
           basis: 'at',
         },
         reverse: true,
-        change: {type: 'remove', row: {a: 2}},
+        change: makeSourceChangeRemove({a: 2}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1781,7 +1786,7 @@ suite('overlay-vs-fetch-start', () => {
           row: {a: 2},
           basis: 'at',
         },
-        change: {type: 'remove', row: {a: 4}},
+        change: makeSourceChangeRemove({a: 4}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1806,7 +1811,7 @@ suite('overlay-vs-fetch-start', () => {
           basis: 'at',
         },
         reverse: true,
-        change: {type: 'remove', row: {a: 4}},
+        change: makeSourceChangeRemove({a: 4}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1830,7 +1835,7 @@ suite('overlay-vs-fetch-start', () => {
           row: {a: 4},
           basis: 'at',
         },
-        change: {type: 'remove', row: {a: 2}},
+        change: makeSourceChangeRemove({a: 2}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1855,7 +1860,7 @@ suite('overlay-vs-fetch-start', () => {
           basis: 'at',
         },
         reverse: true,
-        change: {type: 'remove', row: {a: 2}},
+        change: makeSourceChangeRemove({a: 2}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1879,7 +1884,7 @@ suite('overlay-vs-fetch-start', () => {
           row: {a: 4},
           basis: 'at',
         },
-        change: {type: 'remove', row: {a: 4}},
+        change: makeSourceChangeRemove({a: 4}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1897,7 +1902,7 @@ suite('overlay-vs-fetch-start', () => {
           basis: 'at',
         },
         reverse: true,
-        change: {type: 'remove', row: {a: 4}},
+        change: makeSourceChangeRemove({a: 4}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1921,7 +1926,7 @@ suite('overlay-vs-fetch-start', () => {
           row: {a: 2},
           basis: 'after',
         },
-        change: {type: 'remove', row: {a: 2}},
+        change: makeSourceChangeRemove({a: 2}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1946,7 +1951,7 @@ suite('overlay-vs-fetch-start', () => {
           basis: 'after',
         },
         reverse: true,
-        change: {type: 'remove', row: {a: 2}},
+        change: makeSourceChangeRemove({a: 2}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1963,7 +1968,7 @@ suite('overlay-vs-fetch-start', () => {
           row: {a: 2},
           basis: 'after',
         },
-        change: {type: 'remove', row: {a: 4}},
+        change: makeSourceChangeRemove({a: 4}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1980,7 +1985,7 @@ suite('overlay-vs-fetch-start', () => {
           row: {a: 4},
           basis: 'after',
         },
-        change: {type: 'remove', row: {a: 2}},
+        change: makeSourceChangeRemove({a: 2}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -1997,7 +2002,7 @@ suite('overlay-vs-fetch-start', () => {
           row: {a: 4},
           basis: 'after',
         },
-        change: {type: 'remove', row: {a: 2}},
+        change: makeSourceChangeRemove({a: 2}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -2014,7 +2019,7 @@ suite('overlay-vs-fetch-start', () => {
           row: {a: 4},
           basis: 'after',
         },
-        change: {type: 'remove', row: {a: 4}},
+        change: makeSourceChangeRemove({a: 4}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -2032,7 +2037,7 @@ suite('overlay-vs-fetch-start', () => {
           basis: 'after',
         },
         reverse: true,
-        change: {type: 'remove', row: {a: 4}},
+        change: makeSourceChangeRemove({a: 4}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -2067,7 +2072,7 @@ suite('overlay-vs-constraint', () => {
       ['a'],
     );
     for (const row of c.startData) {
-      consume(s.push({type: 'add', row}));
+      consume(s.push(makeSourceChangeAdd(row)));
     }
     const out = new OverlaySpy(s.connect(sort));
     out.onPush = () =>
@@ -2092,7 +2097,7 @@ suite('overlay-vs-constraint', () => {
           {a: 4, b: true},
         ],
         constraint: {b: true},
-        change: {type: 'add', row: {a: 1, b: true}},
+        change: makeSourceChangeAdd({a: 1, b: true}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -2124,7 +2129,7 @@ suite('overlay-vs-constraint', () => {
           {a: 4, b: true},
         ],
         constraint: {b: true},
-        change: {type: 'add', row: {a: 1, b: false}},
+        change: makeSourceChangeAdd({a: 1, b: false}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -2150,7 +2155,7 @@ suite('overlay-vs-constraint', () => {
           {a: 5, b: true},
         ],
         constraint: {b: true},
-        change: {type: 'edit', oldRow: {a: 4, b: true}, row: {a: 4, b: false}},
+        change: makeSourceChangeEdit({a: 4, b: false}, {a: 4, b: true}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -2176,7 +2181,7 @@ suite('overlay-vs-constraint', () => {
           {a: 5, b: true},
         ],
         constraint: {b: false},
-        change: {type: 'edit', oldRow: {a: 4, b: true}, row: {a: 4, b: false}},
+        change: makeSourceChangeEdit({a: 4, b: false}, {a: 4, b: true}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -2209,7 +2214,7 @@ suite('overlay-vs-constraint', () => {
           {a: 5, b: true},
         ],
         constraint: {a: 4, b: false},
-        change: {type: 'edit', oldRow: {a: 4, b: true}, row: {a: 4, b: false}},
+        change: makeSourceChangeEdit({a: 4, b: false}, {a: 4, b: true}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -2244,7 +2249,7 @@ suite('overlay-vs-filter', () => {
       ['a', 'b'],
     );
     for (const row of c.startData) {
-      consume(s.push({type: 'add', row}));
+      consume(s.push(makeSourceChangeAdd(row)));
     }
     const sourceInput = s.connect(sort, c.filter);
     const out = new OverlaySpy(sourceInput);
@@ -2276,7 +2281,7 @@ suite('overlay-vs-filter', () => {
           left: {type: 'column', name: 'b'},
           right: {type: 'literal', value: true},
         },
-        change: {type: 'add', row: {a: 1, b: true}},
+        change: makeSourceChangeAdd({a: 1, b: true}),
       }),
     ).toMatchInlineSnapshot(`
       {
@@ -2316,7 +2321,7 @@ suite('overlay-vs-filter', () => {
           left: {type: 'column', name: 'b'},
           right: {type: 'literal', value: true},
         },
-        change: {type: 'add', row: {a: 1, b: false}},
+        change: makeSourceChangeAdd({a: 1, b: false}),
       }),
     ).toMatchInlineSnapshot(`
       {
@@ -2340,7 +2345,7 @@ suite('overlay-vs-filter', () => {
           left: {type: 'column', name: 'b'},
           right: {type: 'literal', value: true},
         },
-        change: {type: 'edit', oldRow: {a: 4, b: true}, row: {a: 4, b: false}},
+        change: makeSourceChangeEdit({a: 4, b: false}, {a: 4, b: true}),
       }),
     ).toMatchInlineSnapshot(`
       {
@@ -2374,7 +2379,7 @@ suite('overlay-vs-filter', () => {
           left: {type: 'column', name: 'b'},
           right: {type: 'literal', value: false},
         },
-        change: {type: 'edit', oldRow: {a: 4, b: true}, row: {a: 4, b: false}},
+        change: makeSourceChangeEdit({a: 4, b: false}, {a: 4, b: true}),
       }),
     ).toMatchInlineSnapshot(`
       {
@@ -2425,7 +2430,7 @@ suite('overlay-vs-filter', () => {
             },
           ],
         },
-        change: {type: 'add', row: {a: 1, b: false}},
+        change: makeSourceChangeAdd({a: 1, b: false}),
       }),
     ).toMatchInlineSnapshot(`
       {
@@ -2483,7 +2488,7 @@ suite('overlay-vs-filter', () => {
             },
           ],
         },
-        change: {type: 'add', row: {a: 1, b: false}},
+        change: makeSourceChangeAdd({a: 1, b: false}),
       }),
     ).toMatchInlineSnapshot(`
       {
@@ -2550,7 +2555,7 @@ suite('overlay-vs-filter', () => {
             },
           ],
         },
-        change: {type: 'add', row: {a: 1, b: false}},
+        change: makeSourceChangeAdd({a: 1, b: false}),
       }),
     ).toMatchInlineSnapshot(`
       {
@@ -2618,7 +2623,7 @@ suite('overlay-vs-filter', () => {
             },
           ],
         },
-        change: {type: 'add', row: {a: 4, b: false}},
+        change: makeSourceChangeAdd({a: 4, b: false}),
       }),
     ).toMatchInlineSnapshot(`
       {
@@ -2667,7 +2672,7 @@ suite('overlay-vs-constraint-and-start', () => {
       ['a'],
     );
     for (const row of c.startData) {
-      consume(s.push({type: 'add', row}));
+      consume(s.push(makeSourceChangeAdd(row)));
     }
     const out = new OverlaySpy(s.connect(sort));
     out.onPush = () =>
@@ -2700,7 +2705,7 @@ suite('overlay-vs-constraint-and-start', () => {
           basis: 'at',
         },
         constraint: {b: false},
-        change: {type: 'add', row: {a: 5.75, b: false}},
+        change: makeSourceChangeAdd({a: 5.75, b: false}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -2747,7 +2752,7 @@ suite('overlay-vs-constraint-and-start', () => {
         },
         reverse: true,
         constraint: {b: false},
-        change: {type: 'add', row: {a: 5.75, b: false}},
+        change: makeSourceChangeAdd({a: 5.75, b: false}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -2793,7 +2798,7 @@ suite('overlay-vs-constraint-and-start', () => {
           basis: 'at',
         },
         constraint: {b: false},
-        change: {type: 'add', row: {a: 4, b: false}},
+        change: makeSourceChangeAdd({a: 4, b: false}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -2833,7 +2838,7 @@ suite('overlay-vs-constraint-and-start', () => {
         },
         reverse: true,
         constraint: {b: false},
-        change: {type: 'add', row: {a: 4, b: false}},
+        change: makeSourceChangeAdd({a: 4, b: false}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -2872,7 +2877,7 @@ suite('overlay-vs-constraint-and-start', () => {
           basis: 'at',
         },
         constraint: {b: false},
-        change: {type: 'add', row: {a: 8, b: false}},
+        change: makeSourceChangeAdd({a: 8, b: false}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -2919,7 +2924,7 @@ suite('overlay-vs-constraint-and-start', () => {
         },
         reverse: true,
         constraint: {b: false},
-        change: {type: 'add', row: {a: 8, b: false}},
+        change: makeSourceChangeAdd({a: 8, b: false}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -2965,7 +2970,7 @@ suite('overlay-vs-constraint-and-start', () => {
           basis: 'after',
         },
         constraint: {b: false},
-        change: {type: 'add', row: {a: 6.5, b: false}},
+        change: makeSourceChangeAdd({a: 6.5, b: false}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -3012,7 +3017,7 @@ suite('overlay-vs-constraint-and-start', () => {
         },
         reverse: true,
         constraint: {b: false},
-        change: {type: 'add', row: {a: 6.5, b: false}},
+        change: makeSourceChangeAdd({a: 6.5, b: false}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -3063,7 +3068,7 @@ suite('overlay-vs-constraint-and-start', () => {
           basis: 'at',
         },
         constraint: {b: true, c: 1},
-        change: {type: 'add', row: {a: 5.5, b: true, c: 1}},
+        change: makeSourceChangeAdd({a: 5.5, b: true, c: 1}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -3110,7 +3115,7 @@ suite('overlay-vs-constraint-and-start', () => {
         },
         reverse: true,
         constraint: {b: true, c: 1},
-        change: {type: 'add', row: {a: 5.5, b: true, c: 1}},
+        change: makeSourceChangeAdd({a: 5.5, b: true, c: 1}),
       }),
     ).toMatchInlineSnapshot(`
       [
@@ -3156,9 +3161,9 @@ test('per-output-sorts', () => {
   const out1 = new Catch(s.connect(sort1));
   const out2 = new Catch(s.connect(sort2));
 
-  consume(s.push({type: 'add', row: {a: 2, b: 3}}));
-  consume(s.push({type: 'add', row: {a: 1, b: 2}}));
-  consume(s.push({type: 'add', row: {a: 3, b: 1}}));
+  consume(s.push(makeSourceChangeAdd({a: 2, b: 3})));
+  consume(s.push(makeSourceChangeAdd({a: 1, b: 2})));
+  consume(s.push(makeSourceChangeAdd({a: 3, b: 1})));
 
   expect(out1.fetch({})).toEqual(
     asNodes([
@@ -3188,9 +3193,9 @@ test('streams-are-one-time-only', () => {
     {a: {type: 'number'}},
     ['a'],
   );
-  consume(source.push({type: 'add', row: {a: 1}}));
-  consume(source.push({type: 'add', row: {a: 2}}));
-  consume(source.push({type: 'add', row: {a: 3}}));
+  consume(source.push(makeSourceChangeAdd({a: 1})));
+  consume(source.push(makeSourceChangeAdd({a: 2})));
+  consume(source.push(makeSourceChangeAdd({a: 3})));
 
   const conn = source.connect([['a', 'asc']]);
   const stream = conn.fetch({});
@@ -3224,9 +3229,9 @@ test('json is a valid type to read and write to/from a source', () => {
     ['a'],
   );
 
-  consume(source.push({type: 'add', row: {a: 1, j: {foo: 'bar'}}}));
-  consume(source.push({type: 'add', row: {a: 2, j: {baz: 'qux'}}}));
-  consume(source.push({type: 'add', row: {a: 3, j: {foo: 'foo'}}}));
+  consume(source.push(makeSourceChangeAdd({a: 1, j: {foo: 'bar'}})));
+  consume(source.push(makeSourceChangeAdd({a: 2, j: {baz: 'qux'}})));
+  consume(source.push(makeSourceChangeAdd({a: 3, j: {foo: 'foo'}})));
 
   const out = new Catch(source.connect([['a', 'asc']]));
   expect(out.fetch({})).toEqual(
@@ -3237,9 +3242,9 @@ test('json is a valid type to read and write to/from a source', () => {
     ]),
   );
 
-  consume(source.push({type: 'add', row: {a: 4, j: {foo: 'foo'}}}));
-  consume(source.push({type: 'add', row: {a: 5, j: {baz: 'qux'}}}));
-  consume(source.push({type: 'add', row: {a: 6, j: {foo: 'bar'}}}));
+  consume(source.push(makeSourceChangeAdd({a: 4, j: {foo: 'foo'}})));
+  consume(source.push(makeSourceChangeAdd({a: 5, j: {baz: 'qux'}})));
+  consume(source.push(makeSourceChangeAdd({a: 6, j: {foo: 'bar'}})));
   expect(out.pushes).toEqual([
     {
       type: 'add',
@@ -3258,13 +3263,11 @@ test('json is a valid type to read and write to/from a source', () => {
   // check edit and remove too
   out.reset();
   consume(
-    source.push({
-      type: 'edit',
-      oldRow: {a: 5, j: {baz: 'qux'}},
-      row: {a: 5, j: {baz: 'qux2'}},
-    }),
+    source.push(
+      makeSourceChangeEdit({a: 5, j: {baz: 'qux2'}}, {a: 5, j: {baz: 'qux'}}),
+    ),
   );
-  consume(source.push({type: 'remove', row: {a: 5, j: {baz: 'qux'}}}));
+  consume(source.push(makeSourceChangeRemove({a: 5, j: {baz: 'qux'}})));
   expect(out.pushes).toMatchInlineSnapshot(`
     [
       {
@@ -3359,9 +3362,9 @@ test('IS and IS NOT comparisons against null', () => {
     ['a'],
   );
 
-  consume(source.push({type: 'add', row: {a: 1, s: 'foo'}}));
-  consume(source.push({type: 'add', row: {a: 2, s: 'bar'}}));
-  consume(source.push({type: 'add', row: {a: 3, s: null}}));
+  consume(source.push(makeSourceChangeAdd({a: 1, s: 'foo'})));
+  consume(source.push(makeSourceChangeAdd({a: 2, s: 'bar'})));
+  consume(source.push(makeSourceChangeAdd({a: 3, s: null})));
 
   let out = new Catch(
     source.connect([['a', 'asc']], {
@@ -3468,8 +3471,8 @@ test('constant/literal expression', () => {
     ['n'],
   );
 
-  consume(source.push({type: 'add', row: {n: 1, b: true, s: 'foo'}}));
-  consume(source.push({type: 'add', row: {n: 2, b: false, s: 'bar'}}));
+  consume(source.push(makeSourceChangeAdd({n: 1, b: true, s: 'foo'})));
+  consume(source.push(makeSourceChangeAdd({n: 2, b: false, s: 'bar'})));
   const allData = asNodes([
     {n: 1, b: true, s: 'foo'},
     {n: 2, b: false, s: 'bar'},
@@ -3547,7 +3550,7 @@ suite('epoch-based overlay semantic equivalence', () => {
     });
 
     // Push an add - this will trigger 4 push phases (one per connection)
-    consume(s.push({type: 'add', row: {a: 1}}));
+    consume(s.push(makeSourceChangeAdd({a: 1})));
 
     // Verify the invariant: connection sees overlay iff its index <= current push target
     // Phase 0: pushing to conn[0], only conn[0] should see overlay
@@ -3574,7 +3577,7 @@ suite('epoch-based overlay semantic equivalence', () => {
     );
 
     // Add initial data
-    consume(s.push({type: 'add', row: {a: 1, b: 'old'}}));
+    consume(s.push(makeSourceChangeAdd({a: 1, b: 'old'})));
 
     // Create 3 connections - middle one has splitEditKeys on 'b'
     const spies = [
@@ -3600,9 +3603,7 @@ suite('epoch-based overlay semantic equivalence', () => {
     });
 
     // Push an edit that will be split into remove + add
-    consume(
-      s.push({type: 'edit', oldRow: {a: 1, b: 'old'}, row: {a: 1, b: 'new'}}),
-    );
+    consume(s.push(makeSourceChangeEdit({a: 1, b: 'new'}, {a: 1, b: 'old'})));
 
     // Split edit creates 6 push phases: 3 for remove, 3 for add
     expect(observations[0].length).toBe(6);

--- a/packages/zql/src/ivm/source.ts
+++ b/packages/zql/src/ivm/source.ts
@@ -2,31 +2,34 @@ import type {Condition, Ordering} from '../../../zero-protocol/src/ast.ts';
 import type {Row} from '../../../zero-protocol/src/data.ts';
 import type {TableSchema} from '../../../zero-types/src/schema.ts';
 import type {DebugDelegate} from '../builder/debug-delegate.ts';
+import {ChangeType} from './change-type.ts';
 import type {Input} from './operator.ts';
 import type {Stream} from './stream.ts';
 
-// TODO(arv): Make this a 3 tuple as well.
-
-export type SourceChangeAdd = {
-  type: 'add';
-  row: Row;
-};
-
-export type SourceChangeRemove = {
-  type: 'remove';
-  row: Row;
-};
-
-export type SourceChangeEdit = {
-  type: 'edit';
-  row: Row;
-  oldRow: Row;
-};
+export type SourceChangeAdd = [type: ChangeType.ADD, row: Row, extra: null];
+export type SourceChangeRemove = [
+  type: ChangeType.REMOVE,
+  row: Row,
+  extra: null,
+];
+export type SourceChangeEdit = [type: ChangeType.EDIT, row: Row, oldRow: Row];
 
 export type SourceChange =
   | SourceChangeAdd
   | SourceChangeRemove
   | SourceChangeEdit;
+
+export function makeSourceChangeAdd(row: Row): SourceChangeAdd {
+  return [ChangeType.ADD, row, null];
+}
+
+export function makeSourceChangeRemove(row: Row): SourceChangeRemove {
+  return [ChangeType.REMOVE, row, null];
+}
+
+export function makeSourceChangeEdit(row: Row, oldRow: Row): SourceChangeEdit {
+  return [ChangeType.EDIT, row, oldRow];
+}
 
 /**
  * A source is an input that serves as the root data source of the pipeline.

--- a/packages/zql/src/ivm/source.ts
+++ b/packages/zql/src/ivm/source.ts
@@ -5,6 +5,8 @@ import type {DebugDelegate} from '../builder/debug-delegate.ts';
 import type {Input} from './operator.ts';
 import type {Stream} from './stream.ts';
 
+// TODO(arv): Make this a 3 tuple as well.
+
 export type SourceChangeAdd = {
   type: 'add';
   row: Row;

--- a/packages/zql/src/ivm/take.fetch.test.ts
+++ b/packages/zql/src/ivm/take.fetch.test.ts
@@ -17,6 +17,7 @@ import {consume} from './stream.ts';
 import {Take, type PartitionKey} from './take.ts';
 import {createSource} from './test/source-factory.ts';
 
+import {makeSourceChangeAdd} from './source.ts';
 const lc = createSilentLogContext();
 
 suite('take with no partition', () => {
@@ -414,7 +415,7 @@ test('early return during hydrate', () => {
     {id: 'i3', created: 300},
   ];
   for (const row of sourceRows) {
-    consume(source.push({type: 'add', row}));
+    consume(source.push(makeSourceChangeAdd(row)));
   }
   const snitch = new Snitch(source.connect([['id', 'asc']]), 'takeSnitch', log);
   const storage = new MemoryStorage();
@@ -1413,7 +1414,7 @@ function takeTest(t: TakeTest): TakeTestResults {
     t.primaryKey,
   );
   for (const row of t.sourceRows) {
-    consume(source.push({type: 'add', row}));
+    consume(source.push(makeSourceChangeAdd(row)));
   }
   const snitch = new Snitch(
     source.connect(t.sort || [['id', 'asc']]),

--- a/packages/zql/src/ivm/take.push-child.test.ts
+++ b/packages/zql/src/ivm/take.push-child.test.ts
@@ -7,6 +7,7 @@ import {
 } from './test/fetch-and-push-tests.ts';
 import type {Format} from './view.ts';
 
+import {makeSourceChangeAdd} from './source.ts';
 const sources: Sources = {
   issue: {
     columns: {
@@ -85,10 +86,7 @@ test('child change, parent is within bound', () => {
     pushes: [
       [
         'comment',
-        {
-          type: 'add',
-          row: {id: 'c3', issueID: 'i2', text: 'i2 c3 text'},
-        },
+        makeSourceChangeAdd({id: 'c3', issueID: 'i2', text: 'i2 c3 text'}),
       ],
     ],
     format,
@@ -196,10 +194,7 @@ test('child change, parent is after bound', () => {
     pushes: [
       [
         'comment',
-        {
-          type: 'add',
-          row: {id: 'c3', issueID: 'i3', text: 'i3 c3 text'},
-        },
+        makeSourceChangeAdd({id: 'c3', issueID: 'i3', text: 'i3 c3 text'}),
       ],
     ],
     format,

--- a/packages/zql/src/ivm/take.push.test.ts
+++ b/packages/zql/src/ivm/take.push.test.ts
@@ -1,7 +1,12 @@
 import {describe, expect, test} from 'vitest';
 import type {AST} from '../../../zero-protocol/src/ast.ts';
 import type {Row} from '../../../zero-protocol/src/data.ts';
-import type {SourceChange} from './source.ts';
+import {
+  type SourceChange,
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+  makeSourceChangeRemove,
+} from './source.ts';
 import {runPushTest, type Sources} from './test/fetch-and-push-tests.ts';
 
 describe('take with no partition', () => {
@@ -14,7 +19,7 @@ describe('take with no partition', () => {
           {id: 'i3', created: 300, text: null},
         ],
         limit: 0,
-        pushes: [{type: 'add', row: {id: 'i4', created: 50}}],
+        pushes: [makeSourceChangeAdd({id: 'i4', created: 50})],
       });
       expect(data).toMatchInlineSnapshot(`[]`);
       expect(messages).toMatchInlineSnapshot(`
@@ -44,7 +49,7 @@ describe('take with no partition', () => {
           {id: 'i3', created: 300, text: null},
         ],
         limit: 5,
-        pushes: [{type: 'add', row: {id: 'i4', created: 50}}],
+        pushes: [makeSourceChangeAdd({id: 'i4', created: 50})],
       });
       expect(data).toMatchInlineSnapshot(`
         [
@@ -140,7 +145,7 @@ describe('take with no partition', () => {
           {id: 'i3', created: 300, text: null},
         ],
         limit: 5,
-        pushes: [{type: 'add', row: {id: 'i4', created: 350}}],
+        pushes: [makeSourceChangeAdd({id: 'i4', created: 350})],
       });
       expect(data).toMatchInlineSnapshot(`
         [
@@ -235,7 +240,7 @@ describe('take with no partition', () => {
           {id: 'i4', created: 400, text: null},
         ],
         limit: 3,
-        pushes: [{type: 'add', row: {id: 'i5', created: 350}}],
+        pushes: [makeSourceChangeAdd({id: 'i5', created: 350})],
       });
       expect(data).toMatchInlineSnapshot(`
         [
@@ -303,7 +308,7 @@ describe('take with no partition', () => {
           {id: 'i4', created: 400, text: null},
         ],
         limit: 3,
-        pushes: [{type: 'add', row: {id: 'i5', created: 50}}],
+        pushes: [makeSourceChangeAdd({id: 'i5', created: 50})],
         fetchOnPush: true,
       });
       expect(data).toMatchInlineSnapshot(`
@@ -481,7 +486,7 @@ describe('take with no partition', () => {
           {id: 'i4', created: 400, text: null},
         ],
         limit: 1,
-        pushes: [{type: 'add', row: {id: 'i5', created: 50}}],
+        pushes: [makeSourceChangeAdd({id: 'i5', created: 50})],
         fetchOnPush: true,
       });
       expect(data).toMatchInlineSnapshot(`
@@ -610,7 +615,7 @@ describe('take with no partition', () => {
           {id: 'i4', created: 400, text: null},
         ],
         limit: 3,
-        pushes: [{type: 'add', row: {id: 'i5', created: 250}}],
+        pushes: [makeSourceChangeAdd({id: 'i5', created: 250})],
         fetchOnPush: true,
       });
       expect(data).toMatchInlineSnapshot(`
@@ -788,7 +793,7 @@ describe('take with no partition', () => {
           {id: 'i3', created: 300, text: null},
         ],
         limit: 0,
-        pushes: [{type: 'remove', row: {id: 'i1', created: 100}}],
+        pushes: [makeSourceChangeRemove({id: 'i1', created: 100})],
       });
       expect(data).toMatchInlineSnapshot(`[]`);
       expect(messages).toMatchInlineSnapshot(`
@@ -818,7 +823,7 @@ describe('take with no partition', () => {
           {id: 'i3', created: 300, text: null},
         ],
         limit: 5,
-        pushes: [{type: 'remove', row: {id: 'i1', created: 100}}],
+        pushes: [makeSourceChangeRemove({id: 'i1', created: 100})],
       });
       expect(data).toMatchInlineSnapshot(`
         [
@@ -934,7 +939,7 @@ describe('take with no partition', () => {
           {id: 'i3', created: 300, text: null},
         ],
         limit: 5,
-        pushes: [{type: 'remove', row: {id: 'i3', created: 300}}],
+        pushes: [makeSourceChangeRemove({id: 'i3', created: 300})],
       });
       expect(data).toMatchInlineSnapshot(`
         [
@@ -1051,7 +1056,7 @@ describe('take with no partition', () => {
           {id: 'i4', created: 400, text: null},
         ],
         limit: 3,
-        pushes: [{type: 'remove', row: {id: 'i4', created: 400}}],
+        pushes: [makeSourceChangeRemove({id: 'i4', created: 400})],
       });
       expect(data).toMatchInlineSnapshot(`
         [
@@ -1119,7 +1124,7 @@ describe('take with no partition', () => {
           {id: 'i4', created: 400, text: null},
         ],
         limit: 3,
-        pushes: [{type: 'remove', row: {id: 'i1', created: 100}}],
+        pushes: [makeSourceChangeRemove({id: 'i1', created: 100})],
         fetchOnPush: true,
       });
       expect(data).toMatchInlineSnapshot(`
@@ -1314,7 +1319,7 @@ describe('take with no partition', () => {
           {id: 'i4', created: 400, text: null},
         ],
         limit: 2,
-        pushes: [{type: 'remove', row: {id: 'i1', created: 100}}],
+        pushes: [makeSourceChangeRemove({id: 'i1', created: 100})],
         fetchOnPush: true,
       });
       expect(data).toMatchInlineSnapshot(`
@@ -1487,7 +1492,7 @@ describe('take with no partition', () => {
           {id: 'i4', created: 400, text: null},
         ],
         limit: 1,
-        pushes: [{type: 'remove', row: {id: 'i1', created: 100}}],
+        pushes: [makeSourceChangeRemove({id: 'i1', created: 100})],
         fetchOnPush: true,
       });
       expect(data).toMatchInlineSnapshot(`
@@ -1634,7 +1639,7 @@ describe('take with no partition', () => {
           {id: 'i3', created: 300, text: null},
         ],
         limit: 3,
-        pushes: [{type: 'remove', row: {id: 'i1', created: 100}}],
+        pushes: [makeSourceChangeRemove({id: 'i1', created: 100})],
       });
       expect(data).toMatchInlineSnapshot(`
         [
@@ -1751,7 +1756,7 @@ describe('take with no partition', () => {
           {id: 'i4', created: 400, text: null},
         ],
         limit: 3,
-        pushes: [{type: 'remove', row: {id: 'i3', created: 300}}],
+        pushes: [makeSourceChangeRemove({id: 'i3', created: 300})],
         fetchOnPush: true,
       });
       expect(data).toMatchInlineSnapshot(`
@@ -1945,7 +1950,7 @@ describe('take with no partition', () => {
           {id: 'i3', created: 300, text: null},
         ],
         limit: 3,
-        pushes: [{type: 'remove', row: {id: 'i3', created: 300}}],
+        pushes: [makeSourceChangeRemove({id: 'i3', created: 300})],
       });
       expect(data).toMatchInlineSnapshot(`
         [
@@ -2069,11 +2074,10 @@ describe('take with no partition', () => {
         ...base,
         limit: 0,
         pushes: [
-          {
-            type: 'edit',
-            oldRow: {id: 'i2', created: 200, text: 'b'},
-            row: {id: 'i2', created: 200, text: 'c'},
-          },
+          makeSourceChangeEdit(
+            {id: 'i2', created: 200, text: 'c'},
+            {id: 'i2', created: 200, text: 'b'},
+          ),
         ],
       });
       expect(data).toMatchInlineSnapshot(`[]`);
@@ -2108,11 +2112,10 @@ describe('take with no partition', () => {
           ...base,
           limit: 5,
           pushes: [
-            {
-              type: 'edit',
-              oldRow: {id: 'i1', created: 100, text: 'a'},
-              row: {id: 'i1', created: 100, text: 'a2'},
-            },
+            makeSourceChangeEdit(
+              {id: 'i1', created: 100, text: 'a2'},
+              {id: 'i1', created: 100, text: 'a'},
+            ),
           ],
         });
         expect(data).toMatchInlineSnapshot(`
@@ -2222,11 +2225,10 @@ describe('take with no partition', () => {
           ...base,
           limit: 5,
           pushes: [
-            {
-              type: 'edit',
-              oldRow: {id: 'i4', created: 400, text: 'd'},
-              row: {id: 'i4', created: 400, text: 'd2'},
-            },
+            makeSourceChangeEdit(
+              {id: 'i4', created: 400, text: 'd2'},
+              {id: 'i4', created: 400, text: 'd'},
+            ),
           ],
         });
         expect(data).toMatchInlineSnapshot(`
@@ -2338,11 +2340,10 @@ describe('take with no partition', () => {
           ...base,
           limit: 3,
           pushes: [
-            {
-              type: 'edit',
-              oldRow: {id: 'i4', created: 400, text: 'd'},
-              row: {id: 'i4', created: 400, text: 'd2'},
-            },
+            makeSourceChangeEdit(
+              {id: 'i4', created: 400, text: 'd2'},
+              {id: 'i4', created: 400, text: 'd'},
+            ),
           ],
         });
         expect(data).toMatchInlineSnapshot(`
@@ -2413,11 +2414,10 @@ describe('take with no partition', () => {
           ...base,
           limit: 3,
           pushes: [
-            {
-              type: 'edit',
-              oldRow: {id: 'i2', created: 200, text: 'b'},
-              row: {id: 'i2', created: 200, text: 'b2'},
-            },
+            makeSourceChangeEdit(
+              {id: 'i2', created: 200, text: 'b2'},
+              {id: 'i2', created: 200, text: 'b'},
+            ),
           ],
         });
         expect(data).toMatchInlineSnapshot(`
@@ -2521,11 +2521,10 @@ describe('take with no partition', () => {
           ...base,
           limit: 3,
           pushes: [
-            {
-              type: 'edit',
-              oldRow: {id: 'i3', created: 300, text: 'c'},
-              row: {id: 'i3', created: 300, text: 'c2'},
-            },
+            makeSourceChangeEdit(
+              {id: 'i3', created: 300, text: 'c2'},
+              {id: 'i3', created: 300, text: 'c'},
+            ),
           ],
         });
         expect(data).toMatchInlineSnapshot(`
@@ -2630,11 +2629,10 @@ describe('take with no partition', () => {
           limit: 3,
           fetchOnPush: true,
           pushes: [
-            {
-              type: 'edit',
-              oldRow: {id: 'i3', created: 300, text: 'c'},
-              row: {id: 'i3', created: 550, text: 'c'},
-            },
+            makeSourceChangeEdit(
+              {id: 'i3', created: 550, text: 'c'},
+              {id: 'i3', created: 300, text: 'c'},
+            ),
           ],
         });
         expect(data).toMatchInlineSnapshot(`
@@ -2817,11 +2815,10 @@ describe('take with no partition', () => {
           ...base,
           limit: 3,
           pushes: [
-            {
-              type: 'edit',
-              oldRow: {id: 'i2', created: 200, text: 'b'},
-              row: {id: 'i2', created: 50, text: 'b2'},
-            },
+            makeSourceChangeEdit(
+              {id: 'i2', created: 50, text: 'b2'},
+              {id: 'i2', created: 200, text: 'b'},
+            ),
           ],
         });
         expect(data).toMatchInlineSnapshot(`
@@ -2925,11 +2922,10 @@ describe('take with no partition', () => {
           ...base,
           limit: 3,
           pushes: [
-            {
-              type: 'edit',
-              oldRow: {id: 'i4', created: 400, text: 'd'},
-              row: {id: 'i4', created: 250, text: 'd'},
-            },
+            makeSourceChangeEdit(
+              {id: 'i4', created: 250, text: 'd'},
+              {id: 'i4', created: 400, text: 'd'},
+            ),
           ],
           fetchOnPush: true,
         });
@@ -3114,11 +3110,10 @@ describe('take with no partition', () => {
           ...base,
           limit: 3,
           pushes: [
-            {
-              type: 'edit',
-              oldRow: {id: 'i2', created: 200, text: 'b'},
-              row: {id: 'i2', created: 350, text: 'b2'},
-            },
+            makeSourceChangeEdit(
+              {id: 'i2', created: 350, text: 'b2'},
+              {id: 'i2', created: 200, text: 'b'},
+            ),
           ],
         });
         expect(data).toMatchInlineSnapshot(`
@@ -3237,11 +3232,10 @@ describe('take with no partition', () => {
           ...base,
           limit: 3,
           pushes: [
-            {
-              type: 'edit',
-              oldRow: {id: 'i2', created: 200, text: 'b'},
-              row: {id: 'i2', created: 450, text: 'b2'},
-            },
+            makeSourceChangeEdit(
+              {id: 'i2', created: 450, text: 'b2'},
+              {id: 'i2', created: 200, text: 'b'},
+            ),
           ],
           fetchOnPush: true,
         });
@@ -3426,11 +3420,10 @@ describe('take with no partition', () => {
         ...base,
         limit: 1,
         pushes: [
-          {
-            type: 'edit',
-            oldRow: {id: 'i1', created: 100, text: 'a'},
-            row: {id: 'i1', created: 50, text: 'a2'},
-          },
+          makeSourceChangeEdit(
+            {id: 'i1', created: 50, text: 'a2'},
+            {id: 'i1', created: 100, text: 'a'},
+          ),
         ],
       });
       expect(data).toMatchInlineSnapshot(`
@@ -3527,7 +3520,7 @@ describe('take with partition', () => {
           {id: 'c3', issueID: 'i1', created: 300, text: null},
         ],
         limit: 0,
-        pushes: [{type: 'add', row: {id: 'c6', issueID: 'i2', created: 150}}],
+        pushes: [makeSourceChangeAdd({id: 'c6', issueID: 'i2', created: 150})],
       });
       expect(data).toMatchInlineSnapshot(`
         [
@@ -3573,7 +3566,7 @@ describe('take with partition', () => {
           {id: 'c5', issueID: 'i2', created: 500, text: null},
         ],
         limit: 5,
-        pushes: [{type: 'add', row: {id: 'c6', issueID: 'i2', created: 150}}],
+        pushes: [makeSourceChangeAdd({id: 'c6', issueID: 'i2', created: 150})],
       });
       expect(data).toMatchInlineSnapshot(`
         [
@@ -3755,7 +3748,7 @@ describe('take with partition', () => {
           {id: 'c7', issueID: 'i2', created: 700, text: null},
         ],
         limit: 3,
-        pushes: [{type: 'add', row: {id: 'c8', issueID: 'i2', created: 550}}],
+        pushes: [makeSourceChangeAdd({id: 'c8', issueID: 'i2', created: 550})],
         fetchOnPush: true,
       });
       expect(data).toMatchInlineSnapshot(`
@@ -4156,7 +4149,7 @@ describe('take with partition', () => {
           {id: 'c5', issueID: 'i2', created: 500, text: null},
         ],
         limit: 3,
-        pushes: [{type: 'add', row: {id: 'c6', issueID: '3', created: 550}}],
+        pushes: [makeSourceChangeAdd({id: 'c6', issueID: '3', created: 550})],
       });
       expect(data).toMatchInlineSnapshot(`
         [
@@ -4267,7 +4260,7 @@ describe('take with partition', () => {
         ],
         limit: 0,
         pushes: [
-          {type: 'remove', row: {id: 'c1', issueID: 'i1', created: 100}},
+          makeSourceChangeRemove({id: 'c1', issueID: 'i1', created: 100}),
         ],
       });
       expect(data).toMatchInlineSnapshot(`
@@ -4315,7 +4308,7 @@ describe('take with partition', () => {
         ],
         limit: 5,
         pushes: [
-          {type: 'remove', row: {id: 'c1', issueID: 'i1', created: 100}},
+          makeSourceChangeRemove({id: 'c1', issueID: 'i1', created: 100}),
         ],
       });
       expect(data).toMatchInlineSnapshot(`
@@ -4520,7 +4513,7 @@ describe('take with partition', () => {
         ],
         limit: 5,
         pushes: [
-          {type: 'remove', row: {id: 'c6', issueID: 'i3', created: 600}},
+          makeSourceChangeRemove({id: 'c6', issueID: 'i3', created: 600}),
         ],
       });
       expect(data).toMatchInlineSnapshot(`
@@ -4638,11 +4631,10 @@ describe('take with partition', () => {
         ...base,
         limit: 0,
         pushes: [
-          {
-            type: 'edit',
-            oldRow: {id: 'c2', issueID: 'i1', created: 200, text: 'b'},
-            row: {id: 'c2', issueID: 'i1', created: 200, text: 'b2'},
-          },
+          makeSourceChangeEdit(
+            {id: 'c2', issueID: 'i1', created: 200, text: 'b2'},
+            {id: 'c2', issueID: 'i1', created: 200, text: 'b'},
+          ),
         ],
       });
       expect(data).toMatchInlineSnapshot(`
@@ -4692,11 +4684,10 @@ describe('take with partition', () => {
           ...base,
           limit: 5,
           pushes: [
-            {
-              type: 'edit',
-              oldRow: {id: 'c1', issueID: 'i1', created: 100, text: 'a'},
-              row: {id: 'c1', issueID: 'i1', created: 100, text: 'a2'},
-            },
+            makeSourceChangeEdit(
+              {id: 'c1', issueID: 'i1', created: 100, text: 'a2'},
+              {id: 'c1', issueID: 'i1', created: 100, text: 'a'},
+            ),
           ],
         });
         expect(data).toMatchInlineSnapshot(`
@@ -4889,11 +4880,10 @@ describe('take with partition', () => {
           ...base,
           limit: 5,
           pushes: [
-            {
-              type: 'edit',
-              oldRow: {id: 'c5', issueID: 'i2', created: 500, text: 'e'},
-              row: {id: 'c5', issueID: 'i2', created: 500, text: 'e2'},
-            },
+            makeSourceChangeEdit(
+              {id: 'c5', issueID: 'i2', created: 500, text: 'e2'},
+              {id: 'c5', issueID: 'i2', created: 500, text: 'e'},
+            ),
           ],
         });
         expect(data).toMatchInlineSnapshot(`
@@ -5088,11 +5078,10 @@ describe('take with partition', () => {
           ...base,
           limit: 2,
           pushes: [
-            {
-              type: 'edit',
-              oldRow: {id: 'c3', issueID: 'i1', created: 300, text: 'c'},
-              row: {id: 'c3', issueID: 'i1', created: 300, text: 'c2'},
-            },
+            makeSourceChangeEdit(
+              {id: 'c3', issueID: 'i1', created: 300, text: 'c2'},
+              {id: 'c3', issueID: 'i1', created: 300, text: 'c'},
+            ),
           ],
         });
         expect(data).toMatchInlineSnapshot(`
@@ -5198,11 +5187,10 @@ describe('take with partition', () => {
           ...base,
           limit: 3,
           pushes: [
-            {
-              type: 'edit',
-              oldRow: {id: 'c2', issueID: 'i1', created: 200, text: 'b'},
-              row: {id: 'c2', issueID: 'i1', created: 200, text: 'b2'},
-            },
+            makeSourceChangeEdit(
+              {id: 'c2', issueID: 'i1', created: 200, text: 'b2'},
+              {id: 'c2', issueID: 'i1', created: 200, text: 'b'},
+            ),
           ],
         });
         expect(data).toMatchInlineSnapshot(`
@@ -5395,11 +5383,10 @@ describe('take with partition', () => {
           ...base,
           limit: 3,
           pushes: [
-            {
-              type: 'edit',
-              oldRow: {id: 'c3', issueID: 'i1', created: 300, text: 'c'},
-              row: {id: 'c3', issueID: 'i1', created: 300, text: 'c2'},
-            },
+            makeSourceChangeEdit(
+              {id: 'c3', issueID: 'i1', created: 300, text: 'c2'},
+              {id: 'c3', issueID: 'i1', created: 300, text: 'c'},
+            ),
           ],
         });
         expect(data).toMatchInlineSnapshot(`
@@ -5592,11 +5579,10 @@ describe('take with partition', () => {
           ...base,
           limit: 3,
           pushes: [
-            {
-              type: 'edit',
-              oldRow: {id: 'c3', issueID: 'i1', created: 300, text: 'c'},
-              row: {id: 'c3', issueID: 'i1', created: 150, text: 'c2'},
-            },
+            makeSourceChangeEdit(
+              {id: 'c3', issueID: 'i1', created: 150, text: 'c2'},
+              {id: 'c3', issueID: 'i1', created: 300, text: 'c'},
+            ),
           ],
         });
         expect(data).toMatchInlineSnapshot(`
@@ -5810,11 +5796,10 @@ describe('take with partition', () => {
             limit: 2,
             fetchOnPush: true,
             pushes: [
-              {
-                type: 'edit',
-                oldRow: {id: 'c2', issueID: 'i1', created: 200, text: 'b'},
-                row: {id: 'c2', issueID: 'i1', created: 350, text: 'b2'},
-              },
+              makeSourceChangeEdit(
+                {id: 'c2', issueID: 'i1', created: 350, text: 'b2'},
+                {id: 'c2', issueID: 'i1', created: 200, text: 'b'},
+              ),
             ],
           });
         expect(data).toMatchInlineSnapshot(`
@@ -6172,11 +6157,10 @@ describe('take with partition', () => {
           ...base,
           limit: 3,
           pushes: [
-            {
-              type: 'edit',
-              oldRow: {id: 'c2', issueID: 'i1', created: 200, text: 'b'},
-              row: {id: 'c2', issueID: 'i1', created: 50, text: 'b2'},
-            },
+            makeSourceChangeEdit(
+              {id: 'c2', issueID: 'i1', created: 50, text: 'b2'},
+              {id: 'c2', issueID: 'i1', created: 200, text: 'b'},
+            ),
           ],
         });
         expect(data).toMatchInlineSnapshot(`
@@ -6370,11 +6354,10 @@ describe('take with partition', () => {
             ...base,
             limit: 2,
             pushes: [
-              {
-                type: 'edit',
-                oldRow: {id: 'c3', issueID: 'i1', created: 300, text: 'c'},
-                row: {id: 'c3', issueID: 'i1', created: 150, text: 'c2'},
-              },
+              makeSourceChangeEdit(
+                {id: 'c3', issueID: 'i1', created: 150, text: 'c2'},
+                {id: 'c3', issueID: 'i1', created: 300, text: 'c'},
+              ),
             ],
             fetchOnPush: true,
           });
@@ -6734,11 +6717,10 @@ describe('take with partition', () => {
           ...base,
           limit: 2,
           pushes: [
-            {
-              type: 'edit',
-              oldRow: {id: 'c1', issueID: 'i1', created: 100, text: 'a'},
-              row: {id: 'c1', issueID: 'i1', created: 250, text: 'a2'},
-            },
+            makeSourceChangeEdit(
+              {id: 'c1', issueID: 'i1', created: 250, text: 'a2'},
+              {id: 'c1', issueID: 'i1', created: 100, text: 'a'},
+            ),
           ],
         });
         expect(data).toMatchInlineSnapshot(`
@@ -6943,11 +6925,10 @@ describe('take with partition', () => {
             ...base,
             limit: 2,
             pushes: [
-              {
-                type: 'edit',
-                oldRow: {id: 'c1', issueID: 'i1', created: 100, text: 'a'},
-                row: {id: 'c1', issueID: 'i1', created: 350, text: 'a2'},
-              },
+              makeSourceChangeEdit(
+                {id: 'c1', issueID: 'i1', created: 350, text: 'a2'},
+                {id: 'c1', issueID: 'i1', created: 100, text: 'a'},
+              ),
             ],
             fetchOnPush: true,
           });
@@ -7309,11 +7290,10 @@ describe('take with partition', () => {
             ...base,
             limit: 2,
             pushes: [
-              {
-                type: 'edit',
-                oldRow: {id: 'c1', issueID: 'i1', created: 100, text: 'a'},
-                row: {id: 'c1', issueID: 'i2', created: 100, text: 'a2'},
-              },
+              makeSourceChangeEdit(
+                {id: 'c1', issueID: 'i2', created: 100, text: 'a2'},
+                {id: 'c1', issueID: 'i1', created: 100, text: 'a'},
+              ),
             ],
             fetchOnPush: true,
           });
@@ -8017,7 +7997,7 @@ describe('take limit 0 with related query', () => {
         },
         ast,
         format,
-        pushes: [['owner', {type: 'add', row: {id: 'o1', name: 'Alice'}}]],
+        pushes: [['owner', makeSourceChangeAdd({id: 'o1', name: 'Alice'})]],
       });
 
       expect(data).toEqual([]);

--- a/packages/zql/src/ivm/take.ts
+++ b/packages/zql/src/ivm/take.ts
@@ -3,7 +3,14 @@ import {hasOwn} from '../../../shared/src/has-own.ts';
 import type {Row, Value} from '../../../zero-protocol/src/data.ts';
 import type {PrimaryKey} from '../../../zero-protocol/src/primary-key.ts';
 import {assertOrderingIncludesPK} from '../query/complete-ordering.ts';
-import {type Change, type EditChange, type RemoveChange} from './change.ts';
+import {ChangeIndex} from './change-index.ts';
+import {ChangeType} from './change-type.ts';
+import {
+  makeAddChange,
+  makeRemoveChange,
+  type Change,
+  type EditChange,
+} from './change.ts';
 import type {Constraint} from './constraint.ts';
 import {compareValues, type Comparator, type Node} from './data.ts';
 import {
@@ -238,27 +245,27 @@ export class Take implements Operator {
   }
 
   *push(change: Change): Stream<'yield'> {
-    if (change.type === 'edit') {
+    if (change[ChangeIndex.TYPE] === ChangeType.EDIT) {
       yield* this.#pushEditChange(change);
       return;
     }
 
     const {takeState, takeStateKey, maxBound, constraint} =
-      this.#getStateAndConstraint(change.node.row);
+      this.#getStateAndConstraint(change[ChangeIndex.NODE].row);
     if (!takeState) {
       return;
     }
 
     const {compareRows} = this.getSchema();
 
-    if (change.type === 'add') {
+    if (change[ChangeIndex.TYPE] === ChangeType.ADD) {
       if (takeState.size < this.#limit) {
         this.#setTakeState(
           takeStateKey,
           takeState.size + 1,
           takeState.bound === undefined ||
-            compareRows(takeState.bound, change.node.row) < 0
-            ? change.node.row
+            compareRows(takeState.bound, change[ChangeIndex.NODE].row) < 0
+            ? change[ChangeIndex.NODE].row
             : takeState.bound,
           maxBound,
         );
@@ -268,7 +275,7 @@ export class Take implements Operator {
       // size === limit
       if (
         takeState.bound === undefined ||
-        compareRows(change.node.row, takeState.bound) >= 0
+        compareRows(change[ChangeIndex.NODE].row, takeState.bound) >= 0
       ) {
         return;
       }
@@ -314,29 +321,32 @@ export class Take implements Operator {
         boundNode !== undefined,
         'Take: boundNode must be found during fetch',
       );
-      const removeChange: RemoveChange = {
-        type: 'remove',
-        node: boundNode,
-      };
+      const removeChange = makeRemoveChange(boundNode);
       // Remove before add to maintain invariant that
       // output size <= limit.
       this.#setTakeState(
         takeStateKey,
         takeState.size,
         beforeBoundNode === undefined ||
-          compareRows(change.node.row, beforeBoundNode.row) > 0
-          ? change.node.row
+          compareRows(change[ChangeIndex.NODE].row, beforeBoundNode.row) > 0
+          ? change[ChangeIndex.NODE].row
           : beforeBoundNode.row,
         maxBound,
       );
-      yield* this.#pushWithRowHiddenFromFetch(change.node.row, removeChange);
+      yield* this.#pushWithRowHiddenFromFetch(
+        change[ChangeIndex.NODE].row,
+        removeChange,
+      );
       yield* this.#output.push(change, this);
-    } else if (change.type === 'remove') {
+    } else if (change[ChangeIndex.TYPE] === ChangeType.REMOVE) {
       if (takeState.bound === undefined) {
         // change is after bound
         return;
       }
-      const compToBound = compareRows(change.node.row, takeState.bound);
+      const compToBound = compareRows(
+        change[ChangeIndex.NODE].row,
+        takeState.bound,
+      );
       if (compToBound > 0) {
         // change is after bound
         return;
@@ -397,13 +407,7 @@ export class Take implements Operator {
           newBound.node.row,
           maxBound,
         );
-        yield* this.#output.push(
-          {
-            type: 'add',
-            node: newBound.node,
-          },
-          this,
-        );
+        yield* this.#output.push(makeAddChange(newBound.node), this);
         return;
       }
       this.#setTakeState(
@@ -413,12 +417,12 @@ export class Take implements Operator {
         maxBound,
       );
       yield* this.#output.push(change, this);
-    } else if (change.type === 'child') {
+    } else if (change[ChangeIndex.TYPE] === ChangeType.CHILD) {
       // A 'child' change should be pushed to output if its row
       // is <= bound.
       if (
         takeState.bound &&
-        compareRows(change.node.row, takeState.bound) <= 0
+        compareRows(change[ChangeIndex.NODE].row, takeState.bound) <= 0
       ) {
         yield* this.#output.push(change, this);
       }
@@ -428,27 +432,33 @@ export class Take implements Operator {
   *#pushEditChange(change: EditChange): Stream<'yield'> {
     assert(
       !this.#partitionKeyComparator ||
-        this.#partitionKeyComparator(change.oldNode.row, change.node.row) === 0,
+        this.#partitionKeyComparator(
+          change[ChangeIndex.OLD_NODE].row,
+          change[ChangeIndex.NODE].row,
+        ) === 0,
       'Unexpected change of partition key',
     );
 
     const {takeState, takeStateKey, maxBound, constraint} =
-      this.#getStateAndConstraint(change.oldNode.row);
+      this.#getStateAndConstraint(change[ChangeIndex.OLD_NODE].row);
     if (!takeState) {
       return;
     }
 
     assert(takeState.bound, 'Bound should be set');
     const {compareRows} = this.getSchema();
-    const oldCmp = compareRows(change.oldNode.row, takeState.bound);
-    const newCmp = compareRows(change.node.row, takeState.bound);
+    const oldCmp = compareRows(
+      change[ChangeIndex.OLD_NODE].row,
+      takeState.bound,
+    );
+    const newCmp = compareRows(change[ChangeIndex.NODE].row, takeState.bound);
 
     const that = this;
     const replaceBoundAndForwardChange = function* () {
       that.#setTakeState(
         takeStateKey,
         takeState.size,
-        change.node.row,
+        change[ChangeIndex.NODE].row,
         maxBound,
       );
       yield* that.#output.push(change, that);
@@ -528,7 +538,7 @@ export class Take implements Operator {
 
       // The next row is the new row. We can replace the bounds and keep the
       // edit change.
-      if (compareRows(newBoundNode.row, change.node.row) === 0) {
+      if (compareRows(newBoundNode.row, change[ChangeIndex.NODE].row) === 0) {
         yield* replaceBoundAndForwardChange();
         return;
       }
@@ -541,17 +551,11 @@ export class Take implements Operator {
         newBoundNode.row,
         maxBound,
       );
-      yield* this.#pushWithRowHiddenFromFetch(newBoundNode.row, {
-        type: 'remove',
-        node: change.oldNode,
-      });
-      yield* this.#output.push(
-        {
-          type: 'add',
-          node: newBoundNode,
-        },
-        this,
+      yield* this.#pushWithRowHiddenFromFetch(
+        newBoundNode.row,
+        makeRemoveChange(change[ChangeIndex.OLD_NODE]),
       );
+      yield* this.#output.push(makeAddChange(newBoundNode), this);
       return;
     }
 
@@ -603,17 +607,11 @@ export class Take implements Operator {
         newBoundNode.row,
         maxBound,
       );
-      yield* this.#pushWithRowHiddenFromFetch(change.node.row, {
-        type: 'remove',
-        node: oldBoundNode,
-      });
-      yield* this.#output.push(
-        {
-          type: 'add',
-          node: change.node,
-        },
-        this,
+      yield* this.#pushWithRowHiddenFromFetch(
+        change[ChangeIndex.NODE].row,
+        makeRemoveChange(oldBoundNode),
       );
+      yield* this.#output.push(makeAddChange(change[ChangeIndex.NODE]), this);
 
       return;
     }
@@ -654,16 +652,13 @@ export class Take implements Operator {
       );
 
       // The new row is the new bound. Use an edit change.
-      if (compareRows(afterBoundNode.row, change.node.row) === 0) {
+      if (compareRows(afterBoundNode.row, change[ChangeIndex.NODE].row) === 0) {
         yield* replaceBoundAndForwardChange();
         return;
       }
 
       yield* this.#output.push(
-        {
-          type: 'remove',
-          node: change.oldNode,
-        },
+        makeRemoveChange(change[ChangeIndex.OLD_NODE]),
         this,
       );
       this.#setTakeState(
@@ -672,13 +667,7 @@ export class Take implements Operator {
         afterBoundNode.row,
         maxBound,
       );
-      yield* this.#output.push(
-        {
-          type: 'add',
-          node: afterBoundNode,
-        },
-        this,
-      );
+      yield* this.#output.push(makeAddChange(afterBoundNode), this);
       return;
     }
 

--- a/packages/zql/src/ivm/test/fetch-and-push-tests.ts
+++ b/packages/zql/src/ivm/test/fetch-and-push-tests.ts
@@ -12,6 +12,7 @@ import {ArrayView} from '../array-view.ts';
 import {Catch} from '../catch.ts';
 import type {Input} from '../operator.ts';
 import type {Source, SourceChange} from '../source.ts';
+import {makeSourceChangeAdd} from '../source.ts';
 import {consume} from '../stream.ts';
 import type {Format} from '../view.ts';
 import {createSource} from './source-factory.ts';
@@ -32,7 +33,7 @@ function makeSource(
     primaryKeys,
   );
   for (const row of rows) {
-    consume(source.push({type: 'add', row}));
+    consume(source.push(makeSourceChangeAdd(row)));
   }
   return source;
 }

--- a/packages/zql/src/ivm/union-fan-in.ts
+++ b/packages/zql/src/ivm/union-fan-in.ts
@@ -1,5 +1,7 @@
 import {assert} from '../../../shared/src/asserts.ts';
 import type {Writable} from '../../../shared/src/writable.ts';
+import {ChangeIndex} from './change-index.ts';
+import {ChangeType} from './change-type.ts';
 import type {Change} from './change.ts';
 import type {Constraint} from './constraint.ts';
 import type {Node} from './data.ts';
@@ -139,15 +141,16 @@ export class UnionFanIn implements Operator {
    *    An edit that would result in a remove or add will have been split into an add/remove pair rather than being an edit.
    */
   *#pushInternalChange(change: Change, pusher: InputBase): Stream<'yield'> {
-    if (change.type === 'child') {
+    if (change[ChangeIndex.TYPE] === ChangeType.CHILD) {
       yield* this.#output.push(change, this);
       return;
     }
 
     assert(
-      change.type === 'add' || change.type === 'remove',
+      change[ChangeIndex.TYPE] === ChangeType.ADD ||
+        change[ChangeIndex.TYPE] === ChangeType.REMOVE,
       () =>
-        `UnionFanIn: expected add or remove change type, got ${change.type}`,
+        `UnionFanIn: expected add or remove change type, got ${change[ChangeIndex.TYPE]}`,
     );
 
     let hadMatch = false;
@@ -159,7 +162,7 @@ export class UnionFanIn implements Operator {
 
       const constraint: Writable<Constraint> = {};
       for (const key of this.#schema.primaryKey) {
-        constraint[key] = change.node.row[key];
+        constraint[key] = change[ChangeIndex.NODE].row[key];
       }
       const fetchResult = input.fetch({
         constraint,
@@ -185,7 +188,7 @@ export class UnionFanIn implements Operator {
     this.#fanOutPushStarted = true;
   }
 
-  *fanOutDonePushing(fanOutChangeType: Change['type']): Stream<'yield'> {
+  *fanOutDonePushing(fanOutChangeType: ChangeType): Stream<'yield'> {
     assert(
       this.#fanOutPushStarted,
       'UnionFanIn: fanOutDonePushing called without fanOutStartedPushing',

--- a/packages/zql/src/ivm/union-fan-out.test.ts
+++ b/packages/zql/src/ivm/union-fan-out.test.ts
@@ -6,6 +6,11 @@ import {consume} from './stream.ts';
 import {createSource} from './test/source-factory.ts';
 import {UnionFanOut} from './union-fan-out.ts';
 
+import {
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+  makeSourceChangeRemove,
+} from './source.ts';
 const lc = createSilentLogContext();
 const mockFanIn = {
   fanOutStartedPushing() {},
@@ -29,11 +34,9 @@ test('push broadcasts change to all outputs', () => {
   const catch2 = new Catch(fanOut);
   const catch3 = new Catch(fanOut);
 
-  consume(s.push({type: 'add', row: {a: 1, b: 'foo'}}));
-  consume(
-    s.push({type: 'edit', oldRow: {a: 1, b: 'foo'}, row: {a: 1, b: 'bar'}}),
-  );
-  consume(s.push({type: 'remove', row: {a: 1, b: 'bar'}}));
+  consume(s.push(makeSourceChangeAdd({a: 1, b: 'foo'})));
+  consume(s.push(makeSourceChangeEdit({a: 1, b: 'bar'}, {a: 1, b: 'foo'})));
+  consume(s.push(makeSourceChangeRemove({a: 1, b: 'bar'})));
 
   expect(catch1.pushes).toMatchInlineSnapshot(`
     [
@@ -85,11 +88,11 @@ test('setOutput adds new output to list', () => {
   fanOut.setFanIn(mockFanIn);
   const catch1 = new Catch(fanOut);
 
-  consume(s.push({type: 'add', row: {a: 1}}));
+  consume(s.push(makeSourceChangeAdd({a: 1})));
 
   const catch2 = new Catch(fanOut);
 
-  consume(s.push({type: 'add', row: {a: 2}}));
+  consume(s.push(makeSourceChangeAdd({a: 2})));
 
   expect(catch1.pushes).toHaveLength(2);
   expect(catch2.pushes).toHaveLength(1);
@@ -136,9 +139,9 @@ test('fetch delegates to input', () => {
     ['a'],
   );
 
-  consume(s.push({type: 'add', row: {a: 1, b: 'foo'}}));
-  consume(s.push({type: 'add', row: {a: 2, b: 'bar'}}));
-  consume(s.push({type: 'add', row: {a: 3, b: 'baz'}}));
+  consume(s.push(makeSourceChangeAdd({a: 1, b: 'foo'})));
+  consume(s.push(makeSourceChangeAdd({a: 2, b: 'bar'})));
+  consume(s.push(makeSourceChangeAdd({a: 3, b: 'baz'})));
 
   const connector = s.connect([['a', 'asc']]);
   const fanOut = new UnionFanOut(connector);

--- a/packages/zql/src/ivm/union-fan-out.ts
+++ b/packages/zql/src/ivm/union-fan-out.ts
@@ -1,5 +1,6 @@
 import {assert} from '../../../shared/src/asserts.ts';
 import {must} from '../../../shared/src/must.ts';
+import {ChangeIndex} from './change-index.ts';
 import type {Change} from './change.ts';
 import type {Node} from './data.ts';
 import type {FetchRequest, Input, Operator, Output} from './operator.ts';
@@ -28,7 +29,7 @@ export class UnionFanOut implements Operator {
     for (const output of this.#outputs) {
       yield* output.push(change, this);
     }
-    yield* must(this.#unionFanIn).fanOutDonePushing(change.type);
+    yield* must(this.#unionFanIn).fanOutDonePushing(change[ChangeIndex.TYPE]);
   }
 
   setOutput(output: Output): void {

--- a/packages/zql/src/ivm/yield.push.test.ts
+++ b/packages/zql/src/ivm/yield.push.test.ts
@@ -13,9 +13,15 @@ import {FlippedJoin} from './flipped-join.ts';
 import {Join} from './join.ts';
 import {MemorySource} from './memory-source.ts';
 import {MemoryStorage} from './memory-storage.ts';
-import type {InputBase, FetchRequest} from './operator.ts';
+import type {FetchRequest, InputBase} from './operator.ts';
 import {Skip} from './skip.ts';
-import type {SourceChange, SourceInput} from './source.ts';
+import {
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+  makeSourceChangeRemove,
+  type SourceChange,
+  type SourceInput,
+} from './source.ts';
 import type {Stream} from './stream.ts';
 import {consume} from './stream.ts';
 import {Take} from './take.ts';
@@ -101,19 +107,15 @@ function collectPush(
 }
 
 function makeAdd(id: string): SourceChange {
-  return {type: 'add', row: {id}};
+  return makeSourceChangeAdd({id});
 }
 
 function makeRemove(id: string): SourceChange {
-  return {type: 'remove', row: {id}};
+  return makeSourceChangeRemove({id});
 }
 
 function makeEdit(id: string, oldId: string): SourceChange {
-  return {
-    type: 'edit',
-    row: {id},
-    oldRow: {id: oldId},
-  };
+  return makeSourceChangeEdit({id}, {id: oldId});
 }
 
 describe('Yield Propagation (Push)', () => {
@@ -292,8 +294,8 @@ describe('Yield Propagation (Push)', () => {
 
       // Initialize data
       consume(parent.push(makeAdd('1')));
-      consume(child.push({type: 'add', row: {id: 'c1', parentId: '1'}}));
-      consume(child.push({type: 'add', row: {id: 'c2', parentId: '2'}}));
+      consume(child.push(makeSourceChangeAdd({id: 'c1', parentId: '1'})));
+      consume(child.push(makeSourceChangeAdd({id: 'c2', parentId: '2'})));
 
       const join = new Join({
         parent: parent.connect([['id', 'asc']]),
@@ -340,10 +342,7 @@ describe('Yield Propagation (Push)', () => {
       // Push to child with parentId='1' which matches the existing parent.
       // Join fetches from parent. Parent has 1 matching node, so fetch yields 2 (1 before node + 1 at end).
       expect(
-        collectPush(child, {
-          type: 'add',
-          row: {id: 'c1', parentId: '1'},
-        }),
+        collectPush(child, makeSourceChangeAdd({id: 'c1', parentId: '1'})),
       ).toEqual(['yield', 'yield']);
     });
 
@@ -371,10 +370,7 @@ describe('Yield Propagation (Push)', () => {
 
       // Push to child with matching parent. YieldOutput yields.
       expect(
-        collectPush(child, {
-          type: 'add',
-          row: {id: 'c1', parentId: '1'},
-        }),
+        collectPush(child, makeSourceChangeAdd({id: 'c1', parentId: '1'})),
       ).toEqual(['yield', 'yield']);
     });
   });
@@ -388,7 +384,7 @@ describe('Yield Propagation (Push)', () => {
 
       // Initialize data
       consume(parent.push(makeAdd('1')));
-      consume(child.push({type: 'add', row: {id: 'c1', parentId: '1'}}));
+      consume(child.push(makeSourceChangeAdd({id: 'c1', parentId: '1'})));
 
       const flippedJoin = new FlippedJoin({
         parent: parent.connect([['id', 'asc']]),
@@ -407,7 +403,7 @@ describe('Yield Propagation (Push)', () => {
       // Push child with parentId='1' which matches the existing parent.
       // Parent fetch yields 2 (1 before node + 1 at end).
       expect(
-        collectPush(child, {type: 'add', row: {id: 'c2', parentId: '1'}}),
+        collectPush(child, makeSourceChangeAdd({id: 'c2', parentId: '1'})),
       ).toEqual(['yield', 'yield']);
     });
 
@@ -417,7 +413,7 @@ describe('Yield Propagation (Push)', () => {
       const child = new YieldMemorySource(CHILD_SCHEMA);
       child.yieldOnFetch = true;
 
-      consume(child.push({type: 'add', row: {id: 'c1', parentId: '1'}}));
+      consume(child.push(makeSourceChangeAdd({id: 'c1', parentId: '1'})));
 
       const flippedJoin = new FlippedJoin({
         parent: parent.connect([['id', 'asc']]),
@@ -444,7 +440,7 @@ describe('Yield Propagation (Push)', () => {
       child.yieldOnFetch = false;
 
       // Initialize child with matching data
-      consume(child.push({type: 'add', row: {id: 'c1', parentId: '1'}}));
+      consume(child.push(makeSourceChangeAdd({id: 'c1', parentId: '1'})));
 
       const flippedJoin = new FlippedJoin({
         parent: parent.connect([['id', 'asc']]),
@@ -471,7 +467,7 @@ describe('Yield Propagation (Push)', () => {
       const child = new YieldMemorySource(CHILD_SCHEMA);
       child.yieldOnFetch = false;
 
-      consume(child.push({type: 'add', row: {id: 'c1', parentId: '1'}}));
+      consume(child.push(makeSourceChangeAdd({id: 'c1', parentId: '1'})));
 
       const join = new Join({
         parent: parent.connect([['id', 'asc']]),
@@ -499,8 +495,8 @@ describe('Yield Propagation (Push)', () => {
       const child = new YieldMemorySource(CHILD_SCHEMA);
       child.yieldOnFetch = true;
 
-      consume(child.push({type: 'add', row: {id: 'c1', parentId: '1'}}));
-      consume(child.push({type: 'add', row: {id: 'c2', parentId: '1'}}));
+      consume(child.push(makeSourceChangeAdd({id: 'c1', parentId: '1'})));
+      consume(child.push(makeSourceChangeAdd({id: 'c2', parentId: '1'})));
 
       const join = new Join({
         parent: parent.connect([['id', 'asc']]),

--- a/packages/zql/src/query/measure-push-operator.test.ts
+++ b/packages/zql/src/query/measure-push-operator.test.ts
@@ -1,6 +1,7 @@
 import {describe, expect, test, vi} from 'vitest';
 import {emptyArray} from '../../../shared/src/sentinels.ts';
 import type {Change} from '../ivm/change.ts';
+import {makeAddChange} from '../ivm/change.ts';
 import type {Node} from '../ivm/data.ts';
 import type {FetchRequest, Input, Output} from '../ivm/operator.ts';
 import type {SourceSchema} from '../ivm/schema.ts';
@@ -107,10 +108,7 @@ describe('MeasurePushOperator', () => {
     );
     measurePushOperator.setOutput(mockOutput);
 
-    const change: Change = {
-      type: 'add',
-      node: {} as Node,
-    };
+    const change: Change = makeAddChange({} as Node);
 
     [...measurePushOperator.push(change)];
 
@@ -148,10 +146,7 @@ describe('MeasurePushOperator', () => {
     );
     measurePushOperator.setOutput(mockOutput);
 
-    const change: Change = {
-      type: 'add',
-      node: {} as Node,
-    };
+    const change: Change = makeAddChange({} as Node);
 
     expect(() => [...measurePushOperator.push(change)]).toThrow('Test error');
     expect(mockMetricsDelegate.addMetric).not.toHaveBeenCalled();

--- a/packages/zql/src/query/query-impl.query-kitchen-sink.test.ts
+++ b/packages/zql/src/query/query-impl.query-kitchen-sink.test.ts
@@ -6,6 +6,7 @@ import {newQuery} from './query-impl.ts';
 import {QueryDelegateImpl} from './test/query-delegate.ts';
 import {schema} from './test/test-schemas.ts';
 
+import {makeSourceChangeAdd} from '../ivm/source.ts';
 function addData(queryDelegate: QueryDelegate) {
   const userSource = must(queryDelegate.getSource('user'));
   const issueSource = must(queryDelegate.getSource('issue'));
@@ -15,373 +16,389 @@ function addData(queryDelegate: QueryDelegate) {
   const issueLabelSource = must(queryDelegate.getSource('issueLabel'));
 
   consume(
-    userSource.push({
-      type: 'add',
-      row: {id: '001', name: 'Alice', metadata: null},
-    }),
+    userSource.push(
+      makeSourceChangeAdd({id: '001', name: 'Alice', metadata: null}),
+    ),
   );
   consume(
-    userSource.push({
-      type: 'add',
-      row: {id: '002', name: 'Bob', metadata: null},
-    }),
+    userSource.push(
+      makeSourceChangeAdd({id: '002', name: 'Bob', metadata: null}),
+    ),
   );
   consume(
-    userSource.push({
-      type: 'add',
-      row: {id: '003', name: 'Charlie', metadata: {foo: 1}},
-    }),
+    userSource.push(
+      makeSourceChangeAdd({id: '003', name: 'Charlie', metadata: {foo: 1}}),
+    ),
   );
   consume(
-    userSource.push({
-      type: 'add',
-      row: {id: '004', name: 'Daniel', metadata: null},
-    }),
+    userSource.push(
+      makeSourceChangeAdd({id: '004', name: 'Daniel', metadata: null}),
+    ),
   );
 
   consume(
-    issueSource.push({
-      type: 'add',
-      row: {
+    issueSource.push(
+      makeSourceChangeAdd({
         id: '101',
         title: 'Issue 1',
         description: 'Description 1',
         closed: false,
         ownerId: '001',
         createdAt: 1,
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    issueSource.push({
-      type: 'add',
-      row: {
+    issueSource.push(
+      makeSourceChangeAdd({
         id: '102',
         title: 'Issue 2',
         description: 'Description 2',
         closed: false,
         ownerId: '001',
         createdAt: 2,
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    issueSource.push({
-      type: 'add',
-      row: {
+    issueSource.push(
+      makeSourceChangeAdd({
         id: '103',
         title: 'Issue 3',
         description: 'Description 3',
         closed: false,
         ownerId: '001',
         createdAt: 3,
-      },
-    }),
+      }),
+    ),
   );
 
   consume(
-    issueSource.push({
-      type: 'add',
-      row: {
+    issueSource.push(
+      makeSourceChangeAdd({
         id: '104',
         title: 'Issue 4',
         description: 'Description 4',
         closed: false,
         ownerId: '002',
         createdAt: 4,
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    issueSource.push({
-      type: 'add',
-      row: {
+    issueSource.push(
+      makeSourceChangeAdd({
         id: '105',
         title: 'Issue 5',
         description: 'Description 5',
         closed: false,
         ownerId: '002',
         createdAt: 5,
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    issueSource.push({
-      type: 'add',
-      row: {
+    issueSource.push(
+      makeSourceChangeAdd({
         id: '106',
         title: 'Issue 6',
         description: 'Description 6',
         closed: true,
         ownerId: '002',
         createdAt: 6,
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    issueSource.push({
-      type: 'add',
-      row: {
+    issueSource.push(
+      makeSourceChangeAdd({
         id: '107',
         title: 'Issue 7',
         description: 'Description 7',
         closed: true,
         ownerId: '003',
         createdAt: 7,
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    issueSource.push({
-      type: 'add',
-      row: {
+    issueSource.push(
+      makeSourceChangeAdd({
         id: '108',
         title: 'Issue 8',
         description: 'Description 8',
         closed: true,
         ownerId: '003',
         createdAt: 8,
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    issueSource.push({
-      type: 'add',
-      row: {
+    issueSource.push(
+      makeSourceChangeAdd({
         id: '109',
         title: 'Issue 9',
         description: 'Description 9',
         closed: false,
         ownerId: '003',
         createdAt: 9,
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    issueSource.push({
-      type: 'add',
-      row: {
+    issueSource.push(
+      makeSourceChangeAdd({
         id: '110',
         title: 'Issue 10',
         description: 'Description 10',
         closed: false,
         ownerId: '004',
         createdAt: 10,
-      },
-    }),
+      }),
+    ),
   );
 
   consume(
-    commentSource.push({
-      type: 'add',
-      row: {
+    commentSource.push(
+      makeSourceChangeAdd({
         id: '201',
         issueId: '101',
         text: 'Comment 1',
         authorId: '001',
         createdAt: 1,
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    commentSource.push({
-      type: 'add',
-      row: {
+    commentSource.push(
+      makeSourceChangeAdd({
         id: '202',
         issueId: '101',
         text: 'Comment 2',
         authorId: '002',
         createdAt: 2,
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    commentSource.push({
-      type: 'add',
-      row: {
+    commentSource.push(
+      makeSourceChangeAdd({
         id: '203',
         issueId: '101',
         text: 'Comment 3',
         authorId: '003',
         createdAt: 3,
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    commentSource.push({
-      type: 'add',
-      row: {
+    commentSource.push(
+      makeSourceChangeAdd({
         id: '204',
         issueId: '102',
         text: 'Comment 4',
         authorId: '001',
         createdAt: 4,
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    commentSource.push({
-      type: 'add',
-      row: {
+    commentSource.push(
+      makeSourceChangeAdd({
         id: '205',
         issueId: '102',
         text: 'Comment 5',
         authorId: '002',
         createdAt: 5,
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    commentSource.push({
-      type: 'add',
-      row: {
+    commentSource.push(
+      makeSourceChangeAdd({
         id: '206',
         issueId: '102',
         text: 'Comment 6',
         authorId: '003',
         createdAt: 6,
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    commentSource.push({
-      type: 'add',
-      row: {
+    commentSource.push(
+      makeSourceChangeAdd({
         id: '207',
         issueId: '103',
         text: 'Comment 7',
         authorId: '001',
         createdAt: 7,
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    commentSource.push({
-      type: 'add',
-      row: {
+    commentSource.push(
+      makeSourceChangeAdd({
         id: '208',
         issueId: '103',
         text: 'Comment 8',
         authorId: '002',
         createdAt: 8,
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    commentSource.push({
-      type: 'add',
-      row: {
+    commentSource.push(
+      makeSourceChangeAdd({
         id: '209',
         issueId: '103',
         text: 'Comment 9',
         authorId: '003',
         createdAt: 9,
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    commentSource.push({
-      type: 'add',
-      row: {
+    commentSource.push(
+      makeSourceChangeAdd({
         id: '210',
         issueId: '105',
         text: 'Comment 10',
         authorId: '001',
         createdAt: 10,
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    commentSource.push({
-      type: 'add',
-      row: {
+    commentSource.push(
+      makeSourceChangeAdd({
         id: '211',
         issueId: '105',
         text: 'Comment 11',
         authorId: '002',
         createdAt: 11,
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    commentSource.push({
-      type: 'add',
-      row: {
+    commentSource.push(
+      makeSourceChangeAdd({
         id: '212',
         issueId: '105',
         text: 'Comment 12',
         authorId: '003',
         createdAt: 12,
-      },
-    }),
+      }),
+    ),
   );
 
   consume(
-    revisionSource.push({
-      type: 'add',
-      row: {id: '301', commentId: '209', text: 'Revision 1', authorId: '001'},
-    }),
+    revisionSource.push(
+      makeSourceChangeAdd({
+        id: '301',
+        commentId: '209',
+        text: 'Revision 1',
+        authorId: '001',
+      }),
+    ),
   );
   consume(
-    revisionSource.push({
-      type: 'add',
-      row: {id: '302', commentId: '209', text: 'Revision 2', authorId: '001'},
-    }),
+    revisionSource.push(
+      makeSourceChangeAdd({
+        id: '302',
+        commentId: '209',
+        text: 'Revision 2',
+        authorId: '001',
+      }),
+    ),
   );
   consume(
-    revisionSource.push({
-      type: 'add',
-      row: {id: '303', commentId: '209', text: 'Revision 3', authorId: '001'},
-    }),
+    revisionSource.push(
+      makeSourceChangeAdd({
+        id: '303',
+        commentId: '209',
+        text: 'Revision 3',
+        authorId: '001',
+      }),
+    ),
   );
   consume(
-    revisionSource.push({
-      type: 'add',
-      row: {id: '304', commentId: '208', text: 'Revision 1', authorId: '002'},
-    }),
+    revisionSource.push(
+      makeSourceChangeAdd({
+        id: '304',
+        commentId: '208',
+        text: 'Revision 1',
+        authorId: '002',
+      }),
+    ),
   );
   consume(
-    revisionSource.push({
-      type: 'add',
-      row: {id: '305', commentId: '208', text: 'Revision 2', authorId: '002'},
-    }),
+    revisionSource.push(
+      makeSourceChangeAdd({
+        id: '305',
+        commentId: '208',
+        text: 'Revision 2',
+        authorId: '002',
+      }),
+    ),
   );
   consume(
-    revisionSource.push({
-      type: 'add',
-      row: {id: '306', commentId: '208', text: 'Revision 3', authorId: '002'},
-    }),
+    revisionSource.push(
+      makeSourceChangeAdd({
+        id: '306',
+        commentId: '208',
+        text: 'Revision 3',
+        authorId: '002',
+      }),
+    ),
   );
   consume(
-    revisionSource.push({
-      type: 'add',
-      row: {id: '307', commentId: '211', text: 'Revision 1', authorId: '003'},
-    }),
+    revisionSource.push(
+      makeSourceChangeAdd({
+        id: '307',
+        commentId: '211',
+        text: 'Revision 1',
+        authorId: '003',
+      }),
+    ),
   );
   consume(
-    revisionSource.push({
-      type: 'add',
-      row: {id: '308', commentId: '211', text: 'Revision 2', authorId: '003'},
-    }),
+    revisionSource.push(
+      makeSourceChangeAdd({
+        id: '308',
+        commentId: '211',
+        text: 'Revision 2',
+        authorId: '003',
+      }),
+    ),
   );
   consume(
-    revisionSource.push({
-      type: 'add',
-      row: {id: '309', commentId: '211', text: 'Revision 3', authorId: '003'},
-    }),
+    revisionSource.push(
+      makeSourceChangeAdd({
+        id: '309',
+        commentId: '211',
+        text: 'Revision 3',
+        authorId: '003',
+      }),
+    ),
   );
 
-  consume(labelSource.push({type: 'add', row: {id: '401', name: 'bug'}}));
-  consume(labelSource.push({type: 'add', row: {id: '402', name: 'feature'}}));
+  consume(labelSource.push(makeSourceChangeAdd({id: '401', name: 'bug'})));
+  consume(labelSource.push(makeSourceChangeAdd({id: '402', name: 'feature'})));
 
   consume(
-    issueLabelSource.push({type: 'add', row: {issueId: '103', labelId: '401'}}),
+    issueLabelSource.push(
+      makeSourceChangeAdd({issueId: '103', labelId: '401'}),
+    ),
   );
   consume(
-    issueLabelSource.push({type: 'add', row: {issueId: '102', labelId: '401'}}),
+    issueLabelSource.push(
+      makeSourceChangeAdd({issueId: '102', labelId: '401'}),
+    ),
   );
   consume(
-    issueLabelSource.push({type: 'add', row: {issueId: '102', labelId: '402'}}),
+    issueLabelSource.push(
+      makeSourceChangeAdd({issueId: '102', labelId: '402'}),
+    ),
   );
 }
 

--- a/packages/zql/src/query/query-impl.query.test.ts
+++ b/packages/zql/src/query/query-impl.query.test.ts
@@ -15,6 +15,11 @@ import {QueryDelegateImpl} from './test/query-delegate.ts';
 import {schema} from './test/test-schemas.ts';
 import type {TypedView} from './typed-view.ts';
 
+import {
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+  makeSourceChangeRemove,
+} from '../ivm/source.ts';
 /**
  * Some basic manual tests to get us started.
  *
@@ -40,22 +45,20 @@ function addData(queryDelegate: QueryDelegate) {
   const labelSource = must(queryDelegate.getSource('label'));
   const issueLabelSource = must(queryDelegate.getSource('issueLabel'));
   consume(
-    userSource.push({
-      type: 'add',
-      row: {
+    userSource.push(
+      makeSourceChangeAdd({
         id: '0001',
         name: 'Alice',
         metadata: {
           registrar: 'github',
           login: 'alicegh',
         },
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    userSource.push({
-      type: 'add',
-      row: {
+    userSource.push(
+      makeSourceChangeAdd({
         id: '0002',
         name: 'Bob',
         metadata: {
@@ -63,101 +66,93 @@ function addData(queryDelegate: QueryDelegate) {
           login: 'bob@gmail.com',
           altContacts: ['bobwave', 'bobyt', 'bobplus'],
         },
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    issueSource.push({
-      type: 'add',
-      row: {
+    issueSource.push(
+      makeSourceChangeAdd({
         id: '0001',
         title: 'issue 1',
         description: 'description 1',
         closed: false,
         ownerId: '0001',
         createdAt: 1,
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    issueSource.push({
-      type: 'add',
-      row: {
+    issueSource.push(
+      makeSourceChangeAdd({
         id: '0002',
         title: 'issue 2',
         description: 'description 2',
         closed: false,
         ownerId: '0002',
         createdAt: 2,
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    issueSource.push({
-      type: 'add',
-      row: {
+    issueSource.push(
+      makeSourceChangeAdd({
         id: '0003',
         title: 'issue 3',
         description: 'description 3',
         closed: false,
         ownerId: null,
         createdAt: 3,
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    commentSource.push({
-      type: 'add',
-      row: {
+    commentSource.push(
+      makeSourceChangeAdd({
         id: '0001',
         authorId: '0001',
         issueId: '0001',
         text: 'comment 1',
         createdAt: 1,
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    commentSource.push({
-      type: 'add',
-      row: {
+    commentSource.push(
+      makeSourceChangeAdd({
         id: '0002',
         authorId: '0002',
         issueId: '0001',
         text: 'comment 2',
         createdAt: 2,
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    revisionSource.push({
-      type: 'add',
-      row: {
+    revisionSource.push(
+      makeSourceChangeAdd({
         id: '0001',
         authorId: '0001',
         commentId: '0001',
         text: 'revision 1',
-      },
-    }),
+      }),
+    ),
   );
 
   consume(
-    labelSource.push({
-      type: 'add',
-      row: {
+    labelSource.push(
+      makeSourceChangeAdd({
         id: '0001',
         name: 'label 1',
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    issueLabelSource.push({
-      type: 'add',
-      row: {
+    issueLabelSource.push(
+      makeSourceChangeAdd({
         issueId: '0001',
         labelId: '0001',
-      },
-    }),
+      }),
+    ),
   );
 
   return {
@@ -206,16 +201,15 @@ describe('bare select', () => {
     expect(rows).toEqual([]);
 
     consume(
-      queryDelegate.getSource('issue').push({
-        type: 'add',
-        row: {
+      queryDelegate.getSource('issue').push(
+        makeSourceChangeAdd({
           id: '0001',
           title: 'title',
           description: 'description',
           closed: false,
           ownerId: '0001',
-        },
-      }),
+        }),
+      ),
     );
     queryDelegate.commit();
 
@@ -230,12 +224,11 @@ describe('bare select', () => {
     ]);
 
     consume(
-      queryDelegate.getSource('issue').push({
-        type: 'remove',
-        row: {
+      queryDelegate.getSource('issue').push(
+        makeSourceChangeRemove({
           id: '0001',
-        },
-      }),
+        }),
+      ),
     );
     queryDelegate.commit();
 
@@ -245,17 +238,16 @@ describe('bare select', () => {
   test('source with initial data', () => {
     const queryDelegate = new QueryDelegateImpl();
     consume(
-      queryDelegate.getSource('issue').push({
-        type: 'add',
-        row: {
+      queryDelegate.getSource('issue').push(
+        makeSourceChangeAdd({
           id: '0001',
           title: 'title',
           description: 'description',
           closed: false,
           ownerId: '0001',
           createdAt: 10,
-        },
-      }),
+        }),
+      ),
     );
 
     const issueQuery = newQuery(schema, 'issue');
@@ -282,17 +274,16 @@ describe('bare select', () => {
     const queryDelegate = new QueryDelegateImpl();
 
     consume(
-      queryDelegate.getSource('issue').push({
-        type: 'add',
-        row: {
+      queryDelegate.getSource('issue').push(
+        makeSourceChangeAdd({
           id: '0001',
           title: 'title',
           description: 'description',
           closed: false,
           ownerId: '0001',
           createdAt: 10,
-        },
-      }),
+        }),
+      ),
     );
 
     const issueQuery = newQuery(schema, 'issue');
@@ -315,17 +306,16 @@ describe('bare select', () => {
     ]);
 
     consume(
-      queryDelegate.getSource('issue').push({
-        type: 'add',
-        row: {
+      queryDelegate.getSource('issue').push(
+        makeSourceChangeAdd({
           id: '0002',
           title: 'title2',
           description: 'description2',
           closed: false,
           ownerId: '0002',
           createdAt: 20,
-        },
-      }),
+        }),
+      ),
     );
     queryDelegate.commit();
 
@@ -362,17 +352,16 @@ describe('bare select', () => {
     expect(rows).toEqual([]);
 
     consume(
-      queryDelegate.getSource('issue').push({
-        type: 'add',
-        row: {
+      queryDelegate.getSource('issue').push(
+        makeSourceChangeAdd({
           id: '0001',
           title: 'title',
           description: 'description',
           closed: false,
           ownerId: '0001',
           createdAt: 10,
-        },
-      }),
+        }),
+      ),
     );
     queryDelegate.commit();
 
@@ -390,12 +379,11 @@ describe('bare select', () => {
     m.destroy();
 
     consume(
-      queryDelegate.getSource('issue').push({
-        type: 'remove',
-        row: {
+      queryDelegate.getSource('issue').push(
+        makeSourceChangeRemove({
           id: '0001',
-        },
-      }),
+        }),
+      ),
     );
     queryDelegate.commit();
 
@@ -451,17 +439,16 @@ describe('joins and filters', () => {
     expect(doubleFilterWithNoResultsRows).toEqual([]);
 
     consume(
-      queryDelegate.getSource('issue').push({
-        type: 'remove',
-        row: {
+      queryDelegate.getSource('issue').push(
+        makeSourceChangeRemove({
           id: '0001',
           title: 'issue 1',
           description: 'description 1',
           closed: false,
           ownerId: '0001',
           createdAt: 10,
-        },
-      }),
+        }),
+      ),
     );
     queryDelegate.commit();
 
@@ -470,17 +457,16 @@ describe('joins and filters', () => {
     expect(doubleFilterWithNoResultsRows).toEqual([]);
 
     consume(
-      queryDelegate.getSource('issue').push({
-        type: 'add',
-        row: {
+      queryDelegate.getSource('issue').push(
+        makeSourceChangeAdd({
           id: '0001',
           title: 'issue 1',
           description: 'description 1',
           closed: true,
           ownerId: '0001',
           createdAt: 10,
-        },
-      }),
+        }),
+      ),
     );
 
     // no commit
@@ -588,43 +574,40 @@ describe('joins and filters', () => {
     `);
 
     consume(
-      queryDelegate.getSource('issue').push({
-        type: 'remove',
-        row: {
+      queryDelegate.getSource('issue').push(
+        makeSourceChangeRemove({
           id: '0001',
           title: 'issue 1',
           description: 'description 1',
           closed: false,
           ownerId: '0001',
           createdAt: 1,
-        },
-      }),
+        }),
+      ),
     );
     consume(
-      queryDelegate.getSource('issue').push({
-        type: 'remove',
-        row: {
+      queryDelegate.getSource('issue').push(
+        makeSourceChangeRemove({
           id: '0002',
           title: 'issue 2',
           description: 'description 2',
           closed: false,
           ownerId: '0002',
           createdAt: 2,
-        },
-      }),
+        }),
+      ),
     );
     consume(
-      queryDelegate.getSource('issue').push({
-        type: 'remove',
-        row: {
+      queryDelegate.getSource('issue').push(
+        makeSourceChangeRemove({
           id: '0003',
           title: 'issue 3',
           description: 'description 3',
           closed: false,
           ownerId: null,
           createdAt: 3,
-        },
-      }),
+        }),
+      ),
     );
     queryDelegate.commit();
 
@@ -1115,17 +1098,16 @@ describe('run with options', () => {
       type: 'complete',
     });
     consume(
-      issueSource.push({
-        type: 'remove',
-        row: {
+      issueSource.push(
+        makeSourceChangeRemove({
           id: '0001',
           title: 'issue 1',
           description: 'description 1',
           closed: false,
           ownerId: '0001',
           createdAt: 10,
-        },
-      }),
+        }),
+      ),
     );
     queryDelegate.callAllGotCallbacks();
     const singleFilterRowsUnknown = await singleFilterRowsUnknownP;
@@ -1475,12 +1457,7 @@ test('join with compound keys', async () => {
     {id: 1, a1: 2, a2: 3, a3: 4},
     {id: 2, a1: 2, a2: 3, a3: 5},
   ]) {
-    consume(
-      aSource.push({
-        type: 'add',
-        row,
-      }),
-    );
+    consume(aSource.push(makeSourceChangeAdd(row)));
   }
 
   for (const row of [
@@ -1488,12 +1465,7 @@ test('join with compound keys', async () => {
     {id: 1, b1: 1, b2: 2, b3: 4},
     {id: 2, b1: 2, b2: 3, b3: 5},
   ]) {
-    consume(
-      bSource.push({
-        type: 'add',
-        row,
-      }),
-    );
+    consume(bSource.push(makeSourceChangeAdd(row)));
   }
 
   const relatedQuery = newQuery(schema, 'a').related('b');
@@ -1566,39 +1538,36 @@ test('where exists', () => {
   const labelSource = must(queryDelegate.getSource('label'));
   const issueLabelSource = must(queryDelegate.getSource('issueLabel'));
   consume(
-    issueSource.push({
-      type: 'add',
-      row: {
+    issueSource.push(
+      makeSourceChangeAdd({
         id: '0001',
         title: 'issue 1',
         description: 'description 1',
         closed: false,
         ownerId: '0001',
         createdAt: 10,
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    issueSource.push({
-      type: 'add',
-      row: {
+    issueSource.push(
+      makeSourceChangeAdd({
         id: '0002',
         title: 'issue 2',
         description: 'description 2',
         closed: true,
         ownerId: '0002',
         createdAt: 20,
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    labelSource.push({
-      type: 'add',
-      row: {
+    labelSource.push(
+      makeSourceChangeAdd({
         id: '0001',
         name: 'bug',
-      },
-    }),
+      }),
+    ),
   );
 
   const materializedQuery = newQuery(schema, 'issue')
@@ -1611,13 +1580,12 @@ test('where exists', () => {
   expect(materialized.data).toEqual([]);
 
   consume(
-    issueLabelSource.push({
-      type: 'add',
-      row: {
+    issueLabelSource.push(
+      makeSourceChangeAdd({
         issueId: '0002',
         labelId: '0001',
-      },
-    }),
+      }),
+    ),
   );
 
   expect(materialized.data).toMatchInlineSnapshot(`
@@ -1642,13 +1610,12 @@ test('where exists', () => {
   `);
 
   consume(
-    issueLabelSource.push({
-      type: 'remove',
-      row: {
+    issueLabelSource.push(
+      makeSourceChangeRemove({
         issueId: '0002',
         labelId: '0001',
-      },
-    }),
+      }),
+    ),
   );
 
   expect(materialized.data).toEqual([]);
@@ -1661,17 +1628,16 @@ test("flipped exists, or'ed", () => {
   const issueSource = must(queryDelegate.getSource('issue'));
 
   consume(
-    issueSource.push({
-      type: 'add',
-      row: {
+    issueSource.push(
+      makeSourceChangeAdd({
         id: '0001',
         title: 'issue 1',
         description: 'description 1',
         closed: false,
         ownerId: '0001',
         createdAt: 10,
-      },
-    }),
+      }),
+    ),
   );
 
   const q = newQuery(schema, 'issue').where(({or, exists}) =>
@@ -1684,16 +1650,15 @@ test("flipped exists, or'ed", () => {
   const view = queryDelegate.materialize(q);
 
   consume(
-    commentSource.push({
-      type: 'add',
-      row: {
+    commentSource.push(
+      makeSourceChangeAdd({
         id: 'c1',
         issueId: '0001',
         authorId: 'a1',
         text: 'bug',
         createdAt: 1,
-      },
-    }),
+      }),
+    ),
   );
 
   // Symbol(rc) should be ONE
@@ -1715,23 +1680,24 @@ test("flipped exists, or'ed", () => {
   `);
 
   consume(
-    commentSource.push({
-      type: 'edit',
-      oldRow: {
-        id: 'c1',
-        issueId: '0001',
-        authorId: 'a1',
-        text: 'bug',
-        createdAt: 1,
-      },
-      row: {
-        id: 'c1',
-        issueId: '0001',
-        authorId: 'a2',
-        text: 'bug',
-        createdAt: 1,
-      },
-    }),
+    commentSource.push(
+      makeSourceChangeEdit(
+        {
+          id: 'c1',
+          issueId: '0001',
+          authorId: 'a2',
+          text: 'bug',
+          createdAt: 1,
+        },
+        {
+          id: 'c1',
+          issueId: '0001',
+          authorId: 'a1',
+          text: 'bug',
+          createdAt: 1,
+        },
+      ),
+    ),
   );
 
   expect(view.data).toMatchInlineSnapshot(`
@@ -1749,16 +1715,15 @@ test("flipped exists, or'ed", () => {
   `);
 
   consume(
-    commentSource.push({
-      type: 'remove',
-      row: {
+    commentSource.push(
+      makeSourceChangeRemove({
         id: 'c1',
         issueId: '0001',
         authorId: 'a1',
         text: 'bug',
         createdAt: 1,
-      },
-    }),
+      }),
+    ),
   );
 
   // should have retracted once, without error
@@ -1766,38 +1731,38 @@ test("flipped exists, or'ed", () => {
 
   // will not match the filter
   consume(
-    commentSource.push({
-      type: 'add',
-      row: {
+    commentSource.push(
+      makeSourceChangeAdd({
         id: 'c1',
         issueId: '0001',
         authorId: 'a1',
         text: 'not a bug',
         createdAt: 1,
-      },
-    }),
+      }),
+    ),
   );
 
   expect(view.data).toMatchInlineSnapshot(`[]`);
 
   consume(
-    commentSource.push({
-      type: 'edit',
-      oldRow: {
-        id: 'c1',
-        issueId: '0001',
-        authorId: 'a1',
-        text: 'not a bug',
-        createdAt: 1,
-      },
-      row: {
-        id: 'c1',
-        issueId: '0001',
-        authorId: 'a2',
-        text: 'bug',
-        createdAt: 1,
-      },
-    }),
+    commentSource.push(
+      makeSourceChangeEdit(
+        {
+          id: 'c1',
+          issueId: '0001',
+          authorId: 'a2',
+          text: 'bug',
+          createdAt: 1,
+        },
+        {
+          id: 'c1',
+          issueId: '0001',
+          authorId: 'a1',
+          text: 'not a bug',
+          createdAt: 1,
+        },
+      ),
+    ),
   );
 
   expect(view.data.length).toBe(1);
@@ -1811,44 +1776,41 @@ test('broken flipped exists', async () => {
 
   // issue 1 will have comments
   consume(
-    issueSource.push({
-      type: 'add',
-      row: {
+    issueSource.push(
+      makeSourceChangeAdd({
         id: '0001',
         title: 'issue 1',
         description: 'description 1',
         closed: false,
         ownerId: '0001',
         createdAt: 10,
-      },
-    }),
+      }),
+    ),
   );
   // issue 2 will have no comments
   consume(
-    issueSource.push({
-      type: 'add',
-      row: {
+    issueSource.push(
+      makeSourceChangeAdd({
         id: '0002',
         title: 'issue 2',
         description: 'description 2',
         closed: false,
         ownerId: '0001',
         createdAt: 10,
-      },
-    }),
+      }),
+    ),
   );
 
   consume(
-    commentSource.push({
-      type: 'add',
-      row: {
+    commentSource.push(
+      makeSourceChangeAdd({
         id: 'c1',
         issueId: '0001',
         authorId: 'a1',
         text: 'not a bug',
         createdAt: 1,
-      },
-    }),
+      }),
+    ),
   );
 
   const flipQuery = newQuery(schema, 'issue').whereExists('comments', q =>
@@ -1878,39 +1840,36 @@ test('duplicative where exists', () => {
   const labelSource = must(queryDelegate.getSource('label'));
   const issueLabelSource = must(queryDelegate.getSource('issueLabel'));
   consume(
-    issueSource.push({
-      type: 'add',
-      row: {
+    issueSource.push(
+      makeSourceChangeAdd({
         id: '0001',
         title: 'issue 1',
         description: 'description 1',
         closed: false,
         ownerId: '0001',
         createdAt: 10,
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    issueSource.push({
-      type: 'add',
-      row: {
+    issueSource.push(
+      makeSourceChangeAdd({
         id: '0002',
         title: 'issue 2',
         description: 'description 2',
         closed: true,
         ownerId: '0002',
         createdAt: 20,
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    labelSource.push({
-      type: 'add',
-      row: {
+    labelSource.push(
+      makeSourceChangeAdd({
         id: '0001',
         name: 'bug',
-      },
-    }),
+      }),
+    ),
   );
 
   const materializedQuery2 = newQuery(schema, 'issue')
@@ -1924,13 +1883,12 @@ test('duplicative where exists', () => {
   expect(materialized.data).toEqual([]);
 
   consume(
-    issueLabelSource.push({
-      type: 'add',
-      row: {
+    issueLabelSource.push(
+      makeSourceChangeAdd({
         issueId: '0002',
         labelId: '0001',
-      },
-    }),
+      }),
+    ),
   );
 
   expect(materialized.data).toMatchInlineSnapshot(`
@@ -1955,13 +1913,12 @@ test('duplicative where exists', () => {
   `);
 
   consume(
-    issueLabelSource.push({
-      type: 'remove',
-      row: {
+    issueLabelSource.push(
+      makeSourceChangeRemove({
         issueId: '0002',
         labelId: '0001',
-      },
-    }),
+      }),
+    ),
   );
 
   expect(materialized.data).toEqual([]);
@@ -1979,17 +1936,16 @@ test('where exists before where, see https://bugs.rocicorp.dev/issue/3417', () =
 
   // push a row that does not match the where filter
   consume(
-    issueSource.push({
-      type: 'add',
-      row: {
+    issueSource.push(
+      makeSourceChangeAdd({
         id: '0001',
         title: 'issue 1',
         description: 'description 1',
         closed: false,
         ownerId: '0001',
         createdAt: 10,
-      },
-    }),
+      }),
+    ),
   );
 
   expect(materialized.data).toEqual([]);

--- a/packages/zqlite/src/query.test.ts
+++ b/packages/zqlite/src/query.test.ts
@@ -2,6 +2,10 @@ import {beforeEach, expect, expectTypeOf, test} from 'vitest';
 import {testLogConfig} from '../../otel/src/test-log-config.ts';
 import {createSilentLogContext} from '../../shared/src/logging-test-utils.ts';
 import {must} from '../../shared/src/must.ts';
+import {
+  makeSourceChangeAdd,
+  makeSourceChangeRemove,
+} from '../../zql/src/ivm/source.ts';
 import {consume} from '../../zql/src/ivm/stream.ts';
 import type {QueryDelegate} from '../../zql/src/query/query-delegate.ts';
 import {newQuery} from '../../zql/src/query/query-impl.ts';
@@ -25,22 +29,20 @@ beforeEach(() => {
   const labelSource = must(queryDelegate.getSource('label'));
 
   consume(
-    userSource.push({
-      type: 'add',
-      row: {
+    userSource.push(
+      makeSourceChangeAdd({
         id: '0001',
         name: 'Alice',
         metadata: JSON.stringify({
           registrar: 'github',
           login: 'alicegh',
         }),
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    userSource.push({
-      type: 'add',
-      row: {
+    userSource.push(
+      makeSourceChangeAdd({
         id: '0002',
         name: 'Bob',
         metadata: JSON.stringify({
@@ -48,54 +50,50 @@ beforeEach(() => {
           login: 'bob@gmail.com',
           altContacts: ['bobwave', 'bobyt', 'bobplus'],
         }),
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    issueSource.push({
-      type: 'add',
-      row: {
+    issueSource.push(
+      makeSourceChangeAdd({
         id: '0001',
         title: 'issue 1',
         description: 'description 1',
         closed: false,
         owner_id: '0001',
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    issueSource.push({
-      type: 'add',
-      row: {
+    issueSource.push(
+      makeSourceChangeAdd({
         id: '0002',
         title: 'issue 2',
         description: 'description 2',
         closed: false,
         owner_id: '0002',
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    issueSource.push({
-      type: 'add',
-      row: {
+    issueSource.push(
+      makeSourceChangeAdd({
         id: '0003',
         title: 'issue 3',
         description: 'description 3',
         closed: false,
         owner_id: null,
-      },
-    }),
+      }),
+    ),
   );
 
   consume(
-    labelSource.push({
-      type: 'add',
-      row: {
+    labelSource.push(
+      makeSourceChangeAdd({
         id: '0001',
         name: 'bug',
-      },
-    }),
+      }),
+    ),
   );
 });
 
@@ -245,13 +243,12 @@ test('where exists retracts when an edit causes a row to no longer match', () =>
 
   const labelSource = must(queryDelegate.getSource('issueLabel'));
   consume(
-    labelSource.push({
-      type: 'add',
-      row: {
+    labelSource.push(
+      makeSourceChangeAdd({
         issueId: '0001',
         labelId: '0001',
-      },
-    }),
+      }),
+    ),
   );
 
   expect(mapResultToClientNames(view.data, schema, 'issue'))
@@ -275,13 +272,12 @@ test('where exists retracts when an edit causes a row to no longer match', () =>
     `);
 
   consume(
-    labelSource.push({
-      type: 'remove',
-      row: {
+    labelSource.push(
+      makeSourceChangeRemove({
         issueId: '0001',
         labelId: '0001',
-      },
-    }),
+      }),
+    ),
   );
 
   expect(view.data).toMatchInlineSnapshot(`[]`);
@@ -292,39 +288,36 @@ test('schema applied `one`', async () => {
   const commentSource = must(queryDelegate.getSource('comments'));
   const revisionSource = must(queryDelegate.getSource('revision'));
   consume(
-    commentSource.push({
-      type: 'add',
-      row: {
+    commentSource.push(
+      makeSourceChangeAdd({
         id: '0001',
         authorId: '0001',
         issue_id: '0001',
         text: 'comment 1',
         createdAt: 1,
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    commentSource.push({
-      type: 'add',
-      row: {
+    commentSource.push(
+      makeSourceChangeAdd({
         id: '0002',
         authorId: '0002',
         issue_id: '0001',
         text: 'comment 2',
         createdAt: 2,
-      },
-    }),
+      }),
+    ),
   );
   consume(
-    revisionSource.push({
-      type: 'add',
-      row: {
+    revisionSource.push(
+      makeSourceChangeAdd({
         id: '0001',
         authorId: '0001',
         commentId: '0001',
         text: 'revision 1',
-      },
-    }),
+      }),
+    ),
   );
   const query = newQuery(schema, 'issue')
     .related('owner')

--- a/packages/zqlite/src/table-source.test.ts
+++ b/packages/zqlite/src/table-source.test.ts
@@ -19,6 +19,11 @@ import {Database, Statement} from './db.ts';
 import {format} from './internal/sql.ts';
 import {filtersToSQL} from './query-builder.ts';
 import {
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+  makeSourceChangeRemove,
+} from '../../zql/src/ivm/source.ts';
+import {
   fromSQLiteTypes,
   TableSource,
   UnsupportedValueError,
@@ -353,10 +358,9 @@ test('pushing values does the correct writes and outputs', () => {
      * 4. add a row that already exists throws
      */
     consume(
-      source.push({
-        type: 'add',
-        row: {a: 1, b: 2.123, c: false, d: 'json string'},
-      }),
+      source.push(
+        makeSourceChangeAdd({a: 1, b: 2.123, c: false, d: 'json string'}),
+      ),
     );
 
     expect(outputted.shift()).toEqual(
@@ -372,12 +376,7 @@ test('pushing values does the correct writes and outputs', () => {
     );
     expect(read.all()).toEqual([{a: 1, b: 2.123, c: 0, d: '"json string"'}]);
 
-    consume(
-      source.push({
-        type: 'remove',
-        row: {a: 1, b: 2.123},
-      }),
-    );
+    consume(source.push(makeSourceChangeRemove({a: 1, b: 2.123})));
 
     expect(outputted.shift()).toEqual(
       makeRemoveChange({
@@ -391,21 +390,11 @@ test('pushing values does the correct writes and outputs', () => {
     expect(read.all()).toEqual([]);
 
     expect(() => {
-      consume(
-        source.push({
-          type: 'remove',
-          row: {a: 1, b: 2.123},
-        }),
-      );
+      consume(source.push(makeSourceChangeRemove({a: 1, b: 2.123})));
     }).toThrow();
     expect(read.all()).toEqual([]);
 
-    consume(
-      source.push({
-        type: 'add',
-        row: {a: 1, b: 2.123, c: true, d: {}},
-      }),
-    );
+    consume(source.push(makeSourceChangeAdd({a: 1, b: 2.123, c: true, d: {}})));
 
     expect(outputted.shift()).toEqual(
       makeAddChange({
@@ -422,24 +411,20 @@ test('pushing values does the correct writes and outputs', () => {
 
     expect(() => {
       consume(
-        source.push({
-          type: 'add',
-          row: {a: 1, b: 2.123, c: true, d: null},
-        }),
+        source.push(makeSourceChangeAdd({a: 1, b: 2.123, c: true, d: null})),
       );
     }).toThrow();
 
     // bigint rows
     consume(
-      source.push({
-        type: 'add',
-        row: {
+      source.push(
+        makeSourceChangeAdd({
           a: BigInt(Number.MAX_SAFE_INTEGER),
           b: 3.456,
           c: true,
           d: [],
-        } as unknown as Row,
-      }),
+        } as unknown as Row),
+      ),
     );
 
     expect(outputted.shift()).toEqual(
@@ -461,28 +446,26 @@ test('pushing values does the correct writes and outputs', () => {
     ]);
 
     consume(
-      source.push({
-        type: 'add',
-        row: {
+      source.push(
+        makeSourceChangeAdd({
           a: BigInt(Number.MAX_SAFE_INTEGER) + 1n,
           b: 0,
           c: true,
           d: true,
-        } as unknown as Row,
-      }),
+        } as unknown as Row),
+      ),
     );
     outputted.shift();
 
     consume(
-      source.push({
-        type: 'add',
-        row: {
+      source.push(
+        makeSourceChangeAdd({
           a: 0,
           b: BigInt(Number.MIN_SAFE_INTEGER) - 1n,
           c: true,
           d: false,
-        } as unknown as Row,
-      }),
+        } as unknown as Row),
+      ),
     );
     outputted.shift();
 
@@ -506,36 +489,35 @@ test('pushing values does the correct writes and outputs', () => {
     read.safeIntegers(false);
 
     consume(
-      source.push({
-        type: 'remove',
-        row: {
+      source.push(
+        makeSourceChangeRemove({
           a: BigInt(Number.MAX_SAFE_INTEGER) + 1n,
           b: 0,
           c: true,
-        } as unknown as Row,
-      }),
+        } as unknown as Row),
+      ),
     );
     outputted.shift();
 
     consume(
-      source.push({
-        type: 'remove',
-        row: {
+      source.push(
+        makeSourceChangeRemove({
           a: 0,
           b: BigInt(Number.MIN_SAFE_INTEGER) - 1n,
           c: true,
-        } as unknown as Row,
-      }),
+        } as unknown as Row),
+      ),
     );
     outputted.shift();
 
     // edit changes
     consume(
-      source.push({
-        type: 'edit',
-        row: {a: 1, b: 2.123, c: false, d: {a: true}} as unknown as Row,
-        oldRow: {a: 1, b: 2.123, c: true, d: {}} as unknown as Row,
-      }),
+      source.push(
+        makeSourceChangeEdit(
+          {a: 1, b: 2.123, c: false, d: {a: true}} as unknown as Row,
+          {a: 1, b: 2.123, c: true, d: {}} as unknown as Row,
+        ),
+      ),
     );
 
     expect(outputted.shift()).toEqual(
@@ -552,11 +534,12 @@ test('pushing values does the correct writes and outputs', () => {
 
     // edit pk should fall back to remove and insert
     consume(
-      source.push({
-        type: 'edit',
-        oldRow: {a: 1, b: 2.123, c: false, d: {a: true}},
-        row: {a: 1, b: 3, c: false, d: {a: true}},
-      }),
+      source.push(
+        makeSourceChangeEdit(
+          {a: 1, b: 3, c: false, d: {a: true}},
+          {a: 1, b: 2.123, c: false, d: {a: true}},
+        ),
+      ),
     );
     expect(outputted.shift()).toEqual(
       makeEditChange(
@@ -575,11 +558,12 @@ test('pushing values does the correct writes and outputs', () => {
     // non existing old row
     expect(() => {
       consume(
-        source.push({
-          type: 'edit',
-          row: {a: 11, b: 2.123, c: 0},
-          oldRow: {a: 12, b: 2.123, c: 1},
-        }),
+        source.push(
+          makeSourceChangeEdit(
+            {a: 11, b: 2.123, c: 0},
+            {a: 12, b: 2.123, c: 1},
+          ),
+        ),
       );
     }).toThrow('Row not found');
   }

--- a/packages/zqlite/src/table-source.test.ts
+++ b/packages/zqlite/src/table-source.test.ts
@@ -7,7 +7,12 @@ import {must} from '../../shared/src/must.ts';
 import type {Row, Value} from '../../zero-protocol/src/data.ts';
 import type {DebugDelegate} from '../../zql/src/builder/debug-delegate.ts';
 import {Catch} from '../../zql/src/ivm/catch.ts';
-import type {Change} from '../../zql/src/ivm/change.ts';
+import {
+  makeAddChange,
+  makeEditChange,
+  makeRemoveChange,
+  type Change,
+} from '../../zql/src/ivm/change.ts';
 import {makeComparator} from '../../zql/src/ivm/data.ts';
 import {consume} from '../../zql/src/ivm/stream.ts';
 import {Database, Statement} from './db.ts';
@@ -354,9 +359,8 @@ test('pushing values does the correct writes and outputs', () => {
       }),
     );
 
-    expect(outputted.shift()).toEqual({
-      type: 'add',
-      node: {
+    expect(outputted.shift()).toEqual(
+      makeAddChange({
         relationships: {},
         row: {
           a: 1,
@@ -364,8 +368,8 @@ test('pushing values does the correct writes and outputs', () => {
           c: false,
           d: 'json string',
         },
-      },
-    });
+      }),
+    );
     expect(read.all()).toEqual([{a: 1, b: 2.123, c: 0, d: '"json string"'}]);
 
     consume(
@@ -375,16 +379,15 @@ test('pushing values does the correct writes and outputs', () => {
       }),
     );
 
-    expect(outputted.shift()).toEqual({
-      type: 'remove',
-      node: {
+    expect(outputted.shift()).toEqual(
+      makeRemoveChange({
         relationships: {},
         row: {
           a: 1,
           b: 2.123,
         },
-      },
-    });
+      }),
+    );
     expect(read.all()).toEqual([]);
 
     expect(() => {
@@ -404,9 +407,8 @@ test('pushing values does the correct writes and outputs', () => {
       }),
     );
 
-    expect(outputted.shift()).toEqual({
-      type: 'add',
-      node: {
+    expect(outputted.shift()).toEqual(
+      makeAddChange({
         relationships: {},
         row: {
           a: 1,
@@ -414,8 +416,8 @@ test('pushing values does the correct writes and outputs', () => {
           c: true,
           d: {},
         },
-      },
-    });
+      }),
+    );
     expect(read.all()).toEqual([{a: 1, b: 2.123, c: 1, d: '{}'}]);
 
     expect(() => {
@@ -440,9 +442,8 @@ test('pushing values does the correct writes and outputs', () => {
       }),
     );
 
-    expect(outputted.shift()).toEqual({
-      type: 'add',
-      node: {
+    expect(outputted.shift()).toEqual(
+      makeAddChange({
         relationships: {},
         row: {
           a: 9007199254740991n,
@@ -450,8 +451,8 @@ test('pushing values does the correct writes and outputs', () => {
           c: true,
           d: [],
         },
-      },
-    });
+      }),
+    );
 
     expect(read.all()).toEqual([
       {a: 1, b: 2.123, c: 1, d: '{}'},
@@ -536,11 +537,12 @@ test('pushing values does the correct writes and outputs', () => {
       }),
     );
 
-    expect(outputted.shift()).toEqual({
-      type: 'edit',
-      oldNode: {row: {a: 1, b: 2.123, c: true, d: {}}, relationships: {}},
-      node: {row: {a: 1, b: 2.123, c: false, d: {a: true}}, relationships: {}},
-    });
+    expect(outputted.shift()).toEqual(
+      makeEditChange(
+        {row: {a: 1, b: 2.123, c: false, d: {a: true}}, relationships: {}},
+        {row: {a: 1, b: 2.123, c: true, d: {}}, relationships: {}},
+      ),
+    );
 
     expect(read.all()).toEqual([
       {a: 1, b: 2.123, c: 0, d: '{"a":true}'},
@@ -555,14 +557,15 @@ test('pushing values does the correct writes and outputs', () => {
         row: {a: 1, b: 3, c: false, d: {a: true}},
       }),
     );
-    expect(outputted.shift()).toEqual({
-      type: 'edit',
-      oldNode: {
-        row: {a: 1, b: 2.123, c: false, d: {a: true}},
-        relationships: {},
-      },
-      node: {row: {a: 1, b: 3, c: false, d: {a: true}}, relationships: {}},
-    });
+    expect(outputted.shift()).toEqual(
+      makeEditChange(
+        {row: {a: 1, b: 3, c: false, d: {a: true}}, relationships: {}},
+        {
+          row: {a: 1, b: 2.123, c: false, d: {a: true}},
+          relationships: {},
+        },
+      ),
+    );
     expect(read.all()).toEqual([
       {a: 9007199254740991, b: 3.456, c: 1, d: '[]'},
       {a: 1, b: 3, c: 0, d: '{"a":true}'},

--- a/packages/zqlite/src/table-source.test.ts
+++ b/packages/zqlite/src/table-source.test.ts
@@ -14,15 +14,15 @@ import {
   type Change,
 } from '../../zql/src/ivm/change.ts';
 import {makeComparator} from '../../zql/src/ivm/data.ts';
-import {consume} from '../../zql/src/ivm/stream.ts';
-import {Database, Statement} from './db.ts';
-import {format} from './internal/sql.ts';
-import {filtersToSQL} from './query-builder.ts';
 import {
   makeSourceChangeAdd,
   makeSourceChangeEdit,
   makeSourceChangeRemove,
 } from '../../zql/src/ivm/source.ts';
+import {consume} from '../../zql/src/ivm/stream.ts';
+import {Database, Statement} from './db.ts';
+import {format} from './internal/sql.ts';
+import {filtersToSQL} from './query-builder.ts';
 import {
   fromSQLiteTypes,
   TableSource,

--- a/packages/zqlite/src/table-source.test.ts
+++ b/packages/zqlite/src/table-source.test.ts
@@ -446,7 +446,8 @@ test('pushing values does the correct writes and outputs', () => {
       makeAddChange({
         relationships: {},
         row: {
-          a: 9007199254740991n,
+          // TODO(arv): Fix Row type!!!
+          a: 9007199254740991n as unknown as number,
           b: 3.456,
           c: true,
           d: [],

--- a/packages/zqlite/src/table-source.ts
+++ b/packages/zqlite/src/table-source.ts
@@ -18,6 +18,7 @@ import {
   createPredicate,
   transformFilters,
 } from '../../zql/src/builder/filter.ts';
+import {ChangeType} from '../../zql/src/ivm/change-type.ts';
 import {makeComparator, type Node} from '../../zql/src/ivm/data.ts';
 import {
   generateWithOverlay,
@@ -29,6 +30,7 @@ import {
 } from '../../zql/src/ivm/memory-source.ts';
 import {type FetchRequest} from '../../zql/src/ivm/operator.ts';
 import type {SourceSchema} from '../../zql/src/ivm/schema.ts';
+import {SourceChangeIndex} from '../../zql/src/ivm/source-change-index.ts';
 import {
   type Source,
   type SourceChange,
@@ -412,34 +414,39 @@ export class TableSource implements Source {
   }
 
   #writeChange(change: SourceChange) {
-    switch (change.type) {
-      case 'add':
+    switch (change[SourceChangeIndex.TYPE]) {
+      case ChangeType.ADD:
         this.#stmts.insert.run(
           ...toSQLiteTypes(
+            // TODO(arv): Compute this once!
             Object.keys(this.#columns),
-            change.row,
+            change[SourceChangeIndex.ROW],
             this.#columns,
           ),
         );
         break;
-      case 'remove':
+      case ChangeType.REMOVE:
         this.#stmts.delete.run(
-          ...toSQLiteTypes(this.#primaryKey, change.row, this.#columns),
+          ...toSQLiteTypes(
+            this.#primaryKey,
+            change[SourceChangeIndex.ROW],
+            this.#columns,
+          ),
         );
         break;
-      case 'edit': {
+      case ChangeType.EDIT: {
         // If the PK is the same, use UPDATE.
         if (
           canUseUpdate(
-            change.oldRow,
-            change.row,
+            change[SourceChangeIndex.OLD_ROW],
+            change[SourceChangeIndex.ROW],
             this.#columns,
             this.#primaryKey,
           )
         ) {
           const mergedRow = {
-            ...change.oldRow,
-            ...change.row,
+            ...change[SourceChangeIndex.OLD_ROW],
+            ...change[SourceChangeIndex.ROW],
           };
           const params = [
             ...nonPrimaryValues(this.#columns, this.#primaryKey, mergedRow),
@@ -448,12 +455,16 @@ export class TableSource implements Source {
           must(this.#stmts.update).run(params);
         } else {
           this.#stmts.delete.run(
-            ...toSQLiteTypes(this.#primaryKey, change.oldRow, this.#columns),
+            ...toSQLiteTypes(
+              this.#primaryKey,
+              change[SourceChangeIndex.OLD_ROW],
+              this.#columns,
+            ),
           );
           this.#stmts.insert.run(
             ...toSQLiteTypes(
               Object.keys(this.#columns),
-              change.row,
+              change[SourceChangeIndex.ROW],
               this.#columns,
             ),
           );


### PR DESCRIPTION
# refactor(zql): Change from object union to monomorphic tuple

```ts
{type: 'add', node: Node}
{type: 'remove', node: Node}
{type: 'child', node: Node, child: ChildData}
{type: 'edit', node: Node, oldNode: Node}
```

to a monomorphic 3-tuple:

```ts
[ChangeType.Add /* SMI */, Node, null]
[ChangeType.Remove /* SMI */, Node, null]
[ChangeType.Child /* SMI */, Node, ChildData]
[ChangeType.Edit /* SMI */, Node, Node]
```

Motivation
---

The previous object union was **polymorphic** — each variant has a different shape, so V8 must track multiple hidden classes at every callsite that touches a `Change`. Polymorphic IC (inline cache) misses are expensive in hot IVM push paths.

The tuple form is **monomorphic**: every `Change` is an array of the same length with the same element types at each index, so V8 can compile a single fast path.

Switching the discriminant from a string to an SMI also helps: SMIs are stack-allocated and compared by value; strings are heap-allocated and compared by hash.

Performance
---

5×5 runs on `main` vs this branch, `NODE_OPTIONS=--expose-gc` + `inner_gc: true`, metric: median-of-5 `min`.

| Benchmark | main | branch | Δ |
|---|--:|--:|--:|
| **IVM push / edit** | | | |
| zql: edit for limited query, inside bound | 7.8 µs | 6.4 µs | **−18%** |
| MemorySource push: edit 1 000 rows, sort 4 keys | 13.7 µs | 11.2 µs | **−18%** |
| push: add issue (no join) | 33.3 µs | 27.5 µs | **−18%** |
| Filter: push add open issue (passes filter) | 7.5 µs | 6.8 µs | **−9%** |
| Join: push edit issue title | 12.2 µs | 10.4 µs | **−15%** |
| Join: push add/remove issue with owner | 18.5 µs | 17.9 µs | **−3%** |
| zql: push into limited query, inside bound | 131 µs | 115 µs | **−13%** |
| **Fetch / hydration** | | | |
| Join: fetch 1 000 issues → 20 users | 2.47 ms | 2.07 ms | **−16%** |
| MemorySource fetch: scan 1 000 rows, sort 1 key | 390 µs | 336 µs | **−14%** |
| MemorySource fetch: scan 1 000 rows, sort 4 keys | 379 µs | 323 µs | **−15%** |
| hydrate: issues with creator + comments | 4.51 ms | 3.96 ms | **−12%** |
| hydrate: issues limit 50 | 250 µs | 221 µs | **−12%** |
| **Full query (Chinook)** | | | |
| tracks with artist name (not flipped) | 111.6 ms | 98.0 ms | **−12%** |
| zqlite: all playlists | 1 093 ms | 996 ms | **−9%** |
