### PR TITLE
[codex] Preserve original IVM advance errors

### DIFF
--- a/packages/zero-client/src/client/ivm-branch.test.ts
+++ b/packages/zero-client/src/client/ivm-branch.test.ts
@@ -13,6 +13,7 @@ import {
 import {initFromStore, IVMSourceBranch} from './ivm-branch.ts';
 
 import type {FrozenJSONValue} from '../../../replicache/src/frozen-json.ts';
+import type {Hash} from '../../../replicache/src/hash.ts';
 import type {Diff} from '../../../replicache/src/sync/patch.ts';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
 import type {Node} from '../../../zql/src/ivm/data.ts';
@@ -390,6 +391,59 @@ describe('advance', () => {
           .fetch({}),
       ]).toEqual(expected);
     });
+  });
+
+  test('poisons the branch with the original error when advance fails', async () => {
+    const {dagStore} = await createDb([], timestamp++);
+    const branch = new IVMSourceBranch({
+      users: {
+        name: 'users',
+        columns: {
+          id: {type: 'string'},
+          name: {type: 'string'},
+        },
+        primaryKey: ['id'],
+      },
+    });
+
+    let originalError: unknown;
+    try {
+      branch.advance(undefined, 'head1' as Hash, [
+        {
+          op: 'add',
+          key: `${ENTITIES_KEY_PREFIX}users/u1`,
+          newValue: {id: 'u1', name: 'Alice'},
+        },
+        {
+          op: 'add',
+          key: `${ENTITIES_KEY_PREFIX}users/u1`,
+          newValue: {id: 'u1', name: 'Alice'},
+        },
+      ]);
+    } catch (e) {
+      originalError = e;
+    }
+
+    expect(originalError).toBeInstanceOf(Error);
+    expect(String(originalError)).toContain('Row already exists');
+
+    try {
+      branch.advance('head1' as Hash, 'head2' as Hash, []);
+      expect.fail('Expected poisoned branch advance to throw');
+    } catch (e) {
+      expect(e).toBe(originalError);
+    }
+
+    try {
+      branch.getSource('users');
+      expect.fail('Expected poisoned branch getSource to throw');
+    } catch (e) {
+      expect(e).toBe(originalError);
+    }
+
+    await expect(branch.forkToHead(dagStore, 'head2' as Hash)).rejects.toBe(
+      originalError,
+    );
   });
 });
 

--- a/packages/zero-client/src/client/ivm-branch.ts
+++ b/packages/zero-client/src/client/ivm-branch.ts
@@ -46,6 +46,7 @@ import {
 export class IVMSourceBranch {
   readonly #sources: Map<string, MemorySource | undefined>;
   readonly #tables: Record<string, TableSchema>;
+  #advanceError: unknown;
   hash: Hash | undefined;
 
   constructor(
@@ -59,6 +60,8 @@ export class IVMSourceBranch {
   }
 
   getSource(name: string): MemorySource | undefined {
+    this.#throwIfInvalid();
+
     if (this.#sources.has(name)) {
       return this.#sources.get(name);
     }
@@ -75,19 +78,33 @@ export class IVMSourceBranch {
     this.#sources.clear();
   }
 
+  #throwIfInvalid() {
+    if (this.#advanceError) {
+      throw this.#advanceError;
+    }
+  }
+
   /**
    * Mutates the current branch, advancing it to the new head
    * by applying the given diffs.
    */
   advance(expectedHead: Hash | undefined, newHead: Hash, diffs: NoIndexDiff) {
+    this.#throwIfInvalid();
+
     assert(
       this.hash === expectedHead,
       () =>
         `Expected head must match the main head. Got: ${this.hash}, expected: ${expectedHead}`,
     );
 
-    applyDiffs(diffs, this);
-    this.hash = newHead;
+    try {
+      applyDiffs(diffs, this);
+      this.hash = newHead;
+    } catch (e) {
+      this.#advanceError = e;
+      this.clear();
+      throw e;
+    }
   }
 
   /**
@@ -98,6 +115,8 @@ export class IVMSourceBranch {
     desiredHead: Hash,
     readOptions?: ZeroReadOptions,
   ): Promise<IVMSourceBranch> {
+    this.#throwIfInvalid();
+
     const fork = this.fork();
 
     if (fork.hash === desiredHead) {


### PR DESCRIPTION
## Summary
- poison an IVMSourceBranch after advance() throws so later branch access rethrows the original error
- clear detached source references after the first failed advance to avoid continuing through known-corrupt branch state
- add a regression test that forces a partial advance failure and verifies advance(), getSource(), and forkToHead() preserve the same error

## Why
We periodically get error reports from the field of "Row already exists" from the IVM system.

I saw one of these today in zbugs and it occurred after some other error put the client into error mode. I don't know what error the original one was, but it's clear that errors processing pokes can result in "Row not found" errors after because of the non-transactionality of IVMBranch: we can partially apply a poke, fail, then attempt again when refreshing from the perdag and get the same error.

Preserving the first error keeps the Zero instance in a stable failure mode and leaves the original crash site visible.
