### PR TITLE
fix(benchmark): remove CI number from benchmark upload command

### DIFF
--- a/.github/workflows/reusable-benchmark.yml
+++ b/.github/workflows/reusable-benchmark.yml
@@ -68,7 +68,6 @@ jobs:
           cat output.json |\
           bencher run \
           --project zero \
-          --ci-number ${{ github.run_number }} \
           --testbed self-hosted-metal \
           --token '${{ secrets.BENCHER_API_TOKEN }}' \
           --adapter json \


### PR DESCRIPTION
With this we ended up getting comments on unrelated old PRs.