### PR TITLE
feat: added optional query to tx.run() and others

### DIFF
--- a/packages/zero-client/src/client/custom.test.ts
+++ b/packages/zero-client/src/client/custom.test.ts
@@ -395,6 +395,53 @@ describe('custom mutators can query the local store during an optimistic mutatio
     ]);
   });
 
+  test('tx.run handles conditional queries', async () => {
+    const zql = createBuilder(legacySchema);
+    let skippedQueryResult: unknown;
+    let skippedCompleteQueryResult: unknown;
+    let falseQueryResult: unknown;
+
+    const z = zeroForTest({
+      schema: legacySchema,
+      mutators: {
+        issue: {
+          maybeQuery: async (tx: MutatorTx, args: {enabled: boolean}) => {
+            const maybeQuery = args.enabled ? zql.issue : undefined;
+            const result = await tx.run(maybeQuery);
+            expectTypeOf(result).toEqualTypeOf<
+              Row<typeof legacySchema.tables.issue>[] | undefined
+            >();
+            skippedQueryResult = result;
+
+            const maybeCompleteQuery = args.enabled ? zql.issue : undefined;
+            const skippedCompleteResult = await tx.run(maybeCompleteQuery, {
+              type: 'complete',
+            });
+            expectTypeOf(skippedCompleteResult).toEqualTypeOf<
+              Row<typeof legacySchema.tables.issue>[] | undefined
+            >();
+            skippedCompleteQueryResult = skippedCompleteResult;
+
+            const falseQuery = args.enabled && zql.issue;
+            const falseResult = await tx.run(falseQuery);
+            expectTypeOf(falseResult).toEqualTypeOf<
+              Row<typeof legacySchema.tables.issue>[] | undefined
+            >();
+            falseQueryResult = falseResult;
+          },
+        },
+      } as const,
+    });
+
+    await z.mutate.issue.maybeQuery({enabled: false}).client;
+
+    expect(skippedQueryResult).toBeUndefined();
+    expect(skippedCompleteQueryResult).toBeUndefined();
+    expect(falseQueryResult).toBeUndefined();
+
+    await z.close();
+  });
+
   test('closeAll using tx.run', async () => {
     const zql = createBuilder(legacySchema);
 

--- a/packages/zero-client/src/client/custom.test.ts
+++ b/packages/zero-client/src/client/custom.test.ts
@@ -397,9 +397,9 @@ describe('custom mutators can query the local store during an optimistic mutatio
 
   test('tx.run handles conditional queries', async () => {
     const zql = createBuilder(legacySchema);
-    let skippedQueryResult: unknown;
-    let skippedCompleteQueryResult: unknown;
-    let falseQueryResult: unknown;
+    let skippedQueryResult: unknown = true;
+    let skippedCompleteQueryResult: unknown = true;
+    let falseQueryResult: unknown = true;
 
     const z = zeroForTest({
       schema: legacySchema,

--- a/packages/zero-client/src/client/custom.ts
+++ b/packages/zero-client/src/client/custom.ts
@@ -3,6 +3,7 @@ import type {ZeroTxData} from '../../../replicache/src/replicache-options.ts';
 import type {WriteTransactionImpl} from '../../../replicache/src/transactions.ts';
 import {zeroData} from '../../../replicache/src/transactions.ts';
 import {assert} from '../../../shared/src/asserts.ts';
+import type {Falsy} from '../../../shared/src/falsy.ts';
 import type {ReadonlyJSONValue} from '../../../shared/src/json.ts';
 import {must} from '../../../shared/src/must.ts';
 import {emptyFunction} from '../../../shared/src/sentinels.ts';
@@ -166,7 +167,18 @@ export class TransactionImpl<
   run<TTable extends keyof TSchema['tables'] & string, TReturn>(
     query: Query<TTable, TSchema, TReturn>,
     options?: RunOptions,
-  ): Promise<HumanReadable<TReturn>> {
+  ): Promise<HumanReadable<TReturn>>;
+  run<TTable extends keyof TSchema['tables'] & string, TReturn>(
+    query: Query<TTable, TSchema, TReturn> | Falsy,
+    options?: RunOptions,
+  ): Promise<HumanReadable<TReturn> | undefined>;
+  run<TTable extends keyof TSchema['tables'] & string, TReturn>(
+    query: Query<TTable, TSchema, TReturn> | Falsy,
+    options?: RunOptions,
+  ): Promise<HumanReadable<TReturn> | undefined> {
+    if (!query) {
+      return Promise.resolve(undefined);
+    }
     return this.#zeroContext.run(query, options);
   }
 }

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -29,11 +29,13 @@ import {
 } from '../../../shared/src/browser-env.ts';
 import {getDocumentVisibilityWatcher} from '../../../shared/src/document-visible.ts';
 import {getErrorMessage} from '../../../shared/src/error.ts';
+import type {Falsy} from '../../../shared/src/falsy.ts';
 import {h64} from '../../../shared/src/hash.ts';
 import type {ReadonlyJSONValue} from '../../../shared/src/json.ts';
 import {must} from '../../../shared/src/must.ts';
 import {navigator} from '../../../shared/src/navigator.ts';
 import {promiseRace} from '../../../shared/src/promise-race.ts';
+import {promiseVoid} from '../../../shared/src/resolved-promises.ts';
 import {emptyFunction} from '../../../shared/src/sentinels.ts';
 import {sleep, sleepWithAbort} from '../../../shared/src/sleep.ts';
 import {Subscribable} from '../../../shared/src/subscribable.ts';
@@ -939,7 +941,41 @@ export class Zero<
   >(
     query: QueryOrQueryRequest<TTable, TInput, TOutput, S, TReturn, C>,
     options?: PreloadOptions,
-  ) {
+  ): {
+    cleanup: () => void;
+    complete: Promise<void>;
+  };
+  preload<
+    TTable extends keyof S['tables'] & string,
+    TInput extends ReadonlyJSONValue | undefined,
+    TOutput extends ReadonlyJSONValue | undefined,
+    TReturn,
+  >(
+    query: QueryOrQueryRequest<TTable, TInput, TOutput, S, TReturn, C> | Falsy,
+    options?: PreloadOptions,
+  ): {
+    cleanup: () => void;
+    complete: Promise<void>;
+  };
+  preload<
+    TTable extends keyof S['tables'] & string,
+    TInput extends ReadonlyJSONValue | undefined,
+    TOutput extends ReadonlyJSONValue | undefined,
+    TReturn,
+  >(
+    query: QueryOrQueryRequest<TTable, TInput, TOutput, S, TReturn, C> | Falsy,
+    options?: PreloadOptions,
+  ): {
+    cleanup: () => void;
+    complete: Promise<void>;
+  } {
+    if (!query) {
+      return {
+        cleanup: emptyFunction,
+        complete: promiseVoid,
+      };
+    }
+
     return this.#zeroContext.preload(
       addContextToQuery(query, this.context),
       options,
@@ -974,7 +1010,29 @@ export class Zero<
   >(
     query: QueryOrQueryRequest<TTable, TInput, TOutput, S, TReturn, C>,
     runOptions?: RunOptions,
-  ): Promise<HumanReadable<TReturn>> {
+  ): Promise<HumanReadable<TReturn>>;
+  run<
+    TTable extends keyof S['tables'] & string,
+    TInput extends ReadonlyJSONValue | undefined,
+    TOutput extends ReadonlyJSONValue | undefined,
+    TReturn,
+  >(
+    query: QueryOrQueryRequest<TTable, TInput, TOutput, S, TReturn, C> | Falsy,
+    runOptions?: RunOptions,
+  ): Promise<HumanReadable<TReturn> | undefined>;
+  run<
+    TTable extends keyof S['tables'] & string,
+    TInput extends ReadonlyJSONValue | undefined,
+    TOutput extends ReadonlyJSONValue | undefined,
+    TReturn,
+  >(
+    query: QueryOrQueryRequest<TTable, TInput, TOutput, S, TReturn, C> | Falsy,
+    runOptions?: RunOptions,
+  ): Promise<HumanReadable<TReturn> | undefined> {
+    if (!query) {
+      return Promise.resolve(undefined);
+    }
+
     return this.#zeroContext.run(
       addContextToQuery(query, this.context),
       runOptions,

--- a/packages/zero-client/src/client/zero.type.test.ts
+++ b/packages/zero-client/src/client/zero.type.test.ts
@@ -1,5 +1,6 @@
 import {
   afterAll,
+  assert,
   beforeAll,
   describe,
   expect,
@@ -185,21 +186,21 @@ describe('run', () => {
       expectTypeOf(skippedFalse).toEqualTypeOf<Issue[] | undefined>();
     };
 
-    expectTypeOf(check).toBeFunction();
+    assert(check);
   });
 });
 
 describe('preload', () => {
-  test('preload with many rows', async () => {
-    const result = await z.preload(zql.issues);
+  test('preload with many rows', () => {
+    const result = z.preload(zql.issues);
     expectTypeOf(result.complete).toEqualTypeOf<Promise<void>>();
-    await z.preload(queries.issues());
+    z.preload(queries.issues());
   });
 
-  test('preload with one row', async () => {
-    const result = await z.preload(zql.issues.one());
+  test('preload with one row', () => {
+    const result = z.preload(zql.issues.one());
     expectTypeOf(result.complete).toEqualTypeOf<Promise<void>>();
-    await z.preload(queries.issue());
+    z.preload(queries.issue());
   });
 
   test('preload with conditional query', async () => {

--- a/packages/zero-client/src/client/zero.type.test.ts
+++ b/packages/zero-client/src/client/zero.type.test.ts
@@ -59,6 +59,10 @@ const mutators = defineMutatorsWithType<typeof schema>()({
 });
 
 const zql = createBuilder(schema);
+type Issue = {
+  readonly id: string;
+  readonly value: number;
+};
 
 const queries = defineQueriesWithType<typeof schema>()({
   issues: defineQueryWithType<typeof schema>()(() => zql.issues),
@@ -120,6 +124,69 @@ describe('run', () => {
     >();
     expect(y).toEqual({id: 'a', value: 1, [refCountSymbol]: 1});
   });
+
+  test('run with conditional query', async () => {
+    const enabled = true as boolean;
+
+    const maybeIssuesQuery = enabled ? zql.issues : undefined;
+    const x = await z.run(maybeIssuesQuery);
+    expectTypeOf(x).toEqualTypeOf<Issue[] | undefined>();
+    expect(x).toEqual([{id: 'a', value: 1, [refCountSymbol]: 1}]);
+
+    const maybeIssuesRequest = enabled ? queries.issues() : undefined;
+    const y = await z.run(maybeIssuesRequest);
+    expectTypeOf(y).toEqualTypeOf<Issue[] | undefined>();
+    expect(y).toEqual([{id: 'a', value: 1, [refCountSymbol]: 1}]);
+
+    const maybeIssuesAndQuery = enabled && zql.issues;
+    const issuesFromAndQuery = await z.run(maybeIssuesAndQuery);
+    expectTypeOf(issuesFromAndQuery).toEqualTypeOf<Issue[] | undefined>();
+
+    const disabled = false as boolean;
+    const skippedQuery = disabled ? zql.issues : undefined;
+    const skipped = await z.run(skippedQuery);
+    expectTypeOf(skipped).toEqualTypeOf<Issue[] | undefined>();
+    expect(skipped).toBeUndefined();
+
+    const skippedFalseQuery = disabled && zql.issues;
+    const skippedFalse = await z.run(skippedFalseQuery);
+    expectTypeOf(skippedFalse).toEqualTypeOf<Issue[] | undefined>();
+    expect(skippedFalse).toBeUndefined();
+  });
+
+  test('tx.run with conditional query return types', () => {
+    const check = async (tx: Transaction<typeof schema>) => {
+      const issues = await tx.run(zql.issues);
+      expectTypeOf(issues).toEqualTypeOf<Issue[]>();
+
+      const issue = await tx.run(zql.issues.one());
+      expectTypeOf(issue).toEqualTypeOf<Issue | undefined>();
+
+      const enabled = true as boolean;
+      const maybeIssuesQuery = enabled ? zql.issues : undefined;
+      const maybeIssues = await tx.run(maybeIssuesQuery);
+      expectTypeOf(maybeIssues).toEqualTypeOf<Issue[] | undefined>();
+
+      const maybeIssuesAndQuery = enabled && zql.issues;
+      const maybeIssuesAnd = await tx.run(maybeIssuesAndQuery);
+      expectTypeOf(maybeIssuesAnd).toEqualTypeOf<Issue[] | undefined>();
+
+      const maybeIssueQuery = enabled ? zql.issues.one() : undefined;
+      const maybeIssue = await tx.run(maybeIssueQuery);
+      expectTypeOf(maybeIssue).toEqualTypeOf<Issue | undefined>();
+
+      const disabled = false as boolean;
+      const skippedQuery = disabled ? zql.issues : undefined;
+      const skipped = await tx.run(skippedQuery);
+      expectTypeOf(skipped).toEqualTypeOf<Issue[] | undefined>();
+
+      const skippedFalseQuery = disabled && zql.issues;
+      const skippedFalse = await tx.run(skippedFalseQuery);
+      expectTypeOf(skippedFalse).toEqualTypeOf<Issue[] | undefined>();
+    };
+
+    expectTypeOf(check).toBeFunction();
+  });
 });
 
 describe('preload', () => {
@@ -133,6 +200,27 @@ describe('preload', () => {
     const result = await z.preload(zql.issues.one());
     expectTypeOf(result.complete).toEqualTypeOf<Promise<void>>();
     await z.preload(queries.issue());
+  });
+
+  test('preload with conditional query', async () => {
+    const enabled = false as boolean;
+
+    const maybePreload = z.preload(enabled ? zql.issues : undefined);
+    expectTypeOf(maybePreload.complete).toEqualTypeOf<Promise<void>>();
+    await maybePreload.complete;
+    maybePreload.cleanup();
+
+    const skippedQuery = enabled ? zql.issues : undefined;
+    const skipped = z.preload(skippedQuery);
+    expectTypeOf(skipped.complete).toEqualTypeOf<Promise<void>>();
+    await skipped.complete;
+    skipped.cleanup();
+
+    const skippedFalseQuery = enabled && zql.issues;
+    const skippedFalse = z.preload(skippedFalseQuery);
+    expectTypeOf(skippedFalse.complete).toEqualTypeOf<Promise<void>>();
+    await skippedFalse.complete;
+    skippedFalse.cleanup();
   });
 });
 

--- a/packages/zero-server/src/custom.ts
+++ b/packages/zero-server/src/custom.ts
@@ -1,4 +1,5 @@
 import {assert} from '../../shared/src/asserts.ts';
+import type {Falsy} from '../../shared/src/falsy.ts';
 import {mapValues} from '../../shared/src/objects.ts';
 import {recordProxy} from '../../shared/src/record-proxy.ts';
 import {
@@ -149,7 +150,19 @@ export class TransactionImpl<
   run<TTable extends keyof TSchema['tables'] & string, TReturn>(
     query: Query<TTable, TSchema, TReturn>,
     _options?: RunOptions,
-  ): Promise<HumanReadable<TReturn>> {
+  ): Promise<HumanReadable<TReturn>>;
+  run<TTable extends keyof TSchema['tables'] & string, TReturn>(
+    query: Query<TTable, TSchema, TReturn> | Falsy,
+    _options?: RunOptions,
+  ): Promise<HumanReadable<TReturn> | undefined>;
+  run<TTable extends keyof TSchema['tables'] & string, TReturn>(
+    query: Query<TTable, TSchema, TReturn> | Falsy,
+    _options?: RunOptions,
+  ): Promise<HumanReadable<TReturn> | undefined> {
+    if (!query) {
+      return Promise.resolve(undefined);
+    }
+
     const queryInternals = asQueryInternals(query);
 
     // Execute the query using the database-specific executor

--- a/packages/zero-server/src/query.pg.test.ts
+++ b/packages/zero-server/src/query.pg.test.ts
@@ -1,4 +1,4 @@
-import {beforeEach, describe, expect, test} from 'vitest';
+import {beforeEach, describe, expect, expectTypeOf, test} from 'vitest';
 import {testDBs} from '../../zero-cache/src/test/db.ts';
 import type {PostgresDB} from '../../zero-cache/src/types/pg.ts';
 import {makeServerTransaction} from './custom.ts';
@@ -80,6 +80,45 @@ describe('makeSchemaQuery', () => {
       // Test that tx.query.table.run() works (the fix for the bug)
       const result = await transaction.query.basic.run();
       expect(result).toEqual([{id: '1', a: 2, b: 'foo', c: true}]);
+    });
+  });
+
+  test('tx.run handles falsy query', async () => {
+    await pg.begin(async tx => {
+      const dbTransaction = new Transaction(tx);
+      const transaction = await makeServerTransaction(
+        dbTransaction,
+        'test-client',
+        1,
+        schema,
+      );
+
+      const enabled = false as boolean;
+      const query = enabled ? transaction.query.basic : undefined;
+      const result = await transaction.run(query);
+      expectTypeOf(result).toEqualTypeOf<
+        | {
+            readonly id: string;
+            readonly a: number;
+            readonly b: string;
+            readonly c: boolean | null;
+          }[]
+        | undefined
+      >();
+      expect(result).toBeUndefined();
+
+      const falseQuery = enabled && transaction.query.basic;
+      const falseResult = await transaction.run(falseQuery);
+      expectTypeOf(falseResult).toEqualTypeOf<
+        | {
+            readonly id: string;
+            readonly a: number;
+            readonly b: string;
+            readonly c: boolean | null;
+          }[]
+        | undefined
+      >();
+      expect(falseResult).toBeUndefined();
     });
   });
 });

--- a/packages/zero-server/src/zql-database.pg.test.ts
+++ b/packages/zero-server/src/zql-database.pg.test.ts
@@ -1,10 +1,13 @@
-import {beforeEach, expect, test} from 'vitest';
+import {beforeEach, expect, expectTypeOf, test} from 'vitest';
 import {
   getClientsTableDefinition,
   getMutationsTableDefinition,
 } from '../../zero-cache/src/services/change-source/pg/schema/shard.ts';
 import {testDBs} from '../../zero-cache/src/test/db.ts';
 import type {PostgresDB} from '../../zero-cache/src/types/pg.ts';
+import {createSchema} from '../../zero-schema/src/builder/schema-builder.ts';
+import {string, table} from '../../zero-schema/src/builder/table-builder.ts';
+import {createBuilder} from '../../zql/src/query/create-builder.ts';
 import {zeroPostgresJS} from './adapters/postgresjs.ts';
 
 let sql: PostgresDB;
@@ -82,4 +85,38 @@ test('write mutation result', async () => {
     await sql`SELECT "result" FROM zero_0.mutations WHERE "clientGroupID" = 'cg1' AND "clientID" = 'c1' AND "mutationID" = 1`;
   // expect the result to match
   expect(result).toEqual([{result: {data: {foo: 'bar'}}}]);
+});
+
+test('run handles conditional query', async () => {
+  const user = table('user')
+    .columns({
+      id: string(),
+      name: string(),
+    })
+    .primaryKey('id');
+  const schema = createSchema({tables: [user]});
+  const builder = createBuilder(schema);
+  const db = zeroPostgresJS(schema, sql);
+  const enabled = false as boolean;
+
+  const maybeQuery = enabled ? builder.user : undefined;
+  const users = await db.run(maybeQuery);
+  expectTypeOf(users).toEqualTypeOf<
+    {readonly id: string; readonly name: string}[] | undefined
+  >();
+  expect(users).toBeUndefined();
+
+  const skippedQuery = enabled ? builder.user : undefined;
+  const skipped = await db.run(skippedQuery);
+  expectTypeOf(skipped).toEqualTypeOf<
+    {readonly id: string; readonly name: string}[] | undefined
+  >();
+  expect(skipped).toBeUndefined();
+
+  const skippedFalseQuery = enabled && builder.user;
+  const skippedFalse = await db.run(skippedFalseQuery);
+  expectTypeOf(skippedFalse).toEqualTypeOf<
+    {readonly id: string; readonly name: string}[] | undefined
+  >();
+  expect(skippedFalse).toBeUndefined();
 });

--- a/packages/zero-server/src/zql-database.ts
+++ b/packages/zero-server/src/zql-database.ts
@@ -1,3 +1,4 @@
+import type {Falsy} from '../../shared/src/falsy.ts';
 import type {MaybePromise} from '../../shared/src/types.ts';
 import {formatPg, sql} from '../../z2s/src/sql.ts';
 import type {CleanupResultsArg} from '../../zero-protocol/src/mutation.ts';
@@ -121,7 +122,19 @@ export class ZQLDatabase<
   run<TTable extends keyof TSchema['tables'] & string, TReturn>(
     query: Query<TTable, TSchema, TReturn>,
     options?: RunOptions,
-  ): Promise<HumanReadable<TReturn>> {
+  ): Promise<HumanReadable<TReturn>>;
+  run<TTable extends keyof TSchema['tables'] & string, TReturn>(
+    query: Query<TTable, TSchema, TReturn> | Falsy,
+    options?: RunOptions,
+  ): Promise<HumanReadable<TReturn> | undefined>;
+  run<TTable extends keyof TSchema['tables'] & string, TReturn>(
+    query: Query<TTable, TSchema, TReturn> | Falsy,
+    options?: RunOptions,
+  ): Promise<HumanReadable<TReturn> | undefined> {
+    if (!query) {
+      return Promise.resolve(undefined);
+    }
+
     return this.transaction(tx => tx.run(query, options));
   }
 }

--- a/packages/zql/src/mutate/custom.ts
+++ b/packages/zql/src/mutate/custom.ts
@@ -1,4 +1,5 @@
 import {assert} from '../../../shared/src/asserts.ts';
+import type {Falsy} from '../../../shared/src/falsy.ts';
 import type {AST} from '../../../zero-protocol/src/ast.ts';
 import type {
   DefaultSchema,
@@ -51,6 +52,10 @@ export interface TransactionBase<S extends Schema> {
     query: Query<TTable, S, TReturn>,
     options?: RunOptions,
   ): Promise<HumanReadable<TReturn>>;
+  run<TTable extends keyof S['tables'] & string, TReturn>(
+    query: Query<TTable, S, TReturn> | Falsy,
+    options?: RunOptions,
+  ): Promise<HumanReadable<TReturn> | undefined>;
 }
 
 export type Transaction<


### PR DESCRIPTION
It felt like this should exist, when using Zero on CZ; I wanted it to exist, and it felt asymmetric and confusing when it didn't.

- Allow conditional/falsy queries in `tx.run`, `zero.run`, `zero.preload`, and server `ZQLDatabase.run`, matching the `useQuery` maybe-query pattern.
- Return `undefined` or a no-op preload handle when a conditional query is disabled instead of trying to execute it.
- Add Vitest `expectTypeOf` coverage for strict vs conditional return types, plus runtime coverage for skipped conditional queries.