### PR TITLE
fix(replicache): fix putMany rebalancing duplicating entries across adjacent children

### DIFF
--- a/packages/replicache/src/btree/node.ts
+++ b/packages/replicache/src/btree/node.ts
@@ -566,7 +566,7 @@ export class InternalNodeImpl extends NodeImpl<Hash> {
       }> = [];
 
       for (const {index, node} of childrenToRebalance) {
-        const lastGroup = groups[groups.length - 1];
+        const lastGroup = groups.at(-1);
         // Adjacent to previous group? (within 1 index of the last group's max)
         if (lastGroup && index <= lastGroup.maxIndex + 1) {
           lastGroup.nodes.set(index, node);
@@ -586,10 +586,7 @@ export class InternalNodeImpl extends NodeImpl<Hash> {
 
         // Extend range by one sibling on each side for merge context.
         const startIndex = Math.max(0, group.minIndex - 1);
-        const endIndex = Math.min(
-          newEntries.length - 1,
-          group.maxIndex + 1,
-        );
+        const endIndex = Math.min(newEntries.length - 1, group.maxIndex + 1);
         const removeCount = endIndex - startIndex + 1;
 
         // Collect all entries from the range: use the putMany result for

--- a/packages/replicache/src/btree/node.ts
+++ b/packages/replicache/src/btree/node.ts
@@ -449,62 +449,6 @@ function readonlySplice<T>(
   return arr;
 }
 
-/**
- * Helper for putMany that merges and partitions a child node.
- * Returns the new entries and the splice parameters (startIndex and removeCount).
- */
-async function putManyMergeAndPartition(
-  tree: BTreeWrite,
-  parentLevel: number,
-  i: number,
-  childNode: DataNodeImpl | InternalNodeImpl,
-  currentEntries: Entry<Hash>[],
-): Promise<{entries: Entry<Hash>[]; startIndex: number; removeCount: number}> {
-  const level = parentLevel - 1;
-
-  type IterableHashEntries = Iterable<Entry<Hash>>;
-
-  let values: IterableHashEntries;
-  let startIndex: number;
-  let removeCount: number;
-  if (i > 0) {
-    const hash = currentEntries[i - 1][1];
-    const previousSibling = await tree.getNode(hash);
-    values = joinIterables(
-      previousSibling.entries as IterableHashEntries,
-      childNode.entries as IterableHashEntries,
-    );
-    startIndex = i - 1;
-    removeCount = 2;
-  } else if (i < currentEntries.length - 1) {
-    const hash = currentEntries[i + 1][1];
-    const nextSibling = await tree.getNode(hash);
-    values = joinIterables(
-      childNode.entries as IterableHashEntries,
-      nextSibling.entries as IterableHashEntries,
-    );
-    startIndex = i;
-    removeCount = 2;
-  } else {
-    values = childNode.entries as IterableHashEntries;
-    startIndex = i;
-    removeCount = 1;
-  }
-
-  const newEntries = partition(
-    values,
-    e => e[2],
-    tree.minSize - tree.chunkHeaderSize,
-    tree.maxSize - tree.chunkHeaderSize,
-    entries => {
-      const node = tree.newNodeImpl(entries, level);
-      return createNewInternalEntryForNode(node, tree.getEntrySize);
-    },
-  );
-
-  return {entries: newEntries, startIndex, removeCount};
-}
-
 export class InternalNodeImpl extends NodeImpl<Hash> {
   readonly level: number;
 
@@ -602,22 +546,80 @@ export class InternalNodeImpl extends NodeImpl<Hash> {
       }
     }
 
-    // Handle rebalancing - process from right to left to maintain indices
+    // Handle rebalancing - merge adjacent children that need rebalancing
+    // into contiguous groups and process each group as one unit.
+    //
+    // BUG FIX: Previously, each child was rebalanced independently R-to-L.
+    // When adjacent children (e.g., indices 0 and 1) both needed rebalancing,
+    // child[1] would merge with sibling[0] (the ORIGINAL), then child[0]
+    // would merge with the rebalanced result at position 1, duplicating
+    // child[0]'s data. The fix groups adjacent indices together.
     if (childrenToRebalance.length > 0) {
-      childrenToRebalance.sort((a, b) => b.index - a.index);
+      childrenToRebalance.sort((a, b) => a.index - b.index);
+
+      // Group adjacent indices into contiguous runs, each extended by one
+      // sibling on either side for merge context.
+      const groups: Array<{
+        nodes: Map<number, DataNodeImpl | InternalNodeImpl>;
+        minIndex: number;
+        maxIndex: number;
+      }> = [];
 
       for (const {index, node} of childrenToRebalance) {
-        const {
-          entries: rebalanced,
-          startIndex,
-          removeCount,
-        } = await putManyMergeAndPartition(
-          tree,
-          this.level,
-          index,
-          node,
-          newEntries,
+        const lastGroup = groups[groups.length - 1];
+        // Adjacent to previous group? (within 1 index of the last group's max)
+        if (lastGroup && index <= lastGroup.maxIndex + 1) {
+          lastGroup.nodes.set(index, node);
+          lastGroup.maxIndex = index;
+        } else {
+          groups.push({
+            nodes: new Map([[index, node]]),
+            minIndex: index,
+            maxIndex: index,
+          });
+        }
+      }
+
+      // Process groups from right to left to maintain indices during splices.
+      for (let g = groups.length - 1; g >= 0; g--) {
+        const group = groups[g];
+
+        // Extend range by one sibling on each side for merge context.
+        const startIndex = Math.max(0, group.minIndex - 1);
+        const endIndex = Math.min(
+          newEntries.length - 1,
+          group.maxIndex + 1,
         );
+        const removeCount = endIndex - startIndex + 1;
+
+        // Collect all entries from the range: use the putMany result for
+        // indices that were rebalanced, the current newEntries node otherwise.
+        type IterableHashEntries = Iterable<Entry<Hash>>;
+        const allValues: IterableHashEntries[] = [];
+        for (let idx = startIndex; idx <= endIndex; idx++) {
+          const rebalancedNode = group.nodes.get(idx);
+          if (rebalancedNode) {
+            allValues.push(rebalancedNode.entries as IterableHashEntries);
+          } else {
+            const hash = newEntries[idx][1];
+            const existingNode = await tree.getNode(hash);
+            allValues.push(existingNode.entries as IterableHashEntries);
+          }
+        }
+
+        const level = this.level - 1;
+        const merged = joinIterables(...allValues);
+        const rebalanced = partition(
+          merged,
+          e => e[2],
+          tree.minSize - tree.chunkHeaderSize,
+          tree.maxSize - tree.chunkHeaderSize,
+          entries => {
+            const node = tree.newNodeImpl(entries, level);
+            return createNewInternalEntryForNode(node, tree.getEntrySize);
+          },
+        );
+
         newEntries.splice(startIndex, removeCount, ...rebalanced);
       }
     }

--- a/packages/replicache/src/sync/patch-putmany-diff.test.ts
+++ b/packages/replicache/src/sync/patch-putmany-diff.test.ts
@@ -1,0 +1,148 @@
+import {LogContext} from '@rocicorp/logger';
+import {describe, expect, test} from 'vitest';
+import type {InternalDiff} from '../btree/node.ts';
+import {TestStore} from '../dag/test-store.ts';
+import {ChainBuilder} from '../db/test-helpers.ts';
+import {newWriteSnapshotDD31} from '../db/write.ts';
+import * as FormatVersion from '../format-version-enum.ts';
+import {deepFreeze} from '../frozen-json.ts';
+import type {PatchOperationInternal} from '../patch-operation.ts';
+import {withWriteNoImplicitCommit} from '../with-transactions.ts';
+import {apply} from './patch.ts';
+
+const formatVersion = FormatVersion.Latest;
+const clientID = 'client-id';
+const lc = new LogContext();
+
+function makeEntityValue(i: number, version: number) {
+  return {
+    id: `ent_${String(i).padStart(6, '0')}`,
+    shortID: i + 1000000,
+    title: `Entity title number ${i} with some extra padding text to make it realistic`,
+    open: i % 3 !== 0,
+    modified: 1769711510846 + i,
+    created: 1767179995185 + i,
+    creatorID: `usr_${String(i % 100).padStart(4, '0')}`,
+    assigneeID: `usr_${String((i + 37) % 100).padStart(4, '0')}`,
+    description: `Description for entity ${i}. This is some filler text to make the value realistically sized.`,
+    visibility: 'public',
+    projectID: `proj_${String(i % 50).padStart(3, '0')}`,
+    version,
+  };
+}
+
+describe('putMany diff correctness', () => {
+  const diffConfig = {
+    shouldComputeDiffs: () => true,
+    shouldComputeDiffsForIndex: () => false,
+  };
+
+  // This reproduces the production scenario:
+  // 1. Initial sync: small poke applies via putMany → becomes main head
+  // 2. Later poke: big patch with overlapping keys applied via putMany
+  // 3. Diff between main head and sync head should be correct
+  //
+  // The key difference from the previous test: BOTH trees are built via
+  // putMany (simulating multiple poke rounds through the same code path).
+  test('putMany on both base and new tree', async () => {
+    const store = new TestStore();
+    const b = new ChainBuilder(store, undefined, formatVersion);
+    await b.addGenesis(clientID);
+
+    // Step 1: Simulate poke 1-3 building base via apply (putMany)
+    const basePatch: PatchOperationInternal[] = [];
+    for (let i = 0; i < 103; i++) {
+      const key = `e/entity/ent_${String(i).padStart(6, '0')}`;
+      basePatch.push({op: 'put', key, value: makeEntityValue(i, 1)});
+    }
+    // Also add some non-entity keys (like desired queries, got queries)
+    for (let i = 0; i < 3; i++) {
+      basePatch.push({
+        op: 'put',
+        key: `d/${clientID}/hash${i}`,
+        value: null,
+      });
+    }
+
+    const baseHash = await withWriteNoImplicitCommit(store, async dagWrite => {
+      const dbWrite = await newWriteSnapshotDD31(
+        b.chain[0].chunk.hash,
+        {[clientID]: 1},
+        'cookie1',
+        dagWrite,
+        clientID,
+        formatVersion,
+      );
+      await apply(lc, dbWrite, basePatch);
+      return dbWrite.commit('main');
+    });
+
+    // Step 2: Simulate poke 4 with 4913 puts, overlapping base
+    const bigPatch: PatchOperationInternal[] = [];
+    // All entity keys from 0-4912, overlapping 0-102 with base
+    for (let i = 0; i < 4913; i++) {
+      const key = `e/entity/ent_${String(i).padStart(6, '0')}`;
+      bigPatch.push({
+        op: 'put',
+        key,
+        value: makeEntityValue(i, i < 103 ? 2 : 1),
+      });
+    }
+
+    // Apply via putMany (the optimized path)
+    const [, optimizedDiffsMap] = await withWriteNoImplicitCommit(
+      store,
+      async dagWrite => {
+        const dbWrite = await newWriteSnapshotDD31(
+          baseHash,
+          {[clientID]: 1},
+          'cookie2',
+          dagWrite,
+          clientID,
+          formatVersion,
+        );
+        await apply(lc, dbWrite, bigPatch);
+        return dbWrite.commitWithDiffs('sync', diffConfig);
+      },
+    );
+    const optimizedDiffs: InternalDiff = optimizedDiffsMap.get('') ?? [];
+
+    // Apply via sequential put
+    const [, sequentialDiffsMap] = await withWriteNoImplicitCommit(
+      store,
+      async dagWrite => {
+        const dbWrite = await newWriteSnapshotDD31(
+          baseHash,
+          {[clientID]: 1},
+          'cookie3',
+          dagWrite,
+          clientID,
+          formatVersion,
+        );
+        for (const op of bigPatch) {
+          if (op.op === 'put') {
+            await dbWrite.put(lc, op.key, deepFreeze(op.value));
+          }
+        }
+        return dbWrite.commitWithDiffs('sync2', diffConfig);
+      },
+    );
+    const sequentialDiffs: InternalDiff = sequentialDiffsMap.get('') ?? [];
+
+    // Validate
+    const baseKeys = new Set<string>();
+    for (let i = 0; i < 103; i++) {
+      baseKeys.add(`e/entity/ent_${String(i).padStart(6, '0')}`);
+    }
+
+    const wrongAdds = optimizedDiffs.filter(
+      d => d.op === 'add' && baseKeys.has(d.key),
+    );
+    expect(
+      wrongAdds.map(d => d.key),
+      `putMany produced ${wrongAdds.length} wrong add diffs for existing keys`,
+    ).toEqual([]);
+
+    expect(optimizedDiffs.length).toBe(sequentialDiffs.length);
+  });
+});


### PR DESCRIPTION
## Problem

`putMany`'s rebalancing logic in `InternalNodeImpl` produced duplicate keys across sibling leaf nodes, causing the BTree `diff` algorithm to report incorrect `add` operations for rows that already existed. This triggered `"Row already exists"` assertion failures in the IVM `MemorySource` during poke processing.

## Root Cause

When two adjacent children (e.g., indices 0 and 1) both needed rebalancing after `putMany`, the old code processed them independently right-to-left:

1. **Child[1]** merged with sibling at `newEntries[0]` (the original child[0] data), producing rebalanced nodes containing child[0]'s entries.
2. **Child[0]** then merged with its next sibling at `newEntries[1]`, which was now the rebalanced result from step 1 — already containing child[0]'s data.

This duplicated child[0]'s entries across multiple leaf nodes, breaking the BTree's sorted+unique invariant. The `diff` algorithm's `diffEntries` merge then produced wrong results because the flattened composite entries were no longer sorted.

## Fix

Adjacent children that need rebalancing are now grouped into contiguous runs. Each group (extended by one sibling on each side for merge context) is flattened and repartitioned as a single unit, preventing any child's data from appearing in two separate merge operations.

The now-unused `putManyMergeAndPartition` helper was removed since its logic is subsumed by the group-based approach.
