### PR TITLE
fix(zero-cache): preserve compound primary key column order

### DIFF
--- a/packages/z2s/src/compiler.output.test.ts
+++ b/packages/z2s/src/compiler.output.test.ts
@@ -117,6 +117,17 @@ const alternateUser = table('alternate_user')
   })
   .primaryKey('id');
 
+// Table with compound PK where user-defined order differs from alphabetical.
+// PK order: callId, userId, connectionId
+// Alphabetical: callId, connectionId, userId
+const connectedCalls = table('connected_calls')
+  .columns({
+    callId: string(),
+    userId: string(),
+    connectionId: string(),
+  })
+  .primaryKey('callId', 'userId', 'connectionId');
+
 const schema = createSchema({
   tables: [
     user,
@@ -129,6 +140,7 @@ const schema = createSchema({
     timestampsTable,
     timesTable,
     alternateUser,
+    connectedCalls,
   ],
 });
 
@@ -188,6 +200,11 @@ const serverSchema: ServerSchema = {
     id: {type: 'text', isArray: false, isEnum: false},
     name: {type: 'text', isArray: false, isEnum: false},
     age: {type: 'numeric', isArray: false, isEnum: false},
+  },
+  'connected_calls': {
+    callId: {type: 'text', isArray: false, isEnum: false},
+    userId: {type: 'text', isArray: false, isEnum: false},
+    connectionId: {type: 'text', isArray: false, isEnum: false},
   },
 };
 
@@ -1441,4 +1458,23 @@ test('scalar subquery with NOT EXISTS generates IS NOT operator', () => {
       ],
     }
   `);
+});
+
+test('compound primary key ORDER BY preserves user-defined column order', () => {
+  // Verifies that compile() generates ORDER BY with PK columns in the
+  // user-defined order (callId, userId, connectionId), NOT alphabetical
+  // (callId, connectionId, userId).
+  // See: https://bugs.rocicorp.dev/p/zero/issue/246641
+  const result = formatPgInternalConvert(
+    compile(serverSchema, schema, {table: 'connected_calls'}),
+  );
+  // The ORDER BY should have columns in PK-defined order:
+  // callId, userId, connectionId
+  expect(result.text).toContain(
+    'ORDER BY "connected_calls_0"."callId" ASC NULLS FIRST, "connected_calls_0"."userId" ASC NULLS FIRST, "connected_calls_0"."connectionId" ASC NULLS FIRST',
+  );
+  // It should NOT have alphabetical order (connectionId before userId)
+  expect(result.text).not.toContain(
+    'ORDER BY "connected_calls_0"."callId" ASC NULLS FIRST, "connected_calls_0"."connectionId" ASC NULLS FIRST, "connected_calls_0"."userId" ASC NULLS FIRST',
+  );
 });

--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -12,6 +12,8 @@
     "test:pg16:watch": "vitest --project='*16*'",
     "test:pg17": "vitest --project='*17*' run",
     "test:pg17:watch": "vitest --project='*17*'",
+    "test:pg18": "vitest --project='*18*' run",
+    "test:pg18:watch": "vitest --project='*18*'",
     "test:no-pg": "vitest --project='*no-pg*' run",
     "test:no-pg:watch": "vitest --project='*no-pg*'",
     "check-types": "tsc",

--- a/packages/zero-cache/src/db/lite-tables.test.ts
+++ b/packages/zero-cache/src/db/lite-tables.test.ts
@@ -594,9 +594,9 @@ describe('computeZqlSpec', () => {
           "tableSpec": {
             "allPotentialPrimaryKeys": [
               [
-                "a",
                 "b",
                 "d",
+                "a",
               ],
             ],
             "backfilling": [],
@@ -629,15 +629,15 @@ describe('computeZqlSpec', () => {
             "minRowVersion": null,
             "name": "foo",
             "primaryKey": [
-              "a",
               "b",
               "d",
+              "a",
             ],
             "uniqueKeys": [
               [
-                "a",
                 "b",
                 "d",
+                "a",
               ],
               [
                 "a",
@@ -674,9 +674,9 @@ describe('computeZqlSpec', () => {
           "tableSpec": {
             "allPotentialPrimaryKeys": [
               [
-                "a",
                 "b",
                 "d",
+                "a",
               ],
             ],
             "backfilling": [],
@@ -717,15 +717,15 @@ describe('computeZqlSpec', () => {
             "minRowVersion": null,
             "name": "foo",
             "primaryKey": [
-              "a",
               "b",
               "d",
+              "a",
             ],
             "uniqueKeys": [
               [
-                "a",
                 "b",
                 "d",
+                "a",
               ],
               [
                 "a",
@@ -764,9 +764,9 @@ describe('computeZqlSpec', () => {
           "tableSpec": {
             "allPotentialPrimaryKeys": [
               [
+                "d",
                 "a",
                 "c",
-                "d",
               ],
             ],
             "backfilling": [],
@@ -807,15 +807,15 @@ describe('computeZqlSpec', () => {
             "minRowVersion": null,
             "name": "foo",
             "primaryKey": [
+              "d",
               "a",
               "c",
-              "d",
             ],
             "uniqueKeys": [
               [
+                "d",
                 "a",
                 "c",
-                "d",
               ],
             ],
           },
@@ -838,6 +838,20 @@ describe('computeZqlSpec', () => {
     `);
   });
 
+  test('compound key preserves index column order', () => {
+    // Regression test: compound primary key columns should preserve the
+    // order defined in the index (d, a, c), not be alphabetically sorted
+    // (a, c, d). Alphabetical sorting causes incorrect ORDER BY and index
+    // usage downstream.
+    // See: https://bugs.rocicorp.dev/p/zero/issue/246641
+    const result = t(`
+    CREATE TABLE foo(a "INT|NOT_NULL", b "INT|NOT_NULL", c "INT|NOT_NULL", d "INT|NOT_NULL");
+    CREATE UNIQUE INDEX foo_pkey ON foo(d ASC, a ASC, c ASC);
+    `);
+    const tableSpec = result[0].tableSpec;
+    expect(tableSpec.primaryKey).toEqual(['d', 'a', 'c']);
+  });
+
   test('additional unique key', () => {
     expect(
       t(`
@@ -854,8 +868,8 @@ describe('computeZqlSpec', () => {
                 "b",
               ],
               [
-                "a",
                 "c",
+                "a",
               ],
             ],
             "backfilling": [],
@@ -903,8 +917,8 @@ describe('computeZqlSpec', () => {
                 "b",
               ],
               [
-                "a",
                 "c",
+                "a",
               ],
             ],
           },

--- a/packages/zero-cache/src/db/lite-tables.ts
+++ b/packages/zero-cache/src/db/lite-tables.ts
@@ -290,9 +290,7 @@ export function computeZqlSpecsFromLiteSpecs(
       columns: Object.fromEntries(visibleColumns),
       primaryKey: v.parse(primaryKey, primaryKeySchema),
       uniqueKeys: uniqueKeys.map(key => v.parse(key, primaryKeySchema)),
-      allPotentialPrimaryKeys: keys.map(key =>
-        v.parse(key, primaryKeySchema),
-      ),
+      allPotentialPrimaryKeys: keys.map(key => v.parse(key, primaryKeySchema)),
       minRowVersion: fullTable.minRowVersion ?? null,
     };
 

--- a/packages/zero-cache/src/db/lite-tables.ts
+++ b/packages/zero-cache/src/db/lite-tables.ts
@@ -288,12 +288,10 @@ export function computeZqlSpecsFromLiteSpecs(
     const tableSpec = {
       ...fullTable,
       columns: Object.fromEntries(visibleColumns),
-      // normalize (sort) keys to minimize creating new objects.
-      // See row-key.ts: normalizedKeyOrder()
-      primaryKey: v.parse(primaryKey.sort(), primaryKeySchema),
-      uniqueKeys: uniqueKeys.map(key => v.parse(key.sort(), primaryKeySchema)),
+      primaryKey: v.parse(primaryKey, primaryKeySchema),
+      uniqueKeys: uniqueKeys.map(key => v.parse(key, primaryKeySchema)),
       allPotentialPrimaryKeys: keys.map(key =>
-        v.parse(key.sort(), primaryKeySchema),
+        v.parse(key, primaryKeySchema),
       ),
       minRowVersion: fullTable.minRowVersion ?? null,
     };

--- a/packages/zql/src/query/complete-ordering.test.ts
+++ b/packages/zql/src/query/complete-ordering.test.ts
@@ -529,4 +529,31 @@ describe('completeOrdering', () => {
         }
       `);
   });
+
+  test('compound primary key preserves user-defined column order', () => {
+    // This test verifies that completeOrdering preserves the order of
+    // compound primary key columns as defined by the user, not alphabetically.
+    // See: https://bugs.rocicorp.dev/p/zero/issue/246641
+    // The bug was that lite-tables.ts called primaryKey.sort() which
+    // alphabetized compound PK columns (e.g., ['callId', 'userId', 'connectionId']
+    // became ['callId', 'connectionId', 'userId']), causing incorrect ORDER BY
+    // and index column ordering.
+
+    // Simulate the correct PK order as user defined it
+    const userDefinedOrder = ['callId', 'userId', 'connectionId'] as const;
+
+    const baseAST = {table: 'issueLabel'} as const;
+
+    const resultWithCorrectOrder = completeOrdering(
+      baseAST,
+      () => userDefinedOrder,
+    );
+
+    // With correct user-defined order, PK columns should be in user-defined order
+    expect(resultWithCorrectOrder.orderBy).toEqual([
+      ['callId', 'asc'],
+      ['userId', 'asc'],
+      ['connectionId', 'asc'],
+    ]);
+  });
 });


### PR DESCRIPTION
Stop alphabetically sorting primaryKey, uniqueKeys, and allPotentialPrimaryKeys in computeZqlSpecs. The sorting caused compound primary key columns to be reordered alphabetically (e.g. [callId, userId, connectionId] became [callId, connectionId, userId]), which resulted in incorrect ORDER BY clauses and index column ordering in SQLite.

This mismatch between the ORDER BY column order and the actual index column order forces SQLite to fall back to full table scans instead of using the index, causing severe performance degradation.

The sorting was originally added as an optimization so that normalizedKeyOrder() in row-key.ts could take its fast path (already-sorted check) and avoid allocating new objects. However, these two concerns are independent:

- Row identity (normalizedKeyOrder) sorts RowKey object properties alphabetically at each point of use (change-log, snapshotter, CVR) for deterministic stringification. It handles unsorted input fine.
- Query ordering (completeOrdering -> addPrimaryKeys) appends PK columns to ORDER BY in the PK array order from the tableSpec. This is where the bug manifested.

Removing the pre-sort is safe: row identity still gets normalized at point of use, and query ordering now preserves the index-defined column order.

Fixes: https://bugs.rocicorp.dev/p/zero/issue/246641