### PR TITLE
chore(zero-cache): cover more post-close cases when demoting EPIPE errors to 'warn'

### DIFF
--- a/packages/zero-cache/src/services/life-cycle.ts
+++ b/packages/zero-cache/src/services/life-cycle.ts
@@ -141,7 +141,7 @@ export class ProcessManager {
     // fails. This is not really an error when the server is shutting down,
     // so log any post-close errors at 'warn'.
     proc.on('error', err =>
-      this.#lc[isOpen ? 'error' : 'warn']?.(
+      this.#lc[!isOpen || this.#drainStart > 0 ? 'warn' : 'error']?.(
         `error from ${name} ${proc.pid}`,
         err,
       ),


### PR DESCRIPTION
To quiet down more false alerts: https://rocicorp.slack.com/archives/C0AT24D3GQ5/p1776276383645849