### PR TITLE
fix(zero-cache): downgrade inspect parse/analyze failures to warnings

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/inspect-handler.ts
+++ b/packages/zero-cache/src/services/view-syncer/inspect-handler.ts
@@ -161,7 +161,7 @@ export async function handleInspect(
         unreachable(body);
     }
   } catch (e) {
-    lc.error?.('Error handling inspect message', e);
+    lc.warn?.('Error handling inspect message', e);
     client.sendInspectResponse(lc, {
       op: 'error',
       id: body.id,

--- a/packages/zero-cache/src/workers/connection.ts
+++ b/packages/zero-cache/src/workers/connection.ts
@@ -186,14 +186,14 @@ export class Connection {
       const value = JSON.parse(data);
       msg = valita.parse(value, upstreamSchema);
     } catch (e) {
-      this.#lc.warn?.(`failed to parse message "${data}": ${String(e)}`);
+      const errorBody = {
+        kind: ErrorKind.InvalidMessage,
+        message: String(e),
+        origin: ErrorOrigin.ZeroCache,
+      } as const;
       this.#closeWithError(
-        {
-          kind: ErrorKind.InvalidMessage,
-          message: String(e),
-          origin: ErrorOrigin.ZeroCache,
-        },
-        e,
+        errorBody,
+        new ProtocolErrorWithLevel(errorBody, 'warn'),
       );
       return;
     }


### PR DESCRIPTION
Inspector analyze requests are user-generated and can fail during debugging without indicating a cache/server fault.

- Log inspect handler failures at warn level while still returning inspect error responses.

- Wrap InvalidMessage parse failures with ProtocolErrorWithLevel('warn') so websocket error emission stays warn.