### PR TITLE
fix(zero-cache): Rewrite `mapPostgresToLiteDefault` to use allowlist.

### DIFF
--- a/packages/zero-cache/src/db/pg-to-lite.test.ts
+++ b/packages/zero-cache/src/db/pg-to-lite.test.ts
@@ -408,25 +408,77 @@ test.each([
 );
 
 test.each([
+  // Expressions with parentheses
   ['(id + 2)'],
   ['generate(id)'],
+  ['now()'],
+
+  // Time-related keywords/functions
   ['current_timestamp'],
   ['CURRENT_TIMESTAMP'],
   ['Current_Time'],
   ['current_DATE'],
+  ['LOCALTIME'],
+  ['LOCALTIMESTAMP'],
+
+  // Session variables
+  ['CURRENT_USER'],
+  ['SESSION_USER'],
+  ['CURRENT_SCHEMA'],
+
+  // Non-empty PG array constructors (need backfill)
+  ["ARRAY['a', 'b']::text[]"],
+  ['ARRAY[1,2,3]::integer[]'],
+
+  // Bare type casts (without quotes)
+  ['1::integer'],
+  ['0::smallint'],
+
+  // Boolean expressions
+  ['true AND false'],
+  ['NOT true'],
+
+  // Other PG-specific syntax
+  ['uuid_generate_v4()'],
+  ['gen_random_uuid()'],
+
+  // Bare quoted strings without type cast (need explicit ::type)
+  ["'foo'"],
+  ["'hello world'"],
 ])('unsupported column default %s', value => {
-  expect(() =>
-    mapPostgresToLiteDefault('foo', 'bar', 'boolean', value),
-  ).toThrow(UnsupportedColumnDefaultError);
+  expect(() => mapPostgresToLiteDefault('foo', 'bar', value)).toThrow(
+    UnsupportedColumnDefaultError,
+  );
 });
 
 test.each([
-  ['123', '123', 'int4'],
-  ['true', '1', 'boolean'],
-  ['false', '0', 'boolean'],
-  ["'12345678901234567890'::bigint", "'12345678901234567890'", 'int8'],
-])('supported column default %s', (input, output, dataType) => {
-  expect(mapPostgresToLiteDefault('foo', 'bar', dataType, input)).toEqual(
-    output,
-  );
+  // Integers
+  ['123', '123'],
+  ['0', '0'],
+  ['-456', '-456'],
+  ['2147483648', '2147483648'],
+
+  // Decimals
+  ['123.456', '123.456'],
+  ['-0.5', '-0.5'],
+
+  // Booleans (converted to 1/0)
+  ['true', '1'],
+  ['false', '0'],
+
+  // Quoted strings with type casts
+  ["'12345678901234567890'::bigint", "'12345678901234567890'"],
+  ["'foo'::text", "'foo'"],
+  ["'hello world'::varchar", "'hello world'"],
+  ["''::text", "''"], // empty string
+  ["'it''s'::text", "'it''s'"], // escaped quote
+
+  // Empty arrays → JSON empty array
+  ['ARRAY[]::text[]', "'[]'"],
+  ['ARRAY[]::integer[]', "'[]'"],
+  ['ARRAY[ ]::text[]', "'[]'"], // with whitespace
+  ["'{}'::text[]", "'[]'"], // PG literal syntax
+  ["'{}'::integer[]", "'[]'"],
+])('supported column default %s', (input, output) => {
+  expect(mapPostgresToLiteDefault('foo', 'bar', input)).toEqual(output);
 });

--- a/packages/zero-cache/src/db/pg-to-lite.ts
+++ b/packages/zero-cache/src/db/pg-to-lite.ts
@@ -63,49 +63,83 @@ export function warnIfDataTypeSupported(
   }
 }
 
-// As per https://www.sqlite.org/lang_altertable.html#altertabaddcol,
-// expressions with parentheses are disallowed ...
-const SIMPLE_TOKEN_EXPRESSION_REGEX = /^[^'()]+$/; // e.g. true, false, 1234, 1234.5678
+// Numeric literals: integers and decimals, optionally negative
+const NUMERIC_LITERAL_REGEX = /^-?\d+(\.\d+)?$/;
 
-// as well as current_time, current_date, and current_timestamp ...
-const UNSUPPORTED_TOKENS = /\b(current_time|current_date|current_timestamp)\b/i;
+// Boolean literals (PG emits lowercase)
+const BOOLEAN_LITERAL_REGEX = /^(true|false)$/;
 
+// Quoted string with type cast to a simple scalar type: 'value'::typename
 // For strings and certain incarnations of primitives (e.g. integers greater
 // than 2^31-1, Postgres' nodeToString() represents the values as type-casted
 // 'string' values, e.g. `'2147483648'::bigint`, `'foo'::text`.
-//
-// These type-qualifiers must be removed, as SQLite doesn't understand or
-// care about them.
-const STRING_EXPRESSION_REGEX = /^('.*')::[^']+$/;
+// Only matches simple type names (word characters) - array types like
+// `::text[]` won't match and will trigger backfill.
+const QUOTED_STRING_WITH_CAST_REGEX = /^('.*')::(\w+)$/;
 
+// Empty array constructor syntax: ARRAY[]::text[], ARRAY[]::integer[], etc.
+// Maps to '[]' (JSON empty array) in SQLite.
+const EMPTY_ARRAY_CONSTRUCTOR_REGEX = /^ARRAY\s*\[\s*\]::\w+\[\]$/i;
+
+// Empty array literal syntax: '{}'::text[], '{}'::integer[], etc.
+// Maps to '[]' (JSON empty array) in SQLite.
+const EMPTY_ARRAY_LITERAL_REGEX = /^'\{\}'::\w+\[\]$/;
+
+// Conservative allowlist approach for SQLite ADD COLUMN defaults.
+// We only allow patterns we know are safe. Everything else triggers
+// backfill from PostgreSQL, which correctly handles complex defaults.
+//
+// Note: We don't validate that the default value matches the column type
+// (e.g., that a numeric literal is used with a numeric column). PostgreSQL
+// already enforces this at schema definition time - you can't define
+// `ALTER TABLE foo ADD bar TEXT DEFAULT 123` in PG. So we trust that any
+// default we receive from the replication stream is type-compatible with
+// whatever we map the type to in SQLite.
+//
+// Example: `true`/`false` literals can only appear as defaults for boolean
+// columns in PG, so we don't need to check the column type before converting
+// to 1/0.
+//
+// See: https://www.sqlite.org/lang_altertable.html#altertabaddcol
+//
 // Exported for testing.
 export function mapPostgresToLiteDefault(
   table: string,
   column: string,
-  dataType: string,
   defaultExpression: string | null | undefined,
-) {
+): string | null {
   if (!defaultExpression) {
     return null;
   }
-  if (UNSUPPORTED_TOKENS.test(defaultExpression)) {
-    throw new UnsupportedColumnDefaultError(
-      `Cannot ADD a column with CURRENT_TIME, CURRENT_DATE, or CURRENT_TIMESTAMP`,
-    );
-  }
-  if (SIMPLE_TOKEN_EXPRESSION_REGEX.test(defaultExpression)) {
-    if (liteTypeToZqlValueType(dataType) === 'boolean') {
-      return defaultExpression === 'true' ? '1' : '0';
-    }
+
+  // Numeric literals pass through unchanged
+  if (NUMERIC_LITERAL_REGEX.test(defaultExpression)) {
     return defaultExpression;
   }
-  const match = STRING_EXPRESSION_REGEX.exec(defaultExpression);
-  if (!match) {
-    throw new UnsupportedColumnDefaultError(
-      `Unsupported default value for ${table}.${column}: ${defaultExpression}`,
-    );
+
+  // Boolean literals convert to SQLite's 1/0
+  if (BOOLEAN_LITERAL_REGEX.test(defaultExpression)) {
+    return defaultExpression === 'true' ? '1' : '0';
   }
-  return match[1];
+
+  // Quoted strings with type casts: extract just the quoted part
+  const match = QUOTED_STRING_WITH_CAST_REGEX.exec(defaultExpression);
+  if (match) {
+    return match[1];
+  }
+
+  // Empty arrays: ARRAY[]::type[] or '{}'::type[] → '[]'
+  if (
+    EMPTY_ARRAY_CONSTRUCTOR_REGEX.test(defaultExpression) ||
+    EMPTY_ARRAY_LITERAL_REGEX.test(defaultExpression)
+  ) {
+    return "'[]'";
+  }
+
+  // Everything else triggers backfill
+  throw new UnsupportedColumnDefaultError(
+    `Unsupported default value for ${table}.${column}: ${defaultExpression}`,
+  );
 }
 
 export function mapPostgresToLiteColumn(
@@ -142,7 +176,7 @@ export function mapPostgresToLiteColumn(
     dflt:
       ignoreDefault === 'ignore-default'
         ? null
-        : mapPostgresToLiteDefault(table, column.name, dataType, dflt),
+        : mapPostgresToLiteDefault(table, column.name, dflt),
     elemPgTypeClass,
   };
 }

--- a/packages/zero-cache/src/services/change-source/pg/change-source.backfill.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.backfill.pg.test.ts
@@ -473,7 +473,84 @@ describe.each([
           columns: {
             id: {dataType: 'int4|NOT_NULL', pos: 1},
             num: {dataType: 'int4', pos: 2},
-            expr: {dataType: 'int4', pos: 4},
+            // dflt is null because backfill was used (expression default not supported)
+            expr: {dataType: 'int4', pos: 4, dflt: null},
+          },
+        },
+      ],
+    ],
+    [
+      'column with non-empty array default triggers backfill',
+      PG_15_UP,
+      /*sql*/ `
+      ALTER TABLE published.bar ADD COLUMN tags TEXT[] DEFAULT ARRAY['a', 'b']::text[];
+      `,
+      null,
+      {
+        ['published.bar']: [
+          {
+            id: 1n,
+            num: 1n,
+            tags: '["a","b"]',
+          },
+          {
+            id: 2n,
+            num: 2n,
+            tags: '["a","b"]',
+          },
+          {
+            id: 3n,
+            num: 3n,
+            tags: '["a","b"]',
+          },
+        ],
+      },
+      [
+        {
+          name: 'published.bar',
+          columns: {
+            id: {dataType: 'int4|NOT_NULL', pos: 1},
+            num: {dataType: 'int4', pos: 2},
+            // dflt is null because backfill was used (non-empty array not supported)
+            tags: {dataType: 'text[]|TEXT_ARRAY', pos: 4, dflt: null},
+          },
+        },
+      ],
+    ],
+    [
+      'column with CURRENT_USER default triggers backfill',
+      PG_15_UP,
+      /*sql*/ `
+      ALTER TABLE published.bar ADD COLUMN created_by TEXT DEFAULT CURRENT_USER;
+      `,
+      null,
+      {
+        ['published.bar']: [
+          {
+            id: 1n,
+            num: 1n,
+            created_by: 'test',
+          },
+          {
+            id: 2n,
+            num: 2n,
+            created_by: 'test',
+          },
+          {
+            id: 3n,
+            num: 3n,
+            created_by: 'test',
+          },
+        ],
+      },
+      [
+        {
+          name: 'published.bar',
+          columns: {
+            id: {dataType: 'int4|NOT_NULL', pos: 1},
+            num: {dataType: 'int4', pos: 2},
+            // dflt is null because backfill was used (CURRENT_USER not supported)
+            created_by: {dataType: 'text', pos: 4, dflt: null},
           },
         },
       ],


### PR DESCRIPTION
The previous implementation used a denylist and had many cases of valid PG syntax that would not be mapped correctly to SQLite values:

- LOCALTIME, LOCALTIMESTAMP
- CURRENT_USER, CURRENT_ROLE, CURRENT_SCHEMA, CURRENT_CATALOG
- SESSION_USER
- true AND false
- NOT true
- etc...

Now we only map a small set of common known-supported values and everything else falls back to backfill:

- Numeric literals: 123, -45.67
- Boolean literals: true/false → 1/0
- Quoted strings with simple type casts: 'foo'::text
- Empty arrays: ARRAY[]::type[] and '{}'::type[] → '[]'

Removed the dataType parameter since we trust PG's type validation - PG already enforces that defaults match column types at schema definition time.

This supersedes https://github.com/rocicorp/mono/pull/5867