### PR TITLE
fix(zero-cache): exit on SIGTERM (drain) signal if no workers have been started

### DIFF
--- a/packages/zero-cache/src/services/life-cycle.test.ts
+++ b/packages/zero-cache/src/services/life-cycle.test.ts
@@ -4,6 +4,7 @@ import {beforeEach, describe, expect, test} from 'vitest';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
 import {promiseVoid} from '../../../shared/src/resolved-promises.ts';
 import {
+  INTENTIONAL_SHUTDOWN_ERROR_CODE,
   ProcessManager,
   runUntilKilled,
   type WorkerType,
@@ -82,6 +83,24 @@ describe('shutdown', () => {
 
     await Promise.all(all.map(w => w.running.promise));
   });
+
+  test.each([
+    ['SIGTERM', 0],
+    ['SIGINT', 0],
+    ['SIGQUIT', INTENTIONAL_SHUTDOWN_ERROR_CODE],
+    ['SIGABRT', -1],
+  ])(
+    'shutdown before workers started: %s',
+    async (signal, expectedExitCode) => {
+      const {promise: exitCode, resolve} = resolver<number>();
+      proc = new EventEmitter();
+      proc.on('exit', resolve);
+
+      new ProcessManager(lc, proc);
+      proc.emit(signal);
+      expect(await exitCode).toBe(expectedExitCode);
+    },
+  );
 
   test.each([['SIGTERM'], ['SIGINT']])(
     'graceful shutdown: %s',

--- a/packages/zero-cache/src/services/life-cycle.ts
+++ b/packages/zero-cache/src/services/life-cycle.ts
@@ -39,7 +39,7 @@ export const UNHANDLED_EXCEPTION_ERROR_CODE = 13;
 // An internal error code used to indicate that the server should exit
 // without draining (e.g. due to a supporting worker get a signal to shut
 // down), but the exit is otherwise intentional.
-const INTENTIONAL_SHUTDOWN_ERROR_CODE = 14;
+export const INTENTIONAL_SHUTDOWN_ERROR_CODE = 14;
 
 /**
  * Handles readiness, termination signals, and coordination of graceful
@@ -110,6 +110,11 @@ export class ProcessManager {
   }
 
   #startDrain(signal: GracefulShutdownSignal) {
+    if (this.#all.size === 0) {
+      // Shutdown if a signal is received before any subprocesses are added.
+      this.#lc.info?.(`exiting on ${signal}`);
+      this.#exit(0);
+    }
     this.#lc.info?.(`initiating drain (${signal})`);
     this.#drainStart = Date.now();
     if (this.#userFacing.size) {


### PR DESCRIPTION
Server startup may take arbitrarily long (e.g. a large litestream restore), and the zero-cache should respond to drain signals when starting up. This reduces the chance of more servers running than what some of the code is built to assume.

Context:
* https://rocicorp.slack.com/archives/C0AK5KX8HGE/p1775852012306929