### PR TITLE
fix(zero-cache): classify ConcurrentModificationException as a Rehome

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr-store.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.ts
@@ -1319,7 +1319,7 @@ export class ConcurrentModificationException extends ProtocolErrorWithLevel {
   constructor(expectedVersion: string, actualVersion: string) {
     super(
       {
-        kind: ErrorKind.Internal,
+        kind: ErrorKind.Rehome,
         message: `CVR has been concurrently modified. Expected ${expectedVersion}, got ${actualVersion}`,
         origin: ErrorOrigin.ZeroCache,
       },


### PR DESCRIPTION
This signals the client to reconnect (presumably to the right VS, based on the sticky cookie).

Context:
* https://rocicorp.slack.com/archives/C0AK5KX8HGE/p1778180835614519