### PR TITLE
Fix hang creating replication slot

### DIFF
--- a/packages/analyze-query/src/bin-analyze.ts
+++ b/packages/analyze-query/src/bin-analyze.ts
@@ -301,6 +301,7 @@ async function runHash(hash: string) {
   const cvrDB = pgClient(
     lc,
     must(config.cvr.db, 'CVR DB must be provided when using the hash option'),
+    'analyze-query-hash-cvr',
   );
 
   const rows = await cvrDB`select "clientAST", "internal" from ${cvrDB(

--- a/packages/analyze-query/src/bin-transform.ts
+++ b/packages/analyze-query/src/bin-transform.ts
@@ -35,7 +35,7 @@ const config = parseOptions(options, {envNamePrefix: ZERO_ENV_VAR_PREFIX});
 const lc = new LogContext('debug', {}, consoleLogSink);
 const {permissions} = await loadSchemaAndPermissions(config.schema);
 
-const cvrDB = pgClient(lc, config.cvr.db);
+const cvrDB = pgClient(lc, config.cvr.db, 'analyze-query-transform-cvr');
 
 const rows =
   await cvrDB`select "clientAST", "internal" from ${cvrDB(upstreamSchema(getShardID(config)) + '/cvr')}."queries" where "queryHash" = ${must(

--- a/packages/zero-cache/src/db/initial-sync-bench.pg.test.ts
+++ b/packages/zero-cache/src/db/initial-sync-bench.pg.test.ts
@@ -33,7 +33,7 @@ describe.skipIf(!UPSTREAM_DB)('initial-sync-bench', () => {
       const lc = createSilentLogContext();
 
       // Count rows in all user tables for the report.
-      const sql = pgClient(lc, upstreamURI);
+      const sql = pgClient(lc, upstreamURI, 'initial-sync-bench');
       const tables = await sql<{table: string; rows: bigint}[]>`
         SELECT schemaname || '.' || relname AS table,
                n_live_tup AS rows

--- a/packages/zero-cache/src/scripts/decommission.ts
+++ b/packages/zero-cache/src/scripts/decommission.ts
@@ -43,7 +43,7 @@ export async function decommissionZero(
   lc.info?.(`Decommissioning app "${app.id}"`);
 
   if (cfg.upstream.type === 'pg') {
-    const upstream = pgClient(lc, cfg.upstream.db);
+    const upstream = pgClient(lc, cfg.upstream.db, 'decommission-upstream');
     await decommissionShard(lc, upstream, app.id, shard.num);
 
     lc.debug?.(`Cleaning up upstream metadata from ${hostPort(upstream)}`);
@@ -51,12 +51,16 @@ export async function decommissionZero(
     await upstream.end();
   }
 
-  const cvr = pgClient(lc, cfg.cvr.db ?? cfg.upstream.db);
+  const cvr = pgClient(lc, cfg.cvr.db ?? cfg.upstream.db, 'decommission-cvr');
   lc.debug?.(`Cleaning up cvc data from ${hostPort(cvr)}`);
   await cvr.unsafe(`DROP SCHEMA IF EXISTS ${id(cvrSchema(shardID))} CASCADE`);
   await cvr.end();
 
-  const cdc = pgClient(lc, cfg.change.db ?? cfg.upstream.db);
+  const cdc = pgClient(
+    lc,
+    cfg.change.db ?? cfg.upstream.db,
+    'decommission-cdc',
+  );
   lc.debug?.(`Cleaning up cdc data from ${hostPort(cdc)}`);
   await cdc.unsafe(`DROP SCHEMA IF EXISTS ${id(cdcSchema(shardID))} CASCADE`);
   await cdc.end();

--- a/packages/zero-cache/src/scripts/deploy-permissions.ts
+++ b/packages/zero-cache/src/scripts/deploy-permissions.ts
@@ -123,7 +123,7 @@ async function deployPermissions(
   permissions: PermissionsConfig,
   force: boolean,
 ) {
-  const db = pgClient(lc, upstreamURI);
+  const db = pgClient(lc, upstreamURI, 'deploy-permissions');
   const {host, port} = db.options;
   colorConsole.debug(`Connecting to upstream@${host}:${port}`);
   try {

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -15,10 +15,7 @@ import {initializeStreamer} from '../services/change-streamer/change-streamer-se
 import type {ChangeStreamerService} from '../services/change-streamer/change-streamer.ts';
 import {ReplicaMonitor} from '../services/change-streamer/replica-monitor.ts';
 import {initChangeStreamerSchema} from '../services/change-streamer/schema/init.ts';
-import {
-  AutoResetSignal,
-  CHANGE_STREAMER_APP_NAME,
-} from '../services/change-streamer/schema/tables.ts';
+import {AutoResetSignal} from '../services/change-streamer/schema/tables.ts';
 import {PurgeLocker} from '../services/change-streamer/storer.ts';
 import {exitAfter, runUntilKilled} from '../services/life-cycle.ts';
 import {
@@ -75,9 +72,9 @@ export default async function runWorker(
   const changeDB = pgClient(
     lc,
     change.db,
+    'change-streamer',
     {
       max: change.maxConns,
-      connection: {['application_name']: CHANGE_STREAMER_APP_NAME},
     },
     {sendStringAsJson: true},
   );

--- a/packages/zero-cache/src/server/reaper.ts
+++ b/packages/zero-cache/src/server/reaper.ts
@@ -32,9 +32,8 @@ export default async function runWorker(
 
   const {cvr} = config;
   const shard = getShardID(config);
-  const cvrDB = pgClient(lc, cvr.db, {
+  const cvrDB = pgClient(lc, cvr.db, `sync-cvr-purger`, {
     max: 1,
-    connection: {['application_name']: `zero-sync-cvr-purger`},
   });
   await initViewSyncerSchema(lc, cvrDB, shard);
   parent.send(['ready', {ready: true}]);

--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -88,18 +88,16 @@ export default function runWorker(
   const replicaFile = replicaFileName(config.replica.file, fileMode);
   lc.debug?.(`running view-syncer on ${replicaFile}`);
 
-  const cvrDB = pgClient(lc, cvr.db, {
+  const cvrDB = pgClient(lc, cvr.db, `sync-worker-${pid}-cvr`, {
     max: must(cvr.maxConnsPerWorker, 'cvr.maxConnsPerWorker must be set'),
-    connection: {['application_name']: `zero-sync-worker-${pid}-cvr`},
   });
 
   const upstreamDB = enableCrudMutations
-    ? pgClient(lc, upstream.db, {
+    ? pgClient(lc, upstream.db, `sync-worker-${pid}-upstream`, {
         max: must(
           upstream.maxConnsPerWorker,
           'upstream.maxConnsPerWorker must be set',
         ),
-        connection: {['application_name']: `zero-sync-worker-${pid}-upstream`},
       })
     : undefined;
 

--- a/packages/zero-cache/src/services/change-source/pg/backfill-stream.ts
+++ b/packages/zero-cache/src/services/change-source/pg/backfill-stream.ts
@@ -88,8 +88,7 @@ export async function* streamBackfill(
 
   const {flushThresholdBytes = POSTGRES_COPY_CHUNK_SIZE, textCopy = false} =
     opts;
-  const db = pgClient(lc, upstreamURI, {
-    connection: {['application_name']: 'backfill-stream'},
+  const db = pgClient(lc, upstreamURI, 'backfill-stream', {
     ['max_lifetime']: 120 * 60, // set a long (2h) limit for COPY streaming
   });
   let tx: TransactionPool | undefined;
@@ -291,10 +290,15 @@ async function createSnapshotTransaction(
   db: PostgresDB,
   slotNamePrefix: string,
 ) {
-  const replicationSession = pgClient(lc, upstreamURI, {
-    ['fetch_types']: false, // Necessary for the streaming protocol
-    connection: {replication: 'database'}, // https://www.postgresql.org/docs/current/protocol-replication.html
-  });
+  const replicationSession = pgClient(
+    lc,
+    upstreamURI,
+    'backfill-replication-session',
+    {
+      ['fetch_types']: false, // Necessary for the streaming protocol
+      connection: {replication: 'database'}, // https://www.postgresql.org/docs/current/protocol-replication.html
+    },
+  );
   const tempSlot = `${slotNamePrefix}_bf_${Date.now()}`;
   try {
     const {snapshot_name: snapshot, consistent_point: lsn} =

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -137,7 +137,7 @@ export async function initializePostgresChangeSource(
 
   // Check that upstream is properly setup, and throw an AutoReset to re-run
   // initial sync if not.
-  const db = pgClient(lc, upstreamURI);
+  const db = pgClient(lc, upstreamURI, 'change-source-init');
   try {
     const upstreamReplica = await checkAndUpdateUpstream(
       lc,
@@ -271,11 +271,10 @@ class PostgresChangeSource implements ChangeSource {
     textCopy?: boolean | undefined,
   ) {
     this.#lc = lc.withContext('component', 'change-source');
-    this.#db = pgClient(lc, upstreamUri, {
+    this.#db = pgClient(lc, upstreamUri, 'replication-monitor', {
       max: 1,
       // used occasionally for schema changes, periodically for lag reporting
       ['idle_timeout']: 60,
-      connection: {['application_name']: 'zero-replication-monitor'},
     });
     this.#upstreamUri = upstreamUri;
     this.#shard = shard;

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
@@ -2901,18 +2901,19 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
       const lc = createSilentLogContext();
       const upstreamURI = getConnectionURI(upstream);
       const timeoutSlot = `${APP_ID}_${SHARD_NUM}_${Date.now()}_timeout`;
-      const blocker = pgClient(lc, upstreamURI, {
+      const blocker = pgClient(lc, upstreamURI, 'slot-timeout-blocker', {
         max: 1,
-        connection: {['application_name']: 'slot-timeout-blocker'},
       });
-      const timeoutSession = pgClient(lc, upstreamURI, {
-        max: 1,
-        ['fetch_types']: false,
-        connection: {
-          replication: 'database',
-          ['application_name']: 'slot-timeout-under-test',
+      const timeoutSession = pgClient(
+        lc,
+        upstreamURI,
+        'slot-timeout-under-test',
+        {
+          max: 1,
+          ['fetch_types']: false,
+          connection: {replication: 'database'},
         },
-      });
+      );
 
       let blockerInTransaction = false;
       try {

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
@@ -25,9 +25,10 @@ import {
   initDB as initLiteDB,
 } from '../../../test/lite.ts';
 import {PG_17} from '../../../types/pg-versions.ts';
-import type {PostgresDB} from '../../../types/pg.ts';
+import {pgClient, type PostgresDB} from '../../../types/pg.ts';
 import {ZERO_VERSION_COLUMN_NAME} from '../../replicator/schema/replication-state.ts';
 import {
+  createReplicationSlot,
   initialSync,
   INSERT_BATCH_SIZE,
   shadowInitialSync,
@@ -2892,6 +2893,53 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
       'Error: The App ID may only consist of lower-case letters, numbers, and the underscore character',
     );
   });
+
+  test(
+    'createReplicationSlot times out behind an older idle transaction',
+    {timeout: 15_000},
+    async () => {
+      const lc = createSilentLogContext();
+      const upstreamURI = getConnectionURI(upstream);
+      const timeoutSlot = `${APP_ID}_${SHARD_NUM}_${Date.now()}_timeout`;
+      const blocker = pgClient(lc, upstreamURI, {
+        max: 1,
+        connection: {['application_name']: 'slot-timeout-blocker'},
+      });
+      const timeoutSession = pgClient(lc, upstreamURI, {
+        max: 1,
+        ['fetch_types']: false,
+        connection: {
+          replication: 'database',
+          ['application_name']: 'slot-timeout-under-test',
+        },
+      });
+
+      let blockerInTransaction = false;
+      try {
+        // Start a transaction in one session and leave it open.
+        await blocker`BEGIN`;
+        blockerInTransaction = true;
+        await blocker`SELECT txid_current()`;
+
+        // Create replication slot in different session.
+        await expect(
+          createReplicationSlot(lc, timeoutSession, timeoutSlot),
+        ).rejects.toThrow(
+          `Timed out after 5000 ms creating replication slot ${timeoutSlot}. Crashing to force a clean restart.`,
+        );
+      } finally {
+        if (blockerInTransaction) {
+          await blocker`ROLLBACK`;
+        }
+        await blocker.end();
+        await timeoutSession.end().catch(() => {});
+        await upstream`
+          SELECT pg_drop_replication_slot(slot_name)
+            FROM pg_replication_slots
+            WHERE slot_name = ${timeoutSlot} AND NOT active`;
+      }
+    },
+  );
 
   describe('shadow initial sync', () => {
     const SHADOW_SHARD = {

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
@@ -122,13 +122,13 @@ export async function initialSync(
     shadow,
   } = syncOptions;
   const copyProfiler = profileCopy ? await CpuProfiler.connect() : null;
-  const sql = pgClient(lc, upstreamURI);
+  const sql = pgClient(lc, upstreamURI, 'initial-sync');
   // Replication session is only needed to create a replication slot in the
   // real path. In shadow mode we export a snapshot on a normal connection
   // instead, so no replication session is opened.
   const replicationSession = shadow
     ? undefined
-    : pgClient(lc, upstreamURI, {
+    : pgClient(lc, upstreamURI, 'initial-sync-replication-session', {
         ['fetch_types']: false, // Necessary for the streaming protocol
         connection: {replication: 'database'}, // https://www.postgresql.org/docs/current/protocol-replication.html
       });
@@ -246,9 +246,8 @@ export async function initialSync(
         ? numTables
         : Math.min(tableCopyWorkers, numTables);
 
-    const copyPool = pgClient(lc, upstreamURI, {
+    const copyPool = pgClient(lc, upstreamURI, 'initial-sync-copy-worker', {
       max: numWorkers,
-      connection: {['application_name']: 'initial-sync-copy-worker'},
       ['max_lifetime']: 120 * 60, // set a long (2h) limit for COPY streaming
     });
     const copiers = startTableCopyWorkers(
@@ -552,9 +551,8 @@ async function acquireExportedSnapshotForShadowSync(
   lsn: string;
   release: () => Promise<void>;
 }> {
-  const holder = pgClient(lc, upstreamURI, {
+  const holder = pgClient(lc, upstreamURI, 'shadow-initial-sync-snapshot', {
     max: 1,
-    connection: {['application_name']: 'shadow-initial-sync-snapshot'},
   });
   const ready = resolver<{snapshot: string; lsn: string}>();
   const release = resolver<void>();

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
@@ -57,6 +57,7 @@ import {CpuProfiler} from '../../../types/profiler.ts';
 import type {ShardConfig} from '../../../types/shards.ts';
 import {ALLOWED_APP_ID_CHARACTERS} from '../../../types/shards.ts';
 import {id} from '../../../types/sql.ts';
+import {orTimeout} from '../../../types/timeout.ts';
 import {ReplicationStatusPublisher} from '../../replicator/replication-status.ts';
 import {ColumnMetadataStore} from '../../replicator/schema/column-metadata.ts';
 import {initReplicationState} from '../../replicator/schema/replication-state.ts';
@@ -529,6 +530,10 @@ type ReplicationSlot = {
   output_plugin: string;
 };
 
+// Successful CREATE_REPLICATION_SLOT calls have always completed within 1s in
+// observed production runs; use 5s as a hard stop for pathological hangs.
+const CREATE_REPLICATION_SLOT_TIMEOUT_MS = 5_000;
+
 /**
  * Shadow-mode alternative to `createReplicationSlot`: opens a dedicated
  * READ ONLY REPEATABLE READ transaction on a normal connection, exports the
@@ -604,13 +609,28 @@ export async function createReplicationSlot(
   // Note: must be false if pgVersion < PG_17. Caller must verify.
   failover = false,
 ): Promise<ReplicationSlot> {
-  const [slot] = failover
-    ? await session.unsafe<ReplicationSlot[]>(
+  const createSlot = failover
+    ? session.unsafe<ReplicationSlot[]>(
         /*sql*/ `CREATE_REPLICATION_SLOT "${slotName}" LOGICAL pgoutput (FAILOVER)`,
       )
-    : await session.unsafe<ReplicationSlot[]>(
+    : session.unsafe<ReplicationSlot[]>(
         /*sql*/ `CREATE_REPLICATION_SLOT "${slotName}" LOGICAL pgoutput`,
       );
+  const raced = await orTimeout(createSlot, CREATE_REPLICATION_SLOT_TIMEOUT_MS);
+  if (raced === 'timed-out') {
+    // Create slot can block indefinitely waiting for old transactions. End
+    // this connection in the background and fail fast so the process restarts.
+    void session
+      .end()
+      .catch(e =>
+        lc.warn?.(`Error closing timed out replication slot session`, e),
+      );
+    throw new Error(
+      `Timed out after ${CREATE_REPLICATION_SLOT_TIMEOUT_MS} ms creating replication slot ${slotName}. ` +
+        `Crashing to force a clean restart.`,
+    );
+  }
+  const [slot] = raced;
   lc.info?.(`Created replication slot ${slotName}`, slot);
   return slot;
 }

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
@@ -214,10 +214,9 @@ export class ChangeStreamerHttpClient implements ChangeStreamer {
     this.#shardID = shardID;
     // Create a pg client with a single short-lived connection for the purpose
     // of change-streamer discovery (i.e. ChangeDB as DNS).
-    this.#changeDB = pgClient(lc, changeDB, {
+    this.#changeDB = pgClient(lc, changeDB, 'change-streamer-discovery', {
       max: 1,
       ['idle_timeout']: 15,
-      connection: {['application_name']: 'change-streamer-discovery'},
     });
     this.#changeStreamerURI = changeStreamerURI;
   }

--- a/packages/zero-cache/src/services/statz.ts
+++ b/packages/zero-cache/src/services/statz.ts
@@ -15,7 +15,7 @@ import {getReplicationState} from './replicator/schema/replication-state.ts';
 
 async function upstreamStats(lc: LogContext, config: ZeroConfig) {
   const schema = upstreamSchema(getShardID(config));
-  const sql = pgClient(lc, config.upstream.db);
+  const sql = pgClient(lc, config.upstream.db, 'statz-upstream');
   try {
     return await getPgStats([
       [
@@ -38,7 +38,7 @@ async function upstreamStats(lc: LogContext, config: ZeroConfig) {
 
 async function cvrStats(lc: LogContext, config: ZeroConfig) {
   const schema = upstreamSchema(getShardID(config)) + '/cvr';
-  const sql = pgClient(lc, config.cvr.db);
+  const sql = pgClient(lc, config.cvr.db, 'statz-cvr');
 
   function numQueriesPerClientGroup(
     active: boolean,
@@ -204,7 +204,7 @@ async function cvrStats(lc: LogContext, config: ZeroConfig) {
 
 async function changeLogStats(lc: LogContext, config: ZeroConfig) {
   const schema = upstreamSchema(getShardID(config)) + '/cdc';
-  const sql = pgClient(lc, config.change.db);
+  const sql = pgClient(lc, config.change.db, 'statz-change');
 
   try {
     return await getPgStats([

--- a/packages/zero-cache/src/types/pg.ts
+++ b/packages/zero-cache/src/types/pg.ts
@@ -319,12 +319,17 @@ export type PostgresTransaction = postgres.TransactionSql<{
 export function pgClient(
   lc: LogContext,
   connectionURI: string,
+  // A descriptive name for the code that is making the connection, so that we
+  // can debug things like deadlocks.
+  applicationName: string,
   options?: postgres.Options<{
     bigint: PostgresType<bigint>;
     json: PostgresType<JSONValue>;
   }>,
   opts?: TypeOptions,
 ): PostgresDB {
+  applicationName = `zero-${applicationName}`;
+
   const onnotice = (n: Notice) => {
     // https://www.postgresql.org/docs/current/plpgsql-errors-and-messages.html#PLPGSQL-STATEMENTS-RAISE
     switch (n.severity) {
@@ -360,6 +365,7 @@ export function pgClient(
 
   // Set connections to expire between 5 and 10 minutes to free up state on PG.
   const maxLifetimeSeconds = randInt(5 * 60, 10 * 60);
+  const providedConnection = options?.connection ?? {};
 
   return postgres(connectionURI, {
     ...postgresTypeConfig(opts),
@@ -367,6 +373,10 @@ export function pgClient(
     ['max_lifetime']: maxLifetimeSeconds,
     ssl,
     ...options,
+    connection: {
+      ...providedConnection,
+      ['application_name']: applicationName,
+    },
   });
 }
 

--- a/packages/zero-server/src/adapters/postgresjs.ts
+++ b/packages/zero-server/src/adapters/postgresjs.ts
@@ -112,7 +112,9 @@ export function zeroPostgresJS<
   T extends Record<string, unknown> = Record<string, unknown>,
 >(schema: S, pg: postgres.Sql<T> | string) {
   if (typeof pg === 'string') {
-    pg = postgres(pg) as postgres.Sql<T>;
+    pg = postgres(pg, {
+      connection: {['application_name']: 'zero-server'},
+    }) as postgres.Sql<T>;
   }
   return new ZQLDatabase(new PostgresJSConnection(pg), schema);
 }


### PR DESCRIPTION
We saw two instances of zero-cache refusing to startup due to hang creating a replication slot. This was caused by an idle transaction hanging open.

"Fixed" immediate issue by adding a timeout to this statement. This will cause zero-cache to restart, but if the offending process is not zero-cache this won't help.

Also required all pg connections to be named so that if the offending transaction is part of zero cache we'll be able to identify it next time.