### PR TITLE
fix(zero-cache): partial fix for `CREATE|DROP INDEX CONCURRENTLY` ddl statements

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -1049,7 +1049,6 @@ class ChangeMaker {
         }
 
       case 'commit':
-        this.#lastReplicationEventInTx = undefined;
         return [
           [
             'commit',
@@ -1072,7 +1071,7 @@ class ChangeMaker {
     }
   }
 
-  #lastReplicationEventInTx: ReplicationEvent | undefined;
+  #lastReplicationEvent: ReplicationEvent | undefined;
 
   #handleDdlMessage(lc: LogContext, msg: MessageMessage): ChangeStreamData[] {
     const event = parseLogicalMessageContent(msg, replicationEventSchema);
@@ -1084,7 +1083,7 @@ class ChangeMaker {
     // is about to happen, so as to avoid interfering / redundant work.
     clearTimeout(this.#replicaIdentityTimer);
 
-    let prevEvent = this.#lastReplicationEventInTx;
+    let prevEvent = this.#lastReplicationEvent;
     const {type} = event;
     switch (type) {
       case 'ddlStart':
@@ -1100,7 +1099,7 @@ class ChangeMaker {
     }
 
     // Store the new event to diff against the next event.
-    this.#lastReplicationEventInTx = event;
+    this.#lastReplicationEvent = event;
     if (!prevEvent) {
       lc.info?.(`received ${msg.prefix}/${type} event`, event);
       return []; // First snapshot in the tx.


### PR DESCRIPTION
This partially fixes handling of `CREATE INDEX CONCURRENTLY` and `DROP INDEX CONCURRENTLY` statements, for which the `on_ddl_start` and `on_ddl_end` event triggers fire in different transactions.

Context: https://rocicorp.slack.com/archives/C0AK5KX8HGE/p1776539834479759

The change-source code no longer clears the last replication event at the end of a transaction, and instead remembers the last replication event across transactions.

This fix is incomplete in that it relies on the change-source processing both replication events (the start and end of CREATE INDEX CONCURRENTLY) in a single session, as these replication events do not persist across sessions.

A complete fix will require a larger change and is forthcoming. 