### PR TITLE
chore(rm): first shadow sync at ~12 hrs

### DIFF
--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -610,11 +610,13 @@ test('zero-cache --help', () => {
                                                                         drift, PG version quirks, etc.), the shadow run fails before a customer                                                    
                                                                         actually needs a full reset.                                                                                               
                                                                                                                                                                                                    
-     --shadow-sync-interval-hours number                                default: 24                                                                                                                
+     --shadow-sync-interval-hours number                                default: 12                                                                                                                
        ZERO_SHADOW_SYNC_INTERVAL_HOURS env                                                                                                                                                         
-                                                                        The interval between shadow initial-sync runs, in hours. The first run                                                     
-                                                                        is additionally staggered by a random fraction of this interval so that                                                    
-                                                                        a fleet restart does not cause all tasks to canary simultaneously.                                                         
+                                                                        The interval between shadow initial-sync runs, in hours. The first                                                         
+                                                                        run fires within [2/3, 1) of this interval after startup, so the                                                           
+                                                                        canary completes at least once per task lifetime (the replication                                                          
+                                                                        manager is restarted every ~24h) while still jittering so a fleet                                                          
+                                                                        restart does not cause all tasks to canary simultaneously.                                                                 
                                                                                                                                                                                                    
      --shadow-sync-sample-rate number                                   default: 0.1                                                                                                               
        ZERO_SHADOW_SYNC_SAMPLE_RATE env                                                                                                                                                            

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -947,11 +947,13 @@ export const zeroOptions = {
     },
 
     intervalHours: {
-      type: v.number().default(24),
+      type: v.number().default(12),
       desc: [
-        `The interval between shadow initial-sync runs, in hours. The first run`,
-        `is additionally staggered by a random fraction of this interval so that`,
-        `a fleet restart does not cause all tasks to canary simultaneously.`,
+        `The interval between shadow initial-sync runs, in hours. The first`,
+        `run fires within [2/3, 1) of this interval after startup, so the`,
+        `canary completes at least once per task lifetime (the replication`,
+        `manager is restarted every ~24h) while still jittering so a fleet`,
+        `restart does not cause all tasks to canary simultaneously.`,
       ],
     },
 

--- a/packages/zero-cache/src/services/shadow-sync/shadow-sync-service.test.ts
+++ b/packages/zero-cache/src/services/shadow-sync/shadow-sync-service.test.ts
@@ -45,16 +45,15 @@ describe('ShadowSyncService scheduling', () => {
     );
   }
 
-  test('first run waits at least one full interval (jitter = 0)', async () => {
+  test('first run waits at least 2/3 of an interval (jitter = 0)', async () => {
+    // minFirstRunDelay = floor(1000 * 2 / 3) = 666, jitter = 0.
     vi.spyOn(Math, 'random').mockReturnValue(0);
     const service = makeService();
     const running = service.run();
 
-    // One interval minus a tick — no run yet.
-    await vi.advanceTimersByTimeAsync(INTERVAL_MS - 1);
+    await vi.advanceTimersByTimeAsync(665);
     expect(shadowInitialSyncMock).not.toHaveBeenCalled();
 
-    // Cross the one-interval boundary — first run fires.
     await vi.advanceTimersByTimeAsync(1);
     expect(shadowInitialSyncMock).toHaveBeenCalledTimes(1);
 
@@ -62,13 +61,14 @@ describe('ShadowSyncService scheduling', () => {
     await running;
   });
 
-  test('first run waits up to two intervals (jitter ≈ max)', async () => {
-    // Math.floor(0.9999 * 1000) = 999, so firstRunDelay = 1999.
+  test('first run fires before one full interval (jitter ≈ max)', async () => {
+    // minFirstRunDelay = 666, range = 1000 - 666 = 334.
+    // Math.floor(0.9999 * 334) = 333, so firstRunDelay = 999.
     vi.spyOn(Math, 'random').mockReturnValue(0.9999);
     const service = makeService();
     const running = service.run();
 
-    await vi.advanceTimersByTimeAsync(INTERVAL_MS * 2 - 2);
+    await vi.advanceTimersByTimeAsync(998);
     expect(shadowInitialSyncMock).not.toHaveBeenCalled();
 
     await vi.advanceTimersByTimeAsync(1);

--- a/packages/zero-cache/src/services/shadow-sync/shadow-sync-service.ts
+++ b/packages/zero-cache/src/services/shadow-sync/shadow-sync-service.ts
@@ -40,11 +40,16 @@ export class ShadowSyncService implements Service {
   async run() {
     const {intervalMs, sampleRate, maxRowsPerTable, textCopy} = this.#options;
 
-    // Why: wait at least one full interval before the first run so shadow
-    // sync never fires immediately on task startup, and add a random
-    // fraction of the interval on top so a fleet-wide restart does not
-    // cause every task to canary simultaneously.
-    const firstRunDelay = intervalMs + Math.floor(Math.random() * intervalMs);
+    // Why: first run fires in [intervalMs * 2/3, intervalMs) — late enough
+    // that shadow sync never fires immediately on task startup, but always
+    // before one full interval elapses so the canary completes at least once
+    // per task lifetime (the replication manager is restarted every ~24h).
+    // The last third is randomized so a fleet-wide restart does not cause
+    // every task to canary simultaneously.
+    const minFirstRunDelay = Math.floor((intervalMs * 2) / 3);
+    const firstRunDelay =
+      minFirstRunDelay +
+      Math.floor(Math.random() * (intervalMs - minFirstRunDelay));
     this.#lc.info?.(
       `shadow-syncer started; first run in ${firstRunDelay} ms, then every ${intervalMs} ms`,
     );


### PR DESCRIPTION
We restart the RM every 24 hrs. So shadow-sync needs to run before then.

https://rocicorp.slack.com/archives/C013XFG80JC/p1777048675512559