### PR TITLE
fix(zero-cache): fix zombie ViewSyncers inflating active-client-groups metric

### DIFF
--- a/packages/zero-cache/src/services/runner.test.ts
+++ b/packages/zero-cache/src/services/runner.test.ts
@@ -65,4 +65,46 @@ describe('services/runner', () => {
     const s2 = runner.getService('foo');
     expect(s1).not.toBe(s2);
   });
+
+  // Models the zombie ViewSyncer scenario: a service whose run() blocks on
+  // an unresolved initialization promise should be cleaned up when that
+  // promise is rejected (e.g. when all clients disconnect before
+  // initConnection completes).
+  test('zombie cleanup on rejected initialization', async () => {
+    const initialized = resolver<void>();
+    let runCompleted = false;
+
+    const zombieRunner = new ServiceRunner<TestService>(
+      createSilentLogContext(),
+      (id: string) => {
+        const service = new TestService(id);
+        // Override run() to block on the initialization promise,
+        // modeling ViewSyncerService.run() blocking on readyState().
+        service.run = async () => {
+          try {
+            await initialized.promise;
+          } catch {
+            // Rejection means shutdown before initialization.
+          }
+          runCompleted = true;
+        };
+        return service;
+      },
+      () => true,
+    );
+
+    // Service is created and run() starts, blocking on initialized.promise
+    zombieRunner.getService('zombie');
+    expect(zombieRunner.size).toBe(1);
+
+    // Without the fix, rejecting the initialization promise would never
+    // happen in the idle-shutdown path, leaving the service as a zombie.
+    // With the fix, the shutdown path rejects #initialized, which
+    // unblocks run() and allows cleanup.
+    initialized.reject('shut down before initialization completed');
+    await sleep(1);
+
+    expect(runCompleted).toBe(true);
+    expect(zombieRunner.size).toBe(0);
+  });
 });

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
@@ -6203,6 +6203,11 @@ describe('view-syncer/service', () => {
   test('view-syncer run completes when client disconnects before initialization', async () => {
     const destroySpy = vi.spyOn(PipelineDriver.prototype, 'destroy');
 
+    // Use fake timers starting from *now* so that advancing past the
+    // keepalive window (DEFAULT_KEEPALIVE_MS = 5000, set at construction
+    // time using real Date.now()) works correctly.
+    vi.setSystemTime(vi.getRealSystemTime());
+
     const {source} = connectWithQueueAndSource(SYNC_CONTEXT, [
       {op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY},
     ]);
@@ -6211,13 +6216,27 @@ describe('view-syncer/service', () => {
     // has a chance to resolve #initialized.
     source.cancel();
 
-    // Fire the shutdown timer callback (setTimeout is mocked in this harness).
-    // #scheduleShutdown registers via the mock — find and invoke it.
-    // Note: there may be multiple setTimeout calls (TTL clock, auth timer,
-    // etc.), so we fire ALL pending callbacks to ensure the shutdown path runs.
+    // Let the initConnection async callback acquire and release the lock.
+    await sleep(100);
+
+    // Advance time past the keepalive window (DEFAULT_KEEPALIVE_MS = 5000)
+    // so that #checkForShutdownConditionsInLock returns true.
+    vi.setSystemTime(Date.now() + 6000);
+
+    // Fire ALL pending timer callbacks (setTimeout is mocked).
     for (const call of setTimeoutFn.mock.calls) {
       call[0]();
     }
+
+    // Let the shutdown lock acquisition and async cleanup settle.
+    await sleep(100);
+
+    // Fire any newly scheduled callbacks (shutdown may reschedule).
+    vi.setSystemTime(Date.now() + 6000);
+    for (const call of setTimeoutFn.mock.calls) {
+      call[0]();
+    }
+    await sleep(100);
 
     // The idle-shutdown path fires (runInLockWithCVR →
     // checkForShutdownConditionsInLock → rejects #initialized →

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
@@ -6235,4 +6235,3 @@ describe('view-syncer/service', () => {
     expect(destroySpy).toHaveBeenCalled();
   });
 });
-

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
@@ -6194,4 +6194,34 @@ describe('view-syncer/service', () => {
     expect(destroySpy).toHaveBeenCalled();
     expect(destroyCalledAfterRelease).toBe(true);
   });
+
+  // Regression test: a client that disconnects before initConnection's async
+  // callback resolves #initialized used to leave the ViewSyncer as a zombie
+  // in the ServiceRunner (run() blocked on readyState() forever), inflating
+  // the active-client-groups gauge. The fix rejects #initialized in the
+  // idle-shutdown path so that run() can exit.
+  test('view-syncer run completes when client disconnects before initialization', async () => {
+    const {source} = connectWithQueueAndSource(SYNC_CONTEXT, [
+      {op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY},
+    ]);
+
+    // Disconnect immediately, before the async initConnection callback
+    // has a chance to resolve #initialized.
+    source.cancel();
+
+    // Fire the shutdown timer callback (setTimeout is mocked in this harness).
+    const shutdownFn = setTimeoutFn.mock.lastCall![0];
+    shutdownFn();
+
+    // The idle-shutdown path fires (runInLockWithCVR →
+    // checkForShutdownConditionsInLock → rejects #initialized →
+    // stateChanges.cancel). This should cause vs.run() to exit.
+    // Without the fix, viewSyncerDone would never resolve here.
+    const timeout = sleep(5000).then(() => 'timeout' as const);
+    const result = await Promise.race([
+      viewSyncerDone.then(() => 'done' as const),
+      timeout,
+    ]);
+    expect(result).toBe('done');
+  });
 });

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
@@ -6201,6 +6201,8 @@ describe('view-syncer/service', () => {
   // the active-client-groups gauge. The fix rejects #initialized in the
   // idle-shutdown path so that run() can exit.
   test('view-syncer run completes when client disconnects before initialization', async () => {
+    const destroySpy = vi.spyOn(PipelineDriver.prototype, 'destroy');
+
     const {source} = connectWithQueueAndSource(SYNC_CONTEXT, [
       {op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY},
     ]);
@@ -6215,7 +6217,8 @@ describe('view-syncer/service', () => {
 
     // The idle-shutdown path fires (runInLockWithCVR →
     // checkForShutdownConditionsInLock → rejects #initialized →
-    // stateChanges.cancel). This should cause vs.run() to exit.
+    // stateChanges.cancel). This should cause vs.run() to exit via its
+    // catch block (which calls #cleanup) and finally block.
     // Without the fix, viewSyncerDone would never resolve here.
     const timeout = sleep(5000).then(() => 'timeout' as const);
     const result = await Promise.race([
@@ -6223,5 +6226,8 @@ describe('view-syncer/service', () => {
       timeout,
     ]);
     expect(result).toBe('done');
+
+    // Verify that #cleanup ran (pipelines destroyed).
+    expect(destroySpy).toHaveBeenCalled();
   });
 });

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
@@ -6212,8 +6212,12 @@ describe('view-syncer/service', () => {
     source.cancel();
 
     // Fire the shutdown timer callback (setTimeout is mocked in this harness).
-    const shutdownFn = setTimeoutFn.mock.lastCall![0];
-    shutdownFn();
+    // #scheduleShutdown registers via the mock — find and invoke it.
+    // Note: there may be multiple setTimeout calls (TTL clock, auth timer,
+    // etc.), so we fire ALL pending callbacks to ensure the shutdown path runs.
+    for (const call of setTimeoutFn.mock.calls) {
+      call[0]();
+    }
 
     // The idle-shutdown path fires (runInLockWithCVR →
     // checkForShutdownConditionsInLock → rejects #initialized →
@@ -6231,3 +6235,4 @@ describe('view-syncer/service', () => {
     expect(destroySpy).toHaveBeenCalled();
   });
 });
+

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -403,6 +403,9 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       // If all clients have disconnected, cancel all pending work.
       if (await this.#checkForShutdownConditionsInLock()) {
         this.#lc.info?.(`closing clientGroupID=${this.id}`);
+        // Reject #initialized so that run() unblocks if it is still
+        // waiting on readyState(). This is a no-op if already resolved.
+        this.#initialized.reject('shut down before initialization completed');
         this.#stateChanges.cancel(); // Note: #stateChanges.active becomes false.
         return;
       }


### PR DESCRIPTION
When a client disconnects before `initConnection`'s async callback resolves `#initialized`, the ViewSyncer's `run()` stays blocked on `readyState()` forever. The idle-shutdown path (`#checkForShutdownConditionsInLock`) cancels `#stateChanges` but never rejects `#initialized`, so `run()` never exits and the instance accumulates permanently in the ServiceRunner map — only cleaned up on pod drain.

This causes the `active-client-groups` gauge to grow unboundedly while `active-sync-clients` shows the true count.

**Fix:** Reject `#initialized` in the idle-shutdown path (mirroring what `stop()` already does). The resolver's `reject` is idempotent — it's a no-op if already resolved.
