### PR TITLE
feat(zql): bring back cap!

### DIFF
--- a/packages/zql-integration-tests/src/cap.pg.test.ts
+++ b/packages/zql-integration-tests/src/cap.pg.test.ts
@@ -522,3 +522,125 @@ describe('Cap edge cases', () => {
     expect(view.data).toEqual(qd.materialize(q).data);
   });
 });
+
+describe('Cap OR with multiple EXISTS', () => {
+  let pg3: PostgresDB;
+  let sqlite3: Database;
+  let issueQuery3: Query<'issue', Schema>;
+  let qd: QueryDelegate;
+
+  beforeAll(async () => {
+    pg3 = await testDBs.create('cap-or-exists');
+    await pg3.unsafe(createTableSQL);
+    sqlite3 = new Database(lc, ':memory:');
+
+    // Two users so the two EXISTS branches are independently meaningful:
+    //   exists('comments')      → this issue has any direct comments
+    //   exists('ownerComments') → this issue's OWNER has authored ≥1 comment
+    //                             anywhere in the table
+    await pg3.unsafe(/*sql*/ `
+      INSERT INTO "users" ("id", "name") VALUES
+        ('u1', 'User 1'),
+        ('u2', 'User 2');
+
+      INSERT INTO "issues" ("id", "title", "description", "closed", "owner_id", "createdAt") VALUES
+        ('iA', 'A', 'dA', false, 'u1', TIMESTAMPTZ '2001-01-01T00:00:00.000Z'),
+        ('iB', 'B', 'dB', false, 'u2', TIMESTAMPTZ '2001-01-02T00:00:00.000Z'),
+        ('iC', 'C', 'dC', false, 'u1', TIMESTAMPTZ '2001-01-03T00:00:00.000Z'),
+        ('iD', 'D', 'dD', false, 'u2', TIMESTAMPTZ '2001-01-04T00:00:00.000Z');
+
+      -- Only u1 authors anything initially.
+      -- iA: has direct comments AND owner=u1 has authored → both branches TRUE
+      -- iB: no direct comments AND owner=u2 has NOT authored → both FALSE (excluded)
+      -- iC: no direct comments BUT owner=u1 has authored (on iA) → only ownerComments TRUE
+      -- iD: no direct comments AND owner=u2 has NOT authored → both FALSE (excluded)
+      INSERT INTO "comments" ("id", "authorId", "issue_id", "text", "createdAt") VALUES
+        ('cA1', 'u1', 'iA', 'a1', TIMESTAMP '2002-01-01 00:00:00');
+    `);
+
+    await initialSync(
+      new LogContext('debug', {}, consoleLogSink),
+      {appID: 'cap_or', shardNum: 0, publications: []},
+      sqlite3,
+      getConnectionURI(pg3),
+      {tableCopyWorkers: 1},
+      {},
+    );
+
+    qd = newQueryDelegate(lc, testLogConfig, sqlite3, schema);
+    issueQuery3 = newQuery(schema, 'issue');
+  });
+
+  test('OR of two EXISTS: dedup, independent branches, drift-free', () => {
+    const q = issueQuery3.where(({exists, or}) =>
+      or(exists('comments'), exists('ownerComments')),
+    );
+    const view = qd.materialize(q);
+
+    // Initial: iA (both branches), iC (ownerComments only).
+    const initial = view.data as ReadonlyArray<{readonly id: string}>;
+    expect(new Set(initial.map(r => r.id))).toEqual(new Set(['iA', 'iC']));
+    expect(view.data).toEqual(qd.materialize(q).data);
+
+    // Push: u2 authors a comment on iD.
+    //   exists('comments') for iD:      cB1 is on iD → TRUE
+    //   exists('ownerComments') for iD: iD.owner=u2, cB1 is by u2 → TRUE
+    //   exists('ownerComments') for iB: iB.owner=u2, cB1 is by u2 → TRUE
+    // Both branches fire for iD; FanIn must dedup → iD appears once.
+    // iB also becomes visible via ownerComments only.
+    consume(
+      must(qd.getSource('comments')).push(
+        makeSourceChangeAdd({
+          id: 'cD1',
+          authorId: 'u2',
+          issue_id: 'iD',
+          text: 'd1',
+          createdAt: 1100000000000,
+        }),
+      ),
+    );
+    const after = view.data as ReadonlyArray<{readonly id: string}>;
+    expect(new Set(after.map(r => r.id))).toEqual(
+      new Set(['iA', 'iB', 'iC', 'iD']),
+    );
+    // Crucial: no duplicates from the FanIn when both branches match.
+    expect(after.length).toBe(4);
+    expect(view.data).toEqual(qd.materialize(q).data);
+
+    // Push: remove cA1 (authored by u1, on iA).
+    //   iA loses direct comments.
+    //   iA loses ownerComments (u1 no longer has any comment anywhere).
+    //   iC loses ownerComments (same reason) → iC disappears.
+    //   iA: both branches now FALSE → disappears.
+    consume(
+      must(qd.getSource('comments')).push(
+        makeSourceChangeRemove({
+          id: 'cA1',
+          authorId: 'u1',
+          issue_id: 'iA',
+          text: 'a1',
+          createdAt: 1009843200000,
+        }),
+      ),
+    );
+    const after2 = view.data as ReadonlyArray<{readonly id: string}>;
+    expect(new Set(after2.map(r => r.id))).toEqual(new Set(['iB', 'iD']));
+    expect(view.data).toEqual(qd.materialize(q).data);
+
+    // Push: remove cD1 → iB and iD both lose their only backing.
+    consume(
+      must(qd.getSource('comments')).push(
+        makeSourceChangeRemove({
+          id: 'cD1',
+          authorId: 'u2',
+          issue_id: 'iD',
+          text: 'd1',
+          createdAt: 1100000000000,
+        }),
+      ),
+    );
+    const after3 = view.data as ReadonlyArray<{readonly id: string}>;
+    expect(after3.map(r => r.id)).toEqual([]);
+    expect(view.data).toEqual(qd.materialize(q).data);
+  });
+});

--- a/packages/zql-integration-tests/src/cap.pg.test.ts
+++ b/packages/zql-integration-tests/src/cap.pg.test.ts
@@ -644,3 +644,168 @@ describe('Cap OR with multiple EXISTS', () => {
     expect(view.data).toEqual(qd.materialize(q).data);
   });
 });
+
+describe('Cap AND with multiple EXISTS', () => {
+  let pg4: PostgresDB;
+  let sqlite4: Database;
+  let issueQuery4: Query<'issue', Schema>;
+  let qd: QueryDelegate;
+
+  beforeAll(async () => {
+    pg4 = await testDBs.create('cap-and-exists');
+    await pg4.unsafe(createTableSQL);
+    sqlite4 = new Database(lc, ':memory:');
+
+    // Same shape as the OR fixture but the truth tables matter
+    // differently for AND: a row is included only when BOTH branches
+    // hold. Each branch lives behind its own Cap (limit 3, unordered),
+    // so a single comment change can simultaneously toggle both
+    // branches for the same issue.
+    //
+    //   exists('comments')      — issue has any direct comment
+    //   exists('ownerComments') — issue's owner has authored ≥1 comment anywhere
+    //
+    // Initial truth table:
+    //   iA  u1 owns, has cA1 by u1     → comments=T, ownerComments=T → INCLUDED
+    //   iB  u2 owns, no comments       → comments=F, ownerComments=F → excluded
+    //   iC  u1 owns, no direct comment → comments=F, ownerComments=T → excluded (AND)
+    //   iD  u2 owns, no comments       → comments=F, ownerComments=F → excluded
+    await pg4.unsafe(/*sql*/ `
+      INSERT INTO "users" ("id", "name") VALUES
+        ('u1', 'User 1'),
+        ('u2', 'User 2');
+
+      INSERT INTO "issues" ("id", "title", "description", "closed", "owner_id", "createdAt") VALUES
+        ('iA', 'A', 'dA', false, 'u1', TIMESTAMPTZ '2001-01-01T00:00:00.000Z'),
+        ('iB', 'B', 'dB', false, 'u2', TIMESTAMPTZ '2001-01-02T00:00:00.000Z'),
+        ('iC', 'C', 'dC', false, 'u1', TIMESTAMPTZ '2001-01-03T00:00:00.000Z'),
+        ('iD', 'D', 'dD', false, 'u2', TIMESTAMPTZ '2001-01-04T00:00:00.000Z');
+
+      INSERT INTO "comments" ("id", "authorId", "issue_id", "text", "createdAt") VALUES
+        ('cA1', 'u1', 'iA', 'a1', TIMESTAMP '2002-01-01 00:00:00');
+    `);
+
+    await initialSync(
+      new LogContext('debug', {}, consoleLogSink),
+      {appID: 'cap_and', shardNum: 0, publications: []},
+      sqlite4,
+      getConnectionURI(pg4),
+      {tableCopyWorkers: 1},
+      {},
+    );
+
+    qd = newQueryDelegate(lc, testLogConfig, sqlite4, schema);
+    issueQuery4 = newQuery(schema, 'issue');
+  });
+
+  test('AND of two EXISTS: both branches must hold, drift-free', () => {
+    // Two chained whereExists() compose with AND. Each builds its own
+    // Cap; the join above feeds rows that survived the first Exists
+    // into the second's parent stream. If either Cap mishandled
+    // refill or partition keys, the live view would diverge from a
+    // fresh materialization.
+    const q = issueQuery4.whereExists('comments').whereExists('ownerComments');
+    const view = qd.materialize(q);
+
+    const initial = view.data as ReadonlyArray<{readonly id: string}>;
+    expect(initial.map(r => r.id)).toEqual(['iA']);
+    expect(view.data).toEqual(qd.materialize(q).data);
+
+    // Add a u1 comment on iC. Now iC has direct comments AND its owner
+    // (u1) had already authored cA1 → both branches TRUE → iC enters.
+    consume(
+      must(qd.getSource('comments')).push(
+        makeSourceChangeAdd({
+          id: 'cC1',
+          authorId: 'u1',
+          issue_id: 'iC',
+          text: 'c1',
+          createdAt: 1100000000000,
+        }),
+      ),
+    );
+    expect(
+      (view.data as ReadonlyArray<{readonly id: string}>).map(r => r.id),
+    ).toEqual(['iA', 'iC']);
+    expect(view.data).toEqual(qd.materialize(q).data);
+
+    // u2 authors a comment on iD. iD: comments TRUE (cD1 on iD) AND
+    // ownerComments TRUE (u2 just authored) → enters. iB: comments
+    // still FALSE on iB itself → AND fails → still excluded even
+    // though owner=u2 now has a comment.
+    consume(
+      must(qd.getSource('comments')).push(
+        makeSourceChangeAdd({
+          id: 'cD1',
+          authorId: 'u2',
+          issue_id: 'iD',
+          text: 'd1',
+          createdAt: 1100000001000,
+        }),
+      ),
+    );
+    expect(
+      new Set(
+        (view.data as ReadonlyArray<{readonly id: string}>).map(r => r.id),
+      ),
+    ).toEqual(new Set(['iA', 'iC', 'iD']));
+    expect(view.data).toEqual(qd.materialize(q).data);
+
+    // Remove cA1: iA loses comments AND its owner u1 loses ownerComments
+    // (u1 still has cC1 on iC) — wait, u1 authored cC1 above, so
+    // ownerComments stays TRUE for u1's issues. iA loses comments only;
+    // AND fails → iA exits. iC keeps both branches.
+    consume(
+      must(qd.getSource('comments')).push(
+        makeSourceChangeRemove({
+          id: 'cA1',
+          authorId: 'u1',
+          issue_id: 'iA',
+          text: 'a1',
+          createdAt: 1009843200000,
+        }),
+      ),
+    );
+    expect(
+      new Set(
+        (view.data as ReadonlyArray<{readonly id: string}>).map(r => r.id),
+      ),
+    ).toEqual(new Set(['iC', 'iD']));
+    expect(view.data).toEqual(qd.materialize(q).data);
+
+    // Remove cC1: iC loses comments. u1 has no more comments anywhere
+    // → ownerComments FALSE for iA and iC both. iC exits.
+    consume(
+      must(qd.getSource('comments')).push(
+        makeSourceChangeRemove({
+          id: 'cC1',
+          authorId: 'u1',
+          issue_id: 'iC',
+          text: 'c1',
+          createdAt: 1100000000000,
+        }),
+      ),
+    );
+    expect(
+      (view.data as ReadonlyArray<{readonly id: string}>).map(r => r.id),
+    ).toEqual(['iD']);
+    expect(view.data).toEqual(qd.materialize(q).data);
+
+    // Remove cD1: iD loses everything. View is empty.
+    consume(
+      must(qd.getSource('comments')).push(
+        makeSourceChangeRemove({
+          id: 'cD1',
+          authorId: 'u2',
+          issue_id: 'iD',
+          text: 'd1',
+          createdAt: 1100000001000,
+        }),
+      ),
+    );
+    expect(
+      (view.data as ReadonlyArray<{readonly id: string}>).map(r => r.id),
+    ).toEqual([]);
+    expect(view.data).toEqual(qd.materialize(q).data);
+  });
+});

--- a/packages/zql-integration-tests/src/cap.pg.test.ts
+++ b/packages/zql-integration-tests/src/cap.pg.test.ts
@@ -1,5 +1,5 @@
 import {consoleLogSink, LogContext} from '@rocicorp/logger';
-import {beforeAll, expect, test} from 'vitest';
+import {beforeAll, describe, expect, test} from 'vitest';
 import {testLogConfig} from '../../otel/src/test-log-config.ts';
 import {createSilentLogContext} from '../../shared/src/logging-test-utils.ts';
 import {must} from '../../shared/src/must.ts';
@@ -16,6 +16,7 @@ import {newQueryDelegate} from '../../zqlite/src/test/source-factory.ts';
 
 import {
   makeSourceChangeAdd,
+  makeSourceChangeEdit,
   makeSourceChangeRemove,
 } from '../../zql/src/ivm/source.ts';
 const lc = createSilentLogContext();
@@ -304,4 +305,220 @@ test('join-level unordered overlay — remove comment triggers overlay for multi
     consume(source.push(makeSourceChangeRemove(row)));
     expect(view.data).toEqual(queryDelegate.materialize(q).data);
   }
+});
+
+describe('Cap edge cases', () => {
+  let pg2: PostgresDB;
+  let sqlite2: Database;
+  let issueQuery2: Query<'issue', Schema>;
+  let qd: QueryDelegate;
+
+  beforeAll(async () => {
+    pg2 = await testDBs.create('cap-edge-cases');
+    await pg2.unsafe(createTableSQL);
+    sqlite2 = new Database(lc, ':memory:');
+
+    await pg2.unsafe(/*sql*/ `
+      INSERT INTO "users" ("id", "name") VALUES ('u1', 'User 1');
+
+      -- i1: 5 comments (3 tracked by cap, 2 overflow) — used by gap 2
+      INSERT INTO "issues" ("id", "title", "description", "closed", "owner_id", "createdAt") VALUES
+        ('i1', 'Issue 1', 'd1', false, 'u1', TIMESTAMPTZ '2001-01-01T00:00:00.000Z');
+      INSERT INTO "comments" ("id", "authorId", "issue_id", "text", "createdAt") VALUES
+        ('c1a', 'u1', 'i1', 'a', TIMESTAMP '2002-01-01 00:00:00'),
+        ('c1b', 'u1', 'i1', 'b', TIMESTAMP '2002-01-02 00:00:00'),
+        ('c1c', 'u1', 'i1', 'c', TIMESTAMP '2002-01-03 00:00:00'),
+        ('c1d', 'u1', 'i1', 'd', TIMESTAMP '2002-01-04 00:00:00'),
+        ('c1e', 'u1', 'i1', 'e', TIMESTAMP '2002-01-05 00:00:00');
+
+      -- i2: 1 comment c2a with 2 revisions — used by gap 3 (CHILD)
+      INSERT INTO "issues" ("id", "title", "description", "closed", "owner_id", "createdAt") VALUES
+        ('i2', 'Issue 2', 'd2', false, 'u1', TIMESTAMPTZ '2001-01-02T00:00:00.000Z');
+      INSERT INTO "comments" ("id", "authorId", "issue_id", "text", "createdAt") VALUES
+        ('c2a', 'u1', 'i2', 'only', TIMESTAMP '2002-02-01 00:00:00');
+      INSERT INTO "revision" ("id", "authorId", "commentId", "text") VALUES
+        ('r2a1', 'u1', 'c2a', 'rev1'),
+        ('r2a2', 'u1', 'c2a', 'rev2');
+
+      -- i3: 1 comment c3a with 1 revision — used by gap 4 (churn both levels)
+      INSERT INTO "issues" ("id", "title", "description", "closed", "owner_id", "createdAt") VALUES
+        ('i3', 'Issue 3', 'd3', false, 'u1', TIMESTAMPTZ '2001-01-03T00:00:00.000Z');
+      INSERT INTO "comments" ("id", "authorId", "issue_id", "text", "createdAt") VALUES
+        ('c3a', 'u1', 'i3', 'only', TIMESTAMP '2002-03-01 00:00:00');
+      INSERT INTO "revision" ("id", "authorId", "commentId", "text") VALUES
+        ('r3a1', 'u1', 'c3a', 'rev1');
+
+      -- i4: 1 comment — used by gap 6 (drain-to-zero and refill)
+      INSERT INTO "issues" ("id", "title", "description", "closed", "owner_id", "createdAt") VALUES
+        ('i4', 'Issue 4', 'd4', false, 'u1', TIMESTAMPTZ '2001-01-04T00:00:00.000Z');
+      INSERT INTO "comments" ("id", "authorId", "issue_id", "text", "createdAt") VALUES
+        ('c4a', 'u1', 'i4', 'only', TIMESTAMP '2002-04-01 00:00:00');
+    `);
+
+    await initialSync(
+      new LogContext('debug', {}, consoleLogSink),
+      {appID: 'cap_edge', shardNum: 0, publications: []},
+      sqlite2,
+      getConnectionURI(pg2),
+      {tableCopyWorkers: 1},
+      {},
+    );
+
+    qd = newQueryDelegate(lc, testLogConfig, sqlite2, schema);
+    issueQuery2 = newQuery(schema, 'issue');
+  });
+
+  // Gap 2: EDIT of an untracked (overflow) row must be dropped by Cap
+  // without perturbing the live view. Cap tracks the first 3 comments
+  // of i1; c1d is overflow. The drift assertion would flag any mismatch
+  // between live state and a fresh materialization.
+  test('edit of untracked overflow comment does not disturb view', () => {
+    const q = issueQuery2.whereExists('comments').related('comments');
+    const view = qd.materialize(q);
+
+    expect(view.data).toEqual(qd.materialize(q).data);
+
+    consume(
+      must(qd.getSource('comments')).push(
+        makeSourceChangeEdit(
+          {
+            id: 'c1d',
+            authorId: 'u1',
+            issue_id: 'i1',
+            text: 'd-edited',
+            createdAt: 1009843200000 + 3 * 86400000,
+          },
+          {
+            id: 'c1d',
+            authorId: 'u1',
+            issue_id: 'i1',
+            text: 'd',
+            createdAt: 1009843200000 + 3 * 86400000,
+          },
+        ),
+      ),
+    );
+
+    expect(view.data).toEqual(qd.materialize(q).data);
+  });
+
+  // Gap 3: nested whereExists. A revision change that does NOT flip
+  // existence of its parent comment travels up the inner Exists as a
+  // CHILD change and must be forwarded by the outer Cap for tracked
+  // rows (cap.ts:272-277).
+  test('nested whereExists — inner revision change forwarded as CHILD', () => {
+    const q = issueQuery2
+      .whereExists('comments', c => c.whereExists('revisions'))
+      .related('comments', c => c.related('revisions'));
+    const view = qd.materialize(q);
+
+    expect(view.data).toEqual(qd.materialize(q).data);
+
+    // Add a revision on c2a. c2a still has revisions both before and
+    // after, so existence is unchanged — change flows as CHILD.
+    consume(
+      must(qd.getSource('revision')).push(
+        makeSourceChangeAdd({
+          id: 'r2a3',
+          authorId: 'u1',
+          commentId: 'c2a',
+          text: 'rev3',
+        }),
+      ),
+    );
+
+    expect(view.data).toEqual(qd.materialize(q).data);
+
+    // Remove a non-last revision of c2a — still existence-unchanged.
+    consume(
+      must(qd.getSource('revision')).push(
+        makeSourceChangeRemove({
+          id: 'r2a1',
+          authorId: 'u1',
+          commentId: 'c2a',
+          text: 'rev1',
+        }),
+      ),
+    );
+
+    expect(view.data).toEqual(qd.materialize(q).data);
+  });
+
+  // Gap 4: doubly-nested whereExists produces two Cap levels. Exercise
+  // churn on the inner level (revisions) that forces existence flips on
+  // the middle level (comments) and in turn on the outer (issues),
+  // covering the full propagation and the Cap size transitions.
+  test('doubly nested whereExists stays consistent under existence flips', () => {
+    const q = issueQuery2.whereExists('comments', c =>
+      c.whereExists('revisions'),
+    );
+    const view = qd.materialize(q);
+
+    expect(view.data).toEqual(qd.materialize(q).data);
+
+    // Remove c3a's only revision → c3a loses existence → i3 retracts.
+    consume(
+      must(qd.getSource('revision')).push(
+        makeSourceChangeRemove({
+          id: 'r3a1',
+          authorId: 'u1',
+          commentId: 'c3a',
+          text: 'rev1',
+        }),
+      ),
+    );
+    expect(view.data).toEqual(qd.materialize(q).data);
+
+    // Re-add a revision → c3a regains existence → i3 reappears.
+    // This also exercises the outer Cap transitioning away from size=0
+    // for i3's partition.
+    consume(
+      must(qd.getSource('revision')).push(
+        makeSourceChangeAdd({
+          id: 'r3a2',
+          authorId: 'u1',
+          commentId: 'c3a',
+          text: 'rev2',
+        }),
+      ),
+    );
+    expect(view.data).toEqual(qd.materialize(q).data);
+  });
+
+  // Gap 6: capState.size === 0 early-return path. After all comments
+  // of i4 are removed, i4's partition in the cap stores {size: 0}.
+  // A subsequent ADD must transition from 0 correctly, and the live
+  // view must agree with a fresh materialization.
+  test('cap transitions through size=0 without drift', () => {
+    const q = issueQuery2.whereExists('comments').related('comments');
+    const view = qd.materialize(q);
+
+    expect(view.data).toEqual(qd.materialize(q).data);
+
+    consume(
+      must(qd.getSource('comments')).push(
+        makeSourceChangeRemove({
+          id: 'c4a',
+          authorId: 'u1',
+          issue_id: 'i4',
+          text: 'only',
+          createdAt: 1017633600000,
+        }),
+      ),
+    );
+    expect(view.data).toEqual(qd.materialize(q).data);
+
+    consume(
+      must(qd.getSource('comments')).push(
+        makeSourceChangeAdd({
+          id: 'c4b',
+          authorId: 'u1',
+          issue_id: 'i4',
+          text: 'second',
+          createdAt: 1100000000000,
+        }),
+      ),
+    );
+    expect(view.data).toEqual(qd.materialize(q).data);
+  });
 });

--- a/packages/zql-integration-tests/src/cap.pg.test.ts
+++ b/packages/zql-integration-tests/src/cap.pg.test.ts
@@ -370,8 +370,7 @@ describe('Cap edge cases', () => {
 
   // Gap 2: EDIT of an untracked (overflow) row must be dropped by Cap
   // without perturbing the live view. Cap tracks the first 3 comments
-  // of i1; c1d is overflow. The drift assertion would flag any mismatch
-  // between live state and a fresh materialization.
+  // of i1; c1d is overflow.
   test('edit of untracked overflow comment does not disturb view', () => {
     const q = issueQuery2.whereExists('comments').related('comments');
     const view = qd.materialize(q);
@@ -402,11 +401,7 @@ describe('Cap edge cases', () => {
     expect(view.data).toEqual(qd.materialize(q).data);
   });
 
-  // Gap 3: nested whereExists. A revision change that does NOT flip
-  // existence of its parent comment travels up the inner Exists as a
-  // CHILD change and must be forwarded by the outer Cap for tracked
-  // rows (cap.ts:272-277).
-  test('nested whereExists — inner revision change forwarded as CHILD', () => {
+  test('nested whereExists', () => {
     const q = issueQuery2
       .whereExists('comments', c => c.whereExists('revisions'))
       .related('comments', c => c.related('revisions'));
@@ -415,7 +410,7 @@ describe('Cap edge cases', () => {
     expect(view.data).toEqual(qd.materialize(q).data);
 
     // Add a revision on c2a. c2a still has revisions both before and
-    // after, so existence is unchanged — change flows as CHILD.
+    // after, so existence is unchanged
     consume(
       must(qd.getSource('revision')).push(
         makeSourceChangeAdd({
@@ -571,7 +566,7 @@ describe('Cap OR with multiple EXISTS', () => {
     issueQuery3 = newQuery(schema, 'issue');
   });
 
-  test('OR of two EXISTS: dedup, independent branches, drift-free', () => {
+  test('OR of two EXISTS: dedup, independent branches', () => {
     const q = issueQuery3.where(({exists, or}) =>
       or(exists('comments'), exists('ownerComments')),
     );
@@ -698,7 +693,7 @@ describe('Cap AND with multiple EXISTS', () => {
     issueQuery4 = newQuery(schema, 'issue');
   });
 
-  test('AND of two EXISTS: both branches must hold, drift-free', () => {
+  test('AND of two EXISTS', () => {
     // Two chained whereExists() compose with AND. Each builds its own
     // Cap; the join above feeds rows that survived the first Exists
     // into the second's parent stream. If either Cap mishandled

--- a/packages/zql/src/builder/builder.ts
+++ b/packages/zql/src/builder/builder.ts
@@ -19,6 +19,7 @@ import type {
 } from '../../../zero-protocol/src/ast.ts';
 import type {Row} from '../../../zero-protocol/src/data.ts';
 import type {PrimaryKey} from '../../../zero-protocol/src/primary-key.ts';
+import {Cap} from '../ivm/cap.ts';
 import {Exists} from '../ivm/exists.ts';
 import {FanIn} from '../ivm/fan-in.ts';
 import {FanOut} from '../ivm/fan-out.ts';
@@ -258,6 +259,7 @@ function buildPipelineInternal(
   queryID: string,
   name: string,
   partitionKey?: CompoundKey,
+  isNonFlippedExistsChild?: boolean | undefined,
 ): Input {
   const source = delegate.getSource(ast.table);
   if (!source) {
@@ -288,8 +290,18 @@ function buildPipelineInternal(
       }
     }
   }
+  if (isNonFlippedExistsChild) {
+    assert(ast.start === undefined, 'EXISTS subqueries must not have start');
+    assert(
+      ast.related === undefined,
+      'EXISTS subqueries must not have related',
+    );
+  }
+
   const conn = source.connect(
-    must(ast.orderBy),
+    // exists pipelines are unordered — orderBy is ignored here.
+    // Non-exists pipelines always have orderBy completed with PKs.
+    isNonFlippedExistsChild ? undefined : must(ast.orderBy),
     ast.where,
     splitEditKeys,
     delegate.debug,
@@ -333,15 +345,32 @@ function buildPipelineInternal(
   }
 
   if (ast.limit !== undefined) {
-    const takeName = `${name}:take`;
-    const take = new Take(
-      end,
-      delegate.createStorage(takeName),
-      ast.limit,
-      partitionKey,
-    );
-    delegate.addEdge(end, take);
-    end = delegate.decorateInput(take, takeName);
+    // We end `exists` pipelines with `cap`
+    // The reason is that `cap` does not care about the order of the pipeline.
+    // This allows SQLite to chose the order and never end up creating temp b-trees.
+    // The problem with SQLite creating a temp b-tree is it will incur a scan of the entire
+    // result set where exists only needs the first row.
+    if (isNonFlippedExistsChild) {
+      const capName = `${name}:cap`;
+      const cap = new Cap(
+        end,
+        delegate.createStorage(capName),
+        ast.limit,
+        partitionKey,
+      );
+      delegate.addEdge(end, cap);
+      end = delegate.decorateInput(cap, capName);
+    } else {
+      const takeName = `${name}:take`;
+      const take = new Take(
+        end,
+        delegate.createStorage(takeName),
+        ast.limit,
+        partitionKey,
+      );
+      delegate.addEdge(end, take);
+      end = delegate.decorateInput(take, takeName);
+    }
   }
 
   if (ast.related) {
@@ -455,6 +484,7 @@ function applyFilterWithFlips(
         '',
         `${name}.${sq.subquery.alias}`,
         sq.correlation.childField,
+        false,
       );
       const flippedJoin = new FlippedJoin({
         parent: end,
@@ -629,6 +659,7 @@ function applyCorrelatedSubQuery(
     queryID,
     `${name}.${sq.subquery.alias}`,
     sq.correlation.childField,
+    fromCondition,
   );
 
   const joinName = `${name}:join(${sq.subquery.alias})`;

--- a/packages/zql/src/ivm/cap.push.test.ts
+++ b/packages/zql/src/ivm/cap.push.test.ts
@@ -1150,6 +1150,54 @@ describe('Cap limit 0', () => {
       expect(result).toEqual([]);
     },
   );
+
+  test('pushes are dropped when limit=0 (no capState ever set)', () => {
+    // limit=0 short-circuits #initialFetch before capState is written.
+    // Every subsequent push must therefore see capState===undefined and
+    // silently drop. If capState ever leaked in (e.g. from a future
+    // refactor that pre-seeds state), pushes would start forwarding and
+    // produce rows that EXISTS-with-limit-0 must never emit.
+    const source = createSource(
+      lc,
+      testLogConfig,
+      'table',
+      {
+        id: {type: 'string'},
+        group: {type: 'string'},
+        text: {type: 'string'},
+      },
+      ['id'],
+    );
+    consume(
+      source.push(makeSourceChangeAdd({id: '1', group: 'g1', text: 'a'})),
+    );
+
+    const storage = new MemoryStorage();
+    const cap = new Cap(source.connect([['id', 'asc']]), storage, 0, ['group']);
+    const c = new Catch(cap);
+
+    // Fetch first — the early-return path that does NOT seed capState.
+    expect(c.fetch({constraint: {group: 'g1'}})).toEqual([]);
+
+    // ADD / REMOVE / EDIT must all be no-ops at the Cap level.
+    consume(
+      source.push(makeSourceChangeAdd({id: '2', group: 'g1', text: 'b'})),
+    );
+    consume(
+      source.push(makeSourceChangeRemove({id: '1', group: 'g1', text: 'a'})),
+    );
+    consume(
+      source.push(
+        makeSourceChangeEdit(
+          {id: '2', group: 'g1', text: 'b updated'},
+          {id: '2', group: 'g1', text: 'b'},
+        ),
+      ),
+    );
+
+    expect(c.pushes).toEqual([]);
+    expect(storage.cloneData()).toEqual({});
+  });
 });
 
 describe('Cap wiring', () => {
@@ -1221,6 +1269,169 @@ describe('Cap wiring', () => {
 
     const capKeys = Object.keys(actualStorage).filter(k => k.endsWith(':cap'));
     expect(capKeys).toEqual([]);
+  });
+
+  test('EXISTS subquery with start throws', () => {
+    // builder.ts:294 asserts that non-flipped EXISTS children have no
+    // `start` bound. If anything ever serializes a `start` into an
+    // EXISTS subquery AST, the assert is the only thing standing between
+    // us and a Cap pipeline that silently uses an unsupported bound.
+    const astWithStart: AST = {
+      table: 'issue',
+      orderBy: [['id', 'asc']],
+      where: {
+        type: 'correlatedSubquery',
+        related: {
+          system: 'client',
+          correlation: {parentField: ['id'], childField: ['issueID']},
+          subquery: {
+            table: 'comment',
+            alias: 'comments',
+            orderBy: [['id', 'asc']],
+            start: {row: {id: 'c0'}, exclusive: false},
+          },
+        },
+        op: 'EXISTS',
+      },
+    } as const;
+
+    expect(() =>
+      runPushTest({
+        sources,
+        sourceContents: {issue: [], comment: []},
+        ast: astWithStart,
+        format,
+        pushes: [],
+      }),
+    ).toThrow('EXISTS subqueries must not have start');
+  });
+
+  test('EXISTS subquery with related throws', () => {
+    // builder.ts:297 asserts that non-flipped EXISTS children have no
+    // `related`. EXISTS is a presence check; nesting a `related` into
+    // it would build a Join under Cap that's never observed, and the
+    // companion partition assumptions would break.
+    const astWithRelated: AST = {
+      table: 'issue',
+      orderBy: [['id', 'asc']],
+      where: {
+        type: 'correlatedSubquery',
+        related: {
+          system: 'client',
+          correlation: {parentField: ['id'], childField: ['issueID']},
+          subquery: {
+            table: 'comment',
+            alias: 'comments',
+            orderBy: [['id', 'asc']],
+            related: [
+              {
+                system: 'client',
+                correlation: {
+                  parentField: ['issueID'],
+                  childField: ['id'],
+                },
+                subquery: {
+                  table: 'issue',
+                  alias: 'issue',
+                  orderBy: [['id', 'asc']],
+                },
+              },
+            ],
+          },
+        },
+        op: 'EXISTS',
+      },
+    } as const;
+
+    expect(() =>
+      runPushTest({
+        sources,
+        sourceContents: {issue: [], comment: []},
+        ast: astWithRelated,
+        format,
+        pushes: [],
+      }),
+    ).toThrow('EXISTS subqueries must not have related');
+  });
+
+  test('nested EXISTS produces a Cap at every level', () => {
+    // Each non-flipped EXISTS in the tree gets its own Cap. The outer
+    // Cap caps issues' direct comments; the inner Cap caps each
+    // comment's revisions. If wiring ever flattens these, only one
+    // Cap storage would appear and inner-level overfetch would be
+    // invisible.
+    const sourcesNested: Sources = {
+      issue: {
+        columns: {id: {type: 'string'}},
+        primaryKeys: ['id'],
+      },
+      comment: {
+        columns: {
+          id: {type: 'string'},
+          issueID: {type: 'string'},
+        },
+        primaryKeys: ['id'],
+      },
+      revision: {
+        columns: {
+          id: {type: 'string'},
+          commentID: {type: 'string'},
+        },
+        primaryKeys: ['id'],
+      },
+    };
+
+    const nestedAst: AST = {
+      table: 'issue',
+      orderBy: [['id', 'asc']],
+      where: {
+        type: 'correlatedSubquery',
+        related: {
+          system: 'client',
+          correlation: {parentField: ['id'], childField: ['issueID']},
+          subquery: {
+            table: 'comment',
+            alias: 'comments',
+            orderBy: [['id', 'asc']],
+            where: {
+              type: 'correlatedSubquery',
+              related: {
+                system: 'client',
+                correlation: {
+                  parentField: ['id'],
+                  childField: ['commentID'],
+                },
+                subquery: {
+                  table: 'revision',
+                  alias: 'revisions',
+                  orderBy: [['id', 'asc']],
+                },
+              },
+              op: 'EXISTS',
+            },
+          },
+        },
+        op: 'EXISTS',
+      },
+    } as const;
+
+    const sourceContents: SourceContents = {
+      issue: [{id: 'i1'}],
+      comment: [{id: 'c1', issueID: 'i1'}],
+      revision: [{id: 'r1', commentID: 'c1'}],
+    };
+    const {actualStorage} = runPushTest({
+      sources: sourcesNested,
+      sourceContents,
+      ast: nestedAst,
+      format: {singular: false, relationships: {}},
+      pushes: [],
+    });
+
+    const capKeys = Object.keys(actualStorage)
+      .filter(k => k.endsWith(':cap'))
+      .sort();
+    expect(capKeys).toEqual(['.comments.revisions:cap', '.comments:cap']);
   });
 
   test('permissions-system EXISTS uses cap limit=1', () => {
@@ -1441,6 +1652,206 @@ describe('Cap push - compound partition key', () => {
             "["c5"]",
           ],
           "size": 1,
+        },
+      }
+    `);
+  });
+});
+
+describe('Cap push - compound primary key', () => {
+  // Child PK is ['groupId','seq']. Exercises the multi-element loops in
+  // serializePK and deserializePKToConstraint (cap.ts:315-329) — every
+  // other test in this file uses single-column PK ['id'], so the
+  // multi-element path is otherwise unverified. The PK-point-lookup
+  // re-fetch (cap.ts:113-122) deserializes back into a constraint, so
+  // a broken round-trip here would either return wrong rows from the
+  // source or cause the source to throw on an unrecognized constraint.
+  const sources: Sources = {
+    parent: {
+      columns: {
+        id: {type: 'string'},
+        groupId: {type: 'string'},
+      },
+      primaryKeys: ['id'],
+    },
+    child: {
+      columns: {
+        groupId: {type: 'string'},
+        seq: {type: 'string'},
+        text: {type: 'string'},
+      },
+      primaryKeys: ['groupId', 'seq'],
+    },
+  };
+
+  const ast: AST = {
+    table: 'parent',
+    orderBy: [['id', 'asc']],
+    where: {
+      type: 'correlatedSubquery',
+      related: {
+        system: 'client',
+        correlation: {parentField: ['groupId'], childField: ['groupId']},
+        subquery: {
+          table: 'child',
+          alias: 'children',
+          orderBy: [['seq', 'asc']],
+        },
+      },
+      op: 'EXISTS',
+    },
+  } as const;
+
+  const format: Format = {
+    singular: false,
+    relationships: {
+      children: {
+        singular: false,
+        relationships: {},
+      },
+    },
+  };
+
+  test('initial hydration tracks PKs as JSON-encoded compound arrays', () => {
+    const sourceContents: SourceContents = {
+      parent: [{id: 'p1', groupId: 'g1'}],
+      child: [
+        {groupId: 'g1', seq: 's1', text: 'a'},
+        {groupId: 'g1', seq: 's2', text: 'b'},
+      ],
+    };
+    const {actualStorage} = runPushTest({
+      sources,
+      sourceContents,
+      ast,
+      format,
+      pushes: [],
+    });
+
+    // Each entry in pks is JSON.stringify of [groupId, seq] in PK order.
+    // A bug that serialized only the first PK column would yield
+    // duplicate '"g1"' entries instead of distinct compound arrays.
+    expect(actualStorage['.children:cap']).toMatchInlineSnapshot(`
+      {
+        "["cap","g1"]": {
+          "pks": [
+            "["g1","s1"]",
+            "["g1","s2"]",
+          ],
+          "size": 2,
+        },
+      }
+    `);
+  });
+
+  test('remove + refill round-trips compound PKs through point lookup', () => {
+    // Removing s1 forces Cap to refill: it scans the partition, skips
+    // pks already in its set (deserialized from compound JSON), and
+    // picks the next one. If deserializePKToConstraint built a wrong
+    // constraint shape, the refill would either pick a wrong row or
+    // re-pick the removed row.
+    const sourceContents: SourceContents = {
+      parent: [{id: 'p1', groupId: 'g1'}],
+      child: [
+        {groupId: 'g1', seq: 's1', text: 'a'},
+        {groupId: 'g1', seq: 's2', text: 'b'},
+        {groupId: 'g1', seq: 's3', text: 'c'},
+        {groupId: 'g1', seq: 's4', text: 'd'},
+      ],
+    };
+    const {data, actualStorage} = runPushTest({
+      sources,
+      sourceContents,
+      ast,
+      format,
+      pushes: [
+        [
+          'child',
+          makeSourceChangeRemove({groupId: 'g1', seq: 's1', text: 'a'}),
+        ],
+      ],
+    });
+
+    expect(actualStorage['.children:cap']).toMatchInlineSnapshot(`
+      {
+        "["cap","g1"]": {
+          "pks": [
+            "["g1","s2"]",
+            "["g1","s3"]",
+            "["g1","s4"]",
+          ],
+          "size": 3,
+        },
+      }
+    `);
+    expect(data).toMatchInlineSnapshot(`
+      [
+        {
+          "children": [
+            {
+              "groupId": "g1",
+              "seq": "s2",
+              "text": "b",
+              Symbol(rc): 1,
+            },
+            {
+              "groupId": "g1",
+              "seq": "s3",
+              "text": "c",
+              Symbol(rc): 1,
+            },
+            {
+              "groupId": "g1",
+              "seq": "s4",
+              "text": "d",
+              Symbol(rc): 1,
+            },
+          ],
+          "groupId": "g1",
+          "id": "p1",
+          Symbol(rc): 1,
+        },
+      ]
+    `);
+  });
+
+  test('edit that changes a non-leading PK column updates tracked set', () => {
+    // The PK is ['groupId','seq']; we keep groupId stable (so the
+    // partition assertion passes) but change seq. The new compound PK
+    // must replace the old one in the tracked set with the columns in
+    // the right order — a bug that swapped column order would emit
+    // '["s1_new","g1"]' here.
+    const sourceContents: SourceContents = {
+      parent: [{id: 'p1', groupId: 'g1'}],
+      child: [
+        {groupId: 'g1', seq: 's1', text: 'a'},
+        {groupId: 'g1', seq: 's2', text: 'b'},
+      ],
+    };
+    const {actualStorage} = runPushTest({
+      sources,
+      sourceContents,
+      ast,
+      format,
+      pushes: [
+        [
+          'child',
+          makeSourceChangeEdit(
+            {groupId: 'g1', seq: 's1_new', text: 'a'},
+            {groupId: 'g1', seq: 's1', text: 'a'},
+          ),
+        ],
+      ],
+    });
+
+    expect(actualStorage['.children:cap']).toMatchInlineSnapshot(`
+      {
+        "["cap","g1"]": {
+          "pks": [
+            "["g1","s1_new"]",
+            "["g1","s2"]",
+          ],
+          "size": 2,
         },
       }
     `);

--- a/packages/zql/src/ivm/cap.push.test.ts
+++ b/packages/zql/src/ivm/cap.push.test.ts
@@ -104,10 +104,43 @@ describe('Cap push - basic behavior', () => {
         },
       ]
     `);
-    expect(actualStorage['.comments:cap']).toMatchInlineSnapshot(`undefined`);
-    expect(log.filter(msg => msg[0] === '.comments:cap')).toMatchInlineSnapshot(
-      `[]`,
-    );
+    expect(actualStorage['.comments:cap']).toMatchInlineSnapshot(`
+      {
+        "["cap","i1"]": {
+          "pks": [
+            "["c1"]",
+            "["c2"]",
+          ],
+          "size": 2,
+        },
+      }
+    `);
+    expect(log.filter(msg => msg[0] === '.comments:cap'))
+      .toMatchInlineSnapshot(`
+      [
+        [
+          ".comments:cap",
+          "push",
+          {
+            "row": {
+              "id": "c2",
+              "issueID": "i1",
+              "text": "c2",
+            },
+            "type": "add",
+          },
+        ],
+        [
+          ".comments:cap",
+          "fetch",
+          {
+            "constraint": {
+              "issueID": "i1",
+            },
+          },
+        ],
+      ]
+    `);
     expect(pushes).toMatchInlineSnapshot(`
       [
         {
@@ -183,7 +216,18 @@ describe('Cap push - basic behavior', () => {
         },
       ]
     `);
-    expect(actualStorage['.comments:cap']).toMatchInlineSnapshot(`undefined`);
+    expect(actualStorage['.comments:cap']).toMatchInlineSnapshot(`
+      {
+        "["cap","i1"]": {
+          "pks": [
+            "["c1"]",
+            "["c2"]",
+            "["c3"]",
+          ],
+          "size": 3,
+        },
+      }
+    `);
     expect(log.filter(msg => msg[0] === '.comments:cap')).toMatchInlineSnapshot(
       `[]`,
     );
@@ -242,10 +286,65 @@ describe('Cap push - basic behavior', () => {
         },
       ]
     `);
-    expect(actualStorage['.comments:cap']).toMatchInlineSnapshot(`undefined`);
-    expect(log.filter(msg => msg[0] === '.comments:cap')).toMatchInlineSnapshot(
-      `[]`,
-    );
+    expect(actualStorage['.comments:cap']).toMatchInlineSnapshot(`
+      {
+        "["cap","i1"]": {
+          "pks": [
+            "["c1"]",
+            "["c3"]",
+            "["c4"]",
+          ],
+          "size": 3,
+        },
+      }
+    `);
+    expect(log.filter(msg => msg[0] === '.comments:cap'))
+      .toMatchInlineSnapshot(`
+      [
+        [
+          ".comments:cap",
+          "push",
+          {
+            "row": {
+              "id": "c2",
+              "issueID": "i1",
+              "text": "c2",
+            },
+            "type": "remove",
+          },
+        ],
+        [
+          ".comments:cap",
+          "fetch",
+          {
+            "constraint": {
+              "issueID": "i1",
+            },
+          },
+        ],
+        [
+          ".comments:cap",
+          "push",
+          {
+            "row": {
+              "id": "c4",
+              "issueID": "i1",
+              "text": "c4",
+            },
+            "type": "add",
+          },
+        ],
+        [
+          ".comments:cap",
+          "fetch",
+          {
+            "constraint": {
+              "issueID": "i1",
+            },
+          },
+        ],
+      ]
+    `);
     expect(pushes).toMatchInlineSnapshot(`
       [
         {
@@ -332,10 +431,42 @@ describe('Cap push - basic behavior', () => {
         },
       ]
     `);
-    expect(actualStorage['.comments:cap']).toMatchInlineSnapshot(`undefined`);
-    expect(log.filter(msg => msg[0] === '.comments:cap')).toMatchInlineSnapshot(
-      `[]`,
-    );
+    expect(actualStorage['.comments:cap']).toMatchInlineSnapshot(`
+      {
+        "["cap","i1"]": {
+          "pks": [
+            "["c2"]",
+          ],
+          "size": 1,
+        },
+      }
+    `);
+    expect(log.filter(msg => msg[0] === '.comments:cap'))
+      .toMatchInlineSnapshot(`
+      [
+        [
+          ".comments:cap",
+          "push",
+          {
+            "row": {
+              "id": "c1",
+              "issueID": "i1",
+              "text": "c1",
+            },
+            "type": "remove",
+          },
+        ],
+        [
+          ".comments:cap",
+          "fetch",
+          {
+            "constraint": {
+              "issueID": "i1",
+            },
+          },
+        ],
+      ]
+    `);
     expect(pushes).toMatchInlineSnapshot(`
       [
         {
@@ -382,10 +513,40 @@ describe('Cap push - basic behavior', () => {
     });
 
     expect(data).toMatchInlineSnapshot(`[]`);
-    expect(actualStorage['.comments:cap']).toMatchInlineSnapshot(`undefined`);
-    expect(log.filter(msg => msg[0] === '.comments:cap')).toMatchInlineSnapshot(
-      `[]`,
-    );
+    expect(actualStorage['.comments:cap']).toMatchInlineSnapshot(`
+      {
+        "["cap","i1"]": {
+          "pks": [],
+          "size": 0,
+        },
+      }
+    `);
+    expect(log.filter(msg => msg[0] === '.comments:cap'))
+      .toMatchInlineSnapshot(`
+      [
+        [
+          ".comments:cap",
+          "push",
+          {
+            "row": {
+              "id": "c1",
+              "issueID": "i1",
+              "text": "c1",
+            },
+            "type": "remove",
+          },
+        ],
+        [
+          ".comments:cap",
+          "fetch",
+          {
+            "constraint": {
+              "issueID": "i1",
+            },
+          },
+        ],
+      ]
+    `);
     expect(pushes).toMatchInlineSnapshot(`
       [
         {
@@ -465,7 +626,18 @@ describe('Cap push - basic behavior', () => {
         },
       ]
     `);
-    expect(actualStorage['.comments:cap']).toMatchInlineSnapshot(`undefined`);
+    expect(actualStorage['.comments:cap']).toMatchInlineSnapshot(`
+      {
+        "["cap","i1"]": {
+          "pks": [
+            "["c1"]",
+            "["c2"]",
+            "["c3"]",
+          ],
+          "size": 3,
+        },
+      }
+    `);
     expect(log.filter(msg => msg[0] === '.comments:cap')).toMatchInlineSnapshot(
       `[]`,
     );
@@ -519,10 +691,48 @@ describe('Cap push - basic behavior', () => {
         },
       ]
     `);
-    expect(actualStorage['.comments:cap']).toMatchInlineSnapshot(`undefined`);
-    expect(log.filter(msg => msg[0] === '.comments:cap')).toMatchInlineSnapshot(
-      `[]`,
-    );
+    expect(actualStorage['.comments:cap']).toMatchInlineSnapshot(`
+      {
+        "["cap","i1"]": {
+          "pks": [
+            "["c1"]",
+            "["c2"]",
+          ],
+          "size": 2,
+        },
+      }
+    `);
+    expect(log.filter(msg => msg[0] === '.comments:cap'))
+      .toMatchInlineSnapshot(`
+      [
+        [
+          ".comments:cap",
+          "push",
+          {
+            "oldRow": {
+              "id": "c1",
+              "issueID": "i1",
+              "text": "c1",
+            },
+            "row": {
+              "id": "c1",
+              "issueID": "i1",
+              "text": "c1 updated",
+            },
+            "type": "edit",
+          },
+        ],
+        [
+          ".comments:cap",
+          "fetch",
+          {
+            "constraint": {
+              "issueID": "i1",
+            },
+          },
+        ],
+      ]
+    `);
     expect(pushes).toMatchInlineSnapshot(`
       [
         {
@@ -677,10 +887,83 @@ describe('Cap push - unordered overlay in join', () => {
         },
       ]
     `);
-    expect(actualStorage['.children:cap']).toMatchInlineSnapshot(`undefined`);
-    expect(log.filter(msg => msg[0] === '.children:cap')).toMatchInlineSnapshot(
-      `[]`,
-    );
+    expect(actualStorage['.children:cap']).toMatchInlineSnapshot(`
+      {
+        "["cap","g1"]": {
+          "pks": [
+            "["x2"]",
+            "["x3"]",
+            "["x4"]",
+          ],
+          "size": 3,
+        },
+      }
+    `);
+    expect(log.filter(msg => msg[0] === '.children:cap'))
+      .toMatchInlineSnapshot(`
+      [
+        [
+          ".children:cap",
+          "push",
+          {
+            "row": {
+              "group": "g1",
+              "id": "x1",
+              "text": "x1",
+            },
+            "type": "remove",
+          },
+        ],
+        [
+          ".children:cap",
+          "fetch",
+          {
+            "constraint": {
+              "group": "g1",
+            },
+          },
+        ],
+        [
+          ".children:cap",
+          "fetch",
+          {
+            "constraint": {
+              "group": "g1",
+            },
+          },
+        ],
+        [
+          ".children:cap",
+          "push",
+          {
+            "row": {
+              "group": "g1",
+              "id": "x4",
+              "text": "x4",
+            },
+            "type": "add",
+          },
+        ],
+        [
+          ".children:cap",
+          "fetch",
+          {
+            "constraint": {
+              "group": "g1",
+            },
+          },
+        ],
+        [
+          ".children:cap",
+          "fetch",
+          {
+            "constraint": {
+              "group": "g1",
+            },
+          },
+        ],
+      ]
+    `);
     expect(pushes).toMatchInlineSnapshot(`
       [
         {

--- a/packages/zql/src/ivm/cap.push.test.ts
+++ b/packages/zql/src/ivm/cap.push.test.ts
@@ -1274,3 +1274,175 @@ describe('Cap wiring', () => {
     `);
   });
 });
+
+describe('Cap push - compound partition key', () => {
+  // Compound correlation: parent.(region,org) → child.(region,org).
+  // Exercises multi-column partitioning in getCapStateKey, serializePK,
+  // and makePartitionKeyComparator — paths the single-column tests skip.
+  const sources: Sources = {
+    parent: {
+      columns: {
+        id: {type: 'string'},
+        region: {type: 'string'},
+        org: {type: 'string'},
+      },
+      primaryKeys: ['id'],
+    },
+    child: {
+      columns: {
+        id: {type: 'string'},
+        region: {type: 'string'},
+        org: {type: 'string'},
+        text: {type: 'string'},
+      },
+      primaryKeys: ['id'],
+    },
+  };
+
+  const ast: AST = {
+    table: 'parent',
+    orderBy: [['id', 'asc']],
+    where: {
+      type: 'correlatedSubquery',
+      related: {
+        system: 'client',
+        correlation: {
+          parentField: ['region', 'org'],
+          childField: ['region', 'org'],
+        },
+        subquery: {
+          table: 'child',
+          alias: 'children',
+          orderBy: [['id', 'asc']],
+        },
+      },
+      op: 'EXISTS',
+    },
+  } as const;
+
+  const format: Format = {
+    singular: false,
+    relationships: {
+      children: {
+        singular: false,
+        relationships: {},
+      },
+    },
+  };
+
+  test('partitions are keyed by all compound fields', () => {
+    const sourceContents: SourceContents = {
+      parent: [
+        {id: 'p1', region: 'us', org: 'acme'},
+        {id: 'p2', region: 'us', org: 'wayne'},
+        {id: 'p3', region: 'eu', org: 'acme'},
+      ],
+      child: [
+        {id: 'cA', region: 'us', org: 'acme', text: 'A'},
+        {id: 'cB', region: 'us', org: 'wayne', text: 'B'},
+      ],
+    };
+    const {data, actualStorage} = runPushTest({
+      sources,
+      sourceContents,
+      ast,
+      format,
+      pushes: [],
+    });
+
+    // p1 (us,acme) and p2 (us,wayne) each have their own child;
+    // p3 (eu,acme) has no matching child → excluded.
+    expect((data as unknown as readonly {id: string}[]).map(r => r.id)).toEqual(
+      ['p1', 'p2'],
+    );
+
+    // Storage keys include BOTH partition columns — a single-column
+    // key would collide (us,acme) with (us,wayne) and both parents
+    // would appear to share a cap bucket.
+    // p3 (eu,acme) has no matching children; its partition is still
+    // hydrated with size=0 during the initial scan.
+    expect(actualStorage['.children:cap']).toMatchInlineSnapshot(`
+      {
+        "["cap","eu","acme"]": {
+          "pks": [],
+          "size": 0,
+        },
+        "["cap","us","acme"]": {
+          "pks": [
+            "["cA"]",
+          ],
+          "size": 1,
+        },
+        "["cap","us","wayne"]": {
+          "pks": [
+            "["cB"]",
+          ],
+          "size": 1,
+        },
+      }
+    `);
+  });
+
+  test('push to one compound partition does not affect another', () => {
+    const sourceContents: SourceContents = {
+      parent: [
+        {id: 'p1', region: 'us', org: 'acme'},
+        {id: 'p2', region: 'us', org: 'wayne'},
+      ],
+      child: [
+        {id: 'c1', region: 'us', org: 'acme', text: 'x'},
+        {id: 'c2', region: 'us', org: 'acme', text: 'y'},
+        {id: 'c3', region: 'us', org: 'acme', text: 'z'},
+      ],
+    };
+    const {actualStorage} = runPushTest({
+      sources,
+      sourceContents,
+      ast,
+      format,
+      pushes: [
+        // 4th child in (us,acme) — exceeds cap limit of 3 → dropped.
+        [
+          'child',
+          makeSourceChangeAdd({
+            id: 'c4',
+            region: 'us',
+            org: 'acme',
+            text: 'w',
+          }),
+        ],
+        // 1st child in (us,wayne) — independent bucket, accepted.
+        [
+          'child',
+          makeSourceChangeAdd({
+            id: 'c5',
+            region: 'us',
+            org: 'wayne',
+            text: 'v',
+          }),
+        ],
+      ],
+    });
+
+    // (us,acme) cap still has c1,c2,c3 (c4 dropped; overflow).
+    // (us,wayne) cap now has c5.
+    expect(actualStorage['.children:cap']).toMatchInlineSnapshot(`
+      {
+        "["cap","us","acme"]": {
+          "pks": [
+            "["c1"]",
+            "["c2"]",
+            "["c3"]",
+          ],
+          "size": 3,
+        },
+        "["cap","us","wayne"]": {
+          "pks": [
+            "["c5"]",
+          ],
+          "size": 1,
+        },
+      }
+    `);
+  });
+});

--- a/packages/zql/src/ivm/cap.push.test.ts
+++ b/packages/zql/src/ivm/cap.push.test.ts
@@ -1151,3 +1151,126 @@ describe('Cap limit 0', () => {
     },
   );
 });
+
+describe('Cap wiring', () => {
+  const sources: Sources = {
+    issue: {
+      columns: {
+        id: {type: 'string'},
+        text: {type: 'string'},
+      },
+      primaryKeys: ['id'],
+    },
+    comment: {
+      columns: {
+        id: {type: 'string'},
+        issueID: {type: 'string'},
+        text: {type: 'string'},
+      },
+      primaryKeys: ['id'],
+    },
+  };
+  const format: Format = {
+    singular: false,
+    relationships: {
+      comments: {
+        singular: false,
+        relationships: {},
+      },
+    },
+  };
+
+  test('flipped EXISTS subquery is NOT wired through Cap', () => {
+    // Flipped EXISTS children route through FlippedJoin, which depends
+    // on ordering. If the builder ever accidentally sends them through
+    // Cap instead, ordering guarantees silently break. This test pins
+    // the wiring.
+    const flippedAst: AST = {
+      table: 'issue',
+      orderBy: [['id', 'asc']],
+      where: {
+        type: 'correlatedSubquery',
+        related: {
+          system: 'client',
+          correlation: {parentField: ['id'], childField: ['issueID']},
+          subquery: {
+            table: 'comment',
+            alias: 'comments',
+            orderBy: [['id', 'asc']],
+          },
+        },
+        op: 'EXISTS',
+        flip: true,
+      },
+    } as const;
+
+    const sourceContents: SourceContents = {
+      issue: [{id: 'i1', text: 'i1'}],
+      comment: [
+        {id: 'c1', issueID: 'i1', text: 'c1'},
+        {id: 'c2', issueID: 'i1', text: 'c2'},
+      ],
+    };
+    const {actualStorage} = runPushTest({
+      sources,
+      sourceContents,
+      ast: flippedAst,
+      format,
+      pushes: [],
+    });
+
+    const capKeys = Object.keys(actualStorage).filter(k => k.endsWith(':cap'));
+    expect(capKeys).toEqual([]);
+  });
+
+  test('permissions-system EXISTS uses cap limit=1', () => {
+    // EXISTS on a subquery with system='permissions' must use the
+    // PERMISSIONS_EXISTS_LIMIT (1) rather than the default EXISTS_LIMIT
+    // (3). If this constant is ever changed, permissions checks could
+    // overfetch or undercount — security-relevant.
+    const permissionsAst: AST = {
+      table: 'issue',
+      orderBy: [['id', 'asc']],
+      where: {
+        type: 'correlatedSubquery',
+        related: {
+          system: 'permissions',
+          correlation: {parentField: ['id'], childField: ['issueID']},
+          subquery: {
+            table: 'comment',
+            alias: 'comments',
+            orderBy: [['id', 'asc']],
+          },
+        },
+        op: 'EXISTS',
+      },
+    } as const;
+
+    const sourceContents: SourceContents = {
+      issue: [{id: 'i1', text: 'i1'}],
+      comment: [
+        {id: 'c1', issueID: 'i1', text: 'c1'},
+        {id: 'c2', issueID: 'i1', text: 'c2'},
+        {id: 'c3', issueID: 'i1', text: 'c3'},
+      ],
+    };
+    const {actualStorage} = runPushTest({
+      sources,
+      sourceContents,
+      ast: permissionsAst,
+      format,
+      pushes: [],
+    });
+
+    expect(actualStorage['.comments:cap']).toMatchInlineSnapshot(`
+      {
+        "["cap","i1"]": {
+          "pks": [
+            "["c1"]",
+          ],
+          "size": 1,
+        },
+      }
+    `);
+  });
+});

--- a/packages/zql/src/ivm/cap.push.test.ts
+++ b/packages/zql/src/ivm/cap.push.test.ts
@@ -761,6 +761,66 @@ describe('Cap push - basic behavior', () => {
       ]
     `);
   });
+
+  test('child edit that changes PK updates tracked set', () => {
+    const sourceContents: SourceContents = {
+      issue: [{id: 'i1', text: 'i1'}],
+      comment: [
+        {id: 'c1', issueID: 'i1', text: 'c1'},
+        {id: 'c2', issueID: 'i1', text: 'c2'},
+      ],
+    };
+    const {data, actualStorage} = runPushTest({
+      sources,
+      sourceContents,
+      ast,
+      format,
+      pushes: [
+        [
+          'comment',
+          makeSourceChangeEdit(
+            {id: 'c1_renamed', issueID: 'i1', text: 'c1'},
+            {id: 'c1', issueID: 'i1', text: 'c1'},
+          ),
+        ],
+      ],
+    });
+
+    expect(actualStorage['.comments:cap']).toMatchInlineSnapshot(`
+      {
+        "["cap","i1"]": {
+          "pks": [
+            "["c1_renamed"]",
+            "["c2"]",
+          ],
+          "size": 2,
+        },
+      }
+    `);
+    expect(data).toMatchInlineSnapshot(`
+      [
+        {
+          "comments": [
+            {
+              "id": "c1_renamed",
+              "issueID": "i1",
+              "text": "c1",
+              Symbol(rc): 1,
+            },
+            {
+              "id": "c2",
+              "issueID": "i1",
+              "text": "c2",
+              Symbol(rc): 1,
+            },
+          ],
+          "id": "i1",
+          "text": "i1",
+          Symbol(rc): 1,
+        },
+      ]
+    `);
+  });
 });
 
 describe('Cap push - unordered overlay in join', () => {

--- a/packages/zql/src/ivm/cap.ts
+++ b/packages/zql/src/ivm/cap.ts
@@ -88,56 +88,36 @@ export class Cap implements Operator {
     assert(!req.start, 'Cap does not support start');
     assert(!req.reverse, 'Cap does not support reverse');
 
-    if (
+    // Cap is only built for non-flipped EXISTS subqueries, whose only
+    // downstream consumer is a Join that always fetches with a constraint
+    // built from the correlation's childField — which is Cap's partition
+    // key. So either partitionKey is undefined, or constraint matches.
+    assert(
       !this.#partitionKey ||
-      (req.constraint &&
-        constraintMatchesPartitionKey(req.constraint, this.#partitionKey))
-    ) {
-      const capStateKey = getCapStateKey(this.#partitionKey, req.constraint);
-      const capState = this.#storage.get(capStateKey);
-      if (!capState) {
-        yield* this.#initialFetch(req);
-        return;
-      }
-      if (capState.size === 0) {
-        return;
-      }
-      // PK-based point lookups: fetch each tracked row by its PK directly,
-      // rather than scanning the partition and filtering.
-      for (const pk of capState.pks) {
-        const constraint = deserializePKToConstraint(pk, this.#primaryKey);
-        for (const inputNode of this.#input.fetch({constraint})) {
-          if (inputNode === 'yield') {
-            yield inputNode;
-            continue;
-          }
-          yield inputNode;
-        }
-      }
+        (req.constraint !== undefined &&
+          constraintMatchesPartitionKey(req.constraint, this.#partitionKey)),
+      'Cap fetch: constraint must match partition key when partitioned',
+    );
+
+    const capStateKey = getCapStateKey(this.#partitionKey, req.constraint);
+    const capState = this.#storage.get(capStateKey);
+    if (!capState) {
+      yield* this.#initialFetch(req);
       return;
     }
-    // There is a partition key, but the fetch is not constrained or constrained
-    // on a different key. This currently only happens with nested sub-queries.
-    const pkSetCache = new Map<string, Set<string> | null>();
-    for (const inputNode of this.#input.fetch(req)) {
-      if (inputNode === 'yield') {
-        yield inputNode;
-        continue;
-      }
-      const capStateKey = getCapStateKey(this.#partitionKey, inputNode.row);
-      if (!pkSetCache.has(capStateKey)) {
-        const capState = this.#storage.get(capStateKey);
-        pkSetCache.set(
-          capStateKey,
-          capState && capState.size > 0 ? new Set(capState.pks) : null,
-        );
-      }
-      const pkSet = pkSetCache.get(capStateKey);
-      if (pkSet) {
-        const pk = serializePK(inputNode.row, this.#primaryKey);
-        if (pkSet.has(pk)) {
+    if (capState.size === 0) {
+      return;
+    }
+    // PK-based point lookups: fetch each tracked row by its PK directly,
+    // rather than scanning the partition and filtering.
+    for (const pk of capState.pks) {
+      const constraint = deserializePKToConstraint(pk, this.#primaryKey);
+      for (const inputNode of this.#input.fetch({constraint})) {
+        if (inputNode === 'yield') {
           yield inputNode;
+          continue;
         }
+        yield inputNode;
       }
     }
   }


### PR DESCRIPTION
- #5857 enables CAP since we now detect query result drift in the same CVR version

# Wire up `Cap` for non-flipped EXISTS subqueries

## Summary

Switches the builder to use the `Cap` operator (instead of `Take`) for the child pipeline of a non-flipped `whereExists`, and tightens `Cap`'s fetch invariants now that its call shape is fully constrained by the builder.

The functional code change is small. The bulk of this PR is tests covering the wiring across push paths, edge cases, compound keys, OR/AND combinations, and a PG integration sweep.

## Code changes

`packages/zql/src/builder/builder.ts`
- Thread an `isNonFlippedExistsChild` flag through `buildPipelineInternal`. When set:
  - Pass `undefined` for `orderBy` to `source.connect` (Cap doesn't need it).
  - Use `Cap` instead of `Take` for the `limit` operator.
  - Assert `ast.start === undefined` and `ast.related === undefined` (EXISTS subqueries should never carry these).
- Pass `false` from the flipped-EXISTS path and `fromCondition` from the standard correlated-subquery path.

`packages/zql/src/ivm/cap.ts`
- Remove the fallback branch that handled fetches with no constraint or with a constraint that didn't match the partition key. With the new builder wiring, `Cap`'s only downstream consumer is the EXISTS `Join`, which always fetches with a constraint built from the correlation's `childField` (i.e., `Cap`'s partition key). Replace the conditional with an assertion documenting the invariant.

## Tests

Mostly new: ~1.6k lines of tests around ~120 lines of production change.

`packages/zql/src/ivm/cap.push.test.ts` — unit-level push/fetch behavior:
- Basic behavior (add/edit/remove, under and over the cap).
- Unordered overlay in join.
- `limit: 0` semantics.
- Wiring (verifying the builder selects `Cap` vs `Take` correctly across query shapes).
- Compound partition key.
- Compound primary key.

`packages/zql-integration-tests/src/cap.pg.test.ts` — end-to-end against PG/SQLite:
- Initial materialization correctness.
- Add/remove transitions across the cap boundary (including overflow, untracked overflow, size-0 transitions).
- Join-level unordered overlay across multiple parents.
- Nested `whereExists` (single and double nesting).
- OR of two EXISTS — dedup and independent branches.
- AND of two EXISTS
