### PR TITLE
chore(zql-integration-tests): add CPU profiling test for ZQL queries

### DIFF
--- a/packages/zql-integration-tests/src/school-access/schema.ts
+++ b/packages/zql-integration-tests/src/school-access/schema.ts
@@ -1,0 +1,288 @@
+import {relationships} from '../../../zero-schema/src/builder/relationship-builder.ts';
+import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
+import {
+  number,
+  string,
+  table,
+} from '../../../zero-schema/src/builder/table-builder.ts';
+import {createBuilder} from '../../../zql/src/query/create-builder.ts';
+
+const district = table('district')
+  .columns({
+    id: number(),
+    name: string(),
+  })
+  .primaryKey('id');
+
+const school = table('school')
+  .columns({
+    id: number(),
+    name: string(),
+    districtId: number().from('district_id'),
+  })
+  .primaryKey('id');
+
+const teacher = table('teacher')
+  .columns({
+    id: number(),
+    userId: string().from('user_id'),
+    role: string(),
+    schoolId: number().from('school_id'),
+  })
+  .primaryKey('id');
+
+const teacherToCoTeacher = table('teacherToCoTeacher')
+  .from('teacher_to_co_teacher')
+  .columns({
+    id: number(),
+    fromTeacherId: number().from('from_teacher_id'),
+    toTeacherId: number().from('to_teacher_id'),
+  })
+  .primaryKey('id');
+
+const klass = table('class')
+  .columns({
+    id: number(),
+    name: string(),
+    schoolId: number().from('school_id'),
+  })
+  .primaryKey('id');
+
+const teacherToClass = table('teacherToClass')
+  .from('teacher_to_class')
+  .columns({
+    id: number(),
+    teacherId: number().from('teacher_id'),
+    classId: number().from('class_id'),
+  })
+  .primaryKey('id');
+
+const student = table('student')
+  .columns({
+    id: number(),
+    name: string(),
+  })
+  .primaryKey('id');
+
+const studentClassMembership = table('studentClassMembership')
+  .from('student_class_membership')
+  .columns({
+    id: number(),
+    studentId: number().from('student_id'),
+    classId: number().from('class_id'),
+  })
+  .primaryKey('id');
+
+const teacherStudentAccess = table('teacherStudentAccess')
+  .from('teacher_student_access')
+  .columns({
+    id: number(),
+    teacherId: number().from('teacher_id'),
+    studentId: number().from('student_id'),
+  })
+  .primaryKey('id');
+
+const teacherClassAccess = table('teacherClassAccess')
+  .from('teacher_class_access')
+  .columns({
+    id: number(),
+    teacherId: number().from('teacher_id'),
+    classId: number().from('class_id'),
+  })
+  .primaryKey('id');
+
+const districtRelationships = relationships(district, ({many}) => ({
+  schools: many({
+    sourceField: ['id'],
+    destField: ['districtId'],
+    destSchema: school,
+  }),
+}));
+
+const schoolRelationships = relationships(school, ({one, many}) => ({
+  group: one({
+    sourceField: ['districtId'],
+    destField: ['id'],
+    destSchema: district,
+  }),
+  teachers: many({
+    sourceField: ['id'],
+    destField: ['schoolId'],
+    destSchema: teacher,
+  }),
+  classes: many({
+    sourceField: ['id'],
+    destField: ['schoolId'],
+    destSchema: klass,
+  }),
+}));
+
+const teacherRelationships = relationships(teacher, ({one, many}) => ({
+  school: one({
+    sourceField: ['schoolId'],
+    destField: ['id'],
+    destSchema: school,
+  }),
+  coTeacherGrants: many({
+    sourceField: ['id'],
+    destField: ['fromTeacherId'],
+    destSchema: teacherToCoTeacher,
+  }),
+  classAssignments: many({
+    sourceField: ['id'],
+    destField: ['teacherId'],
+    destSchema: teacherToClass,
+  }),
+  studentAccesses: many({
+    sourceField: ['id'],
+    destField: ['teacherId'],
+    destSchema: teacherStudentAccess,
+  }),
+  classAccesses: many({
+    sourceField: ['id'],
+    destField: ['teacherId'],
+    destSchema: teacherClassAccess,
+  }),
+}));
+
+const teacherToCoTeacherRelationships = relationships(
+  teacherToCoTeacher,
+  ({one}) => ({
+    fromTeacher: one({
+      sourceField: ['fromTeacherId'],
+      destField: ['id'],
+      destSchema: teacher,
+    }),
+    toTeacher: one({
+      sourceField: ['toTeacherId'],
+      destField: ['id'],
+      destSchema: teacher,
+    }),
+  }),
+);
+
+const klassRelationships = relationships(klass, ({one, many}) => ({
+  school: one({
+    sourceField: ['schoolId'],
+    destField: ['id'],
+    destSchema: school,
+  }),
+  teachers: many({
+    sourceField: ['id'],
+    destField: ['classId'],
+    destSchema: teacherToClass,
+  }),
+  memberships: many({
+    sourceField: ['id'],
+    destField: ['classId'],
+    destSchema: studentClassMembership,
+  }),
+  teacherClassAccesses: many({
+    sourceField: ['id'],
+    destField: ['classId'],
+    destSchema: teacherClassAccess,
+  }),
+}));
+
+const teacherToClassRelationships = relationships(teacherToClass, ({one}) => ({
+  teacher: one({
+    sourceField: ['teacherId'],
+    destField: ['id'],
+    destSchema: teacher,
+  }),
+  class: one({
+    sourceField: ['classId'],
+    destField: ['id'],
+    destSchema: klass,
+  }),
+}));
+
+const studentRelationships = relationships(student, ({many}) => ({
+  classes: many({
+    sourceField: ['id'],
+    destField: ['studentId'],
+    destSchema: studentClassMembership,
+  }),
+  teacherAccess: many({
+    sourceField: ['id'],
+    destField: ['studentId'],
+    destSchema: teacherStudentAccess,
+  }),
+}));
+
+const studentClassMembershipRelationships = relationships(
+  studentClassMembership,
+  ({one}) => ({
+    student: one({
+      sourceField: ['studentId'],
+      destField: ['id'],
+      destSchema: student,
+    }),
+    class: one({
+      sourceField: ['classId'],
+      destField: ['id'],
+      destSchema: klass,
+    }),
+  }),
+);
+
+const teacherStudentAccessRelationships = relationships(
+  teacherStudentAccess,
+  ({one}) => ({
+    teacher: one({
+      sourceField: ['teacherId'],
+      destField: ['id'],
+      destSchema: teacher,
+    }),
+    student: one({
+      sourceField: ['studentId'],
+      destField: ['id'],
+      destSchema: student,
+    }),
+  }),
+);
+
+const teacherClassAccessRelationships = relationships(
+  teacherClassAccess,
+  ({one}) => ({
+    teacher: one({
+      sourceField: ['teacherId'],
+      destField: ['id'],
+      destSchema: teacher,
+    }),
+    class: one({
+      sourceField: ['classId'],
+      destField: ['id'],
+      destSchema: klass,
+    }),
+  }),
+);
+
+export const schema = createSchema({
+  tables: [
+    district,
+    school,
+    teacher,
+    teacherToCoTeacher,
+    klass,
+    teacherToClass,
+    student,
+    studentClassMembership,
+    teacherStudentAccess,
+    teacherClassAccess,
+  ],
+  relationships: [
+    districtRelationships,
+    schoolRelationships,
+    teacherRelationships,
+    teacherToCoTeacherRelationships,
+    klassRelationships,
+    teacherToClassRelationships,
+    studentRelationships,
+    studentClassMembershipRelationships,
+    teacherStudentAccessRelationships,
+    teacherClassAccessRelationships,
+  ],
+});
+
+export const builder = createBuilder(schema);

--- a/packages/zql-integration-tests/src/school-access/school-access-profile.pg.test.ts
+++ b/packages/zql-integration-tests/src/school-access/school-access-profile.pg.test.ts
@@ -1,0 +1,346 @@
+/* oxlint-disable no-console */
+import {writeFileSync} from 'node:fs';
+import * as inspector from 'node:inspector';
+import {join} from 'node:path';
+import {describe, expect, test} from 'vitest';
+import type {AnyQuery, Query} from '../../../zql/src/query/query.ts';
+import '../helpers/comparePg.ts';
+import {bootstrap} from '../helpers/runner.ts';
+import {schema} from './schema.ts';
+import {generatePgContent, makeSeed, USER_ID} from './seed.ts';
+
+type Schema = typeof schema;
+
+/**
+ * CPU profile of the normalized OR + flipped-exists query at 8x topology
+ * (where the OR fan-out cost is most exposed). Captures a .cpuprofile via
+ * node:inspector and prints the top self-time hot spots inline so we can
+ * see at a glance where IVM dispatch time is going. The .cpuprofile is
+ * written to /tmp for opening in Chrome DevTools (chrome://inspect →
+ * "Open dedicated DevTools for Node" → Performance → "Load profile…").
+ */
+
+const PROFILE_TOPOLOGY_SCALE = 8;
+const ITERATIONS = 200;
+
+function buildNormalizedQuery(
+  q: Query<'student', Schema>,
+): Query<'student', Schema> {
+  return q.whereExists(
+    'classes',
+    sc =>
+      sc.whereExists(
+        'class',
+        c =>
+          c.where(({or, exists}) =>
+            or(
+              exists(
+                'teachers',
+                tc =>
+                  tc.whereExists(
+                    'teacher',
+                    t => t.where('userId', '=', USER_ID),
+                    {flip: true, scalar: true},
+                  ),
+                {flip: true},
+              ),
+              exists(
+                'teachers',
+                tc =>
+                  tc.whereExists(
+                    'teacher',
+                    t =>
+                      t.whereExists(
+                        'coTeacherGrants',
+                        g =>
+                          g.whereExists(
+                            'toTeacher',
+                            co => co.where('userId', '=', USER_ID),
+                            {flip: true, scalar: true},
+                          ),
+                        {flip: true},
+                      ),
+                    {flip: true},
+                  ),
+                {flip: true},
+              ),
+              exists(
+                'teachers',
+                tc =>
+                  tc.whereExists(
+                    'teacher',
+                    t =>
+                      t.whereExists(
+                        'school',
+                        s =>
+                          s.whereExists(
+                            'teachers',
+                            st =>
+                              st.where(({and, cmp}) =>
+                                and(
+                                  cmp('userId', '=', USER_ID),
+                                  cmp('role', '=', 'school-administrator'),
+                                ),
+                              ),
+                            {flip: true, scalar: true},
+                          ),
+                        {flip: true},
+                      ),
+                    {flip: true},
+                  ),
+                {flip: true},
+              ),
+              exists(
+                'teachers',
+                tc =>
+                  tc.whereExists(
+                    'teacher',
+                    t =>
+                      t.whereExists(
+                        'school',
+                        s =>
+                          s.whereExists(
+                            'group',
+                            g =>
+                              g.whereExists(
+                                'schools',
+                                ds =>
+                                  ds.whereExists(
+                                    'teachers',
+                                    dt =>
+                                      dt.where(({and, cmp}) =>
+                                        and(
+                                          cmp('userId', '=', USER_ID),
+                                          cmp('role', '=', 'administrator'),
+                                        ),
+                                      ),
+                                    {flip: true, scalar: true},
+                                  ),
+                                {flip: true},
+                              ),
+                            {flip: true},
+                          ),
+                        {flip: true},
+                      ),
+                    {flip: true},
+                  ),
+                {flip: true},
+              ),
+            ),
+          ),
+        {flip: true},
+      ),
+    {flip: true},
+  );
+}
+
+function buildClassAccessQuery(
+  q: Query<'student', Schema>,
+): Query<'student', Schema> {
+  return q.whereExists(
+    'classes',
+    sc =>
+      sc.whereExists(
+        'class',
+        c =>
+          c.whereExists(
+            'teacherClassAccesses',
+            tca =>
+              tca.whereExists('teacher', t => t.where('userId', '=', USER_ID), {
+                flip: true,
+                scalar: true,
+              }),
+            {flip: true},
+          ),
+        {flip: true},
+      ),
+    {flip: true},
+  );
+}
+
+type CpuProfileNode = {
+  id: number;
+  callFrame: {
+    functionName: string;
+    scriptId: string;
+    url: string;
+    lineNumber: number;
+    columnNumber: number;
+  };
+  hitCount?: number;
+  children?: number[];
+};
+
+type CpuProfile = {
+  nodes: CpuProfileNode[];
+  startTime: number;
+  endTime: number;
+  samples?: number[];
+  timeDeltas?: number[];
+};
+
+async function captureProfile<T>(fn: () => Promise<T> | T): Promise<{
+  result: T;
+  profile: CpuProfile;
+  elapsedMs: number;
+}> {
+  const session = new inspector.Session();
+  session.connect();
+
+  const post = <U>(method: string, params?: object): Promise<U> =>
+    new Promise((resolve, reject) => {
+      session.post(method, params ?? {}, (err, value) => {
+        if (err) reject(err);
+        else resolve(value as U);
+      });
+    });
+
+  await post('Profiler.enable');
+  // 100us sampling — finer than default (1ms) so short pipeline ops aren't lost.
+  await post('Profiler.setSamplingInterval', {interval: 100});
+  await post('Profiler.start');
+
+  const start = performance.now();
+  const result = await fn();
+  const elapsedMs = performance.now() - start;
+
+  const {profile} = await post<{profile: CpuProfile}>('Profiler.stop');
+  session.disconnect();
+
+  return {result, profile, elapsedMs};
+}
+
+type HotEntry = {
+  fn: string;
+  url: string;
+  hits: number;
+  selfMs: number;
+};
+
+function topHotFrames(
+  profile: CpuProfile,
+  topN: number,
+  filter?: (n: CpuProfileNode) => boolean,
+): HotEntry[] {
+  const totalHits = profile.nodes.reduce(
+    (acc, n) => acc + (n.hitCount ?? 0),
+    0,
+  );
+  const totalElapsedMs = (profile.endTime - profile.startTime) / 1000;
+
+  const entries: HotEntry[] = [];
+  for (const n of profile.nodes) {
+    const hits = n.hitCount ?? 0;
+    if (hits === 0) continue;
+    if (filter && !filter(n)) continue;
+    const selfMs = (hits / totalHits) * totalElapsedMs;
+    const fn = n.callFrame.functionName || '(anonymous)';
+    const url = n.callFrame.url;
+    entries.push({fn, url, hits, selfMs});
+  }
+  entries.sort((a, b) => b.selfMs - a.selfMs);
+  return entries.slice(0, topN);
+}
+
+function shortenUrl(url: string): string {
+  if (!url) return '(native)';
+  const i = url.indexOf('/packages/');
+  return i >= 0 ? url.slice(i + 1) : url;
+}
+
+function logHot(label: string, entries: HotEntry[]) {
+  console.log(`\n=== ${label} (top ${entries.length} self-time frames) ===`);
+  console.log(
+    'self ms'.padStart(8) +
+      '  hits'.padStart(8) +
+      '  ' +
+      'function'.padEnd(40) +
+      '  source',
+  );
+  for (const e of entries) {
+    console.log(
+      e.selfMs.toFixed(2).padStart(8) +
+        '  ' +
+        e.hits.toString().padStart(6) +
+        '  ' +
+        e.fn.slice(0, 40).padEnd(40) +
+        '  ' +
+        shortenUrl(e.url),
+    );
+  }
+}
+
+// Gated on PROFILE=1 so CI doesn't burn time generating .cpuprofile files.
+//   PROFILE=1 npm --workspace=zql-integration-tests run test -- \
+//     --project=zero-cache/pg-18 school-access-profile
+describe.skipIf(!process.env.PROFILE)(
+  'school access — CPU profile (normalized vs class-access denorm)',
+  {timeout: 600_000},
+  () => {
+    test(`profile both shapes at ${PROFILE_TOPOLOGY_SCALE}x topology`, async () => {
+      const seed = makeSeed({
+        studentScale: 1,
+        topologyScale: PROFILE_TOPOLOGY_SCALE,
+      });
+      const harness = await bootstrap({
+        suiteName: `school_access_profile_${PROFILE_TOPOLOGY_SCALE}x`,
+        zqlSchema: schema,
+        pgContent: generatePgContent(seed),
+      });
+
+      const normalizedQ = buildNormalizedQuery(harness.queries.student)
+        .orderBy('id', 'asc')
+        .limit(500);
+      const classDenormQ = buildClassAccessQuery(harness.queries.student)
+        .orderBy('id', 'asc')
+        .limit(500);
+
+      // Warm-up so we don't profile JIT compilation.
+      for (let i = 0; i < 5; i++) {
+        await harness.delegates.sqlite.run(normalizedQ);
+        await harness.delegates.sqlite.run(classDenormQ);
+      }
+
+      async function hammer(q: AnyQuery, label: string) {
+        const {profile, elapsedMs} = await captureProfile(() => {
+          for (let i = 0; i < ITERATIONS; i++) {
+            const view = harness.delegates.sqlite.materialize(q);
+            view.destroy();
+          }
+        });
+
+        const outPath = join('/tmp', `school-access-${label}.cpuprofile`);
+        writeFileSync(outPath, JSON.stringify(profile));
+        console.log(
+          `\n[${label}] ${ITERATIONS} iters in ${elapsedMs.toFixed(
+            1,
+          )}ms  (${(elapsedMs / ITERATIONS).toFixed(2)} ms/iter)  → ${outPath}`,
+        );
+
+        // All frames
+        logHot(`${label} — all frames`, topHotFrames(profile, 20));
+
+        // Frames in our packages (drops node internals + GC + native)
+        logHot(
+          `${label} — packages/* only`,
+          topHotFrames(profile, 20, n =>
+            (n.callFrame.url ?? '').includes('/packages/'),
+          ),
+        );
+
+        // Frames in the IVM operator code specifically
+        logHot(
+          `${label} — packages/zql/src/ivm`,
+          topHotFrames(profile, 15, n =>
+            (n.callFrame.url ?? '').includes('/packages/zql/src/ivm/'),
+          ),
+        );
+      }
+
+      await hammer(normalizedQ, 'normalized');
+      await hammer(classDenormQ, 'classDenorm');
+
+      expect(true).toBe(true); // primary signal is the log + .cpuprofile
+    });
+  },
+);

--- a/packages/zql-integration-tests/src/school-access/seed.ts
+++ b/packages/zql-integration-tests/src/school-access/seed.ts
@@ -1,0 +1,308 @@
+/**
+ * Generates a deterministic dataset that mirrors the customer's profile.
+ *
+ * The shape is deliberately built so that THREE of the four OR branches in
+ * the normalized access query stay live at runtime, each producing matches
+ * for every (student, class) membership. This is what stresses the OR
+ * fan-out: every membership row gets evaluated against three independent
+ * flipped-exists pipelines.
+ *
+ *   - 1 district, 1 school
+ *   - 32 teachers at the school (31 regular + 1 school-administrator).
+ *     The 1 admin is the requesting user.
+ *   - 29 classes
+ *   - teacher_to_class:
+ *       - 29 rows for the 29 regular teachers (1:1 teacher → class)
+ *       - 29 rows for the admin (admin teaches every class) → DIRECT branch
+ *         resolves to admin and matches every class.
+ *   - teacher_to_co_teacher:
+ *       - 29 rows: each of the 29 teaching teachers grants admin co-teacher
+ *         access → CO_TEACHER branch resolves to admin and matches every
+ *         class via the granter's teacher_to_class.
+ *   - school-admin role is held by admin → SCHOOL_ADMIN branch matches.
+ *   - DISTRICT_ADMIN: dead. The scalar (user_id=USER, role='administrator')
+ *     resolves to no row, so the branch is compiled out — admin holds the
+ *     school-administrator role, not administrator. Matches the customer's
+ *     reported plan, where one of the role-scoped branches dies.
+ *   - `numStudents` students, `numStudents * membershipsPerStudent` total
+ *     student_class_membership rows.
+ *   - 1 teacher_student_access row per membership for the denorm shape.
+ */
+
+export const USER_ID = 'user-admin-1';
+
+export const BASE_SEED = {
+  baseNumClasses: 29,
+  // numTeachers is derived: numClasses + 2 non-teaching + 1 admin
+  baseNumStudents: 564,
+  membershipsPerStudent: 2,
+  adminTeacherId: 9999,
+  districtId: 1,
+  schoolId: 1,
+} as const;
+
+export type Seed = {
+  numTeachers: number;
+  numClasses: number;
+  numStudents: number;
+  membershipsPerStudent: number;
+  adminTeacherId: number;
+  districtId: number;
+  schoolId: number;
+};
+
+export type ScaleOptions = {
+  /** Multiplier on numStudents (and proportional memberships/access). */
+  studentScale?: number;
+  /**
+   * Multiplier on numClasses and numTeachers (school topology). The
+   * normalized OR branches do work proportional to school topology, not to
+   * student data, so this is the axis that should grow the norm/denorm
+   * ratio if our hypothesis is right.
+   */
+  topologyScale?: number;
+};
+
+export function makeSeed(opts: number | ScaleOptions = 1): Seed {
+  const studentScale =
+    typeof opts === 'number' ? opts : (opts.studentScale ?? 1);
+  const topologyScale =
+    typeof opts === 'number' ? 1 : (opts.topologyScale ?? 1);
+
+  const numClasses = BASE_SEED.baseNumClasses * topologyScale;
+  // numTeachers = numClasses (each teaches 1 class) + 2 non-teaching + 1 admin
+  const numTeachers = numClasses + 3;
+
+  return {
+    numTeachers,
+    numClasses,
+    numStudents: BASE_SEED.baseNumStudents * studentScale,
+    membershipsPerStudent: BASE_SEED.membershipsPerStudent,
+    adminTeacherId: BASE_SEED.adminTeacherId,
+    districtId: BASE_SEED.districtId,
+    schoolId: BASE_SEED.schoolId,
+  };
+}
+
+// Backwards-compatible default (scale = 1 on both axes) used by the original test.
+export const SEED: Seed = makeSeed(1);
+
+export const DDL = /* sql */ `
+CREATE TABLE district (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL
+);
+
+CREATE TABLE school (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL,
+  district_id INTEGER NOT NULL
+);
+CREATE INDEX school_district_id_idx ON school (district_id);
+
+CREATE TABLE teacher (
+  id INTEGER PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  role TEXT NOT NULL,
+  school_id INTEGER NOT NULL
+);
+CREATE UNIQUE INDEX teacher_user_id_unique ON teacher (user_id);
+CREATE INDEX teacher_school_id_idx ON teacher (school_id);
+
+CREATE TABLE teacher_to_co_teacher (
+  id INTEGER PRIMARY KEY,
+  from_teacher_id INTEGER NOT NULL,
+  to_teacher_id INTEGER NOT NULL
+);
+CREATE INDEX teacher_to_co_teacher_from_idx ON teacher_to_co_teacher (from_teacher_id);
+CREATE INDEX teacher_to_co_teacher_to_idx ON teacher_to_co_teacher (to_teacher_id);
+
+CREATE TABLE class (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL,
+  school_id INTEGER NOT NULL
+);
+CREATE INDEX class_school_id_idx ON class (school_id);
+
+CREATE TABLE teacher_to_class (
+  id INTEGER PRIMARY KEY,
+  teacher_id INTEGER NOT NULL,
+  class_id INTEGER NOT NULL
+);
+CREATE INDEX teacher_to_class_teacher_id_idx ON teacher_to_class (teacher_id);
+CREATE INDEX teacher_to_class_class_id_idx ON teacher_to_class (class_id);
+
+CREATE TABLE student (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL
+);
+
+CREATE TABLE student_class_membership (
+  id INTEGER PRIMARY KEY,
+  student_id INTEGER NOT NULL,
+  class_id INTEGER NOT NULL
+);
+CREATE INDEX student_class_membership_student_id_idx ON student_class_membership (student_id);
+CREATE INDEX student_class_membership_class_id_idx ON student_class_membership (class_id);
+
+CREATE TABLE teacher_student_access (
+  id INTEGER PRIMARY KEY,
+  teacher_id INTEGER NOT NULL,
+  student_id INTEGER NOT NULL
+);
+CREATE INDEX teacher_student_access_teacher_id_idx ON teacher_student_access (teacher_id);
+CREATE INDEX teacher_student_access_student_id_idx ON teacher_student_access (student_id);
+
+CREATE TABLE teacher_class_access (
+  id INTEGER PRIMARY KEY,
+  teacher_id INTEGER NOT NULL,
+  class_id INTEGER NOT NULL
+);
+CREATE INDEX teacher_class_access_teacher_id_idx ON teacher_class_access (teacher_id);
+CREATE INDEX teacher_class_access_class_id_idx ON teacher_class_access (class_id);
+`;
+
+export function generateInserts(seed: Seed = SEED): string {
+  const lines: string[] = [];
+  const {
+    numTeachers,
+    numClasses,
+    numStudents,
+    membershipsPerStudent,
+    adminTeacherId,
+    districtId,
+    schoolId,
+  } = seed;
+
+  lines.push(`INSERT INTO district VALUES (${districtId}, 'District 1');`);
+  lines.push(
+    `INSERT INTO school VALUES (${schoolId}, 'School 1', ${districtId});`,
+  );
+
+  // 31 regular teachers
+  const regularTeachers = numTeachers - 1;
+  const teacherValues: string[] = [];
+  for (let i = 1; i <= regularTeachers; i++) {
+    teacherValues.push(`(${i}, 'teacher-user-${i}', 'teacher', ${schoolId})`);
+  }
+  // 1 admin (the requester)
+  teacherValues.push(
+    `(${adminTeacherId}, '${USER_ID}', 'school-administrator', ${schoolId})`,
+  );
+  lines.push(
+    `INSERT INTO teacher (id, user_id, role, school_id) VALUES ${teacherValues.join(
+      ',\n  ',
+    )};`,
+  );
+
+  // 29 classes
+  const classValues: string[] = [];
+  for (let i = 1; i <= numClasses; i++) {
+    classValues.push(`(${i}, 'Class ${i}', ${schoolId})`);
+  }
+  lines.push(
+    `INSERT INTO class (id, name, school_id) VALUES ${classValues.join(
+      ',\n  ',
+    )};`,
+  );
+
+  // teacher_to_class:
+  //   - 1 row per regular teacher i in [1..numClasses]
+  //   - 1 row per admin per class (admin teaches every class) — keeps the
+  //     DIRECT branch live at runtime.
+  const tcValues: string[] = [];
+  let tcId = 1;
+  for (let i = 1; i <= numClasses; i++) {
+    tcValues.push(`(${tcId++}, ${i}, ${i})`);
+  }
+  for (let i = 1; i <= numClasses; i++) {
+    tcValues.push(`(${tcId++}, ${adminTeacherId}, ${i})`);
+  }
+  lines.push(
+    `INSERT INTO teacher_to_class (id, teacher_id, class_id) VALUES ${tcValues.join(
+      ',\n  ',
+    )};`,
+  );
+
+  // teacher_to_co_teacher: each of the 29 teaching regular teachers grants
+  // admin co-teacher access. Keeps the CO_TEACHER branch live at runtime —
+  // it walks back from admin to all granting teachers and from each granter
+  // to their classes.
+  const cotValues: string[] = [];
+  for (let i = 1; i <= numClasses; i++) {
+    cotValues.push(`(${i}, ${i}, ${adminTeacherId})`);
+  }
+  lines.push(
+    `INSERT INTO teacher_to_co_teacher (id, from_teacher_id, to_teacher_id) VALUES ${cotValues.join(
+      ',\n  ',
+    )};`,
+  );
+
+  // students
+  const studentValues: string[] = [];
+  for (let s = 1; s <= numStudents; s++) {
+    studentValues.push(`(${s}, 'Student ${s}')`);
+  }
+  lines.push(
+    `INSERT INTO student (id, name) VALUES ${studentValues.join(',\n  ')};`,
+  );
+
+  // memberships: each student in `membershipsPerStudent` classes
+  const membershipValues: string[] = [];
+  let membershipId = 1;
+  for (let s = 1; s <= numStudents; s++) {
+    for (let m = 0; m < membershipsPerStudent; m++) {
+      // Deterministic spread across classes
+      const classId = ((s + m * 7) % numClasses) + 1;
+      membershipValues.push(`(${membershipId++}, ${s}, ${classId})`);
+    }
+  }
+  lines.push(
+    `INSERT INTO student_class_membership (id, student_id, class_id) VALUES ${membershipValues.join(
+      ',\n  ',
+    )};`,
+  );
+
+  // teacher_student_access for the admin: 1 row per membership.
+  // Admin sees every student-class pair at the school.
+  const accessValues: string[] = [];
+  let accessId = 1;
+  for (let s = 1; s <= numStudents; s++) {
+    for (let m = 0; m < membershipsPerStudent; m++) {
+      accessValues.push(`(${accessId++}, ${adminTeacherId}, ${s})`);
+    }
+  }
+  lines.push(
+    `INSERT INTO teacher_student_access (id, teacher_id, student_id) VALUES ${accessValues.join(
+      ',\n  ',
+    )};`,
+  );
+
+  // teacher_class_access (smaller denorm): 1 row per (teacher_with_access,
+  // class). For our admin, that's 1 row per class. Plus 1 row per regular
+  // teaching teacher × the class they teach (direct access). The customer's
+  // real maintenance trigger would also write rows for co-teacher grants
+  // (granter's classes propagate to grantees) but for our query the admin
+  // already has access via school-admin so we don't need separate rows.
+  const tcaValues: string[] = [];
+  let tcaId = 1;
+  // Admin's class access: every class.
+  for (let i = 1; i <= numClasses; i++) {
+    tcaValues.push(`(${tcaId++}, ${adminTeacherId}, ${i})`);
+  }
+  // Each regular teacher's class access (direct): 1 row per class they teach.
+  for (let i = 1; i <= numClasses; i++) {
+    tcaValues.push(`(${tcaId++}, ${i}, ${i})`);
+  }
+  lines.push(
+    `INSERT INTO teacher_class_access (id, teacher_id, class_id) VALUES ${tcaValues.join(
+      ',\n  ',
+    )};`,
+  );
+
+  return lines.join('\n');
+}
+
+export function generatePgContent(seed: Seed = SEED): string {
+  return `${DDL}\n${generateInserts(seed)}\n`;
+}


### PR DESCRIPTION
Minimal infrastructure to demonstrate the flipped-join speedup. The profile test materializes a normalized OR + flipped-exists query against a school dataset (admin user reading a student list with many classes), captures a node:inspector .cpuprofile to /tmp, and prints the top self-time hot frames.

Gated on PROFILE=1 so CI doesn't burn time generating profiles. Run with:

```
PROFILE=1 npm --workspace=zql-integration-tests run test -- \
  --project=zero-cache/pg-18 school-access-profile
```

Useful pattern for future debugging of query performance issues.

Follow up PRs use this to increase `FlippedJoin` speed by 6x on the generated dataset.

Example output:

```
[normalized] 200 iters in 7977.5ms  (39.89 ms/iter)  → /tmp/school-access-normalized.cpuprofile

=== normalized — all frames (top 20 self-time frames) ===
 self ms    hits  function                                  source
  427.38    3331  next                                      (native)
  325.63    2538  #fetchMergeSort                           packages/zql/src/ivm/flipped-join.ts
  283.55    2210  fetch                                     packages/zql/src/ivm/flipped-join.ts
  244.03    1902  next                                      (native)
  206.44    1609  next                                      (native)
  199.25    1553  next                                      (native)
  185.14    1443  next                                      (native)
  177.83    1386  (garbage collector)                       (native)
  153.83    1199  #fetchMergeSort                           packages/zql/src/ivm/flipped-join.ts
  131.38    1024  fetch                                     packages/zql/src/ivm/flipped-join.ts
  114.96     896  #fetchMergeSort                           packages/zql/src/ivm/flipped-join.ts
  112.52     877  next                                      (native)
   93.15     726  next                                      (native)
   91.22     711  next                                      (native)
   89.81     700  next                                      packages/zqlite/src/db.ts
   86.60     675  next                                      packages/zqlite/src/db.ts
   82.50     643  (program)                                 (native)
   77.37     603  fetch                                     packages/zql/src/ivm/flipped-join.ts
   69.67     543  (anonymous)                               packages/zqlite/src/internal/sql.ts
   66.97     522  next                                      packages/zqlite/src/db.ts

=== normalized — packages/* only (top 20 self-time frames) ===
 self ms    hits  function                                  source
  325.63    2538  #fetchMergeSort                           packages/zql/src/ivm/flipped-join.ts
  283.55    2210  fetch                                     packages/zql/src/ivm/flipped-join.ts
  153.83    1199  #fetchMergeSort                           packages/zql/src/ivm/flipped-join.ts
  131.38    1024  fetch                                     packages/zql/src/ivm/flipped-join.ts
  114.96     896  #fetchMergeSort                           packages/zql/src/ivm/flipped-join.ts
   89.81     700  next                                      packages/zqlite/src/db.ts
   86.60     675  next                                      packages/zqlite/src/db.ts
   77.37     603  fetch                                     packages/zql/src/ivm/flipped-join.ts
   69.67     543  (anonymous)                               packages/zqlite/src/internal/sql.ts
   66.97     522  next                                      packages/zqlite/src/db.ts
   58.38     455  next                                      packages/zqlite/src/db.ts
   58.25     454  #fetchMergeSort                           packages/zql/src/ivm/flipped-join.ts
   56.32     439  (anonymous)                               packages/zqlite/src/internal/sql.ts
   53.89     420  get                                       packages/zqlite/src/internal/statement-cache.ts
   53.25     415  normalizeWhitespace                       packages/zqlite/src/internal/statement-cache.ts
   48.11     375  get                                       packages/zqlite/src/internal/statement-cache.ts
   44.39     346  #fetchQuicksort                           packages/zql/src/ivm/flipped-join.ts
   42.08     328  buildSelectQuery                          packages/zqlite/src/query-builder.ts
   39.26     306  next                                      packages/zqlite/src/db.ts
   38.49     300  next                                      packages/zqlite/src/db.ts

=== normalized — packages/zql/src/ivm (top 15 self-time frames) ===
 self ms    hits  function                                  source
  325.63    2538  #fetchMergeSort                           packages/zql/src/ivm/flipped-join.ts
  283.55    2210  fetch                                     packages/zql/src/ivm/flipped-join.ts
  153.83    1199  #fetchMergeSort                           packages/zql/src/ivm/flipped-join.ts
  131.38    1024  fetch                                     packages/zql/src/ivm/flipped-join.ts
  114.96     896  #fetchMergeSort                           packages/zql/src/ivm/flipped-join.ts
   77.37     603  fetch                                     packages/zql/src/ivm/flipped-join.ts
   58.25     454  #fetchMergeSort                           packages/zql/src/ivm/flipped-join.ts
   44.39     346  #fetchQuicksort                           packages/zql/src/ivm/flipped-join.ts
   34.00     265  fetch                                     packages/zql/src/ivm/flipped-join.ts
   32.85     256  #fetchQuicksort                           packages/zql/src/ivm/flipped-join.ts
   29.25     228  #yieldParentWithOverlay                   packages/zql/src/ivm/flipped-join.ts
   23.61     184  #yieldParentWithOverlay                   packages/zql/src/ivm/flipped-join.ts
   18.73     146  #yieldParentWithOverlay                   packages/zql/src/ivm/flipped-join.ts
   18.22     142  generateWithOverlayInner                  packages/zql/src/ivm/memory-source.ts
   17.19     134  #fetchQuicksort                           packages/zql/src/ivm/flipped-join.ts
```