### PR TITLE
refactor: replace TESTING global with import.meta.env.VITEST

### DIFF
--- a/apps/zbugs/env.d.ts
+++ b/apps/zbugs/env.d.ts
@@ -3,6 +3,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_PUBLIC_SERVER: string;
+  readonly VITEST?: string;
   // more env variables...
 }
 

--- a/apps/zbugs/tsconfig.json
+++ b/apps/zbugs/tsconfig.json
@@ -8,6 +8,6 @@
     },
     "declaration": true
   },
-  "include": ["src", "shared/*"],
+  "include": ["src", "shared/*", "env.d.ts"],
   "exclude": ["src/server"]
 }

--- a/apps/zbugs/tsconfig.node.json
+++ b/apps/zbugs/tsconfig.node.json
@@ -10,5 +10,5 @@
       ]
     }
   },
-  "include": ["vite.config.ts", "api/index.ts"]
+  "include": ["vite.config.ts", "api/index.ts", "env.d.ts"]
 }

--- a/packages/analyze-query/src/env.d.ts
+++ b/packages/analyze-query/src/env.d.ts
@@ -1,0 +1,3 @@
+interface ImportMeta {
+  readonly env?: {readonly VITEST?: string | boolean};
+}

--- a/packages/ast-to-zql/src/env.d.ts
+++ b/packages/ast-to-zql/src/env.d.ts
@@ -1,0 +1,3 @@
+interface ImportMeta {
+  readonly env?: {readonly VITEST?: string | boolean};
+}

--- a/packages/datadog/src/env.d.ts
+++ b/packages/datadog/src/env.d.ts
@@ -1,0 +1,3 @@
+interface ImportMeta {
+  readonly env?: {readonly VITEST?: string | boolean};
+}

--- a/packages/otel/src/env.d.ts
+++ b/packages/otel/src/env.d.ts
@@ -1,0 +1,3 @@
+interface ImportMeta {
+  readonly env?: {readonly VITEST?: string | boolean};
+}

--- a/packages/replicache-perf/src/env.d.ts
+++ b/packages/replicache-perf/src/env.d.ts
@@ -1,0 +1,3 @@
+interface ImportMeta {
+  readonly env?: {readonly VITEST?: string | boolean};
+}

--- a/packages/replicache-perf/tool/build.ts
+++ b/packages/replicache-perf/tool/build.ts
@@ -9,7 +9,10 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 async function buildIndex(): Promise<void> {
   const minify = true;
-  const define = makeDefine('release');
+  const define = {
+    ...makeDefine('release'),
+    'import.meta.env': 'undefined',
+  };
   await esbuild.build({
     ...sharedOptions(minify),
     external: ['node:*', 'expo*'],

--- a/packages/replicache/src/db/write.test.ts
+++ b/packages/replicache/src/db/write.test.ts
@@ -513,7 +513,7 @@ test('putMany with large batch and indexes', async () => {
     for (let i = 0; i < 100; i++) {
       entries.push([
         `key${i.toString().padStart(3, '0')}`,
-        deepFreeze({id: i}),
+        deepFreeze({id: i.toString().padStart(3, '0')}),
       ]);
     }
 
@@ -536,9 +536,9 @@ test('putMany with large batch and indexes', async () => {
     );
 
     // Check some entries
-    expect(await w.get('key000')).toEqual({id: 0});
-    expect(await w.get('key050')).toEqual({id: 50});
-    expect(await w.get('key099')).toEqual({id: 99});
+    expect(await w.get('key000')).toEqual({id: '000'});
+    expect(await w.get('key050')).toEqual({id: '050'});
+    expect(await w.get('key099')).toEqual({id: '099'});
 
     // Count all entries to verify bulk load worked
     const allKeys = await asyncIterableToArray(w.map.keys());

--- a/packages/replicache/src/env.d.ts
+++ b/packages/replicache/src/env.d.ts
@@ -1,1 +1,3 @@
-import 'mocha';
+interface ImportMeta {
+  readonly env?: {readonly VITEST?: string | boolean};
+}

--- a/packages/replicache/src/replicache-impl.ts
+++ b/packages/replicache/src/replicache-impl.ts
@@ -8,6 +8,7 @@ import {getBrowserGlobal} from '../../shared/src/browser-env.ts';
 import {getDocumentVisibilityWatcher} from '../../shared/src/document-visible.ts';
 import type {JSONValue, ReadonlyJSONValue} from '../../shared/src/json.ts';
 import {promiseVoid} from '../../shared/src/resolved-promises.ts';
+import {TESTING} from '../../shared/src/testing.ts';
 import type {MaybePromise} from '../../shared/src/types.ts';
 import {PullDelegate, PushDelegate} from './connection-loop-delegates.ts';
 import {ConnectionLoop, MAX_DELAY_MS, MIN_DELAY_MS} from './connection-loop.ts';
@@ -127,8 +128,6 @@ import {
   withWrite,
   withWriteNoImplicitCommit,
 } from './with-transactions.ts';
-
-declare const TESTING: boolean;
 
 declare const process: {
   env: {

--- a/packages/replicache/src/replicache-mutation-recovery-dd31.test.ts
+++ b/packages/replicache/src/replicache-mutation-recovery-dd31.test.ts
@@ -33,6 +33,7 @@ import {
   initReplicacheTesting,
   replicacheForTesting,
   tickAFewTimes,
+  tickUntil,
 } from './test-util.ts';
 import {withRead, withWriteNoImplicitCommit} from './with-transactions.ts';
 
@@ -1493,7 +1494,7 @@ describe('DD31', () => {
 
   test('mutation recovery is invoked at startup', async () => {
     const rep = await replicacheForTesting('mutation-recovery-startup-dd31');
-    expect(rep.recoverMutationsFake).toHaveBeenCalledTimes(1);
+    await tickUntil(vi, () => rep.recoverMutationsFake.mock.calls.length >= 1);
     expect(rep.recoverMutationsFake).toHaveBeenCalledTimes(1);
     expect(await rep.recoverMutationsFake.mock.results[0].value).toBe(true);
   });
@@ -1509,6 +1510,7 @@ describe('DD31', () => {
         useDefaultURLs: false,
       },
     );
+    await tickUntil(vi, () => rep.recoverMutationsFake.mock.calls.length >= 1);
     expect(rep.recoverMutationsFake).toHaveBeenCalledTimes(1);
     expect(await rep.recoverMutationsFake.mock.results[0].value).toBe(false);
     expect(await rep.recoverMutations()).toBe(false);
@@ -1522,6 +1524,7 @@ describe('DD31', () => {
       },
       disableAllBackgroundProcesses,
     );
+    await tickUntil(vi, () => rep.recoverMutationsFake.mock.calls.length >= 1);
     expect(rep.recoverMutationsFake).toHaveBeenCalledTimes(1);
     expect(await rep.recoverMutationsFake.mock.results[0].value).toBe(false);
     expect(await rep.recoverMutations()).toBe(false);
@@ -1532,6 +1535,7 @@ describe('DD31', () => {
     const rep = await replicacheForTesting('mutation-recovery-online', {
       pullURL,
     });
+    await tickUntil(vi, () => rep.recoverMutationsFake.mock.calls.length >= 1);
     expect(rep.recoverMutationsFake).toHaveBeenCalledTimes(1);
     expect(rep.online).toBe(true);
 
@@ -1563,6 +1567,7 @@ describe('DD31', () => {
 
   test('mutation recovery is invoked on 5 minute interval', async () => {
     const rep = await replicacheForTesting('mutation-recovery-startup-dd31-4');
+    await tickUntil(vi, () => rep.recoverMutationsFake.mock.calls.length >= 1);
     expect(rep.recoverMutationsFake).toHaveBeenCalledTimes(1);
     await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
     expect(rep.recoverMutationsFake).toHaveBeenCalledTimes(2);

--- a/packages/replicache/tool/build.ts
+++ b/packages/replicache/tool/build.ts
@@ -27,7 +27,10 @@ function basePath(...parts: string[]): string {
 }
 
 async function buildReplicache(options: BuildOptions) {
-  const define = makeDefine(options.mode);
+  const define = {
+    ...makeDefine(options.mode),
+    'import.meta.env': 'undefined',
+  };
   const {ext, mode, external, ...restOfOptions} = options;
   const outfile = basePath('out', 'replicache.' + ext);
   const entryPoints = {

--- a/packages/replicache/tool/build.ts
+++ b/packages/replicache/tool/build.ts
@@ -29,7 +29,7 @@ function basePath(...parts: string[]): string {
 async function buildReplicache(options: BuildOptions) {
   const define = {
     ...makeDefine(options.mode),
-    'import.meta.env': 'undefined',
+    ...(forBundleSizeDashboard ? {'import.meta.env': 'undefined'} : {}),
   };
   const {ext, mode, external, ...restOfOptions} = options;
   const outfile = basePath('out', 'replicache.' + ext);

--- a/packages/replicache/tsconfig.build.json
+++ b/packages/replicache/tsconfig.build.json
@@ -11,6 +11,7 @@
     "src/impl.ts",
     "src/expo-sqlite.ts",
     "src/op-sqlite.ts",
-    "src/sqlite.ts"
+    "src/sqlite.ts",
+    "../shared/src/env.d.ts"
   ]
 }

--- a/packages/shared/src/build.ts
+++ b/packages/shared/src/build.ts
@@ -50,7 +50,6 @@ export function makeDefine(
     ),
     ['process.env.ZERO_VERSION']: JSON.stringify(getVersion('zero')),
     ['process.env.DISABLE_MUTATION_RECOVERY']: 'false',
-    ['TESTING']: 'false',
   };
   if (mode === 'unknown') {
     return define;

--- a/packages/shared/src/env.d.ts
+++ b/packages/shared/src/env.d.ts
@@ -1,0 +1,3 @@
+interface ImportMeta {
+  readonly env?: {readonly VITEST?: string | boolean};
+}

--- a/packages/shared/src/testing.ts
+++ b/packages/shared/src/testing.ts
@@ -1,0 +1,7 @@
+import {assert} from './asserts.ts';
+
+export const TESTING = import.meta.env?.VITEST;
+
+export function assertTesting(msg = 'Expected to be in test mode'): void {
+  assert(TESTING, msg);
+}

--- a/packages/shared/src/tool/vitest-config.ts
+++ b/packages/shared/src/tool/vitest-config.ts
@@ -24,6 +24,7 @@ assertValidBrowser(VITEST_BROWSER);
 
 const define = {
   ...makeDefine(),
+  'import.meta.env.VITEST': 'true',
 };
 
 const logSilenceMessages = [

--- a/packages/shared/src/tool/vitest-config.ts
+++ b/packages/shared/src/tool/vitest-config.ts
@@ -24,7 +24,6 @@ assertValidBrowser(VITEST_BROWSER);
 
 const define = {
   ...makeDefine(),
-  ['TESTING']: 'true',
 };
 
 const logSilenceMessages = [

--- a/packages/z2s/src/env.d.ts
+++ b/packages/z2s/src/env.d.ts
@@ -1,0 +1,3 @@
+interface ImportMeta {
+  readonly env?: {readonly VITEST?: string | boolean};
+}

--- a/packages/zero-cache/src/env.d.ts
+++ b/packages/zero-cache/src/env.d.ts
@@ -1,0 +1,3 @@
+interface ImportMeta {
+  readonly env?: {readonly VITEST?: string | boolean};
+}

--- a/packages/zero-client/src/client/test-utils.ts
+++ b/packages/zero-client/src/client/test-utils.ts
@@ -5,6 +5,7 @@ import type {Store} from '../../../replicache/src/dag/store.ts';
 import {assert} from '../../../shared/src/asserts.ts';
 import type {JSONValue, ReadonlyJSONValue} from '../../../shared/src/json.ts';
 import {TestLogSink} from '../../../shared/src/logging-test-utils.ts';
+import {assertTesting} from '../../../shared/src/testing.ts';
 import type {ConnectedMessage} from '../../../zero-protocol/src/connect.ts';
 import type {Downstream} from '../../../zero-protocol/src/down.ts';
 import type {
@@ -118,12 +119,12 @@ export class TestZero<
   }
 
   get connectionStatus(): ConnectionStatus {
-    assert(TESTING, 'Expected TESTING to be true');
+    assertTesting();
     return this[exposedToTestingSymbol].connectionManager().state.name;
   }
 
   get connectionState(): ConnectionManagerState {
-    assert(TESTING, 'Expected TESTING to be true');
+    assertTesting();
     return this[exposedToTestingSymbol].connectionManager().state;
   }
 
@@ -151,7 +152,7 @@ export class TestZero<
   }
 
   [createLogOptionsSymbol](options: {consoleLogLevel: LogLevel}): LogOptions {
-    assert(TESTING, 'Expected TESTING to be true');
+    assertTesting();
     return {
       logLevel: options.consoleLogLevel,
       logSink: new TestLogSink(),
@@ -159,7 +160,7 @@ export class TestZero<
   }
 
   get testLogSink(): TestLogSink {
-    assert(TESTING, 'Expected TESTING to be true');
+    assertTesting();
     const {logSink} = this[exposedToTestingSymbol].logOptions;
     assert(
       logSink instanceof TestLogSink,
@@ -284,22 +285,22 @@ export class TestZero<
   declare [exposedToTestingSymbol]: TestingContext;
 
   get pusher() {
-    assert(TESTING, 'Expected TESTING to be true');
+    assertTesting();
     return this[exposedToTestingSymbol].pusher;
   }
 
   get puller() {
-    assert(TESTING, 'Expected TESTING to be true');
+    assertTesting();
     return this[exposedToTestingSymbol].puller;
   }
 
   set reload(r: () => void) {
-    assert(TESTING, 'Expected TESTING to be true');
+    assertTesting();
     this[exposedToTestingSymbol].setReload(r);
   }
 
   get queryDelegate() {
-    assert(TESTING, 'Expected TESTING to be true');
+    assertTesting();
     return this[exposedToTestingSymbol].queryDelegate();
   }
 
@@ -330,7 +331,7 @@ export class TestZero<
    * want to simulate that all queries have been fully synced from the server.
    */
   async markAllQueriesAsGot(): Promise<void> {
-    assert(TESTING, 'Expected TESTING to be true');
+    assertTesting();
     const queryManager = this[exposedToTestingSymbol].queryManager();
     const gotQueriesPatch = Array.from(
       queryManager.getAllNonGotQueryHashes(),
@@ -348,8 +349,6 @@ export class TestZero<
     await this.triggerPoke({gotQueriesPatch});
   }
 }
-
-declare const TESTING: boolean;
 
 let testZeroCounter = 0;
 

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -37,6 +37,7 @@ import {promiseRace} from '../../../shared/src/promise-race.ts';
 import {emptyFunction} from '../../../shared/src/sentinels.ts';
 import {sleep, sleepWithAbort} from '../../../shared/src/sleep.ts';
 import {Subscribable} from '../../../shared/src/subscribable.ts';
+import {assertTesting, TESTING} from '../../../shared/src/testing.ts';
 import * as valita from '../../../shared/src/valita.ts';
 import type {Writable} from '../../../shared/src/writable.ts';
 import {type ClientSchema} from '../../../zero-protocol/src/client-schema.ts';
@@ -188,8 +189,6 @@ import {
 
 export type NoRelations = Record<string, never>;
 
-declare const TESTING: boolean;
-
 export type TestingContext = {
   puller: Puller;
   pusher: Pusher;
@@ -307,7 +306,7 @@ const internalReplicacheImplMap = new WeakMap<object, ReplicacheImpl>();
 export function getInternalReplicacheImplForTesting(
   z: object,
 ): ReplicacheImpl<MutatorDefs> {
-  assert(TESTING, 'Expected TESTING to be true');
+  assertTesting();
   return must(internalReplicacheImplMap.get(z));
 }
 

--- a/packages/zero-client/src/env.d.ts
+++ b/packages/zero-client/src/env.d.ts
@@ -1,1 +1,3 @@
-import 'mocha';
+interface ImportMeta {
+  readonly env?: {readonly VITEST?: string | boolean};
+}

--- a/packages/zero-events/src/env.d.ts
+++ b/packages/zero-events/src/env.d.ts
@@ -1,0 +1,3 @@
+interface ImportMeta {
+  readonly env?: {readonly VITEST?: string | boolean};
+}

--- a/packages/zero-pg/src/env.d.ts
+++ b/packages/zero-pg/src/env.d.ts
@@ -1,0 +1,3 @@
+interface ImportMeta {
+  readonly env?: {readonly VITEST?: string | boolean};
+}

--- a/packages/zero-protocol/src/env.d.ts
+++ b/packages/zero-protocol/src/env.d.ts
@@ -1,0 +1,3 @@
+interface ImportMeta {
+  readonly env?: {readonly VITEST?: string | boolean};
+}

--- a/packages/zero-react-native/src/env.d.ts
+++ b/packages/zero-react-native/src/env.d.ts
@@ -1,0 +1,3 @@
+interface ImportMeta {
+  readonly env?: {readonly VITEST?: string | boolean};
+}

--- a/packages/zero-react/src/env.d.ts
+++ b/packages/zero-react/src/env.d.ts
@@ -1,0 +1,3 @@
+interface ImportMeta {
+  readonly env?: {readonly VITEST?: string | boolean};
+}

--- a/packages/zero-react/src/use-query.tsx
+++ b/packages/zero-react/src/use-query.tsx
@@ -1,5 +1,6 @@
 import {resolver} from '@rocicorp/resolver';
 import React, {useSyncExternalStore} from 'react';
+import {TESTING} from '../../shared/src/testing.ts';
 import {
   type Immutable,
   addContextToQuery,
@@ -344,8 +345,6 @@ function makeError(retry: () => void, error: ErroredQuery): QueryErrorDetails {
     },
   };
 }
-
-declare const TESTING: boolean;
 
 // oxlint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyViewWrapper = ViewWrapper<any, any, any, any, any>;

--- a/packages/zero-schema/src/env.d.ts
+++ b/packages/zero-schema/src/env.d.ts
@@ -1,0 +1,3 @@
+interface ImportMeta {
+  readonly env?: {readonly VITEST?: string | boolean};
+}

--- a/packages/zero-server/src/env.d.ts
+++ b/packages/zero-server/src/env.d.ts
@@ -1,0 +1,3 @@
+interface ImportMeta {
+  readonly env?: {readonly VITEST?: string | boolean};
+}

--- a/packages/zero-solid/src/env.d.ts
+++ b/packages/zero-solid/src/env.d.ts
@@ -1,0 +1,3 @@
+interface ImportMeta {
+  readonly env?: {readonly VITEST?: string | boolean};
+}

--- a/packages/zero-types/src/env.d.ts
+++ b/packages/zero-types/src/env.d.ts
@@ -1,0 +1,3 @@
+interface ImportMeta {
+  readonly env?: {readonly VITEST?: string | boolean};
+}

--- a/packages/zero/src/env.d.ts
+++ b/packages/zero/src/env.d.ts
@@ -1,0 +1,3 @@
+interface ImportMeta {
+  readonly env?: {readonly VITEST?: string | boolean};
+}

--- a/packages/zero/tsconfig.client.json
+++ b/packages/zero/tsconfig.client.json
@@ -8,6 +8,7 @@
     "src/react-native.ts",
     "src/sqlite.ts",
     "src/expo-sqlite.ts",
-    "src/op-sqlite.ts"
+    "src/op-sqlite.ts",
+    "../shared/src/env.d.ts"
   ]
 }

--- a/packages/zero/tsconfig.server.json
+++ b/packages/zero/tsconfig.server.json
@@ -15,6 +15,7 @@
     "src/analyze-query.ts",
     "src/analyze.ts",
     "src/transform-query.ts",
-    "src/zero-out.ts"
+    "src/zero-out.ts",
+    "../shared/src/env.d.ts"
   ]
 }

--- a/packages/zql-benchmarks/src/env.d.ts
+++ b/packages/zql-benchmarks/src/env.d.ts
@@ -1,0 +1,3 @@
+interface ImportMeta {
+  readonly env?: {readonly VITEST?: string | boolean};
+}

--- a/packages/zql-integration-tests/src/env.d.ts
+++ b/packages/zql-integration-tests/src/env.d.ts
@@ -1,0 +1,3 @@
+interface ImportMeta {
+  readonly env?: {readonly VITEST?: string | boolean};
+}

--- a/packages/zql/src/env.d.ts
+++ b/packages/zql/src/env.d.ts
@@ -1,0 +1,3 @@
+interface ImportMeta {
+  readonly env?: {readonly VITEST?: string | boolean};
+}

--- a/packages/zql/src/ivm/constraint.ts
+++ b/packages/zql/src/ivm/constraint.ts
@@ -1,5 +1,6 @@
 import {assert} from '../../../shared/src/asserts.ts';
 import {stringCompare} from '../../../shared/src/string-compare.ts';
+import {assertTesting} from '../../../shared/src/testing.ts';
 import type {Writable} from '../../../shared/src/writable.ts';
 import type {
   Condition,
@@ -158,14 +159,11 @@ function extractColumn(
   return undefined;
 }
 
-declare const TESTING: boolean;
-
 export class SetOfConstraint {
   #data: Constraint[] = [];
 
   constructor() {
-    // Only used in testing
-    assert(TESTING, 'SetOfConstraint is only available in testing');
+    assertTesting('SetOfConstraint is only available in testing');
   }
 
   #indexOf(value: Constraint): number {

--- a/packages/zql/tool/build.ts
+++ b/packages/zql/tool/build.ts
@@ -29,7 +29,7 @@ async function buildPackages() {
     platform: 'browser',
     define: {
       ...define,
-      ['TESTING']: 'false',
+      'import.meta.env': 'undefined',
     },
     format: 'esm',
     entryPoints: [basePath('src', 'index.ts')],

--- a/packages/zql/tool/build.ts
+++ b/packages/zql/tool/build.ts
@@ -27,10 +27,7 @@ async function buildPackages() {
     ...shared,
     external: await getExternalFromPackageJSON(import.meta.url),
     platform: 'browser',
-    define: {
-      ...define,
-      'import.meta.env': 'undefined',
-    },
+    define,
     format: 'esm',
     entryPoints: [basePath('src', 'index.ts')],
     bundle: true,

--- a/packages/zqlite-zql-test/src/env.d.ts
+++ b/packages/zqlite-zql-test/src/env.d.ts
@@ -1,0 +1,3 @@
+interface ImportMeta {
+  readonly env?: {readonly VITEST?: string | boolean};
+}

--- a/packages/zqlite/src/env.d.ts
+++ b/packages/zqlite/src/env.d.ts
@@ -1,0 +1,3 @@
+interface ImportMeta {
+  readonly env?: {readonly VITEST?: string | boolean};
+}


### PR DESCRIPTION
Vitest sets import.meta.env.VITEST natively, so the custom esbuild-injected TESTING global is redundant. Centralizes TESTING and assertTesting() in packages/shared/src/testing.ts. Esbuild build scripts define 'import.meta.env' as 'undefined' for dead-code elimination in production.