### PR TITLE
 chore(zero-cache): detect row-set signature drift and re-execute drifted queries

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -790,6 +790,15 @@ export class CVRQueryDrivenUpdater extends CVRUpdater {
     return this._cvr.version;
   }
 
+  /**
+   * Public alias for {@link _ensureNewVersion}. Forces a `configVersion` bump
+   * when the caller needs a new CVR version for reasons outside the built-in
+   * tracking (e.g. rowSetSignature drift re-execution).
+   */
+  ensureNewVersion(): CVRVersion {
+    return this._ensureNewVersion();
+  }
+
   override flush(
     lc: LogContext,
     lastConnectTime: number,

--- a/packages/zero-cache/src/services/view-syncer/view-syncer-test-util.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer-test-util.ts
@@ -41,6 +41,7 @@ import {CustomQueryTransformer} from '../../custom-queries/transform-query.ts';
 import {InspectorDelegate} from '../../server/inspector-delegate.ts';
 import type {TestDBs} from '../../test/db.ts';
 import {DbFile} from '../../test/lite.ts';
+import type {PostgresDB} from '../../types/pg.ts';
 import {upstreamSchema} from '../../types/shards.ts';
 import {id} from '../../types/sql.ts';
 import type {Source} from '../../types/streams.ts';
@@ -750,9 +751,8 @@ export async function setup(
   const replicator = fakeReplicator(lc, replica);
   const stateChanges: Subscription<ReplicaState> = Subscription.create();
   const drainCoordinator = new DrainCoordinator();
-  const operatorStorage = new DatabaseStorage(
-    storageDB,
-  ).createClientGroupStorage(serviceID);
+  const databaseStorage = new DatabaseStorage(storageDB);
+  const operatorStorage = databaseStorage.createClientGroupStorage(serviceID);
 
   const config = {
     auth: {...authConfig},
@@ -917,7 +917,149 @@ export async function setup(
       queryFetch.reset();
       restoreFetch();
     },
+    config,
+    databaseStorage,
   };
+}
+
+/**
+ * Builds a fresh {@link ViewSyncerService} against resources produced by
+ * {@link setup}. Intended for tests that need to simulate a process restart —
+ * the original `vs` must have been `stop()`ed (destroys pipelines / operator
+ * storage / snapshotter) before calling this. The returned instance shares
+ * `storageDB`, `replicaDbFile`, `cvrDB`, and `customQueryTransformer` with the
+ * original but gets its own pipelines, snapshotter, operator storage,
+ * state-change subscription, drain coordinator, and connection-context
+ * manager.
+ */
+export function restartViewSyncer(params: {
+  databaseStorage: DatabaseStorage;
+  replicaDbFile: DbFile;
+  cvrDB: PostgresDB;
+  config: NormalizedZeroConfig;
+  customQueryTransformer: CustomQueryTransformer | undefined;
+  setTimeoutFn: Awaited<ReturnType<typeof setup>>['setTimeoutFn'];
+}) {
+  const {
+    databaseStorage,
+    replicaDbFile,
+    cvrDB,
+    config,
+    customQueryTransformer,
+    setTimeoutFn,
+  } = params;
+  const lc = createSilentLogContext();
+
+  const stateChanges: Subscription<ReplicaState> = Subscription.create();
+  const drainCoordinator = new DrainCoordinator();
+  const operatorStorage = databaseStorage.createClientGroupStorage(serviceID);
+  const inspectorDelegate = new InspectorDelegate(customQueryTransformer);
+
+  const {query} = config;
+  const contextManager = new ConnectionContextManagerImpl(
+    lc,
+    config.auth.revalidateIntervalSeconds,
+    config.auth.retransformIntervalSeconds,
+    {
+      url: query.url,
+      apiKey: query.apiKey,
+      allowedClientHeaders: query.allowedClientHeaders,
+      forwardCookies: query.forwardCookies,
+    },
+    {
+      url: config.push?.url ?? config.mutate?.url,
+      apiKey: config.push?.apiKey ?? config.mutate?.apiKey,
+      allowedClientHeaders:
+        config.push?.allowedClientHeaders ??
+        config.mutate?.allowedClientHeaders,
+      forwardCookies:
+        config.push?.forwardCookies ?? config.mutate?.forwardCookies ?? false,
+    },
+  );
+
+  const vs = new ViewSyncerService(
+    config,
+    lc,
+    SHARD,
+    TASK_ID,
+    serviceID,
+    cvrDB,
+    new PipelineDriver(
+      lc.withContext('component', 'pipeline-driver'),
+      testLogConfig,
+      new Snapshotter(lc, replicaDbFile.path, SHARD),
+      SHARD,
+      operatorStorage,
+      'view-syncer-restart',
+      inspectorDelegate,
+      () => YIELD_THRESHOLD_MS,
+    ),
+    stateChanges,
+    drainCoordinator,
+    100,
+    inspectorDelegate,
+    contextManager,
+    customQueryTransformer,
+    (_lc, _description, op) => op(),
+    undefined,
+    setTimeoutFn,
+  );
+  const viewSyncerDone = vs.run();
+
+  function connect(
+    ctx: SyncContext,
+    desiredQueriesPatch: UpQueriesPatch,
+    clientSchema: ClientSchema | null = defaultClientSchema,
+    activeClients?: string[],
+  ): Queue<Downstream> {
+    const selector = {clientID: ctx.clientID, wsID: ctx.wsID};
+    vs.contextManager.registerConnection(
+      selector,
+      {
+        protocolVersion: ctx.protocolVersion,
+        clientID: ctx.clientID,
+        clientGroupID: serviceID,
+        profileID: ctx.profileID,
+        baseCookie: ctx.baseCookie,
+        timestamp: Date.now(),
+        lmID: 0,
+        wsID: ctx.wsID,
+        debugPerf: false,
+        auth: ctx.auth?.raw,
+        userID: ctx.userID,
+        initConnectionMsg: undefined,
+        httpCookie: ctx.httpCookie,
+        origin: ctx.origin,
+      },
+      ctx.auth,
+    );
+    vs.contextManager.initConnection(selector, {
+      desiredQueriesPatch,
+      clientSchema: clientSchema ?? undefined,
+      activeClients,
+    });
+    const source = vs.initConnection(selector, [
+      'initConnection',
+      {
+        desiredQueriesPatch,
+        clientSchema: clientSchema ?? undefined,
+        activeClients,
+      },
+    ]);
+    const queue = new Queue<Downstream>();
+    void (async function () {
+      try {
+        for await (const msg of source) {
+          queue.enqueue(msg);
+        }
+      } catch (e) {
+        queue.enqueueRejection(e);
+      }
+    })();
+    return queue;
+  }
+
+  return {vs, stateChanges, viewSyncerDone, drainCoordinator, connect};
 }
 
 /**

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
@@ -4955,6 +4955,153 @@ describe('view-syncer/service', () => {
     }
   });
 
+  test('rowSetSignature: emptied-by-advance query rehydrates to "0" without drift', async () => {
+    // Phase 1: hydrate non-empty. Signature is sig(1) ^ sig(2).
+    pruneIssues('3', '4', '5');
+    const client1 = connect(SYNC_CONTEXT, [
+      {op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY2},
+    ]);
+    await nextPoke(client1);
+    stateChanges.push({state: 'version-ready'});
+    await nextPoke(client1);
+    expect(await loadStoredSig('query-hash1')).toEqual(
+      expectedIssuesSig(issueRowID('1'), issueRowID('2')),
+    );
+
+    // Advance: delete both rows via the replicator. #trackRowSetSignatures
+    // XORs each REMOVE with the same unit the ADD contributed, so the live
+    // signature returns to 0n and the CVR persists hex "0".
+    replicator.processTransaction(
+      '123',
+      messages.delete('issues', {id: '1'}),
+      messages.delete('issues', {id: '2'}),
+    );
+    stateChanges.push({state: 'version-ready'});
+    const phase1Cookie = cookieOf(await nextPoke(client1));
+    expect(await loadStoredSig('query-hash1')).toEqual('0');
+
+    // Phase 2: restart. Rehydration yields 0 rows → the map entry is never
+    // created → provider returns undefined → candidate = undefined ?? 0n = 0n.
+    // Stored "0" parses to 0n. Match: no drift, no re-execution.
+    const {
+      queue,
+      stateChanges: rsc,
+      cleanup,
+    } = await restartAfter({
+      baseCookie: phase1Cookie,
+      mutate: () => {},
+      queriesPatch: [{op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY2}],
+    });
+    const removeSpy = vi.spyOn(PipelineDriver.prototype, 'removeQuery');
+    try {
+      rsc.push({state: 'version-ready'});
+
+      expect(await drainUntilRowsPatchOrQuiet(queue)).toBeUndefined();
+      expect(await loadStoredSig('query-hash1')).toEqual('0');
+
+      // Single call = internal removeQuery from the one addQuery in
+      // hydrateUnchangedQueries. Drift would be 3.
+      const calls = removeSpy.mock.calls.filter(
+        ([id]) => id === 'query-hash1',
+      ).length;
+      expect(calls).toBe(1);
+    } finally {
+      removeSpy.mockRestore();
+      await cleanup();
+    }
+  });
+
+  test('rowSetSignature: transformationHash change bypasses the drift check', async () => {
+    // Direct-mock the transformer so we can drive the transformationHash
+    // explicitly (the real transformer caches by query id for 5s, which would
+    // re-serve phase 1's hash in phase 2).
+    pruneIssues('3', '4', '5');
+    const transformSpy = vi
+      .spyOn(customQueryTransformer!, 'transform')
+      .mockResolvedValue(
+        transformAttempt([
+          {
+            id: 'custom-1',
+            transformedAst: ISSUES_QUERY2,
+            transformationHash: 'hash-1',
+          },
+        ]),
+      );
+
+    // Phase 1: hydrate with hash-1. CVR persists transformationHash=hash-1 and
+    // the row-set signature for issues {1, 2}.
+    const client1 = connect(SYNC_CONTEXT, [
+      {op: 'put', hash: 'custom-1', name: 'named-query', args: ['thing']},
+    ]);
+    await nextPoke(client1);
+    stateChanges.push({state: 'version-ready'});
+    const phase1Cookie = cookieOf(await nextPoke(client1));
+    expect(await loadStoredSig('custom-1')).toEqual(
+      expectedIssuesSig(issueRowID('1'), issueRowID('2')),
+    );
+
+    // Tamper the stored sig: if drift *were* checked in phase 2, a bogus
+    // stored value would force a drift re-execution. The hash-mismatch filter
+    // in #hydrateUnchangedQueries must drop this query before the drift
+    // comparison is reached.
+    const BOGUS_SIG = 'deadbeefcafebabe';
+
+    // Phase 2: restart. Transformer now returns hash-2 (different from the
+    // CVR's stored hash-1). In hydrateUnchangedQueries, the custom-query
+    // branch filters the mismatched entry out before any addQuery / drift
+    // check runs. #syncQueryPipelineSet then re-hydrates fresh.
+    const {
+      queue,
+      stateChanges: rsc,
+      cleanup,
+    } = await restartAfter({
+      baseCookie: phase1Cookie,
+      mutate: async () => {
+        await cvrDB`
+          UPDATE ${cvrDB(cvrSchema(SHARD))}.queries
+             SET "rowSetSignature" = ${BOGUS_SIG}
+           WHERE "clientGroupID" = ${serviceID}
+             AND "queryHash" = 'custom-1'
+        `;
+      },
+      queriesPatch: [
+        {op: 'put', hash: 'custom-1', name: 'named-query', args: ['thing']},
+      ],
+    });
+    transformSpy.mockResolvedValue(
+      transformAttempt([
+        {
+          id: 'custom-1',
+          transformedAst: ISSUES_QUERY2,
+          transformationHash: 'hash-2',
+        },
+      ]),
+    );
+    const removeSpy = vi.spyOn(PipelineDriver.prototype, 'removeQuery');
+    try {
+      rsc.push({state: 'version-ready'});
+      await drainUntilRowsPatchOrQuiet(queue);
+
+      // Transformation-hash-change path: query is dropped from
+      // hydrateUnchangedQueries at the hash-mismatch filter (no addQuery, no
+      // drift check). #syncQueryPipelineSet then hydrates fresh; its single
+      // addQuery fires one internal removeQuery. Total: 1.
+      // The drift path for this same query would produce 3 calls.
+      const calls = removeSpy.mock.calls.filter(
+        ([id]) => id === 'custom-1',
+      ).length;
+      expect(calls).toBe(1);
+
+      // Sig is overwritten by the fresh hydration (no longer BOGUS).
+      expect(await loadStoredSig('custom-1')).toEqual(
+        expectedIssuesSig(issueRowID('1'), issueRowID('2')),
+      );
+    } finally {
+      removeSpy.mockRestore();
+      await cleanup();
+    }
+  });
+
   test('process advancement with lmid change, client has no queries.  See https://bugs.rocicorp.dev/issue/3628', async () => {
     const client = connect(SYNC_CONTEXT, []);
     expect(await nextPoke(client)).toMatchInlineSnapshot(`

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
@@ -4756,6 +4756,7 @@ describe('view-syncer/service', () => {
       mutate: () => {},
       queriesPatch: [{op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY2}],
     });
+    const removeSpy = vi.spyOn(PipelineDriver.prototype, 'removeQuery');
     try {
       rsc.push({state: 'version-ready'});
 
@@ -4765,7 +4766,16 @@ describe('view-syncer/service', () => {
       // Sig unchanged (re-execution via CVRQueryDrivenUpdater never ran,
       // which is the only path that would flush a new sig here).
       expect(await loadStoredSig('query-hash1')).toEqual(expectedSig);
+
+      // addQuery internally calls removeQuery(queryID); so a single hydration
+      // in hydrateUnchangedQueries produces exactly one call. Drift would add
+      // an explicit removeQuery plus a second hydration (3 total).
+      const callsForHash1 = removeSpy.mock.calls.filter(
+        ([id]) => id === 'query-hash1',
+      ).length;
+      expect(callsForHash1).toBe(1);
     } finally {
+      removeSpy.mockRestore();
       await cleanup();
     }
   });
@@ -4804,6 +4814,7 @@ describe('view-syncer/service', () => {
         {op: 'put', hash: 'query-hash-B', ast: USERS_QUERY},
       ],
     });
+    const removeSpy = vi.spyOn(PipelineDriver.prototype, 'removeQuery');
     try {
       rsc.push({state: 'version-ready'});
       const rowsPoke = await drainUntilRowsPatchOrQuiet(queue);
@@ -4825,7 +4836,16 @@ describe('view-syncer/service', () => {
         expectedIssuesSig(issueRowID('2'), issueRowID('6')),
       );
       expect(await loadStoredSig('query-hash-B')).toEqual(initialSigB);
+
+      // A was re-executed (drift): addQuery-internal + explicit drift-branch
+      // removeQuery + second hydration's internal = 3 calls.
+      // B was kept (no drift): just the single hydrateUnchangedQueries call = 1.
+      const callsFor = (id: string) =>
+        removeSpy.mock.calls.filter(([q]) => q === id).length;
+      expect(callsFor('query-hash-A')).toBe(3);
+      expect(callsFor('query-hash-B')).toBe(1);
     } finally {
+      removeSpy.mockRestore();
       await cleanup();
     }
   });

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
@@ -63,6 +63,7 @@ import {
   permissionsAll,
   type QueryFetchMock,
   REPLICA_VERSION,
+  restartViewSyncer,
   serviceID,
   setup,
   SHARD,
@@ -115,6 +116,8 @@ describe('view-syncer/service', () => {
   let customQueryTransformer: CustomQueryTransformer | undefined;
   let clearMocks: () => void;
   let queryFetch: QueryFetchMock;
+  let config: Awaited<ReturnType<typeof setup>>['config'];
+  let databaseStorage: Awaited<ReturnType<typeof setup>>['databaseStorage'];
 
   function callNextSetTimeout(delta: number) {
     // Sanity check that the system time is the mocked time.
@@ -156,6 +159,8 @@ describe('view-syncer/service', () => {
       customQueryTransformer,
       queryFetch,
       clearMocks,
+      config,
+      databaseStorage,
     } = await setup(testDBs, 'view_syncer_service_test', permissionsAll, {
       queryFetchMode: 'empty-validation',
     }));
@@ -4434,24 +4439,22 @@ describe('view-syncer/service', () => {
       `);
   });
 
-  test('rowSetSignature persisted by end-to-end hydrate and advance', async () => {
-    const issue = (id: string): RowID => ({
-      schema: '',
-      table: 'issues',
-      rowKey: {id},
-    });
-    const expectedSig = (...rows: RowID[]) =>
-      formatSignature(rows.reduce((s, r) => s ^ rowIDSignatureUnit(r), 0n));
-    const loadSig = async (hash: string) => {
-      const [{rowSetSignature}] = await cvrDB<
-        {rowSetSignature: string | null}[]
-      >`
-        SELECT "rowSetSignature" FROM ${cvrDB(cvrSchema(SHARD))}.queries
-         WHERE "clientGroupID" = ${serviceID} AND "queryHash" = ${hash}
-      `;
-      return rowSetSignature;
-    };
+  const issueRowID = (id: string): RowID => ({
+    schema: '',
+    table: 'issues',
+    rowKey: {id},
+  });
+  const expectedIssuesSig = (...rows: RowID[]) =>
+    formatSignature(rows.reduce((s, r) => s ^ rowIDSignatureUnit(r), 0n));
+  const loadStoredSig = async (hash: string) => {
+    const [row] = await cvrDB<{rowSetSignature: string | null}[]>`
+      SELECT "rowSetSignature" FROM ${cvrDB(cvrSchema(SHARD))}.queries
+       WHERE "clientGroupID" = ${serviceID} AND "queryHash" = ${hash}
+    `;
+    return row?.rowSetSignature ?? null;
+  };
 
+  test('rowSetSignature persisted by end-to-end hydrate and advance', async () => {
     const client = connect(SYNC_CONTEXT, [
       {op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY},
     ]);
@@ -4460,8 +4463,13 @@ describe('view-syncer/service', () => {
     stateChanges.push({state: 'version-ready'});
     await nextPoke(client); // initial hydration — rows 1,2,3,4
 
-    expect(await loadSig('query-hash1')).toEqual(
-      expectedSig(issue('1'), issue('2'), issue('3'), issue('4')),
+    expect(await loadStoredSig('query-hash1')).toEqual(
+      expectedIssuesSig(
+        issueRowID('1'),
+        issueRowID('2'),
+        issueRowID('3'),
+        issueRowID('4'),
+      ),
     );
 
     // Advance: delete issue 3 (leaves the query), update issue 4 (stays in the
@@ -4480,9 +4488,79 @@ describe('view-syncer/service', () => {
     stateChanges.push({state: 'version-ready'});
     await nextPoke(client);
 
-    expect(await loadSig('query-hash1')).toEqual(
-      expectedSig(issue('1'), issue('2'), issue('4')),
+    expect(await loadStoredSig('query-hash1')).toEqual(
+      expectedIssuesSig(issueRowID('1'), issueRowID('2'), issueRowID('4')),
     );
+  });
+
+  test('rowSetSignature drift on rehydration triggers re-execution and CVR correction', async () => {
+    // Phase 1: initial hydration via the current VS. CVR persists the
+    // authoritative signature for query-hash1.
+    const client = connect(SYNC_CONTEXT, [
+      {op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY},
+    ]);
+    await nextPoke(client); // desiredQueriesPatch
+    stateChanges.push({state: 'version-ready'});
+    await nextPoke(client); // initial hydration
+
+    const correctSig = expectedIssuesSig(
+      issueRowID('1'),
+      issueRowID('2'),
+      issueRowID('3'),
+      issueRowID('4'),
+    );
+    expect(await loadStoredSig('query-hash1')).toEqual(correctSig);
+
+    // Phase 2: stop the VS, then tamper with the stored signature to simulate
+    // what the CVR would hold if a prior non-deterministic hydration (e.g. the
+    // Cap operator picking a different N-row subset) had produced a different
+    // row-set at this same stateVersion.
+    await vs.stop();
+    await viewSyncerDone;
+
+    const BOGUS_SIG = 'deadbeefcafebabe';
+    await cvrDB`
+      UPDATE ${cvrDB(cvrSchema(SHARD))}.queries
+         SET "rowSetSignature" = ${BOGUS_SIG}
+       WHERE "clientGroupID" = ${serviceID}
+         AND "queryHash" = 'query-hash1'
+    `;
+    expect(await loadStoredSig('query-hash1')).toEqual(BOGUS_SIG);
+
+    // Phase 3: fresh VS against the same cvrDB / replicaDbFile. A client
+    // connects to keep the service alive through the reset path so that
+    // #hydrateUnchangedQueries runs and detects the drift between the
+    // (bogus) stored signature and the freshly-computed driver signature.
+    const restart = restartViewSyncer({
+      databaseStorage,
+      replicaDbFile,
+      cvrDB,
+      config,
+      customQueryTransformer,
+      setTimeoutFn,
+    });
+    try {
+      // A connected client prevents the run loop from shutting down when it
+      // sees no clients. Reuse SYNC_CONTEXT with a new wsID to avoid
+      // "connection replaced" log noise.
+      restart.connect({...SYNC_CONTEXT, wsID: 'ws2'}, [
+        {op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY},
+      ]);
+      restart.stateChanges.push({state: 'version-ready'});
+
+      // The CVRQueryDrivenUpdater flush writes the corrected signature
+      // asynchronously. Poll until it matches what the driver would produce.
+      const deadline = Date.now() + 10_000;
+      let finalSig = await loadStoredSig('query-hash1');
+      while (finalSig !== correctSig && Date.now() < deadline) {
+        await sleep(20);
+        finalSig = await loadStoredSig('query-hash1');
+      }
+      expect(finalSig).toEqual(correctSig);
+    } finally {
+      await restart.vs.stop();
+      await restart.viewSyncerDone;
+    }
   });
 
   test('process advancement with lmid change, client has no queries.  See https://bugs.rocicorp.dev/issue/3628', async () => {

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
@@ -4454,6 +4454,138 @@ describe('view-syncer/service', () => {
     return row?.rowSetSignature ?? null;
   };
 
+  // ---- drift-test helpers ----
+
+  // Direct-SQL row mutations bypass the replicator so the replica stateVersion
+  // stays put — simulating how a non-deterministic operator (e.g. Cap) would
+  // produce a different row set on re-execution at the same stateVersion.
+  const pruneIssues = (...ids: readonly string[]) => {
+    if (ids.length === 0) return;
+    const placeholders = ids.map(() => '?').join(', ');
+    replica
+      .prepare(`DELETE FROM issues WHERE id IN (${placeholders})`)
+      .run(...ids);
+  };
+  const deleteIssue = (id: string) => {
+    replica.prepare(`DELETE FROM issues WHERE id = ?`).run(id);
+  };
+  const insertIssue = (
+    id: string,
+    opts: {
+      title?: string | undefined;
+      owner?: string | undefined;
+      version?: string | undefined;
+    } = {},
+  ) => {
+    replica
+      .prepare(
+        `INSERT INTO issues (id, title, owner, parent, big, _0_version)
+           VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        id,
+        opts.title ?? `issue ${id}`,
+        opts.owner ?? '100',
+        null,
+        0,
+        opts.version ?? '01',
+      );
+  };
+
+  const cookieOf = (poke: Downstream[]): string | null => {
+    const end = poke.find(([c]) => c === 'pokeEnd') as
+      | [string, PokeEndBody]
+      | undefined;
+    return end?.[1].cookie ?? null;
+  };
+
+  // Drains pokes from `queue` until one carrying a non-empty rowsPatch is
+  // received. Returns `undefined` if the queue stays quiet for `quietMs` ms
+  // before producing such a poke — which is the expected signal for the
+  // no-drift and legacy-null-sig cases (the run loop never forces a re-execute,
+  // so no row-diff poke is ever emitted).
+  async function drainUntilRowsPatchOrQuiet(
+    queue: Queue<Downstream>,
+    quietMs = 250,
+  ): Promise<Downstream[] | undefined> {
+    const sentinel = Symbol('quiet') as unknown as Downstream;
+    let current: Downstream[] = [];
+    for (;;) {
+      const msg = await queue.dequeue(sentinel, quietMs);
+      if (msg === sentinel) return undefined;
+      current.push(msg);
+      if (msg[0] === 'pokeEnd') {
+        const part = current.find(([c]) => c === 'pokePart') as
+          | [string, PokePartBody]
+          | undefined;
+        if (part?.[1].rowsPatch?.length) {
+          return current;
+        }
+        current = [];
+      }
+    }
+  }
+
+  function rowOpsFor(poke: Downstream[], tableName: string) {
+    const part = poke.find(([c]) => c === 'pokePart') as
+      | [string, PokePartBody]
+      | undefined;
+    const rowsPatch = part?.[1].rowsPatch ?? [];
+    const puts = rowsPatch.filter(
+      (p): p is {op: 'put'; tableName: string; value: {id: string}} =>
+        p.op === 'put' && p.tableName === tableName,
+    );
+    const dels = rowsPatch.filter(
+      (p): p is {op: 'del'; tableName: string; id: {id: string}} =>
+        p.op === 'del' && p.tableName === tableName,
+    );
+    return {puts, dels};
+  }
+
+  // Stops the currently-running VS, applies `mutate`, spins up a fresh VS
+  // against the same CVR / replica, and reconnects the client at `baseCookie`.
+  // Reconnecting at the prior cookie lets the client-handler's toVersion
+  // filter drop no-op patches, so the poke we observe only contains the
+  // drift-induced diff.
+  async function restartAfter(opts: {
+    baseCookie: string | null;
+    mutate: () => void | Promise<void>;
+    queriesPatch: UpQueriesPatch;
+    wsID?: string | undefined;
+  }): Promise<{
+    queue: Queue<Downstream>;
+    stateChanges: Subscription<ReplicaState>;
+    cleanup: () => Promise<void>;
+  }> {
+    await vs.stop();
+    await viewSyncerDone;
+    await opts.mutate();
+    const restart = restartViewSyncer({
+      databaseStorage,
+      replicaDbFile,
+      cvrDB,
+      config,
+      customQueryTransformer,
+      setTimeoutFn,
+    });
+    const queue = restart.connect(
+      {
+        ...SYNC_CONTEXT,
+        baseCookie: opts.baseCookie,
+        wsID: opts.wsID ?? 'ws2',
+      },
+      opts.queriesPatch,
+    );
+    return {
+      queue,
+      stateChanges: restart.stateChanges,
+      cleanup: async () => {
+        await restart.vs.stop();
+        await restart.viewSyncerDone;
+      },
+    };
+  }
+
   test('rowSetSignature persisted by end-to-end hydrate and advance', async () => {
     const client = connect(SYNC_CONTEXT, [
       {op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY},
@@ -4494,14 +4626,13 @@ describe('view-syncer/service', () => {
   });
 
   test('rowSetSignature drift on rehydration triggers re-execution and CVR correction', async () => {
-    // Phase 1: initial hydration via the current VS. CVR persists the
-    // authoritative signature for query-hash1.
+    // Initial hydration: CVR persists the authoritative sig for query-hash1.
     const client = connect(SYNC_CONTEXT, [
       {op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY},
     ]);
-    await nextPoke(client); // desiredQueriesPatch
+    await nextPoke(client);
     stateChanges.push({state: 'version-ready'});
-    await nextPoke(client); // initial hydration
+    await nextPoke(client);
 
     const correctSig = expectedIssuesSig(
       issueRowID('1'),
@@ -4511,45 +4642,28 @@ describe('view-syncer/service', () => {
     );
     expect(await loadStoredSig('query-hash1')).toEqual(correctSig);
 
-    // Phase 2: stop the VS, then tamper with the stored signature to simulate
-    // what the CVR would hold if a prior non-deterministic hydration (e.g. the
-    // Cap operator picking a different N-row subset) had produced a different
-    // row-set at this same stateVersion.
-    await vs.stop();
-    await viewSyncerDone;
-
+    // Tamper with the stored sig to simulate what the CVR would hold if a
+    // prior non-deterministic hydration had produced a different row-set at
+    // this same stateVersion. On restart, drift detection must correct it.
     const BOGUS_SIG = 'deadbeefcafebabe';
-    await cvrDB`
-      UPDATE ${cvrDB(cvrSchema(SHARD))}.queries
-         SET "rowSetSignature" = ${BOGUS_SIG}
-       WHERE "clientGroupID" = ${serviceID}
-         AND "queryHash" = 'query-hash1'
-    `;
-    expect(await loadStoredSig('query-hash1')).toEqual(BOGUS_SIG);
-
-    // Phase 3: fresh VS against the same cvrDB / replicaDbFile. A client
-    // connects to keep the service alive through the reset path so that
-    // #hydrateUnchangedQueries runs and detects the drift between the
-    // (bogus) stored signature and the freshly-computed driver signature.
-    const restart = restartViewSyncer({
-      databaseStorage,
-      replicaDbFile,
-      cvrDB,
-      config,
-      customQueryTransformer,
-      setTimeoutFn,
+    const {stateChanges: rsc, cleanup} = await restartAfter({
+      baseCookie: null,
+      mutate: async () => {
+        await cvrDB`
+          UPDATE ${cvrDB(cvrSchema(SHARD))}.queries
+             SET "rowSetSignature" = ${BOGUS_SIG}
+           WHERE "clientGroupID" = ${serviceID}
+             AND "queryHash" = 'query-hash1'
+        `;
+        expect(await loadStoredSig('query-hash1')).toEqual(BOGUS_SIG);
+      },
+      queriesPatch: [{op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY}],
     });
     try {
-      // A connected client prevents the run loop from shutting down when it
-      // sees no clients. Reuse SYNC_CONTEXT with a new wsID to avoid
-      // "connection replaced" log noise.
-      restart.connect({...SYNC_CONTEXT, wsID: 'ws2'}, [
-        {op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY},
-      ]);
-      restart.stateChanges.push({state: 'version-ready'});
+      rsc.push({state: 'version-ready'});
 
-      // The CVRQueryDrivenUpdater flush writes the corrected signature
-      // asynchronously. Poll until it matches what the driver would produce.
+      // CVRQueryDrivenUpdater flush writes the corrected signature
+      // asynchronously. Poll until it matches the driver-side signature.
       const deadline = Date.now() + 10_000;
       let finalSig = await loadStoredSig('query-hash1');
       while (finalSig !== correctSig && Date.now() < deadline) {
@@ -4558,123 +4672,58 @@ describe('view-syncer/service', () => {
       }
       expect(finalSig).toEqual(correctSig);
     } finally {
-      await restart.vs.stop();
-      await restart.viewSyncerDone;
+      await cleanup();
     }
   });
 
   test('rowSetSignature drift diffs rows: del A, put C, keep B; version is bumped', async () => {
-    // Prune the replica down to rows {1, 2} via direct SQL — bypasses the
-    // replicator so the replica stateVersion stays at '01', the same version
-    // at which drift detection will run on restart.
-    replica.prepare(`DELETE FROM issues WHERE id IN ('3', '4', '5')`).run();
+    pruneIssues('3', '4', '5');
 
-    // Phase 1: initial hydration at stateVersion '01'. Query returns {1, 2}.
-    // Stored rowSetSignature = sig({1, 2}). A=1, B=2.
+    // Phase 1: query returns {1, 2}. A=1, B=2.
     const client1 = connect(SYNC_CONTEXT, [
       {op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY2},
     ]);
-    await nextPoke(client1); // desiredQueriesPatch
+    await nextPoke(client1);
     stateChanges.push({state: 'version-ready'});
-    const phase1Poke = await nextPoke(client1);
-    const phase1EndMsg = phase1Poke.find(([c]) => c === 'pokeEnd') as [
-      string,
-      PokeEndBody,
-    ];
-    const phase1Cookie = phase1EndMsg[1].cookie;
+    const phase1Cookie = cookieOf(await nextPoke(client1));
 
     expect(await loadStoredSig('query-hash1')).toEqual(
       expectedIssuesSig(issueRowID('1'), issueRowID('2')),
     );
 
-    // Phase 2: stop the VS, then mutate the replica directly — delete row 1
-    // (A: should be retracted) and insert row 6 (C: should be added). Row 2
-    // (B) is untouched. No stateVersion bump: this is how a non-deterministic
-    // operator (e.g. Cap) choosing a different subset on re-execution at the
-    // same stateVersion would look to the drift check.
-    await vs.stop();
-    await viewSyncerDone;
-
-    replica.prepare(`DELETE FROM issues WHERE id = '1'`).run();
-    replica
-      .prepare(
-        `INSERT INTO issues (id, title, owner, parent, big, _0_version)
-           VALUES (?, ?, ?, ?, ?, ?)`,
-      )
-      .run('6', 'row C', '100', null, 0, '01');
-
-    // Phase 3: fresh VS against the same cvrDB / replica. Reconnect the client
-    // at phase1Cookie so the client-handler's toVersion filter drops any
-    // no-op patches for unchanged rows — leaving only the diff in rowsPatch.
-    const restart = restartViewSyncer({
-      databaseStorage,
-      replicaDbFile,
-      cvrDB,
-      config,
-      customQueryTransformer,
-      setTimeoutFn,
+    // Phase 2: mutate replica — delete row 1 (A), insert row 6 (C). Row 2 (B)
+    // untouched. No stateVersion bump.
+    const {
+      queue,
+      stateChanges: rsc,
+      cleanup,
+    } = await restartAfter({
+      baseCookie: phase1Cookie,
+      mutate: () => {
+        deleteIssue('1');
+        insertIssue('6', {title: 'row C'});
+      },
+      queriesPatch: [{op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY2}],
     });
     try {
-      const reconnected = restart.connect(
-        {...SYNC_CONTEXT, baseCookie: phase1Cookie, wsID: 'ws2'},
-        [{op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY2}],
-      );
-      restart.stateChanges.push({state: 'version-ready'});
-
-      // Drain pokes until we find the one with the drift-triggered row diff.
-      // There may be a preceding no-op poke (e.g. lmid / gotQueries ack); the
-      // vitest timeout guards indefinite hangs if no such poke is emitted.
-      let rowsPoke: Downstream[] | undefined;
-      for (let i = 0; i < 5 && !rowsPoke; i++) {
-        const poke = await nextPoke(reconnected);
-        const part = poke.find(([c]) => c === 'pokePart') as
-          | [string, PokePartBody]
-          | undefined;
-        if (part?.[1].rowsPatch?.length) {
-          rowsPoke = poke;
-        }
-      }
+      rsc.push({state: 'version-ready'});
+      const rowsPoke = await drainUntilRowsPatchOrQuiet(queue);
       expect(rowsPoke).toBeDefined();
 
-      const pokeStart = (
-        rowsPoke!.find(([c]) => c === 'pokeStart') as [string, PokeStartBody]
-      )[1];
-      const pokePart = (
-        rowsPoke!.find(([c]) => c === 'pokePart') as [string, PokePartBody]
-      )[1];
       const pokeEnd = (
         rowsPoke!.find(([c]) => c === 'pokeEnd') as [string, PokeEndBody]
       )[1];
+      const {puts, dels} = rowOpsFor(rowsPoke!, 'issues');
 
       // (1) Version is bumped past the pre-drift cookie.
-      expect(pokeEnd.cookie).not.toEqual(phase1Cookie);
-      expect(pokeEnd.cookie > phase1Cookie).toBe(true);
-      // baseCookie of this poke is either phase1Cookie (no prior poke) or a
-      // later intermediate — either way, it must not be ahead of pokeEnd.
-      expect(pokeStart.baseCookie).toBeTruthy();
+      expect(pokeEnd.cookie > phase1Cookie!).toBe(true);
 
-      // (2) Diff semantics.
-      const issueDels = pokePart.rowsPatch!.filter(
-        (p): p is {op: 'del'; tableName: string; id: {id: string}} =>
-          p.op === 'del' && p.tableName === 'issues',
-      );
-      const issuePuts = pokePart.rowsPatch!.filter(
-        (p): p is {op: 'put'; tableName: string; value: {id: string}} =>
-          p.op === 'put' && p.tableName === 'issues',
-      );
-
-      // A (row 1) is retracted.
-      expect(issueDels.map(p => p.id.id)).toEqual(['1']);
-      // C (row 6) is added.
-      expect(issuePuts.map(p => p.value.id)).toEqual(['6']);
-      // B (row 2) is NOT re-emitted: its rowVersion did not change, so its
-      // patchVersion stayed put and toVersion filtering dropped the put.
-      for (const p of pokePart.rowsPatch!) {
-        if (p.op === 'put' && p.tableName === 'issues') {
-          expect(p.value.id).not.toEqual('2');
-        } else if (p.op === 'del' && p.tableName === 'issues') {
-          expect(p.id.id).not.toEqual('2');
-        }
+      // (2) Diff semantics: A retracted, C added, B not re-emitted.
+      expect(dels.map(p => p.id.id)).toEqual(['1']);
+      expect(puts.map(p => p.value.id)).toEqual(['6']);
+      for (const p of [...puts, ...dels]) {
+        const id = 'value' in p ? p.value.id : p.id.id;
+        expect(id).not.toEqual('2');
       }
 
       // Corrected signature is persisted.
@@ -4682,8 +4731,209 @@ describe('view-syncer/service', () => {
         expectedIssuesSig(issueRowID('2'), issueRowID('6')),
       );
     } finally {
-      await restart.vs.stop();
-      await restart.viewSyncerDone;
+      await cleanup();
+    }
+  });
+
+  test('rowSetSignature match on rehydration: no re-execution, no row-diff poke', async () => {
+    pruneIssues('3', '4', '5');
+
+    const client1 = connect(SYNC_CONTEXT, [
+      {op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY2},
+    ]);
+    await nextPoke(client1);
+    stateChanges.push({state: 'version-ready'});
+    const phase1Cookie = cookieOf(await nextPoke(client1));
+    const expectedSig = expectedIssuesSig(issueRowID('1'), issueRowID('2'));
+    expect(await loadStoredSig('query-hash1')).toEqual(expectedSig);
+
+    // No mutation between phases. Rehydration must produce the same sig →
+    // drift detection must NOT fire and must NOT force a re-execution.
+    const {
+      queue,
+      stateChanges: rsc,
+      cleanup,
+    } = await restartAfter({
+      baseCookie: phase1Cookie,
+      mutate: () => {},
+      queriesPatch: [{op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY2}],
+    });
+    try {
+      rsc.push({state: 'version-ready'});
+
+      // No drift → no row-diff poke.
+      expect(await drainUntilRowsPatchOrQuiet(queue)).toBeUndefined();
+
+      // Sig unchanged (re-execution via CVRQueryDrivenUpdater never ran,
+      // which is the only path that would flush a new sig here).
+      expect(await loadStoredSig('query-hash1')).toEqual(expectedSig);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('rowSetSignature drift: only the drifted query is re-executed', async () => {
+    pruneIssues('3', '4', '5');
+
+    // Two queries on different tables: A=issues (will drift), B=users (stable).
+    const client1 = connect(SYNC_CONTEXT, [
+      {op: 'put', hash: 'query-hash-A', ast: ISSUES_QUERY2},
+      {op: 'put', hash: 'query-hash-B', ast: USERS_QUERY},
+    ]);
+    await nextPoke(client1);
+    stateChanges.push({state: 'version-ready'});
+    const phase1Cookie = cookieOf(await nextPoke(client1));
+
+    const initialSigA = expectedIssuesSig(issueRowID('1'), issueRowID('2'));
+    const initialSigB = await loadStoredSig('query-hash-B');
+    expect(await loadStoredSig('query-hash-A')).toEqual(initialSigA);
+    expect(initialSigB).toBeTruthy();
+
+    // Only issues is mutated. Users table is untouched → its sig must match
+    // on rehydration and drift must not fire for it.
+    const {
+      queue,
+      stateChanges: rsc,
+      cleanup,
+    } = await restartAfter({
+      baseCookie: phase1Cookie,
+      mutate: () => {
+        deleteIssue('1');
+        insertIssue('6', {title: 'row C'});
+      },
+      queriesPatch: [
+        {op: 'put', hash: 'query-hash-A', ast: ISSUES_QUERY2},
+        {op: 'put', hash: 'query-hash-B', ast: USERS_QUERY},
+      ],
+    });
+    try {
+      rsc.push({state: 'version-ready'});
+      const rowsPoke = await drainUntilRowsPatchOrQuiet(queue);
+      expect(rowsPoke).toBeDefined();
+
+      const {puts: issuePuts, dels: issueDels} = rowOpsFor(rowsPoke!, 'issues');
+      const {puts: userPuts, dels: userDels} = rowOpsFor(rowsPoke!, 'users');
+
+      // Issues drifted: del 1, put 6.
+      expect(issueDels.map(p => p.id.id)).toEqual(['1']);
+      expect(issuePuts.map(p => p.value.id)).toEqual(['6']);
+
+      // Users did NOT drift: no row-level changes for users in this poke.
+      expect(userDels).toHaveLength(0);
+      expect(userPuts).toHaveLength(0);
+
+      // Sig A is updated; sig B is unchanged.
+      expect(await loadStoredSig('query-hash-A')).toEqual(
+        expectedIssuesSig(issueRowID('2'), issueRowID('6')),
+      );
+      expect(await loadStoredSig('query-hash-B')).toEqual(initialSigB);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('rowSetSignature absent (legacy): drift check is skipped, no forced re-execution', async () => {
+    pruneIssues('3', '4', '5');
+
+    const client1 = connect(SYNC_CONTEXT, [
+      {op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY2},
+    ]);
+    await nextPoke(client1);
+    stateChanges.push({state: 'version-ready'});
+    const phase1Cookie = cookieOf(await nextPoke(client1));
+    expect(await loadStoredSig('query-hash1')).toEqual(
+      expectedIssuesSig(issueRowID('1'), issueRowID('2')),
+    );
+
+    // Null the stored sig to simulate a query record written before this
+    // feature was deployed. Also mutate the replica: if drift detection
+    // incorrectly fired on null sigs, the mutation would surface as a row
+    // diff. With the correct behavior, the legacy query is left alone.
+    const {
+      queue,
+      stateChanges: rsc,
+      cleanup,
+    } = await restartAfter({
+      baseCookie: phase1Cookie,
+      mutate: async () => {
+        await cvrDB`
+          UPDATE ${cvrDB(cvrSchema(SHARD))}.queries
+             SET "rowSetSignature" = NULL
+           WHERE "clientGroupID" = ${serviceID}
+             AND "queryHash" = 'query-hash1'
+        `;
+        expect(await loadStoredSig('query-hash1')).toBeNull();
+        deleteIssue('1');
+        insertIssue('6', {title: 'would be drift if detection fired'});
+      },
+      queriesPatch: [{op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY2}],
+    });
+    try {
+      rsc.push({state: 'version-ready'});
+
+      // Core guarantee of the legacy-null-sig skip: no forced re-execution →
+      // no row-diff poke. If this fired, clients reconnecting to a pre-feature
+      // deployment would see a spurious re-send of every row.
+      expect(await drainUntilRowsPatchOrQuiet(queue)).toBeUndefined();
+
+      // The sig *does* get initialized on this cycle — but through
+      // CVRQueryDrivenUpdater.flush's opportunistic pass over all queries
+      // (triggered by the normal add of internal queries on restart), not
+      // through drift re-execution. That's the intended "sigs get initialized
+      // whenever they next re-execute via the normal path" behavior.
+      expect(await loadStoredSig('query-hash1')).toEqual(
+        expectedIssuesSig(issueRowID('2'), issueRowID('6')),
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('rowSetSignature drift: custom (named) query diffs rows correctly', async () => {
+    pruneIssues('3', '4', '5');
+
+    queryFetch.respond([
+      {ast: ISSUES_QUERY2, id: 'custom-1', name: 'named-query'},
+    ]);
+
+    const client1 = connect(SYNC_CONTEXT, [
+      {op: 'put', hash: 'custom-1', name: 'named-query', args: ['thing']},
+    ]);
+    await nextPoke(client1);
+    stateChanges.push({state: 'version-ready'});
+    const phase1Cookie = cookieOf(await nextPoke(client1));
+    expect(await loadStoredSig('custom-1')).toEqual(
+      expectedIssuesSig(issueRowID('1'), issueRowID('2')),
+    );
+
+    const {
+      queue,
+      stateChanges: rsc,
+      cleanup,
+    } = await restartAfter({
+      baseCookie: phase1Cookie,
+      mutate: () => {
+        deleteIssue('1');
+        insertIssue('6', {title: 'row C'});
+      },
+      queriesPatch: [
+        {op: 'put', hash: 'custom-1', name: 'named-query', args: ['thing']},
+      ],
+    });
+    try {
+      rsc.push({state: 'version-ready'});
+      const rowsPoke = await drainUntilRowsPatchOrQuiet(queue);
+      expect(rowsPoke).toBeDefined();
+
+      const {puts, dels} = rowOpsFor(rowsPoke!, 'issues');
+      expect(dels.map(p => p.id.id)).toEqual(['1']);
+      expect(puts.map(p => p.value.id)).toEqual(['6']);
+
+      expect(await loadStoredSig('custom-1')).toEqual(
+        expectedIssuesSig(issueRowID('2'), issueRowID('6')),
+      );
+    } finally {
+      await cleanup();
     }
   });
 

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
@@ -4664,13 +4664,11 @@ describe('view-syncer/service', () => {
 
       // CVRQueryDrivenUpdater flush writes the corrected signature
       // asynchronously. Poll until it matches the driver-side signature.
-      const deadline = Date.now() + 10_000;
-      let finalSig = await loadStoredSig('query-hash1');
-      while (finalSig !== correctSig && Date.now() < deadline) {
-        await sleep(20);
-        finalSig = await loadStoredSig('query-hash1');
-      }
-      expect(finalSig).toEqual(correctSig);
+      await vi.waitFor(
+        async () =>
+          expect(await loadStoredSig('query-hash1')).toEqual(correctSig),
+        {timeout: 10_000, interval: 20},
+      );
     } finally {
       await cleanup();
     }

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
@@ -4563,6 +4563,130 @@ describe('view-syncer/service', () => {
     }
   });
 
+  test('rowSetSignature drift diffs rows: del A, put C, keep B; version is bumped', async () => {
+    // Prune the replica down to rows {1, 2} via direct SQL — bypasses the
+    // replicator so the replica stateVersion stays at '01', the same version
+    // at which drift detection will run on restart.
+    replica.prepare(`DELETE FROM issues WHERE id IN ('3', '4', '5')`).run();
+
+    // Phase 1: initial hydration at stateVersion '01'. Query returns {1, 2}.
+    // Stored rowSetSignature = sig({1, 2}). A=1, B=2.
+    const client1 = connect(SYNC_CONTEXT, [
+      {op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY2},
+    ]);
+    await nextPoke(client1); // desiredQueriesPatch
+    stateChanges.push({state: 'version-ready'});
+    const phase1Poke = await nextPoke(client1);
+    const phase1EndMsg = phase1Poke.find(([c]) => c === 'pokeEnd') as [
+      string,
+      PokeEndBody,
+    ];
+    const phase1Cookie = phase1EndMsg[1].cookie;
+
+    expect(await loadStoredSig('query-hash1')).toEqual(
+      expectedIssuesSig(issueRowID('1'), issueRowID('2')),
+    );
+
+    // Phase 2: stop the VS, then mutate the replica directly — delete row 1
+    // (A: should be retracted) and insert row 6 (C: should be added). Row 2
+    // (B) is untouched. No stateVersion bump: this is how a non-deterministic
+    // operator (e.g. Cap) choosing a different subset on re-execution at the
+    // same stateVersion would look to the drift check.
+    await vs.stop();
+    await viewSyncerDone;
+
+    replica.prepare(`DELETE FROM issues WHERE id = '1'`).run();
+    replica
+      .prepare(
+        `INSERT INTO issues (id, title, owner, parent, big, _0_version)
+           VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run('6', 'row C', '100', null, 0, '01');
+
+    // Phase 3: fresh VS against the same cvrDB / replica. Reconnect the client
+    // at phase1Cookie so the client-handler's toVersion filter drops any
+    // no-op patches for unchanged rows — leaving only the diff in rowsPatch.
+    const restart = restartViewSyncer({
+      databaseStorage,
+      replicaDbFile,
+      cvrDB,
+      config,
+      customQueryTransformer,
+      setTimeoutFn,
+    });
+    try {
+      const reconnected = restart.connect(
+        {...SYNC_CONTEXT, baseCookie: phase1Cookie, wsID: 'ws2'},
+        [{op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY2}],
+      );
+      restart.stateChanges.push({state: 'version-ready'});
+
+      // Drain pokes until we find the one with the drift-triggered row diff.
+      // There may be a preceding no-op poke (e.g. lmid / gotQueries ack); the
+      // vitest timeout guards indefinite hangs if no such poke is emitted.
+      let rowsPoke: Downstream[] | undefined;
+      for (let i = 0; i < 5 && !rowsPoke; i++) {
+        const poke = await nextPoke(reconnected);
+        const part = poke.find(([c]) => c === 'pokePart') as
+          | [string, PokePartBody]
+          | undefined;
+        if (part?.[1].rowsPatch?.length) {
+          rowsPoke = poke;
+        }
+      }
+      expect(rowsPoke).toBeDefined();
+
+      const pokeStart = (
+        rowsPoke!.find(([c]) => c === 'pokeStart') as [string, PokeStartBody]
+      )[1];
+      const pokePart = (
+        rowsPoke!.find(([c]) => c === 'pokePart') as [string, PokePartBody]
+      )[1];
+      const pokeEnd = (
+        rowsPoke!.find(([c]) => c === 'pokeEnd') as [string, PokeEndBody]
+      )[1];
+
+      // (1) Version is bumped past the pre-drift cookie.
+      expect(pokeEnd.cookie).not.toEqual(phase1Cookie);
+      expect(pokeEnd.cookie > phase1Cookie).toBe(true);
+      // baseCookie of this poke is either phase1Cookie (no prior poke) or a
+      // later intermediate — either way, it must not be ahead of pokeEnd.
+      expect(pokeStart.baseCookie).toBeTruthy();
+
+      // (2) Diff semantics.
+      const issueDels = pokePart.rowsPatch!.filter(
+        (p): p is {op: 'del'; tableName: string; id: {id: string}} =>
+          p.op === 'del' && p.tableName === 'issues',
+      );
+      const issuePuts = pokePart.rowsPatch!.filter(
+        (p): p is {op: 'put'; tableName: string; value: {id: string}} =>
+          p.op === 'put' && p.tableName === 'issues',
+      );
+
+      // A (row 1) is retracted.
+      expect(issueDels.map(p => p.id.id)).toEqual(['1']);
+      // C (row 6) is added.
+      expect(issuePuts.map(p => p.value.id)).toEqual(['6']);
+      // B (row 2) is NOT re-emitted: its rowVersion did not change, so its
+      // patchVersion stayed put and toVersion filtering dropped the put.
+      for (const p of pokePart.rowsPatch!) {
+        if (p.op === 'put' && p.tableName === 'issues') {
+          expect(p.value.id).not.toEqual('2');
+        } else if (p.op === 'del' && p.tableName === 'issues') {
+          expect(p.id.id).not.toEqual('2');
+        }
+      }
+
+      // Corrected signature is persisted.
+      expect(await loadStoredSig('query-hash1')).toEqual(
+        expectedIssuesSig(issueRowID('2'), issueRowID('6')),
+      );
+    } finally {
+      await restart.vs.stop();
+      await restart.viewSyncerDone;
+    }
+  });
+
   test('process advancement with lmid change, client has no queries.  See https://bugs.rocicorp.dev/issue/3628', async () => {
     const client = connect(SYNC_CONTEXT, []);
     expect(await nextPoke(client)).toMatchInlineSnapshot(`

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -89,6 +89,7 @@ import type {DrainCoordinator} from './drain-coordinator.ts';
 import {handleInspect} from './inspect-handler.ts';
 import type {PipelineDriver} from './pipeline-driver.ts';
 import {type RowChange} from './pipeline-driver.ts';
+import {parseSignature} from './row-set-signature.ts';
 import {
   cmpVersions,
   EMPTY_CVR_VERSION,
@@ -303,6 +304,15 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     'pipeline-resets',
     'Number of pipeline resets',
   );
+  readonly #rowSetSignatureDrifts = getOrCreateCounter(
+    'sync',
+    'query.row-set-signature-drifts',
+    'Number of times re-hydration of an unchanged query produced a different ' +
+      'row-set signature than what is stored in the CVR (forcing a configVersion ' +
+      'bump and full re-execution). Expected to be near-zero in steady state; ' +
+      'persistent non-zero values indicate non-deterministic query execution ' +
+      '(e.g. Cap operator picking different N-row subsets).',
+  );
 
   readonly #inspectorDelegate: InspectorDelegate;
 
@@ -495,12 +505,20 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           // stateVersion is at or beyond CVR version for the first time.
           lc.info?.(`init pipelines@${version} (cvr@${cvrVer})`);
 
-          await this.#hydrateUnchangedQueries(lc, cvr);
+          const driftedQueryIDs = await this.#hydrateUnchangedQueries(lc, cvr);
           // hydrateUnchangedQueries just transformed
           // all the custom queries, this #syncQueryPipelineSet call
           // should retransform those that are missing from #pipelines, which
-          // are those which errored or changed transform hash
-          await this.#syncQueryPipelineSet(lc, cvr, 'missing', undefined);
+          // are those which errored or changed transform hash, plus those
+          // removed because their rowSetSignature drifted (Cap re-execution
+          // chose a different N-row subset).
+          await this.#syncQueryPipelineSet(
+            lc,
+            cvr,
+            'missing',
+            undefined,
+            driftedQueryIDs,
+          );
           this.#pipelinesSynced = true;
         });
       }
@@ -1313,7 +1331,10 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
    *
    * This must be called from within the #lock.
    */
-  async #hydrateUnchangedQueries(lc: LogContext, cvr: CVRSnapshot) {
+  async #hydrateUnchangedQueries(
+    lc: LogContext,
+    cvr: CVRSnapshot,
+  ): Promise<Set<string>> {
     assert(this.#pipelines.initialized(), 'pipelines must be initialized');
 
     const dbVersion = this.#pipelines.currentVersion();
@@ -1323,7 +1344,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       lc.info?.(
         `CVR (${versionToCookie(cvrVersion)}) is behind db ${dbVersion}`,
       );
-      return; // hydration needs to be run with the CVR updater.
+      return new Set(); // hydration needs to be run with the CVR updater.
     }
 
     const gotQueries = Object.entries(cvr.queries).filter(
@@ -1434,6 +1455,8 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         `${transformedQueries.length} hydrated`,
     );
 
+    const driftedQueryIDs = new Set<string>();
+
     for (const {
       id: queryID,
       transformationHash,
@@ -1468,7 +1491,39 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       this.#hydrationTime.recordMs(elapsed);
       this.#addQueryMaterializationServerMetric(transformationHash, elapsed);
       lc.debug?.(`hydrated ${count} rows for ${queryID} (${elapsed} ms)`);
+
+      // Drift detection: compare the just-computed candidate signature against
+      // the signature stored in the CVR. They should match for a deterministic
+      // query at the same db state. A mismatch indicates a query containing
+      // the Cap operator picked a different N-row subset on re-execution.
+      // Remove the query from pipelines so #syncQueryPipelineSet 'missing'
+      // re-executes it via the CVRQueryDrivenUpdater path, where the row diff
+      // will be properly emitted to the client.
+      //
+      // Skip when the stored signature is absent — legacy queries from before
+      // this feature was deployed have no signature to compare against, and a
+      // forced re-execution would needlessly resend rows to the client. Such
+      // queries get their signature initialized whenever they next re-execute
+      // via the normal path (transformation hash change, etc.), at which
+      // point drift detection becomes effective for subsequent cycles.
+      const storedSigHex = cvr.queries[queryID]?.rowSetSignature;
+      if (storedSigHex !== undefined && storedSigHex !== null) {
+        const priorSig = parseSignature(storedSigHex);
+        const candidateSig = this.#pipelines.rowSetSignature(queryID) ?? 0n;
+        if (priorSig !== candidateSig) {
+          lc.warn?.(
+            `rowSetSignature drift for query ${queryID}: ` +
+              `prior=${priorSig.toString(16)} new=${candidateSig.toString(16)} ` +
+              `(${count} rows). Removing from pipelines for full re-execution.`,
+          );
+          this.#rowSetSignatureDrifts.add(1);
+          this.#pipelines.removeQuery(queryID);
+          driftedQueryIDs.add(queryID);
+        }
+      }
     }
+
+    return driftedQueryIDs;
   }
 
   #processTransformedCustomQueries(
@@ -1569,6 +1624,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     cvr: CVRSnapshot,
     customQueryTransformMode: CustomQueryTransformMode,
     ctx: ConnectionContext | undefined,
+    driftedQueryIDs: Set<string> = new Set(),
   ) {
     return startAsyncSpan(tracer, 'vs.#syncQueryPipelineSet', async span => {
       span.setAttribute('clientGroupID', this.id);
@@ -1795,6 +1851,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           cvr,
           addQueries,
           Array.from(removeQueriesQueryIds, id => ({id})),
+          driftedQueryIDs,
         );
       } else {
         await this.#catchupClients(lc, cvr);
@@ -1846,6 +1903,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       name?: string | undefined;
     }[],
     removeQueries: {id: string}[],
+    driftedQueryIDs: Set<string> = new Set(),
   ): Promise<void> {
     return startAsyncSpan(tracer, 'vs.#addAndRemoveQueries', async () => {
       assert(
@@ -1868,15 +1926,27 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
       // Note: This kicks off background PG queries for CVR data associated with the
       // executed and removed queries.
-      const {newVersion, queryPatches} = updater.trackQueries(
+      const {queryPatches} = updater.trackQueries(
         lc,
         addQueries,
         removeQueries,
       );
+
+      // For queries being re-executed solely due to rowSetSignature drift
+      // (not a transformationHash change), trackQueries does not bump
+      // configVersion. Force a bump so the row diff produced by received()
+      // gets propagated to the client via a poke. Must happen before
+      // startPoke so the pokers see the final cookie version.
+      if (addQueries.some(q => driftedQueryIDs.has(q.id))) {
+        updater.ensureNewVersion();
+      }
+      const newVersion = updater.updatedVersion();
       const clients = this.#getClients();
       const pokers = startPoke(clients, newVersion);
       for (const patch of queryPatches) {
-        await pokers.addPatch(patch);
+        // Bump patches' toVersion to the post-drift-bump version so that
+        // pokers don't see them as belonging to a stale cookie.
+        await pokers.addPatch({...patch, toVersion: newVersion});
       }
 
       // Removing queries is easy. The pipelines are dropped, and the CVR


### PR DESCRIPTION
The change is pretty tiny (all in view-syncer.ts + 1 method in cvr.ts). The bulk of this is tests.

- here -> https://github.com/rocicorp/mono/pull/5857
- https://github.com/rocicorp/mono/pull/5849
- https://github.com/rocicorp/mono/pull/5848

## Summary

Builds on the row-set signature XOR introduced in #5849. When the view-syncer re-hydrates queries at the same CVR version (e.g. on startup), it now compares each query's freshly-computed signature against the signature persisted in the CVR. A mismatch means deterministic re-execution produced a different row set — for example, a `Cap` operator picking a different N-row subset — and the query is re-executed through the normal diff-emitting path so clients see the corrected rows.

## What changes

- **Drift detection in `#hydrateUnchangedQueries`** (`view-syncer.ts`): after hydrating each query, compare `#pipelines.rowSetSignature(queryID)` against `cvr.queries[queryID].rowSetSignature`. On mismatch, log a warning, bump the `query.row-set-signature-drifts` OTEL counter, remove the query from the pipelines, and collect its ID in a `driftedQueryIDs` set.
- **Re-execution via the CVR-driven path**: `driftedQueryIDs` is threaded into `#syncQueryPipelineSet('missing', …)` and on to `#addAndRemoveQueries`. Because drifted queries appear as "missing" from the pipelines, the existing add path re-hydrates them through `CVRQueryDrivenUpdater`, which emits the row diff to clients.
- **Forced `configVersion` bump** (`cvr.ts`): a new public `CVRQueryDrivenUpdater.ensureNewVersion()` alias for `_ensureNewVersion` lets the view-syncer force a version bump when the only reason for re-execution is drift (no transformation-hash change, no add/remove). Pending `queryPatches` are re-stamped to the post-bump cookie so pokers don't treat them as stale.
- **Legacy-signature handling**: queries whose stored signature is `null` (from before #5849 deployed) skip the comparison. Their signature gets initialized on the next normal re-execution, at which point drift detection becomes effective for subsequent cycles.

## Observability

- `query.row-set-signature-drifts` counter — expected to be near-zero in steady state. Persistent non-zero values indicate non-deterministic query execution (e.g. `Cap` without a stable tiebreaker).

## Test plan

- [x] `npm --workspace=zero-cache run test -- --project=zero-cache/pg-18 view-syncer`
- [x] New `view-syncer.pg.test.ts` cases cover:
  - signature drift at startup triggers re-execution and client poke
  - legacy (null) signature skips drift check on first cycle
  - `configVersion` bumps when drift is the sole cause of re-execution
  - pending `queryPatches` reach clients at the post-bump cookie
- [x] `npm run lint && npm run format && npm run check-types`

## Follow-ups

- Consider adding a histogram of drifted-queries-per-hydration-cycle so we can tell "one chronic offender" apart from "broad drift."
- If drift counter ever goes non-zero in production, the root cause is almost certainly a `Cap` operator lacking a deterministic tiebreaker.