### PR TITLE
fix(zero-cache): gate shared retransform on view-syncer readiness

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/connection-context-manager.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/connection-context-manager.test.ts
@@ -393,6 +393,7 @@ describe('ConnectionContextManager', () => {
     register(manager, 'c1', 'ws1', 'user-1');
     register(manager, 'c2', 'ws2', 'user-1');
     validate(manager, 'c1', 'ws1');
+    manager.setSharedRetransformReady(true);
 
     const initial = manager.getGroupState();
 
@@ -448,6 +449,7 @@ describe('ConnectionContextManager', () => {
     );
     register(manager, 'c1', 'ws1', 'user-1');
     validate(manager, 'c1', 'ws1');
+    manager.setSharedRetransformReady(true);
     const previousAuth = manager.mustGetConnectionContext(
       selector('c1', 'ws1'),
     ).auth;
@@ -485,6 +487,7 @@ describe('ConnectionContextManager', () => {
     register(manager, 'c2', 'ws2', 'user-1');
     validate(manager, 'c1', 'ws1');
     validate(manager, 'c2', 'ws2');
+    manager.setSharedRetransformReady(true);
 
     await expect(
       manager.updateAuth(selector('c2', 'ws2'), {auth: 'token-ws2-new'}),
@@ -664,6 +667,7 @@ describe('ConnectionContextManager', () => {
     register(manager, 'c3', 'ws3', 'user-1');
     validate(manager, 'c2', 'ws2');
     validate(manager, 'c1', 'ws1');
+    manager.setSharedRetransformReady(true);
 
     expect(manager.planMaintenance()).toEqual({
       dueRevalidations: [],
@@ -740,6 +744,7 @@ describe('ConnectionContextManager', () => {
     );
     register(manager, 'c1', 'ws1', 'user-1');
     validate(manager, 'c1', 'ws1');
+    manager.setSharedRetransformReady(true);
 
     expect(manager.getConnectionContext(selector('c1', 'ws1'))).toMatchObject({
       revalidateAt: 6_000,
@@ -779,6 +784,7 @@ describe('ConnectionContextManager', () => {
     register(manager, 'c2', 'ws2', 'user-1');
     validate(manager, 'c1', 'ws1');
     validate(manager, 'c2', 'ws2');
+    manager.setSharedRetransformReady(true);
 
     now = 3_000;
     manager.deferMaintenance('retransform');
@@ -808,6 +814,53 @@ describe('ConnectionContextManager', () => {
       ],
       dueRetransform: true,
       earliestDeadlineAt: 3_000,
+    });
+  });
+
+  test('does not schedule shared retransform until readiness is enabled', () => {
+    let now = 1_000;
+    const manager = new ConnectionContextManagerImpl(
+      lc,
+      5,
+      2,
+      undefined,
+      undefined,
+      undefined,
+      () => now,
+    );
+    register(manager, 'c1', 'ws1', 'user-1');
+    validate(manager, 'c1', 'ws1');
+
+    expect(manager.getGroupState().retransformAt).toBeUndefined();
+    expect(manager.planMaintenance()).toEqual({
+      dueRevalidations: [],
+      dueRetransform: false,
+      earliestDeadlineAt: 6_000,
+    });
+
+    manager.setSharedRetransformReady(true);
+
+    expect(manager.getGroupState().retransformAt).toBe(3_000);
+    expect(manager.planMaintenance()).toEqual({
+      dueRevalidations: [],
+      dueRetransform: false,
+      earliestDeadlineAt: 3_000,
+    });
+
+    now = 3_000;
+    expect(manager.planMaintenance()).toEqual({
+      dueRevalidations: [],
+      dueRetransform: true,
+      earliestDeadlineAt: 3_000,
+    });
+
+    manager.setSharedRetransformReady(false);
+
+    expect(manager.getGroupState().retransformAt).toBeUndefined();
+    expect(manager.planMaintenance()).toEqual({
+      dueRevalidations: [],
+      dueRetransform: false,
+      earliestDeadlineAt: 6_000,
     });
   });
 });

--- a/packages/zero-cache/src/services/view-syncer/connection-context-manager.ts
+++ b/packages/zero-cache/src/services/view-syncer/connection-context-manager.ts
@@ -140,6 +140,8 @@ export type ConnectionContextManager = {
     revision: number,
   ): void;
 
+  setSharedRetransformReady(ready: boolean): void;
+
   deferMaintenance(kind: 'revalidate' | 'retransform'): void;
 
   getConnectionContext(
@@ -188,6 +190,7 @@ export class ConnectionContextManagerImpl implements ConnectionContextManager {
   readonly #retransformIntervalMs: number | undefined;
   readonly #queryConfig: FetchConfig | undefined;
   readonly #pushConfig: FetchConfig | undefined;
+  #sharedRetransformReady = false;
   #nextInsertionOrder = 0;
 
   constructor(
@@ -495,6 +498,14 @@ export class ConnectionContextManagerImpl implements ConnectionContextManager {
     this.#updateBackgroundRetransformDeadline(true);
   }
 
+  setSharedRetransformReady(ready: boolean): void {
+    if (this.#sharedRetransformReady === ready) {
+      return;
+    }
+    this.#sharedRetransformReady = ready;
+    this.#updateBackgroundRetransformDeadline(true);
+  }
+
   deferMaintenance(kind: 'revalidate' | 'retransform'): void {
     const intervalMs =
       kind === 'revalidate'
@@ -787,11 +798,16 @@ export class ConnectionContextManagerImpl implements ConnectionContextManager {
    * When `reset` is false, this seeds a deadline only when shared retransform
    * is now possible and no deadline exists yet, preserving any existing
    * cadence. When `reset` is true, it starts a fresh interval from `#now()` if
-   * retransform is schedulable, or clears the deadline if it is not.
+   * retransform is schedulable for the current ready ViewSyncer instance, or
+   * clears the deadline if it is not.
    */
   #updateBackgroundRetransformDeadline(reset: boolean) {
     const backgroundConnection = this.#getBackgroundConnectionContext();
-    if (!backgroundConnection || this.#retransformIntervalMs === undefined) {
+    if (
+      !backgroundConnection ||
+      this.#retransformIntervalMs === undefined ||
+      !this.#sharedRetransformReady
+    ) {
       if (this.#group.retransformAt !== undefined) {
         this.#setGroup({
           ...this.#group,

--- a/packages/zero-cache/src/services/view-syncer/view-syncer-auth-maintenance.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer-auth-maintenance.pg.test.ts
@@ -112,6 +112,15 @@ describe('view-syncer/auth maintenance', () => {
     fn?.();
   }
 
+  function hasScheduledTimeout(
+    setTimeoutFn: ReturnType<typeof vi.fn<typeof setTimeout>>,
+    delay: number,
+  ) {
+    return setTimeoutFn.mock.calls.some(
+      ([, scheduledDelay]) => scheduledDelay === delay,
+    );
+  }
+
   const SYNC_CONTEXT: SyncContext = {
     clientID: 'foo',
     profileID: 'p0000g00000003203',
@@ -419,6 +428,135 @@ describe('view-syncer/auth maintenance', () => {
       };
     });
 
+    test('schedules shared retransform only after initial pipeline sync', async () => {
+      const transformer = customQueryTransformer;
+      expect(transformer).toBeDefined();
+      using validateSpy = vi
+        .spyOn(transformer!, 'validate')
+        .mockResolvedValue(validationSuccess('user-1'));
+      using transformSpy = vi
+        .spyOn(transformer!, 'transform')
+        .mockResolvedValueOnce(
+          transformSuccess([
+            {
+              id: 'custom-1',
+              transformedAst: ISSUES_QUERY,
+              transformationHash: 'hash-1',
+            },
+          ]),
+        )
+        .mockResolvedValueOnce(
+          transformSuccess([
+            {
+              id: 'custom-1',
+              transformedAst: ISSUES_QUERY,
+              transformationHash: 'hash-2',
+            },
+          ]),
+        );
+
+      const client = connect(
+        {...SYNC_CONTEXT, auth: {type: 'opaque', raw: 'token-selected'}},
+        [
+          {
+            op: 'put',
+            hash: 'custom-1',
+            name: 'named-query-1',
+            args: ['thing'],
+          },
+        ],
+      );
+
+      await nextPoke(client);
+
+      expect(validateSpy).toHaveBeenCalledTimes(1);
+      expect(transformSpy).toHaveBeenCalledTimes(0);
+      expect(hasScheduledTimeout(setTimeoutFn, MAINTENANCE_INTERVAL_MS)).toBe(
+        false,
+      );
+
+      stateChanges.push({state: 'version-ready'});
+      await nextPoke(client);
+
+      expect(transformSpy).toHaveBeenCalledTimes(1);
+      await vi.waitFor(() => {
+        expect(
+          vs.connContextManager.getBackgroundConnectionContext(),
+        ).toBeDefined();
+        expect(
+          vs.connContextManager.getGroupState().retransformAt,
+        ).toBeDefined();
+        expect(hasScheduledTimeout(setTimeoutFn, MAINTENANCE_INTERVAL_MS)).toBe(
+          true,
+        );
+      });
+
+      callNextSetTimeout(setTimeoutFn, MAINTENANCE_INTERVAL_MS);
+
+      await vi.waitFor(() => expect(transformSpy).toHaveBeenCalledTimes(2), {
+        timeout: 2_000,
+      });
+    });
+
+    test('stale scheduled background retransform does not run after stop', async () => {
+      const transformer = customQueryTransformer;
+      expect(transformer).toBeDefined();
+      using validateSpy = vi
+        .spyOn(transformer!, 'validate')
+        .mockResolvedValue(validationSuccess('user-1'));
+      using transformSpy = vi
+        .spyOn(transformer!, 'transform')
+        .mockResolvedValueOnce(
+          transformSuccess([
+            {
+              id: 'custom-1',
+              transformedAst: ISSUES_QUERY,
+              transformationHash: 'hash-1',
+            },
+          ]),
+        );
+
+      const client = connect(
+        {...SYNC_CONTEXT, auth: {type: 'opaque', raw: 'token-selected'}},
+        [
+          {
+            op: 'put',
+            hash: 'custom-1',
+            name: 'named-query-1',
+            args: ['thing'],
+          },
+        ],
+      );
+
+      await nextPoke(client);
+      stateChanges.push({state: 'version-ready'});
+      await nextPoke(client);
+
+      await vi.waitFor(() => {
+        expect(validateSpy).toHaveBeenCalledTimes(1);
+        expect(transformSpy).toHaveBeenCalledTimes(1);
+        expect(
+          vs.connContextManager.getGroupState().retransformAt,
+        ).toBeDefined();
+        expect(hasScheduledTimeout(setTimeoutFn, MAINTENANCE_INTERVAL_MS)).toBe(
+          true,
+        );
+      });
+
+      await vs.stop();
+
+      expect(vs.connContextManager.getGroupState().retransformAt).toBeUndefined();
+
+      // Fire the previously scheduled maintenance callback after shutdown to
+      // prove the stopped service no longer performs shared retransform work.
+      callNextSetTimeout(setTimeoutFn, MAINTENANCE_INTERVAL_MS);
+
+      await vi.waitFor(() => {
+        expect(transformSpy).toHaveBeenCalledTimes(1);
+        expect(vs.connContextManager.getGroupState().retransformAt).toBeUndefined();
+      });
+    });
+
     test('retries scheduled background retransform with a promoted replacement connection', async () => {
       const transformer = customQueryTransformer;
       expect(transformer).toBeDefined();
@@ -558,6 +696,11 @@ describe('view-syncer/auth maintenance', () => {
 
       expect(validateSpy).toHaveBeenCalledTimes(1);
       expect(transformSpy).toHaveBeenCalledTimes(1);
+      await vi.waitFor(() =>
+        expect(
+          vs.connContextManager.getGroupState().retransformAt,
+        ).toBeDefined(),
+      );
       expect(client.size()).toBe(0);
 
       callNextSetTimeout(setTimeoutFn, MAINTENANCE_INTERVAL_MS);

--- a/packages/zero-cache/src/services/view-syncer/view-syncer-auth-maintenance.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer-auth-maintenance.pg.test.ts
@@ -545,7 +545,9 @@ describe('view-syncer/auth maintenance', () => {
 
       await vs.stop();
 
-      expect(vs.connContextManager.getGroupState().retransformAt).toBeUndefined();
+      expect(
+        vs.connContextManager.getGroupState().retransformAt,
+      ).toBeUndefined();
 
       // Fire the previously scheduled maintenance callback after shutdown to
       // prove the stopped service no longer performs shared retransform work.
@@ -553,7 +555,9 @@ describe('view-syncer/auth maintenance', () => {
 
       await vi.waitFor(() => {
         expect(transformSpy).toHaveBeenCalledTimes(1);
-        expect(vs.connContextManager.getGroupState().retransformAt).toBeUndefined();
+        expect(
+          vs.connContextManager.getGroupState().retransformAt,
+        ).toBeUndefined();
       });
     });
 

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -492,6 +492,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
             this.#pipelineResets.add(1, {reason: result.reason});
             this.#pipelines.reset(clientSchema);
             this.#pipelinesSynced = false;
+            this.connContextManager.setSharedRetransformReady(false);
           }
 
           // Advance the snapshot to the current version.
@@ -521,6 +522,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
             driftedQueryIDs,
           );
           this.#pipelinesSynced = true;
+          this.connContextManager.setSharedRetransformReady(true);
         });
       }
 
@@ -2491,12 +2493,14 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
   stop(): Promise<void> {
     this.#lc.info?.('stopping view syncer');
+    this.connContextManager.setSharedRetransformReady(false);
     this.#initialized.reject('shut down before initialization completed');
     this.#stateChanges.cancel();
     return this.#stopped.promise;
   }
 
   async #cleanup(err?: unknown) {
+    this.connContextManager.setSharedRetransformReady(false);
     this.#stopTTLClockInterval();
     this.#stopExpireTimer();
     this.#stopAuthMaintenanceTimer();


### PR DESCRIPTION
Gate shared background retransform on the current `ViewSyncerService` instance reaching first successful pipeline sync.

**Details**
- added explicit lifecycle readiness for shared retransform scheduling in `ConnectionContextManager`
- made `retransformAt` require both:
  - a validated background connection
  - readiness from the current `ViewSyncerService` instance
- set readiness only after the initial `#syncQueryPipelineSet()` succeeds
- clear readiness on pipeline reset, `stop()`, and cleanup

**Original Issue**

`Error: pipelines must be initialized (syncQueryPipelineSet)`

This happened during `SIGTERM` drain of `view-syncer`.

The underlying issue was that a later `ViewSyncerService` instance for the same logical client group could validate a background connection and become eligible for shared auth-maintenance retransform work before that specific service instance had completed its first successful pipeline sync.