### PR TITLE
Nullable Array column "null" value handling

### DIFF
--- a/packages/z2s/src/compiler.output.test.ts
+++ b/packages/z2s/src/compiler.output.test.ts
@@ -413,7 +413,7 @@ test('compile with timestamp (with timezone)', () => {
     {
       "text": "SELECT 
         COALESCE(json_agg(row_to_json("zql_root")), '[]'::json)::text AS "zql_result"
-        FROM (SELECT "timestampsTable_0"."id" as "id",((EXTRACT(EPOCH FROM "timestampsTable_0"."timestampWithTz") * 1000)::bigint + 86400000) % 86400000 as "timestampWithTz",ARRAY(SELECT ((EXTRACT(EPOCH FROM unnest("timestampsTable_0"."timestampWithTzArray")) * 1000)::bigint + 86400000) % 86400000) as "timestampWithTzArray",EXTRACT(EPOCH FROM "timestampsTable_0"."timestampWithoutTz") * 1000 as "timestampWithoutTz",ARRAY(SELECT EXTRACT(EPOCH FROM unnest("timestampsTable_0"."timestampWithoutTzArray")) * 1000) as "timestampWithoutTzArray"
+        FROM (SELECT "timestampsTable_0"."id" as "id",((EXTRACT(EPOCH FROM "timestampsTable_0"."timestampWithTz") * 1000)::bigint + 86400000) % 86400000 as "timestampWithTz",CASE WHEN "timestampsTable_0"."timestampWithTzArray" IS NULL THEN NULL ELSE ARRAY(SELECT ((EXTRACT(EPOCH FROM unnest("timestampsTable_0"."timestampWithTzArray")) * 1000)::bigint + 86400000) % 86400000) END as "timestampWithTzArray",EXTRACT(EPOCH FROM "timestampsTable_0"."timestampWithoutTz") * 1000 as "timestampWithoutTz",CASE WHEN "timestampsTable_0"."timestampWithoutTzArray" IS NULL THEN NULL ELSE ARRAY(SELECT EXTRACT(EPOCH FROM unnest("timestampsTable_0"."timestampWithoutTzArray")) * 1000) END as "timestampWithoutTzArray"
         FROM "timestampsTable" AS "timestampsTable_0"
         WHERE "timestampsTable_0"."timestampWithTz" = to_timestamp($1::text::numeric / 1000.0)
          
@@ -444,7 +444,7 @@ test('compile with timestamp array (with timezone)', () => {
     {
       "text": "SELECT 
         COALESCE(json_agg(row_to_json("zql_root")), '[]'::json)::text AS "zql_result"
-        FROM (SELECT "timestampsTable_0"."id" as "id",((EXTRACT(EPOCH FROM "timestampsTable_0"."timestampWithTz") * 1000)::bigint + 86400000) % 86400000 as "timestampWithTz",ARRAY(SELECT ((EXTRACT(EPOCH FROM unnest("timestampsTable_0"."timestampWithTzArray")) * 1000)::bigint + 86400000) % 86400000) as "timestampWithTzArray",EXTRACT(EPOCH FROM "timestampsTable_0"."timestampWithoutTz") * 1000 as "timestampWithoutTz",ARRAY(SELECT EXTRACT(EPOCH FROM unnest("timestampsTable_0"."timestampWithoutTzArray")) * 1000) as "timestampWithoutTzArray"
+        FROM (SELECT "timestampsTable_0"."id" as "id",((EXTRACT(EPOCH FROM "timestampsTable_0"."timestampWithTz") * 1000)::bigint + 86400000) % 86400000 as "timestampWithTz",CASE WHEN "timestampsTable_0"."timestampWithTzArray" IS NULL THEN NULL ELSE ARRAY(SELECT ((EXTRACT(EPOCH FROM unnest("timestampsTable_0"."timestampWithTzArray")) * 1000)::bigint + 86400000) % 86400000) END as "timestampWithTzArray",EXTRACT(EPOCH FROM "timestampsTable_0"."timestampWithoutTz") * 1000 as "timestampWithoutTz",CASE WHEN "timestampsTable_0"."timestampWithoutTzArray" IS NULL THEN NULL ELSE ARRAY(SELECT EXTRACT(EPOCH FROM unnest("timestampsTable_0"."timestampWithoutTzArray")) * 1000) END as "timestampWithoutTzArray"
         FROM "timestampsTable" AS "timestampsTable_0"
         WHERE "timestampsTable_0"."timestampWithTzArray" = ARRAY(
               SELECT to_timestamp(value::text::numeric / 1000.0) FROM jsonb_array_elements_text($1::text::jsonb)
@@ -477,7 +477,7 @@ test('compile with timestamp (without timezone)', () => {
     {
       "text": "SELECT 
         COALESCE(json_agg(row_to_json("zql_root")), '[]'::json)::text AS "zql_result"
-        FROM (SELECT "timestampsTable_0"."id" as "id",((EXTRACT(EPOCH FROM "timestampsTable_0"."timestampWithTz") * 1000)::bigint + 86400000) % 86400000 as "timestampWithTz",ARRAY(SELECT ((EXTRACT(EPOCH FROM unnest("timestampsTable_0"."timestampWithTzArray")) * 1000)::bigint + 86400000) % 86400000) as "timestampWithTzArray",EXTRACT(EPOCH FROM "timestampsTable_0"."timestampWithoutTz") * 1000 as "timestampWithoutTz",ARRAY(SELECT EXTRACT(EPOCH FROM unnest("timestampsTable_0"."timestampWithoutTzArray")) * 1000) as "timestampWithoutTzArray"
+        FROM (SELECT "timestampsTable_0"."id" as "id",((EXTRACT(EPOCH FROM "timestampsTable_0"."timestampWithTz") * 1000)::bigint + 86400000) % 86400000 as "timestampWithTz",CASE WHEN "timestampsTable_0"."timestampWithTzArray" IS NULL THEN NULL ELSE ARRAY(SELECT ((EXTRACT(EPOCH FROM unnest("timestampsTable_0"."timestampWithTzArray")) * 1000)::bigint + 86400000) % 86400000) END as "timestampWithTzArray",EXTRACT(EPOCH FROM "timestampsTable_0"."timestampWithoutTz") * 1000 as "timestampWithoutTz",CASE WHEN "timestampsTable_0"."timestampWithoutTzArray" IS NULL THEN NULL ELSE ARRAY(SELECT EXTRACT(EPOCH FROM unnest("timestampsTable_0"."timestampWithoutTzArray")) * 1000) END as "timestampWithoutTzArray"
         FROM "timestampsTable" AS "timestampsTable_0"
         WHERE "timestampsTable_0"."timestampWithoutTz" = to_timestamp($1::text::numeric / 1000.0) AT TIME ZONE 'UTC'
          
@@ -508,7 +508,7 @@ test('compile with timestamp (without timezone) array', () => {
     {
       "text": "SELECT 
         COALESCE(json_agg(row_to_json("zql_root")), '[]'::json)::text AS "zql_result"
-        FROM (SELECT "timestampsTable_0"."id" as "id",((EXTRACT(EPOCH FROM "timestampsTable_0"."timestampWithTz") * 1000)::bigint + 86400000) % 86400000 as "timestampWithTz",ARRAY(SELECT ((EXTRACT(EPOCH FROM unnest("timestampsTable_0"."timestampWithTzArray")) * 1000)::bigint + 86400000) % 86400000) as "timestampWithTzArray",EXTRACT(EPOCH FROM "timestampsTable_0"."timestampWithoutTz") * 1000 as "timestampWithoutTz",ARRAY(SELECT EXTRACT(EPOCH FROM unnest("timestampsTable_0"."timestampWithoutTzArray")) * 1000) as "timestampWithoutTzArray"
+        FROM (SELECT "timestampsTable_0"."id" as "id",((EXTRACT(EPOCH FROM "timestampsTable_0"."timestampWithTz") * 1000)::bigint + 86400000) % 86400000 as "timestampWithTz",CASE WHEN "timestampsTable_0"."timestampWithTzArray" IS NULL THEN NULL ELSE ARRAY(SELECT ((EXTRACT(EPOCH FROM unnest("timestampsTable_0"."timestampWithTzArray")) * 1000)::bigint + 86400000) % 86400000) END as "timestampWithTzArray",EXTRACT(EPOCH FROM "timestampsTable_0"."timestampWithoutTz") * 1000 as "timestampWithoutTz",CASE WHEN "timestampsTable_0"."timestampWithoutTzArray" IS NULL THEN NULL ELSE ARRAY(SELECT EXTRACT(EPOCH FROM unnest("timestampsTable_0"."timestampWithoutTzArray")) * 1000) END as "timestampWithoutTzArray"
         FROM "timestampsTable" AS "timestampsTable_0"
         WHERE "timestampsTable_0"."timestampWithoutTzArray" = ARRAY(
               SELECT to_timestamp(value::text::numeric / 1000.0) AT TIME ZONE 'UTC' FROM jsonb_array_elements_text($1::text::jsonb)
@@ -535,7 +535,7 @@ test('compile with time/timetz projects milliseconds', () => {
     {
       "text": "SELECT 
         COALESCE(json_agg(row_to_json("zql_root")), '[]'::json)::text AS "zql_result"
-        FROM (SELECT "timesTable_0"."id" as "id",((EXTRACT(EPOCH FROM "timesTable_0"."timeWithTz") * 1000)::bigint + 86400000) % 86400000 as "timeWithTz",ARRAY(SELECT ((EXTRACT(EPOCH FROM unnest("timesTable_0"."timeWithTzArray")) * 1000)::bigint + 86400000) % 86400000) as "timeWithTzArray",EXTRACT(EPOCH FROM "timesTable_0"."timeWithoutTz") * 1000 as "timeWithoutTz",ARRAY(SELECT EXTRACT(EPOCH FROM unnest("timesTable_0"."timeWithoutTzArray")) * 1000) as "timeWithoutTzArray"
+        FROM (SELECT "timesTable_0"."id" as "id",((EXTRACT(EPOCH FROM "timesTable_0"."timeWithTz") * 1000)::bigint + 86400000) % 86400000 as "timeWithTz",CASE WHEN "timesTable_0"."timeWithTzArray" IS NULL THEN NULL ELSE ARRAY(SELECT ((EXTRACT(EPOCH FROM unnest("timesTable_0"."timeWithTzArray")) * 1000)::bigint + 86400000) % 86400000) END as "timeWithTzArray",EXTRACT(EPOCH FROM "timesTable_0"."timeWithoutTz") * 1000 as "timeWithoutTz",CASE WHEN "timesTable_0"."timeWithoutTzArray" IS NULL THEN NULL ELSE ARRAY(SELECT EXTRACT(EPOCH FROM unnest("timesTable_0"."timeWithoutTzArray")) * 1000) END as "timeWithoutTzArray"
         FROM "timesTable" AS "timesTable_0"
          
          

--- a/packages/z2s/src/compiler.pg.test.ts
+++ b/packages/z2s/src/compiler.pg.test.ts
@@ -26,10 +26,27 @@ const timesTable = table('timesTable')
       .from('nullable_time_without_tz_array'),
     timeWithTz: number().from('time_with_tz'),
     timeWithTzArray: json<number[]>().from('time_with_tz_array'),
+    nullableTimeWithTzArray: json<number[]>()
+      .optional()
+      .from('nullable_time_with_tz_array'),
   })
   .primaryKey('id');
 
-const schema = createSchema({tables: [timesTable]});
+const temporalsTable = table('temporalsTable')
+  .from('temporals')
+  .columns({
+    id: string(),
+    nullableDateArray: json<number[]>().optional().from('nullable_date_array'),
+    nullableTimestampArray: json<number[]>()
+      .optional()
+      .from('nullable_timestamp_array'),
+    nullableTimestamptzArray: json<number[]>()
+      .optional()
+      .from('nullable_timestamptz_array'),
+  })
+  .primaryKey('id');
+
+const schema = createSchema({tables: [timesTable, temporalsTable]});
 
 const serverSchema: ServerSchema = {
   times: {
@@ -43,6 +60,25 @@ const serverSchema: ServerSchema = {
     },
     time_with_tz: {type: 'timetz', isArray: false, isEnum: false},
     time_with_tz_array: {type: 'timetz', isArray: true, isEnum: false},
+    nullable_time_with_tz_array: {
+      type: 'timetz',
+      isArray: true,
+      isEnum: false,
+    },
+  },
+  temporals: {
+    id: {type: 'text', isArray: false, isEnum: false},
+    nullable_date_array: {type: 'date', isArray: true, isEnum: false},
+    nullable_timestamp_array: {
+      type: 'timestamp',
+      isArray: true,
+      isEnum: false,
+    },
+    nullable_timestamptz_array: {
+      type: 'timestamptz',
+      isArray: true,
+      isEnum: false,
+    },
   },
 };
 
@@ -59,7 +95,8 @@ describe('compiler with PostgreSQL', () => {
         time_without_tz_array TIME[] NOT NULL,
         nullable_time_without_tz_array TIME[],
         time_with_tz TIMETZ NOT NULL,
-        time_with_tz_array TIMETZ[] NOT NULL
+        time_with_tz_array TIMETZ[] NOT NULL,
+        nullable_time_with_tz_array TIMETZ[]
       );
 
       INSERT INTO times (
@@ -68,15 +105,26 @@ describe('compiler with PostgreSQL', () => {
         time_without_tz_array,
         nullable_time_without_tz_array,
         time_with_tz,
-        time_with_tz_array
+        time_with_tz_array,
+        nullable_time_with_tz_array
       ) VALUES (
         'row1',
         '09:08:07.654',
         ARRAY['09:08:07.654'::time, '00:00:00'::time],
         NULL,
         '01:00:00+02',
-        ARRAY['01:00:00+02'::timetz, '23:00:00-02'::timetz]
+        ARRAY['01:00:00+02'::timetz, '23:00:00-02'::timetz],
+        NULL
       );
+
+      CREATE TABLE temporals (
+        id TEXT PRIMARY KEY,
+        nullable_date_array DATE[],
+        nullable_timestamp_array TIMESTAMP[],
+        nullable_timestamptz_array TIMESTAMPTZ[]
+      );
+
+      INSERT INTO temporals (id) VALUES ('row1');
     `);
   });
 
@@ -92,7 +140,8 @@ describe('compiler with PostgreSQL', () => {
         time_without_tz_array AS "timeWithoutTzArray",
         nullable_time_without_tz_array AS "nullableTimeWithoutTzArray",
         time_with_tz AS "timeWithTz",
-        time_with_tz_array AS "timeWithTzArray"
+        time_with_tz_array AS "timeWithTzArray",
+        nullable_time_with_tz_array AS "nullableTimeWithTzArray"
       FROM times
       ORDER BY id
     `);
@@ -105,6 +154,7 @@ describe('compiler with PostgreSQL', () => {
         nullableTimeWithoutTzArray: null,
         timeWithTz: 82800000,
         timeWithTzArray: [82800000, 3600000],
+        nullableTimeWithTzArray: null,
       },
     ]);
 
@@ -120,5 +170,27 @@ describe('compiler with PostgreSQL', () => {
     );
 
     expect(compiled).toEqual(raw);
+  });
+
+  test('null date/timestamp/timestamptz arrays are preserved as null', async () => {
+    const sqlQuery = formatPgInternalConvert(
+      compile(serverSchema, schema, {
+        table: 'temporalsTable',
+        related: [],
+      }),
+    );
+
+    const compiled = extractZqlResult(
+      await pg.unsafe(sqlQuery.text, sqlQuery.values as JSONValue[]),
+    );
+
+    expect(compiled).toEqual([
+      {
+        id: 'row1',
+        nullableDateArray: null,
+        nullableTimestampArray: null,
+        nullableTimestamptzArray: null,
+      },
+    ]);
   });
 });

--- a/packages/z2s/src/compiler.pg.test.ts
+++ b/packages/z2s/src/compiler.pg.test.ts
@@ -21,6 +21,9 @@ const timesTable = table('timesTable')
     id: string(),
     timeWithoutTz: number().from('time_without_tz'),
     timeWithoutTzArray: json<number[]>().from('time_without_tz_array'),
+    nullableTimeWithoutTzArray: json<number[]>().optional().from(
+      'nullable_time_without_tz_array',
+    ),
     timeWithTz: number().from('time_with_tz'),
     timeWithTzArray: json<number[]>().from('time_with_tz_array'),
   })
@@ -33,6 +36,7 @@ const serverSchema: ServerSchema = {
     id: {type: 'text', isArray: false, isEnum: false},
     time_without_tz: {type: 'time', isArray: false, isEnum: false},
     time_without_tz_array: {type: 'time', isArray: true, isEnum: false},
+    nullable_time_without_tz_array: {type: 'time', isArray: true, isEnum: false},
     time_with_tz: {type: 'timetz', isArray: false, isEnum: false},
     time_with_tz_array: {type: 'timetz', isArray: true, isEnum: false},
   },
@@ -49,6 +53,7 @@ describe('compiler with PostgreSQL', () => {
         id TEXT PRIMARY KEY,
         time_without_tz TIME NOT NULL,
         time_without_tz_array TIME[] NOT NULL,
+        nullable_time_without_tz_array TIME[],
         time_with_tz TIMETZ NOT NULL,
         time_with_tz_array TIMETZ[] NOT NULL
       );
@@ -57,12 +62,14 @@ describe('compiler with PostgreSQL', () => {
         id,
         time_without_tz,
         time_without_tz_array,
+        nullable_time_without_tz_array,
         time_with_tz,
         time_with_tz_array
       ) VALUES (
         'row1',
         '09:08:07.654',
         ARRAY['09:08:07.654'::time, '00:00:00'::time],
+        NULL,
         '01:00:00+02',
         ARRAY['01:00:00+02'::timetz, '23:00:00-02'::timetz]
       );
@@ -79,6 +86,7 @@ describe('compiler with PostgreSQL', () => {
         id,
         time_without_tz AS "timeWithoutTz",
         time_without_tz_array AS "timeWithoutTzArray",
+        nullable_time_without_tz_array AS "nullableTimeWithoutTzArray",
         time_with_tz AS "timeWithTz",
         time_with_tz_array AS "timeWithTzArray"
       FROM times
@@ -90,6 +98,7 @@ describe('compiler with PostgreSQL', () => {
         id: 'row1',
         timeWithoutTz: 32887654,
         timeWithoutTzArray: [32887654, 0],
+        nullableTimeWithoutTzArray: null,
         timeWithTz: 82800000,
         timeWithTzArray: [82800000, 3600000],
       },
@@ -108,4 +117,5 @@ describe('compiler with PostgreSQL', () => {
 
     expect(compiled).toEqual(raw);
   });
+
 });

--- a/packages/z2s/src/compiler.pg.test.ts
+++ b/packages/z2s/src/compiler.pg.test.ts
@@ -21,9 +21,9 @@ const timesTable = table('timesTable')
     id: string(),
     timeWithoutTz: number().from('time_without_tz'),
     timeWithoutTzArray: json<number[]>().from('time_without_tz_array'),
-    nullableTimeWithoutTzArray: json<number[]>().optional().from(
-      'nullable_time_without_tz_array',
-    ),
+    nullableTimeWithoutTzArray: json<number[]>()
+      .optional()
+      .from('nullable_time_without_tz_array'),
     timeWithTz: number().from('time_with_tz'),
     timeWithTzArray: json<number[]>().from('time_with_tz_array'),
   })
@@ -36,7 +36,11 @@ const serverSchema: ServerSchema = {
     id: {type: 'text', isArray: false, isEnum: false},
     time_without_tz: {type: 'time', isArray: false, isEnum: false},
     time_without_tz_array: {type: 'time', isArray: true, isEnum: false},
-    nullable_time_without_tz_array: {type: 'time', isArray: true, isEnum: false},
+    nullable_time_without_tz_array: {
+      type: 'time',
+      isArray: true,
+      isEnum: false,
+    },
     time_with_tz: {type: 'timetz', isArray: false, isEnum: false},
     time_with_tz_array: {type: 'timetz', isArray: true, isEnum: false},
   },
@@ -117,5 +121,4 @@ describe('compiler with PostgreSQL', () => {
 
     expect(compiled).toEqual(raw);
   });
-
 });

--- a/packages/z2s/src/compiler.ts
+++ b/packages/z2s/src/compiler.ts
@@ -650,9 +650,10 @@ function selectIdent(server: ServerSpec, column: QualifiedColumn): SQLQuery {
             : epochExpr;
 
         if (serverColumnSchema.isArray) {
-          return sql`ARRAY(SELECT ${toMs(
-            sql`EXTRACT(EPOCH FROM unnest(${colIdent(server, column)})) * 1000`,
-          )}) as ${sql.ident(column.zql)}`;
+          const col = colIdent(server, column);
+          return sql`CASE WHEN ${col} IS NULL THEN NULL ELSE ARRAY(SELECT ${toMs(
+            sql`EXTRACT(EPOCH FROM unnest(${col})) * 1000`,
+          )}) END as ${sql.ident(column.zql)}`;
         }
 
         return sql`${toMs(

--- a/packages/z2s/src/sql.ts
+++ b/packages/z2s/src/sql.ts
@@ -172,6 +172,10 @@ function createPlaceholder(index: number, arg: SqlConvertArg) {
     return `$${index}`;
   }
 
+  if (arg.value === null && arg.plural) {
+    return `$${index}`;
+  }
+
   if (arg[sqlConvert] === 'literal') {
     const {value} = arg;
     if (Array.isArray(value)) {

--- a/packages/zero-server/src/custom.pg.test.ts
+++ b/packages/zero-server/src/custom.pg.test.ts
@@ -157,6 +157,31 @@ describe('makeSchemaCRUD', () => {
     });
   });
 
+  test('insert/update/upsert with nullable array columns preserves null', async () => {
+    await pg.begin(async tx => {
+      const transaction = new Transaction(tx);
+      const crud = crudProvider(
+        transaction,
+        await getServerSchema(transaction, schema),
+      );
+
+      await crud.arrayCases.insert({id: '1', tags: null});
+      await checkDb(tx, 'arrayCases', [{id: '1', tags: null}]);
+
+      await crud.arrayCases.update({id: '1', tags: ['a', 'b']});
+      await checkDb(tx, 'arrayCases', [{id: '1', tags: ['a', 'b']}]);
+
+      await crud.arrayCases.update({id: '1', tags: null});
+      await checkDb(tx, 'arrayCases', [{id: '1', tags: null}]);
+
+      await crud.arrayCases.upsert({id: '1', tags: ['c']});
+      await checkDb(tx, 'arrayCases', [{id: '1', tags: ['c']}]);
+
+      await crud.arrayCases.upsert({id: '1', tags: null});
+      await checkDb(tx, 'arrayCases', [{id: '1', tags: null}]);
+    });
+  });
+
   test('upsert', async () => {
     await pg.begin(async tx => {
       const transaction = new Transaction(tx);

--- a/packages/zero-server/src/test/schema.ts
+++ b/packages/zero-server/src/test/schema.ts
@@ -52,6 +52,12 @@ export const schema = createSchema({
         d: number(),
       })
       .primaryKey('ts'),
+    table('arrayCases')
+      .columns({
+        id: string(),
+        tags: json<string[]>().optional(),
+      })
+      .primaryKey('id'),
     table('jsonCases')
       .columns({
         ...jsonCols,
@@ -120,6 +126,11 @@ CREATE TABLE "dateTypes" (
   "tswotz" TIMESTAMP WITHOUT TIME ZONE,
   "d" DATE,
   PRIMARY KEY ("ts")
+);
+
+CREATE TABLE "arrayCases" (
+  "id" TEXT PRIMARY KEY,
+  "tags" TEXT[]
 );
 
 CREATE TABLE "jsonbCases" (

--- a/packages/zql-integration-tests/src/v20-array-style.test.ts
+++ b/packages/zql-integration-tests/src/v20-array-style.test.ts
@@ -72,3 +72,59 @@ test('reading from old array style tables', async () => {
     ]
   `);
 });
+
+test('nullable array columns preserve null vs empty array', async () => {
+  const lc = createSilentLogContext();
+  const sqlite = new Database(lc, ':memory:');
+  sqlite.exec(`CREATE TABLE "bar" (
+    "id" "int4|NOT_NULL",
+    "tags" "text[]",
+    "_0_version" "text",
+    primary key ("id")
+  );
+
+  INSERT INTO "bar" ("id", "tags", "_0_version") VALUES
+    (1, NULL, '4f58sg'),
+    (2, '[]', '4f58sg'),
+    (3, '["a", "b"]', '4f58sg');
+  `);
+
+  const schema = createSchema({
+    tables: [
+      table('bar')
+        .columns({
+          id: number(),
+          tags: json<string[]>().optional(),
+        })
+        .primaryKey('id'),
+    ],
+  });
+
+  const d = newQueryDelegate(lc, testLogConfig, sqlite, schema);
+  const queries = createBuilder(schema);
+
+  const rows = await d.run(queries.bar.orderBy('id', 'asc'));
+
+  expect(rows).toMatchInlineSnapshot(`
+    [
+      {
+        "id": 1,
+        "tags": null,
+        Symbol(rc): 1,
+      },
+      {
+        "id": 2,
+        "tags": [],
+        Symbol(rc): 1,
+      },
+      {
+        "id": 3,
+        "tags": [
+          "a",
+          "b",
+        ],
+        Symbol(rc): 1,
+      },
+    ]
+  `);
+});


### PR DESCRIPTION
Includes two fixes for nullable array columns :

- Preserve `NULL` for nullable array column writes instead of converting to `[]`
- Temporal nullable array columns no longer convert `NULL` to `[]` on reads
