### PR TITLE
chore: remove simple-git-hooks and update git hook scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "@rocicorp/mono",
       "version": "0.0.0",
-      "hasInstallScript": true,
       "workspaces": [
         "apps/*",
         "packages/*",
@@ -24,7 +23,6 @@
         "oxfmt": "^0.45.0",
         "oxlint": "^1.60.0",
         "oxlint-tsgolint": "^0.20.0",
-        "simple-git-hooks": "^2.13.1",
         "syncpack": "^14.3.0",
         "tsx": "^4.21.0",
         "turbo": "^2.4.4",
@@ -30452,17 +30450,6 @@
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
-      }
-    },
-    "node_modules/simple-git-hooks": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/simple-git-hooks/-/simple-git-hooks-2.13.1.tgz",
-      "integrity": "sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "simple-git-hooks": "cli.js"
       }
     },
     "node_modules/simple-oauth2": {

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "verify-deps:fix": "cd tools/verify-package-deps && npm run verify:fix",
     "bench": "npx turbo run bench --concurrency=1",
     "bench:bmf": "npx turbo run bench:bmf --concurrency=1",
-    "bench:bmf:silent": "npx turbo run bench:bmf:silent --concurrency=1",
-    "postinstall": "simple-git-hooks"
+    "bench:bmf:silent": "npx turbo run bench:bmf:silent --concurrency=1"
   },
   "devDependencies": {
     "@e18e/eslint-plugin": "^0.3.0",
@@ -41,7 +40,6 @@
     "oxfmt": "^0.45.0",
     "oxlint": "^1.60.0",
     "oxlint-tsgolint": "^0.20.0",
-    "simple-git-hooks": "^2.13.1",
     "syncpack": "^14.3.0",
     "tsx": "^4.21.0",
     "turbo": "^2.4.4",
@@ -50,10 +48,6 @@
   },
   "overrides": {
     "esbuild": "^0.27.4"
-  },
-  "simple-git-hooks": {
-    "pre-commit": "./tools/git-hooks/pre-commit.ts",
-    "pre-push": "./tools/git-hooks/pre-push.ts"
   },
   "engines": {
     "node": ">=22"

--- a/packages/replicache/CONTRIBUTING.md
+++ b/packages/replicache/CONTRIBUTING.md
@@ -46,3 +46,27 @@ All contributors must sign a contributor agreement, either for an <a href="https
       - request and response content
       - some process is starting
   - We do not use a warning level because warnings are typically not actionable and are mostly ignored. We prefer the developer to take a position: does the thing rise to the level that a developer should go do something about it or not? We do not use a trace level because we haven't yet found a use for it, and extra log levels are just confusing.
+
+### Git Hooks
+
+We provide optional pre-commit and pre-push hooks in `tools/git-hooks/`.
+
+**pre-commit**: Automatically formats staged files using `oxfmt` and re-adds them before the commit.
+
+To install, create `.git/hooks/pre-commit`:
+
+```sh
+#!/bin/sh
+./tools/git-hooks/pre-commit.ts
+```
+
+**pre-push**: Runs `syncpack lint`, `oxlint`, and `oxfmt --check` against files changed relative to `origin/main` before pushing.
+
+To install, create `.git/hooks/pre-push`:
+
+```sh
+#!/bin/sh
+./tools/git-hooks/pre-push.ts
+```
+
+Make both files executable with `chmod +x .git/hooks/pre-commit .git/hooks/pre-push`.

--- a/tools/git-hooks/pre-commit.ts
+++ b/tools/git-hooks/pre-commit.ts
@@ -1,4 +1,10 @@
 #!/usr/bin/env node
+
+// To use this add a file called .git/hooks/pre-commit with the following content:
+//
+// #!/bin/sh
+// ./tools/git-hooks/pre-commit.ts
+
 import {$} from 'zx';
 
 const files = (

--- a/tools/git-hooks/pre-push.ts
+++ b/tools/git-hooks/pre-push.ts
@@ -1,5 +1,10 @@
 #!/usr/bin/env node
 
+// To use this add a file called .git/hooks/pre-push with the following content:
+//
+// #!/bin/sh
+// ./tools/git-hooks/pre-push.ts
+
 // oxlint-disable no-console
 import {$} from 'zx';
 


### PR DESCRIPTION
To use the new git hook scripts, add the following content to the corresponding files in .git/hooks:

For pre-commit:

```
./tools/git-hooks/pre-commit.ts
```

For pre-push:

```
./tools/git-hooks/pre-push.ts
```