### PR TITLE
fix(zero-cache,replicache): preserve sqlite tx failures via Error.cause

### DIFF
--- a/packages/replicache/src/kv/expo-sqlite/store.test.node.ts
+++ b/packages/replicache/src/kv/expo-sqlite/store.test.node.ts
@@ -2,12 +2,16 @@ import fs from 'node:fs';
 import path from 'node:path';
 import sqlite3 from '@rocicorp/zero-sqlite3';
 import {expect, test, vi} from 'vitest';
-import {withRead, withWrite} from '../../with-transactions.ts';
+import {
+  withRead,
+  withWrite,
+  withWriteNoImplicitCommit,
+} from '../../with-transactions.ts';
 import {
   registerCreatedFile,
   runSQLiteStoreTests,
 } from '../sqlite-store-test-util.ts';
-import {clearAllNamedStoresForTesting} from '../sqlite-store.ts';
+import {clearAllNamedStoresForTesting, safeFilename} from '../sqlite-store.ts';
 import {expoSQLiteStoreProvider, type ExpoSQLiteStoreOptions} from './store.ts';
 
 //Mock the expo-sqlite module with Node SQLite implementation
@@ -136,4 +140,38 @@ test('different configuration options', async () => {
   });
 
   await storeWithOptions.close();
+});
+
+test('withWriteNoImplicitCommit reports both operation and rollback errors', async () => {
+  const storeName = 'auto-rollback-expo';
+  const store = createStore(storeName);
+  const filename = path.resolve(
+    __dirname,
+    `expo_${safeFilename(storeName)}.db`,
+  );
+  const triggerDb = sqlite3(filename);
+  triggerDb.exec(`
+    DROP TRIGGER IF EXISTS entry_auto_rollback_expo;
+    CREATE TRIGGER entry_auto_rollback_expo
+    BEFORE INSERT ON entry
+    WHEN NEW.key = 'trigger-rollback'
+    BEGIN
+      SELECT RAISE(ROLLBACK, 'auto rollback put failure');
+    END;
+  `);
+  triggerDb.close();
+
+  const err = await withWriteNoImplicitCommit(store, async write => {
+    await write.put('trigger-rollback', 'value');
+  }).then(
+    () => undefined,
+    e => e,
+  );
+
+  expect(err).toBeInstanceOf(Error);
+  expect(String(err)).toContain('auto rollback put failure');
+  expect(String(err)).toContain('cannot rollback');
+  expect(String((err as Error).cause)).toContain('auto rollback put failure');
+
+  await store.close();
 });

--- a/packages/replicache/src/kv/op-sqlite/store.test.node.ts
+++ b/packages/replicache/src/kv/op-sqlite/store.test.node.ts
@@ -2,12 +2,16 @@ import fs from 'node:fs';
 import path from 'node:path';
 import sqlite3 from '@rocicorp/zero-sqlite3';
 import {expect, test, vi} from 'vitest';
-import {withRead, withWrite} from '../../with-transactions.ts';
+import {
+  withRead,
+  withWrite,
+  withWriteNoImplicitCommit,
+} from '../../with-transactions.ts';
 import {
   registerCreatedFile,
   runSQLiteStoreTests,
 } from '../sqlite-store-test-util.ts';
-import {clearAllNamedStoresForTesting} from '../sqlite-store.ts';
+import {clearAllNamedStoresForTesting, safeFilename} from '../sqlite-store.ts';
 import {opSQLiteStoreProvider, type OpSQLiteStoreOptions} from './store.ts';
 
 // Mock the @op-engineering/op-sqlite module with Node SQLite implementation
@@ -140,4 +144,35 @@ test('OpSQLite specific configuration options', async () => {
   });
 
   await storeWithOptions.close();
+});
+
+test('withWriteNoImplicitCommit reports both operation and rollback errors', async () => {
+  const storeName = 'auto-rollback-op';
+  const store = createStore(storeName);
+  const filename = path.resolve(__dirname, `op_${safeFilename(storeName)}.db`);
+  const triggerDb = sqlite3(filename);
+  triggerDb.exec(`
+    DROP TRIGGER IF EXISTS entry_auto_rollback_op;
+    CREATE TRIGGER entry_auto_rollback_op
+    BEFORE INSERT ON entry
+    WHEN NEW.key = 'trigger-rollback'
+    BEGIN
+      SELECT RAISE(ROLLBACK, 'auto rollback put failure');
+    END;
+  `);
+  triggerDb.close();
+
+  const err = await withWriteNoImplicitCommit(store, async write => {
+    await write.put('trigger-rollback', 'value');
+  }).then(
+    () => undefined,
+    e => e,
+  );
+
+  expect(err).toBeInstanceOf(Error);
+  expect(String(err)).toContain('auto rollback put failure');
+  expect(String(err)).toContain('cannot rollback');
+  expect(String((err as Error).cause)).toContain('auto rollback put failure');
+
+  await store.close();
 });

--- a/packages/replicache/src/kv/sqlite-store.ts
+++ b/packages/replicache/src/kv/sqlite-store.ts
@@ -274,12 +274,19 @@ export class SQLiteWrite implements Write {
   release(): void {
     if (!this.#closed) {
       this.#closed = true;
-
+      let rollbackError: unknown;
       if (!this.#committed) {
-        this.#dbDelegate.execSync('ROLLBACK');
+        try {
+          this.#dbDelegate.execSync('ROLLBACK');
+        } catch (e) {
+          rollbackError = e;
+        }
       }
 
       this.#release();
+      if (rollbackError !== undefined) {
+        throw rollbackError;
+      }
     }
   }
 

--- a/packages/replicache/src/with-transactions.ts
+++ b/packages/replicache/src/with-transactions.ts
@@ -49,9 +49,31 @@ export async function using<TX extends Release, Return>(
   fn: (tx: TX) => Return | Promise<Return>,
 ): Promise<Return> {
   const write = await x;
+  let result: Return | undefined;
+  let operationError: unknown;
   try {
-    return await fn(write);
-  } finally {
-    write.release();
+    result = await fn(write);
+  } catch (e) {
+    operationError = e;
   }
+
+  try {
+    write.release();
+  } catch (releaseError) {
+    if (operationError !== undefined) {
+      const combinedError = new Error(
+        `Transaction operation failed and release also failed: operation error = ${String(
+          operationError,
+        )}; release error = ${String(releaseError)}`,
+      );
+      combinedError.cause = operationError;
+      throw combinedError;
+    }
+    throw releaseError;
+  }
+
+  if (operationError !== undefined) {
+    throw operationError;
+  }
+  return result as Return;
 }

--- a/packages/zero-cache/src/auth/write-authorizer.test.ts
+++ b/packages/zero-cache/src/auth/write-authorizer.test.ts
@@ -544,6 +544,46 @@ describe('primary key validation', () => {
     );
   });
 
+  test('preserves original sqlite auto-rollback error', async () => {
+    replica.exec(/*sql*/ `
+      CREATE TRIGGER "AutoRollbackWriteAuthorizer"
+      BEFORE INSERT ON foo
+      BEGIN
+        SELECT RAISE(ROLLBACK, 'auto rollback write authorizer');
+      END;
+    `);
+
+    const authorizer = new WriteAuthorizerImpl(
+      lc,
+      zeroConfig,
+      replica,
+      'the_app',
+      'cg',
+      writeAuthzStorage,
+    );
+
+    const err = await authorizer
+      .canPostMutation({sub: '2'}, [
+        {
+          op: 'insert',
+          primaryKey: ['id'],
+          tableName: 'foo',
+          value: {id: '2', a: 'value'},
+        },
+      ])
+      .then(
+        () => undefined,
+        e => e,
+      );
+
+    expect(err).toBeInstanceOf(Error);
+    expect(String(err)).toContain('auto rollback write authorizer');
+    expect(String(err)).toContain('cannot rollback - no transaction is active');
+    expect(String((err as Error).cause)).toContain(
+      'auto rollback write authorizer',
+    );
+  });
+
   test('rejects upsert when primary key column missing from value', () => {
     const authorizer = new WriteAuthorizerImpl(
       lc,

--- a/packages/zero-cache/src/auth/write-authorizer.ts
+++ b/packages/zero-cache/src/auth/write-authorizer.ts
@@ -165,6 +165,7 @@ export class WriteAuthorizerImpl implements WriteAuthorizer {
     ops: Exclude<CRUDOp, UpsertOp>[],
   ) {
     this.#statementRunner.beginConcurrent();
+    let opError: unknown;
     try {
       for (const op of ops) {
         const source = this.#getSource(op.tableName);
@@ -214,8 +215,22 @@ export class WriteAuthorizerImpl implements WriteAuthorizer {
             break;
         }
       }
+    } catch (e) {
+      opError = e;
+      throw e;
     } finally {
-      this.#statementRunner.rollback();
+      try {
+        this.#statementRunner.rollback();
+      } catch (rollbackError) {
+        if (opError !== undefined) {
+          const combinedError = new Error(
+            `canPostMutation failed and rollback also failed: operation error = ${String(opError)}; rollback error = ${String(rollbackError)}`,
+          );
+          combinedError.cause = opError;
+          throw combinedError;
+        }
+        throw rollbackError;
+      }
     }
 
     return true;

--- a/packages/zero-cache/src/db/migration-lite.test.ts
+++ b/packages/zero-cache/src/db/migration-lite.test.ts
@@ -254,4 +254,118 @@ describe('db/migration-lite', () => {
       db.close();
     });
   }
+
+  const thrownValue = {type: 'custom-throw-value'};
+
+  type ErrorCase = {
+    name: string;
+    setup: Migration;
+    verify: (err: unknown) => void;
+  };
+
+  const errorCases: ErrorCase[] = [
+    {
+      name: 'preserves sqlite error for internal rollback',
+      setup: {
+        migrateSchema: (_log, db) => {
+          db.exec(`
+            CREATE TABLE "AutoRollback" (
+              id INTEGER PRIMARY KEY
+            );
+
+            CREATE TRIGGER "AutoRollbackTrigger"
+            BEFORE INSERT ON "AutoRollback"
+            BEGIN
+              SELECT RAISE(ROLLBACK, 'auto rollback');
+            END;
+          `);
+          db.prepare(`INSERT INTO "AutoRollback" (id) VALUES (1)`).run();
+        },
+      },
+      verify: err => {
+        expect(err).toBeInstanceOf(Error);
+        expect(String(err)).toContain('auto rollback');
+        expect(String(err)).toContain(
+          'cannot rollback - no transaction is active',
+        );
+        expect(String((err as Error).cause)).toContain('auto rollback');
+      },
+    },
+    {
+      name: 'preserves sqlite error without internal rollback',
+      setup: {
+        migrateSchema: (_log, db) => {
+          db.exec(`
+            CREATE TABLE "NoAutoRollback" (
+              id INTEGER PRIMARY KEY,
+              email TEXT UNIQUE
+            );
+          `);
+          db.prepare(
+            `INSERT INTO "NoAutoRollback" (id, email) VALUES (1, 'a@example.com')`,
+          ).run();
+          db.prepare(
+            `INSERT INTO "NoAutoRollback" (id, email) VALUES (2, 'a@example.com')`,
+          ).run();
+        },
+      },
+      verify: err => {
+        expect(String(err)).toContain('UNIQUE constraint failed');
+      },
+    },
+    {
+      name: 'preserves synchronous javascript error',
+      setup: {
+        migrateSchema: () => {
+          throw new Error('sync javascript error');
+        },
+      },
+      verify: err => {
+        expect(err).toBeInstanceOf(Error);
+        expect((err as Error).message).toBe('sync javascript error');
+      },
+    },
+    {
+      name: 'preserves asynchronous javascript error',
+      setup: {
+        migrateData: async () => {
+          await Promise.resolve();
+          throw new Error('async javascript error');
+        },
+      },
+      verify: err => {
+        expect(err).toBeInstanceOf(Error);
+        expect((err as Error).message).toBe('async javascript error');
+      },
+    },
+    {
+      name: 'preserves non-Error thrown values',
+      setup: {
+        migrateSchema: () => {
+          throw thrownValue;
+        },
+      },
+      verify: err => {
+        expect(err).toBe(thrownValue);
+      },
+    },
+  ];
+
+  test.each(errorCases)('$name', async c => {
+    let err: unknown;
+    try {
+      await runSchemaMigrations(
+        createSilentLogContext(),
+        debugName,
+        dbFile.path,
+        c.setup,
+        {1: {}},
+      );
+    } catch (e) {
+      err = e;
+    }
+
+    expect(err).toBeDefined();
+    c.verify(err);
+  });
 });

--- a/packages/zero-cache/src/db/migration-lite.ts
+++ b/packages/zero-cache/src/db/migration-lite.ts
@@ -336,7 +336,18 @@ async function runTransaction<T>(
     return result;
   } catch (e) {
     log.error?.('Aborted transaction due to error', e);
-    db.prepare('ROLLBACK').run();
+    try {
+      db.prepare('ROLLBACK').run();
+    } catch (rollbackError) {
+      log.error?.('Unable to rollback transaction', rollbackError);
+      const combinedError = new Error(
+        `Transaction failed and rollback also failed: operation error = ${String(
+          e,
+        )}; rollback error = ${String(rollbackError)}`,
+      );
+      combinedError.cause = e;
+      throw combinedError;
+    }
     throw e;
   }
 }

--- a/packages/zero-cache/src/db/statements.test.ts
+++ b/packages/zero-cache/src/db/statements.test.ts
@@ -46,4 +46,10 @@ describe('db/statements', () => {
 
     expectTables(db.db, {foo: [{id: 987}]});
   });
+
+  test('rollback throws if no transaction is active', () => {
+    expect(() => db.rollback()).toThrow(
+      'cannot rollback - no transaction is active',
+    );
+  });
 });

--- a/packages/zero-cache/src/services/replicator/change-processor.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.test.ts
@@ -3759,6 +3759,49 @@ describe('replicator/change-processor-errors', () => {
     processor.abort(lc);
     expect(replica.inTransaction).toBe(false);
   });
+
+  test('preserves original sqlite auto-rollback error', () => {
+    const failures: unknown[] = [];
+    const processor = createChangeProcessor(replica, (_, err) =>
+      failures.push(err),
+    );
+    const messages = new ReplicationMessages({auto_rollback: 'id'});
+
+    replica.exec(/*sql*/ `
+      CREATE TABLE auto_rollback(
+        id INTEGER,
+        _0_version TEXT,
+        PRIMARY KEY(id)
+      );
+
+      CREATE TRIGGER "AutoRollbackChangeProcessor"
+      BEFORE INSERT ON auto_rollback
+      BEGIN
+        SELECT RAISE(ROLLBACK, 'auto rollback change processor');
+      END;
+    `);
+
+    processor.processMessage(lc, [
+      'begin',
+      messages.begin(),
+      {commitWatermark: '0e'},
+    ]);
+    processor.processMessage(lc, [
+      'data',
+      messages.insert('auto_rollback', {id: 123}),
+    ]);
+
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toBeInstanceOf(Error);
+    expect(String(failures[0])).toContain('auto rollback change processor');
+    expect(String(failures[0])).toContain(
+      'cannot rollback - no transaction is active',
+    );
+    expect(String((failures[0] as Error).cause)).toContain(
+      'auto rollback change processor',
+    );
+    expect(replica.inTransaction).toBe(false);
+  });
 });
 
 describe('replicator/column-metadata-integration', () => {

--- a/packages/zero-cache/src/services/replicator/change-processor.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.ts
@@ -114,11 +114,20 @@ export class ChangeProcessor {
 
   #fail(lc: LogContext, err: unknown) {
     if (!this.#failure) {
-      this.#currentTx?.abort(lc); // roll back any pending transaction.
+      let failureError = err;
+      try {
+        this.#currentTx?.abort(lc); // roll back any pending transaction.
+      } catch (rollbackError) {
+        const combinedError = new Error(
+          `Message processing failed and rollback also failed: operation error = ${String(err)}; rollback error = ${String(rollbackError)}`,
+        );
+        combinedError.cause = err;
+        failureError = combinedError;
+      }
 
-      this.#failure = ensureError(err);
+      this.#failure = ensureError(failureError);
 
-      if (!(err instanceof AbortError)) {
+      if (!(this.#failure instanceof AbortError)) {
         // Propagate the failure up to the service.
         lc.error?.('Message Processing failed:', this.#failure);
         this.#failService(lc, this.#failure);


### PR DESCRIPTION
Some SQLite errors auto-abort the transaction. In this case, calling ROLLBACK throws a new error, obscuring the original one.

Fix this pattern throughout the codebase.

Original report: https://discord.com/channels/830183651022471199/1495148037935206620/1496448522860630017