### PR TITLE
feat(zql): heap-based merge in #fetchMergeSort

### DIFF
--- a/packages/zql/src/ivm/flipped-join.fetch.test.ts
+++ b/packages/zql/src/ivm/flipped-join.fetch.test.ts
@@ -2352,6 +2352,119 @@ suite('fetch with compound primary key === parentKey (quicksort path)', () => {
   });
 });
 
+// Targets the merge-sort path specifically (#fetchMergeSort): parentKey
+// is non-unique on the parent, so #fetchQuicksort is bypassed and the
+// heap-based K-way merge is exercised. Other suites cover small K (1-2);
+// these scale K up and exercise reverse: true, which has no other
+// merge-sort coverage.
+suite('merge-sort path: large K and reverse', () => {
+  const base = {
+    columns: [
+      {id: {type: 'number'}, groupId: {type: 'number'}},
+      {id: {type: 'number'}, parentGroupId: {type: 'number'}},
+    ],
+    primaryKeys: [['id'], ['id']],
+    joins: [
+      {
+        parentKey: ['groupId'],
+        childKey: ['parentGroupId'],
+        relationshipName: 'children',
+      },
+    ],
+  } as const;
+
+  // Parent ids are assigned round-robin across groups so each per-group
+  // cursor's rows are interleaved with every other cursor's rows in the
+  // global id ordering. The heap has to compare-and-pop across all K
+  // streams throughout, not just within a contiguous run per cursor.
+  function makeParents(numGroups: number, perGroup: number): Row[] {
+    const out: Row[] = [];
+    for (let p = 0; p < perGroup; p++) {
+      for (let g = 0; g < numGroups; g++) {
+        out.push({id: p * numGroups + g, groupId: g});
+      }
+    }
+    return out;
+  }
+  function makeChildren(numGroups: number): Row[] {
+    return Array.from({length: numGroups}, (_, g) => ({
+      id: 1000 + g,
+      parentGroupId: g,
+    }));
+  }
+
+  test('reverse: true with K=2 streams emits parents in descending order', () => {
+    const results = fetchTest({
+      ...base,
+      sources: [makeParents(2, 3), makeChildren(2)],
+      fetchRequest: {reverse: true},
+    });
+
+    expect(
+      results.data.map(n => (n as CaughtNode & {row: Row}).row.id),
+    ).toEqual([5, 4, 3, 2, 1, 0]);
+  });
+
+  test('K=10 streams interleave correctly under heap merge (forward)', () => {
+    const results = fetchTest({
+      ...base,
+      sources: [makeParents(10, 5), makeChildren(10)],
+    });
+
+    expect(
+      results.data.map(n => (n as CaughtNode & {row: Row}).row.id),
+    ).toEqual(Array.from({length: 50}, (_, i) => i));
+  });
+
+  test('K=10 streams with reverse: true emit in descending order', () => {
+    const results = fetchTest({
+      ...base,
+      sources: [makeParents(10, 5), makeChildren(10)],
+      fetchRequest: {reverse: true},
+    });
+
+    expect(
+      results.data.map(n => (n as CaughtNode & {row: Row}).row.id),
+    ).toEqual(Array.from({length: 50}, (_, i) => 49 - i));
+  });
+
+  // Combines dedup-by-canonical-key with the heap merge: 80 child nodes
+  // collapse to K=20 unique cursors, each returning 5 parents. Verifies
+  // both the global ordering and that every emitted parent gets all four
+  // children sharing its groupId attached (dedup map → children).
+  test('K=20 with shared parent-keys exercises dedup → heap together', () => {
+    const numGroups = 20;
+    const perGroup = 5;
+    const childrenPerGroup = 4;
+    const parents = makeParents(numGroups, perGroup);
+    const children: Row[] = [];
+    for (let g = 0; g < numGroups; g++) {
+      for (let dup = 0; dup < childrenPerGroup; dup++) {
+        children.push({
+          id: 1000 + g * childrenPerGroup + dup,
+          parentGroupId: g,
+        });
+      }
+    }
+    const results = fetchTest({
+      ...base,
+      sources: [parents, children],
+    });
+
+    expect(
+      results.data.map(n => (n as CaughtNode & {row: Row}).row.id),
+    ).toEqual(Array.from({length: numGroups * perGroup}, (_, i) => i));
+
+    for (const node of results.data) {
+      const n = node as CaughtNode & {
+        row: Row;
+        relationships: Record<string, CaughtNode[]>;
+      };
+      expect(n.relationships.children).toHaveLength(childrenPerGroup);
+    }
+  });
+});
+
 function fetchTest(t: FetchTest): FetchTestResults {
   assert(t.sources.length > 0, 'Expected at least one source');
   assert(

--- a/packages/zql/src/ivm/flipped-join.ts
+++ b/packages/zql/src/ivm/flipped-join.ts
@@ -24,6 +24,7 @@ import {
   isJoinMatch,
   rowEqualsForCompoundKey,
 } from './join-utils.ts';
+import {mergeSortedStreams} from './memory-source.ts';
 import {
   throwOutput,
   type FetchRequest,
@@ -282,96 +283,38 @@ export class FlippedJoin implements Input {
       return;
     }
 
-    const parentIterators: Iterator<Node | 'yield'>[] = [];
-    let threw = false;
-    try {
-      for (const c of computedKeys) {
-        const stream = this.#parent.fetch({
-          ...req,
-          constraint: req.constraint ? {...req.constraint, ...c} : c,
-        });
-        parentIterators.push(stream[Symbol.iterator]());
-      }
-      const nextParentNodes: (Node | null)[] = [];
-      for (let i = 0; i < parentIterators.length; i++) {
-        const iter = parentIterators[i];
-        let result = iter.next();
-        // yield yields when initializing
-        while (!result.done && result.value === 'yield') {
-          yield result.value;
-          result = iter.next();
-        }
-        nextParentNodes[i] = result.done ? null : (result.value as Node);
-      }
+    const compareRows = this.#schema.compareRows;
+    const compare: (a: Node, b: Node) => number = req.reverse
+      ? (a, b) => compareRows(b.row, a.row)
+      : (a, b) => compareRows(a.row, b.row);
 
-      // Linear-scan K-way merge over per-unique-key cursors. Each cursor
-      // matches a distinct parent-key value, so the cursors return
-      // disjoint sets of parent rows and the merge sees no ties — every
-      // emit maps back to exactly one entry in childIndexesByKey.
-      while (true) {
-        let minIdx = -1;
-        let minParentNode: Node | null = null;
-        for (let i = 0; i < nextParentNodes.length; i++) {
-          const parentNode = nextParentNodes[i];
-          if (parentNode === null) {
-            continue;
-          }
-          if (
-            minParentNode === null ||
-            this.#schema.compareRows(parentNode.row, minParentNode.row) *
-              (req.reverse ? -1 : 1) <
-              0
-          ) {
-            minParentNode = parentNode;
-            minIdx = i;
-          }
-        }
-        if (minParentNode === null) {
-          return;
-        }
-        // Every fetched parent row matches the constraint for one entry
-        // in `computedKeys`, whose canonical key was inserted into the
-        // map — so the lookup is guaranteed to hit. Children retain
-        // their original input order within the group because we
-        // appended to the indexes array in iteration order.
-        const idxs = must(
-          childIndexesByKey.get(canonicalKey(minParentNode.row, parentKey)),
-        );
-        const relatedChildNodes: Node[] = idxs.map(i => childNodes[i]);
+    // One stream per unique parent-key value. Each stream returns its
+    // matching parent rows in compareRows order; the heap merges them
+    // into a globally ordered stream. Distinct rows can't compare equal
+    // (compareRows includes the primary key), so no tie handling needed
+    // — every emit maps back to exactly one entry in childIndexesByKey.
+    const streams: Stream<Node | 'yield'>[] = computedKeys.map(c =>
+      this.#parent.fetch({
+        ...req,
+        constraint: req.constraint ? {...req.constraint, ...c} : c,
+      }),
+    );
 
-        const iter = parentIterators[minIdx];
-        let result = iter.next();
-        // yield yields when advancing
-        while (!result.done && result.value === 'yield') {
-          yield result.value;
-          result = iter.next();
-        }
-        nextParentNodes[minIdx] = result.done ? null : (result.value as Node);
-
-        yield* this.#yieldParentWithOverlay(minParentNode, relatedChildNodes);
+    for (const node of mergeSortedStreams(streams, compare)) {
+      if (node === 'yield') {
+        yield 'yield';
+        continue;
       }
-    } catch (e) {
-      threw = true;
-      for (const iter of parentIterators) {
-        try {
-          iter.throw?.(e);
-        } catch (_cleanupError) {
-          // error in the iter.throw cleanup,
-          // catch so other iterators are cleaned up
-        }
-      }
-      throw e;
-    } finally {
-      if (!threw) {
-        for (const iter of parentIterators) {
-          try {
-            iter.return?.();
-          } catch (_cleanupError) {
-            // error in the iter.return cleanup,
-            // catch so other iterators are cleaned up
-          }
-        }
-      }
+      // Every fetched parent row matches the constraint for one entry
+      // in `computedKeys`, whose canonical key was inserted into the
+      // map — so the lookup is guaranteed to hit. Children retain
+      // their original input order within the group because we
+      // appended to the indexes array in iteration order.
+      const idxs = must(
+        childIndexesByKey.get(canonicalKey(node.row, parentKey)),
+      );
+      const relatedChildNodes: Node[] = idxs.map(i => childNodes[i]);
+      yield* this.#yieldParentWithOverlay(node, relatedChildNodes);
     }
   }
 

--- a/packages/zqlite/src/flipped-join-merge.perf.test.ts
+++ b/packages/zqlite/src/flipped-join-merge.perf.test.ts
@@ -1,0 +1,194 @@
+/* oxlint-disable no-console */
+import {describe, test} from 'vitest';
+import {testLogConfig} from '../../otel/src/test-log-config.ts';
+import {createSilentLogContext} from '../../shared/src/logging-test-utils.ts';
+import {Catch, type CaughtNode} from '../../zql/src/ivm/catch.ts';
+import {FlippedJoin} from '../../zql/src/ivm/flipped-join.ts';
+import {Database} from './db.ts';
+import {TableSource} from './table-source.ts';
+
+/**
+ * Wall-clock perf for FlippedJoin against a real zqlite TableSource on
+ * the non-unique parentKey path — the path optimized by the heap-merge
+ * + dedup changes.
+ *
+ * Two compounding wins this test surfaces:
+ *  - **Dedup of redundant parent fetches.** Children sharing a
+ *    parent-key value now produce one parent cursor, not N. Pre-fix the
+ *    code opened one cursor per child and each cursor refetched the
+ *    same parent rows.
+ *  - **Heap-based K-way merge.** O(log K) per emit instead of O(K) per
+ *    emit (linear scan of every iterator's head row). K = number of
+ *    open per-key cursors, so K = #childNodes pre-dedup vs #unique-keys
+ *    post-dedup — the dedup win shrinks K too.
+ *
+ * Gated on PERF=1 so it doesn't run in CI. To run:
+ *
+ *   PERF=1 npm --workspace=zqlite run test -- flipped-join-merge.perf
+ *
+ * To compare against the pre-heap-merge / pre-dedup algorithm, check
+ * out a revision before those changes landed in a worktree and port
+ * this file across — the FlippedJoin and TableSource constructor
+ * signatures are identical at that revision, so no test-side changes
+ * are needed.
+ */
+
+const lc = createSilentLogContext();
+
+function setupDb(
+  numChildren: number,
+  uniqueBuckets: number,
+): {parent: TableSource; child: TableSource} {
+  const db = new Database(lc, ':memory:');
+  // parent.bucket is intentionally NOT unique — that's what forces
+  // FlippedJoin down the merge-sort path (i.e. the path the heap-merge
+  // + dedup changes optimized). With a unique parent key the operator
+  // takes the quicksort path instead, which doesn't exercise either of
+  // the wins we want to measure.
+  db.exec(/* sql */ `
+    CREATE TABLE parent (
+      id INTEGER NOT NULL,
+      bucket INTEGER NOT NULL
+    );
+    CREATE UNIQUE INDEX parent_id_idx ON parent (id);
+    CREATE INDEX parent_bucket_idx ON parent (bucket);
+    CREATE TABLE child (
+      id INTEGER NOT NULL,
+      bucket INTEGER NOT NULL
+    );
+    CREATE UNIQUE INDEX child_id_idx ON child (id);
+    CREATE INDEX child_bucket_idx ON child (bucket);
+  `);
+
+  // 1:1 parents-to-children-per-bucket so total emitted-row count is
+  // independent of the dedup factor — only the merge K and per-cursor
+  // work change across cases.
+  const numParents = numChildren;
+  const insertParent = db.prepare(
+    'INSERT INTO parent (id, bucket) VALUES (?,?)',
+  );
+  const insertChild = db.prepare('INSERT INTO child (id, bucket) VALUES (?,?)');
+  db.transaction(() => {
+    for (let i = 1; i <= numParents; i++) {
+      insertParent.run(i, ((i - 1) % uniqueBuckets) + 1);
+    }
+    for (let i = 1; i <= numChildren; i++) {
+      insertChild.run(i, ((i - 1) % uniqueBuckets) + 1);
+    }
+  });
+
+  const parent = new TableSource(
+    lc,
+    testLogConfig,
+    db,
+    'parent',
+    {id: {type: 'number'}, bucket: {type: 'number'}},
+    ['id'],
+  );
+  const child = new TableSource(
+    lc,
+    testLogConfig,
+    db,
+    'child',
+    {id: {type: 'number'}, bucket: {type: 'number'}},
+    ['id'],
+  );
+  return {parent, child};
+}
+
+type RunResult = {
+  numChildren: number;
+  uniqueBuckets: number;
+  childrenPerBucket: number;
+  rowsOut: number;
+  elapsedMs: number;
+};
+
+function runOnce(numChildren: number, uniqueBuckets: number): RunResult {
+  const {parent, child} = setupDb(numChildren, uniqueBuckets);
+
+  const fj = new FlippedJoin({
+    parent: parent.connect([['id', 'asc']]),
+    child: child.connect([['id', 'asc']]),
+    parentKey: ['bucket'],
+    childKey: ['bucket'],
+    relationshipName: 'parents',
+    hidden: false,
+    system: 'client',
+  });
+
+  const start = performance.now();
+  const result: CaughtNode[] = new Catch(fj).fetch({});
+  const elapsedMs = performance.now() - start;
+
+  return {
+    numChildren,
+    uniqueBuckets,
+    childrenPerBucket: numChildren / uniqueBuckets,
+    rowsOut: result.length,
+    elapsedMs,
+  };
+}
+
+function logHeader() {
+  console.log(
+    'children'.padStart(10) +
+      'buckets'.padStart(10) +
+      'kidsPerBkt'.padStart(12) +
+      'rowsOut'.padStart(10) +
+      'elapsedMs'.padStart(12) +
+      'ms/row'.padStart(11),
+  );
+}
+
+function logRow(r: RunResult) {
+  console.log(
+    r.numChildren.toString().padStart(10) +
+      r.uniqueBuckets.toString().padStart(10) +
+      r.childrenPerBucket.toString().padStart(12) +
+      r.rowsOut.toString().padStart(10) +
+      r.elapsedMs.toFixed(1).padStart(12) +
+      (r.elapsedMs / Math.max(1, r.rowsOut)).toFixed(4).padStart(11),
+  );
+}
+
+describe.skipIf(!process.env.PERF)(
+  'FlippedJoin perf — non-unique parentKey (merge-sort path)',
+  {timeout: 600_000},
+  () => {
+    test('2.5k children, sweep dedup factor', () => {
+      const N = 2_500;
+      // Warm-up so JIT compilation is amortized away from the timing.
+      runOnce(500, 50);
+
+      // dedup factor = N / uniqueBuckets. Pre-fix the code always
+      // opened N cursors regardless of dedup, so cases with high dedup
+      // show the largest cursor-count delta. K = uniqueBuckets is also
+      // the merge fan-in, so high-K rows show the heap vs linear-scan
+      // win. Scale is intentionally small so the pre-fix algorithm (no
+      // batching, K = N cursors at dedup=1) finishes in seconds, not
+      // minutes — useful for A/B against the previous algorithm.
+      const cases = [N, N / 5, N / 25, N / 125, N / 625];
+
+      console.log(
+        `\n=== FlippedJoin merge-sort: ${N.toLocaleString()} children, 1:1 parents-per-bucket ===`,
+      );
+      logHeader();
+      for (const buckets of cases) {
+        logRow(runOnce(N, buckets));
+      }
+    });
+
+    test('2.5k children, dedup=25, repeated for variance', () => {
+      const N = 2_500;
+      runOnce(500, 50);
+      console.log(
+        `\n=== FlippedJoin merge-sort: ${N.toLocaleString()} children, dedup=25 (3 runs) ===`,
+      );
+      logHeader();
+      for (let i = 0; i < 3; i++) {
+        logRow(runOnce(N, N / 25));
+      }
+    });
+  },
+);


### PR DESCRIPTION
Swap the linear-scan K-way merge for `mergeSortedStreams` (O(log K) per
row vs O(K) per row). K = number of open cursors.

Adds a PERF=1-gated zqlite perf test that exercises the merge-sort
path against a real TableSource so the heap-vs-linear and dedup wins
can be compared against an earlier revision.