### PR TITLE
chore: disable /keepalive timeouts by default when not in ECS

### DIFF
--- a/packages/zero-cache/src/config/normalize.ts
+++ b/packages/zero-cache/src/config/normalize.ts
@@ -28,6 +28,13 @@ export function isDevelopmentMode(): boolean {
   return process.env.NODE_ENV === 'development';
 }
 
+function isRunningInECS(): boolean {
+  // https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-environment-variables.html
+  return process.env.ECS_CONTAINER_METADATA_URI_V4 !== undefined;
+}
+
+const DEFAULT_ECS_KEEPALIVE_TIMEOUT_MS = 20_000;
+
 export function assertNormalized(
   config: ZeroConfig,
 ): asserts config is NormalizedZeroConfig {
@@ -101,6 +108,11 @@ export function normalizeZeroConfig(
   if (!config.cvr.db) {
     config.cvr.db = config.upstream.db;
     env['ZERO_CVR_DB'] = config.upstream.db;
+  }
+
+  if (!config.keepaliveTimeoutMs && isRunningInECS()) {
+    config.keepaliveTimeoutMs = DEFAULT_ECS_KEEPALIVE_TIMEOUT_MS;
+    env['ZERO_KEEPALIVE_TIMEOUT_MS'] = String(DEFAULT_ECS_KEEPALIVE_TIMEOUT_MS);
   }
 
   lc.info?.(`runtime env: taskID=${config.taskID}, hostIP=${hostIP}`);

--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -332,6 +332,24 @@ test('zero-cache --help', () => {
        ZERO_PORT env                                                                                                                                                                               
                                                                         The port for sync connections.                                                                                             
                                                                                                                                                                                                    
+     --keepalive-timeout-ms number                                      optional                                                                                                                   
+       ZERO_KEEPALIVE_TIMEOUT_MS env                                                                                                                                                               
+                                                                        The timeout since the last /keepalive request after which the server will initiate                                         
+                                                                        a graceful shutdown. This is a workaround for AWS Elastic Container Service, which                                         
+                                                                        otherwise provides no signal that a target has been deregistered (and should thus begin                                    
+                                                                        shutdown); the cessation of health checks at /keepalive is instead used as the signal to                                   
+                                                                        drain. (ECS later sends a SIGTERM before killing the server but only allows a 30-second                                    
+                                                                        timeout before sending SIGKILL).                                                                                           
+                                                                                                                                                                                                   
+                                                                        Other container runners explicitly send a SIGTERM followed by a configurable drain interval,                               
+                                                                        in which case /keepalive logic is not necessary.                                                                           
+                                                                                                                                                                                                   
+                                                                        When running the server in ECS, this timeout should be set to some multiple of the health                                  
+                                                                        check interval. If the option is unset, the keepalive timeout is disabled in non-ECS environments,                         
+                                                                        and defaults to 20 seconds when run in ECS (determined by the presence of the                                              
+                                                                        ECS_CONTAINER_METADATA_URI_V4 environment variable as per                                                                  
+                                                                        https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-environment-variables.html).                               
+                                                                                                                                                                                                   
      --change-streamer-uri string                                       optional                                                                                                                   
        ZERO_CHANGE_STREAMER_URI env                                                                                                                                                                
                                                                         When set, connects to the change-streamer at the given URI.                                                                

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -525,6 +525,27 @@ export const zeroOptions = {
     desc: [`The port for sync connections.`],
   },
 
+  keepaliveTimeoutMs: {
+    type: v.number().optional(),
+    desc: [
+      `The timeout since the last /keepalive request after which the server will initiate`,
+      `a graceful shutdown. This is a workaround for AWS Elastic Container Service, which`,
+      `otherwise provides no signal that a target has been deregistered (and should thus begin`,
+      `shutdown); the cessation of health checks at /keepalive is instead used as the signal to`,
+      `drain. (ECS later sends a SIGTERM before killing the server but only allows a 30-second`,
+      `timeout before sending SIGKILL).`,
+      ``,
+      `Other container runners explicitly send a SIGTERM followed by a configurable drain interval,`,
+      `in which case /keepalive logic is not necessary.`,
+      ``,
+      `When running the server in ECS, this timeout should be set to some multiple of the health`,
+      `check interval. If the option is unset, the keepalive timeout is disabled in non-ECS environments,`,
+      `and defaults to 20 seconds when run in ECS (determined by the presence of the`,
+      `{bold ECS_CONTAINER_METADATA_URI_V4} environment variable as per`,
+      `https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-environment-variables.html).`,
+    ],
+  },
+
   changeStreamer: {
     uri: {
       type: v.string().optional(),

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -58,6 +58,7 @@ export default async function runWorker(
     replica,
     initialSync,
     litestream,
+    keepaliveTimeoutMs,
   } = config;
 
   startOtelAuto(
@@ -228,7 +229,7 @@ export default async function runWorker(
   const changeStreamerWebServer = new ChangeStreamerHttpServer(
     lc,
     config,
-    {port, startupDelayMs},
+    {port, keepaliveTimeoutMs, startupDelayMs},
     parent,
     changeStreamer,
     monitor instanceof BackupMonitor ? monitor : null,

--- a/packages/zero-cache/src/server/runner/run-worker.ts
+++ b/packages/zero-cache/src/server/runner/run-worker.ts
@@ -49,7 +49,7 @@ export async function runWorker(
   const config = normalizeZeroConfig(lc, cfg, env, defaultTaskID);
   const processes = new ProcessManager(lc, parent ?? process);
 
-  const {port, lazyStartup} = config;
+  const {port, keepaliveTimeoutMs, lazyStartup} = config;
   const serverVersion = getServerVersion(config);
   lc.info?.(`starting server${!serverVersion ? '' : `@${serverVersion}`} `, {
     protocolVersion: PROTOCOL_VERSION,
@@ -90,8 +90,12 @@ export async function runWorker(
     await runUntilKilled(
       lc,
       parent ?? process,
-      new ZeroDispatcher(config, lc, {port}, startZeroCache, () =>
-        printStartupMessage(env),
+      new ZeroDispatcher(
+        config,
+        lc,
+        {port, keepaliveTimeoutMs},
+        startZeroCache,
+        () => printStartupMessage(env),
       ),
     );
   } catch (err) {

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.pg.test.ts
@@ -100,7 +100,7 @@ describe('change-streamer/http', () => {
     const server = new ChangeStreamerHttpServer(
       lc,
       createTestConfig(),
-      {port: 0, startupDelayMs: 10000},
+      {port: 0, startupDelayMs: 10000, keepaliveTimeoutMs: undefined},
       parent,
       {
         id: 'change-streamer',
@@ -158,6 +158,7 @@ describe('change-streamer/http', () => {
       {
         port: 0,
         startupDelayMs: 10000,
+        keepaliveTimeoutMs: undefined,
       },
       parent,
       {

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
@@ -37,6 +37,7 @@ const CHANGES_PATH = `/replication/v${PROTOCOL_VERSION}/changes`;
 
 type Options = {
   port: number;
+  keepaliveTimeoutMs: number | undefined;
   startupDelayMs: number;
 };
 

--- a/packages/zero-cache/src/services/http-service.ts
+++ b/packages/zero-cache/src/services/http-service.ts
@@ -7,6 +7,7 @@ import type {Service} from './service.ts';
 
 export type Options = {
   port: number;
+  keepaliveTimeoutMs: number | undefined;
 };
 
 /**
@@ -20,7 +21,7 @@ export class HttpService implements Service {
   readonly #fastify: FastifyInstance;
   readonly #port: number;
   protected readonly _state: RunningState;
-  readonly #heartbeatMonitor: HeartbeatMonitor;
+  readonly #heartbeatMonitor: HeartbeatMonitor | undefined;
   readonly #init: (fastify: FastifyInstance) => void | Promise<void>;
 
   constructor(
@@ -29,13 +30,16 @@ export class HttpService implements Service {
     opts: Options,
     init: (fastify: FastifyInstance) => void | Promise<void>,
   ) {
+    const {port, keepaliveTimeoutMs} = opts;
     this.id = id;
     this._lc = lc.withContext('component', this.id);
     this.#fastify = Fastify();
-    this.#port = opts.port;
+    this.#port = port;
     this.#init = init;
     this._state = new RunningState(id);
-    this.#heartbeatMonitor = new HeartbeatMonitor(this._lc);
+    this.#heartbeatMonitor = keepaliveTimeoutMs
+      ? new HeartbeatMonitor(this._lc, keepaliveTimeoutMs)
+      : undefined;
   }
 
   // Life-cycle hooks for subclass implementations
@@ -48,7 +52,7 @@ export class HttpService implements Service {
   async start(): Promise<string> {
     this.#fastify.get('/', (_req, res) => res.send('OK'));
     this.#fastify.get('/keepalive', ({headers}, res) => {
-      this.#heartbeatMonitor.onHeartbeat(headers);
+      this.#heartbeatMonitor?.onHeartbeat(headers);
       return res.send('OK');
     });
     await this.#init(this.#fastify);
@@ -68,7 +72,7 @@ export class HttpService implements Service {
 
   async stop(): Promise<void> {
     this._lc.info?.(`${this.id}: no longer accepting connections`);
-    this.#heartbeatMonitor.stop();
+    this.#heartbeatMonitor?.stop();
     this._state.stop(this._lc);
     await this.#fastify.close();
     await this._onStop();

--- a/packages/zero-cache/src/services/life-cycle.ts
+++ b/packages/zero-cache/src/services/life-cycle.ts
@@ -315,8 +315,6 @@ export async function exitAfter(run: () => Promise<void>) {
   }
 }
 
-const DEFAULT_STOP_INTERVAL_MS = 20_000;
-
 /**
  * The HeartbeatMonitor monitors the cadence heartbeats (e.g. "/keepalive"
  * health checks made to HttpServices) that signal that the server
@@ -336,7 +334,7 @@ export class HeartbeatMonitor {
   #checkImmediateTimer: NodeJS.Immediate | undefined;
   #lastHeartbeat = 0;
 
-  constructor(lc: LogContext, stopInterval = DEFAULT_STOP_INTERVAL_MS) {
+  constructor(lc: LogContext, stopInterval: number) {
     this.#lc = lc;
     this.#stopInterval = stopInterval;
   }


### PR DESCRIPTION
Makes the `/keepalive` timeout + graceful-shutdown logic an explicit option, defaulting to 20 seconds when run in ECS and disabled otherwise. (For non ECS environments, SIGINT/SIGTERM is already an appropriate drain signal).