### PR TITLE
feat(zero-cache): schema change improvements

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg.test.ts
@@ -137,6 +137,10 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
           break;
         case 'data':
           data.push(change[1]);
+          if (change[1].tag === 'backfill-completed') {
+            // TODO: for debugging on GitHub actions. Remove before submitting.
+            console.error(`received backfill-completed`, change[1]);
+          }
           break;
         case 'commit':
         case 'rollback':
@@ -1897,6 +1901,70 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
       ],
     ],
     [
+      'working ALTER PUBLICATION trigger not affected by surrounding COMMENTs',
+      /*sql*/ `
+      COMMENT ON PUBLICATION zero_some_public IS 'bonk';
+      ALTER PUBLICATION zero_some_public SET TABLE existing, TABLE existing_full,
+        TABLE foo (id, "newInt", flt);
+      COMMENT ON PUBLICATION zero_some_public IS 'bonk';
+      `,
+      [
+        [
+          {
+            tag: 'add-column',
+            table: {schema: 'public', name: 'foo'},
+            tableMetadata: {
+              schemaOID: expect.any(Number),
+              relationOID: expect.any(Number),
+              rowKey: {id: {attNum: 1}},
+            },
+            backfill: {attNum: expect.any(Number)},
+          },
+        ],
+        [{tag: 'backfill-completed'}],
+      ],
+      {foo: []},
+      [
+        {
+          name: 'foo',
+          columns: {
+            id: {
+              characterMaximumLength: null,
+              dataType: 'text|NOT_NULL',
+              elemPgTypeClass: null,
+              dflt: null,
+              notNull: false,
+              pos: 1,
+            },
+            ['_0_version']: {
+              characterMaximumLength: null,
+              dataType: 'TEXT',
+              elemPgTypeClass: null,
+              notNull: false,
+              pos: 2,
+            },
+            flt: {
+              characterMaximumLength: null,
+              dataType: 'float8',
+              elemPgTypeClass: null,
+              dflt: null,
+              notNull: false,
+              pos: 3,
+            },
+            newInt: {
+              characterMaximumLength: null,
+              dataType: 'int4',
+              elemPgTypeClass: null,
+              dflt: null,
+              notNull: false,
+              pos: 4,
+            },
+          },
+        },
+      ],
+      [],
+    ],
+    [
       'disable ALTER PUBLICATION trigger',
       /*sql*/ `
       DROP EVENT TRIGGER ${APP_ID}_ddl_start_0;
@@ -1931,6 +1999,11 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
       `,
       [
         [
+          {
+            tag: 'drop-column',
+            table: {schema: 'public', name: 'foo'},
+            column: 'newInt',
+          },
           {
             tag: 'add-column',
             table: {schema: 'public', name: 'foo'},
@@ -2051,61 +2124,6 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
       }
     },
   );
-
-  // TODO: Flaky - fix in a follow-up PR.
-  // These tests fail intermittently because a backfill-completed message from
-  // a prior test bleeds into these tests via the shared downstream queue.
-  test.skip('working ALTER PUBLICATION trigger not affected by surrounding COMMENTs', async () => {
-    await upstream.unsafe(/*sql*/ `
-      COMMENT ON PUBLICATION zero_some_public IS 'bonk';
-      ALTER PUBLICATION zero_some_public SET TABLE existing, TABLE existing_full,
-        TABLE foo (id, "newInt", flt);
-      COMMENT ON PUBLICATION zero_some_public IS 'bonk';
-      `);
-    const t1 = await nextTransaction();
-    expect(t1).toMatchObject([
-      {
-        tag: 'add-column',
-        table: {schema: 'public', name: 'foo'},
-        tableMetadata: {
-          schemaOID: expect.any(Number),
-          relationOID: expect.any(Number),
-          rowKey: {id: {attNum: 1}},
-        },
-        backfill: {attNum: expect.any(Number)},
-      },
-    ]);
-    const t2 = await nextTransaction();
-    expect(t2).toMatchObject([{tag: 'backfill-completed'}]);
-  });
-
-  test.skip('missing ALTER PUBLICATION trigger covered by surrounding COMMENTs', async () => {
-    await upstream.unsafe(/*sql*/ `
-      COMMENT ON PUBLICATION zero_some_public IS 'bonk';
-      ALTER PUBLICATION zero_some_public SET TABLE existing, TABLE existing_full,
-        TABLE foo (id, "newInt", int, flt);
-      COMMENT ON PUBLICATION zero_some_public IS 'bonk';
-
-      -- Additional comments have no effect.
-      COMMENT ON PUBLICATION zero_some_public IS 'bonk';
-      COMMENT ON PUBLICATION zero_some_public IS NULL;
-      `);
-    const t1 = await nextTransaction();
-    expect(t1).toMatchObject([
-      {
-        tag: 'add-column',
-        table: {schema: 'public', name: 'foo'},
-        tableMetadata: {
-          schemaOID: expect.any(Number),
-          relationOID: expect.any(Number),
-          rowKey: {id: {attNum: 1}},
-        },
-        backfill: {attNum: expect.any(Number)},
-      },
-    ]);
-    const t2 = await nextTransaction();
-    expect(t2).toMatchObject([{tag: 'backfill-completed'}]);
-  });
 });
 
 function removeAlterPublication(tags: readonly string[]) {

--- a/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg.test.ts
@@ -1832,28 +1832,6 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
       ],
     ],
     [
-      'disable ALTER PUBLICATION trigger',
-      /*sql*/ `
-      DROP EVENT TRIGGER ${APP_ID}_ddl_start_0;
-      DROP EVENT TRIGGER ${APP_ID}_ddl_end_0;
-
-      CREATE EVENT TRIGGER ${APP_ID}_ddl_start_0
-        ON ddl_command_start
-        WHEN TAG IN (${literal(removeAlterPublication(TAGS))})
-        EXECUTE PROCEDURE ${APP_ID}_0.emit_ddl_start();
-
-      CREATE EVENT TRIGGER ${APP_ID}_ddl_end_0
-        ON ddl_command_end
-        WHEN TAG IN (${literal(removeAlterPublication([...TAGS, 'COMMENT']))})
-        EXECUTE PROCEDURE ${APP_ID}_0.emit_ddl_end();
-      `,
-      [],
-      {},
-      [],
-      [],
-    ],
-    // Cases hereafter no longer have the ALTER PUBLICATION TRIGGER
-    [
       'concurrent schema changes',
       [
         // statements are run in parallel
@@ -1897,6 +1875,8 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
 
      CREATE TABLE your.table_that_gets_rls (id INT8 PRIMARY KEY, val INT8 NOT NULL);
      CREATE UNIQUE INDEX val_idx ON your.table_that_gets_rls (val);
+
+     DROP EVENT TRIGGER add_rls_trigger;
       `,
       [[{tag: 'create-table'}, {tag: 'create-index'}, {tag: 'create-index'}]],
       {['your.table_that_gets_rls']: []},
@@ -1915,6 +1895,121 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
           unique: true,
         },
       ],
+    ],
+    [
+      'disable ALTER PUBLICATION trigger',
+      /*sql*/ `
+      DROP EVENT TRIGGER ${APP_ID}_ddl_start_0;
+      DROP EVENT TRIGGER ${APP_ID}_ddl_end_0;
+
+      CREATE EVENT TRIGGER ${APP_ID}_ddl_start_0
+        ON ddl_command_start
+        WHEN TAG IN (${literal(removeAlterPublication(TAGS))})
+        EXECUTE PROCEDURE ${APP_ID}_0.emit_ddl_start();
+
+      CREATE EVENT TRIGGER ${APP_ID}_ddl_end_0
+        ON ddl_command_end
+        WHEN TAG IN (${literal(removeAlterPublication([...TAGS, 'COMMENT']))})
+        EXECUTE PROCEDURE ${APP_ID}_0.emit_ddl_end();
+      `,
+      [],
+      {},
+      [],
+      [],
+    ],
+    // Cases hereafter no longer have the ALTER PUBLICATION TRIGGER
+    [
+      'missing ALTER PUBLICATION trigger covered by COMMENT',
+      /*sql*/ `
+      ALTER PUBLICATION zero_some_public SET TABLE existing, TABLE existing_full,
+        TABLE foo (id, int, flt);
+      COMMENT ON PUBLICATION zero_some_public IS 'bonk';
+
+      -- Additional comments have no effect.
+      COMMENT ON PUBLICATION zero_some_public IS 'bonk';
+      COMMENT ON PUBLICATION zero_some_public IS NULL;
+      `,
+      [
+        [
+          {
+            tag: 'add-column',
+            table: {schema: 'public', name: 'foo'},
+            tableMetadata: {
+              schemaOID: expect.any(Number),
+              relationOID: expect.any(Number),
+              rowKey: {id: {attNum: 1}},
+            },
+            backfill: {attNum: expect.any(Number)},
+          },
+        ],
+        [{tag: 'backfill-completed'}],
+      ],
+      {foo: []},
+      [
+        {
+          name: 'foo',
+          columns: {
+            id: {
+              characterMaximumLength: null,
+              dataType: 'text|NOT_NULL',
+              elemPgTypeClass: null,
+              dflt: null,
+              notNull: false,
+              pos: 1,
+            },
+            ['_0_version']: {
+              characterMaximumLength: null,
+              dataType: 'TEXT',
+              elemPgTypeClass: null,
+              notNull: false,
+              pos: 2,
+            },
+            flt: {
+              characterMaximumLength: null,
+              dataType: 'float8',
+              elemPgTypeClass: null,
+              dflt: null,
+              notNull: false,
+              pos: 3,
+            },
+            int: {
+              characterMaximumLength: null,
+              dataType: 'int4',
+              elemPgTypeClass: null,
+              dflt: null,
+              notNull: false,
+              pos: 4,
+            },
+          },
+        },
+      ],
+      [],
+    ],
+    [
+      'disable all event triggers',
+      /*sql*/ `
+      DROP EVENT TRIGGER ${APP_ID}_ddl_start_0;
+      DROP EVENT TRIGGER ${APP_ID}_ddl_end_0;
+      `,
+      [],
+      {},
+      [],
+      [],
+    ],
+    // Cases hereafter have no the event triggers
+    [
+      'create table covered by update_schemas() call',
+      /*sql*/ `
+      CREATE TABLE IF NOT EXISTS your.new_table (id INT8 PRIMARY KEY);
+      SELECT ${APP_ID}_0.update_schemas();
+      `,
+      [
+        [{tag: 'create-table'}, {tag: 'create-index'}],
+        [{tag: 'backfill-completed'}],
+      ],
+      {['your.new_table']: []},
+      [],
+      [],
     ],
   ] satisfies [
     name: string,

--- a/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg.test.ts
@@ -1,4 +1,4 @@
-import type {LogContext} from '@rocicorp/logger';
+import {consoleLogSink, LogContext} from '@rocicorp/logger';
 import {literal} from 'pg-format';
 import {afterAll, beforeAll, describe, expect, test} from 'vitest';
 import {type JSONValue} from '../../../../../shared/src/bigint-json.ts';
@@ -38,7 +38,8 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
   let replicator: ChangeProcessor;
 
   beforeAll(async () => {
-    lc = createSilentLogContext();
+    lc = new LogContext('debug', {}, consoleLogSink);
+    createSilentLogContext();
     upstream = await testDBs.create('change_source_end_to_mid_test_upstream');
     replicaDbFile = new DbFile('change_source_end_to_mid_test_replica');
     replica = replicaDbFile.connect(lc);
@@ -139,8 +140,7 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
           data.push(change[1]);
           if (change[1].tag === 'backfill-completed') {
             // TODO: for debugging on GitHub actions. Remove before submitting.
-            // oxlint-disable-next-line
-            console.error(`received backfill-completed`, change[1]);
+            lc.error?.(`received backfill-completed`, change[1]);
           }
           break;
         case 'commit':

--- a/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg.test.ts
@@ -124,7 +124,7 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
   async function nextTransaction(): Promise<DataOrSchemaChange[]> {
     const data: DataOrSchemaChange[] = [];
     for (;;) {
-      const change = await downstream.dequeue('timeout', 10_000);
+      const change = await downstream.dequeue('timeout', 20_000);
       if (change === 'timeout') {
         throw new Error('timed out waiting for change');
       }
@@ -137,20 +137,20 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
         case 'begin':
           break;
         case 'data':
+          // TODO: for debugging on GitHub actions. Remove before submitting.
+          lc.info?.(`received data`, change[1].tag);
           data.push(change[1]);
-          if (change[1].tag === 'backfill-completed') {
-            // TODO: for debugging on GitHub actions. Remove before submitting.
-            lc.error?.(`received backfill-completed`, change[1]);
-          }
           break;
         case 'commit':
+          if (data.length) {
+            return data;
+          }
+          break; // skip empty transactions
         case 'rollback':
+          throw new Error(`received rollback: ${JSON.stringify(change)}`);
         case 'control':
         case 'status':
-          if (data.length === 0) {
-            break; // skip empty transactions
-          }
-          return data;
+          break;
         default:
           change satisfies never;
       }

--- a/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg.test.ts
@@ -139,6 +139,7 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
           data.push(change[1]);
           if (change[1].tag === 'backfill-completed') {
             // TODO: for debugging on GitHub actions. Remove before submitting.
+            // oxlint-disable-next-line
             console.error(`received backfill-completed`, change[1]);
           }
           break;

--- a/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg.test.ts
@@ -1,4 +1,4 @@
-import {consoleLogSink, LogContext} from '@rocicorp/logger';
+import type {LogContext} from '@rocicorp/logger';
 import {literal} from 'pg-format';
 import {afterAll, beforeAll, describe, expect, test} from 'vitest';
 import {type JSONValue} from '../../../../../shared/src/bigint-json.ts';
@@ -38,8 +38,7 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
   let replicator: ChangeProcessor;
 
   beforeAll(async () => {
-    lc = new LogContext('debug', {}, consoleLogSink);
-    createSilentLogContext();
+    lc = createSilentLogContext();
     upstream = await testDBs.create('change_source_end_to_mid_test_upstream');
     replicaDbFile = new DbFile('change_source_end_to_mid_test_replica');
     replica = replicaDbFile.connect(lc);
@@ -124,7 +123,7 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
   async function nextTransaction(): Promise<DataOrSchemaChange[]> {
     const data: DataOrSchemaChange[] = [];
     for (;;) {
-      const change = await downstream.dequeue('timeout', 20_000);
+      const change = await downstream.dequeue('timeout', 30_000);
       if (change === 'timeout') {
         throw new Error('timed out waiting for change');
       }
@@ -137,8 +136,6 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
         case 'begin':
           break;
         case 'data':
-          // TODO: for debugging on GitHub actions. Remove before submitting.
-          lc.info?.(`received data`, change[1].tag);
           data.push(change[1]);
           break;
         case 'commit':

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -1112,7 +1112,7 @@ class ChangeMaker {
     // The tag (i.e. command) is used as an optimization to determine whether
     // backfill is necessary (CREATE TABLE vs ALTER TABLE vs
     // ALTER PUBLICATION). If the context is not available (rare), the tag
-    // defaults to 'UNKNOWN', which conservatively initiates a backfill.
+    // falls back to 'UNKNOWN', which conservatively initiates a backfill.
     //
     // Because ddl events may be nested, e.g.
     //

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -1070,6 +1070,8 @@ class ChangeMaker {
     }
   }
 
+  // The lastReplicationEvent is stored to understand the context
+  // of the next one.
   #lastReplicationEvent: ReplicationEvent | undefined;
 
   #handleDdlMessage(lc: LogContext, msg: MessageMessage): ChangeStreamData[] {
@@ -1082,36 +1084,36 @@ class ChangeMaker {
     // is about to happen, so as to avoid interfering / redundant work.
     clearTimeout(this.#replicaIdentityTimer);
 
-    let prevEvent = this.#lastReplicationEvent;
     const {type} = event;
     switch (type) {
       case 'ddlStart':
       case 'schemaSnapshot':
-        break;
       case 'ddlUpdate':
-        if (!prevEvent) {
-          // A fix for this is in the works. Log an error with the full
-          // LogContext (e.g. including the tag and query) to collect/confirm
-          // the scenarios in which this happens.
-          lc.error?.(`ddlUpdate received without a ddlStart`, {event});
-          assert(prevEvent, `ddlUpdate received without a ddlStart`);
-        }
         break;
       default: // Ignore unknown types for forwards compatibility
         lc.info?.(`ignoring unknown ddl message type: ${type}`);
         return [];
     }
 
-    // Store the new event to diff against the next event.
+    const prevEvent = this.#lastReplicationEvent;
+    // Store the new event to understand the context of the next event.
     this.#lastReplicationEvent = event;
-    if (!prevEvent) {
+
+    const prevSchema =
+      event.previousSchema === undefined // pre-v21 event => use prevEvent
+        ? prevEvent?.schema
+        : event.previousSchema;
+    if (!prevSchema) {
       lc.info?.(`received ${msg.prefix}/${type} event`, {event});
-      return []; // First snapshot in the tx.
+      return [];
     }
     lc.info?.(`processing ${msg.prefix}/${type} event`, {event});
 
-    // The tag (i.e. command) is used to determine whether backfill is
-    // necessary (CREATE TABLE vs ALTER TABLE vs ALTER PUBLICATION).
+    // The tag (i.e. command) is used as an optimization to determine whether
+    // backfill is necessary (CREATE TABLE vs ALTER TABLE vs
+    // ALTER PUBLICATION). If the context is not available (rare), the tag
+    // defaults to 'UNKNOWN', which conservatively initiates a backfill.
+    //
     // Because ddl events may be nested, e.g.
     //
     // ```
@@ -1119,14 +1121,20 @@ class ChangeMaker {
     // ddl_start => ddl_start => ddl_end => ddl_start => ddl_end => ddl_end
     // ```
     //
-    // The effective tag is determined from the starting event if it is
-    // ddl_start (e.g. cases 1, 2, and 4), and from the ending event
-    // otherwise (cases 3 and 5)
+    // The effective tag is determined from the previous event if it is
+    // ddl_start (e.g. cases 1, 2, and 4), and from the current event
+    // if it is a ddl_end (case 5), and 'UNKNOWN' otherwise (case 3 and
+    // 'schemaSnapshot' workarounds).
     const effectiveTag =
-      prevEvent.type === 'ddlStart' ? prevEvent.event.tag : event.event.tag;
+      prevEvent?.type === 'ddlStart'
+        ? prevEvent.event.tag
+        : event.type === 'ddlUpdate'
+          ? event.event.tag
+          : 'UNKNOWN';
+    lc.info?.(`Processing ${effectiveTag} command from ${event.type}`);
     const changes = this.#makeSchemaChanges(
       lc,
-      prevEvent.schema,
+      prevSchema,
       event,
       effectiveTag,
     ).map(change => ['data', change] satisfies Data);
@@ -1246,10 +1254,15 @@ class ChangeMaker {
           spec,
           metadata: getMetadata(spec),
         };
+        // Only tables introduced by a `CREATE` statement can skip backfill.
+        // All other scenarios in which tables are introduced into the
+        // schema, e.g.
+        // * ALTER PUBLICATION statements
+        // * COMMENT statements
+        // * MANUAL snapshots
+        // * UNKNOWN command tags
+        // must be backfilled.
         if (!tag.startsWith('CREATE')) {
-          // Tables introduced to the publication via ALTER statements
-          // or the COMMENT statement (from schemaSnapshots) must be
-          // backfilled.
           createTable.backfill = mapValues(spec.columns, ({pos: attNum}) => ({
             attNum,
           })) satisfies Record<string, ColumnMetadata>;
@@ -1330,10 +1343,14 @@ class ChangeMaker {
       }
     }
 
-    // All columns introduced by a publication change require backfill
-    // (which appear as ALTER PUBLICATION or COMMENT tags).
-    // Columns created by ALTER TABLE, on the other hand, only require
-    // backfill if they have non-constant defaults.
+    // Only columns introduced by `ALTER TABLE` statements can potentially
+    // skip backfill if they have non-constant defaults. All other scenarios
+    // in which columns are introduced, e.g.
+    // * ALTER PUBLICATION
+    // * COMMENT
+    // * MANUAL
+    // * UNKNOWN
+    // must be backfilled.
     const alwaysBackfill = ddlTag !== 'ALTER TABLE';
 
     // ADD

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -1107,7 +1107,6 @@ class ChangeMaker {
       lc.info?.(`received ${msg.prefix}/${type} event`, {event});
       return [];
     }
-    lc.info?.(`processing ${msg.prefix}/${type} event`, {event});
 
     // The tag (i.e. command) is used as an optimization to determine whether
     // backfill is necessary (CREATE TABLE vs ALTER TABLE vs
@@ -1131,7 +1130,9 @@ class ChangeMaker {
         : event.type === 'ddlUpdate'
           ? event.event.tag
           : 'UNKNOWN';
-    lc.info?.(`Processing ${effectiveTag} command from ${event.type}`);
+    lc.info?.(`processing ${effectiveTag} command from ${msg.prefix}/${type}`, {
+      event,
+    });
     const changes = this.#makeSchemaChanges(
       lc,
       prevSchema,

--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl.pg.test.ts
@@ -11,6 +11,7 @@ import type {
 } from '../logical-replication/pgoutput.types.ts';
 import {subscribe} from '../logical-replication/stream.ts';
 import {
+  createEventFunctionStatements,
   createEventTriggerStatements,
   ddlStartEventSchema,
   ddlUpdateEventSchema,
@@ -38,13 +39,14 @@ describe('change-source/tables/ddl', () => {
 
     await upstream.unsafe(STARTING_SCHEMA);
 
-    await upstream.unsafe(
-      createEventTriggerStatements({
-        appID: APP_ID,
-        shardNum: SHARD_NUM,
-        publications: ['zero_all', 'zero_sum'],
-      }),
-    );
+    const shard = {
+      appID: APP_ID,
+      shardNum: SHARD_NUM,
+      publications: ['zero_all', 'zero_sum'],
+    };
+
+    await upstream.unsafe(createEventFunctionStatements(shard));
+    await upstream.unsafe(createEventTriggerStatements(shard));
 
     await upstream`SELECT pg_create_logical_replication_slot(${SLOT_NAME}, 'pgoutput')`;
 
@@ -109,6 +111,7 @@ describe('change-source/tables/ddl', () => {
     type: 'ddlStart',
     version: 1,
     event: {tag: 'UNUSED'},
+    previousSchema: null,
     schema: {
       tables: [
         {
@@ -1305,7 +1308,7 @@ describe('change-source/tables/ddl', () => {
         },
       },
     ],
-  ] satisfies [string, string, DdlUpdateEvent][])(
+  ] satisfies [string, string, Partial<DdlUpdateEvent>][])(
     '%s',
     async (_, query, ddlUpdate) => {
       await upstream.begin(async tx => {
@@ -1319,14 +1322,14 @@ describe('change-source/tables/ddl', () => {
         {tag: 'insert'},
         {
           tag: 'message',
-          prefix: 'zap/0',
+          prefix: 'zap/0/ddl',
           content: expect.any(Uint8Array),
           flags: 1,
           transactional: true,
         },
         {
           tag: 'message',
-          prefix: 'zap/0',
+          prefix: 'zap/0/ddl',
           content: expect.any(Uint8Array),
           flags: 1,
           transactional: true,
@@ -1339,7 +1342,7 @@ describe('change-source/tables/ddl', () => {
         ...DDL_START,
         event: ddlUpdate.event,
         context: {query},
-      } satisfies DdlStartEvent);
+      } satisfies Partial<DdlStartEvent>);
 
       msg = messages[4] as MessageMessage;
       expect(parseDDLUpdateEvent(msg)).toMatchObject(ddlUpdate);
@@ -1348,22 +1351,73 @@ describe('change-source/tables/ddl', () => {
 
   test.each([
     [
-      'schema snapshot',
-      `COMMENT ON PUBLICATION zero_sum IS 'foo'`,
+      'COMMENT',
+      /*sql*/ `
+      ALTER PUBLICATION zero_sum DROP TABLE pub.boo;
+      COMMENT ON PUBLICATION zero_sum IS 'foo'
+      `,
       {
         context: {
-          query: `COMMENT ON PUBLICATION zero_sum IS 'foo'`,
+          query: /*sql*/ `
+      ALTER PUBLICATION zero_sum DROP TABLE pub.boo;
+      COMMENT ON PUBLICATION zero_sum IS 'foo'
+      `,
         },
         type: 'schemaSnapshot',
         version: 1,
         event: {tag: 'COMMENT'},
-        schema: DDL_START.schema,
+        schema: {
+          tables: replaced(DDL_START.schema.tables, 0, 1, {
+            ...DDL_START.schema.tables[0],
+            // No longer associated with the zero_sum publication.
+            publications: {['zero_all']: {rowFilter: null}},
+          }),
+          indexes: DDL_START.schema.indexes,
+        },
       },
     ],
-  ] satisfies [string, string, SchemaSnapshotEvent][])(
-    '%s',
+    [
+      'Manually SELECT update_schemas()',
+      /*sql*/ `
+      ALTER PUBLICATION zero_sum DROP TABLE pub.foo;
+      SELECT ${APP_ID}_${SHARD_NUM}.update_schemas();
+      `,
+      {
+        context: {
+          query: /*sql*/ `
+      ALTER PUBLICATION zero_sum DROP TABLE pub.foo;
+      SELECT ${APP_ID}_${SHARD_NUM}.update_schemas();
+      `,
+        },
+        type: 'schemaSnapshot',
+        version: 1,
+        event: {tag: 'MANUAL'},
+        schema: {
+          tables: replaced(DDL_START.schema.tables, 1, 1, {
+            ...DDL_START.schema.tables[1],
+            // No longer associated with the zero_sum publication.
+            publications: {['zero_all']: {rowFilter: null}},
+          }),
+          indexes: DDL_START.schema.indexes,
+        },
+      },
+    ],
+  ] satisfies [string, string, Partial<SchemaSnapshotEvent>][])(
+    'Snapshot workarounds when event triggers are unavailable: %s',
     async (_, query, schemaSnapshot) => {
       await upstream.begin(async tx => {
+        // Disable all event triggers, and re-enable only the COMMENT one,
+        // in order to simulate a diff in the schema that isn't caught by
+        // the standard event triggers.
+        await tx.unsafe(/*sql*/ `
+          DROP EVENT TRIGGER ${APP_ID}_ddl_start_${SHARD_NUM};
+          DROP EVENT TRIGGER ${APP_ID}_ddl_end_${SHARD_NUM};
+
+          CREATE EVENT TRIGGER ${APP_ID}_ddl_end_${SHARD_NUM}
+            ON ddl_command_end
+            WHEN TAG IN ('COMMENT')
+            EXECUTE PROCEDURE ${APP_ID}_${SHARD_NUM}.emit_ddl_end();
+        `);
         await tx`INSERT INTO pub.boo(id) VALUES('1')`;
         await tx.unsafe(query);
       });
@@ -1393,19 +1447,21 @@ describe('change-source/tables/ddl', () => {
   test.each([
     [
       'CREATE TABLE private.bar(id TEXT PRIMARY KEY, a INT4 UNIQUE, b INT8 UNIQUE, UNIQUE(b, a))',
-      [/ignoring CREATE TABLE .*private.bar/],
+      [/ignoring irrelevant CREATE TABLE .*private.bar/],
     ],
     [
       'CREATE INDEX foo_name_index on private.foo (name desc, id)',
-      [/ignoring CREATE INDEX .*private.foo_name_index/],
+      [/ignoring irrelevant CREATE INDEX .*private.foo_name_index/],
     ],
     [
       `ALTER TABLE private.foo RENAME name to handle`,
-      [/ignoring ALTER TABLE .*private.foo.handle/],
+      [/ignoring irrelevant ALTER TABLE .*private.foo.handle/],
     ],
     [
       `ALTER PUBLICATION nonzeropub ADD TABLE pub.yoo`,
-      [/ignoring ALTER PUBLICATION .*pub.yoo in publication nonzeropub/],
+      [
+        /ignoring irrelevant ALTER PUBLICATION .*pub.yoo in publication nonzeropub/,
+      ],
     ],
     [
       `
@@ -1421,13 +1477,13 @@ describe('change-source/tables/ddl', () => {
       );
       SELECT "dataVersion", "schemaVersion", "minSafeVersion" FROM "cvr"."versionHistory";
       `,
-      [/ignoring CREATE TABLE .*cvr.\\"versionHistory\\"/],
+      [/ignoring irrelevant CREATE TABLE .*cvr.\\"versionHistory\\"/],
     ],
     [
       `CREATE TABLE IF NOT EXISTS pub.foo(id TEXT PRIMARY KEY, name TEXT UNIQUE, description TEXT);`,
       [
         /relation "foo" already exists, skipping/,
-        /ignoring CREATE TABLE .*"object_identity":null/,
+        /ignoring irrelevant CREATE TABLE .*"object_identity":null/,
       ],
     ],
   ] satisfies [string, RegExp[]][])(
@@ -1449,7 +1505,7 @@ describe('change-source/tables/ddl', () => {
         {tag: 'insert'},
         {
           tag: 'message',
-          prefix: 'zap/0',
+          prefix: 'zap/0/ddl',
           content: expect.any(Uint8Array),
           flags: 1,
           transactional: true,
@@ -1462,6 +1518,7 @@ describe('change-source/tables/ddl', () => {
         type: 'ddlStart',
       });
 
+      expect((await notices.dequeue()).message).toMatch(/Emitted .* ddlStart/);
       for (const n of expectedNotices) {
         const notice = await notices.dequeue();
         expect(notice.message).toMatch(n);
@@ -1472,14 +1529,20 @@ describe('change-source/tables/ddl', () => {
   test.each([
     [
       `COMMENT ON TABLE zero.foo IS 'whatever';`,
-      [/ignoring COMMENT.*zero.foo/],
+      [/ignoring irrelevant COMMENT.*zero.foo/],
     ],
     [
       `COMMENT ON PUBLICATION nonzeropub IS 'whatever';`,
-      [/ignoring COMMENT.*nonzeropub/],
+      [/ignoring irrelevant COMMENT.*nonzeropub/],
     ],
+    // TODO: include this test when no-op schemaSnapshots are skipped,
+    // once 1.5.0 is rollback safe. (1.0.0 ~ 1.4.0 rely on them)
+    // [
+    //   `COMMENT ON PUBLICATION zero_sum IS 'foo'`,
+    //   [/ignoring noop COMMENT.*zero_sum/],
+    // ],
   ] satisfies [string, RegExp[]][])(
-    'ignore unrelated comments: %s',
+    'ignore unrelated or noop comments: %s',
     async (query, expectedNotices) => {
       while (notices.size()) {
         await notices.dequeue();
@@ -1518,14 +1581,14 @@ describe('change-source/tables/ddl', () => {
       {tag: 'begin'},
       {
         tag: 'message',
-        prefix: 'zap/0',
+        prefix: 'zap/0/ddl',
         content: expect.any(Uint8Array),
         flags: 1,
         transactional: true,
       },
       {
         tag: 'message',
-        prefix: 'zap/0',
+        prefix: 'zap/0/ddl',
         content: expect.any(Uint8Array),
         flags: 1,
         transactional: true,
@@ -1535,28 +1598,28 @@ describe('change-source/tables/ddl', () => {
       {tag: 'begin'},
       {
         tag: 'message',
-        prefix: 'zap/0',
+        prefix: 'zap/0/ddl',
         content: expect.any(Uint8Array),
         flags: 1,
         transactional: true,
       },
       {
         tag: 'message',
-        prefix: 'zap/0',
+        prefix: 'zap/0/ddl',
         content: expect.any(Uint8Array),
         flags: 1,
         transactional: true,
       },
       {
         tag: 'message',
-        prefix: 'zap/0',
+        prefix: 'zap/0/ddl',
         content: expect.any(Uint8Array),
         flags: 1,
         transactional: true,
       },
       {
         tag: 'message',
-        prefix: 'zap/0',
+        prefix: 'zap/0/ddl',
         content: expect.any(Uint8Array),
         flags: 1,
         transactional: true,

--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl.ts
@@ -96,9 +96,6 @@ export type DdlUpdateEvent = v.Infer<typeof ddlUpdateEventSchema>;
  * COMMIT;
  * ```
  *
- * The COMMENT statement will only result emitting a `schemaSnapshot`
- * message if a relevant change to the published schema was detected.
- *
  * Note that it is fine to invoke `COMMENT ON PUBLICATION` statements
  * on a database that *does* support event triggers on
  * `ALTER PUBLICATION` statements, as it will simply be a no-op.

--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl.ts
@@ -25,15 +25,33 @@ export const ddlEventSchema = triggerEvent.extend({
   event: v.object({tag: v.string()}),
 });
 
-// The `ddlStart` message is computed before every DDL event, regardless of
-// whether the subsequent event affects the shard. Downstream processing should
-// capture the contained schema information in order to determine the schema
-// changes necessary to apply a subsequent `ddlUpdate` message. Note that a
-// `ddlUpdate` message may not follow, as updates determined to be irrelevant
-// to the shard will not result in a message. However, all `ddlUpdate` messages
-// are guaranteed to be preceded by a `ddlStart` message.
+/**
+ * A {@link DdlStartEvent} message is emitted before every DDL event, containing
+ * the current `schema` and the command `tag`.
+ *
+ * In most cases, the `DdlStartEvent` itself will not be associated with a
+ * schema change, in which case `previousSchema` will be `null`. However, the
+ * message is still emitted, both for backwards compatibility and to provide
+ * the command `tag` context in case an immediately following `DdlStartEvent`
+ * tag is emitted with a schema change (which can happen when another event
+ * trigger results in a nested ddl statement).
+ *
+ * In such cases, the `previousSchema` and `schema` fields of the latter event
+ * are used to determine the necessary schema change operations (as they are
+ * with `ddlUpdate` and `schemaSnapshot` events), and the `tag` of the
+ * preceding start event indicates the command that precipitated the schema
+ * change (e.g. a CREATE vs ALTER) to determine whether a backfill is
+ * necessary.
+ */
 export const ddlStartEventSchema = ddlEventSchema.extend({
   type: v.literal('ddlStart'),
+  // For ddlStart messages, previousSchema is `null` if there was no change
+  // in schema detected. The `schema` field is always set to the current
+  // schema.
+  //
+  // In 1.5.0 it is always present, and can be made non-optional when
+  // rollback safe.
+  previousSchema: publishedSchema.nullable().optional(),
   // For backwards compatibility with previous versions of the trigger,
   // default an absent `event` field with a semantic equivalent. This
   // field override can be removed in a version that is rollback safe
@@ -44,19 +62,18 @@ export const ddlStartEventSchema = ddlEventSchema.extend({
 export type DdlStartEvent = v.Infer<typeof ddlStartEventSchema>;
 
 /**
- * The {@link DdlUpdateEvent} contains an updated schema resulting from
- * a particular ddl event. The event type provides information
- * (i.e. constraints) on the difference from the schema of the preceding
- * {@link DdlStartEvent}.
- *
- * Note that in almost all cases (the exception being `CREATE` events),
- * it is possible that there is no relevant difference between the
- * ddl-start schema and the ddl-update schema, as many aspects of the
- * schema (e.g. column constraints) are not relevant to downstream
- * replication.
+ * A {@link DdlUpdateEvent} is emitted if there was a change in the schema.
+ * It always contains `previousSchema` and (current) `schema` fields, leaving
+ * it to the receiver to compute the necessary schema change operations.
  */
 export const ddlUpdateEventSchema = ddlEventSchema.extend({
   type: v.literal('ddlUpdate'),
+  // ddlUpdate messages are only emitted if the schema changed, with the
+  // `previousSchema` containing the schema before the change.
+  //
+  // In 1.5.0 it is always set, and can be made non-optional when
+  // rollback safe.
+  previousSchema: publishedSchema.optional(),
 });
 
 export type DdlUpdateEvent = v.Infer<typeof ddlUpdateEventSchema>;
@@ -64,47 +81,31 @@ export type DdlUpdateEvent = v.Infer<typeof ddlUpdateEventSchema>;
 /**
  * The `schemaSnapshot` message is a snapshot of a schema taken in response to
  * a `COMMENT ON PUBLICATION` command, which is a hook recognized by zero
- * to manually emit schema snapshots to support detection of schema changes
- * from `ALTER PUBLICATION` commands on supabase, which does not fire event
- * triggers for them (https://github.com/supabase/supautils/issues/123).
+ * to manually emit `previousSchema` and `schema` snapshots when a difference
+ * is detected. This is a workaround provided to support detection of schema
+ * changes from `ALTER PUBLICATION` commands on supabase, which does not fire
+ * event triggers for them (https://github.com/supabase/supautils/issues/123).
  *
- * The hook is exercised by bookmarking the publication change with
- * `COMMENT ON PUBLICATION` statements within e.g.
+ * The hook is exercised by trailing the publication change with a
+ * `COMMENT ON PUBLICATION` statement, e.g.
  *
  * ```sql
  * BEGIN;
- * COMMENT ON PUBLICATION my_publication IS 'whatever';
  * ALTER PUBLICATION my_publication ...;
  * COMMENT ON PUBLICATION my_publication IS 'whatever';
  * COMMIT;
  * ```
  *
- * The `change-source` will perform the diff between a `schemaSnapshot`
- * events and its preceding `schemaSnapshot` (or `ddlUpdate`) within the
- * transaction.
+ * The COMMENT statement will only result emitting a `schemaSnapshot`
+ * message if a relevant change to the published schema was detected.
  *
- * In the case where event trigger support is missing, this results in
- * diffing the `schemaSnapshot`s before and after the `ALTER PUBLICATION`
- * statement, thus effecting the same logic that would have been exercised
- * between the `ddlStart` and `ddlEvent` events fired by a database with
- * fully functional event triggers.
- *
- * Note that if the same transaction is run on a database that *does*
- * support event triggers on `ALTER PUBLICATION` statements, the sequence
- * of emitted messages will be:
- *
- * * `schemaSnapshot`
- * * `ddlStart`
- * * `ddlUpdate`
- * * `schemaSnapshot`
- *
- * Since `schemaSnapshot` messages are diffed with the preceding
- * `schemaSnapshot` or `ddlUpdate` event (if any), there will be no schema
- * difference between the `ddlUpdate` and the second `schemaSnapshot`, and
- * thus the extra `COMMENT` statements will effectively be no-ops.
+ * Note that it is fine to invoke `COMMENT ON PUBLICATION` statements
+ * on a database that *does* support event triggers on
+ * `ALTER PUBLICATION` statements, as it will simply be a no-op.
  */
 export const schemaSnapshotEventSchema = ddlEventSchema.extend({
   type: v.literal('schemaSnapshot'),
+  previousSchema: publishedSchema.optional(),
 });
 
 export type SchemaSnapshotEvent = v.Infer<typeof schemaSnapshotEventSchema>;
@@ -144,7 +145,7 @@ const DDL_SERIALIZATION_LOCK = 0x3c6b8468f1bac0b0n;
  * Instead, we opt for the simplicity and isolation of having each shard
  * completely own (and maintain) the entirety of its trigger/function stack.
  */
-function createEventFunctionStatements(shard: ShardConfig) {
+export function createEventFunctionStatements(shard: ShardConfig) {
   const {appID, shardNum, publications} = shard;
   const schema = id(upstreamSchema(shard)); // e.g. "{APP_ID}_{SHARD_ID}"
   return /*sql*/ `
@@ -161,49 +162,102 @@ END
 $$ LANGUAGE plpgsql;
 
 
-CREATE OR REPLACE FUNCTION ${schema}.notice_ignore(tag TEXT, target record)
+CREATE OR REPLACE FUNCTION ${schema}.notice_ignore(reason TEXT, tag TEXT, target record)
 RETURNS void AS $$
 BEGIN
-  RAISE NOTICE 'zero(%) ignoring % %', ${lit(shardNum)}, tag, row_to_json(target);
+  RAISE NOTICE '${appID}_${shardNum} ignoring % % %', reason, tag, 
+    COALESCE(row_to_json(target)::text, '');
 END
 $$ LANGUAGE plpgsql;
 
 
-CREATE OR REPLACE FUNCTION ${schema}.schema_specs()
-RETURNS TEXT 
+-- Note: DROP and CREATE to upgrade from v20 to v21 because the
+-- return type has changed. This can be simplified to CREATE OR REPLACE
+-- once 1.5.0 is rollback safe.
+DROP FUNCTION IF EXISTS ${schema}.schema_specs();
+CREATE FUNCTION ${schema}.schema_specs()
+RETURNS JSON 
 STABLE
 AS $$
   ${publishedSchemaQuery(publications)}
 $$ LANGUAGE sql;
 
 
+-- Stores the most recent published schema
+CREATE TABLE IF NOT EXISTS ${schema}."publishedSchema" (
+  current JSON,
+  exists BOOL PRIMARY KEY DEFAULT true CHECK (exists)
+);
+
+INSERT INTO ${schema}."publishedSchema" (current) VALUES (${schema}.schema_specs())
+  ON CONFLICT (exists) DO 
+  UPDATE SET current = excluded.current;
+
+
+CREATE OR REPLACE FUNCTION ${schema}.update_schemas(event_type text, tag text, target record)
+RETURNS void AS $$
+DECLARE
+  prev_schema_specs JSON;
+  schema_specs JSON;
+  message TEXT;
+BEGIN
+  SELECT current FROM ${schema}."publishedSchema" INTO prev_schema_specs;
+  SELECT ${schema}.schema_specs() INTO schema_specs;
+  
+  IF prev_schema_specs::text != schema_specs::text THEN
+    UPDATE ${schema}."publishedSchema" SET current = schema_specs;
+  ELSIF event_type = 'ddlStart' THEN
+    -- ddlStart events are always be emitted to allow the zero-cache
+    -- to track the context of the current command tag in the face of
+    -- nested event triggers (e.g. start->start->end->end).
+    prev_schema_specs = NULL;
+  ELSIF event_type = 'ddlUpdate' THEN
+    -- TODO: fold 'schemaSnapshot' into this condition too (i.e. make it "ELSE")
+    -- when 1.5.0 is rollback safe. Until then, noop schemaSnapshots are sent
+    -- for compatibility with 1.0.0 ~ 1.4.0.
+    PERFORM ${schema}.notice_ignore('noop', tag, target);
+    RETURN;
+  END IF;
+
+  SELECT json_build_object(
+    'type', event_type,
+    'version', ${PROTOCOL_VERSION},
+    'previousSchema', prev_schema_specs,
+    'schema', schema_specs,
+    'event', json_build_object('tag', tag),
+    'context', ${schema}.get_trigger_context()
+  ) INTO message;
+
+  PERFORM pg_logical_emit_message(true, '${appID}/${shardNum}/ddl', message);
+
+  RAISE NOTICE 'Emitted ${appID}_${shardNum} % for % %', event_type, tag, 
+    COALESCE(row_to_json(target)::text, '');
+END
+$$ LANGUAGE plpgsql;
+
+
+-- Hook/workaround to manually trigger replication of schema changes on DBs 
+-- that do not support/allow event triggers.
+CREATE OR REPLACE FUNCTION ${schema}.update_schemas()
+RETURNS void AS $$
+BEGIN
+  PERFORM ${schema}.update_schemas('schemaSnapshot', 'MANUAL', NULL);
+END
+$$ LANGUAGE plpgsql;
+
+
 CREATE OR REPLACE FUNCTION ${schema}.emit_ddl_start()
 RETURNS event_trigger AS $$
 DECLARE
-  schema_specs TEXT;
+  schema_specs JSON;
   message TEXT;
 BEGIN
   -- serialize DDL statements to compute correct schema change diffs
   PERFORM pg_advisory_xact_lock(${DDL_SERIALIZATION_LOCK});
-
-  SELECT ${schema}.schema_specs() INTO schema_specs;
-
-  SELECT json_build_object(
-    'type', 'ddlStart',
-    'version', ${PROTOCOL_VERSION},
-    'schema', schema_specs::json,
-    'event', json_build_object('tag', TG_TAG),
-    'context', ${schema}.get_trigger_context()
-  ) INTO message;
-
-  PERFORM pg_logical_emit_message(true, ${lit(
-    `${appID}/${shardNum}`,
-  )}, message);
+  PERFORM ${schema}.update_schemas('ddlStart', TG_TAG, NULL);
 END
 $$ LANGUAGE plpgsql;
 
--- Delete legacy function (and dependent legacy triggers).
-DROP FUNCTION IF EXISTS ${schema}.emit_ddl_end(text) CASCADE;
 
 CREATE OR REPLACE FUNCTION ${schema}.emit_ddl_end()
 RETURNS event_trigger AS $$
@@ -211,11 +265,9 @@ DECLARE
   publications TEXT[];
   target RECORD;
   relevant RECORD;
-  schema_specs TEXT;
+  schema_specs JSON;
   message TEXT;
   event TEXT;
-  event_type TEXT;
-  event_prefix TEXT;
 BEGIN
   publications := ARRAY[${lit(publications)}];
 
@@ -275,38 +327,21 @@ BEGIN
   END IF;
 
   IF relevant IS NULL THEN
-    PERFORM ${schema}.notice_ignore(TG_TAG, target);
+    PERFORM ${schema}.notice_ignore('irrelevant', TG_TAG, target);
     RETURN;
   END IF;
 
   IF TG_TAG = 'COMMENT' THEN
     -- Only make schemaSnapshots for COMMENT ON PUBLICATION
     IF target.object_type != 'publication' THEN
-      PERFORM ${schema}.notice_ignore(TG_TAG, target);
+      PERFORM ${schema}.notice_ignore('irrelevant', TG_TAG, target);
       RETURN;
     END IF;
-    event_type := 'schemaSnapshot';
-    event_prefix := '/ddl';
+    PERFORM ${schema}.update_schemas('schemaSnapshot', TG_TAG, target);
   ELSE
-    event_type := 'ddlUpdate';
-    event_prefix := '';  -- TODO: Use '/ddl' for both when rollback safe
+    PERFORM ${schema}.update_schemas('ddlUpdate', TG_TAG, target);
   END IF;
 
-  RAISE INFO 'Creating % for % %', event_type, TG_TAG, row_to_json(target);
-
-  SELECT ${schema}.schema_specs() INTO schema_specs;
-
-  SELECT json_build_object(
-    'type', event_type,
-    'version', ${PROTOCOL_VERSION},
-    'schema', schema_specs::json,
-    'event', json_build_object('tag', TG_TAG),
-    'context', ${schema}.get_trigger_context()
-  ) INTO message;
-
-  PERFORM pg_logical_emit_message(true, ${lit(
-    `${appID}/${shardNum}`,
-  )} || event_prefix, message);
 END
 $$ LANGUAGE plpgsql;
 `;
@@ -336,11 +371,7 @@ export function createEventTriggerStatements(shard: ShardConfig) {
 
   const triggers = [
     dropEventTriggerStatements(shard.appID, shard.shardNum),
-    createEventFunctionStatements(shard),
-  ];
-
-  // A single ddl_command_start trigger covering all relevant tags.
-  triggers.push(/*sql*/ `
+    /*sql*/ `
 CREATE EVENT TRIGGER ${sharded(`${appID}_ddl_start`)}
   ON ddl_command_start
   WHEN TAG IN (${lit(TAGS)})
@@ -350,9 +381,14 @@ CREATE EVENT TRIGGER ${sharded(`${appID}_ddl_end`)}
   ON ddl_command_end
   WHEN TAG IN (${lit([...TAGS, 'COMMENT'])})
   EXECUTE PROCEDURE ${schema}.emit_ddl_end();
-`);
+`,
+  ];
 
   // Drop legacy functions / triggers.
+  triggers.push(
+    `DROP FUNCTION IF EXISTS ${schema}.emit_ddl_end(text) CASCADE;`,
+    `DROP FUNCTION IF EXISTS ${schema}.notice_ignore(text, record);`,
+  );
   for (const tag of [...TAGS, 'COMMENT']) {
     const tagID = tag.toLowerCase().replace(' ', '_');
     triggers.push(`DROP FUNCTION IF EXISTS ${schema}.emit_${tagID}() CASCADE;`);

--- a/packages/zero-cache/src/services/change-source/pg/schema/init.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.ts
@@ -234,24 +234,18 @@ function getIncrementalMigrations(
 
     // v16: Upgrade DDL trigger to fire on all ALTER TABLE statements
     // to catch the *removal* of a table from the published set.
-    // (subsumed by v17)
-
-    // v17: Upgrade DDL triggers to support the COMMENT ON PUBLICATION hook for
+    // v17 (1.0.0): Upgrade DDL triggers to support the COMMENT ON PUBLICATION hook for
     // working around the lack of event trigger support for PUBLICATION
     // changes in supabase.
-    //
     // This also adds forwards-compatible support for hierarchical logical
     // message prefixes and unknown ddl event types.
-    // (subsumed by v18)
-
     // v18: Pure refactoring of event trigger code.
-    // (subsumed by v19)
+    // v19 (1.4.0): Correctly handle concurrently issued DDL statements.
+    // v20 (1.4.0): Handle nested DDL triggers
 
-    // v19: Correctly handle concurrently issued DDL statements.
-    // (subsumed by v20)
-
-    // v20: Handle nested DDL triggers
-    20: {
+    // v21 (1.5.0): Handle cross-transaction DDL operations (i.e. concurrent
+    // index operations), and support manual invocation of update_schemas().
+    21: {
       migrateSchema: async (lc, sql) => {
         const [{publications}] = await sql<{publications: string[]}[]>`
           SELECT publications FROM ${sql(shardConfigTable)}`;

--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
@@ -14,7 +14,10 @@ import type {PostgresDB, PostgresTransaction} from '../../../../types/pg.ts';
 import type {AppID, ShardConfig, ShardID} from '../../../../types/shards.ts';
 import {appSchema, check, upstreamSchema} from '../../../../types/shards.ts';
 import {id} from '../../../../types/sql.ts';
-import {createEventTriggerStatements} from './ddl.ts';
+import {
+  createEventFunctionStatements,
+  createEventTriggerStatements,
+} from './ddl.ts';
 import {
   getPublicationInfo,
   publishedSchema,
@@ -388,6 +391,12 @@ export async function setupTriggers(
   const schema = upstreamSchema(shard);
   const [{ddlDetection}] = await tx<InternalShardConfig[]> /*sql*/ `
     SELECT "ddlDetection" FROM ${tx(schema)}."shardConfig"`;
+
+  // The functions invoked by event triggers are installed even if
+  // event triggers are not supported/allowed by the db provider.
+  // This allows users to manually invoke the update_schemas() function
+  // as a workaround.
+  await tx.unsafe(createEventFunctionStatements(shard));
   try {
     await tx.savepoint(sub => sub.unsafe(triggerSetup(shard)));
   } catch (e) {


### PR DESCRIPTION
### Improvements

1. Expose a Postgres change function to detect / replicate schema changes on upstream DBs that do not allow/support event triggers (e.g. Render). Example:

```sql
CREATE TABLE foo(id TEXT PRIMARY KEY);
SELECT zero_0.update_schemas();  -- the pg schema is `${ZERO_APP_ID}_0`
```

2. Simplify the `COMMENT ON PUBLICATION` schema change hook for replicating publication changes on Supabase. The `COMMENT` statement now only needs to follow the `ALTER PUBLICATION` statement, rather than bookending it (although bookending it is still fine):

```sql
-- No need for the preceding COMMENT anymore
-- COMMENT ON PUBLICATION zero_pub IS 'unnecessary';
ALTER PUBLICATION zero_pub ADD TABLE foo;
COMMENT ON PUBLICATION zero_pub IS 'anything';
```

3. Reliably handle `{CREATE,DROP} INDEX CONCURRENTLY` statements, even if the replication-manager starts the replication stream at a point where the index is being built.

### Implementation

Rather than relying on before-and-after ddl messages to compute the diff between schema snapshots, the ddl detection logic now persists each schema snapshot to an upstream metadata table. Each ddl trigger now looks up the previous schema snapshot from the table and updates the table with the new snapshot, sending both previous and new schemas in a single message.

* This eliminates the need for the ddlStart and ddlUpdate messages to appear in the same transaction. They can be arbitrarily far apart, as can be the case with `CREATE INDEX CONCURRENTLY`.
* This also affords an optimization in which no-op changes can skip message emission entirely; if the schema snapshots are identical, the ddlUpdate message is not sent (similarly to when the ddl event itself is determined to be irrelevant to the publication).
* no-op `schemaSnapshot` messages are, for the time being, still sent for backwards compatibility.

### Rollback safety

The updated event trigger behavior is compatible with zero-cache versions back to 1.0.0.

### Miscellaneous

Restore tests that were disabled in https://github.com/rocicorp/mono/pull/5877.

The problem was the `dequeue()` timeout being exceeded when run on GitHub Actions.