### PR TITLE
chore(zero-cache): improve error handling for rep slot creation timeout

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/backfill-stream.ts
+++ b/packages/zero-cache/src/services/change-source/pg/backfill-stream.ts
@@ -319,7 +319,7 @@ async function createSnapshotTransaction(
       `SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots
          WHERE slot_name = '${tempSlot}'`,
     );
-    lc.error?.(`Failed to create backfill snapshot`, e);
+    lc.warn?.(`Failed to create backfill snapshot`, e);
     throw e;
   } finally {
     await replicationSession.end();

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
@@ -2898,7 +2898,7 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
 
   test(
     'createReplicationSlot times out behind an older idle transaction',
-    {timeout: 15_000},
+    {timeout: 45_000},
     async () => {
       const lc = createSilentLogContext();
       const upstreamURI = getConnectionURI(upstream);

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.test.ts
@@ -240,8 +240,8 @@ describe('createReplicationSlot', () => {
         caught = e;
       });
 
-      // Advance past the 5s client-side timeout.
-      await vi.advanceTimersByTimeAsync(6_000);
+      // Advance past the 30s client-side timeout.
+      await vi.advanceTimersByTimeAsync(31_000);
       await result;
 
       expect(caught).toBeInstanceOf(Error);

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
@@ -529,8 +529,14 @@ type ReplicationSlot = {
   output_plugin: string;
 };
 
-// Successful CREATE_REPLICATION_SLOT calls have always completed within 1s in
-// observed production runs; use 30s as a hard stop for pathological hangs.
+// When creating a replication slot, Postgres waits for open transactions
+// to complete before reserving a consistent_point (LSN) in the WAL and creating
+// a matching transaction snapshot. As such, it can technically take an arbitrary
+// amount of time (e.g. DDL operations, table-wide operations, etc.).
+//
+// However, to detect pathological situations, bound the amount of time that
+// the server waits for replication slot creation, so that a continual failure to
+// create a replication slot is surfaced by errors / alerts.
 const CREATE_REPLICATION_SLOT_TIMEOUT_MS = 30_000;
 
 // The lock_timeout is set 1s before the client-side orTimeout so that

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
@@ -530,8 +530,8 @@ type ReplicationSlot = {
 };
 
 // Successful CREATE_REPLICATION_SLOT calls have always completed within 1s in
-// observed production runs; use 5s as a hard stop for pathological hangs.
-const CREATE_REPLICATION_SLOT_TIMEOUT_MS = 5_000;
+// observed production runs; use 30s as a hard stop for pathological hangs.
+const CREATE_REPLICATION_SLOT_TIMEOUT_MS = 30_000;
 
 // The lock_timeout is set 1s before the client-side orTimeout so that
 // Postgres reliably aborts first and tears down the walsender cleanly.


### PR DESCRIPTION
Increase timeout to 30 seconds, slot creation does often take sometime as it waits for all open transactions to complete.

Also only log errors for timeouts during slot creation for backfill once the maximum retry backoff has been reached: https://github.com/rocicorp/mono/blob/604f104b41dad4b91533d0c1af30e82822f6e23e/packages/zero-cache/src/services/change-source/common/backfill-manager.ts#L191

Timeout errors during initial sync immediately log error and crash the server.