### PR TITLE
fix(zero-cache): limit websocket compression to sync clients

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.pg.test.ts
@@ -28,6 +28,7 @@ function createTestConfig(overrides?: Partial<ZeroConfig>) {
   return {
     websocketCompression: false,
     websocketCompressionOptions: undefined,
+    websocketMaxPayloadBytes: 10 * 1024 * 1024,
     ...overrides,
   } as ZeroConfig;
 }

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
@@ -62,25 +62,10 @@ export class ChangeStreamerHttpServer extends HttpService {
     backupMonitor: BackupMonitor | null,
   ) {
     super('change-streamer-http-server', lc, opts, async fastify => {
-      const websocketOptions: {perMessageDeflate?: boolean | object} = {};
-      if (config.websocketCompression) {
-        if (config.websocketCompressionOptions) {
-          try {
-            websocketOptions.perMessageDeflate = JSON.parse(
-              config.websocketCompressionOptions,
-            );
-          } catch (e) {
-            throw new Error(
-              `Failed to parse ZERO_WEBSOCKET_COMPRESSION_OPTIONS: ${String(e)}. Expected valid JSON.`,
-            );
-          }
-        } else {
-          websocketOptions.perMessageDeflate = true;
-        }
-      }
-
       await fastify.register(websocket, {
-        options: websocketOptions,
+        options: {
+          maxPayload: config.websocketMaxPayloadBytes,
+        },
       });
 
       fastify.get(CHANGES_PATH_PATTERN, {websocket: true}, this.#subscribe);


### PR DESCRIPTION
## Summary

This keeps `ZERO_WEBSOCKET_COMPRESSION` and `ZERO_WEBSOCKET_COMPRESSION_OPTIONS` scoped to client-facing sync websockets.

Replication/change-streamer websockets no longer negotiate per-message deflate, avoiding the CPU tradeoff on replication-manager -> view-syncer traffic. The replication websocket server still honors `ZERO_WEBSOCKET_MAX_PAYLOAD_BYTES` as an inbound message safety limit.

## Validation

- `npm --workspace=zero-cache run check-types`
- `npm --workspace=zero-cache run check-format`
- `npm --workspace=zero-cache run lint`

Note: PG tests were not run locally because the earlier attempt was blocked by no available container runtime strategy.
