### PR TITLE
Fix: Exclude null clientAST values from statz query

### DIFF
--- a/packages/zero-cache/src/services/statz.ts
+++ b/packages/zero-cache/src/services/statz.ts
@@ -166,6 +166,7 @@ async function cvrStats(lc: LogContext, config: ZeroConfig) {
         'biggestAstHash',
         sql`SELECT "queryHash", length("clientAST"::text) AS "ast_length"
       FROM ${sql(schema)}."queries"
+      WHERE "clientAST" IS NOT NULL
       ORDER BY length("clientAST"::text) DESC
       LIMIT 1;`,
       ],


### PR DESCRIPTION
## Summary

- `biggestAstHash` in `statz.ts` returns a result with `ast_length: null` instead of the largest AST whenever any `queries` row has a `NULL` `clientAST`. The cause is PostgreSQL's default NULL ordering: with `ORDER BY ... DESC`,
  NULLs sort before non-null values, so a single NULL returns from `LIMIT 1`.
- [Custom queries intentionally store `NULL` in `clientAST`](https://github.com/rocicorp/mono/blob/f52c6d2ef340bf9c9937523e2a77d2eab66217b0/packages/zero-cache/src/services/view-syncer/schema/cvr.ts#L124-L129) because custom queries don't persist an AST.
- **Fix**: Added WHERE "clientAST" IS NOT NULL to the biggestAstHash query.

## Why

The current largest AST statz endpoint is unhelpful.
<img width="768" height="312" alt="image" src="https://github.com/user-attachments/assets/4796a1ff-96b8-4587-80a1-7f0fcf10b92b" />

## Validation 

- `npm test`