### PR TITLE
feat(zql): fix types for args to be optional when undefined

### DIFF
--- a/packages/zql/src/mutate/mutator-registry.test.ts
+++ b/packages/zql/src/mutate/mutator-registry.test.ts
@@ -1,15 +1,15 @@
 // oxlint-disable require-await
-import type { StandardSchemaV1 } from '@standard-schema/spec';
-import { assert, describe, expect, expectTypeOf, test, vi } from 'vitest';
-import type { ReadonlyJSONValue } from '../../../shared/src/json.ts';
-import { createSchema } from '../../../zero-schema/src/builder/schema-builder.ts';
+import type {StandardSchemaV1} from '@standard-schema/spec';
+import {assert, describe, expect, expectTypeOf, test, vi} from 'vitest';
+import type {ReadonlyJSONValue} from '../../../shared/src/json.ts';
+import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import {
   number,
   string,
   table,
 } from '../../../zero-schema/src/builder/table-builder.ts';
-import type { Schema } from '../../../zero-types/src/schema.ts';
-import type { AnyTransaction, Transaction } from './custom.ts';
+import type {Schema} from '../../../zero-types/src/schema.ts';
+import type {AnyTransaction, Transaction} from './custom.ts';
 import {
   defineMutators,
   defineMutatorsWithType,
@@ -18,7 +18,7 @@ import {
   iterateMutators,
   mustGetMutator,
 } from './mutator-registry.ts';
-import { defineMutator, defineMutatorWithType, type Mutator } from './mutator.ts';
+import {defineMutator, defineMutatorWithType, type Mutator} from './mutator.ts';
 
 const schema = createSchema({
   tables: [
@@ -333,7 +333,7 @@ test('mustGetMutator makes ctx optional only for fallback unknown context', () =
     tx: {} as Transaction<typeof schema, unknown>,
   });
   expectTypeOf(unknownContextMutator.fn).toBeCallableWith({
-    args: {id: '1'}, 
+    args: {id: '1'},
     ctx: {arbitrary: true},
     tx: {} as Transaction<typeof schema, unknown>,
   });

--- a/packages/zql/src/mutate/mutator-registry.test.ts
+++ b/packages/zql/src/mutate/mutator-registry.test.ts
@@ -1,15 +1,15 @@
 // oxlint-disable require-await
-import type {StandardSchemaV1} from '@standard-schema/spec';
-import {assert, describe, expect, expectTypeOf, test, vi} from 'vitest';
-import type {ReadonlyJSONValue} from '../../../shared/src/json.ts';
-import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
+import type { StandardSchemaV1 } from '@standard-schema/spec';
+import { assert, describe, expect, expectTypeOf, test, vi } from 'vitest';
+import type { ReadonlyJSONValue } from '../../../shared/src/json.ts';
+import { createSchema } from '../../../zero-schema/src/builder/schema-builder.ts';
 import {
   number,
   string,
   table,
 } from '../../../zero-schema/src/builder/table-builder.ts';
-import type {Schema} from '../../../zero-types/src/schema.ts';
-import type {AnyTransaction, Transaction} from './custom.ts';
+import type { Schema } from '../../../zero-types/src/schema.ts';
+import type { AnyTransaction, Transaction } from './custom.ts';
 import {
   defineMutators,
   defineMutatorsWithType,
@@ -18,7 +18,7 @@ import {
   iterateMutators,
   mustGetMutator,
 } from './mutator-registry.ts';
-import {defineMutator, defineMutatorWithType, type Mutator} from './mutator.ts';
+import { defineMutator, defineMutatorWithType, type Mutator } from './mutator.ts';
 
 const schema = createSchema({
   tables: [
@@ -302,6 +302,15 @@ test('mustGetMutator makes ctx optional only for fallback unknown context', () =
     }),
   });
 
+  const concreteNoArgsMutators = defineMutatorsWithType<typeof schema>()({
+    run: defineMutator<undefined, typeof schema, Context, DbTransaction>(
+      async ({ctx, tx}) => {
+        void ctx;
+        void tx;
+      },
+    ),
+  });
+
   const concreteContextMutators = defineMutatorsWithType<typeof schema>()({
     run: defineMutator<{id: string}, typeof schema, Context, DbTransaction>(
       async ({args, ctx, tx}) => {
@@ -313,16 +322,25 @@ test('mustGetMutator makes ctx optional only for fallback unknown context', () =
   });
 
   const unknownContextMutator = mustGetMutator(unknownContextMutators, 'run');
+  const concreteNoArgsMutator = mustGetMutator(concreteNoArgsMutators, 'run');
   const concreteContextMutator = mustGetMutator(concreteContextMutators, 'run');
 
+  expectTypeOf(unknownContextMutator.fn).toBeCallableWith({
+    tx: {} as Transaction<typeof schema, unknown>,
+  });
   expectTypeOf(unknownContextMutator.fn).toBeCallableWith({
     args: undefined,
     tx: {} as Transaction<typeof schema, unknown>,
   });
   expectTypeOf(unknownContextMutator.fn).toBeCallableWith({
-    args: {id: '1'},
+    args: {id: '1'}, 
     ctx: {arbitrary: true},
     tx: {} as Transaction<typeof schema, unknown>,
+  });
+
+  expectTypeOf(concreteNoArgsMutator.fn).toBeCallableWith({
+    ctx: {userId: '123'},
+    tx: {} as Transaction<typeof schema, DbTransaction>,
   });
 
   expectTypeOf(concreteContextMutator.fn).toBeCallableWith({
@@ -330,6 +348,14 @@ test('mustGetMutator makes ctx optional only for fallback unknown context', () =
     ctx: {userId: '123'},
     tx: {} as Transaction<typeof schema, DbTransaction>,
   });
+
+  const callWithoutArgs = () =>
+    // @ts-expect-error args is still required when it does not include undefined
+    concreteContextMutators.run.fn({
+      ctx: {userId: '123'},
+      tx: {} as Transaction<typeof schema, DbTransaction>,
+    });
+  void callWithoutArgs;
 
   // @ts-expect-error ctx is still required when a concrete context exists
   void concreteContextMutator.fn({
@@ -623,6 +649,9 @@ describe('input/output type separation', () => {
     } as Transaction<typeof schema, unknown>;
 
     // When fn is called, it should transform undefined to 'default-value'
+    expectTypeOf(mutators.item.create.fn).toBeCallableWith({
+      tx: mockTx,
+    });
     expectTypeOf(mutators.item.create.fn).toBeCallableWith({
       args: undefined,
       tx: mockTx,

--- a/packages/zql/src/mutate/mutator.ts
+++ b/packages/zql/src/mutate/mutator.ts
@@ -203,10 +203,20 @@ export type MutatorExecutionFunction<
   TContext,
   TTransaction,
 > = (
-  options: IsUnknown<TContext> extends true
-    ? {args: TOutput; tx: TTransaction; ctx?: TContext}
-    : {args: TOutput; tx: TTransaction; ctx: TContext},
+  options: MutatorExecutionOptions<TOutput, TContext, TTransaction>,
 ) => Promise<void>;
+
+type MutatorExecutionOptions<
+  TOutput extends ReadonlyJSONValue | undefined,
+  TContext,
+  TTransaction,
+> = undefined extends TOutput
+  ? IsUnknown<TContext> extends true
+    ? {args?: TOutput | undefined; tx: TTransaction; ctx?: TContext | undefined}
+    : {args?: TOutput | undefined; tx: TTransaction; ctx: TContext}
+  : IsUnknown<TContext> extends true
+    ? {args: TOutput; tx: TTransaction; ctx?: TContext | undefined}
+    : {args: TOutput; tx: TTransaction; ctx: TContext};
 
 // ----------------------------------------------------------------------------
 // Mutator and MutateRequest types

--- a/packages/zql/src/query/query-registry.test.ts
+++ b/packages/zql/src/query/query-registry.test.ts
@@ -225,11 +225,28 @@ describe('defineQueries', () => {
       table: 'foo',
     });
 
+    expectTypeOf(queries.getAllUsers.fn).toBeCallableWith({
+      ctx: {userId: 'ctx-user'},
+    });
+
+    const result2 = queries.getAllUsers.fn({ctx: {userId: 'ctx-user'}});
+    expect(asQueryInternals(result2).ast).toEqual({
+      table: 'foo',
+    });
+
     // Should also work with explicit undefined
-    const result2 = addContextToQuery(queries.getAllUsers(), {
+    const result3 = queries.getAllUsers.fn({
+      args: undefined,
+      ctx: {userId: 'ctx-user'},
+    });
+    expect(asQueryInternals(result3).ast).toEqual({
+      table: 'foo',
+    });
+
+    const result4 = addContextToQuery(queries.getAllUsers(), {
       userId: 'ctx-user',
     });
-    expect(asQueryInternals(result2).ast).toEqual({
+    expect(asQueryInternals(result4).ast).toEqual({
       table: 'foo',
     });
   });
@@ -294,6 +311,7 @@ describe('defineQueries', () => {
       .toEqualTypeOf<string | undefined>();
     expectTypeOf(queries.getValue.fn).toBeCallableWith({args: undefined});
     expectTypeOf(queries.getValue.fn).toBeCallableWith({args: 'explicit'});
+    expectTypeOf(queries.getValue.fn).toBeCallableWith({});
 
     // Call with undefined - query function gets transformed value
     const result = addContextToQuery(queries.getValue(undefined), {});
@@ -517,6 +535,11 @@ describe('defineQueries types', () => {
     expectTypeOf<Parameters<typeof queries.getUser.fn>>().toEqualTypeOf<
       [{args: string; ctx: {userId: string}}]
     >();
+
+    const callWithoutArgs = () =>
+      // @ts-expect-error args is still required when it does not include undefined
+      queries.getUser.fn({ctx: {userId: '123'}});
+    void callWithoutArgs;
   });
 
   test('after setting args, should have query but not be callable again', () => {

--- a/packages/zql/src/query/query-registry.ts
+++ b/packages/zql/src/query/query-registry.ts
@@ -303,10 +303,19 @@ export type QueryExecutionFunction<
   TReturn,
   TContext,
 > = (
-  options: IsUnknown<TContext> extends true
-    ? {args: TInput; ctx?: TContext}
-    : {args: TInput; ctx: TContext},
+  options: QueryExecutionOptions<TInput, TContext>,
 ) => Query<TTable, Schema, TReturn>;
+
+type QueryExecutionOptions<
+  TInput extends ReadonlyJSONValue | undefined,
+  TContext,
+> = undefined extends TInput
+  ? IsUnknown<TContext> extends true
+    ? {args?: TInput | undefined; ctx?: TContext | undefined}
+    : {args?: TInput | undefined; ctx: TContext}
+  : IsUnknown<TContext> extends true
+    ? {args: TInput; ctx?: TContext | undefined}
+    : {args: TInput; ctx: TContext};
 
 /**
  * Defines a query to be used with {@link defineQueries}.


### PR DESCRIPTION
Custom query and mutator execution functions now treat `args` as optional when the args type already allows `undefined`.

This lets callers write:

```ts
queries.teams.fn({ctx: user});
mutators.teams.fn({tx, ctx: user});
```

instead of having to pass:

```ts
queries.teams.fn({args: undefined, ctx: user});
mutators.teams.fn({args: undefined, tx, ctx: user});
```

## Details

- Adds conditional execution option types for custom queries and mutators.
- Keeps `args` required when the args type does not include `undefined`.
- Preserves existing `ctx` behavior: `ctx` is only optional for unknown context.
- Preserves existing mutator behavior: `tx` is always required.
- Adds type coverage for omitted `args`, explicit `args: undefined`, optional validator inputs, and required-args rejection.