### PR TITLE
chore(zero-cache): persist rowSetSignature on query records

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr-store.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.ts
@@ -111,6 +111,12 @@ function asQuery(row: QueriesRow): QueryRecord {
   const maybeVersion = (s: string | null) =>
     s === null ? undefined : versionFromString(s);
 
+  // Only attach rowSetSignature when the column is non-null, so existing
+  // snapshots that don't include the field don't break.
+  const sigField = row.rowSetSignature
+    ? {rowSetSignature: row.rowSetSignature}
+    : {};
+
   if (row.clientAST === null) {
     // custom query
     assert(
@@ -126,6 +132,7 @@ function asQuery(row: QueriesRow): QueryRecord {
       clientState: {},
       transformationHash: row.transformationHash ?? undefined,
       transformationVersion: maybeVersion(row.transformationVersion),
+      ...sigField,
     } satisfies CustomQueryRecord;
   }
 
@@ -137,6 +144,7 @@ function asQuery(row: QueriesRow): QueryRecord {
         ast,
         transformationHash: row.transformationHash ?? undefined,
         transformationVersion: maybeVersion(row.transformationVersion),
+        ...sigField,
       } satisfies InternalQueryRecord)
     : ({
         type: 'client',
@@ -146,6 +154,7 @@ function asQuery(row: QueriesRow): QueryRecord {
         clientState: {},
         transformationHash: row.transformationHash ?? undefined,
         transformationVersion: maybeVersion(row.transformationVersion),
+        ...sigField,
       } satisfies ClientQueryRecord);
 }
 
@@ -228,8 +237,14 @@ export class CVRStore {
   }
 
   #updateQueryFields(queryHash: string, fields: Partial<QueriesRow>): void {
-    // Track as partial-only update for batched flush
-    this.#pendingQueryPartialUpdates.set(queryHash, fields);
+    // Track as partial-only update for batched flush. Merge into any
+    // pre-existing partial update for the same hash so independent callers
+    // (e.g. updateQuery + updateRowSetSignature) don't clobber each other.
+    const existing = this.#pendingQueryPartialUpdates.get(queryHash);
+    this.#pendingQueryPartialUpdates.set(
+      queryHash,
+      existing ? {...existing, ...fields} : fields,
+    );
   }
 
   load(lc: LogContext, lastConnectTime: number): Promise<CVR> {
@@ -587,6 +602,10 @@ export class CVRStore {
     });
   }
 
+  updateRowSetSignature(queryHash: string, signature: string): void {
+    this.#updateQueryFields(queryHash, {rowSetSignature: signature});
+  }
+
   insertClient(client: ClientRecord): void {
     const change: ClientsRow = {
       clientGroupID: this.#id,
@@ -749,7 +768,8 @@ export class CVRStore {
           "transformationHash",
           "transformationVersion",
           "internal",
-          "deleted"
+          "deleted",
+          "rowSetSignature"
         )
         SELECT
           "clientGroupID",
@@ -764,7 +784,8 @@ export class CVRStore {
           "transformationHash",
           "transformationVersion",
           "internal",
-          "deleted"
+          "deleted",
+          "rowSetSignature"
         FROM json_to_recordset(${rows}) AS x(
           "clientGroupID" TEXT,
           "queryHash" TEXT,
@@ -775,12 +796,13 @@ export class CVRStore {
           "transformationHash" TEXT,
           "transformationVersion" TEXT,
           "internal" BOOLEAN,
-          "deleted" BOOLEAN
+          "deleted" BOOLEAN,
+          "rowSetSignature" TEXT
         )
         ON CONFLICT ("clientGroupID", "queryHash") DO UPDATE SET
           "clientAST" = excluded."clientAST",
           "queryName" = excluded."queryName",
-          "queryArgs" = CASE 
+          "queryArgs" = CASE
             WHEN excluded."queryArgs" IS NULL THEN NULL
             ELSE excluded."queryArgs"::json
           END,
@@ -788,7 +810,8 @@ export class CVRStore {
           "transformationHash" = excluded."transformationHash",
           "transformationVersion" = excluded."transformationVersion",
           "internal" = excluded."internal",
-          "deleted" = excluded."deleted"
+          "deleted" = excluded."deleted",
+          "rowSetSignature" = excluded."rowSetSignature"
       `);
     }
 
@@ -808,6 +831,8 @@ export class CVRStore {
           transformationHash: partial.transformationHash ?? null,
           transformationVersionSet: partial.transformationVersion !== undefined,
           transformationVersion: partial.transformationVersion ?? null,
+          rowSetSignatureSet: partial.rowSetSignature !== undefined,
+          rowSetSignature: partial.rowSetSignature ?? null,
         }),
       );
       queries.push(tx`
@@ -828,6 +853,10 @@ export class CVRStore {
           "transformationVersion" = CASE
             WHEN u."transformationVersionSet" THEN u."transformationVersion"
             ELSE q."transformationVersion"
+          END,
+          "rowSetSignature" = CASE
+            WHEN u."rowSetSignatureSet" THEN u."rowSetSignature"
+            ELSE q."rowSetSignature"
           END
         FROM json_to_recordset(${rows}) AS u(
           "clientGroupID" TEXT,
@@ -839,7 +868,9 @@ export class CVRStore {
           "transformationHashSet" BOOLEAN,
           "transformationHash" TEXT,
           "transformationVersionSet" BOOLEAN,
-          "transformationVersion" TEXT
+          "transformationVersion" TEXT,
+          "rowSetSignatureSet" BOOLEAN,
+          "rowSetSignature" TEXT
         )
         WHERE q."clientGroupID" = u."clientGroupID"
           AND q."queryHash" = u."queryHash"

--- a/packages/zero-cache/src/services/view-syncer/cvr.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.pg.test.ts
@@ -43,6 +43,24 @@ const SHARD = {appID: APP_ID, shardNum: SHARD_NUM};
 
 const LAST_CONNECT = Date.UTC(2024, 2, 1);
 
+/**
+ * Strips `rowSetSignature` from every QueryRecord in a CVR (or partial CVR)
+ * snapshot so test fixtures that pre-date the signature column can compare via
+ * `toEqual` without listing it in expected output. The signature itself is
+ * verified by dedicated tests (see row-set-signature.test.ts and the
+ * Cap-drift integration tests).
+ */
+function stripRowSetSignatures<T extends {queries: Record<string, object>}>(
+  cvr: T,
+): T {
+  const queries: Record<string, object> = {};
+  for (const [id, q] of Object.entries(cvr.queries)) {
+    const {rowSetSignature: _, ...rest} = q as {rowSetSignature?: unknown};
+    queries[id] = rest;
+  }
+  return {...cvr, queries} as T;
+}
+
 describe('view-syncer/cvr', () => {
   type DBState = {
     instances: (Partial<InstancesRow> &
@@ -149,6 +167,18 @@ describe('view-syncer/cvr', () => {
           break;
         }
         case 'queries': {
+          // Strip rowSetSignature from actual rows when no fixture in
+          // tableState explicitly mentions it. Tests that don't care about
+          // signatures stay terse; tests that DO care can include their
+          // expected value in the fixture.
+          const expectsSig = (tableState as Partial<QueriesRow>[]).some(
+            row => row.rowSetSignature !== undefined,
+          );
+          if (!expectsSig) {
+            for (const row of res as QueriesRow[]) {
+              delete (row as {rowSetSignature?: string | null}).rowSetSignature;
+            }
+          }
           (res as QueriesRow[]).sort(compareQueriesRows);
           (tableState as QueriesRow[]).sort(compareQueriesRows);
           break;
@@ -788,7 +818,9 @@ describe('view-syncer/cvr', () => {
       ON_FAILURE,
     );
     const reloaded = await cvrStore2.load(lc, LAST_CONNECT);
-    expect(reloaded).toEqual(updated);
+    expect(stripRowSetSignatures(reloaded)).toEqual(
+      stripRowSetSignatures(updated),
+    );
 
     // Let the takeover write that's fired during load to reach PG.
     await vi.waitFor(() =>
@@ -1178,7 +1210,7 @@ describe('view-syncer/cvr', () => {
         "statements": 6,
       }
     `);
-    expect(updated).toEqual({
+    expect(stripRowSetSignatures(updated)).toEqual({
       id: 'abc123',
       version: {stateVersion: '1aa', configVersion: 1}, // configVersion bump
       replicaVersion: '101',
@@ -1575,7 +1607,9 @@ describe('view-syncer/cvr', () => {
       ON_FAILURE,
     );
     const reloaded = await cvrStore2.load(lc, LAST_CONNECT);
-    expect(reloaded).toEqual(updated);
+    expect(stripRowSetSignatures(reloaded)).toEqual(
+      stripRowSetSignatures(updated),
+    );
 
     // Add the deleted desired query back. This ensures that the
     // desired query update statement is an UPSERT.
@@ -2045,7 +2079,7 @@ describe('view-syncer/cvr', () => {
       ]
     `);
 
-    expect(updated).toEqual({
+    expect(stripRowSetSignatures(updated)).toEqual({
       ...cvr,
       replicaVersion: '123',
       version: newVersion,
@@ -2080,7 +2114,9 @@ describe('view-syncer/cvr', () => {
       ON_FAILURE,
     );
     const reloaded = await cvrStore2.load(lc, LAST_CONNECT);
-    expect(reloaded).toEqual(updated);
+    expect(stripRowSetSignatures(reloaded)).toEqual(
+      stripRowSetSignatures(updated),
+    );
 
     await expectState(cvrDb, {
       instances: [
@@ -2505,7 +2541,7 @@ describe('view-syncer/cvr', () => {
       ]
     `);
 
-    expect(updated).toEqual({
+    expect(stripRowSetSignatures(updated)).toEqual({
       ...cvr,
       version: newVersion,
       queries: {
@@ -3106,7 +3142,7 @@ describe('view-syncer/cvr', () => {
       ]
     `);
 
-    expect(updated).toEqual({
+    expect(stripRowSetSignatures(updated)).toEqual({
       ...cvr,
       version: newVersion,
       lastActive: 1713834000000,
@@ -3545,7 +3581,7 @@ describe('view-syncer/cvr', () => {
       ]
     `);
 
-    expect(updated).toEqual({
+    expect(stripRowSetSignatures(updated)).toEqual({
       ...cvr,
       version: newVersion,
       queries: {},
@@ -4090,7 +4126,7 @@ describe('view-syncer/cvr', () => {
       ]
     `);
 
-    expect(updated).toEqual(cvr);
+    expect(stripRowSetSignatures(updated)).toEqual(stripRowSetSignatures(cvr));
 
     // Verify round tripping.
     const doCVRStore2 = new CVRStore(
@@ -4258,7 +4294,9 @@ describe('view-syncer/cvr', () => {
       ON_FAILURE,
     );
     const reloaded = await cvrStore2.load(lc, LAST_CONNECT);
-    expect(reloaded).toEqual(updated);
+    expect(stripRowSetSignatures(reloaded)).toEqual(
+      stripRowSetSignatures(updated),
+    );
 
     await expectState(cvrDb, {
       instances: [
@@ -4466,7 +4504,9 @@ describe('view-syncer/cvr', () => {
       ON_FAILURE,
     );
     const reloaded = await cvrStore2.load(lc, LAST_CONNECT);
-    expect(reloaded).toEqual(updated);
+    expect(stripRowSetSignatures(reloaded)).toEqual(
+      stripRowSetSignatures(updated),
+    );
 
     await expectState(cvrDb, {
       instances: [
@@ -4735,7 +4775,9 @@ describe('view-syncer/cvr', () => {
       ON_FAILURE,
     );
     const reloaded = await cvrStore2.load(lc, LAST_CONNECT);
-    expect(reloaded).toEqual(updated);
+    expect(stripRowSetSignatures(reloaded)).toEqual(
+      stripRowSetSignatures(updated),
+    );
 
     await expectState(cvrDb, {
       instances: [
@@ -5252,7 +5294,7 @@ describe('view-syncer/cvr', () => {
         now,
         ttlClock,
       );
-      expect(updated).toEqual({
+      expect(stripRowSetSignatures(updated)).toEqual({
         clients: {
           fooClient: {
             desiredQueryIDs: [],
@@ -5586,7 +5628,7 @@ describe('view-syncer/cvr', () => {
         now,
         ttlClock,
       );
-      expect(updated).toEqual({
+      expect(stripRowSetSignatures(updated)).toEqual({
         clients: {
           fooClient: {
             desiredQueryIDs: [],
@@ -6030,6 +6072,7 @@ describe('view-syncer/cvr', () => {
             "queryArgs": null,
             "queryHash": "oneHash",
             "queryName": null,
+            "rowSetSignature": null,
             "transformationHash": null,
             "transformationVersion": null,
           },

--- a/packages/zero-cache/src/services/view-syncer/schema/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/cvr.ts
@@ -114,6 +114,9 @@ export type QueriesRow = {
   transformationVersion: string | null;
   internal: boolean | null;
   deleted: boolean | null;
+  // Optional because (a) old DBs migrated to v17 will start with NULL, and
+  // (b) test fixtures predate this column.
+  rowSetSignature?: string | null;
 };
 
 function createQueriesTable(shard: ShardID) {
@@ -129,6 +132,7 @@ CREATE TABLE ${schema(shard)}.queries (
   "transformationVersion" TEXT,
   "internal"              BOOL,  -- If true, no need to track / send patches
   "deleted"               BOOL,  -- put vs del "got" query
+  "rowSetSignature"       TEXT,  -- Hex XOR of h64([schema,table,rowKey]) for rows in this query (drift detection for Cap)
 
   PRIMARY KEY ("clientGroupID", "queryHash"),
 

--- a/packages/zero-cache/src/services/view-syncer/schema/init.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/init.ts
@@ -213,6 +213,12 @@ export async function initViewSyncerSchema(
     },
   };
 
+  const migratedV16ToV17: Migration = {
+    migrateSchema: async (_, sql) => {
+      await sql`ALTER TABLE ${sql(schema)}.queries ADD COLUMN "rowSetSignature" TEXT`;
+    },
+  };
+
   const schemaVersionMigrationMap: IncrementalMigrationMap = {
     2: migrateV1toV2,
     3: migrateV2ToV3,
@@ -245,6 +251,10 @@ export async function initViewSyncerSchema(
     // V16 adds instances."profileID" and a corresponding index for estimating
     // active user counts more accurately for apps that use memstore.
     16: migratedV15ToV16,
+    // V17 adds queries."rowSetSignature" — XOR'd hash of row IDs attached to
+    // each query, used to detect drift on re-hydration of queries containing
+    // the Cap operator.
+    17: migratedV16ToV17,
   };
 
   await runSchemaMigrations(

--- a/packages/zero-cache/src/services/view-syncer/schema/types.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/types.ts
@@ -156,6 +156,21 @@ export const baseQueryRecordSchema = v.object({
    * queries with a newer `transformationVersion`.
    */
   transformationVersion: cvrVersionSchema.optional(),
+
+  /**
+   * Hex-encoded XOR signature over `h64(JSON.stringify([schema, table, rowKey]))`
+   * of every row currently attached to this query in the CVR (i.e. every row whose
+   * `refCounts[queryID] > 0`). Maintained incrementally as rows join/leave the query
+   * via {@link CVRQueryDrivenUpdater}.
+   *
+   * Used to detect drift on re-hydration of queries containing the `Cap` operator,
+   * which intentionally does not impose ordering and thus may pick a different N-row
+   * subset on re-execution. Comparing the pre-hydration signature with the post-
+   * hydration signature lets us force a `configVersion` bump so the standard CVR-diff
+   * machinery emits the reconciling poke. Absent or `'0'` means the signature is
+   * empty (no rows currently attached).
+   */
+  rowSetSignature: v.string().optional(),
 });
 
 /**
@@ -340,6 +355,7 @@ export function queryRecordToQueryRow(
         transformationVersion: maybeVersionString(query.transformationVersion),
         internal: true,
         deleted: false, // put vs del "got" query
+        rowSetSignature: query.rowSetSignature ?? null,
       };
     case 'client':
       return {
@@ -353,6 +369,7 @@ export function queryRecordToQueryRow(
         transformationVersion: maybeVersionString(query.transformationVersion),
         internal: null,
         deleted: false, // put vs del "got" query
+        rowSetSignature: query.rowSetSignature ?? null,
       };
     case 'custom':
       return {
@@ -366,6 +383,7 @@ export function queryRecordToQueryRow(
         transformationVersion: maybeVersionString(query.transformationVersion),
         internal: null,
         deleted: false, // put vs del "got" query
+        rowSetSignature: query.rowSetSignature ?? null,
       };
   }
 }


### PR DESCRIPTION
This is to support hashing queries and Cap. This will let us determine if a query ever hydrates to a different result at the same CVR version.

Adds a nullable `rowSetSignature` TEXT column to the CVR `queries` table (schema v16→v17) and threads it through the load and upsert/merge paths in CVRStore. `asQuery()` only attaches the field when non-null so existing QueryRecord snapshots without the field are unchanged. `#updateQueryFields` now merges partial updates instead of overwriting, so independent callers of the partial-update path don't clobber each other. No code populates the column yet — values stay null until the next commit.