### PR TITLE
fix(zero-cache): improve resolution of latency histograms

### DIFF
--- a/packages/zero-cache/src/observability/metrics.ts
+++ b/packages/zero-cache/src/observability/metrics.ts
@@ -75,8 +75,7 @@ export function getOrCreateUpDownCounter(
  * durations and converts them to seconds internally.
  *
  * Use {@link getOrCreateLatencyHistogram} to create one — the unit (`'s'`),
- * bucket boundaries, and ms→s conversion are all baked in and cannot be
- * forgotten.
+ * bucket boundaries, and ms→s conversion are all baked in
  */
 export type LatencyHistogram = {
   /**
@@ -98,13 +97,14 @@ export type LatencyHistogram = {
  * The operational range is 1 ms – 5,000 ms (including customers actively
  * tuning queries). ~2× logarithmic steps give proportionally consistent
  * `histogram_quantile` accuracy regardless of where values cluster within
- * that range. 10,000 ms is an overflow catcher for truly broken states.
+ * that range. 10,000 ms and 30,000 ms are overflow catchers for truly broken
+ * states.
  *
  *   1 ms, 2 ms, 5 ms, 10 ms, 20 ms, 50 ms, 100 ms, 200 ms, 500 ms,
- *   1 s, 2 s, 5 s, 10 s
+ *   1 s, 2 s, 5 s, 10 s, 30 s
  */
 const LATENCY_HISTOGRAM_BOUNDARIES_S = [
-  0.001, 0.002, 0.005, 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10,
+  0.001, 0.002, 0.005, 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30,
 ];
 
 const latencyHistograms = cache<Histogram>();
@@ -140,10 +140,10 @@ export function getOrCreateLatencyHistogram(
     }),
   );
   return {
-    recordMs: (durationMs, attributes) => h.record(durationMs / 1000, attributes),
+    recordMs: (durationMs, attributes) =>
+      h.record(durationMs / 1000, attributes),
   };
 }
-
 
 const counters = cache<Counter>();
 

--- a/packages/zero-cache/src/observability/metrics.ts
+++ b/packages/zero-cache/src/observability/metrics.ts
@@ -20,7 +20,6 @@ export type Category =
 let meter: Meter | undefined;
 
 type Options = MetricOptions & {description: string};
-type OptionsWithUnit = MetricOptions & {description: string; unit: string};
 
 function getMeter() {
   if (!meter) {
@@ -71,35 +70,80 @@ export function getOrCreateUpDownCounter(
   );
 }
 
-const histograms = cache<Histogram>();
+/**
+ * A latency histogram whose {@link recordMs} method accepts raw millisecond
+ * durations and converts them to seconds internally.
+ *
+ * Use {@link getOrCreateLatencyHistogram} to create one — the unit (`'s'`),
+ * bucket boundaries, and ms→s conversion are all baked in and cannot be
+ * forgotten.
+ */
+export type LatencyHistogram = {
+  /**
+   * Record a duration. Pass the raw elapsed milliseconds — the conversion to
+   * seconds (required by the `unit: 's'` OTel histogram) is handled internally.
+   *
+   * @param durationMs  Elapsed time in **milliseconds** (do NOT pre-divide).
+   * @param attributes  Optional OTel attributes to attach to the observation.
+   */
+  recordMs(
+    durationMs: number,
+    attributes?: Parameters<Histogram['record']>[1],
+  ): void;
+};
 
-export function getOrCreateHistogram(
+/**
+ * Bucket boundaries (in seconds) for zero's latency histograms.
+ *
+ * The operational range is 1 ms – 5,000 ms (including customers actively
+ * tuning queries). ~2× logarithmic steps give proportionally consistent
+ * `histogram_quantile` accuracy regardless of where values cluster within
+ * that range. 10,000 ms is an overflow catcher for truly broken states.
+ *
+ *   1 ms, 2 ms, 5 ms, 10 ms, 20 ms, 50 ms, 100 ms, 200 ms, 500 ms,
+ *   1 s, 2 s, 5 s, 10 s
+ */
+const LATENCY_HISTOGRAM_BOUNDARIES_S = [
+  0.001, 0.002, 0.005, 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10,
+];
+
+const latencyHistograms = cache<Histogram>();
+
+/**
+ * Creates (or retrieves) a latency histogram for the given metric.
+ *
+ * - `unit` is always `'s'` (seconds), matching the OTel convention.
+ * - Bucket boundaries are pre-set for zero's typical operation range
+ *   (1 ms – 5 s); see {@link LATENCY_HISTOGRAM_BOUNDARIES_S}.
+ * - The returned {@link LatencyHistogram} accepts **milliseconds** via
+ *   `recordMs()`, so callers never need to divide by 1000.
+ *
+ * @example
+ * ```ts
+ * readonly #hydrationTime = getOrCreateLatencyHistogram(
+ *   'sync', 'hydration-time', 'Time to hydrate a query.',
+ * );
+ * // ...
+ * this.#hydrationTime.recordMs(performance.now() - start);
+ * ```
+ */
+export function getOrCreateLatencyHistogram(
   category: Category,
   name: string,
   description: string,
-): Histogram;
-export function getOrCreateHistogram(
-  category: Category,
-  name: string,
-  options: OptionsWithUnit,
-): Histogram;
-export function getOrCreateHistogram(
-  category: Category,
-  name: string,
-  opts: string | OptionsWithUnit,
-): Histogram {
-  return histograms(name, name => {
-    const options: {description: string; unit: string; boundaries?: number[]} =
-      typeof opts === 'string'
-        ? {
-            description: opts,
-            unit: 'milliseconds',
-          }
-        : opts;
-
-    return getMeter().createHistogram(`zero.${category}.${name}`, options);
-  });
+): LatencyHistogram {
+  const h = latencyHistograms(name, name =>
+    getMeter().createHistogram(`zero.${category}.${name}`, {
+      description,
+      unit: 's',
+      boundaries: LATENCY_HISTOGRAM_BOUNDARIES_S,
+    }),
+  );
+  return {
+    recordMs: (durationMs, attributes) => h.record(durationMs / 1000, attributes),
+  };
 }
+
 
 const counters = cache<Counter>();
 

--- a/packages/zero-cache/src/observability/metrics.ts
+++ b/packages/zero-cache/src/observability/metrics.ts
@@ -136,7 +136,9 @@ export function getOrCreateLatencyHistogram(
     getMeter().createHistogram(`zero.${category}.${name}`, {
       description,
       unit: 's',
-      boundaries: LATENCY_HISTOGRAM_BOUNDARIES_S,
+      advice: {
+        explicitBucketBoundaries: LATENCY_HISTOGRAM_BOUNDARIES_S,
+      },
     }),
   );
   return {

--- a/packages/zero-cache/src/services/view-syncer/client-handler.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.ts
@@ -26,7 +26,7 @@ import {mutationResultSchema} from '../../../../zero-protocol/src/push.ts';
 import type {RowPatchOp} from '../../../../zero-protocol/src/row-patch.ts';
 import {
   getOrCreateCounter,
-  getOrCreateHistogram,
+  getOrCreateLatencyHistogram,
 } from '../../observability/metrics.ts';
 import {
   getLogLevel,
@@ -121,11 +121,11 @@ export class ClientHandler {
   readonly #downstream: Subscription<Downstream>;
   #baseVersion: NullableCVRVersion;
 
-  readonly #pokeTime = getOrCreateHistogram('sync', 'poke.time', {
-    description:
-      'Time elapsed for each poke transaction. Canceled / noop pokes are excluded.',
-    unit: 's',
-  });
+  readonly #pokeTime = getOrCreateLatencyHistogram(
+    'sync',
+    'poke.time',
+    'Time elapsed for each poke transaction. Canceled / noop pokes are excluded.',
+  );
 
   readonly #pokeTransactions = getOrCreateCounter(
     'sync',
@@ -328,7 +328,7 @@ export class ClientHandler {
 
         const elapsed = performance.now() - start;
         this.#pokeTransactions.add(1);
-        this.#pokeTime.record(elapsed / 1000);
+        this.#pokeTime.recordMs(elapsed);
       },
     };
   }

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -48,7 +48,7 @@ import {computeZqlSpecs, mustGetTableSpec} from '../../db/lite-tables.ts';
 import type {LiteAndZqlSpec, LiteTableSpec} from '../../db/specs.ts';
 import {
   getOrCreateCounter,
-  getOrCreateHistogram,
+  getOrCreateLatencyHistogram,
 } from '../../observability/metrics.ts';
 import type {InspectorDelegate} from '../../server/inspector-delegate.ts';
 import {type RowKey} from '../../types/row-key.ts';
@@ -153,11 +153,11 @@ export class PipelineDriver {
   #primaryKeys: Map<string, PrimaryKey> | null = null;
   #permissions: LoadedPermissions | null = null;
 
-  readonly #advanceTime = getOrCreateHistogram('sync', 'ivm.advance-time', {
-    description:
-      'Time to advance all queries for a given client group for in response to a single change.',
-    unit: 's',
-  });
+  readonly #advanceTime = getOrCreateLatencyHistogram(
+    'sync',
+    'ivm.advance-time',
+    'Time to advance all queries for a given client group in response to a single change.',
+  );
 
   readonly #conflictRowsDeleted = getOrCreateCounter(
     'sync',
@@ -751,7 +751,7 @@ export class PipelineDriver {
         }
 
         const elapsed = timer.totalElapsed() - start;
-        this.#advanceTime.record(elapsed / 1000, {
+        this.#advanceTime.recordMs(elapsed, {
           table,
           type,
         });

--- a/packages/zero-cache/src/services/view-syncer/row-record-cache.ts
+++ b/packages/zero-cache/src/services/view-syncer/row-record-cache.ts
@@ -10,7 +10,7 @@ import {runTx} from '../../db/run-transaction.ts';
 import {TransactionPool} from '../../db/transaction-pool.ts';
 import {
   getOrCreateCounter,
-  getOrCreateHistogram,
+  getOrCreateLatencyHistogram,
 } from '../../observability/metrics.ts';
 import {type PostgresDB, type PostgresTransaction} from '../../types/pg.ts';
 import {rowIDString} from '../../types/row-key.ts';
@@ -104,12 +104,12 @@ export class RowRecordCache {
   #flushedRowsVersion: CVRVersion | null = null;
   #flushing: Resolver<void> | null = null;
 
-  readonly #cvrFlushTime = getOrCreateHistogram('sync', 'cvr.flush-time', {
-    description:
-      'Time to flush a CVR transaction. This includes both synchronous ' +
-      'and asynchronous flushes, distinguished by the flush.type attribute',
-    unit: 's',
-  });
+  readonly #cvrFlushTime = getOrCreateLatencyHistogram(
+    'sync',
+    'cvr.flush-time',
+    'Time to flush a CVR transaction. This includes both synchronous ' +
+      'and asynchronous flushes, distinguished by the flush.type attribute.',
+  );
   readonly #cvrRowsFlushed = getOrCreateCounter(
     'sync',
     'cvr.rows-flushed',
@@ -135,7 +135,7 @@ export class RowRecordCache {
   }
 
   recordSyncFlushStats(stats: CVRFlushStats, elapsedMs: number) {
-    this.#cvrFlushTime.record(elapsedMs / 1000, {
+    this.#cvrFlushTime.recordMs(elapsedMs, {
       [FLUSH_TYPE_ATTRIBUTE]: 'sync',
     });
     if (stats.rowsDeferred === 0) {
@@ -144,7 +144,7 @@ export class RowRecordCache {
   }
 
   #recordAsyncFlushStats(rows: number, elapsedMs: number) {
-    this.#cvrFlushTime.record(elapsedMs / 1000, {
+    this.#cvrFlushTime.recordMs(elapsedMs, {
       [FLUSH_TYPE_ATTRIBUTE]: 'async',
     });
     this.#cvrRowsFlushed.add(rows);

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -47,7 +47,7 @@ import type {
 } from '../../custom-queries/transform-query.ts';
 import {
   getOrCreateCounter,
-  getOrCreateHistogram,
+  getOrCreateLatencyHistogram,
   getOrCreateUpDownCounter,
 } from '../../observability/metrics.ts';
 import type {InspectorDelegate} from '../../server/inspector-delegate.ts';
@@ -263,31 +263,25 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     'hydration',
     'Number of query hydrations',
   );
-  readonly #hydrationTime = getOrCreateHistogram('sync', 'hydration-time', {
-    description: 'Time to hydrate a query.',
-    unit: 's',
-  });
-  readonly #transactionAdvanceTime = getOrCreateHistogram(
+  readonly #hydrationTime = getOrCreateLatencyHistogram(
+    'sync',
+    'hydration-time',
+    'Time to hydrate a query.',
+  );
+  readonly #transactionAdvanceTime = getOrCreateLatencyHistogram(
     'sync',
     'advance-time',
-    {
-      description:
-        'Time to advance all queries for a given client group after applying a new transaction to the replica.',
-      unit: 's',
-    },
+    'Time to advance all queries for a given client group after applying a new transaction to the replica.',
   );
   readonly #queryTransformations = getOrCreateCounter(
     'sync',
     'query.transformations',
     'Number of query transformations performed',
   );
-  readonly #queryTransformationTime = getOrCreateHistogram(
+  readonly #queryTransformationTime = getOrCreateLatencyHistogram(
     'sync',
     'query.transformation-time',
-    {
-      description: 'Time to transform custom queries via API server',
-      unit: 's',
-    },
+    'Time to transform custom queries via API server.',
   );
   readonly #queryTransformationHashChanges = getOrCreateCounter(
     'sync',
@@ -299,10 +293,11 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     'query.transformation-no-ops',
     'Number of times query transformation resulted in no-op (hash unchanged)',
   );
-  readonly #lockWaitTime = getOrCreateHistogram('sync', 'lock-wait-time', {
-    description: 'Time spent waiting to acquire the ViewSyncer lock.',
-    unit: 's',
-  });
+  readonly #lockWaitTime = getOrCreateLatencyHistogram(
+    'sync',
+    'lock-wait-time',
+    'Time spent waiting to acquire the ViewSyncer lock.',
+  );
   readonly #pipelineResets = getOrCreateCounter(
     'sync',
     'pipeline-resets',
@@ -375,7 +370,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     this.#lc.debug?.('about to acquire lock for cvr ', rid);
     const lockWaitStart = performance.now();
     return this.#lock.withLock(async () => {
-      this.#lockWaitTime.record((performance.now() - lockWaitStart) / 1000);
+      this.#lockWaitTime.recordMs(performance.now() - lockWaitStart);
       this.#lc.debug?.('acquired lock in #runInLockWithCVR ', rid);
       const lc = this.#lc.withContext('lock', rid);
       if (!this.#stateChanges.active) {
@@ -1470,7 +1465,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
       const elapsed = timer.totalElapsed();
       this.#hydrations.add(1);
-      this.#hydrationTime.record(elapsed / 1000);
+      this.#hydrationTime.recordMs(elapsed);
       this.#addQueryMaterializationServerMetric(transformationHash, elapsed);
       lc.debug?.(`hydrated ${count} rows for ${queryID} (${elapsed} ms)`);
     }
@@ -1698,8 +1693,8 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           this.#queryTransformations.add(1, {result: 'error'});
           throw e;
         } finally {
-          const transformDuration = (performance.now() - transformStart) / 1000;
-          this.#queryTransformationTime.record(transformDuration);
+          const transformDuration = performance.now() - transformStart;
+          this.#queryTransformationTime.recordMs(transformDuration);
         }
 
         // Process the transformed queries and track which ones succeeded.
@@ -1927,7 +1922,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           });
         }
         hydrations.add(1);
-        hydrationTime.record(totalProcessTime / 1000);
+        hydrationTime.recordMs(totalProcessTime);
       }
       // #processChanges does batched de-duping of rows. Wrap all pipelines in
       // a single generator in order to maximize de-duping.
@@ -2233,7 +2228,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       lc.info?.(
         `finished processing advancement of ${numChanges} changes ((process: ${totalProcessTime} ms, wall: ${wallTime} ms))`,
       );
-      this.#transactionAdvanceTime.record(totalProcessTime / 1000);
+      this.#transactionAdvanceTime.recordMs(totalProcessTime);
       return 'success';
     });
   }


### PR DESCRIPTION
## Fix histogram bucket boundaries for latency metrics

All latency histograms (`hydration-time`, `advance-time`, `ivm.advance-time`, `lock-wait-time`, `query.transformation-time`, `poke.time`, `cvr.flush-time`) were using OTel's default bucket boundaries (`[0, 5, 10, 25, …, 10000]` seconds). Since our operations typically complete in 1–5000ms, 100% of observations landed in the first bucket, producing flat useless quantile lines.

**Fix:**
- Introduce `getOrCreateLatencyHistogram()` → `LatencyHistogram` with a `recordMs()` method that bakes in `unit: 's'`, appropriate bucket boundaries, and the ms→s conversion — making it impossible for future metrics to repeat this mistake.
- Delete the now-unused `getOrCreateHistogram()` so there's no footgun to reach for.
- Migrate all 7 latency histograms to the new API.

Bucket set: `1ms, 2ms, 5ms, 10ms, 20ms, 50ms, 100ms, 200ms, 500ms, 1s, 2s, 5s, 10s, 30s`
