### PR TITLE
feat(zql): add mergeSortedStreams k-way merge utility

### DIFF
--- a/packages/zql/src/ivm/memory-source.test.ts
+++ b/packages/zql/src/ivm/memory-source.test.ts
@@ -8,14 +8,17 @@ import {Catch} from './catch.ts';
 import {ChangeIndex} from './change-index.ts';
 import {ChangeType} from './change-type.ts';
 import type {Change} from './change.ts';
+import type {Node} from './data.ts';
 import {
   generateWithOverlayInner,
   generateWithOverlayInnerUnordered,
   generateWithOverlayUnordered,
   MemorySource,
+  mergeSortedStreams,
   overlaysForConstraintForTest,
   overlaysForStartAtForTest,
 } from './memory-source.ts';
+import type {Stream} from './stream.ts';
 import {consume} from './stream.ts';
 import {compareRowsTest} from './test/compare-rows-test.ts';
 import {createSource} from './test/source-factory.ts';
@@ -731,5 +734,219 @@ describe('generateWithOverlayUnordered', () => {
       ({row}) => row,
     );
     expect(actual).toEqual([{id: 2, s: 'b2', n: 225}, rows[0], rows[2]]);
+  });
+});
+
+describe('mergeSortedStreams', () => {
+  const node = (id: number): Node => ({row: {id}, relationships: {}});
+  const ids = (xs: Iterable<Node | 'yield'>): (number | 'yield')[] =>
+    Array.from(xs, x => (x === 'yield' ? 'yield' : (x.row.id as number)));
+  const byId = (a: Node, b: Node) =>
+    (a.row.id as number) - (b.row.id as number);
+
+  function* gen(values: readonly (Node | 'yield')[]): Stream<Node | 'yield'> {
+    for (const v of values) {
+      yield v;
+    }
+  }
+
+  test('no streams yields nothing', () => {
+    expect(ids(mergeSortedStreams([], byId))).toEqual([]);
+  });
+
+  test('single empty stream yields nothing', () => {
+    expect(ids(mergeSortedStreams([gen([])], byId))).toEqual([]);
+  });
+
+  test('all empty streams yields nothing', () => {
+    expect(ids(mergeSortedStreams([gen([]), gen([]), gen([])], byId))).toEqual(
+      [],
+    );
+  });
+
+  test('single non-empty stream is passed through in order', () => {
+    expect(
+      ids(mergeSortedStreams([gen([node(1), node(2), node(3)])], byId)),
+    ).toEqual([1, 2, 3]);
+  });
+
+  test('two streams are interleaved in compare order', () => {
+    const a = gen([node(1), node(3), node(5)]);
+    const b = gen([node(2), node(4), node(6)]);
+    expect(ids(mergeSortedStreams([a, b], byId))).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  test('three streams of varying lengths', () => {
+    const a = gen([node(1), node(10)]);
+    const b = gen([node(2), node(3), node(4), node(11)]);
+    const c = gen([node(5)]);
+    expect(ids(mergeSortedStreams([a, b, c], byId))).toEqual([
+      1, 2, 3, 4, 5, 10, 11,
+    ]);
+  });
+
+  test('one empty stream among non-empty merges correctly', () => {
+    const a = gen([node(1), node(3)]);
+    const empty = gen([]);
+    const c = gen([node(2), node(4)]);
+    expect(ids(mergeSortedStreams([a, empty, c], byId))).toEqual([1, 2, 3, 4]);
+  });
+
+  test('equal-key rows across streams are all emitted', () => {
+    const a = gen([node(1), node(2)]);
+    const b = gen([node(1), node(2)]);
+    const c = gen([node(2), node(3)]);
+    const out = ids(mergeSortedStreams([a, b, c], byId));
+    expect(out).toEqual([1, 1, 2, 2, 2, 3]);
+  });
+
+  test('reverse order via comparator', () => {
+    const a = gen([node(5), node(3), node(1)]);
+    const b = gen([node(6), node(4), node(2)]);
+    const reverse = (x: Node, y: Node) => byId(y, x);
+    expect(ids(mergeSortedStreams([a, b], reverse))).toEqual([
+      6, 5, 4, 3, 2, 1,
+    ]);
+  });
+
+  test("'yield' forwarded during priming", () => {
+    const a = gen(['yield', node(1), node(3)]);
+    const b = gen([node(2), node(4)]);
+    // Priming both iterators yields the 'yield' from `a`'s first slot
+    // before any Nodes are emitted.
+    expect(ids(mergeSortedStreams([a, b], byId))).toEqual([
+      'yield',
+      1,
+      2,
+      3,
+      4,
+    ]);
+  });
+
+  test("'yield' forwarded during advance", () => {
+    // After yielding node(1) the merge calls advance(0), which sees the
+    // 'yield' before node(3) and forwards it immediately — so the
+    // 'yield' lands between node(1) and node(2), not in id order.
+    const a = gen([node(1), 'yield', node(3)]);
+    const b = gen([node(2), node(4)]);
+    expect(ids(mergeSortedStreams([a, b], byId))).toEqual([
+      1,
+      'yield',
+      2,
+      3,
+      4,
+    ]);
+  });
+
+  test("multiple 'yield's between rows are all forwarded", () => {
+    const a = gen([node(1), 'yield', 'yield', node(3)]);
+    const b = gen([node(2)]);
+    expect(ids(mergeSortedStreams([a, b], byId))).toEqual([
+      1,
+      'yield',
+      'yield',
+      2,
+      3,
+    ]);
+  });
+
+  test('output preserves global sort invariant on randomized input', () => {
+    // Generate a few independently-sorted streams and assert the merged
+    // output is globally sorted. Keeps the test deterministic via a fixed
+    // shuffle.
+    const data = [3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8, 9, 7, 9, 3];
+    const buckets: number[][] = [[], [], [], []];
+    for (let i = 0; i < data.length; i++) {
+      buckets[i % buckets.length].push(data[i]);
+    }
+    const streams = buckets.map(b => gen(b.sort((x, y) => x - y).map(node)));
+    const out = ids(mergeSortedStreams(streams, byId)) as number[];
+    for (let i = 1; i < out.length; i++) {
+      expect(out[i]).toBeGreaterThanOrEqual(out[i - 1]);
+    }
+    expect(out.length).toBe(data.length);
+  });
+
+  test('.return() propagates to un-exhausted sub-iterators on early termination', () => {
+    // Build streams that record whether .return() was invoked.
+    const returned: boolean[] = [false, false, false];
+    const trackable = (i: number, values: readonly Node[]): Stream<Node> => ({
+      [Symbol.iterator]() {
+        let idx = 0;
+        return {
+          next() {
+            if (idx < values.length) {
+              return {value: values[idx++], done: false};
+            }
+            return {value: undefined, done: true};
+          },
+          return(v?: unknown) {
+            returned[i] = true;
+            return {value: v, done: true};
+          },
+          [Symbol.iterator]() {
+            return this;
+          },
+        };
+      },
+    });
+
+    const a = trackable(0, [node(1), node(4), node(7)]);
+    const b = trackable(1, [node(2), node(5), node(8)]);
+    const c = trackable(2, [node(3), node(6), node(9)]);
+
+    const merged = mergeSortedStreams([a, b, c], byId);
+    const it = merged[Symbol.iterator]();
+    // Pull a couple values then break — JS would call .return() under
+    // for-of `break`; we invoke explicitly.
+    expect(it.next().value).toEqual(node(1));
+    expect(it.next().value).toEqual(node(2));
+    it.return?.();
+
+    // All three sub-iterators still had un-yielded rows, so all should
+    // have been .return()-d via mergeSortedStreams's finally block.
+    expect(returned).toEqual([true, true, true]);
+  });
+
+  test('.return() not called on already-exhausted sub-iterators', () => {
+    let aReturned = false;
+    let bReturned = false;
+    const trackable = (
+      values: readonly Node[],
+      onReturn: () => void,
+    ): Stream<Node> => ({
+      [Symbol.iterator]() {
+        let idx = 0;
+        return {
+          next() {
+            if (idx < values.length) {
+              return {value: values[idx++], done: false};
+            }
+            return {value: undefined, done: true};
+          },
+          return(v?: unknown) {
+            onReturn();
+            return {value: v, done: true};
+          },
+          [Symbol.iterator]() {
+            return this;
+          },
+        };
+      },
+    });
+
+    // `a` will be drained; `b` will still have rows when we early-exit.
+    const a = trackable([node(1)], () => (aReturned = true));
+    const b = trackable([node(2), node(3), node(4)], () => (bReturned = true));
+
+    const it = mergeSortedStreams([a, b], byId)[Symbol.iterator]();
+    expect(it.next().value).toEqual(node(1)); // from a — exhausts a
+    expect(it.next().value).toEqual(node(2)); // from b
+    it.return?.();
+
+    // a was exhausted naturally; the merge marks heads[0]=null and skips
+    // .return() on it. b still had rows, so it must be .return()'d.
+    expect(aReturned).toBe(false);
+    expect(bReturned).toBe(true);
   });
 });

--- a/packages/zql/src/ivm/memory-source.ts
+++ b/packages/zql/src/ivm/memory-source.ts
@@ -917,3 +917,129 @@ export function stringify(change: SourceChange) {
     typeof v === 'bigint' ? v.toString() : v,
   );
 }
+
+/**
+ * N-way merge of pre-sorted Node streams. Each input stream must yield
+ * Nodes in `compare` order (and may interleave 'yield' values, which are
+ * forwarded as-is). The merged stream yields Nodes in `compare` order.
+ *
+ * Implemented as a binary min-heap keyed by `compare(entry.row, ...)`, so
+ * each emit costs O(log K) (K = number of streams) rather than the O(K)
+ * a linear-scan-of-heads merge would. Matters when FlippedJoin chunks a
+ * large `multiConstraints` IN-list into hundreds of sub-fetches.
+ *
+ * If the merged stream is closed early (e.g. downstream `Take` `break`s
+ * after hitting its limit, prompting JS to call `.return()` on this
+ * generator), the `finally` block propagates `.return()` to each
+ * non-exhausted sub-iterator so the underlying sources (SQLite cursors,
+ * etc.) can run their cleanup. Without this, mid-merge early-termination
+ * leaves cursors open, causing later writes on the same connection to
+ * fail with "database connection is busy executing a query".
+ */
+export function* mergeSortedStreams(
+  streams: readonly Stream<Node | 'yield'>[],
+  compare: (a: Node, b: Node) => number,
+): Stream<Node | 'yield'> {
+  const iterators: Iterator<Node | 'yield'>[] = streams.map(s =>
+    s[Symbol.iterator](),
+  );
+  // True while iterators[i] hasn't yet returned `done`. The finally
+  // block uses this to skip already-exhausted streams when propagating
+  // `.return()`.
+  const active: boolean[] = new Array(iterators.length).fill(true);
+
+  // Min-heap of entries; `idx` tells us which stream to refill from
+  // after the entry's row is emitted.
+  type Entry = {row: Node; idx: number};
+  const heap: Entry[] = [];
+
+  const siftUp = (start: number) => {
+    let i = start;
+    while (i > 0) {
+      const p = (i - 1) >> 1;
+      if (compare(heap[i].row, heap[p].row) >= 0) return;
+      const t = heap[i];
+      heap[i] = heap[p];
+      heap[p] = t;
+      i = p;
+    }
+  };
+
+  const siftDown = (start: number) => {
+    let i = start;
+    const n = heap.length;
+    while (true) {
+      const l = (i << 1) + 1;
+      const r = l + 1;
+      let smallest = i;
+      if (l < n && compare(heap[l].row, heap[smallest].row) < 0) smallest = l;
+      if (r < n && compare(heap[r].row, heap[smallest].row) < 0) smallest = r;
+      if (smallest === i) return;
+      const t = heap[i];
+      heap[i] = heap[smallest];
+      heap[smallest] = t;
+      i = smallest;
+    }
+  };
+
+  // Pull the next Node from iterator `idx`, forwarding any 'yield's.
+  // Returns the Node, or `undefined` once the stream is exhausted.
+  const pullNext = function* (
+    idx: number,
+  ): Generator<'yield', Node | undefined, undefined> {
+    while (true) {
+      const r = iterators[idx].next();
+      if (r.done) {
+        active[idx] = false;
+        return undefined;
+      }
+      if (r.value === 'yield') {
+        yield 'yield';
+        continue;
+      }
+      return r.value;
+    }
+  };
+
+  try {
+    // Prime: push the first row of each non-empty stream onto the heap.
+    for (let i = 0; i < iterators.length; i++) {
+      const row = yield* pullNext(i);
+      if (row !== undefined) {
+        heap.push({row, idx: i});
+        siftUp(heap.length - 1);
+      }
+    }
+
+    while (heap.length > 0) {
+      // Root is the global min across all active streams.
+      const top = heap[0];
+      yield top.row;
+      const next = yield* pullNext(top.idx);
+      if (next !== undefined) {
+        // Refill root in place (top === heap[0]) and sift down. The
+        // already-yielded `top.row` value is captured by the yield, so
+        // mutating it here doesn't affect what was emitted.
+        top.row = next;
+        siftDown(0);
+      } else {
+        // Stream exhausted. Move tail to root and shrink. Pop returns
+        // the last entry; if the heap had only one entry it was the
+        // root we just yielded, so we just leave the heap empty.
+        const last = must(heap.pop());
+        if (heap.length > 0) {
+          heap[0] = last;
+          siftDown(0);
+        }
+      }
+    }
+  } finally {
+    // Close any iterators that aren't already exhausted so their
+    // `finally` blocks (which release cursors / cached statements) run.
+    for (let i = 0; i < iterators.length; i++) {
+      if (active[i]) {
+        iterators[i].return?.();
+      }
+    }
+  }
+}


### PR DESCRIPTION
On the road to faster flip-join. In support of Goblins to speed up their "district admin viewing students" query (or, in the general case, any query that uses flipped-join).

The existing function that we use to merge streams does O(K) work for each row it emits. As in, each row compares against all other streams.

(K = num streams)

This adds a min-heap based merge so we do O(log K) work per row.

Very useful when a flip-join ends up having hundreds to thousands of unique children as each child is 1 stream.

Standalone for now; used in follow-up work.

Microbench

```
  ┌─────┬───────────────────────┐
  │  K  │ microbench            │
  ├─────┼───────────────────────|
  │  10 │                   tie │
  ├─────┼───────────────────────|
  │  40 │            27% faster │
  ├─────┼───────────────────────|
  │ 100 │            56% faster │
  ├─────┼───────────────────────|
  │ 200 │            70% faster │
  ├─────┼───────────────────────|
  │ 400 │            82% faster │
  └─────┴───────────────────────┘     
```