### PR TITLE
fix(zero-server): fix regression in #5905

### DIFF
--- a/packages/zero-server/src/queries/process-queries.test.ts
+++ b/packages/zero-server/src/queries/process-queries.test.ts
@@ -73,7 +73,7 @@ describe('handleQueryRequest', () => {
       userID: null,
     });
 
-    expect(cb).toHaveBeenCalledWith('namesByFoo', [{foo: 'bar'}]);
+    expect(cb).toHaveBeenCalledWith('namesByFoo', {foo: 'bar'});
     expect(result).toEqual(
       makeCanonicalQuerySuccessResponse(
         [
@@ -124,7 +124,7 @@ describe('handleQueryRequest', () => {
       logLevel: 'debug',
     });
 
-    expect(cb).toHaveBeenCalledWith('basicLimited', []);
+    expect(cb).toHaveBeenCalledWith('basicLimited', undefined);
     expect(result).toEqual(
       makeCanonicalQuerySuccessResponse(
         [

--- a/packages/zero-server/src/queries/process-queries.ts
+++ b/packages/zero-server/src/queries/process-queries.ts
@@ -99,7 +99,7 @@ type NormalizedQueryRequestArgs<S extends Schema> =
   | {
       readonly type: 'request';
       readonly schema: S;
-      readonly handler: QueryRequestHandler | LegacyQueryRequestHandler;
+      readonly handler: LegacyQueryRequestHandler;
       readonly request: Request;
       readonly userID: string | null | undefined;
       readonly logLevel: LogLevel;
@@ -107,7 +107,7 @@ type NormalizedQueryRequestArgs<S extends Schema> =
   | {
       readonly type: 'body';
       readonly schema: S;
-      readonly handler: QueryRequestHandler | LegacyQueryRequestHandler;
+      readonly handler: LegacyQueryRequestHandler;
       readonly jsonBody: ReadonlyJSONValue;
       readonly userID: string | null | undefined;
       readonly logLevel: LogLevel;
@@ -171,16 +171,16 @@ export function handleQueryRequest<S extends Schema>(
 
 export function handleQueryRequest<S extends Schema>(
   inputOrTransformQuery: HandleQueryRequestObjectArgs<S> | QueryRequestHandler,
-  schema?: S | undefined,
-  requestOrJsonBody?: Request | ReadonlyJSONValue | undefined,
-  logLevel?: LogLevel | undefined,
+  schema?: S,
+  requestOrJsonBody?: Request | ReadonlyJSONValue,
+  logLevel?: LogLevel,
 ): Promise<QueryResponse> {
   const normalized =
     typeof inputOrTransformQuery === 'object' &&
     'handler' in inputOrTransformQuery
       ? normalizeQueryRequestInput(inputOrTransformQuery)
       : normalizeLegacyQueryRequestArgs(
-          inputOrTransformQuery,
+          wrapQueryRequestHandler(inputOrTransformQuery),
           schema,
           requestOrJsonBody,
           logLevel,
@@ -193,29 +193,28 @@ function normalizeQueryRequestInput<S extends Schema>(
   input: HandleQueryRequestObjectArgs<S>,
 ): NormalizedQueryRequestArgs<S> {
   return 'request' in input
-    ? {
-        type: 'request',
-        handler: input.handler,
-        schema: input.schema,
-        request: input.request,
-        userID: input.userID ?? null,
-        logLevel: input.logLevel ?? 'info',
-      }
-    : {
-        type: 'body',
-        handler: input.handler,
-        schema: input.schema,
-        jsonBody: input.body,
-        userID: input.userID ?? null,
-        logLevel: input.logLevel ?? 'info',
-      };
+    ? normalizeLegacyQueryRequestArgs(
+        wrapQueryRequestHandler(input.handler),
+        input.schema,
+        input.request,
+        input.logLevel,
+        input.userID ?? null,
+      )
+    : normalizeLegacyQueryRequestArgs(
+        wrapQueryRequestHandler(input.handler),
+        input.schema,
+        input.body,
+        input.logLevel,
+        input.userID ?? null,
+      );
 }
 
 function normalizeLegacyQueryRequestArgs<S extends Schema>(
-  handler: QueryRequestHandler | LegacyQueryRequestHandler,
+  handler: LegacyQueryRequestHandler,
   schema: S | undefined,
   requestOrJsonBody: Request | ReadonlyJSONValue | undefined,
   logLevel: LogLevel | undefined,
+  userID?: string | null,
 ): NormalizedQueryRequestArgs<S> {
   assert(
     typeof schema !== 'undefined',
@@ -228,7 +227,7 @@ function normalizeLegacyQueryRequestArgs<S extends Schema>(
       handler,
       schema,
       request: requestOrJsonBody,
-      userID: undefined,
+      userID,
       logLevel: logLevel ?? 'info',
     };
   }
@@ -243,7 +242,7 @@ function normalizeLegacyQueryRequestArgs<S extends Schema>(
     handler,
     schema,
     jsonBody: requestOrJsonBody,
-    userID: undefined,
+    userID,
     logLevel: logLevel ?? 'info',
   };
 }
@@ -355,8 +354,13 @@ export type QueryRequestHandler = (
 /** @deprecated Use `QueryRequestHandler` instead. */
 export type TransformQueryFunction = QueryRequestHandler;
 
-/** @deprecated Use `QueryRequestHandler` instead. */
 export type LegacyQueryRequestHandler = (
   name: string,
   args: readonly ReadonlyJSONValue[],
 ) => MaybePromise<{query: AnyQuery} | AnyQuery>;
+
+function wrapQueryRequestHandler(
+  handler: QueryRequestHandler,
+): LegacyQueryRequestHandler {
+  return (name, args) => handler(name, args[0]);
+}


### PR DESCRIPTION
Changed to map back to the legacy format of an array of arguments. Regressed in #5905.