### PR TITLE
feat(zql-benchmarks): add query scenario sandbox

### DIFF
--- a/packages/zql-benchmarks/package.json
+++ b/packages/zql-benchmarks/package.json
@@ -14,6 +14,7 @@
     "test": "vitest run --silent=false --disable-console-intercept",
     "test:watch": "vitest watch",
     "bench": "vitest run --config vitest.config.bench.ts",
+    "bench:scenario": "tsx src/query-scenario-compare.ts",
     "bench:deopt": "vitest run --config vitest.config.bench.ts --execArgv=--trace-deopt",
     "bench:bmf": "BENCH_OUTPUT_FORMAT=json npm run bench 2>&1 | npx tsx ../shared/src/tool/mitata-json-to-bmf.ts",
     "bench:bmf:silent": "npm run bench:bmf --silent",

--- a/packages/zql-benchmarks/src/__snapshots__/query-scenarios.test.ts.snap
+++ b/packages/zql-benchmarks/src/__snapshots__/query-scenarios.test.ts.snap
@@ -1,0 +1,81 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`student membership mixed or > rows 1`] = `
+[
+  {
+    "archived_at": null,
+    "created_at": 103,
+    "id": 103,
+    "teacher_id": 2,
+  },
+  {
+    "archived_at": null,
+    "created_at": 102,
+    "id": 102,
+    "teacher_id": 2,
+  },
+  {
+    "archived_at": null,
+    "created_at": 101,
+    "id": 101,
+    "teacher_id": 2,
+  },
+  {
+    "archived_at": null,
+    "created_at": 4,
+    "id": 4,
+    "teacher_id": 1,
+  },
+]
+`;
+
+exports[`student membership mixed or > sql 1`] = `
+[
+  {
+    "sql": "SELECT "id","teacher_id","archived_at","created_at" FROM "assignment" WHERE "archived_at" IS ? ORDER BY "created_at" desc, "id" asc",
+    "table": "assignment",
+  },
+  {
+    "calls": 2003,
+    "sql": "SELECT "assignment_id","student_id","created_at" FROM "assignment_to_student" WHERE "assignment_id" = ? AND "student_id" = ? ORDER BY "assignment_id" asc, "student_id" asc",
+    "table": "assignment_to_student",
+  },
+]
+`;
+
+exports[`student membership simple exists > rows 1`] = `
+[
+  {
+    "archived_at": null,
+    "created_at": 103,
+    "id": 103,
+    "teacher_id": 2,
+  },
+  {
+    "archived_at": null,
+    "created_at": 102,
+    "id": 102,
+    "teacher_id": 2,
+  },
+  {
+    "archived_at": null,
+    "created_at": 101,
+    "id": 101,
+    "teacher_id": 2,
+  },
+]
+`;
+
+exports[`student membership simple exists > sql 1`] = `
+[
+  {
+    "sql": "SELECT "assignment_id","student_id","created_at" FROM "assignment_to_student" WHERE "student_id" = ? ORDER BY "assignment_id" asc, "student_id" asc",
+    "table": "assignment_to_student",
+  },
+  {
+    "calls": 3,
+    "sql": "SELECT "id","teacher_id","archived_at","created_at" FROM "assignment" WHERE "id" = ? AND "archived_at" IS ? ORDER BY "created_at" desc, "id" asc",
+    "table": "assignment",
+  },
+]
+`;

--- a/packages/zql-benchmarks/src/query-scenario-compare.ts
+++ b/packages/zql-benchmarks/src/query-scenario-compare.ts
@@ -1,0 +1,765 @@
+import {spawnSync} from 'node:child_process';
+import {existsSync, realpathSync} from 'node:fs';
+import {mkdir, readdir} from 'node:fs/promises';
+import {basename, dirname, isAbsolute, resolve} from 'node:path';
+import {performance} from 'node:perf_hooks';
+import {pathToFileURL} from 'node:url';
+import {digestRows} from './query-scenarios/digest.ts';
+
+// Compare scenario benchmark results across two local Zero checkouts.
+//
+// Common commands:
+//
+//   npm --workspace=zql-benchmarks run bench:scenario -- --left origin/main --right . --scenario student-membership-mixed-or
+//   npm --workspace=zql-benchmarks run bench:scenario -- --left 9587e11 --right 04dc506 --scenario student-membership-simple-exists
+//   npm --workspace=zql-benchmarks run bench:scenario -- --left . --right . --left-scenario student-membership-simple-exists --right-scenario student-membership-mixed-or
+//
+// The left and right targets can be local git refs, commits, branches, or
+// filesystem paths. Git refs are resolved with the local object database only:
+// no network fetch happens here. Ref targets are checked out into detached
+// worktrees under .tmp/query-scenario-worktrees so the current checkout can stay
+// dirty while the benchmark imports runtime modules from each side.
+//
+// Scenario definitions load from this checkout by default, then run against
+// both targets. That lets a new scenario benchmark older commits without having
+// to backport the scenario file into those commits.
+
+type Format = 'json' | 'markdown';
+
+type Options = {
+  readonly left: string;
+  readonly right: string;
+  readonly scenarioSource: string;
+  readonly scenario: string | undefined;
+  readonly leftScenario: string | undefined;
+  readonly rightScenario: string | undefined;
+  readonly iterations: number;
+  readonly warmups: number;
+  readonly format: Format;
+};
+
+type BenchmarkScenario = {
+  readonly name: string;
+  readonly schema: unknown;
+  readonly seed: (db: BenchmarkDatabase) => void;
+  readonly query: (builder: unknown) => unknown;
+};
+
+type ScenarioEntry = {
+  readonly scenario: BenchmarkScenario;
+  readonly sourceSlug: string | undefined;
+};
+
+type QuerySeen = {
+  readonly table: string;
+  readonly sql: string;
+  calls: number;
+};
+
+type BenchmarkRun = BenchmarkSuccess | BenchmarkFailure;
+
+type BenchmarkSuccess = {
+  readonly status: 'ok';
+  readonly scenarioName: string;
+  readonly rowCount: number;
+  readonly rowDigest: string;
+  readonly medianMs: number;
+  readonly minMs: number;
+  readonly maxMs: number;
+  readonly totalCalls: number;
+  readonly uniqueSQL: number;
+  readonly sql: readonly QuerySeen[];
+};
+
+type BenchmarkFailure = {
+  readonly status: 'error';
+  readonly scenarioName: string;
+  readonly error: string;
+};
+
+type Target = {
+  readonly label: string;
+  readonly root: string;
+  readonly commit: string | undefined;
+};
+
+type Comparison = {
+  readonly context: string;
+  readonly left: BenchmarkRun;
+  readonly right: BenchmarkRun;
+  readonly sameRows: boolean;
+};
+
+type BenchmarkDatabase = {
+  exec(sql: string): void;
+  prepare(sql: string): {run(...values: readonly unknown[]): void};
+  [Symbol.dispose](): void;
+};
+
+type DebugInstance = {
+  initQuery(table: string, query: string): void;
+  reset(): void;
+};
+
+type RuntimeModules = {
+  readonly testLogConfig: unknown;
+  readonly createSilentLogContext: () => unknown;
+  readonly computeZqlSpecs: (
+    lc: unknown,
+    db: BenchmarkDatabase,
+    options: {readonly includeBackfillingColumns: false},
+    tableSpecs: Map<string, unknown>,
+  ) => void;
+  readonly createTableMetadataTable: string;
+  readonly buildPipeline: (
+    ast: unknown,
+    delegate: BenchmarkDelegate,
+    queryID: string,
+    costModel: unknown,
+    lc: unknown,
+  ) => unknown;
+  readonly Debug: new () => DebugInstance;
+  readonly Catch: new (input: unknown) => {
+    fetch(): readonly unknown[];
+    destroy(): void;
+  };
+  readonly createBuilder: (schema: unknown) => unknown;
+  readonly asQueryInternals: (query: unknown) => {readonly ast: unknown};
+  readonly Database: new (lc: unknown, path: string) => BenchmarkDatabase;
+  readonly createSQLiteCostModel: (
+    db: BenchmarkDatabase,
+    tableSpecs: Map<string, unknown>,
+  ) => unknown;
+  readonly newQueryDelegate: (
+    lc: unknown,
+    logConfig: unknown,
+    db: BenchmarkDatabase,
+    schema: unknown,
+  ) => BenchmarkDelegate;
+};
+
+type BenchmarkDelegate = {
+  debug?: DebugInstance | undefined;
+};
+
+const DEFAULT_SCENARIO_SOURCE =
+  'packages/zql-benchmarks/src/query-scenarios/scenarios/index.ts';
+const DEFAULT_ITERATIONS = 9;
+const DEFAULT_WARMUPS = 2;
+
+const options = parseArgs(process.argv.slice(2));
+const repoRoot = git(['rev-parse', '--show-toplevel'], process.cwd());
+
+const scenarioCatalog = await loadScenarios(
+  resolveInputPath(options.scenarioSource),
+);
+const leftScenarios = selectScenarios(scenarioCatalog, {
+  scenario: options.leftScenario ?? options.scenario,
+  side: 'left',
+});
+const rightScenarios = selectScenarios(scenarioCatalog, {
+  scenario: options.rightScenario ?? options.scenario,
+  side: 'right',
+});
+
+if (leftScenarios.length !== rightScenarios.length) {
+  throw new Error(
+    `Scenario count mismatch: left selected ${leftScenarios.length}, right selected ${rightScenarios.length}`,
+  );
+}
+
+const [leftTarget, rightTarget] = await Promise.all([
+  resolveTarget({label: 'left', value: options.left}),
+  resolveTarget({label: 'right', value: options.right}),
+]);
+const [leftModules, rightModules] = await Promise.all([
+  loadRuntimeModules(leftTarget.root),
+  loadRuntimeModules(rightTarget.root),
+]);
+
+const comparisons: Comparison[] = [];
+for (let index = 0; index < leftScenarios.length; index++) {
+  const leftScenario = leftScenarios[index].scenario;
+  const rightScenario = rightScenarios[index].scenario;
+  const [leftRun, rightRun] = await Promise.all([
+    runScenario(leftModules, leftScenario, options),
+    runScenario(rightModules, rightScenario, options),
+  ]);
+  comparisons.push({
+    context:
+      leftScenario.name === rightScenario.name
+        ? leftScenario.name
+        : `${leftScenario.name} -> ${rightScenario.name}`,
+    left: leftRun,
+    right: rightRun,
+    sameRows:
+      leftRun.status === 'ok' &&
+      rightRun.status === 'ok' &&
+      leftRun.rowDigest === rightRun.rowDigest,
+  });
+}
+
+const output = {
+  left: leftTarget,
+  right: rightTarget,
+  iterations: options.iterations,
+  warmups: options.warmups,
+  comparisons,
+};
+
+if (options.format === 'json') {
+  print(`${JSON.stringify(output, null, 2)}\n`);
+} else {
+  print(`${formatMarkdown(output)}\n`);
+}
+
+function parseArgs(args: readonly string[]): Options {
+  let left = 'origin/main';
+  let right = '.';
+  let scenarioSource = DEFAULT_SCENARIO_SOURCE;
+  let scenario: string | undefined;
+  let leftScenario: string | undefined;
+  let rightScenario: string | undefined;
+  let iterations = DEFAULT_ITERATIONS;
+  let warmups = DEFAULT_WARMUPS;
+  let format: Format = 'markdown';
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    const next = () => {
+      const value = args[index + 1];
+      if (value === undefined) {
+        throw new Error(`Missing value for ${arg}`);
+      }
+      index++;
+      return value;
+    };
+
+    switch (arg) {
+      case '--left':
+        left = next();
+        break;
+      case '--right':
+        right = next();
+        break;
+      case '--scenario-source':
+        scenarioSource = next();
+        break;
+      case '--scenario':
+        scenario = next();
+        break;
+      case '--left-scenario':
+        leftScenario = next();
+        break;
+      case '--right-scenario':
+        rightScenario = next();
+        break;
+      case '--iterations':
+        iterations = parsePositiveInteger(next(), arg);
+        break;
+      case '--warmups':
+        warmups = parseNonNegativeInteger(next(), arg);
+        break;
+      case '--format': {
+        const value = next();
+        if (value !== 'json' && value !== 'markdown') {
+          throw new Error('--format must be json or markdown');
+        }
+        format = value;
+        break;
+      }
+      case '--help':
+        printHelp();
+        process.exit(0);
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return {
+    left,
+    right,
+    scenarioSource,
+    scenario,
+    leftScenario,
+    rightScenario,
+    iterations,
+    warmups,
+    format,
+  };
+}
+
+async function resolveTarget({
+  label,
+  value,
+}: {
+  readonly label: string;
+  readonly value: string;
+}): Promise<Target> {
+  const path = resolveInputPath(value);
+  if (existsSync(path)) {
+    return {label: value, root: realpathSync(path), commit: undefined};
+  }
+
+  const commit = git(['rev-parse', '--verify', `${value}^{commit}`]);
+  const shortCommit = commit.slice(0, 12);
+  const worktree = resolve(
+    repoRoot,
+    '.tmp',
+    'query-scenario-worktrees',
+    `${label}-${safeName(value)}-${shortCommit}`,
+  );
+  if (!existsSync(worktree)) {
+    await mkdir(resolve(repoRoot, '.tmp', 'query-scenario-worktrees'), {
+      recursive: true,
+    });
+    git(['worktree', 'add', '--detach', worktree, commit]);
+  }
+  return {label: value, root: worktree, commit};
+}
+
+async function loadScenarios(
+  source: string,
+): Promise<readonly ScenarioEntry[]> {
+  const module = (await import(pathToFileURL(source).href)) as {
+    readonly default: BenchmarkScenario | readonly BenchmarkScenario[];
+  };
+  const scenarios = Array.isArray(module.default)
+    ? module.default
+    : [module.default as BenchmarkScenario];
+  const sourceSlugByScenario =
+    basename(source) === 'index.ts'
+      ? await loadScenarioFileSlugs(dirname(source))
+      : mapScenariosToSlug(
+          scenarios,
+          slugifyScenarioName(basename(source, '.ts')),
+        );
+
+  return scenarios.map(scenario => ({
+    scenario,
+    sourceSlug: sourceSlugByScenario.get(scenario),
+  }));
+}
+
+async function loadScenarioFileSlugs(
+  directory: string,
+): Promise<Map<BenchmarkScenario, string>> {
+  const slugByScenario = new Map<BenchmarkScenario, string>();
+  const entries = await readdir(directory);
+  for (const entry of entries) {
+    if (!entry.endsWith('.ts') || entry === 'index.ts') {
+      continue;
+    }
+    const module = (await import(
+      pathToFileURL(resolve(directory, entry)).href
+    )) as {
+      readonly default: BenchmarkScenario | readonly BenchmarkScenario[];
+    };
+    const scenarios = Array.isArray(module.default)
+      ? module.default
+      : [module.default as BenchmarkScenario];
+    for (const scenario of scenarios) {
+      slugByScenario.set(scenario, slugifyScenarioName(basename(entry, '.ts')));
+    }
+  }
+  return slugByScenario;
+}
+
+function mapScenariosToSlug(
+  scenarios: readonly BenchmarkScenario[],
+  sourceSlug: string,
+): Map<BenchmarkScenario, string> {
+  const slugByScenario = new Map<BenchmarkScenario, string>();
+  for (const scenario of scenarios) {
+    slugByScenario.set(scenario, sourceSlug);
+  }
+  return slugByScenario;
+}
+
+function selectScenarios(
+  scenarios: readonly ScenarioEntry[],
+  {
+    scenario,
+    side,
+  }: {readonly scenario: string | undefined; readonly side: string},
+): readonly ScenarioEntry[] {
+  if (scenario === undefined || scenario === 'all') {
+    return scenarios;
+  }
+
+  const normalized = scenario.endsWith('.ts')
+    ? basename(scenario, '.ts')
+    : scenario;
+  const normalizedSlug = slugifyScenarioName(normalized);
+  const selected = scenarios.filter(entry => {
+    const nameSlug = slugifyScenarioName(entry.scenario.name);
+    const fileSlug = entry.sourceSlug;
+    return (
+      entry.scenario.name === scenario ||
+      nameSlug === normalizedSlug ||
+      nameSlug.includes(normalizedSlug) ||
+      normalizedSlug.includes(nameSlug) ||
+      fileSlug === normalizedSlug
+    );
+  });
+  if (selected.length === 0) {
+    throw new Error(`No ${side} scenario matched ${scenario}`);
+  }
+  if (selected.length > 1) {
+    throw new Error(
+      `${side} scenario ${scenario} matched more than one scenario: ${selected
+        .map(candidate => candidate.scenario.name)
+        .join(', ')}`,
+    );
+  }
+  return selected;
+}
+
+async function loadRuntimeModules(root: string): Promise<RuntimeModules> {
+  const [
+    otel,
+    logging,
+    liteTables,
+    metadata,
+    builder,
+    debugDelegate,
+    catchModule,
+    createBuilderModule,
+    queryInternals,
+    dbModule,
+    costModelModule,
+    sourceFactory,
+  ] = await Promise.all([
+    importFrom(root, 'packages/otel/src/test-log-config.ts'),
+    importFrom(root, 'packages/shared/src/logging-test-utils.ts'),
+    importFrom(root, 'packages/zero-cache/src/db/lite-tables.ts'),
+    importFrom(
+      root,
+      'packages/zero-cache/src/services/replicator/schema/table-metadata.ts',
+    ),
+    importFrom(root, 'packages/zql/src/builder/builder.ts'),
+    importFrom(root, 'packages/zql/src/builder/debug-delegate.ts'),
+    importFrom(root, 'packages/zql/src/ivm/catch.ts'),
+    importFrom(root, 'packages/zql/src/query/create-builder.ts'),
+    importFrom(root, 'packages/zql/src/query/query-internals.ts'),
+    importFrom(root, 'packages/zqlite/src/db.ts'),
+    importFrom(root, 'packages/zqlite/src/sqlite-cost-model.ts'),
+    importFrom(root, 'packages/zqlite/src/test/source-factory.ts'),
+  ]);
+
+  return {
+    testLogConfig: property(otel, 'testLogConfig'),
+    createSilentLogContext: property(logging, 'createSilentLogContext'),
+    computeZqlSpecs: property(liteTables, 'computeZqlSpecs'),
+    createTableMetadataTable: property(metadata, 'CREATE_TABLE_METADATA_TABLE'),
+    buildPipeline: property(builder, 'buildPipeline'),
+    Debug: property(debugDelegate, 'Debug'),
+    Catch: property(catchModule, 'Catch'),
+    createBuilder: property(createBuilderModule, 'createBuilder'),
+    asQueryInternals: property(queryInternals, 'asQueryInternals'),
+    Database: property(dbModule, 'Database'),
+    createSQLiteCostModel: property(costModelModule, 'createSQLiteCostModel'),
+    newQueryDelegate: property(sourceFactory, 'newQueryDelegate'),
+  } as RuntimeModules;
+}
+
+function runScenario(
+  modules: RuntimeModules,
+  scenario: BenchmarkScenario,
+  options: Options,
+): BenchmarkRun {
+  const lc = modules.createSilentLogContext();
+  const db = new modules.Database(lc, ':memory:');
+  try {
+    scenario.seed(db);
+    db.exec(modules.createTableMetadataTable);
+    db.exec('ANALYZE');
+
+    const tableSpecs = new Map<string, unknown>();
+    modules.computeZqlSpecs(
+      lc,
+      db,
+      {includeBackfillingColumns: false},
+      tableSpecs,
+    );
+    const costModel = modules.createSQLiteCostModel(db, tableSpecs);
+    const builder = modules.createBuilder(scenario.schema);
+    const ast = modules.asQueryInternals(scenario.query(builder)).ast;
+    const debug = makeCountingDebug(modules.Debug);
+    const samples: number[] = [];
+    let rowCount = 0;
+    let rowDigest = '';
+
+    for (
+      let iteration = 0;
+      iteration < options.warmups + options.iterations;
+      iteration++
+    ) {
+      debug.reset();
+      const delegate = modules.newQueryDelegate(
+        lc,
+        modules.testLogConfig,
+        db,
+        scenario.schema,
+      );
+      delegate.debug = debug.instance;
+      const start = performance.now();
+      const input = modules.buildPipeline(
+        ast,
+        delegate,
+        'query-scenario-compare',
+        costModel,
+        lc,
+      );
+      const sink = new modules.Catch(input);
+      const rows = sink
+        .fetch()
+        .filter(node => node !== 'yield')
+        .map(node => (node as {readonly row: unknown}).row);
+      sink.destroy();
+      const elapsed = performance.now() - start;
+      rowCount = rows.length;
+      rowDigest = digestRows(rows);
+      if (iteration >= options.warmups) {
+        samples.push(elapsed);
+      }
+    }
+
+    samples.sort((a, b) => a - b);
+    const maxMs = samples.at(-1);
+    if (maxMs === undefined) {
+      throw new Error('No measured benchmark samples were captured');
+    }
+    return {
+      status: 'ok',
+      scenarioName: scenario.name,
+      rowCount,
+      rowDigest,
+      medianMs: round(samples[Math.floor(samples.length / 2)]),
+      minMs: round(samples[0]),
+      maxMs: round(maxMs),
+      totalCalls: debug.queries.reduce(
+        (total, query) => total + query.calls,
+        0,
+      ),
+      uniqueSQL: debug.queries.length,
+      sql: debug.queries,
+    };
+  } catch (error) {
+    return {
+      status: 'error',
+      scenarioName: scenario.name,
+      error: errorMessage(error),
+    };
+  } finally {
+    db[Symbol.dispose]();
+  }
+}
+
+function makeCountingDebug(DebugClass: new () => DebugInstance): {
+  readonly instance: DebugInstance;
+  readonly queries: readonly QuerySeen[];
+  reset(): void;
+} {
+  let queries: QuerySeen[] = [];
+  class CountingDebug extends DebugClass {
+    override initQuery(table: string, query: string): void {
+      const seen = queries.find(
+        candidate => candidate.table === table && candidate.sql === query,
+      );
+      if (seen) {
+        seen.calls++;
+      } else {
+        queries.push({table, sql: query, calls: 1});
+      }
+      super.initQuery(table, query);
+    }
+  }
+  return {
+    instance: new CountingDebug(),
+    get queries() {
+      return queries;
+    },
+    reset() {
+      queries = [];
+    },
+  };
+}
+
+function formatMarkdown({
+  left,
+  right,
+  iterations,
+  warmups,
+  comparisons,
+}: {
+  readonly left: Target;
+  readonly right: Target;
+  readonly iterations: number;
+  readonly warmups: number;
+  readonly comparisons: readonly Comparison[];
+}): string {
+  const lines = [
+    `Compared \`${left.label}\` to \`${right.label}\` with ${iterations} measured iterations after ${warmups} warmups.`,
+    '',
+    '| Context | Before | After |',
+    '| --- | --- | --- |',
+  ];
+
+  for (const comparison of comparisons) {
+    lines.push(
+      `| ${escapeMarkdown(comparison.context)} | ${formatRun(comparison.left)} | ${formatRun(
+        comparison.right,
+      )} |`,
+    );
+  }
+
+  if (
+    comparisons.some(
+      comparison =>
+        comparison.left.status === 'ok' &&
+        comparison.right.status === 'ok' &&
+        !comparison.sameRows,
+    )
+  ) {
+    lines.push('');
+    lines.push(
+      'Warning: at least one comparison returned different rows. That is expected when comparing two different queries, but it is a correctness red flag when comparing the same query across commits.',
+    );
+  }
+  if (
+    comparisons.some(
+      comparison =>
+        comparison.left.status === 'error' ||
+        comparison.right.status === 'error',
+    )
+  ) {
+    lines.push('');
+    lines.push('Warning: at least one comparison hit an error.');
+  }
+
+  return lines.join('\n');
+}
+
+function formatRun(run: BenchmarkRun): string {
+  if (run.status === 'error') {
+    return `error: ${escapeMarkdown(run.error)}`;
+  }
+  return `${formatMs(run.medianMs)}, ${run.totalCalls.toLocaleString()} SQL calls, ${run.uniqueSQL} SQL shapes, ${run.rowCount.toLocaleString()} rows`;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function resolveInputPath(value: string): string {
+  return isAbsolute(value) ? value : resolve(repoRoot, value);
+}
+
+function importFrom(root: string, relativePath: string): Promise<unknown> {
+  return import(pathToFileURL(resolve(root, relativePath)).href);
+}
+
+function property<T>(module: unknown, name: string): T {
+  if (module === null || typeof module !== 'object' || !(name in module)) {
+    throw new Error(`Imported module did not export ${name}`);
+  }
+  return module[name as keyof typeof module] as T;
+}
+
+function git(args: readonly string[], cwd = repoRoot): string {
+  const result = spawnSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `git ${args.join(' ')} failed:\n${result.stderr || result.stdout}`,
+    );
+  }
+  return result.stdout.trim();
+}
+
+function slugifyScenarioName(name: string): string {
+  return name
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, '-')
+    .replaceAll(/^-|-$/g, '');
+}
+
+function safeName(value: string): string {
+  return value.replaceAll(/[^a-zA-Z0-9._-]+/g, '-').slice(0, 80);
+}
+
+function parsePositiveInteger(value: string, label: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function parseNonNegativeInteger(value: string, label: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${label} must be a non-negative integer`);
+  }
+  return parsed;
+}
+
+function round(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+function formatMs(value: number): string {
+  return `${value.toFixed(1)} ms`;
+}
+
+function escapeMarkdown(value: string): string {
+  return value.replaceAll('|', '\\|');
+}
+
+function printHelp(): void {
+  print(`Compare ZQL scenario query performance across local Zero commits.
+
+Usage:
+  npm --workspace=zql-benchmarks run bench:scenario -- [options]
+
+Options:
+  --left <ref-or-path>          Left side. Defaults to origin/main.
+  --right <ref-or-path>         Right side. Defaults to current directory.
+  --scenario <name-or-file>     Run one scenario on both sides. Defaults to all.
+  --left-scenario <name-or-file>
+  --right-scenario <name-or-file>
+                                Compare two different scenario queries.
+  --scenario-source <path>      Module exporting one scenario or an array.
+                                Defaults to the zql-benchmarks scenario catalog.
+  --iterations <n>              Measured iterations. Defaults to 9.
+  --warmups <n>                 Warmup iterations. Defaults to 2.
+  --format markdown|json        Defaults to markdown.
+  --help                        Show this help.
+
+Examples:
+  Compare this checkout against main for one scenario:
+    npm --workspace=zql-benchmarks run bench:scenario -- --left origin/main --right . --scenario student-membership-mixed-or
+
+  Compare two local commits:
+    npm --workspace=zql-benchmarks run bench:scenario -- --left 9587e11 --right 04dc506 --scenario student-membership-simple-exists
+
+  Compare two different query shapes on the same checkout:
+    npm --workspace=zql-benchmarks run bench:scenario -- --left . --right . --left-scenario student-membership-simple-exists --right-scenario student-membership-mixed-or
+
+  Capture exact SQL shapes:
+    npm --workspace=zql-benchmarks run bench:scenario -- --left origin/main --right . --format json > .tmp/query-scenario-compare.json
+
+Scenario selection accepts the full scenario name, "all", or a filename-ish slug
+like "student-membership-mixed-or".
+
+Refs are resolved locally with git rev-parse. The script creates detached
+worktrees under .tmp/query-scenario-worktrees and never fetches from the network.
+Use --right . when you want to benchmark the current working tree.`);
+}
+
+function print(value: string): void {
+  process.stdout.write(value);
+}

--- a/packages/zql-benchmarks/src/query-scenarios.test.ts
+++ b/packages/zql-benchmarks/src/query-scenarios.test.ts
@@ -1,0 +1,11 @@
+import {expect, test} from 'vitest';
+import {runQueryScenario} from './query-scenarios/scenario.ts';
+import scenarios from './query-scenarios/scenarios/index.ts';
+
+for (const scenario of scenarios) {
+  test(scenario.name, () => {
+    const result = runQueryScenario(scenario);
+    expect(result.sql).toMatchSnapshot('sql');
+    expect(result.rows).toMatchSnapshot('rows');
+  });
+}

--- a/packages/zql-benchmarks/src/query-scenarios/digest.ts
+++ b/packages/zql-benchmarks/src/query-scenarios/digest.ts
@@ -1,0 +1,18 @@
+import {createHash} from 'node:crypto';
+
+export function digestRows(rows: readonly unknown[]): string {
+  return createHash('sha256').update(stableStringify(rows)).digest('hex');
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${stableStringify(entry)}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value) ?? 'undefined';
+}

--- a/packages/zql-benchmarks/src/query-scenarios/education-app.ts
+++ b/packages/zql-benchmarks/src/query-scenarios/education-app.ts
@@ -1,0 +1,318 @@
+import {relationships} from '../../../zero-schema/src/builder/relationship-builder.ts';
+import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
+import {
+  number,
+  string,
+  table,
+} from '../../../zero-schema/src/builder/table-builder.ts';
+import type {
+  SchemaValue,
+  TableSchema,
+} from '../../../zero-schema/src/table-schema.ts';
+import type {Database} from '../../../zqlite/src/db.ts';
+
+const assignment = table('assignment')
+  .columns({
+    id: number(),
+    teacher_id: number(),
+    archived_at: string().optional(),
+    created_at: number(),
+  })
+  .primaryKey('id');
+
+const assignmentToStudent = table('assignment_to_student')
+  .columns({
+    assignment_id: number(),
+    student_id: string(),
+    created_at: number(),
+  })
+  .primaryKey('assignment_id', 'student_id');
+
+const teacher = table('teacher')
+  .columns({
+    id: number(),
+    user_id: string(),
+    role: string(),
+    school_id: number(),
+  })
+  .primaryKey('id');
+
+const teacherAssignmentAccess = table('teacher_assignment_access')
+  .columns({
+    assignment_id: number(),
+    teacher_id: number(),
+    access_kind: string(),
+  })
+  .primaryKey('assignment_id', 'teacher_id');
+
+const classroom = table('class')
+  .columns({
+    id: number(),
+    status: string(),
+    school_id: number(),
+  })
+  .primaryKey('id');
+
+const assignmentToClass = table('assignment_to_class')
+  .columns({
+    assignment_id: number(),
+    class_id: number(),
+  })
+  .primaryKey('assignment_id', 'class_id');
+
+const classToStudent = table('class_to_student')
+  .columns({
+    class_id: number(),
+    student_id: string(),
+  })
+  .primaryKey('class_id', 'student_id');
+
+const studentGroup = table('student_group')
+  .columns({
+    id: number(),
+    name: string(),
+  })
+  .primaryKey('id');
+
+const assignmentToGroup = table('assignment_to_group')
+  .columns({
+    assignment_id: number(),
+    group_id: number(),
+  })
+  .primaryKey('assignment_id', 'group_id');
+
+const groupToStudent = table('group_to_student')
+  .columns({
+    group_id: number(),
+    student_id: string(),
+  })
+  .primaryKey('group_id', 'student_id');
+
+const assignmentRelationships = relationships(assignment, ({many}) => ({
+  assignment_to_student: many({
+    sourceField: ['id'],
+    destField: ['assignment_id'],
+    destSchema: assignmentToStudent,
+  }),
+  teacher_access: many({
+    sourceField: ['id'],
+    destField: ['assignment_id'],
+    destSchema: teacherAssignmentAccess,
+  }),
+  assignment_to_class: many({
+    sourceField: ['id'],
+    destField: ['assignment_id'],
+    destSchema: assignmentToClass,
+  }),
+  assignment_to_group: many({
+    sourceField: ['id'],
+    destField: ['assignment_id'],
+    destSchema: assignmentToGroup,
+  }),
+}));
+
+const teacherAssignmentAccessRelationships = relationships(
+  teacherAssignmentAccess,
+  ({one}) => ({
+    teacher: one({
+      sourceField: ['teacher_id'],
+      destField: ['id'],
+      destSchema: teacher,
+    }),
+  }),
+);
+
+const assignmentToClassRelationships = relationships(
+  assignmentToClass,
+  ({one}) => ({
+    class: one({
+      sourceField: ['class_id'],
+      destField: ['id'],
+      destSchema: classroom,
+    }),
+  }),
+);
+
+const classRelationships = relationships(classroom, ({many}) => ({
+  class_to_student: many({
+    sourceField: ['id'],
+    destField: ['class_id'],
+    destSchema: classToStudent,
+  }),
+}));
+
+const assignmentToGroupRelationships = relationships(
+  assignmentToGroup,
+  ({one}) => ({
+    group: one({
+      sourceField: ['group_id'],
+      destField: ['id'],
+      destSchema: studentGroup,
+    }),
+  }),
+);
+
+const groupRelationships = relationships(studentGroup, ({many}) => ({
+  group_to_student: many({
+    sourceField: ['id'],
+    destField: ['group_id'],
+    destSchema: groupToStudent,
+  }),
+}));
+
+export const educationAppSchema = createSchema({
+  tables: [
+    assignment,
+    assignmentToStudent,
+    teacher,
+    teacherAssignmentAccess,
+    classroom,
+    assignmentToClass,
+    classToStudent,
+    studentGroup,
+    assignmentToGroup,
+    groupToStudent,
+  ],
+  relationships: [
+    assignmentRelationships,
+    teacherAssignmentAccessRelationships,
+    assignmentToClassRelationships,
+    classRelationships,
+    assignmentToGroupRelationships,
+    groupRelationships,
+  ],
+});
+
+export const educationAppTables = educationAppSchema.tables;
+export const educationAppRelationships = educationAppSchema.relationships;
+
+export function tableName<const TTable extends TableSchema>(
+  tableSchema: TTable,
+): TTable['serverName'] extends string ? TTable['serverName'] : TTable['name'] {
+  return (tableSchema.serverName ??
+    tableSchema.name) as TTable['serverName'] extends string
+    ? TTable['serverName']
+    : TTable['name'];
+}
+
+export function colName<
+  const TTable extends TableSchema,
+  const TColumn extends keyof TTable['columns'] & string,
+>(
+  tableSchema: TTable,
+  column: TColumn,
+): TTable['columns'][TColumn] extends {
+  serverName: infer ServerName extends string;
+}
+  ? ServerName
+  : TColumn {
+  const schemaValue = tableSchema.columns[column] as SchemaValue;
+  return (schemaValue.serverName ??
+    column) as TTable['columns'][TColumn] extends {
+    serverName: infer ServerName extends string;
+  }
+    ? ServerName
+    : TColumn;
+}
+
+export function relationshipName<
+  const TRelationships extends Record<string, unknown>,
+  const TRelationship extends keyof TRelationships & string,
+>(_relationshipsSchema: TRelationships, relationship: TRelationship) {
+  return relationship;
+}
+
+export function createEducationAppTables(db: Database) {
+  const assignment = educationAppTables.assignment;
+  const assignmentToStudent = educationAppTables.assignment_to_student;
+  const teacher = educationAppTables.teacher;
+  const teacherAssignmentAccess = educationAppTables.teacher_assignment_access;
+  const classroom = educationAppTables.class;
+  const assignmentToClass = educationAppTables.assignment_to_class;
+  const classToStudent = educationAppTables.class_to_student;
+  const studentGroup = educationAppTables.student_group;
+  const assignmentToGroup = educationAppTables.assignment_to_group;
+  const groupToStudent = educationAppTables.group_to_student;
+
+  db.exec(`
+    CREATE TABLE ${tableName(assignment)} (
+      ${colName(assignment, 'id')} INTEGER PRIMARY KEY,
+      ${colName(assignment, 'teacher_id')} INTEGER,
+      ${colName(assignment, 'archived_at')} TEXT,
+      ${colName(assignment, 'created_at')} INTEGER
+    );
+    CREATE UNIQUE INDEX assignment_id_unique ON ${tableName(assignment)}(${colName(assignment, 'id')});
+    CREATE INDEX assignment_teacher_id_idx ON ${tableName(assignment)}(${colName(assignment, 'teacher_id')});
+    CREATE INDEX assignment_created_at_idx ON ${tableName(assignment)}(${colName(assignment, 'created_at')});
+
+    CREATE TABLE ${tableName(assignmentToStudent)} (
+      ${colName(assignmentToStudent, 'assignment_id')} INTEGER,
+      ${colName(assignmentToStudent, 'student_id')} TEXT,
+      ${colName(assignmentToStudent, 'created_at')} INTEGER,
+      PRIMARY KEY (${colName(assignmentToStudent, 'assignment_id')}, ${colName(assignmentToStudent, 'student_id')})
+    );
+    CREATE INDEX assignment_to_student_student_idx ON ${tableName(assignmentToStudent)}(${colName(assignmentToStudent, 'student_id')});
+
+    CREATE TABLE ${tableName(teacher)} (
+      ${colName(teacher, 'id')} INTEGER PRIMARY KEY,
+      ${colName(teacher, 'user_id')} TEXT,
+      ${colName(teacher, 'role')} TEXT,
+      ${colName(teacher, 'school_id')} INTEGER
+    );
+    CREATE UNIQUE INDEX teacher_id_unique ON ${tableName(teacher)}(${colName(teacher, 'id')});
+    CREATE INDEX teacher_user_id_idx ON ${tableName(teacher)}(${colName(teacher, 'user_id')});
+
+    CREATE TABLE ${tableName(teacherAssignmentAccess)} (
+      ${colName(teacherAssignmentAccess, 'assignment_id')} INTEGER,
+      ${colName(teacherAssignmentAccess, 'teacher_id')} INTEGER,
+      ${colName(teacherAssignmentAccess, 'access_kind')} TEXT,
+      PRIMARY KEY (${colName(teacherAssignmentAccess, 'assignment_id')}, ${colName(teacherAssignmentAccess, 'teacher_id')})
+    );
+    CREATE INDEX teacher_assignment_access_teacher_idx ON ${tableName(teacherAssignmentAccess)}(${colName(teacherAssignmentAccess, 'teacher_id')});
+    CREATE INDEX teacher_assignment_access_assignment_idx ON ${tableName(teacherAssignmentAccess)}(${colName(teacherAssignmentAccess, 'assignment_id')});
+
+    CREATE TABLE ${tableName(classroom)} (
+      ${colName(classroom, 'id')} INTEGER PRIMARY KEY,
+      ${colName(classroom, 'status')} TEXT,
+      ${colName(classroom, 'school_id')} INTEGER
+    );
+    CREATE UNIQUE INDEX class_id_unique ON ${tableName(classroom)}(${colName(classroom, 'id')});
+    CREATE INDEX class_status_idx ON ${tableName(classroom)}(${colName(classroom, 'status')});
+
+    CREATE TABLE ${tableName(assignmentToClass)} (
+      ${colName(assignmentToClass, 'assignment_id')} INTEGER,
+      ${colName(assignmentToClass, 'class_id')} INTEGER,
+      PRIMARY KEY (${colName(assignmentToClass, 'assignment_id')}, ${colName(assignmentToClass, 'class_id')})
+    );
+    CREATE INDEX assignment_to_class_class_idx ON ${tableName(assignmentToClass)}(${colName(assignmentToClass, 'class_id')});
+
+    CREATE TABLE ${tableName(classToStudent)} (
+      ${colName(classToStudent, 'class_id')} INTEGER,
+      ${colName(classToStudent, 'student_id')} TEXT,
+      PRIMARY KEY (${colName(classToStudent, 'class_id')}, ${colName(classToStudent, 'student_id')})
+    );
+    CREATE INDEX class_to_student_student_idx ON ${tableName(classToStudent)}(${colName(classToStudent, 'student_id')});
+
+    CREATE TABLE ${tableName(studentGroup)} (
+      ${colName(studentGroup, 'id')} INTEGER PRIMARY KEY,
+      ${colName(studentGroup, 'name')} TEXT
+    );
+    CREATE UNIQUE INDEX student_group_id_unique ON ${tableName(studentGroup)}(${colName(studentGroup, 'id')});
+
+    CREATE TABLE ${tableName(assignmentToGroup)} (
+      ${colName(assignmentToGroup, 'assignment_id')} INTEGER,
+      ${colName(assignmentToGroup, 'group_id')} INTEGER,
+      PRIMARY KEY (${colName(assignmentToGroup, 'assignment_id')}, ${colName(assignmentToGroup, 'group_id')})
+    );
+    CREATE INDEX assignment_to_group_group_idx ON ${tableName(assignmentToGroup)}(${colName(assignmentToGroup, 'group_id')});
+
+    CREATE TABLE ${tableName(groupToStudent)} (
+      ${colName(groupToStudent, 'group_id')} INTEGER,
+      ${colName(groupToStudent, 'student_id')} TEXT,
+      PRIMARY KEY (${colName(groupToStudent, 'group_id')}, ${colName(groupToStudent, 'student_id')})
+    );
+    CREATE INDEX group_to_student_student_idx ON ${tableName(groupToStudent)}(${colName(groupToStudent, 'student_id')});
+  `);
+
+  return educationAppTables;
+}

--- a/packages/zql-benchmarks/src/query-scenarios/scenario.ts
+++ b/packages/zql-benchmarks/src/query-scenarios/scenario.ts
@@ -1,0 +1,101 @@
+import {testLogConfig} from '../../../otel/src/test-log-config.ts';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import {computeZqlSpecs} from '../../../zero-cache/src/db/lite-tables.ts';
+import type {LiteAndZqlSpec} from '../../../zero-cache/src/db/specs.ts';
+import {CREATE_TABLE_METADATA_TABLE} from '../../../zero-cache/src/services/replicator/schema/table-metadata.ts';
+import type {Row} from '../../../zero-protocol/src/data.ts';
+import type {Schema} from '../../../zero-types/src/schema.ts';
+import {buildPipeline} from '../../../zql/src/builder/builder.ts';
+import {Debug} from '../../../zql/src/builder/debug-delegate.ts';
+import {Catch} from '../../../zql/src/ivm/catch.ts';
+import {createBuilder} from '../../../zql/src/query/create-builder.ts';
+import {asQueryInternals} from '../../../zql/src/query/query-internals.ts';
+import type {AnyQuery} from '../../../zql/src/query/query.ts';
+import type {SchemaQuery} from '../../../zql/src/query/schema-query.ts';
+import {Database} from '../../../zqlite/src/db.ts';
+import {createSQLiteCostModel} from '../../../zqlite/src/sqlite-cost-model.ts';
+import {newQueryDelegate} from '../../../zqlite/src/test/source-factory.ts';
+import {digestRows} from './digest.ts';
+
+type QuerySeen = {
+  table: string;
+  sql: string;
+  calls: number;
+};
+
+class ScenarioDebug extends Debug {
+  readonly #queries: QuerySeen[] = [];
+
+  override initQuery(table: string, query: string): void {
+    const seen = this.#queries.find(
+      candidate => candidate.table === table && candidate.sql === query,
+    );
+    if (seen) {
+      seen.calls++;
+    } else {
+      this.#queries.push({table, sql: query, calls: 1});
+    }
+    super.initQuery(table, query);
+  }
+
+  compactQueries(): readonly QueryScenarioSQL[] {
+    return this.#queries.map(({table, sql, calls}) =>
+      calls === 1 ? {table, sql} : {table, sql, calls},
+    );
+  }
+}
+
+export type QueryScenario<S extends Schema = Schema> = {
+  readonly name: string;
+  readonly schema: S;
+  readonly seed: (db: Database) => void;
+  readonly query: (builder: SchemaQuery<S>) => AnyQuery;
+};
+
+export type QueryScenarioSQL = {
+  readonly table: string;
+  readonly sql: string;
+  readonly calls?: number | undefined;
+};
+
+export type QueryScenarioResult = {
+  readonly sql: readonly QueryScenarioSQL[];
+  readonly rows: readonly Row[];
+  readonly rowDigest: string;
+};
+
+export function runQueryScenario<S extends Schema>(
+  scenario: QueryScenario<S>,
+): QueryScenarioResult {
+  const lc = createSilentLogContext();
+  using db = new Database(lc, ':memory:');
+
+  scenario.seed(db);
+  db.exec(CREATE_TABLE_METADATA_TABLE);
+  db.exec('ANALYZE');
+
+  const tableSpecs = new Map<string, LiteAndZqlSpec>();
+  computeZqlSpecs(lc, db, {includeBackfillingColumns: false}, tableSpecs);
+  const costModel = createSQLiteCostModel(db, tableSpecs);
+
+  const builder = createBuilder(scenario.schema);
+  const ast = asQueryInternals(scenario.query(builder)).ast;
+
+  const debug = new ScenarioDebug();
+  const delegate = newQueryDelegate(lc, testLogConfig, db, scenario.schema);
+  delegate.debug = debug;
+
+  const input = buildPipeline(ast, delegate, 'query-scenario', costModel, lc);
+  const sink = new Catch(input);
+  const rows = sink
+    .fetch()
+    .filter(node => node !== 'yield')
+    .map(node => node.row);
+  sink.destroy();
+
+  return {
+    sql: debug.compactQueries(),
+    rows,
+    rowDigest: digestRows(rows),
+  };
+}

--- a/packages/zql-benchmarks/src/query-scenarios/scenarios/index.ts
+++ b/packages/zql-benchmarks/src/query-scenarios/scenarios/index.ts
@@ -1,0 +1,9 @@
+import type {educationAppSchema} from '../education-app.ts';
+import type {QueryScenario} from '../scenario.ts';
+import studentMembershipMixedOr from './student-membership-mixed-or.ts';
+import studentMembershipSimpleExists from './student-membership-simple-exists.ts';
+
+export default [
+  studentMembershipSimpleExists,
+  studentMembershipMixedOr,
+] satisfies readonly QueryScenario<typeof educationAppSchema>[];

--- a/packages/zql-benchmarks/src/query-scenarios/scenarios/student-membership-mixed-or.ts
+++ b/packages/zql-benchmarks/src/query-scenarios/scenarios/student-membership-mixed-or.ts
@@ -1,0 +1,60 @@
+import {
+  colName,
+  createEducationAppTables,
+  educationAppRelationships,
+  educationAppSchema,
+  educationAppTables,
+  relationshipName,
+  tableName,
+} from '../education-app.ts';
+import type {QueryScenario} from '../scenario.ts';
+
+const assignment = educationAppTables.assignment;
+const assignmentToStudent = educationAppTables.assignment_to_student;
+const assignmentToStudentRelationship = relationshipName(
+  educationAppRelationships.assignment,
+  'assignment_to_student',
+);
+
+export default {
+  name: 'student membership mixed or',
+  schema: educationAppSchema,
+  seed: db => {
+    const tables = createEducationAppTables(db);
+    const assignment = tables.assignment;
+    const assignmentToStudent = tables.assignment_to_student;
+
+    const assignmentStmt = db.prepare(
+      `INSERT INTO ${tableName(assignment)} (${colName(assignment, 'id')}, ${colName(assignment, 'teacher_id')}, ${colName(assignment, 'archived_at')}, ${colName(assignment, 'created_at')}) VALUES (?, ?, ?, ?)`,
+    );
+    for (let i = 1; i <= 2_000; i++) {
+      assignmentStmt.run(i, i === 4 ? 1 : 2, null, i);
+    }
+
+    const membershipStmt = db.prepare(
+      `INSERT INTO ${tableName(assignmentToStudent)} (${colName(assignmentToStudent, 'assignment_id')}, ${colName(assignmentToStudent, 'student_id')}, ${colName(assignmentToStudent, 'created_at')}) VALUES (?, ?, ?)`,
+    );
+    membershipStmt.run(101, 'student-1', 101);
+    membershipStmt.run(102, 'student-1', 102);
+    membershipStmt.run(103, 'student-1', 103);
+  },
+  query: builder =>
+    builder[assignment.name]
+      .where(({and, cmp, exists, or}) =>
+        and(
+          cmp(colName(assignment, 'archived_at'), 'IS', null),
+          or(
+            cmp(colName(assignment, 'teacher_id'), '=', 1),
+            exists(assignmentToStudentRelationship, q =>
+              q.where(
+                colName(assignmentToStudent, 'student_id'),
+                '=',
+                'student-1',
+              ),
+            ),
+          ),
+        ),
+      )
+      .orderBy(colName(assignment, 'created_at'), 'desc')
+      .orderBy(colName(assignment, 'id'), 'asc'),
+} satisfies QueryScenario<typeof educationAppSchema>;

--- a/packages/zql-benchmarks/src/query-scenarios/scenarios/student-membership-simple-exists.ts
+++ b/packages/zql-benchmarks/src/query-scenarios/scenarios/student-membership-simple-exists.ts
@@ -1,0 +1,49 @@
+import {
+  colName,
+  createEducationAppTables,
+  educationAppRelationships,
+  educationAppSchema,
+  educationAppTables,
+  relationshipName,
+  tableName,
+} from '../education-app.ts';
+import type {QueryScenario} from '../scenario.ts';
+
+const assignment = educationAppTables.assignment;
+const assignmentToStudent = educationAppTables.assignment_to_student;
+const assignmentToStudentRelationship = relationshipName(
+  educationAppRelationships.assignment,
+  'assignment_to_student',
+);
+
+export default {
+  name: 'student membership simple exists',
+  schema: educationAppSchema,
+  seed: db => {
+    const tables = createEducationAppTables(db);
+    const assignment = tables.assignment;
+    const assignmentToStudent = tables.assignment_to_student;
+
+    const assignmentStmt = db.prepare(
+      `INSERT INTO ${tableName(assignment)} (${colName(assignment, 'id')}, ${colName(assignment, 'teacher_id')}, ${colName(assignment, 'archived_at')}, ${colName(assignment, 'created_at')}) VALUES (?, ?, ?, ?)`,
+    );
+    for (let i = 1; i <= 2_000; i++) {
+      assignmentStmt.run(i, i === 4 ? 1 : 2, null, i);
+    }
+
+    const membershipStmt = db.prepare(
+      `INSERT INTO ${tableName(assignmentToStudent)} (${colName(assignmentToStudent, 'assignment_id')}, ${colName(assignmentToStudent, 'student_id')}, ${colName(assignmentToStudent, 'created_at')}) VALUES (?, ?, ?)`,
+    );
+    membershipStmt.run(101, 'student-1', 101);
+    membershipStmt.run(102, 'student-1', 102);
+    membershipStmt.run(103, 'student-1', 103);
+  },
+  query: builder =>
+    builder[assignment.name]
+      .where(colName(assignment, 'archived_at'), 'IS', null)
+      .whereExists(assignmentToStudentRelationship, q =>
+        q.where(colName(assignmentToStudent, 'student_id'), '=', 'student-1'),
+      )
+      .orderBy(colName(assignment, 'created_at'), 'desc')
+      .orderBy(colName(assignment, 'id'), 'asc'),
+} satisfies QueryScenario<typeof educationAppSchema>;

--- a/packages/zql-benchmarks/vitest.config.no-pg.ts
+++ b/packages/zql-benchmarks/vitest.config.no-pg.ts
@@ -1,0 +1,3 @@
+import {configForNoPg} from '../zero-cache/vitest.config.ts';
+
+export default configForNoPg(import.meta.url);


### PR DESCRIPTION
This pulls out the scenarios idea from the larger planner PR into a small `zql-benchmarks`-only change.

The goal is to make it easy to contribute app-shaped query sandboxes without coupling them to a particular optimizer proposal. A scenario just defines:

```ts
{
  name,
  schema,
  seed,
  query,
}
```

From there we can do two useful things:

1. Snapshot the current generated SQL and result rows for each scenario.
2. Benchmark the same scenario catalog against two local refs or worktrees.

What is in this PR:

- a small `QueryScenario` contract in `packages/zql-benchmarks/src/query-scenarios/scenario.ts`
- a starter `education-app` sandbox inspired by a real Goblins query shape, but kept hypothetical and sanitized
- two starter scenarios in `packages/zql-benchmarks/src/query-scenarios/scenarios/`
- snapshot tests in `packages/zql-benchmarks/src/query-scenarios.test.ts` that record the current SQL and rows
- a `bench:scenario` CLI in `packages/zql-benchmarks/src/query-scenario-compare.ts` that compares two local refs or paths against the same scenario catalog

What is intentionally not in this PR:

- no planner changes
- no expected AST assertions
- no "optimal SQL" expectations
- no known failure bookkeeping
- no claim that the current SQL is ideal, only that it is observable and comparable

A few details that felt important:

- The default scenario catalog lives in `zql-benchmarks`, not `zqlite` test code, so the harness can stand on its own.
- The comparison CLI still imports the actual runtime modules from each checked out target when it executes, so it can benchmark untouched commits against the same scenario definitions.
- The snapshot tests are no-PG and lightweight. They are meant to give us a stable record of what a planner change actually emitted.

Example commands:

```bash
npm --workspace=zql-benchmarks run test
npm --workspace=zql-benchmarks run bench:scenario -- --left origin/main --right . --scenario student-membership-mixed-or
npm --workspace=zql-benchmarks run bench:scenario -- --left 9587e11 --right 04dc506 --format json
```

My hope is that this gives us a clean place to keep adding real-world scenarios over time, and eventually to evaluate planner changes against customer-shaped sandboxes before shipping them.
