### PR TITLE
chore(zero-cache): test verifying `create index concurrently`

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg.test.ts
@@ -1229,6 +1229,23 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
       [],
     ],
     [
+      'create index concurrently',
+      `
+      CREATE INDEX CONCURRENTLY foo_flt3 ON foo (flt DESC, id ASC);
+      `,
+      [[{tag: 'create-index'}]],
+      {foo: []},
+      [],
+      [
+        {
+          tableName: 'foo',
+          name: 'foo_flt3',
+          columns: {flt: 'DESC', id: 'ASC'},
+          unique: false,
+        },
+      ],
+    ],
+    [
       'remove table (with indexes) from publication',
       `ALTER PUBLICATION zero_some_public DROP TABLE boo`,
       [


### PR DESCRIPTION
Test to accompany https://github.com/rocicorp/mono/pull/5858