### PR TITLE
chore(zero-cache): sampled sync for use in test reset

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
@@ -30,11 +30,15 @@ import {
   initialSync,
   INSERT_BATCH_SIZE,
   shadowInitialSync,
+  verifyShadowReplica,
 } from './initial-sync.ts';
 import {fromStateVersionString} from './lsn.ts';
 import {ensureShardSchema} from './schema/init.ts';
 import {getPublicationInfo} from './schema/published.ts';
-import {replicationSlotExpression} from './schema/shard.ts';
+import {
+  getInternalShardConfig,
+  replicationSlotExpression,
+} from './schema/shard.ts';
 import {UnsupportedTableSchemaError} from './schema/validation.ts';
 
 const APP_ID = '1';
@@ -3069,6 +3073,86 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
       // And it still left no upstream footprint.
       expect(await countSlots(upstream)).toBe(0);
       expect(await countReplicas(upstream)).toBe(0);
+    });
+
+    describe('verifyShadowReplica', () => {
+      async function runShadowSync() {
+        await seedWithManyRows(upstream, 20);
+        const lc = createSilentLogContext();
+        const replica = new Database(lc, ':memory:');
+        await initialSync(
+          lc,
+          SHADOW_SHARD,
+          replica,
+          getConnectionURI(upstream),
+          {tableCopyWorkers: 1, shadow: {sampleRate: 1}},
+          TEST_CONTEXT,
+        );
+        const {publications} = await getInternalShardConfig(
+          upstream,
+          SHADOW_SHARD,
+        );
+        const publishedInfo = await getPublicationInfo(upstream, publications);
+        const [{count}] = replica
+          .prepare('SELECT COUNT(*) as count FROM big')
+          .all<{count: number}>();
+        return {lc, replica, publishedInfo, bigCount: count};
+      }
+
+      test('passes on a valid replica', async () => {
+        const {lc, replica, publishedInfo, bigCount} = await runShadowSync();
+        const rowsByTable = new Map([['big', bigCount]]);
+        expect(() =>
+          verifyShadowReplica(lc, replica, publishedInfo, rowsByTable),
+        ).not.toThrow();
+      });
+
+      test('throws when a published table is missing from the replica', async () => {
+        const {lc, replica, publishedInfo} = await runShadowSync();
+        replica.exec('DROP TABLE big');
+        expect(() =>
+          verifyShadowReplica(lc, replica, publishedInfo, new Map()),
+        ).toThrow(/missing table in replica: big/);
+      });
+
+      test('throws on row-count mismatch', async () => {
+        const {lc, replica, publishedInfo} = await runShadowSync();
+        const rowsByTable = new Map([['big', 999_999]]);
+        expect(() =>
+          verifyShadowReplica(lc, replica, publishedInfo, rowsByTable),
+        ).toThrow(
+          /row count mismatch for table big: copy counter reported 999999/,
+        );
+      });
+
+      test('throws on missing column_metadata row', async () => {
+        const {lc, replica, publishedInfo} = await runShadowSync();
+        replica.exec(
+          `DELETE FROM "_zero.column_metadata"
+             WHERE table_name = 'big' AND column_name = 'val'`,
+        );
+        expect(() =>
+          verifyShadowReplica(lc, replica, publishedInfo, new Map()),
+        ).toThrow(/missing column_metadata row for big\.val/);
+      });
+
+      test('throws when a table is unqueryable via ZQL', async () => {
+        const {lc, replica, publishedInfo} = await runShadowSync();
+        // Dropping the only unique index over non-null columns makes
+        // computeZqlSpecs silently exclude the table.
+        const idx = replica
+          .prepare(
+            `SELECT name FROM sqlite_master
+              WHERE type = 'index' AND tbl_name = 'big' AND name NOT LIKE 'sqlite_%'`,
+          )
+          .all<{name: string}>();
+        for (const {name} of idx) {
+          replica.exec(`DROP INDEX "${name}"`);
+        }
+        expect(() =>
+          verifyShadowReplica(lc, replica, publishedInfo, new Map()),
+        ).toThrow(/dropped by computeZqlSpecs.*big/s);
+      });
     });
   });
 });

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
@@ -1,5 +1,6 @@
-import {readdir} from 'node:fs/promises';
+import {mkdtemp, readdir, rm} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
+import {join} from 'node:path';
 import {LogContext} from '@rocicorp/logger';
 import {nanoid} from 'nanoid/non-secure';
 import {beforeEach, describe, expect} from 'vitest';
@@ -3054,25 +3055,35 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
       const lc = createSilentLogContext();
       await seedWithManyRows(upstream, 50);
 
-      const before = (await readdir(tmpdir())).filter(n =>
-        n.startsWith('zero-shadow-sync-'),
-      );
+      // Isolate this test's tempdir so concurrent test configs (pg-15 /
+      // pg-16 / pg-17 / pg-18 run in parallel under one vitest invocation
+      // and all share the real OS tmpdir) can't race on `zero-shadow-sync-*`
+      // entries created by each other's runs.
+      const testTmp = await mkdtemp(join(tmpdir(), 'shadow-cleanup-test-'));
+      const prevTmpdir = process.env.TMPDIR;
+      process.env.TMPDIR = testTmp;
+      try {
+        await shadowInitialSync(
+          lc,
+          SHADOW_SHARD,
+          getConnectionURI(upstream),
+          {sampleRate: 0.5, maxRowsPerTable: 10},
+          TEST_CONTEXT,
+        );
 
-      await shadowInitialSync(
-        lc,
-        SHADOW_SHARD,
-        getConnectionURI(upstream),
-        {sampleRate: 0.5, maxRowsPerTable: 10},
-        TEST_CONTEXT,
-      );
-
-      const after = (await readdir(tmpdir())).filter(n =>
-        n.startsWith('zero-shadow-sync-'),
-      );
-      expect(after).toEqual(before);
-      // And it still left no upstream footprint.
-      expect(await countSlots(upstream)).toBe(0);
-      expect(await countReplicas(upstream)).toBe(0);
+        // Nothing the wrapper created should remain.
+        expect(await readdir(testTmp)).toEqual([]);
+        // And it still left no upstream footprint.
+        expect(await countSlots(upstream)).toBe(0);
+        expect(await countReplicas(upstream)).toBe(0);
+      } finally {
+        if (prevTmpdir === undefined) {
+          delete process.env.TMPDIR;
+        } else {
+          process.env.TMPDIR = prevTmpdir;
+        }
+        await rm(testTmp, {recursive: true, force: true});
+      }
     });
 
     describe('verifyShadowReplica', () => {

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
@@ -2949,10 +2949,13 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
       expect(await countReplicas(upstream)).toBe(0);
       expect(eventSink).toEqual([]);
 
-      // And no walsender connections should have been opened.
+      // And no walsender connections should have been opened against this
+      // test's database. Scoped by datname so concurrent tests in other DBs
+      // on the same cluster (which may legitimately open walsenders as part
+      // of real initial-sync flows) don't contaminate the check.
       const walsenders = await upstream<{count: number}[]>`
         SELECT COUNT(*)::int as count FROM pg_stat_activity
-         WHERE backend_type = 'walsender'`;
+         WHERE backend_type = 'walsender' AND datname = current_database()`;
       expect(walsenders[0].count).toBe(0);
     });
 

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
@@ -3058,19 +3058,17 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
       const lc = createSilentLogContext();
       await seedWithManyRows(upstream, 50);
 
-      // Isolate this test's tempdir so concurrent test configs (pg-15 /
-      // pg-16 / pg-17 / pg-18 run in parallel under one vitest invocation
-      // and all share the real OS tmpdir) can't race on `zero-shadow-sync-*`
-      // entries created by each other's runs.
+      // Isolate this test's scratch dir via parentDir so concurrent test
+      // configs (pg-15 / pg-16 / pg-17 / pg-18 run in parallel under one
+      // vitest invocation and all share the real OS tmpdir) can't race on
+      // `zero-shadow-sync-*` entries created by each other's runs.
       const testTmp = await mkdtemp(join(tmpdir(), 'shadow-cleanup-test-'));
-      const prevTmpdir = process.env.TMPDIR;
-      process.env.TMPDIR = testTmp;
       try {
         await shadowInitialSync(
           lc,
           SHADOW_SHARD,
           getConnectionURI(upstream),
-          {sampleRate: 0.5, maxRowsPerTable: 10},
+          {sampleRate: 0.5, maxRowsPerTable: 10, parentDir: testTmp},
           TEST_CONTEXT,
         );
 
@@ -3080,11 +3078,6 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
         expect(await countSlots(upstream)).toBe(0);
         expect(await countReplicas(upstream)).toBe(0);
       } finally {
-        if (prevTmpdir === undefined) {
-          delete process.env.TMPDIR;
-        } else {
-          process.env.TMPDIR = prevTmpdir;
-        }
         await rm(testTmp, {recursive: true, force: true});
       }
     });

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
@@ -1,8 +1,12 @@
 import {readdir} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
+import {LogContext} from '@rocicorp/logger';
 import {nanoid} from 'nanoid/non-secure';
 import {beforeEach, describe, expect} from 'vitest';
-import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
+import {
+  createSilentLogContext,
+  TestLogSink,
+} from '../../../../../shared/src/logging-test-utils.ts';
 import type {ZeroEvent} from '../../../../../zero-events/src/index.ts';
 import {Database} from '../../../../../zqlite/src/db.ts';
 import {listIndexes, listTables} from '../../../db/lite-tables.ts';
@@ -3011,6 +3015,37 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
       expect(await countReplicas(upstream)).toBe(1);
     });
 
+    test('shadowInitialSync uses a single table-copy worker', async () => {
+      await seedWithManyRows(upstream, 20);
+      // Publish an extra table so numTables > 1 — otherwise
+      // `Math.min(tableCopyWorkers, numTables)` would clamp to 1 regardless.
+      await upstream`CREATE TABLE extra(id int4 PRIMARY KEY)`;
+      await upstream`INSERT INTO extra(id) VALUES (1)`;
+
+      const sink = new TestLogSink();
+      const lc = new LogContext('info', undefined, sink);
+
+      await shadowInitialSync(
+        lc,
+        SHADOW_SHARD,
+        getConnectionURI(upstream),
+        {sampleRate: 1, maxRowsPerTable: 5},
+        TEST_CONTEXT,
+      );
+
+      const workersLog = sink.messages.find(([, , args]) =>
+        args.some(
+          a =>
+            typeof a === 'string' &&
+            a.startsWith('Started ') &&
+            a.includes(' workers to copy '),
+        ),
+      );
+      expect(workersLog?.[2][0]).toMatch(
+        /^Started 1 workers to copy [2-9]\d* tables$/,
+      );
+    });
+
     test('shadowInitialSync wrapper cleans up tempfile dir', async () => {
       const lc = createSilentLogContext();
       await seedWithManyRows(upstream, 50);
@@ -3025,7 +3060,6 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
         getConnectionURI(upstream),
         {sampleRate: 0.5, maxRowsPerTable: 10},
         TEST_CONTEXT,
-        {tableCopyWorkers: 1},
       );
 
       const after = (await readdir(tmpdir())).filter(n =>

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
@@ -1,3 +1,5 @@
+import {readdir} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
 import {nanoid} from 'nanoid/non-secure';
 import {beforeEach, describe, expect} from 'vitest';
 import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
@@ -20,10 +22,15 @@ import {
 import {PG_17} from '../../../types/pg-versions.ts';
 import type {PostgresDB} from '../../../types/pg.ts';
 import {ZERO_VERSION_COLUMN_NAME} from '../../replicator/schema/replication-state.ts';
-import {initialSync, INSERT_BATCH_SIZE} from './initial-sync.ts';
+import {
+  initialSync,
+  INSERT_BATCH_SIZE,
+  shadowInitialSync,
+} from './initial-sync.ts';
 import {fromStateVersionString} from './lsn.ts';
 import {ensureShardSchema} from './schema/init.ts';
 import {getPublicationInfo} from './schema/published.ts';
+import {replicationSlotExpression} from './schema/shard.ts';
 import {UnsupportedTableSchemaError} from './schema/validation.ts';
 
 const APP_ID = '1';
@@ -2749,6 +2756,12 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
       result = e;
     }
     expect(result).toBeInstanceOf(UnsupportedTableSchemaError);
+
+    // Regression: real-path initial-sync must clean up its orphaned slot.
+    const leftoverSlots = await upstream<{slotName: string}[]>`
+      SELECT slot_name as "slotName" FROM pg_replication_slots
+       WHERE slot_name LIKE ${replicationSlotExpression(shardConfig)}`;
+    expect(leftoverSlots).toEqual([]);
   });
 
   test.each([
@@ -2869,5 +2882,159 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
     expect(String(result)).toEqual(
       'Error: The App ID may only consist of lower-case letters, numbers, and the underscore character',
     );
+  });
+
+  describe('shadow initial sync', () => {
+    const SHADOW_SHARD = {
+      appID: APP_ID,
+      shardNum: SHARD_NUM,
+      publications: [],
+    } as const;
+    const SLOT_LIKE = replicationSlotExpression(SHADOW_SHARD);
+
+    async function seedWithManyRows(upstream: PostgresDB, rows: number) {
+      await upstream`CREATE TABLE big(id int4 PRIMARY KEY, val text)`;
+      await upstream`
+        INSERT INTO big (id, val)
+          SELECT g, 'row-' || g FROM generate_series(1, ${rows}) g`;
+      await ensureShardSchema(createSilentLogContext(), upstream, SHADOW_SHARD);
+    }
+
+    async function countSlots(upstream: PostgresDB): Promise<number> {
+      const [{count}] = await upstream<{count: number}[]>`
+        SELECT COUNT(*)::int as count FROM pg_replication_slots
+         WHERE slot_name LIKE ${SLOT_LIKE}`;
+      return count;
+    }
+
+    async function countReplicas(upstream: PostgresDB): Promise<number> {
+      const schema = `${APP_ID}_${SHARD_NUM}`;
+      const [{count}] = await upstream<{count: number}[]>`
+        SELECT COUNT(*)::int as count FROM ${upstream(schema)}."replicas"`;
+      return count;
+    }
+
+    test('does not create a replication slot, add a replicas row, or publish events', async () => {
+      const lc = createSilentLogContext();
+      await seedWithManyRows(upstream, 200);
+
+      const slotsBefore = await countSlots(upstream);
+      const replicasBefore = await countReplicas(upstream);
+      expect(slotsBefore).toBe(0);
+      expect(replicasBefore).toBe(0);
+
+      const eventSink: ZeroEvent[] = [];
+      initEventSinkForTesting(eventSink);
+
+      const replica = new Database(lc, ':memory:');
+      await initialSync(
+        lc,
+        SHADOW_SHARD,
+        replica,
+        getConnectionURI(upstream),
+        {tableCopyWorkers: 2, shadow: {sampleRate: 0.5, maxRowsPerTable: 20}},
+        TEST_CONTEXT,
+      );
+
+      expect(await countSlots(upstream)).toBe(0);
+      expect(await countReplicas(upstream)).toBe(0);
+      expect(eventSink).toEqual([]);
+
+      // And no walsender connections should have been opened.
+      const walsenders = await upstream<{count: number}[]>`
+        SELECT COUNT(*)::int as count FROM pg_stat_activity
+         WHERE backend_type = 'walsender'`;
+      expect(walsenders[0].count).toBe(0);
+    });
+
+    test('caps rows per table via sampleRate + maxRowsPerTable', async () => {
+      const lc = createSilentLogContext();
+      await seedWithManyRows(upstream, 500);
+
+      const replica = new Database(lc, ':memory:');
+      await initialSync(
+        lc,
+        SHADOW_SHARD,
+        replica,
+        getConnectionURI(upstream),
+        {tableCopyWorkers: 2, shadow: {sampleRate: 0.2, maxRowsPerTable: 25}},
+        TEST_CONTEXT,
+      );
+
+      const [{count}] = replica
+        .prepare('SELECT COUNT(*) as count FROM big')
+        .all<{count: number}>();
+      expect(count).toBeLessThanOrEqual(25);
+      expect(count).toBeLessThan(500);
+    });
+
+    test('shadow failure does not drop or touch existing replication slots', async () => {
+      const lc = createSilentLogContext();
+
+      // First establish a real shard + slot via a normal initial sync.
+      await upstream`CREATE TABLE foo(id int4 PRIMARY KEY)`;
+      await upstream`INSERT INTO foo(id) VALUES (1)`;
+      const real = new Database(lc, ':memory:');
+      await initialSync(
+        lc,
+        SHADOW_SHARD,
+        real,
+        getConnectionURI(upstream),
+        {tableCopyWorkers: 1},
+        TEST_CONTEXT,
+      );
+      expect(await countSlots(upstream)).toBe(1);
+      expect(await countReplicas(upstream)).toBe(1);
+
+      // Force a shadow failure mid-sync by adding an invalid table to the
+      // publication after shard setup.
+      await upstream`CREATE TABLE "has/inval!d/ch@aracter$"(id int4)`;
+
+      const replica = new Database(lc, ':memory:');
+      let err: unknown;
+      try {
+        await initialSync(
+          lc,
+          SHADOW_SHARD,
+          replica,
+          getConnectionURI(upstream),
+          {tableCopyWorkers: 1, shadow: {sampleRate: 1}},
+          TEST_CONTEXT,
+        );
+      } catch (e) {
+        err = e;
+      }
+      expect(err).toBeInstanceOf(UnsupportedTableSchemaError);
+
+      // The pre-existing slot and replica row must be untouched.
+      expect(await countSlots(upstream)).toBe(1);
+      expect(await countReplicas(upstream)).toBe(1);
+    });
+
+    test('shadowInitialSync wrapper cleans up tempfile dir', async () => {
+      const lc = createSilentLogContext();
+      await seedWithManyRows(upstream, 50);
+
+      const before = (await readdir(tmpdir())).filter(n =>
+        n.startsWith('zero-shadow-sync-'),
+      );
+
+      await shadowInitialSync(
+        lc,
+        SHADOW_SHARD,
+        getConnectionURI(upstream),
+        {sampleRate: 0.5, maxRowsPerTable: 10},
+        TEST_CONTEXT,
+        {tableCopyWorkers: 1},
+      );
+
+      const after = (await readdir(tmpdir())).filter(n =>
+        n.startsWith('zero-shadow-sync-'),
+      );
+      expect(after).toEqual(before);
+      // And it still left no upstream footprint.
+      expect(await countSlots(upstream)).toBe(0);
+      expect(await countReplicas(upstream)).toBe(0);
+    });
   });
 });

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
@@ -3006,7 +3006,7 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
           SHADOW_SHARD,
           replica,
           getConnectionURI(upstream),
-          {tableCopyWorkers: 1, shadow: {sampleRate: 1}},
+          {tableCopyWorkers: 1, shadow: {sampleRate: 1, maxRowsPerTable: 100}},
           TEST_CONTEXT,
         );
       } catch (e) {
@@ -3085,7 +3085,7 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
           SHADOW_SHARD,
           replica,
           getConnectionURI(upstream),
-          {tableCopyWorkers: 1, shadow: {sampleRate: 1}},
+          {tableCopyWorkers: 1, shadow: {sampleRate: 1, maxRowsPerTable: 100}},
           TEST_CONTEXT,
         );
         const {publications} = await getInternalShardConfig(

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.test.ts
@@ -1,0 +1,79 @@
+import {describe, expect, test} from 'vitest';
+import type {PublishedTableSpec} from '../../../db/specs.ts';
+import {makeDownloadStatements} from './initial-sync.ts';
+
+function spec(
+  publications: Record<string, {rowFilter: string | null}> = {
+    pub1: {rowFilter: null},
+  },
+): PublishedTableSpec {
+  return {
+    schema: 'public',
+    name: 't',
+    publications,
+  } as unknown as PublishedTableSpec;
+}
+
+describe('makeDownloadStatements', () => {
+  test('default path has no TABLESAMPLE or LIMIT', () => {
+    const stmts = makeDownloadStatements(spec(), ['a', 'b']);
+    expect(stmts.select).not.toMatch(/TABLESAMPLE/i);
+    expect(stmts.select).not.toMatch(/\bLIMIT\b/i);
+    expect(stmts.getTotalRows).not.toMatch(/TABLESAMPLE/i);
+    expect(stmts.getTotalRows).not.toMatch(/FROM \(/i);
+    expect(stmts.getTotalBytes).not.toMatch(/TABLESAMPLE/i);
+    expect(stmts.getTotalBytes).not.toMatch(/FROM \(/i);
+    expect(stmts.select).toBe(`SELECT "a","b" FROM "public"."t" `);
+  });
+
+  test('sampleRate === 1 does not inject TABLESAMPLE', () => {
+    const stmts = makeDownloadStatements(spec(), ['a'], 1);
+    expect(stmts.select).not.toMatch(/TABLESAMPLE/i);
+    expect(stmts.select).not.toMatch(/\bLIMIT\b/i);
+  });
+
+  test('sampleRate undefined does not inject TABLESAMPLE', () => {
+    const stmts = makeDownloadStatements(spec(), ['a'], undefined);
+    expect(stmts.select).not.toMatch(/TABLESAMPLE/i);
+  });
+
+  test('sampleRate < 1 injects TABLESAMPLE BERNOULLI', () => {
+    const stmts = makeDownloadStatements(spec(), ['a'], 0.25);
+    expect(stmts.select).toMatch(/ TABLESAMPLE BERNOULLI\(25\) /);
+    expect(stmts.getTotalRows).toMatch(/ TABLESAMPLE BERNOULLI\(25\) /);
+    expect(stmts.getTotalBytes).toMatch(/ TABLESAMPLE BERNOULLI\(25\) /);
+    // No LIMIT without maxRowsPerTable.
+    expect(stmts.select).not.toMatch(/\bLIMIT\b/i);
+  });
+
+  test('maxRowsPerTable injects LIMIT and wraps counts in subquery', () => {
+    const stmts = makeDownloadStatements(spec(), ['a', 'b'], undefined, 50);
+    expect(stmts.select).toMatch(/ LIMIT 50$/);
+    expect(stmts.getTotalRows).toMatch(
+      /SELECT COUNT\(\*\)::bigint AS "totalRows" FROM \(SELECT 1 AS _ FROM .* LIMIT 50\) s/,
+    );
+    expect(stmts.getTotalBytes).toMatch(
+      /SELECT COALESCE\(SUM\(b\), 0\)::bigint AS "totalBytes" FROM \(SELECT \(.+\) AS b FROM .* LIMIT 50\) s/,
+    );
+  });
+
+  test('sample + limit compose', () => {
+    const stmts = makeDownloadStatements(spec(), ['a'], 0.5, 10);
+    expect(stmts.select).toMatch(
+      /SELECT "a" FROM "public"\."t" TABLESAMPLE BERNOULLI\(50\) \s*LIMIT 10$/,
+    );
+    expect(stmts.getTotalRows).toMatch(/TABLESAMPLE BERNOULLI\(50\)/);
+    expect(stmts.getTotalRows).toMatch(/LIMIT 10\) s$/);
+  });
+
+  test('row filters still appear in WHERE clause alongside sampling', () => {
+    const stmts = makeDownloadStatements(
+      spec({p: {rowFilter: 'a > 10'}}),
+      ['a'],
+      0.5,
+    );
+    expect(stmts.select).toMatch(
+      /FROM "public"\."t" TABLESAMPLE BERNOULLI\(50\) WHERE a > 10/,
+    );
+  });
+});

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.test.ts
@@ -1,6 +1,11 @@
 import {describe, expect, test} from 'vitest';
+import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
 import type {PublishedTableSpec} from '../../../db/specs.ts';
-import {makeDownloadStatements} from './initial-sync.ts';
+import type {PostgresDB} from '../../../types/pg.ts';
+import {
+  getInitialDownloadState,
+  makeDownloadStatements,
+} from './initial-sync.ts';
 
 function spec(
   publications: Record<string, {rowFilter: string | null}> = {
@@ -75,5 +80,66 @@ describe('makeDownloadStatements', () => {
     expect(stmts.select).toMatch(
       /FROM "public"\."t" TABLESAMPLE BERNOULLI\(50\) WHERE a > 10/,
     );
+  });
+});
+
+describe('getInitialDownloadState', () => {
+  function tableSpec(): PublishedTableSpec {
+    return {
+      schema: 'public',
+      name: 't',
+      columns: {a: {dataType: 'int4'}, b: {dataType: 'text'}},
+      publications: {pub1: {rowFilter: null}},
+    } as unknown as PublishedTableSpec;
+  }
+
+  test('skipTotals=true returns zeros without touching the DB', async () => {
+    let called = false;
+    const sql = {
+      unsafe() {
+        called = true;
+        throw new Error('sql should not be called when skipTotals=true');
+      },
+    } as unknown as PostgresDB;
+
+    const state = await getInitialDownloadState(
+      createSilentLogContext(),
+      sql,
+      tableSpec(),
+      true,
+    );
+    expect(called).toBe(false);
+    expect(state.status).toEqual({
+      table: 't',
+      columns: ['a', 'b'],
+      rows: 0,
+      totalRows: 0,
+      totalBytes: 0,
+    });
+  });
+
+  test('skipTotals=false runs the expensive queries', async () => {
+    const received: string[] = [];
+    const sql = {
+      unsafe(stmt: string) {
+        received.push(stmt);
+        const row = stmt.includes('totalRows')
+          ? [{totalRows: 42n}]
+          : [{totalBytes: 1024n}];
+        return {execute: () => Promise.resolve(row)};
+      },
+    } as unknown as PostgresDB;
+
+    const state = await getInitialDownloadState(
+      createSilentLogContext(),
+      sql,
+      tableSpec(),
+      false,
+    );
+    expect(received).toHaveLength(2);
+    expect(received.some(s => s.includes('COUNT(*)'))).toBe(true);
+    expect(received.some(s => s.includes('pg_column_size'))).toBe(true);
+    expect(state.status.totalRows).toBe(42);
+    expect(state.status.totalBytes).toBe(1024);
   });
 });

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
@@ -152,7 +152,10 @@ export async function initialSync(
     let lsn: string;
 
     if (shadow) {
-      const acquired = await acquireExportedSnapshot(lc, upstreamURI);
+      const acquired = await acquireExportedSnapshotForShadowSync(
+        lc,
+        upstreamURI,
+      );
       snapshot = acquired.snapshot;
       lsn = acquired.lsn;
       releaseShadowSnapshot = acquired.release;
@@ -517,7 +520,7 @@ type ReplicationSlot = {
  * Idle-in-transaction timeout is disabled locally so the exporter doesn't
  * get killed while workers are still importing.
  */
-async function acquireExportedSnapshot(
+async function acquireExportedSnapshotForShadowSync(
   lc: LogContext,
   upstreamURI: string,
 ): Promise<{
@@ -692,8 +695,9 @@ export async function getInitialDownloadState(
   const table = liteTableName(spec);
   const columns = Object.keys(spec.columns);
   if (skipTotals) {
-    // Shadow sync suppresses status events, so the expensive COUNT(*) and
+    // Shadow sync suppresses status events, so the COUNT(*) and
     // per-column pg_column_size sums would be computed and thrown away.
+    // These are also expensive statements that run table scans.
     return {
       spec,
       status: {table, columns, rows: 0, totalRows: 0, totalBytes: 0},

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
@@ -19,6 +19,11 @@ import {
   createLiteIndexStatement,
   createLiteTableStatement,
 } from '../../../db/create.ts';
+import {
+  computeZqlSpecs,
+  listIndexes,
+  listTables,
+} from '../../../db/lite-tables.ts';
 import * as Mode from '../../../db/mode-enum.ts';
 import {
   BinaryCopyParser,
@@ -307,7 +312,13 @@ export async function initialSync(
       const index = performance.now() - indexStart;
       lc.info?.(`Created indexes (${index.toFixed(3)} ms)`);
 
-      if (!shadow) {
+      if (shadow) {
+        const rowsByTable = new Map<string, number>();
+        for (let i = 0; i < downloads.length; i++) {
+          rowsByTable.set(downloads[i].status.table, rowCounts[i].rows);
+        }
+        verifyShadowReplica(lc, tx, published, rowsByTable);
+      } else {
         await addReplica(
           sql,
           shard,
@@ -605,6 +616,102 @@ function createLiteTables(
 function createLiteIndices(tx: Database, indices: IndexSpec[]) {
   for (const index of indices) {
     tx.exec(createLiteIndexStatement(mapPostgresToLiteIndex(index)));
+  }
+}
+
+/**
+ * Runs structural assertions over a just-synced replica and throws if any
+ * fail. Only called in shadow mode — a successful return means the replica
+ * is schema-complete, row-count consistent, ZQL-queryable, and its column
+ * metadata is in sync with its lite schema.
+ *
+ * Exported for testing.
+ */
+export function verifyShadowReplica(
+  lc: LogContext,
+  db: Database,
+  published: {tables: PublishedTableSpec[]; indexes: IndexSpec[]},
+  rowsByTable: ReadonlyMap<string, number>,
+): void {
+  const issues: string[] = [];
+
+  // 1. Schema completeness: every published table exists in the replica
+  //    with at least the expected column set.
+  const liteTables = listTables(db);
+  const liteTableByName = new Map(liteTables.map(t => [t.name, t]));
+  for (const pt of published.tables) {
+    const name = liteTableName(pt);
+    const lite = liteTableByName.get(name);
+    if (!lite) {
+      issues.push(`missing table in replica: ${name}`);
+      continue;
+    }
+    for (const col of Object.keys(pt.columns)) {
+      if (!(col in lite.columns)) {
+        issues.push(`column missing in replica table ${name}: ${col}`);
+      }
+    }
+  }
+
+  //    Every published index exists in the replica.
+  const liteIndexNames = new Set(listIndexes(db).map(i => i.name));
+  for (const ix of published.indexes) {
+    const mapped = mapPostgresToLiteIndex(ix);
+    if (!liteIndexNames.has(mapped.name)) {
+      issues.push(
+        `missing index in replica: ${mapped.name} on ${mapped.tableName}`,
+      );
+    }
+  }
+
+  // 2. Row counts: SQLite COUNT(*) matches the in-memory copy counter.
+  for (const [table, expected] of rowsByTable) {
+    try {
+      const [row] = db
+        .prepare(`SELECT COUNT(*) as count FROM "${table}"`)
+        .all<{count: number}>();
+      if (row.count !== expected) {
+        issues.push(
+          `row count mismatch for table ${table}: ` +
+            `copy counter reported ${expected}, replica has ${row.count}`,
+        );
+      }
+    } catch (e) {
+      issues.push(`could not count rows in table ${table}: ${String(e)}`);
+    }
+  }
+
+  // 3. ZQL-queryability: every published table survives computeZqlSpecs's
+  //    filtering (primary-key candidate, ZQL-typed columns, etc.).
+  const tableSpecs = computeZqlSpecs(lc, db, {
+    includeBackfillingColumns: false,
+  });
+  for (const pt of published.tables) {
+    const name = liteTableName(pt);
+    if (!tableSpecs.has(name)) {
+      issues.push(
+        `table not queryable via ZQL (dropped by computeZqlSpecs): ${name}`,
+      );
+    }
+  }
+
+  // 4. Column metadata: every published column has a _zero.column_metadata row.
+  const meta = must(ColumnMetadataStore.getInstance(db));
+  for (const pt of published.tables) {
+    const name = liteTableName(pt);
+    const rows = meta.getTable(name);
+    for (const col of Object.keys(pt.columns)) {
+      if (!rows.has(col)) {
+        issues.push(`missing column_metadata row for ${name}.${col}`);
+      }
+    }
+  }
+
+  if (issues.length) {
+    throw new Error(
+      `Shadow replica verification failed (${issues.length} issue(s)):\n` +
+        issues.map(i => `  - ${i}`).join('\n'),
+    );
   }
 }
 

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
@@ -1,4 +1,6 @@
-import {platform} from 'node:os';
+import {mkdtemp, rm} from 'node:fs/promises';
+import {platform, tmpdir} from 'node:os';
+import {join} from 'node:path';
 import {Writable} from 'node:stream';
 import {pipeline} from 'node:stream/promises';
 import {
@@ -6,12 +8,13 @@ import {
   PG_INSUFFICIENT_PRIVILEGE,
 } from '@drdgvhbh/postgres-error-codes';
 import type {LogContext} from '@rocicorp/logger';
+import {resolver} from '@rocicorp/resolver';
 import postgres from 'postgres';
 import type {JSONObject} from '../../../../../shared/src/bigint-json.ts';
 import {must} from '../../../../../shared/src/must.ts';
 import {equals} from '../../../../../shared/src/set-utils.ts';
 import type {DownloadStatus} from '../../../../../zero-events/src/status.ts';
-import type {Database} from '../../../../../zqlite/src/db.ts';
+import {Database} from '../../../../../zqlite/src/db.ts';
 import {
   createLiteIndexStatement,
   createLiteTableStatement,
@@ -69,6 +72,21 @@ export type InitialSyncOptions = {
   profileCopy?: boolean | undefined;
   textCopy?: boolean | undefined;
   replicationSlotFailover?: boolean | undefined;
+  /**
+   * When set, run initial sync in "shadow" mode for verification: skip all
+   * upstream mutations (no replication slot, no addReplica, no dropShard, no
+   * slot drop on failure), suppress status events, and optionally sample
+   * rows from each table via TABLESAMPLE BERNOULLI + LIMIT. The caller is
+   * responsible for providing (and discarding) a throwaway SQLite `tx`.
+   */
+  shadow?:
+    | {
+        /** 0 < rate <= 1. When 1 (or undefined), no TABLESAMPLE clause is added. */
+        sampleRate: number;
+        /** Optional LIMIT N cap appended after TABLESAMPLE. */
+        maxRowsPerTable?: number | undefined;
+      }
+    | undefined;
 };
 
 /** Server context to store with the initial sync metadata for debugging. */
@@ -92,68 +110,98 @@ export async function initialSync(
     profileCopy,
     textCopy = false,
     replicationSlotFailover = false,
+    shadow,
   } = syncOptions;
   const copyProfiler = profileCopy ? await CpuProfiler.connect() : null;
   const sql = pgClient(lc, upstreamURI);
-  const replicationSession = pgClient(lc, upstreamURI, {
-    ['fetch_types']: false, // Necessary for the streaming protocol
-    connection: {replication: 'database'}, // https://www.postgresql.org/docs/current/protocol-replication.html
-  });
+  // Replication session is only needed to create a replication slot in the
+  // real path. In shadow mode we export a snapshot on a normal connection
+  // instead, so no replication session is opened.
+  const replicationSession = shadow
+    ? undefined
+    : pgClient(lc, upstreamURI, {
+        ['fetch_types']: false, // Necessary for the streaming protocol
+        connection: {replication: 'database'}, // https://www.postgresql.org/docs/current/protocol-replication.html
+      });
   const slotName = newReplicationSlot(shard);
   const statusPublisher = ReplicationStatusPublisher.forRunningTransaction(
     tx,
+    shadow ? async () => {} : undefined,
   ).publish(lc, 'Initializing');
+  let releaseShadowSnapshot: (() => Promise<void>) | undefined;
   try {
     const pgVersion = await checkUpstreamConfig(sql);
 
-    const {publications} = await ensurePublishedTables(lc, sql, shard);
+    // In shadow mode we assume the shard is already initialized and just
+    // read back the existing publications. `ensurePublishedTables` would
+    // otherwise run DDL and potentially call `dropShard`, which must never
+    // happen during a shadow run.
+    const {publications} = shadow
+      ? await getInternalShardConfig(sql, shard)
+      : await ensurePublishedTables(lc, sql, shard);
     lc.info?.(`Upstream is setup with publications [${publications}]`);
 
     const {database, host} = sql.options;
-    lc.info?.(`opening replication session to ${database}@${host}`);
+    lc.info?.(
+      shadow
+        ? `acquiring exported snapshot on ${database}@${host} (shadow mode)`
+        : `opening replication session to ${database}@${host}`,
+    );
 
-    let slot: ReplicationSlot;
-    for (let first = true; ; first = false) {
-      try {
-        slot = await createReplicationSlot(
-          lc,
-          replicationSession,
-          slotName,
-          replicationSlotFailover && pgVersion >= PG_17,
-        );
-        break;
-      } catch (e) {
-        if (first && e instanceof postgres.PostgresError) {
-          if (e.code === PG_INSUFFICIENT_PRIVILEGE) {
-            // Some Postgres variants (e.g. Google Cloud SQL) require that
-            // the user have the REPLICATION role in order to create a slot.
-            // Note that this must be done by the upstreamDB connection, and
-            // does not work in the replicationSession itself.
-            await sql`ALTER ROLE current_user WITH REPLICATION`;
-            lc.info?.(`Added the REPLICATION role to database user`);
-            continue;
-          }
-          if (e.code === PG_CONFIGURATION_LIMIT_EXCEEDED) {
-            const slotExpression = replicationSlotExpression(shard);
+    let snapshot: string;
+    let lsn: string;
 
-            const dropped = await sql<{slot: string}[]>`
-              SELECT slot_name as slot, pg_drop_replication_slot(slot_name) 
-                FROM pg_replication_slots
-                WHERE slot_name LIKE ${slotExpression} AND NOT active`;
-            if (dropped.length) {
-              lc.warn?.(
-                `Dropped inactive replication slots: ${dropped.map(({slot}) => slot)}`,
-                e,
-              );
+    if (shadow) {
+      const acquired = await acquireExportedSnapshot(lc, upstreamURI);
+      snapshot = acquired.snapshot;
+      lsn = acquired.lsn;
+      releaseShadowSnapshot = acquired.release;
+    } else {
+      let slot: ReplicationSlot;
+      for (let first = true; ; first = false) {
+        try {
+          slot = await createReplicationSlot(
+            lc,
+            must(replicationSession),
+            slotName,
+            replicationSlotFailover && pgVersion >= PG_17,
+          );
+          break;
+        } catch (e) {
+          if (first && e instanceof postgres.PostgresError) {
+            if (e.code === PG_INSUFFICIENT_PRIVILEGE) {
+              // Some Postgres variants (e.g. Google Cloud SQL) require that
+              // the user have the REPLICATION role in order to create a slot.
+              // Note that this must be done by the upstreamDB connection, and
+              // does not work in the replicationSession itself.
+              await sql`ALTER ROLE current_user WITH REPLICATION`;
+              lc.info?.(`Added the REPLICATION role to database user`);
               continue;
             }
-            lc.error?.(`Unable to drop replication slots`, e);
+            if (e.code === PG_CONFIGURATION_LIMIT_EXCEEDED) {
+              const slotExpression = replicationSlotExpression(shard);
+
+              const dropped = await sql<{slot: string}[]>`
+                SELECT slot_name as slot, pg_drop_replication_slot(slot_name)
+                  FROM pg_replication_slots
+                  WHERE slot_name LIKE ${slotExpression} AND NOT active`;
+              if (dropped.length) {
+                lc.warn?.(
+                  `Dropped inactive replication slots: ${dropped.map(({slot}) => slot)}`,
+                  e,
+                );
+                continue;
+              }
+              lc.error?.(`Unable to drop replication slots`, e);
+            }
           }
+          throw e;
         }
-        throw e;
       }
+      snapshot = slot.snapshot_name;
+      lsn = slot.consistent_point;
     }
-    const {snapshot_name: snapshot, consistent_point: lsn} = slot;
+
     const initialVersion = toStateVersionString(lsn);
 
     initReplicationState(tx, publications, initialVersion, context);
@@ -200,10 +248,12 @@ export async function initialSync(
     );
     try {
       createLiteTables(tx, tables, initialVersion);
+      const sampleRate = shadow?.sampleRate;
+      const maxRowsPerTable = shadow?.maxRowsPerTable;
       const downloads = await Promise.all(
         tables.map(spec =>
           copiers.processReadTask((db, lc) =>
-            getInitialDownloadState(lc, db, spec),
+            getInitialDownloadState(lc, db, spec, sampleRate, maxRowsPerTable),
           ),
         ),
       );
@@ -219,7 +269,16 @@ export async function initialSync(
       const rowCounts = await Promise.all(
         downloads.map(table =>
           copiers.processReadTask((db, lc) =>
-            copy(lc, table, copyPool, db, tx, textCopy),
+            copy(
+              lc,
+              table,
+              copyPool,
+              db,
+              tx,
+              textCopy,
+              sampleRate,
+              maxRowsPerTable,
+            ),
           ),
         ),
       );
@@ -245,14 +304,16 @@ export async function initialSync(
       const index = performance.now() - indexStart;
       lc.info?.(`Created indexes (${index.toFixed(3)} ms)`);
 
-      await addReplica(
-        sql,
-        shard,
-        slotName,
-        initialVersion,
-        published,
-        context,
-      );
+      if (!shadow) {
+        await addReplica(
+          sql,
+          shard,
+          slotName,
+          initialVersion,
+          published,
+          context,
+        );
+      }
 
       const elapsed = performance.now() - start;
       lc.info?.(
@@ -264,19 +325,82 @@ export async function initialSync(
       void copyPool.end().catch(e => lc.warn?.(`Error closing copyPool`, e));
     }
   } catch (e) {
-    // If initial-sync did not succeed, make a best effort to drop the
-    // orphaned replication slot to avoid running out of slots in
-    // pathological cases that result in repeated failures.
-    lc.warn?.(`dropping replication slot ${slotName}`, e);
-    await sql`
-      SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots
-        WHERE slot_name = ${slotName};
-    `.catch(e => lc.warn?.(`Unable to drop replication slot ${slotName}`, e));
+    if (!shadow) {
+      // If initial-sync did not succeed, make a best effort to drop the
+      // orphaned replication slot to avoid running out of slots in
+      // pathological cases that result in repeated failures.
+      lc.warn?.(`dropping replication slot ${slotName}`, e);
+      await sql`
+        SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots
+          WHERE slot_name = ${slotName};
+      `.catch(e => lc.warn?.(`Unable to drop replication slot ${slotName}`, e));
+    }
     await statusPublisher.publishAndThrowError(lc, 'Initializing', e);
   } finally {
     statusPublisher.stop();
-    await replicationSession.end();
+    if (releaseShadowSnapshot) {
+      await releaseShadowSnapshot().catch(e =>
+        lc.warn?.(`Error releasing shadow snapshot`, e),
+      );
+    }
+    if (replicationSession) {
+      await replicationSession.end();
+    }
     await sql.end();
+  }
+}
+
+export type ShadowSyncOptions = {
+  sampleRate: number;
+  maxRowsPerTable?: number | undefined;
+};
+
+/**
+ * Exercises the initial-sync code path against a sample of rows from every
+ * published table, writing into a throwaway SQLite database that is deleted
+ * when the run ends. Produces zero upstream mutations: no replication slot,
+ * no `addReplica`, no `dropShard`, no status events.
+ *
+ * Intended to be invoked periodically so that if a customer ever needs a
+ * full reset, we have recent confidence that `initialSync` still works.
+ * The shard must already be initialized upstream.
+ */
+export async function shadowInitialSync(
+  lc: LogContext,
+  shard: ShardConfig,
+  upstreamURI: string,
+  shadow: ShadowSyncOptions,
+  context: ServerContext,
+  syncOptions?: Omit<
+    InitialSyncOptions,
+    'shadow' | 'profileCopy' | 'replicationSlotFailover'
+  >,
+): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), 'zero-shadow-sync-'));
+  const dbPath = join(dir, 'shadow-replica.db');
+  const db = new Database(lc, dbPath);
+  try {
+    await initialSync(
+      lc,
+      shard,
+      db,
+      upstreamURI,
+      {
+        tableCopyWorkers: syncOptions?.tableCopyWorkers ?? 5,
+        textCopy: syncOptions?.textCopy,
+        shadow,
+      },
+      context,
+    );
+  } finally {
+    try {
+      db.close();
+    } catch (e) {
+      lc.warn?.(`Error closing shadow replica db`, e);
+    }
+    await rm(dir, {recursive: true, force: true}).catch(e =>
+      lc.warn?.(`Error cleaning up shadow replica dir ${dir}`, e),
+    );
   }
 }
 
@@ -384,6 +508,60 @@ type ReplicationSlot = {
   output_plugin: string;
 };
 
+/**
+ * Shadow-mode alternative to `createReplicationSlot`: opens a dedicated
+ * READ ONLY REPEATABLE READ transaction on a normal connection, exports the
+ * snapshot and captures the current WAL LSN, then holds the transaction
+ * open until `release()` is called. The held transaction keeps the snapshot
+ * importable by the table-copy workers for the duration of the COPY phase.
+ *
+ * Idle-in-transaction timeout is disabled locally so the exporter doesn't
+ * get killed while workers are still importing.
+ */
+async function acquireExportedSnapshot(
+  lc: LogContext,
+  upstreamURI: string,
+): Promise<{
+  snapshot: string;
+  lsn: string;
+  release: () => Promise<void>;
+}> {
+  const holder = pgClient(lc, upstreamURI, {
+    max: 1,
+    connection: {['application_name']: 'shadow-initial-sync-snapshot'},
+  });
+  const ready = resolver<{snapshot: string; lsn: string}>();
+  const release = resolver<void>();
+  const held = holder
+    .begin(Mode.READONLY, async tx => {
+      await tx`SET LOCAL idle_in_transaction_session_timeout = 0`.execute();
+      const [row] = await tx<{snapshot: string; lsn: string}[]>`
+        SELECT pg_export_snapshot() AS snapshot,
+               pg_current_wal_lsn()::text AS lsn`;
+      ready.resolve(row);
+      await release.promise;
+    })
+    .catch(e => ready.reject(e));
+
+  const {snapshot, lsn} = await ready.promise;
+  lc.info?.(
+    `Exported snapshot ${snapshot} at LSN ${lsn} (shadow initial sync)`,
+  );
+  return {
+    snapshot,
+    lsn,
+    release: async () => {
+      release.resolve();
+      try {
+        await held;
+      } catch (e) {
+        lc.warn?.(`snapshot holder transaction ended with error`, e);
+      }
+      await holder.end();
+    },
+  };
+}
+
 // Note: The replication connection does not support the extended query protocol,
 //       so all commands must be sent using sql.unsafe(). This is technically safe
 //       because all placeholder values are under our control (i.e. "slotName").
@@ -444,9 +622,29 @@ export type DownloadStatements = {
   getTotalBytes: string;
 };
 
+/**
+ * Produces ` TABLESAMPLE BERNOULLI(n)` when `sampleRate` is < 1, else `''`.
+ * Row-level Bernoulli sampling is used (rather than SYSTEM) because it
+ * produces a more uniform sample and, unlike SYSTEM, still returns rows
+ * for small tables at low rates.
+ */
+function tableSampleClause(sampleRate: number | undefined): string {
+  return sampleRate !== undefined && sampleRate < 1
+    ? /*sql*/ ` TABLESAMPLE BERNOULLI(${sampleRate * 100})`
+    : '';
+}
+
+function limitClause(maxRowsPerTable: number | undefined): string {
+  return maxRowsPerTable !== undefined
+    ? /*sql*/ ` LIMIT ${maxRowsPerTable}`
+    : '';
+}
+
 export function makeDownloadStatements(
   table: PublishedTableSpec,
   cols: string[],
+  sampleRate?: number | undefined,
+  maxRowsPerTable?: number | undefined,
 ): DownloadStatements {
   const filterConditions = Object.values(table.publications)
     .map(({rowFilter}) => rowFilter)
@@ -455,14 +653,28 @@ export function makeDownloadStatements(
     filterConditions.length === 0
       ? ''
       : /*sql*/ `WHERE ${filterConditions.join(' OR ')}`;
-  const fromTable = /*sql*/ `FROM ${id(table.schema)}.${id(table.name)} ${where}`;
+  const sample = tableSampleClause(sampleRate);
+  const limit = limitClause(maxRowsPerTable);
+  const fromTable = /*sql*/ `FROM ${id(table.schema)}.${id(table.name)}${sample} ${where}`;
+  const select = /*sql*/ `SELECT ${cols.map(id).join(',')} ${fromTable}${limit}`;
+  if (limit) {
+    // With LIMIT, wrap counts/sums in a subquery so they reflect the
+    // capped rowset rather than the full (sampled) table.
+    const bytesExpr = cols
+      .map(col => `COALESCE(pg_column_size(${id(col)}), 0)`)
+      .join(' + ');
+    return {
+      select,
+      getTotalRows: /*sql*/ `SELECT COUNT(*)::bigint AS "totalRows" FROM (SELECT 1 AS _ ${fromTable}${limit}) s`,
+      getTotalBytes: /*sql*/ `SELECT COALESCE(SUM(b), 0)::bigint AS "totalBytes" FROM (SELECT (${bytesExpr}) AS b ${fromTable}${limit}) s`,
+    };
+  }
   const totalBytes = `(${cols.map(col => `SUM(COALESCE(pg_column_size(${id(col)}), 0))`).join(' + ')})`;
-  const stmts = {
-    select: /*sql*/ `SELECT ${cols.map(id).join(',')} ${fromTable}`,
+  return {
+    select,
     getTotalRows: /*sql*/ `SELECT COUNT(*) AS "totalRows" ${fromTable}`,
     getTotalBytes: /*sql*/ `SELECT ${totalBytes} AS "totalBytes" ${fromTable}`,
   };
-  return stmts;
 }
 
 type DownloadState = {
@@ -474,11 +686,18 @@ async function getInitialDownloadState(
   lc: LogContext,
   sql: PostgresDB,
   spec: PublishedTableSpec,
+  sampleRate?: number | undefined,
+  maxRowsPerTable?: number | undefined,
 ): Promise<DownloadState> {
   const start = performance.now();
   const table = liteTableName(spec);
   const columns = Object.keys(spec.columns);
-  const stmts = makeDownloadStatements(spec, columns);
+  const stmts = makeDownloadStatements(
+    spec,
+    columns,
+    sampleRate,
+    maxRowsPerTable,
+  );
   const rowsResult = sql
     .unsafe<{totalRows: bigint}[]>(stmts.getTotalRows)
     .execute();
@@ -510,11 +729,22 @@ function copy(
   from: PostgresTransaction,
   to: Database,
   textCopy: boolean,
+  sampleRate?: number | undefined,
+  maxRowsPerTable?: number | undefined,
 ) {
   if (textCopy) {
-    return copyText(lc, table, status, dbClient, from, to);
+    return copyText(
+      lc,
+      table,
+      status,
+      dbClient,
+      from,
+      to,
+      sampleRate,
+      maxRowsPerTable,
+    );
   }
-  return copyBinary(lc, table, status, from, to);
+  return copyBinary(lc, table, status, from, to, sampleRate, maxRowsPerTable);
 }
 
 async function copyBinary(
@@ -523,6 +753,8 @@ async function copyBinary(
   status: DownloadStatus,
   from: PostgresTransaction,
   to: Database,
+  sampleRate?: number | undefined,
+  maxRowsPerTable?: number | undefined,
 ) {
   const start = performance.now();
   let flushTime = 0;
@@ -551,11 +783,13 @@ async function copyBinary(
     filterConditions.length === 0
       ? ''
       : /*sql*/ `WHERE ${filterConditions.join(' OR ')}`;
-  const fromTable = /*sql*/ `FROM ${id(table.schema)}.${id(table.name)} ${where}`;
+  const sample = tableSampleClause(sampleRate);
+  const limit = limitClause(maxRowsPerTable);
+  const fromTable = /*sql*/ `FROM ${id(table.schema)}.${id(table.name)}${sample} ${where}`;
   const selectColumns = orderedColumns.map(([name, spec]) =>
     hasBinaryDecoder(spec) ? id(name) : `${id(name)}::text`,
   );
-  const select = /*sql*/ `SELECT ${selectColumns.join(',')} ${fromTable}`;
+  const select = /*sql*/ `SELECT ${selectColumns.join(',')} ${fromTable}${limit}`;
 
   const decoders = orderedColumns.map(([, spec]) =>
     hasBinaryDecoder(spec) ? makeBinaryDecoder(spec) : textCastDecoder,
@@ -661,6 +895,8 @@ async function copyText(
   dbClient: PostgresDB,
   from: PostgresTransaction,
   to: Database,
+  sampleRate?: number | undefined,
+  maxRowsPerTable?: number | undefined,
 ) {
   const start = performance.now();
   let flushTime = 0;
@@ -681,7 +917,12 @@ async function copyText(
     insertSql + `,${valuesSql}`.repeat(INSERT_BATCH_SIZE - 1),
   );
 
-  const {select} = makeDownloadStatements(table, columnNames);
+  const {select} = makeDownloadStatements(
+    table,
+    columnNames,
+    sampleRate,
+    maxRowsPerTable,
+  );
   const valuesPerRow = columnSpecs.length;
   const valuesPerBatch = valuesPerRow * INSERT_BATCH_SIZE;
 

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
@@ -371,10 +371,7 @@ export async function shadowInitialSync(
   upstreamURI: string,
   shadow: ShadowSyncOptions,
   context: ServerContext,
-  syncOptions?: Omit<
-    InitialSyncOptions,
-    'shadow' | 'profileCopy' | 'replicationSlotFailover'
-  >,
+  syncOptions?: Pick<InitialSyncOptions, 'textCopy'>,
 ): Promise<void> {
   const dir = await mkdtemp(join(tmpdir(), 'zero-shadow-sync-'));
   const dbPath = join(dir, 'shadow-replica.db');
@@ -386,7 +383,9 @@ export async function shadowInitialSync(
       db,
       upstreamURI,
       {
-        tableCopyWorkers: syncOptions?.tableCopyWorkers ?? 5,
+        // Shadow sync copies small samples, so one worker is plenty —
+        // no reason to burn additional upstream connections.
+        tableCopyWorkers: 1,
         textCopy: syncOptions?.textCopy,
         shadow,
       },

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
@@ -370,6 +370,11 @@ export async function initialSync(
 export type ShadowSyncOptions = {
   sampleRate: number;
   maxRowsPerTable: number;
+  /**
+   * Parent directory for the throwaway SQLite replica. Defaults to the OS
+   * tmpdir. Primarily for tests that need to isolate the scratch directory.
+   */
+  parentDir?: string | undefined;
 };
 
 /**
@@ -390,7 +395,9 @@ export async function shadowInitialSync(
   context: ServerContext,
   syncOptions?: Pick<InitialSyncOptions, 'textCopy'>,
 ): Promise<void> {
-  const dir = await mkdtemp(join(tmpdir(), 'zero-shadow-sync-'));
+  const dir = await mkdtemp(
+    join(shadow.parentDir ?? tmpdir(), 'zero-shadow-sync-'),
+  );
   const dbPath = join(dir, 'shadow-replica.db');
   const db = new Database(lc, dbPath);
   try {
@@ -559,7 +566,18 @@ async function acquireExportedSnapshotForShadowSync(
     })
     .catch(e => ready.reject(e));
 
-  const {snapshot, lsn} = await ready.promise;
+  let snapshot: string;
+  let lsn: string;
+  try {
+    ({snapshot, lsn} = await ready.promise);
+  } catch (e) {
+    await holder
+      .end()
+      .catch(err =>
+        lc.warn?.(`Error ending shadow snapshot holder after failure`, err),
+      );
+    throw e;
+  }
   lc.info?.(
     `Exported snapshot ${snapshot} at LSN ${lsn} (shadow initial sync)`,
   );
@@ -741,9 +759,13 @@ export type DownloadStatements = {
  * for small tables at low rates.
  */
 function tableSampleClause(sampleRate: number | undefined): string {
-  return sampleRate !== undefined && sampleRate < 1
-    ? /*sql*/ ` TABLESAMPLE BERNOULLI(${sampleRate * 100})`
-    : '';
+  if (sampleRate === undefined || sampleRate >= 1) {
+    return '';
+  }
+  // Round away float noise (e.g. 0.3 * 100 = 30.000000000000004) while still
+  // preserving sub-integer rates like 0.001 (= 0.1%).
+  const pct = parseFloat((sampleRate * 100).toFixed(6));
+  return /*sql*/ ` TABLESAMPLE BERNOULLI(${pct})`;
 }
 
 function limitClause(maxRowsPerTable: number | undefined): string {

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
@@ -86,10 +86,13 @@ export type InitialSyncOptions = {
    */
   shadow?:
     | {
-        /** 0 < rate <= 1. When 1 (or undefined), no TABLESAMPLE clause is added. */
+        /** 0 < rate <= 1. When 1, no TABLESAMPLE clause is added. */
         sampleRate: number;
-        /** Optional LIMIT N cap appended after TABLESAMPLE. */
-        maxRowsPerTable?: number | undefined;
+        /**
+         * LIMIT N cap appended after TABLESAMPLE. Required: shadow sync is
+         * for verification only, so every run must commit to a row budget.
+         */
+        maxRowsPerTable: number;
       }
     | undefined;
 };
@@ -366,7 +369,7 @@ export async function initialSync(
 
 export type ShadowSyncOptions = {
   sampleRate: number;
-  maxRowsPerTable?: number | undefined;
+  maxRowsPerTable: number;
 };
 
 /**

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
@@ -253,7 +253,7 @@ export async function initialSync(
       const downloads = await Promise.all(
         tables.map(spec =>
           copiers.processReadTask((db, lc) =>
-            getInitialDownloadState(lc, db, spec, sampleRate, maxRowsPerTable),
+            getInitialDownloadState(lc, db, spec, shadow !== undefined),
           ),
         ),
       );
@@ -682,22 +682,25 @@ type DownloadState = {
   status: DownloadStatus;
 };
 
-async function getInitialDownloadState(
+// Exported for testing.
+export async function getInitialDownloadState(
   lc: LogContext,
   sql: PostgresDB,
   spec: PublishedTableSpec,
-  sampleRate?: number | undefined,
-  maxRowsPerTable?: number | undefined,
+  skipTotals: boolean,
 ): Promise<DownloadState> {
   const start = performance.now();
   const table = liteTableName(spec);
   const columns = Object.keys(spec.columns);
-  const stmts = makeDownloadStatements(
-    spec,
-    columns,
-    sampleRate,
-    maxRowsPerTable,
-  );
+  if (skipTotals) {
+    // Shadow sync suppresses status events, so the expensive COUNT(*) and
+    // per-column pg_column_size sums would be computed and thrown away.
+    return {
+      spec,
+      status: {table, columns, rows: 0, totalRows: 0, totalBytes: 0},
+    };
+  }
+  const stmts = makeDownloadStatements(spec, columns);
   const rowsResult = sql
     .unsafe<{totalRows: bigint}[]>(stmts.getTotalRows)
     .execute();


### PR DESCRIPTION
`initialSync` runs only when a customer first onboards. If a customer ever
needs a full reset (schema drift, corruption, disaster recovery, support
request), we rely on that code path working — but it hasn't been exercised
on their data in months, and bugs can sit dormant until the moment they
matter most.

Shadow initial sync is a periodic canary. It exercises the real
`initialSync` code path against a small sample of every published table,
writes to a throwaway SQLite database, and verifies the resulting replica
is structurally sound. If the production code path is broken, shadow fails
before a real reset ever needs to run.

## For a follow up PR

- The scheduler that fires `shadowInitialSync` on an interval. 