### PR TITLE
[codex] reduce view syncer info logs

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/client-handler.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.ts
@@ -192,7 +192,7 @@ export class ClientHandler {
 
     const baseCookie = versionToNullableCookie(this.#baseVersion);
     const cookie = versionToCookie(tentativeVersion);
-    lc.info?.(`starting poke from ${baseCookie} to ${cookie}`);
+    lc.debug?.(`starting poke from ${baseCookie} to ${cookie}`);
 
     const start = performance.now();
 

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -689,7 +689,7 @@ export class PipelineDriver {
       numChanges,
       pos: 0,
     };
-    this.#lc.info?.(
+    this.#lc.debug?.(
       `starting pipeline advancement of ${numChanges} changes with an ` +
         `advancement time limited based on total hydration time of ` +
         `${totalHydrationTimeMs} ms.`,

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -2322,7 +2322,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
       const wallTime = performance.now() - start;
       const totalProcessTime = timer.totalElapsed();
-      lc.info?.(
+      lc.debug?.(
         `finished processing advancement of ${numChanges} changes ((process: ${totalProcessTime} ms, wall: ${wallTime} ms))`,
       );
       this.#transactionAdvanceTime.recordMs(totalProcessTime);


### PR DESCRIPTION
These lines are creating an absolutely stupendous about of data, like 200MB / minute on one customer. Of this 99.8% is generated by these three lines (in about equal parts).
