### PR TITLE
feat(zero-cache): added threading of validated user ID through to ctx manager

### DIFF
--- a/packages/zero-cache/src/services/mutagen/pusher.test.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.test.ts
@@ -834,7 +834,8 @@ describe('pusher service', () => {
       errorBody: {
         kind: ErrorKind.PushFailed,
         origin: ErrorOrigin.ZeroCache,
-        reason: ErrorReason.Internal,
+        reason: ErrorReason.HTTP,
+        status: 401,
         message: 'Connection userID does not match validated server userID.',
         mutationIDs: [{clientID, id: 1}],
       },

--- a/packages/zero-cache/src/services/mutagen/pusher.test.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.test.ts
@@ -718,6 +718,134 @@ describe('pusher service', () => {
     await pusher.stop();
   });
 
+  test('canonical null mutate responses validate logged-out connections', async () => {
+    const fetch = (global.fetch = vi.fn());
+    fetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          kind: 'MutateResponse',
+          userID: null,
+          mutations: [],
+        }),
+    });
+
+    const pusher = newPusherService({
+      url: ['http://example.com'],
+      apiKey: 'api-key',
+      forwardCookies: false,
+    });
+    void pusher.run();
+    const {selector} = openConnection(pusher, {
+      clientID,
+      wsID,
+    });
+
+    pusher.enqueuePush(selector, makePush(1, clientID));
+
+    await vi.waitFor(() =>
+      expect(
+        getContextManager(pusher).getConnectionContext(selector),
+      ).toMatchObject({
+        clientID,
+        wsID,
+        userID: undefined,
+        state: 'validated',
+        revision: 1,
+      }),
+    );
+    expect(getContextManager(pusher).getGroupState()).toMatchObject({
+      userID: undefined,
+      validated: true,
+      backgroundConnection: selector,
+    });
+
+    await pusher.stop();
+  });
+
+  test('legacy successful pushes still validate using the stored connection userID', async () => {
+    const fetch = (global.fetch = vi.fn());
+    fetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          mutations: [],
+        }),
+    });
+
+    const pusher = newPusherService({
+      url: ['http://example.com'],
+      apiKey: 'api-key',
+      forwardCookies: false,
+    });
+    void pusher.run();
+    const {selector} = openConnection(pusher, {
+      clientID,
+      wsID,
+      auth: 'jwt',
+      userID: 'user-123',
+    });
+
+    pusher.enqueuePush(selector, makePush(1, clientID));
+
+    await vi.waitFor(() =>
+      expect(
+        getContextManager(pusher).getConnectionContext(selector),
+      ).toMatchObject({
+        clientID,
+        wsID,
+        userID: 'user-123',
+        state: 'validated',
+        revision: 1,
+      }),
+    );
+
+    await pusher.stop();
+  });
+
+  test('mismatched canonical mutate responses fail the live connection', async () => {
+    const fetch = (global.fetch = vi.fn());
+    fetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          kind: 'MutateResponse',
+          userID: 'user-bad',
+          mutations: [],
+        }),
+    });
+
+    const pusher = newPusherService({
+      url: ['http://example.com'],
+      apiKey: 'api-key',
+      forwardCookies: false,
+    });
+    void pusher.run();
+    const {selector, stream} = openConnection(pusher, {
+      clientID,
+      wsID,
+      auth: 'jwt',
+      userID: 'user-123',
+    });
+
+    pusher.enqueuePush(selector, makePush(1, clientID));
+
+    await expect(stream[Symbol.asyncIterator]().next()).rejects.toMatchObject({
+      errorBody: {
+        kind: ErrorKind.PushFailed,
+        origin: ErrorOrigin.ZeroCache,
+        reason: ErrorReason.Internal,
+        message: 'Connection userID does not match validated server userID.',
+        mutationIDs: [{clientID, id: 1}],
+      },
+    });
+    expect(
+      getContextManager(pusher).getConnectionContext(selector),
+    ).toBeUndefined();
+
+    await pusher.stop();
+  });
+
   test('push auth failure responses remove the live connection', async () => {
     const fetch = (global.fetch = vi.fn());
     fetch.mockResolvedValue({

--- a/packages/zero-cache/src/services/mutagen/pusher.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.ts
@@ -572,6 +572,8 @@ class PushWorker {
       }
 
       if (isProtocolError(e) && isAuthErrorBody(e.errorBody)) {
+        // The push completed far enough for local validation to reject the
+        // connection, so invalidate it and surface the result as PushFailed.
         this.#lc.warn?.('Push validation failed; invalidating connection', {
           clientID: entry.context.clientID,
           response: e.message,

--- a/packages/zero-cache/src/services/mutagen/pusher.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.ts
@@ -549,6 +549,7 @@ class PushWorker {
       this.#contextManager.validateConnection(
         entry.context,
         entry.context.revision,
+        'kind' in response ? response.userID : undefined,
       );
       return response;
     } catch (e) {
@@ -568,6 +569,24 @@ class PushWorker {
           );
         }
         return response;
+      }
+
+      if (isProtocolError(e) && isAuthErrorBody(e.errorBody)) {
+        this.#lc.warn?.('Push validation failed; invalidating connection', {
+          clientID: entry.context.clientID,
+          response: e.message,
+        });
+        this.#contextManager.failConnection(
+          entry.context,
+          entry.context.revision,
+        );
+        return {
+          kind: ErrorKind.PushFailed,
+          origin: ErrorOrigin.ZeroCache,
+          reason: ErrorReason.Internal,
+          message: e.message,
+          mutationIDs,
+        } as const satisfies PushFailedBody;
       }
 
       return {

--- a/packages/zero-cache/src/services/mutagen/pusher.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.ts
@@ -1,4 +1,4 @@
-import {ROOT_CONTEXT, context, propagation} from '@opentelemetry/api';
+import {context, propagation, ROOT_CONTEXT} from '@opentelemetry/api';
 import type {LogContext} from '@rocicorp/logger';
 import {groupBy} from '../../../../shared/src/arrays.ts';
 import {assert} from '../../../../shared/src/asserts.ts';
@@ -17,8 +17,8 @@ import * as MutationType from '../../../../zero-protocol/src/mutation-type-enum.
 import {
   apiMutateResponseSchema,
   CLEANUP_RESULTS_MUTATION_NAME,
-  type MutationID,
   type APIMutateResponse,
+  type MutationID,
   type PushBody,
 } from '../../../../zero-protocol/src/push.ts';
 import {authEquals, isAuthErrorBody} from '../../auth/auth.ts';
@@ -585,8 +585,9 @@ class PushWorker {
         return {
           kind: ErrorKind.PushFailed,
           origin: ErrorOrigin.ZeroCache,
-          reason: ErrorReason.Internal,
+          reason: ErrorReason.HTTP,
           message: e.message,
+          status: 401,
           mutationIDs,
         } as const satisfies PushFailedBody;
       }

--- a/packages/zero-cache/src/services/view-syncer/connection-context-manager.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/connection-context-manager.test.ts
@@ -91,10 +91,15 @@ function validate(
   manager: ConnectionContextManager,
   clientID: string,
   wsID: string,
+  validatedUserID: string | null | undefined,
   revision = manager.mustGetConnectionContext(selector(clientID, wsID))
     .revision,
 ) {
-  return manager.validateConnection(selector(clientID, wsID), revision);
+  return manager.validateConnection(
+    selector(clientID, wsID),
+    revision,
+    validatedUserID,
+  );
 }
 
 describe('ConnectionContextManager', () => {
@@ -169,11 +174,11 @@ describe('ConnectionContextManager', () => {
     });
   });
 
-  test('binds the first validated userID', () => {
+  test('binds the first validated userID from client', () => {
     const manager = new ConnectionContextManagerImpl(lc);
     register(manager, 'c1', 'ws1', 'user-1');
 
-    expect(validate(manager, 'c1', 'ws1')).toEqual({
+    expect(validate(manager, 'c1', 'ws1', undefined)).toEqual({
       connection: expect.objectContaining({
         clientID: 'c1',
         wsID: 'ws1',
@@ -196,7 +201,7 @@ describe('ConnectionContextManager', () => {
     registerLoggedOut(manager, 'c1', 'ws1');
     register(manager, 'c2', 'ws2', 'user-2');
 
-    expect(validate(manager, 'c1', 'ws1')).toEqual({
+    expect(validate(manager, 'c1', 'ws1', null)).toEqual({
       connection: expect.objectContaining({
         clientID: 'c1',
         wsID: 'ws1',
@@ -213,20 +218,45 @@ describe('ConnectionContextManager', () => {
     });
 
     expect(() =>
-      validate(manager, 'c2', 'ws2'),
+      validate(manager, 'c2', 'ws2', undefined),
     ).toThrowErrorMatchingInlineSnapshot(
       `[ProtocolError: Client groups are pinned to a single userID. Connection userID does not match existing client group userID.]`,
     );
+  });
+
+  test('rejects mismatched validated userIDs and keeps the connection provisional', () => {
+    const manager = new ConnectionContextManagerImpl(lc);
+    register(manager, 'c1', 'ws1', 'user-1');
+
+    expect(() =>
+      validate(manager, 'c1', 'ws1', 'user-2'),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[ProtocolError: Connection userID does not match validated server userID.]`,
+    );
+
+    expect(manager.getConnectionContext(selector('c1', 'ws1'))).toMatchObject({
+      clientID: 'c1',
+      wsID: 'ws1',
+      state: 'provisional',
+      userID: 'user-1',
+    });
+    expect(manager.getGroupState()).toEqual({
+      userID: undefined,
+      validated: false,
+      backgroundConnection: undefined,
+      maintenanceNotBeforeAt: undefined,
+      retransformAt: undefined,
+    });
   });
 
   test('rejects mismatched userIDs and keeps the connection provisional', () => {
     const manager = new ConnectionContextManagerImpl(lc);
     register(manager, 'c1', 'ws1', 'user-1');
     register(manager, 'c2', 'ws2', 'user-2');
-    validate(manager, 'c1', 'ws1');
+    validate(manager, 'c1', 'ws1', undefined);
 
     expect(() =>
-      validate(manager, 'c2', 'ws2'),
+      validate(manager, 'c2', 'ws2', undefined),
     ).toThrowErrorMatchingInlineSnapshot(
       `[ProtocolError: Client groups are pinned to a single userID. Connection userID does not match existing client group userID.]`,
     );
@@ -245,7 +275,7 @@ describe('ConnectionContextManager', () => {
   test('keeps the group userID pinned after all live connections are removed', () => {
     const manager = new ConnectionContextManagerImpl(lc);
     register(manager, 'c1', 'ws1', 'user-1');
-    validate(manager, 'c1', 'ws1');
+    validate(manager, 'c1', 'ws1', undefined);
 
     manager.closeConnection(selector('c1', 'ws1'));
     register(manager, 'c2', 'ws2', 'user-2');
@@ -256,7 +286,7 @@ describe('ConnectionContextManager', () => {
       validated: true,
     });
     expect(() =>
-      validate(manager, 'c2', 'ws2'),
+      validate(manager, 'c2', 'ws2', undefined),
     ).toThrowErrorMatchingInlineSnapshot(
       `[ProtocolError: Client groups are pinned to a single userID. Connection userID does not match existing client group userID.]`,
     );
@@ -268,9 +298,9 @@ describe('ConnectionContextManager', () => {
     register(manager, 'c2', 'ws2', 'user-1');
     register(manager, 'c3', 'ws3', 'user-1');
 
-    validate(manager, 'c1', 'ws1');
-    validate(manager, 'c2', 'ws2');
-    validate(manager, 'c3', 'ws3');
+    validate(manager, 'c1', 'ws1', undefined);
+    validate(manager, 'c2', 'ws2', undefined);
+    validate(manager, 'c3', 'ws3', undefined);
 
     expect(manager.getGroupState()).toMatchObject({
       userID: 'user-1',
@@ -298,7 +328,7 @@ describe('ConnectionContextManager', () => {
       () => 1_000,
     );
     register(manager, 'c1', 'ws1', 'user-1');
-    validate(manager, 'c1', 'ws1');
+    validate(manager, 'c1', 'ws1', undefined);
     const previousAuth = manager.mustGetConnectionContext(
       selector('c1', 'ws1'),
     ).auth;
@@ -334,8 +364,8 @@ describe('ConnectionContextManager', () => {
     );
     register(manager, 'c1', 'ws1', 'user-1');
     register(manager, 'c2', 'ws2', 'user-1');
-    validate(manager, 'c1', 'ws1');
-    validate(manager, 'c2', 'ws2');
+    validate(manager, 'c1', 'ws1', undefined);
+    validate(manager, 'c2', 'ws2', undefined);
 
     await expect(
       manager.updateAuth(selector('c2', 'ws2'), {auth: 'token-ws2-new'}),
@@ -365,9 +395,9 @@ describe('ConnectionContextManager', () => {
     register(manager, 'c1', 'ws1', 'user-1');
     register(manager, 'c2', 'ws2', 'user-1');
     register(manager, 'c3', 'ws3', 'user-1');
-    validate(manager, 'c1', 'ws1');
-    validate(manager, 'c2', 'ws2');
-    validate(manager, 'c3', 'ws3');
+    validate(manager, 'c1', 'ws1', undefined);
+    validate(manager, 'c2', 'ws2', undefined);
+    validate(manager, 'c3', 'ws3', undefined);
 
     expect(manager.getBackgroundConnectionContext()).toMatchObject({
       clientID: 'c1',
@@ -388,7 +418,7 @@ describe('ConnectionContextManager', () => {
     register(manager, 'c1', 'ws2');
 
     expect(
-      manager.validateConnection(selector('c1', 'ws1'), 0),
+      manager.validateConnection(selector('c1', 'ws1'), 0, undefined),
     ).toBeUndefined();
     expect(manager.closeConnection(selector('c1', 'ws1'))).toBeUndefined();
     expect(() =>
@@ -486,7 +516,11 @@ describe('ConnectionContextManager', () => {
     });
 
     expect(
-      manager.validateConnection(selector('c1', 'ws1'), registered.revision),
+      manager.validateConnection(
+        selector('c1', 'ws1'),
+        registered.revision,
+        undefined,
+      ),
     ).toBeUndefined();
     expect(
       manager.failConnection(selector('c1', 'ws1'), registered.revision),
@@ -513,8 +547,8 @@ describe('ConnectionContextManager', () => {
     register(manager, 'c1', 'ws1', 'user-1');
     register(manager, 'c2', 'ws2', 'user-1');
     register(manager, 'c3', 'ws3', 'user-1');
-    validate(manager, 'c2', 'ws2');
-    validate(manager, 'c1', 'ws1');
+    validate(manager, 'c2', 'ws2', undefined);
+    validate(manager, 'c1', 'ws1', undefined);
 
     expect(manager.planMaintenance()).toEqual({
       dueRevalidations: [],
@@ -568,8 +602,8 @@ describe('ConnectionContextManager', () => {
       earliestDeadlineAt: 6_000,
     });
 
-    validate(manager, 'c2', 'ws2');
-    validate(manager, 'c1', 'ws1');
+    validate(manager, 'c2', 'ws2', undefined);
+    validate(manager, 'c1', 'ws1', undefined);
 
     expect(manager.planMaintenance()).toEqual({
       dueRevalidations: [],
@@ -590,7 +624,7 @@ describe('ConnectionContextManager', () => {
       () => now,
     );
     register(manager, 'c1', 'ws1', 'user-1');
-    validate(manager, 'c1', 'ws1');
+    validate(manager, 'c1', 'ws1', undefined);
 
     expect(manager.getConnectionContext(selector('c1', 'ws1'))).toMatchObject({
       revalidateAt: 6_000,
@@ -598,7 +632,7 @@ describe('ConnectionContextManager', () => {
     expect(manager.getGroupState().retransformAt).toBe(3_000);
 
     now = 1_500;
-    validate(manager, 'c1', 'ws1');
+    validate(manager, 'c1', 'ws1', undefined);
 
     expect(manager.getConnectionContext(selector('c1', 'ws1'))).toMatchObject({
       revalidateAt: 6_500,
@@ -628,8 +662,8 @@ describe('ConnectionContextManager', () => {
     );
     register(manager, 'c1', 'ws1', 'user-1');
     register(manager, 'c2', 'ws2', 'user-1');
-    validate(manager, 'c1', 'ws1');
-    validate(manager, 'c2', 'ws2');
+    validate(manager, 'c1', 'ws1', undefined);
+    validate(manager, 'c2', 'ws2', undefined);
 
     now = 3_000;
     manager.deferMaintenance('retransform');

--- a/packages/zero-cache/src/services/view-syncer/connection-context-manager.ts
+++ b/packages/zero-cache/src/services/view-syncer/connection-context-manager.ts
@@ -372,6 +372,8 @@ export class ConnectionContextManagerImpl implements ConnectionContextManager {
       connection.userID,
     );
 
+    // Check that the ws connection userID provided by the client
+    // matches the confirmed identity from the API server
     if (connection.userID !== effectiveValidatedUserID) {
       throw new ProtocolErrorWithLevel(
         {
@@ -383,6 +385,8 @@ export class ConnectionContextManagerImpl implements ConnectionContextManager {
       );
     }
 
+    // Once a client group is validated, every later validated connection must
+    // agree with that pinned identity.
     if (
       this.#group.validated &&
       this.#group.userID !== effectiveValidatedUserID
@@ -770,6 +774,9 @@ function normalizeValidatedUserID(
   validatedUserID: string | null | undefined,
   fallbackUserID: string | undefined,
 ) {
+  // `null` means the API server explicitly validated a logged-out connection.
+  // `undefined` preserves legacy callers that only validated the stored
+  // connection userID and had no authoritative server userID to thread back.
   if (validatedUserID === null) {
     return undefined;
   }

--- a/packages/zero-cache/src/services/view-syncer/connection-context-manager.ts
+++ b/packages/zero-cache/src/services/view-syncer/connection-context-manager.ts
@@ -108,6 +108,7 @@ export type ConnectionContextManager = {
   validateConnection(
     selector: ConnectionSelector,
     revision: number,
+    validatedUserID: string | null | undefined,
   ):
     | Readonly<{
         connection: ConnectionContext;
@@ -154,7 +155,7 @@ export type ConnectionContextManager = {
  *
  * Connections are registered as `provisional`, optionally backfilled with
  * `initConnection` metadata, and then promoted to `validated` once their
- * stored `userID` is confirmed as valid. The manager also tracks which
+ * effective `userID` is confirmed as valid. The manager also tracks which
  * validated connection currently serves as the group's background connection.
  *
  * This is intentionally side-effect free.
@@ -345,6 +346,7 @@ export class ConnectionContextManagerImpl implements ConnectionContextManager {
   validateConnection(
     selector: ConnectionSelector,
     revision: number,
+    validatedUserID: string | null | undefined,
   ):
     | Readonly<{
         connection: ConnectionContext;
@@ -365,7 +367,26 @@ export class ConnectionContextManagerImpl implements ConnectionContextManager {
       return undefined;
     }
 
-    if (this.#group.validated && this.#group.userID !== connection.userID) {
+    const effectiveValidatedUserID = normalizeValidatedUserID(
+      validatedUserID,
+      connection.userID,
+    );
+
+    if (connection.userID !== effectiveValidatedUserID) {
+      throw new ProtocolErrorWithLevel(
+        {
+          kind: ErrorKind.Unauthorized,
+          message: 'Connection userID does not match validated server userID.',
+          origin: ErrorOrigin.ZeroCache,
+        },
+        'warn',
+      );
+    }
+
+    if (
+      this.#group.validated &&
+      this.#group.userID !== effectiveValidatedUserID
+    ) {
       throw new ProtocolErrorWithLevel(
         {
           kind: ErrorKind.Unauthorized,
@@ -379,7 +400,7 @@ export class ConnectionContextManagerImpl implements ConnectionContextManager {
 
     if (!this.#group.validated) {
       this.#group.validated = true;
-      this.#group.userID = connection.userID;
+      this.#group.userID = effectiveValidatedUserID;
     }
 
     connection.state = 'validated';
@@ -743,6 +764,16 @@ function snapshotGroup(group: GroupAuthState): Readonly<GroupAuthState> {
       ? {...group.backgroundConnection}
       : undefined,
   };
+}
+
+function normalizeValidatedUserID(
+  validatedUserID: string | null | undefined,
+  fallbackUserID: string | undefined,
+) {
+  if (validatedUserID === null) {
+    return undefined;
+  }
+  return validatedUserID ?? fallbackUserID;
 }
 
 function compareByInsertionOrder(

--- a/packages/zero-cache/src/services/view-syncer/view-syncer-auth-maintenance.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer-auth-maintenance.pg.test.ts
@@ -249,6 +249,37 @@ describe('view-syncer/auth maintenance', () => {
       expect(client.size()).toBe(0);
     });
 
+    test('scheduled revalidation fails the connection on userID mismatch', async () => {
+      const transformer = customQueryTransformer;
+      expect(transformer).toBeDefined();
+      using validateSpy = vi
+        .spyOn(transformer!, 'validate')
+        .mockResolvedValueOnce(validationSuccess('user-1'))
+        .mockResolvedValueOnce(validationSuccess('user-bad'));
+
+      const client = connect(
+        {...SYNC_CONTEXT, auth: {type: 'opaque', raw: 'token-1'}},
+        [{op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY}],
+      );
+
+      await nextPoke(client);
+      stateChanges.push({state: 'version-ready'});
+      await nextPoke(client);
+
+      expect(validateSpy).toHaveBeenCalledTimes(1);
+
+      callNextSetTimeout(setTimeoutFn, MAINTENANCE_INTERVAL_MS);
+
+      await vi.waitFor(
+        async () =>
+          await expect(client.dequeue()).rejects.toThrow(
+            'Connection userID does not match validated server userID.',
+          ),
+        {timeout: 2_000},
+      );
+      expect(validateSpy).toHaveBeenCalledTimes(2);
+    });
+
     test('ignores stale scheduled revalidation failures after auth changes', async () => {
       const transformer = customQueryTransformer;
       expect(transformer).toBeDefined();

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
@@ -74,8 +74,9 @@ describe('view-syncer/service', () => {
   function transformAttempt(
     result: HashedTransformResponse['result'],
     cached = false,
+    userID?: string | null,
   ): HashedTransformResponse {
-    return {result, cached};
+    return {result, cached, userID};
   }
 
   afterEach(() => {
@@ -2746,6 +2747,32 @@ describe('view-syncer/service', () => {
       expect(cvr.queries['query-hash-bad']).toBeUndefined();
     });
 
+    test('validation userID mismatch during connect fails the connection', async () => {
+      using validateSpy = vi
+        .spyOn(customQueryTransformer!, 'validate')
+        .mockResolvedValueOnce({
+          kind: 'QueryResponse',
+          userID: 'user-server',
+          queries: [],
+        });
+
+      const badContext: SyncContext = {
+        ...SYNC_CONTEXT,
+        clientID: 'bad',
+        wsID: 'ws-bad',
+        userID: 'user-bad',
+        auth: {type: 'opaque', raw: 'token-bad'},
+      };
+      const badClient = connect(badContext, [
+        {op: 'put', hash: 'query-hash-bad', ast: ISSUES_QUERY},
+      ]);
+
+      await expect(badClient.dequeue()).rejects.toThrow(
+        'Connection userID does not match validated server userID.',
+      );
+      expect(validateSpy).toHaveBeenCalledTimes(1);
+    });
+
     test('transform 401 during updateAuth disconnects the failing connection', async () => {
       using transformSpy = vi
         .spyOn(customQueryTransformer!, 'transform')
@@ -2831,6 +2858,41 @@ describe('view-syncer/service', () => {
 
       await expect(nextPoke(badClient)).rejects.toThrow(
         'Fetch from API server returned non-OK status 401',
+      );
+    });
+
+    test('transform userID mismatch during connect fails only that connection', async () => {
+      using transformSpy = vi
+        .spyOn(customQueryTransformer!, 'transform')
+        .mockResolvedValueOnce(
+          transformAttempt(
+            [
+              {
+                id: 'custom-1',
+                transformedAst: ISSUES_QUERY,
+                transformationHash: 'hash-1',
+              },
+            ],
+            false,
+            'user-server',
+          ),
+        );
+
+      const badContext: SyncContext = {
+        ...SYNC_CONTEXT,
+        userID: 'user-bad',
+        auth: {type: 'opaque', raw: 'token-bad'},
+      };
+      const badClient = connect(badContext, [
+        {op: 'put', hash: 'custom-1', name: 'named-query-1', args: ['thing']},
+      ]);
+
+      await nextPoke(badClient);
+      stateChanges.push({state: 'version-ready'});
+      await vi.waitFor(() => expect(transformSpy).toHaveBeenCalledTimes(1));
+
+      await expect(nextPoke(badClient)).rejects.toThrow(
+        'Connection userID does not match validated server userID.',
       );
     });
 

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -1385,6 +1385,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         this.contextManager.validateConnection(
           backgroundContext,
           backgroundContext.revision,
+          transformedCustomQueries.userID,
         );
       }
 
@@ -1690,6 +1691,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
               this.contextManager.validateConnection(
                 resolvedContext,
                 resolvedContext.revision,
+                transformedCustomQueries.userID,
               );
             }
             this.#queryTransformations.add(1, {result: 'success'});
@@ -2350,14 +2352,20 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
   async #validateConnection(ctx: ConnectionContext): Promise<boolean> {
     try {
+      let validatedUserID: string | null | undefined = undefined;
       if (this.#customQueryTransformer) {
         const validation = await this.#customQueryTransformer.validate(ctx);
         if (validation.kind === 'TransformFailed') {
           throw new ProtocolErrorWithLevel(validation, 'warn');
         }
+        validatedUserID = validation.userID;
       }
 
-      this.contextManager.validateConnection(ctx, ctx.revision);
+      this.contextManager.validateConnection(
+        ctx,
+        ctx.revision,
+        validatedUserID,
+      );
       return true;
     } catch (e) {
       if (isProtocolError(e) && isAuthErrorBody(e.errorBody)) {

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -1381,6 +1381,8 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
             customQueries.values(),
           ),
       );
+      // Uncached results can also return the authoritative server userID
+      // for that snapshot.
       if (!transformedCustomQueries.cached) {
         this.contextManager.validateConnection(
           backgroundContext,
@@ -1685,8 +1687,8 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
             );
           } else {
             // If the transform wasn't cached, we mark the connection as validated.
-            // This also passes the revision to ensure that race conditions with auth
-            // don't validate stale credentials.
+            // This also threads the authoritative server userID through the
+            // revision check so auth races do not validate stale credentials.
             if (!transformedCustomQueries.cached) {
               this.contextManager.validateConnection(
                 resolvedContext,
@@ -2369,6 +2371,15 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       return true;
     } catch (e) {
       if (isProtocolError(e) && isAuthErrorBody(e.errorBody)) {
+        this.#lc.warn?.(
+          'Connection auth validation failed; invalidating connection',
+          {
+            clientID: ctx.clientID,
+            wsID: ctx.wsID,
+            revision: ctx.revision,
+            message: e.message,
+          },
+        );
         this.#failMaintenanceConnection(ctx, e);
         return false;
       }

--- a/packages/zero-cache/src/workers/syncer.test.ts
+++ b/packages/zero-cache/src/workers/syncer.test.ts
@@ -2,6 +2,7 @@
 import {
   afterAll,
   afterEach,
+  assert,
   beforeEach,
   describe,
   expect,
@@ -670,10 +671,11 @@ describe('connection hijacking prevention', () => {
     );
 
     const contextManager = contextManagers.get('1');
-    expect(contextManager).toBeDefined();
-    contextManager!.validateConnection(
+    assert(contextManager);
+    contextManager.validateConnection(
       {clientID: 'target-client', wsID: 'ws-1'},
       0,
+      undefined,
     );
 
     const attackerWs = new MockWebSocket() as unknown as WebSocket;

--- a/packages/zero-protocol/src/error-kind-enum.ts
+++ b/packages/zero-protocol/src/error-kind-enum.ts
@@ -88,8 +88,7 @@ export type Rebalance = typeof Rebalance;
  */
 export type Rehome = typeof Rehome;
 /**
- * JWT validation failure (used in CRUD mutators).
- * @deprecated
+ * Unauthorized client request.
  */
 export type Unauthorized = typeof Unauthorized;
 /**


### PR DESCRIPTION
Cuts over the user ID validation in zero-cache from implicitly from client to server-authoritative with a fallback to the client-implicit flow.