### PR TITLE
feat(zero-cache): add region to litestream config

### DIFF
--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -831,6 +831,15 @@ export const zeroOptions = {
       ],
     },
 
+    region: {
+      type: v.string().optional(),
+      desc: [
+        `The AWS region for the litestream backup bucket. Required for non-standard AWS partitions`,
+        `(e.g. GovCloud {bold us-gov-west-1}) where Litestream cannot auto-detect the region.`,
+        `The {bold replication-manager} and {bold view-syncers} must have the same region.`,
+      ],
+    },
+
     port: {
       type: v.number().optional(),
       desc: [

--- a/packages/zero-cache/src/services/litestream/commands.ts
+++ b/packages/zero-cache/src/services/litestream/commands.ts
@@ -95,6 +95,7 @@ function getLitestream(
     logLevel,
     configPath,
     endpoint,
+    region,
     port = config.port + 2,
     checkpointThresholdMB,
     minCheckpointPageCount = checkpointThresholdMB * 250, // SQLite page size is 4KB
@@ -140,6 +141,7 @@ function getLitestream(
       ['LITESTREAM_CONFIG']: configPath,
       ['LITESTREAM_PORT']: String(port),
       ...(endpoint ? {['ZERO_LITESTREAM_ENDPOINT']: endpoint} : {}),
+      ...(region ? {['ZERO_LITESTREAM_REGION']: region} : {}),
     },
   };
 }

--- a/packages/zero-cache/src/services/litestream/config.yml
+++ b/packages/zero-cache/src/services/litestream/config.yml
@@ -7,6 +7,7 @@ dbs:
     replicas:
       - url: ${ZERO_LITESTREAM_BACKUP_URL}
         endpoint: ${ZERO_LITESTREAM_ENDPOINT}
+        region: ${ZERO_LITESTREAM_REGION}
         retention: ${ZERO_LITESTREAM_SNAPSHOT_BACKUP_INTERVAL_MINUTES}m
         retention-check-interval: 1h
         sync-interval: ${ZERO_LITESTREAM_INCREMENTAL_BACKUP_INTERVAL_MINUTES}m


### PR DESCRIPTION
Expose a `ZERO_LITESTREAM_REGION` to set a region for non-standard AWS Partitions

Context:
When deploying zero-cache in AWS GovCloud (us-gov-west-1) or other non-standard AWS partitions, Litestream S3 backups fail with: `AuthorizationHeaderMalformed: the region 'us-east-1' is wrong; expecting 'us-gov-west-1'`