### PR TITLE
fix(ci): use npm trusted publishing for canary releases

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -8,6 +8,10 @@ jobs:
   canary-release:
     name: Canary Release
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release-canary')
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -34,8 +38,6 @@ jobs:
 
       - name: Run canary release
         id: release
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           output=$(node packages/zero/tool/release.ts canary ${{ github.event.pull_request.base.ref }} --yes --skip-tests 2>&1 | tee /dev/stderr)
           version=$(echo "$output" | grep -oP 'Published @rocicorp/zero@\K[^\s]+')


### PR DESCRIPTION
## Summary
- switch canary release workflow auth from `NODE_AUTH_TOKEN` to npm trusted publishing (OIDC)
- add explicit job permissions needed for this flow:
  - `id-token: write` for npm OIDC exchange
  - `contents: write` for pushing release tags
  - `pull-requests: write` for PR comment posting
- remove direct dependency on `secrets.NPM_TOKEN` from the release step

## Why
The current CI release flow can fail when npm requires interactive OTP for token-based publish. Trusted publishing avoids OTP prompts in CI and removes long-lived publish token usage.

## Validation
- `npm run format`
- `npm run lint`
- `npm run check-types` *(fails due to pre-existing `zero-cache` type errors unrelated to this workflow change)*

## Follow-up
Ensure `@rocicorp/zero` is configured with a trusted publisher in npm package settings for this GitHub workflow.