### PR TITLE
fix(zero-cache): avoid creating a deadlock with resetting the cdc changeLog

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/schema/tables.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/schema/tables.pg.test.ts
@@ -254,6 +254,111 @@ describe('change-streamer/schema/tables', () => {
     ).rejects.toThrow(AutoResetSignal);
   });
 
+  test('no deadlocks when table is reset', async () => {
+    // Set up initial replication config.
+    await ensureReplicationConfig(
+      lc,
+      sql,
+      {
+        replicaVersion: '183',
+        publications: ['zero_data', 'zero_metadata'],
+        watermark: '183',
+      },
+      shard,
+      true,
+    );
+
+    await sql`
+      UPDATE "rezo_8/cdc"."replicationState" SET owner = 'me'
+    `.simple();
+    await sql`
+      INSERT INTO "rezo_8/cdc"."changeLog" (watermark, pos, change)
+        VALUES ('184', 0, '{"tag":"begin"}'::json),
+               ('184', 1, '{"tag":"commit"}'::json),
+               ('185', 0, '{"tag":"begin"}'::json),
+               ('185', 1, '{"tag":"commit"}'::json)
+    `.simple();
+
+    const readReplicationState = resolver();
+    const canProceed = resolver();
+
+    // Simulate the sequence of locking / reading / writing done by the
+    // storer when updating the changeLog.
+    const changeLogPreUpdateState = sql.begin(async tx => {
+      const state = tx<{owner: string; lastWatermark: string}[]>`
+        SELECT owner, "lastWatermark" FROM "rezo_8/cdc"."replicationState" FOR UPDATE
+      `.execute();
+      readReplicationState.resolve();
+      await canProceed.promise;
+
+      await tx`
+        INSERT INTO "rezo_8/cdc"."changeLog" (watermark, pos, change)
+          VALUES ('186', 0, '{"tag":"begin"}'::json),
+                 ('186', 1, '{"tag":"commit"}'::json),
+                 ('187', 0, '{"tag":"begin"}'::json),
+                 ('187', 1, '{"tag":"commit"}'::json)
+      `.simple();
+
+      await tx`
+        UPDATE "rezo_8/cdc"."replicationState" SET "lastWatermark" = '187';
+      `;
+
+      return state;
+    });
+
+    // Start the reset once the changeLogUpdate has acquired the replicationState lock.
+    await readReplicationState.promise;
+    const resetDone = ensureReplicationConfig(
+      lc,
+      sql,
+      {
+        replicaVersion: '190',
+        publications: ['zero_data', 'zero_metadata'],
+        watermark: '190',
+      },
+      shard,
+      true,
+    );
+
+    // Let the changeLogUpdate proceed after the reset gets going.
+    // The reset itself should block when attempting to truncate the
+    // replicationState table.
+    setTimeout(canProceed.resolve, 500);
+
+    // The changeLog update should succeeded.
+    // If, on the other hand, the reset logic doesn't operate on the tables
+    // in the same lock acquisition order, one of the requests will fail at the
+    // Postgres level with a `deadlock detected` error.
+    expect(await changeLogPreUpdateState).toEqual([
+      {lastWatermark: '183', owner: 'me'},
+    ]);
+
+    // Verify the final state after the reset finishes.
+    await resetDone;
+    await expectTables(sql, {
+      ['rezo_8/cdc.replicationState']: [
+        {
+          lastWatermark: '190',
+          lock: 1,
+          owner: null,
+          ownerAddress: null,
+        },
+      ],
+      ['rezo_8/cdc.changeLog']: [
+        {watermark: '190', pos: 0n, change: {tag: 'begin'}, precommit: null},
+        {watermark: '190', pos: 1n, change: {tag: 'commit'}, precommit: null},
+      ],
+      ['rezo_8/cdc.replicationConfig']: [
+        {
+          replicaVersion: '190',
+          publications: ['zero_data', 'zero_metadata'],
+          resetRequired: null,
+          lock: 1,
+        },
+      ],
+    });
+  });
+
   test('terminateChangeDBLockHolders with multiple blockers', async () => {
     // Set up initial replication config.
     await ensureReplicationConfig(

--- a/packages/zero-cache/src/services/change-streamer/schema/tables.ts
+++ b/packages/zero-cache/src/services/change-streamer/schema/tables.ts
@@ -209,15 +209,18 @@ export async function ensureReplicationConfig(
           `Data in cdc tables @${replicaVersion} is incompatible ` +
             `with replica @${replicaConfig.replicaVersion}. Clearing tables.`,
         );
-        // Note: The replicationState table is explicitly not TRUNCATE'd.
-        //       Any existing row must be overwritten by an UPDATE or
-        //       INSERT ... ON CONFLICT clause in order to correctly abort
-        //       any pending transaction by a concurrently running
-        //       change-streamer. Deleting the existing row and creating
-        //       a new one, on the other hand, may not properly trigger the
-        //       SERIALIZATION failure necessary to abort the pending tx.
+        // Note: The order of TRUNCATE matters. The replicationState table is
+        //       truncated before the changeLog table, in order to acquire
+        //       (exclusive) locks on the tables in the same order that the
+        //       storer.ts acquires locks when writing the changeLog, namely:
+        //
+        // 1. SELECT ... FROM replicationState FOR UPDATE;
+        // 2. INSERT INTO changeLog ...;
+        //    ...
+        // n. UPDATE replicationState ...;
         needsTruncate = true;
         stmts.push(
+          sql`TRUNCATE TABLE ${sql(schema)}."replicationState"`,
           sql`TRUNCATE TABLE ${sql(schema)}."changeLog"`,
           sql`TRUNCATE TABLE ${sql(schema)}."replicationConfig"`,
           sql`TRUNCATE TABLE ${sql(schema)}."tableMetadata"`,


### PR DESCRIPTION
Fix a Postgres-detected deadlock that can happen when a post-initial-sync changeLog reset happens at the same time as changeLog update of a live replication-manager (i.e. during an elective, non-disruptive resync).

Because the steady-state changeLog update logic: (1) first acquires a `FOR UPDATE` lock on the `replicationState` for the ownership check, and then (2) writes `changeLog` entries, the post-initial-sync reset logic must in turn acquire a lock on the  `replicationState` table before truncating the `changeLog` table. Failure to do so results in a deadlock detected by Postgres:
* https://rocicorp.slack.com/archives/C0B2Z2735AR/p1778518999854209

This corrects the previous attempt to fix a similar situation (https://github.com/rocicorp/mono/pull/5416); the right fix is to truncate the `replicationState` table first, thereby acquiring an (exclusive) lock on that table before operating on the changeLog table. This ensures that both pieces of logic acquire locks in the same order.