### PR TITLE
chore(zero-cache): loosen invariant in shadow sync

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
@@ -3144,10 +3144,11 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
         ).toThrow(/missing column_metadata row for big\.val/);
       });
 
-      test('throws when a table is unqueryable via ZQL', async () => {
-        const {lc, replica, publishedInfo} = await runShadowSync();
-        // Dropping the only unique index over non-null columns makes
-        // computeZqlSpecs silently exclude the table.
+      test('does not check ZQL-queryability (matches prod tolerance)', async () => {
+        // computeZqlSpecs silently drops tables with no PK / no qualifying
+        // unique index in production too — there's nothing shadow-specific
+        // about that condition, so the verifier should NOT fail on it.
+        const {replica, publishedInfo, bigCount} = await runShadowSync();
         const idx = replica
           .prepare(
             `SELECT name FROM sqlite_master
@@ -3157,9 +3158,15 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
         for (const {name} of idx) {
           replica.exec(`DROP INDEX "${name}"`);
         }
+        const filtered = {
+          ...publishedInfo,
+          indexes: publishedInfo.indexes.filter(i => i.tableName !== 'big'),
+        };
+        const lc = createSilentLogContext();
+        const rowsByTable = new Map([['big', bigCount]]);
         expect(() =>
-          verifyShadowReplica(lc, replica, publishedInfo, new Map()),
-        ).toThrow(/dropped by computeZqlSpecs.*big/s);
+          verifyShadowReplica(lc, replica, filtered, rowsByTable),
+        ).not.toThrow();
       });
     });
   });

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
@@ -15,11 +15,7 @@ import {
   createLiteIndexStatement,
   createLiteTableStatement,
 } from '../../../db/create.ts';
-import {
-  computeZqlSpecs,
-  listIndexes,
-  listTables,
-} from '../../../db/lite-tables.ts';
+import {listIndexes, listTables} from '../../../db/lite-tables.ts';
 import * as Mode from '../../../db/mode-enum.ts';
 import {
   BinaryCopyParser,
@@ -569,8 +565,14 @@ function createLiteIndices(tx: Database, indices: IndexSpec[]) {
 /**
  * Runs structural assertions over a just-synced replica and throws if any
  * fail. Only called in shadow mode — a successful return means the replica
- * is schema-complete, row-count consistent, ZQL-queryable, and its column
- * metadata is in sync with its lite schema.
+ * is schema-complete, row-count consistent, and its column metadata is in
+ * sync with its lite schema.
+ *
+ * Note: this intentionally does NOT verify ZQL-queryability. Tables that
+ * `computeZqlSpecs` drops (no PK / no all-NOT-NULL unique index, unsupported
+ * column types, etc.) are silently skipped in production too — there's
+ * nothing shadow-specific about them, so failing here would diverge from
+ * prod over an upstream-schema condition prod accepts.
  *
  * Exported for testing.
  */
@@ -633,21 +635,7 @@ export function verifyShadowReplica(
     }
   }
 
-  // 3. ZQL-queryability: every published table survives computeZqlSpecs's
-  //    filtering (primary-key candidate, ZQL-typed columns, etc.).
-  const tableSpecs = computeZqlSpecs(lc, db, {
-    includeBackfillingColumns: false,
-  });
-  for (const pt of published.tables) {
-    const name = liteTableName(pt);
-    if (!tableSpecs.has(name)) {
-      issues.push(
-        `table not queryable via ZQL (dropped by computeZqlSpecs): ${name}`,
-      );
-    }
-  }
-
-  // 4. Column metadata: every published column has a _zero.column_metadata row.
+  // 3. Column metadata: every published column has a _zero.column_metadata row.
   const meta = must(ColumnMetadataStore.getInstance(db));
   for (const pt of published.tables) {
     const name = liteTableName(pt);


### PR DESCRIPTION
https://rocicorp.slack.com/archives/C0AK5KX8HGE/p1778482696395909?thread_ts=1778344567.202889&cid=C0AK5KX8HGE

Shadow sync would throw if a table that was synced could not be queried by ZQL. Prod just silently ignores this case.