### PR TITLE
fix(zero-cache): handle PG array defaults in ALTER TABLE ADD COLUMN

### DIFF
--- a/packages/zero-cache/src/db/pg-to-lite.test.ts
+++ b/packages/zero-cache/src/db/pg-to-lite.test.ts
@@ -414,6 +414,10 @@ test.each([
   ['CURRENT_TIMESTAMP'],
   ['Current_Time'],
   ['current_DATE'],
+  // Non-empty array constructors are unsupported (trigger backfill path)
+  ["ARRAY['foo']::text[]"],
+  ["ARRAY['a','b']::text[]"],
+  ['ARRAY[1,2]::integer[]'],
 ])('unsupported column default %s', value => {
   expect(() =>
     mapPostgresToLiteDefault('foo', 'bar', 'boolean', value),
@@ -425,6 +429,12 @@ test.each([
   ['true', '1', 'boolean'],
   ['false', '0', 'boolean'],
   ["'12345678901234567890'::bigint", "'12345678901234567890'", 'int8'],
+  // Empty PG array constructors map to JSON empty array string literal
+  ['ARRAY[]::text[]', "'[]'", 'text[]'],
+  ['ARRAY[]::integer[]', "'[]'", 'integer[]'],
+  ['array[]::text[]', "'[]'", 'text[]'],
+  ['ARRAY[ ]::text[]', "'[]'", 'text[]'],
+  ['ARRAY [  ]::text[]', "'[]'", 'text[]'],
 ])('supported column default %s', (input, output, dataType) => {
   expect(mapPostgresToLiteDefault('foo', 'bar', dataType, input)).toEqual(
     output,

--- a/packages/zero-cache/src/db/pg-to-lite.ts
+++ b/packages/zero-cache/src/db/pg-to-lite.ts
@@ -97,7 +97,7 @@ export function mapPostgresToLiteDefault(
   }
   if (UNSUPPORTED_TOKENS.test(defaultExpression)) {
     throw new UnsupportedColumnDefaultError(
-      `Cannot ADD a column with CURRENT_TIME, CURRENT_DATE, or CURRENT_TIMESTAMP`,
+      `Cannot ADD a column with CURRENT_TIME, CURRENT_DATE, or CURRENT_TIMESTAMP for ${table}.${column}`,
     );
   }
   if (ARRAY_CONSTRUCTOR_REGEX.test(defaultExpression)) {

--- a/packages/zero-cache/src/db/pg-to-lite.ts
+++ b/packages/zero-cache/src/db/pg-to-lite.ts
@@ -78,6 +78,13 @@ const UNSUPPORTED_TOKENS = /\b(current_time|current_date|current_timestamp)\b/i;
 // care about them.
 const STRING_EXPRESSION_REGEX = /^('.*')::[^']+$/;
 
+// PostgreSQL array constructor expressions, e.g. `ARRAY[]::text[]`,
+// `ARRAY['a','b']::text[]`. The empty form is stored as a JSON empty array
+// string literal in SQLite. Non-empty forms are unsupported and trigger
+// the backfill path.
+const ARRAY_CONSTRUCTOR_REGEX = /^ARRAY\s*\[/i;
+const EMPTY_ARRAY_CONSTRUCTOR_REGEX = /^ARRAY\s*\[\s*\]/i;
+
 // Exported for testing.
 export function mapPostgresToLiteDefault(
   table: string,
@@ -91,6 +98,15 @@ export function mapPostgresToLiteDefault(
   if (UNSUPPORTED_TOKENS.test(defaultExpression)) {
     throw new UnsupportedColumnDefaultError(
       `Cannot ADD a column with CURRENT_TIME, CURRENT_DATE, or CURRENT_TIMESTAMP`,
+    );
+  }
+  if (ARRAY_CONSTRUCTOR_REGEX.test(defaultExpression)) {
+    if (EMPTY_ARRAY_CONSTRUCTOR_REGEX.test(defaultExpression)) {
+      // ARRAY[]::text[] → store as JSON empty array string
+      return `'[]'`;
+    }
+    throw new UnsupportedColumnDefaultError(
+      `Unsupported default value for ${table}.${column}: ${defaultExpression}`,
     );
   }
   if (SIMPLE_TOKEN_EXPRESSION_REGEX.test(defaultExpression)) {

--- a/packages/zero-cache/src/services/replicator/change-processor.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.ts
@@ -603,9 +603,42 @@ class TransactionProcessor {
     const table = liteTableName(msg.table);
     const {name} = msg.column;
     const spec = mapPostgresToLiteColumn(table, msg.column);
-    this.#db.db.exec(
-      `ALTER TABLE ${id(table)} ADD ${id(name)} ${liteColumnDef(spec)}`,
-    );
+    const ddl = `ALTER TABLE ${id(table)} ADD ${id(name)} ${liteColumnDef(spec)}`;
+    try {
+      this.#db.db.exec(ddl);
+    } catch (e) {
+      if (e instanceof SqliteError) {
+        if (
+          e.code === 'SQLITE_ERROR' &&
+          e.message.includes('duplicate column name')
+        ) {
+          // The column was already added (e.g. crash after exec but before
+          // watermark update). Log and continue — this is idempotent.
+          this.#lc.warn?.(
+            `Column ${table}.${name} already exists, skipping ADD`,
+          );
+        } else if (spec.dflt !== null) {
+          // The DEFAULT clause may have contained an expression that SQLite
+          // rejected (e.g. a PG-specific syntax that slipped through). Retry
+          // without the DEFAULT so the column is at least added.
+          //
+          // This is safe because mapPostgresToLiteColumn always returns
+          // notNull: false for SQLite replica columns, so SQLite will accept
+          // ADD COLUMN without a DEFAULT (a NOT NULL column without a default
+          // is the only case SQLite rejects).
+          this.#lc.warn?.(
+            `Failed to ADD column ${table}.${name} with DEFAULT (${spec.dflt}), retrying without DEFAULT: ${e.message}`,
+          );
+          this.#db.db.exec(
+            `ALTER TABLE ${id(table)} ADD ${id(name)} ${liteColumnDef({...spec, dflt: null})}`,
+          );
+        } else {
+          throw e;
+        }
+      } else {
+        throw e;
+      }
+    }
 
     // Write to metadata table
     this.#columnMetadata.insert(table, name, msg.column.spec, msg.backfill);

--- a/packages/zero-cache/src/services/replicator/change-processor.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.ts
@@ -20,6 +20,7 @@ import {
   mapPostgresToLite,
   mapPostgresToLiteColumn,
   mapPostgresToLiteIndex,
+  UnsupportedColumnDefaultError,
 } from '../../db/pg-to-lite.ts';
 import type {StatementRunner} from '../../db/statements.ts';
 import type {LexiVersion} from '../../types/lexi-version.ts';
@@ -603,38 +604,18 @@ class TransactionProcessor {
     const table = liteTableName(msg.table);
     const {name} = msg.column;
     const spec = mapPostgresToLiteColumn(table, msg.column);
-    const ddl = `ALTER TABLE ${id(table)} ADD ${id(name)} ${liteColumnDef(spec)}`;
     try {
-      this.#db.db.exec(ddl);
+      this.#db.db.exec(
+        `ALTER TABLE ${id(table)} ADD ${id(name)} ${liteColumnDef(spec)}`,
+      );
     } catch (e) {
-      if (e instanceof SqliteError) {
-        if (
-          e.code === 'SQLITE_ERROR' &&
-          e.message.includes('duplicate column name')
-        ) {
-          // The column was already added (e.g. crash after exec but before
-          // watermark update). Log and continue — this is idempotent.
-          this.#lc.warn?.(
-            `Column ${table}.${name} already exists, skipping ADD`,
-          );
-        } else if (spec.dflt !== null) {
-          // The DEFAULT clause may have contained an expression that SQLite
-          // rejected (e.g. a PG-specific syntax that slipped through). Retry
-          // without the DEFAULT so the column is at least added.
-          //
-          // This is safe because mapPostgresToLiteColumn always returns
-          // notNull: false for SQLite replica columns, so SQLite will accept
-          // ADD COLUMN without a DEFAULT (a NOT NULL column without a default
-          // is the only case SQLite rejects).
-          this.#lc.warn?.(
-            `Failed to ADD column ${table}.${name} with DEFAULT (${spec.dflt}), retrying without DEFAULT: ${e.message}`,
-          );
-          this.#db.db.exec(
-            `ALTER TABLE ${id(table)} ADD ${id(name)} ${liteColumnDef({...spec, dflt: null})}`,
-          );
-        } else {
-          throw e;
-        }
+      if (e instanceof SqliteError && spec.dflt !== null) {
+        // The DEFAULT clause may have contained an expression that SQLite
+        // rejected (e.g. a PG-specific syntax that slipped through). Force backfill
+        // of the column.
+        throw new UnsupportedColumnDefaultError(
+          `Unsupported default value for ${table}.${name}: ${spec.dflt}`,
+        );
       } else {
         throw e;
       }


### PR DESCRIPTION
## Problem

When a PostgreSQL column with an array default (e.g. `ARRAY[]::text[]` or `ARRAY['a','b']::text[]`) is added via `ALTER TABLE ADD COLUMN`, the default expression was not handled by `mapPostgresToLiteDefault`, causing it to fall through to SQLite which doesn't understand PG array constructor syntax and would reject the statement.

## Fix

**`pg-to-lite.ts`**: Add explicit handling for PG array constructor expressions (`ARRAY[...]::type[]`):
- Empty arrays (`ARRAY[]::text[]`) are mapped to the JSON string literal `'[]'` in SQLite.
- Non-empty arrays (`ARRAY['a','b']::text[]`) throw `UnsupportedColumnDefaultError`, triggering the existing backfill path in `change-source`.

**`change-processor.ts`**: If SQLite rejects an `ADD COLUMN` with a `DEFAULT` (i.e. a PG-specific expression slipped through), throw `UnsupportedColumnDefaultError` instead of failing hard. This causes `change-source` to backfill the column from upstream rather than crashing.
