### PR TITLE
chore: avoid swallowing trigger update errors if ddlDetection is on

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.pg.test.ts
@@ -362,7 +362,7 @@ describe('change-source/pg', () => {
         {
           lock: true,
           publications: ['_woo_metadata_0', 'zero_foo'],
-          ddlDetection: true, // degraded mode
+          ddlDetection: true,
         },
       ],
     });

--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.pg.test.ts
@@ -8,6 +8,7 @@ import {getPublicationInfo} from './published.ts';
 import {
   addReplica,
   setupTablesAndReplication,
+  setupTriggers,
   validatePublicationName,
   validatePublications,
 } from './shard.ts';
@@ -342,6 +343,44 @@ describe('change-source/pg', () => {
     `);
 
     expect(await db`SELECT evtname from pg_event_trigger`.values()).toEqual([]);
+  });
+
+  test('trigger upgrade failure detected', async () => {
+    const shardConfig = {
+      appID: 'woo',
+      shardNum: 0,
+      publications: ['zero_foo'],
+    };
+
+    await db /*sql*/ `
+      CREATE TABLE foo(id INT4 PRIMARY KEY);
+      CREATE PUBLICATION zero_foo FOR TABLE foo;
+    `.simple();
+    await db.begin(tx => setupTablesAndReplication(lc, tx, shardConfig));
+    await expectTables(db, {
+      ['woo_0.shardConfig']: [
+        {
+          lock: true,
+          publications: ['_woo_metadata_0', 'zero_foo'],
+          ddlDetection: true, // degraded mode
+        },
+      ],
+    });
+    expect(
+      await db`SELECT evtname from pg_event_trigger`.values(),
+    ).toMatchObject([['woo_ddl_start_0'], ['woo_ddl_end_0']]);
+
+    // Now try to upgrade as a different user.
+    await db /*sql*/ `
+      CREATE ROLE different_user IN ROLE current_user;
+      SET ROLE different_user;
+    `.simple();
+
+    await expect(
+      db.begin(tx => setupTriggers(lc, tx, shardConfig)),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[PostgresError: permission denied to create event trigger "woo_ddl_start_0"]`,
+    );
   });
 
   test('permissions hash trigger', async () => {

--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
@@ -377,9 +377,17 @@ export async function setupTriggers(
   tx: PostgresTransaction,
   shard: ShardConfig,
 ) {
+  const schema = upstreamSchema(shard);
+  const [{ddlDetection}] = await tx<InternalShardConfig[]> /*sql*/ `
+    SELECT "ddlDetection" FROM ${tx(schema)}."shardConfig"`;
   try {
     await tx.savepoint(sub => sub.unsafe(triggerSetup(shard)));
   } catch (e) {
+    if (ddlDetection) {
+      // If ddlDetection has already been enabled, subsequent failures to
+      // upgrade the trigger should be propagated rather than swallowed.
+      throw e;
+    }
     if (
       !(
         e instanceof postgres.PostgresError &&


### PR DESCRIPTION
The initial trigger event setup logic handles the Postgres "insufficient privilege" error code by proceeding without ddl detection, for Postgres providers that do not support event triggers.

This same error can happen when attempting to upgrade existing event triggers (on a Postgres provider that _does_ support event triggers) if, for example, the zero-cache is running as a different user.

In such cases, the error should be propagated instead of swallowed, as the application is essentially unable to perform the schema upgrade that it needs to correctly proceed.


Context:
* https://rocicorp.slack.com/archives/C0AK5KX8HGE/p1777052557306029