### PR TITLE
perf(replicache): Batch concurrent get/has operations in SQLiteStore

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -212,9 +212,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -232,9 +229,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -252,9 +246,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -272,9 +263,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -292,9 +280,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -312,9 +297,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -626,9 +608,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -646,9 +625,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -666,9 +642,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -686,9 +659,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -706,9 +676,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -726,9 +693,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6817,414 +6781,6 @@
         "source-map-support": "^0.5.21"
       }
     },
-    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-arm": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
-      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
-      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
-      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.18.20",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/darwin-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
-      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
-      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
-      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-arm": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
-      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
-      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-ia32": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
-      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-loong64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
-      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
-      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
-      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
-      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-s390x": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
-      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
-      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
-      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
-      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/sunos-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
-      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
-      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-ia32": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
-      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
-      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild-kit/core-utils/node_modules/esbuild": {
-      "version": "0.18.20",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/android-arm": "0.18.20",
-        "@esbuild/android-arm64": "0.18.20",
-        "@esbuild/android-x64": "0.18.20",
-        "@esbuild/darwin-arm64": "0.18.20",
-        "@esbuild/darwin-x64": "0.18.20",
-        "@esbuild/freebsd-arm64": "0.18.20",
-        "@esbuild/freebsd-x64": "0.18.20",
-        "@esbuild/linux-arm": "0.18.20",
-        "@esbuild/linux-arm64": "0.18.20",
-        "@esbuild/linux-ia32": "0.18.20",
-        "@esbuild/linux-loong64": "0.18.20",
-        "@esbuild/linux-mips64el": "0.18.20",
-        "@esbuild/linux-ppc64": "0.18.20",
-        "@esbuild/linux-riscv64": "0.18.20",
-        "@esbuild/linux-s390x": "0.18.20",
-        "@esbuild/linux-x64": "0.18.20",
-        "@esbuild/netbsd-x64": "0.18.20",
-        "@esbuild/openbsd-x64": "0.18.20",
-        "@esbuild/sunos-x64": "0.18.20",
-        "@esbuild/win32-arm64": "0.18.20",
-        "@esbuild/win32-ia32": "0.18.20",
-        "@esbuild/win32-x64": "0.18.20"
-      }
-    },
     "node_modules/@esbuild-kit/esm-loader": {
       "version": "2.6.5",
       "dev": true,
@@ -7293,21 +6849,6 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.12",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
       ],
       "engines": {
         "node": ">=18"
@@ -10929,9 +10470,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10949,9 +10487,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10969,9 +10504,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10989,9 +10521,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11009,9 +10538,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11029,9 +10555,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11049,9 +10572,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11069,9 +10589,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11326,9 +10843,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11344,9 +10858,6 @@
       "integrity": "sha512-XQKXZIKYJC3GQJ8FnD3iMntpw69Wd9kDDK/Xt79p6xnFYlGGxSNv2vIBvRTDg5CKByWFWWZLCRDOXoP/m6YN4g==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -11364,9 +10875,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11382,9 +10890,6 @@
       "integrity": "sha512-V7dXKoSyEbWAkkSF4JJNtF+NJZDmJoSarSoP30WCsB3X636Rehd3CvxBj49FIJxEBFWhvcUjGSHVeU8Erck1bQ==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -11402,9 +10907,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11420,9 +10922,6 @@
       "integrity": "sha512-RR7xKgNpqwENnK0aYCGYg0JycY2n93J0reNjHyes+I9Gq52dH95x+CBlnlAQHCPfz6FGnKA9HirgUl14WO6o7w==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -11440,9 +10939,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11458,9 +10954,6 @@
       "integrity": "sha512-o5TLOUCF0RWQjsIS06yVC+kFgp092/yLe6qBGSUvtnmTVw9gxjpdQSXc3VN5Cnive4K11HNstEZF8ROKHfDFSw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -11746,9 +11239,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11766,9 +11256,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11786,9 +11273,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11806,9 +11290,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11826,9 +11307,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11846,9 +11324,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11866,9 +11341,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11886,9 +11358,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12797,9 +12266,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12817,9 +12283,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12837,9 +12300,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12857,9 +12317,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12877,9 +12334,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12897,9 +12351,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15031,39 +14482,6 @@
     "node_modules/@vercel/node/node_modules/es-module-lexer": {
       "version": "1.4.1",
       "license": "MIT"
-    },
-    "node_modules/@vercel/node/node_modules/esbuild": {
-      "version": "0.14.47",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "esbuild-android-64": "0.14.47",
-        "esbuild-android-arm64": "0.14.47",
-        "esbuild-darwin-64": "0.14.47",
-        "esbuild-darwin-arm64": "0.14.47",
-        "esbuild-freebsd-64": "0.14.47",
-        "esbuild-freebsd-arm64": "0.14.47",
-        "esbuild-linux-32": "0.14.47",
-        "esbuild-linux-64": "0.14.47",
-        "esbuild-linux-arm": "0.14.47",
-        "esbuild-linux-arm64": "0.14.47",
-        "esbuild-linux-mips64le": "0.14.47",
-        "esbuild-linux-ppc64le": "0.14.47",
-        "esbuild-linux-riscv64": "0.14.47",
-        "esbuild-linux-s390x": "0.14.47",
-        "esbuild-netbsd-64": "0.14.47",
-        "esbuild-openbsd-64": "0.14.47",
-        "esbuild-sunos-64": "0.14.47",
-        "esbuild-windows-32": "0.14.47",
-        "esbuild-windows-64": "0.14.47",
-        "esbuild-windows-arm64": "0.14.47"
-      }
     },
     "node_modules/@vercel/node/node_modules/node-fetch": {
       "version": "2.6.9",
@@ -18876,471 +18294,6 @@
         "drizzle-kit": "bin.cjs"
       }
     },
-    "node_modules/drizzle-kit/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/android-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/android-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/android-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/linux-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/linux-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/win32-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/drizzle-kit/node_modules/esbuild": {
-      "version": "0.25.12",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.12",
-        "@esbuild/android-arm": "0.25.12",
-        "@esbuild/android-arm64": "0.25.12",
-        "@esbuild/android-x64": "0.25.12",
-        "@esbuild/darwin-arm64": "0.25.12",
-        "@esbuild/darwin-x64": "0.25.12",
-        "@esbuild/freebsd-arm64": "0.25.12",
-        "@esbuild/freebsd-x64": "0.25.12",
-        "@esbuild/linux-arm": "0.25.12",
-        "@esbuild/linux-arm64": "0.25.12",
-        "@esbuild/linux-ia32": "0.25.12",
-        "@esbuild/linux-loong64": "0.25.12",
-        "@esbuild/linux-mips64el": "0.25.12",
-        "@esbuild/linux-ppc64": "0.25.12",
-        "@esbuild/linux-riscv64": "0.25.12",
-        "@esbuild/linux-s390x": "0.25.12",
-        "@esbuild/linux-x64": "0.25.12",
-        "@esbuild/netbsd-arm64": "0.25.12",
-        "@esbuild/netbsd-x64": "0.25.12",
-        "@esbuild/openbsd-arm64": "0.25.12",
-        "@esbuild/openbsd-x64": "0.25.12",
-        "@esbuild/openharmony-arm64": "0.25.12",
-        "@esbuild/sunos-x64": "0.25.12",
-        "@esbuild/win32-arm64": "0.25.12",
-        "@esbuild/win32-ia32": "0.25.12",
-        "@esbuild/win32-x64": "0.25.12"
-      }
-    },
     "node_modules/drizzle-orm": {
       "version": "0.45.1",
       "dev": true,
@@ -19754,20 +18707,6 @@
         "@esbuild/win32-arm64": "0.27.4",
         "@esbuild/win32-ia32": "0.27.4",
         "@esbuild/win32-x64": "0.27.4"
-      }
-    },
-    "node_modules/esbuild-darwin-arm64": {
-      "version": "0.14.47",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/darwin-arm64": {
@@ -22976,9 +21915,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -22998,9 +21934,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -23022,9 +21955,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -23044,9 +21974,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -26318,9 +25245,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -26336,9 +25260,6 @@
       "integrity": "sha512-Qm2SEU7/f2b2Rg76Pj49BdMFF7Vv7+2qLPxaae4aH1515kzVv6nZW0bqCo4fPDDyiE4bryF7Jr+WKhllBxvXPw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -26356,9 +25277,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -26374,9 +25292,6 @@
       "integrity": "sha512-IdbJ/rwsaEPQx11mQwGoClqhAmVaAF9+3VmDRYVmfsYsrhX1Ue1HvBdVHDvtHzJDuumC/X/codkVId9Ss+7fVg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -26394,9 +25309,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -26412,9 +25324,6 @@
       "integrity": "sha512-hlfoDmWvgSbexoJ9u3KwAJwpeu91FfJR6++fQjeYXD2InK4gZow9o3DRoTpN/kslZwzUNpiRURqxey/RvWh8JQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -34149,9 +33058,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34167,9 +33073,6 @@
       "integrity": "sha512-vCS3Fk7gFslTqE1lUE2IlroyVV7u/9SmMA/uBqDoshuck2psGWcjW0ePyPZI3rM3+qtf2pDaMVIKMHozraifuw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -34187,9 +33090,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34205,9 +33105,6 @@
       "integrity": "sha512-SYt0UhOvZD/UwZz9sXq6J2uAw8o24f5VZpLB2DH01f6MevshmlgakQlZe2lwek2sZJkd07eLu7mZa0g7yeiw7Q==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -34225,9 +33122,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34243,9 +33137,6 @@
       "integrity": "sha512-mdxt5L8OQLxkQH+JVpdC/lknZNe0lX4hlO3d8+xvw2wToo+iDrid9tiGOd5bmHfUVd5wVhrUry0qlu5vq66NkQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -34263,9 +33154,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34281,9 +33169,6 @@
       "integrity": "sha512-g2SKTTurP5mWjd8Ecait0erYqmltL4IqW1EwttM25BxM6NiTt4ubobJYMR1uox1V2QgG4UfHH10CGRvWlUixjw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -34657,9 +33542,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34677,9 +33559,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34697,9 +33576,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34717,9 +33593,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34737,9 +33610,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34757,9 +33627,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34777,9 +33644,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34797,9 +33661,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34962,9 +33823,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34980,9 +33838,6 @@
       "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -35000,9 +33855,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -35018,9 +33870,6 @@
       "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -35038,9 +33887,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -35056,9 +33902,6 @@
       "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -35809,9 +34652,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -35829,9 +34669,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -35849,9 +34686,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -35869,9 +34703,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -35889,9 +34720,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -35909,9 +34737,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36340,9 +35165,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36360,9 +35182,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36380,9 +35199,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36400,9 +35216,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36420,9 +35233,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36440,9 +35250,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36460,9 +35267,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36480,9 +35284,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/packages/replicache/src/kv/expo-sqlite/store.test.node.ts
+++ b/packages/replicache/src/kv/expo-sqlite/store.test.node.ts
@@ -49,19 +49,17 @@ vi.mock('expo-sqlite', () => ({
             try {
               const isSelectQuery = /^\s*select/i.test(sql);
               if (isSelectQuery) {
-                const result = stmt.all(...params);
+                const rows = stmt.raw(true).all(...params) as unknown[][];
                 return Promise.resolve({
                   getFirstAsync: () =>
-                    Promise.resolve(
-                      result.length > 0
-                        ? Object.values(result[0] as Record<string, unknown>)
-                        : null,
-                    ),
+                    Promise.resolve(rows.length > 0 ? rows[0] : null),
+                  getAllAsync: () => Promise.resolve(rows),
                 });
               }
               stmt.run(...params);
               return Promise.resolve({
                 getFirstAsync: () => Promise.resolve(null),
+                getAllAsync: () => Promise.resolve([]),
               });
             } catch (error) {
               return Promise.reject(error);

--- a/packages/replicache/src/kv/expo-sqlite/store.ts
+++ b/packages/replicache/src/kv/expo-sqlite/store.ts
@@ -14,8 +14,11 @@ import type {StoreProvider} from '../store.ts';
 
 export type ExpoSQLiteStoreOptions = SQLiteStoreOptions;
 
-export function dropExpoSQLiteStore(name: string): Promise<void> {
-  return dropStore(name, filename => new ExpoSQLiteDatabase(filename));
+export function dropExpoSQLiteStore(
+  name: string,
+  opts?: ExpoSQLiteStoreOptions,
+): Promise<void> {
+  return dropStore(name, filename => new ExpoSQLiteDatabase(filename), opts);
 }
 
 /**
@@ -29,7 +32,7 @@ export function expoSQLiteStoreProvider(
   return {
     create: name =>
       new SQLiteStore(name, name => new ExpoSQLiteDatabase(name), opts),
-    drop: dropExpoSQLiteStore,
+    drop: name => dropExpoSQLiteStore(name, opts),
   };
 }
 
@@ -40,14 +43,13 @@ class ExpoSQLitePreparedStatement implements PreparedStatement {
     this.#statement = statement;
   }
 
-  async firstValue(params: string[]): Promise<string | undefined> {
-    const result = await this.#statement.executeForRawResultAsync(params);
-    const row = await result.getFirstAsync();
-    return row === null ? undefined : row[0];
-  }
-
   async exec(params: string[]): Promise<void> {
     await this.#statement.executeForRawResultAsync(params);
+  }
+
+  async all(params: string[]): Promise<unknown[][]> {
+    const result = await this.#statement.executeForRawResultAsync(params);
+    return result.getAllAsync() as Promise<unknown[][]>;
   }
 }
 

--- a/packages/replicache/src/kv/op-sqlite/store.ts
+++ b/packages/replicache/src/kv/op-sqlite/store.ts
@@ -13,10 +13,14 @@ export type OpSQLiteStoreOptions = SQLiteStoreOptions & {
   encryptionKey?: string;
 };
 
-function dropOpSQLiteStore(name: string): Promise<void> {
+function dropOpSQLiteStore(
+  name: string,
+  opts?: OpSQLiteStoreOptions,
+): Promise<void> {
   return dropStore(
     name,
-    (filename, opts) => new OpSQLiteDatabase(filename, opts),
+    (filename, options) => new OpSQLiteDatabase(filename, options),
+    opts,
   );
 }
 
@@ -36,7 +40,7 @@ export function opSQLiteStoreProvider(
         (name, options) => new OpSQLiteDatabase(name, options),
         opts,
       ),
-    drop: dropOpSQLiteStore,
+    drop: name => dropOpSQLiteStore(name, opts),
   };
 }
 
@@ -49,13 +53,12 @@ class OpSQLitePreparedStatement implements PreparedStatement {
     this.#sql = sql;
   }
 
-  async firstValue(params: string[]): Promise<string | undefined> {
-    const rows = await this.#db.executeRaw(this.#sql, params);
-    return rows[0]?.[0];
-  }
-
   async exec(params: string[]): Promise<void> {
     await this.#db.executeRaw(this.#sql, params);
+  }
+
+  all(params: string[]): Promise<unknown[][]> {
+    return this.#db.executeRaw(this.#sql, params);
   }
 }
 

--- a/packages/replicache/src/kv/sqlite-store-test-util.ts
+++ b/packages/replicache/src/kv/sqlite-store-test-util.ts
@@ -90,6 +90,36 @@ export function runSQLiteStoreTests<TOptions = unknown>(
   runAll(storeName, () => createStoreWithDefaults(`test-${++storeCounter}`));
 
   // SQLite-specific tests
+  test('concurrent get and has calls return correct results', async () => {
+    const store = createStoreWithDefaults(`batch-test-${++storeCounter}`);
+
+    await withWrite(store, async wt => {
+      await wt.put('a', 'alpha');
+      await wt.put('b', 'beta');
+    });
+
+    await withRead(store, async rt => {
+      const [valA, valB, hasA, hasC] = await Promise.all([
+        rt.get('a'),
+        rt.get('b'),
+        rt.has('a'),
+        rt.has('c'),
+      ]);
+      expect(valA).toBe('alpha');
+      expect(valB).toBe('beta');
+      expect(hasA).toBe(true);
+      expect(hasC).toBe(false);
+    });
+
+    await withWrite(store, async wt => {
+      const [valA, hasB] = await Promise.all([wt.get('a'), wt.has('b')]);
+      expect(valA).toBe('alpha');
+      expect(hasB).toBe(true);
+    });
+
+    await store.close();
+  });
+
   test('shared read transaction behavior', async () => {
     const store = createStoreWithDefaults(`shared-read-test-${++storeCounter}`);
 

--- a/packages/replicache/src/kv/sqlite-store.test.node.ts
+++ b/packages/replicache/src/kv/sqlite-store.test.node.ts
@@ -1,0 +1,123 @@
+import {expect, test} from 'vitest';
+import {SQLiteStoreRead, type PreparedStatements} from './sqlite-store.ts';
+
+function makeMockStatements(
+  opts: {
+    getRows?: unknown[][];
+    getManyRows?: unknown[][];
+    hasRows?: unknown[][];
+    hasManyRows?: unknown[][];
+  } = {},
+): {
+  stmts: PreparedStatements;
+  getCallCount: () => number;
+  getManyCallCount: () => number;
+  hasCallCount: () => number;
+  hasManyCallCount: () => number;
+} {
+  let getCount = 0;
+  let getManyCount = 0;
+  let hasCount = 0;
+  let hasManyCount = 0;
+
+  const stmts: PreparedStatements = {
+    put: {async exec() {}, all: () => Promise.resolve([])},
+    del: {async exec() {}, all: () => Promise.resolve([])},
+    get: {
+      async exec() {},
+      // oxlint-disable-next-line require-await
+      async all() {
+        getCount++;
+        return opts.getRows ?? [];
+      },
+    },
+    has: {
+      async exec() {},
+      // oxlint-disable-next-line require-await
+      async all() {
+        hasCount++;
+        return opts.hasRows ?? [];
+      },
+    },
+    getMany: {
+      async exec() {},
+      // oxlint-disable-next-line require-await
+      async all() {
+        getManyCount++;
+        return opts.getManyRows ?? [];
+      },
+    },
+    hasMany: {
+      async exec() {},
+      // oxlint-disable-next-line require-await
+      async all() {
+        hasManyCount++;
+        return opts.hasManyRows ?? [];
+      },
+    },
+  };
+
+  return {
+    stmts,
+    getCallCount: () => getCount,
+    getManyCallCount: () => getManyCount,
+    hasCallCount: () => hasCount,
+    hasManyCallCount: () => hasManyCount,
+  };
+}
+
+test('concurrent gets are batched into a single getMany call', async () => {
+  const {stmts, getManyCallCount} = makeMockStatements({
+    getManyRows: [
+      ['a', '"alpha"'],
+      ['b', '"beta"'],
+    ],
+  });
+  const read = new SQLiteStoreRead(() => {}, stmts);
+
+  const [valA, valB, valC] = await Promise.all([
+    read.get('a'),
+    read.get('b'),
+    read.get('c'),
+  ]);
+
+  expect(getManyCallCount()).toBe(1);
+  expect(valA).toBe('alpha');
+  expect(valB).toBe('beta');
+  expect(valC).toBeUndefined();
+});
+
+test('concurrent has calls are batched into a single hasMany call', async () => {
+  const {stmts, hasManyCallCount} = makeMockStatements({
+    hasManyRows: [['a']],
+  });
+  const read = new SQLiteStoreRead(() => {}, stmts);
+
+  const [hasA, hasB] = await Promise.all([read.has('a'), read.has('b')]);
+
+  expect(hasManyCallCount()).toBe(1);
+  expect(hasA).toBe(true);
+  expect(hasB).toBe(false);
+});
+
+test('sequential awaited gets use the single-key fast path', async () => {
+  const {stmts, getCallCount, getManyCallCount} = makeMockStatements();
+  const read = new SQLiteStoreRead(() => {}, stmts);
+
+  await read.get('a');
+  await read.get('b');
+
+  expect(getCallCount()).toBe(2);
+  expect(getManyCallCount()).toBe(0);
+});
+
+test('mixed concurrent gets and has use separate sql calls', async () => {
+  const {stmts, getManyCallCount, hasCallCount} = makeMockStatements();
+  const read = new SQLiteStoreRead(() => {}, stmts);
+
+  // Two concurrent gets → getMany; one concurrent has → has (single-key path)
+  await Promise.all([read.get('a'), read.has('b'), read.get('c')]);
+
+  expect(getManyCallCount()).toBe(1);
+  expect(hasCallCount()).toBe(1);
+});

--- a/packages/replicache/src/kv/sqlite-store.test.ts
+++ b/packages/replicache/src/kv/sqlite-store.test.ts
@@ -1,6 +1,7 @@
 import {expect, test, vi} from 'vitest';
 import {
   SQLiteWrite,
+  SQLiteStoreRead,
   type PreparedStatements,
   type SQLiteDatabase,
 } from './sqlite-store.ts';
@@ -52,4 +53,36 @@ test('SQLiteWrite batches deletes and upserts into one statement each', async ()
   ]);
   expect(db.execSync).toHaveBeenCalledWith('COMMIT');
   expect(release).toHaveBeenCalledTimes(1);
+});
+
+test('SQLiteStoreRead rejects pending get and has operations when closed', async () => {
+  const release = vi.fn();
+  const preparedStatements = makePreparedStatements();
+
+  const read = new SQLiteStoreRead(release, preparedStatements);
+
+  // Schedule multiple get and has operations
+  const getPromise1 = read.get('key-1');
+  const getPromise2 = read.get('key-2');
+  const hasPromise1 = read.has('key-3');
+  const hasPromise2 = read.has('key-4');
+
+  // Close the transaction before microtask executes
+  read.release();
+
+  // Yield control to allow microtask to run
+  await Promise.resolve();
+
+  // All pending promises should be rejected with "Transaction is closed"
+  await expect(getPromise1).rejects.toThrow('Transaction is closed');
+  await expect(getPromise2).rejects.toThrow('Transaction is closed');
+  await expect(hasPromise1).rejects.toThrow('Transaction is closed');
+  await expect(hasPromise2).rejects.toThrow('Transaction is closed');
+
+  expect(release).toHaveBeenCalledTimes(1);
+  // Database statements should not have been called
+  expect(preparedStatements.get.all).not.toHaveBeenCalled();
+  expect(preparedStatements.has.all).not.toHaveBeenCalled();
+  expect(preparedStatements.getMany.all).not.toHaveBeenCalled();
+  expect(preparedStatements.hasMany.all).not.toHaveBeenCalled();
 });

--- a/packages/replicache/src/kv/sqlite-store.test.ts
+++ b/packages/replicache/src/kv/sqlite-store.test.ts
@@ -7,7 +7,7 @@ import {
 
 function makePreparedStatement() {
   return {
-    firstValue: vi.fn().mockResolvedValue(undefined),
+    all: vi.fn().mockResolvedValue([]),
     exec: vi.fn().mockResolvedValue(undefined),
   };
 }
@@ -16,6 +16,8 @@ function makePreparedStatements(): PreparedStatements {
   return {
     has: makePreparedStatement(),
     get: makePreparedStatement(),
+    hasMany: makePreparedStatement(),
+    getMany: makePreparedStatement(),
     del: makePreparedStatement(),
     put: makePreparedStatement(),
   };

--- a/packages/replicache/src/kv/sqlite-store.ts
+++ b/packages/replicache/src/kv/sqlite-store.ts
@@ -3,22 +3,18 @@ import type {ReadonlyJSONValue} from '../../../shared/src/json.ts';
 import {deepFreeze} from '../frozen-json.ts';
 import type {Read, Store, Write} from './store.ts';
 import {
+  maybeTransactionIsClosedRejection,
   throwIfStoreClosed,
-  throwIfTransactionClosed,
   transactionIsClosedRejection,
 } from './throw-if-closed.ts';
 import {deleteSentinel, WriteImplBase} from './write-impl-base.ts';
 
 /**
  * A SQLite prepared statement.
- *
- * `run` executes the statement with optional parameters.
- * `all` executes the statement and returns the result rows.
- * `finalize` releases the statement.
  */
 export interface PreparedStatement {
-  firstValue(params: string[]): Promise<unknown>;
   exec(params: string[]): Promise<void>;
+  all(params: string[]): Promise<unknown[][]>;
 }
 
 export interface SQLiteDatabase {
@@ -64,7 +60,7 @@ export class SQLiteStore implements Store {
     create: CreateSQLiteDatabase,
     opts?: SQLiteStoreOptions,
   ) {
-    this.#filename = safeFilename(name);
+    this.#filename = resolveFilename(name, opts);
     this.#entry = getOrCreateEntry(name, create, opts);
   }
 
@@ -132,9 +128,17 @@ export function safeFilename(name: string): string {
   return name.replace(/[^a-zA-Z0-9]/g, '_');
 }
 
+function resolveFilename(name: string, opts?: SQLiteStoreOptions): string {
+  const safe = safeFilename(name);
+  const dir = opts?.directory;
+  return dir ? `${dir}/${safe}` : safe;
+}
+
 export type PreparedStatements = {
   has: PreparedStatement;
   get: PreparedStatement;
+  hasMany: PreparedStatement;
+  getMany: PreparedStatement;
   put: PreparedStatement;
   del: PreparedStatement;
 };
@@ -145,6 +149,8 @@ export interface SQLiteStoreOptions {
   journalMode?: 'WAL' | 'DELETE';
   synchronous?: 'NORMAL' | 'FULL';
   readUncommitted?: boolean;
+  /** Directory in which to create the SQLite file. Defaults to the process CWD. */
+  directory?: string | undefined;
 }
 
 /**
@@ -176,6 +182,12 @@ export function setupDatabase(
   return {
     has: delegate.prepare(`SELECT 1 FROM entry WHERE key = ? LIMIT 1`),
     get: delegate.prepare('SELECT value FROM entry WHERE key = ?'),
+    hasMany: delegate.prepare(
+      `SELECT key FROM entry WHERE key IN (SELECT value FROM json_each(?))`,
+    ),
+    getMany: delegate.prepare(
+      `SELECT key, value FROM entry WHERE key IN (SELECT value FROM json_each(?))`,
+    ),
     put: delegate.prepare(
       `INSERT OR REPLACE INTO entry (key, value)
    SELECT e.value->>0, e.value->1 FROM json_each(?) e`,
@@ -186,31 +198,166 @@ export function setupDatabase(
   };
 }
 
+// Callbacks are stored as striped pairs: [resolve, reject, resolve, reject, ...]
+const CB_STRIDE = 2;
+const CB_RESOLVE = 0;
+const CB_REJECT = 1;
+
+type GetResolve = (v: ReadonlyJSONValue | undefined) => void;
+type HasResolve = (v: boolean) => void;
+type Reject = (e: unknown) => void;
+
+function parseRawValue(raw: string | undefined): ReadonlyJSONValue | undefined {
+  return raw === undefined
+    ? undefined
+    : deepFreeze(JSON.parse(raw) as ReadonlyJSONValue);
+}
+
+function resolveGet(
+  resolve: GetResolve,
+  reject: Reject,
+  raw: string | undefined,
+): void {
+  try {
+    resolve(parseRawValue(raw));
+  } catch (e) {
+    reject(e);
+  }
+}
+
+async function flushSingle(
+  key: string,
+  callbacks: unknown[],
+  stmt: PreparedStatement,
+  settle: (rows: unknown[][], callbacks: unknown[]) => void,
+): Promise<void> {
+  let rows: unknown[][];
+  try {
+    rows = await stmt.all([key]);
+  } catch (e) {
+    (callbacks[CB_REJECT] as Reject)(e);
+    return;
+  }
+  settle(rows, callbacks);
+}
+
+function settleSingleGet(rows: unknown[][], callbacks: unknown[]): void {
+  resolveGet(
+    callbacks[CB_RESOLVE] as GetResolve,
+    callbacks[CB_REJECT] as Reject,
+    rows[0]?.[0] as string | undefined,
+  );
+}
+
+function settleSingleHas(rows: unknown[][], callbacks: unknown[]): void {
+  (callbacks[CB_RESOLVE] as HasResolve)(rows.length > 0);
+}
+
+async function flushBatch(
+  keys: string[],
+  callbacks: unknown[],
+  stmt: PreparedStatement,
+  settle: (keys: string[], callbacks: unknown[], rows: unknown[][]) => void,
+): Promise<void> {
+  let rows: unknown[][];
+  try {
+    rows = await stmt.all([JSON.stringify(keys)]);
+  } catch (e) {
+    for (let i = CB_REJECT; i < callbacks.length; i += CB_STRIDE) {
+      (callbacks[i] as Reject)(e);
+    }
+    return;
+  }
+  settle(keys, callbacks, rows);
+}
+
+function settleGets(
+  keys: string[],
+  callbacks: unknown[],
+  rows: unknown[][],
+): void {
+  const resultMap = new Map(rows as [string, string][]);
+  for (let i = 0; i < keys.length; i++) {
+    resolveGet(
+      callbacks[i * CB_STRIDE + CB_RESOLVE] as GetResolve,
+      callbacks[i * CB_STRIDE + CB_REJECT] as Reject,
+      resultMap.get(keys[i]),
+    );
+  }
+}
+
+function settleHas(
+  keys: string[],
+  callbacks: unknown[],
+  rows: unknown[][],
+): void {
+  const existingKeys = new Set(rows.map(row => row[0] as string));
+  for (let i = 0; i < keys.length; i++) {
+    (callbacks[i * CB_STRIDE + CB_RESOLVE] as HasResolve)(
+      existingKeys.has(keys[i]),
+    );
+  }
+}
+
 export class SQLiteStoreRead implements Read {
-  #release: () => void;
+  readonly #release: () => void;
+  readonly #preparedStatements: PreparedStatements;
   #closed = false;
-  #preparedStatements: PreparedStatements;
+  #pendingGetKeys: string[] = [];
+  #pendingGetCallbacks: unknown[] = [];
+  #pendingHasKeys: string[] = [];
+  #pendingHasCallbacks: unknown[] = [];
+  #scheduled = false;
 
   constructor(release: () => void, preparedStatements: PreparedStatements) {
     this.#release = release;
     this.#preparedStatements = preparedStatements;
   }
 
-  async has(key: string): Promise<boolean> {
-    throwIfTransactionClosed(this);
-    const value = await this.#preparedStatements.has.firstValue([key]);
-    return value !== undefined;
+  has(key: string): Promise<boolean> {
+    return (
+      maybeTransactionIsClosedRejection(this) ??
+      new Promise((resolve, reject) => {
+        this.#pendingHasKeys.push(key);
+        this.#pendingHasCallbacks.push(resolve, reject);
+        this.#scheduleLookup();
+      })
+    );
   }
 
-  async get(key: string): Promise<ReadonlyJSONValue | undefined> {
-    throwIfTransactionClosed(this);
-    const value = await this.#preparedStatements.get.firstValue([key]);
-    if (!value) {
-      return undefined;
-    }
+  get(key: string): Promise<ReadonlyJSONValue | undefined> {
+    return (
+      maybeTransactionIsClosedRejection(this) ??
+      new Promise((resolve, reject) => {
+        this.#pendingGetKeys.push(key);
+        this.#pendingGetCallbacks.push(resolve, reject);
+        this.#scheduleLookup();
+      })
+    );
+  }
 
-    const parsedValue = JSON.parse(value as string) as ReadonlyJSONValue;
-    return deepFreeze(parsedValue);
+  #scheduleLookup(): void {
+    if (!this.#scheduled) {
+      this.#scheduled = true;
+      queueMicrotask(() => {
+        this.#scheduled = false;
+        const {get, has, getMany, hasMany} = this.#preparedStatements;
+        const getKeys = this.#pendingGetKeys.splice(0);
+        const getCallbacks = this.#pendingGetCallbacks.splice(0);
+        const hasKeys = this.#pendingHasKeys.splice(0);
+        const hasCallbacks = this.#pendingHasCallbacks.splice(0);
+        if (getKeys.length === 1) {
+          void flushSingle(getKeys[0], getCallbacks, get, settleSingleGet);
+        } else if (getKeys.length > 1) {
+          void flushBatch(getKeys, getCallbacks, getMany, settleGets);
+        }
+        if (hasKeys.length === 1) {
+          void flushSingle(hasKeys[0], hasCallbacks, has, settleSingleHas);
+        } else if (hasKeys.length > 1) {
+          void flushBatch(hasKeys, hasCallbacks, hasMany, settleHas);
+        }
+      });
+    }
   }
 
   release(): void {
@@ -292,7 +439,6 @@ export class SQLiteWrite extends WriteImplBase implements Write {
           rollbackError = e;
         }
       }
-
       this.#release();
       if (rollbackError !== undefined) {
         throw rollbackError;
@@ -326,7 +472,7 @@ function getOrCreateEntry(
   create: (filename: string, opts?: SQLiteStoreOptions) => SQLiteDatabase,
   opts?: SQLiteStoreOptions,
 ): StoreEntry {
-  const filename = safeFilename(name);
+  const filename = resolveFilename(name, opts);
   const entry = stores.get(filename);
 
   if (entry) {
@@ -381,8 +527,9 @@ export function dropStore(
     filename: string,
     opts?: SQLiteStoreOptions,
   ) => SQLiteDatabase,
+  opts?: SQLiteStoreOptions,
 ): Promise<void> {
-  const filename = safeFilename(name);
+  const filename = resolveFilename(name, opts);
   const entry = stores.get(filename);
   if (entry) {
     try {

--- a/packages/replicache/src/kv/sqlite-store.ts
+++ b/packages/replicache/src/kv/sqlite-store.ts
@@ -559,7 +559,7 @@ export function dropStore(
   }
 
   // Create a temporary delegate to handle database deletion
-  const tempDelegate = createDelegate(filename);
+  const tempDelegate = createDelegate(filename, opts);
   try {
     // we close the db before destroying it - this
     // caused an issue with expo-sqlite since it requires this

--- a/packages/replicache/src/kv/sqlite-store.ts
+++ b/packages/replicache/src/kv/sqlite-store.ts
@@ -6,7 +6,6 @@ import {
   maybeTransactionIsClosedRejection,
   throwIfStoreClosed,
   transactionError,
-  transactionIsClosedRejection,
 } from './throw-if-closed.ts';
 import {deleteSentinel, WriteImplBase} from './write-impl-base.ts';
 
@@ -62,7 +61,7 @@ export class SQLiteStore implements Store {
     opts?: SQLiteStoreOptions,
   ) {
     this.#filename = resolveFilename(name, opts);
-    this.#entry = getOrCreateEntry(name, create, opts);
+    this.#entry = getOrCreateEntry(this.#filename, create, opts);
   }
 
   async read(): Promise<Read> {
@@ -208,10 +207,10 @@ type GetResolve = (v: ReadonlyJSONValue | undefined) => void;
 type HasResolve = (v: boolean) => void;
 type Reject = (e: unknown) => void;
 
-function parseRawValue(raw: string | undefined): ReadonlyJSONValue | undefined {
-  return raw === undefined
-    ? undefined
-    : deepFreeze(JSON.parse(raw) as ReadonlyJSONValue);
+function rejectAll(callbacks: unknown[], e: unknown): void {
+  for (let i = CB_REJECT; i < callbacks.length; i += CB_STRIDE) {
+    (callbacks[i] as Reject)(e);
+  }
 }
 
 function resolveGet(
@@ -220,63 +219,39 @@ function resolveGet(
   raw: string | undefined,
 ): void {
   try {
-    resolve(parseRawValue(raw));
+    resolve(
+      raw === undefined
+        ? undefined
+        : deepFreeze(JSON.parse(raw) as ReadonlyJSONValue),
+    );
   } catch (e) {
     reject(e);
   }
 }
 
-async function flushSingle(
-  key: string,
+async function flushGets(
+  keys: string[],
   callbacks: unknown[],
-  stmt: PreparedStatement,
-  settle: (rows: unknown[][], callbacks: unknown[]) => void,
+  ps: PreparedStatements,
 ): Promise<void> {
   let rows: unknown[][];
   try {
-    rows = await stmt.all([key]);
+    rows =
+      keys.length === 1
+        ? await ps.get.all([keys[0]])
+        : await ps.getMany.all([JSON.stringify(keys)]);
   } catch (e) {
-    (callbacks[CB_REJECT] as Reject)(e);
+    rejectAll(callbacks, e);
     return;
   }
-  settle(rows, callbacks);
-}
-
-function settleSingleGet(rows: unknown[][], callbacks: unknown[]): void {
-  resolveGet(
-    callbacks[CB_RESOLVE] as GetResolve,
-    callbacks[CB_REJECT] as Reject,
-    rows[0]?.[0] as string | undefined,
-  );
-}
-
-function settleSingleHas(rows: unknown[][], callbacks: unknown[]): void {
-  (callbacks[CB_RESOLVE] as HasResolve)(rows.length > 0);
-}
-
-async function flushBatch(
-  keys: string[],
-  callbacks: unknown[],
-  stmt: PreparedStatement,
-  settle: (keys: string[], callbacks: unknown[], rows: unknown[][]) => void,
-): Promise<void> {
-  let rows: unknown[][];
-  try {
-    rows = await stmt.all([JSON.stringify(keys)]);
-  } catch (e) {
-    for (let i = CB_REJECT; i < callbacks.length; i += CB_STRIDE) {
-      (callbacks[i] as Reject)(e);
-    }
+  if (keys.length === 1) {
+    resolveGet(
+      callbacks[CB_RESOLVE] as GetResolve,
+      callbacks[CB_REJECT] as Reject,
+      rows[0]?.[0] as string | undefined,
+    );
     return;
   }
-  settle(keys, callbacks, rows);
-}
-
-function settleGets(
-  keys: string[],
-  callbacks: unknown[],
-  rows: unknown[][],
-): void {
   const resultMap = new Map(rows as [string, string][]);
   for (let i = 0; i < keys.length; i++) {
     resolveGet(
@@ -287,11 +262,25 @@ function settleGets(
   }
 }
 
-function settleHas(
+async function flushHas(
   keys: string[],
   callbacks: unknown[],
-  rows: unknown[][],
-): void {
+  ps: PreparedStatements,
+): Promise<void> {
+  let rows: unknown[][];
+  try {
+    rows =
+      keys.length === 1
+        ? await ps.has.all([keys[0]])
+        : await ps.hasMany.all([JSON.stringify(keys)]);
+  } catch (e) {
+    rejectAll(callbacks, e);
+    return;
+  }
+  if (keys.length === 1) {
+    (callbacks[CB_RESOLVE] as HasResolve)(rows.length > 0);
+    return;
+  }
   const existingKeys = new Set(rows.map(row => row[0] as string));
   for (let i = 0; i < keys.length; i++) {
     (callbacks[i * CB_STRIDE + CB_RESOLVE] as HasResolve)(
@@ -343,7 +332,7 @@ export class SQLiteStoreRead implements Read {
       queueMicrotask(() => {
         this.#scheduled = false;
 
-        const {get, has, getMany, hasMany} = this.#preparedStatements;
+        const ps = this.#preparedStatements;
         const getKeys = this.#pendingGetKeys;
         this.#pendingGetKeys = [];
         const getCallbacks = this.#pendingGetCallbacks;
@@ -355,24 +344,16 @@ export class SQLiteStoreRead implements Read {
 
         if (this.#closed) {
           const e = transactionError();
-          for (let i = CB_REJECT; i < getCallbacks.length; i += CB_STRIDE) {
-            (getCallbacks[i] as Reject)(e);
-          }
-          for (let i = CB_REJECT; i < hasCallbacks.length; i += CB_STRIDE) {
-            (hasCallbacks[i] as Reject)(e);
-          }
+          rejectAll(getCallbacks, e);
+          rejectAll(hasCallbacks, e);
           return;
         }
 
-        if (getKeys.length === 1) {
-          void flushSingle(getKeys[0], getCallbacks, get, settleSingleGet);
-        } else if (getKeys.length > 1) {
-          void flushBatch(getKeys, getCallbacks, getMany, settleGets);
+        if (getKeys.length > 0) {
+          void flushGets(getKeys, getCallbacks, ps);
         }
-        if (hasKeys.length === 1) {
-          void flushSingle(hasKeys[0], hasCallbacks, has, settleSingleHas);
-        } else if (hasKeys.length > 1) {
-          void flushBatch(hasKeys, hasCallbacks, hasMany, settleHas);
+        if (hasKeys.length > 0) {
+          void flushHas(hasKeys, hasCallbacks, ps);
         }
       });
     }
@@ -410,7 +391,7 @@ export class SQLiteWrite extends WriteImplBase implements Write {
 
   async commit(): Promise<void> {
     if (this.#closed) {
-      return transactionIsClosedRejection();
+      throw transactionError();
     }
 
     const deleteKeys: string[] = [];
@@ -425,20 +406,15 @@ export class SQLiteWrite extends WriteImplBase implements Write {
       deleteKeys.length > 0
         ? this.#preparedStatements.del.exec([JSON.stringify(deleteKeys)])
         : undefined;
-    const upP =
+    const putP =
       this._pending.size > 0
         ? this.#preparedStatements.put.exec([
             JSON.stringify([...this._pending]),
           ])
         : undefined;
 
-    if (delP && upP) {
-      await Promise.all([delP, upP]);
-    } else if (delP) {
-      await delP;
-    } else if (upP) {
-      await upP;
-    }
+    if (putP) await putP;
+    if (delP) await delP;
 
     this.#dbDelegate.execSync('COMMIT');
     this._pending.clear();
@@ -486,11 +462,10 @@ const stores = new Map<string, StoreEntry>();
  * name share the same database connection, lock, and delegate.
  */
 function getOrCreateEntry(
-  name: string,
+  filename: string,
   create: (filename: string, opts?: SQLiteStoreOptions) => SQLiteDatabase,
   opts?: SQLiteStoreOptions,
 ): StoreEntry {
-  const filename = resolveFilename(name, opts);
   const entry = stores.get(filename);
 
   if (entry) {

--- a/packages/replicache/src/kv/sqlite-store.ts
+++ b/packages/replicache/src/kv/sqlite-store.ts
@@ -5,6 +5,7 @@ import type {Read, Store, Write} from './store.ts';
 import {
   maybeTransactionIsClosedRejection,
   throwIfStoreClosed,
+  transactionError,
   transactionIsClosedRejection,
 } from './throw-if-closed.ts';
 import {deleteSentinel, WriteImplBase} from './write-impl-base.ts';
@@ -341,11 +342,28 @@ export class SQLiteStoreRead implements Read {
       this.#scheduled = true;
       queueMicrotask(() => {
         this.#scheduled = false;
+
         const {get, has, getMany, hasMany} = this.#preparedStatements;
-        const getKeys = this.#pendingGetKeys.splice(0);
-        const getCallbacks = this.#pendingGetCallbacks.splice(0);
-        const hasKeys = this.#pendingHasKeys.splice(0);
-        const hasCallbacks = this.#pendingHasCallbacks.splice(0);
+        const getKeys = this.#pendingGetKeys;
+        this.#pendingGetKeys = [];
+        const getCallbacks = this.#pendingGetCallbacks;
+        this.#pendingGetCallbacks = [];
+        const hasKeys = this.#pendingHasKeys;
+        this.#pendingHasKeys = [];
+        const hasCallbacks = this.#pendingHasCallbacks;
+        this.#pendingHasCallbacks = [];
+
+        if (this.#closed) {
+          const e = transactionError();
+          for (let i = CB_REJECT; i < getCallbacks.length; i += CB_STRIDE) {
+            (getCallbacks[i] as Reject)(e);
+          }
+          for (let i = CB_REJECT; i < hasCallbacks.length; i += CB_STRIDE) {
+            (hasCallbacks[i] as Reject)(e);
+          }
+          return;
+        }
+
         if (getKeys.length === 1) {
           void flushSingle(getKeys[0], getCallbacks, get, settleSingleGet);
         } else if (getKeys.length > 1) {

--- a/packages/replicache/src/kv/throw-if-closed.ts
+++ b/packages/replicache/src/kv/throw-if-closed.ts
@@ -2,7 +2,7 @@ function storeError(): Error {
   return new Error('Store is closed');
 }
 
-function transactionError(): Error {
+export function transactionError(): Error {
   return new Error('Transaction is closed');
 }
 

--- a/packages/replicache/src/kv/zero-sqlite/store.test.node.ts
+++ b/packages/replicache/src/kv/zero-sqlite/store.test.node.ts
@@ -1,3 +1,4 @@
+import {tmpdir} from 'node:os';
 import {expect, test} from 'vitest';
 import {withRead, withWrite} from '../../with-transactions.ts';
 import {
@@ -7,15 +8,16 @@ import {
 import {clearAllNamedStoresForTesting} from '../sqlite-store.ts';
 import {zeroSQLiteStoreProvider, type ZeroSQLiteStoreOptions} from './store.ts';
 
-const defaultStoreOptions = {
+const defaultStoreOptions: ZeroSQLiteStoreOptions = {
   busyTimeout: 200,
   journalMode: 'WAL',
   synchronous: 'NORMAL',
   readUncommitted: false,
-} as const;
+  directory: tmpdir(),
+};
 
 function createStore(name: string, opts?: ZeroSQLiteStoreOptions) {
-  const provider = zeroSQLiteStoreProvider(opts);
+  const provider = zeroSQLiteStoreProvider({...defaultStoreOptions, ...opts});
   name = `zero_${name}`;
   const store = provider.create(name);
   registerCreatedFile(name);

--- a/packages/replicache/src/kv/zero-sqlite/store.ts
+++ b/packages/replicache/src/kv/zero-sqlite/store.ts
@@ -11,8 +11,11 @@ export {safeFilename} from '../sqlite-store.ts';
 
 export type ZeroSQLiteStoreOptions = SQLiteStoreOptions;
 
-export function dropZeroSQLiteStore(name: string): Promise<void> {
-  return dropStore(name, filename => new ZeroSQLiteDatabase(filename));
+export function dropZeroSQLiteStore(
+  name: string,
+  opts?: ZeroSQLiteStoreOptions,
+): Promise<void> {
+  return dropStore(name, filename => new ZeroSQLiteDatabase(filename), opts);
 }
 
 /**
@@ -26,7 +29,7 @@ export function zeroSQLiteStoreProvider(
   return {
     create: name =>
       new SQLiteStore(name, name => new ZeroSQLiteDatabase(name), opts),
-    drop: dropZeroSQLiteStore,
+    drop: name => dropZeroSQLiteStore(name, opts),
   };
 }
 
@@ -38,17 +41,13 @@ class ZeroSQLitePreparedStatement implements PreparedStatement {
   }
 
   // oxlint-disable-next-line require-await
-  async firstValue(params: string[]): Promise<unknown | undefined> {
-    const result = this.#statement.all(...params);
-    if (result === undefined || result.length === 0) {
-      return undefined;
-    }
-    return Object.values(result[0] as Record<string, unknown>)[0];
+  async exec(params: string[]): Promise<void> {
+    this.#statement.run(params);
   }
 
   // oxlint-disable-next-line require-await
-  async exec(params: string[]): Promise<void> {
-    this.#statement.run(params);
+  async all(params: string[]): Promise<unknown[][]> {
+    return this.#statement.raw(true).all(...params) as unknown[][];
   }
 }
 


### PR DESCRIPTION
## Summary

Optimize `SQLiteStoreRead` by batching concurrent `get()` and `has()` calls into single database queries using microtask scheduling, reducing round-trips when multiple keys are accessed concurrently.

## Key Changes

- **Batching in `SQLiteStoreRead`**: `get()` and `has()` calls queue into striped callback arrays (`[resolve, reject, resolve, reject, ...]`) and are flushed together in a `queueMicrotask` callback. `get` and `has` operations are batched independently.

- **Single-key fast path**: When exactly one key is pending at flush time, the original single-row SQL (`WHERE key = ?`) is used directly, avoiding JSON serialization overhead for the common sequential case.

- **New batch statements**: Added `getMany` (`SELECT key, value FROM entry WHERE key IN (SELECT value FROM json_each(?))`) and `hasMany` (`SELECT key FROM entry WHERE key IN (SELECT value FROM json_each(?))`) prepared statements alongside the existing single-key `get`/`has` statements.

- **Updated `PreparedStatement` interface**: Replaced `firstValue()` with `all(params): Promise<unknown[][]>` to support returning multiple rows for batch queries.

- **Type aliases for casts**: `GetResolve`, `HasResolve`, `Reject` aliases make the necessary `as`-casts on the `unknown[]` callback array concise.

- **All adapters updated**: zero-sqlite, expo-sqlite, and op-sqlite implement the new `all()` method. The expo-sqlite mock's `executeForRawResultAsync` gains `getAllAsync()` support.

- **`directory` option**: `SQLiteStoreOptions` gains an optional `directory` field so stores can be created in a specific path; `dropStore`/`dropZeroSQLiteStore` accept it too for consistent file resolution.

## Tests

- `sqlite-store.test.node.ts`: Unit tests verifying batching behaviour — concurrent gets coalesce into one `getMany` call, sequential awaited gets use the single-key path, concurrent has coalesces into `hasMany`, mixed get+has use separate SQL calls.
- `sqlite-store.test.ts`: Integration test for `SQLiteWrite` batch commit (deletes + upserts flushed as one statement each).