### PR TITLE
chore(zero-cache): preemptive slot cleanup, consolidate to always use lock

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/replication-slots.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/replication-slots.pg.test.ts
@@ -97,7 +97,7 @@ describe('createReplicationSlot', () => {
     }
   });
 
-  test('create replica and slots reuses pool names', async () => {
+  test('create replica and slots cleans up and reuses pool names', async () => {
     const lc = createSilentLogContext();
     const upstreamURI = getConnectionURI(upstream);
     const session = pgClient(lc, upstreamURI, 'slot-pool', {
@@ -105,6 +105,17 @@ describe('createReplicationSlot', () => {
       ['fetch_types']: false,
       connection: {replication: 'database'},
     });
+
+    // Create some unused slots. These should be dropped and reused.
+    await createReplicationSlot(lc, session, {slotName: 'zero_18_a'});
+    await createReplicationSlot(lc, session, {slotName: 'zero_18_d'});
+
+    expect(
+      await upstream`
+      SELECT slot_name FROM pg_replication_slots 
+        WHERE slot_name LIKE 'zero_18_%' 
+        ORDER BY slot_name`.values(),
+    ).toEqual([['zero_18_a'], ['zero_18_d']]);
 
     const create = (id: string) =>
       createReplicaAndSlot(lc, upstream, session, shard, id, false);
@@ -122,6 +133,13 @@ describe('createReplicationSlot', () => {
 
     ({slot_name: name} = await create('rep_4'));
     expect(name).toBe('zero_18_b');
+
+    expect(
+      await upstream`
+      SELECT slot_name FROM pg_replication_slots 
+        WHERE slot_name LIKE 'zero_18_%' 
+        ORDER BY slot_name`.values(),
+    ).toEqual([['zero_18_a'], ['zero_18_b'], ['zero_18_c']]);
 
     expect(
       await upstream`SELECT id, slot, version FROM ${upstream(`${APP_ID}_${SHARD_NUM}`)}.replicas`,

--- a/packages/zero-cache/src/services/change-source/pg/replication-slots.ts
+++ b/packages/zero-cache/src/services/change-source/pg/replication-slots.ts
@@ -1,9 +1,6 @@
-import {
-  PG_CONFIGURATION_LIMIT_EXCEEDED,
-  PG_INSUFFICIENT_PRIVILEGE,
-} from '@drdgvhbh/postgres-error-codes';
+import {PG_INSUFFICIENT_PRIVILEGE} from '@drdgvhbh/postgres-error-codes';
 import type {LogContext} from '@rocicorp/logger';
-import postgres from 'postgres';
+import type postgres from 'postgres';
 import {runTx} from '../../../db/run-transaction';
 import {isPostgresError, type PostgresDB} from '../../../types/pg';
 import {upstreamSchema, type ShardID} from '../../../types/shards';
@@ -130,6 +127,8 @@ export async function createReplicaAndSlot(
   replicaID: string,
   failover: boolean,
 ): Promise<ReplicationSlot> {
+  await dropUnclaimedSlots(lc, sql, shard);
+
   const lockName = replicationSlotManagementLock(shard);
   const slotPoolPrefix = replicationSlotPrefix(shard);
   for (let first = true; ; first = false) {
@@ -168,32 +167,14 @@ export async function createReplicaAndSlot(
         return slot;
       });
     } catch (e) {
-      if (first && e instanceof postgres.PostgresError) {
-        if (isPostgresError(e, PG_INSUFFICIENT_PRIVILEGE)) {
-          // Some Postgres variants (e.g. Google Cloud SQL) require that
-          // the user have the REPLICATION role in order to create a slot.
-          // Note that this must be done by the upstreamDB connection, and
-          // does not work in the replicationSession itself.
-          await sql`ALTER ROLE current_user WITH REPLICATION`;
-          lc.info?.(`Added the REPLICATION role to database user`);
-          continue;
-        }
-        if (isPostgresError(e, PG_CONFIGURATION_LIMIT_EXCEEDED)) {
-          const slotExpression = replicationSlotExpression(shard);
-
-          const dropped = await sql<{slot: string}[]>`
-                SELECT slot_name as slot, pg_drop_replication_slot(slot_name)
-                  FROM pg_replication_slots
-                  WHERE slot_name LIKE ${slotExpression} AND NOT active`;
-          if (dropped.length) {
-            lc.warn?.(
-              `Dropped inactive replication slots: ${dropped.map(({slot}) => slot)}`,
-              e,
-            );
-            continue;
-          }
-          lc.error?.(`Unable to drop replication slots`, e);
-        }
+      if (first && isPostgresError(e, PG_INSUFFICIENT_PRIVILEGE)) {
+        // Some Postgres variants (e.g. Google Cloud SQL) require that
+        // the user have the REPLICATION role in order to create a slot.
+        // Note that this must be done by the upstreamDB connection, and
+        // does not work in the replicationSession itself.
+        await sql`ALTER ROLE current_user WITH REPLICATION`;
+        lc.info?.(`Added the REPLICATION role to database user`);
+        continue;
       }
       throw e;
     }
@@ -226,11 +207,21 @@ export async function dropOldReplicasAndSlots(
     await sql`DELETE FROM ${sql(replicasTable)} WHERE rank < ${beforeRank}`;
   }
 
+  return dropUnclaimedSlots(lc, sql, shard);
+}
+
+function dropUnclaimedSlots(
+  lc: LogContext,
+  sql: PostgresDB,
+  shard: ShardID,
+): Promise<{dropped: number; active: number; draining: number}> {
   // The slot / replica cleanup happens within a transaction while holding
   // the replication slot management lock for this shard, to ensure that no
   // slot that belongs to a newer replica is dropped.
   const lockName = replicationSlotManagementLock(shard);
   const slotExpression = replicationSlotExpression(shard);
+  const replicasTable = `${upstreamSchema(shard)}.replicas`;
+
   return runTx(sql, async tx => {
     await tx`SELECT pg_advisory_xact_lock(hashtext(${lockName}))`;
 


### PR DESCRIPTION
Consolidates the slot cleanup logic so that it always acquires the management lock.

Preemptively cleanup orphaned slots upon new slot creation, rather than only if the configured max is hit. This avoids a pathological case where initial sync continual failing can cause the pool of slot names to be used up.