### PR TITLE
chore(zero-cache): stringify change streamer payloads before subscriber fanout

### DIFF
--- a/packages/zero-cache/src/server/change-streamer.pg.test.ts
+++ b/packages/zero-cache/src/server/change-streamer.pg.test.ts
@@ -114,6 +114,7 @@ test('change-streamer startup does not deadlock on autoreset retry when change a
         ZERO_NUM_SYNC_WORKERS: '1',
         ZERO_PORT: String(changeStreamerPort - 1),
         ZERO_CHANGE_STREAMER_PORT: String(changeStreamerPort),
+        ZERO_LOG_LEVEL: 'error', // silence logs from the worker
       };
 
       const workerDone = runWorker(worker, env);

--- a/packages/zero-cache/src/services/change-streamer/broadcast.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/broadcast.test.ts
@@ -1,15 +1,16 @@
-import {consoleLogSink, LogContext} from '@rocicorp/logger';
 import {describe, expect, test} from 'vitest';
+import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {sleep} from '../../../../shared/src/sleep.ts';
 import {ReplicationMessages} from '../replicator/test-utils.ts';
 import {Broadcast} from './broadcast.ts';
 import {createSubscriber} from './test-utils.ts';
 
+const json = BigIntJSON.stringify;
+
 describe('change-streamer/broadcast', () => {
   const messages = new ReplicationMessages({issues: 'id'});
-  const lc = new LogContext('debug', {}, consoleLogSink);
-  createSilentLogContext();
+  const lc = createSilentLogContext();
 
   test('without tracking', () => {
     const [sub1, stream1] = createSubscriber('00', true);
@@ -19,7 +20,11 @@ describe('change-streamer/broadcast', () => {
 
     Broadcast.withoutTracking(
       [sub1, sub2, sub3, sub4],
-      ['11', ['begin', messages.begin(), {commitWatermark: '13'}]],
+      [
+        '11',
+        'begin',
+        json(['begin', messages.begin(), {commitWatermark: '13'}]),
+      ],
     );
 
     for (const sub of [sub1, sub2, sub3, sub4]) {
@@ -43,7 +48,11 @@ describe('change-streamer/broadcast', () => {
 
     const broadcast = new Broadcast(
       [sub1, sub2, sub3, sub4],
-      ['11', ['begin', messages.begin(), {commitWatermark: '13'}]],
+      [
+        '11',
+        'begin',
+        json(['begin', messages.begin(), {commitWatermark: '13'}]),
+      ],
     );
 
     expect(broadcast.isDone).toBe(false);
@@ -75,7 +84,11 @@ describe('change-streamer/broadcast', () => {
 
     const broadcast = new Broadcast(
       [sub1, sub2, sub3, sub4],
-      ['11', ['begin', messages.begin(), {commitWatermark: '13'}]],
+      [
+        '11',
+        'begin',
+        json(['begin', messages.begin(), {commitWatermark: '13'}]),
+      ],
     );
 
     expect(broadcast.isDone).toBe(false);

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.pg.test.ts
@@ -3,6 +3,7 @@ import {resolver} from '@rocicorp/resolver';
 import Fastify from 'fastify';
 import {beforeEach, describe, expect, type MockedFunction, vi} from 'vitest';
 import WebSocket from 'ws';
+import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import type {ZeroConfig} from '../../config/zero-config.ts';
 import {getConnectionURI, type PgTest, test} from '../../test/db.ts';
@@ -39,10 +40,10 @@ const SHARD_ID = {
 describe('change-streamer/http', () => {
   let lc: LogContext;
   let changeDB: PostgresDB;
-  let downstream: Subscription<Downstream>;
+  let downstream: Subscription<string>;
   let snapshotStream: Subscription<SnapshotMessage>;
   let subscribeFn: MockedFunction<
-    (ctx: SubscriberContext) => Promise<Subscription<Downstream>>
+    (ctx: SubscriberContext) => Promise<Subscription<string>>
   >;
   let snapshotFn: MockedFunction<(id: string) => Subscription<SnapshotMessage>>;
   let endReservationFn: MockedFunction<(id: string) => void>;
@@ -72,7 +73,10 @@ describe('change-streamer/http', () => {
 
     const {promise, resolve: cleanup} = resolver<Downstream[]>();
     connectionClosed = promise;
-    downstream = Subscription.create({cleanup});
+    downstream = Subscription.create({
+      cleanup: msgs =>
+        cleanup(msgs.map(m => BigIntJSON.parse(m) as Downstream)),
+    });
     snapshotStream = Subscription.create();
     subscribeFn = vi.fn();
     snapshotFn = vi.fn();
@@ -110,6 +114,8 @@ describe('change-streamer/http', () => {
           service.resolve();
           return service.promise;
         }),
+        scheduleCleanup: vi.fn(),
+        getChangeLogState: vi.fn(),
       },
       {
         startSnapshotReservation: snapshotFn.mockReturnValue(snapshotStream),
@@ -169,6 +175,8 @@ describe('change-streamer/http', () => {
           service.resolve();
           return service.promise;
         }),
+        scheduleCleanup: vi.fn(),
+        getChangeLogState: vi.fn(),
       },
       null,
     );
@@ -294,8 +302,12 @@ describe('change-streamer/http', () => {
 
       expect(endReservationFn).toHaveBeenCalledWith('foo-task');
 
-      downstream.push(['begin', {tag: 'begin'}, {commitWatermark: '456'}]);
-      downstream.push(['commit', {tag: 'commit'}, {watermark: '456'}]);
+      downstream.push(
+        JSON.stringify(['begin', {tag: 'begin'}, {commitWatermark: '456'}]),
+      );
+      downstream.push(
+        JSON.stringify(['commit', {tag: 'commit'}, {watermark: '456'}]),
+      );
 
       expect(await drain(2, sub)).toEqual([
         ['begin', {tag: 'begin'}, {commitWatermark: '456'}],
@@ -335,7 +347,7 @@ describe('change-streamer/http', () => {
       big3: BigInt(Number.MAX_SAFE_INTEGER) + 3n,
     });
 
-    downstream.push(['data', insert]);
+    downstream.push(BigIntJSON.stringify(['data', insert]));
     expect(await drain(1, sub)).toMatchInlineSnapshot(`
       [
         [

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
@@ -9,17 +9,22 @@ import type {IncomingMessageSubset} from '../../types/http.ts';
 import {pgClient, type PostgresDB} from '../../types/pg.ts';
 import {type Worker} from '../../types/processes.ts';
 import {type ShardID} from '../../types/shards.ts';
-import {streamIn, streamOut, type Source} from '../../types/streams.ts';
+import {
+  streamIn,
+  streamOut,
+  streamOutStringified,
+  type Source,
+} from '../../types/streams.ts';
 import {URLParams} from '../../types/url-params.ts';
 import {installWebSocketReceiver} from '../../types/websocket-handoff.ts';
 import {closeWithError, PROTOCOL_ERROR} from '../../types/ws.ts';
 import {HttpService} from '../http-service.ts';
-import type {Service} from '../service.ts';
 import type {BackupMonitor} from './backup-monitor.ts';
 import {
   downstreamSchema,
   PROTOCOL_VERSION,
   type ChangeStreamer,
+  type ChangeStreamerService,
   type Downstream,
   type SubscriberContext,
 } from './change-streamer.ts';
@@ -45,7 +50,7 @@ export class ChangeStreamerHttpServer extends HttpService {
   readonly id = 'change-streamer-http-server';
   readonly #lc: LogContext;
   readonly #opts: Options;
-  readonly #changeStreamer: ChangeStreamer & Service;
+  readonly #changeStreamer: ChangeStreamerService;
   readonly #backupMonitor: BackupMonitor | null;
 
   constructor(
@@ -53,7 +58,7 @@ export class ChangeStreamerHttpServer extends HttpService {
     config: ZeroConfig,
     opts: Options,
     parent: Worker,
-    changeStreamer: ChangeStreamer & Service,
+    changeStreamer: ChangeStreamerService,
     backupMonitor: BackupMonitor | null,
   ) {
     super('change-streamer-http-server', lc, opts, async fastify => {
@@ -159,7 +164,7 @@ export class ChangeStreamerHttpServer extends HttpService {
         // end the reservation to safely resume scheduling cleanup.
         this.#backupMonitor.endReservation(ctx.taskID);
       }
-      void streamOut(this._lc, downstream, ws);
+      void streamOutStringified(this._lc, downstream, ws);
     } catch (err) {
       closeWithError(this._lc, ws, err, PROTOCOL_ERROR);
     }

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -5,7 +5,7 @@ import postgres from 'postgres';
 import {beforeEach, describe, expect, vi, type Mock} from 'vitest';
 import {AbortError} from '../../../../shared/src/abort-error.ts';
 import {assert} from '../../../../shared/src/asserts.ts';
-import {stringify} from '../../../../shared/src/bigint-json.ts';
+import {BigIntJSON, stringify} from '../../../../shared/src/bigint-json.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {Queue} from '../../../../shared/src/queue.ts';
 import {sleep} from '../../../../shared/src/sleep.ts';
@@ -107,11 +107,11 @@ describe('change-streamer/service', () => {
     };
   });
 
-  function drainToQueue(sub: Source<Downstream>): Queue<Downstream> {
+  function drainToQueue(sub: Source<string>): Queue<Downstream> {
     const queue = new Queue<Downstream>();
     void (async () => {
       for await (const msg of sub) {
-        queue.enqueue(msg);
+        queue.enqueue(BigIntJSON.parse(msg) as Downstream);
       }
     })();
     return queue;
@@ -868,7 +868,8 @@ describe('change-streamer/service', () => {
     expect(setTimeoutFn).toHaveBeenCalledTimes(3);
 
     drainToQueue(sub1);
-    for await (const msg of sub2) {
+    for await (const json of sub2) {
+      const msg: Downstream = BigIntJSON.parse(json) as Downstream;
       if (msg[0] === 'commit' && msg[2].watermark === '08') {
         // Now that sub2 has consumed past '06',
         // a purge should successfully clear records before '06'

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -21,6 +21,7 @@ import type {
 import {
   type ChangeStreamControl,
   type ChangeStreamData,
+  type Rollback,
 } from '../change-source/protocol/current/downstream.ts';
 import {
   publishReplicationError,
@@ -35,7 +36,6 @@ import {
 } from '../running-state.ts';
 import {
   type ChangeStreamerService,
-  type Downstream,
   type Status,
   type SubscriberContext,
 } from './change-streamer.ts';
@@ -107,6 +107,8 @@ export async function initializeStreamer(
 
 const REPLICATION_STATUS_ERROR_DELAY_THRESHOLD_MS = 5000;
 
+export type ChangeTag = ChangeStreamData[1]['tag'];
+
 /**
  * Internally all Downstream messages (not just commits) are given a watermark.
  * These are used for internal ordering for:
@@ -116,8 +118,16 @@ const REPLICATION_STATUS_ERROR_DELAY_THRESHOLD_MS = 5000;
  * However, only the watermark for `Commit` messages are exposed to
  * subscribers, as that is the only semantically correct watermark to
  * use for tracking a position in a replication stream.
+ *
+ * Additionally, the ChangeStreamData is eagerly stringified once, after which
+ * the string is passed to the changeLog and all subscribers, eliminating
+ * redundant stringification and reducing GC churn.
  */
-export type WatermarkedChange = [watermark: string, ChangeStreamData];
+export type WatermarkedChange = [
+  watermark: string,
+  tag: ChangeTag,
+  json: string,
+];
 
 /**
  * Upstream-agnostic dispatch of messages in a {@link ChangeStreamMessage} to a
@@ -430,8 +440,9 @@ class ChangeStreamerImpl implements ChangeStreamerService {
               break;
           }
 
-          const entry: WatermarkedChange = [watermark, change];
-          unflushedBytes += this.#storer.store(entry);
+          const json = this.#storer.store(watermark, change);
+          const entry: WatermarkedChange = [watermark, change[1].tag, json];
+          unflushedBytes += json.length;
           if (unflushedBytes < flushBytesThreshold) {
             // pipeline changes until flushBytesThreshold
             this.#forwarder.forward(entry);
@@ -468,7 +479,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       if (watermark) {
         this.#lc.warn?.(`aborting interrupted transaction ${watermark}`);
         this.#storer.abort();
-        this.#forwarder.forward([watermark, ['rollback', {tag: 'rollback'}]]);
+        this.#forwarder.forward([watermark, 'rollback', ROLLBACK_JSON]);
       }
 
       // Backoff and drain any pending entries in the storer before reconnecting.
@@ -511,12 +522,12 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     }
   }
 
-  subscribe(ctx: SubscriberContext): Promise<Source<Downstream>> {
+  subscribe(ctx: SubscriberContext): Promise<Source<string>> {
     const {protocolVersion, id, mode, replicaVersion, watermark} = ctx;
     if (mode === 'serving') {
       this.#serving.resolve();
     }
-    const downstream = Subscription.create<Downstream>({
+    const downstream = Subscription.create<string>({
       cleanup: () => this.#forwarder.remove(subscriber),
     });
     const subscriber = new Subscriber(
@@ -639,3 +650,8 @@ class ChangeStreamerImpl implements ChangeStreamerService {
 // so that the `change-streamer` can track its progress and know when it has
 // surpassed the initial watermark of the backup [1].
 const CLEANUP_DELAY_MS = DEFAULT_MAX_RETRY_DELAY_MS * 3;
+
+const ROLLBACK_JSON = JSON.stringify([
+  'rollback',
+  {tag: 'rollback'},
+] satisfies Rollback);

--- a/packages/zero-cache/src/services/change-streamer/change-streamer.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer.ts
@@ -1,7 +1,6 @@
 import type {Enum} from '../../../../shared/src/enum.ts';
 import * as v from '../../../../shared/src/valita.ts';
 import type {Source} from '../../types/streams.ts';
-import {type Change} from '../change-source/protocol/current/data.ts';
 import {changeStreamDataSchema} from '../change-source/protocol/current/downstream.ts';
 import type {ReplicatorMode} from '../replicator/replicator.ts';
 import {changeSourceTimingsSchema} from '../replicator/reporter/report-schema.ts';
@@ -125,17 +124,6 @@ export type SubscriberContext = {
   initial: boolean;
 };
 
-export type ChangeEntry = {
-  change: Change;
-
-  /**
-   * Note that it is technically possible for multiple changes to have
-   * the same watermark, but that of a commit is guaranteed to be final,
-   * so subscribers should only store the watermark of commit changes.
-   */
-  watermark: string;
-};
-
 /**
  * The StatusMessage payload for now is empty, but can be extended to
  * include meta-level information in the future.
@@ -206,7 +194,14 @@ export function errorTypeToReadableName(val: ErrorType) {
  */
 export type Downstream = v.Infer<typeof downstreamSchema>;
 
-export interface ChangeStreamerService extends ChangeStreamer, Service {
+export interface ChangeStreamerService
+  extends Omit<ChangeStreamer, 'subscribe'>, Service {
+  /**
+   * The server-side interface overrides `subscribe()` to return a stream
+   * of already-stringified {@link Downstream} payloads.
+   */
+  subscribe(ctx: SubscriberContext): Promise<Source<string>>;
+
   /**
    * Notifies the change streamer of a watermark that has been backed up,
    * indicating that changes before the watermark can be purged if active

--- a/packages/zero-cache/src/services/change-streamer/forwarder.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/forwarder.test.ts
@@ -1,8 +1,11 @@
 import {describe, expect, test} from 'vitest';
+import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {ReplicationMessages} from '../replicator/test-utils.ts';
 import {Forwarder} from './forwarder.ts';
 import {createSubscriber} from './test-utils.ts';
+
+const json = BigIntJSON.stringify;
 
 describe('change-streamer/forwarder', () => {
   const messages = new ReplicationMessages({issues: 'id'});
@@ -18,21 +21,25 @@ describe('change-streamer/forwarder', () => {
     forwarder.add(sub1);
     forwarder.forward([
       '11',
-      ['begin', messages.begin(), {commitWatermark: '13'}],
+      'begin',
+      json(['begin', messages.begin(), {commitWatermark: '13'}]),
     ]);
     forwarder.add(sub2);
     void forwarder.forwardWithFlowControl([
       '12',
-      ['data', messages.truncate('issues')],
+      'truncate',
+      json(['data', messages.truncate('issues')]),
     ]);
     void forwarder.forwardWithFlowControl([
       '13',
-      ['commit', messages.commit(), {watermark: '13'}],
+      'commit',
+      json(['commit', messages.commit(), {watermark: '13'}]),
     ]);
     forwarder.add(sub3);
     forwarder.forward([
       '14',
-      ['begin', messages.begin(), {commitWatermark: '15'}],
+      'begin',
+      json(['begin', messages.begin(), {commitWatermark: '15'}]),
     ]);
     forwarder.add(sub4);
 
@@ -163,18 +170,25 @@ describe('change-streamer/forwarder', () => {
     forwarder.add(sub1);
     forwarder.forward([
       '11',
-      ['begin', messages.begin(), {commitWatermark: '14'}],
+      'begin',
+      json(['begin', messages.begin(), {commitWatermark: '14'}]),
     ]);
     forwarder.add(sub2);
-    forwarder.forward(['12', ['data', messages.truncate('issues')]]);
+    forwarder.forward([
+      '12',
+      'truncate',
+      json(['data', messages.truncate('issues')]),
+    ]);
     void forwarder.forwardWithFlowControl([
       '13',
-      ['rollback', messages.rollback()],
+      'rollback',
+      json(['rollback', messages.rollback()]),
     ]);
     forwarder.add(sub3);
     forwarder.forward([
       '14',
-      ['begin', messages.begin(), {commitWatermark: '15'}],
+      'begin',
+      json(['begin', messages.begin(), {commitWatermark: '15'}]),
     ]);
     forwarder.add(sub4);
 

--- a/packages/zero-cache/src/services/change-streamer/forwarder.ts
+++ b/packages/zero-cache/src/services/change-streamer/forwarder.ts
@@ -1,8 +1,7 @@
 import type {LogContext} from '@rocicorp/logger';
 import {joinIterables, wrapIterable} from '../../../../shared/src/iterables.ts';
-import type {ChangeStreamData} from '../change-source/protocol/current.ts';
 import {Broadcast} from './broadcast.ts';
-import type {WatermarkedChange} from './change-streamer-service.ts';
+import type {ChangeTag, WatermarkedChange} from './change-streamer-service.ts';
 import type {Status} from './change-streamer.ts';
 import type {Subscriber} from './subscriber.ts';
 
@@ -113,8 +112,8 @@ export class Forwarder {
     }
   }
 
-  #updateActiveSubscribers([type]: ChangeStreamData) {
-    switch (type) {
+  #updateActiveSubscribers(tag: ChangeTag) {
+    switch (tag) {
       case 'begin':
         // While in a Transaction, all added subscribers are "queued" so that no
         // messages are forwarded to them. This state corresponds to being queued

--- a/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
@@ -1,25 +1,36 @@
 import {PG_LOCK_NOT_AVAILABLE} from '@drdgvhbh/postgres-error-codes';
 import postgres from 'postgres';
 import {beforeEach, describe, expect} from 'vitest';
+import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {Queue} from '../../../../shared/src/queue.ts';
 import {sleep} from '../../../../shared/src/sleep.ts';
 import {type PgTest, test} from '../../test/db.ts';
 import type {PostgresDB} from '../../types/pg.ts';
 import type {Subscription} from '../../types/subscription.ts';
-import {type Commit} from '../change-source/protocol/current/downstream.ts';
+import {
+  type ChangeStreamData,
+  type Commit,
+} from '../change-source/protocol/current/downstream.ts';
 import type {UpstreamStatusMessage} from '../change-source/protocol/current/status.ts';
 import {ReplicationMessages} from '../replicator/test-utils.ts';
 import {type Downstream} from './change-streamer.ts';
 import * as ErrorType from './error-type-enum.ts';
 import {ensureReplicationConfig, setupCDCTables} from './schema/tables.ts';
-import {PurgeLocker, Storer, type TuningOptions} from './storer.ts';
+import {
+  extractChangeSubstring,
+  PurgeLocker,
+  Storer,
+  type TuningOptions,
+} from './storer.ts';
 import {createSubscriber} from './test-utils.ts';
 
 const opts: TuningOptions = {
   backPressureLimitHeapProportion: 0.04,
   statementTimeoutMs: 20_000,
 };
+
+const json = BigIntJSON.stringify;
 
 describe('change-streamer/storer', () => {
   const lc = createSilentLogContext();
@@ -82,9 +93,10 @@ describe('change-streamer/storer', () => {
 
   const messages = new ReplicationMessages({issues: 'id'});
 
-  async function drain(sub: Subscription<Downstream>, untilWatermark?: string) {
+  async function drain(sub: Subscription<string>, untilWatermark?: string) {
     const msgs: Downstream[] = [];
-    for await (const msg of sub) {
+    for await (const json of sub) {
+      const msg: Downstream = JSON.parse(json);
       msgs.push(msg);
       if (msg[0] === 'commit' && msg[2].watermark === untilWatermark) {
         break;
@@ -167,11 +179,8 @@ describe('change-streamer/storer', () => {
         await storer.getStartStreamInitializationParameters(),
       ).toMatchObject({lastWatermark: '06', backfillRequests: []});
 
-      storer.store([
-        '08',
-        ['begin', messages.begin(), {commitWatermark: '08'}],
-      ]);
-      storer.store(['08', ['commit', messages.commit(), {watermark: '08'}]]);
+      storer.store('08', ['begin', messages.begin(), {commitWatermark: '08'}]);
+      storer.store('08', ['commit', messages.commit(), {watermark: '08'}]);
 
       await storer.allProcessed();
       expect(
@@ -180,28 +189,22 @@ describe('change-streamer/storer', () => {
 
       // Add table metadata. This should be stored, but not returned in
       // initialization parameters without any backfill data.
-      storer.store([
-        '09',
-        ['begin', messages.begin(), {commitWatermark: '09'}],
-      ]);
-      storer.store([
-        '09',
-        [
-          'data',
-          {
-            tag: 'create-table',
-            spec: {
-              schema: 'my',
-              name: 'foo',
-              columns: {},
-            },
-            metadata: {
-              rowKey: {type: 'index', columns: ['a', 'b']},
-            },
+      storer.store('09', ['begin', messages.begin(), {commitWatermark: '09'}]);
+      storer.store('09', [
+        'data',
+        {
+          tag: 'create-table',
+          spec: {
+            schema: 'my',
+            name: 'foo',
+            columns: {},
           },
-        ],
+          metadata: {
+            rowKey: {type: 'index', columns: ['a', 'b']},
+          },
+        },
       ]);
-      storer.store(['09', ['commit', messages.commit(), {watermark: '09'}]]);
+      storer.store('09', ['commit', messages.commit(), {watermark: '09'}]);
 
       // No backfillRequests should be present.
       await storer.allProcessed();
@@ -214,30 +217,24 @@ describe('change-streamer/storer', () => {
       `);
 
       // Add a different table with backfill metadata only.
-      storer.store([
-        '0a',
-        ['begin', messages.begin(), {commitWatermark: '0a'}],
-      ]);
-      storer.store([
-        '0a',
-        [
-          'data',
-          {
-            tag: 'create-table',
-            spec: {
-              schema: 'your',
-              name: 'bar',
-              columns: {},
-            },
-            backfill: {
-              a: {fooID: 987, barID: 'zoo'},
-              b: {fooID: 843, barID: 'ozz'},
-              d: {fooID: 777, barID: 'zoz'},
-            },
+      storer.store('0a', ['begin', messages.begin(), {commitWatermark: '0a'}]);
+      storer.store('0a', [
+        'data',
+        {
+          tag: 'create-table',
+          spec: {
+            schema: 'your',
+            name: 'bar',
+            columns: {},
           },
-        ],
+          backfill: {
+            a: {fooID: 987, barID: 'zoo'},
+            b: {fooID: 843, barID: 'ozz'},
+            d: {fooID: 777, barID: 'zoz'},
+          },
+        },
       ]);
-      storer.store(['0a', ['commit', messages.commit(), {watermark: '0a'}]]);
+      storer.store('0a', ['commit', messages.commit(), {watermark: '0a'}]);
 
       // The table should appear in the backfillRequests, with null metadata
       // since none was ever specified.
@@ -273,26 +270,20 @@ describe('change-streamer/storer', () => {
         `);
 
       // Add a column to the original table backfill metadata.
-      storer.store([
-        '0b',
-        ['begin', messages.begin(), {commitWatermark: '0a'}],
-      ]);
-      storer.store([
-        '0b',
-        [
-          'data',
-          {
-            tag: 'add-column',
-            table: {
-              schema: 'my',
-              name: 'foo',
-            },
-            column: {name: 'c', spec: {pos: 3, dataType: 'text'}},
-            backfill: {fooID: 123, barID: 'baz'},
+      storer.store('0b', ['begin', messages.begin(), {commitWatermark: '0a'}]);
+      storer.store('0b', [
+        'data',
+        {
+          tag: 'add-column',
+          table: {
+            schema: 'my',
+            name: 'foo',
           },
-        ],
+          column: {name: 'c', spec: {pos: 3, dataType: 'text'}},
+          backfill: {fooID: 123, barID: 'baz'},
+        },
       ]);
-      storer.store(['0b', ['commit', messages.commit(), {watermark: '0b'}]]);
+      storer.store('0b', ['commit', messages.commit(), {watermark: '0b'}]);
 
       // Now the original table shows up in the backfillRequests, with its
       // table metadata.
@@ -349,29 +340,23 @@ describe('change-streamer/storer', () => {
         `);
 
       // Add another column to the same table with new table metadata.
-      storer.store([
-        '0c',
-        ['begin', messages.begin(), {commitWatermark: '0b'}],
-      ]);
-      storer.store([
-        '0c',
-        [
-          'data',
-          {
-            tag: 'add-column',
-            table: {
-              schema: 'my',
-              name: 'foo',
-            },
-            tableMetadata: {
-              rowKey: {type: 'default', columns: ['b']},
-            },
-            column: {name: 'd', spec: {pos: 4, dataType: 'text'}},
-            backfill: {fooID: 456, barID: 'boo'},
+      storer.store('0c', ['begin', messages.begin(), {commitWatermark: '0b'}]);
+      storer.store('0c', [
+        'data',
+        {
+          tag: 'add-column',
+          table: {
+            schema: 'my',
+            name: 'foo',
           },
-        ],
+          tableMetadata: {
+            rowKey: {type: 'default', columns: ['b']},
+          },
+          column: {name: 'd', spec: {pos: 4, dataType: 'text'}},
+          backfill: {fooID: 456, barID: 'boo'},
+        },
       ]);
-      storer.store(['0c', ['commit', messages.commit(), {watermark: '0c'}]]);
+      storer.store('0c', ['commit', messages.commit(), {watermark: '0c'}]);
 
       await storer.allProcessed();
       expect(await storer.getStartStreamInitializationParameters())
@@ -429,30 +414,24 @@ describe('change-streamer/storer', () => {
         `);
 
       // Update the table metadata of the new table.
-      storer.store([
-        '0d',
-        ['begin', messages.begin(), {commitWatermark: '0c'}],
-      ]);
-      storer.store([
-        '0d',
-        [
-          'data',
-          {
-            tag: 'update-table-metadata',
-            table: {
-              schema: 'your',
-              name: 'bar',
-            },
-            old: {
-              rowKey: {type: 'full', columns: ['a', 'b']},
-            },
-            new: {
-              rowKey: {type: 'default', columns: ['a']},
-            },
+      storer.store('0d', ['begin', messages.begin(), {commitWatermark: '0c'}]);
+      storer.store('0d', [
+        'data',
+        {
+          tag: 'update-table-metadata',
+          table: {
+            schema: 'your',
+            name: 'bar',
           },
-        ],
+          old: {
+            rowKey: {type: 'full', columns: ['a', 'b']},
+          },
+          new: {
+            rowKey: {type: 'default', columns: ['a']},
+          },
+        },
       ]);
-      storer.store(['0d', ['commit', messages.commit(), {watermark: '0d'}]]);
+      storer.store('0d', ['commit', messages.commit(), {watermark: '0d'}]);
 
       await storer.allProcessed();
       expect(await storer.getStartStreamInitializationParameters())
@@ -517,32 +496,26 @@ describe('change-streamer/storer', () => {
         `);
 
       // Rename one of the backfilling columns
-      storer.store([
-        '0e',
-        ['begin', messages.begin(), {commitWatermark: '0e'}],
-      ]);
-      storer.store([
-        '0e',
-        [
-          'data',
-          {
-            tag: 'update-column',
-            table: {
-              schema: 'your',
-              name: 'bar',
-            },
-            old: {
-              name: 'b',
-              spec: {pos: 2, dataType: 'text'},
-            },
-            new: {
-              name: 'newName',
-              spec: {pos: 2, dataType: 'text'},
-            },
+      storer.store('0e', ['begin', messages.begin(), {commitWatermark: '0e'}]);
+      storer.store('0e', [
+        'data',
+        {
+          tag: 'update-column',
+          table: {
+            schema: 'your',
+            name: 'bar',
           },
-        ],
+          old: {
+            name: 'b',
+            spec: {pos: 2, dataType: 'text'},
+          },
+          new: {
+            name: 'newName',
+            spec: {pos: 2, dataType: 'text'},
+          },
+        },
       ]);
-      storer.store(['0e', ['commit', messages.commit(), {watermark: '0e'}]]);
+      storer.store('0e', ['commit', messages.commit(), {watermark: '0e'}]);
 
       await storer.allProcessed();
       expect(await storer.getStartStreamInitializationParameters())
@@ -607,25 +580,19 @@ describe('change-streamer/storer', () => {
         `);
 
       // Drop a backfilling column.
-      storer.store([
-        '0f',
-        ['begin', messages.begin(), {commitWatermark: '0f'}],
-      ]);
-      storer.store([
-        '0f',
-        [
-          'data',
-          {
-            tag: 'drop-column',
-            table: {
-              schema: 'your',
-              name: 'bar',
-            },
-            column: 'newName',
+      storer.store('0f', ['begin', messages.begin(), {commitWatermark: '0f'}]);
+      storer.store('0f', [
+        'data',
+        {
+          tag: 'drop-column',
+          table: {
+            schema: 'your',
+            name: 'bar',
           },
-        ],
+          column: 'newName',
+        },
       ]);
-      storer.store(['0f', ['commit', messages.commit(), {watermark: '0f'}]]);
+      storer.store('0f', ['commit', messages.commit(), {watermark: '0f'}]);
 
       await storer.allProcessed();
       expect(await storer.getStartStreamInitializationParameters())
@@ -686,27 +653,25 @@ describe('change-streamer/storer', () => {
         `);
 
       // Set the other backfilling columns to completed
-      storer.store([
-        '110',
-        ['begin', messages.begin(), {commitWatermark: '110'}],
+      storer.store('110', [
+        'begin',
+        messages.begin(),
+        {commitWatermark: '110'},
       ]);
-      storer.store([
-        '110',
-        [
-          'data',
-          {
-            tag: 'backfill-completed',
-            relation: {
-              schema: 'your',
-              name: 'bar',
-              rowKey: {columns: ['a']},
-            },
-            columns: ['d'],
-            watermark: '0f',
+      storer.store('110', [
+        'data',
+        {
+          tag: 'backfill-completed',
+          relation: {
+            schema: 'your',
+            name: 'bar',
+            rowKey: {columns: ['a']},
           },
-        ],
+          columns: ['d'],
+          watermark: '0f',
+        },
       ]);
-      storer.store(['110', ['commit', messages.commit(), {watermark: '110'}]]);
+      storer.store('110', ['commit', messages.commit(), {watermark: '110'}]);
 
       await storer.allProcessed();
       expect(await storer.getStartStreamInitializationParameters())
@@ -743,43 +708,38 @@ describe('change-streamer/storer', () => {
         `);
 
       // Rename the backfilling table, and a contained column in the same tx.
-      storer.store([
-        '111',
-        ['begin', messages.begin(), {commitWatermark: '111'}],
+      storer.store('111', [
+        'begin',
+        messages.begin(),
+        {commitWatermark: '111'},
       ]);
-      storer.store([
-        '111',
-        [
-          'data',
-          {
-            tag: 'rename-table',
-            old: {schema: 'my', name: 'foo'},
-            new: {schema: 'your', name: 'bloo'},
+      storer.store('111', [
+        'data',
+        {
+          tag: 'rename-table',
+          old: {schema: 'my', name: 'foo'},
+          new: {schema: 'your', name: 'bloo'},
+        },
+      ]);
+      storer.store('111', [
+        'data',
+        {
+          tag: 'update-column',
+          table: {
+            schema: 'your',
+            name: 'bloo',
           },
-        ],
-      ]);
-      storer.store([
-        '111',
-        [
-          'data',
-          {
-            tag: 'update-column',
-            table: {
-              schema: 'your',
-              name: 'bloo',
-            },
-            old: {
-              name: 'd',
-              spec: {pos: 2, dataType: 'text'},
-            },
-            new: {
-              name: 'deez',
-              spec: {pos: 2, dataType: 'text'},
-            },
+          old: {
+            name: 'd',
+            spec: {pos: 2, dataType: 'text'},
           },
-        ],
+          new: {
+            name: 'deez',
+            spec: {pos: 2, dataType: 'text'},
+          },
+        },
       ]);
-      storer.store(['111', ['commit', messages.commit(), {watermark: '111'}]]);
+      storer.store('111', ['commit', messages.commit(), {watermark: '111'}]);
 
       await storer.allProcessed();
       expect(await storer.getStartStreamInitializationParameters())
@@ -816,21 +776,19 @@ describe('change-streamer/storer', () => {
         `);
 
       // Drop the backfilling table
-      storer.store([
-        '112',
-        ['begin', messages.begin(), {commitWatermark: '112'}],
+      storer.store('112', [
+        'begin',
+        messages.begin(),
+        {commitWatermark: '112'},
       ]);
-      storer.store([
-        '112',
-        [
-          'data',
-          {
-            tag: 'drop-table',
-            id: {schema: 'your', name: 'bloo'},
-          },
-        ],
+      storer.store('112', [
+        'data',
+        {
+          tag: 'drop-table',
+          id: {schema: 'your', name: 'bloo'},
+        },
       ]);
-      storer.store(['112', ['commit', messages.commit(), {watermark: '112'}]]);
+      storer.store('112', ['commit', messages.commit(), {watermark: '112'}]);
 
       await storer.allProcessed();
       expect(await storer.getStartStreamInitializationParameters())
@@ -923,13 +881,10 @@ describe('change-streamer/storer', () => {
       // SELECT will read the new owner immediately.
       await db`UPDATE "xero_5/cdc"."replicationState" SET owner = 'other-task'`;
 
-      storer.store([
-        '07',
-        ['begin', messages.begin(), {commitWatermark: '08'}],
-      ]);
+      storer.store('07', ['begin', messages.begin(), {commitWatermark: '08'}]);
       storer.catchup(sub1, 'serving');
-      storer.store(['07', ['data', messages.insert('issues', {id: 'foo'})]]);
-      storer.store(['08', ['commit', messages.commit(), {watermark: '08'}]]);
+      storer.store('07', ['data', messages.insert('issues', {id: 'foo'})]);
+      storer.store('08', ['commit', messages.commit(), {watermark: '08'}]);
       storer.catchup(sub2, 'serving');
 
       await expect(done).rejects.toThrow(
@@ -946,11 +901,8 @@ describe('change-streamer/storer', () => {
     test('ownership change not possible during transaction', async () => {
       // Start a transaction — this begins a SERIALIZABLE tx that
       // reads replicationState (owner = 'task-id').
-      storer.store([
-        '07',
-        ['begin', messages.begin(), {commitWatermark: '08'}],
-      ]);
-      storer.store(['07', ['data', messages.insert('issues', {id: 'foo'})]]);
+      storer.store('07', ['begin', messages.begin(), {commitWatermark: '08'}]);
+      storer.store('07', ['data', messages.insert('issues', {id: 'foo'})]);
 
       // Wait for the storer to process 'begin' and start the SERIALIZABLE tx.
       // The pipelined SELECT of replicationState should have executed by now.
@@ -969,7 +921,7 @@ describe('change-streamer/storer', () => {
       );
 
       // Now send commit.
-      storer.store(['08', ['commit', messages.commit(), {watermark: '08'}]]);
+      storer.store('08', ['commit', messages.commit(), {watermark: '08'}]);
 
       // Now an ownership change should succeed.
       expect(
@@ -987,19 +939,13 @@ describe('change-streamer/storer', () => {
     });
 
     test('abort', async () => {
-      storer.store([
-        '0b',
-        ['begin', messages.begin(), {commitWatermark: '0b'}],
-      ]);
-      storer.store(['0b', ['data', messages.insert('issues', {id: 'foo'})]]);
+      storer.store('0b', ['begin', messages.begin(), {commitWatermark: '0b'}]);
+      storer.store('0b', ['data', messages.insert('issues', {id: 'foo'})]);
       storer.abort();
 
-      storer.store([
-        '0a',
-        ['begin', messages.begin(), {commitWatermark: '0a'}],
-      ]);
-      storer.store(['0a', ['data', messages.insert('issues', {id: 'bar'})]]);
-      storer.store(['0a', ['commit', messages.commit(), {watermark: '0a'}]]);
+      storer.store('0a', ['begin', messages.begin(), {commitWatermark: '0a'}]);
+      storer.store('0a', ['data', messages.insert('issues', {id: 'bar'})]);
+      storer.store('0a', ['commit', messages.commit(), {watermark: '0a'}]);
 
       await expectConsumed('0a');
 
@@ -1035,9 +981,14 @@ describe('change-streamer/storer', () => {
       // This should be buffered until catchup is complete.
       void sub.send([
         '07',
-        ['begin', messages.begin(), {commitWatermark: '08'}],
+        'begin',
+        json(['begin', messages.begin(), {commitWatermark: '08'}]),
       ]);
-      void sub.send(['08', ['commit', messages.commit(), {watermark: '08'}]]);
+      void sub.send([
+        '08',
+        'commit',
+        json(['commit', messages.commit(), {watermark: '08'}]),
+      ]);
 
       // Catchup should start immediately since there are no txes in progress.
       storer.catchup(sub, 'backup');
@@ -1157,33 +1108,35 @@ describe('change-streamer/storer', () => {
       // This should be buffered until catchup is complete.
       void sub1.send([
         '09',
-        ['begin', messages.begin(), {commitWatermark: '0a'}],
+        'begin',
+        json(['begin', messages.begin(), {commitWatermark: '0a'}]),
       ]);
       void sub1.send([
         '0a',
-        ['commit', messages.commit({buffer: 'me'}), {watermark: '0a'}],
+        'commit',
+        json(['commit', messages.commit({buffer: 'me'}), {watermark: '0a'}]),
       ]);
       void sub2.send([
         '09',
-        ['begin', messages.begin(), {commitWatermark: '0a'}],
+        'begin',
+        json(['begin', messages.begin(), {commitWatermark: '0a'}]),
       ]);
       void sub2.send([
         '0a',
-        ['commit', messages.commit({buffer: 'me'}), {watermark: '0a'}],
+        'commit',
+        json(['commit', messages.commit({buffer: 'me'}), {watermark: '0a'}]),
       ]);
 
       // Start a transaction before enqueuing catchup.
-      storer.store([
-        '07',
-        ['begin', messages.begin(), {commitWatermark: '08'}],
-      ]);
+      storer.store('07', ['begin', messages.begin(), {commitWatermark: '08'}]);
       // Enqueue catchup before transaction completes.
       storer.catchup(sub1, 'serving');
       storer.catchup(sub2, 'serving');
       // Finish the transaction.
-      storer.store([
-        '08',
-        ['commit', messages.commit({extra: 'stuff'}), {watermark: '08'}],
+      storer.store('08', [
+        'commit',
+        messages.commit({extra: 'stuff'}),
+        {watermark: '08'},
       ]);
 
       storer.status(['status', {ack: true}, {watermark: '0e'}]);
@@ -1420,31 +1373,32 @@ describe('change-streamer/storer', () => {
       // This should be buffered until catchup is complete.
       void sub1.send([
         '09',
-        ['begin', messages.begin(), {commitWatermark: '0a'}],
+        'begin',
+        json(['begin', messages.begin(), {commitWatermark: '0a'}]),
       ]);
       void sub1.send([
         '0a',
-        ['commit', messages.commit({buffer: 'me'}), {watermark: '0a'}],
+        'commit',
+        json(['commit', messages.commit({buffer: 'me'}), {watermark: '0a'}]),
       ]);
       void sub2.send([
         '09',
-        ['begin', messages.begin(), {commitWatermark: '0a'}],
+        'begin',
+        json(['begin', messages.begin(), {commitWatermark: '0a'}]),
       ]);
       void sub2.send([
         '0a',
-        ['commit', messages.commit({buffer: 'me'}), {watermark: '0a'}],
+        'commit',
+        json(['commit', messages.commit({buffer: 'me'}), {watermark: '0a'}]),
       ]);
 
       // Start a transaction before enqueuing catchup.
-      storer.store([
-        '07',
-        ['begin', messages.begin(), {commitWatermark: '08'}],
-      ]);
+      storer.store('07', ['begin', messages.begin(), {commitWatermark: '08'}]);
       // Enqueue catchup before transaction completes.
       storer.catchup(sub1, 'backup');
       storer.catchup(sub2, 'serving');
       // Rollback the transaction.
-      storer.store(['08', ['rollback', messages.rollback()]]);
+      storer.store('08', ['rollback', messages.rollback()]);
 
       storer.status(['status', {ack: true}, {watermark: '0a'}]);
       storer.status(['status', {ack: true}, {watermark: '0c'}]);
@@ -1623,34 +1577,31 @@ describe('change-streamer/storer', () => {
       // This should be buffered until catchup is complete.
       void sub.send([
         '0b',
-        ['begin', messages.begin(), {commitWatermark: '0c'}],
+        'begin',
+        json(['begin', messages.begin(), {commitWatermark: '0c'}]),
       ]);
       void sub.send([
         '0c',
-        ['commit', messages.commit({waa: 'hoo'}), {watermark: '0c'}],
+        'commit',
+        json(['commit', messages.commit({waa: 'hoo'}), {watermark: '0c'}]),
       ]);
 
       // Start a transaction before enqueuing catchup.
-      storer.store([
-        '07',
-        ['begin', messages.begin(), {commitWatermark: '08'}],
-      ]);
+      storer.store('07', ['begin', messages.begin(), {commitWatermark: '08'}]);
       // Enqueue catchup before transaction completes.
       storer.catchup(sub, 'serving');
       // Finish the transaction.
-      storer.store([
-        '08',
-        ['commit', messages.commit({extra: 'fields'}), {watermark: '08'}],
+      storer.store('08', [
+        'commit',
+        messages.commit({extra: 'fields'}),
+        {watermark: '08'},
       ]);
 
       // And finish another the transaction. In reality, these would be
       // sent by the forwarder, but we skip it in the test to confirm that
       // catchup doesn't include the next transaction.
-      storer.store([
-        '09',
-        ['begin', messages.begin(), {commitWatermark: '0a'}],
-      ]);
-      storer.store(['0a', ['commit', messages.commit(), {watermark: '0a'}]]);
+      storer.store('09', ['begin', messages.begin(), {commitWatermark: '0a'}]);
+      storer.store('0a', ['commit', messages.commit(), {watermark: '0a'}]);
 
       storer.status(['status', {ack: true}, {watermark: '0d'}]);
       storer.status(['status', {ack: true}, {watermark: '0e'}]);
@@ -1777,4 +1728,24 @@ describe('change-streamer/storer', () => {
     const purgeLocker = new PurgeLocker(lc, shard, db);
     expect(await purgeLocker.acquire()).toBeNull();
   });
+
+  const msgs = new ReplicationMessages({foo: 'id'});
+
+  test.each([
+    [['begin', {tag: 'begin'}, {commitWatermark: 'foo'}]],
+    [['commit', {tag: 'commit'}, {watermark: 'foo'}]],
+    [['data', msgs.insert('foo', {id: 'bar', val: 'baz'})]],
+    [['data', msgs.delete('foo', {id: 'bar'})]],
+    [['data', msgs.renameTable('foo', 'bar')]],
+  ] satisfies [ChangeStreamData][])(
+    'extract change message substring: %',
+    changeStreamData => {
+      expect(
+        extractChangeSubstring(
+          BigIntJSON.stringify(changeStreamData),
+          changeStreamData[1].tag,
+        ),
+      ).toBe(JSON.stringify(changeStreamData[1]));
+    },
+  );
 });

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -25,15 +25,17 @@ import {
   type SchemaChange,
   type TableMetadata,
 } from '../change-source/protocol/current.ts';
-import {type Commit} from '../change-source/protocol/current/downstream.ts';
+import {
+  type ChangeStreamData,
+  type Commit,
+} from '../change-source/protocol/current/downstream.ts';
 import type {
   DownstreamStatusMessage,
   UpstreamStatusMessage,
 } from '../change-source/protocol/current/status.ts';
 import type {ReplicatorMode} from '../replicator/replicator.ts';
 import type {Service} from '../service.ts';
-import type {WatermarkedChange} from './change-streamer-service.ts';
-import {type ChangeEntry} from './change-streamer.ts';
+import type {ChangeTag, WatermarkedChange} from './change-streamer-service.ts';
 import * as ErrorType from './error-type-enum.ts';
 import {
   AutoResetSignal,
@@ -272,20 +274,16 @@ export class Storer implements Service {
   }
 
   /**
-   * @returns The size of the serialized entry, for memory / I/O estimations.
+   * @returns The JSON stringified stream message to be sent downstream.
    */
-  store(entry: WatermarkedChange) {
-    const [watermark, [_tag, change]] = entry;
-    // Eagerly stringify the JSON object so that the memory usage can be
-    // more accurately measured (i.e. without an extra object traversal and
-    // ad hoc memory counting heuristics).
-    //
-    // This essentially moves the stringify() computation out of the pg client,
-    // which is instead configured to pass `string` objects directly as JSON
-    // strings for JSON-valued columns (see TypeOptions.sendStringAsJson).
-    const json = BigIntJSON.stringify(change);
+  store(watermark: string, data: ChangeStreamData) {
+    // Eagerly stringify the JSON payload to:
+    // - avoid redundant stringification when fanning out to subscribers
+    // - efficiently estimate the amount of memory the payload consumes
+    const json = BigIntJSON.stringify(data);
     this.#approximateQueuedBytes += json.length;
 
+    const change = data[1];
     this.#queue.enqueue([
       'change',
       watermark,
@@ -293,7 +291,7 @@ export class Storer implements Service {
       isDataChange(change) ? null : change, // drop DataChanges to save memory
     ]);
 
-    return json.length;
+    return json;
   }
 
   abort() {
@@ -489,7 +487,9 @@ export class Storer implements Service {
           watermark: tag === 'commit' ? watermark : tx.preCommitWatermark,
           precommit: tag === 'commit' ? tx.preCommitWatermark : null,
           pos: tx.pos,
-          change: json,
+          // For backwards compatibility, only the change message is stored
+          // in the cdc changeLog.
+          change: extractChangeSubstring(json, tag),
         };
 
         const processed = tx.pool.process(sql => [
@@ -602,8 +602,8 @@ export class Storer implements Service {
         let count = 0;
         let lastBatchConsumed: Promise<unknown> | undefined;
 
-        for await (const entries of tx<ChangeEntry[]> /*sql*/ `
-          SELECT watermark, change FROM ${this.#cdc('changeLog')}
+        for await (const entries of tx<ChangeLogEntry[]> /*sql*/ `
+          SELECT watermark, change->'tag' as tag, change::text FROM ${this.#cdc('changeLog')}
            WHERE watermark >= ${sub.watermark}
              AND watermark <= ${lastWatermark}
            ORDER BY watermark, pos`.cursor(2000)) {
@@ -829,17 +829,62 @@ export class Storer implements Service {
   }
 }
 
-function toDownstream(entry: ChangeEntry): WatermarkedChange {
-  const {watermark, change} = entry;
-  switch (change.tag) {
+/**
+ * Extracts the stringified change message from the stringified
+ * stream message (e.g. the second tuple element). This optimization
+ * facilitates stringifying (and sharing the result of) the stream
+ * message exactly once, but storing only the change message substring
+ * in the changeLog for backwards compatibility.
+ */
+export function extractChangeSubstring(
+  streamMessageJSON: string,
+  tag: Change['tag'] | undefined,
+) {
+  switch (tag) {
     case 'begin':
-      return [watermark, ['begin', change, {commitWatermark: watermark}]];
     case 'commit':
-      return [watermark, ['commit', change, {watermark}]];
-    case 'rollback':
-      return [watermark, ['rollback', change]];
+      // e.g.
+      // ["begin",<message-json>,{"commitWatermark":"92fj2d0s"}]
+      // ["commit",<message-json>,{"watermark":"92fj2d0s"}]
+      return streamMessageJSON.substring(
+        streamMessageJSON.indexOf(',') + 1,
+        streamMessageJSON.lastIndexOf(','),
+      );
     default:
-      return [watermark, ['data', change]];
+      // ["data",<message-json>]
+      return streamMessageJSON.substring(
+        streamMessageJSON.indexOf(',') + 1,
+        streamMessageJSON.lastIndexOf(']'),
+      );
+  }
+}
+
+type ChangeLogEntry = {
+  watermark: string;
+  tag: string;
+  change: string;
+};
+
+function toDownstream(entry: ChangeLogEntry): WatermarkedChange {
+  const {watermark, change} = entry;
+  const tag = entry.tag as ChangeTag;
+  switch (tag) {
+    case 'begin':
+      return [
+        watermark,
+        tag,
+        `["begin",${change},{"commitWatermark":"${watermark}"}]`,
+      ];
+    case 'commit':
+      return [
+        watermark,
+        tag,
+        `["commit",${change},{"watermark":"${watermark}"}]`,
+      ];
+    case 'rollback':
+      return [watermark, tag, `["rollback",${change}]`];
+    default:
+      return [watermark, tag, `["data",${change}]`];
   }
 }
 

--- a/packages/zero-cache/src/services/change-streamer/subscriber.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/subscriber.test.ts
@@ -2,6 +2,8 @@ import {describe, expect, test} from 'vitest';
 import {ReplicationMessages} from '../replicator/test-utils.ts';
 import {createSubscriber} from './test-utils.ts';
 
+const json = JSON.stringify;
+
 describe('change-streamer/subscriber', () => {
   const messages = new ReplicationMessages({issues: 'id'});
 
@@ -9,8 +11,16 @@ describe('change-streamer/subscriber', () => {
     const [sub, stream] = createSubscriber('00');
 
     // Send some messages while it is catching up.
-    void sub.send(['11', ['begin', messages.begin(), {commitWatermark: '12'}]]);
-    void sub.send(['12', ['commit', messages.commit(), {watermark: '12'}]]);
+    void sub.send([
+      '11',
+      'begin',
+      json(['begin', messages.begin(), {commitWatermark: '12'}]),
+    ]);
+    void sub.send([
+      '12',
+      'commit',
+      json(['commit', messages.commit(), {watermark: '12'}]),
+    ]);
 
     // Status messages before initialization should be ignored.
     sub.sendStatus({tag: 'status', lagReport: {nextSendTimeMs: 123}});
@@ -18,20 +28,33 @@ describe('change-streamer/subscriber', () => {
     // Send catchup messages.
     void sub.catchup([
       '01',
-      ['begin', messages.begin(), {commitWatermark: '02'}],
+      'begin',
+      json(['begin', messages.begin(), {commitWatermark: '02'}]),
     ]);
 
     // Status messages after initialization are sent. These can happen
     // within a transaction.
     sub.sendStatus({tag: 'status', lagReport: {nextSendTimeMs: 234}});
 
-    void sub.catchup(['02', ['commit', messages.commit(), {watermark: '02'}]]);
+    void sub.catchup([
+      '02',
+      'commit',
+      json(['commit', messages.commit(), {watermark: '02'}]),
+    ]);
 
     sub.setCaughtUp();
 
     // Send some messages after catchup.
-    void sub.send(['21', ['begin', messages.begin(), {commitWatermark: '22'}]]);
-    void sub.send(['22', ['commit', messages.commit(), {watermark: '22'}]]);
+    void sub.send([
+      '21',
+      'begin',
+      json(['begin', messages.begin(), {commitWatermark: '22'}]),
+    ]);
+    void sub.send([
+      '22',
+      'commit',
+      json(['commit', messages.commit(), {watermark: '22'}]),
+    ]);
 
     sub.sendStatus({tag: 'status', lagReport: {nextSendTimeMs: 456}});
 
@@ -129,31 +152,51 @@ describe('change-streamer/subscriber', () => {
     // does just to ensure that catchup messages are subject to the filter.
     void sub.catchup([
       '01',
-      ['begin', messages.begin(), {commitWatermark: '02'}],
+      'begin',
+      json(['begin', messages.begin(), {commitWatermark: '02'}]),
     ]);
-    void sub.catchup(['02', ['commit', messages.commit(), {watermark: '02'}]]);
+    void sub.catchup([
+      '02',
+      'commit',
+      json(['commit', messages.commit(), {watermark: '02'}]),
+    ]);
     sub.setCaughtUp();
 
     // Still lower than the watermark ...
     void sub.send([
       '121',
-      ['begin', messages.begin(), {commitWatermark: '123'}],
+      'begin',
+      json(['begin', messages.begin(), {commitWatermark: '123'}]),
     ]);
-    void sub.send(['123', ['commit', messages.commit(), {watermark: '123'}]]);
+    void sub.send([
+      '123',
+      'commit',
+      json(['commit', messages.commit(), {watermark: '123'}]),
+    ]);
 
     // These should be sent.
     void sub.send([
       '124',
-      ['begin', messages.begin(), {commitWatermark: '125'}],
+      'begin',
+      json(['begin', messages.begin(), {commitWatermark: '125'}]),
     ]);
-    void sub.send(['125', ['commit', messages.commit(), {watermark: '125'}]]);
+    void sub.send([
+      '125',
+      'commit',
+      json(['commit', messages.commit(), {watermark: '125'}]),
+    ]);
 
     // Replays should be ignored.
     void sub.send([
       '124',
-      ['begin', messages.begin(), {commitWatermark: '125'}],
+      'begin',
+      json(['begin', messages.begin(), {commitWatermark: '125'}]),
     ]);
-    void sub.send(['125', ['commit', messages.commit(), {watermark: '125'}]]);
+    void sub.send([
+      '125',
+      'commit',
+      json(['commit', messages.commit(), {watermark: '125'}]),
+    ]);
 
     sub.close();
     expect(stream).toMatchInlineSnapshot(`
@@ -190,23 +233,48 @@ describe('change-streamer/subscriber', () => {
     const [sub, _, receiver] = createSubscriber('00');
 
     // Send some messages while it is catching up.
-    void sub.send(['11', ['begin', messages.begin(), {commitWatermark: '12'}]]);
-    void sub.send(['12', ['commit', messages.commit(), {watermark: '12'}]]);
+    void sub.send([
+      '11',
+      'begin',
+      json(['begin', messages.begin(), {commitWatermark: '12'}]),
+    ]);
+    void sub.send([
+      '12',
+      'commit',
+      json(['commit', messages.commit(), {watermark: '12'}]),
+    ]);
 
     // Send catchup messages.
     void sub.catchup([
       '01',
-      ['begin', messages.begin(), {commitWatermark: '02'}],
+      'begin',
+      json(['begin', messages.begin(), {commitWatermark: '02'}]),
     ]);
-    void sub.catchup(['02', ['commit', messages.commit(), {watermark: '02'}]]);
+    void sub.catchup([
+      '02',
+      'commit',
+      json(['commit', messages.commit(), {watermark: '02'}]),
+    ]);
 
     sub.setCaughtUp();
 
     // Send some messages after catchup.
-    void sub.send(['21', ['begin', messages.begin(), {commitWatermark: '22'}]]);
-    void sub.send(['22', ['commit', messages.commit(), {watermark: '22'}]]);
+    void sub.send([
+      '21',
+      'begin',
+      json(['begin', messages.begin(), {commitWatermark: '22'}]),
+    ]);
+    void sub.send([
+      '22',
+      'commit',
+      json(['commit', messages.commit(), {watermark: '22'}]),
+    ]);
 
-    void sub.send(['31', ['begin', messages.begin(), {commitWatermark: '31'}]]);
+    void sub.send([
+      '31',
+      'begin',
+      json(['begin', messages.begin(), {commitWatermark: '31'}]),
+    ]);
 
     expect(sub.acked).toBe('00');
 
@@ -216,7 +284,8 @@ describe('change-streamer/subscriber', () => {
     expect(sub.numPending).toBe(pending);
 
     let txNum = 0;
-    for await (const msg of receiver) {
+    for await (const json of receiver) {
+      const msg = JSON.parse(json);
       expect(sub.numProcessed).toBe(processed++);
       expect(sub.numPending).toBe(pending--);
 

--- a/packages/zero-cache/src/services/change-streamer/subscriber.ts
+++ b/packages/zero-cache/src/services/change-streamer/subscriber.ts
@@ -1,10 +1,10 @@
 import {assert} from '../../../../shared/src/asserts.ts';
+import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
 import type {Enum} from '../../../../shared/src/enum.ts';
 import {must} from '../../../../shared/src/must.ts';
 import {max} from '../../types/lexi-version.ts';
 import type {Subscription} from '../../types/subscription.ts';
-import type {ChangeStreamData} from '../change-source/protocol/current.ts';
-import type {WatermarkedChange} from './change-streamer-service.ts';
+import type {ChangeTag, WatermarkedChange} from './change-streamer-service.ts';
 import {type Downstream, type Status} from './change-streamer.ts';
 import * as ErrorType from './error-type-enum.ts';
 
@@ -20,7 +20,7 @@ type ErrorType = Enum<typeof ErrorType>;
 export class Subscriber {
   readonly #protocolVersion: number;
   readonly id: string;
-  readonly #downstream: Subscription<Downstream>;
+  readonly #downstream: Subscription<string>;
   readonly #latestStatus: () => Status;
   #watermark: string;
   #acked: string;
@@ -30,7 +30,7 @@ export class Subscriber {
     protocolVersion: number,
     id: string,
     watermark: string,
-    downstream: Subscription<Downstream>,
+    downstream: Subscription<string>,
     latestStatus: () => Status,
   ) {
     this.#protocolVersion = protocolVersion;
@@ -107,25 +107,29 @@ export class Subscriber {
   }
 
   async #sendChange(change: WatermarkedChange) {
-    const [watermark, downstream] = change;
+    const [watermark, tag, json] = change;
     if (watermark <= this.watermark) {
       return;
     }
-    if (!this.supportsMessage(downstream[1])) {
+    if (!this.supportsMessage(tag)) {
       return;
     }
-    if (downstream[0] === 'commit') {
+    if (tag === 'commit') {
       this.#watermark = watermark;
     }
-    const result = await this.#sendDownstream(downstream);
-    if (downstream[0] === 'commit' && result === 'consumed') {
+    const result = await this.#sendStringifiedDownstream(json);
+    if (tag === 'commit' && result === 'consumed') {
       this.#acked = max(this.#acked, watermark);
     }
   }
 
-  async #sendDownstream(downstream: Downstream) {
+  #sendDownstream(downstream: Downstream) {
+    return this.#sendStringifiedDownstream(BigIntJSON.stringify(downstream));
+  }
+
+  async #sendStringifiedDownstream(json: string) {
     this.#pending++;
-    const {result} = this.#downstream.push(downstream);
+    const {result} = this.#downstream.push(json);
     try {
       return await result;
     } finally {
@@ -188,8 +192,8 @@ export class Subscriber {
     return {processRate, pending};
   }
 
-  supportsMessage(change: ChangeStreamData[1]) {
-    switch (change.tag) {
+  supportsMessage(tag: ChangeTag) {
+    switch (tag) {
       case 'update-table-metadata':
         // update-table-row-key is only understood by subscribers >= protocol v5
         return this.#protocolVersion >= 5;
@@ -203,9 +207,10 @@ export class Subscriber {
 
   close(error?: ErrorType, message?: string) {
     if (error) {
-      const {result} = this.#downstream.push(['error', {type: error, message}]);
       // Wait for the ACK of the error message before closing the connection.
-      void result.then(() => this.#downstream.cancel());
+      void this.#sendDownstream(['error', {type: error, message}]).finally(() =>
+        this.#downstream.cancel(),
+      );
     } else {
       this.#downstream.cancel();
     }

--- a/packages/zero-cache/src/services/change-streamer/test-utils.ts
+++ b/packages/zero-cache/src/services/change-streamer/test-utils.ts
@@ -7,11 +7,11 @@ let nextID = 1;
 export function createSubscriber(
   watermark = '00',
   caughtUp = false,
-): [Subscriber, Downstream[], Subscription<Downstream>] {
+): [Subscriber, Downstream[], Subscription<string>] {
   const id = '' + nextID++;
   const received: Downstream[] = [];
-  const sub = Subscription.create<Downstream>({
-    cleanup: unconsumed => received.push(...unconsumed),
+  const sub = Subscription.create<string>({
+    cleanup: unconsumed => received.push(...unconsumed.map(m => JSON.parse(m))),
   });
   const subscriber = new Subscriber(
     PROTOCOL_VERSION,

--- a/packages/zero-cache/src/types/streams.test.ts
+++ b/packages/zero-cache/src/types/streams.test.ts
@@ -18,6 +18,7 @@ import {
   stream,
   streamIn,
   streamOut,
+  streamOutStringified,
   type Sink,
   type Source,
 } from './streams.ts';
@@ -214,6 +215,7 @@ describe('streams with internal acks', () => {
 
   let server: FastifyInstance;
   let producer: Subscription<Message>;
+  let stringifiedProducer: Subscription<string>;
   let consumed: Queue<Message>;
   let cleanedUp: Promise<Message[]>;
   let cleanup: (m: Message[]) => void;
@@ -233,10 +235,14 @@ describe('streams with internal acks', () => {
       consumed: m => consumed.enqueue(m),
       cleanup: resolve,
     });
+    stringifiedProducer = Subscription.create();
 
     server = Fastify();
     await server.register(websocket);
-    server.get('/', {websocket: true}, ws => streamOut(lc, producer, ws));
+    server.get('/', {websocket: true}, ws => {
+      void streamOut(lc, producer, ws);
+      void streamOutStringified(lc, stringifiedProducer, ws);
+    });
 
     // Run the server for real instead of using `injectWS()`, as that has a
     // different behavior for ws.close().
@@ -458,6 +464,15 @@ describe('streams with internal acks', () => {
 
   test('passthrough', async () => {
     producer.push({from: 1, to: 2, str: 'foo', extra: 'bar'} as Message);
+
+    const {consumer} = await startReceiver();
+    expect(await drain(1, consumer)).toEqual([
+      {from: 1, to: 2, str: 'foo', extra: 'bar'},
+    ]);
+  });
+
+  test('stringified source', async () => {
+    stringifiedProducer.push('{"from":1,"to":2,"str":"foo","extra":"bar"}');
 
     const {consumer} = await startReceiver();
     expect(await drain(1, consumer)).toEqual([

--- a/packages/zero-cache/src/types/streams.ts
+++ b/packages/zero-cache/src/types/streams.ts
@@ -224,10 +224,30 @@ type Streamed<T> = {
   id: number;
 };
 
-export async function streamOut<T extends JSONValue>(
+export function streamOut<T extends JSONValue>(
   lc: LogContext,
   source: Source<T>,
   sink: WebSocket,
+): Promise<void> {
+  return streamOutInternal(lc, source, sink, BigIntJSON.stringify);
+}
+
+/**
+ * Streams out a `Source` for which messages are already stringified JSON.
+ */
+export function streamOutStringified(
+  lc: LogContext,
+  source: Source<string>,
+  sink: WebSocket,
+): Promise<void> {
+  return streamOutInternal(lc, source, sink, json => json);
+}
+
+async function streamOutInternal<T extends JSONValue>(
+  lc: LogContext,
+  source: Source<T>,
+  sink: WebSocket,
+  stringify: (payload: T) => string,
 ): Promise<void> {
   sendPingsForLiveness(lc, sink, PING_INTERVAL_MS);
 
@@ -253,7 +273,7 @@ export async function streamOut<T extends JSONValue>(
       lc.debug?.(`started pipelined outbound stream`);
       for await (const {value: msg, consumed} of pipeline) {
         const id = ++nextID;
-        const data = BigIntJSON.stringify({msg, id} satisfies Streamed<T>);
+        const data = `{"id":${id},"msg":${stringify(msg)}}`;
         // Enable for debugging. Otherwise too verbose.
         // lc.debug?.(`pipelining`, data);
         sink.send(data);
@@ -271,7 +291,7 @@ export async function streamOut<T extends JSONValue>(
       lc.debug?.(`started synchronous outbound stream`);
       for await (const msg of source) {
         const id = ++nextID;
-        const data = BigIntJSON.stringify({msg, id} satisfies Streamed<T>);
+        const data = `{"id":${id},"msg":${stringify(msg)}}`;
         // Enable for debugging. Otherwise too verbose.
         // lc.debug?.(`sending`, data);
         sink.send(data);


### PR DESCRIPTION
Reduce the amount of JSON stringification performed in the replication-manager by:
* stringifying each change payload once before fanning out to subscribers (i.e. view-syncers and backup replicator)
* avoiding parsing and re-stringifying JSON payloads when catching up subcribers from the change DB

A local (MacBook) load test was run with replication-managers connected to 20 view-syncers. With the caveat that the MacBook has to time share its 16 cores across 42+ busy processes, the data shows a meaningful improvement in performance.

<img width="1445" height="894" alt="replication-manager CPU (with 20 connected view-syncers)" src="https://github.com/user-attachments/assets/4ff1ba70-92f3-4a75-a2da-b8cc24f97a6c" />
