### PR TITLE
feat(zero-cache): shadow initial sync

### DIFF
--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -602,6 +602,31 @@ test('zero-cache --help', () => {
                                                                         This is slower but can work around issues with binary encoding of                                                          
                                                                         certain data types.                                                                                                        
                                                                                                                                                                                                    
+     --shadow-sync-enabled boolean                                      default: false                                                                                                             
+       ZERO_SHADOW_SYNC_ENABLED env                                                                                                                                                                
+                                                                        Periodically exercises the initial-sync code path against a sample of                                                      
+                                                                        rows from every published table, writing to a throwaway SQLite database.                                                   
+                                                                        This acts as a canary: if the real initial-sync path ever breaks (schema                                                   
+                                                                        drift, PG version quirks, etc.), the shadow run fails before a customer                                                    
+                                                                        actually needs a full reset.                                                                                               
+                                                                                                                                                                                                   
+     --shadow-sync-interval-hours number                                default: 24                                                                                                                
+       ZERO_SHADOW_SYNC_INTERVAL_HOURS env                                                                                                                                                         
+                                                                        The interval between shadow initial-sync runs, in hours. The first run                                                     
+                                                                        is additionally staggered by a random fraction of this interval so that                                                    
+                                                                        a fleet restart does not cause all tasks to canary simultaneously.                                                         
+                                                                                                                                                                                                   
+     --shadow-sync-sample-rate number                                   default: 0.1                                                                                                               
+       ZERO_SHADOW_SYNC_SAMPLE_RATE env                                                                                                                                                            
+                                                                        The BERNOULLI sampling rate for each table (0 < rate <= 1). A value of                                                     
+                                                                        1 disables sampling and copies all rows (still subject to                                                                  
+                                                                        max-rows-per-table).                                                                                                       
+                                                                                                                                                                                                   
+     --shadow-sync-max-rows-per-table number                            default: 10000                                                                                                             
+       ZERO_SHADOW_SYNC_MAX_ROWS_PER_TABLE env                                                                                                                                                     
+                                                                        The hard upper bound on rows copied per table per shadow run. Guards                                                       
+                                                                        against unexpectedly large tables consuming disk / upstream bandwidth.                                                     
+                                                                                                                                                                                                   
      --lazy-startup boolean                                             default: false                                                                                                             
        ZERO_LAZY_STARTUP env                                                                                                                                                                       
                                                                         Delay starting the majority of zero-cache until first request.                                                             

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -956,7 +956,7 @@ export const zeroOptions = {
     },
 
     sampleRate: {
-      type: v.number().default(0.01),
+      type: v.number().default(0.1),
       desc: [
         `The BERNOULLI sampling rate for each table (0 < rate <= 1). A value of`,
         `1 disables sampling and copies all rows (still subject to`,
@@ -965,7 +965,7 @@ export const zeroOptions = {
     },
 
     maxRowsPerTable: {
-      type: v.number().default(1000),
+      type: v.number().default(10000),
       desc: [
         `The hard upper bound on rows copied per table per shadow run. Guards`,
         `against unexpectedly large tables consuming disk / upstream bandwidth.`,

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -934,6 +934,45 @@ export const zeroOptions = {
     },
   },
 
+  shadowSync: {
+    enabled: {
+      type: v.boolean().default(false),
+      desc: [
+        `Periodically exercises the initial-sync code path against a sample of`,
+        `rows from every published table, writing to a throwaway SQLite database.`,
+        `This acts as a canary: if the real initial-sync path ever breaks (schema`,
+        `drift, PG version quirks, etc.), the shadow run fails before a customer`,
+        `actually needs a full reset.`,
+      ],
+    },
+
+    intervalHours: {
+      type: v.number().default(24),
+      desc: [
+        `The interval between shadow initial-sync runs, in hours. The first run`,
+        `is additionally staggered by a random fraction of this interval so that`,
+        `a fleet restart does not cause all tasks to canary simultaneously.`,
+      ],
+    },
+
+    sampleRate: {
+      type: v.number().default(0.01),
+      desc: [
+        `The BERNOULLI sampling rate for each table (0 < rate <= 1). A value of`,
+        `1 disables sampling and copies all rows (still subject to`,
+        `{bold max-rows-per-table}).`,
+      ],
+    },
+
+    maxRowsPerTable: {
+      type: v.number().default(1000),
+      desc: [
+        `The hard upper bound on rows copied per table per shadow run. Guards`,
+        `against unexpectedly large tables consuming disk / upstream bandwidth.`,
+      ],
+    },
+  },
+
   /** @deprecated */
   targetClientRowCount: {
     type: v.number().default(20_000),

--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -33,6 +33,7 @@ import {
   MUTATOR_URL,
   REAPER_URL,
   REPLICATOR_URL,
+  SHADOW_SYNCER_URL,
   SYNCER_URL,
 } from './worker-urls.ts';
 
@@ -147,6 +148,15 @@ export default async function runWorker(
     // Before starting the view-syncers, ensure that the reaper has started
     // up, indicating that any CVR db migrations have been performed.
     await reaperReady;
+  }
+
+  // Only run the shadow-sync canary on the replication-manager (or in
+  // single-node mode, where it also owns upstream). Running on every
+  // view-syncer would hammer the upstream with N redundant canaries.
+  if (config.shadowSync.enabled && runChangeStreamer) {
+    const {promise: shadowReady, resolve: shadowStarted} = resolver();
+    loadWorker(SHADOW_SYNCER_URL, 'supporting').once('message', shadowStarted);
+    await shadowReady;
   }
 
   const syncers: Worker[] = [];

--- a/packages/zero-cache/src/server/shadow-syncer.ts
+++ b/packages/zero-cache/src/server/shadow-syncer.ts
@@ -10,7 +10,6 @@ import {
   type Worker,
 } from '../types/processes.ts';
 import {getShardConfig} from '../types/shards.ts';
-import {startAnonymousTelemetry} from './anonymous-otel-start.ts';
 import {createLogContext} from './logging.ts';
 import {startOtelAuto} from './otel-start.ts';
 
@@ -23,10 +22,13 @@ export default function runWorker(
 ): Promise<void> {
   const config = getNormalizedZeroConfig({env, argv});
 
-  startOtelAuto(createLogContext(config, {worker: 'shadow-syncer'}, false));
-  const lc = createLogContext(config, {worker: 'shadow-syncer'}, true);
+  startOtelAuto(
+    createLogContext(config, 'shadow-syncer', 0, false),
+    'shadow-syncer',
+    0,
+  );
+  const lc = createLogContext(config, 'shadow-syncer');
   initEventSink(lc, config);
-  startAnonymousTelemetry(lc, config);
 
   const {shadowSync, upstream, initialSync} = config;
   const shard = getShardConfig(config);

--- a/packages/zero-cache/src/server/shadow-syncer.ts
+++ b/packages/zero-cache/src/server/shadow-syncer.ts
@@ -1,0 +1,56 @@
+import {must} from '../../../shared/src/must.ts';
+import {getServerContext} from '../config/server-context.ts';
+import {getNormalizedZeroConfig} from '../config/zero-config.ts';
+import {initEventSink} from '../observability/events.ts';
+import {exitAfter, runUntilKilled} from '../services/life-cycle.ts';
+import {ShadowSyncService} from '../services/shadow-sync/shadow-sync-service.ts';
+import {
+  parentWorker,
+  singleProcessMode,
+  type Worker,
+} from '../types/processes.ts';
+import {getShardConfig} from '../types/shards.ts';
+import {startAnonymousTelemetry} from './anonymous-otel-start.ts';
+import {createLogContext} from './logging.ts';
+import {startOtelAuto} from './otel-start.ts';
+
+const MS_PER_HOUR = 1000 * 60 * 60;
+
+export default function runWorker(
+  parent: Worker,
+  env: NodeJS.ProcessEnv,
+  ...argv: string[]
+): Promise<void> {
+  const config = getNormalizedZeroConfig({env, argv});
+
+  startOtelAuto(createLogContext(config, {worker: 'shadow-syncer'}, false));
+  const lc = createLogContext(config, {worker: 'shadow-syncer'}, true);
+  initEventSink(lc, config);
+  startAnonymousTelemetry(lc, config);
+
+  const {shadowSync, upstream, initialSync} = config;
+  const shard = getShardConfig(config);
+  const service = new ShadowSyncService(
+    lc,
+    shard,
+    upstream.db,
+    getServerContext(config),
+    {
+      intervalMs: shadowSync.intervalHours * MS_PER_HOUR,
+      sampleRate: shadowSync.sampleRate,
+      maxRowsPerTable: shadowSync.maxRowsPerTable,
+      textCopy: initialSync.textCopy,
+    },
+  );
+
+  parent.send(['ready', {ready: true}]);
+
+  return runUntilKilled(lc, parent, service);
+}
+
+// fork()
+if (!singleProcessMode()) {
+  void exitAfter(() =>
+    runWorker(must(parentWorker), process.env, ...process.argv.slice(2)),
+  );
+}

--- a/packages/zero-cache/src/server/worker-urls.ts
+++ b/packages/zero-cache/src/server/worker-urls.ts
@@ -19,5 +19,6 @@ export const MAIN_URL = resolve('./main.ts');
 export const MUTATOR_URL = resolve('./mutator.ts');
 export const REAPER_URL = resolve('./reaper.ts');
 export const REPLICATOR_URL = resolve('./replicator.ts');
+export const SHADOW_SYNCER_URL = resolve('./shadow-syncer.ts');
 export const SYNCER_URL = resolve('./syncer.ts');
 export const WRITE_WORKER_URL = resolve('./write-worker.ts');

--- a/packages/zero-cache/src/services/shadow-sync/shadow-sync-service.pg.test.ts
+++ b/packages/zero-cache/src/services/shadow-sync/shadow-sync-service.pg.test.ts
@@ -1,0 +1,112 @@
+import {LogContext} from '@rocicorp/logger';
+import {beforeEach, describe, expect} from 'vitest';
+import {
+  createSilentLogContext,
+  TestLogSink,
+} from '../../../../shared/src/logging-test-utils.ts';
+import {sleep} from '../../../../shared/src/sleep.ts';
+import {getConnectionURI, type PgTest, test} from '../../test/db.ts';
+import type {PostgresDB} from '../../types/pg.ts';
+import {ensureShardSchema} from '../change-source/pg/schema/init.ts';
+import {ShadowSyncService} from './shadow-sync-service.ts';
+
+const APP_ID = '1';
+const SHARD_NUM = 24;
+
+const SHARD = {
+  appID: APP_ID,
+  shardNum: SHARD_NUM,
+  publications: [] as readonly string[],
+} as const;
+
+const CONTEXT = {foo: 'shadow-sync-service-test'};
+
+const BASE_OPTIONS = {
+  intervalMs: 50,
+  sampleRate: 1,
+  maxRowsPerTable: 10,
+} as const;
+
+function countMessagesStartingWith(sink: TestLogSink, prefix: string): number {
+  return sink.messages.filter(([, , args]) =>
+    args.some(a => typeof a === 'string' && a.startsWith(prefix)),
+  ).length;
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs: number) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await sleep(25);
+  }
+}
+
+describe('ShadowSyncService', () => {
+  let upstream: PostgresDB;
+
+  beforeEach<PgTest>(async ({testDBs}) => {
+    upstream = await testDBs.create('shadow_sync_service_test');
+    return () => testDBs.drop(upstream);
+  });
+
+  test('completes shadow sync runs and stops cleanly', async () => {
+    await upstream`CREATE TABLE items(id int4 PRIMARY KEY)`;
+    await upstream`
+      INSERT INTO items(id) SELECT g FROM generate_series(1, 20) g`;
+    await ensureShardSchema(createSilentLogContext(), upstream, SHARD);
+
+    const sink = new TestLogSink();
+    const lc = new LogContext('info', undefined, sink);
+
+    const service = new ShadowSyncService(
+      lc,
+      SHARD,
+      getConnectionURI(upstream),
+      CONTEXT,
+      BASE_OPTIONS,
+    );
+
+    const running = service.run();
+    await waitFor(
+      () =>
+        countMessagesStartingWith(sink, 'shadow initial-sync completed') > 0,
+      10_000,
+    );
+    expect(
+      countMessagesStartingWith(sink, 'shadow initial-sync completed'),
+    ).toBeGreaterThanOrEqual(1);
+    expect(countMessagesStartingWith(sink, 'shadow initial-sync failed')).toBe(
+      0,
+    );
+
+    await service.stop();
+    await running;
+  });
+
+  test('keeps running after a failing run', async () => {
+    const sink = new TestLogSink();
+    const lc = new LogContext('info', undefined, sink);
+
+    const service = new ShadowSyncService(
+      lc,
+      SHARD,
+      // Bogus URI: the postgres client will reject without ever touching
+      // an upstream server.
+      'postgres://nonexistent.invalid:5/does_not_exist',
+      CONTEXT,
+      BASE_OPTIONS,
+    );
+
+    const running = service.run();
+    await waitFor(
+      () => countMessagesStartingWith(sink, 'shadow initial-sync failed') >= 2,
+      15_000,
+    );
+    expect(
+      countMessagesStartingWith(sink, 'shadow initial-sync failed'),
+    ).toBeGreaterThanOrEqual(2);
+
+    await service.stop();
+    await running;
+  });
+});

--- a/packages/zero-cache/src/services/shadow-sync/shadow-sync-service.test.ts
+++ b/packages/zero-cache/src/services/shadow-sync/shadow-sync-service.test.ts
@@ -1,0 +1,131 @@
+import {resolver} from '@rocicorp/resolver';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import {ShadowSyncService} from './shadow-sync-service.ts';
+
+const shadowInitialSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../change-source/pg/initial-sync.ts', () => ({
+  shadowInitialSync: shadowInitialSyncMock,
+}));
+
+const SHARD = {
+  appID: '1',
+  shardNum: 0,
+  publications: [] as readonly string[],
+} as const;
+
+const CONTEXT = {foo: 'shadow-sync-schedule-test'};
+
+const INTERVAL_MS = 1000;
+
+describe('ShadowSyncService scheduling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    shadowInitialSyncMock.mockReset();
+    shadowInitialSyncMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  function makeService() {
+    return new ShadowSyncService(
+      createSilentLogContext(),
+      SHARD,
+      'postgres://unused',
+      CONTEXT,
+      {
+        intervalMs: INTERVAL_MS,
+        sampleRate: 1,
+        maxRowsPerTable: 10,
+      },
+    );
+  }
+
+  test('first run waits at least one full interval (jitter = 0)', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const service = makeService();
+    const running = service.run();
+
+    // One interval minus a tick — no run yet.
+    await vi.advanceTimersByTimeAsync(INTERVAL_MS - 1);
+    expect(shadowInitialSyncMock).not.toHaveBeenCalled();
+
+    // Cross the one-interval boundary — first run fires.
+    await vi.advanceTimersByTimeAsync(1);
+    expect(shadowInitialSyncMock).toHaveBeenCalledTimes(1);
+
+    await service.stop();
+    await running;
+  });
+
+  test('first run waits up to two intervals (jitter ≈ max)', async () => {
+    // Math.floor(0.9999 * 1000) = 999, so firstRunDelay = 1999.
+    vi.spyOn(Math, 'random').mockReturnValue(0.9999);
+    const service = makeService();
+    const running = service.run();
+
+    await vi.advanceTimersByTimeAsync(INTERVAL_MS * 2 - 2);
+    expect(shadowInitialSyncMock).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(shadowInitialSyncMock).toHaveBeenCalledTimes(1);
+
+    await service.stop();
+    await running;
+  });
+
+  test('subsequent runs are spaced by intervalMs after completion', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0); // first run at intervalMs
+
+    // Gate each sync call on an external resolver so we control completion.
+    let current = resolver<void>();
+    shadowInitialSyncMock.mockImplementation(() => current.promise);
+
+    const service = makeService();
+    const running = service.run();
+
+    // Reach the first run.
+    await vi.advanceTimersByTimeAsync(INTERVAL_MS);
+    expect(shadowInitialSyncMock).toHaveBeenCalledTimes(1);
+
+    // Complete first run. The service now sleeps intervalMs before run #2.
+    const first = current;
+    current = resolver<void>();
+    first.resolve();
+    await vi.advanceTimersByTimeAsync(0); // flush the post-completion sleep scheduling
+
+    // Just before the interval elapses — no second run yet.
+    await vi.advanceTimersByTimeAsync(INTERVAL_MS - 1);
+    expect(shadowInitialSyncMock).toHaveBeenCalledTimes(1);
+
+    // Cross the boundary — second run fires.
+    await vi.advanceTimersByTimeAsync(1);
+    expect(shadowInitialSyncMock).toHaveBeenCalledTimes(2);
+
+    // Clean up: resolve the in-flight sync, then stop. The service will
+    // enter one more sleep(intervalMs) whose abort listener registers after
+    // the signal is aborted, so we flush that final timer manually.
+    current.resolve();
+    const stopped = service.stop();
+    await vi.runAllTimersAsync();
+    await stopped;
+    await running;
+  });
+
+  test('stop during the initial sleep exits promptly', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    const service = makeService();
+    const running = service.run();
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(shadowInitialSyncMock).not.toHaveBeenCalled();
+
+    await service.stop();
+    await running;
+    expect(shadowInitialSyncMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/zero-cache/src/services/shadow-sync/shadow-sync-service.ts
+++ b/packages/zero-cache/src/services/shadow-sync/shadow-sync-service.ts
@@ -1,0 +1,81 @@
+import type {LogContext} from '@rocicorp/logger';
+import {promiseVoid} from '../../../../shared/src/resolved-promises.ts';
+import type {ShardConfig} from '../../types/shards.ts';
+import type {ServerContext} from '../change-source/pg/initial-sync.ts';
+import {shadowInitialSync} from '../change-source/pg/initial-sync.ts';
+import {RunningState} from '../running-state.ts';
+import type {Service} from '../service.ts';
+
+export type ShadowSyncOptions = {
+  intervalMs: number;
+  sampleRate: number;
+  maxRowsPerTable: number;
+  textCopy?: boolean | undefined;
+};
+
+export class ShadowSyncService implements Service {
+  readonly id = 'shadow-syncer';
+
+  readonly #lc: LogContext;
+  readonly #shard: ShardConfig;
+  readonly #upstreamURI: string;
+  readonly #context: ServerContext;
+  readonly #options: ShadowSyncOptions;
+  readonly #state = new RunningState('shadow-syncer');
+
+  constructor(
+    lc: LogContext,
+    shard: ShardConfig,
+    upstreamURI: string,
+    context: ServerContext,
+    options: ShadowSyncOptions,
+  ) {
+    this.#lc = lc;
+    this.#shard = shard;
+    this.#upstreamURI = upstreamURI;
+    this.#context = context;
+    this.#options = options;
+  }
+
+  async run() {
+    const {intervalMs, sampleRate, maxRowsPerTable, textCopy} = this.#options;
+
+    // Why: stagger the first run by a random fraction of the interval so a
+    // fleet-wide restart does not cause every task to canary simultaneously.
+    const jitter = Math.floor(Math.random() * intervalMs);
+    this.#lc.info?.(
+      `shadow-syncer started; first run in ${jitter} ms, then every ${intervalMs} ms`,
+    );
+    await this.#state.sleep(jitter);
+
+    while (this.#state.shouldRun()) {
+      const start = performance.now();
+      try {
+        await shadowInitialSync(
+          this.#lc,
+          this.#shard,
+          this.#upstreamURI,
+          {sampleRate, maxRowsPerTable},
+          this.#context,
+          textCopy !== undefined ? {textCopy} : undefined,
+        );
+        const elapsed = performance.now() - start;
+        this.#lc.info?.(
+          `shadow initial-sync completed (${elapsed.toFixed(0)} ms)`,
+        );
+      } catch (e) {
+        const elapsed = performance.now() - start;
+        this.#lc.error?.(
+          `shadow initial-sync failed after ${elapsed.toFixed(0)} ms`,
+          e,
+        );
+      }
+      await this.#state.sleep(intervalMs);
+    }
+  }
+
+  stop(): Promise<void> {
+    this.#state.stop(this.#lc);
+    return promiseVoid;
+  }
+}

--- a/packages/zero-cache/src/services/shadow-sync/shadow-sync-service.ts
+++ b/packages/zero-cache/src/services/shadow-sync/shadow-sync-service.ts
@@ -40,13 +40,15 @@ export class ShadowSyncService implements Service {
   async run() {
     const {intervalMs, sampleRate, maxRowsPerTable, textCopy} = this.#options;
 
-    // Why: stagger the first run by a random fraction of the interval so a
-    // fleet-wide restart does not cause every task to canary simultaneously.
-    const jitter = Math.floor(Math.random() * intervalMs);
+    // Why: wait at least one full interval before the first run so shadow
+    // sync never fires immediately on task startup, and add a random
+    // fraction of the interval on top so a fleet-wide restart does not
+    // cause every task to canary simultaneously.
+    const firstRunDelay = intervalMs + Math.floor(Math.random() * intervalMs);
     this.#lc.info?.(
-      `shadow-syncer started; first run in ${jitter} ms, then every ${intervalMs} ms`,
+      `shadow-syncer started; first run in ${firstRunDelay} ms, then every ${intervalMs} ms`,
     );
-    await this.#state.sleep(jitter);
+    await this.#state.sleep(firstRunDelay);
 
     while (this.#state.shouldRun()) {
       const start = performance.now();


### PR DESCRIPTION
## Summary
- Adds a `shadow-syncer` worker that periodically re-runs `initialSync` against
  a throwaway SQLite file using a sampled subset of every published table. Acts
  as a canary so we catch schema-drift, PG version quirks, or encoding
  regressions before a real customer needs a full reset.
- Runs only on the replication-manager (`runChangeStreamer`) so view-syncers
  don't stampede the upstream with redundant canaries.
- Disabled by default (`ZERO_SHADOW_SYNC_ENABLED=true` to opt in).

## Behavior
- **Interval**: `shadowSync.intervalHours` (default 24h).
- **First run**: sleeps `[intervalMs, 2·intervalMs)` — waits at least one full
  interval on task startup *plus* jitter, so a fleet restart doesn't stampede
  and a fresh task never shadow-syncs immediately.
- **Sampling**: `TABLESAMPLE BERNOULLI(sampleRate) LIMIT maxRowsPerTable`.
  Defaults: `sampleRate=0.1`, `maxRowsPerTable=10000` (~100k rows scanned per
  big table, same upstream cost as earlier 1%/1k defaults but 10× more rows
  exercised downstream through COPY → SQLite).
- **Failure handling**: logs and keeps running; one bad run never disables the
  canary.


---

Note on alternate approach:

## Future work: CTID-window sampling

Commit `92562f4ad` ("ctid windodws?") prototypes an alternative to
`TABLESAMPLE BERNOULLI`: a deterministic sliding window over the main-heap
block range, parameterized by a `runNumber` (e.g.
`floor(Date.now() / cron_period_ms)`).

```
start = (runNumber * windowBlocks) % relpages
end   = min(start + windowBlocks, relpages)
WHERE ctid >= '(start,0)'::tid AND ctid < '(end,0)'::tid
```

Tables with `relpages <= windowBlocks` are scanned in full; larger tables
slide forward each run until the whole heap has been covered, then wrap.

**Why it's compelling**:
- **Predictable scan size** — each run reads a fixed number of heap blocks
  regardless of row density, versus BERNOULLI where scan cost grows with
  `maxRowsPerTable / sampleRate`.
- **Eventual full coverage** — every heap block gets visited over
  `ceil(relpages / windowBlocks)` runs, unlike random sampling which never
  guarantees coverage.
- **Cheaper probe** — replaces per-run `COUNT(*)` / `pg_column_size()` sums
  (full table scans) with a single `pg_relation_size(regclass)` lookup.
- **Consistent data loads** — byte volume is dominated by block count, not
  sampling luck; run-to-run variance mostly reflects TOAST fetches.

No state to persist: `runNumber` is derived from the wall clock as
`floor(Date.now() / intervalMs)`, so a restarted task picks up the same
window its predecessor would have used without any extra bookkeeping.

Not included in this PR — landing the canary on BERNOULLI first, since the
windowing scheme still needs more soak time.