### PR TITLE
perf(zero-cache): batch change-streamer ACKs

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
@@ -238,7 +238,7 @@ export class ChangeStreamerHttpClient implements ChangeStreamer {
     const params = getParams(ctx);
     const ws = new WebSocket(uri + `?${params.toString()}`);
 
-    return streamIn(this.#lc, ws, downstreamSchema);
+    return streamIn(this.#lc, ws, downstreamSchema, {ack: 'cumulative'});
   }
 }
 

--- a/packages/zero-cache/src/types/streams.test.ts
+++ b/packages/zero-cache/src/types/streams.test.ts
@@ -6,6 +6,7 @@ import Fastify, {type FastifyInstance} from 'fastify';
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import WebSocket from 'ws';
 import {unreachable} from '../../../shared/src/asserts.ts';
+import type {JSONValue} from '../../../shared/src/bigint-json.ts';
 import {
   createSilentLogContext,
   TestLogSink,
@@ -219,6 +220,7 @@ describe('streams with internal acks', () => {
   let consumed: Queue<Message>;
   let cleanedUp: Promise<Message[]>;
   let cleanup: (m: Message[]) => void;
+  let ackMessages: number[];
   let port: number;
 
   let ws: WebSocket;
@@ -231,6 +233,7 @@ describe('streams with internal acks', () => {
     cleanup = resolve;
 
     consumed = new Queue();
+    ackMessages = [];
     producer = Subscription.create({
       consumed: m => consumed.enqueue(m),
       cleanup: resolve,
@@ -240,6 +243,16 @@ describe('streams with internal acks', () => {
     server = Fastify();
     await server.register(websocket);
     server.get('/', {websocket: true}, ws => {
+      ws.on('message', data => {
+        const text = data.toString();
+        if (!text.startsWith('{"ack":')) {
+          return;
+        }
+        const {ack} = JSON.parse(text) as {ack?: unknown};
+        if (typeof ack === 'number') {
+          ackMessages.push(ack);
+        }
+      });
       void streamOut(lc, producer, ws);
       void streamOutStringified(lc, stringifiedProducer, ws);
     });
@@ -260,11 +273,9 @@ describe('streams with internal acks', () => {
     ws = new WebSocket(`http://localhost:${port}/`);
     return {
       ws,
-      consumer: (await streamIn(
-        lc,
-        ws,
-        messageSchema,
-      )) as Subscription<Message>,
+      consumer: (await streamIn(lc, ws, messageSchema, {
+        ack: 'cumulative',
+      })) as Subscription<Message>,
     };
   }
 
@@ -346,6 +357,78 @@ describe('streams with internal acks', () => {
       'consumed',
       'consumed',
     ]);
+  });
+
+  test('pipelined cumulative ack batches consumed messages', async () => {
+    const messageCount = 96;
+    const results: Promise<Result>[] = [];
+    for (let i = 0; i < messageCount; i++) {
+      results.push(producer.push({from: i, to: i + 1, str: `msg-${i}`}).result);
+    }
+
+    const {consumer} = await startReceiver();
+    await vi.waitFor(() => expect(consumer.queued).toBe(messageCount));
+
+    const entries = await drainPipeline(messageCount, consumer);
+    for (const {consumed} of entries) {
+      consumed();
+    }
+
+    expect(await Promise.all(results)).toEqual(
+      Array<Result>(messageCount).fill('consumed'),
+    );
+    expect(ackMessages).toEqual([
+      8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96,
+    ]);
+    consumer.cancel();
+    expect(await cleanedUp).toEqual([]);
+  });
+
+  test('pipelined cumulative ack flushes pending ack on cleanup', async () => {
+    const messageCount = 3;
+    const results: Promise<Result>[] = [];
+    for (let i = 0; i < messageCount; i++) {
+      results.push(producer.push({from: i, to: i + 1, str: `msg-${i}`}).result);
+    }
+
+    const {consumer} = await startReceiver();
+    await vi.waitFor(() => expect(consumer.queued).toBe(messageCount));
+
+    const entries = await drainPipeline(messageCount, consumer);
+    for (const {consumed} of entries) {
+      consumed();
+    }
+    expect(ackMessages).toEqual([]);
+
+    consumer.cancel();
+
+    expect(await Promise.all(results)).toEqual(
+      Array<Result>(messageCount).fill('consumed'),
+    );
+    expect(ackMessages).toEqual([3]);
+    expect(await cleanedUp).toEqual([]);
+  });
+
+  test('pipelined backwards ack closes connection', async () => {
+    const received: JSONValue[] = [];
+    const closed = resolver<void>();
+    const results: Promise<Result>[] = [];
+
+    ws = new WebSocket(`http://localhost:${port}/`);
+    ws.on('message', data =>
+      received.push(JSON.parse(data.toString()) as JSONValue),
+    );
+    ws.on('close', () => closed.resolve());
+
+    results.push(producer.push({from: 0, to: 1, str: 'foo'}).result);
+    results.push(producer.push({from: 1, to: 2, str: 'bar'}).result);
+
+    await vi.waitFor(() => expect(received).toHaveLength(2));
+    ws.send(JSON.stringify({ack: 2}));
+    expect(await Promise.all(results)).toEqual(['consumed', 'consumed']);
+
+    ws.send(JSON.stringify({ack: 1}));
+    await closed.promise;
   });
 
   test('pipelined (unconsumed)', async () => {
@@ -458,6 +541,28 @@ describe('streams with internal acks', () => {
       if (++i === num) {
         break;
       }
+    }
+    return drained;
+  }
+
+  async function drainPipeline(
+    num: number,
+    consumer: Source<Message>,
+  ): Promise<{value: Message; consumed: () => void}[]> {
+    const {pipeline} = consumer;
+    expect(pipeline).not.toBeUndefined();
+    if (!pipeline) {
+      unreachable();
+    }
+    const iterator = pipeline[Symbol.asyncIterator]();
+    const drained: {value: Message; consumed: () => void}[] = [];
+    for (let i = 0; i < num; i++) {
+      const result = await iterator.next();
+      expect(result.done).not.toBe(true);
+      if (result.done) {
+        unreachable();
+      }
+      drained.push(result.value);
     }
     return drained;
   }

--- a/packages/zero-cache/src/types/streams.ts
+++ b/packages/zero-cache/src/types/streams.ts
@@ -28,6 +28,8 @@ import {
 // Consistent with Postgres keepalives, and shorter than the
 // commonly used default idle timeout of 1 minute.
 const PING_INTERVAL_MS = 30_000;
+const CUMULATIVE_ACK_EVERY = 8;
+const CUMULATIVE_ACK_INTERVAL_MS = 5;
 
 export type Source<T> = AsyncIterable<T> & {
   /**
@@ -216,6 +218,17 @@ const ackSchema = v.object({ack: v.number()});
 
 type Ack = v.Infer<typeof ackSchema>;
 
+function parseAck(data: unknown): Ack {
+  if (typeof data !== 'string') {
+    throw new Error('Expected string message');
+  }
+  const ack = v.parse(JSON.parse(data), ackSchema);
+  if (!Number.isSafeInteger(ack.ack) || ack.ack < 0) {
+    throw new Error(`Invalid ack ${ack.ack}`);
+  }
+  return ack;
+}
+
 type Streamed<T> = {
   /** Application-level message. */
   msg: T;
@@ -253,41 +266,62 @@ async function streamOutInternal<T extends JSONValue>(
 
   const closer = WebSocketCloser.forSource(lc, sink, source);
 
-  const acks = new Queue<Ack>();
-  sink.addEventListener('message', ({data}) => {
-    try {
-      if (typeof data !== 'string') {
-        throw new Error('Expected string message');
-      }
-      acks.enqueue(v.parse(JSON.parse(data), ackSchema));
-    } catch (e) {
-      lc.error?.(`error parsing ack`, e);
-      closer.close(e);
-    }
-  });
-
   try {
     let nextID = 0;
     const {pipeline} = source;
     if (pipeline) {
+      let lastAck = 0;
+      const pending = new Map<number, () => void>();
+      sink.addEventListener('message', ({data}) => {
+        try {
+          const {ack} = parseAck(data);
+          if (ack < lastAck) {
+            throw new Error(`Ack moved backwards from ${lastAck} to ${ack}`);
+          }
+          if (ack > nextID) {
+            if (nextID === 0 && pending.size === 0) {
+              return;
+            }
+            throw new Error(
+              `Unexpected ack ${ack}; only sent through ${nextID}`,
+            );
+          }
+          if (ack === lastAck) {
+            return;
+          }
+          lastAck = ack;
+          for (const [id, consumed] of pending) {
+            if (id <= ack) {
+              consumed();
+              pending.delete(id);
+            }
+          }
+        } catch (e) {
+          lc.error?.(`error handling ack`, e);
+          closer.close(e);
+        }
+      });
+
       lc.debug?.(`started pipelined outbound stream`);
       for await (const {value: msg, consumed} of pipeline) {
         const id = ++nextID;
         const data = `{"id":${id},"msg":${stringify(msg)}}`;
         // Enable for debugging. Otherwise too verbose.
         // lc.debug?.(`pipelining`, data);
+        pending.set(id, consumed);
         sink.send(data);
-
-        void (async () => {
-          const {ack} = await acks.dequeue();
-          // lc.debug?.(`received ack`, ack);
-          if (ack !== id) {
-            throw new Error(`Unexpected ack for ${id}: ${ack}`);
-          }
-          consumed();
-        })();
       }
     } else {
+      const acks = new Queue<Ack>();
+      sink.addEventListener('message', ({data}) => {
+        try {
+          acks.enqueue(parseAck(data));
+        } catch (e) {
+          lc.error?.(`error parsing ack`, e);
+          closer.close(e);
+        }
+      });
+
       lc.debug?.(`started synchronous outbound stream`);
       for await (const msg of source) {
         const id = ++nextID;
@@ -312,6 +346,7 @@ export async function streamIn<T extends JSONValue>(
   lc: LogContext,
   source: WebSocket,
   schema: v.Type<T>,
+  options: StreamInOptions = {},
 ): Promise<Source<T>> {
   expectPingsForLiveness(lc, source, PING_INTERVAL_MS);
 
@@ -319,11 +354,15 @@ export async function streamIn<T extends JSONValue>(
     msg: schema,
     id: v.number(),
   });
+  const acker = new CumulativeAcker(source, options.ack === 'cumulative');
 
   const sink: Subscription<T, Streamed<T>> = new Subscription<T, Streamed<T>>(
     {
-      consumed: ({id}) => source.send(JSON.stringify({ack: id} satisfies Ack)),
-      cleanup: () => closer.close(),
+      consumed: ({id}) => acker.consumed(id),
+      cleanup: () => {
+        acker.close();
+        closer.close();
+      },
     },
     ({msg}) => msg,
   );
@@ -339,6 +378,7 @@ export async function streamIn<T extends JSONValue>(
     try {
       const value = BigIntJSON.parse(data);
       const msg = v.parse(value, streamedSchema, 'passthrough');
+      acker.received(msg.id);
       // Enable for debugging. Otherwise too verbose.
       // lc.debug?.(`received`, data);
       sink.push(msg);
@@ -349,6 +389,100 @@ export async function streamIn<T extends JSONValue>(
 
   await closer.connected;
   return sink;
+}
+
+type StreamInOptions = {
+  ack?: 'per-message' | 'cumulative' | undefined;
+};
+
+class CumulativeAcker {
+  readonly #ws: WebSocket;
+  readonly #batch: boolean;
+  readonly #outOfOrder = new Set<number>();
+  #highestReceived = 0;
+  #highestAckable = 0;
+  #lastSent = 0;
+  #pendingSinceLastSend = 0;
+
+  #timer: NodeJS.Timeout | undefined;
+
+  constructor(ws: WebSocket, batch: boolean) {
+    this.#ws = ws;
+    this.#batch = batch;
+  }
+
+  received(id: number) {
+    this.#validateID(id);
+    this.#highestReceived = Math.max(this.#highestReceived, id);
+  }
+
+  consumed(id: number) {
+    this.#validateID(id);
+    if (id <= this.#highestAckable) {
+      return;
+    }
+    const previous = this.#highestAckable;
+    if (id === this.#highestAckable + 1) {
+      this.#highestAckable = id;
+      while (this.#outOfOrder.delete(this.#highestAckable + 1)) {
+        this.#highestAckable++;
+      }
+    } else {
+      this.#outOfOrder.add(id);
+    }
+    const advanced = this.#highestAckable - previous;
+    if (advanced === 0) {
+      return;
+    }
+    this.#pendingSinceLastSend += advanced;
+    if (
+      this.#batch &&
+      this.#pendingSinceLastSend < CUMULATIVE_ACK_EVERY &&
+      !(
+        this.#pendingSinceLastSend > 1 &&
+        this.#highestAckable === this.#highestReceived
+      )
+    ) {
+      this.#schedule();
+    } else {
+      this.flush();
+    }
+  }
+
+  flush() {
+    this.#clearTimer();
+    if (this.#highestAckable <= this.#lastSent) {
+      return;
+    }
+    if (this.#ws.readyState !== this.#ws.OPEN) {
+      return;
+    }
+    this.#ws.send(JSON.stringify({ack: this.#highestAckable} satisfies Ack));
+    this.#lastSent = this.#highestAckable;
+    this.#pendingSinceLastSend = 0;
+  }
+
+  close() {
+    this.flush();
+    this.#clearTimer();
+  }
+
+  #schedule() {
+    this.#timer ??= setTimeout(() => this.flush(), CUMULATIVE_ACK_INTERVAL_MS);
+  }
+
+  #clearTimer() {
+    if (this.#timer !== undefined) {
+      clearTimeout(this.#timer);
+      this.#timer = undefined;
+    }
+  }
+
+  #validateID(id: number) {
+    if (!Number.isSafeInteger(id) || id <= 0) {
+      throw new Error(`Invalid stream message id ${id}`);
+    }
+  }
 }
 
 class WebSocketCloser {


### PR DESCRIPTION
## AI-generated draft

This draft PR was prepared by an AI coding agent. It is intentionally still draft, but it is a clean production PR against `main`; the ACK benchmark harness lives in [#5959](https://github.com/rocicorp/mono/pull/5959).

## Why This Is Worth It

The internal change-streamer WebSocket stream currently pays one ACK frame for every consumed message. That is correct, but it means ACK traffic scales with message count even when the receiver is processing a normal contiguous pipeline.

The worst case is not that each ACK is large. Each ACK is tiny. The problem is the shape under throughput:

```text
10,000 streamed messages/sec
----------------------------
old behavior: 10,000 data frames + 10,000 ACK frames

Every ACK competes for:
- WebSocket framing
- JSON parse/stringify
- event-loop turns
- sender-side pending-message cleanup
```

This PR changes only the ACK watermark for the opt-in internal change-streamer path. Instead of saying "message 1 is consumed, message 2 is consumed, message 3 is consumed," the receiver can say "everything through 3 is consumed."

```text
Before
------
server -> msg 1 -> client
server <- ack 1 <- client
server -> msg 2 -> client
server <- ack 2 <- client
server -> msg 3 -> client
server <- ack 3 <- client

After
-----
server -> msg 1 -> client
server -> msg 2 -> client
server -> msg 3 -> client
server <- ack 3 <- client
```

The key property: `ack 3` means all messages up through 3 were consumed. It does not acknowledge gaps.

## Clean PR Set

Base for the cleaned branches: `rocicorp/mono@65f1461f761936288a11fde0585d100432ce9aef`.

| PR | Role | Relationship |
|---|---|---|
| [#5959](https://github.com/rocicorp/mono/pull/5959) | Benchmark suite | Provides `perf:ack` evidence |
| [#5960](https://github.com/rocicorp/mono/pull/5960) | Production byte-aware poke flushing | Independent |
| [#5963](https://github.com/rocicorp/mono/pull/5963) | This PR | Production cumulative ACKs |
| [#5964](https://github.com/rocicorp/mono/pull/5964) | Production fanout release timing | Independent |

## What Changed

- `streamIn(..., {ack: "cumulative"})` can batch ACKs.
- The change-streamer HTTP client opts into cumulative ACKs for internal streams.
- Generic `streamIn` callers keep per-message ACKs unless they explicitly opt in.
- The sender accepts monotonic cumulative ACKs and marks all pending messages up to that ID as consumed.
- The receiver only advances the ACK watermark across contiguous consumed messages.
- Pending ACKs flush on cleanup so a short stream is not left unacknowledged.
- Backwards ACKs are treated as protocol errors and close the connection.

## Gap Semantics

This is the correctness core of the PR.

```text
received IDs:  1  2  3  4  5
consumed IDs:  y  y  n  y  y
ackable ID:    2

No ack 5 is sent yet.
Message 3 is still the hole in the consumed prefix.
When 3 is consumed, the watermark can advance to 5 in one ACK.
```

There is no new timeout for a gap. If message 3 never becomes consumed, the sender keeps the later messages pending just like it would keep an unacked message pending today. The PR reduces normal-case ACK chatter; it does not weaken the consumed-before-release contract.

## Benchmark Headline

Benchmark harness: [#5959](https://github.com/rocicorp/mono/pull/5959), `npm --workspace=zero-cache run perf:ack`.

Smoke scenarios reduce ACK frames by about 53% to 87%. The biggest wins show up in bursty streams because many messages become one contiguous consumed prefix.

[#5959](https://github.com/rocicorp/mono/pull/5959) also includes an idealized simulation table with larger ACK reductions. This PR uses the actual implementation numbers below, which are intentionally more conservative because they include batching thresholds, cleanup flushing, and real stream behavior.

| Scenario | Main / per-message ACK | This PR / cumulative ACK | ACK traffic delta | p95 latency delta | Decision |
|---|---:|---:|---:|---:|---|
| steady, 1 msg every 1 ms, small 96 B payload | 1,000 ACKs, 10.6 KiB, p95 0.494 ms | 466 ACKs, 4.96 KiB, p95 0.594 ms | -53.4% messages, -53.4% bytes | +0.100 ms | GO |
| steady, 1 msg every 1 ms, medium 1 KiB payload | 1,000 ACKs, 10.6 KiB, p95 0.636 ms | 461 ACKs, 4.91 KiB, p95 0.549 ms | -53.9% messages, -53.9% bytes | -0.087 ms | GO |
| burst, 10 msgs every 10 ms, small 96 B payload | 1,000 ACKs, 10.6 KiB, p95 2.415 ms | 200 ACKs, 2.13 KiB, p95 1.805 ms | -80.0% messages, -80.0% bytes | -0.610 ms | GO |
| burst, 10 msgs every 10 ms, medium 1 KiB payload | 1,000 ACKs, 10.6 KiB, p95 2.472 ms | 200 ACKs, 2.13 KiB, p95 1.492 ms | -80.0% messages, -80.0% bytes | -0.980 ms | GO |
| burst, 100 msgs every 100 ms, small 96 B payload | 1,000 ACKs, 10.6 KiB, p95 8.177 ms | 130 ACKs, 1.38 KiB, p95 5.717 ms | -87.0% messages, -87.0% bytes | -2.460 ms | GO |
| burst, 100 msgs every 100 ms, medium 1 KiB payload | 1,000 ACKs, 10.6 KiB, p95 8.346 ms | 130 ACKs, 1.38 KiB, p95 5.890 ms | -87.0% messages, -87.0% bytes | -2.456 ms | GO |

The important read is not "ACK bytes dominate the system." They probably do not. The important read is that this removes fixed per-message control-plane work from a hot internal stream without changing the streamed application messages.

## Safety Story: Review Contract

- Cannot acknowledge an unconsumed gap. The receiver only sends the highest contiguous consumed ID.
- Cannot move the ACK watermark backwards. A backwards ACK closes the connection.
- Cannot acknowledge a future message after normal startup. The sender rejects ACKs beyond what it has sent.
- Cannot affect generic stream users by default. Cumulative ACKs are opt-in.
- Cannot strand a short stream just below the batch threshold. Cleanup flushes the highest contiguous ACK that is actually ackable; it does not jump across a gap.
- Cannot change the data frame payload. The streamed message shape is unchanged; this PR changes ACK semantics for the opted-in path.

## What Reviewers Should Be Skeptical About

- Mixed-version rollout is the biggest operational risk. New sender with old receiver is naturally okay because per-message ACKs are monotonic. Old sender with new cumulative receiver can be unsafe because the old pipelined sender expects exact per-message ACK IDs. That is why cumulative mode is opt-in and why rollout should keep the internal change-streamer sender/receiver on compatible code.
- A bug in contiguous-ID tracking could release messages before they are actually consumed. The tests focus on batching, cleanup flush, gaps, and backwards ACK rejection because that is the scary correctness surface.
- Delayed ACKs can keep more messages pending on the sender for a few milliseconds.
- The benchmark is still synthetic. Longer/full-mode reruns are useful before treating the exact p95 deltas as capacity evidence.

## Validation

- `npm --workspace=zero-cache run check-types`
- `npm --workspace=zero-cache run lint`
- `npm --workspace=zero-cache run test:no-pg -- streams.test.ts`
