### PR TITLE
chore(zero-cache): catch and publish all change-streamer init errors

### DIFF
--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -1,3 +1,4 @@
+import {consoleLogSink, LogContext} from '@rocicorp/logger';
 import {assert} from '../../../shared/src/asserts.ts';
 import {must} from '../../../shared/src/must.ts';
 import {DatabaseInitError} from '../../../zqlite/src/db.ts';
@@ -36,6 +37,9 @@ import {getShardConfig} from '../types/shards.ts';
 import {createLogContext} from './logging.ts';
 import {startOtelAuto} from './otel-start.ts';
 
+// Default LogContext, overridden in runWorker
+let lc = new LogContext('info', {}, consoleLogSink);
+
 export default async function runWorker(
   parent: Worker,
   env: NodeJS.ProcessEnv,
@@ -66,7 +70,7 @@ export default async function runWorker(
     'change-streamer',
     0,
   );
-  const lc = createLogContext(config, 'change-streamer');
+  lc = createLogContext(config, 'change-streamer');
   initEventSink(lc, config);
 
   // Kick off DB connection warmup in the background.
@@ -184,10 +188,6 @@ export default async function runWorker(
         purgeLock = null;
         continue; // execute again with a fresh initial-sync
       }
-      await publishCriticalEvent(
-        lc,
-        replicationStatusError(lc, 'Initializing', e),
-      );
       if (e instanceof DatabaseInitError) {
         throw new Error(
           `Cannot open ZERO_REPLICA_FILE at "${replica.file}". Please check that the path is valid.`,
@@ -243,7 +243,10 @@ export default async function runWorker(
 
 // fork()
 if (!singleProcessMode()) {
-  void exitAfter(() =>
-    runWorker(must(parentWorker), process.env, ...process.argv.slice(2)),
+  void exitAfter(lc, () =>
+    runWorker(must(parentWorker), process.env, ...process.argv.slice(2)).catch(
+      e =>
+        publishCriticalEvent(lc, replicationStatusError(lc, 'Initializing', e)),
+    ),
   );
 }

--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import {consoleLogSink, LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
 import {must} from '../../../shared/src/must.ts';
 import {getNormalizedZeroConfig} from '../config/zero-config.ts';
@@ -39,6 +40,9 @@ import {
 
 const clientConnectionBifurcated = false;
 
+// Default LogContext, overridden in runWorker
+let lc = new LogContext('info', {}, consoleLogSink);
+
 export default async function runWorker(
   parent: Worker,
   env: NodeJS.ProcessEnv,
@@ -51,7 +55,7 @@ export default async function runWorker(
     'dispatcher',
     0,
   );
-  const lc = createLogContext(config, 'dispatcher');
+  lc = createLogContext(config, 'dispatcher');
   initEventSink(lc, config);
 
   const processes = new ProcessManager(lc, parent);
@@ -218,5 +222,5 @@ export default async function runWorker(
 }
 
 if (!singleProcessMode()) {
-  void exitAfter(() => runWorker(must(parentWorker), process.env));
+  void exitAfter(lc, () => runWorker(must(parentWorker), process.env));
 }

--- a/packages/zero-cache/src/server/mutator.ts
+++ b/packages/zero-cache/src/server/mutator.ts
@@ -1,3 +1,4 @@
+import {consoleLogSink, LogContext} from '@rocicorp/logger';
 import {must} from '../../../shared/src/must.ts';
 import {getNormalizedZeroConfig} from '../config/zero-config.ts';
 import {initEventSink} from '../observability/events.ts';
@@ -11,6 +12,9 @@ import {Mutator} from '../workers/mutator.ts';
 import {createLogContext} from './logging.ts';
 import {startOtelAuto} from './otel-start.ts';
 
+// Default LogContext, overridden in runWorker
+let lc = new LogContext('info', {}, consoleLogSink);
+
 function runWorker(
   parent: Worker,
   env: NodeJS.ProcessEnv,
@@ -18,7 +22,7 @@ function runWorker(
 ): Promise<void> {
   const config = getNormalizedZeroConfig({env, argv: args.slice(1)});
   startOtelAuto(createLogContext(config, 'mutator', 0, false), 'mutator', 0);
-  const lc = createLogContext(config, 'mutator');
+  lc = createLogContext(config, 'mutator');
   initEventSink(lc, config);
 
   // TODO: create `PusherFactory`
@@ -26,7 +30,7 @@ function runWorker(
 }
 
 if (!singleProcessMode()) {
-  void exitAfter(() =>
+  void exitAfter(lc, () =>
     runWorker(must(parentWorker), process.env, ...process.argv.slice(2)),
   );
 }

--- a/packages/zero-cache/src/server/reaper.ts
+++ b/packages/zero-cache/src/server/reaper.ts
@@ -1,3 +1,4 @@
+import {consoleLogSink, LogContext} from '@rocicorp/logger';
 import {must} from '../../../shared/src/must.ts';
 import {getNormalizedZeroConfig} from '../config/zero-config.ts';
 import {initEventSink} from '../observability/events.ts';
@@ -18,6 +19,9 @@ import {startOtelAuto} from './otel-start.ts';
 
 const MS_PER_HOUR = 1000 * 60 * 60;
 
+// Default LogContext, overridden in runWorker
+let lc = new LogContext('info', {}, consoleLogSink);
+
 export default async function runWorker(
   parent: Worker,
   env: NodeJS.ProcessEnv,
@@ -26,7 +30,7 @@ export default async function runWorker(
   const config = getNormalizedZeroConfig({env, argv});
 
   startOtelAuto(createLogContext(config, 'reaper', 0, false), 'reaper', 0);
-  const lc = createLogContext(config, 'reaper');
+  lc = createLogContext(config, 'reaper');
   initEventSink(lc, config);
   startAnonymousTelemetry(lc, config);
 
@@ -57,7 +61,7 @@ export default async function runWorker(
 
 // fork()
 if (!singleProcessMode()) {
-  void exitAfter(() =>
+  void exitAfter(lc, () =>
     runWorker(must(parentWorker), process.env, ...process.argv.slice(2)),
   );
 }

--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -1,7 +1,7 @@
 import {stat} from 'node:fs/promises';
 import {pid} from 'node:process';
 import type {ObservableCallback} from '@opentelemetry/api';
-import type {LogContext} from '@rocicorp/logger';
+import {consoleLogSink, LogContext} from '@rocicorp/logger';
 import {assert} from '../../../shared/src/asserts.ts';
 import {must} from '../../../shared/src/must.ts';
 import * as v from '../../../shared/src/valita.ts';
@@ -32,6 +32,9 @@ import {
 import {createLogContext} from './logging.ts';
 import {startOtelAuto} from './otel-start.ts';
 
+// Default LogContext, overridden in runWorker
+let lc = new LogContext('info', {}, consoleLogSink);
+
 export default async function runWorker(
   parent: Worker,
   env: NodeJS.ProcessEnv,
@@ -44,7 +47,7 @@ export default async function runWorker(
   const mode: ReplicatorMode = fileMode === 'backup' ? 'backup' : 'serving';
   const workerName = `${mode}-replicator`;
   startOtelAuto(createLogContext(config, workerName, 0, false), workerName, 0);
-  const lc = createLogContext(config, workerName);
+  lc = createLogContext(config, workerName);
   initEventSink(lc, config);
 
   const {file: dbPath, walMode} = await setupReplica(
@@ -140,7 +143,7 @@ function observeFileSize(lc: LogContext, file: string): ObservableCallback {
 
 // fork()
 if (!singleProcessMode()) {
-  void exitAfter(() =>
+  void exitAfter(lc, () =>
     runWorker(must(parentWorker), process.env, ...process.argv.slice(2)),
   );
 }

--- a/packages/zero-cache/src/server/runner/main.ts
+++ b/packages/zero-cache/src/server/runner/main.ts
@@ -1,3 +1,4 @@
+import {consoleLogSink, LogContext} from '@rocicorp/logger';
 import '../../../../shared/src/dotenv.ts';
 
 import {exitAfter} from '../../services/life-cycle.ts';
@@ -5,7 +6,9 @@ import {parentWorker, singleProcessMode} from '../../types/processes.ts';
 import {runWorker} from './run-worker.ts';
 
 if (!singleProcessMode()) {
-  void exitAfter(() => runWorker(parentWorker, process.env));
+  void exitAfter(new LogContext('info', {}, consoleLogSink), () =>
+    runWorker(parentWorker, process.env),
+  );
 }
 
 export default runWorker;

--- a/packages/zero-cache/src/server/shadow-syncer.ts
+++ b/packages/zero-cache/src/server/shadow-syncer.ts
@@ -1,3 +1,4 @@
+import {consoleLogSink, LogContext} from '@rocicorp/logger';
 import {must} from '../../../shared/src/must.ts';
 import {getServerContext} from '../config/server-context.ts';
 import {getNormalizedZeroConfig} from '../config/zero-config.ts';
@@ -15,6 +16,9 @@ import {startOtelAuto} from './otel-start.ts';
 
 const MS_PER_HOUR = 1000 * 60 * 60;
 
+// Default LogContext, overridden in runWorker
+let lc = new LogContext('info', {}, consoleLogSink);
+
 export default function runWorker(
   parent: Worker,
   env: NodeJS.ProcessEnv,
@@ -27,7 +31,7 @@ export default function runWorker(
     'shadow-syncer',
     0,
   );
-  const lc = createLogContext(config, 'shadow-syncer');
+  lc = createLogContext(config, 'shadow-syncer');
   initEventSink(lc, config);
 
   const {shadowSync, upstream, initialSync} = config;
@@ -52,7 +56,7 @@ export default function runWorker(
 
 // fork()
 if (!singleProcessMode()) {
-  void exitAfter(() =>
+  void exitAfter(lc, () =>
     runWorker(must(parentWorker), process.env, ...process.argv.slice(2)),
   );
 }

--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -2,6 +2,7 @@ import {randomUUID} from 'node:crypto';
 import {tmpdir} from 'node:os';
 import path from 'node:path';
 import {pid} from 'node:process';
+import {consoleLogSink, LogContext} from '@rocicorp/logger';
 import {assert} from '../../../shared/src/asserts.ts';
 import {must} from '../../../shared/src/must.ts';
 import {randInt} from '../../../shared/src/rand.ts';
@@ -65,6 +66,9 @@ function getCustomQueryConfig(
   };
 }
 
+// Default LogContext, overridden in runWorker
+let lc = new LogContext('info', {}, consoleLogSink);
+
 export default function runWorker(
   parent: Worker,
   env: NodeJS.ProcessEnv,
@@ -80,7 +84,7 @@ export default function runWorker(
     'syncer',
     workerIndex,
   );
-  const lc = createLogContext(config, 'syncer', workerIndex);
+  lc = createLogContext(config, 'syncer', workerIndex);
   initEventSink(lc, config);
 
   const {cvr, upstream, enableCrudMutations} = config;
@@ -271,7 +275,7 @@ export default function runWorker(
 
 // fork()
 if (!singleProcessMode()) {
-  void exitAfter(() =>
+  void exitAfter(lc, () =>
     runWorker(must(parentWorker), process.env, ...process.argv.slice(2)),
   );
 }

--- a/packages/zero-cache/src/services/life-cycle.ts
+++ b/packages/zero-cache/src/services/life-cycle.ts
@@ -302,15 +302,13 @@ export async function runUntilKilled(
   }
 }
 
-export async function exitAfter(run: () => Promise<void>) {
+export async function exitAfter(lc: LogContext, run: () => Promise<void>) {
   try {
     await run();
-    // oxlint-disable-next-line no-console
-    console.info(`pid ${pid} exiting normally`);
+    lc.info?.(`pid ${pid} exiting normally`);
     process.exit(0);
   } catch (e) {
-    // oxlint-disable-next-line no-console
-    console.error(`pid ${pid} exiting with error`, e);
+    lc.error?.(`exiting with error: {String(e)}`, e);
     process.exit(-1);
   }
 }

--- a/packages/zero-cache/src/services/life-cycle.ts
+++ b/packages/zero-cache/src/services/life-cycle.ts
@@ -308,7 +308,7 @@ export async function exitAfter(lc: LogContext, run: () => Promise<void>) {
     lc.info?.(`pid ${pid} exiting normally`);
     process.exit(0);
   } catch (e) {
-    lc.error?.(`exiting with error: {String(e)}`, e);
+    lc.error?.(`exiting with error: ${String(e)}`, e);
     process.exit(-1);
   }
 }


### PR DESCRIPTION
Improve coverage of the try/catch logic that publishes critical events when the change-streamer process exits on an error. Previously this did not catch errors thrown from `initChangeStreamerSchema()`.

Also refactor the exit / logging logic for all workers to use the `LogContext` set up by the worker when possible. This will include useful context variables to investigate when a process exits uncleanly.

Context:
* https://rocicorp.slack.com/archives/C013XFG80JC/p1778545004612709