### PR TITLE
chore(zero-cachee): log error (with context) before asserting on missing ddl_start

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -1089,8 +1089,13 @@ class ChangeMaker {
       case 'schemaSnapshot':
         break;
       case 'ddlUpdate':
-        // guaranteed by event triggers
-        assert(prevEvent, `ddlUpdate received without a ddlStart`);
+        if (!prevEvent) {
+          // A fix for this is in the works. Log an error with the full
+          // LogContext (e.g. including the tag and query) to collect/confirm
+          // the scenarios in which this happens.
+          lc.error?.(`ddlUpdate received without a ddlStart`);
+          assert(prevEvent, `ddlUpdate received without a ddlStart`);
+        }
         break;
       default: // Ignore unknown types for forwards compatibility
         lc.info?.(`ignoring unknown ddl message type: ${type}`);

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -1093,7 +1093,7 @@ class ChangeMaker {
           // A fix for this is in the works. Log an error with the full
           // LogContext (e.g. including the tag and query) to collect/confirm
           // the scenarios in which this happens.
-          lc.error?.(`ddlUpdate received without a ddlStart`);
+          lc.error?.(`ddlUpdate received without a ddlStart`, {event});
           assert(prevEvent, `ddlUpdate received without a ddlStart`);
         }
         break;
@@ -1105,10 +1105,10 @@ class ChangeMaker {
     // Store the new event to diff against the next event.
     this.#lastReplicationEvent = event;
     if (!prevEvent) {
-      lc.info?.(`received ${msg.prefix}/${type} event`, event);
+      lc.info?.(`received ${msg.prefix}/${type} event`, {event});
       return []; // First snapshot in the tx.
     }
-    lc.info?.(`processing ${msg.prefix}/${type} event`, event);
+    lc.info?.(`processing ${msg.prefix}/${type} event`, {event});
 
     // The tag (i.e. command) is used to determine whether backfill is
     // necessary (CREATE TABLE vs ALTER TABLE vs ALTER PUBLICATION).


### PR DESCRIPTION
Log an error-level with message with full context before asserting on a missing ddlStart message to collect/confirm the situations in which this happens.

This is a short-term data gathering step before the fix is in place.