### PR TITLE
chore(zero-cache): handle NULL current_query() and log unparseable ddl events

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -805,7 +805,7 @@ class LagReporter {
       msg.prefix === this.messagePrefix,
       `unexpected message prefix: ${msg.prefix}`,
     );
-    const report = parseLogicalMessageContent(msg, lagReportSchema);
+    const report = parseLogicalMessageContent(this.#lc, msg, lagReportSchema);
     return this.#processLagReport(
       report,
       toStateVersionString(msg.messageLsn ?? '0/0'),
@@ -1040,7 +1040,7 @@ class ChangeMaker {
     lsn: bigint,
     msg: MessageMessage,
   ): ChangeStreamData[] {
-    const event = parseLogicalMessageContent(msg, replicationEventSchema);
+    const event = parseLogicalMessageContent(lc, msg, replicationEventSchema);
     lc = lc
       .withContext('lsn', fromBigInt(lsn))
       .withContext('tag', event.event.tag)
@@ -1675,13 +1675,22 @@ class ShutdownSignal extends AbortError {
 }
 
 function parseLogicalMessageContent<T>(
-  {content}: MessageMessage,
+  lc: LogContext,
+  msg: MessageMessage,
   schema: v.Type<T>,
 ) {
+  const {content} = msg;
   const str =
     content instanceof Buffer
       ? content.toString('utf-8')
       : new TextDecoder().decode(content);
-  const json = JSON.parse(str);
-  return v.parse(json, schema, 'passthrough');
+  try {
+    const json = JSON.parse(str);
+    return v.parse(json, schema, 'passthrough');
+  } catch (e) {
+    lc.error?.(`unable to parse logical message content: ${String(e)}`, {
+      message: {...msg, content: str},
+    });
+    throw e;
+  }
 }

--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl.ts
@@ -153,7 +153,7 @@ RETURNS record AS $$
 DECLARE
   result record;
 BEGIN
-  SELECT current_query() AS "query" into result;
+  SELECT COALESCE(current_query(), 'current_query() returned NULL') AS "query" into result;
   RETURN result;
 END
 $$ LANGUAGE plpgsql;

--- a/packages/zero-cache/src/services/change-source/pg/schema/init.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.ts
@@ -242,17 +242,8 @@ function getIncrementalMigrations(
     // v18: Pure refactoring of event trigger code.
     // v19 (1.4.0): Correctly handle concurrently issued DDL statements.
     // v20 (1.4.0): Handle nested DDL triggers
-
     // v21 (1.5.0): Handle cross-transaction DDL operations (i.e. concurrent
     // index operations), and support manual invocation of update_schemas().
-    21: {
-      migrateSchema: async (lc, sql) => {
-        const [{publications}] = await sql<{publications: string[]}[]>`
-          SELECT publications FROM ${sql(shardConfigTable)}`;
-        await setupTriggers(lc, sql, {...shard, publications});
-        lc.info?.(`Upgraded DDL event triggers`);
-      },
-    },
 
     22: {
       migrateSchema: async (_, sql) => {
@@ -272,6 +263,17 @@ function getIncrementalMigrations(
           ALTER TABLE ${sql(upstreamSchema(shard))}.replicas 
             ADD COLUMN rank BIGSERIAL;
         `;
+      },
+    },
+
+    // v23 (1.6.0): Event triggers: Handle the case where current_query()
+    // returns NULL. Add more logging to debug unexpected messages
+    23: {
+      migrateSchema: async (lc, sql) => {
+        const [{publications}] = await sql<{publications: string[]}[]>`
+          SELECT publications FROM ${sql(shardConfigTable)}`;
+        await setupTriggers(lc, sql, {...shard, publications});
+        lc.info?.(`Upgraded DDL event triggers`);
       },
     },
   };


### PR DESCRIPTION
For debugging a unexpected parse error when handling a ddl event message:

```
TypeError: Expected string at context.query. Got null: Expected string at context.query. Got null
```

Context:
* https://rocicorp.slack.com/archives/C0B2JKKK9QC/p1778261548602499