### PR TITLE
fix(zero-cache): distinguish metrics across processes

### DIFF
--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -64,19 +64,11 @@ export default async function runWorker(
   } = config;
 
   startOtelAuto(
-    createLogContext(
-      config,
-      {worker: 'change-streamer', workerIndex: 0},
-      false,
-    ),
+    createLogContext(config, 'change-streamer', 0, false),
     'change-streamer',
     0,
   );
-  const lc = createLogContext(
-    config,
-    {worker: 'change-streamer', workerIndex: 0},
-    true,
-  );
+  const lc = createLogContext(config, 'change-streamer');
   initEventSink(lc, config);
 
   // Kick off DB connection warmup in the background.

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -64,10 +64,19 @@ export default async function runWorker(
   } = config;
 
   startOtelAuto(
-    createLogContext(config, {worker: 'change-streamer'}, false),
+    createLogContext(
+      config,
+      {worker: 'change-streamer', workerIndex: 0},
+      false,
+    ),
     'change-streamer',
+    0,
   );
-  const lc = createLogContext(config, {worker: 'change-streamer'}, true);
+  const lc = createLogContext(
+    config,
+    {worker: 'change-streamer', workerIndex: 0},
+    true,
+  );
   initEventSink(lc, config);
 
   // Kick off DB connection warmup in the background.

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -63,7 +63,10 @@ export default async function runWorker(
     litestream,
   } = config;
 
-  startOtelAuto(createLogContext(config, {worker: 'change-streamer'}, false));
+  startOtelAuto(
+    createLogContext(config, {worker: 'change-streamer'}, false),
+    'change-streamer',
+  );
   const lc = createLogContext(config, {worker: 'change-streamer'}, true);
   initEventSink(lc, config);
 

--- a/packages/zero-cache/src/server/logging.ts
+++ b/packages/zero-cache/src/server/logging.ts
@@ -11,11 +11,12 @@ import {OtelLogSink} from './otel-log-sink.ts';
 
 export function createLogContext(
   {log}: {log: LogConfig},
-  context: {worker: string; workerIndex: number},
+  worker: string,
+  workerIndex = 0,
   includeOtel = true,
 ): LogContext {
   const logSink = createLogSink(log, includeOtel);
-  const lc = createLogContextShared({log}, context, logSink);
+  const lc = createLogContextShared({log}, {worker, workerIndex}, logSink);
   process.on('uncaughtException', async (err, origin) => {
     lc.error?.(origin, err);
     await logSink.flush?.();

--- a/packages/zero-cache/src/server/logging.ts
+++ b/packages/zero-cache/src/server/logging.ts
@@ -11,7 +11,7 @@ import {OtelLogSink} from './otel-log-sink.ts';
 
 export function createLogContext(
   {log}: {log: LogConfig},
-  context: {worker: string},
+  context: {worker: string; workerIndex: number},
   includeOtel = true,
 ): LogContext {
   const logSink = createLogSink(log, includeOtel);

--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -45,7 +45,10 @@ export default async function runWorker(
   const startMs = Date.now();
   const config = getNormalizedZeroConfig({env});
 
-  startOtelAuto(createLogContext(config, {worker: 'dispatcher'}, false));
+  startOtelAuto(
+    createLogContext(config, {worker: 'dispatcher'}, false),
+    'dispatcher',
+  );
   const lc = createLogContext(config, {worker: 'dispatcher'}, true);
   initEventSink(lc, config);
 

--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -46,10 +46,15 @@ export default async function runWorker(
   const config = getNormalizedZeroConfig({env});
 
   startOtelAuto(
-    createLogContext(config, {worker: 'dispatcher'}, false),
+    createLogContext(config, {worker: 'dispatcher', workerIndex: 0}, false),
     'dispatcher',
+    0,
   );
-  const lc = createLogContext(config, {worker: 'dispatcher'}, true);
+  const lc = createLogContext(
+    config,
+    {worker: 'dispatcher', workerIndex: 0},
+    true,
+  );
   initEventSink(lc, config);
 
   const processes = new ProcessManager(lc, parent);
@@ -166,7 +171,7 @@ export default async function runWorker(
 
     const notifier = createNotifierFrom(lc, replicator);
     for (let i = 0; i < numSyncers; i++) {
-      syncers.push(loadWorker(SYNCER_URL, 'user-facing', i + 1, mode));
+      syncers.push(loadWorker(SYNCER_URL, 'user-facing', i, mode, String(i)));
     }
     syncers.forEach(syncer => handleSubscriptionsFrom(lc, syncer, notifier));
   }

--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -46,15 +46,11 @@ export default async function runWorker(
   const config = getNormalizedZeroConfig({env});
 
   startOtelAuto(
-    createLogContext(config, {worker: 'dispatcher', workerIndex: 0}, false),
+    createLogContext(config, 'dispatcher', 0, false),
     'dispatcher',
     0,
   );
-  const lc = createLogContext(
-    config,
-    {worker: 'dispatcher', workerIndex: 0},
-    true,
-  );
+  const lc = createLogContext(config, 'dispatcher');
   initEventSink(lc, config);
 
   const processes = new ProcessManager(lc, parent);

--- a/packages/zero-cache/src/server/mutator.ts
+++ b/packages/zero-cache/src/server/mutator.ts
@@ -17,11 +17,7 @@ function runWorker(
   ...args: string[]
 ): Promise<void> {
   const config = getNormalizedZeroConfig({env, argv: args.slice(1)});
-  startOtelAuto(
-    createLogContext(config, 'mutator', 0, false),
-    'mutator',
-    0,
-  );
+  startOtelAuto(createLogContext(config, 'mutator', 0, false), 'mutator', 0);
   const lc = createLogContext(config, 'mutator');
   initEventSink(lc, config);
 

--- a/packages/zero-cache/src/server/mutator.ts
+++ b/packages/zero-cache/src/server/mutator.ts
@@ -9,6 +9,7 @@ import {
 } from '../types/processes.ts';
 import {Mutator} from '../workers/mutator.ts';
 import {createLogContext} from './logging.ts';
+import {startOtelAuto} from './otel-start.ts';
 
 function runWorker(
   parent: Worker,
@@ -16,7 +17,12 @@ function runWorker(
   ...args: string[]
 ): Promise<void> {
   const config = getNormalizedZeroConfig({env, argv: args.slice(1)});
-  const lc = createLogContext(config, {worker: 'mutator'});
+  startOtelAuto(
+    createLogContext(config, {worker: 'mutator', workerIndex: 0}, false),
+    'mutator',
+    0,
+  );
+  const lc = createLogContext(config, {worker: 'mutator', workerIndex: 0});
   initEventSink(lc, config);
 
   // TODO: create `PusherFactory`

--- a/packages/zero-cache/src/server/mutator.ts
+++ b/packages/zero-cache/src/server/mutator.ts
@@ -18,11 +18,11 @@ function runWorker(
 ): Promise<void> {
   const config = getNormalizedZeroConfig({env, argv: args.slice(1)});
   startOtelAuto(
-    createLogContext(config, {worker: 'mutator', workerIndex: 0}, false),
+    createLogContext(config, 'mutator', 0, false),
     'mutator',
     0,
   );
-  const lc = createLogContext(config, {worker: 'mutator', workerIndex: 0});
+  const lc = createLogContext(config, 'mutator');
   initEventSink(lc, config);
 
   // TODO: create `PusherFactory`

--- a/packages/zero-cache/src/server/otel-diag-integration.test.ts
+++ b/packages/zero-cache/src/server/otel-diag-integration.test.ts
@@ -112,7 +112,7 @@ describe('Diagnostic Logger Integration Tests', () => {
     const {diag} = await import('@opentelemetry/api');
     const {startOtelAuto} = await import('./otel-start.js');
 
-    startOtelAuto(mockLogContext);
+    startOtelAuto(mockLogContext, 'test', 0);
 
     // Diagnostic logger should be set up once (after SDK initialization, NodeSDK prevented from setting its own)
     expect(diag.setLogger).toHaveBeenCalledTimes(1);
@@ -148,7 +148,7 @@ describe('Diagnostic Logger Integration Tests', () => {
     vi.mocked(diag.setLogger).mockClear();
 
     // Start main OTEL - should not configure again since it's already done
-    startOtelAuto(mockLogContext);
+    startOtelAuto(mockLogContext, 'test', 0);
     expect(diag.setLogger).toHaveBeenCalledTimes(0); // No new calls since already configured
   });
 
@@ -157,7 +157,7 @@ describe('Diagnostic Logger Integration Tests', () => {
     const {startAnonymousTelemetry} = await import('./anonymous-otel-start.js');
 
     // Should not throw errors when called without LogContext
-    expect(() => startOtelAuto()).not.toThrow();
+    expect(() => startOtelAuto(undefined, 'test', 0)).not.toThrow();
     expect(() => startAnonymousTelemetry()).not.toThrow();
   });
 
@@ -167,8 +167,8 @@ describe('Diagnostic Logger Integration Tests', () => {
 
     // Multiple calls should not cause issues
     expect(() => {
-      startOtelAuto(mockLogContext);
-      startOtelAuto(mockLogContext);
+      startOtelAuto(mockLogContext, 'test', 0);
+      startOtelAuto(mockLogContext, 'test', 0);
       startAnonymousTelemetry(mockLogContext);
       startAnonymousTelemetry(mockLogContext);
     }).not.toThrow();
@@ -190,7 +190,7 @@ describe('Diagnostic Logger Integration Tests', () => {
 
       // Call startOtelAuto (it might be already started, but that's ok for this test)
       // The key is that OTEL_LOG_LEVEL should remain after the call
-      startOtelAuto(mockLogContext);
+      startOtelAuto(mockLogContext, 'test', 0);
 
       // Verify OTEL_LOG_LEVEL is still set (was properly restored by the finally block)
       expect(process.env.OTEL_LOG_LEVEL).toBe('DEBUG');

--- a/packages/zero-cache/src/server/otel-log-sink.ts
+++ b/packages/zero-cache/src/server/otel-log-sink.ts
@@ -8,15 +8,11 @@ import {
 import type {Context, LogLevel, LogSink} from '@rocicorp/logger';
 import {stringify} from '../../../shared/src/bigint-json.ts';
 import {errorOrObject} from '../../../shared/src/logging.ts';
-import {startOtelAuto} from './otel-start.ts';
 
 export class OtelLogSink implements LogSink {
   readonly #logger: Logger;
 
   constructor() {
-    // start otel in case it was not started yet
-    // this is a no-op if already started
-    startOtelAuto();
     this.#logger = logs.getLogger('zero-cache');
   }
 

--- a/packages/zero-cache/src/server/otel-start.ts
+++ b/packages/zero-cache/src/server/otel-start.ts
@@ -25,7 +25,11 @@ class OtelManager {
     return OtelManager.#instance;
   }
 
-  startOtelAuto(lc?: LogContext, workerName?: string | undefined) {
+  startOtelAuto(
+    lc: LogContext | undefined,
+    workerName: string,
+    workerIndex: number,
+  ) {
     if (this.#started || !otelEnabled()) {
       return;
     }
@@ -43,14 +47,15 @@ class OtelManager {
 
     const resource = resourceFromAttributes({
       [ATTR_SERVICE_VERSION]: process.env.ZERO_SERVER_VERSION ?? 'unknown',
-      // Tag every metric/trace/log with the PID and worker name so each
+      // Tag every metric/trace/log with the worker name and index so each
       // worker process in a multi-worker pod is distinguishable. Without
       // this, N syncer workers sharing the same pod labels clobber each
       // other in the OTel collector on every scrape interval.
-      // 'process.worker' mirrors the 'worker' key in every log context
-      // so logs and metrics can be correlated on the same field.
-      'process.pid': process.pid,
-      ...(workerName !== undefined ? {'process.worker': workerName} : {}),
+      // These mirror the 'worker' and 'workerIndex' keys in every log
+      // context so logs and metrics can be correlated on the same fields.
+      // Using a stable index instead of PID avoids label churn in Prometheus.
+      'process.worker': workerName,
+      'process.worker_index': workerIndex,
     });
 
     // Set defaults to be backwards compatible with the previously
@@ -89,6 +94,7 @@ class OtelManager {
 }
 
 export const startOtelAuto = (
-  lc?: LogContext,
-  workerName?: string | undefined,
-) => OtelManager.getInstance().startOtelAuto(lc, workerName);
+  lc: LogContext | undefined,
+  workerName: string,
+  workerIndex: number,
+) => OtelManager.getInstance().startOtelAuto(lc, workerName, workerIndex);

--- a/packages/zero-cache/src/server/otel-start.ts
+++ b/packages/zero-cache/src/server/otel-start.ts
@@ -25,7 +25,7 @@ class OtelManager {
     return OtelManager.#instance;
   }
 
-  startOtelAuto(lc?: LogContext) {
+  startOtelAuto(lc?: LogContext, workerName?: string | undefined) {
     if (this.#started || !otelEnabled()) {
       return;
     }
@@ -43,6 +43,14 @@ class OtelManager {
 
     const resource = resourceFromAttributes({
       [ATTR_SERVICE_VERSION]: process.env.ZERO_SERVER_VERSION ?? 'unknown',
+      // Tag every metric/trace/log with the PID and worker name so each
+      // worker process in a multi-worker pod is distinguishable. Without
+      // this, N syncer workers sharing the same pod labels clobber each
+      // other in the OTel collector on every scrape interval.
+      // 'process.worker' mirrors the 'worker' key in every log context
+      // so logs and metrics can be correlated on the same field.
+      'process.pid': process.pid,
+      ...(workerName !== undefined ? {'process.worker': workerName} : {}),
     });
 
     // Set defaults to be backwards compatible with the previously
@@ -80,5 +88,7 @@ class OtelManager {
   }
 }
 
-export const startOtelAuto = (lc?: LogContext) =>
-  OtelManager.getInstance().startOtelAuto(lc);
+export const startOtelAuto = (
+  lc?: LogContext,
+  workerName?: string | undefined,
+) => OtelManager.getInstance().startOtelAuto(lc, workerName);

--- a/packages/zero-cache/src/server/reaper.ts
+++ b/packages/zero-cache/src/server/reaper.ts
@@ -26,11 +26,11 @@ export default async function runWorker(
   const config = getNormalizedZeroConfig({env, argv});
 
   startOtelAuto(
-    createLogContext(config, {worker: 'reaper', workerIndex: 0}, false),
+    createLogContext(config, 'reaper', 0, false),
     'reaper',
     0,
   );
-  const lc = createLogContext(config, {worker: 'reaper', workerIndex: 0}, true);
+  const lc = createLogContext(config, 'reaper');
   initEventSink(lc, config);
   startAnonymousTelemetry(lc, config);
 

--- a/packages/zero-cache/src/server/reaper.ts
+++ b/packages/zero-cache/src/server/reaper.ts
@@ -25,7 +25,7 @@ export default async function runWorker(
 ): Promise<void> {
   const config = getNormalizedZeroConfig({env, argv});
 
-  startOtelAuto(createLogContext(config, {worker: 'reaper'}, false));
+  startOtelAuto(createLogContext(config, {worker: 'reaper'}, false), 'reaper');
   const lc = createLogContext(config, {worker: 'reaper'}, true);
   initEventSink(lc, config);
   startAnonymousTelemetry(lc, config);

--- a/packages/zero-cache/src/server/reaper.ts
+++ b/packages/zero-cache/src/server/reaper.ts
@@ -25,8 +25,12 @@ export default async function runWorker(
 ): Promise<void> {
   const config = getNormalizedZeroConfig({env, argv});
 
-  startOtelAuto(createLogContext(config, {worker: 'reaper'}, false), 'reaper');
-  const lc = createLogContext(config, {worker: 'reaper'}, true);
+  startOtelAuto(
+    createLogContext(config, {worker: 'reaper', workerIndex: 0}, false),
+    'reaper',
+    0,
+  );
+  const lc = createLogContext(config, {worker: 'reaper', workerIndex: 0}, true);
   initEventSink(lc, config);
   startAnonymousTelemetry(lc, config);
 

--- a/packages/zero-cache/src/server/reaper.ts
+++ b/packages/zero-cache/src/server/reaper.ts
@@ -25,11 +25,7 @@ export default async function runWorker(
 ): Promise<void> {
   const config = getNormalizedZeroConfig({env, argv});
 
-  startOtelAuto(
-    createLogContext(config, 'reaper', 0, false),
-    'reaper',
-    0,
-  );
+  startOtelAuto(createLogContext(config, 'reaper', 0, false), 'reaper', 0);
   const lc = createLogContext(config, 'reaper');
   initEventSink(lc, config);
   startAnonymousTelemetry(lc, config);

--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -44,11 +44,11 @@ export default async function runWorker(
   const mode: ReplicatorMode = fileMode === 'backup' ? 'backup' : 'serving';
   const workerName = `${mode}-replicator`;
   startOtelAuto(
-    createLogContext(config, {worker: workerName, workerIndex: 0}, false),
+    createLogContext(config, workerName, 0, false),
     workerName,
     0,
   );
-  const lc = createLogContext(config, {worker: workerName, workerIndex: 0});
+  const lc = createLogContext(config, workerName);
   initEventSink(lc, config);
 
   const {file: dbPath, walMode} = await setupReplica(

--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -43,11 +43,7 @@ export default async function runWorker(
   const config = getNormalizedZeroConfig({env, argv: args.slice(1)});
   const mode: ReplicatorMode = fileMode === 'backup' ? 'backup' : 'serving';
   const workerName = `${mode}-replicator`;
-  startOtelAuto(
-    createLogContext(config, workerName, 0, false),
-    workerName,
-    0,
-  );
+  startOtelAuto(createLogContext(config, workerName, 0, false), workerName, 0);
   const lc = createLogContext(config, workerName);
   initEventSink(lc, config);
 

--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -30,6 +30,7 @@ import {
   type WalMode,
 } from '../workers/replicator.ts';
 import {createLogContext} from './logging.ts';
+import {startOtelAuto} from './otel-start.ts';
 
 export default async function runWorker(
   parent: Worker,
@@ -42,6 +43,10 @@ export default async function runWorker(
   const config = getNormalizedZeroConfig({env, argv: args.slice(1)});
   const mode: ReplicatorMode = fileMode === 'backup' ? 'backup' : 'serving';
   const workerName = `${mode}-replicator`;
+  startOtelAuto(
+    createLogContext(config, {worker: workerName}, false),
+    workerName,
+  );
   const lc = createLogContext(config, {worker: workerName});
   initEventSink(lc, config);
 

--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -44,10 +44,11 @@ export default async function runWorker(
   const mode: ReplicatorMode = fileMode === 'backup' ? 'backup' : 'serving';
   const workerName = `${mode}-replicator`;
   startOtelAuto(
-    createLogContext(config, {worker: workerName}, false),
+    createLogContext(config, {worker: workerName, workerIndex: 0}, false),
     workerName,
+    0,
   );
-  const lc = createLogContext(config, {worker: workerName});
+  const lc = createLogContext(config, {worker: workerName, workerIndex: 0});
   initEventSink(lc, config);
 
   const {file: dbPath, walMode} = await setupReplica(

--- a/packages/zero-cache/src/server/runner/run-worker.ts
+++ b/packages/zero-cache/src/server/runner/run-worker.ts
@@ -25,7 +25,7 @@ export async function runWorker(
   // Note: Deprecation warnings are only emitted at this top-level parse;
   //       they are suppressed when parsed in subprocesses.
   const cfg = getZeroConfig({env, emitDeprecationWarnings: true});
-  const lc = createLogContext(cfg, {worker: 'runner', workerIndex: 0});
+  const lc = createLogContext(cfg, 'runner');
 
   const defaultTaskID = await getTaskID(lc);
   const config = normalizeZeroConfig(lc, cfg, env, defaultTaskID);

--- a/packages/zero-cache/src/server/runner/run-worker.ts
+++ b/packages/zero-cache/src/server/runner/run-worker.ts
@@ -25,7 +25,7 @@ export async function runWorker(
   // Note: Deprecation warnings are only emitted at this top-level parse;
   //       they are suppressed when parsed in subprocesses.
   const cfg = getZeroConfig({env, emitDeprecationWarnings: true});
-  const lc = createLogContext(cfg, {worker: 'runner'});
+  const lc = createLogContext(cfg, {worker: 'runner', workerIndex: 0});
 
   const defaultTaskID = await getTaskID(lc);
   const config = normalizeZeroConfig(lc, cfg, env, defaultTaskID);

--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -76,11 +76,11 @@ export default function runWorker(
   const config = getNormalizedZeroConfig({env, argv: args.slice(2)});
 
   startOtelAuto(
-    createLogContext(config, {worker: 'syncer', workerIndex}, false),
+    createLogContext(config, 'syncer', workerIndex, false),
     'syncer',
     workerIndex,
   );
-  const lc = createLogContext(config, {worker: 'syncer', workerIndex}, true);
+  const lc = createLogContext(config, 'syncer', workerIndex);
   initEventSink(lc, config);
 
   const {cvr, upstream, enableCrudMutations} = config;

--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -70,14 +70,18 @@ export default function runWorker(
   env: NodeJS.ProcessEnv,
   ...args: string[]
 ): Promise<void> {
-  const config = getNormalizedZeroConfig({env, argv: args.slice(1)});
-
-  startOtelAuto(createLogContext(config, {worker: 'syncer'}, false), 'syncer');
-  const lc = createLogContext(config, {worker: 'syncer'}, true);
-  initEventSink(lc, config);
-
-  assert(args.length > 0, `replicator mode not specified`);
+  assert(args.length >= 2, `expected [fileMode, workerIndex, ...flags]`);
   const fileMode = v.parse(args[0], replicaFileModeSchema);
+  const workerIndex = Number(args[1]);
+  const config = getNormalizedZeroConfig({env, argv: args.slice(2)});
+
+  startOtelAuto(
+    createLogContext(config, {worker: 'syncer', workerIndex}, false),
+    'syncer',
+    workerIndex,
+  );
+  const lc = createLogContext(config, {worker: 'syncer', workerIndex}, true);
+  initEventSink(lc, config);
 
   const {cvr, upstream, enableCrudMutations} = config;
 

--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -72,7 +72,7 @@ export default function runWorker(
 ): Promise<void> {
   const config = getNormalizedZeroConfig({env, argv: args.slice(1)});
 
-  startOtelAuto(createLogContext(config, {worker: 'syncer'}, false));
+  startOtelAuto(createLogContext(config, {worker: 'syncer'}, false), 'syncer');
   const lc = createLogContext(config, {worker: 'syncer'}, true);
   initEventSink(lc, config);
 

--- a/packages/zero-cache/src/services/replicator/write-worker.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker.ts
@@ -49,7 +49,10 @@ function createAPI(): API {
       pragmas: PragmaConfig,
       logConfig: LogConfig,
     ) {
-      lc = createLogContext({log: logConfig}, {worker: 'write-worker'});
+      lc = createLogContext(
+        {log: logConfig},
+        {worker: 'write-worker', workerIndex: 0},
+      );
       db = new Database(lc, dbPath);
       applyPragmas(db, pragmas);
       runner = new StatementRunner(db);

--- a/packages/zero-cache/src/services/replicator/write-worker.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker.ts
@@ -49,10 +49,7 @@ function createAPI(): API {
       pragmas: PragmaConfig,
       logConfig: LogConfig,
     ) {
-      lc = createLogContext(
-        {log: logConfig},
-        {worker: 'write-worker', workerIndex: 0},
-      );
+      lc = createLogContext({log: logConfig}, 'write-worker');
       db = new Database(lc, dbPath);
       applyPragmas(db, pragmas);
       runner = new StatementRunner(db);


### PR DESCRIPTION
## Fix metric clobbering across syncer worker processes

Each syncer worker process independently starts the OTel SDK and exports metrics to the collector. Without a distinguishing identifier, all N workers on a pod emit metrics with identical resource labels, causing the collector to arbitrarily overwrite values on each scrape — resulting in oscillating metrics.

<img width="1072" height="496" alt="image" src="https://github.com/user-attachments/assets/51ffd1c0-b67f-4f4f-ac6c-ceedb91cc159" />

### Fix

Add `process.worker` and `process.worker_index` as OTel Resource attributes in `startOtelAuto`. These are automatically attached to every metric, trace, and log from that SDK instance — no changes needed to individual metric call sites.

- `process.worker` mirrors the `worker` key in log contexts for correlation
- `process.worker_index` is a stable 0-based index (not PID) to avoid label churn in Prometheus
-  Added `workerIndex` to log context for being able to correlate metrics and logs.

### Cleanup

- Made `workerName` and `workerIndex` required params on `startOtelAuto` and `createLogContext` — every worker must declare its identity
- Added missing `startOtelAuto` calls in `replicator.ts` and `mutator.ts` (they were relying on `OtelLogSink`'s lazy fallback)
- Removed `OtelLogSink`'s lazy `startOtelAuto()` call — SDK initialization is the responsibility of each worker entry point, not the log sink

