### PR TITLE
fix(zero-cache): remove replication websocket max payload

### DIFF
--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -228,7 +228,6 @@ export default async function runWorker(
 
   const changeStreamerWebServer = new ChangeStreamerHttpServer(
     lc,
-    config,
     {port, keepaliveTimeoutMs, startupDelayMs},
     parent,
     changeStreamer,

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.pg.test.ts
@@ -5,7 +5,6 @@ import {beforeEach, describe, expect, type MockedFunction, vi} from 'vitest';
 import WebSocket from 'ws';
 import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
-import type {ZeroConfig} from '../../config/zero-config.ts';
 import {getConnectionURI, type PgTest, test} from '../../test/db.ts';
 import {type PostgresDB} from '../../types/pg.ts';
 import {inProcChannel} from '../../types/processes.ts';
@@ -23,15 +22,6 @@ import type {Downstream, SubscriberContext} from './change-streamer.ts';
 import {PROTOCOL_VERSION} from './change-streamer.ts';
 import {setupCDCTables} from './schema/tables.ts';
 import {type SnapshotMessage} from './snapshot.ts';
-
-function createTestConfig(overrides?: Partial<ZeroConfig>) {
-  return {
-    websocketCompression: false,
-    websocketCompressionOptions: undefined,
-    websocketMaxPayloadBytes: 10 * 1024 * 1024,
-    ...overrides,
-  } as ZeroConfig;
-}
 
 const SHARD_ID = {
   appID: 'foo',
@@ -104,7 +94,6 @@ describe('change-streamer/http', () => {
     // different behavior for ws.close().
     const server = new ChangeStreamerHttpServer(
       lc,
-      createTestConfig(),
       {port: 0, startupDelayMs: 10000, keepaliveTimeoutMs: undefined},
       parent,
       {
@@ -161,7 +150,6 @@ describe('change-streamer/http', () => {
     const service = resolver();
     const server = new ChangeStreamerHttpServer(
       lc,
-      createTestConfig(),
       {
         port: 0,
         startupDelayMs: 10000,

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
@@ -4,7 +4,6 @@ import type {LogContext} from '@rocicorp/logger';
 import WebSocket from 'ws';
 import {assert} from '../../../../shared/src/asserts.ts';
 import {must} from '../../../../shared/src/must.ts';
-import type {ZeroConfig} from '../../config/zero-config.ts';
 import type {IncomingMessageSubset} from '../../types/http.ts';
 import {pgClient, type PostgresDB} from '../../types/pg.ts';
 import {type Worker} from '../../types/processes.ts';
@@ -55,18 +54,13 @@ export class ChangeStreamerHttpServer extends HttpService {
 
   constructor(
     lc: LogContext,
-    config: ZeroConfig,
     opts: Options,
     parent: Worker,
     changeStreamer: ChangeStreamerService,
     backupMonitor: BackupMonitor | null,
   ) {
     super('change-streamer-http-server', lc, opts, async fastify => {
-      await fastify.register(websocket, {
-        options: {
-          maxPayload: config.websocketMaxPayloadBytes,
-        },
-      });
+      await fastify.register(websocket);
 
       fastify.get(CHANGES_PATH_PATTERN, {websocket: true}, this.#subscribe);
       fastify.get(


### PR DESCRIPTION
## Summary

Follow-up to #5919: keep the compression split, but do not apply websocket config to replication/change-streamer websockets.

The websocket compression and max-payload options are for untrusted client-facing websocket traffic. Replication-manager -> view-syncer traffic is internal, so the change-streamer websocket registration now goes back to the default `@fastify/websocket` options and `ChangeStreamerHttpServer` no longer accepts the unused config parameter.

## Validation

- `npm --workspace=zero-cache run check-types`
- `npm --workspace=zero-cache run check-format`
- `npm --workspace=zero-cache run lint`
