### PR TITLE
chore: make new ddl logic backwards compatible with old events

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl.pg.test.ts
@@ -105,9 +105,10 @@ describe('change-source/tables/ddl', () => {
     `;
 
   // For zero_all, zero_sum
-  const DDL_START: Omit<DdlStartEvent, 'context' | 'event'> = {
+  const DDL_START: Omit<DdlStartEvent, 'context'> = {
     type: 'ddlStart',
     version: 1,
+    event: {tag: 'UNUSED'},
     schema: {
       tables: [
         {

--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl.pg.test.ts
@@ -105,10 +105,9 @@ describe('change-source/tables/ddl', () => {
     `;
 
   // For zero_all, zero_sum
-  const DDL_START: Omit<DdlStartEvent, 'context'> = {
+  const DDL_START: Omit<DdlStartEvent, 'context' | 'event'> = {
     type: 'ddlStart',
     version: 1,
-    event: {tag: 'UNUSED'},
     schema: {
       tables: [
         {
@@ -1592,6 +1591,23 @@ describe('change-source/tables/ddl', () => {
         query: `ALTER TABLE pub.foo ADD boo text; ALTER TABLE pub.foo DROP boo;`,
       },
       event: {tag: 'ALTER TABLE'},
+    });
+  });
+
+  test('parse legacy ddlStartEvent', () => {
+    const legacyDdlStartEvent: Omit<DdlStartEvent, 'event'> = {
+      type: 'ddlStart',
+      version: 1,
+      context: {query: 'foo'},
+      schema: {tables: [], indexes: []},
+    };
+    const parsed = v.parse(legacyDdlStartEvent, ddlStartEventSchema);
+    expect(parsed).toMatchObject({
+      type: 'ddlStart',
+      version: 1,
+      context: {query: 'foo'},
+      schema: {tables: [], indexes: []},
+      event: {tag: 'UNKNOWN'},
     });
   });
 });

--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl.ts
@@ -34,6 +34,11 @@ export const ddlEventSchema = triggerEvent.extend({
 // are guaranteed to be preceded by a `ddlStart` message.
 export const ddlStartEventSchema = ddlEventSchema.extend({
   type: v.literal('ddlStart'),
+  // For backwards compatibility with previous versions of the trigger,
+  // default an absent `event` field with a semantic equivalent. This
+  // field override can be removed in a version that is rollback safe
+  // with 1.4.0.
+  event: v.object({tag: v.string()}).optional(() => ({tag: 'UNKNOWN'})),
 });
 
 export type DdlStartEvent = v.Infer<typeof ddlStartEventSchema>;


### PR DESCRIPTION
Make the ddl logic introduced in https://github.com/rocicorp/mono/pull/5829, which modifies the format of the emitted events, backwards compatible with events from the previous schema.

Event though the event triggers / functions are upgraded when a server first starts, the server may have to process existing (legacy) events in the replication stream, so event trigger processing code must be backwards compatible with previous schemas.

Context:
* https://rocicorp.slack.com/archives/C0B033F75FD/p1777355058552969