### PR TITLE
perf(zql): replace skipYields generator with IterableIterator to reduce allocations

### DIFF
--- a/packages/zql/src/ivm/operator.ts
+++ b/packages/zql/src/ivm/operator.ts
@@ -6,6 +6,8 @@ import type {Node} from './data.ts';
 import type {SourceSchema} from './schema.ts';
 import type {Stream} from './stream.ts';
 
+export {skipYields} from './skip-yields.ts';
+
 /**
  * Input to an operator.
  */
@@ -85,14 +87,6 @@ export const throwOutput: Output = {
     throw new Error('Output not set');
   },
 };
-
-export function* skipYields(stream: Stream<Node | 'yield'>): Stream<Node> {
-  for (const node of stream) {
-    if (node !== 'yield') {
-      yield node;
-    }
-  }
-}
 
 /**
  * Operators are arranged into pipelines.

--- a/packages/zql/src/ivm/skip-yields.ts
+++ b/packages/zql/src/ivm/skip-yields.ts
@@ -1,0 +1,46 @@
+import type {Node} from './data.ts';
+import type {Stream} from './stream.ts';
+
+// Implemented as a custom IterableIterator rather than a generator function to
+// reduce allocations. A generator creates a new state-machine object each time
+// it is called. By returning `this` from [Symbol.iterator](), the same object
+// acts as both the Iterable and the Iterator, so iterating the stream incurs
+// only one allocation (the SkipYieldsStream instance itself) instead of two.
+// Additionally, the IteratorResult objects ({value, done}) from the inner
+// iterator are returned directly rather than being recreated, avoiding further
+// per-item allocations.
+class SkipYieldsStream implements IterableIterator<Node> {
+  readonly #stream: Stream<Node | 'yield'>;
+  #it: Iterator<Node | 'yield'> | undefined = undefined;
+
+  constructor(stream: Stream<Node | 'yield'>) {
+    this.#stream = stream;
+  }
+
+  [Symbol.iterator](): IterableIterator<Node> {
+    this.#it = this.#stream[Symbol.iterator]();
+    return this;
+  }
+
+  next(): IteratorResult<Node> {
+    // #it is always set before next() is called, as [Symbol.iterator]() must
+    // be called first (e.g. by a for-of loop).
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const it = this.#it!;
+    for (;;) {
+      const r = it.next();
+      if (r.done || r.value !== 'yield') {
+        return r as IteratorResult<Node>;
+      }
+    }
+  }
+
+  return(value?: undefined): IteratorResult<Node> {
+    this.#it?.return?.(value);
+    return {done: true, value: undefined};
+  }
+}
+
+export function skipYields(stream: Stream<Node | 'yield'>): Stream<Node> {
+  return new SkipYieldsStream(stream);
+}


### PR DESCRIPTION
## perf(zql): replace skipYields generator with IterableIterator

Replaces the `skipYields` generator function in `operator.ts` with a
custom `SkipYieldsStream` class that implements `IterableIterator<Node>`
directly. The implementation is extracted into a new file,
`packages/zql/src/ivm/skip-yields.ts`, and re-exported from
`operator.ts` to keep the public API unchanged.

### Why this is faster

A generator function creates two objects on every call: a state-machine
object and an iterator wrapper. By implementing `IterableIterator`
directly and returning `this` from `[Symbol.iterator]()`, the same
single instance serves as both the iterable and the iterator, halving
the allocation count per call site.

Additionally, the `IteratorResult` objects `{value, done}` from the
inner iterator are forwarded directly rather than being recreated by
a `yield` statement, avoiding per-item allocations on the hot path.

### Benchmark results (3 runs each, median)

| Benchmark | Before (generator) | After (IterableIterator) | Δ |
|---|---|---|---|
| hydrate: issues only | 264.7 µs | 221.0 µs | **−16%** |
| hydrate: with creator | 1.08 ms | 997 µs | **−8%** |
| hydrate: creator+comments | 2.14 ms | 1.81 ms | **−15%** |
| hydrate: filtered open | 258.5 µs | 217.0 µs | **−16%** |
| hydrate: limit 50 | 31.3 µs | 29.6 µs | **−5%** |
| push: add issue (no join) | 35.0 µs | 34.4 µs | −2% |
| push: add issue (creator join) | 5.16 µs | 5.59 µs | noise |
| push: edit title | 4.72 µs | 4.98 µs | noise |
| push: add comment | 6.46 µs | 6.27 µs | noise |
| push: inside limit(50) | 2.69 µs | 2.67 µs | noise |
| push: outside limit(50) | 1.94 µs | 2.15 µs | noise |

Hydration is consistently **5–16% faster**. Push benchmarks show no
meaningful difference — those paths are short and the sub-µs deltas
are within noise.