### PR TITLE
fix(zero-cache): use pg_class estimates for initial sync progress reporting

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
@@ -3263,8 +3263,10 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
       expect(state.status.rows).toBe(0); // rows starts at 0, incremented during copy
       // After ANALYZE, reltuples should be exactly 1000.
       expect(state.status.totalRows).toBe(1000);
-      // pg_relation_size should return a positive byte count.
-      expect(state.status.totalBytes).toBeGreaterThan(0);
+      // 1000 rows × ~150 bytes each (100-byte data + id + name + overhead).
+      // pg_relation_size returns the on-disk file size, expect 100KB-500KB.
+      expect(state.status.totalBytes).toBeGreaterThan(100_000);
+      expect(state.status.totalBytes).toBeLessThan(500_000);
     });
 
     test('returns zeros for a never-analyzed empty table', async () => {
@@ -3316,7 +3318,10 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
       const state = await getInitialDownloadState(lc, upstream, spec, false);
 
       expect(state.status.totalRows).toBe(100);
-      expect(state.status.totalBytes).toBeGreaterThan(0);
+      // 100 rows × ~40 bytes each (id + val + overhead).
+      // Expect at least one 8KB page and no more than 64KB.
+      expect(state.status.totalBytes).toBeGreaterThanOrEqual(8192);
+      expect(state.status.totalBytes).toBeLessThan(65_536);
     });
   });
 });

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
@@ -31,6 +31,7 @@ import {pgClient, type PostgresDB} from '../../../types/pg.ts';
 import {ZERO_VERSION_COLUMN_NAME} from '../../replicator/schema/replication-state.ts';
 import {
   createReplicationSlot,
+  getInitialDownloadState,
   initialSync,
   INSERT_BATCH_SIZE,
   shadowInitialSync,
@@ -3218,6 +3219,104 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
           verifyShadowReplica(lc, replica, publishedInfo, new Map()),
         ).toThrow(/dropped by computeZqlSpecs.*big/s);
       });
+    });
+  });
+
+  describe('getInitialDownloadState', () => {
+    let upstream: PostgresDB;
+
+    beforeEach<PgTest>(async ({testDBs}) => {
+      upstream = await testDBs.create('download_state_test');
+      return () => testDBs.drop(upstream);
+    });
+
+    test('returns estimates from pg_class for a populated table', async () => {
+      await upstream.unsafe(/*sql*/ `
+        CREATE TABLE estimate_test (
+          id INTEGER PRIMARY KEY,
+          name TEXT,
+          data TEXT
+        );
+        INSERT INTO estimate_test (id, name, data)
+          SELECT i, 'name_' || i, repeat('x', 100)
+          FROM generate_series(1, 1000) AS i;
+        ANALYZE estimate_test;
+      `);
+
+      const lc = createSilentLogContext();
+      const spec: PublishedTableSpec = {
+        schema: 'public',
+        name: 'estimate_test',
+        columns: {
+          id: {dataType: 'int4', pos: 1},
+          name: {dataType: 'text', pos: 2},
+          data: {dataType: 'text', pos: 3},
+        },
+        publications: {pub1: {rowFilter: null}},
+      } as unknown as PublishedTableSpec;
+
+      const state = await getInitialDownloadState(lc, upstream, spec, false);
+
+      expect(state.spec).toBe(spec);
+      expect(state.status.table).toBe('estimate_test');
+      expect(state.status.columns).toEqual(['id', 'name', 'data']);
+      expect(state.status.rows).toBe(0); // rows starts at 0, incremented during copy
+      // After ANALYZE, reltuples should be exactly 1000.
+      expect(state.status.totalRows).toBe(1000);
+      // pg_relation_size should return a positive byte count.
+      expect(state.status.totalBytes).toBeGreaterThan(0);
+    });
+
+    test('returns zeros for a never-analyzed empty table', async () => {
+      await upstream.unsafe(/*sql*/ `
+        CREATE TABLE empty_test (
+          id INTEGER PRIMARY KEY
+        );
+      `);
+
+      const lc = createSilentLogContext();
+      const spec: PublishedTableSpec = {
+        schema: 'public',
+        name: 'empty_test',
+        columns: {
+          id: {dataType: 'int4', pos: 1},
+        },
+        publications: {pub1: {rowFilter: null}},
+      } as unknown as PublishedTableSpec;
+
+      const state = await getInitialDownloadState(lc, upstream, spec, false);
+
+      expect(state.status.totalRows).toBe(0);
+      expect(state.status.totalBytes).toBe(0);
+    });
+
+    test('handles non-public schema tables', async () => {
+      await upstream.unsafe(/*sql*/ `
+        CREATE SCHEMA test_schema;
+        CREATE TABLE test_schema.my_table (
+          id INTEGER PRIMARY KEY,
+          val TEXT
+        );
+        INSERT INTO test_schema.my_table (id, val)
+          SELECT i, 'val_' || i FROM generate_series(1, 100) AS i;
+        ANALYZE test_schema.my_table;
+      `);
+
+      const lc = createSilentLogContext();
+      const spec: PublishedTableSpec = {
+        schema: 'test_schema',
+        name: 'my_table',
+        columns: {
+          id: {dataType: 'int4', pos: 1},
+          val: {dataType: 'text', pos: 2},
+        },
+        publications: {pub1: {rowFilter: null}},
+      } as unknown as PublishedTableSpec;
+
+      const state = await getInitialDownloadState(lc, upstream, spec, false);
+
+      expect(state.status.totalRows).toBe(100);
+      expect(state.status.totalBytes).toBeGreaterThan(0);
     });
   });
 });

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.test.ts
@@ -97,12 +97,18 @@ describe('getInitialDownloadState', () => {
 
   test('skipTotals=true returns zeros without touching the DB', async () => {
     let called = false;
-    const sql = {
-      unsafe() {
+    const sql = Object.assign(
+      () => {
         called = true;
         throw new Error('sql should not be called when skipTotals=true');
       },
-    } as unknown as PostgresDB;
+      {
+        unsafe() {
+          called = true;
+          throw new Error('sql should not be called when skipTotals=true');
+        },
+      },
+    ) as unknown as PostgresDB;
 
     const state = await getInitialDownloadState(
       createSilentLogContext(),
@@ -120,17 +126,23 @@ describe('getInitialDownloadState', () => {
     });
   });
 
-  test('skipTotals=false runs the expensive queries', async () => {
-    const received: string[] = [];
-    const sql = {
-      unsafe(stmt: string) {
-        received.push(stmt);
-        const row = stmt.includes('totalRows')
-          ? [{totalRows: 42n}]
-          : [{totalBytes: 1024n}];
-        return {execute: () => Promise.resolve(row)};
+  test('skipTotals=false uses pg_class estimates', async () => {
+    // The tagged template sql`...` is called as a function with
+    // (strings, ...values) when used as a template tag.
+    const sql = Object.assign(
+      (strings: TemplateStringsArray, ..._values: unknown[]) => {
+        const query = strings.join('$1');
+        if (query.includes('pg_class')) {
+          return Promise.resolve([{totalRows: 42, totalBytes: 8192}]);
+        }
+        return Promise.resolve([]);
       },
-    } as unknown as PostgresDB;
+      {
+        unsafe() {
+          throw new Error('unsafe should not be called');
+        },
+      },
+    ) as unknown as PostgresDB;
 
     const state = await getInitialDownloadState(
       createSilentLogContext(),
@@ -138,11 +150,8 @@ describe('getInitialDownloadState', () => {
       tableSpec(),
       false,
     );
-    expect(received).toHaveLength(2);
-    expect(received.some(s => s.includes('COUNT(*)'))).toBe(true);
-    expect(received.some(s => s.includes('pg_column_size'))).toBe(true);
     expect(state.status.totalRows).toBe(42);
-    expect(state.status.totalBytes).toBe(1024);
+    expect(state.status.totalBytes).toBe(8192);
   });
 });
 

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
@@ -900,7 +900,7 @@ export async function getInitialDownloadState(
   const estimateResult = await sql<
     {totalRows: number; totalBytes: number}[]
   >`SELECT GREATEST(reltuples, 0)::float8 AS "totalRows",
-         pg_relation_size(oid)::float8 AS "totalBytes"
+         pg_table_size(oid)::float8 AS "totalBytes"
     FROM pg_class
     WHERE oid = ${qualifiedName}::regclass`;
 

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
@@ -886,21 +886,28 @@ export async function getInitialDownloadState(
   const table = liteTableName(spec);
   const columns = Object.keys(spec.columns);
   if (skipTotals) {
-    // Shadow sync suppresses status events, so the COUNT(*) and
-    // per-column pg_column_size sums would be computed and thrown away.
-    // These are also expensive statements that run table scans.
+    // Shadow sync suppresses status events, so the pg_class
+    // estimates would be computed and thrown away.
     return {
       spec,
       status: {table, columns, rows: 0, totalRows: 0, totalBytes: 0},
     };
   }
-  const stmts = makeDownloadStatements(spec, columns);
-  const rowsResult = sql
-    .unsafe<{totalRows: bigint}[]>(stmts.getTotalRows)
-    .execute();
-  const bytesResult = sql
-    .unsafe<{totalBytes: bigint}[]>(stmts.getTotalBytes)
-    .execute();
+  // Use pg_class estimates instead of expensive COUNT(*) and
+  // SUM(pg_column_size(...)) full table scans. The exact values are only
+  // used for progress reporting, so estimates are sufficient.
+  const qualifiedName = `${id(spec.schema)}.${id(spec.name)}`;
+  const estimateResult = await sql<
+    {totalRows: number; totalBytes: number}[]
+  >`SELECT GREATEST(reltuples, 0)::float8 AS "totalRows",
+         pg_relation_size(oid)::float8 AS "totalBytes"
+    FROM pg_class
+    WHERE oid = ${qualifiedName}::regclass`;
+
+  const {totalRows, totalBytes} = estimateResult[0] ?? {
+    totalRows: 0,
+    totalBytes: 0,
+  };
 
   const state: DownloadState = {
     spec,
@@ -908,8 +915,8 @@ export async function getInitialDownloadState(
       table,
       columns,
       rows: 0,
-      totalRows: Number((await rowsResult)[0].totalRows),
-      totalBytes: Number((await bytesResult)[0].totalBytes),
+      totalRows,
+      totalBytes,
     },
   };
   const elapsed = (performance.now() - start).toFixed(3);


### PR DESCRIPTION
Replace expensive COUNT(*) and SUM(pg_column_size(...)) full table scans in getInitialDownloadState with instant pg_class.reltuples and pg_table_size() lookups. These values are only used for progress reporting status events.

The previous exact queries caused failures on large databases as each scan could take hours on large tables.