### PR TITLE
chore(zero-cache): fix inactive slot cleanup

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/replication-slots.ts
+++ b/packages/zero-cache/src/services/change-source/pg/replication-slots.ts
@@ -1,4 +1,7 @@
-import {PG_INSUFFICIENT_PRIVILEGE} from '@drdgvhbh/postgres-error-codes';
+import {
+  PG_CONFIGURATION_LIMIT_EXCEEDED,
+  PG_INSUFFICIENT_PRIVILEGE,
+} from '@drdgvhbh/postgres-error-codes';
 import type {LogContext} from '@rocicorp/logger';
 import type postgres from 'postgres';
 import {runTx} from '../../../db/run-transaction';
@@ -127,11 +130,10 @@ export async function createReplicaAndSlot(
   replicaID: string,
   failover: boolean,
 ): Promise<ReplicationSlot> {
-  await dropUnclaimedSlots(lc, sql, shard);
-
   const lockName = replicationSlotManagementLock(shard);
   const slotPoolPrefix = replicationSlotPrefix(shard);
   for (let first = true; ; first = false) {
+    await dropUnclaimedSlots(lc, sql, shard);
     try {
       return runTx(sql, async tx => {
         await tx`SELECT pg_advisory_xact_lock(hashtext(${lockName}))`;
@@ -175,6 +177,18 @@ export async function createReplicaAndSlot(
         await sql`ALTER ROLE current_user WITH REPLICATION`;
         lc.info?.(`Added the REPLICATION role to database user`);
         continue;
+      }
+      if (first && isPostgresError(e, PG_CONFIGURATION_LIMIT_EXCEEDED)) {
+        lc.warn?.(
+          `Reached max replication slots. Attempting to clean up unused slots`,
+          e,
+        );
+        // Drop any inactive replicas from failed initial syncs (e.g. inactive slots).
+        const replicasTable = `${upstreamSchema(shard)}.replicas`;
+        await sql`
+          DELETE FROM ${sql(replicasTable)} USING pg_replication_slots slots
+            WHERE replicas.slot = slots.slot_name AND NOT slots.active`;
+        continue; // then let dropUnclaimedSlots() perform its cleanup
       }
       throw e;
     }

--- a/packages/zero-cache/src/services/change-source/pg/replication-slots.ts
+++ b/packages/zero-cache/src/services/change-source/pg/replication-slots.ts
@@ -178,6 +178,9 @@ export async function createReplicaAndSlot(
         lc.info?.(`Added the REPLICATION role to database user`);
         continue;
       }
+      // Note: This is currently manually tested since max_replication_slots
+      //       is a PG startup parameter that other tests depend on.
+      // TODO: Figure out a way to unit test this (with the full PG setup).
       if (first && isPostgresError(e, PG_CONFIGURATION_LIMIT_EXCEEDED)) {
         lc.warn?.(
           `Reached max replication slots. Attempting to clean up unused slots`,

--- a/packages/zero-cache/src/services/change-source/pg/replication-slots.ts
+++ b/packages/zero-cache/src/services/change-source/pg/replication-slots.ts
@@ -135,7 +135,7 @@ export async function createReplicaAndSlot(
   for (let first = true; ; first = false) {
     await dropUnclaimedSlots(lc, sql, shard);
     try {
-      return runTx(sql, async tx => {
+      return await runTx(sql, async tx => {
         await tx`SELECT pg_advisory_xact_lock(hashtext(${lockName}))`;
 
         // Pick an available slotName from the slotPoolPrefix pool.


### PR DESCRIPTION
Correction to the fix in https://github.com/rocicorp/mono/pull/5947. 

In addition to acquiring the lock before deleting replication slots, restore the policy of deleting inactive slots by removing the associated replicas. Otherwise, failed initial syncs will still "claim" these slots because they will have a row in the `replicas` table.