### PR TITLE
fix(zero-cache): handle nested ddl events

### DIFF
--- a/packages/zero-cache/src/scripts/decommission.pg.test.ts
+++ b/packages/zero-cache/src/scripts/decommission.pg.test.ts
@@ -70,17 +70,7 @@ describe('decommission', () => {
     );
     expect(
       await upstream`SELECT evtname FROM pg_event_trigger WHERE evtname LIKE 'zeroout%'`.values(),
-    ).toEqual([
-      ['zeroout_ddl_start_13'],
-      ['zeroout_create_table_13'],
-      ['zeroout_alter_table_13'],
-      ['zeroout_create_index_13'],
-      ['zeroout_drop_table_13'],
-      ['zeroout_drop_index_13'],
-      ['zeroout_alter_publication_13'],
-      ['zeroout_alter_schema_13'],
-      ['zeroout_comment_13'],
-    ]);
+    ).toEqual([['zeroout_ddl_start_13'], ['zeroout_ddl_end_13']]);
     expect(
       await upstream`SELECT slot_name FROM pg_replication_slots WHERE slot_name LIKE 'zeroout%'`.values(),
     ).toMatchObject([[expect.stringMatching('zeroout_13_')]]);

--- a/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg.test.ts
@@ -1,4 +1,5 @@
 import type {LogContext} from '@rocicorp/logger';
+import {literal} from 'pg-format';
 import {afterAll, beforeAll, describe, expect, test} from 'vitest';
 import {type JSONValue} from '../../../../../shared/src/bigint-json.ts';
 import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
@@ -15,6 +16,7 @@ import {createChangeProcessor} from '../../replicator/test-utils.ts';
 import type {DataOrSchemaChange} from '../protocol/current/data.ts';
 import type {ChangeStreamMessage} from '../protocol/current/downstream.ts';
 import {initializePostgresChangeSource} from './change-source.ts';
+import {TAGS} from './schema/ddl.ts';
 
 const APP_ID = 'orez';
 
@@ -1878,7 +1880,20 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
     ],
     [
       'disable ALTER PUBLICATION trigger',
-      /*sql*/ `DROP EVENT TRIGGER ${APP_ID}_alter_publication_0;`,
+      /*sql*/ `
+      DROP EVENT TRIGGER ${APP_ID}_ddl_start_0;
+      DROP EVENT TRIGGER ${APP_ID}_ddl_end_0;
+
+      CREATE EVENT TRIGGER ${APP_ID}_ddl_start_0
+        ON ddl_command_start
+        WHEN TAG IN (${literal(removeAlterPublication(TAGS))})
+        EXECUTE PROCEDURE ${APP_ID}_0.emit_ddl_start();
+
+      CREATE EVENT TRIGGER ${APP_ID}_ddl_end_0
+        ON ddl_command_end
+        WHEN TAG IN (${literal(removeAlterPublication([...TAGS, 'COMMENT']))})
+        EXECUTE PROCEDURE ${APP_ID}_0.emit_ddl_end();
+      `,
       [],
       {},
       [],
@@ -1982,6 +1997,48 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
       [],
       [],
     ],
+    [
+      'nested DDL event (RLS)',
+      /*sql*/ `
+     CREATE OR REPLACE FUNCTION add_rls()
+     RETURNS event_trigger AS $$
+     DECLARE
+       target RECORD;
+     BEGIN
+       SELECT object_identity as name
+         FROM pg_event_trigger_ddl_commands() 
+         LIMIT 1 INTO target; 
+       -- This results in firing nested ddl_start / ddl_end triggers
+       EXECUTE format('ALTER TABLE %s ENABLE ROW LEVEL SECURITY', target.name);
+     END
+     $$ LANGUAGE plpgsql;
+
+     CREATE EVENT TRIGGER add_rls_trigger
+      ON ddl_command_end
+      WHEN TAG IN ('CREATE TABLE')
+      EXECUTE PROCEDURE add_rls();
+
+     CREATE TABLE your.table_that_gets_rls (id INT8 PRIMARY KEY, val INT8 NOT NULL);
+     CREATE UNIQUE INDEX val_idx ON your.table_that_gets_rls (val);
+      `,
+      [[{tag: 'create-table'}, {tag: 'create-index'}, {tag: 'create-index'}]],
+      {['your.table_that_gets_rls']: []},
+      [],
+      [
+        {
+          tableName: 'your.table_that_gets_rls',
+          name: 'your.table_that_gets_rls_pkey',
+          columns: {id: 'ASC'},
+          unique: true,
+        },
+        {
+          tableName: 'your.table_that_gets_rls',
+          name: 'your.val_idx',
+          columns: {val: 'ASC'},
+          unique: true,
+        },
+      ],
+    ],
   ] satisfies [
     name: string,
     statements: string | string[],
@@ -2023,3 +2080,7 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
     },
   );
 });
+
+function removeAlterPublication(tags: readonly string[]) {
+  return tags.filter(tag => tag !== 'ALTER PUBLICATION');
+}

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -88,11 +88,7 @@ import type {
 } from './logical-replication/pgoutput.types.ts';
 import {subscribe, type StreamMessage} from './logical-replication/stream.ts';
 import {fromBigInt, toBigInt, toStateVersionString, type LSN} from './lsn.ts';
-import {
-  replicationEventSchema,
-  type DdlUpdateEvent,
-  type SchemaSnapshotEvent,
-} from './schema/ddl.ts';
+import {replicationEventSchema, type ReplicationEvent} from './schema/ddl.ts';
 import {updateShardSchema} from './schema/init.ts';
 import {
   getPublicationInfo,
@@ -1041,7 +1037,7 @@ class ChangeMaker {
         }
 
       case 'commit':
-        this.#lastSnapshotInTx = undefined;
+        this.#lastReplicationEventInTx = undefined;
         return [
           [
             'commit',
@@ -1064,8 +1060,7 @@ class ChangeMaker {
     }
   }
 
-  #preSchema: PublishedSchema | undefined;
-  #lastSnapshotInTx: PublishedSchema | undefined;
+  #lastReplicationEventInTx: ReplicationEvent | undefined;
 
   #handleDdlMessage(msg: MessageMessage) {
     const event = parseLogicalMessageContent(msg, replicationEventSchema);
@@ -1073,40 +1068,48 @@ class ChangeMaker {
     // is about to happen, so as to avoid interfering / redundant work.
     clearTimeout(this.#replicaIdentityTimer);
 
-    let previousSchema: PublishedSchema | null;
+    let prevEvent = this.#lastReplicationEventInTx;
     const {type} = event;
     switch (type) {
       case 'ddlStart':
-        // Store the schema in order to diff it with a subsequent ddlUpdate.
-        this.#preSchema = event.schema;
-        return [];
+      case 'schemaSnapshot':
+        break;
       case 'ddlUpdate':
         // guaranteed by event triggers
-        previousSchema = must(
-          this.#preSchema,
-          `ddlUpdate received without a ddlStart`,
-        );
-        break;
-      case 'schemaSnapshot':
-        previousSchema = this.#lastSnapshotInTx ?? null;
+        assert(prevEvent, `ddlUpdate received without a ddlStart`);
         break;
       default: // Ignore unknown types for forwards compatibility
         this.#lc.info?.(`ignoring unknown ddl message type: ${type}`);
         return [];
     }
 
-    // Store the schema (from either a ddlUpdate or schemaSnapshot) to
-    // diff against the next schemaSnapshot.
-    this.#lastSnapshotInTx = event.schema;
-    if (!previousSchema) {
+    // Store the new event to diff against the next event.
+    this.#lastReplicationEventInTx = event;
+    if (!prevEvent) {
       this.#lc.info?.(`received ${msg.prefix}/${type} event`);
-      return []; // First schemaSnapshot in the tx.
+      return []; // First snapshot in the tx.
     }
     this.#lc.info?.(`processing ${msg.prefix}/${type} event`, event);
 
-    const changes = this.#makeSchemaChanges(previousSchema, event).map(
-      change => ['data', change] satisfies Data,
-    );
+    // The tag (i.e. command) is used to determine whether backfill is
+    // necessary (CREATE TABLE vs ALTER TABLE vs ALTER PUBLICATION).
+    // Because ddl events may be nested, e.g.
+    //
+    // ```
+    //          [1]          [2]        [3]          [4]        [5]
+    // ddl_start => ddl_start => ddl_end => ddl_start => ddl_end => ddl_end
+    // ```
+    //
+    // The effective tag is determined from the starting event if it is
+    // ddl_start (e.g. cases 1, 2, and 4), and from the ending event
+    // otherwise (cases 3 and 5)
+    const effectiveTag =
+      prevEvent.type === 'ddlStart' ? prevEvent.event.tag : event.event.tag;
+    const changes = this.#makeSchemaChanges(
+      prevEvent.schema,
+      event,
+      effectiveTag,
+    ).map(change => ['data', change] satisfies Data);
 
     this.#lc
       .withContext('tag', event.event.tag)
@@ -1158,11 +1161,12 @@ class ChangeMaker {
    */
   #makeSchemaChanges(
     preSchema: PublishedSchema,
-    update: DdlUpdateEvent | SchemaSnapshotEvent,
+    event: ReplicationEvent,
+    tag: string,
   ): SchemaChange[] {
     try {
       const [prevTbl, prevIdx] = specsByID(preSchema);
-      const [nextTbl, nextIdx] = specsByID(update.schema);
+      const [nextTbl, nextIdx] = specsByID(event.schema);
       const changes: SchemaChange[] = [];
 
       // Validate the new table schemas
@@ -1211,7 +1215,7 @@ class ChangeMaker {
           ...this.#getTableChanges(
             must(prevTbl.get(id)),
             must(nextTbl.get(id)),
-            update.event.tag,
+            tag,
           ),
         );
       }
@@ -1223,7 +1227,7 @@ class ChangeMaker {
           spec,
           metadata: getMetadata(spec),
         };
-        if (!update.event.tag.startsWith('CREATE')) {
+        if (!tag.startsWith('CREATE')) {
           // Tables introduced to the publication via ALTER statements
           // or the COMMENT statement (from schemaSnapshots) must be
           // backfilled.
@@ -1242,7 +1246,7 @@ class ChangeMaker {
       }
       return changes;
     } catch (e) {
-      throw new UnsupportedSchemaChangeError(String(e), update, {cause: e});
+      throw new UnsupportedSchemaChangeError(String(e), event, {cause: e});
     }
   }
 
@@ -1628,11 +1632,11 @@ function makeRelation(relation: PostgresRelation): MessageRelation {
 class UnsupportedSchemaChangeError extends Error {
   readonly name = 'UnsupportedSchemaChangeError';
   readonly description: string;
-  readonly event: DdlUpdateEvent | SchemaSnapshotEvent;
+  readonly event: ReplicationEvent;
 
   constructor(
     description: string,
-    event: DdlUpdateEvent | SchemaSnapshotEvent,
+    event: ReplicationEvent,
     options?: ErrorOptions,
   ) {
     super(

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -1086,7 +1086,7 @@ class ChangeMaker {
     // Store the new event to diff against the next event.
     this.#lastReplicationEventInTx = event;
     if (!prevEvent) {
-      this.#lc.info?.(`received ${msg.prefix}/${type} event`);
+      this.#lc.info?.(`received ${msg.prefix}/${type} event`, event);
       return []; // First snapshot in the tx.
     }
     this.#lc.info?.(`processing ${msg.prefix}/${type} event`, event);

--- a/packages/zero-cache/src/services/change-source/pg/decommission.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/decommission.pg.test.ts
@@ -49,17 +49,7 @@ describe('decommission', () => {
     );
     expect(
       await upstream`SELECT evtname FROM pg_event_trigger WHERE evtname LIKE 'zerooutcs%'`.values(),
-    ).toEqual([
-      ['zerooutcs_ddl_start_13'],
-      ['zerooutcs_create_table_13'],
-      ['zerooutcs_alter_table_13'],
-      ['zerooutcs_create_index_13'],
-      ['zerooutcs_drop_table_13'],
-      ['zerooutcs_drop_index_13'],
-      ['zerooutcs_alter_publication_13'],
-      ['zerooutcs_alter_schema_13'],
-      ['zerooutcs_comment_13'],
-    ]);
+    ).toEqual([['zerooutcs_ddl_start_13'], ['zerooutcs_ddl_end_13']]);
     expect(
       await upstream`SELECT slot_name FROM pg_replication_slots WHERE slot_name LIKE 'zerooutcs%'`.values(),
     ).toMatchObject([[expect.stringMatching('zerooutcs_13_')]]);

--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl.pg.test.ts
@@ -1337,6 +1337,7 @@ describe('change-source/tables/ddl', () => {
       let msg = messages[3] as MessageMessage;
       expect(parseDDLStartEvent(msg)).toMatchObject({
         ...DDL_START,
+        event: ddlUpdate.event,
         context: {query},
       } satisfies DdlStartEvent);
 

--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl.pg.test.ts
@@ -108,6 +108,7 @@ describe('change-source/tables/ddl', () => {
   const DDL_START: Omit<DdlStartEvent, 'context'> = {
     type: 'ddlStart',
     version: 1,
+    event: {tag: 'UNUSED'},
     schema: {
       tables: [
         {

--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl.ts
@@ -22,6 +22,7 @@ const triggerEvent = v.object({
 export const ddlEventSchema = triggerEvent.extend({
   version: v.literal(PROTOCOL_VERSION),
   schema: publishedSchema,
+  event: v.object({tag: v.string()}),
 });
 
 // The `ddlStart` message is computed before every DDL event, regardless of
@@ -51,7 +52,6 @@ export type DdlStartEvent = v.Infer<typeof ddlStartEventSchema>;
  */
 export const ddlUpdateEventSchema = ddlEventSchema.extend({
   type: v.literal('ddlUpdate'),
-  event: v.object({tag: v.string()}),
 });
 
 export type DdlUpdateEvent = v.Infer<typeof ddlUpdateEventSchema>;
@@ -100,7 +100,6 @@ export type DdlUpdateEvent = v.Infer<typeof ddlUpdateEventSchema>;
  */
 export const schemaSnapshotEventSchema = ddlEventSchema.extend({
   type: v.literal('schemaSnapshot'),
-  event: v.object({tag: v.string()}),
 });
 
 export type SchemaSnapshotEvent = v.Infer<typeof schemaSnapshotEventSchema>;
@@ -188,6 +187,7 @@ BEGIN
     'type', 'ddlStart',
     'version', ${PROTOCOL_VERSION},
     'schema', schema_specs::json,
+    'event', json_build_object('tag', TG_TAG),
     'context', ${schema}.get_trigger_context()
   ) INTO message;
 
@@ -197,9 +197,11 @@ BEGIN
 END
 $$ LANGUAGE plpgsql;
 
+-- Delete legacy function (and dependent legacy triggers).
+DROP FUNCTION IF EXISTS ${schema}.emit_ddl_end(text) CASCADE;
 
-CREATE OR REPLACE FUNCTION ${schema}.emit_ddl_end(tag TEXT)
-RETURNS void AS $$
+CREATE OR REPLACE FUNCTION ${schema}.emit_ddl_end()
+RETURNS event_trigger AS $$
 DECLARE
   publications TEXT[];
   target RECORD;
@@ -223,7 +225,7 @@ BEGIN
   --       tables, and there is no way to determine if the table "used to be" in the
   --       set. Thus, all ALTER TABLE statements must produce a ddl update, similar to
   --       any DROP * statement.
-  IF (target.object_type = 'table' AND tag != 'ALTER TABLE') 
+  IF (target.object_type = 'table' AND TG_TAG != 'ALTER TABLE') 
      OR target.object_type = 'table column' THEN
     SELECT ns.nspname AS "schema", c.relname AS "name" FROM pg_class AS c
       JOIN pg_namespace AS ns ON c.relnamespace = ns.oid
@@ -263,19 +265,19 @@ BEGIN
       INTO relevant;
 
   -- no-op CREATE IF NOT EXIST statements
-  ELSIF tag LIKE 'CREATE %' AND target.object_type IS NULL THEN
+  ELSIF TG_TAG LIKE 'CREATE %' AND target.object_type IS NULL THEN
     relevant := NULL;
   END IF;
 
   IF relevant IS NULL THEN
-    PERFORM ${schema}.notice_ignore(tag, target);
+    PERFORM ${schema}.notice_ignore(TG_TAG, target);
     RETURN;
   END IF;
 
-  IF tag = 'COMMENT' THEN
+  IF TG_TAG = 'COMMENT' THEN
     -- Only make schemaSnapshots for COMMENT ON PUBLICATION
     IF target.object_type != 'publication' THEN
-      PERFORM ${schema}.notice_ignore(tag, target);
+      PERFORM ${schema}.notice_ignore(TG_TAG, target);
       RETURN;
     END IF;
     event_type := 'schemaSnapshot';
@@ -285,18 +287,15 @@ BEGIN
     event_prefix := '';  -- TODO: Use '/ddl' for both when rollback safe
   END IF;
 
-  RAISE INFO 'Creating % for % %', event_type, tag, row_to_json(target);
+  RAISE INFO 'Creating % for % %', event_type, TG_TAG, row_to_json(target);
 
-  -- Construct and emit the DdlUpdateEvent message.
-  SELECT json_build_object('tag', tag) INTO event;
-  
   SELECT ${schema}.schema_specs() INTO schema_specs;
 
   SELECT json_build_object(
     'type', event_type,
     'version', ${PROTOCOL_VERSION},
     'schema', schema_specs::json,
-    'event', event::json,
+    'event', json_build_object('tag', TG_TAG),
     'context', ${schema}.get_trigger_context()
   ) INTO message;
 
@@ -341,24 +340,17 @@ CREATE EVENT TRIGGER ${sharded(`${appID}_ddl_start`)}
   ON ddl_command_start
   WHEN TAG IN (${lit(TAGS)})
   EXECUTE PROCEDURE ${schema}.emit_ddl_start();
+
+CREATE EVENT TRIGGER ${sharded(`${appID}_ddl_end`)}
+  ON ddl_command_end
+  WHEN TAG IN (${lit([...TAGS, 'COMMENT'])})
+  EXECUTE PROCEDURE ${schema}.emit_ddl_end();
 `);
 
-  // A per-tag ddl_command_end trigger that dispatches to ${schema}.emit_ddl_end(tag)
+  // Drop legacy functions / triggers.
   for (const tag of [...TAGS, 'COMMENT']) {
     const tagID = tag.toLowerCase().replace(' ', '_');
-    triggers.push(/*sql*/ `
-CREATE OR REPLACE FUNCTION ${schema}.emit_${tagID}() 
-RETURNS event_trigger AS $$
-BEGIN
-  PERFORM ${schema}.emit_ddl_end(${lit(tag)});
-END
-$$ LANGUAGE plpgsql;
-
-CREATE EVENT TRIGGER ${sharded(`${appID}_${tagID}`)}
-  ON ddl_command_end
-  WHEN TAG IN (${lit(tag)})
-  EXECUTE PROCEDURE ${schema}.emit_${tagID}();
-`);
+    triggers.push(`DROP FUNCTION IF EXISTS ${schema}.emit_${tagID}() CASCADE;`);
   }
   return triggers.join('');
 }
@@ -368,18 +360,8 @@ export function dropEventTriggerStatements(
   appID: string,
   shardID: string | number,
 ) {
-  const stmts: string[] = [];
-  // A single ddl_command_start trigger covering all relevant tags.
-  stmts.push(/*sql*/ `
+  return /*sql*/ `
     DROP EVENT TRIGGER IF EXISTS ${id(`${appID}_ddl_start_${shardID}`)};
-  `);
-
-  // A per-tag ddl_command_end trigger that dispatches to ${schema}.emit_ddl_end(tag)
-  for (const tag of [...TAGS, 'COMMENT']) {
-    const tagID = tag.toLowerCase().replace(' ', '_');
-    stmts.push(/*sql*/ `
-      DROP EVENT TRIGGER IF EXISTS ${id(`${appID}_${tagID}_${shardID}`)};
-    `);
-  }
-  return stmts.join('');
+    DROP EVENT TRIGGER IF EXISTS ${id(`${appID}_ddl_end_${shardID}`)};
+  `;
 }

--- a/packages/zero-cache/src/services/change-source/pg/schema/init.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.ts
@@ -248,7 +248,10 @@ function getIncrementalMigrations(
     // (subsumed by v19)
 
     // v19: Correctly handle concurrently issued DDL statements.
-    19: {
+    // (subsumed by v20)
+
+    // v20: Handle nested DDL triggers
+    20: {
       migrateSchema: async (lc, sql) => {
         const [{publications}] = await sql<{publications: string[]}[]>`
           SELECT publications FROM ${sql(shardConfigTable)}`;

--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.pg.test.ts
@@ -84,17 +84,7 @@ describe('change-source/pg', () => {
 
     expect(
       (await db`SELECT evtname from pg_event_trigger`.values()).flat(),
-    ).toEqual([
-      'zro_ddl_start_0',
-      'zro_create_table_0',
-      'zro_alter_table_0',
-      'zro_create_index_0',
-      'zro_drop_table_0',
-      'zro_drop_index_0',
-      'zro_alter_publication_0',
-      'zro_alter_schema_0',
-      'zro_comment_0',
-    ]);
+    ).toEqual(['zro_ddl_start_0', 'zro_ddl_end_0']);
   });
 
   test('default publication, join table', async () => {


### PR DESCRIPTION
Correctly handle nested DDL events in schema change detection.

External event triggers that execute their own DDL statements (e.g. an event trigger that enables RLS on `CREATE TABLE` statements) can cause a nesting of zero events, e.g.

* ddlStart
  * ddlStart
  * ddlUpdate
  * ddlStart
  * ddlUpdate
* ddlUpdate

The previous logic of always comparing a ddlUpdate with the preceding ddlStart would result in missing schema changes when nested in this fashion.

The updated logic treats all events uniformly, each producing a schema snapshot in a linear timeline. Any two snapshots within a transaction are diffed with the immediately preceding snapshot. This ensures that the diff logic correctly matches the actual sequence of potential ddl changes.

Context:
* https://rocicorp.slack.com/archives/C0ARBDKG3D4/p1776376302026549

### Miscellaneous

Coalesce the previous per-command functions / triggers into a single `ddl_end` function / trigger pair, using the built in `TG_TAG` variable to determine the tag instead.