### PR TITLE
chore(zero-cache): add statement response timeout to change-log transaction statements

### DIFF
--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -497,6 +497,17 @@ export const zeroOptions = {
         `{bold zero-cache} replication subscriptions.`,
       ],
     },
+
+    statementTimeoutMs: {
+      type: v.number().default(20_000),
+      desc: [
+        `Fail change-log transactions if a statement response from postgres is not received within`,
+        `the specified timeout. This differs from a postgres {bold statement_timeout} in that`,
+        `it is implemented to handle a pathological case in which Postgres does not return a`,
+        `response but otherwise believes the transaction to be idle.`,
+      ],
+      hidden: true, // make visible if proven to be effective/necessary
+    },
   },
 
   replica: replicaOptions,

--- a/packages/zero-cache/src/db/transaction-pool.pg.test.ts
+++ b/packages/zero-cache/src/db/transaction-pool.pg.test.ts
@@ -11,10 +11,12 @@ import type {PostgresDB} from '../types/pg.ts';
 import * as Mode from './mode-enum.ts';
 import {
   importSnapshot,
+  ResponseTimeoutError,
   sharedSnapshot,
   synchronizedSnapshots,
   TIMEOUT_TASKS,
   TransactionPool,
+  type Options,
   type Task,
 } from './transaction-pool.ts';
 
@@ -53,11 +55,17 @@ describe('db/transaction-pool', () => {
     maxWorkers = initialWorkers,
     timeoutTasks = TIMEOUT_TASKS, // Overridden for tests.
   ) {
-    const pool = new TransactionPool(
-      lc,
+    return newTransactionPoolWithOpts(
       {mode, init, cleanup, initialWorkers, maxWorkers},
       timeoutTasks,
     );
+  }
+
+  function newTransactionPoolWithOpts(
+    opts: Options,
+    timeoutTasks = TIMEOUT_TASKS,
+  ) {
+    const pool = new TransactionPool(lc, opts, timeoutTasks);
     pools.push(pool);
     return pool;
   }
@@ -103,6 +111,40 @@ describe('db/transaction-pool', () => {
       ],
       ['public.workers']: [{id: 1}],
       ['public.cleaned']: [{id: 1}],
+    });
+  });
+
+  test('response timeout', async () => {
+    await db`INSERT INTO foo (id) VALUES (1)`;
+
+    // To induce a response timeout, we hold a lock in one tx and wait
+    // for another tx to timeout.
+    const lockHolder = newTransactionPool(Mode.READ_COMMITTED).run(db);
+    void lockHolder.process(task(`SELECT * FROM foo FOR UPDATE`));
+
+    const lockWaiter = newTransactionPoolWithOpts({
+      mode: Mode.READ_COMMITTED,
+      statementResponseTimeout: 50,
+    }).run(db);
+
+    const promise = lockWaiter.process(task(`DELETE FROM foo`));
+    lockWaiter.setDone();
+
+    // Note: The promise returned by process never throws, but it should
+    //       resolve once the response timeout aborts the transaction.
+    await promise;
+
+    // Release the lock to allow the transaction to proceed.
+    lockHolder.setDone();
+
+    // The final transaction should abort with the ResponseTimeoutError.
+    await expect(lockWaiter.done()).rejects.toThrow(ResponseTimeoutError);
+
+    await lockHolder.done();
+
+    // The delete should not have succeeded.
+    await expectTables(db, {
+      ['public.foo']: [{id: 1, val: null}],
     });
   });
 
@@ -408,7 +450,6 @@ describe('db/transaction-pool', () => {
     void pool.process(task(`INSERT INTO foo (id) VALUES (2)`));
     void pool.process(task(`INSERT INTO foo (id, val) VALUES (8, 'foo')`));
     void pool.process(task(`INSERT INTO foo (id) VALUES (5)`));
-    pool.setDone();
 
     // Set the failure before running.
     pool.fail(new Error('oh nose'));

--- a/packages/zero-cache/src/db/transaction-pool.ts
+++ b/packages/zero-cache/src/db/transaction-pool.ts
@@ -70,6 +70,16 @@ export type Options = {
    * workers will be shut down after an idle timeout of 5 seconds.
    */
   maxWorkers?: number;
+
+  /**
+   * Aborts the transaction if the response for a statement is not received
+   * within the specified timeout. Note that this is different from a Postgres
+   * `statement_timeout` or `lock_timeout` in that it is specifically intended
+   * to detect situations in which Postgres either never received the
+   * statement, or the application never got the response for the executed
+   * statement.
+   */
+  statementResponseTimeout?: number;
 };
 
 /**
@@ -89,6 +99,7 @@ export class TransactionPool {
   readonly #workers: Promise<unknown>[] = [];
   readonly #initialWorkers: number;
   readonly #maxWorkers: number;
+  readonly #responseTimeout: number | undefined;
   readonly #timeoutTask: TimeoutTasks;
   #numWorkers: number;
   #numWorking = 0;
@@ -96,6 +107,7 @@ export class TransactionPool {
 
   #done = false;
   #failure: Error | undefined;
+  #orphanedQueryCheckInterval: NodeJS.Timeout;
 
   constructor(
     lc: LogContext,
@@ -108,6 +120,7 @@ export class TransactionPool {
       cleanup,
       initialWorkers = 1,
       maxWorkers = initialWorkers,
+      statementResponseTimeout,
     } = opts;
     assert(initialWorkers > 0, 'initialWorkers must be positive');
     assert(
@@ -123,6 +136,12 @@ export class TransactionPool {
     this.#numWorkers = initialWorkers;
     this.#maxWorkers = maxWorkers;
     this.#timeoutTask = timeoutTasks;
+    this.#responseTimeout = statementResponseTimeout;
+
+    this.#orphanedQueryCheckInterval = setInterval(
+      this.#checkForOrphanedQueries,
+      Math.min(5_000, statementResponseTimeout ?? 5_000),
+    );
   }
 
   /**
@@ -313,6 +332,13 @@ export class TransactionPool {
 
   readonly #start = performance.now();
   #stmts = 0;
+  #latestDoneIndex = 0;
+  #latestDoneTime = 0;
+
+  readonly #pending = new Map<
+    Query,
+    {index: number; time: number; abort: (e: ResponseTimeoutError) => void}
+  >();
 
   /**
    * Implements the semantics specified in {@link process()}.
@@ -345,28 +371,89 @@ export class TransactionPool {
         // Execute the statements (i.e. send to the db) immediately.
         // The last result is returned for the worker to await before
         // closing the transaction.
-        const last = stmts.reduce(
-          (_, stmt) =>
-            stmt
-              .execute()
-              .then(() => {
-                if (++this.#stmts % 1000 === 0) {
-                  const log = this.#stmts % 10000 === 0 ? 'info' : 'debug';
-                  const q = stmt as unknown as Query;
-                  lc[log]?.(
-                    `executed ${this.#stmts}th statement (${(performance.now() - this.#start).toFixed(3)} ms)`,
-                    {statement: q.string},
-                  );
-                }
-              })
-              .catch(e => this.fail(e)),
-          promiseVoid,
-        );
-        return {pending: last.then(r.resolve)};
+        const time = Date.now();
+        const last = stmts.reduce((_, stmt) => {
+          const query = stmt as unknown as Query;
+          const index = ++this.#stmts;
+          const {promise: aborted, reject: abort} = resolver();
+          aborted.catch(() => {}); // always consider it "handled"
+
+          this.#pending.set(query, {index, time, abort});
+          const responded = stmt
+            .execute()
+            .then(() => {
+              if (index % 1000 === 0) {
+                const log = index % 10000 === 0 ? 'info' : 'debug';
+                lc[log]?.(
+                  `executed ${this.#stmts}th statement (${(performance.now() - this.#start).toFixed(3)} ms)`,
+                  {statement: query.string},
+                );
+              }
+            })
+            .catch(e => this.fail(e))
+            .finally(() => {
+              this.#pending.delete(query);
+              if (index > this.#latestDoneIndex) {
+                this.#latestDoneIndex = index;
+                this.#latestDoneTime = Date.now();
+              }
+            });
+
+          const done = Promise.race([responded, aborted]);
+          done.catch(() => {});
+
+          return done;
+        }, promiseVoid);
+        return {pending: last.finally(r.resolve)};
       },
       rejected: r.resolve,
     };
   }
+
+  /**
+   * Periodically checks the map of `#pending` queries for which Promises
+   * have yet to be resolved. Checks for pathological scenarios that have
+   * been observed:
+   *
+   * * A promise does not resolve, even though the transaction is otherwise
+   *   healthy with keepalives being sent.
+   * * A transaction never "finishes" at the postgres.js level after the
+   *   worker exits, implying that postgres.js is awaiting the `last` promise
+   *   returned. In this case Postgres disconnected the application with an
+   *   idle-in-transaction timeout, suggesting that all statements did in
+   *   fact complete.
+   */
+  readonly #checkForOrphanedQueries = () => {
+    if (this.#pending.size === 0) {
+      return;
+    }
+    const now = Date.now();
+    for (const [query, {index, time, abort}] of this.#pending.entries()) {
+      const statement = query.string;
+      const abortWith = (msg: string) => {
+        this.#lc.warn?.(msg, {statement});
+        const err = new ResponseTimeoutError(msg);
+        abort(err);
+        this.fail(err);
+        this.#pending.delete(query);
+      };
+
+      if (index < this.#latestDoneIndex) {
+        const elapsed = now - this.#latestDoneTime;
+        if (this.#responseTimeout && elapsed > this.#responseTimeout) {
+          abortWith(
+            `statement ${this.#latestDoneIndex} completed ${elapsed} ms ago, but statement ${index} has not.`,
+          );
+        }
+      } else {
+        // Nothing out of order, but checking for a response timeout.
+        const elapsed = now - time;
+        if (this.#responseTimeout && elapsed > this.#responseTimeout) {
+          abortWith(`response for statement timed out after ${elapsed} ms`);
+        }
+      }
+    }
+  };
 
   /**
    * Processes and returns the result of executing the {@link ReadTask} from
@@ -447,6 +534,9 @@ export class TransactionPool {
     for (let i = 0; i < this.#numWorkers; i++) {
       this.#tasks.enqueue('done');
     }
+    void Promise.allSettled(this.#workers).then(() =>
+      clearInterval(this.#orphanedQueryCheckInterval),
+    );
   }
 
   isRunning(): boolean {
@@ -457,7 +547,7 @@ export class TransactionPool {
    * Signals all workers to fail their transactions with the given {@link err}.
    */
   fail(err: unknown) {
-    if (!this.#failure) {
+    if (!this.#done && !this.#failure) {
       this.#failure = ensureError(err); // Fail fast: this is checked in the worker loop.
       // Logged for informational purposes. It is the responsibility of
       // higher level logic to classify and handle the exception.
@@ -469,6 +559,9 @@ export class TransactionPool {
         // Enqueue the Error to terminate any workers waiting for tasks.
         this.#tasks.enqueue(this.#failure);
       }
+      void Promise.allSettled(this.#workers).then(() =>
+        clearInterval(this.#orphanedQueryCheckInterval),
+      );
     }
   }
 }
@@ -760,3 +853,11 @@ export const TIMEOUT_TASKS: TimeoutTasks = {
 // The slice of information from the Query object in Postgres.js that gets logged for debugging.
 // https://github.com/porsager/postgres/blob/f58cd4f3affd3e8ce8f53e42799672d86cd2c70b/src/connection.js#L219
 type Query = {string: string; parameters: object[]};
+
+export class ResponseTimeoutError extends Error {
+  static readonly name = 'ResponseTimeoutError';
+
+  constructor(msg: string) {
+    super(msg);
+  }
+}

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -157,8 +157,11 @@ export default async function runWorker(
         subscriptionState,
         purgeLock,
         autoReset ?? false,
-        backPressureLimitHeapProportion,
-        flowControlConsensusPaddingSeconds,
+        {
+          backPressureLimitHeapProportion,
+          flowControlConsensusPaddingSeconds,
+          statementTimeoutMs: change.statementTimeoutMs,
+        },
         setTimeout,
       );
       break;

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -25,7 +25,10 @@ import {
   type SubscriptionState,
 } from '../replicator/schema/replication-state.ts';
 import {ReplicationMessages} from '../replicator/test-utils.ts';
-import {initializeStreamer} from './change-streamer-service.ts';
+import {
+  initializeStreamer,
+  type TuningOptions,
+} from './change-streamer-service.ts';
 import {
   PROTOCOL_VERSION,
   type ChangeStreamerService,
@@ -34,6 +37,12 @@ import {
 import * as ErrorType from './error-type-enum.ts';
 import {AutoResetSignal, ensureReplicationConfig} from './schema/tables.ts';
 import {PurgeLocker} from './storer.ts';
+
+const opts: TuningOptions = {
+  backPressureLimitHeapProportion: 0.04,
+  flowControlConsensusPaddingSeconds: 1,
+  statementTimeoutMs: 20_000,
+};
 
 describe('change-streamer/service', () => {
   let lc: LogContext;
@@ -87,8 +96,7 @@ describe('change-streamer/service', () => {
       replicaConfig,
       null,
       true,
-      0.04,
-      1,
+      opts,
       setTimeoutFn as unknown as typeof setTimeout,
     );
     streamerDone = streamer.run();
@@ -959,8 +967,7 @@ describe('change-streamer/service', () => {
       replicaConfig,
       null,
       true,
-      0.04,
-      1,
+      opts,
     );
     void streamer.run();
 
@@ -989,8 +996,7 @@ describe('change-streamer/service', () => {
       replicaConfig,
       null,
       true,
-      0.04,
-      1,
+      opts,
     );
     void streamer.run();
 
@@ -1014,8 +1020,7 @@ describe('change-streamer/service', () => {
       replicaConfig,
       null,
       true,
-      0.04,
-      1,
+      opts,
     );
     void streamer.run();
 
@@ -1053,8 +1058,7 @@ describe('change-streamer/service', () => {
       replicaConfig,
       lock,
       true,
-      0.04,
-      1,
+      opts,
     );
     void streamer.run();
 
@@ -1097,8 +1101,7 @@ describe('change-streamer/service', () => {
       replicaConfig,
       null,
       true,
-      0.04,
-      1,
+      opts,
     );
     void streamer.run();
 
@@ -1140,8 +1143,7 @@ describe('change-streamer/service', () => {
       replicaConfig,
       null,
       true,
-      0.04,
-      1,
+      opts,
     );
     void streamer.run();
 
@@ -1200,8 +1202,7 @@ describe('change-streamer/service', () => {
       replicaConfig,
       null,
       true,
-      0.04,
-      1,
+      opts,
     );
     void streamer.run();
 
@@ -1277,8 +1278,7 @@ describe('change-streamer/service', () => {
       replicaConfig,
       null,
       true,
-      0.04,
-      1,
+      opts,
     );
     void streamer.run();
 

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -47,8 +47,16 @@ import {
   ensureReplicationConfig,
   markResetRequired,
 } from './schema/tables.ts';
-import {Storer, type PurgeLock} from './storer.ts';
+import {
+  Storer,
+  type PurgeLock,
+  type TuningOptions as StorerOptions,
+} from './storer.ts';
 import {Subscriber} from './subscriber.ts';
+
+export type TuningOptions = StorerOptions & {
+  flowControlConsensusPaddingSeconds: number;
+};
 
 /**
  * Performs initialization and schema migrations to initialize a ChangeStreamerImpl.
@@ -65,8 +73,7 @@ export async function initializeStreamer(
   subscriptionState: SubscriptionState,
   purgeLock: PurgeLock | null,
   autoReset: boolean,
-  backPressureLimitHeapProportion: number,
-  flowControlConsensusPaddingSeconds: number,
+  opts: TuningOptions,
   setTimeoutFn = setTimeout,
 ): Promise<ChangeStreamerService> {
   // Make sure the ChangeLog DB is set up.
@@ -93,8 +100,7 @@ export async function initializeStreamer(
     replicationStatusPublisher,
     purgeLock,
     autoReset,
-    backPressureLimitHeapProportion,
-    flowControlConsensusPaddingSeconds,
+    opts,
     setTimeoutFn,
   );
 }
@@ -303,8 +309,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     replicationStatusPublisher: ReplicationStatusPublisher,
     initialPurgeLock: PurgeLock | null,
     autoReset: boolean,
-    backPressureLimitHeapProportion: number,
-    flowControlConsensusPaddingSeconds: number,
+    opts: TuningOptions,
     setTimeoutFn = setTimeout,
   ) {
     this.id = `change-streamer`;
@@ -323,10 +328,11 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       replicaVersion,
       consumed => this.#stream?.acks.push(['status', consumed[1], consumed[2]]),
       err => this.stop(err),
-      backPressureLimitHeapProportion,
+      opts,
     );
     this.#forwarder = new Forwarder(lc, {
-      flowControlConsensusPaddingSeconds,
+      flowControlConsensusPaddingSeconds:
+        opts.flowControlConsensusPaddingSeconds,
     });
     this.#replicationStatusPublisher = replicationStatusPublisher;
     this.#purgeLock = initialPurgeLock;

--- a/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
@@ -13,8 +13,13 @@ import {ReplicationMessages} from '../replicator/test-utils.ts';
 import {type Downstream} from './change-streamer.ts';
 import * as ErrorType from './error-type-enum.ts';
 import {ensureReplicationConfig, setupCDCTables} from './schema/tables.ts';
-import {PurgeLocker, Storer} from './storer.ts';
+import {PurgeLocker, Storer, type TuningOptions} from './storer.ts';
 import {createSubscriber} from './test-utils.ts';
+
+const opts: TuningOptions = {
+  backPressureLimitHeapProportion: 0.04,
+  statementTimeoutMs: 20_000,
+};
 
 describe('change-streamer/storer', () => {
   const lc = createSilentLogContext();
@@ -100,7 +105,7 @@ describe('change-streamer/storer', () => {
         REPLICA_VERSION,
         msg => consumed.enqueue(msg),
         err => fatalErrors.enqueue(err),
-        0.04,
+        opts,
       );
       await storer.assumeOwnership();
       done = storer.run();
@@ -1754,7 +1759,7 @@ describe('change-streamer/storer', () => {
         REPLICA_VERSION,
         msg => consumed.enqueue(msg),
         err => fatalErrors.enqueue(err),
-        0.04,
+        opts,
       );
       await storer.assumeOwnership();
       done = storer.run();

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -72,6 +72,11 @@ type PendingTransaction = {
 
 const backfillRequestsSchema = v.array(backfillRequestSchema);
 
+export type TuningOptions = {
+  backPressureLimitHeapProportion: number;
+  statementTimeoutMs: number;
+};
+
 /**
  * Handles the storage of changes and the catchup of subscribers
  * that are behind.
@@ -115,6 +120,7 @@ export class Storer implements Service {
   readonly #onFatal: (err: Error) => void;
   readonly #queue = new Queue<QueueEntry>();
   readonly #backPressureThresholdBytes: number;
+  readonly #statementTimeoutMs: number;
 
   #approximateQueuedBytes = 0;
   #running = false;
@@ -129,7 +135,7 @@ export class Storer implements Service {
     replicaVersion: string,
     onConsumed: (c: Commit | UpstreamStatusMessage) => void,
     onFatal: (err: Error) => void,
-    backPressureLimitHeapProportion: number,
+    {backPressureLimitHeapProportion, statementTimeoutMs}: TuningOptions,
   ) {
     this.#lc = lc.withContext('component', 'change-log');
     this.#shard = shard;
@@ -140,6 +146,7 @@ export class Storer implements Service {
     this.#replicaVersion = replicaVersion;
     this.#onConsumed = onConsumed;
     this.#onFatal = onFatal;
+    this.#statementTimeoutMs = statementTimeoutMs;
 
     const heapStats = getHeapStatistics();
     this.#backPressureThresholdBytes =
@@ -449,7 +456,10 @@ export class Storer implements Service {
           tx = {
             pool: new TransactionPool(
               this.#lc.withContext('watermark', watermark),
-              {mode: Mode.READ_COMMITTED},
+              {
+                mode: Mode.READ_COMMITTED,
+                statementResponseTimeout: this.#statementTimeoutMs,
+              },
             ),
             preCommitWatermark: watermark,
             pos: 0,


### PR DESCRIPTION
Adds logic in the TransactionPool to check for orphaned statements for which responses do not arrive. This is to investigate/work-around a pathological scenario in which change-streamer progress halts on a Promise (either being awaited in the storer loop or in the postgres.js begin() code) even though Postgres itself believes the transaction to be idle:

* https://rocicorp.slack.com/archives/C0AQDEA9N10/p1775232642218719
* https://rocicorp.slack.com/archives/C0AQDEA9N10/p1776270576471669