### PR TITLE
perf(zero-cache): flush poke parts by byte budget

### DIFF
--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -476,6 +476,19 @@ test('zero-cache --help', () => {
                                                                                                                                                                                                    
                                                                         A password is optional in development mode but required in production mode.                                                
                                                                                                                                                                                                    
+     --poke-part-flush-max-bytes number                                 default: 131072                                                                                                            
+       ZERO_POKE_PART_FLUSH_MAX_BYTES env                                                                                                                                                          
+                                                                        Target maximum JSON bytes per pokePart before the view-syncer flushes to WebSocket.                                        
+                                                                                                                                                                                                   
+                                                                        This bounds large row pokes without changing the sync protocol. Actual messages can exceed                                 
+                                                                        this target by one patch because rows are estimated before flushing. Default: 128KB.                                       
+                                                                                                                                                                                                   
+     --poke-part-flush-max-rows number                                  default: 100                                                                                                               
+       ZERO_POKE_PART_FLUSH_MAX_ROWS env                                                                                                                                                           
+                                                                        Maximum row/config patches per pokePart before flushing.                                                                   
+                                                                                                                                                                                                   
+                                                                        This remains as a pathological-object guard in addition to the byte target.                                                
+                                                                                                                                                                                                   
      --websocket-compression boolean                                    default: false                                                                                                             
        ZERO_WEBSOCKET_COMPRESSION env                                                                                                                                                              
                                                                         Enable WebSocket per-message deflate compression.                                                                          

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -734,6 +734,26 @@ export const zeroOptions = {
     ],
   },
 
+  pokePartFlush: {
+    maxBytes: {
+      type: v.number().default(128 * 1024),
+      desc: [
+        'Target maximum JSON bytes per pokePart before the view-syncer flushes to WebSocket.',
+        '',
+        'This bounds large row pokes without changing the sync protocol. Actual messages can exceed',
+        'this target by one patch because rows are estimated before flushing. Default: 128KB.',
+      ],
+    },
+    maxRows: {
+      type: v.number().default(100),
+      desc: [
+        'Maximum row/config patches per pokePart before flushing.',
+        '',
+        'This remains as a pathological-object guard in addition to the byte target.',
+      ],
+    },
+  },
+
   websocketCompression: {
     type: v.boolean().default(false),
     desc: [

--- a/packages/zero-cache/src/services/view-syncer/client-handler.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.test.ts
@@ -11,6 +11,7 @@ import type {
 import {Subscription} from '../../types/subscription.ts';
 import {
   ClientHandler,
+  DEFAULT_POKE_PART_FLUSH_BYTES,
   ensureSafeJSON,
   startPoke,
   type Patch,
@@ -368,6 +369,199 @@ describe('view-syncer/client-handler', () => {
         {pokeID: '123', baseCookie: '121'},
       ] satisfies PokeStartMessage,
       ['pokeEnd', {pokeID: '123', cookie: '123'}] satisfies PokeEndMessage,
+    ]);
+  });
+
+  test('flushes poke parts by estimated bytes and max row guard', async () => {
+    const {subscription, close} = createSubscription();
+    const handler = new ClientHandler(
+      lc,
+      'g1',
+      'id1',
+      'ws1',
+      SHARD,
+      '121',
+      subscription,
+      {maxBytes: 450, maxRows: 10},
+    );
+    const poker = handler.startPoke({stateVersion: '123'});
+
+    await poker.addPatches(
+      [0, 1, 2].map(i => ({
+        toVersion: {stateVersion: '123'},
+        patch: {
+          type: 'row',
+          op: 'put',
+          id: {schema: 'public', table: 'issues', rowKey: {id: `byte-${i}`}},
+          contents: {id: `byte-${i}`, payload: 'x'.repeat(180)},
+        },
+      })) satisfies Parameters<PokeHandler['addPatches']>[0],
+    );
+    await poker.end({stateVersion: '123'});
+
+    const {received} = await close();
+    const byteFlushParts = received.filter(
+      (msg): msg is PokePartMessage => msg[0] === 'pokePart',
+    );
+    expect(byteFlushParts.map(part => part[1].rowsPatch?.length)).toEqual([
+      2, 1,
+    ]);
+    for (const part of byteFlushParts) {
+      expect(JSON.stringify(part).length).toBeLessThan(
+        DEFAULT_POKE_PART_FLUSH_BYTES,
+      );
+    }
+
+    const guarded = createSubscription();
+    const guardedHandler = new ClientHandler(
+      lc,
+      'g1',
+      'id1',
+      'ws1',
+      SHARD,
+      '121',
+      guarded.subscription,
+      {maxBytes: 10_000, maxRows: 2},
+    );
+    const guardedPoker = guardedHandler.startPoke({stateVersion: '123'});
+    await guardedPoker.addPatches(
+      [0, 1, 2].map(i => ({
+        toVersion: {stateVersion: '123'},
+        patch: {
+          type: 'row',
+          op: 'put',
+          id: {schema: 'public', table: 'issues', rowKey: {id: `row-${i}`}},
+          contents: {id: `row-${i}`, payload: 'x'},
+        },
+      })) satisfies Parameters<PokeHandler['addPatches']>[0],
+    );
+    await guardedPoker.end({stateVersion: '123'});
+
+    const guardedParts = (await guarded.close()).received.filter(
+      (msg): msg is PokePartMessage => msg[0] === 'pokePart',
+    );
+    expect(guardedParts.map(part => part[1].rowsPatch?.length)).toEqual([2, 1]);
+  });
+
+  test('batched addPatches preserves ordering and filters by base version', async () => {
+    const {subscription, close} = createSubscription();
+    const handler = new ClientHandler(
+      lc,
+      'g1',
+      'id1',
+      'ws1',
+      SHARD,
+      '121',
+      subscription,
+    );
+    const poker = handler.startPoke({stateVersion: '123'});
+
+    await poker.addPatches([
+      {
+        toVersion: {stateVersion: '121'},
+        patch: {
+          type: 'row',
+          op: 'put',
+          id: {schema: 'public', table: 'issues', rowKey: {id: 'old'}},
+          contents: {id: 'old'},
+        },
+      },
+      {
+        toVersion: {stateVersion: '122'},
+        patch: {
+          type: 'query',
+          op: 'put',
+          id: 'query-a',
+        },
+      },
+      {
+        toVersion: {stateVersion: '123'},
+        patch: {
+          type: 'row',
+          op: 'put',
+          id: {schema: 'public', table: 'issues', rowKey: {id: 'first'}},
+          contents: {id: 'first'},
+        },
+      },
+      {
+        toVersion: {stateVersion: '123'},
+        patch: {
+          type: 'row',
+          op: 'del',
+          id: {schema: 'public', table: 'issues', rowKey: {id: 'second'}},
+        },
+      },
+    ]);
+    await poker.end({stateVersion: '123'});
+
+    const part = (await close()).received.find(
+      (msg): msg is PokePartMessage => msg[0] === 'pokePart',
+    );
+    expect(part?.[1].gotQueriesPatch).toEqual([{op: 'put', hash: 'query-a'}]);
+    expect(part?.[1].rowsPatch).toEqual([
+      {op: 'put', tableName: 'issues', value: {id: 'first'}},
+      {op: 'del', tableName: 'issues', id: {id: 'second'}},
+    ]);
+  });
+
+  test('multi-client addPatches applies each client base version independently', async () => {
+    const subscriptions = [createSubscription(), createSubscription()];
+    const handlers = [
+      new ClientHandler(
+        lc,
+        'g1',
+        'id1',
+        'ws1',
+        SHARD,
+        '121',
+        subscriptions[0].subscription,
+      ),
+      new ClientHandler(
+        lc,
+        'g1',
+        'id2',
+        'ws2',
+        SHARD,
+        '120',
+        subscriptions[1].subscription,
+      ),
+    ];
+    const pokers = startPoke(handlers, {stateVersion: '123'});
+
+    await pokers.addPatches([
+      {
+        toVersion: {stateVersion: '121'},
+        patch: {
+          type: 'row',
+          op: 'put',
+          id: {schema: 'public', table: 'issues', rowKey: {id: 'old'}},
+          contents: {id: 'old'},
+        },
+      },
+      {
+        toVersion: {stateVersion: '123'},
+        patch: {
+          type: 'row',
+          op: 'put',
+          id: {schema: 'public', table: 'issues', rowKey: {id: 'new'}},
+          contents: {id: 'new'},
+        },
+      },
+    ]);
+    await pokers.end({stateVersion: '123'});
+
+    const results = await Promise.all(subscriptions.map(sub => sub.close()));
+    const rows = results.map(result =>
+      result.received
+        .filter((msg): msg is PokePartMessage => msg[0] === 'pokePart')
+        .flatMap(msg => msg[1].rowsPatch ?? []),
+    );
+    expect(rows).toEqual([
+      [{op: 'put', tableName: 'issues', value: {id: 'new'}}],
+      [
+        {op: 'put', tableName: 'issues', value: {id: 'old'}},
+        {op: 'put', tableName: 'issues', value: {id: 'new'}},
+      ],
     ]);
   });
 

--- a/packages/zero-cache/src/services/view-syncer/client-handler.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.ts
@@ -32,6 +32,7 @@ import {
   getLogLevel,
   wrapWithProtocolError,
 } from '../../types/error-with-level.ts';
+import {preencodeDownstream} from '../../types/preencoded.ts';
 import {upstreamSchema, type ShardID} from '../../types/shards.ts';
 import type {Subscription} from '../../types/subscription.ts';
 import {
@@ -71,12 +72,14 @@ export type PatchToVersion = {
 
 export interface PokeHandler {
   addPatch(patch: PatchToVersion): Promise<void>;
+  addPatches(patches: Iterable<PatchToVersion>): Promise<void>;
   cancel(): Promise<void>;
   end(finalVersion: CVRVersion): Promise<void>;
 }
 
 const NOOP: PokeHandler = {
   addPatch: () => promiseVoid,
+  addPatches: () => promiseVoid,
   cancel: () => promiseVoid,
   end: () => promiseVoid,
 };
@@ -95,6 +98,10 @@ export function startPoke(
     addPatch: async patch => {
       await Promise.allSettled(pokers.map(poker => poker.addPatch(patch)));
     },
+    addPatches: async patches => {
+      const batch = [...patches];
+      await Promise.allSettled(pokers.map(poker => poker.addPatches(batch)));
+    },
     cancel: async () => {
       await Promise.allSettled(pokers.map(poker => poker.cancel()));
     },
@@ -104,9 +111,23 @@ export function startPoke(
   };
 }
 
-// Semi-arbitrary threshold at which poke body parts are flushed.
-// When row size is being computed, that should be used as a threshold instead.
-const PART_COUNT_FLUSH_THRESHOLD = 100;
+export const DEFAULT_POKE_PART_FLUSH_BYTES = 128 * 1024;
+export const DEFAULT_POKE_PART_FLUSH_ROWS = 100;
+
+export type PokePartFlushConfig = {
+  readonly maxBytes?: number | undefined;
+  readonly maxRows?: number | undefined;
+};
+
+type NormalizedPokePartFlushConfig = {
+  readonly maxBytes: number;
+  readonly maxRows: number;
+};
+
+const defaultPokePartFlushConfig = {
+  maxBytes: DEFAULT_POKE_PART_FLUSH_BYTES,
+  maxRows: DEFAULT_POKE_PART_FLUSH_ROWS,
+} satisfies NormalizedPokePartFlushConfig;
 
 /**
  * Handles a single `ViewSyncer` connection.
@@ -120,6 +141,7 @@ export class ClientHandler {
   readonly #lc: LogContext;
   readonly #downstream: Subscription<Downstream>;
   #baseVersion: NullableCVRVersion;
+  readonly #pokePartFlushConfig: NormalizedPokePartFlushConfig;
 
   readonly #pokeTime = getOrCreateLatencyHistogram(
     'sync',
@@ -147,6 +169,7 @@ export class ClientHandler {
     shard: ShardID,
     baseCookie: string | null,
     downstream: Subscription<Downstream>,
+    pokePartFlushConfig: PokePartFlushConfig = {},
   ) {
     lc.debug?.('new client handler');
     this.#clientGroupID = clientGroupID;
@@ -156,6 +179,12 @@ export class ClientHandler {
     this.#zeroMutationsTable = `${upstreamSchema(shard)}.mutations`;
     this.#lc = lc;
     this.#downstream = downstream;
+    this.#pokePartFlushConfig = {
+      maxBytes:
+        pokePartFlushConfig.maxBytes ?? defaultPokePartFlushConfig.maxBytes,
+      maxRows:
+        pokePartFlushConfig.maxRows ?? defaultPokePartFlushConfig.maxRows,
+    };
     this.#baseVersion = cookieToVersion(baseCookie);
   }
 
@@ -201,100 +230,86 @@ export class ClientHandler {
     let pokeStarted = false;
     let body: PokePartBody | undefined;
     let partCount = 0;
-    const ensureBody = async () => {
+    let estimatedBytes = pokePartBaseBytes(pokeID);
+    const flushBytesThreshold = this.#pokePartFlushConfig.maxBytes;
+    const flushRowsThreshold = this.#pokePartFlushConfig.maxRows;
+
+    const ensureStarted = async () => {
       if (!pokeStarted) {
         await this.#push(['pokeStart', pokeStart]);
         pokeStarted = true;
       }
-      return (body ??= {pokeID});
     };
+    const ensureBody = () => (body ??= {pokeID});
     const flushBody = async () => {
       if (body) {
-        await this.#push(['pokePart', body]);
+        await ensureStarted();
+        await this.#push(preencodeDownstream(['pokePart', body]));
         body = undefined;
         partCount = 0;
+        estimatedBytes = pokePartBaseBytes(pokeID);
       }
     };
+    const shouldFlushBody = () =>
+      estimatedBytes >= flushBytesThreshold || partCount >= flushRowsThreshold;
 
-    const addPatch = async (patchToVersion: PatchToVersion) => {
+    const addPatchToPendingBody = (patchToVersion: PatchToVersion) => {
       const {patch, toVersion} = patchToVersion;
       if (cmpVersions(toVersion, this.#baseVersion) <= 0) {
-        return;
-      }
-      const body = await ensureBody();
-
-      const {type, op} = patch;
-      switch (type) {
-        case 'query': {
-          const patches = patch.clientID
-            ? ((body.desiredQueriesPatches ??= {})[patch.clientID] ??= [])
-            : (body.gotQueriesPatch ??= []);
-          if (op === 'put') {
-            patches.push({op, hash: patch.id});
-          } else {
-            patches.push({op, hash: patch.id});
-          }
-          break;
-        }
-        case 'row':
-          if (patch.id.table === this.#zeroClientsTable) {
-            this.#updateLMIDs((body.lastMutationIDChanges ??= {}), patch);
-          } else if (patch.id.table === this.#zeroMutationsTable) {
-            const patches = (body.mutationsPatch ??= []);
-            if (op === 'put') {
-              const row = v.parse(
-                ensureSafeJSON(patch.contents),
-                mutationRowSchema,
-                'passthrough',
-              );
-              patches.push({
-                op: 'put',
-                mutation: {
-                  id: {
-                    clientID: row.clientID,
-                    id: row.mutationID,
-                  },
-                  result: row.result,
-                },
-              });
-            } else {
-              const {clientID, mutationID} = patch.id.rowKey;
-              assert(
-                typeof clientID === 'string',
-                'client id must be a string',
-              );
-              const id = Number(mutationID);
-              assert(
-                !Number.isNaN(id) && Number.isFinite(id) && id >= 0,
-                'mutation id must be a finite number',
-              );
-              patches.push({
-                op: 'del',
-                id: {
-                  clientID,
-                  id,
-                },
-              });
-            }
-          } else {
-            (body.rowsPatch ??= []).push(makeRowPatch(patch));
-          }
-          break;
-        default:
-          unreachable(patch);
+        return false;
       }
 
-      if (++partCount >= PART_COUNT_FLUSH_THRESHOLD) {
-        await flushBody();
-      }
+      estimatedBytes += addPatchToBody(
+        ensureBody(),
+        patch,
+        this.#zeroClientsTable,
+        this.#zeroMutationsTable,
+        patch.type === 'row'
+          ? (lmids: Record<string, number>) => this.#updateLMIDs(lmids, patch)
+          : undefined,
+      );
+      partCount++;
+      return true;
     };
 
     return {
       addPatch: async (patchToVersion: PatchToVersion) => {
         try {
-          await addPatch(patchToVersion);
-          if (patchToVersion.patch.type === 'row') {
+          if (cmpVersions(patchToVersion.toVersion, this.#baseVersion) > 0) {
+            await ensureStarted();
+          }
+          const added = addPatchToPendingBody(patchToVersion);
+          if (added && patchToVersion.patch.type === 'row') {
             this.#pokedRows.add(1);
+          }
+          if (shouldFlushBody()) {
+            await flushBody();
+          }
+        } catch (e) {
+          this.#downstream.fail(wrapWithProtocolError(e));
+        }
+      },
+
+      addPatches: async (patches: Iterable<PatchToVersion>) => {
+        let rows = 0;
+        try {
+          for (const patch of patches) {
+            if (
+              !pokeStarted &&
+              cmpVersions(patch.toVersion, this.#baseVersion) > 0
+            ) {
+              await ensureStarted();
+            }
+            const added = addPatchToPendingBody(patch);
+            if (added && patch.patch.type === 'row') {
+              rows++;
+            }
+            if (shouldFlushBody()) {
+              await flushBody();
+            }
+          }
+          if (rows > 0) {
+            this.#pokedRows.add(rows);
           }
         } catch (e) {
           this.#downstream.fail(wrapWithProtocolError(e));
@@ -313,7 +328,7 @@ export class ClientHandler {
           if (cmpVersions(this.#baseVersion, finalVersion) === 0) {
             return; // Nothing changed and nothing was sent.
           }
-          await this.#push(['pokeStart', pokeStart]);
+          await ensureStarted();
         } else if (cmpVersions(this.#baseVersion, finalVersion) >= 0) {
           // Sanity check: If the poke was started, the finalVersion
           // must be > #baseVersion.
@@ -383,6 +398,108 @@ export class ClientHandler {
       patch.op satisfies 'constrain' | 'del';
     }
   }
+}
+
+function addPatchToBody(
+  body: PokePartBody,
+  patch: Patch,
+  clientsTable: string,
+  mutationsTable: string,
+  updateLMIDs: ((lmids: Record<string, number>) => void) | undefined,
+) {
+  const {type, op} = patch;
+  switch (type) {
+    case 'query': {
+      const patchOp = {op, hash: patch.id};
+      if (patch.clientID) {
+        const patches = (body.desiredQueriesPatches ??= {});
+        pushEstimated(patches, patch.clientID, patchOp);
+      } else {
+        (body.gotQueriesPatch ??= []).push(patchOp);
+      }
+      return estimatedKeyedJSONEntryBytes(
+        patch.clientID ?? 'gotQueriesPatch',
+        patchOp,
+      );
+    }
+    case 'row':
+      if (patch.id.table === clientsTable) {
+        assert(updateLMIDs, 'missing lmid updater');
+        updateLMIDs((body.lastMutationIDChanges ??= {}));
+        return estimatedKeyedJSONEntryBytes(
+          'lastMutationIDChanges',
+          patch.id.rowKey,
+        );
+      }
+      if (patch.id.table === mutationsTable) {
+        const mutationPatch = makeMutationPatch(patch);
+        (body.mutationsPatch ??= []).push(mutationPatch);
+        return estimatedKeyedJSONEntryBytes('mutationsPatch', mutationPatch);
+      }
+      const rowPatch = makeRowPatch(patch);
+      (body.rowsPatch ??= []).push(rowPatch);
+      return estimatedKeyedJSONEntryBytes('rowsPatch', rowPatch);
+    default:
+      unreachable(patch);
+  }
+}
+
+function pushEstimated<T>(record: Record<string, T[]>, key: string, value: T) {
+  (record[key] ??= []).push(value);
+}
+
+function makeMutationPatch(patch: RowPatch) {
+  const {op} = patch;
+  if (op === 'put') {
+    const row = v.parse(
+      ensureSafeJSON(patch.contents),
+      mutationRowSchema,
+      'passthrough',
+    );
+    return {
+      op: 'put' as const,
+      mutation: {
+        id: {
+          clientID: row.clientID,
+          id: row.mutationID,
+        },
+        result: row.result,
+      },
+    };
+  }
+
+  const {clientID, mutationID} = patch.id.rowKey;
+  assert(typeof clientID === 'string', 'client id must be a string');
+  const id = Number(mutationID);
+  assert(
+    !Number.isNaN(id) && Number.isFinite(id) && id >= 0,
+    'mutation id must be a finite number',
+  );
+  return {
+    op: 'del' as const,
+    id: {
+      clientID,
+      id,
+    },
+  };
+}
+
+const pokePartEnvelopeBytes = Buffer.byteLength('["pokePart",]');
+
+function pokePartBaseBytes(pokeID: string) {
+  return (
+    pokePartEnvelopeBytes +
+    Buffer.byteLength('{"pokeID":}') +
+    estimatedJSONBytes(pokeID)
+  );
+}
+
+function estimatedKeyedJSONEntryBytes(key: string, value: unknown) {
+  return Buffer.byteLength(`,"${key}":`) + estimatedJSONBytes(value);
+}
+
+function estimatedJSONBytes(value: unknown) {
+  return Buffer.byteLength(JSON.stringify(value));
 }
 
 // Note: The {APP_ID}_{SHARD_ID}.clients table is set up in replicator/initial-sync.ts.

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -814,6 +814,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         this.#shard,
         connCtx.baseCookie,
         downstream,
+        this.#config.pokePartFlush,
       );
       this.#clients
         .get(connCtx.clientID)
@@ -1059,9 +1060,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
             this.#getClients(cvr.version),
             newCVR.version,
           );
-          for (const patch of patches) {
-            await pokers.addPatch(patch);
-          }
+          await pokers.addPatches(patches);
           await pokers.end(newCVR.version);
         },
       );
@@ -1973,11 +1972,9 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
       const clients = this.#getClients();
       const pokers = startPoke(clients, newVersion);
-      for (const patch of queryPatches) {
-        // Bump patches' toVersion to the post-drift-bump version so that
-        // pokers don't see them as belonging to a stale cookie.
-        await pokers.addPatch(patch);
-      }
+      // Bump patches' toVersion to the post-drift-bump version so that
+      // pokers don't see them as belonging to a stale cookie.
+      await pokers.addPatches(queryPatches);
 
       // Removing queries is easy. The pipelines are dropped, and the CVR
       // updater handles the updates and pokes.
@@ -2046,9 +2043,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         tracer,
         'vs.#syncQueryPipelineSet.deleteUnreferencedRows',
         async () => {
-          for (const patch of await updater.deleteUnreferencedRows(lc)) {
-            await pokers.addPatch(patch);
-          }
+          await pokers.addPatches(await updater.deleteUnreferencedRows(lc));
         },
       );
 
@@ -2140,6 +2135,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       // await the rowPatches first so that the AsyncGenerator kicks off.
       let rowPatchCount = 0;
       for await (const rows of rowPatches) {
+        const rowPatchBatch: PatchToVersion[] = [];
         for (const row of rows) {
           const {schema, table} = row;
           const rowKey = row.rowKey as RowKey;
@@ -2157,10 +2153,10 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
             const {contents} = contentsAndVersion(row);
             patch = {type: 'row', op: 'put', id, contents};
           }
-          const patchToVersion = {patch, toVersion};
-          await pokers.addPatch(patchToVersion);
+          rowPatchBatch.push({patch, toVersion});
           rowPatchCount++;
         }
+        await pokers.addPatches(rowPatchBatch);
       }
       span.setAttribute('rowPatchCount', rowPatchCount);
       if (rowPatchCount) {
@@ -2168,9 +2164,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       }
 
       // Then await the config patches which were fetched in parallel.
-      for (const patch of await configPatches) {
-        await pokers.addPatch(patch);
-      }
+      await pokers.addPatches(await configPatches);
 
       if (!usePokers) {
         await pokers.end(cvr.version);
@@ -2205,9 +2199,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
             'processBatch.flushToClient',
             async span => {
               span.setAttribute('patches', patches.length);
-              for (const patch of patches) {
-                await pokers.addPatch(patch);
-              }
+              await pokers.addPatches(patches);
             },
           );
           rows.clear();

--- a/packages/zero-cache/src/types/preencoded.ts
+++ b/packages/zero-cache/src/types/preencoded.ts
@@ -1,0 +1,12 @@
+import type {Downstream} from '../../../zero-protocol/src/down.ts';
+
+const preencodedDownstreams = new WeakMap<Downstream, string>();
+
+export function preencodeDownstream(data: Downstream): Downstream {
+  preencodedDownstreams.set(data, JSON.stringify(data));
+  return data;
+}
+
+export function getPreencodedDownstream(data: Downstream): string | undefined {
+  return preencodedDownstreams.get(data);
+}

--- a/packages/zero-cache/src/workers/connection.test.ts
+++ b/packages/zero-cache/src/workers/connection.test.ts
@@ -9,6 +9,7 @@ import type {Downstream} from '../../../zero-protocol/src/down.ts';
 import {ErrorKind} from '../../../zero-protocol/src/error-kind.ts';
 import {ErrorOrigin} from '../../../zero-protocol/src/error-origin.ts';
 import {ProtocolErrorWithLevel} from '../types/error-with-level.ts';
+import {preencodeDownstream} from '../types/preencoded.ts';
 import {send, sendError, type WebSocketLike} from './connection.ts';
 
 class MockSocket implements WebSocketLike {
@@ -47,6 +48,18 @@ describe('send', () => {
     ws.readyState = WebSocket.OPEN;
     send(lc, ws, data, callback);
     expect(sendSpy).toHaveBeenCalledWith(JSON.stringify(data), callback);
+  });
+
+  test('uses preencoded downstream JSON when available', () => {
+    using sendSpy = vi.spyOn(ws, 'send');
+    const callback = () => {};
+    const msg = preencodeDownstream(['pokePart', {pokeID: 'p1'}]);
+    ws.readyState = WebSocket.OPEN;
+    send(lc, ws, msg, callback);
+    expect(sendSpy).toHaveBeenCalledWith(
+      '["pokePart",{"pokeID":"p1"}]',
+      callback,
+    );
   });
 });
 

--- a/packages/zero-cache/src/workers/connection.ts
+++ b/packages/zero-cache/src/workers/connection.ts
@@ -23,6 +23,7 @@ import {
   getLogLevel,
   wrapWithProtocolError,
 } from '../types/error-with-level.ts';
+import {getPreencodedDownstream} from '../types/preencoded.ts';
 import type {Source} from '../types/streams.ts';
 import type {ConnectParams} from './connect-params.ts';
 
@@ -322,7 +323,7 @@ export class Connection {
     callback: ((err?: Error | null) => void) | 'ignore-backpressure',
   ) {
     this.#lastDownstreamMsgTime = Date.now();
-    return send(this.#lc, this.#ws, data, callback);
+    send(this.#lc, this.#ws, data, callback);
   }
 
   sendError(errorBody: ErrorBody, thrown?: unknown) {
@@ -340,10 +341,10 @@ export function send(
   ws: WebSocketLike,
   data: Downstream,
   callback: ((err?: Error | null) => void) | 'ignore-backpressure',
-) {
+): void {
   if (ws.readyState === WebSocket.OPEN) {
     ws.send(
-      JSON.stringify(data),
+      getPreencodedDownstream(data) ?? JSON.stringify(data),
       callback === 'ignore-backpressure' ? undefined : callback,
     );
   } else {


### PR DESCRIPTION
## AI-generated draft

This draft PR was prepared by an AI coding agent. It is intentionally still draft, but it is a clean production PR against `main`; benchmark scaffolding lives in [#5959](https://github.com/rocicorp/mono/pull/5959).

## Why This Is Worth It

The current flush rule asks one question: "have we collected 100 row/config patches yet?" That is easy to reason about, but it ignores the part a browser, WebSocket buffer, and JS runtime actually feel: bytes.

The scary case is not the average poke. It is one large transaction landing in one subscribed tab:

```text
100 rows, 8 KiB each
--------------------
current rule:  count rows to 100
result:        one ~810 KiB pokePart frame

client side:
large frame -> allocate -> parse JSON -> dispatch patch batch
            -> event loop is busy while every other tab task waits
```

This PR changes the control unit from "about 100 patches" to "about 128 KiB or 100 patches, whichever comes first." The wire protocol does not change. Only the cut points change.

```text
Before
------
patch patch patch ... patch
|-------------------------|
        one large pokePart

After
-----
patch patch patch ... patch
|-----|-----|-----|-----|--
  smaller pokeParts with the same pokePart shape
```

The improvement is not compression. The improvement is turning one tail-latency-shaped frame into several smaller frames so WebSocket framing, JSON parse, dispatch, and backpressure get multiple scheduling boundaries instead of one large synchronous-looking lump.

## Clean PR Set

Base for the cleaned branches: `rocicorp/mono@65f1461f761936288a11fde0585d100432ce9aef`.

| PR | Role | Relationship |
|---|---|---|
| [#5959](https://github.com/rocicorp/mono/pull/5959) | Benchmark suite | Provides `perf:poke` evidence |
| [#5960](https://github.com/rocicorp/mono/pull/5960) | This PR | Production byte-aware poke flushing |
| [#5963](https://github.com/rocicorp/mono/pull/5963) | Production cumulative ACKs | Independent |
| [#5964](https://github.com/rocicorp/mono/pull/5964) | Production fanout release timing | Independent |

## What Changed

- Adds `pokePartFlush.maxBytes` and `pokePartFlush.maxRows` config.
- Keeps `maxRows = 100` as the old pathological-object guard.
- Adds `maxBytes = 128 * 1024` as the new target byte budget.
- Flushes when either the byte target or row target is reached.
- Batches patch insertion with `addPatches()` so hot paths do not await per patch.
- Pre-encodes the outbound pokePart once it is ready to send.
- Keeps the sync protocol unchanged: clients still receive normal `pokeStart`, `pokePart`, and `pokeEnd` messages.

## Benchmark Headline

Benchmark harness: [#5959](https://github.com/rocicorp/mono/pull/5959), `npm --workspace=zero-cache run perf:poke:full`.

For the workload count-based flushing handles worst, the max frame drops from 810.2 KiB to 129.7 KiB. Total encoded bytes stay essentially the same.

```text
100 rows/tx, 8 KiB rows
-----------------------
main:     1 pokePart per tx, max frame 810.2 KiB
this PR: ~7 pokeParts per tx, max frame 129.7 KiB

volume:       same order, about 791 MiB either way
distribution: one huge frame becomes several smaller frames
tradeoff:     more WebSocket messages and dispatch events
```

| Scenario | Main / fixed-count batching | This PR / byte-aware batching | What changed |
|---|---:|---:|---|
| 10 rows/tx, small 96 B rows | 3,000 messages, 1,000 pokeParts, 2.05 MiB encoded, 1.98 KiB max msg, p95 0.083 ms, CPU 16.45 ms | 3,000 messages, 1,000 pokeParts, 2.05 MiB encoded, 1.98 KiB max msg, p95 0.103 ms, CPU 17.63 ms | No real chunking change; overhead is tiny |
| 10 rows/tx, large 8 KiB rows | 3,000 messages, 1,000 pokeParts, 79.3 MiB encoded, 81.0 KiB max msg, p95 0.627 ms, CPU 157.55 ms | 3,000 messages, 1,000 pokeParts, 79.3 MiB encoded, 81.0 KiB max msg, p95 0.591 ms, CPU 153.02 ms | Same chunking; no regression |
| 100 rows/tx, small 96 B rows | 3,000 messages, 1,000 pokeParts, 19.2 MiB encoded, 19.6 KiB max msg, p95 0.440 ms, CPU 93.55 ms | 3,000 messages, 1,000 pokeParts, 19.2 MiB encoded, 19.6 KiB max msg, p95 0.489 ms, CPU 101.28 ms | No chunking change; small CPU/p95 cost |
| 100 rows/tx, large 8 KiB rows | 3,000 messages, 1,000 pokeParts, 791.3 MiB encoded, 810.2 KiB max msg, p95 0.993 ms, CPU 452.39 ms | 9,000 messages, 7,000 pokeParts, 791.5 MiB encoded, 129.7 KiB max msg, p95 1.101 ms, CPU 480.33 ms | Max message -84.0%; messages +200%; CPU +6.2% |

That last row is the whole argument for the PR: it buys a much smaller worst frame in exchange for more frames. The +200% message count is real; the bet is that several ~130 KiB frames are kinder to buffers, parse work, and dispatch scheduling than one ~810 KiB frame. Review should focus on whether that is the right tradeoff for large-row subscriber experience.

## Safety Story: Review Contract

- Cannot change the sync protocol. The outbound message is still a normal `pokePart`; only the grouping changes.
- Cannot remove the old guard. `maxRows = 100` remains, so pathological object count is still bounded.
- Cannot promise a hard 128 KiB cap. The implementation estimates bytes before flushing, so a frame can exceed the target by the patch that crosses it.
- Cannot grow a global pre-encoding cache. Pre-encoded payloads are keyed by the downstream message object and disappear with that object lifetime.
- Cannot send patches for clients that should not see them. The existing base-version filtering still happens before a patch is added to the pending body.
- Cannot make one huge row small. A single row larger than the byte budget can still produce a large frame; the threshold only prevents groups of large rows from accumulating into one frame.

## What Reviewers Should Be Skeptical About

- Large-row workloads send more messages and pokeParts. That can increase WebSocket framing overhead, event-loop scheduling, and client dispatch overhead.
- This benchmark does not measure browser parse time. That is the missing client-side confirmation for the theory that smaller frames are easier on the tab.
- Byte estimation is intentionally approximate because final JSON shape and framing can differ from the estimate.
- The 128 KiB default is a tunable runtime tradeoff, chosen as a conservative target far below the measured 810 KiB tail frame, not as a protocol law.
- Smaller chunks can alter backpressure timing. That is part of the intended behavior, but it deserves rollout attention.

## Validation

- `npm --workspace=zero-cache run check-types`
- `npm --workspace=zero-cache run lint`
- `npm --workspace=zero-cache run test:no-pg -- client-handler.test.ts connection.test.ts zero-config.test.ts`

`client-handler.test.ts` includes the new byte-threshold flush case and the retained max-row guard case.
