### PR TITLE
feat(zero-client): log sink option to redirect client output

### DIFF
--- a/packages/analyze-query/src/analyze-cli.ts
+++ b/packages/analyze-query/src/analyze-cli.ts
@@ -1,6 +1,8 @@
 import '../../shared/src/dotenv.ts';
 
+import {Console} from 'node:console';
 import {styleText} from 'node:util';
+import type {LogSink} from '@rocicorp/logger';
 import {WebSocket as NodeWebSocket} from 'ws';
 import {logLevel, logOptions} from '../../otel/src/log-options.ts';
 import {colorConsole} from '../../shared/src/logging.ts';
@@ -116,6 +118,24 @@ type QueryPlan =
   | {kind: 'zql'; text: string}
   | {kind: 'named'; name: string; args: ReadonlyArray<unknown>};
 
+// Route all Zero client log output to stderr so stdout contains only the
+// analyze result. Shell redirection (`2>/dev/null`) can then cleanly silence
+// logs without affecting output.
+const stderrConsole = new Console({
+  stdout: process.stderr,
+  stderr: process.stderr,
+});
+const stderrLogSink: LogSink = {
+  log(level, context, ...args) {
+    const ctx = context
+      ? Object.entries(context).map(([k, v]) =>
+          v === undefined ? k : `${k}=${v}`,
+        )
+      : [];
+    stderrConsole[level](...ctx, ...args);
+  },
+};
+
 /**
  * Entry point for a user's `cli.ts`. Parses argv, connects to a remote
  * zero-cache by standing up an in-process Zero client (in-memory storage,
@@ -186,6 +206,7 @@ export async function runAnalyzeCLI(opts: AnalyzeCLIOptions): Promise<void> {
     userID: config.userId ?? 'analyze-cli',
     kvStore: 'mem',
     logLevel: config.log.level,
+    logSink: stderrLogSink,
   });
 
   let result: AnalyzeQueryResult;

--- a/packages/analyze-query/src/analyze-cli.ts
+++ b/packages/analyze-query/src/analyze-cli.ts
@@ -20,7 +20,7 @@ import type {SchemaQuery} from '../../zql/src/query/schema-query.ts';
 export type AnalyzeCLIOptions = {
   schema: Schema;
   /** Defaults to `process.argv.slice(2)`. */
-  argv?: readonly string[];
+  argv?: readonly string[] | undefined;
 };
 
 const options = {

--- a/packages/zero-client/src/client/log-options.ts
+++ b/packages/zero-client/src/client/log-options.ts
@@ -49,17 +49,19 @@ export function createLogOptions(
     consoleLogLevel: LogLevel;
     server: HTTPString | null;
     enableAnalytics: boolean;
+    consoleLogSink?: LogSink | undefined;
   },
   createDatadogLogSink: (options: DatadogLogSinkOptions) => LogSink = (
     options: DatadogLogSinkOptions,
   ) => new DatadogLogSink(options),
 ): LogOptions {
   const {consoleLogLevel, server, enableAnalytics} = options;
+  const userSink = options.consoleLogSink ?? consoleLogSink;
 
   if (!enableAnalytics || server === null) {
     return {
       logLevel: consoleLogLevel,
-      logSink: consoleLogSink,
+      logSink: userSink,
     };
   }
 
@@ -73,7 +75,7 @@ export function createLogOptions(
   const baseURL = new URL(appendPath(server, '/logs/v0/log'));
   const logLevel = consoleLogLevel === 'debug' ? 'debug' : 'info';
   const logSink = new TeeLogSink([
-    new LevelFilterLogSink(consoleLogSink, consoleLogLevel),
+    new LevelFilterLogSink(userSink, consoleLogLevel),
     new LevelFilterLogSink(
       createDatadogLogSink({
         service: datadogServiceLabel,

--- a/packages/zero-client/src/client/options.ts
+++ b/packages/zero-client/src/client/options.ts
@@ -1,4 +1,4 @@
-import type {LogLevel} from '@rocicorp/logger';
+import type {LogLevel, LogSink} from '@rocicorp/logger';
 import type {StoreProvider} from '../../../replicache/src/kv/store.ts';
 import * as v from '../../../shared/src/valita.ts';
 import type {
@@ -87,6 +87,19 @@ export type ZeroOptions<
    * Default is `'error'`.
    */
   logLevel?: LogLevel | undefined;
+
+  /**
+   * Destination for Zero's log output. When omitted, logs are written with
+   * `console.log`/`info`/`warn`/`error` etc.
+   *
+   * Provide a custom {@linkcode LogSink} to redirect logs — for example, to
+   * `process.stderr` in a CLI so that the tool's structured stdout output
+   * isn't polluted by log lines.
+   *
+   * Note: this overrides only the console sink. When analytics logging is
+   * enabled, the Datadog sink is still installed alongside this one.
+   */
+  logSink?: LogSink | undefined;
 
   /**
    * This defines the schema of the tables used in Zero and their relationships

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -1,4 +1,4 @@
-import {LogContext, type LogLevel} from '@rocicorp/logger';
+import {LogContext, type LogLevel, type LogSink} from '@rocicorp/logger';
 import {type Resolver, resolver} from '@rocicorp/resolver';
 import {type DeletedClients} from '../../../replicache/src/deleted-clients.ts';
 import {getKVStoreProvider} from '../../../replicache/src/get-kv-store-provider.ts';
@@ -524,6 +524,7 @@ export class Zero<
       consoleLogLevel: options.logLevel ?? 'warn',
       server: null, //server, // Reenable remote logging
       enableAnalytics: this.#enableAnalytics,
+      consoleLogSink: options.logSink,
     });
     const logOptions = this.#logOptions;
 
@@ -901,6 +902,7 @@ export class Zero<
     consoleLogLevel: LogLevel;
     server: HTTPString | null;
     enableAnalytics: boolean;
+    consoleLogSink?: LogSink | undefined;
   }): LogOptions {
     if (TESTING) {
       const testZero = asTestZero(this);


### PR DESCRIPTION
If a user runs zero-client inside a node process this would be a generally desired thing to do. Even in the browser if the user wants to collect zero-client logs in a special way.