### PR TITLE
feat(zero-cache): support synchronized_standby_slots for Postgres 17+ logical replication failover

### DIFF
--- a/apps/zbugs/docker/docker-compose.yml
+++ b/apps/zbugs/docker/docker-compose.yml
@@ -1,5 +1,5 @@
 x-postgres-common: &postgres-common
-  image: postgres:17-alpine
+  image: postgres:16.2-alpine
   shm_size: 1g
   user: postgres
   restart: always
@@ -21,10 +21,8 @@ services:
     command: |
       postgres 
       -c wal_level=logical
-      -c max_wal_senders=50 
-      -c max_replication_slots=20 
-      -c max_slot_wal_keep_size=1GB
-      -c max_connections=500
+      -c max_wal_senders=10 
+      -c max_replication_slots=5 
       -c hot_standby=on 
       -c hot_standby_feedback=on
     volumes:
@@ -41,10 +39,8 @@ services:
     command: |
       postgres 
       -c wal_level=logical
-      -c max_wal_senders=50 
-      -c max_replication_slots=20
-      -c max_slot_wal_keep_size=1GB
-      -c max_connections=500
+      -c max_wal_senders=10 
+      -c max_replication_slots=5 
       -c hot_standby=on 
       -c hot_standby_feedback=on
     volumes:

--- a/apps/zbugs/docker/docker-compose.yml
+++ b/apps/zbugs/docker/docker-compose.yml
@@ -4,7 +4,7 @@ x-postgres-common: &postgres-common
   user: postgres
   restart: always
   healthcheck:
-    test: "pg_isready -U user --dbname=postgres"
+    test: 'pg_isready -U user --dbname=postgres'
     interval: 10s
     timeout: 5s
     retries: 5

--- a/apps/zbugs/docker/docker-compose.yml
+++ b/apps/zbugs/docker/docker-compose.yml
@@ -1,10 +1,10 @@
 x-postgres-common: &postgres-common
-  image: postgres:16.2-alpine
+  image: postgres:17-alpine
   shm_size: 1g
   user: postgres
   restart: always
   healthcheck:
-    test: 'pg_isready -U user --dbname=postgres'
+    test: "pg_isready -U user --dbname=postgres"
     interval: 10s
     timeout: 5s
     retries: 5
@@ -21,8 +21,10 @@ services:
     command: |
       postgres 
       -c wal_level=logical
-      -c max_wal_senders=10 
-      -c max_replication_slots=5 
+      -c max_wal_senders=50 
+      -c max_replication_slots=20 
+      -c max_slot_wal_keep_size=1GB
+      -c max_connections=500
       -c hot_standby=on 
       -c hot_standby_feedback=on
     volumes:
@@ -39,8 +41,10 @@ services:
     command: |
       postgres 
       -c wal_level=logical
-      -c max_wal_senders=10 
-      -c max_replication_slots=5 
+      -c max_wal_senders=50 
+      -c max_replication_slots=20
+      -c max_slot_wal_keep_size=1GB
+      -c max_connections=500
       -c hot_standby=on 
       -c hot_standby_feedback=on
     volumes:

--- a/packages/zero-cache/src/server/change-streamer.pg.test.ts
+++ b/packages/zero-cache/src/server/change-streamer.pg.test.ts
@@ -67,8 +67,10 @@ test('change-streamer startup does not deadlock on autoreset retry when change a
       {test: 'context'},
     ));
 
-    const [{slot: oldSlot}] = await upstream<{slot: string}[]>`
-      SELECT slot FROM ${upstream(`${shard.appID}_${shard.shardNum}.replicas`)}`;
+    const [{id: oldID, slot: oldSlot}] = await upstream<
+      {id: string; slot: string}[]
+    >`
+      SELECT id, slot FROM ${upstream(`${shard.appID}_${shard.shardNum}.replicas`)}`;
 
     const restoredReplica = replicaFile.connect(lc);
     const subscriptionState = getSubscriptionState(
@@ -130,13 +132,14 @@ test('change-streamer startup does not deadlock on autoreset retry when change a
       process.env.SINGLE_PROCESS = originalSingleProcess;
     }
 
-    const liveSlots = await upstream<{slot: string}[]>`
-      SELECT slot_name as slot
+    const liveSlots = await upstream<{id: string; slot: string}[]>`
+      SELECT id, slot, rank
         FROM pg_replication_slots
-       WHERE slot_name LIKE ${`${shard.appID}\\_${shard.shardNum}\\_%`}
-       ORDER BY slot_name`;
-    expect(liveSlots).toHaveLength(1);
-    expect(liveSlots[0].slot).not.toBe(oldSlot);
+        JOIN ${upstream(`${shard.appID}_${shard.shardNum}.replicas`)} ON slot_name = slot
+        ORDER BY rank DESC LIMIT 1;
+    `;
+    expect(liveSlots[0].slot).toBe(oldSlot); // same slot name
+    expect(liveSlots[0].id).not.toBe(oldID); // was reused for new replica
   } finally {
     await initialSource?.stop().catch(() => {});
     replicaFile.delete();

--- a/packages/zero-cache/src/services/change-source/pg/backfill-stream.ts
+++ b/packages/zero-cache/src/services/change-source/pg/backfill-stream.ts
@@ -32,12 +32,12 @@ import {
   tableMetadataSchema,
 } from './backfill-metadata.ts';
 import {
-  createReplicationSlot,
   makeBinarySelectExprs,
   makeDownloadStatements,
   type DownloadStatements,
 } from './initial-sync.ts';
 import {toStateVersionString} from './lsn.ts';
+import {createReplicationSlot} from './replication-slots.ts';
 import {getPublicationInfo} from './schema/published.ts';
 import type {Replica} from './schema/shard.ts';
 
@@ -299,15 +299,15 @@ async function createSnapshotTransaction(
       connection: {replication: 'database'}, // https://www.postgresql.org/docs/current/protocol-replication.html
     },
   );
-  const tempSlot = `${slotNamePrefix}_bf_${Date.now()}`;
+  const slotName = `${slotNamePrefix}_bf_${Date.now()}`;
   try {
     const {snapshot_name: snapshot, consistent_point: lsn} =
-      await createReplicationSlot(lc, replicationSession, tempSlot);
+      await createReplicationSlot(lc, replicationSession, {slotName});
 
     const {init, imported} = importSnapshot(snapshot);
     const tx = new TransactionPool(lc, {mode: READONLY, init}).run(db);
     await imported;
-    await replicationSession.unsafe(`DROP_REPLICATION_SLOT "${tempSlot}"`);
+    await replicationSession.unsafe(`DROP_REPLICATION_SLOT "${slotName}"`);
 
     const watermark = toStateVersionString(lsn);
     lc.info?.(`Opened snapshot transaction at LSN ${lsn} (${watermark})`);
@@ -317,7 +317,7 @@ async function createSnapshotTransaction(
     await replicationSession.unsafe(
       /*sql*/
       `SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots
-         WHERE slot_name = '${tempSlot}'`,
+         WHERE slot_name = '${slotName}'`,
     );
     lc.warn?.(`Failed to create backfill snapshot`, e);
     throw e;

--- a/packages/zero-cache/src/services/change-source/pg/change-source.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.pg.test.ts
@@ -1076,7 +1076,7 @@ describe('change-source/pg', {timeout: 30000, retry: 3}, () => {
 
     // Start a *third* initial sync with an empty replica.
     const replicaFile3 = new DbFile('change_source_pg_test_replica2');
-    await initializePostgresChangeSource(
+    const {changeSource: source3} = await initializePostgresChangeSource(
       lc,
       upstreamURI,
       {
@@ -1105,8 +1105,6 @@ describe('change-source/pg', {timeout: 30000, retry: 3}, () => {
     // subscription and drop the first replication slot.
     const {changes: changes2} = await startStream('00', source2);
 
-    await expect(() => downstream1.dequeue()).rejects.toThrow(AbortError);
-
     // The new stream should get the same changes since it was synced
     // before they occurred.
     const downstream2 = drainToQueue(changes2);
@@ -1125,17 +1123,36 @@ describe('change-source/pg', {timeout: 30000, retry: 3}, () => {
       {watermark: expect.stringMatching(WATERMARK_REGEX)},
     ]);
 
-    changes2.cancel();
-
     // Verify that the older replica state has been cleaned up.
     // The newer replica state should remain.
-    const replicasAfterTakeover = await upstream.unsafe(`
+    const replicasAfterSource2 = await upstream.unsafe(`
       SELECT slot FROM "${APP_ID}_${SHARD_NUM}".replicas ORDER BY slot
     `);
-    expect(replicasAfterTakeover).toEqual(replicas3.slice(1));
+    expect(replicasAfterSource2).toEqual(replicas3.slice(1));
 
-    // Verify that the two latter slots remain. (Use waitFor to reduce
-    // flakiness because the drop is non-transactional.)
+    // However, all 3 replication slots should remain because [1] is still
+    // active and [3], although not yet active, is a newer replica.
+    const slots3 = await upstream<{slot: string}[]>`
+        SELECT slot_name as slot FROM pg_replication_slots
+          WHERE slot_name LIKE ${APP_ID + '\\_' + SHARD_NUM + '\\_%'}
+          ORDER BY slot_name
+      `.values();
+    expect(slots3).toHaveLength(3);
+
+    // Shut down the first replica slot and then start the third one.
+    changes1.cancel();
+    const {changes: changes3} = await startStream('00', source3);
+
+    // Now there should only be one replica left.
+    const replicasAfterSource3 = await upstream.unsafe(`
+      SELECT slot FROM "${APP_ID}_${SHARD_NUM}".replicas ORDER BY slot
+    `);
+    expect(replicasAfterSource3).toEqual(replicas3.slice(2));
+
+    // Verify that the two latter slots remain. The first one should have
+    // been dropped because the source stopped subscribing. The second
+    // one is allowed to drain.
+    // (Use waitFor to reduce flakiness because the drop is non-transactional.)
     await vi.waitFor(
       async () => {
         const slots3 = await upstream<{slot: string}[]>`
@@ -1145,11 +1162,11 @@ describe('change-source/pg', {timeout: 30000, retry: 3}, () => {
     `.values();
         expect(slots3).toEqual(slots2.slice(1));
       },
-      {
-        interval: 100,
-      },
+      {interval: 100},
     );
 
+    changes2.cancel();
+    changes3.cancel();
     replicaFile2.delete();
     replicaFile3.delete();
   });

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -1,7 +1,6 @@
 import {
   PG_ADMIN_SHUTDOWN,
   PG_INSUFFICIENT_PRIVILEGE,
-  PG_OBJECT_IN_USE,
 } from '@drdgvhbh/postgres-error-codes';
 import type {LogContext} from '@rocicorp/logger';
 import {nanoid} from 'nanoid';
@@ -17,14 +16,12 @@ import {
   intersection,
   symmetricDifferences,
 } from '../../../../../shared/src/set-utils.ts';
-import {sleep} from '../../../../../shared/src/sleep.ts';
 import * as v from '../../../../../shared/src/valita.ts';
 import {Database} from '../../../../../zqlite/src/db.ts';
 import {
   mapPostgresToLiteColumn,
   UnsupportedColumnDefaultError,
 } from '../../../db/pg-to-lite.ts';
-import {runTx} from '../../../db/run-transaction.ts';
 import type {
   ColumnSpec,
   PublishedIndexSpec,
@@ -88,6 +85,7 @@ import type {
 } from './logical-replication/pgoutput.types.ts';
 import {subscribe, type StreamMessage} from './logical-replication/stream.ts';
 import {fromBigInt, toBigInt, toStateVersionString, type LSN} from './lsn.ts';
+import {dropOldReplicasAndSlots} from './replication-slots.ts';
 import {replicationEventSchema, type ReplicationEvent} from './schema/ddl.ts';
 import {updateShardSchema} from './schema/init.ts';
 import {
@@ -100,13 +98,14 @@ import {
   getInternalShardConfig,
   getReplicaAtVersion,
   internalPublicationPrefix,
-  legacyReplicationSlot,
   replicaIdentitiesForTablesWithoutPrimaryKeys,
-  replicationSlotExpression,
+  replicationSlotPrefix,
   type InternalShardConfig,
   type Replica,
 } from './schema/shard.ts';
 import {validate} from './schema/validation.ts';
+
+const REPLICA_SLOT_CLEANUP_INTERVAL_MS = 30_000;
 
 /**
  * Initializes a Postgres change source, including the initial sync of the
@@ -294,6 +293,7 @@ class PostgresChangeSource implements ChangeSource {
 
   async stop(): Promise<void> {
     this.#lagReporter?.stop();
+    clearTimeout(this.#cleanupTimer);
     await this.#db.end();
   }
 
@@ -328,10 +328,9 @@ class PostgresChangeSource implements ChangeSource {
     clientWatermark: string,
     backfillRequests: BackfillRequest[] = [],
   ): Promise<ChangeStream> {
-    const {slot} = this.#replica;
-
-    await this.#stopExistingReplicationSlotSubscribers(slot);
+    await this.#stopExistingReplicationSlotSubscriber();
     const config = await getInternalShardConfig(this.#db, this.#shard);
+    const {slot} = this.#replica;
     this.#lc.info?.(`starting replication stream@${slot}`);
     return this.#startStream(slot, clientWatermark, config, backfillRequests);
   }
@@ -505,117 +504,72 @@ class PostgresChangeSource implements ChangeSource {
   }
 
   /**
-   * Stops replication slots associated with this shard, and returns
-   * a `cleanup` task that drops any slot other than the specified
-   * `slotToKeep`.
-   *
-   * Note that replication slots created after `slotToKeep` (as indicated by
-   * the timestamp suffix) are preserved, as those are newly syncing replicas
-   * that will soon take over the slot.
+   * Stops replication slots associated with this shard, and asynchronously
+   * runs a cleanup task that drops older replicas and slots.
    */
-  async #stopExistingReplicationSlotSubscribers(slotToKeep: string) {
-    const slotExpression = replicationSlotExpression(this.#shard);
-    const legacySlotName = legacyReplicationSlot(this.#shard);
+  async #stopExistingReplicationSlotSubscriber() {
+    const sql = this.#db;
+    const {id: replicaID, slot} = this.#replica;
+    const replicasTable = `${upstreamSchema(this.#shard)}.replicas`;
 
-    const result = await runTx(this.#db, async sql => {
-      // Note: `slot_name <= slotToKeep` uses a string compare of the millisecond
-      // timestamp, which works until it exceeds 13 digits (sometime in 2286).
-      const result = await sql<
-        {slot: string; pid: string | null; terminated: boolean | null}[]
-      > /*sql*/ `
-      SELECT slot_name as slot, pg_terminate_backend(active_pid) as terminated, active_pid as pid
-        FROM pg_replication_slots 
-        WHERE (slot_name LIKE ${slotExpression} OR slot_name = ${legacySlotName})
-              AND slot_name <= ${slotToKeep}`;
-      this.#lc.info?.(
-        `terminated replication slots: ${JSON.stringify(result)}`,
-      );
-      const replicasTable = `${upstreamSchema(this.#shard)}.replicas`;
-      const replicasBefore = await sql`
-        SELECT slot, version, "initialSyncContext", "subscriberContext" 
-          FROM ${sql(replicasTable)} ORDER BY slot`;
-
-      if (result.length === 0) {
-        const shardSlots = await sql`
+    const result = await sql`
+      SELECT pg_terminate_backend(active_pid) as terminated, active_pid as pid
+        FROM pg_replication_slots
+        WHERE slot_name = ${slot}
+    `;
+    if (result.length === 0) {
+      const slotExpression = replicationSlotPrefix(this.#shard);
+      const replicas = await sql`
+        SELECT id, rank, slot, version, "initialSyncContext", "subscriberContext" 
+          FROM ${sql(replicasTable)} ORDER BY rank DESC`;
+      const slots = await sql`
         SELECT slot_name as slot, active, active_pid as pid
           FROM pg_replication_slots
-          WHERE slot_name LIKE ${slotExpression} OR slot_name = ${legacySlotName}
+          WHERE slot_name LIKE ${slotExpression}
           ORDER BY slot_name`;
-        this.#lc.warn?.(
-          `slot ${slotToKeep} not found while cleaning subscribers`,
-          {slots: shardSlots, replicas: replicasBefore},
-        );
-        throw new AbortError(
-          `replication slot ${slotToKeep} is missing. A different ` +
-            `replication-manager should now be running on a new ` +
-            `replication slot.`,
-        );
-      }
-      // Clear the state of the older replicas.
-      this.#lc.info?.(
-        `replicas before cleanup (slotToKeep=${slotToKeep}): ${JSON.stringify(
-          replicasBefore,
-        )}`,
-      );
-      await sql`
-        DELETE FROM ${sql(replicasTable)} WHERE slot < ${slotToKeep}`;
-      await sql`
-        UPDATE ${sql(replicasTable)} 
-          SET "subscriberContext" = ${this.#context}
-          WHERE slot = ${slotToKeep}`;
-      const replicasAfter = await sql<{slot: string; version: string}[]>`
-      SELECT slot, version FROM ${sql(replicasTable)} ORDER BY slot`;
-      this.#lc.info?.(
-        `replicas after cleanup (slotToKeep=${slotToKeep}): ${JSON.stringify(
-          replicasAfter,
-        )}`,
-      );
-      return result;
-    });
-
-    const pids = result.filter(({pid}) => pid !== null).map(({pid}) => pid);
-    if (pids.length) {
-      this.#lc.info?.(`signaled subscriber ${pids} to shut down`);
-    }
-    const otherSlots = result
-      .filter(({slot}) => slot !== slotToKeep)
-      .map(({slot}) => slot);
-
-    if (otherSlots.length) {
-      void this.#dropReplicationSlots(otherSlots).catch(e =>
-        this.#lc.warn?.(`error dropping replication slots`, e),
+      this.#lc.warn?.(`slot ${slot} not found while cleaning subscribers`, {
+        slots,
+        replicas,
+      });
+      throw new AbortError(
+        `replication slot ${slot} is missing. A different ` +
+          `replication-manager should now be running on a new ` +
+          `replication slot.`,
       );
     }
+    this.#lc.info?.(`terminated replication slots: ${JSON.stringify(result)}`);
+    await sql`
+      UPDATE ${sql(replicasTable)} 
+        SET "subscriberContext" = ${this.#context}
+        WHERE id = ${replicaID}`;
+    void this.#cleanUpOlderReplicasAndSlots();
   }
 
-  async #dropReplicationSlots(slots: string[]) {
-    this.#lc.info?.(`dropping other replication slot(s) ${slots}`);
-    const sql = this.#db;
-    for (let i = 0; i < 5; i++) {
-      try {
-        await sql`
-          SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots
-            WHERE slot_name IN ${sql(slots)}
-        `;
-        this.#lc.info?.(`successfully dropped ${slots}`);
+  #cleanupTimer: NodeJS.Timeout | undefined;
+
+  async #cleanUpOlderReplicasAndSlots() {
+    clearTimeout(this.#cleanupTimer);
+
+    try {
+      const result = await dropOldReplicasAndSlots(
+        this.#lc,
+        this.#db,
+        this.#shard,
+        this.#replica.rank,
+      );
+      if (result.draining === 0) {
+        this.#lc.info?.(`finished cleaning up replicas and slots`, {result});
         return;
-      } catch (e) {
-        // error: replication slot "zero_slot_change_source_test_id" is active for PID 268
-        if (
-          e instanceof postgres.PostgresError &&
-          e.code === PG_OBJECT_IN_USE
-        ) {
-          // The freeing up of the replication slot is not transactional;
-          // sometimes it takes time for Postgres to consider the slot
-          // inactive.
-          this.#lc.debug?.(`attempt ${i + 1}: ${String(e)}`, e);
-        } else {
-          this.#lc.warn?.(`error dropping ${slots}`, e);
-        }
-        await sleep(1000);
       }
+      this.#lc.info?.(`old slots still draining`, {result});
+    } catch (e) {
+      this.#lc.warn?.(`error dropping replication slots`, e);
     }
-    this.#lc.warn?.(`maximum attempts exceeded dropping ${slots}`);
+
+    this.#cleanupTimer = setTimeout(
+      () => this.#cleanUpOlderReplicasAndSlots(),
+      REPLICA_SLOT_CLEANUP_INTERVAL_MS,
+    );
   }
 }
 

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
@@ -1,10 +1,8 @@
 import {mkdtemp, readdir, rm} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
-import {PG_LOCK_NOT_AVAILABLE} from '@drdgvhbh/postgres-error-codes';
 import {LogContext} from '@rocicorp/logger';
 import {nanoid} from 'nanoid/non-secure';
-import postgres from 'postgres';
 import {beforeEach, describe, expect} from 'vitest';
 import {
   createSilentLogContext,
@@ -27,10 +25,9 @@ import {
   initDB as initLiteDB,
 } from '../../../test/lite.ts';
 import {PG_17} from '../../../types/pg-versions.ts';
-import {pgClient, type PostgresDB} from '../../../types/pg.ts';
+import {type PostgresDB} from '../../../types/pg.ts';
 import {ZERO_VERSION_COLUMN_NAME} from '../../replicator/schema/replication-state.ts';
 import {
-  createReplicationSlot,
   getInitialDownloadState,
   initialSync,
   INSERT_BATCH_SIZE,
@@ -2646,7 +2643,7 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
           .map(([_, spec]) => spec);
         for (const r of replicas) {
           expect(r).toMatchObject({
-            slot: expect.stringMatching(`${APP_ID}_${SHARD_NUM}_\\d+`),
+            slot: expect.stringMatching(`${APP_ID}_${SHARD_NUM}_[a-z]`),
             // Importantly, the initialSchema column is populated during initial sync.
             initialSchema: {
               tables: tableSpecs,
@@ -2896,61 +2893,6 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
       'Error: The App ID may only consist of lower-case letters, numbers, and the underscore character',
     );
   });
-
-  test(
-    'createReplicationSlot times out behind an older idle transaction',
-    {timeout: 45_000},
-    async () => {
-      const lc = createSilentLogContext();
-      const upstreamURI = getConnectionURI(upstream);
-      const timeoutSlot = `${APP_ID}_${SHARD_NUM}_${Date.now()}_timeout`;
-      const blocker = pgClient(lc, upstreamURI, 'slot-timeout-blocker', {
-        max: 1,
-      });
-      const timeoutSession = pgClient(
-        lc,
-        upstreamURI,
-        'slot-timeout-under-test',
-        {
-          max: 1,
-          ['fetch_types']: false,
-          connection: {replication: 'database'},
-        },
-      );
-
-      let blockerInTransaction = false;
-      try {
-        // Start a transaction in one session and leave it open.
-        await blocker`BEGIN`;
-        blockerInTransaction = true;
-        await blocker`SELECT txid_current()`;
-
-        // The server-side lock_timeout (set inside createReplicationSlot)
-        // should fire before the client-side orTimeout, producing a
-        // PostgresError with code 55P03 (lock_not_available).
-        let caught: unknown;
-        try {
-          await createReplicationSlot(lc, timeoutSession, timeoutSlot);
-        } catch (e) {
-          caught = e;
-        }
-        expect(caught).toBeInstanceOf(postgres.PostgresError);
-        expect((caught as postgres.PostgresError).code).toBe(
-          PG_LOCK_NOT_AVAILABLE,
-        );
-      } finally {
-        if (blockerInTransaction) {
-          await blocker`ROLLBACK`;
-        }
-        await blocker.end();
-        await timeoutSession.end().catch(() => {});
-        await upstream`
-          SELECT pg_drop_replication_slot(slot_name)
-            FROM pg_replication_slots
-            WHERE slot_name = ${timeoutSlot} AND NOT active`;
-      }
-    },
-  );
 
   describe('shadow initial sync', () => {
     const SHADOW_SHARD = {

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.test.ts
@@ -4,10 +4,10 @@ import {createSilentLogContext} from '../../../../../shared/src/logging-test-uti
 import type {PublishedTableSpec} from '../../../db/specs.ts';
 import type {PostgresDB} from '../../../types/pg.ts';
 import {
-  createReplicationSlot,
   getInitialDownloadState,
   makeDownloadStatements,
 } from './initial-sync.ts';
+import {createReplicationSlot} from './replication-slots.ts';
 
 function spec(
   publications: Record<string, {rowFilter: string | null}> = {
@@ -182,7 +182,7 @@ describe('createReplicationSlot', () => {
     const result = await createReplicationSlot(
       createSilentLogContext(),
       session,
-      'test_slot',
+      {slotName: 'test_slot'},
     );
     expect(result).toEqual(slot);
   });
@@ -204,7 +204,9 @@ describe('createReplicationSlot', () => {
       ]);
     });
 
-    await createReplicationSlot(createSilentLogContext(), session, 's');
+    await createReplicationSlot(createSilentLogContext(), session, {
+      slotName: 's',
+    });
     expect(calls[0]).toMatch(/^SET lock_timeout = \d+$/);
     expect(calls[1]).toMatch(/CREATE_REPLICATION_SLOT/);
   });
@@ -221,7 +223,9 @@ describe('createReplicationSlot', () => {
     });
 
     await expect(
-      createReplicationSlot(createSilentLogContext(), session, 'test_slot'),
+      createReplicationSlot(createSilentLogContext(), session, {
+        slotName: 'test_slot',
+      }),
     ).rejects.toBe(pgError);
   });
 
@@ -241,11 +245,9 @@ describe('createReplicationSlot', () => {
       // between the time advanceTimersByTimeAsync triggers it and the
       // time we assert on it.
       let caught: unknown;
-      const result = createReplicationSlot(
-        createSilentLogContext(),
-        session,
-        'hang_slot',
-      ).catch(e => {
+      const result = createReplicationSlot(createSilentLogContext(), session, {
+        slotName: 'hang_slot',
+      }).catch(e => {
         caught = e;
       });
 

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
@@ -3,13 +3,9 @@ import {platform, tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {Writable} from 'node:stream';
 import {pipeline} from 'node:stream/promises';
-import {
-  PG_CONFIGURATION_LIMIT_EXCEEDED,
-  PG_INSUFFICIENT_PRIVILEGE,
-} from '@drdgvhbh/postgres-error-codes';
 import type {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
-import postgres from 'postgres';
+import {assert} from '../../../../../shared/src/asserts.ts';
 import type {JSONObject} from '../../../../../shared/src/bigint-json.ts';
 import {must} from '../../../../../shared/src/must.ts';
 import {equals} from '../../../../../shared/src/set-utils.ts';
@@ -57,19 +53,17 @@ import {CpuProfiler} from '../../../types/profiler.ts';
 import type {ShardConfig} from '../../../types/shards.ts';
 import {ALLOWED_APP_ID_CHARACTERS} from '../../../types/shards.ts';
 import {id} from '../../../types/sql.ts';
-import {orTimeout} from '../../../types/timeout.ts';
 import {ReplicationStatusPublisher} from '../../replicator/replication-status.ts';
 import {ColumnMetadataStore} from '../../replicator/schema/column-metadata.ts';
 import {initReplicationState} from '../../replicator/schema/replication-state.ts';
 import {toStateVersionString} from './lsn.ts';
+import {createReplicaAndSlot} from './replication-slots.ts';
 import {ensureShardSchema} from './schema/init.ts';
 import {getPublicationInfo} from './schema/published.ts';
 import {
-  addReplica,
   dropShard,
   getInternalShardConfig,
-  newReplicationSlot,
-  replicationSlotExpression,
+  initReplica,
   validatePublications,
 } from './schema/shard.ts';
 
@@ -132,7 +126,9 @@ export async function initialSync(
         ['fetch_types']: false, // Necessary for the streaming protocol
         connection: {replication: 'database'}, // https://www.postgresql.org/docs/current/protocol-replication.html
       });
-  const slotName = newReplicationSlot(shard);
+
+  const replicaID = Date.now().toString();
+  let slotName: string | undefined; // undefined === shadow
   const statusPublisher = ReplicationStatusPublisher.forRunningTransaction(
     tx,
     shadow ? async () => {} : undefined,
@@ -169,49 +165,17 @@ export async function initialSync(
       lsn = acquired.lsn;
       releaseShadowSnapshot = acquired.release;
     } else {
-      let slot: ReplicationSlot;
-      for (let first = true; ; first = false) {
-        try {
-          slot = await createReplicationSlot(
-            lc,
-            must(replicationSession),
-            slotName,
-            replicationSlotFailover && pgVersion >= PG_17,
-          );
-          break;
-        } catch (e) {
-          if (first && e instanceof postgres.PostgresError) {
-            if (e.code === PG_INSUFFICIENT_PRIVILEGE) {
-              // Some Postgres variants (e.g. Google Cloud SQL) require that
-              // the user have the REPLICATION role in order to create a slot.
-              // Note that this must be done by the upstreamDB connection, and
-              // does not work in the replicationSession itself.
-              await sql`ALTER ROLE current_user WITH REPLICATION`;
-              lc.info?.(`Added the REPLICATION role to database user`);
-              continue;
-            }
-            if (e.code === PG_CONFIGURATION_LIMIT_EXCEEDED) {
-              const slotExpression = replicationSlotExpression(shard);
-
-              const dropped = await sql<{slot: string}[]>`
-                SELECT slot_name as slot, pg_drop_replication_slot(slot_name)
-                  FROM pg_replication_slots
-                  WHERE slot_name LIKE ${slotExpression} AND NOT active`;
-              if (dropped.length) {
-                lc.warn?.(
-                  `Dropped inactive replication slots: ${dropped.map(({slot}) => slot)}`,
-                  e,
-                );
-                continue;
-              }
-              lc.error?.(`Unable to drop replication slots`, e);
-            }
-          }
-          throw e;
-        }
-      }
+      const slot = await createReplicaAndSlot(
+        lc,
+        sql,
+        must(replicationSession),
+        shard,
+        replicaID,
+        replicationSlotFailover && pgVersion >= PG_17,
+      );
       snapshot = slot.snapshot_name;
       lsn = slot.consistent_point;
+      slotName = slot.slot_name;
     }
 
     const initialVersion = toStateVersionString(lsn);
@@ -315,21 +279,15 @@ export async function initialSync(
       const index = performance.now() - indexStart;
       lc.info?.(`Created indexes (${index.toFixed(3)} ms)`);
 
-      if (shadow) {
+      if (slotName && replicaID) {
+        await initReplica(sql, shard, replicaID, published, context);
+      } else {
+        assert(shadow, 'expected to be in shadow sync if there is no slotName');
         const rowsByTable = new Map<string, number>();
         for (let i = 0; i < downloads.length; i++) {
           rowsByTable.set(downloads[i].status.table, rowCounts[i].rows);
         }
         verifyShadowReplica(lc, tx, published, rowsByTable);
-      } else {
-        await addReplica(
-          sql,
-          shard,
-          slotName,
-          initialVersion,
-          published,
-          context,
-        );
       }
 
       const elapsed = performance.now() - start;
@@ -342,7 +300,7 @@ export async function initialSync(
       void copyPool.end().catch(e => lc.warn?.(`Error closing copyPool`, e));
     }
   } catch (e) {
-    if (!shadow) {
+    if (slotName) {
       // If initial-sync did not succeed, make a best effort to drop the
       // orphaned replication slot to avoid running out of slots in
       // pathological cases that result in repeated failures.
@@ -521,29 +479,6 @@ function startTableCopyWorkers(
   return tableCopiers;
 }
 
-// Row returned by `CREATE_REPLICATION_SLOT`
-type ReplicationSlot = {
-  slot_name: string;
-  consistent_point: string;
-  snapshot_name: string;
-  output_plugin: string;
-};
-
-// When creating a replication slot, Postgres waits for open transactions
-// to complete before reserving a consistent_point (LSN) in the WAL and creating
-// a matching transaction snapshot. As such, it can technically take an arbitrary
-// amount of time (e.g. DDL operations, table-wide operations, etc.).
-//
-// However, to detect pathological situations, bound the amount of time that
-// the server waits for replication slot creation, so that a continual failure to
-// create a replication slot is surfaced by errors / alerts.
-const CREATE_REPLICATION_SLOT_TIMEOUT_MS = 30_000;
-
-// The lock_timeout is set 1s before the client-side orTimeout so that
-// Postgres reliably aborts first and tears down the walsender cleanly.
-// The client-side timeout remains as a fallback for network-level failures.
-const SERVER_LOCK_TIMEOUT_MS = CREATE_REPLICATION_SLOT_TIMEOUT_MS - 1_000;
-
 /**
  * Shadow-mode alternative to `createReplicationSlot`: opens a dedicated
  * READ ONLY REPEATABLE READ transaction on a normal connection, exports the
@@ -606,59 +541,6 @@ async function acquireExportedSnapshotForShadowSync(
       await holder.end();
     },
   };
-}
-
-// Note: The replication connection does not support the extended query protocol,
-//       so all commands must be sent using sql.unsafe(). This is technically safe
-//       because all placeholder values are under our control (i.e. "slotName").
-export async function createReplicationSlot(
-  lc: LogContext,
-  session: postgres.Sql,
-  slotName: string,
-  // Note: must be false if pgVersion < PG_17. Caller must verify.
-  failover = false,
-): Promise<ReplicationSlot> {
-  // CREATE_REPLICATION_SLOT can hang indefinitely waiting for long-running
-  // transactions to finish: internally it calls SnapBuildWaitSnapshot →
-  // XactLockTableWait → LockAcquire on each running XID. statement_timeout
-  // does NOT apply to replication commands, but lock_timeout does (it governs
-  // the heavyweight lock wait inside LockAcquire). Setting it here causes
-  // Postgres to raise ERRCODE_LOCK_NOT_AVAILABLE and cleanly tear down the
-  // walsender, rather than relying solely on the client-side orTimeout
-  // which can leave an orphaned backend.
-  //
-  // An orphaned walsender is actively harmful: by this point the replication
-  // slot has already been created and is pinning WAL retention and catalog_xmin.
-  // Worse, the slot is marked `active` (the walsender PID is still alive), so
-  // the existing cleanup code (which drops inactive slots on retry) can't
-  // reclaim it. Without lock_timeout the orphan persists until TCP keepalive
-  // fires (~2h default) or the blocking transaction finishes.
-  await session.unsafe(`SET lock_timeout = ${SERVER_LOCK_TIMEOUT_MS}`);
-
-  const createSlot = failover
-    ? session.unsafe<ReplicationSlot[]>(
-        /*sql*/ `CREATE_REPLICATION_SLOT "${slotName}" LOGICAL pgoutput (FAILOVER)`,
-      )
-    : session.unsafe<ReplicationSlot[]>(
-        /*sql*/ `CREATE_REPLICATION_SLOT "${slotName}" LOGICAL pgoutput`,
-      );
-  const raced = await orTimeout(createSlot, CREATE_REPLICATION_SLOT_TIMEOUT_MS);
-  if (raced === 'timed-out') {
-    // Create slot can block indefinitely waiting for old transactions. End
-    // this connection in the background and fail fast so the process restarts.
-    void session
-      .end()
-      .catch(e =>
-        lc.warn?.(`Error closing timed out replication slot session`, e),
-      );
-    throw new Error(
-      `Timed out after ${CREATE_REPLICATION_SLOT_TIMEOUT_MS} ms creating replication slot ${slotName}. ` +
-        `Crashing to force a clean restart.`,
-    );
-  }
-  const [slot] = raced;
-  lc.info?.(`Created replication slot ${slotName}`, slot);
-  return slot;
 }
 
 function createLiteTables(

--- a/packages/zero-cache/src/services/change-source/pg/replication-slots.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/replication-slots.pg.test.ts
@@ -1,0 +1,230 @@
+import {PG_LOCK_NOT_AVAILABLE} from '@drdgvhbh/postgres-error-codes';
+import postgres from 'postgres';
+import {beforeEach, describe, expect} from 'vitest';
+import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
+import {getConnectionURI, type PgTest, test} from '../../../test/db.ts';
+import {pgClient, type PostgresDB} from '../../../types/pg.ts';
+import type {ShardID} from '../../../types/shards.ts';
+import {
+  createReplicaAndSlot,
+  createReplicationSlot,
+  dropOldReplicasAndSlots,
+  slotPoolSuffix,
+} from './replication-slots.ts';
+import {ensureGlobalTables, shardSetup} from './schema/shard.ts';
+
+test.each([
+  [0, 'a'],
+  [1, 'b'],
+  [25, 'z'],
+  [26, 'aa'],
+  [27, 'ab'],
+  [26 * 2, 'ba'],
+  [26 ** 2, 'za'],
+  [26 ** 2 + 25, 'zz'],
+  [26 ** 2 + 26, 'aaa'],
+])('slotPoolSuffix: %d', (num, suffix) => {
+  expect(slotPoolSuffix(num)).toBe(suffix);
+});
+
+describe('createReplicationSlot', () => {
+  const APP_ID = 'zero';
+  const SHARD_NUM = 18;
+  const shard: ShardID = {appID: APP_ID, shardNum: SHARD_NUM};
+
+  let upstream: PostgresDB;
+
+  beforeEach<PgTest>(async ({testDBs}) => {
+    upstream = await testDBs.create('replication_slots');
+    await ensureGlobalTables(upstream, shard);
+    await upstream.unsafe(
+      shardSetup({...shard, publications: ['foo_pub', 'meta_pub']}, 'meta_pub'),
+    );
+    return () => testDBs.drop(upstream);
+  });
+
+  test('createReplicationSlot times out behind an older idle transaction', async () => {
+    const lc = createSilentLogContext();
+    const upstreamURI = getConnectionURI(upstream);
+    const timeoutSlot = `${APP_ID}_${SHARD_NUM}_${Date.now()}_timeout`;
+    const blocker = pgClient(lc, upstreamURI, 'slot-timeout-blocker', {
+      max: 1,
+    });
+    const timeoutSession = pgClient(
+      lc,
+      upstreamURI,
+      'slot-timeout-under-test',
+      {
+        max: 1,
+        ['fetch_types']: false,
+        connection: {replication: 'database'},
+      },
+    );
+
+    let blockerInTransaction = false;
+    try {
+      // Start a transaction in one session and leave it open.
+      await blocker`BEGIN`;
+      blockerInTransaction = true;
+      await blocker`SELECT txid_current()`;
+
+      // The server-side lock_timeout (set inside createReplicationSlot)
+      // should fire before the client-side orTimeout, producing a
+      // PostgresError with code 55P03 (lock_not_available).
+      let caught: unknown;
+      try {
+        await createReplicationSlot(lc, timeoutSession, {
+          slotName: timeoutSlot,
+          lockTimeout: 100,
+        });
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(postgres.PostgresError);
+      expect((caught as postgres.PostgresError).code).toBe(
+        PG_LOCK_NOT_AVAILABLE,
+      );
+    } finally {
+      if (blockerInTransaction) {
+        await blocker`ROLLBACK`;
+      }
+      await blocker.end();
+      await timeoutSession.end().catch(() => {});
+      await upstream`
+          SELECT pg_drop_replication_slot(slot_name)
+            FROM pg_replication_slots
+            WHERE slot_name = ${timeoutSlot} AND NOT active`;
+    }
+  });
+
+  test('create replica and slots reuses pool names', async () => {
+    const lc = createSilentLogContext();
+    const upstreamURI = getConnectionURI(upstream);
+    const session = pgClient(lc, upstreamURI, 'slot-pool', {
+      max: 1,
+      ['fetch_types']: false,
+      connection: {replication: 'database'},
+    });
+
+    const create = (id: string) =>
+      createReplicaAndSlot(lc, upstream, session, shard, id, false);
+
+    let {slot_name: name} = await create('rep_1');
+    expect(name).toBe('zero_18_a');
+
+    ({slot_name: name} = await create('rep_2'));
+    expect(name).toBe('zero_18_b');
+
+    ({slot_name: name} = await create('rep_3'));
+    expect(name).toBe('zero_18_c');
+
+    await session`DROP_REPLICATION_SLOT zero_18_b`.simple();
+
+    ({slot_name: name} = await create('rep_4'));
+    expect(name).toBe('zero_18_b');
+
+    expect(
+      await upstream`SELECT id, slot, version FROM ${upstream(`${APP_ID}_${SHARD_NUM}`)}.replicas`,
+    ).toMatchObject([
+      {
+        id: 'rep_1',
+        slot: 'zero_18_a',
+        version: /[a-z0-9]{5,}/,
+      },
+      {
+        id: 'rep_2',
+        slot: 'zero_18_b',
+        version: /[a-z0-9]{5,}/,
+      },
+      {
+        id: 'rep_3',
+        slot: 'zero_18_c',
+        version: /[a-z0-9]{5,}/,
+      },
+      {
+        id: 'rep_4',
+        slot: 'zero_18_b',
+        version: /[a-z0-9]{5,}/,
+      },
+    ]);
+
+    // Cleanup
+    expect(await dropOldReplicasAndSlots(lc, upstream, shard, 100n)).toEqual({
+      dropped: 3,
+      active: 0,
+      draining: 0,
+    });
+  });
+
+  test('concurrent replica creation uses different slot names', async () => {
+    const lc = createSilentLogContext();
+    const upstreamURI = getConnectionURI(upstream);
+    const sessions = Array.from({length: 3}, () =>
+      pgClient(lc, upstreamURI, 'slot-pool', {
+        max: 1,
+        ['fetch_types']: false,
+        connection: {replication: 'database'},
+      }),
+    );
+
+    const results = await Promise.all(
+      sessions.map((session, i) =>
+        createReplicaAndSlot(lc, upstream, session, shard, `rep_${i}`, false),
+      ),
+    );
+    const expectedSlots = new Set(['zero_18_a', 'zero_18_b', 'zero_18_c']);
+    const names = new Set(results.map(({slot_name}) => slot_name));
+    expect(names).toEqual(expectedSlots);
+
+    const replicaSlots = await upstream<{slot: string}[]> /*sql*/ `
+      SELECT slot FROM zero_18.replicas`.values();
+    expect(new Set(replicaSlots.flat())).toEqual(expectedSlots);
+
+    // Cleanup
+    expect(await dropOldReplicasAndSlots(lc, upstream, shard, 100n)).toEqual({
+      dropped: 3,
+      active: 0,
+      draining: 0,
+    });
+  });
+
+  test('dropReplicaAndSlots', async () => {
+    const lc = createSilentLogContext();
+    const upstreamURI = getConnectionURI(upstream);
+    const session = pgClient(lc, upstreamURI, 'slot-pool', {
+      max: 1,
+      ['fetch_types']: false,
+      connection: {replication: 'database'},
+    });
+    await upstream`CREATE PUBLICATION foo_pub FOR ALL TABLES`;
+
+    const create = (id: string) =>
+      createReplicaAndSlot(lc, upstream, session, shard, id, false);
+
+    await create('rep_1');
+    await create('rep_2');
+    await create('rep_3');
+
+    // Subscribe to the second replication slot to prevent it from
+    // being dropped.
+    const stream = await session
+      .unsafe(`
+      START_REPLICATION SLOT zero_18_b LOGICAL 0/0 
+        (proto_version '1', publication_names 'foo_pub');`)
+      .readable();
+
+    expect(await dropOldReplicasAndSlots(lc, upstream, shard, 3n)).toEqual({
+      active: 1,
+      draining: 1,
+      dropped: 1,
+    });
+
+    stream.destroy();
+
+    expect(await dropOldReplicasAndSlots(lc, upstream, shard, 4n)).toEqual({
+      active: 0,
+      draining: 0,
+      dropped: 2,
+    });
+  });
+});

--- a/packages/zero-cache/src/services/change-source/pg/replication-slots.ts
+++ b/packages/zero-cache/src/services/change-source/pg/replication-slots.ts
@@ -292,6 +292,6 @@ export function slotPoolSuffix(n: number) {
   return suffix;
 }
 
-export function replicationSlotManagementLock(shard: ShardID) {
+function replicationSlotManagementLock(shard: ShardID) {
   return `replication-slot-management:${shard.appID}_${shard.shardNum}`;
 }

--- a/packages/zero-cache/src/services/change-source/pg/replication-slots.ts
+++ b/packages/zero-cache/src/services/change-source/pg/replication-slots.ts
@@ -1,0 +1,297 @@
+import {
+  PG_CONFIGURATION_LIMIT_EXCEEDED,
+  PG_INSUFFICIENT_PRIVILEGE,
+} from '@drdgvhbh/postgres-error-codes';
+import type {LogContext} from '@rocicorp/logger';
+import postgres from 'postgres';
+import {runTx} from '../../../db/run-transaction';
+import {isPostgresError, type PostgresDB} from '../../../types/pg';
+import {upstreamSchema, type ShardID} from '../../../types/shards';
+import {orTimeout} from '../../../types/timeout';
+import {toStateVersionString} from './lsn';
+import {
+  createReplica,
+  replicationSlotExpression,
+  replicationSlotPrefix,
+} from './schema/shard';
+
+// Record returned by `CREATE_REPLICATION_SLOT`
+export type ReplicationSlot = {
+  slot_name: string;
+  consistent_point: string;
+  snapshot_name: string;
+  output_plugin: string;
+};
+
+export type CreateSlotSpec = {
+  slotName: string;
+
+  // Note: must be false if pgVersion < PG_17. Caller must verify.
+  failover?: boolean;
+
+  // For overriding in tests.
+  lockTimeout?: number;
+};
+
+// When creating a replication slot, Postgres waits for open transactions
+// to complete before reserving a consistent_point (LSN) in the WAL and creating
+// a matching transaction snapshot. As such, it can technically take an arbitrary
+// amount of time (e.g. DDL operations, table-wide operations, etc.).
+//
+// However, to detect pathological situations, bound the amount of time that
+// the server waits for replication slot creation, so that a continual failure to
+// create a replication slot is surfaced by errors / alerts.
+const CREATE_REPLICATION_SLOT_TIMEOUT_MS = 30_000;
+
+// The lock_timeout is set 1s before the client-side orTimeout so that
+// Postgres reliably aborts first and tears down the walsender cleanly.
+// The client-side timeout remains as a fallback for network-level failures.
+const SERVER_LOCK_TIMEOUT_MS = CREATE_REPLICATION_SLOT_TIMEOUT_MS - 1_000;
+
+// Note: The replication connection does not support the extended query protocol,
+//       so all commands must be sent using sql.unsafe(). This is technically safe
+//       because all placeholder values are under our control (i.e. "slotName").
+export async function createReplicationSlot(
+  lc: LogContext,
+  session: postgres.Sql,
+  {slotName, failover, lockTimeout = SERVER_LOCK_TIMEOUT_MS}: CreateSlotSpec,
+): Promise<ReplicationSlot> {
+  // CREATE_REPLICATION_SLOT can hang indefinitely waiting for long-running
+  // transactions to finish: internally it calls SnapBuildWaitSnapshot →
+  // XactLockTableWait → LockAcquire on each running XID. statement_timeout
+  // does NOT apply to replication commands, but lock_timeout does (it governs
+  // the heavyweight lock wait inside LockAcquire). Setting it here causes
+  // Postgres to raise ERRCODE_LOCK_NOT_AVAILABLE and cleanly tear down the
+  // walsender, rather than relying solely on the client-side orTimeout
+  // which can leave an orphaned backend.
+  //
+  // An orphaned walsender is actively harmful: by this point the replication
+  // slot has already been created and is pinning WAL retention and catalog_xmin.
+  // Worse, the slot is marked `active` (the walsender PID is still alive), so
+  // the existing cleanup code (which drops inactive slots on retry) can't
+  // reclaim it. Without lock_timeout the orphan persists until TCP keepalive
+  // fires (~2h default) or the blocking transaction finishes.
+  await session.unsafe(`SET lock_timeout = ${lockTimeout}`);
+
+  const createSlot = failover
+    ? session.unsafe<ReplicationSlot[]>(
+        /*sql*/ `CREATE_REPLICATION_SLOT "${slotName}" LOGICAL pgoutput (FAILOVER)`,
+      )
+    : session.unsafe<ReplicationSlot[]>(
+        /*sql*/ `CREATE_REPLICATION_SLOT "${slotName}" LOGICAL pgoutput`,
+      );
+  const raced = await orTimeout(createSlot, CREATE_REPLICATION_SLOT_TIMEOUT_MS);
+  if (raced === 'timed-out') {
+    // Create slot can block indefinitely waiting for old transactions. End
+    // this connection in the background and fail fast so the process restarts.
+    void session
+      .end()
+      .catch(e =>
+        lc.warn?.(`Error closing timed out replication slot session`, e),
+      );
+    throw new Error(
+      `Timed out after ${CREATE_REPLICATION_SLOT_TIMEOUT_MS} ms creating replication slot ${slotName}. ` +
+        `Crashing to force a clean restart.`,
+    );
+  }
+  const [slot] = raced;
+  lc.info?.(`Created replication slot ${slotName}`, slot);
+  return slot;
+}
+
+/**
+ * Replica and slot creation involves two sessions for proper coordination
+ * with other replica management logic:
+ *
+ * * A normal transaction is started and acquires an advisory lock for
+ *   replica slot management. This is the same lock that cleanup logic
+ *   acquires before cleaning up replication slots.
+ * * With the lock held, a new replication slot is created in a
+ *   replication session. The API of CREATE_REPLICATION_SLOT is such
+ *   that it cannot be done in a transaction, and cannot be followed by
+ *   any writes, or else its snapshot (which is needed for initial sync)
+ *   would be invalidated.
+ * * Once the slot is created, the slot and replica information are recorded
+ *   in the `replicas` table before releasing the lock.
+ *
+ * This locking ensures that:
+ * 1. multiple replication managers attempting to create a replication slot
+ *    will not use the same name for the replication slot (which is selected
+ *    from a pool of reused names).
+ * 2. Running replication managers (which use an earlier replica of a lower
+ *    rank) will not delete the new slot during their cleanup logic, since
+ *    the slot will belong to a replica of a higher rank.
+ */
+export async function createReplicaAndSlot(
+  lc: LogContext,
+  sql: PostgresDB,
+  replicationSession: postgres.Sql,
+  shard: ShardID,
+  replicaID: string,
+  failover: boolean,
+): Promise<ReplicationSlot> {
+  const lockName = replicationSlotManagementLock(shard);
+  const slotPoolPrefix = replicationSlotPrefix(shard);
+  for (let first = true; ; first = false) {
+    try {
+      return runTx(sql, async tx => {
+        await tx`SELECT pg_advisory_xact_lock(hashtext(${lockName}))`;
+
+        // Pick an available slotName from the slotPoolPrefix pool.
+        let slotName: string;
+        const names = await tx<{name: string}[]> /*sql*/ `
+          SELECT slot_name as name FROM pg_replication_slots
+            WHERE slot_name LIKE ${slotPoolPrefix + '%'};
+        `.values();
+        const inUse = new Set(names.flat());
+        for (let next = 0; ; next++) {
+          const candidateName = `${slotPoolPrefix}${slotPoolSuffix(next)}`;
+          if (!inUse.has(candidateName)) {
+            slotName = candidateName;
+            break;
+          }
+        }
+
+        const slot = await createReplicationSlot(lc, replicationSession, {
+          slotName,
+          failover,
+        });
+
+        await createReplica(
+          tx,
+          shard,
+          replicaID,
+          slot.slot_name,
+          toStateVersionString(slot.consistent_point),
+        );
+
+        return slot;
+      });
+    } catch (e) {
+      if (first && e instanceof postgres.PostgresError) {
+        if (isPostgresError(e, PG_INSUFFICIENT_PRIVILEGE)) {
+          // Some Postgres variants (e.g. Google Cloud SQL) require that
+          // the user have the REPLICATION role in order to create a slot.
+          // Note that this must be done by the upstreamDB connection, and
+          // does not work in the replicationSession itself.
+          await sql`ALTER ROLE current_user WITH REPLICATION`;
+          lc.info?.(`Added the REPLICATION role to database user`);
+          continue;
+        }
+        if (isPostgresError(e, PG_CONFIGURATION_LIMIT_EXCEEDED)) {
+          const slotExpression = replicationSlotExpression(shard);
+
+          const dropped = await sql<{slot: string}[]>`
+                SELECT slot_name as slot, pg_drop_replication_slot(slot_name)
+                  FROM pg_replication_slots
+                  WHERE slot_name LIKE ${slotExpression} AND NOT active`;
+          if (dropped.length) {
+            lc.warn?.(
+              `Dropped inactive replication slots: ${dropped.map(({slot}) => slot)}`,
+              e,
+            );
+            continue;
+          }
+          lc.error?.(`Unable to drop replication slots`, e);
+        }
+      }
+      throw e;
+    }
+  }
+}
+
+/**
+ * Deletes "old" replicas (i.e. those with a lower rank than the current)
+ * and attempts to drop replication slots that are not associated with any
+ * replica.
+ *
+ * If a slot could not be dropped because there is still an active subscriber,
+ * it will be reflected in the `draining` count that is returned. When there
+ * are draining slots, the method should be retried until all orphaned slots
+ * have been dropped.
+ */
+export async function dropOldReplicasAndSlots(
+  lc: LogContext,
+  sql: PostgresDB,
+  shard: ShardID,
+  beforeRank: bigint,
+): Promise<{dropped: number; active: number; draining: number}> {
+  const replicasTable = `${upstreamSchema(shard)}.replicas`;
+  const oldReplicas = await sql`
+    SELECT id, rank::float8, slot, version, "initialSyncContext", "subscriberContext"
+     FROM ${sql(replicasTable)} WHERE rank < ${beforeRank};
+  `;
+  if (oldReplicas.length) {
+    lc.info?.(`Deleting ${oldReplicas.length} old replica(s)`, {oldReplicas});
+    await sql`DELETE FROM ${sql(replicasTable)} WHERE rank < ${beforeRank}`;
+  }
+
+  // The slot / replica cleanup happens within a transaction while holding
+  // the replication slot management lock for this shard, to ensure that no
+  // slot that belongs to a newer replica is dropped.
+  const lockName = replicationSlotManagementLock(shard);
+  const slotExpression = replicationSlotExpression(shard);
+  return runTx(sql, async tx => {
+    await tx`SELECT pg_advisory_xact_lock(hashtext(${lockName}))`;
+
+    const dropped = await tx /*sql*/ `
+      SELECT slot_name as slot, pg_drop_replication_slot(slot_name) 
+        FROM pg_replication_slots
+        LEFT JOIN ${tx(replicasTable)} replica on slot_name = slot
+        WHERE slot_name LIKE ${slotExpression} 
+          AND NOT active
+          AND replica.id IS NULL;
+    `;
+    if (dropped.length) {
+      lc.info?.(`dropped inactive replication slots`, {dropped});
+    }
+
+    const remaining = await tx<
+      {slot: string; pid: number | null; id: string | null}[]
+    > /*sql*/ `
+      SELECT slot_name as slot, active_pid as pid, replica.id as id
+        FROM pg_replication_slots
+        LEFT JOIN ${tx(replicasTable)} replica on slot_name = slot
+        WHERE slot_name LIKE ${slotExpression};
+    `;
+    if (remaining.length) {
+      lc.info?.(`remaining replication slots`, {remaining});
+    }
+
+    let active = 0;
+    let draining = 0;
+    for (const {id} of remaining) {
+      if (id === null) {
+        draining++;
+      } else {
+        active++;
+      }
+    }
+
+    return {
+      dropped: dropped.length,
+      active,
+      draining,
+    };
+  });
+}
+
+const ALPHABET = 'abcdefghijklmnopqrstuvwxyz';
+
+// Alphabetic notation is used as the slot pool suffix to distinguish
+// it from the (numeric) shard num that's also encoded in the slot name.
+export function slotPoolSuffix(n: number) {
+  n++; // Adjust for 0-based indexing
+
+  let suffix = '';
+  while (n > 0) {
+    n--;
+    suffix = ALPHABET[n % 26] + suffix;
+    n = Math.floor(n / 26);
+  }
+  return suffix;
+}
+
+export function replicationSlotManagementLock(shard: ShardID) {
+  return `replication-slot-management:${shard.appID}_${shard.shardNum}`;
+}

--- a/packages/zero-cache/src/services/change-source/pg/schema/init.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.pg.test.ts
@@ -1,5 +1,5 @@
 import type {LogContext} from '@rocicorp/logger';
-import {beforeEach, describe} from 'vitest';
+import {beforeEach, describe, expect} from 'vitest';
 import {createSilentLogContext} from '../../../../../../shared/src/logging-test-utils.ts';
 import {
   createVersionHistoryTable,
@@ -18,7 +18,7 @@ import {
   ensureShardSchema,
   updateShardSchema,
 } from './init.ts';
-import {addReplica, metadataPublicationName} from './shard.ts';
+import {createReplica, initReplica, metadataPublicationName} from './shard.ts';
 
 const APP_ID = 'zappz';
 const SHARD_NUM = 23;
@@ -66,6 +66,8 @@ describe('change-streamer/pg/schema/init', () => {
         ],
         [`${APP_ID}_${SHARD_NUM}.replicas`]: [
           {
+            id: /\d{10,}/,
+            rank: expect.any(BigInt),
             slot: `${APP_ID}_${SHARD_NUM}_1234`,
             version: '2dhf29ef',
             initialSchema: {tables: [], indexes: []},
@@ -95,6 +97,8 @@ describe('change-streamer/pg/schema/init', () => {
         ],
         [`${APP_ID}_${SHARD_NUM}.replicas`]: [
           {
+            id: /\d{10,}/,
+            rank: expect.any(BigInt),
             slot: `${APP_ID}_${SHARD_NUM}_5678`,
             version: 's8dfh2d',
             initialSchema: {tables: [], indexes: []},
@@ -174,6 +178,8 @@ describe('change-streamer/pg/schema/init', () => {
         ],
         [`${APP_ID}_${SHARD_NUM}.replicas`]: [
           {
+            id: /[a-z0-9]{10,}/, // Random ID is backfilled
+            rank: expect.any(BigInt),
             slot: `${APP_ID}_${SHARD_NUM}`,
             version: '123',
             initialSchema: {tables: [], indexes: []},
@@ -209,11 +215,17 @@ describe('change-streamer/pg/schema/init', () => {
           publications: c.requestedPublications ?? [],
         });
         if (c.newReplica) {
-          await addReplica(
+          await createReplica(
             upstream,
             {appID: APP_ID, shardNum: SHARD_NUM},
+            '12345',
             c.newReplica[0],
             c.newReplica[1],
+          );
+          await initReplica(
+            upstream,
+            {appID: APP_ID, shardNum: SHARD_NUM},
+            '12345',
             {tables: [], indexes: []},
             {foo: 'bar'},
           );

--- a/packages/zero-cache/src/services/change-source/pg/schema/init.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.ts
@@ -253,6 +253,27 @@ function getIncrementalMigrations(
         lc.info?.(`Upgraded DDL event triggers`);
       },
     },
+
+    22: {
+      migrateSchema: async (_, sql) => {
+        await sql`
+          ALTER TABLE ${sql(upstreamSchema(shard))}.replicas 
+            ALTER "initialSchema" DROP NOT NULL;
+        `;
+        await sql`
+          ALTER TABLE ${sql(upstreamSchema(shard))}.replicas 
+            DROP CONSTRAINT replicas_pkey;
+        `;
+        await sql`
+          ALTER TABLE ${sql(upstreamSchema(shard))}.replicas 
+            ADD COLUMN id TEXT PRIMARY KEY DEFAULT replace(gen_random_uuid()::text, '-', '');
+        `;
+        await sql`
+          ALTER TABLE ${sql(upstreamSchema(shard))}.replicas 
+            ADD COLUMN rank BIGSERIAL;
+        `;
+      },
+    },
   };
 }
 

--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.pg.test.ts
@@ -2,11 +2,18 @@ import {LogContext} from '@rocicorp/logger';
 import {beforeEach, describe, expect} from 'vitest';
 import {TestLogSink} from '../../../../../../shared/src/logging-test-utils.ts';
 import {Index} from '../../../../db/postgres-replica-identity-enum.ts';
-import {expectTables, initDB, type PgTest, test} from '../../../../test/db.ts';
+import {
+  expectTables,
+  expectTablesToMatch,
+  initDB,
+  type PgTest,
+  test,
+} from '../../../../test/db.ts';
 import type {PostgresDB} from '../../../../types/pg.ts';
 import {getPublicationInfo} from './published.ts';
 import {
-  addReplica,
+  createReplica,
+  initReplica,
   setupTablesAndReplication,
   setupTriggers,
   validatePublicationName,
@@ -45,11 +52,17 @@ describe('change-source/pg', () => {
         shardNum: 0,
         publications: [],
       });
-      await addReplica(
+      await createReplica(
         tx,
         {appID: APP_ID, shardNum: 0},
+        '12345',
         'zro_0_1234',
         '0wdfj02',
+      );
+      await initReplica(
+        tx,
+        {appID: APP_ID, shardNum: 0},
+        '12345',
         {tables: [], indexes: []},
         {foo: 'bar'},
       );
@@ -62,7 +75,7 @@ describe('change-source/pg', () => {
       ['_zro_public_0', null, null, null],
     ]);
 
-    await expectTables(db, {
+    await expectTablesToMatch(db, {
       ['zro.permissions']: [{lock: true, permissions: null, hash: null}],
       ['zro_0.shardConfig']: [
         {
@@ -73,6 +86,7 @@ describe('change-source/pg', () => {
       ],
       ['zro_0.replicas']: [
         {
+          id: /\d{10,}/,
           slot: 'zro_0_1234',
           version: '0wdfj02',
           initialSchema: {tables: [], indexes: []},

--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
@@ -74,10 +74,6 @@ export function replicationSlotExpression(shard: ShardID) {
   return `${replicationSlotPrefix(shard)}%`.replaceAll('_', '\\_');
 }
 
-export function newReplicationSlot(shard: ShardID) {
-  return replicationSlotPrefix(shard) + Date.now();
-}
-
 function defaultPublicationName(appID: string, shardID: string | number) {
   return `_${appID}_public_${shardID}`;
 }
@@ -199,9 +195,13 @@ export function shardSetup(
     );
 
   CREATE TABLE ${shard}.replicas (
-    "slot"               TEXT PRIMARY KEY,
+    -- The DEFAULT exists purely for backwards compatibility support.
+    -- New code always specifies a value based on Date.now().
+    "id"                 TEXT PRIMARY KEY DEFAULT replace(gen_random_uuid()::text, '-', ''),
+    "rank"               BIGSERIAL,
+    "slot"               TEXT NOT NULL,
     "version"            TEXT NOT NULL,
-    "initialSchema"      JSON NOT NULL,
+    "initialSchema"      JSON,  -- set after initial sync
     "initialSyncContext" JSON,
     "subscriberContext"  JSON
   );
@@ -230,6 +230,8 @@ const internalShardConfigSchema = v.object({
 export type InternalShardConfig = v.Infer<typeof internalShardConfigSchema>;
 
 const replicaSchema = internalShardConfigSchema.extend({
+  id: v.string(),
+  rank: v.bigint(),
   slot: v.string(),
   version: v.string(),
   initialSchema: publishedSchema,
@@ -250,23 +252,44 @@ function triggerSetup(shard: ShardConfig): string {
   );
 }
 
-// Called in initial-sync to store the exact schema that was initially synced.
-export async function addReplica(
+/**
+ * Creates a new replica to mark it as the owner of a specified `slot`.
+ * This should be done with an advisory lock for replica/slot management
+ * to ensure that the slot does not get dropped by concurrent cleanup
+ * logic.
+ *
+ * Once initial sync is complete, {@link initReplica} should be called to
+ * make the replica usable for incremental sync.
+ */
+export async function createReplica(
   sql: PostgresDB,
   shard: ShardID,
+  id: string,
   slot: string,
   replicaVersion: string,
+) {
+  const schema = upstreamSchema(shard);
+  const values = {id, slot, version: replicaVersion};
+  await sql`INSERT INTO ${sql(schema)}.replicas ${sql(values)}`;
+}
+
+// Called in initial-sync to store the exact schema that was initially synced.
+export async function initReplica(
+  sql: PostgresDB,
+  shard: ShardID,
+  id: string,
   {tables, indexes}: PublishedSchema,
   initialSyncContext: JSONObject,
 ) {
   const schema = upstreamSchema(shard);
   const synced: PublishedSchema = {tables, indexes};
-  await sql`
-    INSERT INTO ${sql(schema)}.replicas
-      ("slot", "version", "initialSchema", "initialSyncContext")
-      VALUES (${slot}, ${replicaVersion}, ${synced}, ${initialSyncContext})`;
+  const values = {initialSchema: synced, initialSyncContext};
+  await sql`UPDATE ${sql(schema)}.replicas SET ${sql(values)} WHERE id = ${id}`;
 }
 
+/**
+ * Gets the latest initialized replica at the specified version.
+ */
 export async function getReplicaAtVersion(
   lc: LogContext,
   sql: PostgresDB,
@@ -277,6 +300,8 @@ export async function getReplicaAtVersion(
   const schema = sql(upstreamSchema(shard));
   const result = await sql`
     SELECT
+      replicas."id",
+      replicas."rank",
       replicas."slot",
       replicas."version",
       replicas."initialSchema",
@@ -285,12 +310,13 @@ export async function getReplicaAtVersion(
       "shardConfig"."publications",
       "shardConfig"."ddlDetection"
     FROM ${schema}.replicas JOIN ${schema}."shardConfig" ON true
-      WHERE version = ${replicaVersion};
+      WHERE version = ${replicaVersion} AND "initialSyncContext" IS NOT NULL
+      ORDER BY rank DESC LIMIT 1;
   `;
   if (result.length === 0) {
     // log out all the replicas and the joined shardConfig
     const allReplicas = await sql`
-      SELECT slot, version, "initialSyncContext", "subscriberContext" 
+      SELECT id, slot, version, "initialSyncContext", "subscriberContext" 
         FROM ${schema}.replicas`;
     lc.info?.(
       `Replica ${replicaVersion} ` +


### PR DESCRIPTION
## Background

* Postgres 17+ supports [Logical Replication Failover](https://www.postgresql.org/docs/current/logical-replication-failover.html)
* Configuration for this feature requires registering the (set of) replication slot(s) that should be synchronized to standby servers ([synchronized_standby_slots](https://www.postgresql.org/docs/current/runtime-config-replication.html#GUC-SYNCHRONIZED-STANDBY-SLOTS)).
* This is incompatible with the way zero previously used dynamic replication slot names (which included a timestamp in the name for cleanup/management purposes)

## New Support

In order to support Logical Replication Failover, and in particular, the [synchronized_standby_slots](https://www.postgresql.org/docs/current/runtime-config-replication.html#GUC-SYNCHRONIZED-STANDBY-SLOTS) configuration parameter, the zero-cache now creates replication slots with an ordinal naming scheme, reusing early names when possible, with the format being `{ZERO_APP_ID}_0_{a-z}`, e.g.
* `zero_0_a`
* `zero_0_b`

In the current replication-manager implementation, a second slot (`zero_0_b`) is only created for non-disruptive resync, after which the first slot (`zero_0_a`) will be cleaned up. The next resync will then reuse `zero_0_a`. As a result, the number of slot names used is confined to the maximum number of slots that zero will concurrently use (generally, 2 for the current replication-manager implementation).

(For RMv2, it will be possible to run simultaneously multiple replication-managers for high availability, and thus the number of slots in use can be greater than 2, but it will still hold that the slot names will not exceed the maximum number of concurrently used slots.)

Therefore, the guidance for configuring Postgres Logical Replication Failover with zero is to register the slot names `{ZERO_APP_ID}_0_a` through `{ZERO_APP_ID}_0_z` to provide plenty of headroom (26) for replication slots. Note that the zero-cache can technically create more than 26 slots (e.g. `{ZERO_APP_ID}_0_aa`), but this is not expected to necessary even with RMv2.

## Implementation Notes

The previous naming scheme for replication slots included a timestamp suffix which was used to implement a "ranking" of slots such that slots created for newly synced replicas would not be cleaned up (i.e. dropped) by older replicas.

This lexicographical ranking is no longer possible when slot names are drawn from a reusable pool of names.

Instead, each slot is associated with a "replica" in the existing `replicas` table, with each replica now getting a monotonic (i.e. `SERIAL`) rank that is used to denote when a slot is being used by a newer replica. The creation of replication slots and the association of them with a replica is guarded by an advisory lock to ensure that creation and cleanup logic are serialized. This (conveniently) is a step towards to the tracking of slots and replicas done in RMv2.

## Refactoring Notes

Consolidated replication slot logic from `initial-sync.ts` and `change-source.ts` into a new `replication-slots.ts` file to better abstract the related mechanisms (e.g. locking) of the two logical processes. 
 
 