### PR TITLE
chore(zero-cache): compute XOR signatures for queries

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           node-version: 24.x
           cache: 'npm'
-      - run: npx oxfmt --check
+      - run: npx oxfmt@^0.45.0 --check
 
   lint:
     name: Lint

--- a/packages/zero-cache/src/services/view-syncer/cvr.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.pg.test.ts
@@ -20,6 +20,7 @@ import {
   type CVRSnapshot,
   CVRUpdater,
 } from './cvr.ts';
+import {formatSignature} from './row-set-signature.ts';
 import {
   type ClientsRow,
   compareClientsRows,
@@ -5158,6 +5159,90 @@ describe('view-syncer/cvr', () => {
           },
         ],
       }),
+    );
+  });
+
+  test('flush persists rowSetSignature from signatureProvider', async () => {
+    const initialState: DBState = {
+      instances: [
+        {
+          clientGroupID: 'abc123',
+          version: '1aa',
+          replicaVersion: '120',
+          lastActive: Date.UTC(2024, 3, 23),
+          ttlClock: ttlClockFromNumber(Date.UTC(2024, 3, 23)),
+          clientSchema: null,
+        },
+      ],
+      clients: [{clientGroupID: 'abc123', clientID: 'fooClient'}],
+      queries: [
+        {
+          clientGroupID: 'abc123',
+          queryHash: 'oneHash',
+          clientAST: {table: 'issues'},
+          queryArgs: null,
+          queryName: null,
+          transformationHash: 'serverOneHash',
+          transformationVersion: '1aa',
+          patchVersion: '1aa:01',
+          internal: null,
+          deleted: null,
+        },
+      ],
+      desires: [
+        {
+          clientGroupID: 'abc123',
+          clientID: 'fooClient',
+          queryHash: 'oneHash',
+          patchVersion: '1a9:01',
+          deleted: null,
+          inactivatedAt: null,
+          ttl: DEFAULT_TTL_MS,
+        },
+      ],
+      rows: [],
+    };
+
+    await setInitialState(cvrDb, initialState);
+    const cvrStore = new CVRStore(
+      lc,
+      cvrDb,
+      SHARD,
+      'my-task',
+      'abc123',
+      ON_FAILURE,
+    );
+    const cvr = await cvrStore.load(lc, LAST_CONNECT);
+    const providedSig = 0xdeadbeefn;
+    const updater = new CVRQueryDrivenUpdater(
+      cvrStore,
+      cvr,
+      '1ba',
+      '120',
+      queryID => (queryID === 'oneHash' ? providedSig : undefined),
+    );
+    const {cvr: updated} = await updater.flush(
+      lc,
+      LAST_CONNECT,
+      Date.UTC(2024, 3, 23, 1),
+      ttlClockFromNumber(Date.UTC(2024, 3, 23, 1)),
+    );
+    expect(updated.queries.oneHash.rowSetSignature).toEqual(
+      formatSignature(providedSig),
+    );
+
+    // Reload and verify round trip.
+    const reloadStore = new CVRStore(
+      lc,
+      cvrDb,
+      SHARD,
+      'my-task',
+      'abc123',
+      ON_FAILURE,
+    );
+    const reloaded = await reloadStore.load(lc, LAST_CONNECT);
+    expect(reloaded.queries.oneHash.rowSetSignature).toEqual(
+      formatSignature(providedSig),
     );
   });
 

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -30,6 +30,7 @@ import {rowIDString} from '../../types/row-key.ts';
 import {upstreamSchema, type ShardID} from '../../types/shards.ts';
 import type {Patch, PatchToVersion} from './client-handler.ts';
 import {type CVRFlushStats, type CVRStore} from './cvr-store.ts';
+import {formatSignature, parseSignature} from './row-set-signature.ts';
 import {
   cmpVersions,
   maxVersion,
@@ -535,6 +536,14 @@ type RowPatchInfo = {
 };
 
 /**
+ * Callback used by {@link CVRQueryDrivenUpdater.flush} to retrieve the
+ * current row-set signature maintained by the pipeline driver for a given
+ * query. Returning `undefined` means "no pipeline for this query right now" —
+ * the stored signature on disk is left alone.
+ */
+export type RowSetSignatureProvider = (queryID: string) => bigint | undefined;
+
+/**
  * A {@link CVRQueryDrivenUpdater} is used for updating a CVR after making queries.
  * The caller should invoke:
  *
@@ -554,19 +563,26 @@ export class CVRQueryDrivenUpdater extends CVRUpdater {
     rowIDString,
   );
   readonly #lastPatches = new CustomKeyMap<RowID, RowPatchInfo>(rowIDString);
+  readonly #rowSetSignature: RowSetSignatureProvider | undefined;
 
   #existingRows: Promise<Iterable<RowRecord>> | undefined = undefined;
 
   /**
    * @param stateVersion The `stateVersion` at which the queries were executed.
+   * @param rowSetSignature Optional callback that returns the current row-set
+   *        signature for a query, typically backed by
+   *        `PipelineDriver.rowSetSignature`. When provided, {@link flush}
+   *        persists any signature deltas it observes.
    */
   constructor(
     cvrStore: CVRStore,
     cvr: CVRSnapshot,
     stateVersion: LexiVersion,
     replicaVersion: string,
+    rowSetSignature?: RowSetSignatureProvider,
   ) {
     super(cvrStore, cvr, replicaVersion);
+    this.#rowSetSignature = rowSetSignature;
 
     assert(
       // We should either be setting the cvr.replicaVersion for the first time, or it should
@@ -774,6 +790,34 @@ export class CVRQueryDrivenUpdater extends CVRUpdater {
     return this._cvr.version;
   }
 
+  override flush(
+    lc: LogContext,
+    lastConnectTime: number,
+    lastActive: number,
+    ttlClock: TTLClock,
+  ): Promise<{cvr: CVRSnapshot; flushed: CVRFlushStats | false}> {
+    if (this.#rowSetSignature) {
+      // Persist the per-query row-set signature for any query whose
+      // pipeline-driver signature differs from what's on disk. Queries
+      // without an active pipeline (provider returns undefined) keep their
+      // stored value.
+      for (const [queryID, query] of Object.entries(this._cvr.queries)) {
+        const sig = this.#rowSetSignature(queryID);
+        if (sig === undefined) {
+          continue;
+        }
+        const stored = parseSignature(query.rowSetSignature);
+        if (stored === sig) {
+          continue;
+        }
+        const hex = formatSignature(sig);
+        query.rowSetSignature = hex;
+        this._cvrStore.updateRowSetSignature(queryID, hex);
+      }
+    }
+    return super.flush(lc, lastConnectTime, lastActive, ttlClock);
+  }
+
   /**
    * Tracks rows received from executing queries. This will update row records
    * and row patches if the received rows have a new version. The method also
@@ -956,6 +1000,7 @@ export class CVRQueryDrivenUpdater extends CVRUpdater {
           undefined,
           this.#removedOrExecutedQueryIDs,
         );
+
         // If a row is still referenced, we update the refCounts but not the
         // patchVersion (as the existence and contents of the row have not
         // changed from the clients' perspective). If the row is deleted, it

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -10,6 +10,7 @@ import {
   string,
   table,
 } from '../../../../zero-schema/src/builder/table-builder.ts';
+import {ChangeType} from '../../../../zql/src/ivm/change-type.ts';
 import {
   CREATE_STORAGE_TABLE,
   DatabaseStorage,
@@ -19,6 +20,7 @@ import {Database} from '../../../../zqlite/src/db.ts';
 import {listTables} from '../../db/lite-tables.ts';
 import {InspectorDelegate} from '../../server/inspector-delegate.ts';
 import {DbFile} from '../../test/lite.ts';
+import type {RowKey} from '../../types/row-key.ts';
 import {upstreamSchema, type ShardID} from '../../types/shards.ts';
 import {populateFromExistingTables} from '../replicator/schema/column-metadata.ts';
 import {initReplicationState} from '../replicator/schema/replication-state.ts';
@@ -28,7 +30,9 @@ import {
   type FakeReplicator,
 } from '../replicator/test-utils.ts';
 import {getMutationResultsQuery} from './cvr.ts';
-import {PipelineDriver, type Timer} from './pipeline-driver.ts';
+import {PipelineDriver, type RowChange, type Timer} from './pipeline-driver.ts';
+import {rowIDSignatureUnit} from './row-set-signature.ts';
+import type {RowID} from './schema/types.ts';
 import {ResetPipelinesSignal, Snapshotter} from './snapshotter.ts';
 import {TimeSliceTimer} from './view-syncer.ts';
 
@@ -864,6 +868,185 @@ describe('view-syncer/pipeline-driver', () => {
         },
       ]
     `);
+  });
+
+  test('rowSetSignature reflects hydrate + advance deltas', () => {
+    const toID = (c: RowChange): RowID => ({
+      schema: '',
+      table: c.table,
+      rowKey: c.rowKey as RowKey,
+    });
+    const sigFromChanges = (changes: readonly RowChange[]) => {
+      let sig = 0n;
+      for (const c of changes) {
+        if (c.type === ChangeType.EDIT) continue;
+        sig ^= rowIDSignatureUnit(toID(c));
+      }
+      return sig;
+    };
+    const onlyRowChanges = (
+      xs: Iterable<RowChange | 'yield'>,
+    ): readonly RowChange[] =>
+      [...xs].filter((c): c is RowChange => c !== 'yield');
+
+    pipelines.init(clientSchema);
+    const hydrated = onlyRowChanges(
+      pipelines.addQuery(
+        'hash1',
+        'queryID1',
+        ISSUES_AND_COMMENTS,
+        startTimer(),
+      ),
+    );
+    expect(pipelines.rowSetSignature('queryID1')).toEqual(
+      sigFromChanges(hydrated),
+    );
+
+    // Delete issues/1 (cascades to comments/10) and insert a fresh issues/4.
+    replicator.processTransaction(
+      '134',
+      messages.delete('issues', {id: '1'}),
+      messages.insert('issues', {id: '4', closed: 0}),
+    );
+    const advanced = onlyRowChanges(changes());
+    expect(pipelines.rowSetSignature('queryID1')).toEqual(
+      sigFromChanges([...hydrated, ...advanced]),
+    );
+
+    // An update that doesn't touch relationship keys yields EDITs only;
+    // the signature must stay the same.
+    const sigBeforeEdit = pipelines.rowSetSignature('queryID1');
+    replicator.processTransaction(
+      '135',
+      messages.update('comments', {id: '22', issueID: '2', upvotes: 99}),
+    );
+    const afterEdit = onlyRowChanges(changes());
+    expect(afterEdit.length).toBeGreaterThan(0);
+    expect(afterEdit.every(c => c.type === ChangeType.EDIT)).toBe(true);
+    expect(pipelines.rowSetSignature('queryID1')).toEqual(sigBeforeEdit);
+
+    // removeQuery clears the entry.
+    pipelines.removeQuery('queryID1');
+    expect(pipelines.rowSetSignature('queryID1')).toBeUndefined();
+  });
+
+  test('rowSetSignature resets on re-execution (addQuery with same queryID)', () => {
+    const toID = (c: RowChange): RowID => ({
+      schema: '',
+      table: c.table,
+      rowKey: c.rowKey as RowKey,
+    });
+    const sigFromChanges = (changes: readonly RowChange[]) => {
+      let sig = 0n;
+      for (const c of changes) {
+        if (c.type === ChangeType.EDIT) continue;
+        sig ^= rowIDSignatureUnit(toID(c));
+      }
+      return sig;
+    };
+    const onlyRowChanges = (
+      xs: Iterable<RowChange | 'yield'>,
+    ): readonly RowChange[] =>
+      [...xs].filter((c): c is RowChange => c !== 'yield');
+
+    pipelines.init(clientSchema);
+
+    const firstChanges = onlyRowChanges(
+      pipelines.addQuery(
+        'hash1',
+        'queryID1',
+        ISSUES_AND_COMMENTS,
+        startTimer(),
+      ),
+    );
+    const firstSig = pipelines.rowSetSignature('queryID1');
+    expect(firstSig).toEqual(sigFromChanges(firstChanges));
+    expect(firstSig).not.toEqual(0n);
+
+    // Re-execute with a new transformation hash. addQuery internally calls
+    // removeQuery, which must reset the signature before hydration accumulates
+    // from 0. If it didn't, the second hydration's XORs would cancel the
+    // first's (same AST, same rows) and land at 0n.
+    const secondChanges = onlyRowChanges(
+      pipelines.addQuery(
+        'hash2',
+        'queryID1',
+        ISSUES_AND_COMMENTS,
+        startTimer(),
+      ),
+    );
+    expect(pipelines.rowSetSignature('queryID1')).toEqual(
+      sigFromChanges(secondChanges),
+    );
+    expect(pipelines.rowSetSignature('queryID1')).toEqual(firstSig);
+  });
+
+  test('rowSetSignature is maintained independently per query', () => {
+    const toID = (c: RowChange): RowID => ({
+      schema: '',
+      table: c.table,
+      rowKey: c.rowKey as RowKey,
+    });
+    const sigFromChanges = (changes: readonly RowChange[]) => {
+      let sig = 0n;
+      for (const c of changes) {
+        if (c.type === ChangeType.EDIT) continue;
+        sig ^= rowIDSignatureUnit(toID(c));
+      }
+      return sig;
+    };
+    const onlyRowChanges = (
+      xs: Iterable<RowChange | 'yield'>,
+    ): readonly RowChange[] =>
+      [...xs].filter((c): c is RowChange => c !== 'yield');
+
+    const ISSUES_ONLY: AST = {table: 'issues', orderBy: [['id', 'desc']]};
+
+    pipelines.init(clientSchema);
+
+    const commentedHydrated = onlyRowChanges(
+      pipelines.addQuery(
+        'hash-issues-comments',
+        'qIssuesComments',
+        ISSUES_AND_COMMENTS,
+        startTimer(),
+      ),
+    );
+    const issuesHydrated = onlyRowChanges(
+      pipelines.addQuery(
+        'hash-issues',
+        'qIssuesOnly',
+        ISSUES_ONLY,
+        startTimer(),
+      ),
+    );
+
+    expect(pipelines.rowSetSignature('qIssuesComments')).toEqual(
+      sigFromChanges(commentedHydrated),
+    );
+    expect(pipelines.rowSetSignature('qIssuesOnly')).toEqual(
+      sigFromChanges(issuesHydrated),
+    );
+
+    const issuesOnlySigBefore = pipelines.rowSetSignature('qIssuesOnly');
+
+    // Delete a comment: only qIssuesComments reads from the comments table,
+    // so only its signature should change. qIssuesOnly's pipeline never sees
+    // the event, so its signature is untouched.
+    replicator.processTransaction(
+      '134',
+      messages.delete('comments', {id: '22'}),
+    );
+    const advanced = onlyRowChanges(changes());
+    expect(advanced.length).toBeGreaterThan(0);
+    expect(advanced.every(c => c.queryID === 'qIssuesComments')).toBe(true);
+
+    expect(pipelines.rowSetSignature('qIssuesComments')).toEqual(
+      sigFromChanges([...commentedHydrated, ...advanced]),
+    );
+    expect(pipelines.rowSetSignature('qIssuesOnly')).toEqual(
+      issuesOnlySigBefore,
+    );
   });
 
   test('timeout on slow advancement', () => {

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -58,6 +58,7 @@ import {
   ZERO_VERSION_COLUMN_NAME,
 } from '../replicator/schema/replication-state.ts';
 import {checkClientSchema} from './client-schema.ts';
+import {rowIDSignatureUnit} from './row-set-signature.ts';
 import type {Snapshotter} from './snapshotter.ts';
 import {ResetPipelinesSignal, type SnapshotDiff} from './snapshotter.ts';
 
@@ -125,6 +126,15 @@ export class PipelineDriver {
   readonly #tables = new Map<string, TableSource>();
   // Query id to pipeline
   readonly #pipelines = new Map<string, Pipeline>();
+  /**
+   * XOR signature of the set of rows currently attached to each active
+   * query, maintained as RowChanges are yielded from {@link addQuery} and
+   * {@link advance}. ADDs / REMOVEs XOR the row's unit in (XOR is
+   * self-inverse, so one op serves both directions); EDITs are no-ops.
+   * Hydration implicitly reseeds from `0n` because {@link addQuery} calls
+   * {@link removeQuery} first, which deletes the entry.
+   */
+  readonly #rowSetSignatures = new Map<string, bigint>();
 
   readonly #lc: LogContext;
   readonly #snapshotter: Snapshotter;
@@ -214,6 +224,7 @@ export class PipelineDriver {
     this.#pipelines.clear();
     this.#tables.clear();
     this.#allTableNames.clear();
+    this.#rowSetSignatures.clear();
     this.#initAndResetCommon(clientSchema);
   }
 
@@ -394,7 +405,18 @@ export class PipelineDriver {
    *        when yielding the thread for time-slicing).
    * @return The rows from the initial hydration of the query.
    */
-  *addQuery(
+  addQuery(
+    transformationHash: string,
+    queryID: string,
+    query: AST,
+    timer: Timer,
+  ): Iterable<RowChange | 'yield'> {
+    return this.#trackRowSetSignatures(
+      this.#addQueryImpl(transformationHash, queryID, query, timer),
+    );
+  }
+
+  *#addQueryImpl(
     transformationHash: string,
     queryID: string,
     query: AST,
@@ -569,6 +591,39 @@ export class PipelineDriver {
         companion.input.destroy();
       }
     }
+    this.#rowSetSignatures.delete(queryID);
+  }
+
+  /**
+   * Current XOR signature of the row-set attached to `queryID`, or
+   * `undefined` if no pipeline for the query is currently active.
+   * Maintained incrementally by {@link addQuery} and {@link advance}.
+   */
+  rowSetSignature(queryID: string): bigint | undefined {
+    return this.#rowSetSignatures.get(queryID);
+  }
+
+  /**
+   * Wraps an iterable of RowChanges, XORing each row's unit hash into the
+   * query's signature (ADDs and REMOVEs share the same op; EDITs are no-ops).
+   * Used to intercept the yield streams from {@link addQuery} and
+   * {@link advance}.
+   */
+  *#trackRowSetSignatures(
+    changes: Iterable<RowChange | 'yield'>,
+  ): Iterable<RowChange | 'yield'> {
+    for (const change of changes) {
+      if (change !== 'yield' && change.type !== ChangeType.EDIT) {
+        const cur = this.#rowSetSignatures.get(change.queryID) ?? 0n;
+        const unit = rowIDSignatureUnit({
+          schema: '',
+          table: change.table,
+          rowKey: change.rowKey as RowKey,
+        });
+        this.#rowSetSignatures.set(change.queryID, cur ^ unit);
+      }
+      yield change;
+    }
   }
 
   /**
@@ -614,7 +669,7 @@ export class PipelineDriver {
     return {
       version: curr.version,
       numChanges: changes,
-      changes: this.#advance(diff, timer, changes),
+      changes: this.#trackRowSetSignatures(this.#advance(diff, timer, changes)),
     };
   }
 

--- a/packages/zero-cache/src/services/view-syncer/row-set-signature.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/row-set-signature.test.ts
@@ -1,0 +1,41 @@
+import {describe, expect, test} from 'vitest';
+import {
+  formatSignature,
+  parseSignature,
+  rowIDSignatureUnit,
+} from './row-set-signature.ts';
+import type {RowID} from './schema/types.ts';
+
+function rowID(table: string, id: string): RowID {
+  return {schema: 'public', table, rowKey: {id}};
+}
+
+describe('row-set-signature', () => {
+  test('formatSignature serializes bigints as hex', () => {
+    expect(formatSignature(0n)).toEqual('0');
+    expect(formatSignature(0xabcdn)).toEqual('abcd');
+  });
+
+  test('parseSignature round-trips via formatSignature', () => {
+    for (const v of [0n, 1n, 0xdeadbeefn, 0xffffffffffffffffn]) {
+      expect(parseSignature(formatSignature(v))).toEqual(v);
+    }
+  });
+
+  test('parseSignature treats null / undefined / empty as 0n', () => {
+    expect(parseSignature(null)).toEqual(0n);
+    expect(parseSignature(undefined)).toEqual(0n);
+    expect(parseSignature('')).toEqual(0n);
+  });
+
+  test('rowIDSignatureUnit is stable and distinct across rows', () => {
+    const a = rowIDSignatureUnit(rowID('issues', '1'));
+    const a2 = rowIDSignatureUnit(rowID('issues', '1'));
+    const b = rowIDSignatureUnit(rowID('issues', '2'));
+    const c = rowIDSignatureUnit(rowID('users', '1'));
+    expect(a).toEqual(a2);
+    expect(a).not.toEqual(b);
+    // Same rowKey in a different table must hash differently.
+    expect(a).not.toEqual(c);
+  });
+});

--- a/packages/zero-cache/src/services/view-syncer/row-set-signature.ts
+++ b/packages/zero-cache/src/services/view-syncer/row-set-signature.ts
@@ -1,0 +1,30 @@
+import {h64} from '../../../../shared/src/hash.ts';
+import {rowIDString} from '../../types/row-key.ts';
+import type {RowID} from './schema/types.ts';
+
+/**
+ * The hash of a row ID used as the unit XOR'd into a query's
+ * {@link rowSetSignature}. Includes schema + table + rowKey, so the hash is
+ * unique across tables in the same query.
+ */
+export function rowIDSignatureUnit(id: RowID): bigint {
+  return h64(rowIDString(id));
+}
+
+/**
+ * Parses a hex-encoded signature back to its bigint form. Empty / undefined
+ * is the identity (`0n`).
+ */
+export function parseSignature(hex: string | undefined | null): bigint {
+  if (!hex) {
+    return 0n;
+  }
+  return BigInt('0x' + hex);
+}
+
+/**
+ * Serializes a bigint signature to lowercase hex. `0n` serializes to `'0'`.
+ */
+export function formatSignature(sig: bigint): string {
+  return sig.toString(16);
+}

--- a/packages/zero-cache/src/services/view-syncer/schema/types.ts
+++ b/packages/zero-cache/src/services/view-syncer/schema/types.ts
@@ -159,9 +159,10 @@ export const baseQueryRecordSchema = v.object({
 
   /**
    * Hex-encoded XOR signature over `h64(JSON.stringify([schema, table, rowKey]))`
-   * of every row currently attached to this query in the CVR (i.e. every row whose
-   * `refCounts[queryID] > 0`). Maintained incrementally as rows join/leave the query
-   * via {@link CVRQueryDrivenUpdater}.
+   * of every row currently attached to this query. Maintained incrementally by
+   * `PipelineDriver` as ADDs / REMOVEs are yielded from the query's pipeline
+   * (EDITs no-op), and persisted via `CVRQueryDrivenUpdater.flush` by a
+   * signature-provider callback.
    *
    * Used to detect drift on re-hydration of queries containing the `Cap` operator,
    * which intentionally does not impose ordering and thus may pick a different N-row

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
@@ -41,6 +41,8 @@ import {CVRStore} from './cvr-store.ts';
 import {CVRQueryDrivenUpdater, CVRUpdater} from './cvr.ts';
 import type {DrainCoordinator} from './drain-coordinator.ts';
 import {PipelineDriver} from './pipeline-driver.ts';
+import {formatSignature, rowIDSignatureUnit} from './row-set-signature.ts';
+import type {RowID} from './schema/types.ts';
 import {ttlClockFromNumber} from './ttl-clock.ts';
 import {
   app2Messages,
@@ -2523,6 +2525,7 @@ describe('view-syncer/service', () => {
               "patchVersion": {
                 "stateVersion": "01",
               },
+              "rowSetSignature": "7b557aaf85ad1c06",
               "transformationHash": "hash-1",
               "transformationVersion": {
                 "stateVersion": "01",
@@ -2556,6 +2559,7 @@ describe('view-syncer/service', () => {
               "patchVersion": {
                 "stateVersion": "01",
               },
+              "rowSetSignature": "7b557aaf85ad1c06",
               "transformationHash": "hash-2",
               "transformationVersion": {
                 "stateVersion": "01",
@@ -4428,6 +4432,57 @@ describe('view-syncer/service', () => {
           },
         ]
       `);
+  });
+
+  test('rowSetSignature persisted by end-to-end hydrate and advance', async () => {
+    const issue = (id: string): RowID => ({
+      schema: '',
+      table: 'issues',
+      rowKey: {id},
+    });
+    const expectedSig = (...rows: RowID[]) =>
+      formatSignature(rows.reduce((s, r) => s ^ rowIDSignatureUnit(r), 0n));
+    const loadSig = async (hash: string) => {
+      const [{rowSetSignature}] = await cvrDB<
+        {rowSetSignature: string | null}[]
+      >`
+        SELECT "rowSetSignature" FROM ${cvrDB(cvrSchema(SHARD))}.queries
+         WHERE "clientGroupID" = ${serviceID} AND "queryHash" = ${hash}
+      `;
+      return rowSetSignature;
+    };
+
+    const client = connect(SYNC_CONTEXT, [
+      {op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY},
+    ]);
+    await nextPoke(client); // desiredQueriesPatch
+
+    stateChanges.push({state: 'version-ready'});
+    await nextPoke(client); // initial hydration — rows 1,2,3,4
+
+    expect(await loadSig('query-hash1')).toEqual(
+      expectedSig(issue('1'), issue('2'), issue('3'), issue('4')),
+    );
+
+    // Advance: delete issue 3 (leaves the query), update issue 4 (stays in the
+    // query, row-version bump only — must not change the signature).
+    replicator.processTransaction(
+      '123',
+      messages.delete('issues', {id: '3'}),
+      messages.update('issues', {
+        id: '4',
+        title: 'edited bar',
+        owner: 101,
+        parent: 2,
+        big: 100n,
+      }),
+    );
+    stateChanges.push({state: 'version-ready'});
+    await nextPoke(client);
+
+    expect(await loadSig('query-hash1')).toEqual(
+      expectedSig(issue('1'), issue('2'), issue('4')),
+    );
   });
 
   test('process advancement with lmid change, client has no queries.  See https://bugs.rocicorp.dev/issue/3628', async () => {

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -1862,6 +1862,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         cvr,
         stateVersion,
         this.#pipelines.replicaVersion,
+        queryID => this.#pipelines.rowSetSignature(queryID),
       );
 
       // Note: This kicks off background PG queries for CVR data associated with the
@@ -2191,6 +2192,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         cvr,
         version,
         this.#pipelines.replicaVersion,
+        queryID => this.#pipelines.rowSetSignature(queryID),
       );
       // Only poke clients that are at the cvr.version. New clients that
       // are behind need to first be caught up when their initConnection


### PR DESCRIPTION
Computes an XOR hash of a query result. This will catch if a query's results change between hydrations at the same CVR version which is a required feature for CAP. The reason is that `cap` does not order the source and row order can change between vacuums of the DB.

- https://github.com/rocicorp/mono/pull/5848