### PR TITLE
fix(zero-cache): use LogContext in exitAfter for proper structured logging

### DIFF
--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -27,6 +27,7 @@ import {
   type NormalizedZeroConfig,
 } from './normalize.ts';
 export type {LogConfig} from '../../../otel/src/log-options.ts';
+export type {NormalizedZeroConfig} from './normalize.ts';
 
 export const ZERO_ENV_VAR_PREFIX = 'ZERO_';
 

--- a/packages/zero-cache/src/server/change-streamer.pg.test.ts
+++ b/packages/zero-cache/src/server/change-streamer.pg.test.ts
@@ -1,6 +1,7 @@
 import {expect, vi} from 'vitest';
 import {assert} from '../../../shared/src/asserts.ts';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import {getNormalizedZeroConfig} from '../config/zero-config.ts';
 import {StatementRunner} from '../db/statements.ts';
 import {initializePostgresChangeSource} from '../services/change-source/pg/change-source.ts';
 import {initChangeStreamerSchema} from '../services/change-streamer/schema/init.ts';
@@ -117,7 +118,8 @@ test('change-streamer startup does not deadlock on autoreset retry when change a
         ZERO_LOG_LEVEL: 'error', // silence logs from the worker
       };
 
-      const workerDone = runWorker(worker, env);
+      const config = getNormalizedZeroConfig({env});
+      const workerDone = runWorker(lc, worker, config);
       const startup = await orTimeout(
         Promise.all([ready, workerDone]).then(() => true),
         7_500,

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -1,8 +1,12 @@
+import type {LogContext} from '@rocicorp/logger';
 import {assert} from '../../../shared/src/asserts.ts';
 import {must} from '../../../shared/src/must.ts';
 import {DatabaseInitError} from '../../../zqlite/src/db.ts';
 import {getServerContext} from '../config/server-context.ts';
-import {getNormalizedZeroConfig} from '../config/zero-config.ts';
+import {
+  getNormalizedZeroConfig,
+  type NormalizedZeroConfig,
+} from '../config/zero-config.ts';
 import {deleteLiteDB} from '../db/delete-lite-db.ts';
 import {warmupConnections} from '../db/warmup.ts';
 import {initEventSink, publishCriticalEvent} from '../observability/events.ts';
@@ -37,12 +41,11 @@ import {createLogContext} from './logging.ts';
 import {startOtelAuto} from './otel-start.ts';
 
 export default async function runWorker(
+  lc: LogContext,
   parent: Worker,
-  env: NodeJS.ProcessEnv,
-  ...argv: string[]
+  config: NormalizedZeroConfig,
 ): Promise<void> {
   const workerStartTime = Date.now();
-  const config = getNormalizedZeroConfig({env, argv});
   const {
     taskID,
     changeStreamer: {
@@ -61,12 +64,6 @@ export default async function runWorker(
     keepaliveTimeoutMs,
   } = config;
 
-  startOtelAuto(
-    createLogContext(config, 'change-streamer', 0, false),
-    'change-streamer',
-    0,
-  );
-  const lc = createLogContext(config, 'change-streamer');
   initEventSink(lc, config);
 
   // Kick off DB connection warmup in the background.
@@ -244,7 +241,15 @@ export default async function runWorker(
 
 // fork()
 if (!singleProcessMode()) {
-  void exitAfter(() =>
-    runWorker(must(parentWorker), process.env, ...process.argv.slice(2)),
+  const config = getNormalizedZeroConfig({
+    env: process.env,
+    argv: process.argv.slice(2),
+  });
+  startOtelAuto(
+    createLogContext(config, 'change-streamer', 0, false),
+    'change-streamer',
+    0,
   );
+  const lc = createLogContext(config, 'change-streamer');
+  void exitAfter(lc, () => runWorker(lc, must(parentWorker), config));
 }

--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -1,7 +1,11 @@
 import path from 'node:path';
+import type {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
 import {must} from '../../../shared/src/must.ts';
-import {getNormalizedZeroConfig} from '../config/zero-config.ts';
+import {
+  getNormalizedZeroConfig,
+  type NormalizedZeroConfig,
+} from '../config/zero-config.ts';
 import {initEventSink} from '../observability/events.ts';
 import {
   exitAfter,
@@ -40,18 +44,13 @@ import {
 const clientConnectionBifurcated = false;
 
 export default async function runWorker(
+  lc: LogContext,
   parent: Worker,
   env: NodeJS.ProcessEnv,
+  config: NormalizedZeroConfig,
 ): Promise<void> {
   const startMs = Date.now();
-  const config = getNormalizedZeroConfig({env});
 
-  startOtelAuto(
-    createLogContext(config, 'dispatcher', 0, false),
-    'dispatcher',
-    0,
-  );
-  const lc = createLogContext(config, 'dispatcher');
   initEventSink(lc, config);
 
   const processes = new ProcessManager(lc, parent);
@@ -218,5 +217,14 @@ export default async function runWorker(
 }
 
 if (!singleProcessMode()) {
-  void exitAfter(() => runWorker(must(parentWorker), process.env));
+  const config = getNormalizedZeroConfig({env: process.env});
+  startOtelAuto(
+    createLogContext(config, 'dispatcher', 0, false),
+    'dispatcher',
+    0,
+  );
+  const lc = createLogContext(config, 'dispatcher');
+  void exitAfter(lc, () =>
+    runWorker(lc, must(parentWorker), process.env, config),
+  );
 }

--- a/packages/zero-cache/src/server/mutator.ts
+++ b/packages/zero-cache/src/server/mutator.ts
@@ -1,3 +1,4 @@
+import type {LogContext} from '@rocicorp/logger';
 import {must} from '../../../shared/src/must.ts';
 import {getNormalizedZeroConfig} from '../config/zero-config.ts';
 import {initEventSink} from '../observability/events.ts';
@@ -11,22 +12,18 @@ import {Mutator} from '../workers/mutator.ts';
 import {createLogContext} from './logging.ts';
 import {startOtelAuto} from './otel-start.ts';
 
-function runWorker(
-  parent: Worker,
-  env: NodeJS.ProcessEnv,
-  ...args: string[]
-): Promise<void> {
-  const config = getNormalizedZeroConfig({env, argv: args.slice(1)});
-  startOtelAuto(createLogContext(config, 'mutator', 0, false), 'mutator', 0);
-  const lc = createLogContext(config, 'mutator');
-  initEventSink(lc, config);
-
+function runWorker(lc: LogContext, parent: Worker): Promise<void> {
   // TODO: create `PusherFactory`
   return runUntilKilled(lc, parent, new Mutator());
 }
 
 if (!singleProcessMode()) {
-  void exitAfter(() =>
-    runWorker(must(parentWorker), process.env, ...process.argv.slice(2)),
-  );
+  const config = getNormalizedZeroConfig({
+    env: process.env,
+    argv: process.argv.slice(3),
+  });
+  startOtelAuto(createLogContext(config, 'mutator', 0, false), 'mutator', 0);
+  const lc = createLogContext(config, 'mutator');
+  initEventSink(lc, config);
+  void exitAfter(lc, () => runWorker(lc, must(parentWorker)));
 }

--- a/packages/zero-cache/src/server/reaper.ts
+++ b/packages/zero-cache/src/server/reaper.ts
@@ -1,5 +1,9 @@
+import type {LogContext} from '@rocicorp/logger';
 import {must} from '../../../shared/src/must.ts';
-import {getNormalizedZeroConfig} from '../config/zero-config.ts';
+import {
+  getNormalizedZeroConfig,
+  type NormalizedZeroConfig,
+} from '../config/zero-config.ts';
 import {initEventSink} from '../observability/events.ts';
 import {exitAfter, runUntilKilled} from '../services/life-cycle.ts';
 import {ActiveUsersGauge} from '../services/view-syncer/active-users-gauge.ts';
@@ -19,14 +23,10 @@ import {startOtelAuto} from './otel-start.ts';
 const MS_PER_HOUR = 1000 * 60 * 60;
 
 export default async function runWorker(
+  lc: LogContext,
   parent: Worker,
-  env: NodeJS.ProcessEnv,
-  ...argv: string[]
+  config: NormalizedZeroConfig,
 ): Promise<void> {
-  const config = getNormalizedZeroConfig({env, argv});
-
-  startOtelAuto(createLogContext(config, 'reaper', 0, false), 'reaper', 0);
-  const lc = createLogContext(config, 'reaper');
   initEventSink(lc, config);
   startAnonymousTelemetry(lc, config);
 
@@ -57,7 +57,11 @@ export default async function runWorker(
 
 // fork()
 if (!singleProcessMode()) {
-  void exitAfter(() =>
-    runWorker(must(parentWorker), process.env, ...process.argv.slice(2)),
-  );
+  const config = getNormalizedZeroConfig({
+    env: process.env,
+    argv: process.argv.slice(2),
+  });
+  startOtelAuto(createLogContext(config, 'reaper', 0, false), 'reaper', 0);
+  const lc = createLogContext(config, 'reaper');
+  void exitAfter(lc, () => runWorker(lc, must(parentWorker), config));
 }

--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -5,7 +5,10 @@ import type {LogContext} from '@rocicorp/logger';
 import {assert} from '../../../shared/src/asserts.ts';
 import {must} from '../../../shared/src/must.ts';
 import * as v from '../../../shared/src/valita.ts';
-import {getNormalizedZeroConfig} from '../config/zero-config.ts';
+import {
+  getNormalizedZeroConfig,
+  type NormalizedZeroConfig,
+} from '../config/zero-config.ts';
 import {initEventSink} from '../observability/events.ts';
 import {getOrCreateGauge} from '../observability/metrics.ts';
 import {ChangeStreamerHttpClient} from '../services/change-streamer/change-streamer-http.ts';
@@ -27,24 +30,20 @@ import {
   replicaFileModeSchema,
   setUpMessageHandlers,
   setupReplica,
+  type ReplicaFileMode,
   type WalMode,
 } from '../workers/replicator.ts';
 import {createLogContext} from './logging.ts';
 import {startOtelAuto} from './otel-start.ts';
 
 export default async function runWorker(
+  lc: LogContext,
   parent: Worker,
-  env: NodeJS.ProcessEnv,
-  ...args: string[]
+  fileMode: ReplicaFileMode,
+  config: NormalizedZeroConfig,
 ): Promise<void> {
-  assert(args.length > 0, `replicator mode not specified`);
-  const fileMode = v.parse(args[0], replicaFileModeSchema);
-
-  const config = getNormalizedZeroConfig({env, argv: args.slice(1)});
   const mode: ReplicatorMode = fileMode === 'backup' ? 'backup' : 'serving';
   const workerName = `${mode}-replicator`;
-  startOtelAuto(createLogContext(config, workerName, 0, false), workerName, 0);
-  const lc = createLogContext(config, workerName);
   initEventSink(lc, config);
 
   const {file: dbPath, walMode} = await setupReplica(
@@ -140,7 +139,16 @@ function observeFileSize(lc: LogContext, file: string): ObservableCallback {
 
 // fork()
 if (!singleProcessMode()) {
-  void exitAfter(() =>
-    runWorker(must(parentWorker), process.env, ...process.argv.slice(2)),
-  );
+  const args = process.argv.slice(2);
+  assert(args.length > 0, `replicator mode not specified`);
+  const fileMode = v.parse(args[0], replicaFileModeSchema);
+  const config = getNormalizedZeroConfig({
+    env: process.env,
+    argv: args.slice(1),
+  });
+  const mode: ReplicatorMode = fileMode === 'backup' ? 'backup' : 'serving';
+  const workerName = `${mode}-replicator`;
+  startOtelAuto(createLogContext(config, workerName, 0, false), workerName, 0);
+  const lc = createLogContext(config, workerName);
+  void exitAfter(lc, () => runWorker(lc, must(parentWorker), fileMode, config));
 }

--- a/packages/zero-cache/src/server/runner/main.ts
+++ b/packages/zero-cache/src/server/runner/main.ts
@@ -1,11 +1,15 @@
 import '../../../../shared/src/dotenv.ts';
 
+import {getZeroConfig} from '../../config/zero-config.ts';
 import {exitAfter} from '../../services/life-cycle.ts';
 import {parentWorker, singleProcessMode} from '../../types/processes.ts';
+import {createLogContext} from '../logging.ts';
 import {runWorker} from './run-worker.ts';
 
 if (!singleProcessMode()) {
-  void exitAfter(() => runWorker(parentWorker, process.env));
+  const config = getZeroConfig({env: process.env});
+  const lc = createLogContext(config, 'runner');
+  void exitAfter(lc, () => runWorker(parentWorker, process.env));
 }
 
 export default runWorker;

--- a/packages/zero-cache/src/server/shadow-syncer.ts
+++ b/packages/zero-cache/src/server/shadow-syncer.ts
@@ -1,6 +1,10 @@
+import type {LogContext} from '@rocicorp/logger';
 import {must} from '../../../shared/src/must.ts';
 import {getServerContext} from '../config/server-context.ts';
-import {getNormalizedZeroConfig} from '../config/zero-config.ts';
+import {
+  getNormalizedZeroConfig,
+  type NormalizedZeroConfig,
+} from '../config/zero-config.ts';
 import {initEventSink} from '../observability/events.ts';
 import {exitAfter, runUntilKilled} from '../services/life-cycle.ts';
 import {ShadowSyncService} from '../services/shadow-sync/shadow-sync-service.ts';
@@ -16,18 +20,10 @@ import {startOtelAuto} from './otel-start.ts';
 const MS_PER_HOUR = 1000 * 60 * 60;
 
 export default function runWorker(
+  lc: LogContext,
   parent: Worker,
-  env: NodeJS.ProcessEnv,
-  ...argv: string[]
+  config: NormalizedZeroConfig,
 ): Promise<void> {
-  const config = getNormalizedZeroConfig({env, argv});
-
-  startOtelAuto(
-    createLogContext(config, 'shadow-syncer', 0, false),
-    'shadow-syncer',
-    0,
-  );
-  const lc = createLogContext(config, 'shadow-syncer');
   initEventSink(lc, config);
 
   const {shadowSync, upstream, initialSync} = config;
@@ -52,7 +48,15 @@ export default function runWorker(
 
 // fork()
 if (!singleProcessMode()) {
-  void exitAfter(() =>
-    runWorker(must(parentWorker), process.env, ...process.argv.slice(2)),
+  const config = getNormalizedZeroConfig({
+    env: process.env,
+    argv: process.argv.slice(2),
+  });
+  startOtelAuto(
+    createLogContext(config, 'shadow-syncer', 0, false),
+    'shadow-syncer',
+    0,
   );
+  const lc = createLogContext(config, 'shadow-syncer');
+  void exitAfter(lc, () => runWorker(lc, must(parentWorker), config));
 }

--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -2,6 +2,7 @@ import {randomUUID} from 'node:crypto';
 import {tmpdir} from 'node:os';
 import path from 'node:path';
 import {pid} from 'node:process';
+import type {LogContext} from '@rocicorp/logger';
 import {assert} from '../../../shared/src/asserts.ts';
 import {must} from '../../../shared/src/must.ts';
 import {randInt} from '../../../shared/src/rand.ts';
@@ -10,8 +11,10 @@ import * as v from '../../../shared/src/valita.ts';
 import {DatabaseStorage} from '../../../zqlite/src/database-storage.ts';
 import type {ValidateLegacyJWT} from '../auth/auth.ts';
 import {tokenConfigOptions, verifyToken} from '../auth/jwt.ts';
-import type {NormalizedZeroConfig} from '../config/normalize.ts';
-import {getNormalizedZeroConfig} from '../config/zero-config.ts';
+import {
+  getNormalizedZeroConfig,
+  type NormalizedZeroConfig,
+} from '../config/zero-config.ts';
 import {CustomQueryTransformer} from '../custom-queries/transform-query.ts';
 import {warmupConnections} from '../db/warmup.ts';
 import {initEventSink} from '../observability/events.ts';
@@ -36,7 +39,11 @@ import {
 } from '../types/processes.ts';
 import {getShardID} from '../types/shards.ts';
 import type {Subscription} from '../types/subscription.ts';
-import {replicaFileModeSchema, replicaFileName} from '../workers/replicator.ts';
+import {
+  replicaFileModeSchema,
+  replicaFileName,
+  type ReplicaFileMode,
+} from '../workers/replicator.ts';
 import {Syncer} from '../workers/syncer.ts';
 import {startAnonymousTelemetry} from './anonymous-otel-start.ts';
 import {InspectorDelegate} from './inspector-delegate.ts';
@@ -66,21 +73,11 @@ function getCustomQueryConfig(
 }
 
 export default function runWorker(
+  lc: LogContext,
   parent: Worker,
-  env: NodeJS.ProcessEnv,
-  ...args: string[]
+  fileMode: ReplicaFileMode,
+  config: NormalizedZeroConfig,
 ): Promise<void> {
-  assert(args.length >= 2, `expected [fileMode, workerIndex, ...flags]`);
-  const fileMode = v.parse(args[0], replicaFileModeSchema);
-  const workerIndex = Number(args[1]);
-  const config = getNormalizedZeroConfig({env, argv: args.slice(2)});
-
-  startOtelAuto(
-    createLogContext(config, 'syncer', workerIndex, false),
-    'syncer',
-    workerIndex,
-  );
-  const lc = createLogContext(config, 'syncer', workerIndex);
   initEventSink(lc, config);
 
   const {cvr, upstream, enableCrudMutations} = config;
@@ -271,7 +268,19 @@ export default function runWorker(
 
 // fork()
 if (!singleProcessMode()) {
-  void exitAfter(() =>
-    runWorker(must(parentWorker), process.env, ...process.argv.slice(2)),
+  const args = process.argv.slice(2);
+  assert(args.length >= 2, `expected [fileMode, workerIndex, ...flags]`);
+  const fileMode = v.parse(args[0], replicaFileModeSchema);
+  const workerIndex = Number(args[1]);
+  const config = getNormalizedZeroConfig({
+    env: process.env,
+    argv: args.slice(2),
+  });
+  startOtelAuto(
+    createLogContext(config, 'syncer', workerIndex, false),
+    'syncer',
+    workerIndex,
   );
+  const lc = createLogContext(config, 'syncer', workerIndex);
+  void exitAfter(lc, () => runWorker(lc, must(parentWorker), fileMode, config));
 }

--- a/packages/zero-cache/src/services/life-cycle.ts
+++ b/packages/zero-cache/src/services/life-cycle.ts
@@ -1,5 +1,4 @@
 import type {IncomingHttpHeaders} from 'node:http';
-import {pid} from 'node:process';
 import type {EventEmitter} from 'stream';
 import type {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
@@ -302,15 +301,13 @@ export async function runUntilKilled(
   }
 }
 
-export async function exitAfter(run: () => Promise<void>) {
+export async function exitAfter(lc: LogContext, run: () => Promise<void>) {
   try {
     await run();
-    // oxlint-disable-next-line no-console
-    console.info(`pid ${pid} exiting normally`);
+    lc.info?.(`exiting normally`);
     process.exit(0);
   } catch (e) {
-    // oxlint-disable-next-line no-console
-    console.error(`pid ${pid} exiting with error`, e);
+    lc.error?.(`exiting with error`, e);
     process.exit(-1);
   }
 }

--- a/packages/zero-client/src/client/ivm-branch.test.ts
+++ b/packages/zero-client/src/client/ivm-branch.test.ts
@@ -441,6 +441,13 @@ describe('advance', () => {
       expect(e).toBe(originalError);
     }
 
+    try {
+      branch.fork();
+      expect.fail('Expected poisoned branch fork to throw');
+    } catch (e) {
+      expect(e).toBe(originalError);
+    }
+
     await expect(branch.forkToHead(dagStore, 'head2' as Hash)).rejects.toBe(
       originalError,
     );

--- a/packages/zero-client/src/client/ivm-branch.ts
+++ b/packages/zero-client/src/client/ivm-branch.ts
@@ -137,6 +137,8 @@ export class IVMSourceBranch {
    * The mutations modify the fork rather than original branch.
    */
   fork() {
+    this.#throwIfInvalid();
+
     return new IVMSourceBranch(
       this.#tables,
       this.hash,


### PR DESCRIPTION
## Summary
- Refactors `exitAfter()` to take a `LogContext` parameter instead of using `console.error`
- Previously exit errors had no log level field in structured logs, making it harder to filter/alert
- Hoists config and LogContext creation to module scope in all worker modules
- Updates all worker `runWorker()` signatures to receive `lc` and `config` as params

## Test plan
- [x] Type checking passes
- [x] Non-pg tests pass
- [ ] Manual verification that exit errors now have proper log level

🤖 Generated with [Claude Code](https://claude.com/claude-code)