### PR TITLE
chore(zql): improve asQueryInternals assertion message

### DIFF
--- a/packages/zql/src/query/query-internals.test.ts
+++ b/packages/zql/src/query/query-internals.test.ts
@@ -1,0 +1,10 @@
+import {expect, test} from 'vitest';
+import {asQueryInternals} from './query-internals.ts';
+import type {Query} from './query.ts';
+
+test('asQueryInternals throws with duplicate-Zero hint when tag is missing', () => {
+  const fake = {} as Query<string, never, never>;
+  expect(() => asQueryInternals(fake)).toThrowError(
+    'two copies of Zero in your runtime',
+  );
+});

--- a/packages/zql/src/query/query-internals.ts
+++ b/packages/zql/src/query/query-internals.ts
@@ -84,7 +84,10 @@ export function asQueryInternals<
 >(
   query: Query<TTable, TSchema, TReturn>,
 ): QueryInternals<TTable, TSchema, TReturn> {
-  assert(queryInternalsTag in query, 'Query does not implement QueryInternals');
+  assert(
+    queryInternalsTag in query,
+    'Query does not implement QueryInternals. This likely means there are two copies of Zero in your runtime.',
+  );
   return query as unknown as QueryInternals<TTable, TSchema, TReturn>;
 }
 


### PR DESCRIPTION
Improve asQueryInternals assertion message to hint at duplicate Zero copies.