### PR TITLE
fix(zero-cache): use change-db to prevent change-log purges during replication-manager handoff

### DIFF
--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -41,6 +41,7 @@ export default async function runWorker(
   env: NodeJS.ProcessEnv,
   ...argv: string[]
 ): Promise<void> {
+  const workerStartTime = Date.now();
   const config = getNormalizedZeroConfig({env, argv});
   const {
     taskID,
@@ -84,15 +85,21 @@ export default async function runWorker(
   await initChangeStreamerSchema(lc, changeDB, shard);
   const purgeLock = await new PurgeLocker(lc, shard, changeDB).acquire();
 
-  let restoreStart = new Date();
   // Restore from litestream if the change-log has entries.
   if (purgeLock) {
+    let restored = false;
     try {
-      restoreStart = await restoreReplica(lc, config, purgeLock);
+      restored = await restoreReplica(lc, config, purgeLock);
     } catch (e) {
       // If the restore failed, e.g. due to a corrupt backup, the
       // replication-manager recovers by re-syncing.
       lc.error?.('error restoring backup. resyncing the replica.', e);
+    }
+    if (!restored) {
+      // The purgeLock must be released if the backup could not be restored,
+      // or it will otherwise prevent the change-db update after the resync
+      // completes.
+      await purgeLock.release();
     }
   }
 
@@ -191,7 +198,7 @@ export default async function runWorker(
         // generally takes longer).
         //
         // Consider: Also account for permanent volumes?
-        Date.now() - restoreStart.getTime(),
+        Date.now() - workerStartTime,
       )
     : new ReplicaMonitor(lc, replica.file, changeStreamer);
 

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -14,11 +14,14 @@ import {ChangeStreamerHttpServer} from '../services/change-streamer/change-strea
 import {initializeStreamer} from '../services/change-streamer/change-streamer-service.ts';
 import type {ChangeStreamerService} from '../services/change-streamer/change-streamer.ts';
 import {ReplicaMonitor} from '../services/change-streamer/replica-monitor.ts';
+import {initChangeStreamerSchema} from '../services/change-streamer/schema/init.ts';
 import {
   AutoResetSignal,
   CHANGE_STREAMER_APP_NAME,
 } from '../services/change-streamer/schema/tables.ts';
+import {PurgeLocker} from '../services/change-streamer/storer.ts';
 import {exitAfter, runUntilKilled} from '../services/life-cycle.ts';
+import {restoreReplica} from '../services/litestream/commands.ts';
 import {
   replicationStatusError,
   ReplicationStatusPublisher,
@@ -36,12 +39,9 @@ import {startOtelAuto} from './otel-start.ts';
 export default async function runWorker(
   parent: Worker,
   env: NodeJS.ProcessEnv,
-  ...args: string[]
+  ...argv: string[]
 ): Promise<void> {
-  assert(args.length > 0, `parent startMs not specified`);
-  const parentStartMs = parseInt(args[0]);
-
-  const config = getNormalizedZeroConfig({env, argv: args.slice(1)});
+  const config = getNormalizedZeroConfig({env, argv});
   const {
     taskID,
     changeStreamer: {
@@ -77,6 +77,24 @@ export default async function runWorker(
 
   const {autoReset, replicationLag} = config;
   const shard = getShardConfig(config);
+
+  // Ensure the change DB schema is initialized/up-to-date, then acquire
+  // a lock to prevent change-lock purges. This ensures that (this)
+  // change-streamer will be able to resume from the backup.
+  await initChangeStreamerSchema(lc, changeDB, shard);
+  const purgeLock = await new PurgeLocker(lc, shard, changeDB).acquire();
+
+  let restoreStart = new Date();
+  // Restore from litestream if the change-log has entries.
+  if (purgeLock) {
+    try {
+      restoreStart = await restoreReplica(lc, config, purgeLock);
+    } catch (e) {
+      // If the restore failed, e.g. due to a corrupt backup, the
+      // replication-manager recovers by re-syncing.
+      lc.error?.('error restoring backup. resyncing the replica.', e);
+    }
+  }
 
   let changeStreamer: ChangeStreamerService | undefined;
 
@@ -120,6 +138,7 @@ export default async function runWorker(
         changeSource,
         replicationStatusPublisher,
         subscriptionState,
+        purgeLock,
         autoReset ?? false,
         backPressureLimitHeapProportion,
         flowControlConsensusPaddingSeconds,
@@ -172,7 +191,7 @@ export default async function runWorker(
         // generally takes longer).
         //
         // Consider: Also account for permanent volumes?
-        Date.now() - parentStartMs,
+        Date.now() - restoreStart.getTime(),
       )
     : new ReplicaMonitor(lc, replica.file, changeStreamer);
 

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -21,7 +21,10 @@ import {
 } from '../services/change-streamer/schema/tables.ts';
 import {PurgeLocker} from '../services/change-streamer/storer.ts';
 import {exitAfter, runUntilKilled} from '../services/life-cycle.ts';
-import {restoreReplica} from '../services/litestream/commands.ts';
+import {
+  BackupNotFoundException,
+  restoreReplica,
+} from '../services/litestream/commands.ts';
 import {
   replicationStatusError,
   ReplicationStatusPublisher,
@@ -83,23 +86,26 @@ export default async function runWorker(
   // a lock to prevent change-lock purges. This ensures that (this)
   // change-streamer will be able to resume from the backup.
   await initChangeStreamerSchema(lc, changeDB, shard);
-  const purgeLock = await new PurgeLocker(lc, shard, changeDB).acquire();
+  let purgeLock = await new PurgeLocker(lc, shard, changeDB).acquire();
 
   // Restore from litestream if the change-log has entries.
   if (purgeLock) {
-    let restored = false;
     try {
-      restored = await restoreReplica(lc, config, purgeLock);
+      await restoreReplica(lc, config, purgeLock);
     } catch (e) {
-      // If the restore failed, e.g. due to a corrupt backup, the
+      // If the restore failed, e.g. due to a corrupt or missing backup, the
       // replication-manager recovers by re-syncing.
-      lc.error?.('error restoring backup. resyncing the replica.', e);
-    }
-    if (!restored) {
+      const log = e instanceof BackupNotFoundException ? 'warn' : 'error';
+      lc[log]?.(
+        `error restoring backup. resyncing the replica: ${String(e)}`,
+        e,
+      );
+
       // The purgeLock must be released if the backup could not be restored,
       // or it will otherwise prevent the change-db update after the resync
       // completes.
       await purgeLock.release();
+      purgeLock = null;
     }
   }
 

--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -94,71 +94,57 @@ export default async function runWorker(
   const runChangeStreamer =
     changeStreamerMode === 'dedicated' && changeStreamerURI === undefined;
 
-  let restoreStart = new Date();
-  if (litestream.backupURL || (litestream.executable && !runChangeStreamer)) {
-    try {
-      restoreStart = await restoreReplica(lc, config);
-    } catch (e) {
-      if (runChangeStreamer) {
-        // If the restore failed, e.g. due to a corrupt backup, the
-        // replication-manager recovers by re-syncing.
-        lc.error?.('error restoring backup. resyncing the replica.', e);
-      } else {
-        // View-syncers, on the other hand, have no option other than to retry
-        // until a valid backup has been published. This is achieved by
-        // shutting down and letting the container runner retry with its
-        // configured policy.
-        throw e;
-      }
+  let changeStreamer: Worker | undefined;
+
+  if (!runChangeStreamer) {
+    changeStreamer = undefined;
+    if (litestream.executable) {
+      // For view-syncers, the backup is restored here. For the replication-manager,
+      // the backup is restored in the change-streamer worker.
+      await restoreReplica(lc, config, null);
+    }
+  } else {
+    const {promise: changeStreamerReady, resolve: changeStreamerStarted} =
+      resolver();
+    changeStreamer = loadWorker(
+      CHANGE_STREAMER_URL,
+      'supporting',
+      undefined,
+    ).once('message', changeStreamerStarted);
+
+    // Wait for the change-streamer to be ready to guarantee that a replica
+    // file is present.
+    await changeStreamerReady;
+
+    if (litestream.backupURL) {
+      // Start a backup replicator and corresponding litestream backup process.
+      const {promise: backupReady, resolve} = resolver();
+      const mode: ReplicaFileMode = 'backup';
+      loadWorker(REPLICATOR_URL, 'supporting', mode, mode).once(
+        // Wait for the Replicator's first message (i.e. "ready") before starting
+        // litestream backup in order to avoid contending on the lock when the
+        // replicator first prepares the db file.
+        'message',
+        () => {
+          processes.addSubprocess(
+            startReplicaBackupProcess(lc, config),
+            'supporting',
+            'litestream',
+          );
+          resolve();
+        },
+      );
+      await backupReady;
     }
   }
 
-  const {promise: changeStreamerReady, resolve: changeStreamerStarted} =
-    resolver();
-  const changeStreamer = runChangeStreamer
-    ? loadWorker(
-        CHANGE_STREAMER_URL,
-        'supporting',
-        undefined,
-        String(restoreStart.getTime()),
-      ).once('message', changeStreamerStarted)
-    : (changeStreamerStarted() ?? undefined);
-
-  const {promise: reaperReady, resolve: reaperStarted} = resolver();
   if (numSyncers > 0) {
+    const {promise: reaperReady, resolve: reaperStarted} = resolver();
     loadWorker(REAPER_URL, 'supporting').once('message', reaperStarted);
-  } else {
-    reaperStarted();
+    // Before starting the view-syncers, ensure that the reaper has started
+    // up, indicating that any CVR db migrations have been performed.
+    await reaperReady;
   }
-
-  // Wait for the change-streamer to be ready to guarantee that a replica
-  // file is present.
-  await changeStreamerReady;
-
-  if (runChangeStreamer && litestream.backupURL) {
-    // Start a backup replicator and corresponding litestream backup process.
-    const {promise: backupReady, resolve} = resolver();
-    const mode: ReplicaFileMode = 'backup';
-    loadWorker(REPLICATOR_URL, 'supporting', mode, mode).once(
-      // Wait for the Replicator's first message (i.e. "ready") before starting
-      // litestream backup in order to avoid contending on the lock when the
-      // replicator first prepares the db file.
-      'message',
-      () => {
-        processes.addSubprocess(
-          startReplicaBackupProcess(lc, config),
-          'supporting',
-          'litestream',
-        );
-        resolve();
-      },
-    );
-    await backupReady;
-  }
-
-  // Before starting the view-syncers, ensure that the reaper has started
-  // up, indicating that any CVR db migrations have been performed.
-  await reaperReady;
 
   const syncers: Worker[] = [];
   if (numSyncers) {

--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -106,11 +106,10 @@ export default async function runWorker(
   } else {
     const {promise: changeStreamerReady, resolve: changeStreamerStarted} =
       resolver();
-    changeStreamer = loadWorker(
-      CHANGE_STREAMER_URL,
-      'supporting',
-      undefined,
-    ).once('message', changeStreamerStarted);
+    changeStreamer = loadWorker(CHANGE_STREAMER_URL, 'supporting').once(
+      'message',
+      changeStreamerStarted,
+    );
 
     // Wait for the change-streamer to be ready to guarantee that a replica
     // file is present.

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -1,5 +1,7 @@
+import {PG_LOCK_NOT_AVAILABLE} from '@drdgvhbh/postgres-error-codes';
 import type {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
+import postgres from 'postgres';
 import {beforeEach, describe, expect, vi, type Mock} from 'vitest';
 import {AbortError} from '../../../../shared/src/abort-error.ts';
 import {assert} from '../../../../shared/src/asserts.ts';
@@ -31,6 +33,7 @@ import {
 } from './change-streamer.ts';
 import * as ErrorType from './error-type-enum.ts';
 import {AutoResetSignal, ensureReplicationConfig} from './schema/tables.ts';
+import {PurgeLocker} from './storer.ts';
 
 describe('change-streamer/service', () => {
   let lc: LogContext;
@@ -82,6 +85,7 @@ describe('change-streamer/service', () => {
       },
       ReplicationStatusPublisher.forTesting(),
       replicaConfig,
+      null,
       true,
       0.04,
       1,
@@ -953,6 +957,7 @@ describe('change-streamer/service', () => {
       source,
       ReplicationStatusPublisher.forTesting(),
       replicaConfig,
+      null,
       true,
       0.04,
       1,
@@ -982,6 +987,7 @@ describe('change-streamer/service', () => {
       source,
       ReplicationStatusPublisher.forTesting(),
       replicaConfig,
+      null,
       true,
       0.04,
       1,
@@ -1006,6 +1012,7 @@ describe('change-streamer/service', () => {
       source,
       ReplicationStatusPublisher.forTesting(),
       replicaConfig,
+      null,
       true,
       0.04,
       1,
@@ -1013,6 +1020,48 @@ describe('change-streamer/service', () => {
     void streamer.run();
 
     expect(await requests.dequeue()).toBe('04');
+  });
+
+  test('initial purge lock released', async () => {
+    const purgeLocker = new PurgeLocker(lc, shard, sql);
+    const lock = await purgeLocker.acquire();
+    expect(lock?.minWatermark).toBe('01');
+
+    let locked: unknown;
+    try {
+      // Verify that the row is locked.
+      await sql`SELECT FROM "zoro_3/cdc"."changeLog" FOR UPDATE NOWAIT`;
+    } catch (e) {
+      locked = e;
+    }
+    expect(locked).toBeInstanceOf(postgres.PostgresError);
+    expect((locked as postgres.PostgresError).code).toBe(PG_LOCK_NOT_AVAILABLE);
+
+    const streamer = await initializeStreamer(
+      lc,
+      shard,
+      'task-id',
+      'change.streamer:12345',
+      'ws',
+      sql,
+      {
+        startStream: vi.fn(),
+        startLagReporter: () => null,
+        stop: () => Promise.resolve(),
+      },
+      ReplicationStatusPublisher.forTesting(),
+      replicaConfig,
+      lock,
+      true,
+      0.04,
+      1,
+    );
+    void streamer.run();
+
+    // This should succeed once the purge lock is released.
+    await sql`SELECT FROM "zoro_3/cdc"."changeLog" FOR UPDATE`;
+
+    streamer.stop();
   });
 
   test('retry on change stream error', async () => {
@@ -1046,6 +1095,7 @@ describe('change-streamer/service', () => {
       source,
       ReplicationStatusPublisher.forTesting(),
       replicaConfig,
+      null,
       true,
       0.04,
       1,
@@ -1088,6 +1138,7 @@ describe('change-streamer/service', () => {
       source,
       ReplicationStatusPublisher.forTesting(),
       replicaConfig,
+      null,
       true,
       0.04,
       1,
@@ -1147,6 +1198,7 @@ describe('change-streamer/service', () => {
       source,
       ReplicationStatusPublisher.forTesting(),
       replicaConfig,
+      null,
       true,
       0.04,
       1,
@@ -1223,6 +1275,7 @@ describe('change-streamer/service', () => {
       source,
       ReplicationStatusPublisher.forTesting(),
       replicaConfig,
+      null,
       true,
       0.04,
       1,

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -1061,7 +1061,7 @@ describe('change-streamer/service', () => {
     // This should succeed once the purge lock is released.
     await sql`SELECT FROM "zoro_3/cdc"."changeLog" FOR UPDATE`;
 
-    streamer.stop();
+    void streamer.stop();
   });
 
   test('retry on change stream error', async () => {

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -47,7 +47,7 @@ import {
   ensureReplicationConfig,
   markResetRequired,
 } from './schema/tables.ts';
-import {Storer} from './storer.ts';
+import {Storer, type PurgeLock} from './storer.ts';
 import {Subscriber} from './subscriber.ts';
 
 /**
@@ -63,6 +63,7 @@ export async function initializeStreamer(
   changeSource: ChangeSource,
   replicationStatusPublisher: ReplicationStatusPublisher,
   subscriptionState: SubscriptionState,
+  purgeLock: PurgeLock | null,
   autoReset: boolean,
   backPressureLimitHeapProportion: number,
   flowControlConsensusPaddingSeconds: number,
@@ -90,6 +91,7 @@ export async function initializeStreamer(
     replicaVersion,
     changeSource,
     replicationStatusPublisher,
+    purgeLock,
     autoReset,
     backPressureLimitHeapProportion,
     flowControlConsensusPaddingSeconds,
@@ -286,6 +288,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   );
 
   #latestStatus: Status;
+  #purgeLock: PurgeLock | null;
   #stream: ChangeStream | undefined;
 
   constructor(
@@ -298,6 +301,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     replicaVersion: string,
     source: ChangeSource,
     replicationStatusPublisher: ReplicationStatusPublisher,
+    initialPurgeLock: PurgeLock | null,
     autoReset: boolean,
     backPressureLimitHeapProportion: number,
     flowControlConsensusPaddingSeconds: number,
@@ -325,6 +329,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       flowControlConsensusPaddingSeconds,
     });
     this.#replicationStatusPublisher = replicationStatusPublisher;
+    this.#purgeLock = initialPurgeLock;
     this.#autoReset = autoReset;
     this.#state = new RunningState(this.id, undefined, setTimeoutFn);
     this.#latestStatus = {tag: 'status'};
@@ -342,7 +347,8 @@ class ChangeStreamerImpl implements ChangeStreamerService {
 
     // Once this change-streamer acquires "ownership" of the change DB,
     // it is safe to start the storer.
-    await this.#storer.assumeOwnership();
+    await this.#storer.assumeOwnership(this.#purgeLock);
+    this.#purgeLock = null;
 
     // The threshold in (estimated number of) bytes to send() on subscriber
     // websockets before `await`-ing the I/O buffers to be ready for more.

--- a/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
@@ -11,7 +11,7 @@ import {ReplicationMessages} from '../replicator/test-utils.ts';
 import {type Downstream} from './change-streamer.ts';
 import * as ErrorType from './error-type-enum.ts';
 import {ensureReplicationConfig, setupCDCTables} from './schema/tables.ts';
-import {Storer} from './storer.ts';
+import {PurgeLocker, Storer} from './storer.ts';
 import {createSubscriber} from './test-utils.ts';
 
 describe('change-streamer/storer', () => {
@@ -62,7 +62,7 @@ describe('change-streamer/storer', () => {
 
     return async () => {
       await testDBs.drop(db);
-      void storer.stop();
+      void storer?.stop();
       await done;
     };
   });
@@ -860,6 +860,46 @@ describe('change-streamer/storer', () => {
         {watermark: '06', pos: 1n},
         {watermark: '06', pos: 2n},
       ]);
+    });
+
+    test('purge prevented by purge lock', async () => {
+      // Move the changeLog forward slightly to test non-initial numbers.
+      const result1 = await storer.purgeRecordsBefore('03');
+      expect(result1).toBe(2);
+
+      const lock = await new PurgeLocker(lc, shard, db).acquire();
+      expect(lock?.minWatermark).toBe('03');
+      expect(lock?.replicaVersion).toBe('00');
+
+      const result2 = await storer.purgeRecordsBefore('06');
+      expect(result2).toBe(0);
+
+      expect(
+        await db`SELECT watermark, pos FROM "xero_5/cdc"."changeLog"`,
+      ).toEqual([
+        {watermark: '03', pos: 0n},
+        {watermark: '03', pos: 1n},
+        {watermark: '03', pos: 2n},
+        {watermark: '06', pos: 0n},
+        {watermark: '06', pos: 1n},
+        {watermark: '06', pos: 2n},
+      ]);
+
+      await lock?.release();
+
+      const result3 = await storer.purgeRecordsBefore('06');
+      expect(result3).toBe(3);
+
+      expect(
+        await db`SELECT watermark, pos FROM "xero_5/cdc"."changeLog"`,
+      ).toEqual([
+        {watermark: '06', pos: 0n},
+        {watermark: '06', pos: 1n},
+        {watermark: '06', pos: 2n},
+      ]);
+
+      // Redundant calls to release should be ignored (and not assert, e.g.)
+      await lock?.release();
     });
 
     test('ownership change detected at begin aborts transaction', async () => {
@@ -1717,5 +1757,11 @@ describe('change-streamer/storer', () => {
         await db`SELECT "ownerAddress" FROM "xero_5/cdc"."replicationState" WHERE owner = 'task-id'`,
       ).toEqual([{ownerAddress: 'wss://change-streamer:12345'}]);
     });
+  });
+
+  test('purge lock on empty change-log (e.g. before initial sync)', async () => {
+    await db`TRUNCATE "xero_5/cdc"."changeLog"`;
+    const purgeLocker = new PurgeLocker(lc, shard, db);
+    expect(await purgeLocker.acquire()).toBeNull();
   });
 });

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -238,29 +238,24 @@ export class Storer implements Service {
   async purgeRecordsBefore(watermark: string): Promise<number> {
     try {
       return await runTx(this.#db, async sql => {
-        // If the row is purge-locked by an incoming replication-manager, it
-        // will assume ownership of the change-log before releasing the lock.
-        // This would cause the DELETE in this purge attempt to block until
-        // the lock is released, followed by an abort after seeing the change
-        // in ownership (this is what will happen with earlier versions of
-        // the code).
-        //
         // This NOWAIT pre-check is an optimization to abort the transaction
-        // (and release associated resources) earlier.
+        // (and release associated resources) early.
         await sql<{watermark: string}[]>`
           SELECT watermark FROM ${this.#cdc('changeLog')}
             ORDER BY watermark, pos LIMIT 1
             FOR UPDATE NOWAIT
-      `;
+        `;
+        // If the row is purge-locked by an incoming replication-manager, it
+        // will assume ownership of the change-log before releasing the lock.
+        // This DELETE blocks until the lock is released, allowing the change
+        // in ownership to be reliably detected (and the transaction aborted)
+        // in the subsequent check.
         const [{deleted}] = await sql<{deleted: bigint}[]>`
         WITH purged AS (
           DELETE FROM ${this.#cdc('changeLog')} WHERE watermark < ${watermark} 
             RETURNING watermark, pos
         ) SELECT COUNT(*) as deleted FROM purged;`;
 
-        // Before committing the purge, check that this process is still the
-        // owner. This is done after the DELETE to minimize the amount of time
-        // that writes to the changeLog are delayed.
         const [{owner}] = await sql<ReplicationState[]>`
         SELECT * FROM ${this.#cdc('replicationState')} FOR SHARE`;
         if (owner !== this.#taskID) {

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -187,7 +187,7 @@ export class Storer implements Service {
       // purging of change-log records can be released, as a change-streamer
       // that was attempting to purge records will correspondingly abort on the
       // ownership check.
-      await purgeLock.release();
+      void purgeLock.release();
     }
   }
 

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -1,4 +1,5 @@
 import {getHeapStatistics} from 'node:v8';
+import {PG_LOCK_NOT_AVAILABLE} from '@drdgvhbh/postgres-error-codes';
 import type {LogContext} from '@rocicorp/logger';
 import {resolver, type Resolver} from '@rocicorp/resolver';
 import {type PendingQuery, type Row} from 'postgres';
@@ -11,7 +12,11 @@ import * as v from '../../../../shared/src/valita.ts';
 import * as Mode from '../../db/mode-enum.ts';
 import {runTx} from '../../db/run-transaction.ts';
 import {TransactionPool} from '../../db/transaction-pool.ts';
-import {type PostgresDB, type PostgresTransaction} from '../../types/pg.ts';
+import {
+  isPostgresError,
+  type PostgresDB,
+  type PostgresTransaction,
+} from '../../types/pg.ts';
 import {cdcSchema, type ShardID} from '../../types/shards.ts';
 import {
   backfillRequestSchema,
@@ -159,7 +164,7 @@ export class Storer implements Service {
     return this.#db(`${cdcSchema(this.#shard)}.${table}`);
   }
 
-  async assumeOwnership() {
+  async assumeOwnership(purgeLock?: PurgeLock | null) {
     const db = this.#db;
     const owner = this.#taskID;
     const ownerAddress = this.#discoveryAddress;
@@ -176,6 +181,14 @@ export class Storer implements Service {
     this.#lc.info?.(
       `assumed ownership at ${addressWithProtocol} (${elapsed} ms)`,
     );
+
+    if (purgeLock) {
+      // Once ownership has been assumed, any initial purge-lock preventing the
+      // purging of change-log records can be released, as a change-streamer
+      // that was attempting to purge records will correspondingly abort on the
+      // ownership check.
+      await purgeLock.release();
+    }
   }
 
   async getStartStreamInitializationParameters(): Promise<{
@@ -222,26 +235,50 @@ export class Storer implements Service {
     return minWatermark;
   }
 
-  purgeRecordsBefore(watermark: string): Promise<number> {
-    return runTx(this.#db, async sql => {
-      const [{deleted}] = await sql<{deleted: bigint}[]>`
+  async purgeRecordsBefore(watermark: string): Promise<number> {
+    try {
+      return await runTx(this.#db, async sql => {
+        // If the row is purge-locked by an incoming replication-manager, it
+        // will assume ownership of the change-log before releasing the lock.
+        // This would cause the DELETE in this purge attempt to block until
+        // the lock is released, followed by an abort after seeing the change
+        // in ownership (this is what will happen with earlier versions of
+        // the code).
+        //
+        // This NOWAIT pre-check is an optimization to abort the transaction
+        // (and release associated resources) earlier.
+        await sql<{watermark: string}[]>`
+          SELECT watermark FROM ${this.#cdc('changeLog')}
+            ORDER BY watermark, pos LIMIT 1
+            FOR UPDATE NOWAIT
+      `;
+        const [{deleted}] = await sql<{deleted: bigint}[]>`
         WITH purged AS (
           DELETE FROM ${this.#cdc('changeLog')} WHERE watermark < ${watermark} 
             RETURNING watermark, pos
         ) SELECT COUNT(*) as deleted FROM purged;`;
 
-      // Before committing the purge, check that this process is still the
-      // owner. This is done after the DELETE to minimize the amount of time
-      // that writes to the changeLog are delayed.
-      const [{owner}] = await sql<ReplicationState[]>`
+        // Before committing the purge, check that this process is still the
+        // owner. This is done after the DELETE to minimize the amount of time
+        // that writes to the changeLog are delayed.
+        const [{owner}] = await sql<ReplicationState[]>`
         SELECT * FROM ${this.#cdc('replicationState')} FOR SHARE`;
-      if (owner !== this.#taskID) {
-        throw new AbortError(
-          `aborting changeLog purge to ${watermark} because ownership has been taken by ${owner}`,
+        if (owner !== this.#taskID) {
+          throw new AbortError(
+            `aborting changeLog purge to ${watermark} because ownership has been taken by ${owner}`,
+          );
+        }
+        return Number(deleted);
+      });
+    } catch (e) {
+      if (isPostgresError(e, PG_LOCK_NOT_AVAILABLE)) {
+        this.#lc.info?.(
+          `changeLog is locked from being purged. trying purge later.`,
         );
+        return 0;
       }
-      return Number(deleted);
-    });
+      throw e;
+    }
   }
 
   /**
@@ -810,5 +847,82 @@ function toDownstream(entry: ChangeEntry): WatermarkedChange {
       return [watermark, ['rollback', change]];
     default:
       return [watermark, ['data', change]];
+  }
+}
+
+export class PurgeLock {
+  readonly #lc: LogContext;
+  readonly #tx: TransactionPool;
+  readonly replicaVersion: string;
+  readonly minWatermark: string;
+
+  constructor(
+    lc: LogContext,
+    tx: TransactionPool,
+    replicaVersion: string,
+    watermark: string,
+  ) {
+    this.#lc = lc;
+    this.#tx = tx;
+    this.replicaVersion = replicaVersion;
+    this.minWatermark = watermark;
+  }
+
+  #released = false;
+
+  async release() {
+    if (this.#released) {
+      return;
+    }
+    this.#released = true;
+    this.#tx.setDone();
+    await this.#tx
+      .done()
+      .catch(e => this.#lc.warn?.(`error from purge-lock release`, e));
+    this.#lc.info?.(`released purge lock on ${this.minWatermark}`);
+  }
+}
+
+export class PurgeLocker {
+  readonly #lc: LogContext;
+  readonly #shard: ShardID;
+  readonly #db: PostgresDB;
+
+  constructor(lc: LogContext, shard: ShardID, db: PostgresDB) {
+    this.#lc = lc.withContext('component', 'purge-locker');
+    this.#shard = shard;
+    this.#db = db;
+  }
+
+  // For readability in SQL statements.
+  #cdc(table: string) {
+    return this.#db(`${cdcSchema(this.#shard)}.${table}`);
+  }
+
+  async acquire() {
+    const tx = new TransactionPool(this.#lc, Mode.READ_COMMITTED).run(this.#db);
+    const row = await tx.processReadTask(
+      sql => sql<{watermark: string}[]>`
+      SELECT watermark FROM ${this.#cdc('changeLog')}
+        ORDER BY watermark, pos LIMIT 1
+        FOR SHARE 
+    `,
+    );
+    if (row.length === 0) {
+      this.#lc.info?.(`changeLog is empty. No rows to purge-lock.`);
+      tx.setDone();
+      await tx.done();
+      return null;
+    }
+    const [{watermark}] = row;
+    const [{replicaVersion}] = await tx.processReadTask(
+      sql => sql<{replicaVersion: string}[]>`
+        SELECT "replicaVersion" FROM ${this.#cdc('replicationConfig')}
+      `,
+    );
+    this.#lc.info?.(
+      `locked watermark ${watermark} from being purged from replica@${replicaVersion}`,
+    );
+    return new PurgeLock(this.#lc, tx, replicaVersion, watermark);
   }
 }

--- a/packages/zero-cache/src/services/litestream/commands.ts
+++ b/packages/zero-cache/src/services/litestream/commands.ts
@@ -34,14 +34,15 @@ type ReplicaConstraints = {
  *        restoring for the change-streamer (replication-manager). For the
  *        view-syncer, this should be unspecified so that the constraints are
  *        retrieved from the replication-manager via the snapshot protocol.
- * @returns The time at which the last restore started
- *          (i.e. not counting failed attempts).
+ * @returns Whether a backup was found. This will only return `false` for the
+ *        replication-manager (i.e. when replicaConstraints are specified), as
+ *        the replication-manager can recover by resyncing.
  */
 export async function restoreReplica(
   lc: LogContext,
   config: ZeroConfig,
   replicaConstraints: ReplicaConstraints | null,
-): Promise<Date> {
+): Promise<boolean> {
   for (let i = 0; i < MAX_RETRIES; i++) {
     if (i > 0) {
       lc.info?.(
@@ -49,16 +50,18 @@ export async function restoreReplica(
       );
       await sleep(RETRY_INTERVAL_MS);
     }
-    const start = new Date();
     const restored = await tryRestore(lc, config, replicaConstraints);
     if (restored) {
-      return start;
+      return true;
     }
     if (replicaConstraints) {
       // This can happen if the litestream URL is purposefully changed to
       // force a resync.
-      lc.warn?.('no litestream backup found', replicaConstraints);
-      return start;
+      lc.warn?.('no litestream backup found', {
+        ...replicaConstraints,
+        backupURL: config.litestream.backupURL,
+      });
+      return false;
     }
   }
   throw new Error(`max attempts exceeded restoring replica`);

--- a/packages/zero-cache/src/services/litestream/commands.ts
+++ b/packages/zero-cache/src/services/litestream/commands.ts
@@ -42,8 +42,6 @@ export async function restoreReplica(
   config: ZeroConfig,
   replicaConstraints: ReplicaConstraints | null,
 ): Promise<Date> {
-  const {changeStreamer} = config;
-
   for (let i = 0; i < MAX_RETRIES; i++) {
     if (i > 0) {
       lc.info?.(
@@ -56,11 +54,10 @@ export async function restoreReplica(
     if (restored) {
       return start;
     }
-    if (
-      changeStreamer.mode === 'dedicated' &&
-      changeStreamer.uri === undefined
-    ) {
-      lc.info?.('no litestream backup found');
+    if (replicaConstraints) {
+      // This can happen if the litestream URL is purposefully changed to
+      // force a resync.
+      lc.warn?.('no litestream backup found', replicaConstraints);
       return start;
     }
   }

--- a/packages/zero-cache/src/services/litestream/commands.ts
+++ b/packages/zero-cache/src/services/litestream/commands.ts
@@ -24,13 +24,23 @@ import {getSubscriptionState} from '../replicator/schema/replication-state.ts';
 const MAX_RETRIES = 60;
 const RETRY_INTERVAL_MS = 3000;
 
+type ReplicaConstraints = {
+  replicaVersion: string;
+  minWatermark: string;
+};
+
 /**
+ * @param replicaConstraints The constraints of the restored backup when
+ *        restoring for the change-streamer (replication-manager). For the
+ *        view-syncer, this should be unspecified so that the constraints are
+ *        retrieved from the replication-manager via the snapshot protocol.
  * @returns The time at which the last restore started
  *          (i.e. not counting failed attempts).
  */
 export async function restoreReplica(
   lc: LogContext,
   config: ZeroConfig,
+  replicaConstraints: ReplicaConstraints | null,
 ): Promise<Date> {
   const {changeStreamer} = config;
 
@@ -42,7 +52,7 @@ export async function restoreReplica(
       await sleep(RETRY_INTERVAL_MS);
     }
     const start = new Date();
-    const restored = await tryRestore(lc, config);
+    const restored = await tryRestore(lc, config, replicaConstraints);
     if (restored) {
       return start;
     }
@@ -123,26 +133,18 @@ function getLitestream(
   };
 }
 
-async function tryRestore(lc: LogContext, config: ZeroConfig) {
-  const {changeStreamer} = config;
-
-  const isViewSyncer =
-    changeStreamer.mode === 'discover' || changeStreamer.uri !== undefined;
-
-  // Fire off a snapshot reservation to the current replication-manager
-  // (if there is one).
-  const firstMessage = reserveAndGetSnapshotStatus(lc, config, isViewSyncer);
+async function tryRestore(
+  lc: LogContext,
+  config: ZeroConfig,
+  replicaConstraints: ReplicaConstraints | null,
+) {
   let snapshotStatus: SnapshotStatus | undefined;
-  if (isViewSyncer) {
-    // The return value is required by view-syncers ...
-    snapshotStatus = await firstMessage;
+  if (!replicaConstraints) {
+    // view-syncers fetch replica constraints from the replication-manager
+    // via the snapshot protocol.
+    snapshotStatus = await reserveAndGetSnapshotStatus(lc, config);
     lc.info?.(`restoring backup from ${snapshotStatus.backupURL}`);
-  } else {
-    // but it is also useful to pause change-log cleanup when a new
-    // replication-manager is starting up. In this case, the request is
-    // best-effort. In particular, there may not be a previous
-    // replication-manager running at all.
-    void firstMessage.catch(e => lc.debug?.(e));
+    replicaConstraints = snapshotStatus;
   }
 
   const {litestream, env} = getLitestream(
@@ -179,10 +181,7 @@ async function tryRestore(lc: LogContext, config: ZeroConfig) {
   if (!existsSync(config.replica.file)) {
     return false;
   }
-  if (
-    snapshotStatus &&
-    !replicaIsValid(lc, config.replica.file, snapshotStatus)
-  ) {
+  if (!replicaIsValid(lc, config.replica.file, replicaConstraints)) {
     lc.info?.(`Deleting local replica and retrying restore`);
     deleteLiteDB(config.replica.file);
     return false;
@@ -193,29 +192,29 @@ async function tryRestore(lc: LogContext, config: ZeroConfig) {
 function replicaIsValid(
   lc: LogContext,
   replica: string,
-  snapshot: SnapshotStatus,
+  constraints: ReplicaConstraints,
 ) {
   const db = new Database(lc, replica);
   try {
     const {replicaVersion, watermark} = getSubscriptionState(
       new StatementRunner(db),
     );
-    if (replicaVersion !== snapshot.replicaVersion) {
+    if (replicaVersion !== constraints.replicaVersion) {
       lc.warn?.(
-        `Local replica version ${replicaVersion} does not match change-streamer replicaVersion ${snapshot.replicaVersion}`,
-        snapshot,
+        `Local replica version ${replicaVersion} does not match expected replicaVersion ${constraints.replicaVersion}`,
+        constraints,
       );
       return false;
     }
-    if (watermark < snapshot.minWatermark) {
+    if (watermark < constraints.minWatermark) {
       lc.warn?.(
-        `Local replica watermark ${watermark} is earlier than change-streamer minWatermark ${snapshot.minWatermark}`,
+        `Local replica watermark ${watermark} is earlier than minWatermark ${constraints.minWatermark}`,
       );
       return false;
     }
     lc.info?.(
-      `Local replica at version ${replicaVersion} and watermark ${watermark} is compatible with change-streamer`,
-      snapshot,
+      `Local replica at version ${replicaVersion} and watermark ${watermark} is compatible`,
+      constraints,
     );
     return true;
   } catch (e) {
@@ -242,7 +241,6 @@ export function startReplicaBackupProcess(
 function reserveAndGetSnapshotStatus(
   lc: LogContext,
   config: ZeroConfig,
-  isViewSyncer: boolean,
 ): Promise<SnapshotStatus> {
   const {promise: status, resolve, reject} = resolver<SnapshotStatus>();
 
@@ -252,7 +250,7 @@ function reserveAndGetSnapshotStatus(
     process.on('SIGTERM', () => abort.abort());
 
     for (let i = 0; ; i++) {
-      let err: unknown | string = '';
+      let err: unknown;
       try {
         let resolved = false;
         const stream = await reserveSnapshot(lc, config);
@@ -270,9 +268,6 @@ function reserveAndGetSnapshotStatus(
         }
       } catch (e) {
         err = e;
-      }
-      if (!isViewSyncer) {
-        return reject(err);
       }
       // Retry in the view-syncer since it cannot proceed until it connects
       // to a (compatible) replication-manager. In particular, a

--- a/packages/zero-cache/src/services/litestream/commands.ts
+++ b/packages/zero-cache/src/services/litestream/commands.ts
@@ -29,20 +29,25 @@ type ReplicaConstraints = {
   minWatermark: string;
 };
 
+export class BackupNotFoundException extends Error {
+  static readonly name = 'BackupNotFoundException';
+
+  constructor(backupURL: string | undefined) {
+    super(`backup not found at ${backupURL}`);
+  }
+}
+
 /**
  * @param replicaConstraints The constraints of the restored backup when
  *        restoring for the change-streamer (replication-manager). For the
  *        view-syncer, this should be unspecified so that the constraints are
  *        retrieved from the replication-manager via the snapshot protocol.
- * @returns Whether a backup was found. This will only return `false` for the
- *        replication-manager (i.e. when replicaConstraints are specified), as
- *        the replication-manager can recover by resyncing.
  */
 export async function restoreReplica(
   lc: LogContext,
   config: ZeroConfig,
   replicaConstraints: ReplicaConstraints | null,
-): Promise<boolean> {
+) {
   for (let i = 0; i < MAX_RETRIES; i++) {
     if (i > 0) {
       lc.info?.(
@@ -52,16 +57,12 @@ export async function restoreReplica(
     }
     const restored = await tryRestore(lc, config, replicaConstraints);
     if (restored) {
-      return true;
+      return;
     }
     if (replicaConstraints) {
       // This can happen if the litestream URL is purposefully changed to
       // force a resync.
-      lc.warn?.('no litestream backup found', {
-        ...replicaConstraints,
-        backupURL: config.litestream.backupURL,
-      });
-      return false;
+      throw new BackupNotFoundException(config.litestream.backupURL);
     }
   }
   throw new Error(`max attempts exceeded restoring replica`);


### PR DESCRIPTION
Use a Postgres row lock on the Change DB to prevent change-log cleanup during a replication-manager handoff.

The previous reliance on the `/snapshot` websocket connection is susceptible to "dropping the baton" if the outgoing replication-manager is shutdown (and restarted), making it possible for an RM to purge change-log entries needed by the incoming RM:
* https://rocicorp.slack.com/archives/C0AS00SDCKV/p1775849670636429

Instead of using the `/snapshot` protocol (which also could only be best-effort for replication-manager startup, since a previous replication-manager may not exist), a share lock on the earliest row of the "changeLog" table is used to prevent purges.

At startup, the replication-manager:

1. acquires a "FOR SHARE" lock on the earliest `changeLog` row
2. restores from litestream if such a row exists (otherwise, initiates initial sync).
3. verifies that the restored backup matches the constraints read from the Change DB
  a. retrying the restore if not
4. assumes Change DB ownership (as before)
5. releases the "FOR SHARE" lock

The "FOR SHARE" lock prevents any change-log DELETE's from happening until the lock is released. By waiting until  ownership is assumed (a write to the ownership column) before releasing the lock, this mechanism is _backwards compatible_ with previous change-streamer code, which checks the ownership column before committing a transaction purge, and aborts if ownership has changed. 

As an optimization, new change-streamer code will first attempt to acquire a "FOR UPDATE NOWAIT" lock on the first row to abort early (and release transaction resources) if the row is locked.

An additional benefit of this protocol is that it serves to verify the expected constraints of the backup at replication-manager startup; the view-syncer receives these constraints via the `/snapshot` protocol, and now the replication-manager determines the equivalent information directly from the change-db. The associated verification of constraints allows the existing delete-and-retry loop to handle pathological cases in which the wrong backup is restored, all happening before the server announces readiness.

Theoretically, the view-syncer logic _could_ be switched to this protocol as well. However:
* having view-syncers directly access the Change DB breaks the replication-manager abstraction and makes the system harder to maintain and upgrade. In particular, this would complicate the migration to an upcoming architecture in which Postgres is no longer used for storing the change-log.
* the consequence of a "dropped baton" in the case of a view-syncer startup is much less disruptive, as it involves a restart and restore rather than a full replica resync, and view-syncers are redundant as well.

As such, view-syncer restores continue to use the existing `/snapshot` protocol for reserving snapshots.