### PR TITLE
fix(zero-client): rotate zero instance w/o page reload

### DIFF
--- a/packages/zero-client/src/client/options.ts
+++ b/packages/zero-client/src/client/options.ts
@@ -235,16 +235,24 @@ export type ZeroOptions<
 
   /**
    * `onClientStateNotFound` is called when this client is no longer able
-   * to sync with the zero-cache due to missing synchronization state.  This
+   * to sync with zero-cache due to missing synchronization state. This
    * can be because:
    * - the local persistent synchronization state has been garbage collected.
    *   This can happen if the client has no pending mutations and has not been
    *   used for a while (e.g. the client's tab has been hidden for a long time).
-   * - the zero-cache fails to find the server side synchronization state for
+   * - zero-cache fails to find the server side synchronization state for
    *   this client.
+   * - zero-cache rejects this client's persisted synchronization state,
+   *   requiring the local Replicache database to be reset.
    *
-   * The default behavior is to reload the page (using `location.reload()`).
-   * Provide your own function to prevent the page from reloading automatically.
+   * The current `Zero` instance should be treated as dead and replaced, not
+   * reconnected.
+   *
+   * The default behavior for the Zero client is to reload the page
+   * (using `location.reload()`). The React and SolidJS providers will replace
+   * the client in-place, without a full page reload.
+   *
+   * Provide your own function to prevent this functionality.
    */
   onClientStateNotFound?: (() => void) | undefined;
 

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -15,6 +15,7 @@ import {
   setDeletedClients,
   type DeletedClients,
 } from '../../../replicache/src/deleted-clients.ts';
+import {hasMemStore} from '../../../replicache/src/kv/mem-store.ts';
 import {makeClientV6} from '../../../replicache/src/persist/clients-test-helpers.ts';
 import {
   getClients,
@@ -2925,70 +2926,110 @@ test('SchemaVersionNotSupported custom onUpdateNeeded handler', async () => {
   });
 });
 
-test('ClientNotFound default handler', async () => {
-  const storage: Record<string, string> = {};
-  vi.spyOn(window, 'sessionStorage', 'get').mockImplementation(() =>
-    storageMock(storage),
-  );
-  const {promise, resolve} = resolver();
-  const fake = vi.fn(resolve);
-  const z = zeroForTest(undefined, false);
-  z.reload = fake;
-
-  await z.triggerError({
+const clientStateNotFoundErrorCases = [
+  {
     kind: ErrorKind.ClientNotFound,
     message: 'server test message',
-    origin: ErrorOrigin.ZeroCache,
-  });
-  await vi.advanceTimersToNextTimerAsync();
-  await promise;
-  expect(z.connectionStatus).toBe(ConnectionStatus.Error);
-
-  expect(fake).toBeCalledTimes(1);
-
-  expect(storage[RELOAD_REASON_STORAGE_KEY]).toBe(
-    `["ClientNotFound","Server could not find state needed to synchronize this client. server test message"]`,
-  );
-});
-
-test('ClientNotFound custom onClientStateNotFound handler', async () => {
-  const {promise, resolve} = resolver();
-  const fake = vi.fn(() => {
-    resolve();
-  });
-  const z = zeroForTest({onClientStateNotFound: fake});
-  await z.triggerError({
-    kind: ErrorKind.ClientNotFound,
-    message: 'server test message',
-    origin: ErrorOrigin.ZeroCache,
-  });
-  await promise;
-  expect(z.connectionStatus).toBe(ConnectionStatus.Error);
-
-  expect(fake).toBeCalledTimes(1);
-});
-
-test('server ahead', async () => {
-  const {promise, resolve} = resolver();
-  const storage: Record<string, string> = {};
-  vi.spyOn(window, 'sessionStorage', 'get').mockImplementation(() =>
-    storageMock(storage),
-  );
-  const z = zeroForTest();
-  z.reload = resolve;
-
-  await z.triggerError({
+    expectedReloadReason:
+      '["ClientNotFound","Server could not find state needed to synchronize this client. server test message"]',
+    dropsDatabase: false,
+  },
+  {
     kind: ErrorKind.InvalidConnectionRequestBaseCookie,
     message: 'unexpected BaseCookie',
-    origin: ErrorOrigin.ZeroCache,
-  });
+    expectedReloadReason:
+      '["InvalidConnectionRequestBaseCookie","Server reported that client is ahead of server. This probably happened because the server is in development mode and restarted. Currently when this happens, the dev server loses its state and on reconnect sees the client as ahead. If you see this in other cases, it may be a bug in Zero."]',
+    dropsDatabase: true,
+  },
+  {
+    kind: ErrorKind.InvalidConnectionRequestLastMutationID,
+    message: 'unexpected lastMutationID',
+    expectedReloadReason:
+      '["InvalidConnectionRequestLastMutationID","Server reported that client is ahead of server. This probably happened because the server is in development mode and restarted. Currently when this happens, the dev server loses its state and on reconnect sees the client as ahead. If you see this in other cases, it may be a bug in Zero."]',
+    dropsDatabase: true,
+  },
+] as const;
 
-  await vi.waitUntil(() => storage[RELOAD_REASON_STORAGE_KEY]);
+test.each(clientStateNotFoundErrorCases)(
+  '$kind default onClientStateNotFound handler',
+  async ({kind, message, expectedReloadReason, dropsDatabase}) => {
+    const storage: Record<string, string> = {};
+    vi.spyOn(window, 'sessionStorage', 'get').mockImplementation(() =>
+      storageMock(storage),
+    );
+    const {promise, resolve} = resolver();
+    const reload = vi.fn(resolve);
+    const z = zeroForTest();
+    z.reload = reload;
 
+    expect(hasMemStore(z.idbName)).toBe(true);
+
+    await z.triggerError({
+      kind,
+      message,
+      origin: ErrorOrigin.ZeroCache,
+    });
+
+    await vi.waitUntil(() => storage[RELOAD_REASON_STORAGE_KEY] !== undefined);
+    await promise;
+
+    expect(z.connectionStatus).toBe(ConnectionStatus.Error);
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(storage[RELOAD_REASON_STORAGE_KEY]).toBe(expectedReloadReason);
+    expect(hasMemStore(z.idbName)).toBe(!dropsDatabase);
+  },
+);
+
+test.each(clientStateNotFoundErrorCases)(
+  '$kind custom onClientStateNotFound handler',
+  async ({kind, message, dropsDatabase}) => {
+    const {promise, resolve} = resolver();
+    let z: TestZero<Schema>;
+    const fake = vi.fn(() => {
+      expect(hasMemStore(z.idbName)).toBe(!dropsDatabase);
+      resolve();
+    });
+    z = zeroForTest({onClientStateNotFound: fake});
+    const reload = vi.fn();
+    z.reload = reload;
+
+    expect(hasMemStore(z.idbName)).toBe(true);
+
+    await z.triggerError({
+      kind,
+      message,
+      origin: ErrorOrigin.ZeroCache,
+    });
+
+    await promise;
+
+    expect(z.connectionStatus).toBe(ConnectionStatus.Error);
+    expect(fake).toHaveBeenCalledTimes(1);
+    expect(fake).toHaveBeenCalledWith();
+    expect(reload).not.toHaveBeenCalled();
+    expect(hasMemStore(z.idbName)).toBe(!dropsDatabase);
+  },
+);
+
+test('local onClientStateNotFound default handler', async () => {
+  const storage: Record<string, string> = {};
+  vi.spyOn(window, 'sessionStorage', 'get').mockImplementation(() =>
+    storageMock(storage),
+  );
+  const {promise, resolve} = resolver();
+  const reload = vi.fn(resolve);
+  const z = zeroForTest(undefined);
+  z.reload = reload;
+
+  getInternalReplicacheImplForTesting(z).onClientStateNotFound?.();
+
+  await vi.waitUntil(() => storage[RELOAD_REASON_STORAGE_KEY] !== undefined);
+  await vi.advanceTimersToNextTimerAsync();
   await promise;
 
-  expect(storage[RELOAD_REASON_STORAGE_KEY]).toEqual(
-    `["InvalidConnectionRequestBaseCookie","Server reported that client is ahead of server. This probably happened because the server is in development mode and restarted. Currently when this happens, the dev server loses its state and on reconnect sees the client as ahead. If you see this in other cases, it may be a bug in Zero."]`,
+  expect(reload).toHaveBeenCalledTimes(1);
+  expect(storage[RELOAD_REASON_STORAGE_KEY]).toBe(
+    '["ClientNotFound","The local persistent state needed to synchronize this client has been garbage collected."]',
   );
 });
 

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -375,7 +375,7 @@ export class Zero<
   readonly #onlineManager: OnlineManager;
 
   readonly #onUpdateNeeded: (reason: UpdateNeededReason) => void;
-  readonly #onClientStateNotFound: (reason?: string) => void;
+  readonly #onClientStateNotFound: (kind: ErrorKind, message: string) => void;
   // Last cookie used to initiate a connection
   #connectCookie: NullableVersion = null;
   // Total number of sockets successfully connected by this client
@@ -693,18 +693,19 @@ export class Zero<
       onUpdateNeededCallback(convertOnUpdateNeededReason(reason));
     };
 
-    const onClientStateNotFoundCallback =
-      onClientStateNotFound ??
-      ((reason?: string) => {
-        reloadWithReason(
-          this.#lc,
-          this.#reload,
-          ErrorKind.ClientNotFound,
-          reason ?? ON_CLIENT_STATE_NOT_FOUND_REASON_CLIENT,
-        );
-      });
-    this.#onClientStateNotFound = onClientStateNotFoundCallback;
-    this.#rep.onClientStateNotFound = onClientStateNotFoundCallback;
+    this.#onClientStateNotFound = (kind: ErrorKind, message: string) => {
+      if (onClientStateNotFound) {
+        onClientStateNotFound();
+      } else {
+        reloadWithReason(this.#lc, this.#reload, kind, message);
+      }
+    };
+    this.#rep.onClientStateNotFound = () => {
+      this.#onClientStateNotFound(
+        ErrorKind.ClientNotFound,
+        ON_CLIENT_STATE_NOT_FOUND_REASON_CLIENT,
+      );
+    };
 
     const mutatorProxy = new MutatorProxy(
       this.#lc,
@@ -1441,7 +1442,10 @@ export class Zero<
       });
     } else if (kind === ErrorKind.ClientNotFound) {
       await this.#rep.disableClientGroup();
-      this.#onClientStateNotFound?.(onClientStateNotFoundServerReason(message));
+      this.#onClientStateNotFound(
+        kind,
+        onClientStateNotFoundServerReason(message),
+      );
     } else if (
       kind === ErrorKind.InvalidConnectionRequestLastMutationID ||
       kind === ErrorKind.InvalidConnectionRequestBaseCookie
@@ -1449,7 +1453,8 @@ export class Zero<
       await dropReplicacheDatabase(this.#rep.idbName, {
         kvStore: this.#kvStore,
       });
-      reloadWithReason(lc, this.#reload, kind, serverAheadReloadReason);
+
+      this.#onClientStateNotFound(kind, serverAheadReloadReason);
     }
   }
 

--- a/packages/zero-react/src/zero-provider.test.tsx
+++ b/packages/zero-react/src/zero-provider.test.tsx
@@ -16,6 +16,8 @@ vi.mock('./zero.ts', async importOriginal => {
 
 import {Zero as ZeroConstructor} from './zero.ts';
 
+const fakeSchema = {} as Schema;
+
 function createMockZero(clientID = 'test-client'): Zero<Schema> {
   const closeMock = vi.fn().mockResolvedValue(undefined);
   const connectMock = vi.fn().mockResolvedValue(undefined);
@@ -128,7 +130,7 @@ describe('ZeroProvider', () => {
       });
     });
 
-    test('calls init callback with zero instance', () => {
+    test('does not call init callback when zero is provided externally', () => {
       const mockZero = createMockZero();
       const initMock = vi.fn();
 
@@ -213,7 +215,7 @@ describe('ZeroProvider', () => {
       const options: ZeroOptions<Schema> = {
         cacheURL: 'https://example.com',
         userID: 'test-user',
-        schema: {} as Schema,
+        schema: fakeSchema,
       };
 
       const root = renderWithRoot(
@@ -251,7 +253,7 @@ describe('ZeroProvider', () => {
       } = {
         cacheURL: 'https://example.com',
         userID: 'test-user',
-        schema: {} as Schema,
+        schema: fakeSchema,
         init: initMock,
       };
 
@@ -278,7 +280,7 @@ describe('ZeroProvider', () => {
 
       const options: ZeroOptions<Schema> = {
         cacheURL: 'https://example.com',
-        schema: {} as Schema,
+        schema: fakeSchema,
         userID: 'test-user',
       };
 
@@ -308,7 +310,7 @@ describe('ZeroProvider', () => {
 
       const options: ZeroOptions<Schema> = {
         cacheURL: 'https://example.com',
-        schema: {} as Schema,
+        schema: fakeSchema,
         auth,
         userID: 'test-user',
       };
@@ -337,7 +339,7 @@ describe('ZeroProvider', () => {
         return mockZero;
       });
 
-      const schema = {} as Schema;
+      const schema = fakeSchema;
 
       const root = renderWithRoot(
         <ZeroProvider
@@ -409,7 +411,7 @@ describe('ZeroProvider', () => {
         return mockZero;
       });
 
-      const schema = {} as Schema;
+      const schema = fakeSchema;
 
       const root = renderWithRoot(
         <ZeroProvider
@@ -454,7 +456,7 @@ describe('ZeroProvider', () => {
         return mockZero2;
       });
 
-      const schema = {} as Schema;
+      const schema = fakeSchema;
       let capturedZero: Zero<Schema> | undefined;
 
       function TestComponent() {
@@ -514,7 +516,7 @@ describe('ZeroProvider', () => {
         return mockZero2;
       });
 
-      const schema = {} as Schema;
+      const schema = fakeSchema;
       let capturedZero: Zero<Schema> | undefined;
 
       function TestComponent() {
@@ -636,7 +638,7 @@ describe('ZeroProvider', () => {
       const root = renderWithRoot(
         <ZeroProvider
           cacheURL="https://example.com"
-          schema={{} as Schema}
+          schema={fakeSchema}
           userID="test-user"
         >
           <ChildComponent />
@@ -680,7 +682,7 @@ describe('ZeroProvider', () => {
       const root = renderWithRoot(
         <ZeroProvider
           cacheURL="https://example1.com"
-          schema={{} as Schema}
+          schema={fakeSchema}
           userID="test-user"
         >
           <TestComponent label="1" />
@@ -695,7 +697,7 @@ describe('ZeroProvider', () => {
         root.render(
           <ZeroProvider
             cacheURL="https://example2.com"
-            schema={{} as Schema}
+            schema={fakeSchema}
             userID="test-user"
           >
             <TestComponent label="2" />
@@ -708,6 +710,169 @@ describe('ZeroProvider', () => {
       expect(mockZero1.close).toHaveBeenCalledTimes(1);
       expect(capturedZero2).toBe(mockZero2);
       expect(capturedZero2).not.toBe(capturedZero1);
+
+      act(() => {
+        root.unmount();
+      });
+    });
+
+    test('does not recreate zero when custom onClientStateNotFound fires', () => {
+      const mockZero1 = createMockZero('client-1');
+      const mockZero2 = createMockZero('client-2');
+      const ZeroMock = vi.mocked(ZeroConstructor);
+      ZeroMock.mockImplementationOnce(function () {
+        return mockZero1;
+      }).mockImplementationOnce(function () {
+        return mockZero2;
+      });
+
+      const onClientStateNotFound = vi.fn();
+      let capturedZero: Zero<Schema> | undefined;
+
+      function TestComponent() {
+        capturedZero = useZero<Schema>();
+        return <div>test</div>;
+      }
+
+      const root = renderWithRoot(
+        <ZeroProvider
+          cacheURL="https://example.com"
+          schema={fakeSchema}
+          onClientStateNotFound={onClientStateNotFound}
+        >
+          <TestComponent />
+        </ZeroProvider>,
+      );
+
+      const zeroArgs = ZeroMock.mock.calls[0]?.[0] as ZeroOptions<Schema>;
+      expect(capturedZero).toBe(mockZero1);
+
+      act(() => {
+        zeroArgs.onClientStateNotFound?.();
+      });
+
+      expect(onClientStateNotFound).toHaveBeenCalledTimes(1);
+      expect(ZeroMock).toHaveBeenCalledTimes(1);
+      expect(mockZero1.close).not.toHaveBeenCalled();
+      expect(capturedZero).toBe(mockZero1);
+
+      act(() => {
+        root.unmount();
+      });
+    });
+
+    test('re-runs init when zero is recreated after client state not found', async () => {
+      const mockZero1 = createMockZero('client-1');
+      const mockZero2 = createMockZero('client-2');
+      const ZeroMock = vi.mocked(ZeroConstructor);
+      ZeroMock.mockImplementationOnce(function () {
+        return mockZero1;
+      }).mockImplementationOnce(function () {
+        return mockZero2;
+      });
+
+      const init = vi.fn();
+
+      const root = renderWithRoot(
+        <ZeroProvider
+          cacheURL="https://example.com"
+          schema={fakeSchema}
+          init={init}
+        >
+          <div>test</div>
+        </ZeroProvider>,
+      );
+
+      const zeroArgs = ZeroMock.mock.calls[0]?.[0] as ZeroOptions<Schema>;
+
+      act(() => {
+        zeroArgs.onClientStateNotFound?.();
+      });
+
+      await vi.waitFor(() => {
+        expect(ZeroMock).toHaveBeenCalledTimes(2);
+        expect(init).toHaveBeenCalledTimes(2);
+      });
+
+      act(() => {
+        root.unmount();
+      });
+    });
+
+    test('dedupes repeated client state not found requests while rotation is pending', async () => {
+      const mockZero1 = createMockZero('client-1');
+      const mockZero2 = createMockZero('client-2');
+      const ZeroMock = vi.mocked(ZeroConstructor);
+      ZeroMock.mockImplementationOnce(function () {
+        return mockZero1;
+      }).mockImplementationOnce(function () {
+        return mockZero2;
+      });
+      const root = renderWithRoot(
+        <ZeroProvider cacheURL="https://example.com" schema={fakeSchema}>
+          <div>test</div>
+        </ZeroProvider>,
+      );
+
+      const zeroArgs = ZeroMock.mock.calls[0]?.[0] as ZeroOptions<Schema>;
+      const onNotFound = zeroArgs.onClientStateNotFound;
+      expect(onNotFound).toBeDefined();
+
+      act(() => {
+        onNotFound!();
+        onNotFound!();
+      });
+
+      await vi.waitFor(() => {
+        expect(ZeroMock).toHaveBeenCalledTimes(2);
+      });
+
+      act(() => {
+        root.unmount();
+      });
+    });
+
+    test('still rotates when onClientStateNotFound callback throws', async () => {
+      const mockZero1 = createMockZero('client-1');
+      const mockZero2 = createMockZero('client-2');
+      const ZeroMock = vi.mocked(ZeroConstructor);
+      ZeroMock.mockImplementationOnce(function () {
+        return mockZero1;
+      }).mockImplementationOnce(function () {
+        return mockZero2;
+      });
+
+      const onClientStateNotFound = vi.fn(() => {
+        throw new Error('boom');
+      });
+
+      function TestComponent() {
+        useZero<Schema>();
+        return <div>test</div>;
+      }
+
+      const root = renderWithRoot(
+        <ZeroProvider
+          cacheURL="https://example.com"
+          schema={fakeSchema}
+          onClientStateNotFound={onClientStateNotFound}
+        >
+          <TestComponent />
+        </ZeroProvider>,
+      );
+
+      const zeroArgs = ZeroMock.mock.calls[0]?.[0] as ZeroOptions<Schema>;
+
+      expect(() => {
+        act(() => {
+          zeroArgs.onClientStateNotFound?.();
+        });
+      }).not.toThrow();
+
+      await vi.waitFor(() => {
+        expect(onClientStateNotFound).toHaveBeenCalledTimes(1);
+        expect(ZeroMock).toHaveBeenCalledTimes(2);
+      });
 
       act(() => {
         root.unmount();

--- a/packages/zero-react/src/zero-provider.tsx
+++ b/packages/zero-react/src/zero-provider.tsx
@@ -59,6 +59,12 @@ export type ZeroProviderProps<
   MD extends CustomMutatorDefs | undefined = undefined,
   Context extends BaseDefaultContext = DefaultContext,
 > = (ZeroOptions<S, MD, Context> | {zero: Zero<S, MD, Context>}) & {
+  /**
+   * Called after ZeroProvider constructs a new Zero instance.
+   *
+   * This runs only when the provider creates Zero from options, and is not
+   * called when an existing instance is passed with `zero`.
+   */
   init?: (zero: Zero<S, MD, Context>) => void;
   children: ReactNode;
 };
@@ -73,10 +79,20 @@ export function ZeroProvider<
   const [zero, setZero] = useState<Zero<S, MD, Context> | undefined>(
     isExternalZero ? props.zero : undefined,
   );
+  const [rotationGeneration, setRotationGeneration] = useState(0);
 
   const auth = 'auth' in props ? props.auth : undefined;
   const hasAuth = typeof auth === 'string';
   const prevAuthRef = useRef<typeof auth>(auth);
+  const rotationPendingRef = useRef(false);
+
+  const scheduleRotation = () => {
+    if (rotationPendingRef.current) {
+      return;
+    }
+    rotationPendingRef.current = true;
+    setRotationGeneration(gen => gen + 1);
+  };
 
   const keysWithoutAuth = useMemo(
     () =>
@@ -94,14 +110,34 @@ export function ZeroProvider<
   // component.
   useEffect(() => {
     if (isExternalZero) {
+      rotationPendingRef.current = false;
       setZero(props.zero);
       return;
     }
 
-    const z = new Zero(props);
+    const z = new Zero({
+      ...props,
+      onClientStateNotFound: () => {
+        if (rotationPendingRef.current) {
+          return;
+        }
+
+        if (props.onClientStateNotFound) {
+          try {
+            props.onClientStateNotFound();
+            return;
+          } catch {
+            // rotate since zero client is now closed
+          }
+        }
+
+        scheduleRotation();
+      },
+    });
     prevAuthRef.current = auth;
     init?.(z);
     setZero(z);
+    rotationPendingRef.current = false;
 
     return () => {
       void z.close();
@@ -109,7 +145,7 @@ export function ZeroProvider<
     };
     // we intentionally don't include auth in the dependency array
     // to avoid closing zero when auth changes
-  }, [hasAuth, init, ...keysWithoutAuth]);
+  }, [hasAuth, init, rotationGeneration, ...keysWithoutAuth]);
 
   useEffect(() => {
     if (!zero || isExternalZero) return;

--- a/packages/zero-solid/src/use-zero.test.tsx
+++ b/packages/zero-solid/src/use-zero.test.tsx
@@ -18,6 +18,8 @@ const ZeroMock = vi.mocked(ZeroConstructor);
 
 type MockZero = ReturnType<typeof createMockZero>;
 
+const fakeSchema = {} as Schema;
+
 function createMockZero(clientID = 'test-client'): Zero<Schema> & {
   close: Mock;
   connection: {connect: Mock};
@@ -96,10 +98,9 @@ describe('ZeroProvider', () => {
       });
 
       const [server, setServer] = createSignal('foo');
-      const schema = {} as Schema;
 
       const wrapper = (props: {children: JSX.Element}) => (
-        <ZeroProvider cacheURL={server()} schema={schema} userID="u">
+        <ZeroProvider cacheURL={server()} schema={fakeSchema} userID="u">
           {props.children}
         </ZeroProvider>
       );
@@ -126,10 +127,9 @@ describe('ZeroProvider', () => {
       });
 
       const [wrap, setWrap] = createSignal(false);
-      const schema = {} as Schema;
 
       const wrapper = (props: {children: JSX.Element}) => (
-        <ZeroProvider cacheURL="foo" schema={schema} userID="u">
+        <ZeroProvider cacheURL="foo" schema={fakeSchema} userID="u">
           {wrap() ? <div>{props.children}</div> : props.children}
         </ZeroProvider>
       );
@@ -193,19 +193,19 @@ describe('ZeroProvider', () => {
 
     test('calls init callback with constructed zero', () => {
       const zero = createMockZero();
-      ZeroMock.mockImplementation(function () {
+      const capturedOptions: object[] = [];
+      ZeroMock.mockImplementation(function (options) {
+        capturedOptions.push(options as object);
         return zero;
       });
       const init = vi.fn();
-
-      const schema = {} as Schema;
 
       renderHook(() => useZero<Schema>(), {
         initialProps: [],
         wrapper: (props: {children: JSX.Element}) => (
           <ZeroProvider
             cacheURL="https://example.com"
-            schema={schema}
+            schema={fakeSchema}
             userID="u"
             init={init}
           >
@@ -216,6 +216,148 @@ describe('ZeroProvider', () => {
 
       expect(init).toHaveBeenCalledWith(zero);
       expect(init).toHaveBeenCalledTimes(1);
+      expect(capturedOptions[0]).not.toHaveProperty('init');
+    });
+
+    test('does not recreate zero when custom onClientStateNotFound fires', () => {
+      const zero1 = createMockZero('client-1');
+      const zero2 = createMockZero('client-2');
+
+      ZeroMock.mockImplementationOnce(function () {
+        return zero1;
+      }).mockImplementationOnce(function () {
+        return zero2;
+      });
+
+      const onClientStateNotFound = vi.fn();
+
+      const {result} = renderHook(() => useZero<Schema>(), {
+        initialProps: [],
+        wrapper: (props: {children: JSX.Element}) => (
+          <ZeroProvider
+            cacheURL="https://example.com"
+            schema={fakeSchema}
+            onClientStateNotFound={onClientStateNotFound}
+          >
+            {props.children}
+          </ZeroProvider>
+        ),
+      });
+
+      const zeroArgs = ZeroMock.mock.calls[0]?.[0] as ZeroOptions<Schema>;
+
+      expect(result()).toBe(zero1);
+
+      zeroArgs.onClientStateNotFound?.();
+
+      expect(onClientStateNotFound).toHaveBeenCalledTimes(1);
+      expect(ZeroMock).toHaveBeenCalledTimes(1);
+      expect(zero1.close).not.toHaveBeenCalled();
+      expect(result()).toBe(zero1);
+    });
+
+    test('re-runs init when zero is recreated after client state not found', () => {
+      const zero1 = createMockZero('client-1');
+      const zero2 = createMockZero('client-2');
+
+      ZeroMock.mockImplementationOnce(function () {
+        return zero1;
+      }).mockImplementationOnce(function () {
+        return zero2;
+      });
+
+      const init = vi.fn();
+
+      renderHook(() => useZero<Schema>(), {
+        initialProps: [],
+        wrapper: (props: {children: JSX.Element}) => (
+          <ZeroProvider
+            cacheURL="https://example.com"
+            schema={fakeSchema}
+            init={init}
+          >
+            {props.children}
+          </ZeroProvider>
+        ),
+      });
+
+      const zeroArgs = ZeroMock.mock.calls[0]?.[0] as ZeroOptions<Schema>;
+
+      zeroArgs.onClientStateNotFound?.();
+
+      expect(init).toHaveBeenCalledTimes(2);
+      expect(init).toHaveBeenNthCalledWith(1, zero1);
+      expect(init).toHaveBeenNthCalledWith(2, zero2);
+    });
+
+    test('dedupes repeated client state not found requests while rotation is pending', () => {
+      const zero1 = createMockZero('client-1');
+      const zero2 = createMockZero('client-2');
+
+      ZeroMock.mockImplementationOnce(function () {
+        return zero1;
+      }).mockImplementationOnce(function () {
+        return zero2;
+      });
+
+      renderHook(() => useZero<Schema>(), {
+        initialProps: [],
+        wrapper: (props: {children: JSX.Element}) => (
+          <ZeroProvider cacheURL="https://example.com" schema={fakeSchema}>
+            {props.children}
+          </ZeroProvider>
+        ),
+      });
+
+      const zeroArgs = ZeroMock.mock.calls[0]?.[0] as ZeroOptions<Schema>;
+      const onNotFound = zeroArgs.onClientStateNotFound;
+
+      expect(onNotFound).toBeDefined();
+
+      onNotFound!();
+      onNotFound!();
+
+      expect(ZeroMock).toHaveBeenCalledTimes(2);
+      expect(zero1.close).toHaveBeenCalledTimes(1);
+    });
+
+    test('still rotates when onClientStateNotFound callback throws', () => {
+      const zero1 = createMockZero('client-1');
+      const zero2 = createMockZero('client-2');
+
+      ZeroMock.mockImplementationOnce(function () {
+        return zero1;
+      }).mockImplementationOnce(function () {
+        return zero2;
+      });
+
+      const onClientStateNotFound = vi.fn(() => {
+        throw new Error('boom');
+      });
+
+      const {result} = renderHook(() => useZero<Schema>(), {
+        initialProps: [],
+        wrapper: (props: {children: JSX.Element}) => (
+          <ZeroProvider
+            cacheURL="https://example.com"
+            schema={fakeSchema}
+            onClientStateNotFound={onClientStateNotFound}
+          >
+            {props.children}
+          </ZeroProvider>
+        ),
+      });
+
+      const zeroArgs = ZeroMock.mock.calls[0]?.[0] as ZeroOptions<Schema>;
+
+      expect(() => {
+        zeroArgs.onClientStateNotFound?.();
+      }).not.toThrow();
+
+      expect(onClientStateNotFound).toHaveBeenCalledTimes(1);
+      expect(ZeroMock).toHaveBeenCalledTimes(2);
+      expect(zero1.close).toHaveBeenCalledTimes(1);
+      expect(result()).toBe(zero2);
     });
   });
 
@@ -244,6 +386,33 @@ describe('ZeroProvider', () => {
       expect(zero1.close).not.toHaveBeenCalled();
       expect(zero2.close).not.toHaveBeenCalled();
     });
+
+    test('does not call init when zero is provided externally', () => {
+      const zero1 = createMockZero('client-1');
+      const zero2 = createMockZero('client-2');
+      const init = vi.fn();
+
+      const [zero, setZero] = createSignal<Zero<Schema>>(zero1);
+
+      const wrapper = (props: {children: JSX.Element}) => (
+        <ZeroProvider zero={zero()} init={init}>
+          {props.children}
+        </ZeroProvider>
+      );
+
+      const {result} = renderHook(() => useZero<Schema>(), {
+        initialProps: [],
+        wrapper,
+      });
+
+      expect(result()).toBe(zero1);
+      expect(init).not.toHaveBeenCalled();
+
+      setZero(zero2);
+
+      expect(result()).toBe(zero2);
+      expect(init).not.toHaveBeenCalled();
+    });
   });
 
   describe('auth handling', () => {
@@ -255,14 +424,12 @@ describe('ZeroProvider', () => {
         return zero;
       });
 
-      const schema = {} as Schema;
-
       renderHook(() => useZero<Schema>(), {
         initialProps: [],
         wrapper: (props: {children: JSX.Element}) => (
           <ZeroProvider
             cacheURL="https://example.com"
-            schema={schema}
+            schema={fakeSchema}
             auth="token-1"
             userID="u"
           >
@@ -284,14 +451,12 @@ describe('ZeroProvider', () => {
         return zero;
       });
 
-      const schema = {} as Schema;
-
       renderHook(() => useZero<Schema>(), {
         initialProps: [],
         wrapper: (props: {children: JSX.Element}) => (
           <ZeroProvider
             cacheURL="https://example.com"
-            schema={schema}
+            schema={fakeSchema}
             userID="u"
           >
             {props.children}
@@ -309,13 +474,12 @@ describe('ZeroProvider', () => {
         return zero;
       });
 
-      const schema = {} as Schema;
       const [auth, setAuth] = createSignal('token-1');
 
       const wrapper = (props: {children: JSX.Element}) => (
         <ZeroProvider
           cacheURL="https://example.com"
-          schema={schema}
+          schema={fakeSchema}
           auth={auth()}
           userID="u"
         >
@@ -353,13 +517,12 @@ describe('ZeroProvider', () => {
         return zeros[capturedOptions.length - 1]!;
       });
 
-      const schema = {} as Schema;
       const [auth, setAuth] = createSignal<string | undefined>(undefined);
 
       const wrapper = (props: {children: JSX.Element}) => (
         <ZeroProvider
           cacheURL="https://example.com"
-          schema={schema}
+          schema={fakeSchema}
           auth={auth()}
           userID="u"
         >
@@ -392,13 +555,12 @@ describe('ZeroProvider', () => {
         return zeros[capturedOptions.length - 1]!;
       });
 
-      const schema = {} as Schema;
       const [auth, setAuth] = createSignal<string | undefined>('token-initial');
 
       const wrapper = (props: {children: JSX.Element}) => (
         <ZeroProvider
           cacheURL="https://example.com"
-          schema={schema}
+          schema={fakeSchema}
           userID="u"
           auth={auth()}
         >

--- a/packages/zero-solid/src/use-zero.ts
+++ b/packages/zero-solid/src/use-zero.ts
@@ -3,6 +3,7 @@ import {
   createContext,
   createEffect,
   createMemo,
+  createSignal,
   onCleanup,
   splitProps,
   untrack,
@@ -79,6 +80,12 @@ export function ZeroProvider<
 >(
   props: {
     children: JSX.Element;
+    /**
+     * Called after ZeroProvider constructs a new Zero instance.
+     *
+     * This runs only when the provider creates Zero from options, and is not
+     * called when an existing instance is passed with `zero`.
+     */
     init?: (zero: Zero<S, MD, Context>) => void;
   } & (
     | {
@@ -88,27 +95,56 @@ export function ZeroProvider<
   ),
 ) {
   let prevAuth = 'auth' in props ? props.auth : undefined;
+  const [rotationGeneration, setRotationGeneration] = createSignal(0);
 
   const auth = createMemo(() => ('auth' in props ? props.auth : undefined));
   const hasAuth = createMemo(() => typeof auth() === 'string');
 
   const zero = createMemo(() => {
+    rotationGeneration();
+
     if ('zero' in props) {
       return props.zero;
     }
 
     hasAuth();
 
-    const [, options] = splitProps(props, ['children', 'auth']);
+    const [local, options] = splitProps(props, ['children', 'auth', 'init']);
 
     const authValue = untrack(auth);
     prevAuth = authValue;
+    let rotationRequested = false;
+
+    const scheduleRotation = () => {
+      if (rotationRequested) {
+        return;
+      }
+      rotationRequested = true;
+      setRotationGeneration(gen => gen + 1);
+    };
+
     const createdZero = new Zero({
       ...options,
       ...(authValue !== undefined ? {auth: authValue} : {}),
       batchViewUpdates: batch,
+      onClientStateNotFound: () => {
+        if (rotationRequested) {
+          return;
+        }
+
+        if (options.onClientStateNotFound) {
+          try {
+            options.onClientStateNotFound();
+            return;
+          } catch {
+            // rotate since zero client is now closed
+          }
+        }
+
+        scheduleRotation();
+      },
     });
-    options.init?.(createdZero);
+    local.init?.(createdZero);
     onCleanup(() => createdZero.close());
     return createdZero;
   });

--- a/packages/zero-solid/vitest.config.ts
+++ b/packages/zero-solid/vitest.config.ts
@@ -2,4 +2,12 @@ import solid from 'vite-plugin-solid';
 import {defineConfig, mergeConfig} from 'vitest/config';
 import config from '../shared/src/tool/vitest-config.ts';
 
-export default mergeConfig(config, defineConfig({plugins: [solid()]}));
+export default mergeConfig(
+  config,
+  defineConfig({
+    plugins: [solid()],
+    test: {
+      environment: 'node',
+    },
+  }),
+);


### PR DESCRIPTION
We currently do a full page refresh when a client comes back to an app after:

- 24h local client GC: stale tab cleaned up by another active tab
- 48h server purge: inactive CVR state cleanup

It causes flashing and odd issues that are unexpected for developers. It comes up with both zbugs and cloudzero - the full page refresh ends up causing more churn than is necessary. It's why coming back to CZ after a couple days is super slow and flashes.

**Description**
- teach the React and Solid `ZeroProvider`s to recreate provider-owned `Zero` instances when `onClientStateNotFound` is called
- expand `onClientStateNotFound` to handle `InvalidConnectionRequestLastMutationID` and `InvalidConnectionRequestBaseCookie`

**Details**
- `zero-client` still owns dropping the Replicache DB before recovery continues
- provider-owned React and Solid providers now rotate on `onClientStateNotFound`
- repeated stale-client callbacks are deduped while a rotation is already pending
- `init` is re-run for the replacement instance
- external `zero={...}` usage is unchanged and still requires the caller to replace the instance
- `onUpdateNeeded` behavior is unchanged and still causes page refresh

**Original Issue**

The timeline below shows that we double the load time due to this. It could have been loaded at 4s but ends up settled at 8s with a major refresh flash.

| Time              | What happened                    | Request / signal                    | Result                                  |
|-------------------|----------------------------------|-------------------------------------|-----------------------------------------|
| T+0.000s          | Initial navigation starts         | GET /                               | Browser begins loading CZ               |
| T+2.725s          | Server redirects into app route   | 307 → /z                            | Browser redirects              |
| T+2.918s          | First HTML document is received   | GET /z → 200                        | First app document is available         |
| T+2.934s          | Initial assets begin loading      | CSS, JS, route chunks, fonts        | Client app starts booting               |
| T+3.046s          | First page reaches DOM ready      | DOMContentLoaded                    | First page lifecycle is active          |
| T+3.153s          | App fetches session               | GET /api/auth/get-session → 200     | Session state is loaded                 |
| T+3.430s          | App loads route-specific code     | Team/stacks route chunks            | Target route code is prepared           |
| T+3.847s          | App opens Zero websocket          | wss://sync.../connect → 101         | Zero connection starts                  |
| T+4.080s          | Zero returns stale-client error   | ClientNotFound                      | Local Zero client state is invalid      |
| T+4.084s          | Client triggers hard reload       | GET /z/*redacted*              | Second full document navigation starts  |
| T+4.084s–T+6.367s | Browser waits for replacement HTML| ~2.28s server wait / TTFB           | Likely flash window                     |
| T+6.367s          | Second HTML document arrives      | GET /z/*redacted* → 200        | Reloaded page can start booting         |
| T+6.389s          | Assets load again                 | CSS, JS, route chunks, fonts        | Second app bootstrap starts             |
| T+6.897s          | Second page reaches DOM ready     | DOMContentLoaded                    | Reloaded document is active             |
| T+6.955s          | App opens second Zero websocket   | second websocket connection         | New Zero connection succeeds            |
| T+7.706s+         | Later server/data calls run       | server function POSTs               | Affects data state, not initial flash   |


**Comparisons:**

Here's a comparison before/after with zbugs network slowed to 2 mbps.

**Before:**

https://github.com/user-attachments/assets/6c6f5dcb-56c2-44d5-be5b-bfadadc5c77b

**After:**

https://github.com/user-attachments/assets/7aa1a7cf-952b-42f7-a294-b98d6e41cdd5