### PR TITLE
fix(zql): added optional ctx when context is unknown

### DIFF
--- a/packages/zero-types/src/default-types.ts
+++ b/packages/zero-types/src/default-types.ts
@@ -17,6 +17,12 @@ import type {Schema} from './schema.ts';
  */
 export interface DefaultTypes {}
 
+export type IsUnknown<T> = unknown extends T
+  ? [T] extends [unknown]
+    ? true
+    : false
+  : false;
+
 export type DefaultSchema<TDefaultTypes = DefaultTypes> =
   TDefaultTypes extends {
     readonly schema: infer S extends Schema;

--- a/packages/zql/src/mutate/mutator-registry.test.ts
+++ b/packages/zql/src/mutate/mutator-registry.test.ts
@@ -291,6 +291,53 @@ test('mustGetMutator throws for unknown names and returns the correct type', () 
   );
 });
 
+test('mustGetMutator makes ctx optional only for fallback unknown context', () => {
+  type Context = {userId: string};
+  type DbTransaction = {db: true};
+
+  const unknownContextMutators = defineMutatorsWithType<typeof schema>()({
+    run: defineMutator(async ({args, tx}) => {
+      void args;
+      void tx;
+    }),
+  });
+
+  const concreteContextMutators = defineMutatorsWithType<typeof schema>()({
+    run: defineMutator<{id: string}, typeof schema, Context, DbTransaction>(
+      async ({args, ctx, tx}) => {
+        void args;
+        void ctx;
+        void tx;
+      },
+    ),
+  });
+
+  const unknownContextMutator = mustGetMutator(unknownContextMutators, 'run');
+  const concreteContextMutator = mustGetMutator(concreteContextMutators, 'run');
+
+  expectTypeOf(unknownContextMutator.fn).toBeCallableWith({
+    args: undefined,
+    tx: {} as Transaction<typeof schema, unknown>,
+  });
+  expectTypeOf(unknownContextMutator.fn).toBeCallableWith({
+    args: {id: '1'},
+    ctx: {arbitrary: true},
+    tx: {} as Transaction<typeof schema, unknown>,
+  });
+
+  expectTypeOf(concreteContextMutator.fn).toBeCallableWith({
+    args: {id: '1'},
+    ctx: {userId: '123'},
+    tx: {} as Transaction<typeof schema, DbTransaction>,
+  });
+
+  // @ts-expect-error ctx is still required when a concrete context exists
+  void concreteContextMutator.fn({
+    args: {id: '1'},
+    tx: {} as Transaction<typeof schema, DbTransaction>,
+  });
+});
+
 test('isMutatorRegistry returns false for non-registries', () => {
   expect(isMutatorRegistry(null)).toBe(false);
   expect(isMutatorRegistry(undefined)).toBe(false);

--- a/packages/zql/src/mutate/mutator-registry.test.ts
+++ b/packages/zql/src/mutate/mutator-registry.test.ts
@@ -191,7 +191,6 @@ test('mutator.fn validates args when validator is provided', async () => {
 
   await mutators.item.test.fn({
     args: {id: '456'},
-    ctx: undefined,
     tx: mockTx,
   });
 
@@ -234,7 +233,6 @@ test('mutator.fn throws on validation failure and does not run', async () => {
   await expect(
     mutators.item.test.fn({
       args: {id: 'bad'},
-      ctx: undefined,
       tx: {} as Transaction<typeof schema, unknown>,
     }),
   ).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -531,7 +529,6 @@ describe('input/output type separation', () => {
     // Call fn with string input (simulating server receiving raw args)
     await mutators.item.update.fn({
       args: '42',
-      ctx: undefined,
       tx: mockTx,
     });
 
@@ -579,9 +576,12 @@ describe('input/output type separation', () => {
     } as Transaction<typeof schema, unknown>;
 
     // When fn is called, it should transform undefined to 'default-value'
+    expectTypeOf(mutators.item.create.fn).toBeCallableWith({
+      args: undefined,
+      tx: mockTx,
+    });
     await mutators.item.create.fn({
       args: undefined,
-      ctx: undefined,
       tx: mockTx,
     });
 
@@ -743,11 +743,10 @@ describe('type inference', () => {
       .toEqualTypeOf<ReadonlyJSONValue | undefined>();
     const request3 = mutators.def3('whatever');
     expectTypeOf(request3.args).toEqualTypeOf<ReadonlyJSONValue | undefined>();
-    expectTypeOf<typeof request3.mutator.fn>().parameter(0).toEqualTypeOf<{
-      args: ReadonlyJSONValue | undefined;
-      ctx: unknown;
-      tx: Transaction<typeof schema, unknown>;
-    }>();
+    expectTypeOf(request3.mutator.fn).toBeCallableWith({
+      args: undefined,
+      tx: {} as Transaction<typeof schema, unknown>,
+    });
 
     const request4 = mutators.def4('test-string');
     expectTypeOf(request4.args).toEqualTypeOf<string>();

--- a/packages/zql/src/mutate/mutator-registry.ts
+++ b/packages/zql/src/mutate/mutator-registry.ts
@@ -295,7 +295,7 @@ function createMutator<
       : (options.args as unknown as ArgsOutput);
     await definition.fn({
       args: validatedArgs,
-      ctx: options.ctx,
+      ctx: options.ctx as C,
       tx: options.tx,
     });
   };

--- a/packages/zql/src/mutate/mutator-registry.ts
+++ b/packages/zql/src/mutate/mutator-registry.ts
@@ -24,7 +24,7 @@ import {
   type MutateRequestTypes,
   type Mutator,
   type MutatorDefinition,
-  type MutatorDefinitionFunction,
+  type MutatorExecutionFunction,
   type MutatorTypes,
 } from './mutator.ts';
 
@@ -285,7 +285,7 @@ function createMutator<
 
   // fn takes ReadonlyJSONValue args because it's called during rebase (from
   // stored JSON) and on the server (from wire format). Validation happens here.
-  const fn: MutatorDefinitionFunction<
+  const fn: MutatorExecutionFunction<
     ArgsInput,
     C,
     Transaction<TSchema, TWrappedTransaction>

--- a/packages/zql/src/mutate/mutator.ts
+++ b/packages/zql/src/mutate/mutator.ts
@@ -5,6 +5,7 @@ import type {
   DefaultContext,
   DefaultSchema,
   DefaultWrappedTransaction,
+  IsUnknown,
 } from '../../../zero-types/src/default-types.ts';
 import type {Schema} from '../../../zero-types/src/schema.ts';
 import type {AnyTransaction, Transaction} from './custom.ts';
@@ -197,6 +198,16 @@ export type MutatorDefinitionFunction<
   tx: TTransaction;
 }) => Promise<void>;
 
+export type MutatorExecutionFunction<
+  TOutput extends ReadonlyJSONValue | undefined,
+  TContext,
+  TTransaction,
+> = (
+  options: IsUnknown<TContext> extends true
+    ? {args: TOutput; tx: TTransaction; ctx?: TContext}
+    : {args: TOutput; tx: TTransaction; ctx: TContext},
+) => Promise<void>;
+
 // ----------------------------------------------------------------------------
 // Mutator and MutateRequest types
 // ----------------------------------------------------------------------------
@@ -234,7 +245,7 @@ export type Mutator<
    * during rebase (from stored JSON) and on the server (from wire format).
    * Validation happens internally before the recipe function runs.
    */
-  readonly 'fn': MutatorDefinitionFunction<
+  readonly 'fn': MutatorExecutionFunction<
     TInput,
     TContext,
     Transaction<TSchema, TWrappedTransaction>

--- a/packages/zql/src/query/query-registry.test.ts
+++ b/packages/zql/src/query/query-registry.test.ts
@@ -1197,6 +1197,45 @@ describe('mustGetQuery', () => {
     expectTypeOf(query2['~']['$schema']).toEqualTypeOf<typeof schema>();
   });
 
+  test('mustGetQuery makes ctx optional only for fallback unknown context', () => {
+    type Context = {userId: string};
+
+    const unknownContextQueries = defineQueriesWithType<typeof schema>()({
+      getUser: defineQuery(({args}) => {
+        void args;
+        return builder.foo;
+      }),
+    });
+
+    const concreteContextQueries = defineQueriesWithType<typeof schema>()({
+      getUser: defineQuery(({args, ctx}: {args: string; ctx: Context}) => {
+        void ctx;
+        return builder.foo.where('id', '=', args);
+      }),
+    });
+
+    const unknownContextQuery = mustGetQuery(unknownContextQueries, 'getUser');
+    const concreteContextQuery = mustGetQuery(
+      concreteContextQueries,
+      'getUser',
+    );
+
+    expectTypeOf(unknownContextQuery.fn).toBeCallableWith({args: undefined});
+    expectTypeOf(unknownContextQuery.fn).toBeCallableWith({args: 'abc'});
+    expectTypeOf(unknownContextQuery.fn).toBeCallableWith({
+      args: 'abc',
+      ctx: {arbitrary: true},
+    });
+
+    expectTypeOf(concreteContextQuery.fn).toBeCallableWith({
+      args: 'abc',
+      ctx: {userId: '123'},
+    });
+
+    // @ts-expect-error ctx is still required when a concrete context exists
+    void concreteContextQuery.fn({args: 'abc'});
+  });
+
   test('throws for non-existent query', () => {
     const queries = defineQueries({
       getUser: defineQuery(() => builder.foo),

--- a/packages/zql/src/query/query-registry.test.ts
+++ b/packages/zql/src/query/query-registry.test.ts
@@ -292,6 +292,8 @@ describe('defineQueries', () => {
     expectTypeOf(queries.getValue)
       .parameter(0)
       .toEqualTypeOf<string | undefined>();
+    expectTypeOf(queries.getValue.fn).toBeCallableWith({args: undefined});
+    expectTypeOf(queries.getValue.fn).toBeCallableWith({args: 'explicit'});
 
     // Call with undefined - query function gets transformed value
     const result = addContextToQuery(queries.getValue(undefined), {});
@@ -314,7 +316,7 @@ describe('defineQueries', () => {
     });
 
     // Call with actual string value
-    const result2 = queries.getValue.fn({args: 'explicit', ctx: {}});
+    const result2 = queries.getValue.fn({args: 'explicit'});
 
     // The query AST should use the input value (no transform needed)
     expect(asQueryInternals(result2).ast).toEqual({

--- a/packages/zql/src/query/query-registry.ts
+++ b/packages/zql/src/query/query-registry.ts
@@ -11,6 +11,7 @@ import type {
   BaseDefaultSchema,
   DefaultContext,
   DefaultSchema,
+  IsUnknown,
 } from '../../../zero-types/src/default-types.ts';
 import type {Schema} from '../../../zero-types/src/schema.ts';
 import {asQueryInternals} from './query-internals.ts';
@@ -48,7 +49,7 @@ export type CustomQuery<
   TContext = DefaultContext,
 > = {
   readonly 'queryName': string;
-  readonly 'fn': QueryDefinitionFunction<TTable, TInput, TReturn, TContext>;
+  readonly 'fn': QueryExecutionFunction<TTable, TInput, TReturn, TContext>;
   readonly '~': CustomQueryTypes<TTable, TInput, TSchema, TReturn, TContext>;
 } & CustomQueryCallable<TTable, TInput, TOutput, TSchema, TReturn, TContext>;
 
@@ -296,6 +297,17 @@ export type QueryDefinitionFunction<
   TContext,
 > = (options: {args: TInput; ctx: TContext}) => Query<TTable, Schema, TReturn>;
 
+export type QueryExecutionFunction<
+  TTable extends string,
+  TInput extends ReadonlyJSONValue | undefined,
+  TReturn,
+  TContext,
+> = (
+  options: IsUnknown<TContext> extends true
+    ? {args: TInput; ctx?: TContext}
+    : {args: TInput; ctx: TContext},
+) => Query<TTable, Schema, TReturn>;
+
 /**
  * Defines a query to be used with {@link defineQueries}.
  *
@@ -509,7 +521,7 @@ export function createQuery<
 ): CustomQuery<TTable, TInput, TOutput, TSchema, TReturn, TContext> {
   const {validator} = definition;
 
-  const fn: QueryDefinitionFunction<
+  const fn: QueryExecutionFunction<
     TTable,
     TInput,
     TReturn,
@@ -522,7 +534,7 @@ export function createQuery<
     return asQueryInternals(
       definition.fn({
         args: validatedArgs,
-        ctx: options.ctx,
+        ctx: options.ctx as TContext,
       }),
     ).nameAndArgs(
       name,


### PR DESCRIPTION
Currently when you don't have a context type defined it will default to `unknown` and that means that you need to do this weird workaround:

```tsx
const result = await handleMutateRequest(
  dbProvider,
  transact =>
    transact((tx, name, args) => {
      const mutator = mustGetMutator(mutators, name)
      return mutator.fn({
        args,
        tx,
        // workaround
        ctx: undefined,
      })
    }),
  request
)
```

This allows you to omit `ctx` when `unknown`:

```tsx
const result = await handleMutateRequest(
  dbProvider,
  transact =>
    transact((tx, name, args) => {
      const mutator = mustGetMutator(mutators, name)
      return mutator.fn({
        args,
        tx,
      })
    }),
  request
)
```

But require when you define a context type (with either the global types or `defineMutatorWithType`).